### PR TITLE
feat(tui): fuzzer §-marker highlight, per-marker set chips, DIST sidebar

### DIFF
--- a/spec/fuzz_spec.cr
+++ b/spec/fuzz_spec.cr
@@ -98,6 +98,31 @@ describe F::Template do
     # cursor inside the marked span → strip it
     F::Template.mark_word("user=§admin§", 8).should eq("user=admin")
   end
+
+  it "marked_spans returns [start,end) char offsets incl. delimiters, 1:1 with positions" do
+    t = "GET /a?x=§foo§&y=§bar§ HTTP/1.1\r\n\r\n"
+    spans = F::Template.marked_spans(t)
+    spans.size.should eq(F::Template.parse(t).position_count)
+    a, b = spans[0]
+    t[a].should eq('§')
+    t[b - 1].should eq('§')
+    t[(a + 1)...(b - 1)].should eq("foo")
+  end
+
+  it "marked_spans honours §§ escape and unbalanced trailing § (matches parse)" do
+    F::Template.marked_spans("a§§b").should be_empty # escaped literal §
+    F::Template.marked_spans("a§b").should be_empty  # unbalanced trailing §
+    F::Template.marked_spans("x=§A§&y=§z").should eq([{2, 5}])
+    F::Template.marked_spans("§a§b§c§").should eq([{0, 3}, {4, 7}])
+    F::Template.marked_spans("k=§§§v§").should eq([{4, 7}]) # leading §§ escaped, then a pair
+  end
+
+  it "marked_spans count always equals parse.position_count" do
+    ["plain", "§a§", "§§", "§a§b§c§", "k=§§§v§", "x=§A§&y=§z",
+     F::Template.auto_mark("GET /?q=hi&p=2 HTTP/1.1\r\n\r\n")].each do |t|
+      F::Template.marked_spans(t).size.should eq(F::Template.parse(t).position_count)
+    end
+  end
 end
 
 describe F::ContentLength do

--- a/spec/support/memory_backend.cr
+++ b/spec/support/memory_backend.cr
@@ -5,10 +5,12 @@ require "../../src/gori"
 class MemoryBackend < Gori::Tui::Backend
   getter grid : Array(Array(Char))
   getter fg_grid : Array(Array(Gori::Tui::Color))
+  getter bg_grid : Array(Array(Gori::Tui::Color))
 
   def initialize(@w : Int32, @h : Int32)
     @grid = Array.new(@h) { Array.new(@w, ' ') }
     @fg_grid = Array.new(@h) { Array.new(@w, Gori::Tui::Color.default) }
+    @bg_grid = Array.new(@h) { Array.new(@w, Gori::Tui::Color.default) }
   end
 
   def put(x : Int32, y : Int32, grapheme : Char | String, fg : Gori::Tui::Color, bg : Gori::Tui::Color, attr : Gori::Tui::Attribute) : Nil
@@ -16,6 +18,7 @@ class MemoryBackend < Gori::Tui::Backend
     ch = grapheme.is_a?(Char) ? grapheme : (grapheme.empty? ? ' ' : grapheme[0])
     @grid[y][x] = ch
     @fg_grid[y][x] = fg
+    @bg_grid[y][x] = bg
   end
 
   def size : {Int32, Int32}
@@ -28,6 +31,10 @@ class MemoryBackend < Gori::Tui::Backend
 
   def fg_at(x : Int32, y : Int32) : Gori::Tui::Color
     @fg_grid[y][x]
+  end
+
+  def bg_at(x : Int32, y : Int32) : Gori::Tui::Color
+    @bg_grid[y][x]
   end
 
   def contains?(text : String) : Bool

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -1,7 +1,20 @@
 require "../spec_helper"
+require "../support/memory_backend"
 require "file_utils"
 
 include Gori::Tui
