### PR TITLE
feat(prism): harden scanner + split checks into one-rule-per-file

### DIFF
--- a/spec/prism_spec.cr
+++ b/spec/prism_spec.cr
@@ -14,18 +14,37 @@ private def with_store(&)
 end
 
 # Insert a flow + response and return its full FlowDetail (what the analyzer feeds Passive).
+# `req_headers` is raw extra request-header lines (each ending \r\n); `req_body` the request body.
 private def capture_flow(store, resp_head : String, *, scheme = "https", host = "acme.test",
                          target = "/", status = 200, content_type : String? = "text/html",
-                         body : String? = nil) : Gori::Store::FlowDetail
+                         body : String? = nil, method = "GET", req_headers = "",
+                         req_body : String? = nil) : Gori::Store::FlowDetail
+  head = String.build do |io|
+    io << method << " " << target << " HTTP/1.1\r\nHost: " << host << "\r\n" << req_headers << "\r\n"
+  end
   req = Gori::Store::CapturedRequest.new(
     created_at: 1_000_i64, scheme: scheme, host: host, port: scheme == "https" ? 443 : 80,
-    method: "GET", target: target, http_version: "HTTP/1.1",
-    head: "GET #{target} HTTP/1.1\r\nHost: #{host}\r\n\r\n".to_slice, body: nil)
+    method: method, target: target, http_version: "HTTP/1.1",
+    head: head.to_slice, body: req_body.try(&.to_slice))
   id = store.insert_flow(req)
   store.update_response(Gori::Store::CapturedResponse.new(
     flow_id: id, status: status, head: resp_head.to_slice, body: body.try(&.to_slice),
     reason: "OK", content_type: content_type, duration_us: 1_i64))
   store.get_flow(id).not_nil!
+end
+
+# Run passive analysis on one flow and return the detections (ungrouped).
+private def analyze(store, **kw) : Array(Gori::Prism::Detection)
+  Gori::Prism::Passive.analyze(capture_flow(store, **kw))
+end
+
+private def codes_of(dets : Array(Gori::Prism::Detection)) : Array(String)
+  dets.map(&.code)
+end
+
+private def make_issue(code, host = "acme.test") : Gori::Store::PrismIssue
+  Gori::Store::PrismIssue.new(1_i64, code, "headers", host, "t",
+    Gori::Store::Severity::Low, Gori::Store::Status::Open, 1_i64, [] of String, nil, nil, 1_i64, 1_i64)
 end
 
 private def codes(store) : Array(String)
@@ -143,5 +162,242 @@ describe Gori::Prism::Mode do
     Gori::Prism::Mode.from_setting(nil).should eq(Gori::Prism::Mode::Passive)
     Gori::Prism::Mode::Off.cycle.should eq(Gori::Prism::Mode::Passive)
     Gori::Prism::Mode::Active.cycle.should eq(Gori::Prism::Mode::Off)
+  end
+end
+
+describe "Gori::Prism::Passive (FP reduction)" do
+  it "does not flag a dotted version string in a JS bundle as a private IP" do
+    with_store do |store|
+      js = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n",
+        content_type: "application/javascript", body: "const VERSION='10.15.2.3';")
+      codes_of(js).should_not contain("private_ip_leak")
+      # ...but a genuine private IP in an HTML body IS flagged.
+      html = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n",
+        content_type: "text/html", body: "<p>backend at 10.0.0.5</p>")
+      html.find(&.code.==("private_ip_leak")).not_nil!.evidence.should eq("10.0.0.5")
+    end
+  end
+
+  it "does not treat a 5-segment version (10.1.2.3.4) as a private IP" do
+    with_store do |store|
+      dets = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n",
+        content_type: "text/html", body: "<span>build 10.1.2.3.4 ok</span>")
+      codes_of(dets).should_not contain("private_ip_leak")
+    end
+  end
+
+  it "does not flag prose containing a bare '.rb:' but flags a real backtrace frame" do
+    with_store do |store|
+      prose = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n",
+        content_type: "text/html", body: "Edit the helper.rb: add a method.")
+      codes_of(prose).should_not contain("error_stack_leak")
+      trace = analyze(store, resp_head: "HTTP/1.1 500 Server Error\r\n\r\n", status: 500,
+        content_type: "text/html", body: "app/models/user.rb:42:in `save'")
+      codes_of(trace).should contain("error_stack_leak")
+    end
+  end
+
+  it "does not flag unsafe-inline confined to style-src, but does for script-src" do
+    with_store do |store|
+      safe = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Security-Policy: " \
+                                       "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'\r\n\r\n",
+        content_type: "text/html")
+      codes_of(safe).should_not contain("weak_csp")
+      weak = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Security-Policy: " \
+                                       "default-src 'self'; script-src 'self' 'unsafe-inline'\r\n\r\n",
+        content_type: "text/html")
+      codes_of(weak).should contain("weak_csp")
+    end
+  end
+
+  it "still demands X-Frame-Options when CSP frame-ancestors is permissive (*)" do
+    with_store do |store|
+      permissive = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Security-Policy: " \
+                                             "default-src 'self'; frame-ancestors *\r\n\r\n",
+        content_type: "text/html")
+      codes_of(permissive).should contain("missing_x_frame_options")
+      restrictive = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Security-Policy: " \
+                                              "default-src 'self'; frame-ancestors 'self'\r\n\r\n",
+        content_type: "text/html")
+      codes_of(restrictive).should_not contain("missing_x_frame_options")
+    end
+  end
+
+  it "does not fingerprint an Elasticsearch query-DSL body as GraphQL" do
+    with_store do |store|
+      es = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", target: "/api/search",
+        method: "POST", req_headers: "Content-Type: application/json\r\n",
+        req_body: %({"query":{"match":{"name":"x"}}}), content_type: nil)
+      codes_of(es).should_not contain("tech_graphql")
+      gql = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", target: "/api/gw",
+        method: "POST", req_headers: "Content-Type: application/json\r\n",
+        req_body: %({"query":"{ me { id } }"}), content_type: nil)
+      codes_of(gql).should contain("tech_graphql")
+    end
+  end
+end
+
+describe "Gori::Prism::Passive (secret in URL)" do
+  it "matches hyphen/underscore/case variants and benign-named JWT values" do
+    with_store do |store|
+      hyphen = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n",
+        target: "/cb?access-token=abc", content_type: nil)
+      hit = hyphen.find(&.code.==("secret_in_url")).not_nil!
+      hit.severity.should eq(Gori::Store::Severity::High)
+      hit.evidence.should eq("access-token")
+
+      jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.sigsigsig"
+      under_benign = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n",
+        target: "/p?t=#{jwt}", content_type: nil)
+      under_benign.find(&.code.==("secret_in_url")).not_nil!
+        .severity.should eq(Gori::Store::Severity::High)
+    end
+  end
+
+  it "rates signed-URL params Low and ignores benign code/key params" do
+    with_store do |store|
+      sig = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", target: "/dl?sig=xyz", content_type: nil)
+      sig.find(&.code.==("secret_in_url")).not_nil!.severity.should eq(Gori::Store::Severity::Low)
+      benign = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n",
+        target: "/list?code=42&key=pubMapsKey&page=2", content_type: nil)
+      codes_of(benign).should_not contain("secret_in_url")
+    end
+  end
+end
+
+describe "Gori::Prism::Passive (new patterns)" do
+  it "flags reflected-origin CORS with credentials as High but stays quiet without them" do
+    with_store do |store|
+      reflected = analyze(store,
+        resp_head: "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: https://evil.example\r\n" \
+                   "Access-Control-Allow-Credentials: true\r\n\r\n",
+        req_headers: "Origin: https://evil.example\r\n", content_type: nil)
+      hit = reflected.find(&.code.==("cors_reflected_origin")).not_nil!
+      hit.severity.should eq(Gori::Store::Severity::High)
+
+      no_creds = analyze(store,
+        resp_head: "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: https://evil.example\r\n\r\n",
+        req_headers: "Origin: https://evil.example\r\n", content_type: nil)
+      codes_of(no_creds).should_not contain("cors_reflected_origin")
+
+      # A server echoing its OWN origin (same host) with credentials is legitimate — not flagged.
+      same_origin = analyze(store, host: "acme.test",
+        resp_head: "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: https://acme.test\r\n" \
+                   "Access-Control-Allow-Credentials: true\r\n\r\n",
+        req_headers: "Origin: https://acme.test\r\n", content_type: nil)
+      codes_of(same_origin).should_not contain("cors_reflected_origin")
+    end
+  end
+
+  it "flags the null CORS origin" do
+    with_store do |store|
+      dets = analyze(store,
+        resp_head: "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: null\r\n\r\n", content_type: nil)
+      codes_of(dets).should contain("cors_null_origin")
+    end
+  end
+
+  it "flags a credential leaked in the response body (type only, never the value)" do
+    with_store do |store|
+      dets = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", content_type: "text/html",
+        body: %({"aws":"AKIAIOSFODNN7EXAMPLE"}))
+      hit = dets.find(&.code.==("secret_in_body")).not_nil!
+      hit.severity.should eq(Gori::Store::Severity::High)
+      hit.evidence.should eq("AWS access key id")
+      hit.evidence.not_nil!.should_not contain("AKIA") # never the secret itself
+    end
+  end
+
+  it "treats HSTS max-age=0 as disabled but a long max-age as present" do
+    with_store do |store|
+      disabled = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nStrict-Transport-Security: max-age=0\r\n\r\n",
+        content_type: "text/html")
+      codes_of(disabled).should contain("missing_hsts")
+      present = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nStrict-Transport-Security: max-age=31536000\r\n\r\n",
+        content_type: "text/html")
+      codes_of(present).should_not contain("missing_hsts")
+    end
+  end
+
+  it "flags SameSite=None cookies missing Secure" do
+    with_store do |store|
+      insecure = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nSet-Cookie: sid=x; SameSite=None\r\n\r\n",
+        content_type: "text/html")
+      codes_of(insecure).should contain("cookie_samesite_none_insecure")
+      ok = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nSet-Cookie: sid=x; SameSite=None; Secure\r\n\r\n",
+        content_type: "text/html")
+      codes_of(ok).should_not contain("cookie_samesite_none_insecure")
+      codes_of(ok).should_not contain("cookie_no_samesite")
+    end
+  end
+
+  it "still flags a cookie literally named 'samesite' as missing the attribute" do
+    with_store do |store|
+      dets = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nSet-Cookie: samesite=1; Path=/\r\n\r\n",
+        content_type: "text/html")
+      hit = dets.find(&.code.==("cookie_no_samesite")).not_nil!
+      hit.evidence.should eq("samesite")
+    end
+  end
+end
+
+describe "Gori::Prism::Active (safety + coverage)" do
+  it "does not probe mutating methods (POST), only safe ones (GET)" do
+    with_store do |store|
+      post = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/comment", method: "POST",
+        req_headers: "Content-Type: application/x-www-form-urlencoded\r\n", req_body: "text=hi", content_type: nil)
+      Gori::Prism::Active.plan(post).should be_nil
+      get = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=hi", content_type: nil)
+      Gori::Prism::Active.plan(get).should_not be_nil
+    end
+  end
+
+  it "keys the dedup signature by method and parameter location" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=hi", content_type: nil)
+      key = Gori::Prism::Active.plan(detail).not_nil!.dedup_key
+      key.should contain("GET")
+      key.should contain("q@query")
+    end
+  end
+
+  it "detects a canary reflected ONLY in a response header (e.g. Location)" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/go?url=here", content_type: nil)
+      plan = Gori::Prism::Active.plan(detail).not_nil!
+      canary = plan.params.first.canary
+      result = Gori::Replay::Result.new(
+        "HTTP/1.1 302 Found\r\nLocation: https://site/?url=#{canary}\r\n\r\n".to_slice,
+        Bytes.empty, nil, 1_i64)
+      dets = Gori::Prism::Active.detections(plan, result, detail)
+      dets.size.should eq(1)
+      dets.first.code.should eq("reflected_param")
+    end
+  end
+
+  it "rates an HTML reflection Medium and a non-HTML (JSON) reflection Low" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=hi", content_type: nil)
+      plan = Gori::Prism::Active.plan(detail).not_nil!
+      canary = plan.params.first.canary
+      html = Gori::Replay::Result.new(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n".to_slice,
+        "<p>#{canary}</p>".to_slice, nil, 1_i64)
+      Gori::Prism::Active.detections(plan, html, detail).first.severity.should eq(Gori::Store::Severity::Medium)
+      json = Gori::Replay::Result.new(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n".to_slice,
+        %({"q":"#{canary}"}).to_slice, nil, 1_i64)
+      Gori::Prism::Active.detections(plan, json, detail).first.severity.should eq(Gori::Store::Severity::Low)
+    end
+  end
+end
+
+describe "Gori::Prism::Filter (incomplete terms)" do
+  it "treats a mid-typed negated field term as a no-op (does not blank the list)" do
+    issues = [make_issue("missing_csp"), make_issue("missing_hsts")]
+    Gori::Prism::Filter.parse("-host:").apply(issues).size.should eq(2)
+    Gori::Prism::Filter.parse("host:").apply(issues).size.should eq(2)
+    # a complete negated term still filters
+    Gori::Prism::Filter.parse("-code:csp").apply(issues).map(&.code).should eq(["missing_hsts"])
   end
 end

