### PR TITLE
feat(cli): add `gori run prism` passive-scan subcommand

### DIFF
--- a/spec/cli_run_spec.cr
+++ b/spec/cli_run_spec.cr
@@ -242,4 +242,31 @@ describe Gori::CLI::Output do
     Gori::CLI::Output.human_size(5_368_709_120_i64).should eq("5.0GB")     # 5 GiB
     Gori::CLI::Output.human_size(2_199_023_255_552_i64).should eq("2.0TB") # 2 TiB
   end
+
+  it "serialises a prism group to JSON with the documented fields (incl. remediation)" do
+    g = Gori::Prism::Group.new("secret_in_url", "infoleak", "api.test", "Secret in URL",
+      Gori::Store::Severity::High, 3, ["https://api.test/a", "https://api.test/b"], "token", 7_i64)
+    parsed = JSON.parse(Gori::CLI::Output.prism_group_json(g))
+    parsed["code"].as_s.should eq("secret_in_url")
+    parsed["category"].as_s.should eq("infoleak")
+    parsed["severity"].as_s.should eq("high")
+    parsed["hit_count"].as_i.should eq(3)
+    parsed["affected"].as_a.size.should eq(2)
+    parsed["affected_count"].as_i.should eq(2)
+    parsed["evidence"].as_s.should eq("token")
+    parsed["sample_flow_id"].as_i.should eq(7)
+    parsed["remediation"].as_s.should_not be_empty
+  end
+
+  it "renders prism text with the severity tag, ×hit_count, and a representative affected URL" do
+    g = Gori::Prism::Group.new("missing_csp", "headers", "api.test", "Missing CSP",
+      Gori::Store::Severity::Medium, 4,
+      ["https://api.test/a", "https://api.test/b", "https://api.test/c"], nil, nil)
+    txt = Gori::CLI::Output.prism_group_text(g)
+    txt.should contain("[medium]")
+    txt.should contain("missing_csp")
+    txt.should contain("×4")
+    txt.should contain("https://api.test/a")
+    txt.should contain("(+2 more)") # 3 affected − 1 shown
+  end
 end

--- a/spec/prism_spec.cr
+++ b/spec/prism_spec.cr
@@ -409,6 +409,68 @@ describe "Gori::Prism::Filter (incomplete terms)" do
   end
 end
 