+
+private def fuzz_result(idx : Int32, status : Int32?, len : Int32, *,
+                        words : Int32 = 40, matched : Bool = false, error : String? = nil) : Gori::Fuzz::Result
+  Gori::Fuzz::Result.new(idx.to_i64, ["p#{idx}"], nil, status, len.to_i64, words, 5,
+    (1000 + idx * 100).to_i64, error, matched, false, nil)
+end
+
+private def loaded_fuzzer : FuzzerView
+  view = FuzzerView.new
+  view.load_request("https://h", "GET /?x=1 HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
+  view
+end
 
 describe Gori::Tui::FuzzerView do
   it "label uses the custom name when set, else the template summary" do
@@ -23,6 +36,81 @@ describe Gori::Tui::FuzzerView do
     label = view.label(8)
     label.size.should be <= 8
     label.should end_with("…")
+  end
+
+  describe "template marker highlight" do
+    it "tints the §…§ marked region (payload + delimiters) with the marker background" do
+      view = FuzzerView.new
+      view.load_request("https://h", "GET /?x=§foo§ HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
+      backend = MemoryBackend.new(120, 30)
+      view.render(Screen.new(backend), Rect.new(0, 0, 120, 30))
+      tint = Theme.marker_bg(0) # a unique chromatic blend — no other cell uses it
+      tinted = [] of Char
+      (0...30).each do |y|
+        (0...120).each { |x| tinted << backend.grid[y][x] if backend.bg_at(x, y) == tint }
+      end
+      tinted.should contain('f') # the "foo" payload value
+      tinted.should contain('§') # both delimiters bracketed
+    end
+
+    it "does not tint Replay/Notes editors (opt-in: bg_regions stays empty)" do
+      ta = TextArea.new("GET /?x=§foo§ HTTP/1.1")
+      backend = MemoryBackend.new(60, 5)
+      ta.render(Screen.new(backend), Rect.new(0, 0, 60, 5), cursor: false, highlight: :request)
+      marker = Theme.marker_bg(0)
+      (0...5).each do |y|
+        (0...60).each { |x| backend.bg_at(x, y).should_not eq(marker) }
+      end
+    end
+  end
+
+  describe "DIST sidebar" do
+    it "renders a colored status distribution beside the results (lone 500 in red)" do
+      view = loaded_fuzzer
+      5.times { |i| view.append_result(fuzz_result(i, 200, 1200)) }
+      view.append_result(fuzz_result(99, 500, 320))
+      backend = MemoryBackend.new(120, 30)
+      view.render(Screen.new(backend), Rect.new(0, 0, 120, 30))
+      backend.contains?("DIST").should be_true
+      backend.contains?("200").should be_true
+      # the 500 status label appears in the DIST columns (right of results) drawn in red
+      found = false
+      (0...30).each do |y|
+        idx = backend.row(y).index("500")
+        next unless idx && idx >= 86 # DIST region (results width ≈ 85)
+        backend.fg_at(idx, y).should eq(Theme.red)
+        found = true
+      end
+      found.should be_true
+    end
+
+    it "hides the sidebar on a narrow terminal (results take full width)" do
+      view = loaded_fuzzer
+      3.times { |i| view.append_result(fuzz_result(i, 200, 1200)) }
+      backend = MemoryBackend.new(50, 30)
+      view.render(Screen.new(backend), Rect.new(0, 0, 50, 30))
+      backend.contains?("DIST").should be_false
+      backend.contains?("RESULTS").should be_true
+    end
+
+    it "shows the full distribution even when the results list is matched-filtered" do
+      view = loaded_fuzzer
+      3.times { |i| view.append_result(fuzz_result(i, 200, 1200, matched: true)) }
+      view.append_result(fuzz_result(99, 500, 320, matched: false)) # the anomaly, NOT matched
+      view.toggle_matched_only                                      # results list now hides the 500…
+      backend = MemoryBackend.new(120, 30)
+      view.render(Screen.new(backend), Rect.new(0, 0, 120, 30))
+      backend.contains?("500").should be_true # …but DIST still surfaces it
+    end
+
+    it "v toggles the sidebar off" do
+      view = loaded_fuzzer
+      view.append_result(fuzz_result(0, 200, 1200))
+      view.toggle_dist # hide
+      backend = MemoryBackend.new(120, 30)
+      view.render(Screen.new(backend), Rect.new(0, 0, 120, 30))
+      backend.contains?("DIST").should be_false
+    end
   end
 end
 

--- a/spec/tui/spark_spec.cr
+++ b/spec/tui/spark_spec.cr
@@ -1,0 +1,84 @@
+require "../spec_helper"
+
+private alias S = Gori::Tui::Spark
+
+private def w(str : String) : Int32
+  Gori::Tui::Screen.display_width(str)
+end
+
+describe Gori::Tui::Spark do
+  describe ".bar" do
+    it "draws full blocks + space pad to exactly `width` columns" do
+      S.bar(5, 10, 10).should eq("█████     ")
+      w(S.bar(5, 10, 10)).should eq(10)
+      S.bar(10, 10, 10).should eq("██████████")
+      S.bar(0, 10, 10).should eq(" " * 10)
+    end
+
+    it "renders the fractional 1/8th cell" do
+      S.bar(1, 8, 1).should eq("▏")
+      S.bar(5, 8, 1).should eq("▋")
+      S.bar(8, 8, 1).should eq("█")
+    end
+
+    it "shows at least a 1/8 sliver for any nonzero value (the anomaly cue)" do
+      S.bar(1, 1000, 10).should start_with("▏")
+      w(S.bar(1, 1000, 10)).should eq(10)
+    end
+
+    it "guards degenerate inputs" do
+      S.bar(5, 10, 0).should eq("")
+      S.bar(5, 0, 10).should eq(" " * 10)   # max <= 0
+      S.bar(-3, 10, 10).should eq(" " * 10) # value <= 0
+    end
+  end
+
+  describe ".line" do
+    it "blanks all-zero / empty input" do
+      S.line([0, 0, 0]).should eq("   ")
+      S.line([] of Int32).should eq("")
+    end
+
+    it "renders a single nonzero bucket at full level" do
+      S.line([1]).should eq("█")
+    end
+
+    it "scales levels to the max bucket and blanks zero buckets" do
+      S.line([5, 5, 5]).should eq("███")
+      gap = S.line([0, 5, 0])
+      gap.size.should eq(3)
+      gap[0].should eq(' ')
+      gap[1].should eq('█')
+      gap[2].should eq(' ')
+      asc = S.line([1, 2, 4, 8])
+      w(asc).should eq(4)
+      asc[3].should eq('█') # the max bucket
+    end
+  end
+
+  describe ".histogram" do
+    it "counts into equal-width bins (max value is top-inclusive)" do
+      S.histogram([0, 9], 10).first.should eq(1) # 0 → bin 0
+      S.histogram([0, 9], 10).last.should eq(1)  # 9 (max) → last bin
+    end
+
+    it "puts all identical / single values in bin 0 (no spread)" do
+      S.histogram([5, 5, 5], 4).should eq([3, 0, 0, 0])
+      S.histogram([7], 4).should eq([1, 0, 0, 0])
+    end
+
+    it "handles empty input and non-positive bins" do
+      S.histogram([] of Int32, 4).should eq([0, 0, 0, 0])
+      S.histogram([1, 2], 0).should eq([] of Int32)
+    end
+
+    it "clamps values outside an explicit [min,max] into the edge bins" do
+      S.histogram([-100, 100], 4, 0.0, 10.0).should eq([1, 0, 0, 1])
+    end
+
+    it "works for Int64 and Float64 element types" do
+      S.histogram([0_i64, 100_i64], 2).sum.should eq(2)
+      S.histogram([0.0, 1.0], 2).sum.should eq(2)
+    end
+  end
+end

--- a/src/gori/fuzz/template.cr
+++ b/src/gori/fuzz/template.cr
@@ -81,6 +81,53 @@ module Gori::Fuzz
       @positions.size
     end
 
+    # The `[start, end)` CHARACTER offsets (into `text`) of every CLOSED `§…§`
+    # region, in marker order, INCLUDING both `§` delimiters. 1:1 with
+    # `parse(text).positions` — same `§§`-escape and unbalanced-trailing-§ rules — so
+    # a highlight built from these covers exactly the bytes that get fuzzed. An
+    # unbalanced trailing `§` yields NO span (parse folds it into literal text).
+    # Offsets index `text.chars`; feed the SAME LF-joined string the editor holds
+    # (`TextArea#text`), never the CRLF wire form. (Used for the TUI marker tint; the
+    # scan is branch-for-branch identical to `parse` above, minus the literal building,
+    # so `render`'s byte-exact path stays untouched.)
+    def self.marked_spans(text : String) : Array({Int32, Int32})
+      spans = [] of {Int32, Int32}
+      chars = text.chars
+      n = chars.size
+      i = 0
+      while i < n
+        if chars[i] == MARKER
+          if chars[i + 1]? == MARKER # escaped literal § — not an opener
+            i += 2
+            next
+          end
+          open = i
+          j = i + 1
+          closed = false
+          while j < n
+            if chars[j] == MARKER
+              if chars[j + 1]? == MARKER # §§ inside a marker → literal §
+                j += 2
+                next
+              end
+              closed = true
+              break
+            end
+            j += 1
+          end
+          if closed
+            spans << {open, j + 1} # [§ … §] inclusive of both delimiters
+            i = j + 1
+          else
+            break # unbalanced trailing § opens no position (matches parse's tail-fold)
+          end
+        else
+          i += 1
+        end
+      end
+      spans
+    end
+
     def default_payloads : Array(String)
       @positions.map(&.default)
     end

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -265,6 +265,7 @@ module Gori::Tui
       when key.down?    then v.results_move(1)
       when key.lower_o? then @host.status(v.cycle_sort)
       when key.lower_m? then @host.status(v.toggle_matched_only)
+      when key.lower_v? then @host.status(v.toggle_dist)
       end
     end
 

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -1042,9 +1042,10 @@ module Gori::Tui
       pp = @config.mode.per_position? # set i → marker i (Pitchfork/ClusterBomb)
       header = "Sets"
       screen.text(inner.x, y, header, Theme.muted, Theme.bg)
-      if pp && !@sets.empty? && @sets.size != marker_spans.size
+      mcount = marker_spans.size
+      if pp && !@sets.empty? && @sets.size != mcount
         hx = inner.x + header.size + 1
-        screen.text(hx, y, sets_hint(marker_spans.size, @sets.size), Theme.muted, Theme.bg,
+        screen.text(hx, y, sets_hint(mcount, @sets.size), Theme.muted, Theme.bg,
           width: {inner.right - hx, 1}.max)
       end
       y += 1

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -4,6 +4,7 @@ require "./theme"
 require "./frame"
 require "./text_area"
 require "./fmt"
+require "./spark"
 require "../store"
 require "../fuzz"
 require "../fuzzy"
@@ -22,6 +23,20 @@ module Gori::Tui
     RESULT_CAP = 5000 # ring cap on retained result rows (metrics are cheap; bodies kept only for matched)
 
     record SetSpec, kind : Symbol, value : String
+
+    # Aggregated result distribution for the DIST sidebar. Raw numbers only — bakes no
+    # Color, so a theme switch needs no cache rebuild (colours resolve live at draw).
+    record DistData,
+      codes : Array({Int32, Int32}), # (status, count), ascending
+      err : Int32,                   # status-nil rows (network/timeout failures)
+      len_hist : Array(Int32), len_min : Int64, len_max : Int64,
+      words_hist : Array(Int32), words_min : Int32, words_max : Int32,
+      time_hist : Array(Int32), time_min : Int64, time_max : Int64
+
+    STATUS_MAX_ROWS =  6 # ≤ this many distinct codes → per-code bars; else collapse to classes
+    DIST_MIN_TOTAL  = 60 # narrowest bottom width that still earns a sidebar
+    DIST_MIN_VW     = 22 # min / max sidebar width
+    DIST_MAX_VW     = 34
 
     getter focus : Symbol # :target | :template | :config | :results | :detail
     getter target : String
@@ -70,10 +85,19 @@ module Gori::Tui
       @p_min = "1"
       @p_max = "3"
       @results = [] of Fuzz::Result
+      @results_rev = 0_i64 # bumped on every @results mutation — the DIST cache key
       @sel = 0
       @scroll = 0
       @sort = :index
       @matched_only = false
+      # §-region offsets, recomputed only when the buffer changes (keyed on @editor.edits).
+      # Backs BOTH the template tint colours and the Sets→marker chips, so they can't disagree.
+      @marker_text_rev = -1
+      @marker_spans = [] of {Int32, Int32}
+      @show_dist = true # the DIST sidebar beside RESULTS (toggled with `v`)
+      @dist_cache = nil.as(DistData?)
+      @dist_cache_rev = -1_i64
+      @dist_cache_w = -1
       @progress = nil.as(Fuzz::Progress?)
       @run_total = nil.as(Int64?)
       @stop_requested = false
@@ -254,7 +278,19 @@ module Gori::Tui
     end
 
     def position_count : Int32
-      Fuzz::Template.parse(@editor.text).position_count
+      marker_spans.size
+    end
+
+    # Cached `§…§` char-offset spans for the current template buffer, recomputed only
+    # when the editor content changes (cheap Int compare on @editor.edits). marked_spans
+    # is 1:1 with parse().positions, so `.size == position_count`. Backs the template
+    # tint colours AND the config Sets→marker chips so the two can never disagree.
+    private def marker_spans : Array({Int32, Int32})
+      if @editor.edits != @marker_text_rev
+        @marker_text_rev = @editor.edits
+        @marker_spans = Fuzz::Template.marked_spans(@editor.text)
+      end
+      @marker_spans
     end
 
     # --- run lifecycle -------------------------------------------------------
@@ -268,6 +304,7 @@ module Gori::Tui
 
     def begin_run(total : Int64?) : Nil
       @results.clear
+      @results_rev += 1
       @sel = 0
       @scroll = 0
       @running = true
@@ -287,6 +324,7 @@ module Gori::Tui
     def append_result(r : Fuzz::Result) : Nil
       @results << r
       @results.shift if @results.size > RESULT_CAP
+      @results_rev += 1 # grow AND ring-evict both bump (size is pinned once full)
     end
 
     def matched_count : Int32
@@ -856,10 +894,29 @@ module Gori::Tui
 
     private def render_bottom(screen : Screen, rect : Rect, focused : Bool) : Nil
       if @focus == :detail
-        render_detail(screen, rect, focused)
-      else
-        render_results(screen, rect, focused && @focus == :results)
+        render_detail(screen, rect, focused) # full width — detail is unchanged
+        return
       end
+      vw = @show_dist ? dist_width(rect.w) : 0
+      if vw <= 0
+        render_results(screen, rect, focused && @focus == :results) # graceful: full width
+      else
+        rw = rect.w - vw - 1 # results width minus the 1-col gap (mirrors render_top)
+        render_results(screen, Rect.new(rect.x, rect.y, rw, rect.h), focused && @focus == :results)
+        render_dist(screen, Rect.new(rect.x + rw + 1, rect.y, vw, rect.h)) # read-only sidebar
+      end
+    end
+
+    # Sidebar width for a bottom rect `w` cols wide, or 0 (no sidebar) when too narrow.
+    private def dist_width(w : Int32) : Int32
+      return 0 if w < DIST_MIN_TOTAL
+      vw = {w * 30 // 100, DIST_MAX_VW}.min
+      vw < DIST_MIN_VW ? 0 : vw
+    end
+
+    def toggle_dist : String
+      @show_dist = !@show_dist
+      @show_dist ? "distribution shown" : "distribution hidden"
     end
 
     private def render_target(screen : Screen, rect : Rect, focused : Bool) : Nil
@@ -884,12 +941,16 @@ module Gori::Tui
 
     private def render_template(screen : Screen, rect : Rect, focused : Bool) : Nil
       return if rect.w < 2 || rect.h < 2
-      pc = position_count
+      spans = marker_spans
+      pc = spans.size
       label = @http2 ? "TEMPLATE (h2)" : "TEMPLATE"
       Frame.card(screen, rect, label, bg: Theme.bg, border: Frame.pane_border(focused))
       badge = " §#{pc} "
       screen.text({rect.right - badge.size - 1, rect.x + label.size + 4}.max, rect.y, badge,
         pc > 0 ? Theme.text_bright : Theme.muted, pc > 0 ? Theme.accent_bg : Theme.bg)
+      # Marker i ↔ position i ↔ generator.set_for(i). Colours resolved fresh each frame
+      # (theme-reactive without a revision key, since the cached offsets are colour-free).
+      @editor.bg_regions = spans.map_with_index { |(a, b), i| {a, b, Theme.marker_bg(i)} }
       @editor.render(screen, rect.inset(1, 1), cursor: focused, highlight: :request)
     end
 
@@ -978,7 +1039,14 @@ module Gori::Tui
     # (the bottom budget reserved for the Mode/Advanced tail). Overflow collapses
     # into a "… +N more" line. Returns the next free y.
     private def render_sets(screen, inner, y, focused, limit : Int32) : Int32
-      screen.text(inner.x, y, "Sets", Theme.muted, Theme.bg)
+      pp = @config.mode.per_position? # set i → marker i (Pitchfork/ClusterBomb)
+      header = "Sets"
+      screen.text(inner.x, y, header, Theme.muted, Theme.bg)
+      if pp && !@sets.empty? && @sets.size != marker_spans.size
+        hx = inner.x + header.size + 1
+        screen.text(hx, y, sets_hint(marker_spans.size, @sets.size), Theme.muted, Theme.bg,
+          width: {inner.right - hx, 1}.max)
+      end
       y += 1
       if @sets.empty?
         screen.text(inner.x + 2, y, "(none — pick a type above, ⏎ add)", Theme.muted, Theme.bg)
@@ -988,11 +1056,7 @@ module Gori::Tui
       shown = @sets.size <= avail ? @sets.size : {avail - 1, 0}.max
       @sets.first(shown).each_with_index do |s, i|
         sel = focused && current_field == :set && current_set_index == i
-        bg = sel ? Theme.accent_bg : Theme.bg
-        screen.fill(Rect.new(inner.x, y, inner.w, 1), bg) if sel
-        pos = @config.mode.per_position? ? " →#{i + 1}" : ""
-        screen.text(inner.x + 1, y, "#{i + 1} #{s.kind} #{s.value}#{pos}",
-          sel ? Theme.text_bright : Theme.text, bg, width: {inner.w - 2, 1}.max)
+        render_set_row(screen, inner, y, s, i, sel, pp)
         y += 1
       end
       if shown < @sets.size
@@ -1000,6 +1064,32 @@ module Gori::Tui
         y += 1
       end
       y
+    end
+
+    # One Sets row. In per-position modes (pp) it carries a marker-coloured swatch + →N
+    # chip tying it to template marker i (same tint marker i shows in the editor); the
+    # chip draws AFTER the selection fill so it survives on the selected (accent_bg) row.
+    private def render_set_row(screen, inner : Rect, y : Int32, s : SetSpec, i : Int32, sel : Bool, pp : Bool) : Nil
+      bg = sel ? Theme.accent_bg : Theme.bg
+      screen.fill(Rect.new(inner.x, y, inner.w, 1), bg) if sel
+      fg = sel ? Theme.text_bright : Theme.text
+      label = "#{i + 1} #{s.kind} #{s.value}"
+      unless pp
+        screen.text(inner.x + 1, y, label, fg, bg, width: {inner.w - 2, 1}.max)
+        return
+      end
+      chip = "→#{i + 1}"
+      cwid = 2 + chip.size + 1 # '▎' + ' ' + token + ' '
+      cx = {inner.right - cwid, inner.x + 1}.max
+      screen.text(inner.x + 1, y, label, fg, bg, width: {cx - inner.x - 2, 1}.max)
+      screen.cell(cx, y, '▎', Theme.marker_hue(i), bg)
+      screen.text(cx + 1, y, " #{chip} ", Theme.marker_fg, Theme.marker_bg(i))
+    end
+
+    # set_for(p) = @sets[p]? || @sets[0]: with fewer sets than markers the extras wrap
+    # back to set 1; with more, the surplus sets are unused. 1-based to match the rows.
+    private def sets_hint(markers : Int32, sets : Int32) : String
+      sets < markers ? "· #{markers} markers, #{sets} sets — marker #{sets + 1}+ reuse set 1" : "· #{markers} markers — set #{markers + 1}+ unused"
     end
 
     private def label_at(screen, x, y, label) : Int32
@@ -1135,6 +1225,113 @@ module Gori::Tui
       end
     end
 
+    # ── DIST sidebar — result distribution at a glance ───────────────────────────
+    # Status bars + Len/Words/Time sparkline histograms over ALL @results (NOT the
+    # matched/sort-filtered view) so the outlier you're filtering out still shows and
+    # the picture stays stable while you re-sort. Read-only; data cached on @results_rev.
+
+    private def render_dist(screen : Screen, rect : Rect, focused : Bool = false) : Nil
+      return if rect.w < 2 || rect.h < 2
+      Frame.card(screen, rect, "DIST", bg: Theme.bg, border: Frame.pane_border(focused))
+      inner = rect.inset(1, 1)
+      return if inner.empty?
+      if @results.empty?
+        screen.text(inner.x, inner.y, @running ? "sampling…" : "no results yet",
+          Theme.muted, Theme.bg, width: inner.w)
+        return
+      end
+      d = dist_data(inner.w)
+      # Reserve 6 rows for the 3 spark sections when the pane is tall; else status takes all.
+      status_limit = inner.h >= 8 ? {inner.bottom - 6, inner.y + 1}.max : inner.bottom
+      y = render_dist_status(screen, inner, inner.y, status_limit, d)
+      y = render_dist_spark(screen, inner, y, "len", d.len_hist, Fmt.size(d.len_min), Fmt.size(d.len_max)) if y + 2 <= inner.bottom
+      y = render_dist_spark(screen, inner, y, "wrd", d.words_hist, d.words_min.to_s, d.words_max.to_s) if y + 2 <= inner.bottom
+      render_dist_spark(screen, inner, y, "tim", d.time_hist, Fmt.dur(d.time_min), Fmt.dur(d.time_max)) if y + 2 <= inner.bottom
+    end
+
+    private def render_dist_status(screen, inner : Rect, y0 : Int32, limit : Int32, d : DistData) : Int32
+      rows_budget = {limit - y0, 1}.max
+      groups = dist_status_groups(d, rows_budget)
+      return y0 if groups.empty?
+      total = d.codes.sum(&.[1]) + d.err
+      maxc = groups.max_of?(&.[1]) || 1
+      label_w = 4                      # "200 " / "5xx " / "ERR "
+      num_w = {total.to_s.size, 4}.min # right-aligned count column (≤ RESULT_CAP digits)
+      bar_w = {inner.w - label_w - num_w - 1, 1}.max
+      y = y0
+      groups.each_with_index do |(label, count, code), i|
+        break if y >= limit
+        if i == rows_budget - 1 && groups.size > rows_budget
+          screen.text(inner.x, y, "+#{groups.size - i} more", Theme.muted, Theme.bg, width: inner.w)
+          return y + 1
+        end
+        col = code ? Theme.status_color(code) : Theme.red # ERR (nil) → red; resolved LIVE
+        screen.text(inner.x, y, label.ljust(label_w), col, Theme.bg)
+        screen.text(inner.x + label_w, y, Spark.bar(count, maxc, bar_w), col, Theme.bg)
+        screen.text(inner.x + label_w + bar_w + 1, y, count.to_s.rjust(num_w), Theme.muted, Theme.bg, width: num_w)
+        y += 1
+      end
+      y
+    end
+
+    # Distinct codes when they fit (a lone 500 keeps its own red bar — max signal);
+    # otherwise collapse to classes 2xx/3xx/4xx/5xx (+ ERR for status-nil rows).
+    private def dist_status_groups(d : DistData, budget : Int32) : Array({String, Int32, Int32?})
+      n = d.codes.size + (d.err > 0 ? 1 : 0)
+      out = [] of {String, Int32, Int32?}
+      if n <= {budget, STATUS_MAX_ROWS}.min
+        d.codes.each { |(s, c)| out << {s.to_s, c, s.as(Int32?)} }
+      else
+        cls = Hash(Int32, Int32).new(0)
+        d.codes.each { |(s, c)| cls[s // 100] += c }
+        cls.to_a.sort_by!(&.[0]).each { |(k, c)| out << {"#{k}xx", c, (k * 100).as(Int32?)} }
+      end
+      out << {"ERR", d.err, nil.as(Int32?)} if d.err > 0
+      out
+    end
+
+    private def render_dist_spark(screen, inner : Rect, y : Int32, label : String,
+                                  hist : Array(Int32), lo_s : String, hi_s : String) : Int32
+      screen.text(inner.x, y, "#{label} #{lo_s} … #{hi_s}", Theme.muted, Theme.bg, width: inner.w)
+      screen.text(inner.x, y + 1, Spark.line(hist), Theme.text, Theme.bg, width: inner.w)
+      y + 2
+    end
+
+    # Aggregate @results into the DIST view, cached on {@results_rev, pane width}. NOT
+    # keyed on Theme.revision — DistData bakes no Color (resolved live at draw); NOT on
+    # @matched_only/@sort — the distribution is intentionally over the full result set.
+    private def dist_data(w : Int32) : DistData
+      c = @dist_cache
+      return c if c && @dist_cache_rev == @results_rev && @dist_cache_w == w
+      @dist_cache_rev = @results_rev
+      @dist_cache_w = w
+      @dist_cache = build_dist(w)
+    end
+
+    private def build_dist(w : Int32) : DistData
+      codes = Hash(Int32, Int32).new(0)
+      err = 0
+      lens = [] of Int64
+      words = [] of Int32
+      times = [] of Int64
+      @results.each do |r|
+        if s = r.status
+          codes[s] += 1
+          lens << r.length # response rows only — keep error 0-rows out of len/wrd spikes
+          words << r.words
+        else
+          err += 1
+        end
+        times << r.duration_us # every row: a timeout's latency IS the signal
+      end
+      DistData.new(
+        codes: codes.to_a.sort_by!(&.[0]), err: err,
+        len_hist: Spark.histogram(lens, w), len_min: (lens.min? || 0_i64), len_max: (lens.max? || 0_i64),
+        words_hist: Spark.histogram(words, w), words_min: (words.min? || 0), words_max: (words.max? || 0),
+        time_hist: Spark.histogram(times, w), time_min: (times.min? || 0_i64), time_max: (times.max? || 0_i64),
+      )
+    end
+
     private def adjust_scroll(h : Int32) : Nil
       rows_h = {h - 1, 1}.max
       @scroll = @sel if @sel < @scroll
@@ -1190,8 +1387,11 @@ module Gori::Tui
       if my < rest.y + top_h
         half = {(rest.w - 1) // 2, 1}.max
         mx < rest.x + half ? :template : :config
+      elsif @focus == :detail
+        :detail
       else
-        @focus == :detail ? :detail : :results
+        vw = @show_dist ? dist_width(rest.w) : 0
+        vw > 0 && mx >= rest.x + rest.w - vw ? nil : :results # read-only DIST sidebar → no-op
       end
     end
   end

--- a/src/gori/tui/spark.cr
+++ b/src/gori/tui/spark.cr
@@ -1,0 +1,92 @@
+module Gori::Tui
+  # Compact in-terminal microcharts for the Fuzzer DIST pane. Pure functions (no
+  # Screen/Theme) — width-safe (every glyph is exactly one terminal column) and
+  # spec-testable. Sibling to Fmt: one place for the block-element math so bars and
+  # sparklines round identically everywhere.
+  module Spark
+    FULL    = '█'        # U+2588 full block
+    EIGHTHS = "▏▎▍▌▋▊▉"  # U+258F..U+2589 — 1/8 .. 7/8 left-fill, rising width
+    LEVELS  = "▁▂▃▄▅▆▇█" # U+2581..U+2588 — 8 rising levels for sparklines
+
+    # A horizontal bar of `value/max`, exactly `width` columns wide: full blocks plus
+    # one fractional 1/8th cell, space-padded so display width == width. value<=0 or
+    # max<=0 → all spaces; a nonzero value always shows ≥ a 1/8 sliver (so a lone
+    # count-of-1 bar is still visible — the anomaly cue).
+    def self.bar(value : Int | Float, max : Int | Float, width : Int32) : String
+      return "" if width <= 0
+      return " " * width if max.to_f <= 0 || value.to_f <= 0
+      frac = (value.to_f / max.to_f).clamp(0.0, 1.0)
+      eighths = (frac * width * 8).round.to_i
+      eighths = 1 if eighths < 1 # guarantee a visible sliver for value > 0
+      eighths = width * 8 if eighths > width * 8
+      full = eighths // 8
+      rem = eighths % 8
+      String.build do |io|
+        full.times { io << FULL }
+        if rem > 0 && full < width
+          io << EIGHTHS[rem - 1] # rem ∈ 1..7 → EIGHTHS[0..6]
+          full += 1
+        end
+        (width - full).times { io << ' ' }
+      end
+    end
+
+    # A sparkline of `▁..█` from per-bucket counts, scaled to the tallest bucket. Zero
+    # buckets render as a blank (so an outlier bucket pops out of empty space); any
+    # nonzero bucket shows at least `▁`. All-zero / empty → blanks. Result is exactly
+    # `width` (default counts.size) columns.
+    def self.line(counts : Array(Int32), width : Int32? = nil) : String
+      w = width || counts.size
+      return "" if w <= 0
+      data = fit(counts, w)
+      max = data.max? || 0
+      return " " * w if max <= 0
+      String.build do |io|
+        data.each do |c|
+          if c <= 0
+            io << ' '
+          else
+            lvl = ((c.to_f / max) * (LEVELS.size - 1)).round.to_i
+            io << LEVELS[lvl.clamp(0, LEVELS.size - 1)]
+          end
+        end
+      end
+    end
+
+    # Per-bin counts of `values` over `bins` equal-width bins across [min,max]
+    # (defaults to the data's own min/max). Left-inclusive bins; the max value lands
+    # in the last bin (top-inclusive). Values outside an explicit [min,max] clamp into
+    # the edge bins. min==max (all identical / single value) → everything in bin 0 (a
+    # single spike — the "no spread" signal). Generic over Int32/Int64/Float.
+    def self.histogram(values : Array(T), bins : Int32, min : Float64? = nil, max : Float64? = nil) : Array(Int32) forall T
+      return [] of Int32 if bins <= 0
+      counts = Array(Int32).new(bins, 0)
+      return counts if values.empty?
+      lo = min || values.min.to_f
+      hi = max || values.max.to_f
+      if hi <= lo
+        counts[0] = values.size
+        return counts
+      end
+      span = hi - lo
+      values.each do |v|
+        idx = ((v.to_f - lo) / span * bins).floor.to_i
+        counts[idx.clamp(0, bins - 1)] += 1
+      end
+      counts
+    end
+
+    # Resize `counts` to exactly `w` entries. Equal → identity (the normal path, since
+    # the histogram is built with bins = pane width). Shorter → right-pad with zeros.
+    # Longer → max-pool so an outlier bucket survives the squeeze.
+    private def self.fit(counts : Array(Int32), w : Int32) : Array(Int32)
+      return counts if counts.size == w
+      return Array(Int32).new(w) { |i| counts[i]? || 0 } if counts.size < w
+      Array(Int32).new(w) do |i|
+        lo = i * counts.size // w
+        hi = {(i + 1) * counts.size // w, lo + 1}.max
+        (lo...hi).max_of { |j| counts[j] }
+      end
+    end
+  end
+end

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -25,12 +25,20 @@ module Gori::Tui
       @gutter = false              # left line-number gutter (on for the Replay request body)
       @search_hl = ""              # active ^F query → matches highlighted in render
       @reveal = false              # show whitespace (space ·, tab →) instead of syntax colours
+      @edits = 0                   # monotonic content-change counter — cheap cache key for owners
+      # Opt-in background tints: [start, end) FULL-buffer char offsets + colour, painted
+      # UNDER the text (over syntax/plain, beneath search + cursor). Empty for every editor
+      # except the Fuzzer template — Replay/Notes never set it, so they're unaffected. The
+      # widget knows nothing about §-markers; the owner supplies offsets + resolved colours.
+      @bg_regions = [] of {Int32, Int32, Color}
       set_text(text)
     end
 
     setter gutter : Bool
     setter search_hl : String
     setter reveal : Bool
+    setter bg_regions : Array({Int32, Int32, Color})
+    getter edits : Int32
 
     def set_text(text : String) : Nil
       @lines = text.split('\n').map(&.rstrip('\r'))
@@ -40,6 +48,7 @@ module Gori::Tui
       @scroll = 0
       @preedit = ""
       @styled = nil
+      @edits += 1
     end
 
     # Preedit/composing text from IME (e.g. current Hangul syllable while typing jamo).
@@ -75,6 +84,7 @@ module Gori::Tui
       @lines[@cy] = "#{line[0, cx]}#{ch}#{line[cx..]}"
       @cx = cx + 1
       @styled = nil
+      @edits += 1
     end
 
     def insert_newline : Nil
@@ -85,6 +95,7 @@ module Gori::Tui
       @cy += 1
       @cx = 0
       @styled = nil
+      @edits += 1
     end
 
     def backspace : Nil
@@ -101,6 +112,7 @@ module Gori::Tui
         @cy -= 1
       end
       @styled = nil
+      @edits += 1
     end
 
     def move(dr : Int32, dc : Int32) : Nil
@@ -200,6 +212,10 @@ module Gori::Tui
       cx0 = rect.x + gw                                          # content start x (after the optional gutter)
       cw = {rect.w - gw, 0}.max                                  # content width
       styled = highlight ? highlighted(highlight) : nil
+      # Buffer char-offset of the first visible line — advanced per row so each line
+      # knows its start for the bg-region overlay without an O(n²) rescan.
+      line_off = 0
+      (0...@scroll).each { |k| line_off += @lines[k].size + 1 } # +1 for the joining '\n'
       (0...rect.h).each do |i|
         li = @scroll + i
         break if li >= @lines.size
@@ -229,6 +245,11 @@ module Gori::Tui
             screen.text(cx0, rect.y + i, line, Theme.text, width: cw)
           end
         end
+        # Marker tint UNDER search/cursor — skip the IME-preedit line (its columns are
+        # shifted by the composing text, which isn't in `line`). paint_bg_regions itself
+        # no-ops when there are no regions or in reveal mode.
+        paint_bg_regions(screen, cx0, rect.y + i, line_off, line, cw) unless li == @cy && !@preedit.empty?
+        line_off += line.size + 1 # advance BEFORE the cursor `next` so it can't desync
         SearchHi.mark(screen, cx0, rect.y + i, line, @search_hl, cx0 + cw) unless @search_hl.empty?
         next unless cursor && li == @cy
         prefix_w = Screen.display_width(line[0, @cx])
@@ -243,6 +264,28 @@ module Gori::Tui
             screen.cell(cxs + off, rect.y + i, cch, Theme.bg, Theme.accent)
           end
         end
+      end
+    end
+
+    # Overlay the bg_regions intersecting THIS line. `off0` is the line's start offset
+    # in the full LF-joined buffer. Column math mirrors SearchHi.mark (same
+    # Screen.display_width as the base draw, so an ambiguous-width glyph can't drift the
+    # tint off the cells). Multi-line regions clamp to [0, line.size): first line tints
+    # col→EOL, fully-covered lines 0→size, last line BOL→col; the '\n' offset has no cell.
+    private def paint_bg_regions(screen : Screen, cx0 : Int32, y : Int32, off0 : Int32,
+                                 line : String, cw : Int32) : Nil
+      return if @bg_regions.empty? || @reveal # opt-in; reveal rewrites the glyphs
+      line_end = off0 + line.size
+      max_x = cx0 + cw
+      @bg_regions.each do |(a, b, color)|
+        next if b <= off0 || a >= line_end # region doesn't touch this line
+        la = (a - off0).clamp(0, line.size)
+        lb = (b - off0).clamp(0, line.size)
+        next if la >= lb
+        col = cx0 + Screen.display_width(line[0, la])
+        next unless col < max_x
+        seg = line[la, lb - la]
+        screen.text(col, y, seg, Theme.marker_fg, color, width: {max_x - col, 0}.max)
       end
     end
 

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -213,9 +213,11 @@ module Gori::Tui
       cw = {rect.w - gw, 0}.max                                  # content width
       styled = highlight ? highlighted(highlight) : nil
       # Buffer char-offset of the first visible line — advanced per row so each line
-      # knows its start for the bg-region overlay without an O(n²) rescan.
+      # knows its start for the bg-region overlay without an O(n²) rescan. Only the
+      # opt-in bg_regions consumer (the Fuzzer template) pays the O(@scroll) prefix sum;
+      # Replay/Notes (no regions) skip it so their hot path is unchanged.
       line_off = 0
-      (0...@scroll).each { |k| line_off += @lines[k].size + 1 } # +1 for the joining '\n'
+      (0...@scroll).each { |k| line_off += @lines[k].size + 1 } unless @bg_regions.empty? # +1 for '\n'
       (0...rect.h).each do |i|
         li = @scroll + i
         break if li >= @lines.size

--- a/src/gori/tui/theme.cr
+++ b/src/gori/tui/theme.cr
@@ -313,6 +313,42 @@ module Gori::Tui
       end
     {% end %}
 
+    # ── Per-marker tints (Fuzzer §…§ regions + the config Sets→marker chips) ──────
+    # Derived at runtime from the ACTIVE palette so they re-theme for free (and need no
+    # new Palette fields). `marker_bg` is a subtle background band; `marker_hue` is the
+    # saturated source used for crisp 1-cell swatches.
+
+    MARKER_TINT = 0.22 # blend ratio toward the canvas: subtle band, still distinguishable
+
+    # 6 maximally-separated hues that exist in every palette (built-in + custom, which
+    # inherit a base). Cycles past 6, mirroring the generator's set_for() wrap.
+    def self.marker_hue(index : Int32) : Color
+      hues = [syn_header, syn_string, orange, syn_literal, yellow, red]
+      hues[index.abs % hues.size]
+    end
+
+    # Subtle background tint for marker `index` — blended toward the canvas so it stays
+    # legible on both dark and light themes (and never reads as the neutral selection band).
+    def self.marker_bg(index : Int32) : Color
+      blend(marker_hue(index), bg, MARKER_TINT)
+    end
+
+    # Foreground for tinted marker text — near-max contrast on the subtle band across themes.
+    def self.marker_fg : Color
+      text_bright
+    end
+
+    # Linear RGB blend of `hue` toward `base` by ratio t (0 = base, 1 = hue).
+    private def self.blend(hue : Color, base : Color, t : Float64) : Color
+      hr, hg, hb = hue.to_rgb_components
+      lr, lg, lb = base.to_rgb_components
+      Color.rgb(
+        (lr.to_i + (hr.to_i - lr.to_i) * t).round.to_i.clamp(0, 255),
+        (lg.to_i + (hg.to_i - lg.to_i) * t).round.to_i.clamp(0, 255),
+        (lb.to_i + (hb.to_i - lb.to_i) * t).round.to_i.clamp(0, 255),
+      )
+    end
+
     def self.method_color(method : String) : Color
       case method.upcase
       when "GET", "HEAD", "QUERY"           then green # QUERY is safe + idempotent like GET (RFC 10008)


### PR DESCRIPTION
## Summary

Three related UX additions to the **Fuzzer** tab, built and verified together.

### 1. `§…§` marker background highlight in the Template editor
Each marked fuzz position now gets a distinct, theme-blended background tint, so positions are visible at a glance instead of hidden in the raw `§` text.
- `Fuzz::Template.marked_spans` — char-offset accessor whose scan mirrors `parse` exactly (so it's 1:1 with what gets fuzzed; `§§` escape + unbalanced-trailing-§ handled identically). `parse`'s byte-exact `render()` path is left untouched.
- `Theme.marker_bg/marker_hue/marker_fg` — tints **blended at runtime** from existing palette hues (no new palette fields → re-themes for free across all 5 built-ins).
- `TextArea#bg_regions` — a **generic, opt-in** background overlay (Replay/Notes never set it → unaffected), painted under search highlight and the cursor.

### 2. Per-marker wordlist legibility (no restructure)
The engine **already** binds payload `set[i] → marker[i]` positionally for Pitchfork/Cluster-bomb — the gap was only that the binding was invisible. Each config Sets row now shows a marker-colored swatch + tinted `→N` chip matching the template, plus a "3 markers, 2 sets — marker 3 reuses set 1" hint on mismatch. No `SetSpec`/schema/navigation change.

### 3. DIST distribution sidebar beside Results
A small read-only pane visualizing the result distribution so anomalies pop without scanning rows.
- New pure `Spark` module: `bar` / `line` / `histogram` block-element microcharts.
- Status bars (colored by code) + Length / Words / Time sparkline histograms over **all** results (so you see the outlier you may be filtering out).
- Auto-hides below 60 cols; `v` toggles it; **non-focusable** so the focus ring / key routing stay untouched.

## Testing
- **759 specs green**, ameba clean (no new findings; `render_sets` kept under the complexity bar via an extracted `render_set_row`).
- Live tmux run verified end-to-end: `§7§` renders with bg = `Theme.marker_bg(0)`; a planted `id=7 → 500` shows as a lone red status bar with the 160B body isolated at the right of the len/words sparklines; `v` toggles the sidebar.
- `MemoryBackend` (spec support) gained `bg` recording to assert the tint.

## Notes
- Implementation plan: `tui-fuzzer-template-rustling-music`.
- Rebased onto latest `main` (PR #28).