### PR TITLE
Improve gori MCP for AI clients

### DIFF
--- a/spec/mcp_fuzz_spec.cr
+++ b/spec/mcp_fuzz_spec.cr
@@ -82,6 +82,20 @@ describe "MCP fuzz tools" do
     end
   end
 
+  it "accepts payloads as a JSON array (not only a JSON string)" do
+    port = start_origin
+    with_store do |store|
+      tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+      args = {
+        "template" => "GET /?q=§x§ HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+        "url"      => "http://127.0.0.1:#{port}",
+        "payloads" => [{"list" => ["only"]}],
+      }.to_json
+      start = call_json(tools, "fuzz_start", args)
+      start["total"].as_i.should eq(1)
+    end
+  end
+
   it "rejects bad args, and gates the tool under --read-only" do
     with_store do |store|
       tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -131,6 +131,33 @@ describe Gori::MCP::Server do
   end
 
   describe "list_history" do
+    it "rejects a QL query that compiles to nothing (not match-all)" do
+      with_store do |store|
+        seed_flow(store, "ex.test", "GET", "/", 200)
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_history","arguments":{"query":"status:>=foo"}}})
+        resp = drive(store, call)[0]
+        resp["result"]["isError"].as_bool.should be_true
+        resp["result"]["content"][0]["text"].as_s.should contain("invalid query")
+        store.count.should eq(1) # didn't silently dump every flow
+      end
+    end
+
+    it "paginates filtered results with before_id" do
+      with_store do |store|
+        a = seed_flow(store, "h.test", "GET", "/a", 500)
+        b = seed_flow(store, "h.test", "GET", "/b", 500)
+        c = seed_flow(store, "h.test", "GET", "/c", 200)
+
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_history","arguments":{"query":"status:500","limit":1}}})
+        page1 = tool_payload(drive(store, call)[0]).as_a
+        page1.map(&.["id"].as_i64).should eq([b])
+
+        cur = %({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_history","arguments":{"query":"status:500","limit":1,"before_id":#{b}}}})
+        page2 = tool_payload(drive(store, cur)[0]).as_a
+        page2.map(&.["id"].as_i64).should eq([a])
+      end
+    end
+
     it "returns flows newest-first, filters by QL, and paginates by before_id" do
       with_store do |store|
         a = seed_flow(store, "alpha.test", "GET", "/a", 200)
@@ -349,7 +376,39 @@ describe Gori::MCP::Server do
     end
   end
 
+  describe "ql_reference" do
+    it "returns the QL syntax reference" do
+      with_store do |store|
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"ql_reference","arguments":{}}})
+        ref = tool_payload(drive(store, call)[0])["reference"].as_s
+        ref.should contain("host:example.com")
+        ref.should contain("status:>=500")
+      end
+    end
+  end
+
+  describe "project_info" do
+    it "includes project metadata fields" do
+      with_store do |store|
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"project_info","arguments":{}}})
+        info = tool_payload(drive(store, call)[0])
+        info["flows"].as_i.should eq(0)
+        info["read_only"].as_bool.should be_false
+      end
+    end
+  end
+
   describe "send_request" do
