### PR TITLE
feat(tui): Findings filter bar, Space severity/status pickers, elegant detail

### DIFF
--- a/spec/findings_query_spec.cr
+++ b/spec/findings_query_spec.cr
@@ -1,0 +1,73 @@
+require "./spec_helper"
+require "../src/gori/findings_query"
+
+include Gori
+
+private def fnd(title : String, severity : Store::Severity, status : Store::Status = Store::Status::Open,
+                host : String? = nil) : Store::Finding
+  Store::Finding.new(1_i64, 0_i64, 0_i64, title, severity, host, nil, "", status)
+end
+
+private def filtered(query : String, list : Array(Store::Finding)) : Array(Store::Finding)
+  Findings::Filter.parse(query).apply(list)
+end
+
+describe Gori::Findings::Filter do
+  list = [
+    fnd("Reflected XSS in search", Store::Severity::High, Store::Status::Open, "app.example.com"),
+    fnd("SQL injection in login", Store::Severity::Critical, Store::Status::Confirmed, "api.example.com"),
+    fnd("Verbose error page", Store::Severity::Low, Store::Status::Resolved, "app.example.com"),
+    fnd("Missing security header", Store::Severity::Info, Store::Status::FalsePositive, "cdn.example.net"),
+  ]
+
+  it "passes everything for an empty query" do
+    filtered("", list).size.should eq(4)
+    Findings::Filter.parse("").empty?.should be_true
+  end
+
+  it "filters by exact triage status" do
+    filtered("status:open", list).map(&.title).should eq(["Reflected XSS in search"])
+    filtered("st:confirmed", list).size.should eq(1)
+    filtered("status:fp", list).size.should eq(1)
+  end
+
+  it "treats status:closed as any non-open state" do
+    filtered("status:closed", list).map(&.severity)
+      .should eq([Store::Severity::Critical, Store::Severity::Low, Store::Severity::Info])
+  end
+
+  it "compares severity ordinally" do
+    filtered("sev:>=high", list).map(&.title).should eq(["Reflected XSS in search", "SQL injection in login"])
+    filtered("severity:critical", list).size.should eq(1)
+    filtered("sev:<medium", list).size.should eq(2) # low + info
+    filtered("sev:crit", list).size.should eq(1)    # abbreviation
+  end
+
+  it "matches host and title substrings, case-insensitively" do
+    filtered("host:api", list).size.should eq(1)
+    filtered("title:XSS", list).size.should eq(1)
+    filtered("example.com", list).size.should eq(3) # free text over host; the .net row is excluded
+  end
+
+  it "negates a field term with a leading -" do
+    filtered("-status:open", list).size.should eq(3)
+    filtered("-host:example.com", list).map(&.host).should eq(["cdn.example.net"])
+  end
+
+  it "ANDs multiple terms" do
+    filtered("status:open sev:>=high", list).size.should eq(1)
+    filtered("host:example.com severity:critical", list).map(&.title).should eq(["SQL injection in login"])
+  end
+
+  it "falls back to free text for an unknown field" do
+    filtered("login", list).size.should eq(1)
+    filtered("nope:zzz", list).size.should eq(0)
+  end
+
+  it "matches all for an empty field value (incremental typing), respecting negation" do
+    filtered("status:", list).size.should eq(4) # mid-type — don't blank the list
+    filtered("sev:>=", list).size.should eq(4)
+    filtered("host:", list).size.should eq(4)
+    filtered("-status:", list).size.should eq(0) # negated empty → match none
+  end
+end

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -114,6 +114,8 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def findings_new : Nil; end
 
+  def findings_query : Nil; end
+
   def findings_move(delta : Int32) : Nil; end
 
   def findings_open : Nil; end
@@ -125,6 +127,10 @@ class FakeExecContext < Gori::Verb::ExecContext
   def finding_severity(delta : Int32) : Nil; end
 
   def finding_status(delta : Int32) : Nil; end
+
+  def finding_set_severity : Nil; end
+
+  def finding_set_status : Nil; end
 
   def finding_edit_notes : Nil; end
 

--- a/spec/tui/choice_picker_spec.cr
+++ b/spec/tui/choice_picker_spec.cr
@@ -1,0 +1,35 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+describe Gori::Tui::ChoicePicker do
+  it "opens on the row whose value is current" do
+    ChoicePicker.for_severity(3).selected_value.should eq(3) # High
+    ChoicePicker.for_status(2).selected_value.should eq(2)   # false-positive
+  end
+
+  it "maps a mnemonic key to its row (case-insensitive), nil for a miss" do
+    p = ChoicePicker.for_severity(0)
+    p.index_for('h').should eq(1) # HIGH
+    p.set_selected(p.index_for('C').not_nil!)
+    p.selected_value.should eq(4) # CRITICAL
+    p.index_for('z').should be_nil
+  end
+
+  it "clamps movement at both ends" do
+    p = ChoicePicker.for_status(0)
+    p.move(-5)
+    p.selected.should eq(0)
+    p.move(99)
+    p.selected_value.should eq(3) # resolved (last)
+  end
+
+  it "renders the title, labels, and a current marker" do
+    backend = MemoryBackend.new(80, 24)
+    ChoicePicker.for_severity(2).render(Screen.new(backend), Rect.new(0, 0, 80, 24))
+    backend.contains?("SET SEVERITY").should be_true
+    backend.contains?("MEDIUM").should be_true
+    backend.contains?("current").should be_true
+  end
+end

--- a/spec/tui/findings_view_spec.cr
+++ b/spec/tui/findings_view_spec.cr
@@ -32,8 +32,8 @@ describe Gori::Tui::FindingsView do
       backend.contains?("SQL injection").should be_true
       backend.contains?("LOW").should be_true
       backend.contains?("open").should be_true # freshly created → Open status tag
-      # critical sorts first
-      backend.row(2).should contain("CRIT")
+      # critical sorts first; rows start at y+3 (filter bar, header, divider above)
+      backend.row(3).should contain("CRIT")
     end
   end
 
