### PR TITLE
feat(tui): keyboard-flow consistency, keymap-drift fixes, roomier space menu

### DIFF
--- a/spec/tui/miner_view_spec.cr
+++ b/spec/tui/miner_view_spec.cr
@@ -12,4 +12,14 @@ describe Gori::Tui::MinerView do
       config: json, flow_id: nil, position: 0, name: nil))
     restored.config.notify.should eq(Gori::Miner::NotifyMode::WhenFound)
   end
+
+  it "fronts a custom name on the sub-tab label (the rename path now wired for Miner)" do
+    view = Gori::Tui::MinerView.new
+    view.load("http://h.test", "GET /a HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice, false, nil,
+      Gori::Miner::Config.new)
+    auto = view.label(18)
+    view.name = "login probe" # MinerController#apply_rename sets this
+    view.label(18).should contain("login")
+    view.label(18).should_not eq(auto) # the custom name overrides the derived summary
+  end
 end

--- a/spec/tui/palette_spec.cr
+++ b/spec/tui/palette_spec.cr
@@ -118,6 +118,50 @@ describe Gori::Tui::PaletteState do
     ids.should contain("import.oas")
   end
 
+  it "renders a verb's EFFECTIVE chord so a rebind is reflected (not the default)" do
+    prev = Gori::Settings.keymap_overrides
+    begin
+      ctx = FakeExecContext.new
+      palette = PaletteState.new(Gori::Verbs.registry)
+      palette.reset(ctx)
+      "Toggle capture".each_char { |c| palette.append(c, ctx) } # capture.toggle (default: c)
+
+      # Default binding: the rebound label is nowhere on screen yet.
+      Gori::Settings.keymap_overrides = {} of String => Array(String)
+      base = MemoryBackend.new(80, 24)
+      palette.render(Screen.new(base), Rect.new(0, 0, 80, 24))
+      base.contains?("ctrl-y").should be_false
+
+      # Rebind capture.toggle → ^Y; the palette's chord column must follow the keymap.
+      Gori::Settings.keymap_overrides = {"capture.toggle" => ["ctrl-y"]}
+      rebound = MemoryBackend.new(80, 24)
+      palette.render(Screen.new(rebound), Rect.new(0, 0, 80, 24))
+      rebound.contains?("ctrl-y").should be_true
+    ensure
+      Gori::Settings.keymap_overrides = prev
+    end
+  end
+
+  it "ignores a hand-edited override for a FIXED verb so it can't advertise a dead chord" do
+    prev = Gori::Settings.keymap_overrides
+    begin
+      ctx = FakeExecContext.new
+      palette = PaletteState.new(Gori::Verbs.registry)
+      palette.reset(ctx)
+      "Command palette".each_char { |c| palette.append(c, ctx) } # app.palette (FIXED: ^P hardcoded)
+
+      # A hand-edited settings.json binds the FIXED app.palette to ctrl-y. Dispatch drops it
+      # (rebindable? == false) and ^P still opens the palette — so the palette must NOT show it.
+      Gori::Settings.keymap_overrides = {"app.palette" => ["ctrl-y"]}
+      backend = MemoryBackend.new(80, 24)
+      palette.render(Screen.new(backend), Rect.new(0, 0, 80, 24))
+      backend.contains?("ctrl-y").should be_false # the dead override is filtered out
+      backend.contains?("ctrl-p").should be_true  # the real (default, hardcoded) chord shows
+    ensure
+      Gori::Settings.keymap_overrides = prev
+    end
+  end
+
   it "prints a colour-coded category sigil before each entry" do
     ctx = FakeExecContext.new
     palette = PaletteState.new(Gori::Verbs.registry)

--- a/spec/tui/space_menu_spec.cr
+++ b/spec/tui/space_menu_spec.cr
@@ -173,6 +173,40 @@ describe Gori::Tui::SpaceMenu do
     backend.contains?(first).should be_false                # the top entries scrolled off
   end
 
