### PR TITLE
feat(prism): FP/FN pass + active CORS arbitrary-origin probe

### DIFF
--- a/spec/prism_spec.cr
+++ b/spec/prism_spec.cr
@@ -263,6 +263,75 @@ describe "Gori::Prism::Passive (FP reduction)" do
     end
   end
 
+  it "does not flag a nonce/hash/strict-dynamic CSP that keeps 'unsafe-inline' for CSP2 fallback" do
+    with_store do |store|
+      # CSP Level 3: a nonce (or hash, or strict-dynamic) makes browsers IGNORE 'unsafe-inline',
+      # so this modern policy is SAFE and must not trip weak_csp (the common FP).
+      nonce = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Security-Policy: " \
+                                        "script-src 'self' 'unsafe-inline' 'nonce-abc123'\r\n\r\n",
+        content_type: "text/html")
+      codes_of(nonce).should_not contain("weak_csp")
+      hash = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Security-Policy: " \
+                                       "script-src 'unsafe-inline' 'sha256-abc123def456ghi789'\r\n\r\n",
+        content_type: "text/html")
+      codes_of(hash).should_not contain("weak_csp")
+      # strict-dynamic also nullifies 'unsafe-inline' AND host/scheme sources (https:, *).
+      strict = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Security-Policy: " \
+                                         "script-src 'strict-dynamic' 'nonce-x' 'unsafe-inline' https: *\r\n\r\n",
+        content_type: "text/html")
+      codes_of(strict).should_not contain("weak_csp")
+    end
+  end
+
+  it "still flags 'unsafe-eval' and a 'data:' script source (neither is nullified by a nonce)" do
+    with_store do |store|
+      # 'unsafe-eval' executes regardless of nonces/strict-dynamic → always weak.
+      eval_csp = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Security-Policy: " \
+                                           "script-src 'self' 'nonce-x' 'unsafe-eval'\r\n\r\n",
+        content_type: "text/html")
+      codes_of(eval_csp).should contain("weak_csp")
+      # a 'data:' script source allows data-URI scripts (XSS) when strict-dynamic is absent.
+      data_csp = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Security-Policy: " \
+                                           "script-src 'self' data:\r\n\r\n",
+        content_type: "text/html")
+      codes_of(data_csp).should contain("weak_csp")
+    end
+  end
+
+  it "rates a wildcard CORS with credentials Medium (the combination is browser-rejected, not High)" do
+    with_store do |store|
+      dets = analyze(store,
+        resp_head: "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: *\r\n" \
+                   "Access-Control-Allow-Credentials: true\r\n\r\n", content_type: nil)
+      hit = dets.find(&.code.==("cors_wildcard")).not_nil!
+      hit.severity.should eq(Gori::Store::Severity::Medium)
+    end
+  end
+
+  it "flags a Go panic dump and Stripe/SendGrid/npm secrets (type only, never the value)" do
+    with_store do |store|
+      go = analyze(store, resp_head: "HTTP/1.1 500 Server Error\r\n\r\n", status: 500,
+        content_type: "text/html",
+        body: "panic: runtime error\n\ngoroutine 1 [running]:\nmain.main()\n\t/app/main.go:10 +0x1d")
+      codes_of(go).should contain("error_stack_leak")
+      stripe = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", content_type: "text/html",
+        body: %({"key":"sk_live_ABCDEFGHIJKLMNOPQRSTUVWX"}))
+      hit = stripe.find(&.code.==("secret_in_body")).not_nil!
+      hit.evidence.should eq("Stripe secret key")
+      hit.evidence.not_nil!.should_not contain("sk_live")
+      sendgrid = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", content_type: "text/html",
+        body: "SG.abcdefghijklmnop.qrstuvwxyz0123456789")
+      sendgrid.find(&.code.==("secret_in_body")).not_nil!.evidence.should eq("SendGrid API key")
+      npm = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", content_type: "text/html",
+        body: "//registry.npmjs.org/:_authToken=npm_abcdefghijklmnopqrstuvwxyz0123456789")
+      npm.find(&.code.==("secret_in_body")).not_nil!.evidence.should eq("npm access token")
+      # a prose mention of "goroutine" (no `[state]:` header) must NOT trip.
+      prose = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", content_type: "text/html",
+        body: "Launch a goroutine to handle each request.")
+      codes_of(prose).should_not contain("error_stack_leak")
+    end
+  end
+
   it "does not fingerprint an Elasticsearch query-DSL body as GraphQL" do
     with_store do |store|
       es = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", target: "/api/search",
