### PR TITLE
feat(miner): notification prefs, remembered overlay, and tab UX parity

### DIFF
--- a/spec/miner/inject_spec.cr
+++ b/spec/miner/inject_spec.cr
@@ -94,6 +94,6 @@ describe Gori::Miner::Detect do
   it "offers only query/cookies/headers for a bodyless GET" do
     appl = M::Detect.detect(req("GET /a HTTP/1.1\r\nHost: h\r\n\r\n"))
     appl.applicable.should eq([M::Location::Query, M::Location::Headers, M::Location::Cookies])
-    appl.default.should eq([M::Location::Query, M::Location::Cookies])
+    appl.default.should eq([M::Location::Query])
   end
 end

--- a/spec/miner/notify_mode_spec.cr
+++ b/spec/miner/notify_mode_spec.cr
@@ -1,0 +1,31 @@
+require "../spec_helper"
+
+describe Gori::Miner::NotifyMode do
+  it "round-trips canonical tokens" do
+    Gori::Miner::NotifyMode.values.each do |mode|
+      parsed = Gori::Miner::NotifyMode.parse?(mode.token)
+      parsed.should eq(mode)
+    end
+  end
+
+  it "parses UI labels and legacy aliases" do
+    Gori::Miner::NotifyMode.parse?("when found").should eq(Gori::Miner::NotifyMode::WhenFound)
+    Gori::Miner::NotifyMode.parse?("found").should eq(Gori::Miner::NotifyMode::WhenFound)
+    Gori::Miner::NotifyMode.parse?("on").should eq(Gori::Miner::NotifyMode::Always)
+  end
+
+  describe "#posts_notification?" do
+    it "suppresses completion notifications per mode" do
+      Gori::Miner::NotifyMode::Off.posts_notification?(3).should be_false
+      Gori::Miner::NotifyMode::WhenFound.posts_notification?(0).should be_false
+      Gori::Miner::NotifyMode::WhenFound.posts_notification?(2).should be_true
+      Gori::Miner::NotifyMode::Always.posts_notification?(0).should be_true
+    end
+
+    it "still notifies on errors unless mode is off" do
+      Gori::Miner::NotifyMode::WhenFound.posts_notification?(0, error: true).should be_true
+      Gori::Miner::NotifyMode::Always.posts_notification?(0, error: true).should be_true
+      Gori::Miner::NotifyMode::Off.posts_notification?(0, error: true).should be_false
+    end
+  end
+end

--- a/spec/tui/mine_config_overlay_spec.cr
+++ b/spec/tui/mine_config_overlay_spec.cr
@@ -30,14 +30,41 @@ describe Gori::Tui::MineConfigOverlay do
     ov.build_config.locations.should eq([Gori::Miner::Location::Query, Gori::Miner::Location::Headers])
   end
 
-  it "cycles concurrency on its row and reports the Start row" do
+  it "cycles concurrency and notification on their rows and reports the Start row" do
     ov = MineConfigOverlay.new(seed([Gori::Miner::Location::Query], [Gori::Miner::Location::Query]))
-    # rows: [0]=query, [1]=concurrency, [2]=start
+    # rows: [0]=query, [1]=concurrency, [2]=notification, [3]=start
     ov.move(1) # concurrency row
     ov.adjust(1)
     ov.build_config.concurrency.should eq(20) # default 10 → next choice
-    ov.move(1)                                # start row
+    ov.move(1) # notification row
+    ov.adjust(1)
+    ov.build_config.notify.should eq(Gori::Miner::NotifyMode::Off)
+    ov.move(1) # start row
     ov.on_start_row?.should be_true