+  it "grows past the old 12-row cap to fit a busy scope without scrolling (History Body has 13)" do
+    # ctx-independent: 15 synthetic entries on a tall body. Old MAX_ROWS=12 clamped the
+    # popup to 14 rows (scrolling 3 off); now it grows to fit all 15 (cap 16).
+    reg = Gori::Verb::Registry.new
+    15.times do |i|
+      reg.register(Gori::Verb::Definition.new(
+        "demo.#{i}", "Item #{i}", "x", Gori::Verb::Scope::Body, mnemonic: ('a'.ord + i).unsafe_chr) { |_| nil })
+    end
+    menu = SpaceMenu.new(reg)
+    menu.open(Gori::Verb::Scope::Body, FakeExecContext.new)
+    menu.entries.size.should eq(15)
+
+    b = menu.box(Rect.new(0, 0, 60, 40)) # tall body — height is entry-bound, not body-bound
+    b.h.should eq(15 + 2)                # all 15 rows + frame; the old cap would have clamped to 14
+
+    backend = MemoryBackend.new(60, 40)
+    menu.render(Screen.new(backend), Rect.new(0, 0, 60, 40))
+    backend.contains?("Item 0").should be_true  # first entry shown
+    backend.contains?("Item 14").should be_true # AND the last — nothing clipped
+    backend.contains?("▼").should be_false      # so no scroll marker
+  end
+
+  it "draws a ▼ scroll marker when entries are hidden below (short terminal)" do
+    ctx = FakeExecContext.new
+    ctx.selected = 5_i64
+    menu = SpaceMenu.new(Gori::Verbs.registry)
+    menu.open(Gori::Verb::Scope::Body, ctx) # selection at the top → list clipped at the bottom
+
+    backend = MemoryBackend.new(40, 8)
+    menu.render(Screen.new(backend), Rect.new(0, 0, 40, 6)) # ~4 rows fit, 13 entries
+    backend.contains?("▼").should be_true                   # "more below" affordance is visible
+    backend.contains?("▲").should be_false                  # nothing hidden above at the top
+  end
+
   # Per menu scope, the keyed entries must never collide, and any verb with NO chord
   # at all must carry a mnemonic (else it's unreachable by ANY single key — the
   # oversight this guards). A verb whose only chord is ctrl/shift (e.g. Replay's
@@ -194,6 +228,42 @@ describe Gori::Tui::SpaceMenu do
       verbs.select(&.chords.empty?).all?(&.menu_key).should be_true # chordless ⇒ keyed
       keys = verbs.compact_map(&.menu_key)
       keys.uniq.size.should eq(keys.size) # no two entries collide on one key
+    end
+  end
+
+  # Registry#validate_menu_keys! turns the convention above into a BOOT-TIME invariant:
+  # Verbs.registry calls it, so a colliding menu key crashes at startup instead of
+  # silently shadowing a verb (SpaceMenu#verb_for is a first-match find).
+  describe "Registry#validate_menu_keys!" do
+    it "passes on the shipped registry" do
+      Gori::Verbs.registry.validate_menu_keys! # builds + re-checks; must not raise
+    end
+
+    it "raises on two verbs sharing a menu key WITHIN one scope" do
+      reg = Gori::Verb::Registry.new
+      reg.register(Gori::Verb::Definition.new("demo.a", "demo:a", "first",
+        Gori::Verb::Scope::Body, [Gori::Verb::Chord.new("z")]) { |_| nil })
+      reg.register(Gori::Verb::Definition.new("demo.b", "demo:b", "second",
+        Gori::Verb::Scope::Body, mnemonic: 'z') { |_| nil }) # derives the same 'z'
+      expect_raises(Gori::Error, /space-menu key collision/) { reg.validate_menu_keys! }
+    end
+
+    it "allows the same menu key across DIFFERENT scopes (scoped menu, deliberate reuse)" do
+      reg = Gori::Verb::Registry.new
+      reg.register(Gori::Verb::Definition.new("demo.a", "demo:a", "first",
+        Gori::Verb::Scope::Body, [Gori::Verb::Chord.new("z")]) { |_| nil })
+      reg.register(Gori::Verb::Definition.new("demo.b", "demo:b", "second",
+        Gori::Verb::Scope::Replay, [Gori::Verb::Chord.new("z")]) { |_| nil })
+      reg.validate_menu_keys! # cross-scope reuse must not raise
+    end
+
+    it "ignores hidden verbs (not shown in the menu, so their key can't collide)" do
+      reg = Gori::Verb::Registry.new
+      reg.register(Gori::Verb::Definition.new("demo.a", "demo:a", "shown",
+        Gori::Verb::Scope::Body, [Gori::Verb::Chord.new("z")]) { |_| nil })
+      reg.register(Gori::Verb::Definition.new("demo.hidden", "demo:hidden", "hidden",
+        Gori::Verb::Scope::Body, [Gori::Verb::Chord.new("z")], hidden: true) { |_| nil })
+      reg.validate_menu_keys! # the hidden verb never fronts a menu key
     end
   end
 end

--- a/src/gori/hotkeys.cr
+++ b/src/gori/hotkeys.cr
@@ -3,10 +3,12 @@ require "./settings"
 
 module Gori
   # Facade over the hotkey engine (Verb::Keymap / OsProfile / Reserved / Conflicts) and
-  # the persisted Settings. The read-path the DISPATCH keymap (`build_keymap`) and the
-  # settings:hotkeys editor share for a verb's effective chord. NOTE: the Help tab and the
-  # status-bar hints still show DEFAULT chords (a documented limitation — they don't route
-  # through here), so a rebind isn't reflected there.
+  # the persisted Settings. The read-path the DISPATCH keymap (`build_keymap`), the
+  # settings:hotkeys editor, and the command PALETTE (via #binding_for) share for a verb's
+  # effective chord — so a rebind is reflected in the palette's chord column. NOTE: the
+  # Help tab and the status-bar hints are still curated DEFAULT-chord prose (a documented
+  # limitation — they don't route through here); a rebind isn't reflected in those, which
+  # is why the Help tab points users to settings:hotkeys.
   module Hotkeys
     # Selectable OS default profiles (the Settings.keymap_os domain). "auto" tracks the
     # build's native platform.
