### PR TITLE
fix: address behavior audit (QL fallback, miner echo FPs, headless TTY guards, mcp/update/browser UX)

### DIFF
--- a/spec/miner/engine_spec.cr
+++ b/spec/miner/engine_spec.cr
@@ -7,21 +7,27 @@ private alias F = Gori::Fuzz
 # of each request; if a "magic" param is present it changes the response accordingly:
 #   - REFLECT params echo their (canary) value in the body.
 #   - GROW params append extra bytes to the body (a metric/length signal, no reflection).
+#   - ECHO mode reflects EVERY param value back (an echo API like httpbin/get), the
+#     reflect-all false-positive trap the miner must recognise and suppress.
 # Everything else returns a stable baseline body.
 private class HiddenParamBackend < F::Backend
   getter origin : F::Origin
   getter sent : Int32 = 0
 
   def initialize(@origin : F::Origin, @reflect : Array(String) = [] of String,
-                 @grow : Array(String) = [] of String)
+                 @grow : Array(String) = [] of String, @echo : Bool = false)
   end
 
   def send(bytes : Bytes) : Gori::Replay::Result
     @sent += 1
     params = query_params(bytes)
     body = "BASELINE BODY CONTENT"
-    @reflect.each { |name| (v = params[name]?) && (body += " reflected=#{v}") }
-    @grow.each { |name| params.has_key?(name) && (body += " XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX") }
+    if @echo
+      params.each { |k, v| body += " #{k}=#{v}" } # echo API: reflects ANY input value
+    else
+      @reflect.each { |name| (v = params[name]?) && (body += " reflected=#{v}") }
+      @grow.each { |name| params.has_key?(name) && (body += " XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX") }
+    end
     ok(body)
   end
 
@@ -97,6 +103,25 @@ describe Gori::Miner::Engine do
     names = ["alpha", "beta", "gamma", "delta", "epsilon"]
     findings = mine(backend, names, cfg)
     findings.should be_empty
+  end
+
+  it "suppresses reflection false positives on an echo endpoint (reflects any input)" do
+    # An echo API reflects EVERY param, so naive reflection detection would report all
+    # candidates. The reflect-all control must recognise this and yield no findings.
+    backend = HiddenParamBackend.new(F::Origin.new("http", "h", 80), echo: true)
+    names = ["alpha", "beta", "gamma", "secret", "delta", "epsilon", "zeta", "eta"]
+    findings = mine(backend, names, cfg)
+    findings.should be_empty
+  end
+
+  it "warns via the baseline event when the endpoint echoes any input" do
+    backend = HiddenParamBackend.new(F::Origin.new("http", "h", 80), echo: true)
+    base = "GET /api HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+    engine = M::Engine.new(base, http2: false, names: ["a", "b"], backend: backend, config: cfg)
+    warning = nil.as(String?)
+    engine.run { |ev| warning = ev.warning if ev.is_a?(M::BaselineEvent) }
+    warning.should_not be_nil
+    warning.not_nil!.should contain("echoes")
   end
 
   it "emits a Done event and a baseline event" do

--- a/spec/ql_spec.cr
+++ b/spec/ql_spec.cr
@@ -63,6 +63,23 @@ describe Gori::QL do
     f.args.should eq(["%login%", "%login%", "%login%"])
   end
 
+  it "free-texts the WHOLE token for an unknown/typo'd field (keeps the prefix)" do
+    # `hosst:acme` is a typo of `host:`. The fallback must search the full token, not
+    # just the value after the ':', so the prefix isn't silently dropped (and a typo
+    # surfaces as a no-match rather than masquerading as a successful host filter).
+    f = Gori::QL.parse("hosst:acme.test")
+    f.sql.should eq("((lower(method) LIKE ? OR lower(host) LIKE ? OR lower(target) LIKE ?))")
+    f.args.should eq(["%hosst:acme.test%", "%hosst:acme.test%", "%hosst:acme.test%"])
+  end
+
+  it "free-texts flag: as an unknown field (no flow-flag store yet)" do
+    # gori has no per-flow flag store (Store#flags_for is a stub), so `flag:` is not a
+    # real field: it free-texts the whole token like any other unknown field rather
+    # than compiling to a silent never-match that looks like a working-but-empty filter.
+    f = Gori::QL.parse("flag:reflected")
+    f.args.should eq(["%flag:reflected%", "%flag:reflected%", "%flag:reflected%"])
+  end
+
   it "matches everything for an empty query" do
     Gori::QL.parse("   ").sql.should eq("1")
   end
