### PR TITLE
refactor(tui): drop (N) count badges on Replay/Findings/Notes tabs

### DIFF
--- a/spec/tui/foundation_spec.cr
+++ b/spec/tui/foundation_spec.cr
@@ -64,13 +64,14 @@ describe Gori::Tui::Chrome do
     backend = MemoryBackend.new(90, 2)
     screen = Screen.new(backend)
     Chrome.render_menu(screen, Rect.new(0, 1, 90, 1),
-      active_tab: :project, focused: true, findings_count: 2, intercept_count: 3)
+      active_tab: :project, focused: true, intercept_count: 3)
 
     backend.contains?("Project").should be_true
     backend.contains?("History").should be_true
     backend.contains?("Intercept").should be_true
     backend.contains?("Sitemap").should be_true
-    backend.contains?("(3)").should be_true # held-message badge on Intercept
+    backend.contains?("(3)").should be_true        # held-message badge on Intercept (the only tab-bar count)
+    backend.contains?("Findings(").should be_false # findings/replay/notes carry no count badge
     # active segment ` Project ` (now first tab) starts at col 2 (rect.x+1 fill, +1 pad); bright accent.
     backend.fg_at(2, 1).should eq(Theme.accent)
     backend.fg_at(12, 1).should eq(Theme.muted) # an inactive label (History) is muted

--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -93,16 +93,15 @@ module Gori::Tui
 
     # A horizontal tab menu (row 1) styled as a segmented control. The active tab
     # is a solid filled segment with bold bright text (ACCENT when the menu has
-    # focus, so the user sees where keys land); inactive tabs are muted. Hot
-    # counts (intercept held / findings) ride inline as `(N)` badges.
+    # focus, so the user sees where keys land); inactive tabs are muted. The
+    # held-intercept count rides inline as a `(N)` badge.
     def self.render_menu(screen : Screen, rect : Rect, *, active_tab : Symbol, focused : Bool,
                          tabs : Array({Symbol, String}) = TABS,
-                         findings_count : Int32 = 0, intercept_count : Int32 = 0,
-                         replay_count : Int32 = 0, notes_count : Int32 = 0) : Nil
+                         intercept_count : Int32 = 0) : Nil
       return if rect.empty?
       screen.fill(rect, Theme.panel)
 
-      segs, start = menu_layout(rect, active_tab, tabs, findings_count, intercept_count, replay_count, notes_count)
+      segs, start = menu_layout(rect, active_tab, tabs, intercept_count)
       screen.cell(rect.x, rect.y, '‹', Theme.muted, Theme.panel) if start > 0 # earlier tabs hidden
       segs.each do |(sym, label, seg)|
         if sym == active_tab
@@ -123,10 +122,9 @@ module Gori::Tui
     # can never drift from what was drawn. Coords are 0-based cells.
     def self.menu_segments(rect : Rect, active_tab : Symbol, *,
                            tabs : Array({Symbol, String}) = TABS,
-                           findings_count : Int32 = 0, intercept_count : Int32 = 0,
-                           replay_count : Int32 = 0, notes_count : Int32 = 0) : Array({Symbol, Rect})
+                           intercept_count : Int32 = 0) : Array({Symbol, Rect})
       return [] of {Symbol, Rect} if rect.empty?
-      menu_layout(rect, active_tab, tabs, findings_count, intercept_count, replay_count, notes_count)[0]
+      menu_layout(rect, active_tab, tabs, intercept_count)[0]
         .map { |(sym, _, seg)| {sym, seg} }
     end
 
@@ -135,10 +133,9 @@ module Gori::Tui
     # Mirrors the old inline render_menu loop exactly — windowing via scroll_start,
     # segments laid " label " with a 1-col gap, the same `> rect.right + 1` break.
     private def self.menu_layout(rect : Rect, active_tab : Symbol, tabs : Array({Symbol, String}),
-                                 findings_count : Int32, intercept_count : Int32, replay_count : Int32,
-                                 notes_count : Int32) : {Array({Symbol, String, Rect}), Int32}
+                                 intercept_count : Int32) : {Array({Symbol, String, Rect}), Int32}
       segs = [] of {Symbol, String, Rect}
