### PR TITLE
feat(ql): size:/dur: comparisons, header: filter, and `~` regex over text fields

### DIFF
--- a/spec/ql_spec.cr
+++ b/spec/ql_spec.cr
@@ -84,6 +84,62 @@ describe Gori::QL do
                     "OR (response_body IS NOT NULL AND lower(CAST(response_body AS TEXT)) LIKE ? ESCAPE '\\')))")
     f.args.should eq(["%ab%", "%ab%"])
   end
+
+  it "compiles size: as a numeric comparison on response_size" do
+    f = Gori::QL.parse("size:>1000")
+    f.sql.should eq("(response_size > ?)")
+    f.args.should eq([1000_i64])
+    Gori::QL.parse("size:<=500").sql.should eq("(response_size <= ?)")
+    Gori::QL.parse("size:0").sql.should eq("(response_size = ?)") # bare value → equality
+  end
+
+  it "compiles dur: as milliseconds against duration_us, honouring ms/s suffixes" do
+    Gori::QL.parse("dur:>500").sql.should eq("(duration_us > ?)")
+    Gori::QL.parse("dur:>500").args.should eq([500_000_i64]) # bare magnitude = ms
+    Gori::QL.parse("dur:>500ms").args.should eq([500_000_i64])
+    Gori::QL.parse("dur:>2s").args.should eq([2_000_000_i64])
+    Gori::QL.parse("dur:<=1.5s").sql.should eq("(duration_us <= ?)")
+    Gori::QL.parse("dur:<=1.5s").args.should eq([1_500_000_i64]) # fractional seconds
+  end
+
+  it "drops a size:/dur: term whose magnitude is not numeric (match-all EMPTY)" do
+    Gori::QL.parse("size:big").sql.should eq("1")
+    Gori::QL.parse("dur:>fast").sql.should eq("1")
+  end
+
+  it "compiles header: as a case-insensitive substring over the head bytes" do
+    f = Gori::QL.parse("header:Set-Cookie")
+    f.sql.should eq("((lower(CAST(request_head AS TEXT)) LIKE ? ESCAPE '\\' OR " \
+                    "(response_head IS NOT NULL AND lower(CAST(response_head AS TEXT)) LIKE ? ESCAPE '\\')))")
+    f.args.should eq(["%set-cookie%", "%set-cookie%"]) # lowercased, substring
+  end
+
+  it "compiles the ~ operator to a REGEXP over text fields" do
+    Gori::QL.parse("host~^api\\.").sql.should eq("(host REGEXP ?)")
+    Gori::QL.parse("host~^api\\.").args.should eq(["^api\\."])
+    Gori::QL.parse("path~\\.json$").sql.should eq("(target REGEXP ?)")
+    Gori::QL.parse("url~^https").sql.should eq("((scheme || '://' || host || target) REGEXP ?)")
+
+    body = Gori::QL.parse("body~secret\\d+")
+    body.sql.should eq("(((request_body IS NOT NULL AND CAST(request_body AS TEXT) REGEXP ?) OR " \
+                       "(response_body IS NOT NULL AND CAST(response_body AS TEXT) REGEXP ?)))")
+    body.args.should eq(["secret\\d+", "secret\\d+"])
+
+    hdr = Gori::QL.parse("header~^Set-Cookie:") # `~` wins over a later ':' in the value
+    hdr.sql.should eq("((CAST(request_head AS TEXT) REGEXP ? OR " \
+                      "(response_head IS NOT NULL AND CAST(response_head AS TEXT) REGEXP ?)))")
+    hdr.args.should eq(["^Set-Cookie:", "^Set-Cookie:"])
+  end
+
+  it "picks the first separator so a regex value may itself contain ':'" do
+    Gori::QL.parse("body~https?://x").args.should eq(["https?://x", "https?://x"])
+  end
+
+  it "emits a never-matches clause for an invalid ~ regex (no raise)" do
+    f = Gori::QL.parse("body~[")
+    f.sql.should eq("(0)")
+    f.args.should be_empty
+  end
 end
 
 describe "Gori::Store#search (QL)" do
@@ -143,6 +199,92 @@ describe "Gori::Store#search (QL)" do
       neg.should_not contain(req_match)
       neg.should_not contain(resp_match)
       neg.size.should eq(1) # the "/about" flow (body "nothing here") survives
