### PR TITLE
feat(tui): redesign space menu — grouped sections, tab-level menu, smart Copy

### DIFF
--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -75,6 +75,10 @@ class FakeExecContext < Gori::Verb::ExecContext
     @replay_tab_count
   end
 
+  def replay_rename_subtab : Nil; end
+
+  def replay_close_subtab : Nil; end
+
   def replay_toggle_hex : Nil; end
 
   def replay_toggle_decoded : Nil; end
@@ -82,6 +86,10 @@ class FakeExecContext < Gori::Verb::ExecContext
   def replay_toggle_sni : Nil; end
 
   def replay_toggle_auto_content_length : Nil; end
+
+  def replay_toggle_resp_diff : Nil; end
+
+  def replay_toggle_resp_hex : Nil; end
 
   def replay_toggle_mark_transform : Nil; end
 
@@ -124,6 +132,10 @@ class FakeExecContext < Gori::Verb::ExecContext
   def fuzz_list_paste : Nil; end
 
   def fuzz_clear_marks : Nil; end
+
+  def fuzzer_rename_subtab : Nil; end
+
+  def fuzzer_close_subtab : Nil; end
 
   def fuzzer_copy : Nil; end
 
@@ -299,14 +311,20 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def convert_close : Nil; end
 
+  def convert_rename_subtab : Nil; end
+
   def convert_clear : Nil; end
 
   def convert_copy : Nil; end
 
   def convert_copy_selection : Nil; end
 
+  def convert_copy_all : Nil; end
+
+  property convert_read_mode : Bool = false # settable so grouped-menu specs can exercise COMMON's Copy
+
   def convert_read_mode? : Bool
-    false
+    @convert_read_mode
   end
 
   def convert_cycle_mode : Nil; end
@@ -352,6 +370,8 @@ class FakeExecContext < Gori::Verb::ExecContext
   def read_select_line : Nil; end
 
   def read_clear_selection : Nil; end
+
+  def read_copy : Nil; end
 
   def detail_navigable? : Bool
     false

--- a/spec/tui/space_menu_spec.cr
+++ b/spec/tui/space_menu_spec.cr
@@ -9,7 +9,7 @@ describe Gori::Tui::SpaceMenu do
     ctx = FakeExecContext.new
     ctx.selected = 5_i64 # flow-gated Body actions available
     menu = SpaceMenu.new(Gori::Verbs.registry)
-    menu.open(Gori::Verb::Scope::Body, ctx)
+    menu.open(Gori::Verb::Scope::Body, :common, ctx)
 
     menu.entries.size.should be > 0
     menu.entries.all?(&.scope.body?).should be_true         # strictly scope-local
@@ -22,7 +22,7 @@ describe Gori::Tui::SpaceMenu do
     ctx = FakeExecContext.new
     ctx.selected = 5_i64
     menu = SpaceMenu.new(Gori::Verbs.registry)
-    menu.open(Gori::Verb::Scope::Body, ctx)
+    menu.open(Gori::Verb::Scope::Body, :common, ctx)
 
     menu.verb_for('y').try(&.id).should eq("history.copy")
     menu.verb_for('r').try(&.id).should eq("history.replay")
@@ -33,7 +33,7 @@ describe Gori::Tui::SpaceMenu do
     ctx = FakeExecContext.new
     ctx.selected = 5_i64
     menu = SpaceMenu.new(Gori::Verbs.registry)
-    menu.open(Gori::Verb::Scope::Body, ctx)
+    menu.open(Gori::Verb::Scope::Body, :common, ctx)
 
     menu.move(-5)
     menu.selected.should eq(0)
@@ -45,7 +45,7 @@ describe Gori::Tui::SpaceMenu do
     ctx = FakeExecContext.new
     ctx.selected = 5_i64
     menu = SpaceMenu.new(Gori::Verbs.registry)
-    menu.open(Gori::Verb::Scope::HistoryDetail, ctx) # detail drill-in is navigable now
+    menu.open(Gori::Verb::Scope::HistoryDetail, :common, ctx) # detail drill-in is navigable now
 
     menu.entries.size.should be > 0
     menu.entries.all?(&.scope.history_detail?).should be_true # strictly scope-local
@@ -60,7 +60,7 @@ describe Gori::Tui::SpaceMenu do
     ctx = FakeExecContext.new
     ctx.scope_has_rule = true # edit/delete are gated on a selected rule
     menu = SpaceMenu.new(Gori::Verbs.registry)
-    menu.open(Gori::Verb::Scope::Project, ctx)
+    menu.open(Gori::Verb::Scope::Project, :common, ctx)
 
     ids = menu.entries.map(&.id)
     ids.should contain("scope.lens-toggle") # the lens toggle is now a menu item, not a bare space key
@@ -75,7 +75,7 @@ describe Gori::Tui::SpaceMenu do
     ctx = FakeExecContext.new
     ctx.env_has_var = true # edit/delete are gated on a selected var
     menu = SpaceMenu.new(Gori::Verbs.registry)
-    menu.open(Gori::Verb::Scope::Env, ctx)
+    menu.open(Gori::Verb::Scope::Env, :common, ctx)
 
     menu.entries.all?(&.scope.env?).should be_true # strictly scope-local — no scope-rule bleed
     menu.entries.all?(&.menu_key).should be_true
@@ -92,7 +92,7 @@ describe Gori::Tui::SpaceMenu do
   it "hides the env-var edit/delete entries when no var is selected" do
     ctx = FakeExecContext.new # env_has_var defaults to false
     menu = SpaceMenu.new(Gori::Verbs.registry)
-    menu.open(Gori::Verb::Scope::Env, ctx)
+    menu.open(Gori::Verb::Scope::Env, :common, ctx)
 
     ids = menu.entries.map(&.id)
     ids.should contain("env.add-var")     # always available
@@ -105,7 +105,7 @@ describe Gori::Tui::SpaceMenu do
     ctx = FakeExecContext.new
     ctx.current_tab = :notes
     menu = SpaceMenu.new(Gori::Verbs.registry)
-    menu.open(Gori::Verb::Scope::Notes, ctx)
+    menu.open(Gori::Verb::Scope::Notes, :common, ctx)
 
     menu.entries.size.should be > 0
     menu.entries.all?(&.scope.notes?).should be_true
@@ -124,7 +124,7 @@ describe Gori::Tui::SpaceMenu do
   it "lists the Prism list's detail-parity actions (promote, evidence, delete)" do
     ctx = FakeExecContext.new
     menu = SpaceMenu.new(Gori::Verbs.registry)
-    menu.open(Gori::Verb::Scope::Prism, ctx)
+    menu.open(Gori::Verb::Scope::Prism, :common, ctx)
 
     ids = menu.entries.map(&.id)
     ids.should contain("prism.promote-selected")
@@ -141,26 +141,187 @@ describe Gori::Tui::SpaceMenu do
 
   it "lists the Convert tab's actions in the Convert scope (reachable from the sub-tab strip)" do
     ctx = FakeExecContext.new
-    ctx.current_tab = :convert # the Convert verbs gate on the active tab
+    ctx.current_tab = :convert   # the Convert verbs gate on the active tab
+    ctx.convert_read_mode = true # so COMMON's Copy is available too
     menu = SpaceMenu.new(Gori::Verbs.registry)
-    menu.open(Gori::Verb::Scope::Convert, ctx)
+    menu.open(Gori::Verb::Scope::Convert, :common, ctx)
 
     menu.entries.size.should be > 0
     menu.entries.all?(&.scope.convert?).should be_true # strictly scope-local
     menu.entries.all?(&.menu_key).should be_true       # every shown entry has a key
     ids = menu.entries.map(&.id)
+    ids.should contain("convert.copy") # the single smart Copy (copy-all is gone)
+    menu.verb_for('y').try(&.id).should eq("convert.copy")
+  end
+
+  it "keeps Convert's New/Close in COMMON (Round 4) so they show from every context, not just the tab bar/strip" do
+    ctx = FakeExecContext.new
+    ctx.current_tab = :convert
+    ctx.convert_read_mode = true # so COMMON's Copy shows too, for a fuller COMMON+CONTEXT picture
+    menu = SpaceMenu.new(Gori::Verbs.registry)
+
+    # Tab-bar focus (@focus == :menu): Round 5 moved Save/Load to :tab (session-level),
+    # so this is now COMMON + a real TAB group — New/Close/Copy/Save/Load all present.
+    menu.open(Gori::Verb::Scope::Convert, :tab, ctx)
+    ids = menu.entries.map(&.id)
+    ids.should contain("convert.copy")
     ids.should contain("convert.new")
     ids.should contain("convert.close")
-    ids.should contain("convert.copy-all")
+    ids.should contain("convert.save")
+    ids.should contain("convert.load")
     menu.verb_for('n').try(&.id).should eq("convert.new")
     menu.verb_for('w').try(&.id).should eq("convert.close")
-    menu.verb_for('O').try(&.id).should eq("convert.copy-all")
+    menu.verb_for('s').try(&.id).should eq("convert.save")
+    menu.verb_for('o').try(&.id).should eq("convert.load")
+
+    # Sub-tab strip focus (@focus == :subtabs): Convert now has its OWN :subtab verb
+    # (rename, mirroring Replay/Fuzzer) — COMMON + SUBTAB, New/Close/Copy/Rename all
+    # reachable from the strip.
+    menu.open(Gori::Verb::Scope::Convert, :subtab, ctx)
+    ids = menu.entries.map(&.id)
+    ids.should contain("convert.copy")
+    ids.should contain("convert.new")
+    ids.should contain("convert.close")
+    ids.should contain("convert.rename-subtab")
+    menu.verb_for('e').try(&.id).should eq("convert.rename-subtab")
+    ids.should_not contain("convert.save") # :tab-only, not :subtab — no bleed
+
+    # Body-pane focus: OUTPUT gets Cycle output mode + COMMON's New/Close/Copy —
+    # the whole point of Round 4 is New/Close now show INSIDE the body panes too.
+    menu.open(Gori::Verb::Scope::Convert, :output, ctx)
+    ids = menu.entries.map(&.id)
+    ids.should contain("convert.mode")
+    ids.should contain("convert.new")
+    ids.should contain("convert.close")
+    ids.should_not contain("convert.save") # a DIFFERENT group (:tab) — no bleed
+
+    # CHAIN pane: Round 5 moved Save/Load OUT of :chain (into :tab), so CHAIN has no
+    # actions of its own left — falls back to a flat COMMON-only render (the
+    # single-group-omits-header rule), same as a single-region tab.
+    menu.open(Gori::Verb::Scope::Convert, :chain, ctx)
+    ids = menu.entries.map(&.id)
+    ids.should contain("convert.new")
+    ids.should contain("convert.close")
+    ids.should_not contain("convert.save")
+    ids.should_not contain("convert.mode")
+  end
+
+  it "yields COMMON + the focus-area's own group when opened with a non-common section (Replay), and a single flat group for :common" do
+    ctx = FakeExecContext.new
+    ctx.current_tab = :replay
+    menu = SpaceMenu.new(Gori::Verbs.registry)
+
+    menu.open(Gori::Verb::Scope::Replay, :request, ctx)
+    ids = menu.entries.map(&.id)
+    ids.should contain("replay.send")           # COMMON
+    ids.should contain("replay.insert-marker")  # :request
+    ids.should_not contain("replay.toggle-sni") # a DIFFERENT section (:target) — no bleed
+    menu.verb_for('i').try(&.id).should eq("replay.insert-marker")
+
+    backend = MemoryBackend.new(100, 30)
+    menu.render(Screen.new(backend), Rect.new(0, 0, 100, 28))
+    backend.contains?("SPACE · REQUEST").should be_true # card title carries the section label
+    backend.contains?("COMMON").should be_true          # dim group header
+    backend.contains?("REQUEST").should be_true
+
+    # :common alone → single flat group: no header, no :request bleed.
+    menu.open(Gori::Verb::Scope::Replay, :common, ctx)
+    ids = menu.entries.map(&.id)
+    ids.should contain("replay.send")
+    ids.should_not contain("replay.insert-marker")
+
+    backend2 = MemoryBackend.new(100, 30)
+    menu.render(Screen.new(backend2), Rect.new(0, 0, 100, 28))
+    backend2.contains?("SPACE · COMMON").should be_false # flat render — no section suffix
+  end
+
+  it "yields COMMON + the focus-area's own group when opened with a non-common section (Fuzzer)" do
+    ctx = FakeExecContext.new
+    ctx.current_tab = :fuzzer
+    menu = SpaceMenu.new(Gori::Verbs.registry)
+
+    menu.open(Gori::Verb::Scope::Fuzzer, :template, ctx)
+    ids = menu.entries.map(&.id)
+    ids.should contain("fuzz.run")      # COMMON
+    ids.should contain("fuzz.new")      # Round 5: New moved into COMMON, so it's here too
+    ids.should contain("fuzz.automark") # :template
+    menu.verb_for('m').try(&.id).should eq("fuzz.automark")
+
+    # Round 5: fuzz.new moved :tab → :common, so Fuzzer no longer has any :tab-only
+    # verbs — the tab bar now falls back to a flat COMMON-only render (same rule that
+    # already covered Convert's tab bar pre-Round-5), New/Run/Stop/Copy all present.
+    menu.open(Gori::Verb::Scope::Fuzzer, :tab, ctx)
+    ids = menu.entries.map(&.id)
+    ids.should contain("fuzz.run")
+    ids.should contain("fuzz.new")
+    ids.should_not contain("fuzz.automark") # :template-only — no bleed
+    menu.verb_for('n').try(&.id).should eq("fuzz.new")
+  end
+
+  it "populates Replay's :subtab group with rename/close (Round 4 — was raw key-dispatch)" do
+    ctx = FakeExecContext.new
+    ctx.current_tab = :replay
+    menu = SpaceMenu.new(Gori::Verbs.registry)
+
+    menu.open(Gori::Verb::Scope::Replay, :subtab, ctx)
+    ids = menu.entries.map(&.id)
+    ids.should contain("replay.send")              # COMMON
+    ids.should contain("replay.rename-subtab")     # :subtab
+    ids.should contain("replay.close-subtab")      # :subtab
+    ids.should_not contain("replay.insert-marker") # a DIFFERENT section (:request) — no bleed
+    menu.verb_for('e').try(&.id).should eq("replay.rename-subtab")
+    menu.verb_for('w').try(&.id).should eq("replay.close-subtab")
+  end
+
+  it "populates Replay's :response group with diff/hex alongside pretty (Round 4 — was raw key-dispatch)" do
+    ctx = FakeExecContext.new
+    ctx.current_tab = :replay
+    menu = SpaceMenu.new(Gori::Verbs.registry)
+
+    menu.open(Gori::Verb::Scope::Replay, :response, ctx)
+    ids = menu.entries.map(&.id)
+    ids.should contain("replay.send")            # COMMON
+    ids.should contain("replay.toggle-pretty")   # :response
+    ids.should contain("replay.toggle-diff")     # :response
+    ids.should contain("replay.toggle-resp-hex") # :response
+    menu.verb_for('p').try(&.id).should eq("replay.toggle-pretty")
+    menu.verb_for('d').try(&.id).should eq("replay.toggle-diff")
+    menu.verb_for('x').try(&.id).should eq("replay.toggle-resp-hex")
+  end
+
+  it "populates Fuzzer's :subtab group with rename/close (Round 4 — was raw key-dispatch)" do
+    ctx = FakeExecContext.new
+    ctx.current_tab = :fuzzer
+    menu = SpaceMenu.new(Gori::Verbs.registry)
+
+    menu.open(Gori::Verb::Scope::Fuzzer, :subtab, ctx)
+    ids = menu.entries.map(&.id)
+    ids.should contain("fuzz.run")           # COMMON
+    ids.should contain("fuzz.rename-subtab") # :subtab
+    ids.should contain("fuzz.close-subtab")  # :subtab
+    ids.should_not contain("fuzz.automark")  # a DIFFERENT section (:template) — no bleed
+    menu.verb_for('e').try(&.id).should eq("fuzz.rename-subtab")
+    menu.verb_for('w').try(&.id).should eq("fuzz.close-subtab")
+  end
+
+  it "populates Convert's :subtab group with rename (asymmetry fix — was flat COMMON, no way to rename from the strip)" do
+    ctx = FakeExecContext.new
+    ctx.current_tab = :convert
+    menu = SpaceMenu.new(Gori::Verbs.registry)
+
+    menu.open(Gori::Verb::Scope::Convert, :subtab, ctx)
+    ids = menu.entries.map(&.id)
+    ids.should contain("convert.new")           # COMMON
+    ids.should contain("convert.rename-subtab") # :subtab
+    ids.should_not contain("convert.save")      # a DIFFERENT section (:tab) — no bleed
+    ids.should_not contain("convert.mode")      # a DIFFERENT section (:output) — no bleed
+    menu.verb_for('e').try(&.id).should eq("convert.rename-subtab")
   end
 
   it "hides the scope rule edit/delete entries when no rule is selected" do
     ctx = FakeExecContext.new # scope_has_rule defaults to false
     menu = SpaceMenu.new(Gori::Verbs.registry)