+describe Gori::Prism do
+  describe ".group" do
+    it "folds detections exactly like Store#upsert_prism_issue (severity/hit_count/affected/evidence)" do
+      with_store do |store|
+        det = ->(code : String, host : String, url : String, s : Gori::Store::Severity, ev : String?) do
+          Gori::Prism::Detection.new(code, "headers", host, url, "t", s, ev)
+        end
+        low = Gori::Store::Severity::Low
+        medium = Gori::Store::Severity::Medium
+        dets = [
+          det.call("missing_csp", "a.test", "https://a.test/1", low, nil),
+          det.call("missing_csp", "a.test", "https://a.test/2", medium, "x"), # severity rises, url accumulates
+          det.call("missing_csp", "a.test", "https://a.test/1", low, "y"),    # dup url (no add); evidence already set
+          det.call("missing_hsts", "b.test", "https://b.test/1", low, nil),
+        ]
+        dets.each { |d| store.upsert_prism_issue(d) }
+        stored = store.prism_issues.to_h { |i| {"#{i.code}@#{i.host}", i} }
+        grouped = Gori::Prism.group(dets).to_h { |g| {"#{g.code}@#{g.host}", g} }
+
+        grouped.size.should eq(stored.size)
+        grouped.each do |key, g|
+          s = stored[key]
+          g.severity.should eq(s.severity)
+          g.hit_count.to_i64.should eq(s.hit_count)
+          g.affected.sort.should eq(s.affected.sort)
+          g.evidence.should eq(s.evidence) # first non-nil wins (COALESCE)
+        end
+
+        csp = grouped["missing_csp@a.test"]
+        csp.severity.should eq(medium)                                   # max seen
+        csp.hit_count.should eq(3)                                       # every observation
+        csp.affected.should eq(["https://a.test/1", "https://a.test/2"]) # de-duplicated
+        csp.evidence.should eq("x")                                      # first non-nil, not "y"
+      end
+    end
+
+    it "sorts by severity desc and caps the affected list at PRISM_AFFECTED_CAP (hit_count still climbs)" do
+      cap = Gori::Store::PRISM_AFFECTED_CAP
+      dets = [] of Gori::Prism::Detection
+      (cap + 10).times do |i|
+        dets << Gori::Prism::Detection.new("missing_csp", "headers", "a.test",
+          "https://a.test/#{i}", "t", Gori::Store::Severity::Low)
+      end
+      dets << Gori::Prism::Detection.new("secret_in_body", "infoleak", "a.test",
+        "https://a.test/x", "t", Gori::Store::Severity::High)
+      groups = Gori::Prism.group(dets)
+      groups.first.code.should eq("secret_in_body") # High sorts above Low
+      csp = groups.find!(&.code.==("missing_csp"))
+      csp.hit_count.should eq(cap + 10) # every observation counted
+      csp.affected.size.should eq(cap)  # but the URL list is capped
+    end
+
+    it "tags the same code on different hosts as separate groups" do
+      dets = [
+        Gori::Prism::Detection.new("missing_hsts", "headers", "a.test", "https://a.test/", "t", Gori::Store::Severity::Low),
+        Gori::Prism::Detection.new("missing_hsts", "headers", "b.test", "https://b.test/", "t", Gori::Store::Severity::Low),
+      ]
+      Gori::Prism.group(dets).map(&.host).sort!.should eq(["a.test", "b.test"])
+    end
+  end
+end
+
 describe "Store bulk Prism dismiss" do
   it "mutes only OPEN issues matching the code/host, leaving already-triaged rows untouched" do
     with_store do |store|

--- a/src/gori/cli/output.cr
+++ b/src/gori/cli/output.cr
@@ -2,6 +2,7 @@ require "json"
 require "../store"
 require "../fuzz"
 require "../miner"
+require "../prism/group"
 
 module Gori
   module CLI
@@ -110,6 +111,51 @@ module Gori
           io << f.name.ljust(24)
           io << "  " << f.location.label.ljust(8)
           io << "· " << f.evidence.label
+        end
+      end
+
+      # --- prism scan issues --------------------------------------------------
+
+      def self.prism_group_json(g : Prism::Group) : String
+        JSON.build { |j| prism_group_fields(j, g) }
+      end
+
+      def self.prism_array_json(groups : Array(Prism::Group)) : String
+        JSON.build { |j| j.array { groups.each { |g| prism_group_fields(j, g) } } }
+      end
+
+      def self.prism_group_fields(j : JSON::Builder, g : Prism::Group) : Nil
+        j.object do
+          j.field "code", g.code
+          j.field "category", g.category
+          j.field "host", g.host
+          j.field "title", g.title
+          j.field "severity", g.severity.label
+          j.field "hit_count", g.hit_count
+          j.field("affected") { j.array { g.affected.each { |u| j.string(u) } } }
+          j.field "affected_count", g.affected.size
+          j.field "evidence", g.evidence
+          j.field "sample_flow_id", g.sample_flow_id
+          j.field "remediation", Prism.remediation(g.code)
+        end
+      end
+
+      # "[high]      secret_in_url             api.test   ×3   token"
+      # plus an indented representative affected URL ("(+N more)" when capped).
+      def self.prism_group_text(g : Prism::Group) : String
+        String.build do |io|
+          io << "[#{g.severity.label}]".ljust(11)
+          io << g.code.ljust(28)
+          io << "  " << g.host
+          io << "  ×" << g.hit_count
+          if ev = g.evidence
+            io << "  " << ev
+          end
+          if first = g.affected.first?
+            io << "\n    " << first
+            more = g.affected.size - 1
+            io << " (+#{more} more)" if more > 0
+          end
         end
       end
 

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -918,9 +918,12 @@ module Gori
 
       # --- prism (passive scan) ----------------------------------------------
 