+  end
+
+  it "defaults notification to when-found" do
+    ov = MineConfigOverlay.new(seed([Gori::Miner::Location::Query], [Gori::Miner::Location::Query]))
+    ov.build_config.notify.should eq(Gori::Miner::NotifyMode::WhenFound)
+  end
+
+  it "restores the last saved overlay choices from Settings" do
+    Gori::Settings.mine_locations = ["query", "json"]
+    Gori::Settings.mine_concurrency = 20
+    Gori::Settings.mine_notify = "always"
+    Gori::Settings.mine_prefs_saved = true
+    ov = MineConfigOverlay.new(seed(
+      [Gori::Miner::Location::Query, Gori::Miner::Location::Json, Gori::Miner::Location::Headers],
+      [Gori::Miner::Location::Query]))
+    cfg = ov.build_config
+    cfg.locations.should eq([Gori::Miner::Location::Query, Gori::Miner::Location::Json])
+    cfg.concurrency.should eq(20)
+    cfg.notify.should eq(Gori::Miner::NotifyMode::Always)
+  ensure
+    Gori::Settings.mine_locations = [] of String
+    Gori::Settings.mine_concurrency = 10
+    Gori::Settings.mine_notify = "when-found"
+    Gori::Settings.mine_prefs_saved = false
   end
 
   it "renders without crashing and maps a click to a row" do

--- a/spec/tui/miner_view_spec.cr
+++ b/spec/tui/miner_view_spec.cr
@@ -1,0 +1,15 @@
+require "../spec_helper"
+
+describe Gori::Tui::MinerView do
+  it "round-trips notify mode in session config JSON" do
+    view = Gori::Tui::MinerView.new
+    view.load("http://h.test", "GET /a HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice, false, nil,
+      Gori::Miner::Config.new(notify: Gori::Miner::NotifyMode::WhenFound))
+    json = view.config_json
+    restored = Gori::Tui::MinerView.new
+    restored.restore(Gori::Store::MinerSessionRecord.new(
+      id: 1, target: "http://h.test", request: Bytes.empty, http2: false, sni: nil,
+      config: json, flow_id: nil, position: 0, name: nil))
+    restored.config.notify.should eq(Gori::Miner::NotifyMode::WhenFound)
+  end
+end

--- a/src/gori/miner/detect.cr
+++ b/src/gori/miner/detect.cr
@@ -26,11 +26,10 @@ module Gori::Miner
         default << Location::Json
       end
 
-      # Cookies always apply and default ON; headers apply but default OFF (noisy,
-      # multiplies the request budget, and infra often strips/echoes them).
+      # Cookies/headers always apply; both default OFF (noisy, multiplies the
+      # request budget, and infra often strips/echoes them).
       applicable << Location::Headers
       applicable << Location::Cookies
-      default << Location::Cookies
 
       Applicability.new(applicable, default)
     end

--- a/src/gori/miner/types.cr
+++ b/src/gori/miner/types.cr
@@ -70,6 +70,48 @@ module Gori
       end
     end
 
+    # When a background mine posts to the notification center on completion.
+    # Persisted/config tokens: "when-found", "off", "always" (see #token / .parse?).
+    enum NotifyMode
+      WhenFound # default — only when at least one parameter was discovered
+      Off       # never post a completion notification
+      Always    # always post, even when zero parameters were found
+
+      def label : String
+        case self
+        in WhenFound then "when found"
+        in Off       then "off"
+        in Always    then "always"
+        end
+      end
+
+      # Canonical persisted token (round-trips through JSON config).
+      def token : String
+        case self
+        in WhenFound then "when-found"
+        in Off       then "off"
+        in Always    then "always"
+        end
+      end
+
+      # True when a finished mine should post to the notification center.
+      def posts_notification?(found : Int32, error : Bool = false) : Bool
+        return false if off?
+        return true if error
+        return false if when_found? && found == 0
+        true
+      end
+
+      def self.parse?(token : String) : NotifyMode?
+        norm = token.downcase.strip.gsub(/[\s_]+/, "-")
+        case norm
+        when "when-found", "whenfound", "found" then WhenFound
+        when "off", "none", "no"                then Off
+        when "always", "on", "all"              then Always
+        end
+      end
+    end
+
     # One discovered parameter.
     record Finding,
       name : String,
@@ -134,6 +176,7 @@ module Gori
       property max_requests : Int64?    # hard cap on total sends
       property? add_content_length_when_missing : Bool
       property user_wordlist : String?
+      property notify : NotifyMode
 
       # Per-Burp ceilings; query/form are additionally clamped by the URL byte budget
       # in Inject so a stuffed line can't exceed common request-line limits.
@@ -150,7 +193,8 @@ module Gori
                      @concurrency = 10, @rps = nil, @throttle_ms = nil, @jitter_ms = 0,
                      @timeout = nil, @retries = 1, @retry_pause = 500.milliseconds,
                      @stability_rounds = 4, @confirm_rounds = 2, @max_requests = nil,
