### PR TITLE
fix(cli): harden `gori run` — crashes, silent-wrong output, and inconsistencies

### DIFF
--- a/spec/cli_run_spec.cr
+++ b/spec/cli_run_spec.cr
@@ -207,4 +207,10 @@ describe Gori::CLI::Output do
     Gori::CLI::Output.human_us(500_i64).should eq("500µs")
     Gori::CLI::Output.human_us(1_500_i64).should eq("1.5ms")
   end
+
+  it "scales human_size up to GB and TB (no '1024.0MB')" do
+    Gori::CLI::Output.human_size(1_073_741_824_i64).should eq("1.0GB")     # exactly 1 GiB
+    Gori::CLI::Output.human_size(5_368_709_120_i64).should eq("5.0GB")     # 5 GiB
+    Gori::CLI::Output.human_size(2_199_023_255_552_i64).should eq("2.0TB") # 2 TiB
+  end
 end

--- a/spec/cli_run_spec.cr
+++ b/spec/cli_run_spec.cr
@@ -139,7 +139,41 @@ describe Gori::Findings::Export do
       md.should contain("### Request")
       md.should contain("GET /v1/debug HTTP/1.1")
       md.should contain("(##{fid})")
+      # The header block's terminating CRLF CRLF is trimmed, so the last header
+      # line abuts the closing fence (no stack of blank lines inside the block).
+      md.should contain("Host: api.test\n```")
+      md.should_not contain("\r\n\r\n")
     end
+  end
+
+  it "separates evidence headers from the body with exactly one blank line" do
+    with_store do |store|
+      req = Gori::Store::CapturedRequest.new(
+        created_at: 0_i64, scheme: "https", host: "api.test", port: 443, method: "POST",
+        target: "/login", http_version: "HTTP/1.1",
+        head: "POST /login HTTP/1.1\r\nHost: api.test\r\nContent-Length: 9\r\n\r\n".to_slice,
+        body: "user=root".to_slice)
+      fid = store.insert_flow(req)
+      store.flush
+      findings = [Gori::Store::Finding.new(1_i64, 0_i64, 0_i64, "creds in body",
+        Gori::Store::Severity::High, "api.test", fid, "", Gori::Store::Status::Open)]
+      md = Gori::Findings::Export.markdown(findings, store, "demo")
+      # one blank line between the last header and the body — not three
+      md.should contain("Content-Length: 9\n\nuser=root")
+      md.should_not contain("Content-Length: 9\n\n\nuser=root")
+    end
+  end
+end
+
+describe Gori::QL do
+  # `gori run history -q` relies on this: a query that fails to compile to any
+  # clause collapses to the match-all EMPTY filter. The CLI special-cases that so
+  # a typo like `status:>=foo` errors instead of silently dumping every flow.
+  it "collapses an un-compilable query to EMPTY (so the CLI can reject it)" do
+    Gori::QL.parse("status:>=foo").should eq(Gori::QL::EMPTY)
+    Gori::QL.parse("-status:bar").should eq(Gori::QL::EMPTY)
+    Gori::QL.parse("login").should_not eq(Gori::QL::EMPTY)
+    Gori::QL.parse("status:>=500").should_not eq(Gori::QL::EMPTY)
   end
 end
 

--- a/src/gori/app.cr
+++ b/src/gori/app.cr
@@ -119,7 +119,9 @@ module Gori
         event = session.flow_events.receive
         next unless event.kind == :updated # one line per completed/errored flow
         if row = session.store.flow_row(event.id)
-          puts(format == :json ? CLI::Output.flow_row_json(row) : format_row(row))
+          # Stream the SAME row rendering `gori run history` prints, so capture and
+          # history output never drift (text = human-readable; json = stable contract).
+          puts(format == :json ? CLI::Output.flow_row_json(row) : CLI::Output.flow_row_text(row))
           STDOUT.flush # stream each flow promptly even when piped (block-buffered)
           printed += 1
           if max && printed >= max
@@ -135,11 +137,6 @@ module Gori
       # order), so a buffered event can race in and query a now-closed DB. That's
       # a clean shutdown, not an error — stop quietly instead of crashing the fiber
       # (which would drop the final lines).