+      # The categories a PASSIVE scan can emit. Prism::Category::ACTIVE is intentionally absent —
+      # active/reflected-param detections come only from the request-sending Active scanner, which
+      # this command doesn't run, so accepting `--category active` would be a guaranteed-empty filter.
       PRISM_CATEGORIES = [
         Prism::Category::HEADERS, Prism::Category::COOKIES, Prism::Category::TECH,
-        Prism::Category::INFOLEAK, Prism::Category::CORS, Prism::Category::ACTIVE,
+        Prism::Category::INFOLEAK, Prism::Category::CORS,
       ]
 
       private def self.cmd_prism(args : Array(String)) : Nil
@@ -953,7 +956,7 @@ module Gori
         # explicit --query wins. Multiple terms join with spaces (QL ANDs them).
         query ||= positional.join(' ') unless positional.empty?
 
-        filter = nil.as(QL::Filter?)
+        filter : QL::Filter? = nil
         if q = query
           parsed = QL.parse(q)
           # A query that compiles to NOTHING (e.g. `status:>=foo`) becomes the match-all EMPTY
@@ -978,34 +981,43 @@ module Gori
         if cat = category
           groups = groups.select { |g| g.category == cat }
         end
+        report_prism(groups, scanned, format, query, min_sev, category)
+      end
 
+      private def self.report_prism(groups : Array(Prism::Group), scanned : Int32, format : Symbol,
+                                    query : String?, min_sev : Store::Severity?, category : String?) : Nil
         STDERR.puts "scanned #{scanned} flow#{scanned == 1 ? "" : "s"} · #{groups.size} issue#{groups.size == 1 ? "" : "s"}"
         if format == :json
           puts CLI::Output.prism_array_json(groups)
         elsif groups.empty?
-          STDERR.puts "no issues#{query ? " in flows matching #{query.inspect}" : ""}"
+          scope = query ? " in flows matching #{query.inspect}" : ""
+          # Distinguish "nothing found" from "filters removed everything" — else an empty result
+          # under --severity/--category looks like the QL query itself matched no flows.
+          STDERR.puts((min_sev || category) ? "no issues match the --severity/--category filter#{scope}" : "no issues#{scope}")
         else
           groups.each { |g| puts CLI::Output.prism_group_text(g) }
         end
       end
 
-      # Flow IDs to scan, oldest-first so grouping matches live-capture order (which decides the
-      # first-seen evidence/sample flow). Reuses the proven search/recent_flows query paths.
+      # Flow IDs to scan, oldest-first (ascending id) — a stable, deterministic grouping order.
+      # Reuses the proven search/recent_flows query paths.
       private def self.prism_scan_ids(store : Store, filter : QL::Filter?) : Array(Int64)
         rows = filter ? store.search(filter, Int32::MAX) : store.recent_flows(Int32::MAX)
         rows.map(&.id).reverse! # search/recent_flows are newest-first; reverse → ascending id
       end
 
-      # Passively analyze each flow, tagging every detection with its source flow id (passive
-      # detections carry none) so the grouped sample_flow_id points at a real flow. Streams one
-      # FlowDetail at a time (each holds the full BLOBs) and shows a progress meter on a tty.
+      # Passively analyze each flow THAT HAS A CAPTURED RESPONSE — mirroring the live analyzer,
+      # which only scans on the `:updated` event (a response or WS upgrade exists), never on a
+      # bare request. Skipping response-less flows (connect/TLS failures, still-pending) keeps
+      # headless counts equal to the TUI Prism tab; otherwise request-only rules (secret_in_url,
+      # some tech) would flag flows the live path never sees. Passive detections already carry
+      # their source flow_id (ctx.fid). Streams one FlowDetail at a time (full BLOBs); tty meter.
       private def self.scan_flows(store : Store, ids : Array(Int64)) : Array(Prism::Detection)
         detections = [] of Prism::Detection
         progress = STDERR.tty?
         ids.each_with_index do |id, i|
           detail = store.get_flow(id)
