### PR TITLE
feat(tui): payload-first Fuzzer config + wordlist path auto-complete

### DIFF
--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "file_utils"
 
 include Gori::Tui
 
@@ -22,5 +23,80 @@ describe Gori::Tui::FuzzerView do
     label = view.label(8)
     label.size.should be <= 8
     label.should end_with("…")
+  end
+end
+
+describe Gori::Tui::PathComplete do
+  it "lists a directory's children, directories trailing a slash" do
+    root = File.tempname("gori_pc")
+    Dir.mkdir_p(File.join(root, "sub"))
+    File.write(File.join(root, "words.txt"), "a\nb\n")
+    File.write(File.join(root, "other.lst"), "x\n")
+    begin
+      pc = PathComplete.new
+      pc.refresh("#{root}/")
+      pc.open?.should be_true
+      file = pc.entries.find { |e| e.label == "words.txt" }.not_nil!
+      file.insert.should eq("#{root}/words.txt")
+      file.dir.should be_false
+      dir = pc.entries.find { |e| e.label == "sub" }.not_nil!
+      dir.insert.should eq("#{root}/sub/") # trailing slash so the user keeps drilling
+      dir.dir.should be_true
+    ensure
+      FileUtils.rm_rf(root)
+    end
+  end
+
+  it "filters by the typed basename partial" do
+    root = File.tempname("gori_pc")
+    Dir.mkdir_p(root)
+    File.write(File.join(root, "words.txt"), "")
+    File.write(File.join(root, "other.txt"), "")
+    begin
+      pc = PathComplete.new
+      pc.refresh("#{root}/wo")
+      pc.entries.map(&.label).should eq(["words.txt"])
+    ensure
+      FileUtils.rm_rf(root)
+    end
+  end
+
+  it "completes bare names from ~/.gori/wordlists with an ABSOLUTE insert (G1)" do
+    home = File.tempname("gori_home")
+    wl = File.join(home, "wordlists")
+    Dir.mkdir_p(wl)
+    File.write(File.join(wl, "rockyou.txt"), "")
+    old = ENV["GORI_HOME"]?
+    ENV["GORI_HOME"] = home
+    begin
+      pc = PathComplete.new
+      pc.refresh("rock")
+      hit = pc.entries.find { |e| e.label.starts_with?("rockyou.txt") }.not_nil!
+      # The engine opens wordlist paths relative to CWD, so a wordlists-dir-only name
+      # MUST resolve absolutely — a bare "rockyou.txt" insert would fail at run time.
+      hit.insert.should eq(File.join(wl, "rockyou.txt"))
+      hit.label.should contain("·~/.gori")
+    ensure
+      old ? (ENV["GORI_HOME"] = old) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(home)
+    end
+  end
+
+  it "accept returns the highlighted insert + dir flag; move clamps at the top" do
+    root = File.tempname("gori_pc")
+    Dir.mkdir_p(File.join(root, "dir"))
+    File.write(File.join(root, "a.txt"), "")
+    begin
+      pc = PathComplete.new
+      pc.refresh("#{root}/")
+      pc.move(-1) # clamp at the top
+      pc.selected.should eq(0)
+      first = pc.entries[0]
+      res = pc.accept.not_nil!
+      res[0].should eq(first.insert)
+      res[1].should eq(first.dir)
+    ensure
+      FileUtils.rm_rf(root)
+    end
   end
 end

--- a/src/gori/paths.cr
+++ b/src/gori/paths.cr
@@ -28,8 +28,16 @@ module Gori
       File.join(home_dir, "ca")
     end
 
+    # Convention dir for fuzzer wordlists: bare (slash-less) names typed into the
+    # Fuzzer's wordlist field auto-complete from here (and the current dir). Users
+    # drop `*.txt` lists in here for discovery without typing a full path.
+    def self.wordlists_dir : String
+      File.join(home_dir, "wordlists")
+    end
+
     def self.ensure_dirs : Nil
       ensure_dir(home_dir)
+      ensure_dir(wordlists_dir)
     end
 
     # Race-tolerant `mkdir -p`: two gori instances can start simultaneously and

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -80,11 +80,16 @@ module Gori::Tui
       case v.focus
       when :target   then "type URL · ↵/↓ template · ^R run · ↹ pane · esc tabs"
       when :template then "type · ^A params · ^K word · ^T point · ^U clear · ^O config · ^R run · ↹ pane"
