### PR TITLE
feat(prism): honour the scope lens in Prism and Project tech summary

### DIFF
--- a/spec/tui/prism_view_spec.cr
+++ b/spec/tui/prism_view_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "../support/memory_backend"
 
 private def view_store(&)
   path = File.tempname("gori-prismview", ".db")
@@ -63,6 +64,74 @@ describe Gori::Tui::PrismView do
 
       "status:fp".each_char { |c| view.query_insert(c) }
       view.target_issue.should_not be_nil # the explicit status term reveals it
+    end
+  end
+
+  it "filters the issue list to in-scope hosts once the scope lens is ON" do
+    view_store do |store|
+      seed(store, "missing_hsts", "a.test")
+      seed(store, "missing_hsts", "b.test")
+
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "a.test")
+      scope.active?.should be_false # configured but not enabled yet
+
+      view = Gori::Tui::PrismView.new
+      view.set_scope(scope)
+      view.reload(store)
+      view.empty?.should be_false
+
+      # Lens off ⇒ both hosts show up.
+      b0 = MemoryBackend.new(80, 20)
+      view.render(Gori::Tui::Screen.new(b0), Gori::Tui::Rect.new(0, 0, 80, 20))
+      b0.contains?("a.test").should be_true
+      b0.contains?("b.test").should be_true
+
+      scope.enable
+      view.reload(store)
+      b1 = MemoryBackend.new(80, 20)
+      view.render(Gori::Tui::Screen.new(b1), Gori::Tui::Rect.new(0, 0, 80, 20))
+      b1.contains?("a.test").should be_true
+      b1.contains?("b.test").should be_false
+    end
+  end
+
+  it "shows the scope-lens empty hint (not the triage hint) when the lens empties the list" do
+    view_store do |store|
+      seed(store, "missing_hsts", "a.test")
+
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "other.test") # excludes a.test → in-scope set empty
+      scope.enable
+
+      view = Gori::Tui::PrismView.new
+      view.set_scope(scope)
+      view.reload(store)
+
+      b = MemoryBackend.new(80, 20)
+      view.render(Gori::Tui::Screen.new(b), Gori::Tui::Rect.new(0, 0, 80, 20))
+      rows = (0...20).map { |y| b.row(y) }.join("\n")
+      rows.should contain("no issues in scope")
+      rows.should contain("⇧S clears the scope lens")
+    end
+  end
+
+  it "drops the MODE band tech chip for a fingerprint seen only on an out-of-scope host" do
+    view_store do |store|
+      store.upsert_prism_issue(
+        Gori::Prism::Detection.new("tech_grpc", "tech", "a.test", "https://a.test/", "gRPC detected", Gori::Store::Severity::Info))
+
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "other.test")
+      scope.enable
+
+      view = Gori::Tui::PrismView.new
+      view.set_scope(scope)
+      view.reload(store)
+
+      b = MemoryBackend.new(80, 20)
+      view.render(Gori::Tui::Screen.new(b), Gori::Tui::Rect.new(0, 0, 80, 20))
+      b.contains?("gRPC").should be_false
     end
   end
 end

--- a/spec/tui/project_view_spec.cr
+++ b/spec/tui/project_view_spec.cr
@@ -137,6 +137,36 @@ describe "ProjectView DESCRIPTION scrolling" do
   end
 end
 
+describe "ProjectView AT A GLANCE Technologies" do
+  it "drops tech facts fingerprinted only on out-of-scope hosts once the scope lens is ON" do
+    tmp_store do |store|
+      store.upsert_prism_issue(
+        Gori::Prism::Detection.new("tech_grpc", "tech", "a.test", "https://a.test/", "gRPC detected", Gori::Store::Severity::Info))
+      store.upsert_prism_issue(
+        Gori::Prism::Detection.new("tech_websocket", "tech", "b.test", "https://b.test/", "WebSocket detected", Gori::Store::Severity::Info))
+      project = Gori::Project.new("t", File.tempname("gori-projview-p"))
+
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "a.test")
+      view = ProjectView.new(scope, Gori::HostOverrides.load(store))
+      view.reload(project, store)
+      rect = Rect.new(0, 0, 120, 30)
+
+      b0 = MemoryBackend.new(120, 30)
+      view.render(Screen.new(b0), rect, focused: false)
+      b0.contains?("gRPC").should be_true
+      b0.contains?("WebSocket").should be_true # lens off ⇒ every host's facts show
+
+      scope.enable
+      view.reload(project, store)
+      b1 = MemoryBackend.new(120, 30)
+      view.render(Screen.new(b1), rect, focused: false)
+      b1.contains?("gRPC").should be_true
+      b1.contains?("WebSocket").should be_false # out-of-scope host's fact dropped
+    end
+  end
+end
+
 describe "ProjectView#pane_at" do
   it "splits the body into the overview band + SCOPE/HOST-OVERRIDES (left) / DESCRIPTION (right) cards" do
     tmp_store do |store|

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -545,20 +545,22 @@ module Gori
       set_setting(Prism::MODE_SETTING_KEY, mode.label)
     end
 
