### PR TITLE
feat(tui): top-bar clock; drop capture/identity chips

### DIFF
--- a/spec/tui/foundation_spec.cr
+++ b/spec/tui/foundation_spec.cr
@@ -123,15 +123,16 @@ describe Gori::Tui::Chrome do
     backend.contains?("capture:on").should be_false # replaced, not appended
   end
 
-  it "renders the top bar with capture indicator" do
+  it "renders the top bar with project, scope, and the right-aligned clock" do
     backend = MemoryBackend.new(80, 1)
     screen = Screen.new(backend)
     Chrome.render_top_bar(screen, Rect.new(0, 0, 80, 1),
-      project: "acme", capturing: true, listen: "127.0.0.1:8080", identity: "user", scope: "scope:2")
+      project: "acme", listen: "127.0.0.1:8080", time: "13:37", scope: "scope:2")
     backend.row(0).should contain("gori")
     backend.row(0).should contain("acme")
-    backend.row(0).should contain("rec")
     backend.row(0).should contain("scope:2")
+    backend.row(0).should contain("13:37")
+    backend.row(0).should_not contain("rec") # capture state moved to the bottom status bar
   end
 end
 

--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -73,21 +73,21 @@ module Gori::Tui
     end
 
     def self.render_top_bar(screen : Screen, rect : Rect, *, project : String,
-                            capturing : Bool, listen : String, identity : String,
+                            listen : String, time : String,
                             scope : String, rules : String = "", intercept : String = "") : Nil
       screen.fill(rect, Theme.panel)
       x = screen.text(rect.x + 1, rect.y, "gori", Theme.text_bright, Theme.panel, Attribute::Bold)
       screen.text(x + 1, rect.y, "· #{project}", Theme.muted, Theme.panel)
 
-      # right-aligned status chips: ● rec · scope:N · rules:N · intercept:on(N) · listen · id
-      # value-emphasized, dim · separators; hot states (capture, intercept) in RED.
+      # right-aligned status chips: scope:N · rules:N · intercept:on(N) · listen · HH:MM
+      # value-emphasized, dim · separators; the hot intercept state in RED. The clock
+      # is the rightmost anchor. (Capture state lives on the bottom status bar.)
       chips = [] of {String, Color}
-      chips << {capturing ? "● rec" : "○ idle", capturing ? Theme.red : Theme.muted}
       chips << {scope, scope.ends_with?(":off") ? Theme.muted : Theme.text} unless scope.empty?
       chips << {rules, Theme.text} unless rules.empty?
       chips << {intercept, Theme.red} unless intercept.empty?
       chips << {listen, Theme.muted}
-      chips << {"id:#{identity}", Theme.muted}
+      chips << {time, Theme.muted}
       render_chips(screen, rect, chips)
     end
 

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -213,6 +213,7 @@ module Gori::Tui
       last_wf = @session.store.write_failures
       last_dv = @session.store.data_version # SQLite change counter for cross-process refresh
       last_dv_poll = Time.instant
+      last_clock = clock_label # top-bar wall clock; re-render only when the minute rolls over
       loop do
         ev = @term.poll_event(50)
         dirty = false
@@ -263,6 +264,12 @@ module Gori::Tui
         # Debounced QL filter: fire the deferred search once typing has paused.
         dirty = true if history_controller.flush_query_reload_if_due(now)
         dirty = true if sitemap_controller.flush_query_reload_if_due(now)
+        # Tick the top-bar clock: dirty only when the displayed minute changes, so the
+        # idle loop wakes once a minute to repaint rather than every second.
+        if (clock = clock_label) != last_clock
+          last_clock = clock
+          dirty = true
+        end
         render if dirty
         break unless @outcome == :running
       end
@@ -1336,8 +1343,8 @@ module Gori::Tui
 
       layout = Layout.compute(w, h)
       Chrome.render_top_bar(screen, layout.topbar, project: @session.project.name,
-        capturing: @session.capturing?, listen: "#{@session.proxy.host}:#{@session.proxy.port}",
-        identity: "user", scope: scope_label, rules: rules_label, intercept: intercept_label)
+        listen: "#{@session.proxy.host}:#{@session.proxy.port}", time: clock_label,
+        scope: scope_label, rules: rules_label, intercept: intercept_label)
       Chrome.render_menu(screen, layout.menu, active_tab: @active_tab, focused: @focus == :menu,
         tabs: effective_tabs,
         findings_count: @findings_count, intercept_count: @session.interceptor.pending_count,
@@ -1398,6 +1405,13 @@ module Gori::Tui
 
     private def scope_label : String
       @scope.active? ? "scope:#{@scope.size}" : "scope:off"
+    end
+
+    # The wall clock shown at the far right of the top bar. Minute granularity — the
+    # event loop only bumps `dirty` when this string changes (see `last_clock`), so
+    # an idle TUI re-renders once a minute, not every second (preserves idle-zero-CPU).
+    private def clock_label : String
+      Time.local.to_s("%H:%M")
     end
 
     private def rules_label : String


### PR DESCRIPTION
## Summary
- Top bar's right side now ends in a right-aligned **HH:MM wall clock** as the rightmost anchor.
- Removed the **capture indicator** (`● rec` / `○ idle`) and the **`id:user`** chip from the top bar.
- Capture state still lives on the **bottom status bar** (`capture:on` / `capture:off` / `capture:FAILING(N)`), so no information is lost.

## Top bar, before → after
```
before:  gori · proj    ● rec · scope:N · rules:N · intercept:on(N) · 127.0.0.1:PORT · id:user
after:   gori · proj            scope:N · rules:N · intercept:on(N) · 127.0.0.1:PORT · HH:MM
```

## Clock ticking vs idle-zero-CPU
The render loop only repaints when something changes. A new `last_clock` check bumps `dirty` when the **displayed minute** rolls over, so the clock advances while preserving the idle-zero-CPU property — the loop wakes to repaint **once a minute**, not once a second. Minute granularity (`%H:%M`) is the deliberate choice for this reason.

## Verification
- `crystal build src/main.cr` — clean.
- `crystal spec spec/tui/` — 220 examples, 0 failures (updated the top-bar foundation spec).
- Visual smoke test via tmux pty: top bar renders `... · 127.0.0.1:19191 · 22:31`; `● rec`/`id:user` gone; bottom bar still shows `capture:on`.