### PR TITLE
feat(tui): customizable top tab bar via settings:tabs (show/hide + reorder)

### DIFF
--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -171,4 +171,50 @@ describe Gori::Settings do
       Gori::Settings.editor_markdown = true
     end
   end
+
+  it "round-trips the tab-bar layout (order + a hidden tab; false must survive)" do
+    dir = File.tempname("gori-settings-tabs")
+    Dir.mkdir_p(dir)
+    prev = ENV["GORI_HOME"]?
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.tab_prefs = [{"help", true}, {"project", true}, {"agent", false}]
+      Gori::Settings.save.should be_true
+      Gori::Settings.tab_prefs = [] of {String, Bool} # clear, then reload from disk
+      Gori::Settings.load
+      Gori::Settings.tab_prefs.should eq([{"help", true}, {"project", true}, {"agent", false}])
+
+      # an older file with no "tabs" key keeps the current in-memory value (the default
+      # [] at real startup), like the other fields — never resurrects a phantom layout
+      File.write(Gori::Settings.path, %({"theme":"goridark"}))
+      Gori::Settings.tab_prefs = [{"notes", false}]
+      Gori::Settings.load
+      Gori::Settings.tab_prefs.should eq([{"notes", false}])
+
+      # malformed entries are tolerated: blank/missing id dropped, non-bool visible ⇒ visible
+      File.write(Gori::Settings.path, %({"tabs":[{"id":"replay"},{"id":""},{"visible":false},{"id":"notes","visible":"x"}]}))
+      Gori::Settings.load
+      Gori::Settings.tab_prefs.should eq([{"replay", true}, {"notes", true}])
+    ensure
+      prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(dir)
+      Gori::Settings.tab_prefs = [] of {String, Bool}
+    end
+  end
+
+  it "omits the tabs key entirely when tab_prefs is empty" do
+    dir = File.tempname("gori-settings-notabs")
+    Dir.mkdir_p(dir)
+    prev = ENV["GORI_HOME"]?
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.tab_prefs = [] of {String, Bool}
+      Gori::Settings.save.should be_true
+      File.read(Gori::Settings.path).includes?("tabs").should be_false
+    ensure
+      prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(dir)
+      Gori::Settings.tab_prefs = [] of {String, Bool}
+    end
+  end
 end

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -24,6 +24,8 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def focus_tab(tab : Symbol) : Nil; end
 
+  def focus_visible_tab(n : Int32) : Nil; end
+
   def cycle_tab(delta : Int32) : Nil; end
 
   def move_selection(delta : Int32) : Nil; end

--- a/spec/tui/chrome_tabs_spec.cr
+++ b/spec/tui/chrome_tabs_spec.cr
@@ -1,0 +1,60 @@
+require "../spec_helper"
+
+include Gori::Tui
+
+# The tab-bar config layer: Chrome.reconcile normalizes a stored {id,visible} layout
+# against the canonical catalog (drop unknown, dedupe, append-new, ≥1 visible), and
+# Chrome.visible_tabs derives the rendered/nav strip (with `force:` for the active tab).
+describe "Chrome.reconcile" do
+  it "yields the full catalog with Agent hidden by default on empty prefs" do
+    out = Chrome.reconcile([] of {String, Bool})
+    out.map(&.first).should eq(Chrome::TABS.map(&.first)) # canonical order, all present
+    out.select { |(_, _, v)| v }.map(&.first).includes?(:agent).should be_false
+    out.find { |(s, _, _)| s == :agent }.not_nil![2].should be_false
+    out.find { |(s, _, _)| s == :project }.not_nil![2].should be_true
+  end
+
+  it "honors a stored order and visibility, appending catalog tabs absent from prefs" do
+    out = Chrome.reconcile([{"help", true}, {"project", false}])
+    out[0][0].should eq(:help)    # stored order respected
+    out[1][0].should eq(:project)
+    out[1][2].should be_false     # explicit hide survives
+    out.map(&.first).includes?(:history).should be_true # appended (was absent from prefs)
+    out.find { |(s, _, _)| s == :history }.not_nil![2].should be_true # appended visible
+  end
+
+  it "drops unknown ids and collapses duplicates to the first occurrence" do
+    out = Chrome.reconcile([{"bogus", true}, {"replay", false}, {"replay", true}])
+    out.map(&.first).includes?(:bogus).should be_false
+    out.count { |(s, _, _)| s == :replay }.should eq(1)
+    out.find { |(s, _, _)| s == :replay }.not_nil![2].should be_false # first wins (hidden)
+  end
+
+  it "reveals the first entry when a hand-edited config hides everything" do
+    all_hidden = Chrome::TABS.map { |(sym, _)| {sym.to_s, false} }
+    out = Chrome.reconcile(all_hidden)
+    out.count { |(_, _, v)| v }.should eq(1)
+    out[0][2].should be_true
+  end
+end
+
+describe "Chrome.visible_tabs" do
+  it "returns only the visible tabs in order (Agent excluded by default)" do
+    vis = Chrome.visible_tabs([] of {String, Bool}).map(&.first)
+    vis.includes?(:agent).should be_false
+    vis.first.should eq(:project)
+    vis.size.should eq(Chrome::TABS.size - 1)
+  end
+
+  it "force-includes a hidden active tab at its catalog-relative position" do
+    # Agent hidden by default; forcing it must slot it where it sits in the catalog (last).
+    vis = Chrome.visible_tabs([] of {String, Bool}, force: :agent).map(&.first)
+    vis.includes?(:agent).should be_true
+    vis.index(:agent).not_nil!.should be > vis.index(:notes).not_nil!
+    vis.index(:agent).not_nil!.should be < vis.index(:help).not_nil!
+  end
+
+  it "is a no-op for force: when the active tab is already visible" do
+    Chrome.visible_tabs([] of {String, Bool}, force: :project).should eq(Chrome.visible_tabs([] of {String, Bool}))
+  end
+end

--- a/spec/tui/intercept_view_spec.cr
+++ b/spec/tui/intercept_view_spec.cr
@@ -90,9 +90,11 @@ describe "Intercept verbs (P1)" do
     reg["intercept.forward-all"].scope.should eq(Gori::Verb::Scope::Intercept)
   end
 
