### PR TITLE
feat(tui): project scope ↑-at-top pops focus to tab bar

### DIFF
--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -176,7 +176,12 @@ module Gori::Tui
         save
         @host.request_focus(:menu)
       elsif key.up?
-        @project_view.scope_select(-1)
+        if @project_view.scope_at_top? # ↑ on the first rule pops up to the tab bar
+          save
+          @host.request_focus(:menu)
+        else
+          @project_view.scope_select(-1)
+        end
       elsif key.down?
         @project_view.scope_select(1)
       elsif key.right?

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -180,6 +180,12 @@ module Gori::Tui
       @sel = (@sel + d).clamp(0, n - 1)
     end
 
+    # Selection on the first rule (or an empty list) → ↑ pops focus to the tab bar,
+    # mirroring the DESCRIPTION editor's `at_top?`.
+    def scope_at_top? : Bool
+      @sel <= 0
+    end
+
     def scope_add_start : Nil
       @adding = true
       @edit_id = nil


### PR DESCRIPTION
## What

In the Project tab's **SCOPE** rule list, pressing **↑** while on the top row (or with an empty list) now pops focus up to the tab bar — mirroring the DESCRIPTION editor's existing `↑`-at-top behaviour.

Previously `↑` at the top of the scope list was a silent no-op (`scope_select(-1)` clamps at row 0), leaving no keyboard path back up to the tab bar from the scope list other than `esc`.

## How

- `ProjectView#scope_at_top?` — true when the selection is on the first rule or the list is empty.
- `ProjectController#handle_project_scope_key` — the `↑` arm routes through it: at top → `save` + `request_focus(:menu)`; otherwise `scope_select(-1)` as before.

## Verification

Built (`shards build`) and smoke-tested end-to-end via tmux:
- Down/Up within the list still moves the selection.
- **↑ on the top row** flips the hint from `BODY ↑/↓ move …` to `TABS ←/→ switch tab …` (focus left the body for the tab bar).
- Re-entering with **↓** restores the SCOPE pane with the top selection preserved.

The `crystal tool format` crash on this file is a pre-existing Crystal 1.20.2 formatter bug (Unicode in the `body_hint` string, line 41) present on unmodified `main` too; `--check` returns 0.