### PR TITLE
feat(tui): highlight active main tab with the gold focus-pill

### DIFF
--- a/spec/tui/foundation_spec.cr
+++ b/spec/tui/foundation_spec.cr
@@ -72,17 +72,19 @@ describe Gori::Tui::Chrome do
     backend.contains?("Sitemap").should be_true
     backend.contains?("(3)").should be_true        # held-message badge on Intercept (the only tab-bar count)
     backend.contains?("Findings(").should be_false # findings/replay/notes carry no count badge
-    # active segment ` Project ` (now first tab) starts at col 2 (rect.x+1 fill, +1 pad); bright accent.
-    backend.fg_at(2, 1).should eq(Theme.accent)
+    # active segment ` Project ` (now first tab) starts at col 2 (rect.x+1 fill, +1 pad); FOCUS_GOLD pill.
+    backend.fg_at(2, 1).should eq(Theme.ink_on(Theme.focus_gold))
+    backend.bg_at(2, 1).should eq(Theme.focus_gold)
     backend.fg_at(12, 1).should eq(Theme.muted) # an inactive label (History) is muted
   end
 
-  it "settles the active segment to bold TEXT (no accent) when the menu is unfocused" do
+  it "settles the active segment to bold TEXT (no gold pill) when the menu is unfocused" do
     backend = MemoryBackend.new(90, 2)
     Chrome.render_menu(Screen.new(backend), Rect.new(0, 1, 90, 1),
       active_tab: :project, focused: false)
     backend.fg_at(2, 1).should eq(Theme.text) # active but body-focused: present, not lit
-    backend.fg_at(2, 1).should_not eq(Theme.accent)
+    backend.bg_at(2, 1).should eq(Theme.selection_dim)
+    backend.bg_at(2, 1).should_not eq(Theme.focus_gold)
   end
 
   it "windows the tab strip so the active tab stays visible when the row is too narrow" do

--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -102,8 +102,9 @@ module Gori::Tui
     end
 
     # A horizontal tab menu (row 1) styled as a segmented control. The active tab
-    # is a solid filled segment with bold bright text (ACCENT when the menu has
-    # focus, so the user sees where keys land); inactive tabs are muted. The
+    # is a solid FOCUS_GOLD pill when the menu holds focus (mirroring the Replay/
+    # Notes sub-tab strip, so "gold = focus is here" reads the same one level up);
+    # at rest it settles to a dim SELECTION_DIM band. Inactive tabs are muted. The
     # held-intercept count rides inline as a `(N)` badge.
     def self.render_menu(screen : Screen, rect : Rect, *, active_tab : Symbol, focused : Bool,
                          tabs : Array({Symbol, String}) = TABS,
@@ -115,10 +116,8 @@ module Gori::Tui
       screen.cell(rect.x, rect.y, '‹', Theme.muted, Theme.panel) if start > 0 # earlier tabs hidden
       segs.each do |(sym, label, seg)|
         if sym == active_tab
-          # focus brightens the active segment (ACCENT) so the user sees the menu
-          # is live; when the body holds focus it stays bold but settles to TEXT.
-          bg = focused ? Theme.accent_bg : Theme.selection_dim
-          fg = focused ? Theme.accent : Theme.text
+          bg = focused ? Theme.focus_gold : Theme.selection_dim
+          fg = focused ? Theme.ink_on(Theme.focus_gold) : Theme.text
           screen.fill(seg, bg)
           screen.text(seg.x + 1, seg.y, label, fg, bg, Attribute::Bold)
         else


### PR DESCRIPTION
## Summary
- The top tab bar's active segment (Project/Sitemap/History/...) used a subtle `accent_bg` band, much less visible than the FOCUS_GOLD pill sub-tab strips already use (Replay/Notes).
- `Chrome.render_menu` now mirrors `Chrome.render_tab_strip`: focused active tab fills `Theme.focus_gold` + `Theme.ink_on(Theme.focus_gold)` text; unfocused stays `Theme.selection_dim` + `Theme.text`.
- Updated the two `foundation_spec.cr` specs asserting on the active main-tab colors.

## Test plan
- [x] `crystal spec` — 1022 examples, 0 failures
- [x] `crystal tool format` / `./bin/ameba src/gori/tui/chrome.cr` clean
- [x] Verified visually via tmux (GORI_HOME-isolated instance): Project tab renders with `#c2a05a` gold background