### PR TITLE
feat(tui): category sigils in the command palette

### DIFF
--- a/spec/tui/palette_spec.cr
+++ b/spec/tui/palette_spec.cr
@@ -69,4 +69,26 @@ describe Gori::Tui::PaletteState do
     backend.contains?("settings:hotkeys").should be_true
     backend.contains?("soon").should be_true # the placeholder badge
   end
+
+  it "categorizes Global verbs so the palette can group them by kind" do
+    r = Gori::Verbs.registry
+    r["tab.history"].category.should eq(Gori::Verb::Category::Navigation)
+    r["nav.next-tab"].category.should eq(Gori::Verb::Category::Navigation)
+    r["app.back"].category.should eq(Gori::Verb::Category::Navigation)
+    r["settings.theme"].category.should eq(Gori::Verb::Category::Settings)
+    r["app.quit"].category.should eq(Gori::Verb::Category::System)
+    r["app.palette"].category.should eq(Gori::Verb::Category::System)
+    r["capture.toggle"].category.should eq(Gori::Verb::Category::Action) # the default kind
+  end
+
+  it "prints a colour-coded category sigil before each entry" do
+    ctx = FakeExecContext.new
+    palette = PaletteState.new(Gori::Verbs.registry)
+    palette.reset(ctx)
+    "Toggle capture".each_char { |c| palette.append(c, ctx) } # an Action verb
+
+    backend = MemoryBackend.new(80, 24)
+    palette.render(Screen.new(backend), Rect.new(0, 0, 80, 24))
+    backend.contains?("▸ Toggle capture").should be_true # the Action sigil precedes the title
+  end
 end

--- a/src/gori/tui/palette.cr
+++ b/src/gori/tui/palette.cr
@@ -101,10 +101,16 @@ module Gori::Tui
         soon = verb.coming_soon?
         screen.fill(Rect.new(box.x + 1, ry, w - 2, 1), bg)
         screen.cell(box.x + 1, ry, active ? '▎' : ' ', Theme.accent, bg)
+        # Category sigil — a colour-coded glyph grouping the command by kind
+        # (navigation »/action ▸/settings ≡/system ×) so the list reads at a glance.
+        # Drawn at a fixed column with the title one cell past it, so a width-1 or
+        # width-2 glyph both stay aligned. Dimmed (with the title) for coming-soon.
+        glyph, gfg = category_badge(verb.category)
+        screen.cell(box.x + 3, ry, glyph, soon && !active ? Theme.muted : gfg, bg)
         # Coming-soon verbs are dimmed at rest (still readable when selected) so the
         # list signals what's not functional yet without hiding it.
         title_fg = active ? Theme.text_bright : (soon ? Theme.muted : Theme.text)
-        screen.text(box.x + 3, ry, verb.title, title_fg, bg, width: w - 19)
+        screen.text(box.x + 5, ry, verb.title, title_fg, bg, width: w - 21)
         if soon
           badge = "soon"
           screen.text(box.right - badge.size - 2, ry, badge, Theme.yellow, bg)
@@ -112,6 +118,19 @@ module Gori::Tui
           hint = chord.label
           screen.text(box.right - hint.size - 2, ry, hint, Theme.muted, bg)
         end
+      end
+    end
+
+    # Maps a verb category to its palette sigil + colour. Pure presentation, so it
+    # lives here rather than on the Category enum (which stays Theme-free data). The
+    # glyphs are BMP, non-emoji, and render single-width — per the glyph-decoration
+    # notes — and the colours come from the active theme so they re-theme for free.
+    private def category_badge(cat : Verb::Category) : {Char, Color}
+      case cat
+      in Verb::Category::Navigation then {'»', Theme.accent}
+      in Verb::Category::Action     then {'▸', Theme.green}
+      in Verb::Category::Settings   then {'≡', Theme.orange}
+      in Verb::Category::System     then {'×', Theme.red}
       end
     end
 

--- a/src/gori/verb.cr
+++ b/src/gori/verb.cr
@@ -22,6 +22,17 @@ module Gori
       PaletteOpen    # the command palette overlay is up
     end
 
