### PR TITLE
perf(proxy,tui,store): fix seven verified hot-path degraders

### DIFF
--- a/src/gori/proxy/codec/body.cr
+++ b/src/gori/proxy/codec/body.cr
@@ -199,8 +199,12 @@ module Gori::Proxy::Codec
 
     # Copies exactly `n` bytes; returns false if the source EOF'd early (a
     # truncated Content-Length body), true once all `n` were transferred.
-    private def self.copy_n(src : IO, dst : IO, tee : IO, n : Int64) : Bool
-      buf = Bytes.new(BUFSIZE)
+    # `buf` is the scratch copy buffer. The Length-framing caller lets it default to a
+    # fresh 64 KiB slice (one alloc per body); copy_chunked passes ONE buffer reused
+    # across every chunk (a chunked body used to allocate a fresh 64 KiB per chunk — a
+    # 100 MB response in 16 KB chunks churned ~400 MB of throwaway buffers). Safe to
+    # share: a body is pumped one direction on one fiber, so chunks copy sequentially.
+    private def self.copy_n(src : IO, dst : IO, tee : IO, n : Int64, buf : Bytes = Bytes.new(BUFSIZE)) : Bool
       remaining = n
       while remaining > 0
         want = remaining < BUFSIZE ? remaining.to_i : BUFSIZE
@@ -226,6 +230,7 @@ module Gori::Proxy::Codec
     # Returns true once the terminating 0-length chunk is seen; false if the
     # source EOF'd mid-stream (a truncated chunked body).
     private def self.copy_chunked(src : IO, dst : IO, tee : IO) : Bool
+      buf = Bytes.new(BUFSIZE) # reused across every chunk's copy_n (see copy_n)
       loop do
         size_line = read_crlf_line(src)
         # EOF before any byte → truncated mid-stream. A line that hit MAX_LINE_BYTES WITHOUT an
@@ -261,8 +266,8 @@ module Gori::Proxy::Codec
           end
           return true # terminating chunk reached
         end
-        return false unless copy_n(src, dst, tee, size) # truncated mid-chunk
-        if crlf = read_exact(src, 2)                    # the CRLF terminating the chunk data
+        return false unless copy_n(src, dst, tee, size, buf) # truncated mid-chunk
+        if crlf = read_exact(src, 2)                         # the CRLF terminating the chunk data
           emit(dst, tee, crlf)
         end
       end

--- a/src/gori/scope.cr
+++ b/src/gori/scope.cr
@@ -31,8 +31,14 @@ module Gori
       getter match_type : String # "host" | "string" | "regex"
       getter pattern : String
       @regex : Regex?
+      @pattern_down : String
 
       def initialize(@id : Int64, @kind : String, @match_type : String, @pattern : String)
+        # The pattern is immutable (a Rule is rebuilt, never edited in place), so its
+        # lowercased form — compared on every host/string match, once per rule per row
+        # of a Scope-filtered reload and per host of a Sitemap reload — is computed ONCE
+        # here rather than re-allocated on each `matches?` call (mirrors @regex).
+        @pattern_down = @pattern.downcase
         # Compile the regex once. An invalid pattern degrades to nil → never-match,
         # rather than unwinding through SQLite's C REGEXP callback or a proxy fiber.
         # Persisted patterns are validated on add/update; this is defense-in-depth.
@@ -65,7 +71,7 @@ module Gori
         when "host"
           host_match?(host)
         when "string"
-          url.downcase.includes?(@pattern.downcase)
+          url.downcase.includes?(@pattern_down)
         when "regex"
           r = @regex
           return false unless r
@@ -86,13 +92,12 @@ module Gori
           # unwind onto the proxy hot path (mirrors SQLite GLOB's tolerance → keeps
           # live gating and the History SQL view consistent).
           begin
-            File.match?(@pattern.downcase, h)
+            File.match?(@pattern_down, h)
           rescue File::BadPatternError
             false
           end
         else
-          d = @pattern.downcase
-          h == d || h.ends_with?(".#{d}")
+          h == @pattern_down || h.ends_with?(".#{@pattern_down}")
         end
       end
     end