@@ -35,12 +37,19 @@ module Gori
     # Build the dispatch keymap from the registry under the persisted OS profile + user
     # overrides. Replaces the bare Verb::Keymap.build at its call sites.
     def self.build_keymap(registry : Verb::Registry) : Verb::Keymap
-      # Drop overrides for verbs the editor would never let you rebind (hidden nav
-      # primitives, fixed ids, multi-chord nav-alias verbs) — a hand-edited settings.json
-      # could otherwise install one and collapse a verb's structural chords (e.g. enter/
-      # arrows on body.open), the exact case the editor's rebindable? gate prevents.
-      overrides = chord_overrides.select { |id, _| (v = registry[id]?) && rebindable?(v) }
-      Verb::Keymap.build(registry, Verb::OsProfile.resolve(Settings.keymap_os), overrides)
+      Verb::Keymap.build(registry, Verb::OsProfile.resolve(Settings.keymap_os), rebindable_overrides(registry))
+    end
+
+    # The user overrides that actually reach the dispatch keymap: chord_overrides minus
+    # any id the editor would never let you rebind (hidden nav primitives, FIXED ids,
+    # multi-chord nav-alias verbs). A hand-edited settings.json could otherwise install one
+    # and collapse a verb's structural chords (e.g. enter/arrows on body.open) — the case
+    # the editor's rebindable? gate prevents. The command PALETTE resolves its shown chord
+    # through THIS set (not raw chord_overrides), so its column can never advertise a chord
+    # dispatch would drop — build_keymap and the palette must agree, so they share this one
+    # filter rather than duplicating it.
+    def self.rebindable_overrides(registry : Verb::Registry) : Hash(String, Array(Verb::Chord))
+      chord_overrides.select { |id, _| (v = registry[id]?) && rebindable?(v) }
     end
 
     # The persisted user overrides, parsed from Settings' label strings into Chords. A

--- a/src/gori/tui/controllers/comparer_controller.cr
+++ b/src/gori/tui/controllers/comparer_controller.cr
@@ -39,7 +39,7 @@ module Gori::Tui
       when key.down?, key.lower_j?
         @view.scroll(1)
         true
-      when key.left?, key.right?
+      when key.left?, key.right?, key.lower_h?, key.lower_l?
         @view.toggle_pane
         true
       when key.escape?

--- a/src/gori/tui/controllers/convert_controller.cr
+++ b/src/gori/tui/controllers/convert_controller.cr
@@ -441,8 +441,8 @@ module Gori::Tui
       s = cur
       key = ev.key
       case
-      when key.up?                 then s.view.output_at_top? ? (s.pane = :chain) : s.view.scroll_output(-1)
-      when key.down?               then s.view.scroll_output(1)
+      when key.up?, key.lower_k?   then s.view.output_at_top? ? (s.pane = :chain) : s.view.scroll_output(-1)
+      when key.down?, key.lower_j? then s.view.scroll_output(1)
       when key.left? && ev.shift?  then s.view.hscroll_output(-1)
       when key.right? && ev.shift? then s.view.hscroll_output(1)
       end

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -87,7 +87,7 @@ module Gori::Tui
       when :target   then "type URL · ↵/↓ template · ^R run · ↹ pane · esc tabs"
       when :template then "type · ^A params · ^K word · ^T point · ^U clear · ^O config · ^R run · ^N new · ↹ pane"
       when :config   then config_hint(v)
-      when :results  then "↑/↓ select · ↵ detail · o sort · m matched · ^R run · ^X stop · space cmds · ↹ pane"
+      when :results  then "↑/↓ select · ↵ detail · o sort · m matched · v dist · ^R run · ^X stop · space cmds · ↹ pane"
       when :detail   then "↑/↓ scroll · ←/→ pane · ⇧←/→ h-scroll · esc back"
       else                "↹/esc tabs"
       end
@@ -273,20 +273,20 @@ module Gori::Tui
     private def handle_results(ev : Termisu::Event::Key, v : FuzzerView) : Nil
       key = ev.key
       case
-      when key.enter?   then v.open_detail
-      when key.up?      then v.at_top? ? @host.request_focus(subtab_strip_shown? ? :subtabs : :menu) : v.results_move(-1)
-      when key.down?    then v.results_move(1)
-      when key.lower_o? then @host.status(v.cycle_sort)
-      when key.lower_m? then @host.status(v.toggle_matched_only)
-      when key.lower_v? then @host.status(v.toggle_dist)
+      when key.enter?              then v.open_detail
+      when key.up?, key.lower_k?   then v.at_top? ? @host.request_focus(subtab_strip_shown? ? :subtabs : :menu) : v.results_move(-1)
+      when key.down?, key.lower_j? then v.results_move(1)
+      when key.lower_o?            then @host.status(v.cycle_sort)
+      when key.lower_m?            then @host.status(v.toggle_matched_only)
+      when key.lower_v?            then @host.status(v.toggle_dist)
       end
     end
 
     private def handle_detail(ev : Termisu::Event::Key, v : FuzzerView) : Nil
       key = ev.key
       case
