### PR TITLE
fix: bug-hunt pass over today's env/MCP/WS/pretty features

### DIFF
--- a/spec/env_spec.cr
+++ b/spec/env_spec.cr
@@ -36,4 +36,33 @@ describe Gori::Env do
   ensure
     Gori::Settings.env_vars = [] of {String, String}
   end
+
+  it "expand_wire normalizes both LF and already-CRLF input to single CRLF" do
+    Gori::Settings.env_prefix = "$"
+    Gori::Settings.env_vars = [] of {String, String}
+    Gori::Settings.project_env_vars = [] of {String, String}
+    # already-CRLF wire bytes (captured flow) must NOT double to \r\r\n
+    crlf = "GET / HTTP/1.1\r\nHost: x\r\n\r\nbody"
+    String.new(Gori::Env.expand_wire(crlf)).should eq(crlf)
+    # LF-only input is upgraded to CRLF
+    lf = "GET / HTTP/1.1\nHost: x\n\nbody"
+    String.new(Gori::Env.expand_wire(lf)).should eq(crlf)
+  ensure
+    Gori::Settings.env_prefix = "$"
+  end
+
+  it "mask_secrets does not corrupt a token an earlier replacement inserted" do
+    # ABCD's value contains Q's KEY name; a sequential gsub would mangle it to "$$Q".
+    vars = {"ABCD" => "s3cr3tXY", "Q" => "ABCD"}
+    masked = Gori::Env.mask_secrets("token=s3cr3tXY here", vars, "$")
+    masked.should eq("token=$ABCD here")
+    # and it round-trips back through expand
+    Gori::Env.expand(masked, vars, "$").should eq("token=s3cr3tXY here")
+  end
+
+  it "mask_secrets prefers the longest value at each position" do
+    vars = {"SHORT" => "secret", "LONG" => "secret_value"}
+    Gori::Env.mask_secrets("x=secret_value", vars, "$").should eq("x=$LONG")
+    Gori::Env.mask_secrets("x=secret!", vars, "$").should eq("x=$SHORT!")
+  end
 end

--- a/spec/pretty_spec.cr
+++ b/spec/pretty_spec.cr
@@ -202,4 +202,19 @@ describe Gori::Pretty do
       res.bytes.to_unsafe.should_not eq(body.to_unsafe)
     end
   end
+
+  describe "format_request (marker-preserving pretty)" do
+    it "restores every §…§ marker intact with ≥11 markers (no placeholder prefix-collision)" do
+      head = "POST /x HTTP/1.1\r\nContent-Type: application/json"
+      pairs = (0...12).map { |i| %("k#{i}":"§m#{i}§") }
+      body = "{#{pairs.join(",")}}"
+      out = Gori::Pretty.format_request(head, body)
+      out.should_not be_nil
+      formatted = out.not_nil!
+      # Under the old ascending-order gsub, marker 10 became "§m1§0" (idx-1 placeholder
+      # is a prefix of idx-10's). Every marker must survive verbatim.
+      (0...12).each { |i| formatted.should contain("§m#{i}§") }
+      formatted.lines.size.should be > 1 # actually reflowed
+    end
+  end
 end

--- a/spec/replay/flow_request_spec.cr
+++ b/spec/replay/flow_request_spec.cr
@@ -26,4 +26,31 @@ describe Gori::Replay::FlowRequest do
       Gori::Replay::FlowRequest.parse_target(t).should eq({"https", "2001:db8::1", 8443})
     end
   end