-                     @add_content_length_when_missing = false, @user_wordlist = nil)
+                     @add_content_length_when_missing = false, @user_wordlist = nil,
+                     @notify = NotifyMode::WhenFound)
       end
 
       def bucket_for(loc : Location) : Int32

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -63,6 +63,12 @@ module Gori
     class_property convert_chain : String = ""
     class_property convert_sessions : Array({String, String, String}) = [] of {String, String, String}
     class_property convert_chains : Array({String, String}) = [] of {String, String}
+    # Last Mine-parameters overlay choices (global scratch — not project data).
+    # locations: checked location labels; concurrency/notify mirror the overlay.
+    class_property mine_locations : Array(String) = [] of String
+    class_property mine_concurrency : Int32 = 10
+    class_property mine_notify : String = "when-found"
+    class_property? mine_prefs_saved : Bool = false
 
     def self.path : String
       File.join(Paths.home_dir, "settings.json")
@@ -93,6 +99,7 @@ module Gori
         self.convert_sessions = parse_convert_sessions(cv["sessions"]?)
         self.convert_chains = parse_convert_chains(cv["chains"]?)
       end
+      parse_mine_prefs(root["mine"]?)
     rescue
       # no file yet / unreadable / bad JSON — keep current values
     end
@@ -186,6 +193,29 @@ module Gori
       return unless h = node.try(&.as_h?)
       self.keymap_os = normalize_os(h["os"]?.try(&.as_s?))
       self.keymap_overrides = parse_keymap_bindings(h["bindings"]?)
+    end
+
+    private def self.parse_mine_prefs(node : JSON::Any?) : Nil
+      obj = node.try(&.as_h?)
+      unless obj
+        self.mine_prefs_saved = false
+        return
+      end
+      self.mine_prefs_saved = true
+      if locs = obj["locations"]?.try(&.as_a?)
+        self.mine_locations = locs.compact_map(&.as_s?).map(&.downcase.strip).reject(&.empty?)
+      end
+      obj["concurrency"]?.try(&.as_i?).try { |n| self.mine_concurrency = n }
+      obj["notify"]?.try(&.as_s?).try { |s| self.mine_notify = s }
+    end
+
+    # Persist the overlay's last confirmed choices (called when mining starts).
+    def self.save_mine_prefs(locations : Array(String), concurrency : Int32, notify : String) : Nil
+      self.mine_locations = locations.map(&.downcase.strip).reject(&.empty?)
+      self.mine_concurrency = concurrency
+      self.mine_notify = notify
+      self.mine_prefs_saved = true
+      save
     end
 
     private def self.parse_keymap_bindings(node : JSON::Any?) : Hash(String, Array(String))
@@ -293,6 +323,17 @@ module Gori
           # preserve the legacy input/chain scalars so an un-opened Convert tab never loses
           # them. (`all?` is vacuously true for an empty array.)
           sessions_blank = convert_sessions.all? { |(i, c, n)| i.empty? && c.empty? && n.empty? }
+          if mine_prefs_saved?
+            j.field "mine" do
+              j.object do
+                j.field "locations" do
+                  j.array { mine_locations.each { |l| j.string l } }
+                end
+                j.field "concurrency", mine_concurrency
+                j.field "notify", mine_notify
+              end
+            end
+          end
           unless sessions_blank && convert_chains.empty? && convert_input.empty? && convert_chain.empty?
             j.field "convert" do
               j.object do

--- a/src/gori/tui/controllers/miner_controller.cr
+++ b/src/gori/tui/controllers/miner_controller.cr
@@ -54,6 +54,12 @@ module Gori::Tui
       @miners.map_with_index { |t, i| "#{i + 1}:#{t.view.label(18)}" }
     end
 
+    # Show the strip from the FIRST session (not ≥2): a single mine still labels its
+    # chip and exposes the strip's space-menu (^W close). Empty → no strip.
+    def subtab_strip_shown? : Bool
+      !@miners.empty?
+    end
+
     def subtab_index : Int32
       @current_idx
     end
