### PR TITLE
feat(ux): TUI/CLI/MCP completeness polish (behavior-preserving)

### DIFF
--- a/spec/tui/clipboard_spec.cr
+++ b/spec/tui/clipboard_spec.cr
@@ -23,4 +23,18 @@ describe Gori::Tui::Clipboard do
     Gori::Tui::Clipboard.copy("xyz", io)
     io.to_s.should contain(Base64.strict_encode("xyz"))
   end
+
+  it "returns the byte count actually placed on the clipboard" do
+    # "héllo" is 6 bytes (é = 2 bytes) but 5 chars — the return is bytes.
+    Gori::Tui::Clipboard.copy("héllo", IO::Memory.new).should eq(6)
+  end
+
+  it "clips to MAX_CLIP BYTES, not chars, for multi-byte payloads" do
+    # 30k chars × 3 bytes = 90k bytes: over the 64KB byte cap but under it by char
+    # count, so a char-based clip would overshoot the cap. The return must be the cap.
+    big = "한" * 30_000
+    big.size.should be < Gori::Tui::Clipboard::MAX_CLIP     # under cap by chars
+    big.bytesize.should be > Gori::Tui::Clipboard::MAX_CLIP # over cap by bytes
+    Gori::Tui::Clipboard.copy(big, IO::Memory.new).should eq(Gori::Tui::Clipboard::MAX_CLIP)
+  end
 end

--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -376,6 +376,27 @@ describe Gori::Tui::HistoryView do
       backend.fg_at(hx, hy).should eq(Theme.syn_header)
     end
   end
+
+  it "shows the scope-lens empty hint (not the filter hint) when querying with a blank query" do
+    tmp_store do |store|
+      add_flow(store, "GET", "/a", 200) # captured on host h.test
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "other.test") # excludes the h.test flow → in-scope set empty
+      scope.enable
+      view = HistoryView.new
+      view.set_scope(scope)
+      view.reload(store)
+      view.rows.empty?.should be_true
+      view.start_query # filter bar open, query still blank
+
+      backend = MemoryBackend.new(80, 12)
+      view.render_list(Screen.new(backend), Rect.new(0, 0, 80, 12))
+      rows = (0...12).map { |y| backend.row(y) }.join("\n")
+      rows.should contain("no flows in scope")
+      rows.should contain("⇧S clears the scope lens")
+      rows.should_not contain("esc clears the filter") # would be misleading — esc won't unfilter
+    end
+  end
 end
 
 describe Gori::Tui::Keybind do

--- a/spec/tui/sitemap_view_spec.cr
+++ b/spec/tui/sitemap_view_spec.cr
@@ -99,7 +99,7 @@ describe Gori::Tui::SitemapView do
     end
   end
 
-  it "renders the filter bar: scope chip + hint, then the query prompt" do
+  it "renders the filter bar: scope chip + hint, then the filter prompt" do
     tmp_store do |store|
       capture(store, "acme.test", "GET", "/")
       view = SitemapView.new
@@ -114,7 +114,7 @@ describe Gori::Tui::SitemapView do
       "host:acme".each_char { |c| view.query_insert(c) }
       b1 = MemoryBackend.new(70, 20)
       view.render(Screen.new(b1), Rect.new(0, 0, 70, 20))
-      b1.contains?("query").should be_true
+      b1.contains?("filter ›").should be_true # active editing prompt (unified with Findings/Prism)
       b1.contains?("host:acme").should be_true
     end
   end

--- a/src/gori/app.cr
+++ b/src/gori/app.cr
@@ -173,6 +173,7 @@ module Gori
       STDERR.puts "  root CA: #{@ca.ca_cert_path}"
       STDERR.puts "  trust the CA above, then point your client's HTTP+HTTPS proxy at #{proxy.host}:#{proxy.port}"
       STDERR.puts "  db: #{session.project.db_path}"
+      STDERR.puts "  press Ctrl-C to stop"
     end
 
     private def install_signal_traps : Nil

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -176,10 +176,11 @@ module Gori
     end
 
     private def self.run_export(args : Array(String)) : Nil
-      if args.empty? || args.any? { |a| ["-h", "--help"].includes?(a) }
-        puts "Usage: gori export <subcommand>"
-        puts "Subcommands:"
-        puts "  ca-cert   Print path to the root CA certificate (for client trust)"
+      # Only the generic usage when there's no subcommand (bare or a leading flag);
+      # `gori export ca-cert --help` must fall through to the ca-cert parser, which
+      # documents --ca-dir and its own -h/--help.
+      if args.empty? || args[0].starts_with?("-")
+        print_export_usage(STDOUT)
         return
       end
 
@@ -189,7 +190,7 @@ module Gori
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori export ca-cert [options]"
           p.on("--ca-dir=DIR", "Directory for the root CA") { |v| ca_dir = v }
-          p.on("-h", "--help") { puts p; exit 0 }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.invalid_option { |flag| abort "unknown option: #{flag}\n#{p}" }
           p.missing_option { |flag| abort "missing value for #{flag}" }
         end
@@ -197,8 +198,16 @@ module Gori
         Paths.ensure_dirs
         puts Proxy::Tls::CertAuthority.load_or_create(ca_dir).ca_cert_path
       else
-        abort "unknown export subcommand: #{args[0]}"
+        STDERR.puts "unknown export subcommand: #{args[0]}"
+        print_export_usage(STDERR)
+        exit 1
       end
+    end
+
+    private def self.print_export_usage(io : IO) : Nil
+      io.puts "Usage: gori export <subcommand>"
+      io.puts "Subcommands:"
+      io.puts "  ca-cert   Print path to the root CA certificate (for client trust)"
     end
 
     # Handler for `gori run` (the non-interactive CLI mode). Named run_run to match

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -176,10 +176,11 @@ module Gori
     end
 
     private def self.run_export(args : Array(String)) : Nil
-      # Only the generic usage when there's no subcommand (bare or a leading flag);
-      # `gori export ca-cert --help` must fall through to the ca-cert parser, which
-      # documents --ca-dir and its own -h/--help.
-      if args.empty? || args[0].starts_with?("-")
+      # Generic usage only for a bare invocation or a top-level help flag. An unknown
+      # dash-prefixed first arg (e.g. `--bogus`) must still fall through to the else
+      # below (error + exit 1), and `gori export ca-cert --help` must reach the
+      # ca-cert parser (which documents --ca-dir and its own -h/--help).
+      if args.empty? || args[0] == "-h" || args[0] == "--help"
         print_export_usage(STDOUT)
         return
       end

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -92,15 +92,15 @@ module Gori
         max : Int32? = nil
 
         parser = OptionParser.new do |p|
-          p.banner = "Usage: gori run capture [options]"
+          p.banner = "Usage: gori run capture [options]\n\nRun the proxy and stream captured flows to STDOUT until Ctrl-C (or --for / --max)."
           p.on("-lHOST", "--listen=HOST", "Listen address (default #{listen})") { |v| listen = v }
           p.on("-pPORT", "--port=PORT", "Listen port (default #{port})") { |v| port = parse_port(v) }
           p.on("--project=NAME", "Capture into project NAME (created if missing; default 'default')") { |v| project_name = v }
           p.on("--db=PATH", "Capture into an explicit SQLite db file") { |v| db_path = v }
-          p.on("--insecure-upstream", "Do not verify upstream TLS certificates") { insecure = true }
-          p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
+          p.on("-k", "--insecure-upstream", "Do not verify upstream TLS certificates") { insecure = true }
+          p.on("--format=FMT", "Output: text (default) | json (JSON-Lines)") { |v| format = parse_format(v, [:text, :json]) }
           p.on("--for=DURATION", "Stop after DURATION (e.g. 30s, 5m, 1h)") { |v| every = parse_duration(v) }