+
+  describe ".resync_content_length" do
+    it "rewrites an existing Content-Length to the actual body length" do
+      # body is 10 bytes ("ABCDEFGHIJ") but the header claims 3 — resync corrects it
+      wire = "POST /x HTTP/1.1\r\nContent-Length: 3\r\n\r\nABCDEFGHIJ".to_slice
+      out = String.new(Gori::Replay::FlowRequest.resync_content_length(wire))
+      out.should eq("POST /x HTTP/1.1\r\nContent-Length: 10\r\n\r\nABCDEFGHIJ")
+    end
+
+    it "matches the byte length after env expansion grows the body" do
+      # a $KEY expands to a longer value → CL must follow
+      expanded = Gori::Env.expand_wire("POST /x HTTP/1.1\nContent-Length: 5\n\nvalue-here",
+        {"K" => "value-here"}, "$")
+      out = String.new(Gori::Replay::FlowRequest.resync_content_length(expanded))
+      out.should contain("Content-Length: 10\r\n")
+    end
+
+    it "never adds a header (a GET with no Content-Length is untouched)" do
+      wire = "GET /x HTTP/1.1\r\nHost: t\r\n\r\n".to_slice
+      Gori::Replay::FlowRequest.resync_content_length(wire).should eq(wire)
+    end
+
+    it "leaves bytes without a CRLFCRLF separator untouched" do
+      wire = "GET /x HTTP/1.1\r\nHost: t\r\n".to_slice
+      Gori::Replay::FlowRequest.resync_content_length(wire).should eq(wire)
+    end
+  end
 end

--- a/spec/replay/ws_engine_spec.cr
+++ b/spec/replay/ws_engine_spec.cr
@@ -115,4 +115,21 @@ describe Gori::Replay::WsEngine do
     received.includes?(0xFF_u8).should be_true
     received.includes?(0xFE_u8).should be_true
   end
+
+  describe ".upgrade_request?" do
+    it "matches the Upgrade: websocket header case-insensitively with flexible spacing" do
+      WsEngine.upgrade_request?("GET /ws HTTP/1.1\r\nUpgrade: websocket\r\n\r\n").should be_true
+      WsEngine.upgrade_request?("GET /ws HTTP/1.1\nupgrade: websocket\n\n").should be_true
+      WsEngine.upgrade_request?("GET /ws HTTP/1.1\r\nUpgrade: WebSocket\r\n\r\n").should be_true
+      WsEngine.upgrade_request?("GET /ws HTTP/1.1\r\nUpgrade:websocket\r\n\r\n").should be_true
+    end
+
+    it "does not match a mid-line 'upgrade: websocket' inside another header value" do
+      WsEngine.upgrade_request?("GET / HTTP/1.1\r\nX-Note: please upgrade: websocket\r\n\r\n").should be_false
+    end
+
+    it "is false for an ordinary request" do
+      WsEngine.upgrade_request?("GET / HTTP/1.1\r\nHost: t\r\n\r\n").should be_false
+    end
+  end
 end

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -113,6 +113,8 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def fuzz_list_paste : Nil; end
 
+  def fuzz_clear_marks : Nil; end
+
   def mine_selected : Nil; end
 
   def mine_from_replay : Nil; end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -216,6 +216,10 @@ private class FakeContext < ExecContext
     @calls << :fuzz_pretty_template
   end
 
+  def fuzz_clear_marks : Nil
+    @calls << :fuzz_clear_marks
+  end
+
   def mine_selected : Nil
     @calls << :mine_selected
   end
@@ -654,6 +658,9 @@ describe Gori::Verb do
       keymap.lookup(Chord.new("right"), Scope::HistoryDetail).should eq("detail.next-pane")
       keymap.lookup(Chord.new("left"), Scope::HistoryDetail).should eq("detail.prev-pane")
       keymap.lookup(Chord.new("x"), Scope::HistoryDetail).should eq("detail.toggle-hex")
+      # ^U in the Fuzzer pretty-prints the template (must NOT be intercepted as clear-marks
+      # anymore — clear-marks moved to the space menu as fuzz.clear-marks).
+      keymap.lookup(Chord.new("u", ctrl: true), Scope::Fuzzer).should eq("fuzz.pretty-template")
       # a Global chord (^P palette) resolves from ANY scope
       keymap.lookup(Chord.new("p", ctrl: true), Scope::Body).should eq("app.palette")
       # 'q' (back to projects) is bound only on the tab bar (Sidebar), not in a body —

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -349,7 +349,9 @@ module Gori
 
       # Build args
       args = ["mcp"]
-      args << "--db=#{File.realpath(db_path)}" if db_path && !db_path.empty?
+      # expand_path (not realpath): the db need not exist yet — `gori mcp` creates it on
+      # first serve. realpath raises File::NotFoundError on a fresh path and aborts install.
+      args << "--db=#{File.expand_path(db_path)}" if db_path && !db_path.empty?
       args << "--project=#{project}" if project && !project.empty?
       args << "--read-only" if read_only
       args << "--insecure-upstream" if insecure_upstream
