### PR TITLE
feat(tui): sitemap filter, replay response metrics, and SNI override

### DIFF
--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -66,6 +66,8 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def sitemap_collapse : Nil; end
 
+  def sitemap_query : Nil; end
+
   def scope_open : Nil; end
 
   def scope_add_host : Nil; end

--- a/spec/tui/mouse_spec.cr
+++ b/spec/tui/mouse_spec.cr
@@ -107,10 +107,11 @@ describe "SitemapView#row_at / #marker_hit?" do
       rect = Rect.new(0, 0, 70, 20)
       view.render(Screen.new(MemoryBackend.new(70, 20)), rect)
 
-      view.row_at(rect, 5, rect.y).should eq(0)           # first row = host node
-      view.row_at(rect, 5, rect.y - 1).should be_nil      # above the list
-      view.row_at(rect, 5, rect.y + 19).should be_nil     # past the populated rows
-      view.row_at(rect, rect.right, rect.y).should be_nil # past the right frame column (mx bound)
+      # not querying → the tree starts at rect.y + 1 (the QL filter bar takes row 0)
+      view.row_at(rect, 5, rect.y + 1).should eq(0)           # first tree row = host node
+      view.row_at(rect, 5, rect.y).should be_nil             # the QL bar row, above the tree
+      view.row_at(rect, 5, rect.y + 19).should be_nil        # past the populated rows
+      view.row_at(rect, rect.right, rect.y + 1).should be_nil # past the right frame column (mx bound)
 
       view.marker_hit?(rect, rect.x + 1, 0).should be_true  # host marker at depth 0 → x+1
       view.marker_hit?(rect, rect.x + 9, 0).should be_false # elsewhere on the row

--- a/spec/tui/replay_view_spec.cr
+++ b/spec/tui/replay_view_spec.cr
@@ -274,4 +274,75 @@ describe Gori::Tui::ReplayView do
       store.replays.first.name.should be_nil
     end
   end
+
+  it "shows the response duration and size on the RESPONSE pane after a send" do
+    view = ReplayView.new
+    view.load_blank
+    head = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n".to_slice
+    body = ("x" * 2048).to_slice
+    view.apply(Gori::Replay::Result.new(head, body, nil, 234_000_i64)) # 234 ms, head+body ≈ 2 KB
+
+    backend = MemoryBackend.new(120, 20)
+    view.render(Screen.new(backend), Rect.new(0, 0, 120, 20))
+    backend.contains?("234ms").should be_true
+    backend.contains?("KB").should be_true
+  end
+
+  it "edits and exposes an SNI override (^S sub-field of the target)" do
+    view = ReplayView.new
+    view.load_blank # focus starts on :target
+    view.sni_override.should be_nil
+    view.editing_sni?.should be_false
+
+    view.toggle_sni_field # ^S → edit the SNI host
+    view.editing_sni?.should be_true
+    "evil.com".each_char { |c| view.target_insert(c) }
+    view.sni.should eq("evil.com")        # the SNI field took the input, not the URL
+    view.target.should eq("https://example.com") # URL untouched
+    view.sni_override.should eq("evil.com")
+    view.dirty?.should be_true
+
+    backend = MemoryBackend.new(120, 20)
+    view.render(Screen.new(backend), Rect.new(0, 0, 120, 20))
+    backend.contains?("SNI").should be_true
+    backend.contains?("evil.com").should be_true
+  end
+
+  it "leaving the target pane exits the SNI sub-field (URL edits never land in SNI)" do
+    view = ReplayView.new
+    view.load_blank
+    view.toggle_sni_field
+    "evil.com".each_char { |c| view.target_insert(c) }
+    view.editing_sni?.should be_true
+
+    view.pane_advance(1) # ↓/Tab down into the request pane
+    view.editing_sni?.should be_false
+    view.focus_first # …then back up to the target pane
+
+    view.editing_sni?.should be_false      # arrives on the URL field, not the stale SNI sub-field
+    view.target_insert('Z')                # a URL keystroke must edit the URL…
+    view.target.should eq("https://example.comZ")
+    view.sni.should eq("evil.com")         # …and leave the SNI value untouched
+  end
+
+  it "restore seeds a persisted SNI override and shows it" do
+    view = ReplayView.new
+    view.restore("https://10.0.0.5", "GET / HTTP/1.1\n\n", false, true, sni: "evil.com")
+    view.sni_override.should eq("evil.com")
+    view.dirty?.should be_false # a restored tab must never be re-saved
+
+    backend = MemoryBackend.new(120, 20)
+    view.render(Screen.new(backend), Rect.new(0, 0, 120, 20))
+    backend.contains?("evil.com").should be_true
+  end
+
+  it "persists a replay tab's SNI override (set / clear)" do
+    replay_tmp_store do |store|
+      id = store.insert_replay("https://h/x", "GET /x HTTP/1.1", false, true, nil, 0, "evil.com")
+      store.replays.first.sni.should eq("evil.com")
+      store.replays_meta.first.sni.should eq("evil.com") # syncs via the fast reconcile poll too
+      store.update_replay(id, "https://h/x", "GET /x HTTP/1.1", false, true, nil) # clear
+      store.replays.first.sni.should be_nil
+    end
+  end
 end

--- a/spec/tui/replay_view_spec.cr
+++ b/spec/tui/replay_view_spec.cr
@@ -325,6 +325,17 @@ describe Gori::Tui::ReplayView do
     view.sni.should eq("evil.com")         # …and leave the SNI value untouched
   end
 
+  it "a click on the TARGET card's bottom border does not enter the SNI sub-field" do
+    view = ReplayView.new
+    view.restore("https://10.0.0.5", "GET / HTTP/1.1\n\n", false, true, sni: "evil.com")
+    rect = Rect.new(0, 0, 120, 20)
+    # With an SNI override the card is 4 rows: border@y, URL@y+1, SNI@y+2, border@y+3.
+    view.target_click_to_cursor(rect, 5, rect.y + 3) # the decorative bottom border
+    view.editing_sni?.should be_false                # …must NOT switch to the SNI field
+    view.target_click_to_cursor(rect, 5, rect.y + 2) # the real SNI row does
+    view.editing_sni?.should be_true
+  end
+
   it "restore seeds a persisted SNI override and shows it" do
     view = ReplayView.new
     view.restore("https://10.0.0.5", "GET / HTTP/1.1\n\n", false, true, sni: "evil.com")

--- a/spec/tui/sitemap_view_spec.cr
+++ b/spec/tui/sitemap_view_spec.cr
@@ -74,4 +74,60 @@ describe Gori::Tui::SitemapView do
       backend.contains?("no traffic captured").should be_true
     end
   end
+
+  it "filters the tree with a QL query" do
+    tmp_store do |store|
+      capture(store, "api.acme.test", "GET", "/v1/users")
+      capture(store, "cdn.acme.test", "GET", "/assets/app.js")
+
+      view = SitemapView.new
+      view.reload(store)
+      b0 = MemoryBackend.new(70, 20)
+      view.render(Screen.new(b0), Rect.new(0, 0, 70, 20))
+      b0.contains?("api.acme.test").should be_true
+      b0.contains?("cdn.acme.test").should be_true
+
+      # type `host:api` into the QL bar and re-derive the tree
+      view.start_query
+      "host:api".each_char { |c| view.query_insert(c) }
+      view.reload(store)
+
+      b1 = MemoryBackend.new(70, 20)
+      view.render(Screen.new(b1), Rect.new(0, 0, 70, 20))
+      b1.contains?("api.acme.test").should be_true
+      b1.contains?("cdn.acme.test").should be_false
+    end
+  end
+
+  it "renders the filter bar: scope chip + hint, then the query prompt" do
+    tmp_store do |store|
+      capture(store, "acme.test", "GET", "/")
+      view = SitemapView.new
+      view.reload(store)
+
+      b0 = MemoryBackend.new(70, 20)
+      view.render(Screen.new(b0), Rect.new(0, 0, 70, 20))
+      b0.contains?("filter").should be_true
+      b0.contains?("scope:off").should be_true
+
+      view.start_query
+      "host:acme".each_char { |c| view.query_insert(c) }
+      b1 = MemoryBackend.new(70, 20)
+      view.render(Screen.new(b1), Rect.new(0, 0, 70, 20))
+      b1.contains?("query").should be_true
+      b1.contains?("host:acme").should be_true
+    end
+  end
+
+  it "completes a field name with Tab" do
+    view = SitemapView.new
+    view.start_query
+    "met".each_char { |c| view.query_insert(c) }
+    view.query_complete.should be_true
+    view.querying?.should be_true
+
+    b = MemoryBackend.new(70, 6)
+    view.render(Screen.new(b), Rect.new(0, 0, 70, 6))
+    b.contains?("method:").should be_true
+  end
 end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -124,6 +124,10 @@ private class FakeContext < ExecContext
     @calls << :sitemap_collapse
   end
 