@@ -92,6 +92,26 @@ describe Gori::Tui::FindingsView do
       "poc".each_char { |c| view.notes_insert(c) }
       view.save_notes(store)
       store.get_finding(id).not_nil!.notes.should eq("poc")
+    end
+  end
+
+  it "filters the list and tab-completes a field without mangling a trailing-space query" do
+    tmp_store do |store|
+      store.insert_finding("SQL injection", Gori::Store::Severity::Critical, "api.test", nil)
+      store.insert_finding("Missing header", Gori::Store::Severity::Low, "app.test", nil)
+      view = FindingsView.new
+      view.reload(store)
+
+      view.start_query
+      "sev".each_char { |c| view.query_insert(c) }
+      view.query_complete.should be_true
+      view.query.should eq("severity:") # completed the field name
+
+      # trailing space → no adjacent word → don't complete and don't corrupt the query
+      view.query_insert(' ')
+      view.query.should eq("severity: ")
+      view.query_complete.should be_false
+      view.query.should eq("severity: ")
     end
   end
 

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -212,6 +212,10 @@ private class FakeContext < ExecContext
     @calls << :findings_new
   end
 
+  def findings_query : Nil
+    @calls << :findings_query
+  end
+
   def findings_move(delta : Int32) : Nil
     @calls << :findings_move
   end
@@ -234,6 +238,14 @@ private class FakeContext < ExecContext
 
   def finding_status(delta : Int32) : Nil
     @calls << :finding_status
+  end
+
+  def finding_set_severity : Nil
+    @calls << :finding_set_severity
+  end
+
+  def finding_set_status : Nil
+    @calls << :finding_set_status
   end
 
   def finding_edit_notes : Nil

--- a/src/gori/findings_query.cr
+++ b/src/gori/findings_query.cr
@@ -1,0 +1,140 @@
+require "./store"
+
+module Gori
+  module Findings
+    # An in-memory predicate over findings, parsed from a History-like filter
+    # string. Findings live wholly in memory (a small severity-sorted list), so —
+    # unlike History's QL→SQL — this matches Crystal-side. Terms are whitespace-
+    # separated and AND-joined; a leading `-` negates a field term; an unrecognised
+    # or bare token is free text over the title + host.
+    #
+    #   open                      → free text "open" in title/host
+    #   status:open sev:>=high    → only OPEN findings at High or Critical
+    #   -status:resolved host:api → not-resolved AND host contains "api"
+    class Filter
+      # One parsed clause. `op` only matters for ordinal (severity) comparisons.
+      private record Term, kind : Symbol, op : Symbol, text : String, negate : Bool
+
+      def self.parse(query : String) : Filter
+        terms = [] of Term
+        query.split.each do |raw|
+          next if raw.empty?
+          negate = false
+          tok = raw
+          if tok.starts_with?('-') && tok.size > 1
+            negate = true
+            tok = tok[1..]
+          end
+          terms << build_term(tok, negate)
+        end
+        new(terms)
+      end
+
+      def initialize(@terms : Array(Term))
+      end
+
+      def empty? : Bool
+        @terms.empty?
+      end
+
+      # Keep store order; every term must match (AND). An empty filter passes all.
+      def apply(findings : Array(Store::Finding)) : Array(Store::Finding)
+        return findings if @terms.empty?
+        findings.select { |f| matches?(f) }
+      end
+
+      def matches?(f : Store::Finding) : Bool
+        @terms.all? { |t| match_term(t, f) }
+      end
+
+      # --- parsing -------------------------------------------------------------
+
+      private def self.build_term(tok : String, negate : Bool) : Term
+        if (colon = tok.index(':'))
+          field = tok[0...colon].downcase
+          value = tok[(colon + 1)..]
+          case field
+          when "severity", "sev"
+            op, text = split_op(value)
+            return Term.new(:severity, op, text.downcase, negate)
+          when "status", "st"
+            return Term.new(:status, :eq, value.downcase, negate)
+          when "host"
+            return Term.new(:host, :eq, value.downcase, negate)
+          when "title"
+            return Term.new(:title, :eq, value.downcase, negate)
+          end
+        end
+        # Unrecognised prefix or bare token → free text (matched over title + host).
+        Term.new(:text, :eq, tok.downcase, negate)
+      end
+
+      # Peel a leading comparison operator (>= <= > < =) off a severity value.
+      private def self.split_op(value : String) : {Symbol, String}
+        return {:ge, value[2..]} if value.starts_with?(">=")
+        return {:le, value[2..]} if value.starts_with?("<=")
+        return {:gt, value[1..]} if value.starts_with?(">")
+        return {:lt, value[1..]} if value.starts_with?("<")
+        return {:eq, value[1..]} if value.starts_with?("=")
+        {:eq, value}
+      end
+
+      # --- matching ------------------------------------------------------------
+
+      private def match_term(t : Term, f : Store::Finding) : Bool
+        # An empty value (mid-type "status:" / "sev:>=") matches all, so the list
+        # doesn't blank out until a value is typed — uniform across every field
+        # kind (host:/title: already do this via includes?("")).
+        return !t.negate if t.text.empty?
+        hit = case t.kind
+              when :severity then match_severity(t, f.severity)
+              when :status   then match_status(t.text, f.status)
+              when :host     then (f.host || "").downcase.includes?(t.text)
+              when :title    then f.title.downcase.includes?(t.text)
+              else                free_text(t.text, f)
+              end
+        t.negate ? !hit : hit
+      end
+
+      private def free_text(text : String, f : Store::Finding) : Bool
+        return true if text.empty?
+        f.title.downcase.includes?(text) || (f.host || "").downcase.includes?(text)
+      end
+
+      private def match_severity(t : Term, sev : Store::Severity) : Bool
+        target = severity_value(t.text)
+        return false unless target
+        cmp = sev.value <=> target
+        case t.op
+        when :ge then cmp >= 0
+        when :gt then cmp > 0
+        when :le then cmp <= 0
+        when :lt then cmp < 0
+        else          cmp == 0
+        end
+      end
+
+      private def severity_value(name : String) : Int32?
+        case name
+        when "info"             then 0
+        when "low"              then 1
+        when "medium", "med"    then 2
+        when "high"             then 3
+        when "critical", "crit" then 4
+        else                         nil
+        end
+      end
+
+      private def match_status(name : String, status : Store::Status) : Bool
+        case name
+        when "open"                 then status.open?
+        when "confirmed", "conf"    then status.confirmed?
+        when "false-positive", "fp" then status.false_positive?
+        when "resolved", "done"     then status.resolved?
+        when "closed"               then !status.open? # any non-open triage state
+        else                             false
+        end
+      end
+    end
+  end
+end

