### PR TITLE
feat(tui): search Replay sub-tabs from the space menu

### DIFF
--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -59,6 +59,14 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def replay_send : Nil; end
 
+  def replay_find_subtab : Nil; end
+
+  property replay_tab_count : Int32 = 0
+
+  def replay_subtab_count : Int32
+    @replay_tab_count
+  end
+
   def replay_toggle_hex : Nil; end
 
   def replay_toggle_sni : Nil; end

--- a/spec/tui/subtab_picker_spec.cr
+++ b/spec/tui/subtab_picker_spec.cr
@@ -1,0 +1,68 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+private def sample_picker : SubtabPicker
+  SubtabPicker.new("FIND SUB-TAB", [
+    SubtabPicker::Row.new(0, "login", "POST /login https://app.example.com"),
+    SubtabPicker::Row.new(1, "search api", "GET /api/search https://api.example.com"),
+    SubtabPicker::Row.new(2, "checkout", "POST /cart/checkout https://shop.example.com"),
+  ])
+end
+
+describe Gori::Tui::SubtabPicker do
+  it "starts on the first row and hands back its absolute index" do
+    p = sample_picker
+    p.selected.should eq(0)
+    p.selected_index.should eq(0)
+  end
+
+  it "filters by label or request line and resets the cursor to the first match" do
+    p = sample_picker
+    p.query_char('a')
+    p.query_char('p')
+    p.query_char('i') # "api" matches only the search-api row (by label) ...
+    p.selected_index.should eq(1)
+
+    p2 = sample_picker
+    "shop".each_char { |c| p2.query_char(c) } # ... and by the target host (detail)
+    p2.selected_index.should eq(2)
+  end
+
+  it "is case-insensitive and ANDs whitespace-separated terms" do
+    p = sample_picker
+    "POST checkout".each_char { |c| p.query_char(c) }
+    p.selected_index.should eq(2) # both terms hit only the checkout row
+  end
+
+  it "reports no match when the filter excludes every row" do
+    p = sample_picker
+    "zzz".each_char { |c| p.query_char(c) }
+    p.selected_index.should be_nil
+  end
+
+  it "restores rows on backspace" do
+    p = sample_picker
+    "checkout".each_char { |c| p.query_char(c) }
+    p.selected_index.should eq(2)
+    8.times { p.backspace }
+    p.selected_index.should eq(0) # full list back, cursor at the top
+  end
+
+  it "clamps movement at both ends" do
+    p = sample_picker
+    p.move(-5)
+    p.selected.should eq(0)
+    p.move(99)
+    p.selected_index.should eq(2) # last row
+  end
+
+  it "renders the title and the sub-tab labels" do
+    backend = MemoryBackend.new(100, 30)
+    sample_picker.render(Screen.new(backend), Rect.new(0, 0, 100, 30))
+    backend.contains?("FIND SUB-TAB").should be_true
+    backend.contains?("login").should be_true
+    backend.contains?("checkout").should be_true
+  end
+end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -116,6 +116,14 @@ private class FakeContext < ExecContext
     @calls << :replay_send
   end
 
+  def replay_find_subtab : Nil
+    @calls << :replay_find_subtab
+  end
+
+  def replay_subtab_count : Int32
+    0
+  end
+
   def replay_toggle_hex : Nil
     @calls << :replay_toggle_hex
   end

--- a/src/gori/tui/controllers/replay_controller.cr
+++ b/src/gori/tui/controllers/replay_controller.cr
@@ -1,5 +1,6 @@
 require "../tab_controller"
 require "../replay_view"
+require "../subtab_picker"
 require "../../store"
 require "../../replay/engine"
 require "../../replay/h2_engine"
@@ -69,6 +70,16 @@ module Gori::Tui
 
     def subtab_labels : Array(String)
       @replays.map_with_index { |tab, i| "#{i + 1}:#{tab.view.label(18)}" }