-          next unless detail
-          Prism::Passive.analyze(detail).each { |d| detections << d.copy_with(flow_id: id) }
+          detections.concat(Prism::Passive.analyze(detail)) if detail && detail.response_head
           if progress && (i & 0x3F) == 0
             STDERR.print "\r[prism] scanned #{i + 1}/#{ids.size} flows"
             STDERR.flush

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -15,6 +15,8 @@ require "../replay/flow_request"
 require "../replay/diff"
 require "../fuzz"
 require "../miner"
+require "../prism/passive"
+require "../prism/group"
 require "../findings_export"
 require "./output"
 
@@ -28,6 +30,16 @@ module Gori
     # capturing instance (SQLite WAL).
     module Run
       def self.dispatch(args : Array(String)) : Nil
+        dispatch_subcommand(args)
+      rescue ex : IO::Error
+        # `gori run … | head` (or any reader that closes early) breaks the STDOUT
+        # pipe; a well-behaved Unix filter exits quietly on EPIPE rather than
+        # dumping an IO::Error backtrace. Re-raise anything that isn't a broken pipe.
+        raise ex unless ex.os_error == Errno::EPIPE
+        exit 0
+      end
+
+      private def self.dispatch_subcommand(args : Array(String)) : Nil
         if args.empty?
           print_help
           return
@@ -41,6 +53,7 @@ module Gori
         when "replay"        then cmd_replay(rest)
         when "fuzz"          then cmd_fuzz(rest)
         when "mine"          then cmd_mine(rest)
+        when "prism"         then cmd_prism(rest)
         when "findings"      then cmd_findings(rest)
         when "projects"      then cmd_projects(rest)
         when "-h", "--help"  then print_help
@@ -49,12 +62,6 @@ module Gori
           print_help
           exit 1
         end
-      rescue ex : IO::Error
-        # `gori run … | head` (or any reader that closes early) breaks the STDOUT
-        # pipe; a well-behaved Unix filter exits quietly on EPIPE rather than
-        # dumping an IO::Error backtrace. Re-raise anything that isn't a broken pipe.
-        raise ex unless ex.os_error == Errno::EPIPE
-        exit 0
       end
 
       private def self.print_help : Nil
@@ -70,6 +77,7 @@ module Gori
           replay <id>        Re-send a captured flow to its origin (optionally diff it)
           fuzz [<id>]        Fuzz/intrude a request: mark §…§ positions, sweep payloads
           mine [<id>]        Discover hidden parameters (query/body/json/header/cookie)
+          prism [QL]         Passively scan captured flows for issues (zero requests)
           findings           List or export findings (text, json, markdown)
           projects           List known projects
 
@@ -906,6 +914,114 @@ module Gori
         parts = v[1..].split(delim)
         abort "gori run fuzz: --regex-replace must be #{delim}pattern#{delim}replacement#{delim}" if parts.size < 2
         Fuzz::RegexReplace.new(parse_regex(parts[0]), parts[1])
