### PR TITLE
feat(prism): fp-centric triage, open-only lens, bulk dismiss, hit_count abbrev

### DIFF
--- a/spec/prism_spec.cr
+++ b/spec/prism_spec.cr
@@ -400,4 +400,39 @@ describe "Gori::Prism::Filter (incomplete terms)" do
     # a complete negated term still filters
     Gori::Prism::Filter.parse("-code:csp").apply(issues).map(&.code).should eq(["missing_hsts"])
   end
+
+  it "reports whether the query explicitly constrains status (drives the open-only lens)" do
+    Gori::Prism::Filter.parse("host:api").has_status_term?.should be_false
+    Gori::Prism::Filter.parse("").has_status_term?.should be_false
+    Gori::Prism::Filter.parse("status:fp host:api").has_status_term?.should be_true
+    Gori::Prism::Filter.parse("-st:open").has_status_term?.should be_true
+  end
+end
+
+describe "Store bulk Prism dismiss" do
+  it "mutes only OPEN issues matching the code/host, leaving already-triaged rows untouched" do
+    with_store do |store|
+      det = ->(code : String, host : String, url : String) do
+        Gori::Prism::Detection.new(code, "headers", host, url, "t", Gori::Store::Severity::Low)
+      end
+      store.upsert_prism_issue(det.call("missing_hsts", "a.test", "https://a.test/"))
+      store.upsert_prism_issue(det.call("missing_csp", "a.test", "https://a.test/"))
+      store.upsert_prism_issue(det.call("missing_hsts", "b.test", "https://b.test/"))
+
+      # Promote one to confirmed: a bulk dismiss must NOT clobber an already-triaged row.
+      hsts_a = store.prism_issues.find { |i| i.code == "missing_hsts" && i.host == "a.test" }.not_nil!
+      store.update_prism_issue_status(hsts_a.id, Gori::Store::Status::Confirmed)
+
+      store.dismiss_prism_by_code("missing_hsts")
+      by_key = store.prism_issues.to_h { |i| {"#{i.code}@#{i.host}", i.status} }
+      by_key["missing_hsts@a.test"].should eq(Gori::Store::Status::Confirmed)     # triaged → untouched
+      by_key["missing_hsts@b.test"].should eq(Gori::Store::Status::FalsePositive) # open → muted
+      by_key["missing_csp@a.test"].should eq(Gori::Store::Status::Open)           # other code → untouched
+
+      store.dismiss_prism_by_host("a.test")
+      after = store.prism_issues.to_h { |i| {"#{i.code}@#{i.host}", i.status} }
+      after["missing_csp@a.test"].should eq(Gori::Store::Status::FalsePositive) # open on host → muted
+      after["missing_hsts@a.test"].should eq(Gori::Store::Status::Confirmed)    # still untouched
+    end
+  end
 end

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -187,7 +187,13 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def prism_delete : Nil; end
 
-  def prism_set_status : Nil; end
+  def prism_dismiss : Nil; end
+
+  def prism_toggle_closed : Nil; end
+
+  def prism_dismiss_code : Nil; end
+
+  def prism_dismiss_host : Nil; end
 
   def prism_open_flow : Nil; end
 

--- a/spec/tui/fmt_spec.cr
+++ b/spec/tui/fmt_spec.cr
@@ -1,0 +1,22 @@
+require "../spec_helper"
+
+describe Gori::Tui::Fmt do
+  describe ".count" do
+    it "shows a plain integer below 1000" do
+      Gori::Tui::Fmt.count(0_i64).should eq("0")
+      Gori::Tui::Fmt.count(999_i64).should eq("999")
+    end
+
+    it "abbreviates thousands/millions/billions with one decimal under 10" do
+      Gori::Tui::Fmt.count(1_000_i64).should eq("1.0k")
+      Gori::Tui::Fmt.count(1_234_i64).should eq("1.2k")
+      Gori::Tui::Fmt.count(12_345_i64).should eq("12k")
+      Gori::Tui::Fmt.count(1_500_000_i64).should eq("1.5M")
+      Gori::Tui::Fmt.count(2_500_000_000_i64).should eq("2.5B")
+    end
+
+    it "rolls a value just under a boundary up to the next unit (no misleading '1000k')" do
+      Gori::Tui::Fmt.count(999_999_i64).should eq("1.0M")
+    end
+  end
+end