+    end
+
+    # Rows for the sub-tab search picker (space → s): the chip label plus a dim,
+    # searchable request line (method/path + target URL) so a session is findable
+    # by host/path even when a custom name hides its summary.
+    def subtab_search_rows : Array(SubtabPicker::Row)
+      @replays.map_with_index do |tab, i|
+        v = tab.view
+        SubtabPicker::Row.new(i, v.label(40), "#{v.summary(60)} #{v.target}".strip)
+      end
     end
 
     def subtab_index : Int32

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -31,6 +31,7 @@ require "./confirm_dialog"
 require "./browser_picker"
 require "./choice_picker"
 require "./flow_picker"
+require "./subtab_picker"
 require "./settings_view"
 require "./tabs_overlay"
 require "./hotkeys_overlay"
@@ -64,7 +65,7 @@ module Gori::Tui
       # and Agent is hidden by default). Settings is loaded (cli.cr) before Runner.new.
       vis = Chrome.visible_tabs(Settings.tab_prefs).map(&.first)
       @active_tab = vis.includes?(:project) ? :project : vis.first
-      @overlay = :none # :none | :palette | :detail | :rules | :finding_new | :confirm | :browser | :choice | :comparer_pick | :settings | :tabs
+      @overlay = :none # :none | :palette | :detail | :rules | :finding_new | :confirm | :browser | :choice | :comparer_pick | :replay_subtab | :settings | :tabs
       # The "space" action menu (helix-style leader popup, bottom-right). Orthogonal
       # to @overlay so it floats over WHATEVER is underneath (the History list, an
       # open detail …) without disturbing that state; the scope is captured at open.
@@ -111,6 +112,8 @@ module Gori::Tui
       @choice_picker = nil.as(ChoicePicker?)
       # The Comparer flow picker (a/b → choose flow A/B); @overlay is :comparer_pick.
       @flow_picker = nil.as(FlowPicker?)
+      # The Replay sub-tab search picker (space → s); @overlay is :replay_subtab.
+      @subtab_picker = nil.as(SubtabPicker?)
       # The settings editor (palette → settings:network); @overlay is :settings.
       @settings_view = SettingsView.new
       # The tab-bar customizer (palette → settings:tabs); @overlay is :tabs. Distinct
@@ -365,6 +368,7 @@ module Gori::Tui
       when :rules         then @rules_overlay.set_preedit(text)
       when :finding_new   then @finding_form.set_preedit(text)
       when :comparer_pick then @flow_picker.try(&.set_preedit(text))
+      when :replay_subtab then @subtab_picker.try(&.set_preedit(text))
       when :settings      then @settings_view.set_preedit(text)
       when :none          then apply_preedit_body(text)
       end
@@ -425,6 +429,7 @@ module Gori::Tui
       return handle_browser_key(ev) if @overlay == :browser
       return handle_choice_key(ev) if @overlay == :choice
       return handle_flow_picker_key(ev) if @overlay == :comparer_pick
+      return handle_subtab_picker_key(ev) if @overlay == :replay_subtab
       return handle_settings_key(ev) if @overlay == :settings
       return handle_tabs_key(ev) if @overlay == :tabs
       return handle_hotkeys_key(ev) if @overlay == :hotkeys
@@ -600,8 +605,8 @@ module Gori::Tui
     # The overlays that fully capture input (a centered card); :detail and :none do not.
     private def modal_overlay? : Bool
       case @overlay
-      when :palette, :rules, :finding_new, :confirm, :browser, :choice, :comparer_pick, :settings, :tabs, :hotkeys then true
-      else                                                                                                              false
+      when :palette, :rules, :finding_new, :confirm, :browser, :choice, :comparer_pick, :replay_subtab, :settings, :tabs, :hotkeys then true
+      else                                                                                                                              false
       end
     end
 
@@ -675,6 +680,7 @@ module Gori::Tui
       when :browser       then click_browser(area, mx, my)
       when :choice        then click_choice(area, mx, my)
       when :comparer_pick then click_flow_picker(area, mx, my)