-    end
-
-    private def format_row(row : Store::FlowRow) : String
-      status = row.status.try(&.to_s) || "---"
-      "##{row.id} #{row.scheme} #{row.method} #{row.host} #{row.target} -> #{status} (#{row.size}b) [#{row.state}]"
     end
 
     private def print_banner(session : Session) : Nil

--- a/src/gori/app.cr
+++ b/src/gori/app.cr
@@ -137,6 +137,11 @@ module Gori
       # order), so a buffered event can race in and query a now-closed DB. That's
       # a clean shutdown, not an error — stop quietly instead of crashing the fiber
       # (which would drop the final lines).
+    rescue IO::Error
+      # STDOUT pipe closed (e.g. `gori run capture | head`): the consumer is gone,
+      # so there's nothing left to stream — wind the session down gracefully
+      # instead of letting the unhandled error take down the whole process.
+      @shutdown.send(nil) rescue nil
     end
 
     private def print_banner(session : Session) : Nil

--- a/src/gori/cli/output.cr
+++ b/src/gori/cli/output.cr
@@ -58,7 +58,10 @@ module Gori
         kb = bytes / 1024.0
         return "#{round1(kb)}kB" if kb < 1024
         mb = kb / 1024.0
-        "#{round1(mb)}MB"
+        return "#{round1(mb)}MB" if mb < 1024
+        gb = mb / 1024.0
+        return "#{round1(gb)}GB" if gb < 1024
+        "#{round1(gb / 1024.0)}TB"
       end
 
       def self.human_us(micros : Int64) : String

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -126,7 +126,20 @@ module Gori
 
         store = open_store(resolve_read_project(project_name, db_path))
         begin
-          rows = (q = query) ? store.search(QL.parse(q), limit) : store.recent_flows(limit)
+          rows =
+            if q = query
+              filter = QL.parse(q)
+              # A query that fails to compile to ANY clause (e.g. `status:>=foo`)
+              # yields the match-all EMPTY filter — silently dumping every flow,
+              # the opposite of what the user asked. Refuse it instead.
+              if !q.strip.empty? && filter == QL::EMPTY
+                store.close
+                abort "gori run history: query #{q.inspect} did not match any field (check syntax, e.g. status:>=500 host:example.com method:POST)"
+              end
+              store.search(filter, limit)
+            else
+              store.recent_flows(limit)
+            end
           if format == :json
             rows.each { |r| puts CLI::Output.flow_row_json(r) }
           elsif rows.empty?
@@ -358,7 +371,10 @@ module Gori
 
         project = resolve_read_project(project_name, db_path)
         store = open_store(project)
-        begin
+        # Build the report while the store is open (markdown resolves linked-flow
+        # evidence), then close BEFORE any file I/O so a write failure can't leak the
+        # connection — and so the abort below runs after a clean close.
+        result = begin
           findings = store.findings
           if findings.empty? && format == :text && export_path.nil?
             STDERR.puts "no findings"
@@ -370,14 +386,21 @@ module Gori
             when :markdown then Findings::Export.markdown(findings, store, project.name)
             else                findings_text(findings)
             end
-          if path = export_path
-            File.write(path, content.ends_with?('\n') ? content : "#{content}\n")
-            STDERR.puts "exported #{findings.size} finding#{findings.size == 1 ? "" : "s"} → #{path}"
-          else
-            puts content
-          end
+          {content, findings.size}
         ensure
           store.close
+        end
+        content, count = result
+
+        if path = export_path
+          begin
+            File.write(path, content.ends_with?('\n') ? content : "#{content}\n")
+          rescue ex : File::Error
+            abort "gori run findings: cannot write to #{path}: #{ex.message}"
+          end
+          STDERR.puts "exported #{count} finding#{count == 1 ? "" : "s"} → #{path}"
+        else
+          puts content
         end
       end
 
@@ -434,7 +457,7 @@ module Gori
       # else the most-recently-active project. Aborts when nothing resolves.
       private def self.resolve_read_project(project_name : String?, db_path : String?) : Project
         if path = db_path
