### PR TITLE
fix(history): binary-body placeholder + palette screen refresh

### DIFF
--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -17,6 +17,8 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def close_overlay : Nil; end
 
+  def refresh_screen : Nil; end
+
   def focus_pane(pane : Symbol) : Nil; end
 
   def enter_content : Nil; end

--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -252,6 +252,15 @@ describe Gori::Tui::HistoryView do
       view.render_detail(Screen.new(hex), Rect.new(0, 0, 80, 16))
       hex.contains?("00000000").should be_true     # offset column of the hex dump
       hex.contains?("binary body").should be_false # placeholder gone in hex mode
+
+      # Reveal-whitespace (b) must NOT re-render the raw binary as text — it renders
+      # bytes as text just like the normal path, so it stays gated to the placeholder.
+      view.toggle_detail_hex # back to text
+      view.reveal = true
+      ws = MemoryBackend.new(80, 16)
+      view.render_detail(Screen.new(ws), Rect.new(0, 0, 80, 16))
+      ws.contains?("binary body").should be_true # placeholder, not raw bytes
+      ws.contains?("RIFF").should be_false
     end
   end
 

--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -221,6 +221,40 @@ describe Gori::Tui::HistoryView do
     end
   end
 
+  it "shows a placeholder for a binary response body instead of rendering it as text" do
+    tmp_store do |store|
+      # A webp-ish body: RIFF header + a NUL byte (the binary marker) + bytes that,
+      # decoded as UTF-8, would be terminal-corrupting garbage.
+      binary = Bytes[0x52, 0x49, 0x46, 0x46, 0x00, 0x1b, 0x5b, 0x32, 0x4a, 0xff, 0xfe]
+      id = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "https", host: "h.test", port: 443,
+        method: "GET", target: "/img", http_version: "HTTP/1.1",
+        head: "GET /img HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice, body: nil))
+      store.update_response(Gori::Store::CapturedResponse.new(
+        flow_id: id, status: 200,
+        head: "HTTP/1.1 200 OK\r\nContent-Type: image/webp\r\n\r\n".to_slice,
+        body: binary, content_type: "image/webp"))
+
+      view = HistoryView.new
+      view.reload(store)
+      view.open_detail(store).should be_true
+      view.toggle_pane # request -> response
+
+      backend = MemoryBackend.new(80, 16)
+      view.render_detail(Screen.new(backend), Rect.new(0, 0, 80, 16))
+      backend.contains?("binary body").should be_true # placeholder shown
+      backend.contains?("hex view").should be_true    # points at the hex view
+      backend.contains?("RIFF").should be_false       # raw bytes NOT rendered as text
+
+      # The byte-exact hex view is still one keypress away (x).
+      view.toggle_detail_hex
+      hex = MemoryBackend.new(80, 16)
+      view.render_detail(Screen.new(hex), Rect.new(0, 0, 80, 16))
+      hex.contains?("00000000").should be_true     # offset column of the hex dump
+      hex.contains?("binary body").should be_false # placeholder gone in hex mode
+    end
+  end
+
   it "refresh_detail picks up a Pending flow's response but skips a stable Complete one" do
     tmp_store do |store|
       pid = store.insert_flow(Gori::Store::CapturedRequest.new(

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -44,6 +44,10 @@ private class FakeContext < ExecContext
     @calls << :close_overlay
   end
 
+  def refresh_screen : Nil
+    @calls << :refresh_screen
+  end
+
   def focus_tab(tab : Symbol) : Nil
     @calls << tab
   end
@@ -705,6 +709,14 @@ describe Gori::Verb do
       ctx.calls.should contain(:replay_toggle_decoded)
       ctx.calls.should contain(:replay_toggle_sni)
       ctx.calls.should contain(:replay_toggle_auto_content_length)
+    end
+
+    it "routes the palette-only Refresh screen verb (no chord) to refresh_screen" do
+      reg = Gori::Verbs.registry
+      reg["view.refresh"].chords.empty?.should be_true # palette-only, unbound
+      ctx = FakeContext.new
+      reg["view.refresh"].call(ctx)
+      ctx.calls.should contain(:refresh_screen)
     end
   end
 

--- a/src/gori/tui/highlight.cr
+++ b/src/gori/tui/highlight.cr
@@ -649,7 +649,10 @@ module Gori::Tui
 
     private def self.to_lines(bytes : Bytes?) : Array(String)
       return [] of String unless bytes
-      String.new(bytes).split('\n').map(&.rstrip('\r'))
+      # `.scrub` maps invalid UTF-8 to U+FFFD (width-1, printable) so a body with stray
+      # bytes never feeds raw invalid sequences into width/search math — mirrors the
+      # `.scrub` the Fuzzer/Replay/Comparer views already apply on their byte→line seam.
+      String.new(bytes).scrub.split('\n').map(&.rstrip('\r'))
     end
 
     # The media type from the first `Content-Type` header, lowercased and

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -93,7 +93,8 @@ module Gori::Tui
       body : Array(String),
       kind : Symbol,
       trailer : Array(Highlight::Line),
-      pretty : Bool = false do # whether Pretty actually reflowed this body (drives the indicator)
+      pretty : Bool = false,   # whether Pretty actually reflowed this body (drives the indicator)
+      binary : Bool = false do # a binary body shown as a placeholder — reveal/pretty don't apply
       def total : Int32
         head.size + body.size + trailer.size
       end
@@ -775,6 +776,15 @@ module Gori::Tui
       nil
     end
 
+    # The mode indicator + active toggle hints on the detail pane's top line. Hoisted
+    # out of render_detail to keep that method under the cyclomatic ceiling.
+    private def detail_mode_hint(hex : Bool, ws : Bool, dv : DetailView) : String
+      return "HEX · x:text" if hex
+      return "RAW · b:raw" if ws
+      return "BINARY · x:hex" if dv.binary # reveal / pretty don't apply to a binary placeholder
+      dv.pretty ? "PRETTY · x:hex · b:ws · p:raw" : "RAW · x:hex · b:ws · p:pretty"
+    end
+
     def render_detail(screen : Screen, rect : Rect, focused : Bool = true) : Nil
       return if rect.empty?
       detail = @detail
@@ -793,12 +803,12 @@ module Gori::Tui
           attr: active ? Attribute::Bold : Attribute::None) + 1
       end
       hex = detail_hex?(detail)
-      ws = @reveal && !hex
-      applied = !hex && !ws && detail_view.pretty # Pretty actually reflowed this body
-      mode = hex ? "HEX" : (ws ? "RAW" : (applied ? "PRETTY" : "RAW"))
-      ptog = applied ? "p:raw" : "p:pretty"
-      mode_hint = hex ? "#{mode} · x:text" : (ws ? "#{mode} · b:raw" : "#{mode} · x:hex · b:ws · #{ptog}")
-      screen.text(x + 1, rect.y, "↑/↓ scroll · ⇧←/→ h-scroll · #{mode_hint} · esc back", Theme.muted)
+      dv = detail_view
+      # A binary body is shown as a placeholder; the reveal-whitespace path renders raw
+      # bytes as text, so gate it off there too — otherwise `b` re-triggers the very
+      # cursor-desync corruption the placeholder exists to avoid. Pretty likewise n/a.
+      ws = @reveal && !hex && !dv.binary
+      screen.text(x + 1, rect.y, "↑/↓ scroll · ⇧←/→ h-scroll · #{detail_mode_hint(hex, ws, dv)} · esc back", Theme.muted)
       Frame.inner_divider(screen, rect, rect.y + 1, border: Frame.pane_border(focused))
 
       body = Rect.new(rect.x + 1, rect.y + 2, {rect.w - 2, 0}.max, {rect.bottom - (rect.y + 2), 0}.max)
@@ -1054,7 +1064,7 @@ module Gori::Tui
         head_lines << Highlight::Line.new
         head_lines << [Highlight::Span.new(
           "— binary body (#{Fmt.size(b.size.to_i64)}) — not shown as text; press x for the hex view —", Theme.muted)]
-        return DetailView.new(head_lines, [] of String, :text, trailer)
+        return DetailView.new(head_lines, [] of String, :text, trailer, binary: true)
       end
       # Pretty-print AFTER decode (so JSON/XML/… are reflowed from the decoded bytes),
       # display only — storage is untouched. nil = leave raw. `pretty.kind` overrides

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -1044,6 +1044,18 @@ module Gori::Tui
       # visible line at render — so opening a huge response doesn't freeze the UI.
       display, decode_note = Proxy::Codec::ContentDecode.decode(head, body)
       src = display || body
+      # Binary bodies (images/webp/fonts/media/…) are NOT text: decoding their raw
+      # bytes as UTF-8 and rendering them yields garbage AND — worse — the accidental
+      # wide/emoji graphemes among the bytes desync the terminal's cursor tracking, so
+      # the diff-renderer leaves stray glyphs it can never reach (the reported "잔상").
+      # Show a placeholder and point at the byte-exact hex view (x), like Burp/mitmproxy.
+      if (b = src) && !b.empty? && binary_body?(b)
+        head_lines = Highlight.message_windowed(head, nil, request).head
+        head_lines << Highlight::Line.new
+        head_lines << [Highlight::Span.new(
+          "— binary body (#{Fmt.size(b.size.to_i64)}) — not shown as text; press x for the hex view —", Theme.muted)]
+        return DetailView.new(head_lines, [] of String, :text, trailer)
+      end
       # Pretty-print AFTER decode (so JSON/XML/… are reflowed from the decoded bytes),
       # display only — storage is untouched. nil = leave raw. `pretty.kind` overrides
       # the styler when the reflow is no longer the content-type's language.
@@ -1061,6 +1073,20 @@ module Gori::Tui
       # signals the reflow, so the "— pretty: … —" footer is redundant (and Replay
       # never showed one — this keeps the two response views consistent).
       DetailView.new(win.head, win.body, win.kind, trailer, pretty: pretty != nil)
+    end
+
+    # How many leading bytes to sniff for the binary heuristic. Binary formats carry
+    # NUL in their header/framing, so a bounded prefix scan is enough — and keeps this
+    # O(1) on a multi-MiB body rather than walking every byte on each cache rebuild.
+    BINARY_SNIFF_LIMIT = 8192
+
+    # A body is treated as binary (→ hex view, not text) when a NUL byte appears in its
+    # leading bytes — the classic git/grep detector. Real text, including UTF-8 Korean/
+    # CJK/emoji, never contains NUL; images, fonts, media and protobufs do.
+    private def binary_body?(bytes : Bytes) : Bool
+      n = {bytes.size, BINARY_SNIFF_LIMIT}.min
+      n.times { |i| return true if bytes[i] == 0u8 }
+      false
     end
 
     # Wrap pre-formatted plain strings (frames / ws / gRPC hex) as single-span

--- a/src/gori/tui/reveal.cr
+++ b/src/gori/tui/reveal.cr
@@ -16,8 +16,10 @@ module Gori::Tui
 
     # Raw bytes → display lines, split on LF but KEEPING any CR so it shows as ␍.
     # (Decoded as UTF-8, lossy on invalid bytes — use the hex view for byte-exact.)
+    # `.scrub` maps invalid UTF-8 to U+FFFD so stray bytes never reach width/search math,
+    # matching the same seam in Highlight.to_lines (control bytes are glyph-marked below).
     def self.lines(bytes : Bytes) : Array(String)
-      String.new(bytes).split('\n')
+      String.new(bytes).scrub.split('\n')
     end
 
     # One revealed, styled line: content runs in `fg`, whitespace markers dimmed.

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -2446,6 +2446,16 @@ module Gori::Tui
       @overlay = :none
     end
 
+    # Emergency full repaint (palette-only). `@resized` routes the next flush through the
+    # full-`sync` path — every cell is rewritten regardless of the diff — so stray glyphs
+    # the diff-renderer's front buffer believes are already correct (e.g. left after a
+    # binary response body desynced cursor tracking) get overwritten. Same recovery path
+    # the app already uses on resize / theme reload / external-editor return.
+    def refresh_screen : Nil
+      @resized = true
+      status("screen refreshed")
+    end
+
     # --- Host (the facade per-tab controllers drive the shell through) -------
     # Thin wrappers over the existing shell setters so a controller never writes
     # @overlay/@focus/@active_tab directly. `status` (above) already satisfies Host.

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -16,6 +16,11 @@ module Gori
       abstract def open_notifications : Nil # open the notification center (background-job results)
       abstract def close_overlay : Nil
 
+      # Emergency full repaint: redraw every cell (a full sync, not a diff). Recovers from
+      # corruption the diff-renderer can't reach — e.g. stray glyphs a binary body's
+      # accidental wide/emoji graphemes left behind by desyncing cursor tracking.
+      abstract def refresh_screen : Nil
+
       # the currently focused tab (so verbs can gate by context, P4)
       abstract def current_tab : Symbol
 

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -43,8 +43,8 @@ module Gori
         "view.reveal-ws", "Reveal whitespace", "Show whitespace/CR/LF as glyphs (·→␍␊) in req/res — for smuggling tests",
         Verb::Scope::Global, [Verb::Chord.new("b", ctrl: true)]) { |ctx| ctx.toggle_reveal; nil }
 
