### PR TITLE
feat(tui): scroll long Project description with the mouse wheel

### DIFF
--- a/spec/tui/project_view_spec.cr
+++ b/spec/tui/project_view_spec.cr
@@ -1,0 +1,98 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# Guards the Project tab DESCRIPTION scroll fix: a long description must scroll inside
+# its card (mouse wheel → TextArea#scroll_view) instead of spilling past the page, and
+# the wheel must hit the pane UNDER the pointer (ProjectView#pane_at, as the controller
+# routes it). The core viewport-scroll mechanism is tested on TextArea directly.
+
+private def tmp_store(&)
+  path = File.tempname("gori-projview", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def render_ta(ta : TextArea, h : Int32) : MemoryBackend
+  b = MemoryBackend.new(40, h)
+  ta.render(Screen.new(b), Rect.new(0, 0, 40, h), cursor: false)
+  b
+end
+
+describe "TextArea#scroll_view" do
+  lines = (1..20).map { |i| "row%02d" % i }.join("\n")
+
+  it "shifts the viewport immediately (independent of the cursor) and clamps both ends" do
+    ta = TextArea.new(lines)
+    render_ta(ta, 5).row(0).includes?("row01").should be_true # top before scrolling
+
+    ta.scroll_view(3)                                         # one wheel notch (±3)
+    render_ta(ta, 5).row(0).includes?("row04").should be_true # window jumped, cursor wasn't at the edge
+
+    ta.scroll_view(100) # past the end → clamp to the last full window
+    b = render_ta(ta, 5)
+    b.row(0).includes?("row16").should be_true # 20 lines − 5 rows = scroll 15
+    b.row(4).includes?("row20").should be_true # last line sits at the bottom, still inside
+
+    ta.scroll_view(-100) # back past the top → clamp to 0
+    render_ta(ta, 5).row(0).includes?("row01").should be_true
+  end
+
+  it "is a no-op before the first render (height unknown) and when the buffer already fits" do
+    ta = TextArea.new(lines)
+    ta.scroll_view(5) # no render yet ⇒ @last_h == 0
+    render_ta(ta, 5).row(0).includes?("row01").should be_true
+
+    short = TextArea.new("a\nb\nc")
+    render_ta(short, 10) # 3 lines fit in 10 rows
+    short.scroll_view(5)
+    render_ta(short, 10).row(0).includes?("a").should be_true
+  end
+end
+
+describe "ProjectView DESCRIPTION scrolling" do
+  it "scrolls a long description into view inside its card, staying on the page" do
+    tmp_store do |store|
+      view = ProjectView.new(Gori::Scope.load(store), "http://127.0.0.1:8080")
+      view.replace_desc((1..40).map { |i| "desc%02d" % i }.join("\n"))
+      view.focus_pane(:desc)
+      rect = Rect.new(0, 0, 120, 30)
+
+      b1 = MemoryBackend.new(120, 30)
+      view.render(Screen.new(b1), rect, focused: true) # establishes the viewport height
+      b1.contains?("desc01").should be_true
+      b1.contains?("desc40").should be_false # the tail is below the fold
+
+      view.desc_scroll(100) # wheel to the bottom
+      b2 = MemoryBackend.new(120, 30)
+      view.render(Screen.new(b2), rect, focused: true)
+      b2.contains?("desc40").should be_true      # the tail scrolled into view
+      b2.contains?("desc01").should be_false     # the head scrolled off
+      b2.contains?("DESCRIPTION").should be_true # the card frame is intact (content stayed bounded)
+    end
+  end
+end
+
+describe "ProjectView#pane_at" do
+  it "splits the body into the overview band + SCOPE / DESCRIPTION cards (the wheel hit-test)" do
+    tmp_store do |store|
+      view = ProjectView.new(Gori::Scope.load(store), "")
+      rect = Rect.new(0, 0, 120, 30)
+      view.render(Screen.new(MemoryBackend.new(120, 30)), rect, focused: false)
+
+      view.pane_at(rect, rect.x + 1, rect.y).should eq(:overview)    # top band
+      content_y = rect.y + 12                                        # below the capped overview (meta_h == 11)
+      view.pane_at(rect, rect.x + 1, content_y).should eq(:scope)    # left card
+      view.pane_at(rect, rect.right - 2, content_y).should eq(:desc) # right card
+      view.pane_at(Rect.new(0, 0, 0, 0), 0, 0).should be_nil         # empty rect → nothing
+    end
+  end
+end

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -81,6 +81,18 @@ module Gori::Tui
       true
     end
 
+    # A wheel notch scrolls the pane UNDER the pointer (not the focused one), so a long
+    # DESCRIPTION scrolls into view on a plain wheel-over — no click-to-focus first. The
+    # DESCRIPTION viewport-scrolls (cursor follows) instead of spilling past the card;
+    # the SCOPE rule list moves its selection (selection-follow, like the keyboard).
+    def handle_wheel_at(step : Int32, mx : Int32, my : Int32, rect : Rect) : Bool
+      case @project_view.pane_at(rect, mx, my)
+      when :desc  then @project_view.desc_scroll(step)
+      when :scope then @project_view.scope_select(step)
+      end # :overview band / outside → nothing to scroll
+      true
+    end
+
     def set_preedit(text : String) : Bool
       @project_view.set_preedit(text)
       true

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -312,6 +312,12 @@ module Gori::Tui
       @desc_area.move(dr, dc)
     end
 
+    # Mouse wheel over the DESCRIPTION: scroll the viewport (cursor follows), so a long
+    # description scrolls into view instead of staying clipped past the card edge.
+    def desc_scroll(step : Int32) : Nil
+      @desc_area.scroll_view(step)
+    end
+
     def goto_line(n : Int32) : Nil
       @desc_area.goto_line(n)
     end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -601,7 +601,7 @@ module Gori::Tui
     private def modal_overlay? : Bool
       case @overlay
       when :palette, :rules, :finding_new, :confirm, :browser, :choice, :comparer_pick, :settings, :tabs, :hotkeys then true
-      else                                                                                                    false
+      else                                                                                                              false
       end
     end
 
@@ -783,7 +783,9 @@ module Gori::Tui
       return @space_menu.move(step) if @space_menu_open
       return wheel_overlay(step) if modal_overlay?
       return unless layout.body.contains?(mx, my)
-      @tabs[@active_tab]?.try(&.handle_wheel(step)) # all body tabs are migrated; controller owns the wheel
+      # Pass the pointer + body rect so a multi-pane tab (Project) scrolls the pane
+      # under the cursor; single-target tabs ignore the coords (base delegates to handle_wheel).
+      @tabs[@active_tab]?.try(&.handle_wheel_at(step, mx, my, layout.body))
     end
 
     # Wheel inside a centered modal scrolls its list (no movement for the button modals).
@@ -1619,9 +1621,9 @@ module Gori::Tui
       when :browser       then "BROWSER"
       when :choice        then @choice_picker.try(&.title) || "CHOOSE"
       when :comparer_pick then "PICK FLOW"
-      when :settings    then "SETTINGS"
-      when :tabs        then "TAB BAR"
-      when :hotkeys     then "HOTKEYS"
+      when :settings      then "SETTINGS"
+      when :tabs          then "TAB BAR"
+      when :hotkeys       then "HOTKEYS"
       else
         case @focus
         when :menu    then "TABS"
@@ -1653,10 +1655,10 @@ module Gori::Tui
       when :browser       then "↑/↓ select · ↵ open · esc cancel"
       when :choice        then "↑/↓ select · ↵ set · key picks · esc cancel"
       when :comparer_pick then "type to filter · ↑/↓ select · ↵ choose · esc cancel"
-      when :settings    then "↑/↓ field · type to edit · ↵ save · ^R reset · esc close"
-      when :tabs        then "↑/↓ select · space show/hide · K/J reorder · r reset · ↵ save · esc cancel"
-      when :hotkeys     then @hotkeys_overlay.capturing? ? "press a key to bind · esc cancel" : "↑/↓ select · e/␣ rebind · x unbind · r reset · ⇧R reset all · ←/→ profile · ↵ save · esc"
-      when :detail      then "←/→ panes · ↑/↓ scroll · ^R replay · ⇧F finding · x hex · p pretty · space cmds · ^G goto · ^F find · esc back"
+      when :settings      then "↑/↓ field · type to edit · ↵ save · ^R reset · esc close"
+      when :tabs          then "↑/↓ select · space show/hide · K/J reorder · r reset · ↵ save · esc cancel"
+      when :hotkeys       then @hotkeys_overlay.capturing? ? "press a key to bind · esc cancel" : "↑/↓ select · e/␣ rebind · x unbind · r reset · ⇧R reset all · ←/→ profile · ↵ save · esc"
+      when :detail        then "←/→ panes · ↑/↓ scroll · ^R replay · ⇧F finding · x hex · p pretty · space cmds · ^G goto · ^F find · esc back"
       else
         # Focus on the tab bar: ←/→ pick the tab, Tab/↵ drop into the body.
         return "←/→ switch tab · ↹/↵ enter · 1-9 jump · ^P cmds · q projects · ^D quit" if @focus == :menu

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -15,23 +15,23 @@ module Gori::Tui
   # controllers can never re-couple via shared private state.
   module Host
     abstract def status(message : String) : Nil       # set the transient status/toast line
-    abstract def request_overlay(kind : Symbol) : Nil  # set @overlay (controllers can't write it directly)
-    abstract def request_focus(pane : Symbol) : Nil    # drive the focus model via focus_pane (:menu | :subtabs | :body)
-    abstract def focus_body : Nil                      # raw: focus the body WITHOUT resetting the pane (for clicks)
-    abstract def switch_tab(tab : Symbol) : Nil        # change the active tab (with save-on-leave + on_enter)
-    abstract def goto_tab(tab : Symbol) : Nil          # raw: set active tab + body focus, no on_enter/view_focus_first (e.g. ^R → Replay)
-    abstract def open_palette : Nil                    # open the command palette overlay
-    abstract def open_space_menu : Nil                 # open the space action menu (bottom-right)
+    abstract def request_overlay(kind : Symbol) : Nil # set @overlay (controllers can't write it directly)
+    abstract def request_focus(pane : Symbol) : Nil   # drive the focus model via focus_pane (:menu | :subtabs | :body)
+    abstract def focus_body : Nil                     # raw: focus the body WITHOUT resetting the pane (for clicks)
+    abstract def switch_tab(tab : Symbol) : Nil       # change the active tab (with save-on-leave + on_enter)
+    abstract def goto_tab(tab : Symbol) : Nil         # raw: set active tab + body focus, no on_enter/view_focus_first (e.g. ^R → Replay)
+    abstract def open_palette : Nil                   # open the command palette overlay
+    abstract def open_space_menu : Nil                # open the space action menu (bottom-right)
     # Destructive-action confirmation modal; `action` runs on confirm.
     abstract def confirm(title : String, message : String, *, confirm_label : String, danger : Bool, &action : -> Nil) : Nil
-    abstract def session : Session                     # store / scope / proxy / registry / interceptor
-    abstract def overlay : Symbol                      # read the overlay state (e.g. History reads :detail)
-    abstract def active_tab : Symbol                   # read the active tab (Replay reconcile gates on it)
-    abstract def focus : Symbol                         # read the focus model (:menu | :subtabs | :body)
-    abstract def reveal? : Bool                        # global whitespace-reveal pref, pushed into views
-    abstract def toggle_reveal : Nil                   # flip the whitespace-reveal pref (^B from any view)
-    abstract def pretty? : Bool                        # global pretty-print-bodies pref, pushed into views
-    abstract def toggle_pretty : Nil                   # flip the pretty-print pref (`p` from History/Replay)
+    abstract def session : Session   # store / scope / proxy / registry / interceptor
+    abstract def overlay : Symbol    # read the overlay state (e.g. History reads :detail)
+    abstract def active_tab : Symbol # read the active tab (Replay reconcile gates on it)
+    abstract def focus : Symbol      # read the focus model (:menu | :subtabs | :body)
+    abstract def reveal? : Bool      # global whitespace-reveal pref, pushed into views
+    abstract def toggle_reveal : Nil # flip the whitespace-reveal pref (^B from any view)
+    abstract def pretty? : Bool      # global pretty-print-bodies pref, pushed into views
+    abstract def toggle_pretty : Nil # flip the pretty-print pref (`p` from History/Replay)
   end
 
   # Shared, state-free body chrome used by BOTH Runner and the per-tab
@@ -96,6 +96,13 @@ module Gori::Tui
     # A scroll-wheel notch over the body (already ±3-scaled).
     def handle_wheel(step : Int32) : Bool
       false
+    end
+
+    # Same notch, but with the pointer position + body rect — lets a multi-pane tab
+    # (Project) scroll the pane UNDER the cursor instead of the focused one. Defaults
+    # to the coordinate-free handle_wheel, so single-target tabs need no change.
+    def handle_wheel_at(step : Int32, mx : Int32, my : Int32, rect : Rect) : Bool
+      handle_wheel(step)
     end
 
     # Live IME composition text for the focused body field. Return true if consumed.

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -15,6 +15,7 @@ module Gori::Tui
       @cy = 0
       @cx = 0
       @scroll = 0
+      @last_h = 0 # viewport height from the last render — lets scroll_view (wheel) clamp
       @preedit = ""
       # Cached syntax-highlight overlay (1:1 with @lines), rebuilt only when the
       # buffer content changes — not on every render frame. @styled_kind tracks
@@ -172,6 +173,19 @@ module Gori::Tui
       @cx = Screen.column_for(@lines[@cy], mx - (rect.x + gw))
     end
 
+    # Viewport scroll by `step` lines (the mouse wheel), INDEPENDENT of the cursor:
+    # shift the visible window, then pull the cursor into it so render's ensure_visible
+    # won't snap the view back to the old cursor line. Unlike move(), the window jumps
+    # immediately (no "wheel until the cursor reaches the edge" lag). No-op before the
+    # first render (height unknown) or when the buffer already fits.
+    def scroll_view(step : Int32) : Nil
+      return if @last_h <= 0 || @lines.size <= @last_h
+      max = @lines.size - @last_h
+      @scroll = (@scroll + step).clamp(0, max)
+      @cy = @cy.clamp(@scroll, {@scroll + @last_h - 1, @lines.size - 1}.min)
+      @cx = @cx.clamp(0, @lines[@cy].size)
+    end
+
     # Jump the cursor to 1-based line `n`, column 0 (out-of-range clamps to the
     # first/last line). render's ensure_visible scrolls it into view next frame.
     def goto_line(n : Int32) : Nil
@@ -207,6 +221,7 @@ module Gori::Tui
     # drawn last, on top — still lands on the right column.
     def render(screen : Screen, rect : Rect, cursor : Bool, highlight : Symbol? = nil) : Nil
       return if rect.empty?
+      @last_h = rect.h # remembered for scroll_view (wheel) clamping
       ensure_visible(rect.h)
       gw = @gutter ? {Gutter.width(@lines.size), rect.w}.min : 0 # never exceed the pane
       cx0 = rect.x + gw                                          # content start x (after the optional gutter)


### PR DESCRIPTION
## Problem

On the **Project** tab, a long `description` extended past its card with no way to scroll it. The description editor (`TextArea`) only scrolls when the cursor moves (keyboard ↑/↓), and the Project tab had no `handle_wheel`, so a plain mouse-wheel-over did nothing — the lower part of a long description was simply unreachable below the card's fold.

## Fix

- **`TextArea#scroll_view`** — a viewport scroll independent of the cursor. The window jumps immediately on each wheel notch (no "wheel until the cursor reaches the edge" lag); the cursor follows into the new window so `ensure_visible` won't snap the view back. Clamped to the buffer; no-op before the first render or when the buffer already fits. The widget now remembers its last render height for the clamp.
- **`ProjectController#handle_wheel_at`** — routes the wheel to the pane **under the pointer** (not the focused one), so the description scrolls on a plain wheel-over with no click-to-focus first. The (usually short) scope rule list still moves its selection (selection-follow, like the keyboard).
- **`TabController#handle_wheel_at`** — new hook carrying the pointer position + body rect. It defaults to the existing coordinate-free `handle_wheel`, so every other (single-target) tab is unchanged.

The description now scrolls inside its card and never spills past the page.

## Tests

New `spec/tui/project_view_spec.cr`:
- `TextArea#scroll_view` — immediate viewport jump + top/bottom clamp + the two no-op guards.
- Project DESCRIPTION scrolling — a 40-line description scrolls its tail into view with the frame intact.
- `ProjectView#pane_at` — the overview/scope/desc geometry the wheel hit-test relies on.

Verified end-to-end in a tmux pty: wheel over a 60-line description scrolls it immediately (no prior click), clamps at top/bottom, stays inside the card, and wheeling over the scope pane leaves the description untouched.

Full suite green: `790 examples, 0 failures`.