### PR TITLE
feat(tui): Project SETTINGS pane + per-project network overrides

### DIFF
--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -1,6 +1,15 @@
 require "./spec_helper"
 require "file_utils"
 
+private def reset_net
+  Gori::Settings.project_bind_host = nil
+  Gori::Settings.project_bind_port = nil
+  Gori::Settings.project_upstream_proxy = nil
+  Gori::Settings.bind_host = "127.0.0.1"
+  Gori::Settings.bind_port = 8070
+  Gori::Settings.upstream_proxy = ""
+end
+
 describe Gori::Settings do
   describe ".upstream_proxy_addr" do
     it "returns nil when unset/blank" do
@@ -386,6 +395,77 @@ describe Gori::Settings do
       FileUtils.rm_rf(dir)
       Gori::Settings.keymap_os = "auto"
       Gori::Settings.keymap_overrides = {} of String => Array(String)
+    end
+  end
+
+  describe "per-project network override layer" do
+    it "effective_* falls back to the global when no override is set" do
+      reset_net
+      Gori::Settings.upstream_proxy = "glob:3128"
+      Gori::Settings.effective_bind_host.should eq("127.0.0.1")
+      Gori::Settings.effective_bind_port.should eq(8070)
+      Gori::Settings.effective_upstream_proxy.should eq("glob:3128")
+    ensure
+      reset_net
+    end
+
+    it "a project override wins over the global (incl. upstream_proxy_addr)" do
+      reset_net
+      Gori::Settings.upstream_proxy = "glob:3128"
+      Gori::Settings.project_bind_host = "0.0.0.0"
+      Gori::Settings.project_bind_port = 9100
+      Gori::Settings.project_upstream_proxy = "corp:8888"
+      Gori::Settings.effective_bind_host.should eq("0.0.0.0")
+      Gori::Settings.effective_bind_port.should eq(9100)
+      Gori::Settings.effective_upstream_proxy.should eq("corp:8888")
+      Gori::Settings.upstream_proxy_addr.should eq({"corp", 8888})
+    ensure
+      reset_net
+    end
+
+    it "an explicit project '' upstream (direct) beats a non-blank global" do
+      reset_net
+      Gori::Settings.upstream_proxy = "glob:3128"
+      Gori::Settings.project_upstream_proxy = ""
+      Gori::Settings.effective_upstream_proxy.should eq("")
+      Gori::Settings.upstream_proxy_addr.should be_nil # "" ⇒ direct
+    ensure
+      reset_net
+    end
+
+    it "never serializes the runtime project layer to settings.json" do
+      dir = File.tempname("gori-settings-projnet")
+      Dir.mkdir_p(dir)
+      prev = ENV["GORI_HOME"]?
+      begin
+        ENV["GORI_HOME"] = dir
+        Gori::Settings.project_bind_host = "10.9.9.9"
+        Gori::Settings.project_bind_port = 9100
+        Gori::Settings.project_upstream_proxy = "corp:8888"
+        Gori::Settings.save.should be_true
+        raw = File.read(Gori::Settings.path)
+        raw.includes?("10.9.9.9").should be_false
+        raw.includes?("9100").should be_false
+        raw.includes?("corp:8888").should be_false
+      ensure
+        prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
+        FileUtils.rm_rf(dir)
+        reset_net
+      end
+    end
+  end
+
+  describe ".upstream_proxy_port_error" do
+    it "accepts blank / no-port / valid ports (incl. bracketed IPv6)" do
+      Gori::Settings.upstream_proxy_port_error("").should be_nil
+      Gori::Settings.upstream_proxy_port_error("proxy.local").should be_nil
+      Gori::Settings.upstream_proxy_port_error("proxy.local:3128").should be_nil
+      Gori::Settings.upstream_proxy_port_error("[::1]:8080").should be_nil
+    end
+
+    it "rejects a non-numeric / out-of-range explicit port" do
+      Gori::Settings.upstream_proxy_port_error("proxy:8O80").should_not be_nil
+      Gori::Settings.upstream_proxy_port_error("proxy:99999").should_not be_nil
     end
   end
 end

--- a/spec/store_extras_spec.cr
+++ b/spec/store_extras_spec.cr
@@ -39,6 +39,17 @@ describe "Gori::Store scope rules + settings (v3)" do
       store.setting("scope_enabled").should eq("0")
     end
   end
+
+  it "deletes a setting so it reads nil again (project network override clear)" do
+    with_store do |store|
+      store.set_setting("net.bind_port", "9100")
+      store.setting("net.bind_port").should eq("9100")
+      store.delete_setting("net.bind_port")
+      store.setting("net.bind_port").should be_nil
+      store.delete_setting("net.bind_port") # deleting an absent key is a no-op
+      store.setting("net.bind_port").should be_nil
+    end
+  end
 end
 
 describe "Gori::Store h2 raw frame log (v5)" do

--- a/spec/tui/project_view_spec.cr
+++ b/spec/tui/project_view_spec.cr
@@ -21,6 +21,16 @@ private def tmp_store(&)
   end
 end
 
+# Reset the global + per-project network layer to a known baseline (specs share Gori::Settings).
+private def reset_projnet
+  Gori::Settings.project_bind_host = nil
+  Gori::Settings.project_bind_port = nil
+  Gori::Settings.project_upstream_proxy = nil
+  Gori::Settings.bind_host = "127.0.0.1"
+  Gori::Settings.bind_port = 8070
+  Gori::Settings.upstream_proxy = ""
+end
+
 private def render_ta(ta : TextArea, h : Int32) : MemoryBackend
   b = MemoryBackend.new(40, h)
   ta.render(Screen.new(b), Rect.new(0, 0, 40, h), cursor: false)
@@ -168,18 +178,83 @@ describe "ProjectView AT A GLANCE Technologies" do
 end
 
 describe "ProjectView#pane_at" do
-  it "splits the body into the overview band + SCOPE/HOST-OVERRIDES (left) / DESCRIPTION (right) cards" do
+  it "splits the body into the overview band + SCOPE/HOST-OVERRIDES (left) / DESCRIPTION over PROJECT SETTINGS (right)" do
     tmp_store do |store|
       view = ProjectView.new(Gori::Scope.load(store), Gori::HostOverrides.load(store))
       rect = Rect.new(0, 0, 120, 30)
       view.render(Screen.new(MemoryBackend.new(120, 30)), rect, focused: false)
 