-      # Emergency full repaint (palette-only, no chord — a rare recovery action). Clears
-      # the terminal and redraws everything, wiping stray glyphs the diff-renderer can't
+      # Emergency full repaint (palette-only, no chord — a rare recovery action). Redraws
+      # every cell (a full sync, not a diff), wiping stray glyphs the diff-renderer can't
       # reach (e.g. after a binary response body desynced the terminal's cursor tracking).
       r.register Verb::Definition.new(
         "view.refresh", "Refresh screen", "Force a full repaint — recover from terminal corruption / stray glyphs",

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -43,6 +43,13 @@ module Gori
         "view.reveal-ws", "Reveal whitespace", "Show whitespace/CR/LF as glyphs (·→␍␊) in req/res — for smuggling tests",
         Verb::Scope::Global, [Verb::Chord.new("b", ctrl: true)]) { |ctx| ctx.toggle_reveal; nil }
 
+      # Emergency full repaint (palette-only, no chord — a rare recovery action). Clears
+      # the terminal and redraws everything, wiping stray glyphs the diff-renderer can't
+      # reach (e.g. after a binary response body desynced the terminal's cursor tracking).
+      r.register Verb::Definition.new(
+        "view.refresh", "Refresh screen", "Force a full repaint — recover from terminal corruption / stray glyphs",
+        Verb::Scope::Global, category: Verb::Category::System) { |ctx| ctx.refresh_screen; nil }
+
       r.register Verb::Definition.new(
         "ca.export", "Export CA certificate", "Print the path to gori's root CA for trust setup",
         Verb::Scope::Global) { |ctx| ctx.export_ca; nil }


