### PR TITLE
feat(cli): add `gori run notes` to read project notes headlessly

### DIFF
--- a/spec/cli_run_spec.cr
+++ b/spec/cli_run_spec.cr
@@ -242,4 +242,113 @@ describe Gori::CLI::Output do
     Gori::CLI::Output.human_size(5_368_709_120_i64).should eq("5.0GB")     # 5 GiB
     Gori::CLI::Output.human_size(2_199_023_255_552_i64).should eq("2.0TB") # 2 TiB
   end
+
+  it "formats a note listing row: 1-based index, title, '*' for the active note" do
+    row = Gori::CLI::Output.note_row_text(1, "scope\nmore", current: true)
+    row.should contain("* 2")                                                           # 0-based 1 → shown as #2
+    row.should contain("scope")                                                         # title = first non-blank line
+    row.should contain("(2 lines, ")                                                    # plural
+    Gori::CLI::Output.note_row_text(0, "x", current: false).should contain(" 1")        # no '*'
+    Gori::CLI::Output.note_row_text(0, "x", current: false).should contain("(1 line, ") # singular
+  end
+
+  it "falls back to 'note N' in a row for a blank note" do
+    Gori::CLI::Output.note_row_text(2, "   \n\t", current: false).should contain("note 3")
+  end
+
+  it "emits a single-note JSON object with the documented fields (text only when asked)" do
+    full = JSON.parse(Gori::CLI::Output.note_object_json(0, "Title\nbody", current: true, with_text: true))
+    full["index"].as_i.should eq(1)
+    full["title"].as_s.should eq("Title")
+    full["lines"].as_i.should eq(2)
+    full["bytes"].as_i.should eq("Title\nbody".bytesize)
+    full["current"].as_bool.should be_true
+    full["text"].as_s.should eq("Title\nbody")
+
+    summary = JSON.parse(Gori::CLI::Output.note_object_json(0, "Title\nbody", current: false, with_text: false))
+    summary["text"]?.should be_nil # summary omits the body
+    summary["title"].as_s.should eq("Title")
+  end
+
+  it "emits the whole note set as a JSON array, marking the active note" do
+    doc = Gori::Notes::Doc.new(1, ["one", "two"])
+    arr = JSON.parse(Gori::CLI::Output.notes_array_json(doc, with_text: false)).as_a
+    arr.size.should eq(2)
+    arr[0]["index"].as_i.should eq(1)
+    arr[0]["current"].as_bool.should be_false
+    arr[1]["current"].as_bool.should be_true # cur == 1
+    arr[0]["text"]?.should be_nil            # summary array
+
+    with_text = JSON.parse(Gori::CLI::Output.notes_array_json(doc, with_text: true)).as_a
+    with_text[1]["text"].as_s.should eq("two")
+  end
+end
+
+describe Gori::Notes do
+  # Doc is a record (struct) → value equality, so whole-Doc comparison avoids
+  # unwrapping the nilable parse result (and keeps the spec ameba-clean).
+  it "parses a well-formed document set" do
+    Gori::Notes.parse(%({"cur":1,"notes":["a","b"]})).should eq(Gori::Notes::Doc.new(1, ["a", "b"]))
+  end
+
+  it "defaults cur to 0 and coerces non-string note entries to empty strings" do
+    Gori::Notes.parse(%({"notes":[1,"x",null]})).should eq(Gori::Notes::Doc.new(0, ["", "x", ""]))
+  end
+
+  it "treats an empty notes array as a (non-nil) empty set" do
+    Gori::Notes.parse(%({"cur":0,"notes":[]})).should eq(Gori::Notes::Doc.new(0, [] of String))
+  end
+
+  it "exposes size/empty? on a Doc" do
+    Gori::Notes::Doc.new(0, ["a", "b"]).size.should eq(2)
+    Gori::Notes::Doc.new(0, ["a", "b"]).empty?.should be_false
+    Gori::Notes::Doc.new(0, [] of String).empty?.should be_true
+  end
+
+  it "returns nil for malformed JSON or a missing notes key (so callers fall back)" do
+    Gori::Notes.parse("not json {{{").should be_nil
+    Gori::Notes.parse(%({"cur":0})).should be_nil
+  end
+
+  it "round-trips through serialize/parse" do
+    raw = Gori::Notes.serialize(2, ["alpha", "beta\ngamma", ""])
+    Gori::Notes.parse(raw).should eq(Gori::Notes::Doc.new(2, ["alpha", "beta\ngamma", ""]))
+  end
+
+  it "loads the JSON set, the legacy single note, and prefers the JSON set over legacy" do
+    with_store do |store|
+      Gori::Notes.load(store).empty?.should be_true # nothing stored yet
+
+      store.set_setting("notes", "legacy body")
+      legacy = Gori::Notes.load(store)
+      legacy.texts.should eq(["legacy body"]) # migrated single note
+
+      store.set_setting("notes.docs", %({"cur":0,"notes":["fresh"]}))
+      Gori::Notes.load(store).texts.should eq(["fresh"]) # JSON set wins
+    end
+  end
+
+  it "falls back through malformed JSON to the legacy key, then to empty" do
+    with_store do |store|
+      store.set_setting("notes.docs", "not json {{{")
+      Gori::Notes.load(store).empty?.should be_true # malformed + no legacy → empty
+
+      store.set_setting("notes", "kept")
+      Gori::Notes.load(store).texts.should eq(["kept"]) # malformed docs → legacy
+    end
+  end
+
+  it "derives a title from the first non-blank line (trimmed, CRLF-tolerant); nil when blank" do
+    Gori::Notes.title("  hello world  ").should eq("hello world")
+    Gori::Notes.title("\n\n  second\nthird").should eq("second") # leading blank lines skipped
+    Gori::Notes.title("done\r\nmore").should eq("done")          # trailing CR trimmed
+    Gori::Notes.title("").should be_nil
+    Gori::Notes.title("   \n\t ").should be_nil # all whitespace
+  end
+
+  it "counts editor lines (an empty note is one line)" do
+    Gori::Notes.line_count("").should eq(1)
+    Gori::Notes.line_count("a\nb").should eq(2)
+    Gori::Notes.line_count("a\n").should eq(2) # trailing newline → a second (empty) line
+  end
 end