-          abort "gori run: db not found: #{path}" unless File.exists?(path)
+          abort "gori run: --db is not a readable file: #{path}" unless File.file?(path)
           return Project.new(File.basename(File.dirname(path)), path)
         end
         projects = ProjectRegistry.new(Paths.projects_dir).list
@@ -451,13 +474,22 @@ module Gori
       # existing one). --db keeps the explicit-file behaviour of legacy --headless.
       private def self.resolve_capture_project(project_name : String?, db_path : String?) : Project
         if path = db_path
-          return Project.new(File.basename(File.dirname(path)), path)
+          # Catch the unopenable cases up front with a clean message — otherwise
+          # SQLite raises a raw DB::ConnectionRefused backtrace deep in Session.open.
+          abort "gori run capture: --db is a directory, not a file: #{path}" if Dir.exists?(path)
+          parent = File.dirname(path)
+          abort "gori run capture: --db parent directory does not exist: #{parent}" unless Dir.exists?(parent)
+          return Project.new(File.basename(parent), path)
         end
         ProjectRegistry.new(Paths.projects_dir).create(project_name || "default")
       end
 
+      # Opening a non-SQLite file (or a path we can't read) raises deep in the driver;
+      # turn that into a clean CLI error instead of an unhandled backtrace.
       private def self.open_store(project : Project) : Store
         Store.open(project.db_path)
+      rescue ex : DB::Error | SQLite3::Exception
+        abort "gori run: cannot open database #{project.db_path}: #{ex.message.presence || "not a valid SQLite database (or unreadable)"}"
       end
 
       private def self.take_flow_id(rest : Array(String), sub : String) : Int64
@@ -482,6 +514,7 @@ module Gori
         m = v.match(/\A(\d+)(s|m|h)?\z/)
         abort "gori run: invalid duration '#{v}' (use e.g. 30s, 5m, 1h)" unless m
         n = m[1].to_i
+        abort "gori run: --for must be greater than 0 (got '#{v}')" if n == 0
         case m[2]?
         when "m" then n.minutes
         when "h" then n.hours
@@ -521,6 +554,12 @@ module Gori
       # head lines + blank + body lines (scrubbed), for the --diff line comparison.
       private def self.message_lines(head : Bytes?, body : Bytes?) : Array(String)
         lines = bytes_to_lines(head)
+        # The head BLOB ends with the CRLF CRLF that terminates the header block,
+        # so splitting it leaves trailing empty lines; drop them and add exactly one
+        # blank separator before the body (matches the non-diff text view).
+        while !lines.empty? && lines.last.empty?
+          lines.pop
+        end
         if body && !body.empty?
           lines << ""
           lines.concat(bytes_to_lines(body))

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -45,6 +45,12 @@ module Gori
           print_help
           exit 1
         end
+      rescue ex : IO::Error
+        # `gori run … | head` (or any reader that closes early) breaks the STDOUT
+        # pipe; a well-behaved Unix filter exits quietly on EPIPE rather than
+        # dumping an IO::Error backtrace. Re-raise anything that isn't a broken pipe.
+        raise ex unless ex.os_error == Errno::EPIPE
+        exit 0
       end
 
       private def self.print_help : Nil
@@ -217,7 +223,7 @@ module Gori
       private def self.show_text(detail : Store::FlowDetail, req : Bool, resp : Bool) : Nil
         if req
           puts "=== REQUEST (#{detail.http_version}) ==="
-          print_message_text(detail.request_head, detail.request_body)
+          print_message_text(detail.request_head, display_body(detail.request_head, detail.request_body))
           puts "  [request body truncated]" if detail.request_body_truncated?
         end
         if resp
@@ -244,19 +250,23 @@ module Gori
             j.field "http_version", detail.http_version
             j.field "error", detail.error
             if req
+              req_body, req_decoded = decode_body(detail.request_head, detail.request_body)
               j.field "request" do
                 j.object do
                   j.field "head", scrub(detail.request_head)
-                  j.field "body", scrub(detail.request_body)
+                  j.field "body", scrub(req_body)
+                  j.field "body_decoded", req_decoded
                   j.field "body_truncated", detail.request_body_truncated?
                 end
               end
             end
             if resp