+  def sitemap_query : Nil
+    @calls << :sitemap_query
+  end
+
   def scope_open : Nil
     @calls << :scope_open
   end

--- a/src/gori/proxy/upstream.cr
+++ b/src/gori/proxy/upstream.cr
@@ -87,10 +87,14 @@ module Gori::Proxy
       end
     end
 
-    def self.dial_tls(host : String, port : Int32, verify : Bool, alpn : String? = nil) : OpenSSL::SSL::Socket::Client?
+    # `sni` overrides the name presented in the TLS ClientHello (and, under verify,
+    # the name the cert is checked against) WITHOUT changing the dialed host:port —
+    # the replay workbench uses it for domain-fronting / vhost-confusion / IP-direct
+    # sends. nil → the dialed host is used (the usual case).
+    def self.dial_tls(host : String, port : Int32, verify : Bool, alpn : String? = nil, sni : String? = nil) : OpenSSL::SSL::Socket::Client?
       tcp = dial(host, port)
       return nil unless tcp
-      ssl = OpenSSL::SSL::Socket::Client.new(tcp, context: client_context(verify, alpn), sync_close: true, hostname: host)
+      ssl = OpenSSL::SSL::Socket::Client.new(tcp, context: client_context(verify, alpn), sync_close: true, hostname: sni || host)
       ssl.sync = true
       ssl
     rescue

--- a/src/gori/replay/engine.cr
+++ b/src/gori/replay/engine.cr
@@ -24,9 +24,9 @@ module Gori
     # Reuses the proxy's dialer/codec; no proxying — this is a direct send.
     module Engine
       def self.send(request : Bytes, *, scheme : String, host : String, port : Int32,
-                    verify_upstream : Bool) : Result
+                    verify_upstream : Bool, sni : String? = nil) : Result
         started = Time.instant
-        upstream = scheme == "https" ? Proxy::Upstream.dial_tls(host, port, verify: verify_upstream) : Proxy::Upstream.dial(host, port)
+        upstream = scheme == "https" ? Proxy::Upstream.dial_tls(host, port, verify: verify_upstream, sni: sni) : Proxy::Upstream.dial(host, port)
         return error("connect failed: #{host}:#{port}", started) unless upstream
 
         begin

--- a/src/gori/replay/h2_engine.cr
+++ b/src/gori/replay/h2_engine.cr
@@ -31,9 +31,9 @@ module Gori
       FORBIDDEN = {"connection", "keep-alive", "proxy-connection", "transfer-encoding", "upgrade", "host"}
 
       def self.send(request : Bytes, *, scheme : String, host : String, port : Int32,
-                    verify_upstream : Bool) : Result
+                    verify_upstream : Bool, sni : String? = nil) : Result
         started = Time.instant
-        upstream = open(scheme, host, port, verify_upstream)
+        upstream = open(scheme, host, port, verify_upstream, sni)
         return failure("h2 connect failed (no h2 negotiated): #{host}:#{port}", started) unless upstream
         begin
           headers, body = parse_request(request, scheme, host, port)
@@ -50,9 +50,9 @@ module Gori
         end
       end
 
-      private def self.open(scheme : String, host : String, port : Int32, verify : Bool) : IO?
+      private def self.open(scheme : String, host : String, port : Int32, verify : Bool, sni : String? = nil) : IO?
         if scheme == "https"
-          ssl = Proxy::Upstream.dial_tls(host, port, verify: verify, alpn: "h2")
+          ssl = Proxy::Upstream.dial_tls(host, port, verify: verify, alpn: "h2", sni: sni)
           return nil unless ssl
           # Origin completed the handshake but won't speak h2 — close the live
           # socket before bailing, else it leaks (it's never returned to `ensure`).

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -306,12 +306,12 @@ module Gori
     # (potentially multi-MB) response on each cross-session commit.
     def replays : Array(ReplayRecord)
       list = [] of ReplayRecord
-      @db.query("SELECT id, target, request, http2, auto_content_length, flow_id, position, response_head, response_body, response_error, response_duration_us, name FROM replays ORDER BY position, id") do |rs|
+      @db.query("SELECT id, target, request, http2, auto_content_length, flow_id, position, response_head, response_body, response_error, response_duration_us, name, sni FROM replays ORDER BY position, id") do |rs|
         rs.each do
           list << ReplayRecord.new(
             rs.read(Int64), rs.read(String), rs.read(String),
             rs.read(Int32) != 0, rs.read(Int32) != 0, rs.read(Int64?), rs.read(Int32),
-            rs.read(Bytes?), rs.read(Bytes?), rs.read(String?), rs.read(Int64?), rs.read(String?))
+            rs.read(Bytes?), rs.read(Bytes?), rs.read(String?), rs.read(Int64?), rs.read(String?), rs.read(String?))
         end
       end
       list
@@ -322,11 +322,12 @@ module Gori
     # response (responses are personal per session). Response fields stay nil.
     def replays_meta : Array(ReplayRecord)
       list = [] of ReplayRecord
-      @db.query("SELECT id, target, request, http2, auto_content_length, flow_id, position FROM replays ORDER BY position, id") do |rs|
+      @db.query("SELECT id, target, request, http2, auto_content_length, flow_id, position, sni FROM replays ORDER BY position, id") do |rs|
         rs.each do
           list << ReplayRecord.new(
             rs.read(Int64), rs.read(String), rs.read(String),
-            rs.read(Int32) != 0, rs.read(Int32) != 0, rs.read(Int64?), rs.read(Int32))
+            rs.read(Int32) != 0, rs.read(Int32) != 0, rs.read(Int64?), rs.read(Int32),
+            sni: rs.read(String?))
         end
       end
       list
@@ -335,19 +336,19 @@ module Gori
     # Returns the new row id (or 0 if the store is closing — the caller normalizes
     # 0 → nil so a later update never targets a bogus row).
     def insert_replay(target : String, request : String, http2 : Bool,
-                      auto_cl : Bool, flow_id : Int64?, position : Int32) : Int64
+                      auto_cl : Bool, flow_id : Int64?, position : Int32, sni : String? = nil) : Int64
       ts = now_us
       exec_task ->(c : DB::Connection) {
-        c.exec("INSERT INTO replays (created_at, updated_at, target, request, http2, auto_content_length, flow_id, position) VALUES (?,?,?,?,?,?,?,?)",
-          ts, ts, target, request, http2 ? 1 : 0, auto_cl ? 1 : 0, flow_id, position)
+        c.exec("INSERT INTO replays (created_at, updated_at, target, request, http2, auto_content_length, flow_id, position, sni) VALUES (?,?,?,?,?,?,?,?,?)",
+          ts, ts, target, request, http2 ? 1 : 0, auto_cl ? 1 : 0, flow_id, position, sni)
         nil
       }
     end
 
-    def update_replay(id : Int64, target : String, request : String, http2 : Bool, auto_cl : Bool) : Nil
+    def update_replay(id : Int64, target : String, request : String, http2 : Bool, auto_cl : Bool, sni : String? = nil) : Nil
       exec_task ->(c : DB::Connection) {
-        c.exec("UPDATE replays SET target = ?, request = ?, http2 = ?, auto_content_length = ?, updated_at = ? WHERE id = ?",
-          target, request, http2 ? 1 : 0, auto_cl ? 1 : 0, now_us, id)
+        c.exec("UPDATE replays SET target = ?, request = ?, http2 = ?, auto_content_length = ?, sni = ?, updated_at = ? WHERE id = ?",
+          target, request, http2 ? 1 : 0, auto_cl ? 1 : 0, sni, now_us, id)
         nil
       }
     end