@@ -72,7 +78,7 @@ module Gori::Tui
       case v.focus
       when :results then "↑/↓ select · ↵ detail · ^X stop · space cmds · ↹ pane · esc tabs"
       when :detail  then "↑/↓ scroll · esc back"
-      else               "↓ findings · ^X stop · ↹ pane · esc tabs"
+      else               "↓ findings · ^X stop · space cmds · ↹ pane · esc tabs"
       end
     end
 
@@ -80,7 +86,7 @@ module Gori::Tui
     def render_body(screen : Screen, rect : Rect, focus : Symbol) : Nil
       body_focused = focus == :body
       body_rect = rect
-      if @miners.size >= 2
+      if subtab_strip_shown?
         sub_rect, body_rect = BodyChrome.carve_subtab_row(rect)
         BodyChrome.render_subtab_strip(screen, sub_rect, subtab_labels, @current_idx, focus == :subtabs)
       end
@@ -100,7 +106,7 @@ module Gori::Tui
       # instead of swallowing it, so the empty Miner tab isn't an input dead-end (^P
       # palette, escape, digit jumps, space all stay live). New runs start upstream.
       return false if v.nil?
-      if v.focus == :results && ev.key.space? && !ev.ctrl? && !ev.alt?
+      if navigable_pane?(v.focus) && ev.key.space? && !ev.ctrl? && !ev.alt?
         @host.open_space_menu
         return true
       end
@@ -119,6 +125,10 @@ module Gori::Tui
       else               return false
       end
       true
+    end
+
+    private def navigable_pane?(pane : Symbol) : Bool
+      pane == :summary || pane == :results
     end
 
     private def chord_action(ev : Termisu::Event::Key, c : Char?) : Symbol?
@@ -154,7 +164,7 @@ module Gori::Tui
       if key.down?
         v.focus_pane(:results)
       elsif key.up?
-        @host.request_focus(@miners.size >= 2 ? :subtabs : :menu)
+        @host.request_focus(subtab_strip_shown? ? :subtabs : :menu)
       end
     end
 
@@ -163,7 +173,7 @@ module Gori::Tui
       case
       when key.enter? then v.open_detail
       when key.down?  then v.results_move(1)
-      when key.up?    then v.at_top? ? @host.request_focus(@miners.size >= 2 ? :subtabs : :menu) : v.results_move(-1)
+      when key.up?    then v.at_top? ? @host.request_focus(subtab_strip_shown? ? :subtabs : :menu) : v.results_move(-1)
       end
     end
 
@@ -177,7 +187,7 @@ module Gori::Tui
     end
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
-      body = @miners.size >= 2 ? BodyChrome.carve_subtab_row(rect)[1] : rect
+      body = subtab_strip_shown? ? BodyChrome.carve_subtab_row(rect)[1] : rect
       return true unless v = current_view
       if pane = v.pane_at(body, mx, my)
         v.focus_pane(pane) unless pane == :detail
@@ -220,7 +230,7 @@ module Gori::Tui
 
     # --- sub-tab nav ---
     def move_subtab(dir : Int32) : Nil
-      return unless @miners.size >= 2
+      return unless subtab_strip_shown? && @miners.size >= 2
       @current_idx = (@current_idx + dir).clamp(0, @miners.size - 1)
     end
 
@@ -378,7 +388,7 @@ module Gori::Tui
       when Miner::ErrorEvent
         v.finish_run
         @host.jobs.finish(v.job_id, :error, ev.message)
-        @host.notifications.push(:error, "Miner: #{ev.message} on #{v.summary}", goto_for(v))
+        push_mine_notification(v, :error, "Miner: #{ev.message} on #{v.summary}")
         @host.status("miner error: #{ev.message}")
       end
     end
@@ -386,10 +396,15 @@ module Gori::Tui
     private def finish_job(v : MinerView, ev : Miner::DoneEvent) : Nil
       n = v.found_count
       @host.jobs.finish(v.job_id, :done, "#{n} found")
-      level = n > 0 ? :success : :info
       msg = "Miner: #{n} param#{n == 1 ? "" : "s"} found on #{v.summary}#{ev.stopped ? " (stopped)" : ""}"
-      @host.notifications.push(level, msg, goto_for(v))
+      level = n > 0 ? :success : :info
+      push_mine_notification(v, level, msg, found: n)
       @host.status(msg)
