### PR TITLE
feat(tui): manual fuzz marker (^T) for byte-exact § placement

### DIFF
--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -79,7 +79,7 @@ module Gori::Tui
       return "↹/esc tabs · ^N new" unless v
       case v.focus
       when :target   then "type URL · ↵/↓ template · ^R run · ↹ pane · esc tabs"
-      when :template then "type · ^A mark params · ^K word · ^U clear · ^O config · ^R run · ↹ pane"
+      when :template then "type · ^A params · ^K word · ^T point · ^U clear · ^O config · ^R run · ↹ pane"
       when :config   then "↑/↓ field · ←/→ change·type-tab · type edit · ⏎ add · Del rm · ↹ pane"
       when :results  then "↑/↓ select · ↵ detail · o sort · m matched · ^R run · ^X stop · ↹ pane"
       when :detail   then "↑/↓ scroll · ←/→ req/resp · esc back"
@@ -118,16 +118,17 @@ module Gori::Tui
     # Run the action a chord mapped to; false when it was not a chord (fall through).
     private def dispatch_chord(action : Symbol?, v : FuzzerView, c : Char?) : Bool
       case action
-      when :palette  then save_current; @host.open_palette
-      when :run      then fuzz_run
-      when :stop     then fuzz_stop
-      when :close    then request_close
-      when :automark then @host.status(v.auto_mark)
-      when :markword then @host.status(v.mark_word)
-      when :clear    then @host.status(v.clear_marks)
-      when :config   then v.focus_config
-      when :switch   then switch_subtab(c)
-      else                return false
+      when :palette   then save_current; @host.open_palette
+      when :run       then fuzz_run
+      when :stop      then fuzz_stop
+      when :close     then request_close
+      when :automark  then @host.status(v.auto_mark)
+      when :markword  then @host.status(v.mark_word)
+      when :markpoint then @host.status(v.insert_marker)
+      when :clear     then @host.status(v.clear_marks)
+      when :config    then v.focus_config
+      when :switch    then switch_subtab(c)
+      else                 return false
       end
       true
     end
@@ -143,6 +144,7 @@ module Gori::Tui
       when key.lower_w?         then :close
       when key.lower_a?         then :automark
       when key.lower_k?         then :markword
+      when key.lower_t?         then :markpoint
       when key.lower_u?         then :clear
       when key.lower_o?         then :config
       when c && '1' <= c <= '9' then :switch

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -213,6 +213,24 @@ module Gori::Tui
       Fuzz::Template.parse(after).position_count < Fuzz::Template.parse(before).position_count ? "unmarked position" : "marked position"
     end
 
+    # Drop a single § marker at the cursor. Place two to bracket ANY region by hand:
+    # ^K auto-expands to a whole token, but this gives byte-exact control over the
+    # span — part of a token, or a region crossing delimiters that word-detection
+    # would never pick. An odd marker count means a position is still "open"; move
+    # the cursor and fire again to close it. (parse treats a dangling § as literal.)
+    def insert_marker : String
+      return "mark point (^T) works on the TEMPLATE pane — ↹ to it" unless @focus == :template
+      @editor.insert(Fuzz::Template::MARKER)
+      @editor.set_preedit("")
+      @dirty = true
+      if @editor.text.count(Fuzz::Template::MARKER).odd?
+        "marker opened — move the cursor and ^T again to close the region"
+      else
+        n = Fuzz::Template.parse(@editor.text).position_count
+        "marked point — #{n} position#{n == 1 ? "" : "s"}"
+      end
+    end
+
     def clear_marks : String
       @editor.set_text(@editor.text.gsub("§", ""))
       @dirty = true

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -57,7 +57,7 @@ module Gori::Tui
       ]},
       {"FUZZER", [
         {"⇧I", "send a flow/replay here (History/Replay)"},
-        {"^A · ^K · ^U", "auto-mark params · mark word · clear §"},
+        {"^A · ^K · ^T · ^U", "auto-mark params · mark word · mark point (manual §) · clear §"},
         {"^O", "focus the config pane"},
         {"config", "mode/list/file/num/null/brute/match/filter…"},
         {"^R · ^X", "run · stop"},


### PR DESCRIPTION
## What

Adds a **manual marker key (`^T`)** to the Fuzzer template pane: drop a single `§` at the cursor, place two to bracket **any region by hand**.

## Why

`^K` auto-expands to a whole token via word-boundary detection, so there was no way to mark *part* of a token or a span that crosses delimiters (e.g. `GET §/ H§TTP`). `^T` gives byte-exact control — exactly the "detailed adjustment" that auto-marking couldn't do.

## How

- `FuzzerView#insert_marker` inserts `Template::MARKER` at the cursor (template pane only). Odd marker count → status reports the position is still "open"; even → "marked point — N positions".
- The engine already parses arbitrary `§` pairs and treats a dangling `§` as literal, so this is a **TUI-only** change — no engine/template logic touched.
- `^A` (auto) / `^K` (word) / **`^T` (manual)** / `^U` (clear).

### Key choice
`^T` is free in both the global runner and the Fuzzer chord table. `^G`/`^F`/`^B`/`^E` are globally intercepted (goto-line / find / reveal / external-editor) and `^S`/`^Q`/`^Z` are terminal flow-control/suspend hazards. The fuller Shift+arrow *selection*-based marking stays deferred (needs anchor+range on the shared `TextArea` that Replay/Notes also use → regression risk).

## Verification
- `crystal build` OK · `crystal tool format` applied · no new ameba findings
- `spec/fuzz_spec.cr` → 21 examples, 0 failures
- tmux E2E: `^T` produced `GET §/ H§TTP/1.1` (span crossing a space), title `§1`, status `marked point — 1 position`; open-state and wrong-pane guard messages confirmed

Files: `fuzzer_view.cr`, `controllers/fuzzer_controller.cr`, `help_view.cr` (cheat-sheet synced).