+    end
+  end
+
+  it "matches bodies, hosts and headers by regex (~), case-sensitively" do
+    tmp_store do |store|
+      secret = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "http", host: "api.acme.test", port: 80,
+        method: "POST", target: "/login", http_version: "HTTP/1.1",
+        head: "POST /login HTTP/1.1\r\nHost: api.acme.test\r\n\r\n".to_slice,
+        body: "username=admin&csrf=SeCrEtToken".to_slice))
+      plain = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 2_i64, scheme: "http", host: "cdn.other.test", port: 80,
+        method: "GET", target: "/", http_version: "HTTP/1.1",
+        head: "GET / HTTP/1.1\r\nHost: cdn.other.test\r\n\r\n".to_slice,
+        body: "nothing here".to_slice))
+
+      # body regex is case-sensitive; an inline (?i) opts into case-insensitivity
+      store.search(Gori::QL.parse("body~SeCrEt[A-Za-z]+"), 50).map(&.id).should eq([secret])
+      store.search(Gori::QL.parse("body~secret[a-z]+"), 50).should be_empty
+      store.search(Gori::QL.parse("body~(?i)secrettoken"), 50).map(&.id).should eq([secret])
+
+      # host / header regex
+      store.search(Gori::QL.parse("host~^api\\."), 50).map(&.id).should eq([secret])
+      store.search(Gori::QL.parse("host~test$"), 50).map(&.id).sort.should eq([secret, plain].sort)
+      store.search(Gori::QL.parse("header~Host:\\s"), 50).map(&.id).sort.should eq([secret, plain].sort)
+
+      # an invalid regex matches nothing rather than raising the whole query
+      store.search(Gori::QL.parse("body~["), 50).should be_empty
+
+      # negation is NULL-safe: a bodyless flow is KEPT, the matching one dropped
+      bodyless = capture(store, "no.body.test", "GET", "/", 200)
+      neg = store.search(Gori::QL.parse("-body~SeCrEt"), 50).map(&.id)
+      neg.should contain(bodyless)
+      neg.should contain(plain)
+      neg.should_not contain(secret)
+    end
+  end
+
+  it "scans a binary / invalid-UTF-8 body with body~ without crashing the query" do
+    tmp_store do |store|
+      # leading invalid-UTF-8 bytes + an embedded NUL (the SQLite REGEXP callback
+      # builds the haystack with String.new(ptr), which stops at NUL and does not
+      # validate UTF-8). The scan must run over this row without raising.
+      bin = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "http", host: "bin.test", port: 80,
+        method: "GET", target: "/img", http_version: "HTTP/1.1",
+        head: "GET /img HTTP/1.1\r\nHost: bin.test\r\n\r\n".to_slice,
+        body: Bytes[0xFF, 0xFE, 0x00, 0x41, 0x42, 0x43])) # "ABC" sits after the NUL
+      text = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 2_i64, scheme: "http", host: "txt.test", port: 80,
+        method: "POST", target: "/", http_version: "HTTP/1.1",
+        head: "POST / HTTP/1.1\r\nHost: txt.test\r\n\r\n".to_slice,
+        body: "hello ABC world".to_slice))
+
+      # REGEXP runs over BOTH rows; the binary one must not crash the query.
+      store.search(Gori::QL.parse("body~ABC"), 50).map(&.id).should eq([text])
+    end
+  end
+
+  it "filters by response size and duration (size: / dur:), excluding pending rows" do
+    tmp_store do |store|
+      big = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "http", host: "acme.test", port: 80,
+        method: "GET", target: "/big", http_version: "HTTP/1.1",
+        head: "GET /big HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice, body: nil))
+      store.update_response(Gori::Store::CapturedResponse.new(
+        flow_id: big, status: 200, head: "HTTP/1.1 200 OK\r\n\r\n".to_slice,
+        body: ("A" * 20_000).to_slice, duration_us: 800_000_i64)) # 20KB, 800ms
+
+      small = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 2_i64, scheme: "http", host: "acme.test", port: 80,
+        method: "GET", target: "/small", http_version: "HTTP/1.1",
+        head: "GET /small HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice, body: nil))
+      store.update_response(Gori::Store::CapturedResponse.new(
+        flow_id: small, status: 200, head: "HTTP/1.1 200 OK\r\n\r\n".to_slice,
+        body: "ok".to_slice, duration_us: 50_000_i64)) # 2B, 50ms
+
+      pending = capture(store, "acme.test", "GET", "/pending") # no response → NULL size/dur
+
+      store.search(Gori::QL.parse("size:>10000"), 50).map(&.id).should eq([big])
+      store.search(Gori::QL.parse("dur:>500"), 50).map(&.id).should eq([big])   # 500ms
+      store.search(Gori::QL.parse("dur:<100"), 50).map(&.id).should eq([small]) # 100ms
+
+      # NULL response_size / duration_us never satisfy a numeric comparison
+      store.search(Gori::QL.parse("size:>=0"), 50).map(&.id).should_not contain(pending)
+      store.search(Gori::QL.parse("dur:>=0"), 50).map(&.id).should_not contain(pending)
     end
   end
 end

