### PR TITLE
feat(ux): notif `n` hotkey, single-tab sub-tab strip, gold sub-tab focus

### DIFF
--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -181,8 +181,11 @@ module Gori::Tui
     # ACTIVE one is always visible — advance the window start until [start..active]
     # fits, instead of breaking at the first overflow and hiding the active tab off
     # the right edge. `‹` / `›` markers flag tabs hidden off either edge. Each label
-    # is drawn as a " label " segment; the active one is a filled bright/bold band
-    # (focus → ACCENT_BG, else SELECTION_DIM). Mirrors render_menu's windowing.
+    # is drawn as a " label " segment. The active chip, when the strip HOLDS FOCUS, is a
+    # solid FOCUS_GOLD pill (the same gold that outlines a focused body pane — so "gold =
+    # focus is here" reads one level down too, and clearly beats the old near-identical
+    # ACCENT_BG/SELECTION_DIM bands); at rest it settles to a dim SELECTION_DIM band.
+    # Mirrors render_menu's windowing.
     def self.render_tab_strip(screen : Screen, rect : Rect, labels : Array(String),
                               active : Int32, focused : Bool, *, bg : Color = Theme.panel) : Nil
       return if rect.empty? || labels.empty?
@@ -191,8 +194,8 @@ module Gori::Tui
       segs, start, last = strip_layout(rect, labels, active)
       segs.each do |(i, label, seg)|
         if i == active
-          abg = focused ? Theme.accent_bg : Theme.selection_dim
-          afg = focused ? Theme.text_bright : Theme.text
+          abg = focused ? Theme.focus_gold : Theme.selection_dim
+          afg = focused ? Theme.ink_on(Theme.focus_gold) : Theme.text
           screen.fill(seg, abg)
           screen.text(seg.x + 1, seg.y, label, afg, abg, attr: Attribute::Bold)
         else

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -64,6 +64,12 @@ module Gori::Tui
       @current_idx
     end
 
+    # Show the strip from the FIRST fuzzer (not ≥2): a single session still labels its
+    # chip and exposes the strip's space-menu. Empty → no strip.
+    def subtab_strip_shown? : Bool
+      !@fuzzers.empty?
+    end
+
     def view_at(idx : Int32) : FuzzerView?
       (0 <= idx < @fuzzers.size) ? @fuzzers[idx].view : nil
     end
@@ -96,7 +102,7 @@ module Gori::Tui
     def render_body(screen : Screen, rect : Rect, focus : Symbol) : Nil
       body_focused = focus == :body
       body_rect = rect
-      if @fuzzers.size >= 2
+      if subtab_strip_shown?
         sub_rect, body_rect = BodyChrome.carve_subtab_row(rect)
         BodyChrome.render_subtab_strip(screen, sub_rect, subtab_labels, @current_idx, focus == :subtabs)
       end
@@ -215,7 +221,7 @@ module Gori::Tui
       key = ev.key
       case
       when key.enter?, key.down? then v.pane_advance(1)
-      when key.up?               then @host.request_focus(@fuzzers.size >= 2 ? :subtabs : :menu)
+      when key.up?               then @host.request_focus(subtab_strip_shown? ? :subtabs : :menu)
       when key.backspace?        then v.target_backspace
       when key.left?             then v.target_move(-1)
       when key.right?            then v.target_move(1)
@@ -242,7 +248,7 @@ module Gori::Tui
     end
 
     private def template_up(v : FuzzerView) : Nil
-      v.at_top? ? @host.request_focus(@fuzzers.size >= 2 ? :subtabs : :menu) : v.template_move(-1, 0)
+      v.at_top? ? @host.request_focus(subtab_strip_shown? ? :subtabs : :menu) : v.template_move(-1, 0)
     end
 
     private def edit_config(ev : Termisu::Event::Key, v : FuzzerView) : Nil
@@ -261,14 +267,14 @@ module Gori::Tui
     end
 
     private def config_up(v : FuzzerView) : Nil
-      v.at_top? ? @host.request_focus(@fuzzers.size >= 2 ? :subtabs : :menu) : v.form_move(-1)
+      v.at_top? ? @host.request_focus(subtab_strip_shown? ? :subtabs : :menu) : v.form_move(-1)
     end
 
     private def handle_results(ev : Termisu::Event::Key, v : FuzzerView) : Nil
       key = ev.key
       case
       when key.enter?   then v.open_detail
