### PR TITLE
feat(tui): Convert — split sections into separate cards + navigable OUTPUT pane

### DIFF
--- a/spec/tui/convert_view_spec.cr
+++ b/spec/tui/convert_view_spec.cr
@@ -62,21 +62,51 @@ describe Gori::Tui::ConvertView do
     b.contains?("myhash").should be_true
   end
 
-  it "colours the section-divider tees to match the frame (gold when focused)" do
-    # The ├/┤ land on the frame's side borders, so a focused body must light them
-    # gold instead of leaving a grey notch in the gold frame.
-    [{true, Theme.focus_gold}, {false, Theme.border}].each do |(focused, want)|
-      view = ConvertView.new
-      backend = MemoryBackend.new(80, 30)
-      inner = Rect.new(1, 1, 78, 28) # inset so the left tee at inner.x-1 = col 0 is on-screen
-      result = Gori::Convert.run(REG, "x".to_slice, "hex")
-      view.render(Screen.new(backend), inner,
-        input: TextArea.new("x"), chain: "hex", chain_cx: 3, chain_pre: "",
-        result: result, pane: :input, focused: focused, popup: ChainComplete.new, prompt: nil, prompt_buf: "")
-      tee_row = (0...30).find { |y| backend.grid[y][0] == '├' }
-      tee_row.should_not be_nil
-      backend.fg_at(0, tee_row.not_nil!).should eq(want)
-    end
+  it "lights only the focused section's card border gold (per-pane focus)" do
+    # Each section is its own card now (not a divided single frame), so focusing
+    # INPUT must gild only the INPUT card — the read-only PIPELINE/OUTPUT cards
+    # stay hairline grey. The card's top-left corner '╭' carries the border colour.
+    view = ConvertView.new
+    backend = MemoryBackend.new(80, 30)
+    rect = Rect.new(0, 0, 80, 30)
+    result = Gori::Convert.run(REG, "x".to_slice, "hex")
+    view.render(Screen.new(backend), rect,
+      input: TextArea.new("x"), chain: "hex", chain_cx: 3, chain_pre: "",
+      result: result, pane: :input, focused: true, popup: ChainComplete.new, prompt: nil, prompt_buf: "")
+
+    corners = (0...30).select { |y| backend.grid[y][0] == '╭' }
+    corners.size.should eq 4 # one per card: INPUT, CHAIN, PIPELINE, OUTPUT
+
+    backend.fg_at(0, corners[0]).should eq(Theme.focus_gold) # INPUT (focused) → gold
+    backend.fg_at(0, corners[1]).should eq(Theme.border)     # CHAIN (unfocused) → grey
+    backend.fg_at(0, corners[2]).should eq(Theme.border)     # PIPELINE (read-only) → grey
+    backend.fg_at(0, corners[3]).should eq(Theme.border)     # OUTPUT (read-only) → grey
+  end
+
+  it "gilds the CHAIN card border when the chain pane holds focus" do
+    view = ConvertView.new
+    backend = MemoryBackend.new(80, 30)
+    result = Gori::Convert.run(REG, "x".to_slice, "hex")
+    view.render(Screen.new(backend), Rect.new(0, 0, 80, 30),
+      input: TextArea.new("x"), chain: "hex", chain_cx: 3, chain_pre: "",
+      result: result, pane: :chain, focused: true, popup: ChainComplete.new, prompt: nil, prompt_buf: "")
+    corners = (0...30).select { |y| backend.grid[y][0] == '╭' }
+    backend.fg_at(0, corners[0]).should eq(Theme.border)     # INPUT (unfocused) → grey
+    backend.fg_at(0, corners[1]).should eq(Theme.focus_gold) # CHAIN (focused) → gold
+  end
+
+  it "gilds the OUTPUT card border when the (read-only but navigable) output pane holds focus" do
+    view = ConvertView.new
+    backend = MemoryBackend.new(80, 30)
+    result = Gori::Convert.run(REG, "x".to_slice, "hex")
+    view.render(Screen.new(backend), Rect.new(0, 0, 80, 30),
+      input: TextArea.new("x"), chain: "hex", chain_cx: 3, chain_pre: "",
+      result: result, pane: :output, focused: true, popup: ChainComplete.new, prompt: nil, prompt_buf: "")
+    corners = (0...30).select { |y| backend.grid[y][0] == '╭' }
+    backend.fg_at(0, corners[0]).should eq(Theme.border)     # INPUT → grey
+    backend.fg_at(0, corners[1]).should eq(Theme.border)     # CHAIN → grey
+    backend.fg_at(0, corners[2]).should eq(Theme.border)     # PIPELINE → grey
+    backend.fg_at(0, corners[3]).should eq(Theme.focus_gold) # OUTPUT (focused) → gold
   end
 end
 

