### PR TITLE
fix(store): stop h2 DATA-frame body double-storage + trim capture/FTS bloat

### DIFF
--- a/spec/store/fts_spec.cr
+++ b/spec/store/fts_spec.cr
@@ -74,6 +74,45 @@ describe "contentless FTS (V24)" do
     end
   end
 
+  it "skips a content-encoded (compressed) response body — unsearchable and index-bloating" do
+    fts_store do |store|
+      id = store.insert_flow(req_with_body("/gz", nil))
+      # A text content type, but Content-Encoding present ⇒ the stored body is compressed
+      # wire bytes: high-entropy (trigram-index bloat) and impossible to body-search for
+      # readable text. It must be skipped like a binary body.
+      store.update_response(Gori::Store::CapturedResponse.new(
+        flow_id: id, status: 200,
+        head: "HTTP/1.1 200 OK\r\ncontent-type: text/html\r\ncontent-encoding: gzip\r\n\r\n".to_slice,
+        body: "compressedbodytoken".to_slice, content_type: "text/html"))
+      store.flush
+      body_hits(store, "compressedbodytoken").should be_empty
+    end
+  end
+
+  it "skips a content-encoded request body too" do
+    fts_store do |store|
+      id = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "http", host: "h.test", port: 80,
+        method: "POST", target: "/up", http_version: "HTTP/1.1",
+        head: "POST /up HTTP/1.1\r\nHost: h.test\r\ncontent-encoding: gzip\r\n\r\n".to_slice,
+        body: "gzreqtoken".to_slice))
+      store.flush
+      body_hits(store, "gzreqtoken").should be_empty
+    end
+  end
+
+  it "still indexes an identity/uncompressed text response (regression guard)" do
+    fts_store do |store|
+      id = store.insert_flow(req_with_body("/id", nil))
+      store.update_response(Gori::Store::CapturedResponse.new(
+        flow_id: id, status: 200,
+        head: "HTTP/1.1 200 OK\r\ncontent-type: text/html\r\ncontent-encoding: identity\r\n\r\n".to_slice,
+        body: "identitybodytoken".to_slice, content_type: "text/html"))
+      store.flush
+      body_hits(store, "identitybodytoken").should eq([id]) # identity ⇒ NOT skipped
+    end
+  end
+
   it "removes FTS rows on prune (contentless range delete leaves no dangling match)" do
     fts_store(retention: 5, prune_interval: 10) do |store|
       first = store.insert_flow(req_with_body("/old", "prunedbodytoken"))

--- a/spec/store/store_spec.cr
+++ b/spec/store/store_spec.cr
@@ -194,6 +194,40 @@ describe Gori::Store do
     end
   end
 
+  it "V25 empties duplicated h2 DATA-frame payloads while preserving their length" do
+    path = File.tempname("gori-v25", ".db")
+    db = DB.open("sqlite3:#{path}?journal_mode=wal")
+    begin
+      # bring the schema up to V24 (the state just before the reclaim migration)
+      Gori::Store::Schema::MIGRATIONS[0..23].each_with_index do |stmts, i|
+        db.transaction do |tx|
+          stmts.each { |s| tx.connection.exec(s) }
+          tx.connection.exec("PRAGMA user_version = #{i + 1}")
+        end
+      end
+
+      # OLD writer behaviour: DATA (type 0) stored its full payload; HEADERS (type 1) too.
+      db.exec("INSERT INTO h2_frames (conn_id, created_at, direction, stream_id, type, flags, length, payload) VALUES (?,?,?,?,?,?,?,?)",
+        1_i64, 1_i64, "in", 1_i64, 0, 1, "hello".bytesize, "hello".to_slice) # DATA
+      db.exec("INSERT INTO h2_frames (conn_id, created_at, direction, stream_id, type, flags, length, payload) VALUES (?,?,?,?,?,?,?,?)",
+        1_i64, 2_i64, "in", 1_i64, 1, 4, "hdr".bytesize, "hdr".to_slice) # HEADERS
+
+      Gori::Store::Schema.migrate!(db) # runs V25
+      db.scalar("PRAGMA user_version").as(Int64).should eq(Gori::Store::Schema::VERSION)
+
+      # DATA payload emptied, but its length (the detail-view timeline value) preserved
+      db.scalar("SELECT length FROM h2_frames WHERE type = 0").as(Int64).should eq("hello".bytesize)
+      db.query_one("SELECT payload FROM h2_frames WHERE type = 0", as: Bytes).size.should eq(0)
+      # non-DATA payloads are retained verbatim
+      String.new(db.query_one("SELECT payload FROM h2_frames WHERE type = 1", as: Bytes)).should eq("hdr")
+    ensure
+      db.close
+      File.delete?(path)
+      File.delete?("#{path}-wal")
+      File.delete?("#{path}-shm")
+    end
+  end
+
   it "bounds sitemap_entries by the limit so a huge history can't materialize unbounded" do
     with_store do |store|
       5.times { |i| store.insert_flow(sample_request(host: "h#{i}.test", target: "/p#{i}")) }

