### PR TITLE
feat(tui): custom themes + vertical scrollable theme picker

### DIFF
--- a/doc/themes.md
+++ b/doc/themes.md
@@ -1,0 +1,100 @@
+# Custom themes
+
+gori ships five built-in colour themes — `goridark` (default), `goriday`, `latte`,
+`espresso`, `tokyonight` — selectable from **`settings:theme`** in the command palette
+(`^P`). The picker is a vertical, scrollable list; each row shows a small swatch of the
+theme's own palette, and selecting a row previews it live (`↵` applies + persists, `esc`
+reverts).
+
+You can add your own themes as JSON files. Drop them in:
+
+```
+~/.gori/themes/<name>.json
+```
+
+(`~/.gori` is the gori home directory; override it with `$GORI_HOME`.) The **file name**
+is the theme name — `ocean.json` becomes the theme `ocean`. They appear in the picker
+after the built-ins, in file-name order. gori loads them at startup and again each time
+you open `settings:theme`, so you can drop a file in and reopen the picker — no restart.
+
+## Format
+
+A theme is a JSON object mapping palette fields to `#rrggbb` hex colours. Use the
+optional `"base"` key to inherit every colour you don't override from a built-in theme —
+so a theme can be as small as one accent tweak:
+
+```json
+{
+  "base": "goridark",
+  "accent": "#ff33cc",
+  "syn_header": "#33ccff"
+}
+```
+
+Without `"base"`, the default (`goridark`) supplies any omitted colour.
+
+### A full theme
+
+Every field (all inherit from `base` when omitted):
+
+```json
+{
+  "base": "goridark",
+
+  "bg":            "#0a0a0b",
+  "panel":         "#141417",
+  "elevated":      "#1b1b1f",
+  "border":        "#2a2a30",
+  "border_focus":  "#3a3a42",
+  "focus_gold":    "#c2a05a",
+  "accent":        "#fafafa",
+  "accent_bg":     "#26262c",
+  "selection_dim": "#19191c",
+  "text":          "#c8c8cc",
+  "text_bright":   "#fafafa",
+  "muted":         "#6e6e76",
+  "green":         "#52c77a",
+  "yellow":        "#d6a13a",
+  "red":           "#e5534b",
+  "orange":        "#d9813f",
+  "syn_header":    "#82a8c4",
+  "syn_string":    "#8fb87a",
+  "syn_number":    "#ca9b6a",
+  "syn_literal":   "#b08ec2"
+}
+```
+
+| field           | used for                                             |
+| --------------- | ---------------------------------------------------- |
+| `bg`            | the canvas (main background)                         |
+| `panel`         | top bar, status bar, overlays                        |
+| `elevated`      | header bands, active segments                        |
+| `border`        | resting hairline dividers                            |
+| `border_focus`  | the outline of an active modal card                  |
+| `focus_gold`    | the focused body pane's outline                      |
+| `accent`        | the highlight colour (selection marker, emphasis)    |
+| `accent_bg`     | the selection band in the focused pane               |
+| `selection_dim` | the selection band in an unfocused pane              |
+| `text`          | body text                                            |
+| `text_bright`   | emphasised / active text                             |
+| `muted`         | secondary / dimmed text                              |
+| `green`         | 2xx status                                           |
+| `yellow`        | 4xx status                                           |
+| `red`           | 5xx status / errors                                  |
+| `orange`        | accent for warnings                                  |
+| `syn_header`    | header/field names, JSON keys, tag names             |
+| `syn_string`    | quoted strings                                       |
+| `syn_number`    | numbers, tag attribute names                         |
+| `syn_literal`   | `true` / `false` / `null`                            |
+
+## Notes
+
+- The file name is normalised to lower-case `a–z 0–9 - _`; other characters are dropped
+  (`My Theme!.json` → `mytheme`).
+- A file whose name collides with a built-in (e.g. `goridark.json`) is ignored — the
+  built-ins can't be redefined.
+- Loading is tolerant: an unreadable file, invalid JSON, or a non-object is skipped, and
+  a single malformed colour falls back to the `base` value rather than discarding the
+  whole theme. A broken theme file never crashes the TUI.
+- For readability, keep your functional colours (text, status, syntax) well-contrasted
+  against `bg`; the built-ins target WCAG AA (≥ 4.5:1).

--- a/spec/tui/theme_spec.cr
+++ b/spec/tui/theme_spec.cr
@@ -210,6 +210,25 @@ describe "Theme custom loading" do
       Gori::Tui::Theme.accent.should eq(Termisu::Color.from_hex("#00ffcc"))
     end
   end
+
+  it "lets a custom theme named like a legacy alias (dark/light) be selected, not shadowed" do
+    with_themes({"dark.json" => %({"base": "tokyonight", "accent": "#00ffcc"})}) do
+      Gori::Tui::Theme.load_custom
+      Gori::Tui::Theme.available.should contain("dark")    # registered (not a built-in name)
+      Gori::Tui::Theme.canonical("dark").should eq("dark") # the real theme wins over the LEGACY_ALIAS
+      Gori::Tui::Theme.apply("dark").should be_true
+      Gori::Tui::Theme.active_name.should eq("dark")
+      Gori::Tui::Theme.accent.should eq(Termisu::Color.from_hex("#00ffcc"))
+    end
+  end
+
+  it "still maps a legacy alias when no custom theme by that name is loaded" do
+    with_themes({} of String => String) do
+      Gori::Tui::Theme.load_custom # no custom "dark"/"light"
+      Gori::Tui::Theme.canonical("dark").should eq("goridark")
+      Gori::Tui::Theme.canonical("light").should eq("goriday")
+    end
+  end
 end
 
 describe "SettingsView theme list" do

--- a/spec/tui/theme_spec.cr
+++ b/spec/tui/theme_spec.cr
@@ -19,6 +19,33 @@ private def wcag_contrast(fg : Termisu::Color, bg : Termisu::Color) : Float64
   l1 > l2 ? l1 / l2 : l2 / l1
 end
 