--- a/src/gori/cli/output.cr
+++ b/src/gori/cli/output.cr
@@ -2,6 +2,7 @@ require "json"
 require "../store"
 require "../fuzz"
 require "../miner"
+require "../notes"
 
 module Gori
   module CLI
@@ -124,6 +125,52 @@ module Gori
           io << "  " << human_us(r.duration_us)
           io << "  ⟦" << r.extracted << '⟧' if r.extracted
           io << "  " << r.error if r.error
+        end
+      end
+
+      # --- notes --------------------------------------------------------------
+
+      # Title shown in listings: the note's first non-blank line, or a positional
+      # fallback for a blank note (mirrors the TUI sub-tab's "note N").
+      def self.note_label(idx : Int32, text : String) : String
+        Notes.title(text) || "note #{idx + 1}"
+      end
+
+      # "* 1  title  (12 lines, 340B)" — 1-based index, '*' marks the active note.
+      def self.note_row_text(idx : Int32, text : String, current : Bool) : String
+        lines = Notes.line_count(text)
+        String.build do |io|
+          io << (current ? '*' : ' ') << ' '
+          io << (idx + 1) << "  " << note_label(idx, text)
+          io << "  (" << lines << (lines == 1 ? " line, " : " lines, ") << human_size(text.bytesize.to_i64) << ')'
+        end
+      end
+
+      # The whole note set as a JSON array. `with_text` adds each note's full body
+      # (the `--all` view); without it the array is a summary (the listing view).
+      def self.notes_array_json(doc : Notes::Doc, with_text : Bool) : String
+        JSON.build do |j|
+          j.array do
+            doc.texts.each_with_index do |text, i|
+              note_object_fields(j, i, text, current: doc.cur == i, with_text: with_text)
+            end
+          end
+        end
+      end
+
+      # One note as a standalone JSON object (the `show <n>` view).
+      def self.note_object_json(idx : Int32, text : String, current : Bool, with_text : Bool) : String
+        JSON.build { |j| note_object_fields(j, idx, text, current: current, with_text: with_text) }
+      end
+
+      def self.note_object_fields(j : JSON::Builder, idx : Int32, text : String, current : Bool, with_text : Bool) : Nil
+        j.object do
+          j.field "index", idx + 1
+          j.field "title", Notes.title(text)
+          j.field "lines", Notes.line_count(text)
+          j.field "bytes", text.bytesize
+          j.field "current", current
+          j.field "text", text if with_text
         end
       end
 

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -15,6 +15,7 @@ require "../replay/flow_request"
 require "../replay/diff"
 require "../fuzz"
 require "../miner"