--- a/spec/ql_spec.cr
+++ b/spec/ql_spec.cr
@@ -107,6 +107,13 @@ describe Gori::QL do
     Gori::QL.parse("dur:>fast").sql.should eq("1")
   end
 
+  it "drops an out-of-range / non-finite dur: magnitude instead of raising OverflowError" do
+    Gori::QL.parse("dur:>1e20").sql.should eq("1")           # ms-scaled (×1000) overflows Int64 µs
+    Gori::QL.parse("dur:>1e16s").sql.should eq("1")          # s-scaled (×1e6) overflows
+    Gori::QL.parse("dur:>nan").sql.should eq("1")            # NaN is non-finite
+    Gori::QL.parse("dur:>500").args.should eq([500_000_i64]) # a sane value still compiles
+  end
+
   it "compiles header: as a case-insensitive substring over the head bytes" do
     f = Gori::QL.parse("header:Set-Cookie")
     f.sql.should eq("((lower(CAST(request_head AS TEXT)) LIKE ? ESCAPE '\\' OR " \

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -122,7 +122,7 @@ module Gori
           p.banner = "Usage: gori run history [options]   (alias: ls)"
           p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
-          p.on("-qQL", "--query=QL", "Filter with a QL query (host: status:>=500 body:tok …)") { |v| query = v }
+          p.on("-qQL", "--query=QL", "Filter with a QL query (host: status:>=500 size:>10000 dur:>500 header: body~rx …)") { |v| query = v }
           p.on("-nN", "--limit=N", "Max rows, newest first (default 50)") { |v| limit = parse_count(v) }
           p.on("--format=FMT", "Output: text (default) | json (JSON-Lines)") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -34,7 +34,8 @@ module Gori
         j.array do
           tool j, "list_history",
             "List captured HTTP flows, newest first. Optional gori QL `query` " \
-            "filters (e.g. 'host:example.com status:500 method:POST', 'body:token'); " \
+            "filters (e.g. 'host:example.com status:>=500 size:>10000 dur:>500', " \
+            "'header:set-cookie', 'body~secret\\d+' — `~` is regex, dur is ms); " \
             "empty query returns the most recent. Returns light rows (no bodies); " \
             "use get_flow for full detail." do |s|
             s.field "query", strprop("gori QL filter; empty = most recent")

--- a/src/gori/ql.cr
+++ b/src/gori/ql.cr
@@ -10,8 +10,13 @@ module Gori
   #   method:post path:/api OR flag:x   # OR of AND-groups
   #   -host:cdn  status:5xx  login      # negation, status class, free text
   #   body:token                        # scan request/response body bytes
+  #   size:>10000 dur:>=500 dur:<2s     # response bytes / latency (ms; ms|s suffix)
+  #   header:set-cookie                 # substring over request/response head bytes
+  #   body~secret\d+  host~^api\.       # `~` = regex (host path url header body)
   module QL
-    # Fields: host path method scheme status flag body (+ bare words = free text).
+    # `:` fields:  host path method scheme status size dur header body flag
+    # `~` regex on: host path url header body   (+ bare words = free text).
+    # Comparison ops (<= >= < > =) apply to status/size/dur.
     struct Filter
       getter sql : String # safe to splice into "WHERE ..."; values are in `args`
       getter args : Array(DB::Any)
@@ -60,8 +65,21 @@ module Gori
       term = term[1..] if negate
       return nil if term.empty?
 
-      colon = term.index(':')
-      result = (colon && colon > 0) ? field_cond(term[0...colon].downcase, term[(colon + 1)..]) : free_text(term)
+      # The field/operator separator is the first ':' (field op) or '~' (regex op) —
+      # whichever appears first wins, so a regex value may itself contain ':' (e.g.
+      # body~https?://x). A leading separator (`:foo` / `~foo`) is treated as free text.
+      ci = term.index(':')
+      ti = term.index('~')
+      sep = [ci, ti].compact.min?
+
+      result =
+        if sep && sep > 0
+          field = term[0...sep].downcase
+          value = term[(sep + 1)..]
+          ti == sep ? regex_cond(field, value, term) : field_cond(field, value)
+        else
+          free_text(term)
+        end
       return nil unless result
 
       cond, args = result
@@ -76,6 +94,9 @@ module Gori
       when "method" then {"upper(method) = ?", [value.upcase] of DB::Any}
       when "scheme" then {"scheme = ?", [value.downcase] of DB::Any}
       when "status" then status_cond(value)
+      when "size"   then numeric_cond("response_size", value)
+      when "dur"    then duration_cond(value)
+      when "header" then header_cond(value)
       when "body"   then body_cond(value)
       when "flag"   then {"0", [] of DB::Any} # tags not implemented yet → matches nothing
       else               free_text(value)     # unknown field: treat the value as free text
@@ -102,16 +123,17 @@ module Gori
       {"id IN (SELECT rowid FROM flows_fts WHERE flows_fts MATCH ?)", [phrase] of DB::Any}
     end
 
-    private def self.status_cond(value : String) : {String, Array(DB::Any)}?
-      op = "="
-      rest = value
+    # Split a leading comparison operator (<= >= < > =, default =) off a value. Shared
+    # by status:, size:, dur: so the operator parsing lives in exactly one place.
+    private def self.split_op(value : String) : {String, String}
       {"<=", ">=", "<", ">", "="}.each do |o|
-        if value.starts_with?(o)
-          op = o
-          rest = value[o.size..]
-          break
-        end
+        return {o, value[o.size..]} if value.starts_with?(o)
       end
+      {"=", value}
+    end
+
+    private def self.status_cond(value : String) : {String, Array(DB::Any)}?
+      op, rest = split_op(value)
 
       # status class: 2xx / 4xx / 5xx — honour any comparison operator against the
       # class bounds (e.g. status:>=5xx → status >= 500; bare status:4xx → 400-499).
@@ -129,6 +151,88 @@ module Gori
       n = rest.to_i?
       return nil unless n
       {"status #{op} ?", [n] of DB::Any}
+    end
+
+    # Numeric comparison on an INTEGER column (size: → response_size). A NULL column
+    # (a pending flow has no response_size) never satisfies `col <op> ?`, so such rows
+    # fall out of both the positive and the negated form — pending flows just don't
+    # match. Non-numeric values yield nil (the term is dropped, like a bad status:).
+    private def self.numeric_cond(column : String, value : String) : {String, Array(DB::Any)}?
+      op, rest = split_op(value)
+      n = rest.to_i64?
+      return nil unless n
+      {"#{column} #{op} ?", [n] of DB::Any}
+    end
+
+    # dur: is milliseconds (how latency reads), compared against the microsecond
+    # `duration_us`. A trailing `ms` (×1000) or `s` (×1_000_000) overrides the default
+    # ms scale; the magnitude is parsed as a float so `dur:>1.5s` works. NULL duration
+    # (no response yet) never matches, same as size:.
+    private def self.duration_cond(value : String) : {String, Array(DB::Any)}?
+      op, rest = split_op(value)
+      scale_us = 1000.0 # ms → µs (default)
+      if rest.ends_with?("ms")
+        rest = rest[0...-2]
+      elsif rest.ends_with?('s')
+        rest = rest[0...-1]
+        scale_us = 1_000_000.0
+      end
+      n = rest.to_f?
+      return nil unless n
+      {"duration_us #{op} ?", [(n * scale_us).round.to_i64] of DB::Any}
+    end
+
+    # header: substring-matches the raw request/response head bytes (request line /
+    # status line + header lines), case-insensitively — same shape as body:. It scans
+    # the whole head, so it also sees the request/status line (rare false hit; fine).
+    # request_head is NOT NULL; response_head is guarded so a response-less flow
+    # contributes no match (and `-header:x` correctly keeps it).
+    private def self.header_cond(value : String) : {String, Array(DB::Any)}
+      p = like(value)
+      {"(lower(CAST(request_head AS TEXT)) LIKE ? ESCAPE '\\' OR " \
+       "(response_head IS NOT NULL AND lower(CAST(response_head AS TEXT)) LIKE ? ESCAPE '\\'))",
+       [p, p] of DB::Any}
+    end
+
+    # The `~` operator: case-sensitive regex (SQLite REGEXP, the same shard-provided
+    # function Scope's regex rules use, backed by Crystal Regex) over a text field —
+    # host/path/url/header/body. Any other field falls back to a literal free-text
+    # search of the whole token. An invalid pattern would raise inside the SQLite
+    # REGEXP callback, so we validate up front and emit a never-matches clause instead
+    # (like flag:). For case-insensitive matching use an inline (?i) flag.
+    private def self.regex_cond(field : String, value : String, term : String) : {String, Array(DB::Any)}?
+      return nil if value.empty?
+      return {"0", [] of DB::Any} unless valid_regex?(value)
+      case field
+      when "host"   then {"host REGEXP ?", [value] of DB::Any}
+      when "path"   then {"target REGEXP ?", [value] of DB::Any}
+      when "url"    then {"(scheme || '://' || host || target) REGEXP ?", [value] of DB::Any}
+      when "header" then header_regex_cond(value)
+      when "body"   then body_regex_cond(value)
+      else               free_text(term)
+      end
+    end
+
+    # NULL-guarded REGEXP over both body columns (a bodyless flow contributes no match,
+    # so `-body~x` keeps it — same null-safety as the body: LIKE fallback above).
+    private def self.body_regex_cond(value : String) : {String, Array(DB::Any)}
+      {"((request_body IS NOT NULL AND CAST(request_body AS TEXT) REGEXP ?) OR " \
+       "(response_body IS NOT NULL AND CAST(response_body AS TEXT) REGEXP ?))",
+       [value, value] of DB::Any}
+    end
+
+    private def self.header_regex_cond(value : String) : {String, Array(DB::Any)}
+      {"(CAST(request_head AS TEXT) REGEXP ? OR " \
+       "(response_head IS NOT NULL AND CAST(response_head AS TEXT) REGEXP ?))",
+       [value, value] of DB::Any}
+    end
+
+    # A pattern must compile or the SQLite REGEXP callback raises (mirrors Scope.valid?).
+    private def self.valid_regex?(pattern : String) : Bool
+      Regex.new(pattern)
+      true
+    rescue
+      false
     end
 
     private def self.free_text(word : String) : {String, Array(DB::Any)}

--- a/src/gori/ql.cr
+++ b/src/gori/ql.cr
@@ -178,8 +178,13 @@ module Gori
         scale_us = 1_000_000.0
       end
       n = rest.to_f?
-      return nil unless n
-      {"duration_us #{op} ?", [(n * scale_us).round.to_i64] of DB::Any}
+      return nil unless n && n.finite?
+      us = (n * scale_us).round
+      # Drop an absurd magnitude rather than let Float#to_i64 raise OverflowError out of
+      # QL.parse (a crash on a single TUI keystroke); size: drops the same way via
+      # to_i64?. 9e18 is safely inside Int64 and astronomically beyond any real latency.
+      return nil unless us.abs < 9.0e18
+      {"duration_us #{op} ?", [us.to_i64] of DB::Any}
     end
 
     # header: substring-matches the raw request/response head bytes (request line /

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -1,6 +1,7 @@
 require "db"
 require "sqlite3"
 require "./store/models"
+require "./store/safe_regexp"
 require "./store/schema"
 require "./ql"
 
@@ -92,6 +93,9 @@ module Gori
                   retention_flows : Int32 = RETENTION_DEFAULT) : Store
       url = "sqlite3:#{path}?journal_mode=wal&synchronous=normal&busy_timeout=5000"
       db = DB.open(url)