--- a/spec/store_extras_spec.cr
+++ b/spec/store_extras_spec.cr
@@ -59,14 +59,20 @@ describe "Gori::Store h2 raw frame log (v5)" do
       String.new(frames[0].payload).should eq("hdrblock")
       frames[1].direction.should eq("in")
       frames[1].type.should eq(0)
-      String.new(frames[1].payload).should eq("body")
+      # DATA (type 0) payloads are NOT persisted — they duplicate flows.request_body/
+      # response_body byte-for-byte. The frame log keeps only the metadata + the TRUE byte
+      # count in `length` (what the detail-view timeline renders); the payload is emptied.
+      frames[1].length.should eq("body".bytesize)
+      frames[1].payload.size.should eq(0)
     end
   end
 
   it "h2_frames(limit) returns the MOST RECENT n frames ascending; count is the full total" do
     with_store do |store|
       conn = store.insert_h2_connection("acme.test", 443, "h2")
-      10.times { |i| store.insert_h2_frame(conn, "out", 0x0_u8, 0x0_u8, 1_u32, "f#{i}".to_slice) }
+      # HEADERS (0x1), not DATA — DATA payloads are dropped on write (dedup), so this window
+      # test asserts on retained non-DATA payloads to prove ordering, not the dedup rule.
+      10.times { |i| store.insert_h2_frame(conn, "out", 0x1_u8, 0x0_u8, 1_u32, "f#{i}".to_slice) }
       store.flush
       store.count_h2_frames(conn).should eq(10)                           # full count regardless of the window
       win = store.h2_frames(conn, 3)                                      # bounded to the latest 3

--- a/src/gori/proxy/codec/body.cr
+++ b/src/gori/proxy/codec/body.cr
@@ -79,8 +79,13 @@ module Gori::Proxy::Codec
 
     # Ceiling on a single captured request/response body. Forwarding is never
     # capped (it streams byte-exact); this only bounds what we buffer for the DB,
-    # so a multi-GB download can't OOM the proxy or bloat one row. Tune as needed.
-    CAPTURE_MAX = 8 * 1024 * 1024 # 8 MiB
+    # so a multi-GB download can't OOM the proxy or bloat one row. The TRUE wire
+    # size is preserved in request_size/response_size regardless of this cap, so
+    # lowering it only trims the stored BLOB, never the reported size. 2 MiB keeps
+    # whole HTML/JS/JSON/API bodies while cutting the multi-MB media/protobuf tail
+    # that dominated DB growth (a single 8 MiB Safe-Browsing blob was ~25% of one
+    # capture). Tune as needed.
+    CAPTURE_MAX = 2 * 1024 * 1024 # 2 MiB
 
     # RFC 7230 §3.3.3 framing for a request body.
     def self.request_framing(req : RawRequest) : {BodyFraming, Int64}

