### PR TITLE
Retire dead AI placeholders; add get_current_context to MCP

### DIFF
--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -196,11 +196,11 @@ describe Gori::Settings do
     prev = ENV["GORI_HOME"]?
     begin
       ENV["GORI_HOME"] = dir
-      Gori::Settings.tab_prefs = [{"help", true}, {"project", true}, {"agent", false}]
+      Gori::Settings.tab_prefs = [{"help", true}, {"project", true}, {"miner", false}]
       Gori::Settings.save.should be_true
       Gori::Settings.tab_prefs = [] of {String, Bool} # clear, then reload from disk
       Gori::Settings.load
-      Gori::Settings.tab_prefs.should eq([{"help", true}, {"project", true}, {"agent", false}])
+      Gori::Settings.tab_prefs.should eq([{"help", true}, {"project", true}, {"miner", false}])
 
       # an older file with no "tabs" key keeps the current in-memory value (the default
       # [] at real startup), like the other fields — never resurrects a phantom layout

--- a/spec/tui/chrome_tabs_spec.cr
+++ b/spec/tui/chrome_tabs_spec.cr
@@ -10,8 +10,8 @@ describe "Chrome.reconcile" do
     out = Chrome.reconcile([] of {String, Bool})
     out.map(&.first).should eq(Chrome::TABS.map(&.first)) # canonical order, all present
     visible = out.select { |(_, _, v)| v }.map(&.first)
-    Chrome::DEFAULT_HIDDEN.each { |sym| visible.includes?(sym).should be_false } # only :agent hidden
-    out.find { |(s, _, _)| s == :agent }.not_nil![2].should be_false
+    Chrome::DEFAULT_HIDDEN.each { |sym| visible.includes?(sym).should be_false } # only :miner hidden
+    out.find { |(s, _, _)| s == :miner }.not_nil![2].should be_false
     out.find { |(s, _, _)| s == :comparer }.not_nil![2].should be_true # now a default-visible tab
     out.find { |(s, _, _)| s == :convert }.not_nil![2].should be_true  # now a default-visible tab
     out.find { |(s, _, _)| s == :project }.not_nil![2].should be_true
@@ -19,10 +19,10 @@ describe "Chrome.reconcile" do
 
   it "honors a stored order and visibility, inserting absent catalog tabs at their position" do
     out = Chrome.reconcile([{"help", true}, {"project", false}])
-    out[0][0].should eq(:help)    # stored order respected
+    out[0][0].should eq(:help) # stored order respected
     out[1][0].should eq(:project)
-    out[1][2].should be_false     # explicit hide survives
-    out.map(&.first).includes?(:history).should be_true # inserted (was absent from prefs)
+    out[1][2].should be_false                                         # explicit hide survives
+    out.map(&.first).includes?(:history).should be_true               # inserted (was absent from prefs)
     out.find { |(s, _, _)| s == :history }.not_nil![2].should be_true # inserted visible
   end
 
@@ -54,7 +54,7 @@ end
 describe "Chrome.visible_tabs" do
   it "returns only the visible tabs in order (default-hidden tabs excluded)" do
     vis = Chrome.visible_tabs([] of {String, Bool}).map(&.first)
-    vis.includes?(:agent).should be_false # only Agent is hidden by default now
+    vis.includes?(:miner).should be_false # only Miner is hidden by default now
     vis.includes?(:comparer).should be_true
     vis.includes?(:convert).should be_true
     vis.first.should eq(:project)
@@ -62,11 +62,12 @@ describe "Chrome.visible_tabs" do
   end
 
   it "force-includes a hidden active tab at its catalog-relative position" do
-    # Agent hidden by default; forcing it must slot it where it sits in the catalog (last).
-    vis = Chrome.visible_tabs([] of {String, Bool}, force: :agent).map(&.first)
-    vis.includes?(:agent).should be_true
-    vis.index(:agent).not_nil!.should be > vis.index(:notes).not_nil!
-    vis.index(:agent).not_nil!.should be < vis.index(:help).not_nil!
+    # Miner hidden by default; forcing it must slot it where it sits in the catalog
+    # (between Fuzzer and Convert).
+    vis = Chrome.visible_tabs([] of {String, Bool}, force: :miner).map(&.first)
+    vis.includes?(:miner).should be_true
+    vis.index(:miner).not_nil!.should be > vis.index(:fuzzer).not_nil!
+    vis.index(:miner).not_nil!.should be < vis.index(:convert).not_nil!
   end
 
   it "places the default-visible Convert tab between Fuzzer and Comparer" do

--- a/spec/tui/foundation_spec.cr
+++ b/spec/tui/foundation_spec.cr
@@ -90,9 +90,9 @@ describe Gori::Tui::Chrome do
   it "windows the tab strip so the active tab stays visible when the row is too narrow" do
     backend = MemoryBackend.new(30, 2)
     Chrome.render_menu(Screen.new(backend), Rect.new(0, 1, 30, 1),
-      active_tab: :agent, focused: true)      # last tab — can't all fit in 30 cols
-    backend.contains?("Agent").should be_true # scrolled into view, not dropped
-    backend.row(1).should contain("‹")        # indicator that earlier tabs are hidden
+      active_tab: :help, focused: true)      # last tab — can't all fit in 30 cols
+    backend.contains?("Help").should be_true # scrolled into view, not dropped
+    backend.row(1).should contain("‹")       # indicator that earlier tabs are hidden
   end
 
   it "renders the focus-area badge at the far left of the status bar" do

