### PR TITLE
fix(fuzzer): make RESULTS rows mouse-clickable (select-first, second click opens)

### DIFF
--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -203,6 +203,66 @@ describe Gori::Tui::FuzzerView do
     end
   end
 
+  describe "RESULTS click-to-select" do
+    # On a 120×30 render the RESULTS pane sits at (0,15,85,12) → inner (1,16,83,10):
+    # the header is on y=16, so row i (sorted index @scroll+i) lands on y=17+i.
+    it "maps a click y to the sorted-view row index (header/out-of-range → nil)" do
+      view = loaded_fuzzer
+      5.times { |i| view.append_result(fuzz_result(i, 200, 1200)) }
+      rect = Rect.new(0, 0, 120, 30)
+      view.render(Screen.new(MemoryBackend.new(120, 30)), rect)
+      view.results_row_at(rect, 5, 16).should be_nil # the header row
+      view.results_row_at(rect, 5, 17).should eq(0)  # first result
+      view.results_row_at(rect, 5, 19).should eq(2)
+      view.results_row_at(rect, 5, 21).should eq(4)    # last populated
+      view.results_row_at(rect, 5, 22).should be_nil   # past the last row
+      view.results_row_at(rect, 5, 10).should be_nil   # up in the TEMPLATE/CONFIG band
+      view.results_row_at(rect, 100, 18).should be_nil # over the DIST sidebar
+    end
+
+    it "select_result_row picks a row (clamped) without opening detail" do
+      view = loaded_fuzzer
+      3.times { |i| view.append_result(fuzz_result(i, 200, 1200)) }
+      view.render(Screen.new(MemoryBackend.new(120, 30)), Rect.new(0, 0, 120, 30))
+      view.select_result_row(2)
+      view.results_selected_index.should eq(2)
+      view.focus.should_not eq(:detail)
+      view.select_result_row(99) # clamps to the last row
+      view.results_selected_index.should eq(2)
+    end
+
+    # Replays FuzzerController#click_results: first click on a row grabs focus + selects
+    # it; a second click on the already-selected row (pane already focused) opens detail.
+    it "first click selects + focuses, a second click on the same row opens detail" do
+      view = loaded_fuzzer
+      4.times { |i| view.append_result(fuzz_result(i, 200, 1200)) }
+      rect = Rect.new(0, 0, 120, 30)
+      view.render(Screen.new(MemoryBackend.new(120, 30)), rect)
+      view.focus_pane(:template) # start elsewhere in the focus ring
+      # First click on row 2 (y=19): focus is not on :results yet → select + focus.
+      row = view.results_row_at(rect, 5, 19).not_nil!
+      row.should eq(2)
+      if view.focus == :results && row == view.results_selected_index
+        view.open_detail
+      else
+        view.focus_pane(:results)
+        view.select_result_row(row)
+      end
+      view.focus.should eq(:results)
+      view.results_selected_index.should eq(2)
+      # Second click on the same row: now focused + already selected → open detail.
+      row2 = view.results_row_at(rect, 5, 19).not_nil!
+      if view.focus == :results && row2 == view.results_selected_index
+        view.open_detail
+      else
+        view.focus_pane(:results)
+        view.select_result_row(row2)
+      end
+      view.focus.should eq(:detail)
+      view.selected_result.try(&.index).should eq(2)
+    end
+  end
+
   it "hscroll_detail scrolls a long RESULT response line sideways into view (shift+←/→)" do
     view = loaded_fuzzer
     long_line = "HEAD" + ("." * 100) + "TAIL"

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -330,14 +330,32 @@ module Gori::Tui
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
       body = subtab_strip_shown? ? BodyChrome.carve_subtab_row(rect)[1] : rect
       return true unless v = current_view
-      if pane = v.pane_at(body, mx, my)
-        save_current
+      return true unless pane = v.pane_at(body, mx, my)
+      save_current
+      @host.focus_body
+      if pane == :results
+        click_results(v, body, mx, my)
+      else
         v.focus_pane(pane)
-        @host.focus_body
         v.template_click_to_cursor(body, mx, my) if pane == :template
         v.target_click_to_cursor(body, mx, my) if pane == :target
       end
       true