--- a/src/gori/replay/flow_request.cr
+++ b/src/gori/replay/flow_request.cr
@@ -20,7 +20,7 @@ module Gori
         row = detail.row
         head = detail.request_head
         body = detail.request_body
-        # The captured body is capped at CAPTURE_MAX (8 MiB). If it was truncated, a faithful
+        # The captured body is capped at CAPTURE_MAX. If it was truncated, a faithful
         # h1 replay would BLOCK the origin waiting for bytes that no longer exist (a
         # Content-Length over-promising, or a chunked stream cut before its 0-chunk). Byte-
         # exactness is already lost at the cap, so re-frame the head to a fixed Content-Length

--- a/src/gori/replay/h2_engine.cr
+++ b/src/gori/replay/h2_engine.cr
@@ -24,7 +24,7 @@ module Gori
       # are NOT flow-controlled, so a CONTINUATION flood grows the header block
       # unboundedly, and a streaming/over-large body has no aggregate ceiling.
       MAX_HEADER_BLOCK = 1 << 20         # 1 MiB
-      MAX_BODY         = 8 * 1024 * 1024 # 8 MiB (matches Codec::Body::CAPTURE_MAX)
+      MAX_BODY         = 8 * 1024 * 1024 # 8 MiB (replay response read ceiling; independent of the proxy-capture cap)
       # Hard ceiling on frames processed for one response. HEADERS/DATA are byte-capped
       # above, but non-terminal frames (PING/PRIORITY/WINDOW_UPDATE/SETTINGS on any stream)
       # are neither — a hostile origin can stream them forever without END_STREAM, and the

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -113,7 +113,17 @@ module Gori
       # Make REGEXP byte-safe on every connection before any query runs (so a binary
       # body can't crash a `body~`/`header~` scan or a regex scope rule). See SafeRegexp.
       SafeRegexp.install(db)
+      pre_version = db.scalar("PRAGMA user_version").as(Int64).to_i
       Schema.migrate!(db)
+      # The V25 migration empties duplicated h2 DATA payloads (often ~40% of the DB). That
+      # frees pages for REUSE but doesn't shrink the file, so VACUUM once — only when an
+      # EXISTING db (pre_version >= 1) crossed into the reclaim version. A fresh db
+      # (pre_version 0) has nothing to reclaim; a db already at/after the reclaim version
+      # won't re-run it. VACUUM can't live inside migrate!'s transaction, and it is best-
+      # effort: a failure (disk full / lock) leaves the db fully usable, just un-shrunk.
+      if pre_version >= 1 && pre_version < Schema::RECLAIM_VERSION
+        db.exec("VACUUM") rescue nil
+      end
       new(db, events, prism_events, retention_flows)
     end
 
@@ -1345,7 +1355,7 @@ module Gori
       # row (update_one only carries the response), capped in SQL so a multi-MB upload
       # isn't pulled back whole. DELETE is a cheap tombstone (contentless_delete=1) and
       # also makes a double update_response idempotent (last write wins).
-      resp_fts = binary_content?(resp.content_type) ? "" : fts_text(resp.body)
+      resp_fts = (binary_content?(resp.content_type) || content_encoded?(resp.head)) ? "" : fts_text(resp.body)
       req_fts = request_fts_from_row(conn, resp.flow_id)
       conn.exec("DELETE FROM flows_fts WHERE rowid = ?", resp.flow_id)
       conn.exec("INSERT INTO flows_fts(rowid, req, resp) VALUES (?, ?, ?)", resp.flow_id, req_fts, resp_fts)
@@ -1363,7 +1373,7 @@ module Gori
       return "" unless row
       head, body = row
       return "" if body.nil? || body.empty?
