### PR TITLE
feat(tui): scroll long Project description horizontally to follow the cursor

### DIFF
--- a/spec/tui/project_view_spec.cr
+++ b/spec/tui/project_view_spec.cr
@@ -27,6 +27,14 @@ private def render_ta(ta : TextArea, h : Int32) : MemoryBackend
   b
 end
 
+# Render with a live caret into a `w`×3 grid and return the top row (for the
+# horizontal-scroll assertions).
+private def render_row0(ta : TextArea, w : Int32, highlight : Symbol? = nil) : String
+  b = MemoryBackend.new(w, 3)
+  ta.render(Screen.new(b), Rect.new(0, 0, w, 3), cursor: true, highlight: highlight)
+  b.row(0)
+end
+
 describe "TextArea#scroll_view" do
   lines = (1..20).map { |i| "row%02d" % i }.join("\n")
 
@@ -55,6 +63,54 @@ describe "TextArea#scroll_view" do
     render_ta(short, 10) # 3 lines fit in 10 rows
     short.scroll_view(5)
     render_ta(short, 10).row(0).includes?("a").should be_true
+  end
+end
+
+describe "TextArea horizontal scroll (follow_x)" do
+  long = "HEAD" + ("." * 52) + "TAIL" # one 60-column line, head/tail tagged
+
+  it "scrolls a long line sideways to keep the cursor visible, and resets when it fits" do
+    ta = TextArea.new(long)
+    ta.follow_x = true
+    row = render_row0(ta, 20)
+    row.includes?("HEAD").should be_true # caret at col 0 → window pinned to the start
+    row.includes?("TAIL").should be_false
+
+    ta.move(0, 1000) # caret to the end of the line
+    row = render_row0(ta, 20)
+    row.includes?("TAIL").should be_true  # tail scrolled into view next to the caret
+    row.includes?("HEAD").should be_false # head scrolled off the left edge
+
+    ta.move(0, -1000)                                    # caret back to the start
+    render_row0(ta, 20).includes?("HEAD").should be_true # window slid back to 0
+  end
+
+  it "leaves long lines clipped at the start when follow_x is off (default — other editors)" do
+    ta = TextArea.new(long) # follow_x defaults to false
+    ta.move(0, 1000)        # caret past the right edge
+    row = render_row0(ta, 20)
+    row.includes?("HEAD").should be_true  # no horizontal scroll → head stays put
+    row.includes?("TAIL").should be_false # legacy right-clip: tail is never reached
+  end
+
+  it "handles a wide-glyph (Hangul) line straddling the scroll boundary without drifting" do
+    wide = "시작" + ("가" * 26) + "끝" # 4 + 52 + 2 = 58 columns; the cut lands mid-가
+    ta = TextArea.new(wide)
+    ta.follow_x = true
+    ta.move(0, 1000)
+    row = render_row0(ta, 20)
+    row.includes?("끝").should be_true   # the trailing marker scrolled into view
+    row.includes?("시작").should be_false # the leading marker scrolled off
+  end
+
+  it "keeps the markdown overlay aligned with the scrolled cells" do
+    md = "# HEAD" + ("." * 50) + "TAIL" # heading line, 60 columns
+    ta = TextArea.new(md)
+    ta.follow_x = true
+    ta.move(0, 1000)
+    row = render_row0(ta, 20, highlight: :markdown)
+    row.includes?("TAIL").should be_true  # styled (sliced) overlay shows the tail
+    row.includes?("HEAD").should be_false # …and not the head
   end
 end
 

--- a/src/gori/tui/highlight.cr
+++ b/src/gori/tui/highlight.cr
@@ -339,6 +339,48 @@ module Gori::Tui
       x + visual_col
     end
 