--- a/spec/tui/prism_view_spec.cr
+++ b/spec/tui/prism_view_spec.cr
@@ -1,0 +1,68 @@
+require "../spec_helper"
+
+private def view_store(&)
+  path = File.tempname("gori-prismview", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def seed(store, code, host)
+  store.upsert_prism_issue(
+    Gori::Prism::Detection.new(code, "headers", host, "https://#{host}/", "t", Gori::Store::Severity::Low))
+end
+
+describe Gori::Tui::PrismView do
+  it "defaults to an open-only lens: dismissing empties the visible list but keeps the rows" do
+    view_store do |store|
+      seed(store, "missing_hsts", "a.test")
+      seed(store, "missing_csp", "a.test")
+      view = Gori::Tui::PrismView.new
+      view.reload(store)
+      view.empty?.should be_false
+      view.target_issue.should_not be_nil
+
+      view.toggle_dismiss(store)      # mute the current target
+      view.toggle_dismiss(store)      # selection clamps to the remaining open one → mute it too
+      view.target_issue.should be_nil # nothing left in the open-only lens
+      view.empty?.should be_false     # ...but @all still holds the two dismissed rows
+
+      view.toggle_show_closed.should be_true # reveal triaged rows
+      view.target_issue.should_not be_nil
+    end
+  end
+
+  it "toggles a single issue open ⇄ false-positive" do
+    view_store do |store|
+      seed(store, "missing_hsts", "a.test")
+      view = Gori::Tui::PrismView.new
+      view.reload(store)
+      view.target_issue.not_nil!.status.open?.should be_true
+
+      view.toggle_dismiss(store).try(&.false_positive?).should be_true
+      view.target_issue.should be_nil # dropped from the open-only lens
+
+      view.toggle_show_closed                                # reveal it
+      view.toggle_dismiss(store).try(&.open?).should be_true # un-dismiss
+    end
+  end
+
+  it "honours an explicit status: filter even with the open-only lens (bypasses the default)" do
+    view_store do |store|
+      seed(store, "missing_hsts", "a.test")
+      view = Gori::Tui::PrismView.new
+      view.reload(store)
+      view.toggle_dismiss(store) # now false-positive, hidden by default
+      view.target_issue.should be_nil
+
+      "status:fp".each_char { |c| view.query_insert(c) }
+      view.target_issue.should_not be_nil # the explicit status term reveals it
+    end
+  end
+end

--- a/spec/tui/space_menu_spec.cr
+++ b/spec/tui/space_menu_spec.cr
@@ -150,7 +150,7 @@ describe Gori::Tui::SpaceMenu do
       Gori::Verb::Scope::Comparer, Gori::Verb::Scope::Fuzzer, Gori::Verb::Scope::Intercept,
       Gori::Verb::Scope::HistoryDetail, Gori::Verb::Scope::FindingsDetail,
       Gori::Verb::Scope::Project, Gori::Verb::Scope::Convert, Gori::Verb::Scope::Sitemap,
-      Gori::Verb::Scope::Miner,
+      Gori::Verb::Scope::Miner, Gori::Verb::Scope::Prism, Gori::Verb::Scope::PrismDetail,
     ]
     menu_scopes.each do |scope|
       verbs = registry.select { |v| v.scope == scope && !v.hidden? }

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -348,8 +348,20 @@ private class FakeContext < ExecContext
     @calls << :prism_delete
   end
 
-  def prism_set_status : Nil
-    @calls << :prism_set_status
+  def prism_dismiss : Nil
+    @calls << :prism_dismiss
+  end
+
+  def prism_toggle_closed : Nil
+    @calls << :prism_toggle_closed
+  end
+
+  def prism_dismiss_code : Nil
+    @calls << :prism_dismiss_code
+  end
+
+  def prism_dismiss_host : Nil
+    @calls << :prism_dismiss_host
   end
 
   def prism_open_flow : Nil

