### PR TITLE
feat(tui): surface toggle shortcuts as lit/muted badges across the TUI

### DIFF
--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -103,7 +103,9 @@ describe Gori::Tui::FuzzerView do
       3.times { |i| view.append_result(fuzz_result(i, 200, 1200)) }
       backend = MemoryBackend.new(50, 30)
       view.render(Screen.new(backend), Rect.new(0, 0, 50, 30))
-      backend.contains?("DIST").should be_false
+      # the sidebar CARD (title " DIST ") is gone; the always-on " v:DIST " toggle badge
+      # on the RESULTS border is not the sidebar, so match the spaced card title.
+      backend.contains?(" DIST ").should be_false
       backend.contains?("RESULTS").should be_true
     end
 
@@ -123,7 +125,8 @@ describe Gori::Tui::FuzzerView do
       view.toggle_dist # hide
       backend = MemoryBackend.new(120, 30)
       view.render(Screen.new(backend), Rect.new(0, 0, 120, 30))
-      backend.contains?("DIST").should be_false
+      # sidebar CARD gone; the muted " v:DIST " toggle badge on the RESULTS border remains
+      backend.contains?(" DIST ").should be_false
     end
   end
 

--- a/spec/tui/intercept_view_spec.cr
+++ b/spec/tui/intercept_view_spec.cr
@@ -145,8 +145,9 @@ describe "Intercept filter bar" do
       view.reload(ic)
       backend = MemoryBackend.new(100, 8)
       view.render(Screen.new(backend), Rect.new(0, 0, 100, 8))
-      backend.row(0).includes?("catch:all").should be_true # default direction chip
-      backend.contains?("/ condition").should be_true      # field hint
+      backend.row(0).includes?("c:ALL").should be_true   # default direction chip (c cycles it)
+      backend.row(0).includes?("i:CATCH").should be_true # master catch toggle badge
+      backend.contains?("/ condition").should be_true    # field hint
     end
   end
 
@@ -157,7 +158,7 @@ describe "Intercept filter bar" do
       view.reload(ic)
       backend = MemoryBackend.new(100, 8)
       view.render(Screen.new(backend), Rect.new(0, 0, 100, 8))
-      backend.row(0).includes?("catch:req").should be_true
+      backend.row(0).includes?("c:REQ").should be_true
     end
   end
 
@@ -190,8 +191,8 @@ describe "Intercept filter bar" do
       view.reload(ic)
       backend = MemoryBackend.new(100, 12)
       view.render(Screen.new(backend), Rect.new(0, 0, 100, 12))
-      backend.row(0).includes?("catch:all").should be_true # bar on the top row
-      backend.contains?("QUEUE (1)").should be_true        # queue card still drawn below
+      backend.row(0).includes?("c:ALL").should be_true # bar on the top row
+      backend.contains?("QUEUE (1)").should be_true    # queue card still drawn below
       backend.contains?("acme.test/login").should be_true
     end
   end

--- a/spec/tui/replay_view_spec.cr
+++ b/spec/tui/replay_view_spec.cr
@@ -47,10 +47,9 @@ describe Gori::Tui::ReplayView do
     backend = MemoryBackend.new(120, 20)
     view.render(Screen.new(backend), Rect.new(0, 0, 120, 20))
     backend.contains?("PONG").should be_true
-    # the "response" toggle is the active (bright) segment — i.e. NOT the diff view
-    ry = (0...20).find { |y| backend.row(y).includes?("response") }.not_nil!
-    rx = backend.row(ry).index("response").not_nil!
-    backend.fg_at(rx, ry).should eq(Theme.text_bright)
+    # plain response mode: the diff toggle chip is inactive (muted), not lit — the
+    # pane no longer carries a separate "response" chip (it's titled RESPONSE).
+    ry = (0...20).find { |y| backend.row(y).includes?("d:diff") }.not_nil!
     dx = backend.row(ry).index("diff").not_nil!
     backend.fg_at(dx, ry).should eq(Theme.muted) # diff segment inactive
   end
@@ -107,9 +106,8 @@ describe Gori::Tui::ReplayView do
       backend = MemoryBackend.new(120, 20)
       view.render(Screen.new(backend), Rect.new(0, 0, 120, 20))
       backend.contains?("NEW").should be_true
-      ry = (0...20).find { |y| backend.row(y).includes?("response") }.not_nil!
-      rx = backend.row(ry).index("response").not_nil!
-      backend.fg_at(rx, ry).should eq(Theme.text_bright) # response tab active
+      # response view kept — the diff toggle was NOT auto-opened (muted, inactive)
+      ry = (0...20).find { |y| backend.row(y).includes?("d:diff") }.not_nil!
       dx = backend.row(ry).index("diff").not_nil!
       backend.fg_at(dx, ry).should eq(Theme.muted) # diff tab NOT auto-opened
     end