-  it "maps `3` to the Intercept tab after the Project (leftmost) renumber" do
+  it "maps `3` to the positional jump verb (Nth visible tab — Intercept by default)" do
     reg = Gori::Verbs.registry
     keymap = Gori::Verb::Keymap.build(reg)
-    keymap.lookup(Gori::Verb::Chord.new("3"), Gori::Verb::Scope::Body).should eq("tab.intercept")
+    # Number keys are positional now (digit N → Nth visible tab), handled by nav.pos*; the
+    # Runner resolves N to the actual tab. With the default layout the 3rd visible is Intercept.
+    keymap.lookup(Gori::Verb::Chord.new("3"), Gori::Verb::Scope::Body).should eq("nav.pos3")
   end
 end

--- a/spec/tui/tabs_overlay_spec.cr
+++ b/spec/tui/tabs_overlay_spec.cr
@@ -1,0 +1,31 @@
+require "../spec_helper"
+
+include Gori::Tui
+
+# The settings:tabs overlay must degrade on small terminals instead of becoming an
+# invisible-but-input-capturing modal, and its windowed list draw + click hit-test must
+# stay in sync (both derive the scroll from list_window).
+describe TabsOverlay do
+  it "returns a box on a normal area and nil only when genuinely too small" do
+    o = TabsOverlay.new
+    o.overlay_box(Rect.new(0, 0, 80, 24)).should_not be_nil
+    o.overlay_box(Rect.new(0, 0, 80, 5)).should be_nil  # area.h-2 = 3 < 6 rows
+    o.overlay_box(Rect.new(0, 0, 20, 24)).should be_nil # area.w-4 = 16 < 24 cols
+  end
+
+  it "windows a long catalog on a short area so row_at maps to the scrolled rows" do
+    o = TabsOverlay.new # 9 catalog tabs by default
+    o.select_move(100)  # selection clamps to the last index (8)
+    box = o.overlay_box(Rect.new(0, 0, 60, 9)).not_nil! # short: only a few rows fit
+    # the top visible row is scrolled past index 0 to keep the last-selected row on screen
+    o.row_at(box, box.x + 5, box.y + 2).not_nil!.should be > 0
+    # a click below the visible list rejects (no phantom selection)
+    o.row_at(box, box.x + 5, box.bottom).should be_nil
+  end
+
+  it "shows every catalog row (start at 0) when the area is tall enough" do
+    o = TabsOverlay.new
+    box = o.overlay_box(Rect.new(0, 0, 60, 40)).not_nil!
+    o.row_at(box, box.x + 5, box.y + 2).should eq(0) # no scroll → first row is index 0
+  end
+end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -44,6 +44,10 @@ private class FakeContext < ExecContext
     @calls << tab
   end
 
+  def focus_visible_tab(n : Int32) : Nil
+    @calls << :focus_visible_tab
+  end
+
   def cycle_tab(delta : Int32) : Nil
     @calls << :cycle_tab
   end

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -20,6 +20,10 @@ module Gori
     class_property editor_markdown : Bool = true # syntax-highlight markdown in Notes/Project
     class_property theme : String = "goridark"   # TUI colour theme name (settings:theme); applied by Theme.apply
     class_property mouse : Bool = true           # TUI mouse (click + scroll-wheel) navigation; off restores native text-selection
+    # Top tab-bar layout: ordered {tab-id, visible?}. Empty = never customized → Chrome
+    # reconciles to catalog defaults. Opaque String ids (Crystal has no runtime String→Symbol);
+    # Chrome maps ids→catalog symbols. Only an EXPLICIT false hides a tab.
+    class_property tab_prefs : Array({String, Bool}) = [] of {String, Bool}
 
     def self.path : String
       File.join(Paths.home_dir, "settings.json")
@@ -40,8 +44,26 @@ module Gori
         self.editor = ed["command"]?.try(&.as_s?) || editor
         self.editor_markdown = load_bool(ed, "markdown", editor_markdown)
       end
+      self.tab_prefs = parse_tab_prefs(root["tabs"]?)
     rescue
       # no file yet / unreadable / bad JSON — keep current values
+    end
+
+    # Tolerant tab-bar parse: a non-array (or absent) node keeps the current value;
+    # entries missing/blank "id" are dropped; "visible" absent or non-bool ⇒ visible
+    # (never hide a tab from a malformed flag). Unknown/duplicate ids are left for
+    # Chrome.reconcile to normalize against the canonical catalog.
+    private def self.parse_tab_prefs(node : JSON::Any?) : Array({String, Bool})
+      arr = node.try(&.as_a?)
+      return tab_prefs unless arr
+      out = [] of {String, Bool}
+      arr.each do |e|
+        next unless o = e.as_h?
+        id = o["id"]?.try(&.as_s?)
+        next if id.nil? || id.empty?
+        out << {id, o["visible"]?.try(&.as_bool?) != false} # only explicit false hides
+      end
+      out
     end
 
     # Read a boolean field, keeping `current` when it's absent or non-bool. A plain
@@ -77,6 +99,15 @@ module Gori
             j.object do
               j.field "command", editor
               j.field "markdown", editor_markdown
+            end
+          end
+          # Omit when empty so an untouched install never writes an ambiguous "tabs": []
+          # (a human reader might misread it as "all hidden").
+          unless tab_prefs.empty?
+            j.field "tabs" do
+              j.array do
+                tab_prefs.each { |(id, vis)| j.object { j.field "id", id; j.field "visible", vis } }
+              end
             end
           end
         end

--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -2,8 +2,10 @@ module Gori::Tui
   # The persistent shell: top bar, left sidebar (tabs), and bottom status line.
   # Stateless renderers — they take the current state and draw it (immediate mode).
   module Chrome
-    # Tab identity + sidebar label, in display order. Project is now the default
-    # home tab (leftmost) shown on project entry; History is the raw log (next).
+    # The canonical tab catalog: identity + sidebar label, in default display order.
+    # Project is the default home tab (leftmost); History is the raw log (next). The
+    # EFFECTIVE order/visibility is user config (settings:tabs) — see reconcile below;
+    # this constant is only the catalog every config is reconciled against.
     TABS = [
       {:project, "Project"},
       {:history, "History"},
@@ -16,12 +18,61 @@ module Gori::Tui
       {:help, "Help"},
     ]
 