+              resp_body, resp_decoded = decode_body(detail.response_head, detail.response_body)
               j.field "response" do
                 j.object do
                   j.field "head", scrub(detail.response_head)
-                  j.field "body", scrub(display_body(detail.response_head, detail.response_body))
+                  j.field "body", scrub(resp_body)
+                  j.field "body_decoded", resp_decoded
                   j.field "body_truncated", detail.response_body_truncated?
                 end
               end
@@ -312,7 +322,7 @@ module Gori
 
         # Decode the response body once; only build the diff lines when --diff asked
         # for them (decoding the captured baseline isn't free for large bodies).
-        new_body = display_body(result.head, result.body)
+        new_body, body_decoded = decode_body(result.head, result.body)
         diff =
           if do_diff
             orig = message_lines(detail.response_head, display_body(detail.response_head, detail.response_body))
@@ -320,7 +330,7 @@ module Gori
           end
 
         if format == :json
-          puts replay_json(result, new_body, diff)
+          puts replay_json(result, new_body, body_decoded, diff)
         elsif result.ok?
           STDERR.puts "→ #{result.response.try(&.status) || "?"} in #{CLI::Output.human_us(result.duration_us)}"
           if d = diff
@@ -334,7 +344,7 @@ module Gori
         exit 1 unless result.ok?
       end
 
-      private def self.replay_json(result : Replay::Result, body : Bytes?, diff : Array(Replay::DiffLine)?) : String
+      private def self.replay_json(result : Replay::Result, body : Bytes?, body_decoded : Bool, diff : Array(Replay::DiffLine)?) : String
         JSON.build do |j|
           j.object do
             j.field "ok", result.ok?
@@ -343,6 +353,7 @@ module Gori
             j.field "error", result.error
             j.field "head", scrub(result.head)
             j.field "body", scrub(body)
+            j.field "body_decoded", body_decoded
             if d = diff
               j.field "changed_lines", Replay::Diff.change_count(d)
             end
@@ -494,6 +505,7 @@ module Gori
 
       private def self.take_flow_id(rest : Array(String), sub : String) : Int64
         abort "gori run #{sub}: missing <flow-id>" if rest.empty?
+        abort "gori run #{sub}: too many arguments (expected one <flow-id>, got: #{rest.join(" ")})" if rest.size > 1
         rest[0].to_i64? || abort "gori run #{sub}: invalid flow id '#{rest[0]}'"
       end
 
@@ -535,8 +547,17 @@ module Gori
       end
 
       private def self.display_body(head : Bytes?, body : Bytes?) : Bytes?
+        decode_body(head, body)[0]
+      end
+
+      # Decode a Content-Encoding/Transfer-Encoding body for display, returning the
+      # bytes plus whether any decoding actually happened. When `true`, the bytes no
+      # longer match the message's Content-Encoding/Content-Length headers — the JSON
+      # output surfaces this as `body_decoded` so scripts aren't misled. (`--format
+      # raw` still emits the exact wire bytes.)
+      private def self.decode_body(head : Bytes?, body : Bytes?) : {Bytes?, Bool}
         decoded, _ = Proxy::Codec::ContentDecode.decode(head, body)
-        decoded || body
+        decoded ? {decoded, true} : {body, false}
       end
 
       private def self.scrub(bytes : Bytes?) : String?

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -281,7 +281,7 @@ module Gori
           p.banner = "Usage: gori run replay <flow-id> [options]"
           p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
-          p.on("--target=URL", "Send to URL instead of the captured origin") { |v| target_override = v }
+          p.on("--target=URL", "Send to this origin (scheme://host[:port]) instead of the captured one; path/query kept") { |v| target_override = v }
           p.on("--http2", "Force HTTP/2 (default follows how the flow was captured)") { force_h2 = true }
           p.on("--insecure-upstream", "Do not verify the upstream TLS certificate") { insecure = true }
           p.on("--diff", "Diff the new response against the captured one") { do_diff = true }

