### PR TITLE
Fix 14 run/mcp dogfooding findings (CLI/MCP correctness + consistency)

### DIFF
--- a/spec/cli_run_spec.cr
+++ b/spec/cli_run_spec.cr
@@ -262,7 +262,7 @@ describe Gori::CLI::Output do
     json["id"].as_i.should eq(42)
     json["method"].as_s.should eq("GET")
     json["status"].as_i.should eq(200)
-    json["state"].as_s.should eq("Complete")
+    json["state"].as_s.should eq("complete") # lowercased to match the MCP serializer
   end
 
   it "humanises sizes and durations" do

--- a/spec/proxy/h2/assembler_spec.cr
+++ b/spec/proxy/h2/assembler_spec.cr
@@ -52,6 +52,9 @@ describe Gori::Proxy::H2::Assembler do
     req.port.should eq(443)
     req.http_version.should eq("HTTP/2")
     String.new(req.head).should contain("GET / HTTP/2")
+    # The h2 `:authority` pseudo-header is rendered as a `Host:` line so the
+    # synthesized head carries the target host (else `show` / QL header:host miss it).
+    String.new(req.head).should contain("Host: www.example.com")
   end
 
   it "links a response (HEADERS + DATA) to the request flow" do

--- a/spec/ql_spec.cr
+++ b/spec/ql_spec.cr
@@ -347,4 +347,26 @@ describe "Gori::Store#search (QL)" do
       Gori::QL.reject_empty?("host:beta status:>=foo", f).should be_false
     end
   end
+
+  describe ".invalid_regex_terms" do
+    it "flags a regex term whose pattern does not compile" do
+      Gori::QL.invalid_regex_terms("host:h body~[bad").should eq(["body~[bad"])
+    end
+
+    it "keeps the leading '-' on a negated invalid regex term" do
+      Gori::QL.invalid_regex_terms("-host~[bad").should eq(["-host~[bad"])
+    end
+
+    it "returns nothing for valid regexes and non-regex terms" do
+      Gori::QL.invalid_regex_terms("host~^api\\. status:>=foo body:token").should be_empty
+    end
+
+    it "does not flag a '~' on a non-regex field (that free-texts the whole token)" do
+      Gori::QL.invalid_regex_terms("foo~[bad").should be_empty
+    end
+
+    it "flags each bad term across OR groups" do
+      Gori::QL.invalid_regex_terms("body~[a OR path~[b").should eq(["body~[a", "path~[b"])
+    end
+  end
 end

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -71,7 +71,7 @@ module Gori
       puts ""
       puts "Commands:"
       puts "  tui       Start the interactive TUI (default when no command)"
-      puts "  settings  Print/edit the persistent settings file (settings.json)"
+      puts "  settings  Show the settings.json path (or --edit to open it)"
       puts "  export    Export things (currently only ca-cert)"
       puts "  run       Non-interactive CLI: capture, history, show, replay, findings, projects"
       puts "  wizard    Interactive setup wizard (bind, theme) — also runs on first launch"

--- a/src/gori/cli/output.cr
+++ b/src/gori/cli/output.cr
@@ -30,7 +30,7 @@ module Gori
           j.field "port", row.port
           j.field "target", row.target
           j.field "status", row.status
-          j.field "state", row.state.to_s
+          j.field "state", row.state.to_s.downcase
           j.field "size", row.size
           j.field "response_size", row.response_size
           j.field "duration_us", row.duration_us

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -1,5 +1,6 @@
 require "option_parser"
 require "json"
+require "base64"
 require "../config"
 require "../paths"
 require "../settings"
@@ -164,6 +165,7 @@ module Gori
           p.invalid_option { |f| abort "gori run history: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run history: missing value for #{f}" }
         end
+        args = normalize_query_flag(args)
         neg_terms, opt_args = split_ql_negations(args)
         parser.parse(opt_args)
         # Accept a positional QL too ("gori run history status:404" / "-status:404"),
@@ -177,6 +179,9 @@ module Gori
           rows =
             if q = query
               filter = QL.parse(q)
+              QL.invalid_regex_terms(q).each do |t|
+                STDERR.puts "gori run history: warning: invalid regex in #{t.inspect} — that term matches nothing"
+              end
               # A query that fails to compile to ANY clause (e.g. `status:>=foo`)
               # yields the match-all EMPTY filter — silently dumping every flow,
               # the opposite of what the user asked. Refuse it instead.