-      when :config   then "↑/↓ field · ←/→ change·type-tab · type edit · ⏎ add · Del rm · ↹ pane"
+      when :config   then config_hint(v)
       when :results  then "↑/↓ select · ↵ detail · o sort · m matched · ^R run · ^X stop · ↹ pane"
       when :detail   then "↑/↓ scroll · ←/→ req/resp · esc back"
       else                "↹/esc tabs"
       end
+    end
+
+    private def config_hint(v : FuzzerView) : String
+      return "↑/↓ pick · ↹/↵ complete · esc close · type to filter" if v.path_completing?
+      "↑/↓ field · ←/→ change · type edit · ⏎ add/toggle · Del rm · ↹ pane"
     end
 
     # --- rendering ---
@@ -113,6 +118,26 @@ module Gori::Tui
         ev.key.escape? ? handle_escape(v) : handle_pane_key(ev, v)
       end
       true
+    end
+
+    # The wordlist path autocomplete owns Tab/↵/↑/↓/Esc while its popup is up — the
+    # runner routes here via a pre-ring guard (gated on `path_completing?`) before the
+    # focus ring claims Tab. Mirrors ConvertController#completing?/handle_complete_key.
+    def path_completing? : Bool
+      current_view.try(&.path_completing?) || false
+    end
+
+    def handle_path_complete_key(ev : Termisu::Event::Key) : Bool
+      v = current_view
+      return false unless v
+      key = ev.key
+      case
+      when key.tab?, key.enter?   then v.path_complete_accept; true
+      when key.back_tab?, key.up? then v.path_complete_move(-1); true
+      when key.down?              then v.path_complete_move(1); true
+      when key.escape?            then v.path_complete_close; true
+      else                             false # printables fall through → form_type refilters
+      end
     end
 
     # Run the action a chord mapped to; false when it was not a chord (fall through).

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -6,6 +6,8 @@ require "./text_area"
 require "./fmt"
 require "../store"
 require "../fuzz"
+require "../fuzzy"
+require "../paths"
 require "../replay/flow_request"
 
 module Gori::Tui
@@ -49,9 +51,11 @@ module Gori::Tui
       @cfg_field = 0
       @cfg_caret = 0
       @cfg_scroll = 0
-      @ptype = :list # selected payload-type tab
-      @s_conc = "20" # engine numeric fields are edited as string buffers, committed
-      @s_rate = ""   # to @config at build/persist time (so a field can be cleared)
+      @show_advanced = false            # Engine/Opts/Match/Filter collapsed by default
+      @path_complete = PathComplete.new # wordlist path inline auto-complete
+      @ptype = :list                    # selected payload-type tab
+      @s_conc = "20"                    # engine numeric fields are edited as string buffers, committed
+      @s_rate = ""                      # to @config at build/persist time (so a field can be cleared)
       @s_timeout = ""
       @s_retries = "0"
       @s_m_regex = "" # regex fields buffered as source strings, compiled on commit
@@ -166,6 +170,9 @@ module Gori::Tui
 
     def focus_config : Nil
       @focus = :config
+      @cfg_field = 0 # land straight on the payload type tabs
+      @cfg_caret = 0
+      @path_complete.close
     end
 
     def pane_advance(dir : Int32) : Bool
@@ -282,20 +289,25 @@ module Gori::Tui
     end
 
     # --- config form ---------------------------------------------------------
-    # A flat, ordered list of focusable field ids — ↑/↓ steps through ALL of them
-    # (so the cursor walks left-to-right along a multi-field line, then down).
-    # Payload-type fields are dynamic; payload-set rows live at indices past the
-    # fixed fields (one per @sets entry), addressed as the `:set` pseudo-field.
-    FORM_HEAD = [:mode, :conc, :rate, :timeout, :retries, :follow, :calibrate,
-                 :m_status, :m_size, :m_words, :m_regex,
-                 :f_status, :f_size, :f_words, :f_regex, :ptype]
+    # The cursor (@cfg_field, ↑/↓) walks an ordered field list split around the
+    # variable-length @sets rows: HEAD (payload type + its draft fields + add)
+    # comes first so entering CONFIG lands straight on the payload; the @sets rows
+    # sit in the MIDDLE (the `:set` pseudo-field); TAIL (mode + the collapsible
+    # `▸ Advanced` toggle, then Engine/Opts/Match/Filter only when expanded) is last.
+    ADVANCED_FIELDS = [:conc, :rate, :timeout, :retries, :follow, :calibrate,
+                       :m_status, :m_size, :m_words, :m_regex,
+                       :f_status, :f_size, :f_words, :f_regex]
 
     def config_field : Symbol
       current_field
     end
 