--- a/src/gori/prism/active.cr
+++ b/src/gori/prism/active.cr
@@ -1,163 +1,25 @@
-require "uri"
-require "json"
-require "./issue"
-require "../miner/types"
-require "../miner/inject"
-require "../fuzz/engine"
-require "../fuzz/content_length"
-require "../proxy/codec/http1"
-require "../proxy/codec/content_decode"
+require "./active/types"
+require "./active/reflected_param"
 
 module Gori
   module Prism
-    # The lightweight active check: reflected parameters. For one in-scope flow it replaces
-    # each existing parameter value (query / form / JSON) with a distinct canary, sends ONE
-    # request, and reports the parameters whose canary echoes back unencoded (XSS candidates).
-    # Pure: depends only on the Fuzz sender, the codec, and the body decoder — no Store/TUI.
+    # The lightweight active scanner. Each check is a self-contained `Active::Rule` in its own
+    # file under `active/`; the analyzer iterates RULES, sending each rule's probe and folding
+    # its detections. To add a check: drop a new `Rule` subclass in `active/` and append it here.
     module Active
-      BODY_CAP   = 64 * 1024
-      MAX_PARAMS = 50 # don't probe pathological param sets (request-size / canary budget)
+      # The primary rule, reused for the registry AND the module-level facade.
+      PRIMARY = ReflectedParam.new
 
-      record Param, location : String, name : String, canary : String
+      RULES = [PRIMARY] of Rule
 
-      # A built probe: the canary-stuffed request bytes, the canary↔param map, and the
-      # dedup key the analyzer uses to probe each (host, path, param-set) only once.
-      record Plan, request : Bytes, params : Array(Param), dedup_key : String
-
-      # Build a probe from a captured flow, or nil if there is nothing reflectable.
+      # Convenience facade over the primary (reflected-param) rule. The analyzer drives the
+      # whole RULES list; these keep a stable single-rule entry point for callers/tests.
       def self.plan(detail : Store::FlowDetail) : Plan?
-        req = Proxy::Codec::Http1.parse_request_head(detail.request_head)
-        return nil if req.malformed?
-        path, query = split_target(req.target)
-
-        params = [] of Param
-        new_query, qp = canary_pairs(query, "query")
-        params.concat(qp)
-
-        body = detail.request_body
-        new_body = body
-        if body && !body.empty?
-          ct = (req.headers.get?("Content-Type") || "").downcase
-          if ct.includes?("x-www-form-urlencoded")
-            nb, fp = canary_pairs(String.new(body).scrub, "form")
-            params.concat(fp)
-            new_body = nb.to_slice
-          elsif ct.includes?("json")
-            nb, jp = canary_json(body)
-            if nb
-              params.concat(jp)
-              new_body = nb
-            end
-          end
-        end
-
-        return nil if params.empty? || params.size > MAX_PARAMS
-        request = rebuild(detail.request_head, body, req.target, path, new_query, new_body)
-        key = "#{detail.row.host}|#{path}|#{params.map(&.name).sort!.join(",")}"
-        Plan.new(request, params, key)
+        PRIMARY.plan(detail)
       end
 
-      # Send the probe and return any reflected-parameter Detection (one grouped row per host).
       def self.detections(plan : Plan, result : Replay::Result, detail : Store::FlowDetail) : Array(Detection)
-        reflected = reflections(result, plan.params)
-        return [] of Detection if reflected.empty?
-        names = reflected.map { |p| "#{p.name} (#{p.location})" }
-        names.uniq!
-        url = "#{detail.row.scheme}://#{detail.row.host}#{detail.row.target}"
-        [Detection.new("reflected_param", Category::ACTIVE, detail.row.host, url,
-          "Reflected parameter", Store::Severity::Medium, names.join(", ")[0, 120], detail.row.id)]
-      end
-
-      private def self.reflections(result : Replay::Result, params : Array(Param)) : Array(Param)
-        return [] of Param unless result.ok?
-        decoded, _ = Proxy::Codec::ContentDecode.decode(result.head, result.body)
-        bytes = decoded || result.body
-        return [] of Param if bytes.nil? || bytes.empty?
-        text = String.new(bytes[0, {bytes.size, BODY_CAP}.min]).scrub
-        params.select { |p| text.includes?(p.canary) }
-      end
-
-      # {path, query-without-'?'} — query is "" when the target has none.
-      private def self.split_target(target : String) : {String, String}
-        qi = target.index('?')
-        return {target, ""} unless qi
-        {target[0...qi], target[(qi + 1)..]}
-      end
-
-      # Replace every k=v value in an &-joined string with a fresh canary, keeping bare flags
-      # and empty segments verbatim. Returns {rebuilt string, params}.
-      private def self.canary_pairs(text : String, location : String) : {String, Array(Param)}
-        params = [] of Param
-        return {text, params} if text.empty?
-        rebuilt = text.split('&').map do |pair|
-          next pair if pair.empty?
-          eq = pair.index('=')
-          next pair unless eq
-          name = pair[0...eq]
-          next pair if name.empty?
-          canary = Miner::Canary.fresh
-          params << Param.new(location, decode_name(name), canary)
-          "#{name}=#{canary}"
-        end.join('&')
-        {rebuilt, params}
-      end
-
-      private def self.decode_name(name : String) : String
-        URI.decode_www_form(name)
-      rescue
-        name
-      end
-
-      # Replace top-level JSON string values with canaries; nil unless the root is an object
-      # with at least one string field.
-      private def self.canary_json(body : Bytes) : {Bytes?, Array(Param)}
-        params = [] of Param
-        h = begin
-          JSON.parse(String.new(body).scrub).as_h?
-        rescue JSON::ParseException
-          nil
-        end
-        return {nil, params} unless h
-        merged = {} of String => JSON::Any
-        h.each do |k, v|
-          if v.as_s?
-            canary = Miner::Canary.fresh
-            params << Param.new("json", k, canary)
-            merged[k] = JSON::Any.new(canary)
-          else
-            merged[k] = v
-          end
-        end
-        return {nil, params} if params.empty?
-        {merged.to_json.to_slice, params}
-      end
-
-      # Reassemble the request with the canary-stuffed request-line + body, re-syncing
-      # Content-Length when the body changed.
-      private def self.rebuild(orig_head : Bytes, orig_body : Bytes?, orig_target : String,
-                               path : String, new_query : String, new_body : Bytes?) : Bytes
-        combined = if orig_body && !orig_body.empty?
-                     io = IO::Memory.new(orig_head.size + orig_body.size)
-                     io.write(orig_head)
-                     io.write(orig_body)
-                     io.to_slice
-                   else
-                     orig_head
-                   end
-        head, _, eol = Miner::Inject.split(combined)
-        lines = String.new(head).split(eol)
-        unless lines.empty?
-          parts = lines[0].split(' ')
-          if parts.size == 3
-            new_target = new_query.empty? ? path : "#{path}?#{new_query}"
-            lines[0] = "#{parts[0]} #{new_target} #{parts[2]}"
-          end
-        end
-        io = IO::Memory.new
-        io << lines.join(eol) << eol << eol
-        body = new_body || Bytes.empty
-        io.write(body) unless body.empty?
-        Fuzz::ContentLength.sync(io.to_slice, false)
+        PRIMARY.detections(plan, result, detail)
       end
     end
   end