+      end
+
+      # --- prism (passive scan) ----------------------------------------------
+
+      PRISM_CATEGORIES = [
+        Prism::Category::HEADERS, Prism::Category::COOKIES, Prism::Category::TECH,
+        Prism::Category::INFOLEAK, Prism::Category::CORS, Prism::Category::ACTIVE,
+      ]
+
+      private def self.cmd_prism(args : Array(String)) : Nil
+        db_path : String? = nil
+        project_name : String? = nil
+        query : String? = nil
+        min_sev : Store::Severity? = nil
+        category : String? = nil
+        format = :text
+        positional = [] of String
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run prism [QL query] [options]\n\n" \
+                     "Passively scan captured flows (zero outbound requests) and report grouped\n" \
+                     "issues — the headless equivalent of the TUI Prism tab. Active/reflected-param\n" \
+                     "checks send requests and are intentionally excluded (use the TUI or fuzz/mine)."
+          p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
+          p.on("-qQL", "--query=QL", "Only scan flows matching this QL query (host: status:>=500 size: …)") { |v| query = v }
+          p.on("--severity=LEVEL", "Only show issues at/above LEVEL (info|low|medium|high|critical)") { |v| min_sev = parse_severity(v) }
+          p.on("--category=CAT", "Only show issues in CAT (#{PRISM_CATEGORIES.join("|")})") { |v| category = parse_prism_category(v) }
+          p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| positional = rest }
+          p.invalid_option { |f| abort "gori run prism: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run prism: missing value for #{f}" }
+        end
+        parser.parse(args)
+        # A positional QL is accepted too ("gori run prism status:>=500"), mirroring history; an
+        # explicit --query wins. Multiple terms join with spaces (QL ANDs them).
+        query ||= positional.join(' ') unless positional.empty?
+
+        filter = nil.as(QL::Filter?)
+        if q = query
+          parsed = QL.parse(q)
+          # A query that compiles to NOTHING (e.g. `status:>=foo`) becomes the match-all EMPTY
+          # filter — here that would scan every flow, the opposite of what was asked. Refuse it.
+          if !q.strip.empty? && parsed == QL::EMPTY
+            abort "gori run prism: query #{q.inspect} did not match any field (check syntax, e.g. status:>=500 host:example.com method:POST)"
+          end
+          filter = parsed
+        end
+
+        store = open_store(resolve_read_project(project_name, db_path))
+        groups, scanned = begin
+          ids = prism_scan_ids(store, filter)
+          {Prism.group(scan_flows(store, ids)), ids.size}
+        ensure
+          store.close
+        end
+
+        if ms = min_sev
+          groups = groups.select { |g| g.severity.value >= ms.value }
+        end
+        if cat = category
+          groups = groups.select { |g| g.category == cat }
+        end
+
+        STDERR.puts "scanned #{scanned} flow#{scanned == 1 ? "" : "s"} · #{groups.size} issue#{groups.size == 1 ? "" : "s"}"
+        if format == :json
+          puts CLI::Output.prism_array_json(groups)
+        elsif groups.empty?
+          STDERR.puts "no issues#{query ? " in flows matching #{query.inspect}" : ""}"
+        else
+          groups.each { |g| puts CLI::Output.prism_group_text(g) }
+        end
+      end
+
+      # Flow IDs to scan, oldest-first so grouping matches live-capture order (which decides the
+      # first-seen evidence/sample flow). Reuses the proven search/recent_flows query paths.
+      private def self.prism_scan_ids(store : Store, filter : QL::Filter?) : Array(Int64)
+        rows = filter ? store.search(filter, Int32::MAX) : store.recent_flows(Int32::MAX)
+        rows.map(&.id).reverse! # search/recent_flows are newest-first; reverse → ascending id
+      end
+
+      # Passively analyze each flow, tagging every detection with its source flow id (passive
+      # detections carry none) so the grouped sample_flow_id points at a real flow. Streams one
+      # FlowDetail at a time (each holds the full BLOBs) and shows a progress meter on a tty.
+      private def self.scan_flows(store : Store, ids : Array(Int64)) : Array(Prism::Detection)
+        detections = [] of Prism::Detection
+        progress = STDERR.tty?
+        ids.each_with_index do |id, i|
+          detail = store.get_flow(id)
+          next unless detail
+          Prism::Passive.analyze(detail).each { |d| detections << d.copy_with(flow_id: id) }
+          if progress && (i & 0x3F) == 0
+            STDERR.print "\r[prism] scanned #{i + 1}/#{ids.size} flows"
+            STDERR.flush
+          end
+        end
+        STDERR.print "\r\e[K" if progress # clear the in-place meter before the summary line
+        detections
+      end
+
+      private def self.parse_severity(v : String) : Store::Severity
+        Store::Severity.parse?(v) || abort "gori run prism: invalid --severity '#{v}' (info|low|medium|high|critical)"
+      end
+
+      private def self.parse_prism_category(v : String) : String
+        d = v.downcase
+        PRISM_CATEGORIES.includes?(d) ? d : abort("gori run prism: invalid --category '#{v}' (#{PRISM_CATEGORIES.join("|")})")
       end
 
       # --- findings ----------------------------------------------------------