@@ -128,9 +126,10 @@ describe Gori::Tui::ReplayView do
     backend = MemoryBackend.new(120, 20)
     view.render(Screen.new(backend), Rect.new(0, 0, 120, 20))
     backend.contains?("replay error: connection refused").should be_true
-    ry = (0...20).find { |y| backend.row(y).includes?("response") }.not_nil!
-    rx = backend.row(ry).index("response").not_nil!
-    backend.fg_at(rx, ry).should eq(Theme.text_bright)
+    # fell back to the response view — the diff toggle is inactive (muted)
+    ry = (0...20).find { |y| backend.row(y).includes?("d:diff") }.not_nil!
+    dx = backend.row(ry).index("diff").not_nil!
+    backend.fg_at(dx, ry).should eq(Theme.muted)
   end
 
   it "auto-updates an existing Content-Length to match the edited body on send" do

--- a/src/gori/tui/comparer_view.cr
+++ b/src/gori/tui/comparer_view.cr
@@ -112,7 +112,10 @@ module Gori::Tui
       right_x = sep_x + SEP_W
 
       draw_header(screen, rect, rect.y, left_w, right_x, right_w)
-      Frame.inner_divider(screen, rect, rect.y + 1, border: Frame.pane_border(focused)) if rect.h > 2
+      if rect.h > 2
+        Frame.inner_divider(screen, rect, rect.y + 1, border: Frame.pane_border(focused))
+        render_pane_selector(screen, rect)
+      end
 
       body_top = rect.y + 2
       footer_y = rect.bottom - 1
@@ -143,6 +146,19 @@ module Gori::Tui
       screen.text(right_x, y, header_label("B", @slot_b), Theme.accent, attr: Attribute::Bold, width: right_w) if right_w > 0
     end
 
+    # The REQ ⇄ RES pane selector, right-aligned on the divider row: ←/→ switches which
+    # half of the two flows is diffed; the active side is lit, the other muted — so the
+    # mode + its keys ride the chrome instead of only the footer prose.
+    private def render_pane_selector(screen : Screen, rect : Rect) : Nil
+      hint = "←/→ "
+      total = Screen.display_width(hint) + 10 # " REQ " + " RES "
+      sx = rect.right - total - 1
+      return if sx <= rect.x + 1
+      x = screen.text(sx, rect.y + 1, hint, Theme.muted, Theme.bg)
+      x = Frame.chip(screen, x, rect.y + 1, " REQ ", @pane == :request)
+      Frame.chip(screen, x, rect.y + 1, " RES ", @pane == :response)
+    end
+
     private def header_label(tag : String, d : Store::FlowDetail?) : String
       d ? "#{tag}: #{summary(d)}" : "#{tag}: — empty (press #{tag.downcase} to pick) —"
     end
@@ -171,7 +187,7 @@ module Gori::Tui
       changed = @change_count
       note = changed == 0 ? "identical" : "#{changed} changed line#{changed == 1 ? "" : "s"}"
       note += " · truncated to #{Replay::Diff::MAX_LINES}/side" if @truncated
-      screen.text(rect.x + 1, y, "#{note} · comparing #{@pane} (←/→)", Theme.muted, width: {rect.w - 2, 1}.max)
+      screen.text(rect.x + 1, y, note, Theme.muted, width: {rect.w - 2, 1}.max) # pane + ←/→ moved to the divider selector
     end
 
     private def clamp_scroll(body_h : Int32, total : Int32) : Nil

--- a/src/gori/tui/convert_view.cr
+++ b/src/gori/tui/convert_view.cr
@@ -126,7 +126,13 @@ module Gori::Tui
     # OUTPUT — read-only but navigable (↑/↓ scroll); the title names the active
     # display mode + byte count, and the border gilds when the pane holds focus.
     private def render_output_card(screen : Screen, card : Rect, result : Convert::ChainResult, active : Bool) : Nil
-      Frame.card(screen, card, output_header(result), bg: Theme.bg, border: Frame.pane_border(active))
+      header = output_header(result)
+      Frame.card(screen, card, header, bg: Theme.bg, border: Frame.pane_border(active))
+      # ^X cycles the display mode; ride it on the border as ` ^X:MODE ` — lit when a mode
+      # is forced (HEX/B64), muted for AUTO (which just follows the bytes). Replaces the
+      # old title-embedded mode label so the chord is discoverable in place.
+      name, forced = out_mode_badge
+      Frame.toggle_badge(screen, card.right - 1, card.y, card.x + header.size + 4, "^X", name, forced)
       render_output(screen, card.inset(1, 1), result)
     end
 