-      binary_content?(head_content_type(head)) ? "" : String.new(body)
+      (binary_content?(head_content_type(head)) || content_encoded?(head)) ? "" : String.new(body)
     end
 
     # Body text fed to the FTS index, capped per side so a large body can't bloat
@@ -1379,7 +1389,7 @@ module Gori
     private def request_fts(req : CapturedRequest) : String
       body = req.body
       return "" if body.nil? || body.empty?
-      binary_content?(head_content_type(req.head)) ? "" : fts_text(body)
+      (binary_content?(head_content_type(req.head)) || content_encoded?(req.head)) ? "" : fts_text(body)
     end
 
     # Skip body FTS for clearly-binary content types (images/media/archives/
@@ -1395,12 +1405,29 @@ module Gori
     end
 
     private def head_content_type(head : Bytes) : String?
+      header_field(head, "content-type")
+    end
+
+    # A body carrying a non-identity Content-Encoding is stored in COMPRESSED wire form, so
+    # its bytes are high-entropy: trigram-indexing them explodes flows_fts (many distinct
+    # trigrams per body) while being unsearchable for readable text (you can't `body:` a
+    # gzip stream). Skip the index for them, exactly like a binary content type.
+    private def content_encoded?(head : Bytes) : Bool
+      enc = header_field(head, "content-encoding")
+      return false unless enc
+      e = enc.downcase.strip
+      !e.empty? && e != "identity"
+    end
+
+    # Value of the first matching header (case-insensitive name) in a raw head BLOB, or nil
+    # if absent — reads Content-Type / Content-Encoding off the stored bytes at index time.
+    private def header_field(head : Bytes, name : String) : String?
       String.new(head).each_line do |raw|
         line = raw.chomp
         break if line.empty?
         idx = line.index(':')
         next unless idx
-        return line[(idx + 1)..].strip if line[0...idx].strip.downcase == "content-type"
+        return line[(idx + 1)..].strip if line[0...idx].strip.downcase == name
       end
       nil
     end
@@ -1418,9 +1445,22 @@ module Gori
     # Same columns/casts the old synchronous insert used (so h2_frames readback /
     # to_bytes round-trips are unchanged).
     private def insert_h2_frame_one(conn : DB::Connection, op : InsertH2Frame) : Nil
-      conn.exec("INSERT INTO h2_frames (conn_id, created_at, direction, stream_id, type, flags, length, payload) " \
-                "VALUES (?,?,?,?,?,?,?,?)",
-        op.conn_id, op.created_at, op.direction, op.stream_id, op.type_octet, op.flags, op.payload.size, op.payload)
+      # DATA frames (type 0) duplicate flows.response_body / request_body byte-for-byte
+      # and are the dominant h2_frames byte cost. The frame-log detail view renders the
+      # `length` COLUMN, never the payload, so persist an EMPTY payload while keeping the
+      # TRUE byte count in `length` (op.payload.size, still the full size). HEADERS/
+      # CONTINUATION/SETTINGS/etc stay verbatim — tiny, and their bytes exist nowhere else.
+      # Use the SQL literal X'' (a non-null zero-length BLOB the NOT NULL column accepts):
+      # binding Bytes.empty would bind SQL NULL (empty slice ⇒ null pointer) and violate it.
+      if op.type_octet.zero?
+        conn.exec("INSERT INTO h2_frames (conn_id, created_at, direction, stream_id, type, flags, length, payload) " \
+                  "VALUES (?,?,?,?,?,?,?,X'')",
+          op.conn_id, op.created_at, op.direction, op.stream_id, op.type_octet, op.flags, op.payload.size)
+      else
+        conn.exec("INSERT INTO h2_frames (conn_id, created_at, direction, stream_id, type, flags, length, payload) " \
+                  "VALUES (?,?,?,?,?,?,?,?)",
+          op.conn_id, op.created_at, op.direction, op.stream_id, op.type_octet, op.flags, op.payload.size, op.payload)
+      end
     end
 
     # Runs a write closure on the writer connection; returns last_insert_rowid.

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -1,5 +1,6 @@
 require "db"
 require "sqlite3"
