### PR TITLE
feat(tui): rich empty-state onboarding across tabs

### DIFF
--- a/spec/tui/findings_view_spec.cr
+++ b/spec/tui/findings_view_spec.cr
@@ -37,6 +37,18 @@ describe Gori::Tui::FindingsView do
     end
   end
 
+  it "renders an empty-state when there are no findings" do
+    tmp_store do |store|
+      view = FindingsView.new
+      view.reload(store)
+      backend = MemoryBackend.new(80, 12)
+      view.render(Screen.new(backend), Rect.new(0, 0, 80, 12))
+      backend.contains?("no findings yet").should be_true
+      backend.contains?("FINDINGS").should be_true
+      backend.contains?("⇧F").should be_true
+    end
+  end
+
   it "cycles triage status independently of severity" do
     tmp_store do |store|
       id = store.insert_finding("IDOR", Gori::Store::Severity::High, "acme.test", nil)

--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -450,6 +450,20 @@ describe Gori::Tui::HistoryView do
     end
   end
 
+  it "renders an empty-state when no flows are captured" do
+    tmp_store do |store|
+      view = HistoryView.new
+      view.reload(store)
+      backend = MemoryBackend.new(80, 14)
+      view.render_list(Screen.new(backend), Rect.new(0, 0, 80, 14),
+        listen: "127.0.0.1:8070", capturing: true)
+      backend.contains?("waiting for traffic").should be_true
+      backend.contains?("127.0.0.1:8070").should be_true
+      backend.contains?("Open browser").should be_true
+      backend.contains?("FLOW LOG").should be_true
+    end
+  end
+
   it "shows the scope-lens empty hint (not the filter hint) when querying with a blank query" do
     tmp_store do |store|
       add_flow(store, "GET", "/a", 200) # captured on host h.test

--- a/spec/tui/intercept_view_spec.cr
+++ b/spec/tui/intercept_view_spec.cr
@@ -55,9 +55,12 @@ describe Gori::Tui::InterceptView do
     tmp_interceptor do |ic|
       view = InterceptView.new
       view.reload(ic)
-      backend = MemoryBackend.new(80, 8)
-      view.render(Screen.new(backend), Rect.new(0, 0, 80, 8))
+      backend = MemoryBackend.new(80, 14)
+      view.render(Screen.new(backend), Rect.new(0, 0, 80, 14),
+        listen: "127.0.0.1:8070", capturing: true)
       backend.contains?("no held messages").should be_true
+      backend.contains?("INTERCEPT").should be_true
+      backend.contains?("i:CATCH").should be_true
     end
   end
 

--- a/spec/tui/mouse_spec.cr
+++ b/spec/tui/mouse_spec.cr
@@ -107,8 +107,8 @@ describe "SitemapView#row_at / #marker_hit?" do
       rect = Rect.new(0, 0, 70, 20)
       view.render(Screen.new(MemoryBackend.new(70, 20)), rect)
 
-      # not querying → the tree starts at rect.y + 1 (the QL filter bar takes row 0)
-      view.row_at(rect, 5, rect.y + 1).should eq(0)           # first tree row = host node
+      # not querying → the tree starts at rect.y + 3 (filter bar + header + divider)
+      view.row_at(rect, 5, rect.y + 3).should eq(0)           # first tree row = host node
       view.row_at(rect, 5, rect.y).should be_nil              # the QL bar row, above the tree
       view.row_at(rect, 5, rect.y + 19).should be_nil         # past the populated rows
       view.row_at(rect, rect.right, rect.y + 1).should be_nil # past the right frame column (mx bound)

--- a/spec/tui/notes_view_spec.cr
+++ b/spec/tui/notes_view_spec.cr
@@ -35,6 +35,16 @@ private def render_text(view : NotesView, w = 80, h = 10) : MemoryBackend
 end
 
 describe Gori::Tui::NotesView do
+  it "shows the scratchpad guide on a blank note" do
+    tmp_store do |store|
+      view = NotesView.new
+      view.reload(store)
+      backend = render_text(view, 80, 14)
+      backend.contains?("NOTES").should be_true
+      backend.contains?("scratchpad").should be_true
+    end
+  end
+
   it "loads, edits inline, and persists the note set as JSON" do
     tmp_store do |store|
       view = NotesView.new

--- a/spec/tui/sitemap_view_spec.cr
+++ b/spec/tui/sitemap_view_spec.cr
@@ -69,9 +69,15 @@ describe Gori::Tui::SitemapView do
     tmp_store do |store|
       view = SitemapView.new
       view.reload(store)
-      backend = MemoryBackend.new(70, 6)
-      view.render(Screen.new(backend), Rect.new(0, 0, 70, 6))
+      backend = MemoryBackend.new(70, 14)
+      view.render(Screen.new(backend), Rect.new(0, 0, 70, 14),
+        listen: "127.0.0.1:8070", capturing: true)
       backend.contains?("no traffic captured").should be_true
+      backend.contains?("127.0.0.1:8070").should be_true
+      backend.contains?("Open browser").should be_true
+      backend.contains?("SITE MAP").should be_true
+      backend.contains?("HOST / PATH").should be_true
+      backend.contains?("METHODS").should be_true
     end
   end
 