+# Run the block with GORI_HOME pointed at a fresh temp dir whose themes/ holds `files`
+# (name => JSON), so Theme.load_custom reads exactly those. Restores GORI_HOME, the
+# active theme, the persisted theme, AND the global custom registry (reloaded from an
+# empty dir) afterwards so the @@custom class var can't leak into other specs.
+private def with_themes(files : Hash(String, String), &)
+  home = File.tempname("gori-themes-home")
+  Dir.mkdir_p(File.join(home, "themes"))
+  files.each { |name, body| File.write(File.join(home, "themes", name), body) }
+  prev = ENV["GORI_HOME"]?
+  saved_active = Gori::Tui::Theme.active_name
+  saved_theme = Gori::Settings.theme
+  begin
+    ENV["GORI_HOME"] = home
+    yield
+  ensure
+    Gori::Tui::Theme.apply(saved_active) # back to a built-in before dropping custom
+    empty = File.tempname("gori-empty-home")
+    Dir.mkdir_p(empty)
+    ENV["GORI_HOME"] = empty
+    Gori::Tui::Theme.load_custom # rebuild @@custom from a themes-less dir → empties it
+    prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
+    Gori::Settings.theme = saved_theme
+    FileUtils.rm_rf(home)
+    FileUtils.rm_rf(empty)
+  end
+end
+
 describe Gori::Tui::Theme do
   # Theme.active is global; restore it so later specs (which assert dark colours) pass.
   around_each do |example|
@@ -129,6 +156,182 @@ describe Gori::Tui::SettingsView do
       prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
       FileUtils.rm_rf(dir)
       Gori::Settings.theme = saved_theme