-      when key.up?      then v.at_top? ? @host.request_focus(@fuzzers.size >= 2 ? :subtabs : :menu) : v.results_move(-1)
+      when key.up?      then v.at_top? ? @host.request_focus(subtab_strip_shown? ? :subtabs : :menu) : v.results_move(-1)
       when key.down?    then v.results_move(1)
       when key.lower_o? then @host.status(v.cycle_sort)
       when key.lower_m? then @host.status(v.toggle_matched_only)
@@ -286,7 +292,7 @@ module Gori::Tui
     end
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
-      body = @fuzzers.size >= 2 ? BodyChrome.carve_subtab_row(rect)[1] : rect
+      body = subtab_strip_shown? ? BodyChrome.carve_subtab_row(rect)[1] : rect
       return true unless v = current_view
       if pane = v.pane_at(body, mx, my)
         save_current

--- a/src/gori/tui/controllers/replay_controller.cr
+++ b/src/gori/tui/controllers/replay_controller.cr
@@ -89,6 +89,13 @@ module Gori::Tui
       @current_replay_idx
     end
 
+    # Show the strip from the FIRST session (not ≥2): a single replay still labels its
+    # chip and exposes the strip's space-menu (the editor body swallows space). Empty →
+    # no strip (the "no replays" placeholder takes the full body).
+    def subtab_strip_shown? : Bool
+      !@replays.empty?
+    end
+
     def body_badge : Symbol # request (incl. hex) + target URL are editable; response is read-only
       (v = current_view) ? ((v.focus == :request || v.focus == :target) ? :editor : :body) : :body
     end
@@ -129,7 +136,7 @@ module Gori::Tui
       body_focused = focus == :body
       current_replay_tab.try { |t| t.view.reveal = @host.reveal?; t.view.pretty = @host.pretty? }
       body_rect = rect
-      if @replays.size >= 2
+      if subtab_strip_shown?
         sub_rect, body_rect = BodyChrome.carve_subtab_row(rect)
         BodyChrome.render_subtab_strip(screen, sub_rect, subtab_labels, @current_replay_idx, focus == :subtabs)
       end
@@ -220,7 +227,7 @@ module Gori::Tui
     end
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
-      body = @replays.size >= 2 ? BodyChrome.carve_subtab_row(rect)[1] : rect
+      body = subtab_strip_shown? ? BodyChrome.carve_subtab_row(rect)[1] : rect
       return true unless v = current_view
       if pane = v.pane_at(body, mx, my)
         save_current_replay
@@ -627,7 +634,7 @@ module Gori::Tui
       key = ev.key
       case
       when key.enter? then view.pane_advance(1)                                       # ↵ confirms URL → Request (^R sends, not ↵)
-      when key.up?    then @host.request_focus(@replays.size >= 2 ? :subtabs : :menu) # target is the top pane → ↑ pops up
+      when key.up?    then @host.request_focus(subtab_strip_shown? ? :subtabs : :menu) # target is the top pane → ↑ pops up
       when key.down?  then view.pane_advance(1)                                        # ↓ → drop into the Request pane below
       else                 edit_target_common(ev, view)
       end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1470,12 +1470,11 @@ module Gori::Tui
       @toast = ok ? "hotkeys saved" : "hotkeys applied — could not save to #{Settings.path}"
     end
 
-    # The Notes tab is a live editor (like Replay): typing edits the document
-    # directly. Esc / Ctrl-P / Ctrl-C leave editing and persist first.
-    # A navigable sub-tab strip exists (≥2 chips) — gates entry into :subtabs. Replay
-    # draws its strip at size>0 but a lone chip has nowhere to switch to.
+    # A navigable sub-tab strip is showing — gates entry into :subtabs (and the strip
+    # click/rename paths). Each controller decides its own threshold (Notes/Convert ≥2;
+    # Replay/Fuzzer ≥1 so a single session is still labelled + space-menu reachable).
     private def subtabs_shown? : Bool
-      (@tabs[@active_tab]?.try(&.subtab_labels).try(&.size) || 0) >= 2 # Replay/Fuzzer/Notes/Convert expose a strip
+      @tabs[@active_tab]?.try(&.subtab_strip_shown?) || false
     end
 
     # The focusable sub-tab strip for Replay/Fuzzer/Notes/Convert (@focus == :subtabs). Mirrors the

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -123,6 +123,15 @@ module Gori::Tui
       0
     end
 
+    # Whether the sub-tab strip is drawn AND `:subtabs` is a focusable pane. Default:
+    # only with ≥2 chips — a lone chip has nowhere to switch to, so the row is better
+    # spent on the body. Replay/Fuzzer override to show a single chip too, so the active
+    # session is always labelled and the strip's space-menu is reachable with one open
+    # tab. The Runner reads this (not a raw count) so render + focus + click stay in sync.
+    def subtab_strip_shown? : Bool
+      (subtab_labels.try(&.size) || 0) >= 2
+    end
+
     # Move the active sub-tab by ±1 (strip ←/→), or jump to an absolute index (^1-9).
     def move_subtab(dir : Int32) : Nil
     end