+require "log"
 require "json"
 require "./store/models"
 require "./store/safe_regexp"
@@ -115,16 +116,32 @@ module Gori
       SafeRegexp.install(db)
       pre_version = db.scalar("PRAGMA user_version").as(Int64).to_i
       Schema.migrate!(db)
-      # The V25 migration empties duplicated h2 DATA payloads (often ~40% of the DB). That
-      # frees pages for REUSE but doesn't shrink the file, so VACUUM once — only when an
-      # EXISTING db (pre_version >= 1) crossed into the reclaim version. A fresh db
-      # (pre_version 0) has nothing to reclaim; a db already at/after the reclaim version
-      # won't re-run it. VACUUM can't live inside migrate!'s transaction, and it is best-
-      # effort: a failure (disk full / lock) leaves the db fully usable, just un-shrunk.
-      if pre_version >= 1 && pre_version < Schema::RECLAIM_VERSION
-        db.exec("VACUUM") rescue nil
-      end
+      # V25 empties duplicated h2 DATA payloads (often ~40% of the DB), freeing pages but not
+      # shrinking the file — reclaim to disk once, only when an EXISTING db (pre_version >= 1)
+      # just crossed into the reclaim version. A fresh db (0) has nothing to reclaim; a db
+      # already at/after it won't re-run.
+      reclaim_to_disk(db) if pre_version >= 1 && pre_version < Schema::RECLAIM_VERSION
       new(db, events, prism_events, retention_flows)
+    end
+
+    # Ceiling on the db we auto-VACUUM on the boot path. VACUUM rewrites the WHOLE file
+    # (disk-bandwidth-bound) and holds an exclusive lock, so above this we SKIP it rather than
+    # freeze startup on a huge project — the freed pages are still reused by later writes, and
+    # the operator can VACUUM manually.
+    VACUUM_MAX_BYTES = 512_i64 * 1024 * 1024
+
+    # One-time disk reclaim after the V25 payload-emptying migration. NOT run inside migrate!'s
+    # transaction (VACUUM is illegal there). Best-effort: a failure (disk full, or a concurrent
+    # instance holding the db past busy_timeout) leaves the db fully usable, just un-shrunk.
+    private def self.reclaim_to_disk(db : DB::Database) : Nil
+      bytes = db.scalar("SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()").as(Int64)
+      if bytes > VACUUM_MAX_BYTES
+        Log.info { "store: skipping post-migration VACUUM (#{bytes // (1024 * 1024)} MiB > #{VACUUM_MAX_BYTES // (1024 * 1024)} MiB cap); freed pages will be reused, or VACUUM manually to reclaim disk" }
+        return
+      end
+      db.exec("VACUUM")
+    rescue ex
+      Log.warn(exception: ex) { "store: post-migration VACUUM failed (non-fatal; db un-shrunk)" }
     end
 
     # Count of write batches that failed (e.g. disk full) — surfaced in the TUI
@@ -1355,7 +1372,7 @@ module Gori
       # row (update_one only carries the response), capped in SQL so a multi-MB upload
       # isn't pulled back whole. DELETE is a cheap tombstone (contentless_delete=1) and
       # also makes a double update_response idempotent (last write wins).
-      resp_fts = (binary_content?(resp.content_type) || content_encoded?(resp.head)) ? "" : fts_text(resp.body)
+      resp_fts = (binary_content?(resp.content_type) || encoded?(head_markers(resp.head)[1])) ? "" : fts_text(resp.body)
       req_fts = request_fts_from_row(conn, resp.flow_id)
       conn.exec("DELETE FROM flows_fts WHERE rowid = ?", resp.flow_id)
       conn.exec("INSERT INTO flows_fts(rowid, req, resp) VALUES (?, ?, ?)", resp.flow_id, req_fts, resp_fts)
