### PR TITLE
feat(replay,fuzzer): transform-on-send Convert chains on marked positions

### DIFF
--- a/spec/fuzz_spec.cr
+++ b/spec/fuzz_spec.cr
@@ -123,6 +123,63 @@ describe F::Template do
       F::Template.marked_spans(t).size.should eq(F::Template.parse(t).position_count)
     end
   end
+
+  # --- inline Convert chains (§value¦chain§) ---
+  it "splits a marker's interior on the first unescaped ¦ into {default, chain}" do
+    t = F::Template.parse("tok=§secret¦base64-encode > url-encode§")
+    t.position_count.should eq(1)
+    t.positions.first.default.should eq("secret")
+    t.positions.first.chain.should eq("base64-encode > url-encode") # chain may contain '>' / '|' / ','
+  end
+
+  it "treats a chain-less marker as chain == \"\" (backward compatible)" do
+    F::Template.parse("v=§x§").positions.first.chain.should eq("")
+  end
+
+  it "escapes ¦¦ to a literal ¦ inside the value or chain" do
+    t = F::Template.parse("§a¦¦b¦rot13§") # value 'a¦b', chain 'rot13'
+    t.positions.first.default.should eq("a¦b")
+    t.positions.first.chain.should eq("rot13")
+  end
+
+  it "renders defaults through their chains via apply_chains (failure → untransformed)" do
+    reg = Gori::Convert.default_registry
+    t = F::Template.parse("a=§hi¦base64-encode§&b=§keep¦nope-unknown§&c=§plain§")
+    out = String.new(t.render(t.apply_chains(t.default_payloads, reg)))
+    out.should eq("a=aGk=&b=keep&c=plain") # base64(hi)=aGk=; unknown chain passes through; no chain untouched
+  end
+
+  it "marked_spans still counts chained markers 1:1 with positions" do
+    t = "a=§1¦base64-encode§&b=§2§"
+    F::Template.marked_spans(t).size.should eq(F::Template.parse(t).position_count)
+  end
+
+  it "clear_markers drops the marker AND its chain" do
+    F::Template.clear_markers("tok=§secret¦base64-encode§&x=1").should eq("tok=secret&x=1")
+  end
+
+  it "mark_word unmark strips a stray ¦chain, not just the § delimiters" do
+    # cursor inside the marker → unmark leaves the raw value only (no dangling ¦base64-encode)
+    F::Template.mark_word("tok=§secret¦base64-encode§", 8).should eq("tok=secret")
+  end
+
+  it "chain_at / set_chain read and write the marker under the cursor" do
+    text = "a=§1§&b=§2¦rot13§"
+    F::Template.chain_at(text, 3).should eq("")        # cursor in the first (chain-less) marker
+    F::Template.chain_at(text, 10).should eq("rot13")  # cursor in the second marker
+    F::Template.chain_at("plain", 2).should be_nil     # not in a marker
+    # attach a chain to the first marker
+    F::Template.set_chain(text, 3, "base64-encode").should eq("a=§1¦base64-encode§&b=§2¦rot13§")
+    # clearing (empty) removes the ¦chain
+    F::Template.set_chain(text, 10, "").should eq("a=§1§&b=§2§")
+  end
+
+  it "marker_regions exposes the value|chain split for tinting" do
+    # "a=§1¦rot13§" → open at 2, ¦ at 4, close at 10
+    F::Template.marker_regions("a=§1¦rot13§").should eq([{2, 4, 10}])
+    # chain-less marker: sep == close
+    F::Template.marker_regions("a=§1§").should eq([{2, 4, 4}])
+  end
 end
 
 describe F::ContentLength do
@@ -236,6 +293,26 @@ describe F::Generator do
     seen = 0
     g.each { seen += 1 }
     seen.should eq(9)
+  end
+
+  it "applies a position's inline Convert chain to the payload on the wire" do
+    reg = Gori::Convert.default_registry
+    chained = F::Template.parse("GET /?a=§1¦base64-encode§&b=§2§ HTTP/1.1\r\nHost: h\r\n\r\n")
+    s1 = F::PayloadSet.new(F::InlineList.new(["hi"]))
+    g = F::Generator.new(chained, [s1], F::Config.new(mode: F::Mode::BatteringRam), registry: reg)
+    bytes = [] of String
+    g.each { |j| bytes << String.new(j.bytes) }
+    # position a carries base64(hi)=aGk=; position b (no chain) gets the raw payload.
+    bytes.first.should eq("GET /?a=aGk=&b=hi HTTP/1.1\r\nHost: h\r\n\r\n")
+  end
+
+  it "leaves payloads untransformed when no registry is supplied (3-arg constructor)" do
+    chained = F::Template.parse("GET /?a=§1¦base64-encode§ HTTP/1.1\r\nHost: h\r\n\r\n")
+    s1 = F::PayloadSet.new(F::InlineList.new(["hi"]))
+    g = F::Generator.new(chained, [s1], F::Config.new(mode: F::Mode::BatteringRam))
+    bytes = [] of String
+    g.each { |j| bytes << String.new(j.bytes) }
+    bytes.first.should eq("GET /?a=hi HTTP/1.1\r\nHost: h\r\n\r\n")
   end
 end
 

--- a/spec/store/entity_links_spec.cr
+++ b/spec/store/entity_links_spec.cr
@@ -65,6 +65,7 @@ describe "entity_links (V21)" do
         "INSERT INTO findings (id, created_at, updated_at, title, severity, host, flow_id, notes, status) " \
         "VALUES (1, 5, 5, 'legacy', 2, 'a.test', ?, '', 0)", fid)
       store.@db.exec("DROP TABLE entity_links")
+      store.@db.exec("ALTER TABLE replays DROP COLUMN mark_transform") # V22 (added a column to a pre-V17 table)
       store.@db.exec("PRAGMA user_version = 20")
       store.close
 

--- a/spec/store/store_spec.cr
+++ b/spec/store/store_spec.cr
@@ -41,10 +41,11 @@ describe Gori::Store do
       # Simulate a DB last migrated before V18: drop the post-V17 tables and roll
       # user_version back to 17 (e.g. a project created on the hostname-overrides branch).
       store = Gori::Store.open(path)
-      store.@db.exec("DROP TABLE sitemap_tags")   # V18
-      store.@db.exec("DROP TABLE miner_sessions") # V19
-      store.@db.exec("DROP TABLE prism_issues")   # V20
-      store.@db.exec("DROP TABLE entity_links")   # V21
+      store.@db.exec("DROP TABLE sitemap_tags")                        # V18
+      store.@db.exec("DROP TABLE miner_sessions")                      # V19
+      store.@db.exec("DROP TABLE prism_issues")                        # V20
+      store.@db.exec("DROP TABLE entity_links")                        # V21
+      store.@db.exec("ALTER TABLE replays DROP COLUMN mark_transform") # V22 (added a column to a pre-V17 table)
       store.@db.exec("PRAGMA user_version = 17")
       store.close
 

--- a/spec/store_replays_spec.cr
+++ b/spec/store_replays_spec.cr
@@ -120,4 +120,22 @@ describe "Gori::Store replay tabs (v9)" do
       r.response_error.should eq("connect failed: a.test:443")
     end
   end
+
+  it "round-trips the V22 mark_transform flag (default off, insert + update)" do
+    with_store do |store|
+      # defaults to false when the arg is omitted (existing call sites keep working)
+      id = store.insert_replay("https://a.test", "GET / HTTP/1.1\r\n\r\n", false, true, nil, 0)
+      store.replays.find!(&.id.==(id)).mark_transform?.should be_false
+      store.get_replay(id).not_nil!.mark_transform?.should be_false
+
+      # explicit on via insert
+      on = store.insert_replay("https://b.test", "GET / HTTP/1.1\r\n\r\n", false, true, nil, 1, mark_transform: true)
+      store.replays.find!(&.id.==(on)).mark_transform?.should be_true
+      store.replays_meta.find!(&.id.==(on)).mark_transform?.should be_true
+
+      # flip it via update
+      store.update_replay(id, "https://a.test", "GET / HTTP/1.1\r\n\r\n", false, true, mark_transform: true)
+      store.replays.find!(&.id.==(id)).mark_transform?.should be_true
+    end
+  end
 end

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -79,6 +79,18 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def replay_toggle_auto_content_length : Nil; end
 
+  def replay_toggle_mark_transform : Nil; end
+
+  def replay_auto_mark : Nil; end
+
+  def replay_mark_word : Nil; end
+
+  def replay_insert_marker : Nil; end
+
+  def replay_clear_marks : Nil; end
+
+  def replay_attach_chain : Nil; end
+
   def fuzz_selected : Nil; end
 
   def fuzz_from_replay : Nil; end
@@ -90,6 +102,8 @@ class FakeExecContext < Gori::Verb::ExecContext
   def fuzz_new : Nil; end
 
   def fuzz_automark : Nil; end
+
+  def fuzz_attach_chain : Nil; end
 
   def mine_selected : Nil; end
 

--- a/spec/tui/chain_pane_spec.cr
+++ b/spec/tui/chain_pane_spec.cr
@@ -1,0 +1,43 @@
+require "../spec_helper"
+
+include Gori::Tui
+
+# A key event that types `c` (explicit char overrides the key's own to_char).
+private def char_key(c : Char) : Termisu::Event::Key
+  Termisu::Event::Key.new(Termisu::Input::Key::LowerA, char: c)
+end
+
+private def key(k : Termisu::Input::Key) : Termisu::Event::Key
+  Termisu::Event::Key.new(k)
+end
+
+describe Gori::Tui::ChainPane do
+  it "loads and returns a chain value" do
+    pane = ChainPane.new
+    pane.load("base64-encode > url-encode")
+    pane.value.should eq("base64-encode > url-encode")
+  end
+
+  it "types characters into the chain (consuming the keys)" do
+    pane = ChainPane.new
+    pane.load("")
+    pane.handle_key(char_key('m')).should be_true
+    "d5".each_char { |c| pane.handle_key(char_key(c)) }
+    pane.value.should eq("md5")
+  end
+
+  it "backspaces at the caret" do
+    pane = ChainPane.new
+    pane.load("hex")
+    pane.handle_key(key(Termisu::Input::Key::Backspace)).should be_true
+    pane.value.should eq("he")
+  end
+
+  it "leaves focus-exit keys for the owning view (false when the popup is closed)" do
+    pane = ChainPane.new
+    pane.load("md5")
+    pane.handle_key(key(Termisu::Input::Key::Enter)).should be_false
+    pane.handle_key(key(Termisu::Input::Key::Up)).should be_false
+    pane.handle_key(key(Termisu::Input::Key::Escape)).should be_false
+  end
+end

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -17,6 +17,20 @@ private def loaded_fuzzer : FuzzerView
 end
 
 describe Gori::Tui::FuzzerView do
