### PR TITLE
feat(intercept): catch direction (all/req/res) + conditional intercept filter bar

### DIFF
--- a/spec/intercept_filter_spec.cr
+++ b/spec/intercept_filter_spec.cr
@@ -1,0 +1,84 @@
+require "./spec_helper"
+
+private def req(method = "GET", host = "acme.test", target = "/login", scheme = "http")
+  Gori::InterceptFilter::Subject.new(method: method, host: host, target: target, scheme: scheme)
+end
+
+private def res(status : Int32, method = "GET", host = "acme.test", target = "/login", scheme = "http")
+  Gori::InterceptFilter::Subject.new(method: method, host: host, target: target, scheme: scheme, status: status)
+end
+
+describe Gori::InterceptFilter do
+  it "an empty filter matches everything" do
+    f = Gori::InterceptFilter::EMPTY
+    f.blank?.should be_true
+    f.matches?(req).should be_true
+    f.matches?(res(200)).should be_true
+  end
+
+  it "matches host as a substring (case-insensitive)" do
+    f = Gori::InterceptFilter.new("host:ACME")
+    f.matches?(req(host: "api.acme.test")).should be_true
+    f.matches?(req(host: "evil.test")).should be_false
+  end
+
+  it "matches method exactly (case-insensitive)" do
+    f = Gori::InterceptFilter.new("method:post")
+    f.matches?(req(method: "POST")).should be_true
+    f.matches?(req(method: "GET")).should be_false
+  end
+
+  it "matches path as a substring of the target" do
+    f = Gori::InterceptFilter.new("path:/api")
+    f.matches?(req(target: "/api/v1/users?id=1")).should be_true
+    f.matches?(req(target: "/login")).should be_false
+  end
+
+  it "matches scheme exactly" do
+    Gori::InterceptFilter.new("scheme:https").matches?(req(scheme: "https")).should be_true
+    Gori::InterceptFilter.new("scheme:https").matches?(req(scheme: "http")).should be_false
+  end
+
+  it "status: only matches a response, never a request (request has no status)" do
+    f = Gori::InterceptFilter.new("status:500")
+    f.matches?(res(500)).should be_true
+    f.matches?(res(404)).should be_false
+    f.matches?(req).should be_false # a request can't satisfy a status term
+  end
+
+  it "supports status comparisons and classes" do
+    Gori::InterceptFilter.new("status:>=500").matches?(res(503)).should be_true
+    Gori::InterceptFilter.new("status:>=500").matches?(res(404)).should be_false
+    Gori::InterceptFilter.new("status:5xx").matches?(res(500)).should be_true
+    Gori::InterceptFilter.new("status:5xx").matches?(res(499)).should be_false
+    Gori::InterceptFilter.new("status:<400").matches?(res(200)).should be_true
+  end
+
+  it "ANDs terms within a group, ORs across OR" do
+    f = Gori::InterceptFilter.new("method:POST host:acme")
+    f.matches?(req(method: "POST", host: "acme.test")).should be_true
+    f.matches?(req(method: "POST", host: "other.test")).should be_false
+
+    g = Gori::InterceptFilter.new("host:acme OR host:shop")
+    g.matches?(req(host: "acme.test")).should be_true
+    g.matches?(req(host: "shop.test")).should be_true
+    g.matches?(req(host: "other.test")).should be_false
+  end
+
+  it "negates a term with a leading -" do
+    f = Gori::InterceptFilter.new("-host:acme")
+    f.matches?(req(host: "acme.test")).should be_false
+    f.matches?(req(host: "evil.test")).should be_true
+  end
+
+  it "treats a bare word as free text over method/host/target" do
+    f = Gori::InterceptFilter.new("login")
+    f.matches?(req(target: "/login")).should be_true
+    f.matches?(req(target: "/home")).should be_false
+  end
+
+  it "drops empty-valued terms (so `host:` while typing matches all)" do
+    Gori::InterceptFilter.new("host:").blank?.should be_true
+    Gori::InterceptFilter.new("host:").matches?(req).should be_true
+  end
+end

--- a/spec/interceptor_spec.cr
+++ b/spec/interceptor_spec.cr
@@ -126,6 +126,92 @@ describe Gori::Interceptor do
   end
 end
 
+describe "Gori::Interceptor direction + condition gates" do
+  it "cycle_direction wraps Both → RequestOnly → ResponseOnly → Both" do
+    with_store do |store|
+      ic = Gori::Interceptor.new(Gori::Scope.load(store))
+      ic.direction.should eq(Gori::Interceptor::Direction::Both)
+      ic.cycle_direction.should eq(Gori::Interceptor::Direction::RequestOnly)
+      ic.cycle_direction.should eq(Gori::Interceptor::Direction::ResponseOnly)
+      ic.cycle_direction.should eq(Gori::Interceptor::Direction::Both)
+    end
+  end
+
+  it "honours the catch direction at the request/response gates" do
+    with_store do |store|
+      ic = Gori::Interceptor.new(Gori::Scope.load(store))
+      ic.toggle # enable (default Both)
+      req_ok = -> { ic.intercepts_request?("http://acme.test/x", method: "GET", host: "acme.test", target: "/x", scheme: "http") }
+      res_ok = -> { ic.intercepts_response?("http://acme.test/x", method: "GET", host: "acme.test", target: "/x", scheme: "http", status: 200) }
+
+      req_ok.call.should be_true
+      res_ok.call.should be_true
+
+      ic.cycle_direction # RequestOnly
+      req_ok.call.should be_true
+      res_ok.call.should be_false
+
+      ic.cycle_direction # ResponseOnly
+      req_ok.call.should be_false
+      res_ok.call.should be_true
+    end
+  end
+
+  it "disabled → both gates closed regardless of direction" do
+    with_store do |store|
+      ic = Gori::Interceptor.new(Gori::Scope.load(store))
+      ic.intercepts_request?("http://acme.test/x", method: "GET", host: "acme.test", target: "/x", scheme: "http").should be_false
+      ic.intercepts_response?("http://acme.test/x", method: "GET", host: "acme.test", target: "/x", scheme: "http", status: 200).should be_false
+    end
+  end
+
+  it "the condition filter narrows holding (matched against in-flight attrs)" do
+    with_store do |store|
+      ic = Gori::Interceptor.new(Gori::Scope.load(store))
+      ic.toggle
+      ic.set_filter("method:POST")
+      ic.intercepts_request?("http://acme.test/x", method: "POST", host: "acme.test", target: "/x", scheme: "http").should be_true
+      ic.intercepts_request?("http://acme.test/x", method: "GET", host: "acme.test", target: "/x", scheme: "http").should be_false
+    end
+  end
+
+  it "a status: condition holds only matching responses, never requests" do
+    with_store do |store|
+      ic = Gori::Interceptor.new(Gori::Scope.load(store))
+      ic.toggle
+      ic.set_filter("status:>=500")
+      ic.intercepts_response?("http://acme.test/x", method: "GET", host: "acme.test", target: "/x", scheme: "http", status: 503).should be_true
+      ic.intercepts_response?("http://acme.test/x", method: "GET", host: "acme.test", target: "/x", scheme: "http", status: 200).should be_false
+      ic.intercepts_request?("http://acme.test/x", method: "GET", host: "acme.test", target: "/x", scheme: "http").should be_false
+    end
+  end
+
+  it "bumps revision on cycle_direction / set_filter (drives the TUI redraw)" do
+    with_store do |store|
+      ic = Gori::Interceptor.new(Gori::Scope.load(store))
+      r0 = ic.revision
+      ic.cycle_direction
+      (ic.revision > r0).should be_true
+      r1 = ic.revision
+      ic.set_filter("host:acme")
+      (ic.revision > r1).should be_true
+    end
+  end
+
+  it "the condition still respects the Scope lens" do
+    with_store do |store|
+      scope = Gori::Scope.load(store)
+      ic = Gori::Interceptor.new(scope)
+      ic.toggle
+      scope.add("include", "host", "acme.test")
+      scope.enable
+      ic.set_filter("method:GET")
+      ic.intercepts_request?("http://acme.test/x", method: "GET", host: "acme.test", target: "/x", scheme: "http").should be_true
+      ic.intercepts_request?("http://evil.test/x", method: "GET", host: "evil.test", target: "/x", scheme: "http").should be_false # out of scope
+    end
+  end
+end
+
 describe "Gori::Scope host matching (intercept gate)" do
   it "matches exact host, subdomain, and glob via may_match_host?" do
     with_store do |store|