+    # The KIND of action, orthogonal to Scope (where it fires). Drives the
+    # colour-coded sigil the command palette prints before each entry so users can
+    # tell navigation from a state-changing action at a glance. Action is the default
+    # (and covers every non-palette verb, which never renders a badge).
+    enum Category
+      Action     # does something / opens a tool (capture, intercept, scope, rules, CA …)
+      Navigation # moves focus around the app (tab jumps, back to projects)
+      Settings   # edits configuration (settings:*)
+      System     # app lifecycle (quit, the palette itself)
+    end
+
     # A keybinding as pure data (no terminal dependency). The TUI converts a
     # termisu key event into a Chord and looks it up in the Keymap.
     record Chord, key : String, ctrl : Bool = false, alt : Bool = false, shift : Bool = false do
@@ -45,6 +56,7 @@ module Gori
       getter title : String
       getter description : String
       getter scope : Scope
+      getter category : Category
       getter chords : Array(Chord)
       getter? hidden : Bool
       # Exposed for discoverability but not yet functional — the palette shows it
@@ -54,7 +66,7 @@ module Gori
       def initialize(@id : String, @title : String, @description : String, @scope : Scope,
                      @chords : Array(Chord) = [] of Chord, @hidden : Bool = false,
                      @available : ExecContext -> Bool = ->(_ctx : ExecContext) { true },
-                     @coming_soon : Bool = false,
+                     @coming_soon : Bool = false, @category : Category = Category::Action,
                      &@handler : ExecContext -> String?)
       end
 

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -11,7 +11,7 @@ module Gori
       # verb-driven Sitemap/Findings bodies (a surprising one-key dead-end mid-browse).
       r.register Verb::Definition.new(
         "app.back", "Back to projects", "Close this project and return to the picker", Verb::Scope::Global,
-        [] of Verb::Chord) { |ctx| ctx.leave_project; nil }
+        [] of Verb::Chord, category: Verb::Category::Navigation) { |ctx| ctx.leave_project; nil }
       r.register Verb::Definition.new(
         "app.back-key", "Back to projects", "Close this project (q on the tab bar)", Verb::Scope::Sidebar,
         [Verb::Chord.new("q")], hidden: true) { |ctx| ctx.leave_project; nil }
@@ -20,11 +20,11 @@ module Gori
       # handled in the Runner (single Q quitting was too easy to hit by accident).
       r.register Verb::Definition.new(
         "app.quit", "Quit gori", "Exit gori entirely", Verb::Scope::Global,
-        [] of Verb::Chord) { |ctx| ctx.quit!; nil }
+        [] of Verb::Chord, category: Verb::Category::System) { |ctx| ctx.quit!; nil }
 
       r.register Verb::Definition.new(
         "app.palette", "Command palette", "Open the command palette", Verb::Scope::Global,
-        [Verb::Chord.new("p", ctrl: true)]) { |ctx| ctx.open_palette; nil }
+        [Verb::Chord.new("p", ctrl: true)], category: Verb::Category::System) { |ctx| ctx.open_palette; nil }
 
       r.register Verb::Definition.new(
         "capture.toggle", "Toggle capture", "Start/stop capturing traffic", Verb::Scope::Global,
@@ -54,19 +54,19 @@ module Gori
       # implemented; hotkeys is registered for discoverability (shown "soon") + a TODO toast.
       r.register Verb::Definition.new(
         "settings.network", "settings:network", "Edit the proxy bind address + upstream proxy",
-        Verb::Scope::Global) { |ctx| ctx.open_settings(:network); nil }
+        Verb::Scope::Global, category: Verb::Category::Settings) { |ctx| ctx.open_settings(:network); nil }
       r.register Verb::Definition.new(
         "settings.editor", "settings:editor", "Set the external editor opened by ^E in editable fields",
-        Verb::Scope::Global) { |ctx| ctx.open_settings(:editor); nil }
+        Verb::Scope::Global, category: Verb::Category::Settings) { |ctx| ctx.open_settings(:editor); nil }
       r.register Verb::Definition.new(
         "settings.theme", "settings:theme", "Switch the TUI colour theme (built-ins + your own from ~/.gori/themes/*.json)",
-        Verb::Scope::Global) { |ctx| ctx.open_settings(:theme); nil }
+        Verb::Scope::Global, category: Verb::Category::Settings) { |ctx| ctx.open_settings(:theme); nil }
       r.register Verb::Definition.new(
         "settings.tabs", "settings:tabs", "Customize the top tab bar — show/hide tabs and reorder them",
-        Verb::Scope::Global) { |ctx| ctx.open_settings(:tabs); nil }
+        Verb::Scope::Global, category: Verb::Category::Settings) { |ctx| ctx.open_settings(:tabs); nil }
       r.register Verb::Definition.new(
         "settings.hotkeys", "settings:hotkeys", "Hotkey settings (coming soon)",
-        Verb::Scope::Global, coming_soon: true) { |ctx| ctx.open_settings(:hotkeys); nil }
+        Verb::Scope::Global, coming_soon: true, category: Verb::Category::Settings) { |ctx| ctx.open_settings(:hotkeys); nil }
 
       r.register Verb::Definition.new(
         "scope.edit", "Scope lens", "Edit the in-scope host patterns", Verb::Scope::Global,
@@ -117,11 +117,11 @@ module Gori
       # bracket chords remain a from-anywhere shortcut to cycle tabs.
       r.register Verb::Definition.new(
         "nav.next-tab", "Next tab", "Focus the next tab", Verb::Scope::Global,
-        [Verb::Chord.new("]")]) { |ctx| ctx.cycle_tab(1); nil }
+        [Verb::Chord.new("]")], category: Verb::Category::Navigation) { |ctx| ctx.cycle_tab(1); nil }
 
       r.register Verb::Definition.new(
         "nav.prev-tab", "Previous tab", "Focus the previous tab", Verb::Scope::Global,
-        [Verb::Chord.new("[")]) { |ctx| ctx.cycle_tab(-1); nil }
+        [Verb::Chord.new("[")], category: Verb::Category::Navigation) { |ctx| ctx.cycle_tab(-1); nil }
 
       # Positional tab jump: digit N focuses the Nth VISIBLE tab (the order on the bar) —
       # so the numbers follow the user's settings:tabs order/visibility. Hidden (default:
@@ -141,7 +141,8 @@ module Gori
         :convert => "Convert", :agent => "Agent", :help => "Help",
       }.each do |tab, label|
         r.register Verb::Definition.new(
-          "tab.#{tab}", "Go to #{label}", "Focus the #{label} tab", Verb::Scope::Global) { |ctx| ctx.focus_tab(tab); nil }
+          "tab.#{tab}", "Go to #{label}", "Focus the #{label} tab", Verb::Scope::Global,
+          category: Verb::Category::Navigation) { |ctx| ctx.focus_tab(tab); nil }
       end
 
       # Close the command palette overlay.


### PR DESCRIPTION
## What

Prefixes each Ctrl-P command-palette entry with a colour-coded glyph that groups the command by **kind**, so navigation reads apart from a state-changing action at a glance.

| glyph | category | colour | covers |
|---|---|---|---|
| `»` | navigation | accent | tab jumps (`Go to …`), next/prev tab, back to projects |
| `▸` | action | green | capture · intercept · scope · rules · CA · browser · reveal · findings export |
| `≡` | settings | orange | `settings:*` |
| `×` | system | red | quit, the palette itself |

## How

- **`verb.cr`** — new `Verb::Category` enum (`Action`/`Navigation`/`Settings`/`System`), orthogonal to `Scope` (where a verb fires). `Definition` gains a `category` field defaulting to `Action`, so non-palette verbs need no change and future surfaces (help, MCP) can reuse it.
- **`verbs/core.cr`** — tags the navigation / settings / system Global verbs; the rest fall through to the `Action` default.
- **`tui/palette.cr`** — a `category_badge` helper maps category → sigil + theme colour (lives in the view so the enum stays Theme-free). The glyph is drawn at a fixed column with the title one cell past it, so a width-1 or width-2 glyph both stay aligned; the title's right edge and the chord hint are unchanged. Coming-soon entries dim the glyph with the title.

Glyphs are BMP, non-emoji, single-width (per the prior glyph-decoration research).

## Scope

Applies to the Ctrl-P palette only (as requested). The `:` command line is untouched; the `category` field is already there if we want to extend it later.

## Test plan

- `shards build` ✅
- `crystal spec spec/tui/ spec/verb/` → 238 examples, 0 failures (incl. 2 new palette tests: category mapping + sigil render) ✅
- Manual TUI check via tmux — glyphs, per-category colours (green ×5 / orange ×4 / red ×2), and visibility on the selected highlight band all correct ✅
- `crystal tool format` + `ameba` clean on changed files (pre-existing repo format drift left untouched) ✅