@@ -575,6 +576,12 @@ module Gori
         rs.each { rows << {rs.read(String), rs.read(String), rs.read(String)} }
       end
       rows
+    rescue ex
+      # The Sitemap's `/` filter feeds user QL here; a malformed FTS phrase raises a
+      # SQLite error. A live filter must never crash the run loop — degrade to no
+      # matches (mirrors #search) and let the user fix the query.
+      STDERR.puts "gori: sitemap query failed (#{ex.message})"
+      [] of {String, String, String}
     end
 
     # Passive-signal tags for a flow, fetched lazily per on-screen row (P8 pull,

--- a/src/gori/store/models.cr
+++ b/src/gori/store/models.cr
@@ -216,10 +216,11 @@ module Gori
       getter response_error : String?
       getter response_duration_us : Int64?
       getter name : String? # custom sub-tab label (nil = derive from the request)
+      getter sni : String?  # custom TLS SNI host (nil = present the target host)
 
       def initialize(@id, @target, @request, @http2, @auto_content_length, @flow_id, @position,
                      @response_head = nil, @response_body = nil, @response_error = nil,
-                     @response_duration_us = nil, @name = nil)
+                     @response_duration_us = nil, @name = nil, @sni = nil)
       end
     end
 

--- a/src/gori/store/schema.cr
+++ b/src/gori/store/schema.cr
@@ -7,7 +7,7 @@ module Gori
     # (FTS5 for QL, a tags table, a connections table) arrive as *later*
     # migrations — which is exactly why none of them exist in v1 (P0).
     module Schema
-      VERSION = 14
+      VERSION = 15
 
       V1 = [
         <<-SQL,
@@ -236,7 +236,15 @@ module Gori
         "ALTER TABLE replays ADD COLUMN name TEXT",
       ]
 
-      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14]
+      # A replay tab can carry a custom SNI host — the name presented in the TLS
+      # ClientHello, decoupled from the dialed target host (domain fronting / vhost
+      # confusion / IP-direct sends). NULL = present the target host (the default).
+      # Request-side config, so it syncs across sessions like target/request.
+      V15 = [
+        "ALTER TABLE replays ADD COLUMN sni TEXT",
+      ]
+
+      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15]
 
       def self.migrate!(db : DB::Database) : Nil
         current = db.scalar("PRAGMA user_version").as(Int64).to_i

--- a/src/gori/tui/controllers/replay_controller.cr
+++ b/src/gori/tui/controllers/replay_controller.cr
@@ -30,7 +30,7 @@ module Gori::Tui
       @host.session.store.replays.each do |r|
         view = ReplayView.new
         view.restore(r.target, r.request, r.http2?, r.auto_content_length?,
-          r.response_head, r.response_body, r.response_error, r.response_duration_us)
+          r.response_head, r.response_body, r.response_error, r.response_duration_us, sni: r.sni || "")
         view.name = r.name # custom sub-tab label survives reopen
         seed_replay_original(view, r.flow_id)
         @replays << ReplayTab.new(view, r.flow_id, r.id)
@@ -85,7 +85,8 @@ module Gori::Tui
       return "↹/esc tabs · ^N new" unless v
       return "HEX: 0-9a-f overtype · Ins/Del/⌫ bytes · ←/→/↑/↓ move · ^R send · ^X/esc exit" if v.request_hex?
       case v.focus
-      when :target   then "type URL · ↵/↓ request · ^R send · ↹ pane · ^N new · esc tabs"
+      when :target   then v.editing_sni? ? "type SNI host · ^S/↵/esc back to URL · ^R send" \
+                                          : "type URL · ^S SNI · ↵/↓ request · ^R send · ↹ pane · esc tabs"
       when :response then "↑/↓ scroll · ←/→/d diff · x hex · ^F find · ^R send · ↹ pane · esc tabs"
       else                "type to edit · ^R send · ^G goto · ^F find · ^X hex · ^B ws · ^N new · ^W close · ↹ pane · esc tabs"
       end
@@ -154,8 +155,19 @@ module Gori::Tui
         else
           @host.status("hex edit (^X) applies to the REQUEST pane — ↹ to it")
         end
+      elsif ev.ctrl? && key.lower_s?
+        # ^S toggles the SNI override sub-field (TARGET pane only). The dialed host
+        # is unchanged — only the TLS ClientHello name differs.
+        if (view = current_view) && view.focus == :target
+          view.toggle_sni_field
+          @host.status(view.editing_sni? ? "SNI override: type a domain · ^S/↵/esc back to URL" : "editing target URL")
+        else
+          @host.status("SNI override (^S) applies to the TARGET pane — ↹ to it")
+        end
       elsif key.escape?
-        if (view = current_view) && view.focus == :request && view.request_hex?
+        if (view = current_view) && view.focus == :target && view.editing_sni?
+          view.exit_sni_field # leave the SNI field, back to the URL (value kept)
+        elsif (view = current_view) && view.focus == :request && view.request_hex?
           view.toggle_request_hex # exit hex back to the text editor (only when on the request pane)
         else
           @host.request_focus(:menu)
@@ -298,11 +310,12 @@ module Gori::Tui
         # on ANY peer commit, so most polls touch an identical row — restoring then
         # would needlessly wipe its on-screen response/scroll/focus).
         next if v.target == row.target && v.request_text == row.request &&
-                v.http2? == row.http2? && v.auto_content_length? == row.auto_content_length?
+                v.http2? == row.http2? && v.auto_content_length? == row.auto_content_length? &&
+                v.sni_override == row.sni
         # Live cross-session sync carries only the REQUEST (a response is personal to
         # each session's view); restore() is response-less so a peer's resend never
         # clobbers the local response/scroll/focus.
-        v.restore(row.target, row.request, row.http2?, row.auto_content_length?)
+        v.restore(row.target, row.request, row.http2?, row.auto_content_length?, sni: row.sni || "")
         seed_replay_original(v, row.flow_id) # restore() drops the baseline; re-seed it
       end
 
@@ -310,7 +323,7 @@ module Gori::Tui
       rows.each do |row|
         next if local_ids.includes?(row.id)
         view = ReplayView.new
-        view.restore(row.target, row.request, row.http2?, row.auto_content_length?)
+        view.restore(row.target, row.request, row.http2?, row.auto_content_length?, sni: row.sni || "")
         seed_replay_original(view, row.flow_id)
         @replays << ReplayTab.new(view, row.flow_id, row.id)
       end
@@ -364,7 +377,7 @@ module Gori::Tui
     # reconcile key). A closing store returns 0 → nil, leaving the tab unsaved.
     private def persist_new_replay(view : ReplayView, flow_id : Int64?) : Int64?
       id = @host.session.store.insert_replay(view.target, view.request_text, view.http2?,
-        view.auto_content_length?, flow_id, @replays.size)
+        view.auto_content_length?, flow_id, @replays.size, view.sni_override)
       id == 0 ? nil : id
     end
 
@@ -403,17 +416,18 @@ module Gori::Tui
       verify = !@host.session.config.insecure_upstream?
       bytes = view.request_bytes
       http2 = view.http2?
+      sni = view.sni_override # custom TLS SNI host (nil → present the dialed host)
       results = @replay_results
       view.inflight = true