-    menu.open(Gori::Verb::Scope::Project, ctx)
+    menu.open(Gori::Verb::Scope::Project, :common, ctx)
 
     ids = menu.entries.map(&.id)
     ids.should contain("scope.lens-toggle") # always available
@@ -172,7 +333,7 @@ describe Gori::Tui::SpaceMenu do
   it "no-ops (empty entries) for a scope with only hidden nav verbs" do
     ctx = FakeExecContext.new
     menu = SpaceMenu.new(Gori::Verbs.registry)
-    menu.open(Gori::Verb::Scope::Sidebar, ctx) # tab-bar nav verbs are all hidden
+    menu.open(Gori::Verb::Scope::Sidebar, :common, ctx) # tab-bar nav verbs are all hidden
     menu.entries.empty?.should be_true
   end
 
@@ -180,7 +341,7 @@ describe Gori::Tui::SpaceMenu do
     ctx = FakeExecContext.new
     ctx.selected = 5_i64
     menu = SpaceMenu.new(Gori::Verbs.registry)
-    menu.open(Gori::Verb::Scope::Body, ctx)
+    menu.open(Gori::Verb::Scope::Body, :common, ctx)
 
     backend = MemoryBackend.new(80, 24)
     menu.render(Screen.new(backend), Rect.new(0, 3, 80, 20))
@@ -192,7 +353,7 @@ describe Gori::Tui::SpaceMenu do
     ctx = FakeExecContext.new
     ctx.selected = 5_i64
     menu = SpaceMenu.new(Gori::Verbs.registry)
-    menu.open(Gori::Verb::Scope::Body, ctx)
+    menu.open(Gori::Verb::Scope::Body, :common, ctx)
     menu.entries.size.should be > 4 # Body has ~10 entries
 
     last = menu.entries.last.title
@@ -214,7 +375,7 @@ describe Gori::Tui::SpaceMenu do
         "demo.#{i}", "Item #{i}", "x", Gori::Verb::Scope::Body, mnemonic: ('a'.ord + i).unsafe_chr) { |_| nil })
     end
     menu = SpaceMenu.new(reg)
-    menu.open(Gori::Verb::Scope::Body, FakeExecContext.new)
+    menu.open(Gori::Verb::Scope::Body, :common, FakeExecContext.new)
     menu.entries.size.should eq(15)
 
     b = menu.box(Rect.new(0, 0, 60, 40)) # tall body — height is entry-bound, not body-bound
@@ -227,11 +388,37 @@ describe Gori::Tui::SpaceMenu do
     backend.contains?("▼").should be_false      # so no scroll marker
   end
 
+  it "still draws the scroll marker when the boundary viewport row lands on a group header" do
+    reg = Gori::Verb::Registry.new
+    2.times do |i|
+      reg.register(Gori::Verb::Definition.new(
+        "demo.common.#{i}", "Common #{i}", "x", Gori::Verb::Scope::Body,
+        mnemonic: ('a'.ord + i).unsafe_chr) { |_| nil }) # default section: :common
+    end
+    5.times do |i|
+      reg.register(Gori::Verb::Definition.new(
+        "demo.section.#{i}", "Section #{i}", "x", Gori::Verb::Scope::Body,
+        mnemonic: ('k'.ord + i).unsafe_chr, section: :demo) { |_| nil })
+    end
+    menu = SpaceMenu.new(reg)
+    menu.open(Gori::Verb::Scope::Body, :demo, FakeExecContext.new)
+
+    # display_rows: [header COMMON, Common 0, Common 1, header DEMO, Section 0..4]
+    # (9 rows). A 6-row body clamps the box to h=6 → viewport=4, so the visible
+    # window is rows 0..3 — row 3 (the LAST visible row) is the DEMO header, and
+    # "more below" is true (5 more rows past it). The ▼ affordance must still show
+    # there — it was previously swallowed by the header branch's early `next`.
+    backend = MemoryBackend.new(40, 8)
+    menu.render(Screen.new(backend), Rect.new(0, 0, 40, 6))
+    backend.contains?("─ DEMO ─").should be_true # confirms the header IS at that row
+    backend.contains?("▼").should be_true
+  end
+
   it "draws a ▼ scroll marker when entries are hidden below (short terminal)" do
     ctx = FakeExecContext.new
     ctx.selected = 5_i64
     menu = SpaceMenu.new(Gori::Verbs.registry)
-    menu.open(Gori::Verb::Scope::Body, ctx) # selection at the top → list clipped at the bottom
+    menu.open(Gori::Verb::Scope::Body, :common, ctx) # selection at the top → list clipped at the bottom
 
     backend = MemoryBackend.new(40, 8)
     menu.render(Screen.new(backend), Rect.new(0, 0, 40, 6)) # ~4 rows fit, 13 entries
@@ -239,13 +426,20 @@ describe Gori::Tui::SpaceMenu do
     backend.contains?("▲").should be_false                  # nothing hidden above at the top
   end
 
-  # Per menu scope, the keyed entries must never collide, and any verb with NO chord
-  # at all must carry a mnemonic (else it's unreachable by ANY single key — the
-  # oversight this guards). A verb whose only chord is ctrl/shift (e.g. Replay's
-  # ^X/^S/^L toggles, rebindable since the hotkeys feature) legitimately has no
-  # single-key handle and is just excluded from the menu. Reads the registry
-  # directly to bypass the ctx-gated available?, so coverage is exhaustive.
-  it "gives every chordless menu verb a mnemonic, and never collides keys within a scope" do
+  # Per menu scope, any verb with NO chord at all must carry a mnemonic (else it's
+  # unreachable by ANY single key — the oversight this guards). A verb whose only
+  # chord is ctrl/shift (e.g. Replay's ^X/^S/^L toggles, rebindable since the
+  # hotkeys feature) legitimately has no single-key handle and is just excluded
+  # from the menu. Reads the registry directly to bypass the ctx-gated available?,
+  # so coverage is exhaustive.
+  #
+  # Key collisions are checked PER DISPLAYABLE VIEW (COMMON ∪ one section) rather
+  # than scope-wide: sections never render together (SpaceMenu#open shows at most
+  # COMMON + one context group), so two DIFFERENT sections may legitimately reuse a
+  # key (e.g. Replay's :target 's' and :tab 's') — only a clash WITHIN a view is a
+  # real collision. Mirrors Registry#validate_menu_keys! (registry.cr) as an
+  # independent spec-level check.
+  it "gives every chordless menu verb a mnemonic, and never collides keys within a displayable view (COMMON ∪ one section)" do
     registry = Gori::Verbs.registry
     menu_scopes = [
       Gori::Verb::Scope::Body, Gori::Verb::Scope::Replay, Gori::Verb::Scope::Findings,
@@ -255,11 +449,18 @@ describe Gori::Tui::SpaceMenu do
       Gori::Verb::Scope::Sitemap,
       Gori::Verb::Scope::Miner, Gori::Verb::Scope::Prism, Gori::Verb::Scope::PrismDetail,
     ]
+    no_collision = ->(view : Array(Gori::Verb::Definition)) {
+      keys = view.compact_map(&.menu_key)
+      keys.uniq.size.should eq(keys.size) # no two entries in this view collide on one key
+    }
     menu_scopes.each do |scope|
       verbs = registry.select { |v| v.scope == scope && !v.hidden? }
       verbs.select(&.chords.empty?).all?(&.menu_key).should be_true # chordless ⇒ keyed
-      keys = verbs.compact_map(&.menu_key)
-      keys.uniq.size.should eq(keys.size) # no two entries collide on one key
+
+      common = verbs.select { |v| v.section == :common }
+      no_collision.call(common)
+      sections = verbs.map(&.section).uniq.reject { |s| s == :common }
+      sections.each { |section| no_collision.call(common + verbs.select { |v| v.section == section }) }
     end
   end
 

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -140,6 +140,14 @@ private class FakeContext < ExecContext
     0
   end
 
+  def replay_rename_subtab : Nil
+    @calls << :replay_rename_subtab
+  end
+
+  def replay_close_subtab : Nil
+    @calls << :replay_close_subtab
+  end
+
   def replay_toggle_hex : Nil
     @calls << :replay_toggle_hex
   end
@@ -154,6 +162,14 @@ private class FakeContext < ExecContext
 
   def replay_toggle_auto_content_length : Nil
     @calls << :replay_toggle_auto_content_length
+  end
+
+  def replay_toggle_resp_diff : Nil
+    @calls << :replay_toggle_resp_diff
+  end
+
+  def replay_toggle_resp_hex : Nil
+    @calls << :replay_toggle_resp_hex
   end
 
   def replay_toggle_mark_transform : Nil
@@ -234,6 +250,14 @@ private class FakeContext < ExecContext
 
   def fuzz_clear_marks : Nil
     @calls << :fuzz_clear_marks
+  end
+
+  def fuzzer_rename_subtab : Nil
+    @calls << :fuzzer_rename_subtab
+  end
+
+  def fuzzer_close_subtab : Nil
+    @calls << :fuzzer_close_subtab
   end
 
   def fuzzer_copy : Nil
@@ -600,6 +624,10 @@ private class FakeContext < ExecContext
     @calls << :convert_close
   end
 
+  def convert_rename_subtab : Nil
+    @calls << :convert_rename_subtab
+  end
+
   def convert_clear : Nil
     @calls << :convert_clear
   end
@@ -610,6 +638,10 @@ private class FakeContext < ExecContext
 
   def convert_copy_selection : Nil
     @calls << :convert_copy_selection
+  end
+
+  def convert_copy_all : Nil
+    @calls << :convert_copy_all
   end
 
   def convert_read_mode? : Bool
@@ -690,6 +722,10 @@ private class FakeContext < ExecContext
 
   def read_clear_selection : Nil
     @calls << :read_clear_selection
+  end
+
+  def read_copy : Nil
+    @calls << :read_copy
   end
 
   def detail_navigable? : Bool
@@ -847,6 +883,28 @@ describe Gori::Verb do
       ctx.calls.should contain(:replay_toggle_decoded)
       ctx.calls.should contain(:replay_toggle_sni)
       ctx.calls.should contain(:replay_toggle_auto_content_length)
+    end
+
+    it "routes the Round-4 Replay :subtab/:response verbs through the matching ExecContext methods" do
+      reg = Gori::Verbs.registry
+      ctx = FakeContext.new
+      reg["replay.rename-subtab"].call(ctx)
+      reg["replay.close-subtab"].call(ctx)
+      reg["replay.toggle-diff"].call(ctx)
+      reg["replay.toggle-resp-hex"].call(ctx)
+      ctx.calls.should contain(:replay_rename_subtab)
+      ctx.calls.should contain(:replay_close_subtab)
+      ctx.calls.should contain(:replay_toggle_resp_diff)
+      ctx.calls.should contain(:replay_toggle_resp_hex)
+    end
+
+    it "routes the Round-4 Fuzzer :subtab verbs through the matching ExecContext methods" do
+      reg = Gori::Verbs.registry
+      ctx = FakeContext.new
+      reg["fuzz.rename-subtab"].call(ctx)
+      reg["fuzz.close-subtab"].call(ctx)
+      ctx.calls.should contain(:fuzzer_rename_subtab)
+      ctx.calls.should contain(:fuzzer_close_subtab)
     end
 
     it "routes the palette-only Refresh screen verb (no chord) to refresh_screen" do

--- a/src/gori/tui/controllers/convert_controller.cr
+++ b/src/gori/tui/controllers/convert_controller.cr
@@ -69,6 +69,11 @@ module Gori::Tui
       Verb::Scope::Convert
     end
 
+    # The space menu's CONTEXT section: the current session's focused pane.
+    def command_section : Symbol
+      cur.pane
+    end
+
     # INPUT INS or CHAIN editing → EDITOR; INPUT READ and OUTPUT are navigable.
     def body_badge : Symbol
       s = cur
@@ -219,7 +224,7 @@ module Gori::Tui
           s.input_read.sync_from(s.input)
         else
           commit
-          @host.request_focus(:menu)
+          @host.request_focus(:subtabs)
         end
       else
         case cur.pane
@@ -259,8 +264,8 @@ module Gori::Tui
       if regions.input.contains?(mx, my)
         s.pane = :input
         @popup.close
