### PR TITLE
Reflect auto Content-Length in Replay request editor

### DIFF
--- a/spec/tui/replay_view_spec.cr
+++ b/spec/tui/replay_view_spec.cr
@@ -146,13 +146,41 @@ describe Gori::Tui::ReplayView do
       view = ReplayView.new
       view.load(detail)
       view.auto_content_length?.should be_true # default on
+      view.request_text.includes?("Content-Length: 5").should be_true # reflected in the editor too
       sent = String.new(view.request_bytes)
       sent.includes?("Content-Length: 5").should be_true   # recomputed to the body size
       sent.includes?("Content-Length: 99").should be_false # stale value replaced
 
-      view.toggle_auto_content_length # off → send byte-exact
-      String.new(view.request_bytes).includes?("Content-Length: 99").should be_true
+      view.toggle_auto_content_length # off → send byte-exact (the already-synced editor)
+      String.new(view.request_bytes).includes?("Content-Length: 5").should be_true
+
+      byte_exact = ReplayView.new
+      byte_exact.restore("https://h.test",
+        "POST /x HTTP/1.1\nHost: h.test\nContent-Length: 99\n\nhello", false, false)
+      String.new(byte_exact.request_bytes).includes?("Content-Length: 99").should be_true
     end
+  end
+
+  it "reflects auto Content-Length in the visible REQUEST editor (^L on)" do
+    view = ReplayView.new
+    view.restore("https://h.test",
+      "POST /x HTTP/1.1\nHost: h.test\nContent-Length: 99\n\nhello", false, false)
+    view.request_text.includes?("Content-Length: 99").should be_true
+
+    view.toggle_auto_content_length # on → resync into the editor
+    view.request_text.includes?("Content-Length: 5").should be_true
+    view.request_text.includes?("Content-Length: 99").should be_false
+  end
+
+  it "keeps the REQUEST editor's Content-Length in sync while editing the body" do
+    view = ReplayView.new
+    view.restore("https://h.test",
+      "POST /x HTTP/1.1\nHost: h.test\nContent-Length: 99\n\nhi", false, true)
+    view.pane_advance(1) # :target → :request
+    view.goto_request_line(5) # body line
+    view.edit_insert('!')
+    view.request_text.includes?("Content-Length: 3").should be_true  # body "hi!" is 3 bytes
+    view.request_text.includes?("Content-Length: 99").should be_false
   end
 
   it "MARK transform off (default) sends § verbatim — byte-identical to today" do

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -239,6 +239,7 @@ module Gori::Tui
     def replace_request(text : String) : Nil
       @editor.set_text(text)
       @dirty = true
+      reflect_content_length_in_editor
     end
 
     # The source History flow id for a ^R-opened tab (nil for a hand-authored ^N).
@@ -282,6 +283,7 @@ module Gori::Tui
       @dirty = false
       @req_hex_edit = nil # a fresh load/restore replaces the request → drop any hex buffer
       @scroll_req = 0
+      reflect_content_length_in_editor if @auto_content_length
     end
 
     getter? ws_mode : Bool
@@ -655,6 +657,7 @@ module Gori::Tui
       @dirty = false
       @req_hex_edit = nil # a fresh load/restore replaces the request → drop any hex buffer
       @scroll_req = 0
+      reflect_content_length_in_editor if @auto_content_length
     end
 
     # Re-seed the captured-original diff baseline for a ^R-from-History tab that was
@@ -735,6 +738,8 @@ module Gori::Tui
       return @auto_content_length if @req_hex_edit # meaningless on raw bytes — refuse in hex mode
       @dirty = true
       @auto_content_length = !@auto_content_length
+      reflect_content_length_in_editor if @auto_content_length
+      @auto_content_length
     end
 
     getter? mark_transform : Bool
@@ -858,6 +863,36 @@ module Gori::Tui
       return raw unless idx
       lines[idx] = "Content-Length: #{body.bytesize}"
       "#{lines.join("\r\n")}\r\n\r\n#{body}".to_slice
+    end
+
+    # Mirror the auto-Content-Length resync into the visible REQUEST editor (^L on) so
+    # the pane shows the same header `request_bytes` will send — not only at ^R time.
+    private def reflect_content_length_in_editor : Nil
+      return unless @auto_content_length
+      return if @req_hex_edit || @grpc_mode || @ws_mode
+      return if @decode_kind && @req_pane == :decoded
+
+      raw = @editor.to_bytes
+      synced = sync_content_length(raw)
+      return if synced == raw
+
+      synced_head = String.new(synced).split("\r\n\r\n", limit: 2).first
+      return unless synced_head
+
+      synced_lines = synced_head.split("\r\n")
+      cl_idx = synced_lines.index { |l| l.lstrip.downcase.starts_with?("content-length:") }
+      return unless cl_idx
+
+      env_sep = @editor.text.index("\n\n")
+      return unless env_sep
+
+      head_lines = @editor.text[0, env_sep].split('\n')
+      return unless cl_idx < head_lines.size
+
+      new_line = synced_lines[cl_idx]
+      return if head_lines[cl_idx] == new_line
+
+      @editor.replace_line(cl_idx, new_line)
     end
 
     # {scheme, host, port} parsed from the target field.
@@ -1051,7 +1086,12 @@ module Gori::Tui
     # dirties the right buffer — the envelope (persist/sync) or the decoded payload
     # (→ re-encode on send). Pure navigation dirties neither.
     private def mark_req_edit : Nil
-      (@decode_kind && @req_pane == :decoded) ? (@decoded_dirty = true) : (@dirty = true)
+      if @decode_kind && @req_pane == :decoded
+        @decoded_dirty = true
+      else
+        @dirty = true
+        reflect_content_length_in_editor
+      end
     end
 
     def edit_insert(ch : Char) : Nil

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -233,6 +233,17 @@ module Gori::Tui
       @lines.size
     end
 
+    # Replace one line in-place (cursor clamped when on that row). Used by Replay to
+    # resync a lone Content-Length header without resetting the whole buffer.
+    def replace_line(idx : Int32, content : String) : Nil
+      return if idx < 0 || idx >= @lines.size
+      return if @lines[idx] == content
+      @lines[idx] = content
+      @cx = @cx.clamp(0, content.size) if @cy == idx
+      @styled = nil
+      @edits += 1
+    end
+
     # Flat char offset of the cursor into `text` (LF-joined) — for marking helpers
     # that operate on the whole buffer text (e.g. the Fuzzer's §-position toggle).
     def cursor_offset : Int32


### PR DESCRIPTION
## Summary

Fixes Replay TUI bug where toggling auto Content-Length (`^L`) did not update the visible REQUEST pane — the resync only happened at send time (`^R`).

## Changes

- Add `reflect_content_length_in_editor` to mirror the `^L` resync into the request editor
- Sync on toggle on, body edits, tab load/restore, and `replace_request`
- Add `TextArea#replace_line` to update the Content-Length header without resetting the buffer
- Extend specs for editor visibility and live body-edit sync

## Test plan

- [x] `crystal spec spec/tui/replay_view_spec.cr` — 34 examples, 0 failures