-      when key.up?                 then v.detail_scroll(-1)
-      when key.down?               then v.detail_scroll(1)
+      when key.up?, key.lower_k?   then v.detail_scroll(-1)
+      when key.down?, key.lower_j? then v.detail_scroll(1)
       when key.left? && ev.shift?  then v.hscroll_detail(-1)
       when key.right? && ev.shift? then v.hscroll_detail(1)
       when key.left?               then v.detail_step_pane(-1)

--- a/src/gori/tui/controllers/miner_controller.cr
+++ b/src/gori/tui/controllers/miner_controller.cr
@@ -161,9 +161,9 @@ module Gori::Tui
 
     private def handle_summary(ev : Termisu::Event::Key, v : MinerView) : Nil
       key = ev.key
-      if key.down?
+      if key.down? || key.lower_j?
         v.focus_pane(:results)
-      elsif key.up?
+      elsif key.up? || key.lower_k?
         @host.request_focus(subtab_strip_shown? ? :subtabs : :menu)
       end
     end
@@ -171,17 +171,17 @@ module Gori::Tui
     private def handle_results(ev : Termisu::Event::Key, v : MinerView) : Nil
       key = ev.key
       case
-      when key.enter? then v.open_detail
-      when key.down?  then v.results_move(1)
-      when key.up?    then v.at_top? ? @host.request_focus(subtab_strip_shown? ? :subtabs : :menu) : v.results_move(-1)
+      when key.enter?              then v.open_detail
+      when key.down?, key.lower_j? then v.results_move(1)
+      when key.up?, key.lower_k?   then v.at_top? ? @host.request_focus(subtab_strip_shown? ? :subtabs : :menu) : v.results_move(-1)
       end
     end
 
     private def handle_detail(ev : Termisu::Event::Key, v : MinerView) : Nil
       key = ev.key
-      if key.up?
+      if key.up? || key.lower_k?
         v.detail_scroll(-1)
-      elsif key.down?
+      elsif key.down? || key.lower_j?
         v.detail_scroll(1)
       end
     end

--- a/src/gori/tui/controllers/notes_controller.cr
+++ b/src/gori/tui/controllers/notes_controller.cr
@@ -160,7 +160,7 @@ module Gori::Tui
     end
 
     def body_hint(focus : Symbol) : String
-      "type to edit · ^N new · ^W close · ^G goto · ^F find · ^B ws · ^1-9 · space l links · ↑ sub-tabs · ↹/esc tabs"
+      "type to edit · ^N new · ^W close · ^G goto · ^F find · ^1-9 · ↑ sub-tabs (space l links) · ↹/esc tabs"
     end
 
     def goto_symbol : Symbol?

--- a/src/gori/tui/controllers/prism_controller.cr
+++ b/src/gori/tui/controllers/prism_controller.cr
@@ -68,6 +68,23 @@ module Gori::Tui
       true
     end
 
+    # The issue detail (remediation + affected URLs) is read-only and can be long, so
+    # give it keyboard scroll (↑/↓/j/k) to match every other detail view — otherwise it
+    # was reachable only by the mouse wheel. Everything else (list nav, the o/r/p/c/d
+    # actions, space) defers to the central keymap by returning false. When the detail is
+    # closed we claim nothing, so the list's scoped verbs still run.
+    def handle_body_key(ev : Termisu::Event::Key) : Bool
+      return false unless @prism.detail_open?
+      return false if ev.ctrl? || ev.alt?
+      key = ev.key
+      case
+      when key.up?, key.lower_k?   then @prism.scroll_detail(-1)
+      when key.down?, key.lower_j? then @prism.scroll_detail(1)
+      else                              return false
+      end
+      true
+    end
+
     # The `/` filter bar — a text sub-mode the shell claims before the focus ring (mirrors
     # Findings). Live filtering: every edit re-derives the visible list inside the view.
     def handle_query_key(ev : Termisu::Event::Key) : Bool

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -50,7 +50,7 @@ module Gori::Tui
           ? "type \"IP host\" · ↵ save · esc cancel" \
           : "↑/↓ move · ↑ scope · → desc · a add · ↵/e edit · d del · space cmds · esc"
       else
-        "type to edit · ↑/↓/↔ move · ← scope · ^G goto · ^F find · ^B ws · esc tabs"
+        "type to edit · ↑/↓/↔ move · ← scope · ^G goto · ^F find · esc tabs"
       end
     end
 
@@ -205,15 +205,15 @@ module Gori::Tui
       elsif key.escape?
         save
         @host.request_focus(:menu)
