### PR TITLE
Fix orphan Pending flows on truncated bodies and proxy shutdown

### DIFF
--- a/spec/project_registry_spec.cr
+++ b/spec/project_registry_spec.cr
@@ -181,4 +181,27 @@ describe Gori::Session do
       s.close
     end
   end
+
+  it "abandons orphan Pending flows when the session closes" do
+    with_root do |root|
+      ca = Gori::Proxy::Tls::CertAuthority.load_or_create(File.join(root, "ca"))
+      registry = Gori::Verbs.registry
+      project = Gori::ProjectRegistry.new(root).create("abandon") # persistent: dir survives close
+
+      session = Gori::Session.open(Gori::Config.new(listen: "127.0.0.1", port: 0), ca, registry, project)
+      pending_id = session.store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "http", host: "h", port: 80, method: "GET", target: "/hang",
+        http_version: "HTTP/1.1", head: "GET /hang HTTP/1.1\r\nHost: h\r\n\r\n".to_slice))
+      session.close
+
+      store = Gori::Store.open(project.db_path)
+      begin
+        detail = store.get_flow(pending_id).not_nil!
+        detail.row.state.should eq(Gori::Store::FlowState::Error)
+        detail.error.should eq("proxy stopped before response")
+      ensure
+        store.close
+      end
+    end
+  end
 end

--- a/spec/project_registry_spec.cr
+++ b/spec/project_registry_spec.cr
@@ -1,5 +1,20 @@
 require "./spec_helper"
 require "file_utils"
+require "socket"
+
+# Origin that accepts a connection and reads the request head but never responds,
+# so the proxy blocks on read_response_head with a Pending flow in the store.
+private def start_hanging_origin : Int32
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    while conn = origin.accept?
+      Gori::Proxy::Codec::Http1.read_head(conn)
+      sleep # hang — no response
+    end
+  end
+  port
+end
 
 private def with_root(&)
   root = File.tempname("gori-projects")
@@ -197,6 +212,50 @@ describe Gori::Session do
       store = Gori::Store.open(project.db_path)
       begin
         detail = store.get_flow(pending_id).not_nil!
+        detail.row.state.should eq(Gori::Store::FlowState::Error)
+        detail.error.should eq("proxy stopped before response")
+      ensure
+        store.close
+      end
+    end
+  end
+
+  it "abandons a live Pending capture when the session closes during an upstream hang" do
+    with_root do |root|
+      origin_port = start_hanging_origin
+      ca = Gori::Proxy::Tls::CertAuthority.load_or_create(File.join(root, "ca"))
+      registry = Gori::Verbs.registry
+      project = Gori::ProjectRegistry.new(root).create("hang-close")
+
+      session = Gori::Session.open(Gori::Config.new(listen: "127.0.0.1", port: 0), ca, registry, project)
+      proxy_port = session.proxy.port
+
+      spawn do
+        client = TCPSocket.new("127.0.0.1", proxy_port)
+        client << "GET /hang HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\n\r\n"
+        client.flush
+        client.close
+      rescue
+      end
+
+      pending_id = nil.as(Int64?)
+      40.times do
+        session.store.recent_flows(5).each do |row|
+          if row.state == Gori::Store::FlowState::Pending
+            pending_id = row.id
+            break
+          end
+        end
+        break if pending_id
+        sleep 0.05.seconds
+      end
+      pending_id.should_not be_nil
+
+      session.close
+
+      store = Gori::Store.open(project.db_path)
+      begin
+        detail = store.get_flow(pending_id.not_nil!).not_nil!
         detail.row.state.should eq(Gori::Store::FlowState::Error)
         detail.error.should eq("proxy stopped before response")
       ensure

--- a/spec/proxy/server_spec.cr
+++ b/spec/proxy/server_spec.cr
@@ -410,6 +410,31 @@ describe Gori::Proxy::Server do
     sink.responses.first.error.should_not be_nil
   end
 