+    # Drop the first `start_col` display columns of a styled line, mirroring the
+    # TextArea string slicer: whole spans before the cut are skipped, the span the
+    # cut lands in is trimmed (a straddling wide glyph → leading spaces), and every
+    # following span is kept verbatim. Used by horizontally-scrolled editors so the
+    # styled overlay lines up with the cells actually drawn. Identity when col <= 0.
+    def self.slice_left(line : Line, start_col : Int32) : Line
+      return line if start_col <= 0
+      out = Line.new
+      acc = 0
+      cutting = true
+      line.each do |span|
+        unless cutting
+          out << span
+          next
+        end
+        sw = Screen.display_width(span.text)
+        if acc + sw <= start_col # whole span is left of the cut
+          acc += sw
+          next
+        end
+        kept = String.build do |io|
+          span.text.each_char do |ch|
+            if cutting
+              w = Screen.display_width(ch.to_s)
+              if acc + w <= start_col
+                acc += w
+                next
+              end
+              io << " " * (acc + w - start_col) if acc < start_col # straddling glyph → visible cells as spaces
+              io << ch if acc >= start_col                         # clean boundary keeps the glyph
+              acc += w
+              cutting = false
+            else
+              io << ch
+            end
+          end
+        end
+        out << Span.new(kept, span.fg, span.attr) unless kept.empty?
+      end
+      out
+    end
+
     # --- line builders -------------------------------------------------------
 
     private def self.start_line(raw : String, request : Bool) : Line

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -37,6 +37,7 @@ module Gori::Tui
       @total_captured = 0
       @created = nil
       @desc_area = TextArea.new
+      @desc_area.follow_x = true # long description lines scroll horizontally to keep the cursor visible
       @desc_dirty = false
 
       @pane = :scope            # :scope | :desc

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -15,7 +15,9 @@ module Gori::Tui
       @cy = 0
       @cx = 0
       @scroll = 0
-      @last_h = 0 # viewport height from the last render — lets scroll_view (wheel) clamp
+      @xscroll = 0      # leftmost visible display COLUMN (horizontal scroll); only moves when @follow_x is on
+      @last_h = 0       # viewport height from the last render — lets scroll_view (wheel) clamp
+      @follow_x = false # follow the cursor horizontally (long lines scroll into view); off ⇒ legacy right-clip
       @preedit = ""
       # Cached syntax-highlight overlay (1:1 with @lines), rebuilt only when the
       # buffer content changes — not on every render frame. @styled_kind tracks
@@ -39,6 +41,9 @@ module Gori::Tui
     setter search_hl : String
     setter reveal : Bool
     setter bg_regions : Array({Int32, Int32, Color})
+    # Enable horizontal cursor-following (the Project description); off everywhere
+    # else, so those editors keep @xscroll == 0 and their hot render path unchanged.
+    setter follow_x : Bool
     getter edits : Int32
 
     def set_text(text : String) : Nil
@@ -47,6 +52,7 @@ module Gori::Tui
       @cy = 0
       @cx = 0
       @scroll = 0
+      @xscroll = 0
       @preedit = ""
       @styled = nil
       @edits += 1
@@ -170,7 +176,9 @@ module Gori::Tui
       return if row < 0
       @cy = {@scroll + row, @lines.size - 1}.min
       gw = @gutter ? {Gutter.width(@lines.size), rect.w}.min : 0
-      @cx = Screen.column_for(@lines[@cy], mx - (rect.x + gw))
+      # + @xscroll: the click lands at display column (mx - content_x) WITHIN the
+      # visible window, which is @xscroll columns into the full line.
+      @cx = Screen.column_for(@lines[@cy], mx - (rect.x + gw) + @xscroll)
     end
 
     # Viewport scroll by `step` lines (the mouse wheel), INDEPENDENT of the cursor:
@@ -226,6 +234,7 @@ module Gori::Tui
       gw = @gutter ? {Gutter.width(@lines.size), rect.w}.min : 0 # never exceed the pane
       cx0 = rect.x + gw                                          # content start x (after the optional gutter)
       cw = {rect.w - gw, 0}.max                                  # content width