--- a/spec/tui/palette_spec.cr
+++ b/spec/tui/palette_spec.cr
@@ -79,7 +79,7 @@ describe Gori::Tui::PaletteState do
     r = Gori::Verbs.registry
     # The named tab jumps are the only by-command way to reach a tab hidden in
     # settings:tabs — so every entry in the canonical catalog (incl. the default-hidden
-    # Fuzzer/Miner/Agent) must have one, or it becomes unreachable from the palette.
+    # Miner) must have one, or it becomes unreachable from the palette.
     Gori::Tui::Chrome::TABS.each do |(tab, label)|
       verb = r["tab.#{tab}"]?
       verb.should_not be_nil

--- a/src/gori/app.cr
+++ b/src/gori/app.cr
@@ -55,7 +55,7 @@ module Gori
 
       begin
         # First-run onboarding: no settings.json yet → walk the user through bind /
-        # theme / AI setup once. Inside `begin` so the `ensure term.close` restores
+        # theme setup once. Inside `begin` so the `ensure term.close` restores
         # the terminal if it raises. The wizard persists settings.json (even on skip),
         # so it never auto-launches again.
         Tui::SetupWizard.new(term).run unless File.exists?(Settings.path)

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -18,7 +18,7 @@ module Gori
   # - `gori export ca-cert`         → print CA cert path (refactors old --export-ca)
   # - `gori run <sub>`              → non-interactive CLI (see Gori::CLI::Run)
   # - `gori mcp`                    → MCP (Model Context Protocol) server over stdio
-  # - `gori wizard`                 → interactive first-run setup wizard (bind/theme/AI)
+  # - `gori wizard`                 → interactive first-run setup wizard (bind/theme)
   # - `gori update`                 → print how to update gori (no built-in self-update yet)
   #
   # Old flat flags (`gori --headless`, `gori --export-ca` ...) continue to work
@@ -74,7 +74,7 @@ module Gori
       puts "  settings  Print/edit the persistent settings file (settings.json)"
       puts "  export    Export things (currently only ca-cert)"
       puts "  run       Non-interactive CLI: capture, history, show, replay, findings, projects"
-      puts "  wizard    Interactive setup wizard (bind, theme, AI) — also runs on first launch"
+      puts "  wizard    Interactive setup wizard (bind, theme) — also runs on first launch"
       puts "  mcp       Start an MCP server over stdio (AI/tool integration)"
       puts "  update    Show how to update gori to the latest version"
       puts ""
@@ -321,11 +321,13 @@ module Gori
         abort "gori mcp: no such project: #{name}" unless proj
         return {proj.db_path, proj.name}
       end
-      # Prefer the project the interactive TUI last opened (its ui-state is what
-      # get_current_context reports); fall back to the mtime-MRU project, then the default db.
-      if name = Paths.read_active_project
-        if proj = registry.list.find { |p| p.name.downcase == name.downcase }
-          return {proj.db_path, proj.name}
+      # Prefer the db path the interactive TUI last recorded (its ui-state is what
+      # get_current_context reports). Match by PATH, not name, so a project's display name
+      # vs its dir slug can't miss. Fall back to the mtime-MRU project, then the default db.
+      if path = Paths.read_active_project
+        if File.file?(path)
+          proj = registry.list.find { |p| p.db_path == path }
+          return {path, proj.try(&.name)}
         end
       end
       mru = registry.list.first?

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -219,7 +219,7 @@ module Gori
     end
 
     # `gori wizard` launches the interactive, step-by-step setup wizard (bind
-    # address → theme → AI provider). It also runs automatically on first launch
+    # address → theme). It also runs automatically on first launch
     # (App#run_tui, when settings.json doesn't exist yet); this command re-runs it
     # anytime. Config-only — it edits settings.json + the live theme, so it sets up
     # its own terminal directly instead of going through App (which eagerly loads
@@ -227,7 +227,7 @@ module Gori
     private def self.run_wizard(args : Array(String)) : Nil
       if args.any? { |a| ["-h", "--help"].includes?(a) }
         puts "Usage: gori wizard"
-        puts "  Interactive setup wizard: proxy bind address, TUI theme, AI provider."
+        puts "  Interactive setup wizard: proxy bind address, TUI theme."
         puts "  Runs automatically on first launch; use this to re-run it anytime."
         return
       end
@@ -320,6 +320,13 @@ module Gori
         proj = registry.list.find { |p| p.name.downcase == name.downcase }
         abort "gori mcp: no such project: #{name}" unless proj
         return {proj.db_path, proj.name}
+      end
+      # Prefer the project the interactive TUI last opened (its ui-state is what
+      # get_current_context reports); fall back to the mtime-MRU project, then the default db.
+      if name = Paths.read_active_project
+        if proj = registry.list.find { |p| p.name.downcase == name.downcase }
+          return {proj.db_path, proj.name}
+        end
       end
       mru = registry.list.first?
       {mru.try(&.db_path) || Paths.default_db, mru.try(&.name)}

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -150,6 +150,13 @@ module Gori
             "Project totals: flow count, finding count, captured bytes, earliest capture time, " \
             "plus which project/db is being served (important when no --project was passed)." { }
 
+          tool j, "get_current_context",
+            "What the user is currently viewing in the gori TUI: active tab, focused pane, the " \
+            "selected flow id, and sub-tab index — so you can act on \"the request I'm looking at " \
+            "right now\" without the user pasting ids. Reflects an open (or last-open) gori TUI for " \
+            "this project. Check `project_match`: if false, the focus is for a different project " \
+            "than this server serves. `age_seconds` shows how long since the TUI last recorded focus." { }
+
           if @allow_actions
             tool j, "send_request",
               "Send/replay an HTTP request to its origin and return the response. " \
