### PR TITLE
feat(tui): show running projects with bind address in picker

### DIFF
--- a/spec/capture_status_spec.cr
+++ b/spec/capture_status_spec.cr
@@ -1,0 +1,172 @@
+require "./spec_helper"
+require "file_utils"
+
+private def with_root(&)
+  root = File.tempname("gori-projects")
+  begin
+    yield root
+  ensure
+    FileUtils.rm_rf(root) if Dir.exists?(root)
+  end
+end
+
+describe Gori::CaptureStatus do
+  it "writes, reads, and clears the status sidecar" do
+    dir = File.tempname("gori-status")
+    begin
+      Gori::CaptureStatus.write(dir, "127.0.0.1", 8070, true)
+      File.exists?(Gori::CaptureStatus.path(dir)).should be_true
+
+      status = Gori::CaptureStatus.read(dir)
+      status.should_not be_nil
+      status.not_nil!.host.should eq("127.0.0.1")
+      status.not_nil!.port.should eq(8070)
+      status.not_nil!.listening.should be_true
+
+      Gori::CaptureStatus.clear(dir)
+      File.exists?(Gori::CaptureStatus.path(dir)).should be_false
+      Gori::CaptureStatus.read(dir).should be_nil
+    ensure
+      FileUtils.rm_rf(dir) if Dir.exists?(dir)
+    end
+  end
+
+  it "formats loopback hosts as localhost" do
+    Gori::CaptureStatus.format_endpoint("127.0.0.1", 8070).should eq("localhost:8070")
+    Gori::CaptureStatus.format_endpoint("::1", 9000).should eq("localhost:9000")
+    Gori::CaptureStatus.format_endpoint("0.0.0.0", 8070).should eq("0.0.0.0:8070")
+  end
+end
+
+describe Gori::CaptureLock do
+  it "reports held? when flock is contended on the same lock file" do
+    dir = File.tempname("gori-lock-held")
+    begin
+      Gori::CaptureLock.held?(dir).should be_false
+
+      lock = Gori::CaptureLock.try(dir)
+      lock.should_not be_nil
+      Gori::CaptureLock.held?(dir).should be_true
+
+      lock.not_nil!.close
+      Gori::CaptureLock.held?(dir).should be_false
+    ensure
+      FileUtils.rm_rf(dir) if Dir.exists?(dir)
+    end
+  end
+end
+
+describe Gori::Session, "capture status sidecar" do
+  it "writes status on open and clears on close" do
+    with_root do |root|
+      ca = Gori::Proxy::Tls::CertAuthority.load_or_create(File.join(root, "ca"))
+      registry = Gori::Verbs.registry
+      project = Gori::ProjectRegistry.new(root).create("live")
+      config = Gori::Config.new(listen: "127.0.0.1", port: 0)
+
+      session = Gori::Session.open(config, ca, registry, project)
+      session.capturing?.should be_true
+
+      status = Gori::CaptureStatus.read(project.dir)
+      status.should_not be_nil
+      status.not_nil!.listening.should be_true
+      status.not_nil!.port.should eq(session.proxy.port)
+      Gori::CaptureStatus.format_endpoint(status.not_nil!.host, status.not_nil!.port)
+        .should eq("localhost:#{session.proxy.port}")
+
+      session.close
+      File.exists?(Gori::CaptureStatus.path(project.dir)).should be_false
+    end
+  end
+
+  it "does not write status when opening view-only" do
+    with_root do |root|
+      ca = Gori::Proxy::Tls::CertAuthority.load_or_create(File.join(root, "ca"))
+      registry = Gori::Verbs.registry
+      project = Gori::ProjectRegistry.new(root).temp("shared")
+
+      held = File.open(Gori::CaptureLock.path(project.dir), "w")
+      held.flock_exclusive(blocking: false)
+
+      session = Gori::Session.open(Gori::Config.new(listen: "127.0.0.1", port: 0), ca, registry, project, bind_fallback: true)
+      session.capturing_lock_held?.should be_false
+      Gori::CaptureStatus.read(project.dir).should be_nil
+      session.close
+
+      held.flock_unlock
+      held.close
+    end
+  end
+
+  it "records capture-off when the bind fails but the lock is held" do
+    with_root do |root|
+      ca = Gori::Proxy::Tls::CertAuthority.load_or_create(File.join(root, "ca"))
+      registry = Gori::Verbs.registry
+      reg = Gori::ProjectRegistry.new(root)
+
+      first = Gori::Session.open(Gori::Config.new(listen: "127.0.0.1", port: 0), ca, registry, reg.temp("a"))
+      taken = first.proxy.port
+
+      second = Gori::Session.open(Gori::Config.new(listen: "127.0.0.1", port: taken), ca, registry, reg.temp("b"))
+      second.capturing?.should be_false
+      second.capturing_lock_held?.should be_true
+
+      status = Gori::CaptureStatus.read(second.project.dir)
+      status.should_not be_nil
+      status.not_nil!.listening.should be_false
+      status.not_nil!.port.should eq(taken)
+
+      first.close
+      second.close
+    end
+  end
+
+  it "updates status when capture is toggled off and on" do
+    with_root do |root|
+      ca = Gori::Proxy::Tls::CertAuthority.load_or_create(File.join(root, "ca"))
+      registry = Gori::Verbs.registry
+      project = Gori::ProjectRegistry.new(root).temp("toggle-status")
+      session = Gori::Session.open(Gori::Config.new(listen: "127.0.0.1", port: 0), ca, registry, project)
+
+      session.capturing?.should be_true
+      session.toggle_capture.should be_false
+      off = Gori::CaptureStatus.read(project.dir)
+      off.should_not be_nil
+      off.not_nil!.listening.should be_false
+
+      session.toggle_capture.should be_true
+      on = Gori::CaptureStatus.read(project.dir)
+      on.should_not be_nil
+      on.not_nil!.listening.should be_true
+      on.not_nil!.port.should eq(session.proxy.port)
+
+      session.close
+    end
+  end
+
+  it "updates status when the proxy is rebound" do
+    with_root do |root|
+      ca = Gori::Proxy::Tls::CertAuthority.load_or_create(File.join(root, "ca"))
+      registry = Gori::Verbs.registry
+      project = Gori::ProjectRegistry.new(root).temp("rebind-status")
+      session = Gori::Session.open(Gori::Config.new(listen: "127.0.0.1", port: 0), ca, registry, project)
+
+      session.proxy.rebind("127.0.0.1", 0)
+      session.sync_capture_status!
+      rebound = Gori::CaptureStatus.read(project.dir)
+      rebound.should_not be_nil
+      rebound.not_nil!.listening.should be_true
+      rebound.not_nil!.port.should eq(session.proxy.port)
+
+      session.toggle_capture
+      session.proxy.rebind("127.0.0.1", 9150)
+      session.sync_capture_status!
+      paused = Gori::CaptureStatus.read(project.dir)
+      paused.should_not be_nil
+      paused.not_nil!.listening.should be_false
+      paused.not_nil!.port.should eq(9150)
+
+      session.close
+    end
+  end
+end