-      elsif key.up?
-        if @project_view.scope_at_top? # ↑ on the first rule pops up to the tab bar
+      elsif key.up? || key.lower_k?
+        if @project_view.scope_at_top? # ↑/k on the first rule pops up to the tab bar
           save
           @host.request_focus(:menu)
         else
           @project_view.scope_select(-1)
         end
-      elsif key.down?
-        if @project_view.scope_at_bottom? # ↓ on the last rule drops into HOST OVERRIDES (the card below)
+      elsif key.down? || key.lower_j?
+        if @project_view.scope_at_bottom? # ↓/j on the last rule drops into HOST OVERRIDES (the card below)
           @project_view.focus_pane(:overrides)
         else
           @project_view.scope_select(1)
@@ -314,13 +314,13 @@ module Gori::Tui
       elsif key.escape?
         save
         @host.request_focus(:menu)
-      elsif key.up?
-        if @project_view.ov_at_top? # ↑ on the first override crosses up to the SCOPE pane
+      elsif key.up? || key.lower_k?
+        if @project_view.ov_at_top? # ↑/k on the first override crosses up to the SCOPE pane
           @project_view.pane_advance(-1)
         else
           @project_view.ov_select(-1)
         end
-      elsif key.down?
+      elsif key.down? || key.lower_j?
         @project_view.ov_select(1)
       elsif key.left?
         @project_view.pane_advance(-1) # ← back to SCOPE (the pane above-left)

--- a/src/gori/tui/controllers/replay_controller.cr
+++ b/src/gori/tui/controllers/replay_controller.cr
@@ -117,7 +117,7 @@ module Gori::Tui
       case v.focus
       when :target   then v.editing_sni? ? "type SNI host · ^S/↵/esc back to URL · ^R send" \
                                           : "type URL · ^S SNI · ↵/↓ request · ^R send · ↹ pane · esc tabs"
-      when :response then "↑/↓ scroll · ←/→/d diff · ⇧←/→ h-scroll · x hex · p pretty · ^F find · ^R send · space cmds · ↹ pane · esc tabs"
+      when :response then "↑/↓ scroll · ←/→/d diff · ⇧←/→ h-scroll · x hex · p pretty · ^F find · ↵/^R send · space cmds · ↹ pane · esc tabs"
       else                "type to edit · ^R send · ^G goto · ^F find · ^X hex · ^B ws · ^N new · ^W close · ↹ pane · esc tabs"
       end
     end
@@ -753,9 +753,9 @@ module Gori::Tui
       # ^F search; pretty= resets the scroll), so gate them out after the nav keys.
       transcript = view.ws_mode? || view.grpc_mode?
       case
-      when key.enter?            then replay_send
-      when key.up?               then view.at_top? ? view.focus_first : view.scroll(-1) # ↑-at-top → target field above
-      when key.down?             then view.scroll(1)
+      when key.enter?              then replay_send
+      when key.up?, key.lower_k?   then view.at_top? ? view.focus_first : view.scroll(-1) # ↑/k-at-top → target field above
+      when key.down?, key.lower_j? then view.scroll(1)
       when transcript            then nil
       when key.left?, key.right? then view.toggle_resp_mode
       when key.lower_d?          then view.toggle_resp_mode

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -18,6 +18,7 @@ module Gori::Tui
         {"space", "focus-area action menu"},
         {"c", "toggle capture"},
         {"s · m", "scope lens · Match & Replace rules"},
+        {"n", "notification center (or click the notify:N badge)"},
         {"^B", "reveal whitespace (·→␍␊)"},
         {"^D / ^C ×2", "quit gori"},
         {"q", "back to projects (on the tab bar)"},

--- a/src/gori/tui/palette.cr
+++ b/src/gori/tui/palette.cr
@@ -2,6 +2,7 @@ require "./screen"
 require "./theme"
 require "./frame"
 require "../verb"
+require "../hotkeys"
 
 module Gori::Tui
   # The command palette overlay (Ctrl-P) — the GORI-WIDE app-control surface:
@@ -98,6 +99,11 @@ module Gori::Tui
         return
       end
       ensure_visible(list_h)
+      # Resolve chords through the EFFECTIVE keymap (user override → OS profile → default)
+      # so a rebind is reflected here — the palette is the app's discovery surface. Uses the
+      # SAME filtered set the dispatch keymap does (Hotkeys.rebindable_overrides), so the
+      # column can never advertise a chord that dispatch drops. Parsed once, not per row.
+      overrides = Hotkeys.rebindable_overrides(@registry)
       (0...list_h).each do |i|
         idx = @scroll + i
         break if idx >= @results.size
@@ -121,7 +127,7 @@ module Gori::Tui
         if soon
           badge = "soon"
           screen.text(box.right - badge.size - 2, ry, badge, Theme.yellow, bg)
-        elsif chord = verb.chords.first?
+        elsif chord = Hotkeys.binding_for(@registry, verb.id, overrides)
           hint = chord.label
           screen.text(box.right - hint.size - 2, ry, hint, Theme.muted, bg)
         end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -95,15 +95,15 @@ module Gori::Tui
       @search_target = :none
       @search_hits = [] of Int32
       @search_idx = 0
