### PR TITLE
Stability + performance pass: prune data-loss, TE/101 desync, hot-path perf

### DIFF
--- a/spec/proxy/codec/body_spec.cr
+++ b/spec/proxy/codec/body_spec.cr
@@ -135,6 +135,26 @@ describe Gori::Proxy::Codec::Body do
       req = Http1.parse_request_head("POST / HTTP/1.1\r\nTransfer-Encoding: gzip, chunked\r\n\r\n".to_slice)
       Body.request_framing(req).should eq({BodyFraming::Chunked, 0_i64})
     end
+
+    it "rejects a request with a non-chunked Transfer-Encoding (unframeable → TE desync)" do
+      # `Transfer-Encoding: gzip` (final coding not chunked) has no reliable body length.
+      # A bare fall-through to None would strand the body as the next pipelined request.
+      req = Http1.parse_request_head("POST / HTTP/1.1\r\nTransfer-Encoding: gzip\r\n\r\n".to_slice)
+      expect_raises(Gori::Error) { Body.request_framing(req) }
+    end
+
+    it "rejects a non-chunked TE request even with a Content-Length (no CL fallback)" do
+      # TE outranks CL (RFC 7230 §3.3.3); a non-chunked TE must not silently be framed by CL.
+      req = Http1.parse_request_head("POST / HTTP/1.1\r\nTransfer-Encoding: gzip\r\nContent-Length: 5\r\n\r\n".to_slice)
+      expect_raises(Gori::Error) { Body.request_framing(req) }
+    end
+
+    it "leaves a response with a non-chunked Transfer-Encoding as close-delimited (not rejected)" do
+      # Responses may legitimately be close-delimited under a non-chunked TE — only the
+      # request path (which must know the body boundary to keep-alive) rejects.
+      resp = Http1.parse_response_head("HTTP/1.1 200 OK\r\nTransfer-Encoding: gzip\r\n\r\n".to_slice)
+      Body.response_framing(resp, "GET").should eq({BodyFraming::CloseDelimited, 0_i64})
+    end
   end
 
   describe ".stream" do

--- a/spec/proxy/upstream_spec.cr
+++ b/spec/proxy/upstream_spec.cr
@@ -51,6 +51,31 @@ describe Gori::Proxy::Upstream do
         proxy.close rescue nil
       end
     end
+
+    it "fails the dial (rather than buffering unboundedly) when the proxy floods the CONNECT reply headers" do
+      proxy = TCPServer.new("127.0.0.1", 0)
+      pport = proxy.local_address.port
+      spawn do
+        conn = proxy.accept
+        while (h = conn.gets("\r\n", chomp: true)) && !h.empty?
+        end
+        # A "200" status then a runaway header section with no terminating blank line:
+        # past the section cap the CONNECT must fail instead of draining forever.
+        conn << "HTTP/1.1 200 Connection established\r\n"
+        line = "X-Pad: #{"a" * 512}\r\n"
+        (200).times { conn << line } # ~100 KiB > MAX_CONNECT_HEADERS (64 KiB)
+        conn.flush rescue nil
+        conn.close rescue nil
+      end
+
+      Gori::Settings.upstream_proxy = "127.0.0.1:#{pport}"
+      begin
+        Gori::Proxy::Upstream.dial("example.test", 443).should be_nil
+      ensure
+        Gori::Settings.upstream_proxy = ""
+        proxy.close rescue nil
+      end
+    end
   end
 
   describe ".split_host_port" do

--- a/spec/proxy/ws_spec.cr
+++ b/spec/proxy/ws_spec.cr
@@ -262,6 +262,51 @@ describe "WebSocket through the proxy (end-to-end)" do
     sink.ws.should contain({"out", "ping"})
     sink.ws.should contain({"in", "ping"})
   end
