### PR TITLE
feat(tui): regenerate CA certificate from the command palette

### DIFF
--- a/spec/proxy/tls/cert_authority_spec.cr
+++ b/spec/proxy/tls/cert_authority_spec.cr
@@ -148,6 +148,16 @@ describe Gori::Proxy::Tls::CertAuthority do
     end
   end
 
+  it "recreates the CA dir if it was removed at runtime before regenerating" do
+    with_ca_dir do |dir|
+      ca = Gori::Proxy::Tls::CertAuthority.load_or_create(dir)
+      FileUtils.rm_rf(dir) # the dir disappears out from under the live CA
+      ca.regenerate!       # must re-establish it (parity with load_or_create), not crash
+      File.exists?(File.join(dir, "root.crt.pem")).should be_true
+      File.exists?(File.join(dir, "root.key.pem")).should be_true
+    end
+  end
+
   it "mints a leaf under the NEW root after regeneration" do
     with_ca_dir do |dir|
       ca = Gori::Proxy::Tls::CertAuthority.load_or_create(dir)

--- a/spec/proxy/tls/cert_authority_spec.cr
+++ b/spec/proxy/tls/cert_authority_spec.cr
@@ -129,4 +129,64 @@ describe Gori::Proxy::Tls::CertAuthority do
       ca.context_for("b.test").should_not be(ca.context_for("a.test"))
     end
   end
+
+  it "regenerates a fresh root in place — persisted, leaf cache dropped, key 0600" do
+    with_ca_dir do |dir|
+      ca = Gori::Proxy::Tls::CertAuthority.load_or_create(dir)
+      old_pem = ca.ca_cert_pem
+      old_spki = ca.spki_sha256_base64
+      old_leaf = ca.context_for("a.test") # warm the per-host cache
+
+      ca.regenerate!
+
+      ca.ca_cert_pem.should_not eq(old_pem)         # a brand-new root identity
+      ca.spki_sha256_base64.should_not eq(old_spki) # new key → new SPKI pin
+      ca.context_for("a.test").should_not be(old_leaf) # stale leaf evicted
+      # The swap is persisted: a reload reads the NEW root, not the old one.
+      Gori::Proxy::Tls::CertAuthority.load_or_create(dir).ca_cert_pem.should eq(ca.ca_cert_pem)
+      File.info(File.join(dir, "root.key.pem")).permissions.value.should eq(0o600)
+    end
+  end
+
+  it "mints a leaf under the NEW root after regeneration" do
+    with_ca_dir do |dir|
+      ca = Gori::Proxy::Tls::CertAuthority.load_or_create(dir)
+      ca.regenerate!
+      server_ctx = ca.context_for("localhost")
+
+      # client trusts ONLY the regenerated root (read fresh off disk)
+      client_ctx = OpenSSL::SSL::Context::Client.new
+      ca_cert = Gori::Proxy::Tls::Cert.read_pem(File.join(dir, "root.crt.pem"))
+      store = LibSSL.ssl_ctx_get_cert_store(client_ctx.to_unsafe)
+      LibCrypto.x509_store_add_cert(store, ca_cert.handle).should eq(1)
+
+      tcp_server = TCPServer.new("127.0.0.1", 0)
+      port = tcp_server.local_address.port
+      result = Channel(String).new
+
+      spawn do
+        conn = tcp_server.accept
+        ssl = OpenSSL::SSL::Socket::Server.new(conn, server_ctx, sync_close: true)
+        ssl.puts(ssl.gets)
+        ssl.flush
+        ssl.close
+      rescue ex
+        result.send("server-error: #{ex.message}")
+      end
+
+      spawn do
+        tcp = TCPSocket.new("127.0.0.1", port)
+        ssl = OpenSSL::SSL::Socket::Client.new(tcp, context: client_ctx, sync_close: true, hostname: "localhost")
+        ssl.puts("ping")
+        ssl.flush
+        echo = ssl.gets
+        ssl.close
+        result.send("ok: #{echo}")
+      rescue ex
+        result.send("client-error: #{ex.class}: #{ex.message}")
+      end
+
+      result.receive.should eq("ok: ping") # the new leaf chains to the new root
+    end
+  end
 end

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -120,6 +120,8 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def export_ca : Nil; end
 