-      labels = tabs.map { |(sym, label)| "#{label}#{menu_badge(sym, findings_count, intercept_count, replay_count, notes_count)}" }
+      labels = tabs.map { |(sym, label)| "#{label}#{menu_badge(sym, intercept_count)}" }
       widths = labels.map(&.size.+(2)) # one space of padding each side of the segment
       active_idx = tabs.index { |(sym, _)| sym == active_tab } || 0
       # Window the strip so the active segment is ALWAYS visible: on a narrow row
@@ -256,13 +253,10 @@ module Gori::Tui
       chips.sum { |(label, _)| label.size } + 3 * {chips.size - 1, 0}.max
     end
 
-    # Inline badge for the hot counts (held messages, confirmed findings).
-    private def self.menu_badge(sym : Symbol, findings_count : Int32, intercept_count : Int32,
-                                replay_count : Int32 = 0, notes_count : Int32 = 0) : String
-      return "(#{replay_count})" if sym == :replay && replay_count > 1
-      return "(#{notes_count})" if sym == :notes && notes_count > 1
+    # Inline badge for the held-intercept count — the one hot state worth flagging
+    # on the tab bar (pending requests await a decision). Other tabs carry no count.
+    private def self.menu_badge(sym : Symbol, intercept_count : Int32) : String
       return "(#{intercept_count})" if sym == :intercept && intercept_count > 0
-      return "(#{findings_count})" if sym == :findings && findings_count > 0
       ""
     end
 

--- a/src/gori/tui/controllers/findings_controller.cr
+++ b/src/gori/tui/controllers/findings_controller.cr
@@ -122,7 +122,6 @@ module Gori::Tui
       return unless f = @findings.target_finding
       @host.confirm("DELETE FINDING", "Delete \"#{f.title}\"?\nThis can't be undone.", confirm_label: "delete", danger: true) do
         @findings.delete(@host.session.store)
-        @host.refresh_findings_count
       end
     end
 

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -112,7 +112,6 @@ module Gori::Tui
       @toast = nil.as(String?)        # transient action feedback; nil → show key hints
       @outcome = :running             # :running | :quit | :back
       @quit_armed = false             # first ^D/^C arms quit; second confirms (avoids accidental exit)
-      @findings_count = 0             # cached findings badge (count_findings is too costly to re-query per frame)
       @resized = false                # set on a Resize event → next frame full-repaints
 
       # Per-tab controllers (strangler-fig: tabs migrate into this registry one at a
@@ -185,8 +184,7 @@ module Gori::Tui
     def run : Symbol
       history_controller.view.reload(@session.store)
       project_controller.reload
-      notes_controller.view.reload(@session.store) # load persisted notes up front so the menu's notes-count badge is right before the tab is ever focused
-      refresh_findings_count
+      notes_controller.view.reload(@session.store) # load persisted notes up front so the tab is ready before it's ever focused
       # Surface the bind outcome on entry: capture-off if nothing could bind, or a
       # port-fallback note if the configured port was taken and we picked another.
       requested = @session.config.port
@@ -298,7 +296,6 @@ module Gori::Tui
       @tabs[@active_tab]?.try(&.on_external_change) # migrated tabs refresh themselves
       replay_controller.reconcile
       notes_controller.view.reload(@session.store) unless notes_locked?
-      refresh_findings_count
       search_recompute # a ^F prompt open over the reloaded view keeps fresh hits
     end
 
@@ -580,8 +577,7 @@ module Gori::Tui
     # re-focus the body when the active tab is re-clicked, else just focus the bar.
     private def click_menu(rect : Rect, mx : Int32, my : Int32) : Nil
       seg = Chrome.menu_segments(rect, @active_tab, tabs: effective_tabs,
-        findings_count: @findings_count, intercept_count: @session.interceptor.pending_count,
-        replay_count: replay_controller.count, notes_count: notes_controller.view.count).find { |(_, r)| r.contains?(mx, my) }
+        intercept_count: @session.interceptor.pending_count).find { |(_, r)| r.contains?(mx, my) }
       if seg
         seg[0] == @active_tab ? focus_pane(:body) : focus_tab(seg[0])
       else