+    # Tabs hidden by default on a fresh install (re-enableable in settings:tabs). Agent
+    # is a non-functional "coming soon" placeholder. Only affects reconcile's append path
+    # — once the user saves, tab_prefs is explicit and this no longer applies.
+    DEFAULT_HIDDEN = [:agent]
+
     def self.tab_at(index : Int32) : Symbol
       TABS[index.clamp(0, TABS.size - 1)][0]
     end
 
     def self.tab_index(tab : Symbol) : Int32
       TABS.index { |(sym, _)| sym == tab } || 0
+    end
+
+    # Reconcile stored prefs against the canonical catalog → full ordered
+    # {symbol, label, visible?}. Removed/unknown ids are dropped, duplicates collapse to
+    # first occurrence, and catalog tabs absent from prefs are APPENDED with their default
+    # visibility (a tab added in a newer build is never hidden by an older config).
+    # Guarantees ≥1 visible (a hand-edited all-hidden config reveals the first entry).
+    def self.reconcile(prefs : Array({String, Bool})) : Array({Symbol, String, Bool})
+      label_of = {} of Symbol => String
+      by_str = {} of String => Symbol
+      TABS.each { |(sym, label)| label_of[sym] = label; by_str[sym.to_s] = sym }
+
+      out = [] of {Symbol, String, Bool}
+      seen = [] of Symbol # ≤9 elems; avoids requiring "set"
+      prefs.each do |(id, vis)|
+        next unless sym = by_str[id]? # removed/unknown id → drop
+        next if seen.includes?(sym)   # duplicate → first wins
+        seen << sym
+        out << {sym, label_of[sym], vis}
+      end
+      TABS.each do |(sym, label)| # forward-compat: append missing catalog tabs
+        out << {sym, label, !DEFAULT_HIDDEN.includes?(sym)} unless seen.includes?(sym)
+      end
+      if out.none? { |(_, _, v)| v } # all-hidden (hand-edited json) → reveal #1
+        f = out.first
+        out[0] = {f[0], f[1], true}
+      end
+      out
+    end
+
+    # The rendered/navigation strip: visible, ordered {symbol, label}. `force` (the active
+    # tab) is ALWAYS present at its catalog-relative position even when hidden — so a jump
+    # to a hidden tab is never stranded off-bar and menu_layout's active_idx lookup always
+    # succeeds (instead of silently falling back to 0).
+    def self.visible_tabs(prefs : Array({String, Bool}), force : Symbol? = nil) : Array({Symbol, String})
+      ann = reconcile(prefs)
+      vis = ann.select { |(_, _, v)| v }.map { |(s, l, _)| {s, l} }
+      if force && vis.none? { |(s, _)| s == force }
+        if idx = ann.index { |(s, _, _)| s == force }
+          at = ann[0...idx].count { |(_, _, v)| v }
+          vis.insert(at, {ann[idx][0], ann[idx][1]})
+        end
+      end
+      vis
     end
 
     def self.render_top_bar(screen : Screen, rect : Rect, *, project : String,
@@ -48,12 +99,13 @@ module Gori::Tui
     # focus, so the user sees where keys land); inactive tabs are muted. Hot
     # counts (intercept held / findings) ride inline as `(N)` badges.
     def self.render_menu(screen : Screen, rect : Rect, *, active_tab : Symbol, focused : Bool,
+                         tabs : Array({Symbol, String}) = TABS,
                          findings_count : Int32 = 0, intercept_count : Int32 = 0,
                          replay_count : Int32 = 0, notes_count : Int32 = 0) : Nil
       return if rect.empty?
       screen.fill(rect, Theme.panel)
 
-      segs, start = menu_layout(rect, active_tab, findings_count, intercept_count, replay_count, notes_count)
+      segs, start = menu_layout(rect, active_tab, tabs, findings_count, intercept_count, replay_count, notes_count)
       screen.cell(rect.x, rect.y, '‹', Theme.muted, Theme.panel) if start > 0 # earlier tabs hidden
       segs.each do |(sym, label, seg)|
         if sym == active_tab
@@ -73,10 +125,11 @@ module Gori::Tui
     # computed IDENTICALLY to render_menu (shares menu_layout) so a click hit-test
     # can never drift from what was drawn. Coords are 0-based cells.
     def self.menu_segments(rect : Rect, active_tab : Symbol, *,
+                           tabs : Array({Symbol, String}) = TABS,
                            findings_count : Int32 = 0, intercept_count : Int32 = 0,
                            replay_count : Int32 = 0, notes_count : Int32 = 0) : Array({Symbol, Rect})
       return [] of {Symbol, Rect} if rect.empty?
-      menu_layout(rect, active_tab, findings_count, intercept_count, replay_count, notes_count)[0]
+      menu_layout(rect, active_tab, tabs, findings_count, intercept_count, replay_count, notes_count)[0]
         .map { |(sym, _, seg)| {sym, seg} }
     end
 
@@ -84,19 +137,19 @@ module Gori::Tui
     # rect} plus the window `start` (so render can flag the `‹` overflow marker).
     # Mirrors the old inline render_menu loop exactly — windowing via scroll_start,
     # segments laid " label " with a 1-col gap, the same `> rect.right + 1` break.
-    private def self.menu_layout(rect : Rect, active_tab : Symbol, findings_count : Int32,
-                                 intercept_count : Int32, replay_count : Int32,
+    private def self.menu_layout(rect : Rect, active_tab : Symbol, tabs : Array({Symbol, String}),
+                                 findings_count : Int32, intercept_count : Int32, replay_count : Int32,
                                  notes_count : Int32) : {Array({Symbol, String, Rect}), Int32}
       segs = [] of {Symbol, String, Rect}
-      labels = TABS.map { |(sym, label)| "#{label}#{menu_badge(sym, findings_count, intercept_count, replay_count, notes_count)}" }
+      labels = tabs.map { |(sym, label)| "#{label}#{menu_badge(sym, findings_count, intercept_count, replay_count, notes_count)}" }
       widths = labels.map(&.size.+(2)) # one space of padding each side of the segment
-      active_idx = TABS.index { |(sym, _)| sym == active_tab } || 0
+      active_idx = tabs.index { |(sym, _)| sym == active_tab } || 0
       # Window the strip so the active segment is ALWAYS visible: on a narrow row
       # advance the start until segments [start..active] fit, so the menu scrolls
       # instead of breaking and hiding every tab from the overflow point on.
       start = scroll_start(widths, active_idx, rect.w - 2)
       x = rect.x + 1
-      TABS.each_with_index do |(sym, _), i|
+      tabs.each_with_index do |(sym, _), i|
         next if i < start
         seg_w = widths[i]
         break if x + seg_w > rect.right + 1

--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -23,14 +23,6 @@ module Gori::Tui
     # — once the user saves, tab_prefs is explicit and this no longer applies.
     DEFAULT_HIDDEN = [:agent]
 
-    def self.tab_at(index : Int32) : Symbol
-      TABS[index.clamp(0, TABS.size - 1)][0]
-    end
-
-    def self.tab_index(tab : Symbol) : Int32
-      TABS.index { |(sym, _)| sym == tab } || 0
-    end
-
     # Reconcile stored prefs against the canonical catalog → full ordered
     # {symbol, label, visible?}. Removed/unknown ids are dropped, duplicates collapse to
     # first occurrence, and catalog tabs absent from prefs are APPENDED with their default

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -25,7 +25,8 @@ module Gori::Tui
         {"←/→", "switch tab (on the tab bar)"},
         {"↹ / ⇧↹", "focus ring: tab bar ↔ panes"},
         {"↵ / ↓", "enter the tab body"},
-        {"1-9", "jump straight to tab N"},
+        {"1-9", "jump to the Nth visible tab"},
+        {"settings:tabs", "show/hide + reorder tabs"},
         {"esc", "pop back to the tab bar"},
       ]},
       {"MOUSE", [

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -27,6 +27,7 @@ require "./rules_overlay"
 require "./confirm_dialog"
 require "./browser_picker"
 require "./settings_view"
+require "./tabs_overlay"
 require "./palette"
 require "./command_line"
 require "../paths"
@@ -54,8 +55,11 @@ module Gori::Tui
       @finding_form = FindingForm.new
       @palette = PaletteState.new(@session.registry)
       @command = CommandLine.new(@session.registry)
-      @active_tab = :project
-      @overlay = :none # :none | :palette | :detail | :rules | :finding_new | :confirm | :browser
+      # Land on the home tab, but never on a hidden one (settings:tabs may hide Project,
+      # and Agent is hidden by default). Settings is loaded (cli.cr) before Runner.new.
+      vis = Chrome.visible_tabs(Settings.tab_prefs).map(&.first)
+      @active_tab = vis.includes?(:project) ? :project : vis.first
+      @overlay = :none # :none | :palette | :detail | :rules | :finding_new | :confirm | :browser | :settings | :tabs
       # The ":" context command line (vim/helix-style). Orthogonal to @overlay so it
       # floats over WHATEVER is underneath (the History list, an open detail, the
       # Sitemap …) without disturbing that state; the scope is captured at open time.
@@ -94,6 +98,9 @@ module Gori::Tui
       @browser_picker = nil.as(BrowserPicker?)
       # The settings editor (palette → settings:network); @overlay is :settings.
       @settings_view = SettingsView.new
+      # The tab-bar customizer (palette → settings:tabs); @overlay is :tabs. Distinct
+      # from @tabs (the controller registry built below).
+      @tabs_overlay = TabsOverlay.new
       @theme_restore = nil.as(String?) # theme to revert to if the theme settings are cancelled (live preview)
       @focus = :menu                  # default focus on the tab bar (TABS) on project entry; :body for content
       @toast = nil.as(String?)        # transient action feedback; nil → show key hints
@@ -376,6 +383,7 @@ module Gori::Tui
       return handle_confirm_key(ev) if @overlay == :confirm
       return handle_browser_key(ev) if @overlay == :browser
       return handle_settings_key(ev) if @overlay == :settings
+      return handle_tabs_key(ev) if @overlay == :tabs
       # Text-entry modes own Tab (complete) + Esc within themselves — let them run
       # before the global focus ring claims Tab.
       if @active_tab == :history && @overlay == :none && @focus == :body && history_controller.view.querying?
@@ -525,15 +533,15 @@ module Gori::Tui
     # The overlays that fully capture input (a centered card); :detail and :none do not.
     private def modal_overlay? : Bool
       case @overlay
-      when :palette, :rules, :finding_new, :confirm, :browser, :settings then true
-      else                                                                     false
+      when :palette, :rules, :finding_new, :confirm, :browser, :settings, :tabs then true
+      else                                                                           false
       end
     end
 
     # Click the top tab bar: switch to the clicked tab (immediate, like a number jump),
     # re-focus the body when the active tab is re-clicked, else just focus the bar.
     private def click_menu(rect : Rect, mx : Int32, my : Int32) : Nil
-      seg = Chrome.menu_segments(rect, @active_tab,
+      seg = Chrome.menu_segments(rect, @active_tab, tabs: effective_tabs,
         findings_count: @findings_count, intercept_count: @session.interceptor.pending_count,
         replay_count: replay_controller.count, notes_count: notes_controller.view.count).find { |(_, r)| r.contains?(mx, my) }
       if seg
@@ -603,6 +611,7 @@ module Gori::Tui
       when :browser  then click_browser(area, mx, my)
       when :confirm  then click_confirm(area, mx, my)
       when :settings then click_settings(area, mx, my)
+      when :tabs     then click_tabs(area, mx, my)
         # :finding_new is a text form — keyboard-only in Phase 1 (cursor placement is Phase 2)
       end
     end
@@ -655,6 +664,16 @@ module Gori::Tui
       end
     end
 
+    # Tab-bar customizer: a click outside dismisses (discards the working copy, like
+    # esc); a row click selects it (toggle/reorder stay keyboard-driven).
+    private def click_tabs(area : Rect, mx : Int32, my : Int32) : Nil
+      box = @tabs_overlay.overlay_box(area)
+      return (@overlay = :none) if box.nil? || dismiss_zone?(box, mx, my)
+      if idx = @tabs_overlay.row_at(box, mx, my)
+        @tabs_overlay.set_selected(idx)
+      end
+    end
+
     # True when a click should dismiss a modal: anywhere outside its box (click-away
     # is the universal close affordance — every modal also still closes on esc).
     private def dismiss_zone?(box : Rect, mx : Int32, my : Int32) : Bool
@@ -696,6 +715,7 @@ module Gori::Tui
       when :rules    then @rules_overlay.select_move(step)
       when :browser  then @browser_picker.try(&.move(step))
       when :settings then @settings_view.move_field(step)
+      when :tabs     then @tabs_overlay.select_move(step)
       end
     end
 
@@ -837,6 +857,57 @@ module Gori::Tui
         @settings_view.insert(c)
         @settings_view.set_preedit("")
       end
+    end
+
+    # The tab-bar customizer (settings:tabs). Working copy: ↵ saves+applies, esc discards.
+    # ↑/↓ (and k/j) move the selection; K/J reorder the selected tab; space toggles
+    # show/hide (refused for the last visible tab). ^P jumps back to the palette.
+    private def handle_tabs_key(ev : Termisu::Event::Key) : Nil
+      key = ev.key
+      if ev.ctrl? && key.lower_p?
+        @overlay = :none
+        open_palette
+      elsif key.escape?
+        @overlay = :none # discard the working copy
+      elsif key.enter?
+        save_tabs
+      elsif key.up? && ev.shift?
+        @tabs_overlay.move_selected(-1)
+      elsif key.down? && ev.shift?
+        @tabs_overlay.move_selected(1)
+      elsif key.up?
+        @tabs_overlay.select_move(-1)
+      elsif key.down?
+        @tabs_overlay.select_move(1)
+      elsif (c = ev.char) && c == ' '
+        @toast = "keep at least one tab visible" unless @tabs_overlay.toggle_selected
+      elsif (c = ev.char) && (c == 'K' || c == 'k')
+        c == 'K' ? @tabs_overlay.move_selected(-1) : @tabs_overlay.select_move(-1)
+      elsif (c = ev.char) && (c == 'J' || c == 'j')
+        c == 'J' ? @tabs_overlay.move_selected(1) : @tabs_overlay.select_move(1)
+      end
+    end
+
+    # Commit the tab-bar working copy: persist once, force a full repaint (the tab set/
+    # order changed behind the centered overlay), and if the active tab was just hidden
+    # snap to the first visible one — committing the outgoing tab's edits first (a hidden
+    # Project desc / Replay request must not be silently dropped), mirroring focus_tab.
+    private def save_tabs : Nil
+      Settings.tab_prefs = @tabs_overlay.to_prefs
+      ok = Settings.save
+      @overlay = :none
+      @resized = true
+      # Snap off a now-hidden active tab. Use the GENUINE visibility (no force:) for this
+      # decision — effective_tabs force-includes the active tab, which would mask the hide.
+      vis = Chrome.visible_tabs(Settings.tab_prefs)
+      unless vis.any? { |(s, _)| s == @active_tab }
+        project_controller.commit if @active_tab == :project
+        replay_controller.save_current_replay if @active_tab == :replay
+        @active_tab = vis.first[0]
+        on_enter_tab
+        @focus = :menu
+      end
+      @toast = ok ? "tabs saved" : "tabs: save failed (#{Settings.path})"
     end
 
     # The Notes tab is a live editor (like Replay): typing edits the document
@@ -1146,6 +1217,7 @@ module Gori::Tui
         capturing: @session.capturing?, listen: "#{@session.proxy.host}:#{@session.proxy.port}",
         identity: "user", scope: scope_label, rules: rules_label, intercept: intercept_label)
       Chrome.render_menu(screen, layout.menu, active_tab: @active_tab, focused: @focus == :menu,
+        tabs: effective_tabs,
         findings_count: @findings_count, intercept_count: @session.interceptor.pending_count,
         replay_count: replay_controller.count, notes_count: notes_controller.view.count)
       Chrome.render_rule(screen, layout.rule)
@@ -1159,6 +1231,7 @@ module Gori::Tui
       @confirm.try(&.render(screen, layout.body)) if @overlay == :confirm
       @browser_picker.try(&.render(screen, layout.body)) if @overlay == :browser
       @settings_view.render(screen, layout.body) if @overlay == :settings
+      @tabs_overlay.render(screen, layout.body) if @overlay == :tabs
       # The ":" command line floats over everything else (drawn last), anchored to
       # the bottom: the input on the status row, the suggestion list stacked above.
       render_prompts(screen, layout)
@@ -1225,6 +1298,7 @@ module Gori::Tui
       when :confirm     then "CONFIRM"
       when :browser     then "BROWSER"
       when :settings    then "SETTINGS"
+      when :tabs        then "TAB BAR"
       else
         case @focus
         when :menu    then "TABS"
@@ -1254,6 +1328,7 @@ module Gori::Tui
       when :confirm     then "←/→ choose · y confirm · n/esc cancel · ↵ select"
       when :browser     then "↑/↓ select · ↵ open · esc cancel"
       when :settings    then "↑/↓ field · type to edit · ↵ save · esc close"
+      when :tabs        then "↑/↓ select · space show/hide · K/J reorder · ↵ save · esc cancel"
       when :detail      then "←/→ panes · ↑/↓ scroll · ^R replay · ⇧F finding · x hex · ^G goto · ^F find · esc back"
       else
         # Focus on the tab bar: ←/→ pick the tab, Tab/↵ drop into the body.
@@ -1527,14 +1602,31 @@ module Gori::Tui
       view_focus_first
     end
 
+    # The effective tab strip — the configured order/visibility (settings:tabs), with the
+    # active tab force-included even if hidden (so a cross-tab jump to a hidden tab still
+    # renders + highlights). The single source the menu render, click hit-test, and nav read.
+    private def effective_tabs : Array({Symbol, String})
+      Chrome.visible_tabs(Settings.tab_prefs, force: @active_tab)
+    end
+
+    # Positional number-key target: focus the Nth (1-based) VISIBLE tab — the order shown
+    # on the bar. Out-of-range n (fewer tabs visible than the digit) is a no-op.
+    def focus_visible_tab(n : Int32) : Nil
+      if t = effective_tabs[n - 1]?
+        focus_tab(t[0])
+      end
+    end
 
     def cycle_tab(delta : Int32) : Nil
       if @active_tab == :project
         project_controller.commit
       end
       replay_controller.save_current_replay if @active_tab == :replay # persist the outgoing replay tab
-      idx = Chrome.tab_index(@active_tab)
-      @active_tab = Chrome.tab_at((idx + delta) % Chrome::TABS.size)
+      # Cycle within the VISIBLE strip (skips hidden tabs); effective_tabs force-includes
+      # the active tab so the index is always found and never falls back to 0.
+      tabs = effective_tabs
+      idx = tabs.index { |(s, _)| s == @active_tab } || 0
+      @active_tab = tabs[(idx + delta) % tabs.size][0]
       @overlay = :none
       on_enter_tab
       # Switching tabs on the bar (menu focus) just moves the highlight; switching
@@ -1877,14 +1969,17 @@ module Gori::Tui
       end
     end
 
-    # Open the settings editor for `section` (palette → settings:network/editor/
-    # theme/hotkeys). :network/:editor/:theme are implemented; the rest toast a TODO.
+    # Open the settings editor for `section` (palette → settings:network/editor/theme/
+    # tabs/hotkeys). :network/:editor/:theme/:tabs are implemented; the rest toast a TODO.
     def open_settings(section : Symbol) : Nil
       case section
       when :network, :editor, :theme
         @settings_view.reload(section)
         @overlay = :settings
         @theme_restore = section == :theme ? Settings.theme : nil # baseline for live-preview revert
+      when :tabs
+        @tabs_overlay.reset # rebuild the working copy from persisted config
+        @overlay = :tabs
       else
         @toast = "#{section} settings — coming soon (TODO)"
       end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -907,7 +907,9 @@ module Gori::Tui
         on_enter_tab
         @focus = :menu
       end
-      @toast = ok ? "tabs saved" : "tabs: save failed (#{Settings.path})"
+      # The layout is applied to the live session regardless (like theme/network); only the
+      # disk write can fail, so say so honestly rather than implying nothing happened.
+      @toast = ok ? "tabs saved" : "tabs applied — could not save to #{Settings.path}"
     end
 
     # The Notes tab is a live editor (like Replay): typing edits the document

--- a/src/gori/tui/tabs_overlay.cr
+++ b/src/gori/tui/tabs_overlay.cr
@@ -64,41 +64,71 @@ module Gori::Tui
     end
 
     # Centered overlay box for `area` — the exact rect render() draws into, or nil when
-    # too small (mirrors render's bail, leaving room for the title, list, and hint row).
+    # even a windowed list can't fit. Height shrinks to the content but is also capped to
+    # the area, so on a short terminal the list scrolls instead of demanding all rows (and
+    # the card never becomes an invisible-but-input-capturing modal). The key-hint lives in
+    # the status bar (key_hints), so no row is reserved for it here.
     def overlay_box(area : Rect) : Rect?
       w = {area.w - 4, 48}.min
-      h = {area.h - 2, @items.size + 6}.min
-      return nil if w < 24 || h < @items.size + 6
+      h = {area.h - 2, @items.size + 3}.min # title + up to @items rows + bottom border
+      return nil if w < 24 || h < 6
       Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
+    end
+
+    # List rows that fit between the title gap (box.y+2) and the bottom border (box.bottom-1).
+    private def list_capacity(box : Rect) : Int32
+      {box.bottom - 1 - (box.y + 2), 0}.max
+    end
+
+    # First visible row index, scrolled to keep @selected on screen without overscrolling
+    # past the end. Shared by render + row_at so the draw and the hit-test never drift.
+    private def list_window(cap : Int32) : Int32
+      return 0 if cap <= 0 || @items.size <= cap
+      { {@selected - cap + 1, 0}.max, @items.size - cap }.min
     end
 
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
-      return unless box
+      unless box
+        # Too small to draw the editor — show a one-line hint so the (still input-capturing)
+        # :tabs modal is never fully invisible; esc closes it.
+        screen.text(area.x + 1, area.y, "tab editor needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        return
+      end
       Frame.card(screen, box, "TAB BAR", border: Theme.border_focus)
       meta = "#{visible_count}/#{@items.size} shown"
       screen.text({box.right - meta.size - 2, box.x + 12}.max, box.y, meta, Theme.muted, Theme.panel)
 
-      @items.each_with_index do |(_, label, vis), i|
-        py = box.y + 2 + i
-        sel = i == @selected
-        bg = sel ? Theme.accent_bg : Theme.panel
-        screen.fill(Rect.new(box.x + 1, py, box.w - 2, 1), bg)
-        screen.cell(box.x + 1, py, sel ? '▎' : ' ', Theme.accent, bg)
-        screen.cell(box.x + 3, py, vis ? '✓' : '·', vis ? Theme.accent : Theme.muted, bg)
-        fg = vis ? (sel ? Theme.text_bright : Theme.text) : Theme.muted
-        screen.text(box.x + 5, py, label, fg, bg, width: box.w - 7)
+      list_top = box.y + 2
+      cap = list_capacity(box)
+      start = list_window(cap)
+      cap.times do |row|
+        i = start + row
+        break if i >= @items.size
+        draw_row(screen, box, i, list_top + row)
       end
-
-      hint = "↑/↓ select · space show/hide · K/J reorder · ↵ save · esc cancel"
-      screen.text(box.x + 3, box.bottom - 2, hint, Theme.muted, Theme.panel, width: box.w - 5)
     end
 
-    # Row index under (mx,my) — list starts at box.y+2 (mirrors render's `box.y + 2 + i`).
+    private def draw_row(screen : Screen, box : Rect, i : Int32, py : Int32) : Nil
+      _, label, vis = @items[i]
+      sel = i == @selected
+      bg = sel ? Theme.accent_bg : Theme.panel
+      screen.fill(Rect.new(box.x + 1, py, box.w - 2, 1), bg)
+      screen.cell(box.x + 1, py, sel ? '▎' : ' ', Theme.accent, bg)
+      screen.cell(box.x + 3, py, vis ? '✓' : '·', vis ? Theme.accent : Theme.muted, bg)
+      fg = vis ? (sel ? Theme.text_bright : Theme.text) : Theme.muted
+      screen.text(box.x + 5, py, label, fg, bg, width: box.w - 7)
+    end
+
+    # Row index under (mx,my) — inverts render's windowed layout (list at box.y+2, scrolled
+    # by list_window) so a click maps to the same row that was drawn.
     def row_at(box : Rect, mx : Int32, my : Int32) : Int32?
       return nil unless box.contains?(mx, my)
-      i = my - (box.y + 2)
-      (0 <= i < @items.size) ? i : nil
+      cap = list_capacity(box)
+      row = my - (box.y + 2)
+      return nil if row < 0 || row >= cap
+      i = list_window(cap) + row
+      i < @items.size ? i : nil
     end
   end
 end

--- a/src/gori/tui/tabs_overlay.cr
+++ b/src/gori/tui/tabs_overlay.cr
@@ -1,0 +1,104 @@
+require "./screen"
+require "./theme"
+require "./frame"
+require "./chrome"
+require "../settings"
+
+module Gori::Tui
+  # Overlay editor for the top tab bar (settings:tabs): which tabs show and their
+  # order. Edits a WORKING COPY — committed on ↵, discarded on esc — like the
+  # settings:* family, so the live bar underneath stays put while you edit. Rows are
+  # the FULL catalog (hidden tabs too, so they can be re-enabled), reconciled against
+  # Settings.tab_prefs. The Runner persists the committed copy via Settings.save.
+  #
+  #   ✓ Project      ▎ selected, shown
+  #   · Agent          hidden
+  class TabsOverlay
+    def initialize
+      @items = [] of {Symbol, String, Bool}
+      @selected = 0
+      reset
+    end
+
+    # Rebuild the working copy from persisted config (called when the overlay opens),
+    # so any uncommitted edits from a prior esc-cancelled session are discarded.
+    def reset : Nil
+      @items = Chrome.reconcile(Settings.tab_prefs)
+      @selected = 0
+    end
+
+    def select_move(d : Int32) : Nil
+      @selected = (@selected + d).clamp(0, {@items.size - 1, 0}.max)
+    end
+
+    def set_selected(idx : Int32) : Nil
+      @selected = idx.clamp(0, {@items.size - 1, 0}.max)
+    end
+
+    private def visible_count : Int32
+      @items.count { |(_, _, v)| v }
+    end
+
+    # Flip show/hide of the selected tab. Refuses (false) to hide the last visible one
+    # so the bar can never go empty; the caller toasts the refusal.
+    def toggle_selected : Bool
+      sym, label, vis = @items[@selected]
+      return false if vis && visible_count <= 1
+      @items[@selected] = {sym, label, !vis}
+      true
+    end
+
+    # Move the selected row by ±1 (no wrap); selection follows the moved row so a
+    # repeated press keeps pushing it.
+    def move_selected(dir : Int32) : Nil
+      j = @selected + dir
+      return unless 0 <= j < @items.size
+      @items.swap(@selected, j)
+      @selected = j
+    end
+
+    # Serialize the working copy back to Settings shape — ALL rows (incl. hidden) so a
+    # hidden tab's position survives for when it's re-shown.
+    def to_prefs : Array({String, Bool})
+      @items.map { |(sym, _, vis)| {sym.to_s, vis} }
+    end
+
+    # Centered overlay box for `area` — the exact rect render() draws into, or nil when
+    # too small (mirrors render's bail, leaving room for the title, list, and hint row).
+    def overlay_box(area : Rect) : Rect?
+      w = {area.w - 4, 48}.min
+      h = {area.h - 2, @items.size + 6}.min
+      return nil if w < 24 || h < @items.size + 6
+      Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
+    end
+
+    def render(screen : Screen, area : Rect) : Nil
+      box = overlay_box(area)
+      return unless box
+      Frame.card(screen, box, "TAB BAR", border: Theme.border_focus)
+      meta = "#{visible_count}/#{@items.size} shown"
+      screen.text({box.right - meta.size - 2, box.x + 12}.max, box.y, meta, Theme.muted, Theme.panel)
+
+      @items.each_with_index do |(_, label, vis), i|
+        py = box.y + 2 + i
+        sel = i == @selected
+        bg = sel ? Theme.accent_bg : Theme.panel
+        screen.fill(Rect.new(box.x + 1, py, box.w - 2, 1), bg)
+        screen.cell(box.x + 1, py, sel ? '▎' : ' ', Theme.accent, bg)
+        screen.cell(box.x + 3, py, vis ? '✓' : '·', vis ? Theme.accent : Theme.muted, bg)
+        fg = vis ? (sel ? Theme.text_bright : Theme.text) : Theme.muted
+        screen.text(box.x + 5, py, label, fg, bg, width: box.w - 7)
+      end
+
+      hint = "↑/↓ select · space show/hide · K/J reorder · ↵ save · esc cancel"
+      screen.text(box.x + 3, box.bottom - 2, hint, Theme.muted, Theme.panel, width: box.w - 5)
+    end
+
+    # Row index under (mx,my) — list starts at box.y+2 (mirrors render's `box.y + 2 + i`).
+    def row_at(box : Rect, mx : Int32, my : Int32) : Int32?
+      return nil unless box.contains?(mx, my)
+      i = my - (box.y + 2)
+      (0 <= i < @items.size) ? i : nil
+    end
+  end
+end

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -21,6 +21,9 @@ module Gori
       # pane focus (:sidebar | :body) and tab navigation
       abstract def focus_pane(pane : Symbol) : Nil
       abstract def focus_tab(tab : Symbol) : Nil
+      # Focus the Nth (1-based) VISIBLE tab — the positional number-key target, which
+      # follows the user's settings:tabs order/visibility. Out-of-range n is a no-op.
+      abstract def focus_visible_tab(n : Int32) : Nil
       abstract def cycle_tab(delta : Int32) : Nil
       # Descend from the tab menu into the active tab's content. Tabs with a
       # navigable sub-tab strip (Replay/Notes) land on the STRIP first; others go
@@ -98,7 +101,8 @@ module Gori
       # browser: open a system browser pre-trusting gori's CA + routed via the proxy
       abstract def open_browser_picker : Nil
 
-      # settings: open the config editor for a section (:network | :theme | :hotkeys)
+      # settings: open the config editor for a section (:network | :editor | :theme |
+      # :tabs | :hotkeys). :tabs opens the tab-bar customizer overlay.
       abstract def open_settings(section : Symbol) : Nil
     end
   end

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -56,6 +56,9 @@ module Gori
         "settings.theme", "settings:theme", "Switch the TUI colour theme (goridark · goriday · latte · espresso · tokyonight)",
         Verb::Scope::Global) { |ctx| ctx.open_settings(:theme); nil }
       r.register Verb::Definition.new(
+        "settings.tabs", "settings:tabs", "Customize the top tab bar — show/hide tabs and reorder them",
+        Verb::Scope::Global) { |ctx| ctx.open_settings(:tabs); nil }
+      r.register Verb::Definition.new(
         "settings.hotkeys", "settings:hotkeys", "Hotkey settings (coming soon)",
         Verb::Scope::Global, coming_soon: true) { |ctx| ctx.open_settings(:hotkeys); nil }
 
@@ -104,15 +107,24 @@ module Gori
         "nav.prev-tab", "Previous tab", "Focus the previous tab", Verb::Scope::Global,
         [Verb::Chord.new("[")]) { |ctx| ctx.cycle_tab(-1); nil }
 
-      # Direct tab focus (mirrors the sidebar). Project is 1 (new leftmost default).
-      {
-        "1" => :project, "2" => :history, "3" => :intercept, "4" => :sitemap,
-        "5" => :replay, "6" => :findings, "7" => :notes, "8" => :agent,
-        "9" => :help,
-      }.each do |key, tab|
+      # Positional tab jump: digit N focuses the Nth VISIBLE tab (the order on the bar) —
+      # so the numbers follow the user's settings:tabs order/visibility. Hidden (default:
+      # Agent), so the keys exist but don't clutter the palette; the named "Go to …" verbs
+      # below are the discoverable entries (and the way to reach a hidden tab by command).
+      (1..9).each do |n|
         r.register Verb::Definition.new(
-          "tab.#{tab}", "Go to #{tab.to_s.capitalize}", "Focus the #{tab} tab", Verb::Scope::Global,
-          [Verb::Chord.new(key)]) { |ctx| ctx.focus_tab(tab); nil }
+          "nav.pos#{n}", "Go to tab #{n}", "Focus the #{n}th visible tab", Verb::Scope::Global,
+          [Verb::Chord.new(n.to_s)], hidden: true) { |ctx| ctx.focus_visible_tab(n); nil }
+      end
+
+      # Named tab jumps (no chord) — palette discoverability + the only by-command way to
+      # reach a tab hidden in settings:tabs (focus_tab force-shows it while active).
+      {
+        :project => "Project", :history => "History", :intercept => "Intercept", :sitemap => "Sitemap",
+        :replay => "Replay", :findings => "Findings", :notes => "Notes", :agent => "Agent", :help => "Help",
+      }.each do |tab, label|
+        r.register Verb::Definition.new(
+          "tab.#{tab}", "Go to #{label}", "Focus the #{label} tab", Verb::Scope::Global) { |ctx| ctx.focus_tab(tab); nil }
       end
 
       # Close the command palette overlay.