--- a/src/gori/capture_lock.cr
+++ b/src/gori/capture_lock.cr
@@ -20,6 +20,19 @@ module Gori
       File.join(dir, LOCK_FILE)
     end
 
+    # Non-blocking probe: true when another LIVE instance already holds the lock.
+    # Opens and immediately releases the lock when free. Non-contention failures
+    # from `try` (EACCES, unwritable dir, …) propagate to the caller.
+    def self.held?(dir : String) : Bool
+      lock = try(dir)
+      if lock
+        lock.close
+        false
+      else
+        true
+      end
+    end
+
     # Try to acquire the project's capture lock WITHOUT blocking. Returns a held
     # CaptureLock (the caller MUST keep it alive for the session and `close` it on
     # session end) when this instance is the capturer, or nil when another LIVE

--- a/src/gori/capture_status.cr
+++ b/src/gori/capture_status.cr
@@ -1,0 +1,65 @@
+require "json"
+
+module Gori
+  # Per-project capture sidecar written by the session that holds the capture lock.
+  # The project picker reads it (together with a flock probe) to show the live bind
+  # address of a project opened in another gori instance. The file alone is NOT
+  # authoritative — only a held `.capture.lock` means the project is live.
+  class CaptureStatus
+    STATUS_FILE = ".capture.status"
+
+    record Status, host : String, port : Int32, listening : Bool
+
+    def self.path(dir : String) : String
+      File.join(dir, STATUS_FILE)
+    end
+
+    def self.write(dir : String, host : String, port : Int32, listening : Bool) : Nil
+      Dir.mkdir_p(dir) unless Dir.exists?(dir)
+      dest = path(dir)
+      tmp = "#{dest}.tmp.#{Process.pid}"
+      payload = {
+        "host"      => host,
+        "port"      => port,
+        "listening" => listening,
+      }.to_json
+      begin
+        File.write(tmp, payload)
+        File.rename(tmp, dest)
+      rescue ex
+        File.delete?(tmp)
+        raise ex
+      end
+    end
+
+    def self.read(dir : String) : Status?
+      parse_file(path(dir))
+    end
+
+    # Parse a status file; nil on missing, corrupt, or partial writes.
+    private def self.parse_file(p : String) : Status?
+      return nil unless File.exists?(p)
+      json = JSON.parse(File.read(p))
+      Status.new(
+        host: json["host"].as_s,
+        port: json["port"].as_i,
+        listening: json["listening"].as_bool,
+      )
+    rescue
+      nil
+    end
+
+    def self.clear(dir : String) : Nil
+      File.delete?(path(dir))
+    end
+
+    # Human-friendly bind label for the picker (127.0.0.1 → localhost).
+    def self.format_endpoint(host : String, port : Int32) : String
+      display_host = case host
+                     when "127.0.0.1", "::1" then "localhost"
+                     else host
+                     end
+      "#{display_host}:#{port}"
+    end
+  end
+end