@@ -279,14 +286,15 @@ module Gori
       # Read-only tools (always exposed). nil when `name` isn't one of them.
       private def read_tool(name : String, h) : Result?
         case name
-        when "list_history"  then list_history(h)
-        when "get_flow"      then get_flow(h)
-        when "list_sitemap"  then list_sitemap(h)
-        when "list_findings" then list_findings(h)
-        when "get_finding"   then get_finding(h)
-        when "list_scope"    then list_scope
-        when "project_info"  then project_info
-        when "ql_reference"  then ql_reference
+        when "list_history"        then list_history(h)
+        when "get_flow"            then get_flow(h)
+        when "list_sitemap"        then list_sitemap(h)
+        when "list_findings"       then list_findings(h)
+        when "get_finding"         then get_finding(h)
+        when "list_scope"          then list_scope
+        when "project_info"        then project_info
+        when "get_current_context" then get_current_context
+        when "ql_reference"        then ql_reference
         end
       end
 
@@ -407,6 +415,51 @@ module Gori
             j.field "earliest_created_at", @store.earliest_created_at
             if ea = @store.earliest_created_at
               j.field "earliest_created_at_iso", Serialize.unix_micros_iso(ea)
+            end
+          end
+        end)
+      end
+
+      # What the user is currently viewing in the gori TUI, recorded cross-process to the
+      # project store (Store::UI_STATE_KEY) by the running TUI. Read-only + honest: reports
+      # a project mismatch / freshness rather than silently returning stale focus.
+      private def get_current_context : Result
+        raw = @store.setting(Store::UI_STATE_KEY)
+        parsed = raw.try do |r|
+          begin
+            JSON.parse(r)
+          rescue
+            nil
+          end
+        end
+        Result.new(JSON.build do |j|
+          j.object do
+            j.field "project", @project_name # what this server serves
+            if parsed.nil?
+              j.field "available", false
+              j.field "note", raw.nil? ? "No UI state recorded for this project — the gori TUI may not have run against it." : "Recorded UI state was unreadable."
+            else
+              ctx_project = parsed["active_project"]?.try(&.as_s?)
+              match = ctx_project.nil? || @project_name.nil? || ctx_project == @project_name
+              j.field "available", true
+              j.field "context_project", ctx_project # project the TUI recorded focus for
+              j.field "project_match", match
+              j.field "active_tab", parsed["active_tab"]?.try(&.as_s?)
+              j.field "focus_pane", parsed["focus_pane"]?.try(&.as_s?)
+              if fid = parsed["selected_flow_id"]?.try(&.as_i64?)
+                j.field "selected_flow_id", fid
+              end
+              if st = parsed["subtab"]?.try(&.as_i64?)
+                j.field "subtab", st
+              end
+              if rec = parsed["recorded_at"]?.try(&.as_i64?)
+                j.field "recorded_at", rec
+                j.field "recorded_at_iso", Time.unix_ms(rec).to_rfc3339
+                j.field "age_seconds", (Time.utc.to_unix_ms - rec) // 1000
+              end
+              unless match
+                j.field "note", "The recorded focus is for project '#{ctx_project}', not the served '#{@project_name}' — selected_flow_id refers to the other project."
+              end
             end
           end
         end)

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -152,10 +152,11 @@ module Gori
 
           tool j, "get_current_context",
             "What the user is currently viewing in the gori TUI: active tab, focused pane, the " \
-            "selected flow id, and sub-tab index — so you can act on \"the request I'm looking at " \
-            "right now\" without the user pasting ids. Reflects an open (or last-open) gori TUI for " \
-            "this project. Check `project_match`: if false, the focus is for a different project " \
-            "than this server serves. `age_seconds` shows how long since the TUI last recorded focus." { }
+            "History-selected flow id (only when on the History tab), and sub-tab index — so you " \
+            "can act on \"what I'm looking at right now\" without the user pasting ids. Reflects an " \
+            "open (or last-open) gori TUI for THIS project. `age_seconds` shows how long since the " \
+            "TUI last recorded focus (there is no live-TUI heartbeat) — use it to judge freshness; " \
+            "`available:false` means the TUI never ran against this project." { }
 
           if @allow_actions
             tool j, "send_request",
@@ -421,8 +422,10 @@ module Gori
       end
 
       # What the user is currently viewing in the gori TUI, recorded cross-process to the
-      # project store (Store::UI_STATE_KEY) by the running TUI. Read-only + honest: reports
-      # a project mismatch / freshness rather than silently returning stale focus.
+      # project store (Store::UI_STATE_KEY) by the running TUI. Read-only. The ui-state lives in
+      # THIS project's db, so it always describes this project — freshness is reported via
+      # age_seconds (there is no live-TUI heartbeat), not a name comparison that would skew on
+      # display-name-vs-slug.
       private def get_current_context : Result
         raw = @store.setting(Store::UI_STATE_KEY)
         parsed = raw.try do |r|