+  it "CHAIN pane: focus a template marker, type a chain, commit writes it back" do
+    view = FuzzerView.new
+    # marker at offset 0 → set_text zeroes the cursor, so it sits inside §x§
+    view.load_request("https://h", "§x§ HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
+    view.focus_pane(:template)
+    view.chain_pane_active?.should be_false
+    view.focus_chain_pane.should be_nil # in a marker → enters the pane
+    view.chain_pane_active?.should be_true
+    "rot13".each_char { |c| view.handle_chain_pane_key(Termisu::Event::Key.new(Termisu::Input::Key::LowerA, char: c)) }
+    view.commit_chain_pane
+    view.chain_pane_active?.should be_false
+    view.template_text.should contain("§x¦rot13§")
+  end
+
   it "label uses the custom name when set, else the template summary" do
     view = FuzzerView.new
     view.load_request("https://h", "GET /?x=1 HTTP/1.1\r\nHost: h\r\n\r\n", false, "")

--- a/spec/tui/replay_view_spec.cr
+++ b/spec/tui/replay_view_spec.cr
@@ -156,6 +156,57 @@ describe Gori::Tui::ReplayView do
     end
   end
 
+  it "MARK transform off (default) sends § verbatim — byte-identical to today" do
+    view = ReplayView.new
+    view.restore("https://a.test", "POST /x HTTP/1.1\nHost: a.test\n\nq=§hi§", false, false)
+    view.mark_transform?.should be_false
+    String.new(view.request_bytes).should eq("POST /x HTTP/1.1\r\nHost: a.test\r\n\r\nq=§hi§")
+  end
+
+  it "MARK transform on applies a marker's inline chain on send + resyncs Content-Length" do
+    view = ReplayView.new
+    view.restore("https://a.test",
+      "POST /x HTTP/1.1\nHost: a.test\nContent-Length: 99\n\ntok=§secret¦base64-encode§", false, true)
+    view.toggle_mark_transform
+    view.mark_transform?.should be_true
+    sent = String.new(view.request_bytes)
+    sent.includes?("tok=c2VjcmV0").should be_true       # base64("secret") == c2VjcmV0
+    sent.includes?("Content-Length: 12").should be_true # body "tok=c2VjcmV0" is 12 bytes
+    sent.includes?("Content-Length: 99").should be_false
+  end
+
+  it "restore round-trips the MARK transform flag" do
+    view = ReplayView.new
+    view.restore("https://a.test", "GET / HTTP/1.1\n\n", false, true, mark_transform: true)
+    view.mark_transform?.should be_true
+  end
+
+  it "MARK CHAIN pane: focus a marker, type a chain, commit writes it back" do
+    view = ReplayView.new
+    # marker at offset 0 → set_text zeroes the cursor, so it sits inside §v§
+    view.restore("https://a.test", "§v§ HTTP/1.1\nHost: a.test\n\n", false, false)
+    view.toggle_mark_transform
+    view.chain_pane_active?.should be_false
+    view.focus_pane(:request)
+    view.focus_chain_pane.should be_nil # in a marker → enters the pane (no hint)
+    view.chain_pane_active?.should be_true
+    "md5".each_char { |c| view.handle_chain_pane_key(Termisu::Event::Key.new(Termisu::Input::Key::LowerA, char: c)) }
+    view.commit_chain_pane
+    view.chain_pane_active?.should be_false
+    view.request_text.should contain("§v¦md5§")
+  end
+
+  it "MARK CHAIN pane hints when MARK is off or the cursor isn't in a marker" do
+    view = ReplayView.new
+    view.restore("https://a.test", "GET / HTTP/1.1\n\n", false, false)
+    view.focus_pane(:request)
+    view.focus_chain_pane.should_not be_nil # MARK off → hint, not activated
+    view.chain_pane_active?.should be_false
+    view.toggle_mark_transform
+    view.focus_chain_pane.should_not be_nil # MARK on but no marker under the cursor → hint
+    view.chain_pane_active?.should be_false
+  end
+
   it "load_grpc keeps the framed body byte-exact and the head editable" do
     replay_tmp_store do |store|
       # one gRPC message: 1-byte flag + 4-byte len(3) + payload incl a non-UTF-8 0xFF

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -148,6 +148,30 @@ private class FakeContext < ExecContext
     @calls << :replay_toggle_auto_content_length
   end
 
+  def replay_toggle_mark_transform : Nil
+    @calls << :replay_toggle_mark_transform
+  end
+
+  def replay_auto_mark : Nil
+    @calls << :replay_auto_mark
+  end
+
+  def replay_mark_word : Nil
+    @calls << :replay_mark_word
+  end
+
+  def replay_insert_marker : Nil
+    @calls << :replay_insert_marker
+  end
+
+  def replay_clear_marks : Nil
+    @calls << :replay_clear_marks
+  end
+
+  def replay_attach_chain : Nil
+    @calls << :replay_attach_chain
+  end
+
   def fuzz_selected : Nil
     @calls << :fuzz_selected
   end
@@ -170,6 +194,10 @@ private class FakeContext < ExecContext
 
   def fuzz_automark : Nil
     @calls << :fuzz_automark
+  end
+
+  def fuzz_attach_chain : Nil
+    @calls << :fuzz_attach_chain
   end
 
   def mine_selected : Nil

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -16,6 +16,7 @@ require "../replay/h2_engine"
 require "../replay/flow_request"
 require "../replay/diff"
 require "../fuzz"
+require "../convert"
 require "../miner"
 require "../prism/passive"
 require "../prism/group"
@@ -628,7 +629,7 @@ module Gori
         config = Fuzz::Config.new(mode: mode, concurrency: concurrency, rps: rate, throttle_ms: throttle,
           retries: retries, timeout: timeout, follow_redirects: follow, auto_calibrate: auto_cal, keep_bodies: :none)
         gen_sets = mode.per_position? ? sets : [sets.first]
-        generator = Fuzz::Generator.new(template, gen_sets, config)
+        generator = Fuzz::Generator.new(template, gen_sets, config, registry: Convert.shared_registry)
         sender = Fuzz::Sender.new(Fuzz::Origin.new(scheme, host, port),
           http2: force_h2 || src_h2, verify: !insecure, sni: sni, timeout: timeout)
         engine = Fuzz::Engine.new(generator, matcher, sender, config)

--- a/src/gori/convert.cr
+++ b/src/gori/convert.cr
@@ -35,4 +35,15 @@ module Gori::Convert
   def self.binary?(data : Bytes) : Bool
     !String.new(data).valid_encoding?
   end
+
+  # A process-wide registry built once and reused. The catalog is pure, read-only
+  # data after construction, so concurrent reads (fuzz worker fibers all splice
+  # through it) are safe. Callers that would otherwise rebuild `default_registry`
+  # per request/run — the Fuzzer/Replay send paths, `gori run fuzz`, MCP fuzz —
+  # share this instance instead.
+  @@shared : Registry?
+
+  def self.shared_registry : Registry
+    @@shared ||= default_registry
+  end
 end

--- a/src/gori/fuzz/generator.cr
+++ b/src/gori/fuzz/generator.cr
@@ -6,7 +6,11 @@ module Gori::Fuzz
   #   Pitchfork / ClusterBomb → one set per position (set[i] → position i).
   # (the frontend builds that mapping; out-of-range positions fall back to set 0.)
   class Generator
-    def initialize(@template : Template, @sets : Array(PayloadSet), @config : Config)
+    # `registry` (when given) applies each marked position's inline Convert chain to
+    # its payload at render time — see Template#apply_chains. nil = no transforms
+    # (keeps bare 3-arg callers and specs compiling).
+    def initialize(@template : Template, @sets : Array(PayloadSet), @config : Config,
+                   @registry : Convert::Registry? = nil)
     end
 
     def mode : Mode
@@ -40,7 +44,7 @@ module Gori::Fuzz
     # The unmodified base request (all positions = their defaults), CL-synced — used
     # to seed the matcher baseline for anomaly diffing / auto-calibration.
     def baseline_request : Bytes
-      raw = @template.render(@template.default_payloads)
+      raw = @template.render(chained(@template.default_payloads))
       @config.update_content_length? ? ContentLength.sync(raw, @config.add_content_length_when_missing?) : raw
     end
 
@@ -119,9 +123,15 @@ module Gori::Fuzz
     # ── helpers ──────────────────────────────────────────────────────────────────
 
     private def emit(idx : Int64, payloads : Array(String), pos : Int32?) : Job
-      raw = @template.render(payloads)
+      raw = @template.render(chained(payloads))
       bytes = @config.update_content_length? ? ContentLength.sync(raw, @config.add_content_length_when_missing?) : raw
-      Job.new(idx, payloads, pos, bytes)
+      Job.new(idx, payloads, pos, bytes) # keep the ORIGINAL payloads for reporting; only the wire bytes are transformed
+    end
+
+    # Apply each position's inline Convert chain to its payload (identity when no
+    # registry was supplied). Kept separate so `render` stays a byte-verbatim splice.
+    private def chained(payloads : Array(String)) : Array(String)
+      (reg = @registry) ? @template.apply_chains(payloads, reg) : payloads
     end
 
     private def set_for(p : Int32) : PayloadSet

--- a/src/gori/fuzz/template.cr
+++ b/src/gori/fuzz/template.cr
@@ -1,3 +1,5 @@
+require "../convert"
+
 module Gori::Fuzz
   # A base request with marked payload positions. The marked TEXT is the single
   # source of truth (re-parsed each run), so it stays robust to edits — gori's
@@ -12,8 +14,12 @@ module Gori::Fuzz
   # the byte-exact path remains `gori run replay` / export.
   struct Template
     MARKER = '§'
+    # Value|chain delimiter inside a marker: `§value¦chain§`. NOT '|' — the Convert
+    # chain syntax already uses '|'/','/'>'  as step separators, so the boundary must
+    # be a char the chain never contains. `¦¦` escapes a literal `¦`, mirroring `§§`.
+    CHAIN_SEP = '¦'
 
-    record Position, index : Int32, default : String
+    record Position, index : Int32, default : String, chain : String = ""
 
     getter segments : Array(String) # literal runs; size == positions.size + 1
     getter positions : Array(Position)
@@ -22,59 +28,78 @@ module Gori::Fuzz
     def initialize(@segments : Array(String), @positions : Array(Position), @http2 : Bool)
     end
 
+    # The result of scanning one marker's interior (see scan_interior): the decoded
+    # {default, chain}, whether a chain part was opened (a bare `¦` seen — needed to
+    # rebuild an unbalanced marker faithfully), whether the closing § was found, and the
+    # index just past the closing § (or n when unbalanced).
+    private record InteriorScan, default : String, chain : String,
+      chained : Bool, closed : Bool, next_i : Int32
+
     def self.parse(marked : String, http2 : Bool = false) : Template
       segs = [] of String
-      defs = [] of String
+      defs = [] of {String, String} # {default, chain}
       lit = IO::Memory.new
       chars = marked.chars
       n = chars.size
       i = 0
       while i < n
         c = chars[i]
-        if c == MARKER
-          if chars[i + 1]? == MARKER # escaped literal §
-            lit << MARKER
-            i += 2
-            next
-          end
-          segs << lit.to_s
-          lit = IO::Memory.new
-          j = i + 1
-          val = IO::Memory.new
-          closed = false
-          while j < n
-            cj = chars[j]
-            if cj == MARKER
-              if chars[j + 1]? == MARKER # §§ inside a marker → literal §
-                val << MARKER
-                j += 2
-                next
-              end
-              closed = true
-              break
-            end
-            val << cj
-            j += 1
-          end
-          if closed
-            defs << val.to_s
-            i = j + 1
-          else # unbalanced trailing § → literal text, opens no position
-            # The preceding literal was optimistically pushed as a segment above;
-            # fold it back (with the § and the trailing chars) into `lit` so the
-            # tail lands in the FINAL segment. Otherwise render() — which emits only
-            # positions.size + 1 segments — would silently drop these trailing bytes.
-            lit << (segs.pop? || "") << MARKER << val.to_s
-            i = n
-          end
-        else
+        if c != MARKER
           lit << c
           i += 1
+        elsif chars[i + 1]? == MARKER # escaped literal §
+          lit << MARKER
+          i += 2
+        else
+          s = scan_interior(chars, i, n)
+          if s.closed
+            segs << lit.to_s
+            lit = IO::Memory.new
+            defs << {s.default, s.chain}
+          else # unbalanced trailing § → literal text, opens no position (no truncation:
+            # the § + interior fold into `lit` so render's positions.size+1 segments keep it)
+            lit << MARKER << s.default
+            lit << CHAIN_SEP << s.chain if s.chained
+          end
+          i = s.next_i
         end
       end
       segs << lit.to_s
-      positions = defs.map_with_index { |d, k| Position.new(k, d) }
+      positions = defs.map_with_index { |(d, ch), k| Position.new(k, d, ch) }
       new(segs, positions, http2)
+    end
+
+    # Scan from the opening § at `open` to the matching close, decoding `§§`→§ and
+    # `¦¦`→¦; the first bare `¦` splits the interior into value|chain. Returns the decoded
+    # parts even when unbalanced (closed: false), so parse can fold them back as literal.
+    private def self.scan_interior(chars : Array(Char), open : Int32, n : Int32) : InteriorScan
+      j = open + 1
+      val = IO::Memory.new
+      chn = IO::Memory.new
+      in_chain = false
+      while j < n
+        cj = chars[j]
+        if cj == MARKER
+          if chars[j + 1]? == MARKER # §§ inside a marker → literal §
+            (in_chain ? chn : val) << MARKER
+            j += 2
+            next
+          end
+          return InteriorScan.new(val.to_s, chn.to_s, in_chain, true, j + 1)
+        elsif cj == CHAIN_SEP
+          if chars[j + 1]? == CHAIN_SEP # ¦¦ inside a marker → literal ¦
+            (in_chain ? chn : val) << CHAIN_SEP
+            j += 2
+            next
+          end
+          in_chain ? (chn << CHAIN_SEP) : (in_chain = true) # 1st bare ¦ splits value|chain; a 2nd is literal
+          j += 1
+          next
+        end
+        (in_chain ? chn : val) << cj
+        j += 1
+      end
+      InteriorScan.new(val.to_s, chn.to_s, in_chain, false, n)
     end
 
     def position_count : Int32
@@ -144,6 +169,23 @@ module Gori::Fuzz
       io.to_slice
     end
 
+    # Map each payload through its position's Convert chain (empty chain = identity),
+    # returning a new payload array to feed `render`. A chain that fails — an unknown
+    # token, a step that raised, or output over MAX_OUT — leaves that value
+    # UNTRANSFORMED: Convert.run never raises, and a streaming fuzz run has nowhere to
+    # surface a per-position error (validate chains in the Convert tab). Convert works
+    # on Bytes but the template splices Strings, so the transformed bytes are rewrapped
+    # with String.new — encoders (base64/url/hex/hash/escape) stay ASCII; a decoder that
+    # produces raw bytes may lose fidelity, the same limit binary bodies already have.
+    def apply_chains(payloads : Array(String), registry : Convert::Registry) : Array(String)
+      payloads.map_with_index do |p, k|
+        spec = @positions[k]?.try(&.chain)
+        next p if spec.nil? || spec.empty?
+        res = Convert.run(registry, p.to_slice, spec)
+        (res.ok? && (o = res.output)) ? String.new(o) : p
+      end
+    end
+
     # ── Marking helpers (shared by the TUI editor and the CLI) ────────────────────
 
     # Wrap every query / cookie / urlencoded-or-JSON body VALUE in `§…§`. A no-op if
@@ -183,7 +225,10 @@ module Gori::Fuzz
       cur = cursor.clamp(0, n)
       if span = enclosing_marker(chars, cur)
         a, b = span
-        return String.build { |io| chars.each_with_index { |c, i| io << c unless i == a || i == b } }
+        # Drop the whole marker: both `§` AND any `¦chain` (keep only the raw value),
+        # else unmarking `§v¦b64§` would leave a stray `v¦b64`.
+        value, _ = split_raw_interior(chars[(a + 1)...b])
+        return "#{chars[0, a].join}#{value.join}#{chars[(b + 1)..].join}"
       end
       lo = cur
       while lo > 0 && word_char?(chars[lo - 1])
@@ -201,8 +246,71 @@ module Gori::Fuzz
     end
 
     # Strip every marker, leaving the defaults inline (back to the base request).
+    # Chains are dropped too — `render(default_payloads)` emits only the defaults.
     def self.clear_markers(text : String) : String
-      parse(text).render(parse(text).default_payloads).then { |b| String.new(b) }
+      tmpl = parse(text)
+      String.new(tmpl.render(tmpl.default_payloads))
+    end
+
+    # The Convert-chain string of the `§…§` marker enclosing char index `cursor`, or
+    # nil when the cursor isn't inside a closed marker. Seeds the chain-edit overlay.
+    def self.chain_at(text : String, cursor : Int32) : String?
+      idx = marked_spans(text).index { |(a, b)| a <= cursor && cursor <= b }
+      return nil unless idx
+      parse(text).positions[idx]?.try(&.chain)
+    end
+
+    # Replace/insert/remove the chain of the marker enclosing `cursor`, returning the
+    # new text (nil when the cursor isn't inside a marker). An empty `chain` removes
+    # the `¦…` entirely. The raw default bytes are kept verbatim; the new chain has any
+    # literal `§`/`¦` escaped so it round-trips through `parse`.
+    def self.set_chain(text : String, cursor : Int32, chain : String) : String?
+      chars = text.chars
+      span = marked_spans(text).find { |(a, b)| a <= cursor && cursor <= b }
+      return nil unless span
+      a, b = span
+      close = b - 1 # index of the closing §
+      value, _ = split_raw_interior(chars[(a + 1)...close])
+      clean = chain.strip
+      interior = clean.empty? ? value.join : "#{value.join}#{CHAIN_SEP}#{escape_chain(clean)}"
+      "#{chars[0, a + 1].join}#{interior}#{chars[close..].join}"
+    end
+
+    # Per closed marker: {open, sep, close} char offsets — `open`/`close` index the two
+    # `§`, and `sep` is the value|chain boundary `¦` (== `close` when there's no chain).
+    # Lets the views tint the value and the (dimmer) chain separately; 1:1 with
+    # `positions` / `marked_spans`.
+    def self.marker_regions(text : String) : Array({Int32, Int32, Int32})
+      chars = text.chars
+      marked_spans(text).map do |(a, b)|
+        close = b - 1
+        value, chain = split_raw_interior(chars[(a + 1)...close])
+        sep = chain.nil? ? close : (a + 1 + value.size)
+        {a, sep, close}
+      end
+    end
+
+    # Split a marker's RAW interior chars at the first UNESCAPED `¦` into
+    # {value, chain}. `§§` and `¦¦` are escapes (skip both), so an escaped `¦` isn't a
+    # boundary. `chain` is nil when the marker carries no chain.
+    private def self.split_raw_interior(interior : Array(Char)) : {Array(Char), Array(Char)?}
+      i = 0
+      n = interior.size
+      while i < n
+        c = interior[i]
+        if (c == MARKER && interior[i + 1]? == MARKER) || (c == CHAIN_SEP && interior[i + 1]? == CHAIN_SEP)
+          i += 2
+          next
+        elsif c == CHAIN_SEP
+          return {interior[0, i], interior[(i + 1)..]}
+        end
+        i += 1
+      end
+      {interior, nil}
+    end
+
+    private def self.escape_chain(s : String) : String
+      s.gsub(MARKER, "#{MARKER}#{MARKER}").gsub(CHAIN_SEP, "#{CHAIN_SEP}#{CHAIN_SEP}")
     end
 
     private def self.eol_of(text : String) : String
@@ -278,7 +386,7 @@ module Gori::Fuzz
     end
 
     private def self.word_char?(c : Char) : Bool
-      !c.whitespace? && !"&=?;:/\"'{}[](),§".includes?(c)
+      !c.whitespace? && !"&=?;:/\"'{}[](),§¦".includes?(c)
     end
 
     # The {open, close} char indices of the marker pair enclosing `cursor`, else nil.

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -6,6 +6,7 @@ require "../replay/engine"
 require "../replay/h2_engine"
 require "../replay/flow_request"
 require "../fuzz"
+require "../convert"
 require "../miner"
 require "./serialize"
 require "./request_builder"
@@ -721,7 +722,7 @@ module Gori
         matcher = fuzz_matcher(h)
         config = fuzz_config(h, mode)
         gen_sets = mode.per_position? ? sets : [sets.first]
-        generator = Fuzz::Generator.new(template, gen_sets, config)
+        generator = Fuzz::Generator.new(template, gen_sets, config, registry: Convert.shared_registry)
         sender = Fuzz::Sender.new(origin, http2: use_h2,
           verify: @verify_upstream && !(bool(h, "insecure") || false), timeout: fuzz_timeout(h))
         engine = Fuzz::Engine.new(generator, matcher, sender, config)

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -617,12 +617,13 @@ module Gori
     # (potentially multi-MB) response on each cross-session commit.
     def replays : Array(ReplayRecord)
       list = [] of ReplayRecord
-      @db.query("SELECT id, target, request, http2, auto_content_length, flow_id, position, response_head, response_body, response_error, response_duration_us, name, sni FROM replays ORDER BY position, id") do |rs|
+      @db.query("SELECT id, target, request, http2, auto_content_length, flow_id, position, response_head, response_body, response_error, response_duration_us, name, sni, mark_transform FROM replays ORDER BY position, id") do |rs|
         rs.each do
           list << ReplayRecord.new(
             rs.read(Int64), rs.read(String), rs.read(String),
             rs.read(Int32) != 0, rs.read(Int32) != 0, rs.read(Int64?), rs.read(Int32),
-            rs.read(Bytes?), rs.read(Bytes?), rs.read(String?), rs.read(Int64?), rs.read(String?), rs.read(String?))
+            rs.read(Bytes?), rs.read(Bytes?), rs.read(String?), rs.read(Int64?), rs.read(String?), rs.read(String?),
+            mark_transform: rs.read(Int32) != 0)
         end
       end
       list