@@ -178,23 +184,24 @@ module Gori::Tui
       @out_lines
     end
 
-    # The OUTPUT divider label: mode + byte count, or a failure marker.
+    # The OUTPUT divider label: byte count, or a failure marker. The display mode moved
+    # to the ` ^X:MODE ` border badge (render_output_card).
     private def output_header(result : Convert::ChainResult) : String
       if bytes = result.output
-        "OUTPUT  #{out_mode_label(bytes)} · #{bytes.size} B"
+        "OUTPUT · #{bytes.size} B"
       else
         "OUTPUT  ✗ chain failed"
       end
     end
 
-    # The mode label WITHOUT re-encoding the (possibly huge) output: only :auto needs
-    # to peek at the bytes, and a UTF-8 validity check is far cheaper than a full
-    # hex/base64 encode that the old code immediately threw away.
-    private def out_mode_label(bytes : Bytes) : String
+    # The ` ^X:MODE ` badge {name, forced?}: HEX/B64 (lit, an explicit mode) or AUTO
+    # (muted — follows the bytes). The auto sub-type (text vs binary→base64) is
+    # intentionally not spelled out on the badge.
+    private def out_mode_badge : {String, Bool}
       case @prefer
-      when Convert::RenderAs::Hex    then "hex"
-      when Convert::RenderAs::Base64 then "base64"
-      else                                Convert.binary?(bytes) ? "binary→base64" : "text"
+      when Convert::RenderAs::Hex    then {"HEX", true}
+      when Convert::RenderAs::Base64 then {"B64", true}
+      else                                {"AUTO", false}
       end
     end
 

--- a/src/gori/tui/frame.cr
+++ b/src/gori/tui/frame.cr
@@ -80,5 +80,26 @@ module Gori::Tui
     def self.pane_border(focused : Bool) : Color
       focused ? Theme.focus_gold : Theme.border
     end
+
+    # A left-aligned mode/toggle chip at (x,y), returning the x past it. `lit` (active)
+    # paints bright text on an accent fill; off is a muted, background-less label. Used
+    # for keyed toggle chips on a pane's top border (e.g. Replay's `d:diff`/`x:hex`).
+    def self.chip(screen : Screen, x : Int32, y : Int32, label : String, lit : Bool) : Int32
+      screen.text(x, y, label, lit ? Theme.text_bright : Theme.muted, lit ? Theme.accent_bg : Theme.bg)
+    end
+
+    # One right-aligned toggle badge for a top border, ending just before `right_edge`
+    # (exclusive). Renders " chord:NAME ", lit (accent bg) when `on`, muted with NO
+    # background when off — so a disabled toggle is a quiet hint whose shortcut stays in
+    # view. Returns the badge's left x (chain the next badge to its left there), or
+    # `right_edge` unchanged when it doesn't fit (nothing drawn).
+    def self.toggle_badge(screen : Screen, right_edge : Int32, y : Int32, min_x : Int32,
+                          chord : String, name : String, on : Bool) : Int32
+      text = " #{chord}:#{name} "
+      x = right_edge - text.size
+      return right_edge if x < min_x
+      screen.text(x, y, text, on ? Theme.text_bright : Theme.muted, on ? Theme.accent_bg : Theme.bg)
+      x
+    end
   end
 end

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -1442,14 +1442,19 @@ module Gori::Tui
     private def render_results(screen : Screen, rect : Rect, focused : Bool) : Nil
       return if rect.w < 2 || rect.h < 2
       Frame.card(screen, rect, "RESULTS", bg: Theme.bg, border: Frame.pane_border(focused))