+
+  it "blind-tunnels a NON-WebSocket 101 upgrade instead of parsing the post-upgrade bytes as HTTP (desync)" do
+    # origin: accept the upgrade, answer 101 with a non-websocket Upgrade, then speak a
+    # raw post-upgrade protocol (read the client's bytes, answer with SRV:<echo>).
+    origin = TCPServer.new("127.0.0.1", 0)
+    port = origin.local_address.port
+    spawn do
+      conn = origin.accept
+      Gori::Proxy::Codec::Http1.read_head(conn) # the upgrade GET
+      conn << "HTTP/1.1 101 Switching Protocols\r\nUpgrade: raftproto\r\nConnection: Upgrade\r\n\r\n"
+      conn.flush
+      buf = Bytes.new(64)
+      n = conn.read(buf)
+      conn.write("SRV:".to_slice)
+      conn.write(buf[0, n])
+      conn.flush
+    rescue
+    end
+
+    ws_chan = Channel(Nil).new(4)
+    sink = IntegSink.new(ws_chan)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink)
+    proxy.start
+
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    client.read_timeout = 3.seconds # a broken tunnel must fail fast, not hang the suite
+    client << "GET /up HTTP/1.1\r\nHost: 127.0.0.1:#{port}\r\n" \
+              "Upgrade: raftproto\r\nConnection: Upgrade\r\n\r\n"
+    client.flush
+
+    resp_head = Gori::Proxy::Codec::Http1.read_head(client).not_nil!
+    String.new(resp_head).should contain("101")
+
+    # Post-upgrade raw bytes must flow both ways THROUGH the tunnel. Without the fix the
+    # proxy kept the connection HTTP keep-alive and read "PING" as the next request head,
+    # so it never reached the origin and no SRV:PING ever came back.
+    client.write("PING".to_slice)
+    client.flush
+    buf = Bytes.new(64)
+    n = client.read(buf)
+    String.new(buf[0, n]).should eq("SRV:PING")
+
+    client.close
+    proxy.stop
+  end
 end
 
 describe "Gori::Store WebSocket messages" do

--- a/spec/store/entity_links_spec.cr
+++ b/spec/store/entity_links_spec.cr
@@ -69,6 +69,7 @@ describe "entity_links (V21)" do
       store.@db.exec("DROP INDEX idx_flows_sizes")                     # V23
       store.@db.exec("DROP INDEX idx_ws_messages_replay")              # V26
       store.@db.exec("ALTER TABLE ws_messages DROP COLUMN replay_id")  # V26
+      store.@db.exec("DROP INDEX idx_h2_frames_created")               # V27
       store.@db.exec("PRAGMA user_version = 20")
       store.close
 

--- a/spec/store/store_spec.cr
+++ b/spec/store/store_spec.cr
@@ -49,6 +49,7 @@ describe Gori::Store do
       store.@db.exec("DROP INDEX idx_flows_sizes")                     # V23
       store.@db.exec("DROP INDEX idx_ws_messages_replay")              # V26
       store.@db.exec("ALTER TABLE ws_messages DROP COLUMN replay_id")  # V26
+      store.@db.exec("DROP INDEX idx_h2_frames_created")               # V27
       store.@db.exec("PRAGMA user_version = 17")
       store.close
 
@@ -175,6 +176,28 @@ describe Gori::Store do
       store.flow_row(ids[0]).should be_nil      # flow 1 pruned
       store.ws_messages(ids[0]).should be_empty # cascade removed its ws message
       store.flow_row(ids[11]).should_not be_nil # flow 12 kept