-        s.input_mode = InputMode::Insert
         s.input.click_to_cursor(regions.input.inset(1, 1), mx, my)
+        s.input_read.sync_from(s.input) unless s.input_mode == InputMode::Insert
       elsif regions.chain.contains?(mx, my)
         s.pane = :chain
         field = regions.chain.inset(1, 1)
@@ -287,9 +292,9 @@ module Gori::Tui
     def set_preedit(text : String) : Bool
       s = cur
       case s.pane
-      when :input  then s.input.set_preedit(text) if s.input_mode == InputMode::Insert
-      when :chain  then @chain_pre = text
-      else              nil
+      when :input then s.input.set_preedit(text) if s.input_mode == InputMode::Insert
+      when :chain then @chain_pre = text
+      else             nil
       end
       true
     end
@@ -396,6 +401,27 @@ module Gori::Tui
       end
     end
 
+    # The no-selection fallback for the space-menu/palette "Copy" verb (convert.copy):
+    # routes on the FOCUSED pane like convert_copy_selection, but copies the WHOLE pane
+    # content rather than always OUTPUT (that was the bug — copy_output ignored focus
+    # entirely). Mirrors Replay/Fuzzer's pane_copy_all_text pattern.
+    def convert_copy_all : Nil
+      s = cur
+      text = case s.pane
+             when :output then s.view.output_copy(s.result)
+             when :input  then s.input_read.copy_all(s.input)
+             else              s.chain
+             end
+      if text.empty?
+        @host.status("nothing to copy")
+      else
+        written = Clipboard.copy(text)
+        msg = "copied all (#{written}b)"
+        msg += " — clipped from #{text.bytesize}b (64KB cap)" if written < text.bytesize
+        @host.status(msg)
+      end
+    end
+
     def convert_read_mode? : Bool
       s = cur
       s.pane == :output || (s.pane == :input && s.input_mode == InputMode::Read)
@@ -406,7 +432,7 @@ module Gori::Tui
       case s.pane
       when :input  then s.input_mode == InputMode::Read && s.input_read.selection?
       when :output then s.view.output_selection?
-      else             false
+      else              false
       end
     end
 
@@ -547,8 +573,8 @@ module Gori::Tui
       when key.up?, key.lower_k?
         s.view.output_at_top? ? (s.pane = :chain) : out_nav_step(s, -1, 0, selecting)
       when key.down?, key.lower_j? then out_nav_step(s, 1, 0, selecting)
-      when key.left?  then out_nav_step(s, 0, -1, selecting)
-      when key.right? then out_nav_step(s, 0, 1, selecting)
+      when key.left?               then out_nav_step(s, 0, -1, selecting)
+      when key.right?              then out_nav_step(s, 0, 1, selecting)
       when (c = ev.char || key.to_char) == 'x'
         s.view.output_select_line(s.result)
       when c == 'y'

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -41,6 +41,12 @@ module Gori::Tui
       Verb::Scope::Fuzzer
     end
 
+    # The space menu's CONTEXT section: whichever pane the active session is focused
+    # on (:target/:template/:config/:results/:detail). :common with no session open.
+    def command_section : Symbol
+      current_view.try(&.focus) || :common
+    end
+
     # --- shell-facing accessors ---
     def count : Int32
       @fuzzers.size
@@ -189,7 +195,7 @@ module Gori::Tui
       elsif v.focus == :detail
         v.focus_pane(:results)
       else
-        @host.request_focus(:menu)
+        @host.request_focus(:subtabs)
       end
     end
 
@@ -357,7 +363,12 @@ module Gori::Tui
     end
 
     # The CONFIG summary is a calm single-axis row list — no text entry (that drills into
-    # the Set / Advanced overlays), so ←/→ can only cycle Mode and typing is inert.
+    # the Set / Advanced overlays). TEMPLATE sits directly to CONFIG's left, so LEFT
+    # focuses it (mirrors Shift-Tab) rather than adjusting a row — RIGHT still cycles
+    # Mode forward, and Enter (activate_config_row) reaches every row's editor,
+    # including a forward-only re-cycle of Mode (cycle_mode_forward): with only 4
+    # modes, forward-only cycling still reaches every value, it just costs up to 3
+    # extra presses instead of a reverse step.
     private def edit_config(ev : Termisu::Event::Key, v : FuzzerView) : Nil
       key = ev.key
       case
@@ -365,7 +376,7 @@ module Gori::Tui
       # the Miner summary) — without this, `k` off the RESULTS top dead-ends in CONFIG.
       when key.up?, key.lower_k?       then config_up(v)
       when key.down?, key.lower_j?     then v.form_move(1)
-      when key.left?                   then v.form_adjust(-1)
+      when key.left?                   then v.focus_pane(:template)
       when key.right?                  then v.form_adjust(1)
       when key.enter?                  then activate_config_row(v)
       when key.delete?, key.backspace? then v.form_delete
@@ -441,10 +452,8 @@ module Gori::Tui
         v.focus_pane(pane)
         case pane
         when :template
-          v.enter_template_insert! unless v.template_insert?
           v.template_click_to_cursor(body, mx, my)
         when :target
-          v.enter_target_insert! unless v.target_insert?
           v.target_click_to_cursor(body, mx, my)
         end
       end

--- a/src/gori/tui/controllers/notes_controller.cr
+++ b/src/gori/tui/controllers/notes_controller.cr
@@ -82,7 +82,7 @@ module Gori::Tui
           @notes.exit_insert!
         else
           save_notes
-          @host.request_focus(:menu)
+          @host.request_focus(:subtabs)
         end
       elsif @notes.insert_mode?
         edit_insert(ev, c)

--- a/src/gori/tui/controllers/replay_controller.cr
+++ b/src/gori/tui/controllers/replay_controller.cr
@@ -63,6 +63,12 @@ module Gori::Tui
       Verb::Scope::Replay
     end
 
+    # The space menu's CONTEXT section: whichever pane the active session's editor
+    # is focused on. :common when no session is open (empty state).
+    def command_section : Symbol
+      current_view.try(&.focus) || :common
+    end
+
     # --- shell-facing accessors (strip machinery + orthogonal prompts read these) ---
     def count : Int32
       @replays.size
@@ -241,7 +247,7 @@ module Gori::Tui
         elsif (view = current_view) && view.focus == :target && view.target_insert?
           view.exit_target_insert!
         else
-          @host.request_focus(:menu)
+          @host.request_focus(:subtabs)
         end
       elsif ev.ctrl? || ev.alt?
         # Any OTHER modified chord (^R send, ^X hex, ^S SNI, ^L auto-CL, …) defers to the
@@ -427,10 +433,8 @@ module Gori::Tui
         @host.focus_body
         case pane
         when :request
-          v.enter_request_insert! unless v.request_insert?
           v.request_click_to_cursor(body, mx, my)
         when :target
-          v.enter_target_insert! unless v.target_insert?
           v.target_click_to_cursor(body, mx, my)
         when :response
           v.resp_click_to_cursor(body, mx, my)

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -2455,6 +2455,30 @@ module Gori::Tui
       end
     end
 
+    # The (scope, section) the space menu renders for, captured at the space
+    # keystroke. Deliberately DISTINCT from current_scope (the keymap's resolver,
+    # unchanged above) — the tab bar keeps Sidebar for keybindings (so Replay's
+    # chords don't fire while navigating tabs) but the space menu on the tab bar
+    # should show that TAB's own top actions instead. By the time this is read,
+    # @overlay is always :none or :detail — every other overlay handles its own
+    # keys earlier in handle_key and returns before space is ever checked.
+    private def space_menu_context : {Verb::Scope, Symbol}
+      if @overlay == :detail
+        {Verb::Scope::HistoryDetail, :common}
+      else
+        scope = @tabs[@active_tab]?.try(&.command_scope) || Verb::Scope::Body
+        case @focus
+        when :menu
+          section = @session.registry.has_section?(scope, :tab) ? :tab : :common
+          {scope, section}
+        when :subtabs
+          {scope, :subtab}
+        else
+          {scope, @tabs[@active_tab]?.try(&.command_section) || :common}
+        end
+      end
+    end
+
     private def format_status_message(message : String?) : String?
       return nil unless message
       if message.starts_with?("replaying →") || message.starts_with?("ws replay →") ||
@@ -2830,7 +2854,8 @@ module Gori::Tui
     # scope reflects where space was pressed — the History list → Body, an open
     # detail → HistoryDetail, the Replay response → Replay, the tab bar → Sidebar.
     def open_space_menu : Nil
-      @space_menu.open(current_scope, self) # captures the scope + populates entries
+      scope, section = space_menu_context
+      @space_menu.open(scope, section, self) # captures the scope+section + populates entries
       # Don't open an empty popup: some focus areas (the tab bar, an open detail)
       # have only hidden nav verbs, so the entry list is empty. Opening there would
       # trap input behind an empty box — keep space a no-op (with a hint) instead.
@@ -3686,6 +3711,16 @@ module Gori::Tui
       replay_controller.count
     end
 
+    # Space-menu (:subtab) counterparts of the strip's `r` rename chord / ^W close —
+    # reuse the SAME shell-owned rename prompt / confirm-gated close, not a new path.
+    def replay_rename_subtab : Nil
+      open_rename(current_subtab_index)
+    end
+
+    def replay_close_subtab : Nil
+      replay_controller.request_close
+    end
+
     def replay_toggle_hex : Nil
       replay_controller.replay_toggle_hex
     end
@@ -3700,6 +3735,16 @@ module Gori::Tui
 
     def replay_toggle_auto_content_length : Nil
       replay_controller.replay_toggle_auto_content_length
+    end
+
+    # Space-menu (:response) counterparts of the response pane's raw `d`/`x` keys —
+    # same ReplayView toggles, just reachable without memorizing the key.
+    def replay_toggle_resp_diff : Nil
+      replay_controller.current_view.try(&.toggle_resp_mode)
+    end
+
+    def replay_toggle_resp_hex : Nil
+      replay_controller.current_view.try(&.toggle_resp_hex)
     end
 
     def replay_toggle_mark_transform : Nil
@@ -3795,6 +3840,16 @@ module Gori::Tui
 
     def fuzz_clear_marks : Nil
       fuzzer_controller.fuzz_clear_marks
+    end
+
+    # Space-menu (:subtab) counterparts of the strip's `r` rename chord / ^W close —
+    # reuse the SAME shell-owned rename prompt / confirm-gated close, not a new path.
+    def fuzzer_rename_subtab : Nil
+      open_rename(current_subtab_index)
+    end
+
+    def fuzzer_close_subtab : Nil
+      fuzzer_controller.request_close
     end
 
     def fuzzer_copy : Nil
@@ -4021,6 +4076,13 @@ module Gori::Tui
       resolve_subtab_focus_after_close # don't strand on a now-hidden strip
     end
 
+    # Space-menu (:subtab) counterpart of the strip's `r` rename chord — reuses the
+    # SAME shell-owned rename prompt as Replay/Fuzzer (open_rename already handles
+    # Convert generically via view_at).
+    def convert_rename_subtab : Nil
+      open_rename(current_subtab_index)
+    end
+
     def convert_clear : Nil
       convert_controller.clear_all
     end
@@ -4031,6 +4093,10 @@ module Gori::Tui
 
     def convert_copy_selection : Nil
       convert_controller.convert_copy_selection
+    end
+
+    def convert_copy_all : Nil
+      convert_controller.convert_copy_all
     end
 
     def convert_read_mode? : Bool
@@ -4086,23 +4152,30 @@ module Gori::Tui
       project_controller.project_copy_all
     end
 
+    # The unified Copy verbs whose base title is now plain "Copy" (routed through
+    # read_copy — selection if active, else the whole focused pane; copy-all is
+    # gone). detail.copy is DELIBERATELY excluded: History detail has no whole-pane
+    # alternative (read_copy's :history branch always falls back to
+    # detail_copy_selection), so its title stays the static "Copy selection" —
+    # flipping it here would be a no-op at best and misleading at worst (no
+    # selection ⇒ it still only copies the current line, not "the whole pane").
     READ_COPY_VERBS = %w(
-      notes.copy replay.copy convert.copy finding.copy project.copy detail.copy fuzzer.copy
+      notes.copy replay.copy convert.copy finding.copy project.copy fuzzer.copy
     )
 
     def space_menu_title(verb_id : String) : String?
-      return "Copy selected" if READ_COPY_VERBS.includes?(verb_id) && read_selection_active?
+      return "Copy selection" if READ_COPY_VERBS.includes?(verb_id) && read_selection_active?
       nil
     end
 
     def read_selection_active? : Bool
       case @active_tab
       when :notes    then notes_controller.view.selection?
-      when :replay    then replay_controller.replay_selection_active?
-      when :fuzzer    then fuzzer_controller.fuzzer_selection_active?
-      when :convert   then convert_controller.convert_selection_active?
-      when :findings  then findings_controller.findings_notes_selection_active?
-      when :project   then project_controller.project_desc_selection_active?
+      when :replay   then replay_controller.replay_selection_active?
+      when :fuzzer   then fuzzer_controller.fuzzer_selection_active?
+      when :convert  then convert_controller.convert_selection_active?
+      when :findings then findings_controller.findings_notes_selection_active?
+      when :project  then project_controller.project_desc_selection_active?
       when :history
         @overlay == :detail && history_controller.detail_selection_active?
       else
@@ -4113,11 +4186,11 @@ module Gori::Tui
     def read_select_line : Nil
       case @active_tab
       when :notes    then notes_controller.view.select_line
-      when :replay    then replay_controller.replay_select_line
-      when :fuzzer    then fuzzer_controller.fuzzer_select_line
-      when :convert   then convert_controller.convert_select_line
-      when :findings  then findings_controller.findings_notes_select_line
-      when :project   then project_controller.project_desc_select_line
+      when :replay   then replay_controller.replay_select_line
+      when :fuzzer   then fuzzer_controller.fuzzer_select_line
+      when :convert  then convert_controller.convert_select_line
+      when :findings then findings_controller.findings_notes_select_line
+      when :project  then project_controller.project_desc_select_line
       when :history
         history_controller.detail_select_line if @overlay == :detail
       end
@@ -4126,13 +4199,32 @@ module Gori::Tui
     def read_clear_selection : Nil
       case @active_tab
       when :notes    then notes_controller.view.clear_selection
