### PR TITLE
feat(tui): help tab read-only sub-tabs (Shortcuts/Links/About)

### DIFF
--- a/spec/tui/help_view_spec.cr
+++ b/spec/tui/help_view_spec.cr
@@ -30,4 +30,23 @@ describe Gori::Tui::HelpView do
     after.contains?("OVERLAYS").should be_true # last section now on screen
     view.at_top?.should be_false
   end
+
+  it "renders the Links page with the GitHub repository URL" do
+    view = HelpView.new
+    backend = MemoryBackend.new(90, 20)
+    view.render_links(Screen.new(backend), Rect.new(0, 0, 90, 20))
+
+    backend.contains?("LINKS").should be_true
+    backend.contains?("GitHub").should be_true
+    backend.contains?(Gori::REPOSITORY_URL).should be_true
+  end
+
+  it "renders the About page with the centered version" do
+    view = HelpView.new
+    backend = MemoryBackend.new(90, 20)
+    view.render_version(Screen.new(backend), Rect.new(0, 0, 90, 20))
+
+    backend.contains?("gori").should be_true
+    backend.contains?("v#{Gori::VERSION}").should be_true
+  end
 end

--- a/src/gori.cr
+++ b/src/gori.cr
@@ -6,6 +6,10 @@
 module Gori
   VERSION = "0.1.0"
 
+  # Canonical project home — surfaced in the TUI Help → Links page (and reusable
+  # by the CLI/about screens). Kept beside VERSION as the project's identity.
+  REPOSITORY_URL = "https://github.com/hahwul/gori"
+
   # Single base error for the whole project. Subtype only when a `rescue`
   # actually needs to discriminate (P0 — don't build a hierarchy speculatively).
   class Error < Exception

--- a/src/gori/tui/controllers/help_controller.cr
+++ b/src/gori/tui/controllers/help_controller.cr
@@ -2,11 +2,18 @@ require "../tab_controller"
 require "../help_view"
 
 module Gori::Tui
-  # The Help tab: a read-only, static shortcut cheat-sheet. The simplest possible
-  # controller — it overrides only identity, render, scroll, and the body hint;
-  # everything else uses the TabController defaults. Serves as the pilot proving the
-  # registry + Host contract end-to-end.
+  # The Help tab: three read-only sub-tabs sharing one strip — Shortcuts (the
+  # scrollable cheat-sheet), Links (project URLs), About (version, later a logo).
+  # Unlike Replay/Notes the set is FIXED: no create/close/rename. The strip, focus
+  # routing, ←/→, ^1-9 and click hit-testing all come free from the runner's shared
+  # sub-tab machinery once we expose subtab_labels; we add only the page renderers.
   class HelpController < TabController
+    # The fixed sub-tab strip. Index 0 (Shortcuts) is the default landing page,
+    # preserving the tab's original behaviour.
+    PAGE_LABELS = ["Shortcuts", "Links", "About"]
+
+    @current : Int32 = 0
+
     def initialize(host : Host)
       super(host)
       @help = HelpView.new
@@ -20,35 +27,73 @@ module Gori::Tui
       Verb::Scope::Body
     end
 
-    def render_body(screen : Screen, rect : Rect, focus : Symbol) : Nil
-      focused = focus == :body
-      BodyChrome.framed(screen, rect, focused) { |inner| @help.render(screen, inner, focused: focused) }
+    # --- fixed sub-tab strip (no new/close/rename) ---
+    def subtab_labels : Array(String)
+      PAGE_LABELS
     end
 
-    # Read-only scroll (↑/↓ or j/k). ↑ at the top pops to the tab bar; esc returns
-    # to it. Only the navigation keys are claimed (return true); EVERY other key
-    # must fall through (return false) so the space menu and the global keymap
-    # still see it — otherwise the body's own hint ("^P cmds") points at dead keys.
+    def subtab_index : Int32
+      @current
+    end
+
+    def move_subtab(dir : Int32) : Nil
+      @current = (@current + dir).clamp(0, PAGE_LABELS.size - 1)
+    end
+
+    def jump_subtab(idx : Int32) : Nil
+      @current = idx if 0 <= idx < PAGE_LABELS.size
+    end
+
+    def subtabs_fixed? : Bool # constant set, read-only body — no ^N/^W, no editing
+      true
+    end
+
+    def render_body(screen : Screen, rect : Rect, focus : Symbol) : Nil
+      # Same chrome as Notes/Replay: the strip rides above the framed body (drawn
+      # by the shared BodyChrome, not the view). The set is always 3, so the strip
+      # is always shown.
+      sub_rect, body_rect = BodyChrome.carve_subtab_row(rect)
+      BodyChrome.render_subtab_strip(screen, sub_rect, PAGE_LABELS, @current, focus == :subtabs)
+      focused = focus == :body
+      BodyChrome.framed(screen, body_rect, focused) do |inner|
+        case @current
+        when 1 then @help.render_links(screen, inner)
+        when 2 then @help.render_version(screen, inner)
+        else        @help.render(screen, inner, focused: focused) # Shortcuts
+        end
+      end
+    end
+
+    # Read-only navigation. ←/→ switch pages (claimed so arrows never fall through
+    # to top-level tab switching — there's no caret to move here). ↑/↓ scroll only
+    # the Shortcuts page; ↑ at its top (or any non-scrolling page) steps up to the
+    # strip. esc pops to the tab bar. EVERY other key falls through (return false)
+    # so the space menu and the global keymap still see it.
     def handle_body_key(ev : Termisu::Event::Key) : Bool
       key = ev.key
       case