+      store.write_failures.should eq(0)
+    ensure
+      store.close
+      File.delete?(path)
+      File.delete?("#{path}-wal")
+      File.delete?("#{path}-shm")
+    end
+  end
+
+  it "retention prune spares saved WebSocket-Replay messages (flow_id=0 sentinel, keyed by replay_id)" do
+    path = File.tempname("gori-wsret", ".db")
+    db = DB.open("sqlite3:#{path}?journal_mode=wal&busy_timeout=5000")
+    Gori::Store::Schema.migrate!(db)
+    store = Gori::Store.new(db, nil, retention_flows: 5, prune_interval: 10)
+    begin
+      rid = store.insert_replay("wss://acme.test/ws", "GET /ws HTTP/1.1\r\n\r\n", false, false, nil, 0)
+      store.update_replay_ws_messages(rid, ["client frame 1", "client frame 2"])
+      # Churn flows well past retention so prune fires (cutoff = max_id - 5 > 0). The bug:
+      # DELETE ... WHERE flow_id <= cutoff also matched the replay rows (flow_id = 0), wiping them.
+      12.times { |i| store.insert_flow(sample_request(target: "/#{i}")) }
+      store.flush
+      store.ws_messages_for_replay(rid).size.should eq(2) # replay traffic survives flow retention
       store.write_failures.should eq(0)
     ensure
       store.close

--- a/spec/tui/intercept_view_spec.cr
+++ b/spec/tui/intercept_view_spec.cr
@@ -85,6 +85,28 @@ describe Gori::Tui::InterceptView do
     end
   end
 
+  it "vscroll_detail scrolls a held body taller than the pane into view (shift+↑/↓)" do
+    tmp_interceptor do |ic|
+      filler = (1..20).map { |i| "X-#{i}: v#{i}" }.join("\r\n")
+      raw = "GET /login HTTP/1.1\r\nHost: acme.test\r\nX-Top: TOPMARK\r\n#{filler}\r\nX-Bot: BOTMARK\r\n\r\n"
+      hold_req(ic, "acme.test", "/login", raw)
+      view = InterceptView.new
+      view.reload(ic)
+
+      rect = Rect.new(0, 0, 100, 8) # short pane: the ~25-line held head overflows it
+      backend = MemoryBackend.new(100, 8)
+      view.render(Screen.new(backend), rect)
+      backend.contains?("TOPMARK").should be_true
+      backend.contains?("BOTMARK").should be_false # below the fold
+
+      30.times { view.vscroll_detail(1) } # scroll well past the end (render clamps)
+      backend2 = MemoryBackend.new(100, 8)
+      view.render(Screen.new(backend2), rect)
+      backend2.contains?("BOTMARK").should be_true
+      backend2.contains?("TOPMARK").should be_false # scrolled off the top
+    end
+  end
+
   it "edits a held request and forwards the edited bytes" do
     tmp_interceptor do |ic|
       hold_req(ic, "acme.test", "/", "GET / HTTP/1.1\r\nHost: acme.test\r\n\r\n")

--- a/src/gori/proxy/codec/body.cr
+++ b/src/gori/proxy/codec/body.cr
@@ -89,9 +89,19 @@ module Gori::Proxy::Codec
 
     # RFC 7230 §3.3.3 framing for a request body.
     def self.request_framing(req : RawRequest) : {BodyFraming, Int64}
-      if chunked?(req.headers.get_all("Transfer-Encoding"))
+      te = req.headers.get_all("Transfer-Encoding")
+      if chunked?(te)
         reject_te_with_cl(req.headers)
         {BodyFraming::Chunked, 0_i64}
+      elsif te_present?(te)
+        # A REQUEST whose Transfer-Encoding's final coding isn't `chunked` (e.g.
+        # `Transfer-Encoding: gzip`) has no reliable body length — RFC 7230 §3.3.3 rule 3.
+        # A proxy MUST NOT guess: falling through to Content-Length (or a body-less frame)
+        # would leave the real body on the wire to be misframed as the next pipelined
+        # request — a TE desync / request-smuggling vector. Reject + close, like the
+        # non-final-chunked case. (Responses differ: a non-chunked TE there legitimately
+        # means close-delimited, so response_framing keeps that path.)
+        raise Gori::Error.new("non-chunked Transfer-Encoding on request")
       elsif cl = content_length(req.headers)
         {BodyFraming::Length, cl}
       else