--- a/spec/tui/traffic_empty_state_spec.cr
+++ b/spec/tui/traffic_empty_state_spec.cr
@@ -1,0 +1,153 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+describe Gori::Tui::TrafficEmptyState do
+  it "renders the history flow-log card with listen address and Open browser" do
+    backend = MemoryBackend.new(60, 12)
+    rect = Rect.new(0, 0, 60, 12)
+    TrafficEmptyState.render(Screen.new(backend), rect,
+      variant: :history, listen: "127.0.0.1:8070", capturing: true)
+    backend.contains?("waiting for traffic").should be_true
+    backend.contains?("FLOW LOG").should be_true
+    backend.contains?("127.0.0.1:8070").should be_true
+    backend.contains?("Open browser").should be_true
+    backend.contains?("──►").should be_true
+    backend.contains?("SITE MAP").should be_false
+  end
+
+  it "renders the sitemap site-map card with tree hints" do
+    backend = MemoryBackend.new(60, 12)
+    rect = Rect.new(0, 0, 60, 12)
+    TrafficEmptyState.render(Screen.new(backend), rect,
+      variant: :sitemap, listen: "0.0.0.0:9090", capturing: true)
+    backend.contains?("no traffic captured").should be_true
+    backend.contains?("SITE MAP").should be_true
+    backend.contains?("0.0.0.0:9090").should be_true
+    backend.contains?("hosts group traffic").should be_true
+    backend.contains?("paths nest").should be_true
+    backend.contains?("FLOW LOG").should be_false
+  end
+
+  it "shows a capture-off hint when not capturing" do
+    backend = MemoryBackend.new(60, 12)
+    rect = Rect.new(0, 0, 60, 12)
+    TrafficEmptyState.render(Screen.new(backend), rect,
+      variant: :history, listen: "127.0.0.1:8070", capturing: false)
+    backend.contains?("capture is OFF").should be_true
+    backend.contains?("press c").should be_true
+  end
+
+  it "degrades history to compact stream lines on a narrow pane" do
+    backend = MemoryBackend.new(34, 6)
+    rect = Rect.new(0, 0, 34, 6)
+    TrafficEmptyState.render(Screen.new(backend), rect,
+      variant: :history, listen: "10.0.0.5:3128", capturing: true)
+    backend.contains?("waiting for traffic").should be_true
+    backend.contains?("10.0.0.5:3128").should be_true
+    backend.contains?("──►").should be_true
+    backend.contains?("FLOW LOG").should be_false
+  end
+
+  it "degrades sitemap to compact tree lines on a narrow pane" do
+    backend = MemoryBackend.new(34, 6)
+    rect = Rect.new(0, 0, 34, 6)
+    TrafficEmptyState.render(Screen.new(backend), rect,
+      variant: :sitemap, listen: "10.0.0.5:3128", capturing: true)
+    backend.contains?("no traffic captured").should be_true
+    backend.contains?("◆ proxy").should be_true
+    backend.contains?("host tr").should be_true # truncated on narrow panes
+  end
+
+  it "renders the intercept hold-queue card" do
+    backend = MemoryBackend.new(60, 12)
+    rect = Rect.new(0, 0, 60, 12)
+    TrafficEmptyState.render(Screen.new(backend), rect,
+      variant: :intercept, listen: "127.0.0.1:8070", capturing: true, catch_on: false)
+    backend.contains?("no held messages").should be_true
+    backend.contains?("INTERCEPT").should be_true
+    backend.contains?("press i").should be_true
+    backend.contains?("i:CATCH").should be_true
+  end
+
+  it "renders the replay resend card" do
+    backend = MemoryBackend.new(60, 12)
+    rect = Rect.new(0, 0, 60, 12)
+    TrafficEmptyState.render(Screen.new(backend), rect, variant: :replay)
+    backend.contains?("no replay open").should be_true
+    backend.contains?("REPLAY").should be_true
+    backend.contains?("edit").should be_true
+    backend.contains?("^R").should be_true
+  end
+
+  it "renders the fuzzer probe card" do
+    backend = MemoryBackend.new(60, 12)
+    rect = Rect.new(0, 0, 60, 12)
+    TrafficEmptyState.render(Screen.new(backend), rect, variant: :fuzzer)
+    backend.contains?("no fuzz session").should be_true
+    backend.contains?("FUZZER").should be_true
+    backend.contains?("§").should be_true
+    backend.contains?("⇧I").should be_true
+  end
+
+  it "renders the fuzzer results card while idle" do
+    backend = MemoryBackend.new(50, 8)
+    rect = Rect.new(0, 0, 50, 8)
+    TrafficEmptyState.render(Screen.new(backend), rect, variant: :fuzzer_results, running: false)
+    backend.contains?("no results yet").should be_true
+    backend.contains?("RESULTS").should be_true
+    backend.contains?("^R").should be_true
+  end
+
+  it "renders the prism scan card when scanning is on" do
+    backend = MemoryBackend.new(60, 12)
+    rect = Rect.new(0, 0, 60, 12)
+    TrafficEmptyState.render(Screen.new(backend), rect,
+      variant: :prism, listen: "127.0.0.1:8070", capturing: true, scan_on: true)
+    backend.contains?("no issues yet").should be_true
+    backend.contains?("PRISM").should be_true
+    backend.contains?("scan").should be_true
+    backend.contains?("m:MODE").should be_true
+  end
+
+  it "renders the prism off card when scanning is disabled" do
+    backend = MemoryBackend.new(60, 12)
+    rect = Rect.new(0, 0, 60, 12)
+    TrafficEmptyState.render(Screen.new(backend), rect,
+      variant: :prism, scan_on: false, title: "scanning is OFF")
+    backend.contains?("scanning is OFF").should be_true
+    backend.contains?("PRISM").should be_true
+    backend.contains?("turn scanning on").should be_true
+    backend.contains?("m:MODE").should be_true
+  end
+
+  it "renders the findings triage card" do
+    backend = MemoryBackend.new(60, 12)
+    rect = Rect.new(0, 0, 60, 12)
+    TrafficEmptyState.render(Screen.new(backend), rect, variant: :findings)
+    backend.contains?("no findings yet").should be_true
+    backend.contains?("FINDINGS").should be_true
+    backend.contains?("⇧F").should be_true
+    backend.contains?("triage").should be_true
+  end
+
+  it "renders the notes scratchpad card centred in the pane" do
+    backend = MemoryBackend.new(60, 12)
+    rect = Rect.new(0, 0, 60, 12)
+    TrafficEmptyState.render(Screen.new(backend), rect, variant: :notes)
+    backend.contains?("NOTES").should be_true
+    backend.contains?("scratchpad").should be_true
+    backend.contains?("^N").should be_true
+  end
+
+  it "degrades to a two-line hint on a very small pane" do
+    backend = MemoryBackend.new(38, 3)
+    rect = Rect.new(0, 0, 38, 3)
+    TrafficEmptyState.render(Screen.new(backend), rect,
+      variant: :sitemap, listen: "127.0.0.1:8070", capturing: false)
+    backend.contains?("no traffic captured").should be_true
+    backend.contains?("◆ proxy").should be_true
+    backend.contains?("^P Open br").should be_true # truncated on narrow panes
+  end
+end

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -1,4 +1,5 @@
 require "../tab_controller"
+require "../traffic_empty_state"
 require "../fuzzer_view"
 require "../../store"
 require "../../fuzz"
@@ -115,7 +116,7 @@ module Gori::Tui
         v.render(screen, body_rect, focused: body_focused)
       else
         BodyChrome.framed(screen, body_rect, body_focused) do |inner|
-          screen.text(inner.x + 1, inner.y, "no fuzz sessions — ^N new session · ⇧I from History/Replay", Theme.muted)
+          TrafficEmptyState.render(screen, inner, variant: :fuzzer)
         end
       end
     end

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -41,10 +41,14 @@ module Gori::Tui
       @history.reveal = @host.reveal? # propagate the global whitespace-reveal pref
       @history.pretty = @host.pretty? # propagate the global pretty-print pref
       # Single body pane; the detail view is a drill-in within the same frame.
+      proxy = @host.session.proxy
       if @host.overlay == :detail
         BodyChrome.framed(screen, rect, body_focused) { |inner| @history.render_detail(screen, inner, focused: body_focused) }
       else
-        BodyChrome.framed(screen, rect, body_focused) { |inner| @history.render_list(screen, inner, focused: body_focused) }
+        BodyChrome.framed(screen, rect, body_focused) do |inner|
+          @history.render_list(screen, inner, focused: body_focused,
+            listen: "#{proxy.host}:#{proxy.port}", capturing: @host.session.capturing?)
+        end
       end
     end
 