--- a/src/gori/tui/choice_picker.cr
+++ b/src/gori/tui/choice_picker.cr
@@ -1,0 +1,112 @@
+require "./screen"
+require "./theme"
+require "./frame"
+require "../store"
+
+module Gori::Tui
+  # A small centered value-picker overlay — pick one option from a short coloured
+  # list (a finding's severity or triage status). Structurally a twin of
+  # BrowserPicker: pure state + rendering, while the Runner owns opening/closing
+  # and applying the choice. Each row is fronted by a mnemonic key (helix feel)
+  # and the value currently set on the finding is marked "● current".
+  class ChoicePicker
+    record Choice, label : String, key : Char, color : Color, value : Int32
+
+    getter selected : Int32
+    getter kind : Symbol # :severity | :status — the Runner branches on this to apply
+    getter title : String
+
+    def initialize(@title : String, @choices : Array(Choice), @current : Int32, @kind : Symbol)
+      # Open on the row that's currently set, so ↵ without moving is a no-op.
+      @selected = @choices.index { |c| c.value == @current } || 0
+    end
+
+    # The coloured severity picker (Critical→Info), opened on the current level.
+    def self.for_severity(current : Int32) : ChoicePicker
+      new("SET SEVERITY", [
+        Choice.new("CRITICAL", 'c', Theme.red, 4),
+        Choice.new("HIGH", 'h', Theme.orange, 3),
+        Choice.new("MEDIUM", 'm', Theme.yellow, 2),
+        Choice.new("LOW", 'l', Theme.accent, 1),
+        Choice.new("INFO", 'i', Theme.muted, 0),
+      ], current, :severity)
+    end
+
+    # The coloured triage-status picker, opened on the current status.
+    def self.for_status(current : Int32) : ChoicePicker
+      new("SET STATUS", [
+        Choice.new("open", 'o', Theme.accent, 0),
+        Choice.new("confirmed", 'c', Theme.red, 1),
+        Choice.new("false-positive", 'f', Theme.muted, 2),
+        Choice.new("resolved", 'r', Theme.green, 3),
+      ], current, :status)
+    end
+
+    def move(delta : Int32) : Nil
+      return if @choices.empty?
+      @selected = (@selected + delta).clamp(0, @choices.size - 1)
+    end
+
+    def selected_value : Int32
+      @choices[@selected].value
+    end
+
+    def set_selected(idx : Int32) : Nil
+      return if @choices.empty?
+      @selected = idx.clamp(0, @choices.size - 1)
+    end
+
+    # The row whose mnemonic matches `c` (case-insensitive), or nil for a miss.
+    def index_for(c : Char) : Int32?
+      lc = c.downcase
+      @choices.index { |ch| ch.key == lc }
+    end
+
+    # Centered card geometry over `area` — inverse of render's offset math. nil
+    # when render would draw nothing (mirrors the w/h guard).
+    def overlay_box(area : Rect) : Rect?
+      w = {area.w - 4, label_w + 20}.min
+      h = {@choices.size + 2, area.h - 2}.min
+      return nil if w < 18 || area.h < 5
+      x = area.x + (area.w - w) // 2
+      y = area.y + (area.h - h) // 2
+      Rect.new(x, y, w, h)
+    end
+
+    # Row index under (mx,my), mirroring render's list loop; nil outside. Bound to
+    # the ACTUALLY rendered rows ({box.h - 2, size}.min, matching render's break),
+    # so a click on the bottom border of a height-clamped card can't pick a row
+    # that was never drawn.
+    def row_at(box : Rect, mx : Int32, my : Int32) : Int32?
+      rows = {box.h - 2, @choices.size}.min
+      i = my - (box.y + 1)
+      return nil if i < 0 || i >= rows
+      return nil if mx <= box.x || mx >= box.right - 1
+      i
+    end
+
+    def render(screen : Screen, area : Rect) : Nil
+      box = overlay_box(area)
+      return unless box
+      Frame.card(screen, box, @title, border: Theme.border_focus)
+      @choices.each_with_index do |ch, i|
+        ry = box.y + 1 + i
+        break if ry >= box.bottom - 1
+        active = i == @selected
+        bg = active ? Theme.accent_bg : Theme.panel
+        screen.fill(Rect.new(box.x + 1, ry, box.w - 2, 1), bg)
+        screen.cell(box.x + 1, ry, active ? '▎' : ' ', Theme.accent, bg)
+        screen.text(box.x + 3, ry, ch.key.to_s, Theme.accent, bg, Attribute::Bold)
+        screen.text(box.x + 6, ry, ch.label, ch.color, bg, Attribute::Bold)
+        if ch.value == @current
+          marker = "● current"
+          screen.text(box.right - marker.size - 2, ry, marker, active ? Theme.text_bright : Theme.muted, bg)
+        end
+      end
+    end
+
+    private def label_w : Int32
+      @choices.max_of(&.label.size)
+    end
+  end
+end

--- a/src/gori/tui/controllers/findings_controller.cr
+++ b/src/gori/tui/controllers/findings_controller.cr
@@ -33,8 +33,14 @@ module Gori::Tui
     end
 
     def body_hint(focus : Symbol) : String