+require "../notes"
 require "../findings_export"
 require "./output"
 
@@ -28,6 +29,18 @@ module Gori
     # capturing instance (SQLite WAL).
     module Run
       def self.dispatch(args : Array(String)) : Nil
+        dispatch_subcommand(args)
+      rescue ex : IO::Error
+        # `gori run … | head` (or any reader that closes early) breaks the STDOUT
+        # pipe; a well-behaved Unix filter exits quietly on EPIPE rather than
+        # dumping an IO::Error backtrace. Re-raise anything that isn't a broken pipe.
+        # (Kept as a thin wrapper so the subcommand `case` stays under the
+        # cyclomatic-complexity bar — see dispatch_subcommand.)
+        raise ex unless ex.os_error == Errno::EPIPE
+        exit 0
+      end
+
+      private def self.dispatch_subcommand(args : Array(String)) : Nil
         if args.empty?
           print_help
           return
@@ -41,6 +54,7 @@ module Gori
         when "replay"        then cmd_replay(rest)
         when "fuzz"          then cmd_fuzz(rest)
         when "mine"          then cmd_mine(rest)
+        when "notes"         then cmd_notes(rest)
         when "findings"      then cmd_findings(rest)
         when "projects"      then cmd_projects(rest)
         when "-h", "--help"  then print_help
@@ -49,12 +63,6 @@ module Gori
           print_help
           exit 1
         end
-      rescue ex : IO::Error
-        # `gori run … | head` (or any reader that closes early) breaks the STDOUT
-        # pipe; a well-behaved Unix filter exits quietly on EPIPE rather than
-        # dumping an IO::Error backtrace. Re-raise anything that isn't a broken pipe.
-        raise ex unless ex.os_error == Errno::EPIPE
-        exit 0
       end
 
       private def self.print_help : Nil
@@ -70,6 +78,7 @@ module Gori
           replay <id>        Re-send a captured flow to its origin (optionally diff it)
           fuzz [<id>]        Fuzz/intrude a request: mark §…§ positions, sweep payloads
           mine [<id>]        Discover hidden parameters (query/body/json/header/cookie)
+          notes [<n>]        Read the project's notes (list, show one, or --all)
           findings           List or export findings (text, json, markdown)
           projects           List known projects
 
@@ -906,6 +915,90 @@ module Gori
         parts = v[1..].split(delim)
         abort "gori run fuzz: --regex-replace must be #{delim}pattern#{delim}replacement#{delim}" if parts.size < 2
         Fuzz::RegexReplace.new(parse_regex(parts[0]), parts[1])