@@ -434,16 +437,12 @@ module Gori
         end
         Result.new(JSON.build do |j|
           j.object do
-            j.field "project", @project_name # what this server serves
+            j.field "project", @project_name # the project/db this server serves
             if parsed.nil?
               j.field "available", false
               j.field "note", raw.nil? ? "No UI state recorded for this project — the gori TUI may not have run against it." : "Recorded UI state was unreadable."
             else
-              ctx_project = parsed["active_project"]?.try(&.as_s?)
-              match = ctx_project.nil? || @project_name.nil? || ctx_project == @project_name
               j.field "available", true
-              j.field "context_project", ctx_project # project the TUI recorded focus for
-              j.field "project_match", match
               j.field "active_tab", parsed["active_tab"]?.try(&.as_s?)
               j.field "focus_pane", parsed["focus_pane"]?.try(&.as_s?)
               if fid = parsed["selected_flow_id"]?.try(&.as_i64?)
@@ -454,11 +453,17 @@ module Gori
               end
               if rec = parsed["recorded_at"]?.try(&.as_i64?)
                 j.field "recorded_at", rec
-                j.field "recorded_at_iso", Time.unix_ms(rec).to_rfc3339
-                j.field "age_seconds", (Time.utc.to_unix_ms - rec) // 1000
-              end
-              unless match
-                j.field "note", "The recorded focus is for project '#{ctx_project}', not the served '#{@project_name}' — selected_flow_id refers to the other project."
+                # A corrupt/out-of-range recorded_at must not sink the whole tool: Time.unix_ms
+                # raises on out-of-range, so guard it — keep the raw value, drop derived fields.
+                iso = begin
+                  Time.unix_ms(rec).to_rfc3339
+                rescue
+                  nil
+                end
+                if iso
+                  j.field "recorded_at_iso", iso
+                  j.field "age_seconds", (Time.utc.to_unix_ms - rec) // 1000
+                end
               end
             end
           end

--- a/src/gori/paths.cr
+++ b/src/gori/paths.cr
@@ -35,6 +35,30 @@ module Gori
       File.join(home_dir, "wordlists")
     end
 
+    # A tiny global marker naming the project the interactive TUI last opened, so a
+    # separate `gori mcp` process (given no --db/--project) serves what the user is
+    # viewing instead of an mtime-MRU guess. Never cleared — the last-viewed project is
+    # the sensible default after the TUI closes. Read by CLI.resolve_mcp_db.
+    def self.active_project_file : String
+      File.join(home_dir, "active_project")
+    end
+
+    def self.write_active_project(name : String) : Nil
+      ensure_dir(home_dir)
+      dest = active_project_file
+      tmp = "#{dest}.tmp.#{Process.pid}"
+      File.write(tmp, name)
+      File.rename(tmp, dest)
+    rescue
+      # best-effort: a missing/failed marker just falls back to MRU in resolve_mcp_db.
+    end
+
+    def self.read_active_project : String?
+      File.read(active_project_file).strip.presence
+    rescue
+      nil
+    end
+
     def self.ensure_dirs : Nil
       ensure_dir(home_dir)
       ensure_dir(wordlists_dir)

--- a/src/gori/paths.cr
+++ b/src/gori/paths.cr
@@ -35,19 +35,20 @@ module Gori
       File.join(home_dir, "wordlists")
     end
 
-    # A tiny global marker naming the project the interactive TUI last opened, so a
-    # separate `gori mcp` process (given no --db/--project) serves what the user is
-    # viewing instead of an mtime-MRU guess. Never cleared — the last-viewed project is
-    # the sensible default after the TUI closes. Read by CLI.resolve_mcp_db.
+    # A tiny global marker holding the DB PATH of the project the interactive TUI last
+    # opened, so a separate `gori mcp` process (given no --db/--project) serves what the user
+    # is viewing instead of an mtime-MRU guess. Path (not name) so display-name-vs-slug never
+    # breaks resolution. Never cleared — the last-viewed project is the sensible default after
+    # the TUI closes (a since-deleted path just falls through to MRU). Read by CLI.resolve_mcp_db.
     def self.active_project_file : String
       File.join(home_dir, "active_project")
     end
 
-    def self.write_active_project(name : String) : Nil
+    def self.write_active_project(path : String) : Nil
       ensure_dir(home_dir)
       dest = active_project_file
       tmp = "#{dest}.tmp.#{Process.pid}"
-      File.write(tmp, name)
+      File.write(tmp, path)
       File.rename(tmp, dest)
     rescue
       # best-effort: a missing/failed marker just falls back to MRU in resolve_mcp_db.

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -302,6 +302,11 @@ module Gori
       exec_task ->(c : DB::Connection) { c.exec("DELETE FROM host_overrides WHERE id = ?", id); nil }
     end
 
+    # Key under which the TUI records what the user is currently viewing (active tab,
+    # focus pane, selected flow, sub-tab) so a separate `gori mcp` process can report it
+    # via get_current_context. Written cross-process through the shared settings table.
+    UI_STATE_KEY = "ui_state"
+
     def setting(key : String) : String?
       @db.query_one?("SELECT value FROM settings WHERE key = ?", key, as: String)
     end

--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -19,14 +19,13 @@ module Gori::Tui
       {:prism, "Prism"},
       {:findings, "Findings"},
       {:notes, "Notes"},
-      {:agent, "Agent"},
       {:help, "Help"},
     ]
 
-    # Tabs hidden by default on a fresh install (re-enableable in settings:tabs). Agent
-    # is a non-functional "coming soon" placeholder. Only affects reconcile's append
-    # path — once the user saves, tab_prefs is explicit and this no longer applies.
-    DEFAULT_HIDDEN = [:agent, :miner]
+    # Tabs hidden by default on a fresh install (re-enableable in settings:tabs). Only
+    # affects reconcile's append path — once the user saves, tab_prefs is explicit and
+    # this no longer applies.
+    DEFAULT_HIDDEN = [:miner]
 
     # Reconcile stored prefs against the canonical catalog → full ordered
     # {symbol, label, visible?}. Removed/unknown ids are dropped, duplicates collapse to

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -252,9 +252,10 @@ module Gori::Tui
     end
 
     def run : Symbol