--- a/src/gori/prism_query.cr
+++ b/src/gori/prism_query.cr
@@ -38,6 +38,13 @@ module Gori
         @terms.empty?
       end
 
+      # True when the query explicitly constrains status (status:/st:, possibly negated),
+      # so the list view skips its default open-only restriction and honours the user's
+      # explicit choice of statuses instead.
+      def has_status_term? : Bool
+        @terms.any? { |t| t.kind == :status }
+      end
+
       def apply(issues : Array(Store::PrismIssue)) : Array(Store::PrismIssue)
         return issues if @terms.empty?
         issues.select { |i| matches?(i) }

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -380,6 +380,27 @@ module Gori
       }
     end
 
+    # Bulk-mute every OPEN issue sharing this code (or host) — mark false-positive so the
+    # whole group leaves the default open-only view and stays muted across re-hits. A plain
+    # delete can't durably mute: `upsert_prism_issue` resurrects the row as `open` on the
+    # next matching observation. Already-triaged rows (confirmed/fp/resolved) are left as-is.
+    def dismiss_prism_by_code(code : String) : Nil
+      bulk_dismiss_prism("code = ?", code)
+    end
+
+    def dismiss_prism_by_host(host : String) : Nil
+      bulk_dismiss_prism("host = ?", host)
+    end
+
+    # `clause` is a fixed internal predicate ("code = ?" / "host = ?"), never user text.
+    private def bulk_dismiss_prism(clause : String, arg : DB::Any) : Nil
+      exec_task ->(c : DB::Connection) {
+        c.exec("UPDATE prism_issues SET status = ?, last_seen = ? WHERE #{clause} AND status = ?",
+          Status::FalsePositive.value, now_us, arg, Status::Open.value)
+        nil
+      }
+    end
+
     def delete_prism_issue(id : Int64) : Nil
       exec_task ->(c : DB::Connection) { c.exec("DELETE FROM prism_issues WHERE id = ?", id); nil }
     end

--- a/src/gori/tui/choice_picker.cr
+++ b/src/gori/tui/choice_picker.cr
@@ -52,17 +52,6 @@ module Gori::Tui
       ], current, :prism_mode)
     end
 
-    # The same triage-status choices, but kind :prism_status so the Runner applies it to the
-    # open Prism issue rather than a Finding.
-    def self.for_prism_status(current : Int32) : ChoicePicker
-      new("SET STATUS", [
-        Choice.new("open", 'o', Theme.accent, 0),
-        Choice.new("confirmed", 'c', Theme.red, 1),
-        Choice.new("false-positive", 'f', Theme.muted, 2),
-        Choice.new("resolved", 'r', Theme.green, 3),
-      ], current, :prism_status)
-    end
-
     def move(delta : Int32) : Nil
       return if @choices.empty?
       @selected = (@selected + delta).clamp(0, @choices.size - 1)

--- a/src/gori/tui/controllers/prism_controller.cr
+++ b/src/gori/tui/controllers/prism_controller.cr
@@ -35,13 +35,13 @@ module Gori::Tui
 
     def body_hint(focus : Symbol) : String
       if @prism.detail_open?
-        "o flow · r replay · p promote · c status · d delete · ←/esc back"
+        "o flow · r replay · p promote · c dismiss · d delete · ←/esc back"
       elsif @prism.querying?
         "type to filter · ↹ complete · ↵ apply · esc clear"
       elsif @prism.mode.off?
         "m enable scanning · / filter · space cmds · esc tabs"
       else
-        "↑/↓ move · ↵ open · / filter · m mode · space cmds · esc tabs"
+        "↑/↓ move · ↵ open · c dismiss · m mode · / filter · space cmds"
       end
     end
 
@@ -178,9 +178,35 @@ module Gori::Tui
       end
     end
 