+      end
+
+      # --- notes -------------------------------------------------------------
+
+      private def self.cmd_notes(args : Array(String)) : Nil
+        db_path : String? = nil
+        project_name : String? = nil
+        format = :text
+        all = false
+        positional = [] of String
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run notes [<n>] [options]\n\nList the project's notes; with <n> (1-based) print that note in full, or --all to print them all."
+          p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
+          p.on("--all", "Print every note in full instead of the one-line list") { all = true }
+          p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| positional = rest }
+          p.invalid_option { |f| abort "gori run notes: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run notes: missing value for #{f}" }
+        end
+        parser.parse(args)
+
+        abort "gori run notes: too many arguments (expected at most one note number)" if positional.size > 1
+        index = parse_note_index(positional.first?)
+        abort "gori run notes: <n> and --all are mutually exclusive" if index && all
+
+        store = open_store(resolve_read_project(project_name, db_path))
+        doc = begin
+          Notes.load(store)
+        ensure
+          store.close
+        end
+
+        if n = index
+          abort "gori run notes: no note ##{n} (this project has #{doc.size} note#{doc.size == 1 ? "" : "s"})" unless n <= doc.size
+          show_note(doc, n - 1, format)
+        elsif all
+          show_all_notes(doc, format)
+        else
+          list_notes(doc, format)
+        end
+      end
+
+      private def self.parse_note_index(arg : String?) : Int32?
+        return nil unless arg
+        n = arg.to_i?
+        abort "gori run notes: invalid note number '#{arg}' (expected a positive integer)" unless n && n > 0
+        n
+      end
+
+      # Print one note (`idx` 0-based) in full: its exact text, or a full JSON object.
+      private def self.show_note(doc : Notes::Doc, idx : Int32, format : Symbol) : Nil
+        text = doc.texts[idx]
+        if format == :json
+          puts CLI::Output.note_object_json(idx, text, current: doc.cur == idx, with_text: true)
+        else
+          STDOUT.puts text
+        end
+      end
+
+      private def self.show_all_notes(doc : Notes::Doc, format : Symbol) : Nil
+        if format == :json
+          puts CLI::Output.notes_array_json(doc, with_text: true)
+        elsif doc.empty?
+          STDERR.puts "no notes"
+        else
+          doc.texts.each_with_index do |text, i|
+            puts "" if i > 0
+            puts "=== note #{i + 1}: #{CLI::Output.note_label(i, text)}#{doc.cur == i ? " *" : ""} ==="
+            STDOUT.puts text
+          end
+        end
+      end
+
+      private def self.list_notes(doc : Notes::Doc, format : Symbol) : Nil
+        if format == :json
+          puts CLI::Output.notes_array_json(doc, with_text: false)
+        elsif doc.empty?
+          STDERR.puts "no notes"
+        else
+          doc.texts.each_with_index { |text, i| puts CLI::Output.note_row_text(i, text, current: doc.cur == i) }
+        end
       end
 
       # --- findings ----------------------------------------------------------