@@ -357,12 +359,21 @@ module Gori
       # Ensure config directory exists
       Dir.mkdir_p(config_dir) unless Dir.exists?(config_dir)
 
-      # Load existing config or initialize
+      # Load existing config or initialize. If the file exists but doesn't parse as a
+      # JSON object, REFUSE rather than clobber it — for `claude-code` this is
+      # ~/.claude.json (the user's entire CLI state: projects, auth, other MCP servers),
+      # so a transient/hand-edit parse error must never wipe it.
       config = if File.file?(config_path)
-                 begin
-                   JSON.parse(File.read(config_path)).as_h
-                 rescue
+                 raw = File.read(config_path)
+                 if raw.strip.empty?
                    Hash(String, JSON::Any).new
+                 else
+                   begin
+                     JSON.parse(raw).as_h
+                   rescue
+                     abort "Refusing to overwrite #{config_path}: it exists but isn't a valid JSON object. " \
+                           "Fix or remove it, then re-run the installer."
+                   end
                  end
                else
                  Hash(String, JSON::Any).new

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -506,7 +506,9 @@ module Gori
 
         built = Replay::FlowRequest.build(detail)
         override = target_override # copy the closured flag into a plain local so || narrows
-        bytes = Env.expand_wire(String.new(built.bytes))
+        # Re-sync Content-Length after expansion — a `$KEY` in the body changes its length,
+        # and `build` framed CL over the pre-expansion bytes.
+        bytes = Replay::FlowRequest.resync_content_length(Env.expand_wire(String.new(built.bytes)))
         target = Env.expand(override || built.target)
         scheme, host, port = Replay::FlowRequest.parse_target(target)
         abort "gori run replay: could not determine a target host" if host.empty?

--- a/src/gori/env.cr
+++ b/src/gori/env.cr
@@ -32,9 +32,12 @@ module Gori
     end
 
     # Expand env tokens in wire-form HTTP text (LF or CRLF) and return CRLF bytes.
+    # Uses `gsub(/\r?\n/, "\r\n")` — NOT `split('\n').join("\r\n")` — so already-CRLF
+    # input (captured flow bytes) isn't doubled into `\r\r\n`, which would destroy the
+    # head/body separator and break framing on every CLI/MCP replay+mine send path.
     def self.expand_wire(text : String, vars : Hash(String, String) = effective_vars,
                          prefix : String = Settings.env_prefix) : Bytes
-      expand(text, vars, prefix).split('\n').join("\r\n").to_slice
+      expand(text, vars, prefix).gsub(/\r?\n/, "\r\n").to_slice
     end
 
     # Substitute registered `prefix+KEY` tokens; unknown keys stay literal.
@@ -71,8 +74,13 @@ module Gori
     end
 
     # Scans the text for occurrences of any registered env var value and replaces
-    # it with the corresponding token (e.g. "$KEY"). Sorted by value size descending
-    # to avoid sub-string collisions (e.g. matching "secret_value" before "secret").
+    # it with the corresponding token (e.g. "$KEY"). Longest value wins at each
+    # position (avoids "secret_value" vs "secret" sub-string collisions).
+    #
+    # Single left-to-right pass (NOT sequential `gsub` per value): a `gsub` chain
+    # can re-match a token an earlier replacement inserted — e.g. value "OKEN"
+    # matching inside a just-inserted "$TOKEN" — silently corrupting the mask. The
+    # pass never re-scans replaced spans, so inserted tokens stay intact.
     def self.mask_secrets(text : String, vars : Hash(String, String) = effective_vars,
                           prefix : String = Settings.env_prefix) : String
       return text if prefix.empty? || vars.empty?
@@ -80,18 +88,33 @@ module Gori
       # Filter out empty values and short/common values that might lead to false positives (e.g., single characters)
       candidates = vars.to_a
         .reject { |(k, v)| v.strip.empty? || v.size < 4 }
-        .sort_by { |(k, v)| -v.size }
+        .sort_by! { |(k, v)| -v.size }
+        .map { |(k, v)| {k, v.chars} }
 
       return text if candidates.empty?
 