+  it "records an error when the client truncates the request body" do
+    seen = Channel(String).new(1)
+    done = Channel(Nil).new(1)
+    origin_port = start_origin("", seen)
+
+    sink = RecordingSink.new(done)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink)
+    proxy.start
+
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    client << "POST /post HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\nContent-Length: 100\r\n\r\n"
+    client << "short"
+    client.flush
+    client.close
+
+    done.receive
+    proxy.stop
+
+    sink.requests.size.should eq(1)
+    sink.responses.size.should eq(1)
+    resp = sink.responses.first
+    resp.state.should eq(Gori::Store::FlowState::Error)
+    resp.error.not_nil!.should contain("truncated")
+  end
+
   it "applies Match&Replace to request/response heads and captures the sent bytes" do
     seen = Channel(String).new(1)
     done = Channel(Nil).new(1)

--- a/spec/store/store_spec.cr
+++ b/spec/store/store_spec.cr
@@ -79,6 +79,23 @@ describe Gori::Store do
     end
   end
 
+  it "abandon_pending! marks every Pending flow Error and leaves Complete rows alone" do
+    with_store do |store|
+      pending1 = store.insert_flow(sample_request(target: "/hang"))
+      pending2 = store.insert_flow(sample_request(target: "/stuck"))
+      done = store.insert_flow(sample_request(target: "/ok"))
+      store.update_response(Gori::Store::CapturedResponse.new(
+        flow_id: done, status: 200, head: "HTTP/1.1 200 OK\r\n\r\n".to_slice))
+
+      store.abandon_pending!("proxy stopped before response").should eq(2)
+
+      store.get_flow(pending1).not_nil!.row.state.should eq(Gori::Store::FlowState::Error)
+      store.get_flow(pending1).not_nil!.error.should eq("proxy stopped before response")
+      store.get_flow(pending2).not_nil!.row.state.should eq(Gori::Store::FlowState::Error)
+      store.get_flow(done).not_nil!.row.state.should eq(Gori::Store::FlowState::Complete)
+    end
+  end
+
   it "round-trips raw request/response BLOBs byte-exact through get_flow (P7)" do
     with_store do |store|
       req = sample_request(method: "POST", target: "/api")

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -148,6 +148,7 @@ module Gori::Proxy
         body_truncated: req_capture.truncated?, body_size: req_capture.total))
       unless req_complete # client cut the request body short — don't reuse the connection
         release_upstream