+      when :replay_subtab then click_subtab_picker(area, mx, my)
       when :confirm       then click_confirm(area, mx, my)
       when :settings      then click_settings(area, mx, my)
       when :tabs          then click_tabs(area, mx, my)
@@ -796,6 +802,7 @@ module Gori::Tui
       when :browser       then @browser_picker.try(&.move(step))
       when :choice        then @choice_picker.try(&.move(step))
       when :comparer_pick then @flow_picker.try(&.move(step))
+      when :replay_subtab then @subtab_picker.try(&.move(step))
       when :settings      then (@settings_view.move_field(step); preview_theme) # wheel scrolls the theme list too
       when :tabs          then @tabs_overlay.select_move(step)
       when :hotkeys       then @hotkeys_overlay.select_move(step)
@@ -999,6 +1006,51 @@ module Gori::Tui
     private def close_flow_picker : Nil
       @overlay = :none
       @flow_picker = nil
+    end
+
+    # Replay sub-tab search (space → s): type to filter the open sessions, ↑/↓
+    # select, ↵ jump to the highlighted one, esc cancel.
+    private def handle_subtab_picker_key(ev : Termisu::Event::Key) : Nil
+      sp = @subtab_picker
+      return close_subtab_picker if sp.nil?
+      key = ev.key
+      case
+      when key.escape?    then close_subtab_picker
+      when key.up?        then sp.move(-1)
+      when key.down?      then sp.move(1)
+      when key.enter?     then commit_subtab_picker
+      when key.backspace? then sp.backspace
+      else
+        sp.query_char(ev.char.not_nil!) if ev.char
+      end
+    end
+
+    # Jump to the highlighted sub-tab and close. The picker hands back the absolute
+    # index; jump_subtab clamps + saves the outgoing tab, so a stale index (the
+    # cross-session reconcile reordered behind the modal) is a safe no-op.
+    private def commit_subtab_picker : Nil
+      sp = @subtab_picker
+      return close_subtab_picker if sp.nil?
+      if idx = sp.selected_index
+        replay_controller.jump_subtab(idx)
+        @focus = :body # land on the chosen session's content (we came from the response pane)
+      end
+      close_subtab_picker
+    end
+
+    private def click_subtab_picker(area : Rect, mx : Int32, my : Int32) : Nil
+      sp = @subtab_picker
+      box = sp.try(&.overlay_box(area))
+      return close_subtab_picker if sp.nil? || box.nil? || dismiss_zone?(box, mx, my)
+      if idx = sp.row_at(box, mx, my)
+        sp.set_selected(idx)
+        commit_subtab_picker
+      end
+    end
+
+    private def close_subtab_picker : Nil
+      @overlay = :none
+      @subtab_picker = nil
     end
 
     # Settings editor (palette → settings:network): ↑/↓ pick a field, type to edit,
@@ -1547,6 +1599,7 @@ module Gori::Tui
       @browser_picker.try(&.render(screen, layout.body)) if @overlay == :browser
       @choice_picker.try(&.render(screen, layout.body)) if @overlay == :choice
       @flow_picker.try(&.render(screen, layout.body)) if @overlay == :comparer_pick
+      @subtab_picker.try(&.render(screen, layout.body)) if @overlay == :replay_subtab
       @settings_view.render(screen, layout.body) if @overlay == :settings
       @tabs_overlay.render(screen, layout.body) if @overlay == :tabs
       @hotkeys_overlay.render(screen, layout.body) if @overlay == :hotkeys
@@ -1624,6 +1677,7 @@ module Gori::Tui
       when :browser       then "BROWSER"
       when :choice        then @choice_picker.try(&.title) || "CHOOSE"
       when :comparer_pick then "PICK FLOW"
+      when :replay_subtab then "FIND SUB-TAB"
       when :settings      then "SETTINGS"
       when :tabs          then "TAB BAR"
       when :hotkeys       then "HOTKEYS"