--- a/spec/proxy/server_spec.cr
+++ b/spec/proxy/server_spec.cr
@@ -315,6 +315,56 @@ describe Gori::Proxy::Server do
     sink.requests.first.target.should eq("/held")
   end
 
+  it "evaluates the response intercept condition against the REWRITTEN request line" do
+    # Regression: a Match&Replace rule rewrites /hello → /hi. With a response-only
+    # catch + condition `path:/hi`, the response gate must match the REWRITTEN path
+    # (what was sent + captured + scope-gated), not the original /hello — else the
+    # request's response would slip through unheld.
+    seen = Channel(String).new(1)
+    done = Channel(Nil).new(1)
+    origin_port = start_origin("ok", seen)
+
+    store_path = File.tempname("gori-icrw", ".db")
+    store = Gori::Store.open(store_path)
+    interceptor = Gori::Interceptor.new(Gori::Scope.load(store))
+    interceptor.toggle
+    interceptor.cycle_direction # Both → RequestOnly
+    interceptor.cycle_direction # → ResponseOnly (stream the request, hold only the response)
+    interceptor.set_filter("path:/hi")
+
+    sink = RecordingSink.new(done)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink, rewriter: StubRewriter.new, interceptor: interceptor)
+    proxy.start
+
+    held_kinds = [] of Gori::Interceptor::Kind
+    spawn do
+      loop do
+        interceptor.pending.each do |it|
+          held_kinds << it.kind
+          interceptor.forward(it.id)
+        end
+        sleep 0.01.seconds
+      end
+    end
+
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    client << "GET /hello HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\n\r\n"
+    client.flush
+    client.gets_to_end
+    client.close
+
+    done.receive
+    proxy.stop
+    store.close
+    File.delete?(store_path)
+    File.delete?("#{store_path}-wal")
+    File.delete?("#{store_path}-shm")
+
+    seen.receive.should eq("GET /hi HTTP/1.1")                      # upstream saw the rewritten line
+    held_kinds.should contain(Gori::Interceptor::Kind::Response)    # response held: matched /hi (not /hello)
+    held_kinds.should_not contain(Gori::Interceptor::Kind::Request) # ResponseOnly → request streamed
+  end
+
   it "drops a held request with a 502 and records it Aborted" do
     done = Channel(Nil).new(1)
 

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -114,6 +114,10 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def intercept_forward_all : Nil; end
 
+  def intercept_query : Nil; end
+
+  def intercept_cycle_direction : Nil; end
+
   def selected_intercept_id : Int64?
     nil
   end

--- a/spec/tui/intercept_view_spec.cr
+++ b/spec/tui/intercept_view_spec.cr
@@ -80,6 +80,65 @@ describe Gori::Tui::InterceptView do
   end
 end
 
+describe "Intercept filter bar" do
+  it "shows the catch-direction chip and the condition hint" do
+    tmp_interceptor do |ic|
+      view = InterceptView.new
+      view.reload(ic)
+      backend = MemoryBackend.new(100, 8)
+      view.render(Screen.new(backend), Rect.new(0, 0, 100, 8))
+      backend.row(0).includes?("catch:all").should be_true # default direction chip
+      backend.contains?("/ condition").should be_true      # field hint
+    end
+  end
+
+  it "reflects the interceptor's catch direction after a cycle" do
+    tmp_interceptor do |ic|
+      ic.cycle_direction # Both → RequestOnly
+      view = InterceptView.new
+      view.reload(ic)
+      backend = MemoryBackend.new(100, 8)
+      view.render(Screen.new(backend), Rect.new(0, 0, 100, 8))
+      backend.row(0).includes?("catch:req").should be_true
+    end
+  end
+
+  it "edits the condition query inline" do
+    tmp_interceptor do |ic|
+      view = InterceptView.new
+      view.reload(ic)
+      view.start_query
+      view.querying?.should be_true
+      "host:acme".each_char { |c| view.query_insert(c) }
+      view.query.should eq("host:acme")
+      view.query_backspace
+      view.query.should eq("host:acm")
+
+      backend = MemoryBackend.new(100, 8)
+      view.render(Screen.new(backend), Rect.new(0, 0, 100, 8))
+      backend.contains?("catch ›").should be_true # editing prompt
+      backend.contains?("host:acm").should be_true
+
+      view.cancel_query
+      view.querying?.should be_false
+      view.query.should eq("")
+    end
+  end
+
+  it "keeps the queue rendered below the filter bar" do
+    tmp_interceptor do |ic|
+      hold_req(ic, "acme.test", "/login", "GET /login HTTP/1.1\r\nHost: acme.test\r\n\r\n")
+      view = InterceptView.new
+      view.reload(ic)
+      backend = MemoryBackend.new(100, 12)
+      view.render(Screen.new(backend), Rect.new(0, 0, 100, 12))
+      backend.row(0).includes?("catch:all").should be_true # bar on the top row
+      backend.contains?("QUEUE (1)").should be_true        # queue card still drawn below
+      backend.contains?("acme.test/login").should be_true
+    end
+  end
+end
+
 describe "Intercept verbs (P1)" do
   it "binds `i` to intercept.toggle and scopes forward/drop to Intercept" do
     reg = Gori::Verbs.registry

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -220,6 +220,14 @@ private class FakeContext < ExecContext
     @calls << :intercept_forward_all
   end
 