-      # Record the opened project globally so a separate `gori mcp` (given no --db/--project)
-      # serves what the user is actually viewing instead of an mtime-MRU guess.
-      Paths.write_active_project(@session.project.name)
+      # Record the opened project's db path globally so a separate `gori mcp` (given no
+      # --db/--project) serves what the user is viewing instead of an mtime-MRU guess. Path,
+      # not name, so display-name-vs-slug never breaks resolution (see CLI.resolve_mcp_db).
+      Paths.write_active_project(@session.project.db_path)
       history_controller.view.reload(@session.store)
       notes_controller.view.reload(@session.store) # load persisted notes up front so the tab is ready before it's ever focused
       # Surface the bind outcome on entry: capture-off if nothing could bind, or a
@@ -394,21 +395,29 @@ module Gori::Tui
     # Braille spinner frames (U+2800–U+28FF: EAW-Neutral width 1, no emoji/VS16).
     SPINNER = ['⣾', '⣽', '⣻', '⢿', '⡿', '⣟', '⣯', '⣷']
 
+    # The flow the user is looking at, but only where that's meaningful — the History list.
+    # Replay/Fuzzer/etc. carry their own selection semantics (session ids, not flow ids), so we
+    # don't conflate them under one "selected flow" that get_current_context would misreport.
+    private def current_selected_flow_id : Int64?
+      @active_tab == :history ? history_controller.selected_flow_id : nil
+    end
+
     # A cheap identity of "what the user is viewing" for change detection — no timestamp,
     # so an unchanged view yields a stable string (ui_state_json stamps the time on write).
+    # Project is constant per session, so it's not part of the identity.
     private def ui_state_identity : String
-      "#{@active_tab}|#{@focus}|#{history_controller.selected_flow_id}|#{current_subtab_index}|#{@session.project.name}"
+      "#{@active_tab}|#{@focus}|#{current_selected_flow_id}|#{current_subtab_index}"
     end
 
     # The ui-state payload written to the project store, read cross-process by
-    # `gori mcp get_current_context` to report what the user is currently viewing.
+    # `gori mcp get_current_context`. It lives in this project's own db, so the served project
+    # identity is implicit — no name field (which would skew display-name vs slug).
     private def ui_state_json : String
       JSON.build do |j|
         j.object do
-          j.field "active_project", @session.project.name
           j.field "active_tab", @active_tab.to_s
           j.field "focus_pane", @focus.to_s
-          if fid = history_controller.selected_flow_id
+          if fid = current_selected_flow_id
             j.field "selected_flow_id", fid
           end
           j.field "subtab", current_subtab_index

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -76,8 +76,8 @@ module Gori::Tui
       @finding_form = FindingForm.new
       @palette = PaletteState.new(@session.registry)
       @space_menu = SpaceMenu.new(@session.registry)
-      # Land on the home tab, but never on a hidden one (settings:tabs may hide Project,
-      # and Agent is hidden by default). Settings is loaded (cli.cr) before Runner.new.
+      # Land on the home tab, but never on a hidden one (settings:tabs may hide Project;
+      # Miner is hidden by default). Settings is loaded (cli.cr) before Runner.new.
       vis = Chrome.visible_tabs(Settings.tab_prefs).map(&.first)
       @active_tab = vis.includes?(:project) ? :project : vis.first
       @overlay = :none # :none | :palette | :detail | :rules | :finding_new | :confirm | :browser | :choice | :comparer_pick | :replay_subtab | :links | :finding_pick | :note_pick | :settings | :tabs | :hosts | :hotkeys | :notifications | :mine_config | :fuzz_set | :fuzz_advanced
@@ -252,6 +252,9 @@ module Gori::Tui
     end
 
     def run : Symbol
+      # Record the opened project globally so a separate `gori mcp` (given no --db/--project)
+      # serves what the user is actually viewing instead of an mtime-MRU guess.
+      Paths.write_active_project(@session.project.name)
       history_controller.view.reload(@session.store)
       notes_controller.view.reload(@session.store) # load persisted notes up front so the tab is ready before it's ever focused
       # Surface the bind outcome on entry: capture-off if nothing could bind, or a
@@ -290,8 +293,10 @@ module Gori::Tui
       last_wf = @session.store.write_failures
       last_dv = @session.store.data_version # SQLite change counter for cross-process refresh
       last_dv_poll = Time.instant
-      last_spin = Time.instant # advances the background-job spinner frame
-      last_clock = clock_label # top-bar wall clock; re-render only when the minute rolls over
+      last_spin = Time.instant        # advances the background-job spinner frame
+      last_clock = clock_label        # top-bar wall clock; re-render only when the minute rolls over
+      last_ui_ident = nil.as(String?) # last-written ui-state identity (see UI_STATE_THROTTLE)
+      last_ui_write = Time.instant
       loop do
         ev = @term.poll_event(50)
         dirty = false
@@ -357,6 +362,15 @@ module Gori::Tui
           last_clock = clock
           dirty = true
         end
+        # Record what the user is currently viewing (active tab / focus / selection) to
+        # the project store so a separate `gori mcp` process can report it via
+        # get_current_context. Throttled + diffed so idle focus never churns the WAL.
+        ident = ui_state_identity
+        if ident != last_ui_ident && (last_ui_ident.nil? || now - last_ui_write >= UI_STATE_THROTTLE)
+          @session.store.set_setting(Store::UI_STATE_KEY, ui_state_json)
+          last_ui_ident = ident
+          last_ui_write = now
+        end
         render if dirty
         break unless @outcome == :running
       end
