### PR TITLE
feat(tui): expose Prism detail actions from the issue list

### DIFF
--- a/spec/tui/space_menu_spec.cr
+++ b/spec/tui/space_menu_spec.cr
@@ -89,6 +89,24 @@ describe Gori::Tui::SpaceMenu do
     menu.verb_for('w').try(&.id).should eq("notes.close")
   end
 
+  it "lists the Prism list's detail-parity actions (promote, evidence, delete)" do
+    ctx = FakeExecContext.new
+    menu = SpaceMenu.new(Gori::Verbs.registry)
+    menu.open(Gori::Verb::Scope::Prism, ctx)
+
+    ids = menu.entries.map(&.id)
+    ids.should contain("prism.promote-selected")
+    ids.should contain("prism.open-evidence")
+    ids.should contain("prism.replay-evidence")
+    ids.should contain("prism.delete-selected")
+    menu.verb_for('p').try(&.id).should eq("prism.promote-selected")
+    menu.verb_for('o').try(&.id).should eq("prism.open-evidence")
+    menu.verb_for('r').try(&.id).should eq("prism.replay-evidence")
+    menu.verb_for('d').try(&.id).should eq("prism.delete-selected")
+    menu.verb_for('v').try(&.id).should eq("prism.open")
+    menu.verb_for('g').try(&.id).should eq("prism.dismiss-code")
+  end
+
   it "lists the Convert tab's actions in the Convert scope (reachable from the sub-tab strip)" do
     ctx = FakeExecContext.new
     ctx.current_tab = :convert # the Convert verbs gate on the active tab

--- a/src/gori/tui/controllers/prism_controller.cr
+++ b/src/gori/tui/controllers/prism_controller.cr
@@ -41,7 +41,7 @@ module Gori::Tui
       elsif @prism.mode.off?
         "m enable scanning · / filter · space cmds · esc tabs"
       else
-        "↑/↓ move · ↵ open · c dismiss · m mode · / filter · space cmds"
+        "o flow · r replay · p promote · c dismiss · d delete · m mode · / filter · space cmds"
       end
     end
 

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -2547,7 +2547,7 @@ module Gori::Tui
     # Jump from an issue to its sample flow's request/response in History. CROSS-TAB
     # mediator (mirrors finding_open_flow).
     def prism_open_flow : Nil
-      return unless i = prism_controller.view.detail_issue
+      return unless i = prism_controller.view.target_issue
       return (@toast = "this issue has no sample flow") unless fid = i.sample_flow_id
       if history_controller.view.open_detail_id(fid, @session.store)
         @active_tab = :history
@@ -2560,7 +2560,7 @@ module Gori::Tui
 
     # Send an issue's sample flow to Replay to re-test it (mirrors finding_replay_flow).
     def prism_replay_flow : Nil
-      return unless i = prism_controller.view.detail_issue
+      return unless i = prism_controller.view.target_issue
       return (@toast = "this issue has no sample flow") unless fid = i.sample_flow_id
       if @session.store.get_flow(fid)
         replay_flow(fid)
@@ -2572,7 +2572,7 @@ module Gori::Tui
     # Promote a machine-found Prism issue to a human-confirmed Finding (the bridge to the
     # Findings report). Reuses Store#insert_finding; the issue's severity/host/sample flow carry over.
     def prism_promote : Nil
-      return unless i = prism_controller.view.detail_issue
+      return unless i = prism_controller.view.target_issue
       @session.store.insert_finding(i.title, i.severity, i.host, i.sample_flow_id)
       # Mark the source confirmed (= "promoted to a Finding") so it leaves the default
       # open-only lens instead of lingering as unreviewed noise; still reachable via `a`.

--- a/src/gori/verbs/prism.cr
+++ b/src/gori/verbs/prism.cr
@@ -16,11 +16,12 @@ module Gori
         "prism.up", "Select previous issue", "Move up", Verb::Scope::Prism,
         [Verb::Chord.new("up"), Verb::Chord.new("k")], hidden: true) { |ctx| ctx.prism_move(-1); nil }
 
