### PR TITLE
feat(tui): rename Fuzzer sub-tabs (r / right-click), like Replay

### DIFF
--- a/spec/fuzz_store_spec.cr
+++ b/spec/fuzz_store_spec.cr
@@ -41,6 +41,23 @@ describe "Gori::Store fuzz persistence" do
     end
   end
 
+  it "set_fuzz_session_name sets/clears the custom name without touching the template" do
+    with_store do |store|
+      id = store.insert_fuzz_session("http://h", "GET /?x=§1§ HTTP/1.1\r\n\r\n", false, nil,
+        %({"mode":"sniper"}), nil, 0)
+      store.fuzz_sessions.first.name.should be_nil
+
+      store.set_fuzz_session_name(id, "auth fuzz")
+      s = store.fuzz_sessions.first
+      s.name.should eq("auth fuzz")
+      s.template.should contain("§1§") # the rename must not rewrite the template/config
+      s.config.should eq(%({"mode":"sniper"}))
+
+      store.set_fuzz_session_name(id, nil) # blank clears the custom name
+      store.fuzz_sessions.first.name.should be_nil
+    end
+  end
+
   it "round-trips a run + its results, with paging" do
     with_store do |store|
       run = store.insert_fuzz_run(nil, "http://h", "sniper", 3_i64)

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -1,0 +1,26 @@
+require "../spec_helper"
+
+include Gori::Tui
+
+describe Gori::Tui::FuzzerView do
+  it "label uses the custom name when set, else the template summary" do
+    view = FuzzerView.new
+    view.load_request("https://h", "GET /?x=1 HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
+    view.label(18).should eq("GET /?x=1") # auto-derived from the request line
+    view.name = "auth fuzz"
+    view.label(18).should eq("auth fuzz")
+    view.name = "   " # blank → revert to the auto label
+    view.label(18).should eq("GET /?x=1")
+    view.name = nil
+    view.label(18).should eq("GET /?x=1")
+  end
+
+  it "label truncates a long custom name" do
+    view = FuzzerView.new
+    view.load_request("https://h", "GET / HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
+    view.name = "a-very-long-custom-tab-name"
+    label = view.label(8)
+    label.size.should be <= 8
+    label.should end_with("…")
+  end
+end

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -418,6 +418,16 @@ module Gori
       }
     end
 
+    # Set (or clear, with nil) a fuzz session's custom sub-tab name — its own UPDATE,
+    # separate from update_fuzz_session so a rename never rewrites the template/config
+    # (mirrors set_replay_name).
+    def set_fuzz_session_name(id : Int64, name : String?) : Nil
+      exec_task ->(c : DB::Connection) {
+        c.exec("UPDATE fuzz_sessions SET name = ?, updated_at = ? WHERE id = ?", name, now_us, id)
+        nil
+      }
+    end
+
     def delete_fuzz_session(id : Int64) : Nil
       exec_task ->(c : DB::Connection) { c.exec("DELETE FROM fuzz_sessions WHERE id = ?", id); nil }
     end

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -64,6 +64,10 @@ module Gori::Tui
       @current_idx
     end
 
+    def view_at(idx : Int32) : FuzzerView?
+      (0 <= idx < @fuzzers.size) ? @fuzzers[idx].view : nil
+    end
+
     def body_badge : Symbol
       v = current_view
       return :body unless v
@@ -305,6 +309,20 @@ module Gori::Tui
       return if idx == @current_idx
       save_current
       @current_idx = idx
+    end
+
+    # --- rename (the shell's orthogonal rename prompt drives this by VIEW identity) ---
+    # Apply the typed name to the captured tab + persist it on its own (set_fuzz_session_name,
+    # separate from save_current so the rename lands even when the session is otherwise clean).
+    # Re-find by VIEW identity so a closed/reordered tab is a no-op, never a neighbour. Blank
+    # clears the custom label (the chip reverts to the template-derived summary).
+    def apply_rename(view : FuzzerView, name : String) : Nil
+      return unless tab = @fuzzers.find { |t| t.view.same?(view) }
+      clean = name.strip
+      view.name = clean.empty? ? nil : clean
+      if id = tab.db_id
+        @host.session.store.set_fuzz_session_name(id, view.name)
+      end
     end
 
     # --- async (run loop) ---

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -33,7 +33,7 @@ module Gori::Tui
         {"click tab", "switch to it"},
         {"click row", "select · click again opens"},
         {"click pane", "focus · in an editor, place the caret"},
-        {"sub-tab chip", "switch · right-click renames (Replay)"},
+        {"sub-tab chip", "switch · right-click renames (Replay/Fuzzer)"},
         {"wheel", "scroll / move the selection"},
         {"click outside", "close a popup"},
       ]},