@@ -370,11 +384,38 @@ module Gori::Tui
     # 50ms tick — ~sub-second freshness is plenty.
     DV_POLL_INTERVAL = 750.milliseconds
 
+    # Minimum spacing between ui-state writes (get_current_context). Coalesces a fast
+    # focus/scroll burst into ≤1 write per window so the WAL never churns per frame.
+    UI_STATE_THROTTLE = 300.milliseconds
+
     # How fast the bottom-bar background-job spinner advances (only while a job runs).
     SPINNER_INTERVAL = 120.milliseconds
 
     # Braille spinner frames (U+2800–U+28FF: EAW-Neutral width 1, no emoji/VS16).
     SPINNER = ['⣾', '⣽', '⣻', '⢿', '⡿', '⣟', '⣯', '⣷']
+
+    # A cheap identity of "what the user is viewing" for change detection — no timestamp,
+    # so an unchanged view yields a stable string (ui_state_json stamps the time on write).
+    private def ui_state_identity : String
+      "#{@active_tab}|#{@focus}|#{history_controller.selected_flow_id}|#{current_subtab_index}|#{@session.project.name}"
+    end
+
+    # The ui-state payload written to the project store, read cross-process by
+    # `gori mcp get_current_context` to report what the user is currently viewing.
+    private def ui_state_json : String
+      JSON.build do |j|
+        j.object do
+          j.field "active_project", @session.project.name
+          j.field "active_tab", @active_tab.to_s
+          j.field "focus_pane", @focus.to_s
+          if fid = history_controller.selected_flow_id
+            j.field "selected_flow_id", fid
+          end
+          j.field "subtab", current_subtab_index
+          j.field "recorded_at", Time.utc.to_unix_ms
+        end
+      end
+    end
 
     private def drain_events : Bool
       drained = false
@@ -753,14 +794,14 @@ module Gori::Tui
       @tabs[@active_tab]?.try(&.subtab_index) || 0
     end
 
-    # Per-tab body click. Notes (a lone editor) + Agent just take focus; cursor
-    # placement inside editors is Phase 2.
+    # Per-tab body click. Every tab has a controller; the fallback just takes focus
+    # defensively if somehow none is registered for the active tab.
     private def click_body(body : Rect, mx : Int32, my : Int32) : Nil
-      if c = @tabs[@active_tab]? # migrated tab — controller owns its body clicks
+      if c = @tabs[@active_tab]? # controller owns its body clicks
         c.handle_click(body, mx, my)
         return
       end
-      @focus = :body # unmigrated/placeholder tab (e.g. :agent) — just take focus
+      @focus = :body # defensive: no controller for the active tab — just take focus
     end
 
     # Sitemap: a click selects the row; a click on the ▾/▸ marker toggles it
@@ -2455,20 +2496,15 @@ module Gori::Tui
     end
 
     # Body hints come from the active tab's controller (it knows its focused pane);
-    # an unmigrated/placeholder tab falls back to the bare ring reminder.
+    # falls back to the bare ring reminder if no controller is registered.
     private def body_hints : String
       @tabs[@active_tab]?.try(&.body_hint(@focus)) || "↹/esc tabs · ^P cmds · q projects · ^D quit"
     end
 
     private def render_body(screen : Screen, rect : Rect) : Nil
-      if c = @tabs[@active_tab]? # migrated tab — controller owns its body render
-        c.render_body(screen, rect, @focus)
-        return
-      end
-      # Unmigrated/placeholder tab (e.g. the half-wired :agent).
-      BodyChrome.framed(screen, rect, @focus == :body) do |inner|
-        screen.text(inner.x + 1, inner.y, "#{@active_tab.to_s.capitalize} — coming soon", Theme.muted)
-      end
+      # Every catalog tab has a controller that owns its body render; the `?` guard is
+      # defensive (a blank body beats a crash if the active tab ever lacks one).
+      @tabs[@active_tab]?.try(&.render_body(screen, rect, @focus))
     end
 
     # --- ExecContext (verbs drive the UI through these) ----------------------

--- a/src/gori/tui/setup_wizard.cr
+++ b/src/gori/tui/setup_wizard.cr
@@ -13,8 +13,7 @@ module Gori::Tui
   # `gori wizard`. A config-only tool — no Session/proxy/CA — so it just edits the
   # global Settings + live Theme, mirroring ProjectPicker's run-loop/render shape.
   #
-  # Steps: NETWORK (bind ip/port) → THEME (list + live preview) → AI PROVIDER
-  # (informational yes/no, NOT persisted) → REVIEW (recap + finish).
+  # Steps: NETWORK (bind ip/port) → THEME (list + live preview) → REVIEW (recap + finish).
   #
   # Edits are STAGED in wizard-local fields and committed to Settings only on
   # finish, so "skip" (Esc) is coherent: it reverts the live theme preview to the
@@ -30,7 +29,6 @@ module Gori::Tui
     enum Step
       Bind       # bind ip/port
       Appearance # theme (named Appearance to avoid clashing with the Theme module)
-      Provider   # AI provider (informational)
       Review     # recap + finish
     end
 
@@ -49,8 +47,6 @@ module Gori::Tui
       @theme_name = Theme.canonical(Settings.theme)
       @theme_baseline = Theme.active_name # reverted on skip
       @theme_scroll = 0
-      # AI step — local toggle only; the answer is never written anywhere.
-      @ai_interested = false
       @resized = false # forces a full repaint (resize OR a live theme swap)
       @running = false
     end
@@ -90,7 +86,6 @@ module Gori::Tui
       case @step
       when Step::Bind       then handle_bind_key(ev)
       when Step::Appearance then handle_theme_key(ev)