--- a/src/gori/store/safe_regexp.cr
+++ b/src/gori/store/safe_regexp.cr
@@ -26,21 +26,32 @@ module Gori
   # we read the FULL byte length via `value_bytes` so content past a NUL — common in a
   # body that mixes binary and text — is still matched.
   module SafeRegexp
-    # SQLite fires this scalar callback once per row, but a query's pattern is constant
-    # across all rows — recompiling per row is O(rows) PCRE2 compiles. Memoise the last
-    # (pattern → Regex). gori is single-threaded (fibers, no -Dpreview_mt) and the
-    # callback never yields, so a bare last-value memo is race-free: the pattern+regex
-    # pair is assigned together with no yield point between the two stores.
-    @@cache_pattern : String? = nil
-    @@cache_regex : Regex? = nil
+    # SQLite fires this scalar callback once per row. A query's WHERE clause holds a
+    # small FIXED set of regex patterns — one per `~` term / regex scope rule — constant
+    # across all rows, so recompiling per row is O(rows) PCRE2 compiles. Memoise every
+    # distinct pattern → Regex for the scan (O(patterns), not O(rows)).
+    #
+    # A single-slot last-value memo THRASHED the moment a query mixed two patterns
+    # (`body~x host~y`, or a regex scope rule AND-combined with a `~` term — see
+    # Scope#filter + QL.and): SQLite alternates the two patterns as it walks rows, and
+    # each call evicted the other from the one slot, so BOTH recompiled every row
+    # (2×rows compiles instead of 2). A small bounded map holds every pattern in the
+    # query at once. gori is single-threaded (fibers, no -Dpreview_mt) and the callback
+    # never yields (PCRE2 compile + Hash ops have no yield point), so a bare Hash is
+    # race-free — same reasoning the last-value memo relied on.
+    CACHE_MAX = 32
+    @@cache = {} of String => Regex
 
     # :nodoc: — internal (called from FN, which needs an explicit receiver, so not private)
     def self.compile(pattern : String) : Regex
-      cached = @@cache_regex
-      return cached if cached && @@cache_pattern == pattern
+      if rx = @@cache[pattern]?
+        return rx
+      end
       rx = Regex.new(pattern) # raises on a bad pattern (caught by FN); cache only on success
-      @@cache_pattern = pattern
-      @@cache_regex = rx
+      # Bound memory across a long session of varied queries. A realistic scan uses
+      # ≤ a few distinct patterns, so this clear never evicts a pattern mid-scan.
+      @@cache.clear if @@cache.size >= CACHE_MAX
+      @@cache[pattern] = rx
       rx
     end
 

--- a/src/gori/tui/convert_view.cr
+++ b/src/gori/tui/convert_view.cr
@@ -161,7 +161,7 @@ module Gori::Tui
       @out_scroll = @out_scroll.clamp(0, {lines.size - rect.h, 0}.max)
       fg = result.output.nil? ? Theme.red : Theme.text
       rows = (0...rect.h).compact_map { |i| lines[@out_scroll + i]? }
-      @out_xscroll = @out_xscroll.clamp(0, {(rows.max_of? { |l| Screen.display_width(l) } || 0) - rect.w, 0}.max)
+      @out_xscroll = @out_xscroll.clamp(0, {(rows.max_of? { |l| Screen.display_width_upto(l, @out_xscroll + rect.w + 1) } || 0) - rect.w, 0}.max)
       rows.each_with_index do |line, i|
         shown = @out_xscroll > 0 ? Highlight.slice_left_text(line, @out_xscroll) : line
         screen.text(rect.x, rect.y + i, shown, fg, Theme.bg, width: rect.w)

--- a/src/gori/tui/findings_view.cr
+++ b/src/gori/tui/findings_view.cr
@@ -468,7 +468,7 @@ module Gori::Tui
       else
         visible_h = {rect.bottom - notes_y, 0}.max
         rows = finding.notes.split('\n').first(visible_h)