-      when key.up?, key.lower_k?   then @help.at_top? ? @host.request_focus(:menu) : @help.move(-1)
-      when key.down?, key.lower_j? then @help.move(1)
-      when key.escape?             then @host.request_focus(:menu)
-      else                              return false # ^P / space / q / global keys pass through
+      when key.escape?              then @host.request_focus(:menu)
+      when key.left?, key.lower_h?  then move_subtab(-1)
+      when key.right?, key.lower_l? then move_subtab(1)
+      when key.up?, key.lower_k?
+        (@current == 0 && !@help.at_top?) ? @help.move(-1) : @host.request_focus(:subtabs)
+      when key.down?, key.lower_j?
+        @help.move(1) if @current == 0
+      else
+        return false # ^P / space / q / global keys pass through
       end
       true
     end
 
     def handle_wheel(step : Int32) : Bool
-      @help.move(step)
+      @help.move(step) if @current == 0 # only the Shortcuts page scrolls
       true
     end
 
     def body_hint(focus : Symbol) : String
       # No "q projects": q (back to the picker) is tab-bar-only by design, so the
       # body must not advertise it as a key (esc/↹ to the bar first, then q).
-      "↑/↓ scroll · ↹/esc tabs · ^P cmds"
+      "↑/↓ scroll · ←/→ pages · ↹/esc tabs · ^P cmds"
     end
   end
 end

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -157,5 +157,46 @@ module Gori::Tui
       max = {@rows.size - h, 0}.max
       @scroll = @scroll.clamp(0, max)
     end