@@ -62,6 +62,7 @@ module Gori::Tui
         {"^R · ^X", "run · stop"},
         {"↑/↓ · ↵", "results: select · open detail"},
         {"o · m", "sort · matched-only · ^N/^W session"},
+        {"r", "rename the sub-tab (on the strip)"},
       ]},
       {"COMPARER", [
         {"^P → Comparer", "open the tab (hidden by default)"},

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -81,15 +81,15 @@ module Gori::Tui
       @search_target = :none
       @search_hits = [] of Int32
       @search_idx = 0
-      # The Replay sub-tab rename prompt — orthogonal to @overlay (floats over the
-      # bottom status row, like ^G/^F). @rename_idx is the replay tab being renamed.
+      # The sub-tab rename prompt (Replay + Fuzzer) — orthogonal to @overlay (floats over
+      # the bottom status row, like ^G/^F).
       @rename_open = false
       @rename_buffer = ""
       @rename_preedit = ""
       # The target is held by VIEW identity (not a positional index): the cross-session
       # reconcile can reorder/remove replay tabs while the prompt is open, so the
       # controller's apply_rename re-finds the tab by its view — never a shifted neighbour.
-      @rename_view = nil.as(ReplayView?)
+      @rename_view = nil.as(ReplayView | FuzzerView | Nil)
       # Whitespace reveal (·→␍␊) toggle for the req/res views — global view pref,
       # propagated to the focused view in render_body. Handy for smuggling tests.
       @reveal = false
@@ -534,10 +534,10 @@ module Gori::Tui
       end
     end
 
-    # Right-click: rename a Replay sub-tab chip (the one context menu we have). Only
-    # acts on the sub-tab strip; anywhere else is a no-op (no left-click side effects).
+    # Right-click: rename a Replay/Fuzzer sub-tab chip (the one context menu we have).
+    # Only acts on the sub-tab strip; anywhere else is a no-op (no left-click side effects).
     private def handle_right_click(layout : Layout, mx : Int32, my : Int32) : Nil
-      return unless @active_tab == :replay && @overlay == :none && !@command_open && !@rename_open && subtabs_shown?
+      return unless renameable_subtabs? && @overlay == :none && !@command_open && !@rename_open && subtabs_shown?
       sub_rect, _ = BodyChrome.carve_subtab_row(layout.body)
       return unless sub_rect.contains?(mx, my)
       if seg = Chrome.strip_segments(sub_rect, subtab_labels, current_subtab_index).find { |(_, r)| r.contains?(mx, my) }
@@ -1024,8 +1024,8 @@ module Gori::Tui
         open_palette
       when ev.ctrl? && c && '1' <= c <= '9'
         jump_subtab(c.to_i - 1) # switch + stay on the strip
-      when rename_chord?(ev) && @active_tab == :replay
-        open_rename(replay_controller.current_idx) # rename the active replay sub-tab
+      when rename_chord?(ev)
+        open_rename(current_subtab_index) # rename the active sub-tab (Replay/Fuzzer)
       when key.left?, key.lower_h?
         move_subtab(-1)
       when key.right?, key.lower_l?
@@ -1451,7 +1451,10 @@ module Gori::Tui
       else
         # Focus on the tab bar: ←/→ pick the tab, Tab/↵ drop into the body.
         return "←/→ switch tab · ↹/↵ enter · 1-9 jump · ^P cmds · q projects · ^D quit" if @focus == :menu
-        return "←/→ switch sub-tab · ↓/↵ edit · ^1-9 jump · ^N new · ^W close · ↑/esc tabs" if @focus == :subtabs
+        if @focus == :subtabs
+          rn = renameable_subtabs? ? " · r rename" : ""
+          return "←/→ switch sub-tab · ↓/↵ edit · ^1-9 jump · ^N new · ^W close#{rn} · ↑/esc tabs"
+        end
         body_hints
       end
     end
@@ -1622,17 +1625,28 @@ module Gori::Tui
       end
     end
 
-    # `r` (no modifiers) on the Replay sub-tab strip opens the rename prompt. Factored
+    # `r` (no modifiers) on a renameable sub-tab strip opens the rename prompt. Factored
     # out of handle_subtabs_key's case so its conditions don't inflate that method.
     private def rename_chord?(ev : Termisu::Event::Key) : Bool
-      @active_tab == :replay && ev.key.lower_r? && !ev.ctrl? && !ev.alt?
+      renameable_subtabs? && ev.key.lower_r? && !ev.ctrl? && !ev.alt?
     end
 
-    # Open the rename prompt for replay tab `idx`, seeding its current custom name
-    # (empty when it's still the auto label) so it can be edited in place. The target
-    # is captured by VIEW identity so a reconcile reorder/remove can't redirect it.
+    # The tabs whose sub-tab chips carry a custom name (Replay + Fuzzer). Notes derives
+    # its label from the body text, so it has no rename.
+    private def renameable_subtabs? : Bool
+      @active_tab == :replay || @active_tab == :fuzzer
+    end
+
+    # Open the rename prompt for sub-tab `idx` on the active tab, seeding its current
+    # custom name (empty when it's still the auto label) so it can be edited in place.
+    # The target is captured by VIEW identity so a reconcile reorder/remove can't
+    # redirect it.
     private def open_rename(idx : Int32) : Nil
-      return unless view = replay_controller.view_at(idx)
+      view = case @active_tab
+             when :replay then replay_controller.view_at(idx)
+             when :fuzzer then fuzzer_controller.view_at(idx)
+             end
+      return unless view
       @rename_view = view
       @rename_buffer = view.name || ""
       @rename_preedit = ""
@@ -1645,13 +1659,15 @@ module Gori::Tui
       @rename_view = nil
     end
 
-    # Apply the typed name to the captured tab + persist. Re-find the tab by its view
-    # (the reconcile may have reordered/removed it since the prompt opened — if it's
-    # gone, the rename is a no-op rather than hitting a neighbour). Blank clears the
-    # custom label (the chip reverts to the request-derived summary).
+    # Apply the typed name to the captured tab + persist. The controller re-finds the tab
+    # by its view (a reconcile may have reordered/removed it since the prompt opened — if
+    # it's gone the rename is a no-op, never a neighbour). Blank clears the custom label
+    # (the chip reverts to the request/template-derived summary).
     private def apply_rename(name : String) : Nil
-      return unless v = @rename_view
-      replay_controller.apply_rename(v, name)
+      case v = @rename_view
+      when ReplayView then replay_controller.apply_rename(v, name)
+      when FuzzerView then fuzzer_controller.apply_rename(v, name)
+      end
     end
 
     private def render_rename_prompt(screen : Screen, rect : Rect) : Nil


### PR DESCRIPTION
## Summary

Adds custom sub-tab names to the **Fuzzer** tab, mirroring the existing Replay sub-tab rename. Each fuzz session's chip can now be renamed so a workbench of sessions stays legible (`1:sqli-probe`, `2:idor`, …).

Triggers (same as Replay):
- **`r`** on the Fuzzer sub-tab strip
- **right-click** a chip
- blank name → reverts to the auto (template-derived) label

## What changed

- **runner**: the bottom rename prompt now targets Replay *or* Fuzzer. `@rename_view` is a `ReplayView | FuzzerView` union; `open_rename`/`apply_rename` dispatch by active tab / view type. New `renameable_subtabs?` gates the `r` chord, the right-click, and the strip hint (`… · r rename`).
- **FuzzerController**: `view_at` + `apply_rename` — re-finds the tab by **view identity** so a reconcile reorder/close can never rename a neighbour (the Replay invariant).
- **store**: `set_fuzz_session_name` — its own `UPDATE`, separate from `update_fuzz_session`, so a rename never rewrites the template/config (mirrors `set_replay_name`).
- **help**: document the chip rename + the Fuzzer `r` shortcut.

The view + persistence already carried `name` (schema V16) — this PR just wires the UI triggers.

## Testing

- `crystal spec` → **630 examples, 0 failures**
- New specs: `set_fuzz_session_name` set/clear round-trip (asserts template/config untouched); `FuzzerView` label/name fallback + truncation.
- Live tmux run: created 2 sessions, `r`-renamed one (`2:GET /` → `2:sqli-probe`), confirmed the strip hint shows `r rename`, and verified blank-clears-back-to-auto.
- `crystal build` clean.