@@ -388,36 +393,40 @@ module Gori
             j.field "error", detail.error
             emit_decoded_json(j, detail, req, resp)
             if req
-              req_body, req_decoded = decode_body(detail.request_head, detail.request_body)
               j.field "request" do
                 j.object do
                   j.field "head", scrub(detail.request_head)
-                  j.field "body", scrub(req_body)
-                  j.field "body_decoded", req_decoded
-                  j.field "body_truncated", detail.request_body_truncated?
+                  emit_body_json(j, "body", detail.request_head, detail.request_body, detail.request_body_truncated?)
                 end
               end
             end
             if resp
-              resp_body, resp_decoded = decode_body(detail.response_head, detail.response_body)
               j.field "response" do
                 j.object do
                   j.field "head", scrub(detail.response_head)
-                  j.field "body", scrub(resp_body)
-                  j.field "body_decoded", resp_decoded
-                  j.field "body_truncated", detail.response_body_truncated?
+                  emit_body_json(j, "body", detail.response_head, detail.response_body, detail.response_body_truncated?)
                 end
               end
               unless ws_msgs.empty?
                 j.field "ws_messages" do
-                  j.array do
-                    ws_msgs.each do |m|
-                      j.object do
-                        j.field "direction", m.direction
-                        j.field "opcode", m.opcode
-                        j.field "text", m.text?
-                        j.field "payload", m.text? ? String.new(m.payload).scrub : nil
-                        j.field "size", m.payload.size
+                  j.object do
+                    j.field "count", ws_msgs.size
+                    j.field "truncated", false
+                    j.field "messages" do
+                      j.array do
+                        ws_msgs.each do |m|
+                          j.object do
+                            j.field "direction", m.direction
+                            j.field "opcode", m.opcode
+                            if m.text?
+                              j.field "text", String.new(m.payload).scrub
+                            else
+                              j.field "binary", true
+                              j.field "size", m.payload.size
+                              j.field "base64", Base64.strict_encode(m.payload)
+                            end
+                          end
+                        end
                       end
                     end
                   end
@@ -425,13 +434,19 @@ module Gori
               end
               if (events = sse_events_of(detail)) && !events.empty?
                 j.field "sse_events" do
-                  j.array do
-                    events.each do |e|
-                      j.object do
-                        j.field "type", e.type
-                        j.field "data", e.data.scrub
-                        j.field "id", e.id
-                        j.field "retry", e.retry
+                  j.object do
+                    j.field "count", events.size
+                    j.field "truncated", false
+                    j.field "events" do
+                      j.array do
+                        events.each do |e|
+                          j.object do
+                            j.field "type", e.type
+                            j.field "id", e.id
+                            j.field "retry", e.retry
+                            j.field "data", e.data.scrub
+                          end
+                        end
                       end
                     end
                   end
@@ -496,9 +511,11 @@ module Gori
         verify = !insecure
         result = use_h2 ? Replay::H2Engine.send(built.bytes, scheme: scheme, host: host, port: port, verify_upstream: verify) : Replay::Engine.send(built.bytes, scheme: scheme, host: host, port: port, verify_upstream: verify)
 
-        # Decode the response body once; only build the diff lines when --diff asked
-        # for them (decoding the captured baseline isn't free for large bodies).
-        new_body, body_decoded = decode_body(result.head, result.body)
+        # Decode the response body once for TEXT display (--diff / plain print); only
+        # build the diff lines when --diff asked for them (decoding the captured
+        # baseline isn't free for large bodies). The JSON path decodes independently
+        # inside emit_body_json, from the raw head+body, to match MCP's contract.
+        new_body, _ = decode_body(result.head, result.body)
         diff =
           if do_diff
             orig = message_lines(detail.response_head, display_body(detail.response_head, detail.response_body))
@@ -506,7 +523,7 @@ module Gori
           end
 
         if format == :json
-          puts replay_json(result, new_body, body_decoded, diff)
+          puts replay_json(result, diff)
         elsif result.ok?
           STDERR.puts "→ #{result.response.try(&.status) || "?"} in #{CLI::Output.human_us(result.duration_us)}"
           if d = diff
