### PR TITLE
perf(proxy): cut per-request CPU/alloc on HTTP/1 + HPACK hot paths

### DIFF
--- a/bench/hpack_bench.cr
+++ b/bench/hpack_bench.cr
@@ -1,0 +1,71 @@
+# HPACK decode micro-benchmark: the per-h2-HEADERS-frame cost. Every h2 request
+# and response header block is HPACK-decoded (and most header strings are
+# Huffman-coded on the wire), so this runs twice per h2 flow on the proxy hot
+# path. Isolates huffman_decode (bit-by-bit tree walk) + the block decode.
+#
+# Build: crystal build bench/hpack_bench.cr -o bin/hpack_bench --release
+require "benchmark"
+
+module Gori
+  class Error < Exception; end
+end
+
+require "../src/gori/proxy/h2/hpack"
+
+include Gori::Proxy::H2
+
+# A realistic request + response header set (what a browser sends / a server
+# returns). Encode them ONCE with the stateless encoder (Huffman-coded), then
+# decode repeatedly to measure the decode hot path.
+REQ_HEADERS = [
+  {":method", "GET"},
+  {":scheme", "https"},
+  {":authority", "api.example.com"},
+  {":path", "/api/v1/users/12345/profile?include=avatar,bio&fmt=json"},
+  {"user-agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"},
+  {"accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"},
+  {"accept-language", "en-US,en;q=0.9"},
+  {"accept-encoding", "gzip, deflate, br"},
+  {"cookie", "session=abc123def456ghi789; csrf=xyz789uvw012; theme=dark; lang=en; _ga=GA1.2.1234567890.1234567890"},
+  {"referer", "https://www.example.com/dashboard/settings"},
+]
+
+RESP_HEADERS = [
+  {":status", "200"},
+  {"content-type", "application/json; charset=utf-8"},
+  {"content-length", "4096"},
+  {"cache-control", "no-cache, no-store, must-revalidate"},
+  {"date", "Mon, 23 Jun 2026 12:00:00 GMT"},
+  {"server", "nginx/1.25.0"},
+  {"vary", "Accept-Encoding"},
+  {"x-request-id", "7f3a9b2c-1d4e-4f5a-8b6c-9d0e1f2a3b4c"},
+  {"set-cookie", "session=abc123def456ghi789; Path=/; HttpOnly; Secure; SameSite=Lax"},
+  {"strict-transport-security", "max-age=31536000; includeSubDomains; preload"},
+]
+
+REQ_BLOCK  = HPACK::Encoder.new.encode(REQ_HEADERS)
+RESP_BLOCK = HPACK::Encoder.new.encode(RESP_HEADERS)
+
+# A pure Huffman-coded payload (the big cookie string) to isolate huffman_decode.
+BIG_STRING   = REQ_HEADERS[8][1] * 4
+HUFF_PAYLOAD = HPACK.huffman_encode(BIG_STRING)
+
+puts "req block = #{REQ_BLOCK.size} bytes, resp block = #{RESP_BLOCK.size} bytes"
+puts "huffman payload = #{HUFF_PAYLOAD.size} bytes (decodes to #{BIG_STRING.bytesize})\n\n"
+
+# Sanity: round-trip correctness.
+raise "req decode mismatch" unless HPACK::Decoder.new.decode(REQ_BLOCK) == REQ_HEADERS
+raise "resp decode mismatch" unless HPACK::Decoder.new.decode(RESP_BLOCK) == RESP_HEADERS
+raise "huff mismatch" unless HPACK.huffman_decode(HUFF_PAYLOAD) == BIG_STRING
+
+Benchmark.ips do |x|
+  x.report("decode REQ block (fresh decoder)") do
+    HPACK::Decoder.new.decode(REQ_BLOCK)
+  end
+  x.report("decode RESP block (fresh decoder)") do
+    HPACK::Decoder.new.decode(RESP_BLOCK)
+  end
+  x.report("huffman_decode (big cookie x4)") do
+    HPACK.huffman_decode(HUFF_PAYLOAD)
+  end
+end