-      when :replay    then replay_controller.replay_clear_selection
-      when :fuzzer    then fuzzer_controller.fuzzer_clear_selection
-      when :convert   then convert_controller.convert_clear_selection
-      when :findings  then findings_controller.findings_notes_clear_selection
-      when :project   then project_controller.project_desc_clear_selection
+      when :replay   then replay_controller.replay_clear_selection
+      when :fuzzer   then fuzzer_controller.fuzzer_clear_selection
+      when :convert  then convert_controller.convert_clear_selection
+      when :findings then findings_controller.findings_notes_clear_selection
+      when :project  then project_controller.project_desc_clear_selection
       when :history
         history_controller.detail_clear_selection if @overlay == :detail
+      end
+    end
+
+    # The unified "Copy" fallback: selection if one is active, else the whole
+    # focused pane. Mirrors read_selection_active?'s per-@active_tab dispatch and
+    # reuses the existing copy delegators — no new copy logic. Wired to each tab's
+    # `*.copy` verb (verbs/*.cr) — the *.copy-all verbs are gone.
+    def read_copy : Nil
+      case @active_tab
+      when :notes    then read_selection_active? ? notes_copy : notes_copy_all
+      when :replay   then read_selection_active? ? replay_copy : replay_copy_all
+      when :fuzzer   then read_selection_active? ? fuzzer_copy : fuzzer_copy_all
+      when :convert  then read_selection_active? ? convert_copy_selection : convert_copy_all
+      when :findings then read_selection_active? ? findings_copy : findings_copy_all
+      when :project  then read_selection_active? ? project_copy : project_copy_all
+      when :history
+        # No whole-rendered-pane delegator exists for the detail text pane — both
+        # branches fall back to the selection-or-current-line copy.
+        detail_copy_selection if @overlay == :detail
       end
     end
 

--- a/src/gori/tui/space_menu.cr
+++ b/src/gori/tui/space_menu.cr
@@ -6,16 +6,23 @@ require "../verb"
 module Gori::Tui
   # The "space" action menu — a helix-style leader popup anchored at the
   # BOTTOM-RIGHT of the body. Pressing space in a navigable area opens it; it
-  # lists that area's own verbs (the Verb::Scope captured at open), each fronted
-  # by a single mnemonic key. Pressing the key runs the verb through the SAME
-  # Verb::Definition#call path as a keybinding and the palette (P1 — no separate
-  # execution path).
+  # lists that area's own verbs (the Verb::Scope + Verb::Section captured at
+  # open), each fronted by a single mnemonic key. Pressing the key runs the verb
+  # through the SAME Verb::Definition#call path as a keybinding and the palette
+  # (P1 — no separate execution path).
   #
   # Where Ctrl-P's PaletteState is a centered fuzzy-typed modal of every Global
   # verb, the space menu is mnemonic-only (no text input, no fuzzy filter): the
-  # shown set is exactly `for_scope` narrowed to verbs that have a `menu_key`.
-  # Pure input/state + rendering; the Runner owns opening/closing, capturing the
-  # scope, and executing the selection.
+  # shown set is exactly `for_scope` narrowed to verbs that have a `menu_key`,
+  # then split into a COMMON group (tab-wide) and a CONTEXT group (the focused
+  # section — a body pane, the tab bar, or the sub-tab strip). Render is ALWAYS a
+  # narrow single-column list — one entry per row, growing tall rather than wide
+  # — with a dim section-header row between groups. When there's only ONE group
+  # to show (section == :common, or nothing tags the focused section yet, i.e.
+  # single-region tabs like History/Sitemap/Notes/…), the header is OMITTED
+  # entirely: a flat list, pixel-identical to the pre-grouping menu. Pure
+  # input/state + rendering; the Runner owns opening/closing, capturing the
+  # scope+section, and executing the selection.
   class SpaceMenu
     # Tallest popup before it scrolls. Sized to clear the busiest scope (History's
     # Body has 13 menu entries) with headroom, so the common case never scrolls; when
@@ -24,30 +31,90 @@ module Gori::Tui
     # "don't grow past this even on a tall terminal" ceiling.
     MAX_ROWS = 16
 
+    # Fixed per-row chrome around the title in the narrow single-column layout:
+    # left border(1) + selection indicator(1) + mnemonic key(1) + gap(1) + scroll-
+    # marker column(1) + right border(1) = 6. Box width is exactly the widest
+    # entry title plus this — never widened to pack columns (Round 5: classic
+    # narrow single-column look, not the old row-packed layout).
+    CHROME = 6
+
+    SECTION_LABELS = {
+      :common => "COMMON", :request => "REQUEST", :response => "RESPONSE", :target => "TARGET",
+      :template => "TEMPLATE", :config => "CONFIG", :results => "RESULTS", :detail => "DETAIL",
+      :input => "INPUT", :chain => "CHAIN", :output => "OUTPUT", :tab => "TAB", :subtab => "SUBTAB",
+    } of Symbol => String
+
     getter selected : Int32
+
+    # One group of entries within the popup: `start`/`count` index into the flat
+    # @entries array (contiguous per group, in open()'s build order).
+    private record Group, label : String, start : Int32, count : Int32
+
+    # One drawable row: either a dim section header (`label` set, `entry` nil) or
+    # a single entry row (`entry` set to its index in @entries). Always exactly
+    # one entry per row — no packing.
+    private record DisplayRow, label : String?, entry : Int32?
 
     def initialize(@registry : Verb::Registry)
       @entries = [] of Verb::Definition
       @selected = 0
-      @scroll = 0  # top visible row — keeps the selection on-screen on short terminals
+      @scroll = 0  # top visible row (display-row space) — keeps the selection on-screen
       @title_w = 0 # widest entry title, cached at open() (drives the popup width)
+      # Empty ⇒ single flat column, no headers (today's exact pre-grouping layout).
+      # ≥2 entries ⇒ a COMMON + CONTEXT grouped render with a header per group.
+      @groups = [] of Group
+      @section_label = "" # context label appended to the card title ("SPACE · RESPONSE")
     end
 
-    # The verbs shown: scope-local, non-hidden, available AND carrying a menu_key.
+    # The verbs shown: scope-local, non-hidden, available AND carrying a menu_key —
+    # flattened in group order (COMMON first, then CONTEXT) when grouped.
     def entries : Array(Verb::Definition)
       @entries
     end
 
     @ctx = nil.as(Verb::ExecContext?)
 
-    # Open scoped to `scope` (captured by the Runner at the space keystroke, before
-    # the overlay/focus state can change). Seeds the entry list.
-    def open(scope : Verb::Scope, ctx : Verb::ExecContext) : Nil
+    # Open scoped to `scope`+`section` (captured by the Runner at the space
+    # keystroke, before the overlay/focus state can change). Seeds the entry list
+    # and the group split.
+    def open(scope : Verb::Scope, section : Symbol, ctx : Verb::ExecContext) : Nil
       @ctx = ctx
       @selected = 0
       @scroll = 0
-      @entries = @registry.for_scope(scope, ctx).select(&.menu_key)
-      @title_w = @entries.empty? ? 0 : @entries.max_of { |v| menu_title(v, ctx).size }
+      all = @registry.for_scope(scope, ctx).select(&.menu_key)
+      common = all.select { |v| v.section == :common }
+      context = section == :common ? [] of Verb::Definition : all.select { |v| v.section == section }
+
+      # Only NON-EMPTY sections become a group — an empty COMMON (never happens in
+      # practice, but defensive) or an empty CONTEXT (the common case for
+      # single-region tabs, or a section nothing is tagged for yet) simply drops out
+      # rather than rendering a header with nothing under it.
+      groups = [] of {String, Array(Verb::Definition)}
+      groups << {SECTION_LABELS[:common], common} unless common.empty?
+      label = SECTION_LABELS[section]? || section.to_s.upcase
+      groups << {label, context} unless context.empty?
+
+      if groups.size <= 1
+        # Nothing to distinguish — one flat column, no headers.
+        @entries = groups.empty? ? ([] of Verb::Definition) : groups[0][1]
+        @groups = [] of Group
+        @section_label = ""
+      else
+        @entries = groups.flat_map(&.[1])
+        idx = 0
+        @groups = groups.map do |(glabel, verbs)|
+          g = Group.new(glabel, idx, verbs.size)
+          idx += verbs.size
+          g
+        end
+        @section_label = label
+      end
+      # Widest of the entry titles AND the group headers ("─ LABEL ─", 4 chars of
+      # chrome around the label) — a grouped view with a long section label (e.g.
+      # SECTION_LABELS additions) must still fit inside the box the entries sized.
+      entry_w = @entries.empty? ? 0 : @entries.max_of { |v| menu_title(v, ctx).size }
+      header_w = @groups.empty? ? 0 : @groups.max_of { |g| g.label.size + 4 }
+      @title_w = {entry_w, header_w}.max
     end
 
     private def menu_title(v : Verb::Definition, ctx : Verb::ExecContext) : String
@@ -73,13 +140,28 @@ module Gori::Tui
       @selected = idx.clamp(0, {@entries.size - 1, 0}.max)
     end
 
-    # The popup box: bottom-right of `body`, sized to the entries. Each row is
-    # "│ k  Title │" (indicator+key+gap eat 4 interior cols, +2 for the frame).
-    # Empty Rect when there's nothing to show or it can't fit.
+    # The full row list this frame: a dim header row per group (only when ≥2
+    # groups — see #open) interleaved with exactly one row per entry, in
+    # @entries order. Rebuilt on demand (cheap — a handful of rows) so
+    # box()/render()/row_at() always agree on the exact same layout.
+    private def display_rows : Array(DisplayRow)
+      return @entries.each_index.map { |i| DisplayRow.new(nil, i) }.to_a if @groups.empty?
+      rows = [] of DisplayRow
+      @groups.each do |g|
+        rows << DisplayRow.new(g.label, nil)
+        (g.start...(g.start + g.count)).each { |i| rows << DisplayRow.new(nil, i) }
+      end
+      rows
+    end
+
+    # The popup box: narrow, bottom-right of `body`, exactly as wide as the widest
+    # title needs (+ CHROME) and as tall as the row list needs (+ frame, capped at
+    # MAX_ROWS). Empty Rect when there's nothing to show or it can't fit.
     def box(body : Rect) : Rect
       return Rect.new(0, 0, 0, 0) if @entries.empty?
-      rows = {@entries.size, MAX_ROWS}.min
-      w = {@title_w + 6, body.w - 2}.min
+      total_rows = display_rows.size
+      rows = {total_rows, MAX_ROWS}.min
+      w = {@title_w + CHROME, body.w - 2}.min
       h = {rows + 2, body.h}.min
       return Rect.new(0, 0, 0, 0) if w < 10 || h < 3
       x = body.right - w - 1 # one-col gutter inside the body's right edge
@@ -87,33 +169,51 @@ module Gori::Tui
       Rect.new(x, y, w, h)
     end
 
-    # Draws the popup card with "‹key›  Title" rows; the selected row gets the
-    # accent band + a ▎ indicator (matches the palette / ":" row style).
+    # Draws the popup card — one "‹key›  Title" row at a time, with a dim
+    # "─ LABEL ─" row between groups (omitted entirely for a single group). The
+    # selected row gets the accent band + a ▎ indicator (matches the palette / ":"
+    # row style).
     def render(screen : Screen, body : Rect) : Nil
       b = box(body)
       return if b.empty?
-      Frame.card(screen, b, "SPACE", border: Theme.border_focus)
-      rows = b.h - 2
-      ensure_visible(rows)
-      visible = {rows, @entries.size - @scroll}.min # rows actually drawn this frame
-      (0...rows).each do |i|
-        idx = @scroll + i
-        break if idx >= @entries.size
-        v = @entries[idx]
+      title = @section_label.empty? ? "SPACE" : "SPACE · #{@section_label}"
+      Frame.card(screen, b, title, border: Theme.border_focus)
+
+      rows = display_rows
+      viewport = b.h - 2
+      ensure_visible(rows, viewport)
+      visible = {viewport, rows.size - @scroll}.min
+      (0...viewport).each do |i|
+        ridx = @scroll + i
+        break if ridx >= rows.size
+        row = rows[ridx]
         ry = b.y + 1 + i
-        active = idx == @selected
+        # A header row is never "active" (row.entry is nil, never equal to @selected),
+        # so this covers both rows uniformly.
+        active = row.entry == @selected
         bg = active ? Theme.accent_bg : Theme.panel
         screen.fill(Rect.new(b.x + 1, ry, b.w - 2, 1), bg)
+        # Draw the scroll affordance BEFORE the header early-return: the boundary
+        # viewport row can land on a header, and the ▲/▼/↕ marker must still show
+        # (it was previously swallowed whenever that happened).
+        if mark = scroll_marker(i, visible, viewport, rows.size)
+          screen.cell(b.right - 2, ry, mark, Theme.muted, bg)
+        end
+        if label = row.label
+          # Clamp to the box interior (mirrors the entry row's width: below) so a long
+          # header can never paint past the right border / scroll-marker column.
+          screen.text(b.x + 2, ry, "─ #{label} ─", Theme.muted, bg, width: {b.w - 4, 0}.max)
+          next
+        end
+        idx = row.entry.not_nil!
+        v = @entries[idx]
         screen.cell(b.x + 1, ry, active ? '▎' : ' ', Theme.accent, bg)
         screen.text(b.x + 2, ry, v.menu_key.to_s, Theme.accent, bg, Attribute::Bold)
         title_fg = active ? Theme.text_bright : Theme.text
-        # Reserve the rightmost interior col for the scroll marker (below) so a
+        # Reserve the rightmost interior col for the scroll marker (above) so a
         # widest-title row can't paint over it.
-        title = @ctx.try { |c| menu_title(v, c) } || v.title
-        screen.text(b.x + 4, ry, title, title_fg, bg, width: {b.w - 6, 0}.max)
-        if mark = scroll_marker(i, visible, rows)
-          screen.cell(b.right - 2, ry, mark, Theme.muted, bg)
-        end
+        title_text = @ctx.try { |c| menu_title(v, c) } || v.title
+        screen.text(b.x + 4, ry, title_text, title_fg, bg, width: {b.w - 6, 0}.max)
       end
     end
 
@@ -121,9 +221,9 @@ module Gori::Tui
     # above, ▼ on the bottom row when hidden below, ↕ when a 1-row viewport hides
     # both — so it's obvious the popup scrolls (nil = list fully shown, no marker).
     # Mirrors settings_view's marker convention.
-    private def scroll_marker(i : Int32, visible : Int32, rows : Int32) : Char?
+    private def scroll_marker(i : Int32, visible : Int32, rows : Int32, total : Int32) : Char?
       above = @scroll > 0
-      below = @scroll + rows < @entries.size
+      below = @scroll + rows < total
       first = i == 0
       last = i == visible - 1
       return '↕' if first && last && above && below
@@ -132,25 +232,31 @@ module Gori::Tui
       nil
     end
 