--- a/src/gori/tui/controllers/convert_controller.cr
+++ b/src/gori/tui/controllers/convert_controller.cr
@@ -64,9 +64,9 @@ module Gori::Tui
       Verb::Scope::Convert
     end
 
-    # Both regions capture text → always the EDITOR badge.
+    # INPUT + CHAIN capture text → EDITOR; the read-only OUTPUT pane is navigable.
     def body_badge : Symbol
-      :editor
+      cur.pane == :output ? :body : :editor
     end
 
     # The current session (always valid: ≥1 session, @idx kept in range).
@@ -166,12 +166,12 @@ module Gori::Tui
         BodyChrome.render_subtab_strip(screen, sub_rect, subtab_labels, @idx, focus == :subtabs)
       end
       s = cur
-      BodyChrome.framed(screen, body_rect, body_focused) do |inner|
-        s.view.render(screen, inner,
-          input: s.input, chain: s.chain, chain_cx: s.chain_cx, chain_pre: @chain_pre,
-          result: s.result, pane: s.pane, focused: body_focused,
-          popup: @popup, prompt: @prompt, prompt_buf: @prompt_buf)
-      end
+      # Each section frames its own card (per-pane focus border), so we hand the view
+      # the full body rect rather than wrapping it in one outer frame.
+      s.view.render(screen, body_rect,
+        input: s.input, chain: s.chain, chain_cx: s.chain_cx, chain_pre: @chain_pre,
+        result: s.result, pane: s.pane, focused: body_focused,
+        popup: @popup, prompt: @prompt, prompt_buf: @prompt_buf)
     end
 
     # The body dispatcher. Reached only when this tab is active, no overlay is up,
@@ -204,7 +204,11 @@ module Gori::Tui
         commit
         @host.request_focus(:menu)
       else
-        cur.pane == :input ? edit_input(ev, c) : edit_chain(ev, c)
+        case cur.pane
+        when :input  then edit_input(ev, c)
+        when :output then handle_output(ev)
+        else              edit_chain(ev, c)
+        end
       end
       true
     end
@@ -232,15 +236,21 @@ module Gori::Tui
       @host.focus_body
       body = @sessions.size >= 2 ? BodyChrome.carve_subtab_row(rect)[1] : rect
       s = cur
-      regions = s.view.layout(body.inset(1, 1))
+      # The view frames each card itself, so layout takes the full body rect; the
+      # editable content lives one cell inside each card border.
+      regions = s.view.layout(body)
       if regions.input.contains?(mx, my)
         s.pane = :input
         @popup.close
-        s.input.click_to_cursor(regions.input, mx, my)
+        s.input.click_to_cursor(regions.input.inset(1, 1), mx, my)
       elsif regions.chain.contains?(mx, my)
         s.pane = :chain
-        s.chain_cx = Screen.column_for(s.chain, mx - (regions.chain.x + 2))
+        field = regions.chain.inset(1, 1)
+        s.chain_cx = Screen.column_for(s.chain, mx - (field.x + 2))
         refilter_popup
+      elsif regions.output.contains?(mx, my)
+        s.pane = :output # OUTPUT is navigable now — a click focuses it (wheel still scrolls)
+        @popup.close
       end
       true
     end
@@ -256,17 +266,18 @@ module Gori::Tui
       true
     end
 
-    # --- focus ring (Tab/Shift-Tab): menu ▸ input ▸ chain ▸ menu ---
+    # --- focus ring (Tab/Shift-Tab): menu ▸ input ▸ chain ▸ output ▸ menu ---
+    # OUTPUT is read-only but joins the ring so it can be focused + scrolled.
+    PANE_ORDER = [:input, :chain, :output]
+
     def pane_advance(dir : Int32) : Bool
       s = cur
       @popup.close
-      if dir > 0
-        return (s.pane = :chain; true) if s.pane == :input
-        false
-      else
-        return (s.pane = :input; true) if s.pane == :chain
-        false
-      end
+      i = PANE_ORDER.index(s.pane) || 0
+      ni = i + dir
+      return false if ni < 0 || ni >= PANE_ORDER.size
+      s.pane = PANE_ORDER[ni]
+      true
     end
 
     def focus_first : Nil
@@ -275,16 +286,19 @@ module Gori::Tui
     end
 
     def focus_last : Nil
