### PR TITLE
fix: 7-round bug-hunt across proxy/replay/intercept/scope/fuzzer/settings/cli+mcp

### DIFF
--- a/spec/cli_run_spec.cr
+++ b/spec/cli_run_spec.cr
@@ -5,12 +5,14 @@ require "json"
 # initializers) — enough to exercise the pure reconstruction/formatting code.
 private def flow_detail(scheme : String, host : String, port : Int32, request_head : String,
                         request_body : Bytes? = nil, http_version = "HTTP/1.1",
-                        target = "/", response_head : String? = nil, response_body : String? = nil)
+                        target = "/", response_head : String? = nil, response_body : String? = nil,
+                        request_body_truncated = false)
   row = Gori::Store::FlowRow.new(
     id: 7_i64, created_at: 0_i64, scheme: scheme, method: "GET", host: host, port: port,
     target: target, status: 200, size: 0_i64, state: Gori::Store::FlowState::Complete)
   Gori::Store::FlowDetail.new(row, http_version, request_head.to_slice, request_body,
-    response_head.try(&.to_slice), response_body.try(&.to_slice))
+    response_head.try(&.to_slice), response_body.try(&.to_slice),
+    request_body_truncated: request_body_truncated)
 end
 
 private def flow_row(*, target : String, host : String, status : Int32?, state : Gori::Store::FlowState)
@@ -72,6 +74,23 @@ describe Gori::Replay::FlowRequest do
     body = Bytes[0x0A, 0x41, 0x0A]
     built = Gori::Replay::FlowRequest.build(flow_detail("http", "h", 80, head, request_body: body))
     String.new(built.bytes).should eq("POST /p HTTP/1.1\r\nHost: h\r\n\r\n\nA\n")
+  end
+
+  it "re-syncs Content-Length to the stored body when the capture was truncated" do
+    # Head over-promises CL: 9999 but only 3 bytes survived the 8 MiB cap — replaying the
+    # original CL would hang the origin. build() rewrites CL to the actual length.
+    head = "POST /u HTTP/1.1\r\nHost: h\r\nContent-Length: 9999\r\nX-T: 1\r\n\r\n"
+    body = Bytes[0x41, 0x42, 0x43] # "ABC"
+    built = Gori::Replay::FlowRequest.build(
+      flow_detail("http", "h", 80, head, request_body: body, request_body_truncated: true))
+    String.new(built.bytes).should eq("POST /u HTTP/1.1\r\nHost: h\r\nContent-Length: 3\r\nX-T: 1\r\n\r\nABC")
+  end
+
+  it "leaves Content-Length untouched when the body was NOT truncated" do
+    head = "POST /u HTTP/1.1\r\nHost: h\r\nContent-Length: 3\r\n\r\n"
+    body = Bytes[0x41, 0x42, 0x43]
+    built = Gori::Replay::FlowRequest.build(flow_detail("http", "h", 80, head, request_body: body))
+    String.new(built.bytes).should eq("POST /u HTTP/1.1\r\nHost: h\r\nContent-Length: 3\r\n\r\nABC")
   end
 
   it "preserves a bare-LF request-line terminator when rewriting (no mixed endings)" do

--- a/spec/cli_run_spec.cr
+++ b/spec/cli_run_spec.cr
@@ -93,6 +93,16 @@ describe Gori::Replay::FlowRequest do
     String.new(built.bytes).should eq("POST /u HTTP/1.1\r\nHost: h\r\nContent-Length: 3\r\n\r\nABC")
   end
 
+  it "re-frames a truncated CHUNKED request to Content-Length so it can't hang" do
+    # A chunked body cut at the cap (no terminating 0-chunk) would block the origin; replace
+    # Transfer-Encoding with a Content-Length over the stored bytes so the request terminates.
+    head = "POST /u HTTP/1.1\r\nHost: h\r\nTransfer-Encoding: chunked\r\n\r\n"
+    body = "5\r\nhello\r\n".to_slice # 10 bytes of wire-form chunk data (cut before the 0-chunk)
+    built = Gori::Replay::FlowRequest.build(
+      flow_detail("http", "h", 80, head, request_body: body, request_body_truncated: true))
+    String.new(built.bytes).should eq("POST /u HTTP/1.1\r\nHost: h\r\nContent-Length: 10\r\n\r\n5\r\nhello\r\n")
+  end
+
   it "preserves a bare-LF request-line terminator when rewriting (no mixed endings)" do
     head = "GET http://h/p HTTP/1.1\nHost: h\n\n" # LF-only, absolute-form
     built = Gori::Replay::FlowRequest.build(flow_detail("http", "h", 80, head))

--- a/spec/findings_export_spec.cr
+++ b/spec/findings_export_spec.cr
@@ -87,7 +87,29 @@ describe Gori::Findings::Export do
 
         md = Gori::Findings::Export.markdown(store.findings, store, "proj")
         md.should_not contain("binary body omitted") # the valid text must NOT be dropped