-      status = if @running
-                 p = @progress
-                 "running #{p ? p.sent : 0}/#{@run_total || "?"} · #{matched_count} hit"
-               else
-                 "#{result_count} sent · #{matched_count} hit · sort:#{@sort}#{@matched_only ? " · matched" : ""}"
-               end
-      sx = {rect.right - status.size - 1, rect.x + 10}.max
-      screen.text(sx, rect.y, status, Theme.muted, Theme.bg)
+      # Left: the live count. Right: keyed toggle badges (sort value · matched · dist) so
+      # each results toggle's shortcut rides the border, not just the bottom hint bar.
+      count = if @running
+                p = @progress
+                "running #{p ? p.sent : 0}/#{@run_total || "?"} · #{matched_count} hit"
+              else
+                "#{result_count} sent · #{matched_count} hit"
+              end
+      screen.text(rect.x + 11, rect.y, count, Theme.muted, Theme.bg) # +11 clears the " RESULTS " title
+      min_x = rect.x + 11 + count.size + 1 # badges never overwrite the count
+      rx = Frame.toggle_badge(screen, rect.right - 1, rect.y, min_x, "v", "DIST", @show_dist)
+      rx = Frame.toggle_badge(screen, rx, rect.y, min_x, "m", "MATCH", @matched_only)
+      Frame.toggle_badge(screen, rx, rect.y, min_x, "o", @sort.to_s, false) # sort: a value chip, never lit
       inner = rect.inset(1, 1)
       view = sorted_results
       @sel = @sel.clamp(0, {view.size - 1, 0}.max)

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -877,9 +877,17 @@ module Gori::Tui
         screen.text({rx - count.size, rect.x}.max, rect.y, count, Theme.muted)
         rx -= count.size + 2
       end
-      screen.text({rx - chip.size, rect.x}.max, rect.y, chip, chip_color)
+      scope_x = {rx - chip.size, rect.x}.max
+      screen.text(scope_x, rect.y, chip, chip_color)
+      # The live-tail (follow) toggle, left of the scope chip — same fg accent/muted
+      # style so the two mode toggles read as one cluster, surfacing the `f` chord
+      # (today follow is only implicit in the selection sitting on the newest row).
+      fchip = "f:follow"
+      fx = scope_x - fchip.size - 1
+      follow_shown = fx > rect.x + 1
+      screen.text(fx, rect.y, fchip, @follow ? Theme.accent : Theme.muted) if follow_shown
 
-      left_w = {(rx - chip.size) - (rect.x + 1) - 1, 0}.max
+      left_w = {(follow_shown ? fx : scope_x) - (rect.x + 1) - 1, 0}.max
       if filtering?
         label = @query.blank? ? "(in-scope only)" : ": #{@query}"
         screen.text(rect.x + 1, rect.y, label, Theme.text, width: left_w)

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -355,8 +355,11 @@ module Gori::Tui
         return
       end
 
+      # Left cluster: the master CATCH toggle (lit while holding) then the direction
+      # sub-mode — each carries its chord (i toggles, c cycles) so both are discoverable
+      # in the chrome, not just the empty-state prose.
+      x = Frame.chip(screen, rect.x + 1, rect.y, " i:CATCH ", @enabled) + 1
       label, color = direction_chip
-      x = rect.x + 1
       x = screen.text(x, rect.y, label, color, Theme.bg, Attribute::Bold) + 2
 
       rx = rect.right - 1
@@ -374,13 +377,14 @@ module Gori::Tui
       end
     end
 
-    # The catch-direction chip: text + colour. Dim when intercept is OFF (nothing is
-    # held yet, so the chip advertises what WILL be caught once toggled on).
+    # The catch-direction chip: `c`-chord + which direction, coloured by enabled state.
+    # Dim when intercept is OFF (nothing is held yet, so the chip advertises what WILL be
+    # caught once toggled on).
     private def direction_chip : {String, Color}
       label = case @direction
-              when .request_only?  then "catch:req"
-              when .response_only? then "catch:res"
-              else                      "catch:all"
+              when .request_only?  then "c:REQ"
+              when .response_only? then "c:RES"
+              else                      "c:ALL"
               end
       {label, @enabled ? Theme.accent : Theme.muted}
     end
@@ -418,6 +422,9 @@ module Gori::Tui
       it = selected_item
       title = it.nil? ? "DETAIL" : (it.kind.request? ? "REQUEST (held)" : "RESPONSE (held)")
       Frame.card(screen, rect, title, bg: Theme.bg, border: pane_border(focused))
+      # `e` (or ↵) toggles editing the held bytes vs previewing them — lit while editing,
+      # a muted hint while previewing, so the edit affordance rides the border.
+      Frame.toggle_badge(screen, rect.right - 1, rect.y, rect.x + title.size + 4, "e", "EDIT", @editing) if it
       inner = rect.inset(1, 1)
       unless it
         screen.text(inner.x, inner.y, "—", Theme.muted)

--- a/src/gori/tui/miner_view.cr
+++ b/src/gori/tui/miner_view.cr
@@ -281,11 +281,14 @@ module Gori::Tui
 
     private def render_summary(screen : Screen, rect : Rect, focused : Bool) : Nil
       Frame.card(screen, rect, "MINER", border: focused ? Theme.focus_gold : Theme.border, bg: Theme.bg)