-      # The sub-tab rename prompt (Replay + Fuzzer) — orthogonal to @overlay (floats over
-      # the bottom status row, like ^G/^F).
+      # The sub-tab rename prompt (Replay + Fuzzer + Convert + Miner) — orthogonal to
+      # @overlay (floats over the bottom status row, like ^G/^F).
       @rename_open = false
       @rename_buffer = ""
       @rename_preedit = ""
       # The target is held by VIEW identity (not a positional index): the cross-session
       # reconcile can reorder/remove replay tabs while the prompt is open, so the
       # controller's apply_rename re-finds the tab by its view — never a shifted neighbour.
-      @rename_view = nil.as(ReplayView | FuzzerView | ConvertView | Nil)
+      @rename_view = nil.as(ReplayView | FuzzerView | ConvertView | MinerView | Nil)
       # The import path prompt (palette → import:har/urls/oas) — bottom-anchored like
       # ^G/^F, with filesystem tab-completion via PathComplete.
       @import_open = false
@@ -658,7 +658,7 @@ module Gori::Tui
       end
     end
 
-    # Right-click: rename a Replay/Fuzzer sub-tab chip (the one context menu we have).
+    # Right-click: rename a Replay/Fuzzer/Convert/Miner sub-tab chip (the one context menu we have).
     # Only acts on the sub-tab strip; anywhere else is a no-op (no left-click side effects).
     private def handle_right_click(layout : Layout, mx : Int32, my : Int32) : Nil
       return unless renameable_subtabs? && @overlay == :none && !@space_menu_open && !@rename_open && subtabs_shown?
@@ -695,7 +695,7 @@ module Gori::Tui
     private def modal_overlay? : Bool
       case @overlay
       when :palette, :rules, :finding_new, :confirm, :browser, :choice, :comparer_pick, :replay_subtab, :links, :finding_pick, :note_pick, :settings, :tabs, :hotkeys, :notifications, :mine_config then true
-      else                                                                                                                                                            false
+      else                                                                                                                                                                                               false
       end
     end
 
@@ -1251,7 +1251,7 @@ module Gori::Tui
                      when .replay? then replay_controller.db_id_at(idx)
                      when .fuzz?   then fuzzer_controller.db_id_at(idx)
                      when .miner?  then miner_controller.db_id_at(idx)
-                     else             nil
+                     else               nil
                      end
                    end
           if rid = ref_id
@@ -1319,10 +1319,10 @@ module Gori::Tui
       when key.escape? then close_links_overlay
       when key.up?     then lo.move(-1)
       when key.down?   then lo.move(1)
-      when key.enter?       then open_selected_link(lo)
-      when c == 'o'         then open_selected_link(lo)
-      when c == 'd'         then remove_selected_link(lo)
-      when c == 'a'         then lo.start_add
+      when key.enter?  then open_selected_link(lo)
+      when c == 'o'    then open_selected_link(lo)
+      when c == 'd'    then remove_selected_link(lo)
+      when c == 'a'    then lo.start_add
       end
     end
 
@@ -1520,7 +1520,7 @@ module Gori::Tui
     end
 
     private def commit_link_to_owner(owner_kind : Store::LinkOwnerKind, owner_id : Int64,
-                                   ref_kind : Store::LinkRefKind, ref_id : Int64) : Bool
+                                     ref_kind : Store::LinkRefKind, ref_id : Int64) : Bool
       if @session.store.add_link(owner_kind, owner_id, ref_kind, ref_id)
         @toast = "linked"
         refresh_link_owners(owner_kind, owner_id)
@@ -1866,7 +1866,7 @@ module Gori::Tui
       when ev.ctrl? && c && '1' <= c <= '9'
         jump_subtab(c.to_i - 1) # switch + stay on the strip
       when rename_chord?(ev)
-        open_rename(current_subtab_index) # rename the active sub-tab (Replay/Fuzzer)
+        open_rename(current_subtab_index) # rename the active sub-tab (Replay/Fuzzer/Convert/Miner)
       when key.left?, key.lower_h?
         move_subtab(-1)
       when key.right?, key.lower_l?
@@ -1885,13 +1885,25 @@ module Gori::Tui
     # Sub-tab new/close/commit dispatched across the multi-session tabs. The active
     # tab is matched explicitly (NOT an `else → notes`): tabs with a FIXED strip
     # (Help) also expose subtab_labels, so a stray ^N/^W/^P-commit from their strip
-    # must no-op here, never leak into Notes.
+    # must no-op here, never leak into Notes. :miner is intentionally absent — mining
+    # sessions are seeded by a background job (History/Replay → "Mine parameters"),
+    # not created in-place, so ^N is a deliberate no-op on the Miner strip (its
+    # body_hint never advertises it). Rename/close still work.
     private def subtab_new : Nil
       case @active_tab
       when :replay  then replay_controller.replay_new
       when :fuzzer  then fuzzer_controller.fuzz_new
       when :convert then convert_controller.convert_new
       when :notes   then notes_controller.notes_new