+
+    # --- the "Links" sub-tab page ---------------------------------------------
+    # A small {label, url} table so more rows (issue tracker, docs, …) drop in
+    # here later without touching the renderer.
+    LINKS = [
+      {"GitHub", Gori::REPOSITORY_URL},
+    ]
+
+    # Static (no scroll): a "LINKS" head + one row per link, reusing the same
+    # two-column key/desc layout idiom as draw_row so it lines up with Shortcuts.
+    def render_links(screen : Screen, rect : Rect) : Nil
+      return if rect.empty?
+      screen.text(rect.x + 1, rect.y, "LINKS", Theme.accent, attr: Attribute::Bold, width: {rect.w - 2, 1}.max)
+      LINKS.each_with_index do |(label, url), i|
+        y = rect.y + 2 + i
+        break if y >= rect.bottom
+        screen.text(rect.x + 2, y, label, Theme.text_bright, width: {KEY_W, {rect.w - 3, 1}.max}.min)
+        dx = rect.x + 2 + KEY_W
+        screen.text(dx, y, url, Theme.muted, width: {rect.right - dx - 1, 1}.max) if dx < rect.right - 1
+      end
+    end
+
+    # --- the "About" sub-tab page ---------------------------------------------
+    # Static, centered name + version. Future: an ASCII logo will sit above the
+    # version line (this block is the slot for it).
+    def render_version(screen : Screen, rect : Rect) : Nil
+      return if rect.empty?
+      lines = ["gori", "v#{Gori::VERSION}"]
+      top = rect.y + {(rect.h - lines.size) // 2, 0}.max
+      lines.each_with_index do |line, i|
+        centered(screen, rect, top + i, line, i == 0 ? Theme.accent : Theme.text_bright,
+          attr: i == 0 ? Attribute::Bold : Attribute::None)
+      end
+    end
+
+    # Horizontally center `text` on row `y` within `rect` (mirrors ProjectPicker).
+    private def centered(screen : Screen, rect : Rect, y : Int32, text : String, fg : Color,
+                         attr : Attribute = Attribute::None) : Nil
+      x = rect.x + {(rect.w - text.size) // 2, 0}.max
+      screen.text(x, y, text, fg, Theme.bg, attr: attr)
+    end
   end
 end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1222,13 +1222,16 @@ module Gori::Tui
       end
     end
 
-    # Sub-tab new/close/commit dispatched across the multi-session tabs.
+    # Sub-tab new/close/commit dispatched across the multi-session tabs. The active
+    # tab is matched explicitly (NOT an `else → notes`): tabs with a FIXED strip
+    # (Help) also expose subtab_labels, so a stray ^N/^W/^P-commit from their strip
+    # must no-op here, never leak into Notes.
     private def subtab_new : Nil
       case @active_tab
       when :replay  then replay_controller.replay_new
       when :fuzzer  then fuzzer_controller.fuzz_new
       when :convert then convert_controller.convert_new
-      else               notes_controller.notes_new
+      when :notes   then notes_controller.notes_new
       end
     end
 
@@ -1237,7 +1240,7 @@ module Gori::Tui
       when :replay  then replay_controller.request_close
       when :fuzzer  then fuzzer_controller.request_close
       when :convert then convert_controller.convert_close
-      else               notes_controller.notes_close
+      when :notes   then notes_controller.notes_close
       end
     end
 
@@ -1246,7 +1249,7 @@ module Gori::Tui
       when :replay  then replay_controller.save_current_replay
       when :fuzzer  then fuzzer_controller.save_current
       when :convert then convert_controller.commit
-      else               notes_controller.save_notes
+      when :notes   then notes_controller.save_notes
       end
     end
 
@@ -1661,6 +1664,11 @@ module Gori::Tui
         # Focus on the tab bar: ←/→ pick the tab, Tab/↵ drop into the body.
         return "←/→ switch tab · ↹/↵ enter · 1-9 jump · ^P cmds · q projects · ^D quit" if @focus == :menu
         if @focus == :subtabs
+          # A fixed strip (Help) has no create/close and a read-only body — don't
+          # advertise ^N/^W/edit as live keys there.
+          if @tabs[@active_tab]?.try(&.subtabs_fixed?)
+            return "←/→ switch sub-tab · ↓/↵ enter · ^1-9 jump · ↑/esc tabs"
+          end
           rn = renameable_subtabs? ? " · r rename" : ""
           return "←/→ switch sub-tab · ↓/↵ edit · ^1-9 jump · ^N new · ^W close#{rn} · ↑/esc tabs"
         end

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -119,6 +119,12 @@ module Gori::Tui
     def jump_subtab(idx : Int32) : Nil
     end
 
+    # A FIXED strip (Help): the chip set is constant — no ^N/^W create/close and the
+    # body is read-only. The shell drops "new/close/edit" from the strip hint for it.
+    def subtabs_fixed? : Bool
+      false
+    end
+
     # --- status bar ---
     def body_badge : Symbol # :editor (captures text) | :body (navigable/read-only)
       :body


### PR DESCRIPTION
## Summary
Splits the flat Help cheat-sheet into a fixed, **read-only** sub-tab strip — unlike Replay/Notes, the set is constant (no create/close/rename):

- **Shortcuts** — the existing scrollable keyboard/mouse cheat-sheet (default landing page, unchanged)
- **Links** — project URLs; currently `GitHub → https://github.com/hahwul/gori` (new `Gori::REPOSITORY_URL` constant). List-backed so the issue tracker etc. drop in later.
- **About** — centered `gori` + version, with a slot reserved for a future ASCII logo above the version line.

## How it works
Reuses the runner's existing sub-tab machinery (strip render, focus routing, ←/→, `^1-9` jump, click hit-testing) by exposing `subtab_labels` — only the page renderers are added. Page-switch also works with ←/→ from the body (no caret to move); ↑/↓ scroll only the Shortcuts page.

## Two guards for the FIXED set
1. **New `TabController#subtabs_fixed?` hook** (Help overrides `true`) — the runner's SUBTABS hint drops the inert `^N new · ^W close · edit` keys → `←/→ switch sub-tab · ↓/↵ enter · ^1-9 jump · ↑/esc tabs`.
2. **`subtab_new`/`subtab_close`/`subtab_commit`** now match `:notes` explicitly (was `else → notes`), so a stray `^N`/`^W` from Help's strip no-ops instead of leaking into Notes. (Rename was already gated to replay/fuzzer/convert.)

## Verification
- `shards build gori` ✓
- `crystal spec spec/tui/` — 280 examples, 0 failures (incl. 2 new help-page specs) ✓
- ameba clean on new files ✓
- Live tmux smoke test: all three pages render; ←/→ + click + `^1-9` switch; `^N`/`^W` on Help no-op while Notes' own `^N` still works.

## Files
`src/gori.cr` · `src/gori/tui/help_view.cr` · `src/gori/tui/controllers/help_controller.cr` · `src/gori/tui/runner.cr` · `src/gori/tui/tab_controller.cr` · `spec/tui/help_view_spec.cr`