+    end
+
+    private def push_mine_notification(v : MinerView, level : Symbol, msg : String, found : Int32 = 0) : Nil
+      return unless v.config.notify.posts_notification?(found, error: level == :error)
+      @host.notifications.push(level, msg, goto_for(v))
     end
 
     private def goto_for(v : MinerView) : Jobs::Goto?

--- a/src/gori/tui/mine_config_overlay.cr
+++ b/src/gori/tui/mine_config_overlay.cr
@@ -2,6 +2,7 @@ require "./screen"
 require "./theme"
 require "./frame"
 require "../miner"
+require "../settings"
 
 module Gori::Tui
   # Everything needed to start a mining session, captured from History/Replay when the
@@ -17,11 +18,13 @@ module Gori::Tui
     applicable : Array(Miner::Location),
     default : Array(Miner::Location)
 
-  # The small config popup shown before a mine starts: adaptive location checkboxes +
-  # a concurrency cycler + a Start row. No text field (so no IME plumbing). On Start the
-  # Runner reads build_config + seed and hands them to the MinerController.
+  # The small config popup shown before a mine starts: adaptive location checkboxes,
+  # concurrency + notification cyclers, and a Start row. No text field (so no IME
+  # plumbing). Restores the last confirmed overlay choices from Settings when present.
+  # On Start the Runner reads build_config + seed and hands them to the MinerController.
   class MineConfigOverlay
     CONC_CHOICES = [5, 10, 20, 40]
+    NOTIFY_CHOICES = Miner::NotifyMode.values
 
     getter seed : MineSeed
 
@@ -29,20 +32,47 @@ module Gori::Tui
       @checked = Hash(Miner::Location, Bool).new
       @seed.applicable.each { |l| @checked[l] = @seed.default.includes?(l) }
       @conc_idx = CONC_CHOICES.index(10) || 1
+      @notify_idx = NOTIFY_CHOICES.index(Miner::NotifyMode::WhenFound) || 0
       @selected = 0
+      restore_saved_prefs
     end
 
-    # Rows: one per applicable location, then the concurrency cycler, then Start.
+    # Remember the last confirmed overlay for the next History/Replay mine.
+    def save_prefs : Nil
+      locs = @seed.applicable.select { |l| @checked[l]? }.map(&.label)
+      notify = NOTIFY_CHOICES[@notify_idx].token
+      Settings.save_mine_prefs(locs, CONC_CHOICES[@conc_idx], notify)
+    end
+
+    private def restore_saved_prefs : Nil
+      return unless Settings.mine_prefs_saved?
+      saved = Settings.mine_locations.to_set
+      @seed.applicable.each do |loc|
+        @checked[loc] = saved.includes?(loc.label)
+      end
+      if idx = CONC_CHOICES.index(Settings.mine_concurrency)
+        @conc_idx = idx
+      end
+      if mode = Miner::NotifyMode.parse?(Settings.mine_notify)
+        @notify_idx = NOTIFY_CHOICES.index(mode) || @notify_idx
+      end
+    end
+
+    # Rows: one per applicable location, then concurrency + notification cyclers, then Start.
     private def row_count : Int32
-      @seed.applicable.size + 2
+      @seed.applicable.size + 3
     end
 
     private def conc_row : Int32
       @seed.applicable.size
     end
 
-    private def start_row : Int32
+    private def notify_row : Int32
       @seed.applicable.size + 1
+    end
+
+    private def start_row : Int32
+      @seed.applicable.size + 2
     end
 
     def on_start_row? : Bool
@@ -58,16 +88,18 @@ module Gori::Tui
     end
 
     def adjust(d : Int32) : Nil
-      return unless @selected == conc_row
-      @conc_idx = (@conc_idx + d) % CONC_CHOICES.size
+      case @selected
+      when conc_row   then @conc_idx = (@conc_idx + d) % CONC_CHOICES.size
+      when notify_row then @notify_idx = (@notify_idx + d) % NOTIFY_CHOICES.size
+      end
     end
 
-    # Space/Enter on a location row flips its checkbox; on the concurrency row it cycles.
+    # Space/Enter on a location row flips its checkbox; cyclers advance on space.
     def toggle : Nil
       if @selected < @seed.applicable.size
         loc = @seed.applicable[@selected]
         @checked[loc] = !(@checked[loc]? || false)