-    # Scroll so the selection stays visible when the popup is shorter than the
-    # entry list (short terminals) — mirrors the palette/command-line behaviour.
-    private def ensure_visible(rows : Int32) : Nil
-      return if rows <= 0
-      @scroll = @selected if @selected < @scroll
-      @scroll = @selected - rows + 1 if @selected >= @scroll + rows
+    # Scroll so the selection stays visible when the popup is shorter than the row
+    # list (short terminals) — mirrors the palette/command-line behaviour. Works in
+    # DISPLAY-ROW space (headers count as rows) so it's correct whether or not this
+    # frame has a header at all.
+    private def ensure_visible(rows : Array(DisplayRow), viewport : Int32) : Nil
+      return if viewport <= 0 || rows.empty?
+      sel_row = rows.index { |r| r.entry == @selected } || 0
+      @scroll = sel_row if sel_row < @scroll
+      @scroll = sel_row - viewport + 1 if sel_row >= @scroll + viewport
       @scroll = 0 if @scroll < 0
     end
 
     # Maps a click in `body` to an entry index (or nil) — inverts box()'s rows.
+    # Header rows aren't clickable.
     def row_at(body : Rect, mx : Int32, my : Int32) : Int32?
       b = box(body)
       return nil if b.empty?
-      rows = b.h - 2
+      viewport = b.h - 2
       i = my - (b.y + 1)
-      return nil if i < 0 || i >= rows
+      return nil if i < 0 || i >= viewport
       return nil if mx <= b.x || mx >= b.right - 1
-      idx = @scroll + i
-      idx < @entries.size ? idx : nil
+      rows = display_rows
+      ridx = @scroll + i
+      return nil if ridx >= rows.size
+      rows[ridx].entry
     end
   end
 end

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -149,6 +149,14 @@ module Gori::Tui
     abstract def tab : Symbol                # the registry key (== Chrome::TABS symbol)
     abstract def command_scope : Verb::Scope # the space-menu scope when this tab + body has focus
 
+    # The space menu's CONTEXT section when this tab's body holds focus — the current
+    # focus-area within the tab (e.g. Replay :request/:response/:target). Default
+    # :common: single-region tabs (History, Sitemap, …) have no sub-area to single
+    # out, so their menu is just the one COMMON group, identical to today.
+    def command_section : Symbol
+      :common
+    end
+
     # --- rendering --- (`focus` is the shell's @focus: :menu | :subtabs | :body)
     abstract def render_body(screen : Screen, rect : Rect, focus : Symbol) : Nil
 

--- a/src/gori/verb.cr
+++ b/src/gori/verb.cr
@@ -106,12 +106,19 @@ module Gori
       # chord (y / f / / …) gets its menu key from that for free (see #menu_key);
       # this overrides for verbs whose only chord is ctrl/shift or none.
       getter mnemonic : Char?
+      # Which group within the scope's space menu shows this verb: :common (every
+      # displayable view, tab-wide) or a context section (a focus-area like
+      # :request/:response/:template, or :tab/:subtab for the tab-bar/strip tiers).
+      # Additive — `scope` still selects the tab; `section` subdivides it within
+      # that scope's menu. Defaults to :common so untouched registrations render
+      # exactly as they do today (one flat group).
+      getter section : Symbol
 
       def initialize(@id : String, @title : String, @description : String, @scope : Scope,
                      @chords : Array(Chord) = [] of Chord, @hidden : Bool = false,
                      @available : ExecContext -> Bool = ->(_ctx : ExecContext) { true },
                      @coming_soon : Bool = false, @category : Category = Category::Action,
-                     @mnemonic : Char? = nil,
+                     @mnemonic : Char? = nil, @section : Symbol = :common,
                      &@handler : ExecContext -> String?)
       end
 

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -70,10 +70,14 @@ module Gori
       abstract def replay_send : Nil                       # resend the (edited) request to the target
       abstract def replay_find_subtab : Nil                # open the sub-tab search picker (filter + jump)
       abstract def replay_subtab_count : Int32             # open replay session count (gates the search menu entry)
+      abstract def replay_rename_subtab : Nil              # open the rename prompt for the active sub-tab
+      abstract def replay_close_subtab : Nil               # close the active sub-tab (confirm-gated)
       abstract def replay_toggle_hex : Nil                 # toggle byte-exact hex editing of the request pane
       abstract def replay_toggle_decoded : Nil             # toggle the envelope/decoded split sub-pane (SAML/GraphQL)
       abstract def replay_toggle_sni : Nil                 # toggle the SNI-override sub-field (target pane)
       abstract def replay_toggle_auto_content_length : Nil # recompute Content-Length on send
+      abstract def replay_toggle_resp_diff : Nil           # switch the response pane between raw and diff-vs-previous
+      abstract def replay_toggle_resp_hex : Nil            # toggle a raw hex dump of the response bytes
       # mark-transform mode: mark request values (§…§) and attach Convert chains applied on send
       abstract def replay_toggle_mark_transform : Nil # toggle MARK mode on/off
       abstract def replay_pretty_request : Nil
@@ -88,15 +92,17 @@ module Gori
       abstract def replay_read_mode? : Bool   # focused pane is READ (y/copy verbs gate on this)
 
       # fuzzer workbench (run/stop/marking handled inline; these power the palette + cross-tab)
-      abstract def fuzz_selected : Nil     # send History's selection to the Fuzzer tab
-      abstract def fuzz_from_replay : Nil  # turn the current Replay request into a fuzz template
-      abstract def fuzz_run : Nil          # start the fuzz run
-      abstract def fuzz_stop : Nil         # stop the running fuzz
-      abstract def fuzz_new : Nil          # open a blank fuzz session
-      abstract def fuzz_automark : Nil     # auto-mark every request parameter
-      abstract def fuzz_attach_chain : Nil # open the chain-edit prompt for the marker at the template cursor
-      abstract def fuzz_list_paste : Nil   # open the payload-set editor pre-seeded to a List (multi-line, one value per line)
-      abstract def fuzz_clear_marks : Nil  # strip all §…§ markers (and their chains) from the template
+      abstract def fuzz_selected : Nil        # send History's selection to the Fuzzer tab
+      abstract def fuzz_from_replay : Nil     # turn the current Replay request into a fuzz template
+      abstract def fuzz_run : Nil             # start the fuzz run
+      abstract def fuzz_stop : Nil            # stop the running fuzz
+      abstract def fuzz_new : Nil             # open a blank fuzz session
+      abstract def fuzz_automark : Nil        # auto-mark every request parameter
+      abstract def fuzz_attach_chain : Nil    # open the chain-edit prompt for the marker at the template cursor
+      abstract def fuzz_list_paste : Nil      # open the payload-set editor pre-seeded to a List (multi-line, one value per line)
+      abstract def fuzz_clear_marks : Nil     # strip all §…§ markers (and their chains) from the template
+      abstract def fuzzer_rename_subtab : Nil # open the rename prompt for the active sub-tab
+      abstract def fuzzer_close_subtab : Nil  # close the active sub-tab (confirm-gated)
       abstract def fuzzer_copy : Nil          # copy selection or current line (READ panes)
       abstract def fuzzer_copy_all : Nil      # copy the whole focused pane text
       abstract def fuzzer_read_mode? : Bool   # focused pane is READ (y/copy verbs gate on this)
@@ -223,28 +229,30 @@ module Gori
 
       # convert: the encode/decode/hash workbench (sub-tab + output actions; the body's
       # text editing + focus nav stay inline, these power the space menu + palette)
-      abstract def convert_new : Nil        # open a fresh blank conversion sub-tab
-      abstract def convert_close : Nil      # close the active conversion sub-tab (keeps ≥1)
-      abstract def convert_clear : Nil      # clear the current input + chain
-      abstract def convert_copy : Nil            # copy the entire current output to the clipboard
-      abstract def convert_copy_selection : Nil    # copy selection from INPUT/OUTPUT (READ)
-      abstract def convert_read_mode? : Bool       # INPUT READ or OUTPUT pane (gates y/copy)
-      abstract def convert_cycle_mode : Nil # cycle the output display (text/hex/base64)
-      abstract def convert_save : Nil       # save the current chain by name (in-body prompt)
-      abstract def convert_load : Nil       # load a saved chain by name (in-body prompt)
+      abstract def convert_new : Nil            # open a fresh blank conversion sub-tab
+      abstract def convert_close : Nil          # close the active conversion sub-tab (keeps ≥1)
+      abstract def convert_rename_subtab : Nil  # open the rename prompt for the active sub-tab
+      abstract def convert_clear : Nil          # clear the current input + chain
+      abstract def convert_copy : Nil           # copy the entire current output to the clipboard
+      abstract def convert_copy_selection : Nil # copy selection from INPUT/OUTPUT (READ)
+      abstract def convert_copy_all : Nil       # copy the whole focused pane text (space menu / palette fallback)
+      abstract def convert_read_mode? : Bool    # INPUT READ or OUTPUT pane (gates y/copy)
+      abstract def convert_cycle_mode : Nil     # cycle the output display (text/hex/base64)
+      abstract def convert_save : Nil           # save the current chain by name (in-body prompt)
+      abstract def convert_load : Nil           # load a saved chain by name (in-body prompt)
 
       # notes: the multi-note scratchpad (sub-tab actions; the body's text editing
       # stays inline, these power the space menu reachable from the sub-tab strip)
-      abstract def notes_new : Nil   # open a fresh blank note sub-tab
-      abstract def notes_close : Nil # close the active note sub-tab (keeps ≥1)
-      abstract def notes_copy : Nil       # copy selection or current line (READ mode)
-      abstract def notes_copy_all : Nil   # copy the entire current note to the clipboard
+      abstract def notes_new : Nil         # open a fresh blank note sub-tab
+      abstract def notes_close : Nil       # close the active note sub-tab (keeps ≥1)
+      abstract def notes_copy : Nil        # copy selection or current line (READ mode)
+      abstract def notes_copy_all : Nil    # copy the entire current note to the clipboard
       abstract def notes_read_mode? : Bool # READ vs INS (gates y/copy verbs)
-      abstract def notes_clear : Nil # clear the current note's text
-      abstract def notes_edit : Nil  # open the current note in the external editor
-      abstract def notes_goto : Nil  # open the go-to-line prompt
-      abstract def notes_find : Nil  # open the find-in-note prompt
-      abstract def notes_links : Nil # open the links overlay for the current note
+      abstract def notes_clear : Nil       # clear the current note's text
+      abstract def notes_edit : Nil        # open the current note in the external editor
+      abstract def notes_goto : Nil        # open the go-to-line prompt
+      abstract def notes_find : Nil        # open the find-in-note prompt
+      abstract def notes_links : Nil       # open the links overlay for the current note
 
       # project: description pane copy actions (READ mode on the DESCRIPTION card)
       abstract def project_desc_read_mode? : Bool
@@ -255,6 +263,10 @@ module Gori
       abstract def read_selection_active? : Bool
       abstract def read_select_line : Nil
       abstract def read_clear_selection : Nil
+      # The unified "Copy" verb's fallback: selection if one is active, else the
+      # whole focused pane. Routes to the active tab's existing copy delegators
+      # (not new copy logic) — mirrors read_selection_active?'s per-tab dispatch.
+      abstract def read_copy : Nil
       abstract def detail_navigable? : Bool # History detail text pane (not hex)
       # Override a verb's space-menu title (nil → use the registered default).
       abstract def space_menu_title(verb_id : String) : String?

--- a/src/gori/verb/registry.cr
+++ b/src/gori/verb/registry.cr
@@ -26,25 +26,52 @@ module Gori
         @by_id[id]? || raise Gori::Error.new("unknown verb id: #{id}")
       end
 
-      # Fail fast on a per-scope space-menu key collision. Two non-hidden verbs in the
-      # SAME scope deriving the same menu_key (an explicit mnemonic, else the first plain
-      # single-char chord) means the later one is silently unreachable by that key —
-      # SpaceMenu#verb_for is a first-match find, so the collision has no other symptom.
-      # Cross-scope reuse is fine (the space menu is scoped), so this checks WITHIN each
-      # scope only, mirroring Conflicts' same-scope rule. space_menu_spec asserts the same
-      # invariant; calling this at build time makes it a boot-time guarantee, like the
-      # duplicate verb-id raise in #register.
+      # True when scope has at least one non-hidden, MENU-KEYED verb tagged with
+      # `section` — lets the tab-bar space menu (@focus == :menu) decide whether a
+      # scope has its OWN :tab actions or should fall back to :common instead. Must
+      # match what open() actually renders (SpaceMenu#open only shows verbs carrying
+      # a menu_key), else this could report a section that would render empty.
+      def has_section?(scope : Scope, section : Symbol) : Bool
+        any? { |v| !v.hidden? && v.scope == scope && v.section == section && v.menu_key }
+      end
+
+      # Fail fast on a space-menu key collision WITHIN a displayable view. A view is
+      # COMMON ∪ one context section — that's everything the space menu can show at
+      # once (COMMON always renders; at most one section joins it, per #open in
+      # SpaceMenu). Two non-hidden verbs deriving the same menu_key (an explicit
+      # mnemonic, else the first plain single-char chord) that could appear in the
+      # SAME view means the later one is silently unreachable by that key —
+      # SpaceMenu#verb_for is a first-match find, so the collision has no other
+      # symptom. Two DIFFERENT sections may reuse a key freely (e.g. Replay's request
+      # `i` and response `i`) since they never render together. Cross-scope reuse is
+      # likewise fine (the space menu is scoped), mirroring Conflicts' same-scope
+      # rule. space_menu_spec asserts the same invariant; calling this at build time
+      # makes it a boot-time guarantee, like the duplicate verb-id raise in #register.
       def validate_menu_keys! : Nil
-        seen = Hash(Scope, Hash(Char, String)).new
-        each do |verb|
-          next if verb.hidden?
-          next unless key = verb.menu_key
-          scope_keys = (seen[verb.scope] ||= {} of Char => String)
-          if prior = scope_keys[key]?
-            raise Gori::Error.new(
-              "space-menu key collision: '#{key}' claimed by both #{prior} and #{verb.id} in #{verb.scope}")
+        by_scope = Hash(Scope, Array(Definition)).new { |h, k| h[k] = [] of Definition }
+        each { |v| by_scope[v.scope] << v unless v.hidden? }
+
+        by_scope.each do |scope, verbs|
+          common = verbs.select { |v| v.section == :common }
+          check_menu_keys!(scope, :common, common)
+          sections = verbs.map(&.section).uniq.reject { |s| s == :common }
+          sections.each do |section|
+            view = common + verbs.select { |v| v.section == section }
+            check_menu_keys!(scope, section, view)
           end