-    private def form_fields : Array(Symbol)
-      FORM_HEAD + ptype_fields + [:add]
+    private def head_fields : Array(Symbol)
+      [:ptype] + ptype_fields + [:add]
+    end
+
+    private def tail_fields : Array(Symbol)
+      @show_advanced ? [:mode, :advanced] + ADVANCED_FIELDS : [:mode, :advanced]
     end
 
     private def ptype_fields : Array(Symbol)
@@ -309,22 +321,25 @@ module Gori::Tui
     end
 
     private def field_count : Int32
-      form_fields.size + @sets.size
+      head_fields.size + @sets.size + tail_fields.size
     end
 
     private def current_field : Symbol
-      ff = form_fields
-      @cfg_field < ff.size ? ff[@cfg_field] : :set
+      h = head_fields.size
+      return head_fields[@cfg_field] if @cfg_field < h
+      return :set if @cfg_field < h + @sets.size
+      tail_fields[@cfg_field - h - @sets.size]? || :mode # `|| :mode` guards a stale index
     end
 
     private def current_set_index : Int32
-      @cfg_field - form_fields.size
+      @cfg_field - head_fields.size
     end
 
     # ↑/↓ — move the field cursor (caret resets to the end of the new field).
     def form_move(d : Int32) : Nil
       @cfg_field = (@cfg_field + d).clamp(0, {field_count - 1, 0}.max)
       @cfg_caret = field_text(current_field).size
+      sync_path_complete
     end
 
     # ←/→ — cycle an enum/toggle, else move the text caret.
@@ -332,15 +347,20 @@ module Gori::Tui
       case current_field
       when :mode      then cycle_mode(d)
       when :ptype     then cycle_ptype(d)
+      when :advanced  then toggle_advanced
       when :follow    then @config.follow_redirects = !@config.follow_redirects?; @dirty = true
       when :calibrate then toggle_calibrate
       else                 @cfg_caret = (@cfg_caret + d).clamp(0, field_text(current_field).size)
       end
     end
 
-    # ⏎ — on the Add field append the configured payload set; else step down.
+    # ⏎ — Add field appends the set, Advanced toggles the block, else step down.
     def form_enter : Nil
-      current_field == :add ? add_current_set : form_move(1)
+      case current_field
+      when :add      then add_current_set
+      when :advanced then toggle_advanced
+      else                form_move(1)
+      end
     end
 
     def form_delete : Nil
@@ -356,6 +376,7 @@ module Gori::Tui
         field_set(current_field, "#{s[0, @cfg_caret - 1]}#{s[@cfg_caret..]}")
         @cfg_caret -= 1
         @dirty = true
+        @path_complete.refresh(@p_path) if current_field == :p_path
       end
     end
 
@@ -365,6 +386,38 @@ module Gori::Tui
       field_set(current_field, "#{s[0, @cfg_caret]}#{ch}#{s[@cfg_caret..]}")
       @cfg_caret += 1
       @dirty = true
+      @path_complete.refresh(@p_path) if current_field == :p_path
+    end
+
+    # Keep the wordlist path popup in lockstep with the cursor: open/refresh while
+    # the :p_path field is focused, close on any other field.
+    private def sync_path_complete : Nil
+      current_field == :p_path ? @path_complete.refresh(@p_path) : @path_complete.close
+    end
+
+    # --- wordlist path completion (mirrors Convert's ChainComplete contract) -----
+    # True while the popup owns Tab/Enter/↑/↓/Esc — the runner's pre-ring guard routes
+    # those keys here (via the controller) before the focus ring claims Tab.
+    def path_completing? : Bool
+      @focus == :config && current_field == :p_path && @path_complete.open?
+    end
+
+    def path_complete_move(d : Int32) : Nil
+      @path_complete.move(d)
+    end
+
+    def path_complete_close : Nil
+      @path_complete.close
+    end
+
+    # Apply the highlighted completion: replace the field, jump the caret to the end,
+    # keep the popup open + drill on a directory, close on a file.
+    def path_complete_accept : Nil
+      res = @path_complete.accept || return
+      @p_path, is_dir = res
+      @cfg_caret = @p_path.size
+      @dirty = true
+      is_dir ? @path_complete.refresh(@p_path) : @path_complete.close
     end
 
     private def cycle_mode(d : Int32) : Nil