+    end
+  end
+end
+
+describe "Theme custom loading" do
+  it "loads user themes from <GORI_HOME>/themes/*.json, after the built-ins" do
+    with_themes({
+      "ocean.json"     => %({"base": "goridark", "accent": "#00ffcc", "green": "#00ff00"}),
+      "broken.json"    => %({not valid json),
+      "goridark.json"  => %({"bg": "#000000"}), # shadows a built-in → must be ignored
+      "Bad Name!.json" => %({"base": "latte"}), # sanitised to "badname"
+      "arr.json"       => %([1, 2, 3]),         # not an object → skipped
+    }) do
+      Gori::Tui::Theme.load_custom
+      avail = Gori::Tui::Theme.available
+      avail.first(5).should eq(["goridark", "goriday", "latte", "espresso", "tokyonight"]) # built-ins lead
+      avail.should contain("ocean")
+      avail.should contain("badname")
+      avail.should_not contain("broken")
+      avail.should_not contain("arr")
+      avail.count("goridark").should eq(1) # the shadowing file did not redefine it
+    end
+  end
+
+  it "merges overrides onto the base and inherits omitted colours" do
+    with_themes({"ocean.json" => %({"base": "goridark", "accent": "#00ffcc"})}) do
+      Gori::Tui::Theme.load_custom
+      pal = Gori::Tui::Theme.palette("ocean").not_nil!
+      base = Gori::Tui::Theme.palette("goridark").not_nil!
+      pal.accent.should eq(Termisu::Color.from_hex("#00ffcc")) # overridden
+      pal.bg.should eq(base.bg)                                # inherited from base
+      pal.green.should eq(base.green)                          # inherited from base
+    end
+  end
+
+  it "falls back to the base colour for an invalid hex (one typo can't sink a theme)" do
+    with_themes({"tweak.json" => %({"base": "tokyonight", "accent": "not-a-hex", "red": "#123456"})}) do
+      Gori::Tui::Theme.load_custom
+      pal = Gori::Tui::Theme.palette("tweak").not_nil!
+      base = Gori::Tui::Theme.palette("tokyonight").not_nil!
+      pal.accent.should eq(base.accent)                     # bad hex → base
+      pal.red.should eq(Termisu::Color.from_hex("#123456")) # valid override kept
+    end
+  end
+
+  it "applies a custom theme through canonical/apply" do
+    with_themes({"ocean.json" => %({"base": "goridark", "accent": "#00ffcc"})}) do
+      Gori::Tui::Theme.load_custom
+      Gori::Tui::Theme.canonical("ocean").should eq("ocean")
+      Gori::Tui::Theme.apply("ocean").should be_true
+      Gori::Tui::Theme.active_name.should eq("ocean")
+      Gori::Tui::Theme.accent.should eq(Termisu::Color.from_hex("#00ffcc"))
+    end
+  end
+end
+
+describe "SettingsView theme list" do
+  it "renders the themes as a vertical list and moves selection with ↑/↓" do
+    with_themes({} of String => String) do
+      Gori::Settings.theme = "goridark"
+      view = SettingsView.new
+      view.reload(:theme)
+      view.theme_value.should eq("goridark")
+      view.move_field(1) # ↓ to the next theme
+      view.theme_value.should eq("goriday")
+      view.move_field(-1)
+      view.theme_value.should eq("goridark")
+
+      # the built-ins render as stacked rows (one per line)
+      backend = MemoryBackend.new(80, 24)
+      area = Rect.new(0, 0, 80, 24)
+      view.render(Screen.new(backend), area)
+      box = view.overlay_box(area)
+      backend.row(box.y + 2).includes?("goridark").should be_true # first row
+      backend.row(box.y + 3).includes?("goriday").should be_true  # second row (below, not beside)
+    end
+  end
+
+  it "maps a clicked list row to the theme index" do
+    with_themes({} of String => String) do
+      Gori::Settings.theme = "goridark"
+      view = SettingsView.new
+      view.reload(:theme)
+      backend = MemoryBackend.new(80, 24)
+      area = Rect.new(0, 0, 80, 24)
+      view.render(Screen.new(backend), area)
+      box = view.overlay_box(area)
+      view.field_at(box, box.x + 5, box.y + 2).should eq(0)
+      view.field_at(box, box.x + 5, box.y + 3).should eq(1)
+      view.field_at(box, box.x + 5, box.y + 1).should be_nil # above the list
+      view.set_field(1)
+      view.theme_value.should eq(Gori::Tui::Theme.available[1])
+    end
+  end
+
+  it "scrolls to keep the selected theme visible when the list overflows" do
+    files = {} of String => String
+    (1..9).each { |i| files["z#{i}.json"] = %({"base": "goridark"}) } # 9 custom → 14 total > 10
+    with_themes(files) do
+      Gori::Settings.theme = "goridark"
+      view = SettingsView.new
+      view.reload(:theme)
+      names = Gori::Tui::Theme.available
+      (names.size - 1).times { view.move_field(1) } # select the last theme
+
+      backend = MemoryBackend.new(80, 24)
+      view.render(Screen.new(backend), Rect.new(0, 0, 80, 24))
+      backend.contains?(names.last).should be_true  # selection scrolled into view
+      backend.contains?("goridark").should be_false # first rows scrolled off the top
+    end
+  end
+
+  it "paints each row's swatch in that theme's OWN palette, not the active one" do
+    with_themes({
+      "ocean.json" => %({"base": "goridark", "accent": "#00ffcc"}),
+      "ruby.json"  => %({"base": "goridark", "accent": "#ff0033"}),
+    }) do
+      Gori::Settings.theme = "goridark"
+      Gori::Tui::Theme.apply("goridark") # active accent (#fafafa) differs from both swatches
+      view = SettingsView.new
+      view.reload(:theme)
+      names = Gori::Tui::Theme.available # [..builtins.., ocean, ruby] (file-name order)
+      ocean_row = names.index("ocean").not_nil!
+      ruby_row = names.index("ruby").not_nil!
+
+      backend = MemoryBackend.new(80, 24)
+      area = Rect.new(0, 0, 80, 24)
+      view.render(Screen.new(backend), area)
+      box = view.overlay_box(area)
+      tick_x = box.right - 9 # first swatch tick = the theme's accent (see draw_swatch)
+      # each row's accent swatch is the theme's own colour, proving it's not the active palette
+      backend.fg_at(tick_x, box.y + 2 + ocean_row).should eq(Termisu::Color.from_hex("#00ffcc"))
+      backend.fg_at(tick_x, box.y + 2 + ruby_row).should eq(Termisu::Color.from_hex("#ff0033"))
+    end
+  end
+end
+
+describe "Theme.load_custom active reconciliation" do
+  it "refreshes the live palette when the active custom theme's file is edited" do
+    with_themes({"ocean.json" => %({"base": "goridark", "accent": "#00ffcc"})}) do
+      Gori::Tui::Theme.load_custom
+      Gori::Tui::Theme.apply("ocean")
+      Gori::Tui::Theme.accent.should eq(Termisu::Color.from_hex("#00ffcc"))
+      rev = Gori::Tui::Theme.revision
+
+      # edit the file (new accent) and reload — the active palette must follow, with a bump
+      home = ENV["GORI_HOME"]
+      File.write(File.join(home, "themes", "ocean.json"), %({"base": "goridark", "accent": "#ffaa00"}))
+      Gori::Tui::Theme.load_custom
+      Gori::Tui::Theme.active_name.should eq("ocean")
+      Gori::Tui::Theme.accent.should eq(Termisu::Color.from_hex("#ffaa00"))
+      Gori::Tui::Theme.revision.should eq(rev + 1)
+    end
+  end
+
+  it "falls back to the default when the active custom theme's file is removed" do
+    with_themes({"ocean.json" => %({"base": "goridark", "accent": "#00ffcc"})}) do
+      Gori::Tui::Theme.load_custom
+      Gori::Tui::Theme.apply("ocean")
+      rev = Gori::Tui::Theme.revision
+
+      File.delete(File.join(ENV["GORI_HOME"], "themes", "ocean.json"))
+      Gori::Tui::Theme.load_custom
+      Gori::Tui::Theme.active_name.should eq(Gori::Tui::Theme::DEFAULT_THEME)
+      Gori::Tui::Theme.available.should_not contain("ocean")
+      Gori::Tui::Theme.revision.should eq(rev + 1)
+    end
+  end
+
+  it "leaves a built-in active theme (and the revision) untouched on reload" do
+    with_themes({"ocean.json" => %({"base": "goridark", "accent": "#00ffcc"})}) do
+      Gori::Tui::Theme.apply("goriday")
+      rev = Gori::Tui::Theme.revision
+      Gori::Tui::Theme.load_custom # active is a built-in → no reconciliation, no bump
+      Gori::Tui::Theme.active_name.should eq("goriday")
+      Gori::Tui::Theme.revision.should eq(rev)
     end
   end
 end

--- a/src/gori/app.cr
+++ b/src/gori/app.cr
@@ -38,6 +38,7 @@ module Gori
     # `q`, exit on quit. Logs go to a file (never STDOUT — that's the screen).
     def run_tui : Nil
       setup_logging(File.open(File.join(Paths.home_dir, "gori.log"), "a"))
+      Tui::Theme.load_custom           # register user themes from <GORI_HOME>/themes/*.json
       Tui::Theme.apply(Settings.theme) # honour the persisted theme from the first frame (picker included)
       projects = ProjectRegistry.new(Paths.projects_dir)
       term = Termisu.new

--- a/src/gori/paths.cr
+++ b/src/gori/paths.cr
@@ -18,6 +18,12 @@ module Gori
       File.join(home_dir, "projects")
     end
 
+    # User colour themes: each `*.json` here is loaded as a selectable TUI theme
+    # (filename stem = theme name), merged after the built-ins. See Tui::Theme.load_custom.
+    def self.themes_dir : String
+      File.join(home_dir, "themes")
+    end
+
     def self.default_ca_dir : String
       File.join(home_dir, "ca")
     end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -827,7 +827,7 @@ module Gori::Tui
       key = ev.key
       c = ev.char || key.to_char
       if ev.ctrl? && key.lower_p?
-        @overlay = :none
+        cancel_settings # revert any live theme preview before jumping (mirrors esc); sets @overlay=:none
         open_palette
       elsif key.escape?
         cancel_settings # revert any live theme preview, close
@@ -2002,7 +2002,8 @@ module Gori::Tui
     def open_settings(section : Symbol) : Nil
       case section
       when :network, :editor, :theme
-        @settings_view.reload(section)
+        @settings_view.reload(section)            # :theme reloads custom themes — may reconcile the live palette
+        @resized = true if section == :theme      # so force a full repaint (an edited/removed active theme just changed)
         @overlay = :settings
         @theme_restore = section == :theme ? Settings.theme : nil # baseline for live-preview revert
       when :tabs

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -661,6 +661,7 @@ module Gori::Tui
       return cancel_settings if dismiss_zone?(box, mx, my)
       if idx = @settings_view.field_at(box, mx, my)
         @settings_view.set_field(idx)
+        preview_theme # clicking a theme row live-previews it (no-op outside :theme)
       end
     end
 
@@ -714,7 +715,7 @@ module Gori::Tui
       when :palette  then @palette.move(step)
       when :rules    then @rules_overlay.select_move(step)
       when :browser  then @browser_picker.try(&.move(step))
-      when :settings then @settings_view.move_field(step)
+      when :settings then (@settings_view.move_field(step); preview_theme) # wheel scrolls the theme list too
       when :tabs     then @tabs_overlay.select_move(step)
       end
     end
@@ -843,8 +844,10 @@ module Gori::Tui
         reconcile_mouse # the EDITOR section holds the Mouse toggle — apply it live
       elsif key.up?
         @settings_view.move_field(-1)
+        preview_theme # ↑/↓ moves the theme-list selection in the :theme section
       elsif key.down?
         @settings_view.move_field(1)
+        preview_theme
       elsif key.left?
         @settings_view.toggle_or_move(-1)
         preview_theme
@@ -856,6 +859,7 @@ module Gori::Tui
       elsif c && !ev.ctrl? && !ev.alt?
         @settings_view.insert(c)
         @settings_view.set_preedit("")
+        preview_theme # space cycles the theme in the :theme section — preview it too
       end
     end
 

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -29,10 +29,18 @@ module Gori::Tui
       Field.new("Markdown highlight", "syntax-colour markdown in Notes/Project — ←/→/space toggles", bool: true),
       Field.new("Mouse", "click + scroll-wheel navigation (off restores native text selection)", bool: true),
     ]