+  def regenerate_ca : Nil; end
+
   def open_browser_picker : Nil; end
 
   def open_settings(section : Symbol) : Nil; end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -228,6 +228,10 @@ private class FakeContext < ExecContext
     @calls << :export_ca
   end
 
+  def regenerate_ca : Nil
+    @calls << :regenerate_ca
+  end
+
   def open_browser_picker : Nil
     @calls << :open_browser_picker
   end

--- a/src/gori/proxy/tls/cert_authority.cr
+++ b/src/gori/proxy/tls/cert_authority.cr
@@ -75,6 +75,38 @@ module Gori::Proxy::Tls
       File.read(@ca_cert_path)
     end
 
+    # Regenerate the root CA in place: mint a brand-new self-signed root, persist
+    # it over the existing PEM files, and drop the per-host leaf cache so every
+    # subsequent connection is signed by the NEW root. The Tunnel/proxy hold THIS
+    # object, so the swap is live (no restart) — but the new root is a different
+    # key+identity, so any client that trusted the OLD CA must re-trust it.
+    def regenerate!(common_name : String = DEFAULT_CN) : Nil
+      cert, key = CertBuilder.build_root(common_name)
+      key_path = File.join(File.dirname(@ca_cert_path), CA_KEY_FILE)
+      # Regenerating overwrites a WORKING CA, so a half-written cert/key pair (disk
+      # full, a permission error) must not corrupt it: stage both PEMs in full to
+      # temp files, then rename into place (atomic on POSIX; both temps already
+      # exist, so the on-disk cert/key never disagree past the gap between renames).
+      cert_tmp = "#{@ca_cert_path}.tmp"
+      key_tmp = "#{key_path}.tmp"
+      begin
+        cert.write_pem(cert_tmp)
+        key.write_pem(key_tmp)
+        File.chmod(key_tmp, 0o600) # the CA private key is a machine secret
+        File.rename(key_tmp, key_path)
+        File.rename(cert_tmp, @ca_cert_path)
+      rescue ex
+        File.delete?(cert_tmp)
+        File.delete?(key_tmp)
+        raise ex
+      end
+      @mutex.synchronize do
+        @cert = cert
+        @key = key
+        @cache.clear # old leaves were signed by the previous root — drop them
+      end
+    end
+
     # Base64(SHA-256(DER SubjectPublicKeyInfo)) of the root CA — the value a
     # Chromium browser wants in `--ignore-certificate-errors-spki-list` to trust
     # exactly this CA (and nothing else) for the launched session.

--- a/src/gori/proxy/tls/cert_authority.cr
+++ b/src/gori/proxy/tls/cert_authority.cr
@@ -82,7 +82,9 @@ module Gori::Proxy::Tls
     # key+identity, so any client that trusted the OLD CA must re-trust it.
     def regenerate!(common_name : String = DEFAULT_CN) : Nil
       cert, key = CertBuilder.build_root(common_name)
-      key_path = File.join(File.dirname(@ca_cert_path), CA_KEY_FILE)
+      dir = File.dirname(@ca_cert_path)
+      Gori::Paths.ensure_dir(dir) # parity with load_or_create: the dir may have been removed at runtime
+      key_path = File.join(dir, CA_KEY_FILE)
       # Regenerating overwrites a WORKING CA, so a half-written cert/key pair (disk
       # full, a permission error) must not corrupt it: stage both PEMs in full to
       # temp files, then rename into place (atomic on POSIX; both temps already

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1936,6 +1936,28 @@ module Gori::Tui
       @toast = "root CA path copied to clipboard: #{path}"
     end
 
