### PR TITLE
feat(tui): show Convert sub-tab strip from the first session

### DIFF
--- a/src/gori/tui/controllers/convert_controller.cr
+++ b/src/gori/tui/controllers/convert_controller.cr
@@ -32,9 +32,9 @@ module Gori::Tui
   # consumes EVERY printable key (like Notes), so command_scope is the Convert scope
   # and handle_body_key always returns true: the Convert verbs' single-letter
   # mnemonics never collide with literal text (`:` stays literal) — they're reached
-  # only from the space menu + palette. A runner-owned sub-tab strip appears at ≥2
-  # sessions (^N new · ^W close · ^1-9/←→ switch · r rename); open sessions persist to
-  # the global settings.json.
+  # only from the space menu + palette. A runner-owned sub-tab strip appears from the
+  # first session (^N new · ^W close · ^1-9/←→ switch · r rename); open sessions persist
+  # to the global settings.json.
   class ConvertController < TabController
     SEPS = {'>', '|', ','}
 
@@ -84,13 +84,19 @@ module Gori::Tui
       ConvertSession.new(view, input, chain, chain.size, :input, result)
     end
 
-    # --- sub-tab strip (runner-owned chrome; shown at ≥2 sessions) ---
+    # --- sub-tab strip (runner-owned chrome; shown from the first session) ---
     def subtab_labels : Array(String)
       @sessions.map_with_index { |s, i| "#{i + 1}:#{session_label(s)}" }
     end
 
     def subtab_index : Int32
       @idx
+    end
+
+    # Show the strip from the FIRST session (not ≥2), like Replay/Notes: a lone
+    # conversion still labels its chip and exposes the strip's space-menu.
+    def subtab_strip_shown? : Bool
+      true
     end
 
     # The chip label: the custom name if set, else a compact preview of the chain
@@ -162,7 +168,7 @@ module Gori::Tui
     def render_body(screen : Screen, rect : Rect, focus : Symbol) : Nil
       body_focused = focus == :body
       body_rect = rect
-      if @sessions.size >= 2
+      if subtab_strip_shown?
         sub_rect, body_rect = BodyChrome.carve_subtab_row(rect)
         BodyChrome.render_subtab_strip(screen, sub_rect, subtab_labels, @idx, focus == :subtabs)
       end
@@ -235,7 +241,7 @@ module Gori::Tui
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
       @host.focus_body
-      body = @sessions.size >= 2 ? BodyChrome.carve_subtab_row(rect)[1] : rect
+      body = subtab_strip_shown? ? BodyChrome.carve_subtab_row(rect)[1] : rect
       s = cur
       # The view frames each card itself, so layout takes the full body rect; the
       # editable content lives one cell inside each card border.
@@ -301,7 +307,7 @@ module Gori::Tui
       when :output
         "↑/↓ scroll · ⇧←/→ h-scroll · ↑-top chain · ↹ next · space menu · ^X mode · ^Y copy · esc tabs"
       else
-        "type to edit · ↓/↹ chain · ^L clear · ^Y copy · ^X mode · ^N new · ^W close · esc tabs"
+        "type to edit · ↓/↹ chain · ^L clear · ^Y copy · ^X mode · ^N new · ^W close · ↑ sub-tabs · esc tabs"
       end
     end
 
@@ -357,7 +363,12 @@ module Gori::Tui
       when key.backspace?
         s.input.backspace; touch
       when key.up?
-        s.input.at_top? ? (commit; @host.request_focus(:menu)) : s.input.move(-1, 0)
+        if s.input.at_top?
+          commit
+          @host.request_focus(:subtabs)
+        else
+          s.input.move(-1, 0)
+        end
       when key.down?
         s.input.at_bottom? ? (s.pane = :chain) : s.input.move(1, 0)
       else

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1471,8 +1471,8 @@ module Gori::Tui
     end
 
     # A navigable sub-tab strip is showing — gates entry into :subtabs (and the strip
-    # click/rename paths). Each controller decides its own threshold (Convert ≥2;
-    # Replay/Fuzzer/Notes ≥1 so a single session is still labelled + space-menu reachable).
+    # click/rename paths). Each controller decides its own threshold (Replay/Fuzzer/
+    # Notes/Convert ≥1 so a single session is still labelled + space-menu reachable).
     private def subtabs_shown? : Bool
       @tabs[@active_tab]?.try(&.subtab_strip_shown?) || false
     end
@@ -2292,7 +2292,7 @@ module Gori::Tui
     end
 
     # Descend from the tab menu (↓/↵/j on the tab bar). Tabs with a navigable
-    # sub-tab strip (Replay/Notes, ≥2 chips) land on the STRIP first so ←/→ can
+    # sub-tab strip (Replay/Notes/Convert) land on the STRIP first so ←/→ can
     # switch sub-tabs; ↓/↵ again drops into the editor. Other tabs go straight to
     # the body. (`focus_pane`'s guard would otherwise route an absent strip to the
     # menu, so the active tab is checked here.)


### PR DESCRIPTION
## Summary

Convert 탭의 서브탭 UX를 Replay·Notes와 맞춥니다. 세션이 하나뿐일 때도 서브탭 스트립을 표시해 현재 conversion을 라벨링하고, 스트립 space menu·rename·`^N`/`^W`/`^1-9` 단축키를 바로 쓸 수 있게 합니다.

## Changes

- `ConvertController#subtab_strip_shown?` — 항상 `true` (단일 세션에서도 스트립 표시)
- `render_body` / `handle_click` — `≥2` 세션 조건 대신 `subtab_strip_shown?` 사용
- INPUT 첫 줄에서 ↑ — 탭 바 대신 서브탭 스트립으로 포커스 이동 (Notes와 동일)
- body hint에 `↑ sub-tabs` 안내 추가
- Runner 주석 업데이트

## Test plan

- [x] `crystal spec spec/tui/convert_view_spec.cr spec/tui/space_menu_spec.cr spec/settings_spec.cr` — 44 examples, 0 failures