+    # The THEME section is special: a single field whose value is the selected theme
+    # name, but rendered as a vertical, scrollable list (built-ins + user themes) rather
+    # than the inline ←/→ cycle the other `choices` fields use. `choices` is kept only so
+    # `choice_field?` swallows typing; the live list comes from Theme.available.
     THEME_FIELDS = [
-      Field.new("Theme", "TUI colour theme — ←/→/space cycles, ↵ applies", choices: Theme.available),
+      Field.new("Theme", "TUI colour theme — ↑/↓ select, ↵ applies", choices: Theme.available),
     ]
     SECTIONS = {:network => NETWORK_FIELDS, :editor => EDITOR_FIELDS, :theme => THEME_FIELDS}
+
+    # Max theme rows shown at once before the list scrolls (the box also shrinks to the
+    # terminal height — see overlay_box).
+    THEME_LIST_MAX = 10
 
     getter? saved : Bool = false
     getter section : Symbol = :network
@@ -43,6 +51,7 @@ module Gori::Tui
       @cursor = 0
       @preedit = ""
       @status = nil.as(String?)
+      @theme_scroll = 0 # top row of the THEME list viewport (see render_theme_list)
       reload
     end
 
@@ -54,6 +63,7 @@ module Gori::Tui
     # editor opens). Defaults to :network so the no-arg picker call keeps working.
     def reload(section : Symbol = :network) : Nil
       @section = section
+      Theme.load_custom if section == :theme # pick up theme files dropped since startup
       @values = case section
                 when :editor then [Settings.editor, Settings.editor_markdown ? "on" : "off", Settings.mouse ? "on" : "off"]
                 when :theme  then [Theme.canonical(Settings.theme)]
@@ -64,9 +74,16 @@ module Gori::Tui
       @preedit = ""
       @status = nil
       @saved = false
+      @theme_scroll = 0 # render scrolls to the selected theme on the first frame
     end
 
+    # ↑/↓: move between fields — except in the THEME section, whose single field IS a
+    # vertical list, so up/down move the theme selection (render keeps it on screen).
     def move_field(delta : Int32) : Nil
+      if @section == :theme
+        cycle(delta)
+        return
+      end
       @focused = (@focused + delta).clamp(0, @values.size - 1)
       @cursor = @values[@focused].size
       @preedit = ""
@@ -131,8 +148,18 @@ module Gori::Tui
     end
 
     # Advance the focused choice field by `delta` (wraps; Crystal's % is modulo, so
-    # -1 wraps to the last option for ←).
+    # -1 wraps to the last option for ←). The THEME section reads the live theme list
+    # (Theme.available — includes user themes loaded after this view was built) rather
+    # than the field's captured `choices`.
     private def cycle(delta : Int32) : Nil
+      if @section == :theme
+        names = Theme.available
+        return if names.empty?
+        i = names.index(@values[0]) || 0
+        @values[0] = names[(i + delta) % names.size]
+        @status = nil
+        return
+      end
       choices = fields[@focused].choices
       return unless choices
       i = choices.index(@values[@focused]) || 0
@@ -199,10 +226,12 @@ module Gori::Tui
     end
 
     # The centred settings box for `area` — the exact Rect render draws into (so
-    # hit-tests can be mapped against the same geometry render uses).
+    # hit-tests can be mapped against the same geometry render uses). The interior
+    # holds `content_rows` rows (fields, or the THEME list viewport) plus 6 rows of
+    # chrome (borders + a pad + the footer note block).
     def overlay_box(area : Rect) : Rect
       w = {area.w - 4, 64}.min
-      h = fields.size + 6
+      h = content_rows(area) + 6
       # Empty when render would decline to draw (same guard as render below): a click
       # then falls through to !contains? and closes instead of focusing a field on an
       # undrawn card.
@@ -212,30 +241,59 @@ module Gori::Tui
       Rect.new(x, y, w, h)
     end
 