--- a/src/gori/findings_export.cr
+++ b/src/gori/findings_export.cr
@@ -64,9 +64,11 @@ module Gori
         cap = EVIDENCE_CAP
         io << "\n### " << label << "\n\n```http\n"
         # HEAD: headers are text but can carry stray non-UTF-8 (obs-text) bytes — scrub
-        # them so the report stays a valid UTF-8 file; cap it like the body.
+        # them so the report stays a valid UTF-8 file; cap it like the body. rstrip the
+        # header block's trailing CRLF CRLF so a single blank line (added below) sits
+        # between headers and body instead of a stack of empty lines.
         hslice = head.size > cap ? head[0, cap] : head
-        io << String.new(hslice).scrub
+        io << String.new(hslice).scrub.rstrip
         io << "\n\n[… headers truncated, #{head.size} bytes total …]" if head.size > cap
         if body && !body.empty?
           slice = body[0, {body.size, cap}.min]


### PR DESCRIPTION
## Summary

Drove every `gori run` subcommand end-to-end against a live proxy (HTTP + HTTPS MITM, error flows, large bodies, bad input) and ran an adversarial multi-lens code review over the CLI surface. This PR fixes the bugs and unexpected behaviors that turned up — crashes on realistic input, silently-wrong output, and inconsistencies between subcommands. No behavior change for the happy paths; the JSON contract only gains additive fields.

Worked in three rounds (one commit each).

### Round 1 — harden against bad input (`0f554ac`)
- **Crash → clean error** on a bad `--db` (a directory, a non-SQLite file, or a missing-parent path) for both reads and `capture`, and on `findings --export` to a missing directory. These previously dumped a raw `DB::ConnectionRefused` / `File::NotFoundError` backtrace.
- **`history -q` no longer silently dumps everything** when the query fails to compile (e.g. `status:>=foo` collapsed to match-all). It now errors and points at the syntax.
- **Trimmed the 3-blank-line gap** between headers and body in `replay --diff` and `findings --format markdown` (the header block's trailing `CRLF CRLF` plus an added separator) down to one.
- **`capture --for 0`** is rejected (was accepted and immediately shut down as a no-op).

### Round 2 — output consistency (`9a49fad`)
- **`gori run capture` now streams the same rows as `gori run history`** (aligned columns, human sizes/durations) instead of the legacy `#1 http GET host target -> 200 (307b) [Complete]` format. `--headless` shares the path, so both stay in sync. JSON output unchanged.
- Clarified `replay --target` help: it swaps the origin (scheme/host/port) and keeps the captured request's path/query.

### Round 3 — from the adversarial review (`3da7397`)
- **Broken-pipe (EPIPE) safety**: `gori run show <id> | head` crashed with an `IO::Error` backtrace once the body exceeded the pipe buffer. `dispatch` now exits quietly on EPIPE like a well-behaved filter, and `capture_printer` winds down gracefully when its output pipe closes.
- **`human_size` scales to GB/TB**: a 1 GB+ flow read as `1024.0MB`.
- **Request/response body-decode consistency**: `show` decoded the response body (`Content-Encoding`) but printed the request body raw. Both sides now decode for display, and the JSON output gains a `body_decoded` flag (request, response, and replay) so scripts know the body no longer matches the headers' encoding/length. `--format raw` still emits exact wire bytes.
- **`show`/`replay` reject extra positional args** (`show 1 2` silently ignored `2`).

## Out of scope (noted, not fixed here)
Two deeper issues surfaced during HTTPS testing that live below the `gori run` CLI (in the proxy / cert authority), so they're left for a focused follow-up:
- MITM leaf certs for **IP-literal hosts** lack an IP SAN, so `https://127.0.0.1` via the proxy fails client verification (hostnames are fine).
- A client speaking **HTTP/2** to the proxy against an **HTTP/1-only upstream** fails to bridge.

## Testing
- `crystal spec` — **446 examples, 0 failures** (added coverage: markdown spacing, QL-collapses-to-EMPTY precondition, `human_size` GB/TB).
- `ameba` clean on all touched files.
- Every fix verified against a live `gori run capture` proxy with curl (HTTP, HTTPS MITM, gzip request+response bodies, 3 MB bodies, error flows, concurrent-capture lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)