-      result = text
-      candidates.each do |key, value|
-        result = result.gsub(value, "#{prefix}#{key}")
+      chars = text.chars
+      n = chars.size
+      String.build do |io|
+        i = 0
+        while i < n
+          hit = candidates.find do |(_, vchars)|
+            i + vchars.size <= n && vchars.each_with_index.all? { |c, j| chars[i + j] == c }
+          end
+          if hit
+            io << prefix << hit[0]
+            i += hit[1].size
+          else
+            io << chars[i]
+            i += 1
+          end
+        end
       end
-      result
     end
 
-    # Byte offsets [start, end) of each env-shaped token in `text` (end exclusive).
+    # Char offsets [start, end) of each env-shaped token in `text` (end exclusive).
+    # Char-based (not byte) — the consumer (Highlight.env_spans_in) slices with
+    # `text[a...b]`, which is char-indexed in Crystal, so multi-byte text stays aligned.
     # `known` is true when KEY is registered in `vars`.
     def self.token_regions(text : String, prefix : String = Settings.env_prefix,
                            vars : Hash(String, String) = effective_vars) : Array({Int32, Int32, Bool})

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -616,7 +616,7 @@ module Gori
           j.field "sni", r.sni if r.sni
           emit_capped_text(j, "request", r.request)
 
-          if r.request.includes?("Upgrade: websocket") || r.request.includes?("upgrade: websocket")
+          if Replay::WsEngine.upgrade_request?(r.request)
             ws_msgs = @store.ws_messages_for_replay(r.id)
             j.field "ws_mode", true
             j.field "ws_messages" do
@@ -783,7 +783,8 @@ module Gori
           detail = @store.get_flow(id)
           raise Gori::Error.new("no flow with id #{id}") unless detail
           flow = Replay::FlowRequest.build(detail)
-          bytes = Env.expand_wire(String.new(flow.bytes))
+          # Re-sync Content-Length after expansion (a body `$KEY` changes its length).
+          bytes = Replay::FlowRequest.resync_content_length(Env.expand_wire(String.new(flow.bytes)))
           target = Env.expand(flow.target)
           scheme, host, port = Replay::FlowRequest.parse_target(target)
           raise Gori::Error.new("could not parse target from flow #{id}") if host.empty?
@@ -924,7 +925,7 @@ module Gori
         name = str(h, "name").try { |n| Env.mask_secrets(n) }
 
         # WebSocket mode check