-      @findings.detail_open? ? "[ ] sev · { } status · t title · e notes · o flow · r replay · d del · space cmds · ←/esc back" \
-                             : "↑/↓ move · ↵ open · n new · d delete · x export · space cmds · esc tabs"
+      if @findings.detail_open?
+        @findings.editing_notes? ? "esc save · ^W discard" \
+                                 : "e notes · o flow · r replay · space triage/cmds · ←/esc back"
+      elsif @findings.querying?
+        "type to filter · ↹ complete · ↵ apply · esc clear"
+      else
+        "↑/↓ move · ↵ open · / filter · n new · space cmds · esc tabs"
+      end
     end
 
     def render_body(screen : Screen, rect : Rect, focus : Symbol) : Nil
@@ -49,6 +55,11 @@ module Gori::Tui
         return true
       end
       @host.focus_body
+      # Click the top filter-bar row → start editing the filter (like History).
+      if my == inner.y && !@findings.querying?
+        @findings.start_query
+        return true
+      end
       return true unless idx = @findings.list_row_at(inner, mx, my)
       # SELECT-FIRST (same as History): first click selects, second opens.
       idx == @findings.selected_index ? findings_open : @findings.select_index(idx)
@@ -83,10 +94,43 @@ module Gori::Tui
       true
     end
 
-    # Live IME composition only flows to the inline notes editor.
+    # Live IME composition flows to the `/` filter bar (list) or the inline notes
+    # editor (detail) — whichever text field is active.
     def set_preedit(text : String) : Bool
-      return false unless @findings.editing_notes?
-      @findings.set_preedit(text)
+      if @findings.querying?
+        @findings.query_set_preedit(text)
+        true
+      elsif @findings.editing_notes?
+        @findings.set_preedit(text)
+        true
+      else
+        false
+      end
+    end
+
+    def querying? : Bool
+      @findings.querying?
+    end
+
+    # The `/` filter bar — a text sub-mode the shell claims before the focus ring
+    # (mirrors History's QL bar). Returns true (swallows). Filtering is live, so
+    # every edit re-derives the visible list inside the view.
+    def handle_query_key(ev : Termisu::Event::Key) : Bool
+      key = ev.key
+      c = ev.char || key.to_char
+      case
+      when key.enter?     then @findings.stop_query  # keep the filter, leave edit mode
+      when key.escape?    then @findings.cancel_query # clear + revert
+      when key.tab?       then @findings.query_complete
+      when key.backspace? then @findings.query_backspace
+      when key.left?      then @findings.query_move(-1)
+      when key.right?     then @findings.query_move(1)
+      else
+        if c && !ev.ctrl? && !ev.alt?
+          @findings.query_insert(c)
+          @findings.query_set_preedit("") # commit any preedit
+        end
+      end
       true
     end
 

--- a/src/gori/tui/findings_view.cr
+++ b/src/gori/tui/findings_view.cr
@@ -3,14 +3,18 @@ require "./theme"
 require "./frame"
 require "./text_area"
 require "../store"
+require "../findings_query"
 
 module Gori::Tui
   # The Findings tab (DESIGN.md: the final output — human-confirmed vulns). A
   # severity-sorted list + a detail with inline-editable notes and a severity
   # control. Created from a flow (History `F`) or blank (`n`).
   class FindingsView
+    QUERY_FIELDS = %w(severity: status: host: title:)
+
     def initialize
-      @findings = [] of Store::Finding
+      @all = [] of Store::Finding      # the raw store list (severity-desc)
+      @findings = [] of Store::Finding # the filtered/visible subset
       @selected = 0
       @scroll = 0
       @detail = nil.as(Store::Finding?)
@@ -19,12 +23,24 @@ module Gori::Tui
       @editing_notes = false
       @notes = TextArea.new
       @loaded = false
+      # The `/` filter bar (mirrors History's QL bar but matches in memory).
+      @query = ""
+      @qcx = 0
+      @preedit_q = ""
+      @querying = false
     end
 
     def reload(store : Store) : Nil
-      @findings = store.findings
-      @selected = @selected.clamp(0, {@findings.size - 1, 0}.max)
+      @all = store.findings
+      apply_filter
       @loaded = true
+    end
+
+    # Recompute the visible list from the raw list through the active filter, then
+    # keep the selection in range (called live as the query is edited).
+    private def apply_filter : Nil
+      @findings = Findings::Filter.parse(@query).apply(@all)
+      @selected = @selected.clamp(0, {@findings.size - 1, 0}.max)
     end
 
     def move(delta : Int32) : Nil
@@ -32,12 +48,12 @@ module Gori::Tui
       @selected = (@selected + delta).clamp(0, @findings.size - 1)
     end
 
-    # Inverts render_list's row layout (header at rect.y, divider at +1, rows from
-    # top = rect.y + 2 spanning @scroll..): maps a click to a finding index, or nil
-    # past the last populated row / outside the list pane.
+    # Inverts render_list's row layout (filter bar at rect.y, header at +1, divider
+    # at +2, rows from top = rect.y + 3 spanning @scroll..): maps a click to a
+    # finding index, or nil past the last populated row / outside the list pane.
     def list_row_at(rect : Rect, mx : Int32, my : Int32) : Int32?
       return nil if mx < rect.x || mx >= rect.right
-      top = rect.y + 2
+      top = rect.y + 3 # filter bar (y) + header (y+1) + divider (y+2)
       list_h = {rect.bottom - top, 0}.max
       i = my - top
       return nil if i < 0 || i >= list_h
@@ -76,6 +92,75 @@ module Gori::Tui
 
     def editing_notes? : Bool
       @editing_notes