+      # Run control on the border: while mining a lit ` ^X:STOP `, otherwise a muted
+      # ` ^R:MINE ` (run / re-run) — so both chords stay in view once findings fill the
+      # pane. A state-swapping badge, not a boolean toggle: the chord itself changes.
+      chord, name = @running ? {"^X", "STOP"} : {"^R", "MINE"}
+      Frame.toggle_badge(screen, rect.right - 1, rect.y, rect.x + "MINER".size + 4, chord, name, @running)
       x = rect.x + 2
       y = rect.y + 1
-      screen.text(x, y, summary(rect.w - 18), Theme.text_bright, Theme.bg, Attribute::Bold)
-      state = @running ? "running" : (@progress.names_total > 0 ? "done" : "idle")
-      screen.text(rect.right - state.size - 2, y, state, @running ? Theme.accent : Theme.muted, Theme.bg)
+      screen.text(x, y, summary(rect.w - 4), Theme.text_bright, Theme.bg, Attribute::Bold)
       y += 1
       screen.text(x, y, target_origin, Theme.muted, Theme.bg, width: rect.w - 4) if y < rect.bottom - 1
       y += 1

--- a/src/gori/tui/prism_view.cr
+++ b/src/gori/tui/prism_view.cr
@@ -329,29 +329,36 @@ module Gori::Tui
       screen.text(rect.x + 1, top, msg, Theme.muted)
     end
 
-    # Row 0: a filled MODE chip + detected-tech summary + right-aligned severity tallies.
+    # Row 0: a filled MODE chip (with its `m` cycle chord) + detected-tech summary + the
+    # `a:CLOSED` lens toggle + right-aligned severity tallies.
     private def render_mode_band(screen : Screen, rect : Rect) : Nil
-      x = chip(screen, rect.x + 1, rect.y, " #{@mode.title} ", mode_color(@mode)) + 1
+      x = chip(screen, rect.x + 1, rect.y, " m:#{@mode.title} ", mode_color(@mode)) + 1
+      tallies_x = render_tallies(screen, rect) # leftmost x the tallies occupy (or rect.right-1)
+      # The CLOSED lens toggle chains left of the tallies; lit when showing closed/dismissed
+      # issues, muted (its default open-only) otherwise — so the `a` chord stays in view.
+      cx = Frame.toggle_badge(screen, tallies_x, rect.y, x + 1, "a", "CLOSED", @show_closed)
       unless @tech.empty?
-        screen.text(x, rect.y, @tech.join(" "), Theme.green, width: {rect.right - x - 14, 0}.max)
+        screen.text(x, rect.y, @tech.join(" "), Theme.green, width: {cx - x - 1, 0}.max)
       end
-      render_tallies(screen, rect)
     end
 
-    private def render_tallies(screen : Screen, rect : Rect) : Nil
+    # Draws the right-aligned severity tallies; returns the leftmost x they occupy (or
+    # rect.right-1 when there are none) so the CLOSED lens badge can chain to their left.
+    private def render_tallies(screen : Screen, rect : Rect) : Int32
       labels = {4 => "C", 3 => "H", 2 => "M", 1 => "L", 0 => "I"}
       parts = [] of {String, Color}
       labels.each do |val, lab|
         n = @counts[val]
         parts << {"#{lab}:#{n}", severity_color(Store::Severity.new(val))} if n > 0
       end
-      return if parts.empty?
+      return rect.right - 1 if parts.empty?
       total = parts.sum { |(s, _)| s.size + 1 } - 1
-      rx = rect.right - 1 - total
+      left = rx = rect.right - 1 - total
       parts.each do |(s, color)|
         rx = screen.text(rx, rect.y, s, color)
         rx = screen.text(rx, rect.y, " ", Theme.muted)
       end
+      left
     end
 
     private def render_filter_bar(screen : Screen, rect : Rect, y : Int32) : Nil

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -1443,25 +1443,6 @@ module Gori::Tui
       end
     end
 
