### PR TITLE
fix(tui): single head/body blank line + drop redundant pretty footer

### DIFF
--- a/spec/tui/highlight_spec.cr
+++ b/spec/tui/highlight_spec.cr
@@ -58,19 +58,19 @@ describe Gori::Tui::Highlight do
       end
     end
 
-    it "message() reproduces the old `head + [\"\"] + body` plain layout 1:1" do
+    it "message() separates head from body with exactly one blank line" do
       head = "GET /a HTTP/1.1\r\nContent-Type: application/json\r\n\r\n".to_slice
       body = %({"x":1}).to_slice
-      head_lines = String.new(head).split('\n').map(&.rstrip('\r'))
-      expected = head_lines + [""] + [String.new(body)]
+      # The CRLFCRLF terminator must not leak extra blank lines: one separator only.
+      expected = ["GET /a HTTP/1.1", "Content-Type: application/json", "", String.new(body)]
 
       lines = Highlight.message(head, body, request: true)
       lines.map { |l| l.map(&.text).join }.should eq(expected)
     end
 
-    it "message() with no body matches the head-only plain layout" do
+    it "message() with no body ends on the last header, not blank lines" do
       head = "GET /a HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice
-      expected = String.new(head).split('\n').map(&.rstrip('\r'))
+      expected = ["GET /a HTTP/1.1", "Host: h.test"]
       lines = Highlight.message(head, nil, request: true)
       lines.map { |l| l.map(&.text).join }.should eq(expected)
       # an empty body slice is treated as no body (no spurious separator line)

--- a/src/gori/tui/highlight.cr
+++ b/src/gori/tui/highlight.cr
@@ -23,10 +23,16 @@ module Gori::Tui
     # --- public entry points -------------------------------------------------
 
     # Highlight a full HTTP message held as separate head/body byte slices (the
-    # History detail and Replay response shapes). Mirrors the old
-    # `bytes_to_lines(head) + ["", *bytes_to_lines(body)]` layout exactly.
+    # History detail and Replay response shapes): styled head, then exactly ONE
+    # blank line, then the styled body.
     def self.message(head : Bytes?, body : Bytes?, request : Bool) : Array(Line)
       head_lines = to_lines(head)
+      # Drop the trailing "" entries the CRLFCRLF head terminator leaves behind
+      # (see `message_windowed`) so the head ends on its last header, not on 1–2
+      # blank lines.
+      while head_lines.size > 1 && head_lines[-1].empty?
+        head_lines.pop
+      end
       has_body = !(body.nil? || body.empty?)
       body_lines = has_body ? to_lines(body) : [] of String
       kind = body_kind(content_type_in(head_lines))
@@ -73,6 +79,13 @@ module Gori::Tui
     # output is no longer the content-type's language, e.g. GraphQL/JWT → :text).
     def self.message_windowed(head : Bytes?, body : Bytes?, request : Bool, kind : Symbol? = nil) : Windowed
       head_lines = to_lines(head)
+      # A captured head ends with the CRLFCRLF terminator, which `to_lines` turns
+      # into trailing "" entries ("…\r\n\r\n" → […, "", ""]). Drop them so the
+      # single separator appended below renders as exactly ONE blank line between
+      # the head and the body, not the 2–3 the terminator would otherwise leave.
+      while head_lines.size > 1 && head_lines[-1].empty?
+        head_lines.pop
+      end
       has_body = !(body.nil? || body.empty?)
       kind = kind || body_kind(content_type_in(head_lines))
       styled = [] of Line

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -906,12 +906,9 @@ module Gori::Tui
         note << [Highlight::Span.new("— #{decode_note} —", color)]
         trailer = note + trailer # decode note before the truncation note
       end
-      if pn = pretty
-        prettied = [] of Highlight::Line
-        prettied << Highlight::Line.new
-        prettied << [Highlight::Span.new("— #{pn.note} —", Theme.green)]
-        trailer = prettied + trailer
-      end
+      # No pretty trailer: the "PRETTY" mode indicator in the pane header already
+      # signals the reflow, so the "— pretty: … —" footer is redundant (and Replay
+      # never showed one — this keeps the two response views consistent).
       DetailView.new(win.head, win.body, win.kind, trailer, pretty: pretty != nil)
     end
 


### PR DESCRIPTION
## What

Two TUI Response-tab fixes for pretty/raw body rendering.

### 1. One blank line between head and body (was 3)

A captured head always ends with the `\r\n\r\n` terminator. `to_lines` splits
on `\n` and rstrips `\r`, so `"…\r\n\r\n"` becomes two trailing `""` entries —
and the render path then appended *another* blank separator, so the head/body
gap rendered as **3** blank lines instead of 1.

Fixed by stripping the trailing empties in both `Highlight.message` and
`Highlight.message_windowed` so the separator is exactly one blank line. This
was a general bug (not pretty-specific): it affects History detail, Replay, and
the gRPC head, in both raw and pretty modes.

### 2. Drop the redundant `— pretty: … —` footer

The History response detail showed a `— pretty: html —` style footer. The
**PRETTY** mode indicator in the pane header already signals the reflow, and the
Replay view never showed this footer — removing it keeps the two response views
consistent.

> Note: this also drops the JWT "signature not verified" caveat and form/multipart
> field counts that rode along in that footer. They were never shown in Replay either;
> if we want the JWT caveat preserved it can be surfaced separately.

## Test

- `crystal spec` (highlight / history_view / pretty / replay_view): 86 examples, 0 failures
- Updated the two `highlight_spec.cr` cases that asserted the old 3-blank layout
- `crystal build src/main.cr` compiles clean