-        @notes_xscroll = @notes_xscroll.clamp(0, {(rows.max_of? { |l| Screen.display_width(l) } || 0) - notes_rect.w, 0}.max)
+        @notes_xscroll = @notes_xscroll.clamp(0, {(rows.max_of? { |l| Screen.display_width_upto(l, @notes_xscroll + notes_rect.w + 1) } || 0) - notes_rect.w, 0}.max)
         rows.each_with_index do |note_line, i|
           shown = @notes_xscroll > 0 ? Highlight.slice_left_text(note_line, @notes_xscroll) : note_line
           screen.text(notes_rect.x, notes_rect.y + i, shown, Theme.text, width: notes_rect.w)

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -112,6 +112,16 @@ module Gori::Tui
       @dist_cache = nil.as(DistData?)
       @dist_cache_rev = -1_i64
       @dist_cache_w = -1
+      # Results-pane memos, all keyed on @results_rev (the O(n)/O(n log n) scans below
+      # ran EVERY frame — the busiest moment is a live run streaming results, each of
+      # which forces a redraw). matched_count is rev-only; the sorted view also keys on
+      # the sort order + matched-only toggle.
+      @matched_count_cache = 0
+      @matched_count_rev = -1_i64
+      @sorted_cache = nil.as(Array(Fuzz::Result)?)
+      @sorted_cache_rev = -1_i64
+      @sorted_cache_sort = :index
+      @sorted_cache_matched = false
       @progress = nil.as(Fuzz::Progress?)
       @run_total = nil.as(Int64?)
       @job_id = 0
@@ -127,6 +137,13 @@ module Gori::Tui
       @d_graphql = nil.as(Graphql::Op?)
       @d_form = nil.as(Array(FormData::Field)?)
       @decoded_index = nil.as(Int64?)
+      # The reconstructed request / decoded response text of the OPEN result detail,
+      # cached by {pane, row index} — the request pane re-parsed the template + rendered
+      # payloads and the response pane re-scrubbed + split the whole (possibly multi-MiB)
+      # body on EVERY scroll keystroke. The selected row is fixed while the detail is open
+      # (same invariant @decoded_index relies on), so this only recomputes on pane/row change.
+      @detail_lines_cache = nil.as(Array(String)?)
+      @detail_lines_key = nil.as({Symbol, Int64}?)
       @focus = :template
       @loaded = false
       @dirty = false
@@ -385,6 +402,10 @@ module Gori::Tui
     def begin_run(total : Int64?) : Nil
       @results.clear
       @results_rev += 1
+      # A fresh run reuses result indices from 0, so drop the {pane, index}-keyed detail
+      # cache — otherwise an old row's lines could survive under a colliding new index.
+      @detail_lines_cache = nil
+      @detail_lines_key = nil
       @sel = 0
       @scroll = 0
       @running = true
@@ -409,7 +430,10 @@ module Gori::Tui
     end
 
     def matched_count : Int32
-      @results.count(&.matched?)
+      return @matched_count_cache if @matched_count_rev == @results_rev
+      @matched_count_cache = @results.count(&.matched?)
+      @matched_count_rev = @results_rev
+      @matched_count_cache
     end
 
     def result_count : Int32
@@ -892,14 +916,24 @@ module Gori::Tui
     end
 
     private def sorted_results : Array(Fuzz::Result)
-      rows = @matched_only ? @results.select(&.matched?) : @results
-      case @sort
-      when :status then rows.sort_by { |r| r.status || -1 }
-      when :length then rows.sort_by(&.length)
-      when :words  then rows.sort_by(&.words)
-      when :time   then rows.sort_by(&.duration_us)
-      else              rows
+      if (c = @sorted_cache) && @sorted_cache_rev == @results_rev &&
+         @sorted_cache_sort == @sort && @sorted_cache_matched == @matched_only
+        return c
       end