--- a/src/gori/session.cr
+++ b/src/gori/session.cr
@@ -1,6 +1,7 @@
 require "./config"
 require "./project"
 require "./capture_lock"
+require "./capture_status"
 require "./store"
 require "./rules"
 require "./scope"
@@ -89,7 +90,9 @@ module Gori
             lock = nil
             ex.message || "could not open the project capture lock"
           end
-        new(config, ca, registry, project, store, proxy, events, prism, rules, scope, host_overrides, interceptor, bind_error, lock)
+        session = new(config, ca, registry, project, store, proxy, events, prism, rules, scope, host_overrides, interceptor, bind_error, lock)
+        session.sync_capture_status!
+        session
       rescue ex
         # A store/rules/scope failure (NOT the bind, which is handled above) would
         # otherwise leak the store's writer fiber + db fd, the events channels, the Prism
@@ -126,20 +129,31 @@ module Gori
     # instance). Starting reuses the held lock, or re-acquires it if we were
     # view-only and the other instance has since released it.
     def toggle_capture : Bool
-      if @proxy.listening?
-        @proxy.stop
-        false
-      else
-        @capture_lock ||= CaptureLock.try(@project.dir) # reuse if held, else try to take over
-        return false unless @capture_lock               # still held by another instance
-        @proxy.start(fallback: true)                    # cover a DIFFERENT project's port on resume
-        true
-      end
+      result =
+        if @proxy.listening?
+          @proxy.stop
+          false
+        else
+          @capture_lock ||= CaptureLock.try(@project.dir) # reuse if held, else try to take over
+          return false unless @capture_lock               # still held by another instance
+          @proxy.start(fallback: true)                    # cover a DIFFERENT project's port on resume
+          true
+        end
+      sync_capture_status!
+      result
+    end
+
+    # Refresh the per-project capture sidecar so the project picker can show the
+    # live bind address. No-op when this session doesn't hold the capture lock.
+    def sync_capture_status! : Nil
+      return unless capturing_lock_held?
+      CaptureStatus.write(@project.dir, @proxy.host, @proxy.port, capturing?)
     end
 
     def close : Nil
       @interceptor.release_all # unblock held fibers FIRST so they can write final rows
       @proxy.stop
+      CaptureStatus.clear(@project.dir) if capturing_lock_held?
       @capture_lock.try(&.close) # release the flock so a later open of this project can capture
       # Stop Prism FIRST so its active workers wind down and its passive fiber stops issuing
       # get_flow against a live DB; this also closes the prism_events channel it consumes.

--- a/src/gori/tui/project_picker.cr
+++ b/src/gori/tui/project_picker.cr
@@ -1,4 +1,6 @@
 require "termisu"
+require "../capture_lock"
+require "../capture_status"
 require "../project"
 require "../project_registry"
 require "../fuzzy"
@@ -18,6 +20,12 @@ module Gori::Tui
   # Use arrows + ↵ , ctrl-n/ctrl-t/ctrl-d etc. Returns chosen Project or nil to quit.
   # Monochrome, keyboard-first (Grok Build feel).
   class ProjectPicker
+    # Throttle flock + status-file probes so the 50 ms poll loop doesn't hammer
+    # the filesystem on every visible project row every frame.
+    RUNNING_PROBE_TTL = 400.milliseconds
+
+    record RunningProbe, at : Time::Span, held : Bool, status : CaptureStatus::Status?
+
     def initialize(@term : Termisu, @registry : ProjectRegistry)
       @backend = TermisuBackend.new(@term)
       @projects = @registry.list
