### PR TITLE
feat(fuzzer): paste multi-line List payload values via a floating popup

### DIFF
--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -105,6 +105,8 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def fuzz_attach_chain : Nil; end
 
+  def fuzz_list_paste : Nil; end
+
   def mine_selected : Nil; end
 
   def mine_from_replay : Nil; end

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -31,6 +31,66 @@ describe Gori::Tui::FuzzerView do
     view.template_text.should contain("§x¦rot13§")
   end
 
+  describe "LIST PASTE popup" do
+    it "opens on the List ptype's config field, types multi-line, commits comma-joined" do
+      view = loaded_fuzzer
+      view.focus_config
+      view.list_paste_active?.should be_false
+      view.open_list_paste.should be_nil # ptype defaults to :list
+      view.list_paste_active?.should be_true
+      "admin".each_char { |c| view.handle_list_paste_key(Termisu::Event::Key.new(Termisu::Input::Key::LowerA, char: c)) }
+      view.handle_list_paste_key(Termisu::Event::Key.new(Termisu::Input::Key::Enter))
+      "root".each_char { |c| view.handle_list_paste_key(Termisu::Event::Key.new(Termisu::Input::Key::LowerA, char: c)) }
+      view.commit_list_paste
+      view.list_paste_active?.should be_false
+      backend = MemoryBackend.new(120, 30)
+      view.render(Screen.new(backend), Rect.new(0, 0, 120, 30))
+      backend.contains?("admin,root").should be_true
+    end
+
+    it "re-opening seeds one value per line from the existing comma-joined string" do
+      view = loaded_fuzzer
+      view.focus_config
+      view.open_list_paste
+      "a".each_char { |c| view.handle_list_paste_key(Termisu::Event::Key.new(Termisu::Input::Key::LowerA, char: c)) }
+      view.handle_list_paste_key(Termisu::Event::Key.new(Termisu::Input::Key::Enter))
+      "b".each_char { |c| view.handle_list_paste_key(Termisu::Event::Key.new(Termisu::Input::Key::LowerA, char: c)) }
+      view.handle_list_paste_key(Termisu::Event::Key.new(Termisu::Input::Key::Enter))
+      "c".each_char { |c| view.handle_list_paste_key(Termisu::Event::Key.new(Termisu::Input::Key::LowerA, char: c)) }
+      view.commit_list_paste # @p_values is now "a,b,c"
+
+      view.open_list_paste # reseed: should split into 3 SEPARATE lines, not one blob
+      view.handle_list_paste_key(Termisu::Event::Key.new(Termisu::Input::Key::Down))
+      view.handle_list_paste_key(Termisu::Event::Key.new(Termisu::Input::Key::Down))              # cursor on the "c" line alone
+      view.handle_list_paste_key(Termisu::Event::Key.new(Termisu::Input::Key::LowerA, char: 'Z')) # → "Zc"
+      view.commit_list_paste
+
+      backend = MemoryBackend.new(120, 30)
+      view.render(Screen.new(backend), Rect.new(0, 0, 120, 30))
+      backend.contains?("a,b,Zc").should be_true
+    end
+
+    it "requires the List payload type" do
+      view = loaded_fuzzer
+      view.focus_config
+      view.form_adjust(1) # ptype: list → numbers
+      view.open_list_paste.not_nil!.should contain("List")
+      view.list_paste_active?.should be_false
+    end
+
+    it "esc (via the controller-facing commit) applies and closes, matching the CHAIN pane convention" do
+      view = loaded_fuzzer
+      view.focus_config
+      view.open_list_paste
+      "x".each_char { |c| view.handle_list_paste_key(Termisu::Event::Key.new(Termisu::Input::Key::LowerA, char: c)) }
+      view.commit_list_paste # the controller calls this on both esc and the ^L toggle-close
+      view.list_paste_active?.should be_false
+      backend = MemoryBackend.new(120, 30)
+      view.render(Screen.new(backend), Rect.new(0, 0, 120, 30))
+      backend.contains?("x").should be_true
+    end
+  end
+
   it "label uses the custom name when set, else the template summary" do
     view = FuzzerView.new
     view.load_request("https://h", "GET /?x=1 HTTP/1.1\r\nHost: h\r\n\r\n", false, "")

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -200,6 +200,10 @@ private class FakeContext < ExecContext
     @calls << :fuzz_attach_chain
   end
 
+  def fuzz_list_paste : Nil
+    @calls << :fuzz_list_paste
+  end
+
   def mine_selected : Nil
     @calls << :mine_selected
   end

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -94,8 +94,10 @@ module Gori::Tui
     end
 
     private def config_hint(v : FuzzerView) : String