-    # Applied by the Runner's ChoicePicker (:prism_status).
-    def apply_status(status : Store::Status) : Nil
-      @prism.set_status(@host.session.store, status)
+    # `c`: toggle dismiss (open ↔ false-positive) on the open/selected issue.
+    def prism_dismiss : Nil
+      return unless @prism.target_issue
+      st = @prism.toggle_dismiss(@host.session.store)
+      @host.notifications.push(:success, st.try(&.open?) ? "issue re-opened" : "issue dismissed")
+    end
+
+    # `a`: flip the open-only ⇄ show-closed lens.
+    def prism_toggle_closed : Nil
+      showing = @prism.toggle_show_closed
+      @host.notifications.push(:info, showing ? "showing closed issues" : "showing open issues only")
+    end
+
+    # Space-menu bulk actions: mute every OPEN issue sharing the targeted issue's code / host
+    # (a confirm guards the mass mutation; it's reversible via show-closed + c).
+    def prism_dismiss_code : Nil
+      return unless i = @prism.target_issue
+      @host.confirm("DISMISS GROUP", "Dismiss all open \"#{i.code}\" issues?", confirm_label: "dismiss", danger: false) do
+        n = @prism.dismiss_by_code(@host.session.store)
+        @host.notifications.push(:success, "dismissed #{n} \"#{i.code}\" issue#{n == 1 ? "" : "s"}")
+      end
+    end
+
+    def prism_dismiss_host : Nil
+      return unless i = @prism.target_issue
+      @host.confirm("DISMISS GROUP", "Dismiss all open issues on #{i.host}?", confirm_label: "dismiss", danger: false) do
+        n = @prism.dismiss_by_host(@host.session.store)
+        @host.notifications.push(:success, "dismissed #{n} issue#{n == 1 ? "" : "s"} on #{i.host}")
+      end
     end
   end
 end

--- a/src/gori/tui/fmt.cr
+++ b/src/gori/tui/fmt.cr
@@ -23,6 +23,19 @@ module Gori::Tui
       v < 10 ? "#{v.round(1)}#{suffix}" : "#{v.round.to_i}#{suffix}"
     end
 
+    # Compact occurrence count (1.2k / 3.4M / 5.0B) for tallies that can grow
+    # unbounded (e.g. Prism hit_count). Plain integer below 1000; same rounding
+    # convention as `size` so a value just under a boundary rolls up to the next
+    # unit instead of showing a misleading "1000k".
+    def self.count(n : Int64) : String
+      return n.to_s if n < 1000
+      k = n / 1000.0
+      return unit(k, "k") if k.round < 1000
+      m = n / 1_000_000.0
+      return unit(m, "M") if m.round < 1000
+      unit(n / 1_000_000_000.0, "B")
+    end
+
     # Compact request→response latency (ms/s/m/h), bounded to ≤6 cols. "—" until the
     # response lands; a minute/hour tier keeps very slow flows from overflowing.
     def self.dur(us : Int64?) : String

--- a/src/gori/tui/prism_view.cr
+++ b/src/gori/tui/prism_view.cr
@@ -32,25 +32,43 @@ module Gori::Tui
       @qcx = 0
       @preedit_q = ""
       @querying = false
+      @show_closed = false # default lens: open issues only (triaged ones drop out of view)
     end
 
     def reload(store : Store) : Nil
       @all = store.prism_issues
       @mode = store.prism_mode
       @tech = store.prism_tech_summary
-      recount
       apply_filter
       refresh_detail(store)
     end
 
-    private def recount : Nil
+    private def recount(base : Array(Store::PrismIssue)) : Nil
       @counts = StaticArray(Int32, 5).new(0)
-      @all.each { |i| @counts[i.severity.value] += 1 }
+      base.each { |i| @counts[i.severity.value] += 1 }
     end
 
+    # The default lens shows only OPEN issues; triaged (dismissed/confirmed/resolved) rows
+    # drop out so muting noise actually clears the view. An explicit status: term in the
+    # filter, or the show-closed toggle, opts back into the full set. The severity tallies
+    # follow the same base (pre-text-filter) so dismissing visibly lowers them.
     private def apply_filter : Nil
-      @issues = Prism::Filter.parse(@query).apply(@all)
+      filter = Prism::Filter.parse(@query)
+      base = (@show_closed || filter.has_status_term?) ? @all : @all.select(&.status.open?)
+      recount(base)
+      @issues = filter.apply(base)
       @selected = @selected.clamp(0, {@issues.size - 1, 0}.max)