-    # Draws one mode chip (lit = active) at (x,y), returning the x past it.
-    private def chip(screen : Screen, x : Int32, y : Int32, label : String, lit : Bool) : Int32
-      screen.text(x, y, label, lit ? Theme.text_bright : Theme.muted, lit ? Theme.accent_bg : Theme.bg)
-    end
-
-    # One right-aligned toggle badge for the top border, ending just before `right_edge`
-    # (exclusive). Renders " chord:NAME ", lit (accent bg) when `on`, muted with NO
-    # background when off — so a disabled toggle is a quiet hint and its shortcut stays
-    # in view. Returns the badge's left x (chain the next badge to its left there), or
-    # `right_edge` unchanged when it doesn't fit (nothing drawn).
-    private def toggle_badge(screen : Screen, right_edge : Int32, y : Int32, min_x : Int32,
-                             chord : String, name : String, on : Bool) : Int32
-      text = " #{chord}:#{name} "
-      x = right_edge - text.size
-      return right_edge if x < min_x
-      screen.text(x, y, text, on ? Theme.text_bright : Theme.muted, on ? Theme.accent_bg : Theme.bg)
-      x
-    end
-
     # The RESPONSE pane's top-border chrome: keyed toggle chips + the right-aligned
     # latency·size of the last send. Each chip carries its shortcut (history-style:
     # d diff · x hex · p pretty) so the toggle is discoverable in place, and lights
@@ -1471,9 +1452,9 @@ module Gori::Tui
       resp_plain = !@resp_hex && @resp_mode == :response
       diff_lit = !@resp_hex && @resp_mode == :diff
       pretty_lit = resp_plain && !@reveal && resp_pretty_applied?
-      x = chip(screen, rect.x + 12, rect.y, " d:diff ", diff_lit) + 1
-      x = chip(screen, x, rect.y, " x:hex ", @resp_hex) + 1
-      chips_end = chip(screen, x, rect.y, " p:pretty ", pretty_lit)
+      x = Frame.chip(screen, rect.x + 12, rect.y, " d:diff ", diff_lit) + 1
+      x = Frame.chip(screen, x, rect.y, " x:hex ", @resp_hex) + 1
+      chips_end = Frame.chip(screen, x, rect.y, " p:pretty ", pretty_lit)
       if result = @result
         meta = result.ok? ? "#{Fmt.dur(result.duration_us)} · #{Fmt.size((result.head.size + (result.body.try(&.size) || 0)).to_i64)}" : Fmt.dur(result.duration_us)
         meta_x = rect.right - meta.size - 1
@@ -1514,7 +1495,7 @@ module Gori::Tui
       right_edge = rect.right - 1     # leave the right border cell untouched
       if h = @req_hex_edit
         # A single lit HEX badge — auto-CL/MARK don't apply to raw bytes (^X exits).
-        toggle_badge(screen, right_edge, rect.y, min_x, "^X", "HEX", true)
+        Frame.toggle_badge(screen, right_edge, rect.y, min_x, "^X", "HEX", true)
         @scroll_req = h.render(screen, rect.inset(1, 1), focused, @scroll_req)
         return
       end
@@ -1522,8 +1503,8 @@ module Gori::Tui
       # always shown (so the toggle is discoverable without the bottom hint bar), lit
       # when active and a muted no-background hint when off — ^L auto-Content-Length,
       # ^K MARK-transform.
-      cl_x = toggle_badge(screen, right_edge, rect.y, min_x, "^L", "CL", @auto_content_length)
-      toggle_badge(screen, cl_x, rect.y, min_x, "^K", "MARK", @mark_transform)
+      cl_x = Frame.toggle_badge(screen, right_edge, rect.y, min_x, "^L", "CL", @auto_content_length)
+      Frame.toggle_badge(screen, cl_x, rect.y, min_x, "^K", "MARK", @mark_transform)
       update_request_mark_tint
       @editor.render(screen, rect.inset(1, 1), cursor: focused, highlight: :request)
     end

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -1448,17 +1448,32 @@ module Gori::Tui
       screen.text(x, y, label, lit ? Theme.text_bright : Theme.muted, lit ? Theme.accent_bg : Theme.bg)
     end
 
-    # The RESPONSE pane's top-border chrome: the response|diff|hex|pretty chips (hex
-    # lights instead of response/diff; pretty only when the styled body is on screen)
-    # and the right-aligned latency·size of the last send.
+    # One right-aligned toggle badge for the top border, ending just before `right_edge`
+    # (exclusive). Renders " chord:NAME ", lit (accent bg) when `on`, muted with NO
+    # background when off — so a disabled toggle is a quiet hint and its shortcut stays
+    # in view. Returns the badge's left x (chain the next badge to its left there), or
+    # `right_edge` unchanged when it doesn't fit (nothing drawn).
+    private def toggle_badge(screen : Screen, right_edge : Int32, y : Int32, min_x : Int32,
+                             chord : String, name : String, on : Bool) : Int32
+      text = " #{chord}:#{name} "
+      x = right_edge - text.size
+      return right_edge if x < min_x
+      screen.text(x, y, text, on ? Theme.text_bright : Theme.muted, on ? Theme.accent_bg : Theme.bg)
+      x
+    end
+
+    # The RESPONSE pane's top-border chrome: keyed toggle chips + the right-aligned
+    # latency·size of the last send. Each chip carries its shortcut (history-style:
+    # d diff · x hex · p pretty) so the toggle is discoverable in place, and lights
+    # when active. Plain response mode needs no chip of its own — it's simply none of
+    # these lit (the pane is already titled RESPONSE).
     private def render_response_chrome(screen : Screen, rect : Rect) : Nil