+      return "type/paste · ⏎ newline · ^L / esc applies" if v.list_paste_active?
       return "↑/↓ pick · ↹/↵ complete · esc close · type to filter" if v.path_completing?
-      "↑/↓ field · ←/→ change · type edit · ⏎ add/toggle · Del rm · ↹ pane"
+      base = "↑/↓ field · ←/→ change · type edit · ⏎ add/toggle · Del rm · ↹ pane"
+      v.config_field == :p_values ? "#{base} · ^L paste" : base
     end
 
     # --- rendering ---
@@ -191,6 +193,7 @@ module Gori::Tui
 
     private def handle_escape(v : FuzzerView) : Nil
       return v.commit_chain_pane if v.chain_pane_active? # esc in the CHAIN pane → save + back
+      return v.commit_list_paste if v.list_paste_active? # esc in the paste popup → apply + close
       v.focus == :detail ? v.focus_pane(:results) : @host.request_focus(:menu)
     end
 
@@ -204,6 +207,19 @@ module Gori::Tui
       else
         msg = view.focus_chain_pane
         @host.status(msg || "type the chain · Tab completes · ↵/esc saves")
+      end
+    end
+
+    # ^L: open the multi-line paste popup for the List payload's values (again = apply + close).
+    def fuzz_list_paste : Nil
+      return unless view = current_view
+      if view.list_paste_active?
+        view.commit_list_paste
+        save_current
+        @host.status("list updated")
+      else
+        msg = view.open_list_paste
+        @host.status(msg || "paste values, one per line · ^L / esc applies")
       end
     end
 
@@ -267,6 +283,7 @@ module Gori::Tui
     end
 
     private def edit_config(ev : Termisu::Event::Key, v : FuzzerView) : Nil
+      return v.handle_list_paste_key(ev) if v.list_paste_active? # popup owns typing while open
       key = ev.key
       case
       when key.up?        then config_up(v)
@@ -310,6 +327,7 @@ module Gori::Tui
     end
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
+      return true if current_view.try(&.list_paste_active?) # the floating popup owns the screen — swallow clicks
       body = subtab_strip_shown? ? BodyChrome.carve_subtab_row(rect)[1] : rect
       return true unless v = current_view
       if pane = v.pane_at(body, mx, my)
@@ -323,6 +341,7 @@ module Gori::Tui
     end
 
     def handle_wheel(step : Int32) : Bool
+      return true if current_view.try(&.list_paste_active?) # popup owns the screen — swallow the wheel too
       if v = current_view
         case v.focus
         when :results then v.results_move(step)

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -108,6 +108,12 @@ module Gori::Tui
       @chain_pane = ChainPane.new
       @chain_focused = false
       @chain_marker_cursor = 0
+      # The LIST PASTE popup: a floating multi-line editor for the List payload's
+      # comma-joined @p_values, so a newline-separated wordlist can be pasted directly
+      # instead of retyped as one comma-joined line. ^L toggles it open (seeded one
+      # value per line) / commits (rejoins non-blank lines with ',' into @p_values).
+      @list_paste = TextArea.new
+      @list_paste_open = false
       @show_dist = true # the DIST sidebar beside RESULTS (toggled with `v`)
       @dist_cache = nil.as(DistData?)
       @dist_cache_rev = -1_i64
@@ -241,11 +247,13 @@ module Gori::Tui
     def focus_pane(pane : Symbol) : Nil
       return unless PANE_ORDER.includes?(pane)
       commit_chain_pane if @chain_focused
+      commit_list_paste if @list_paste_open
       @focus = pane
     end
 
     def focus_config : Nil
       commit_chain_pane if @chain_focused
+      commit_list_paste if @list_paste_open
       @focus = :config
       @cfg_field = 0 # land straight on the payload type tabs
       @cfg_caret = 0
@@ -254,6 +262,7 @@ module Gori::Tui
 
     def pane_advance(dir : Int32) : Bool
       commit_chain_pane if @chain_focused
+      commit_list_paste if @list_paste_open
       if @focus == :detail
         @focus = :results
         return true
@@ -278,6 +287,8 @@ module Gori::Tui
     def set_preedit(text : String) : Nil
       if chain_pane_active?
         @chain_pane.set_preedit(text)
+      elsif list_paste_active?
+        @list_paste.set_preedit(text)
       elsif @focus == :template
         @editor.set_preedit(text)
       end
@@ -320,6 +331,52 @@ module Gori::Tui
       return if @chain_pane.handle_key(ev)
       key = ev.key
       commit_chain_pane if key.escape? || key.enter? || key.tab? || key.up?