@@ -443,6 +512,71 @@ describe "Gori::Prism::Passive (new patterns)" do
         content_type: "text/html")
       hit = dets.find(&.code.==("cookie_no_samesite")).not_nil!
       hit.evidence.should eq("samesite")
+    end
+  end
+end
+
+describe "Gori::Prism::Active::CorsReflection" do
+  probe = Gori::Prism::Active::CorsReflection.new
+
+  it "only probes CORS endpoints (response carried ACAO) with a safe method" do
+    with_store do |store|
+      # No ACAO on the captured response → nothing to probe.
+      plain = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/api", content_type: nil)
+      probe.plan(plain).should be_nil
+      # A POST is never probed even if it does CORS.
+      post = capture_flow(store, "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: https://a.test\r\n\r\n",
+        target: "/api", method: "POST", content_type: nil)
+      probe.plan(post).should be_nil
+      # A GET whose response did CORS → a probe is built.
+      cors = capture_flow(store, "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: https://a.test\r\n\r\n",
+        target: "/api", content_type: nil)
+      probe.plan(cors).should_not be_nil
+    end
+  end
+
+  it "sends a single synthetic Origin header (replacing any the browser sent)" do
+    with_store do |store|
+      cors = capture_flow(store, "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: https://real.test\r\n\r\n",
+        target: "/api", req_headers: "Origin: https://real.test\r\n", content_type: nil)
+      plan = probe.plan(cors).not_nil!
+      text = String.new(plan.request)
+      text.scan(/Origin:/i).size.should eq(1) # exactly one Origin header
+      text.should contain("Origin: #{Gori::Prism::Active::CorsReflection::PROBE_ORIGIN}")
+      text.should_not contain("https://real.test") # the browser's Origin was dropped
+    end
+  end
+
+  it "flags High only when the probe origin is reflected WITH credentials" do
+    with_store do |store|
+      cors = capture_flow(store, "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: https://real.test\r\n\r\n",
+        target: "/api", content_type: nil)
+      plan = probe.plan(cors).not_nil!
+      origin = Gori::Prism::Active::CorsReflection::PROBE_ORIGIN
+
+      reflected = Gori::Replay::Result.new(
+        "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: #{origin}\r\n" \
+        "Access-Control-Allow-Credentials: true\r\n\r\n".to_slice, Bytes.empty, nil, 1_i64)
+      dets = probe.detections(plan, reflected, cors)
+      dets.size.should eq(1)
+      dets.first.code.should eq("cors_arbitrary_origin")
+      dets.first.severity.should eq(Gori::Store::Severity::High)
+
+      # Reflected but NO credentials → not exploitable → not flagged.
+      no_creds = Gori::Replay::Result.new(
+        "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: #{origin}\r\n\r\n".to_slice, Bytes.empty, nil, 1_i64)
+      probe.detections(plan, no_creds, cors).should be_empty
+
+      # A correctly-behaving allowlist rejects the probe origin (echoes its own) → not flagged.
+      allowlisted = Gori::Replay::Result.new(
+        "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: https://real.test\r\n" \
+        "Access-Control-Allow-Credentials: true\r\n\r\n".to_slice, Bytes.empty, nil, 1_i64)
+      probe.detections(plan, allowlisted, cors).should be_empty
+
+      # A wildcard is handled by the passive check, not proven here.
+      wildcard = Gori::Replay::Result.new(
+        "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: *\r\n\r\n".to_slice, Bytes.empty, nil, 1_i64)
+      probe.detections(plan, wildcard, cors).should be_empty
     end
   end
 end