-      resp_lit = !@resp_hex && @resp_mode == :response
+      resp_plain = !@resp_hex && @resp_mode == :response
       diff_lit = !@resp_hex && @resp_mode == :diff
-      pretty_lit = resp_lit && !@reveal && resp_pretty_applied?
-      x = chip(screen, rect.x + 12, rect.y, " response ", resp_lit) + 1
-      x = chip(screen, x, rect.y, " diff ", diff_lit) + 1
-      x = chip(screen, x, rect.y, " hex ", @resp_hex)
-      chips_end = chip(screen, x + 1, rect.y, " pretty ", pretty_lit)
+      pretty_lit = resp_plain && !@reveal && resp_pretty_applied?
+      x = chip(screen, rect.x + 12, rect.y, " d:diff ", diff_lit) + 1
+      x = chip(screen, x, rect.y, " x:hex ", @resp_hex) + 1
+      chips_end = chip(screen, x, rect.y, " p:pretty ", pretty_lit)
       if result = @result
         meta = result.ok? ? "#{Fmt.dur(result.duration_us)} · #{Fmt.size((result.head.size + (result.body.try(&.size) || 0)).to_i64)}" : Fmt.dur(result.duration_us)
         meta_x = rect.right - meta.size - 1
@@ -1495,35 +1510,33 @@ module Gori::Tui
         @editor.render(screen, rect.inset(1, 1), cursor: focused, highlight: @grpc_mode ? :request : nil)
         return
       end
+      min_x = rect.x + label.size + 4 # keep clear of the pane title on the top border
+      right_edge = rect.right - 1     # leave the right border cell untouched
       if h = @req_hex_edit
-        # HEX badge replaces the CL indicator (auto-CL is meaningless on raw bytes).
-        badge = " HEX · CL:off "
-        bx = {rect.right - badge.size - 1, rect.x + label.size + 4}.max
-        screen.text(bx, rect.y, badge, Theme.text_bright, Theme.accent_bg)
+        # A single lit HEX badge — auto-CL/MARK don't apply to raw bytes (^X exits).
+        toggle_badge(screen, right_edge, rect.y, min_x, "^X", "HEX", true)
         @scroll_req = h.render(screen, rect.inset(1, 1), focused, @scroll_req)
         return
       end
-      # Content-Length auto-update state rides the top border, right of the title
-      # (^L toggles). Bright/accent when on, muted when off.
-      cl = @auto_content_length ? " CL:auto " : " CL:off "
-      cl_x = {rect.right - cl.size - 1, rect.x + label.size + 4}.max
-      screen.text(cl_x, rect.y, cl, @auto_content_length ? Theme.text_bright : Theme.muted,
-        @auto_content_length ? Theme.accent_bg : Theme.bg)
-      paint_request_mark_tint(screen, rect, label, cl_x)
+      # Toggle indicators ride the top border, right-aligned: [^K:MARK][^L:CL]. Each is
+      # always shown (so the toggle is discoverable without the bottom hint bar), lit
+      # when active and a muted no-background hint when off — ^L auto-Content-Length,
+      # ^K MARK-transform.
+      cl_x = toggle_badge(screen, right_edge, rect.y, min_x, "^L", "CL", @auto_content_length)
+      toggle_badge(screen, cl_x, rect.y, min_x, "^K", "MARK", @mark_transform)
+      update_request_mark_tint
       @editor.render(screen, rect.inset(1, 1), cursor: focused, highlight: :request)
     end
 
-    # In MARK-transform mode: draw the MARK badge (left of the CL badge) and tint each
-    # §…§ marker in the editor — value in the position hue, ¦chain over-painted dimmer.
-    # Off = clear the regions so a toggled-off tab paints untinted (empty = no-op paint).
-    private def paint_request_mark_tint(screen : Screen, rect : Rect, label : String, cl_x : Int32) : Nil
+    # MARK-transform tinting: colour each §…§ marker in the request editor — the value in
+    # the position hue, the ¦chain segment over-painted dimmer. Off = clear the regions so
+    # a toggled-off tab paints untinted (empty = no-op paint). The MARK toggle badge itself
+    # rides the top border (see render_request).
+    private def update_request_mark_tint : Nil
       unless @mark_transform
         @editor.bg_regions = [] of {Int32, Int32, Color}
         return
       end