+    end
+
+    def show_closed? : Bool
+      @show_closed
+    end
+
+    # `a`: flip between the default open-only lens and the full set (incl. triaged rows).
+    def toggle_show_closed : Bool
+      @show_closed = !@show_closed
+      apply_filter
+      @show_closed
     end
 
     # Re-fetch the open detail (its status/affected may have changed) and its sample flow.
@@ -188,10 +206,34 @@ module Gori::Tui
       @detail_scroll = {@detail_scroll + delta, 0}.max
     end
 
-    def set_status(store : Store, status : Store::Status) : Nil
-      return unless issue = target_issue
-      store.update_prism_issue_status(issue.id, status)
+    # `c`: one-key dismiss for the targeted issue. open → false-positive (mute), anything
+    # already triaged → back to open (un-mute). Dismiss is the high-value triage action for
+    # a passive scanner; the full open/confirmed/fp/resolved picker was over-built for
+    # machine-found issues (promote handles "this is real → Finding"). Returns the new state.
+    def toggle_dismiss(store : Store) : Store::Status?
+      return nil unless issue = target_issue
+      next_status = issue.status.open? ? Store::Status::FalsePositive : Store::Status::Open
+      store.update_prism_issue_status(issue.id, next_status)
       reload(store)
+      next_status
+    end
+
+    # Bulk-mute every OPEN issue sharing the targeted issue's code / host. Returns how many
+    # rows were affected (counted in memory; the store UPDATE is fire-and-forget).
+    def dismiss_by_code(store : Store) : Int32
+      return 0 unless issue = target_issue
+      n = @all.count { |i| i.code == issue.code && i.status.open? }
+      store.dismiss_prism_by_code(issue.code)
+      reload(store)
+      n
+    end
+
+    def dismiss_by_host(store : Store) : Int32
+      return 0 unless issue = target_issue
+      n = @all.count { |i| i.host == issue.host && i.status.open? }
+      store.dismiss_prism_by_host(issue.host)
+      reload(store)
+      n
     end
 
     def delete(store : Store) : Nil
@@ -247,9 +289,14 @@ module Gori::Tui
       screen.text(rect.x + 7, y, cat_tag(issue.category), Theme.muted, bg, width: 6)
       # Right-to-left cluster: status · host · ×N(affected).
       rx = rect.right - 1
-      st = status_tag(issue.status)
-      screen.text(rx - st.size, y, st, status_color(issue.status), bg)
-      rx -= st.size + 1
+      # The "open" tag is redundant in the default open-only lens (every visible row is
+      # open); show a status tag only once non-open rows can appear (show-closed / status:
+      # filter), or when the row itself is non-open.
+      if @show_closed || !issue.status.open?
+        st = status_tag(issue.status)
+        screen.text(rx - st.size, y, st, status_color(issue.status), bg)
+        rx -= st.size + 1
+      end
       if !issue.host.empty?
         screen.text({rx - issue.host.size, rect.x}.max, y, issue.host, Theme.muted, bg)
         rx -= issue.host.size + 1
@@ -269,6 +316,8 @@ module Gori::Tui
               "scanning is OFF · press m (or space → set mode) to enable passive scanning"
             elsif filtering?
               @querying ? "no issues match · esc clears the filter" : "no issues match · / to edit the filter"
+            elsif !@all.empty? && !@show_closed
+              "no open issues · all #{@all.size} triaged · press a to show closed"
             else
               "no issues yet · capture in-scope traffic and Prism flags issues passively"
             end
@@ -355,7 +404,7 @@ module Gori::Tui
 
       y = rect.y + 5
       Frame.inner_divider(screen, rect, y, border: Frame.pane_border(focused))
-      head = "AFFECTED URLS (#{issue.affected.size})  ·  seen ×#{issue.hit_count}"
+      head = "AFFECTED URLS (#{issue.affected.size})  ·  seen ×#{Fmt.count(issue.hit_count)}"
       screen.text(rect.x + 1, y + 1, head, Theme.accent, attr: Attribute::Bold)
       list_y = y + 2
       avail = {rect.bottom - list_y, 0}.max

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1106,8 +1106,6 @@ module Gori::Tui
         @session.prism.set_mode(Prism::Mode.new(p.selected_value))
         prism_controller.view.reload(@session.store)
         @toast = "Prism mode: #{@session.prism.mode.title}"