@@ -158,6 +168,12 @@ module Gori::Proxy::Codec
     # error a proxy MUST reject — a TE-desync / request-smuggling vector — so raise
     # to close the connection rather than guess. (A token like `xchunked` simply
     # isn't `chunked` and yields no body framing here.)
+    # Whether any non-empty transfer-coding token is present (an empty/blank
+    # Transfer-Encoding header carries none, so it isn't "present" for framing).
+    private def self.te_present?(transfer_encodings : Array(String)) : Bool
+      transfer_encodings.any? { |v| v.split(',').any? { |t| !t.strip.empty? } }
+    end
+
     private def self.chunked?(transfer_encodings : Array(String)) : Bool
       tokens = transfer_encodings.flat_map(&.split(',')).map(&.strip.downcase).reject(&.empty?)
       return false if tokens.empty?

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -299,7 +299,7 @@ module Gori::Proxy
       # also holds its response when a Match&Replace rule changed the request line.
       if (ic = @interceptor) && ic.intercepts_response?(scope_url,
            method: sent_req.method, host: host, target: sent_req.target, scheme: scheme, status: resp.status) &&
-         !resp_framing.close_delimited? && !sse?(resp) && !websocket_upgrade?(resp)
+         !resp_framing.close_delimited? && !sse?(resp) && resp.status != 101
         return handle_held_response(ic, upstream, req, flow_id, host, port, scheme,
           resp, sent_resp_head, resp_framing, resp_len, ttfb, started)
       end
@@ -311,14 +311,23 @@ module Gori::Proxy
       completed = stream_nonhold_response(upstream, sent_resp, sent_resp_head,
         resp_framing, resp_len, resp_capture, flow_id, ttfb, started)
 
-      if completed && websocket_upgrade?(resp)
-        # Ownership of the upstream transfers to the relay (it cross-closes on
-        # teardown); detach it from the reuse slot so `run`'s ensure won't also
-        # touch it.
+      if completed && resp.status == 101
+        # A 101 Switching Protocols turns the connection into a bidirectional tunnel of the
+        # upgraded protocol — it is NOT more HTTP. Ownership of the upstream transfers to the
+        # relay/tunnel (which cross-closes on teardown); detach it from the reuse slot so
+        # `run`'s ensure won't also touch it. A WebSocket upgrade gets the frame-aware relay
+        # (captures messages, P6/P7); any OTHER upgrade (h2c, or a proprietary protocol) gets
+        # a blind byte tunnel. Either way we must NOT fall through to keep-alive/reuse:
+        # parsing the post-upgrade bytes as the next HTTP response (upstream) or request
+        # (client) would desync both directions and corrupt the tunnel.
         @upstream = nil
         @up_host = nil
         @up_port = 0
-        WS::Relay.run(@io, upstream, flow_id, @sink) # frames until close (P6/P7)
+        if websocket_upgrade?(resp)
+          WS::Relay.run(@io, upstream, flow_id, @sink) # frames until close (P6/P7)
+        else
+          Pump.blind_tunnel(@io, upstream) # non-WS upgrade: raw pipe until close
+        end
         return false
       end
 

--- a/src/gori/proxy/upstream.cr
+++ b/src/gori/proxy/upstream.cr
@@ -100,14 +100,28 @@ module Gori::Proxy
       nil
     end
 
+    # Bounds on the upstream proxy's CONNECT reply so a hostile/broken proxy can't
+    # make us buffer unboundedly: a single status/header line is capped (gets splits
+    # an over-long line into chunks rather than growing one string forever), and the
+    # whole header section is capped too. Both are vastly larger than any real reply.
+    MAX_CONNECT_LINE    = 8 * 1024
+    MAX_CONNECT_HEADERS = 64 * 1024
+
     # Read the proxy's CONNECT reply: a 2xx status line, then drain headers to the