-          scope_keys[key] = verb.id
+        end
+      end
+
+      # Raise on the first key collision among `verbs` (one displayable view's worth).
+      private def check_menu_keys!(scope : Scope, section : Symbol, verbs : Array(Definition)) : Nil
+        seen = {} of Char => String
+        verbs.each do |v|
+          next unless key = v.menu_key
+          if prior = seen[key]?
+            raise Gori::Error.new(
+              "space-menu key collision: '#{key}' claimed by both #{prior} and #{v.id} in #{scope}/#{section}")
+          end
+          seen[key] = v.id
         end
       end
 

--- a/src/gori/verbs/convert.cr
+++ b/src/gori/verbs/convert.cr
@@ -9,6 +9,10 @@ module Gori
     def self.register_convert(r : Verb::Registry) : Nil
       in_convert = ->(ctx : Verb::ExecContext) { ctx.current_tab == :convert }
 
+      # New/Close are COMMON (Round 4), not TAB/SUBTAB: tagging them to the tab-bar/
+      # strip tiers meant they were invisible from inside the body panes (INPUT/
+      # CHAIN/OUTPUT) — COMMON renders in every context, so session management is
+      # now reachable from anywhere in Convert, same as Copy.
       r.register Verb::Definition.new(
         "convert.new", "New conversion", "Open a fresh blank conversion sub-tab",
         Verb::Scope::Convert, available: in_convert, mnemonic: 'n') { |ctx| ctx.convert_new; nil }
@@ -17,31 +21,45 @@ module Gori
         "convert.close", "Close conversion", "Close the active conversion sub-tab (keeps at least one)",
         Verb::Scope::Convert, available: in_convert, mnemonic: 'w') { |ctx| ctx.convert_close; nil }
 
+      # Rename the active sub-tab's chip — mirrors replay.rename-subtab/fuzz.rename-subtab
+      # (verbs/history.cr): Convert is also in renameable_subtabs? (runner.cr), but had no
+      # :subtab verb of its own, so its sub-tab-strip space menu was flat COMMON with no
+      # way to rename. 'e' is free within COMMON ∪ :subtab (COMMON keys: n/w/y).
+      r.register Verb::Definition.new(
+        "convert.rename-subtab", "Rename subtab", "Rename the active conversion's sub-tab chip",
+        Verb::Scope::Convert, available: in_convert, mnemonic: 'e', section: :subtab) { |ctx| ctx.convert_rename_subtab; nil }
+
+      # Clears the INPUT text (and its chain spec) — the INPUT pane's own action.
       r.register Verb::Definition.new(
         "convert.clear", "Clear input + chain", "Clear the current input and chain spec",
-        Verb::Scope::Convert, available: in_convert, mnemonic: 'l') { |ctx| ctx.convert_clear; nil }
+        Verb::Scope::Convert, available: in_convert, mnemonic: 'l', section: :input) { |ctx| ctx.convert_clear; nil }
 
       in_convert_read = ->(ctx : Verb::ExecContext) { ctx.current_tab == :convert && ctx.convert_read_mode? }
+      # The single smart Copy (see replay.copy in verbs/history.cr) — copy-all is gone.
       r.register Verb::Definition.new(
-        "convert.copy", "Copy selection", "Copy the selected text (or current line) from INPUT/OUTPUT",
+        "convert.copy", "Copy", "Copy the selected text, or the whole focused pane if nothing is selected, from INPUT/OUTPUT",
         Verb::Scope::Convert, [Verb::Chord.new("y")],
-        available: in_convert_read, mnemonic: 'y') { |ctx| ctx.convert_copy_selection; nil }
+        available: in_convert_read, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
 
-      r.register Verb::Definition.new(
-        "convert.copy-all", "Copy output", "Copy the entire current output to the clipboard",
-        Verb::Scope::Convert, available: in_convert, mnemonic: 'O') { |ctx| ctx.convert_copy; nil }
-
+      # Cycles the OUTPUT pane's display mode — tagged :output.
       r.register Verb::Definition.new(
         "convert.mode", "Cycle output mode", "Cycle the output display: text / hex / base64",
-        Verb::Scope::Convert, available: in_convert, mnemonic: 'm') { |ctx| ctx.convert_cycle_mode; nil }
+        Verb::Scope::Convert, available: in_convert, mnemonic: 'm', section: :output) { |ctx| ctx.convert_cycle_mode; nil }
 
+      # Save/load a chain spec by name — tagged :tab (session-level), not :chain:
+      # naming and recalling a saved chain is closer to session management (like
+      # Replay's find-subtab / Fuzzer's new-session) than a per-keystroke CHAIN-pane
+      # action, and it keeps that pane from carrying its own near-empty group. This
+      # also seeds has_section?(Convert, :tab), so the tab-bar space menu shows a
+      # deliberate TAB group (COMMON + Save/Load) instead of falling back to
+      # whichever body pane was last focused.
       r.register Verb::Definition.new(
         "convert.save", "Save chain by name", "Save the current chain spec under a name",
-        Verb::Scope::Convert, available: in_convert, mnemonic: 's') { |ctx| ctx.convert_save; nil }
+        Verb::Scope::Convert, available: in_convert, mnemonic: 's', section: :tab) { |ctx| ctx.convert_save; nil }
 
       r.register Verb::Definition.new(
         "convert.load", "Load a saved chain", "Load a previously saved chain spec by name",
-        Verb::Scope::Convert, available: in_convert, mnemonic: 'o') { |ctx| ctx.convert_load; nil }
+        Verb::Scope::Convert, available: in_convert, mnemonic: 'o', section: :tab) { |ctx| ctx.convert_load; nil }
     end
   end
 end

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -126,15 +126,25 @@ module Gori
         "scope.delete-rule", "Delete scope rule", "Remove the selected scope rule",
         Verb::Scope::Project, [Verb::Chord.new("d")], available: scope_rule) { |ctx| ctx.scope_delete_rule; nil }
 
+      # The single smart Copy (see replay.copy in verbs/history.cr) — copy-all is gone.
+      # Was `hidden: true` (the menu only ever showed "Copy description"); now that
+      # this IS the one Copy action, it needs to be visible. Project shares
+      # Verb::Scope::Body with the History list (Body is the generic "content pane
+      # focus" scope), so plain 'y' would collide with history.copy — both in the
+      # SAME (scope, :common) space-menu view (validate_menu_keys! doesn't know the
+      # two are gated to different tabs at runtime) AND as a raw Chord in the SAME
+      # scope (keymap_spec's rebindable-conflict guard: two verbs can't default-bind
+      # the same chord in one scope). Dropping the chord resolves both — the direct
+      # 'y' keypress in the Project description pane is already raw-dispatched by
+      # ProjectController (`when c == 'y' then project_copy`, never touching the
+      # shared Keymap), so the chord here was vestigial. Capital 'Y' keeps a
+      # "copy"-flavored mnemonic for the space menu while staying distinct from
+      # history.copy's 'y' (mirrors fuzzer.select-line's 'S' dodging lowercase 's').
       in_project_desc_read = ->(ctx : Verb::ExecContext) { ctx.project_desc_read_mode? }
       r.register Verb::Definition.new(
-        "project.copy", "Copy selection", "Copy the selected description text (or current line) to the clipboard",
-        Verb::Scope::Body, [Verb::Chord.new("y")],
-        available: in_project_desc_read, hidden: true) { |ctx| ctx.project_copy; nil }
-
-      r.register Verb::Definition.new(
-        "project.copy-all", "Copy description", "Copy the entire project description to the clipboard",
-        Verb::Scope::Body, available: in_project_desc_read, mnemonic: 'O') { |ctx| ctx.project_copy_all; nil }
+        "project.copy", "Copy", "Copy the selected description text, or the whole description if nothing is selected, to the clipboard",
+        Verb::Scope::Body,
+        available: in_project_desc_read, mnemonic: 'Y') { |ctx| ctx.read_copy; nil }
 
       r.register Verb::Definition.new(
         "rules.edit", "Match & Replace", "Edit in-flight request/response head rewrite rules", Verb::Scope::Global,

--- a/src/gori/verbs/findings.cr
+++ b/src/gori/verbs/findings.cr
@@ -71,16 +71,13 @@ module Gori
       # palette stays Global-only, so this doesn't leak there). Each menu key derives
       # from its plain chord — the key you'd press directly. severity/status keep their
       # bracket chords ([ ] { }) hidden (awkward as menu mnemonics; discoverable in Help).
+      # The single smart Copy (see replay.copy in verbs/history.cr) — copy-all is gone.
       in_findings_notes_read = ->(ctx : Verb::ExecContext) { ctx.findings_notes_read_mode? }
 
       r.register Verb::Definition.new(
-        "finding.copy", "Copy selection", "Copy the selected notes text (or current line) to the clipboard",
+        "finding.copy", "Copy", "Copy the selected notes text, or the whole notes if nothing is selected, to the clipboard",
         Verb::Scope::FindingsDetail, [Verb::Chord.new("y")],
-        available: in_findings_notes_read, mnemonic: 'y') { |ctx| ctx.findings_copy; nil }
-
-      r.register Verb::Definition.new(
-        "finding.copy-all", "Copy notes", "Copy the entire finding notes to the clipboard",
-        Verb::Scope::FindingsDetail, available: in_findings_notes_read, mnemonic: 'O') { |ctx| ctx.findings_copy_all; nil }
+        available: in_findings_notes_read, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
 
       r.register Verb::Definition.new(
         "finding.edit-notes", "Edit notes", "Edit the finding notes inline (i/↵/e)", Verb::Scope::FindingsDetail,

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -52,11 +52,22 @@ module Gori
       # --- replay workbench (request editing is inline; these power the palette
       # and show their key hints — actual keys are handled directly by the TUI) ---
       in_replay = ->(ctx : Verb::ExecContext) { ctx.current_tab == :replay }
+      in_replay_read = ->(ctx : Verb::ExecContext) { ctx.current_tab == :replay && ctx.replay_read_mode? }
 
       r.register Verb::Definition.new(
         "replay.send", "Send replay", "Resend the request byte-exact and diff the response",
         Verb::Scope::Replay, [Verb::Chord.new("r", ctrl: true)],
         available: in_replay, mnemonic: 'r') { |ctx| ctx.replay_send; nil }
+
+      # The single smart Copy: selection if one is active, else the whole focused
+      # pane (ctx.read_copy — routes per-tab, added in Round 1). copy-all is gone.
+      # Ordered right after Send (Round 5 — COMMON is curated most-used-first: Send,
+      # Copy, New, Fuzz, Mine, Link-finding, Link-note; registered here rather than
+      # farther down so the physical registration order matches).
+      r.register Verb::Definition.new(
+        "replay.copy", "Copy", "Copy the selected text, or the whole focused pane if nothing is selected, to the clipboard",
+        Verb::Scope::Replay, [Verb::Chord.new("y")],
+        available: in_replay_read, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
 
       r.register Verb::Definition.new(
         "replay.new", "New replay request", "Open a blank request in Replay to author and send",
@@ -64,67 +75,102 @@ module Gori
         available: in_replay, mnemonic: 'n') { |ctx| ctx.replay_new; nil }
 
       # Search the open replay sub-tabs and jump to the chosen one — menu-only
-      # (no chord), shown only when there are ≥2 sessions to pick between.
+      # (no chord), shown only when there are ≥2 sessions to pick between. Tagged
+      # :tab (session-level) rather than :common: it's the one verb that seeds
+      # has_section?(Replay, :tab), so the tab-bar space menu shows a deliberate
+      # TAB group (COMMON + this) instead of falling back to whatever body focus
+      # section (request/response/target) happened to be active last.
       r.register Verb::Definition.new(
         "replay.find-subtab", "Search sub-tabs", "Filter the open replay sessions and jump to one",
         Verb::Scope::Replay,
         available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :replay && ctx.replay_subtab_count >= 2 },
-        mnemonic: 's') { |ctx| ctx.replay_find_subtab; nil }
+        mnemonic: 's', section: :tab) { |ctx| ctx.replay_find_subtab; nil }
 
-      # Request-pane toggles — keymap-driven (Replay scope) so they're rebindable. The
-      # Runner delegators carry the pane-gating + status messages.
+      # Sub-tab rename/close — today's raw key-dispatch on the strip (`r` rename, ^W
+      # close) promoted to verbs so the :subtab space-menu group (reachable from the
+      # strip) isn't empty. Reuse the SAME shell rename prompt + confirm-gated close
+      # (no new logic); mnemonics 'e'/'w' are free within COMMON ∪ :subtab (COMMON's
+      # keys are r/y/n/f/m/k/u — 'e' and 'w' only collide with OTHER sections,
+      # which never render alongside :subtab).
+      r.register Verb::Definition.new(
+        "replay.rename-subtab", "Rename subtab", "Rename the active replay sub-tab's chip",
+        Verb::Scope::Replay, available: in_replay, mnemonic: 'e', section: :subtab) { |ctx| ctx.replay_rename_subtab; nil }
+      r.register Verb::Definition.new(
+        "replay.close-subtab", "Close subtab", "Close the active replay sub-tab",
+        Verb::Scope::Replay, available: in_replay, mnemonic: 'w', section: :subtab) { |ctx| ctx.replay_close_subtab; nil }
+
+      # --- REQUEST pane, mark-transform (mark request values, attach Convert chains
+      # applied on send) — Round 5 order: the marker actions the user reaches for
+      # most (toggle the mode, then insert/mark/auto/clear/attach), THEN the view
+      # toggles (hex/decoded/pretty) below.
+      r.register Verb::Definition.new(
+        "replay.toggle-mark-transform", "Toggle MARK transform", "Mark request values (§…§) and apply Convert chains on send",
+        Verb::Scope::Replay, [Verb::Chord.new("k", ctrl: true)],
+        available: in_replay, mnemonic: 't', section: :request) { |ctx| ctx.replay_toggle_mark_transform; nil }
+      r.register Verb::Definition.new(
+        "replay.insert-marker", "Insert marker", "Drop a single § at the cursor to bracket a region by hand",
+        Verb::Scope::Replay, available: in_replay, mnemonic: 'i', section: :request) { |ctx| ctx.replay_insert_marker; nil }
+      r.register Verb::Definition.new(
+        "replay.mark-word", "Mark word", "Toggle a §…§ marker around the token at the cursor",
+        Verb::Scope::Replay, available: in_replay, mnemonic: 'w', section: :request) { |ctx| ctx.replay_mark_word; nil }
+      r.register Verb::Definition.new(
+        "replay.auto-mark", "Auto-mark params", "Wrap every request parameter value in a §…§ marker",
+        Verb::Scope::Replay, [Verb::Chord.new("a", ctrl: true)],
+        available: in_replay, mnemonic: 'a', section: :request) { |ctx| ctx.replay_auto_mark; nil }
+      r.register Verb::Definition.new(
+        "replay.clear-marks", "Clear markers", "Strip every §…§ marker (and its attached chain)",
+        Verb::Scope::Replay, available: in_replay, mnemonic: 'c', section: :request) { |ctx| ctx.replay_clear_marks; nil }
+      r.register Verb::Definition.new(
+        "replay.attach-chain", "Edit convert chain", "Focus the CHAIN pane to edit the encode/decode chain of the marker at the cursor (applied on send)",
+        Verb::Scope::Replay, [Verb::Chord.new("y", ctrl: true)],
+        available: in_replay, mnemonic: 'e', section: :request) { |ctx| ctx.replay_attach_chain; nil }
+
+      # Request-pane VIEW toggles — keymap-driven (Replay scope) so they're rebindable.
+      # The Runner delegators carry the pane-gating + status messages. Hex-edit the
+      # request bytes, switch its envelope/decoded split, pretty-print its body —
+      # mnemonics added so they front the :request space-menu group (previously
+      # ctrl-only, so menu_key was nil and they were invisible there).
       r.register Verb::Definition.new(
         "replay.toggle-hex", "Toggle hex edit", "Edit the request as raw bytes — sends exactly what you type",
         Verb::Scope::Replay, [Verb::Chord.new("x", ctrl: true)],
-        available: in_replay) { |ctx| ctx.replay_toggle_hex; nil }
+        available: in_replay, mnemonic: 'x', section: :request) { |ctx| ctx.replay_toggle_hex; nil }
       r.register Verb::Definition.new(
         "replay.toggle-decoded", "Switch envelope/decoded", "SAML/GraphQL flow: switch envelope/decoded · in MARK mode: insert a § at the cursor",
         Verb::Scope::Replay, [Verb::Chord.new("t", ctrl: true)],
-        available: in_replay) { |ctx| ctx.replay_toggle_decoded; nil }
+        available: in_replay, mnemonic: 'd', section: :request) { |ctx| ctx.replay_toggle_decoded; nil }
+      r.register Verb::Definition.new(
+        "replay.pretty-request", "Pretty-print request", "Format the request body in-place (JSON/XML/form-urlencoded)",
+        Verb::Scope::Replay, [Verb::Chord.new("u", ctrl: true)],
+        available: in_replay, mnemonic: 'p', section: :request) { |ctx| ctx.replay_pretty_request; nil }
+
+      # Target-pane toggle (SNI override) — tagged :target so it fronts the space menu
+      # when the TARGET field has focus (previously ctrl-only ⇒ invisible there).
       r.register Verb::Definition.new(
         "replay.toggle-sni", "Toggle SNI override", "Override the TLS SNI on the target pane (dialed host unchanged)",
         Verb::Scope::Replay, [Verb::Chord.new("s", ctrl: true)],
-        available: in_replay) { |ctx| ctx.replay_toggle_sni; nil }
+        available: in_replay, mnemonic: 's', section: :target) { |ctx| ctx.replay_toggle_sni; nil }
       r.register Verb::Definition.new(
         "replay.toggle-auto-content-length", "Toggle auto Content-Length", "Recompute Content-Length from the body on send",
         Verb::Scope::Replay, [Verb::Chord.new("l", ctrl: true)],
         available: in_replay) { |ctx| ctx.replay_toggle_auto_content_length; nil }
 