-      # open carries an explicit 'o' mnemonic — its primary chord is enter/l, which would
-      # otherwise front the space menu with the unintuitive 'l'.
+      # open carries an explicit 'v' mnemonic — its primary chord is enter/l, which would
+      # otherwise front the space menu with the unintuitive 'l'. 'o' is reserved for
+      # open-evidence (parity with the detail scope).
       r.register Verb::Definition.new(
         "prism.open", "Open issue", "View the selected issue's detail", Verb::Scope::Prism,
-        [Verb::Chord.new("enter"), Verb::Chord.new("l"), Verb::Chord.new("right")], mnemonic: 'o') { |ctx| ctx.prism_open; nil }
+        [Verb::Chord.new("enter"), Verb::Chord.new("l"), Verb::Chord.new("right")], mnemonic: 'v') { |ctx| ctx.prism_open; nil }
 
       r.register Verb::Definition.new(
         "prism.filter", "Filter issues", "Filter the list (severity:/status:/category:/host:/code:/free text)",
@@ -43,14 +44,32 @@ module Gori
         Verb::Scope::Prism, [Verb::Chord.new("a")]) { |ctx| ctx.prism_toggle_closed; nil }
 
       # Bulk dismiss — space-menu only (mnemonic, no stray hotkey): mute a whole check
-      # code, or a whole host, in one confirmed action.
+      # code, or a whole host, in one confirmed action. 'r' is reserved for replay-evidence
+      # (parity with the detail scope).
       r.register Verb::Definition.new(
         "prism.dismiss-code", "Dismiss all with this code", "Mute every open issue sharing the selected issue's check code",
-        Verb::Scope::Prism, mnemonic: 'r') { |ctx| ctx.prism_dismiss_code; nil }
+        Verb::Scope::Prism, mnemonic: 'g') { |ctx| ctx.prism_dismiss_code; nil }
 
       r.register Verb::Definition.new(
         "prism.dismiss-host", "Dismiss all on this host", "Mute every open issue on the selected issue's host",
         Verb::Scope::Prism, mnemonic: 'h') { |ctx| ctx.prism_dismiss_host; nil }
+
+      # Detail-parity actions on the selected row (no need to drill in first).
+      r.register Verb::Definition.new(
+        "prism.open-evidence", "Open evidence", "Open the selected issue's sample flow in History",
+        Verb::Scope::Prism, [Verb::Chord.new("o")]) { |ctx| ctx.prism_open_flow; nil }
+
+      r.register Verb::Definition.new(
+        "prism.replay-evidence", "Replay evidence", "Send the selected issue's sample flow to Replay",
+        Verb::Scope::Prism, [Verb::Chord.new("r")]) { |ctx| ctx.prism_replay_flow; nil }
+
+      r.register Verb::Definition.new(
+        "prism.promote-selected", "Promote to finding", "Create a Finding from the selected issue",
+        Verb::Scope::Prism, [Verb::Chord.new("p")]) { |ctx| ctx.prism_promote; nil }
+
+      r.register Verb::Definition.new(
+        "prism.delete-selected", "Delete issue", "Delete the selected issue",
+        Verb::Scope::Prism, [Verb::Chord.new("d")]) { |ctx| ctx.prism_delete; nil }
 
       r.register Verb::Definition.new(
         "prism.clear", "Clear issues", "Delete all Prism issues for this project", Verb::Scope::Prism,


### PR DESCRIPTION
## Summary

Prism 상세 보기에서만 쓸 수 있던 promote / evidence / delete 액션을 리스트에서도 바로 쓸 수 있게 합니다. 상세로 들어가지 않고도 선택한 행에 대해 `p` promote, `o` evidence, `r` replay, `d` delete가 동작합니다.

## Changes

- **Verbs (Prism list scope)**: `prism.promote-selected`, `prism.open-evidence`, `prism.replay-evidence`, `prism.delete-selected` 등록
- **Runner**: `prism_open_flow` / `prism_replay_flow` / `prism_promote`가 `target_issue`를 사용 (선택 행 또는 열린 상세)
- **Space menu 키 재배치**: `o`/`r`을 evidence/replay에 맞추고, 상세 열기 → `v`, 코드별 dismiss → `g`
- **Hint bar**: 리스트 뷰에 `o flow · r replay · p promote · d delete` 안내 추가
- **Tests**: space menu spec에 Prism list parity 항목 추가

## Test plan

- [x] `crystal spec spec/tui/space_menu_spec.cr spec/tui/prism_view_spec.cr` — 16 examples, 0 failures