@@ -1373,7 +1390,7 @@ module Gori
       return "" unless row
       head, body = row
       return "" if body.nil? || body.empty?
-      (binary_content?(head_content_type(head)) || content_encoded?(head)) ? "" : String.new(body)
+      skip_body_fts?(head) ? "" : String.new(body)
     end
 
     # Body text fed to the FTS index, capped per side so a large body can't bloat
@@ -1389,7 +1406,7 @@ module Gori
     private def request_fts(req : CapturedRequest) : String
       body = req.body
       return "" if body.nil? || body.empty?
-      (binary_content?(head_content_type(req.head)) || content_encoded?(req.head)) ? "" : fts_text(body)
+      skip_body_fts?(req.head) ? "" : fts_text(body)
     end
 
     # Skip body FTS for clearly-binary content types (images/media/archives/
@@ -1404,32 +1421,39 @@ module Gori
         c.starts_with?("application/wasm")
     end
 
-    private def head_content_type(head : Bytes) : String?
-      header_field(head, "content-type")
+    # Skip FTS for a body that is binary by content type OR compressed by Content-Encoding —
+    # both markers read in ONE pass over the head. A non-identity Content-Encoding means the
+    # body is stored in COMPRESSED wire form: high-entropy bytes that explode the trigram
+    # index while being unsearchable for readable text (you can't `body:` a gzip stream).
+    private def skip_body_fts?(head : Bytes) : Bool
+      ct, ce = head_markers(head)
+      binary_content?(ct) || encoded?(ce)
     end
 
-    # A body carrying a non-identity Content-Encoding is stored in COMPRESSED wire form, so
-    # its bytes are high-entropy: trigram-indexing them explodes flows_fts (many distinct
-    # trigrams per body) while being unsearchable for readable text (you can't `body:` a
-    # gzip stream). Skip the index for them, exactly like a binary content type.
-    private def content_encoded?(head : Bytes) : Bool
-      enc = header_field(head, "content-encoding")
-      return false unless enc
-      e = enc.downcase.strip
-      !e.empty? && e != "identity"
-    end
-
-    # Value of the first matching header (case-insensitive name) in a raw head BLOB, or nil
-    # if absent — reads Content-Type / Content-Encoding off the stored bytes at index time.
-    private def header_field(head : Bytes, name : String) : String?
+    # {Content-Type, Content-Encoding} header values from a raw head BLOB (either nil), read
+    # in a single pass so a skip decision costs one scan, not one per header.
+    private def head_markers(head : Bytes) : {String?, String?}
+      ct = nil.as(String?)
+      ce = nil.as(String?)
       String.new(head).each_line do |raw|
         line = raw.chomp
         break if line.empty?
         idx = line.index(':')
         next unless idx
-        return line[(idx + 1)..].strip if line[0...idx].strip.downcase == name
+        case line[0...idx].strip.downcase
+        when "content-type"     then ct = line[(idx + 1)..].strip
+        when "content-encoding" then ce = line[(idx + 1)..].strip
+        end
       end
-      nil
+      {ct, ce}
+    end
+
+    # A non-identity Content-Encoding ⇒ the body is compressed (skip it from FTS). `ce` comes
+    # from head_markers already stripped, so downcase alone suffices.
+    private def encoded?(ce : String?) : Bool
+      return false unless ce
+      c = ce.downcase
+      !c.empty? && c != "identity"
     end
 
     private def insert_ws_one(conn : DB::Connection, op : InsertWs) : Nil
@@ -1445,22 +1469,19 @@ module Gori
     # Same columns/casts the old synchronous insert used (so h2_frames readback /
     # to_bytes round-trips are unchanged).
     private def insert_h2_frame_one(conn : DB::Connection, op : InsertH2Frame) : Nil