--- a/src/gori/prism/active.cr
+++ b/src/gori/prism/active.cr
@@ -1,5 +1,6 @@
 require "./active/types"
 require "./active/reflected_param"
+require "./active/cors_reflection"
 
 module Gori
   module Prism
@@ -10,7 +11,7 @@ module Gori
       # The primary rule, reused for the registry AND the module-level facade.
       PRIMARY = ReflectedParam.new
 
-      RULES = [PRIMARY] of Rule
+      RULES = [PRIMARY, CorsReflection.new] of Rule
 
       # Convenience facade over the primary (reflected-param) rule. The analyzer drives the
       # whole RULES list; these keep a stable single-rule entry point for callers/tests.

--- a/src/gori/prism/active/cors_reflection.cr
+++ b/src/gori/prism/active/cors_reflection.cr
@@ -1,0 +1,101 @@
+require "./types"
+require "../../miner/inject"
+require "../../proxy/codec/http1"
+
+module Gori
+  module Prism
+    module Active
+      # Active CORS origin-reflection probe. Passive analysis can only judge the origins the
+      # browser actually sent; it CANNOT prove a server reflects *arbitrary* origins. This rule
+      # sends ONE safe-method request with a synthetic, attacker-controlled `Origin` and reports
+      # a High finding only when the server both ECHOES that probe origin AND allows credentials
+      # — the definitive, exploitable reflected-origin CORS misconfiguration.
+      #
+      # Gated hard to keep the scan light and low-FP: only endpoints that ALREADY do CORS (the
+      # captured response carried an Access-Control-Allow-Origin header) are probed, and only
+      # GET/HEAD (no state mutation). A well-behaved allowlist rejects the probe origin, so it is
+      # never flagged.
+      class CorsReflection < Rule
+        # A synthetic origin that is obviously not a legitimate allowlisted one. `.example` is a
+        # reserved TLD (RFC 2606) that never resolves — the value is only ever a header, never
+        # dialed. If the server reflects THIS, it reflects anything.
+        PROBE_ORIGIN = "https://gori-cors-probe.example"
+
+        def plan(detail : Store::FlowDetail) : Plan?
+          req = Proxy::Codec::Http1.parse_request_head(detail.request_head)
+          return nil if req.malformed?
+          return nil unless SAFE_METHODS.includes?(req.method.upcase)
+          # Only probe endpoints that demonstrably do CORS (response already carried an ACAO).
+          rhead = detail.response_head
+          return nil unless rhead
+          resp = Proxy::Codec::Http1.parse_response_head(rhead)
+          return nil unless resp.headers.get?("Access-Control-Allow-Origin")
+          request = rebuild_with_origin(detail.request_head, detail.request_body, PROBE_ORIGIN)
+          key = "cors_reflection|#{detail.row.host}|#{req.method.upcase}|#{path_key(req.target)}"
+          Plan.new(request, [] of Param, key)
+        end
+
+        def detections(plan : Plan, result : Replay::Result, detail : Store::FlowDetail) : Array(Detection)
+          return [] of Detection unless result.ok?
+          resp = Proxy::Codec::Http1.parse_response_head(result.head)
+          acao = resp.headers.get?("Access-Control-Allow-Origin").try(&.strip)
+          # Only a reflection of OUR probe origin proves arbitrary-origin echoing; `*` or a fixed
+          # allowlisted value is not (and `*` is handled by the passive wildcard check).
+          return [] of Detection unless acao == PROBE_ORIGIN
+          creds = resp.headers.get?("Access-Control-Allow-Credentials").try(&.downcase.strip) == "true"
+          return [] of Detection unless creds
+          [Detection.new("cors_arbitrary_origin", Category::CORS, detail.row.host, detail.row.url,
+            "CORS reflects an arbitrary origin with credentials", Store::Severity::High,
+            "confirmed by probe", detail.row.id)]
+        rescue
+          [] of Detection
+        end
+
+        # Rebuild the request with a single, authoritative `Origin: <probe>` header: drop any
+        # existing Origin the browser sent, then insert ours right after the request line. The
+        # body is untouched, so Content-Length stays valid (no resync needed).
+        private def rebuild_with_origin(head : Bytes, body : Bytes?, origin : String) : Bytes
+          combined = if body && !body.empty?
+                       io = IO::Memory.new(head.size + body.size)
+                       io.write(head)
+                       io.write(body)
+                       io.to_slice
+                     else
+                       head
+                     end
+          hbytes, bbytes, eol = Miner::Inject.split(combined)
+          lines = String.new(hbytes).split(eol)
+          kept = [] of String
+          lines.each_with_index do |l, i|
+            next if i > 0 && origin_header?(l) # keep the request line (i == 0) verbatim
+            kept << l
+          end
+          kept.insert(1, "Origin: #{origin}") unless kept.empty?
+          io = IO::Memory.new
+          io << kept.join(eol) << eol << eol
+          io.write(bbytes) unless bbytes.empty?
+          io.to_slice
+        end
+
+        private def origin_header?(line : String) : Bool
+          (c = line.index(':')) ? line[0...c].strip.downcase == "origin" : false
+        end
+
+        # Dedup path: origin-form target with the query stripped (a CORS policy is per-endpoint,
+        # not per-query-value), so one probe per (host, method, path).
+        private def path_key(target : String) : String
+          t = origin_form(target)
+          qi = t.index('?')
+          qi ? t[0...qi] : t
+        end
+
+        private def origin_form(target : String) : String
+          return target unless target.starts_with?("http://") || target.starts_with?("https://")
+          se = target.index("://") || return target
+          slash = target.index('/', se + 3)
+          slash ? target[slash..] : "/"
+        end
+      end
+    end
+  end
+end