@@ -633,24 +634,24 @@ module Gori
     # response (responses are personal per session). Response fields stay nil.
     def get_replay(id : Int64) : ReplayRecord?
       @db.query(
-        "SELECT id, target, request, http2, auto_content_length, flow_id, position, sni FROM replays WHERE id = ?",
+        "SELECT id, target, request, http2, auto_content_length, flow_id, position, sni, mark_transform FROM replays WHERE id = ?",
         id) do |rs|
         return ReplayRecord.new(
           rs.read(Int64), rs.read(String), rs.read(String),
           rs.read(Int32) != 0, rs.read(Int32) != 0, rs.read(Int64?), rs.read(Int32),
-          sni: rs.read(String?)) if rs.move_next
+          sni: rs.read(String?), mark_transform: rs.read(Int32) != 0) if rs.move_next
       end
       nil
     end
 
     def replays_meta : Array(ReplayRecord)
       list = [] of ReplayRecord
-      @db.query("SELECT id, target, request, http2, auto_content_length, flow_id, position, sni FROM replays ORDER BY position, id") do |rs|
+      @db.query("SELECT id, target, request, http2, auto_content_length, flow_id, position, sni, mark_transform FROM replays ORDER BY position, id") do |rs|
         rs.each do
           list << ReplayRecord.new(
             rs.read(Int64), rs.read(String), rs.read(String),
             rs.read(Int32) != 0, rs.read(Int32) != 0, rs.read(Int64?), rs.read(Int32),
-            sni: rs.read(String?))
+            sni: rs.read(String?), mark_transform: rs.read(Int32) != 0)
         end
       end
       list
