### PR TITLE
feat(tui): expand the `space` action menu to detail panes + Project scope

### DIFF
--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -96,6 +96,18 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def scope_toggle_lens : Nil; end
 
+  property scope_has_rule : Bool = false
+
+  def scope_add_rule : Nil; end
+
+  def scope_edit_rule : Nil; end
+
+  def scope_delete_rule : Nil; end
+
+  def scope_rule_selected? : Bool
+    @scope_has_rule
+  end
+
   def rules_open : Nil; end
 
   def finding_create : Nil; end

--- a/spec/tui/space_menu_spec.cr
+++ b/spec/tui/space_menu_spec.cr
@@ -41,10 +41,52 @@ describe Gori::Tui::SpaceMenu do
     menu.selected.should eq(menu.entries.size - 1)
   end
 
+  it "lists the open flow's actions in the History detail scope (mirrors the list menu)" do
+    ctx = FakeExecContext.new
+    ctx.selected = 5_i64
+    menu = SpaceMenu.new(Gori::Verbs.registry)
+    menu.open(Gori::Verb::Scope::HistoryDetail, ctx) # detail drill-in is navigable now
+
+    menu.entries.size.should be > 0
+    menu.entries.all?(&.scope.history_detail?).should be_true   # strictly scope-local
+    ids = menu.entries.map(&.id)
+    ids.should contain("detail.replay")    # flow action carried over from the list
+    ids.should contain("detail.toggle-hex") # a detail-only view toggle
+    menu.verb_for('r').try(&.id).should eq("detail.replay")
+    menu.verb_for('x').try(&.id).should eq("detail.toggle-hex")
+  end
+
+  it "lists the scope-rule actions in the Project scope pane (space replaced the lens toggle)" do
+    ctx = FakeExecContext.new
+    ctx.scope_has_rule = true # edit/delete are gated on a selected rule
+    menu = SpaceMenu.new(Gori::Verbs.registry)
+    menu.open(Gori::Verb::Scope::Project, ctx)
+
+    ids = menu.entries.map(&.id)
+    ids.should contain("scope.lens-toggle") # the lens toggle is now a menu item, not a bare space key
+    ids.should contain("scope.add-rule")
+    ids.should contain("scope.edit-rule")
+    ids.should contain("scope.delete-rule")
+    menu.verb_for('s').try(&.id).should eq("scope.lens-toggle")
+    menu.verb_for('a').try(&.id).should eq("scope.add-rule")
+  end
+
+  it "hides the scope rule edit/delete entries when no rule is selected" do
+    ctx = FakeExecContext.new # scope_has_rule defaults to false
+    menu = SpaceMenu.new(Gori::Verbs.registry)
+    menu.open(Gori::Verb::Scope::Project, ctx)
+
+    ids = menu.entries.map(&.id)
+    ids.should contain("scope.lens-toggle") # always available
+    ids.should contain("scope.add-rule")    # always available
+    ids.should_not contain("scope.edit-rule")
+    ids.should_not contain("scope.delete-rule")
+  end
+
   it "no-ops (empty entries) for a scope with only hidden nav verbs" do
     ctx = FakeExecContext.new
     menu = SpaceMenu.new(Gori::Verbs.registry)
-    menu.open(Gori::Verb::Scope::HistoryDetail, ctx) # detail verbs are all hidden
+    menu.open(Gori::Verb::Scope::Sidebar, ctx) # tab-bar nav verbs are all hidden
     menu.entries.empty?.should be_true
   end
 
@@ -88,6 +130,8 @@ describe Gori::Tui::SpaceMenu do
     menu_scopes = [
       Gori::Verb::Scope::Body, Gori::Verb::Scope::Replay, Gori::Verb::Scope::Findings,
       Gori::Verb::Scope::Comparer, Gori::Verb::Scope::Fuzzer, Gori::Verb::Scope::Intercept,
+      Gori::Verb::Scope::HistoryDetail, Gori::Verb::Scope::FindingsDetail,
+      Gori::Verb::Scope::Project,
     ]
     menu_scopes.each do |scope|
       verbs = registry.select { |v| v.scope == scope && !v.hidden? }

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -184,6 +184,22 @@ private class FakeContext < ExecContext
     @calls << :scope_toggle_lens
   end
 
