### PR TITLE
fix(mcp): clean send_request URL errors + get_flow WebSocket parity

### DIFF
--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -195,6 +195,36 @@ describe Gori::MCP::Server do
       end
     end
 
+    it "includes WebSocket messages for a 101 flow (parity with `gori run show`)" do
+      with_store do |store|
+        id = seed_flow(store, "ws.test", "GET", "/socket", 101,
+          resp_head: "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n\r\n")
+        store.insert_ws_message(id, "out", 1, "hello".to_slice)
+        store.insert_ws_message(id, "in", 1, "world".to_slice)
+        store.insert_ws_message(id, "in", 2, Bytes[0x00, 0x01, 0xff]) # binary frame
+        call = %({"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"get_flow","arguments":{"id":#{id}}}})
+        ws = tool_payload(drive(store, call)[0])["ws_messages"]
+        ws["count"].as_i.should eq(3)
+        ws["truncated"].as_bool.should be_false
+        msgs = ws["messages"].as_a
+        msgs[0]["direction"].as_s.should eq("out")
+        msgs[0]["text"].as_s.should eq("hello")
+        msgs[1]["direction"].as_s.should eq("in")
+        msgs[1]["text"].as_s.should eq("world")
+        msgs[2]["binary"].as_bool.should be_true
+        msgs[2]["size"].as_i.should eq(3)
+        msgs[2].as_h.has_key?("text").should be_false # binary frames never inline a payload
+      end
+    end
+
+    it "omits ws_messages for a non-WebSocket flow" do
+      with_store do |store|
+        id = seed_flow(store, "ex.test", "GET", "/", 200)
+        call = %({"jsonrpc":"2.0","id":11,"method":"tools/call","params":{"name":"get_flow","arguments":{"id":#{id}}}})
+        tool_payload(drive(store, call)[0]).as_h.has_key?("ws_messages").should be_false
+      end
+    end
+
     it "returns isError for an unknown flow id" do
       with_store do |store|
         call = %({"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"get_flow","arguments":{"id":9999}}})
@@ -439,33 +469,43 @@ describe Gori::MCP::RequestBuilder do
     expect_raises(Gori::Error) { Gori::MCP::RequestBuilder.build(args) }
   end
 
+  it "raises a clean Gori::Error (not a leaked URI::Error) for a malformed authority" do
+    args = JSON.parse(%({"url":"https://h.test:abc/"})).as_h
+    expect_raises(Gori::Error, /invalid url/) { Gori::MCP::RequestBuilder.build(args) }
+  end
+
+  it "rejects an out-of-range port instead of dialing a doomed connect" do
+    args = JSON.parse(%({"url":"https://h.test:99999/"})).as_h
+    expect_raises(Gori::Error, /invalid port/) { Gori::MCP::RequestBuilder.build(args) }
+  end
+
   describe "structured-path injection guards" do
     it "rejects CR/LF in a header value (header injection)" do
-      args = {"url" => JSON::Any.new("http://h.test/"),
+      args = {"url"     => JSON::Any.new("http://h.test/"),
               "headers" => JSON::Any.new({"X-Inj" => JSON::Any.new("a\r\nX-Evil: 1")})}
       expect_raises(Gori::Error, /header.*X-Inj/) { Gori::MCP::RequestBuilder.build(args) }
     end
 
     it "rejects a bare LF in a header value (lenient origins split on LF)" do
-      args = {"url" => JSON::Any.new("http://h.test/"),
+      args = {"url"     => JSON::Any.new("http://h.test/"),
               "headers" => JSON::Any.new({"X-LF" => JSON::Any.new("a\nX-Evil: 1")})}
       expect_raises(Gori::Error) { Gori::MCP::RequestBuilder.build(args) }
     end
 
     it "rejects CR/LF in a header name" do
-      args = {"url" => JSON::Any.new("http://h.test/"),
+      args = {"url"     => JSON::Any.new("http://h.test/"),
               "headers" => JSON::Any.new({"X-A\r\nX-S" => JSON::Any.new("1")})}
       expect_raises(Gori::Error, /header name/) { Gori::MCP::RequestBuilder.build(args) }
     end
 
     it "rejects an empty header name" do
-      args = {"url" => JSON::Any.new("http://h.test/"),
+      args = {"url"     => JSON::Any.new("http://h.test/"),
               "headers" => JSON::Any.new({"" => JSON::Any.new("v")})}
       expect_raises(Gori::Error, /empty/) { Gori::MCP::RequestBuilder.build(args) }
     end
 
     it "rejects whitespace/CRLF in the method (request-line forgery)" do
-      args = {"url" => JSON::Any.new("http://h.test/"),
+      args = {"url"    => JSON::Any.new("http://h.test/"),
               "method" => JSON::Any.new("GET /admin HTTP/1.1\r\nHost: a")}
       expect_raises(Gori::Error, /method/) { Gori::MCP::RequestBuilder.build(args) }
     end
@@ -480,16 +520,16 @@ describe Gori::MCP::RequestBuilder do
     it "rejects a whitespace-padded header name (framing-dedup evasion)" do
       # A leading space dodges the case-insensitive Content-Length dedup, so the
       # auto length would be appended too — two conflicting lengths on the wire.
-      args = {"url" => JSON::Any.new("http://h.test/"),
-              "method" => JSON::Any.new("POST"),
-              "body" => JSON::Any.new("abc"),
+      args = {"url"     => JSON::Any.new("http://h.test/"),
+              "method"  => JSON::Any.new("POST"),
+              "body"    => JSON::Any.new("abc"),
               "headers" => JSON::Any.new({" Content-Length" => JSON::Any.new("0")})}
       expect_raises(Gori::Error, /header name/) { Gori::MCP::RequestBuilder.build(args) }
     end
 
     it "still allows a custom method and internal spaces in a header VALUE" do
-      args = {"url" => JSON::Any.new("http://h.test/"),
-              "method" => JSON::Any.new("propfind"),
+      args = {"url"     => JSON::Any.new("http://h.test/"),
+              "method"  => JSON::Any.new("propfind"),
               "headers" => JSON::Any.new({"X-Note" => JSON::Any.new("hello world ok")})}
       out = String.new(Gori::MCP::RequestBuilder.build(args).bytes)
       out.should start_with("PROPFIND / HTTP/1.1\r\n")

--- a/src/gori/mcp/request_builder.cr
+++ b/src/gori/mcp/request_builder.cr
@@ -17,7 +17,16 @@ module Gori
         url = args["url"]?.try(&.as_s?)
         raise Gori::Error.new("'url' is required") if url.nil? || url.empty?
 
-        uri = URI.parse(url)
+        # URI.parse raises URI::Error on a malformed authority (e.g. a non-numeric
+        # port "example.com:abc"); turn that into a clean Gori::Error so the caller
+        # gets an actionable message instead of send_request's generic "tool error:"
+        # leaking the parser's internal "bad port at character N".
+        uri =
+          begin
+            URI.parse(url)
+          rescue ex : URI::Error
+            raise Gori::Error.new("invalid url #{url.inspect}: #{ex.message}")
+          end
         scheme = (uri.scheme || "http").downcase
         raise Gori::Error.new("unsupported scheme: #{scheme} (only http/https)") unless scheme.in?("http", "https")
         host = uri.host
@@ -29,6 +38,10 @@ module Gori
         # Host line).
         reject_token_breakers(host, "url host")
         port = uri.port || default_port(scheme)
+        # URI.parse accepts any digit run as a port (it doesn't range-check), so an
+        # out-of-range ":99999" would otherwise reach the dialer as a doomed connect.
+        # Reject it up front with a clean message (a valid TCP port is 1..65535).
+        raise Gori::Error.new("invalid port #{port} in url (expected 1..65535)") unless 1 <= port <= 65535
 
         bytes =
           if (raw = args["raw"]?.try(&.as_s?)) && !raw.empty?

--- a/src/gori/mcp/serialize.cr
+++ b/src/gori/mcp/serialize.cr
@@ -55,11 +55,13 @@ module Gori
       end
 
       # --- full detail incl. heads + decoded bodies ---------------------------
-      def self.flow_detail_json(detail : Store::FlowDetail) : String
-        JSON.build { |j| flow_detail(j, detail) }
+      def self.flow_detail_json(detail : Store::FlowDetail,
+                                ws_msgs : Array(Store::WsMessage) = [] of Store::WsMessage) : String
+        JSON.build { |j| flow_detail(j, detail, ws_msgs) }
       end
 
-      def self.flow_detail(j : JSON::Builder, detail : Store::FlowDetail) : Nil
+      def self.flow_detail(j : JSON::Builder, detail : Store::FlowDetail,
+                           ws_msgs : Array(Store::WsMessage) = [] of Store::WsMessage) : Nil
         row = detail.row
         j.object do
           j.field "id", row.id
@@ -80,7 +82,44 @@ module Gori
           j.field "response_head", head_text(detail.response_head)
           emit_body(j, "response_body", detail.response_head, detail.response_body, detail.response_body_truncated?)
           emit_sse_events(j, detail)
+          emit_ws_messages(j, ws_msgs)
           emit_decoded(j, detail)
+        end
+      end
+
+      WS_MSGS_MAX    =  500 # cap WS messages serialised for an LLM client
+      WS_PAYLOAD_MAX = 4096 # cap each text frame's payload (chars)
+
+      # A WebSocket flow (status 101) carries a separate message log the heads/bodies
+      # don't show. Mirror the `gori run show` WS pane, bounded for LLM use: text
+      # frames inline their (clipped) payload, binary frames report a size only.
+      # `count` is the true total; `messages` is the first WS_MSGS_MAX of them.
+      def self.emit_ws_messages(j : JSON::Builder, msgs : Array(Store::WsMessage)) : Nil
+        return if msgs.empty?
+        j.field "ws_messages" do
+          j.object do
+            j.field "count", msgs.size
+            j.field "truncated", msgs.size > WS_MSGS_MAX
+            j.field "messages" do
+              j.array do
+                msgs.first(WS_MSGS_MAX).each do |m|
+                  j.object do
+                    j.field "direction", m.direction
+                    j.field "opcode", m.opcode
+                    if m.text?
+                      s = String.new(m.payload).scrub
+                      cut = s.size > WS_PAYLOAD_MAX
+                      j.field "text", cut ? s[0, WS_PAYLOAD_MAX] : s
+                      j.field "text_truncated", true if cut
+                    else
+                      j.field "binary", true
+                      j.field "size", m.payload.size
+                    end
+                  end
+                end
+              end
+            end
+          end
         end
       end
 

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -310,7 +310,10 @@ module Gori
         return Result.new(id_error(h, "id"), is_error: true) unless id
         detail = @store.get_flow(id)
         return Result.new("no flow with id #{id}", is_error: true) unless detail
-        Result.new(Serialize.flow_detail_json(detail))
+        # A WebSocket flow (101) carries a separate message log; fetch it so get_flow
+        # surfaces the frames (parity with `gori run show`). Non-WS flows skip the query.
+        ws_msgs = detail.row.status == 101 ? @store.ws_messages(id) : [] of Store::WsMessage
+        Result.new(Serialize.flow_detail_json(detail, ws_msgs))
       end
 
       private def list_sitemap(h) : Result


### PR DESCRIPTION
## Summary

A test pass over `gori run` and `gori mcp` (both exercised end-to-end) surfaced two issues in the MCP server, both fixed here.

### 1. `send_request` leaked internal errors on malformed URLs (robustness)
A URL with a malformed authority (e.g. `https://h.test:abc/`) made `URI.parse` raise, which fell through to `call()`'s generic wrapper and returned `tool error: Invalid URI: bad port at character 20` — not actionable for an AI client. An out-of-range port (`:99999`) also wasn't checked, so it reached the dialer as a doomed connect. The CLI's `Replay::FlowRequest.parse_target` already rescued these; `RequestBuilder` did not.

`RequestBuilder.build` now wraps `URI.parse` → re-raises a clean `Gori::Error` (`invalid url "…": …`) and range-checks the resolved port (`1..65535`).

### 2. `get_flow` omitted WebSocket messages (feature parity)
`gori run show` prints the WS frame log for a 101 flow, but `get_flow` surfaced none of it — an AI client analyzing a WebSocket flow saw zero frames. `get_flow` now fetches `ws_messages` for status-101 flows and emits a bounded object:

```json
"ws_messages": { "count": 3, "truncated": false,
  "messages": [ {"direction":"out","opcode":1,"text":"…"},
                {"direction":"in","opcode":2,"binary":true,"size":3} ] }
```

LLM-bounded: cap 500 frames / 4096 chars per text frame; binary frames report size only (no inlined payload). Non-WS flows are unchanged (no query, no `ws_messages` key).

## Tests
- +4 specs in `spec/mcp_spec.cr` (2 WS `get_flow`, 2 malformed-URL/port).
- Full suite: **1189 examples, 0 failures**; `crystal tool format` + `ameba` clean on changed files.
- Verified live over stdio (clean error messages; normal `get_flow` unaffected).