--- a/src/gori/tui/theme.cr
+++ b/src/gori/tui/theme.cr
@@ -349,6 +349,17 @@ module Gori::Tui
       )
     end
 
+    # A readable ink for text drawn directly ON a saturated fill — e.g. the focused
+    # sub-tab's focus_gold pill. Picks near-black or near-white by the fill's perceived
+    # luminance (Rec. 601 luma, cheap + good enough for a fg/bg pick) so the label stays
+    # legible whether the fill is a light gold (GORIDARK/ESPRESSO) or a darker one
+    # (GORIDAY/LATTE) — and across custom palettes, which can set any focus_gold.
+    def self.ink_on(fill : Color) : Color
+      r, g, b = fill.to_rgb_components
+      luma = (0.299 * r + 0.587 * g + 0.114 * b) / 255.0
+      luma > 0.6 ? Color.from_hex("#111111") : Color.from_hex("#fafafa")
+    end
+
     def self.method_color(method : String) : Color
       case method.upcase
       when "GET", "HEAD", "QUERY"           then green # QUERY is safe + idempotent like GET (RFC 10008)

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -26,12 +26,14 @@ module Gori
         "app.palette", "Command palette", "Open the command palette", Verb::Scope::Global,
         [Verb::Chord.new("p", ctrl: true)], category: Verb::Category::System) { |ctx| ctx.open_palette; nil }
 
-      # The notification center (background-job results, alerts). Chordless to dodge the
-      # reserved-key set; the clickable bottom-bar `notify:N` badge is the mouse path,
-      # and it's rebindable via settings:hotkeys.
+      # The notification center (background-job results, alerts). `n` is a Global
+      # fallback chord — scope-local `n` (e.g. findings.new on Findings) still wins
+      # where bound, exactly like Global `c` (capture) yields to Intercept's `c`. The
+      # clickable bottom-bar `notify:N` badge is the mouse path; both are rebindable
+      # via settings:hotkeys.
       r.register Verb::Definition.new(
         "app.notifications", "Notifications", "Open the notification center (background-job results)",
-        Verb::Scope::Global, [] of Verb::Chord, category: Verb::Category::System) { |ctx| ctx.open_notifications; nil }
+        Verb::Scope::Global, [Verb::Chord.new("n")], category: Verb::Category::System) { |ctx| ctx.open_notifications; nil }
 
       r.register Verb::Definition.new(
         "capture.toggle", "Toggle capture", "Start/stop capturing traffic", Verb::Scope::Global,


### PR DESCRIPTION
Three small TUI UX fixes (behavior-additive; clean build + 492 specs green across tui/verb/replay/miner/store/cli/mcp).

## 1. Notifications `n` hotkey
`app.notifications` was chordless (palette / `notify:N` badge only). Now bound to a **Global fallback** `n`: scope-local `n` still wins where bound (e.g. `findings.new` on the Findings body), exactly like Global `c` (capture) yields to Intercept's `c`. Confirmed no real collision — the only plain-`n` bindings are findings.new (Findings scope) and replay.new (`ctrl-n`). Still rebindable via settings:hotkeys; the clickable badge is unchanged.

## 2. Single-tab sub-tab strip (Replay / Fuzzer)
The strip was gated at `>= 2` chips. But the Replay/Fuzzer body is a text editor that swallows `space`, so with a single session there was **no way to open the space-menu** for those tabs. Now the strip shows from the first session.

- New overridable `TabController#subtab_strip_shown?` (default `>= 2`; Replay/Fuzzer override to "not empty").
- **Invariant kept:** render + focus-ring + click-hit-test must all agree on strip visibility, so the Runner's `subtabs_shown?` now *delegates* to the active controller's predicate instead of counting labels itself.
- Notes/Convert unchanged (`>= 2`); `replay.find-subtab` still gated `>= 2` (searching one session is pointless).

## 3. Gold focus-pill for sub-tabs
The focused active chip used `accent_bg` + `text_bright`, near-identical to the unfocused `selection_dim` band — focus was too subtle. It's now a solid `focus_gold` pill (the same gold that outlines a focused body pane → "gold = focus is here", one level down), with a new `Theme.ink_on` luma helper choosing a legible #111/#fafafa label across all five built-in themes + custom palettes. Only the sub-tab strip changed; the top tab menu keeps its white-band focus.