-      view.pane_at(rect, rect.x + 1, rect.y).should eq(:overview)       # top band
-      content_y = rect.y + 12                                           # below the capped overview (meta_h == 11)
-      view.pane_at(rect, rect.x + 1, content_y).should eq(:scope)       # top-left card
-      view.pane_at(rect, rect.x + 1, rect.y + 24).should eq(:overrides) # bottom-left card
-      view.pane_at(rect, rect.right - 2, content_y).should eq(:desc)    # right card
-      view.pane_at(Rect.new(0, 0, 0, 0), 0, 0).should be_nil            # empty rect → nothing
+      view.pane_at(rect, rect.x + 1, rect.y).should eq(:overview)          # top band
+      content_y = rect.y + 12                                              # below the capped overview (meta_h == 11)
+      view.pane_at(rect, rect.x + 1, content_y).should eq(:scope)          # top-left card
+      view.pane_at(rect, rect.x + 1, rect.y + 24).should eq(:overrides)    # bottom-left card
+      view.pane_at(rect, rect.right - 2, content_y).should eq(:desc)       # right-top card
+      view.pane_at(rect, rect.right - 2, rect.y + 26).should eq(:settings) # right-bottom card
+      view.pane_at(Rect.new(0, 0, 0, 0), 0, 0).should be_nil               # empty rect → nothing
+    end
+  end
+end
+
+describe "ProjectView PROJECT SETTINGS pane" do
+  it "renders the scope-lens toggle + the three network fields with an inherit marker" do
+    tmp_store do |store|
+      reset_projnet
+      view = ProjectView.new(Gori::Scope.load(store), Gori::HostOverrides.load(store))
+      view.refresh_settings
+      b = MemoryBackend.new(120, 30)
+      view.render(Screen.new(b), Rect.new(0, 0, 120, 30), focused: true)
+      b.contains?("PROJECT SETTINGS").should be_true
+      b.contains?("Scope lens").should be_true
+      b.contains?("Bind IP").should be_true
+      b.contains?("Bind Port").should be_true
+      b.contains?("Upstream proxy").should be_true
+      b.contains?("127.0.0.1").should be_true # inherited global bind host
+      b.contains?("· global").should be_true  # no override yet → inheriting
+    ensure
+      reset_projnet
+    end
+  end
+
+  it "marks a field · project when a per-project override is active" do
+    tmp_store do |store|
+      reset_projnet
+      Gori::Settings.project_bind_port = 9100
+      view = ProjectView.new(Gori::Scope.load(store), Gori::HostOverrides.load(store))
+      view.refresh_settings
+      b = MemoryBackend.new(120, 30)
+      view.render(Screen.new(b), Rect.new(0, 0, 120, 30), focused: true)
+      b.contains?("9100").should be_true
+      b.contains?("· project").should be_true
+    ensure
+      reset_projnet
+    end
+  end
+
+  it "hit-tests a settings row and edits a text field (dirty-tracked)" do
+    tmp_store do |store|
+      reset_projnet
+      view = ProjectView.new(Gori::Scope.load(store), Gori::HostOverrides.load(store))
+      view.refresh_settings
+      view.focus_pane(:settings)
+      rect = Rect.new(0, 0, 120, 30)
+      view.render(Screen.new(MemoryBackend.new(120, 30)), rect, focused: true) # establish geometry
+
+      view.set_row_at(rect, rect.right - 4, rect.y + 26).should_not be_nil # a row in the settings band
+      view.settings_dirty?.should be_false                                 # fresh, inherited pane
+
+      view.select_setting(2) # Bind Port
+      view.settings_scope_row?.should be_false
+      view.settings_text_row?.should be_true
+      view.set_input('9')
+      view.set_input('9')
+      _, port, _ = view.settings_values
+      port.should eq("807099") # inserted at the caret (field end)
+      view.settings_dirty?.should be_true
+
+      view.set_backspace
+      view.settings_values[1].should eq("80709")
+    ensure
+      reset_projnet
     end
   end
 end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -643,6 +643,21 @@ describe Gori::Verb do
       keymap.lookup(Chord.new("down"), Scope::Body).should eq("body.down")
     end
 
+    it "binds bare 's' to the scope-lens toggle from any scope (was jump-to-editor)" do
+      reg = Gori::Verbs.registry
+      keymap = Keymap.build(reg)
+      keymap.lookup(Chord.new("s"), Scope::Body).should eq("scope.toggle-lens")
+      keymap.lookup(Chord.new("s"), Scope::Sitemap).should eq("scope.toggle-lens")
+
+      ctx = FakeContext.new
+      reg["scope.toggle-lens"].call(ctx)
+      ctx.calls.should contain(:scope_toggle_lens)
+
+      # jumping to the scope rule editor is still reachable, now palette-only (no chord)
+      reg["scope.edit"].call(ctx)
+      ctx.calls.should contain(:scope_open)
+    end
+
     it "binds ctrl-n to a new blank replay in the Replay scope" do
       reg = Gori::Verbs.registry
       keymap = Keymap.build(reg)

--- a/src/gori/session.cr
+++ b/src/gori/session.cr
@@ -44,6 +44,16 @@ module Gori
       events = Channel(Store::FlowEvent).new(1024)
       prism_events = Channel(Store::FlowEvent).new(256)
       store = Store.open(project.db_path, events, prism_events)
+      # Per-project network overrides: pull this project's pinned bind/upstream (if any) into
+      # the Settings runtime layer BEFORE binding, so the proxy listens on the project's address
+      # and Upstream.dial (reads Settings.effective_upstream_proxy) tunnels through its upstream.
+      # Always assign all three (nil when unset) so switching projects resets cleanly. Mutating
+      # `config` is safe — App re-seeds it from the global Settings on every project open.
+      Settings.project_bind_host = store.setting(Settings::PROJECT_BIND_HOST_KEY)
+      Settings.project_bind_port = store.setting(Settings::PROJECT_BIND_PORT_KEY).try(&.to_i?)
+      Settings.project_upstream_proxy = store.setting(Settings::PROJECT_UPSTREAM_KEY)
+      config.listen = Settings.effective_bind_host
+      config.port = Settings.effective_bind_port
       prism = nil.as(Prism::Analyzer?)
       begin
         lock = nil.as(CaptureLock?)

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -29,6 +29,35 @@ module Gori
     class_property bind_host : String = DEFAULT_BIND_HOST
     class_property bind_port : Int32 = DEFAULT_BIND_PORT
     class_property upstream_proxy : String = DEFAULT_UPSTREAM_PROXY # "host:port" HTTP proxy; "" = connect directly