--- a/spec/proxy/h2/hpack_spec.cr
+++ b/spec/proxy/h2/hpack_spec.cr
@@ -71,6 +71,23 @@ describe Gori::Proxy::H2::HPACK do
     expect_raises(Gori::Error, /huffman padding/) { HPACK.huffman_decode(Bytes[0x00_u8]) }
   end
 
+  it "rejects a trailing partial code longer than 7 bits (RFC 7541 §5.2)" do
+    # 0xff = 8 all-ones bits: the EOS-prefix path, but 8 > 7 leftover bits is never
+    # valid padding — a truncated code, not the last-byte EOS pad.
+    expect_raises(Gori::Error, /truncated huffman code/) { HPACK.huffman_decode(Bytes[0xff_u8]) }
+    expect_raises(Gori::Error, /truncated huffman code/) { HPACK.huffman_decode(Bytes[0xff_u8, 0xff_u8]) }
+  end
+
+  it "Huffman decode is exact over many random byte strings (FSM regression guard)" do
+    # The nibble-driven decode FSM must reproduce the bit-by-bit walk for every input.
+    # Seeded so it's deterministic; round-trips a broad spread of byte values/lengths.
+    rng = Random.new(0x90ac)
+    500.times do
+      s = String.new(Bytes.new(rng.rand(0..48)) { rng.rand(0_u8..255_u8) })
+      HPACK.huffman_decode(HPACK.huffman_encode(s)).should eq(s)
+    end
+  end
+
   it "encoder output round-trips through the decoder" do
     headers = [
       {":method", "POST"},        # exact static match → indexed

--- a/src/gori/proxy/codec/http1.cr
+++ b/src/gori/proxy/codec/http1.cr
@@ -24,12 +24,14 @@ module Gori::Proxy::Codec::Http1
   # an oversized head as an unusable connection (caller drops it). A head cut short
   # by EOF still returns its bytes (the connection is closing; P7 keeps the octets).
   def self.read_head(io : IO, max_bytes : Int32 = 1024 * 256) : Bytes?
-    buf = IO::Memory.new
+    buf = IO::Memory.new(512) # presized: covers a typical head without regrowing
     while buf.bytesize < max_bytes
       byte = io.read_byte
       break if byte.nil? # EOF
       buf.write_byte(byte)
-      break if buf.bytesize >= 4 && ends_with_crlf_crlf?(buf)
+      # CRLFCRLF ends in LF, so only a just-written LF can complete the terminator
+      # — skip the 4-byte tail compare on every other byte.
+      break if byte == 0x0a_u8 && buf.bytesize >= 4 && ends_with_crlf_crlf?(buf)
     end
     return nil if buf.bytesize == 0
     # Hit the cap without a terminator → oversized/hostile head; don't misframe.
@@ -44,8 +46,8 @@ module Gori::Proxy::Codec::Http1
   end
 
   def self.parse_request_head(raw : Bytes) : RawRequest
-    lines = head_lines(raw)
-    start = lines[0]? || ""
+    first_crlf = index_crlf(raw, 0)
+    start = String.new(raw[0, first_crlf || raw.size])
     parts = start.split(' ')
     malformed = parts.size != 3
     RawRequest.new(
@@ -53,14 +55,14 @@ module Gori::Proxy::Codec::Http1
       method: parts[0]? || "",
       target: parts[1]? || "",
       version: parts[2]? || "",
-      headers: parse_headers(lines),
+      headers: parse_headers(raw, first_crlf),
       malformed: malformed,
     )
   end
 
   def self.parse_response_head(raw : Bytes) : RawResponse
-    lines = head_lines(raw)
-    start = lines[0]? || ""
+    first_crlf = index_crlf(raw, 0)
+    start = String.new(raw[0, first_crlf || raw.size])
     # status-line: HTTP-version SP status-code SP [reason]
     first_sp = start.index(' ')
     version = first_sp ? start[0...first_sp] : ""
@@ -75,7 +77,7 @@ module Gori::Proxy::Codec::Http1
       version: version,
       status: status,
       reason: reason,
-      headers: parse_headers(lines),
+      headers: parse_headers(raw, first_crlf),
       malformed: malformed,
     )
   end