--- a/src/gori/prism/analyzer.cr
+++ b/src/gori/prism/analyzer.cr
@@ -150,8 +150,12 @@ module Gori
         detections = task.rule.detections(task.plan, result, task.detail)
         return if detections.empty?
         detections.each { |d| @store.upsert_prism_issue(d) }
-        summary = detections.first.evidence
-        emit(IssueEvent.new(row.host, "reflected param on #{row.host} (#{summary})"))
+        # Notification wording is rule-agnostic: the detection's own title + evidence (so a CORS
+        # probe reads "CORS reflects an arbitrary origin…", not a hardcoded "reflected param").
+        first = detections.first
+        msg = "#{first.title} on #{row.host}"
+        msg = "#{msg}: #{first.evidence}" if first.evidence
+        emit(IssueEvent.new(row.host, msg))
       rescue DB::Error | SQLite3::Exception
         # store closing — stop quietly (the worker will exit when the queue closes)
       rescue ex

--- a/src/gori/prism/issue.cr
+++ b/src/gori/prism/issue.cr
@@ -42,6 +42,7 @@ module Gori
       "cors_wildcard"                  => "Avoid Access-Control-Allow-Origin: * for credentialed/sensitive endpoints; echo a vetted allowlisted origin instead.",
       "cors_null_origin"               => "Never allow the null origin; it is sent by sandboxed iframes and redirects and is trivially forgeable.",
       "cors_reflected_origin"          => "Don't blindly reflect the Origin with Allow-Credentials: true; validate it against a strict allowlist.",
+      "cors_arbitrary_origin"          => "A probe confirmed the server echoes ANY Origin with Allow-Credentials: true — any site can read authenticated responses. Validate the Origin against a strict allowlist.",
       "private_ip_leak"                => "Strip internal hostnames/IPs from responses; they aid network reconnaissance.",
       "error_stack_leak"               => "Return generic errors to clients; log stack traces server-side only.",
       "secret_in_body"                 => "Rotate the exposed credential and remove it from the response; never ship keys/tokens to clients.",

--- a/src/gori/prism/passive/body_leaks.cr
+++ b/src/gori/prism/passive/body_leaks.cr
@@ -42,6 +42,9 @@ module Gori
           # A real PHP stack/trace frame ("… /var/www/app.php(42): …") — the paren+line form
           # a path reference lacks; keeps the FP-prone bare "app.php:42" colon form out.
           {/\.php\(\d+\)/, "PHP stack frame"},