@@ -180,6 +197,8 @@ describe "Gori::Store#search (QL)" do
       post_login.size.should eq(1)
       post_login.first.target.should eq("/login")
 
+      # flag: is not a real field (no flow-flag store): it free-texts the whole token,
+      # which matches none of these flows' method/host/target.
       none = store.search(Gori::QL.parse("flag:reflected"), 50)
       none.should be_empty
     end

--- a/src/gori/app.cr
+++ b/src/gori/app.cr
@@ -45,7 +45,10 @@ module Gori
       Tui::Theme.load_custom           # register user themes from <GORI_HOME>/themes/*.json
       Tui::Theme.apply(Settings.theme) # honour the persisted theme from the first frame (picker included)
       projects = ProjectRegistry.new(Paths.projects_dir)
-      term = Termisu.new
+      # /dev/tty guard at the shared construction point: covers both this TUI and the
+      # first-run wizard auto-launched below, so a no-tty run (CI/detached) gets a clean
+      # message instead of a raw backtrace.
+      term = Tui.open_terminal("run it directly, not under CI or a detached/background job, or use --headless for non-interactive capture")
       term.enable_enhanced_keyboard       # Kitty 17u (disambig + report_text) for better IME/Unicode; avoids report_all_keys(31u) which can split Hangul jamo. Committed text via raw UTF-8 bytes (IME composed syllables) + CSI for specials; Preedit via 0-code CSI if terminal provides.
       term.enable_mouse if Settings.mouse # SGR-1006 click + scroll-wheel nav; one enable covers both the picker and the runner (same term). Runner reconciles live on settings save; term.close disables on exit.
 

--- a/src/gori/browser.cr
+++ b/src/gori/browser.cr
@@ -138,7 +138,9 @@ module Gori
       if certutil = Process.find_executable("certutil")
         import_firefox_ca(certutil, profile, spec.ca_cert_path) ? "CA imported, proxy set" : "proxy set (CA import failed)"
       else
-        "proxy set — install certutil (nss) to auto-trust the CA"
+        # No certutil → the CA can't be injected into Firefox's NSS store, so HTTPS sites
+        # will show SEC_ERROR/cert warnings. Say so, not just "install certutil".
+        "proxy set — HTTPS will show cert errors; install certutil (nss) to auto-trust the CA"
       end
     end
 

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -225,16 +225,10 @@ module Gori
       Settings.load
       Tui::Theme.load_custom           # register user themes before the theme step
       Tui::Theme.apply(Settings.theme) # honour the persisted theme from the first frame
-      # The wizard drives /dev/tty directly (not STDIN/STDOUT — those may be redirected
-      # while a real terminal is still present), so guard on /dev/tty itself: Termisu.new
-      # opens it and raises with no controlling terminal (CI / a detached or background
-      # job), where the wizard would otherwise stall. Turn that into a clear message.
-      term =
-        begin
-          Termisu.new
-        rescue IO::Error
-          abort "gori wizard: requires an interactive terminal (no /dev/tty) — run it directly, not under CI or a detached/background job"
-        end
+      # The wizard drives /dev/tty directly (not STDIN/STDOUT, which may be redirected
+      # while a real terminal is still present), so the guard lives at the shared
+      # Tui.open_terminal construction point (same as App#run_tui).
+      term = Tui.open_terminal("run the wizard directly, not under CI or a detached/background job")
       term.enable_enhanced_keyboard       # Kitty disambiguation for IME/Unicode (mirrors App#run_tui)
       term.enable_mouse if Settings.mouse # SGR-1006 click + scroll-wheel nav
       begin

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -19,7 +19,7 @@ module Gori
   # - `gori run <sub>`              → non-interactive CLI (see Gori::CLI::Run)
   # - `gori mcp`                    → MCP (Model Context Protocol) server over stdio
   # - `gori wizard`                 → interactive first-run setup wizard (bind/theme/AI)
-  # - `gori update`                 → placeholder for future work
+  # - `gori update`                 → print how to update gori (no built-in self-update yet)
   #
   # Old flat flags (`gori --headless`, `gori --export-ca` ...) continue to work
   # via the tui path for backward compatibility.
