### PR TITLE
fix(replay,prism): 12 bugs from a live + adversarial-workflow hunt

### DIFF
--- a/spec/prism_spec.cr
+++ b/spec/prism_spec.cr
@@ -117,6 +117,20 @@ describe Gori::Prism::Passive do
       csp.affected.should contain("https://acme.test/b")
     end
   end
+
+  # A plaintext forward-proxy request is captured ABSOLUTE-form (the wire truth), so
+  # FlowRow#target already carries the scheme+authority. The affected URL must be that
+  # target verbatim — NOT "http://hosthttp://host:port/path" (the doubling a naive
+  # "scheme://host + target" produced before FlowRow#url).
+  it "does not double the scheme+host for an absolute-form (plain-HTTP) target" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n",
+        scheme: "http", host: "127.0.0.1", target: "http://127.0.0.1:8899/cors")
+      urls = Gori::Prism::Passive.analyze(detail).map(&.url).uniq!
+      urls.should eq(["http://127.0.0.1:8899/cors"])
+      urls.first.should_not contain("127.0.0.1http://")
+    end
+  end
 end
 
 describe Gori::Prism::Active do
@@ -144,6 +158,19 @@ describe Gori::Prism::Active do
     with_store do |store|
       detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/static/app.js", content_type: nil)
       Gori::Prism::Active.plan(detail).should be_nil
+    end
+  end
+
+  it "sends an ORIGIN-FORM request line even for an absolute-form (forward-proxy) target" do
+    with_store do |store|
+      # A plaintext forward-proxy flow is captured absolute-form; the probe goes DIRECT to
+      # the origin, so its request line must be origin-form (some origins reject absolute-form).
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", scheme: "http", host: "target.com",
+        target: "http://target.com/search?q=hello", content_type: nil)
+      plan = Gori::Prism::Active.plan(detail).not_nil!
+      line = String.new(plan.request).each_line.first
+      line.should start_with("GET /search?q=")
+      line.should_not contain("http://target.com")
     end
   end
 end
@@ -286,6 +313,58 @@ describe "Gori::Prism::Passive (new patterns)" do
                    "Access-Control-Allow-Credentials: true\r\n\r\n",
         req_headers: "Origin: https://acme.test\r\n", content_type: nil)
       codes_of(same_origin).should_not contain("cors_reflected_origin")
+    end
+  end
+
+  it "flags a CROSS-SCHEME/CROSS-PORT same-host credentialed reflection (not just cross-host)" do
+    with_store do |store|
+      # Page is https://acme.test (:443); the reflected Origin is the SAME host but a different
+      # scheme — genuinely a different origin, and exploitable with credentials.
+      cross_scheme = analyze(store, scheme: "https", host: "acme.test",
+        resp_head: "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: http://acme.test\r\n" \
+                   "Access-Control-Allow-Credentials: true\r\n\r\n",
+        req_headers: "Origin: http://acme.test\r\n", content_type: nil)
+      codes_of(cross_scheme).should contain("cors_reflected_origin")
+      cross_port = analyze(store, scheme: "https", host: "acme.test",
+        resp_head: "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: https://acme.test:8443\r\n" \
+                   "Access-Control-Allow-Credentials: true\r\n\r\n",
+        req_headers: "Origin: https://acme.test:8443\r\n", content_type: nil)
+      codes_of(cross_port).should contain("cors_reflected_origin")
+    end
+  end
+
+  it "flags a CSP that restricts nothing about scripts (no script-src and no default-src)" do
+    with_store do |store|
+      # A CSP present but with neither script-src nor default-src leaves scripts fully
+      # unrestricted, yet its mere presence suppresses missing_csp — it must trip weak_csp.
+      dets = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Security-Policy: img-src 'self'\r\n\r\n",
+        content_type: "text/html")
+      codes_of(dets).should contain("weak_csp")
+      codes_of(dets).should_not contain("missing_csp")
+      # A restrictive default-src is NOT weak.
+      ok = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Security-Policy: default-src 'self'\r\n\r\n",
+        content_type: "text/html")
+      codes_of(ok).should_not contain("weak_csp")
+    end
+  end
+
+  it "does not flag ordinary docs/tutorial prose that merely NAMES error types" do
+    with_store do |store|
+      {
+        %({"path":"config/routes.rb:15"}),           # a config path value, not a Ruby backtrace frame
+        "See the ActiveRecord::Base guide.",         # a class name in prose, not a Rails error
+        "Import org.springframework.boot to start.", # a package name, not a Spring trace frame
+        "Throws System.ArgumentException on null.",  # a .NET type named in prose
+        "Handle java.lang.IllegalStateException gracefully.",
+      }.each do |prose|
+        dets = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", content_type: "text/html", body: prose)
+        codes_of(dets).should_not contain("error_stack_leak")
+      end
+      # …but a genuinely error-shaped disclosure still fires.
+      real = analyze(store, resp_head: "HTTP/1.1 500 Server Error\r\n\r\n", status: 500,
+        content_type: "text/html",
+        body: "java.lang.IllegalStateException: bad state\n\tat com.acme.Svc.handle(Svc.java:42)")
+      codes_of(real).should contain("error_stack_leak")
     end
   end
 

--- a/spec/prism_spec.cr
+++ b/spec/prism_spec.cr
@@ -133,6 +133,19 @@ describe Gori::Prism::Passive do
   end
 end
 