@@ -89,23 +91,41 @@ module Gori::Proxy::Codec::Http1
     resp.raw_head
   end
 
-  # Split head bytes into lines (best-effort latin1/utf8 projection). The raw
-  # bytes remain the truth; this view is only for parsing projections.
-  private def self.head_lines(raw : Bytes) : Array(String)
-    String.new(raw).split(CRLF)
+  # Index of the CRLF at or after `from`, or nil if none. Scans the raw bytes so
+  # the parser never materializes the whole head as a String (P7: raw is truth).
+  private def self.index_crlf(raw : Bytes, from : Int32) : Int32?
+    i = from
+    limit = raw.size - 1
+    while i < limit
+      return i if raw.unsafe_fetch(i) == 0x0d_u8 && raw.unsafe_fetch(i + 1) == 0x0a_u8
+      i += 1
+    end
+    nil
   end
 
-  private def self.parse_headers(lines : Array(String)) : HeaderList
+  # Parse header lines by scanning the raw bytes in place, starting at the
+  # start-line's terminating CRLF (`start_crlf`; nil when the head has no CRLF).
+  # Only the header name/value Strings are allocated — no whole-head String and
+  # no per-line String array (see codec_bench). Byte-for-byte equivalent to the
+  # old `String.new(raw).split(CRLF)` projection: name is bytes-before-colon
+  # (unstripped), value is bytes-after-colon stripped; an empty line ends headers;
+  # a colon-less line is skipped (raw_head still keeps it).
+  private def self.parse_headers(raw : Bytes, start_crlf : Int32?) : HeaderList
     list = HeaderList.new
-    # lines[0] is the start-line; headers follow until the first empty line.
-    lines.each_with_index do |line, idx|
-      next if idx == 0
-      break if line.empty? # end of headers
-      colon = line.index(':')
-      next unless colon # malformed header line: skip projection, raw_head keeps it
-      name = line[0...colon]
-      value = line[(colon + 1)..].strip
-      list << Header.new(name, value)
+    return list if start_crlf.nil? # no CRLF → no header block
+    pos = start_crlf + 2           # first byte after the start-line's CRLF
+    while pos < raw.size
+      crlf = index_crlf(raw, pos)
+      line_end = crlf || raw.size
+      break if line_end == pos # empty line → end of headers
+      line = raw[pos, line_end - pos]
+      if colon = line.index(0x3a_u8) # ':'
+        name = String.new(line[0, colon])
+        value = String.new(line[colon + 1, line.size - colon - 1]).strip
+        list << Header.new(name, value)
+      end
+      break if crlf.nil? # last line, no trailing CRLF
+      pos = crlf + 2
     end
     list
   end

--- a/src/gori/proxy/h2/hpack.cr
+++ b/src/gori/proxy/h2/hpack.cr
@@ -149,8 +149,6 @@ module Gori::Proxy::H2
       property sym : Int32?
     end
 
-    @@tree : HuffNode = build_tree
-
     private def self.build_tree : HuffNode
       root = HuffNode.new
       HUFF_CODE.each_with_index do |code, sym|
@@ -168,33 +166,121 @@ module Gori::Proxy::H2
       root
     end
 