-    # Distinct (tech code, evidence) rows — the raw material for the project's
+    # Distinct (tech code, host, evidence) rows — the raw material for the project's
     # "representative technologies" summary (Prism.tech_summary maps them to labels).
-    def prism_tech_rows : Array({String, String?})
-      rows = [] of {String, String?}
-      @db.query("SELECT DISTINCT code, evidence FROM prism_issues WHERE category = 'tech' ORDER BY code") do |rs|
-        rs.each { rows << {rs.read(String), rs.read(String?)} }
+    # The host is kept so scope-aware callers (Prism tab, Project AT A GLANCE) can drop
+    # rows fingerprinted on out-of-scope hosts before summarizing.
+    def prism_tech_rows : Array({String, String, String?})
+      rows = [] of {String, String, String?}
+      @db.query("SELECT DISTINCT code, host, evidence FROM prism_issues WHERE category = 'tech' ORDER BY code") do |rs|
+        rs.each { rows << {rs.read(String), rs.read(String), rs.read(String?)} }
       end
       rows
     rescue
-      [] of {String, String?}
+      [] of {String, String, String?}
     end
 
     def prism_tech_summary : Array(String)
-      Prism.tech_summary(prism_tech_rows)
+      Prism.tech_summary(prism_tech_rows.map { |(code, _, ev)| {code, ev} })
     end
 
     private def read_prism_issue(rs : DB::ResultSet) : PrismIssue

--- a/src/gori/tui/controllers/prism_controller.cr
+++ b/src/gori/tui/controllers/prism_controller.cr
@@ -14,6 +14,7 @@ module Gori::Tui
     def initialize(host : Host)
       super(host)
       @prism = PrismView.new