-    # The field-row index under (mx,my) within `box`, mirroring render's row loop
-    # (rows are box.y+2 .. box.y+2+size); nil outside the field rows or the box.
-    def field_at(box : Rect, mx : Int32, my : Int32) : Int32?
-      return nil unless box.contains?(mx, my)
-      i = my - (box.y + 2)
-      (0 <= i < fields.size) ? i : nil
+    # Interior content rows for `area`: one per field, or — in the THEME section — the
+    # theme-list viewport (the list size, capped to THEME_LIST_MAX and to what the
+    # terminal can fit, so a long list scrolls instead of demanding the whole screen).
+    private def content_rows(area : Rect) : Int32
+      return fields.size unless @section == :theme
+      fit = {area.h - 6, 1}.max
+      {Theme.available.size, THEME_LIST_MAX, fit}.min
     end
 
-    # Focus field `idx`, clamped to the current section's field count (same clamp
-    # as move_field) and resetting the caret/preedit to that field.
+    # The row-index under (mx,my) within `box`, mirroring render's row loop. For fields
+    # it's the field index; for the THEME list it's the absolute theme index (offset by
+    # the scroll). nil outside the content rows or the box.
+    def field_at(box : Rect, mx : Int32, my : Int32) : Int32?
+      return nil unless box.contains?(mx, my)
+      row = my - (box.y + 2)
+      if @section == :theme
+        vp = {box.h - 6, 1}.max
+        return nil if row < 0 || row >= vp
+        i = @theme_scroll + row
+        return i < Theme.available.size ? i : nil
+      end
+      (0 <= row < fields.size) ? row : nil
+    end
+
+    # Act on a clicked row: focus a field, or — in the THEME section — select that
+    # theme (the caller live-previews it). Index is clamped to the valid range.
     def set_field(idx : Int32) : Nil
+      if @section == :theme
+        names = Theme.available
+        @values[0] = names[idx.clamp(0, names.size - 1)] unless names.empty?
+        return
+      end
       @focused = idx.clamp(0, @values.size - 1)
       @cursor = @values[@focused].size
       @preedit = ""
     end
 
     def render(screen : Screen, area : Rect) : Nil
-      flds = fields
-      label_w = flds.max_of(&.label.size)
       box = overlay_box(area)
-      w = box.w
-      return if w < 30 || area.h < box.h
+      return if box.w < 30 || area.h < box.h
       Frame.card(screen, box, "SETTINGS · #{@section.to_s.upcase}", border: Theme.border_focus)
+      if @section == :theme
+        render_theme_list(screen, box)
+      else
+        render_fields(screen, box)
+      end
+      render_footer(screen, box)
+    end
 
+    private def render_fields(screen : Screen, box : Rect) : Nil
+      flds = fields
+      w = box.w
+      label_w = flds.max_of(&.label.size)
       flds.each_with_index do |field, i|
         ry = box.y + 2 + i
         focused = i == @focused
@@ -246,43 +304,105 @@ module Gori::Tui
         screen.text(box.x + 3 + label_w + 1, ry, "›", focused ? Theme.accent : Theme.muted, bg)
         vx = box.x + 3 + label_w + 3
         vw = {box.right - vx - 1, 1}.max
-        value = @values[i]
-        if choices = field.choices
-          # List the options left-to-right; the active one is emphasised (◉ + bright).
-          cx = vx
-          left = vw
-          choices.each do |opt|
-            break if left <= 0
-            on = opt == value
-            seg = "#{on ? '◉' : '◯'} #{opt}"
-            screen.text(cx, ry, seg, on ? Theme.text_bright : Theme.muted, bg, width: left)
-            adv = seg.size + 2
-            cx += adv
-            left -= adv
-          end
-        elsif field.bool
-          on = value == "on"
-          glyph = on ? "◉ on" : "◯ off"
-          col = focused ? Theme.text_bright : (on ? Theme.green : Theme.muted)
-          screen.text(vx, ry, glyph, col, bg, width: vw)
-        elsif focused
-          screen.input_line(vx, ry, value, @cursor, @preedit, Theme.text_bright, bg, width: vw)
-        elsif value.empty?
-          screen.text(vx, ry, field.hint, Theme.muted, bg, width: vw)
-        else
-          screen.text(vx, ry, value, Theme.text, bg, width: vw)
-        end
+        render_field_value(screen, field, @values[i], vx, ry, vw, focused, bg)
       end
+    end
 