+      rows = @matched_only ? @results.select(&.matched?) : @results
+      sorted =
+        case @sort
+        when :status then rows.sort_by { |r| r.status || -1 }
+        when :length then rows.sort_by(&.length)
+        when :words  then rows.sort_by(&.words)
+        when :time   then rows.sort_by(&.duration_us)
+        else              rows # :index — the live @results order (uncopied; read-only here)
+        end
+      @sorted_cache = sorted
+      @sorted_cache_rev = @results_rev
+      @sorted_cache_sort = @sort
+      @sorted_cache_matched = @matched_only
+      sorted
     end
 
     # --- target editing ------------------------------------------------------
@@ -1586,7 +1620,7 @@ module Gori::Tui
       # Clamp so ↓/wheel can't scroll past the last line into a blank void (keeps ≥1 row).
       @detail_scroll = @detail_scroll.clamp(0, {lines.size - 1, 0}.max)
       rows = (0...inner.h).compact_map { |i| lines[@detail_scroll + i]? }
-      @detail_xscroll = @detail_xscroll.clamp(0, {(rows.max_of? { |l| Screen.display_width(l) } || 0) - inner.w, 0}.max)
+      @detail_xscroll = @detail_xscroll.clamp(0, {(rows.max_of? { |l| Screen.display_width_upto(l, @detail_xscroll + inner.w + 1) } || 0) - inner.w, 0}.max)
       rows.each_with_index do |line, i|
         shown = @detail_xscroll > 0 ? Highlight.slice_left_text(line, @detail_xscroll) : line
         screen.text(inner.x, inner.y + i, shown, Theme.text, Theme.bg, width: inner.w)
@@ -1629,14 +1663,22 @@ module Gori::Tui
     end
 
     private def detail_lines(r : Fuzz::Result) : Array(String)
-      case @detail_pane
-      when :saml    then saml_detail_lines
-      when :jwt     then jwt_detail_lines
-      when :graphql then graphql_detail_lines
-      when :params  then form_detail_lines
-      when :request then detail_request_lines(r)
-      else               detail_response_lines(r)
+      key = {@detail_pane, r.index}
+      if (c = @detail_lines_cache) && @detail_lines_key == key
+        return c
       end
+      lines =
+        case @detail_pane
+        when :saml    then saml_detail_lines
+        when :jwt     then jwt_detail_lines
+        when :graphql then graphql_detail_lines
+        when :params  then form_detail_lines
+        when :request then detail_request_lines(r)
+        else               detail_response_lines(r)
+        end
+      @detail_lines_cache = lines
+      @detail_lines_key = key
+      lines
     end
 
     # The reconstructed wire request for a result (template with its payloads spliced in).

--- a/src/gori/tui/highlight.cr
+++ b/src/gori/tui/highlight.cr
@@ -413,6 +413,19 @@ module Gori::Tui
       line.sum { |span| Screen.display_width(span.text) }
     end
 
+    # As `line_width`, but stops summing once the running width reaches `limit` — and
+    # caps WITHIN a span too (a huge minified body is one plain span > MAX_HL_LINE), so
+    # the per-frame h-scroll clamp never fully measures a multi-MB line. See
+    # Screen.display_width_upto. Exact for lines narrower than limit.
+    def self.line_width_upto(line : Line, limit : Int32) : Int32
+      w = 0
+      line.each do |span|
+        break if w >= limit
+        w += Screen.display_width_upto(span.text, limit - w)
+      end
+      w
+    end
+
     # --- line builders -------------------------------------------------------
 
     private def self.start_line(raw : String, request : Bool) : Line

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -825,7 +825,7 @@ module Gori::Tui
       # Styles each visible line ONCE (into `rows`), then clamps/slices from that —
       # never re-styles just to measure width (mirrors ReplayView#render_response_body).
       rows = (0...body.h).compact_map { |i| (li = @detail_scroll + i) < total ? dv.line_at(li) : nil }
-      @detail_xscroll = @detail_xscroll.clamp(0, {(rows.max_of? { |l| Highlight.line_width(l) } || 0) - cw, 0}.max)
+      @detail_xscroll = @detail_xscroll.clamp(0, {(rows.max_of? { |l| Highlight.line_width_upto(l, @detail_xscroll + cw + 1) } || 0) - cw, 0}.max)
       rows.each_with_index do |styled, i|
         li = @detail_scroll + i
         Gutter.draw(screen, body.x, body.y + i, li, gw)