+    end
+
+    # --- `/` filter bar ------------------------------------------------------
+    # Findings are in memory, so filtering is live (no debounce) — each edit
+    # re-derives the visible list. Mirrors History's QL-bar editing surface.
+
+    def querying? : Bool
+      @querying
+    end
+
+    def filtering? : Bool
+      !@query.blank?
+    end
+
+    # The committed filter string (for tests / external inspection).
+    getter query : String
+
+    def start_query : Nil
+      @querying = true
+      @qcx = @query.size
+    end
+
+    def stop_query : Nil # Enter: keep the filter, leave edit mode
+      @querying = false
+    end
+
+    def cancel_query : Nil # Esc: clear the filter, leave edit mode
+      @querying = false
+      @query = ""
+      @qcx = 0
+      @preedit_q = ""
+      apply_filter
+    end
+
+    def query_insert(ch : Char) : Nil
+      @query = "#{@query[0, @qcx]}#{ch}#{@query[@qcx..]}"
+      @qcx += 1
+      apply_filter
+    end
+
+    def query_backspace : Nil
+      return if @qcx == 0
+      @query = "#{@query[0, @qcx - 1]}#{@query[@qcx..]}"
+      @qcx -= 1
+      apply_filter
+    end
+
+    def query_move(d : Int32) : Nil
+      @qcx = (@qcx + d).clamp(0, @query.size)
+    end
+
+    # IME composing text for the filter bar (underlined, doesn't touch @query).
+    def query_set_preedit(text : String) : Nil
+      @preedit_q = text
+    end
+
+    # Tab-complete the field name under the cursor (severity:/status:/host:/title:).
+    def query_complete : Bool
+      # The trailing run of non-whitespace right at the cursor — "" when the prefix
+      # ends in a space (don't complete; `split.last` would grab a non-adjacent word
+      # and the slice below would mangle the query).
+      token = @query[0, @qcx][/\S*\z/]
+      return false if token.empty? || token.includes?(':')
+      if field = QUERY_FIELDS.find(&.starts_with?(token.downcase))
+        @query = "#{@query[0, @qcx - token.size]}#{field}#{@query[@qcx..]}"
+        @qcx += field.size - token.size
+        return true
+      end
+      false
     end
 
     def open_detail(store : Store) : Bool
@@ -186,15 +271,18 @@ module Gori::Tui
     end
 
     private def render_list(screen : Screen, rect : Rect, focused : Bool) : Nil
-      screen.text(rect.x + 1, rect.y, "SEV", Theme.muted)
-      screen.text(rect.x + 6, rect.y, "ST", Theme.muted)
-      screen.text(rect.x + 11, rect.y, "TITLE", Theme.muted)
-      Frame.inner_divider(screen, rect, rect.y + 1, border: Frame.pane_border(focused))
-      top = rect.y + 2
+      render_filter_bar(screen, rect)
+      screen.text(rect.x + 1, rect.y + 1, "SEV", Theme.muted)
+      screen.text(rect.x + 6, rect.y + 1, "ST", Theme.muted)
+      screen.text(rect.x + 11, rect.y + 1, "TITLE", Theme.muted)
+      Frame.inner_divider(screen, rect, rect.y + 2, border: Frame.pane_border(focused))
+      top = rect.y + 3
       list_h = {rect.bottom - top, 0}.max
 
       if @findings.empty?
-        screen.text(rect.x + 1, top, "no findings yet · Shift+F on a History flow, or n here", Theme.muted)
+        msg = filtering? ? "no findings match · esc clears the filter" \
+                         : "no findings yet · Shift+F on a History flow, or n here"
+        screen.text(rect.x + 1, top, msg, Theme.muted)
         return
       end
 
@@ -225,27 +313,69 @@ module Gori::Tui
       end
     end
 
+    # The `/` filter bar on the list's top row: while editing, `filter › <input>`;
+    # otherwise the applied query (+ a match count) or a usage hint.
+    private def render_filter_bar(screen : Screen, rect : Rect) : Nil
+      if @querying
+        prefix = "filter › "
+        screen.text(rect.x + 1, rect.y, prefix, Theme.accent)
+        base = rect.x + 1 + prefix.size
+        screen.input_line(base, rect.y, @query, @qcx, @preedit_q, Theme.text_bright, width: {rect.w - prefix.size - 2, 0}.max)
+        return
+      end
+      rx = rect.right - 1
+      if filtering?
+        count = @findings.size.to_s
+        screen.text({rx - count.size, rect.x}.max, rect.y, count, Theme.muted)
+        rx -= count.size + 2
+      end
+      left_w = {rx - (rect.x + 1), 0}.max
+      if filtering?
+        screen.text(rect.x + 1, rect.y, ": #{@query}", Theme.text, width: left_w)
+      else
+        screen.text(rect.x + 1, rect.y, "/ filter  ·  severity:  status:open  status:closed  host:", Theme.muted, width: left_w)
+      end
+    end
+
     private def render_detail(screen : Screen, rect : Rect, focused : Bool) : Nil
       finding = @detail.not_nil!
-      screen.text(rect.x + 1, rect.y, severity_badge(finding.severity), severity_color(finding.severity), attr: Attribute::Bold)
-      screen.text(rect.x + 6, rect.y, status_tag(finding.status), status_color(finding.status))
-      screen.text(rect.x + 11, rect.y, finding.title, Theme.text_bright, width: {rect.w - 12, 0}.max)
-      hint = @editing_notes ? "esc save · ^W discard" \
-                            : "[ ] sev · { } status · t title · e notes · o flow · r replay · d del · esc back"
-      screen.text(rect.x + 1, rect.y + 1, hint, Theme.muted, width: {rect.w - 2, 0}.max)
-      meta = "##{finding.id} · #{finding.status.label} · #{fmt_ts(finding.created_at)}"
+      w = {rect.w - 2, 0}.max
+
+      # y0 — title row: a severity-coloured bullet + the bright title; #id at the right.
+      id_label = "##{finding.id}"
+      screen.text(rect.right - id_label.size - 1, rect.y, id_label, Theme.muted)
+      screen.cell(rect.x + 1, rect.y, '●', severity_color(finding.severity))
+      title_w = {(rect.right - id_label.size - 2) - (rect.x + 3), 0}.max
+      screen.text(rect.x + 3, rect.y, finding.title, Theme.text_bright, width: title_w, attr: Attribute::Bold)
+
+      # y1 — chips: a filled severity chip + a status chip.
+      cx = rect.x + 1
+      cx = chip(screen, cx, rect.y + 1, " #{severity_badge(finding.severity)} ", severity_color(finding.severity))
+      chip(screen, cx + 1, rect.y + 1, " #{finding.status.label} ", status_color(finding.status))
+
+      # y2 — timestamps.
+      meta = "created #{fmt_ts(finding.created_at)}"
       meta += " · edited #{fmt_ts(finding.updated_at)}" if finding.updated_at > finding.created_at