-        is_ws = masked_request.includes?("Upgrade: websocket") || masked_request.includes?("upgrade: websocket")
+        is_ws = Replay::WsEngine.upgrade_request?(masked_request)
 
         id = @store.insert_replay(
           target: masked_target,
@@ -961,8 +962,9 @@ module Gori
           end
         end
 
-        # Derive summary
-        line = request.each_line.first?.try(&.strip) || ""
+        # Derive summary from the MASKED request — the raw request may carry a secret
+        # in the request-target (e.g. ?token=…), and this field is returned to the LLM.
+        line = masked_request.each_line.first?.try(&.strip) || ""
         parts = line.split(' ')
         s = "#{parts[0]?} #{parts[1]?}".strip
         s = line if s.empty?

--- a/src/gori/pretty.cr
+++ b/src/gori/pretty.cr
@@ -489,9 +489,13 @@ module Gori
 
       formatted = String.new(res.bytes)
 
-      # 3. Restore the markers
-      markers.each_with_index do |m, idx|
-        formatted = formatted.gsub("876543210987600#{idx}", m)
+      # 3. Restore the markers — HIGHEST index first. Placeholders share the
+      # "876543210987600" prefix, so e.g. idx 1's "…6001" is a substring-prefix of idx
+      # 10's "…60010". A proper digit-prefix always has fewer digits (⇒ smaller value),
+      # so its collision partner always carries a larger index; replacing high→low
+      # consumes the longer placeholder before its prefix and avoids corrupting markers.
+      (markers.size - 1).downto(0) do |idx|
+        formatted = formatted.gsub("876543210987600#{idx}", markers[idx])
       end
 
       formatted

--- a/src/gori/replay/flow_request.cr
+++ b/src/gori/replay/flow_request.cr
@@ -53,6 +53,25 @@ module Gori
         end.to_slice
       end
 
+      # Rewrite an EXISTING Content-Length to match the actual body length of a wire-form
+      # request. Used after env-var expansion changes body bytes (a `$KEY` in the body):
+      # `build` framed the CL over the pre-expansion body, so re-sync it or the origin
+      # over/under-reads. Never ADDS a header (GETs stay clean) and leaves chunked/h2
+      # bodies (no Content-Length) untouched. Shared by the TUI Replay editor and the
+      # headless CLI/MCP replay-send paths so they can't disagree.
+      def self.resync_content_length(bytes : Bytes) : Bytes
+        text = String.new(bytes)
+        sep = text.index("\r\n\r\n")
+        return bytes unless sep
+        head = text[0, sep]
+        body = text[(sep + 4)..]
+        lines = head.split("\r\n")
+        idx = lines.index { |l| l.lstrip.downcase.starts_with?("content-length:") }
+        return bytes unless idx
+        lines[idx] = "Content-Length: #{body.bytesize}"
+        "#{lines.join("\r\n")}\r\n\r\n#{body}".to_slice
+      end
+
       # "scheme://host[:port]", omitting the port when it's the scheme default —
       # matches ReplayView#build_target so the parsed {scheme,host,port} round-trips.
       def self.build_target(scheme : String, host : String, port : Int32) : String

--- a/src/gori/replay/ws_engine.cr
+++ b/src/gori/replay/ws_engine.cr
@@ -35,6 +35,17 @@ module Gori
       DRAIN_DEADLINE    = 60.seconds          # wall-clock ceiling: a sub-idle ping/fragment cadence can't pin a tab for hours
       MAX_CONTROL_BYTES = 125                 # RFC 6455 §5.5: control-frame payload limit (caps Pong echo)
 
+      # A request head declares a WebSocket upgrade. Matches the `Upgrade: websocket`
+      # header case-insensitively (RFC 6455: the token is case-insensitive; browsers
+      # send lowercase, but `Upgrade: WebSocket` and no-space forms are equally valid),
+      # tolerating flexible whitespace after the colon. The single source of truth for
+      # "is this replay a WebSocket flow?" across the TUI restore paths and MCP tools.
+      UPGRADE_HEADER = /(?:^|\n)upgrade:[ \t]*websocket/i
+
+      def self.upgrade_request?(request : String) : Bool
+        request.matches?(UPGRADE_HEADER)
+      end
+
       # An outbound message to replay (opcode 1=text, 2=binary).
       record OutMsg, opcode : Int32, payload : Bytes
 

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -725,12 +725,12 @@ module Gori
     # response (responses are personal per session). Response fields stay nil.
     def get_replay(id : Int64) : ReplayRecord?
       @db.query(
-        "SELECT id, target, request, http2, auto_content_length, flow_id, position, sni, mark_transform FROM replays WHERE id = ?",
+        "SELECT id, target, request, http2, auto_content_length, flow_id, position, sni, mark_transform, name FROM replays WHERE id = ?",
         id) do |rs|
         return ReplayRecord.new(
           rs.read(Int64), rs.read(String), rs.read(String),
           rs.read(Int32) != 0, rs.read(Int32) != 0, rs.read(Int64?), rs.read(Int32),
-          sni: rs.read(String?), mark_transform: rs.read(Int32) != 0) if rs.move_next
+          sni: rs.read(String?), mark_transform: rs.read(Int32) != 0, name: rs.read(String?)) if rs.move_next
       end
       nil
     end

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -152,7 +152,6 @@ module Gori::Tui
       when :close     then request_close
       when :markword  then @host.status(v.mark_word)
       when :markpoint then @host.status(v.insert_marker)
-      when :clear     then @host.status(v.clear_marks)
       when :config    then v.focus_config
       when :switch    then switch_subtab(c)
       else                 return false
@@ -170,7 +169,6 @@ module Gori::Tui
       when key.lower_w?         then :close
       when key.lower_k?         then :markword
       when key.lower_t?         then :markpoint
-      when key.lower_u?         then :clear
       when key.lower_o?         then :config
       when c && '1' <= c <= '9' then :switch
       end