-      # status line (left) + hint (right) on the bottom interior row
+    # The value column of one field: a choice cycle, a bool toggle, the editable line
+    # (focused), the hint (empty + unfocused), or the plain value.
+    private def render_field_value(screen : Screen, field : Field, value : String,
+                                   vx : Int32, ry : Int32, vw : Int32, focused : Bool, bg : Color) : Nil
+      if choices = field.choices
+        # List the options left-to-right; the active one is emphasised (◉ + bright).
+        cx = vx
+        left = vw
+        choices.each do |opt|
+          break if left <= 0
+          on = opt == value
+          seg = "#{on ? '◉' : '◯'} #{opt}"
+          screen.text(cx, ry, seg, on ? Theme.text_bright : Theme.muted, bg, width: left)
+          adv = seg.size + 2
+          cx += adv
+          left -= adv
+        end
+      elsif field.bool
+        on = value == "on"
+        glyph = on ? "◉ on" : "◯ off"
+        col = focused ? Theme.text_bright : (on ? Theme.green : Theme.muted)
+        screen.text(vx, ry, glyph, col, bg, width: vw)
+      elsif focused
+        screen.input_line(vx, ry, value, @cursor, @preedit, Theme.text_bright, bg, width: vw)
+      elsif value.empty?
+        screen.text(vx, ry, field.hint, Theme.muted, bg, width: vw)
+      else
+        screen.text(vx, ry, value, Theme.text, bg, width: vw)
+      end
+    end
+
+    # The THEME section: a vertical, scrollable list of theme names (built-ins + user
+    # themes), each with a swatch previewing its own palette. The selected row is
+    # kept on screen by following it within the viewport.
+    private def render_theme_list(screen : Screen, box : Rect) : Nil
+      names = Theme.available
+      return if names.empty?
+      sel = names.index(@values[0]) || 0
+      vp = {box.h - 6, 1}.max # interior list rows (box.h == vp + 6 — see overlay_box)
+      # Scroll-follow: clamp to a valid window, then nudge to keep `sel` visible.
+      @theme_scroll = @theme_scroll.clamp(0, {names.size - vp, 0}.max)
+      @theme_scroll = sel if sel < @theme_scroll
+      @theme_scroll = sel - vp + 1 if sel >= @theme_scroll + vp
+
+      list_top = box.y + 2
+      vp.times do |row|
+        i = @theme_scroll + row
+        break if i >= names.size
+        draw_theme_row(screen, box, names[i], i == sel, list_top + row,
+          up: row == 0 && @theme_scroll > 0,
+          down: row == vp - 1 && i < names.size - 1)
+      end
+    end
+
+    private def draw_theme_row(screen : Screen, box : Rect, name : String, selected : Bool, ry : Int32, *, up : Bool, down : Bool) : Nil
+      bg = selected ? Theme.accent_bg : Theme.panel
+      screen.fill(Rect.new(box.x + 1, ry, box.w - 2, 1), bg)
+      screen.cell(box.x + 1, ry, selected ? '▎' : ' ', Theme.accent, bg)
+      screen.cell(box.x + 3, ry, selected ? '◉' : '◯', selected ? Theme.accent : Theme.muted, bg)
+      # Right edge, inside the card border (box.right-1): a scroll marker on the last
+      # interior column (box.right-2), then the swatch left of it with a 1-col gap.
+      mark_x = box.right - 2
+      swatch_w = 7
+      sx = mark_x - 1 - swatch_w
+      name_w = {sx - (box.x + 5) - 1, 1}.max
+      screen.text(box.x + 5, ry, name, selected ? Theme.text_bright : Theme.text, bg, width: name_w)
+      draw_swatch(screen, sx, ry, name)
+      screen.cell(mark_x, ry, '▲', Theme.muted, bg) if up
+      screen.cell(mark_x, ry, '▼', Theme.muted, bg) if down
+    end
+
+    # A tiny preview strip in the theme's OWN palette (not the active one): its canvas
+    # colour framing a few accent ticks, so each row previews the theme without making
+    # it active. Width must match `swatch_w` in draw_theme_row (1 + 5 ticks + 1).
+    private def draw_swatch(screen : Screen, x : Int32, ry : Int32, name : String) : Nil
+      pal = Theme.palette(name)
+      return unless pal
+      ticks = {pal.accent, pal.green, pal.yellow, pal.red, pal.syn_header}
+      screen.cell(x, ry, ' ', pal.bg, pal.bg)
+      ticks.each_with_index { |c, i| screen.cell(x + 1 + i, ry, '█', c, pal.bg) }
+      screen.cell(x + 6, ry, ' ', pal.bg, pal.bg)
+    end
+
+    private def render_footer(screen : Screen, box : Rect) : Nil
       note_y = box.bottom - 2
       if status = @status
         color = status.starts_with?("invalid") || status.starts_with?("save failed") ? Theme.yellow : Theme.green
         screen.text(box.x + 3, note_y, "• #{status}", color, Theme.panel)
+      elsif @section == :theme
+        names = Theme.available
+        screen.text(box.x + 3, note_y, "theme #{(names.index(@values[0]) || 0) + 1}/#{names.size}", Theme.muted, Theme.panel)
       else
         screen.text(box.x + 3, note_y, fields[@focused].hint, Theme.muted, Theme.panel)
       end
-      hint = "↑/↓ field · ↵ save · esc close"
+      hint = @section == :theme ? "↑/↓ select · ↵ apply · esc close" : "↑/↓ field · ↵ save · esc close"
       screen.text(box.right - hint.size - 2, note_y, hint, Theme.muted, Theme.panel)
     end
   end

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -375,8 +375,15 @@ module Gori::Tui
       name_w = {sx - (box.x + 5) - 1, 1}.max
       screen.text(box.x + 5, ry, name, selected ? Theme.text_bright : Theme.text, bg, width: name_w)
       draw_swatch(screen, sx, ry, name)
-      screen.cell(mark_x, ry, '▲', Theme.muted, bg) if up
-      screen.cell(mark_x, ry, '▼', Theme.muted, bg) if down
+      # Scroll marker (one glyph): ↕ when this lone row can scroll both ways (a 1-row
+      # viewport on a tiny terminal), else ▲ for more-above / ▼ for more-below.
+      if up && down
+        screen.cell(mark_x, ry, '↕', Theme.muted, bg)
+      elsif up
+        screen.cell(mark_x, ry, '▲', Theme.muted, bg)
+      elsif down
+        screen.cell(mark_x, ry, '▼', Theme.muted, bg)
+      end
     end
 
     # A tiny preview strip in the theme's OWN palette (not the active one): its canvas

--- a/src/gori/tui/theme.cr
+++ b/src/gori/tui/theme.cr
@@ -192,10 +192,13 @@ module Gori::Tui
       @@custom[name]? || BUILTIN_THEMES[name]?
     end
 
-    # Resolve a (possibly legacy / unknown) name to a valid theme name: map legacy
-    # aliases, then fall back to the default for anything unrecognised (built-in or
-    # custom — whatever is currently loaded).
+    # Resolve a (possibly legacy / unknown) name to a valid theme name: a real theme
+    # (built-in OR custom) wins as-is; otherwise map a legacy alias; otherwise fall
+    # back to the default. The real-theme check comes FIRST so a custom theme named
+    # `dark`/`light` isn't shadowed by the pre-rename aliases (which only matter for an
+    # old settings.json that has no matching theme loaded).
     def self.canonical(name : String) : String
+      return name if palette(name)
       name = LEGACY_ALIASES[name]? || name
       palette(name) ? name : DEFAULT_THEME
     end
@@ -245,25 +248,13 @@ module Gori::Tui
       end
       @@custom = custom
       @@custom_order = order
-      reconcile_active
+      # Re-seat the live palette against the rebuilt registry: re-applying the active
+      # name refreshes an edited custom theme (apply compares content → bumps revision)
+      # and falls a vanished one back to the default (canonical → DEFAULT_THEME). A
+      # built-in active, or an unchanged custom one, is a no-op (apply returns false).
+      apply(@@active_name)
     rescue
       # broken themes dir (permissions, etc.) — keep whatever was loaded before