-      @host.status("replaying → #{host}:#{port}…")
+      @host.status("replaying → #{host}:#{port}#{sni ? " (SNI #{sni})" : ""}…")
       # Off the UI fiber: a round-trip can block up to 30s. The fiber touches only these
       # captured locals + the inflight flag — and hands the Result back through the
       # channel; the run loop applies it (see #drain_results).
       spawn(name: "gori-replay") do
         result = if http2
-                   Replay::H2Engine.send(bytes, scheme: scheme, host: host, port: port, verify_upstream: verify)
+                   Replay::H2Engine.send(bytes, scheme: scheme, host: host, port: port, verify_upstream: verify, sni: sni)
                  else
-                   Replay::Engine.send(bytes, scheme: scheme, host: host, port: port, verify_upstream: verify)
+                   Replay::Engine.send(bytes, scheme: scheme, host: host, port: port, verify_upstream: verify, sni: sni)
                  end
         # Non-blocking hand-off: if the user already left the project the channel is
         # orphaned, so drop the late result instead of blocking this fiber forever.
@@ -440,7 +454,7 @@ module Gori::Tui
       return unless tab = current_replay_tab
       return unless (id = tab.db_id) && tab.view.dirty?
       v = tab.view
-      @host.session.store.update_replay(id, v.target, v.request_text, v.http2?, v.auto_content_length?)
+      @host.session.store.update_replay(id, v.target, v.request_text, v.http2?, v.auto_content_length?, v.sni_override)
       v.clear_dirty
     end
 
@@ -506,15 +520,36 @@ module Gori::Tui
     end
 
     private def edit_replay_target(ev : Termisu::Event::Key, view : ReplayView) : Nil
+      return edit_replay_sni(ev, view) if view.editing_sni? # ^S sub-field of the TARGET pane
       key = ev.key
       c = ev.char || key.to_char
       case
       when key.enter?     then view.pane_advance(1)                                       # ↵ confirms URL → Request (^R sends, not ↵)
       when key.up?        then @host.request_focus(@replays.size >= 2 ? :subtabs : :menu) # target is the top pane → ↑ pops up
-      when key.down?      then view.pane_advance(1)                                       # ↓ → drop into the Request pane below
+      when key.down?      then view.pane_advance(1)                                        # ↓ → drop into the Request pane below
       when key.backspace? then view.target_backspace
       when key.left?      then view.target_move(-1)
       when key.right?     then view.target_move(1)
+      else
+        if c && !ev.ctrl? && !ev.alt?
+          view.target_insert(c)
+          view.set_preedit("")
+        end
+      end
+    end
+
+    # The SNI override sub-field: same single-line editing (the view's target mutators
+    # self-route to it while editing_sni?), but ↵/↑ return to the URL row rather than
+    # advancing panes, and ↓ still drops into the Request pane below.
+    private def edit_replay_sni(ev : Termisu::Event::Key, view : ReplayView) : Nil
+      key = ev.key
+      c = ev.char || key.to_char
+      case
+      when key.enter?, key.up? then view.exit_sni_field
+      when key.down?           then view.pane_advance(1)
+      when key.backspace?      then view.target_backspace
+      when key.left?           then view.target_move(-1)
+      when key.right?          then view.target_move(1)
       else
         if c && !ev.ctrl? && !ev.alt?
           view.target_insert(c)

--- a/src/gori/tui/controllers/sitemap_controller.cr
+++ b/src/gori/tui/controllers/sitemap_controller.cr
@@ -7,9 +7,17 @@ module Gori::Tui
   # sitemap verbs. `reload` is public so the cross-tab scope lens (which filters the
   # tree) can refresh it.
   class SitemapController < TabController
+    QUERY_DEBOUNCE = 110.milliseconds
+
     def initialize(host : Host)
       super(host)
       @sitemap = SitemapView.new
+      @sitemap.set_scope(@host.session.scope) # honour the lens + show its chip on the bar
+      @query_reload_at = nil.as(Time::Instant?)
+    end
+
+    def view : SitemapView
+      @sitemap
     end
 
     def tab : Symbol
@@ -18,6 +26,10 @@ module Gori::Tui
 
     def command_scope : Verb::Scope
       Verb::Scope::Sitemap
+    end
+
+    def body_badge : Symbol # the QL filter bar captures text; else the navigable tree
+      @sitemap.querying? ? :editor : :body
     end
 
     def render_body(screen : Screen, rect : Rect, focus : Symbol) : Nil
@@ -40,7 +52,15 @@ module Gori::Tui
     end
 
     def body_hint(focus : Symbol) : String
-      "↑/↓ move · ↵/→ expand · ← collapse · esc tabs"
+      @sitemap.querying? ? "type query · ↹ complete · ↵ apply · esc clear" \
+                         : "↑/↓ move · / filter · ↵/→ expand · ← collapse · esc tabs"
+    end
+
+    # Live IME composition only flows to the QL filter bar (the one text field).
+    def set_preedit(text : String) : Bool
+      return false unless @sitemap.querying?
+      @sitemap.set_preedit(text)
+      true
     end
 
     def on_enter : Nil
@@ -51,10 +71,61 @@ module Gori::Tui
       reload
     end
 
-    # Re-derive the tree from the store under the current scope filter. Public so the
-    # scope-lens toggle (a cross-tab action mediated by the shell) can refresh it.
+    # Re-derive the tree from the store under the current scope filter + `/` query
+    # (both held by the view). Public so the scope-lens toggle (a cross-tab action
+    # mediated by the shell) can refresh it.
     def reload : Nil
-      @sitemap.reload(@host.session.store, @host.session.scope.filter)
+      @sitemap.reload(@host.session.store)
+    end
+
+    # --- QL filter bar (a text sub-mode; the shell claims it before the focus ring) ---
+    # Returns true (swallows). Mirrors HistoryController#handle_query_key.
+    def handle_query_key(ev : Termisu::Event::Key) : Bool
+      key = ev.key
+      c = ev.char || key.to_char
+      store = @host.session.store
+      case
+      when key.enter?     then flush_query_reload; @sitemap.stop_query
+      when key.escape?    then @query_reload_at = nil; @sitemap.cancel_query; @sitemap.reload(store)
+      when key.tab?       then (@sitemap.query_complete; schedule_query_reload)
+      when key.backspace? then @sitemap.query_backspace; schedule_query_reload
+      when key.left?      then @sitemap.query_move(-1)
+      when key.right?     then @sitemap.query_move(1)
+      else
+        if c && !ev.ctrl? && !ev.alt?
+          @sitemap.query_insert(c)
+          schedule_query_reload
+          @sitemap.set_preedit("") # clear preedit on committed char
+        end
+      end
+      true
+    end
+
+    # Called each run-loop tick: run the debounced filter reload if the deadline
+    # passed. Returns true when it flushed (→ the shell marks the frame dirty).
+    def flush_query_reload_if_due(now : Time::Instant) : Bool
+      if (deadline = @query_reload_at) && now >= deadline
+        flush_query_reload
+        return true
+      end
+      false
+    end
+
+    # Defer the (potentially 10k-node) tree rebuild until typing pauses.
+    private def schedule_query_reload : Nil
+      @query_reload_at = Time.instant + QUERY_DEBOUNCE
+    end
+
+    private def flush_query_reload : Nil
+      return unless @query_reload_at
+      @query_reload_at = nil
+      @sitemap.reload(@host.session.store)
+    end
+
+    # `/` — focus the QL filter bar (verb-dispatched).
+    def sitemap_query : Nil
+      @sitemap.start_query
+      @host.status("filter: type a query · ↹ complete · ↵ apply · esc clear")
     end
 
     # --- verbs (delegated from the Runner's ExecContext) ---

--- a/src/gori/tui/fmt.cr
+++ b/src/gori/tui/fmt.cr
@@ -1,0 +1,37 @@
+module Gori::Tui
+  # Compact, fixed-width formatters for the frequently-scanned size/latency cells
+  # shared by the History list and the Replay response pane. Pure functions (no
+  # Screen/Theme) so any view can reuse them — kept here so there is ONE rounding
+  # convention (e.g. 1023.6 KB rolls up to "1.0MB", not the misleading "1024KB").
+  module Fmt
+    # Compact response size (B/KB/MB/GB), bounded to ≤6 cols. "—" until the response
+    # lands. The unit is picked from the ROUNDED magnitude so a value just under a
+    # boundary (e.g. 1023.6 KB) rolls up to the next unit ("1.0MB") instead of the
+    # misleading "1024KB".
+    def self.size(bytes : Int64?) : String
+      return "—" unless bytes
+      return "#{bytes}B" if bytes < 1024
+      kb = bytes / 1024.0
+      return unit(kb, "KB") if kb.round < 1024
+      mb = bytes / 1_048_576.0
+      return unit(mb, "MB") if mb.round < 1024
+      unit(bytes / 1_073_741_824.0, "GB")
+    end
+
+    # One decimal under 10 (3.4KB), whole at/above (345KB) — keeps the cell ≤6 cols.
+    def self.unit(v : Float64, suffix : String) : String
+      v < 10 ? "#{v.round(1)}#{suffix}" : "#{v.round.to_i}#{suffix}"
+    end
+
+    # Compact request→response latency (ms/s/m/h), bounded to ≤6 cols. "—" until the
+    # response lands; a minute/hour tier keeps very slow flows from overflowing.
+    def self.dur(us : Int64?) : String
+      return "—" unless us
+      ms = us // 1000
+      return "#{ms}ms" if ms < 1000
+      return "#{(ms / 1000.0).round(1)}s" if ms < 60_000
+      return "#{(ms / 60_000.0).round(1)}m" if ms < 3_600_000
+      "#{(ms / 3_600_000.0).round(1)}h"
+    end
+  end
+end

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -48,6 +48,7 @@ module Gori::Tui
         {"^N / ^W", "new / close a sub-tab"},
         {"r", "rename the sub-tab (on the strip)"},
         {"^X", "hex-edit the request"},
+        {"^S", "SNI override (on the target)"},
         {"↹", "cycle target → request → response"},
         {"x · d", "response: hex · diff"},
       ]},