--- a/src/gori/notes.cr
+++ b/src/gori/notes.cr
@@ -1,0 +1,88 @@
+require "json"
+require "./store"
+
+module Gori
+  # Shared reader/writer for the Notes tab's persisted documents. The TUI
+  # `Tui::NotesView` and the headless `gori run notes` CLI both go through here,
+  # so the on-disk layout has a single source of truth.
+  #
+  # Layout: a JSON document set lives in the project settings KV under
+  # "notes.docs" — {"cur":Int32, "notes":[String, ...]}. A project written by the
+  # pre-multi (single-note) build instead has a plain-text body under the legacy
+  # "notes" key; `load` migrates that into a one-note set on read. It never writes
+  # the legacy key back (it's left untouched — harmless).
+  module Notes
+    DOCS_KEY   = "notes.docs" # JSON {"cur":Int32, "notes":[String, ...]}
+    LEGACY_KEY = "notes"      # pre-multi single plain-text note
+
+    # A parsed note set: `cur` is the active sub-tab index (0-based), `texts` holds
+    # each note's full body in tab order.
+    record Doc, cur : Int32, texts : Array(String) do
+      def empty? : Bool
+        texts.empty?
+      end
+
+      def size : Int32
+        texts.size
+      end
+    end
+
+    # Load the persisted note set, applying the legacy-key fallback. Returns an
+    # empty Doc (no texts) when the project has never had a note saved.
+    def self.load(store : Store) : Doc
+      if raw = store.setting(DOCS_KEY)
+        if doc = parse(raw)
+          return doc
+        end
+      end
+      if legacy = store.setting(LEGACY_KEY)
+        return Doc.new(0, [legacy]) unless legacy.empty?
+      end
+      Doc.new(0, [] of String)
+    end
+
+    # Parse the JSON document set; nil on malformed data so callers can fall back
+    # (defensive — the KV value could be hand-edited or written by a future build).
+    def self.parse(raw : String) : Doc?
+      doc = JSON.parse(raw)
+      arr = doc["notes"]?.try(&.as_a?)
+      return nil unless arr
+      cur = doc["cur"]?.try(&.as_i?) || 0
+      Doc.new(cur, arr.map { |v| v.as_s? || "" })
+    rescue JSON::ParseException
+      nil
+    end
+
+    # Serialize a note set back to the "notes.docs" JSON value.
+    def self.serialize(cur : Int32, texts : Array(String)) : String
+      JSON.build do |j|
+        j.object do
+          j.field "cur", cur
+          j.field "notes" do
+            j.array do
+              texts.each { |t| j.string(t) }
+            end
+          end
+        end
+      end
+    end
+
+    # The note's title: its first non-blank line, trimmed; nil when the note is
+    # empty/all-whitespace. Mirrors how the TUI derives each sub-tab's label
+    # (TextArea#first_nonblank_line over lines split on '\n' with '\r' trimmed),
+    # so a CLI listing reads the same titles the editor shows.
+    def self.title(text : String) : String?
+      text.split('\n').each do |raw|
+        line = raw.rstrip('\r')
+        return line.strip unless line.blank?
+      end
+      nil
+    end
+
+    # Number of editor lines in a note (split on '\n'); an empty note is one line,
+    # matching the TUI's TextArea.
+    def self.line_count(text : String) : Int32
+      text.split('\n').size
+    end
+  end
+end

--- a/src/gori/tui/notes_view.cr
+++ b/src/gori/tui/notes_view.cr
@@ -29,11 +29,12 @@ module Gori::Tui
         @area = TextArea.new(text)
       end
 
-      # Sub-tab label: the first non-blank line (trimmed/truncated), else a
-      # positional fallback so empty notes are still addressable.
+      # Sub-tab label: the note's title (first non-blank line, trimmed) truncated
+      # to the chip width, else a positional fallback so empty notes are still
+      # addressable. The title rule itself lives in `Notes.title` — the single
+      # source of truth the CLI listing reads too, so labels can't drift.
       def label(idx : Int32) : String
-        if line = @area.first_nonblank_line
-          t = line.strip
+        if t = Notes.title(@area.text)
           t.size > 15 ? "#{t[0, 14]}…" : t
         else
           "note #{idx + 1}"

--- a/src/gori/tui/notes_view.cr
+++ b/src/gori/tui/notes_view.cr
@@ -1,8 +1,8 @@
-require "json"
 require "./screen"
 require "./theme"
 require "./text_area"
 require "../store"
+require "../notes"
 require "../settings"
 
 module Gori::Tui
@@ -18,8 +18,7 @@ module Gori::Tui
   # is absent) that legacy value is migrated into the first note; the new JSON
   # key is written on the next save (the legacy key is left untouched, harmless).
   class NotesView
-    DOCS_KEY   = "notes.docs" # JSON {"cur":Int32, "notes":[String, ...]}
-    LEGACY_KEY = "notes"      # pre-multi single plain-text note
+    DOCS_KEY = Notes::DOCS_KEY # JSON {"cur":Int32, "notes":[String, ...]}
 
     # One note document: a title is derived from its first non-blank line, so
     # there's no separate rename mode — the tab label tracks what you type.