+    it "replays a captured flow via flow_id without a url" do
+      with_store do |store|
+        id = seed_flow(store, "ex.test", "GET", "/replay-me", 200)
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"send_request","arguments":{"flow_id":#{id}}}})
+        resp = drive(store, call, verify_upstream: false)[0]
+        # May fail to connect in CI, but must NOT error with 'url is required'.
+        resp["result"]["content"][0]["text"].as_s.should_not contain("'url' is required")
+      end
+    end
+
     it "returns isError on a connection failure (port 1)" do
       with_store do |store|
         call = %({"jsonrpc":"2.0","id":12,"method":"tools/call","params":{"name":"send_request","arguments":{"url":"http://127.0.0.1:1/"}}})

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -110,6 +110,8 @@ describe Gori::MCP::Server do
         names = full.map(&.["name"].as_s)
         names.should contain("list_history")
         names.should contain("get_flow")
+        names.should contain("ql_reference")
+        names.should contain("project_info")
         names.should contain("send_request")
         names.should contain("create_finding")
         names.should contain("update_finding")
@@ -419,7 +421,31 @@ describe Gori::MCP::Server do
     end
   end
 
+  describe "list_findings" do
+    it "returns a paginated object (not a bare array)" do
+      with_store do |store|
+        store.insert_finding("a", Gori::Store::Severity::Info, nil, nil)
+        store.insert_finding("b", Gori::Store::Severity::High, nil, nil)
+        store.flush
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_findings","arguments":{"limit":1,"offset":1}}})
+        payload = tool_payload(drive(store, call)[0])
+        payload.as_h.has_key?("findings").should be_true
+        payload["returned"].as_i.should eq(1)
+        payload["offset"].as_i.should eq(1)
+        payload["total"].as_i.should eq(2)
+      end
+    end
+  end
+
   describe "error channels" do
+    it "returns -32600 with echoed id when method is missing" do
+      with_store do |store|
+        out = drive(store, %({"jsonrpc":"2.0","id":"req-1"}))
+        out[0]["error"]["code"].as_i.should eq(-32600)
+        out[0]["id"].as_s.should eq("req-1")
+      end
+    end
+
     it "answers a parse error with id null and keeps serving" do
       with_store do |store|
         out = drive(store, "{not json", %({"jsonrpc":"2.0","id":1,"method":"ping"}))

--- a/spec/ql_spec.cr
+++ b/spec/ql_spec.cr
@@ -332,4 +332,19 @@ describe "Gori::Store#search (QL)" do
       store.search(Gori::QL.parse("dur:>=0"), 50).map(&.id).should_not contain(pending)
     end
   end
+
+  describe ".reject_empty?" do
+    it "flags a non-blank query that compiles to EMPTY" do
+      Gori::QL.reject_empty?("status:>=foo", Gori::QL.parse("status:>=foo")).should be_true
+    end
+
+    it "allows a blank query (caller handles separately)" do
+      Gori::QL.reject_empty?("  ", Gori::QL::EMPTY).should be_false
+    end
+
+    it "allows a query with at least one valid term" do
+      f = Gori::QL.parse("host:beta status:>=foo")
+      Gori::QL.reject_empty?("host:beta status:>=foo", f).should be_false
+    end
+  end
 end

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -277,8 +277,8 @@ module Gori
       Log.setup(:info, Log::IOBackend.new(STDERR))
       Settings.load # send_request's replay engines read the upstream-proxy setting from here
 
-      resolved = resolve_mcp_db(db_path, project)
-      Log.info { "mcp: serving #{resolved} (actions=#{!read_only})" }
+      resolved, project_name = resolve_mcp_db(db_path, project)
+      Log.info { "mcp: serving #{resolved}#{" (#{project_name})" if project_name} (actions=#{!read_only})" }
       # Make the implicit fallback visible (STDERR only — STDOUT is the JSON-RPC stream):
       # with no --db/--project the most-recently-used project (or the default db) is served,
       # which can silently be an empty database an AI client then queries as if it were real.
@@ -294,7 +294,8 @@ module Gori
         end
       Log.warn { "mcp: #{resolved} has no captured flows (empty database)" } if store.count.zero?
       begin
-        server = MCP::Server.new(store, allow_actions: !read_only, verify_upstream: !insecure_upstream)
+        server = MCP::Server.new(store, allow_actions: !read_only, verify_upstream: !insecure_upstream,
+          project_name: project_name, db_path: resolved)
         server.run # blocks until STDIN EOF (client closed)
       ensure
         store.close
@@ -303,13 +304,13 @@ module Gori
 
     # Resolves which project DB `gori mcp` serves: explicit --db wins, then a named
     # --project, then the most-recently-used project, then the default headless db.
-    private def self.resolve_mcp_db(db : String?, project : String?) : String
+    private def self.resolve_mcp_db(db : String?, project : String?) : {String, String?}
       if d = db
         unless d.empty? # an empty --db= falls through to project/MRU (Crystal: "" is truthy)
           # Validate like `gori run` does — else SQLite silently CREATEs a fresh empty DB on a
           # typo'd path and the client queries an empty dataset believing it's the real capture.
           abort "gori mcp: --db is not a readable file: #{d}" unless File.file?(d)
-          return d
+          return {d, nil}
         end
       end
       Paths.ensure_dirs
@@ -318,9 +319,10 @@ module Gori
         # Case-insensitive, matching `gori run` (project slugs are always lowercased).
         proj = registry.list.find { |p| p.name.downcase == name.downcase }
         abort "gori mcp: no such project: #{name}" unless proj
-        return proj.db_path
+        return {proj.db_path, proj.name}
       end
-      registry.list.first?.try(&.db_path) || Paths.default_db
+      mru = registry.list.first?
+      {mru.try(&.db_path) || Paths.default_db, mru.try(&.name)}
     end
 
     private def self.run_update(args : Array(String)) : Nil

--- a/src/gori/mcp/serialize.cr
+++ b/src/gori/mcp/serialize.cr
@@ -23,6 +23,7 @@ module Gori
         j.object do
           j.field "id", row.id
           j.field "created_at", row.created_at
+          j.field "created_at_iso", unix_micros_iso(row.created_at)
           j.field "scheme", row.scheme
           j.field "method", row.method
           j.field "host", row.host
@@ -66,6 +67,7 @@ module Gori
         j.object do
           j.field "id", row.id
           j.field "created_at", row.created_at
+          j.field "created_at_iso", unix_micros_iso(row.created_at)
           j.field "scheme", row.scheme
           j.field "method", row.method
           j.field "host", row.host
@@ -216,6 +218,14 @@ module Gori
       # JSON-RPC line.
       def self.head_text(head : Bytes?) : String?
         head ? String.new(head).scrub : nil
+      end
+
+      # RFC3339 UTC for store timestamps (unix microseconds). Helps LLM clients
+      # that can't interpret raw microsecond integers.
+      def self.unix_micros_iso(us : Int64) : String
+        sec, micro = us.divmod(1_000_000)
+        t = Time.utc(1970, 1, 1) + sec.seconds + micro.microseconds
+        t.to_s("%Y-%m-%dT%H:%M:%S.%LZ")
       end
 
       # Emits a `field_name` field carrying a decoded-body summary. nil/empty body

--- a/src/gori/mcp/serialize.cr
+++ b/src/gori/mcp/serialize.cr
@@ -173,7 +173,9 @@ module Gori
         j.object do
           j.field "id", f.id
           j.field "created_at", f.created_at
+          j.field "created_at_iso", unix_micros_iso(f.created_at)
           j.field "updated_at", f.updated_at
+          j.field "updated_at_iso", unix_micros_iso(f.updated_at)
           j.field "title", f.title
           j.field "severity", f.severity.label
           j.field "status", f.status.label

--- a/src/gori/mcp/server.cr
+++ b/src/gori/mcp/server.cr
@@ -119,7 +119,8 @@ module Gori
       private def instructions_text : String
         base = "gori MCP exposes the active project's captured HTTP traffic " \
                "(history, flows, sitemap, scope, findings). Call ql_reference before " \
-               "writing list_history/list_sitemap queries. Timestamps are unix microseconds."
+               "writing list_history/list_sitemap queries. Timestamps include unix " \
+               "microseconds plus *_iso RFC3339 fields where available."
         if @allow_actions
           "#{base} Action tools are enabled: send_request (supports flow_id replay), " \
           "fuzz_*, mine_*, and create/update_finding make real outbound requests or mutate findings."

--- a/src/gori/mcp/server.cr
+++ b/src/gori/mcp/server.cr
@@ -28,9 +28,11 @@ module Gori
       EMPTY_ARGS = JSON::Any.new({} of String => JSON::Any)
 
       def initialize(@store : Store, *, allow_actions : Bool, verify_upstream : Bool,
+                     project_name : String? = nil, db_path : String? = nil,
                      @input : IO = STDIN, @output : IO = STDOUT)
         @allow_actions = allow_actions
-        @tools = Tools.new(@store, allow_actions, verify_upstream)
+        @tools = Tools.new(@store, allow_actions, verify_upstream,
+          project_name: project_name, db_path: db_path)
         @initialized = false
       end
 
@@ -45,6 +47,7 @@ module Gori
       end
 
       private def handle_line(line : String) : Nil
+        id = nil.as(JSON::Any?)
         root = begin
           JSON.parse(line)
         rescue JSON::ParseException
@@ -70,6 +73,8 @@ module Gori
         end
       rescue ex
         Log.error(exception: ex) { "dispatch error" }
+        # Never leave a request with an id hanging — the client would block forever.
+        write_error(id, -32603, "Internal error: #{ex.message}") if id
       end
 
       private def handle_request(id : JSON::Any, method : String, params : JSON::Any?) : Nil
@@ -113,10 +118,11 @@ module Gori
       # disabled by read-only mode, rather than discovering it only on a rejected call.
       private def instructions_text : String
         base = "gori MCP exposes the active project's captured HTTP traffic " \
-               "(history, flows, sitemap, scope, findings)."
+               "(history, flows, sitemap, scope, findings). Call ql_reference before " \
+               "writing list_history/list_sitemap queries. Timestamps are unix microseconds."
         if @allow_actions
-          "#{base} Action tools are enabled: send_request, fuzz_*, mine_*, and " \
-          "create/update_finding make real outbound requests or mutate findings."
+          "#{base} Action tools are enabled: send_request (supports flow_id replay), " \
+          "fuzz_*, mine_*, and create/update_finding make real outbound requests or mutate findings."
         else
           "#{base} Read-only mode: action tools (send_request, fuzz_*, mine_*, " \
           "create/update_finding) are disabled — restart without --read-only to enable them."

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -133,7 +133,9 @@ module Gori
             s.field "limit", intprop("max entries (default 200, max 5000)")
           end
 
-          tool j, "list_findings", "List triage findings (severity + status), newest/most-severe first." do |s|
+          tool j, "list_findings",
+            "List triage findings (severity + status), newest/most-severe first. " \
+            "Returns an object {findings, returned, offset, total} — not a bare array." do |s|
             s.field "limit", intprop("max rows (default 100, max 500)")
             s.field "offset", intprop("start row (default 0)")
           end
@@ -154,6 +156,7 @@ module Gori
               "ACTIVE: makes a real outbound request from this host. Either pass " \
               "`flow_id` to replay a captured flow byte-exact, OR give an absolute " \
               "`url` with optional method/headers/body, or a verbatim `raw` request. " \
+              "When `flow_id` is set, url/method/headers/body/raw are ignored. " \
               "Host + Content-Length are auto-added when omitted on the url path." do |s|
               s.field "flow_id", intprop("replay a captured flow by id (no url needed; like TUI replay)")
               s.field "url", strprop("absolute URL incl. scheme+host, e.g. https://api.example.com/v1/x")
@@ -402,6 +405,9 @@ module Gori
             j.field "findings", @store.count_findings
             j.field "total_bytes", @store.total_size
             j.field "earliest_created_at", @store.earliest_created_at
+            if ea = @store.earliest_created_at
+              j.field "earliest_created_at_iso", Serialize.unix_micros_iso(ea)
+            end
           end
         end)
       end

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -39,7 +39,8 @@ module Gori
       MINE_MAX_CONCURRENCY =         100
       MINE_MAX_STORED      =      10_000
 
-      def initialize(@store : Store, @allow_actions : Bool, @verify_upstream : Bool)
+      def initialize(@store : Store, @allow_actions : Bool, @verify_upstream : Bool,
+                     @project_name : String? = nil, @db_path : String? = nil)
         @jobs = {} of String => FuzzJob
         @mine_jobs = {} of String => MineJob
         @job_seq = 0
@@ -107,11 +108,16 @@ module Gori
             "'header:set-cookie', 'body~secret\\d+' — `~` is regex, dur is ms); " \
             "empty query returns the most recent. Returns light rows (no bodies); " \
             "use get_flow for full detail. Paginate by passing the oldest id seen as " \
-            "`before_id` (rows are newest-first); a page shorter than `limit` means no older rows." do |s|
+            "`before_id` (rows are newest-first); a page shorter than `limit` means no older rows. " \
+            "Call ql_reference for full QL syntax." do |s|
             s.field "query", strprop("gori QL filter; empty = most recent")
             s.field "limit", intprop("max rows (default 50, max 500)")
-            s.field "before_id", intprop("cursor: only flows with id < this (pagination; ignored when query is set)")
+            s.field "before_id", intprop("cursor: only flows with id < this (pagination; works with query too)")
           end
+
+          tool j, "ql_reference",
+            "Return the gori QL (query language) syntax reference for filtering flows " \
+            "(list_history, list_sitemap). Call this before writing complex queries." { }
 
           tool j, "get_flow",
             "Full request+response for one flow id (heads + decoded bodies). " \
@@ -127,7 +133,10 @@ module Gori
             s.field "limit", intprop("max entries (default 200, max 5000)")
           end
 
-          tool j, "list_findings", "List triage findings (severity + status), newest/most-severe first." { }
+          tool j, "list_findings", "List triage findings (severity + status), newest/most-severe first." do |s|
+            s.field "limit", intprop("max rows (default 100, max 500)")
+            s.field "offset", intprop("start row (default 0)")
+          end
 
           tool j, "get_finding", "Get one finding by id." do |s|
             s.field "id", intprop("finding id"), required: true
@@ -135,20 +144,24 @@ module Gori
 
           tool j, "list_scope", "List the project's scope include/exclude rules." { }
 
-          tool j, "project_info", "Project totals: flow count, finding count, captured bytes, earliest capture time." { }
+          tool j, "project_info",
+            "Project totals: flow count, finding count, captured bytes, earliest capture time, " \
+            "plus which project/db is being served (important when no --project was passed)." { }
 
           if @allow_actions
             tool j, "send_request",
               "Send/replay an HTTP request to its origin and return the response. " \
-              "ACTIVE: makes a real outbound request from this host. Give an " \
-              "absolute `url`; optionally method/headers/body, or a verbatim `raw` " \
-              "request. Host + Content-Length are auto-added when omitted." do |s|
-              s.field "url", strprop("absolute URL incl. scheme+host, e.g. https://api.example.com/v1/x"), required: true
+              "ACTIVE: makes a real outbound request from this host. Either pass " \
+              "`flow_id` to replay a captured flow byte-exact, OR give an absolute " \
+              "`url` with optional method/headers/body, or a verbatim `raw` request. " \
+              "Host + Content-Length are auto-added when omitted on the url path." do |s|
+              s.field "flow_id", intprop("replay a captured flow by id (no url needed; like TUI replay)")
+              s.field "url", strprop("absolute URL incl. scheme+host, e.g. https://api.example.com/v1/x")
               s.field "method", strprop("HTTP method (default GET)")
               s.field "headers", objprop("header name->value map")
               s.field "body", strprop("request body, sent as-is")
               s.field "raw", strprop("verbatim raw HTTP/1.1 request; overrides method/headers/body (scheme/host/port still come from url)")
-              s.field "http2", boolprop("use real HTTP/2 (default false)")
+              s.field "http2", boolprop("use real HTTP/2; defaults to the flow's version when flow_id is set)")
               s.field "insecure", boolprop("skip upstream TLS verification (default false)")
             end
 
@@ -179,9 +192,9 @@ module Gori
               s.field "url", strprop("absolute target URL (scheme+host); required unless flow_id carries one")
               s.field "auto", boolprop("auto-mark every query/cookie/body param when the template has no § markers")
               s.field "mode", strprop("sniper (default) | batteringram | pitchfork | clusterbomb")
-              s.field "payloads", strprop(%(JSON array of sets, e.g. [{"list":["a","b"]},{"numbers":"1-100"},{"wordlist":"/p.txt"},{"null":5},{"brute":"abc:1-3"}]))
-              s.field "match", strprop(%(JSON: keep only responses matching, e.g. {"status":"200,500-599","size":">1000","regex":"err"}))
-              s.field "filter", strprop(%(JSON: drop responses matching, same shape as match))
+              s.field "payloads", arrprop(%(array of payload sets, e.g. [{"list":["a","b"]},{"numbers":"1-100"},{"wordlist":"/p.txt"},{"null":5},{"brute":"abc:1-3"}] — JSON array, NOT a string))
+              s.field "match", jsonprop(%(keep only responses matching, e.g. {"status":"200,500-599","size":">1000","regex":"err"} — object or JSON string))
+              s.field "filter", jsonprop(%(drop responses matching, same shape as match — object or JSON string))
               s.field "extract", strprop("regex; grep a value (capture group 1) from each response")
               s.field "concurrency", intprop("parallel requests (default 20, max #{FUZZ_MAX_CONCURRENCY})")
               s.field "rate", intprop("requests/sec cap (0 = unlimited)")
@@ -266,10 +279,11 @@ module Gori
         when "list_history"  then list_history(h)
         when "get_flow"      then get_flow(h)
         when "list_sitemap"  then list_sitemap(h)
-        when "list_findings" then list_findings
+        when "list_findings" then list_findings(h)
         when "get_finding"   then get_finding(h)
         when "list_scope"    then list_scope
         when "project_info"  then project_info
+        when "ql_reference"  then ql_reference
         end
       end
 
@@ -295,12 +309,15 @@ module Gori
 
       private def list_history(h) : Result
         limit = clamp(int(h, "limit"), 50, 500)
+        before_id = int(h, "before_id")
         query = str(h, "query")
         rows =
           if query && !query.strip.empty?
-            @store.search(QL.parse(query), limit)
+            filter = QL.parse(query)
+            return ql_error(query) if QL.reject_empty?(query, filter)
+            @store.search(filter, limit, before_id)
           else
-            @store.recent_flows(limit, int(h, "before_id"))
+            @store.recent_flows(limit, before_id)
           end
         Result.new(JSON.build { |j| j.array { rows.each { |r| Serialize.flow_row(j, r) } } })
       end
@@ -319,7 +336,14 @@ module Gori
       private def list_sitemap(h) : Result
         limit = clamp(int(h, "limit"), 200, 5000)
         query = str(h, "query")
-        filter = query && !query.strip.empty? ? QL.parse(query) : QL::EMPTY
+        filter =
+          if query && !query.strip.empty?
+            parsed = QL.parse(query)
+            return ql_error(query) if QL.reject_empty?(query, parsed)
+            parsed
+          else
+            QL::EMPTY
+          end
         entries = @store.sitemap_entries(filter, limit)
         Result.new(JSON.build do |j|
           j.array do
@@ -330,8 +354,19 @@ module Gori
         end)
       end
 
-      private def list_findings : Result
-        Result.new(JSON.build { |j| j.array { @store.findings.each { |f| Serialize.finding(j, f, @store) } } })
+      private def list_findings(h) : Result
+        offset = clamp_nonneg(int(h, "offset"))
+        limit = clamp(int(h, "limit"), 100, 500)
+        all = @store.findings
+        page = all[offset, limit]? || [] of Store::Finding
+        Result.new(JSON.build do |j|
+          j.object do
+            j.field("findings") { j.array { page.each { |f| Serialize.finding(j, f, @store) } } }
+            j.field "returned", page.size
+            j.field "offset", offset
+            j.field "total", all.size
+          end
+        end)
       end
 
       private def get_finding(h) : Result
@@ -360,6 +395,9 @@ module Gori
       private def project_info : Result
         Result.new(JSON.build do |j|
           j.object do
+            j.field "project", @project_name
+            j.field "db_path", @db_path
+            j.field "read_only", !@allow_actions
             j.field "flows", @store.count
             j.field "findings", @store.count_findings
             j.field "total_bytes", @store.total_size
@@ -368,11 +406,21 @@ module Gori
         end)
       end
 
+      private def ql_reference : Result
+        Result.new(JSON.build { |j| j.object { j.field "reference", QL::REFERENCE } })
+      end
+
+      private def ql_error(query : String) : Result
+        Result.new(
+          "invalid query #{query.inspect}: did not match any field " \
+          "(call ql_reference; e.g. host:example.com status:>=500 method:POST)",
+          is_error: true)
+      end
+
       # --- action / write tools (gated) ---------------------------------------
 
       private def send_request(h) : Result
-        built = RequestBuilder.build(h)
-        http2 = bool(h, "http2") || false
+        built, http2 = build_send_request(h)
         verify = @verify_upstream && !(bool(h, "insecure") || false)
         result =
           if http2
@@ -389,6 +437,24 @@ module Gori
         # actionable message instead of letting call()'s generic "tool error:"
         # wrapper swallow it, matching fuzz_start's FuzzArgError handling.
         Result.new(ex.message || "invalid request arguments", is_error: true)
+      end
+
+      # Either replays a captured flow (flow_id) or builds from url/raw/method args.
+      private def build_send_request(h) : {RequestBuilder::Built, Bool}
+        if present?(h, "flow_id")
+          id = int(h, "flow_id")
+          raise Gori::Error.new(id_error(h, "flow_id")) unless id
+          detail = @store.get_flow(id)
+          raise Gori::Error.new("no flow with id #{id}") unless detail
+          flow = Replay::FlowRequest.build(detail)
+          scheme, host, port = Replay::FlowRequest.parse_target(flow.target)
+          raise Gori::Error.new("could not parse target from flow #{id}") if host.empty?
+          http2 = bool(h, "http2") || flow.http2
+          {RequestBuilder::Built.new(flow.bytes, scheme, host, port), http2}
+        else
+          built = RequestBuilder.build(h)
+          {built, bool(h, "http2") || false}
+        end
       end
 
       private def create_finding(h) : Result
@@ -762,10 +828,18 @@ module Gori
       end
 
       private def fuzz_sets(h) : Array(Fuzz::PayloadSet)
-        raw = str(h, "payloads")
-        return [] of Fuzz::PayloadSet if raw.nil? || raw.strip.empty?
-        parsed = JSON.parse(raw) rescue raise FuzzArgError.new("'payloads' must be a JSON array of sets")
-        arr = parsed.as_a? || raise FuzzArgError.new("'payloads' must be a JSON array")
+        raw = h["payloads"]?
+        return [] of Fuzz::PayloadSet unless raw
+        arr =
+          if a = raw.as_a?
+            a
+          elsif s = raw.as_s?
+            return [] of Fuzz::PayloadSet if s.strip.empty?
+            parsed = JSON.parse(s) rescue raise FuzzArgError.new("'payloads' must be a JSON array of sets")
+            parsed.as_a? || raise FuzzArgError.new("'payloads' must be a JSON array")
+          else
+            raise FuzzArgError.new("'payloads' must be a JSON array of sets (not a bare string/scalar)")
+          end
         arr.map { |spec| fuzz_set_from(spec) }
       end
 
@@ -812,14 +886,14 @@ module Gori
 
       private def fuzz_matcher(h) : Fuzz::Matcher
         m = Fuzz::Matcher.new(keep_bodies: :none)
-        if c = fuzz_conditions(str(h, "match"), "match")
+        if c = fuzz_conditions(h["match"]?, "match")
           m.match_status = c[:status]
           m.match_size = c[:size]
           m.match_words = c[:words]
           m.match_lines = c[:lines]
           m.match_regex = fuzz_regex(c[:regex], "match")
         end
-        if c = fuzz_conditions(str(h, "filter"), "filter")
+        if c = fuzz_conditions(h["filter"]?, "filter")
           m.filter_status = c[:status]
           m.filter_size = c[:size]
           m.filter_words = c[:words]
@@ -832,9 +906,17 @@ module Gori
 
       private alias FuzzConds = NamedTuple(status: String?, size: String?, words: String?, lines: String?, regex: String?)
 
-      private def fuzz_conditions(raw : String?, which : String) : FuzzConds?
-        return nil if raw.nil? || raw.strip.empty?
-        obj = (JSON.parse(raw).as_h? rescue nil) || raise FuzzArgError.new("'#{which}' must be a JSON object")
+      private def fuzz_conditions(raw : JSON::Any?, which : String) : FuzzConds?
+        return nil unless raw
+        obj =
+          if h = raw.as_h?
+            h
+          elsif s = raw.as_s?
+            return nil if s.strip.empty?
+            (JSON.parse(s).as_h? rescue nil) || raise FuzzArgError.new("'#{which}' must be a JSON object")
+          else
+            raise FuzzArgError.new("'#{which}' must be a JSON object (not a bare string/scalar)")
+          end
         {status: jstr(obj, "status"), size: jstr(obj, "size"), words: jstr(obj, "words"),
          lines: jstr(obj, "lines"), regex: obj["regex"]?.try(&.as_s?)}
       end
@@ -1002,6 +1084,15 @@ module Gori
 
       private def objprop(desc : String) : JSON::Any
         JSON.parse(%({"type":"object","description":#{desc.to_json},"additionalProperties":{"type":"string"}}))
+      end
+
+      private def arrprop(desc : String) : JSON::Any
+        JSON.parse(%({"type":"array","description":#{desc.to_json},"items":{"type":"object"}}))
+      end
+
+      # Accepts a JSON object directly or a JSON-encoded string (LLM clients vary).
+      private def jsonprop(desc : String) : JSON::Any
+        JSON.parse(%({"description":#{desc.to_json},"oneOf":[{"type":"object"},{"type":"string"}]}))
       end
 
       private def prop(type : String, desc : String) : JSON::Any

--- a/src/gori/ql.cr
+++ b/src/gori/ql.cr
@@ -28,6 +28,36 @@ module Gori
 
     EMPTY = Filter.new("1", [] of DB::Any)
 
+    # One-page reference for MCP clients / models. Kept in sync with the parser above.
+    REFERENCE = <<-DOC
+      gori QL filters captured HTTP flows (AND within a group, OR between groups):
+
+        host:example.com status:>=500 method:POST   # AND of terms
+        host:api OR status:5xx                        # OR of AND-groups
+        -host:cdn login                               # negation + free-text search
+
+      Fields (use : for value match, ~ for regex):
+        host path method scheme status size reqsize respsize dur header body url
+
+      Comparisons (status size reqsize respsize dur):
+        status:>=500  size:>10000  dur:>=500  dur:<2s  (dur defaults to ms; suffix ms|s)
+
+      Status class shorthand: status:5xx  status:4xx
+
+      Regex (~): host~^api\\.  body~secret\\d+  path~/admin
+
+      Free text (no field:): matches method, host, or target (case-insensitive substring).
+
+      Invalid syntax (e.g. status:>=foo with no numeric value) is rejected — it does NOT match all flows.
+      DOC
+
+    # A non-blank user query must compile to at least one clause. EMPTY means every
+    # token was dropped (bad field, bad numeric, invalid regex) — matching all flows,
+    # which is the opposite of what the caller asked for.
+    def self.reject_empty?(query : String, filter : Filter) : Bool
+      !query.strip.empty? && filter == EMPTY
+    end
+
     # Combines two filters with AND (used to layer the Scope lens over a query).
     def self.and(a : Filter, b : Filter) : Filter
       return b if a.sql == "1"

--- a/src/gori/ql.cr
+++ b/src/gori/ql.cr
@@ -49,6 +49,7 @@ module Gori
       Free text (no field:): matches method, host, or target (case-insensitive substring).
 
       Invalid syntax (e.g. status:>=foo with no numeric value) is rejected — it does NOT match all flows.
+      A mixed query (host:beta status:>=foo) silently drops only the bad terms and applies the rest.
       DOC
 
     # A non-blank user query must compile to at least one clause. EMPTY means every

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -1040,12 +1040,20 @@ module Gori
       rows
     end
 
-    # Newest-first flows matching a compiled QL filter.
-    def search(filter : QL::Filter, limit : Int32) : Array(FlowRow)
+    # Newest-first flows matching a compiled QL filter. `before_id` is a cursor for
+    # paging into older matches (stable as new rows append, unlike OFFSET).
+    def search(filter : QL::Filter, limit : Int32, before_id : Int64? = nil) : Array(FlowRow)
       rows = [] of FlowRow
       args = filter.args.dup
-      args << limit
-      @db.query("#{SELECT_ROW} WHERE #{filter.sql} ORDER BY id DESC LIMIT ?", args: args) do |rs|
+      if before_id
+        args << before_id
+        args << limit
+        sql = "#{SELECT_ROW} WHERE (#{filter.sql}) AND id < ? ORDER BY id DESC LIMIT ?"
+      else
+        args << limit
+        sql = "#{SELECT_ROW} WHERE #{filter.sql} ORDER BY id DESC LIMIT ?"
+      end
+      @db.query(sql, args: args) do |rs|
         rs.each { rows << read_row(rs) }
       end
       rows


### PR DESCRIPTION
## Summary

Makes `gori mcp` safer and more ergonomic for AI tool clients that drive security workflows over captured HTTP traffic.

## Changes

- **QL safety**: reject queries that compile to match-all (e.g. `status:>=foo`) instead of silently returning every flow — parity with `gori run history`.
- **`send_request` + `flow_id`**: replay a captured flow byte-exact without reconstructing URL/headers manually.
- **Pagination**: `before_id` now works together with QL `query` filters in `list_history`.
- **Discovery**: new `ql_reference` read tool; `project_info` exposes project name, db path, and read-only mode.
- **AI-friendly schemas**: fuzz `payloads`/`match`/`filter` accept native JSON objects (not only escaped strings); `list_findings` gains limit/offset.
- **Timestamps**: add `created_at_iso` (RFC3339) alongside raw microsecond integers.
- **Reliability**: `handle_line` always emits a JSON-RPC error when dispatch fails, so clients do not hang.

## Test plan

- [x] `crystal spec spec/mcp_spec.cr spec/mcp_fuzz_spec.cr` (61 examples, 0 failures)
- [x] Manual JSON-RPC drive against demo project DB