+      @prism.set_scope(@host.session.scope) # honour the lens + show its chip on the bar
       @reload_pending = false
     end
 

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -88,7 +88,7 @@ module Gori::Tui
       {"OTHER TABS", [
         {"Sitemap", "↑/↓ · / filter · ↵/→ expand · t tag · g group · ⇧S scope"},
         {"Findings", "/ filter · ↵ open · n new · space triage · x export · ⇧←/→ h-scroll notes"},
-        {"Prism", "↑/↓ ↵ open · m mode · c dismiss · a all · / filter · space cmds"},
+        {"Prism", "↑/↓ ↵ open · m mode · c dismiss · a all · / filter · ⇧S scope · space cmds"},
         {"Notes", "type to edit · ^N new · ^1-9 switch · space cmds (sub-tab strip)"},
         {"Project", "scope rules + the description editor"},
         {"Intercept", "↵/e edit · f fwd · d drop · F all · c catch dir · / condition · ⇧←/→ h-scroll preview"},

--- a/src/gori/tui/prism_view.cr
+++ b/src/gori/tui/prism_view.cr
@@ -2,6 +2,7 @@ require "./screen"
 require "./theme"
 require "./frame"
 require "../store"
+require "../scope"
 require "../prism"
 require "../prism_query"
 
@@ -33,14 +34,29 @@ module Gori::Tui
       @preedit_q = ""
       @querying = false
       @show_closed = false # default lens: open issues only (triaged ones drop out of view)
+      @scope = nil.as(Scope?)
+      @pre_scope_empty = false
+    end
+
+    # Wires the shared session Scope in (mirrors HistoryView/SitemapView) so the ⇧S
+    # lens filters this tab too, and its chip is discoverable on the filter bar.
+    def set_scope(scope : Scope) : Nil
+      @scope = scope
     end
 
     def reload(store : Store) : Nil
       @all = store.prism_issues
       @mode = store.prism_mode
-      @tech = store.prism_tech_summary
+      @tech = scoped_tech(store.prism_tech_rows)
       apply_filter
       refresh_detail(store)
+    end
+
+    # Drop tech fingerprints seen only on out-of-scope hosts before summarizing —
+    # the MODE band's tech chips should track the same lens as the issue list.
+    private def scoped_tech(rows : Array({String, String, String?})) : Array(String)
+      rows = rows.select { |(_, host, _)| @scope.try(&.host_in_scope?(host)) == true } if scope_active?
+      Prism.tech_summary(rows.map { |(code, _, ev)| {code, ev} })
     end
 
     private def recount(base : Array(Store::PrismIssue)) : Nil
@@ -55,9 +71,17 @@ module Gori::Tui
     private def apply_filter : Nil
       filter = Prism::Filter.parse(@query)
       base = (@show_closed || filter.has_status_term?) ? @all : @all.select(&.status.open?)
+      # Remember whether the triage lens alone already emptied the list — render_empty
+      # needs this to tell "all triaged" apart from "scope lens narrowed it to nothing".
+      @pre_scope_empty = base.empty?
+      base = base.select { |i| @scope.try(&.host_in_scope?(i.host)) == true } if scope_active?
       recount(base)
       @issues = filter.apply(base)
       @selected = @selected.clamp(0, {@issues.size - 1, 0}.max)
+    end
+
+    private def scope_active? : Bool
+      @scope.try(&.active?) == true
     end
 
     def show_closed? : Bool
@@ -119,8 +143,10 @@ module Gori::Tui
       @querying
     end
 
+    # True when a `/` query OR the scope lens is narrowing the list — either way the
+    # filter bar switches to "showing a subset" mode (mirrors HistoryView/SitemapView).
     def filtering? : Bool
-      !@query.blank?
+      !@query.blank? || scope_active?
     end
 
     # Click hit-test: the MODE band (y), filter bar (y+1), header (y+2), divider (y+3),
@@ -317,12 +343,17 @@ module Gori::Tui
     end
 
     private def render_empty(screen : Screen, rect : Rect, top : Int32) : Nil
+      # Branch on a real `/` query FIRST (querying-aware hint): a blank-query empty set
+      # is caused by the triage lens or the scope lens, where "esc clears the filter"
+      # would mislead. Mirrors HistoryView/SitemapView's ordering.
       msg = if @mode.off?
               "scanning is OFF · press m (or space → set mode) to enable passive scanning"
-            elsif filtering?
+            elsif !@query.blank?
               @querying ? "no issues match · esc clears the filter" : "no issues match · / to edit the filter"
-            elsif !@all.empty? && !@show_closed
+            elsif @pre_scope_empty && !@all.empty? && !@show_closed
               "no open issues · all #{@all.size} triaged · press a to show closed"
+            elsif scope_active?
+              "no issues in scope · ⇧S clears the scope lens"
             else
               "no issues yet · capture in-scope traffic and Prism flags issues passively"
             end
@@ -369,15 +400,22 @@ module Gori::Tui
         screen.input_line(base, y, @query, @qcx, @preedit_q, Theme.text_bright, width: {rect.w - prefix.size - 2, 0}.max)
         return
       end
+      # Right cluster: a scope-lens chip (always shown so the ⇧S toggle is discoverable,
+      # mirroring HistoryView/SitemapView) and, when filtering, the row count.
+      scope_on = scope_active?
+      chip, chip_color = scope_on ? {"⇧S scope:#{@scope.try(&.size) || 0}", Theme.accent} : {"⇧S scope:off", Theme.muted}
       rx = rect.right - 1
       if filtering?
         count = @issues.size.to_s
         screen.text({rx - count.size, rect.x}.max, y, count, Theme.muted)
         rx -= count.size + 2
       end
-      left_w = {rx - (rect.x + 1), 0}.max
+      scope_x = {rx - chip.size, rect.x}.max
+      screen.text(scope_x, y, chip, chip_color)
+      left_w = {scope_x - (rect.x + 1) - 1, 0}.max
       if filtering?
-        screen.text(rect.x + 1, y, ": #{@query}", Theme.text, width: left_w)
+        label = @query.blank? ? "(in-scope only)" : ": #{@query}"
+        screen.text(rect.x + 1, y, label, Theme.text, width: left_w)
       else
         screen.text(rect.x + 1, y, "/ filter  ·  severity:  status:open  category:tech  host:", Theme.muted, width: left_w)
       end

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -7,6 +7,7 @@ require "./text_area"
 require "../project"
 require "../store"
 require "../scope"
+require "../prism"
 require "../host_overrides"
 require "../settings"
 
@@ -77,7 +78,7 @@ module Gori::Tui
       @project = project
       @flow_count = store.count
       @findings_count = store.count_findings
-      @prism_tech = store.prism_tech_summary
+      @prism_tech = scoped_tech(store.prism_tech_rows)
       @db_size = project.db_size
       @total_captured = store.total_size
       # AT A GLANCE aggregates: status mix + combined finding/Prism severity tally.
@@ -93,6 +94,14 @@ module Gori::Tui
 
       @desc_area.set_text(store.setting(DESC_KEY) || "")
       @desc_dirty = false
+    end
+
+    # Drop tech fingerprints seen only on out-of-scope hosts before summarizing — with
+    # the scope lens ON, "representative technologies" should describe the in-scope
+    # target, not every host the proxy happened to see traffic for (mirrors PrismView).
+    private def scoped_tech(rows : Array({String, String, String?})) : Array(String)
+      rows = rows.select { |(_, host, _)| @scope.host_in_scope?(host) } if @scope.active?
+      Prism.tech_summary(rows.map { |(code, _, ev)| {code, ev} })
     end
 
     # IME preedit routes to whichever pane is composing: the SCOPE add-row when it's

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -3203,6 +3203,7 @@ module Gori::Tui
       @scope.toggle
       history_controller.view.reload(@session.store)
       sitemap_controller.reload if @active_tab == :sitemap
+      prism_controller.view.reload(@session.store) if @active_tab == :prism
       project_controller.toast_scope_state
     end
 

--- a/src/gori/verbs/prism.cr
+++ b/src/gori/verbs/prism.cr
@@ -43,6 +43,13 @@ module Gori
         "prism.toggle-closed", "Show closed", "Toggle between open-only and all issues (incl. dismissed)",
         Verb::Scope::Prism, [Verb::Chord.new("a")]) { |ctx| ctx.prism_toggle_closed; nil }
 
+      # Toggle the scope lens from Prism too (History has its own ⇧S binding; Sitemap
+      # mirrors it). scope_toggle_lens reloads the active Prism list, and the bar shows
+      # the ⇧S chip — so the toggle is reachable where its effect is visible.
+      r.register Verb::Definition.new(
+        "prism.scope-toggle", "Toggle scope lens", "Filter issues to in-scope hosts on/off",
+        Verb::Scope::Prism, [Verb::Chord.new("s", shift: true)], mnemonic: 's') { |ctx| ctx.scope_toggle_lens; nil }
+
       # Bulk dismiss — space-menu only (mnemonic, no stray hotkey): mute a whole check
       # code, or a whole host, in one confirmed action. 'r' is reserved for replay-evidence
       # (parity with the detail scope).


### PR DESCRIPTION
## Summary
- Prism tab issues now filter to in-scope hosts when the ⇧S scope lens is ON (previously shown regardless of scope), mirroring History/Sitemap.
- Added a discoverable `⇧S scope:N`/`scope:off` chip + a direct `prism.scope-toggle` verb so the lens can be toggled right from Prism.
- Project tab's "Technologies" fact (AT A GLANCE) now also drops fingerprints from out-of-scope hosts once the lens is on.
- `Store#prism_tech_rows` now carries host so scope-aware callers can filter before summarizing.

## Test plan
- [x] `crystal spec` — 1141 examples, 0 failures
- [x] `crystal tool format --check` on touched files
- [x] `bin/ameba` on touched files — no new findings (pre-existing findings only in untouched code)
- [x] Live tmux smoke test: captured traffic from two hosts, scoped to one, confirmed Prism list/tallies/tech chip and Project's Technologies line narrow correctly, and `⇧S` toggles live from within Prism