-      cur.pane = :chain
+      cur.pane = :output
       @popup.close
     end
 
     def body_hint(focus : Symbol) : String
       return "type a name · ↵ save · esc cancel" if @prompt == :save_as
       return "type a name · ↵ load · esc cancel" if @prompt == :load
-      if cur.pane == :chain
+      case cur.pane
+      when :chain
         return "↑/↓ pick · ↹/↵ complete · esc close · type to filter" if @popup.open?
-        "chain (> | ,) · ↑ input · ^Y copy · ^X mode · ^S save · ^O load · ^N new · esc tabs"
+        "chain (> | ,) · ↑ input · ↓ output · ^Y copy · ^X mode · ^S save · ^O load · esc tabs"
+      when :output
+        "↑/↓ scroll · ↑-top chain · ↹ next · space menu · ^X mode · ^Y copy · esc tabs"
       else
         "type to edit · ↓/↹ chain · ^L clear · ^Y copy · ^X mode · ^N new · ^W close · esc tabs"
       end
@@ -366,6 +380,9 @@ module Gori::Tui
       when key.up?
         s.pane = :input
         @popup.close
+      when key.down?
+        s.pane = :output # down from CHAIN drops into the OUTPUT pane (popup owns ↓ while open)
+        @popup.close
       when key.backspace?
         if s.chain_cx > 0
           s.chain = s.chain[0, s.chain_cx - 1] + s.chain[s.chain_cx..]
@@ -390,6 +407,19 @@ module Gori::Tui
           touch
           refilter_popup
         end
+      end
+    end
+
+    # ---- OUTPUT pane (read-only but navigable) ----
+    # Mirrors Replay's response pane: space opens the action menu (nothing to type
+    # here), ↑/↓ scroll, and ↑ at the top pops focus up to the CHAIN field above.
+    private def handle_output(ev : Termisu::Event::Key) : Nil
+      return @host.open_space_menu if ev.key.space? && !ev.ctrl? && !ev.alt?
+      s = cur
+      key = ev.key
+      case
+      when key.up?   then s.view.output_at_top? ? (s.pane = :chain) : s.view.scroll_output(-1)
+      when key.down? then s.view.scroll_output(1)
       end
     end
 

--- a/src/gori/tui/convert_view.cr
+++ b/src/gori/tui/convert_view.cr
@@ -31,72 +31,102 @@ module Gori::Tui
     @out_lines : Array(String) = [] of String
     @out_dirty : Bool = true
 
-    # Sub-rects of the framed interior. Each section but INPUT is preceded by a
-    # labelled divider row (INPUT rides just under the frame's top border, so it
-    # gets a plain label line). Degenerate heights collapse toward OUTPUT-only.
-    def layout(inner : Rect) : Regions
-      empty = Rect.new(inner.x, inner.y, 0, 0)
-      return Regions.new(empty, empty, empty, inner) if inner.h < 8
+    # Card rects for the four sections, stacked top-to-bottom. Each is a full
+    # `Frame.card` (border + interior), NOT a divided slice of one outer frame —
+    # so focusing INPUT or CHAIN lights only that card (mirrors Replay's
+    # TARGET/REQUEST/RESPONSE). CHAIN is a fixed 3-high single-line field; INPUT
+    # takes ~a quarter; PIPELINE sizes to its step count; OUTPUT gets the rest.
+    # Tight bodies fold PIPELINE away, then collapse toward an OUTPUT-only card.
+    def layout(rect : Rect) : Regions
+      empty = Rect.new(rect.x, rect.y, 0, 0)
+      h = rect.h
+      return Regions.new(empty, empty, empty, empty) if h <= 0 || rect.w <= 0
 