+      # Make REGEXP byte-safe on every connection before any query runs (so a binary
+      # body can't crash a `body~`/`header~` scan or a regex scope rule). See SafeRegexp.
+      SafeRegexp.install(db)
       Schema.migrate!(db)
       new(db, events, retention_flows)
     end

--- a/src/gori/store/safe_regexp.cr
+++ b/src/gori/store/safe_regexp.cr
@@ -1,0 +1,53 @@
+require "sqlite3"
+
+module Gori
+  # Byte-safe override of SQLite's `REGEXP(pattern, text)` function.
+  #
+  # crystal-sqlite3 registers a per-connection `regexp` whose body is essentially
+  # `Regex.new(pattern).matches?(String.new(text))` — with NO scrub and NO rescue. When
+  # the haystack holds non-UTF-8 bytes (a binary request/response body CAST to TEXT for
+  # `body~regex`, or any odd byte for a regex Scope rule), Crystal's PCRE2 raises
+  # `UTF-8 error: illegal byte`. That exception propagates out of the C callback and
+  # aborts the WHOLE query, so a single binary body would make any `body~`/`header~`
+  # search (or regex scope lens) silently return nothing.
+  #
+  # We re-register `regexp` on every pooled connection with a version that scrubs the
+  # haystack to valid UTF-8 (invalid sequences → U+FFFD) and rescues any residual error,
+  # so a regex scan can never crash and a binary body simply fails to match a text
+  # pattern. Like the upstream function the haystack is read via `value_text`, which
+  # stops at an embedded NUL — content past a NUL byte isn't scanned (acceptable for a
+  # text search; binary bodies aren't usefully regex-matched anyway).
+  module SafeRegexp
+    # Closure-free proc (no captured locals) so it is valid as a C callback, matching
+    # the driver's own FuncCallback signature: (context, argc, argv) ordered args.
+    FN = ->(context : LibSQLite3::SQLite3Context, _argc : Int32, argv : LibSQLite3::SQLite3Value*) do
+      args = Slice.new(argv, 2)
+      pattern = String.new(LibSQLite3.value_text(args[0]))
+      text = String.new(LibSQLite3.value_text(args[1])).scrub
+      matched =
+        begin
+          Regex.new(pattern).matches?(text)
+        rescue
+          false
+        end
+      LibSQLite3.result_int(context, matched ? 1 : 0)
+      nil
+    end
+
+    # Register the safe `regexp` on every connection of `db` (existing + future). The
+    # driver has already registered its own `regexp` in Connection#initialize; calling
+    # create_function with the same name+arity replaces it on that connection.
+    def self.install(db : DB::Database) : Nil
+      db.setup_connection do |conn|
+        conn.as?(SQLite3::Connection).try(&.gori_install_safe_regexp)
+      end
+    end
+  end
+end
+
+class SQLite3::Connection
+  # Re-register the byte-safe `regexp` on this connection's raw SQLite handle.
+  def gori_install_safe_regexp : Nil
+    LibSQLite3.create_function(@db, "regexp", 2, 1, nil, Gori::SafeRegexp::FN, nil, nil)
+  end
+end