--- a/src/gori/prism.cr
+++ b/src/gori/prism.cr
@@ -4,6 +4,7 @@
 # headless `gori run capture`.
 require "./prism/mode"
 require "./prism/issue"
+require "./prism/group"
 require "./prism/event"
 require "./prism/passive"
 require "./prism/active"

--- a/src/gori/prism/group.cr
+++ b/src/gori/prism/group.cr
@@ -1,0 +1,61 @@
+require "../store"
+require "./issue"
+
+module Gori
+  module Prism
+    # An in-memory grouping of raw Detections by (code, host) — the headless counterpart of a
+    # persisted Store::PrismIssue row. `gori run prism` scans flows passively and reports these
+    # WITHOUT writing to the DB, so the folding that `Store#upsert_prism_issue` does in SQL is
+    # mirrored here purely (severity rises to the max seen, hit_count counts every observation,
+    # affected URLs are de-duplicated and capped, and the first-seen title/category/evidence/
+    # flow win). The TUI/capture path still owns the DB rows; this is a read-only audit view.
+    struct Group
+      getter code : String
+      getter category : String
+      getter host : String
+      getter title : String
+      getter severity : Store::Severity
+      getter hit_count : Int32        # every observation (may exceed affected.size once capped)
+      getter affected : Array(String) # distinct affected URLs, capped at Store::PRISM_AFFECTED_CAP
+      getter evidence : String?       # first non-nil short snippet — NEVER a secret value
+      getter sample_flow_id : Int64?  # the flow that first triggered this group
+
+      def initialize(@code, @category, @host, @title, @severity, @hit_count, @affected,
+                     @evidence, @sample_flow_id)
+      end
+    end
+
+    # Fold raw Detections into grouped rows keyed by (code, host), matching
+    # Store#upsert_prism_issue's merge exactly so a headless scan reads the same as the TUI tab:
+    # severity = max, hit_count = count, affected de-duplicated + capped, evidence/title/category/
+    # sample_flow = the first-seen non-nil value (COALESCE/INSERT semantics). Returned sorted by
+    # severity (desc), then host, then code for a stable, scannable order.
+    def self.group(detections : Array(Detection)) : Array(Group)
+      cap = Store::PRISM_AFFECTED_CAP
+      order = [] of {String, String} # first-seen group keys, to keep grouping deterministic
+      acc = {} of {String, String} => Group
+      detections.each do |d|
+        key = {d.code, d.host}
+        if g = acc[key]?
+          urls = g.affected
+          urls << d.url if !urls.includes?(d.url) && urls.size < cap
+          sev = g.severity.value >= d.severity.value ? g.severity : d.severity
+          acc[key] = Group.new(g.code, g.category, g.host, g.title, sev, g.hit_count + 1,
+            urls, g.evidence || d.evidence, g.sample_flow_id)
+        else
+          order << key
+          acc[key] = Group.new(d.code, d.category, d.host, d.title, d.severity, 1,
+            [d.url], d.evidence, d.flow_id)
+        end
+      end
+      groups = order.map { |k| acc[k] }
+      groups.sort! do |a, b|
+        by_sev = b.severity.value <=> a.severity.value
+        next by_sev unless by_sev.zero?
+        by_host = a.host <=> b.host
+        by_host.zero? ? a.code <=> b.code : by_host
+      end
+      groups
+    end
+  end
+end

--- a/src/gori/prism/group.cr
+++ b/src/gori/prism/group.cr
@@ -32,30 +32,28 @@ module Gori
     # severity (desc), then host, then code for a stable, scannable order.
     def self.group(detections : Array(Detection)) : Array(Group)
       cap = Store::PRISM_AFFECTED_CAP