+  def intercept_query : Nil
+    @calls << :intercept_query
+  end
+
+  def intercept_cycle_direction : Nil
+    @calls << :intercept_cycle_direction
+  end
+
   def selected_intercept_id : Int64?
     @selected
   end

--- a/src/gori/intercept_filter.cr
+++ b/src/gori/intercept_filter.cr
@@ -1,0 +1,159 @@
+module Gori
+  # An in-memory boolean filter that NARROWS what the Interceptor holds — the
+  # "conditional intercept" lens. It mirrors the QL surface (`field:value`, `OR`
+  # groups, `-`negation, bare free-text) but evaluates against a LIVE in-flight
+  # message at the hold gate, BEFORE anything is captured — so QL's SQL compilation
+  # can't be reused (there's no row to query yet). Supported fields:
+  #
+  #   host:acme        substring of the host
+  #   path:/api        substring of the request target (path+query)
+  #   method:POST      exact method (case-insensitive)
+  #   scheme:https     exact scheme
+  #   status:>=500     numeric / class (5xx) comparison — RESPONSES ONLY
+  #   token            bare word → substring over method/host/target
+  #
+  # `status:` only matches a response (a request has no status, so a status term
+  # makes a request never match — i.e. it scopes the condition to responses by
+  # intent). An empty filter matches everything (hold all in-scope traffic).
+  struct InterceptFilter
+    # The message attributes available at a hold gate. `status` is set only for a
+    # held RESPONSE (nil for a request).
+    record Subject,
+      method : String,
+      host : String,
+      target : String,
+      scheme : String,
+      status : Int32? = nil
+
+    # One parsed predicate. `field` is :host/:path/:method/:scheme/:status, or :text
+    # for a bare free-text word. Negation flips the result (mirrors QL's `-term`).
+    private record Term, field : Symbol, value : String, negate : Bool do
+      def matches?(s : Subject) : Bool
+        hit = raw_match?(s)
+        negate ? !hit : hit
+      end
+
+      private def raw_match?(s : Subject) : Bool
+        case field
+        when :host   then s.host.downcase.includes?(value.downcase)
+        when :path   then s.target.downcase.includes?(value.downcase)
+        when :method then s.method.upcase == value.upcase
+        when :scheme then s.scheme.downcase == value.downcase
+        when :status then (st = s.status) ? InterceptFilter.status_match?(st, value) : false
+        else # :text — free-text substring over method/host/target
+          v = value.downcase
+          s.method.downcase.includes?(v) || s.host.downcase.includes?(v) || s.target.downcase.includes?(v)
+        end
+      end
+    end
+
+    EMPTY = new("")
+
+    getter source : String
+
+    def initialize(@source : String)
+      @groups = InterceptFilter.compile(@source) # OR of AND-groups (Array(Array(Term)))
+    end
+
+    # No effective predicates → matches everything (the default "hold all" behaviour).
+    def blank? : Bool
+      @groups.empty?
+    end
+
+    # Match: OR across groups, AND within a group (mirrors QL.parse's grouping). An
+    # empty filter matches all. Called on the proxy hot path, so it allocates nothing.
+    def matches?(s : Subject) : Bool
+      groups = @groups
+      return true if groups.empty?
+      groups.any? { |group| group.all?(&.matches?(s)) }
+    end
+
+    # Parse a query into OR-separated AND-groups of Terms (the same shape QL.parse
+    # builds before it emits SQL). Empty-valued / unparsable terms are dropped; a
+    # group with no surviving terms is dropped; no groups → match-all.
+    protected def self.compile(query : String) : Array(Array(Term))
+      tokens = query.split
+      return [] of Array(Term) if tokens.empty?
+
+      groups = [[] of String]
+      tokens.each { |tok| tok == "OR" ? (groups << [] of String) : groups.last << tok }
+
+      compiled = [] of Array(Term)
+      groups.each do |group|
+        terms = [] of Term
+        group.each do |tok|
+          if term = parse_term(tok)
+            terms << term
+          end
+        end
+        compiled << terms unless terms.empty?
+      end
+      compiled
+    end
+
+    private def self.parse_term(token : String) : Term?
+      negate = token.starts_with?('-')
+      token = token[1..] if negate
+      return nil if token.empty?
+
+      colon = token.index(':')
+      if colon && colon > 0
+        field = field_symbol(token[0...colon].downcase)
+        value = token[(colon + 1)..]
+        return nil if value.empty?
+        Term.new(field, value, negate)
+      else
+        Term.new(:text, token, negate)
+      end
+    end
+
+    # Map a field name to its Term symbol. An unknown field is treated as free text
+    # over the WHOLE token (mirrors QL's "unknown field → free text" fallback).
+    private def self.field_symbol(field : String) : Symbol
+      case field
+      when "host"   then :host
+      when "path"   then :path
+      when "method" then :method
+      when "scheme" then :scheme
+      when "status" then :status
+      else               :text
+      end
+    end
+
+    # Numeric / status-class comparison, mirroring QL.status_cond's semantics so the
+    # live gate and the History `status:` query agree. Supports <,<=,>,>=,= and an
+    # `Nxx` class (e.g. `5xx` → 500..599; `>=4xx` → >=400). Unparsable → no match.
+    def self.status_match?(actual : Int32, value : String) : Bool
+      op = "="
+      rest = value
+      {"<=", ">=", "<", ">", "="}.each do |o|
+        if value.starts_with?(o)
+          op = o
+          rest = value[o.size..]
+          break
+        end
+      end
+
+      if rest.size == 3 && rest[1] == 'x' && rest[2] == 'x' && rest[0].ascii_number?
+        base = rest[0].to_i * 100
+        case op
+        when ">=" then return actual >= base
+        when ">"  then return actual >= base + 100
+        when "<=" then return actual < base + 100
+        when "<"  then return actual < base
+        else           return actual >= base && actual < base + 100
+        end
+      end
+
+      n = rest.to_i?
+      return false unless n
+      case op
+      when ">=" then actual >= n
+      when ">"  then actual > n
+      when "<=" then actual <= n
+      when "<"  then actual < n
+      else           actual == n
+      end
+    end
+  end
+end

--- a/src/gori/interceptor.cr
+++ b/src/gori/interceptor.cr
@@ -1,4 +1,5 @@
 require "./scope"
+require "./intercept_filter"
 
 module Gori
   # The Intercept lens (P4 — the human decides): when enabled, an in-flight HTTP
