### PR TITLE
feat(tui): switch top bar clock to 12-hour format with AM/PM

### DIFF
--- a/spec/tui/foundation_spec.cr
+++ b/spec/tui/foundation_spec.cr
@@ -130,11 +130,11 @@ describe Gori::Tui::Chrome do
     backend = MemoryBackend.new(80, 1)
     screen = Screen.new(backend)
     Chrome.render_top_bar(screen, Rect.new(0, 0, 80, 1),
-      project: "acme", listen: "127.0.0.1:8080", time: "13:37", scope: "scope:2")
+      project: "acme", listen: "127.0.0.1:8080", time: "01:37 PM", scope: "scope:2")
     backend.row(0).should contain("gori")
     backend.row(0).should contain("acme")
     backend.row(0).should contain("scope:2")
-    backend.row(0).should contain("13:37")
+    backend.row(0).should contain("01:37 PM")
     backend.row(0).should_not contain("rec") # capture state moved to the bottom status bar
   end
 end

--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -89,7 +89,7 @@ module Gori::Tui
       x = screen.text(rect.x + 1, rect.y, "gori", Theme.text_bright, Theme.panel, Attribute::Bold)
       screen.text(x + 1, rect.y, "· #{project}", Theme.muted, Theme.panel)
 
-      # right-aligned status chips: scope:N · rules:N · intercept:on(N) · listen · HH:MM
+      # right-aligned status chips: scope:N · rules:N · intercept:on(N) · listen · h:MM AM/PM
       # value-emphasized, dim · separators; the hot intercept state in RED. The clock
       # is the rightmost anchor. (Capture state lives on the bottom status bar.)
       chips = [] of {String, Color}

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1890,7 +1890,7 @@ module Gori::Tui
     # event loop only bumps `dirty` when this string changes (see `last_clock`), so
     # an idle TUI re-renders once a minute, not every second (preserves idle-zero-CPU).
     private def clock_label : String
-      Time.local.to_s("%H:%M")
+      Time.local.to_s("%I:%M %p")
     end
 
     private def rules_label : String


### PR DESCRIPTION
## Summary

Switch the TUI top bar wall clock from 24-hour (`13:37`) to 12-hour with AM/PM (`01:37 PM`).

## Changes

- Update `clock_label` format from `%H:%M` to `%I:%M %p`
- Refresh the chrome comment and foundation spec expectation

## Test plan

- [x] `crystal spec spec/tui/foundation_spec.cr` — 15 examples, 0 failures