### PR TITLE
Test-and-improve audit: fix proxy desync, h2 replay flow control, fuzzer, QL, intercept, certs (21 commits)

### DIFF
--- a/spec/findings_export_spec.cr
+++ b/spec/findings_export_spec.cr
@@ -1,0 +1,73 @@
+require "./spec_helper"
+require "../src/gori/findings_export"
+
+private def with_store(&)
+  path = File.tempname("gori-fexport", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+# Returns the markdown with every fenced code block removed, so anything left is
+# "live" Markdown that a renderer would interpret structurally.
+private def strip_fences(md : String) : String
+  out = [] of String
+  fence : String? = nil
+  md.each_line do |line|
+    stripped = line.strip
+    if f = fence
+      fence = nil if stripped == f # closing fence (bare backticks)
+      next
+    end
+    if stripped.starts_with?("```")
+      fence = stripped.gsub(/[^`]/, "") # the run of backticks that must close it
+      next
+    end
+    out << line
+  end
+  out.join("\n")
+end
+
+describe Gori::Findings::Export do
+  describe ".one_line" do
+    it "collapses control characters so a value stays on one line" do
+      Gori::Findings::Export.one_line("pwn\n## FAKE HEADING").should eq("pwn ## FAKE HEADING")
+      Gori::Findings::Export.one_line("a\r\n\tb").should eq("a b")
+      Gori::Findings::Export.one_line("  clean  ").should eq("clean")
+    end
+  end
+
+  describe ".markdown" do
+    it "keeps an attacker-controlled body (``` + headings) inside its code fence" do
+      with_store do |store|
+        id = store.insert_flow(Gori::Store::CapturedRequest.new(
+          created_at: 1_i64, scheme: "http", host: "h.test", port: 80,
+          method: "POST", target: "/", http_version: "HTTP/1.1",
+          head: "POST / HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice, body: nil))
+        # Body tries to break out of the ```http fence and inject a heading.
+        evil = "```\n## INJECTED HEADING\n```\nmore".to_slice
+        store.update_response(Gori::Store::CapturedResponse.new(
+          flow_id: id, status: 200, head: "HTTP/1.1 200 OK\r\n\r\n".to_slice,
+          body: evil, reason: "OK", content_type: "text/plain", duration_us: 1_i64))
+        store.insert_finding("pwn\n## FAKE TITLE HEADING", Gori::Store::Severity::High, "h.test", id)
+
+        md = Gori::Findings::Export.markdown(store.findings, store, "proj")
+
+        # Body must be fenced with >3 backticks so its own ``` lines can't close it.
+        md.should contain("````http")
+        # With fences removed, no injected heading survives as live Markdown.
+        live = strip_fences(md)
+        live.should_not contain("INJECTED HEADING")
+        # The newline in the title is collapsed — no fake "## FAKE TITLE HEADING" heading.
+        live.lines.any? { |l| l.starts_with?("## FAKE TITLE HEADING") }.should be_false
+        live.should contain("## [high] pwn ## FAKE TITLE HEADING") # one real heading line
+      end
+    end
+  end
+end

--- a/spec/findings_export_spec.cr
+++ b/spec/findings_export_spec.cr
@@ -69,5 +69,18 @@ describe Gori::Findings::Export do
         live.should contain("## [high] pwn ## FAKE TITLE HEADING") # one real heading line
       end
     end
+
+    it "collapses the host field so a fence/newline can't open a runaway block" do
+      with_store do |store|
+        store.insert_finding("clean title", Gori::Store::Severity::Low,
+          "evil.test\n```\n## INJECTED VIA HOST", nil)
+        md = Gori::Findings::Export.markdown(store.findings, store, "proj")
+        # host collapses to one line: the ``` is inline (not its own fence line) and
+        # the "## INJECTED" never becomes a heading.
+        md.lines.count { |l| l.strip == "```" }.should eq(0)
+        md.lines.any? { |l| l.starts_with?("## INJECTED") }.should be_false
+        md.should contain("- **Host:** evil.test ``` ## INJECTED VIA HOST")
+      end
+    end
   end
 end

--- a/spec/fuzz_spec.cr
+++ b/spec/fuzz_spec.cr
@@ -186,6 +186,16 @@ describe F::Generator do
     g = F::Generator.new(base, [huge, huge], F::Config.new(mode: F::Mode::ClusterBomb))
     g.total.should be_nil
   end
+
+  it "clusterbomb total honours the set-0 fallback when sets < positions" do
+    # 2 positions, ONE set (size 3): position 1 falls back to set 0, like each().
+    s1 = F::PayloadSet.new(F::InlineList.new(["x", "y", "z"]))
+    g = F::Generator.new(base, [s1], F::Config.new(mode: F::Mode::ClusterBomb))
+    g.total.should eq(9) # 3 × 3 (was nil/'?' before) — total must agree with each()
+    seen = 0
+    g.each { seen += 1 }
+    seen.should eq(9)
+  end
 end
 
 describe F::Matcher do

--- a/spec/fuzz_spec.cr
+++ b/spec/fuzz_spec.cr
@@ -131,6 +131,15 @@ describe F::ContentLength do
     synced[(synced.size - 4), 4].should eq(body) # last 4 bytes are the exact binary body
     String.new(synced[0, synced.index!(0x0d_u8)]).should eq("POST / HTTP/1.1")
   end
+
+  it "splits at the FIRST blank line: an LF-terminated head whose body holds a CRLFCRLF" do
+    # Head ends with LF LF; the body itself contains a \r\n\r\n. The boundary must be
+    # the head's LFLF (so CL counts the whole body), not the body's later CRLFCRLF.
+    req = "POST / HTTP/1.0\nContent-Length: 0\n\nA\r\n\r\nB".to_slice
+    synced = F::ContentLength.sync(req)
+    # body is "A\r\n\r\nB" = 6 bytes; the head's LF line ending is preserved.
+    String.new(synced).should eq("POST / HTTP/1.0\nContent-Length: 6\n\nA\r\n\r\nB")
+  end
 end
 
 describe F::PayloadSet do

--- a/spec/fuzz_spec.cr
+++ b/spec/fuzz_spec.cr
@@ -47,6 +47,24 @@ describe F::Template do
     F::Template.parse("a§§b").position_count.should eq(0)
     String.new(F::Template.parse("a§§b").render([] of String)).should eq("a§b")
     F::Template.parse("a§b").position_count.should eq(0) # unbalanced trailing § → literal
+    String.new(F::Template.parse("a§b").render([] of String)).should eq("a§b")
+  end
+
+  it "keeps the literal tail after a position when a trailing § is unbalanced (no truncation)" do
+    # x=§A§&y=§z : one position (A), then a stray trailing § that opens no pair.
+    t = F::Template.parse("x=§A§&y=§z")
+    t.position_count.should eq(1)
+    # render must keep '&y=§z' verbatim — it used to drop everything from the stray §.
+    String.new(t.render(["PP"])).should eq("x=PP&y=§z")
+  end
+
+  it "auto-mark leaves empty values unmarked instead of injecting a literal § (§§)" do
+    # Empty values across query / cookie / urlencoded body / JSON must not be wrapped.
+    F::Template.auto_mark("GET /?a=&b=2 HTTP/1.1\r\n\r\n").should eq("GET /?a=&b=§2§ HTTP/1.1\r\n\r\n")
+    body = "POST / HTTP/1.1\r\nContent-Type: application/json\r\n\r\n{\"a\":\"\",\"b\":\"x\"}"
+    marked = F::Template.auto_mark(body)
+    marked.includes?("§§").should be_false                # no escaped-literal collision
+    F::Template.parse(marked).position_count.should eq(1) # only "b"
   end
 
   it "renders defaults back to the base request" do

--- a/spec/proxy/server_spec.cr
+++ b/spec/proxy/server_spec.cr
@@ -292,6 +292,45 @@ describe Gori::Proxy::Server do
     sink.responses.map { |r| String.new(r.body.not_nil!) }.sort.should eq(["RESP-1", "RESP-2"])
   end
 
+  it "refuses a malformed interim 1xx that declares a body (no response smuggling)" do
+    done = Channel(Nil).new(1)
+    origin = TCPServer.new("127.0.0.1", 0)
+    origin_port = origin.local_address.port
+    # A 103 whose Content-Length body is a COMPLETE fake 200, then the real 200.
+    fake = "HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nEVL"
+    spawn do
+      if conn = origin.accept?
+        Gori::Proxy::Codec::Http1.read_head(conn)
+        conn << "HTTP/1.1 103 Early Hints\r\nContent-Length: #{fake.bytesize}\r\n\r\n#{fake}"
+        conn << "HTTP/1.1 200 OK\r\nContent-Length: 4\r\nConnection: close\r\n\r\nREAL"
+        conn.flush
+        conn.close
+      end
+    rescue
+    end
+
+    sink = RecordingSink.new(done)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink)
+    proxy.start
+
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    client.read_timeout = 3.seconds
+    client << "GET http://127.0.0.1:#{origin_port}/a HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\nConnection: keep-alive\r\n\r\n"
+    client.flush
+    got = begin
+      client.gets_to_end
+    rescue
+      ""
+    end
+    client.close
+
+    done.receive
+    proxy.stop
+
+    got.should_not contain("EVL")                                       # fake body never served
+    sink.responses.first.state.should eq(Gori::Store::FlowState::Error) # recorded as an error
+  end
+
   it "records an error flow when the upstream is unreachable" do
     done = Channel(Nil).new(1)
     sink = RecordingSink.new(done)
@@ -443,6 +482,67 @@ describe Gori::Proxy::Server do
     # Origin received the FULL edited body (would be "GR" under the stale CL: 2).
     got_body.receive.should eq("GROWN-BODY")
     String.new(sink.requests.first.head).should contain("Content-Length: 10") # synced + captured
+  end
+
+  it "adds a Content-Length when a held GET gains a body (no unframed smuggling)" do
+    done = Channel(Nil).new(1)
+    got = Channel(String).new(1)
+    origin = TCPServer.new("127.0.0.1", 0)
+    origin_port = origin.local_address.port
+    spawn do
+      if conn = origin.accept?
+        head = Gori::Proxy::Codec::Http1.read_head(conn).not_nil!
+        m = String.new(head).match(/Content-Length:\s*(\d+)/i)
+        clen = m ? m[1].to_i : 0
+        body = Bytes.new(clen)
+        conn.read_fully(body) if clen > 0
+        got.send("#{clen}:#{String.new(body)}")
+        conn << "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"
+        conn.flush
+        conn.close
+      end
+    end
+
+    store_path = File.tempname("gori-icadd", ".db")
+    store = Gori::Store.open(store_path)
+    interceptor = Gori::Interceptor.new(Gori::Scope.load(store))
+    interceptor.toggle
+
+    sink = RecordingSink.new(done)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink, interceptor: interceptor)
+    proxy.start
+
+    spawn do
+      loop do
+        interceptor.pending.each do |it|
+          if it.kind.request?
+            # add a body to a GET that had none + no Content-Length header
+            edited = String.new(it.raw).sub("\r\n\r\n", "\r\n\r\nADDED-BODY")
+            interceptor.forward(it.id, edited.to_slice)
+          else
+            interceptor.forward(it.id)
+          end
+        end
+        sleep 0.01.seconds
+      end
+    end
+
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    client << "GET http://127.0.0.1:#{origin_port}/echo HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\n\r\n"
+    client.flush
+    client.gets_to_end
+    client.close
+
+    done.receive
+    proxy.stop
+    store.close
+    File.delete?(store_path)
+    File.delete?("#{store_path}-wal")
+    File.delete?("#{store_path}-shm")
+
+    # Origin saw the full added body, framed by a synthesized Content-Length — not
+    # dropped + left unframed on the upstream socket.
+    got.receive.should eq("10:ADDED-BODY")
   end
 
   it "evaluates the response intercept condition against the REWRITTEN request line" do

--- a/spec/proxy/server_spec.cr
+++ b/spec/proxy/server_spec.cr
@@ -331,6 +331,65 @@ describe Gori::Proxy::Server do
     sink.responses.first.state.should eq(Gori::Store::FlowState::Error) # recorded as an error
   end
 
+  it "caps a flood of interim 1xx responses instead of spinning forever" do
+    done = Channel(Nil).new(1)
+    origin = TCPServer.new("127.0.0.1", 0)
+    origin_port = origin.local_address.port
+    spawn do
+      if conn = origin.accept?
+        Gori::Proxy::Codec::Http1.read_head(conn)
+        200.times { conn << "HTTP/1.1 103 Early Hints\r\n\r\n"; conn.flush } # > MAX_INTERIM
+        conn.close
+      end
+    rescue
+    end
+
+    sink = RecordingSink.new(done)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink)
+    proxy.start
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    client.read_timeout = 5.seconds
+    client << "GET http://127.0.0.1:#{origin_port}/ HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\nConnection: keep-alive\r\n\r\n"
+    client.flush
+    (client.gets_to_end rescue nil)
+    client.close
+
+    done.receive
+    proxy.stop
+    sink.responses.first.state.should eq(Gori::Store::FlowState::Error) # gave up, recorded an error
+  end
+
+  it "does not forward interim 1xx to an HTTP/1.0 client, but still delivers the final response" do
+    done = Channel(Nil).new(1)
+    origin = TCPServer.new("127.0.0.1", 0)
+    origin_port = origin.local_address.port
+    spawn do
+      if conn = origin.accept?
+        Gori::Proxy::Codec::Http1.read_head(conn)
+        conn << "HTTP/1.1 100 Continue\r\n\r\n"
+        conn << "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nhi"
+        conn.flush
+        conn.close
+      end
+    rescue
+    end
+
+    sink = RecordingSink.new(done)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink)
+    proxy.start
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    client.read_timeout = 3.seconds
+    client << "GET http://127.0.0.1:#{origin_port}/ HTTP/1.0\r\nHost: 127.0.0.1:#{origin_port}\r\n\r\n"
+    client.flush
+    resp = (client.gets_to_end rescue "")
+    client.close
+
+    done.receive
+    proxy.stop
+    resp.should_not contain("100 Continue") # 1.0 client never sees the interim
+    resp.should contain("hi")               # but does get the final 200
+  end
+
   it "records an error flow when the upstream is unreachable" do
     done = Channel(Nil).new(1)
     sink = RecordingSink.new(done)
