### PR TITLE
feat(tui): horizontal scroll for long lines in editors + read-only panes

### DIFF
--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -45,6 +45,8 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def scroll_detail(delta : Int32) : Nil; end
 
+  def hscroll_detail(delta : Int32) : Nil; end
+
   def toggle_detail_pane : Nil; end
 
   def move_detail_pane(dir : Int32) : Nil; end
@@ -166,6 +168,8 @@ class FakeExecContext < Gori::Verb::ExecContext
   def finding_set_status : Nil; end
 
   def finding_edit_notes : Nil; end
+
+  def finding_hscroll(delta : Int32) : Nil; end
 
   def finding_edit_title : Nil; end
 

--- a/spec/tui/convert_view_spec.cr
+++ b/spec/tui/convert_view_spec.cr
@@ -62,6 +62,32 @@ describe Gori::Tui::ConvertView do
     b.contains?("myhash").should be_true
   end
 
+  it "hscroll_output scrolls a long OUTPUT line sideways into view (shift+←/→)" do
+    view = ConvertView.new
+    long_line = "HEAD" + ("." * 150) + "TAIL"
+    # `result` (the OUTPUT content) is independent of the `input:` TextArea (the INPUT
+    # card's own display) — keep INPUT short/unrelated so its unscrolled echo of the
+    # long line's head can't be mistaken for the OUTPUT card's (scrollable) content.
+    result = Gori::Convert.run(REG, long_line.to_slice, "")
+    rect = Rect.new(0, 0, 80, 30)
+    render_args = {
+      input: TextArea.new("unrelated"), chain: "", chain_cx: 0, chain_pre: "",
+      result: result, pane: :output, focused: true, popup: ChainComplete.new,
+      prompt: nil, prompt_buf: "",
+    }
+
+    backend = MemoryBackend.new(80, 30)
+    view.render(Screen.new(backend), rect, **render_args)
+    backend.contains?("HEAD").should be_true
+    backend.contains?("TAIL").should be_false # off the right edge, clipped
+
+    40.times { view.hscroll_output(1) } # scroll well past the line's width
+    backend2 = MemoryBackend.new(80, 30)
+    view.render(Screen.new(backend2), rect, **render_args)
+    backend2.contains?("TAIL").should be_true
+    backend2.contains?("HEAD").should be_false # scrolled off the left edge
+  end
+
   it "lights only the focused section's card border gold (per-pane focus)" do
     # Each section is its own card now (not a divided single frame), so focusing
     # INPUT must gild only the INPUT card — the read-only PIPELINE/OUTPUT cards

--- a/spec/tui/findings_view_spec.cr
+++ b/spec/tui/findings_view_spec.cr
@@ -72,6 +72,29 @@ describe Gori::Tui::FindingsView do
     end
   end
 
+  it "hscroll_notes scrolls a long notes line sideways into view (shift+←/→)" do
+    tmp_store do |store|
+      id = store.insert_finding("XSS", Gori::Store::Severity::Medium, "acme.test", nil)
+      store.update_finding(id, notes: "HEAD" + ("." * 80) + "TAIL")
+      view = FindingsView.new
+      view.reload(store)
+      view.open_detail(store).should be_true
+      view.editing_notes?.should be_false # read-only preview — hscroll_notes applies here
+
+      rect = Rect.new(0, 0, 80, 12)
+      backend = MemoryBackend.new(80, 12)
+      view.render(Screen.new(backend), rect, focused: true)
+      backend.contains?("HEAD").should be_true
+      backend.contains?("TAIL").should be_false # off the right edge, clipped
+
+      20.times { view.hscroll_notes(1) } # scroll well past the line's width
+      backend2 = MemoryBackend.new(80, 12)
+      view.render(Screen.new(backend2), rect, focused: true)
+      backend2.contains?("TAIL").should be_true
+      backend2.contains?("HEAD").should be_false # scrolled off the left edge
+    end
+  end
+
   it "opens a detail, changes severity, and edits + saves notes" do
     tmp_store do |store|
       id = store.insert_finding("XSS", Gori::Store::Severity::Medium, "acme.test", nil)

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -112,6 +112,27 @@ describe Gori::Tui::FuzzerView do
       backend.contains?("DIST").should be_false
     end
   end
+
+  it "hscroll_detail scrolls a long RESULT response line sideways into view (shift+←/→)" do
+    view = loaded_fuzzer
+    long_line = "HEAD" + ("." * 100) + "TAIL"
+    r = Gori::Fuzz::Result.new(0_i64, ["p0"], nil, 200, 1200_i64, 40, 5, 1000_i64, nil, false, false, nil,
+      "HTTP/1.1 200 OK\r\n\r\n".to_slice, long_line.to_slice)
+    view.append_result(r)
+    view.open_detail
+
+    rect = Rect.new(0, 0, 80, 20)
+    backend = MemoryBackend.new(80, 20)
+    view.render(Screen.new(backend), rect)
+    backend.contains?("HEAD").should be_true
+    backend.contains?("TAIL").should be_false # off the right edge, clipped
+
+    20.times { view.hscroll_detail(1) } # scroll well past the line's width
+    backend2 = MemoryBackend.new(80, 20)
+    view.render(Screen.new(backend2), rect)
+    backend2.contains?("TAIL").should be_true
+    backend2.contains?("HEAD").should be_false # scrolled off the left edge
+  end
 end
 
 describe Gori::Tui::PathComplete do

--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -161,6 +161,36 @@ describe Gori::Tui::HistoryView do
     end
   end
 