@@ -76,7 +76,7 @@ module Gori
       puts "  run       Non-interactive CLI: capture, history, show, replay, findings, projects"
       puts "  wizard    Interactive setup wizard (bind, theme, AI) — also runs on first launch"
       puts "  mcp       Start an MCP server over stdio (AI/tool integration)"
-      puts "  update    [placeholder] Self-update"
+      puts "  update    Show how to update gori to the latest version"
       puts ""
       puts "See 'gori <command> --help' for more."
       puts "Flags like --version and --help work at the top level too."
@@ -312,11 +312,19 @@ module Gori
     private def self.run_update(args : Array(String)) : Nil
       if args.any? { |a| ["-h", "--help"].includes?(a) }
         puts "Usage: gori update"
-        puts "  (placeholder) Will check for and apply updates."
+        puts "  Show how to update gori to the latest version."
         return
       end
-      puts "gori update: not implemented yet."
-      puts "If installed via Homebrew: brew upgrade gori"
+      # No built-in self-update yet (no release/download pipeline). Rather than print a
+      # dead "not implemented" line, give the user the real ways to get a newer build.
+      puts "gori #{VERSION}"
+      puts ""
+      puts "gori has no built-in self-update yet. To update:"
+      puts ""
+      puts "  • From source:  git pull && shards install \\"
+      puts "                  && crystal build src/main.cr -o bin/gori --release"
+      puts "  • Releases:     #{REPOSITORY_URL}/releases"
+      puts "  • Homebrew:     brew upgrade gori   (once a formula is published)"
     end
   end
 end

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -270,6 +270,10 @@ module Gori
 
       resolved = resolve_mcp_db(db_path, project)
       Log.info { "mcp: serving #{resolved} (actions=#{!read_only})" }
+      # Make the implicit fallback visible (STDERR only — STDOUT is the JSON-RPC stream):
+      # with no --db/--project the most-recently-used project (or the default db) is served,
+      # which can silently be an empty database an AI client then queries as if it were real.
+      Log.warn { "mcp: no --db/--project given — defaulting to #{resolved}" } if db_path.nil? && project.nil?
 
       # Opening a non-SQLite / unreadable file raises deep in the driver; turn that
       # into a clean error instead of an unhandled backtrace (parity with `gori run`).
@@ -279,6 +283,7 @@ module Gori
         rescue ex : DB::Error | SQLite3::Exception
           abort "gori mcp: cannot open database #{resolved}: #{ex.message.presence || "not a valid SQLite database (or unreadable)"}"
         end
+      Log.warn { "mcp: #{resolved} has no captured flows (empty database)" } if store.count.zero?
       begin
         server = MCP::Server.new(store, allow_actions: !read_only, verify_upstream: !insecure_upstream)
         server.run # blocks until STDIN EOF (client closed)

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -160,6 +160,13 @@ module Gori
         return
       end
 