-      # --- mark-transform (mark request values, attach Convert chains applied on send) ---
+      # --- RESPONSE pane (Round 5 order: diff, hex, pretty) — today's plain `d`/`x`/`p`
+      # keys, handled inline by ReplayController#handle_replay_response; promoted to
+      # verbs purely so the :response space-menu group has something to show. 'd'/'x'/'p'
+      # are free in COMMON ∪ :response (COMMON has none of these; :request's own
+      # 'd'/'x'/'p' — toggle-decoded/toggle-hex/pretty-request — are a DIFFERENT
+      # section, so no bleed). toggle-pretty has no chord (the direct 'p' key in the
+      # response pane is handled inline by the controller) and reuses the SAME shared
+      # @pretty flag as History detail's `p` toggle.
       r.register Verb::Definition.new(
-        "replay.toggle-mark-transform", "Toggle MARK transform", "Mark request values (§…§) and apply Convert chains on send",
-        Verb::Scope::Replay, [Verb::Chord.new("k", ctrl: true)],
-        available: in_replay, mnemonic: 't') { |ctx| ctx.replay_toggle_mark_transform; nil }
+        "replay.toggle-diff", "Toggle diff", "Switch the response pane between the raw response and a diff against the previous one",
+        Verb::Scope::Replay, available: in_replay, mnemonic: 'd', section: :response) { |ctx| ctx.replay_toggle_resp_diff; nil }
       r.register Verb::Definition.new(
-        "replay.pretty-request", "Pretty-print request", "Format the request body in-place (JSON/XML/form-urlencoded)",
-        Verb::Scope::Replay, [Verb::Chord.new("u", ctrl: true)],
-        available: in_replay) { |ctx| ctx.replay_pretty_request; nil }
+        "replay.toggle-resp-hex", "Hex dump", "Toggle a raw hex dump of the response bytes",
+        Verb::Scope::Replay, available: in_replay, mnemonic: 'x', section: :response) { |ctx| ctx.replay_toggle_resp_hex; nil }
       r.register Verb::Definition.new(
-        "replay.auto-mark", "Auto-mark params", "Wrap every request parameter value in a §…§ marker",
-        Verb::Scope::Replay, [Verb::Chord.new("a", ctrl: true)],
-        available: in_replay, mnemonic: 'a') { |ctx| ctx.replay_auto_mark; nil }
-      r.register Verb::Definition.new(
-        "replay.mark-word", "Mark word", "Toggle a §…§ marker around the token at the cursor",
-        Verb::Scope::Replay, available: in_replay, mnemonic: 'w') { |ctx| ctx.replay_mark_word; nil }
-      r.register Verb::Definition.new(
-        "replay.insert-marker", "Insert marker", "Drop a single § at the cursor to bracket a region by hand",
-        Verb::Scope::Replay, available: in_replay, mnemonic: 'i') { |ctx| ctx.replay_insert_marker; nil }
-      r.register Verb::Definition.new(
-        "replay.clear-marks", "Clear markers", "Strip every §…§ marker (and its attached chain)",
-        Verb::Scope::Replay, available: in_replay, mnemonic: 'c') { |ctx| ctx.replay_clear_marks; nil }
-      r.register Verb::Definition.new(
-        "replay.attach-chain", "Edit convert chain", "Focus the CHAIN pane to edit the encode/decode chain of the marker at the cursor (applied on send)",
-        Verb::Scope::Replay, [Verb::Chord.new("y", ctrl: true)],
-        available: in_replay, mnemonic: 'e') { |ctx| ctx.replay_attach_chain; nil }
-      in_replay_read = ->(ctx : Verb::ExecContext) { ctx.current_tab == :replay && ctx.replay_read_mode? }
-      r.register Verb::Definition.new(
-        "replay.copy", "Copy selection", "Copy the selected text (or current line) to the clipboard",
-        Verb::Scope::Replay, [Verb::Chord.new("y")],
-        available: in_replay_read, mnemonic: 'y') { |ctx| ctx.replay_copy; nil }
-      r.register Verb::Definition.new(
-        "replay.copy-all", "Copy all", "Copy the entire focused pane to the clipboard",
-        Verb::Scope::Replay,
-        available: in_replay_read, mnemonic: 'O') { |ctx| ctx.replay_copy_all; nil }
+        "replay.toggle-pretty", "Pretty bodies", "Pretty-print JSON/XML/form/… response bodies (display only)",
+        Verb::Scope::Replay, available: in_replay, mnemonic: 'p', section: :response) { |ctx| ctx.toggle_pretty; nil }
 
       # --- detail view ---
       # esc/q always leave. ← walks back through the panes (FRAMES→RES→REQ) and only
@@ -250,37 +296,48 @@ module Gori
       r.register Verb::Definition.new(
         "fuzz.stop", "Stop fuzz", "Stop the running fuzz", Verb::Scope::Fuzzer,
         [Verb::Chord.new("x", ctrl: true)], available: in_fuzzer, mnemonic: 's') { |ctx| ctx.fuzz_stop; nil }
+      # COMMON (Round 5), not :tab: New-session is a top action the user reaches for
+      # from anywhere in the Fuzzer tab, not just the tab bar — mirrors replay.new
+      # (Replay) and convert.new (Convert, Round 4a), both :common. Fuzzer's COMMON
+      # is now curated most-used-first: Run, Stop, New, Copy, Link-finding, Link-note.
       r.register Verb::Definition.new(
         "fuzz.new", "New fuzz session", "Open a blank fuzz template", Verb::Scope::Fuzzer,
         [Verb::Chord.new("n", ctrl: true)],
         available: in_fuzzer, mnemonic: 'n') { |ctx| ctx.fuzz_new; nil }
+
+      # Sub-tab rename/close — mirrors replay.rename-subtab/replay.close-subtab above:
+      # the strip's raw `r` rename / ^W close, promoted to verbs so :subtab isn't
+      # empty. 'e'/'w' are free in COMMON ∪ :subtab (Fuzzer COMMON keys: r/s/y/k/u/S/v).
+      r.register Verb::Definition.new(
+        "fuzz.rename-subtab", "Rename subtab", "Rename the active fuzz session's sub-tab chip",
+        Verb::Scope::Fuzzer, available: in_fuzzer, mnemonic: 'e', section: :subtab) { |ctx| ctx.fuzzer_rename_subtab; nil }
+      r.register Verb::Definition.new(
+        "fuzz.close-subtab", "Close subtab", "Close the active fuzz session",
+        Verb::Scope::Fuzzer, available: in_fuzzer, mnemonic: 'w', section: :subtab) { |ctx| ctx.fuzzer_close_subtab; nil }
       r.register Verb::Definition.new(
         "fuzz.automark", "Auto-mark params", "Mark every request parameter value", Verb::Scope::Fuzzer,
-        [Verb::Chord.new("a", ctrl: true)], available: in_fuzzer, mnemonic: 'm') { |ctx| ctx.fuzz_automark; nil }
+        [Verb::Chord.new("a", ctrl: true)], available: in_fuzzer, mnemonic: 'm', section: :template) { |ctx| ctx.fuzz_automark; nil }
       r.register Verb::Definition.new(
         "fuzz.attach-chain", "Edit convert chain", "Focus the CHAIN pane to edit the encode/decode chain of the marker at the cursor (applied to each payload on send)",
         Verb::Scope::Fuzzer, [Verb::Chord.new("y", ctrl: true)],
-        available: in_fuzzer, mnemonic: 'c') { |ctx| ctx.fuzz_attach_chain; nil }
+        available: in_fuzzer, mnemonic: 'c', section: :template) { |ctx| ctx.fuzz_attach_chain; nil }
       r.register Verb::Definition.new(
         "fuzz.list-paste", "Add List payload set", "Open the payload-set editor pre-seeded to a List — a multi-line editor, one value per line (paste splits automatically)",
         Verb::Scope::Fuzzer, [Verb::Chord.new("l", ctrl: true)],
-        available: in_fuzzer, mnemonic: 'l') { |ctx| ctx.fuzz_list_paste; nil }
+        available: in_fuzzer, mnemonic: 'l', section: :template) { |ctx| ctx.fuzz_list_paste; nil }
       r.register Verb::Definition.new(
         "fuzz.pretty-template", "Pretty-print template", "Format the request template body in-place (JSON/XML/form-urlencoded)",
         Verb::Scope::Fuzzer, [Verb::Chord.new("u", ctrl: true)],
-        available: in_fuzzer) { |ctx| ctx.fuzz_pretty_template; nil }
+        available: in_fuzzer, mnemonic: 'p', section: :template) { |ctx| ctx.fuzz_pretty_template; nil }
       r.register Verb::Definition.new(
         "fuzz.clear-marks", "Clear markers", "Strip every §…§ marker (and its attached chain) from the template",
-        Verb::Scope::Fuzzer, available: in_fuzzer, mnemonic: 'x') { |ctx| ctx.fuzz_clear_marks; nil }
+        Verb::Scope::Fuzzer, available: in_fuzzer, mnemonic: 'x', section: :template) { |ctx| ctx.fuzz_clear_marks; nil }
       in_fuzzer_read = ->(ctx : Verb::ExecContext) { ctx.current_tab == :fuzzer && ctx.fuzzer_read_mode? }
+      # The single smart Copy (see replay.copy above) — copy-all is gone.
       r.register Verb::Definition.new(
-        "fuzzer.copy", "Copy selection", "Copy the selected text (or current line) to the clipboard",
+        "fuzzer.copy", "Copy", "Copy the selected text, or the whole focused pane if nothing is selected, to the clipboard",
         Verb::Scope::Fuzzer, [Verb::Chord.new("y")],
-        available: in_fuzzer_read, mnemonic: 'y') { |ctx| ctx.fuzzer_copy; nil }
-      r.register Verb::Definition.new(
-        "fuzzer.copy-all", "Copy all", "Copy the entire focused pane to the clipboard",
-        Verb::Scope::Fuzzer,
-        available: in_fuzzer_read, mnemonic: 'O') { |ctx| ctx.fuzzer_copy_all; nil }
+        available: in_fuzzer_read, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
     end
 
     # Param-miner verbs: the cross-tab "Mine parameters" entry (space menu in History,
@@ -307,6 +364,37 @@ module Gori
       r.register Verb::Definition.new(
         "mine.stop", "Stop mining", "Stop the running mine", Verb::Scope::Miner,
         [Verb::Chord.new("x", ctrl: true)], available: in_miner, mnemonic: 's') { |ctx| ctx.mine_stop; nil }