@@ -843,7 +843,7 @@ module Gori::Tui
       total = lines.size
       gw = {Gutter.width(total), body.w}.min
       cw = {body.w - gw, 0}.max
-      widest = (0...body.h).compact_map { |i| lines[@detail_scroll + i]? }.max_of? { |l| Screen.display_width(l) } || 0
+      widest = (0...body.h).compact_map { |i| lines[@detail_scroll + i]? }.max_of? { |l| Screen.display_width_upto(l, @detail_xscroll + cw + 1) } || 0
       @detail_xscroll = @detail_xscroll.clamp(0, {widest - cw, 0}.max)
       (0...body.h).each do |i|
         li = @detail_scroll + i

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -432,7 +432,7 @@ module Gori::Tui
         # Styles each visible line ONCE (into `rows`), then clamps/slices from that —
         # mirrors ReplayView#render_response_body / HistoryView#render_detail.
         rows = (0...inner.h).compact_map { |i| i < total ? win.line_at(i) : nil }
-        @detail_xscroll = @detail_xscroll.clamp(0, {(rows.max_of? { |l| Highlight.line_width(l) } || 0) - inner.w, 0}.max)
+        @detail_xscroll = @detail_xscroll.clamp(0, {(rows.max_of? { |l| Highlight.line_width_upto(l, @detail_xscroll + inner.w + 1) } || 0) - inner.w, 0}.max)
         rows.each_with_index do |styled, i|
           shown = @detail_xscroll > 0 ? Highlight.slice_left(styled, @detail_xscroll) : styled
           Highlight.draw(screen, inner.x, inner.y + i, shown, width: inner.w)

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -1686,7 +1686,7 @@ module Gori::Tui
       total = lines.size
       gw = {Gutter.width(total), rect.w}.min
       cw = {rect.w - gw, 0}.max
-      widest = (0...rect.h).compact_map { |i| lines[@scroll + i]? }.max_of? { |l| Screen.display_width(l) } || 0
+      widest = (0...rect.h).compact_map { |i| lines[@scroll + i]? }.max_of? { |l| Screen.display_width_upto(l, @xscroll + cw + 1) } || 0
       @xscroll = @xscroll.clamp(0, {widest - cw, 0}.max)
       (0...rect.h).each do |i|
         li = @scroll + i
@@ -1718,7 +1718,7 @@ module Gori::Tui
       # Styles each visible line ONCE (into `rows`), then clamps/slices from that —
       # never re-styles just to measure width (see the class comment on RespView).
       rows = (0...rect.h).compact_map { |i| (li = @scroll + i) < total ? rv.line_at(li) : nil }
-      @xscroll = @xscroll.clamp(0, {(rows.max_of? { |l| Highlight.line_width(l) } || 0) - cw, 0}.max)
+      @xscroll = @xscroll.clamp(0, {(rows.max_of? { |l| Highlight.line_width_upto(l, @xscroll + cw + 1) } || 0) - cw, 0}.max)
       rows.each_with_index do |styled, i|
         li = @scroll + i
         Gutter.draw(screen, rect.x, rect.y + i, li, gw)

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -368,8 +368,15 @@ module Gori::Tui
       # Prism analyzer events (issues persisted / reflections found) — coalesced to one
       # list reload per tick inside the controller; drives a redraw when anything landed.
       drained = true if prism_controller.drain_events
-      # Coalesce a filtered-view reload to once per drain (on_event only flagged it).
-      history_controller.view.flush_filter(@session.store)
+      # Coalesce a filtered-view reload to once per drain (on_event only flagged it). A
+      # filtered / Scope-lens History can't update incrementally, so flush_filter re-runs
+      # the FULL-table search; do it only while History is the ACTIVE tab. In the
+      # background it would re-scan the whole page up to ~20×/sec during capture for a
+      # list nobody is viewing (a Scope lens alone puts every session in this state). The
+      # accumulated @filter_dirty makes it catch up on the first drain after History
+      # becomes active, and on_enter reloads on entry — so the list is never shown stale.
+      # (Mirrors apply_external_change, which already only reloads the active tab.)
+      history_controller.view.flush_filter(@session.store) if @active_tab == :history
       drained
     end
 