+      # --edit hands the terminal to $EDITOR/vi, which reads stdin directly. Without an
+      # interactive TTY (pipe/redirect/CI/background job) the editor would hang waiting
+      # for input it can never get, so refuse and point at the non-interactive path.
+      unless STDIN.tty? && STDOUT.tty?
+        abort "gori settings --edit: requires an interactive terminal; run 'gori settings' to print the path, then edit it directly"
+      end
+
       cmd = Settings.editor_command
       status = Process.run(cmd[0], cmd[1..] + [path],
         input: Process::Redirect::Inherit, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
@@ -211,6 +218,12 @@ module Gori
         puts "  Interactive setup wizard: proxy bind address, TUI theme, AI provider."
         puts "  Runs automatically on first launch; use this to re-run it anytime."
         return
+      end
+      # The wizard drives the terminal directly (raw mode + enhanced keyboard). With no
+      # interactive TTY — a pipe, redirect, CI, or a background job — Termisu would block
+      # on /dev/tty (or fail opaquely), so refuse up front with a clear message instead.
+      unless STDIN.tty? && STDOUT.tty?
+        abort "gori wizard: requires an interactive terminal — run it directly, not piped, redirected, or under CI/a background job"
       end
       Paths.ensure_dirs
       Settings.load

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -160,11 +160,13 @@ module Gori
         return
       end
 
-      # --edit hands the terminal to $EDITOR/vi, which reads stdin directly. Without an
-      # interactive TTY (pipe/redirect/CI/background job) the editor would hang waiting
-      # for input it can never get, so refuse and point at the non-interactive path.
-      unless STDIN.tty? && STDOUT.tty?
-        abort "gori settings --edit: requires an interactive terminal; run 'gori settings' to print the path, then edit it directly"
+      # --edit spawns $EDITOR/vi with inherited stdio. A terminal editor reading from a
+      # non-tty stdin (pipe/redirect/CI/background job) hangs waiting for input it can
+      # never get, so require an interactive stdin. Guard on STDIN only: a GUI editor
+      # (`code -w`, `subl -w`) needs no tty, and stdout may legitimately be redirected,
+      # so don't over-restrict those — point at the non-interactive path otherwise.
+      unless STDIN.tty?
+        abort "gori settings --edit: stdin is not an interactive terminal; run 'gori settings' to print the path, then edit it directly"
       end
 
       cmd = Settings.editor_command
@@ -219,17 +221,20 @@ module Gori
         puts "  Runs automatically on first launch; use this to re-run it anytime."
         return
       end
-      # The wizard drives the terminal directly (raw mode + enhanced keyboard). With no
-      # interactive TTY — a pipe, redirect, CI, or a background job — Termisu would block
-      # on /dev/tty (or fail opaquely), so refuse up front with a clear message instead.
-      unless STDIN.tty? && STDOUT.tty?
-        abort "gori wizard: requires an interactive terminal — run it directly, not piped, redirected, or under CI/a background job"
-      end
       Paths.ensure_dirs
       Settings.load
       Tui::Theme.load_custom           # register user themes before the theme step
       Tui::Theme.apply(Settings.theme) # honour the persisted theme from the first frame
-      term = Termisu.new
+      # The wizard drives /dev/tty directly (not STDIN/STDOUT — those may be redirected
+      # while a real terminal is still present), so guard on /dev/tty itself: Termisu.new
+      # opens it and raises with no controlling terminal (CI / a detached or background
+      # job), where the wizard would otherwise stall. Turn that into a clear message.
+      term =
+        begin
+          Termisu.new
+        rescue IO::Error
+          abort "gori wizard: requires an interactive terminal (no /dev/tty) — run it directly, not under CI or a detached/background job"
+        end
       term.enable_enhanced_keyboard       # Kitty disambiguation for IME/Unicode (mirrors App#run_tui)
       term.enable_mouse if Settings.mouse # SGR-1006 click + scroll-wheel nav
       begin

--- a/src/gori/miner/baseline.cr
+++ b/src/gori/miner/baseline.cr
@@ -92,7 +92,7 @@ module Gori::Miner
                (p.metrics.length - base.metrics.length).abs > ltol ||
                (p.metrics.words - base.metrics.words).abs > wtol ||
                (p.metrics.lines - base.metrics.lines).abs > lntol
-      echoes = bogus.any? { |(_, value)| p.body_text.includes?(value) || p.head_text.includes?(value) }
+      echoes = bogus.any? { |(_, value)| p.reflects?(value) }
       {reacts, echoes}
     end
 
@@ -100,7 +100,7 @@ module Gori::Miner
                                  reflects_all : Hash(Location, Bool)) : String?
       notes = [] of String
       notes << "baseline status varies (#{statuses.join("/")})" unless stable
-      notes << "endpoint echoes any input — reflection findings disabled" if reflects_all.any? { |_, v| v }
+      notes << "endpoint echoes input at some locations — reflection findings disabled there" if reflects_all.any? { |_, v| v }
       return nil if notes.empty?
       "#{notes.join("; ")} — findings tentative"
     end
@@ -120,7 +120,7 @@ module Gori::Miner
     # candidate would "reflect", so it carries no discovery signal — only noise.
     unless report.reflects_all[location]?
       canaries_inv.each do |canary, name|
-        reflected[canary] = name if probe.body_text.includes?(canary) || probe.head_text.includes?(canary)
+        reflected[canary] = name if probe.reflects?(canary)
       end
     end
     kind = DiffKind::None

--- a/src/gori/miner/baseline.cr
+++ b/src/gori/miner/baseline.cr
@@ -18,10 +18,12 @@ module Gori::Miner
     reflected : Hash(String, String), # canary => name (echoed canaries)
     kind : DiffKind                   # strongest metric diff, else None
 