@@ -21,6 +22,20 @@ module Gori
       Forward # send `bytes` onward (edited or original)
       Drop    # discard; the proxy answers the client with a canned 502
     end
+
+    # Which leg of a flow to hold: both, requests only, or responses only. Lets a
+    # user who only cares about outgoing requests (the common case) skip the
+    # response round-trip without disabling intercept. Does NOT relax the h2→h1
+    # downgrade gate — a response can only be held on the interceptable h1 path, so
+    # the connection must stay h1 for either direction.
+    enum Direction
+      Both
+      RequestOnly
+      ResponseOnly
+    end
+
+    # The Subject struct the conditional-intercept filter matches against.
+    alias Subject = InterceptFilter::Subject
 
     # The decision the TUI hands back over an Item's reply channel.
     record Decision, action : Action, bytes : Bytes
@@ -46,12 +61,20 @@ module Gori
       end
     end
 
+    @direction : Direction
+    @filter : InterceptFilter
+
     def initialize(@scope : Scope)
       @mutex = Mutex.new
       @enabled = false
       @items = {} of Int64 => Item
       @next_id = 0_i64
       @shutting_down = false
+      # Which leg(s) to hold + an optional in-memory condition that NARROWS holding
+      # (vs Scope, the global lens). Both default permissive (hold every in-scope
+      # message). Mutated by the TUI fiber, read on the proxy hot path → @mutex.
+      @direction = Direction::Both
+      @filter = InterceptFilter::EMPTY
       # Monotonic counter bumped on every queue/enabled change (incl. async holds
       # from proxy fibers). The TUI compares it to know when to re-render, since
       # the queue mutates without any flow event. Atomic → lock-free read.
@@ -65,6 +88,38 @@ module Gori
 
     def enabled? : Bool
       @mutex.synchronize { @enabled }
+    end
+
+    # Which leg(s) are currently held (TUI reads it to render the catch chip).
+    def direction : Direction
+      @mutex.synchronize { @direction }
+    end
+
+    # The raw condition source (TUI reads it to render the filter bar). The query
+    # itself lives in the TUI's edit buffer; this is the committed copy.
+    def filter_source : String
+      @mutex.synchronize { @filter.source }
+    end
+
+    # Cycle the catch direction Both → RequestOnly → ResponseOnly → Both. Returns
+    # the new value; bumps revision so the TUI redraws the chip.
+    def cycle_direction : Direction
+      now = @mutex.synchronize do
+        @direction = case @direction
+                     when .both?         then Direction::RequestOnly
+                     when .request_only? then Direction::ResponseOnly
+                     else                     Direction::Both
+                     end
+      end
+      @revision.add(1)
+      now
+    end
+
+    # Replace the conditional-intercept filter (parsed from a QL-like query). Cheap
+    # to rebuild, so the TUI can call it live on every keystroke. Bumps revision.
+    def set_filter(query : String) : Nil
+      @mutex.synchronize { @filter = InterceptFilter.new(query) }
+      @revision.add(1)
     end
 
     # Toggle on/off. Turning OFF auto-forwards everything currently held (so
@@ -88,19 +143,45 @@ module Gori
     # h2→h1 BEFORE any request exists (so only the host is known). Scope rules that
     # match on path/URL can't be evaluated yet, so this is permissive: downgrade if the
     # host COULD be in scope, then let ClientConn make the precise per-request call via
-    # intercepts_url?. Keeping the connection on h1 is what lets a request be held at all.
+    # intercepts_request?. Keeping the connection on h1 is what lets a request be held.
+    # Direction-agnostic on purpose: holding EITHER a request or a response needs h1.
     def intercepts_host?(host : String) : Bool
       active = @mutex.synchronize { @enabled && !@shutting_down }
       return false unless active
       @scope.active? ? @scope.may_match_host?(host) : true
     end
 
-    # Precise per-request gate, used by ClientConn (which has the full request): hold
-    # this exact flow? `url` is `scheme://host/target` — the same value the Scope SQL
-    # filter builds, so a held request is exactly an in-scope History row.
-    def intercepts_url?(url : String, host : String) : Bool
-      active = @mutex.synchronize { @enabled && !@shutting_down }
-      return false unless active
+    # Precise per-REQUEST gate, used by ClientConn (which has the full request): hold
+    # this exact request? `url` is `scheme://host/target` — the same value the Scope
+    # SQL filter builds, so a held request is exactly an in-scope History row. Folds
+    # in the catch direction (skip when responses-only) and the conditional filter.
+    def intercepts_request?(url : String, *, method : String, host : String,
+                            target : String, scheme : String) : Bool
+      enabled, dir, filter = gate_snapshot
+      return false unless enabled
+      return false if dir.response_only?
+      return false unless scope_allows?(url, host)
+      filter.matches?(Subject.new(method: method, host: host, target: target, scheme: scheme))
+    end
+
+    # Precise per-RESPONSE gate (same shape as the request gate). Skips when
+    # requests-only; the condition can also test `status:` here (a response has one).
+    def intercepts_response?(url : String, *, method : String, host : String,
+                             target : String, scheme : String, status : Int32) : Bool
+      enabled, dir, filter = gate_snapshot
+      return false unless enabled
+      return false if dir.request_only?
+      return false unless scope_allows?(url, host)
+      filter.matches?(Subject.new(method: method, host: host, target: target, scheme: scheme, status: status))
+    end
+
+    # One locked read of the enabled/direction/filter trio, so a single hot-path
+    # call takes @mutex once. Scope has its OWN mutex, so scope_allows? runs after.
+    private def gate_snapshot : {Bool, Direction, InterceptFilter}
+      @mutex.synchronize { {@enabled && !@shutting_down, @direction, @filter} }
+    end
+
+    private def scope_allows?(url : String, host : String) : Bool
       @scope.active? ? @scope.in_scope_url?(url, host) : true
     end
 

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -112,7 +112,8 @@ module Gori::Proxy
       # SAME target that gets captured (sent_req.target, used at the insert below), so a
       # held request is precisely an in-scope History row with no live/SQL divergence.
       scope_url = "#{scheme}://#{host}#{sent_req.target}"
-      if (ic = @interceptor) && ic.intercepts_url?(scope_url, host)
+      if (ic = @interceptor) && ic.intercepts_request?(scope_url,
+           method: sent_req.method, host: host, target: sent_req.target, scheme: scheme)
         return handle_held_request(ic, req, sent_req, sent_head, host, port, scheme,
           created_at, started, req_framing, req_len)
       end
@@ -242,7 +243,9 @@ module Gori::Proxy
       # close-delimited / WebSocket bodies would buffer forever, so they bypass.
       # Use the SAME precise URL gate as the request hold (scope_url built above), so a
       # string/regex-excluded flow whose request wasn't held doesn't get its response held.