@@ -659,19 +660,21 @@ module Gori
     # Returns the new row id (or 0 if the store is closing — the caller normalizes
     # 0 → nil so a later update never targets a bogus row).
     def insert_replay(target : String, request : String, http2 : Bool,
-                      auto_cl : Bool, flow_id : Int64?, position : Int32, sni : String? = nil) : Int64
+                      auto_cl : Bool, flow_id : Int64?, position : Int32, sni : String? = nil,
+                      mark_transform : Bool = false) : Int64
       ts = now_us
       exec_task ->(c : DB::Connection) {
-        c.exec("INSERT INTO replays (created_at, updated_at, target, request, http2, auto_content_length, flow_id, position, sni) VALUES (?,?,?,?,?,?,?,?,?)",
-          ts, ts, target, request, http2 ? 1 : 0, auto_cl ? 1 : 0, flow_id, position, sni)
+        c.exec("INSERT INTO replays (created_at, updated_at, target, request, http2, auto_content_length, flow_id, position, sni, mark_transform) VALUES (?,?,?,?,?,?,?,?,?,?)",
+          ts, ts, target, request, http2 ? 1 : 0, auto_cl ? 1 : 0, flow_id, position, sni, mark_transform ? 1 : 0)
         nil
       }
     end
 
-    def update_replay(id : Int64, target : String, request : String, http2 : Bool, auto_cl : Bool, sni : String? = nil) : Nil
+    def update_replay(id : Int64, target : String, request : String, http2 : Bool, auto_cl : Bool,
+                      sni : String? = nil, mark_transform : Bool = false) : Nil
       exec_task ->(c : DB::Connection) {
-        c.exec("UPDATE replays SET target = ?, request = ?, http2 = ?, auto_content_length = ?, sni = ?, updated_at = ? WHERE id = ?",
-          target, request, http2 ? 1 : 0, auto_cl ? 1 : 0, sni, now_us, id)
+        c.exec("UPDATE replays SET target = ?, request = ?, http2 = ?, auto_content_length = ?, sni = ?, mark_transform = ?, updated_at = ? WHERE id = ?",
+          target, request, http2 ? 1 : 0, auto_cl ? 1 : 0, sni, mark_transform ? 1 : 0, now_us, id)
         nil
       }
     end

--- a/src/gori/store/models.cr
+++ b/src/gori/store/models.cr
@@ -315,12 +315,13 @@ module Gori
       getter response_body : Bytes?
       getter response_error : String?
       getter response_duration_us : Int64?
-      getter name : String? # custom sub-tab label (nil = derive from the request)
-      getter sni : String?  # custom TLS SNI host (nil = present the target host)
+      getter name : String?         # custom sub-tab label (nil = derive from the request)
+      getter sni : String?          # custom TLS SNI host (nil = present the target host)
+      getter? mark_transform : Bool # V22: apply §…§ inline Convert chains on send
 
       def initialize(@id, @target, @request, @http2, @auto_content_length, @flow_id, @position,
                      @response_head = nil, @response_body = nil, @response_error = nil,
-                     @response_duration_us = nil, @name = nil, @sni = nil)
+                     @response_duration_us = nil, @name = nil, @sni = nil, @mark_transform = false)
       end
     end
 

--- a/src/gori/store/schema.cr
+++ b/src/gori/store/schema.cr
@@ -7,7 +7,7 @@ module Gori
     # (FTS5 for QL, a tags table, a connections table) arrive as *later*
     # migrations — which is exactly why none of them exist in v1 (P0).
     module Schema
-      VERSION = 21
+      VERSION = 22
 
       V1 = [
         <<-SQL,
@@ -415,7 +415,14 @@ module Gori
         SQL
       ]
 
-      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21]
+      # Replay tabs gain a per-tab MARK-transform toggle: when on, `§…§` markers in the
+      # request carry inline Convert chains applied on send. Off (0) = byte-identical to
+      # today, so existing rows backfill to disabled.
+      V22 = [
+        "ALTER TABLE replays ADD COLUMN mark_transform INTEGER NOT NULL DEFAULT 0",
+      ]
+
+      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21, V22]
 
       def self.migrate!(db : DB::Database) : Nil
         current = db.scalar("PRAGMA user_version").as(Int64).to_i

--- a/src/gori/tui/chain_pane.cr
+++ b/src/gori/tui/chain_pane.cr
@@ -1,0 +1,143 @@
+require "./screen"
+require "./theme"
+require "./frame"
+require "./convert_view" # ChainComplete lives here
+require "../convert"
+
+module Gori::Tui
+  # A single-line editor for a Convert chain spec (`base64-encode > url-encode`) with
+  # converter-name autocomplete. Embedded below the marker editor in Replay/Fuzzer MARK
+  # mode; the owning view BINDS it to the §…§ marker at the cursor — `load` on focus-in,
+  # `value` on focus-out (the view writes it back via Fuzz::Template.set_chain). Modelled
+  # on the Convert tab's chain field (String + caret + ChainComplete), not a TextArea.
+  class ChainPane
+    getter chain : String = ""
+    @caret : Int32 = 0
+    @pre : String = "" # IME preedit
+    @complete = ChainComplete.new
+
+    SEPS = {'>', '|', ','} # chain step separators — the token under the caret ends at one
+
+    # Bind to a marker: seed the chain (caret at end), clear any stale completion.
+    def load(chain : String) : Nil
+      @chain = chain
+      @caret = chain.size
+      @pre = ""
+      @complete.close
+    end
+
+    def value : String
+      @chain
+    end
+
+    def set_preedit(text : String) : Nil
+      @pre = text
+    end
+
+    # Edit the chain while the pane is focused. Returns false for keys the OWNING VIEW
+    # must handle — the focus-exit keys (up/down/tab/esc/enter) once the popup is closed —
+    # so the view can commit the chain and move focus back to the editor.
+    def handle_key(ev : Termisu::Event::Key) : Bool
+      return true if complete_key(ev)   # popup owns tab/enter/arrows/esc while open
+      return false if exit_key?(ev.key) # focus-exit keys → the owning view handles them
+      edit_key(ev)
+    end
+
+    private def exit_key?(key : Termisu::Input::Key) : Bool
+      key.up? || key.down? || key.tab? || key.back_tab? || key.escape? || key.enter?
+    end
+
+    private def edit_key(ev : Termisu::Event::Key) : Bool
+      key = ev.key
+      case
+      when key.backspace? then backspace
+      when key.left?      then move_caret(-1)
+      when key.right?     then move_caret(1)
+      else
+        c = ev.char || key.to_char
+        return false unless c && !ev.ctrl? && !ev.alt?
+        insert(c)
+      end
+      true
+    end
+
+    def render(screen : Screen, rect : Rect, focused : Bool, header : String, placeholder : String) : Nil
+      return if rect.w < 2 || rect.h < 2
+      Frame.card(screen, rect, header, bg: Theme.bg, border: Frame.pane_border(focused))
+      inner = rect.inset(1, 1)
+      if @chain.empty? && !focused
+        screen.text(inner.x, inner.y, placeholder, Theme.muted, width: {inner.w, 1}.max)
+      else
+        fg = focused ? Theme.text_bright : Theme.text
+        screen.input_line(inner.x, inner.y, @chain, @caret, @pre, fg, Theme.bg, width: {inner.w, 1}.max)
+      end
+      # Dropdown renders DOWNWARD from the input row into the pane body — the pane is
+      # enlarged while focused, so there's room (mirrors the Convert tab).
+      @complete.render(screen, inner, rect) if focused && @complete.open?
+    end
+
+    # --- editing primitives ---------------------------------------------------
+    private def complete_key(ev : Termisu::Event::Key) : Bool
+      return false unless @complete.open?
+      key = ev.key
+      case
+      when key.tab?, key.enter?   then accept
+      when key.up?, key.back_tab? then @complete.move(-1)
+      when key.down?              then @complete.move(1)
+      when key.escape?            then @complete.close
+      else                             return false
+      end
+      true
+    end
+
+    private def insert(c : Char) : Nil
+      @chain = @chain[0, @caret] + c.to_s + @chain[@caret..]
+      @caret += 1
+      @pre = ""
+      refilter
+    end
+
+    private def backspace : Nil
+      return if @caret <= 0
+      @chain = @chain[0, @caret - 1] + @chain[@caret..]
+      @caret -= 1
+      @pre = ""
+      refilter
+    end
+
+    private def move_caret(d : Int32) : Nil
+      @caret = (@caret + d).clamp(0, @chain.size)
+      refilter
+    end
+
+    private def accept : Nil
+      @chain, @caret = @complete.accept(@chain, @caret)
+      @complete.close
+      refilter
+    end
+
+    # Filter the converter autocomplete against the token under the caret.
+    private def refilter : Nil
+      ts, te = token_span
+      tok = @chain[ts...te].strip
+      if tok.empty?
+        @complete.close
+      else
+        matches = Convert.shared_registry.match(tok).map(&.name).uniq!
+        @complete.set(matches.first(40), ts, te)
+      end
+    end
+
+    private def token_span : {Int32, Int32}
+      s = @caret
+      while s > 0 && !SEPS.includes?(@chain[s - 1])
+        s -= 1
+      end
+      e = @caret
+      while e < @chain.size && !SEPS.includes?(@chain[e])
+        e += 1
+      end
+      {s, e}
+    end
+  end
+end

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -190,7 +190,21 @@ module Gori::Tui
     end
 
     private def handle_escape(v : FuzzerView) : Nil