+  it "hscroll_detail scrolls a long response body line sideways into view (shift+←/→)" do
+    tmp_store do |store|
+      id = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "https", host: "h.test", port: 443,
+        method: "GET", target: "/api", http_version: "HTTP/1.1",
+        head: "GET /api HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice, body: nil))
+      store.update_response(Gori::Store::CapturedResponse.new(
+        flow_id: id, status: 200,
+        head: "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n".to_slice,
+        body: ("HEAD" + ("." * 100) + "TAIL").to_slice, content_type: "text/plain"))
+
+      view = HistoryView.new
+      view.reload(store)
+      view.open_detail(store).should be_true
+      view.toggle_pane # request -> response
+
+      rect = Rect.new(0, 0, 80, 16)
+      backend = MemoryBackend.new(80, 16)
+      view.render_detail(Screen.new(backend), rect)
+      backend.contains?("HEAD").should be_true
+      backend.contains?("TAIL").should be_false # off the right edge, clipped
+
+      20.times { view.hscroll_detail(1) } # scroll well past the line's width
+      backend2 = MemoryBackend.new(80, 16)
+      view.render_detail(Screen.new(backend2), rect)
+      backend2.contains?("TAIL").should be_true
+      backend2.contains?("HEAD").should be_false # scrolled off the left edge
+    end
+  end
+
   it "pretty-prints a JSON response body when enabled, and restores raw when off" do
     tmp_store do |store|
       id = store.insert_flow(Gori::Store::CapturedRequest.new(

--- a/spec/tui/intercept_view_spec.cr
+++ b/spec/tui/intercept_view_spec.cr
@@ -61,6 +61,27 @@ describe Gori::Tui::InterceptView do
     end
   end
 
+  it "hscroll_detail scrolls a long held-request header sideways into view (shift+←/→)" do
+    tmp_interceptor do |ic|
+      long_header = "X-Long: HEAD" + ("." * 80) + "TAIL"
+      hold_req(ic, "acme.test", "/login", "GET /login HTTP/1.1\r\nHost: acme.test\r\n#{long_header}\r\n\r\n")
+      view = InterceptView.new
+      view.reload(ic)
+
+      rect = Rect.new(0, 0, 100, 12)
+      backend = MemoryBackend.new(100, 12)
+      view.render(Screen.new(backend), rect)
+      backend.contains?("HEAD").should be_true
+      backend.contains?("TAIL").should be_false # off the right edge, clipped
+
+      20.times { view.hscroll_detail(1) } # scroll well past the line's width
+      backend2 = MemoryBackend.new(100, 12)
+      view.render(Screen.new(backend2), rect)
+      backend2.contains?("TAIL").should be_true
+      backend2.contains?("HEAD").should be_false # scrolled off the left edge
+    end
+  end
+
   it "edits a held request and forwards the edited bytes" do
     tmp_interceptor do |ic|
       hold_req(ic, "acme.test", "/", "GET / HTTP/1.1\r\nHost: acme.test\r\n\r\n")

--- a/spec/tui/replay_view_spec.cr
+++ b/spec/tui/replay_view_spec.cr
@@ -432,4 +432,24 @@ describe Gori::Tui::ReplayView do
       store.replays.first.sni.should be_nil
     end
   end
+
+  it "hscroll scrolls a long response body line sideways into view (shift+←/→)" do
+    view = ReplayView.new
+    view.load_blank
+    long_line = "HEAD" + ("." * 60) + "TAIL"
+    ok = Gori::Replay::Result.new("HTTP/1.1 200 OK\r\n\r\n".to_slice, long_line.to_slice, nil, 1000_i64)
+    view.apply(ok)
+
+    rect = Rect.new(0, 0, 100, 20)
+    backend = MemoryBackend.new(100, 20)
+    view.render(Screen.new(backend), rect)
+    backend.contains?("HEAD").should be_true
+    backend.contains?("TAIL").should be_false # off the right edge, clipped
+
+    20.times { view.hscroll(1) } # scroll well past the line's width
+    backend2 = MemoryBackend.new(100, 20)
+    view.render(Screen.new(backend2), rect)
+    backend2.contains?("TAIL").should be_true
+    backend2.contains?("HEAD").should be_false # scrolled off the left edge
+  end
 end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -88,6 +88,10 @@ private class FakeContext < ExecContext
     @calls << :scroll_detail
   end
 
+  def hscroll_detail(delta : Int32) : Nil
+    @calls << :hscroll_detail
+  end
+
   def toggle_detail_pane : Nil
     @calls << :toggle_detail_pane
   end
@@ -306,6 +310,10 @@ private class FakeContext < ExecContext
 
   def finding_edit_notes : Nil
     @calls << :finding_edit_notes
+  end
+
+  def finding_hscroll(delta : Int32) : Nil
+    @calls << :finding_hscroll
   end
 
   def finding_edit_title : Nil

--- a/src/gori/tui/controllers/convert_controller.cr
+++ b/src/gori/tui/controllers/convert_controller.cr
@@ -77,6 +77,7 @@ module Gori::Tui
     # Build a fresh session from persisted/blank text, running the initial chain.
     private def make_session(input_text : String, chain : String, name : String?) : ConvertSession
       input = TextArea.new(input_text)
+      input.follow_x = true # long input lines scroll horizontally to keep the cursor visible
       result = Convert.run(@registry, input.text.to_slice, chain)
       view = ConvertView.new
       view.name = name
@@ -298,7 +299,7 @@ module Gori::Tui
         return "↑/↓ pick · ↹/↵ complete · esc close · type to filter" if @popup.open?
         "chain (> | ,) · ↑ input · ↓ output · ^Y copy · ^X mode · ^S save · ^O load · esc tabs"
       when :output
-        "↑/↓ scroll · ↑-top chain · ↹ next · space menu · ^X mode · ^Y copy · esc tabs"
+        "↑/↓ scroll · ⇧←/→ h-scroll · ↑-top chain · ↹ next · space menu · ^X mode · ^Y copy · esc tabs"
       else
         "type to edit · ↓/↹ chain · ^L clear · ^Y copy · ^X mode · ^N new · ^W close · esc tabs"
       end
@@ -429,8 +430,10 @@ module Gori::Tui
       s = cur
       key = ev.key
       case
-      when key.up?   then s.view.output_at_top? ? (s.pane = :chain) : s.view.scroll_output(-1)
-      when key.down? then s.view.scroll_output(1)
+      when key.up?                 then s.view.output_at_top? ? (s.pane = :chain) : s.view.scroll_output(-1)
+      when key.down?               then s.view.scroll_output(1)
+      when key.left? && ev.shift?  then s.view.hscroll_output(-1)
+      when key.right? && ev.shift? then s.view.hscroll_output(1)
       end
     end
 

--- a/src/gori/tui/controllers/findings_controller.cr
+++ b/src/gori/tui/controllers/findings_controller.cr
@@ -35,7 +35,7 @@ module Gori::Tui
     def body_hint(focus : Symbol) : String
       if @findings.detail_open?
         @findings.editing_notes? ? "esc save · ^W discard" \
-                                 : "e notes · o flow · r replay · space triage/cmds · ←/esc back"
+                                 : "e notes · o flow · r replay · space triage/cmds · ⇧←/→ h-scroll · ←/esc back"
       elsif @findings.querying?
         "type to filter · ↹ complete · ↵ apply · esc clear"
       else
@@ -179,6 +179,10 @@ module Gori::Tui
 
     def finding_edit_notes : Nil
       @findings.start_notes_edit
+    end
+
+    def finding_hscroll(delta : Int32) : Nil
+      @findings.hscroll_notes(delta)
     end
 
     # Write all findings to the project dir as Markdown (the report) or JSON.

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -88,7 +88,7 @@ module Gori::Tui
       when :template then "type · ^A params · ^K word · ^T point · ^U clear · ^O config · ^R run · ^N new · ↹ pane"
       when :config   then config_hint(v)
       when :results  then "↑/↓ select · ↵ detail · o sort · m matched · ^R run · ^X stop · space cmds · ↹ pane"
-      when :detail   then "↑/↓ scroll · ←/→ req/resp · esc back"
+      when :detail   then "↑/↓ scroll · ←/→ req/resp · ⇧←/→ h-scroll · esc back"
       else                "↹/esc tabs"
       end
     end
@@ -285,9 +285,11 @@ module Gori::Tui
     private def handle_detail(ev : Termisu::Event::Key, v : FuzzerView) : Nil
       key = ev.key
       case
-      when key.up?               then v.detail_scroll(-1)
-      when key.down?             then v.detail_scroll(1)
-      when key.left?, key.right? then v.detail_toggle_pane
+      when key.up?                 then v.detail_scroll(-1)
+      when key.down?               then v.detail_scroll(1)
+      when key.left? && ev.shift?  then v.hscroll_detail(-1)
+      when key.right? && ev.shift? then v.hscroll_detail(1)
+      when key.left?, key.right?   then v.detail_toggle_pane
       end
     end
 

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -195,6 +195,10 @@ module Gori::Tui
       @history.scroll_detail(delta)
     end
 
+    def hscroll_detail(delta : Int32) : Nil
+      @history.hscroll_detail(delta)
+    end
+
     def toggle_detail_pane : Nil
       @history.toggle_pane
     end

--- a/src/gori/tui/controllers/intercept_controller.cr
+++ b/src/gori/tui/controllers/intercept_controller.cr
@@ -37,7 +37,7 @@ module Gori::Tui
       elsif @intercept.querying?
         "type condition · ↵ apply · esc clear"
       else
-        "↑/↓ move · ↵/e edit · f fwd · d drop · F all · / filter · c catch · i on/off · space cmds · ↹ detail · esc tabs"
+        "↑/↓ move · ⇧←/→ h-scroll · ↵/e edit · f fwd · d drop · F all · / filter · c catch · i on/off · space cmds · ↹ detail · esc tabs"
       end
     end
 
@@ -62,7 +62,9 @@ module Gori::Tui
         handle_edit_key(ev)
         true
       else
-        handle_queue_key(ev) # false for c / / (and other unhandled keys) → defer to the keymap
+        # shift+←/→ (h-scroll the preview) checked here rather than inside
+        # handle_queue_key — that dispatch is already at ameba's complexity ceiling.
+        queue_key_hscroll(ev) || handle_queue_key(ev) # false for c / / (and other unhandled keys) → defer to the keymap
       end
     end
 
@@ -127,6 +129,22 @@ module Gori::Tui
       else                               return false
       end
       true
+    end
+
+    # Shift+←/→ horizontal scroll for the read-only held-item preview — kept OUT of
+    # handle_queue_key (called from handle_body_key instead), since that dispatch is
+    # already at ameba's complexity ceiling.
+    private def queue_key_hscroll(ev : Termisu::Event::Key) : Bool
+      key = ev.key
+      if key.left? && ev.shift?
+        @intercept.hscroll_detail(-1)
+        true
+      elsif key.right? && ev.shift?
+        @intercept.hscroll_detail(1)
+        true
+      else
+        false
+      end
     end
 
     # --- catch-condition filter bar (a text sub-mode; the shell claims it before the

--- a/src/gori/tui/controllers/replay_controller.cr
+++ b/src/gori/tui/controllers/replay_controller.cr
@@ -106,18 +106,18 @@ module Gori::Tui
       return "↹/esc tabs · ^N new" unless v
       return "HEX: 0-9a-f overtype · Ins/Del/⌫ bytes · ←/→/↑/↓ move · ^R send · ^X/esc exit" if v.request_hex?
       if v.ws_mode? # WS replay: MESSAGES editor + TRANSCRIPT (no hex/diff/pretty/CL)
-        return v.focus == :response ? "↑/↓ scroll · ^F find · ^R replay · ↹ pane · esc tabs" \
+        return v.focus == :response ? "↑/↓ scroll · ⇧←/→ h-scroll · ^F find · ^R replay · ↹ pane · esc tabs" \
                                     : "edit messages (one per line) · ^R replay · ^G goto · ^F find · ^W close · ↹ pane · esc tabs"
       end
       if v.grpc_mode? # gRPC replay: editable head + verbatim body; deframed response
-        return v.focus == :response ? "↑/↓ scroll · ^F find · ^R replay · ↹ pane · esc tabs" \
+        return v.focus == :response ? "↑/↓ scroll · ⇧←/→ h-scroll · ^F find · ^R replay · ↹ pane · esc tabs" \
                                     : "edit head/metadata · ^R replay · ^G goto · ^F find · ^W close · ↹ pane · esc tabs"
       end
       return decode_hint(v) if v.decode_mode? && v.focus == :request # split: ENVELOPE + DECODED payload
       case v.focus
       when :target   then v.editing_sni? ? "type SNI host · ^S/↵/esc back to URL · ^R send" \
                                           : "type URL · ^S SNI · ↵/↓ request · ^R send · ↹ pane · esc tabs"
-      when :response then "↑/↓ scroll · ←/→/d diff · x hex · p pretty · ^F find · ^R send · space cmds · ↹ pane · esc tabs"
+      when :response then "↑/↓ scroll · ←/→/d diff · ⇧←/→ h-scroll · x hex · p pretty · ^F find · ^R send · space cmds · ↹ pane · esc tabs"
       else                "type to edit · ^R send · ^G goto · ^F find · ^X hex · ^B ws · ^N new · ^W close · ↹ pane · esc tabs"
       end
     end
@@ -734,6 +734,7 @@ module Gori::Tui
     # Response/Diff pane: read-only. ←/→ or d toggles response↔diff, ↑/↓ scroll, Enter re-sends.
     private def handle_replay_response(ev : Termisu::Event::Key, view : ReplayView) : Nil
       return @host.open_space_menu if ev.key.space? && !ev.ctrl? && !ev.alt? # space menu (response is navigable)
+      return if handle_replay_response_hscroll(ev, view)
       key = ev.key
       # A WS/gRPC TRANSCRIPT is scroll-only — the diff/hex/reveal/pretty toggles are
       # meaningless there and have side effects (a stuck @resp_hex would silently break
@@ -749,6 +750,23 @@ module Gori::Tui
       when key.lower_x?          then view.toggle_resp_hex
       when key.lower_b?          then @host.toggle_reveal
       when key.lower_p?          then @host.toggle_pretty
+      end
+    end
+
+    # Shift+←/→ horizontal scroll, split out of handle_replay_response to keep its
+    # cyclomatic complexity under ameba's threshold (this repo's dispatch-methods
+    # habitually tip over the limit one branch at a time). Works even in WS/gRPC
+    # transcript mode, so it's checked before that gate.
+    private def handle_replay_response_hscroll(ev : Termisu::Event::Key, view : ReplayView) : Bool
+      key = ev.key
+      if key.left? && ev.shift?
+        view.hscroll(-1)
+        true
+      elsif key.right? && ev.shift?
+        view.hscroll(1)
+        true
+      else
+        false
       end
     end
   end

--- a/src/gori/tui/convert_view.cr
+++ b/src/gori/tui/convert_view.cr
@@ -23,6 +23,7 @@ module Gori::Tui
     @prefer : Convert::RenderAs? = nil # nil = auto
     @prefer_idx : Int32 = 0
     @out_scroll : Int32 = 0
+    @out_xscroll : Int32 = 0 # horizontal scroll offset for the OUTPUT card (shift+←/→)
     @last_step_count : Int32 = 0
     # Cached OUTPUT lines, rebuilt only when the chain recomputes or the display mode
     # changes (NOT every frame) — encoding/splitting a near-MAX_OUT (32 MiB) output on
@@ -159,10 +160,11 @@ module Gori::Tui
       lines = output_lines(result)
       @out_scroll = @out_scroll.clamp(0, {lines.size - rect.h, 0}.max)
       fg = result.output.nil? ? Theme.red : Theme.text
-      (0...rect.h).each do |i|
-        line = lines[@out_scroll + i]?
-        break unless line
-        screen.text(rect.x, rect.y + i, line, fg, Theme.bg, width: rect.w)
+      rows = (0...rect.h).compact_map { |i| lines[@out_scroll + i]? }
+      @out_xscroll = @out_xscroll.clamp(0, {(rows.max_of? { |l| Screen.display_width(l) } || 0) - rect.w, 0}.max)
+      rows.each_with_index do |line, i|
+        shown = @out_xscroll > 0 ? Highlight.slice_left_text(line, @out_xscroll) : line
+        screen.text(rect.x, rect.y + i, shown, fg, Theme.bg, width: rect.w)
       end
     end
 
@@ -238,6 +240,12 @@ module Gori::Tui
       @out_scroll += step
     end
 
+    # Horizontal companion to `scroll_output` (shift+←/→). Floored at 0 here; render
+    # clamps the upper bound to the widest row actually on screen.
+    def hscroll_output(step : Int32) : Nil
+      @out_xscroll = {@out_xscroll + step * 4, 0}.max
+    end
+
     # Whether the OUTPUT is scrolled to the top — ↑ here pops focus up to CHAIN
     # (render clamps @out_scroll on every frame, so this reads the true top).
     def output_at_top? : Bool
@@ -248,6 +256,7 @@ module Gori::Tui
     # the cached output lines (the content changed).
     def reset_output_scroll : Nil
       @out_scroll = 0
+      @out_xscroll = 0
       @out_dirty = true
     end
   end

--- a/src/gori/tui/findings_view.cr
+++ b/src/gori/tui/findings_view.cr
@@ -20,8 +20,10 @@ module Gori::Tui
       @detail = nil.as(Store::Finding?)
       @detail_flow = nil.as(Store::FlowRow?)
       @detail_scroll = 0
+      @notes_xscroll = 0 # horizontal scroll offset for the read-only notes preview
       @editing_notes = false
       @notes = TextArea.new
+      @notes.follow_x = true # long note lines scroll horizontally to keep the cursor visible
       @loaded = false
       # The `/` filter bar (mirrors History's QL bar but matches in memory).
       @query = ""
@@ -169,8 +171,16 @@ module Gori::Tui
       @detail = finding
       @detail_flow = finding.flow_id.try { |fid| store.flow_row(fid) }
       @detail_scroll = 0
+      @notes_xscroll = 0
       @editing_notes = false
       true
+    end
+
+    # Nudge the read-only notes preview sideways (shift+←/→). No-op while editing —
+    # the TextArea editor's own follow_x already handles that case.
+    def hscroll_notes(delta : Int32) : Nil
+      return if @editing_notes
+      @notes_xscroll = {@notes_xscroll + delta * 4, 0}.max
     end
 
     def close_detail : Nil
@@ -386,9 +396,12 @@ module Gori::Tui
       if @editing_notes
         @notes.render(screen, notes_rect, cursor: focused)
       else
-        finding.notes.split('\n').each_with_index do |note_line, i|
-          break if notes_y + i >= rect.bottom
-          screen.text(notes_rect.x, notes_rect.y + i, note_line, Theme.text, width: notes_rect.w)
+        visible_h = {rect.bottom - notes_y, 0}.max
+        rows = finding.notes.split('\n').first(visible_h)
+        @notes_xscroll = @notes_xscroll.clamp(0, {(rows.max_of? { |l| Screen.display_width(l) } || 0) - notes_rect.w, 0}.max)
+        rows.each_with_index do |note_line, i|
+          shown = @notes_xscroll > 0 ? Highlight.slice_left_text(note_line, @notes_xscroll) : note_line
+          screen.text(notes_rect.x, notes_rect.y + i, shown, Theme.text, width: notes_rect.w)
         end
       end
     end

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -59,6 +59,7 @@ module Gori::Tui
       @http2 = false
       @editor = TextArea.new
       @editor.gutter = true
+      @editor.follow_x = true # long lines (headers, URLs, §-marked params) scroll horizontally to keep the cursor visible
       @config = Fuzz::Config.new(keep_bodies: :matched)
       @sets = [] of SetSpec
       @matcher = Fuzz::Matcher.new(keep_bodies: :matched)
@@ -104,6 +105,7 @@ module Gori::Tui
       @job_id = 0
       @stop_requested = false
       @detail_scroll = 0
+      @detail_xscroll = 0 # horizontal scroll offset for the RESULT detail (shift+←/→)
       @detail_pane = :response
       @focus = :template
       @loaded = false
@@ -726,6 +728,7 @@ module Gori::Tui
       return if sorted_results.empty?
       @focus = :detail
       @detail_scroll = 0
+      @detail_xscroll = 0
       @detail_pane = :response
     end
 
@@ -733,9 +736,16 @@ module Gori::Tui
       @detail_scroll = {@detail_scroll + d, 0}.max
     end
 
+    # Horizontal companion to `detail_scroll` (shift+←/→). Floored at 0 here; the
+    # render loop clamps the upper bound to the widest row actually on screen.
+    def hscroll_detail(delta : Int32) : Nil
+      @detail_xscroll = {@detail_xscroll + delta * 4, 0}.max
+    end
+
     def detail_toggle_pane : Nil
       @detail_pane = @detail_pane == :response ? :request : :response
       @detail_scroll = 0
+      @detail_xscroll = 0
     end
 
     def selected_result : Fuzz::Result?
@@ -1393,10 +1403,11 @@ module Gori::Tui
       lines = @detail_pane == :request ? detail_request_lines(r) : detail_response_lines(r)
       # Clamp so ↓/wheel can't scroll past the last line into a blank void (keeps ≥1 row).
       @detail_scroll = @detail_scroll.clamp(0, {lines.size - 1, 0}.max)
-      (0...inner.h).each do |i|
-        li = @detail_scroll + i
-        break if li >= lines.size
-        screen.text(inner.x, inner.y + i, lines[li], Theme.text, Theme.bg, width: inner.w)
+      rows = (0...inner.h).compact_map { |i| lines[@detail_scroll + i]? }
+      @detail_xscroll = @detail_xscroll.clamp(0, {(rows.max_of? { |l| Screen.display_width(l) } || 0) - inner.w, 0}.max)
+      rows.each_with_index do |line, i|
+        shown = @detail_xscroll > 0 ? Highlight.slice_left_text(line, @detail_xscroll) : line
+        screen.text(inner.x, inner.y + i, shown, Theme.text, Theme.bg, width: inner.w)
       end
     end
 

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -47,6 +47,7 @@ module Gori::Tui
         {"f · /", "follow newest · filter (query language)"},
         {"i", "toggle intercept hold-mode"},
         {"x · b · p", "in a flow: hex · whitespace · pretty bodies"},
+        {"⇧←/→", "in a flow: scroll a long line sideways"},
       ]},
       {"REPLAY", [
         {"^R", "send the request"},
@@ -57,6 +58,7 @@ module Gori::Tui
         {"^L", "toggle auto Content-Length"},
         {"↹", "cycle target → request → response"},
         {"x · d · p", "response: hex · diff · pretty"},
+        {"⇧←/→", "response: scroll a long line sideways"},
       ]},
       {"FUZZER", [
         {"⇧I", "send a flow/replay here (History/Replay)"},
@@ -69,6 +71,7 @@ module Gori::Tui
         {"↑/↓ · ↵", "results: select · open detail"},
         {"o · m", "sort · matched-only"},
         {"r", "rename the sub-tab (on the strip)"},
+        {"⇧←/→", "detail: scroll a long line sideways"},
       ]},
       {"COMPARER", [
         {"a · b", "pick flow A · flow B"},
@@ -83,11 +86,11 @@ module Gori::Tui
       ]},
       {"OTHER TABS", [
         {"Sitemap", "↑/↓ · / filter · ↵/→ expand · t tag · g group · ⇧S scope"},
-        {"Findings", "/ filter · ↵ open · n new · space triage · x export"},
+        {"Findings", "/ filter · ↵ open · n new · space triage · x export · ⇧←/→ h-scroll notes"},
         {"Prism", "↑/↓ ↵ open · m mode · c dismiss · a all · / filter · space cmds"},
         {"Notes", "type to edit · ^N new · ^1-9 switch"},
         {"Project", "scope rules + the description editor"},
-        {"Intercept", "↵/e edit · f fwd · d drop · F all · c catch dir · / condition"},
+        {"Intercept", "↵/e edit · f fwd · d drop · F all · c catch dir · / condition · ⇧←/→ h-scroll preview"},
       ]},
       {"CONVERT", [
         {"type / ↹", "edit input · switch input ↔ chain"},
@@ -98,6 +101,7 @@ module Gori::Tui
         {"^N · ^W", "new · close conversion sub-tab"},
         {"^1-9 · r", "switch sub-tab · rename (on the strip)"},
         {"space", "command menu (on the sub-tab strip)"},
+        {"⇧←/→", "output: scroll a long line sideways"},
       ]},
       {"OVERLAYS", [
         {"palette / settings", "↑/↓ · ↵ · esc"},

--- a/src/gori/tui/highlight.cr
+++ b/src/gori/tui/highlight.cr
@@ -381,6 +381,38 @@ module Gori::Tui
       out
     end
 
+    # The plain-string counterpart of `slice_left` — same straddling-glyph handling,
+    # for the read-only panes that draw raw `String` lines (no syntax overlay) rather
+    # than a styled `Line`. Identity when start_col <= 0.
+    def self.slice_left_text(s : String, start_col : Int32) : String
+      return s if start_col <= 0
+      acc = 0
+      cutting = true
+      String.build do |io|
+        s.each_char do |ch|
+          if cutting
+            w = Screen.display_width(ch.to_s)
+            if acc + w <= start_col
+              acc += w
+              next
+            end
+            io << " " * (acc + w - start_col) if acc < start_col # straddling glyph → visible cells as spaces
+            io << ch if acc >= start_col                         # clean boundary keeps the glyph
+            acc += w
+            cutting = false
+          else
+            io << ch
+          end
+        end
+      end
+    end
+
+    # Total display width of a styled line (sum of its spans) — used to clamp a
+    # horizontal scroll offset against the widest currently-visible row.
+    def self.line_width(line : Line) : Int32
+      line.sum { |span| Screen.display_width(span.text) }
+    end
+
     # --- line builders -------------------------------------------------------
 
     private def self.start_line(raw : String, request : Bool) : Line

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -68,6 +68,7 @@ module Gori::Tui
       @detail_form = nil.as(Array(FormData::Field)?) # form/multipart params → PARAMS pane
       @decoded_id = nil.as(Int64?)                   # flow the decoded panes above were parsed from (skip re-decode)
       @detail_scroll = 0
+      @detail_xscroll = 0 # horizontal scroll offset for the detail body (shift+←/→)
       @detail_pane = :request
       @search_hl = ""                        # active ^F query → highlight in the detail body
       @reveal = false                        # 'w' shows whitespace/CR/LF as glyphs (smuggling)
@@ -318,6 +319,7 @@ module Gori::Tui
       # (DETAIL_LOG_CAP) with the full count kept for the "older not loaded" note.
       load_detail_logs(store)
       @detail_scroll = 0
+      @detail_xscroll = 0
       @detail_pane = :request
       @detail_cache = nil
       @detail_hex = false # hex is a deliberate per-open peek — don't carry it into the next flow
@@ -411,6 +413,7 @@ module Gori::Tui
       return if log_pane? # frames/events have no raw-bytes hex; don't strand a hidden flag
       @detail_hex = !@detail_hex
       @detail_scroll = 0 # row-based offset differs from the line-based one
+      @detail_xscroll = 0
     end
 
     # Re-fetch the currently-open detail from the store (e.g. a peer instance filled
@@ -439,6 +442,12 @@ module Gori::Tui
       @detail_scroll = (@detail_scroll + delta).clamp(0, detail_scroll_max)
     end
 
+    # Horizontal companion to `scroll_detail` (shift+←/→). Floored at 0 here; the
+    # render loop clamps the upper bound to the widest row actually on screen.
+    def hscroll_detail(delta : Int32) : Nil
+      @detail_xscroll = {@detail_xscroll + delta * 4, 0}.max
+    end
+
     # ^G go-to-line in the detail view: scroll so 1-based line `n` is at the top
     # (interpreted in the active pane/mode — request/response/frames/hex row).
     def goto_detail_line(n : Int32) : Nil
@@ -458,6 +467,7 @@ module Gori::Tui
       return if @reveal == on
       @reveal = on
       @detail_scroll = 0
+      @detail_xscroll = 0
     end
 
     # Pretty toggle feeds `build_detail_view`, so a change must drop the windowed
@@ -468,6 +478,7 @@ module Gori::Tui
       @pretty = on
       @detail_cache = nil
       @detail_scroll = 0 # reflow changes the line count → a stale offset could blank the pane (like hex/pane toggles)
+      @detail_xscroll = 0
     end
 
     # Revealed (whitespace-visible) lines of the current pane, cached + rebuilt only
@@ -572,6 +583,7 @@ module Gori::Tui
     private def set_detail_pane(pane : Symbol) : Nil
       @detail_pane = pane
       @detail_scroll = 0
+      @detail_xscroll = 0
       @detail_cache = nil     # pane switch changes the content
       @detail_hex_bytes = nil # …and the hex source bytes
     end
@@ -781,7 +793,7 @@ module Gori::Tui
       mode = hex ? "HEX" : (ws ? "RAW" : (applied ? "PRETTY" : "RAW"))
       ptog = applied ? "p:raw" : "p:pretty"
       mode_hint = hex ? "#{mode} · x:text" : (ws ? "#{mode} · b:raw" : "#{mode} · x:hex · b:ws · #{ptog}")
-      screen.text(x + 1, rect.y, "↑/↓ scroll · #{mode_hint} · esc back", Theme.muted)
+      screen.text(x + 1, rect.y, "↑/↓ scroll · ⇧←/→ h-scroll · #{mode_hint} · esc back", Theme.muted)
       Frame.inner_divider(screen, rect, rect.y + 1, border: Frame.pane_border(focused))
 
       body = Rect.new(rect.x + 1, rect.y + 2, {rect.w - 2, 0}.max, {rect.bottom - (rect.y + 2), 0}.max)
@@ -794,16 +806,29 @@ module Gori::Tui
         return
       end
 
+      render_detail_body(screen, body)
+    end
+
+    # The normal (non-hex, non-reveal) detail body: request/response/decoded-pane text,
+    # windowed + horizontally scrollable. Split out of render_detail to keep that
+    # dispatch's cyclomatic complexity under ameba's threshold.
+    private def render_detail_body(screen : Screen, body : Rect) : Nil
       dv = detail_view
       total = dv.total
       gw = {Gutter.width(total), body.w}.min
       cw = {body.w - gw, 0}.max
-      (0...body.h).each do |i|
+      # Styles each visible line ONCE (into `rows`), then clamps/slices from that —
+      # never re-styles just to measure width (mirrors ReplayView#render_response_body).
+      rows = (0...body.h).compact_map { |i| (li = @detail_scroll + i) < total ? dv.line_at(li) : nil }
+      @detail_xscroll = @detail_xscroll.clamp(0, {(rows.max_of? { |l| Highlight.line_width(l) } || 0) - cw, 0}.max)
+      rows.each_with_index do |styled, i|
         li = @detail_scroll + i
-        break if li >= total
         Gutter.draw(screen, body.x, body.y + i, li, gw)
-        Highlight.draw(screen, body.x + gw, body.y + i, dv.line_at(li), width: cw) # styles only this visible line
-        SearchHi.mark(screen, body.x + gw, body.y + i, dv.line_text(li), @search_hl, body.x + gw + cw) unless @search_hl.empty?
+        shown = @detail_xscroll > 0 ? Highlight.slice_left(styled, @detail_xscroll) : styled
+        Highlight.draw(screen, body.x + gw, body.y + i, shown, width: cw)
+        text = dv.line_text(li)
+        st = @detail_xscroll > 0 ? Highlight.slice_left_text(text, @detail_xscroll) : text
+        SearchHi.mark(screen, body.x + gw, body.y + i, st, @search_hl, body.x + gw + cw) unless @search_hl.empty?
       end
     end
 
@@ -813,12 +838,17 @@ module Gori::Tui
       total = lines.size
       gw = {Gutter.width(total), body.w}.min
       cw = {body.w - gw, 0}.max
+      widest = (0...body.h).compact_map { |i| lines[@detail_scroll + i]? }.max_of? { |l| Screen.display_width(l) } || 0
+      @detail_xscroll = @detail_xscroll.clamp(0, {widest - cw, 0}.max)
       (0...body.h).each do |i|
         li = @detail_scroll + i
         break if li >= total
         Gutter.draw(screen, body.x, body.y + i, li, gw)
-        Highlight.draw(screen, body.x + gw, body.y + i, Reveal.styled(lines[li], li < total - 1, cw), width: cw)
-        SearchHi.mark(screen, body.x + gw, body.y + i, lines[li], @search_hl, body.x + gw + cw) unless @search_hl.empty?
+        styled = Reveal.styled(lines[li], li < total - 1, cw + @detail_xscroll)
+        styled = Highlight.slice_left(styled, @detail_xscroll) if @detail_xscroll > 0
+        Highlight.draw(screen, body.x + gw, body.y + i, styled, width: cw)
+        st = @detail_xscroll > 0 ? Highlight.slice_left_text(lines[li], @detail_xscroll) : lines[li]
+        SearchHi.mark(screen, body.x + gw, body.y + i, st, @search_hl, body.x + gw + cw) unless @search_hl.empty?
       end
     end
 

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -28,7 +28,8 @@ module Gori::Tui
       @selected = 0
       @scroll = 0
       @editor = TextArea.new
-      @editor.gutter = true # line numbers in the held-message editor (pairs with ^G)
+      @editor.gutter = true   # line numbers in the held-message editor (pairs with ^G)
+      @editor.follow_x = true # long lines (headers, URLs) scroll horizontally to keep the cursor visible
       @editing = false
       # Filter bar: the catch direction + on/off mirror the Interceptor (captured on
       # reload, rendered as chips); the condition query is a local edit buffer pushed
@@ -48,6 +49,7 @@ module Gori::Tui
       @detail_win = nil.as(Highlight::Windowed?)
       @detail_win_id = nil.as(Int64?)
       @detail_win_rev = Theme.revision # the theme the cached (colour-baked) head was built under
+      @detail_xscroll = 0              # horizontal scroll offset for the read-only held-item preview
     end
 
     # Fresh snapshot (cheap; called on enter AND every frame via the 50ms loop).
@@ -427,11 +429,22 @@ module Gori::Tui
       else
         win = detail_window_for(it)
         total = win.total
-        (0...inner.h).each do |i|
-          break if i >= total
-          Highlight.draw(screen, inner.x, inner.y + i, win.line_at(i), width: inner.w) # styles only the visible line
+        # Styles each visible line ONCE (into `rows`), then clamps/slices from that —
+        # mirrors ReplayView#render_response_body / HistoryView#render_detail.
+        rows = (0...inner.h).compact_map { |i| i < total ? win.line_at(i) : nil }
+        @detail_xscroll = @detail_xscroll.clamp(0, {(rows.max_of? { |l| Highlight.line_width(l) } || 0) - inner.w, 0}.max)
+        rows.each_with_index do |styled, i|
+          shown = @detail_xscroll > 0 ? Highlight.slice_left(styled, @detail_xscroll) : styled
+          Highlight.draw(screen, inner.x, inner.y + i, shown, width: inner.w)
         end
       end
+    end
+
+    # Nudge the read-only held-item preview sideways (shift+←/→). No-op while
+    # editing — the TextArea editor's own follow_x already handles that case.
+    def hscroll_detail(delta : Int32) : Nil
+      return if @editing
+      @detail_xscroll = {@detail_xscroll + delta * 4, 0}.max
     end
 
     # Windowed view of the held item's raw bytes, cached by item id (held bytes
@@ -441,6 +454,7 @@ module Gori::Tui
     private def detail_window_for(it : Interceptor::Item) : Highlight::Windowed
       cached = @detail_win
       return cached if cached && @detail_win_id == it.id && @detail_win_rev == Theme.revision
+      @detail_xscroll = 0 if @detail_win_id != it.id # a newly-previewed item resets the scroll
       @detail_win_id = it.id
       @detail_win_rev = Theme.revision
       @detail_win = Highlight.from_lines_windowed(String.new(it.raw).split('\n').map(&.rstrip('\r')), it.kind.request?)

--- a/src/gori/tui/notes_view.cr
+++ b/src/gori/tui/notes_view.cr
@@ -27,6 +27,7 @@ module Gori::Tui
 
       def initialize(text : String = "")
         @area = TextArea.new(text)
+        @area.follow_x = true # long lines scroll horizontally to keep the cursor visible (like the Project description)
       end
 
       # Sub-tab label: the note's title (first non-blank line, trimmed) truncated

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -40,9 +40,10 @@ module Gori::Tui
       @scx = 0             # SNI cursor
       @target_field = :url # which field the TARGET pane edits: :url | :sni
       @editor = TextArea.new
-      @editor.gutter = true # line numbers in the request body (pairs with ^G)
-      @search_hl = ""       # active ^F query → highlight in the response pane (request is via @editor)
-      @reveal = false       # 'w' shows whitespace/CR/LF as glyphs (response from raw bytes, request via @editor)
+      @editor.gutter = true   # line numbers in the request body (pairs with ^G)
+      @editor.follow_x = true # long lines (headers, URLs, base64 params) scroll horizontally to keep the cursor visible
+      @search_hl = ""         # active ^F query → highlight in the response pane (request is via @editor)
+      @reveal = false         # 'w' shows whitespace/CR/LF as glyphs (response from raw bytes, request via @editor)
       @reveal_lines = nil.as(Array(String)?)
       @reveal_lines_src = Pointer(UInt8).null
       @original_lines = [] of String
@@ -64,6 +65,7 @@ module Gori::Tui
       @focus = :request
       @resp_mode = :response # :response | :diff
       @scroll = 0
+      @xscroll = 0 # horizontal scroll offset shared by response/diff/reveal/transcript
       @loaded = false
       @http2 = false
       # WebSocket replay mode (a 101 flow): the request editor holds the editable
@@ -93,8 +95,9 @@ module Gori::Tui
       @decode_kind = nil.as(Symbol?) # nil | :saml | :graphql
       @decoded = TextArea.new        # the payload editor (lower split)
       @decoded.gutter = true
-      @req_pane = :envelope  # :envelope | :decoded — which split sub-pane is active
-      @decoded_dirty = false # the decoded payload was edited → re-encode on send
+      @decoded.follow_x = true # long decoded payload lines (SAML XML, GraphQL query) scroll horizontally
+      @req_pane = :envelope    # :envelope | :decoded — which split sub-pane is active
+      @decoded_dirty = false   # the decoded payload was edited → re-encode on send
       @saml_param = "SAMLResponse"
       @saml_binding = :post       # :post (base64) | :redirect (deflate+base64)
       @saml_location = :body      # :body (form) | :query (request line)
@@ -258,6 +261,7 @@ module Gori::Tui
       @focus = :request
       @resp_mode = :response
       @scroll = 0
+      @xscroll = 0
       @diffable = true
       @loaded = true
       @dirty = false
@@ -291,6 +295,7 @@ module Gori::Tui
       @focus = :request
       @resp_mode = :response
       @scroll = 0
+      @xscroll = 0
       @diffable = false
       @loaded = true
       @dirty = false
@@ -317,6 +322,7 @@ module Gori::Tui
       @ws_result = result
       @ws_lines_cache = nil
       @scroll = 0
+      @xscroll = 0
     end
 
     getter? grpc_mode : Bool
@@ -347,6 +353,7 @@ module Gori::Tui
       @focus = :request
       @resp_mode = :response
       @scroll = 0
+      @xscroll = 0
       @diffable = false
       @loaded = true
       @dirty = false
@@ -403,6 +410,7 @@ module Gori::Tui
       @focus = :request
       @resp_mode = :response
       @scroll = 0
+      @xscroll = 0
       @diffable = false
       @loaded = true
       @dirty = false
@@ -601,6 +609,7 @@ module Gori::Tui
       @focus = :target
       @resp_mode = :response
       @scroll = 0
+      @xscroll = 0
       @diffable = false
       @auto_content_length = auto_cl
       @loaded = true
@@ -642,6 +651,7 @@ module Gori::Tui
       @focus = :target
       @resp_mode = :response
       @scroll = 0
+      @xscroll = 0
       @diffable = false
       @loaded = true
       @dirty = false
@@ -865,6 +875,7 @@ module Gori::Tui
       # left untouched, keeping the user where they were.
       @resp_mode = :response unless @resp_mode == :diff && result.ok? && diff_baseline_lines
       @scroll = 0
+      @xscroll = 0
     end
 
     # --- request editor (focus == :request) ---
@@ -954,6 +965,7 @@ module Gori::Tui
       @editor.reveal = on
       @decoded.reveal = on # the decode split's payload editor honours reveal too
       @scroll = 0          # reveal renders the response from RAW bytes → a different line count; reset like pretty=/x/d
+      @xscroll = 0
     end
 
     # Pretty toggle feeds `resp_view`, so a change drops only the response-view cache
@@ -964,6 +976,7 @@ module Gori::Tui
       @pretty = on
       @resp_view_cache = nil
       @scroll = 0 # reflow changes the line count → a stale offset could blank the pane (like x/d toggles)
+      @xscroll = 0
     end
 
     # ^F highlight, scoped to the searched pane (the Runner picks which).
@@ -1068,12 +1081,14 @@ module Gori::Tui
     def toggle_resp_mode : Nil
       @resp_mode = @resp_mode == :response ? :diff : :response
       @scroll = 0
+      @xscroll = 0
     end
 
     # 'x' toggles a raw hex dump of the response bytes (overrides response/diff).
     def toggle_resp_hex : Nil
       @resp_hex = !@resp_hex
       @scroll = 0 # row-based offset differs from the line-based one
+      @xscroll = 0
     end
 
     getter? resp_hex : Bool
@@ -1096,6 +1111,13 @@ module Gori::Tui
 
     def scroll(delta : Int32) : Nil
       @scroll = (@scroll + delta).clamp(0, {resp_line_count - 1, 0}.max)
+    end
+
+    # Horizontal companion to `scroll` (shift+←/→): nudges the response/diff/reveal/
+    # transcript pane sideways. Floored at 0 here; the render loop clamps the upper
+    # bound to the widest row actually on screen, so it can't scroll past content.
+    def hscroll(delta : Int32) : Nil
+      @xscroll = {@xscroll + delta * 4, 0}.max
     end
 
     # ^G go-to-line in the response pane: scroll so 1-based line `n` is at the top
@@ -1318,13 +1340,16 @@ module Gori::Tui
       end
       gw = {Gutter.width(lines.size), body.w}.min
       cw = {body.w - gw, 0}.max
+      widest = (0...body.h).compact_map { |i| lines[@scroll + i]? }.max_of? { |(t, _)| Screen.display_width(t) } || 0
+      @xscroll = @xscroll.clamp(0, {widest - cw, 0}.max)
       (0...body.h).each do |i|
         li = @scroll + i
         break if li >= lines.size
         text, color = lines[li]
         Gutter.draw(screen, body.x, body.y + i, li, gw)
-        screen.text(body.x + gw, body.y + i, text, color, width: cw)
-        SearchHi.mark(screen, body.x + gw, body.y + i, text, @search_hl, body.x + gw + cw) unless @search_hl.empty?
+        shown = @xscroll > 0 ? Highlight.slice_left_text(text, @xscroll) : text
+        screen.text(body.x + gw, body.y + i, shown, color, width: cw)
+        SearchHi.mark(screen, body.x + gw, body.y + i, shown, @search_hl, body.x + gw + cw) unless @search_hl.empty?
       end
     end
 
@@ -1426,12 +1451,17 @@ module Gori::Tui
       total = lines.size
       gw = {Gutter.width(total), rect.w}.min
       cw = {rect.w - gw, 0}.max
+      widest = (0...rect.h).compact_map { |i| lines[@scroll + i]? }.max_of? { |l| Screen.display_width(l) } || 0
+      @xscroll = @xscroll.clamp(0, {widest - cw, 0}.max)
       (0...rect.h).each do |i|
         li = @scroll + i
         break if li >= total
         Gutter.draw(screen, rect.x, rect.y + i, li, gw)
-        Highlight.draw(screen, rect.x + gw, rect.y + i, Reveal.styled(lines[li], li < total - 1, cw), width: cw)
-        SearchHi.mark(screen, rect.x + gw, rect.y + i, lines[li], @search_hl, rect.x + gw + cw) unless @search_hl.empty?
+        styled = Reveal.styled(lines[li], li < total - 1, cw + @xscroll)
+        styled = Highlight.slice_left(styled, @xscroll) if @xscroll > 0
+        Highlight.draw(screen, rect.x + gw, rect.y + i, styled, width: cw)
+        st = @xscroll > 0 ? Highlight.slice_left_text(lines[li], @xscroll) : lines[li]
+        SearchHi.mark(screen, rect.x + gw, rect.y + i, st, @search_hl, rect.x + gw + cw) unless @search_hl.empty?
       end
     end
 
@@ -1450,12 +1480,18 @@ module Gori::Tui
       total = rv.total
       gw = {Gutter.width(total), rect.w}.min
       cw = {rect.w - gw, 0}.max
-      (0...rect.h).each do |i|
+      # Styles each visible line ONCE (into `rows`), then clamps/slices from that —
+      # never re-styles just to measure width (see the class comment on RespView).
+      rows = (0...rect.h).compact_map { |i| (li = @scroll + i) < total ? rv.line_at(li) : nil }
+      @xscroll = @xscroll.clamp(0, {(rows.max_of? { |l| Highlight.line_width(l) } || 0) - cw, 0}.max)
+      rows.each_with_index do |styled, i|
         li = @scroll + i
-        break if li >= total
         Gutter.draw(screen, rect.x, rect.y + i, li, gw)
-        Highlight.draw(screen, rect.x + gw, rect.y + i, rv.line_at(li), width: cw) # styles only this visible line
-        SearchHi.mark(screen, rect.x + gw, rect.y + i, rv.line_text(li), @search_hl, rect.x + gw + cw) unless @search_hl.empty?
+        shown = @xscroll > 0 ? Highlight.slice_left(styled, @xscroll) : styled
+        Highlight.draw(screen, rect.x + gw, rect.y + i, shown, width: cw)
+        text = rv.line_text(li)
+        st = @xscroll > 0 ? Highlight.slice_left_text(text, @xscroll) : text
+        SearchHi.mark(screen, rect.x + gw, rect.y + i, st, @search_hl, rect.x + gw + cw) unless @search_hl.empty?
       end
     end
 
@@ -1463,20 +1499,28 @@ module Gori::Tui
       data = diff_lines
       gw = {Gutter.width(data.size), rect.w}.min
       cw = {rect.w - gw, 0}.max
-      (0...rect.h).each do |i|
+      rows = (0...rect.h).compact_map do |i|
         di = @scroll + i
-        break if di >= data.size
+        next nil if di >= data.size
         d = data[di]
         prefix, color = case d.kind
                         when .add? then {'+', Theme.green}
                         when .del? then {'-', Theme.red}
                         else            {' ', Theme.muted}
                         end
+        {di, "#{prefix} #{d.text}", color, d.text}
+      end
+      @xscroll = @xscroll.clamp(0, {(rows.max_of? { |(_, full, _, _)| Screen.display_width(full) } || 0) - cw, 0}.max)
+      rows.each_with_index do |(di, full, color, text), i|
         Gutter.draw(screen, rect.x, rect.y + i, di, gw)
-        screen.text(rect.x + gw, rect.y + i, "#{prefix} #{d.text}", color, width: cw)
-        # Highlight only the line text (past the 2-col "+ "/"- " prefix), so the marks
-        # match what response_search_lines counts (d.text), not the diff decoration.
-        SearchHi.mark(screen, rect.x + gw + 2, rect.y + i, d.text, @search_hl, rect.x + gw + cw) unless @search_hl.empty?
+        shown = @xscroll > 0 ? Highlight.slice_left_text(full, @xscroll) : full
+        screen.text(rect.x + gw, rect.y + i, shown, color, width: cw)
+        # Highlight only the line text (past the 2-col "+ "/"- " prefix, shifted left by
+        # any horizontal scroll), so the marks match what response_search_lines counts
+        # (d.text), not the diff decoration.
+        mark_x = rect.x + gw + {2 - @xscroll, 0}.max
+        st = @xscroll > 2 ? Highlight.slice_left_text(text, @xscroll - 2) : text
+        SearchHi.mark(screen, mark_x, rect.y + i, st, @search_hl, rect.x + gw + cw) unless @search_hl.empty?
       end
     end
 

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1967,7 +1967,7 @@ module Gori::Tui
       when :hotkeys       then @hotkeys_overlay.capturing? ? "press a key to bind · esc cancel" : "↑/↓ select · e/␣ rebind · x unbind · r reset · ⇧R reset all · ←/→ profile · ↵ save · esc"
       when :notifications then "↑/↓ select · ↵ open · c clear · esc close"
       when :mine_config   then "↑/↓ field · ←/→ adjust · ␣ toggle · ↵ start · esc cancel"
-      when :detail        then "←/→ panes · ↑/↓ scroll · ^R replay · ⇧F finding · x hex · p pretty · space cmds · ^G goto · ^F find · esc back"
+      when :detail        then "←/→ panes · ↑/↓ scroll · ⇧←/→ h-scroll · ^R replay · ⇧F finding · x hex · p pretty · space cmds · ^G goto · ^F find · esc back"
       else
         # Focus on the tab bar: ←/→ pick the tab, Tab/↵ drop into the body.
         return "←/→ switch tab · ↹/↵ enter · 1-9 jump · ^P cmds · q projects · ^D quit" if @focus == :menu
@@ -2453,6 +2453,10 @@ module Gori::Tui
       findings_controller.finding_edit_notes
     end
 
+    def finding_hscroll(delta : Int32) : Nil
+      findings_controller.finding_hscroll(delta)
+    end
+
     # Re-open the create form seeded from the open finding (title + severity), in
     # edit mode — commit updates instead of inserting (create_finding_from_form).
     # Stays in the shell: it opens the finding-form OVERLAY (shell-owned).
@@ -2701,6 +2705,10 @@ module Gori::Tui
 
     def scroll_detail(delta : Int32) : Nil
       history_controller.scroll_detail(delta)
+    end
+
+    def hscroll_detail(delta : Int32) : Nil
+      history_controller.hscroll_detail(delta)
     end
 
     def toggle_detail_pane : Nil

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -333,20 +333,25 @@ module Gori::Tui
     # Screen.display_width as the base draw, so an ambiguous-width glyph can't drift the
     # tint off the cells). Multi-line regions clamp to [0, line.size): first line tints
     # col→EOL, fully-covered lines 0→size, last line BOL→col; the '\n' offset has no cell.
+    # Region columns are computed against the FULL (unscrolled) line, then shifted left by
+    # @xscroll and clipped to the visible window — a no-op when @xscroll == 0 (the common
+    # case, since only the Fuzzer template sets bg_regions and it doesn't enable follow_x).
     private def paint_bg_regions(screen : Screen, cx0 : Int32, y : Int32, off0 : Int32,
                                  line : String, cw : Int32) : Nil
       return if @bg_regions.empty? || @reveal # opt-in; reveal rewrites the glyphs
       line_end = off0 + line.size
-      max_x = cx0 + cw
       @bg_regions.each do |(a, b, color)|
         next if b <= off0 || a >= line_end # region doesn't touch this line
         la = (a - off0).clamp(0, line.size)
         lb = (b - off0).clamp(0, line.size)
         next if la >= lb
-        col = cx0 + Screen.display_width(line[0, la])
-        next unless col < max_x
-        seg = line[la, lb - la]
-        screen.text(col, y, seg, Theme.marker_fg, color, width: {max_x - col, 0}.max)
+        start_col = Screen.display_width(line[0, la]) - @xscroll
+        end_col = Screen.display_width(line[0, lb]) - @xscroll
+        draw_from = {start_col, 0}.max
+        draw_to = {end_col, cw}.min
+        next if draw_from >= draw_to
+        seg = slice_left(line[la, lb - la], draw_from - start_col)
+        screen.text(cx0 + draw_from, y, seg, Theme.marker_fg, color, width: draw_to - draw_from)
       end
     end
 
@@ -413,26 +418,7 @@ module Gori::Tui
     # cut becomes leading spaces for its still-visible cells, so the remaining glyphs
     # keep their columns. Identity when start_col <= 0.
     private def slice_left(s : String, start_col : Int32) : String
-      return s if start_col <= 0
-      acc = 0
-      cutting = true
-      String.build do |io|
-        s.each_char do |ch|
-          if cutting
-            w = Screen.display_width(ch.to_s)
-            if acc + w <= start_col
-              acc += w
-              next
-            end
-            io << " " * (acc + w - start_col) if acc < start_col # straddling glyph → visible cells as spaces
-            io << ch if acc >= start_col                         # clean boundary keeps the glyph
-            acc += w
-            cutting = false
-          else
-            io << ch
-          end
-        end
-      end
+      Highlight.slice_left_text(s, start_col)
     end
   end
 end

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -42,6 +42,9 @@ module Gori
 
       # detail view
       abstract def scroll_detail(delta : Int32) : Nil
+      # Horizontal companion to scroll_detail (shift+←/→) — scrolls a long
+      # request/response/decoded line sideways instead of right-clipping it.
+      abstract def hscroll_detail(delta : Int32) : Nil
       abstract def toggle_detail_pane : Nil
       # Walk the detail panes (REQ→RES→FRAMES) by `dir` (+1 right, −1 left); left
       # past REQUEST returns to the History list.
@@ -122,6 +125,9 @@ module Gori
       abstract def finding_set_severity : Nil            # open the severity colour picker
       abstract def finding_set_status : Nil              # open the triage-status colour picker
       abstract def finding_edit_notes : Nil
+      # Horizontal scroll (shift+←/→) for the read-only notes preview (no-op while
+      # editing — the notes TextArea's own follow_x handles that case).
+      abstract def finding_hscroll(delta : Int32) : Nil
       abstract def finding_edit_title : Nil               # rename + set severity via the form overlay
       abstract def finding_open_flow : Nil                # open the linked flow's detail in History
       abstract def finding_replay_flow : Nil              # send the linked flow to Replay

--- a/src/gori/verbs/findings.cr
+++ b/src/gori/verbs/findings.cr
@@ -75,6 +75,16 @@ module Gori
         "finding.edit-notes", "Edit notes", "Edit the finding notes inline", Verb::Scope::FindingsDetail,
         [Verb::Chord.new("e"), Verb::Chord.new("enter")]) { |ctx| ctx.finding_edit_notes; nil }
 
+      # Shift+←/→ scroll a long notes line sideways. `finding.close` (registered
+      # above) owns plain ← — a distinct chord (shift: true), so no collision.
+      r.register Verb::Definition.new(
+        "finding.hscroll-right", "Scroll notes right", "Scroll a long notes line right", Verb::Scope::FindingsDetail,
+        [Verb::Chord.new("right", shift: true)], hidden: true) { |ctx| ctx.finding_hscroll(1); nil }
+
+      r.register Verb::Definition.new(
+        "finding.hscroll-left", "Scroll notes left", "Scroll a long notes line left", Verb::Scope::FindingsDetail,
+        [Verb::Chord.new("left", shift: true)], hidden: true) { |ctx| ctx.finding_hscroll(-1); nil }
+
       r.register Verb::Definition.new(
         "finding.delete", "Delete finding", "Delete this finding", Verb::Scope::FindingsDetail,
         [Verb::Chord.new("d")]) { |ctx| ctx.findings_delete; nil }

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -114,6 +114,17 @@ module Gori
         "detail.up", "Scroll detail up", "Scroll the detail view up", Verb::Scope::HistoryDetail,
         [Verb::Chord.new("k"), Verb::Chord.new("up")], hidden: true) { |ctx| ctx.scroll_detail(-1); nil }
 