--- a/src/gori/prism/active/reflected_param.cr
+++ b/src/gori/prism/active/reflected_param.cr
@@ -1,0 +1,179 @@
+require "uri"
+require "json"
+require "./types"
+require "../../miner/types"
+require "../../miner/inject"
+require "../../fuzz/engine"
+require "../../fuzz/content_length"
+require "../../proxy/codec/http1"
+require "../../proxy/codec/content_decode"
+
+module Gori
+  module Prism
+    module Active
+      # Reflected parameters. For one in-scope flow it replaces each existing parameter value
+      # (query / form / JSON) with a distinct canary, sends ONE request, and reports the
+      # parameters whose canary echoes back unencoded (XSS candidates). Gated to safe methods
+      # so an automatic probe never mutates server state.
+      class ReflectedParam < Rule
+        # Build a probe from a captured flow, or nil if there is nothing reflectable.
+        def plan(detail : Store::FlowDetail) : Plan?
+          req = Proxy::Codec::Http1.parse_request_head(detail.request_head)
+          return nil if req.malformed?
+          return nil unless SAFE_METHODS.includes?(req.method.upcase)
+          path, query = split_target(req.target)
+
+          params = [] of Param
+          new_query, qp = canary_pairs(query, "query")
+          params.concat(qp)
+
+          body = detail.request_body
+          new_body = body
+          if body && !body.empty?
+            ct = (req.headers.get?("Content-Type") || "").downcase
+            if ct.includes?("x-www-form-urlencoded")
+              nb, fp = canary_pairs(String.new(body).scrub, "form")
+              params.concat(fp)
+              new_body = nb.to_slice
+            elsif ct.includes?("json")
+              nb, jp = canary_json(body)
+              if nb
+                params.concat(jp)
+                new_body = nb
+              end
+            end
+          end
+
+          return nil if params.empty? || params.size > MAX_PARAMS
+          request = rebuild(detail.request_head, body, req.target, path, new_query, new_body)
+          # Key by rule + host + METHOD + path + (name@location) so the same path on a different
+          # method or parameter location is a distinct surface (no collision across rules either).
+          sig = params.map { |p| "#{p.name}@#{p.location}" }.sort!.join(",")
+          key = "reflected_param|#{detail.row.host}|#{req.method.upcase}|#{path}|#{sig}"
+          Plan.new(request, params, key)
+        end
+
+        # Interpret the probe's response: any reflected-parameter Detection (one grouped row per host).
+        def detections(plan : Plan, result : Replay::Result, detail : Store::FlowDetail) : Array(Detection)
+          reflected = reflections(result, plan.params)
+          return [] of Detection if reflected.empty?
+          names = reflected.map { |p| "#{p.name} (#{p.location})" }
+          names.uniq!
+          url = "#{detail.row.scheme}://#{detail.row.host}#{detail.row.target}"
+          # An echo in an HTML response is a plausible XSS sink (Medium); an echo in a non-HTML
+          # response (JSON/text API) is just a reflected value, not exploitable as XSS (Low).
+          html = response_content_type(result).includes?("html")
+          sev = html ? Store::Severity::Medium : Store::Severity::Low
+          title = html ? "Reflected parameter" : "Reflected parameter (non-HTML context)"
+          [Detection.new("reflected_param", Category::ACTIVE, detail.row.host, url,
+            title, sev, names.join(", ")[0, 120], detail.row.id)]
+        end
+
+        # Scan BOTH the response head (reflected Location/Set-Cookie/custom headers) and the
+        # decoded body for each canary — header reflections (e.g. open-redirect Location) are
+        # invisible to a body-only scan.
+        private def reflections(result : Replay::Result, params : Array(Param)) : Array(Param)
+          return [] of Param unless result.ok?
+          head = String.new(result.head).scrub
+          decoded, _ = Proxy::Codec::ContentDecode.decode(result.head, result.body)
+          bytes = decoded || result.body
+          body = (bytes && !bytes.empty?) ? String.new(bytes[0, {bytes.size, BODY_CAP}.min]).scrub : ""
+          hay = "#{head}\n#{body}"
+          params.select { |p| hay.includes?(p.canary) }
+        end
+
+        private def response_content_type(result : Replay::Result) : String
+          if r = result.response
+            return (r.headers.get?("Content-Type") || "").downcase
+          end
+          (Proxy::Codec::Http1.parse_response_head(result.head).headers.get?("Content-Type") || "").downcase
+        rescue
+          ""
+        end
+
+        # {path, query-without-'?'} — query is "" when the target has none.
+        private def split_target(target : String) : {String, String}
+          qi = target.index('?')
+          return {target, ""} unless qi
+          {target[0...qi], target[(qi + 1)..]}
+        end
+
+        # Replace every k=v value in an &-joined string with a fresh canary, keeping bare flags
+        # and empty segments verbatim. Returns {rebuilt string, params}.
+        private def canary_pairs(text : String, location : String) : {String, Array(Param)}
+          params = [] of Param
+          return {text, params} if text.empty?
+          rebuilt = text.split('&').map do |pair|
+            next pair if pair.empty?
+            eq = pair.index('=')
+            next pair unless eq
+            name = pair[0...eq]
+            next pair if name.empty?
+            canary = Miner::Canary.fresh
+            params << Param.new(location, decode_name(name), canary)
+            "#{name}=#{canary}"
+          end.join('&')
+          {rebuilt, params}
+        end
+
+        private def decode_name(name : String) : String
+          URI.decode_www_form(name)
+        rescue
+          name
+        end
+
+        # Replace top-level JSON string values with canaries; nil unless the root is an object
+        # with at least one string field.
+        private def canary_json(body : Bytes) : {Bytes?, Array(Param)}
+          params = [] of Param
+          h = begin
+            JSON.parse(String.new(body).scrub).as_h?
+          rescue JSON::ParseException
+            nil
+          end
+          return {nil, params} unless h
+          merged = {} of String => JSON::Any
+          h.each do |k, v|
+            if v.as_s?
+              canary = Miner::Canary.fresh
+              params << Param.new("json", k, canary)
+              merged[k] = JSON::Any.new(canary)
+            else
+              merged[k] = v
+            end
+          end
+          return {nil, params} if params.empty?
+          {merged.to_json.to_slice, params}
+        end
+
+        # Reassemble the request with the canary-stuffed request-line + body, re-syncing
+        # Content-Length when the body changed.
+        private def rebuild(orig_head : Bytes, orig_body : Bytes?, orig_target : String,
+                            path : String, new_query : String, new_body : Bytes?) : Bytes
+          combined = if orig_body && !orig_body.empty?
+                       io = IO::Memory.new(orig_head.size + orig_body.size)
+                       io.write(orig_head)
+                       io.write(orig_body)
+                       io.to_slice
+                     else
+                       orig_head
+                     end
+          head, _, eol = Miner::Inject.split(combined)
+          lines = String.new(head).split(eol)
+          unless lines.empty?
+            parts = lines[0].split(' ')
+            if parts.size == 3
+              new_target = new_query.empty? ? path : "#{path}?#{new_query}"
+              lines[0] = "#{parts[0]} #{new_target} #{parts[2]}"
+            end
+          end
+          io = IO::Memory.new
+          io << lines.join(eol) << eol << eol
+          body = new_body || Bytes.empty
+          io.write(body) unless body.empty?
+          Fuzz::ContentLength.sync(io.to_slice, false)
+        end
+      end
+    end
+  end
+end

