### PR TITLE
fix(prism): 25+ correctness/robustness bugs across active, passive, TUI, orchestration

### DIFF
--- a/spec/prism_spec.cr
+++ b/spec/prism_spec.cr
@@ -285,6 +285,33 @@ describe Gori::Prism::Analyzer do
     end
   end
 
+  it "pages a >WS_MSG_CAP WebSocket backlog without skipping a band (no missed secret)" do
+    with_store do |store|
+      detail = capture_flow(store,
+        "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n",
+        target: "/ws", status: 101, content_type: nil,
+        req_headers: "Upgrade: websocket\r\nConnection: Upgrade\r\n")
+      fid = detail.row.id
+      store.insert_ws_message(fid, "in", 1, "hello".to_slice) # frame 1 (no secret) → sets hwm
+      scope = Gori::Scope.load(store)
+      feed = Channel(Gori::Store::FlowEvent).new(8)
+      a = Gori::Prism::Analyzer.new(store, scope, feed, Gori::Prism::Mode::Passive, true)
+      a.start
+      feed.send(Gori::Store::FlowEvent.new(fid, :updated)) # initial scan; hwm = frame 1
+      sleep 120.milliseconds
+      # A burst of >WS_MSG_CAP(200) frames arrives with the secret in frame ~30 — the band a
+      # last-200-window rescan would drop (window would be frames ~52..251).
+      250.times do |k|
+        payload = k == 28 ? "token=AKIAIOSFODNN7EXAMPLE" : "frame#{k}"
+        store.insert_ws_message(fid, "in", 1, payload.to_slice)
+      end
+      feed.send(Gori::Store::FlowEvent.new(fid, :updated)) # one rescan must page the whole backlog
+      sleep 250.milliseconds
+      store.prism_issues.count(&.code.== "secret_in_ws").should eq(1) # the banded secret was caught
+      a.stop
+    end
+  end
+
   it "bumps store.prism_generation on persist and honors session suppress after hard delete" do
     with_store do |store|
       detail = capture_flow(store, "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nServer: x\r\n\r\n",

--- a/spec/prism_spec.cr
+++ b/spec/prism_spec.cr
@@ -312,6 +312,30 @@ describe Gori::Prism::Analyzer do
     end
   end
 
+  it "scans a WebSocket flow FIRST seen with a large backlog from its oldest frame" do
+    with_store do |store|
+      detail = capture_flow(store,
+        "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n",
+        target: "/ws", status: 101, content_type: nil,
+        req_headers: "Upgrade: websocket\r\nConnection: Upgrade\r\n")
+      fid = detail.row.id
+      # A >WS_MSG_CAP backlog already exists before the FIRST scan (the live :updated was dropped
+      # and catch_up picks it up late); the secret is in an OLD frame the last-window would skip.
+      260.times do |k|
+        payload = k == 20 ? "token=AKIAIOSFODNN7EXAMPLE" : "frame#{k}"
+        store.insert_ws_message(fid, "in", 1, payload.to_slice)
+      end
+      scope = Gori::Scope.load(store)
+      feed = Channel(Gori::Store::FlowEvent).new(8)
+      a = Gori::Prism::Analyzer.new(store, scope, feed, Gori::Prism::Mode::Passive, true)
+      a.start
+      feed.send(Gori::Store::FlowEvent.new(fid, :updated)) # first scan pages the whole backlog from frame 1
+      sleep 250.milliseconds
+      store.prism_issues.count(&.code.== "secret_in_ws").should eq(1)
+      a.stop
+    end
+  end
+
   it "bumps store.prism_generation on persist and honors session suppress after hard delete" do
     with_store do |store|
       detail = capture_flow(store, "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nServer: x\r\n\r\n",

--- a/spec/prism_spec.cr
+++ b/spec/prism_spec.cr
@@ -205,6 +205,32 @@ describe Gori::Prism::Active do
       line.should_not contain("http://target.com")
     end
   end
+
+  it "normalizes an absolute-form target to origin-form, preserving a query on a PATHLESS URI" do
+    # The authority ends at the first '/', '?' or '#': a pathless absolute-URI carrying a query
+    # must keep it (was collapsed to "/", silently dropping the reflectable surface), and a '/'
+    # that appears only inside the query must not be mistaken for the path.
+    Gori::Prism::Active.origin_form("http://h/p?q=1").should eq("/p?q=1")
+    Gori::Prism::Active.origin_form("http://h?q=1").should eq("/?q=1")
+    Gori::Prism::Active.origin_form("https://h?a=1&b=2").should eq("/?a=1&b=2")
+    Gori::Prism::Active.origin_form("http://h?next=/x").should eq("/?next=/x")
+    Gori::Prism::Active.origin_form("http://h").should eq("/")
+    Gori::Prism::Active.origin_form("/already?x=1").should eq("/already?x=1") # already origin-form
+  end
+
+  it "builds a reflected-param probe for a PATHLESS absolute-form target that carries a query" do
+    with_store do |store|
+      # Captured plaintext forward-proxy flow, absolute-form, empty path + query. Previously
+      # origin_form dropped the query to "/", so plan() found no params and returned nil.
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", scheme: "http", host: "target.com",
+        target: "http://target.com?name=hello", content_type: nil)
+      plan = Gori::Prism::Active.plan(detail).not_nil!
+      plan.params.map(&.name).should eq(["name"])
+      line = String.new(plan.request).each_line.first
+      line.should start_with("GET /?name=")
+      line.should_not contain("http://target.com")
+    end
+  end
 end
 
 describe Gori::Prism::Analyzer do
@@ -870,6 +896,19 @@ describe "Gori::Prism::Active::CorsReflection" do
     end
   end
 
+  it "sends an ORIGIN-FORM request line even for an absolute-form (forward-proxy) CORS flow" do
+    with_store do |store|
+      # Plaintext forward-proxy CORS flow is captured absolute-form; the probe goes DIRECT to the
+      # origin, so its request line must be origin-form or some origins reject it (false negative).
+      cors = capture_flow(store, "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: https://real.test\r\n\r\n",
+        scheme: "http", host: "target.com", target: "http://target.com/api?x=1", content_type: nil)
+      plan = probe.plan(cors).not_nil!
+      line = String.new(plan.request).each_line.first
+      line.should start_with("GET /api?x=1 ")
+      line.should_not contain("http://target.com")
+    end
+  end
+
   it "flags High only when the probe origin is reflected WITH credentials" do
     with_store do |store|
       cors = capture_flow(store, "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: https://real.test\r\n\r\n",
@@ -1148,6 +1187,52 @@ describe "Store bulk Prism dismiss" do
       after = store.prism_issues.to_h { |i| {"#{i.code}@#{i.host}", i.status} }
       after["missing_csp@a.test"].should eq(Gori::Store::Status::FalsePositive) # open on host → muted
       after["missing_hsts@a.test"].should eq(Gori::Store::Status::Confirmed)    # still untouched
+    end
+  end
+end
+
+describe "Store#upsert_prism_issue (title stays consistent with severity)" do
+  # A code whose title is severity-dependent (reflected_param: HTML ⇒ Medium "Reflected
+  # parameter" vs non-HTML ⇒ Low "…(non-HTML context)") merges into one (code, host) group.
+  # The title must track the HIGHEST-severity observation, not stay frozen at first-insert —
+  # otherwise the escalated badge (MED) sits next to a non-HTML (non-exploitable) title.
+  it "adopts the higher-severity title when a group's severity escalates" do
+    with_store do |store|
+      low = Gori::Prism::Detection.new("reflected_param", "active", "ex.test", "https://ex.test/api",
+        "Reflected parameter (non-HTML context)", Gori::Store::Severity::Low, "q")
+      high = Gori::Prism::Detection.new("reflected_param", "active", "ex.test", "https://ex.test/page",
+        "Reflected parameter", Gori::Store::Severity::Medium, "name")
+      store.upsert_prism_issue(low)  # non-HTML seen first
+      store.upsert_prism_issue(high) # HTML on same host escalates the group
+      row = store.prism_issues.find!(&.code.== "reflected_param")
+      row.severity.should eq(Gori::Store::Severity::Medium)
+      row.title.should eq("Reflected parameter") # was frozen at "(non-HTML context)"
+    end
+  end
+
+  it "does not downgrade the title when a later, lower-severity observation merges in" do
+    with_store do |store|
+      high = Gori::Prism::Detection.new("reflected_param", "active", "ex.test", "https://ex.test/page",
+        "Reflected parameter", Gori::Store::Severity::Medium, "name")
+      low = Gori::Prism::Detection.new("reflected_param", "active", "ex.test", "https://ex.test/api",
+        "Reflected parameter (non-HTML context)", Gori::Store::Severity::Low, "q")
+      store.upsert_prism_issue(high)
+      store.upsert_prism_issue(low) # lower severity must not clobber the escalated title
+      row = store.prism_issues.find!(&.code.== "reflected_param")
+      row.severity.should eq(Gori::Store::Severity::Medium)
+      row.title.should eq("Reflected parameter")
+    end
+  end
+
+  it "keeps a fixed-title code's title stable across regroups" do
+    with_store do |store|
+      d1 = Gori::Prism::Detection.new("missing_csp", "headers", "a.test", "https://a.test/1",
+        "Missing Content-Security-Policy", Gori::Store::Severity::Low, nil)
+      d2 = Gori::Prism::Detection.new("missing_csp", "headers", "a.test", "https://a.test/2",
+        "Missing Content-Security-Policy", Gori::Store::Severity::Low, nil)
+      store.upsert_prism_issue(d1)
+      store.upsert_prism_issue(d2)
+      store.prism_issues.find!(&.code.== "missing_csp").title.should eq("Missing Content-Security-Policy")
     end
   end
 end

--- a/spec/prism_spec.cr
+++ b/spec/prism_spec.cr
@@ -261,6 +261,30 @@ describe Gori::Prism::Analyzer do
     end
   end
 
+  it "does not re-count a buffered WebSocket secret on every later frame (incremental rescan)" do
+    with_store do |store|
+      detail = capture_flow(store,
+        "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n",
+        target: "/ws", status: 101, content_type: nil,
+        req_headers: "Upgrade: websocket\r\nConnection: Upgrade\r\n")
+      fid = detail.row.id
+      store.insert_ws_message(fid, "in", 1, "token=AKIAIOSFODNN7EXAMPLE".to_slice) # secret frame
+      scope = Gori::Scope.load(store)
+      feed = Channel(Gori::Store::FlowEvent).new(8)
+      a = Gori::Prism::Analyzer.new(store, scope, feed, Gori::Prism::Mode::Passive, true)
+      a.start
+      feed.send(Gori::Store::FlowEvent.new(fid, :updated)) # initial full scan → detect once
+      sleep 120.milliseconds
+      store.prism_issues.find(&.code.== "secret_in_ws").not_nil!.hit_count.should eq(1_i64)
+      # A later, secret-free frame must NOT re-scan the still-buffered secret frame.
+      store.insert_ws_message(fid, "in", 1, "ping".to_slice)
+      feed.send(Gori::Store::FlowEvent.new(fid, :updated)) # rescan → only the new frame
+      sleep 120.milliseconds
+      store.prism_issues.find(&.code.== "secret_in_ws").not_nil!.hit_count.should eq(1_i64)
+      a.stop
+    end
+  end
+
   it "bumps store.prism_generation on persist and honors session suppress after hard delete" do
     with_store do |store|
       detail = capture_flow(store, "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nServer: x\r\n\r\n",
@@ -1253,6 +1277,26 @@ describe Gori::Prism, "WebSocket + Replay sources" do
       issue = store.prism_issues.find!(&.code.==("tech_server"))
       issue.sample_replay_id.should eq(id)
       issue.sample_flow_id.should be_nil
+    end
+  end
+
+  it "parses request headers from an LF-joined Replay request (normalizes the head to CRLF)" do
+    with_store do |store|
+      # The Replay editor serializes request text with BARE-LF line endings; without CRLF
+      # normalization Http1.parse_headers returns an empty list and every request-side rule
+      # (CORS Origin, Basic auth, request tech) silently misses.
+      req = "POST /login HTTP/1.1\nHost: acme.test\nAuthorization: Basic dXNlcjpwYXNz\n" \
+            "Origin: https://evil.example\n"
+      resp = "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: https://evil.example\r\n" \
+             "Access-Control-Allow-Credentials: true\r\n\r\n"
+      id = store.insert_replay("http://acme.test", req, false, false, nil, 0)
+      store.update_replay_response(id, resp.to_slice, "{}".to_slice, nil, 5_i64)
+      rec = store.replays.find!(&.id.== id)
+      detail = Gori::Prism.detail_from_replay(rec).not_nil!
+      detail.row.method.should eq("POST")
+      codes = Gori::Prism::Passive.analyze(detail).map(&.code)
+      codes.should contain("insecure_basic_auth")  # Authorization header now visible over http
+      codes.should contain("cors_reflected_origin") # Origin header now visible
     end
   end
 

--- a/spec/prism_spec.cr
+++ b/spec/prism_spec.cr
@@ -865,6 +865,90 @@ describe "Gori::Prism::Passive (insecure Basic auth)" do
   end
 end
 
+describe "Gori::Prism::Passive (Round-1 hardening)" do
+  it "resolves duplicate CSP directives first-wins (matches browser enforcement)" do
+    with_store do |store|
+      # First script-src is safe; the duplicate must be IGNORED, so this is not weak.
+      safe = analyze(store, content_type: "text/html", resp_head: "HTTP/1.1 200 OK\r\n" \
+        "Content-Security-Policy: script-src 'self'; script-src 'unsafe-inline'\r\n\r\n")
+      codes_of(safe).should_not contain("weak_csp")
+      # First script-src is unsafe-inline; a later 'self' duplicate must not mask it.
+      weak = analyze(store, content_type: "text/html", resp_head: "HTTP/1.1 200 OK\r\n" \
+        "Content-Security-Policy: script-src 'unsafe-inline'; script-src 'self'\r\n\r\n")
+      codes_of(weak).should contain("weak_csp")
+    end
+  end
+
+  it "suppresses hygiene for sentinel-value and negative-Max-Age deletion cookies" do
+    with_store do |store|
+      # PHP clears cookies with the literal value "deleted" (not empty) + Max-Age=0.
+      php = analyze(store, content_type: "text/html", resp_head: "HTTP/1.1 200 OK\r\n" \
+        "Set-Cookie: PHPSESSID=deleted; Max-Age=0; expires=Thu, 01-Jan-1970 00:00:00 GMT; path=/\r\n\r\n")
+      codes_of(php).should_not contain("cookie_no_secure")
+      codes_of(php).should_not contain("cookie_no_httponly")
+      neg = analyze(store, content_type: "text/html",
+        resp_head: "HTTP/1.1 200 OK\r\nSet-Cookie: sid=; Max-Age=-1\r\n\r\n")
+      codes_of(neg).should_not contain("cookie_no_samesite")
+      # …but a live cookie with a positive Max-Age is still scored.
+      live = analyze(store, content_type: "text/html",
+        resp_head: "HTTP/1.1 200 OK\r\nSet-Cookie: sid=abc; Max-Age=3600\r\n\r\n")
+      codes_of(live).should contain("cookie_no_secure")
+    end
+  end
+
+  it "flags a Basic challenge listed after another scheme in one WWW-Authenticate header" do
+    with_store do |store|
+      dets = analyze(store, scheme: "http", content_type: nil, status: 401,
+        resp_head: "HTTP/1.1 401 Unauthorized\r\nWWW-Authenticate: Negotiate, Basic realm=\"x\"\r\n\r\n")
+      dets.find(&.code.==("insecure_basic_auth")).not_nil!.severity.should eq(Gori::Store::Severity::Medium)
+      none = analyze(store, scheme: "http", content_type: nil, status: 401,
+        resp_head: "HTTP/1.1 401 Unauthorized\r\nWWW-Authenticate: Negotiate, Digest realm=\"x\"\r\n\r\n")
+      codes_of(none).should_not contain("insecure_basic_auth")
+    end
+  end
+
+  it "flags PGP and PKCS#8-encrypted private key blocks (not just RSA/EC)" do
+    with_store do |store|
+      pgp = analyze(store, content_type: "text/html", resp_head: "HTTP/1.1 200 OK\r\n\r\n",
+        body: "-----BEGIN PGP PRIVATE KEY BLOCK-----\nlQOYBF...\n-----END PGP PRIVATE KEY BLOCK-----")
+      pgp.find(&.code.==("secret_in_body")).not_nil!.evidence.should eq("private key block")
+      enc = analyze(store, content_type: "text/html", resp_head: "HTTP/1.1 200 OK\r\n\r\n",
+        body: "-----BEGIN ENCRYPTED PRIVATE KEY-----\nMIIF...\n-----END ENCRYPTED PRIVATE KEY-----")
+      codes_of(enc).should contain("secret_in_body")
+    end
+  end
+
+  it "does not flag a 4-part software version as a private IP but still catches a real leak" do
+    with_store do |store|
+      json = analyze(store, content_type: "application/json",
+        resp_head: "HTTP/1.1 200 OK\r\n\r\n", body: %({"version":"10.0.0.0"}))
+      codes_of(json).should_not contain("private_ip_leak")
+      htmlv = analyze(store, content_type: "text/html",
+        resp_head: "HTTP/1.1 200 OK\r\n\r\n", body: "<span>File version 10.0.1.2</span>")
+      codes_of(htmlv).should_not contain("private_ip_leak")
+      # a genuine private IP after a version-shaped token is still surfaced (scan, not first-match).
+      mixed = analyze(store, content_type: "text/html", resp_head: "HTTP/1.1 200 OK\r\n\r\n",
+        body: "<p>build version 10.0.1.2</p><p>backend at 192.168.1.5</p>")
+      mixed.find(&.code.==("private_ip_leak")).not_nil!.evidence.should eq("192.168.1.5")
+    end
+  end
+
+  it "anchors GraphQL introspection on the result envelope, not raw substrings" do
+    with_store do |store|
+      # An echoed introspection QUERY string carries both tokens but is not a result -> no FP.
+      echoed = analyze(store, content_type: "application/json",
+        resp_head: "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n",
+        body: %({"data":{"savedQuery":"query IntrospectionQuery { __schema { queryType { name } } }"}}))
+      codes_of(echoed).should_not contain("graphql_introspection")
+      # A real introspection envelope is flagged even when queryType is absent from the prefix.
+      env = analyze(store, content_type: "application/json",
+        resp_head: "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n",
+        body: %({"data":{"__schema":{"types":[{"name":"User"}]}}}))
+      codes_of(env).should contain("graphql_introspection")
+    end
+  end
+end
+
 describe "Gori::Prism::Active::CorsReflection" do
   probe = Gori::Prism::Active::CorsReflection.new
 
@@ -1037,6 +1121,7 @@ describe Gori::Prism do
           g.hit_count.to_i64.should eq(s.hit_count)
           g.affected.sort.should eq(s.affected.sort)
           g.evidence.should eq(s.evidence) # first non-nil wins (COALESCE)
+          g.title.should eq(s.title)       # title tracks the same (highest-severity) observation
         end
 
         csp = grouped["missing_csp@a.test"]
@@ -1079,6 +1164,24 @@ describe Gori::Prism do
         Gori::Prism::Detection.new("private_ip_leak", "infoleak", "b.test", "https://b.test/", "t", Gori::Store::Severity::Low, "192.168.0.1"),
       ]
       Gori::Prism.group(ip).find!(&.code.==("private_ip_leak")).evidence.should eq("10.0.0.1")
+    end
+
+    it "adopts the higher-severity title on escalation, staying consistent with the store" do
+      with_store do |store|
+        low = Gori::Prism::Detection.new("reflected_param", "active", "ex.test", "https://ex.test/api",
+          "Reflected parameter (non-HTML context)", Gori::Store::Severity::Low, "q")
+        high = Gori::Prism::Detection.new("reflected_param", "active", "ex.test", "https://ex.test/page",
+          "Reflected parameter", Gori::Store::Severity::Medium, "name")
+        dets = [low, high] # non-HTML first, then HTML escalates
+        g = Gori::Prism.group(dets).find!(&.code.== "reflected_param")
+        g.severity.should eq(Gori::Store::Severity::Medium)
+        g.title.should eq("Reflected parameter") # not frozen at "(non-HTML context)"
+        # and the headless group matches what the store persists for the same detections
+        dets.each { |d| store.upsert_prism_issue(d) }
+        stored = store.prism_issues.find!(&.code.== "reflected_param")
+        g.title.should eq(stored.title)
+        g.severity.should eq(stored.severity)
+      end
     end
 
     it "tags the same code on different hosts as separate groups" do

--- a/spec/tui/prism_view_spec.cr
+++ b/spec/tui/prism_view_spec.cr
@@ -152,4 +152,64 @@ describe Gori::Tui::PrismView do
       view.target_issue.not_nil!.id.should eq(second.id)
     end
   end
+
+  it "bulk-dismiss-by-code respects the scope lens (mutes only in-scope hosts)" do
+    view_store do |store|
+      seed(store, "missing_hsts", "a.test") # in scope
+      seed(store, "missing_hsts", "b.test") # out of scope
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "a.test")
+      scope.enable
+      view = Gori::Tui::PrismView.new
+      view.set_scope(scope)
+      view.reload(store)
+      view.dismiss_by_code(store).should eq(1) # only the in-scope host counted…
+      store.prism_issues.find! { |i| i.host == "b.test" }.status.open?.should be_true            # …and muted
+      store.prism_issues.find! { |i| i.host == "a.test" }.status.false_positive?.should be_true
+    end
+  end
+
+  it "bulk-dismiss-by-code mutes every host when the scope lens is off" do
+    view_store do |store|
+      seed(store, "missing_hsts", "a.test")
+      seed(store, "missing_hsts", "b.test")
+      view = Gori::Tui::PrismView.new
+      view.reload(store)
+      view.dismiss_by_code(store).should eq(2)
+      store.prism_issues.select(&.code.== "missing_hsts").all?(&.status.false_positive?).should be_true
+    end
+  end
+
+  it "delete_by_id removes the chosen issue even after the selection has moved" do
+    view_store do |store|
+      seed(store, "missing_hsts", "a.test")
+      seed(store, "missing_csp", "a.test")
+      view = Gori::Tui::PrismView.new
+      view.reload(store)
+      chosen = view.target_issue.not_nil!
+      view.move(1) # selection now points at the OTHER issue
+      view.target_issue.not_nil!.id.should_not eq(chosen.id)
+      view.delete_by_id(store, chosen.id) # deletes the captured id, not the current selection
+      store.prism_issues.map(&.id).should_not contain(chosen.id)
+      store.prism_issues.size.should eq(1)
+    end
+  end
+
+  it "keeps the MODE chip visible on a narrow band when all severities are present" do
+    view_store do |store|
+      sevs = [Gori::Store::Severity::Info, Gori::Store::Severity::Low, Gori::Store::Severity::Medium,
+              Gori::Store::Severity::High, Gori::Store::Severity::Critical]
+      sevs.each_with_index do |sv, si|
+        20.times do |k|
+          store.upsert_prism_issue(Gori::Prism::Detection.new("c#{si}x#{k}", "headers",
+            "h#{si}-#{k}.test", "https://h/", "t", sv))
+        end
+      end
+      view = Gori::Tui::PrismView.new
+      view.reload(store)
+      b = MemoryBackend.new(30, 20) # narrow: tallies would otherwise overpaint the mode chip
+      view.render(Gori::Tui::Screen.new(b), Gori::Tui::Rect.new(0, 0, 30, 20))
+      b.row(0).should contain("m:PASSIVE") # the mode chip text survives intact
+    end
+  end
 end

--- a/src/gori/prism/active/cors_reflection.cr
+++ b/src/gori/prism/active/cors_reflection.cr
@@ -67,8 +67,16 @@ module Gori
           lines = String.new(hbytes).split(eol)
           kept = [] of String
           lines.each_with_index do |l, i|
-            next if i > 0 && origin_header?(l) # keep the request line (i == 0) verbatim
+            next if i > 0 && origin_header?(l) # the request line (i == 0) is normalized below
             kept << l
+          end
+          # Normalize an absolute-form (forward-proxy) request line to origin-form: like the
+          # ReflectedParam probe, this is sent DIRECT to the origin (no proxy rewrite), and some
+          # origins reject an absolute-form target on a non-proxied request — which would make the
+          # CORS probe silently miss a real arbitrary-origin reflection. Origin-form passes through.
+          unless kept.empty?
+            rl = kept[0].split(' ')
+            kept[0] = "#{rl[0]} #{Active.origin_form(rl[1])} #{rl[2]}" if rl.size == 3
           end
           kept.insert(1, "Origin: #{origin}") unless kept.empty?
           io = IO::Memory.new
@@ -84,16 +92,9 @@ module Gori
         # Dedup path: origin-form target with the query stripped (a CORS policy is per-endpoint,
         # not per-query-value), so one probe per (host, method, path).
         private def path_key(target : String) : String
-          t = origin_form(target)
+          t = Active.origin_form(target)
           qi = t.index('?')
           qi ? t[0...qi] : t
-        end
-
-        private def origin_form(target : String) : String
-          return target unless target.starts_with?("http://") || target.starts_with?("https://")
-          se = target.index("://") || return target
-          slash = target.index('/', se + 3)
-          slash ? target[slash..] : "/"
         end
       end
     end

--- a/src/gori/prism/active/reflected_param.cr
+++ b/src/gori/prism/active/reflected_param.cr
@@ -25,7 +25,7 @@ module Gori
           # probe is sent DIRECT to the origin (Fuzz::Sender → Replay::Engine, no rewrite),
           # so normalize to origin-form here the way the regular replay path (FlowRequest)
           # does — some origins reject an absolute-form target on a non-proxied request.
-          path, query = split_target(origin_form(req.target))
+          path, query = split_target(Active.origin_form(req.target))
 
           params = [] of Param
           new_query, qp = canary_pairs(query, "query")
@@ -94,15 +94,6 @@ module Gori
           (Proxy::Codec::Http1.parse_response_head(result.head).headers.get?("Content-Type") || "").downcase
         rescue
           ""
-        end
-
-        # Strip a scheme://authority prefix so an absolute-form (forward-proxy) target becomes
-        # origin-form; an already-origin-form target passes through unchanged.
-        private def origin_form(target : String) : String
-          return target unless target.starts_with?("http://") || target.starts_with?("https://")
-          scheme_end = target.index("://") || return target
-          slash = target.index('/', scheme_end + 3)
-          slash ? target[slash..] : "/"
         end
 
         # {path, query-without-'?'} — query is "" when the target has none.

--- a/src/gori/prism/active/types.cr
+++ b/src/gori/prism/active/types.cr
@@ -24,6 +24,21 @@ module Gori
       # the analyzer uses to probe each (rule, host, method, path, param-set) only once.
       record Plan, request : Bytes, params : Array(Param), dedup_key : String
 
+      # Strip a scheme://authority prefix so an absolute-form (forward-proxy) target becomes
+      # origin-form; an already-origin-form target passes through unchanged. The authority
+      # ends at the FIRST '/', '?', or '#', so a pathless absolute-URI carrying a query
+      # ("http://h?q=v") normalizes to "/?q=v" — the query (and its reflectable params) is
+      # preserved, not silently dropped to "/" — and a '/' that appears only INSIDE the query
+      # ("http://h?next=/x") is never mistaken for the start of the path.
+      def self.origin_form(target : String) : String
+        return target unless target.starts_with?("http://") || target.starts_with?("https://")
+        scheme_end = target.index("://") || return target
+        rest = target[(scheme_end + 3)..]
+        cut = rest.index(/[\/?#]/) || return "/"
+        seg = rest[cut..]
+        seg.starts_with?('/') ? seg : "/#{seg}"
+      end
+
       # An active rule: build a probe for one flow (nil if nothing to test), then turn the
       # probe's response into Detections. The analyzer owns the send between the two calls.
       abstract class Rule

--- a/src/gori/prism/analyzer.cr
+++ b/src/gori/prism/analyzer.cr
@@ -25,6 +25,8 @@ module Gori
       ACTIVE_TIMEOUT   = 10.seconds # per-probe socket timeout
       ACTIVE_BACKFILL  =    300     # recent History rows to re-arm when Active is enabled
       WS_MSG_CAP       =    200     # max WS messages loaded per flow for passive scan
+      CATCHUP_INTERVAL = 30.seconds # how often the passive catch-up sweep runs
+      CATCHUP_SCAN     =    500     # recent flows the catch-up sweep re-checks each tick
 
       getter events : Channel(Event)
 
@@ -82,6 +84,7 @@ module Gori
         load_suppressions
         spawn(name: "gori-prism") { passive_loop }
         spawn(name: "gori-prism-active") { active_loop }
+        spawn(name: "gori-prism-catchup") { catch_up_loop }
         # Project already set to Active (persisted) — probe recent in-scope History now,
         # not only traffic that arrives after this open.
         arm_active_backfill if @mode.active?
@@ -135,9 +138,11 @@ module Gori
             next unless detail
             @analyzed << ev.id
             trim(@analyzed, ANALYZED_CAP)
-            ws = load_ws(detail)
-            scan_detail(detail, ws_messages: ws, enqueue_active: true)
-            note_ws_scanned(detail.row.id, ws) # mark these frames scanned so rescans stay incremental
+            # HTTP/non-WS rules run once here; WS payloads are ALWAYS handled by the hwm-gated,
+            # gap-free rescan_ws so a 101 flow evicted from @analyzed and re-scanned (or one with a
+            # backlog > WS_MSG_CAP) never re-detects already-scanned frames or skips a band of them.
+            scan_detail(detail, enqueue_active: true)
+            rescan_ws(ev.id) if detail.row.status == 101
           rescue DB::Error | SQLite3::Exception
             # A transient store error (e.g. SQLITE_BUSY) must NOT kill the scanner for the rest
             # of the session — skip this flow and keep draining. On real shutdown the input
@@ -149,41 +154,69 @@ module Gori
         # input closed during shutdown — exit quietly
       end
 
-      # Re-scan ONLY the WS frames that arrived since the last scan. InsertWs republishes
-      # :updated on every frame, so scanning the whole (last-WS_MSG_CAP) buffer each time would
-      # re-detect a secret still buffered from an earlier frame — inflating its hit_count by 1
-      # per frame and re-running the regex over ×200 messages on every frame (O(n²) per socket).
-      # The per-flow high-water-mark keeps each frame scanned exactly once.
+      # Periodic catch-up for the LOSSY passive feed. Store#publish sends each flow's :updated to
+      # the bounded prism_events channel NON-blockingly (drop on full), and for a plain HTTP flow
+      # that lone :updated is its only trigger — a burst that overflows the channel makes
+      # passive_loop never see the flow, and nothing else re-scans captured flows (active_backfill
+      # re-arms ACTIVE probes only). This sweep re-checks recent flows and scans any the live path
+      # missed. @analyzed dedups, so a steady state where everything was delivered costs only a set
+      # lookup per row (no get_flow). Exits when the analyzer stops.
+      private def catch_up_loop : Nil
+        until @stopped
+          sleep CATCHUP_INTERVAL
+          catch_up
+        end
+      end
+
+      private def catch_up : Nil
+        return if @stopped
+        return unless @mode.scanning?
+        @store.recent_flows(CATCHUP_SCAN).each do |row|
+          break if @stopped || !@mode.scanning?
+          next if @analyzed.includes?(row.id)
+          next unless row.state.complete?
+          detail = @store.get_flow(row.id)
+          next unless detail && detail.response_head
+          @analyzed << row.id
+          trim(@analyzed, ANALYZED_CAP)
+          scan_detail(detail, enqueue_active: true)
+          rescan_ws(row.id) if detail.row.status == 101
+        end
+      rescue DB::Error | SQLite3::Exception
+      rescue Channel::ClosedError
+      end
+
+      # Scan the WS frames a 101 flow has accumulated since the last scan — each frame exactly
+      # once. InsertWs republishes :updated on every frame, so re-scanning the whole buffer each
+      # time would re-detect a still-buffered secret (inflating hit_count) and re-run the regex
+      # over ×WS_MSG_CAP messages per frame. The per-flow high-water-mark PAGES FORWARD from the
+      # last scanned id: with a hwm it reads the OLDEST unscanned frames (so a >WS_MSG_CAP backlog
+      # from a dropped-event burst is covered without skipping a band, and an evicted-then-re-
+      # scanned flow doesn't re-detect old frames); the first pass (no hwm) reads the last window.
       private def rescan_ws(flow_id : Int64) : Nil
         detail = @store.get_flow(flow_id)
         return unless detail
         return unless detail.row.status == 101
-        msgs = @store.ws_messages(flow_id, WS_MSG_CAP)
-        return if msgs.empty?
-        hwm = @ws_hwm[flow_id]?
-        fresh = hwm ? msgs.select { |m| m.id > hwm } : msgs
-        note_ws_scanned(flow_id, msgs) # advance past ALL loaded ids (ordered asc → last is max)
-        return if fresh.empty?
-        detections = Passive.analyze_ws(detail, fresh)
-        persist(detections, flow_id: flow_id, replay_id: nil)
+        loop do
+          hwm = @ws_hwm[flow_id]?
+          msgs = hwm ? @store.ws_messages_after(flow_id, hwm, WS_MSG_CAP) : @store.ws_messages(flow_id, WS_MSG_CAP)
+          break if msgs.empty?
+          note_ws_scanned(flow_id, msgs) # ordered asc → advance the hwm to the last id in the batch
+          detections = Passive.analyze_ws(detail, msgs)
+          persist(detections, flow_id: flow_id, replay_id: nil)
+          break if msgs.size < WS_MSG_CAP # fewer than a full page ⇒ backlog drained
+        end
       rescue DB::Error | SQLite3::Exception
       rescue
       end
 
-      # Record the newest ws_message id scanned for a flow so future rescans skip it. Bounded
+      # Advance the newest ws_message id scanned for a flow so future rescans page past it. Bounded
       # like @analyzed (only 101 flows ever get an entry, but cap it for long-lived projects).
       private def note_ws_scanned(flow_id : Int64, msgs : Array(Store::WsMessage)) : Nil
         return if msgs.empty?
         @ws_hwm[flow_id] = msgs.max_of(&.id)
         return if @ws_hwm.size <= ANALYZED_CAP
         @ws_hwm.keys.first(@ws_hwm.size - ANALYZED_CAP).each { |k| @ws_hwm.delete(k) }
-      end
-
-      private def load_ws(detail : Store::FlowDetail) : Array(Store::WsMessage)
-        return [] of Store::WsMessage unless detail.row.status == 101
-        @store.ws_messages(detail.row.id, WS_MSG_CAP)
-      rescue
-        [] of Store::WsMessage
       end
 
       private def persist(detections : Array(Detection), *, flow_id : Int64, replay_id : Int64?) : Nil
@@ -265,13 +298,17 @@ module Gori
       end
 
       private def run_active(task : ActiveTask) : Nil
-        # Don't fire outbound probes while winding down (@stopped) OR after the operator left
-        # Active mode. set_mode(Passive/Off) flips @mode but can't unqueue tasks already sitting
-        # in @active_jobs (up to ACTIVE_QUEUE deep); the enqueue side (maybe_enqueue_active /
-        # active_backfill) only gates NEW work, so the consumer MUST re-check the live mode too —
-        # otherwise buffered canary/CORS probes keep hitting the target for the minutes it takes
-        # the single worker to drain the backlog, violating the "Off ⇒ no probing" mode contract.
-        return if @stopped || !@mode.active?
+        return if @stopped # winding down: don't fire outbound probes (or touch a closing store)
+        # After the operator left Active mode, set_mode(Passive/Off) can't unqueue tasks already
+        # sitting in @active_jobs (up to ACTIVE_QUEUE deep) — the enqueue side only gates NEW work
+        # — so the consumer MUST re-check the live mode, or buffered canary/CORS probes keep hitting
+        # the target after Active was turned off. RELEASE the dedup key when dropping for this
+        # reason: it was recorded at enqueue, and keeping it would suppress the surface forever if
+        # Active is re-enabled (arm_active_backfill would skip it as already-seen).
+        unless @mode.active?
+          @active_seen.delete(task.plan.dedup_key)
+          return
+        end
         row = task.detail.row
         origin = Fuzz::Origin.new(row.scheme, row.host, row.port)
         http2 = task.detail.http_version.starts_with?("HTTP/2")

--- a/src/gori/prism/analyzer.cr
+++ b/src/gori/prism/analyzer.cr
@@ -245,7 +245,13 @@ module Gori
       end
 
       private def run_active(task : ActiveTask) : Nil
-        return if @stopped # don't fire outbound probes while winding down
+        # Don't fire outbound probes while winding down (@stopped) OR after the operator left
+        # Active mode. set_mode(Passive/Off) flips @mode but can't unqueue tasks already sitting
+        # in @active_jobs (up to ACTIVE_QUEUE deep); the enqueue side (maybe_enqueue_active /
+        # active_backfill) only gates NEW work, so the consumer MUST re-check the live mode too —
+        # otherwise buffered canary/CORS probes keep hitting the target for the minutes it takes
+        # the single worker to drain the backlog, violating the "Off ⇒ no probing" mode contract.
+        return if @stopped || !@mode.active?
         row = task.detail.row
         origin = Fuzz::Origin.new(row.scheme, row.host, row.port)
         http2 = task.detail.http_version.starts_with?("HTTP/2")

--- a/src/gori/prism/analyzer.cr
+++ b/src/gori/prism/analyzer.cr
@@ -197,9 +197,13 @@ module Gori
         detail = @store.get_flow(flow_id)
         return unless detail
         return unless detail.row.status == 101
+        # Page forward from the high-water-mark (0 on the first scan) through EVERY unscanned
+        # frame in WS_MSG_CAP-sized batches. Starting from the OLDEST unscanned id — not the last
+        # window — means a flow first scanned late (e.g. via catch_up) with a large buffered
+        # backlog is still covered from frame 1, never skipping a band.
         loop do
-          hwm = @ws_hwm[flow_id]?
-          msgs = hwm ? @store.ws_messages_after(flow_id, hwm, WS_MSG_CAP) : @store.ws_messages(flow_id, WS_MSG_CAP)
+          after = @ws_hwm[flow_id]? || 0_i64
+          msgs = @store.ws_messages_after(flow_id, after, WS_MSG_CAP)
           break if msgs.empty?
           note_ws_scanned(flow_id, msgs) # ordered asc → advance the hwm to the last id in the batch
           detections = Passive.analyze_ws(detail, msgs)
@@ -214,6 +218,10 @@ module Gori
       # like @analyzed (only 101 flows ever get an entry, but cap it for long-lived projects).
       private def note_ws_scanned(flow_id : Int64, msgs : Array(Store::WsMessage)) : Nil
         return if msgs.empty?
+        # delete + re-insert moves this flow to the END of the insertion order (LRU): trimming
+        # drops the OLDEST-touched keys first, so a long-lived, still-active socket is never
+        # evicted ahead of idle ones (a plain reassign keeps its original, front-most position).
+        @ws_hwm.delete(flow_id)
         @ws_hwm[flow_id] = msgs.max_of(&.id)
         return if @ws_hwm.size <= ANALYZED_CAP
         @ws_hwm.keys.first(@ws_hwm.size - ANALYZED_CAP).each { |k| @ws_hwm.delete(k) }

--- a/src/gori/prism/analyzer.cr
+++ b/src/gori/prism/analyzer.cr
@@ -33,6 +33,7 @@ module Gori
       def initialize(@store : Store, @scope : Scope, @input : Channel(Store::FlowEvent),
                      @mode : Mode, @verify_upstream : Bool)
         @analyzed = Set(Int64).new
+        @ws_hwm = {} of Int64 => Int64 # per-101-flow high-water-mark: max ws_message id already scanned
         @active_seen = Set(String).new
         @active_error_hosts = Set(String).new # rate-limit probe-failure notifications per host
         @suppressed = Set(String).new         # "code|host" hard-deleted this session
@@ -136,6 +137,7 @@ module Gori
             trim(@analyzed, ANALYZED_CAP)
             ws = load_ws(detail)
             scan_detail(detail, ws_messages: ws, enqueue_active: true)
+            note_ws_scanned(detail.row.id, ws) # mark these frames scanned so rescans stay incremental
           rescue DB::Error | SQLite3::Exception
             # A transient store error (e.g. SQLITE_BUSY) must NOT kill the scanner for the rest
             # of the session — skip this flow and keep draining. On real shutdown the input
@@ -147,16 +149,34 @@ module Gori
         # input closed during shutdown — exit quietly
       end
 
+      # Re-scan ONLY the WS frames that arrived since the last scan. InsertWs republishes
+      # :updated on every frame, so scanning the whole (last-WS_MSG_CAP) buffer each time would
+      # re-detect a secret still buffered from an earlier frame — inflating its hit_count by 1
+      # per frame and re-running the regex over ×200 messages on every frame (O(n²) per socket).
+      # The per-flow high-water-mark keeps each frame scanned exactly once.
       private def rescan_ws(flow_id : Int64) : Nil
         detail = @store.get_flow(flow_id)
         return unless detail
         return unless detail.row.status == 101
         msgs = @store.ws_messages(flow_id, WS_MSG_CAP)
         return if msgs.empty?
-        detections = Passive.analyze_ws(detail, msgs)
+        hwm = @ws_hwm[flow_id]?
+        fresh = hwm ? msgs.select { |m| m.id > hwm } : msgs
+        note_ws_scanned(flow_id, msgs) # advance past ALL loaded ids (ordered asc → last is max)
+        return if fresh.empty?
+        detections = Passive.analyze_ws(detail, fresh)
         persist(detections, flow_id: flow_id, replay_id: nil)
       rescue DB::Error | SQLite3::Exception
       rescue
+      end
+
+      # Record the newest ws_message id scanned for a flow so future rescans skip it. Bounded
+      # like @analyzed (only 101 flows ever get an entry, but cap it for long-lived projects).
+      private def note_ws_scanned(flow_id : Int64, msgs : Array(Store::WsMessage)) : Nil
+        return if msgs.empty?
+        @ws_hwm[flow_id] = msgs.max_of(&.id)
+        return if @ws_hwm.size <= ANALYZED_CAP
+        @ws_hwm.keys.first(@ws_hwm.size - ANALYZED_CAP).each { |k| @ws_hwm.delete(k) }
       end
 
       private def load_ws(detail : Store::FlowDetail) : Array(Store::WsMessage)

--- a/src/gori/prism/from_replay.cr
+++ b/src/gori/prism/from_replay.cr
@@ -21,9 +21,14 @@ module Gori
                      n = req_text[sep, 4]? == "\r\n\r\n" ? 4 : 2
                      req_text[(sep + n)..]?
                    end
-      # Ensure the head ends with a blank line so Http1.parse_request_head is happy.
-      req_head_bytes = (req_head_s.ends_with?("\r\n\r\n") || req_head_s.ends_with?("\n\n") ?
-        req_head_s : "#{req_head_s.rstrip}\r\n\r\n").to_slice
+      # The Replay editor serializes request text with BARE-LF line endings, but
+      # Http1.parse_headers recognizes only CRLF: without normalizing the internal separators,
+      # the first CRLF found is the appended terminator, so parse_headers starts at the blank
+      # line and returns an EMPTY header list — every request-side rule (CORS Origin, Basic
+      # auth, request tech fingerprints) then silently misses on Replay/CLI/MCP-sourced scans.
+      # Normalize LF→CRLF, then ensure the head ends with a blank line for parse_request_head.
+      head_crlf = req_head_s.gsub(/\r?\n/, "\r\n")
+      req_head_bytes = (head_crlf.ends_with?("\r\n\r\n") ? head_crlf : "#{head_crlf.rstrip}\r\n\r\n").to_slice
       req_body = req_body_s.try { |b| b.empty? ? nil : b.to_slice }
 
       req = Proxy::Codec::Http1.parse_request_head(req_head_bytes)

--- a/src/gori/prism/group.cr
+++ b/src/gori/prism/group.cr
@@ -41,11 +41,16 @@ module Gori
           # size check first so a full list short-circuits the O(n) includes? scan.
           urls << d.url if urls.size < cap && !urls.includes?(d.url)
           sev = g.severity.value >= d.severity.value ? g.severity : d.severity
+          # Title tracks the highest-severity observation (mirrors Store#upsert_prism_issue):
+          # adopt the incoming title only when it RAISES severity, so an escalated group never
+          # shows a lower-severity title (reflected_param: non-HTML Low vs HTML Medium). A
+          # fixed-title code is unaffected.
+          title = d.severity.value > g.severity.value ? d.title : g.title
           # Type-labeled infoleak codes accumulate every distinct type seen (so a body
           # or host leaking several secret/error types surfaces them all); others keep
           # the first representative sample. Mirrors Store#upsert_prism_issue.
           evidence = accumulate_evidence?(d.code) ? merge_evidence(g.evidence, d.evidence) : (g.evidence || d.evidence)
-          acc[key] = Group.new(g.code, g.category, g.host, g.title, sev, g.hit_count + 1,
+          acc[key] = Group.new(g.code, g.category, g.host, title, sev, g.hit_count + 1,
             urls, evidence, g.sample_flow_id, g.sample_replay_id)
         else
           acc[key] = Group.new(d.code, d.category, d.host, d.title, d.severity, 1,

--- a/src/gori/prism/passive/auth.cr
+++ b/src/gori/prism/passive/auth.cr
@@ -23,10 +23,18 @@ module Gori
           end
 
           return unless resp = ctx.response
-          if resp.headers.get_all("WWW-Authenticate").any? { |v| basic?(v) }
+          if resp.headers.get_all("WWW-Authenticate").any? { |v| offers_basic?(v) }
             acc << det(ctx, "HTTP Basic authentication challenged over cleartext HTTP",
               Store::Severity::Medium, "WWW-Authenticate: Basic")
           end
+        end
+
+        # A WWW-Authenticate header may list several comma-separated challenges
+        # ("Negotiate, Basic realm=…"); Basic counts if it is the scheme of ANY of them, not only
+        # the first. (Auth-param values can also carry commas, but a real Basic challenge's scheme
+        # token still opens one of the comma segments.)
+        private def offers_basic?(value : String) : Bool
+          value.split(',').any? { |seg| basic?(seg) }
         end
 
         # An auth header/challenge whose scheme token is `Basic` (case-insensitive, leading

--- a/src/gori/prism/passive/body_leaks.cr
+++ b/src/gori/prism/passive/body_leaks.cr
@@ -67,9 +67,16 @@ module Gori
           text = ctx.body_text
           return if text.nil? || text.empty?
           # Private-IP scan skips script/style payloads, where dotted version strings dominate
-          # and produce the bulk of the false positives.
-          if !scripty?(ctx.content_type) && (m = PRIVATE_IP.match(text))
-            acc << leak(ctx, "private_ip_leak", "Private IP address disclosed", Store::Severity::Low, m[0])
+          # and produce the bulk of the false positives. A 4-part software/assembly version
+          # (e.g. "File version 10.0.1.2", {"version":"10.0.0.0"}) also collides with 10.0.0.0/8,
+          # so skip a candidate immediately preceded by a version-context word and report the
+          # first genuine (non-version) private IP instead.
+          if !scripty?(ctx.content_type)
+            text.scan(PRIVATE_IP) do |m|
+              next if version_context?(m.pre_match)
+              acc << leak(ctx, "private_ip_leak", "Private IP address disclosed", Store::Severity::Low, m[0])
+              break
+            end
           end
           # Report EVERY distinct error-signature / secret TYPE present, not just the
           # first: a body leaking both a Java exception and a Go panic (or an AWS key
@@ -108,6 +115,16 @@ module Gori
           return false if ctype.nil?
           low = ctype.downcase
           low.includes?("javascript") || low.includes?("ecmascript") || low.includes?("css")
+        end
+
+        # True when a private-IP candidate is really a software/assembly VERSION: a version word
+        # sits immediately before it (within a short window of the text preceding the match), e.g.
+        # `File version 10.0.1.2` or `{"version":"10.0.0.0"}`. Keeps a genuine leak (`backend at
+        # 10.0.0.5`) flagged while dropping the ubiquitous 4-part-version false positive.
+        private def version_context?(pre : String) : Bool
+          tail = (pre.size > 24 ? pre[(pre.size - 24)..] : pre).downcase
+          tail.includes?("version") || tail.includes?("build") || tail.includes?("assembly") ||
+            tail.includes?("revision") || tail.includes?("firmware")
         end
       end
     end

--- a/src/gori/prism/passive/body_leaks.cr
+++ b/src/gori/prism/passive/body_leaks.cr
@@ -73,7 +73,11 @@ module Gori
           # first genuine (non-version) private IP instead.
           if !scripty?(ctx.content_type)
             text.scan(PRIVATE_IP) do |m|
-              next if version_context?(m.pre_match)
+              # Only the few chars BEFORE the match decide version-context; slice a bounded window
+              # off the match index rather than m.pre_match (which allocates the whole prefix — over
+              # a body full of version-shaped candidates that is O(n²) transient memory).
+              start = m.begin(0) || 0
+              next if version_context?(text[{start - 24, 0}.max...start])
               acc << leak(ctx, "private_ip_leak", "Private IP address disclosed", Store::Severity::Low, m[0])
               break
             end

--- a/src/gori/prism/passive/cookies.cr
+++ b/src/gori/prism/passive/cookies.cr
@@ -18,8 +18,6 @@ module Gori
         HOST_PREFIX   = "__Host-"
         SECURE_PREFIX = "__Secure-"
 
-        MAX_AGE_ZERO = /\Amax-age\s*=\s*0+\z/
-
         def check(ctx : Context, acc : Array(Detection)) : Nil
           return unless resp = ctx.response
           resp.headers.get_all("Set-Cookie").each do |raw|
@@ -54,11 +52,23 @@ module Gori
           end
         end
 
-        # True for a cookie being cleared: empty value AND a deletion marker (Max-Age=0 or an
-        # Expires attribute — a live cookie sets neither with an empty value).
+        # True for a cookie being cleared (no secret to protect, so its missing flags are noise):
+        #   * Max-Age <= 0 is an UNCONDITIONAL delete regardless of value — a live cookie never
+        #     sets it, and frameworks clear with a sentinel value (PHP emits `sid=deleted;
+        #     Max-Age=0`), so requiring an empty value would miss the common logout pattern.
+        #   * Otherwise, an EMPTY value paired with an Expires attribute is the classic clear.
         private def deletion?(value : String, flags : Array(String)) : Bool
-          return false unless value.empty?
-          flags.any? { |f| MAX_AGE_ZERO.matches?(f) || f.starts_with?("expires=") }
+          return true if flags.any? { |f| max_age_delete?(f) }
+          value.empty? && flags.any?(&.starts_with?("expires="))
+        end
+
+        # Max-Age with a non-positive value (0 or negative) — an immediate deletion (RFC 6265).
+        # `flag` is already stripped + lowercased.
+        private def max_age_delete?(flag : String) : Bool
+          return false unless flag.starts_with?("max-age")
+          eq = flag.index('=') || return false
+          n = flag[(eq + 1)..].strip.to_i64?
+          !n.nil? && n <= 0
         end
 
         # Validate a __Host-/__Secure- prefixed cookie against its browser-enforced rules;

--- a/src/gori/prism/passive/graphql.cr
+++ b/src/gori/prism/passive/graphql.cr
@@ -9,6 +9,15 @@ module Gori
       # usually meant to be disabled in production. Detected passively from a captured response
       # that already carries an introspection result; zero-request, response-gated.
       class GraphqlIntrospection < Rule
+        # The introspection RESULT envelope is `{"data":{"__schema":{…}}}`, i.e. `__schema` as a
+        # quoted JSON KEY opening an object. Anchoring on `"__schema":{`:
+        #   * rejects a response that merely ECHOES an introspection QUERY string (there `__schema`
+        #     appears unquoted as ` __schema {`), the common false positive, and a stray
+        #     "__schema" doc mention;
+        #   * sits at the very START of the body, so it survives the 64 KiB body-prefix cap no
+        #     matter how large the `types` array is — no longer needs `queryType` to also fit.
+        INTROSPECTION_RESULT = /"__schema"\s*:\s*\{/
+
         def check(ctx : Context, acc : Array(Detection)) : Nil
           return unless ctx.response
           # An introspection result is JSON (some servers label it application/graphql-response
@@ -17,11 +26,7 @@ module Gori
           return unless ct.nil? || ct.includes?("json") || ct.includes?("graphql")
           text = ctx.body_text
           return if text.nil? || text.empty?
-          # The reserved introspection fields `__schema` AND `queryType` together are conclusive.
-          # Requiring both keeps a stray "__schema" mention (docs, a schema-registry blob) out —
-          # the introspection envelope is `{"data":{"__schema":{"queryType":…,"types":[…]}}}`, so
-          # both markers sit at the very start and survive the body-prefix cap.
-          return unless text.includes?("__schema") && text.includes?("queryType")
+          return unless INTROSPECTION_RESULT.matches?(text)
           acc << Detection.new("graphql_introspection", Category::INFOLEAK, ctx.host, ctx.url,
             "GraphQL introspection enabled (full schema exposed)", Store::Severity::Medium,
             "introspection response", ctx.fid)

--- a/src/gori/prism/passive/secrets.cr
+++ b/src/gori/prism/passive/secrets.cr
@@ -15,7 +15,7 @@ module Gori
           {/\b(?:sk|rk)_live_[0-9A-Za-z]{20,}\b/, "Stripe secret key"},
           {/\bSG\.[\w\-]{16,}\.[\w\-]{16,}\b/, "SendGrid API key"},
           {/\bnpm_[0-9A-Za-z]{36}\b/, "npm access token"},
-          {/-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----/, "private key block"},
+          {/-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP |ENCRYPTED )?PRIVATE KEY(?: BLOCK)?-----/, "private key block"},
         ]
       end
     end

--- a/src/gori/prism/passive/security_headers.cr
+++ b/src/gori/prism/passive/security_headers.cr
@@ -50,13 +50,16 @@ module Gori
           end
         end
 
-        # Parse a CSP into {directive => [sources]}, all lowercased.
+        # Parse a CSP into {directive => [sources]}, all lowercased. A directive repeated within
+        # one policy is FIRST-wins (CSP3 "parse a serialized CSP": a duplicate directive name is
+        # ignored) — mirror what the browser enforces, so `script-src 'self'; script-src
+        # 'unsafe-inline'` is judged on the first, safe `script-src` (not the last).
         private def parse_csp(csp : String) : Hash(String, Array(String))
           dirs = {} of String => Array(String)
           csp.split(';').each do |segment|
             toks = segment.strip.downcase.split(/\s+/).reject(&.empty?)
             next if toks.empty?
-            dirs[toks[0]] = toks[1..]
+            dirs[toks[0]] ||= toks[1..]
           end
           dirs
         end

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -1156,6 +1156,23 @@ module Gori
       msgs
     end
 
+    # Frames on a flow with id AFTER `after_id`, OLDEST-first, up to `limit`. Lets the Prism WS
+    # rescan page forward from its per-flow high-water-mark and cover every frame exactly once,
+    # even when more than a full window accumulated unscanned (a dropped-event burst) or the flow
+    # was evicted from the analyzed-set and re-scanned.
+    def ws_messages_after(flow_id : Int64, after_id : Int64, limit : Int32) : Array(WsMessage)
+      msgs = [] of WsMessage
+      cols = "id, flow_id, replay_id, created_at, direction, opcode, payload"
+      @db.query("SELECT #{cols} FROM ws_messages WHERE flow_id = ? AND id > ? ORDER BY id LIMIT ?",
+        args: [flow_id, after_id, limit.to_i64] of DB::Any) do |rs|
+        rs.each do
+          msgs << WsMessage.new(rs.read(Int64), rs.read(Int64), rs.read(Int64?), rs.read(Int64),
+            rs.read(String), rs.read(Int32), rs.read(Bytes))
+        end
+      end
+      msgs
+    end
+
     def ws_messages_for_replay(replay_id : Int64, limit : Int32? = nil) : Array(WsMessage)
       msgs = [] of WsMessage
       cols = "id, flow_id, replay_id, created_at, direction, opcode, payload"
@@ -1519,6 +1536,12 @@ module Gori
       return if cutoff <= 0
       conn.transaction do |tx|
         c = tx.connection
+        # NOTE (known limitation): a WebSocket flow still streaming frames after `retention_flows`
+        # newer flows push its id below the cutoff is reaped here mid-stream, which also stops
+        # Prism WS scanning on it. A liveness guard like the h2 one below is the fix, but it must
+        # compare ws_message.created_at against a WS-relative recency floor (flows.created_at and
+        # ws_messages.created_at are set from different sources), so it is left for a focused
+        # retention change rather than bundled here.
         # Only CAPTURED ws messages (replay_id IS NULL, real flow_id) cascade with their
         # pruned flow. WebSocket-Replay output rows (update_replay_ws_messages) are stored
         # with the sentinel flow_id = 0 and keyed by replay_id, so a bare `flow_id <= cutoff`

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -505,21 +505,27 @@ module Gori
           return nil
         end
         existing = c.query_one?(
-          "SELECT id, affected, severity, evidence FROM prism_issues WHERE code = ? AND host = ?",
-          d.code, d.host, as: {Int64, String, Int32, String?})
+          "SELECT id, affected, severity, evidence, title FROM prism_issues WHERE code = ? AND host = ?",
+          d.code, d.host, as: {Int64, String, Int32, String?, String})
         if existing
-          id, aff_json, sev, prev_evidence = existing
+          id, aff_json, sev, prev_evidence, prev_title = existing
           urls = parse_affected(aff_json)
           urls << d.url if !urls.includes?(d.url) && urls.size < PRISM_AFFECTED_CAP
           new_sev = sev > d.severity.value ? sev : d.severity.value
+          # Keep the title in sync with the highest-severity observation: a code whose title
+          # is severity-dependent (reflected_param: HTML ⇒ Medium "Reflected parameter" vs
+          # non-HTML ⇒ Low "…(non-HTML context)") must not show an escalated badge next to the
+          # lower-severity title. Adopt the incoming title only when it RAISES severity; for
+          # fixed-title codes (the vast majority) this is a no-op.
+          new_title = d.severity.value > sev ? d.title : prev_title
           # For the type-labeled infoleak codes, accumulate every distinct type seen
           # for this (code, host) group so a later flow's different secret/error type
           # isn't masked by the first-wins COALESCE. Other codes keep their first
           # representative sample.
           new_evidence = accumulate_evidence?(d.code) ? merge_evidence(prev_evidence, d.evidence) : (prev_evidence || d.evidence)
           c.exec("UPDATE prism_issues SET hit_count = hit_count + 1, affected = ?, severity = ?, " \
-                 "evidence = ?, last_seen = ? WHERE id = ?",
-            urls.to_json, new_sev, new_evidence, ts, id)
+                 "title = ?, evidence = ?, last_seen = ? WHERE id = ?",
+            urls.to_json, new_sev, new_title, new_evidence, ts, id)
         else
           c.exec("INSERT INTO prism_issues (code, category, host, title, severity, status, hit_count, " \
                  "affected, sample_flow_id, evidence, first_seen, last_seen, sample_replay_id) " \

--- a/src/gori/tui/controllers/prism_controller.cr
+++ b/src/gori/tui/controllers/prism_controller.cr
@@ -213,13 +213,16 @@ module Gori::Tui
 
     def prism_delete : Nil
       return unless i = @prism.target_issue
-      @host.confirm("DELETE ISSUE", "Delete \"#{i.title}\" on #{i.host}?", confirm_label: "delete", danger: true) do
-        code, host = i.code, i.host
+      # Capture the id/code/host NOW: the confirm resolves on a later tick, and a background
+      # prism_generation reload can shift the selection in between — so both the suppress and
+      # the delete must target THIS issue by id, not whatever happens to be selected at confirm.
+      id, code, host, title = i.id, i.code, i.host, i.title
+      @host.confirm("DELETE ISSUE", "Delete \"#{title}\" on #{host}?", confirm_label: "delete", danger: true) do
         # Suppress FIRST: delete's exec_task yields to the store writer, and an
         # in-flight Active/passive fiber can re-upsert the same (code, host) in
         # that window if suppress runs after delete.
         @host.session.prism.suppress(code, host)
-        @prism.delete(@host.session.store)
+        @prism.delete_by_id(@host.session.store, id)
       end
     end
 

--- a/src/gori/tui/prism_view.cr
+++ b/src/gori/tui/prism_view.cr
@@ -303,16 +303,20 @@ module Gori::Tui
       next_status
     end
 
-    # Bulk-mute every OPEN issue sharing the targeted issue's code / host. Returns how many
-    # rows were affected (counted in memory; the store UPDATE is fire-and-forget).
+    # Bulk-mute every OPEN issue sharing the targeted issue's code. Respects the ⇧S scope lens:
+    # dismissing "all with this code" from a scoped view must not silently mute issues on
+    # out-of-scope hosts the user can't see, and the returned count must equal what was muted.
+    # With the lens off this is every open issue carrying the code.
     def dismiss_by_code(store : Store) : Int32
       return 0 unless issue = target_issue
-      n = @all.count { |i| i.code == issue.code && i.status.open? }
-      store.dismiss_prism_by_code(issue.code)
+      targets = @all.select { |i| i.code == issue.code && i.status.open? && lens_admits?(i) }
+      targets.each { |i| store.update_prism_issue_status(i.id, Store::Status::FalsePositive) }
       reload(store)
-      n
+      targets.size
     end
 
+    # Mute every OPEN issue on the targeted issue's host. The host is a single visible row, so
+    # the scope lens (which filters by host) already admits it — no cross-scope leak here.
     def dismiss_by_host(store : Store) : Int32
       return 0 unless issue = target_issue
       n = @all.count { |i| i.host == issue.host && i.status.open? }
@@ -321,13 +325,18 @@ module Gori::Tui
       n
     end
 
-    def delete(store : Store) : Nil
-      if issue = @detail
-        store.delete_prism_issue(issue.id)
-        close_detail
-      elsif issue = @issues[@selected]?
-        store.delete_prism_issue(issue.id)
-      end
+    # A row is admitted by the active scope lens (always true when the lens is off).
+    private def lens_admits?(issue : Store::PrismIssue) : Bool
+      return true unless scope_active?
+      @scope.try(&.host_in_scope?(issue.host)) == true
+    end
+
+    # Delete a SPECIFIC issue by id. The controller captures the id when the confirm opens, so a
+    # background reload that shifts the selection between prompt and confirm can't make the delete
+    # (and its paired suppress) target a different issue than the one the user chose.
+    def delete_by_id(store : Store, id : Int64) : Nil
+      store.delete_prism_issue(id)
+      close_detail if @detail.try(&.id) == id
       reload(store)
     end
 
@@ -346,6 +355,9 @@ module Gori::Tui
         render_detail(screen, rect, focused)
       else
         list_rect, preview_rect = list_split(rect)
+        # No preview pane at this size (or after a resize down) ⇒ snap focus back to the list,
+        # or move()/scroll would route arrows to an invisible pane and freeze list navigation.
+        @preview_focus = :list if preview_rect.nil?
         render_list(screen, list_rect, focused && @preview_focus == :list,
           listen: listen, capturing: capturing)
         render_preview_pane(screen, preview_rect, focused) if preview_rect
@@ -389,7 +401,10 @@ module Gori::Tui
       screen.fill(body, Theme.selection_dim) if active
       bg = active ? Theme.selection_dim : Theme.bg
       lines = preview_lines(issue)
-      sc = @preview_scroll.clamp(0, {lines.size - 1, 0}.max)
+      # Write the clamp back (like render_detail) so overscrolling a short preview can't inflate
+      # @preview_scroll and leave later scroll-up presses dead until it drains back into range.
+      @preview_scroll = @preview_scroll.clamp(0, {lines.size - 1, 0}.max)
+      sc = @preview_scroll
       w = {body.w - 2, 0}.max
       (0...body.h).each do |i|
         li = sc + i
@@ -478,7 +493,7 @@ module Gori::Tui
     # `a:CLOSED` lens toggle + right-aligned severity tallies.
     private def render_mode_band(screen : Screen, rect : Rect) : Nil
       x = chip(screen, rect.x + 1, rect.y, " m:#{@mode.title} ", mode_color(@mode)) + 1
-      tallies_x = render_tallies(screen, rect) # leftmost x the tallies occupy (or rect.right-1)
+      tallies_x = render_tallies(screen, rect, x + 1) # right-aligned, but never left of the mode chip
       # The CLOSED lens toggle chains left of the tallies; lit when showing closed/dismissed
       # issues, muted (its default open-only) otherwise — so the `a` chord stays in view.
       cx = Frame.toggle_badge(screen, tallies_x, rect.y, x + 1, "a", "CLOSED", @show_closed)
@@ -489,7 +504,7 @@ module Gori::Tui
 
     # Draws the right-aligned severity tallies; returns the leftmost x they occupy (or
     # rect.right-1 when there are none) so the CLOSED lens badge can chain to their left.
-    private def render_tallies(screen : Screen, rect : Rect) : Int32
+    private def render_tallies(screen : Screen, rect : Rect, floor : Int32) : Int32
       labels = {4 => "C", 3 => "H", 2 => "M", 1 => "L", 0 => "I"}
       parts = [] of {String, Color}
       labels.each do |val, lab|
@@ -498,10 +513,15 @@ module Gori::Tui
       end
       return rect.right - 1 if parts.empty?
       total = parts.sum { |(s, _)| s.size + 1 } - 1
-      left = rx = rect.right - 1 - total
+      # Right-align, but never start left of `floor` (the mode chip): on a band too narrow to
+      # hold everything the tallies truncate at the right edge instead of overpainting the mode
+      # indicator. On a normal-width band `left` is unchanged and nothing truncates.
+      left = rx = {rect.right - 1 - total, floor}.max
       parts.each do |(s, color)|
-        rx = screen.text(rx, rect.y, s, color)
-        rx = screen.text(rx, rect.y, " ", Theme.muted)
+        break if rx >= rect.right
+        rx = screen.text(rx, rect.y, s, color, width: {rect.right - rx, 0}.max)
+        break if rx >= rect.right
+        rx = screen.text(rx, rect.y, " ", Theme.muted, width: 1)
       end
       left
     end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -3573,7 +3573,19 @@ module Gori::Tui
     # Findings report). Reuses Store#insert_finding; the issue's severity/host/sample flow carry over.
     def prism_promote : Nil
       return unless i = prism_controller.view.target_issue
-      @session.store.insert_finding(i.title, i.severity, i.host, i.sample_flow_id)
+      # Promotion marks the source issue Confirmed; a second press would otherwise mint a
+      # duplicate Finding for the same issue. Already-Confirmed ⇒ already promoted.
+      if i.status.confirmed?
+        @toast = "already promoted to a finding"
+        return
+      end
+      fid = @session.store.insert_finding(i.title, i.severity, i.host, i.sample_flow_id)
+      # Preserve Replay-only evidence: with no source flow, link the Finding to the Replay tab
+      # that produced the issue so the evidence pointer survives promotion (insert_finding only
+      # carries a flow id).
+      if i.sample_flow_id.nil? && (rid = i.sample_replay_id)
+        @session.store.add_link(Store::LinkOwnerKind::Finding, fid, Store::LinkRefKind::Replay, rid)
+      end
       # Mark the source confirmed (= "promoted to a Finding") so it leaves the default
       # open-only lens instead of lingering as unreviewed noise; still reachable via `a`.
       @session.store.update_prism_issue_status(i.id, Store::Status::Confirmed)


### PR DESCRIPTION
## Summary

A multi-round audit of the **Prism** scanner (the least-tested feature) — active probes, passive rules, orchestration, the TUI, and the store/CLI/MCP surface. Each finding was surfaced by a fan-out of focused reviewers, **adversarially verified** (default-refute) to drop plausible-but-wrong reports, then reproduced against real code before fixing. ~25 confirmed bugs across 5 commits, every fix with regression coverage.

## What's fixed, by area

**Active scan** (`d944da1`)
- Queued canary/CORS probes kept firing at the target after the operator switched Active→Passive/Off (`run_active` only gated on `@stopped`; `set_mode` can't drain the queue). **Medium.**
- `origin_form` dropped the query of a pathless absolute-form target (`GET http://h?q=v` → `/`) so its params were never probed, and mistook a `/` inside the query for the path. Extracted one correct shared helper.
- `CorsReflection` sent an absolute-form request line direct to the origin (some origins reject it → missed reflections). Normalized to origin-form.
- A merged `(code,host)` group escalated severity but froze the title, so a `reflected_param` row showed a MED badge next to the non-HTML title. Title now tracks the highest-severity observation (in both the store and the headless `group.cr`).

**Passive rules** (`70e502d`)
- CSP duplicate-directive resolution was last-wins vs. the browser's first-wins (weak_csp FP **and** FN).
- Logout cookies with a sentinel value (`sid=deleted; Max-Age=0`) or a negative Max-Age tripped hygiene findings.
- A Basic challenge listed after another scheme in one `WWW-Authenticate` header was missed.
- PGP (`… PRIVATE KEY BLOCK`) and PKCS#8 `ENCRYPTED PRIVATE KEY` blocks never matched the secret pattern.
- A 4-part software version (`File version 10.0.1.2`) was flagged as a private-IP leak.
- GraphQL introspection used loose substrings (echoed query FP; result past the 64 KiB cap FN) → anchored on the `"__schema":{` result envelope.

**Orchestration** (`9ba90f9`, `158c933`)
- Replay/CLI/MCP-sourced scans lost **all** request headers (editor stores bare-LF, parser needs CRLF), silently missing CORS/Basic-auth/tech rules. **Medium.**
- WebSocket rescans re-scanned the whole buffer per frame (hit_count inflation, O(n²)); reworked to a per-flow high-water-mark that pages forward and scans each frame exactly once — fixing both an evicted-flow re-count and a >WS_MSG_CAP backlog skipping a band of frames (missed secret). **Medium.**
- A burst overflowing the droppable `prism_events` feed permanently skipped a plain-HTTP flow's only scan trigger; added a periodic passive catch-up sweep.
- A probe dropped by the mode gate kept its dedup key, suppressing re-probing after Active is re-enabled — key now released.

**TUI** (`d54ee08`)
- Bulk "dismiss all with this code" ignored the ⇧S scope lens (muted out-of-scope hosts, over-reported the count). **Medium.**
- Delete confirmed one issue but deleted whatever was selected at confirm time (a background reload could diverge them). Now targets the captured id. **Medium.**
- Promote created duplicate Findings and dropped Replay-only evidence.
- Narrow-terminal rendering: preview focus stranded list nav, preview scroll never upper-clamped, severity tallies overpainted the MODE chip.

## Not changed
- **store / filter / CLI / MCP** round: adversarial verification confirmed **0** real bugs — the layer is solid.
- **Known limitation documented in-place:** a still-streaming WebSocket flow can be reaped by retention after 100k newer flows; a correct fix needs a WS-relative recency floor (the flow vs. ws-message timestamps are set from different sources) and belongs in a focused retention change.

## Verification
- 180 Prism-touching examples pass; full build (`crystal build src/main.cr`) succeeds.
- The 4 pre-existing `store_spec.cr` failures (migration/FTS/h2 tests) are unrelated — identical on the pristine tree (verified via `git stash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)