-  # Calibrates a stable baseline + a per-location "does it react to ANY unknown param?"
-  # control — the two false-positive killers. Tolerance bands absorb timestamps / CSRF
-  # tokens; a location that reacts to bogus params has its metric findings suppressed
-  # (reflection still counts there).
+  # Calibrates a stable baseline + two per-location controls — the false-positive killers.
+  # Tolerance bands absorb timestamps / CSRF tokens. (1) A location that reacts metrically
+  # to bogus params has its metric findings suppressed (`reflection_only`). (2) A location
+  # that ECHOES bogus values back (an echo API like httpbin/get) has its REFLECTION findings
+  # suppressed (`reflects_all`) — otherwise every random candidate "reflects" and floods the
+  # results with false positives.
   class Baseline
     record Report,
       status : Int32?,
@@ -33,6 +35,7 @@ module Gori::Miner
       base_lines : Int32,
       stable : Bool,
       reflection_only : Hash(Location, Bool),
+      reflects_all : Hash(Location, Bool),
       warning : String?
 
     def initialize(@backend : Fuzz::Backend, @base : Bytes, @config : Config)
@@ -57,35 +60,54 @@ module Gori::Miner
 
       statuses = probes.compact_map(&.metrics.status).uniq!
       stable = statuses.size <= 1
-      warning = stable ? nil : "baseline status varies (#{statuses.join("/")}) — findings tentative"
 
       reflection_only = Hash(Location, Bool).new
+      reflects_all = Hash(Location, Bool).new
       locations.each do |loc|
-        reflection_only[loc] = control_reacts?(loc, base, length_tol, words_tol, lines_tol)
+        reacts, echoes = control_signals(loc, base, length_tol, words_tol, lines_tol)
+        reflection_only[loc] = reacts
+        reflects_all[loc] = echoes
       end
 
       Report.new(base.metrics.status, length_tol, words_tol, lines_tol,
         base.metrics.length, base.metrics.words, base.metrics.lines,
-        stable, reflection_only, warning)
+        stable, reflection_only, reflects_all, baseline_warning(stable, statuses, reflects_all))
     end
 
-    # Inject a bucket of random non-existent names; if the response moves beyond
-    # tolerance, the app reacts to ANY unknown param at this location.
-    private def control_reacts?(loc : Location, base : Probe,
-                                ltol : Int64, wtol : Int32, lntol : Int32) : Bool
+    # Inject a bucket of random non-existent names ONCE per location. Returns
+    # {metric_reacts, reflects_all}:
+    #   metric_reacts — the response moved beyond tolerance, so the app reacts to ANY
+    #     unknown param here → its metric-diff findings are noise (suppressed in `decide`).
+    #   reflects_all  — the bogus VALUES were echoed back, so the endpoint reflects ANY
+    #     input (an echo API, e.g. httpbin/get) → reflection is not a discovery signal
+    #     here and its reflection findings must be suppressed too, else every candidate
+    #     "reflects" and the run floods with false positives.
+    private def control_signals(loc : Location, base : Probe,
+                                ltol : Int64, wtol : Int32, lntol : Int32) : {Bool, Bool}
       bogus = Array.new(8) { {Canary.bogus_name, Canary.fresh} }
       raw = @backend.send(Inject.apply(@base, loc, bogus, @config.add_content_length_when_missing?))
-      return false unless raw.error.nil?
+      return {false, false} unless raw.error.nil?
       p = Fingerprint.probe(raw)
-      return true if p.metrics.status != base.metrics.status
-      return true if (p.metrics.length - base.metrics.length).abs > ltol
-      return true if (p.metrics.words - base.metrics.words).abs > wtol
-      return true if (p.metrics.lines - base.metrics.lines).abs > lntol
-      false
+      reacts = p.metrics.status != base.metrics.status ||
+               (p.metrics.length - base.metrics.length).abs > ltol ||
+               (p.metrics.words - base.metrics.words).abs > wtol ||
+               (p.metrics.lines - base.metrics.lines).abs > lntol
+      echoes = bogus.any? { |(_, value)| p.body_text.includes?(value) || p.head_text.includes?(value) }
+      {reacts, echoes}
+    end
+
+    private def baseline_warning(stable : Bool, statuses : Array(Int32),
+                                 reflects_all : Hash(Location, Bool)) : String?
+      notes = [] of String
+      notes << "baseline status varies (#{statuses.join("/")})" unless stable
+      notes << "endpoint echoes any input — reflection findings disabled" if reflects_all.any? { |_, v| v }
+      return nil if notes.empty?
+      "#{notes.join("; ")} — findings tentative"
     end
 
     private def unreachable : Report