--- a/src/gori/store/safe_regexp.cr
+++ b/src/gori/store/safe_regexp.cr
@@ -18,6 +18,24 @@ module Gori
   # stops at an embedded NUL — content past a NUL byte isn't scanned (acceptable for a
   # text search; binary bodies aren't usefully regex-matched anyway).
   module SafeRegexp
+    # SQLite fires this scalar callback once per row, but a query's pattern is constant
+    # across all rows — recompiling per row is O(rows) PCRE2 compiles. Memoise the last
+    # (pattern → Regex). gori is single-threaded (fibers, no -Dpreview_mt) and the
+    # callback never yields, so a bare last-value memo is race-free: the pattern+regex
+    # pair is assigned together with no yield point between the two stores.
+    @@cache_pattern : String? = nil
+    @@cache_regex : Regex? = nil
+
+    # :nodoc: — internal (called from FN, which needs an explicit receiver, so not private)
+    def self.compile(pattern : String) : Regex
+      cached = @@cache_regex
+      return cached if cached && @@cache_pattern == pattern
+      rx = Regex.new(pattern) # raises on a bad pattern (caught by FN); cache only on success
+      @@cache_pattern = pattern
+      @@cache_regex = rx
+      rx
+    end
+
     # Closure-free proc (no captured locals) so it is valid as a C callback, matching
     # the driver's own FuncCallback signature: (context, argc, argv) ordered args.
     FN = ->(context : LibSQLite3::SQLite3Context, _argc : Int32, argv : LibSQLite3::SQLite3Value*) do