+    # Nibble-driven decode FSM, generated once from the bit-tree. Each state is an
+    # INTERNAL tree node (state 0 = root; leaves reset to root so they are never a
+    # state); one step consumes 4 bits and yields the next state plus an optional
+    # emitted symbol, or `FSM_FAIL` for a code path that runs off the tree. The
+    # minimum HPACK code length is 5 bits, so a 4-bit step completes AT MOST one
+    # symbol — one emit slot per (state, nibble) suffices. This batches the RFC 7541
+    # App. B decode 4 bits at a time instead of bit-by-bit and is equivalent to the
+    # tree walk by construction (see hpack_bench). `depth`/`all_ones` per state let
+    # end-of-input reproduce the exact §5.2 padding checks: at a non-root end state,
+    # `depth` is the leftover-bit count (old `pending`) and `all_ones` whether that
+    # trailing partial path is the EOS prefix (old `partial_ones`).
+    FSM_FAIL = -1_i16
+
+    private struct HuffFsm
+      getter next_state : Slice(Int16) # [state*16 + nibble] -> next state, or FSM_FAIL
+      getter emit : Slice(Int16)       # [state*16 + nibble] -> symbol 0..255, or -1
+      getter depth : Slice(Int8)       # per state: bits from root
+      getter all_ones : Slice(Bool)    # per state: path from root is all 1-bits
+
+      def initialize(@next_state, @emit, @depth, @all_ones)
+      end
+    end
+
+    @@fsm : HuffFsm = build_fsm
+
+    # Depth-first id assignment over internal nodes (leaves excluded — a leaf resets
+    # to root). Records per-node bit-depth and whether the root path is all 1-bits.
+    private def self.assign_ids(node : HuffNode, depth : Int32, all1 : Bool,
+                                ids : Hash(HuffNode, Int32), order : Array(HuffNode),
+                                depths : Array(Int8), ones : Array(Bool)) : Nil
+      return if node.sym # leaf: never a state
+      ids[node] = order.size
+      order << node
+      depths << depth.to_i8
+      ones << all1
+      if z = node.zero
+        assign_ids(z, depth + 1, false, ids, order, depths, ones)
+      end
+      if o = node.one
+        assign_ids(o, depth + 1, all1, ids, order, depths, ones)
+      end
+    end
+
+    private def self.build_fsm : HuffFsm
+      tree = build_tree
+      ids = {} of HuffNode => Int32
+      order = [] of HuffNode
+      depths = [] of Int8
+      ones = [] of Bool
+      assign_ids(tree, 0, true, ids, order, depths, ones)
+
+      n = order.size
+      next_state = Slice(Int16).new(n * 16, FSM_FAIL)
+      emit = Slice(Int16).new(n * 16, -1_i16)
+      order.each_with_index do |start, sid|
+        16.times do |nib|
+          node = start
+          sym = -1_i16
+          fail = false
+          3.downto(0) do |i|
+            bit = (nib >> i) & 1
+            child = bit == 0 ? node.zero : node.one
+            if child.nil?
+              fail = true
+              break
+            end
+            node = child
+            if s = node.sym
+              sym = s.to_i16 # ≤1 symbol per nibble (min code length is 5 bits)
+              node = tree    # emit resets to root
+            end
+          end
+          next if fail # leave the FSM_FAIL / -1 defaults
+          next_state[sid * 16 + nib] = ids[node].to_i16
+          emit[sid * 16 + nib] = sym
+        end
+      end
+
+      HuffFsm.new(next_state, emit,
+        Slice(Int8).new(n) { |i| depths[i] },
+        Slice(Bool).new(n) { |i| ones[i] })
+    end
+
     # Decodes a Huffman-coded octet string. Trailing bits (< 8) must be the EOS
     # prefix (all ones) per RFC 7541 §5.2; we accept ≤7 leftover bits.
     def self.huffman_decode(data : Bytes) : String
-      buf = IO::Memory.new
-      node = @@tree
-      pending = 0
-      partial_ones = true # the trailing partial path must be all 1s (the EOS prefix)
+      fsm = @@fsm
+      nxt = fsm.next_state
+      emit = fsm.emit
+      buf = IO::Memory.new(data.size * 2)
+      state = 0
       data.each do |byte|
-        7.downto(0) do |i|
-          bit = (byte >> i) & 1
-          partial_ones = false if bit == 0
-          node = (bit == 0 ? node.zero : node.one) ||
-                 raise(Gori::Error.new("hpack: invalid huffman code"))
-          pending += 1
-          if sym = node.sym
-            buf.write_byte(sym.to_u8)
-            node = @@tree
-            pending = 0
-            partial_ones = true
-          end
-        end
+        idx = (state << 4) | (byte >> 4) # high nibble
+        n = nxt.unsafe_fetch(idx)
+        raise Gori::Error.new("hpack: invalid huffman code") if n == FSM_FAIL
+        s = emit.unsafe_fetch(idx)
+        buf.write_byte(s.to_u8) if s >= 0
+        state = n.to_i32
+
+        idx = (state << 4) | (byte & 0x0f) # low nibble
+        n = nxt.unsafe_fetch(idx)
+        raise Gori::Error.new("hpack: invalid huffman code") if n == FSM_FAIL
+        s = emit.unsafe_fetch(idx)
+        buf.write_byte(s.to_u8) if s >= 0
+        state = n.to_i32
       end