### PR DESCRIPTION
## What

Adds a `settings:tabs` command-palette entry that lets the user **hide/show and reorder** the TUI top tabs, persisted to `~/.gori/settings.json` so it survives restarts. Mirrors the existing `settings:network/editor/theme` family.

## Behavior decisions

- **Number keys are positional** — digit N focuses the Nth *visible* tab (follows the user's order/visibility). Hidden tabs are unnumbered and reached via the palette "Go to X" entries.
- **The non-functional `Agent` placeholder defaults to hidden** (re-enableable in `settings:tabs`).

## How it works

- `settings.cr` — opaque `tab_prefs : Array({String, Bool})` (string ids, since Crystal has no runtime `String#to_sym`). Tolerant parse (only an explicit `false` hides; malformed entries dropped); serialize omits the key when empty.
- `chrome.cr` — catalog stays `Chrome::TABS`. New **pure** `reconcile` (drop-unknown / dedupe / append-new catalog tabs / guarantee ≥1 visible) and `visible_tabs(prefs, force:)` that force-includes the active tab even when hidden (so cross-tab jumps to a hidden tab still render + highlight, and `menu_layout`'s `active_idx` never falls back to 0). `render_menu`/`menu_segments` gain a defaulted `tabs:` param so existing callers/specs are untouched.
- `tabs_overlay.cr` (new) — working-copy editor modeled on `RulesOverlay`: `↑/↓` select, `space` show/hide (refuses to hide the last visible), `K/J` reorder, `↵` save, `esc` cancel.
- `runner.cr` — full `:tabs` overlay wiring; single `effective_tabs` source for menu render + click hit-test + navigation (no drift); `cycle_tab` walks the visible ring; startup + save snap off a hidden active tab (committing the outgoing tab's edits first so a hidden Project desc / Replay edit isn't lost).
- `verbs/core.cr` — `settings.tabs` verb; replaced the fixed `1-9` chords with hidden positional `nav.pos1..9` verbs + chord-less named "Go to X" verbs (the reachability escape hatch for hidden tabs).

## Tests

- `spec/settings_spec.cr` — `tab_prefs` round-trip (order + hidden tab; `false` survives), empty-omit, malformed tolerance.
- `spec/tui/chrome_tabs_spec.cr` (new) — `reconcile`/`visible_tabs` edge cases (empty ⇒ Agent hidden, removed id dropped, dupes collapse, all-hidden reveals first, `force:` re-inserts a hidden active tab).
- Updated the digit-keymap assertion to `nav.pos3`; added `focus_visible_tab` stubs to both `ExecContext` test doubles.

`crystal spec` → 490 examples, 0 failures. `crystal build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)