@@ -1658,6 +1712,7 @@ module Gori::Tui
       when :browser       then "↑/↓ select · ↵ open · esc cancel"
       when :choice        then "↑/↓ select · ↵ set · key picks · esc cancel"
       when :comparer_pick then "type to filter · ↑/↓ select · ↵ choose · esc cancel"
+      when :replay_subtab then "type to filter · ↑/↓ select · ↵ jump · esc cancel"
       when :settings      then "↑/↓ field · type to edit · ↵ save · ^R reset · esc close"
       when :tabs          then "↑/↓ select · space show/hide · K/J reorder · r reset · ↵ save · esc cancel"
       when :hotkeys       then @hotkeys_overlay.capturing? ? "press a key to bind · esc cancel" : "↑/↓ select · e/␣ rebind · x unbind · r reset · ⇧R reset all · ←/→ profile · ↵ save · esc"
@@ -2280,6 +2335,19 @@ module Gori::Tui
 
     def replay_send : Nil
       replay_controller.replay_send
+    end
+
+    # Open the Replay sub-tab search picker (space → s). Snapshots the open
+    # sessions; the picker filters them in memory and jumps on ↵.
+    def replay_find_subtab : Nil
+      rows = replay_controller.subtab_search_rows
+      return @toast = "no other replay open to search" if rows.size < 2
+      @subtab_picker = SubtabPicker.new("FIND SUB-TAB", rows)
+      @overlay = :replay_subtab
+    end
+
+    def replay_subtab_count : Int32
+      replay_controller.count
     end
 
     def replay_toggle_hex : Nil

