### PR TITLE
fix(tui): show Notes sub-tab strip from the first note

### DIFF
--- a/src/gori/tui/controllers/notes_controller.cr
+++ b/src/gori/tui/controllers/notes_controller.cr
@@ -30,9 +30,10 @@ module Gori::Tui
       body_focused = focus == :body
       subtabs_focused = focus == :subtabs
       body_rect = rect
-      # Same chrome as Replay: the sub-tab strip rides above the framed editor (≥2
-      # notes), drawn by the shared BodyChrome — not inside the view.
-      if @notes.count >= 2
+      # Same chrome as Replay: the sub-tab strip rides above the framed editor (from
+      # the first note, so it's always labelled), drawn by the shared BodyChrome —
+      # not inside the view.
+      if subtab_strip_shown?
         sub_rect, body_rect = BodyChrome.carve_subtab_row(rect)
         BodyChrome.render_subtab_strip(screen, sub_rect, @notes.subtab_labels, @notes.current_index, subtabs_focused)
       end
@@ -87,7 +88,7 @@ module Gori::Tui
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
       @host.focus_body
-      body = @notes.count >= 2 ? BodyChrome.carve_subtab_row(rect)[1] : rect
+      body = subtab_strip_shown? ? BodyChrome.carve_subtab_row(rect)[1] : rect
       @notes.click_to_cursor(body.inset(1, 1), mx, my)
       true
     end
@@ -115,6 +116,13 @@ module Gori::Tui
 
     def subtab_index : Int32
       @notes.current_index
+    end
+
+    # Show the strip from the FIRST note (not ≥2), like Replay/Fuzzer: a lone note
+    # still labels its chip and exposes the strip's space-menu. NotesView never goes
+    # empty (always ≥1 note to type into), so this is unconditional.
+    def subtab_strip_shown? : Bool
+      true
     end
 
     def body_badge : Symbol # the body is a single TextArea

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1471,8 +1471,8 @@ module Gori::Tui
     end
 
     # A navigable sub-tab strip is showing — gates entry into :subtabs (and the strip
-    # click/rename paths). Each controller decides its own threshold (Notes/Convert ≥2;
-    # Replay/Fuzzer ≥1 so a single session is still labelled + space-menu reachable).
+    # click/rename paths). Each controller decides its own threshold (Convert ≥2;
+    # Replay/Fuzzer/Notes ≥1 so a single session is still labelled + space-menu reachable).
     private def subtabs_shown? : Bool
       @tabs[@active_tab]?.try(&.subtab_strip_shown?) || false
     end


### PR DESCRIPTION
## Summary
- Notes only showed its sub-tab strip once ≥2 notes were open, so a fresh/first note had no visible tab label at all.
- Mirrors the fix already applied to Replay/Fuzzer: `NotesController` now overrides `subtab_strip_shown?` (always `true`, since `NotesView` is never empty) instead of inlining `@notes.count >= 2` in `render_body`/`handle_click`.
- `move_subtab` intentionally keeps its `>= 2` guard — switching sub-tabs only makes sense with multiple notes, same as Replay/Fuzzer's own `move_subtab`.

## Test plan
- [x] `crystal build` succeeds
- [x] `bin/ameba` on changed files shows no new findings (pre-existing warnings unrelated, confirmed via `git stash` diff)
- [x] Live TUI verification via tmux (isolated `GORI_HOME`): fresh note shows a `1:note 1` chip immediately, strip is focusable at count 1, and toggling 2→1 notes (`^N` then `^W`) keeps the strip visible instead of disappearing