-      when Step::Provider   then handle_provider_key(ev)
       when Step::Review     then handle_review_key(ev)
       end
     end
@@ -127,7 +122,7 @@ module Gori::Tui
     private def handle_theme_key(ev : Termisu::Event::Key) : Nil
       key = ev.key
       if key.enter? || key.tab?
-        @step = Step::Provider
+        @step = Step::Review
       elsif key.back_tab?
         back_to_bind
       elsif key.up? || key.left?
@@ -137,25 +132,13 @@ module Gori::Tui
       end
     end
 
-    # AI step (informational): ↑/↓/←/→/space toggle yes/no; ↵/⇥ next; ⇧⇥ back.
-    private def handle_provider_key(ev : Termisu::Event::Key) : Nil
-      key = ev.key
-      if key.enter? || key.tab?
-        @step = Step::Review
-      elsif key.back_tab?
-        @step = Step::Appearance
-      elsif key.up? || key.down? || key.left? || key.right? || key.space?
-        @ai_interested = !@ai_interested
-      end
-    end
-
     # Review step: ↵ finishes (commit + persist); ⇧⇥ back.
     private def handle_review_key(ev : Termisu::Event::Key) : Nil
       key = ev.key
       if key.enter?
         finish
       elsif key.back_tab?
-        @step = Step::Provider
+        @step = Step::Appearance
       end
     end
 
@@ -263,7 +246,6 @@ module Gori::Tui
       end
       case @step
       when Step::Appearance then click_theme(mx, my)
-      when Step::Provider   then click_provider(mx, my)
       end
     end
 
@@ -281,18 +263,6 @@ module Gori::Tui
       @theme_name = names[i]
       Theme.apply(@theme_name)
       @resized = true
-    end
-
-    private def click_provider(mx : Int32, my : Int32) : Nil
-      w, h = @backend.size
-      box = step_card(w, h)
-      return unless box.contains?(mx, my)
-      oy = box.y + 2 + 3 # see render_provider: options start 3 rows below the title
-      if my == oy
-        @ai_interested = true
-      elsif my == oy + 1
-        @ai_interested = false
-      end
     end
 
     # --- geometry ------------------------------------------------------------
@@ -317,9 +287,8 @@ module Gori::Tui
     # short to hold them, and render_* draw at fixed offsets up to `box.y + 2 + this`.
     private def content_rows : Int32
       case @step
-      when Step::Bind     then 7 # heading, gap, ip, port, gap, info, status
-      when Step::Provider then 7 # question, note, gap, yes, no, gap, footnote
-      when Step::Review   then 8 # title, gap, 3 recap rows, gap, 2 reminder rows
+      when Step::Bind   then 7 # heading, gap, ip, port, gap, info, status
+      when Step::Review then 7 # title, gap, 2 recap rows, gap, 2 reminder rows
       # ≥7 so the preview panel (header + 3 status rows) is never clipped, capped so a
       # long theme list scrolls (the list viewport derives from the card height) instead
       # of demanding the whole screen.
@@ -358,7 +327,6 @@ module Gori::Tui
       case @step
       when Step::Bind       then render_bind(screen, box)
       when Step::Appearance then render_theme(screen, box)
-      when Step::Provider   then render_provider(screen, box)
       when Step::Review     then render_review(screen, box)
       end
       render_footer(screen, w, h)
@@ -389,9 +357,8 @@ module Gori::Tui
 
     private def progress_label : String
       case @step
-      when Step::Bind       then "step 1 of 3"
-      when Step::Appearance then "step 2 of 3"
-      when Step::Provider   then "step 3 of 3"
+      when Step::Bind       then "step 1 of 2"
+      when Step::Appearance then "step 2 of 2"
       else                       "review"
       end
     end
@@ -400,7 +367,6 @@ module Gori::Tui
       case @step
       when Step::Bind       then "NETWORK · proxy bind"
       when Step::Appearance then "THEME · appearance"
-      when Step::Provider   then "AI PROVIDER"
       else                       "REVIEW"
       end
     end
@@ -409,7 +375,6 @@ module Gori::Tui
       hint = case @step
              when Step::Bind       then "↵ next · ↑/↓ field · esc skip"
              when Step::Appearance then "↑/↓ pick theme · ↵ next · ⇧⇥ back · esc skip"