+describe Gori::Store::FlowRow do
+  it "#url builds an absolute URL: absolute-form verbatim, non-default port kept, IPv6 bracketed" do
+    mk = ->(scheme : String, host : String, port : Int32, target : String) do
+      Gori::Store::FlowRow.new(1_i64, 0_i64, scheme, "GET", host, port, target, 200,
+        0_i64, Gori::Store::FlowState::Complete)
+    end
+    mk.call("https", "ex.com", 443, "/a").url.should eq("https://ex.com/a")       # default port omitted
+    mk.call("https", "ex.com", 8443, "/a").url.should eq("https://ex.com:8443/a") # non-default port kept
+    mk.call("http", "::1", 8080, "/a").url.should eq("http://[::1]:8080/a")       # IPv6 literal bracketed
+    mk.call("http", "h", 80, "http://h:8899/x").url.should eq("http://h:8899/x")  # absolute-form verbatim
+  end
+end
+
 describe Gori::Prism::Active do
   it "builds a canary probe from existing query params and detects reflection" do
     with_store do |store|
@@ -330,6 +343,12 @@ describe "Gori::Prism::Passive (new patterns)" do
                    "Access-Control-Allow-Credentials: true\r\n\r\n",
         req_headers: "Origin: https://acme.test:8443\r\n", content_type: nil)
       codes_of(cross_port).should contain("cors_reflected_origin")
+      # A bracketed IPv6 literal echoing its OWN origin is same-origin — not a false positive.
+      ipv6_same = analyze(store, scheme: "https", host: "::1",
+        resp_head: "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: https://[::1]\r\n" \
+                   "Access-Control-Allow-Credentials: true\r\n\r\n",
+        req_headers: "Origin: https://[::1]\r\n", content_type: nil)
+      codes_of(ipv6_same).should_not contain("cors_reflected_origin")
     end
   end
 
@@ -360,11 +379,19 @@ describe "Gori::Prism::Passive (new patterns)" do
         dets = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", content_type: "text/html", body: prose)
         codes_of(dets).should_not contain("error_stack_leak")
       end
-      # …but a genuinely error-shaped disclosure still fires.
-      real = analyze(store, resp_head: "HTTP/1.1 500 Server Error\r\n\r\n", status: 500,
-        content_type: "text/html",
-        body: "java.lang.IllegalStateException: bad state\n\tat com.acme.Svc.handle(Svc.java:42)")
-      codes_of(real).should contain("error_stack_leak")
+      # …but genuinely error-shaped disclosures still fire (incl. real Python/PHP frames and
+      # an error-shaped ActiveRecord class the tightened patterns must still catch).
+      {
+        "java.lang.IllegalStateException: bad state\n\tat com.acme.Svc.handle(Svc.java:42)",
+        "File \"/srv/app.py\", line 42, in handler",      # real CPython frame
+        "#0 /var/www/app.php(42): Foo->bar()\n#1 {main}", # real PHP trace frame
+        "ActiveRecord::RecordNotFound: Couldn't find User",
+        "ActiveRecord::Rollback: transaction rolled back", # AR class the whitelist used to miss
+      }.each do |leak|
+        dets = analyze(store, resp_head: "HTTP/1.1 500 Server Error\r\n\r\n", status: 500,
+          content_type: "text/html", body: leak)
+        codes_of(dets).should contain("error_stack_leak")
+      end
     end
   end
 

--- a/spec/protocol_decode_spec.cr
+++ b/spec/protocol_decode_spec.cr
@@ -216,6 +216,41 @@ describe Gori::Graphql do
       q.should eq("{ ping }")
       v.should be_nil
     end
+
+    it "does not mistake an in-query '# variables' comment for the variables sentinel" do
+      # '# variables' is a valid GraphQL comment; with GraphQL (not JSON) after it, it must
+      # stay part of the query — not truncate the query and misroute the tail into variables.
+      text = "query {\n  # variables\n  user { id }\n}"
+      o, q, v = Gori::Graphql.parse_display(text)
+      o.should be_nil
+      v.should be_nil
+      q.should eq(text)
+    end
+
+    it "still splits a genuine '# variables' JSON block that follows a query comment" do
+      text = "query {\n  # variables\n  user { id }\n}\n\n# variables\n{\"a\":1}"
+      _, q, v = Gori::Graphql.parse_display(text)
+      q.should eq("query {\n  # variables\n  user { id }\n}")
+      v.should eq(%({"a":1}))
+    end
+  end
+
+  describe ".recompose_query" do
+    it "re-encodes an edited op into a GET query string, preserving unrelated params" do
+      q = Gori::Graphql.recompose_query("query=query%20Old%7Bx%7D&lang=en", "query New { y }")
+      params = URI::Params.parse(q)
+      params["query"].should eq("query New { y }")
+      params["lang"].should eq("en")
+    end
+
+    it "includes operationName and minified variables" do
+      q = Gori::Graphql.recompose_query("query=old",
+        "# operationName: Me\n\nquery Me { z }\n\n# variables\n{\n  \"a\": 1\n}")
+      params = URI::Params.parse(q)
+      params["operationName"].should eq("Me")
+      params["query"].should eq("query Me { z }")
+      JSON.parse(params["variables"]).should eq(JSON.parse(%({"a":1})))
+    end
   end
 
   describe ".recompose" do

--- a/spec/replay/h2_engine_spec.cr
+++ b/spec/replay/h2_engine_spec.cr
@@ -126,6 +126,33 @@ private def start_h2_origin_flow_controlled(status : Int32, body : Bytes) : Int3
   port
 end
 