-      when :prism_status
-        prism_controller.apply_status(Store::Status.new(p.selected_value))
       end
       close_choice_picker
     end
@@ -2525,10 +2523,20 @@ module Gori::Tui
       @overlay = :choice
     end
 
-    def prism_set_status : Nil
-      return unless i = prism_controller.view.detail_issue
-      @choice_picker = ChoicePicker.for_prism_status(i.status.value)
-      @overlay = :choice
+    def prism_dismiss : Nil
+      prism_controller.prism_dismiss
+    end
+
+    def prism_toggle_closed : Nil
+      prism_controller.prism_toggle_closed
+    end
+
+    def prism_dismiss_code : Nil
+      prism_controller.prism_dismiss_code
+    end
+
+    def prism_dismiss_host : Nil
+      prism_controller.prism_dismiss_host
     end
 
     # Jump from an issue to its sample flow's request/response in History. CROSS-TAB
@@ -2561,6 +2569,10 @@ module Gori::Tui
     def prism_promote : Nil
       return unless i = prism_controller.view.detail_issue
       @session.store.insert_finding(i.title, i.severity, i.host, i.sample_flow_id)
+      # Mark the source confirmed (= "promoted to a Finding") so it leaves the default
+      # open-only lens instead of lingering as unreviewed noise; still reachable via `a`.
+      @session.store.update_prism_issue_status(i.id, Store::Status::Confirmed)
+      prism_controller.view.reload(@session.store)
       @toast = "promoted to finding — see the Findings tab"
     end
 

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -128,16 +128,19 @@ module Gori
 
       # prism (passive/active scan issues — grouped by code+host)
       abstract def prism_move(delta : Int32) : Nil
-      abstract def prism_open : Nil        # open the selected issue's detail
-      abstract def prism_close : Nil       # back to the list
-      abstract def prism_query : Nil       # focus the `/` filter bar
-      abstract def prism_set_mode : Nil    # open the OFF/Passive/Active picker
-      abstract def prism_clear : Nil       # delete all issues (after a confirm)
-      abstract def prism_delete : Nil      # delete the open/selected issue (after a confirm)
-      abstract def prism_set_status : Nil  # open the triage-status picker for the open issue
-      abstract def prism_open_flow : Nil   # open the issue's sample flow in History
-      abstract def prism_replay_flow : Nil # send the issue's sample flow to Replay
-      abstract def prism_promote : Nil     # create a Finding from the open issue
+      abstract def prism_open : Nil          # open the selected issue's detail
+      abstract def prism_close : Nil         # back to the list
+      abstract def prism_query : Nil         # focus the `/` filter bar
+      abstract def prism_set_mode : Nil      # open the OFF/Passive/Active picker
+      abstract def prism_clear : Nil         # delete all issues (after a confirm)
+      abstract def prism_delete : Nil        # delete the open/selected issue (after a confirm)
+      abstract def prism_dismiss : Nil       # toggle dismiss (open ↔ false-positive) on the target issue
+      abstract def prism_toggle_closed : Nil # flip the open-only ⇄ show-closed list lens
+      abstract def prism_dismiss_code : Nil  # bulk-dismiss every open issue with the target's code
+      abstract def prism_dismiss_host : Nil  # bulk-dismiss every open issue on the target's host
+      abstract def prism_open_flow : Nil     # open the issue's sample flow in History
+      abstract def prism_replay_flow : Nil   # send the issue's sample flow to Replay
+      abstract def prism_promote : Nil       # create a Finding from the open issue
 
       # intercept (hold-and-decide; P4)
       abstract def intercept_toggle : Nil          # toggle the hold queue on/off

--- a/src/gori/verbs/prism.cr
+++ b/src/gori/verbs/prism.cr
@@ -32,6 +32,26 @@ module Gori
         "prism.mode", "Set mode", "Choose the scan mode (off / passive / passive+active)",
         Verb::Scope::Prism, [Verb::Chord.new("m")]) { |ctx| ctx.prism_set_mode; nil }
 