+      end
+    end
+
+    # The strips where ^N creates a sub-tab (mirrors subtab_new's cases). Miner is excluded
+    # — its sessions are seeded by a background job, not ^N — so the strip hint omits ^N new.
+    private def subtab_new_supported? : Bool
+      case @active_tab
+      when :replay, :fuzzer, :convert, :notes then true
+      else                                         false
       end
     end
 
@@ -2361,6 +2373,11 @@ module Gori::Tui
             return "←/→ switch sub-tab · ↓/↵ enter · ^1-9 jump · ↑/esc tabs"
           end
           rn = renameable_subtabs? ? " · r rename" : ""
+          # Miner sessions are background-seeded (^N is a no-op) and its body is a read-only
+          # table (↵ ENTERS, doesn't edit) — drop the ^N/edit tokens that fit editor strips.
+          unless subtab_new_supported?
+            return "←/→ switch sub-tab · ↓/↵ enter · ^1-9 jump · ^W close · space cmds#{rn} · ↑/esc tabs"
+          end
           return "←/→ switch sub-tab · ↓/↵ edit · ^1-9 jump · ^N new · ^W close · space cmds#{rn} · ↑/esc tabs"
         end
         body_hints
@@ -2583,10 +2600,10 @@ module Gori::Tui
       renameable_subtabs? && ev.key.lower_r? && !ev.ctrl? && !ev.alt?
     end
 
-    # The tabs whose sub-tab chips carry a custom name (Replay + Fuzzer + Convert).
+    # The tabs whose sub-tab chips carry a custom name (Replay + Fuzzer + Convert + Miner).
     # Notes derives its label from the body text, so it has no rename.
     private def renameable_subtabs? : Bool
-      @active_tab == :replay || @active_tab == :fuzzer || @active_tab == :convert
+      @active_tab == :replay || @active_tab == :fuzzer || @active_tab == :convert || @active_tab == :miner
     end
 
     # Open the rename prompt for sub-tab `idx` on the active tab, seeding its current
@@ -2598,6 +2615,7 @@ module Gori::Tui
              when :replay  then replay_controller.view_at(idx)
              when :fuzzer  then fuzzer_controller.view_at(idx)
              when :convert then convert_controller.view_at(idx)
+             when :miner   then miner_controller.view_at(idx)
              end
       return unless view
       @rename_view = view
@@ -2621,6 +2639,7 @@ module Gori::Tui
       when ReplayView  then replay_controller.apply_rename(v, name)
       when FuzzerView  then fuzzer_controller.apply_rename(v, name)
       when ConvertView then convert_controller.apply_rename(v, name)
+      when MinerView   then miner_controller.apply_rename(v, name)
       end
     end
 

--- a/src/gori/tui/space_menu.cr
+++ b/src/gori/tui/space_menu.cr
@@ -17,7 +17,12 @@ module Gori::Tui
   # Pure input/state + rendering; the Runner owns opening/closing, capturing the
   # scope, and executing the selection.
   class SpaceMenu
-    MAX_ROWS = 12 # tallest popup (scopes have far fewer verbs; scrolling deferred)
+    # Tallest popup before it scrolls. Sized to clear the busiest scope (History's
+    # Body has 13 menu entries) with headroom, so the common case never scrolls; when
+    # it does (a short terminal, or a future scope with more verbs) render() draws
+    # ▲/▼ markers. box() still clamps the height to the body, so this is only the
+    # "don't grow past this even on a tall terminal" ceiling.
+    MAX_ROWS = 16
 
     getter selected : Int32
 
@@ -83,6 +88,7 @@ module Gori::Tui
       Frame.card(screen, b, "SPACE", border: Theme.border_focus)
       rows = b.h - 2
       ensure_visible(rows)
+      visible = {rows, @entries.size - @scroll}.min # rows actually drawn this frame
       (0...rows).each do |i|
         idx = @scroll + i
         break if idx >= @entries.size
@@ -94,8 +100,28 @@ module Gori::Tui
         screen.cell(b.x + 1, ry, active ? '▎' : ' ', Theme.accent, bg)
         screen.text(b.x + 2, ry, v.menu_key.to_s, Theme.accent, bg, Attribute::Bold)
         title_fg = active ? Theme.text_bright : Theme.text
-        screen.text(b.x + 4, ry, v.title, title_fg, bg, width: {b.w - 5, 0}.max)
+        # Reserve the rightmost interior col for the scroll marker (below) so a
+        # widest-title row can't paint over it.
+        screen.text(b.x + 4, ry, v.title, title_fg, bg, width: {b.w - 6, 0}.max)
+        if mark = scroll_marker(i, visible, rows)
+          screen.cell(b.right - 2, ry, mark, Theme.muted, bg)
+        end
       end