@@ -424,25 +483,30 @@ describe Gori::Proxy::Server do
     sink.requests.first.target.should eq("/held")
   end
 
-  it "recomputes Content-Length when a held request body is edited" do
+  it "forwards held bytes byte-exact, preserving a deliberately mismatched Content-Length (P7)" do
+    # The proxy must NOT rewrite the bytes the human chose to send — Content-Length
+    # sync is the editor's job (InterceptView#forward_bytes). A forwarded smuggling
+    # probe (CL: 3 but a 7-byte body) reaches the origin verbatim.
     done = Channel(Nil).new(1)
-    got_body = Channel(String).new(1)
+    got = Channel(String).new(1)
     origin = TCPServer.new("127.0.0.1", 0)
     origin_port = origin.local_address.port
     spawn do
       if conn = origin.accept?
         head = Gori::Proxy::Codec::Http1.read_head(conn).not_nil!
-        clen = String.new(head).match(/Content-Length:\s*(\d+)/i).not_nil![1].to_i
+        m = String.new(head).match(/Content-Length:\s*(\d+)/i)
+        clen = m ? m[1].to_i : 0
         body = Bytes.new(clen)
-        conn.read_fully(body)
-        got_body.send(String.new(body))
+        conn.read_fully(body) if clen > 0
+        got.send("#{clen}:#{String.new(body)}")
         conn << "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"
         conn.flush
         conn.close
       end
+    rescue
     end
 
-    store_path = File.tempname("gori-iccl", ".db")
+    store_path = File.tempname("gori-icp7", ".db")
     store = Gori::Store.open(store_path)
     interceptor = Gori::Interceptor.new(Gori::Scope.load(store))
     interceptor.toggle
@@ -455,9 +519,7 @@ describe Gori::Proxy::Server do
       loop do
         interceptor.pending.each do |it|
           if it.kind.request?
-            # grow the body "ab" (CL 2) → "GROWN-BODY" (10) WITHOUT touching the header
-            edited = String.new(it.raw).sub("\r\n\r\nab", "\r\n\r\nGROWN-BODY")
-            interceptor.forward(it.id, edited.to_slice)
+            interceptor.forward(it.id, "POST /e HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\nContent-Length: 3\r\n\r\nSMUGGLE".to_slice)
           else
             interceptor.forward(it.id)
           end
@@ -479,70 +541,8 @@ describe Gori::Proxy::Server do
     File.delete?("#{store_path}-wal")
     File.delete?("#{store_path}-shm")
 
-    # Origin received the FULL edited body (would be "GR" under the stale CL: 2).
-    got_body.receive.should eq("GROWN-BODY")
-    String.new(sink.requests.first.head).should contain("Content-Length: 10") # synced + captured
-  end
-
-  it "adds a Content-Length when a held GET gains a body (no unframed smuggling)" do
-    done = Channel(Nil).new(1)
-    got = Channel(String).new(1)
-    origin = TCPServer.new("127.0.0.1", 0)
-    origin_port = origin.local_address.port
-    spawn do
-      if conn = origin.accept?
-        head = Gori::Proxy::Codec::Http1.read_head(conn).not_nil!
-        m = String.new(head).match(/Content-Length:\s*(\d+)/i)
-        clen = m ? m[1].to_i : 0
-        body = Bytes.new(clen)
-        conn.read_fully(body) if clen > 0
-        got.send("#{clen}:#{String.new(body)}")
-        conn << "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"
-        conn.flush
-        conn.close
-      end
-    end
-
-    store_path = File.tempname("gori-icadd", ".db")
-    store = Gori::Store.open(store_path)
-    interceptor = Gori::Interceptor.new(Gori::Scope.load(store))
-    interceptor.toggle
-
-    sink = RecordingSink.new(done)
-    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink, interceptor: interceptor)
-    proxy.start
-
-    spawn do
-      loop do
-        interceptor.pending.each do |it|
-          if it.kind.request?
-            # add a body to a GET that had none + no Content-Length header
-            edited = String.new(it.raw).sub("\r\n\r\n", "\r\n\r\nADDED-BODY")
-            interceptor.forward(it.id, edited.to_slice)
-          else
-            interceptor.forward(it.id)
-          end
-        end
-        sleep 0.01.seconds
-      end
-    end
-
-    client = TCPSocket.new("127.0.0.1", proxy.port)
-    client << "GET http://127.0.0.1:#{origin_port}/echo HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\n\r\n"
-    client.flush
-    client.gets_to_end
-    client.close
-
-    done.receive
-    proxy.stop
-    store.close
-    File.delete?(store_path)
-    File.delete?("#{store_path}-wal")
-    File.delete?("#{store_path}-shm")
-
-    # Origin saw the full added body, framed by a synthesized Content-Length — not
-    # dropped + left unframed on the upstream socket.
-    got.receive.should eq("10:ADDED-BODY")
+    # Origin saw CL: 3 and read exactly 3 bytes — the proxy did not "fix" the CL to 7.
+    got.receive.should eq("3:SMU")
   end
 
   it "evaluates the response intercept condition against the REWRITTEN request line" do

--- a/spec/proxy/server_spec.cr
+++ b/spec/proxy/server_spec.cr
@@ -36,6 +36,23 @@ private class StubRewriter < Gori::Proxy::HeadRewriter
   end
 end
 
+# Reads from a socket until `marker` appears (or the read times out / EOFs),
+# returning everything read so far. Used to frame one response off a keep-alive
+# connection without consuming the next one.
+private def read_until(io : IO, marker : String) : String
+  buf = IO::Memory.new
+  chunk = Bytes.new(4096)
+  loop do
+    n = io.read(chunk)
+    break if n == 0
+    buf.write(chunk[0, n])
+    break if buf.to_s.includes?(marker)
+  end
+  buf.to_s
+rescue
+  buf.to_s
+end
+
 # A minimal origin server. For each connection: reads the request head, records
 # the request-line it saw, and replies with `body` (Connection: close).
 private def start_origin(body : String, seen : Channel(String)) : Int32
@@ -220,6 +237,59 @@ describe Gori::Proxy::Server do
     resp = sink.responses.first
     resp.content_type.should eq("text/event-stream")
     String.new(resp.body.not_nil!).should contain("data: two") # streamed body captured
+  end
+
+  it "forwards interim 1xx responses then reads the final status, with no reuse desync" do
+    # Origin: for each keep-alive request, send a 100 Continue THEN the real 200.
+    done = Channel(Nil).new(2)
+    origin = TCPServer.new("127.0.0.1", 0)
+    origin_port = origin.local_address.port
+    spawn do
+      while conn = origin.accept?
+        spawn do
+          n = 0
+          while head = Gori::Proxy::Codec::Http1.read_head(conn)
+            n += 1
+            body = "RESP-#{n}"
+            conn << "HTTP/1.1 100 Continue\r\n\r\n"
+            conn << "HTTP/1.1 200 OK\r\nContent-Length: #{body.bytesize}\r\nConnection: keep-alive\r\n\r\n" << body
+            conn.flush
+          end
+          conn.close
+        rescue
+        end
+      end
+    end
+
+    sink = RecordingSink.new(done)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink)
+    proxy.start
+
+    # One client connection, two sequential keep-alive requests through the proxy.
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    client.read_timeout = 3.seconds
+    client << "GET http://127.0.0.1:#{origin_port}/one HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\nConnection: keep-alive\r\n\r\n"
+    client.flush
+    r1 = read_until(client, "RESP-1")
+    client << "GET http://127.0.0.1:#{origin_port}/two HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\nConnection: keep-alive\r\n\r\n"
+    client.flush
+    r2 = read_until(client, "RESP-2")
+    client.close
+
+    done.receive
+    done.receive
+    proxy.stop
+
+    # Client sees the interim 100 AND each request's own final 200 body — no desync.
+    r1.should contain("100 Continue")
+    r1.should contain("RESP-1")
+    r2.should contain("RESP-2")
+    r2.should_not contain("RESP-1")
+
+    # Both flows are recorded as the FINAL 200 (not the interim 100).
+    sink.responses.size.should eq(2)
+    sink.responses.each(&.status.should eq(200))
+    sink.responses.map { |r| String.new(r.body.not_nil!) }.sort.should eq(["RESP-1", "RESP-2"])
   end
 
   it "records an error flow when the upstream is unreachable" do

--- a/spec/proxy/server_spec.cr
+++ b/spec/proxy/server_spec.cr
@@ -385,6 +385,66 @@ describe Gori::Proxy::Server do
     sink.requests.first.target.should eq("/held")
   end
 
+  it "recomputes Content-Length when a held request body is edited" do
+    done = Channel(Nil).new(1)
+    got_body = Channel(String).new(1)
+    origin = TCPServer.new("127.0.0.1", 0)
+    origin_port = origin.local_address.port
+    spawn do
+      if conn = origin.accept?
+        head = Gori::Proxy::Codec::Http1.read_head(conn).not_nil!
+        clen = String.new(head).match(/Content-Length:\s*(\d+)/i).not_nil![1].to_i
+        body = Bytes.new(clen)
+        conn.read_fully(body)
+        got_body.send(String.new(body))
+        conn << "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"
+        conn.flush
+        conn.close
+      end
+    end
+
+    store_path = File.tempname("gori-iccl", ".db")
+    store = Gori::Store.open(store_path)
+    interceptor = Gori::Interceptor.new(Gori::Scope.load(store))
+    interceptor.toggle
+
+    sink = RecordingSink.new(done)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink, interceptor: interceptor)
+    proxy.start
+
+    spawn do
+      loop do
+        interceptor.pending.each do |it|
+          if it.kind.request?
+            # grow the body "ab" (CL 2) → "GROWN-BODY" (10) WITHOUT touching the header
+            edited = String.new(it.raw).sub("\r\n\r\nab", "\r\n\r\nGROWN-BODY")
+            interceptor.forward(it.id, edited.to_slice)
+          else
+            interceptor.forward(it.id)
+          end
+        end
+        sleep 0.01.seconds
+      end
+    end
+
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    client << "POST /e HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\nContent-Length: 2\r\n\r\nab"
+    client.flush
+    client.gets_to_end
+    client.close
+
+    done.receive
+    proxy.stop
+    store.close
+    File.delete?(store_path)
+    File.delete?("#{store_path}-wal")
+    File.delete?("#{store_path}-shm")
+
+    # Origin received the FULL edited body (would be "GR" under the stale CL: 2).
+    got_body.receive.should eq("GROWN-BODY")
+    String.new(sink.requests.first.head).should contain("Content-Length: 10") # synced + captured
+  end
+
   it "evaluates the response intercept condition against the REWRITTEN request line" do
     # Regression: a Match&Replace rule rewrites /hello → /hi. With a response-only
     # catch + condition `path:/hi`, the response gate must match the REWRITTEN path

--- a/spec/proxy/tls/cert_authority_spec.cr
+++ b/spec/proxy/tls/cert_authority_spec.cr
@@ -165,6 +165,17 @@ describe Gori::Proxy::Tls::CertAuthority do
     end
   end
 
+  it "does not abort the handshake for a non-canonical (zero-padded) IP authority" do
+    with_ca_dir do |dir|
+      ca = Gori::Proxy::Tls::CertAuthority.load_or_create(dir)
+      # OpenSSL's IP-SAN parser rejects "01.02.03.04"; minting must fall back to a
+      # DNS SAN — context_for would raise Gori::Error out of CertBuilder.add_ext under
+      # the old lenient ipv4?, failing this test.
+      ctx = ca.context_for("01.02.03.04")
+      ctx.should be_a(OpenSSL::SSL::Context::Server)
+    end
+  end
+
   it "caches the context per host" do
     with_ca_dir do |dir|
       ca = Gori::Proxy::Tls::CertAuthority.load_or_create(dir)

--- a/spec/proxy/tls/cert_authority_spec.cr
+++ b/spec/proxy/tls/cert_authority_spec.cr
@@ -122,6 +122,49 @@ describe Gori::Proxy::Tls::CertAuthority do
     end
   end
 
+  it "mints an IP-literal leaf a client verifies by IP (iPAddress SAN, not DNS)" do
+    with_ca_dir do |dir|
+      ca = Gori::Proxy::Tls::CertAuthority.load_or_create(dir)
+      server_ctx = ca.context_for("127.0.0.1")
+
+      client_ctx = OpenSSL::SSL::Context::Client.new
+      ca_cert = Gori::Proxy::Tls::Cert.read_pem(File.join(dir, "root.crt.pem"))
+      store = LibSSL.ssl_ctx_get_cert_store(client_ctx.to_unsafe)
+      LibCrypto.x509_store_add_cert(store, ca_cert.handle)
+
+      tcp_server = TCPServer.new("127.0.0.1", 0)
+      port = tcp_server.local_address.port
+      result = Channel(String).new
+
+      spawn do
+        conn = tcp_server.accept
+        ssl = OpenSSL::SSL::Socket::Server.new(conn, server_ctx, sync_close: true)
+        ssl.puts(ssl.gets)
+        ssl.flush
+        ssl.close
+      rescue ex
+        result.send("server-error: #{ex.message}")
+      end
+
+      spawn do
+        tcp = TCPSocket.new("127.0.0.1", port)
+        # hostname "127.0.0.1" → OpenSSL verifies the literal IP against the
+        # iPAddress SAN. A DNS:127.0.0.1 SAN (the old bug) fails this, exactly like
+        # curl rejected it with "subjectAltName does not match ipv4 address".
+        ssl = OpenSSL::SSL::Socket::Client.new(tcp, context: client_ctx, sync_close: true, hostname: "127.0.0.1")
+        ssl.puts("ping")
+        ssl.flush
+        echo = ssl.gets
+        ssl.close
+        result.send("ok: #{echo}")
+      rescue ex
+        result.send("client-error: #{ex.class}: #{ex.message}")
+      end
+
+      result.receive.should eq("ok: ping")
+    end
+  end
+
   it "caches the context per host" do
     with_ca_dir do |dir|
       ca = Gori::Proxy::Tls::CertAuthority.load_or_create(dir)