+  def scope_add_rule : Nil
+    @calls << :scope_add_rule
+  end
+
+  def scope_edit_rule : Nil
+    @calls << :scope_edit_rule
+  end
+
+  def scope_delete_rule : Nil
+    @calls << :scope_delete_rule
+  end
+
+  def scope_rule_selected? : Bool
+    true
+  end
+
   def rules_open : Nil
     @calls << :rules_open
   end

--- a/src/gori/tui/controllers/findings_controller.cr
+++ b/src/gori/tui/controllers/findings_controller.cr
@@ -33,7 +33,7 @@ module Gori::Tui
     end
 
     def body_hint(focus : Symbol) : String
-      @findings.detail_open? ? "[ ] sev · { } status · t title · e notes · o flow · r replay · d del · ←/esc back" \
+      @findings.detail_open? ? "[ ] sev · { } status · t title · e notes · o flow · r replay · d del · space cmds · ←/esc back" \
                              : "↑/↓ move · ↵ open · n new · d delete · x export · space cmds · esc tabs"
     end
 

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -22,8 +22,11 @@ module Gori::Tui
       :project
     end
 
+    # The SCOPE rule list is a navigable area with its own action menu (Project scope);
+    # the DESCRIPTION pane is a text editor (no menu — space is literal there), so its
+    # scope is irrelevant (Body, like the other editor tabs).
     def command_scope : Verb::Scope
-      Verb::Scope::Body
+      @project_view.pane == :scope ? Verb::Scope::Project : Verb::Scope::Body
     end
 
     def body_badge : Symbol # the description editor + scope add-row capture text; the rule list is nav
@@ -35,7 +38,7 @@ module Gori::Tui
       if @project_view.pane == :scope
         @project_view.adding? \
           ? "type pattern · ^K kind · ^T type · ↵ save · esc cancel" \
-          : "↑/↓ move · → desc · a add · ↵/e edit · d del · space on/off · esc tabs"
+          : "↑/↓ move · → desc · a add · ↵/e edit · d del · space cmds · esc tabs"
       else
         "type to edit · ↑/↓/↔ move · ← scope · ^G goto · ^F find · ^B ws · esc tabs"
       end
@@ -51,8 +54,15 @@ module Gori::Tui
     end
 
     def handle_body_key(ev : Termisu::Event::Key) : Bool
-      @project_view.pane == :scope ? handle_project_scope_key(ev) : handle_project_desc_key(ev)
-      true
+      # The SCOPE pane defers its action keys (a/e/d → Project verbs, space → action menu,
+      # Global chords → capture/rules/…) to the keymap by returning false; the DESCRIPTION
+      # editor swallows everything (text).
+      if @project_view.pane == :scope
+        handle_project_scope_key(ev)
+      else
+        handle_project_desc_key(ev)
+        true
+      end
     end
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
@@ -153,11 +163,12 @@ module Gori::Tui
     end
 
     # --- SCOPE pane: browse the rule list (or route to the inline add/edit row) ---
-    private def handle_project_scope_key(ev : Termisu::Event::Key) : Nil
-      return handle_project_add_key(ev) if @project_view.adding?
+    # Returns true when consumed; false defers to the keymap — a/e/d fire the scope.*-rule
+    # verbs, space opens the action menu, and Global chords (capture/rules/…) work here too
+    # (the list is navigable, like History). The add-row sub-mode swallows everything (text).
+    private def handle_project_scope_key(ev : Termisu::Event::Key) : Bool
+      return (handle_project_add_key(ev); true) if @project_view.adding?
       key = ev.key
-      c = ev.char || key.to_char
-      plain = c && !ev.ctrl? && !ev.alt?
       if ev.ctrl? && key.lower_p?
         save
         @host.open_palette
@@ -172,17 +183,24 @@ module Gori::Tui
         @project_view.pane_advance(1) # → crosses from the SCOPE list to the DESCRIPTION (right pane)
       elsif key.enter?
         @project_view.scope_edit_start
-      elsif plain && c == ' '
-        @project_view.scope_toggle
-        toast_scope_state
-      elsif plain && c == 'a'
-        @project_view.scope_add_start
-      elsif plain && c == 'e'
-        @project_view.scope_edit_start
-      elsif plain && c == 'd'
-        if pat = @project_view.scope_delete
-          @host.status("removed scope rule: #{pat}")
-        end
+      else
+        return false # a/e/d (scope.*-rule verbs), space (action menu), Global chords
+      end
+      true
+    end
+
+    # --- SCOPE rule verbs (a/e/d via the keymap + the Project action menu) ---
+    def scope_add_rule : Nil
+      @project_view.scope_add_start
+    end
+
+    def scope_edit_rule : Nil
+      @project_view.scope_edit_start
+    end
+
+    def scope_delete_rule : Nil
+      if pat = @project_view.scope_delete
+        @host.status("removed scope rule: #{pat}")
       end
     end
 