+      return v.commit_chain_pane if v.chain_pane_active? # esc in the CHAIN pane → save + back
       v.focus == :detail ? v.focus_pane(:results) : @host.request_focus(:menu)
+    end
+
+    # ^Y: focus the CHAIN pane for the marker under the template cursor (again = save + back).
+    def fuzz_focus_chain_pane : Nil
+      return unless view = current_view
+      if view.chain_pane_active?
+        view.commit_chain_pane
+        save_current
+        @host.status("chain saved")
+      else
+        msg = view.focus_chain_pane
+        @host.status(msg || "type the chain · Tab completes · ↵/esc saves")
+      end
     end
 
     private def switch_subtab(c : Char?) : Nil
@@ -231,6 +245,7 @@ module Gori::Tui
     end
 
     private def edit_template(ev : Termisu::Event::Key, v : FuzzerView) : Nil
+      return v.handle_chain_pane_key(ev) if v.chain_pane_active? # CHAIN sub-pane owns typing
       key = ev.key
       case
       when key.enter?     then v.template_newline

--- a/src/gori/tui/controllers/replay_controller.cr
+++ b/src/gori/tui/controllers/replay_controller.cr
@@ -31,7 +31,8 @@ module Gori::Tui
       @host.session.store.replays.each do |r|
         view = ReplayView.new
         view.restore(r.target, r.request, r.http2?, r.auto_content_length?,
-          r.response_head, r.response_body, r.response_error, r.response_duration_us, sni: r.sni || "")
+          r.response_head, r.response_body, r.response_error, r.response_duration_us,
+          sni: r.sni || "", mark_transform: r.mark_transform?)
         view.name = r.name # custom sub-tab label survives reopen
         seed_replay_original(view, r.flow_id)
         @replays << ReplayTab.new(view, r.flow_id, r.id)
@@ -166,7 +167,9 @@ module Gori::Tui
       elsif ev.ctrl? && key.lower_w?
         request_close
       elsif key.escape?
-        if (view = current_view) && view.focus == :target && view.editing_sni?
+        if (view = current_view) && view.chain_pane_active?
+          view.commit_chain_pane # esc in the CHAIN pane → save + back to the request editor
+        elsif (view = current_view) && view.focus == :target && view.editing_sni?
           view.exit_sni_field # leave the SNI field, back to the URL (value kept)
         elsif (view = current_view) && view.focus == :request && view.request_hex?
           view.toggle_request_hex # exit hex back to the text editor (only when on the request pane)
@@ -224,15 +227,34 @@ module Gori::Tui
       Graphql.from_flow(detail.row.target, detail.request_head, detail.request_body)
     end
 
-    # Toggle the active request sub-pane (^T) in a split-decode tab: envelope ⇄ decoded.
+    # ^T is context-sensitive: a decode tab toggles the envelope/decoded split; a MARK tab
+    # drops a single § at the cursor (Fuzzer parity — the direct-marker keystroke).
     def replay_toggle_decoded : Nil
       view = current_view
       return @host.status("no replay open") unless view
-      return @host.status("not a decode flow — ^T switches the envelope/decoded split for SAML/GraphQL") unless view.decode_mode?
-      @host.request_focus(:body)
-      view.focus_pane(:request)
-      pane = view.toggle_req_pane
-      @host.status(pane == :decoded ? "editing the decoded payload — edits re-encode into the request on ^R send" : "editing the request envelope (headers · target · params)")
+      if view.decode_mode?
+        @host.request_focus(:body)
+        view.focus_pane(:request)
+        pane = view.toggle_req_pane
+        @host.status(pane == :decoded ? "editing the decoded payload — edits re-encode into the request on ^R send" : "editing the request envelope (headers · target · params)")
+      elsif view.mark_transform?
+        @host.status(view.insert_marker)
+      else
+        @host.status("not a decode flow — ^T inserts a § when MARK is on, or switches the SAML/GraphQL split")
+      end
+    end
+
+    # ^Y: focus the CHAIN pane for the marker under the cursor (again = save + back).
+    def replay_focus_chain_pane : Nil
+      return unless view = current_view
+      if view.chain_pane_active?
+        view.commit_chain_pane
+        save_current_replay
+        @host.status("chain saved")
+      else
+        msg = view.focus_chain_pane
+        @host.status(msg || "type the chain · Tab completes · ↵/esc saves")
+      end
     end
 
     def replay_toggle_hex : Nil
@@ -270,6 +292,38 @@ module Gori::Tui
         on = view.toggle_auto_content_length
         @host.status(on ? "auto Content-Length: on" : "auto Content-Length: off")
       end
+    end
+
+    # MARK transform mode: mark request values (§…§) and attach Convert chains applied on
+    # send. Off by default so a plain request is byte-identical (a captured § is literal).
+    def replay_toggle_mark_transform : Nil
+      return unless view = current_view
+      if view.request_hex? || view.grpc_mode? || view.decode_mode? || view.ws_mode?
+        @host.status("MARK transform isn't available in this request mode")
+      else
+        on = view.toggle_mark_transform
+        @host.status(on ? "MARK on · ^A mark all · ^T insert § · ^Y edit chain · ^R send" : "MARK transform: off")
+      end
+    end
+
+    def replay_auto_mark : Nil
+      return unless view = current_view
+      @host.status(view.auto_mark)
+    end
+
+    def replay_mark_word : Nil
+      return unless view = current_view
+      @host.status(view.mark_word)
+    end
+
+    def replay_insert_marker : Nil
+      return unless view = current_view
+      @host.status(view.insert_marker)
+    end
+
+    def replay_clear_marks : Nil
+      return unless view = current_view
+      @host.status(view.clear_marks)
     end
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
@@ -421,11 +475,12 @@ module Gori::Tui
         # would needlessly wipe its on-screen response/scroll/focus).
         next if v.target == row.target && v.request_text == row.request &&
                 v.http2? == row.http2? && v.auto_content_length? == row.auto_content_length? &&
-                v.sni_override == row.sni
+                v.mark_transform? == row.mark_transform? && v.sni_override == row.sni
         # Live cross-session sync carries only the REQUEST (a response is personal to
         # each session's view); restore() is response-less so a peer's resend never
         # clobbers the local response/scroll/focus.
-        v.restore(row.target, row.request, row.http2?, row.auto_content_length?, sni: row.sni || "")
+        v.restore(row.target, row.request, row.http2?, row.auto_content_length?,
+          sni: row.sni || "", mark_transform: row.mark_transform?)
         seed_replay_original(v, row.flow_id) # restore() drops the baseline; re-seed it
       end
 
@@ -433,7 +488,8 @@ module Gori::Tui
       rows.each do |row|
         next if local_ids.includes?(row.id)
         view = ReplayView.new
-        view.restore(row.target, row.request, row.http2?, row.auto_content_length?, sni: row.sni || "")
+        view.restore(row.target, row.request, row.http2?, row.auto_content_length?,
+          sni: row.sni || "", mark_transform: row.mark_transform?)
         seed_replay_original(view, row.flow_id)
         @replays << ReplayTab.new(view, row.flow_id, row.id)
       end
@@ -517,7 +573,8 @@ module Gori::Tui
     # reconcile key). A closing store returns 0 → nil, leaving the tab unsaved.
     private def persist_new_replay(view : ReplayView, flow_id : Int64?) : Int64?
       id = @host.session.store.insert_replay(view.target, view.request_text, view.http2?,
-        view.auto_content_length?, flow_id, @replays.size, view.sni_override)
+        view.auto_content_length?, flow_id, @replays.size, view.sni_override,
+        mark_transform: view.mark_transform?)
       id == 0 ? nil : id
     end
 
@@ -632,7 +689,8 @@ module Gori::Tui
       return unless tab = current_replay_tab
       return unless (id = tab.db_id) && tab.view.dirty?
       v = tab.view
-      @host.session.store.update_replay(id, v.target, v.request_text, v.http2?, v.auto_content_length?, v.sni_override)
+      @host.session.store.update_replay(id, v.target, v.request_text, v.http2?, v.auto_content_length?,
+        v.sni_override, mark_transform: v.mark_transform?)
       v.clear_dirty
     end
 
@@ -661,6 +719,7 @@ module Gori::Tui
 
     private def edit_replay_request(ev : Termisu::Event::Key, view : ReplayView) : Nil
       return edit_replay_request_hex(ev, view) if view.request_hex?
+      return view.handle_chain_pane_key(ev) if view.chain_pane_active? # CHAIN sub-pane owns typing
       key = ev.key
       c = ev.char || key.to_char
       case

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -5,8 +5,10 @@ require "./frame"
 require "./text_area"
 require "./fmt"
 require "./spark"
+require "./chain_pane"
 require "../store"
 require "../fuzz"
+require "../convert"
 require "../fuzzy"
 require "../paths"
 require "../replay/flow_request"
@@ -100,6 +102,12 @@ module Gori::Tui
       # Backs BOTH the template tint colours and the Sets→marker chips, so they can't disagree.
       @marker_text_rev = -1
       @marker_spans = [] of {Int32, Int32}
+      # The CHAIN sub-pane: a visible editor for the Convert chain of the §…§ marker under
+      # the TEMPLATE cursor (transform applied to each payload on send). @chain_focused =
+      # editing it; @chain_marker_cursor remembers which marker to commit back to.
+      @chain_pane = ChainPane.new
+      @chain_focused = false
+      @chain_marker_cursor = 0
       @show_dist = true # the DIST sidebar beside RESULTS (toggled with `v`)
       @dist_cache = nil.as(DistData?)
       @dist_cache_rev = -1_i64
@@ -214,10 +222,13 @@ module Gori::Tui
     end
 
     def focus_pane(pane : Symbol) : Nil
-      @focus = pane if PANE_ORDER.includes?(pane)
+      return unless PANE_ORDER.includes?(pane)
+      commit_chain_pane if @chain_focused
+      @focus = pane
     end
 
     def focus_config : Nil
+      commit_chain_pane if @chain_focused
       @focus = :config
       @cfg_field = 0 # land straight on the payload type tabs
       @cfg_caret = 0
@@ -225,6 +236,7 @@ module Gori::Tui
     end
 
     def pane_advance(dir : Int32) : Bool
+      commit_chain_pane if @chain_focused
       if @focus == :detail
         @focus = :results
         return true
@@ -247,7 +259,57 @@ module Gori::Tui
     end
 
     def set_preedit(text : String) : Nil