+# An origin that interleaves PING frames (no END_STREAM) before the real response — the
+# non-terminal-frame path the MAX_FRAMES counter now guards. A handful must be ACKed and
+# must NOT stall or corrupt the response.
+private def start_h2_origin_pings(status : Int32, body : String, pings : Int32) : Int32
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    next unless conn = origin.accept?
+    conn.read_timeout = 5.seconds
+    Frame.read_preface(conn)
+    loop do
+      f = Frame.read(conn)
+      break if f.nil?
+      break if f.frame_type.in?(Frame::Type::Headers, Frame::Type::Data) && f.end_stream?
+    end
+    conn.write(Frame::Header.new(Frame::Type::Settings.value, 0_u8, 0_u32, Bytes.empty).to_bytes)
+    pings.times { conn.write(Frame::Header.new(Frame::Type::Ping.value, 0_u8, 0_u32, Bytes.new(8)).to_bytes) }
+    sb = HPACK::Encoder.new.encode([{":status", status.to_s}])
+    conn.write(Frame::Header.new(Frame::Type::Headers.value, Frame::END_HEADERS, 1_u32, sb).to_bytes)
+    conn.write(Frame::Header.new(Frame::Type::Data.value, Frame::END_STREAM, 1_u32, body.to_slice).to_bytes)
+    conn.flush
+    sleep 0.2.seconds
+    conn.close
+  end
+  port
+end
+
 describe Gori::Replay::H2Engine do
   it "replays a GET as real cleartext h2 and reassembles the response" do
     seen = Channel(String).new(1)
@@ -165,6 +192,15 @@ describe Gori::Replay::H2Engine do
     seen.receive.should eq("POST /submit body=hello-h2-body")
     result.response.not_nil!.status.should eq(201)
     String.new(result.body.not_nil!).should eq("created")