-      # DATA frames (type 0) duplicate flows.response_body / request_body byte-for-byte
-      # and are the dominant h2_frames byte cost. The frame-log detail view renders the
-      # `length` COLUMN, never the payload, so persist an EMPTY payload while keeping the
-      # TRUE byte count in `length` (op.payload.size, still the full size). HEADERS/
-      # CONTINUATION/SETTINGS/etc stay verbatim — tiny, and their bytes exist nowhere else.
-      # Use the SQL literal X'' (a non-null zero-length BLOB the NOT NULL column accepts):
-      # binding Bytes.empty would bind SQL NULL (empty slice ⇒ null pointer) and violate it.
-      if op.type_octet.zero?
-        conn.exec("INSERT INTO h2_frames (conn_id, created_at, direction, stream_id, type, flags, length, payload) " \
-                  "VALUES (?,?,?,?,?,?,?,X'')",
-          op.conn_id, op.created_at, op.direction, op.stream_id, op.type_octet, op.flags, op.payload.size)
-      else
-        conn.exec("INSERT INTO h2_frames (conn_id, created_at, direction, stream_id, type, flags, length, payload) " \
-                  "VALUES (?,?,?,?,?,?,?,?)",
-          op.conn_id, op.created_at, op.direction, op.stream_id, op.type_octet, op.flags, op.payload.size, op.payload)
-      end
+      # DATA frames (type 0) duplicate flows.response_body / request_body byte-for-byte and
+      # are the dominant h2_frames byte cost. The frame-log detail view renders the `length`
+      # COLUMN, never the payload, so store an EMPTY payload for them while keeping the TRUE
+      # byte count in `length` (op.payload.size). HEADERS/CONTINUATION/SETTINGS/etc keep their
+      # payload — tiny, and their bytes exist nowhere else. For DATA use the SQL literal X''
+      # (a non-null zero-length BLOB the NOT NULL column accepts): binding Bytes.empty would
+      # bind SQL NULL (empty slice ⇒ null pointer) and violate the constraint.
+      data = op.type_octet.zero?
+      args = [op.conn_id, op.created_at, op.direction, op.stream_id,
+              op.type_octet, op.flags, op.payload.size] of DB::Any
+      args << op.payload unless data
+      conn.exec("INSERT INTO h2_frames (conn_id, created_at, direction, stream_id, type, flags, length, payload) " \
+                "VALUES (?,?,?,?,?,?,?,#{data ? "X''" : "?"})", args: args)
     end
 
     # Runs a write closure on the writer connection; returns last_insert_rowid.

--- a/src/gori/store/schema.cr
+++ b/src/gori/store/schema.cr
@@ -7,7 +7,13 @@ module Gori
     # (FTS5 for QL, a tags table, a connections table) arrive as *later*
     # migrations — which is exactly why none of them exist in v1 (P0).
     module Schema
-      VERSION = 24
+      VERSION = 25
+
+      # The migration that reclaims duplicated/low-value bytes already on disk (see V25).
+      # Store.open runs a one-time VACUUM after an EXISTING db crosses this version so the
+      # freed pages actually shrink the file. Pin it to the exact version (not `VERSION`)
+      # so a later migration doesn't re-trigger the VACUUM.
+      RECLAIM_VERSION = 25
 
       V1 = [
         <<-SQL,
@@ -454,7 +460,28 @@ module Gori
         SQL
       ]
 
