### PR TITLE
fix(tui): number-key tab jump focuses the tab bar, not the body

### DIFF
--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1756,9 +1756,9 @@ module Gori::Tui
       focus_pane(subtabs_shown? ? :subtabs : :body)
     end
 
-    # Switch the active tab. `focus` is where focus lands: :body for explicit
-    # "jump to tab" (number keys) which drills into content, :menu for a tab-bar
-    # mouse click which selects the tab without descending into the body.
+    # Switch the active tab. `focus` is where focus lands: :menu for a tab "select"
+    # gesture (tab-bar click, number-key jump) which lands on the bar without descending
+    # into the body, :body for the named "Go to …" palette jumps which drill into content.
     def focus_tab(tab : Symbol, focus : Symbol = :body) : Nil
       if @active_tab == :project
         project_controller.commit
@@ -1781,9 +1781,11 @@ module Gori::Tui
 
     # Positional number-key target: focus the Nth (1-based) VISIBLE tab — the order shown
     # on the bar. Out-of-range n (fewer tabs visible than the digit) is a no-op.
+    # Lands on the tab bar (TABS level), like a tab-bar click: a number jump selects the
+    # tab, it does not drill into the body.
     def focus_visible_tab(n : Int32) : Nil
       if t = effective_tabs[n - 1]?
-        focus_tab(t[0])
+        focus_tab(t[0], focus: :menu)
       end
     end
 


### PR DESCRIPTION
## What

A digit jump (`1`–`9`) used to drill focus into the **body**, unlike a tab-bar **click** which lands on the TABS level (#18). This makes the number-key jump a tab "select" gesture too: `focus_visible_tab` now calls `focus_tab(focus: :menu)`, so it selects the tab without descending into the content.

## Behavior after this change

| Gesture | Focus lands on |
|---|---|
| Tab-bar click | tab bar (`:menu`) — #18 |
| **Number-key jump (1–9)** | **tab bar (`:menu`) — this PR** |
| `]` `[` `h` `l` cycle | current level preserved |
| Palette "Go to …" command | body (`:body`) — explicit command to work in that tab |

`focus_tab`'s trailing `view_focus_first` only resets the tab's internal pane selection, not `@focus`, so `:menu` is preserved — the same path the tab-bar click already uses.

## Test

- `shards build gori` passes.