### PR TITLE
fix(miner): gate completion toast by NotifyMode

### DIFF
--- a/src/gori/tui/controllers/miner_controller.cr
+++ b/src/gori/tui/controllers/miner_controller.cr
@@ -402,7 +402,7 @@ module Gori::Tui
         v.finish_run
         @host.jobs.finish(v.job_id, :error, ev.message)
         push_mine_notification(v, :error, "Miner: #{ev.message} on #{v.summary}")
-        @host.status("miner error: #{ev.message}")
+        @host.status("miner error: #{ev.message}") if v.config.notify.posts_notification?(0, error: true)
       end
     end
 
@@ -412,7 +412,7 @@ module Gori::Tui
       msg = "Miner: #{n} param#{n == 1 ? "" : "s"} found on #{v.summary}#{ev.stopped ? " (stopped)" : ""}"
       level = n > 0 ? :success : :info
       push_mine_notification(v, level, msg, found: n)
-      @host.status(msg)
+      @host.status(msg) if v.config.notify.posts_notification?(n)
     end
 
     private def push_mine_notification(v : MinerView, level : Symbol, msg : String, found : Int32 = 0) : Nil


### PR DESCRIPTION
## Summary
- The Miner's completion toast (`@host.status(...)` in `finish_job` and the `ErrorEvent` branch of `MinerController#apply_event`) fired unconditionally, regardless of the configured `NotifyMode` (when-found / off / always).
- Only the durable notification-center entry (`push_mine_notification`) was actually gated by `posts_notification?` — so users who set "notify when found" still saw a completion message on every run, even with zero params found.
- Fix: gate both `@host.status(...)` calls with the same `v.config.notify.posts_notification?(...)` check used for the durable push.

## Test plan
- [x] `crystal build --no-codegen src/gori.cr` — typecheck clean
- [x] `crystal tool format --check src/gori/tui/controllers/miner_controller.cr` — clean
- [x] `crystal spec` — 1085 examples, 0 failures