+    end
+
+    # A click in the RESULTS pane: select the row under the cursor (grabbing focus
+    # from another pane on the first click), or — a second click on the already-
+    # selected row while the pane already holds focus — open its detail, so mouse
+    # matches ↵ (mirrors History's select-then-open).
+    private def click_results(v : FuzzerView, body : Rect, mx : Int32, my : Int32) : Nil
+      already = v.focus == :results
+      row = v.results_row_at(body, mx, my)
+      if row && already && row == v.results_selected_index
+        v.open_detail
+      else
+        v.focus_pane(:results)
+        v.select_result_row(row) if row
+      end
     end
 
     def handle_wheel(step : Int32) : Bool

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -674,6 +674,18 @@ module Gori::Tui
       @sel = (@sel + d).clamp(0, view.size - 1)
     end
 
+    # The selected sorted-view row index (mouse dispatch: select-first, then open).
+    def results_selected_index : Int32
+      @sel
+    end
+
+    # Mouse: select a row without opening its detail (clamped to the live view).
+    def select_result_row(idx : Int32) : Nil
+      view = sorted_results
+      return if view.empty?
+      @sel = idx.clamp(0, view.size - 1)
+    end
+
     def cycle_sort : String
       order = [:index, :status, :length, :words, :time]
       i = order.index(@sort) || 0
@@ -1533,6 +1545,36 @@ module Gori::Tui
       half = {(rest.w - 1) // 2, 1}.max
       left = Rect.new(rest.x, rest.y, half, top_h)
       @editor.click_to_cursor(left.inset(1, 1), mx, my)
+    end
+
+    # Mouse: the sorted-view result index under a click in the RESULTS pane, or nil
+    # (outside the pane, on the header row, or past the last populated row). Mirrors
+    # render_results' 1-cell inset → header row → @scroll+i row math.
+    def results_row_at(rect : Rect, mx : Int32, my : Int32) : Int32?
+      results = results_rect(rect)
+      return nil if results.nil? || results.empty? || !results.contains?(mx, my)
+      inner = results.inset(1, 1)
+      i = my - (inner.y + 1) # rows start one line below the header
+      return nil if i < 0 || i >= {inner.h - 1, 0}.max
+      ri = @scroll + i
+      ri < sorted_results.size ? ri : nil
+    end
+
+    # The RESULTS pane rect within body `rect`, re-deriving render → render_bottom →
+    # render_results' split (target band → 45%-tall top row → bottom minus the DIST
+    # sidebar). nil when the layout leaves no room. Backs results_row_at hit-testing.
+    private def results_rect(rect : Rect) : Rect?
+      return nil unless @loaded
+      target_h = {rect.h, 3}.min
+      rest = Rect.new(rect.x, rect.y + target_h, rect.w, {rect.h - target_h, 0}.max)
+      return nil if rest.h <= 0
+      top_h = {rest.h * 45 // 100, 5}.max
+      top_h = rest.h if rest.h < 6
+      bottom = Rect.new(rest.x, rest.y + top_h, rest.w, {rest.h - top_h, 0}.max)
+      return nil if bottom.h <= 0
+      vw = @show_dist ? dist_width(bottom.w) : 0
+      rw = vw > 0 ? bottom.w - vw - 1 : bottom.w
+      Rect.new(bottom.x, bottom.y, rw, bottom.h)
     end
 
     def pane_at(rect : Rect, mx : Int32, my : Int32) : Symbol?


### PR DESCRIPTION
## Summary
Clicking a **Fuzzer → RESULTS** row previously did nothing but shift pane focus — it never selected the row under the cursor, and there was no mouse path into a result's detail.

Now it follows the same **select-first, second-click-opens** pattern the History tab already uses:
- **1st click** on a result row → focus the RESULTS pane and select that exact row.
- **2nd click** on the already-selected row (pane already focused) → open its detail, identical to pressing `↵`.

## Changes
- **`fuzzer_view.cr`**
  - `results_row_at(rect, mx, my)` — maps a click to the sorted-view row index, re-deriving the render geometry (target band → 45% top row → bottom minus the DIST sidebar → 1-cell inset → header row → `@scroll+i`). Returns nil on the header, empty space, past the last row, or over the DIST sidebar.
  - `results_rect` (private geometry helper), `results_selected_index`, `select_result_row(idx)` (clamped, no detail open).
- **`fuzzer_controller.cr`** — `handle_click` routes `:results` clicks to a new `click_results` dispatcher; template/target click-to-cursor is unchanged.
- **`fuzzer_view_spec.cr`** — new "RESULTS click-to-select" block: row hit-testing (header/out-of-range/DIST → nil), `select_result_row` clamping, and a test replaying the controller's exact select-then-open decision.

## Verification
- Build clean, `crystal tool format` clean, ameba adds no new failures.
- Full TUI spec suite: **404 examples, 0 failures**; fuzzer view spec: **28, 0 failures** (3 new).