@@ -379,6 +432,7 @@ module Gori::Tui
       i = types.index(@ptype) || 0
       @ptype = types[(i + d) % types.size]
       @cfg_caret = 0
+      sync_path_complete # cursor stays on :ptype → closes a stale wordlist popup
     end
 
     private def toggle_calibrate : Nil
@@ -386,6 +440,13 @@ module Gori::Tui
       @config.auto_calibrate = on
       @matcher.auto_calibrate = on
       @dirty = true
+    end
+
+    # Collapse/expand the Advanced block. Pure UI state — NO @dirty (mirrors
+    # cycle_ptype); re-clamp the cursor since tail_fields just shrank/grew.
+    private def toggle_advanced : Nil
+      @show_advanced = !@show_advanced
+      @cfg_field = @cfg_field.clamp(0, {field_count - 1, 0}.max)
     end
 
     private def add_current_set : Nil
@@ -418,8 +479,8 @@ module Gori::Tui
 
     private def text_field?(f : Symbol) : Bool
       case f
-      when :mode, :ptype, :follow, :calibrate, :add, :set then false
-      else                                                     true
+      when :mode, :ptype, :follow, :calibrate, :add, :set, :advanced then false
+      else                                                                true
       end
     end
 
@@ -830,36 +891,69 @@ module Gori::Tui
       mx = inner.right
       y = inner.y
 
+      # 1. payload type tabs — the cursor lands here on entry
+      draw_ptype(screen, inner.x, y, mx, focused)
+      y += 1
+
+      # 2. the selected type's draft fields + add (capture the :p_path anchor)
+      x = inner.x + 2
+      ppath_x = nil
+      ppath_y = y
+      ptype_fields.each do |f|
+        if f == :p_path
+          ppath_x = x
+          ppath_y = y
+        end
+        x = draw_seg(screen, x, y, ptype_label(f), f, mx, focused)
+      end
+      draw_add(screen, x, y, mx, focused)
+      y += 2
+
+      # 3. payload sets (variable length) — capped so the tail stays on-screen
+      tail_h = @show_advanced ? 7 : 3
+      y = render_sets(screen, inner, y, focused, {inner.bottom - tail_h, y}.max)
+      y += 1
+
+      # 4. mode
       x = label_at(screen, inner.x, y, "Mode")
       x = draw_seg(screen, x, y, "", :mode, mx, focused)
       screen.text(x + 1, y, mode_formula, Theme.muted, Theme.bg) if x + 10 < mx
       y += 1
 
-      x = label_at(screen, inner.x, y, "Engine")
-      x = draw_seg(screen, x, y, "conc", :conc, mx, focused)
-      x = draw_seg(screen, x, y, "rate", :rate, mx, focused)
-      x = draw_seg(screen, x, y, "to", :timeout, mx, focused)
-      draw_seg(screen, x, y, "retry", :retries, mx, focused)
+      # 5. advanced toggle
+      draw_advanced(screen, inner.x, y, mx, focused)
       y += 1
 
-      x = label_at(screen, inner.x, y, "Opts")
-      x = draw_seg(screen, x, y, "follow", :follow, mx, focused)
-      draw_seg(screen, x, y, "calib", :calibrate, mx, focused)
-      y += 1
+      # 6. advanced block — only when expanded
+      if @show_advanced
+        x = label_at(screen, inner.x, y, "Engine")
+        x = draw_seg(screen, x, y, "conc", :conc, mx, focused)
+        x = draw_seg(screen, x, y, "rate", :rate, mx, focused)
+        x = draw_seg(screen, x, y, "to", :timeout, mx, focused)
+        draw_seg(screen, x, y, "retry", :retries, mx, focused)
+        y += 1
 