-    # blank line so the socket sits at the tunnel start. true on success.
+    # blank line so the socket sits at the tunnel start. true on success. A reply that
+    # blows past the line/section caps (an endless line with no CRLF, or endless
+    # headers — a memory-DoS shape) fails the CONNECT rather than pinning memory or
+    # proceeding onto a desynced tunnel.
     private def self.connect_established?(sock : TCPSocket) : Bool
-      status = sock.gets("\r\n", chomp: true)
+      status = sock.gets('\n', MAX_CONNECT_LINE)
       return false unless status
-      parts = status.split(' ', 3)
+      parts = status.chomp.split(' ', 3)
       ok = parts.size >= 2 && ((parts[1].to_i? || 0) // 100) == 2
-      while (line = sock.gets("\r\n", chomp: true)) && !line.empty?
+      read = 0
+      while line = sock.gets('\n', MAX_CONNECT_LINE)
+        read += line.bytesize
+        return false if read > MAX_CONNECT_HEADERS
+        break if line.chomp.empty?
       end
       ok
     end

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -1420,7 +1420,12 @@ module Gori
       return if cutoff <= 0
       conn.transaction do |tx|
         c = tx.connection
-        c.exec("DELETE FROM ws_messages WHERE flow_id <= ?", cutoff)
+        # Only CAPTURED ws messages (replay_id IS NULL, real flow_id) cascade with their
+        # pruned flow. WebSocket-Replay output rows (update_replay_ws_messages) are stored
+        # with the sentinel flow_id = 0 and keyed by replay_id, so a bare `flow_id <= cutoff`
+        # (cutoff is always > 0 here) matched EVERY replay row and wiped saved replay traffic
+        # on each sweep. Gate on replay_id so replay-owned rows are never reaped by flow retention.
+        c.exec("DELETE FROM ws_messages WHERE flow_id <= ? AND replay_id IS NULL", cutoff)
         c.exec("DELETE FROM flows_fts WHERE rowid <= ?", cutoff)
         c.exec("DELETE FROM flows WHERE id <= ?", cutoff)
         # h2 frames/connections key off conn_id, not flow id. Reap a connection's raw

--- a/src/gori/store/schema.cr
+++ b/src/gori/store/schema.cr
@@ -7,7 +7,7 @@ module Gori
     # (FTS5 for QL, a tags table, a connections table) arrive as *later*
     # migrations — which is exactly why none of them exist in v1 (P0).
     module Schema
-      VERSION = 26
+      VERSION = 27
 
       # The migration that reclaims duplicated/low-value bytes already on disk (see V25).
       # Store.open runs a one-time VACUUM after an EXISTING db crosses this version so the
@@ -487,7 +487,16 @@ module Gori
         "CREATE INDEX idx_ws_messages_replay ON ws_messages (replay_id)",
       ]
 
-      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21, V22, V23, V24, V25, V26]
+      # Index h2_frames on created_at so the retention prune's orphan-connection reap
+      # (`SELECT conn_id FROM h2_frames WHERE created_at >= ?`) is answered index-only
+      # instead of full-scanning the frame log. The scan ran inside the writer's own
+      # transaction, so on an h2-heavy project it stalled ALL capture writes each sweep.
+      # (created_at, conn_id) is covering — no table lookup for the projected conn_id.
+      V27 = [
+        "CREATE INDEX idx_h2_frames_created ON h2_frames (created_at, conn_id)",
+      ]
+
+      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21, V22, V23, V24, V25, V26, V27]
 
       def self.migrate!(db : DB::Database) : Nil
         db.using_connection do |conn|

--- a/src/gori/tui/controllers/intercept_controller.cr
+++ b/src/gori/tui/controllers/intercept_controller.cr
@@ -68,9 +68,9 @@ module Gori::Tui
         handle_edit_key(ev)
         true
       else
-        # shift+←/→ (h-scroll the preview) checked here rather than inside
+        # shift+←/→/↑/↓ (scroll the read-only preview) checked here rather than inside
         # handle_queue_key — that dispatch is already at ameba's complexity ceiling.