-          p.on("--max=N", "Stop after N completed flows") { |v| max = parse_count(v) }
+          p.on("--max=N", "Stop after N completed flows") { |v| max = parse_count(v, "--max") }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.invalid_option { |f| abort "gori run capture: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run capture: missing value for #{f}" }
@@ -131,7 +131,7 @@ module Gori
           p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("-qQL", "--query=QL", "Filter with a QL query (host: status:>=500 size:>10000 dur:>500 header: body~rx …)") { |v| query = v }
-          p.on("-nN", "--limit=N", "Max rows, newest first (default 50)") { |v| limit = parse_count(v) }
+          p.on("-nN", "--limit=N", "Max rows, newest first (default 50)") { |v| limit = parse_count(v, "--limit") }
           p.on("--format=FMT", "Output: text (default) | json (JSON-Lines)") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args { |rest, _| positional = rest }
@@ -380,7 +380,7 @@ module Gori
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("--target=URL", "Send to this origin (scheme://host[:port]) instead of the captured one; path/query kept") { |v| target_override = v }
           p.on("--http2", "Force HTTP/2 (default follows how the flow was captured)") { force_h2 = true }
-          p.on("--insecure-upstream", "Do not verify the upstream TLS certificate") { insecure = true }
+          p.on("-k", "--insecure-upstream", "Do not verify the upstream TLS certificate") { insecure = true }
           p.on("--diff", "Diff the new response against the captured one") { do_diff = true }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
@@ -431,6 +431,8 @@ module Gori
           STDERR.puts "→ #{result.response.try(&.status) || "?"} in #{CLI::Output.human_us(result.duration_us)}"
           if d = diff
             print_diff(d)
+            n = Replay::Diff.change_count(d)
+            STDERR.puts(n == 0 ? "no differences" : "#{n} line#{n == 1 ? "" : "s"} changed")
           else
             print_message_text(result.head, new_body)
           end
@@ -504,7 +506,7 @@ module Gori
           p.on("-wPATH", "--wordlist=PATH", "Payload set: a wordlist file (repeatable; order → positions)") { |v| sources << Fuzz::WordlistFile.new(v) }
           p.on("--payloads=LIST", "Payload set: inline comma list (a,b,c)") { |v| sources << Fuzz::InlineList.new(v.split(',')) }
           p.on("--numbers=SPEC", "Payload set: FROM-TO[:STEP] (e.g. 1-100 or 0-255:5)") { |v| sources << parse_numbers(v) }
-          p.on("--null=N", "Payload set: N empty payloads") { |v| sources << Fuzz::NullPayloads.new(parse_count(v)) }
+          p.on("--null=N", "Payload set: N empty payloads") { |v| sources << Fuzz::NullPayloads.new(parse_count(v, "--null")) }
           p.on("--brute=SPEC", "Payload set: CHARSET:MIN-MAX (e.g. abc:1-3)") { |v| sources << parse_brute(v) }
           p.on("--prefix=STR", "Processing: prepend STR to each payload") { |v| processors << Fuzz::Prefix.new(v) }
           p.on("--suffix=STR", "Processing: append STR to each payload") { |v| processors << Fuzz::Suffix.new(v) }
@@ -512,11 +514,11 @@ module Gori
           p.on("--case=KIND", "Processing: upper | lower") { |v| processors << Fuzz::Case.new(parse_case(v)) }
           p.on("--hash=ALGO", "Processing: md5 | sha1 | sha256") { |v| processors << Fuzz::Hasher.new(parse_hash(v)) }
           p.on("--regex-replace=SPEC", "Processing: /pattern/replacement/") { |v| processors << parse_regex_replace(v) }
-          p.on("--concurrency=N", "Parallel requests (default 20)") { |v| concurrency = parse_count(v) }
+          p.on("--concurrency=N", "Parallel requests (default 20)") { |v| concurrency = parse_count(v, "--concurrency") }
           p.on("--rate=RPS", "Cap requests/sec (0 = unlimited)") { |v| rate = parse_rate(v) }
-          p.on("--throttle=MS", "Fixed delay between requests (ms)") { |v| throttle = parse_nonneg(v) }
-          p.on("--timeout=SEC", "Per-request connect + idle timeout (seconds)") { |v| timeout = parse_count(v).seconds }
-          p.on("--retries=N", "Retries on a network error") { |v| retries = parse_nonneg(v) }
+          p.on("--throttle=MS", "Fixed delay between requests (ms)") { |v| throttle = parse_nonneg(v, "--throttle") }
+          p.on("--timeout=SEC", "Per-request connect + idle timeout (seconds)") { |v| timeout = parse_count(v, "--timeout").seconds }
+          p.on("--retries=N", "Retries on a network error") { |v| retries = parse_nonneg(v, "--retries") }
           p.on("--follow-redirects", "Follow same-origin redirects") { follow = true }
           p.on("--mc=SPEC", "Match status (e.g. 200,302,500-599,2xx)") { |v| matcher.match_status = v }
           p.on("--fc=SPEC", "Filter out status") { |v| matcher.filter_status = v }
@@ -631,12 +633,13 @@ module Gori
       end
 
       private def self.fuzz_progress(ev : Fuzz::ProgressEvent, total : Int64?) : Nil
+        return unless STDERR.tty? # the \r-redrawn meter only makes sense on a terminal
         STDERR.print "\r[fuzz] #{ev.progress.sent}/#{total || "?"} · #{ev.progress.matched} hits"
         STDERR.flush
       end
 
       private def self.fuzz_done(ev : Fuzz::DoneEvent, emitted : Int32) : Nil
-        STDERR.print "\r"
+        STDERR.print "\r" if STDERR.tty? # clear the in-place meter (none was drawn when piped)
         STDERR.puts "done · #{ev.progress.sent} sent · #{emitted} shown · #{ev.progress.errors} errors#{ev.stopped ? " (stopped)" : ""}"
       end
 
@@ -702,13 +705,13 @@ module Gori
           p.on("-k", "--insecure-upstream", "Do not verify upstream TLS certificates") { insecure = true }
           p.on("--locations=LIST", "Where to mine: query,form,json,headers,cookies (default: auto-detect)") { |v| locations = parse_mine_locations(v) }
           p.on("--wordlist=PATH", "Extra param-name wordlist (merged with the built-in list)") { |v| wordlist = v }
-          p.on("--bucket=N", "Names stuffed per request before bisection (per location)") { |v| bucket = parse_count(v) }
-          p.on("--concurrency=N", "Parallel requests (default 10)") { |v| concurrency = parse_count(v) }
+          p.on("--bucket=N", "Names stuffed per request before bisection (per location)") { |v| bucket = parse_count(v, "--bucket") }
+          p.on("--concurrency=N", "Parallel requests (default 10)") { |v| concurrency = parse_count(v, "--concurrency") }
           p.on("--rate=RPS", "Cap requests/sec (0 = unlimited)") { |v| rate = parse_rate(v) }