+          # A Go panic dump: the `goroutine N [state]:` header is the runtime's exact shape,
+          # so a prose mention of "goroutine" does not match.
+          {/\bgoroutine \d+ \[[\w ]+\]:/, "Go stack trace"},
           {/(?:\n|\A)Stack trace:\s*(?:\n|#\d)/, "stack trace"},
         ]
 
@@ -53,6 +56,10 @@ module Gori
           {/\bgh[pousr]_[0-9A-Za-z]{36}\b/, "GitHub token"},
           {/\bglpat-[0-9A-Za-z_\-]{20}\b/, "GitLab token"},
           {/\bxox[baprs]-[0-9A-Za-z\-]{10,}/, "Slack token"},
+          # Stripe LIVE keys only (test keys aren't sensitive); the prefix is distinctive.
+          {/\b(?:sk|rk)_live_[0-9A-Za-z]{20,}\b/, "Stripe secret key"},
+          {/\bSG\.[\w\-]{16,}\.[\w\-]{16,}\b/, "SendGrid API key"},
+          {/\bnpm_[0-9A-Za-z]{36}\b/, "npm access token"},
           {/-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----/, "private key block"},
         ]
 

--- a/src/gori/prism/passive/cors.cr
+++ b/src/gori/prism/passive/cors.cr
@@ -12,9 +12,11 @@ module Gori
           return unless acao
           creds = resp.headers.get?("Access-Control-Allow-Credentials").try(&.downcase.strip) == "true"
           if acao == "*"
