### PR TITLE
fix(tui): make Fuzzer/Miner reachable from the command palette

### DIFF
--- a/spec/tui/palette_spec.cr
+++ b/spec/tui/palette_spec.cr
@@ -75,6 +75,27 @@ describe Gori::Tui::PaletteState do
     backend.contains?("soon").should be_true # the placeholder badge
   end
 
+  it "registers a Global 'Go to' jump for every catalog tab so each is palette-reachable" do
+    r = Gori::Verbs.registry
+    # The named tab jumps are the only by-command way to reach a tab hidden in
+    # settings:tabs — so every entry in the canonical catalog (incl. the default-hidden
+    # Fuzzer/Miner/Agent) must have one, or it becomes unreachable from the palette.
+    Gori::Tui::Chrome::TABS.each do |(tab, label)|
+      verb = r["tab.#{tab}"]?
+      verb.should_not be_nil
+      verb.not_nil!.title.should eq("Go to #{label}")
+      verb.not_nil!.scope.should eq(Gori::Verb::Scope::Global)
+    end
+  end
+
+  it "surfaces the Fuzzer tab jump when the palette is filtered by 'fuzz'" do
+    ctx = FakeExecContext.new
+    palette = PaletteState.new(Gori::Verbs.registry)
+    palette.reset(ctx)
+    "fuzz".each_char { |c| palette.append(c, ctx) }
+    palette.results.map(&.id).should contain("tab.fuzzer")
+  end
+
   it "categorizes Global verbs so the palette can group them by kind" do
     r = Gori::Verbs.registry
     r["tab.history"].category.should eq(Gori::Verb::Category::Navigation)

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -112,7 +112,11 @@ module Gori::Tui
     # --- input ---
     def handle_body_key(ev : Termisu::Event::Key) : Bool
       v = current_view
-      return true if v.nil?
+      # No session yet (empty tab placeholder): there's nothing to edit or navigate, so
+      # defer EVERY key to the central handler rather than swallowing it. Otherwise the
+      # empty Fuzzer tab is an input dead-end — ^P (palette), escape (back to the bar),
+      # digit jumps and space all get eaten. ^N (new session) is intercepted upstream.
+      return false if v.nil?
       # space opens the action menu in the navigable results pane; the editor panes
       # (target/template/config) take it as a literal char, so gate on :results.
       if v.focus == :results && ev.key.space? && !ev.ctrl? && !ev.alt?

--- a/src/gori/tui/controllers/miner_controller.cr
+++ b/src/gori/tui/controllers/miner_controller.cr
@@ -96,7 +96,10 @@ module Gori::Tui
     # --- input ---
     def handle_body_key(ev : Termisu::Event::Key) : Bool
       v = current_view
-      return true if v.nil?
+      # No session yet (empty tab placeholder): defer EVERY key to the central handler
+      # instead of swallowing it, so the empty Miner tab isn't an input dead-end (^P
+      # palette, escape, digit jumps, space all stay live). New runs start upstream.
+      return false if v.nil?
       if v.focus == :results && ev.key.space? && !ev.ctrl? && !ev.alt?
         @host.open_space_menu
         return true

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -162,11 +162,14 @@ module Gori
       end
 
       # Named tab jumps (no chord) — palette discoverability + the only by-command way to
-      # reach a tab hidden in settings:tabs (focus_tab force-shows it while active).
+      # reach a tab hidden in settings:tabs (focus_tab force-shows it while active). Keep
+      # this list in sync with Tui::Chrome::TABS so every catalog tab — including the
+      # default-hidden ones (Miner, Agent) — stays reachable from the command palette.
       {
-        :project => "Project", :history => "History", :intercept => "Intercept", :sitemap => "Sitemap",
-        :replay => "Replay", :comparer => "Comparer", :findings => "Findings", :notes => "Notes",
-        :convert => "Convert", :agent => "Agent", :help => "Help",
+        :project => "Project", :sitemap => "Sitemap", :history => "History", :intercept => "Intercept",
+        :replay => "Replay", :fuzzer => "Fuzzer", :miner => "Miner", :convert => "Convert",
+        :comparer => "Comparer", :findings => "Findings", :notes => "Notes", :agent => "Agent",
+        :help => "Help",
       }.each do |tab, label|
         r.register Verb::Definition.new(
           "tab.#{tab}", "Go to #{label}", "Focus the #{label} tab", Verb::Scope::Global,


### PR DESCRIPTION
## What

The Fuzzer (and Miner) tab could not be searched or entered via the `^P` command palette. This fixes that, plus a related input dead-end found while verifying.

## Root causes

**1. Palette discoverability** — `src/gori/verbs/core.cr` holds a hand-maintained map of named "Go to X" tab-jump verbs. This is the *only* by-command way to reach a tab hidden in `settings:tabs` (`focus_tab` force-shows it while active). The map simply **omitted `:fuzzer` and `:miner`**, so neither appeared in the palette. Added both; reordered the literal to mirror `Tui::Chrome::TABS` so it can be audited against drift.

**2. Empty-tab input dead-end** — `FuzzerController#handle_body_key` (and `MinerController`) did `return true if v.nil?`, swallowing **every** key when the tab had zero sessions. Because `focus_tab` lands focus on `:body` and `focus_first` no-ops on a nil view, an empty Fuzzer/Miner tab trapped `^P`/escape/digits/space with no way out. (Replay never hit this — its empty state forces `:menu` focus.) Fix: `return false if v.nil?` so all keys defer to the central handler (`^P`→`app.palette`, escape→`body.to-menu`, digits→`nav.pos`, space→space menu) — matching the existing "unconsumed ctrl/alt → keymap verb" convention. `^N` (new session) is intercepted upstream in the Runner, so it still works.

## Verification

- tmux TUI flow: `^P` → "fuzz" surfaces **Go to Fuzzer** → Enter enters the tab → `^P` re-opens the palette from the empty body, Esc pops to the tab bar, digit jumps to other tabs.
- `crystal spec`: **910 examples, 0 failures** (added 2 regression tests in `palette_spec.cr` asserting a `tab.<sym>` jump exists for every catalog tab and that "fuzz" surfaces `tab.fuzzer`).