-      screen.text(rect.x + 1, rect.y + 2, meta, Theme.muted, width: {rect.w - 2, 0}.max)
-      y = rect.y + 3
-      if flow = @detail_flow
-        line = "flow ##{flow.id}: #{flow.method} #{flow_location(flow)} → #{flow.status || "-"}"
-        screen.text(rect.x + 1, y, line, Theme.muted, width: {rect.w - 2, 0}.max)
-      elsif finding.flow_id
-        screen.text(rect.x + 1, y, "flow ##{finding.flow_id}: (no longer captured)", Theme.muted)
-      end
-      y += 1
+      screen.text(rect.x + 1, rect.y + 2, meta, Theme.muted, width: w)
+
+      # y3 — linked-flow evidence.
+      evidence = if flow = @detail_flow
+                   "evidence  #{flow.method} #{flow_location(flow)} → #{flow.status || "-"}"
+                 elsif fid = finding.flow_id
+                   "evidence  flow ##{fid} (no longer captured)"
+                 else
+                   "evidence  (none — standalone finding)"
+                 end
+      screen.text(rect.x + 1, rect.y + 3, evidence, Theme.muted, width: w)
+
+      # y4 — divider; y5 — NOTES label (+ edit affordance); y6+ — notes body / editor.
+      y = rect.y + 4
       Frame.inner_divider(screen, rect, y, border: Frame.pane_border(focused))
       screen.text(rect.x + 1, y + 1, "NOTES", Theme.accent, attr: Attribute::Bold)
+      unless @editing_notes
+        edit_hint = "e to edit"
+        screen.text(rect.right - edit_hint.size - 1, y + 1, edit_hint, Theme.muted)
+      end
       notes_y = y + 2
       notes_rect = Rect.new(rect.x + 1, notes_y, {rect.w - 2, 0}.max, {rect.bottom - notes_y, 0}.max)
       if @editing_notes
@@ -256,6 +386,12 @@ module Gori::Tui
           screen.text(notes_rect.x, notes_rect.y + i, note_line, Theme.text, width: notes_rect.w)
         end
       end