@@ -195,7 +213,10 @@ module Gori::Tui
         if !scope.enabled?
           "scope lens OFF — showing all flows"
         elsif n == 0
-          "scope lens ON, but no rules yet — add some in Project (s)"
+          # Signpost the add path for where the toggle fired: 'a' on the Project scope
+          # pane itself, else 's' (scope.edit) to jump here from History/Sitemap.
+          @host.active_tab == :project ? "scope lens ON, but no rules yet — add one here (a)" \
+                                       : "scope lens ON, but no rules yet — add some in Project (s)"
         else
           "scope lens ON — showing in-scope only (#{n} rule#{n == 1 ? "" : "s"})"
         end
@@ -235,9 +256,9 @@ module Gori::Tui
       when :ok
         n = @host.session.scope.size
         # Confirm the add AND surface that the lens is still off (the common "I added
-        # a rule but nothing filtered" confusion — space enables it).
+        # a rule but nothing filtered" confusion — the space menu's 's' enables it).
         @host.status(@host.session.scope.enabled? ? "scope rule added — #{n} rule#{n == 1 ? "" : "s"}" \
-                                                   : "scope rule added — #{n} rule#{n == 1 ? "" : "s"} · press space to enable the lens")
+                                                   : "scope rule added — #{n} rule#{n == 1 ? "" : "s"} · space → s to enable the lens")
       end
     end
   end

--- a/src/gori/tui/hotkeys_overlay.cr
+++ b/src/gori/tui/hotkeys_overlay.cr
@@ -30,6 +30,7 @@ module Gori::Tui
       Verb::Scope::FindingsDetail => "FINDING DETAIL",
       Verb::Scope::Intercept      => "INTERCEPT",
       Verb::Scope::Comparer       => "COMPARER",
+      Verb::Scope::Project        => "PROJECT SCOPE",
       Verb::Scope::PaletteOpen    => "PALETTE",
     }
 

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -264,10 +264,6 @@ module Gori::Tui
       rule.pattern
     end
 
-    def scope_toggle : Nil
-      @scope.toggle
-    end
-
     private def current_rule : Scope::Rule?
       @scope.rules[@sel]?
     end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -520,12 +520,13 @@ module Gori::Tui
 
       # "space" opens the focused area's action menu (helix leader). Placed AFTER the
       # scoped keymap so any area that already binds space wins — Sitemap's space
-      # toggles a tree node (sitemap.toggle), and Project's controller claims space
-      # for the scope-rule toggle above. Only reached in NAVIGABLE contexts: text
-      # editors (Replay request/target, Notes, Project desc, the QL "/" bar, Findings
-      # notes, Intercept edit) swallow keys upstream, so space stays a literal char
-      # there. (The read-only Replay response pane + the Intercept queue route space
-      # from their own handlers, which return before this point.)
+      # toggles a tree node (sitemap.toggle). The Project SCOPE pane instead DEFERS
+      # space to here (its lens toggle is the menu-only scope.lens-toggle verb). Only
+      # reached in NAVIGABLE contexts: text editors (Replay request/target, Notes,
+      # Project desc, the QL "/" bar, Findings notes, Intercept edit) swallow keys
+      # upstream, so space stays a literal char there. (The read-only Replay response
+      # pane + the Intercept queue route space from their own handlers, which return
+      # before this point.)
       open_space_menu if ev.key.space? && !ev.ctrl? && !ev.alt?
     end
 
@@ -1558,7 +1559,7 @@ module Gori::Tui
       when :settings    then "↑/↓ field · type to edit · ↵ save · esc close"
       when :tabs        then "↑/↓ select · space show/hide · K/J reorder · ↵ save · esc cancel"
       when :hotkeys     then @hotkeys_overlay.capturing? ? "press a key to bind · esc cancel" : "↑/↓ select · e/␣ rebind · x unbind · r reset · ⇧R reset all · ←/→ profile · ↵ save · esc"