-        md.should contain("body truncated")           # it's shown (truncated), not omitted
+        md.should contain("body truncated")          # it's shown (truncated), not omitted
+      end
+    end
+
+    it "still shows the readable prefix when an invalid byte is deeper than the cap" do
+      with_store do |store|
+        id = store.insert_flow(Gori::Store::CapturedRequest.new(
+          created_at: 1_i64, scheme: "http", host: "h.test", port: 80,
+          method: "GET", target: "/", http_version: "HTTP/1.1",
+          head: "GET / HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice, body: nil))
+        cap = Gori::Findings::Export::EVIDENCE_CAP
+        # Valid ASCII through the cap, then a stray 0xFF byte DEEPER than the cap. The slice
+        # (first `cap` bytes) is valid text, so the readable prefix must still be shown —
+        # checking the whole body would wrongly call it binary.
+        body = ("a" * cap).to_slice + Bytes[0xFF_u8] + ("bbbbb").to_slice
+        store.update_response(Gori::Store::CapturedResponse.new(
+          flow_id: id, status: 200, head: "HTTP/1.1 200 OK\r\n\r\n".to_slice,
+          body: body, reason: "OK", content_type: "text/plain", duration_us: 1_i64))
+        store.insert_finding("deep invalid byte", Gori::Store::Severity::High, "h.test", id)
+
+        md = Gori::Findings::Export.markdown(store.findings, store, "proj")
+        md.should_not contain("binary body omitted")
+        md.should contain("body truncated")
       end
     end
 

--- a/spec/findings_export_spec.cr
+++ b/spec/findings_export_spec.cr
@@ -70,6 +70,27 @@ describe Gori::Findings::Export do
       end
     end
 
+    it "does not drop a valid-UTF-8 body that truncation splits mid-codepoint" do
+      with_store do |store|
+        id = store.insert_flow(Gori::Store::CapturedRequest.new(
+          created_at: 1_i64, scheme: "http", host: "h.test", port: 80,
+          method: "GET", target: "/", http_version: "HTTP/1.1",
+          head: "GET / HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice, body: nil))
+        cap = Gori::Findings::Export::EVIDENCE_CAP
+        # Pad so a 3-byte char straddles the cap boundary: body[0, cap] ends mid-codepoint,
+        # which used to make the slice's valid_encoding? false → whole body dropped as binary.
+        big = ("a" * (cap - 1)) + "한" # 65535 ASCII + a 3-byte UTF-8 char → the cut splits it
+        store.update_response(Gori::Store::CapturedResponse.new(
+          flow_id: id, status: 200, head: "HTTP/1.1 200 OK\r\n\r\n".to_slice,
+          body: big.to_slice, reason: "OK", content_type: "text/plain", duration_us: 1_i64))
+        store.insert_finding("big utf8 body", Gori::Store::Severity::High, "h.test", id)
+
+        md = Gori::Findings::Export.markdown(store.findings, store, "proj")
+        md.should_not contain("binary body omitted") # the valid text must NOT be dropped
+        md.should contain("body truncated")           # it's shown (truncated), not omitted
+      end
+    end
+
     it "collapses the host field so a fence/newline can't open a runaway block" do
       with_store do |store|
         store.insert_finding("clean title", Gori::Store::Severity::Low,

--- a/spec/fuzz_spec.cr
+++ b/spec/fuzz_spec.cr
@@ -184,6 +184,13 @@ describe F::PayloadSet do
     upper.should eq(["X-AB"])
   end
 
+  it "stops at an Int64::MAX boundary without overflowing the run" do
+    vals = [] of String
+    # to == Int64::MAX: the terminal `@cur + @step` used to overflow → OverflowError aborts.
+    F::PayloadSet.new(F::NumberRange.new(Int64::MAX - 2, Int64::MAX, step: 1_i64)).each { |v| vals << v }
+    vals.should eq([(Int64::MAX - 2).to_s, (Int64::MAX - 1).to_s, Int64::MAX.to_s])
+  end
+
   it "counts brute-force size and enumerates the odometer" do
     bf = F::BruteForce.new("12", 1, 2)
     bf.size.should eq(6) # 2 + 4

--- a/spec/proxy/codec/body_spec.cr
+++ b/spec/proxy/codec/body_spec.cr
@@ -114,6 +114,13 @@ describe Gori::Proxy::Codec::Body do
       expect_raises(Gori::Error) { Body.request_framing(req) }
     end
 
+    it "rejects a Content-Length with a leading + sign (CL desync)" do
+      # RFC 7230 §3.3.3: Content-Length is 1*DIGIT. `+5` must be rejected (not framed as 5)
+      # — a stricter downstream peer would interpret it differently, a smuggling primitive.
+      req = Http1.parse_request_head("POST / HTTP/1.1\r\nContent-Length: +5\r\n\r\n".to_slice)
+      expect_raises(Gori::Error) { Body.request_framing(req) }
+    end
+
     it "rejects Transfer-Encoding + Content-Length coexistence (CL.TE/TE.CL smuggling)" do
       req = Http1.parse_request_head("POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\nContent-Length: 5\r\n\r\n".to_slice)
       expect_raises(Gori::Error) { Body.request_framing(req) }
@@ -133,6 +140,17 @@ describe Gori::Proxy::Codec::Body do
   describe ".stream" do
     it "aborts a chunked body on a malformed chunk size (no fabricated terminator → desync)" do
       src = IO::Memory.new("zz\r\ndata") # "zz" is not valid hex
+      dst = IO::Memory.new
+      Body.stream(src, dst, BodyFraming::Chunked, 0_i64, IO::Memory.new).should be_false
+    end
+
+    it "aborts a chunked body whose size line overruns the cap without an LF (desync)" do
+      # A chunk-size line of >MAX_LINE_BYTES hex digits and no terminating LF: read_crlf_line
+      # caps at 64 KiB and used to hand the partial to parse_chunk_size, which read an all-'0'
+      # prefix as a 0-length terminating chunk — completing the body while the line remainder
+      # stayed on the wire to misframe the next keep-alive message. An unterminated size line
+      # must abort (→ close) instead.
+      src = IO::Memory.new("#{"0" * (65 * 1024)}\r\n\r\nNEXT")
       dst = IO::Memory.new
       Body.stream(src, dst, BodyFraming::Chunked, 0_i64, IO::Memory.new).should be_false
     end
@@ -180,7 +198,7 @@ describe Gori::Proxy::Codec::Body do
       src = IO::Memory.new(wire)
       dst = IO::Memory.new
       Body.stream(src, dst, BodyFraming::Chunked, 0_i64, IO::Memory.new).should be_true
-      dst.to_s.should eq("0\r\nA\n\r\n")  # forwarded through the genuine blank line
+      dst.to_s.should eq("0\r\nA\n\r\n") # forwarded through the genuine blank line
       src.gets_to_end.should eq("NEXT")  # next message starts clean — no orphaned CRLF
     end
 

--- a/spec/ql_spec.cr
+++ b/spec/ql_spec.cr
@@ -152,6 +152,15 @@ describe Gori::QL do
     f.sql.should eq("(0)")
     f.args.should be_empty
   end
+
+  it "free-texts a ~ token on a non-regex field instead of never-matching" do
+    # `foo` is not a regex field, so `~` is not a regex operator here: the whole token
+    # must fall back to a free-text LIKE search, NOT compile to the never-match clause
+    # (the validity guard only applies to real regex fields).
+    f = Gori::QL.parse("foo~[")
+    f.sql.should eq("((lower(method) LIKE ? OR lower(host) LIKE ? OR lower(target) LIKE ?))")
+    f.args.should eq(["%foo~[%", "%foo~[%", "%foo~[%"])
+  end
 end
 
 describe "Gori::Store#search (QL)" do

--- a/spec/replay/flow_request_spec.cr
+++ b/spec/replay/flow_request_spec.cr
@@ -1,0 +1,29 @@
+require "../spec_helper"
+
+describe Gori::Replay::FlowRequest do
+  describe ".build_target / .parse_target" do
+    it "omits the default port and round-trips a normal host" do
+      t = Gori::Replay::FlowRequest.build_target("https", "api.test", 443)
+      t.should eq("https://api.test")
+      Gori::Replay::FlowRequest.parse_target(t).should eq({"https", "api.test", 443})
+    end
+
+    it "keeps a non-default port" do
+      t = Gori::Replay::FlowRequest.build_target("http", "api.test", 8080)
+      t.should eq("http://api.test:8080")
+      Gori::Replay::FlowRequest.parse_target(t).should eq({"http", "api.test", 8080})
+    end
+
+    it "brackets an IPv6 literal host so it round-trips (was dropped to host=\"\")" do
+      t = Gori::Replay::FlowRequest.build_target("http", "::1", 80)
+      t.should eq("http://[::1]")
+      Gori::Replay::FlowRequest.parse_target(t).should eq({"http", "::1", 80})
+    end
+
+    it "brackets an IPv6 literal host with a non-default port" do
+      t = Gori::Replay::FlowRequest.build_target("https", "2001:db8::1", 8443)
+      t.should eq("https://[2001:db8::1]:8443")
+      Gori::Replay::FlowRequest.parse_target(t).should eq({"https", "2001:db8::1", 8443})
+    end
+  end
+end

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -30,6 +30,15 @@ describe Gori::Settings do
     ensure
       Gori::Settings.upstream_proxy = ""
     end
+
+    it "parses a bracketed IPv6 literal, with and without a port" do
+      Gori::Settings.upstream_proxy = "[::1]"
+      Gori::Settings.upstream_proxy_addr.should eq({"::1", 8080})
+      Gori::Settings.upstream_proxy = "[2001:db8::1]:3128"
+      Gori::Settings.upstream_proxy_addr.should eq({"2001:db8::1", 3128})
+    ensure
+      Gori::Settings.upstream_proxy = ""
+    end
   end
 
   it "persists and reloads the network settings as JSON" do

--- a/spec/tui/text_area_spec.cr
+++ b/spec/tui/text_area_spec.cr
@@ -1,0 +1,40 @@
+require "../spec_helper"
+
+include Gori::Tui
+
+describe Gori::Tui::TextArea do
+  describe "#home / #end_of_line" do
+    it "jumps the caret to the start / end of the current line (insert lands there)" do
+      ta = TextArea.new("abc")
+      ta.end_of_line
+      ta.insert('X') # appended at end
+      ta.home
+      ta.insert('Y') # prepended at start
+      ta.text.should eq("YabcX")
+    end
+  end
+
+  describe "#delete" do
+    it "removes the char under the caret" do
+      ta = TextArea.new("abc") # caret at column 0 after construction
+      ta.delete
+      ta.text.should eq("bc")
+    end
+
+    it "joins the next line when the caret is at end-of-line" do
+      ta = TextArea.new("ab\ncd")
+      ta.end_of_line # caret at end of line 0
+      ta.delete      # forward-delete across the line break
+      ta.text.should eq("abcd")
+    end
+
+    it "is a no-op at the very end of the buffer (does not dirty)" do
+      ta = TextArea.new("ab")
+      ta.end_of_line
+      before = ta.edits
+      ta.delete
+      ta.text.should eq("ab")
+      ta.edits.should eq(before)
+    end
+  end
+end

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -277,11 +277,19 @@ module Gori
     # Resolves which project DB `gori mcp` serves: explicit --db wins, then a named
     # --project, then the most-recently-used project, then the default headless db.
     private def self.resolve_mcp_db(db : String?, project : String?) : String
-      return db if db && !db.empty? # an empty --db= falls through to project/MRU (Crystal: "" is truthy)
+      if d = db
+        unless d.empty? # an empty --db= falls through to project/MRU (Crystal: "" is truthy)
+          # Validate like `gori run` does — else SQLite silently CREATEs a fresh empty DB on a
+          # typo'd path and the client queries an empty dataset believing it's the real capture.
+          abort "gori mcp: --db is not a readable file: #{d}" unless File.file?(d)
+          return d
+        end
+      end
       Paths.ensure_dirs
       registry = ProjectRegistry.new(Paths.projects_dir)
       if name = project
-        proj = registry.list.find { |p| p.name == name }
+        # Case-insensitive, matching `gori run` (project slugs are always lowercased).
+        proj = registry.list.find { |p| p.name.downcase == name.downcase }
         abort "gori mcp: no such project: #{name}" unless proj
         return proj.db_path
       end

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -121,19 +121,25 @@ module Gori
         query : String? = nil
         limit = 50
         format = :text
+        positional = [] of String
 
         parser = OptionParser.new do |p|
-          p.banner = "Usage: gori run history [options]   (alias: ls)"
+          p.banner = "Usage: gori run history [QL query] [options]   (alias: ls)"
           p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("-qQL", "--query=QL", "Filter with a QL query (host: status:>=500 size:>10000 dur:>500 header: body~rx …)") { |v| query = v }
           p.on("-nN", "--limit=N", "Max rows, newest first (default 50)") { |v| limit = parse_count(v) }
           p.on("--format=FMT", "Output: text (default) | json (JSON-Lines)") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| positional = rest }
           p.invalid_option { |f| abort "gori run history: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run history: missing value for #{f}" }
         end
         parser.parse(args)
+        # Accept a positional QL too ("gori run history status:404"), mirroring the TUI's `/`
+        # bar — otherwise a positional query was silently dropped and EVERY flow dumped.
+        # An explicit --query wins. Multiple terms join with spaces (QL ANDs them).
+        query ||= positional.join(' ') unless positional.empty?
 
         store = open_store(resolve_read_project(project_name, db_path))
         begin
@@ -390,6 +396,13 @@ module Gori
           store.close
         end
         abort "gori run replay: no flow ##{id}" unless detail
+
+        # The captured request body was capped at 8 MiB; FlowRequest.build re-syncs the
+        # Content-Length to the stored bytes so the request stays well-formed, but warn that
+        # the resent body differs from what the origin originally received.
+        if detail.request_body_truncated?
+          STDERR.puts "gori run replay: request body was truncated at the 8 MiB capture cap — resending the stored (shorter) body with a corrected Content-Length"
+        end
 
         built = Replay::FlowRequest.build(detail)
         override = target_override # copy the closured flag into a plain local so || narrows

--- a/src/gori/findings_export.cr
+++ b/src/gori/findings_export.cr
@@ -83,10 +83,12 @@ module Gori
           c << String.new(hslice).scrub.rstrip
           c << "\n\n[… headers truncated, #{head.size} bytes total …]" if head.size > cap
           if body && !body.empty?
-            slice = body[0, {body.size, cap}.min]
-            text = String.new(slice)
-            if text.valid_encoding?
-              c << "\n\n" << text
+            # Decide text-vs-binary on the WHOLE body, not the truncated slice: cutting at
+            # `cap` bytes can split a UTF-8 codepoint, making the slice invalid even for a
+            # valid-UTF-8 body — which previously dropped it as "[binary body omitted]".
+            if String.new(body).valid_encoding?
+              slice = body[0, {body.size, cap}.min]
+              c << "\n\n" << String.new(slice).scrub # scrub the partial codepoint at the cut
               c << "\n\n[… body truncated, #{body.size} bytes total …]" if body.size > cap
             else
               c << "\n\n[binary body omitted, #{body.size} bytes]"

--- a/src/gori/findings_export.cr
+++ b/src/gori/findings_export.cr
@@ -83,12 +83,13 @@ module Gori
           c << String.new(hslice).scrub.rstrip
           c << "\n\n[… headers truncated, #{head.size} bytes total …]" if head.size > cap
           if body && !body.empty?
-            # Decide text-vs-binary on the WHOLE body, not the truncated slice: cutting at
-            # `cap` bytes can split a UTF-8 codepoint, making the slice invalid even for a
-            # valid-UTF-8 body — which previously dropped it as "[binary body omitted]".
-            if String.new(body).valid_encoding?
-              slice = body[0, {body.size, cap}.min]
-              c << "\n\n" << String.new(slice).scrub # scrub the partial codepoint at the cut
+            # Decide text-vs-binary on the readable PREFIX (≤ cap), not the whole body: a body
+            # that is valid text up to the cap but has a stray byte deeper still shows its
+            # readable prefix. But back the cut off to a UTF-8 codepoint boundary first, so a
+            # multi-byte char split at exactly `cap` isn't misread as binary.
+            slice = body.size > cap ? trim_to_codepoint_boundary(body[0, cap]) : body
+            if String.new(slice).valid_encoding?
+              c << "\n\n" << String.new(slice)
               c << "\n\n[… body truncated, #{body.size} bytes total …]" if body.size > cap
             else
               c << "\n\n[binary body omitted, #{body.size} bytes]"
@@ -98,6 +99,18 @@ module Gori
         fence = "`" * fence_len(content)
         io << "\n### " << label << "\n\n" << fence << "http\n"
         io << content << "\n" << fence << "\n"
+      end
+
+      # Drop a UTF-8 sequence the `cap` cut left incomplete: walk back over trailing
+      # continuation bytes (10xxxxxx), then over the lead byte (11xxxxxx) they belonged to.
+      # Leaves the slice ending on a whole codepoint so a split char isn't read as binary.
+      private def self.trim_to_codepoint_boundary(slice : Bytes) : Bytes
+        n = slice.size
+        while n > 0 && (slice[n - 1] & 0xC0) == 0x80 # continuation byte
+          n -= 1
+        end
+        n -= 1 if n > 0 && (slice[n - 1] & 0xC0) == 0xC0 # the lead byte whose tail was cut
+        slice[0, n]
       end
 
       # A CommonMark fenced block is closed only by a line of >= as many backticks

--- a/src/gori/findings_query.cr
+++ b/src/gori/findings_query.cr
@@ -84,7 +84,8 @@ module Gori
       private def match_term(t : Term, f : Store::Finding) : Bool
         # An empty value (mid-type "status:" / "sev:>=") matches all, so the list
         # doesn't blank out until a value is typed — uniform across every field
-        # kind (host:/title: already do this via includes?("")).
+        # kind (host:/title: already do this via includes?("")). Negation is honoured:
+        # `status:` matches all, so its negation `-status:` matches none (spec-pinned).
         return !t.negate if t.text.empty?
         hit = case t.kind
               when :severity then match_severity(t, f.severity)

--- a/src/gori/fuzz/engine.cr
+++ b/src/gori/fuzz/engine.cr
@@ -263,11 +263,14 @@ module Gori::Fuzz
     end
 
     private def pace(interval : Time::Span?) : Nil
-      return unless interval
-      now = Time.instant
-      target = @last_dispatch + interval
-      sleep(target - now) if now < target
-      @last_dispatch = Time.instant
+      if interval
+        now = Time.instant
+        target = @last_dispatch + interval
+        sleep(target - now) if now < target
+        @last_dispatch = Time.instant
+      end
+      # Jitter applies on its own — don't gate it behind a base rate, which silently
+      # dropped jitter unless rps/throttle was also set.
       sleep(rand(@config.jitter_ms).milliseconds) if @config.jitter_ms > 0
     end
 

--- a/src/gori/fuzz/payload.cr
+++ b/src/gori/fuzz/payload.cr
@@ -126,13 +126,23 @@ module Gori::Fuzz
     end
 
     private class NumberIterator < SetIterator
+      @done = false
+
       def initialize(@cur : Int64, @to : Int64, @step : Int64, @base : Symbol, @pad : Int32)
       end
 
       def next_value : String?
+        return nil if @done
         return nil if (@step > 0 && @cur > @to) || (@step < 0 && @cur < @to)
         v = format(@cur)
-        @cur += @step
+        # A range ending at Int64::MAX/MIN would overflow on `@cur + @step` and abort the
+        # run. Use a wrapping add and detect the wrap (sum moved the wrong way) → stop.
+        nxt = @cur &+ @step
+        if (@step > 0 && nxt < @cur) || (@step < 0 && nxt > @cur)
+          @done = true
+        else
+          @cur = nxt
+        end
         v
       end
 

--- a/src/gori/hotkeys.cr
+++ b/src/gori/hotkeys.cr
@@ -35,7 +35,12 @@ module Gori
     # Build the dispatch keymap from the registry under the persisted OS profile + user
     # overrides. Replaces the bare Verb::Keymap.build at its call sites.
     def self.build_keymap(registry : Verb::Registry) : Verb::Keymap
-      Verb::Keymap.build(registry, Verb::OsProfile.resolve(Settings.keymap_os), chord_overrides)
+      # Drop overrides for verbs the editor would never let you rebind (hidden nav
+      # primitives, fixed ids, multi-chord nav-alias verbs) — a hand-edited settings.json
+      # could otherwise install one and collapse a verb's structural chords (e.g. enter/
+      # arrows on body.open), the exact case the editor's rebindable? gate prevents.
+      overrides = chord_overrides.select { |id, _| (v = registry[id]?) && rebindable?(v) }
+      Verb::Keymap.build(registry, Verb::OsProfile.resolve(Settings.keymap_os), overrides)
     end
 
     # The persisted user overrides, parsed from Settings' label strings into Chords. A

--- a/src/gori/proxy/codec/body.cr
+++ b/src/gori/proxy/codec/body.cr
@@ -166,7 +166,16 @@ module Gori::Proxy::Codec
       # delimited, as before).
       tokens = values.flat_map(&.split(',')).map(&.strip).reject(&.empty?)
       return nil if tokens.empty?
-      nums = tokens.map { |t| t.to_i64? || raise Gori::Error.new("invalid Content-Length #{t.inspect}") }
+      # RFC 7230 §3.3.3: Content-Length is 1*DIGIT. `to_i64?` alone would accept a leading
+      # '+' (the `n < 0` guard below only rejects '-'), so `Content-Length: +5` would frame
+      # a 5-byte body that a stricter peer rejects/reinterprets — a CL desync primitive.
+      # Mirror parse_chunk_size's pure-digit guard and reject any non-digit token.
+      nums = tokens.map do |t|
+        unless t.each_char.all?(&.ascii_number?)
+          raise Gori::Error.new("invalid Content-Length #{t.inspect}")
+        end
+        t.to_i64? || raise Gori::Error.new("invalid Content-Length #{t.inspect}")
+      end
       raise Gori::Error.new("conflicting Content-Length values") if nums.uniq.size > 1
       n = nums.first
       raise Gori::Error.new("negative Content-Length #{n}") if n < 0
@@ -204,7 +213,12 @@ module Gori::Proxy::Codec
     private def self.copy_chunked(src : IO, dst : IO, tee : IO) : Bool
       loop do
         size_line = read_crlf_line(src)
-        return false if size_line.nil? # EOF mid-stream — truncated
+        # EOF before any byte → truncated mid-stream. A line that hit MAX_LINE_BYTES WITHOUT an
+        # LF is also unterminated: parse_chunk_size could still read a valid-looking size from the
+        # partial (all-'0' → 0 terminating chunk; '5;<oversized ext>' → 5), leaving the rest of the
+        # line on the wire to desync the next message. A real chunk-size line always ends in LF.
+        return false if size_line.nil?
+        return false unless size_line[size_line.size - 1] == 0x0a_u8
         emit(dst, tee, size_line)
         size = parse_chunk_size(size_line)
         # A malformed / out-of-range chunk size is NOT a terminating chunk: bailing
@@ -219,7 +233,12 @@ module Gori::Proxy::Codec
           trailer_total = 0_i64
           loop do
             trailer = read_crlf_line(src)
-            break if trailer.nil? # clean EOF after the 0-chunk — tolerate (as before)
+            # Clean EOF after the 0-chunk → tolerate (as before). But an unterminated (LF-less,
+            # cap-truncated) trailer line is a framing error: forwarding it and keeping the
+            # connection alive would leak the line remainder onto the wire to misframe the next
+            # message — abort and close instead.
+            break if trailer.nil?
+            return false unless trailer[trailer.size - 1] == 0x0a_u8
             emit(dst, tee, trailer)
             trailer_total += trailer.size
             return false if trailer_total > MAX_TRAILER_BYTES

--- a/src/gori/proxy/codec/body.cr
+++ b/src/gori/proxy/codec/body.cr
@@ -54,6 +54,18 @@ module Gori::Proxy::Codec
     end
   end
 
+  # A write-only sink that discards everything (no buffering). Used as `Body.stream`'s
+  # `tee` when the caller only needs the `dst` copy (e.g. `read_complete`), so the body
+  # isn't accumulated a second time.
+  class DiscardIO < IO
+    def write(slice : Bytes) : Nil
+    end
+
+    def read(slice : Bytes) : Int32
+      raise NotImplementedError.new("DiscardIO is write-only")
+    end
+  end
+
   module Body
     BUFSIZE = 64 * 1024
 
@@ -128,7 +140,10 @@ module Gori::Proxy::Codec
     def self.read_complete(src : IO, framing : BodyFraming, length : Int64) : {Bytes?, Bool}
       return {nil, true} if framing.none?
       capture = IO::Memory.new
-      complete = stream(src, capture, framing, length, IO::Memory.new) # tee discarded
+      # The body is already buffered once in `capture`; tee into a discard sink rather than
+      # a second IO::Memory so a large response isn't held in memory TWICE (the old
+      # `IO::Memory.new` tee doubled peak RAM on every replay/read_complete).
+      complete = stream(src, capture, framing, length, DiscardIO.new)
       {capture.to_slice.dup, complete}
     end
 

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -125,7 +125,9 @@ module Gori::Proxy
       end
 
       # Non-hold path: stream the request body byte-for-byte (P6), unchanged.
-      retryable = retryable_request?(req, req_framing.none?)
+      # Replay-safety keys on the ACTUALLY-SENT method (sent_req): an M&R rule that rewrites
+      # the request line GET→POST must not leave a non-idempotent request marked retryable.
+      retryable = retryable_request?(sent_req, req_framing.none?)
       req_capture = Codec::CaptureBuffer.new(Codec::Body::CAPTURE_MAX)
       req_complete = true
       upstream, reused, sent = acquire_and_send(host, port, retryable) do |up|
@@ -159,7 +161,14 @@ module Gori::Proxy
                                     host : String, port : Int32, scheme : String,
                                     created_at : Int64, started : Time::Instant,
                                     req_framing : Codec::BodyFraming, req_len : Int64) : Bool
-      buffered = Codec::Body.read(@io, req_framing, req_len)
+      buffered, body_complete = Codec::Body.read_complete(@io, req_framing, req_len)
+      unless body_complete
+        # The client cut its request body short — there's nothing whole to hold/forward, and
+        # forwarding a short body under the original Content-Length would desync the upstream
+        # (mirrors the non-hold path's req_complete guard). Record + close instead of holding.
+        record_error(sent_req, scheme, host, port, created_at, "client truncated request body")
+        return false
+      end
       decision = ic.hold_request(build_message(sent_head, buffered),
         method: sent_req.method, target: sent_req.target,
         host: host, port: port, scheme: scheme)
@@ -174,7 +183,10 @@ module Gori::Proxy
       # the human chose to send (e.g. a deliberately CL-mismatched smuggling probe).
       sent_head, edited_body = split_message(decision.bytes)
       sent_req = Codec::Http1.parse_request_head(sent_head)
-      retryable = retryable_request?(req, edited_body.nil? || edited_body.empty?)
+      # Key replay-safety on the EDITED request: if the human changed the method (e.g.
+      # GET→POST), retryability must follow the method actually being sent, not the
+      # original — else a now-non-idempotent request could be replayed on a stale-conn retry.
+      retryable = retryable_request?(sent_req, edited_body.nil? || edited_body.empty?)
       upstream, reused, sent = acquire_and_send(host, port, retryable) { |up| write_request(up, sent_head, edited_body) }
       unless upstream && sent
         release_upstream
@@ -382,7 +394,9 @@ module Gori::Proxy
       # truncated/misframed body must NOT leave the upstream parked — its stray
       # unread bytes would become the next reused request's response (desync).
       buf = IO::Memory.new
-      resp_complete = Codec::Body.stream(upstream, buf, resp_framing, resp_len, IO::Memory.new)
+      # tee into a discard sink, not a second IO::Memory — the body is already buffered in
+      # `buf`; a throwaway IO::Memory would hold the whole response a second time.
+      resp_complete = Codec::Body.stream(upstream, buf, resp_framing, resp_len, Codec::DiscardIO.new)
       body = resp_framing.none? ? nil : buf.to_slice.dup
       decision = ic.hold_response(build_message(sent_resp_head, body),
         flow_id: flow_id, method: req.method, target: "#{resp.status} #{resp.reason}",
@@ -411,6 +425,10 @@ module Gori::Proxy
       # Reuse the upstream iff we read the WHOLE body cleanly AND the origin kept
       # its side alive. The CLIENT keep-alive (return value) uses the edited resp.
       update_upstream_reuse(resp_complete && origin_keep_alive?(req, resp, resp_framing))
+      # A truncated upstream body was forwarded short — close the client connection so it
+      # sees end-of-response instead of blocking for the missing bytes while we read its
+      # next keep-alive request (mirrors the non-held path's resp_complete guard).
+      return false unless resp_complete
       keep_alive?(req, sent_resp, Codec::Body.response_framing(sent_resp, req.method)[0])
     end
 

--- a/src/gori/proxy/upstream.cr
+++ b/src/gori/proxy/upstream.cr
@@ -59,7 +59,10 @@ module Gori::Proxy
                                     io_timeout : Time::Span = IO_TIMEOUT) : TCPSocket?
       sock = direct_dial(proxy_host, proxy_port, connect_timeout, io_timeout)
       return nil unless sock
-      sock << "CONNECT #{host}:#{port} HTTP/1.1\r\nHost: #{host}:#{port}\r\n\r\n"
+      # An IPv6 literal host must be bracketed in the CONNECT request-target / Host header
+      # ("CONNECT [::1]:443"), else the upstream proxy sees a malformed authority.
+      authority = host.includes?(':') && !host.starts_with?('[') ? "[#{host}]:#{port}" : "#{host}:#{port}"
+      sock << "CONNECT #{authority} HTTP/1.1\r\nHost: #{authority}\r\n\r\n"
       sock.flush
       return sock if connect_established?(sock)
       sock.close rescue nil

--- a/src/gori/ql.cr
+++ b/src/gori/ql.cr
@@ -221,15 +221,25 @@ module Gori
     # REGEXP callback, so we validate up front and emit a never-matches clause instead
     # (like flag:). For case-insensitive matching use an inline (?i) flag.
     private def self.regex_cond(field : String, value : String, term : String) : {String, Array(DB::Any)}?
-      return nil if value.empty?
-      return {"0", [] of DB::Any} unless valid_regex?(value)
+      # A non-regex field name means `~` wasn't a regex operator here (e.g. `foo~bar`):
+      # fall back to a literal free-text search of the WHOLE token. This must happen BEFORE
+      # the validity guard — otherwise `foo~[` (an unterminated char class) would compile to
+      # the never-match clause instead of free-texting "foo~[".
       case field
-      when "host"   then {"host REGEXP ?", [value] of DB::Any}
-      when "path"   then {"target REGEXP ?", [value] of DB::Any}
-      when "url"    then {"(scheme || '://' || host || target) REGEXP ?", [value] of DB::Any}
-      when "header" then header_regex_cond(value)
-      when "body"   then body_regex_cond(value)
-      else               free_text(term)
+      when "host", "path", "url", "header", "body"
+        return nil if value.empty?
+        # An invalid pattern would raise inside the SQLite REGEXP callback, so validate up
+        # front and emit a never-matches clause instead (like flag:).
+        return {"0", [] of DB::Any} unless valid_regex?(value)
+        case field
+        when "host"   then {"host REGEXP ?", [value] of DB::Any}
+        when "path"   then {"target REGEXP ?", [value] of DB::Any}
+        when "url"    then {"(scheme || '://' || host || target) REGEXP ?", [value] of DB::Any}
+        when "header" then header_regex_cond(value)
+        else               body_regex_cond(value)
+        end
+      else
+        free_text(term)
       end
     end
 

--- a/src/gori/replay/flow_request.cr
+++ b/src/gori/replay/flow_request.cr
@@ -18,11 +18,34 @@ module Gori
 
       def self.build(detail : Store::FlowDetail) : Built
         row = detail.row
+        head = detail.request_head
+        body = detail.request_body
+        # The captured body is capped at CAPTURE_MAX (8 MiB). If it was truncated, the head's
+        # Content-Length over-promises and a faithful h1 replay BLOCKS the origin waiting for
+        # bytes that no longer exist. Byte-exactness is already lost at capture, so rewrite CL
+        # to the actual (truncated) length we will send so the replay completes.
+        head = rewrite_content_length(head, body.try(&.size) || 0) if detail.request_body_truncated?
         Built.new(
           target: build_target(row.scheme, row.host, row.port),
-          bytes: origin_form_bytes(detail.request_head, detail.request_body),
+          bytes: origin_form_bytes(head, body),
           http2: detail.http_version == "HTTP/2",
         )
+      end
+
+      # Replace the Content-Length header value in an HTTP/1 head — used ONLY when the
+      # captured body was truncated (so the CL no longer matches what we can resend).
+      # Case-insensitive header-name match; preserves each line's CRLF/LF terminator.
+      private def self.rewrite_content_length(head : Bytes, length : Int32) : Bytes
+        String.build do |io|
+          String.new(head).each_line(chomp: false) do |line|
+            if line.lstrip[0, 15]?.try(&.downcase) == "content-length:"
+              eol = line.ends_with?("\r\n") ? "\r\n" : (line.ends_with?('\n') ? "\n" : "")
+              io << "Content-Length: " << length << eol
+            else
+              io << line
+            end
+          end
+        end.to_slice
       end
 
       # "scheme://host[:port]", omitting the port when it's the scheme default —

--- a/src/gori/replay/flow_request.cr
+++ b/src/gori/replay/flow_request.cr
@@ -20,11 +20,12 @@ module Gori
         row = detail.row
         head = detail.request_head
         body = detail.request_body
-        # The captured body is capped at CAPTURE_MAX (8 MiB). If it was truncated, the head's
-        # Content-Length over-promises and a faithful h1 replay BLOCKS the origin waiting for
-        # bytes that no longer exist. Byte-exactness is already lost at capture, so rewrite CL
-        # to the actual (truncated) length we will send so the replay completes.
-        head = rewrite_content_length(head, body.try(&.size) || 0) if detail.request_body_truncated?
+        # The captured body is capped at CAPTURE_MAX (8 MiB). If it was truncated, a faithful
+        # h1 replay would BLOCK the origin waiting for bytes that no longer exist (a
+        # Content-Length over-promising, or a chunked stream cut before its 0-chunk). Byte-
+        # exactness is already lost at the cap, so re-frame the head to a fixed Content-Length
+        # over the bytes we actually send, so the replay terminates instead of hanging.
+        head = resync_truncated_head(head, body.try(&.size) || 0) if detail.request_body_truncated?
         Built.new(
           target: build_target(row.scheme, row.host, row.port),
           bytes: origin_form_bytes(head, body),
@@ -32,15 +33,19 @@ module Gori
         )
       end
 
-      # Replace the Content-Length header value in an HTTP/1 head — used ONLY when the
-      # captured body was truncated (so the CL no longer matches what we can resend).
-      # Case-insensitive header-name match; preserves each line's CRLF/LF terminator.
-      private def self.rewrite_content_length(head : Bytes, length : Int32) : Bytes
+      # Make a TRUNCATED request self-framed so the replay can't hang. Used ONLY when the
+      # captured body was capped. Rewrites an existing Content-Length to the stored byte
+      # count, OR replaces a Transfer-Encoding (chunked — whose stored wire-form bytes were
+      # cut mid-stream) with a Content-Length over those bytes so the origin reads a complete
+      # body. Case-insensitive header-name match; preserves each line's CRLF/LF terminator.
+      private def self.resync_truncated_head(head : Bytes, length : Int32) : Bytes
         String.build do |io|
           String.new(head).each_line(chomp: false) do |line|
-            if line.lstrip[0, 15]?.try(&.downcase) == "content-length:"
-              eol = line.ends_with?("\r\n") ? "\r\n" : (line.ends_with?('\n') ? "\n" : "")
-              io << "Content-Length: " << length << eol
+            lname = line.lstrip
+            eol = line.ends_with?("\r\n") ? "\r\n" : (line.ends_with?('\n') ? "\n" : "")
+            if lname[0, 15]?.try(&.downcase) == "content-length:" ||
+               lname[0, 18]?.try(&.downcase) == "transfer-encoding:"
+              io << "Content-Length: " << length << eol # RFC 7230 forbids TE+CL, so only one fires
             else
               io << line
             end

--- a/src/gori/replay/flow_request.cr
+++ b/src/gori/replay/flow_request.cr
@@ -29,7 +29,10 @@ module Gori
       # matches ReplayView#build_target so the parsed {scheme,host,port} round-trips.
       def self.build_target(scheme : String, host : String, port : Int32) : String
         default = scheme == "https" ? 443 : 80
-        port == default ? "#{scheme}://#{host}" : "#{scheme}://#{host}:#{port}"
+        # An IPv6 literal host (contains ':') must be bracketed in a URL, else both the
+        # `:port` suffix below and URI.parse in parse_target split it wrong (host → "").
+        h = host.includes?(':') && !host.starts_with?('[') ? "[#{host}]" : host
+        port == default ? "#{scheme}://#{h}" : "#{scheme}://#{h}:#{port}"
       end
 
       # {scheme, host, port} parsed back out of a target string (the inverse of
@@ -39,11 +42,17 @@ module Gori
         raw = "http://#{raw}" unless raw.includes?("://")
         uri = URI.parse(raw)
         scheme = uri.scheme || "http"
-        host = uri.host || ""
+        host = strip_ipv6_brackets(uri.host || "")
         port = uri.port || (scheme == "https" ? 443 : 80)
         {scheme, host, port}
       rescue
         {"http", "", 0}
+      end
+
+      # URI.parse keeps the [] around an IPv6 literal host; strip them so the bare address
+      # is what we dial/round-trip (TCPSocket wants "::1", not "[::1]").
+      private def self.strip_ipv6_brackets(host : String) : String
+        host.starts_with?('[') && host.ends_with?(']') ? host[1..-2] : host
       end
 
       # Rewrite the request-line to origin-form when it's absolute-form, keeping the

--- a/src/gori/replay/h2_engine.cr
+++ b/src/gori/replay/h2_engine.cr
@@ -75,7 +75,12 @@ module Gori
 
       private def self.write_request(io : IO, headers : Array({String, String}), body : Bytes?) : Nil
         io.write(Frame::PREFACE)
-        io.write(Frame::Header.new(Frame::Type::Settings.value, 0_u8, 0_u32, Bytes.empty).to_bytes)
+        # SETTINGS_ENABLE_PUSH=0 (id 0x2): a one-shot replay never wants server push, and
+        # pushed DATA on a non-1 stream would consume the connection flow-control window
+        # without being credited back (the DATA loop only credits stream 1), stalling a
+        # large response. Disabling push at the source avoids the whole class.
+        no_push = Bytes[0x00_u8, 0x02_u8, 0x00_u8, 0x00_u8, 0x00_u8, 0x00_u8]
+        io.write(Frame::Header.new(Frame::Type::Settings.value, 0_u8, 0_u32, no_push).to_bytes)
         block = HPACK::Encoder.new.encode(headers)
         end_stream = body.nil? || body.empty?
         flags = Frame::END_HEADERS | (end_stream ? Frame::END_STREAM : 0_u8)
@@ -146,6 +151,7 @@ module Gori
             if frame.end_headers?
               status = absorb(header_buf, decoder, headers, status)
               done = clean_eos = true if end_stream_pending
+              headers.clear if !end_stream_pending && interim?(status)
             end
           when Frame::Type::Continuation
             next unless frame.stream_id == 1
@@ -154,6 +160,7 @@ module Gori
             if frame.end_headers?
               status = absorb(header_buf, decoder, headers, status)
               done = clean_eos = true if end_stream_pending
+              headers.clear if !end_stream_pending && interim?(status)
             end
           when Frame::Type::Data
             next unless frame.stream_id == 1
@@ -183,12 +190,24 @@ module Gori
         decoder.decode(buf.to_slice).each do |(name, value)|
           if name == ":status"
             status = value.to_i? || status
-          elsif !name.starts_with?(':')
+          elsif !name.starts_with?(':') && !forbidden_field?(name) && !forbidden_field?(value)
             headers << {name, value}
           end
         end
         buf.clear
         status
+      end
+
+      # An interim (informational) response: its header fields precede — and are not part
+      # of — the final response (RFC 9110 §15.2), so they're dropped, not merged.
+      private def self.interim?(status : Int32) : Bool
+        100 <= status < 200
+      end
+
+      # RFC 9113 §8.2.1 forbids CR/LF/NUL in h2 field names+values. A decoded value carrying
+      # one must not fold into a phantom line of the synthesized HTTP/1 head (header injection).
+      private def self.forbidden_field?(s : String) : Bool
+        s.includes?('\r') || s.includes?('\n') || s.includes?('\u0000')
       end
 
       private def self.ack(io : IO, type : Frame::Type, payload : Bytes) : Nil

--- a/src/gori/replay/h2_engine.cr
+++ b/src/gori/replay/h2_engine.cr
@@ -190,8 +190,8 @@ module Gori
         decoder.decode(buf.to_slice).each do |(name, value)|
           if name == ":status"
             status = value.to_i? || status
-          elsif !name.starts_with?(':') && !forbidden_field?(name) && !forbidden_field?(value)
-            headers << {name, value}
+          elsif !name.starts_with?(':')
+            headers << {visualize_field(name), visualize_field(value)}
           end
         end
         buf.clear
@@ -204,10 +204,14 @@ module Gori
         100 <= status < 200
       end
 
-      # RFC 9113 §8.2.1 forbids CR/LF/NUL in h2 field names+values. A decoded value carrying
-      # one must not fold into a phantom line of the synthesized HTTP/1 head (header injection).
-      private def self.forbidden_field?(s : String) : Bool
-        s.includes?('\r') || s.includes?('\n') || s.includes?('\u0000')
+      # RFC 9113 §8.2.1 forbids CR/LF in an h2 field name/value. If a non-compliant origin
+      # smuggles one in, ESCAPE it (don't drop the header) so it can't fold into a phantom
+      # line of the synthesized HTTP/1 head while STILL SHOWING the tester the injection
+      # attempt — a malformed response header is a security finding, not noise to hide. gori
+      # is a security-testing proxy: it must surface bad bytes, not silently swallow them.
+      private def self.visualize_field(s : String) : String
+        return s unless s.includes?('\r') || s.includes?('\n')
+        s.gsub('\r', "\\r").gsub('\n', "\\n")
       end
 
       private def self.ack(io : IO, type : Frame::Type, payload : Bytes) : Nil

--- a/src/gori/replay/ws_engine.cr
+++ b/src/gori/replay/ws_engine.cr
@@ -24,7 +24,8 @@ module Gori
       MAX_RECV_MESSAGES = 1000                # cap captured server messages (anti-flood)
       MAX_RECV_BYTES    = 8_i64 * 1024 * 1024 # cap total captured server payload bytes
       MAX_DRAIN_FRAMES  = 100_000             # hard ceiling on frames processed (ping/empty-fragment flood)
-      MAX_CONTROL_BYTES =     125             # RFC 6455 §5.5: control-frame payload limit (caps Pong echo)
+      DRAIN_DEADLINE    = 60.seconds          # wall-clock ceiling: a sub-idle ping/fragment cadence can't pin a tab for hours
+      MAX_CONTROL_BYTES = 125                 # RFC 6455 §5.5: control-frame payload limit (caps Pong echo)
 
       # An outbound message to replay (opcode 1=text, 2=binary).
       record OutMsg, opcode : Int32, payload : Bytes
@@ -111,10 +112,14 @@ module Gori
         recv_bytes = 0_i64
         recv_count = 0
         frames = 0
+        started = Time.instant
         loop do
           # Count EVERY frame, not just completed messages: an origin flooding pings or
           # empty/non-fin fragments faster than `idle` trips neither the data caps nor
           # the read timeout, so this frame ceiling is what guarantees termination.
+          # A wall-clock deadline also caps total drain time: a steady sub-idle ping cadence
+          # stays under MAX_DRAIN_FRAMES yet could otherwise pin the tab "inflight" for hours.
+          break if Time.instant - started > DRAIN_DEADLINE
           frame = begin
             Proxy::WS.read_frame(io)
           rescue IO::Error

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -219,9 +219,16 @@ module Gori
     # not crash the TUI); returns whether it succeeded.
     def self.save : Bool
       Paths.ensure_dirs
-      File.write(path, serialize)
+      # Atomic write: a torn File.write (crash / two instances / disk-full) would leave a
+      # half-written settings.json that load()'s blanket rescue silently resets to factory
+      # defaults — losing theme, hotkeys, hostname overrides, tab prefs, convert sessions.
+      # Stage to a sibling temp then rename (atomic on POSIX), mirroring cert_authority.
+      tmp = "#{path}.tmp"
+      File.write(tmp, serialize)
+      File.rename(tmp, path)
       true
     rescue
+      File.delete?("#{path}.tmp") rescue nil
       false
     end
 

--- a/src/gori/tui/controllers/convert_controller.cr
+++ b/src/gori/tui/controllers/convert_controller.cr
@@ -359,10 +359,21 @@ module Gori::Tui
         s.input.at_top? ? (commit; @host.request_focus(:menu)) : s.input.move(-1, 0)
       when key.down?
         s.input.at_bottom? ? (s.pane = :chain) : s.input.move(1, 0)
-      when key.left?
-        s.input.move(0, -1)
-      when key.right?
-        s.input.move(0, 1)
+      else
+        edit_input_caret(ev, s, c) # ←/→/Home/End/Delete + literal insert
+      end
+    end
+
+    # The within-line caret keys + literal insert for the INPUT editor (split out of
+    # edit_input so its ↑/↓ pane-transition logic stays under the complexity budget).
+    private def edit_input_caret(ev : Termisu::Event::Key, s, c : Char?) : Nil
+      key = ev.key
+      case
+      when key.left?   then s.input.move(0, -1)
+      when key.right?  then s.input.move(0, 1)
+      when key.home?   then s.input.home
+      when key.end?    then s.input.end_of_line
+      when key.delete? then s.input.delete; touch
       else
         if c && !ev.ctrl? && !ev.alt?
           s.input.insert(c)

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -229,6 +229,9 @@ module Gori::Tui
       when key.down?      then v.template_move(1, 0)
       when key.left?      then v.template_move(0, -1)
       when key.right?     then v.template_move(0, 1)
+      when key.home?      then v.template_home
+      when key.end?       then v.template_end
+      when key.delete?    then v.template_delete
       else
         printable(ev).try { |ch| v.template_insert(ch) }
       end

--- a/src/gori/tui/controllers/intercept_controller.cr
+++ b/src/gori/tui/controllers/intercept_controller.cr
@@ -86,6 +86,12 @@ module Gori::Tui
         @intercept.edit_move(0, -1)
       elsif key.right?
         @intercept.edit_move(0, 1)
+      elsif key.home?
+        @intercept.edit_home
+      elsif key.end?
+        @intercept.edit_end
+      elsif key.delete?
+        @intercept.edit_delete
       elsif c && !ev.ctrl? && !ev.alt?
         @intercept.edit_insert(c)
       end
@@ -96,18 +102,29 @@ module Gori::Tui
     # those are now Intercept-scope verbs so they're rebindable. The queue is a navigable
     # list (not a text field), so deferring unhandled keys is safe; the held-bytes editor
     # and condition bar keep swallowing `c`/`/` as literal text (separate handlers).
+    # ⇧F = "forward all". Most terminals deliver a typed capital as the char 'F' with NO
+    # shift modifier (only Kitty's protocol sets shift), so accept both (cf. Keybind's
+    # `c.ascii_uppercase?` normalisation) — else ⇧F is a dead key on a plain terminal.
+    private def forward_all_key?(ev : Termisu::Event::Key) : Bool
+      (ev.key.lower_f? && ev.shift?) || (ev.char || ev.key.to_char) == 'F'
+    end
+
     private def handle_queue_key(ev : Termisu::Event::Key) : Bool
       key = ev.key
+      # A modified chord (^F, alt+…) must NOT trigger a queue action — bare `key.lower_f?`
+      # matches Ctrl+F too, which would IRREVERSIBLY forward the selected held message.
+      # Defer modified chords to the central keymap (shift is kept for ⇧F forward-all).
+      return false if ev.ctrl? || ev.alt?
       case
-      when key.escape?               then @host.request_focus(:menu)
-      when key.lower_j?, key.down?   then @intercept.move(1)
-      when key.lower_k?, key.up?     then @intercept.at_top? ? @host.request_focus(:menu) : @intercept.move(-1)
-      when key.enter?, key.lower_e?  then @intercept.toggle_edit
-      when key.lower_f? && ev.shift? then intercept_forward_all
-      when key.lower_f?              then intercept_forward
-      when key.lower_d?              then intercept_drop
-      when key.lower_i?              then intercept_toggle
-      else                                return false
+      when key.escape?              then @host.request_focus(:menu)
+      when key.lower_j?, key.down?  then @intercept.move(1)
+      when key.lower_k?, key.up?    then @intercept.at_top? ? @host.request_focus(:menu) : @intercept.move(-1)
+      when key.enter?, key.lower_e? then @intercept.toggle_edit
+      when forward_all_key?(ev)     then intercept_forward_all
+      when key.lower_f?             then intercept_forward
+      when key.lower_d?             then intercept_drop
+      when key.lower_i?             then intercept_toggle
+      else                               return false
       end
       true
     end

--- a/src/gori/tui/controllers/notes_controller.cr
+++ b/src/gori/tui/controllers/notes_controller.cr
@@ -98,7 +98,10 @@ module Gori::Tui
     end
 
     def on_enter : Nil
-      reload
+      # NEVER reload over UNSAVED edits: reload replaces the buffer from disk and resets
+      # @dirty, so re-entering Notes after leaving via Tab/mouse (gestures that don't flush
+      # the editor) would silently discard the in-memory edits. Only refresh a clean buffer.
+      reload unless @notes.dirty?
     end
 
     def commit : Nil

--- a/src/gori/tui/controllers/notes_controller.cr
+++ b/src/gori/tui/controllers/notes_controller.cr
@@ -70,6 +70,12 @@ module Gori::Tui
         @notes.move(0, -1)
       elsif key.right?
         @notes.move(0, 1)
+      elsif key.home?
+        @notes.home
+      elsif key.end?
+        @notes.end_of_line
+      elsif key.delete?
+        @notes.delete
       else
         if c && !ev.ctrl? && !ev.alt?
           @notes.insert(c)

--- a/src/gori/tui/controllers/replay_controller.cr
+++ b/src/gori/tui/controllers/replay_controller.cr
@@ -592,6 +592,9 @@ module Gori::Tui
       when key.down?      then view.edit_move(1, 0)
       when key.left?      then view.edit_move(0, -1)
       when key.right?     then view.edit_move(0, 1)
+      when key.home?      then view.edit_home
+      when key.end?       then view.edit_end
+      when key.delete?    then view.edit_delete
       else
         if c && !ev.ctrl? && !ev.alt?
           view.edit_insert(c)
@@ -622,19 +625,11 @@ module Gori::Tui
     private def edit_replay_target(ev : Termisu::Event::Key, view : ReplayView) : Nil
       return edit_replay_sni(ev, view) if view.editing_sni? # ^S sub-field of the TARGET pane
       key = ev.key
-      c = ev.char || key.to_char
       case
-      when key.enter?     then view.pane_advance(1)                                       # ↵ confirms URL → Request (^R sends, not ↵)
-      when key.up?        then @host.request_focus(@replays.size >= 2 ? :subtabs : :menu) # target is the top pane → ↑ pops up
-      when key.down?      then view.pane_advance(1)                                        # ↓ → drop into the Request pane below
-      when key.backspace? then view.target_backspace
-      when key.left?      then view.target_move(-1)
-      when key.right?     then view.target_move(1)
-      else
-        if c && !ev.ctrl? && !ev.alt?
-          view.target_insert(c)
-          view.set_preedit("")
-        end
+      when key.enter? then view.pane_advance(1)                                       # ↵ confirms URL → Request (^R sends, not ↵)
+      when key.up?    then @host.request_focus(@replays.size >= 2 ? :subtabs : :menu) # target is the top pane → ↑ pops up
+      when key.down?  then view.pane_advance(1)                                        # ↓ → drop into the Request pane below
+      else                 edit_target_common(ev, view)
       end
     end
 
@@ -643,14 +638,26 @@ module Gori::Tui
     # advancing panes, and ↓ still drops into the Request pane below.
     private def edit_replay_sni(ev : Termisu::Event::Key, view : ReplayView) : Nil
       key = ev.key
-      c = ev.char || key.to_char
       case
       when key.enter?, key.up? then view.exit_sni_field
       when key.down?           then view.pane_advance(1)
-      when key.backspace?      then view.target_backspace
-      when key.left?           then view.target_move(-1)
-      when key.right?          then view.target_move(1)
+      else                          edit_target_common(ev, view)
+      end
+    end
+
+    # Shared single-line editing for the TARGET / SNI fields (both route through the view's
+    # target_* mutators): caret nav (←/→/Home/End), delete/backspace, and literal insert.
+    private def edit_target_common(ev : Termisu::Event::Key, view : ReplayView) : Nil
+      key = ev.key
+      case
+      when key.backspace? then view.target_backspace
+      when key.left?      then view.target_move(-1)
+      when key.right?     then view.target_move(1)
+      when key.home?      then view.target_home
+      when key.end?       then view.target_end
+      when key.delete?    then view.target_delete
       else
+        c = ev.char || key.to_char
         if c && !ev.ctrl? && !ev.alt?
           view.target_insert(c)
           view.set_preedit("")

--- a/src/gori/tui/controllers/sitemap_controller.cr
+++ b/src/gori/tui/controllers/sitemap_controller.cr
@@ -172,6 +172,9 @@ module Gori::Tui
         text = @sitemap.tag_buffer
         @host.session.store.set_sitemap_tag(host, path, text)
         @sitemap.apply_tag(text) # stamp in place — keeps the selection, no re-derive
+        # A `tag:` filter must re-evaluate against the changed tag (the in-place stamp
+        # doesn't re-filter), else the just-tagged node stays hidden / a cleared tag shown.
+        reload if @sitemap.filtering?
       else
         @sitemap.cancel_tag
       end

--- a/src/gori/tui/findings_view.cr
+++ b/src/gori/tui/findings_view.cr
@@ -280,8 +280,13 @@ module Gori::Tui
       list_h = {rect.bottom - top, 0}.max
 
       if @findings.empty?
-        msg = filtering? ? "no findings match · esc clears the filter" \
-                         : "no findings yet · Shift+F on a History flow, or n here"
+        msg = if !filtering?
+                "no findings yet · Shift+F on a History flow, or n here"
+              elsif querying?
+                "no findings match · esc clears the filter" # esc cancels the open query bar
+              else
+                "no findings match · / to edit the filter" # a committed filter: esc goes to tabs, not clear
+              end
         screen.text(rect.x + 1, top, msg, Theme.muted)
         return
       end

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -790,6 +790,21 @@ module Gori::Tui
       @editor.move(dr, dc)
     end
 
+    # Home/End: caret to line start/end — pure navigation, no dirty.
+    def template_home : Nil
+      @editor.home
+    end
+
+    def template_end : Nil
+      @editor.end_of_line
+    end
+
+    # Forward-delete the char under the caret — a content edit.
+    def template_delete : Nil
+      @editor.delete
+      @dirty = true
+    end
+
     # --- config serialization ------------------------------------------------
     def config_json : String
       commit_buffers # fold edited buffers into @config/@matcher before serializing
@@ -1054,17 +1069,40 @@ module Gori::Tui
         return y + 1
       end
       avail = {limit - y, 1}.max
-      shown = @sets.size <= avail ? @sets.size : {avail - 1, 0}.max
-      @sets.first(shown).each_with_index do |s, i|
+      return render_sets_all(screen, inner, y, focused, pp) if @sets.size <= avail
+      render_sets_windowed(screen, inner, y, focused, avail, pp)
+    end
+
+    # Every set fits — render them all (no scroll).
+    private def render_sets_all(screen, inner : Rect, y : Int32, focused : Bool, pp : Bool) : Int32
+      @cfg_scroll = 0
+      @sets.each_with_index do |s, i|
         sel = focused && current_field == :set && current_set_index == i
         render_set_row(screen, inner, y, s, i, sel, pp)
         y += 1
       end
-      if shown < @sets.size
-        screen.text(inner.x + 1, y, "… +#{@sets.size - shown} more", Theme.muted, Theme.bg)
+      y
+    end
+
+    # The list exceeds the pane: window it around the focused set (the unused @cfg_scroll
+    # meant selection/delete could operate on a row scrolled off-screen). One row is
+    # reserved for an "above/below" overflow indicator.
+    private def render_sets_windowed(screen, inner : Rect, y : Int32, focused : Bool, avail : Int32, pp : Bool) : Int32
+      visible = {avail - 1, 1}.max
+      idx = current_set_index
+      @cfg_scroll = idx if idx < @cfg_scroll
+      @cfg_scroll = idx - visible + 1 if idx >= @cfg_scroll + visible
+      @cfg_scroll = @cfg_scroll.clamp(0, {@sets.size - visible, 0}.max)
+      stop = {@cfg_scroll + visible, @sets.size}.min
+      (@cfg_scroll...stop).each do |i|
+        sel = focused && current_field == :set && current_set_index == i
+        render_set_row(screen, inner, y, @sets[i], i, sel, pp)
         y += 1
       end
-      y
+      above, below = @cfg_scroll, @sets.size - stop
+      hint = above > 0 && below > 0 ? "… #{above} above · #{below} below" : (above > 0 ? "… #{above} above" : "… +#{below} more")
+      screen.text(inner.x + 1, y, hint, Theme.muted, Theme.bg)
+      y + 1
     end
 
     # One Sets row. In per-position modes (pp) it carries a marker-coloured swatch + →N
@@ -1351,6 +1389,8 @@ module Gori::Tui
       screen.text(tx, rect.y, " response ", @detail_pane == :response ? Theme.text_bright : Theme.muted, @detail_pane == :response ? Theme.accent_bg : Theme.bg)
       inner = rect.inset(1, 1)
       lines = @detail_pane == :request ? detail_request_lines(r) : detail_response_lines(r)
+      # Clamp so ↓/wheel can't scroll past the last line into a blank void (keeps ≥1 row).
+      @detail_scroll = @detail_scroll.clamp(0, {lines.size - 1, 0}.max)
       (0...inner.h).each do |i|
         li = @detail_scroll + i
         break if li >= lines.size

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -445,6 +445,14 @@ module Gori::Tui
       # match the render/goto predicate so search agrees (not a bare @detail_hex).
       return hits if query.empty? || (@detail_hex && !log_pane?)
       q = query.downcase
+      # Reveal-whitespace renders on its OWN line space (raw head+body bytes) with its own
+      # scroll bounds (detail_scroll_max). Search must scan reveal_lines so the hit indices
+      # match what goto_detail_line scrolls to — mirroring the hex exclusion above (the
+      # decoded/pretty detail_view has a different line count, so its indices would scroll wrong).
+      if @reveal && (rl = reveal_lines)
+        rl.each_with_index { |ln, i| hits << i if ln.downcase.includes?(q) }
+        return hits
+      end
       dv = detail_view
       (0...dv.total).each { |i| hits << i if dv.line_text(i).downcase.includes?(q) }
       hits

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -175,6 +175,22 @@ module Gori::Tui
       @editor.move(dr, dc) if @editing
     end
 
+    # Home/End: caret to line start/end — pure navigation, doesn't change the bytes.
+    def edit_home : Nil
+      @editor.home if @editing
+    end
+
+    def edit_end : Nil
+      @editor.end_of_line if @editing
+    end
+
+    # Forward-delete the char under the caret — a content edit.
+    def edit_delete : Nil
+      return unless @editing
+      @editor.delete
+      @editor_dirty = true
+    end
+
     # ^G go-to-line / ^F search in the held-message editor (only while editing).
     def edit_goto_line(n : Int32) : Nil
       @editor.goto_line(n) if @editing

--- a/src/gori/tui/notes_view.cr
+++ b/src/gori/tui/notes_view.cr
@@ -117,6 +117,21 @@ module Gori::Tui
       current.area.move(dr, dc)
     end
 
+    # Home/End: caret to line start/end — pure navigation, does not dirty.
+    def home : Nil
+      current.area.home
+    end
+
+    def end_of_line : Nil
+      current.area.end_of_line
+    end
+
+    # Forward-delete the char under the caret — a content edit.
+    def delete : Nil
+      current.area.delete
+      @dirty = true
+    end
+
     # Mouse: place the cursor at a click. `rect` is the framed interior the runner
     # passes to render; re-apply render's 1-col side inset so the editor geometry matches.
     def click_to_cursor(rect : Rect, mx : Int32, my : Int32) : Nil

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -486,6 +486,7 @@ module Gori::Tui
       uri = URI.parse(raw)
       scheme = uri.scheme || "http"
       host = uri.host || ""
+      host = host[1..-2] if host.starts_with?('[') && host.ends_with?(']') # bare IPv6 literal for dialing
       port = uri.port || (scheme == "https" ? 443 : 80)
       {scheme, host, port}
     rescue
@@ -649,6 +650,24 @@ module Gori::Tui
     def edit_move(dr : Int32, dc : Int32) : Nil
       return unless @focus == :request
       @editor.move(dr, dc)
+      # Cursor navigation is NOT a content edit: leave @dirty alone. Marking it here made
+      # pure arrow-key movement persist the tab (V11) and, worse, latch sync-clobber
+      # protection so a live cross-session update could no longer refresh the tab.
+    end
+
+    # Home/End: pure navigation (caret to line start/end) → does NOT dirty, like edit_move.
+    def edit_home : Nil
+      @editor.home if @focus == :request
+    end
+
+    def edit_end : Nil
+      @editor.end_of_line if @focus == :request
+    end
+
+    # Forward-delete: a content edit → dirties (matches edit_backspace).
+    def edit_delete : Nil
+      return unless @focus == :request
+      @editor.delete
       @dirty = true
     end
 
@@ -668,8 +687,10 @@ module Gori::Tui
     # Whitespace reveal toggle — response renders from raw bytes; the request editor
     # shows within-line whitespace too.
     def reveal=(on : Bool) : Nil
+      return if @reveal == on # the controller pushes this every frame; guard so @scroll isn't zeroed each render
       @reveal = on
       @editor.reveal = on
+      @scroll = 0 # reveal renders the response from RAW bytes → a different line count; reset like pretty=/x/d
     end
 
     # Pretty toggle feeds `resp_view`, so a change drops only the response-view cache
@@ -753,6 +774,28 @@ module Gori::Tui
         @scx = (@scx + d).clamp(0, @sni.size)
       else
         @tcx = (@tcx + d).clamp(0, @target.size)
+      end
+      # Cursor navigation is not a content edit — do NOT dirty (caret is never persisted),
+      # mirroring edit_move/goto_request_line/hex_move.
+    end
+
+    # Home/End on the single-line target/SNI field — pure caret moves, no dirty.
+    def target_home : Nil
+      @target_field == :sni ? (@scx = 0) : (@tcx = 0)
+    end
+
+    def target_end : Nil
+      @target_field == :sni ? (@scx = @sni.size) : (@tcx = @target.size)
+    end
+
+    # Forward-delete the char under the caret on the target/SNI field — a content edit.
+    def target_delete : Nil
+      if @target_field == :sni
+        return if @scx >= @sni.size
+        @sni = "#{@sni[0, @scx]}#{@sni[@scx + 1..]}"
+      else
+        return if @tcx >= @target.size
+        @target = "#{@target[0, @tcx]}#{@target[@tcx + 1..]}"
       end
       @dirty = true
     end
@@ -1256,7 +1299,9 @@ module Gori::Tui
 
     private def build_target(scheme : String, host : String, port : Int32) : String
       default = scheme == "https" ? 443 : 80
-      port == default ? "#{scheme}://#{host}" : "#{scheme}://#{host}:#{port}"
+      # Bracket an IPv6 literal host (contains ':') so the URL parses back correctly.
+      h = host.includes?(':') && !host.starts_with?('[') ? "[#{host}]" : host
+      port == default ? "#{scheme}://#{h}" : "#{scheme}://#{h}:#{port}"
     end
 
     # Rewrites an absolute-form request-line ("GET http://h/p ...") to origin-form

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -16,6 +16,7 @@ require "../replay/engine"
 require "../replay/h2_engine"
 require "../replay/ws_engine"
 require "../replay/diff"
+require "../replay/flow_request"
 
 module Gori::Tui
   # The Replay workbench (a tab). Layout: a target URL field on top, then a split
@@ -480,17 +481,10 @@ module Gori::Tui
     end
 
     # {scheme, host, port} parsed from the target field.
+    # Delegate to the engine's parser so the TUI field and `gori run`/the replay engine never
+    # disagree on host/port (they used to be byte-for-byte duplicate implementations).
     def parse_target : {String, String, Int32}
-      raw = @target.strip
-      raw = "http://#{raw}" unless raw.includes?("://")
-      uri = URI.parse(raw)
-      scheme = uri.scheme || "http"
-      host = uri.host || ""
-      host = host[1..-2] if host.starts_with?('[') && host.ends_with?(']') # bare IPv6 literal for dialing
-      port = uri.port || (scheme == "https" ? 443 : 80)
-      {scheme, host, port}
-    rescue
-      {"http", "", 0}
+      Replay::FlowRequest.parse_target(@target)
     end
 
     # The TARGET card grows to a second content row (4 high vs 3) whenever an SNI
@@ -1298,10 +1292,7 @@ module Gori::Tui
     end
 
     private def build_target(scheme : String, host : String, port : Int32) : String
-      default = scheme == "https" ? 443 : 80
-      # Bracket an IPv6 literal host (contains ':') so the URL parses back correctly.
-      h = host.includes?(':') && !host.starts_with?('[') ? "[#{host}]" : host
-      port == default ? "#{scheme}://#{h}" : "#{scheme}://#{h}:#{port}"
+      Replay::FlowRequest.build_target(scheme, host, port) # shared with the engine (was duplicated)
     end
 
     # Rewrites an absolute-form request-line ("GET http://h/p ...") to origin-form

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -2097,6 +2097,7 @@ module Gori::Tui
       replay_controller.save_current_replay if @active_tab == :replay && @focus == :body && pane != :body
       fuzzer_controller.save_current if @active_tab == :fuzzer && @focus == :body && pane != :body
       convert_controller.commit if @active_tab == :convert && @focus == :body && pane != :body
+      notes_controller.save_notes if @active_tab == :notes && @focus == :body && pane != :body
       @focus = pane
       @overlay = :none
       view_focus_first if pane == :body
@@ -2121,6 +2122,7 @@ module Gori::Tui
       replay_controller.save_current_replay if @active_tab == :replay # persist the outgoing replay tab
       fuzzer_controller.save_current if @active_tab == :fuzzer
       convert_controller.commit if @active_tab == :convert # flush sub-tab edits/renames (dirty-guarded)
+      notes_controller.save_notes if @active_tab == :notes # flush unsaved note edits (dirty-guarded)
       @active_tab = tab
       @focus = focus
       @overlay = :none
@@ -2152,6 +2154,7 @@ module Gori::Tui
       replay_controller.save_current_replay if @active_tab == :replay # persist the outgoing replay tab
       fuzzer_controller.save_current if @active_tab == :fuzzer
       convert_controller.commit if @active_tab == :convert # flush sub-tab edits/renames (dirty-guarded)
+      notes_controller.save_notes if @active_tab == :notes # flush unsaved note edits (dirty-guarded)
       # Cycle within the VISIBLE strip (skips hidden tabs); effective_tabs force-includes
       # the active tab so the index is always found and never falls back to 0.
       tabs = effective_tabs

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -249,9 +249,17 @@ module Gori::Tui
     private def upstream_port_error(value : String) : String?
       return nil if value.empty?
       bare = value.sub(/\Ahttps?:\/\//, "").rstrip('/')
-      i = bare.rindex(':')
-      return nil unless i && i < bare.size - 1 # no explicit port → defaults are fine
-      seg = bare[(i + 1)..]
+      if bare.starts_with?('[') # bracketed IPv6 literal: [::1] or [::1]:port — the port is after ']'
+        return nil unless close = bare.index(']')
+        rest = bare[(close + 1)..]
+        return nil unless rest.starts_with?(':') && rest.size > 1 # no explicit port → defaults fine
+        seg = rest[1..]
+      else
+        i = bare.rindex(':')
+        return nil unless i && i < bare.size - 1 # no explicit port → defaults fine
+        return nil if bare[0...i].includes?(':') # pre-colon host has a ':' → unbracketed IPv6 literal, no port
+        seg = bare[(i + 1)..]
+      end
       p = seg.to_i?
       (p && 0 <= p <= 65535) ? nil : "settings: invalid upstream proxy port #{seg.inspect}"
     end

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -97,6 +97,11 @@ module Gori::Tui
       @tag_buffer = ""
       @tag_cx = 0
       @tag_preedit = ""
+      # The (host, path) the open editor targets, PINNED at start_tag — a mid-edit external
+      # reload resets @selected to 0, so a selection-based lookup at commit would tag the
+      # wrong (usually top host) node. Pinning keeps the tag landing on the intended node.
+      @tag_host = ""
+      @tag_path = ""
     end
 
     # Inject the Scope lens so the tree honours it AND the bar can show its state
@@ -391,6 +396,9 @@ module Gori::Tui
     def start_tag : Bool
       node = selected_node
       return false unless node && !node.grouped
+      target = resolve_target # selection-based (host, path) — captured NOW, before any reload
+      return false unless target
+      @tag_host, @tag_path = target
       @tagging = true
       @tag_buffer = node.tag || ""
       @tag_cx = @tag_buffer.size
@@ -409,8 +417,12 @@ module Gori::Tui
     # the editor. No re-derive — the tree structure is unchanged, so the selection
     # stays put and draw_row reads the fresh tag live.
     def apply_tag(text : String) : Nil
-      node = selected_node
-      node.tag = text.blank? ? nil : text if node && !node.grouped
+      # Stamp the live node in place ONLY while the selection still points at the pinned
+      # target (no external reload retargeted @selected); otherwise the persisted tag is
+      # picked up by the next reload, so skip rather than stamp the WRONG node.
+      if resolve_target == tag_target && (node = selected_node) && !node.grouped
+        node.tag = text.blank? ? nil : text
+      end
       cancel_tag
     end
 
@@ -440,7 +452,15 @@ module Gori::Tui
     # The (host, path) the tag editor targets — the selected node's address (the host
     # is the nearest depth-0 row above the selection). Nil when the selection isn't
     # taggable (a group node / empty tree). The controller persists the buffer here.
+    # The PINNED (host, path) the open tag editor targets (captured at start_tag); nil
+    # when not tagging. Commit persists to this so a mid-edit reload can't retarget it.
     def tag_target : {String, String}?
+      @tagging ? {@tag_host, @tag_path} : nil
+    end
+
+    # Selection-based (host, path) for the row currently under the cursor — the LIVE
+    # target, used to seed the pin at start_tag and to detect a reload in apply_tag.
+    private def resolve_target : {String, String}?
       rows = visible_rows
       return nil unless row = rows[@selected]?
       return nil if row.node.grouped

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -122,6 +122,34 @@ module Gori::Tui
       @edits += 1
     end
 
+    # Home / End: jump the cursor to the start / end of the current line. Pure navigation
+    # (no buffer change), so @styled/@edits are untouched — mirrors `move`.
+    def home : Nil
+      @cx = 0
+    end
+
+    def end_of_line : Nil
+      @cx = @lines[@cy].size
+    end
+
+    # Forward delete: remove the char under the cursor, or join the next line when at EOL.
+    # A buffer mutation, so it invalidates the highlight cache and bumps @edits (like backspace).
+    def delete : Nil
+      line = @lines[@cy]
+      cx = @cx.clamp(0, line.size)
+      if cx < line.size
+        @lines[@cy] = "#{line[0, cx]}#{line[cx + 1..]}"
+      elsif @cy < @lines.size - 1
+        @lines[@cy] = line + @lines[@cy + 1]
+        @lines.delete_at(@cy + 1)
+      else
+        return # end of buffer — nothing to delete, don't dirty
+      end
+      @cx = cx
+      @styled = nil
+      @edits += 1
+    end
+
     def move(dr : Int32, dc : Int32) : Nil
       if dr != 0
         @cy = (@cy + dr).clamp(0, @lines.size - 1)


### PR DESCRIPTION
A feature-by-feature bug-hunt of the built gori, run in 7 rounds. Each round drove the
real tool (tmux TUI + `gori run` CLI + `gori mcp` + curl against a local test server)
while a deep parallel audit (per-area finders → adversarial verifiers) cross-checked it.
~37 confirmed bugs fixed; 876 specs pass, ameba clean.

## Rounds
- **R1 proxy + History** — `Content-Length: +5` smuggling leniency, chunk-size-line
  overflow desync, QL `~`-on-non-regex-field, `^F` reveal-mode search.
- **R2 Replay** — cursor-move marked tab dirty, reveal scroll, **Home/End/Delete added
  to the text editors**, `read_complete` double-buffer, IPv6 target, h2 1xx-merge / CRLF /
  push-disable, WS drain deadline.
- **R3 Intercept + M&R** — held-response truncation kept the client alive, edited-method
  replay-safety, held-request completeness, **Ctrl+F irreversibly forwarded a held
  message**, ⇧F dead-key on non-Kitty terminals.
- **R4 Scope/Findings/Sitemap** — Markdown export dropped a valid-UTF-8 body when
  truncation split a codepoint, sitemap tag editor mis-targeted after a mid-edit reload,
  findings empty-state hint.
- **R5 Fuzzer/Convert/Comparer/Notes** — **HIGH: Notes edits silently discarded** on
  Tab/mouse tab-switch, fuzzer CONFIG Sets scroll, NumberRange Int64 overflow crash,
  jitter ignored without a base rate, detail scroll-into-void.
- **R6 Settings/Hotkeys/Hostnames** — **non-atomic `Settings.save`** (torn write reset
  ALL settings), IPv6 upstream-proxy validation, IPv6 override CONNECT bracket, hotkeys
  rebindable-gate on load.
- **R7 CLI + MCP** — truncated-request-body replay hung the origin under the original
  Content-Length, `gori run history` silently dropped a positional QL, `gori mcp --db
  <typo>` created an empty DB, `gori mcp --project` case-sensitivity.

## Note for review — security-testing capability
gori's purpose includes sending intentionally non-spec-compliant HTTP. Several R1/R3
fixes added strictness on the **auto-forward** path (reject `+5`, truncated chunk lines).
The deliberate malformed-probe paths are **Replay** and **Intercept** (raw byte editing,
byte-exact forward) — please verify those still forward arbitrary malformed bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)