+    end
+
+    LIST_PASTE_PLACEHOLDER = "one payload per line — pasted newline-separated text splits automatically"
+
+    # True while the LIST PASTE popup owns the CONFIG pane's keyboard input.
+    def list_paste_active? : Bool
+      @list_paste_open && @focus == :config
+    end
+
+    # ^L: open the popup, seeded from the comma-joined @p_values (one entry per line).
+    # Returns a hint string when it can't (surfaced by the controller), nil on success.
+    def open_list_paste : String?
+      return "put the cursor in CONFIG first (^O)" unless @focus == :config
+      return "switch the payload type to List first (←/→)" unless @ptype == :list
+      @list_paste.set_text(@p_values.split(',').map(&.strip).reject(&.empty?).join('\n'))
+      @list_paste_open = true
+      nil
+    end
+
+    # Rejoin the popup's non-blank lines with ',' back into @p_values and close it.
+    # Idempotent so the focus changers above can call it freely.
+    def commit_list_paste : Nil
+      return unless @list_paste_open
+      @p_values = @list_paste.text.split('\n').map(&.strip).reject(&.empty?).join(',')
+      @dirty = true
+      @list_paste_open = false
+    end
+
+    # Route a key while the LIST PASTE popup is focused (the controller owns the
+    # escape/^L exit keys, which commit + close via commit_list_paste).
+    def handle_list_paste_key(ev : Termisu::Event::Key) : Nil
+      key = ev.key
+      case
+      when key.enter?     then @list_paste.insert_newline
+      when key.backspace? then @list_paste.backspace
+      when key.delete?    then @list_paste.delete
+      when key.up?        then @list_paste.move(-1, 0)
+      when key.down?      then @list_paste.move(1, 0)
+      when key.left?      then @list_paste.move(0, -1)
+      when key.right?     then @list_paste.move(0, 1)
+      when key.home?      then @list_paste.home
+      when key.end?       then @list_paste.end_of_line
+      else
+        ch = ev.char || key.to_char
+        @list_paste.insert(ch) if ch && !ev.ctrl? && !ev.alt?
+      end
     end
 
     # "§N" label for the marker under the template cursor (1-based), or "§" when not in one.
@@ -1082,6 +1139,7 @@ module Gori::Tui
       bottom = Rect.new(rest.x, rest.y + top_h, rest.w, {rest.h - top_h, 0}.max)
       render_top(screen, top, focused)
       render_bottom(screen, bottom, focused) if bottom.h > 0
+      render_list_paste(screen, rect) if list_paste_active?
     end
 
     private def render_top(screen : Screen, rect : Rect, focused : Bool) : Nil
@@ -1138,6 +1196,38 @@ module Gori::Tui
         rw = rect.w - vw - 1 # results width minus the 1-col gap (mirrors render_top)
         render_results(screen, Rect.new(rect.x, rect.y, rw, rect.h), focused && @focus == :results)
         render_dist(screen, Rect.new(rect.x + rw + 1, rect.y, vw, rect.h)) # read-only sidebar
+      end
+    end
+
+    # Centered box for the LIST PASTE popup within the whole session `area` — sized
+    # generously (it's meant to hold a pasted wordlist) but capped to the terminal,
+    # nil when even a small popup can't fit.
+    private def list_paste_box(area : Rect) : Rect?
+      w = {area.w - 8, 70}.min
+      h = {area.h - 6, 22}.min
+      return nil if w < 24 || h < 6
+      Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
+    end
+
+    private def render_list_paste(screen : Screen, area : Rect) : Nil
+      box = list_paste_box(area)
+      return unless box
+      # bg: Theme.bg (not the card default Theme.panel) — the embedded TextArea always
+      # paints its lines on Theme.bg, so the card must match or the interior two-tones.
+      Frame.card(screen, box, "PASTE LIST", bg: Theme.bg, border: Theme.border_focus)
+      n = @list_paste.text.split('\n').map(&.strip).reject(&.empty?).size
+      meta = "#{n} value#{n == 1 ? "" : "s"}"
+      screen.text({box.right - meta.size - 2, box.x + 13}.max, box.y, meta, Theme.muted, Theme.bg)
+      inner = box.inset(1, 1)
+      return if inner.h < 2
+      hint_y = inner.bottom - 1
+      screen.text(inner.x, hint_y, "one value per line · ⏎ newline · ^L / esc applies", Theme.muted, Theme.bg, width: inner.w)
+      editor = Rect.new(inner.x, inner.y, inner.w, inner.h - 1)
+      if @list_paste.line_count == 1 && @list_paste.text.empty?
+        screen.text(editor.x, editor.y, LIST_PASTE_PLACEHOLDER, Theme.muted, Theme.bg, width: editor.w)
+        screen.cursor(editor.x, editor.y)
+      else
+        @list_paste.render(screen, editor, cursor: true)
       end
     end
 