@@ -211,6 +209,13 @@ module Gori::Tui
       else
         @host.status("pretty-printed template request body")
       end
+    end
+
+    # Strip every §…§ marker (and its chain) from the template. Space-menu only —
+    # `^U` now pretty-prints (matching Replay); clearing lives in the space menu here too.
+    def fuzz_clear_marks : Nil
+      return unless view = current_view
+      @host.status(view.clear_marks)
     end
 
     # The Runner calls these when an overlay applies (esc / ↵-on-last-field).
@@ -290,8 +295,10 @@ module Gori::Tui
     private def edit_config(ev : Termisu::Event::Key, v : FuzzerView) : Nil
       key = ev.key
       case
-      when key.up?                     then config_up(v)
-      when key.down?                   then v.form_move(1)
+      # CONFIG is a row list, not a text field, so j/k navigate here (like RESULTS and
+      # the Miner summary) — without this, `k` off the RESULTS top dead-ends in CONFIG.
+      when key.up?, key.lower_k?       then config_up(v)
+      when key.down?, key.lower_j?     then v.form_move(1)
       when key.left?                   then v.form_adjust(-1)
       when key.right?                  then v.form_adjust(1)
       when key.enter?                  then activate_config_row(v)

--- a/src/gori/tui/controllers/replay_controller.cr
+++ b/src/gori/tui/controllers/replay_controller.cr
@@ -32,7 +32,7 @@ module Gori::Tui
       @host.session.store.replays.each do |r|
         view = ReplayView.new
         ws_msgs = nil.as(Array(String)?)
-        if r.request.includes?("Upgrade: websocket") || r.request.includes?("upgrade: websocket")
+        if Replay::WsEngine.upgrade_request?(r.request)
           ws_msgs = @host.session.store.ws_messages_for_replay(r.id).compact_map do |m|
             m.direction == "out" ? String.new(m.payload) : nil
           end
@@ -234,7 +234,7 @@ module Gori::Tui
       true
     end
 
-     # The split-decode request hint: which sub-pane is being edited + how to switch.
+    # The split-decode request hint: which sub-pane is being edited + how to switch.
     private def decode_hint(v : ReplayView) : String
       sub = if v.req_pane != :decoded
               "edit request envelope"
@@ -540,7 +540,7 @@ module Gori::Tui
         # each session's view); restore() is response-less so a peer's resend never
         # clobbers the local response/scroll/focus.
         ws_msgs = nil.as(Array(String)?)
-        if row.request.includes?("Upgrade: websocket") || row.request.includes?("upgrade: websocket")
+        if Replay::WsEngine.upgrade_request?(row.request)
           ws_msgs = @host.session.store.ws_messages_for_replay(row.id).compact_map do |m|
             m.direction == "out" ? String.new(m.payload) : nil
           end
@@ -555,7 +555,7 @@ module Gori::Tui
         next if local_ids.includes?(row.id)
         view = ReplayView.new
         ws_msgs = nil.as(Array(String)?)
-        if row.request.includes?("Upgrade: websocket") || row.request.includes?("upgrade: websocket")
+        if Replay::WsEngine.upgrade_request?(row.request)
           ws_msgs = @host.session.store.ws_messages_for_replay(row.id).compact_map do |m|
             m.direction == "out" ? String.new(m.payload) : nil
           end
@@ -762,13 +762,13 @@ module Gori::Tui
       return unless (id = tab.db_id) && tab.view.dirty?
       v = tab.view
       if v.ws_mode?