-      @editor.set_preedit(text) if @focus == :template
+      if chain_pane_active?
+        @chain_pane.set_preedit(text)
+      elsif @focus == :template
+        @editor.set_preedit(text)
+      end
+    end
+
+    CHAIN_PLACEHOLDER = "put the cursor in a §…§ marker, then ^Y to add an encode chain (e.g. base64-encode)"
+
+    # The CHAIN sub-pane owns keyboard input (focused on the TEMPLATE column). The
+    # controller routes template keys here when true.
+    def chain_pane_active? : Bool
+      @chain_focused && @focus == :template
+    end
+
+    # ^Y: focus the CHAIN pane for the marker under the template cursor. Returns a hint
+    # string when it can't (surfaced by the controller), nil on success.
+    def focus_chain_pane : String?
+      return "move to the TEMPLATE pane first (↹)" unless @focus == :template
+      chain = Fuzz::Template.chain_at(@editor.text, @editor.cursor_offset)
+      return "put the cursor in a §…§ marker · ^A mark all · ^T insert §" if chain.nil?
+      @chain_marker_cursor = @editor.cursor_offset
+      @chain_pane.load(chain)
+      @chain_focused = true
+      nil
+    end
+
+    # Commit the CHAIN pane back to the bound marker + return focus to the template editor.
+    # Idempotent so the focus changers above can call it freely.
+    def commit_chain_pane : Nil
+      return unless @chain_focused
+      if updated = Fuzz::Template.set_chain(@editor.text, @chain_marker_cursor, @chain_pane.value)
+        @editor.set_text(updated)
+        @dirty = true
+      end
+      @chain_focused = false
+    end
+
+    # Route a key while the CHAIN pane is focused (typing/autocomplete stays; a focus-exit
+    # key commits + returns to the template editor).
+    def handle_chain_pane_key(ev : Termisu::Event::Key) : Nil
+      return if @chain_pane.handle_key(ev)
+      key = ev.key
+      commit_chain_pane if key.escape? || key.enter? || key.tab? || key.up?
+    end
+
+    # "§N" label for the marker under the template cursor (1-based), or "§" when not in one.
+    private def marker_label : String
+      cur = @editor.cursor_offset
+      idx = marker_spans.index { |(a, b)| a <= cur && cur <= b }
+      idx ? "§#{idx + 1}" : "§"
     end
 
     # --- marking -------------------------------------------------------------
@@ -288,7 +350,9 @@ module Gori::Tui
     end
 
     def clear_marks : String
-      @editor.set_text(@editor.text.gsub("§", ""))
+      # clear_markers renders the defaults inline — drops both the § delimiters AND any
+      # ¦chain (a naive gsub("§","") would leave a stray value¦chain behind).
+      @editor.set_text(Fuzz::Template.clear_markers(@editor.text))
       @dirty = true
       "cleared all § markers"
     end
@@ -680,7 +744,7 @@ module Gori::Tui
       return {nil, "invalid target — use scheme://host[:port]/path"} if host.empty?
       sets = @sets.map { |s| Fuzz::PayloadSet.new(build_source(s)) }
       gen_sets = @config.mode.per_position? ? sets : [sets.first]
-      generator = Fuzz::Generator.new(template, gen_sets, @config)
+      generator = Fuzz::Generator.new(template, gen_sets, @config, registry: Convert.shared_registry)
       sender = Fuzz::Sender.new(Fuzz::Origin.new(scheme, host, port),
         http2: @http2, verify: verify, sni: sni_override, timeout: @config.timeout)
       @matcher.auto_calibrate = @config.auto_calibrate?
