### PR TITLE
fix: harden recently-added features (History scrub, Fuzzer run-count, Project net)

### DIFF
--- a/spec/sse_spec.cr
+++ b/spec/sse_spec.cr
@@ -93,6 +93,16 @@ describe Gori::Sse do
       parse("retry: 99999999999999\ndata: x\n\n")[0].retry.should eq(Int32::MAX)
       parse("retry: 1500\ndata: x\n\n")[0].retry.should eq(1500)
     end
+
+    it "scrubs invalid UTF-8 so no raw bytes reach the display (a lying content-type can route binary here)" do
+      # "data: A" + a truncated 3-byte sequence (\xE4\xB8) + "B\n\n"
+      body = Bytes[0x64, 0x61, 0x74, 0x61, 0x3a, 0x20, 0x41, 0xE4, 0xB8, 0x42, 0x0a, 0x0a]
+      events = Gori::Sse.events(body)
+      events.size.should eq(1)
+      events[0].data.valid_encoding?.should be_true # the width-desync corruption vector is gone
+      events[0].data.should start_with("A")
+      events[0].data.should end_with("B")
+    end
   end
 
   describe ".event_stream?" do

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -88,6 +88,16 @@ describe Gori::Tui::FuzzerView do
       view.run_request_count.should eq(10_i64)
     end
 