--- a/src/gori/tui/controllers/intercept_controller.cr
+++ b/src/gori/tui/controllers/intercept_controller.cr
@@ -46,8 +46,10 @@ module Gori::Tui
     end
 
     def render_body(screen : Screen, rect : Rect, focus : Symbol) : Nil
-      @intercept.reload(@host.session.interceptor)             # live refresh (50ms loop)
-      @intercept.render(screen, rect, focused: focus == :body) # view frames its own panes
+      @intercept.reload(@host.session.interceptor) # live refresh (50ms loop)
+      proxy = @host.session.proxy
+      @intercept.render(screen, rect, focused: focus == :body,
+        listen: "#{proxy.host}:#{proxy.port}", capturing: @host.session.capturing?)
     end
 
     def handle_body_key(ev : Termisu::Event::Key) : Bool

--- a/src/gori/tui/controllers/prism_controller.cr
+++ b/src/gori/tui/controllers/prism_controller.cr
@@ -48,7 +48,11 @@ module Gori::Tui
 
     def render_body(screen : Screen, rect : Rect, focus : Symbol) : Nil
       focused = focus == :body
-      BodyChrome.framed(screen, rect, focused) { |inner| @prism.render(screen, inner, focused: focused) }
+      proxy = @host.session.proxy
+      BodyChrome.framed(screen, rect, focused) do |inner|
+        @prism.render(screen, inner, focused: focused,
+          listen: "#{proxy.host}:#{proxy.port}", capturing: @host.session.capturing?)
+      end
     end
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool

--- a/src/gori/tui/controllers/replay_controller.cr
+++ b/src/gori/tui/controllers/replay_controller.cr
@@ -1,4 +1,5 @@
 require "../tab_controller"
+require "../traffic_empty_state"
 require "../replay_view"
 require "../subtab_picker"
 require "../../store"
@@ -146,7 +147,7 @@ module Gori::Tui
         v.render(screen, body_rect, focused: body_focused)
       else
         BodyChrome.framed(screen, body_rect, body_focused) do |inner|
-          screen.text(inner.x + 1, inner.y, "no replays — ^N new request · ^R from History", Theme.muted)
+          TrafficEmptyState.render(screen, inner, variant: :replay)
         end
       end
     end

--- a/src/gori/tui/controllers/sitemap_controller.cr
+++ b/src/gori/tui/controllers/sitemap_controller.cr
@@ -34,7 +34,11 @@ module Gori::Tui
 
     def render_body(screen : Screen, rect : Rect, focus : Symbol) : Nil
       focused = focus == :body
-      BodyChrome.framed(screen, rect, focused) { |inner| @sitemap.render(screen, inner, focused: focused) }
+      proxy = @host.session.proxy
+      BodyChrome.framed(screen, rect, focused) do |inner|
+        @sitemap.render(screen, inner, focused: focused,
+          listen: "#{proxy.host}:#{proxy.port}", capturing: @host.session.capturing?)
+      end
     end
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool

--- a/src/gori/tui/findings_view.cr
+++ b/src/gori/tui/findings_view.cr
@@ -1,6 +1,7 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./traffic_empty_state"
 require "./text_area"
 require "../store"
 require "../findings_query"
@@ -331,14 +332,14 @@ module Gori::Tui
       list_h = {rect.bottom - top, 0}.max
 
       if @findings.empty?
-        msg = if !filtering?
-                "no findings yet · Shift+F on a History flow, or n here"
-              elsif querying?
-                "no findings match · esc clears the filter" # esc cancels the open query bar
-              else
-                "no findings match · / to edit the filter" # a committed filter: esc goes to tabs, not clear
-              end
-        screen.text(rect.x + 1, top, msg, Theme.muted)
+        list_rect = Rect.new(rect.x + 1, top, {rect.w - 2, 0}.max, {rect.bottom - top, 0}.max)
+        if !filtering?
+          TrafficEmptyState.render(screen, list_rect, variant: :findings)
+        elsif querying?
+          screen.text(rect.x + 1, top, "no findings match · esc clears the filter", Theme.muted)
+        else
+          screen.text(rect.x + 1, top, "no findings match · / to edit the filter", Theme.muted)
+        end
         return
       end
 

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -2,6 +2,7 @@ require "json"
 require "./screen"
 require "./theme"
 require "./frame"
+require "./traffic_empty_state"
 require "./text_area"
 require "./fmt"
 require "./spark"
@@ -960,8 +961,7 @@ module Gori::Tui
     def render(screen : Screen, rect : Rect, focused : Bool = true) : Nil
       return if rect.empty?
       unless @loaded
-        screen.text(rect.x + 1, rect.y, "no request loaded", Theme.muted)
-        screen.text(rect.x + 1, rect.y + 2, "select a flow in History/Replay and press ⇧I to send it here", Theme.muted)
+        TrafficEmptyState.render(screen, rect, variant: :fuzzer, title: "no request loaded")
         return
       end
       target_h = {rect.h, 3}.min
@@ -1259,7 +1259,8 @@ module Gori::Tui
         render_result_row(screen, inner, inner.y + 1 + i, view[ri], ri == @sel)
       end
       if view.empty?
-        screen.text(inner.x + 1, inner.y + 2, @running ? "running…" : "no results yet — ^R run", Theme.muted)
+        body = Rect.new(inner.x, inner.y + 1, inner.w, {inner.h - 1, 0}.max)
+        TrafficEmptyState.render(screen, body, variant: :fuzzer_results, running: @running)
       end
     end
 
@@ -1298,8 +1299,7 @@ module Gori::Tui
       inner = rect.inset(1, 1)
       return if inner.empty?
       if @results.empty?
-        screen.text(inner.x, inner.y, @running ? "sampling…" : "no results yet",
-          Theme.muted, Theme.bg, width: inner.w)
+        TrafficEmptyState.render(screen, inner, variant: :fuzzer_results, running: @running)
         return
       end
       d = dist_data(inner.w)

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -1,6 +1,8 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./traffic_empty_state"
+require "../settings"
 require "./highlight"
 require "./hex_view"
 require "./gutter"
@@ -620,7 +622,8 @@ module Gori::Tui
 
     # --- rendering -----------------------------------------------------------
 
-    def render_list(screen : Screen, rect : Rect, focused : Bool = true) : Nil
+    def render_list(screen : Screen, rect : Rect, focused : Bool = true, *,
+                    listen : String? = nil, capturing : Bool = true) : Nil
       return if rect.empty?
       render_ql_bar(screen, rect)
       hdr_y = rect.y + 1
@@ -688,7 +691,10 @@ module Gori::Tui
           elsif filtering? # in-scope subset is empty (Scope lens, no QL query)
             {"no flows in scope", "⇧S clears the scope lens"}
           else