--- a/src/gori/prism/active/types.cr
+++ b/src/gori/prism/active/types.cr
@@ -1,0 +1,35 @@
+require "../issue"
+require "../../store"
+require "../../replay/engine"
+
+module Gori
+  module Prism
+    # The lightweight active scan: each rule builds ONE probe per in-scope flow, the analyzer
+    # sends it, and the rule interprets the response. Pure: rules depend only on the codec, the
+    # body decoder, and the Fuzz sender — no Store/TUI. One rule per file under `active/`;
+    # register new ones in `Active::RULES` (active.cr).
+    module Active
+      BODY_CAP   = 64 * 1024
+      MAX_PARAMS = 50 # don't probe pathological param sets (request-size / canary budget)
+
+      # Only methods WITHOUT side effects are probed. The active scan runs automatically over
+      # captured traffic, so re-sending a POST/PUT/PATCH/DELETE with canary values would cause
+      # real server-side mutations (duplicate records, messages, deletions). Reflected-XSS via
+      # query parameters — the common case — is fully covered by GET/HEAD.
+      SAFE_METHODS = Set{"GET", "HEAD"}
+
+      record Param, location : String, name : String, canary : String
+
+      # A built probe: the canary-stuffed request bytes, the canary↔param map, and the dedup key
+      # the analyzer uses to probe each (rule, host, method, path, param-set) only once.
+      record Plan, request : Bytes, params : Array(Param), dedup_key : String
+
+      # An active rule: build a probe for one flow (nil if nothing to test), then turn the
+      # probe's response into Detections. The analyzer owns the send between the two calls.
+      abstract class Rule
+        abstract def plan(detail : Store::FlowDetail) : Plan?
+        abstract def detections(plan : Plan, result : Replay::Result, detail : Store::FlowDetail) : Array(Detection)
+      end
+    end
+  end
+end

--- a/src/gori/prism/analyzer.cr
+++ b/src/gori/prism/analyzer.cr
@@ -22,7 +22,7 @@ module Gori
 
       getter events : Channel(Event)
 
-      private record ActiveTask, plan : Active::Plan, detail : Store::FlowDetail
+      private record ActiveTask, rule : Active::Rule, plan : Active::Plan, detail : Store::FlowDetail
 
       def initialize(@store : Store, @scope : Scope, @input : Channel(Store::FlowEvent),
                      @mode : Mode, @verify_upstream : Bool)
@@ -51,11 +51,13 @@ module Gori
         spawn(name: "gori-prism-active") { active_loop }
       end
 
-      # Winds the analyzer down BEFORE the store/channels close: stop accepting active work
-      # and close the active queue so its worker exits. The passive fiber exits when the
-      # input (prism_events) channel is closed by Session#close.
+      # Winds the analyzer down BEFORE the store/channels close: stop accepting active work,
+      # close the active queue so its worker exits, and close the input feed so the passive
+      # fiber unblocks and exits (this analyzer is the channel's only consumer; the store's
+      # publish side is non-blocking and guards against the close). Idempotent.
       def stop : Nil
         @stopped = true
+        @input.close
         @active_jobs.close
       rescue Channel::ClosedError
       end
@@ -70,16 +72,21 @@ module Gori
           next unless @mode.scanning?
           next unless ev.kind == :updated # analyze when the response side exists
           next if @analyzed.includes?(ev.id)
-          detail = @store.get_flow(ev.id)
-          next unless detail
-          @analyzed << ev.id
-          trim(@analyzed, ANALYZED_CAP)
-          process(detail)
+          begin
+            detail = @store.get_flow(ev.id)
+            next unless detail
+            @analyzed << ev.id
+            trim(@analyzed, ANALYZED_CAP)
+            process(detail)
+          rescue DB::Error | SQLite3::Exception
+            # A transient store error (e.g. SQLITE_BUSY) must NOT kill the scanner for the rest
+            # of the session — skip this flow and keep draining. On real shutdown the input
+            # channel is closed, so the next receive? returns nil and the loop exits cleanly.
+            next
+          end
         end
       rescue Channel::ClosedError
         # input closed during shutdown — exit quietly
-      rescue DB::Error | SQLite3::Exception
-        # store closing under a buffered event — clean shutdown, stop the fiber
       end
 
       private def process(detail : Store::FlowDetail) : Nil
@@ -90,7 +97,7 @@ module Gori
         end
         maybe_enqueue_active(detail)
       rescue ex : DB::Error | SQLite3::Exception
-        raise ex # shutdown — let passive_loop's rescue exit
+        raise ex # bubble to passive_loop's per-flow rescue (skip this flow, keep scanning)
       rescue
         # a single flow's analysis blew up — skip it, keep scanning the rest
       end
@@ -103,17 +110,23 @@ module Gori
         # Active probes ONLY configured+enabled in-scope hosts (in_scope_url? is permissive
         # when scope is inactive, so gate on active? first) — the user's "in-scope only" rule.
         return unless @scope.active? && @scope.in_scope_url?(url, row.host)
-        plan = Active.plan(detail)
+        Active::RULES.each { |rule| enqueue_probe(rule, detail) }
+      rescue Channel::ClosedError
+      end
+
+      private def enqueue_probe(rule : Active::Rule, detail : Store::FlowDetail) : Nil
+        plan = rule.plan(detail)
         return unless plan
         return if @active_seen.includes?(plan.dedup_key)
-        @active_seen << plan.dedup_key
-        trim(@active_seen, ACTIVE_SEEN_CAP)
         select
-        when @active_jobs.send(ActiveTask.new(plan, detail))
+        when @active_jobs.send(ActiveTask.new(rule, plan, detail))
+          # Record the dedup key ONLY once the task is actually queued, so a target dropped on
+          # a full queue is re-probed when its next flow arrives (not suppressed forever).
+          @active_seen << plan.dedup_key
+          trim(@active_seen, ACTIVE_SEEN_CAP)
         else
-          # queue full — drop (dedup key already recorded; a lightweight scan tolerates gaps)
+          # queue full — drop without recording; the next matching flow re-attempts.
         end
-      rescue Channel::ClosedError
       end
 
       # --- active fiber -----------------------------------------------------------------
@@ -128,12 +141,13 @@ module Gori
       end
 
       private def run_active(task : ActiveTask) : Nil
+        return if @stopped # don't fire outbound probes while winding down
         row = task.detail.row
         origin = Fuzz::Origin.new(row.scheme, row.host, row.port)
         http2 = task.detail.http_version.starts_with?("HTTP/2")
         sender = Fuzz::Sender.new(origin, http2, @verify_upstream, timeout: ACTIVE_TIMEOUT)
         result = sender.send(task.plan.request)
-        detections = Active.detections(task.plan, result, task.detail)
+        detections = task.rule.detections(task.plan, result, task.detail)
         return if detections.empty?
         detections.each { |d| @store.upsert_prism_issue(d) }
         summary = detections.first.evidence

--- a/src/gori/prism/issue.cr
+++ b/src/gori/prism/issue.cr
@@ -37,10 +37,15 @@ module Gori
       "cookie_no_secure"               => "Add the Secure attribute so the cookie is only sent over HTTPS.",
       "cookie_no_httponly"             => "Add HttpOnly so client-side script cannot read the cookie.",
       "cookie_no_samesite"             => "Add SameSite=Lax/Strict to reduce CSRF exposure.",
+      "cookie_samesite_none_insecure"  => "SameSite=None requires the Secure attribute; add Secure or use SameSite=Lax/Strict.",
       "secret_in_url"                  => "Move credentials/tokens out of the URL (they leak via logs, history, and Referer) into headers or the body.",
       "cors_wildcard"                  => "Avoid Access-Control-Allow-Origin: * for credentialed/sensitive endpoints; echo a vetted allowlisted origin instead.",
+      "cors_null_origin"               => "Never allow the null origin; it is sent by sandboxed iframes and redirects and is trivially forgeable.",
+      "cors_reflected_origin"          => "Don't blindly reflect the Origin with Allow-Credentials: true; validate it against a strict allowlist.",
       "private_ip_leak"                => "Strip internal hostnames/IPs from responses; they aid network reconnaissance.",
       "error_stack_leak"               => "Return generic errors to clients; log stack traces server-side only.",
+      "secret_in_body"                 => "Rotate the exposed credential and remove it from the response; never ship keys/tokens to clients.",
+      "mixed_content"                  => "Load all sub-resources over HTTPS; active http:// scripts/iframes on an HTTPS page are blocked and insecure.",
       "reflected_param"                => "Context-encode reflected input; this parameter echoes attacker-controlled data and may enable XSS.",
     } of String => String
 

--- a/src/gori/prism/passive.cr
+++ b/src/gori/prism/passive.cr
@@ -1,219 +1,37 @@
 require "./issue"
-require "../proxy/codec/http1"
-require "../proxy/codec/content_decode"
-require "../proxy/h2/grpc"
-require "../sse"
+require "./passive/context"
+require "./passive/rule"
+require "./passive/tech"
+require "./passive/secret_in_url"
+require "./passive/security_headers"
+require "./passive/cookies"
+require "./passive/cors"
+require "./passive/body_leaks"
 
 module Gori
   module Prism
-    # Zero-request passive checks over a single captured flow. Pure: depends only on the
-    # codec, the body decoder, and the protocol detectors — no Store/Scope/TUI. Returns the
-    # raw Detections; the analyzer folds them into grouped Store::PrismIssue rows.
+    # Zero-request passive checks over a single captured flow. Pure: depends only on the codec,
+    # the body decoder, and the protocol detectors — no Store/Scope/TUI. Each check is a self-
+    # contained `Passive::Rule` in its own file under `passive/`; `analyze` parses the flow once
+    # (Context) and runs every registered rule, returning the raw Detections. The analyzer folds
+    # them into grouped Store::PrismIssue rows.
+    #
+    # To add a check: drop a new `Rule` subclass in `passive/` and append it to RULES.
     module Passive