-      # Fixed overhead: INPUT label (1) + 3 divider rows + CHAIN field (1) = 5.
-      avail = inner.h - 5
-      input_h = (inner.h * 25 // 100).clamp(2, 8)
-      input_h = {input_h, avail - 2}.min # always leave ≥2 for pipeline+output
-      rest = avail - input_h
-      steps = {@last_step_count, 1}.max
-      pipe_h = {steps, {rest - 1, 1}.max}.min # already in [1, rest-1]
-      out_h = {rest - pipe_h, 1}.max
-
-      y = inner.y + 1 # row inner.y holds the INPUT label
-      input = Rect.new(inner.x, y, inner.w, input_h); y += input_h
-      y += 1 # CHAIN divider
-      chain = Rect.new(inner.x, y, inner.w, 1); y += 1
-      y += 1 # PIPELINE divider
-      pipeline = Rect.new(inner.x, y, inner.w, pipe_h); y += pipe_h
-      y += 1 # OUTPUT divider
-      output = Rect.new(inner.x, y, inner.w, out_h)
-      Regions.new(input, chain, pipeline, output)
+      chain_h = 3 # 1-line field framed top + bottom
+      if h >= 12
+        rest = h - chain_h                           # input + pipeline + output (≥ 9)
+        input_h = (h * 25 // 100).clamp(3, rest - 6) # leave ≥3 each for pipe + out
+        remaining = rest - input_h                   # pipeline + output (≥ 6)
+        steps = {@last_step_count, 1}.max
+        pipe_h = (steps + 2).clamp(3, remaining - 3) # leave ≥3 for out
+        out_h = remaining - pipe_h
+        stack(rect, {input_h, chain_h, pipe_h, out_h})
+      elsif h >= 9
+        # No room for four min-height cards — fold PIPELINE away, keep the workflow
+        # cards (INPUT to type · CHAIN to spec · OUTPUT to read).
+        rest = h - chain_h # input + output (≥ 6)
+        input_h = (rest // 2).clamp(3, rest - 3)
+        stack(rect, {input_h, chain_h, 0, rest - input_h})
+      else
+        Regions.new(empty, empty, empty, rect) # too short for cards → output-only
+      end
     end
 
-    def render(screen : Screen, inner : Rect, *, input : TextArea, chain : String,
+    # Stack the four card rects vertically from the given heights (a 0 height = the
+    # folded-away section, returned as an empty rect the renderer skips).
+    private def stack(rect : Rect, heights : {Int32, Int32, Int32, Int32}) : Regions
+      y = rect.y
+      cards = heights.map do |hh|
+        c = hh > 0 ? Rect.new(rect.x, y, rect.w, hh) : Rect.new(rect.x, y, 0, 0)
+        y += hh
+        c
+      end
+      Regions.new(cards[0], cards[1], cards[2], cards[3])
+    end
+
+    def render(screen : Screen, rect : Rect, *, input : TextArea, chain : String,
                chain_cx : Int32, chain_pre : String, result : Convert::ChainResult,
                pane : Symbol, focused : Bool, popup : ChainComplete, prompt : Symbol?,
                prompt_buf : String) : Nil
-      return if inner.empty?
+      return if rect.empty?
       @last_step_count = result.steps.size
-      r = layout(inner)
-      return if r.input.empty? # too small to draw the notebook
+      r = layout(rect)
 
-      # INPUT — label rides under the frame top; the TextArea draws below it.
-      screen.text(inner.x, inner.y, "INPUT", Theme.muted, Theme.bg, Attribute::Bold)
-      input.render(screen, r.input, cursor: focused && pane == :input)
+      render_input(screen, r.input, input, focused && pane == :input) unless r.input.empty?
+      render_chain(screen, r.chain, chain, chain_cx, chain_pre, focused && pane == :chain) unless r.chain.empty?
+      render_pipeline(screen, r.pipeline, result) unless r.pipeline.empty?
+      render_output_card(screen, r.output, result, focused && pane == :output) unless r.output.empty?
 
-      # CHAIN — divider + single-line field with a "›" prompt.
-      divider(screen, inner, r.chain.y - 1, "CHAIN", focused)
-      screen.text(r.chain.x, r.chain.y, "› ", Theme.accent, Theme.bg)
-      chain_fg = pane == :chain ? Theme.text_bright : Theme.text
-      screen.input_line(r.chain.x + 2, r.chain.y, chain, chain_cx, pane == :chain ? chain_pre : "",
-        chain_fg, Theme.bg, width: {r.chain.w - 2, 1}.max)
-
-      # PIPELINE — one row per step.
-      divider(screen, inner, r.pipeline.y - 1, "PIPELINE", focused)
-      render_steps(screen, r.pipeline, result)
-
-      # OUTPUT — final bytes, scrollable; the divider names the active display mode.
-      divider(screen, inner, r.output.y - 1, output_header(result), focused)
-      render_output(screen, r.output, result)
-
-      # The autocomplete popup + the save/load prompt float LAST (over the notebook).
-      popup.render(screen, r.chain, inner) if pane == :chain && popup.open?
-      render_prompt(screen, r.output, prompt, prompt_buf) if prompt
+      # The autocomplete popup (anchored under the CHAIN field) + the save/load
+      # prompt float LAST, over the cards below them.
+      popup.render(screen, r.chain.inset(1, 1), rect) if pane == :chain && popup.open? && !r.chain.empty?
+      render_prompt(screen, r.output.inset(1, 1), prompt, prompt_buf) if prompt && !r.output.empty?
     end
 
-    # The ├ / ┤ tees land on the frame's side borders, so they must take the SAME
-    # colour as the enclosing card (gold when the body is focused) — otherwise the
-    # seam reads as a grey notch in the gold frame. Mirrors history_view/findings_view.
-    private def divider(screen : Screen, inner : Rect, y : Int32, label : String, focused : Bool) : Nil
-      Frame.inner_divider(screen, inner, y, bg: Theme.bg, border: Frame.pane_border(focused))
-      screen.text(inner.x + 1, y, " #{label} ", Theme.muted, Theme.bg, width: {inner.w - 2, 1}.max)
+    # INPUT — a framed TextArea; gold border only when it holds focus.
+    private def render_input(screen : Screen, card : Rect, input : TextArea, active : Bool) : Nil
+      Frame.card(screen, card, "INPUT", bg: Theme.bg, border: Frame.pane_border(active))
+      input.render(screen, card.inset(1, 1), cursor: active)
+    end
+
+    # CHAIN — a framed single-line spec field with a "›" prompt; gold when focused.
+    # Only the focused field shows the block caret (matches Replay's target row).
+    private def render_chain(screen : Screen, card : Rect, chain : String, chain_cx : Int32,
+                             chain_pre : String, active : Bool) : Nil
+      Frame.card(screen, card, "CHAIN", bg: Theme.bg, border: Frame.pane_border(active))
+      c = card.inset(1, 1)
+      return if c.h <= 0
+      screen.text(c.x, c.y, "› ", Theme.accent, Theme.bg)
+      fg = active ? Theme.text_bright : Theme.text
+      vw = {c.w - 2, 1}.max
+      if active
+        screen.input_line(c.x + 2, c.y, chain, chain_cx, chain_pre, fg, Theme.bg, width: vw)
+      else
+        screen.text(c.x + 2, c.y, chain, fg, Theme.bg, width: vw)
+      end
+    end
+
+    # PIPELINE — a read-only card (never focusable), one row per step.
+    private def render_pipeline(screen : Screen, card : Rect, result : Convert::ChainResult) : Nil
+      Frame.card(screen, card, "PIPELINE", bg: Theme.bg, border: Theme.border)
+      render_steps(screen, card.inset(1, 1), result)
+    end
+
+    # OUTPUT — read-only but navigable (↑/↓ scroll); the title names the active
+    # display mode + byte count, and the border gilds when the pane holds focus.
+    private def render_output_card(screen : Screen, card : Rect, result : Convert::ChainResult, active : Bool) : Nil
+      Frame.card(screen, card, output_header(result), bg: Theme.bg, border: Frame.pane_border(active))
+      render_output(screen, card.inset(1, 1), result)
     end
 
     private def render_steps(screen : Screen, rect : Rect, result : Convert::ChainResult) : Nil
@@ -206,6 +236,12 @@ module Gori::Tui
 
     def scroll_output(step : Int32) : Nil
       @out_scroll += step
+    end
+
+    # Whether the OUTPUT is scrolled to the top — ↑ here pops focus up to CHAIN
+    # (render clamps @out_scroll on every frame, so this reads the true top).
+    def output_at_top? : Bool
+      @out_scroll <= 0
     end
 
     # Invoked by the controller after every recompute: reset scroll AND invalidate


### PR DESCRIPTION
## Summary

Reworks the Convert tab so each section is its own focusable card, addressing that the whole body lit up gold on focus (hard to tell which pane was active).

- **Four separate `Frame.card`s** (INPUT · CHAIN · PIPELINE · OUTPUT) stacked vertically instead of one outer frame with `├─┤` inner dividers — mirrors Replay's TARGET/REQUEST/RESPONSE. Only the focused card's border gilds.
- **OUTPUT is now a read-only-but-navigable pane** in the focus ring (`PANE_ORDER = [:input, :chain, :output]`):
  - `Tab`/`Shift-Tab` reaches it (border gilds), click focuses it
  - `↑`/`↓` scroll; `↑` at the top pops focus back up to CHAIN; `↓` from CHAIN drops into it
  - `space` opens the action menu (Convert verbs) — natural since there's nothing to type there
  - badge reads `BODY` (vs `EDITOR`), like Replay's response pane
- Layout degrades gracefully on short terminals (folds PIPELINE away, then collapses toward OUTPUT-only).

## Test plan

- `crystal spec` — 782 examples, 0 failures (added per-pane focus-border specs for INPUT/CHAIN/OUTPUT)
- `crystal build` clean; `ameba` clean on changed view
- Live-verified in tmux: per-pane gold focus, OUTPUT scroll, `↑`-at-top → CHAIN, `space` → action menu, `BODY` badge