+
+    # Per-project network overrides — a RUNTIME layer set by Session.open from the OPEN
+    # project's DB and NEVER persisted to settings.json (the project's own DB is the source
+    # of truth). nil = inherit the matching global value above. The proxy bind + Upstream.dial
+    # read the effective_* helpers, so a project can pin its own bind/upstream while the global
+    # settings:network editor keeps writing the shared defaults. Stored in the project's generic
+    # KV `settings` table under these keys (Store#setting/#set_setting/#delete_setting).
+    PROJECT_BIND_HOST_KEY = "net.bind_host"
+    PROJECT_BIND_PORT_KEY = "net.bind_port"
+    PROJECT_UPSTREAM_KEY  = "net.upstream_proxy"
+    class_property project_bind_host : String? = nil
+    class_property project_bind_port : Int32? = nil
+    class_property project_upstream_proxy : String? = nil
+
+    def self.effective_bind_host : String
+      project_bind_host || bind_host
+    end
+
+    def self.effective_bind_port : Int32
+      project_bind_port || bind_port
+    end
+
+    # The upstream proxy the proxy actually dials through: a project override wins, else the
+    # global. NOTE an explicit project "" (direct) is truthy in Crystal, so it correctly beats
+    # a non-blank global — only an ABSENT override (nil) falls through to the global value.
+    def self.effective_upstream_proxy : String
+      project_upstream_proxy || upstream_proxy
+    end
+
     # Global hostname overrides (a process-wide /etc/hosts): ordered {host (lowercased),
     # ip} pairs. Read LIVE by Upstream.dial (edits apply on the next flow); layered
     # UNDER each project's own HostOverrides, which wins on a host collision. Edited via
@@ -394,7 +423,7 @@ module Gori
     # "host:port" with an optional "http://" scheme prefix; defaults the port to
     # 8080 when omitted.
     def self.upstream_proxy_addr : {String, Int32}?