+    end
+
+    # A filled "chip": ` LABEL ` painted with `color` as the background. Returns the
+    # x just past it so chips lay out left-to-right.
+    private def chip(screen : Screen, x : Int32, y : Int32, label : String, color : Color) : Int32
+      screen.text(x, y, label, Theme.bg, color, Attribute::Bold)
     end
 
     private def refresh_detail(store : Store) : Nil

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -82,7 +82,7 @@ module Gori::Tui
       ]},
       {"OTHER TABS", [
         {"Sitemap", "↑/↓ move · / filter · ↵/→ expand · ← collapse"},
-        {"Findings", "↵ open · n new · d delete · x export"},
+        {"Findings", "/ filter · ↵ open · n new · space triage · x export"},
         {"Notes", "type to edit · ^N new · ^1-9 switch"},
         {"Project", "scope rules + the description editor"},
         {"Intercept", "↵/e edit · f fwd · d drop · F all · c catch dir · / condition"},

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -29,6 +29,7 @@ require "./intercept_view"
 require "./rules_overlay"
 require "./confirm_dialog"
 require "./browser_picker"
+require "./choice_picker"
 require "./flow_picker"
 require "./settings_view"
 require "./tabs_overlay"
@@ -63,7 +64,7 @@ module Gori::Tui
       # and Agent is hidden by default). Settings is loaded (cli.cr) before Runner.new.
       vis = Chrome.visible_tabs(Settings.tab_prefs).map(&.first)
       @active_tab = vis.includes?(:project) ? :project : vis.first
-      @overlay = :none # :none | :palette | :detail | :rules | :finding_new | :confirm | :browser | :comparer_pick | :settings | :tabs
+      @overlay = :none # :none | :palette | :detail | :rules | :finding_new | :confirm | :browser | :choice | :comparer_pick | :settings | :tabs
       # The "space" action menu (helix-style leader popup, bottom-right). Orthogonal
       # to @overlay so it floats over WHATEVER is underneath (the History list, an
       # open detail …) without disturbing that state; the scope is captured at open.
@@ -103,6 +104,8 @@ module Gori::Tui
       # The "open browser" picker (palette → browser.open); @overlay is :browser
       # while it's up.
       @browser_picker = nil.as(BrowserPicker?)
+      # The severity/status value picker (Findings detail → space); @overlay is :choice.
+      @choice_picker = nil.as(ChoicePicker?)
       # The Comparer flow picker (a/b → choose flow A/B); @overlay is :comparer_pick.
       @flow_picker = nil.as(FlowPicker?)
       # The settings editor (palette → settings:network); @overlay is :settings.
@@ -417,6 +420,7 @@ module Gori::Tui
       return handle_finding_new_key(ev) if @overlay == :finding_new
       return handle_confirm_key(ev) if @overlay == :confirm
       return handle_browser_key(ev) if @overlay == :browser
+      return handle_choice_key(ev) if @overlay == :choice
       return handle_flow_picker_key(ev) if @overlay == :comparer_pick
       return handle_settings_key(ev) if @overlay == :settings
       return handle_tabs_key(ev) if @overlay == :tabs
@@ -431,6 +435,9 @@ module Gori::Tui
       end
       if @active_tab == :intercept && @overlay == :none && @focus == :body && intercept_controller.querying?
         return if intercept_controller.handle_query_key(ev)
+      end
+      if @active_tab == :findings && @overlay == :none && @focus == :body && findings_controller.view.querying?
+        return if findings_controller.handle_query_key(ev)
       end
       if @active_tab == :findings && @overlay == :none && @focus == :body && findings_controller.view.editing_notes?
         return if findings_controller.handle_notes_key(ev)
@@ -590,7 +597,7 @@ module Gori::Tui
     # The overlays that fully capture input (a centered card); :detail and :none do not.
     private def modal_overlay? : Bool
       case @overlay
-      when :palette, :rules, :finding_new, :confirm, :browser, :comparer_pick, :settings, :tabs, :hotkeys then true
+      when :palette, :rules, :finding_new, :confirm, :browser, :choice, :comparer_pick, :settings, :tabs, :hotkeys then true
       else                                                                                                    false
       end
     end
@@ -663,6 +670,7 @@ module Gori::Tui
       when :palette       then click_palette(area, mx, my)
       when :rules         then click_rules(area, mx, my)
       when :browser       then click_browser(area, mx, my)
+      when :choice        then click_choice(area, mx, my)
       when :comparer_pick then click_flow_picker(area, mx, my)
       when :confirm       then click_confirm(area, mx, my)
       when :settings      then click_settings(area, mx, my)
@@ -781,6 +789,7 @@ module Gori::Tui
       when :palette       then @palette.move(step)
       when :rules         then @rules_overlay.select_move(step)
       when :browser       then @browser_picker.try(&.move(step))
+      when :choice        then @choice_picker.try(&.move(step))
       when :comparer_pick then @flow_picker.try(&.move(step))
       when :settings      then (@settings_view.move_field(step); preview_theme) # wheel scrolls the theme list too
       when :tabs          then @tabs_overlay.select_move(step)
@@ -883,6 +892,57 @@ module Gori::Tui
     private def close_browser_picker : Nil
       @overlay = :none
       @browser_picker = nil
+    end
+
+    # Severity/status value picker (Findings detail → space → s/c): ↑/↓ pick, ↵
+    # set, a printable matching a row's mnemonic sets it directly, esc cancels.
+    private def handle_choice_key(ev : Termisu::Event::Key) : Nil
+      key = ev.key
+      p = @choice_picker
+      return close_choice_picker unless p
+      case
+      when key.escape? then close_choice_picker
+      when key.up?     then p.move(-1)
+      when key.down?   then p.move(1)
+      when key.enter?  then apply_choice
+      else
+        if (c = ev.char) && !ev.ctrl? && !ev.alt? && (idx = p.index_for(c))
+          p.set_selected(idx)
+          apply_choice
+        end
+        # any other key is ignored (the picker stays up — a value pick is deliberate)
+      end
+    end
+
+    private def click_choice(area : Rect, mx : Int32, my : Int32) : Nil
+      p = @choice_picker
+      box = p.try(&.overlay_box(area))
+      return close_choice_picker if p.nil? || box.nil? || dismiss_zone?(box, mx, my)
+      if idx = p.row_at(box, mx, my)
+        p.set_selected(idx)
+        apply_choice
+      end
+    end
+
+    # Persist the picked value to the open finding, then close. The detail finding
+    # can't change while the modal is up, so reading it at commit is safe.
+    private def apply_choice : Nil
+      p = @choice_picker
+      return close_choice_picker unless p
+      if f = findings_controller.view.detail_finding
+        store = @session.store
+        case p.kind
+        when :severity then store.update_finding(f.id, severity: Store::Severity.new(p.selected_value))
+        when :status   then store.update_finding(f.id, status: Store::Status.new(p.selected_value))
+        end
+        findings_controller.view.resync(store)
+      end
+      close_choice_picker
+    end
+
+    private def close_choice_picker : Nil
+      @overlay = :none
+      @choice_picker = nil
     end
 
     # Comparer flow picker (a/b → choose flow A/B): type to filter, ↑/↓ select,
@@ -1446,6 +1506,7 @@ module Gori::Tui
       @finding_form.render(screen, layout.body) if @overlay == :finding_new
       @confirm.try(&.render(screen, layout.body)) if @overlay == :confirm
       @browser_picker.try(&.render(screen, layout.body)) if @overlay == :browser
+      @choice_picker.try(&.render(screen, layout.body)) if @overlay == :choice
       @flow_picker.try(&.render(screen, layout.body)) if @overlay == :comparer_pick
       @settings_view.render(screen, layout.body) if @overlay == :settings
       @tabs_overlay.render(screen, layout.body) if @overlay == :tabs
@@ -1522,6 +1583,7 @@ module Gori::Tui
       when :detail        then "DETAIL"
       when :confirm       then "CONFIRM"
       when :browser       then "BROWSER"
+      when :choice        then @choice_picker.try(&.title) || "CHOOSE"
       when :comparer_pick then "PICK FLOW"
       when :settings    then "SETTINGS"
       when :tabs        then "TAB BAR"
@@ -1555,6 +1617,7 @@ module Gori::Tui
       when :finding_new   then "type title · ↵ create · esc cancel"
       when :confirm       then "←/→ choose · y confirm · n/esc cancel · ↵ select"
       when :browser       then "↑/↓ select · ↵ open · esc cancel"
+      when :choice        then "↑/↓ select · ↵ set · key picks · esc cancel"
       when :comparer_pick then "type to filter · ↑/↓ select · ↵ choose · esc cancel"
       when :settings    then "↑/↓ field · type to edit · ↵ save · esc close"
       when :tabs        then "↑/↓ select · space show/hide · K/J reorder · ↵ save · esc cancel"
@@ -1950,6 +2013,10 @@ module Gori::Tui
       @overlay = :finding_new
     end
 
+    def findings_query : Nil
+      findings_controller.view.start_query
+    end
+
     def findings_move(delta : Int32) : Nil
       findings_controller.findings_move(delta)
     end
@@ -1972,6 +2039,20 @@ module Gori::Tui
 
     def finding_status(delta : Int32) : Nil
       findings_controller.finding_status(delta)
+    end
+
+    # Open the colour pickers for the finding currently in the detail view. The
+    # picker (a shell overlay) applies the chosen value on commit (apply_choice).
+    def finding_set_severity : Nil
+      return unless f = findings_controller.view.detail_finding
+      @choice_picker = ChoicePicker.for_severity(f.severity.value)
+      @overlay = :choice
+    end
+
+    def finding_set_status : Nil
+      return unless f = findings_controller.view.detail_finding
+      @choice_picker = ChoicePicker.for_status(f.status.value)
+      @overlay = :choice
     end
 
     def finding_edit_notes : Nil

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -93,12 +93,15 @@ module Gori
       # findings
       abstract def finding_create : Nil # new finding from the selected flow
       abstract def findings_new : Nil   # new blank finding
+      abstract def findings_query : Nil # focus the `/` filter bar (list)
       abstract def findings_move(delta : Int32) : Nil
       abstract def findings_open : Nil
       abstract def finding_close : Nil
       abstract def findings_delete : Nil
-      abstract def finding_severity(delta : Int32) : Nil
-      abstract def finding_status(delta : Int32) : Nil
+      abstract def finding_severity(delta : Int32) : Nil # ±1 step (hidden [ ] chords)
+      abstract def finding_status(delta : Int32) : Nil   # ±1 step (hidden { } chords)
+      abstract def finding_set_severity : Nil            # open the severity colour picker
+      abstract def finding_set_status : Nil              # open the triage-status colour picker
       abstract def finding_edit_notes : Nil
       abstract def finding_edit_title : Nil               # rename + set severity via the form overlay
       abstract def finding_open_flow : Nil                # open the linked flow's detail in History

--- a/src/gori/verbs/findings.cr
+++ b/src/gori/verbs/findings.cr
@@ -27,6 +27,10 @@ module Gori
         [Verb::Chord.new("enter"), Verb::Chord.new("l"), Verb::Chord.new("right")], mnemonic: 'o') { |ctx| ctx.findings_open; nil }
 
       r.register Verb::Definition.new(
+        "findings.filter", "Filter findings", "Filter the list (severity:/status:/host:/free text)",
+        Verb::Scope::Findings, [Verb::Chord.new("/")]) { |ctx| ctx.findings_query; nil }
+
+      r.register Verb::Definition.new(
         "findings.new", "New finding", "Create a blank finding", Verb::Scope::Findings,
         [Verb::Chord.new("n")]) { |ctx| ctx.findings_new; nil }
 
@@ -43,13 +47,24 @@ module Gori
         "finding.close", "Back to list", "Return to the findings list", Verb::Scope::FindingsDetail,
         [Verb::Chord.new("escape"), Verb::Chord.new("left"), Verb::Chord.new("h")], hidden: true) { |ctx| ctx.finding_close; nil }
 