-      elsif @selected == conc_row
+      elsif @selected == conc_row || @selected == notify_row
         adjust(1)
       end
     end
@@ -76,6 +108,7 @@ module Gori::Tui
       c = Miner::Config.new
       c.locations = @seed.applicable.select { |l| @checked[l]? }
       c.concurrency = CONC_CHOICES[@conc_idx]
+      c.notify = NOTIFY_CHOICES[@notify_idx]
       c
     end
 
@@ -120,6 +153,9 @@ module Gori::Tui
       elsif i == conc_row
         screen.text(x, py, "concurrency:", Theme.muted, bg)
         screen.text(x + 13, py, "#{CONC_CHOICES[@conc_idx]}  ‹/›", sel ? Theme.text_bright : Theme.text, bg)
+      elsif i == notify_row
+        screen.text(x, py, "notification:", Theme.muted, bg)
+        screen.text(x + 14, py, "#{NOTIFY_CHOICES[@notify_idx].label}  ‹/›", sel ? Theme.text_bright : Theme.text, bg)
       else
         label = any_checked? ? "[ Start mining ]" : "[ select a location ]"
         screen.text(x, py, label, any_checked? ? Theme.accent : Theme.muted, bg, Attribute::Bold)

--- a/src/gori/tui/miner_view.cr
+++ b/src/gori/tui/miner_view.cr
@@ -232,6 +232,7 @@ module Gori::Tui
             j.array { @config.locations.each { |l| j.string l.label } }
           end
           j.field "concurrency", @config.concurrency
+          j.field "notify", @config.notify.token
           j.field "stability_rounds", @config.stability_rounds
           j.field "confirm_rounds", @config.confirm_rounds
           j.field "buckets" do
@@ -252,6 +253,7 @@ module Gori::Tui
         @config.locations = parsed unless parsed.empty?
       end
       any["concurrency"]?.try(&.as_i?).try { |n| @config.concurrency = n }
+      any["notify"]?.try(&.as_s?).try { |s| Miner::NotifyMode.parse?(s) }.try { |m| @config.notify = m }
       any["stability_rounds"]?.try(&.as_i?).try { |n| @config.stability_rounds = n }
       any["confirm_rounds"]?.try(&.as_i?).try { |n| @config.confirm_rounds = n }
       if buckets = any["buckets"]?.try(&.as_h?)

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1542,6 +1542,7 @@ module Gori::Tui
       case @active_tab
       when :replay  then replay_controller.request_close
       when :fuzzer  then fuzzer_controller.request_close
+      when :miner   then miner_controller.request_close
       when :convert then convert_controller.convert_close
       when :notes   then notes_controller.notes_close
       end
@@ -1551,6 +1552,7 @@ module Gori::Tui
       case @active_tab
       when :replay  then replay_controller.save_current_replay
       when :fuzzer  then fuzzer_controller.save_current
+      when :miner   then miner_controller.save_current
       when :convert then convert_controller.commit
       when :notes   then notes_controller.save_notes
       end
@@ -2962,6 +2964,7 @@ module Gori::Tui
         @toast = "select at least one location to mine"
         return
       end
+      ov.save_prefs
       miner_controller.start_session(ov.seed, ov.build_config)
       close_mine_config
     end


### PR DESCRIPTION
## Summary

- Add **notification** setting to the Mine parameters overlay (`when found` / `off` / `always`) and gate background-job alerts accordingly
- **Remember** the last confirmed overlay choices (locations, concurrency, notification) in global `settings.json`
- Bring **Miner tab UX** in line with Replay/Fuzzer: sub-tab strip from the first session, `space` command menu on summary/results, `^W` close from body and sub-tab strip
- **Exclude cookies** from default checked mining locations (still available manually)

## Test plan

- [x] `crystal spec` — 1076 examples, 0 failures
- [x] `spec/miner/notify_mode_spec.cr` — notify token round-trip and gating matrix
- [x] `spec/tui/mine_config_overlay_spec.cr` — overlay UI + saved prefs restore
- [x] `spec/tui/miner_view_spec.cr` — session config JSON round-trip
- [x] `spec/miner/inject_spec.cr` — cookies no longer default-on