-      when :detail      then "←/→ panes · ↑/↓ scroll · ^R replay · ⇧F finding · x hex · p pretty · ^G goto · ^F find · esc back"
+      when :detail      then "←/→ panes · ↑/↓ scroll · ^R replay · ⇧F finding · x hex · p pretty · space cmds · ^G goto · ^F find · esc back"
       else
         # Focus on the tab bar: ←/→ pick the tab, Tab/↵ drop into the body.
         return "←/→ switch tab · ↹/↵ enter · 1-9 jump · ^P cmds · q projects · ^D quit" if @focus == :menu
@@ -2046,6 +2047,23 @@ module Gori::Tui
       history_controller.view.reload(@session.store)
       sitemap_controller.reload if @active_tab == :sitemap
       project_controller.toast_scope_state
+    end
+
+    # Project SCOPE-pane rule editing (the inline a/e/d keys + its space menu both route here).
+    def scope_add_rule : Nil
+      project_controller.scope_add_rule
+    end
+
+    def scope_edit_rule : Nil
+      project_controller.scope_edit_rule
+    end
+
+    def scope_delete_rule : Nil
+      project_controller.scope_delete_rule
+    end
+
+    def scope_rule_selected? : Bool
+      @scope.size > 0
     end
 
     def sitemap_move(delta : Int32) : Nil

--- a/src/gori/verb.cr
+++ b/src/gori/verb.cr
@@ -19,6 +19,7 @@ module Gori
       FindingsDetail # a finding's detail is open
       Intercept      # the Intercept queue tab has focus
       Comparer       # the Comparer tab has focus
+      Project        # the Project tab's SCOPE rule list has focus
       PaletteOpen    # the command palette overlay is up
     end
 

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -81,6 +81,12 @@ module Gori
       abstract def scope_add_host : Nil    # add the selected flow's host to scope
       abstract def scope_toggle_lens : Nil # toggle the scope display lens on/off (filters History/Sitemap)
 
+      # scope rule editing (Project tab SCOPE pane — also drives its "space" action menu)
+      abstract def scope_add_rule : Nil        # open the inline add-row for a new rule
+      abstract def scope_edit_rule : Nil       # edit the selected rule in the add-row
+      abstract def scope_delete_rule : Nil     # remove the selected rule
+      abstract def scope_rule_selected? : Bool # a scope rule is selected (gates edit/delete in the menu)
+
       # match&replace lens
       abstract def rules_open : Nil # open the match&replace overlay editor
 

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -81,6 +81,24 @@ module Gori
         Verb::Scope::Body, [Verb::Chord.new("s", shift: true)],
         available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :history }, mnemonic: 's') { |ctx| ctx.scope_toggle_lens; nil }
 
+      # --- Project tab SCOPE pane: the rule-list action menu (space) + its a/e/d keys.
+      # Project scope is unique to that pane, so no current_tab gate is needed. The lens
+      # toggle is menu-only (mnemonic 's') — it REPLACED the old direct space=toggle, which
+      # now opens this menu instead; add/edit/delete keep their a/e/d direct chords.
+      scope_rule = ->(ctx : Verb::ExecContext) { ctx.scope_rule_selected? }
+      r.register Verb::Definition.new(
+        "scope.lens-toggle", "Toggle scope lens", "Filter History/Sitemap to in-scope flows on/off",
+        Verb::Scope::Project, mnemonic: 's') { |ctx| ctx.scope_toggle_lens; nil }
+      r.register Verb::Definition.new(
+        "scope.add-rule", "Add scope rule", "Open the inline row to add an include/exclude rule",
+        Verb::Scope::Project, [Verb::Chord.new("a")]) { |ctx| ctx.scope_add_rule; nil }
+      r.register Verb::Definition.new(
+        "scope.edit-rule", "Edit scope rule", "Edit the selected scope rule in place",
+        Verb::Scope::Project, [Verb::Chord.new("e")], available: scope_rule) { |ctx| ctx.scope_edit_rule; nil }
+      r.register Verb::Definition.new(
+        "scope.delete-rule", "Delete scope rule", "Remove the selected scope rule",
+        Verb::Scope::Project, [Verb::Chord.new("d")], available: scope_rule) { |ctx| ctx.scope_delete_rule; nil }
+
       r.register Verb::Definition.new(
         "rules.edit", "Match & Replace", "Edit in-flight request/response head rewrite rules", Verb::Scope::Global,
         [Verb::Chord.new("m")]) { |ctx| ctx.rules_open; nil }