-            sev = creds ? Store::Severity::High : Store::Severity::Medium
+            # `*` + Allow-Credentials is REJECTED by browsers (the credentialed request fails),
+            # so the combination is a non-functional misconfiguration — NOT more exploitable than
+            # a bare wildcard. Keep it Medium and say so, rather than inflating to High.
             acc << cors(ctx, "cors_wildcard", "Permissive CORS (Access-Control-Allow-Origin: *)",
-              sev, creds ? "with credentials" : nil)
+              Store::Severity::Medium, creds ? "with credentials (browser-rejected combination)" : nil)
           elsif acao.downcase == "null"
             sev = creds ? Store::Severity::High : Store::Severity::Medium
             acc << cors(ctx, "cors_null_origin", "CORS allows the null origin",

--- a/src/gori/prism/passive/security_headers.cr
+++ b/src/gori/prism/passive/security_headers.cr
@@ -61,17 +61,32 @@ module Gori
           dirs
         end
 
-        # Weak when the SCRIPT context (script-src, else the default-src fallback) allows
-        # unsafe-inline / unsafe-eval or a bare wildcard — OR when it is ABSENT entirely: a
-        # CSP with neither script-src nor default-src places ZERO restriction on script
-        # loading/execution (the CSP spec's no-fallback case), which is as XSS-permissive as
-        # having no CSP at all, yet the header's mere presence suppresses the missing_csp
-        # check — so it must be caught here. (`unsafe-inline` confined to style-src is a
-        # common, low-risk pattern and still does NOT trip this.)
+        # A nonce-source or hash-source in the script context (parse_csp keeps the quotes and
+        # lowercases, so the value's original case is irrelevant to this prefix test).
+        SCRIPT_NONCE_HASH = /\A'(?:nonce|sha256|sha384|sha512)-/
+
+        # Weak when the SCRIPT context (script-src, else the default-src fallback) is unsafe —
+        # accounting for CSP Level 3 nullification so a modern, safe policy is NOT a false
+        # positive:
+        #   * ABSENT entirely (neither script-src nor default-src) ⇒ scripts unrestricted (as
+        #     XSS-permissive as no CSP, yet the header's presence suppresses missing_csp).
+        #   * 'unsafe-eval' ⇒ always weak (a nonce / 'strict-dynamic' does NOT nullify eval()).
+        #   * 'unsafe-inline' ⇒ weak ONLY when no nonce/hash source AND no 'strict-dynamic':
+        #     browsers IGNORE 'unsafe-inline' in the presence of either, so a nonce-based CSP
+        #     that keeps 'unsafe-inline' for CSP2-browser fallback is safe, not weak.
+        #   * a bare '*' or a 'data:' script source ⇒ any-origin / data-URI scripts (XSS), weak
+        #     UNLESS 'strict-dynamic' is present (it makes host/scheme sources be ignored).
+        # (`unsafe-inline` confined to style-src is a common, low-risk pattern; only the SCRIPT
+        # context is inspected, so it still does NOT trip this.)
         private def weak_csp?(dirs : Hash(String, Array(String))) : Bool
           script = dirs["script-src"]? || dirs["default-src"]?
           return true if script.nil?
-          script.any? { |s| s.includes?("unsafe-inline") || s.includes?("unsafe-eval") || s == "*" }
+          return true if script.any?(&.includes?("unsafe-eval"))
+          nonce_or_hash = script.any? { |s| SCRIPT_NONCE_HASH.matches?(s) }
+          strict_dynamic = script.includes?("'strict-dynamic'")
+          return true if !nonce_or_hash && !strict_dynamic && script.any?(&.includes?("unsafe-inline"))
+          return true if !strict_dynamic && script.any? { |s| s == "*" || s == "data:" }
+          false
         end
 
         private def hdr(ctx : Context, code : String, title : String, sev : Store::Severity, evidence : String? = nil) : Detection


### PR DESCRIPTION
## Summary

Prism 완성도 개선 — 잔존 FP/FN을 줄이고, "매우 가벼운 ActiveScan"에 능동 CORS 검사를 추가했습니다.

### 오탐(FP) 감소
- **weak_csp — CSP Level 3 준수**: nonce·hash 소스나 `'strict-dynamic'`가 있으면 브라우저가 `'unsafe-inline'`을 무시합니다. `script-src 'self' 'unsafe-inline' 'nonce-…'`(CSP2 하위호환용 흔한 현대 패턴)에서 나던 오탐을 제거했습니다. `'unsafe-eval'`은 무력화되지 않으므로 여전히 탐지합니다.
- **CORS `*` + credentials 심각도 정정**: `Access-Control-Allow-Origin: *` + `Allow-Credentials: true` 조합은 브라우저가 거부해 실제 악용 불가(inert) → High에서 Medium으로 조정. (`null`+creds는 sandboxed iframe으로 악용 가능하므로 High 유지)

### 미탐(FN) 감소
- **weak_csp**: `data:` 스크립트 소스(데이터-URI 스크립트 XSS) 탐지 추가
- **body_leaks**: Go 패닉/스택트레이스 시그니처, Stripe(`sk_live_`/`rk_live_`)·SendGrid·npm 토큰 패턴 추가 — 접두사 앵커로 저(低)오탐, evidence는 값이 아닌 "타입"만 노출

### 신규: 능동 CORS origin-reflection 프로브
Passive는 브라우저가 보낸 Origin만 판단할 수 있어 "임의 origin 반사"를 증명할 수 없습니다. 합성 Origin(`https://gori-cors-probe.example`)을 담은 GET/HEAD 한 번을 보내, 서버가 그 origin을 **자격증명과 함께** 반사할 때만 High `cors_arbitrary_origin`을 보고합니다.
- 게이팅: 원 응답에 이미 ACAO가 있던(=CORS를 하는) 엔드포인트 + 안전 메서드만 프로브 → 저오탐·경량
- 올바른 allowlist는 프로브 origin을 거부하므로 탐지되지 않고, `*`는 passive 검사가 담당
- 실제 반사형 서버로 end-to-end 검증 완료

### 부수 버그 수정
active-scan 알림이 `"reflected param on …"`으로 하드코딩되어 CORS 탐지를 잘못 표기하던 것을 탐지 title 기반 rule-agnostic 문구로 수정.

## Test
- Prism 스펙 39 → 46 (회귀 테스트 7개 추가)
- 전체 스위트 1041 examples, 0 failures
- 변경 파일 ameba-clean