-      if (ic = @interceptor) && ic.intercepts_url?(scope_url, host) &&
+      # The response gate also honours the catch direction + can test `status:`.
+      if (ic = @interceptor) && ic.intercepts_response?(scope_url,
+           method: req.method, host: host, target: req.target, scheme: scheme, status: resp.status) &&
          !resp_framing.close_delimited? && !sse?(resp) && !websocket_upgrade?(resp)
         return handle_held_response(ic, upstream, req, flow_id, host, port, scheme,
           resp, sent_resp_head, resp_framing, resp_len, ttfb, started)

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -143,7 +143,7 @@ module Gori::Proxy
         return false
       end
       handle_response(upstream, req, flow_id, started, host, port, scheme,
-        reused: reused, sent_head: sent_head, can_retry: retryable, scope_url: scope_url)
+        reused: reused, sent_head: sent_head, can_retry: retryable, scope_url: scope_url, sent_req: sent_req)
     end
 
     # The intercept-hold request path: buffer the body, let the human edit/drop
@@ -179,7 +179,7 @@ module Gori::Proxy
         body: stored, body_truncated: trunc, body_size: size))
       handle_response(upstream, req, flow_id, started, host, port, scheme,
         reused: reused, sent_head: sent_head, can_retry: retryable,
-        scope_url: "#{scheme}://#{host}#{sent_req.target}")
+        scope_url: "#{scheme}://#{host}#{sent_req.target}", sent_req: sent_req)
     end
 
     # Acquires the (reused-or-fresh) upstream and runs `send` on it. If a REUSED
@@ -224,7 +224,8 @@ module Gori::Proxy
     # keep the connection alive.
     private def handle_response(upstream : IO, req : Codec::RawRequest, flow_id : Int64,
                                 started : Time::Instant, host : String, port : Int32, scheme : String,
-                                *, reused : Bool, sent_head : Bytes, can_retry : Bool, scope_url : String) : Bool
+                                *, reused : Bool, sent_head : Bytes, can_retry : Bool, scope_url : String,
+                                sent_req : Codec::RawRequest) : Bool
       resp_head, upstream = read_response_head(upstream, host, port, reused, sent_head, can_retry)
       if resp_head.nil?
         @sink.on_response(FlowMapper.error_response(flow_id, "no response from upstream"))
@@ -243,9 +244,12 @@ module Gori::Proxy
       # close-delimited / WebSocket bodies would buffer forever, so they bypass.
       # Use the SAME precise URL gate as the request hold (scope_url built above), so a
       # string/regex-excluded flow whose request wasn't held doesn't get its response held.
-      # The response gate also honours the catch direction + can test `status:`.
+      # The response gate also honours the catch direction + can test `status:`. Match the
+      # CONDITION against `sent_req` (the rewritten/edited request that was captured + scope-
+      # gated), not the original `req`, so a `method:`/`path:` rule that holds the request
+      # also holds its response when a Match&Replace rule changed the request line.
       if (ic = @interceptor) && ic.intercepts_response?(scope_url,
-           method: req.method, host: host, target: req.target, scheme: scheme, status: resp.status) &&
+           method: sent_req.method, host: host, target: sent_req.target, scheme: scheme, status: resp.status) &&
          !resp_framing.close_delimited? && !sse?(resp) && !websocket_upgrade?(resp)
         return handle_held_response(ic, upstream, req, flow_id, host, port, scheme,
           resp, sent_resp_head, resp_framing, resp_len, ttfb, started)

--- a/src/gori/tui/controllers/intercept_controller.cr
+++ b/src/gori/tui/controllers/intercept_controller.cr
@@ -27,13 +27,18 @@ module Gori::Tui
       Verb::Scope::Intercept
     end
 
-    def body_badge : Symbol # the held-message editor captures text; else the queue list
-      @intercept.editing? ? :editor : :body
+    def body_badge : Symbol # the editor / condition bar capture text; else the queue list
+      @intercept.editing? || @intercept.querying? ? :editor : :body
     end
 
     def body_hint(focus : Symbol) : String
-      @intercept.editing? ? "type to edit · ^R forward · ⇧↹/esc queue" \
-                          : "↑/↓ move · ↵/e edit · f forward · d drop · F all · : cmds · ↹ detail · esc tabs"
+      if @intercept.editing?
+        "type to edit · ^R forward · ⇧↹/esc queue"
+      elsif @intercept.querying?
+        "type condition · ↵ apply · esc clear"
+      else
+        "↑/↓ move · ↵/e edit · f fwd · d drop · F all · / filter · c catch · i on/off · : cmds · ↹ detail · esc tabs"
+      end
     end
 
     def goto_symbol : Symbol? # the held-message editor is ^G/^F-searchable
@@ -47,46 +52,100 @@ module Gori::Tui
 
     def handle_body_key(ev : Termisu::Event::Key) : Bool
       key = ev.key
-      c = ev.char || key.to_char
       if ev.ctrl? && key.lower_p?
         @host.open_palette
       elsif ev.char == ':' && !ev.ctrl? && !ev.alt? && !@intercept.editing?
         @host.open_command # ":" cmdline in the navigable queue (editing swallows ":" as a char)
       elsif @intercept.editing?
-        if key.escape?
-          @intercept.stop_edit
-        elsif ev.ctrl? && key.lower_r?
-          intercept_forward
-        elsif key.enter?
-          @intercept.edit_newline
-        elsif key.backspace?
-          @intercept.edit_backspace
-        elsif key.up?
-          @intercept.edit_move(-1, 0)
-        elsif key.down?
-          @intercept.edit_move(1, 0)
-        elsif key.left?
-          @intercept.edit_move(0, -1)
-        elsif key.right?
-          @intercept.edit_move(0, 1)
-        elsif c && !ev.ctrl? && !ev.alt?
-          @intercept.edit_insert(c)
-        end
+        handle_edit_key(ev)
       else
