### PR TITLE
chore(deps): switch termisu back to upstream omarluq/termisu v0.5.0

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -13,6 +13,6 @@ shards:
     version: 0.23.0
 
   termisu:
-    git: https://github.com/hahwul/termisu.git
-    version: 0.4.5+git.commit.f6e86b36edaecad3b8c725da390bf5e4f1f843dd
+    git: https://github.com/omarluq/termisu.git
+    version: 0.5.0
 

--- a/shard.yml
+++ b/shard.yml
@@ -20,10 +20,11 @@ license: Apache-2.0
 
 dependencies:
   termisu:
-    github: hahwul/termisu
-    branch: main
-    # Using fork main for active development of input/preedit fixes (see recent commits on hahwul/termisu)
-    # Current: fixed double-English + jamo-separation by using 17u flags + parser text extraction + protocol_active guard + Preedit for key=0 text events.
+    github: omarluq/termisu
+    version: ~> 0.5
+    # Back on upstream: the input/preedit fixes we forked for (double-English +
+    # jamo-separation: protocol_active dup-guard + Preedit for key=0 text events)
+    # are merged upstream as of v0.5.0.
 
   db:
     github: crystal-lang/crystal-db


### PR DESCRIPTION
## What

Point the `termisu` dependency back at the original upstream repo, pinned to the released tag.

```diff
 termisu:
-  github: hahwul/termisu
-  branch: main
+  github: omarluq/termisu
+  version: ~> 0.5
```

`shard.lock` → `https://github.com/omarluq/termisu.git` @ `0.5.0`.

## Why it's safe

We forked `hahwul/termisu` for the Hangul input fix (double-English + jamo-separation). That fix is now merged upstream as of **v0.5.0**, so we can drop the fork.

Verified before switching:
- Fork `main` and upstream `main`/`v0.5.0` are **byte-identical for all library source** — only `.github/workflows/*.yml` CI files differ.
- The fix markers are present in upstream v0.5.0 `input/parser.cr`:
  - `return Event::Key.new(Key::Unknown) if @protocol_active && dup == c`
  - `Event::Preedit.new(text_str)` (codepoint-0 text events)

## Verification

- `shards update termisu` → installs `termisu (0.5.0)` from upstream
- `crystal build src/main.cr` → exit 0
- binary `--help` smoke test → exit 0

Also pins the released tag (`~> 0.5`) instead of tracking a branch, for reproducible builds.