+      # `c`: one-key dismiss for the selected row (open ⇄ false-positive). The high-value
+      # triage action; mutes recurring noise so it drops out of the default open-only lens.
+      r.register Verb::Definition.new(
+        "prism.dismiss-selected", "Dismiss issue", "Toggle dismiss (false-positive ⇄ open) on the selected issue",
+        Verb::Scope::Prism, [Verb::Chord.new("c")]) { |ctx| ctx.prism_dismiss; nil }
+
+      r.register Verb::Definition.new(
+        "prism.toggle-closed", "Show closed", "Toggle between open-only and all issues (incl. dismissed)",
+        Verb::Scope::Prism, [Verb::Chord.new("a")]) { |ctx| ctx.prism_toggle_closed; nil }
+
+      # Bulk dismiss — space-menu only (mnemonic, no stray hotkey): mute a whole check
+      # code, or a whole host, in one confirmed action.
+      r.register Verb::Definition.new(
+        "prism.dismiss-code", "Dismiss all with this code", "Mute every open issue sharing the selected issue's check code",
+        Verb::Scope::Prism, mnemonic: 'r') { |ctx| ctx.prism_dismiss_code; nil }
+
+      r.register Verb::Definition.new(
+        "prism.dismiss-host", "Dismiss all on this host", "Mute every open issue on the selected issue's host",
+        Verb::Scope::Prism, mnemonic: 'h') { |ctx| ctx.prism_dismiss_host; nil }
+
       r.register Verb::Definition.new(
         "prism.clear", "Clear issues", "Delete all Prism issues for this project", Verb::Scope::Prism,
         [Verb::Chord.new("x")]) { |ctx| ctx.prism_clear; nil }
@@ -58,8 +78,8 @@ module Gori
         [Verb::Chord.new("p")]) { |ctx| ctx.prism_promote; nil }
 
       r.register Verb::Definition.new(
-        "prism.set-status", "Set status", "Pick this issue's triage status",
-        Verb::Scope::PrismDetail, [Verb::Chord.new("c")]) { |ctx| ctx.prism_set_status; nil }
+        "prism.dismiss", "Dismiss issue", "Toggle dismiss (false-positive ⇄ open) on this issue",
+        Verb::Scope::PrismDetail, [Verb::Chord.new("c")]) { |ctx| ctx.prism_dismiss; nil }
 
       r.register Verb::Definition.new(
         "prism.delete", "Delete issue", "Delete this issue", Verb::Scope::PrismDetail,


### PR DESCRIPTION
## Summary

Reworks the Prism results UX. Passive issues are low-confidence and high-volume, so the full Findings-parity triage (open/confirmed/fp/resolved) was too much manual work for both humans and AI. Key constraint: a plain delete can't durably mute an issue — `upsert_prism_issue` resurrects the row as `open` on the next matching hit — so a persistent status is necessary, just simpler.

### Changes
- **fp-centric status** — `c` is a one-key dismiss toggle (open ↔ false-positive) in both the list and detail. The 4-way status picker is removed. `prism_promote` now marks the source `confirmed` (= "promoted to a Finding") so it leaves the default view automatically.
- **default open-only lens** — the list shows only OPEN issues; `a` toggles closed in/out, and an explicit `status:` filter bypasses the default. Severity tallies follow the same base so dismissing visibly lowers them. The redundant "open" row tag is hidden when the lens is open-only.
- **bulk dismiss** — space-menu actions to mute every open issue sharing a check code (`r`) or host (`h`), confirm-guarded, OPEN rows only (already-triaged rows untouched).
- **`Fmt.count`** — `1.2k`/`3.4M`/`5.0B` abbreviation for the unbounded `seen ×N` hit_count.

### Tests
- New: store bulk-dismiss, `Filter#has_status_term?`, `PrismView` lens/toggle/dismiss, `Fmt.count`.
- Extended the menu_key-uniqueness spec to cover the `Prism`/`PrismDetail` scopes.
- Full suite green (947 examples), build clean.