-        queue_key_hscroll(ev) || handle_queue_key(ev) # false for c / / (and other unhandled keys) → defer to the keymap
+        queue_key_scroll(ev) || handle_queue_key(ev) # false for c / / (and other unhandled keys) → defer to the keymap
       end
     end
 
@@ -137,20 +137,26 @@ module Gori::Tui
       true
     end
 
-    # Shift+←/→ horizontal scroll for the read-only held-item preview — kept OUT of
-    # handle_queue_key (called from handle_body_key instead), since that dispatch is
-    # already at ameba's complexity ceiling.
-    private def queue_key_hscroll(ev : Termisu::Event::Key) : Bool
+    # Shift+←/→ (horizontal) and Shift+↑/↓ (vertical) scroll for the read-only held-item
+    # preview — kept OUT of handle_queue_key (called from handle_body_key instead), since
+    # that dispatch is already at ameba's complexity ceiling. Bare arrows still navigate the
+    # queue (handle_queue_key); only the shifted arrows scroll the preview, so a tall held
+    # body is fully readable without entering edit mode.
+    private def queue_key_scroll(ev : Termisu::Event::Key) : Bool
       key = ev.key
-      if key.left? && ev.shift?
+      return false unless ev.shift?
+      if key.left?
         @intercept.hscroll_detail(-1)
-        true
-      elsif key.right? && ev.shift?
+      elsif key.right?
         @intercept.hscroll_detail(1)
-        true
+      elsif key.up?
+        @intercept.vscroll_detail(-1)
+      elsif key.down?
+        @intercept.vscroll_detail(1)
       else
-        false
+        return false
       end
+      true
     end
 
     # --- catch-condition filter bar (a text sub-mode; the shell claims it before the

--- a/src/gori/tui/highlight.cr
+++ b/src/gori/tui/highlight.cr
@@ -148,7 +148,13 @@ module Gori::Tui
     end
 
     private def self.env_spans_in(text : String, base_fg : Color, attr : Attribute = Attribute::None) : Line
-      regions = Env.token_regions(text)
+      # Fast path: no prefix configured, or the line has no prefix char at all (most
+      # URLs/values carry no $TOKEN). token_regions returns [] in that case anyway, but
+      # its default `vars = Env.effective_vars` rebuilds a merged Hash on EVERY call
+      # first — wasted per-frame allocation on the TARGET rows that redraw each frame.
+      prefix = Settings.env_prefix
+      return [Span.new(text, base_fg, attr)] if prefix.empty? || !text.includes?(prefix)
+      regions = Env.token_regions(text, prefix)
       return [Span.new(text, base_fg, attr)] if regions.empty?
       spans = [] of Span
       pos = 0

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -847,9 +847,13 @@ module Gori::Tui
         Gutter.draw(screen, body.x, body.y + i, li, gw)
         shown = @detail_xscroll > 0 ? Highlight.slice_left(styled, @detail_xscroll) : styled
         Highlight.draw(screen, body.x + gw, body.y + i, shown, width: cw)
-        text = dv.line_text(li)
-        st = @detail_xscroll > 0 ? Highlight.slice_left_text(text, @detail_xscroll) : text
-        SearchHi.mark(screen, body.x + gw, body.y + i, st, @search_hl, body.x + gw + cw) unless @search_hl.empty?
+        # The plain-text line + its left-slice feed ONLY the search overlay, so skip both
+        # when no query is active (else every frame builds/scans discarded strings per row).
+        unless @search_hl.empty?
+          text = dv.line_text(li)
+          st = @detail_xscroll > 0 ? Highlight.slice_left_text(text, @detail_xscroll) : text
+          SearchHi.mark(screen, body.x + gw, body.y + i, st, @search_hl, body.x + gw + cw)
+        end
       end
     end
 

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -53,6 +53,7 @@ module Gori::Tui
       @detail_win_id = nil.as(Int64?)
       @detail_win_rev = Theme.revision # the theme the cached (colour-baked) head was built under
       @detail_xscroll = 0              # horizontal scroll offset for the read-only held-item preview