-            {"waiting for traffic…", "browse through the proxy, then return here"}
+            addr = listen || "#{Settings.effective_bind_host}:#{Settings.effective_bind_port}"
+            list_rect = Rect.new(time_x, list_top, rect.right - time_x, list_h)
+            TrafficEmptyState.render(screen, list_rect, variant: :history, listen: addr, capturing: capturing)
+            return
           end
         screen.text(time_x, list_top, msg, Theme.muted)
         screen.text(time_x, list_top + 2, hint, Theme.muted) if list_h > 2

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -1,6 +1,8 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./traffic_empty_state"
+require "../settings"
 require "./highlight"
 require "./text_area"
 require "./url"
@@ -322,18 +324,17 @@ module Gori::Tui
 
     # --- rendering -----------------------------------------------------------
 
-    def render(screen : Screen, rect : Rect, focused : Bool = true) : Nil
+    def render(screen : Screen, rect : Rect, focused : Bool = true, *,
+               listen : String? = nil, capturing : Bool = true) : Nil
       return if rect.empty?
       render_filter_bar(screen, Rect.new(rect.x, rect.y, rect.w, FILTER_BAR_H), focused)
       body = body_rect(rect)
       return if body.empty?
 
       if @items.empty?
-        Frame.card(screen, body, "INTERCEPT", bg: Theme.bg, border: pane_border(focused))
-        inner = body.inset(1, 1)
-        screen.text(inner.x + 1, inner.y, "no held messages", Theme.muted)
-        hint = @enabled ? "intercept ON — in-scope requests/responses will appear here" : "turn intercept on (i) — held requests/responses appear here"
-        screen.text(inner.x + 1, inner.y + 2, hint, Theme.muted)
+        addr = listen || "#{Settings.effective_bind_host}:#{Settings.effective_bind_port}"
+        TrafficEmptyState.render(screen, body, variant: :intercept, listen: addr,
+          capturing: capturing, catch_on: @enabled)
         return
       end
 

--- a/src/gori/tui/notes_view.cr
+++ b/src/gori/tui/notes_view.cr
@@ -1,5 +1,6 @@
 require "./screen"
 require "./theme"
+require "./traffic_empty_state"
 require "./text_area"
 require "../store"
 require "../notes"
@@ -227,6 +228,7 @@ module Gori::Tui
       # (and that Notes used before): only the strip/band above the editor moved —
       # the editor body renders exactly where it did, now filling the freed height.
       area = Rect.new(rect.x + 1, rect.y, {rect.w - 2, 0}.max, rect.h)
+      TrafficEmptyState.render(screen, area, variant: :notes) if current_blank?
       current.area.render(screen, area, cursor: focused,
         highlight: Settings.editor_markdown ? :markdown : nil)
     end

--- a/src/gori/tui/prism_view.cr
+++ b/src/gori/tui/prism_view.cr
@@ -1,6 +1,8 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./traffic_empty_state"
+require "../settings"
 require "../store"
 require "../scope"
 require "../prism"
@@ -280,12 +282,15 @@ module Gori::Tui
 
     # --- rendering ------------------------------------------------------------
 
-    def render(screen : Screen, rect : Rect, focused : Bool = true) : Nil
+    def render(screen : Screen, rect : Rect, focused : Bool = true, *,
+               listen : String? = nil, capturing : Bool = true) : Nil
       return if rect.empty?
-      @detail ? render_detail(screen, rect, focused) : render_list(screen, rect, focused)
+      @detail ? render_detail(screen, rect, focused) : render_list(screen, rect, focused,
+        listen: listen, capturing: capturing)
     end
 
-    private def render_list(screen : Screen, rect : Rect, focused : Bool) : Nil
+    private def render_list(screen : Screen, rect : Rect, focused : Bool, *,
+                            listen : String? = nil, capturing : Bool = true) : Nil
       render_mode_band(screen, rect)
       render_filter_bar(screen, rect, rect.y + 1)
       screen.text(rect.x + 1, rect.y + 2, "SEV", Theme.muted)
@@ -294,7 +299,7 @@ module Gori::Tui
       Frame.inner_divider(screen, rect, rect.y + 3, border: Frame.pane_border(focused))
       top = rect.y + 4
       list_h = {rect.bottom - top, 0}.max
-      return render_empty(screen, rect, top) if @issues.empty?
+      return render_empty(screen, rect, top, listen: listen, capturing: capturing) if @issues.empty?
 
       ensure_visible(list_h)
       (0...list_h).each do |i|
@@ -342,22 +347,25 @@ module Gori::Tui
       screen.text(title_x, y, issue.title, selected ? Theme.text_bright : Theme.text, bg, width: tw)
     end
 
-    private def render_empty(screen : Screen, rect : Rect, top : Int32) : Nil
+    private def render_empty(screen : Screen, rect : Rect, top : Int32, *,
+                             listen : String? = nil, capturing : Bool = true) : Nil
       # Branch on a real `/` query FIRST (querying-aware hint): a blank-query empty set
       # is caused by the triage lens or the scope lens, where "esc clears the filter"
       # would mislead. Mirrors HistoryView/SitemapView's ordering.
-      msg = if @mode.off?
-              "scanning is OFF · press m (or space → set mode) to enable passive scanning"
-            elsif !@query.blank?
-              @querying ? "no issues match · esc clears the filter" : "no issues match · / to edit the filter"
-            elsif @pre_scope_empty && !@all.empty? && !@show_closed
-              "no open issues · all #{@all.size} triaged · press a to show closed"
-            elsif scope_active?
-              "no issues in scope · ⇧S clears the scope lens"
-            else
-              "no issues yet · capture in-scope traffic and Prism flags issues passively"
-            end
-      screen.text(rect.x + 1, top, msg, Theme.muted)
+      list_rect = Rect.new(rect.x + 1, top, {rect.w - 2, 0}.max, {rect.bottom - top, 0}.max)
+      if !@query.blank?
+        msg = @querying ? "no issues match · esc clears the filter" : "no issues match · / to edit the filter"
+        screen.text(rect.x + 1, top, msg, Theme.muted)
+      elsif @pre_scope_empty && !@all.empty? && !@show_closed
+        screen.text(rect.x + 1, top, "no open issues · all #{@all.size} triaged · press a to show closed", Theme.muted)
+      elsif scope_active?
+        screen.text(rect.x + 1, top, "no issues in scope · ⇧S clears the scope lens", Theme.muted)
+      else
+        addr = listen || "#{Settings.effective_bind_host}:#{Settings.effective_bind_port}"
+        TrafficEmptyState.render(screen, list_rect, variant: :prism, listen: addr,
+          capturing: capturing, scan_on: !@mode.off?,
+          title: @mode.off? ? "scanning is OFF" : "no issues yet")
+      end
     end
 
     # Row 0: a filled MODE chip (with its `m` cycle chord) + detected-tech summary + the

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -2,6 +2,7 @@ require "uri"
 require "./screen"
 require "./theme"
 require "./frame"