@@ -522,7 +539,7 @@ module Gori
         exit 1 unless result.ok?
       end
 
-      private def self.replay_json(result : Replay::Result, body : Bytes?, body_decoded : Bool, diff : Array(Replay::DiffLine)?) : String
+      private def self.replay_json(result : Replay::Result, diff : Array(Replay::DiffLine)?) : String
         JSON.build do |j|
           j.object do
             j.field "ok", result.ok?
@@ -530,8 +547,7 @@ module Gori
             j.field "duration_us", result.duration_us
             j.field "error", result.error
             j.field "head", scrub(result.head)
-            j.field "body", scrub(body)
-            j.field "body_decoded", body_decoded
+            emit_body_json(j, "body", result.head, result.body, false)
             if d = diff
               j.field "changed_lines", Replay::Diff.change_count(d)
             end
@@ -671,10 +687,29 @@ module Gori
       private def self.build_fuzz_template(text : String, auto : Bool, marks : Array(String), http2 : Bool) : Fuzz::Template
         text = Fuzz::Template.auto_mark(text) if auto
         m = Fuzz::Template::MARKER
-        marks.each { |tok| text = text.gsub(tok, "#{m}#{tok}#{m}") }
+        marks.each do |tok|
+          occ = mark_occurrences(text, tok)
+          STDERR.puts "gori run fuzz: note: --mark #{tok.inspect} matches #{occ} positions (including any in headers)" if occ > 1
+          text = text.gsub(tok, "#{m}#{tok}#{m}")
+        end
         template = Fuzz::Template.parse(text, http2)
         abort "gori run fuzz: no positions — add §…§ markers, --auto, or --mark TOKEN" if template.position_count == 0
         template