-        case
-        when key.escape?               then @host.request_focus(:menu)
-        when key.lower_j?, key.down?   then @intercept.move(1)
-        when key.lower_k?, key.up?     then @intercept.at_top? ? @host.request_focus(:menu) : @intercept.move(-1)
-        when key.enter?, key.lower_e?  then @intercept.toggle_edit
-        when key.lower_f? && ev.shift? then intercept_forward_all
-        when key.lower_f?              then intercept_forward
-        when key.lower_d?              then intercept_drop
+        handle_queue_key(ev)
+      end
+      true
+    end
+
+    # Keys while editing the held-message bytes (the right detail editor).
+    private def handle_edit_key(ev : Termisu::Event::Key) : Nil
+      key = ev.key
+      c = ev.char || key.to_char
+      if key.escape?
+        @intercept.stop_edit
+      elsif ev.ctrl? && key.lower_r?
+        intercept_forward
+      elsif key.enter?
+        @intercept.edit_newline
+      elsif key.backspace?
+        @intercept.edit_backspace
+      elsif key.up?
+        @intercept.edit_move(-1, 0)
+      elsif key.down?
+        @intercept.edit_move(1, 0)
+      elsif key.left?
+        @intercept.edit_move(0, -1)
+      elsif key.right?
+        @intercept.edit_move(0, 1)
+      elsif c && !ev.ctrl? && !ev.alt?
+        @intercept.edit_insert(c)
+      end
+    end
+
+    # Keys while navigating the held queue (the left list).
+    private def handle_queue_key(ev : Termisu::Event::Key) : Nil
+      key = ev.key
+      case
+      when key.escape?               then @host.request_focus(:menu)
+      when ev.char == '/'            then intercept_query # catch-condition filter bar
+      when key.lower_j?, key.down?   then @intercept.move(1)
+      when key.lower_k?, key.up?     then @intercept.at_top? ? @host.request_focus(:menu) : @intercept.move(-1)
+      when key.enter?, key.lower_e?  then @intercept.toggle_edit
+      when key.lower_f? && ev.shift? then intercept_forward_all
+      when key.lower_f?              then intercept_forward
+      when key.lower_d?              then intercept_drop
+      when key.lower_c?              then intercept_cycle_direction
+      when key.lower_i?              then intercept_toggle
+      end
+    end
+
+    # --- catch-condition filter bar (a text sub-mode; the shell claims it before the
+    # focus ring, exactly like History's QL bar). Returns true (always swallows). ---
+    def querying? : Bool
+      @intercept.querying?
+    end
+
+    def handle_query_key(ev : Termisu::Event::Key) : Bool
+      key = ev.key
+      c = ev.char || key.to_char
+      ic = @host.session.interceptor
+      case
+      when key.enter?     then @intercept.stop_query
+      when key.escape?    then @intercept.cancel_query; ic.set_filter("")
+      when key.backspace? then @intercept.query_backspace; ic.set_filter(@intercept.query)
+      when key.left?      then @intercept.query_move(-1)
+      when key.right?     then @intercept.query_move(1)
+      else
+        if c && !ev.ctrl? && !ev.alt?
+          @intercept.query_insert(c)
+          ic.set_filter(@intercept.query) # live: narrow holding as you type (only ever narrows from "all")
+          @intercept.set_preedit("")
         end
       end
       true
     end
 
+    # Live IME composition only flows to the condition bar (the one text field besides
+    # the held-message editor, which the shell routes via ^F/^G, not preedit).
+    def set_preedit(text : String) : Bool
+      return false unless @intercept.querying?
+      @intercept.set_preedit(text)
+      true
+    end
+
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
+      if zone = @intercept.bar_zone_at(rect, mx, my) # click the top filter bar
+        @host.focus_body
+        zone == :direction ? intercept_cycle_direction : intercept_query
+        return true
+      end
       return true unless pane = @intercept.pane_at(rect, mx, my)
       @host.focus_body
       if pane == :list
@@ -149,6 +208,27 @@ module Gori::Tui
       @host.session.interceptor.forward_all
       @intercept.reload(@host.session.interceptor)
       @host.status("forwarded all (#{n})")
+    end
+
+    # Open the catch-condition filter bar (a query that narrows which messages hold).
+    def intercept_query : Nil
+      @intercept.start_query
+      @host.status("catch condition: host: method: path: status: scheme: · ↵ apply · esc clear")
+    end
+
+    # Cycle which leg(s) to hold: all → requests → responses → all.
+    def intercept_cycle_direction : Nil
+      dir = @host.session.interceptor.cycle_direction
+      @intercept.reload(@host.session.interceptor)
+      @host.status("intercept catch: #{direction_phrase(dir)}")
+    end
+
+    private def direction_phrase(dir : Interceptor::Direction) : String
+      case dir
+      when .request_only?  then "requests only"
+      when .response_only? then "responses only"
+      else                      "requests & responses"
+      end
     end
 
     def selected_intercept_id : Int64?

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -63,7 +63,7 @@ module Gori::Tui
         {"Findings", "↵ open · n new · d delete · x export"},
         {"Notes", "type to edit · ^N new · ^1-9 switch"},
         {"Project", "scope rules + the description editor"},