@@ -1117,7 +1113,6 @@ module Gori::Tui
         @active_tab = :findings
         @focus = :body
         findings_controller.view.reload(@session.store)
-        refresh_findings_count
         @toast = "finding created"
       end
       @overlay = :none
@@ -1339,9 +1334,7 @@ module Gori::Tui
         capturing: @session.capturing?, listen: "#{@session.proxy.host}:#{@session.proxy.port}",
         identity: "user", scope: scope_label, rules: rules_label, intercept: intercept_label)
       Chrome.render_menu(screen, layout.menu, active_tab: @active_tab, focused: @focus == :menu,
-        tabs: effective_tabs,
-        findings_count: @findings_count, intercept_count: @session.interceptor.pending_count,
-        replay_count: replay_controller.count, notes_count: notes_controller.view.count)
+        tabs: effective_tabs, intercept_count: @session.interceptor.pending_count)
       Chrome.render_rule(screen, layout.rule)
       render_body(screen, layout.body)
       Chrome.render_status(screen, layout.status, focus: focus_label, hints: @toast || key_hints,
@@ -1829,12 +1822,6 @@ module Gori::Tui
 
     def findings_delete : Nil
       findings_controller.findings_delete
-    end
-
-    # Cached findings badge for the tab bar — refreshed only when findings change
-    # (create/delete), not re-queried from SQLite on every render frame.
-    def refresh_findings_count : Nil
-      @findings_count = @session.store.count_findings
     end
 
     def finding_severity(delta : Int32) : Nil

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -24,7 +24,6 @@ module Gori::Tui
     abstract def open_command : Nil                    # open the ":" context command line
     # Destructive-action confirmation modal; `action` runs on confirm.
     abstract def confirm(title : String, message : String, *, confirm_label : String, danger : Bool, &action : -> Nil) : Nil
-    abstract def refresh_findings_count : Nil # re-cache the tab-bar findings badge after a create/delete
     abstract def session : Session                     # store / scope / proxy / registry / interceptor
     abstract def overlay : Symbol                      # read the overlay state (e.g. History reads :detail)
     abstract def active_tab : Symbol                   # read the active tab (Replay reconcile gates on it)


### PR DESCRIPTION
## What

Removes the numeric `(N)` count badges that rode on the **Replay**, **Findings**, and **Notes** entries in the top tab bar.

| | Before | After |
|---|---|---|
| Tab bar | `Intercept(2)  Replay(3)  Findings(5)  Notes(2)` | `Intercept(2)  Replay  Findings  Notes` |

## Why

These counts were informational clutter — the operator already sees them inside each tab (the Replay/Notes sub-tab strip, the Findings list). **Intercept's `(N)` is kept on purpose**: it flags pending *held* requests that need a decision — a genuine hot state, not just a tally.

## Scope

- **Kept:** Intercept's `(N)` badge; the Replay/Notes sub-tab chip numbering (`1:label  2:label`); the Project tab's "Findings: N" stat.
- **Removed dead plumbing:** `render_menu` / `menu_segments` / `menu_layout` / `menu_badge` drop `findings_count` / `replay_count` / `notes_count` (only `intercept_count` remains); the `@findings_count` cache and `refresh_findings_count` (Runner method, `Host` abstract decl, and the `FindingsController` caller) are gone.

## Verification

- `crystal spec` — 627 examples, 0 failures. `foundation_spec` updated to assert only the Intercept `(N)` renders and `Findings(` does not.
- `crystal build` clean.
- Manual tmux check: created 3 notes → Notes tab shows **no** `(3)` badge, while the sub-tab strip still reads `1:note 1  2:note 2  3:note 3`.

Diff is intentionally minimal (no repo-wide formatter churn).