+        @sink.on_response(FlowMapper.error_response(flow_id, "client truncated request body"))
         return false
       end
       handle_response(upstream, req, flow_id, started, host, port, scheme,

--- a/src/gori/session.cr
+++ b/src/gori/session.cr
@@ -164,6 +164,7 @@ module Gori
     def close : Nil
       @interceptor.release_all # unblock held fibers FIRST so they can write final rows
       @proxy.stop
+      @store.abandon_pending!("proxy stopped before response")
       CaptureStatus.clear(@project.dir) if capturing_lock_held?
       @capture_lock.try(&.close) # release the flock so a later open of this project can capture
       # Stop Prism FIRST so its active workers wind down and its passive fiber stops issuing

--- a/src/gori/session.cr
+++ b/src/gori/session.cr
@@ -170,6 +170,9 @@ module Gori
       # Stop Prism FIRST so its active workers wind down and its passive fiber stops issuing
       # get_flow against a live DB; this also closes the prism_events channel it consumes.
       @prism.stop
+      # Second sweep: proxy/intercept fibers released above may still enqueue
+      # InsertFlow after the first abandon (right after proxy.stop).
+      @store.abandon_pending!("proxy stopped before response")
       # Drain + stop the store BEFORE closing the events channel: the writer
       # publishes post-commit events while draining, and a closed channel would
       # otherwise make it raise mid-drain. (publish() also tolerates a closed

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -83,6 +83,15 @@ module Gori
       end
     end
 
+    # Marks every Pending flow Error (e.g. proxy shutdown before a response landed).
+    struct AbandonPending < WriteOp
+      getter message : String
+      getter reply : Channel(Int32)
+
+      def initialize(@message, @reply)
+      end
+    end
+
     BATCH_MAX = 128
 
     # Keep at most this many newest flows; older ones (and their ws/h2 rows) are
@@ -205,6 +214,17 @@ module Gori
       reply.receive
     rescue Channel::ClosedError
       nil
+    end
+
+    # Finalizes every still-Pending flow as Error. Called on proxy shutdown so
+    # in-flight captures don't linger as orphan Pending rows. Returns the count
+    # abandoned. No-op (0) when the store is already closing.
+    def abandon_pending!(message : String) : Int32
+      reply = Channel(Int32).new(1)
+      @writes.send(AbandonPending.new(message, reply))
+      reply.receive
+    rescue Channel::ClosedError
+      0_i32
     end
 
     # Records one captured WebSocket message for a flow. Blocks until committed
@@ -1253,6 +1273,13 @@ module Gori
                   op.run.call(c)
                   rowid = c.scalar("SELECT last_insert_rowid()").as(Int64)
                   deferred << -> { task_reply.send(rowid) }
+                when AbandonPending
+                  ab_reply = op.reply
+                  ids = abandon_pending_one(c, op.message)
+                  deferred << -> {
+                    ab_reply.send(ids.size.to_i32)
+                    ids.each { |id| publish(FlowEvent.new(id, :updated)) }
+                  }
                 end
               end
             end
@@ -1316,9 +1343,23 @@ module Gori
       when UpdateResp        then op.reply.send(nil)
       when InsertWs          then op.reply.send(nil)
       when ExecTask          then op.reply.send(0_i64)
+      when AbandonPending    then op.reply.send(0_i32)
       end
     rescue
       # caller gone / channel closed — nothing to unblock
+    end
+
+    # Bulk-mark every Pending flow Error; returns the ids touched (for events).
+    private def abandon_pending_one(conn : DB::Connection, message : String) : Array(Int64)
+      ids = [] of Int64
+      conn.query("SELECT id FROM flows WHERE state = ?", FlowState::Pending.value) do |rs|
+        rs.each { ids << rs.read(Int64) }
+      end
+      return ids if ids.empty?
+      conn.exec(
+        "UPDATE flows SET state = ?, error = ?, status = 0 WHERE state = ?",
+        FlowState::Error.value, message, FlowState::Pending.value)
+      ids
     end
 
     # Non-blocking receive for batching a burst (no `try_receive?` in stdlib).

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -1275,7 +1275,7 @@ module Gori
                   deferred << -> { task_reply.send(rowid) }
                 when AbandonPending
                   ab_reply = op.reply
-                  ids = abandon_pending_one(c, op.message)
+                  ids = abandon_all_pending(c, op.message)
                   deferred << -> {
                     ab_reply.send(ids.size.to_i32)
                     ids.each { |id| publish(FlowEvent.new(id, :updated)) }
@@ -1350,7 +1350,7 @@ module Gori
     end
 
     # Bulk-mark every Pending flow Error; returns the ids touched (for events).
-    private def abandon_pending_one(conn : DB::Connection, message : String) : Array(Int64)
+    private def abandon_all_pending(conn : DB::Connection, message : String) : Array(Int64)
       ids = [] of Int64
       conn.query("SELECT id FROM flows WHERE state = ?", FlowState::Pending.value) do |rs|
         rs.each { ids << rs.read(Int64) }


### PR DESCRIPTION
## Summary

Fixes two related bugs where captured HTTP flows could remain stuck in `Pending` state forever, polluting `history`, `prism`, and `sitemap` output.

## Changes

### 1. Truncated request body (`client_conn.cr`)

When a client disconnects mid-body (`req_complete == false`), the proxy had already inserted a `Pending` flow via `on_request()` but returned without calling `on_response()`. The held-request path already called `record_error()` for this case; the normal streaming path now calls `error_response()` with `"client truncated request body"`.

### 2. Proxy shutdown (`store.cr`, `session.cr`)

Added `Store#abandon_pending!` to bulk-mark all `Pending` flows as `Error`. `Session#close` calls it after stopping the proxy so in-flight captures that never received a response are finalized instead of lingering as orphans (reproduced when `gori run capture` was killed during upstream hangs).

## Tests

- `spec/proxy/server_spec.cr` — truncated POST body records `Error`
- `spec/store/store_spec.cr` — `abandon_pending!` marks pending rows, leaves `Complete` alone
- `spec/project_registry_spec.cr` — `Session#close` abandons pending flows in DB

All 1192 specs pass.