-      Report.new(nil, 0_i64, 0, 0, 0_i64, 0, 0, false, Hash(Location, Bool).new, "baseline unreachable")
+      Report.new(nil, 0_i64, 0, 0, 0_i64, 0, 0, false,
+        Hash(Location, Bool).new, Hash(Location, Bool).new, "baseline unreachable")
     end
   end
 
@@ -94,8 +116,12 @@ module Gori::Miner
   def self.decide(report : Baseline::Report, probe : Probe,
                   canaries_inv : Hash(String, String), location : Location) : Decision
     reflected = Hash(String, String).new
-    canaries_inv.each do |canary, name|
-      reflected[canary] = name if probe.body_text.includes?(canary) || probe.head_text.includes?(canary)
+    # Skip reflection detection on an echo endpoint (reflects ANY input): there every
+    # candidate would "reflect", so it carries no discovery signal — only noise.
+    unless report.reflects_all[location]?
+      canaries_inv.each do |canary, name|
+        reflected[canary] = name if probe.body_text.includes?(canary) || probe.head_text.includes?(canary)
+      end
     end
     kind = DiffKind::None
     unless report.reflection_only[location]?

--- a/src/gori/miner/fingerprint.cr
+++ b/src/gori/miner/fingerprint.cr
@@ -10,7 +10,15 @@ module Gori::Miner
   record Probe,
     metrics : Fuzz::Metrics,
     body_text : String,
-    head_text : String
+    head_text : String do
+    # Whether `needle` appears verbatim in the decoded body or head text. The ONE place
+    # reflection membership is decided — both decide() (candidate detection) and the
+    # Baseline echo-API control call this, so the suppression control can't drift from
+    # the detection it gates.
+    def reflects?(needle : String) : Bool
+      body_text.includes?(needle) || head_text.includes?(needle)
+    end
+  end
 
   module Fingerprint
     def self.probe(raw : Replay::Result) : Probe

--- a/src/gori/ql.cr
+++ b/src/gori/ql.cr
@@ -7,7 +7,7 @@ module Gori
   # injection-safe). The analysis surface; QL is how you find things (P8: pull).
   #
   #   host:acme status:>=500            # AND of terms
-  #   method:post path:/api OR flag:x   # OR of AND-groups
+  #   method:post path:/api OR status:5xx # OR of AND-groups
   #   -host:cdn  status:5xx  login      # negation, status class, free text
   #   body:token                        # scan request/response body bytes
   #   size:>10000 dur:>=500 dur:<2s     # total bytes (req+resp) / latency (ms; ms|s)
@@ -15,7 +15,7 @@ module Gori
   #   header:set-cookie                 # substring over request/response head bytes
   #   body~secret\d+  host~^api\.       # `~` = regex (host path url header body)
   module QL
-    # `:` fields:  host path method scheme status size reqsize respsize dur header body flag
+    # `:` fields:  host path method scheme status size reqsize respsize dur header body
     # `~` regex on: host path url header body   (+ bare words = free text).
     # Comparison ops (<= >= < > =) apply to status/size/reqsize/respsize/dur.
     struct Filter
@@ -77,7 +77,7 @@ module Gori
         if sep && sep > 0
           field = term[0...sep].downcase
           value = term[(sep + 1)..]
-          ti == sep ? regex_cond(field, value, term) : field_cond(field, value)
+          ti == sep ? regex_cond(field, value, term) : field_cond(field, value, term)
         else
           free_text(term)
         end
@@ -87,7 +87,7 @@ module Gori
       {negate ? "NOT (#{cond})" : cond, args}
     end
 
-    private def self.field_cond(field : String, value : String) : {String, Array(DB::Any)}?
+    private def self.field_cond(field : String, value : String, term : String) : {String, Array(DB::Any)}?
       return nil if value.empty?
       case field
       when "host"                        then {"lower(host) LIKE ? ESCAPE '\\'", [like(value)] of DB::Any}
@@ -99,8 +99,15 @@ module Gori
       when "dur"                         then duration_cond(value)
       when "header"                      then header_cond(value)
       when "body"                        then body_cond(value)