-          p.on("--throttle=MS", "Fixed delay between requests (ms)") { |v| throttle = parse_nonneg(v) }
-          p.on("--timeout=SEC", "Per-request connect + idle timeout (seconds)") { |v| timeout = parse_count(v).seconds }
-          p.on("--retries=N", "Retries on a network error") { |v| retries = parse_nonneg(v) }
-          p.on("--max-requests=N", "Hard cap on total requests sent") { |v| max_requests = parse_count(v).to_i64 }
+          p.on("--throttle=MS", "Fixed delay between requests (ms)") { |v| throttle = parse_nonneg(v, "--throttle") }
+          p.on("--timeout=SEC", "Per-request connect + idle timeout (seconds)") { |v| timeout = parse_count(v, "--timeout").seconds }
+          p.on("--retries=N", "Retries on a network error") { |v| retries = parse_nonneg(v, "--retries") }
+          p.on("--max-requests=N", "Hard cap on total requests sent") { |v| max_requests = parse_count(v, "--max-requests").to_i64 }
           p.on("--format=FMT", "Output: text (default) | json | jsonl") { |v| format = parse_format(v, [:text, :json, :jsonl]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args { |rest, _| positional = rest }
@@ -821,13 +824,14 @@ module Gori
       end
 
       private def self.mine_progress(ev : Miner::ProgressEvent, total : Int64) : Nil
+        return unless STDERR.tty? # the \r-redrawn meter only makes sense on a terminal
         p = ev.progress
         STDERR.print "\r[mine] #{p.names_done}/#{total} names · #{p.found} found · #{p.sent} sent"
         STDERR.flush
       end
 
       private def self.mine_done(ev : Miner::DoneEvent, found : Int32) : Nil
-        STDERR.print "\r"
+        STDERR.print "\r" if STDERR.tty? # clear the in-place meter (none was drawn when piped)
         STDERR.puts "done · #{found} found · #{ev.progress.sent} sent · #{ev.progress.errors} errors#{ev.stopped ? " (stopped)" : ""}"
       end
 
@@ -890,9 +894,9 @@ module Gori
         n == 0 ? nil : n
       end
 
-      private def self.parse_nonneg(v : String) : Int32
+      private def self.parse_nonneg(v : String, flag : String? = nil) : Int32
         n = v.to_i?
-        abort "gori run: invalid count '#{v}' (expected a non-negative integer)" unless n && n >= 0
+        abort "gori run: invalid #{flag || "count"} '#{v}' (expected a non-negative integer)" unless n && n >= 0
         n
       end
 
@@ -995,6 +999,7 @@ module Gori
                   j.field "db_path", pr.db_path
                   j.field "db_size", pr.db_size
                   j.field "last_modified", pr.last_modified.try(&.to_unix)
+                  j.field "time", pr.last_modified.try(&.to_local.to_s("%Y-%m-%dT%H:%M:%S%:z"))
                 end
               end
             end
@@ -1062,9 +1067,9 @@ module Gori
         n
       end
 
-      private def self.parse_count(v : String) : Int32
+      private def self.parse_count(v : String, flag : String? = nil) : Int32
         n = v.to_i?
-        abort "gori run: invalid count '#{v}' (expected a positive integer)" unless n && n > 0
+        abort "gori run: invalid #{flag || "count"} '#{v}' (expected a positive integer)" unless n && n > 0
         n
       end
 

--- a/src/gori/mcp/serialize.cr
+++ b/src/gori/mcp/serialize.cr
@@ -182,10 +182,6 @@ module Gori
               j.field "encoding", "text"
               j.field "size", bytes.size
               j.field "truncated", cut || wire_truncated
-              # `truncated` stays true for either cause (back-compat); `wire_truncated`
-              # disambiguates a capture-time cut (data gone at source, not just the
-              # display cap) so the caller knows whether more is recoverable.
-              j.field "wire_truncated", true if wire_truncated
               # byte_slice can sever a multi-byte codepoint at the cap → scrub the
               # partial tail so the JSON line stays valid UTF-8.
               j.field "text", cut ? s.byte_slice(0, MAX_TEXT).scrub : s
@@ -196,12 +192,12 @@ module Gori
               j.field "binary", true
               j.field "size", bytes.size
               j.field "truncated", cut || wire_truncated
-              # `truncated` stays true for either cause (back-compat); `wire_truncated`
-              # disambiguates a capture-time cut (data gone at source, not just the
-              # display cap) so the caller knows whether more is recoverable.
-              j.field "wire_truncated", true if wire_truncated
               j.field "base64", Base64.strict_encode(slice)
             end
+            # `truncated` (above) is true for either cause (back-compat); `wire_truncated`
+            # disambiguates a capture-time cut (data gone at source, not just the display
+            # cap) so the caller knows whether more is recoverable. Branch-independent.
+            j.field "wire_truncated", true if wire_truncated
             j.field "note", note if note
           end
         end

--- a/src/gori/mcp/serialize.cr
+++ b/src/gori/mcp/serialize.cr
@@ -163,8 +163,10 @@ module Gori
       end
 
       # Emits a `field_name` field carrying a decoded-body summary. nil/empty body
-      # → JSON null. Otherwise an object: {encoding, size, truncated, text|base64,
-      # note?}. `wire_truncated` reflects gori's capture cap on the stored bytes.
+      # → JSON null. Otherwise an object: {encoding, size, truncated, wire_truncated?,
+      # text|base64, note?}. `truncated` is true when the returned text/base64 was cut
+      # (display cap OR capture cap); `wire_truncated` is emitted only when the stored
+      # bytes themselves were cut at gori's capture cap (so the data is gone at source).
       def self.emit_body(j : JSON::Builder, field_name : String, head : Bytes?, body : Bytes?, wire_truncated : Bool) : Nil
         if body.nil? || body.empty?
           j.field field_name, nil
@@ -180,6 +182,10 @@ module Gori
               j.field "encoding", "text"
               j.field "size", bytes.size
               j.field "truncated", cut || wire_truncated
+              # `truncated` stays true for either cause (back-compat); `wire_truncated`
+              # disambiguates a capture-time cut (data gone at source, not just the
+              # display cap) so the caller knows whether more is recoverable.
+              j.field "wire_truncated", true if wire_truncated
               # byte_slice can sever a multi-byte codepoint at the cap → scrub the
               # partial tail so the JSON line stays valid UTF-8.
               j.field "text", cut ? s.byte_slice(0, MAX_TEXT).scrub : s
@@ -190,6 +196,10 @@ module Gori
               j.field "binary", true
               j.field "size", bytes.size
               j.field "truncated", cut || wire_truncated
+              # `truncated` stays true for either cause (back-compat); `wire_truncated`
+              # disambiguates a capture-time cut (data gone at source, not just the
+              # display cap) so the caller knows whether more is recoverable.
+              j.field "wire_truncated", true if wire_truncated
               j.field "base64", Base64.strict_encode(slice)
             end
             j.field "note", note if note

--- a/src/gori/mcp/server.cr
+++ b/src/gori/mcp/server.cr
@@ -29,6 +29,7 @@ module Gori
 
       def initialize(@store : Store, *, allow_actions : Bool, verify_upstream : Bool,
                      @input : IO = STDIN, @output : IO = STDOUT)
+        @allow_actions = allow_actions
         @tools = Tools.new(@store, allow_actions, verify_upstream)
         @initialized = false
       end
@@ -102,7 +103,23 @@ module Gori
                 j.field "version", Gori::VERSION
               end
             end
+            j.field "instructions", instructions_text
           end
+        end
+      end
+
+      # Surfaced at the handshake so the client/model knows up front what this server
+      # exposes — in particular whether the (otherwise simply absent) action tools are
+      # disabled by read-only mode, rather than discovering it only on a rejected call.
+      private def instructions_text : String
+        base = "gori MCP exposes the active project's captured HTTP traffic " \
+               "(history, flows, sitemap, scope, findings)."
+        if @allow_actions
+          "#{base} Action tools are enabled: send_request, fuzz_*, mine_*, and " \
+          "create/update_finding make real outbound requests or mutate findings."
+        else
+          "#{base} Read-only mode: action tools (send_request, fuzz_*, mine_*, " \
+          "create/update_finding) are disabled — restart without --read-only to enable them."
         end
       end
 

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -105,7 +105,8 @@ module Gori
             "filters (e.g. 'host:example.com status:>=500 size:>10000 dur:>500', " \
             "'header:set-cookie', 'body~secret\\d+' — `~` is regex, dur is ms); " \
             "empty query returns the most recent. Returns light rows (no bodies); " \
-            "use get_flow for full detail." do |s|
+            "use get_flow for full detail. Paginate by passing the oldest id seen as " \
+            "`before_id` (rows are newest-first); a page shorter than `limit` means no older rows." do |s|
             s.field "query", strprop("gori QL filter; empty = most recent")
             s.field "limit", intprop("max rows (default 50, max 500)")
             s.field "before_id", intprop("cursor: only flows with id < this (pagination; ignored when query is set)")
@@ -169,7 +170,8 @@ module Gori
               "Start a fuzz/intruder run against an origin and return a job_id " \
               "immediately (poll with fuzz_status / fuzz_results; end with fuzz_stop). " \
               "ACTIVE: sends many real outbound requests from this host. Mark payload " \
-              "positions with §…§ in `template`, or pass `flow_id` + auto:true. Capped " \
+              "positions with §…§ in `template`, or pass `flow_id` + auto:true, then " \
+              "provide payload sets via `payloads`. Capped " \
               "at #{FUZZ_MAX_REQUESTS} requests / #{FUZZ_MAX_CONCURRENCY} concurrency." do |s|
               s.field "template", strprop("raw HTTP request with §…§ position markers")
               s.field "flow_id", intprop("seed the template from a captured flow id (instead of template)")
@@ -184,8 +186,8 @@ module Gori
               s.field "rate", intprop("requests/sec cap (0 = unlimited)")
               s.field "timeout_ms", intprop("per-request connect + idle (read/write) timeout in milliseconds")
               s.field "retries", intprop("retries per request on a network error")
-              s.field "http2", boolprop("use real HTTP/2")
-              s.field "insecure", boolprop("skip upstream TLS verification")
+              s.field "http2", boolprop("use real HTTP/2 (default false)")
+              s.field "insecure", boolprop("skip upstream TLS verification (default false)")
               s.field "max_requests", intprop("caller cap on total requests")
             end
 
@@ -195,11 +197,12 @@ module Gori
 
             tool j, "fuzz_results",
               "Paged matched results for a fuzz job (metrics only — status/length/words/" \
-              "extracted; no raw bodies. Use get_flow/send_request for full detail)." do |s|
+              "extracted; no raw bodies and no per-result flow id). To inspect a hit, " \
+              "re-issue it with send_request, substituting the payload into your template." do |s|
               s.field "job_id", strprop("id from fuzz_start"), required: true
               s.field "offset", intprop("start row (default 0)")
               s.field "limit", intprop("max rows (default 100, max 1000)")
-              s.field "matched_only", boolprop("only matched rows (results are matched-only already)")
+              s.field "matched_only", boolprop("no-op: fuzz results are stored matched-only, so this never changes the page")
             end
 
             tool j, "fuzz_stop", "Stop a running fuzz job (in-flight requests finish)." do |s|
@@ -222,8 +225,8 @@ module Gori
               s.field "rate", intprop("requests/sec cap (0 = unlimited)")
               s.field "timeout_ms", intprop("per-request connect + idle timeout in milliseconds")
               s.field "retries", intprop("retries per request on a network error")
-              s.field "http2", boolprop("use real HTTP/2")
-              s.field "insecure", boolprop("skip upstream TLS verification")
+              s.field "http2", boolprop("use real HTTP/2 (default false)")
+              s.field "insecure", boolprop("skip upstream TLS verification (default false)")
               s.field "max_requests", intprop("caller cap on total requests")
             end
 
@@ -232,7 +235,7 @@ module Gori
             end
 
             tool j, "mine_results",
-              "Paged discovered parameters for a mine job (name, location, evidence, confidence)." do |s|
+              "Paged discovered parameters for a mine job (name, location, evidence, confidence, canary, status, delta)." do |s|
               s.field "job_id", strprop("id from mine_start"), required: true
               s.field "offset", intprop("start row (default 0)")
               s.field "limit", intprop("max rows (default 100, max 1000)")
@@ -377,6 +380,11 @@ module Gori
         Log.info { "send_request #{built.scheme}://#{built.host}:#{built.port} http2=#{http2} -> #{result.ok? ? "ok" : result.error}" }
         return Result.new("send failed: #{result.error}", is_error: true) unless result.ok?
         Result.new(Serialize.replay_result_json(result))
+      rescue ex : Gori::Error
+        # Bad input (missing/invalid url, illegal header, …) — return a clean
+        # actionable message instead of letting call()'s generic "tool error:"
+        # wrapper swallow it, matching fuzz_start's FuzzArgError handling.
+        Result.new(ex.message || "invalid request arguments", is_error: true)
       end
 
       private def create_finding(h) : Result

--- a/src/gori/replay/engine.cr
+++ b/src/gori/replay/engine.cr
@@ -41,7 +41,7 @@ module Gori
         ct = timeout || Proxy::Upstream::CONNECT_TIMEOUT
         it = timeout || Proxy::Upstream::IO_TIMEOUT
         upstream = scheme == "https" ? Proxy::Upstream.dial_tls(host, port, verify: verify_upstream, sni: sni, connect_timeout: ct, io_timeout: it) : Proxy::Upstream.dial(host, port, connect_timeout: ct, io_timeout: it)
-        return error("connect failed: #{host}:#{port}", started) unless upstream
+        return error(connect_error(scheme, host, port, verify_upstream), started) unless upstream
 
         begin
           upstream.write(request)
@@ -83,6 +83,18 @@ module Gori
 
       private def self.error(message : String, started : Time::Instant) : Result
         Result.new(Bytes.new(0), nil, nil, elapsed(started), message)
+      end
+
+      # The dialer collapses DNS failure / connection refused / timeout / TLS-verify
+      # rejection into a single nil socket, so spell out the likely causes — and, for
+      # verified https, that a self-signed/expired cert is a common one — rather than
+      # leaving the user with a bare "connect failed".
+      private def self.connect_error(scheme : String, host : String, port : Int32, verify : Bool) : String
+        if scheme == "https" && verify
+          "connect failed: #{host}:#{port} — host unreachable (DNS/refused/timeout) or the origin's TLS certificate failed verification (e.g. self-signed/expired)"
+        else
+          "connect failed: #{host}:#{port} — host unreachable (DNS/refused/timeout)"
+        end
       end
 
       private def self.elapsed(started : Time::Instant) : Int64

--- a/src/gori/replay/h2_engine.cr
+++ b/src/gori/replay/h2_engine.cr
@@ -38,7 +38,7 @@ module Gori
                     timeout : Time::Span? = nil) : Result
         started = Time.instant
         upstream = open(scheme, host, port, verify_upstream, sni, timeout)
-        return failure("h2 connect failed (no h2 negotiated): #{host}:#{port}", started) unless upstream
+        return failure(connect_error(scheme, host, port, verify_upstream), started) unless upstream
         begin
           headers, body = parse_request(request, scheme, host, port)
           write_request(upstream, headers, body)
@@ -305,6 +305,18 @@ module Gori
 
       private def self.failure(message : String, started : Time::Instant) : Result
         Result.new(Bytes.new(0), nil, nil, elapsed(started), message)
+      end
+
+      # A nil socket here means no usable HTTP/2 connection — could be unreachable,
+      # an origin that doesn't offer h2 over ALPN, or (for verified https) a cert that
+      # failed verification. Spell that out instead of a bare "connect failed".
+      private def self.connect_error(scheme : String, host : String, port : Int32, verify : Bool) : String
+        base = "h2 connect failed (no h2 negotiated): #{host}:#{port}"
+        if scheme == "https" && verify
+          "#{base} — host unreachable, the origin doesn't offer HTTP/2 via ALPN, or its TLS certificate failed verification"
+        else
+          "#{base} — host unreachable or the origin doesn't offer HTTP/2 (h2c) here"
+        end
       end
 
       private def self.elapsed(started : Time::Instant) : Int64

--- a/src/gori/tui/browser_picker.cr
+++ b/src/gori/tui/browser_picker.cr
@@ -54,7 +54,10 @@ module Gori::Tui
     # Centered list card over `area` (the body rect).
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
-      return unless box
+      unless box
+        screen.text(area.x + 1, area.y, "browser picker needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        return
+      end
       w = box.w
       Frame.card(screen, box, "OPEN BROWSER", border: Theme.border_focus)
       screen.text(box.x + 2, box.y + 1, "pre-trusted · proxy auto-set", Theme.muted, Theme.panel)

--- a/src/gori/tui/choice_picker.cr
+++ b/src/gori/tui/choice_picker.cr
@@ -97,7 +97,10 @@ module Gori::Tui
 
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
-      return unless box
+      unless box
+        screen.text(area.x + 1, area.y, "picker needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        return
+      end
       Frame.card(screen, box, @title, border: Theme.border_focus)
       @choices.each_with_index do |ch, i|
         ry = box.y + 1 + i

--- a/src/gori/tui/clipboard.cr
+++ b/src/gori/tui/clipboard.cr
@@ -31,7 +31,11 @@ module Gori::Tui
     # Returns the number of bytes actually placed on the clipboard (≤ MAX_CLIP), so
     # callers can compare against the source size and report when the copy was clipped.
     def self.copy(data : String, io : IO = STDOUT) : Int32
-      data = data[0, MAX_CLIP] if data.size > MAX_CLIP # bound the tty write
+      # Clip by BYTES (not chars): MAX_CLIP bounds the OSC 52 tty write, and the
+      # returned count is a byte count the caller compares to the source byte size.
+      # `byte_slice` may sever a trailing multi-byte codepoint, but the sequence is
+      # base64-encoded from the raw bytes, so that's harmless for a clipboard cap.
+      data = data.byte_slice(0, MAX_CLIP) if data.bytesize > MAX_CLIP
       io.print(osc52(data, tmux: !ENV["TMUX"]?.nil?))
       io.flush
       data.bytesize

--- a/src/gori/tui/clipboard.cr
+++ b/src/gori/tui/clipboard.cr
@@ -27,10 +27,14 @@ module Gori::Tui
     # Emits the sequence to the terminal. In TUI mode STDOUT is the controlling
     # tty (same device termisu draws to); OSC 52 is state-neutral, so it does not
     # disturb the cell grid — the next diff render repaints normally.
-    def self.copy(data : String, io : IO = STDOUT) : Nil
+    #
+    # Returns the number of bytes actually placed on the clipboard (≤ MAX_CLIP), so
+    # callers can compare against the source size and report when the copy was clipped.
+    def self.copy(data : String, io : IO = STDOUT) : Int32
       data = data[0, MAX_CLIP] if data.size > MAX_CLIP # bound the tty write
       io.print(osc52(data, tmux: !ENV["TMUX"]?.nil?))
       io.flush
+      data.bytesize
     end
   end
 end

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -390,7 +390,13 @@ module Gori::Tui
       case ev
       when Fuzz::ProgressEvent
         v.apply_progress(ev.progress)
-        @host.jobs.progress(v.job_id, ev.progress.sent.to_i, ev.progress.total.try(&.to_i), "#{ev.progress.matched} hit")
+        # Fuzz totals are Int64 and can exceed Int32::MAX (cluster-bomb / brute / huge
+        # ranges); Jobs.progress takes Int32, and Int64#to_i is checked (raises
+        # OverflowError on the run-loop fiber). Clamp to the Int32 ceiling for display.
+        @host.jobs.progress(v.job_id,
+          ev.progress.sent.clamp(0_i64, Int32::MAX.to_i64).to_i32,
+          ev.progress.total.try(&.clamp(0_i64, Int32::MAX.to_i64).to_i32),
+          "#{ev.progress.matched} hit")
       when Fuzz::ResultEvent then v.append_result(ev.result)
       when Fuzz::DoneEvent
         v.finish_run

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -388,14 +388,42 @@ module Gori::Tui
 
     private def apply_event(v : FuzzerView, ev : Fuzz::Event) : Nil
       case ev
-      when Fuzz::ProgressEvent then v.apply_progress(ev.progress)
-      when Fuzz::ResultEvent   then v.append_result(ev.result)
+      when Fuzz::ProgressEvent
+        v.apply_progress(ev.progress)
+        @host.jobs.progress(v.job_id, ev.progress.sent.to_i, ev.progress.total.try(&.to_i), "#{ev.progress.matched} hit")
+      when Fuzz::ResultEvent then v.append_result(ev.result)
       when Fuzz::DoneEvent
         v.finish_run
-        @host.status("fuzz done · #{v.matched_count}/#{v.result_count} matched#{ev.stopped ? " (stopped)" : ""}")
+        finish_job(v, ev)
       when Fuzz::ErrorEvent
         v.finish_run
+        # Persist the failure in the bottom bar + notification center so it survives the
+        # next keystroke (a transient toast alone is cleared on the very next key).
+        @host.jobs.finish(v.job_id, :error, ev.message)
+        @host.notifications.push(:error, "Fuzzer: #{ev.message} on #{v.summary}", goto_for(v))
         @host.status("fuzz error: #{ev.message}")
+      end
+    end
+
+    private def finish_job(v : FuzzerView, ev : Fuzz::DoneEvent) : Nil
+      n = v.matched_count
+      @host.jobs.finish(v.job_id, :done, "#{n} hit")
+      level = n > 0 ? :success : :info
+      msg = "Fuzzer: #{n} hit#{n == 1 ? "" : "s"} / #{v.result_count} sent on #{v.summary}#{ev.stopped ? " (stopped)" : ""}"
+      @host.notifications.push(level, msg, goto_for(v))
+      @host.status(msg)
+    end
+
+    private def goto_for(v : FuzzerView) : Jobs::Goto?
+      tab = @fuzzers.find(&.view.same?(v))
+      (tab && (id = tab.db_id)) ? Jobs::Goto.new(:fuzzer, id) : nil
+    end
+
+    # Focus a fuzz sub-tab by persisted id (notification "jump to result").
+    def reveal_session(id : Int64) : Nil
+      if idx = @fuzzers.index { |t| t.db_id == id }
+        @current_idx = idx
+        @host.focus_body
       end
     end
 
@@ -406,6 +434,12 @@ module Gori::Tui
         @host.status("fuzz running — ^X to stop")
         return
       end
+      # Flush any trailing Done/Error from a just-finished run before we rebind
+      # job_id below. The engine sends its terminal event onto @fuzz_events BEFORE
+      # the fiber's `ensure` flips running? false, so a ^R landing in that window
+      # would otherwise apply the stale event to the NEW run's job (premature/wrong
+      # "done", orphaned bottom-bar spinner). Draining now settles the old job first.
+      drain_events
       engine, err = v.build_engine(!@host.session.config.insecure_upstream?)
       unless engine
         @host.status(err || "cannot run")
@@ -429,6 +463,7 @@ module Gori::Tui
     private def start_run(v : FuzzerView, engine : Fuzz::Engine, total : Int64?) : Nil
       save_current
       v.begin_run(total)
+      v.job_id = @host.jobs.start(:fuzz, v.summary, goto: goto_for(v))
       events = @fuzz_events
       calibrate = v.config.auto_calibrate?
       spawn(name: "gori-fuzz") do
@@ -504,6 +539,10 @@ module Gori::Tui
       return if @current_idx < 0 || @current_idx >= @fuzzers.size
       tab = @fuzzers[@current_idx]
       tab.view.request_stop # halt a running sweep before detaching its view (the run fiber polls this)
+      # Finish the job NOW: once the view leaves @fuzzers, drain_events drops its remaining
+      # events (incl. Done), so jobs.finish would never run and the bottom-bar spinner would
+      # animate forever (mirrors MinerController#close_tab).
+      @host.jobs.finish(tab.view.job_id, :stopped, "closed") if tab.view.running?
       if id = tab.db_id
         @host.session.store.delete_fuzz_session(id)
       end

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -180,8 +180,10 @@ module Gori::Tui
       io = IO::Memory.new
       io.write(detail.request_head)
       io.write(detail.request_body.not_nil!) if detail.request_body
-      Clipboard.copy(String.new(io.to_slice))
-      @host.status("copied #{detail.row.method} #{Url.origin_path(detail.row.target)} to clipboard (#{io.size}b)")
+      written = Clipboard.copy(String.new(io.to_slice))
+      msg = "copied #{detail.row.method} #{Url.origin_path(detail.row.target)} to clipboard (#{written}b)"
+      msg += " — clipped from #{io.size}b (64KB cap)" if written < io.size
+      @host.status(msg)
     end
 
     def history_query : Nil

--- a/src/gori/tui/controllers/miner_controller.cr
+++ b/src/gori/tui/controllers/miner_controller.cr
@@ -328,6 +328,11 @@ module Gori::Tui
         @host.status("already mining — ^X to stop")
         return
       end
+      # Flush any trailing Done/Error from a just-finished run before start_run rebinds
+      # job_id: the engine sends its terminal event BEFORE the fiber's `ensure` flips
+      # running? false, so a re-run landing in that window would otherwise settle the
+      # stale event against the NEW job (premature/wrong "done", orphaned spinner).
+      drain_events
       start_run(v)
     end
 

--- a/src/gori/tui/controllers/prism_controller.cr
+++ b/src/gori/tui/controllers/prism_controller.cr
@@ -35,7 +35,7 @@ module Gori::Tui
 
     def body_hint(focus : Symbol) : String
       if @prism.detail_open?
-        "o flow · r replay · p promote · c dismiss · d delete · ←/esc back"
+        "o flow · r replay · p promote · c dismiss · d delete · space cmds · ←/esc back"
       elsif @prism.querying?
         "type to filter · ↹ complete · ↵ apply · esc clear"
       elsif @prism.mode.off?
@@ -182,13 +182,15 @@ module Gori::Tui
     def prism_dismiss : Nil
       return unless @prism.target_issue
       st = @prism.toggle_dismiss(@host.session.store)
-      @host.notifications.push(:success, st.try(&.open?) ? "issue re-opened" : "issue dismissed")
+      # A synchronous user action → transient toast (the list updates in place too),
+      # matching the rest of the app; the notification center is for async events.
+      @host.status(st.try(&.open?) ? "issue re-opened" : "issue dismissed")
     end
 
     # `a`: flip the open-only ⇄ show-closed lens.
     def prism_toggle_closed : Nil
       showing = @prism.toggle_show_closed
-      @host.notifications.push(:info, showing ? "showing closed issues" : "showing open issues only")
+      @host.status(showing ? "showing closed issues" : "showing open issues only")
     end
 
     # Space-menu bulk actions: mute every OPEN issue sharing the targeted issue's code / host
@@ -197,7 +199,7 @@ module Gori::Tui
       return unless i = @prism.target_issue
       @host.confirm("DISMISS GROUP", "Dismiss all open \"#{i.code}\" issues?", confirm_label: "dismiss", danger: false) do
         n = @prism.dismiss_by_code(@host.session.store)
-        @host.notifications.push(:success, "dismissed #{n} \"#{i.code}\" issue#{n == 1 ? "" : "s"}")
+        @host.status("dismissed #{n} \"#{i.code}\" issue#{n == 1 ? "" : "s"}")
       end
     end
 
@@ -205,7 +207,7 @@ module Gori::Tui
       return unless i = @prism.target_issue
       @host.confirm("DISMISS GROUP", "Dismiss all open issues on #{i.host}?", confirm_label: "dismiss", danger: false) do
         n = @prism.dismiss_by_host(@host.session.store)
-        @host.notifications.push(:success, "dismissed #{n} issue#{n == 1 ? "" : "s"} on #{i.host}")
+        @host.status("dismissed #{n} issue#{n == 1 ? "" : "s"} on #{i.host}")
       end
     end
   end

--- a/src/gori/tui/controllers/replay_controller.cr
+++ b/src/gori/tui/controllers/replay_controller.cr
@@ -308,7 +308,7 @@ module Gori::Tui
         if (id = tab.db_id) && result.ok?
           @host.session.store.update_replay_response(id, result.head, result.body, result.error, result.duration_us)
         end
-        @host.status(result.ok? ? "replayed → #{result.response.try(&.status)} in #{result.duration_us // 1000}ms"
+        @host.status(result.ok? ? "replayed → #{result.response.try(&.status)} in #{result.duration_us // 1000}ms#{result.incomplete? ? " (incomplete)" : ""}"
                                  : "replay error: #{result.error}")
         applied = true
       end
@@ -483,7 +483,7 @@ module Gori::Tui
       end
       scheme, host, port = view.parse_target
       if host.empty?
-        @host.status("replay: invalid target")
+        @host.status("replay: invalid target — use scheme://host[:port]/path")
         return
       end
       if view.ws_mode?

--- a/src/gori/tui/controllers/sitemap_controller.cr
+++ b/src/gori/tui/controllers/sitemap_controller.cr
@@ -175,6 +175,7 @@ module Gori::Tui
         # A `tag:` filter must re-evaluate against the changed tag (the in-place stamp
         # doesn't re-filter), else the just-tagged node stays hidden / a cleared tag shown.
         reload if @sitemap.filtering?
+        @host.status(text.empty? ? "tag cleared" : "tagged: #{text}")
       else
         @sitemap.cancel_tag
       end

--- a/src/gori/tui/flow_picker.cr
+++ b/src/gori/tui/flow_picker.cr
@@ -96,7 +96,10 @@ module Gori::Tui
 
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
-      return unless box
+      unless box
+        screen.text(area.x + 1, area.y, "flow picker needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        return
+      end
       Frame.card(screen, box, "PICK FLOW #{@target.to_s.upcase}", border: Theme.border_focus)
 
       if @query.empty? && @preedit.empty?

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -45,6 +45,7 @@ module Gori::Tui
     getter? dirty : Bool
     getter? running : Bool
     property name : String?
+    property job_id : Int32 # bottom-bar/notification job handle (0 = no active job)
     getter config : Fuzz::Config
     getter matcher : Fuzz::Matcher
 
@@ -100,6 +101,7 @@ module Gori::Tui
       @dist_cache_w = -1
       @progress = nil.as(Fuzz::Progress?)
       @run_total = nil.as(Int64?)
+      @job_id = 0
       @stop_requested = false
       @detail_scroll = 0
       @detail_pane = :response
@@ -660,7 +662,7 @@ module Gori::Tui
       return {nil, "mark a position first — ^A params · ^K word"} if template.position_count == 0
       return {nil, "add a payload set — ^O config · pick a type · ⏎ add"} if @sets.empty?
       scheme, host, port = Replay::FlowRequest.parse_target(@target)
-      return {nil, "invalid target"} if host.empty?
+      return {nil, "invalid target — use scheme://host[:port]/path"} if host.empty?
       sets = @sets.map { |s| Fuzz::PayloadSet.new(build_source(s)) }
       gen_sets = @config.mode.per_position? ? sets : [sets.first]
       generator = Fuzz::Generator.new(template, gen_sets, @config)

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -17,6 +17,7 @@ module Gori::Tui
         {"^P", "command palette"},
         {"space", "focus-area action menu"},
         {"c", "toggle capture"},
+        {"s · m", "scope lens · Match & Replace rules"},
         {"^B", "reveal whitespace (·→␍␊)"},
         {"^D / ^C ×2", "quit gori"},
         {"q", "back to projects (on the tab bar)"},
@@ -34,7 +35,7 @@ module Gori::Tui
         {"click tab", "switch to it"},
         {"click row", "select · click again opens"},
         {"click pane", "focus · in an editor, place the caret"},
-        {"sub-tab chip", "switch · right-click renames (Replay/Fuzzer)"},
+        {"sub-tab chip", "switch · right-click renames (Replay/Fuzzer/Convert)"},
         {"wheel", "scroll / move the selection"},
         {"click outside", "close a popup"},
       ]},
@@ -53,6 +54,7 @@ module Gori::Tui
         {"r", "rename the sub-tab (on the strip)"},
         {"^X", "hex-edit the request"},
         {"^S", "SNI override (on the target)"},
+        {"^L", "toggle auto Content-Length"},
         {"↹", "cycle target → request → response"},
         {"x · d · p", "response: hex · diff · pretty"},
       ]},
@@ -80,8 +82,9 @@ module Gori::Tui
         {"^B", "reveal whitespace"},
       ]},
       {"OTHER TABS", [
-        {"Sitemap", "↑/↓ move · / filter · ↵/→ expand · ← collapse"},
+        {"Sitemap", "↑/↓ · / filter · ↵/→ expand · t tag · g group · ⇧S scope"},
         {"Findings", "/ filter · ↵ open · n new · space triage · x export"},
+        {"Prism", "↑/↓ ↵ open · m mode · c dismiss · a all · / filter · space cmds"},
         {"Notes", "type to edit · ^N new · ^1-9 switch"},
         {"Project", "scope rules + the description editor"},
         {"Intercept", "↵/e edit · f fwd · d drop · F all · c catch dir · / condition"},
@@ -99,7 +102,7 @@ module Gori::Tui
       {"OVERLAYS", [
         {"palette / settings", "↑/↓ · ↵ · esc"},
         {"confirm", "←/→ choose · y / n · ↵"},
-        {"settings: mouse", "toggle mouse support on/off"},
+        {"settings:editor", "toggle mouse support (Mouse field)"},
       ]},
     ]
 

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -610,11 +610,12 @@ module Gori::Tui
         # Mirror Findings/Prism: a recovery hint under the message. The QL-clear
         # cue only applies to a real query (not a Scope-lens-only empty set, which
         # ⇧S toggles off), so branch on @querying / @query before filtering?.
+        # Branch on a real `/` query FIRST (querying-aware hint): a blank-query empty
+        # set is caused by the Scope lens or no traffic, where "esc clears the filter"
+        # would mislead (⇧S clears the lens). Mirrors sitemap_view's ordering.
         msg, hint =
-          if @querying
-            {"no flows match", "esc clears the filter"}
-          elsif !@query.blank?
-            {"no flows match", "/ to edit the filter"}
+          if !@query.blank?
+            {"no flows match", @querying ? "esc clears the filter" : "/ to edit the filter"}
           elsif filtering? # in-scope subset is empty (Scope lens, no QL query)
             {"no flows in scope", "⇧S clears the scope lens"}
           else

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -607,8 +607,21 @@ module Gori::Tui
       ensure_visible(list_h)
 
       if @rows.empty?
-        msg = filtering? ? "no flows match" : "waiting for traffic…"
+        # Mirror Findings/Prism: a recovery hint under the message. The QL-clear
+        # cue only applies to a real query (not a Scope-lens-only empty set, which
+        # ⇧S toggles off), so branch on @querying / @query before filtering?.
+        msg, hint =
+          if @querying
+            {"no flows match", "esc clears the filter"}
+          elsif !@query.blank?
+            {"no flows match", "/ to edit the filter"}
+          elsif filtering? # in-scope subset is empty (Scope lens, no QL query)
+            {"no flows in scope", "⇧S clears the scope lens"}
+          else
+            {"waiting for traffic…", "browse through the proxy, then return here"}
+          end
         screen.text(time_x, list_top, msg, Theme.muted)
+        screen.text(time_x, list_top + 2, hint, Theme.muted) if list_h > 2
         return
       end
 
@@ -759,7 +772,7 @@ module Gori::Tui
 
     private def render_ql_bar(screen : Screen, rect : Rect) : Nil
       if @querying
-        prefix = "query › "
+        prefix = "filter › "
         screen.text(rect.x + 1, rect.y, prefix, Theme.accent)
         base = rect.x + 1 + prefix.size
         screen.input_line(base, rect.y, @query, @qcx, @preedit, Theme.text_bright, width: rect.w - prefix.size - 2)

--- a/src/gori/tui/miner_view.cr
+++ b/src/gori/tui/miner_view.cr
@@ -213,7 +213,7 @@ module Gori::Tui
     # --- engine ---
     def build_engine(verify : Bool) : {Miner::Engine?, String?}
       scheme, host, port = Replay::FlowRequest.parse_target(@target)
-      return {nil, "invalid target"} if host.empty?
+      return {nil, "invalid target — use scheme://host[:port]/path"} if host.empty?
       return {nil, "no locations selected"} if @config.locations.empty?
       names = Miner::Wordlist.load(@config.user_wordlist)
       return {nil, "wordlist is empty"} if names.empty?
@@ -316,7 +316,15 @@ module Gori::Tui
       Frame.card(screen, rect, "FINDINGS (#{@results.size})", border: focused ? Theme.focus_gold : Theme.border, bg: Theme.bg)
       inner = rect.inset(1, 1)
       if @results.empty?
-        msg = @running ? "mining… discovered parameters appear here" : "no hidden parameters found"
+        # Distinguish never-run from a completed run that found nothing, using the
+        # same signal the status line does (names_total > 0 ⇒ a run happened).
+        msg = if @running
+                "mining… discovered parameters appear here"
+              elsif @progress.names_total > 0
+                "no hidden parameters found"
+              else
+                "no run yet — ^R to mine"
+              end
         screen.text(inner.x + 1, inner.y, msg, Theme.muted, Theme.bg)
         return
       end

--- a/src/gori/tui/palette.cr
+++ b/src/gori/tui/palette.cr
@@ -78,7 +78,10 @@ module Gori::Tui
     # Renders a centered overlay box within `area`.
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
-      return if box.empty?
+      if box.empty?
+        screen.text(area.x + 1, area.y, "command palette needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        return
+      end
       w = box.w
       Frame.card(screen, box, "COMMANDS", border: Theme.border_focus)
 
@@ -90,6 +93,10 @@ module Gori::Tui
 
       list_top = box.y + 3
       list_h = box.bottom - 1 - list_top
+      if @results.empty?
+        screen.text(box.x + 3, list_top, "no commands match", Theme.muted, Theme.panel)
+        return
+      end
       ensure_visible(list_h)
       (0...list_h).each do |i|
         idx = @scroll + i

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -935,6 +935,13 @@ module Gori::Tui
         meta = result.ok? ? "#{Fmt.dur(result.duration_us)} · #{Fmt.size((result.head.size + (result.body.try(&.size) || 0)).to_i64)}" : Fmt.dur(result.duration_us)
         meta_x = rect.right - meta.size - 1
         screen.text(meta_x, rect.y, meta, Theme.muted, Theme.bg) if meta_x > chips_end + 1
+        # A persistent amber marker when the response was cut short (the body the
+        # origin sent is incomplete) — the transient send toast scrolls away.
+        if result.incomplete?
+          warn = "⚠ incomplete"
+          warn_x = meta_x - warn.size - 2
+          screen.text(warn_x, rect.y, warn, Theme.yellow, Theme.bg) if warn_x > chips_end + 1
+        end
       end
     end
 

--- a/src/gori/tui/rules_overlay.cr
+++ b/src/gori/tui/rules_overlay.cr
@@ -14,6 +14,7 @@ module Gori::Tui
   class RulesOverlay
     def initialize(@rules : Rules)
       @selected = 0
+      @scroll = 0
       @input = ""
       @icx = 0
       @preedit = ""
@@ -21,6 +22,7 @@ module Gori::Tui
 
     def reset : Nil
       @selected = 0
+      @scroll = 0
       @input = ""
       @icx = 0
       @preedit = ""
@@ -108,7 +110,10 @@ module Gori::Tui
 
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
-      return unless box
+      unless box
+        screen.text(area.x + 1, area.y, "Match & Replace editor needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        return
+      end
       w = box.w
       Frame.card(screen, box, "MATCH & REPLACE", border: Theme.border_focus)
 
@@ -128,11 +133,24 @@ module Gori::Tui
       if rules.empty?
         screen.text(box.x + 3, list_top, "(none — e.g.  resp: Old => New )", Theme.muted, Theme.panel)
       else
+        ensure_visible(list_h)
         (0...list_h).each do |i|
-          break if i >= rules.size
-          render_rule_row(screen, box, rules[i], list_top + i, w, i == @selected)
+          idx = @scroll + i
+          break if idx >= rules.size
+          render_rule_row(screen, box, rules[idx], list_top + i, w, idx == @selected)
         end
       end
+    end
+
+    # Scroll the list so the selected rule stays on screen (sibling-overlay idiom).
+    private def ensure_visible(list_h : Int32) : Nil
+      return if list_h <= 0
+      if @selected < @scroll
+        @scroll = @selected
+      elsif @selected >= @scroll + list_h
+        @scroll = @selected - list_h + 1
+      end
+      @scroll = @scroll.clamp(0, {@rules.rules.size - list_h, 0}.max)
     end
 
     # One row in the rule list: selection bar, enabled `✓`/`·`, REQ/RES tag, rule.
@@ -156,7 +174,8 @@ module Gori::Tui
       list_top = box.y + 3
       i = my - list_top
       return nil if i < 0 || i >= box.bottom - 1 - list_top
-      i < @rules.rules.size ? i : nil
+      idx = @scroll + i
+      idx < @rules.rules.size ? idx : nil
     end
 
     # Clamp the selection to a populated row (matches select_move's bounds).

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1366,8 +1366,8 @@ module Gori::Tui
         @hosts_overlay.add_start
       elsif c == 'd'
         if host = @hosts_overlay.delete_selected
-          save_hosts
-          @toast = "removed host override: #{host}"
+          ok = save_hosts
+          @toast = ok ? "removed host override: #{host}" : "removed #{host} — could not save to #{Settings.path}"
         end
       end
     end
@@ -1385,8 +1385,8 @@ module Gori::Tui
         when :invalid then @toast = %(host override: need "IP host" — a valid IP + a hostname)
         when :dup     then @toast = "host override: host already mapped"
         when :ok
-          save_hosts
-          @toast = "host override saved — #{@hosts_overlay.to_overrides.size} total"
+          ok = save_hosts
+          @toast = ok ? "host override saved — #{@hosts_overlay.to_overrides.size} total" : "host override applied — could not save to #{Settings.path}"
         end
       elsif key.left?
         @hosts_overlay.move_cursor(-1)
@@ -1400,7 +1400,9 @@ module Gori::Tui
       end
     end
 
-    private def save_hosts : Nil
+    # Returns Settings.save's success so callers can branch the toast (saved vs
+    # applied-but-not-persisted), like save_tabs/save_hotkeys.
+    private def save_hosts : Bool
       Settings.hostname_overrides = @hosts_overlay.to_overrides.dup
       Settings.save
     end

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -483,9 +483,18 @@ module Gori::Tui
       return if tree.h <= 0
 
       unless @loaded && !@hosts.empty?
-        msg = filtering? ? "no endpoints match" : "no traffic captured yet"
+        # A recovery hint mirrors Findings/Prism. The QL-clear cue only applies to a
+        # real `/` query — a Scope-lens-only empty set isn't cleared with esc//.
+        msg, hint =
+          if !@query.blank?
+            {"no endpoints match", querying? ? "esc clears the filter" : "/ to edit the filter"}
+          elsif filtering? # in-scope subset is empty (Scope lens, no QL query)
+            {"no endpoints in scope", nil}
+          else
+            {"no traffic captured yet", "browse through the proxy, then return here"}
+          end
         screen.text(tree.x + 1, tree.y, msg, Theme.muted)
-        screen.text(tree.x + 1, tree.y + 2, "browse through the proxy, then return here", Theme.muted) unless filtering?
+        screen.text(tree.x + 1, tree.y + 2, hint, Theme.muted) if hint && tree.h > 2
         return
       end
 
@@ -619,7 +628,7 @@ module Gori::Tui
 
     private def render_ql_bar(screen : Screen, rect : Rect) : Nil
       if @querying
-        prefix = "query › "
+        prefix = "filter › "
         screen.text(rect.x + 1, rect.y, prefix, Theme.accent)
         base = rect.x + 1 + prefix.size
         screen.input_line(base, rect.y, @query, @qcx, @preedit, Theme.text_bright, width: rect.w - prefix.size - 2)

--- a/src/gori/tui/subtab_picker.cr
+++ b/src/gori/tui/subtab_picker.cr
@@ -94,7 +94,10 @@ module Gori::Tui
 
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
-      return unless box
+      unless box
+        screen.text(area.x + 1, area.y, "picker needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        return
+      end
       Frame.card(screen, box, @title, border: Theme.border_focus)
 
       if @query.empty? && @preedit.empty?


### PR DESCRIPTION
## What

A design-completeness pass across the **TUI, CLI, and MCP** surfaces. Every change is **polish / feedback / consistency — no functional behavior changes**. Driven by a per-surface UX audit (46 of 47 findings implemented; 1 deferred with rationale).

## TUI
- **Help cheat-sheet accuracy**: GLOBAL `s · m` (scope lens / Match & Replace), REPLAY `^L`, a Prism row, refreshed Sitemap row, `(Replay/Fuzzer/Convert)` rename note, and fixed the bogus `settings: mouse` → `settings:editor`.
- **Empty-states**: History/Sitemap second-line + filter-clear hints (mirroring Findings/Prism); palette + all 5 centered pickers draw a *"needs a larger window"* fallback when too small; palette *"no commands match"*; Miner distinguishes never-run from ran-empty.
- **rules_overlay**: scrolls to keep the selection on screen.
- **Feedback / errors**: clipboard copy reports the 64KB clip; Replay shows a persistent `⚠ incomplete` marker; replay `Engine`/`H2Engine` connect-failure spells out DNS/refused/timeout/cert-verify; `save_hosts` branches the toast on `Settings.save`; Prism triage uses transient toasts; unified filter prompt `query ›` → `filter ›`; actionable `invalid target` message.
- Wire the **Fuzzer into the Jobs/Notifications** layer (like the Miner), draining trailing events on re-run so a stale `Done` can't settle the new job.

## CLI
- `gori export ca-cert --help` works (and `--ca-dir` is documented); unknown `export` subcommand lists subcommands + exits non-zero; `-k` alias on capture/replay; `\r` progress meters gated on `STDERR.tty?`; numeric parse errors name the flag; `replay --diff` prints a change summary; projects JSON gains an ISO `time`; capture banner + Ctrl-C hint.

## MCP
- `initialize` returns an `instructions` string (read-only vs actions-enabled); `send_request` returns clean input errors; serialize emits `wire_truncated` distinct from the display-cap `truncated`; tool-description fixes (fuzz payloads-required / fuzz_results no-flow-id / matched_only no-op / http2+insecure defaults / mine_results fields / list_history `before_id` cursor).

## Deferred (1)
Findings/Prism filter bars advertise `↹ complete` but show no live suggestion-preview row like History/Sitemap. Adding it needs a layout offset threaded through `top`/mouse-hit-testing/scroll in two core views — highest regression risk for the lowest-severity gap, and Tab-complete already works.

## Testing
- `shards build` clean; **947 specs pass** (0 failures).
- Format-clean (touched files) and lint-neutral (only pre-existing ameba items remain).
- Smoke-tested via tmux (Help rows, empty-states, filter hints, palette empty-state), plus MCP `instructions` and CLI `ca-cert --help`/unknown-subcommand verified directly.