### PR TITLE
style(tui): unify command palette labels to "Category: Action"

### DIFF
--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -143,7 +143,7 @@ module Gori
       edit = false
       parser = OptionParser.new do |p|
         p.banner = "Usage: gori settings [--edit]"
-        p.on("--edit", "Open the settings file in your editor (settings:editor / $VISUAL / $EDITOR / vi)") { edit = true }
+        p.on("--edit", "Open the settings file in your editor (Settings: Editor / $VISUAL / $EDITOR / vi)") { edit = true }
         p.on("-h", "--help", "Show this help") { puts p; exit 0 }
         p.invalid_option { |flag| abort "unknown option: #{flag}\n#{p}" }
         p.missing_option { |flag| abort "missing value for #{flag}" }

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -22,14 +22,14 @@ module Gori::Tui
         {"^B", "reveal whitespace (·→␍␊)"},
         {"^D / ^C ×2", "quit gori"},
         {"q", "back to projects (on the tab bar)"},
-        {"settings:hotkeys", "rebind any shortcut below (^P → settings:hotkeys)"},
+        {"Settings: Hotkeys", "rebind any shortcut below (^P → Settings: Hotkeys)"},
       ]},
       {"TABS & FOCUS", [
         {"←/→", "switch tab (on the tab bar)"},
         {"↹ / ⇧↹", "focus ring: tab bar ↔ panes"},
         {"↵ / ↓", "enter the tab body"},
         {"1-9", "jump to the Nth visible tab"},
-        {"settings:tabs", "show/hide + reorder tabs"},
+        {"Settings: Tabs", "show/hide + reorder tabs"},
         {"esc", "pop back to the tab bar"},
       ]},
       {"MOUSE", [
@@ -108,7 +108,7 @@ module Gori::Tui
       {"OVERLAYS", [
         {"palette / settings", "↑/↓ · ↵ · esc"},
         {"confirm", "←/→ choose · y / n · ↵"},
-        {"settings:editor", "toggle mouse support (Mouse field)"},
+        {"Settings: Editor", "toggle mouse support (Mouse field)"},
       ]},
     ]
 

--- a/src/gori/tui/setup_wizard.cr
+++ b/src/gori/tui/setup_wizard.cr
@@ -422,7 +422,7 @@ module Gori::Tui
       fy = box.y + 4
       render_field(screen, box, fy, "Bind IP", @ip, @bind_field == :ip)
       render_field(screen, box, fy + 1, "Bind Port", @port, @bind_field == :port)
-      screen.text(ix, fy + 3, "Default 127.0.0.1:8070 — change later in settings:network.", Theme.muted, Theme.panel, width: iw)
+      screen.text(ix, fy + 3, "Default 127.0.0.1:8070 — change later in Settings: Network.", Theme.muted, Theme.panel, width: iw)
       if st = @status
         screen.text(ix, fy + 4, "• #{st}", Theme.yellow, Theme.panel, width: iw)
       end
@@ -563,7 +563,7 @@ module Gori::Tui
       recap(screen, box, ix, y, "AI provider", @ai_interested ? "interested (coming soon)" : "not now"); y += 2
       screen.text(ix, y, "Change anytime from the command palette (^P):", Theme.muted, Theme.panel, width: {box.w - 6, 1}.max)
       y += 1
-      screen.text(ix, y, "settings:network · settings:theme", Theme.text, Theme.panel, width: {box.w - 6, 1}.max)
+      screen.text(ix, y, "Settings: Network · Settings: Theme", Theme.text, Theme.panel, width: {box.w - 6, 1}.max)
     end
 
     private def recap(screen : Screen, box : Rect, ix : Int32, y : Int32, key : String, value : String) : Nil

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -69,22 +69,22 @@ module Gori
       # Settings (config control) — palette-only. network/editor/theme are
       # implemented; hotkeys is registered for discoverability (shown "soon") + a TODO toast.
       r.register Verb::Definition.new(
-        "settings.network", "settings:network", "Edit the proxy bind address + upstream proxy",
+        "settings.network", "Settings: Network", "Edit the proxy bind address + upstream proxy",
         Verb::Scope::Global, category: Verb::Category::Settings) { |ctx| ctx.open_settings(:network); nil }
       r.register Verb::Definition.new(
-        "settings.editor", "settings:editor", "Set the external editor opened by ^E in editable fields",
+        "settings.editor", "Settings: Editor", "Set the external editor opened by ^E in editable fields",
         Verb::Scope::Global, category: Verb::Category::Settings) { |ctx| ctx.open_settings(:editor); nil }
       r.register Verb::Definition.new(
-        "settings.theme", "settings:theme", "Switch the TUI colour theme (built-ins + your own from ~/.gori/themes/*.json)",
+        "settings.theme", "Settings: Theme", "Switch the TUI colour theme (built-ins + your own from ~/.gori/themes/*.json)",
         Verb::Scope::Global, category: Verb::Category::Settings) { |ctx| ctx.open_settings(:theme); nil }
       r.register Verb::Definition.new(
-        "settings.tabs", "settings:tabs", "Customize the top tab bar — show/hide tabs and reorder them",
+        "settings.tabs", "Settings: Tabs", "Customize the top tab bar — show/hide tabs and reorder them",
         Verb::Scope::Global, category: Verb::Category::Settings) { |ctx| ctx.open_settings(:tabs); nil }
       r.register Verb::Definition.new(
-        "settings.host-overrides", "settings:hostnames", "Edit global hostname overrides — a /etc/hosts mapping hosts to IPs the proxy dials",
+        "settings.host-overrides", "Settings: Hostnames", "Edit global hostname overrides — a /etc/hosts mapping hosts to IPs the proxy dials",
         Verb::Scope::Global, category: Verb::Category::Settings) { |ctx| ctx.open_settings(:hosts); nil }
       r.register Verb::Definition.new(
-        "settings.hotkeys", "settings:hotkeys", "Rebind keyboard shortcuts (press a key) + pick an OS default profile",
+        "settings.hotkeys", "Settings: Hotkeys", "Rebind keyboard shortcuts (press a key) + pick an OS default profile",
         Verb::Scope::Global, category: Verb::Category::Settings) { |ctx| ctx.open_settings(:hotkeys); nil }
 
       # `s` toggles the scope lens from anywhere (its original behavior — this used to jump to

--- a/src/gori/verbs/import.cr
+++ b/src/gori/verbs/import.cr
@@ -4,13 +4,13 @@ module Gori
   module Verbs
     def self.register_import(r : Verb::Registry) : Nil
       r.register Verb::Definition.new(
-        "import.har", "import:har", "Import HTTP flows from a HAR file into History",
+        "import.har", "Import: HAR", "Import HTTP flows from a HAR file into History",
         Verb::Scope::Global, category: Verb::Category::Action) { |ctx| ctx.import_har; nil }
       r.register Verb::Definition.new(
-        "import.urls", "import:urls", "Import URLs from a text file into History (one URL per line)",
+        "import.urls", "Import: URLs", "Import URLs from a text file into History (one URL per line)",
         Verb::Scope::Global, category: Verb::Category::Action) { |ctx| ctx.import_urls; nil }
       r.register Verb::Definition.new(
-        "import.oas", "import:oas", "Import request templates from an OpenAPI spec into History",
+        "import.oas", "Import: OpenAPI", "Import request templates from an OpenAPI spec into History",
         Verb::Scope::Global, category: Verb::Category::Action) { |ctx| ctx.import_oas; nil }
     end
   end


### PR DESCRIPTION
## What

The command palette (^P) mixed two label styles:

- **179** Title Case natural-language verbs — `Go to Project`, `Toggle capture`, `Run fuzz`, …
- **9** colon-lowercase config-key labels — `settings:network`, `import:har`, …

The colon style read like a config key rather than a palette action and was the odd minority. This folds those 9 outliers into the majority using the VS Code palette **`Category: Action`** form, which keeps prefix grouping/search while matching the Title Case convention.

## Label changes

| Before | After |
|--------|-------|
| `settings:network` / `editor` / `theme` / `tabs` / `hostnames` / `hotkeys` | `Settings: Network` / `Editor` / `Theme` / `Tabs` / `Hostnames` / `Hotkeys` |
| `import:har` / `urls` / `oas` | `Import: HAR` / `URLs` / `OpenAPI` |

Only the `Verb::Definition` `title` field (the palette display label) changed — ids, chords, and menu keys are untouched.

## Also updated

User-facing strings that referenced the old labels, so palette search still finds them:

- Help tab rows (`help_view.cr`)
- Setup wizard hints (`setup_wizard.cr`)
- `gori settings --edit` option help (`cli.cr`)

Code comments that reference the sections conceptually are left as-is (no render impact, minimal diff).

## Test

`crystal spec` — 1189 examples, 0 failures.