--- a/src/gori/verbs/findings.cr
+++ b/src/gori/verbs/findings.cr
@@ -18,9 +18,13 @@ module Gori
         "findings.up", "Select previous finding", "Move up", Verb::Scope::Findings,
         [Verb::Chord.new("up"), Verb::Chord.new("k")], hidden: true) { |ctx| ctx.findings_move(-1); nil }
 
+      # open/delete are NON-hidden so they join New in the Findings list's "space" menu
+      # (the palette stays Global-only, so this doesn't leak there). open carries an
+      # explicit 'o' mnemonic — its primary chord is enter/l, which would otherwise
+      # front the menu with the unintuitive 'l'.
       r.register Verb::Definition.new(
         "findings.open", "Open finding", "View/edit the selected finding", Verb::Scope::Findings,
-        [Verb::Chord.new("enter"), Verb::Chord.new("l"), Verb::Chord.new("right")], hidden: true) { |ctx| ctx.findings_open; nil }
+        [Verb::Chord.new("enter"), Verb::Chord.new("l"), Verb::Chord.new("right")], mnemonic: 'o') { |ctx| ctx.findings_open; nil }
 
       r.register Verb::Definition.new(
         "findings.new", "New finding", "Create a blank finding", Verb::Scope::Findings,
@@ -28,7 +32,7 @@ module Gori
 
       r.register Verb::Definition.new(
         "findings.delete", "Delete finding", "Delete the selected finding", Verb::Scope::Findings,
-        [Verb::Chord.new("d")], hidden: true) { |ctx| ctx.findings_delete; nil }
+        [Verb::Chord.new("d")]) { |ctx| ctx.findings_delete; nil }
 
       r.register Verb::Definition.new(
         "findings.leave", "Back to menu", "Return focus to the tab menu", Verb::Scope::Findings,
@@ -47,13 +51,18 @@ module Gori
         "finding.severity-down", "Lower severity", "Decrease severity", Verb::Scope::FindingsDetail,
         [Verb::Chord.new("["), Verb::Chord.new("left")], hidden: true) { |ctx| ctx.finding_severity(-1); nil }
 
+      # edit-notes/edit-title/open-flow/replay-flow/delete are NON-hidden so they front
+      # the finding-detail "space" action menu (parity with the History detail; the
+      # palette stays Global-only, so this doesn't leak there). Each menu key derives
+      # from its plain chord — the key you'd press directly. severity/status keep their
+      # bracket chords ([ ] { }) hidden (awkward as menu mnemonics; discoverable in Help).
       r.register Verb::Definition.new(
         "finding.edit-notes", "Edit notes", "Edit the finding notes inline", Verb::Scope::FindingsDetail,
-        [Verb::Chord.new("e"), Verb::Chord.new("enter")], hidden: true) { |ctx| ctx.finding_edit_notes; nil }
+        [Verb::Chord.new("e"), Verb::Chord.new("enter")]) { |ctx| ctx.finding_edit_notes; nil }
 
       r.register Verb::Definition.new(
         "finding.delete", "Delete finding", "Delete this finding", Verb::Scope::FindingsDetail,
-        [Verb::Chord.new("d")], hidden: true) { |ctx| ctx.findings_delete; nil }
+        [Verb::Chord.new("d")]) { |ctx| ctx.findings_delete; nil }
 
       r.register Verb::Definition.new(
         "finding.status-up", "Advance status", "Cycle triage status forward (open→confirmed→fp→resolved)",
@@ -65,15 +74,15 @@ module Gori
 
       r.register Verb::Definition.new(
         "finding.edit-title", "Edit title/severity", "Rename the finding and set its severity",
-        Verb::Scope::FindingsDetail, [Verb::Chord.new("t")], hidden: true) { |ctx| ctx.finding_edit_title; nil }
+        Verb::Scope::FindingsDetail, [Verb::Chord.new("t")]) { |ctx| ctx.finding_edit_title; nil }
 
       r.register Verb::Definition.new(
         "finding.open-flow", "Open evidence", "Open the linked flow's request/response in History",
-        Verb::Scope::FindingsDetail, [Verb::Chord.new("o")], hidden: true) { |ctx| ctx.finding_open_flow; nil }
+        Verb::Scope::FindingsDetail, [Verb::Chord.new("o")]) { |ctx| ctx.finding_open_flow; nil }
 
       r.register Verb::Definition.new(
         "finding.replay-flow", "Replay evidence", "Send the linked flow to the Replay tab",
-        Verb::Scope::FindingsDetail, [Verb::Chord.new("r")], hidden: true) { |ctx| ctx.finding_replay_flow; nil }
+        Verb::Scope::FindingsDetail, [Verb::Chord.new("r")]) { |ctx| ctx.finding_replay_flow; nil }
 
       # Export (palette/Global — the findings' way out): write a report to the project dir.
       r.register Verb::Definition.new(
@@ -87,9 +96,10 @@ module Gori
       # The discoverable 'x' export chord on the Findings tab (the verbs above are the
       # palette entries / both formats). Findings-scoped so 'x' doesn't collide with
       # the hex toggles elsewhere; defaults to the human-readable Markdown report.
+      # NON-hidden so it joins the Findings list's "space" menu (key derives from 'x').
       r.register Verb::Definition.new(
         "findings.export-key", "Export findings (Markdown)", "Write the Markdown report to the project dir",
-        Verb::Scope::Findings, [Verb::Chord.new("x")], hidden: true) { |ctx| ctx.findings_export(:markdown); nil }
+        Verb::Scope::Findings, [Verb::Chord.new("x")]) { |ctx| ctx.findings_export(:markdown); nil }
     end
   end
 end

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -106,37 +106,59 @@ module Gori
         "detail.toggle-pane", "Switch pane (cycle)", "Cycle REQ → RES → FRAMES",
         Verb::Scope::HistoryDetail, [Verb::Chord.new("tab")], hidden: true) { |ctx| ctx.toggle_detail_pane; nil }
 