+      ensure_visible_x(cw)                                       # slide @xscroll so the caret stays on screen (no-op unless @follow_x)
       styled = highlight ? highlighted(highlight) : nil
       # Buffer char-offset of the first visible line — advanced per row so each line
       # knows its start for the bg-region overlay without an O(n²) rescan. Only the
@@ -238,7 +247,9 @@ module Gori::Tui
         break if li >= @lines.size
         Gutter.draw(screen, rect.x, rect.y + i, li, gw, current: li == @cy) if @gutter
         line = @lines[li]
-        if @reveal
+        if @xscroll > 0
+          draw_scrolled(screen, cx0, rect.y + i, li, line, styled, cw)
+        elsif @reveal
           Highlight.draw(screen, cx0, rect.y + i, Reveal.styled(line, false, cw), width: cw)
         elsif styled && (sl = styled[li]?)
           Highlight.draw(screen, cx0, rect.y + i, sl, width: cw)
@@ -267,13 +278,18 @@ module Gori::Tui
         # no-ops when there are no regions or in reveal mode.
         paint_bg_regions(screen, cx0, rect.y + i, line_off, line, cw) unless li == @cy && !@preedit.empty?
         line_off += line.size + 1 # advance BEFORE the cursor `next` so it can't desync
-        SearchHi.mark(screen, cx0, rect.y + i, line, @search_hl, cx0 + cw) unless @search_hl.empty?
+        unless @search_hl.empty?
+          # Mark on the visible (left-sliced) text so the highlight columns line up
+          # with the cells we actually drew once horizontally scrolled.
+          st = @xscroll > 0 ? slice_left(line, @xscroll) : line
+          SearchHi.mark(screen, cx0, rect.y + i, st, @search_hl, cx0 + cw)
+        end
         next unless cursor && li == @cy
         prefix_w = Screen.display_width(line[0, @cx])
         preedit_w = Screen.display_width(@preedit)
-        cxs = cx0 + prefix_w + preedit_w
-        screen.cursor(cxs, rect.y + i) if cxs < cx0 + cw
-        if cxs < cx0 + cw
+        cxs = cx0 + prefix_w + preedit_w - @xscroll
+        if cxs >= cx0 && cxs < cx0 + cw
+          screen.cursor(cxs, rect.y + i)
           cgw = [Screen.display_width((@preedit.empty? ? (@cx < line.size ? line[@cx] : ' ') : @preedit[0]).to_s), 1].max
           ch = @preedit.empty? ? (@cx < line.size ? line[@cx] : ' ') : @preedit[0]
           (0...cgw).each do |off|
@@ -321,6 +337,74 @@ module Gori::Tui
       @scroll = @cy if @cy < @scroll
       @scroll = @cy - h + 1 if @cy >= @scroll + h
       @scroll = 0 if @scroll < 0