@@ -26,7 +44,7 @@ module Gori
       text = String.new(LibSQLite3.value_text(args[1])).scrub
       matched =
         begin
-          Regex.new(pattern).matches?(text)
+          SafeRegexp.compile(pattern).matches?(text)
         rescue
           false
         end

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -728,7 +728,7 @@ module Gori::Tui
         label = @query.blank? ? "(in-scope only)" : ": #{@query}"
         screen.text(rect.x + 1, rect.y, label, Theme.text, width: left_w)
       else
-        screen.text(rect.x + 1, rect.y, "/ filter  ·  host:  status:>=500  size:>10000  dur:>500  header:  body~regex", Theme.muted, width: left_w)
+        screen.text(rect.x + 1, rect.y, "/ filter  ·  host:  method:  status:>=500  path:  scheme:  size:>10000  dur:>500  header:  body~regex", Theme.muted, width: left_w)
       end
     end
 

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -34,7 +34,7 @@ module Gori::Tui
     # We load the MOST RECENT this-many (so a live tail keeps updating) and show an
     # "older not loaded" note; the raw frames remain whole in SQLite.
     DETAIL_LOG_CAP = 10_000
-    QL_FIELDS      = %w(host method status path scheme body flag)
+    QL_FIELDS      = %w(host method status path scheme body header size dur flag)
     METHOD_VAL     = %w(GET POST PUT DELETE PATCH HEAD OPTIONS QUERY)
 
     getter rows : Array(Store::FlowRow)