+  end
+
+  it "handles interleaved PING frames before the response without stalling" do
+    port = start_h2_origin_pings(200, "pong-ok", 20)
+    result = Gori::Replay::H2Engine.send("GET / HTTP/2\r\n\r\n".to_slice,
+      scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
+    result.ok?.should be_true
+    result.response.not_nil!.status.should eq(200)
+    String.new(result.body.not_nil!).should eq("pong-ok")
   end
 
   it "reports an error when the origin is unreachable" do

--- a/spec/tui/replay_decode_spec.cr
+++ b/spec/tui/replay_decode_spec.cr
@@ -68,6 +68,23 @@ describe "ReplayView split-decode (SAML/GraphQL)" do
       JSON.parse(body)["query"].as_s.should contain("ONSEND")
     end
 
+    it "rewrites the URL query (not a phantom body) when the GraphQL op is GET-bound" do
+      get_target = "/graphql?query=#{URI.encode_www_form("query Q { a }")}"
+      get_head = "GET #{get_target} HTTP/1.1\r\nHost: api.test\r\n\r\n"
+      detail = detail_of(get_target, get_head, "")
+      op = Gori::Graphql.from_flow(get_target, get_head.to_slice, nil).not_nil!
+      view = ReplayView.new
+      view.load_graphql(detail, op)
+
+      view.toggle_req_pane.should eq(:decoded)
+      move_to_line_end(view)
+      " EDITED".each_char { |c| view.edit_insert(c) }
+      raw = String.new(view.request_bytes) # commits on send
+      raw.should_not contain(%("query":))  # the edit must NOT be spliced into a phantom JSON body
+      qs = raw.each_line.first.split(' ')[1].split('?', 2)[1]
+      URI::Params.parse(qs)["query"].should contain("EDITED") # it reached the URL query
+    end
+
     it "reflects an envelope-side query edit into DECODED, then merges a decoded edit (bidirectional)" do
       view = load_gql(gql_head, gql_body)
       # Edit the ENVELOPE directly: a new body whose query mentions ENVEDIT.

--- a/src/gori/graphql.cr
+++ b/src/gori/graphql.cr
@@ -90,7 +90,7 @@ module Gori
       lines.each_with_index do |l, i|
         next unless l.strip == "# variables"
         trailing = lines[(i + 1)..].join('\n').strip
-        vi = i unless trailing.empty? || !json?(trailing)
+        vi = i if !trailing.empty? && json?(trailing)
       end
       vars = vi ? lines[(vi + 1)..].join('\n').strip : nil
       body = vi ? lines[0...vi] : lines
@@ -139,8 +139,9 @@ module Gori
     end
 
     # Where a flow carries its op: :body (a POST JSON body that parses as GraphQL) or
-    # :query (a GET `?query=…`). Drives which side the Replay re-encode targets.
-    def location(target : String, req_body : Bytes?) : Symbol
+    # :query (a GET `?query=…`). Drives which side the Replay re-encode targets. Decided
+    # solely by whether the request body is a GraphQL JSON document.
+    def location(req_body : Bytes?) : Symbol
       if (b = req_body) && !b.empty? && b.size <= MAX_BODY && from_json(String.new(b))
         :body
       else

--- a/src/gori/graphql.cr
+++ b/src/gori/graphql.cr
@@ -76,12 +76,22 @@ module Gori
     end
 
     # Parse the editable DECODED-pane text back into {operationName?, query, variables?}.
-    # The variables block is whatever follows the LAST `# variables` line; an optional
-    # leading `# operationName:` header is lifted off; the rest is the query.
+    # The variables block is whatever follows the LAST *genuine* `# variables` line; an
+    # optional leading `# operationName:` header is lifted off; the rest is the query.
+    #
+    # `# variables` is ALSO a valid GraphQL source comment, so a comment line inside the
+    # query could masquerade as the sentinel and truncate the query. Disambiguate on the
+    # trailing block: the real sentinel is always followed by the variables JSON, whereas a
+    # query comment is followed by more GraphQL — so only accept a `# variables` whose
+    # remainder parses as JSON. This keeps an in-query `# variables` comment in the query.
     def parse_display(text : String) : {String?, String, String?}
       lines = text.split('\n')
       vi = nil.as(Int32?)
-      lines.each_with_index { |l, i| vi = i if l.strip == "# variables" }
+      lines.each_with_index do |l, i|
+        next unless l.strip == "# variables"
+        trailing = lines[(i + 1)..].join('\n').strip
+        vi = i unless trailing.empty? || !json?(trailing)
+      end
       vars = vi ? lines[(vi + 1)..].join('\n').strip : nil
       body = vi ? lines[0...vi] : lines
       op = nil.as(String?)
@@ -110,6 +120,39 @@ module Gori
       end
       base.try &.each { |k, v| obj[k] = v unless obj.has_key?(k) } # keep extensions etc.
       obj.to_json
+    end
+
+    # Re-encode the edited DECODED pane back into a GET request's query string, overlaying
+    # query/operationName/variables onto the ORIGINAL params (any other params survive).
+    # Variables are minified. The GET-binding sibling of recompose (which targets the body).
+    def recompose_query(orig_query : String, decoded_text : String) : String
+      op, query, vars_text = parse_display(decoded_text)
+      managed = {"query", "operationName", "variables"}
+      parts = orig_query.split('&').reject { |pair| pair.empty? || managed.includes?(pair.partition('=')[0]) }
+      parts << "query=#{URI.encode_www_form(query)}"
+      parts << "operationName=#{URI.encode_www_form(op)}" if op
+      if vars_text
+        mini = (JSON.parse(vars_text).to_json rescue vars_text)
+        parts << "variables=#{URI.encode_www_form(mini)}"
+      end
+      parts.join('&')
+    end
+
+    # Where a flow carries its op: :body (a POST JSON body that parses as GraphQL) or
+    # :query (a GET `?query=…`). Drives which side the Replay re-encode targets.
+    def location(target : String, req_body : Bytes?) : Symbol
+      if (b = req_body) && !b.empty? && b.size <= MAX_BODY && from_json(String.new(b))
+        :body
+      else
+        :query
+      end
+    end
+
+    private def json?(s : String) : Bool
+      JSON.parse(s)
+      true
+    rescue
+      false
     end
 
     private def strip(s : String) : String

--- a/src/gori/prism/active/reflected_param.cr
+++ b/src/gori/prism/active/reflected_param.cr
@@ -21,7 +21,11 @@ module Gori
           req = Proxy::Codec::Http1.parse_request_head(detail.request_head)
           return nil if req.malformed?
           return nil unless SAFE_METHODS.includes?(req.method.upcase)
-          path, query = split_target(req.target)
+          # A plaintext forward-proxy flow is captured ABSOLUTE-form ("GET http://h/p"); the
+          # probe is sent DIRECT to the origin (Fuzz::Sender → Replay::Engine, no rewrite),
+          # so normalize to origin-form here the way the regular replay path (FlowRequest)
+          # does — some origins reject an absolute-form target on a non-proxied request.
+          path, query = split_target(origin_form(req.target))
 
           params = [] of Param
           new_query, qp = canary_pairs(query, "query")
@@ -59,7 +63,7 @@ module Gori
           return [] of Detection if reflected.empty?
           names = reflected.map { |p| "#{p.name} (#{p.location})" }
           names.uniq!
-          url = "#{detail.row.scheme}://#{detail.row.host}#{detail.row.target}"
+          url = detail.row.url
           # An echo in an HTML response is a plausible XSS sink (Medium); an echo in a non-HTML
           # response (JSON/text API) is just a reflected value, not exploitable as XSS (Low).
           html = response_content_type(result).includes?("html")
@@ -89,6 +93,15 @@ module Gori
           (Proxy::Codec::Http1.parse_response_head(result.head).headers.get?("Content-Type") || "").downcase
         rescue
           ""
+        end
+
+        # Strip a scheme://authority prefix so an absolute-form (forward-proxy) target becomes
+        # origin-form; an already-origin-form target passes through unchanged.
+        private def origin_form(target : String) : String
+          return target unless target.starts_with?("http://") || target.starts_with?("https://")
+          scheme_end = target.index("://") || return target
+          slash = target.index('/', scheme_end + 3)
+          slash ? target[slash..] : "/"
         end
 
         # {path, query-without-'?'} — query is "" when the target has none.

--- a/src/gori/prism/analyzer.cr
+++ b/src/gori/prism/analyzer.cr
@@ -106,7 +106,7 @@ module Gori
         return if @stopped
         return unless @mode.active?
         row = detail.row
-        url = "#{row.scheme}://#{row.host}#{row.target}"
+        url = row.url
         # Active probes ONLY configured+enabled in-scope hosts (in_scope_url? is permissive
         # when scope is inactive, so gate on active? first) — the user's "in-scope only" rule.
         return unless @scope.active? && @scope.in_scope_url?(url, row.host)

--- a/src/gori/prism/passive/body_leaks.cr
+++ b/src/gori/prism/passive/body_leaks.cr
@@ -13,19 +13,27 @@ module Gori
         PRIVATE_IP = /(?<![\w.])(?:10(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}|172\.(?:1[6-9]|2\d|3[01])(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){2}|192\.168(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){2}|127\.0\.0\.1)(?![\w.])/
 
         # Server-side error / stack-trace signatures, each tightened to a specific frame or
-        # exception shape so generic prose (a bare ".rb:" or "at System." in docs / a source
-        # viewer) does not match. {pattern, evidence label}.
+        # exception shape so a mere SYMBOL MENTION in documentation / tutorials / package
+        # registries (e.g. "config/routes.rb:15", "ActiveRecord::Base", "org.springframework
+        # .boot", "System.ArgumentException") does NOT match — only an actual backtrace frame
+        # or a `Type: message` / newline-`at` disclosure does. {pattern, evidence label}.
         ERROR_SIGNATURES = [
           {/Traceback \(most recent call last\)/, "Python traceback"},
-          {/\.(?:rb|py|php):\d+(?::in )?/, "source file:line frame"},
+          # Ruby backtrace frame: the `:in ` distinguishes a real frame from a config path.
+          {/\.rb:\d+:in /, "Ruby backtrace frame"},
           {/\bat [\w.$]+\([\w]+\.java:\d+\)/, "Java stack frame"},
           {/(?:\n|\A)\s+at [\w.$<>]+ \([^)]*:\d+:\d+\)/, "Node.js stack frame"},
           {/\bORA-\d{5}\b/, "Oracle error"},
           {/\bSQLSTATE\[/, "SQL error"},
-          {/\bjava\.lang\.[A-Z]\w+(?:Error|Exception)\b/, "Java exception"},
-          {/\borg\.springframework\.[\w.]{4,}/, "Spring framework trace"},
-          {/\bSystem\.[A-Z]\w+Exception\b/, ".NET exception"},
-          {/\b(?:NoMethodError|NameError|ActiveRecord::)\b/, "Ruby/Rails error"},
+          # A Java/.NET exception only counts as a disclosure when error-shaped: followed by a
+          # `: message` or a newline-`at` frame — not when merely named in prose.
+          {/\bjava\.lang\.[A-Z]\w+(?:Error|Exception)(?::|\r?\n\s*at )/, "Java exception"},
+          {/\bat org\.springframework\.[\w.]{4,}/, "Spring framework trace"},
+          {/\bSystem\.[A-Z]\w+Exception(?::|\r?\n\s*at )/, ".NET exception"},
+          # Rails: an actual error class (not the ubiquitous ActiveRecord::Base/Migration).
+          {/\bActiveRecord::[A-Z]\w*(?:Error|NotFound|Invalid|NotSaved|NotUnique)\b/, "Rails error"},
+          {/\b(?:NoMethodError|NameError|NoMatchingPatternError)(?::| \()/, "Ruby error"},
+          {/PHP (?:Fatal error|Parse error|Warning|Notice):/, "PHP error"},
           {/(?:\n|\A)Stack trace:\s*(?:\n|#\d)/, "stack trace"},
         ]
 

--- a/src/gori/prism/passive/body_leaks.cr
+++ b/src/gori/prism/passive/body_leaks.cr
@@ -19,6 +19,9 @@ module Gori
         # or a `Type: message` / newline-`at` disclosure does. {pattern, evidence label}.
         ERROR_SIGNATURES = [
           {/Traceback \(most recent call last\)/, "Python traceback"},
+          # A real CPython frame (`File "x.py", line N`) — the exact shape, so a bare
+          # "app.py:42" path reference (the old colon form's false positive) stays out.
+          {/File "[^"]*\.py", line \d+/, "Python stack frame"},
           # Ruby backtrace frame: the `:in ` distinguishes a real frame from a config path.
           {/\.rb:\d+:in /, "Ruby backtrace frame"},
           {/\bat [\w.$]+\([\w]+\.java:\d+\)/, "Java stack frame"},
@@ -30,10 +33,15 @@ module Gori
           {/\bjava\.lang\.[A-Z]\w+(?:Error|Exception)(?::|\r?\n\s*at )/, "Java exception"},
           {/\bat org\.springframework\.[\w.]{4,}/, "Spring framework trace"},
           {/\bSystem\.[A-Z]\w+Exception(?::|\r?\n\s*at )/, ".NET exception"},
-          # Rails: an actual error class (not the ubiquitous ActiveRecord::Base/Migration).
-          {/\bActiveRecord::[A-Z]\w*(?:Error|NotFound|Invalid|NotSaved|NotUnique)\b/, "Rails error"},
+          # Rails: any ActiveRecord class, but only when error-shaped (`: message` / newline-
+          # `at`), so a real error (RecordNotFound, Rollback, StatementInvalid, …) is caught
+          # while the ubiquitous doc mention "ActiveRecord::Base guide" is not.
+          {/\bActiveRecord::[A-Z]\w+(?::|\r?\n\s*at )/, "Rails error"},
           {/\b(?:NoMethodError|NameError|NoMatchingPatternError)(?::| \()/, "Ruby error"},
           {/PHP (?:Fatal error|Parse error|Warning|Notice):/, "PHP error"},
+          # A real PHP stack/trace frame ("… /var/www/app.php(42): …") — the paren+line form
+          # a path reference lacks; keeps the FP-prone bare "app.php:42" colon form out.
+          {/\.php\(\d+\)/, "PHP stack frame"},
           {/(?:\n|\A)Stack trace:\s*(?:\n|#\d)/, "stack trace"},
         ]
 

--- a/src/gori/prism/passive/context.cr
+++ b/src/gori/prism/passive/context.cr
@@ -22,8 +22,7 @@ module Gori
         def initialize(@detail : Store::FlowDetail)
           @req = Proxy::Codec::Http1.parse_request_head(@detail.request_head)
           @resp = @detail.response_head.try { |h| Proxy::Codec::Http1.parse_response_head(h) }
-          r = @detail.row
-          @url = "#{r.scheme}://#{r.host}#{r.target}"
+          @url = @detail.row.url
         end
 
         def row : Store::FlowRow

--- a/src/gori/prism/passive/cors.cr
+++ b/src/gori/prism/passive/cors.cr
@@ -19,19 +19,26 @@ module Gori
             sev = creds ? Store::Severity::High : Store::Severity::Medium
             acc << cors(ctx, "cors_null_origin", "CORS allows the null origin",
               sev, creds ? "with credentials" : nil)
-          elsif creds && (origin = ctx.request_origin) && (oh = origin_host(origin)) &&
-                oh != ctx.host.downcase && acao == origin.strip
+          elsif creds && (origin = ctx.request_origin) && cross_origin?(origin, ctx) &&
+                acao == origin.strip
             # The server echoes a CROSS-ORIGIN request Origin AND allows credentials — the classic
             # exploitable reflected-origin CORS misconfiguration. A same-origin echo (the page's
-            # own host) is legitimate and suppressed to avoid the common false positive.
+            # own scheme+host+port) is legitimate and suppressed to avoid the common false positive.
             acc << cors(ctx, "cors_reflected_origin",
               "CORS reflects a cross-origin request Origin with credentials",
               Store::Severity::High, origin.strip[0, 80])
           end
         end
 
-        private def origin_host(origin : String) : String?
-          origin.strip.match(%r{\Ahttps?://([^/:]+)}).try(&.[1].downcase)
+        # The request Origin is a DIFFERENT origin (scheme, host, OR port) from the page.
+        # CORS same-origin requires all three equal; comparing host alone (the old check)
+        # missed a credentialed reflection of a cross-SCHEME (http↔https) or cross-PORT
+        # same-host origin, which is genuinely exploitable. Unparseable → treat as cross.
+        private def cross_origin?(origin : String, ctx : Context) : Bool
+          m = origin.strip.downcase.match(%r{\A(https?)://([^/:]+)(?::(\d+))?\z}) || return true
+          scheme, host = m[1], m[2]
+          port = m[3]?.try(&.to_i?) || (scheme == "https" ? 443 : 80)
+          !(scheme == ctx.scheme.downcase && host == ctx.host.downcase && port == ctx.row.port)
         end
 
         private def cors(ctx : Context, code : String, title : String, sev : Store::Severity, evidence : String?) : Detection

--- a/src/gori/prism/passive/cors.cr
+++ b/src/gori/prism/passive/cors.cr
@@ -33,10 +33,13 @@ module Gori
         # The request Origin is a DIFFERENT origin (scheme, host, OR port) from the page.
         # CORS same-origin requires all three equal; comparing host alone (the old check)
         # missed a credentialed reflection of a cross-SCHEME (http↔https) or cross-PORT
-        # same-host origin, which is genuinely exploitable. Unparseable → treat as cross.
+        # same-host origin, which is genuinely exploitable. Unparsable → treat as cross.
         private def cross_origin?(origin : String, ctx : Context) : Bool
-          m = origin.strip.downcase.match(%r{\A(https?)://([^/:]+)(?::(\d+))?\z}) || return true
-          scheme, host = m[1], m[2]
+          # Host is a bracketed IPv6 literal ([::1]) OR a normal reg-name/IPv4; either with an
+          # optional port. Strip the IPv6 brackets to compare against the bare stored host.
+          m = origin.strip.downcase.match(%r{\A(https?)://(\[[^\]]+\]|[^/:]+)(?::(\d+))?\z}) || return true
+          scheme = m[1]
+          host = m[2].lchop('[').rchop(']')
           port = m[3]?.try(&.to_i?) || (scheme == "https" ? 443 : 80)
           !(scheme == ctx.scheme.downcase && host == ctx.host.downcase && port == ctx.row.port)
         end

--- a/src/gori/prism/passive/security_headers.cr
+++ b/src/gori/prism/passive/security_headers.cr
@@ -61,12 +61,16 @@ module Gori
           dirs
         end
 
-        # Weak only when the SCRIPT context (script-src, else the default-src fallback) allows
-        # unsafe-inline / unsafe-eval or a bare wildcard. `unsafe-inline` confined to style-src
-        # is a common, low-risk pattern and no longer trips this.
+        # Weak when the SCRIPT context (script-src, else the default-src fallback) allows
+        # unsafe-inline / unsafe-eval or a bare wildcard — OR when it is ABSENT entirely: a
+        # CSP with neither script-src nor default-src places ZERO restriction on script
+        # loading/execution (the CSP spec's no-fallback case), which is as XSS-permissive as
+        # having no CSP at all, yet the header's mere presence suppresses the missing_csp
+        # check — so it must be caught here. (`unsafe-inline` confined to style-src is a
+        # common, low-risk pattern and still does NOT trip this.)
         private def weak_csp?(dirs : Hash(String, Array(String))) : Bool
           script = dirs["script-src"]? || dirs["default-src"]?
-          return false unless script
+          return true if script.nil?
           script.any? { |s| s.includes?("unsafe-inline") || s.includes?("unsafe-eval") || s == "*" }
         end
 

--- a/src/gori/replay/h2_engine.cr
+++ b/src/gori/replay/h2_engine.cr
@@ -25,6 +25,12 @@ module Gori
       # unboundedly, and a streaming/over-large body has no aggregate ceiling.
       MAX_HEADER_BLOCK = 1 << 20         # 1 MiB
       MAX_BODY         = 8 * 1024 * 1024 # 8 MiB (matches Codec::Body::CAPTURE_MAX)
+      # Hard ceiling on frames processed for one response. HEADERS/DATA are byte-capped
+      # above, but non-terminal frames (PING/PRIORITY/WINDOW_UPDATE/SETTINGS on any stream)
+      # are neither — a hostile origin can stream them forever without END_STREAM, and the
+      # per-op io_timeout only fires on IDLE, so bytes-always-arriving pins the fiber. This
+      # bounds the loop the way the h1 engine's MAX_INTERIM does (RFC-hostile-origin guard).
+      MAX_FRAMES = 100_000
 
       private alias Frame = Proxy::H2::Frame
       private alias HPACK = Proxy::H2::HPACK
@@ -114,6 +120,7 @@ module Gori
         done = false
         clean_eos = false          # a genuine END_STREAM closed the stream
         end_stream_pending = false # END_STREAM seen on a HEADERS frame whose block isn't closed yet
+        frames = 0                 # every frame counted (incl. ping/priority) — bounds a junk-frame flood
 
         until done
           # An IO error mid-response (connection reset — e.g. an origin that closed
@@ -129,6 +136,12 @@ module Gori
             nil
           end
           break if frame.nil?
+          # Count EVERY frame, not just data/headers: an origin flooding PING/PRIORITY/
+          # WINDOW_UPDATE without ever sending END_STREAM trips no byte cap and no idle
+          # timeout, so this ceiling is what guarantees the loop terminates. On trip the
+          # stream is left un-closed → the response is flagged incomplete.
+          frames += 1
+          break if frames > MAX_FRAMES
           case frame.frame_type
           when Frame::Type::Settings
             ack(io, Frame::Type::Settings, Bytes.empty) unless frame.ack?
@@ -256,7 +269,11 @@ module Gori
 
       private def self.authority(host : String, port : Int32, scheme : String) : String
         default = scheme == "https" ? 443 : 80
-        port == default ? host : "#{host}:#{port}"
+        # An IPv6 literal host must be bracketed in the :authority pseudo-header, else the
+        # colons collide with the port separator and a strict server rejects the stream
+        # (mirrors FlowRequest.build_target's h1 bracketing).
+        h = host.includes?(':') && !host.starts_with?('[') ? "[#{host}]" : host
+        port == default ? h : "#{h}:#{port}"
       end
 
       # Split at the first CRLFCRLF (head/body boundary); the editor always joins

--- a/src/gori/store/models.cr
+++ b/src/gori/store/models.cr
@@ -85,10 +85,14 @@ module Gori
       # The full absolute URL of the request. Plaintext forward-proxy requests are captured
       # ABSOLUTE-form (`http://host:port/path` — the wire truth, P7), so `target` already
       # carries the scheme+authority; return it verbatim. Origin-form targets (the HTTPS /
-      # CONNECT case — a bare "/path") get scheme+host prefixed. Prevents the doubled
-      # "http://hosthttp://host/path" a naive "#{scheme}://#{host}#{target}" produces on HTTP.
+      # CONNECT case — a bare "/path") get scheme+host[:port] prefixed, keeping a non-default
+      # port and bracketing an IPv6 literal (mirrors FlowRequest.build_target). Prevents the
+      # doubled "http://hosthttp://host/path" a naive "#{scheme}://#{host}#{target}" produced.
       def url : String
-        (target.starts_with?("http://") || target.starts_with?("https://")) ? target : "#{scheme}://#{host}#{target}"
+        return target if target.starts_with?("http://") || target.starts_with?("https://")
+        h = host.includes?(':') && !host.starts_with?('[') ? "[#{host}]" : host
+        default = scheme == "https" ? 443 : 80
+        port == default ? "#{scheme}://#{h}#{target}" : "#{scheme}://#{h}:#{port}#{target}"
       end
     end
 

--- a/src/gori/store/models.cr
+++ b/src/gori/store/models.cr
@@ -81,6 +81,15 @@ module Gori
                      @status, @size, @state, @response_size = nil, @duration_us = nil,
                      @content_type = nil)
       end
+
+      # The full absolute URL of the request. Plaintext forward-proxy requests are captured
+      # ABSOLUTE-form (`http://host:port/path` — the wire truth, P7), so `target` already
+      # carries the scheme+authority; return it verbatim. Origin-form targets (the HTTPS /
+      # CONNECT case — a bare "/path") get scheme+host prefixed. Prevents the doubled
+      # "http://hosthttp://host/path" a naive "#{scheme}://#{host}#{target}" produces on HTTP.
+      def url : String
+        (target.starts_with?("http://") || target.starts_with?("https://")) ? target : "#{scheme}://#{host}#{target}"
+      end
     end
 
     # Full detail incl. truth bytes — loaded lazily when a row is selected.

--- a/src/gori/tui/prism_view.cr
+++ b/src/gori/tui/prism_view.cr
@@ -298,13 +298,18 @@ module Gori::Tui
         rx -= st.size + 1
       end
       if !issue.host.empty?
-        screen.text({rx - issue.host.size, rect.x}.max, y, issue.host, Theme.muted, bg)
-        rx -= issue.host.size + 1
+        # Right-align the host, but width-cap it: a host wider than its slot would otherwise
+        # (screen.text with no width) run to the SCREEN edge, painting over the status tag and
+        # title already drawn to its right. Cap to the span up to rx so it truncates instead.
+        hx = {rx - issue.host.size, rect.x}.max
+        screen.text(hx, y, issue.host, Theme.muted, bg, width: {rx - hx, 0}.max)
+        rx = hx - 1
       end
       if issue.affected.size > 1
         cnt = "×#{issue.affected.size}"
-        screen.text({rx - cnt.size, rect.x}.max, y, cnt, Theme.muted, bg)
-        rx -= cnt.size + 1
+        cx = {rx - cnt.size, rect.x}.max
+        screen.text(cx, y, cnt, Theme.muted, bg, width: {rx - cx, 0}.max)
+        rx = cx - 1
       end
       title_x = rect.x + 14
       tw = {rx - title_x, 0}.max
@@ -486,7 +491,10 @@ module Gori::Tui
       return if h <= 0
       @scroll = @selected if @selected < @scroll
       @scroll = @selected - h + 1 if @selected >= @scroll + h
-      @scroll = 0 if @scroll < 0
+      # Clamp to the current list size: a filter/dismiss that SHRINKS @issues can leave
+      # @scroll pointing past the (now shorter) end, so the draw loop breaks after one row
+      # and the pane shows only a trailing sliver. Pull it back to the last full page.
+      @scroll = @scroll.clamp(0, {@issues.size - h, 0}.max)
     end
   end
 end

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -386,7 +386,7 @@ module Gori::Tui
       # Record the binding (POST body vs GET ?query=) so the re-encode targets the right place —
       # mirrors @saml_location. Without it a GET GraphQL edit would splice into a phantom body
       # while the origin reads the stale URL query (the decoded edit would never reach it).
-      @graphql_location = Graphql.location(detail.row.target, detail.request_body)
+      @graphql_location = Graphql.location(detail.request_body)
       seed_decode(detail, :graphql, Graphql.display(op))
     end
 

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -101,6 +101,7 @@ module Gori::Tui
       @saml_param = "SAMLResponse"
       @saml_binding = :post       # :post (base64) | :redirect (deflate+base64)
       @saml_location = :body      # :body (form) | :query (request line)
+      @graphql_location = :body   # :body (POST JSON) | :query (GET ?query=) — where the op lives
       @inflight = false           # a replay round-trip is outstanding — gates re-send (^R mashing)
       @diffable = false           # true only when loaded from a captured flow (has an original to diff)
       @auto_content_length = true # recompute Content-Length from the edited body on send
@@ -382,6 +383,10 @@ module Gori::Tui
     # Load a GraphQL flow: envelope = full request; decoded = the operation as readable
     # query + variables (Graphql.display), re-composed into the JSON body on send.
     def load_graphql(detail : Store::FlowDetail, op : Graphql::Op) : Nil
+      # Record the binding (POST body vs GET ?query=) so the re-encode targets the right place —
+      # mirrors @saml_location. Without it a GET GraphQL edit would splice into a phantom body
+      # while the origin reads the stale URL query (the decoded edit would never reach it).
+      @graphql_location = Graphql.location(detail.row.target, detail.request_body)
       seed_decode(detail, :graphql, Graphql.display(op))
     end
 
@@ -523,8 +528,27 @@ module Gori::Tui
     end
 
     private def graphql_splice_text(env : String) : String
-      sep = env.index("\n\n") || return env
-      "#{env[0, sep]}\n\n#{Graphql.recompose(env[(sep + 2)..], @decoded.text)}"
+      if @graphql_location == :query # GET: rewrite the request-line query (no body), like SAML Redirect
+        lines = env.split('\n')
+        lines[0] = graphql_query_line(lines[0], @decoded.text) if lines[0]?
+        lines.join('\n')
+      else # POST: recompose the JSON body, preserving other fields
+        sep = env.index("\n\n") || return env
+        "#{env[0, sep]}\n\n#{Graphql.recompose(env[(sep + 2)..], @decoded.text)}"
+      end
+    end
+
+    # Rewrite a request line's query with the edited GraphQL op re-encoded (GET binding),
+    # reading the original query from the line itself — mirrors saml_query_line.
+    private def graphql_query_line(rl : String, decoded_text : String) : String
+      sp1 = rl.index(' ')
+      sp2 = rl.rindex(' ')
+      return rl unless sp1 && sp2 && sp2 > sp1
+      target = rl[(sp1 + 1)...sp2]
+      qidx = target.index('?')
+      path = qidx ? target[0, qidx] : target
+      query = Graphql.recompose_query(qidx ? target[(qidx + 1)..] : "", decoded_text)
+      "#{rl[0, sp1]} #{path}?#{query} #{rl[(sp2 + 1)..]}"
     end
 
     # Rewrite the Content-Length header (if present) to the envelope body's byte size —

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -321,6 +321,7 @@ module Gori::Tui
           cgw = [Screen.display_width((@preedit.empty? ? (@cx < line.size ? line[@cx] : ' ') : @preedit[0]).to_s), 1].max
           ch = @preedit.empty? ? (@cx < line.size ? line[@cx] : ' ') : @preedit[0]
           (0...cgw).each do |off|
+            break if cxs + off >= cx0 + cw # a wide-glyph caret at the last column must not spill its 2nd cell onto the pane border
             cch = (off == 0 ? ch : ' ')
             screen.cell(cxs + off, rect.y + i, cch, Theme.bg, Theme.accent)
           end


### PR DESCRIPTION
Focused bug hunt on the recently-improved **Replay** and **Prism** features — driving the real TUI against a test origin **and** an 8-dimension adversarial workflow (each finding checked by 2 independent verifiers). **12 confirmed bugs**, each with a regression spec. Full suite green (**1033 examples, 0 failures**).

## Prism
- **Doubled affected URLs on plain-HTTP** — forward-proxy plaintext flows store the *absolute-form* target, so `"scheme://host + target"` produced `http://hosthttp://host:port/path`, persisted into every issue's `affected` list. New canonical `Store::FlowRow#url`; `context`/`analyzer`/`reflected_param` routed through it.
- **Active probe sent absolute-form request lines** direct to origins — normalized to origin-form (the regular replay path already does this).
- **weak_csp false-negative** — a CSP with neither `script-src` nor `default-src` leaves scripts unrestricted yet suppressed `missing_csp`; now flagged.
- **error_stack_leak false-positives** — docs merely *naming* `ActiveRecord::Base` / `org.springframework.boot` / `System.ArgumentException` / `routes.rb:15` tripped it; signatures tightened to require trace/error framing.
- **CORS reflected-origin** now compares full scheme+host+**port** (missed cross-scheme / cross-port credentialed reflections).
- **Prism list**: `@scroll` clamped to the shrunken list after a filter (was showing only a trailing row); host width-capped so a long host can't overwrite the status tag / title.

## Replay
- **h2 hang/DoS** — `read_response` had no cap on non-terminal frames; a PING/PRIORITY flood without `END_STREAM` pinned the fiber. Added `MAX_FRAMES`. Also bracket IPv6 h2 `:authority`.
- **GraphQL split editor** — honor the GET binding (rewrite the URL query instead of appending a phantom body that the origin ignores); disambiguate the `# variables` sentinel from an in-query comment via a JSON guard.
- **text_area** — a wide-glyph caret at the last column no longer spills its second cell onto the pane border when horizontally scrolled.

## Verified working (no change needed)
Replay split-editor re-encode-on-send (edited GraphQL reached the origin with `Content-Length` re-synced); JWT `exp` crash already guarded.

## Test plan
- `crystal build` clean · `crystal spec` → 1033 examples, 0 failures · `crystal tool format` clean · no new ameba findings.
- Live-verified the doubled-URL fix end-to-end in the TUI (affected-URLs pane now renders clean URLs).