-      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21, V22, V23, V24]
+      # Reclaim the single biggest source of on-disk bloat: h2 DATA frames (type 0) stored
+      # their payload in full even though the SAME bytes already live in flows.request_body/
+      # response_body. In one real capture this raw-frame duplication was ~44% of the whole
+      # DB. The frame-log detail view only ever renders the `length` column, never the
+      # payload, so empty every historical DATA payload while leaving `length` (already the
+      # true byte count) untouched. NEW inserts already store empty DATA payloads — see
+      # Store#insert_h2_frame_one. Freed pages are returned to the OS by the one-time VACUUM
+      # in Store.open (see RECLAIM_VERSION).
+      #
+      # NOTE: flows_fts is deliberately NOT rebuilt here. Its bloat comes from trigram-
+      # indexing COMPRESSED text bodies (high-entropy → trigram explosion), which the write
+      # path now skips going forward (Store#content_encoded?/#binary_content?). It can't be
+      # reclaimed cheaply in place: flows_fts is contentless, so DELETE only adds tombstones
+      # (grows it), and a SQL rebuild via CAST(body AS TEXT) truncates at the first NUL byte
+      # — silently dropping search coverage the runtime (String.new) had indexed. So the
+      # existing index is left to shrink naturally via retention rather than risk a lossy
+      # auto-rebuild on everyone's data.
+      V25 = [
+        "UPDATE h2_frames SET payload = X'' WHERE type = 0",
+      ]
+
+      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21, V22, V23, V24, V25]
 
       def self.migrate!(db : DB::Database) : Nil
         current = db.scalar("PRAGMA user_version").as(Int64).to_i


### PR DESCRIPTION
## Problem

Browsing a single site (`www.hahwul.com`) grew the project DB to **30.5 MB** (Caido does the same browsing in ~800 KB). Breakdown of the real capture (99 flows, 92 over HTTP/2):

| store | size | share |
|---|---|---|
| `h2_frames` | 14.25 MB | 44% |
| `flows` (resp_body 12.77 MB) | 13.0 MB | 40% |
| `flows_fts` | 4.5 MB | 14% |

The root cause is structural: **HTTP/2 response bodies are stored twice** — decoded in `flows.response_body` and again raw in the `h2_frames` DATA payloads. The raw frame log's only reader is the History detail *frames* pane, which renders each frame's `length`, never the payload.

## Fixes

**A — h2 DATA-frame dedup (biggest win).** `insert_h2_frame_one` stores an empty payload for DATA frames (type 0), keeping the true size in the `length` column. Migration `V25` reclaims existing rows. Measured: `h2_frames` **14.25 MB → 90 KB**.

**B — capture cap 8 MiB → 2 MiB.** One constant. `request_size`/`response_size` keep the true wire size, so only the stored BLOB is trimmed; the size columns and the "truncated at N MiB" trailer stay honest.

**C — FTS skips compressed bodies.** The binary-content-type skip was already in place; the actual `flows_fts` bloat is **compressed** text bodies (high-entropy → trigram explosion, and unsearchable anyway). New `content_encoded?(head)` skips them at index time.

**Reclaim to disk.** A one-time best-effort `VACUUM` in `Store.open` after the V25 reclaim so existing files shrink. Verified on a copy of the real DB: **30.4 MB → 17.9 MB**. New captures of the same browsing land ~7 MB (the h2 doubling is gone entirely).

## Deliberately out of scope
- **Scope-gated body storage** — would surprise users who treat scope as a display/intercept lens; deserves an explicit "capture in-scope only" setting.
- **Auto-rebuild of existing `flows_fts`** — a contentless index can't DELETE-reclaim (DELETE only adds tombstones, measured 4.49 → 5.10 MB), and a SQL `CAST(body AS TEXT)` rebuild truncates at the first NUL byte, silently dropping search coverage the runtime (`String.new`) had indexed. Left to shrink via retention.

## Gotcha fixed mid-way
Binding `Bytes.empty` to a `BLOB NOT NULL` column binds SQL **NULL** (empty slice = null pointer) → constraint violation → the store-writer fiber dies → every later `store.flush` deadlocks. Fixed with the SQL literal `X''`.

## Verification
- Full suite: **1141 examples, 0 failures, 0 errors**. New regression tests for V25, compressed/binary FTS skip, and the h2 dedup invariant.
- `crystal tool format` clean; no new ameba findings.
- Real DB copy: 30.4 MB → 17.9 MB.