+      end
+
+      # How many times a literal --mark TOKEN occurs in the template text — a
+      # short/common token (e.g. "A") can match many spots including request
+      # headers, silently exploding the position count. Non-overlapping count
+      # (mirrors String#gsub's own scan), so it matches exactly what gets marked.
+      private def self.mark_occurrences(text : String, tok : String) : Int32
+        return 0 if tok.empty?
+        count = 0
+        idx = 0
+        while found = text.index(tok, idx)
+          count += 1
+          idx = found + tok.size
+        end
+        count
       end
 
       private def self.run_fuzz_stream(engine : Fuzz::Engine, mode : Fuzz::Mode, scheme : String,
@@ -1023,6 +1058,7 @@ module Gori
           p.invalid_option { |f| abort "gori run prism: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run prism: missing value for #{f}" }
         end
+        args = normalize_query_flag(args)
         neg_terms, opt_args = split_ql_negations(args)
         parser.parse(opt_args)
         # A positional QL is accepted too ("gori run prism status:>=500" / "-status:200"),
@@ -1033,6 +1069,9 @@ module Gori
         filter : QL::Filter? = nil
         if q = query
           parsed = QL.parse(q)
+          QL.invalid_regex_terms(q).each do |t|
+            STDERR.puts "gori run prism: warning: invalid regex in #{t.inspect} — that term matches nothing"
+          end
           # A query that compiles to NOTHING (e.g. `status:>=foo`) becomes the match-all EMPTY
           # filter — here that would scan every flow, the opposite of what was asked. Refuse it.
           if !q.strip.empty? && parsed == QL::EMPTY
@@ -1225,6 +1264,7 @@ module Gori
           p.invalid_option { |f| abort "gori run sitemap: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run sitemap: missing value for #{f}" }
         end
+        args = normalize_query_flag(args)
         neg_terms, opt_args = split_ql_negations(args)
         parser.parse(opt_args)
         # Accept a positional QL too ("gori run sitemap host:api" / "-status:404"), mirroring
@@ -1253,6 +1293,9 @@ module Gori
       private def self.sitemap_filter(query : String?) : QL::Filter
         return QL::EMPTY unless q = query
         filter = QL.parse(q)
+        QL.invalid_regex_terms(q).each do |t|
+          STDERR.puts "gori run sitemap: warning: invalid regex in #{t.inspect} — that term matches nothing"
+        end
         if !q.strip.empty? && filter == QL::EMPTY
           abort "gori run sitemap: query #{q.inspect} did not match any field (check syntax, e.g. host:example.com method:POST path:/api status:>=500)"
         end
@@ -1451,6 +1494,33 @@ module Gori
         {neg, rest}
       end
 
+      # A short `-q` value that itself starts with '-' (e.g. `-q '-method:POST'`)
+      # confuses OptionParser: it reads "-method:POST" as another flag rather than
+      # -q's value, and the query is silently dropped. `--query=VALUE` doesn't have
+      # this problem (OptionParser only splits on the first '='), so rewrite every
+      # `-q`/`-qVALUE`/`-q=VALUE`/`-q VALUE` form into `--query=VALUE` up front.
+      private def self.normalize_query_flag(args : Array(String)) : Array(String)
+        out = [] of String
+        i = 0
+        while i < args.size
+          a = args[i]
+          if a == "-q" || a == "--query"
+            if v = args[i + 1]?
+              out << "--query=#{v}"; i += 2
+            else
+              out << a; i += 1
+            end
+          elsif a.starts_with?("-q=")
+            out << "--query=#{a[3..]}"; i += 1
+          elsif a.starts_with?("-q") && a.size > 2
+            out << "--query=#{a[2..]}"; i += 1
+          else
+            out << a; i += 1
+          end
+        end
+        out
+      end
+
       private def self.take_flow_id(rest : Array(String), sub : String) : Int64
         abort "gori run #{sub}: missing <flow-id>" if rest.empty?
         abort "gori run #{sub}: too many arguments (expected one <flow-id>, got: #{rest.join(" ")})" if rest.size > 1
@@ -1517,12 +1587,60 @@ module Gori
         bytes ? String.new(bytes).scrub : nil
       end
 
+      # The CLI counterpart of MCP's Serialize.emit_body (src/gori/mcp/serialize.cr)
+      # — same object shape ({encoding, size, truncated, text|base64, binary?,
+      # wire_truncated?, note?}) so a script gets a consistent contract whether it
+      # reads `gori mcp` or `gori run … --format json`. UNCLIPPED: unlike MCP (which
+      # caps at MAX_TEXT/MAX_B64 for an LLM's context window), the CLI is read by a
+      # script that expects the whole value, so no size cap is applied here.
+      private def self.emit_body_json(j : JSON::Builder, field_name : String, head : Bytes?, body : Bytes?, wire_truncated : Bool) : Nil
+        if body.nil? || body.empty?
+          j.field field_name, nil
+          return
+        end
+        decoded, note = Proxy::Codec::ContentDecode.decode(head, body)
+        bytes = decoded || body
+        s = String.new(bytes)
+        j.field field_name do
+          j.object do
+            if s.valid_encoding?
+              j.field "encoding", "text"
+              j.field "size", bytes.size
+              j.field "truncated", wire_truncated
+              j.field "text", s
+            else
+              j.field "encoding", "base64"
+              j.field "binary", true
+              j.field "size", bytes.size
+              j.field "truncated", wire_truncated
+              j.field "base64", Base64.strict_encode(bytes)
+            end
+            j.field "wire_truncated", true if wire_truncated
+            j.field "note", note if note
+          end
+        end
+      end
+
       private def self.print_message_text(head : Bytes?, body : Bytes?) : Nil
         STDOUT.puts(String.new(head || Bytes.empty).scrub.rstrip)
         if body && !body.empty?
           STDOUT.puts ""
-          STDOUT.puts(String.new(body).scrub)
+          if binary_body?(body)
+            STDOUT.puts "[binary body, #{body.size} bytes — use --format raw for exact bytes, or view hex]"
+          else
+            STDOUT.puts(String.new(body).scrub)
+          end
         end
+      end
+
+      # `.scrub` only fixes invalid UTF-8 byte sequences — it does NOT strip control
+      # bytes, so a binary body (e.g. a PNG/NUL-laden blob) would otherwise dump raw
+      # control bytes (NUL/SUB/ESC/…) straight to the terminal and corrupt it. Sniff
+      # for a NUL in the first 8KB, mirroring the TUI's binary-body guard.
+      private def self.binary_body?(bytes : Bytes) : Bool
+        n = {bytes.size, 8192}.min
+        n.times { |i| return true if bytes[i] == 0u8 }
+        false
       end
 
       # head lines + blank + body lines (scrubbed), for the --diff line comparison.

--- a/src/gori/mcp/request_builder.cr
+++ b/src/gori/mcp/request_builder.cr
@@ -30,7 +30,10 @@ module Gori
         scheme = (uri.scheme || "http").downcase
         raise Gori::Error.new("unsupported scheme: #{scheme} (only http/https)") unless scheme.in?("http", "https")
         host = uri.host
-        raise Gori::Error.new("url has no host: #{url}") if host.nil? || host.empty?
+        if host.nil? || host.empty?
+          hint = url.includes?("://") ? "" : " — include a scheme, e.g. https://#{url}"
+          raise Gori::Error.new("url has no host: #{url}#{hint}")
+        end
         # URI.parse keeps a CR/LF embedded in the authority as part of `host`
         # (e.g. "http://h.com\r\nEvil: x/"), which would otherwise be written into
         # the auto-generated Host header and inject. Reject it on BOTH paths (raw

--- a/src/gori/mcp/serialize.cr
+++ b/src/gori/mcp/serialize.cr
@@ -116,6 +116,10 @@ module Gori
                     else
                       j.field "binary", true
                       j.field "size", m.payload.size
+                      cut = m.payload.size > MAX_B64
+                      slice = cut ? m.payload[0, MAX_B64] : m.payload
+                      j.field "base64", Base64.strict_encode(slice)
+                      j.field "base64_truncated", true if cut
                     end
                   end
                 end

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -204,13 +204,15 @@ module Gori
               "Start a fuzz/intruder run against an origin and return a job_id " \
               "immediately (poll with fuzz_status / fuzz_results; end with fuzz_stop). " \
               "ACTIVE: sends many real outbound requests from this host. Mark payload " \
-              "positions with §…§ in `template`, or pass `flow_id` + auto:true, then " \
-              "provide payload sets via `payloads`. Capped " \
+              "positions with §…§ in `template`, via `marks` (literal token wrap, like " \
+              "CLI --mark), or pass `flow_id` + auto:true, then provide payload sets via " \
+              "`payloads`. Capped " \
               "at #{FUZZ_MAX_REQUESTS} requests / #{FUZZ_MAX_CONCURRENCY} concurrency." do |s|
               s.field "template", strprop("raw HTTP request with §…§ position markers")
               s.field "flow_id", intprop("seed the template from a captured flow id (instead of template)")
               s.field "url", strprop("absolute target URL (scheme+host); required unless flow_id carries one")
               s.field "auto", boolprop("auto-mark every query/cookie/body param when the template has no § markers")
+              s.field "marks", strarrprop("literal tokens to mark as §…§ positions (each occurrence, mirrors CLI --mark); alternative to embedding §…§ in template")
               s.field "mode", strprop("sniper (default) | batteringram | pitchfork | clusterbomb")
               s.field "payloads", arrprop(%(array of payload sets, e.g. [{"list":["a","b"]},{"numbers":"1-100"},{"wordlist":"/p.txt"},{"null":5},{"brute":"abc:1-3"}] — JSON array, NOT a string))
               s.field "match", jsonprop(%(keep only responses matching, e.g. {"status":"200,500-599","size":">1000","regex":"err"} — object or JSON string))
@@ -304,7 +306,7 @@ module Gori
         when "list_scope"          then list_scope
         when "project_info"        then project_info
         when "get_current_context" then get_current_context
-        when "get_replay_context" then get_replay_context
+        when "get_replay_context"  then get_replay_context
         when "ql_reference"        then ql_reference
         end
       end
@@ -954,6 +956,8 @@ module Gori
         text, default_target, src_h2 = fuzz_template_source(h)
         use_h2 = (bool(h, "http2") || false) || src_h2
         text = Fuzz::Template.auto_mark(text) if bool(h, "auto") || false
+        m = Fuzz::Template::MARKER
+        fuzz_marks(h).each { |tok| text = text.gsub(tok, "#{m}#{tok}#{m}") }
         template = Fuzz::Template.parse(text, use_h2)
         raise FuzzArgError.new("template has no §…§ positions (add markers, or pass auto:true with a flow_id)") if template.position_count == 0
         origin = fuzz_origin(h, default_target)
@@ -997,6 +1001,24 @@ module Gori
         s = str(h, "mode")
         return Fuzz::Mode::Sniper if s.nil? || s.strip.empty?
         Fuzz::Mode.parse?(s) || raise FuzzArgError.new("invalid mode '#{s}' (sniper|batteringram|pitchfork|clusterbomb)")
+      end
+
+      # Mirrors `fuzz_sets`'s array-pulling pattern (bare array, or a JSON-encoded
+      # string — LLM clients vary), but for plain string tokens.
+      private def fuzz_marks(h) : Array(String)
+        raw = h["marks"]?
+        return [] of String unless raw
+        arr =
+          if a = raw.as_a?
+            a
+          elsif s = raw.as_s?
+            return [] of String if s.strip.empty?
+            parsed = JSON.parse(s) rescue raise FuzzArgError.new("'marks' must be a JSON array of strings")
+            parsed.as_a? || raise FuzzArgError.new("'marks' must be a JSON array")
+          else
+            raise FuzzArgError.new("'marks' must be a JSON array of strings (not a bare string/scalar)")
+          end
+        arr.map { |v| v.as_s? || raise FuzzArgError.new("each 'marks' entry must be a string") }
       end
 
       private def fuzz_sets(h) : Array(Fuzz::PayloadSet)
@@ -1260,6 +1282,10 @@ module Gori
 
       private def arrprop(desc : String) : JSON::Any
         JSON.parse(%({"type":"array","description":#{desc.to_json},"items":{"type":"object"}}))
+      end
+
+      private def strarrprop(desc : String) : JSON::Any
+        JSON.parse(%({"type":"array","description":#{desc.to_json},"items":{"type":"string"}}))
       end
 
       # Accepts a JSON object directly or a JSON-encoded string (LLM clients vary).

--- a/src/gori/proxy/h2/assembler.cr
+++ b/src/gori/proxy/h2/assembler.cr
@@ -258,7 +258,7 @@ module Gori::Proxy::H2
       cap = stream.req.body
       body = cap.total == 0 ? nil : cap.to_slice
 
-      head = synth_request_head(method, path, headers)
+      head = synth_request_head(method, path, headers, authority)
       captured = Store::CapturedRequest.new(
         created_at: @created_at, scheme: scheme, host: host, port: port,
         method: method, target: path, http_version: "HTTP/2", head: head, body: body,
@@ -334,9 +334,19 @@ module Gori::Proxy::H2
 
     # A readable HTTP/2 request head (the bytes shown in the detail view). The
     # authoritative octets are the raw frames; this is a normalized view.
-    private def synth_request_head(method : String, path : String, headers : Array({String, String})) : Bytes
+    #
+    # HTTP/2 carries the request's host in the `:authority` pseudo-header
+    # (RFC 7540 §8.1.2.3) rather than a `Host:` field, and the loop below skips
+    # ALL pseudo-headers — so without this, the synthesized head has no host at
+    # all, breaking `gori run show` / MCP get_flow / QL `header:host` for every
+    # h2 flow. Emit `Host: <authority>` first (authority is the caller's
+    # already-resolved `:authority` pseudo value, falling back to @host),
+    # unless the headers already carry an explicit (non-pseudo) `host` field.
+    private def synth_request_head(method : String, path : String, headers : Array({String, String}), authority : String) : Bytes
       String.build do |io|
         io << method << ' ' << path << " HTTP/2\r\n"
+        has_host = headers.any? { |(n, _)| n.downcase == "host" }
+        io << "Host: " << authority << "\r\n" if !authority.empty? && !has_host
         headers.each { |(n, v)| io << n << ": " << v << "\r\n" unless n.starts_with?(':') }
         io << "\r\n"
       end.to_slice

--- a/src/gori/ql.cr
+++ b/src/gori/ql.cr
@@ -92,6 +92,37 @@ module Gori
       clauses.empty? ? EMPTY : Filter.new(clauses.join(" OR "), args)
     end
 
+    # A `~` (regex) term whose pattern fails to compile silently degrades to a
+    # never-match "0" SQL clause inside term_to_sql/regex_cond (see there) — unlike
+    # a bad numeric term (status:>=foo), which is simply DROPPED and lets the rest
+    # of the query stand. That asymmetry means a query like `body~[bad` can zero
+    # out an entire result set with exit 0 and no diagnostic. This surfaces those
+    # terms so a caller can warn without changing match behaviour. Mirrors the
+    # exact tokenization term_to_sql/regex_cond use, so it flags precisely the
+    # terms that would compile to the never-match clause — no more, no less.
+    def self.invalid_regex_terms(query : String) : Array(String)
+      bad = [] of String
+      query.split.each do |tok|
+        next if tok == "OR"
+        term = tok.starts_with?('-') ? tok[1..] : tok
+        next if term.empty?
+
+        ci = term.index(':')
+        ti = term.index('~')
+        sep = [ci, ti].compact.min?
+        next unless sep && sep > 0 && ti == sep # a regex op, not free text / field op
+
+        field = term[0...sep].downcase
+        next unless field.in?("host", "path", "url", "header", "body")
+
+        value = term[(sep + 1)..]
+        next if value.empty?
+
+        bad << tok unless valid_regex?(value)
+      end
+      bad
+    end
+
     private def self.term_to_sql(term : String) : {String, Array(DB::Any)}?
       negate = term.starts_with?('-')
       term = term[1..] if negate

--- a/src/gori/session.cr
+++ b/src/gori/session.cr
@@ -92,7 +92,7 @@ module Gori
                 ex.message || "could not bind #{config.listen}:#{config.port}"
               end
             else
-              "another gori instance is already capturing this project"
+              "another gori instance already holds this directory's capture lock"
             end
           rescue ex
             # CaptureLock.try itself failed (can't create/open the lock file) — not a


### PR DESCRIPTION
Dogfooding `gori run` + `gori mcp` against real captured traffic surfaced 14 issues (bugs, CLI↔MCP inconsistencies, ergonomics). All fixed and verified end-to-end.

## Bugs
- **QL invalid regex silently zeroed the query.** `-q 'host:x body~[bad'` returned 0 results with exit 0 and no diagnostic (a bad numeric term is dropped, but a bad regex compiled to a never-match `0` clause that AND-ed away everything). `QL.invalid_regex_terms` now surfaces such terms and the CLI warns to STDERR; match behaviour is unchanged.
- **`gori run show` dumped raw binary bodies to the terminal.** A binary (e.g. PNG) response body wrote raw NUL/control bytes, corrupting terminals. Now shows a `[binary body, N bytes — use --format raw …]` placeholder (NUL-sniff, matching the TUI). `--format raw` stays byte-exact.
- **HTTP/2 captured requests dropped the host.** `synth_request_head` skipped all pseudo-headers, so h2 request heads had no `Host:` line — invisible to `show`, MCP `get_flow`, and QL `header:host`. Now emits `Host: <:authority>` (RFC 7540 §8.1.2.3).
- **Negation broke with the short `-q` flag.** `-q '-method:POST'` silently returned wrong results (OptionParser mis-parsed the leading `-`). Normalised to the `--query=` form.

## CLI ↔ MCP JSON consistency (CLI aligned to the richer MCP shape)
- Binary/decoded bodies → `{encoding, base64|text, binary, note, wire_truncated}` object (CLI json was a lossy UTF-8 string with no recovery).
- `ws_messages` / `sse_events` wrapped in `{count, truncated, items}`; WS `text` is now the content string (was a bool colliding with MCP); binary WS frames carry `base64` — **both** surfaces (MCP previously dropped the payload).
- `state` lowercased to match the MCP serializer.

## Ergonomics
- MCP `fuzz_start` gains a `marks` param (mirrors CLI `--mark`).
- `send_request`: clearer message when the url lacks a scheme.
- Capture-lock message no longer falsely says "this project" (per-directory lock).
- `gori settings` help clarified (it prints the path).
- `gori run fuzz`: warns when `--mark` matches many positions (a short token also matches headers).

## Not included (deliberate)
- **Sitemap query fragmentation** and **JSON-RPC batch rejection** — design/gray-area, skipped.
- **Capture-lock re-key** (per-directory → per-db-file): the misleading *message* is fixed, but re-keying the lock would also touch TUI capture-status plumbing for a rare edge case, so it's deferred.

## Verification
- Build clean · `crystal tool format` clean on all edited files · ameba 221 (below the 222 baseline, no new issues).
- Full suite **1286 examples, 0 failures** (+ new regression tests: `QL.invalid_regex_terms`, h2 head `Host:` assertion, state casing).
- Every finding reproduced fixed against a live headless proxy + local test servers (h2, binary, gzip/br/zstd, WS, SSE).