-    end
-
-    # Re-seat the live palette after the custom registry is rebuilt. Built-in actives
-    # are immutable (name↔palette is 1:1) so they need nothing; a custom active may
-    # have changed colours (refresh) or vanished (fall back to the default). Bumps the
-    # revision when it changes anything so colour-baked render caches rebuild.
-    private def self.reconcile_active : Nil
-      return if BUILTIN_THEMES.has_key?(@@active_name)
-      if pal = @@custom[@@active_name]?
-        return if pal == @@active
-        @@active = pal
-      else
-        @@active = BUILTIN_THEMES[DEFAULT_THEME]
-        @@active_name = DEFAULT_THEME
-      end
-      @@revision &+= 1
     end
 
     # Theme names are used as JSON keys, display labels, and the persisted setting, so

--- a/src/gori/tui/theme.cr
+++ b/src/gori/tui/theme.cr
@@ -1,3 +1,6 @@
+require "json"
+require "../paths"
+
 module Gori::Tui
   # The TUI colour palette. gori ships five themes — GORIDARK (the default; a
   # monochrome palette in the spirit of Grok Build: near-black canvas, white/grey
@@ -157,29 +160,44 @@ module Gori::Tui
       syn_literal: Color.from_hex("#bb9af7"), # true / false / null (magenta)
     )
 
-    THEMES        = {"goridark" => GORIDARK, "goriday" => GORIDAY, "latte" => LATTE, "espresso" => ESPRESSO, "tokyonight" => TOKYONIGHT}
-    DEFAULT_THEME = "goridark"
+    BUILTIN_THEMES = {"goridark" => GORIDARK, "goriday" => GORIDAY, "latte" => LATTE, "espresso" => ESPRESSO, "tokyonight" => TOKYONIGHT}
+    DEFAULT_THEME  = "goridark"
     # Pre-rename names so a settings.json from the first theme release still resolves.
     LEGACY_ALIASES = {"dark" => "goridark", "light" => "goriday"}
+
+    # User themes loaded from <GORI_HOME>/themes/*.json (filename stem = name), merged
+    # AFTER the built-ins. Empty until load_custom runs (startup + on opening
+    # settings:theme). Built-in names always win — a custom file that shadows one is
+    # ignored — so the canonical palettes (and the contrast spec) can't be redefined.
+    @@custom : Hash(String, Palette) = {} of String => Palette
+    @@custom_order : Array(String) = [] of String
 
     @@active : Palette = GORIDARK
     @@active_name : String = DEFAULT_THEME
     @@revision : UInt32 = 0_u32
 
-    # The names of the available themes (selectable in settings:theme), in display order.
+    # The names of the available themes (selectable in settings:theme), in display
+    # order: the built-ins first, then user themes in filename order.
     def self.available : Array(String)
-      THEMES.keys
+      BUILTIN_THEMES.keys + @@custom_order
     end
 
     def self.active_name : String
       @@active_name
     end
 
+    # The palette for `name` (built-in or custom), or nil when unknown — lets the
+    # settings list draw each theme's own swatch without making it active.
+    def self.palette(name : String) : Palette?
+      @@custom[name]? || BUILTIN_THEMES[name]?
+    end
+
     # Resolve a (possibly legacy / unknown) name to a valid theme name: map legacy
-    # aliases, then fall back to the default for anything unrecognised.
+    # aliases, then fall back to the default for anything unrecognised (built-in or
+    # custom — whatever is currently loaded).
     def self.canonical(name : String) : String
       name = LEGACY_ALIASES[name]? || name
-      THEMES.has_key?(name) ? name : DEFAULT_THEME
+      palette(name) ? name : DEFAULT_THEME
     end
 
     # Bumped whenever the active palette changes; colour-baking render caches compare
@@ -190,14 +208,110 @@ module Gori::Tui
 
     # Switch the active palette by name (legacy/unknown names are normalised via
     # `canonical`). Returns true when the palette actually changed (so the caller can
-    # force a repaint only when needed).
+    # force a repaint only when needed). Compares palette CONTENT, not just the name:
+    # a custom theme's colours can change under a stable name (its file was edited +
+    # reloaded), and re-applying it must still refresh the live palette + revision.
     def self.apply(name : String) : Bool
       key = canonical(name)
-      return false if key == @@active_name
-      @@active = THEMES[key]
+      pal = palette(key) || GORIDARK
+      return false if key == @@active_name && pal == @@active
+      @@active = pal
       @@active_name = key
       @@revision &+= 1
       true