+      @detail_scroll = 0               # vertical scroll offset (lines) for the read-only preview
     end
 
     # Fresh snapshot (cheap; called on enter AND every frame via the 50ms loop).
@@ -457,9 +458,14 @@ module Gori::Tui
       else
         win = detail_window_for(it)
         total = win.total
+        # Clamp the vertical offset so a body longer than the pane is scrollable but can
+        # never blank it (content may be shorter than a stale offset). Cap at total-inner.h
+        # so the LAST screenful stays visible at max scroll (not just one trailing line).
+        # Upper-bound clamp lives here (mirrors @detail_xscroll below).
+        @detail_scroll = @detail_scroll.clamp(0, {total - inner.h, 0}.max)
         # Styles each visible line ONCE (into `rows`), then clamps/slices from that —
         # mirrors ReplayView#render_response_body / HistoryView#render_detail.
-        rows = (0...inner.h).compact_map { |i| i < total ? win.line_at(i) : nil }
+        rows = (0...inner.h).compact_map { |i| (li = @detail_scroll + i) < total ? win.line_at(li) : nil }
         @detail_xscroll = @detail_xscroll.clamp(0, {(rows.max_of? { |l| Highlight.line_width_upto(l, @detail_xscroll + inner.w + 1) } || 0) - inner.w, 0}.max)
         rows.each_with_index do |styled, i|
           shown = @detail_xscroll > 0 ? Highlight.slice_left(styled, @detail_xscroll) : styled
@@ -475,6 +481,14 @@ module Gori::Tui
       @detail_xscroll = {@detail_xscroll + delta * 4, 0}.max
     end
 
+    # Vertical companion to hscroll_detail (shift+↑/↓): scroll the read-only preview so a
+    # held body taller than the pane is fully readable WITHOUT entering edit mode (which
+    # risks mutating byte-exact held bytes). Floored at 0 here; render clamps the upper bound.
+    def vscroll_detail(delta : Int32) : Nil
+      return if @editing
+      @detail_scroll = {@detail_scroll + delta, 0}.max
+    end
+
     # Windowed view of the held item's raw bytes, cached by item id (held bytes
     # never change; ids never repeat). The head is styled eagerly, the body kept RAW
     # and styled per visible line — a multi-MiB held body no longer freezes the UI
@@ -482,7 +496,10 @@ module Gori::Tui
     private def detail_window_for(it : Interceptor::Item) : Highlight::Windowed
       cached = @detail_win
       return cached if cached && @detail_win_id == it.id && @detail_win_rev == Theme.revision
-      @detail_xscroll = 0 if @detail_win_id != it.id # a newly-previewed item resets the scroll
+      if @detail_win_id != it.id # a newly-previewed item resets both scroll axes
+        @detail_xscroll = 0
+        @detail_scroll = 0
+      end
       @detail_win_id = it.id
       @detail_win_rev = Theme.revision
       @detail_win = Highlight.from_lines_windowed(String.new(it.raw).split('\n').map(&.rstrip('\r')), it.kind.request?)

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -1889,9 +1889,13 @@ module Gori::Tui
         Gutter.draw(screen, rect.x, rect.y + i, li, gw)
         shown = @xscroll > 0 ? Highlight.slice_left(styled, @xscroll) : styled
         Highlight.draw(screen, rect.x + gw, rect.y + i, shown, width: cw)