+require "./traffic_empty_state"
 require "./highlight"
 require "./hex_view"
 require "./hex_edit"
@@ -1359,8 +1360,7 @@ module Gori::Tui
     def render(screen : Screen, rect : Rect, focused : Bool = true) : Nil
       return if rect.empty?
       unless @loaded
-        screen.text(rect.x + 1, rect.y, "no flow loaded", Theme.muted)
-        screen.text(rect.x + 1, rect.y + 2, "select a flow in History and press ^R to replay it", Theme.muted)
+        TrafficEmptyState.render(screen, rect, variant: :replay, title: "no flow loaded")
         return
       end
 

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -1,5 +1,8 @@
 require "./screen"
 require "./theme"
+require "./frame"
+require "./traffic_empty_state"
+require "../settings"
 require "../store"
 require "../ql"
 require "../scope"
@@ -377,12 +380,19 @@ module Gori::Tui
       {host, row.node.path}
     end
 
-    def render(screen : Screen, rect : Rect, focused : Bool = true) : Nil
+    def render(screen : Screen, rect : Rect, focused : Bool = true, *,
+               listen : String? = nil, capturing : Bool = true) : Nil
       return if rect.empty?
       render_ql_bar(screen, rect)
-      # The bar takes the top row; while querying a suggestion row sits below it.
-      offset = bar_rows
-      tree = Rect.new(rect.x, rect.y + offset, rect.w, {rect.h - offset, 0}.max)
+      hdr_y = rect.y + 1
+      if @querying
+        render_suggestions(screen, rect, hdr_y)
+        hdr_y += 1
+      end
+      render_column_headers(screen, rect, hdr_y)
+      Frame.inner_divider(screen, rect, hdr_y + 1, border: Frame.pane_border(focused))
+      tree_top = hdr_y + 2
+      tree = Rect.new(rect.x, tree_top, rect.w, {rect.bottom - tree_top, 0}.max)
       return if tree.h <= 0
 
       unless @loaded && !@hosts.empty?
@@ -394,7 +404,9 @@ module Gori::Tui
           elsif filtering? # in-scope subset is empty (Scope lens, no QL query)
             {"no endpoints in scope", nil}
           else
-            {"no traffic captured yet", "browse through the proxy, then return here"}
+            addr = listen || "#{Settings.effective_bind_host}:#{Settings.effective_bind_port}"
+            TrafficEmptyState.render(screen, tree, variant: :sitemap, listen: addr, capturing: capturing)
+            return
           end
         screen.text(tree.x + 1, tree.y, msg, Theme.muted)
         screen.text(tree.x + 1, tree.y + 2, hint, Theme.muted) if hint && tree.h > 2
@@ -523,10 +535,12 @@ module Gori::Tui
       end
     end
 
-    # Rows the QL bar occupies at the top of the body: 1 (the bar) + 1 suggestion
-    # row while querying. The tree renders below it; clicks subtract the same offset.
-    private def bar_rows : Int32
-      @querying ? 2 : 1
+    # The first tree-row screen-y — mirrors render: filter bar, optional suggestion
+    # row while querying, column header, then divider.
+    private def list_top(rect : Rect) : Int32
+      hdr_y = rect.y + 1
+      hdr_y += 1 if @querying
+      hdr_y + 2
     end
 
     private def render_ql_bar(screen : Screen, rect : Rect) : Nil
@@ -535,7 +549,6 @@ module Gori::Tui
         screen.text(rect.x + 1, rect.y, prefix, Theme.accent)
         base = rect.x + 1 + prefix.size
         screen.input_line(base, rect.y, @query, @qcx, @preedit, Theme.text_bright, width: rect.w - prefix.size - 2)
-        render_suggestions(screen, rect, rect.y + 1)
         return
       end
 
@@ -569,18 +582,28 @@ module Gori::Tui
       end
     end
 
+    private def render_column_headers(screen : Screen, rect : Rect, hdr_y : Int32) : Nil
+      label_x = rect.x + 1
+      methods_w = 8
+      methods_x = {rect.right - methods_w, label_x + 12}.max
+      label_w = {methods_x - label_x - 1, 6}.max
+      screen.text(label_x, hdr_y, "HOST / PATH", Theme.muted, width: label_w) if label_w > 0
+      screen.text(methods_x, hdr_y, "METHODS", Theme.muted, width: methods_w)
+    end
+
     private def render_suggestions(screen : Screen, rect : Rect, y : Int32) : Nil
       sugg = query_suggestions
       return if sugg.empty?
       screen.text(rect.x + 1, y, "↹ #{sugg.first(8).join("  ")}", Theme.muted, width: rect.w - 2)
     end
 
-    # Inverts render's tree placement (offset below the QL bar) to find which
+    # Inverts render's tree placement (offset below the chrome band) to find which
     # visible_rows index a click lands on; nil past the last populated row.
     def row_at(rect : Rect, mx : Int32, my : Int32) : Int32?
       return nil if mx < rect.x || mx >= rect.right # reject the frame border columns (mirror the other list helpers)
-      i = my - (rect.y + bar_rows)
-      return nil if i < 0 || i >= {rect.h - bar_rows, 0}.max
+      top = list_top(rect)
+      i = my - top
+      return nil if i < 0 || i >= {rect.bottom - top, 0}.max
       idx = @scroll + i
       idx < visible_rows.size ? idx : nil
     end