-        handshake_req = String.new(v.ws_upgrade_bytes)
-        @host.session.store.update_replay(id, v.target, handshake_req, v.http2?, v.auto_content_length?,
+        # Persist the RAW handshake text (request_text = the editor's `$KEY` tokens, LF),
+        # NOT ws_upgrade_bytes (env-expanded + CRLF): baking the expanded form in would
+        # write secrets to the DB and defeat the reconcile guard (which compares LF text).
+        @host.session.store.update_replay(id, v.target, v.request_text, v.http2?, v.auto_content_length?,
           v.sni_override, mark_transform: v.mark_transform?)
-        
-        # Convert OutMsg array to String array
-        ws_texts = v.ws_out_messages.compact_map { |msg| String.new(msg.payload) }
-        @host.session.store.update_replay_ws_messages(id, ws_texts)
+        # Raw message lines too — the store masks secrets; env tokens re-expand on send.
+        @host.session.store.update_replay_ws_messages(id, v.ws_out_texts_raw)
       else
         @host.session.store.update_replay(id, v.target, v.request_text, v.http2?, v.auto_content_length?,
           v.sni_override, mark_transform: v.mark_transform?)

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -324,13 +324,22 @@ module Gori::Tui
     end
 
     # The editable outbound messages, parsed from the editor — one TEXT frame per
-    # non-empty line. Uses @decoded.text (LF-joined) NOT to_bytes (CRLF-joined), else
-    # every frame but the last would carry a spurious trailing '\r'. (A captured frame
-    # with an embedded newline can't be represented one-per-line — a known v1 limit.)
+    # non-empty line, with `$KEY` env tokens expanded at send time (parity with the
+    # handshake and every other outbound path). Uses @decoded.text (LF-joined) NOT
+    # to_bytes (CRLF-joined), else every frame but the last would carry a spurious
+    # trailing '\r'. (A captured frame with an embedded newline can't be represented
+    # one-per-line — a known v1 limit.)
     def ws_out_messages : Array(Replay::WsEngine::OutMsg)
       @decoded.text.split('\n').compact_map do |line|
-        line.empty? ? nil : Replay::WsEngine::OutMsg.new(1, line.to_slice)
+        line.empty? ? nil : Replay::WsEngine::OutMsg.new(1, Env.expand(line).to_slice)
       end
+    end
+
+    # Raw outbound message lines (LF-split, env tokens UNexpanded) for persistence.
+    # The store masks secrets and stores these verbatim, so `$KEY` survives to re-expand
+    # on the next send — never bake an expanded secret into the DB (see ws_out_messages).
+    def ws_out_texts_raw : Array(String)
+      @decoded.text.split('\n').reject(&.empty?)
     end
 
     def ws_upgrade_bytes : Bytes
@@ -701,7 +710,7 @@ module Gori::Tui
       @scx = @sni.size
       @target_field = :url
 
-      is_ws = !ws_messages.nil? || request.includes?("Upgrade: websocket") || request.includes?("upgrade: websocket")
+      is_ws = !ws_messages.nil? || Replay::WsEngine.upgrade_request?(request)
       if is_ws
         @ws_mode = true
         @ws_upgrade = request.to_slice
@@ -971,18 +980,10 @@ module Gori::Tui
     # actual edited body length (the part after the blank line). Common when
     # tampering with a captured body — you change the JSON and the length should
     # follow. Only an EXISTING header is updated (never added, so GETs stay clean);
-    # chunked/h2 bodies have no Content-Length and are left untouched.
+    # chunked/h2 bodies have no Content-Length and are left untouched. Shared with the
+    # headless CLI/MCP replay-send paths via FlowRequest so they can't drift apart.
     private def sync_content_length(raw : Bytes) : Bytes
-      text = String.new(raw)
-      sep = text.index("\r\n\r\n")
-      return raw unless sep
-      head = text[0, sep]
-      body = text[(sep + 4)..]
-      lines = head.split("\r\n")
-      idx = lines.index { |l| l.lstrip.downcase.starts_with?("content-length:") }
-      return raw unless idx
-      lines[idx] = "Content-Length: #{body.bytesize}"
-      "#{lines.join("\r\n")}\r\n\r\n#{body}".to_slice
+      Replay::FlowRequest.resync_content_length(raw)
     end
 
     # Mirror the auto-Content-Length resync into the visible REQUEST editor (^L on) so

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -3739,6 +3739,10 @@ module Gori::Tui
       fuzzer_controller.fuzz_pretty_template
     end
 
+    def fuzz_clear_marks : Nil
+      fuzzer_controller.fuzz_clear_marks
+    end
+
     # --- Miner ExecContext / cross-tab mediators ---
     # CROSS-TAB: open the config popup for History's selected flow (space → Mine params).
     def mine_selected : Nil

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -91,6 +91,7 @@ module Gori
       abstract def fuzz_automark : Nil     # auto-mark every request parameter
       abstract def fuzz_attach_chain : Nil # open the chain-edit prompt for the marker at the template cursor
       abstract def fuzz_list_paste : Nil   # open the payload-set editor pre-seeded to a List (multi-line, one value per line)
+      abstract def fuzz_clear_marks : Nil  # strip all §…§ markers (and their chains) from the template
 
       # param miner (cross-tab seeds open a config popup, then mining runs in background)
       abstract def mine_selected : Nil    # mine History's selected flow (opens the config popup)

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -253,6 +253,9 @@ module Gori
         "fuzz.pretty-template", "Pretty-print template", "Format the request template body in-place (JSON/XML/form-urlencoded)",
         Verb::Scope::Fuzzer, [Verb::Chord.new("u", ctrl: true)],
         available: in_fuzzer) { |ctx| ctx.fuzz_pretty_template; nil }