+    # run_request_count runs on the render fiber; a wordlist file must never be line-counted
+    # there when doing so could freeze (huge file) or block forever (/dev/zero, a FIFO). An
+    # uncountable file reports nil (the Run row just omits the count) instead of reading it.
+    it "run_request_count omits a wordlist file it can't safely count on the render path" do
+      view = FuzzerView.new
+      view.load_request("https://h", "GET /?x=§1§ HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
+      view.apply_set(nil, Gori::Tui::SetSpec.new(:file, "/nonexistent/gori-spec-wordlist"))
+      view.run_request_count.should be_nil # File.info? → nil → unknown, never a blocking read
+    end
+
     it "advanced_snapshot round-trips through apply_advanced" do
       view = loaded_fuzzer
       snap = view.advanced_snapshot

--- a/spec/tui/project_view_spec.cr
+++ b/spec/tui/project_view_spec.cr
@@ -257,4 +257,22 @@ describe "ProjectView PROJECT SETTINGS pane" do
       reset_projnet
     end
   end
+
+  # Regression: settings_dirty? must diff the LOAD-TIME baseline, not live effective_*.
+  # A global settings:network save (or a startup port-fallback) changes effective under an
+  # untouched pane; if that read as "dirty", the next tab-leave `commit` would persist the
+  # stale snapshot as a phantom per-project override, silently reverting the global edit.
+  it "an untouched pane stays clean after a global edit moves effective (no phantom override)" do
+    tmp_store do |store|
+      reset_projnet
+      view = ProjectView.new(Gori::Scope.load(store), Gori::HostOverrides.load(store))
+      view.refresh_settings # baseline = inherited global (8070)
+      view.settings_dirty?.should be_false
+
+      Gori::Settings.bind_port = 9090      # a global settings:network save, no project override
+      view.settings_dirty?.should be_false # the user never touched the pane → not dirty
+    ensure
+      reset_projnet
+    end
+  end
 end

--- a/src/gori/session.cr
+++ b/src/gori/session.cr
@@ -44,18 +44,19 @@ module Gori
       events = Channel(Store::FlowEvent).new(1024)
       prism_events = Channel(Store::FlowEvent).new(256)
       store = Store.open(project.db_path, events, prism_events)
-      # Per-project network overrides: pull this project's pinned bind/upstream (if any) into
-      # the Settings runtime layer BEFORE binding, so the proxy listens on the project's address
-      # and Upstream.dial (reads Settings.effective_upstream_proxy) tunnels through its upstream.
-      # Always assign all three (nil when unset) so switching projects resets cleanly. Mutating
-      # `config` is safe — App re-seeds it from the global Settings on every project open.
-      Settings.project_bind_host = store.setting(Settings::PROJECT_BIND_HOST_KEY)
-      Settings.project_bind_port = store.setting(Settings::PROJECT_BIND_PORT_KEY).try(&.to_i?)
-      Settings.project_upstream_proxy = store.setting(Settings::PROJECT_UPSTREAM_KEY)
-      config.listen = Settings.effective_bind_host
-      config.port = Settings.effective_bind_port
       prism = nil.as(Prism::Analyzer?)
       begin
+        # Per-project network overrides: pull this project's pinned bind/upstream (if any) into
+        # the Settings runtime layer BEFORE binding, so the proxy listens on the project's address
+        # and Upstream.dial (reads Settings.effective_upstream_proxy) tunnels through its upstream.
+        # Always assign all three (nil when unset) so switching projects resets cleanly. Mutating
+        # `config` is safe — App re-seeds it from the global Settings on every project open. Inside
+        # the begin so a failing settings read is torn down below rather than leaking store+channels.
+        Settings.project_bind_host = store.setting(Settings::PROJECT_BIND_HOST_KEY)
+        Settings.project_bind_port = store.setting(Settings::PROJECT_BIND_PORT_KEY).try(&.to_i?)
+        Settings.project_upstream_proxy = store.setting(Settings::PROJECT_UPSTREAM_KEY)
+        config.listen = Settings.effective_bind_host
+        config.port = Settings.effective_bind_port
         lock = nil.as(CaptureLock?)
         sink = Proxy::StoreSink.new(store)
         rules = Rules.load(store)                  # shared: proxy reads, TUI edits (Mutex-guarded)

--- a/src/gori/sse.cr
+++ b/src/gori/sse.cr
@@ -66,7 +66,7 @@ module Gori
       # Normalise all three line terminators to LF so a single split suffices, and
       # drop one leading BOM (U+FEFF) — WHATWG preprocessing — so the first field name
       # isn't mangled (a BOM-prefixed stream would otherwise lose its first event).
-      text = String.new(body).gsub("\r\n", "\n").gsub('\r', '\n').lchop(0xFEFF.chr)
+      text = String.new(body).scrub.gsub("\r\n", "\n").gsub('\r', '\n').lchop(0xFEFF.chr)
 
       last_id = nil.as(String?) # stream-level: persists across blocks (per spec)
       data = [] of String       # data lines accumulated for the current block

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -177,6 +177,13 @@ module Gori::Tui
       @project_view.save(@host.session.store)
     end
 
+    # Re-sync the SETTINGS pane's inherited network fields after a global settings:network
+    # save changed the effective config — but not while the user has an uncommitted edit in
+    # the pane (settings_dirty?), so their in-progress typing survives.
+    def refresh_network : Nil
+      @project_view.refresh_settings unless @project_view.settings_dirty?
+    end
+
     # --- DESCRIPTION pane: live multi-line editing ---
     private def handle_project_desc_key(ev : Termisu::Event::Key) : Nil
       key = ev.key

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -555,11 +555,29 @@ module Gori::Tui
 
     private def compute_run_count : Int64?
       return nil if @sets.empty? || position_count == 0
-      sizes = @sets.map { |s| Fuzz::PayloadSet.new(build_source(s)).size }
+      sizes = @sets.map { |s| estimated_set_size(s) }
       return nil if sizes.any?(Nil) # any unknown / overflowing size → unknown total
       run_count_for_mode(sizes.compact)
     rescue
       nil
+    end
+
+    # Only line-count a wordlist this small on the render fiber; anything larger
+    # reports "unknown" for the live estimate rather than freezing the UI.
+    COUNT_FILE_CAP = 8_i64 * 1024 * 1024
+
+    # A set's payload count for the LIVE Run-row estimate. `run_request_count` runs on
+    # the render fiber, so a wordlist file is counted only when it's a regular file
+    # within COUNT_FILE_CAP — a rockyou-scale file would freeze the UI for seconds
+    # (re-read on every Mode cycle) and a non-regular path (/dev/zero, a FIFO) would
+    # block forever. Those report nil → the Run row just omits the count; the exact
+    # total is still computed off this path when the run actually starts.
+    private def estimated_set_size(s : SetSpec) : Int64?
+      if s.kind == :file
+        info = File.info?(s.value)
+        return nil unless info && info.type.file? && info.size <= COUNT_FILE_CAP
+      end
+      Fuzz::PayloadSet.new(build_source(s)).size
     end
 
     private def run_count_for_mode(ns : Array(Int64)) : Int64?

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -1102,7 +1102,10 @@ module Gori::Tui
     # Wrap pre-formatted plain strings (frames / ws / gRPC hex) as single-span
     # body-text lines so they share the styled rendering path.
     private def wrap(strs : Array(String)) : Array(Highlight::Line)
-      strs.map { |s| [Highlight::Span.new(s, Theme.text)] of Highlight::Span }
+      # `.scrub` maps invalid UTF-8 to U+FFFD (width-1) so stray bytes in a WS text
+      # payload or SSE data line never desync the terminal — the same guard every
+      # sibling surface (Replay/CLI/MCP) already applies on this byte→line seam.
+      strs.map { |s| [Highlight::Span.new(s.scrub, Theme.text)] of Highlight::Span }
     end
 
     # Wrap a bounded log (frames/messages) and, when the window dropped older rows,
@@ -1215,12 +1218,15 @@ module Gori::Tui
 
     # A "▸ …" accent header line introducing a decoded-protocol section.
     private def derived_header(text : String) : Highlight::Line
-      [Highlight::Span.new("▸ #{text}", Theme.accent)] of Highlight::Span
+      [Highlight::Span.new("▸ #{text.scrub}", Theme.accent)] of Highlight::Span
     end
 
     # Append `raw`'s lines to `lines`, styled per `kind`, stopping at DERIVED_LINE_CAP.
     private def append_styled(lines : Array(Highlight::Line), raw : String, kind : Symbol) : Nil
-      raw.split('\n').each do |ln|
+      # Scrub before styling: decoded SAML/JWT/GraphQL payloads come from URL-/base64-
+      # decoded bytes that can be invalid UTF-8, and the `:text`/`plain` styler keeps
+      # them raw — matching the `.scrub` the CLI/MCP/decoded_view emitters apply.
+      raw.scrub.split('\n').each do |ln|
         if lines.size >= DERIVED_LINE_CAP
           lines << [Highlight::Span.new("… (truncated)", Theme.yellow)] of Highlight::Span
           break
@@ -1277,9 +1283,9 @@ module Gori::Tui
       tag = f.source == :query ? "?" : " "
       note = f.note
       [
-        Highlight::Span.new("#{tag} #{f.name}", Theme.syn_string),
+        Highlight::Span.new("#{tag} #{f.name.scrub}", Theme.syn_string),
         Highlight::Span.new(" = ", Theme.muted),
-        Highlight::Span.new(note ? "(#{note})" : f.value, note ? Theme.yellow : Theme.text),
+        Highlight::Span.new(note ? "(#{note})" : f.value.scrub, note ? Theme.yellow : Theme.text),
       ] of Highlight::Span
     end
   end

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -76,6 +76,7 @@ module Gori::Tui
       @set_sel = 0
       @set_values = ["", "", ""]
       @set_overridden = [false, false, false]
+      @set_baseline = {"", "", ""} # the three fields as last loaded; drives settings_dirty?
       @set_cursor = 0
       @set_preedit = ""
       load_settings_values
@@ -114,6 +115,7 @@ module Gori::Tui
       @set_values = [Settings.effective_bind_host, Settings.effective_bind_port.to_s, Settings.effective_upstream_proxy]
       @set_overridden = [!Settings.project_bind_host.nil?, !Settings.project_bind_port.nil?, !Settings.project_upstream_proxy.nil?]
       @set_cursor = current_set_value.size
+      @set_baseline = settings_values # capture the load state so "dirty" means the USER edited a field
     end
 
     private def current_set_value : String
@@ -322,11 +324,13 @@ module Gori::Tui
       {@set_values[0].strip, @set_values[1].strip, @set_values[2].strip}
     end
 
-    # True when any network field differs from the currently-applied effective config — the
-    # commit path skips a no-op apply (and its toast) when nothing was actually edited.
+    # True when the user edited a network field since it was last loaded. Diffs against the
+    # LOAD-TIME baseline, NOT live effective_* — a global settings:network save or a startup
+    # port-fallback mutates effective under an untouched pane, and diffing against it would
+    # make `commit` (fires on every tab-leave/quit) persist that stale snapshot as a phantom
+    # per-project override, silently reverting the global edit. Mirrors @desc_dirty.
     def settings_dirty? : Bool
-      h, p, u = settings_values
-      h != Settings.effective_bind_host || p != Settings.effective_bind_port.to_s || u != Settings.effective_upstream_proxy
+      settings_values != @set_baseline
     end
 
     # Move between the pane's rows (keyboard ↑/↓ + wheel); clamps to the row range.

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -253,7 +253,6 @@ module Gori::Tui
 
     def run : Symbol
       history_controller.view.reload(@session.store)
-      project_controller.reload
       notes_controller.view.reload(@session.store) # load persisted notes up front so the tab is ready before it's ever focused
       # Surface the bind outcome on entry: capture-off if nothing could bind, or a
       # port-fallback note if the configured port was taken and we picked another.
@@ -278,6 +277,9 @@ module Gori::Tui
         end
         @toast = "port #{requested} in use — capturing on #{@session.proxy.port} instead (point your client there)"
       end
+      # Reload AFTER the fallback sync above so the Project SETTINGS pane's snapshot (and its
+      # dirty baseline) reflect the ACTUAL bound port, not the requested one that was taken.
+      project_controller.reload
       render # initial paint (the loop below only re-renders when something changed)
       # The render loop polls input on a 50ms cadence (so async channels are still
       # checked ≤50ms), but RENDER only runs when the frame would actually change —
@@ -1671,7 +1673,7 @@ module Gori::Tui
         # rest just persist (the value is read live or only matters next session).
         msg = @settings_view.save
         @toast = case @settings_view.section
-                 when :network then apply_settings(msg)
+                 when :network then apply_settings(msg).tap { project_controller.refresh_network } # re-sync the Project pane's inherited fields to the new global
                  when :theme   then apply_theme(msg)
                  else               msg
                  end


### PR DESCRIPTION
Stability review + fixes over the recently-merged features (PRs #82–#87).

## Fixes

**1. History detail — terminal corruption (잔상) via unscrubbed render seams — HIGH**
The PR#86 binary-body guard covered only the response **body** seam. History detail has five more byte→line seams where raw bytes reached the terminal — **MESSAGES** (WS text), **EVENTS** (SSE), **PARAMS** (URL-decoded), **GRAPHQL**, **SAML** — while every sibling surface (Replay/Fuzzer/CLI/MCP/decoded_view) already scrubbed the same data. A server lying about `Content-Type: text/event-stream`, or a WS text frame carrying binary, re-triggered the wide-char width desync. Fixed at the shared line-builders (`wrap` / `append_styled` / `derived_header` / `form_field_line`).

**2. `Sse.events` didn't actually scrub — HIGH**
Its comment claimed "invalid bytes become U+FFFD" but the code was bare `String.new(body)`. Fixed at source, so `e.type`/`e.id`/`e.data` are clean for every consumer.

**3. Fuzzer run-count freezes/hangs the UI — HIGH**
`run_request_count` runs on the render fiber and, for a `:file` set, read the whole wordlist (`File.each_line`). A rockyou-scale file froze the UI for seconds (re-read on every Mode cycle); a non-regular path (`/dev/zero`, a FIFO — reachable via `/dev/` path-complete) hung it forever (the `rescue` can't catch a blocking read). Now `estimated_set_size` counts a `:file` set only when it's a regular file ≤ 8 MiB; otherwise the Run row omits the count. The exact total is still computed off the render path at run time.

**4. Project SETTINGS phantom override — HIGH**
`settings_dirty?` diffed the pane snapshot against **live** `effective_*`. A global `settings:network` save or a startup port-fallback mutates effective under an untouched pane, and `commit` fires on every tab-leave/quit → the stale snapshot got persisted as a per-project override, silently reverting the global edit / pinning the transient fallback port. Now diffs a **load-time baseline** (mirrors `@desc_dirty`). Also: reload the pane after the fallback sync and after a global network save; move `Session.open`'s project-settings reads inside the `begin/rescue` so a failing read tears down store+channels instead of leaking.

## Deliberately not changed (low, parity with existing behavior)
Bind port 0 (ephemeral) acceptance and persist-before-validate bind IP match the existing global settings behavior and are recoverable; over-validating IPs risks rejecting legit values.

## Verification
- Regression tests added: SSE scrub, uncountable-wordlist → nil, untouched-pane-stays-clean.
- `shards build` clean, full spec suite **1183 passing**, ameba net-new **0** (`project_controller.cr` excluded — known formatter crash).