@@ -139,8 +182,8 @@ describe Gori::Proxy::Tls::CertAuthority do
 
       ca.regenerate!
 
-      ca.ca_cert_pem.should_not eq(old_pem)         # a brand-new root identity
-      ca.spki_sha256_base64.should_not eq(old_spki) # new key → new SPKI pin
+      ca.ca_cert_pem.should_not eq(old_pem)            # a brand-new root identity
+      ca.spki_sha256_base64.should_not eq(old_spki)    # new key → new SPKI pin
       ca.context_for("a.test").should_not be(old_leaf) # stale leaf evicted
       # The swap is persisted: a reload reads the NEW root, not the old one.
       Gori::Proxy::Tls::CertAuthority.load_or_create(dir).ca_cert_pem.should eq(ca.ca_cert_pem)

--- a/spec/ql_spec.cr
+++ b/spec/ql_spec.cr
@@ -249,11 +249,12 @@ describe "Gori::Store#search (QL)" do
     end
   end
 
-  it "scans a binary / invalid-UTF-8 body with body~ without crashing the query" do
+  it "scans a binary / invalid-UTF-8 body with body~ past a NUL without crashing" do
     tmp_store do |store|
-      # leading invalid-UTF-8 bytes + an embedded NUL (the SQLite REGEXP callback
-      # builds the haystack with String.new(ptr), which stops at NUL and does not
-      # validate UTF-8). The scan must run over this row without raising.
+      # leading invalid-UTF-8 bytes + an embedded NUL with "ABC" AFTER it. The scan
+      # must (1) not crash on the invalid UTF-8 (scrubbed) and (2) still see content
+      # past the NUL — the haystack is read by its true byte length (value_bytes),
+      # not the NUL-terminated value_text.
       bin = store.insert_flow(Gori::Store::CapturedRequest.new(
         created_at: 1_i64, scheme: "http", host: "bin.test", port: 80,
         method: "GET", target: "/img", http_version: "HTTP/1.1",
@@ -265,8 +266,8 @@ describe "Gori::Store#search (QL)" do
         head: "POST / HTTP/1.1\r\nHost: txt.test\r\n\r\n".to_slice,
         body: "hello ABC world".to_slice))
 
-      # REGEXP runs over BOTH rows; the binary one must not crash the query.
-      store.search(Gori::QL.parse("body~ABC"), 50).map(&.id).should eq([text])
+      # Both match now: the binary row's "ABC" after the NUL is no longer truncated.
+      store.search(Gori::QL.parse("body~ABC"), 50).map(&.id).sort.should eq([bin, text].sort)
     end
   end
 

--- a/spec/ql_spec.cr
+++ b/spec/ql_spec.cr
@@ -85,12 +85,17 @@ describe Gori::QL do
     f.args.should eq(["%ab%", "%ab%"])
   end
 
-  it "compiles size: as a numeric comparison on response_size" do
+  it "compiles size: as a comparison on the TOTAL (req+resp), matching the displayed size" do
     f = Gori::QL.parse("size:>1000")
-    f.sql.should eq("(response_size > ?)")
+    f.sql.should eq("((request_size + COALESCE(response_size, 0)) > ?)")
     f.args.should eq([1000_i64])
-    Gori::QL.parse("size:<=500").sql.should eq("(response_size <= ?)")
-    Gori::QL.parse("size:0").sql.should eq("(response_size = ?)") # bare value → equality
+    Gori::QL.parse("size:<=500").sql.should eq("((request_size + COALESCE(response_size, 0)) <= ?)")
+    Gori::QL.parse("size:0").sql.should eq("((request_size + COALESCE(response_size, 0)) = ?)") # bare → equality
+  end
+
+  it "compiles reqsize: / respsize: against a single side" do
+    Gori::QL.parse("reqsize:>1000").sql.should eq("(request_size > ?)")
+    Gori::QL.parse("respsize:<500").sql.should eq("(response_size < ?)")
   end
 
   it "compiles dur: as milliseconds against duration_us, honouring ms/s suffixes" do
@@ -265,7 +270,7 @@ describe "Gori::Store#search (QL)" do
     end
   end
 