-      when "flag"                        then {"0", [] of DB::Any} # tags not implemented yet → matches nothing
-      else                                    free_text(value)     # unknown field: treat the value as free text
+      else
+        # Unknown field — a typo (`hosst:x`) or a literal colon in a value (`time:12:00`):
+        # free-text the WHOLE token (prefix included), not just the part after the ':'. This
+        # mirrors regex_cond's fallback, searches what the user actually typed, and makes a
+        # typo'd field self-evident (it matches nothing real) instead of silently searching
+        # only the value. NOTE: `flag:` lands here too — gori has no flow-flag store yet
+        # (Store#flags_for is a stub), so there is nothing to match; it free-texts like any
+        # other unknown field rather than advertising an unimplemented filter.
+        free_text(term)
       end
     end
 

--- a/src/gori/ql.cr
+++ b/src/gori/ql.cr
@@ -225,8 +225,8 @@ module Gori
     # function Scope's regex rules use, backed by Crystal Regex) over a text field —
     # host/path/url/header/body. Any other field falls back to a literal free-text
     # search of the whole token. An invalid pattern would raise inside the SQLite
-    # REGEXP callback, so we validate up front and emit a never-matches clause instead
-    # (like flag:). For case-insensitive matching use an inline (?i) flag.
+    # REGEXP callback, so we validate up front and emit a never-matches clause instead.
+    # For case-insensitive matching use an inline (?i) flag.
     private def self.regex_cond(field : String, value : String, term : String) : {String, Array(DB::Any)}?
       # A non-regex field name means `~` wasn't a regex operator here (e.g. `foo~bar`):
       # fall back to a literal free-text search of the WHOLE token. This must happen BEFORE
@@ -236,7 +236,7 @@ module Gori
       when "host", "path", "url", "header", "body"
         return nil if value.empty?
         # An invalid pattern would raise inside the SQLite REGEXP callback, so validate up
-        # front and emit a never-matches clause instead (like flag:).
+        # front and emit a never-matches clause instead.
         return {"0", [] of DB::Any} unless valid_regex?(value)
         case field
         when "host"   then {"host REGEXP ?", [value] of DB::Any}

--- a/src/gori/replay/ws_engine.cr
+++ b/src/gori/replay/ws_engine.cr
@@ -12,10 +12,18 @@ module Gori
     # H2Engine (one request → one buffered response), this does the HTTP/1.1
     # upgrade handshake, then a scripted exchange: send each outbound message as a
     # masked client frame, then drain inbound frames until the server sends Close
-    # or goes idle. One-shot and sequential — it does NOT interleave per-message
-    # request/response, and it strips permessage-deflate from the handshake (so a
-    # session originally captured WITH compression replays its stored payloads
-    # uncompressed; edit the messages, or expect garbage for compressed binaries).
+    # or goes idle.
+    #
+    # Two deliberate limitations of this simplified replay:
+    #  - Sequential, not interleaved: ALL recorded client→server messages are sent
+    #    first, then the server's responses are drained. A protocol that depends on
+    #    per-message request/response interleaving will not replay faithfully.
+    #  - No permessage-deflate: the handshake omits the extension, AND the live
+    #    capture relay stores frame payloads verbatim without decompressing them. So
+    #    a session captured over a compressed connection holds COMPRESSED bytes;
+    #    replaying them to a server that isn't negotiating deflate sends undecodable
+    #    input (and compressed server frames likewise can't be read). To replay such
+    #    a session, capture it with compression disabled in the browser.
     module WsEngine
       GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11" # RFC 6455 §1.3 accept magic
 

--- a/src/gori/tui.cr
+++ b/src/gori/tui.cr
@@ -8,6 +8,18 @@ module Gori
   module Tui
     alias Color = Termisu::Color
     alias Attribute = Termisu::Attribute
+
+    # Construct the terminal, turning the "no controlling terminal" failure into a clean
+    # message instead of a raw backtrace. Termisu opens /dev/tty directly (independent of
+    # STDIN/STDOUT redirection), and raises when there is none — CI, or a detached /
+    # background job. `hint` tails the message with how to run interactively. Every
+    # interactive entrypoint (the TUI and `gori wizard`) goes through here so the guard
+    # lives at the one shared construction point.
+    def self.open_terminal(hint : String) : Termisu
+      Termisu.new
+    rescue IO::Error
+      abort "gori: requires an interactive terminal (no /dev/tty) — #{hint}"
+    end
   end
 end
 