--- a/src/gori/tui/traffic_empty_state.cr
+++ b/src/gori/tui/traffic_empty_state.cr
@@ -1,0 +1,418 @@
+require "./screen"
+require "./theme"
+require "./frame"
+require "../settings"
+
+module Gori::Tui
+  # Rich onboarding panels for tabs with nothing to show yet. Each variant has its
+  # own visual voice; the title rides the top edge and the card is centred below it.
+  # Degrades gracefully on narrow/short panes (card → plain lines → two-line hint).
+  module TrafficEmptyState
+    extend self
+
+    FULL_MIN_H = 7
+    FULL_MIN_W = 42
+    MED_MIN_H  = 5
+    MED_MIN_W  = 30
+
+    def render(screen : Screen, rect : Rect, *,
+               variant : Symbol,
+               listen : String? = nil,
+               capturing : Bool = true,
+               catch_on : Bool = false,
+               running : Bool = false,
+               scan_on : Bool = true,
+               title : String? = nil) : Nil
+      return if rect.empty?
+
+      addr = listen || "#{Settings.effective_bind_host}:#{Settings.effective_bind_port}"
+      headline = title || default_title(variant, running: running, scan_on: scan_on)
+      min_h = variant == :fuzzer_results ? 5 : FULL_MIN_H
+
+      if rect.h >= min_h && rect.w >= FULL_MIN_W
+        render_full(screen, rect, variant, headline, addr, capturing, catch_on, running, scan_on)
+      elsif rect.h >= MED_MIN_H && rect.w >= MED_MIN_W
+        render_medium(screen, rect, variant, headline, addr, capturing, catch_on, running, scan_on)
+      else
+        render_minimal(screen, rect, variant, headline, addr, capturing, catch_on, running, scan_on)
+      end
+    end
+
+    private def default_title(variant : Symbol, *, running : Bool, scan_on : Bool) : String
+      case variant
+      when :history         then "waiting for traffic…"
+      when :sitemap         then "no traffic captured yet"
+      when :intercept       then "no held messages"
+      when :replay          then "no replay open"
+      when :fuzzer          then "no fuzz session open"
+      when :fuzzer_results  then running ? "running…" : "no results yet"
+      when :prism            then scan_on ? "no issues yet" : "scanning is OFF"
+      when :findings         then "no findings yet"
+      when :notes            then "empty note"
+      else                       "nothing here yet"
+      end
+    end
+
+    private def render_full(screen : Screen, rect : Rect, variant : Symbol, headline : String,
+                            addr : String, capturing : Bool, catch_on : Bool, running : Bool,
+                            scan_on : Bool) : Nil
+      case variant
+      when :history        then render_history_full(screen, rect, headline, addr, capturing)
+      when :sitemap        then render_sitemap_full(screen, rect, headline, addr, capturing)
+      when :intercept      then render_intercept_full(screen, rect, headline, addr, capturing, catch_on)
+      when :replay          then render_replay_full(screen, rect, headline)
+      when :fuzzer          then render_fuzzer_full(screen, rect, headline)
+      when :fuzzer_results  then render_fuzzer_results_full(screen, rect, headline, running)
+      when :prism           then render_prism_full(screen, rect, headline, addr, capturing, scan_on)
+      when :findings        then render_findings_full(screen, rect, headline)
+      when :notes           then render_notes_full(screen, rect)
+      end
+    end
+
+    private def render_medium(screen : Screen, rect : Rect, variant : Symbol, headline : String,
+                              addr : String, capturing : Bool, catch_on : Bool, running : Bool,
+                              scan_on : Bool) : Nil
+      lines = case variant
+              when :history
+                medium_history(headline, addr, capturing)
+              when :sitemap
+                medium_sitemap(headline, addr, capturing)
+              when :intercept
+                medium_intercept(headline, catch_on)
+              when :replay
+                medium_replay(headline)
+              when :fuzzer
+                medium_fuzzer(headline)
+              when :fuzzer_results
+                medium_fuzzer_results(headline, running)
+              when :prism
+                medium_prism(headline, scan_on)
+              when :findings
+                medium_findings(headline)
+              when :notes
+                medium_notes(headline)
+              else
+                [headline]
+              end
+      draw_medium_lines(screen, rect, lines)
+    end
+
+    private def render_minimal(screen : Screen, rect : Rect, variant : Symbol, headline : String,
+                                 addr : String, capturing : Bool, catch_on : Bool, running : Bool,
+                                 scan_on : Bool) : Nil
+      hint = case variant
+             when :history
+               "──► #{addr} ──► ^P Open browser#{capturing ? "" : " · press c"}"
+             when :sitemap
+               "◆ proxy #{addr} · ^P Open browser#{capturing ? "" : " · press c"}"
+             when :intercept
+               catch_on ? "⏸ queue empty · i catch · / filter" : "press i to enable catch"
+             when :replay
+               "^N new · History ^R replay"
+             when :fuzzer
+               "^N new · ⇧I from History"
+             when :fuzzer_results
+               running ? "sampling…" : "^R run · ^O sets"
+             when :prism
+               scan_on ? "traffic ──► scan · press m" : "press m to enable scanning"
+             when :findings
+               "⇧F from History · n create"
+             when :notes
+               "^N new note · start typing"
+             else
+               headline
+             end
+      screen.text(rect.x + 1, rect.y, headline, Theme.muted, width: {rect.w - 2, 0}.max)
+      screen.text(rect.x + 1, rect.y + 2, hint, Theme.muted, width: {rect.w - 2, 0}.max) if rect.h > 2
+    end
+
+    # Title rides the top edge; the card is centred in the space below it.
+    private def place_centered_card(rect : Rect, card_w : Int32, card_h : Int32) : {Int32, Rect}
+      y0 = rect.y
+      body = Rect.new(rect.x, y0 + 1, rect.w, {rect.h - 1, 0}.max)
+      {y0, place_centered_card_in(body, card_w, card_h)}
+    end
+
+    # Card centred in the full rect (no headline row above — used by Notes).
+    private def place_centered_card_in(rect : Rect, card_w : Int32, card_h : Int32) : Rect
+      card_x = rect.x + {(rect.w - card_w) // 2, 0}.max
+      card_y = rect.y + {(rect.h - card_h) // 2, 0}.max
+      Rect.new(card_x, card_y, card_w, card_h)
+    end
+
+    private def draw_headline(screen : Screen, rect : Rect, y0 : Int32, headline : String) : Nil
+      screen.text(rect.x + 1, y0, headline, Theme.muted, width: {rect.w - 2, 0}.max)
+    end
+
+    private def begin_card(screen : Screen, rect : Rect, headline : String, card_title : String,
+                           inner_h : Int32) : {Int32, Rect, Int32, Int32}
+      card_h = inner_h + 2
+      card_w = {rect.w - 4, 50}.min.clamp(FULL_MIN_W, rect.w)
+      y0, card = place_centered_card(rect, card_w, card_h)
+      draw_headline(screen, rect, y0, headline)
+      Frame.card(screen, card, card_title, bg: Theme.bg, border: Theme.border)
+      inner = card.inset(1, 1)
+      ix = inner.x + 1
+      iw = {inner.w - 2, 1}.max
+      {y0, inner, ix, iw}
+    end
+
+    private def render_history_full(screen : Screen, rect : Rect, headline : String,
+                                    addr : String, capturing : Bool) : Nil
+      inner_h = 5 + (capturing ? 0 : 1) + 2
+      _, inner, ix, iw = begin_card(screen, rect, headline, "FLOW LOG", inner_h)
+      y = inner.y
+
+      screen.text(ix, y, "Requests stream in here as they pass through the proxy.", Theme.text, Theme.bg, width: iw)
+      y += 2
+      screen.text(ix + 2, y, addr, Theme.accent, Theme.bg, Attribute::Bold, width: iw)
+      y += 1
+      screen.text(ix, y, fit_history_flow(addr, iw), Theme.muted, Theme.bg, width: iw)
+      y += 2
+      unless capturing
+        screen.text(ix, y, "capture is OFF — press c to start", Theme.yellow, Theme.bg, width: iw)
+        y += 1
+      end
+      Frame.inner_divider(screen, inner, y, bg: Theme.bg, border: Theme.border)
+      y += 1
+      y = draw_palette_hint(screen, ix, y, iw, bullet: "▸ ")
+      screen.text(ix, y, "or set your client's HTTP+HTTPS proxy", Theme.muted, Theme.bg, width: iw)
+    end
+
+    private def render_sitemap_full(screen : Screen, rect : Rect, headline : String,
+                                    addr : String, capturing : Bool) : Nil
+      inner_h = 6 + (capturing ? 0 : 1) + 2
+      _, inner, ix, iw = begin_card(screen, rect, headline, "SITE MAP", inner_h)
+      y = inner.y
+
+      screen.text(ix, y, "Browsing builds a host → path tree from captured traffic.", Theme.text, Theme.bg, width: iw)
+      y += 2
+      screen.text(ix, y, "◆ hosts group traffic", Theme.muted, Theme.bg, width: iw)
+      y += 1
+      screen.text(ix, y, "  └ paths nest under each host", Theme.muted, Theme.bg, width: iw)
+      y += 2
+      screen.text(ix, y, "proxy ", Theme.muted, Theme.bg)
+      px = ix + "proxy ".size
+      screen.text(px, y, addr, Theme.accent, Theme.bg, Attribute::Bold, width: {ix + iw - px, 0}.max)
+      y += 2
+      unless capturing
+        screen.text(ix, y, "capture is OFF — press c to start", Theme.yellow, Theme.bg, width: iw)
+        y += 1
+      end
+      y = draw_palette_hint(screen, ix, y, iw, bullet: "◆ ")
+      screen.text(ix, y, "or set your client's HTTP+HTTPS proxy", Theme.muted, Theme.bg, width: iw)
+    end
+
+    private def render_intercept_full(screen : Screen, rect : Rect, headline : String,
+                                      addr : String, capturing : Bool, catch_on : Bool) : Nil
+      inner_h = 5 + (catch_on ? 0 : 1) + 3 + (capturing ? 0 : 1)
+      _, inner, ix, iw = begin_card(screen, rect, headline, "INTERCEPT", inner_h)
+      y = inner.y
+
+      msg = catch_on ? "Matching traffic pauses here for review before it continues." \
+                     : "Catch is OFF — press i to hold matching requests/responses."
+      screen.text(ix, y, msg, Theme.text, Theme.bg, width: iw)
+      y += 2
+      screen.text(ix, y, "traffic ──► ⏸ hold ──► f forward · d drop", Theme.muted, Theme.bg, width: iw)
+      y += 2
+      unless catch_on
+        screen.text(ix, y, "catch is OFF — press i to enable", Theme.yellow, Theme.bg, width: iw)
+        y += 1
+      end
+      unless capturing
+        screen.text(ix, y, "capture is OFF — press c to start", Theme.yellow, Theme.bg, width: iw)
+        y += 1
+      end
+      y = draw_chord_hint(screen, ix, y, iw, " i:CATCH ", "toggle catch", bullet: "⏸ ")
+      y = draw_chord_hint(screen, ix, y, iw, " c:ALL ", "cycle REQ/RES/ALL", bullet: "▸ ")
+      screen.text(ix, y, "▸ / condition — filter what gets held", Theme.muted, Theme.bg, width: iw)
+      y += 1
+      draw_palette_hint(screen, ix, y, iw, bullet: "▸ ")
+    end
+
+    private def render_replay_full(screen : Screen, rect : Rect, headline : String) : Nil
+      inner_h = 5 + 2
+      _, inner, ix, iw = begin_card(screen, rect, headline, "REPLAY", inner_h)
+      y = inner.y
+
+      screen.text(ix, y, "Edit a captured request and resend it — compare the response.", Theme.text, Theme.bg, width: iw)
+      y += 2
+      screen.text(ix, y, "flow ──► edit ──► send ──► response", Theme.muted, Theme.bg, width: iw)
+      y += 2
+      Frame.inner_divider(screen, inner, y, bg: Theme.bg, border: Theme.border)
+      y += 1
+      y = draw_chord_hint(screen, ix, y, iw, " ^R ", "replay from History", bullet: "▸ ")
+      draw_chord_hint(screen, ix, y, iw, " ^N ", "new blank replay tab", bullet: "▸ ")
+    end
+
+    private def render_fuzzer_full(screen : Screen, rect : Rect, headline : String) : Nil
+      inner_h = 5 + 2
+      _, inner, ix, iw = begin_card(screen, rect, headline, "FUZZER", inner_h)
+      y = inner.y
+
+      screen.text(ix, y, "Probe endpoints by swapping §markers§ in a template.", Theme.text, Theme.bg, width: iw)
+      y += 2
+      screen.text(ix, y, "template ──► §payloads§ ──► probe", Theme.muted, Theme.bg, width: iw)
+      y += 2
+      Frame.inner_divider(screen, inner, y, bg: Theme.bg, border: Theme.border)
+      y += 1
+      y = draw_chord_hint(screen, ix, y, iw, " ^N ", "new fuzz session", bullet: "§ ")
+      draw_chord_hint(screen, ix, y, iw, " ⇧I ", "send from History/Replay", bullet: "▸ ")
+    end
+
+    private def render_fuzzer_results_full(screen : Screen, rect : Rect, headline : String, running : Bool) : Nil
+      inner_h = running ? 3 : 4
+      _, inner, ix, iw = begin_card(screen, rect, headline, "RESULTS", inner_h)
+      y = inner.y
+
+      msg = running ? "Probes are in flight — hits and status codes land here." \
+                    : "Add payload sets (^O), then press ^R to start a fuzz run."
+      screen.text(ix, y, msg, Theme.text, Theme.bg, width: iw)
+      y += 2
+      draw_chord_hint(screen, ix, y, iw, " ^R ", running ? "running…" : "run fuzzer", bullet: "▸ ") unless running
+    end
+
+    private def render_prism_full(screen : Screen, rect : Rect, headline : String,
+                                  addr : String, capturing : Bool, scan_on : Bool) : Nil
+      inner_h = scan_on ? 6 + (capturing ? 0 : 1) + 2 : 4
+      _, inner, ix, iw = begin_card(screen, rect, headline, "PRISM", inner_h)
+      y = inner.y
+
+      if scan_on
+        screen.text(ix, y, "Passive scanning flags issues as traffic flows through the proxy.", Theme.text, Theme.bg, width: iw)
+        y += 2
+        screen.text(ix, y, "traffic ──► scan ──► issues", Theme.muted, Theme.bg, width: iw)
+        y += 2
+        screen.text(ix + 2, y, addr, Theme.accent, Theme.bg, Attribute::Bold, width: iw)
+        y += 2
+        unless capturing
+          screen.text(ix, y, "capture is OFF — press c to start", Theme.yellow, Theme.bg, width: iw)
+          y += 1
+        end
+        y = draw_chord_hint(screen, ix, y, iw, " m:MODE ", "cycle scan mode", bullet: "◇ ")
+        draw_palette_hint(screen, ix, y, iw, bullet: "▸ ")
+      else
+        screen.text(ix, y, "Prism is not analyzing traffic while scanning is OFF.", Theme.text, Theme.bg, width: iw)
+        y += 2
+        screen.text(ix, y, "enable PASSIVE (safe) or ACTIVE to detect issues", Theme.muted, Theme.bg, width: iw)
+        y += 2
+        draw_chord_hint(screen, ix, y, iw, " m:MODE ", "turn scanning on", bullet: "◇ ")
+      end
+    end
+
+    private def render_findings_full(screen : Screen, rect : Rect, headline : String) : Nil
+      inner_h = 5 + 2
+      _, inner, ix, iw = begin_card(screen, rect, headline, "FINDINGS", inner_h)
+      y = inner.y
+
+      screen.text(ix, y, "Track confirmed vulnerabilities you triage by hand.", Theme.text, Theme.bg, width: iw)
+      y += 2
+      screen.text(ix, y, "flow ──► finding ──► triage ──► resolve", Theme.muted, Theme.bg, width: iw)
+      y += 2
+      Frame.inner_divider(screen, inner, y, bg: Theme.bg, border: Theme.border)
+      y += 1
+      y = draw_chord_hint(screen, ix, y, iw, " ⇧F ", "finding from History flow", bullet: "▸ ")
+      draw_chord_hint(screen, ix, y, iw, " n ", "create a finding here", bullet: "▸ ")
+    end
+
+    private def render_notes_full(screen : Screen, rect : Rect) : Nil
+      inner_h = 5 + 1
+      card_h = inner_h + 2
+      card_w = {rect.w - 4, 46}.min.clamp(FULL_MIN_W, rect.w)
+      card = place_centered_card_in(rect, card_w, card_h)
+      Frame.card(screen, card, "NOTES", bg: Theme.bg, border: Theme.border)
+      inner = card.inset(1, 1)
+      ix = inner.x + 1
+      iw = {inner.w - 2, 1}.max
+      y = inner.y
+
+      screen.text(ix, y, "Your project scratchpad — observations, hypotheses, write-ups.", Theme.text, Theme.bg, width: iw)
+      y += 2
+      screen.text(ix, y, "notes stack as sub-tabs · first line becomes the title", Theme.muted, Theme.bg, width: iw)
+      y += 2
+      y = draw_chord_hint(screen, ix, y, iw, " ^N ", "new note tab", bullet: "▸ ")
+      draw_chord_hint(screen, ix, y, iw, " ^W ", "close current note", bullet: "▸ ")
+    end
+
+    private def medium_history(headline, addr, capturing) : Array(String)
+      lines = [headline, "──► proxy #{addr} ──► flows"]
+      lines << "capture is OFF — press c to start" unless capturing
+      lines << "^P → Open browser · or set HTTP+HTTPS proxy"
+      lines
+    end
+
+    private def medium_sitemap(headline, addr, capturing) : Array(String)
+      lines = [headline, "◆ proxy #{addr} → host tree"]
+      lines << "capture is OFF — press c to start" unless capturing
+      lines << "^P → Open browser · or set HTTP+HTTPS proxy"
+      lines
+    end
+
+    private def medium_intercept(headline, catch_on) : Array(String)
+      lines = [headline]
+      lines << (catch_on ? "⏸ queue empty · matching traffic pauses here" : "press i to enable catch")
+      lines << "f forward · d drop · / condition"
+      lines
+    end
+
+    private def medium_replay(headline) : Array(String)
+      [headline, "flow ──► edit ──► send", "^N new tab · History ^R replay"]
+    end
+
+    private def medium_fuzzer(headline) : Array(String)
+      [headline, "§ template ──► payloads ──► probe", "^N new session · ⇧I from History"]
+    end
+
+    private def medium_fuzzer_results(headline, running) : Array(String)
+      running ? [headline, "sampling probes…"] : [headline, "^O payload sets · ^R run"]
+    end
+
+    private def medium_prism(headline, scan_on) : Array(String)
+      if scan_on
+        [headline, "traffic ──► scan ──► issues", "m:MODE · capture in-scope traffic"]
+      else
+        [headline, "press m to enable scanning", "m:MODE cycle OFF/PASSIVE/ACTIVE"]
+      end
+    end
+
+    private def medium_findings(headline) : Array(String)
+      [headline, "flow ──► finding ──► triage", "⇧F from History · n create"]
+    end
+
+    private def medium_notes(headline) : Array(String)
+      [headline, "scratchpad for this project", "^N new note · ^W close"]
+    end
+
+    private def draw_medium_lines(screen : Screen, rect : Rect, lines : Array(String)) : Nil
+      y0 = rect.y
+      lines.each_with_index do |line, i|
+        y = y0 + i
+        break if y >= rect.bottom
+        col = i == 0 ? Theme.muted : (i == 1 ? Theme.accent : Theme.muted)
+        attr = i == 1 ? Attribute::Bold : Attribute::None
+        screen.text(rect.x + 1, y, line, col, attr: attr, width: {rect.w - 2, 0}.max)
+      end
+    end
+
+    private def draw_palette_hint(screen : Screen, ix : Int32, y : Int32, iw : Int32, *, bullet : String) : Int32
+      draw_chord_hint(screen, ix, y, iw, " ^P ", "Open browser", bullet: bullet)
+    end
+
+    private def draw_chord_hint(screen : Screen, ix : Int32, y : Int32, iw : Int32,
+                                chord : String, label : String, *, bullet : String) : Int32
+      bg = Theme.bg
+      screen.text(ix, y, bullet, Theme.muted, bg)
+      bx = ix + bullet.size
+      x = Frame.chip(screen, bx, y, chord, true) + 1
+      screen.text(x, y, " #{label}", Theme.text, bg, width: {ix + iw - x, 0}.max)
+      y + 1
+    end
+
+    private def fit_history_flow(listen : String, max_w : Int32) : String
+      full = "client ──► #{listen} ──► flows"
+      return full if full.size <= max_w
+      short = "──► proxy ──► flows"
+      short.size <= max_w ? short : "──► #{listen} ──►"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a shared `TrafficEmptyState` renderer so empty tabs show contextual onboarding instead of a single muted line.

- **Capture tabs** (History, Sitemap): proxy bind address, `^P` Open browser, capture-off hint
- **Workflow tabs** (Intercept, Replay, Fuzzer): tab-specific cards with relevant chords
- **Analysis tabs** (Prism, Findings): scan/triage guidance with distinct visual tone
- **Notes**: centred scratchpad card when the current note is blank

Filter/scope/triage empty cases keep the existing one-line recovery hints.

## Other changes

- Sitemap chrome now matches History: filter bar + `HOST / PATH` / `METHODS` headers + divider
- Empty-state cards are centred; headline text stays top-aligned in the list area

## Test plan

- [x] `crystal spec spec/tui/` — 429 examples, 0 failures
- [x] New `spec/tui/traffic_empty_state_spec.cr` covers variants and degrade tiers