-             when Step::Provider   then "↑/↓ choose · ↵ next · ⇧⇥ back · esc skip"
              else                       "↵ finish · ⇧⇥ back · esc skip"
              end
       screen.text({(w - hint.size) // 2, 0}.max, h - 1, hint, Theme.muted, Theme.bg)
@@ -534,33 +499,13 @@ module Gori::Tui
       end
     end
 
-    private def render_provider(screen : Screen, box : Rect) : Nil
-      ix = box.x + 3
-      iw = {box.w - 6, 1}.max
-      screen.text(ix, box.y + 2, "Set up an AI provider?", Theme.text_bright, Theme.panel, width: iw)
-      screen.text(ix, box.y + 3, "gori's AI features are coming soon — you'll connect a provider here.", Theme.muted, Theme.panel, width: iw)
-      oy = box.y + 2 + 3
-      draw_choice(screen, box, oy, "Yes, I'm interested", @ai_interested)
-      draw_choice(screen, box, oy + 1, "Not now", !@ai_interested)
-      screen.text(ix, oy + 3, "Just a heads-up — your answer isn't saved yet.", Theme.muted, Theme.panel, width: iw)
-    end
-
-    private def draw_choice(screen : Screen, box : Rect, ry : Int32, label : String, on : Bool) : Nil
-      bg = on ? Theme.accent_bg : Theme.panel
-      screen.fill(Rect.new(box.x + 1, ry, box.w - 2, 1), bg)
-      screen.cell(box.x + 1, ry, on ? '▎' : ' ', Theme.accent, bg)
-      screen.cell(box.x + 3, ry, on ? '◉' : '◯', on ? Theme.accent : Theme.muted, bg)
-      screen.text(box.x + 5, ry, label, on ? Theme.text_bright : Theme.text, bg, width: {box.w - 7, 1}.max)
-    end
-
     private def render_review(screen : Screen, box : Rect) : Nil
       ix = box.x + 3
       y = box.y + 2
       screen.text(ix, y, "You're all set!", Theme.text_bright, Theme.panel, width: {box.w - 6, 1}.max)
       y += 2
       recap(screen, box, ix, y, "Proxy", "#{effective_ip}:#{@port.strip}"); y += 1
-      recap(screen, box, ix, y, "Theme", @theme_name); y += 1
-      recap(screen, box, ix, y, "AI provider", @ai_interested ? "interested (coming soon)" : "not now"); y += 2
+      recap(screen, box, ix, y, "Theme", @theme_name); y += 2
       screen.text(ix, y, "Change anytime from the command palette (^P):", Theme.muted, Theme.panel, width: {box.w - 6, 1}.max)
       y += 1
       screen.text(ix, y, "Settings: Network · Settings: Theme", Theme.text, Theme.panel, width: {box.w - 6, 1}.max)

--- a/src/gori/tui/tabs_overlay.cr
+++ b/src/gori/tui/tabs_overlay.cr
@@ -12,7 +12,7 @@ module Gori::Tui
   # Settings.tab_prefs. The Runner persists the committed copy via Settings.save.
   #
   #   ✓ Project      ▎ selected, shown
-  #   · Agent          hidden
+  #   · Miner           hidden
   class TabsOverlay
     def initialize
       @items = [] of {Symbol, String, Bool}

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -166,9 +166,9 @@ module Gori
         [Verb::Chord.new("[")], category: Verb::Category::Navigation) { |ctx| ctx.cycle_tab(-1); nil }
 
       # Positional tab jump: digit N focuses the Nth VISIBLE tab (the order on the bar) —
-      # so the numbers follow the user's settings:tabs order/visibility. Hidden (default:
-      # Agent), so the keys exist but don't clutter the palette; the named "Go to …" verbs
-      # below are the discoverable entries (and the way to reach a hidden tab by command).
+      # so the numbers follow the user's settings:tabs order/visibility. Hidden, so the
+      # keys exist but don't clutter the palette; the named "Go to …" verbs below are the
+      # discoverable entries (and the way to reach a hidden tab by command).
       (1..9).each do |n|
         r.register Verb::Definition.new(
           "nav.pos#{n}", "Go to tab #{n}", "Focus the #{n}th visible tab", Verb::Scope::Global,
@@ -178,12 +178,12 @@ module Gori
       # Named tab jumps (no chord) — palette discoverability + the only by-command way to
       # reach a tab hidden in settings:tabs (focus_tab force-shows it while active). Keep
       # this list in sync with Tui::Chrome::TABS so every catalog tab — including the
-      # default-hidden ones (Miner, Agent) — stays reachable from the command palette.
+      # default-hidden one (Miner) — stays reachable from the command palette.
       {
         :project => "Project", :sitemap => "Sitemap", :history => "History", :intercept => "Intercept",
         :replay => "Replay", :fuzzer => "Fuzzer", :miner => "Miner", :convert => "Convert",
         :comparer => "Comparer", :prism => "Prism", :findings => "Findings", :notes => "Notes",
-        :agent => "Agent", :help => "Help",
+        :help => "Help",
       }.each do |tab, label|
         r.register Verb::Definition.new(
           "tab.#{tab}", "Go to #{label}", "Focus the #{label} tab", Verb::Scope::Global,


### PR DESCRIPTION
Retire dead AI placeholders; add get_current_context to MCP

Two small, related changes after deciding NOT to build in-tool AI chat
(embedded assistants read as "meh" in this tool class and duplicate the
MCP/Prism paths). The real value is the MCP orchestration seam gori already
ships — so this closes the dead placeholders and strengthens that seam.

Part 1 — remove the dead AI placeholders
- Drop the non-functional ":agent" (Agent) tab from the catalog and its
  references (goto verb, settings:tabs help, runner comments + the now-dead
  "coming soon" render fallback). :agent was the only controller-less tab.
- Remove the setup wizard's throwaway "AI PROVIDER" step (never persisted):
  NETWORK -> THEME -> REVIEW, "step N of 2".
- Update the specs that keyed on :agent (retarget to :miner / :help).

Part 2 — add a get_current_context MCP tool
- The TUI records what the user is viewing (active tab, focused pane, selected
  flow, sub-tab) to the project store via a throttled, diffed render-loop hook
  (Store::UI_STATE_KEY) — idle focus never churns the WAL.
- New read-only MCP tool get_current_context reports it, with an honest
  project_match / age_seconds staleness guard instead of misleading focus.
- A global active_project marker (written on project open) lets `gori mcp`
  (given no --db/--project) serve what the user is viewing instead of an
  mtime-MRU guess.

Verified: full codegen build + spec suite green (no new failures — 8
pre-existing proxy-bind failures reproduce on the pristine tree); MCP + TUI
end-to-end (get_current_context reflects live focus, marker beats MRU, no
Agent tab, 2-step wizard); crystal tool format clean; no new ameba findings.