-      y = render_cond_line(screen, inner.x, y, mx, focused, "Match", :m_status, :m_size, :m_words, :m_regex)
-      y = render_cond_line(screen, inner.x, y, mx, focused, "Filtr", :f_status, :f_size, :f_words, :f_regex)
-      y += 1
+        x = label_at(screen, inner.x, y, "Opts")
+        x = draw_seg(screen, x, y, "follow", :follow, mx, focused)
+        draw_seg(screen, x, y, "calib", :calibrate, mx, focused)
+        y += 1
 
-      draw_ptype(screen, inner.x, y, mx, focused)
-      y += 1
+        y = render_cond_line(screen, inner.x, y, mx, focused, "Match", :m_status, :m_size, :m_words, :m_regex)
+        render_cond_line(screen, inner.x, y, mx, focused, "Filtr", :f_status, :f_size, :f_words, :f_regex)
+      end
 
-      x = inner.x + 2
-      ptype_fields.each { |f| x = draw_seg(screen, x, y, ptype_label(f), f, mx, focused) }
-      draw_add(screen, x, y, mx, focused)
-      y += 2
+      # the wordlist completion popup floats over the lines below the :p_path field
+      if @ptype == :wordlist && (ax = ppath_x) && @path_complete.open?
+        @path_complete.render(screen, ax, ppath_y + 1, inner)
+      end
+    end
 
-      render_sets(screen, inner, y, focused)
+    private def draw_advanced(screen, x, y, mx, pane_focused) : Nil
+      foc = pane_focused && current_field == :advanced
+      label = @show_advanced ? "▾ Advanced" : "▸ Advanced (Engine · Match · Filter)"
+      bg = foc ? Theme.accent_bg : Theme.bg
+      fg = foc ? Theme.text_bright : Theme.muted
+      screen.text(x, y, label, fg, bg, width: {mx - x, 1}.max)
     end
 
     private def render_cond_line(screen, ox, y, mx, focused, label, st, sz, wd, re) : Int32
@@ -871,15 +965,19 @@ module Gori::Tui
       y + 1
     end
 
-    private def render_sets(screen, inner, y, focused) : Nil
+    # Render the "Sets" header + rows, bounded so the rows never overrun `limit`
+    # (the bottom budget reserved for the Mode/Advanced tail). Overflow collapses
+    # into a "… +N more" line. Returns the next free y.
+    private def render_sets(screen, inner, y, focused, limit : Int32) : Int32
       screen.text(inner.x, y, "Sets", Theme.muted, Theme.bg)
       y += 1
       if @sets.empty?
         screen.text(inner.x + 2, y, "(none — pick a type above, ⏎ add)", Theme.muted, Theme.bg)
-        return
+        return y + 1
       end
-      @sets.each_with_index do |s, i|
-        break if y >= inner.bottom
+      avail = {limit - y, 1}.max
+      shown = @sets.size <= avail ? @sets.size : {avail - 1, 0}.max
+      @sets.first(shown).each_with_index do |s, i|
         sel = focused && current_field == :set && current_set_index == i
         bg = sel ? Theme.accent_bg : Theme.bg
         screen.fill(Rect.new(inner.x, y, inner.w, 1), bg) if sel
@@ -888,6 +986,11 @@ module Gori::Tui
           sel ? Theme.text_bright : Theme.text, bg, width: {inner.w - 2, 1}.max)
         y += 1
       end
+      if shown < @sets.size
+        screen.text(inner.x + 1, y, "… +#{@sets.size - shown} more", Theme.muted, Theme.bg)
+        y += 1
+      end
+      y
     end
 
     private def label_at(screen, x, y, label) : Int32
@@ -1080,6 +1183,124 @@ module Gori::Tui
         mx < rest.x + half ? :template : :config
       else
         @focus == :detail ? :detail : :results