+
+      # Replay's/Fuzzer's "Link to finding/note" (Round 5 — relocated OUT of
+      # register_links, which registers before register_fuzz/register_miner in
+      # Verbs.registry: leaving them there put Link-finding/Link-note AHEAD of
+      # Fuzz/Mine in the Replay/Fuzzer COMMON group, when the curated order wants
+      # them LAST (COMMON = most-used-first: Send/Copy/New/Fuzz/Mine/Link-finding/
+      # Link-note for Replay; Run/Stop/New/Copy/Link-finding/Link-note for Fuzzer).
+      # Registering them here — after replay.mine above, and after register_fuzz
+      # already ran — achieves that order for free (menu order == registration
+      # order, per Registry#for_scope with an empty query). Same ids/titles/
+      # handlers as before; only the registration SITE moved. History's own
+      # link.history.*/link.history-detail.* and Miner's link.miner.* stay in
+      # register_links (their relative order wasn't in scope for this round).
+      replay_linkable = ->(ctx : Verb::ExecContext) {
+        ctx.current_tab == :replay && !ctx.link_replay_id.nil?
+      }
+      fuzz_linkable = ->(ctx : Verb::ExecContext) {
+        ctx.current_tab == :fuzzer && !ctx.link_fuzz_id.nil?
+      }
+      r.register Verb::Definition.new(
+        "link.replay.to-finding", "Link to finding", "Attach this replay session to a finding",
+        Verb::Scope::Replay, available: replay_linkable, mnemonic: 'k') { |ctx| ctx.link_to_finding; nil }
+      r.register Verb::Definition.new(
+        "link.replay.to-note", "Link to note", "Attach this replay session to a note",
+        Verb::Scope::Replay, available: replay_linkable, mnemonic: 'u') { |ctx| ctx.link_to_note; nil }
+      r.register Verb::Definition.new(
+        "link.fuzzer.to-finding", "Link to finding", "Attach this fuzz session to a finding",
+        Verb::Scope::Fuzzer, available: fuzz_linkable, mnemonic: 'k') { |ctx| ctx.link_to_finding; nil }
+      r.register Verb::Definition.new(
+        "link.fuzzer.to-note", "Link to note", "Attach this fuzz session to a note",
+        Verb::Scope::Fuzzer, available: fuzz_linkable, mnemonic: 'u') { |ctx| ctx.link_to_note; nil }
     end
 
     # Builds a registry with every built-in verb registered.

--- a/src/gori/verbs/links.cr
+++ b/src/gori/verbs/links.cr
@@ -2,15 +2,14 @@ require "../verb"
 
 module Gori
   module Verbs
+    # Replay's/Fuzzer's own "Link to finding/note" (link.replay.*/link.fuzzer.*) are
+    # registered in register_miner (history.cr) instead of here — Round 5 moved them
+    # there so their Replay/Fuzzer COMMON menu position lands AFTER Fuzz/Mine (see
+    # the comment at their new registration site for why). History's/HistoryDetail's/
+    # Miner's own link verbs are unaffected and stay below.
     def self.register_links(r : Verb::Registry) : Nil
       flow_available = ->(ctx : Verb::ExecContext) {
         ctx.current_tab == :history && !ctx.link_flow_id.nil?
-      }
-      replay_linkable = ->(ctx : Verb::ExecContext) {
-        ctx.current_tab == :replay && !ctx.link_replay_id.nil?
-      }
-      fuzz_linkable = ->(ctx : Verb::ExecContext) {
-        ctx.current_tab == :fuzzer && !ctx.link_fuzz_id.nil?
       }
       miner_linkable = ->(ctx : Verb::ExecContext) {
         ctx.current_tab == :miner && !ctx.link_miner_id.nil?
@@ -31,22 +30,6 @@ module Gori
       r.register Verb::Definition.new(
         "link.history-detail.to-note", "Link to note", "Attach this flow to a note",
         Verb::Scope::HistoryDetail, available: flow_available, mnemonic: 'u') { |ctx| ctx.link_to_note; nil }
-
-      r.register Verb::Definition.new(
-        "link.replay.to-finding", "Link to finding", "Attach this replay session to a finding",
-        Verb::Scope::Replay, available: replay_linkable, mnemonic: 'k') { |ctx| ctx.link_to_finding; nil }
-
-      r.register Verb::Definition.new(
-        "link.replay.to-note", "Link to note", "Attach this replay session to a note",
-        Verb::Scope::Replay, available: replay_linkable, mnemonic: 'u') { |ctx| ctx.link_to_note; nil }
-
-      r.register Verb::Definition.new(
-        "link.fuzzer.to-finding", "Link to finding", "Attach this fuzz session to a finding",
-        Verb::Scope::Fuzzer, available: fuzz_linkable, mnemonic: 'k') { |ctx| ctx.link_to_finding; nil }
-
-      r.register Verb::Definition.new(
-        "link.fuzzer.to-note", "Link to note", "Attach this fuzz session to a note",
-        Verb::Scope::Fuzzer, available: fuzz_linkable, mnemonic: 'u') { |ctx| ctx.link_to_note; nil }
 
       r.register Verb::Definition.new(
         "link.miner.to-finding", "Link to finding", "Attach this miner session to a finding",

--- a/src/gori/verbs/notes.cr
+++ b/src/gori/verbs/notes.cr
@@ -17,15 +17,12 @@ module Gori
         "notes.close", "Close note", "Close the active note sub-tab (keeps at least one)",
         Verb::Scope::Notes, available: in_notes, mnemonic: 'w') { |ctx| ctx.notes_close; nil }
 
+      # The single smart Copy (see replay.copy in verbs/history.cr) — copy-all is gone.
       in_notes_read = ->(ctx : Verb::ExecContext) { ctx.current_tab == :notes && ctx.notes_read_mode? }
       r.register Verb::Definition.new(
-        "notes.copy", "Copy selection", "Copy the selected text (or current line) to the clipboard",
+        "notes.copy", "Copy", "Copy the selected text, or the whole current note if nothing is selected, to the clipboard",
         Verb::Scope::Notes, [Verb::Chord.new("y")],
-        available: in_notes_read, mnemonic: 'y') { |ctx| ctx.notes_copy; nil }
-
-      r.register Verb::Definition.new(
-        "notes.copy-all", "Copy note", "Copy the entire current note to the clipboard",
-        Verb::Scope::Notes, available: in_notes, mnemonic: 'O') { |ctx| ctx.notes_copy_all; nil }
+        available: in_notes_read, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
 
       r.register Verb::Definition.new(
         "notes.clear", "Clear note", "Clear the current note's text",

--- a/src/gori/verbs/read_edit.cr
+++ b/src/gori/verbs/read_edit.cr
@@ -6,6 +6,15 @@ module Gori
     # and copy verbs whose menu title flips to "Copy selected" when a selection is active
     # (see ExecContext#space_menu_title). Registered per scope so the space menu stays
     # strictly local to the focused pane.
+    #
+    # Round 5: these are low-frequency next to Send/Copy/New/etc., so on the
+    # multi-section tabs (Replay/Fuzzer/Convert) they're tagged into the single most
+    # relevant focus-area section instead of :common — available? still gates them by
+    # read-mode across ALL of that tab's read-mode panes, so the keybinding (mostly
+    # plain 'x'/'v') keeps working everywhere; only the SPACE-MENU listing is scoped to
+    # one section. Single-region tabs (Notes/Findings/Project/HistoryDetail) have
+    # nowhere else to put them, so they stay :common (their one and only group) —
+    # unchanged, no clutter concern since there's only ever one group to show.
     def self.register_read_edit(r : Verb::Registry) : Nil
       in_sel = ->(ctx : Verb::ExecContext) { ctx.read_selection_active? }
 
@@ -18,32 +27,43 @@ module Gori
         "notes.clear-selection", "Clear selection", "Clear the text selection",
         Verb::Scope::Notes, available: in_sel, mnemonic: 'v') { |ctx| ctx.read_clear_selection; nil }
 
+      # Tagged :response (not :common): select/clear are equally available in the
+      # REQUEST/TARGET panes (in_replay_read covers all three), but :response is
+      # where reading-then-copying a snippet is the natural flow, and :request is
+      # already the busiest section (9 marker/view-toggle actions) — keeping these
+      # out of it (and out of COMMON) keeps both lean. The plain 'x' keybinding still
+      # works in every read-mode pane regardless of where the menu lists it.
       in_replay_read = ->(ctx : Verb::ExecContext) { ctx.current_tab == :replay && ctx.replay_read_mode? }
       r.register Verb::Definition.new(
         "replay.select-line", "Select line", "Select the entire current line",
         Verb::Scope::Replay, [Verb::Chord.new("x")],
-        available: in_replay_read, mnemonic: 'l') { |ctx| ctx.read_select_line; nil }
+        available: in_replay_read, mnemonic: 'l', section: :response) { |ctx| ctx.read_select_line; nil }
       r.register Verb::Definition.new(
         "replay.clear-selection", "Clear selection", "Clear the text selection",
-        Verb::Scope::Replay, available: in_sel, mnemonic: 'v') { |ctx| ctx.read_clear_selection; nil }
+        Verb::Scope::Replay, available: in_sel, mnemonic: 'v', section: :response) { |ctx| ctx.read_clear_selection; nil }
 
+      # Tagged :input (Convert's read-mode panes are INPUT-read and OUTPUT; :input is
+      # the more relevant "editing" pane — OUTPUT keeps 'x' reachable by keybinding).
       in_convert_read = ->(ctx : Verb::ExecContext) { ctx.current_tab == :convert && ctx.convert_read_mode? }
       r.register Verb::Definition.new(
         "convert.select-line", "Select line", "Select the entire current line",
         Verb::Scope::Convert, [Verb::Chord.new("x")],
-        available: in_convert_read, mnemonic: 'x') { |ctx| ctx.read_select_line; nil }
+        available: in_convert_read, mnemonic: 'x', section: :input) { |ctx| ctx.read_select_line; nil }
       r.register Verb::Definition.new(
         "convert.clear-selection", "Clear selection", "Clear the text selection",
-        Verb::Scope::Convert, available: in_sel, mnemonic: 'v') { |ctx| ctx.read_clear_selection; nil }
+        Verb::Scope::Convert, available: in_sel, mnemonic: 'v', section: :input) { |ctx| ctx.read_clear_selection; nil }
 
+      # Tagged :template (Fuzzer's only section named for this in Round 5's spec —
+      # :target/:results/:detail are also read-mode-gated, but :template is the one
+      # focus area the user singled out; 'x'/'v' keep working by keybinding elsewhere).
       in_fuzzer_read = ->(ctx : Verb::ExecContext) { ctx.current_tab == :fuzzer && ctx.fuzzer_read_mode? }
       r.register Verb::Definition.new(
         "fuzzer.select-line", "Select line", "Select the entire current line",
         Verb::Scope::Fuzzer, [Verb::Chord.new("x")],
-        available: in_fuzzer_read, mnemonic: 'S') { |ctx| ctx.read_select_line; nil }
+        available: in_fuzzer_read, mnemonic: 'S', section: :template) { |ctx| ctx.read_select_line; nil }
       r.register Verb::Definition.new(
         "fuzzer.clear-selection", "Clear selection", "Clear the text selection",
-        Verb::Scope::Fuzzer, available: in_sel, mnemonic: 'v') { |ctx| ctx.read_clear_selection; nil }
+        Verb::Scope::Fuzzer, available: in_sel, mnemonic: 'v', section: :template) { |ctx| ctx.read_clear_selection; nil }
 
       in_findings_notes = ->(ctx : Verb::ExecContext) { ctx.findings_notes_read_mode? }
       r.register Verb::Definition.new(


### PR DESCRIPTION
## Summary

Overhauls the `space` menu from a single flat per-scope list into a **context-aware grouped popup**, adds a **tab-level menu**, unifies **Copy**, and fixes three navigation rough edges. Renders as a **narrow single vertical column anchored bottom-right** with dim section headers.

Design decisions were confirmed with the user up front: contextual single-column-with-headers layout; tab-level menu = per-tab top actions + common; single smart Copy (no separate "Copy all"); shipped on one branch.

## What changed

### Space menu
- **`section` field** on `Verb::Definition` (`:common` | focus-area like `:request`/`:response`/`:template`/`:input`/`:output` | `:tab` | `:subtab`). The popup shows a **COMMON** group + the **currently-focused context's** group, each with a `─ LABEL ─` header (header omitted when there's only one group). One item per row, narrow, bottom-right.
- **Tab-level menu** — space on the tab bar now opens the active tab's `:tab` actions + COMMON (previously a no-op that mapped to `Scope::Sidebar`). Implemented via a dedicated `space_menu_context` so the keymap's `current_scope` is untouched; falls back to **COMMON-only** for tabs without `:tab` actions (so the tab bar never bleeds a body pane's section).
- **Per-view key uniqueness** — `validate_menu_keys!` now enforces uniqueness within each renderable view (`COMMON ∪ one section`) at registry build; new `Registry#has_section?`.
- **Curation** — high-frequency actions lead COMMON (Replay: Send/Copy/New/Fuzz/Mine/Link; Fuzzer: Run/Stop/New/Copy/Link; Convert: New/Close/Copy); markers-first in Replay `:request`; selection helpers moved out of COMMON into their read/edit sections; response **Diff/Hex** and subtab **Rename/Close** promoted from raw key-dispatch to real verbs so those sections populate.

### Copy
- One smart **"Copy"** per tab (`replay`/`fuzzer`/`convert`/`notes`/`finding`/`project`) → `read_copy`: copies the **selection** when present, else the **whole focused pane**. Convert's fallback is **pane-aware** (INPUT/OUTPUT). Menu label flips to "Copy selection" when a selection is live. `detail.copy-flow` (raw flow bytes) kept as a distinct action.

### Navigation fixes
- Editor **mouse-click leaves editors in READ** mode (was forcing INS) in Replay/Fuzzer/Convert; `i`/`Enter` still enter INS.
- Fuzzer **CONFIG: LEFT focuses TEMPLATE** (was swallowed by value cycling).
- **Esc** from a body region now targets the **subtab strip** (body → strip → tab bar); strip-less tabs still go straight to the tab bar.

## Review & verification
- Built a 3-finder code review over the render/index math, runner routing, and verb tagging; **7 findings fixed** (Convert Copy pane-routing, scroll ▲/▼ affordance swallowed on header rows, tab-bar section bleed, header width-clamp, false "(keeps at least one)" text, missing Convert `:subtab` Rename, `has_section?` menu_key match). Positively cleared the riskiest suspects (scope separation, empty-menu safety, click→READ cursor self-heal, Esc no-stranding/no-double-save).
- `crystal build src/main.cr` clean; `crystal spec` **1342 examples, 0 failures**.
- Visually verified in tmux: narrow single-column popup, context group swaps per focused pane, tab-bar menu is COMMON-only for Fuzzer.

## Notes / judgment calls
- Convert **Save/Load** live in the `:tab` section (session-level), so they're menu-discoverable from the tab bar/strip rather than from inside the CHAIN pane — reverting those two `section:` tags to `:chain` is a one-line change each if that reads better in practice.
- Some `:tab`/`:subtab`/focus-area verbs are gated by `available?` (e.g. Copy needs content, Link needs a target, Stop needs a running job), so a fresh/empty tab shows a leaner menu by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)