+      # Severity/status edits live on the Space menu (a colour picker) so arrows
+      # never change them by accident. The bracket/brace chords stay as hidden
+      # power-shortcuts (one-step cycling); the pickers are the discoverable path.
+      r.register Verb::Definition.new(
+        "finding.set-severity", "Set severity", "Pick this finding's severity",
+        Verb::Scope::FindingsDetail, [] of Verb::Chord, mnemonic: 's') { |ctx| ctx.finding_set_severity; nil }
+
+      r.register Verb::Definition.new(
+        "finding.set-status", "Set status", "Pick this finding's triage status",
+        Verb::Scope::FindingsDetail, [] of Verb::Chord, mnemonic: 'c') { |ctx| ctx.finding_set_status; nil }
+
       r.register Verb::Definition.new(
         "finding.severity-up", "Raise severity", "Increase severity", Verb::Scope::FindingsDetail,
-        [Verb::Chord.new("]"), Verb::Chord.new("right")], hidden: true) { |ctx| ctx.finding_severity(1); nil }
+        [Verb::Chord.new("]")], hidden: true) { |ctx| ctx.finding_severity(1); nil }
 
       r.register Verb::Definition.new(
         "finding.severity-down", "Lower severity", "Decrease severity", Verb::Scope::FindingsDetail,
-        [Verb::Chord.new("["), Verb::Chord.new("left")], hidden: true) { |ctx| ctx.finding_severity(-1); nil }
+        [Verb::Chord.new("[")], hidden: true) { |ctx| ctx.finding_severity(-1); nil }
 
       # edit-notes/edit-title/open-flow/replay-flow/delete are NON-hidden so they front
       # the finding-detail "space" action menu (parity with the History detail; the


### PR DESCRIPTION
## What & why

Three friction points on the **Findings** tab, addressed:

### 1. `/` filter bar (like History)
- New in-memory `Gori::Findings::Filter` (`src/gori/findings_query.cr`) — `severity:`/`sev:` (ordinal `>= > <= < =`, `crit` alias), `status:`/`st:` (incl. `status:closed` = any non-open), `host:`, `title:`, `-` negation, free text. Live-filtered (no debounce — small in-memory list), with field-name Tab-completion.
- Deliberately **not** `QL.parse` — its `status:`/`size:` map to HTTP/flow columns (wrong semantics for findings).

### 2. Severity/status via a Space colour-picker (no more accidental arrows)
- Removed the accident-prone **←/→ severity bindings**; severity & status are now set through a new reusable **`ChoicePicker`** overlay (`src/gori/tui/choice_picker.cr`, a twin of `BrowserPicker`) opened from the Space menu (`s` severity, `c` status). Shows coloured options with the current value marked `● current`.
- `[ ]`/`{ }` kept as hidden power-shortcuts.

### 3. Elegant detail redesign
- Severity-coloured `●` bullet + bold title + `#id`, a filled severity/status **chip** row, an `evidence` line, and `NOTES` with an `e to edit` affordance — replacing the cramped one-line header + cryptic `[ ] sev · { } status` hint.

## Notes
- TUI-only; **no store migration** (reuses `update_finding`'s existing `severity:`/`status:`).
- New `:choice` modal overlay wired through every Runner touch-point (mirrors `:browser`).
- Rebased on current `main` (reconciled cleanly with the #28 Space-menu expansion).

## Verification
- `crystal spec` → **778 examples, 0 failures** (new `findings_query_spec`, `choice_picker_spec` + regression tests).
- tmux end-to-end: filter narrowing, both pickers, arrow-key safety, Tab-completion, redesigned detail.
- A 3-dimension adversarial review caught + fixed 3 issues (query_complete trailing-space, empty-value term consistency, picker row_at clamp on tiny terminals).