+    end
+
+    # (Re)load user themes from <GORI_HOME>/themes/*.json. Each file is a JSON object
+    # of `"field": "#rrggbb"` colours; an optional `"base"` (a built-in theme name)
+    # supplies any colour the file omits, so a theme can override just an accent. A
+    # bad colour falls back to the base and a broken file is skipped — loading must
+    # never crash the TUI. Files whose stem collides with a built-in (or another
+    # already-loaded custom theme) are ignored. If the ACTIVE theme is a custom one,
+    # its live palette is reconciled to the rebuilt registry (so an edited file shows
+    # at once, and a removed one falls back to the default) with a revision bump.
+    def self.load_custom : Nil
+      custom = {} of String => Palette
+      order = [] of String
+      dir = Paths.themes_dir
+      if Dir.exists?(dir)
+        Dir.glob(File.join(dir, "*.json")).sort.each do |file|
+          name = sanitize_name(File.basename(file, ".json"))
+          next if name.empty? || BUILTIN_THEMES.has_key?(name) || custom.has_key?(name)
+          if pal = parse_theme_file(file)
+            custom[name] = pal
+            order << name
+          end
+        end
+      end
+      @@custom = custom
+      @@custom_order = order
+      reconcile_active
+    rescue
+      # broken themes dir (permissions, etc.) — keep whatever was loaded before
+    end
+
+    # Re-seat the live palette after the custom registry is rebuilt. Built-in actives
+    # are immutable (name↔palette is 1:1) so they need nothing; a custom active may
+    # have changed colours (refresh) or vanished (fall back to the default). Bumps the
+    # revision when it changes anything so colour-baked render caches rebuild.
+    private def self.reconcile_active : Nil
+      return if BUILTIN_THEMES.has_key?(@@active_name)
+      if pal = @@custom[@@active_name]?
+        return if pal == @@active
+        @@active = pal
+      else
+        @@active = BUILTIN_THEMES[DEFAULT_THEME]
+        @@active_name = DEFAULT_THEME
+      end
+      @@revision &+= 1
+    end
+
+    # Theme names are used as JSON keys, display labels, and the persisted setting, so
+    # constrain them to a safe slug (lower-case alnum + - _); other characters are dropped.
+    private def self.sanitize_name(raw : String) : String
+      raw.downcase.gsub(/[^a-z0-9_-]/, "")
+    end
+
+    # Build a Palette from a theme file, or nil if it can't be read/parsed.
+    private def self.parse_theme_file(file : String) : Palette?
+      root = JSON.parse(File.read(file))
+      return nil unless root.as_h?
+      base = BUILTIN_THEMES[canonical_builtin(root["base"]?.try(&.as_s?) || DEFAULT_THEME)]
+      merge_palette(base, root)
+    rescue
+      nil
+    end
+
+    # A theme's `base` must be a BUILT-IN (custom themes can't chain off each other —
+    # load order would matter); unknown → the default.
+    private def self.canonical_builtin(name : String) : String
+      name = LEGACY_ALIASES[name]? || name
+      BUILTIN_THEMES.has_key?(name) ? name : DEFAULT_THEME
+    end
+
+    # Overlay the hex colours in `root` onto `base`, field by field. The {% begin %}
+    # wrapper forces the {% for %} to expand before the call args are parsed (a bare
+    # loop inside a call's parens doesn't compose).
+    private def self.merge_palette(base : Palette, root : JSON::Any) : Palette
+      {% begin %}
+        Palette.new(
+          {% for f in %w(bg panel elevated border border_focus focus_gold accent accent_bg selection_dim text text_bright muted green yellow red orange syn_header syn_string syn_number syn_literal) %}
+            {{ f.id }}: color_field(root, {{ f }}, base.{{ f.id }}),
+          {% end %}
+        )
+      {% end %}
+    end
+
+    # The hex colour at root[key], or `base` when the key is absent, not a string, or
+    # not a valid hex (a single typo'd colour inherits rather than sinking the theme).
+    private def self.color_field(root : JSON::Any, key : String, base : Color) : Color
+      if hex = root[key]?.try(&.as_s?)
+        Color.from_hex(hex)
+      else
+        base
+      end
+    rescue
+      base
     end
 
     # Colour accessors generated from the Palette fields. Each reads the active

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -59,7 +59,7 @@ module Gori
         "settings.editor", "settings:editor", "Set the external editor opened by ^E in editable fields",
         Verb::Scope::Global) { |ctx| ctx.open_settings(:editor); nil }
       r.register Verb::Definition.new(
-        "settings.theme", "settings:theme", "Switch the TUI colour theme (goridark · goriday · latte · espresso · tokyonight)",
+        "settings.theme", "settings:theme", "Switch the TUI colour theme (built-ins + your own from ~/.gori/themes/*.json)",
         Verb::Scope::Global) { |ctx| ctx.open_settings(:theme); nil }
       r.register Verb::Definition.new(
         "settings.tabs", "settings:tabs", "Customize the top tab bar — show/hide tabs and reorder them",


### PR DESCRIPTION
## What

Reworks `settings:theme` and adds user-defined themes.

### 1. Vertical, scrollable theme picker (was a horizontal choice strip)
- Themes stack top-to-bottom; each row shows a small **swatch in that theme's own palette**.
- Scrolls when the list overflows, with `▲/▼` markers and a `theme N/total` position indicator.
- `↑/↓` · `←/→` · space · wheel · click move the selection with **live preview**; `↵` applies + persists, `esc` reverts.

### 2. Custom themes from `~/.gori/themes/*.json`
- Filename stem = theme name (e.g. `ocean.json` → `ocean`); merged after the built-ins.
- Optional `"base"` (a built-in) supplies any omitted colour, so a theme can be a one-line tweak:
  ```json
  { "base": "goridark", "accent": "#ff33cc" }
  ```
- Loaded at startup **and** on each `settings:theme` open (drop a file in, reopen — no restart).
- Tolerant: bad JSON / non-object / unreadable files are skipped, a single bad hex falls back to the base, and a file whose name collides with a built-in is ignored. Loading never crashes the TUI.
- Format documented in `doc/themes.md` (full 20-field reference).

## Implementation notes
- `theme.cr`: split the registry into `BUILTIN_THEMES` + `@@custom`/`@@custom_order`; `load_custom`/`parse_theme_file`/`merge_palette`/`color_field`.
- **Cache invariant fix:** a custom palette can change under a stable name, so `apply()` now compares palette **content** (not just the name), and `load_custom` reconciles the active palette + bumps `Theme.revision` when an active custom theme is edited/removed — otherwise the colour-baked render caches (history/replay/textarea/intercept) would go stale.
- `settings_view.cr`: vertical `render_theme_list`/`draw_theme_row`/`draw_swatch` + theme-aware `field_at`/`overlay_box`/footer; `field_at`/`render`/`overlay_box` agree on the viewport via `box.h - 6`.
- `paths.cr`: `Paths.themes_dir`. `app.cr`: `Theme.load_custom` at startup.

## Testing
- `crystal spec` — **516 examples, 0 failures** (theme spec expanded 12 → 23: loading / base-merge / collision / scroll-follow / swatch-uses-own-palette / active-reconcile).
- Manually verified in a real TUI (tmux): vertical list, swatch colours, scroll + `▲/▼`, live preview, esc-revert, apply→persist, restart restore, and **editing the active custom theme's file → reopen → live palette refreshes**.
- Reviewed via an adversarial multi-agent pass; the one real finding (stale active custom palette) is the cache-invariant fix above.