-      mark = " MARK "
-      mx = {cl_x - mark.size, rect.x + label.size + 4}.max
-      screen.text(mx, rect.y, mark, Theme.text_bright, Theme.accent_bg) if mx + mark.size <= cl_x
       bg = [] of {Int32, Int32, Color}
       Fuzz::Template.marker_regions(@editor.text).each_with_index do |region, i|
         a, sep, close = region

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -550,9 +550,17 @@ module Gori::Tui
         screen.text({rx - count.size, rect.x}.max, rect.y, count, Theme.muted)
         rx -= count.size + 2
       end
-      screen.text({rx - chip.size, rect.x}.max, rect.y, chip, chip_color)
+      scope_x = {rx - chip.size, rect.x}.max
+      screen.text(scope_x, rect.y, chip, chip_color)
+      # The numeric path-param grouping toggle, left of the scope chip — same fg
+      # accent/muted style so the two lens toggles read as one cluster, and its `g`
+      # chord stays in view (grouping-on vs -off renders identically without sequences).
+      gchip = "g:group"
+      gx = scope_x - gchip.size - 1
+      group_shown = gx > rect.x + 1
+      screen.text(gx, rect.y, gchip, @grouping ? Theme.accent : Theme.muted) if group_shown
 
-      left_w = {(rx - chip.size) - (rect.x + 1) - 1, 0}.max
+      left_w = {(group_shown ? gx : scope_x) - (rect.x + 1) - 1, 0}.max
       if filtering?
         label = @query.blank? ? "(in-scope only)" : ": #{@query}"
         screen.text(rect.x + 1, rect.y, label, Theme.text, width: left_w)


### PR DESCRIPTION
## Summary

Makes every toggle-type control in the TUI advertise its shortcut inline as a **lit/muted badge on the pane chrome**, so a toggle's key is discoverable without reading the bottom hint bar. Started from the Replay tab (per user request) and propagated the pattern across the app.

Lit = active (bright text on an accent fill); off = a muted label with no background.

## What changed

**Foundation** — hoisted `chip` + `toggle_badge` out of `ReplayView` into the shared `Frame` module (`Frame.chip`, `Frame.toggle_badge`), pure static drawers; Replay delegates to them (behavior-preserving — its specs are the extraction canary).

**Replay** (`814a97c`)
- REQUEST border: `^K:MARK` · `^L:CL` (always shown; MARK used to appear only when on)
- RESPONSE border: `d:diff` · `x:hex` · `p:pretty` (the redundant `response` chip was dropped — the pane is already titled RESPONSE — which also keeps the latency·size meta visible at 120 cols)

**Rollout** (`a540369`)
| View | Badges |
|------|--------|
| Fuzzer | `o:<sort>` · `m:MATCH` · `v:DIST` on the RESULTS border |
| Prism | `m:<mode>` prefix on the mode chip + `a:CLOSED` lens |
| Sitemap / History | `g:group` / `f:follow` in the QL bars (fg-only, matching the scope chip) |
| Intercept | `i:CATCH` + `c:ALL/REQ/RES` + `e:EDIT` |
| Convert | `^X:AUTO/HEX/B64` on the OUTPUT border |
| Comparer | `←/→ REQ/RES` pane selector on the divider |
| Miner | state-swapping `^R:MINE` / `^X:STOP` run control |

## Deliberately parked: the global bars

The survey proposed prefixing the bottom-bar `capture:on` chip with its `c` chord, but `c` is **scope-overloaded** — `intercept.direction` binds `c` in Intercept scope, and the keymap resolves active-scope-first, so on the Intercept body `c` cycles direction, not capture. A persistent global `c capture` hint would lie there. The pattern belongs on tab-local pane borders (unambiguous, has room); the Intercept tab's own `i:CATCH` already surfaces `i` where it applies. Global top/bottom bars left unchanged.

## Verification
- Full suite green: **1137 examples, 0 failures** (updated the Fuzzer `DIST` and Intercept direction spec assertions the relabels touched)
- Live-tested in the real TUI across History, Sitemap, Fuzzer, Intercept, Prism, Comparer, Convert, Replay — lit/muted colors flip with actual toggle state
- Ameba: no new findings; adversarial multi-agent review of the diff: 0 confirmed defects