+      # The view-toggles are NON-hidden so they front the detail's "space" action menu
+      # (the palette stays Global-only, so un-hiding doesn't leak there). The shown
+      # menu key derives from each plain chord — exactly the key you'd press directly.
       r.register Verb::Definition.new(
         "detail.toggle-hex", "Hex view", "Toggle a raw hex dump of the request/response bytes",
-        Verb::Scope::HistoryDetail, [Verb::Chord.new("x")], hidden: true) { |ctx| ctx.toggle_detail_hex; nil }
+        Verb::Scope::HistoryDetail, [Verb::Chord.new("x")]) { |ctx| ctx.toggle_detail_hex; nil }
 
       r.register Verb::Definition.new(
         "detail.toggle-ws", "Reveal whitespace", "Show whitespace/CR/LF as glyphs (·→␍␊)",
-        Verb::Scope::HistoryDetail, [Verb::Chord.new("b")], hidden: true) { |ctx| ctx.toggle_reveal; nil }
+        Verb::Scope::HistoryDetail, [Verb::Chord.new("b")]) { |ctx| ctx.toggle_reveal; nil }
 
       r.register Verb::Definition.new(
         "detail.toggle-pretty", "Pretty bodies", "Pretty-print JSON/XML/form/… bodies (display only)",
-        Verb::Scope::HistoryDetail, [Verb::Chord.new("p")], hidden: true) { |ctx| ctx.toggle_pretty; nil }
+        Verb::Scope::HistoryDetail, [Verb::Chord.new("p")]) { |ctx| ctx.toggle_pretty; nil }
 
-      # ^R replays the open flow (mirrors history.replay from the list) — close the
-      # detail first so it doesn't float over the Replay tab.
+      # The flow actions mirror the History list's "space" menu so the muscle memory
+      # carries into the drill-in (the user's goal). Each keeps the list's exact chord
+      # + mnemonic; replay/finding/fuzz close the detail first so it doesn't float over
+      # the destination tab.
       r.register Verb::Definition.new(
         "detail.replay", "Replay flow", "Open this flow in the Replay tab",
         Verb::Scope::HistoryDetail, [Verb::Chord.new("r", ctrl: true)],
-        hidden: true) { |ctx| ctx.close_detail; ctx.replay_selected; nil }
+        mnemonic: 'r') { |ctx| ctx.close_detail; ctx.replay_selected; nil }
 
       # Create a finding while reading the flow — the natural moment to file one.