+    end
+
+    # Horizontal companion to ensure_visible: slide @xscroll so the caret (cursor +
+    # any IME preedit) stays inside the visible column window. A line that fits whole
+    # resets to 0 (no needless side-scroll). No-op unless @follow_x, so every other
+    # editor keeps @xscroll == 0 and renders exactly as before.
+    private def ensure_visible_x(cw : Int32) : Nil
+      return unless @follow_x
+      return if cw <= 0
+      line = @lines[@cy]
+      pw = Screen.display_width(@preedit)
+      if Screen.display_width(line) + pw <= cw
+        @xscroll = 0
+        return
+      end
+      cx = @cx.clamp(0, line.size)
+      curx = Screen.display_width(line[0, cx]) + pw     # caret's display column in the full line
+      @xscroll = curx if curx < @xscroll                # caret left of the window → snap left
+      @xscroll = curx - cw + 1 if curx >= @xscroll + cw # caret past the right edge → snap right
+      @xscroll = 0 if @xscroll < 0
+    end
+
+    # The horizontally-scrolled per-line draw (only when @xscroll > 0): left-slice
+    # the line by @xscroll display columns so the caret's neighbourhood is visible,
+    # then reuse the normal drawers (which handle right truncation + the … ellipsis).
+    private def draw_scrolled(screen : Screen, cx0 : Int32, y : Int32, li : Int32,
+                              line : String, styled : Array(Highlight::Line)?, cw : Int32) : Nil
+      if @reveal
+        Highlight.draw(screen, cx0, y, Highlight.slice_left(Reveal.styled(line, false, cw + @xscroll), @xscroll), width: cw)
+      elsif styled && (sl = styled[li]?)
+        Highlight.draw(screen, cx0, y, Highlight.slice_left(sl, @xscroll), width: cw)
+      elsif li == @cy && !@preedit.empty?
+        cx = @cx.clamp(0, line.size)
+        spans = Highlight::Line.new
+        spans << Highlight::Span.new(line[0, cx], Theme.text) if cx > 0
+        spans << Highlight::Span.new(@preedit, Theme.text, Attribute::Underline) unless @preedit.empty?
+        suffix = line[cx..]
+        spans << Highlight::Span.new(suffix, Theme.text) unless suffix.empty?
+        Highlight.draw(screen, cx0, y, Highlight.slice_left(spans, @xscroll), width: cw)
+      else
+        screen.text(cx0, y, slice_left(line, @xscroll), Theme.text, width: cw)
+      end
+    end
+
+    # Drop the first `start_col` display columns of `s`. A wide glyph straddling the
+    # cut becomes leading spaces for its still-visible cells, so the remaining glyphs
+    # keep their columns. Identity when start_col <= 0.
+    private def slice_left(s : String, start_col : Int32) : String
+      return s if start_col <= 0
+      acc = 0
+      cutting = true
+      String.build do |io|
+        s.each_char do |ch|
+          if cutting
+            w = Screen.display_width(ch.to_s)
+            if acc + w <= start_col
+              acc += w
+              next
+            end
+            io << " " * (acc + w - start_col) if acc < start_col # straddling glyph → visible cells as spaces
+            io << ch if acc >= start_col                         # clean boundary keeps the glyph
+            acc += w
+            cutting = false
+          else
+            io << ch
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

A long line in the Project **DESCRIPTION** ran past the right edge of its card and the caret simply vanished. `TextArea` only scrolled vertically, so once the cursor moved beyond the content width it was clipped and never drawn. (The earlier wheel-scroll PR #38 only addressed the vertical axis.)

## Fix

Horizontal scrolling that follows the cursor, gated behind a `follow_x` flag enabled **only** for the Project description — every other editor (Replay, Notes, Convert, Fuzzer, Intercept) keeps `@xscroll == 0` and renders byte-for-byte as before, so there's no regression surface.

- `TextArea#ensure_visible_x` slides a new `@xscroll` (leftmost visible column) so the caret — cursor + any IME preedit — stays on screen, and resets to 0 when the line fits.
- `draw_scrolled` + `TextArea#slice_left` / `Highlight.slice_left` left-slice each line (plain, markdown-styled, reveal, IME-preedit) by `@xscroll` display columns, then reuse the existing drawers (right-truncation + `…` ellipsis). A wide glyph straddling the cut becomes leading spaces so columns never drift.
- `click_to_cursor`, the cursor cell, and `SearchHi` all factor in `@xscroll`.
- `ProjectView` enables `follow_x` on its description editor.

Chose horizontal scroll over soft-wrap because it preserves the editor's 1-line-per-row model that the gutter, click-to-cursor, search, wheel-scroll, and Fuzzer bg-regions all depend on.

## Verification

- **796 specs pass** (4 new: ascii scroll-and-reset, `follow_x`-off legacy clip, Hangul straddle, markdown overlay alignment). Build clean, formatted.
- **Live TUI (tmux):** typed a long line → view follows the cursor to the tail; moving left scrolls back to the head with a `…` indicator; Korean text renders correctly; the wide-glyph straddle at the boundary shows clean leading-space padding with no corruption or crash.