@@ -57,7 +58,7 @@ module Gori::Tui
         {"^B", "reveal whitespace"},
       ]},
       {"OTHER TABS", [
-        {"Sitemap", "↑/↓ move · ↵/→ expand · ← collapse"},
+        {"Sitemap", "↑/↓ move · / filter · ↵/→ expand · ← collapse"},
         {"Findings", "↵ open · n new · d delete · x export"},
         {"Notes", "type to edit · ^N new · ^1-9 switch"},
         {"Project", "scope rules + the description editor"},

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -7,6 +7,7 @@ require "./gutter"
 require "./search_hi"
 require "./reveal"
 require "./url"
+require "./fmt"
 require "../store"
 require "../ql"
 require "../scope"
@@ -597,29 +598,13 @@ module Gori::Tui
     # boundary (e.g. 1023.6 KB) rolls up to the next unit ("1.0MB") instead of the
     # misleading "1024KB".
     private def fmt_size(bytes : Int64?) : String
-      return "—" unless bytes
-      return "#{bytes}B" if bytes < 1024
-      kb = bytes / 1024.0
-      return fmt_unit(kb, "KB") if kb.round < 1024
-      mb = bytes / 1_048_576.0
-      return fmt_unit(mb, "MB") if mb.round < 1024
-      fmt_unit(bytes / 1_073_741_824.0, "GB")
-    end
-
-    # One decimal under 10 (3.4KB), whole at/above (345KB) — keeps the cell ≤6 cols.
-    private def fmt_unit(v : Float64, unit : String) : String
-      v < 10 ? "#{v.round(1)}#{unit}" : "#{v.round.to_i}#{unit}"
+      Fmt.size(bytes)
     end
 
     # Compact request→response latency (ms/s/m/h), bounded to ≤6 cols. "—" until the
     # response lands; a minute/hour tier keeps very slow flows from overflowing.
     private def fmt_dur(us : Int64?) : String
-      return "—" unless us
-      ms = us // 1000
-      return "#{ms}ms" if ms < 1000
-      return "#{(ms / 1000.0).round(1)}s" if ms < 60_000
-      return "#{(ms / 60_000.0).round(1)}m" if ms < 3_600_000
-      "#{(ms / 3_600_000.0).round(1)}h"
+      Fmt.dur(us)
     end
 
     # Compact response MIME — the useful subtype (json/html/png/js…), params dropped.

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -439,7 +439,9 @@ module Gori::Tui
     # and place that field's caret. The value bases mirror render_target (field_base).
     def target_click_to_cursor(rect : Rect, mx : Int32, my : Int32) : Nil
       return unless @loaded
-      if sni_active? && my >= rect.y + 2
+      # The SNI row is at exactly rect.y+2 (bottom border is rect.y+3) — match it
+      # precisely, so a click on the card's border doesn't route edits into @sni.
+      if sni_active? && my == rect.y + 2
         @target_field = :sni
         @scx = Screen.column_for(@sni, mx - field_base(rect, SNI_PREFIX))
       else
@@ -693,10 +695,15 @@ module Gori::Tui
       base = field_base(rect, prefix)
       screen.text(base, row, value, Theme.text_bright, width: {rect.right - base - 1, 1}.max)
       if active
-        ch = cx < value.size ? value[cx] : ' '
         cursor_x = base + Screen.display_width(value[0, cx])
-        screen.cell(cursor_x, row, ch, Theme.bg, Theme.accent)
-        screen.cursor(cursor_x, row)
+        # Only paint the caret while it's inside the field (before the right border) —
+        # a value longer than the drawn width must not place the cursor over the
+        # border or into the neighbouring pane (mirrors Screen#input_line's guard).
+        if cursor_x < rect.right - 1
+          ch = cx < value.size ? value[cx] : ' '
+          screen.cell(cursor_x, row, ch, Theme.bg, Theme.accent)
+          screen.cursor(cursor_x, row)
+        end
       end
     end
 

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -9,6 +9,7 @@ require "./text_area"
 require "./gutter"
 require "./search_hi"
 require "./reveal"
+require "./fmt"
 require "../store"
 require "../replay/engine"
 require "../replay/h2_engine"
@@ -31,7 +32,10 @@ module Gori::Tui
       @name = nil
       @flow = nil.as(Store::FlowDetail?)
       @target = ""
-      @tcx = 0 # target cursor
+      @tcx = 0              # target (URL) cursor
+      @sni = ""             # custom TLS SNI host ("" = present the target host)
+      @scx = 0              # SNI cursor
+      @target_field = :url  # which field the TARGET pane edits: :url | :sni
       @editor = TextArea.new
       @editor.gutter = true # line numbers in the request body (pairs with ^G)
       @search_hl = ""       # active ^F query → highlight in the response pane (request is via @editor)
@@ -185,6 +189,9 @@ module Gori::Tui
       @http2 = detail.http_version == "HTTP/2"
       @target = build_target(detail.row.scheme, detail.row.host, detail.row.port)
       @tcx = @target.size
+      @sni = ""
+      @scx = 0
+      @target_field = :url
       @editor.set_text(origin_form_text(detail))
       @original_lines = message_lines(detail.response_head, display_body(detail.response_head, detail.response_body))
 
@@ -210,11 +217,15 @@ module Gori::Tui
     # us — that would echo back to the peer.
     def restore(target : String, request : String, http2 : Bool, auto_cl : Bool,
                 response_head : Bytes? = nil, response_body : Bytes? = nil,
-                response_error : String? = nil, response_duration_us : Int64? = nil) : Nil
+                response_error : String? = nil, response_duration_us : Int64? = nil,
+                sni : String = "") : Nil
       @flow = nil
       @http2 = http2
       @target = target
       @tcx = @target.size
+      @sni = sni
+      @scx = @sni.size
+      @target_field = :url
       @editor.set_text(request)
       @original_lines = [] of String
       # Rebuild the persisted result: a head (success) or an error (failed send)
@@ -259,6 +270,9 @@ module Gori::Tui
       @http2 = false
       @target = BLANK_TARGET
       @tcx = @target.size
+      @sni = ""
+      @scx = 0
+      @target_field = :url
       @editor.set_text(BLANK_REQUEST)
       @original_lines = [] of String
       @result = nil
@@ -329,6 +343,26 @@ module Gori::Tui
       {"http", "", 0}
     end
 
+    # The TARGET card grows to a second content row (4 high vs 3) whenever an SNI
+    # override is set OR is being edited — so the override is always visible, and the
+    # input row only appears once you reach for it (^S).
+    private def sni_active? : Bool
+      !@sni.strip.empty? || (editing_sni? && @focus == :target)
+    end
+
+    private def target_card_h : Int32
+      sni_active? ? 4 : 3
+    end
+
+    # The TARGET card row prefixes (marker + the field value 1 col to its right). Kept
+    # as constants so render_target and the click→caret mapping agree on the value base.
+    TARGET_PREFIX = "›"
+    SNI_PREFIX    = "SNI ›"
+
+    private def field_base(rect : Rect, prefix : String) : Int32
+      rect.x + 2 + prefix.size + 1
+    end
+
     # --- focus ring (driven by the Runner's Tab/Shift-Tab) ---
     # Pane order top-to-bottom: target ▸ request ▸ response. focus_first/last are
     # the ends of the ring; pane_advance returns false when it would step off an
@@ -336,11 +370,20 @@ module Gori::Tui
     PANE_ORDER = [:target, :request, :response]
 
     def focus_first : Nil
-      @focus = :target
+      set_focus(:target)
     end
 
     def focus_last : Nil
-      @focus = :response
+      set_focus(:response)
+    end
+
+    # Move focus to `pane`, exiting the ^S SNI sub-field. SNI editing is an explicit
+    # per-visit sub-mode (you opt in with ^S each time you're on the target), so ANY
+    # focus change drops back to the URL field — otherwise navigating away while
+    # editing SNI and returning would silently route URL keystrokes into @sni.
+    private def set_focus(pane : Symbol) : Nil
+      @focus = pane
+      @target_field = :url
     end
 
     def set_preedit(text : String) : Nil
@@ -351,21 +394,22 @@ module Gori::Tui
       i = PANE_ORDER.index(@focus) || 0
       ni = i + dir
       return false if ni < 0 || ni >= PANE_ORDER.size
-      @focus = PANE_ORDER[ni]
+      set_focus(PANE_ORDER[ni])
       true
     end
 
     # Public setter mirroring the focus ring: jump straight to a pane (e.g. a click)
     # rather than stepping with pane_advance. Ignores anything not in PANE_ORDER.
+    # (A click on the SNI row re-enters it: target_click_to_cursor runs after this.)
     def focus_pane(pane : Symbol) : Nil
-      @focus = pane if PANE_ORDER.includes?(pane)
+      set_focus(pane) if PANE_ORDER.includes?(pane)
     end
 
     # Inverts render's layout: a 3-row target band on top, then a half-width
     # request|response split (the column at content.x + half is the divider).
     def pane_at(rect : Rect, mx : Int32, my : Int32) : Symbol?
       return nil unless @loaded && rect.contains?(mx, my)
-      target_h = {rect.h, 3}.min
+      target_h = {rect.h, target_card_h}.min
       return :target if my < rect.y + target_h
       content = Rect.new(rect.x, rect.y + target_h, rect.w, {rect.h - target_h, 0}.max)
       return nil if content.h <= 0
@@ -379,7 +423,7 @@ module Gori::Tui
     # (target band + split, then the card's 1-cell inset) exactly as render_request does.
     def request_click_to_cursor(rect : Rect, mx : Int32, my : Int32) : Nil
       return unless @loaded
-      target_h = {rect.h, 3}.min
+      target_h = {rect.h, target_card_h}.min
       content = Rect.new(rect.x, rect.y + target_h, rect.w, {rect.h - target_h, 0}.max)
       return if content.h <= 0
       half = {(content.w - 1) // 2, 1}.max
@@ -391,11 +435,17 @@ module Gori::Tui
       end
     end
 
-    # Mouse: place the single-line TARGET caret at a click. render_target draws
-    # @target at rect.x + 4 of the target band (which shares the body's x).
+    # Mouse: focus the URL or SNI field of the TARGET band by which row was clicked,
+    # and place that field's caret. The value bases mirror render_target (field_base).
     def target_click_to_cursor(rect : Rect, mx : Int32, my : Int32) : Nil
       return unless @loaded
-      @tcx = Screen.column_for(@target, mx - (rect.x + 4))
+      if sni_active? && my >= rect.y + 2
+        @target_field = :sni
+        @scx = Screen.column_for(@sni, mx - field_base(rect, SNI_PREFIX))
+      else
+        @target_field = :url
+        @tcx = Screen.column_for(@target, mx - field_base(rect, TARGET_PREFIX))
+      end
     end
 
     # Top boundary of the focused pane — the Runner pops focus to the tab bar when
@@ -481,21 +531,68 @@ module Gori::Tui
     end
 
     # --- target field (focus == :target) ---
+    # The TARGET pane edits one of two single-line fields — the URL or the SNI host
+    # override — selected by @target_field (^S toggles). The mutators below act on
+    # whichever is active so one set of keys drives both.
+    getter sni : String
+
+    # The SNI host to present in the TLS handshake, or nil when blank (→ the dialed
+    # target host is used, the usual case).
+    def sni_override : String?
+      s = @sni.strip
+      s.empty? ? nil : s
+    end
+
+    def editing_sni? : Bool
+      @target_field == :sni
+    end
+
+    # ^S (on the TARGET pane): flip between editing the URL and the SNI host. Entering
+    # the SNI field homes its caret to the end; leaving it returns to the URL.
+    def toggle_sni_field : Nil
+      if @target_field == :sni
+        @target_field = :url
+      else
+        @target_field = :sni
+        @scx = @sni.size
+      end
+    end
+
+    # Drop back to URL editing (↵/esc in the SNI field) without changing the value.
+    def exit_sni_field : Nil
+      @target_field = :url
+    end
+
     def target_insert(ch : Char) : Nil
-      @target = "#{@target[0, @tcx]}#{ch}#{@target[@tcx..]}"
-      @tcx += 1
+      if @target_field == :sni
+        @sni = "#{@sni[0, @scx]}#{ch}#{@sni[@scx..]}"
+        @scx += 1
+      else
+        @target = "#{@target[0, @tcx]}#{ch}#{@target[@tcx..]}"
+        @tcx += 1
+      end
       @dirty = true
     end
 
     def target_backspace : Nil
-      return if @tcx == 0
-      @target = "#{@target[0, @tcx - 1]}#{@target[@tcx..]}"
-      @tcx -= 1
+      if @target_field == :sni
+        return if @scx == 0
+        @sni = "#{@sni[0, @scx - 1]}#{@sni[@scx..]}"
+        @scx -= 1
+      else
+        return if @tcx == 0
+        @target = "#{@target[0, @tcx - 1]}#{@target[@tcx..]}"
+        @tcx -= 1
+      end
       @dirty = true
     end
 
     def target_move(d : Int32) : Nil
-      @tcx = (@tcx + d).clamp(0, @target.size)
+      if @target_field == :sni
+        @scx = (@scx + d).clamp(0, @sni.size)
+      else
+        @tcx = (@tcx + d).clamp(0, @target.size)
+      end
       @dirty = true
     end
 
@@ -557,8 +654,9 @@ module Gori::Tui
         return
       end
 
-      # target pane: a 3-row card on top; request | response cards fill the rest.
-      target_h = {rect.h, 3}.min
+      # target pane: a 3-row card on top (4 when an SNI override is set/edited);
+      # request | response cards fill the rest.
+      target_h = {rect.h, target_card_h}.min
       render_target(screen, Rect.new(rect.x, rect.y, rect.w, target_h), focused && @focus == :target)
 
       content = Rect.new(rect.x, rect.y + target_h, rect.w, {rect.h - target_h, 0}.max)
@@ -577,13 +675,26 @@ module Gori::Tui
     private def render_target(screen : Screen, rect : Rect, focused : Bool) : Nil
       return if rect.h < 2
       Frame.card(screen, rect, "TARGET", bg: Theme.bg, border: pane_border(focused))
-      row = rect.y + 1
-      screen.text(rect.x + 2, row, "›", focused ? Theme.accent : Theme.muted)
-      base = rect.x + 4
-      screen.text(base, row, @target, Theme.text_bright, width: {rect.w - 6, 1}.max)
-      if focused
-        ch = @tcx < @target.size ? @target[@tcx] : ' '
-        cursor_x = base + Screen.display_width(@target[0, @tcx])
+      # An at-a-glance SNI marker on the top border (right of the title) whenever an
+      # override is set, so a custom SNI is visible even before the row is reached.
+      unless @sni.strip.empty?
+        badge = " SNI "
+        bx = {rect.right - badge.size - 1, rect.x + 9}.max
+        screen.text(bx, rect.y, badge, Theme.text_bright, Theme.accent_bg)
+      end
+      draw_target_row(screen, rect, rect.y + 1, TARGET_PREFIX, @target, @tcx, focused && @target_field == :url)
+      draw_target_row(screen, rect, rect.y + 2, SNI_PREFIX, @sni, @scx, focused && @target_field == :sni) if sni_active? && rect.h >= 4
+    end
+
+    # One single-line field row of the TARGET card: a marker prefix, then the value,
+    # with the block caret + terminal cursor when this row is the active field.
+    private def draw_target_row(screen : Screen, rect : Rect, row : Int32, prefix : String, value : String, cx : Int32, active : Bool) : Nil
+      screen.text(rect.x + 2, row, prefix, active ? Theme.accent : Theme.muted)
+      base = field_base(rect, prefix)
+      screen.text(base, row, value, Theme.text_bright, width: {rect.right - base - 1, 1}.max)
+      if active
+        ch = cx < value.size ? value[cx] : ' '
+        cursor_x = base + Screen.display_width(value[0, cx])
         screen.cell(cursor_x, row, ch, Theme.bg, Theme.accent)
         screen.cursor(cursor_x, row)
       end
@@ -620,8 +731,18 @@ module Gori::Tui
         !@resp_hex && @resp_mode == :response ? Theme.accent_bg : Theme.bg) + 1
       tx = screen.text(tx, rect.y, " diff ", !@resp_hex && @resp_mode == :diff ? Theme.text_bright : Theme.muted,
         !@resp_hex && @resp_mode == :diff ? Theme.accent_bg : Theme.bg) + 1
-      screen.text(tx, rect.y, " hex ", @resp_hex ? Theme.text_bright : Theme.muted,
+      chips_end = screen.text(tx, rect.y, " hex ", @resp_hex ? Theme.text_bright : Theme.muted,
         @resp_hex ? Theme.accent_bg : Theme.bg)
+
+      # Latency · size of the last send, right-aligned on the top border (the body
+      # already shows the status line, so duration + total wire bytes are the gap).
+      # Drawn only when it clears the mode chips, so a narrow pane drops it cleanly.
+      if result = @result
+        meta = result.ok? ? "#{Fmt.dur(result.duration_us)} · #{Fmt.size((result.head.size + (result.body.try(&.size) || 0)).to_i64)}"
+                          : Fmt.dur(result.duration_us)
+        meta_x = rect.right - meta.size - 1
+        screen.text(meta_x, rect.y, meta, Theme.muted, Theme.bg) if meta_x > chips_end + 1
+      end
 
       body = rect.inset(1, 1)
       if @resp_hex

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -233,6 +233,7 @@ module Gori::Tui
         end
         # Debounced QL filter: fire the deferred search once typing has paused.
         dirty = true if history_controller.flush_query_reload_if_due(now)
+        dirty = true if sitemap_controller.flush_query_reload_if_due(now)
         render if dirty
         break unless @outcome == :running
       end
@@ -379,6 +380,9 @@ module Gori::Tui
       # before the global focus ring claims Tab.
       if @active_tab == :history && @overlay == :none && @focus == :body && history_controller.view.querying?
         return if history_controller.handle_query_key(ev)
+      end
+      if @active_tab == :sitemap && @overlay == :none && @focus == :body && sitemap_controller.view.querying?
+        return if sitemap_controller.handle_query_key(ev)
       end
       if @active_tab == :findings && @overlay == :none && @focus == :body && findings_controller.view.editing_notes?
         return if findings_controller.handle_notes_key(ev)
@@ -1708,6 +1712,10 @@ module Gori::Tui
 
     def sitemap_collapse : Nil
       sitemap_controller.sitemap_collapse
+    end
+
+    def sitemap_query : Nil
+      sitemap_controller.sitemap_query
     end
 
     # --- History / detail ExecContext --- (delegated to HistoryController)

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -3,6 +3,7 @@ require "./screen"
 require "./theme"
 require "../store"
 require "../ql"
+require "../scope"
 
 module Gori::Tui
   # The Sitemap tab: a literal host → path tree built from captured flows (no ID
@@ -36,6 +37,10 @@ module Gori::Tui
       end
     end
 
+    # The QL fields meaningful for the endpoint tree (no `flag` — tags aren't
+    # produced yet). Mirrors History's set so the same `/` query language applies.
+    QL_FIELDS = %w(host path method status scheme body)
+
     def initialize
       @hosts = [] of Node
       @selected = 0
@@ -44,11 +49,25 @@ module Gori::Tui
       # Flattened (node, depth) rows, rebuilt only when the tree or its expand
       # state changes — not re-walked on every render frame.
       @visible_cache = nil.as(Array({Node, Int32})?)
+      # QL filter bar (mirrors HistoryView): the Scope lens + a `/` query are AND-ed
+      # into the one filter that builds the tree.
+      @scope = nil.as(Scope?)
+      @query = ""
+      @querying = false
+      @qcx = 0      # caret position within @query
+      @preedit = "" # IME composition, drawn at the caret
     end
 
-    def reload(store : Store, filter : QL::Filter = QL::EMPTY) : Nil
+    # Inject the Scope lens so the tree honours it AND the bar can show its state
+    # (the scope chip). Mirrors HistoryController wiring the same Scope into its view.
+    def set_scope(scope : Scope) : Nil
+      @scope = scope
+    end
+
+    def reload(store : Store) : Nil
+      combined = QL.and(@scope.try(&.filter) || QL::EMPTY, QL.parse(@query))
       @hosts = [] of Node
-      store.sitemap_entries(filter).each do |(host, method, target)|
+      store.sitemap_entries(combined).each do |(host, method, target)|
         add(host, normalize_path(target), method)
       end
       @selected = 0
@@ -95,14 +114,103 @@ module Gori::Tui
       end
     end
 
+    # --- QL filter bar (mirrors HistoryView) ---------------------------------
+
+    def querying? : Bool
+      @querying
+    end
+
+    # True when the tree is a filtered subset (a `/` query or the Scope lens is on).
+    def filtering? : Bool
+      !@query.blank? || (@scope.try(&.active?) == true)
+    end
+
+    def start_query : Nil
+      @querying = true
+      @qcx = @query.size
+    end
+
+    def stop_query : Nil # Enter: keep the filter, leave edit mode
+      @querying = false
+    end
+
+    def cancel_query : Nil # Esc: clear the filter, leave edit mode
+      @querying = false
+      @query = ""
+      @qcx = 0
+      @preedit = ""
+    end
+
+    def query_insert(ch : Char) : Nil
+      @query = "#{@query[0, @qcx]}#{ch}#{@query[@qcx..]}"
+      @qcx += 1
+    end
+
+    def query_backspace : Nil
+      return if @qcx == 0
+      @query = "#{@query[0, @qcx - 1]}#{@query[@qcx..]}"
+      @qcx -= 1
+    end
+
+    def query_move(d : Int32) : Nil
+      @qcx = (@qcx + d).clamp(0, @query.size)
+    end
+
+    def set_preedit(text : String) : Nil
+      @preedit = text
+    end
+
+    # Tab-complete the current token to the first field-name suggestion.
+    def query_complete : Bool
+      sugg = query_suggestions
+      return false if sugg.empty?
+      s, e = current_token_bounds
+      @query = "#{@query[0, s]}#{sugg.first}#{@query[e..]}"
+      @qcx = s + sugg.first.size
+      true
+    end
+
+    # Field-name suggestions for the token under the cursor (values aren't suggested
+    # — the tree's useful axes are host/path/method, which are open-ended).
+    def query_suggestions : Array(String)
+      token = current_token
+      return [] of String if token.empty? || token.includes?(':')
+      QL_FIELDS.select(&.starts_with?(token.downcase)).map { |f| "#{f}:" }
+    end
+
+    private def current_token : String
+      s, e = current_token_bounds
+      @query[s...e]
+    end
+
+    private def current_token_bounds : {Int32, Int32}
+      s = @qcx
+      while s > 0 && @query[s - 1] != ' '
+        s -= 1
+      end
+      e = @qcx
+      while e < @query.size && @query[e] != ' '
+        e += 1
+      end
+      {s, e}
+    end
+
     def render(screen : Screen, rect : Rect, focused : Bool = true) : Nil
       return if rect.empty?
+      render_ql_bar(screen, rect)
+      # The bar takes the top row; while querying a suggestion row sits below it.
+      offset = bar_rows
+      tree = Rect.new(rect.x, rect.y + offset, rect.w, {rect.h - offset, 0}.max)
+      return if tree.h <= 0
+
       unless @loaded && !@hosts.empty?
-        screen.text(rect.x + 1, rect.y, "no traffic captured yet", Theme.muted)
-        screen.text(rect.x + 1, rect.y + 2, "browse through the proxy, then return here", Theme.muted)
+        msg = filtering? ? "no endpoints match" : "no traffic captured yet"
+        screen.text(tree.x + 1, tree.y, msg, Theme.muted)
+        screen.text(tree.x + 1, tree.y + 2, "browse through the proxy, then return here", Theme.muted) unless filtering?
         return
       end
 
+      rect = tree
       rows = visible_rows
       ensure_visible(rows.size, rect.h)
       (0...rect.h).each do |i|
@@ -129,12 +237,56 @@ module Gori::Tui
       end
     end
 
-    # Inverts render's `y = rect.y + i` (no header) to find which visible_rows
-    # index a click lands on; nil past the last populated row.
+    # Rows the QL bar occupies at the top of the body: 1 (the bar) + 1 suggestion
+    # row while querying. The tree renders below it; clicks subtract the same offset.
+    private def bar_rows : Int32
+      @querying ? 2 : 1
+    end
+
+    private def render_ql_bar(screen : Screen, rect : Rect) : Nil
+      if @querying
+        prefix = "query › "
+        screen.text(rect.x + 1, rect.y, prefix, Theme.accent)
+        base = rect.x + 1 + prefix.size
+        screen.input_line(base, rect.y, @query, @qcx, @preedit, Theme.text_bright, width: rect.w - prefix.size - 2)
+        render_suggestions(screen, rect, rect.y + 1)
+        return
+      end
+
+      # Right cluster: the scope-lens chip (always shown so the ⇧S toggle is
+      # discoverable — the Scope lens filters the tree too) and, when filtering, the
+      # matching host count.
+      scope_on = @scope.try(&.active?) == true
+      chip, chip_color = scope_on ? {"⇧S scope:#{@scope.try(&.size) || 0}", Theme.accent} : {"⇧S scope:off", Theme.muted}
+      rx = rect.right - 1
+      if filtering?
+        count = "#{@hosts.size}h"
+        screen.text({rx - count.size, rect.x}.max, rect.y, count, Theme.muted)
+        rx -= count.size + 2
+      end
+      screen.text({rx - chip.size, rect.x}.max, rect.y, chip, chip_color)
+
+      left_w = {(rx - chip.size) - (rect.x + 1) - 1, 0}.max
+      if filtering?
+        label = @query.blank? ? "(in-scope only)" : ": #{@query}"
+        screen.text(rect.x + 1, rect.y, label, Theme.text, width: left_w)
+      else
+        screen.text(rect.x + 1, rect.y, "/ filter  ·  host:  method:  path:  status:>=500", Theme.muted, width: left_w)
+      end
+    end
+
+    private def render_suggestions(screen : Screen, rect : Rect, y : Int32) : Nil
+      sugg = query_suggestions
+      return if sugg.empty?
+      screen.text(rect.x + 1, y, "↹ #{sugg.first(8).join("  ")}", Theme.muted, width: rect.w - 2)
+    end
+
+    # Inverts render's tree placement (offset below the QL bar) to find which
+    # visible_rows index a click lands on; nil past the last populated row.
     def row_at(rect : Rect, mx : Int32, my : Int32) : Int32?
       return nil if mx < rect.x || mx >= rect.right # reject the frame border columns (mirror the other list helpers)
-      i = my - rect.y
-      return nil if i < 0 || i >= rect.h
+      i = my - (rect.y + bar_rows)
+      return nil if i < 0 || i >= {rect.h - bar_rows, 0}.max
       idx = @scroll + i
       idx < visible_rows.size ? idx : nil
     end

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -57,6 +57,7 @@ module Gori
       abstract def sitemap_toggle : Nil
       abstract def sitemap_expand : Nil
       abstract def sitemap_collapse : Nil
+      abstract def sitemap_query : Nil # focus the QL filter bar
 
       # scope lens
       abstract def scope_open : Nil        # jump to the Project tab's scope editor

--- a/src/gori/verbs/sitemap.cr
+++ b/src/gori/verbs/sitemap.cr
@@ -24,6 +24,17 @@ module Gori
         [Verb::Chord.new("left"), Verb::Chord.new("h")], hidden: true) { |ctx| ctx.sitemap_collapse; nil }
 
       r.register Verb::Definition.new(
+        "sitemap.query", "Filter (QL)", "Filter the tree with a query (host: path: method: status: …)",
+        Verb::Scope::Sitemap, [Verb::Chord.new("/")]) { |ctx| ctx.sitemap_query; nil }
+
+      # Toggle the scope lens from the Sitemap too (History has its own ⇧S binding).
+      # scope_toggle_lens reloads the active sitemap, and the bar shows the ⇧S chip —
+      # so the toggle is reachable where its effect is visible.
+      r.register Verb::Definition.new(
+        "sitemap.scope-toggle", "Toggle scope lens", "Filter the tree to in-scope endpoints on/off",
+        Verb::Scope::Sitemap, [Verb::Chord.new("s", shift: true)]) { |ctx| ctx.scope_toggle_lens; nil }
+
+      r.register Verb::Definition.new(
         "sitemap.to-menu", "Back to menu", "Move focus up to the tab menu", Verb::Scope::Sitemap,
         [Verb::Chord.new("escape")], hidden: true) { |ctx| ctx.focus_pane(:menu); nil }
     end


### PR DESCRIPTION
Three independent TUI enhancements.

## 1. Sitemap scope filter & search
- `/` opens a QL filter bar **identical to History** — reuses `QL.parse`/`QL.and`, supports `host: path: method: status: scheme: body:` + free text, AND-combined with the Scope lens.
- A persistent top bar shows the scope chip (`⇧S scope:N`/`off`) + filter hint, making scope state visible (it was applied silently before). `⇧S` now also toggles the lens **from the Sitemap** (new sitemap-scoped verb — previously History-only).
- Debounced reload (110ms, matching History). `Store#sitemap_entries` now degrades a malformed FTS query to empty instead of crashing the run loop.

## 2. Replay response DUR & size
- Right-aligned `234ms · 2.0KB` cluster on the RESPONSE pane border (total wire bytes = head + body).
- Extracts a shared `Tui::Fmt` module from History's private formatters; History delegates (zero behavior change).

## 3. Replay SNI override (`^S` on the target)
- `^S` toggles an `SNI ›` row inside the TARGET card (with a border marker); the focus ring stays target→request→response.
- Threaded `sni` through `dial_tls` → both replay engines (`hostname: sni || host`) — the dialed `host:port` is unchanged, only the TLS ClientHello name differs.
- Persisted via schema **V15** (`replays.sni`) and synced cross-session through the reconcile poll, mirroring `target`/`name`.
- Any focus change exits the `^S` SNI sub-field, so URL keystrokes never land in it.

## Testing
- `crystal build` clean; **full spec suite green** (new specs for sitemap filtering/Tab-completion, replay DUR/size, and SNI edit/persist/focus-exit).
- V14→V15 migration verified end-to-end (fresh DB → V15; old DB upgrades with the `sni` column added, no data loss).
- Help cheat-sheet updated (`^S` under REPLAY, `/ filter` under Sitemap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)