--- a/src/gori/tui/subtab_picker.cr
+++ b/src/gori/tui/subtab_picker.cr
@@ -1,0 +1,152 @@
+require "./screen"
+require "./theme"
+require "./frame"
+
+module Gori::Tui
+  # A type-to-filter picker over a tab's sub-tabs — search the open sessions by
+  # their chip label / request line, ↑/↓ select, ↵ jump to the chosen one. The
+  # structural twin of FlowPicker (in-memory substring filter, IME preedit,
+  # selection-follow scroll, mouse hit-test) but lists sub-tabs instead of flows.
+  # Pure state + rendering; the Runner owns the @overlay lifecycle and applies the
+  # pick. Generic over any sub-tab strip (only Replay wires it today).
+  class SubtabPicker
+    # `index` is the sub-tab's absolute position — the value handed back on commit;
+    # `label` is the chip text, `detail` the dim searchable request line.
+    record Row, index : Int32, label : String, detail : String
+
+    getter title : String
+    getter selected : Int32
+    @indexed : Array({Row, String}) # each row paired with its precomputed filter haystack
+
+    def initialize(@title : String, @rows : Array(Row))
+      @query = ""
+      @preedit = "" # live IME composition (e.g. Hangul jamo) shown under the filter caret
+      # Precompute each row's filter haystack ONCE (not per keystroke).
+      @indexed = @rows.map { |row| {row, "#{row.label} #{row.detail}".downcase} }
+      @filtered = @rows
+      @selected = 0
+      @scroll = 0
+    end
+
+    def set_preedit(text : String) : Nil
+      @preedit = text
+    end
+
+    # The absolute sub-tab index of the highlighted row (nil when nothing matches).
+    def selected_index : Int32?
+      @filtered[@selected]?.try(&.index)
+    end
+
+    def move(delta : Int32) : Nil
+      return if @filtered.empty?
+      @selected = (@selected + delta).clamp(0, @filtered.size - 1)
+    end
+
+    def set_selected(idx : Int32) : Nil
+      return if @filtered.empty?
+      @selected = idx.clamp(0, @filtered.size - 1)
+    end
+
+    def query_char(ch : Char) : Nil
+      return if ch.control?
+      @preedit = "" # a committed char ends any in-progress composition
+      @query += ch
+      refilter
+    end
+
+    def backspace : Nil
+      return if @query.empty?
+      @preedit = ""
+      @query = @query[0, @query.size - 1]
+      refilter
+    end
+
+    # Recompute the visible rows from the precomputed haystacks: every whitespace-
+    # separated term must appear (case-insensitive). Resets the cursor to the top.
+    private def refilter : Nil
+      terms = @query.downcase.split
+      @filtered = terms.empty? ? @rows : @indexed.select { |(_, hay)| terms.all? { |t| hay.includes?(t) } }.map(&.first)
+      @selected = 0
+      @scroll = 0
+    end
+
+    # A centred card filling most of the body area (stable height). nil when there
+    # isn't room to draw.
+    def overlay_box(area : Rect) : Rect?
+      w = {area.w - 4, 96}.min
+      h = area.h - 2
+      return nil if w < 30 || h < 8
+      x = area.x + (area.w - w) // 2
+      y = area.y + (area.h - h) // 2
+      Rect.new(x, y, w, h)
+    end
+
+    # Row index under (mx, my), mirroring render's list loop; nil outside the list.
+    def row_at(box : Rect, mx : Int32, my : Int32) : Int32?
+      list_top = box.y + 3
+      list_h = box.bottom - 1 - list_top
+      i = my - list_top
+      return nil if i < 0 || i >= list_h
+      return nil if mx < box.x + 1 || mx >= box.right - 1
+      ri = @scroll + i
+      ri < @filtered.size ? ri : nil
+    end
+
+    def render(screen : Screen, area : Rect) : Nil
+      box = overlay_box(area)
+      return unless box
+      Frame.card(screen, box, @title, border: Theme.border_focus)
+
+      if @query.empty? && @preedit.empty?
+        screen.text(box.x + 2, box.y + 1, "type to filter · ↑/↓ select · ↵ jump · esc cancel",
+          Theme.muted, Theme.panel, width: box.w - 4)
+      else
+        px = screen.text(box.x + 2, box.y + 1, "filter: ", Theme.muted, Theme.panel)
+        screen.input_line(px, box.y + 1, @query, @query.size, @preedit, Theme.text_bright,
+          Theme.panel, width: {box.right - 1 - px, 1}.max)
+      end
+      Frame.tee_divider(screen, box, box.y + 2)
+
+      list_top = box.y + 3
+      list_h = box.bottom - 1 - list_top
+      ensure_visible(list_h)
+
+      if @filtered.empty?
+        msg = @rows.empty? ? "no sub-tabs open" : "no sub-tabs match"
+        screen.text(box.x + 3, list_top, msg, Theme.muted, Theme.panel)
+        return
+      end
+
+      (0...list_h).each do |i|
+        ri = @scroll + i
+        break if ri >= @filtered.size
+        draw_row(screen, box, list_top + i, @filtered[ri], ri == @selected)
+      end
+    end
+
+    private def draw_row(screen : Screen, box : Rect, ry : Int32, row : Row, active : Bool) : Nil
+      bg = active ? Theme.accent_bg : Theme.panel
+      fg = active ? Theme.text_bright : Theme.text
+      screen.fill(Rect.new(box.x + 1, ry, box.w - 2, 1), bg)
+      screen.cell(box.x + 1, ry, active ? '▎' : ' ', Theme.accent, bg)
+
+      num_x = box.x + 3
+      label_x = num_x + 4
+      label_w = {box.w // 3, 16}.max
+      detail_x = label_x + label_w + 1
+      detail_w = {box.right - 1 - detail_x, 1}.max
+
+      screen.text(num_x, ry, "#{row.index + 1}", Theme.accent, bg, width: 3)
+      screen.text(label_x, ry, row.label, fg, bg, Attribute::Bold, width: label_w)
+      screen.text(detail_x, ry, row.detail, Theme.muted, bg, width: detail_w)
+    end
+
+    # Keep the selection on-screen (selection-follow scroll), like the History list.
+    private def ensure_visible(list_h : Int32) : Nil
+      return if list_h <= 0
+      @scroll = @selected if @selected < @scroll
+      @scroll = @selected - list_h + 1 if @selected >= @scroll + list_h
+      @scroll = @scroll.clamp(0, {@filtered.size - list_h, 0}.max)
+    end
+  end
+end

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -57,6 +57,8 @@ module Gori
       abstract def replay_selected : Nil                   # load History's selection into Replay
       abstract def replay_new : Nil                        # open a blank, hand-authored replay request
       abstract def replay_send : Nil                       # resend the (edited) request to the target
+      abstract def replay_find_subtab : Nil                # open the sub-tab search picker (filter + jump)
+      abstract def replay_subtab_count : Int32             # open replay session count (gates the search menu entry)
       abstract def replay_toggle_hex : Nil                 # toggle byte-exact hex editing of the request pane
       abstract def replay_toggle_sni : Nil                 # toggle the SNI-override sub-field (target pane)
       abstract def replay_toggle_auto_content_length : Nil # recompute Content-Length on send

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -61,6 +61,14 @@ module Gori
         Verb::Scope::Replay, [Verb::Chord.new("n", ctrl: true)],
         available: in_replay, mnemonic: 'n') { |ctx| ctx.replay_new; nil }
 