@@ -728,7 +728,7 @@ module Gori::Tui
         label = @query.blank? ? "(in-scope only)" : ": #{@query}"
         screen.text(rect.x + 1, rect.y, label, Theme.text, width: left_w)
       else
-        screen.text(rect.x + 1, rect.y, "/ filter  ·  host:  method:  status:>=500  path:  scheme:", Theme.muted, width: left_w)
+        screen.text(rect.x + 1, rect.y, "/ filter  ·  host:  status:>=500  size:>10000  dur:>500  header:  body~regex", Theme.muted, width: left_w)
       end
     end
 
@@ -743,6 +743,8 @@ module Gori::Tui
                when "scheme" then ["http", "https"]
                when "method" then METHOD_VAL
                when "status" then ["2xx", "3xx", "4xx", "5xx", ">=400", ">=500"]
+               when "size"   then [">10000", ">100000", "<1000"]
+               when "dur"    then [">500", ">1s", ">=200", "<100"]
                else               return [] of String
                end
       values.select(&.downcase.starts_with?(prefix.downcase)).map { |v| "#{field}:#{v}" }

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -39,7 +39,7 @@ module Gori::Tui
 
     # The QL fields meaningful for the endpoint tree (no `flag` — tags aren't
     # produced yet). Mirrors History's set so the same `/` query language applies.
-    QL_FIELDS = %w(host path method status scheme body)
+    QL_FIELDS = %w(host path method status scheme body header size dur)
 
     def initialize
       @hosts = [] of Node
@@ -271,7 +271,7 @@ module Gori::Tui
         label = @query.blank? ? "(in-scope only)" : ": #{@query}"
         screen.text(rect.x + 1, rect.y, label, Theme.text, width: left_w)
       else
-        screen.text(rect.x + 1, rect.y, "/ filter  ·  host:  method:  path:  status:>=500", Theme.muted, width: left_w)
+        screen.text(rect.x + 1, rect.y, "/ filter  ·  host:  status:>=500  size:>10000  dur:>500  header:  body~regex", Theme.muted, width: left_w)
       end
     end
 

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -271,7 +271,7 @@ module Gori::Tui
         label = @query.blank? ? "(in-scope only)" : ": #{@query}"
         screen.text(rect.x + 1, rect.y, label, Theme.text, width: left_w)
       else