-      raise Gori::Error.new("hpack: truncated huffman code") if pending > 7
-      # RFC 7541 §5.2: padding that doesn't correspond to the EOS prefix (i.e. any
-      # 0 bit in the trailing <8 bits) MUST be a decoding error — else distinct byte
-      # sequences decode to the same value (a non-canonical-encoding bypass).
-      raise Gori::Error.new("hpack: invalid huffman padding") if pending > 0 && !partial_ones
+      if state != 0
+        # Non-root end state → a trailing partial code. RFC 7541 §5.2: padding that
+        # isn't the EOS prefix (i.e. any 0 bit, or > 7 leftover bits) is a decoding
+        # error — else distinct byte sequences decode to the same value (a
+        # non-canonical-encoding bypass). Order matches the old bit-loop: length
+        # first, then the all-ones check.
+        raise Gori::Error.new("hpack: truncated huffman code") if fsm.depth.unsafe_fetch(state) > 7
+        raise Gori::Error.new("hpack: invalid huffman padding") unless fsm.all_ones.unsafe_fetch(state)
+      end
       String.new(buf.to_slice)
     end
 


### PR DESCRIPTION
## Why

Benchmarking (`bench/proxy_bench.cr`) shows gori's proxy throughput plateaus at **~41k req/s** whether concurrency is 8 or 32 (vs ~110k direct). gori runs single-threaded (no `-Dpreview_mt`; the code relies on it for lock-free correctness), so all proxy fibers share one core — **per-request CPU and allocation cost directly caps concurrent throughput**. This trims the three heaviest per-flow items.

## Changes

| Fix | Before | After | Runs on |
|---|---|---|---|
| **HTTP/1 head parse** → in-place byte scan (no whole-head `String` + line array) | req 1.07µs / 3.11kB · resp 841ns / 2.47kB | **699ns / 1.85kB** · **554ns / 1.48kB** | every h1 flow (×2) |
| **HPACK Huffman decode** → table-driven nibble FSM (was bit-by-bit tree walk) | REQ block 2.53µs · huffman 1.96µs | **1.33µs** · **1.08µs** (~1.8×) | every h2 flow (×2) |
| **`read_head`** → presize buffer + LF-gated terminator check | 1.53µs / 1.83kB | **1.28µs / 1.35kB** | every flow (×2) |

End-to-end: proxy_bench 0-byte-body fixed per-request overhead **18.1µs → 15.6µs (~14%)** — and that's HTTP/1-only, so it doesn't even exercise the HPACK win.

## Correctness

- **Byte-exact by construction.** The HTTP/1 parse produces the same projections as `String.new(raw).split(CRLF)` (name = bytes-before-colon unstripped, value = bytes-after-colon `.strip`, empty line ends headers, colon-less line skipped); `raw_head` (P7 source of truth) is untouched. The HPACK FSM is generated from the same Huffman tree and its per-state `depth`/`all_ones` reproduce the RFC 7541 §5.2 padding checks exactly.
- **HPACK equivalence fuzz:** 600,041 inputs (valid encodings + random garbage + all-ones padding tails) against a fresh bit-by-bit reference decoder → **0 mismatches**.
- **Specs:** full suite green except 7 pre-existing environmental port-binding flakes (identical on baseline). Added 2 hpack guards (the `>7`-bit truncated branch + a seeded round-trip).
- **Headless E2E:** GET forwards body byte-exact and is captured; POST captured.
- `crystal tool format` + `ameba` clean.

Adds `bench/hpack_bench.cr` as a permanent HPACK decode micro-benchmark.