+      r.register Verb::Definition.new(
+        "fuzz.clear-marks", "Clear markers", "Strip every §…§ marker (and its attached chain) from the template",
+        Verb::Scope::Fuzzer, available: in_fuzzer, mnemonic: 'x') { |ctx| ctx.fuzz_clear_marks; nil }
     end
 
     # Param-miner verbs: the cross-tab "Mine parameters" entry (space menu in History,


### PR DESCRIPTION
Reviewed 2026-07-07's newly-added features (global/project env-var substitution, MCP replay CRUD + secret masking + installer flags, WS handshake editing, `ctrl-u` pretty-print, Fuzzer/Miner focus nav) with four parallel reviewers, verified each finding against the code, and fixed them.

## High
- **`Env.expand_wire` CRLF doubling** — `split('\n').join("\r\n")` turned already-CRLF wire bytes into `\r\r\n`, destroying the head/body separator. Broke **every** CLI/MCP `replay`/`mine` path fed captured flow bytes. → `gsub(/\r?\n/, "\r\n")` (handles LF and CRLF).
- **Fuzzer `^U` destroyed markers** — the `^U PRETTY` badge advertised pretty-print, but a leftover `^U → clear-marks` chord ran before the keymap and **wiped all `§…§` markers**. → removed the chord; added a `fuzz.clear-marks` space-menu verb (mirrors `replay.clear-marks`).
- **Installer clobbered `~/.claude.json`** — on any parse error it fell back to `{}` then overwrote the file (whole CLI state lost). → refuse instead. Also `File.realpath(db_path)` → `File.expand_path` (a not-yet-created `--db` path no longer aborts install).

## Medium
- **`summary` secret leak** — `create_replay`/`update_replay` derived the returned `summary` from the raw (unmasked) request. → derive from `masked_request`.
- **`Env.mask_secrets` corruption** — sequential per-value `gsub` re-matched tokens inserted by an earlier replacement. → single longest-match left-to-right pass.
- **`Pretty.format_request` ≥11-marker corruption** — placeholder `…6001` is a digit-prefix of `…60010`. → restore highest index first.

## WebSocket replay
- `ws_out_messages` now `Env.expand`s each line at send (parity with the handshake & every other outbound path); persistence uses a separate **raw** accessor and stores the raw handshake (`request_text`) so secrets/`$KEY` tokens never bake into the DB.
- `get_replay` now selects `name` (`update_replay` previously echoed `name:""`).

## Robustness / cleanup
- Case-insensitive WS detection via `Replay::WsEngine.upgrade_request?` (replaces 6 duplicated `includes?` checks; also rejects mid-line header-value matches).
- Re-sync Content-Length after env expansion on the **concrete** replay-send paths via shared `Replay::FlowRequest.resync_content_length` (mine template paths excluded — the miner reframes per candidate; TUI `sync_content_length` now delegates to the shared helper).
- Fuzzer `j`/`k` no longer dead-ends in the CONFIG pane.

## Tests
Added regression specs: `expand_wire` CRLF, `mask_secrets` corruption + longest-match, `format_request` 12-marker restore, `upgrade_request?` casing/mid-line, `resync_content_length`, and `^U → fuzz.pretty-template` keymap. **Suite 1318/0; binary builds clean.**