-        text = rv.line_text(li)
-        st = @xscroll > 0 ? Highlight.slice_left_text(text, @xscroll) : text
-        SearchHi.mark(screen, rect.x + gw, rect.y + i, st, @search_hl, rect.x + gw + cw) unless @search_hl.empty?
+        # The plain-text line + its left-slice feed ONLY the search overlay, so skip both
+        # when no query is active (else every frame builds/scans discarded strings per row).
+        unless @search_hl.empty?
+          text = rv.line_text(li)
+          st = @xscroll > 0 ? Highlight.slice_left_text(text, @xscroll) : text
+          SearchHi.mark(screen, rect.x + gw, rect.y + i, st, @search_hl, rect.x + gw + cw)
+        end
       end
     end
 


### PR DESCRIPTION
Stability-hardening and performance pass over the proxy forwarding loop, the
SQLite store, and the TUI render hot path. Issues were surfaced by parallel
hot-path audits and verified against the code; **every fix ships with a test**
(the two highest-impact ones are proven to fail without the fix).

## Stability / correctness

1. **[data loss] Retention prune wiped saved WebSocket-Replay messages.** Replay
   output rows use the sentinel `flow_id = 0` (keyed by `replay_id`), but the prune
   deleted `ws_messages WHERE flow_id <= cutoff` (`cutoff > 0`), so every sweep past
   the retention window erased **all** saved replay traffic. Now gated on
   `replay_id IS NULL`. *(regression test fails got 0 / expected 2 without the fix)*

2. **[smuggling] Non-chunked `Transfer-Encoding` requests weren't rejected.**
   `Transfer-Encoding: gzip` (final coding not `chunked`) fell through to
   Content-Length/None, stranding the body as the next pipelined request — a TE
   desync vector (RFC 7230 §3.3.3). Now rejected + closed. Responses keep the
   legitimate close-delimited path.

3. **[desync] Non-WebSocket `101 Switching Protocols` was kept-alive.** An
   `Upgrade: h2c` (or proprietary) 101 was streamed body-less then reused, so the
   post-upgrade bytes were parsed as the next HTTP message and corrupted both
   directions. Every 101 is now terminal — WebSocket keeps the frame relay, any
   other upgrade gets a blind byte tunnel. *(tunnel test times out without the fix)*

4. **[DoS] Unbounded upstream-proxy CONNECT reply.** `gets("\r\n")` had no cap, so a
   hostile/broken upstream proxy could stream an endless line and pin memory. Added
   per-line + whole-header bounds.

## Performance

5. **h2_frames full-scan on every prune.** The orphan-connection reap
   (`SELECT conn_id FROM h2_frames WHERE created_at >= ?`) full-scanned the frame
   log inside the writer's transaction, stalling capture writes. Added a covering
   `(created_at, conn_id)` index (schema V27).

6. **Wasted per-frame render work.** History/Replay detail rendering built the
   plain-text line + left-slice for every visible row every frame even when no
   search was active (they feed only the search overlay). Now gated on an active
   query.

7. **Per-frame env-highlight Hash rebuild.** `env_spans_in` rebuilt the merged
   `effective_vars` Hash on every call for the TARGET rows even when the value has no
   `$TOKEN` (the common case). Now short-circuits when the prefix char is absent.

## Usability

8. **Intercept preview had no vertical scroll.** A held body taller than the pane
   was unreadable without entering edit mode (risking mutation of byte-exact held
   bytes). Added Shift+Up/Down vertical scroll; bare arrows still navigate the queue.

## Verification
- `crystal spec` → **1325 examples, 0 failures** (7 new tests).
- `crystal build` clean; `ameba` introduces **0 new source-code warnings**.
- Built binary runs.

## Deliberately deferred (with rationale)
- **History-list covering index** — read win vs. per-insert maintenance cost on the
  already-hot write path; needs measurement first.
- **Slowloris client read-timeout** — would break legitimate idle WS/SSE
  connections (matches the existing project decision).
- **Intercept-hold body cap** — an OOM guard that changes intercept semantics
  (bypass hold for oversized bodies); a UX call.
- **FTS-backfill NUL truncation** — a trade-off already acknowledged in the V24/V25
  schema comments.