-      BODY_CAP = 64 * 1024 # per-side ceiling on body text fed to the string scans
-
-      # Query-param names that should never travel in a URL. Tier governs severity.
-      HIGH_PARAMS = Set{"token", "access_token", "refresh_token", "id_token", "auth_token",
-                        "secret", "client_secret", "password", "passwd", "pwd", "jwt", "apikey", "api_key"}
-      MED_PARAMS = Set{"key", "sig", "signature", "auth", "session", "sessionid", "sid", "code"}
-
-      PRIVATE_IP = /\b(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|127\.0\.0\.1)\b/
-
-      ERROR_SIGNATURES = [
-        "Traceback (most recent call last)", ".java:", "java.lang.", "ORA-0", "SQLSTATE",
-        "Fatal error:", "Stack trace:", "at System.", "System.Exception", "org.springframework",
-        "NoMethodError", "NameError", ".rb:", # Ruby/Rails
-      ]
+      RULES = [
+        Tech.new,
+        SecretInUrl.new,
+        SecurityHeaders.new,
+        Cookies.new,
+        Cors.new,
+        BodyLeaks.new,
+      ] of Rule
 
       def self.analyze(detail : Store::FlowDetail) : Array(Detection)
+        ctx = Context.new(detail)
         acc = [] of Detection
-        row = detail.row
-        url = "#{row.scheme}://#{row.host}#{row.target}"
-        req = Proxy::Codec::Http1.parse_request_head(detail.request_head)
-        resp = detail.response_head.try { |h| Proxy::Codec::Http1.parse_response_head(h) }
-
-        check_tech(acc, detail, req, resp, url)
-        check_secret_in_url(acc, req, row.host, url, row.id)
-        if resp && resp.status != 101 && resp.status != 0
-          html = !!row.content_type.try(&.downcase.includes?("text/html"))
-          check_headers(acc, resp, row.scheme, html, row.host, url, row.id)
-          check_cookies(acc, resp, row.scheme, row.host, url, row.id)
-          check_cors(acc, resp, row.host, url, row.id)
-          check_body_leaks(acc, detail, row.content_type, row.host, url, row.id)
-        end
+        RULES.each(&.check(ctx, acc))
         acc
-      end
-
-      # --- technology / protocol fingerprints (category "tech", Info) -------------------
-
-      private def self.check_tech(acc, detail, req, resp, url) : Nil
-        host = detail.row.host
-        fid = detail.row.id
-        check_protocols(acc, detail, req, resp, url, host, fid)
-        check_tech_headers(acc, resp, url, host, fid)
-      end
-
-      private def self.check_protocols(acc, detail, req, resp, url, host, fid) : Nil
-        req_ct = req.headers.get?("Content-Type")
-        resp_ct = detail.row.content_type
-        if detail.row.status == 101 && resp.try(&.headers.get?("Upgrade").try(&.downcase)) == "websocket"
-          acc << tech(host, url, fid, "tech_websocket", "WebSocket endpoint")
-        end
-        if Proxy::H2::Grpc.grpc?(req_ct) || Proxy::H2::Grpc.grpc?(resp_ct)
-          acc << tech(host, url, fid, "tech_grpc", "gRPC service")
-        end
-        acc << tech(host, url, fid, "tech_graphql", "GraphQL endpoint") if graphql?(detail, req, req_ct)
-        acc << tech(host, url, fid, "tech_sse", "Server-Sent Events stream") if Sse.event_stream?(detail.response_head)
-        if detail.http_version.starts_with?("HTTP/2") || !detail.h2_conn_id.nil?
-          acc << tech(host, url, fid, "tech_http2", "HTTP/2")
-        end
-      end
-
-      private def self.check_tech_headers(acc, resp, url, host, fid) : Nil
-        return unless r = resp
-        if (server = r.headers.get?("Server")) && !server.blank?
-          acc << tech(host, url, fid, "tech_server", "Server: #{server.strip}", server.strip)
-        end
-        if (pb = r.headers.get?("X-Powered-By")) && !pb.blank?
-          acc << tech(host, url, fid, "tech_powered_by", "X-Powered-By: #{pb.strip}", pb.strip)
-        end
-      end
-
-      private def self.graphql?(detail, req, req_ct) : Bool
-        return true if req.target.downcase.includes?("/graphql")
-        return false unless req_ct.try(&.downcase.includes?("json"))
-        body = detail.request_body
-        return false unless body
-        text = String.new(body[0, {body.size, 4096}.min]).scrub
-        text.includes?(%("query")) && text.includes?('{')
-      end
-
-      private def self.tech(host, url, fid, code, title, evidence = nil) : Detection
-        Detection.new(code, Category::TECH, host, url, title, Store::Severity::Info, evidence, fid)
-      end
-
-      # --- secrets in the URL (category "infoleak") -------------------------------------
-
-      private def self.check_secret_in_url(acc, req, host, url, fid) : Nil
-        names = query_param_names(req.target)
-        return if names.empty?
-        hit = names.find { |n| HIGH_PARAMS.includes?(n) }
-        sev = Store::Severity::High
-        unless hit
-          hit = names.find { |n| MED_PARAMS.includes?(n) }
-          sev = Store::Severity::Medium
-        end
-        return unless hit
-        acc << Detection.new("secret_in_url", Category::INFOLEAK, host, url,
-          "Sensitive parameter in URL", sev, hit, fid)
-      end
-
-      private def self.query_param_names(target : String) : Array(String)
-        qi = target.index('?')
-        return [] of String unless qi
-        query = target[(qi + 1)..]
-        query.split('&').compact_map do |pair|
-          next if pair.empty?
-          eq = pair.index('=')
-          name = eq ? pair[0...eq] : pair
-          name.downcase
-        end
-      end
-
-      # --- security response headers (category "headers") -------------------------------
-
-      private def self.check_headers(acc, resp, scheme, html, host, url, fid) : Nil
-        if scheme == "https" && resp.headers.get?("Strict-Transport-Security").nil?
-          acc << hdr(host, url, fid, "missing_hsts", "Missing HSTS header", Store::Severity::Medium)
-        end
-        check_doc_headers(acc, resp.headers, host, url, fid) if html
-      end
-
-      # Document-only header checks (gated on text/html upstream).
-      private def self.check_doc_headers(acc, h, host, url, fid) : Nil
-        csp = h.get?("Content-Security-Policy")
-        if csp.nil?
-          acc << hdr(host, url, fid, "missing_csp", "Missing Content-Security-Policy", Store::Severity::Medium)
-        elsif weak_csp?(csp)
-          acc << hdr(host, url, fid, "weak_csp", "Weak Content-Security-Policy", Store::Severity::Low, csp[0, 80])
-        end
-        if h.get?("X-Frame-Options").nil? && !(csp.try(&.downcase.includes?("frame-ancestors")))
-          acc << hdr(host, url, fid, "missing_x_frame_options", "Missing X-Frame-Options", Store::Severity::Low)
-        end
-        if h.get?("X-Content-Type-Options").try(&.downcase.strip) != "nosniff"
-          acc << hdr(host, url, fid, "missing_x_content_type_options", "Missing X-Content-Type-Options: nosniff", Store::Severity::Low)
-        end
-        if h.get?("Referrer-Policy").nil?
-          acc << hdr(host, url, fid, "missing_referrer_policy", "Missing Referrer-Policy", Store::Severity::Info)
-        end
-      end
-
-      private def self.weak_csp?(csp : String) : Bool
-        low = csp.downcase
-        low.includes?("unsafe-inline") || low.includes?("unsafe-eval") || low.includes?(" * ") ||
-          low.includes?("default-src *") || low.includes?("script-src *")
-      end
-
-      private def self.hdr(host, url, fid, code, title, sev, evidence = nil) : Detection
-        Detection.new(code, Category::HEADERS, host, url, title, sev, evidence, fid)
-      end
-
-      # --- cookie flags (category "cookies") --------------------------------------------
-
-      private def self.check_cookies(acc, resp, scheme, host, url, fid) : Nil
-        resp.headers.get_all("Set-Cookie").each do |raw|
-          eq = raw.index('=')
-          name = (eq ? raw[0...eq] : raw).strip
-          attrs = raw.split(';').map(&.strip.downcase)
-          if scheme == "https" && !attrs.includes?("secure")
-            acc << cookie(host, url, fid, "cookie_no_secure", "Cookie without Secure flag", Store::Severity::Medium, name)
-          end
-          unless attrs.includes?("httponly")
-            acc << cookie(host, url, fid, "cookie_no_httponly", "Cookie without HttpOnly flag", Store::Severity::Low, name)
-          end
-          unless attrs.any?(&.starts_with?("samesite"))
-            acc << cookie(host, url, fid, "cookie_no_samesite", "Cookie without SameSite attribute", Store::Severity::Low, name)
-          end
-        end
-      end
-
-      private def self.cookie(host, url, fid, code, title, sev, name) : Detection
-        Detection.new(code, Category::COOKIES, host, url, title, sev, name, fid)
-      end
-
-      # --- CORS (category "cors") -------------------------------------------------------
-
-      private def self.check_cors(acc, resp, host, url, fid) : Nil
-        return unless resp.headers.get?("Access-Control-Allow-Origin").try(&.strip) == "*"
-        creds = resp.headers.get?("Access-Control-Allow-Credentials").try(&.downcase.strip) == "true"
-        sev = creds ? Store::Severity::High : Store::Severity::Medium
-        acc << Detection.new("cors_wildcard", Category::CORS, host, url,
-          "Permissive CORS (Access-Control-Allow-Origin: *)", sev, creds ? "with credentials" : nil, fid)
-      end
-
-      # --- response body disclosure (category "infoleak") -------------------------------
-
-      private def self.check_body_leaks(acc, detail, ctype, host, url, fid) : Nil
-        return unless texty?(ctype)
-        decoded, _ = Proxy::Codec::ContentDecode.decode(detail.response_head, detail.response_body)
-        bytes = decoded || detail.response_body
-        return if bytes.nil? || bytes.empty?
-        text = String.new(bytes[0, {bytes.size, BODY_CAP}.min]).scrub
-        if m = PRIVATE_IP.match(text)
-          acc << Detection.new("private_ip_leak", Category::INFOLEAK, host, url,
-            "Private IP address disclosed", Store::Severity::Low, m[0], fid)
-        end
-        if sig = ERROR_SIGNATURES.find { |s| text.includes?(s) }
-          acc << Detection.new("error_stack_leak", Category::INFOLEAK, host, url,
-            "Error/stack trace disclosed", Store::Severity::Medium, sig, fid)
-        end
-      end
-
-      private def self.texty?(ctype : String?) : Bool
-        return true if ctype.nil? # unknown — be permissive (the scan is cheap)
-        low = ctype.downcase
-        low.includes?("text/") || low.includes?("json") || low.includes?("xml") ||
-          low.includes?("javascript") || low.includes?("html") || low.includes?("urlencoded")
       end
     end
   end