-  it "filters by response size and duration (size: / dur:), excluding pending rows" do
+  it "filters by total size and duration; respsize:/dur: exclude pending rows" do
     tmp_store do |store|
       big = store.insert_flow(Gori::Store::CapturedRequest.new(
         created_at: 1_i64, scheme: "http", host: "acme.test", port: 80,
@@ -285,12 +290,16 @@ describe "Gori::Store#search (QL)" do
 
       pending = capture(store, "acme.test", "GET", "/pending") # no response → NULL size/dur
 
-      store.search(Gori::QL.parse("size:>10000"), 50).map(&.id).should eq([big])
-      store.search(Gori::QL.parse("dur:>500"), 50).map(&.id).should eq([big])   # 500ms
-      store.search(Gori::QL.parse("dur:<100"), 50).map(&.id).should eq([small]) # 100ms
+      store.search(Gori::QL.parse("size:>10000"), 50).map(&.id).should eq([big]) # total ~20KB
+      store.search(Gori::QL.parse("dur:>500"), 50).map(&.id).should eq([big])    # 500ms
+      store.search(Gori::QL.parse("dur:<100"), 50).map(&.id).should eq([small])  # 100ms
 
-      # NULL response_size / duration_us never satisfy a numeric comparison
-      store.search(Gori::QL.parse("size:>=0"), 50).map(&.id).should_not contain(pending)
+      # size: spans the TOTAL (incl. the request), so a pending flow matches on its
+      # request bytes — consistent with the displayed `size` column.
+      store.search(Gori::QL.parse("size:>=0"), 50).map(&.id).should contain(pending)
+      # respsize:/dur: target a response-only column that's NULL until the response
+      # lands, so a pending flow never matches them.
+      store.search(Gori::QL.parse("respsize:>=0"), 50).map(&.id).should_not contain(pending)
       store.search(Gori::QL.parse("dur:>=0"), 50).map(&.id).should_not contain(pending)
     end
   end

--- a/spec/replay/h2_engine_spec.cr
+++ b/spec/replay/h2_engine_spec.cr
@@ -76,6 +76,56 @@ private def start_h2_origin_truncated(status : Int32, partial : String) : Int32
   port
 end
 
+# A cleartext-h2 origin that ENFORCES flow control: it sends `body` as DATA frames
+# but never exceeds the available connection/stream window (both start at the 65535
+# default), blocking for the client's WINDOW_UPDATE frames to replenish. A client
+# that never sends WINDOW_UPDATE stalls past 65535 bytes (the bug this guards).
+private def start_h2_origin_flow_controlled(status : Int32, body : Bytes) : Int32
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    next unless conn = origin.accept?
+    conn.read_timeout = 5.seconds
+    Frame.read_preface(conn)
+    # drain to the request's END_STREAM (a body-less GET)
+    loop do
+      f = Frame.read(conn)
+      break if f.nil?
+      break if f.frame_type == Frame::Type::Headers && f.stream_id == 1 && f.end_stream?
+    end
+    conn.write(Frame::Header.new(Frame::Type::Settings.value, 0_u8, 0_u32, Bytes.empty).to_bytes)
+    sb = HPACK::Encoder.new.encode([{":status", status.to_s}])
+    conn.write(Frame::Header.new(Frame::Type::Headers.value, Frame::END_HEADERS, 1_u32, sb).to_bytes)
+    conn.flush
+
+    conn_win = 65535
+    stream_win = 65535
+    offset = 0
+    begin
+      while offset < body.size
+        while conn_win <= 0 || stream_win <= 0
+          f = Frame.read(conn)
+          break if f.nil?
+          next unless f.frame_type == Frame::Type::WindowUpdate
+          inc = (IO::ByteFormat::BigEndian.decode(UInt32, f.payload) & 0x7fff_ffff).to_i
+          f.stream_id == 0 ? (conn_win += inc) : (stream_win += inc)
+        end
+        n = {16384, body.size - offset, conn_win, stream_win}.min
+        last = offset + n >= body.size
+        conn.write(Frame::Header.new(Frame::Type::Data.value, last ? Frame::END_STREAM : 0_u8, 1_u32, body[offset, n]).to_bytes)
+        conn.flush
+        conn_win -= n
+        stream_win -= n
+        offset += n
+      end
+      sleep 0.2.seconds
+    rescue
+    end
+    conn.close
+  end
+  port
+end
+
 describe Gori::Replay::H2Engine do
   it "replays a GET as real cleartext h2 and reassembles the response" do
     seen = Channel(String).new(1)
@@ -99,7 +149,7 @@ describe Gori::Replay::H2Engine do
     request = "GET /trunc HTTP/2\r\n\r\n".to_slice
     result = Gori::Replay::H2Engine.send(request, scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
 
-    result.ok?.should be_true                            # a status + partial body did arrive
+    result.ok?.should be_true # a status + partial body did arrive
     result.response.not_nil!.status.should eq(200)
     String.new(result.body.not_nil!).should eq("partial") # what arrived is captured
     result.incomplete?.should be_true                     # but no END_STREAM — incomplete
@@ -122,5 +172,17 @@ describe Gori::Replay::H2Engine do
       scheme: "http", host: "127.0.0.1", port: 1, verify_upstream: false)
     result.ok?.should be_false
     result.error.should_not be_nil
+  end
+
+  it "credits flow-control windows so a response past the default window completes" do
+    body = Bytes.new(100_000) { |i| (65 + i % 26).to_u8 } # 100 KB > the 65535 window
+    port = start_h2_origin_flow_controlled(200, body)
+
+    result = Gori::Replay::H2Engine.send("GET / HTTP/2\r\nhost: 127.0.0.1\r\n\r\n".to_slice,
+      scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
+
+    result.ok?.should be_true # would time out (incomplete) without WINDOW_UPDATE
+    result.response.not_nil!.status.should eq(200)
+    result.body.not_nil!.size.should eq(100_000)
   end
 end

--- a/spec/replay_spec.cr
+++ b/spec/replay_spec.cr
@@ -38,6 +38,29 @@ describe Gori::Replay::Engine do
     result.ok?.should be_false
     result.error.should_not be_nil
   end
+
+  it "skips interim 1xx responses and returns the final status" do
+    # Origin sends 100 Continue then 103 Early Hints then the real 200.
+    origin = TCPServer.new("127.0.0.1", 0)
+    port = origin.local_address.port
+    spawn do
+      if conn = origin.accept?
+        Gori::Proxy::Codec::Http1.read_head(conn)
+        conn << "HTTP/1.1 100 Continue\r\n\r\n"
+        conn << "HTTP/1.1 103 Early Hints\r\nLink: </s.css>; rel=preload\r\n\r\n"
+        conn << "HTTP/1.1 200 OK\r\nContent-Length: 4\r\nConnection: close\r\n\r\ndone"
+        conn.flush
+        conn.close
+      end
+    end
+
+    result = Gori::Replay::Engine.send("POST /u HTTP/1.1\r\nHost: 127.0.0.1\r\nExpect: 100-continue\r\n\r\n".to_slice,
+      scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
+
+    result.ok?.should be_true
+    result.response.not_nil!.status.should eq(200) # not 100 / 103
+    String.new(result.body.not_nil!).should eq("done")
+  end
 end
 
 describe Gori::Replay::Diff do

--- a/spec/replay_spec.cr
+++ b/spec/replay_spec.cr
@@ -61,6 +61,24 @@ describe Gori::Replay::Engine do
     result.response.not_nil!.status.should eq(200) # not 100 / 103
     String.new(result.body.not_nil!).should eq("done")
   end
+
+  it "gives up (no hang) after too many interim 1xx responses" do
+    origin = TCPServer.new("127.0.0.1", 0)
+    port = origin.local_address.port
+    spawn do
+      if conn = origin.accept?
+        Gori::Proxy::Codec::Http1.read_head(conn)
+        200.times { conn << "HTTP/1.1 103 Early Hints\r\n\r\n"; conn.flush } # > MAX_INTERIM
+        conn.close
+      end
+    rescue
+    end
+
+    result = Gori::Replay::Engine.send("GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n".to_slice,
+      scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
+    result.ok?.should be_false
+    result.error.not_nil!.should contain("too many interim")
+  end
 end
 
 describe Gori::Replay::Diff do

--- a/spec/tui/intercept_view_spec.cr
+++ b/spec/tui/intercept_view_spec.cr
@@ -78,6 +78,27 @@ describe Gori::Tui::InterceptView do
       view.empty?.should be_true
     end
   end
+
+  it "forwards a viewed-but-unedited held body byte-exact (no LF→CRLF rewrite)" do
+    tmp_interceptor do |ic|
+      raw = "POST /e HTTP/1.1\r\nHost: h\r\nContent-Length: 11\r\n\r\nline1\nline2" # bare LF in body
+      hold_req(ic, "h", "/e", raw)
+      view = InterceptView.new
+      view.reload(ic)
+      it = view.selected_item.not_nil!
+
+      view.toggle_edit # OPEN the editor (view only — no keystroke)
+      view.editing?.should be_true
+      # Opening to inspect then forwarding must be byte-exact: the bare LF stays a
+      # bare LF (the TextArea round-trip would otherwise rewrite it to CRLF).
+      String.new(view.forward_bytes(it)).should eq(raw)
+
+      # An actual edit DOES send the edited bytes (line-ending normalization there is
+      # an accepted text-editor limitation).
+      view.edit_insert('X')
+      String.new(view.forward_bytes(it)).should_not eq(raw)
+    end
+  end
 end
 
 describe "Intercept filter bar" do

--- a/spec/tui/intercept_view_spec.cr
+++ b/spec/tui/intercept_view_spec.cr
@@ -99,6 +99,22 @@ describe Gori::Tui::InterceptView do
       String.new(view.forward_bytes(it)).should_not eq(raw)
     end
   end
+
+  it "recomputes Content-Length when an edited held body is forwarded (adds one to a GET)" do
+    tmp_interceptor do |ic|
+      hold_req(ic, "h", "/", "GET / HTTP/1.1\r\nHost: h\r\n\r\n") # no body, no Content-Length
+      view = InterceptView.new
+      view.reload(ic)
+      it = view.selected_item.not_nil!
+      view.toggle_edit
+      view.edit_move(99, 0) # down to the (empty) body line
+      "BODY".each_char { |c| view.edit_insert(c) }
+
+      out = String.new(view.forward_bytes(it))
+      out.should contain("Content-Length: 4") # synthesized so the added body is framed
+      out.should end_with("\r\n\r\nBODY")
+    end
+  end
 end
 
 describe "Intercept filter bar" do

--- a/src/gori/app.cr
+++ b/src/gori/app.cr
@@ -121,13 +121,15 @@ module Gori
       loop do
         event = session.flow_events.receive
         next unless event.kind == :updated # one line per completed/errored flow
-        # A streaming flow (WebSocket, HTTP/2, SSE) emits an :updated PER message /
-        # frame on the SAME id. Print + count it ONCE (its first update), else it
-        # prints duplicate rows and its own messages trip --max, tearing the live
-        # connection down mid-stream.
+        # A WebSocket flow (status 101) emits an :updated PER message on the SAME id;
+        # print + count it ONCE (its first update), else it prints duplicate rows and
+        # its own messages trip --max, tearing the live connection down mid-stream.
         next if seen.includes?(event.id)
         if row = session.store.flow_row(event.id)
-          seen << event.id
+          # Only WS re-emits :updated, so only WS ids need de-dup tracking — keeping
+          # `seen` bounded by concurrent WS flows instead of growing per HTTP flow for
+          # the lifetime of a long `gori run capture` session.
+          seen << event.id if row.status == 101
           # Stream the SAME row rendering `gori run history` prints, so capture and
           # history output never drift (text = human-readable; json = stable contract).
           puts(format == :json ? CLI::Output.flow_row_json(row) : CLI::Output.flow_row_text(row))

--- a/src/gori/app.cr
+++ b/src/gori/app.cr
@@ -117,10 +117,17 @@ module Gori
 
     private def capture_printer(session : Session, format : Symbol, max : Int32?) : Nil
       printed = 0
+      seen = Set(Int64).new
       loop do
         event = session.flow_events.receive
         next unless event.kind == :updated # one line per completed/errored flow
+        # A streaming flow (WebSocket, HTTP/2, SSE) emits an :updated PER message /
+        # frame on the SAME id. Print + count it ONCE (its first update), else it
+        # prints duplicate rows and its own messages trip --max, tearing the live
+        # connection down mid-stream.
+        next if seen.includes?(event.id)
         if row = session.store.flow_row(event.id)
+          seen << event.id
           # Stream the SAME row rendering `gori run history` prints, so capture and
           # history output never drift (text = human-readable; json = stable contract).
           puts(format == :json ? CLI::Output.flow_row_json(row) : CLI::Output.flow_row_text(row))

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -240,7 +240,14 @@ module Gori
       resolved = resolve_mcp_db(db_path, project)
       Log.info { "mcp: serving #{resolved} (actions=#{!read_only})" }
 
-      store = Store.open(resolved, events: nil, retention_flows: 0) # never prune the user's history
+      # Opening a non-SQLite / unreadable file raises deep in the driver; turn that
+      # into a clean error instead of an unhandled backtrace (parity with `gori run`).
+      store =
+        begin
+          Store.open(resolved, events: nil, retention_flows: 0) # never prune the user's history
+        rescue ex : DB::Error | SQLite3::Exception
+          abort "gori mcp: cannot open database #{resolved}: #{ex.message.presence || "not a valid SQLite database (or unreadable)"}"
+        end
       begin
         server = MCP::Server.new(store, allow_actions: !read_only, verify_upstream: !insecure_upstream)
         server.run # blocks until STDIN EOF (client closed)

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -109,6 +109,7 @@ module Gori
         p.on("-h", "--help", "Show this help") { puts p; exit 0 }
         p.on("-v", "--version", "Show version") { puts "gori #{VERSION}"; exit 0 }
         p.invalid_option { |flag| abort "unknown option: #{flag}\n#{p}" }
+        p.missing_option { |flag| abort "missing value for #{flag}" }
       end
       parser.parse(args)
 
@@ -144,6 +145,7 @@ module Gori
         p.on("--edit", "Open the settings file in your editor (settings:editor / $VISUAL / $EDITOR / vi)") { edit = true }
         p.on("-h", "--help", "Show this help") { puts p; exit 0 }
         p.invalid_option { |flag| abort "unknown option: #{flag}\n#{p}" }
+        p.missing_option { |flag| abort "missing value for #{flag}" }
       end
       parser.parse(args)
 
@@ -179,6 +181,7 @@ module Gori
           p.on("--ca-dir=DIR", "Directory for the root CA") { |v| ca_dir = v }
           p.on("-h", "--help") { puts p; exit 0 }
           p.invalid_option { |flag| abort "unknown option: #{flag}\n#{p}" }
+          p.missing_option { |flag| abort "missing value for #{flag}" }
         end
         parser.parse(args[1..])
         Paths.ensure_dirs
@@ -226,6 +229,7 @@ module Gori
         p.on("--read-only", "Disable action tools (send_request, create/update_finding)") { read_only = true }
         p.on("-h", "--help", "Show this help") { puts p; exit 0 }
         p.invalid_option { |flag| abort "unknown option: #{flag}\n#{p}" }
+        p.missing_option { |flag| abort "missing value for #{flag}" }
       end
       parser.parse(args)
 

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -190,10 +190,13 @@ module Gori
         id = take_flow_id(positional, "show")
 
         # Close the store before any abort (abort/exit skip ensure blocks); get_flow
-        # has already loaded the BLOBs we need.
+        # has already loaded the BLOBs we need. A WebSocket flow (101) also carries a
+        # ws_messages log — fetch it now while the store is open.
         store = open_store(resolve_read_project(project_name, db_path))
-        detail = begin
-          store.get_flow(id)
+        detail, ws_msgs = begin
+          d = store.get_flow(id)
+          msgs = d && d.row.status == 101 ? store.ws_messages(id) : [] of Store::WsMessage
+          {d, msgs}
         ensure
           store.close
         end
@@ -203,8 +206,8 @@ module Gori
         show_response = !req_only
         case format
         when :raw  then show_raw(detail, show_request, show_response)
-        when :json then puts show_json(detail, show_request, show_response)
-        else            show_text(detail, show_request, show_response)
+        when :json then puts show_json(detail, show_request, show_response, ws_msgs)
+        else            show_text(detail, show_request, show_response, ws_msgs)
         end
       end
 
@@ -226,7 +229,8 @@ module Gori
         STDOUT.flush
       end
 
-      private def self.show_text(detail : Store::FlowDetail, req : Bool, resp : Bool) : Nil
+      private def self.show_text(detail : Store::FlowDetail, req : Bool, resp : Bool,
+                                 ws_msgs : Array(Store::WsMessage)) : Nil
         if req
           puts "=== REQUEST (#{detail.http_version}) ==="
           print_message_text(detail.request_head, display_body(detail.request_head, detail.request_body))
@@ -244,10 +248,28 @@ module Gori
           elsif detail.error.nil?
             puts "(no response captured)"
           end
+          unless ws_msgs.empty?
+            puts ""
+            puts "=== WEBSOCKET MESSAGES (#{ws_msgs.size}) ==="
+            ws_msgs.each { |m| puts ws_message_text(m) }
+          end
         end
       end
 
-      private def self.show_json(detail : Store::FlowDetail, req : Bool, resp : Bool) : String
+      # "→ out" (client→server) / "← in" (server→client). Text frames print their
+      # (scrubbed) payload; binary frames print a size + short hex preview.
+      private def self.ws_message_text(m : Store::WsMessage) : String
+        arrow = m.direction == "out" ? "→" : "←"
+        if m.text?
+          "#{arrow} #{String.new(m.payload).scrub}"
+        else
+          preview = m.payload[0, {m.payload.size, 16}.min].hexstring
+          "#{arrow} [binary #{m.payload.size}B] #{preview}#{m.payload.size > 16 ? "…" : ""}"
+        end
+      end
+
+      private def self.show_json(detail : Store::FlowDetail, req : Bool, resp : Bool,
+                                 ws_msgs : Array(Store::WsMessage)) : String
         JSON.build do |j|
           j.object do
             j.field "flow" do
@@ -274,6 +296,21 @@ module Gori
                   j.field "body", scrub(resp_body)
                   j.field "body_decoded", resp_decoded
                   j.field "body_truncated", detail.response_body_truncated?
+                end
+              end
+              unless ws_msgs.empty?
+                j.field "ws_messages" do
+                  j.array do
+                    ws_msgs.each do |m|
+                      j.object do
+                        j.field "direction", m.direction
+                        j.field "opcode", m.opcode
+                        j.field "text", m.text?
+                        j.field "payload", m.text? ? String.new(m.payload).scrub : nil
+                        j.field "size", m.payload.size
+                      end
+                    end
+                  end
                 end
               end
             end

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -100,6 +100,7 @@ module Gori
           p.on("--max=N", "Stop after N completed flows") { |v| max = parse_count(v) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.invalid_option { |f| abort "gori run capture: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run capture: missing value for #{f}" }
         end
         parser.parse(args)
 
@@ -130,6 +131,7 @@ module Gori
           p.on("--format=FMT", "Output: text (default) | json (JSON-Lines)") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.invalid_option { |f| abort "gori run history: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run history: missing value for #{f}" }
         end
         parser.parse(args)
 
@@ -181,6 +183,7 @@ module Gori
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args { |rest, _| positional = rest }
           p.invalid_option { |f| abort "gori run show: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run show: missing value for #{f}" }
         end
         parser.parse(args)
         abort "gori run show: --request-only and --response-only are mutually exclusive" if req_only && resp_only
@@ -302,6 +305,7 @@ module Gori
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args { |rest, _| positional = rest }
           p.invalid_option { |f| abort "gori run replay: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run replay: missing value for #{f}" }
         end
         parser.parse(args)
         id = take_flow_id(positional, "replay")
@@ -443,6 +447,7 @@ module Gori
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args { |rest, _| positional = rest }
           p.invalid_option { |f| abort "gori run fuzz: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run fuzz: missing value for #{f}" }
         end
         parser.parse(args)
 
@@ -661,6 +666,7 @@ module Gori
           p.on("--export=PATH", "Write to PATH instead of STDOUT") { |v| export_path = v }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.invalid_option { |f| abort "gori run findings: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run findings: missing value for #{f}" }
         end
         parser.parse(args)
 
@@ -719,6 +725,7 @@ module Gori
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.invalid_option { |f| abort "gori run projects: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run projects: missing value for #{f}" }
         end
         parser.parse(args)
 

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -708,8 +708,10 @@ module Gori
       private def self.findings_text(findings : Array(Store::Finding)) : String
         String.build do |io|
           findings.each do |f|
-            io << '#' << f.id << "  [" << f.severity.label << '/' << f.status.label << "]  " << f.title
-            io << "  (" << f.host << ')' if f.host
+            io << '#' << f.id << "  [" << f.severity.label << '/' << f.status.label << "]  " << Findings::Export.one_line(f.title)
+            if h = f.host
+              io << "  (" << Findings::Export.one_line(h) << ')'
+            end
             io << "  flow#" << f.flow_id if f.flow_id
             io << '\n'
           end

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -360,6 +360,7 @@ module Gori
         override = target_override # copy the closured flag into a plain local so || narrows
         scheme, host, port = Replay::FlowRequest.parse_target(override || built.target)
         abort "gori run replay: could not determine a target host" if host.empty?
+        abort "gori run replay: unsupported target scheme #{scheme.inspect} (use http:// or https://)" unless scheme.in?("http", "https")
         use_h2 = force_h2 || built.http2
         verify = !insecure
         result = use_h2 ? Replay::H2Engine.send(built.bytes, scheme: scheme, host: host, port: port, verify_upstream: verify) : Replay::Engine.send(built.bytes, scheme: scheme, host: host, port: port, verify_upstream: verify)
@@ -611,6 +612,7 @@ module Gori
         target = override || default_target || abort("gori run fuzz: --target is required for --request/stdin")
         scheme, host, port = Replay::FlowRequest.parse_target(target)
         abort "gori run fuzz: could not determine a target host" if host.empty?
+        abort "gori run fuzz: unsupported target scheme #{scheme.inspect} (use http:// or https://)" unless scheme.in?("http", "https")
         {scheme, host, port}
       end
 

--- a/src/gori/findings_export.cr
+++ b/src/gori/findings_export.cr
@@ -17,7 +17,7 @@ module Gori
           io << "_" << findings.size << " findings · exported " << Time.local.to_s("%Y-%m-%d %H:%M") << "_\n"
           findings.each do |f|
             flow = f.flow_id.try { |fid| store.get_flow(fid) }
-            io << "\n## [" << f.severity.label << "] " << f.title << "\n\n"
+            io << "\n## [" << f.severity.label << "] " << one_line(f.title) << "\n\n"
             io << "- **Severity:** " << f.severity.label << "\n"
             io << "- **Status:** " << f.status.label << "\n"
             io << "- **Host:** " << (f.host || "—") << "\n"
@@ -59,28 +59,60 @@ module Gori
         end
       end
 
+      # Collapse control characters (CR/LF/tab/…) to a single space so a value with
+      # embedded newlines can't break the single-line structure it sits in — a
+      # Markdown heading here, a one-row line in the text export. Shared with
+      # `gori run findings --format text`.
+      def self.one_line(s : String) : String
+        s.gsub(/[[:cntrl:]]+/, " ").strip
+      end
+
       private def self.append_evidence(io : String::Builder, label : String, head : Bytes?, body : Bytes?) : Nil
         return if head.nil? || head.empty?
         cap = EVIDENCE_CAP
-        io << "\n### " << label << "\n\n```http\n"
-        # HEAD: headers are text but can carry stray non-UTF-8 (obs-text) bytes — scrub
-        # them so the report stays a valid UTF-8 file; cap it like the body. rstrip the
-        # header block's trailing CRLF CRLF so a single blank line (added below) sits
-        # between headers and body instead of a stack of empty lines.
-        hslice = head.size > cap ? head[0, cap] : head
-        io << String.new(hslice).scrub.rstrip
-        io << "\n\n[… headers truncated, #{head.size} bytes total …]" if head.size > cap
-        if body && !body.empty?
-          slice = body[0, {body.size, cap}.min]
-          text = String.new(slice)
-          if text.valid_encoding?
-            io << "\n\n" << text
-            io << "\n\n[… body truncated, #{body.size} bytes total …]" if body.size > cap
-          else
-            io << "\n\n[binary body omitted, #{body.size} bytes]"
+        # Build the embedded request/response text first, THEN pick a fence longer
+        # than any backtick run inside it. Bodies are fully attacker-controlled
+        # (proxied traffic), so a bare ``` line in a body would otherwise close the
+        # ```http fence early and inject live Markdown/HTML into the shared report.
+        content = String.build do |c|
+          # HEAD: headers are text but can carry stray non-UTF-8 (obs-text) bytes —
+          # scrub them so the report stays valid UTF-8; cap it like the body. rstrip
+          # the header block's trailing CRLF CRLF so a single blank line (added
+          # below) sits between headers and body instead of a stack of empty lines.
+          hslice = head.size > cap ? head[0, cap] : head
+          c << String.new(hslice).scrub.rstrip
+          c << "\n\n[… headers truncated, #{head.size} bytes total …]" if head.size > cap
+          if body && !body.empty?
+            slice = body[0, {body.size, cap}.min]
+            text = String.new(slice)
+            if text.valid_encoding?
+              c << "\n\n" << text
+              c << "\n\n[… body truncated, #{body.size} bytes total …]" if body.size > cap
+            else
+              c << "\n\n[binary body omitted, #{body.size} bytes]"
+            end
           end
         end
-        io << "\n```\n"
+        fence = "`" * fence_len(content)
+        io << "\n### " << label << "\n\n" << fence << "http\n"
+        io << content << "\n" << fence << "\n"
+      end
+
+      # A CommonMark fenced block is closed only by a line of >= as many backticks
+      # as the opener, so use one more than the longest backtick run in the content
+      # (minimum 3) — guaranteeing no embedded line can terminate it.
+      private def self.fence_len(content : String) : Int32
+        longest = 0
+        run = 0
+        content.each_char do |ch|
+          if ch == '`'
+            run += 1
+            longest = run if run > longest
+          else
+            run = 0
+          end
+        end
+        {3, longest + 1}.max
       end
     end
   end

--- a/src/gori/findings_export.cr
+++ b/src/gori/findings_export.cr
@@ -20,7 +20,7 @@ module Gori
             io << "\n## [" << f.severity.label << "] " << one_line(f.title) << "\n\n"
             io << "- **Severity:** " << f.severity.label << "\n"
             io << "- **Status:** " << f.status.label << "\n"
-            io << "- **Host:** " << (f.host || "—") << "\n"
+            io << "- **Host:** " << (f.host.try { |h| one_line(h) } || "—") << "\n"
             if fid = f.flow_id
               io << "- **Flow:** "
               if flow

--- a/src/gori/fuzz/content_length.cr
+++ b/src/gori/fuzz/content_length.cr
@@ -39,19 +39,20 @@ module Gori::Fuzz
       io.to_slice
     end
 
-    # Locate the head/body separator: prefer CRLFCRLF, fall back to LFLF. Returns the
-    # separator's start index (nil if none), its width, and the head's line ending.
+    # Locate the head/body separator = the FIRST blank line, whether CRLFCRLF or
+    # LFLF. Returns its start index (nil if none), width, and line ending. A single
+    # left-to-right scan (not "all CRLFCRLF, then all LFLF") matters when the head is
+    # LF-terminated but the BODY contains a CRLFCRLF: scanning all CRLFCRLF first would
+    # find the body's and split at the wrong place. A well-formed CRLF head has no
+    # LFLF inside it, so this is unchanged for normal CRLF messages.
     private def self.boundary(bytes : Bytes) : {Int32?, Int32, String}
       i = 0
-      while i + 3 < bytes.size
-        if bytes[i] == 0x0d_u8 && bytes[i + 1] == 0x0a_u8 && bytes[i + 2] == 0x0d_u8 && bytes[i + 3] == 0x0a_u8
+      while i + 1 < bytes.size
+        return {i, 2, "\n"} if bytes[i] == 0x0a_u8 && bytes[i + 1] == 0x0a_u8 # LFLF
+        if i + 3 < bytes.size && bytes[i] == 0x0d_u8 && bytes[i + 1] == 0x0a_u8 &&
+           bytes[i + 2] == 0x0d_u8 && bytes[i + 3] == 0x0a_u8 # CRLFCRLF
           return {i, 4, "\r\n"}
         end
-        i += 1
-      end
-      i = 0
-      while i + 1 < bytes.size
-        return {i, 2, "\n"} if bytes[i] == 0x0a_u8 && bytes[i + 1] == 0x0a_u8
         i += 1
       end
       {nil, 0, "\r\n"}

--- a/src/gori/fuzz/generator.cr
+++ b/src/gori/fuzz/generator.cr
@@ -138,8 +138,12 @@ module Gori::Fuzz
     end
 
     private def cluster_total : Int64?
+      return nil if @sets.empty?
+      # Use set_for(p) (with the set-0 fallback) exactly like each()/recurse() do —
+      # otherwise a run with fewer payload sets than positions reports an unknown
+      # ('?') total and demands --force, even though it's perfectly bounded.
       acc = 1_i64.as(Int64?)
-      (0...@template.position_count).each { |p| acc = mul(acc, @sets[p]?.try(&.size)) }
+      (0...@template.position_count).each { |p| acc = mul(acc, set_for(p).size) }
       acc
     end
 

--- a/src/gori/fuzz/template.cr
+++ b/src/gori/fuzz/template.cr
@@ -59,8 +59,12 @@ module Gori::Fuzz
           if closed
             defs << val.to_s
             i = j + 1
-          else # unbalanced trailing § → literal, no position
-            lit << MARKER << val.to_s
+          else # unbalanced trailing § → literal text, opens no position
+            # The preceding literal was optimistically pushed as a segment above;
+            # fold it back (with the § and the trailing chars) into `lit` so the
+            # tail lands in the FINAL segment. Otherwise render() — which emits only
+            # positions.size + 1 segments — would silently drop these trailing bytes.
+            lit << (segs.pop? || "") << MARKER << val.to_s
             i = n
           end
         else
@@ -191,9 +195,12 @@ module Gori::Fuzz
     end
 
     # Wrap the value after `=` in each `sep`-separated pair (leading space preserved).
+    # An EMPTY value (`a=`) is left unmarked: a bare `§§` parses as an escaped literal
+    # § (injecting a stray byte and creating no position), so empty values can't be
+    # auto-marked — wrap them by hand with an explicit default if you want to fuzz them.
     private def self.mark_pairs(s : String, sep : Char) : String
       s.split(sep).map do |pair|
-        (eq = pair.index('=')) ? "#{pair[0..eq]}#{MARKER}#{pair[(eq + 1)..]}#{MARKER}" : pair
+        (eq = pair.index('=')) && eq + 1 < pair.size ? "#{pair[0..eq]}#{MARKER}#{pair[(eq + 1)..]}#{MARKER}" : pair
       end.join(sep)
     end
 
@@ -213,9 +220,13 @@ module Gori::Fuzz
       body.includes?('=') && !body.includes?('\n') && !body.lstrip.starts_with?('{')
     end
 
-    # Wrap JSON string and number values (best-effort; keys are left alone).
+    # Wrap JSON string and number values (best-effort; keys are left alone). An
+    # EMPTY string value (`"k":""`) is skipped — `§§` would parse as a literal § and
+    # inject a stray byte (also producing invalid JSON), so empty values stay inert.
     private def self.mark_json(body : String) : String
-      out = body.gsub(/("(?:[^"\\]|\\.)*"\s*:\s*")((?:[^"\\]|\\.)*)(")/) { "#{$1}#{MARKER}#{$2}#{MARKER}#{$3}" }
+      out = body.gsub(/("(?:[^"\\]|\\.)*"\s*:\s*")((?:[^"\\]|\\.)*)(")/) do |m|
+        $2.empty? ? m : "#{$1}#{MARKER}#{$2}#{MARKER}#{$3}"
+      end
       out.gsub(/("(?:[^"\\]|\\.)*"\s*:\s*)(-?\d+(?:\.\d+)?)/) { "#{$1}#{MARKER}#{$2}#{MARKER}" }
     end
 

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -232,8 +232,28 @@ module Gori::Proxy
         release_upstream
         return false
       end
-      ttfb = (Time.instant - started).total_microseconds.to_i64
       resp = Codec::Http1.parse_response_head(resp_head)
+
+      # Interim 1xx (RFC 9110 §15.2): an informational response (100 Continue,
+      # 103 Early Hints, …) is NOT the final response. A conformant proxy forwards
+      # it to the client verbatim and keeps reading until the final (>=200) status;
+      # otherwise the real response is stranded on the upstream socket — it gets
+      # wrongly recorded as THIS flow's response AND served to the next reused
+      # request on this connection (response desync). 101 Switching Protocols is the
+      # exception: it is terminal (the protocol upgrade), so it falls through to the
+      # normal path (WebSocket handling below).
+      while interim_response?(resp)
+        @io.write(resp_head) # forward byte-exact (P6/P7); no rewrite on interim
+        @io.flush
+        resp_head = Codec::Http1.read_head(upstream)
+        if resp_head.nil?
+          @sink.on_response(FlowMapper.error_response(flow_id, "upstream closed after interim 1xx response"))
+          release_upstream
+          return false
+        end
+        resp = Codec::Http1.parse_response_head(resp_head)
+      end
+      ttfb = (Time.instant - started).total_microseconds.to_i64
 
       # Match&Replace (response head). Framing/keep-alive/upgrade stay on the
       # ORIGINAL response so the upstream body is read correctly.
@@ -379,6 +399,13 @@ module Gori::Proxy
 
     private def websocket_upgrade?(resp : Codec::RawResponse) : Bool
       resp.status == 101 && resp.headers.get?("Upgrade").try(&.downcase) == "websocket"
+    end
+
+    # An interim 1xx informational response (100 Continue / 102 / 103 Early Hints /
+    # …) — forwarded to the client, then skipped to read the final status. 101
+    # Switching Protocols is terminal (handled as an upgrade), so it is NOT interim.
+    private def interim_response?(resp : Codec::RawResponse) : Bool
+      resp.status >= 100 && resp.status < 200 && resp.status != 101
     end
 
     # CONNECT host:port -> 200, then TLS MITM (if configured) or blind tunnel.

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -11,7 +11,6 @@ require "../upstream"
 require "../pump"
 require "../ws/relay"
 require "../../flow_mapper"
-require "../../fuzz/content_length"
 
 module Gori::Proxy
   # Handles one client connection over an `IO` (a plaintext TCPSocket, or — after
@@ -20,6 +19,10 @@ module Gori::Proxy
   # loop, forwards them byte-faithfully, captures the request/response pair, and
   # streams the response back.
   class ClientConn
+    # Max consecutive interim 1xx responses to forward before giving up — a guard
+    # against a hostile upstream streaming an unbounded run of body-less 103s.
+    MAX_INTERIM = 64
+
     # `fixed_host`/`fixed_port` pin all requests to one origin (post-CONNECT TLS
     # tunnel); when nil the upstream is resolved per request from the target /
     # Host header (plaintext forward proxy). `tls_upstream` wraps the origin
@@ -163,17 +166,11 @@ module Gori::Proxy
         write_intercept_drop
         return false
       end
-      # forward (edited or original): re-parse the sent head for capture (P7).
-      # Recompute Content-Length to match the (possibly edited) body — like Burp's
-      # default. A human who grows/shrinks a held body would otherwise desync the
-      # origin, which reads only the stale CL's worth and truncates the rest.
-      # add_when_missing: true so adding a body to a request that had none (e.g. a
-      # GET) ALSO gets a Content-Length — otherwise the body is unframed: the origin
-      # drops it AND the bytes strand on the keep-alive upstream, prepended to the
-      # next reused request (smuggling). No-ops on chunked / already-correct, so an
-      # unedited forward stays byte-exact; byte-exact CL-mismatch smuggling tests go
-      # through replay/fuzz, not the editor.
-      sent_head, edited_body = split_message(Fuzz::ContentLength.sync(decision.bytes, add_when_missing: true))
+      # forward the decision bytes BYTE-EXACT (P7): re-parse the sent head for capture.
+      # The intercept editor owns the "update Content-Length" decision (it knows what
+      # was edited) — see InterceptView#forward_bytes; the proxy must not rewrite bytes
+      # the human chose to send (e.g. a deliberately CL-mismatched smuggling probe).
+      sent_head, edited_body = split_message(decision.bytes)
       sent_req = Codec::Http1.parse_request_head(sent_head)
       retryable = retryable_request?(req, edited_body.nil? || edited_body.empty?)
       upstream, reused, sent = acquire_and_send(host, port, retryable) { |up| write_request(up, sent_head, edited_body) }
@@ -252,6 +249,7 @@ module Gori::Proxy
       # request on this connection (response desync). 101 Switching Protocols is the
       # exception: it is terminal (the protocol upgrade), so it falls through to the
       # normal path (WebSocket handling below).
+      interim_seen = 0
       while interim_response?(resp)
         # RFC 9112 §6: a 1xx response MUST NOT carry content. An interim that declares
         # a body (Content-Length / Transfer-Encoding) is malformed AND a desync vector
@@ -263,8 +261,20 @@ module Gori::Proxy
           release_upstream
           return false
         end
-        @io.write(resp_head) # forward byte-exact (P6/P7); no rewrite on interim
-        @io.flush
+        # Cap consecutive 1xx (like Burp/nginx) so a hostile upstream streaming endless
+        # body-less 103s can't spin this fiber forever / flood the client (per-conn DoS).
+        interim_seen += 1
+        if interim_seen > MAX_INTERIM
+          @sink.on_response(FlowMapper.error_response(flow_id, "too many interim 1xx responses (>#{MAX_INTERIM})"))
+          release_upstream
+          return false
+        end
+        # RFC 9110 §15.2 / RFC 7231: a proxy MUST NOT forward a 1xx to an HTTP/1.0
+        # client (it can't parse it). Read past it for everyone; forward only to 1.1.
+        if req.version == "HTTP/1.1"
+          @io.write(resp_head) # forward byte-exact (P6/P7); no rewrite on interim
+          @io.flush
+        end
         resp_head = Codec::Http1.read_head(upstream)
         if resp_head.nil?
           @sink.on_response(FlowMapper.error_response(flow_id, "upstream closed after interim 1xx response"))
@@ -383,10 +393,11 @@ module Gori::Proxy
         release_upstream
         return false
       end
-      # Sync Content-Length to the (possibly edited) body so the client isn't fed a
-      # stale length (truncation) or an unframed body. No-ops on chunked / already-
-      # correct (P7-preserving for an unedited forward).
-      out_head, out_body = split_message(Fuzz::ContentLength.sync(decision.bytes, add_when_missing: true))
+      # Forward the decision bytes BYTE-EXACT (P7); the editor already synced
+      # Content-Length for an edited body (InterceptView#forward_bytes). Keeping the
+      # proxy byte-exact also preserves the head verbatim for a HEAD/304/204 response
+      # forwarded unedited (whose Content-Length describes the entity, not the bytes).
+      out_head, out_body = split_message(decision.bytes)
       sent_resp = Codec::Http1.parse_response_head(out_head)
       @io.write(out_head)
       @io.write(out_body) if out_body

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -11,6 +11,7 @@ require "../upstream"
 require "../pump"
 require "../ws/relay"
 require "../../flow_mapper"
+require "../../fuzz/content_length"
 
 module Gori::Proxy
   # Handles one client connection over an `IO` (a plaintext TCPSocket, or — after
@@ -163,7 +164,12 @@ module Gori::Proxy
         return false
       end
       # forward (edited or original): re-parse the sent head for capture (P7).
-      sent_head, edited_body = split_message(decision.bytes)
+      # Recompute Content-Length to match the (possibly edited) body — like Burp's
+      # default. A human who grows/shrinks a held body would otherwise desync the
+      # origin, which reads only the stale CL's worth and truncates the rest.
+      # No-ops on chunked / already-correct, so an unedited forward stays byte-exact;
+      # byte-exact CL-mismatch smuggling tests go through replay/fuzz, not the editor.
+      sent_head, edited_body = split_message(Fuzz::ContentLength.sync(decision.bytes))
       sent_req = Codec::Http1.parse_request_head(sent_head)
       retryable = retryable_request?(req, edited_body.nil? || edited_body.empty?)
       upstream, reused, sent = acquire_and_send(host, port, retryable) { |up| write_request(up, sent_head, edited_body) }
@@ -363,7 +369,10 @@ module Gori::Proxy
         release_upstream
         return false
       end
-      out_head, out_body = split_message(decision.bytes)
+      # Sync Content-Length to the (possibly edited) body so the client isn't fed a
+      # stale length (truncation). No-ops on chunked / already-correct (P7-preserving
+      # for an unedited forward).
+      out_head, out_body = split_message(Fuzz::ContentLength.sync(decision.bytes))
       sent_resp = Codec::Http1.parse_response_head(out_head)
       @io.write(out_head)
       @io.write(out_body) if out_body

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -167,9 +167,13 @@ module Gori::Proxy
       # Recompute Content-Length to match the (possibly edited) body — like Burp's
       # default. A human who grows/shrinks a held body would otherwise desync the
       # origin, which reads only the stale CL's worth and truncates the rest.
-      # No-ops on chunked / already-correct, so an unedited forward stays byte-exact;
-      # byte-exact CL-mismatch smuggling tests go through replay/fuzz, not the editor.
-      sent_head, edited_body = split_message(Fuzz::ContentLength.sync(decision.bytes))
+      # add_when_missing: true so adding a body to a request that had none (e.g. a
+      # GET) ALSO gets a Content-Length — otherwise the body is unframed: the origin
+      # drops it AND the bytes strand on the keep-alive upstream, prepended to the
+      # next reused request (smuggling). No-ops on chunked / already-correct, so an
+      # unedited forward stays byte-exact; byte-exact CL-mismatch smuggling tests go
+      # through replay/fuzz, not the editor.
+      sent_head, edited_body = split_message(Fuzz::ContentLength.sync(decision.bytes, add_when_missing: true))
       sent_req = Codec::Http1.parse_request_head(sent_head)
       retryable = retryable_request?(req, edited_body.nil? || edited_body.empty?)
       upstream, reused, sent = acquire_and_send(host, port, retryable) { |up| write_request(up, sent_head, edited_body) }
@@ -249,6 +253,16 @@ module Gori::Proxy
       # exception: it is terminal (the protocol upgrade), so it falls through to the
       # normal path (WebSocket handling below).
       while interim_response?(resp)
+        # RFC 9112 §6: a 1xx response MUST NOT carry content. An interim that declares
+        # a body (Content-Length / Transfer-Encoding) is malformed AND a desync vector
+        # — its "body" can embed a fake final response while the real one is stranded
+        # for the next reused request. Refuse it: close the connection (don't parse a
+        # body as the next response, don't reuse the upstream).
+        if interim_has_body?(resp)
+          @sink.on_response(FlowMapper.error_response(flow_id, "malformed interim 1xx response (declared a body)"))
+          release_upstream
+          return false
+        end
         @io.write(resp_head) # forward byte-exact (P6/P7); no rewrite on interim
         @io.flush
         resp_head = Codec::Http1.read_head(upstream)
@@ -370,9 +384,9 @@ module Gori::Proxy
         return false
       end
       # Sync Content-Length to the (possibly edited) body so the client isn't fed a
-      # stale length (truncation). No-ops on chunked / already-correct (P7-preserving
-      # for an unedited forward).
-      out_head, out_body = split_message(Fuzz::ContentLength.sync(decision.bytes))
+      # stale length (truncation) or an unframed body. No-ops on chunked / already-
+      # correct (P7-preserving for an unedited forward).
+      out_head, out_body = split_message(Fuzz::ContentLength.sync(decision.bytes, add_when_missing: true))
       sent_resp = Codec::Http1.parse_response_head(out_head)
       @io.write(out_head)
       @io.write(out_body) if out_body
@@ -415,6 +429,12 @@ module Gori::Proxy
     # Switching Protocols is terminal (handled as an upgrade), so it is NOT interim.
     private def interim_response?(resp : Codec::RawResponse) : Bool
       resp.status >= 100 && resp.status < 200 && resp.status != 101
+    end
+
+    # A 1xx that illegally declares body framing (Content-Length / Transfer-Encoding)
+    # — malformed per RFC 9112 §6 and a response-smuggling vector.
+    private def interim_has_body?(resp : Codec::RawResponse) : Bool
+      !!(resp.headers.get?("Content-Length") || resp.headers.get?("Transfer-Encoding"))
     end
 
     # CONNECT host:port -> 200, then TLS MITM (if configured) or blind tunnel.

--- a/src/gori/proxy/tls/cert_builder.cr
+++ b/src/gori/proxy/tls/cert_builder.cr
@@ -40,7 +40,7 @@ module Gori::Proxy::Tls
         LibCrypto.x509_set_pubkey(x, pubkey.handle)
 
         add_ext(x, NID_BASIC_CONSTR, is_ca ? "critical,CA:TRUE" : "critical,CA:FALSE")
-        add_ext(x, NID_SUBJECT_ALT, "DNS:#{san_dns}") if san_dns && safe_san?(san_dns)
+        add_ext(x, NID_SUBJECT_ALT, san_value(san_dns)) if san_dns && safe_san?(san_dns)
 
         raise Gori::Error.new("X509_sign failed") if LibCrypto.x509_sign(x, signing_key.handle, LibCrypto.evp_sha256) == 0
         Cert.new(x)
@@ -58,6 +58,20 @@ module Gori::Proxy::Tls
     # that bogus host — the safe outcome) rather than minting an injected cert.
     private def self.safe_san?(host : String) : Bool
       !host.empty? && host.bytesize <= 253 && (host =~ /\A[A-Za-z0-9.\-*]+\z/) != nil
+    end
+
+    # An IP-literal CONNECT/SNI target must get an iPAddress SAN, not a dNSName:
+    # RFC 6125 / RFC 2818 clients (curl, browsers) verify a literal IP against an
+    # iPAddress SAN and reject a cert that only carries DNS:1.2.3.4 — which blocked
+    # MITM of any HTTPS target addressed by IP. The IPv4 character set is a subset
+    # of safe_san?'s, so this stays injection-safe.
+    private def self.san_value(host : String) : String
+      ipv4?(host) ? "IP:#{host}" : "DNS:#{host}"
+    end
+
+    private def self.ipv4?(host : String) : Bool
+      octets = host.split('.')
+      octets.size == 4 && octets.all? { |o| o.to_u8? != nil }
     end
 
     private def self.add_ext(x : LibCrypto::X509, nid : Int32, value : String) : Nil

--- a/src/gori/proxy/tls/cert_builder.cr
+++ b/src/gori/proxy/tls/cert_builder.cr
@@ -69,9 +69,19 @@ module Gori::Proxy::Tls
       ipv4?(host) ? "IP:#{host}" : "DNS:#{host}"
     end
 
+    # CANONICAL dotted-quad only. OpenSSL's IP-SAN parser (a2i_GENERAL_NAME) rejects
+    # zero-padded octets ("01.02.03.04"), so accepting them here would emit an
+    # IP:<host> SAN that fails X509V3_EXT_nconf_nid → the leaf mint aborts and the
+    # TLS MITM handshake tears down. A non-canonical IP falls through to a DNS SAN
+    # instead (harmless: it just won't verify for that odd literal), never a crash.
     private def self.ipv4?(host : String) : Bool
       octets = host.split('.')
-      octets.size == 4 && octets.all? { |o| o.to_u8? != nil }
+      return false unless octets.size == 4
+      octets.all? do |o|
+        next false if o.empty? || o.size > 3
+        next false if o.size > 1 && o[0] == '0' # no leading zeros
+        o.to_u8? != nil                         # 0..255
+      end
     end
 
     private def self.add_ext(x : LibCrypto::X509, nid : Int32, value : String) : Nil

--- a/src/gori/ql.cr
+++ b/src/gori/ql.cr
@@ -10,13 +10,14 @@ module Gori
   #   method:post path:/api OR flag:x   # OR of AND-groups
   #   -host:cdn  status:5xx  login      # negation, status class, free text
   #   body:token                        # scan request/response body bytes
-  #   size:>10000 dur:>=500 dur:<2s     # response bytes / latency (ms; ms|s suffix)
+  #   size:>10000 dur:>=500 dur:<2s     # total bytes (req+resp) / latency (ms; ms|s)
+  #   reqsize:>1000 respsize:<500       # request-only / response-only byte size
   #   header:set-cookie                 # substring over request/response head bytes
   #   body~secret\d+  host~^api\.       # `~` = regex (host path url header body)
   module QL
-    # `:` fields:  host path method scheme status size dur header body flag
+    # `:` fields:  host path method scheme status size reqsize respsize dur header body flag
     # `~` regex on: host path url header body   (+ bare words = free text).
-    # Comparison ops (<= >= < > =) apply to status/size/dur.
+    # Comparison ops (<= >= < > =) apply to status/size/reqsize/respsize/dur.
     struct Filter
       getter sql : String # safe to splice into "WHERE ..."; values are in `args`
       getter args : Array(DB::Any)
@@ -89,18 +90,30 @@ module Gori
     private def self.field_cond(field : String, value : String) : {String, Array(DB::Any)}?
       return nil if value.empty?
       case field
-      when "host"   then {"lower(host) LIKE ? ESCAPE '\\'", [like(value)] of DB::Any}
-      when "path"   then {"lower(target) LIKE ? ESCAPE '\\'", [like(value)] of DB::Any}
-      when "method" then {"upper(method) = ?", [value.upcase] of DB::Any}
-      when "scheme" then {"scheme = ?", [value.downcase] of DB::Any}
-      when "status" then status_cond(value)
-      when "size"   then numeric_cond("response_size", value)
-      when "dur"    then duration_cond(value)
-      when "header" then header_cond(value)
-      when "body"   then body_cond(value)
-      when "flag"   then {"0", [] of DB::Any} # tags not implemented yet → matches nothing
-      else               free_text(value)     # unknown field: treat the value as free text
+      when "host"                        then {"lower(host) LIKE ? ESCAPE '\\'", [like(value)] of DB::Any}
+      when "path"                        then {"lower(target) LIKE ? ESCAPE '\\'", [like(value)] of DB::Any}
+      when "method"                      then {"upper(method) = ?", [value.upcase] of DB::Any}
+      when "scheme"                      then {"scheme = ?", [value.downcase] of DB::Any}
+      when "status"                      then status_cond(value)
+      when "size", "reqsize", "respsize" then size_cond(field, value)
+      when "dur"                         then duration_cond(value)
+      when "header"                      then header_cond(value)
+      when "body"                        then body_cond(value)
+      when "flag"                        then {"0", [] of DB::Any} # tags not implemented yet → matches nothing
+      else                                    free_text(value)     # unknown field: treat the value as free text
       end
+    end
+
+    # size: → the TOTAL bytes (request + response), so it matches the displayed/JSON
+    # `size`; reqsize:/respsize: target a single side. A NULL response_size (pending
+    # flow) never matches respsize:, while size:/reqsize: fall back on the request bytes.
+    private def self.size_cond(field : String, value : String) : {String, Array(DB::Any)}?
+      column = case field
+               when "reqsize"  then "request_size"
+               when "respsize" then "response_size"
+               else                 "(request_size + COALESCE(response_size, 0))"
+               end
+      numeric_cond(column, value)
     end
 
     # Body search uses the trigram FTS index over request/response body text —
@@ -153,10 +166,12 @@ module Gori
       {"status #{op} ?", [n] of DB::Any}
     end
 
-    # Numeric comparison on an INTEGER column (size: → response_size). A NULL column
-    # (a pending flow has no response_size) never satisfies `col <op> ?`, so such rows
-    # fall out of both the positive and the negated form — pending flows just don't
-    # match. Non-numeric values yield nil (the term is dropped, like a bad status:).
+    # Numeric comparison on an INTEGER column/expression. `size:` uses the total
+    # (request_size + COALESCE(response_size, 0)) so it matches the displayed/JSON
+    # `size`; `reqsize:`/`respsize:` target one side. A NULL column (e.g. respsize:
+    # on a pending flow) never satisfies `col <op> ?`, so such rows fall out of both
+    # the positive and negated form. Non-numeric values yield nil (the term is
+    # dropped, like a bad status:).
     private def self.numeric_cond(column : String, value : String) : {String, Array(DB::Any)}?
       op, rest = split_op(value)
       n = rest.to_i64?

--- a/src/gori/replay/engine.cr
+++ b/src/gori/replay/engine.cr
@@ -48,6 +48,16 @@ module Gori
           return error("no response from #{host}:#{port}", started) unless head
 
           resp = Proxy::Codec::Http1.parse_response_head(head)
+          # Skip interim 1xx informational responses (RFC 9110 §15.2): a captured
+          # request carrying `Expect: 100-continue`, or an origin/CDN that emits
+          # 103 Early Hints, would otherwise return the 100/103 as the replay
+          # result. Read on until the final (>=200) status. 101 Switching Protocols
+          # is terminal (a protocol upgrade), so it is NOT skipped.
+          while resp.status >= 100 && resp.status < 200 && resp.status != 101
+            head = Proxy::Codec::Http1.read_head(upstream)
+            return error("upstream closed after interim 1xx from #{host}:#{port}", started) unless head
+            resp = Proxy::Codec::Http1.parse_response_head(head)
+          end
           framing, len = Proxy::Codec::Body.response_framing(resp, request_method(request))
           body, complete = Proxy::Codec::Body.read_complete(upstream, framing, len)
           Result.new(head, body, resp, elapsed(started), incomplete: !complete)

--- a/src/gori/replay/engine.cr
+++ b/src/gori/replay/engine.cr
@@ -29,6 +29,8 @@ module Gori
     # Sends a request byte-exact to its origin and captures the response (P7).
     # Reuses the proxy's dialer/codec; no proxying — this is a direct send.
     module Engine
+      MAX_INTERIM = 64 # cap a run of interim 1xx responses (hostile-origin guard)
+
       def self.send(request : Bytes, *, scheme : String, host : String, port : Int32,
                     verify_upstream : Bool, sni : String? = nil,
                     timeout : Time::Span? = nil) : Result
@@ -53,6 +55,7 @@ module Gori
           # 103 Early Hints, would otherwise return the 100/103 as the replay
           # result. Read on until the final (>=200) status. 101 Switching Protocols
           # is terminal (a protocol upgrade), so it is NOT skipped.
+          interim_seen = 0
           while resp.status >= 100 && resp.status < 200 && resp.status != 101
             # RFC 9112 §6: a 1xx MUST NOT carry content. One that declares a body
             # (Content-Length / Transfer-Encoding) is malformed and a desync vector
@@ -60,6 +63,10 @@ module Gori
             if resp.headers.get?("Content-Length") || resp.headers.get?("Transfer-Encoding")
               return error("malformed interim 1xx response (declared a body) from #{host}:#{port}", started)
             end
+            # Cap the run so an origin streaming endless body-less 103s can't hang the
+            # replay/fuzz worker fiber indefinitely (there is no whole-request deadline).
+            interim_seen += 1
+            return error("too many interim 1xx responses from #{host}:#{port}", started) if interim_seen > MAX_INTERIM
             head = Proxy::Codec::Http1.read_head(upstream)
             return error("upstream closed after interim 1xx from #{host}:#{port}", started) unless head
             resp = Proxy::Codec::Http1.parse_response_head(head)

--- a/src/gori/replay/engine.cr
+++ b/src/gori/replay/engine.cr
@@ -54,6 +54,12 @@ module Gori
           # result. Read on until the final (>=200) status. 101 Switching Protocols
           # is terminal (a protocol upgrade), so it is NOT skipped.
           while resp.status >= 100 && resp.status < 200 && resp.status != 101
+            # RFC 9112 §6: a 1xx MUST NOT carry content. One that declares a body
+            # (Content-Length / Transfer-Encoding) is malformed and a desync vector
+            # (its body can embed a fake final response) — refuse it.
+            if resp.headers.get?("Content-Length") || resp.headers.get?("Transfer-Encoding")
+              return error("malformed interim 1xx response (declared a body) from #{host}:#{port}", started)
+            end
             head = Proxy::Codec::Http1.read_head(upstream)
             return error("upstream closed after interim 1xx from #{host}:#{port}", started) unless head
             resp = Proxy::Codec::Http1.parse_response_head(head)

--- a/src/gori/replay/h2_engine.cr
+++ b/src/gori/replay/h2_engine.cr
@@ -12,8 +12,11 @@ module Gori
     # `Replay::Result` the h1 engine produces (so the diff/view path is shared).
     #
     # One-shot and intentionally minimal: empty client SETTINGS (ACK on receipt),
-    # PING answered, no flow control beyond the default 64 KiB window (large
-    # request bodies could stall — fine for the manual workbench).
+    # PING answered. The RESPONSE side is flow-controlled — each DATA frame is
+    # credited straight back with a WINDOW_UPDATE on the connection + stream, so
+    # responses past the 65535-byte default window stream fine. The REQUEST side is
+    # not flow-controlled (a >64 KiB request body could stall — fine for the
+    # workbench; replay bodies are typically small).
     module H2Engine
       MAX_FRAME = 16384
       # Caps for the one-shot response read, mirroring the live assembler. Without
@@ -108,7 +111,11 @@ module Gori
         end_stream_pending = false # END_STREAM seen on a HEADERS frame whose block isn't closed yet
 
         until done
-          frame = Frame.read(io)
+          # A read error mid-response (connection reset, e.g. an origin that closed
+          # right after a non-END_STREAM DATA) is end-of-data, not a hard failure —
+          # treat it like a clean EOF and return what arrived, flagged incomplete
+          # (mirrors the h1 engine's premature-EOF handling).
+          frame = Frame.read(io) rescue nil
           break if frame.nil?
           case frame.frame_type
           when Frame::Type::Settings
@@ -143,9 +150,18 @@ module Gori
             end
           when Frame::Type::Data
             next unless frame.stream_id == 1
+            consumed = frame.payload.size # flow control counts the WHOLE DATA payload (incl. padding)
             body.write(data_block(frame)) if body.bytesize < MAX_BODY
             done = clean_eos = true if frame.end_stream?
             break if body.bytesize >= MAX_BODY # over-large/streaming body — truncate
+            # Replenish the connection (stream 0) AND stream flow-control windows by
+            # what we just consumed, so the origin keeps sending past the 65535-byte
+            # default window. Without this, any response body > 64 KiB stalls until
+            # the IO timeout (no WINDOW_UPDATE was ever sent).
+            if !done && consumed > 0
+              window_update(io, 0_u32, consumed)
+              window_update(io, 1_u32, consumed)
+            end
           else
             # WINDOW_UPDATE / PUSH_PROMISE / PRIORITY — ignored for a one-shot
           end
@@ -171,6 +187,20 @@ module Gori
       private def self.ack(io : IO, type : Frame::Type, payload : Bytes) : Nil
         io.write(Frame::Header.new(type.value, Frame::ACK, 0_u32, payload).to_bytes)
         io.flush
+      end
+
+      # WINDOW_UPDATE crediting `increment` bytes back to `stream_id` (0 = connection-
+      # level). The reserved high bit stays clear (increment is a small frame size).
+      private def self.window_update(io : IO, stream_id : UInt32, increment : Int32) : Nil
+        return if increment <= 0
+        payload = Bytes.new(4)
+        IO::ByteFormat::BigEndian.encode(increment.to_u32, payload)
+        io.write(Frame::Header.new(Frame::Type::WindowUpdate.value, 0_u8, stream_id, payload).to_bytes)
+        io.flush
+      rescue
+        # The origin may have already closed (e.g. a truncated response) — crediting a
+        # window we no longer need is moot; the next Frame.read sees the EOF and ends
+        # the loop. Don't let a dead-socket write fail an otherwise-usable response.
       end
 
       private def self.parse_request(request : Bytes, scheme : String, host : String,

--- a/src/gori/replay/h2_engine.cr
+++ b/src/gori/replay/h2_engine.cr
@@ -111,11 +111,18 @@ module Gori
         end_stream_pending = false # END_STREAM seen on a HEADERS frame whose block isn't closed yet
 
         until done
-          # A read error mid-response (connection reset, e.g. an origin that closed
-          # right after a non-END_STREAM DATA) is end-of-data, not a hard failure —
+          # An IO error mid-response (connection reset — e.g. an origin that closed
+          # right after a non-END_STREAM DATA) is end-of-data, not a hard failure:
           # treat it like a clean EOF and return what arrived, flagged incomplete
-          # (mirrors the h1 engine's premature-EOF handling).
-          frame = Frame.read(io) rescue nil
+          # (mirrors the h1 engine). A Gori::Error from Frame.read (oversized/corrupt
+          # frame — a real protocol violation) is NOT swallowed: it propagates to the
+          # outer rescue and surfaces as a failed replay, since the workbench exists to
+          # reveal exactly that.
+          frame = begin
+            Frame.read(io)
+          rescue IO::Error
+            nil
+          end
           break if frame.nil?
           case frame.frame_type
           when Frame::Type::Settings

--- a/src/gori/store/safe_regexp.cr
+++ b/src/gori/store/safe_regexp.cr
@@ -1,5 +1,12 @@
 require "sqlite3"
 
+# The shard binds value_text but not value_bytes; add it so the REGEXP haystack can
+# be read by its true byte length (value_text alone is NUL-terminated). Re-opening
+# the lib is additive — it doesn't touch the vendored shard.
+lib LibSQLite3
+  fun value_bytes = sqlite3_value_bytes(SQLite3Value) : Int32
+end
+
 module Gori
   # Byte-safe override of SQLite's `REGEXP(pattern, text)` function.
   #
@@ -14,9 +21,10 @@ module Gori
   # We re-register `regexp` on every pooled connection with a version that scrubs the
   # haystack to valid UTF-8 (invalid sequences → U+FFFD) and rescues any residual error,
   # so a regex scan can never crash and a binary body simply fails to match a text
-  # pattern. Like the upstream function the haystack is read via `value_text`, which
-  # stops at an embedded NUL — content past a NUL byte isn't scanned (acceptable for a
-  # text search; binary bodies aren't usefully regex-matched anyway).
+  # pattern. Unlike the upstream function (which reads the haystack via `value_text`, a
+  # NUL-terminated pointer, and so silently stops scanning at the first embedded NUL),
+  # we read the FULL byte length via `value_bytes` so content past a NUL — common in a
+  # body that mixes binary and text — is still matched.
   module SafeRegexp
     # SQLite fires this scalar callback once per row, but a query's pattern is constant
     # across all rows — recompiling per row is O(rows) PCRE2 compiles. Memoise the last
@@ -41,7 +49,11 @@ module Gori
     FN = ->(context : LibSQLite3::SQLite3Context, _argc : Int32, argv : LibSQLite3::SQLite3Value*) do
       args = Slice.new(argv, 2)
       pattern = String.new(LibSQLite3.value_text(args[0]))
-      text = String.new(LibSQLite3.value_text(args[1])).scrub
+      # value_text first (forces the text representation + keeps the pointer valid),
+      # then value_bytes for its true length — so an embedded NUL doesn't truncate.
+      hay_ptr = LibSQLite3.value_text(args[1])
+      hay_len = LibSQLite3.value_bytes(args[1])
+      text = hay_ptr.null? || hay_len <= 0 ? "" : String.new(hay_ptr, hay_len).scrub
       matched =
         begin
           SafeRegexp.compile(pattern).matches?(text)

--- a/src/gori/tui/controllers/help_controller.cr
+++ b/src/gori/tui/controllers/help_controller.cr
@@ -28,8 +28,7 @@ module Gori::Tui
     # Read-only scroll (↑/↓ or j/k). ↑ at the top pops to the tab bar; esc returns
     # to it. Only the navigation keys are claimed (return true); EVERY other key
     # must fall through (return false) so the ':' command line and the global keymap
-    # still see it — otherwise the body's own hint ("^P cmds · q projects") points
-    # at dead keys.
+    # still see it — otherwise the body's own hint ("^P cmds") points at dead keys.
     def handle_body_key(ev : Termisu::Event::Key) : Bool
       key = ev.key
       case
@@ -47,7 +46,9 @@ module Gori::Tui
     end
 
     def body_hint(focus : Symbol) : String
-      "↑/↓ scroll · ↹/esc tabs · ^P cmds · q projects"
+      # No "q projects": q (back to the picker) is tab-bar-only by design, so the
+      # body must not advertise it as a key (esc/↹ to the bar first, then q).
+      "↑/↓ scroll · ↹/esc tabs · ^P cmds"
     end
   end
 end

--- a/src/gori/tui/controllers/help_controller.cr
+++ b/src/gori/tui/controllers/help_controller.cr
@@ -26,15 +26,17 @@ module Gori::Tui
     end
 
     # Read-only scroll (↑/↓ or j/k). ↑ at the top pops to the tab bar; esc returns
-    # to it. Nothing is selectable, so EVERY other key is swallowed here — mirrors
-    # the old `return handle_help_key(ev)` (the help body never falls through to the
-    # verb keymap), hence the unconditional `true`.
+    # to it. Only the navigation keys are claimed (return true); EVERY other key
+    # must fall through (return false) so the ':' command line and the global keymap
+    # still see it — otherwise the body's own hint ("^P cmds · q projects") points
+    # at dead keys.
     def handle_body_key(ev : Termisu::Event::Key) : Bool
       key = ev.key
       case
       when key.up?, key.lower_k?   then @help.at_top? ? @host.request_focus(:menu) : @help.move(-1)
       when key.down?, key.lower_j? then @help.move(1)
       when key.escape?             then @host.request_focus(:menu)
+      else                              return false # ^P / : / q / global keys pass through
       end
       true
     end

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -35,7 +35,7 @@ module Gori::Tui
     # We load the MOST RECENT this-many (so a live tail keeps updating) and show an
     # "older not loaded" note; the raw frames remain whole in SQLite.
     DETAIL_LOG_CAP = 10_000
-    QL_FIELDS      = %w(host method status path scheme body header size dur flag)
+    QL_FIELDS      = %w(host method status path scheme body header size reqsize respsize dur flag)
     METHOD_VAL     = %w(GET POST PUT DELETE PATCH HEAD OPTIONS QUERY)
 
     getter rows : Array(Store::FlowRow)

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -65,8 +65,8 @@ module Gori::Tui
       @reveal = false                        # 'w' shows whitespace/CR/LF as glyphs (smuggling)
       @reveal_lines = nil.as(Array(String)?) # cached revealed lines, keyed on the pane bytes ptr
       @reveal_lines_src = Pointer(UInt8).null
-      @detail_hex = false                # 'x' toggles a raw hex dump of the current pane (req/resp)
-      @detail_hex_bytes = nil.as(Bytes?) # cached combined head+body for the current pane (hex source)
+      @detail_hex = false                      # 'x' toggles a raw hex dump of the current pane (req/resp)
+      @detail_hex_bytes = nil.as(Bytes?)       # cached combined head+body for the current pane (hex source)
       @pretty = Settings.pretty_bodies_default # 'p' pretty-prints bodies (display only); pushed from the runner
       # Windowed detail content, rebuilt only when the detail/pane changes (NOT on
       # scroll or every frame). The head/notes are pre-styled; the body is kept RAW
@@ -389,7 +389,17 @@ module Gori::Tui
     # ^F search: 0-based indices of the detail text lines containing `query` (case-
     # insensitive). Empty in hex mode (the hex view has no text lines).
     setter search_hl : String
-    setter reveal : Bool
+
+    # Reveal-whitespace renders on a separate path with a different (usually much
+    # shorter) line count than the normal/pretty view, so toggling it must reset
+    # the scroll offset — otherwise a stale offset left over from scrolling the
+    # longer view blanks the revealed pane (it has nothing to render that far down).
+    # Change-detected because the runner pushes this every frame.
+    def reveal=(on : Bool) : Nil
+      return if @reveal == on
+      @reveal = on
+      @detail_scroll = 0
+    end
 
     # Pretty toggle feeds `build_detail_view`, so a change must drop the windowed
     # cache (unlike reveal/hex, which render on separate paths). Change-detected

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -310,7 +310,8 @@ module Gori::Tui
         Frame.card(screen, body, "INTERCEPT", bg: Theme.bg, border: pane_border(focused))
         inner = body.inset(1, 1)
         screen.text(inner.x + 1, inner.y, "no held messages", Theme.muted)
-        screen.text(inner.x + 1, inner.y + 2, "turn intercept on (i) — held requests/responses appear here", Theme.muted)
+        hint = @enabled ? "intercept ON — in-scope requests/responses will appear here" : "turn intercept on (i) — held requests/responses appear here"
+        screen.text(inner.x + 1, inner.y + 2, hint, Theme.muted)
         return
       end
 

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -5,6 +5,7 @@ require "./highlight"
 require "./text_area"
 require "./url"
 require "../interceptor"
+require "../fuzz/content_length"
 
 module Gori::Tui
   # The Intercept tab: a queue of held requests/responses (P4 — the human decides
@@ -138,15 +139,18 @@ module Gori::Tui
       @editing = false
     end
 
-    # The forward payload: the edited bytes only when the editor holds THIS item AND
-    # it was actually modified — otherwise the original raw bytes byte-exact (P7).
-    # Merely OPENING the editor to view a held message must not mutate it: TextArea
-    # is a line editor (set_text splits on LF + rstrips CR; to_bytes rejoins with
-    # CRLF), so an un-dirty round-trip would rewrite bare LF/binary bodies. An actual
-    # edit still normalizes line endings — a documented text-editor limitation, same
-    # as the Replay editor; byte-exact tampering goes through replay/fuzz.
+    # The forward payload. An UNEDITED forward (editor never opened, or opened to view
+    # only) returns the original raw bytes BYTE-EXACT (P7) — so merely inspecting a
+    # held message can't mutate it, and a deliberately CL-mismatched smuggling probe
+    # forwards untouched. Only an ACTUAL edit returns the editor's bytes, with
+    # Content-Length recomputed to match the edited body (Burp's "update
+    # Content-Length", default on; add_when_missing: true so adding a body to a GET
+    # that had none still gets framed). The proxy itself stays byte-exact — the
+    # update-CL decision lives here, in the human's editor, not the wire path. (An edit
+    # still normalizes line endings — a text-editor limitation shared with Replay.)
     def forward_bytes(it : Interceptor::Item) : Bytes
-      @loaded_id == it.id && @editor_dirty ? @editor.to_bytes : it.raw
+      return it.raw unless @loaded_id == it.id && @editor_dirty
+      Fuzz::ContentLength.sync(@editor.to_bytes, add_when_missing: true)
     end
 
     def edit_insert(ch : Char) : Nil

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -39,6 +39,7 @@ module Gori::Tui
       @qcx = 0
       @preedit = ""
       @loaded_id = nil.as(Int64?) # which item the editor currently holds
+      @editor_dirty = false       # whether the held bytes were actually edited (vs just viewed)
       # Cached highlight of the selected held item's raw bytes (read-only detail
       # pane). Held bytes are immutable and item ids are monotonic, so the id is a
       # perfect cache key — recomputed only when the selection changes, not on
@@ -128,6 +129,7 @@ module Gori::Tui
       elsif it = selected_item
         @editor.set_text(String.new(it.raw))
         @loaded_id = it.id
+        @editor_dirty = false # freshly loaded — not yet modified
         @editing = true
       end
     end
@@ -136,22 +138,33 @@ module Gori::Tui
       @editing = false
     end
 
-    # The forward payload: edited bytes when the editor holds THIS item, else the
-    # original bytes (byte-exact passthrough, P7).
+    # The forward payload: the edited bytes only when the editor holds THIS item AND
+    # it was actually modified — otherwise the original raw bytes byte-exact (P7).
+    # Merely OPENING the editor to view a held message must not mutate it: TextArea
+    # is a line editor (set_text splits on LF + rstrips CR; to_bytes rejoins with
+    # CRLF), so an un-dirty round-trip would rewrite bare LF/binary bodies. An actual
+    # edit still normalizes line endings — a documented text-editor limitation, same
+    # as the Replay editor; byte-exact tampering goes through replay/fuzz.
     def forward_bytes(it : Interceptor::Item) : Bytes
-      @loaded_id == it.id ? @editor.to_bytes : it.raw
+      @loaded_id == it.id && @editor_dirty ? @editor.to_bytes : it.raw
     end
 
     def edit_insert(ch : Char) : Nil
-      @editor.insert(ch) if @editing
+      return unless @editing
+      @editor.insert(ch)
+      @editor_dirty = true
     end
 
     def edit_newline : Nil
-      @editor.insert_newline if @editing
+      return unless @editing
+      @editor.insert_newline
+      @editor_dirty = true
     end
 
     def edit_backspace : Nil
-      @editor.backspace if @editing
+      return unless @editing
+      @editor.backspace
+      @editor_dirty = true
     end
 
     def edit_move(dr : Int32, dc : Int32) : Nil
@@ -178,7 +191,9 @@ module Gori::Tui
     # Replace the held item's editable bytes (e.g. from the external editor); only
     # while editing — forward_bytes then sends the edited text.
     def replace_editor(text : String) : Nil
-      @editor.set_text(text) if @editing
+      return unless @editing
+      @editor.set_text(text)
+      @editor_dirty = true
     end
 
     # --- focus ring (driven by the Runner's Tab/Shift-Tab) ---


### PR DESCRIPTION
## Summary

A two-round, multi-agent **test-and-improve audit of every gori feature**: build → exhaustively exercise the proxy, TUI, and CLI in isolated environments → fix each real bug or unexpected behavior as its own commit → verify. **21 commits**, full suite green (**675 specs, 0 failures**), each fix carrying a regression spec where unit-testable plus end-to-end verification.

- **Round 1** (17 testing agents across every feature area) surfaced 43 issues → fixed 1 high + all 12 mediums.
- **Round 2** (10 regression + adversarial-hunt agents) confirmed all round-1 fixes hold (**0 regressions**) and caught follow-up bugs in them — including 2 new highs — all fixed.

## Correctness / smuggling (proxy + replay)

- **Interim `1xx` response desync** *(high)* — the proxy treated a `100 Continue` / `103 Early Hints` as the final response, stranding the real one on the keep-alive upstream (served to the *next* request → response smuggling) and breaking `Expect: 100-continue`. Now forwards each 1xx and reads on to the final status (RFC 9110 §15.2); same fix in `gori run replay`.
- **`1xx` carrying a declared body** *(round-2)* — a malformed 1xx with `Content-Length`/`Transfer-Encoding` whose "body" embeds a fake response is now refused, not parsed as the response.
- **Intercept Content-Length** — editing a held body now recomputes `Content-Length` (Burp default), and **adding a body to a bodyless request (e.g. a GET)** *(round-2 high)* now frames it — previously it was dropped and the bytes stranded on the upstream (smuggling).
- **Intercept byte-faithfulness** — opening a held message to *view* and forwarding it no longer rewrites bare `LF`→`CRLF` (a TextArea round-trip); only an actual edit normalizes line endings.

## HTTP/2 / TLS

- **h2 replay flow control** *(round-2 high)* — `Replay::H2Engine` never sent `WINDOW_UPDATE`, so any response over the 65535-byte default window hung 30s then failed. Now credits each DATA frame back on the connection + stream — a 1.29 MB cloudflare.com response replays in ~0.4 s (was a timeout). Affects CLI/TUI/MCP replay.
- **IP-literal MITM certs** — leaf certs for IP hosts now carry an `iPAddress` SAN (was `dNSName`), so curl/browsers accept HTTPS-by-IP interception. Zero-padded octets *(round-2)* fall back to a DNS SAN instead of aborting the handshake.

## Fuzzer

- Unbalanced trailing `§` no longer truncates the request body; auto-mark no longer injects a literal `§` for empty values (`§§` collision).
- `clusterbomb` request-count honours the set-0 fallback (no spurious `--force` prompt for a bounded run).

## QL / findings / CLI

- **`size:`** now filters the displayed request+response **total** (was response-only — filtering by the shown size silently missed); adds `reqsize:` / `respsize:`.
- **`body~` / `header~` regex** now scans **past an embedded NUL** (was truncated by `value_text`).
- **Findings export** hardened against captured-traffic injection — a `` ``` `` in a body can't break the code fence; titles/host collapse to one line.
- Clean errors for: a value-option given no value (all subcommands), an unreadable `gori mcp` db, a non-`http(s)` replay/fuzz `--target` scheme.
- `gori run show` now renders captured **WebSocket frames**; `gori run capture` prints/counts a streaming flow (WS/h2/SSE) **once** (was per-message, tripping `--max` and tearing down live connections).

## TUI

- Help-tab body passes `^P` / `:` through (were dead keys); reveal-whitespace toggle no longer blanks the detail pane; intercept empty-state reflects on/off.

## Deferred (documented, not regressions)

Live keep-alive **SSE** incremental capture, **h2→h1** ALPN downgrade for h1-only origins, and per-file capture-lock keying are architectural changes left as documented follow-ups rather than rushed into a heavily-hardened proxy. See the commit history and `audit-2026-06-27` notes.

## Test plan

`crystal spec` → 675 examples, 0 failures. `crystal tool format --check` clean on the diff. End-to-end smoke across capture / gzip-decode / QL / replay / fuzz / findings-export / MCP all pass.

https://claude.ai/code/session_011qvBRr44cwkf2ymqdUewkz
