### PR TITLE
feat(tui): fuzzer New parity with Replay — target-first focus + ^N chord

### DIFF
--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -79,7 +79,7 @@ module Gori::Tui
       return "↹/esc tabs · ^N new" unless v
       case v.focus
       when :target   then "type URL · ↵/↓ template · ^R run · ↹ pane · esc tabs"
-      when :template then "type · ^A params · ^K word · ^T point · ^U clear · ^O config · ^R run · ↹ pane"
+      when :template then "type · ^A params · ^K word · ^T point · ^U clear · ^O config · ^R run · ^N new · ↹ pane"
       when :config   then config_hint(v)
       when :results  then "↑/↓ select · ↵ detail · o sort · m matched · ^R run · ^X stop · space cmds · ↹ pane"
       when :detail   then "↑/↓ scroll · ←/→ req/resp · esc back"
@@ -104,7 +104,7 @@ module Gori::Tui
         v.render(screen, body_rect, focused: body_focused)
       else
         BodyChrome.framed(screen, body_rect, body_focused) do |inner|
-          screen.text(inner.x + 1, inner.y, "no fuzz sessions — ⇧I from History/Replay · ^N new", Theme.muted)
+          screen.text(inner.x + 1, inner.y, "no fuzz sessions — ^N new session · ⇧I from History/Replay", Theme.muted)
         end
       end
     end
@@ -452,9 +452,9 @@ module Gori::Tui
     # --- new / close / cross-tab seeds ---
     def fuzz_new : Nil
       view = FuzzerView.new
-      view.load_request("https://example.com", "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n", false, "")
+      view.load_blank
       open_session(view, nil)
-      @host.status("new fuzz session — ^A mark params · ^O config · ^R run")
+      @host.status("new fuzz session — type the target URL · ^A mark params · ^O config · ^R run")
     end
 
     # ⇧I from History (or Findings evidence): open a captured flow as a fuzz session.

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -108,6 +108,15 @@ module Gori::Tui
       @dirty = false
     end
 
+    # A fresh, hand-authored fuzz session (^N). Focus starts on the TARGET field —
+    # the scaffold URL is a placeholder you almost always change first (mirrors
+    # ReplayView#load_blank; the ⇧I/from-Replay paths keep template focus since their
+    # URL is already real).
+    def load_blank : Nil
+      load_request("https://example.com", "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n", false, "")
+      @focus = :target
+    end
+
     def restore(rec : Store::FuzzSessionRecord) : Nil
       @target = rec.target
       @tcx = rec.target.size

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -58,13 +58,14 @@ module Gori::Tui
       ]},
       {"FUZZER", [
         {"⇧I", "send a flow/replay here (History/Replay)"},
+        {"^N / ^W", "new / close a sub-tab"},
         {"^A · ^K · ^T · ^U", "auto-mark params · mark word · mark point (manual §) · clear §"},
         {"^O", "focus the config pane (lands on Payload)"},
         {"config", "payload type/fields · ⏎ +add · ▸ Advanced (mode/engine/match/filter)"},
         {"wordlist path", "⇥/type to auto-complete from the dir + ~/.gori/wordlists"},
         {"^R · ^X", "run · stop"},
         {"↑/↓ · ↵", "results: select · open detail"},
-        {"o · m", "sort · matched-only · ^N/^W session"},
+        {"o · m", "sort · matched-only"},
         {"r", "rename the sub-tab (on the strip)"},
       ]},
       {"COMPARER", [

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -163,6 +163,7 @@ module Gori
         [Verb::Chord.new("x", ctrl: true)], available: in_fuzzer, mnemonic: 's') { |ctx| ctx.fuzz_stop; nil }
       r.register Verb::Definition.new(
         "fuzz.new", "New fuzz session", "Open a blank fuzz template", Verb::Scope::Fuzzer,
+        [Verb::Chord.new("n", ctrl: true)],
         available: in_fuzzer, mnemonic: 'n') { |ctx| ctx.fuzz_new; nil }
       r.register Verb::Definition.new(
         "fuzz.automark", "Auto-mark params", "Mark every request parameter value", Verb::Scope::Fuzzer,


### PR DESCRIPTION
## What

When you create a new Fuzzer session, focus now lands on the **TARGET (URL)** field first instead of the template — matching Replay's behavior. The scaffold URL (`https://example.com`) is a placeholder you almost always change first, so this is the natural first focus.

Also brings the Fuzzer's **New** affordance to full parity with Replay.

## Changes

- **Target-first focus on New** — `FuzzerView#load_blank` (new) loads the scaffold then focuses `:target`, mirroring `ReplayView#load_blank`. `fuzz_new` uses it. The `⇧I`-from-History and from-Replay paths are **untouched** — they keep `:template` focus since their URL is already real.
- **`^N` chord on `fuzz.new`** — registered for palette/Help hint derivation, exactly like `replay.new`. Both stay in `FIXED_IDS` (not rebindable) because their `^N` is consumed by the runner's hardcoded handler before the keymap.
- **Help tab** — promote Fuzzer's `^N / ^W` to its own "new / close a sub-tab" row (was buried at the tail of the `o · m` line), matching Replay.
- **Hints** — template-editor hint now advertises `^N new`; the empty-state hint leads with `^N new session`.

## Verification

- `crystal build` ✓, `crystal tool format` clean on touched files.
- 322 specs pass (`spec/tui` incl. `space_menu_spec`, `spec/verb`, `hotkeys`, `fuzz*`, `mcp_fuzz`).
- Live TUI (tmux): new `^N` session → typing lands in the TARGET URL; `⇧I` session → typing lands in the TEMPLATE body (unchanged). Help row + hints render as expected.