--- a/src/gori/prism/passive/body_leaks.cr
+++ b/src/gori/prism/passive/body_leaks.cr
@@ -1,0 +1,88 @@
+require "./rule"
+
+module Gori
+  module Prism
+    module Passive
+      # Response-body disclosures (category "infoleak", except mixed-content under "headers"):
+      # private IPs, server error/stack traces, leaked credentials, and active mixed content.
+      # Response-gated; scans the shared, decoded `ctx.body_text`.
+      class BodyLeaks < Rule
+        # Private-IP ranges with valid 0-255 octets, required to stand alone (not embedded in a
+        # longer dotted/word token). The leading/trailing guards keep multi-segment version
+        # strings such as "10.1.2.3.4" or "v10.1.2.3" out of the match.
+        PRIVATE_IP = /(?<![\w.])(?:10(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}|172\.(?:1[6-9]|2\d|3[01])(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){2}|192\.168(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){2}|127\.0\.0\.1)(?![\w.])/
+
+        # Server-side error / stack-trace signatures, each tightened to a specific frame or
+        # exception shape so generic prose (a bare ".rb:" or "at System." in docs / a source
+        # viewer) does not match. {pattern, evidence label}.
+        ERROR_SIGNATURES = [
+          {/Traceback \(most recent call last\)/, "Python traceback"},
+          {/\.(?:rb|py|php):\d+(?::in )?/, "source file:line frame"},
+          {/\bat [\w.$]+\([\w]+\.java:\d+\)/, "Java stack frame"},
+          {/(?:\n|\A)\s+at [\w.$<>]+ \([^)]*:\d+:\d+\)/, "Node.js stack frame"},
+          {/\bORA-\d{5}\b/, "Oracle error"},
+          {/\bSQLSTATE\[/, "SQL error"},
+          {/\bjava\.lang\.[A-Z]\w+(?:Error|Exception)\b/, "Java exception"},
+          {/\borg\.springframework\.[\w.]{4,}/, "Spring framework trace"},
+          {/\bSystem\.[A-Z]\w+Exception\b/, ".NET exception"},
+          {/\b(?:NoMethodError|NameError|ActiveRecord::)\b/, "Ruby/Rails error"},
+          {/(?:\n|\A)Stack trace:\s*(?:\n|#\d)/, "stack trace"},
+        ]
+
+        # High-confidence credential shapes leaked in a response body (anchored to keep FP low).
+        # The evidence is the credential TYPE — NEVER the matched value. {pattern, label}.
+        SECRET_PATTERNS = [
+          {/\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/, "AWS access key id"},
+          {/\bAIza[0-9A-Za-z_\-]{35}\b/, "Google API key"},
+          {/\bgh[pousr]_[0-9A-Za-z]{36}\b/, "GitHub token"},
+          {/\bglpat-[0-9A-Za-z_\-]{20}\b/, "GitLab token"},
+          {/\bxox[baprs]-[0-9A-Za-z\-]{10,}/, "Slack token"},
+          {/-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----/, "private key block"},
+        ]
+
+        # An active sub-resource (script/iframe) loaded over plain http on an https page —
+        # genuine active mixed content (browsers block it; it signals an insecure dependency).
+        MIXED_ACTIVE = /<(?:script|iframe)\b[^>]*\bsrc\s*=\s*["']?http:\/\//i
+
+        def check(ctx : Context, acc : Array(Detection)) : Nil
+          return unless ctx.response
+          return unless texty?(ctx.content_type)
+          text = ctx.body_text
+          return if text.nil? || text.empty?
+          # Private-IP scan skips script/style payloads, where dotted version strings dominate
+          # and produce the bulk of the false positives.
+          if !scripty?(ctx.content_type) && (m = PRIVATE_IP.match(text))
+            acc << leak(ctx, "private_ip_leak", "Private IP address disclosed", Store::Severity::Low, m[0])
+          end
+          if hit = ERROR_SIGNATURES.find { |(pat, _)| pat.matches?(text) }
+            acc << leak(ctx, "error_stack_leak", "Error/stack trace disclosed", Store::Severity::Medium, hit[1])
+          end
+          if hit = SECRET_PATTERNS.find { |(pat, _)| pat.matches?(text) }
+            acc << leak(ctx, "secret_in_body", "Credential/secret disclosed in response body", Store::Severity::High, hit[1])
+          end
+          if ctx.html? && ctx.scheme == "https" && MIXED_ACTIVE.matches?(text)
+            acc << Detection.new("mixed_content", Category::HEADERS, ctx.host, ctx.url,
+              "Active mixed content (http:// sub-resource on an HTTPS page)", Store::Severity::Low, nil, ctx.fid)
+          end
+        end
+
+        private def leak(ctx : Context, code : String, title : String, sev : Store::Severity, evidence : String?) : Detection
+          Detection.new(code, Category::INFOLEAK, ctx.host, ctx.url, title, sev, evidence, ctx.fid)
+        end
+
+        private def texty?(ctype : String?) : Bool
+          return true if ctype.nil? # unknown — be permissive (the scan is cheap)
+          low = ctype.downcase
+          low.includes?("text/") || low.includes?("json") || low.includes?("xml") ||
+            low.includes?("javascript") || low.includes?("html") || low.includes?("urlencoded")
+        end
+
+        private def scripty?(ctype : String?) : Bool
+          return false if ctype.nil?
+          low = ctype.downcase
+          low.includes?("javascript") || low.includes?("ecmascript") || low.includes?("css")
+        end
+      end
+    end
+  end
+end

--- a/src/gori/prism/passive/context.cr
+++ b/src/gori/prism/passive/context.cr
@@ -1,0 +1,83 @@
+require "../../store"
+require "../../proxy/codec/http1"
+require "../../proxy/codec/content_decode"
+
+module Gori
+  module Prism
+    module Passive
+      # Everything a passive rule needs about one captured flow, parsed/decoded ONCE and
+      # shared across rules (the request/response heads, the URL, and a lazily-decoded body
+      # text). Passing this to every rule keeps each rule self-contained and avoids re-parsing.
+      class Context
+        BODY_CAP = 64 * 1024 # per-side ceiling on body text fed to the string scans
+
+        getter detail : Store::FlowDetail
+        getter req : Proxy::Codec::RawRequest
+        getter url : String
+
+        @resp : Proxy::Codec::RawResponse?
+        @body_text : String?
+        @body_text_done = false
+
+        def initialize(@detail : Store::FlowDetail)
+          @req = Proxy::Codec::Http1.parse_request_head(@detail.request_head)
+          @resp = @detail.response_head.try { |h| Proxy::Codec::Http1.parse_response_head(h) }
+          r = @detail.row
+          @url = "#{r.scheme}://#{r.host}#{r.target}"
+        end
+
+        def row : Store::FlowRow
+          @detail.row
+        end
+
+        def host : String
+          row.host
+        end
+
+        def fid : Int64
+          row.id
+        end
+
+        def scheme : String
+          row.scheme
+        end
+
+        def content_type : String?
+          row.content_type
+        end
+
+        def html? : Bool
+          !!content_type.try(&.downcase.includes?("text/html"))
+        end
+
+        def request_origin : String?
+          @req.headers.get?("Origin")
+        end
+
+        # The parsed response head if one exists (including a 101 upgrade) — used by the tech
+        # fingerprints, which inspect upgrade/server headers regardless of status.
+        def raw_response : Proxy::Codec::RawResponse?
+          @resp
+        end
+
+        # A real, scorable HTTP response: excludes a 101 upgrade and the synthetic status 0
+        # (no response captured). The header/cookie/CORS/body rules gate on this.
+        def response : Proxy::Codec::RawResponse?
+          r = @resp
+          return nil if r.nil? || row.status == 101 || row.status == 0
+          r
+        end
+
+        # Decoded, capped, scrubbed response body text — computed once and shared by the rules
+        # that scan the body. nil when there is no body.
+        def body_text : String?
+          return @body_text if @body_text_done
+          @body_text_done = true
+          decoded, _ = Proxy::Codec::ContentDecode.decode(@detail.response_head, @detail.response_body)
+          bytes = decoded || @detail.response_body
+          @body_text = (bytes && !bytes.empty?) ? String.new(bytes[0, {bytes.size, BODY_CAP}.min]).scrub : nil
+        end
+      end
+    end
+  end
+end

--- a/src/gori/prism/passive/cookies.cr
+++ b/src/gori/prism/passive/cookies.cr
@@ -1,0 +1,40 @@
+require "./rule"
+
+module Gori
+  module Prism
+    module Passive
+      # Set-Cookie flag hygiene (category "cookies"): Secure / HttpOnly / SameSite, plus the
+      # SameSite=None-without-Secure misconfiguration. Response-gated. The name is split from
+      # the attribute segments so a cookie literally named "samesite"/"secure" can't masquerade
+      # as a flag.
+      class Cookies < Rule
+        def check(ctx : Context, acc : Array(Detection)) : Nil
+          return unless resp = ctx.response
+          resp.headers.get_all("Set-Cookie").each do |raw|
+            eq = raw.index('=')
+            name = (eq ? raw[0...eq] : raw).strip
+            flags = raw.split(';').map(&.strip.downcase)[1..]? || [] of String
+            if ctx.scheme == "https" && !flags.includes?("secure")
+              acc << cookie(ctx, "cookie_no_secure", "Cookie without Secure flag", Store::Severity::Medium, name)
+            end
+            unless flags.includes?("httponly")
+              acc << cookie(ctx, "cookie_no_httponly", "Cookie without HttpOnly flag", Store::Severity::Low, name)
+            end
+            samesite = flags.find(&.starts_with?("samesite"))
+            if samesite.nil?
+              acc << cookie(ctx, "cookie_no_samesite", "Cookie without SameSite attribute", Store::Severity::Low, name)
+            elsif samesite == "samesite=none" && !flags.includes?("secure")
+              # SameSite=None REQUIRES Secure; browsers reject the cookie otherwise.
+              acc << cookie(ctx, "cookie_samesite_none_insecure",
+                "Cookie SameSite=None without Secure", Store::Severity::Medium, name)
+            end
+          end
+        end
+
+        private def cookie(ctx : Context, code : String, title : String, sev : Store::Severity, name : String) : Detection
+          Detection.new(code, Category::COOKIES, ctx.host, ctx.url, title, sev, name, ctx.fid)
+        end
+      end
+    end
+  end
+end

--- a/src/gori/prism/passive/cors.cr
+++ b/src/gori/prism/passive/cors.cr
@@ -1,0 +1,43 @@
+require "./rule"
+
+module Gori
+  module Prism
+    module Passive
+      # CORS misconfigurations (category "cors"): wildcard, the null origin, and a credentialed
+      # reflection of a CROSS-ORIGIN request Origin (the classic exploitable case). Response-gated.
+      class Cors < Rule
+        def check(ctx : Context, acc : Array(Detection)) : Nil
+          return unless resp = ctx.response
+          acao = resp.headers.get?("Access-Control-Allow-Origin").try(&.strip)
+          return unless acao
+          creds = resp.headers.get?("Access-Control-Allow-Credentials").try(&.downcase.strip) == "true"
+          if acao == "*"
+            sev = creds ? Store::Severity::High : Store::Severity::Medium
+            acc << cors(ctx, "cors_wildcard", "Permissive CORS (Access-Control-Allow-Origin: *)",
+              sev, creds ? "with credentials" : nil)
+          elsif acao.downcase == "null"
+            sev = creds ? Store::Severity::High : Store::Severity::Medium
+            acc << cors(ctx, "cors_null_origin", "CORS allows the null origin",
+              sev, creds ? "with credentials" : nil)
+          elsif creds && (origin = ctx.request_origin) && (oh = origin_host(origin)) &&
+                oh != ctx.host.downcase && acao == origin.strip
+            # The server echoes a CROSS-ORIGIN request Origin AND allows credentials — the classic
+            # exploitable reflected-origin CORS misconfiguration. A same-origin echo (the page's
+            # own host) is legitimate and suppressed to avoid the common false positive.
+            acc << cors(ctx, "cors_reflected_origin",
+              "CORS reflects a cross-origin request Origin with credentials",
+              Store::Severity::High, origin.strip[0, 80])
+          end
+        end
+
+        private def origin_host(origin : String) : String?
+          origin.strip.match(%r{\Ahttps?://([^/:]+)}).try(&.[1].downcase)
+        end
+
+        private def cors(ctx : Context, code : String, title : String, sev : Store::Severity, evidence : String?) : Detection
+          Detection.new(code, Category::CORS, ctx.host, ctx.url, title, sev, evidence, ctx.fid)
+        end
+      end
+    end
+  end
+end

--- a/src/gori/prism/passive/rule.cr
+++ b/src/gori/prism/passive/rule.cr
@@ -1,0 +1,16 @@
+require "../issue"
+require "./context"
+
+module Gori
+  module Prism
+    module Passive
+      # A passive rule: pure, zero-request analysis of one captured flow. Each rule appends its
+      # Detections to `acc`. Rules self-gate (e.g. `return unless resp = ctx.response`), so the
+      # orchestrator just runs every registered rule in order. One rule per file under
+      # `passive/`; register new ones in `Passive::RULES` (passive.cr).
+      abstract class Rule
+        abstract def check(ctx : Context, acc : Array(Detection)) : Nil
+      end
+    end
+  end
+end

--- a/src/gori/prism/passive/secret_in_url.cr
+++ b/src/gori/prism/passive/secret_in_url.cr
@@ -1,0 +1,70 @@
+require "uri"
+require "./rule"
+
+module Gori
+  module Prism
+    module Passive
+      # Sensitive data carried in the query string (category "infoleak"): it leaks via logs,
+      # browser history, and the Referer header. Names are matched NORMALIZED (lowercased with
+      # '-'/'_' stripped) so hyphen/underscore/case variants collapse to one form, and a
+      # JWT-shaped value under ANY name is flagged regardless of the name.
+      class SecretInUrl < Rule
+        HIGH_PARAMS = Set{"token", "accesstoken", "refreshtoken", "idtoken", "authtoken",
+                          "secret", "clientsecret", "secretkey", "password", "passwd", "pwd",
+                          "jwt", "apikey", "authorization", "bearer", "sessiontoken",
+                          "privatetoken", "accesskey"}
+        MED_PARAMS = Set{"session", "sessionid", "sid"} # session identifiers
+        LOW_PARAMS = Set{"sig", "signature"}            # signed-URL params (frequently intentional)
+
+        JWT_VALUE = /\beyJ[A-Za-z0-9_\-]{6,}\.[A-Za-z0-9_\-]{6,}\.[A-Za-z0-9_\-]+/
+
+        def check(ctx : Context, acc : Array(Detection)) : Nil
+          pairs = query_pairs(ctx.req.target)
+          return if pairs.empty?
+          # A JWT-shaped value under any name is the strongest, lowest-FP signal — flag High.
+          if hit = pairs.find { |(_, v)| JWT_VALUE.matches?(v) }
+            return emit(acc, ctx, hit[0], Store::Severity::High)
+          end
+          # Otherwise rank by the name tier (High > Medium > Low); the highest present wins.
+          {Store::Severity::High => HIGH_PARAMS, Store::Severity::Medium => MED_PARAMS,
+           Store::Severity::Low => LOW_PARAMS}.each do |sev, names|
+            if hit = pairs.find { |(n, _)| names.includes?(normalize(n)) }
+              return emit(acc, ctx, hit[0], sev)
+            end
+          end
+        end
+
+        private def emit(acc : Array(Detection), ctx : Context, name : String, sev : Store::Severity) : Nil
+          acc << Detection.new("secret_in_url", Category::INFOLEAK, ctx.host, ctx.url,
+            "Sensitive parameter in URL", sev, display_name(name), ctx.fid)
+        end
+
+        # Lowercase + strip '-'/'_' so hyphen/underscore/case variants collapse to one form.
+        private def normalize(name : String) : String
+          decode(name).downcase.gsub(/[-_]/, "")
+        end
+
+        private def display_name(name : String) : String
+          decode(name).downcase
+        end
+
+        private def decode(name : String) : String
+          URI.decode_www_form(name)
+        rescue
+          name
+        end
+
+        # {name, raw value} for each query pair; bare flags carry an empty value.
+        private def query_pairs(target : String) : Array({String, String})
+          qi = target.index('?')
+          return [] of {String, String} unless qi
+          target[(qi + 1)..].split('&').compact_map do |pair|
+            next if pair.empty?
+            eq = pair.index('=')
+            eq ? {pair[0...eq], pair[(eq + 1)..]} : {pair, ""}
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/gori/prism/passive/security_headers.cr
+++ b/src/gori/prism/passive/security_headers.cr
@@ -1,0 +1,79 @@
+require "./rule"
+
+module Gori
+  module Prism
+    module Passive
+      # Security response headers (category "headers"): HSTS on HTTPS, and the document-only
+      # CSP / X-Frame-Options / X-Content-Type-Options / Referrer-Policy checks (gated on
+      # text/html upstream). Response-gated.
+      class SecurityHeaders < Rule
+        def check(ctx : Context, acc : Array(Detection)) : Nil
+          return unless resp = ctx.response
+          if ctx.scheme == "https"
+            hsts = resp.headers.get?("Strict-Transport-Security")
+            if hsts.nil? || hsts_disabled?(hsts)
+              acc << hdr(ctx, "missing_hsts", "Missing or disabled HSTS header", Store::Severity::Medium)
+            end
+          end
+          check_doc_headers(ctx, resp.headers, acc) if ctx.html?
+        end
+
+        # HSTS with no max-age, or max-age=0 (RFC 6797: instructs the UA to DROP the policy), is
+        # effectively disabled even though the header is present.
+        private def hsts_disabled?(value : String) : Bool
+          m = value.downcase.match(/max-age\s*=\s*"?(\d+)/)
+          return true if m.nil?
+          (m[1].to_i64? || 1_i64) == 0
+        end
+
+        private def check_doc_headers(ctx : Context, h, acc : Array(Detection)) : Nil
+          csp = h.get?("Content-Security-Policy")
+          if csp
+            dirs = parse_csp(csp)
+            acc << hdr(ctx, "weak_csp", "Weak Content-Security-Policy", Store::Severity::Low, csp[0, 80]) if weak_csp?(dirs)
+          else
+            dirs = nil
+            acc << hdr(ctx, "missing_csp", "Missing Content-Security-Policy", Store::Severity::Medium)
+          end
+          # A CSP frame-ancestors directive only substitutes for X-Frame-Options when it is
+          # actually restrictive (not '*').
+          fa = dirs.try(&.["frame-ancestors"]?)
+          framed_ok = fa && !fa.empty? && !fa.includes?("*")
+          if h.get?("X-Frame-Options").nil? && !framed_ok
+            acc << hdr(ctx, "missing_x_frame_options", "Missing X-Frame-Options", Store::Severity::Low)
+          end
+          if h.get?("X-Content-Type-Options").try(&.downcase.strip) != "nosniff"
+            acc << hdr(ctx, "missing_x_content_type_options", "Missing X-Content-Type-Options: nosniff", Store::Severity::Low)
+          end
+          if h.get?("Referrer-Policy").nil?
+            acc << hdr(ctx, "missing_referrer_policy", "Missing Referrer-Policy", Store::Severity::Info)
+          end
+        end
+
+        # Parse a CSP into {directive => [sources]}, all lowercased.
+        private def parse_csp(csp : String) : Hash(String, Array(String))
+          dirs = {} of String => Array(String)
+          csp.split(';').each do |segment|
+            toks = segment.strip.downcase.split(/\s+/).reject(&.empty?)
+            next if toks.empty?
+            dirs[toks[0]] = toks[1..]
+          end
+          dirs
+        end
+
+        # Weak only when the SCRIPT context (script-src, else the default-src fallback) allows
+        # unsafe-inline / unsafe-eval or a bare wildcard. `unsafe-inline` confined to style-src
+        # is a common, low-risk pattern and no longer trips this.
+        private def weak_csp?(dirs : Hash(String, Array(String))) : Bool
+          script = dirs["script-src"]? || dirs["default-src"]?
+          return false unless script
+          script.any? { |s| s.includes?("unsafe-inline") || s.includes?("unsafe-eval") || s == "*" }
+        end
+
+        private def hdr(ctx : Context, code : String, title : String, sev : Store::Severity, evidence : String? = nil) : Detection
+          Detection.new(code, Category::HEADERS, ctx.host, ctx.url, title, sev, evidence, ctx.fid)
+        end
+      end
+    end
+  end
+end

--- a/src/gori/prism/passive/tech.cr
+++ b/src/gori/prism/passive/tech.cr
@@ -1,0 +1,72 @@
+require "json"
+require "./rule"
+require "../../proxy/h2/grpc"
+require "../../sse"
+
+module Gori
+  module Prism
+    module Passive
+      # Technology / protocol fingerprints (category "tech", Info). These also feed the
+      # project's "representative technologies" summary. Runs on every flow (not response-gated):
+      # several signals live on the request side or on a 101 upgrade.
+      class Tech < Rule
+        def check(ctx : Context, acc : Array(Detection)) : Nil
+          check_protocols(ctx, acc)
+          check_tech_headers(ctx, acc)
+        end
+
+        private def check_protocols(ctx : Context, acc : Array(Detection)) : Nil
+          detail = ctx.detail
+          req_ct = ctx.req.headers.get?("Content-Type")
+          resp_ct = ctx.content_type
+          resp = ctx.raw_response
+          if ctx.row.status == 101 && resp.try(&.headers.get?("Upgrade").try(&.downcase)) == "websocket"
+            acc << tech(ctx, "tech_websocket", "WebSocket endpoint")
+          end
+          if Proxy::H2::Grpc.grpc?(req_ct) || Proxy::H2::Grpc.grpc?(resp_ct)
+            acc << tech(ctx, "tech_grpc", "gRPC service")
+          end
+          acc << tech(ctx, "tech_graphql", "GraphQL endpoint") if graphql?(ctx, req_ct)
+          acc << tech(ctx, "tech_sse", "Server-Sent Events stream") if Sse.event_stream?(detail.response_head)
+          if detail.http_version.starts_with?("HTTP/2") || !detail.h2_conn_id.nil?
+            acc << tech(ctx, "tech_http2", "HTTP/2")
+          end
+        end
+
+        private def check_tech_headers(ctx : Context, acc : Array(Detection)) : Nil
+          return unless r = ctx.raw_response
+          if (server = r.headers.get?("Server")) && !server.blank?
+            acc << tech(ctx, "tech_server", "Server: #{server.strip}", server.strip)
+          end
+          if (pb = r.headers.get?("X-Powered-By")) && !pb.blank?
+            acc << tech(ctx, "tech_powered_by", "X-Powered-By: #{pb.strip}", pb.strip)
+          end
+        end
+
+        # GraphQL is identified by the path, or by a JSON request body whose `query` field is a
+        # STRING holding a GraphQL document. Requiring a string value keeps Elasticsearch /
+        # OpenSearch query DSL bodies (where `query` is an OBJECT) out of the match.
+        private def graphql?(ctx : Context, req_ct : String?) : Bool
+          return true if ctx.req.target.downcase.includes?("/graphql")
+          return false unless req_ct.try(&.downcase.includes?("json"))
+          body = ctx.detail.request_body
+          return false unless body
+          text = String.new(body[0, {body.size, 8192}.min]).scrub
+          q = begin
+            JSON.parse(text).as_h?.try(&.["query"]?).try(&.as_s?)
+          rescue JSON::ParseException
+            nil
+          end
+          return false unless q
+          doc = q.lstrip
+          doc.starts_with?('{') || doc.starts_with?("query") || doc.starts_with?("mutation") ||
+            doc.starts_with?("subscription") || doc.starts_with?("fragment")
+        end
+
+        private def tech(ctx : Context, code : String, title : String, evidence : String? = nil) : Detection
+          Detection.new(code, Category::TECH, ctx.host, ctx.url, title, Store::Severity::Info, evidence, ctx.fid)
+        end
+      end
+    end
+  end
+end

--- a/src/gori/prism_query.cr
+++ b/src/gori/prism_query.cr
@@ -74,7 +74,9 @@ module Gori
       end
 
       private def match_term(t : Term, i : Store::PrismIssue) : Bool
-        return !t.negate if t.text.empty?
+        # An incomplete term (e.g. mid-typing `host:` or `-host:`) filters nothing — match all.
+        # (Previously a NEGATED empty term matched nothing and blanked the whole list.)
+        return true if t.text.empty?
         hit = case t.kind
               when :severity then match_severity(t, i.severity)
               when :status   then match_status(t.text, i.status)


### PR DESCRIPTION
Two-part improvement to the Prism passive/active scanner, driven by a multi-agent audit (5 lenses → adversarial verification) and a follow-up structural refactor. Public API and behavior of every existing check are preserved; the suite is green.

## Track A — stability / bug removal
- **Active-scan safety**: probes are now gated to `GET`/`HEAD`. The scanner runs automatically over captured traffic, so re-sending a `POST`/`PUT`/`PATCH`/`DELETE` with canary values caused real server-side side effects. Query-param reflected-XSS (the common case) is fully covered by `GET`.
- **Fiber/channel leak**: `Analyzer#stop` now closes `prism_events` (the passive fiber + channel previously leaked on every session close — `Session#close` already documented this intent and `publish()` already tolerates the closed channel).
- **Transient DB resilience**: a single `SQLITE_BUSY` from `get_flow` no longer kills passive scanning for the rest of the session (per-iteration rescue; shutdown is signalled by the channel close).
- `run_active` gets a `@stopped` guard (no outbound probes during teardown).
- Active `dedup_key` includes method + parameter location and is recorded **only on successful enqueue** (overflow-dropped targets are re-probed instead of suppressed forever).
- Cookie attribute parsing splits name from flags (a cookie named `samesite`/`secure` no longer masquerades as a flag); `prism_query` empty-value term (`-host:`) no longer blanks the list mid-typing.

## Track B — pattern improvement / FP·FN reduction
**FP↓** — `PRIVATE_IP` (0-255 octets + standalone boundaries + skip JS/CSS bodies → no version-string hits); `ERROR_SIGNATURES` (tightened to real frame/exception shapes); `secret_in_url` (normalize names, broaden HIGH, JWT-value→High, trim benign `code`/`key`); `weak_csp` (directive-aware — `unsafe-inline` confined to `style-src` no longer flagged); `graphql` (require a string-valued `query` → no Elasticsearch DSL FP).

**FN↑ / new** — CORS reflected cross-origin + credentials (same-origin echo suppressed) and `null` origin; response-body secret leaks (AWS/Google/GitHub/GitLab/Slack/PEM — evidence is the *type*, never the value); HSTS `max-age=0`; `SameSite=None` without `Secure`; active reflection now scans the response **head** (Location, etc.); `reflected_param` severity gated on HTML content-type (kills "JSON API echo flagged as XSS").

## Refactor — one rule per file
Passive/active checks are now **one self-contained `Rule` per file**, registered in `RULES`:

```
prism/passive/  context.cr rule.cr tech.cr secret_in_url.cr
                security_headers.cr cookies.cr cors.cr body_leaks.cr
prism/active/   types.cr reflected_param.cr
```

`passive.cr`/`active.cr` are thin orchestrators; a shared `Context` parses each flow once (and memoizes the decoded body). The analyzer iterates `Active::RULES`, so adding a check = new file + one registry line. `Passive.analyze` / `Active.plan` / `Active.detections` / `Active::Plan` are unchanged.

## Verification
- `prism_spec` 9 → 28 examples (new coverage for every changed/added behavior)
- Full suite: **939 examples, 0 failures**
- Full `crystal build` clean; `ameba` clean on all changed files (one pre-existing `set_mode` nit left untouched)