@@ -990,8 +1054,42 @@ module Gori::Tui
       half = {(rect.w - 1) // 2, 1}.max
       left = Rect.new(rect.x, rect.y, half, rect.h)
       right = Rect.new(rect.x + half + 1, rect.y, {rect.w - half - 1, 0}.max, rect.h)
-      render_template(screen, left, focused && @focus == :template)
+      tmpl_focused = focused && @focus == :template
+      tmpl, chain = template_chain_split(left)
+      render_template(screen, tmpl, tmpl_focused && !@chain_focused)
+      render_chain_pane(screen, chain, tmpl_focused && @chain_focused)
       render_config(screen, right, focused && @focus == :config)
+    end
+
+    # TEMPLATE (top) + CHAIN (bottom) split — a slim 3-row CHAIN strip that grows (≥8, for
+    # the autocomplete dropdown) while focused; the template editor keeps the rest (≥1).
+    private def template_chain_split(col : Rect) : {Rect, Rect}
+      want = @chain_focused ? {col.h // 2, 8}.max : 3
+      chain_h = want.clamp(1, {col.h - 1, 1}.max)
+      tmpl_h = {col.h - chain_h, 1}.max
+      {Rect.new(col.x, col.y, col.w, tmpl_h),
+       Rect.new(col.x, col.y + tmpl_h, col.w, {col.h - tmpl_h, 0}.max)}
+    end
+
+    # The CHAIN sub-pane. Focused → the live editor (autocomplete); else a read-only view
+    # of the chain of the marker UNDER THE CURSOR (or a hint), so it's always visible.
+    private def render_chain_pane(screen : Screen, rect : Rect, focused : Bool) : Nil
+      return if rect.w < 2 || rect.h < 2
+      if focused
+        @chain_pane.render(screen, rect, true, "CHAIN · #{marker_label}", CHAIN_PLACEHOLDER)
+        return
+      end
+      chain = Fuzz::Template.chain_at(@editor.text, @editor.cursor_offset)
+      Frame.card(screen, rect, chain ? "CHAIN · #{marker_label}" : "CHAIN", bg: Theme.bg, border: Frame.pane_border(false))
+      inner = rect.inset(1, 1)
+      w = {inner.w, 1}.max
+      if chain.nil?
+        screen.text(inner.x, inner.y, "put the cursor in a §…§ marker · ^Y to edit", Theme.muted, width: w)
+      elsif chain.empty?
+        screen.text(inner.x, inner.y, "^Y to add an encode chain (e.g. base64-encode)", Theme.muted, width: w)
+      else
+        screen.text(inner.x, inner.y, chain, Theme.text, width: w)
+      end
     end
 
     private def render_bottom(screen : Screen, rect : Rect, focused : Bool) : Nil
@@ -1050,9 +1148,17 @@ module Gori::Tui
       badge = " §#{pc} "
       screen.text({rect.right - badge.size - 1, rect.x + label.size + 4}.max, rect.y, badge,
         pc > 0 ? Theme.text_bright : Theme.muted, pc > 0 ? Theme.accent_bg : Theme.bg)
-      # Marker i ↔ position i ↔ generator.set_for(i). Colours resolved fresh each frame
-      # (theme-reactive without a revision key, since the cached offsets are colour-free).
-      @editor.bg_regions = spans.map_with_index { |(a, b), i| {a, b, Theme.marker_bg(i)} }
+      # Marker i ↔ position i ↔ generator.set_for(i). The value gets the position hue; a
+      # trailing ¦chain (Convert transform-on-send) is over-painted with a neutral band so
+      # it reads as metadata, not payload. Colours resolved fresh each frame (offsets are
+      # colour-free); marker_regions is 1:1 with `spans`, so the config chips stay in sync.
+      bg = [] of {Int32, Int32, Color}
+      Fuzz::Template.marker_regions(@editor.text).each_with_index do |region, i|
+        a, sep, close = region
+        bg << {a, close + 1, Theme.marker_bg(i)}
+        bg << {sep, close + 1, Theme.elevated} if sep < close # dim the ¦chain segment
+      end
+      @editor.bg_regions = bg
       @editor.render(screen, rect.inset(1, 1), cursor: focused, highlight: :request)
     end
 

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -17,6 +17,9 @@ require "../replay/h2_engine"
 require "../replay/ws_engine"
 require "../replay/diff"
 require "../replay/flow_request"
+require "../fuzz"
+require "../convert"
+require "./chain_pane"
 
 module Gori::Tui
   # The Replay workbench (a tab). Layout: a target URL field on top, then a split
@@ -105,7 +108,18 @@ module Gori::Tui
       @inflight = false           # a replay round-trip is outstanding — gates re-send (^R mashing)
       @diffable = false           # true only when loaded from a captured flow (has an original to diff)
       @auto_content_length = true # recompute Content-Length from the edited body on send
-      @dirty = false              # set by every editor/target/flag mutator, cleared on save/restore
+      # Mark-transform mode (V22, opt-in, default off): when on, `§…§` markers in the
+      # request carry inline Convert chains applied on send (mark a value, attach
+      # base64-encode → it's encoded on the wire). Off = byte-identical to a plain send,
+      # so a captured `§` is never reinterpreted unless the user turns this on.
+      @mark_transform = false
+      # The CHAIN sub-pane (MARK mode): a visible editor for the chain of the §…§ marker
+      # under the request cursor. @chain_focused = editing it (split enlarges + keys route
+      # there); @chain_marker_cursor remembers which marker to write back to on commit.
+      @chain_pane = ChainPane.new
+      @chain_focused = false
+      @chain_marker_cursor = 0
+      @dirty = false # set by every editor/target/flag mutator, cleared on save/restore
     end
 
     # --- hex edit (^X on the REQUEST pane) ---
@@ -611,7 +625,7 @@ module Gori::Tui
     def restore(target : String, request : String, http2 : Bool, auto_cl : Bool,
                 response_head : Bytes? = nil, response_body : Bytes? = nil,
                 response_error : String? = nil, response_duration_us : Int64? = nil,
-                sni : String = "") : Nil
+                sni : String = "", mark_transform : Bool = false) : Nil
       @flow = nil
       @http2 = http2
       @target = target
@@ -636,6 +650,7 @@ module Gori::Tui
       @xscroll = 0
       @diffable = false
       @auto_content_length = auto_cl
+      @mark_transform = mark_transform
       @loaded = true
       @dirty = false
       @req_hex_edit = nil # a fresh load/restore replaces the request → drop any hex buffer
@@ -687,7 +702,20 @@ module Gori::Tui
       return @req_hex_edit.not_nil!.to_bytes if @req_hex_edit # byte-exact; NO auto-CL in hex mode
       return grpc_request_bytes if @grpc_mode                 # edited head + verbatim framed body
       return decoded_request_bytes if @decode_kind            # envelope + re-encoded decoded payload
+      return marked_request_bytes if @mark_transform          # §…§ inline Convert chains applied on send
       raw = @editor.to_bytes
+      @auto_content_length ? sync_content_length(raw) : raw
+    end
+
+    # MARK-transform mode: parse the CRLF wire form as a Fuzz template and render each
+    # marked position's default through its inline Convert chain (Template#apply_chains),
+    # then resync Content-Length as usual. Parsing the CRLF form (not @editor.text, which
+    # is LF) keeps render's output in wire form so the existing CRLF-based
+    # sync_content_length works unchanged. A chain-less `§v§` renders `v`; a failing chain
+    # passes the value through untransformed.
+    private def marked_request_bytes : Bytes
+      tmpl = Fuzz::Template.parse(String.new(@editor.to_bytes))
+      raw = tmpl.render(tmpl.apply_chains(tmpl.default_payloads, Convert.shared_registry))
       @auto_content_length ? sync_content_length(raw) : raw
     end
 
@@ -707,6 +735,111 @@ module Gori::Tui
       return @auto_content_length if @req_hex_edit # meaningless on raw bytes — refuse in hex mode
       @dirty = true
       @auto_content_length = !@auto_content_length
+    end
+
+    getter? mark_transform : Bool
+
+    # Toggle MARK-transform mode. Refused in the alternate request modes (hex / gRPC /
+    # decode / WS) where `§…§` templating doesn't apply — their request_bytes paths take
+    # precedence over the marked path anyway. Dirties so the flag persists.
+    def toggle_mark_transform : Bool
+      return @mark_transform if request_hex? || @grpc_mode || @decode_kind || @ws_mode
+      commit_chain_pane if @chain_focused # leaving MARK mode → save any pending chain edit
+      @dirty = true
+      @mark_transform = !@mark_transform
+    end
+
+    CHAIN_PLACEHOLDER = "put the cursor in a §…§ marker, then ^Y to add an encode chain (e.g. base64-encode)"
+
+    # Whether the CHAIN sub-pane currently owns keyboard input (MARK mode + focused +
+    # actually on the request column). The controller routes body keys here when true.
+    def chain_pane_active? : Bool
+      @mark_transform && @chain_focused && @focus == :request && !request_hex?
+    end
+
+    # ^Y: drop focus into the CHAIN pane for the marker under the request cursor. Returns
+    # a hint string when it can't (surfaced by the controller), nil on success.
+    def focus_chain_pane : String?
+      return "enable MARK mode first (^K)" unless @mark_transform
+      return "not available in hex edit" if request_hex?
+      return "move to the REQUEST pane first (↹)" unless @focus == :request
+      chain = Fuzz::Template.chain_at(@editor.text, @editor.cursor_offset)
+      return "put the cursor in a §…§ marker · ^A mark all · ^T insert §" if chain.nil?
+      @chain_marker_cursor = @editor.cursor_offset
+      @chain_pane.load(chain)
+      @chain_focused = true
+      nil
+    end
+
+    # Commit the CHAIN pane's text back to the bound marker and return focus to the editor.
+    # Idempotent — a no-op when the pane isn't focused (so set_focus can call it freely).
+    def commit_chain_pane : Nil
+      return unless @chain_focused
+      if updated = Fuzz::Template.set_chain(@editor.text, @chain_marker_cursor, @chain_pane.value)
+        @editor.set_text(updated)
+        @dirty = true
+      end
+      @chain_focused = false
+    end
+
+    # Route a key while the CHAIN pane is focused: typing/autocomplete stays in the pane;
+    # a focus-exit key (esc/↵/tab/↑) commits + returns to the request editor.
+    def handle_chain_pane_key(ev : Termisu::Event::Key) : Nil
+      return if @chain_pane.handle_key(ev) # consumed by the pane (edit / completion nav)
+      key = ev.key
+      commit_chain_pane if key.escape? || key.enter? || key.tab? || key.up?
+    end
+
+    # --- marking (MARK-transform mode) ---------------------------------------
+    # These mirror the Fuzzer's marking helpers but are gated on MARK mode + the REQUEST
+    # pane: a § is only special on send when MARK is on, so marking is pointless (and the
+    # tint hidden) otherwise. All delegate to the shared Fuzz::Template helpers.
+    def auto_mark : String
+      return mark_hint unless markable?
+      @editor.set_text(Fuzz::Template.auto_mark(@editor.text))
+      @dirty = true
+      n = Fuzz::Template.parse(@editor.text).position_count
+      "auto-marked #{n} position#{n == 1 ? "" : "s"}"
+    end
+
+    def mark_word : String
+      return mark_hint unless markable?
+      before = @editor.text
+      after = Fuzz::Template.mark_word(before, @editor.cursor_offset)
+      return "no word at the cursor — place it on a token (or auto-mark)" if after == before
+      @editor.set_text(after)
+      @dirty = true
+      Fuzz::Template.parse(after).position_count < Fuzz::Template.parse(before).position_count ? "unmarked position" : "marked position"
+    end
+
+    def insert_marker : String
+      return mark_hint unless markable?
+      @editor.insert(Fuzz::Template::MARKER)
+      @editor.set_preedit("")
+      @dirty = true
+      if @editor.text.count(Fuzz::Template::MARKER).odd?
+        "marker opened — move the cursor and mark again to close the region"
+      else
+        n = Fuzz::Template.parse(@editor.text).position_count
+        "marked point — #{n} position#{n == 1 ? "" : "s"}"
+      end
+    end
+
+    def clear_marks : String
+      return mark_hint unless markable?
+      @editor.set_text(Fuzz::Template.clear_markers(@editor.text))
+      @dirty = true
+      "cleared all § markers"
+    end
+
+    private def markable? : Bool
+      @mark_transform && @focus == :request && !request_hex?
+    end
+
+    private def mark_hint : String
+      return "enable MARK mode first (toggle it on)" unless @mark_transform
+      return "marking isn't available in hex edit" if request_hex?
+      "marking works on the REQUEST pane — ↹ to it"
     end
 
     # When enabled, rewrite an existing `Content-Length` header so it matches the
@@ -773,12 +906,13 @@ module Gori::Tui
     # focus change drops back to the URL field — otherwise navigating away while
     # editing SNI and returning would silently route URL keystrokes into @sni.
     private def set_focus(pane : Symbol) : Nil
+      commit_chain_pane if @chain_focused # any focus change saves a pending chain edit
       @focus = pane
       @target_field = :url
     end
 
     def set_preedit(text : String) : Nil
-      req_editor.set_preedit(text)
+      chain_pane_active? ? @chain_pane.set_preedit(text) : req_editor.set_preedit(text)
     end
 
     def pane_advance(dir : Int32) : Bool
@@ -827,6 +961,16 @@ module Gori::Tui
         else
           switch_req_pane(:envelope)
           @editor.click_to_cursor(env.inset(1, 1), mx, my)
+        end
+        return
+      end
+      if @mark_transform # split: click the CHAIN strip to edit it, else place the request caret
+        req, chain = req_chain_split(col)
+        if my >= chain.y
+          focus_chain_pane # binds to the marker at the current request cursor (hint ignored on a click)
+        else
+          commit_chain_pane if @chain_focused
+          @editor.click_to_cursor(req.inset(1, 1), mx, my)
         end
         return
       end
@@ -1195,10 +1339,56 @@ module Gori::Tui
         env, dec = decode_split(left)
         render_request(screen, env, req_focused && @req_pane == :envelope)
         render_decoded(screen, dec, req_focused && @req_pane == :decoded)
+      elsif @mark_transform # split into REQUEST (top) + CHAIN pane (bottom)
+        req, chain = req_chain_split(left)
+        render_request(screen, req, req_focused && !@chain_focused)
+        render_chain_pane(screen, chain, req_focused && @chain_focused)
       else
         render_request(screen, left, req_focused)
       end
       render_response(screen, right, focused && @focus == :response)
+    end
+
+    # REQUEST (top) + CHAIN (bottom) split for a MARK tab. The CHAIN strip is a slim 3
+    # rows normally and grows (≥8, for the autocomplete dropdown) while it's focused; the
+    # request editor keeps the rest (≥1 row).
+    private def req_chain_split(col : Rect) : {Rect, Rect}
+      want = @chain_focused ? {col.h // 2, 8}.max : 3
+      chain_h = want.clamp(1, {col.h - 1, 1}.max)
+      req_h = {col.h - chain_h, 1}.max
+      {Rect.new(col.x, col.y, col.w, req_h),
+       Rect.new(col.x, col.y + req_h, col.w, {col.h - req_h, 0}.max)}
+    end
+
+    # The CHAIN sub-pane. Focused → the live ChainPane editor (with autocomplete). Not
+    # focused → a read-only view of the chain of the marker UNDER THE CURSOR (updates as
+    # you move), or a hint when the cursor isn't in a marker — so the transform is always
+    # visible without entering the pane.
+    private def render_chain_pane(screen : Screen, rect : Rect, focused : Bool) : Nil
+      return if rect.w < 2 || rect.h < 2
+      if focused
+        @chain_pane.render(screen, rect, true, "CHAIN · #{marker_label}", CHAIN_PLACEHOLDER)
+        return
+      end
+      chain = Fuzz::Template.chain_at(@editor.text, @editor.cursor_offset)
+      Frame.card(screen, rect, chain ? "CHAIN · #{marker_label}" : "CHAIN", bg: Theme.bg, border: pane_border(false))
+      inner = rect.inset(1, 1)
+      w = {inner.w, 1}.max
+      if chain.nil?
+        screen.text(inner.x, inner.y, "put the cursor in a §…§ marker · ^Y to edit", Theme.muted, width: w)
+      elsif chain.empty?
+        screen.text(inner.x, inner.y, "^Y to add an encode chain (e.g. base64-encode)", Theme.muted, width: w)
+      else
+        screen.text(inner.x, inner.y, chain, Theme.text, width: w)
+      end
+    end
+
+    # "§N" label for the marker under the cursor (1-based), or "§" when not in one.
+    private def marker_label : String
+      spans = Fuzz::Template.marked_spans(@editor.text)
+      cur = @editor.cursor_offset
+      idx = spans.index { |(a, b)| a <= cur && cur <= b }
+      idx ? "§#{idx + 1}" : "§"
     end
 
     # The DECODED split sub-pane: the editable payload (SAML XML / GraphQL query+vars),
@@ -1319,7 +1509,28 @@ module Gori::Tui
       cl_x = {rect.right - cl.size - 1, rect.x + label.size + 4}.max
       screen.text(cl_x, rect.y, cl, @auto_content_length ? Theme.text_bright : Theme.muted,
         @auto_content_length ? Theme.accent_bg : Theme.bg)
+      paint_request_mark_tint(screen, rect, label, cl_x)
       @editor.render(screen, rect.inset(1, 1), cursor: focused, highlight: :request)
+    end
+
+    # In MARK-transform mode: draw the MARK badge (left of the CL badge) and tint each
+    # §…§ marker in the editor — value in the position hue, ¦chain over-painted dimmer.
+    # Off = clear the regions so a toggled-off tab paints untinted (empty = no-op paint).
+    private def paint_request_mark_tint(screen : Screen, rect : Rect, label : String, cl_x : Int32) : Nil
+      unless @mark_transform
+        @editor.bg_regions = [] of {Int32, Int32, Color}
+        return
+      end
+      mark = " MARK "
+      mx = {cl_x - mark.size, rect.x + label.size + 4}.max
+      screen.text(mx, rect.y, mark, Theme.text_bright, Theme.accent_bg) if mx + mark.size <= cl_x
+      bg = [] of {Int32, Int32, Color}
+      Fuzz::Template.marker_regions(@editor.text).each_with_index do |region, i|
+        a, sep, close = region
+        bg << {a, close + 1, Theme.marker_bg(i)}
+        bg << {sep, close + 1, Theme.elevated} if sep < close # dim the ¦chain segment
+      end
+      @editor.bg_regions = bg
     end
 
     private def render_response(screen : Screen, rect : Rect, focused : Bool) : Nil

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -3359,6 +3359,32 @@ module Gori::Tui
       replay_controller.replay_toggle_auto_content_length
     end
 
+    def replay_toggle_mark_transform : Nil
+      replay_controller.replay_toggle_mark_transform
+    end
+
+    def replay_auto_mark : Nil
+      replay_controller.replay_auto_mark
+    end
+
+    def replay_mark_word : Nil
+      replay_controller.replay_mark_word
+    end
+
+    def replay_insert_marker : Nil
+      replay_controller.replay_insert_marker
+    end
+
+    def replay_clear_marks : Nil
+      replay_controller.replay_clear_marks
+    end
+
+    # ^Y: jump focus DOWN into the visible CHAIN pane (the marker under the cursor). The
+    # controller gates on MARK mode + cursor-in-marker and toasts otherwise.
+    def replay_attach_chain : Nil
+      replay_controller.replay_focus_chain_pane
+    end
+
     def close_replay_tab : Nil
       replay_controller.close_replay_tab
     end
@@ -3391,6 +3417,12 @@ module Gori::Tui
 
     def fuzz_automark : Nil
       (v = fuzzer_controller.current_view) && (@toast = v.auto_mark)
+    end
+
+    # ^Y: jump focus DOWN into the visible CHAIN pane (the marker under the template
+    # cursor). The controller gates on cursor-in-marker and toasts otherwise.
+    def fuzz_attach_chain : Nil
+      fuzzer_controller.fuzz_focus_chain_pane
     end
 
     # --- Miner ExecContext / cross-tab mediators ---

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -67,14 +67,22 @@ module Gori
       abstract def replay_toggle_decoded : Nil             # toggle the envelope/decoded split sub-pane (SAML/GraphQL)
       abstract def replay_toggle_sni : Nil                 # toggle the SNI-override sub-field (target pane)
       abstract def replay_toggle_auto_content_length : Nil # recompute Content-Length on send
+      # mark-transform mode: mark request values (§…§) and attach Convert chains applied on send
+      abstract def replay_toggle_mark_transform : Nil # toggle MARK mode on/off
+      abstract def replay_auto_mark : Nil             # wrap every request param value in §…§
+      abstract def replay_mark_word : Nil             # toggle a marker around the token at the cursor
+      abstract def replay_insert_marker : Nil         # drop a single § at the cursor (bracket by hand)
+      abstract def replay_clear_marks : Nil           # strip all markers (and their chains)
+      abstract def replay_attach_chain : Nil          # open the chain-edit prompt for the marker at the cursor
 
       # fuzzer workbench (run/stop/marking handled inline; these power the palette + cross-tab)
-      abstract def fuzz_selected : Nil    # send History's selection to the Fuzzer tab
-      abstract def fuzz_from_replay : Nil # turn the current Replay request into a fuzz template
-      abstract def fuzz_run : Nil         # start the fuzz run
-      abstract def fuzz_stop : Nil        # stop the running fuzz
-      abstract def fuzz_new : Nil         # open a blank fuzz session
-      abstract def fuzz_automark : Nil    # auto-mark every request parameter
+      abstract def fuzz_selected : Nil     # send History's selection to the Fuzzer tab
+      abstract def fuzz_from_replay : Nil  # turn the current Replay request into a fuzz template
+      abstract def fuzz_run : Nil          # start the fuzz run
+      abstract def fuzz_stop : Nil         # stop the running fuzz
+      abstract def fuzz_new : Nil          # open a blank fuzz session
+      abstract def fuzz_automark : Nil     # auto-mark every request parameter
+      abstract def fuzz_attach_chain : Nil # open the chain-edit prompt for the marker at the template cursor
 
       # param miner (cross-tab seeds open a config popup, then mining runs in background)
       abstract def mine_selected : Nil    # mine History's selected flow (opens the config popup)
@@ -131,9 +139,9 @@ module Gori
       abstract def finding_edit_title : Nil               # rename + set severity via the form overlay
       abstract def finding_open_flow : Nil                # open the linked flow's detail in History
       abstract def finding_replay_flow : Nil              # send the linked flow to Replay
-      abstract def finding_links : Nil                     # open the links overlay for the open finding
-      abstract def finding_open_link : Nil                 # open the selected related item in its tab
-      abstract def finding_link_move(delta : Int32) : Nil  # move selection in the RELATED list
+      abstract def finding_links : Nil                    # open the links overlay for the open finding
+      abstract def finding_open_link : Nil                # open the selected related item in its tab
+      abstract def finding_link_move(delta : Int32) : Nil # move selection in the RELATED list
       abstract def findings_export(format : Symbol) : Nil # :markdown | :json → project dir
 
       # entity links (cross-tab attach + link-target ids for availability gating)

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -77,7 +77,7 @@ module Gori
         Verb::Scope::Replay, [Verb::Chord.new("x", ctrl: true)],
         available: in_replay) { |ctx| ctx.replay_toggle_hex; nil }
       r.register Verb::Definition.new(
-        "replay.toggle-decoded", "Switch envelope/decoded", "For a SAML/GraphQL flow: switch between the request envelope and the decoded payload",
+        "replay.toggle-decoded", "Switch envelope/decoded", "SAML/GraphQL flow: switch envelope/decoded · in MARK mode: insert a § at the cursor",
         Verb::Scope::Replay, [Verb::Chord.new("t", ctrl: true)],
         available: in_replay) { |ctx| ctx.replay_toggle_decoded; nil }
       r.register Verb::Definition.new(
@@ -88,6 +88,29 @@ module Gori
         "replay.toggle-auto-content-length", "Toggle auto Content-Length", "Recompute Content-Length from the body on send",
         Verb::Scope::Replay, [Verb::Chord.new("l", ctrl: true)],
         available: in_replay) { |ctx| ctx.replay_toggle_auto_content_length; nil }
+
+      # --- mark-transform (mark request values, attach Convert chains applied on send) ---
+      r.register Verb::Definition.new(
+        "replay.toggle-mark-transform", "Toggle MARK transform", "Mark request values (§…§) and apply Convert chains on send",
+        Verb::Scope::Replay, [Verb::Chord.new("k", ctrl: true)],
+        available: in_replay, mnemonic: 't') { |ctx| ctx.replay_toggle_mark_transform; nil }
+      r.register Verb::Definition.new(
+        "replay.auto-mark", "Auto-mark params", "Wrap every request parameter value in a §…§ marker",
+        Verb::Scope::Replay, [Verb::Chord.new("a", ctrl: true)],
+        available: in_replay, mnemonic: 'a') { |ctx| ctx.replay_auto_mark; nil }
+      r.register Verb::Definition.new(
+        "replay.mark-word", "Mark word", "Toggle a §…§ marker around the token at the cursor",
+        Verb::Scope::Replay, available: in_replay, mnemonic: 'w') { |ctx| ctx.replay_mark_word; nil }
+      r.register Verb::Definition.new(
+        "replay.insert-marker", "Insert marker", "Drop a single § at the cursor to bracket a region by hand",
+        Verb::Scope::Replay, available: in_replay, mnemonic: 'i') { |ctx| ctx.replay_insert_marker; nil }
+      r.register Verb::Definition.new(
+        "replay.clear-marks", "Clear markers", "Strip every §…§ marker (and its attached chain)",
+        Verb::Scope::Replay, available: in_replay, mnemonic: 'c') { |ctx| ctx.replay_clear_marks; nil }
+      r.register Verb::Definition.new(
+        "replay.attach-chain", "Edit convert chain", "Focus the CHAIN pane to edit the encode/decode chain of the marker at the cursor (applied on send)",
+        Verb::Scope::Replay, [Verb::Chord.new("y", ctrl: true)],
+        available: in_replay, mnemonic: 'e') { |ctx| ctx.replay_attach_chain; nil }
 
       # --- detail view ---
       # esc/q always leave. ← walks back through the panes (FRAMES→RES→REQ) and only
@@ -214,6 +237,10 @@ module Gori
       r.register Verb::Definition.new(
         "fuzz.automark", "Auto-mark params", "Mark every request parameter value", Verb::Scope::Fuzzer,
         [Verb::Chord.new("a", ctrl: true)], available: in_fuzzer, mnemonic: 'm') { |ctx| ctx.fuzz_automark; nil }
+      r.register Verb::Definition.new(
+        "fuzz.attach-chain", "Edit convert chain", "Focus the CHAIN pane to edit the encode/decode chain of the marker at the cursor (applied to each payload on send)",
+        Verb::Scope::Fuzzer, [Verb::Chord.new("y", ctrl: true)],
+        available: in_fuzzer, mnemonic: 'c') { |ctx| ctx.fuzz_attach_chain; nil }
     end
 
     # Param-miner verbs: the cross-tab "Mine parameters" entry (space menu in History,


### PR DESCRIPTION
## Summary

Mark a request value Fuzzer-style (`§…§`) and attach a **Convert encode/decode chain** that is applied **automatically on send**.

```
user=admin&token=§secret¦base64-encode§   →   user=admin&token=c2VjcmV0
```

The chain lives inline in the marker (`¦` delimiter — not `|`, which the chain syntax already uses as a step separator; `¦¦` escapes a literal). One data model drives **Replay**, **Fuzzer**, and the headless **`gori run fuzz`** / **MCP** paths.

- **Fuzzer** — chains apply per-payload at the render seam (`Generator#emit`), covering all four attack modes; `gori run fuzz` / MCP inherit them for free.
- **Replay** — an **opt-in per-tab MARK toggle** (`^K`); default off is byte-identical to today (a captured `§` stays literal). Persisted via **schema V22** (`replays.mark_transform`).
- Pure `Template#apply_chains` over the cached `Convert.shared_registry`; a failing / unknown chain passes the value through untransformed and never raises. Content-Length is resynced after the transform.

## UX

A **visible CHAIN pane** (shared `ChainPane` widget) sits below the request/template editor in MARK mode and shows/edits the chain of the marker **under the cursor** (header `CHAIN · §N`), with converter-name **autocomplete**.

- `^K` toggle MARK · `^T` insert a `§` · `^Y` focus the CHAIN pane · `^A` auto-mark params
- Guiding hints on toggle and in the pane; all replace the earlier hidden modal prompt.

## Also

Fixes two latent `Fuzz::Template` bugs surfaced once chains exist: `clear_markers` dead-code `.then`-on-`Slice`, and `mark_word` unmark leaving a stray `¦chain`.

## Testing

- `crystal spec` — **1116 examples, 0 failures** (new `chain_pane_spec` + Template/Generator/store/Replay/Fuzzer coverage).
- Headless e2e: `gori run fuzz` against a local listener confirms `hello → aGVsbG8=` on the wire with Content-Length resynced.
- Live TUI (tmux): MARK badge, `CHAIN · §1` pane, autocomplete, and commit writing `§GET¦base64-encode§`.