-        screen.text(rect.x + 1, rect.y, "/ filter  ·  host:  status:>=500  size:>10000  dur:>500  header:  body~regex", Theme.muted, width: left_w)
+        screen.text(rect.x + 1, rect.y, "/ filter  ·  host:  method:  path:  status:>=500  size:>10000  dur:>500  header:  body~regex", Theme.muted, width: left_w)
       end
     end
 

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -24,7 +24,7 @@ module Gori
         available: history_selected) { |ctx| ctx.open_detail; nil }
 
       r.register Verb::Definition.new(
-        "history.query", "Filter (QL)", "Filter the list with a query (host: status:>=500 …)",
+        "history.query", "Filter (QL)", "Filter the list with a query (host: status:>=500 size:>10000 body~regex …)",
         Verb::Scope::Body, [Verb::Chord.new("/")], available: in_history) { |ctx| ctx.history_query; nil }
 
       r.register Verb::Definition.new(


### PR DESCRIPTION
## What

Extends the query language (`Gori::QL`, `src/gori/ql.cr`) that powers **History**, **Sitemap**, `gori run history`, and the MCP `list_history`/`list_sitemap` tools.

| Token | Meaning | Example |
|---|---|---|
| `size:` | numeric comparison on `response_size` (bytes) | `size:>10000`, `size:<=500` |
| `dur:` | latency in **milliseconds** (`ms`/`s` suffixes, fractional secs) → `duration_us` | `dur:>500`, `dur:<2s`, `dur:<=1.5s` |
| `header:` | case-insensitive substring over request/response head bytes | `header:set-cookie` |
| `FIELD~REGEX` | case-sensitive regex via SQLite REGEXP, on `host path url header body` | `body~secret\d+`, `host~^api\.` |

`status:`/`size:`/`dur:` now share one `split_op` operator parser (`<= >= < > =`). The `~` parser picks the first of `:`/`~`, so a regex value may itself contain `:`. An invalid `~` pattern compiles to a never-matches clause (mirrors `Scope.valid?`), so a bad regex never raises in the SQLite callback.

## Why the REGEXP-safety change (`src/gori/store/safe_regexp.cr`)

The crystal-sqlite3 driver registers `regexp(pattern, text)` as `Regex.new(pattern).matches?(String.new(text))` — **no scrub, no rescue**. When the haystack holds non-UTF-8 bytes (a binary body `CAST` to TEXT for `body~`, or any odd byte for a regex Scope rule), Crystal's PCRE2 raises `UTF-8 error: illegal byte`. That propagates out of the C callback and **aborts the whole query** → a single binary body (image, font, file upload) would make any `body~`/regex-scope search silently return nothing.

Fix: re-register a byte-safe `regexp` on every pooled connection (via `db.setup_connection`, which covers the eager initial connection + all future ones) that `.scrub`s the haystack and rescues. This also hardens the existing regex Scope rules. (Caveat: like the driver, the haystack is read via `value_text`, which stops at an embedded NUL — content past a NUL isn't scanned. Documented.)

## Scope note

#9 merged `Gori::InterceptFilter` — a **separate**, in-memory QL-like matcher for the Intercept hold gate (`host:/path:/method:/scheme:/status:`). It does not reuse `QL.parse`, so these additions do **not** extend it. Extending the intercept filter (e.g. `header:`/`body~`) is a sensible follow-up but has different semantics (intercept-time data availability for size/dur; `Subject` carries no headers/body today) — happy to do it as a separate PR.

## Verification

- **Full suite: 551 examples, 0 failures** (added 16 QL examples incl. unit SQL assertions, `Store#search` integration tests, NULL-safe negation, and a **binary-body no-crash regression**).
- **CLI end-to-end** through the compiled binary against a populated DB: `size:`, `dur:`, `header:`, `body~`, `host~` all filter correctly; `body~` scans a binary octet-stream body without crashing; invalid regex → graceful empty; non-numeric `size:big` → syntax-hint abort.
- **Live TUI** (tmux): autocomplete surfaces `size:`/`dur:`/`header:`; filter-bar hint updated on History + Sitemap.
- New code is ameba- and format-clean.

## Docs updated

`QL_FIELDS` + filter-bar hints (History/Sitemap), MCP `list_history` doc, `gori run history` help, `history.query` verb description.