-        {"Intercept", "↵/e edit · f forward · d drop · F all"},
+        {"Intercept", "↵/e edit · f fwd · d drop · F all · c catch dir · / condition"},
       ]},
       {"OVERLAYS", [
         {"palette / settings", "↑/↓ · ↵ · esc"},

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -14,7 +14,13 @@ module Gori::Tui
   # Pure view: it reads the shared Interceptor snapshot; the Runner performs the
   # actual forward/drop. No diff (that's Replay's job).
   class InterceptView
+    # Height of the top filter bar (catch direction + condition), reserved above the
+    # queue|detail split — the Intercept tab's analogue of History's QL bar.
+    FILTER_BAR_H = 1
+
     getter? editing : Bool
+    getter? querying : Bool
+    getter query : String
 
     def initialize
       @items = [] of Interceptor::Item
@@ -23,6 +29,15 @@ module Gori::Tui
       @editor = TextArea.new
       @editor.gutter = true # line numbers in the held-message editor (pairs with ^G)
       @editing = false
+      # Filter bar: the catch direction + on/off mirror the Interceptor (captured on
+      # reload, rendered as chips); the condition query is a local edit buffer pushed
+      # to the Interceptor on every keystroke (live, like History's filter).
+      @enabled = false
+      @direction = Interceptor::Direction::Both
+      @querying = false
+      @query = ""
+      @qcx = 0
+      @preedit = ""
       @loaded_id = nil.as(Int64?) # which item the editor currently holds
       # Cached highlight of the selected held item's raw bytes (read-only detail
       # pane). Held bytes are immutable and item ids are monotonic, so the id is a
@@ -38,6 +53,8 @@ module Gori::Tui
     def reload(interceptor : Interceptor) : Nil
       @items = interceptor.pending
       @selected = @selected.clamp(0, {@items.size - 1, 0}.max)
+      @enabled = interceptor.enabled?
+      @direction = interceptor.direction
       if @editing && (id = @loaded_id) && @items.none? { |it| it.id == id }
         @editing = false
         @loaded_id = nil
@@ -65,6 +82,44 @@ module Gori::Tui
     # to the tab bar on ↑.
     def at_top? : Bool
       !@editing && @selected == 0
+    end
+
+    # --- catch-condition filter bar (a text sub-mode; mirrors History's QL bar) ---
+    def start_query : Nil
+      @querying = true
+      @qcx = @query.size
+    end
+
+    def stop_query : Nil # Enter: keep the condition, leave edit mode
+      @querying = false
+    end
+
+    def cancel_query : Nil # Esc: clear the condition, leave edit mode
+      @querying = false
+      @query = ""
+      @qcx = 0
+      @preedit = ""
+    end
+
+    def query_insert(ch : Char) : Nil
+      @query = "#{@query[0, @qcx]}#{ch}#{@query[@qcx..]}"
+      @qcx += 1
+    end
+
+    def query_backspace : Nil
+      return if @qcx == 0
+      @query = "#{@query[0, @qcx - 1]}#{@query[@qcx..]}"
+      @qcx -= 1
+    end
+
+    def query_move(d : Int32) : Nil
+      @qcx = (@qcx + d).clamp(0, @query.size)
+    end
+
+    # Live IME composition shown underlined ahead of the committed query; cleared
+    # when a char commits (same model as the History bar / TextArea).
+    def set_preedit(text : String) : Nil
+      @preedit = text
     end
 
     def toggle_edit : Nil
@@ -153,31 +208,49 @@ module Gori::Tui
 
     # --- mouse hit-testing (inverts render's offset math; coords are 0-based) ---
 
-    # The w//3 split render() uses (render: `half = {rect.w // 3, 1}.max`).
-    private def split_panes(rect : Rect) : {Rect, Rect}
-      half = {rect.w // 3, 1}.max
-      left = Rect.new(rect.x, rect.y, half, rect.h)
-      right = Rect.new(rect.x + half + 1, rect.y, {rect.w - half - 1, 0}.max, rect.h)
+    # The body (queue|detail split) sits BELOW the filter bar — every hit-test must
+    # subtract the bar row first, exactly as render() does.
+    private def body_rect(rect : Rect) : Rect
+      Rect.new(rect.x, rect.y + FILTER_BAR_H, rect.w, {rect.h - FILTER_BAR_H, 0}.max)
+    end
+
+    # The w//3 split render() uses (render: `half = {body.w // 3, 1}.max`). `body` is
+    # the post-bar rect (body_rect), NOT the full tab rect.
+    private def split_panes(body : Rect) : {Rect, Rect}
+      half = {body.w // 3, 1}.max
+      left = Rect.new(body.x, body.y, half, body.h)
+      right = Rect.new(body.x + half + 1, body.y, {body.w - half - 1, 0}.max, body.h)
       {left, right}
+    end
+
+    # Which catch direction (if any) the filter-bar click landed on: :direction (the
+    # catch chip), :condition (the rest of the bar), else nil. Only on the bar row and
+    # only while NOT editing the condition (then the bar is a plain input line).
+    def bar_zone_at(rect : Rect, mx : Int32, my : Int32) : Symbol?
+      return nil if @querying || my != rect.y
+      label, _ = direction_chip
+      cx = rect.x + 1
+      return :direction if mx >= cx && mx < cx + label.size
+      mx < rect.right ? :condition : nil
     end
 
     # Which pane a click landed in: :list (left queue), :detail (right editor),
     # else nil. Mirrors render's split; nil while empty (single full-rect card, no
-    # split) and in the 1-cell gap column between the panes.
+    # split), on the filter-bar row, and in the 1-cell gap column between the panes.
     def pane_at(rect : Rect, mx : Int32, my : Int32) : Symbol?
       return nil if @items.empty?
-      left, right = split_panes(rect)
+      left, right = split_panes(body_rect(rect))
       return :list if left.contains?(mx, my)
       return :detail if right.contains?(mx, my)
       nil
     end
 
     # The @items index under a click in the LEFT queue list, or nil. Inverts
-    # render_list: the card border is `rect.inset(1, 1)`, then row i sits at
+    # render_list: the card border is `left.inset(1, 1)`, then row i sits at
     # `inner.y + i` for idx = @scroll + i (clamped to populated rows).
     def list_row_at(rect : Rect, mx : Int32, my : Int32) : Int32?
       return nil if @items.empty?
-      left, _ = split_panes(rect)
+      left, _ = split_panes(body_rect(rect))
       inner = left.inset(1, 1)
       return nil unless inner.contains?(mx, my)
       idx = @scroll + (my - inner.y)
@@ -206,7 +279,7 @@ module Gori::Tui
     # as render_detail does. Only meaningful while editing (the editor is shown then).
     def editor_click_to_cursor(rect : Rect, mx : Int32, my : Int32) : Nil
       return unless @editing
-      _, right = split_panes(rect)
+      _, right = split_panes(body_rect(rect))
       @editor.click_to_cursor(right.inset(1, 1), mx, my)
     end
 
@@ -214,19 +287,64 @@ module Gori::Tui
 
     def render(screen : Screen, rect : Rect, focused : Bool = true) : Nil
       return if rect.empty?
+      render_filter_bar(screen, Rect.new(rect.x, rect.y, rect.w, FILTER_BAR_H), focused)
+      body = body_rect(rect)
+      return if body.empty?
+
       if @items.empty?
-        Frame.card(screen, rect, "INTERCEPT", bg: Theme.bg, border: pane_border(focused))
-        inner = rect.inset(1, 1)
+        Frame.card(screen, body, "INTERCEPT", bg: Theme.bg, border: pane_border(focused))
+        inner = body.inset(1, 1)
         screen.text(inner.x + 1, inner.y, "no held messages", Theme.muted)
         screen.text(inner.x + 1, inner.y + 2, "turn intercept on (i) — held requests/responses appear here", Theme.muted)
         return
       end
 
-      half = {rect.w // 3, 1}.max
-      left = Rect.new(rect.x, rect.y, half, rect.h)
-      right = Rect.new(rect.x + half + 1, rect.y, {rect.w - half - 1, 0}.max, rect.h)
-      render_list(screen, left, focused && !@editing)
+      left, right = split_panes(body)
+      render_list(screen, left, focused && !@editing && !@querying)
       render_detail(screen, right, focused && @editing)
+    end
+
+    # The top filter bar: while editing the condition it's a single input line
+    # (`catch › …`); otherwise a catch-direction chip, the committed condition (or a
+    # field hint), and a right-aligned held count. Mirrors History's QL bar.
+    private def render_filter_bar(screen : Screen, rect : Rect, focused : Bool) : Nil
+      return if rect.empty?
+      if @querying
+        prefix = "catch › "
+        screen.text(rect.x + 1, rect.y, prefix, Theme.accent)
+        base = rect.x + 1 + prefix.size
+        screen.input_line(base, rect.y, @query, @qcx, @preedit, Theme.text_bright, width: {rect.w - prefix.size - 2, 0}.max)
+        return
+      end
+
+      label, color = direction_chip
+      x = rect.x + 1
+      x = screen.text(x, rect.y, label, color, Theme.bg, Attribute::Bold) + 2
+
+      rx = rect.right - 1
+      if !@items.empty?
+        count = @items.size.to_s
+        screen.text({rx - count.size, rect.x}.max, rect.y, count, Theme.muted)
+        rx -= count.size + 2
+      end
+
+      left_w = {rx - x, 0}.max
+      if @query.blank?
+        screen.text(x, rect.y, "/ condition  ·  host:  method:  path:  status:>=500  scheme:", Theme.muted, width: left_w)
+      else
+        screen.text(x, rect.y, ": #{@query}", Theme.text, width: left_w)
+      end
+    end
+
+    # The catch-direction chip: text + colour. Dim when intercept is OFF (nothing is
+    # held yet, so the chip advertises what WILL be caught once toggled on).
+    private def direction_chip : {String, Color}
+      label = case @direction
+              when .request_only?  then "catch:req"
+              when .response_only? then "catch:res"
+              else                      "catch:all"
+              end
+      {label, @enabled ? Theme.accent : Theme.muted}
     end
 
     private def pane_border(focused : Bool) : Color

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -392,6 +392,9 @@ module Gori::Tui
       if @active_tab == :sitemap && @overlay == :none && @focus == :body && sitemap_controller.view.querying?
         return if sitemap_controller.handle_query_key(ev)
       end
+      if @active_tab == :intercept && @overlay == :none && @focus == :body && intercept_controller.querying?
+        return if intercept_controller.handle_query_key(ev)
+      end
       if @active_tab == :findings && @overlay == :none && @focus == :body && findings_controller.view.editing_notes?
         return if findings_controller.handle_notes_key(ev)
       end
@@ -1921,6 +1924,14 @@ module Gori::Tui
 
     def intercept_forward_all : Nil
       intercept_controller.intercept_forward_all
+    end
+
+    def intercept_query : Nil
+      intercept_controller.intercept_query
+    end
+
+    def intercept_cycle_direction : Nil
+      intercept_controller.intercept_cycle_direction
     end
 
     def selected_intercept_id : Int64?

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -86,10 +86,12 @@ module Gori
       abstract def findings_export(format : Symbol) : Nil # :markdown | :json → project dir
 
       # intercept (hold-and-decide; P4)
-      abstract def intercept_toggle : Nil      # toggle the hold queue on/off
-      abstract def intercept_forward : Nil     # forward the selected held message (edited bytes)
-      abstract def intercept_drop : Nil        # drop the selected held message
-      abstract def intercept_forward_all : Nil # forward every held message
+      abstract def intercept_toggle : Nil          # toggle the hold queue on/off
+      abstract def intercept_forward : Nil         # forward the selected held message (edited bytes)
+      abstract def intercept_drop : Nil            # drop the selected held message
+      abstract def intercept_forward_all : Nil     # forward every held message
+      abstract def intercept_query : Nil           # focus the catch-condition filter bar
+      abstract def intercept_cycle_direction : Nil # cycle catch direction (all/req/res)
       abstract def selected_intercept_id : Int64?
 
       # capture / proxy control

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -97,6 +97,16 @@ module Gori
         "intercept.forward-all", "Forward all held", "Forward every held message",
         Verb::Scope::Intercept, available: intercept_selected) { |ctx| ctx.intercept_forward_all; nil }
 
+      # Catch controls — what to hold (direction) + a condition that narrows it. Both
+      # are handled inline on the Intercept tab (`c` / `/`); registered here (no chord)
+      # for palette discoverability (P1).
+      r.register Verb::Definition.new(
+        "intercept.direction", "Catch direction", "Cycle which to hold: all / requests only / responses only",
+        Verb::Scope::Intercept) { |ctx| ctx.intercept_cycle_direction; nil }
+      r.register Verb::Definition.new(
+        "intercept.filter", "Catch condition", "Only hold messages matching a query (host: method: path: status: scheme:)",
+        Verb::Scope::Intercept) { |ctx| ctx.intercept_query; nil }
+
       # Tab/Shift-Tab are the focus ring (handled directly in the Runner); these
       # bracket chords remain a from-anywhere shortcut to cycle tabs.
       r.register Verb::Definition.new(


### PR DESCRIPTION
## What

Adds a History-style **filter bar** to the top of the Intercept tab with two controls.

### 1. Catch direction — all / req / res
`c` cycles `catch:all → catch:req → catch:res` (chip in the bar). For someone who only wants to inspect outgoing requests, `catch:req` streams responses straight through (no buffering/hold); `catch:res` does the reverse.

- New `Interceptor::Direction` (Both/RequestOnly/ResponseOnly).
- Folded into the gates: `intercepts_request?` skips when ResponseOnly, `intercepts_response?` skips when RequestOnly.
- **Direction-agnostic at the h2→h1 host gate** (`intercepts_host?`) on purpose — holding *either* leg requires the interceptable h1 path, so the downgrade decision must not depend on direction.

### 2. Conditional intercept
A condition that **narrows** what gets held (vs Scope, the global lens). Edited via `/`, shown as `: <query>`.

- New `Gori::InterceptFilter`: a QL-like **in-memory** matcher — `host:` `path:` `method:` `scheme:` `status:` + bare free-text, `OR` groups, `-`negation.
- Can't reuse `QL` (it compiles to SQL; here we match a *live* message before it's captured).
- `status:` only matches a response (a request has no status). Empty filter → hold all. Applied live as you type (only ever narrows from the default "hold all", so mid-typing is safe).

### Plumbing
- Replaces `Interceptor#intercepts_url?(url, host)` with `intercepts_request?` / `intercepts_response?` (named `method`/`host`/`target`/`scheme`[/`status`]); both `client_conn` call sites updated.
- TUI: `intercept_view.cr` reserves a top bar row (`body_rect` offsets the queue|detail split + all hit-tests); runner claims intercept `querying?` before the focus ring (mirrors History/Sitemap); `intercept.direction` / `intercept.filter` verbs registered for palette discoverability.
- **Incidental fix:** `i` was silently swallowed on the Intercept body, so the empty-state "turn intercept on (i)" hint was a dead key — now it toggles inline.

### Scope
Per-session (not persisted), consistent with the intercept enabled state. Persisting via Store/settings is a possible follow-up.

## Tests
- New `spec/intercept_filter_spec.cr` (matcher semantics) + additions to `interceptor_spec` (direction/condition gates) and `intercept_view_spec` (filter bar render/edit).
- Full suite: **524 examples, 0 failures**. Formatted; ameba clean (only the codebase's pre-existing tolerated `set_*`/complexity conventions).

## Manual verification (live, through the proxy)
- `catch:req` holds the request, streams the response; `catch:res` the reverse. ✓
- `path:/yes` condition holds matching requests, lets `/no` pass through (404 returned, not held). ✓
- Held-count chip, condition open/apply/clear, direction cycling, `i` toggle all work. ✓