### PR DESCRIPTION
## Summary

Reviewed all 13 reported behavior/bug items and fixed the ones that were clear,
well-scoped, and low-risk. Each fix is its own commit. The remaining items are
genuinely architectural or by-design in delicate code (proxy/h2, fiber model,
TUI hint plumbing) — those are documented below with rationale rather than
half-fixed.

Build clean, `crystal tool format` clean, no new `ameba` findings, full suite
**908 examples, 0 failures**. CLI changes smoke-tested by hand.

## Fixed

| Item | Fix | Commit |
|---|---|---|
| 1 — `flag:` QL filter silently matched nothing | `flag:` has no backing store (`Store#flags_for` is a stub), so it's no longer a documented field — it free-texts like any other unknown field instead of advertising a dead filter | `fix(ql): …` |
| 2 — unknown QL field dropped its prefix on fallback | Free-text the **whole token** (e.g. `hosst:x`), matching `regex_cond`'s fallback; a typo now searches what was typed and self-evidently matches nothing | `fix(ql): …` |
| 3 — Param Miner reflection false positives on echo APIs | Per-location control now detects **reflect-all** (bogus values echoed back) separately from metric reaction; reflection findings are suppressed on echo endpoints, with a baseline warning | `fix(miner): …` |
| 4 — `gori wizard` / `settings --edit` hang with no TTY | Both require an interactive `STDIN`/`STDOUT` TTY and abort with a clear message (settings points at the non-interactive path) | `fix(cli): …` |
| 5 — `gori update` stub printed misleading text | Real guidance: build-from-source, releases page, Homebrew-when-published; dropped `[placeholder]` markers | `fix(cli): …` |
| 6 — `gori mcp` silently served a default/empty DB | Logs the implicit `--db`/`--project` fallback and an empty-database warning to **STDERR** (STDOUT stays JSON-RPC clean) | `fix(mcp): …` |
| 9 — misleading WS-replay deflate note | Docstring now states both limitations accurately (sequential, not interleaved; no permessage-deflate, relay stores payloads undecompressed) + the workaround | `docs(replay): …` |
| 10 — silent Firefox CA skip without certutil | Warning now spells out that HTTPS will show cert errors, not just "install certutil" | `fix(browser): …` |

New regression tests cover items 2, 3 (echo-endpoint suppression + warning).

## Deferred (with rationale)

These were investigated and are **not** quick/safe fixes:

- **7 / 13 — HTTP/2 & SSE streaming surfaces only on half-close.** The raw
  frames are already captured live; only the *projected* flow row is delayed.
  Emitting early needs a new partial/streaming `FlowState`, keeping streams
  alive past first emit, re-emitting on `END_STREAM`, and replay/diff/TUI
  handling of a streaming row — a real feature in the delicate h2 assembler,
  not a small change. SSE bodies are already bounded at the 8 MiB capture cap,
  so the "unbounded memory" concern doesn't apply. Documented as v1 scope in
  `assembler.cr`.
- **8 — hotkey rebinds not reflected in hints/Help.** Documented limitation in
  `hotkeys.cr`. Fixing it means routing ~100+ hardcoded hint strings across
  ~15 files through the live keymap — a dedicated refactor.
- **11 — interceptor ghost items on client disconnect.** The proxy fiber is
  *blocked* inside `hold` on `reply.receive`, so a `ClientConn#run` `ensure`
  cleanup can't fire while an item is held. A correct fix needs cancellable
  holds (watch the client socket while parked) — architectural, and the current
  failure mode is low-harm (a forward to a dead socket is already caught).
- **12 — scope regex is case-sensitive.** Intentional, for memory↔SQLite
  `REGEXP` parity; the `(?i)` inline flag is the documented escape hatch.
  Changing the default would silently alter existing users' precise rules.

## Test plan

- `crystal build src/main.cr -o bin/gori` — clean
- `crystal tool format` — clean; `ameba` — no new findings (2 pre-existing
  complexity warnings on untouched methods)
- `crystal spec` — 908 examples, 0 failures
- Manual: `gori update`, `gori --help`, `gori settings --edit </dev/null`,
  `gori wizard </dev/null`, `gori mcp` on a fresh empty `GORI_HOME`