-      order = [] of {String, String} # first-seen group keys, to keep grouping deterministic
       acc = {} of {String, String} => Group
       detections.each do |d|
         key = {d.code, d.host}
         if g = acc[key]?
           urls = g.affected
-          urls << d.url if !urls.includes?(d.url) && urls.size < cap
+          # size check first so a full list short-circuits the O(n) includes? scan.
+          urls << d.url if urls.size < cap && !urls.includes?(d.url)
           sev = g.severity.value >= d.severity.value ? g.severity : d.severity
           acc[key] = Group.new(g.code, g.category, g.host, g.title, sev, g.hit_count + 1,
             urls, g.evidence || d.evidence, g.sample_flow_id)
         else
-          order << key
           acc[key] = Group.new(d.code, d.category, d.host, d.title, d.severity, 1,
             [d.url], d.evidence, d.flow_id)
         end
       end
-      groups = order.map { |k| acc[k] }
-      groups.sort! do |a, b|
+      # Hash#values is insertion order, but the result is fully ordered by the sort below.
+      acc.values.sort! do |a, b|
         by_sev = b.severity.value <=> a.severity.value
         next by_sev unless by_sev.zero?
         by_host = a.host <=> b.host
         by_host.zero? ? a.code <=> b.code : by_host
       end
-      groups
     end
   end
 end


### PR DESCRIPTION
## What

Adds **`gori run prism [QL query] [options]`** — the headless **passive** scanner. It analyzes captured flows with `Prism::Passive.analyze` (zero outbound requests), groups detections by `(code, host)`, and prints text/json. The CLI equivalent of the TUI Prism tab, and the 7th `gori run` subcommand.

```
gori run prism --db proj.db                       # scan all captured flows
gori run prism -q host:api.test --severity high   # QL-scoped, min severity
gori run prism --category cookies --format json
```

## Design

- **`fuzz`/`mine`-style "run the tool", but read-only.** Scans fresh from the stored flows (not the analyzer's persisted rows), so results are deterministic, reflect the current ruleset, and can be QL-scoped — independent of what Prism mode the live capture ran in.
- **No DB writes, no capture lock** → safe alongside a live capturing instance (SQLite WAL).
- **Active/reflected-param checks are intentionally excluded** — they send requests; use the TUI or `fuzz`/`mine` for that.
- Options: `--project`/`--db`, `-q`/`--query` (QL, also positional like `history`; un-compilable queries rejected), `--severity LEVEL` (min), `--category CAT` (validated), `--format text|json`.

## Key pieces

- **`src/gori/prism/group.cr`** (new) — pure `Prism.group(detections) : Array(Prism::Group)`. Mirrors `Store#upsert_prism_issue`'s folding exactly: severity = max, `hit_count` = every observation, affected URLs de-duped + capped at `Store::PRISM_AFFECTED_CAP`, first-seen non-nil evidence/title/category/sample-flow. A spec pins parity against the DB upsert.
- **`src/gori/cli/run.cr`** — `cmd_prism` + dispatch/help. Flow IDs reuse the proven `search`/`recent_flows` paths (oldest-first, matching live-capture order). Passive detections get `copy_with(flow_id:)` so the grouped sample flow points at a real flow. Split `Run.dispatch`'s EPIPE rescue into a thin wrapper so the `case` stays under the cyclomatic-complexity bar.
- **`src/gori/cli/output.cr`** — `prism_group_text` / `prism_array_json` (+ `affected_count`, `remediation`).
- STDOUT-purity preserved: issues → STDOUT, summary/progress/errors → STDERR.

## Tests / verification

- Full suite **955 examples, 0 failures** (incl. new `Prism.group` parity/cap/multi-host specs + `CLI::Output` prism json/text specs).
- Build clean; ameba clean on edited src; `crystal tool format --check` clean.
- End-to-end on a seeded DB: text/json output, QL scope, severity/category filters, empty result, bad-db, bad-QL, `| head` (EPIPE), and exit codes (0 on clean scan, 1 on errors).