+      # Search the open replay sub-tabs and jump to the chosen one — menu-only
+      # (no chord), shown only when there are ≥2 sessions to pick between.
+      r.register Verb::Definition.new(
+        "replay.find-subtab", "Search sub-tabs", "Filter the open replay sessions and jump to one",
+        Verb::Scope::Replay,
+        available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :replay && ctx.replay_subtab_count >= 2 },
+        mnemonic: 's') { |ctx| ctx.replay_find_subtab; nil }
+
       # Request-pane toggles — keymap-driven (Replay scope) so they're rebindable. The
       # Runner delegators carry the pane-gating + status messages.
       r.register Verb::Definition.new(


### PR DESCRIPTION
## What

Adds a **`s` Search sub-tabs** entry to the Replay tab's `space` menu. Pressing `space` (from the response pane) → `s` opens a type-to-filter picker over the open replay sessions; `↵` jumps to the chosen one.

## Why

With many replay sessions open, the sub-tab strip gets crowded and hard to scan. This makes any session reachable by typing part of its name, method, host, or path — no horizontal hunting.

## How

| File | Change |
|---|---|
| `src/gori/tui/subtab_picker.cr` *(new)* | Generic `SubtabPicker` overlay — a twin of `FlowPicker` (in-memory multi-term filter, IME preedit, selection-follow scroll, mouse hit-test). Returns the chosen sub-tab's absolute index. |
| `src/gori/verbs/history.cr` | New `replay.find-subtab` verb — Replay scope, mnemonic `s`, menu-only (no chord), gated to `>=2` open sessions so the entry hides when there's nothing to search. |
| `src/gori/verb/context.cr` | New `ExecContext` methods `replay_find_subtab` + `replay_subtab_count`. |
| `src/gori/tui/runner.cr` | New `:replay_subtab` overlay wired exactly like `:comparer_pick`; commit calls the existing `jump_subtab` then lands focus on the body. |
| `src/gori/tui/controllers/replay_controller.cr` | `subtab_search_rows` builds rows (label + searchable "method/path + target URL" detail, so a session is findable even when a custom name hides its summary). |
| `spec/` | New `subtab_picker_spec.cr` (7 cases) + fake-context stubs in both fakes. |

Note: the Replay `space` menu opens only from the **response pane** (the request/target editors keep `space` literal) — consistent with the existing space-menu design.

## Verification

- Build clean; full suite green (**799 examples, 0 failures**).
- `ameba`: only the same `set_preedit`/`set_selected` accessor-name nits the existing `FlowPicker`/`ChoicePicker` carry.
- tmux TUI end-to-end: 4 sessions → `space` shows "**s Search sub-tabs**" → `s` opens the picker → `login` filter narrows → `↵` jumps (REQUEST → `GET /login`); "no sub-tabs match", `esc` cancels cleanly, and with 1 tab the entry is correctly hidden (≥2 gate).