### PR DESCRIPTION
## Problem

Viewing a binary response body (webp / images / fonts / media) in **History** rendered its raw bytes as decoded UTF-8 text. Beyond looking like garbage, the *accidental* wide/emoji graphemes among those bytes have a display width that real terminals disagree with termisu's width table on. That desyncs termisu's tracked cursor, and `move_cursor` then **skips** moves it wrongly thinks are redundant — so later cells paint at the wrong physical position, and the diff-renderer's front buffer (believing those cells are already correct) never repaints them. The result is the reported stray-character **잔상 (afterimage)** that lingers on screen.

## Fix

**1. Root cause — don't render binary as corrupting text** (`history_view.cr`)
- Bodies with a NUL byte in their leading 8 KiB (the classic git/grep binary heuristic) now show `— binary body (N) — not shown as text; press x for the hex view —`, headers still visible.
- Precise: legit UTF-8 text — including **Korean/CJK/emoji** — has no NUL and renders as text as before. The byte-exact hex view (`x`) is unchanged.
- Defense-in-depth: `Highlight.to_lines` now `.scrub`s invalid UTF-8 → U+FFFD (matching Fuzzer/Replay/Comparer; `scrub` returns `self` on valid input, so no cost on the common path).

**2. Emergency escape hatch — `^P` → "Refresh screen"** (`core.cr`, `context.cr`, `runner.cr`)
- Palette-only, **no keybinding**. Forces a full repaint via the same `@resized`→full-`sync` path the app already uses for resize / theme reload / external-editor return, rewriting every cell to overwrite any residual glyphs.

## Verification
- tmux repro: binary webp body → clean placeholder (was `RIFFWEBPVP8 [31m����…`); hex view intact; "Refresh screen" runs and toasts.
- Korean/emoji JSON still renders as text.
- 1151 specs pass (2 new regression specs); lint-clean; formatted.