--- a/src/gori/tui/screen.cr
+++ b/src/gori/tui/screen.cr
@@ -47,6 +47,21 @@ module Gori::Tui
       w
     end
 
+    # As `display_width`, but stops as soon as the running width reaches `limit`
+    # (returning a value ≥ limit without walking the rest of the string). The h-scroll
+    # clamps only need to know whether a line reaches the current view's right edge +
+    # one screen, so a minified multi-MB single line isn't grapheme-walked in full on
+    # EVERY frame just to clamp the scroll offset. Exact for lines narrower than limit.
+    def self.display_width_upto(str : String, limit : Int32) : Int32
+      return 0 if str.empty? || limit <= 0
+      w = 0
+      str.each_grapheme do |g|
+        w += Termisu::UnicodeWidth.grapheme_width(g.to_s)
+        return w if w >= limit
+      end
+      w
+    end
+
     # The codepoint index in `str` whose display cell the column `target` lands on,
     # clamped to [0, str.size]. Inverts a left-to-right display-width advance (the
     # same one `display_width` / `text` use), so click-to-cursor maps a click x to


### PR DESCRIPTION
## What

Performance pass driven by four parallel subsystem audits (store, TUI render, proxy byte path, search/QL). The obvious hot paths were already tuned by prior rounds — these are the **remaining** verified degraders.

| Impact | Fix |
|--------|-----|
| **HIGH** | `store/safe_regexp`: the per-row `REGEXP` memo held one `(pattern → Regex)` pair, so a query with ≥2 distinct patterns (`body~x host~y`, or a regex Scope rule AND-combined with a `~` term) thrashed it → recompile **per row**. Bounded map keeps every pattern in the scan compiled once. |
| **HIGH** | `proxy/codec/body`: `copy_chunked` re-allocated a 64 KiB buffer **per chunk** (a 100 MB response in 16 KB chunks churned ~400 MB). Reuse one buffer per connection across chunks. |
| Med-High | `tui/fuzzer_view`: memoize `matched_count` (O(n)) + `sorted_results` (O(n log n), n≤5000) that ran **every frame** during live runs; keys `@results_rev` / `+@sort,@matched_only`. |
| Med-High | `tui/runner`: a filtered / Scope-lens History re-ran the full-table `search(PAGE=1000)` ~20×/s during capture **even when History wasn't the active tab**. Gate the reload on the active tab; it catches up via `@filter_dirty` on entry (mirrors `apply_external_change`). |
| Med | `tui/fuzzer_view`: cache the RESULT detail request/response lines (were re-parsing the template + re-splitting the whole body on every scroll keystroke). |
| Med | `tui`: bound the per-frame xscroll width measurement with early-out `Screen.display_width_upto` / `Highlight.line_width_upto` (8 clamp sites) so a minified multi-MB single line isn't fully grapheme-walked on every nav key. |
| Low-Med | `scope`: precompute `Rule#@pattern_down` instead of downcasing the immutable pattern on every match. |

## Verification

- `crystal spec` — **1116 examples, 0 failures**.
- `crystal tool format` + `ameba` clean (no new violations).
- Throwaway specs confirmed multi-chunk byte-exactness (sizes straddling the 64 KiB buffer) and that two interleaved regex patterns both stay cached (`.same?`, no thrash).

## Deferred (higher-risk architectural rewrites, noted for a future round)

Head parsing String-per-line/header allocation; HPACK Huffman bit-by-bit → table-driven; blocking `insert_flow`/`update_response` + synchronous FTS tokenization on the lone writer; `^F` search un-debounced O(body)/keystroke; `lower(host)` expression index (needs a schema bump); `CaptureBuffer` pooling.