+      end
+    end
+  end
+
+  # Inline filesystem path completion for the wordlist payload field. Mirrors the
+  # Convert tab's ChainComplete (scroll-window dropdown) but with path-aware accept:
+  # it keeps the typed directory prefix, replaces only the basename, and appends "/"
+  # to directories so the user can keep drilling. Bare names (no "/") complete from
+  # BOTH the current working dir and ~/.gori/wordlists. Per-directory child caching
+  # keeps steady-state keystrokes off the filesystem.
+  class PathComplete
+    CAP = 60
+
+    record Entry, label : String, insert : String, dir : Bool
+
+    getter? open : Bool = false
+    getter entries : Array(Entry) = [] of Entry
+    getter selected : Int32 = 0
+    @scroll = 0
+    @cache = {} of String => Array(String) # dir → sorted children
+
+    def refresh(value : String) : Nil
+      @entries = candidates(value)
+      @selected = 0
+      @scroll = 0
+      @open = !@entries.empty?
+    end
+
+    def move(d : Int32) : Nil
+      return if @entries.empty?
+      @selected = (@selected + d).clamp(0, @entries.size - 1)
+    end
+
+    def close : Nil
+      @open = false
+    end
+
+    # The chosen insert string + whether it is a directory (the caller keeps the
+    # popup open + refreshes on a dir, closes on a file). nil when nothing selectable.
+    def accept : {String, Bool}?
+      e = @entries[@selected]? || return nil
+      {e.insert, e.dir}
+    end
+
+    private def candidates(value : String) : Array(Entry)
+      if slash = value.rindex('/')
+        prefix = value[0..slash] # kept verbatim, incl. trailing '/'
+        partial = value[(slash + 1)..]
+        read_dir = Path[prefix].expand(home: true).to_s
+        merged = ranked(read_dir, partial).map do |name, is_dir, rank|
+          {Entry.new(name, "#{prefix}#{name}#{is_dir ? "/" : ""}", is_dir), rank}
+        end
+        merge_cap(merged)
+      else
+        # bare name → cwd (bare insert) + ~/.gori/wordlists (ABSOLUTE insert: the
+        # engine opens wordlist paths relative to CWD, so a wordlists-dir-only name
+        # MUST resolve absolutely or it would fail at run time). Both sources are
+        # ranked TOGETHER so a prefix/wordlist hit isn't buried under cwd fuzz.
+        wl = Gori::Paths.wordlists_dir
+        merged = ranked(Dir.current, value).map do |name, is_dir, rank|
+          {Entry.new(name, "#{name}#{is_dir ? "/" : ""}", is_dir), rank}
+        end
+        ranked(wl, value).each do |name, is_dir, rank|
+          merged << {Entry.new("#{name}  ·~/.gori", "#{File.join(wl, name)}#{is_dir ? "/" : ""}", is_dir), rank}
+        end
+        merge_cap(merged)
+      end
+    end
+
+    private def merge_cap(scored : Array({Entry, Int32})) : Array(Entry)
+      scored.sort_by! { |(e, rank)| {-rank, e.label} }
+      scored.first(CAP).map { |(e, _)| e }
+    end
+
+    # Children of `dir` matching `partial` (case-insensitive prefix OR fuzzy),
+    # ranked prefix-first then by score then name. Returns [{name, dir?, rank}],
+    # capped; only the survivors are stat'd for directory-ness.
+    private def ranked(dir : String, partial : String) : Array({String, Bool, Int32})
+      pl = partial.downcase
+      scored = children_of(dir).compact_map do |name|
+        dn = name.downcase
+        if partial.empty?
+          {name, 1}
+        elsif dn.starts_with?(pl)
+          {name, 1_000_000}
+        elsif s = Gori::Fuzzy.score(pl, dn)
+          {name, s}
+        else
+          nil
+        end
+      end
+      scored.sort_by! { |(name, rank)| {-rank, name} }
+      scored.first(CAP).map { |(name, rank)| {name, File.directory?(File.join(dir, name)), rank} }
+    end
+
+    # Per-directory children cache (bounded): re-read only when a dir is first seen.
+    private def children_of(dir : String) : Array(String)
+      @cache.clear if @cache.size > 8
+      @cache[dir] ||= (Dir.children(dir).sort rescue [] of String)
+    end
+
+    # Frame-less dropdown anchored at (x, y), clamped within `inner`. Same scroll +
+    # accent-bg selection as ChainComplete.
+    def render(screen : Screen, x : Int32, y : Int32, inner : Rect) : Nil
+      return if !@open || @entries.empty?
+      w = ({@entries.max_of(&.label.size) + 2, 18}.max).clamp(1, {inner.right - x, 1}.max)
+      h = {@entries.size, 8, {inner.bottom - y, 1}.max}.min
+      return if h <= 0
+      @scroll = @selected if @selected < @scroll
+      @scroll = @selected - h + 1 if @selected >= @scroll + h
+      @scroll = @scroll.clamp(0, {@entries.size - h, 0}.max)
+      (0...h).each do |i|
+        e = @entries[@scroll + i]? || break
+        active = (@scroll + i) == @selected
+        bg = active ? Theme.accent_bg : Theme.elevated
+        screen.fill(Rect.new(x, y + i, w, 1), bg)
+        screen.cell(x, y + i, active ? '▎' : ' ', Theme.accent, bg)
+        screen.text(x + 1, y + i, e.label, active ? Theme.text_bright : Theme.text, bg, width: {w - 1, 1}.max)
       end
     end
   end

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -58,8 +58,9 @@ module Gori::Tui
       {"FUZZER", [
         {"⇧I", "send a flow/replay here (History/Replay)"},
         {"^A · ^K · ^T · ^U", "auto-mark params · mark word · mark point (manual §) · clear §"},
-        {"^O", "focus the config pane"},
-        {"config", "mode/list/file/num/null/brute/match/filter…"},
+        {"^O", "focus the config pane (lands on Payload)"},
+        {"config", "payload type/fields · ⏎ +add · ▸ Advanced (mode/engine/match/filter)"},
+        {"wordlist path", "⇥/type to auto-complete from the dir + ~/.gori/wordlists"},
         {"^R · ^X", "run · stop"},
         {"↑/↓ · ↵", "results: select · open detail"},
         {"o · m", "sort · matched-only · ^N/^W session"},

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -434,6 +434,12 @@ module Gori::Tui
       if @active_tab == :convert && @overlay == :none && @focus == :body && convert_controller.completing?
         return if convert_controller.handle_complete_key(ev)
       end
+      # The Fuzzer wordlist-path autocomplete owns Tab/↵/↑/↓/Esc while its popup is up —
+      # before the focus ring claims Tab. Gated on the :p_path field + an open popup, so
+      # Tab on any other field/pane still advances panes. Non-popup keys fall through.
+      if @active_tab == :fuzzer && @overlay == :none && @focus == :body && fuzzer_controller.path_completing?
+        return if fuzzer_controller.handle_path_complete_key(ev)
+      end
 
       # Focusable sub-tab strip (Replay/Notes): ←/→ switch sub-tabs, ↓/↵ drop into
       # the editor, ↑/esc pop to the tab bar. Claimed BEFORE the Tab ring + ^N so the


### PR DESCRIPTION
## Why

Two friction points in the TUI Fuzzer's CONFIG area:
- Reaching the **Payload** setting required ~15 ↓ presses past Engine/Opts/Match/Filter — knobs most users never touch.
- The Wordlist field was a bare text input: you had to know the exact file path.

## What

**1. Payload-first CONFIG + collapsible Advanced**
- Entering config (`^O`) now lands on the payload type. Order: `Payload (type/fields/+add) → Sets → Mode → ▸ Advanced`.
- Engine/Opts/Match/Filter collapse behind a `▸ Advanced` toggle (Enter/←/→). Pure UI state — no new keybinding, no persistence/`@dirty` impact.
- Cursor model = head/tail split around the variable-length `:set` rows; `render_sets` caps to a bottom budget (`… +N more`) so the tail stays visible.

**2. Wordlist inline path auto-complete**
- New `PathComplete` popup (modeled on Convert's `ChainComplete`) lists only the typed directory — cheaper than a recursive fuzzy-finder, with per-directory child caching (zero FS reads on steady-state keystrokes).
- Bare names complete from the current dir **and** a new `~/.gori/wordlists` convention; cwd (fuzzy) + wordlist (prefix) matches are ranked together.
- Reuses the Convert pre-ring Tab-guard pattern; the view stays free of Termisu event types (controller dispatches).

### Correctness (G1)
`WordlistFile` opens paths relative to the process CWD, so a name found only in `~/.gori/wordlists` is inserted as an **absolute** path — a bare insert would fail at run time. Proven end-to-end in a live run (the fuzz used the wordlists-dir-only file's lines as payloads).

## Verification
- `crystal tool format` clean (changed files), ameba clean bar the 2 pre-existing tolerated `set_preedit` warnings.
- Full suite: **683 examples, 0 failures** (incl. 4 new `PathComplete` unit tests).
- Live tmux run: payload-first layout, `^O` landing, wordlist completion + ranking, absolute-path accept, engine reads the file, Advanced expand/collapse.

Note (intended, G3): while the path popup is open it owns ↓/Enter — leave the field with Esc then ↓ (shown in the hint line).