+    end
+
+    # The scroll affordance for row `i`: ▲ on the top row when entries are hidden
+    # above, ▼ on the bottom row when hidden below, ↕ when a 1-row viewport hides
+    # both — so it's obvious the popup scrolls (nil = list fully shown, no marker).
+    # Mirrors settings_view's marker convention.
+    private def scroll_marker(i : Int32, visible : Int32, rows : Int32) : Char?
+      above = @scroll > 0
+      below = @scroll + rows < @entries.size
+      first = i == 0
+      last = i == visible - 1
+      return '↕' if first && last && above && below
+      return '▲' if first && above
+      return '▼' if last && below
+      nil
     end
 
     # Scroll so the selection stays visible when the popup is shorter than the

--- a/src/gori/verb/registry.cr
+++ b/src/gori/verb/registry.cr
@@ -26,6 +26,28 @@ module Gori
         @by_id[id]? || raise Gori::Error.new("unknown verb id: #{id}")
       end
 
+      # Fail fast on a per-scope space-menu key collision. Two non-hidden verbs in the
+      # SAME scope deriving the same menu_key (an explicit mnemonic, else the first plain
+      # single-char chord) means the later one is silently unreachable by that key —
+      # SpaceMenu#verb_for is a first-match find, so the collision has no other symptom.
+      # Cross-scope reuse is fine (the space menu is scoped), so this checks WITHIN each
+      # scope only, mirroring Conflicts' same-scope rule. space_menu_spec asserts the same
+      # invariant; calling this at build time makes it a boot-time guarantee, like the
+      # duplicate verb-id raise in #register.
+      def validate_menu_keys! : Nil
+        seen = Hash(Scope, Hash(Char, String)).new
+        each do |verb|
+          next if verb.hidden?
+          next unless key = verb.menu_key
+          scope_keys = (seen[verb.scope] ||= {} of Char => String)
+          if prior = scope_keys[key]?
+            raise Gori::Error.new(
+              "space-menu key collision: '#{key}' claimed by both #{prior} and #{verb.id} in #{verb.scope}")
+          end
+          scope_keys[key] = verb.id
+        end
+      end
+
       def each(& : Definition ->)
         @order.each { |id| yield @by_id[id] }
       end

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -258,6 +258,7 @@ module Gori
       register_convert(r)
       register_notes(r)
       register_host_overrides(r)
+      r.validate_menu_keys! # fail fast if any scope has a colliding space-menu key
       r
     end
   end


### PR DESCRIPTION
## Summary

A UX pass over gori's keyboard flow — the result of a source audit, implementation, and an adversarial multi-agent review of the diff. Focused on consistency and discoverability, no behavior removed.

### Keyboard-flow consistency
- **`j/k` parity** in every read-only/nav pane that lacked it: Replay response, Fuzzer results+detail, Miner results+detail+summary, Convert output, and the Project scope + host-overrides lists. `j/k` already worked in the browse tabs; now it works everywhere a tester reads.
- **Prism detail keyboard scroll** — previously mouse-wheel only (a keyboard dead-end for long issue detail). New `PrismController#handle_body_key`, gated on `detail_open?` so the list keeps its scoped-verb nav.
- **Comparer `h/l`** pane toggle (it already had `j/k`).
- **Miner sub-tab rename** wired up — it was fully implemented but unreachable dead code.
- **Hint fixes**: Replay response now shows `↵/^R send` (Enter silently re-fired a request), Fuzzer results shows `v dist`, the no-op `^B ws` is dropped from Notes/Project editors, and Help lists the `n` notification center.

### Keymap drift
- The **command palette** chord column now resolves through the effective keymap (`Hotkeys.binding_for`) so a rebind is reflected — filtered the same way the dispatch keymap is, so a hand-edited FIXED-id binding can't advertise a chord that never dispatches.
- **`Registry#validate_menu_keys!`** makes per-scope space-menu key uniqueness a boot-time invariant (was convention-only, guarded only by a spec).

### Space menu sizing
- Raised `SpaceMenu::MAX_ROWS` 12 → 16 (History's Body scope has **13** entries — "Mine parameters" was clipped at 12) and added `▲/▼/↕` scroll markers so clipping is visible on short terminals.

## Notes
- A durable-notification reframe explored during this work was **dropped** in favour of #73's merged approach (which gates the completion toast and the log together by `NotifyMode`). This branch is rebased on top of #73 and does not touch that logic.
- `Help`/status-bar hints are deliberately **not** converted to derive from the keymap — they're free-form prose; the palette covers the rebind-discovery need.

## Verification
- Full suite **1094 examples, 0 failures**; typecheck + `crystal tool format` clean (except the two files the formatter pre-existingly crashes on); no new ameba findings.
- New specs: palette reflects a rebind + ignores FIXED-id hand-edits; registry collision detection; SpaceMenu grows past 12 + shows the scroll marker when clipped; Miner rename label.
- Live E2E (tmux, real proxy traffic): `j/k` scroll the Replay response, palette renders chords, Help shows the `n` entry, and the History space menu now shows all 13 entries with a `▼` cue when a short terminal clips it.