+      # Shift+←/→ scroll a long line sideways instead of walking panes (plain ←/→,
+      # registered above as detail.next-pane/detail.prev-pane) — distinct chords
+      # (shift: true), so they coexist without collision.
+      r.register Verb::Definition.new(
+        "detail.hscroll-right", "Scroll detail right", "Scroll a long line right", Verb::Scope::HistoryDetail,
+        [Verb::Chord.new("right", shift: true)], hidden: true) { |ctx| ctx.hscroll_detail(1); nil }
+
+      r.register Verb::Definition.new(
+        "detail.hscroll-left", "Scroll detail left", "Scroll a long line left", Verb::Scope::HistoryDetail,
+        [Verb::Chord.new("left", shift: true)], hidden: true) { |ctx| ctx.hscroll_detail(-1); nil }
+
       r.register Verb::Definition.new(
         "detail.toggle-pane", "Switch pane (cycle)", "Cycle REQ → RES → FRAMES",
         Verb::Scope::HistoryDetail, [Verb::Chord.new("tab")], hidden: true) { |ctx| ctx.toggle_detail_pane; nil }


### PR DESCRIPTION
## Summary
- Turn on `TextArea#follow_x` (built earlier for the Project description, off everywhere else) for every hand-typed editor: Replay's ENVELOPE/DECODED split editor, Notes, Intercept's held-message editor, Findings notes, Convert INPUT, Fuzzer template — long lines now scroll sideways to follow the cursor instead of right-clipping.
- Fix a latent bug in `TextArea#paint_bg_regions` (Fuzzer's §-marker background tint) that would have misaligned once that editor could scroll horizontally.
- Extend the same fix to 6 **read-only** panes that previously right-clipped long lines with no way to see the overflow: Replay response/diff/reveal/transcript, History detail, Intercept's held-item preview, Findings notes preview, Convert OUTPUT, Fuzzer result detail — via a new manual `shift+←/→` scroll (`Highlight.slice_left_text`/`line_width` helpers, per-view `@xscroll`-style ivars).
- Update in-pane hints and the Help tab to document the new shortcut.

## Test plan
- [x] `shards build gori`
- [x] `crystal spec` — 1022 examples, 0 failures
- [x] `./bin/ameba` on all touched files — 73/73 findings before/after (no net-new; two dispatch methods that would have crossed the cyclomatic-complexity ceiling were refactored to stay under it)
- [x] New specs added per view exercising the horizontal scroll (clip → scroll → tail visible → head clipped)