-      value = upstream_proxy.strip
+      value = effective_upstream_proxy.strip
       return nil if value.empty?
       value = value.sub(/\Ahttps?:\/\//, "").rstrip('/')
       # Bracketed IPv6 ("[::1]" / "[::1]:8080"): host is inside the brackets, the
@@ -414,6 +443,28 @@ module Gori
       return nil if host.empty?
       return {value, 8080} if host.includes?(':') # unbracketed IPv6 literal → no port
       {host, value[(idx + 1)..].to_i? || 8080}
+    end
+
+    # nil if `value` is an acceptable upstream-proxy string; an error message if its explicit
+    # port segment isn't a valid 0-65535 int — so a typo ("proxy:8O80") is caught at save time
+    # instead of silently resolving to 8080 (upstream_proxy_addr) and failing every captured
+    # flow later, far from the mistake. Shared by settings:network AND the Project settings pane.
+    def self.upstream_proxy_port_error(value : String) : String?
+      return nil if value.empty?
+      bare = value.sub(/\Ahttps?:\/\//, "").rstrip('/')
+      if bare.starts_with?('[') # bracketed IPv6 literal: [::1] or [::1]:port — the port is after ']'
+        return nil unless close = bare.index(']')
+        rest = bare[(close + 1)..]
+        return nil unless rest.starts_with?(':') && rest.size > 1 # no explicit port → defaults fine
+        seg = rest[1..]
+      else
+        i = bare.rindex(':')
+        return nil unless i && i < bare.size - 1 # no explicit port → defaults fine
+        return nil if bare[0...i].includes?(':') # pre-colon host has a ':' → unbracketed IPv6 literal, no port
+        seg = bare[(i + 1)..]
+      end
+      p = seg.to_i?
+      (p && 0 <= p <= 65535) ? nil : "settings: invalid upstream proxy port #{seg.inspect}"
     end
   end
 end

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -293,6 +293,15 @@ module Gori
       }
     end
 
+    # Drop a per-project setting so `setting(key)` reads nil again (the Project settings pane
+    # clears a network override this way — reverting the field to inherit the global value).
+    def delete_setting(key : String) : Nil
+      exec_task ->(c : DB::Connection) {
+        c.exec("DELETE FROM settings WHERE key = ?", key)
+        nil
+      }
+    end
+
     # --- findings ------------------------------------------------------------
 
     def insert_finding(title : String, severity : Severity, host : String?, flow_id : Int64?) : Int64

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -33,8 +33,10 @@ module Gori::Tui
       end
     end
 
-    def body_badge : Symbol # the description editor + either add-row capture text; the rule/override lists are nav
-      (@project_view.pane == :desc || @project_view.adding? || @project_view.ov_adding?) ? :editor : :body
+    def body_badge : Symbol # the description editor, add-row capture text, and settings text fields capture keys; the lists/toggle are nav
+      editing = @project_view.pane == :desc || @project_view.adding? || @project_view.ov_adding? ||
+                (@project_view.pane == :settings && @project_view.settings_text_row?)
+      editing ? :editor : :body
     end
 
     # Hints depend on the focused pane (SCOPE rule list / HOST OVERRIDES list / their
@@ -49,8 +51,12 @@ module Gori::Tui
         @project_view.ov_adding? \
           ? "type \"IP host\" · ↵ save · esc cancel" \
           : "↑/↓ move · ↑ scope · → desc · a add · ↵/e edit · d del · space cmds · esc"
+      when :settings
+        @project_view.settings_text_row? \
+          ? "type to edit · ↵ apply · ←/→ cursor · ↑/↓ move · esc" \
+          : "space/↵ toggle lens · ↑/↓ move · ← overrides · ↑ desc · esc"
       else
-        "type to edit · ↑/↓/↔ move · ← scope · ^G goto · ^F find · esc tabs"
+        "type to edit · ↑/↓/↔ move · ← scope · ↓ settings · ^G goto · ^F find · esc tabs"
       end
     end
 
@@ -70,6 +76,9 @@ module Gori::Tui
       case @project_view.pane
       when :scope     then handle_project_scope_key(ev)
       when :overrides then handle_project_overrides_key(ev)
+      when :settings
+        handle_project_settings_key(ev)
+        true
       else
         handle_project_desc_key(ev)
         true
@@ -79,6 +88,9 @@ module Gori::Tui
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
       return true unless pane = @project_view.pane_at(rect, mx, my)
       @host.focus_body
+      # Clicking OUT of the settings pane applies any pending network edit (mirrors the
+      # keyboard leave paths); idempotent + dirty-guarded, so a same-pane click is a no-op.
+      commit_project_network(on_leave: true) if @project_view.pane == :settings && pane != :settings
       case pane
       when :scope
         @project_view.focus_pane(:scope)
@@ -93,6 +105,12 @@ module Gori::Tui
       when :desc
         @project_view.focus_pane(:desc)
         @project_view.desc_click_to_cursor(rect, mx, my)
+      when :settings
+        @project_view.focus_pane(:settings)
+        if idx = @project_view.set_row_at(rect, mx, my)
+          @project_view.select_setting(idx)
+          idx == 0 ? @host.toggle_scope_lens : @project_view.setting_click_to_cursor(rect, mx, my)
+        end
       end # :overview band → just take body focus
       true
     end
@@ -106,6 +124,7 @@ module Gori::Tui
       when :desc      then @project_view.desc_scroll(step)
       when :scope     then @project_view.scope_select(step)
       when :overrides then @project_view.ov_select(step)
+      when :settings  then @project_view.set_select(step)
       end # :overview band / outside → nothing to scroll
       true
     end
@@ -115,8 +134,10 @@ module Gori::Tui
       true
     end
 
-    # --- focus ring (SCOPE ◂▸ DESCRIPTION) ---
+    # --- focus ring (SCOPE ◂▸ HOST OVERRIDES ◂▸ DESCRIPTION ◂▸ PROJECT SETTINGS) ---
     def pane_advance(dir : Int32) : Bool
+      # Tab-ing off the settings pane applies its pending network edit before the pane changes.
+      commit_project_network(on_leave: true) if @project_view.pane == :settings
       @project_view.pane_advance(dir)
     end
 
@@ -134,6 +155,7 @@ module Gori::Tui
 
     def commit : Nil
       save
+      commit_project_network(on_leave: true) # apply a pending network edit before the tab leaves/quits
     end
 
     # True while EITHER inline add/edit row (SCOPE or HOST OVERRIDES) is composing — the
@@ -178,6 +200,9 @@ module Gori::Tui
         end
       elsif key.left? && @project_view.desc_at_start?
         @project_view.focus_pane(:scope) # ← at the very start of the description crosses back to SCOPE (left)
+      elsif key.down? && @project_view.desc_at_bottom?
+        save
+        @project_view.focus_pane(:settings) # ↓ on the last line drops into PROJECT SETTINGS (the card below)
       elsif key.down?
         @project_view.move(1, 0)
       elsif key.left?
@@ -253,9 +278,9 @@ module Gori::Tui
           "scope lens OFF — showing all flows"
         elsif n == 0
           # Signpost the add path for where the toggle fired: 'a' on the Project scope
-          # pane itself, else 's' (scope.edit) to jump here from History/Sitemap.
+          # pane itself, else point at the Project tab from History/Sitemap.
           @host.active_tab == :project ? "scope lens ON, but no rules yet — add one here (a)" \
-                                       : "scope lens ON, but no rules yet — add some in Project (s)"
+                                       : "scope lens ON, but no rules yet — add some in the Project tab"
         else
           "scope lens ON — showing in-scope only (#{n} rule#{n == 1 ? "" : "s"})"
         end
@@ -377,6 +402,103 @@ module Gori::Tui
       when :dup     then @host.status("host override: host already mapped — edit it (e)")
       when :ok      then @host.status("host override added — #{@host.session.host_overrides.size} total")
       end
+    end
+
+    # --- PROJECT SETTINGS pane: scope-lens toggle (row 0) + inline network fields (rows 1-3).
+    # handle_body_key returns true for it, so the pane OWNS every key — space toggles the lens
+    # on its row, and the text fields accept letters, so nothing falls through to the keymap.
+    private def handle_project_settings_key(ev : Termisu::Event::Key) : Nil
+      key = ev.key
+      if ev.ctrl? && key.lower_p?
+        commit_project_network(on_leave: true)
+        save
+        @host.open_palette
+      elsif key.escape?
+        commit_project_network(on_leave: true)
+        save
+        @host.request_focus(:menu)
+      elsif key.up?
+        settings_move(-1)
+      elsif key.down?
+        settings_move(1)
+      else
+        handle_project_settings_action(ev)
+      end
+    end
+
+    # ↑/↓ move between rows, crossing out at the boundaries (↑ off row 0 → DESCRIPTION above;
+    # ↓ off the last row → the tab bar). ONLY ↑/↓ move rows — the text fields need j/k as input.
+    private def settings_move(dir : Int32) : Nil
+      if dir < 0 && @project_view.set_at_top?
+        @project_view.focus_pane(:desc)
+      elsif dir > 0 && @project_view.set_at_bottom?
+        commit_project_network(on_leave: true)
+        @host.request_focus(:menu)
+      else
+        @project_view.set_select(dir)
+      end
+    end
+
+    private def handle_project_settings_action(ev : Termisu::Event::Key) : Nil
+      @project_view.settings_scope_row? ? handle_project_settings_scope_key(ev) : handle_project_settings_field_key(ev)
+    end
+
+    # Row 0 (scope lens): space/↵ toggles it; ← crosses to the left column.
+    private def handle_project_settings_scope_key(ev : Termisu::Event::Key) : Nil
+      key = ev.key
+      if key.enter? || key.space?
+        @host.toggle_scope_lens
+      elsif key.left?
+        @project_view.focus_pane(:overrides)
+      end # → is the rightmost column — nothing to cross to
+    end
+
+    # Rows 1-3 (bind IP / port / upstream): type to edit, ↵ applies, ← at the field start
+    # crosses to the left column (else moves the caret).
+    private def handle_project_settings_field_key(ev : Termisu::Event::Key) : Nil
+      key = ev.key
+      c = ev.char || key.to_char
+      if key.enter?
+        commit_project_network(on_leave: false)
+      elsif key.left?
+        if @project_view.set_at_cursor_start?
+          commit_project_network(on_leave: true)
+          @project_view.focus_pane(:overrides)
+        else
+          @project_view.set_move_cursor(-1)
+        end
+      elsif key.right?
+        @project_view.set_move_cursor(1)
+      elsif key.backspace?
+        @project_view.set_backspace
+      elsif c && !ev.ctrl? && !ev.alt?
+        @project_view.set_input(c)
+        @project_view.set_preedit("") # commit any preedit
+      end
+    end
+
+    # Validate + apply the pane's network fields to THIS project (persist to its DB + live
+    # rebind). `on_leave` = the commit fired because the pane is being left (esc/Tab/arrow/
+    # click) rather than an explicit ↵: a leave with an invalid field drops the bad edit, while
+    # ↵ keeps it so the user can fix it. Dirty-guarded so an unchanged pane never re-applies.
+    private def commit_project_network(on_leave : Bool = false) : Nil
+      return unless @project_view.settings_dirty?
+      host, port_s, upstream = @project_view.settings_values
+      return settings_invalid("bind IP is required", on_leave) if host.empty?
+      port = port_s.to_i?
+      unless port && 0 <= port <= 65535
+        return settings_invalid("invalid bind port #{port_s.inspect}", on_leave)
+      end
+      if err = Settings.upstream_proxy_port_error(upstream)
+        return settings_invalid(err, on_leave)
+      end
+      @host.status(@host.apply_project_network(host, port, upstream))
+      @project_view.refresh_settings
+    end
+
+    private def settings_invalid(msg : String, on_leave : Bool) : Nil
+      @host.status(msg.starts_with?("settings:") ? msg : "project network: #{msg}")
+      @project_view.refresh_settings if on_leave # leaving the pane drops the half-typed value
     end
   end
 end

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -17,7 +17,7 @@ module Gori::Tui
         {"^P", "command palette"},
         {"space", "focus-area action menu"},
         {"c", "toggle capture"},
-        {"s · m", "scope lens · Match & Replace rules"},
+        {"s · m", "toggle scope lens · Match & Replace rules"},
         {"n", "notification center (or click the notify:N badge)"},
         {"^B", "reveal whitespace (·→␍␊)"},
         {"^D / ^C ×2", "quit gori"},

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -69,6 +69,16 @@ module Gori::Tui
       @ov_input = ""               # add-row text ("IP host")
       @ov_icx = 0                  # add-row cursor index
       @ov_preedit = ""             # IME preedit for the add-row
+
+      # PROJECT SETTINGS pane: scope-lens toggle (row 0) + inline-editable network fields
+      # (rows 1-3: bind IP / bind port / upstream proxy). @set_values holds the three text
+      # fields; @set_overridden tracks whether each is a project override (vs inheriting global).
+      @set_sel = 0
+      @set_values = ["", "", ""]
+      @set_overridden = [false, false, false]
+      @set_cursor = 0
+      @set_preedit = ""
+      load_settings_values
     end
 
     # Snapshot stats from the live session (called on tab enter and initial run).
@@ -94,6 +104,20 @@ module Gori::Tui
 
       @desc_area.set_text(store.setting(DESC_KEY) || "")
       @desc_dirty = false
+      load_settings_values # refresh the network fields (Session.open loaded any project overrides)
+    end
+
+    # (Re)load the PROJECT SETTINGS network fields from the effective config — the project
+    # override when pinned, else the global default (Session.open populated Settings.project_*
+    # from this project's DB on open). @set_overridden drives the "· project/global" marker.
+    private def load_settings_values : Nil
+      @set_values = [Settings.effective_bind_host, Settings.effective_bind_port.to_s, Settings.effective_upstream_proxy]
+      @set_overridden = [!Settings.project_bind_host.nil?, !Settings.project_bind_port.nil?, !Settings.project_upstream_proxy.nil?]
+      @set_cursor = current_set_value.size
+    end
+
+    private def current_set_value : String
+      @set_sel >= 1 ? @set_values[@set_sel - 1] : ""
     end
 
     # Drop tech fingerprints seen only on out-of-scope hosts before summarizing — with
@@ -111,6 +135,8 @@ module Gori::Tui
         @add_preedit = text
       elsif @pane == :overrides && @ov_adding
         @ov_preedit = text
+      elsif @pane == :settings && settings_text_row?
+        @set_preedit = text
       else
         @desc_area.set_preedit(text)
       end
@@ -120,8 +146,13 @@ module Gori::Tui
       @desc_area.text
     end
 
-    # --- focus ring (three panes: :scope → :overrides → :desc, cycled by the Tab ring) ---
-    PANES = [:scope, :overrides, :desc]
+    # --- focus ring (four panes: :scope → :overrides → :desc → :settings, cycled by the Tab
+    # ring). :settings is the PROJECT SETTINGS pane below DESCRIPTION (scope lens + network). ---
+    PANES = [:scope, :overrides, :desc, :settings]
+
+    # PROJECT SETTINGS pane rows: row 0 is the scope-lens toggle, rows 1-3 the network fields.
+    SETTINGS_LABELS  = ["Scope lens", "Bind IP", "Bind Port", "Upstream proxy"]
+    SETTINGS_LABEL_W = 14 # value column starts past the widest label ("Upstream proxy")
 
     def focus_first : Nil
       @pane = :scope
@@ -174,11 +205,15 @@ module Gori::Tui
       vw < VIZ_MIN_W ? 0 : vw
     end
 
-    # The three body-pane rects below the OVERVIEW band: {SCOPE (top-left), HOST
-    # OVERRIDES (bottom-left), DESCRIPTION (full-height right)}, or nil when the body is
-    # too small to split. The left column is halved vertically; DESCRIPTION fills the
-    # right past a 1-col divider.
-    private def body_panes(rect : Rect) : {Rect, Rect, Rect}?
+    # The four body-pane rects below the OVERVIEW band: {SCOPE (top-left), HOST OVERRIDES
+    # (bottom-left), DESCRIPTION (right-top), PROJECT SETTINGS (right-bottom)}, or nil when the
+    # body is too small to split. The left column is halved vertically; the right column stacks
+    # DESCRIPTION over a PROJECT SETTINGS band pinned to the bottom (its card border + the scope
+    # row + 3 network rows ≈ SETTINGS_H), with DESCRIPTION keeping the remainder (≥ MIN_DESC_H).
+    SETTINGS_H = 6 # 2 border rows + scope-lens row + 3 network rows
+    MIN_DESC_H = 3 # never squeeze DESCRIPTION below this when the settings band can shrink
+
+    private def body_panes(rect : Rect) : {Rect, Rect, Rect, Rect}?
       oh = overview_h(rect)
       content = Rect.new(rect.x, rect.y + oh, rect.w, {rect.h - oh, 0}.max)
       return nil if content.h < 2 || content.w < 4
@@ -186,20 +221,26 @@ module Gori::Tui
       scope_h = {content.h // 2, 1}.max
       scope_rect = Rect.new(content.x, content.y, left_w, scope_h)
       ov_rect = Rect.new(content.x, content.y + scope_h, left_w, {content.h - scope_h, 0}.max)
-      right = Rect.new(content.x + left_w + 1, content.y, {content.w - left_w - 1, 0}.max, content.h)
-      {scope_rect, ov_rect, right}
+      right_x = content.x + left_w + 1
+      right_w = {content.w - left_w - 1, 0}.max
+      set_h = {SETTINGS_H, {content.h - MIN_DESC_H, 1}.max}.min # settings ≤ its full height, desc keeps its min
+      desc_h = {content.h - set_h, 0}.max
+      desc_rect = Rect.new(right_x, content.y, right_w, desc_h)
+      set_rect = Rect.new(right_x, content.y + desc_h, right_w, set_h)
+      {scope_rect, ov_rect, desc_rect, set_rect}
     end
 
     # --- mouse hit-testing (inverts render's offset math; coords are 0-based) ---
 
-    # The pane symbol under (mx,my): :scope, :overrides, :desc, or :overview (top band).
+    # The pane symbol under (mx,my): :scope, :overrides, :desc, :settings, or :overview (band).
     def pane_at(rect : Rect, mx : Int32, my : Int32) : Symbol?
       return nil if rect.empty? || !rect.contains?(mx, my)
       return :overview if my < rect.y + overview_h(rect)
       return nil unless panes = body_panes(rect)
       return :scope if panes[0].contains?(mx, my)
       return :overrides if panes[1].contains?(mx, my)
-      panes[2].contains?(mx, my) ? :desc : nil
+      return :desc if panes[2].contains?(mx, my)
+      panes[3].contains?(mx, my) ? :settings : nil
     end
 
     # Index of the scope-rule row clicked, or nil outside the populated list.
@@ -249,6 +290,105 @@ module Gori::Tui
     def desc_click_to_cursor(rect : Rect, mx : Int32, my : Int32) : Nil
       return unless panes = body_panes(rect)
       @desc_area.click_to_cursor(panes[2].inset(1, 1), mx, my)
+    end
+
+    # --- PROJECT SETTINGS pane (delegated from ProjectController#handle_project_settings_key) ---
+    def set_sel : Int32
+      @set_sel
+    end
+
+    def settings_scope_row? : Bool
+      @set_sel == 0
+    end
+
+    def settings_text_row? : Bool
+      @set_sel >= 1
+    end
+
+    def set_at_top? : Bool
+      @set_sel <= 0
+    end
+
+    def set_at_bottom? : Bool
+      @set_sel >= SETTINGS_LABELS.size - 1
+    end
+
+    def set_at_cursor_start? : Bool
+      @set_cursor <= 0
+    end
+
+    # The three network fields, trimmed, for commit: {bind IP, bind port, upstream proxy}.
+    def settings_values : {String, String, String}
+      {@set_values[0].strip, @set_values[1].strip, @set_values[2].strip}
+    end
+
+    # True when any network field differs from the currently-applied effective config — the
+    # commit path skips a no-op apply (and its toast) when nothing was actually edited.
+    def settings_dirty? : Bool
+      h, p, u = settings_values
+      h != Settings.effective_bind_host || p != Settings.effective_bind_port.to_s || u != Settings.effective_upstream_proxy
+    end
+
+    # Move between the pane's rows (keyboard ↑/↓ + wheel); clamps to the row range.
+    def set_select(delta : Int32) : Nil
+      @set_sel = (@set_sel + delta).clamp(0, SETTINGS_LABELS.size - 1)
+      @set_cursor = current_set_value.size
+      @set_preedit = ""
+    end
+
+    # Mouse: focus a specific settings row (clamped).
+    def select_setting(idx : Int32) : Nil
+      @set_sel = idx.clamp(0, SETTINGS_LABELS.size - 1)
+      @set_cursor = current_set_value.size
+      @set_preedit = ""
+    end
+
+    def set_input(ch : Char) : Nil
+      return unless settings_text_row?
+      v = @set_values[@set_sel - 1]
+      c = @set_cursor.clamp(0, v.size)
+      @set_values[@set_sel - 1] = "#{v[0, c]}#{ch}#{v[c..]}"
+      @set_cursor = c + 1
+      @set_preedit = ""
+    end
+
+    # ⌫: delete the char before the caret. Returns false on an at-start caret so the caller can
+    # treat ⌫ as a no-op there (the text rows never auto-leave the pane, unlike the add-rows).
+    def set_backspace : Bool
+      return false unless settings_text_row? && @set_cursor > 0
+      v = @set_values[@set_sel - 1]
+      @set_values[@set_sel - 1] = "#{v[0, @set_cursor - 1]}#{v[@set_cursor..]}"
+      @set_cursor -= 1
+      true
+    end
+
+    def set_move_cursor(delta : Int32) : Nil
+      return unless settings_text_row?
+      @set_cursor = (@set_cursor + delta).clamp(0, @set_values[@set_sel - 1].size)
+    end
+
+    # Re-read the network fields after an apply (Settings.project_* / effective values changed).
+    def refresh_settings : Nil
+      load_settings_values
+    end
+
+    # Mouse hit-test: the settings row index under (mx,my), or nil outside the pane's rows.
+    def set_row_at(rect : Rect, mx : Int32, my : Int32) : Int32?
+      return nil unless pane_at(rect, mx, my) == :settings
+      return nil unless panes = body_panes(rect)
+      inner = panes[3].inset(1, 1)
+      return nil if inner.h <= 0 || !inner.contains?(mx, my)
+      row = my - inner.y
+      (0 <= row < SETTINGS_LABELS.size) ? row : nil
+    end
+
+    # Mouse: place the caret in the focused network field at a click (no-op on the toggle row).
+    def setting_click_to_cursor(rect : Rect, mx : Int32, my : Int32) : Nil
+      return unless settings_text_row?
+      return unless panes = body_panes(rect)
+      inner = panes[3].inset(1, 1)
+      vx = inner.x + 1 + SETTINGS_LABEL_W + 1
+      @set_cursor = (mx - vx).clamp(0, @set_values[@set_sel - 1].size)
     end
 
     # --- SCOPE pane editing (delegated from Runner#handle_project_scope_key) ---
@@ -526,6 +666,11 @@ module Gori::Tui
       @desc_area.at_start?
     end
 
+    # Cursor on the last line of the description → ↓ crosses down to the PROJECT SETTINGS pane.
+    def desc_at_bottom? : Bool
+      @desc_area.at_bottom?
+    end
+
     # Self-framed (like Replay/Intercept): an OVERVIEW card on top (read-only stats),
     # then SCOPE (top-left) over HOST OVERRIDES (bottom-left) and DESCRIPTION (right) —
     # three focusable panes. The focused pane's card lights gold.
@@ -534,6 +679,7 @@ module Gori::Tui
       scope_focused = focused && @pane == :scope
       ov_focused = focused && @pane == :overrides
       desc_focused = focused && @pane == :desc
+      settings_focused = focused && @pane == :settings
 
       # OVERVIEW band on top; below it SCOPE (top-left) over HOST OVERRIDES (bottom-left),
       # with DESCRIPTION filling the right column. The band splits into OVERVIEW (left) and
@@ -548,6 +694,7 @@ module Gori::Tui
       render_scope_card(screen, panes[0], scope_focused)
       render_overrides_card(screen, panes[1], ov_focused)
       render_desc_card(screen, panes[2], desc_focused)
+      render_settings_card(screen, panes[3], settings_focused)
     end
 
     private def render_overview(screen : Screen, rect : Rect) : Nil
@@ -855,6 +1002,56 @@ module Gori::Tui
       Frame.card(screen, rect, "DESCRIPTION", bg: Theme.bg, border: Frame.pane_border(focused))
       @desc_area.render(screen, rect.inset(1, 1), cursor: focused,
         highlight: Settings.editor_markdown ? :markdown : nil)
+    end
+
+    # PROJECT SETTINGS card: the scope-lens toggle (row 0) over the three inline-editable network
+    # fields (bind IP / bind port / upstream proxy). Each network row carries a "· project" /
+    # "· global" marker so a pinned override reads distinct from an inherited global value.
+    private def render_settings_card(screen : Screen, rect : Rect, focused : Bool) : Nil
+      return if rect.w < 2 || rect.h < 2
+      Frame.card(screen, rect, "PROJECT SETTINGS", bg: Theme.bg, border: Frame.pane_border(focused))
+      inner = rect.inset(1, 1)
+      return if inner.h <= 0 || inner.w <= 0
+      SETTINGS_LABELS.each_with_index do |label, i|
+        break if i >= inner.h
+        render_settings_row(screen, inner, inner.y + i, i, label, focused && @set_sel == i)
+      end
+    end
+
+    private def render_settings_row(screen : Screen, inner : Rect, y : Int32, i : Int32,
+                                    label : String, selected : Bool) : Nil
+      bg = selected ? Theme.accent_bg : Theme.bg
+      if selected
+        screen.fill(Rect.new(inner.x, y, inner.w, 1), bg)
+        screen.cell(inner.x, y, '▎', Theme.accent, bg)
+      end
+      lx = inner.x + 1
+      screen.text(lx, y, label, selected ? Theme.text_bright : Theme.text, bg, width: SETTINGS_LABEL_W)
+      vx = lx + SETTINGS_LABEL_W + 1
+      return if vx >= inner.right
+      if i == 0
+        # Scope-lens toggle — ON (accent) / OFF (muted), reading the shared session Scope.
+        on = @scope.enabled?
+        screen.text(vx, y, on ? "ON" : "OFF", on ? Theme.accent : Theme.muted, bg, Attribute::Bold)
+      else
+        render_settings_field(screen, inner, y, vx, i - 1, selected, bg)
+      end
+    end
+
+    # One network text field: the value (editable input_line when the row is focused) plus a
+    # right-aligned "· project" / "· global" override marker.
+    private def render_settings_field(screen : Screen, inner : Rect, y : Int32, vx : Int32,
+                                      fi : Int32, selected : Bool, bg : Color) : Nil
+      overridden = @set_overridden[fi]
+      marker = overridden ? "· project" : "· global"
+      mx = inner.right - marker.size
+      fw = {mx - vx - 1, 3}.max
+      if selected
+        screen.input_line(vx, y, @set_values[fi], @set_cursor, @set_preedit, Theme.text_bright, bg, width: fw)
+      else
+        screen.text(vx, y, @set_values[fi], Theme.text, bg, width: fw)
+      end
+      screen.text(mx, y, marker, overridden ? Theme.accent : Theme.muted, bg) if mx > vx + 3
     end
 
     # Scroll offset that keeps `sel` visible in a window of `h` rows over `total`.

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -260,7 +260,14 @@ module Gori::Tui
             "view-only — #{err}. History/Replay work; press c to take over if it closed"
           end
       elsif requested > 0 && @session.proxy.port != requested
-        Settings.bind_port = @session.proxy.port # keep the settings UI showing the live port
+        # Reflect the fallback port in whichever layer is effective so the settings UIs show the
+        # live port AND apply_settings won't see a phantom mismatch. Only the runtime layer — a
+        # transient environmental fallback must not be persisted into the project's pinned config.
+        if Settings.project_bind_port
+          Settings.project_bind_port = @session.proxy.port
+        else
+          Settings.bind_port = @session.proxy.port
+        end
         @toast = "port #{requested} in use — capturing on #{@session.proxy.port} instead (point your client there)"
       end
       render # initial paint (the loop below only re-renders when something changed)
@@ -3207,6 +3214,12 @@ module Gori::Tui
       project_controller.toast_scope_state
     end
 
+    # Host-facade alias so a TabController (the Project settings pane's lens row + click) flips
+    # the lens through the same reload+toast path a keybind/menu uses.
+    def toggle_scope_lens : Nil
+      scope_toggle_lens
+    end
+
     # Project SCOPE-pane rule editing (the inline a/e/d keys + its space menu both route here).
     def scope_add_rule : Nil
       project_controller.scope_add_rule
@@ -3695,9 +3708,14 @@ module Gori::Tui
     # rebind (port in use / bad address) keeps the current bind.
     private def apply_settings(save_msg : String) : String
       proxy = @session.proxy
-      return save_msg if Settings.bind_host == proxy.host && Settings.bind_port == proxy.port
+      # Rebind against the EFFECTIVE bind (a project override wins over the global). So a global
+      # settings:network edit while a project pins its own bind is a no-op here (effective
+      # unchanged), and a Project-pane edit rebinds because the effective address moved.
+      eff_host = Settings.effective_bind_host
+      eff_port = Settings.effective_bind_port
+      return save_msg if eff_host == proxy.host && eff_port == proxy.port
       begin
-        proxy.rebind(Settings.bind_host, Settings.bind_port)
+        proxy.rebind(eff_host, eff_port)
         @session.sync_capture_status!
         if @session.capturing?
           "settings saved — now listening on #{proxy.host}:#{proxy.port} (repoint your client)"
@@ -3708,6 +3726,25 @@ module Gori::Tui
       rescue ex
         "settings saved, but rebind failed: #{ex.message} (kept #{proxy.host}:#{proxy.port})"
       end
+    end
+
+    # Persist + apply the Project settings pane's per-project network config. Each field is
+    # stored only when it DIFFERS from the current global (else the KV key is dropped, so the
+    # project inherits — and later global edits propagate). Refreshes the Settings runtime
+    # override layer, then rebinds the live proxy (the upstream is already live via effective_*).
+    def apply_project_network(bind_host : String, bind_port : Int32, upstream : String) : String
+      set_or_clear(Settings::PROJECT_BIND_HOST_KEY, bind_host, Settings.bind_host)
+      set_or_clear(Settings::PROJECT_BIND_PORT_KEY, bind_port.to_s, Settings.bind_port.to_s)
+      set_or_clear(Settings::PROJECT_UPSTREAM_KEY, upstream, Settings.upstream_proxy)
+      Settings.project_bind_host = bind_host == Settings.bind_host ? nil : bind_host
+      Settings.project_bind_port = bind_port == Settings.bind_port ? nil : bind_port
+      Settings.project_upstream_proxy = upstream == Settings.upstream_proxy ? nil : upstream
+      apply_settings("project network saved")
+    end
+
+    private def set_or_clear(key : String, value : String, global : String) : Nil
+      store = @session.store
+      value == global ? store.delete_setting(key) : store.set_setting(key, value)
     end
 
     # Open the settings editor for `section` (palette → settings:network/editor/theme/

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -231,7 +231,7 @@ module Gori::Tui
         return "settings: invalid bind port #{@values[1].inspect}"
       end
       up = @values[2].strip
-      if err = upstream_port_error(up)
+      if err = Settings.upstream_proxy_port_error(up)
         @status = "invalid upstream port"
         return err
       end
@@ -240,28 +240,6 @@ module Gori::Tui
       Settings.upstream_proxy = up
       @values = [Settings.bind_host, Settings.bind_port.to_s, Settings.upstream_proxy, hostnames_summary]
       persist
-    end
-
-    # nil if the upstream-proxy string is acceptable; an error message if its explicit
-    # port segment isn't a valid 0-65535 int — so a typo ("proxy:8O80") is caught at
-    # save time instead of silently resolving to 8080 (Settings.upstream_proxy_addr)
-    # and failing every captured flow later, far from the mistake.
-    private def upstream_port_error(value : String) : String?
-      return nil if value.empty?
-      bare = value.sub(/\Ahttps?:\/\//, "").rstrip('/')
-      if bare.starts_with?('[') # bracketed IPv6 literal: [::1] or [::1]:port — the port is after ']'
-        return nil unless close = bare.index(']')
-        rest = bare[(close + 1)..]
-        return nil unless rest.starts_with?(':') && rest.size > 1 # no explicit port → defaults fine
-        seg = rest[1..]
-      else
-        i = bare.rindex(':')
-        return nil unless i && i < bare.size - 1 # no explicit port → defaults fine
-        return nil if bare[0...i].includes?(':') # pre-colon host has a ':' → unbracketed IPv6 literal, no port
-        seg = bare[(i + 1)..]
-      end
-      p = seg.to_i?
-      (p && 0 <= p <= 65535) ? nil : "settings: invalid upstream proxy port #{seg.inspect}"
     end
 
     private def persist : String

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -36,6 +36,9 @@ module Gori::Tui
     abstract def toggle_pretty : Nil           # flip the pretty-print pref (`p` from History/Replay)
     abstract def jobs : Jobs                   # shared background-job registry (bottom-bar activity)
     abstract def notifications : Notifications # shared notification store (center + badge)
+    abstract def toggle_scope_lens : Nil       # flip the scope display lens (Project settings pane row/click)
+    # Persist + apply the Project settings pane's per-project network config; returns a toast.
+    abstract def apply_project_network(bind_host : String, bind_port : Int32, upstream : String) : String
   end
 
   # Shared, state-free body chrome used by BOTH Runner and the per-tab

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -80,9 +80,14 @@ module Gori
         "settings.hotkeys", "settings:hotkeys", "Rebind keyboard shortcuts (press a key) + pick an OS default profile",
         Verb::Scope::Global, category: Verb::Category::Settings) { |ctx| ctx.open_settings(:hotkeys); nil }
 
+      # `s` toggles the scope lens from anywhere (its original behavior — this used to jump to
+      # the Project scope editor). Jumping there is now the palette-only `scope.edit` below.
       r.register Verb::Definition.new(
-        "scope.edit", "Scope lens", "Edit the in-scope host patterns", Verb::Scope::Global,
-        [Verb::Chord.new("s")]) { |ctx| ctx.scope_open; nil }
+        "scope.toggle-lens", "Toggle scope lens", "Filter History/Sitemap to in-scope flows on/off",
+        Verb::Scope::Global, [Verb::Chord.new("s")]) { |ctx| ctx.scope_toggle_lens; nil }
+      r.register Verb::Definition.new(
+        "scope.edit", "Edit scope rules", "Jump to the Project tab's scope rule editor",
+        Verb::Scope::Global) { |ctx| ctx.scope_open; nil }
 
       r.register Verb::Definition.new(
         "scope.add-host", "Add host to scope", "Add the selected flow's host to the scope lens",


### PR DESCRIPTION
## What

Adds a **PROJECT SETTINGS** pane below DESCRIPTION in the Project tab — a project-scoped control panel:

- **Scope lens toggle** (row 0)
- **Inline-editable network fields**: bind IP / bind port / upstream proxy

The network fields are **per-project overrides**: stored in the project DB, applied on open, and inheriting the global `settings:network` values when unset. Each row is marked `· project` (pinned override) or `· global` (inherited).

Also restores **global `s` = toggle scope lens** (it had become jump-to-editor).

## How

- **`Settings.project_bind_host/port/upstream_proxy`** — a runtime layer set by `Session.open` from the project DB, **never serialized** to `settings.json`. `effective_*` helpers resolve `project ?? global`; `upstream_proxy_addr` reads the effective value, so `Upstream.dial` is unchanged.
- **`apply_settings`** rebinds on the *effective* bind → a global `settings:network` edit never clobbers an active project override; the pane's save does rebind the live proxy.
- **Store-if-different inheritance** (new `Store#delete_setting`): saving a value equal to the global clears the override — reversible with no separate reset UI.
- **`s`** → new `scope.toggle-lens` verb (Global, chord `s`); `scope.edit` (jump) kept palette-only. The Project SCOPE-pane Space-menu `s` is untouched.
- Project tab body is now **4 focusable panes** (`body_panes` → 4-tuple; right column splits DESCRIPTION over PROJECT SETTINGS).

## Verification

- `crystal build` clean; **1160 specs, 0 failures** (+11 new: effective layer, `delete_setting`, pane render/hit-test/edit, `s`-toggles-lens).
- Live TUI (tmux, isolated `GORI_HOME`): pane renders · space toggles the lens (persisted) · global `s` toggles from History · editing bind port creates a `· project` override + **live rebind** · invalid port rejected (toast, no rebind) · leave-with-invalid reverts · override **persists across reopen** · a global edit left the running proxy on the project's port · resetting to the global value cleared the override.

## Notes

- Headless `gori run` / `gori mcp` replay don't call `Session.open`, so they still use the global upstream — an independent follow-up if desired.