+    # Regenerate the root CA — irreversible (the old key is overwritten) and it
+    # voids any existing trust, so it's gated behind a confirm. On accept the swap
+    # is live (the proxy mints new leaves immediately); the path is copied so the
+    # operator's next step — re-trusting the new cert — is one paste away.
+    def regenerate_ca : Nil
+      path = @session.ca.ca_cert_path
+      confirm("REGENERATE CA",
+        "Replace the current root CA with a new one?\n\n" \
+        "The old CA becomes untrusted — re-export and\n" \
+        "re-trust the new certificate in your clients.\n" \
+        "New connections use it immediately.",
+        confirm_label: "regenerate", danger: true) do
+        begin
+          @session.ca.regenerate!
+          Clipboard.copy(path)
+          @toast = "root CA regenerated — re-export & re-trust it (path copied): #{path}"
+        rescue ex
+          @toast = "CA regeneration failed: #{ex.message}"
+        end
+      end
+    end
+
     # --- browser (open a pre-trusted system browser) ---
 
     # Detect installed browsers and open the picker; if none qualify, just toast.

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -97,6 +97,7 @@ module Gori
 
       # certificate authority
       abstract def export_ca : Nil
+      abstract def regenerate_ca : Nil # mint a fresh root CA (after a confirm)
 
       # browser: open a system browser pre-trusting gori's CA + routed via the proxy
       abstract def open_browser_picker : Nil

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -38,6 +38,12 @@ module Gori
         "ca.export", "Export CA certificate", "Print the path to gori's root CA for trust setup",
         Verb::Scope::Global) { |ctx| ctx.export_ca; nil }
 
+      # Palette-only (destructive — gated behind a confirm in the Runner): mint a
+      # fresh root CA, replacing the old one. Invalidates any prior trust.
+      r.register Verb::Definition.new(
+        "ca.regenerate", "Regenerate CA certificate", "Replace gori's root CA with a fresh one (old trust is invalidated)",
+        Verb::Scope::Global) { |ctx| ctx.regenerate_ca; nil }
+
       # Palette-only (no chord — used rarely): open a system browser pre-trusting
       # gori's CA and routed through the proxy, like Burp/Caido's embedded browser.
       r.register Verb::Definition.new(


### PR DESCRIPTION
## Summary
Adds a **Regenerate CA certificate** command to the Cmd+P palette so an operator can mint a fresh root CA without leaving the TUI or restarting gori.

- New palette verb `ca.regenerate` (Global, palette-only, no chord) sitting next to the existing `ca.export`.
- Selecting it opens the existing `ConfirmDialog` with a red **danger** "regenerate" button (default = cancel, so a reflexive ↵ does nothing). The prompt warns that the old CA becomes untrusted and must be re-exported / re-trusted.
- On accept, `CertAuthority#regenerate!` rebuilds the root **in place** and the proxy picks it up live.

## Design notes
- **Live swap, no restart.** `App` creates one `CertAuthority` and passes the same object into every `Session`; the proxy's `Tunnel` holds it. `regenerate!` swaps `@cert`/`@key` under the mutex and clears the per-host leaf cache, so the next `context_for` mints leaves under the new root. In-flight TLS sockets keep their old leaf context (it up-refs the old cert) — same invariant as the existing `MAX_LEAVES` eviction.
- **Atomicity.** Regeneration overwrites a *working* CA (unlike first-run create), so both PEMs are staged to `*.tmp` then `rename`d into place (temps removed on failure). A half-written cert/key pair can't corrupt a working CA. Key stays `0600`.
- After success the CA path is copied to the clipboard with a re-export/re-trust toast.

## Tests
- `CertAuthority#regenerate!`: in-place swap, persistence across reload, leaf-cache drop, key `0600`.
- A real-handshake spec proving a leaf minted *after* regeneration chains to the **new** root.
- Two `ExecContext` test doubles updated with `regenerate_ca`.

Full suite: **504 examples, 0 failures**. `ameba` clean on changed source files.

## Caveat
Other *already-running* gori instances keep their old in-memory CA until restarted, since the regenerated files are the global root at `~/.gori/ca/`. The triggering instance swaps live.