-      # Mirrors detail.replay (close the detail, then act on the still-selected flow);
-      # without this, ⇧F silently dead-ends in the detail (it's a Body-scope verb).
+      # Without this, ⇧F silently dead-ends in the detail (it's a Body-scope verb).
       r.register Verb::Definition.new(
         "detail.finding", "Add finding", "Create a finding from this flow",
         Verb::Scope::HistoryDetail, [Verb::Chord.new("f", shift: true)],
-        hidden: true) { |ctx| ctx.close_detail; ctx.finding_create; nil }
+        mnemonic: 'a') { |ctx| ctx.close_detail; ctx.finding_create; nil }
 
       # Send the open flow to the Comparer (mirrors history.compare from the list).
       r.register Verb::Definition.new(
         "detail.compare", "Send to Comparer", "Send this flow to the Comparer (next slot A/B)",
-        Verb::Scope::HistoryDetail) { |ctx| ctx.comparer_add_selected; nil }
+        Verb::Scope::HistoryDetail, mnemonic: 'c') { |ctx| ctx.comparer_add_selected; nil }
+
+      # Copy the open flow (mirrors history.copy 'y' from the list) — stays in the detail.
+      r.register Verb::Definition.new(
+        "detail.copy", "Copy flow", "Copy this flow to the clipboard",
+        Verb::Scope::HistoryDetail, [Verb::Chord.new("y")]) { |ctx| ctx.copy_selection; nil }
+
+      # Send the open flow to the Fuzzer (mirrors history.fuzz ⇧I/'z' from the list) —
+      # close the detail first so it doesn't float over the Fuzzer tab.
+      r.register Verb::Definition.new(
+        "detail.fuzz", "Send to Fuzzer", "Open this flow in the Fuzzer tab",
+        Verb::Scope::HistoryDetail, [Verb::Chord.new("i", shift: true)],
+        mnemonic: 'z') { |ctx| ctx.close_detail; ctx.fuzz_selected; nil }
+
+      # Add the open flow's host to the scope lens (mirrors scope.add-host 'h' from the
+      # list — also menu-only there; 'h' is the ← pane-nav chord in the detail).
+      r.register Verb::Definition.new(
+        "detail.add-host", "Add host to scope", "Add this flow's host to the scope lens",
+        Verb::Scope::HistoryDetail, mnemonic: 'h') { |ctx| ctx.scope_add_host; nil }
     end
 
     # Fuzzer/Intruder verbs: the cross-tab "send to Fuzzer" (⇧I from History, palette


### PR DESCRIPTION
## Summary
Expands the helix-style **`space` leader menu** so it works in every navigable area that has shortcut actions — making the menu a discoverable mirror of each tab's keys (accessibility + muscle memory). Previously it only fronted a few top-level list scopes; the flow/finding detail drill-ins and the Project SCOPE pane were empty or had `space` bound to something else.

**Key enabler:** the Ctrl-P palette lists only `Scope::Global` (`palette.cr`), so un-hiding a *scoped* verb surfaces it in the space menu **only** — never the palette.

## What changed
- **History flow detail** (was empty → "no commands"): now mirrors the History list menu — `r` replay · `a` finding · `c` compare · `y` copy · `z` fuzz · `h` add-host · `x` hex · `b` reveal-ws · `p` pretty. replay/finding/fuzz close the detail first. Reuses existing `ExecContext` methods (no lockstep).
- **Findings detail** (was empty): `e` notes · `t` title · `o` open · `r` replay · `d` delete. **Findings list:** added `o` open · `d` delete · `x` export (was just New).
- **Project SCOPE pane:** `space` **no longer bare-toggles the lens** — it opens the action menu. The lens toggle is now the menu-only `scope.lens-toggle` (`s`); `a`/`e`/`d` are real keymap verbs. The pane now **defers unhandled keys to the keymap** (intercept-controller pattern), so `a`/`e`/`d` + Global chords (`c`/`m`/`i`) work there like in History. New `Scope::Project` + 4 `ExecContext` methods.

Editor tabs (Notes/Convert/Project desc) keep `space` **literal** by design — no modes, so the leader stays out of text fields.

## Testing
- `crystal build` clean; **full `crystal spec` green (738 examples)**.
- tmux e2e on every menu + direct chords (toggles, copy/replay/fuzz, add/edit/delete, lens toggle, gated edit/delete).
- Two multi-agent adversarial review rounds: **0 correctness/regression bugs**. Cosmetic findings fixed (stale hot-path comment; in-Project toast signpost).

## Notes
- History/Sitemap toggle the lens with a direct `⇧S`; the Project pane's toggle is menu-only by request ("handle via the space menu"). A direct `⇧S` for parity is a 1-line follow-up if wanted.