@@ -212,43 +211,17 @@ module Gori::Tui
       @notes[@current.clamp(0, @notes.size - 1)]
     end
 
-    # Read the persisted notes: prefer the JSON set, fall back to the legacy
-    # single-note plain text, else nothing (reload then seeds one empty note).
+    # Read the persisted notes via the shared `Notes` reader (JSON set, with the
+    # legacy single-note fallback). `cur` becomes the active sub-tab; `reload`
+    # clamps it after this and seeds one empty note when the set is empty.
     private def load_notes(store : Store) : Array(Note)
-      if raw = store.setting(DOCS_KEY)
-        if notes = parse_docs(raw)
-          return notes
-        end
-      end
-      legacy = store.setting(LEGACY_KEY)
-      @current = 0
-      return [Note.new(legacy)] if legacy && !legacy.empty?
-      [] of Note
-    end
-
-    # Parse the JSON document set; nil on malformed data so the caller falls back
-    # (defensive — the KV value could be hand-edited or written by a future build).
-    private def parse_docs(raw : String) : Array(Note)?
-      doc = JSON.parse(raw)
-      arr = doc["notes"]?.try(&.as_a?)
-      return nil unless arr
-      @current = doc["cur"]?.try(&.as_i?) || 0
-      arr.map { |v| Note.new(v.as_s? || "") }
-    rescue JSON::ParseException
-      nil
+      doc = Notes.load(store)
+      @current = doc.cur
+      doc.texts.map { |t| Note.new(t) }
     end
 
     private def serialize : String
-      JSON.build do |j|
-        j.object do
-          j.field "cur", @current
-          j.field "notes" do
-            j.array do
-              @notes.each { |n| j.string(n.area.text) }
-            end
-          end
-        end
-      end
+      Notes.serialize(@current, @notes.map(&.area.text))
     end
   end
 end


### PR DESCRIPTION
## Summary

Adds a `notes` subcommand to the non-interactive `gori run` CLI so the project's Notes-tab documents can be read headlessly (reports, grep, piping into other tools) — the read-only counterpart to the TUI Notes tab.

- `gori run notes` — list one line per note: index, title (first non-blank line), line/byte count; `*` marks the active note
- `gori run notes <n>` — print note `<n>` (1-based) in full
- `gori run notes --all` — print every note in full
- `--format text|json`, `--project NAME` / `--db PATH` (same resolution as the other read subcommands)

Read-only: no DB writes, no capture lock → safe alongside a live capturing instance (SQLite WAL), consistent with `history`/`show`/`findings`.

## Design

- New shared `Gori::Notes` module (`src/gori/notes.cr`) owns the `notes.docs` JSON format (+ legacy single-note fallback), `parse`/`load`/`serialize`/`title`/`line_count`. **Single source of truth**: the TUI `NotesView` now delegates its load/parse/serialize to it instead of duplicating the format.
- Output formatting lives in `CLI::Output` (matching `prism`/`fuzz`/`mine`), making it unit-testable.
- `Run.dispatch` split into a thin EPIPE wrapper + `dispatch_subcommand` to keep the subcommand `case` under the cyclomatic-complexity bar.

## Testing

- `crystal spec` — **964 examples, 0 failures** (incl. 13 new: `Gori::Notes` parse/load/title/line_count + `CLI::Output` note row/json formatting; existing `NotesView` specs still pass after the refactor).
- Ameba clean on edited files (only the pre-existing tolerated `cmd_replay` 13/12 and the conventional `set_preedit` naming remain); `crystal tool format --check` clean.
- End-to-end on a seeded DB: list/show/`--all` in text+json, active-note marker, blank-note title fallback, out-of-range/invalid-index/conflicting-flags/bad-db exit codes (all exit 1), empty project (`no notes` / `[]`, exit 0), and EPIPE-to-`head` (clean exit, no backtrace).