@@ -34,6 +42,7 @@ module Gori::Tui
       @confirm = nil.as(ConfirmDialog?)
       @pending_delete = nil.as(Project?)
       @settings = SettingsView.new # the config editor (ctrl-, → :settings mode)
+      @running_cache = {} of String => RunningProbe
     end
 
     def run : Project?
@@ -243,6 +252,7 @@ module Gori::Tui
       if project = @pending_delete
         @registry.delete(project)
         @projects = @registry.list
+        invalidate_running_cache
         @selected = 2
       end
       cancel_confirm
@@ -471,12 +481,12 @@ module Gori::Tui
           bg = is_selected ? Theme.accent_bg : Theme.panel
           screen.fill(Rect.new(box.x + 1, py, cw - 2, 1), bg) if is_selected
           screen.cell(box.x + 1, py, is_selected ? '▎' : ' ', Theme.accent, bg)
-          meta = proj.last_modified.try { |t| relative_time(Time.utc - t) } || "new"
+          meta, meta_fg = project_meta(proj)
           mdw = Screen.display_width(meta)
           name_w = cw - 3 - (mdw + 2)
           screen.text(box.x + 3, py, proj.name, is_selected ? Theme.text_bright : Theme.text, bg, width: [name_w, 1].max)
           meta_x = box.right - mdw - 2
-          screen.text(meta_x, py, meta, Theme.muted, bg) unless meta.empty?
+          screen.text(meta_x, py, meta, meta_fg, bg) unless meta.empty?
         end
       end
 
@@ -576,6 +586,46 @@ module Gori::Tui
       @results_scroll = 0 if @results_scroll < 0
       max_s = [total - list_h, 0].max
       @results_scroll = max_s if @results_scroll > max_s
+    end
+
+    private def invalidate_running_cache : Nil
+      @running_cache.clear
+    end
+
+    private def project_meta(proj : Project) : {String, Color}
+      held, status = probe_running(proj)
+      if held
+        if status && status.listening
+          {"● #{CaptureStatus.format_endpoint(status.host, status.port)}", Theme.green}
+        elsif status
+          {"● off · #{CaptureStatus.format_endpoint(status.host, status.port)}", Theme.yellow}
+        else
+          {"● off", Theme.yellow}
+        end
+      else
+        meta = proj.last_modified.try { |t| relative_time(Time.utc - t) } || "new"
+        {meta, Theme.muted}
+      end
+    end
+
+    private def probe_running(proj : Project) : {Bool, CaptureStatus::Status?}
+      now = Time.monotonic
+      if cached = @running_cache[proj.dir]?
+        return {cached.held, cached.status} if now - cached.at < RUNNING_PROBE_TTL
+      end
+      held, status = fetch_running(proj.dir)
+      @running_cache[proj.dir] = RunningProbe.new(at: now, held: held, status: status)
+      {held, status}
+    end
+
+    private def fetch_running(dir : String) : {Bool, CaptureStatus::Status?}
+      held = CaptureLock.held?(dir)
+      return {false, nil} unless held
+      status = CaptureStatus.read(dir)
+      status ||= CaptureStatus.read(dir) # retry once after a concurrent write
+      {true, status}
+    rescue IO::Error | File::Error
+      {false, nil}
     end
 
     private def relative_time(span : Time::Span) : String

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -3179,6 +3179,7 @@ module Gori::Tui
       return save_msg if Settings.bind_host == proxy.host && Settings.bind_port == proxy.port
       begin
         proxy.rebind(Settings.bind_host, Settings.bind_port)
+        @session.sync_capture_status!
         if @session.capturing?
           "settings saved — now listening on #{proxy.host}:#{proxy.port} (repoint your client)"
         else


### PR DESCRIPTION
## Summary

프로젝트 선택 TUI에서 다른 gori 인스턴스가 열고 있는 프로젝트를 표시합니다.

- capture ON: `● localhost:8070` (green)
- capture OFF: `● off · localhost:8070` (yellow)
- 미실행: 기존 `2h ago` meta 유지

## Implementation

- `.capture.status` JSON sidecar로 프로젝트별 실제 bind 주소 기록
- `.capture.lock` flock probe로 실행 여부 판별 (stale status 파일 오표시 방지)
- Session open/close/toggle/rebind 시 status 동기화
- Picker: 400ms TTL 캐시, IO 예외 fallback, 원자적 status 쓰기

## Test plan

- [x] `crystal spec spec/capture_status_spec.cr`
- [x] `crystal spec spec/project_registry_spec.cr`