@@ -1451,7 +1541,7 @@ module Gori::Tui
                 "#{result_count} sent · #{matched_count} hit"
               end
       screen.text(rect.x + 11, rect.y, count, Theme.muted, Theme.bg) # +11 clears the " RESULTS " title
-      min_x = rect.x + 11 + count.size + 1 # badges never overwrite the count
+      min_x = rect.x + 11 + count.size + 1                           # badges never overwrite the count
       rx = Frame.toggle_badge(screen, rect.right - 1, rect.y, min_x, "v", "DIST", @show_dist)
       rx = Frame.toggle_badge(screen, rx, rect.y, min_x, "m", "MATCH", @matched_only)
       Frame.toggle_badge(screen, rx, rect.y, min_x, "o", @sort.to_s, false) # sort: a value chip, never lit

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -66,7 +66,7 @@ module Gori::Tui
         {"^N / ^W", "new / close a sub-tab"},
         {"^A · ^K · ^T · ^U", "auto-mark params · mark word · mark point (manual §) · clear §"},
         {"^O", "focus the config pane (lands on Payload)"},
-        {"config", "payload type/fields · ⏎ +add · ▸ Advanced (mode/engine/match/filter)"},
+        {"config", "payload type/fields · ⏎ +add · ^L paste List values (one per line) · ▸ Advanced (mode/engine/match/filter)"},
         {"wordlist path", "⇥/type to auto-complete from the dir + ~/.gori/wordlists"},
         {"^R · ^X", "run · stop"},
         {"↑/↓ · ↵", "results: select · open detail"},

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -3432,6 +3432,11 @@ module Gori::Tui
       fuzzer_controller.fuzz_focus_chain_pane
     end
 
+    # ^L: open the multi-line paste popup for the List payload's values (again = apply + close).
+    def fuzz_list_paste : Nil
+      fuzzer_controller.fuzz_list_paste
+    end
+
     # --- Miner ExecContext / cross-tab mediators ---
     # CROSS-TAB: open the config popup for History's selected flow (space → Mine params).
     def mine_selected : Nil

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -83,6 +83,7 @@ module Gori
       abstract def fuzz_new : Nil          # open a blank fuzz session
       abstract def fuzz_automark : Nil     # auto-mark every request parameter
       abstract def fuzz_attach_chain : Nil # open the chain-edit prompt for the marker at the template cursor
+      abstract def fuzz_list_paste : Nil   # open/commit the multi-line paste popup for the List payload values
 
       # param miner (cross-tab seeds open a config popup, then mining runs in background)
       abstract def mine_selected : Nil    # mine History's selected flow (opens the config popup)

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -241,6 +241,10 @@ module Gori
         "fuzz.attach-chain", "Edit convert chain", "Focus the CHAIN pane to edit the encode/decode chain of the marker at the cursor (applied to each payload on send)",
         Verb::Scope::Fuzzer, [Verb::Chord.new("y", ctrl: true)],
         available: in_fuzzer, mnemonic: 'c') { |ctx| ctx.fuzz_attach_chain; nil }
+      r.register Verb::Definition.new(
+        "fuzz.list-paste", "Paste list values", "Open a multi-line popup to paste newline-separated values for the List payload (pressing it again applies + closes)",
+        Verb::Scope::Fuzzer, [Verb::Chord.new("l", ctrl: true)],
+        available: in_fuzzer, mnemonic: 'l') { |ctx| ctx.fuzz_list_paste; nil }
     end
 
     # Param-miner verbs: the cross-tab "Mine parameters" entry (space menu in History,


### PR DESCRIPTION
## Summary
- `^L` in the Fuzzer CONFIG pane (List payload type) opens a floating multi-line popup, seeded one value per line from the existing comma-joined field
- `^L` again (or esc) rejoins non-blank lines with `,` back into the field — the persisted config JSON shape and the run-time `InlineList` split are unchanged
- Wired as a normal rebindable verb (`fuzz.list-paste`), same pattern as the existing `^Y` chain-pane verb

## Test plan
- [x] `crystal spec` — 1141 examples, 0 failures (incl. 4 new tests: open/seed, multi-line commit/rejoin, per-line re-seed on reopen, payload-type guard)
- [x] `crystal build --no-codegen` type-checks clean
- [x] `crystal tool format --check` clean