### PR TITLE
Rebrand TUI top-bar and README title to ǤØɌɨ

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gori
+# ǤØɌɨ
 
 TODO: Write a description here
 

--- a/spec/tui/foundation_spec.cr
+++ b/spec/tui/foundation_spec.cr
@@ -131,7 +131,7 @@ describe Gori::Tui::Chrome do
     screen = Screen.new(backend)
     Chrome.render_top_bar(screen, Rect.new(0, 0, 80, 1),
       project: "acme", listen: "127.0.0.1:8080", time: "01:37 PM", scope: "scope:2")
-    backend.row(0).should contain("gori")
+    backend.row(0).should contain("ǤØɌɨ")
     backend.row(0).should contain("acme")
     backend.row(0).should contain("scope:2")
     backend.row(0).should contain("01:37 PM")

--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -86,7 +86,7 @@ module Gori::Tui
                             listen : String, time : String,
                             scope : String, rules : String = "", intercept : String = "") : Nil
       screen.fill(rect, Theme.panel)
-      x = screen.text(rect.x + 1, rect.y, "gori", Theme.text_bright, Theme.panel, Attribute::Bold)
+      x = screen.text(rect.x + 1, rect.y, "ǤØɌɨ", Theme.text_bright, Theme.panel, Attribute::Bold)
       screen.text(x + 1, rect.y, "· #{project}", Theme.muted, Theme.panel)
 
       # right-aligned status chips: scope:N · rules:N · intercept:on(N) · listen · h:MM AM/PM


### PR DESCRIPTION
## Summary
- Replace the "gori" logo text in the TUI top bar with "ǤØɌɨ"
- Update the README title to "ǤØɌɨ"
- Update the matching spec assertion in foundation_spec.cr

## Test plan
- [x] `crystal build --no-codegen src/gori.cr`
- [x] `crystal spec spec/tui/foundation_spec.cr`
- [x] `crystal spec` (full suite: 1224 examples, 8 pre-existing failures unrelated to this change, verified failing identically on main)