### PR TITLE
fix: correctness audit — ~120 bugs across TUI, MCP, RUN/proxy, prism, parsers, store

### DIFF
--- a/spec/convert_spec.cr
+++ b/spec/convert_spec.cr
@@ -128,6 +128,11 @@ describe Gori::Convert do
       conv("unicode-unescape", "a\\u00e9").should eq "aé"
       conv("unicode-unescape", conv("unicode-escape", "x🎉y")).should eq "x🎉y"
     end
+
+    it "unicode-unescape reports a lone/unpaired surrogate as a ConvertError (not a raw ArgumentError)" do
+      expect_raises(Gori::Convert::ConvertError) { conv("unicode-unescape", "\\ud800") }
+      expect_raises(Gori::Convert::ConvertError) { conv("unicode-unescape", "\\udc00") }
+    end
   end
 
   describe "text transforms" do

--- a/spec/convert_spec.cr
+++ b/spec/convert_spec.cr
@@ -62,6 +62,12 @@ describe Gori::Convert do
   end
 
   describe "more encodings" do
+    it "base58-decode counts leading zeros consistently across embedded whitespace" do
+      # "11 1abc" and "111abc" are numerically identical to the value parser (whitespace
+      # skipped); the leading-zero byte count must agree too.
+      Gori::Convert::Codecs.base58_decode("11 1abc").should eq Gori::Convert::Codecs.base58_decode("111abc")
+    end
+
     it "base32 round-trips and matches the RFC 4648 vector" do
       conv("base32-encode", "foobar").should eq "MZXW6YTBOI======"
       conv("base32-decode", "MZXW6YTBOI======").should eq "foobar"

--- a/spec/fuzz_spec.cr
+++ b/spec/fuzz_spec.cr
@@ -92,6 +92,14 @@ describe F::Template do
     F::Template.auto_mark("q=§hi§").should eq("q=§hi§")
   end
 
+  it "auto-marks JSON boolean and null values, not only strings/numbers" do
+    body = "POST / HTTP/1.1\r\nContent-Type: application/json\r\n\r\n{\"name\":\"bob\",\"admin\":true,\"age\":30,\"gone\":null}"
+    marked = F::Template.auto_mark(body)
+    marked.includes?("\"admin\":§true§").should be_true
+    marked.includes?("\"gone\":§null§").should be_true
+    F::Template.parse(marked).position_count.should eq(4) # name, admin, age, gone
+  end
+
   it "toggles a marker around the word at the cursor" do
     # cursor inside "admin"
     F::Template.mark_word("user=admin", 7).should eq("user=§admin§")

--- a/spec/import/import_spec.cr
+++ b/spec/import/import_spec.cr
@@ -59,6 +59,41 @@ describe Gori::Import do
     end
   end
 
+  it "preserves duplicate response headers (multiple Set-Cookie) on HAR import" do
+    har = File.tempname("gori", ".har")
+    begin
+      File.write(har, <<-JSON)
+        {
+          "log": {
+            "entries": [
+              {
+                "startedDateTime": "2026-06-01T12:00:00.000Z", "time": 1,
+                "request": {"method": "GET", "url": "https://shop.test/x", "httpVersion": "HTTP/1.1", "headers": []},
+                "response": {
+                  "status": 200, "statusText": "OK", "httpVersion": "HTTP/1.1",
+                  "headers": [
+                    {"name": "Set-Cookie", "value": "session=abc"},
+                    {"name": "Set-Cookie", "value": "csrf=def"}
+                  ],
+                  "content": {"mimeType": "text/html", "text": "ok"}
+                }
+              }
+            ]
+          }
+        }
+        JSON
+
+      with_store do |store|
+        Gori::Import.import_file(store, :har, har)
+        row = store.search(Gori::QL::EMPTY, 10).first
+        head = String.new(store.get_flow(row.id).not_nil!.response_head.not_nil!)
+        head.scan(/^set-cookie:/im).size.should eq(2) # both cookies survive, not collapsed to the last
+      end
+    ensure
+      File.delete?(har)
+    end
+  end
+
   it "imports pending flows from a URL list file" do
     urls = File.tempname("gori", ".txt")
     begin

--- a/spec/prism_spec.cr
+++ b/spec/prism_spec.cr
@@ -72,6 +72,51 @@ describe Gori::Prism::Passive do
     end
   end
 
+  it "detects a GitHub fine-grained personal access token in a response body" do
+    with_store do |store|
+      body = %({"token":"github_pat_11ABCDEFGHIJKLMNOPQRSTUV_abcdefghijklmno"})
+      dets = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n",
+        content_type: "application/json", body: body)
+      codes_of(dets).should contain("secret_in_body")
+    end
+  end
+
+  it "does not flag a Spring class name in prose, but does flag a real Spring frame" do
+    with_store do |store|
+      prose = "See the JavaDoc at org.springframework.boot.SpringApplication for details."
+      codes_of(analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n", body: prose))
+        .should_not contain("error_stack_leak")
+      frame = "err\n\tat org.springframework.aop.framework.CglibAopProxy.intercept(Native Method)"
+      codes_of(analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n", body: frame))
+        .should contain("error_stack_leak")
+    end
+  end
+
+  it "does not treat a non-adjacent version word as version context for a private-IP leak" do
+    with_store do |store|
+      codes_of(analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n",
+        body: "Our firmware serves 10.0.0.5 today")).should contain("private_ip_leak")
+      codes_of(analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n",
+        body: "File version 10.0.1.2 released")).should_not contain("private_ip_leak")
+    end
+  end
+
+  it "flags cleartext Basic auth even behind a later duplicate Authorization header" do
+    with_store do |store|
+      dets = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n",
+        scheme: "http", req_headers: "Authorization: Basic dXNlcjpwYXNz\r\nAuthorization: Bearer tok\r\n")
+      codes_of(dets).should contain("insecure_basic_auth")
+    end
+  end
+
+  it "does not flag CORS when the response carries duplicate ACAO headers (browser blocks it)" do
+    with_store do |store|
+      head = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n" \
+             "Access-Control-Allow-Origin: *\r\nAccess-Control-Allow-Origin: https://x.test\r\n\r\n"
+      codes_of(analyze(store, resp_head: head)).should_not contain("cors_wildcard")
+    end
+  end
+
   it "does not flag document headers when they are present" do
     with_store do |store|
       head = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n" \

--- a/spec/proxy/codec/body_spec.cr
+++ b/spec/proxy/codec/body_spec.cr
@@ -155,6 +155,13 @@ describe Gori::Proxy::Codec::Body do
       resp = Http1.parse_response_head("HTTP/1.1 200 OK\r\nTransfer-Encoding: gzip\r\n\r\n".to_slice)
       Body.response_framing(resp, "GET").should eq({BodyFraming::CloseDelimited, 0_i64})
     end
+
+    it "frames a response with a non-chunked TE AND a Content-Length as close-delimited, NOT by CL" do
+      # RFC 7230 §3.3.3 rule 3: TE outranks CL. Framing by CL would read only CL bytes and
+      # leave the rest on the wire to misframe the next response on a reused upstream (desync).
+      resp = Http1.parse_response_head("HTTP/1.1 200 OK\r\nTransfer-Encoding: identity\r\nContent-Length: 3\r\n\r\n".to_slice)
+      Body.response_framing(resp, "GET").should eq({BodyFraming::CloseDelimited, 0_i64})
+    end
   end
 
   describe ".stream" do

--- a/spec/proxy/h2/assembler_spec.cr
+++ b/spec/proxy/h2/assembler_spec.cr
@@ -84,6 +84,23 @@ describe Gori::Proxy::H2::Assembler do
     resp.ttfb_us.should_not be_nil # first response HEADERS frame anchors ttfb
   end
 
+  it "reports the FINAL status, not an interim 1xx, when a 100 precedes the 200" do
+    sink = RecSink.new
+    assembler = Gori::Proxy::H2::Assembler.new(sink, "example.com", 443, 1_i64)
+    assembler.feed("out", headers_frame(1_u32, Frame::END_HEADERS | Frame::END_STREAM,
+      hexb("828684418cf1e3c2e5f23a6ba0ab90f4ff")))
+    # Interim 100 Continue (END_HEADERS, NO END_STREAM): HPACK literal :status = "100".
+    assembler.feed("in", headers_frame(1_u32, Frame::END_HEADERS,
+      Bytes[0x48_u8, 0x03_u8, 0x31_u8, 0x30_u8, 0x30_u8]))
+    # Then the real 200 (static index 8) + body + END_STREAM.
+    assembler.feed("in", headers_frame(1_u32, Frame::END_HEADERS, Bytes[0x88_u8]))
+    assembler.feed("in", data_frame(1_u32, Frame::END_STREAM, "ok"))
+
+    sink.responses.size.should eq(1)
+    sink.responses.first.status.should eq(200) # was: 100 — the interim block merged ahead of the final
+    String.new(sink.responses.first.head).should contain("HTTP/2 200")
+  end
+
   it "carries a request body across DATA frames" do
     sink = RecSink.new
     assembler = Gori::Proxy::H2::Assembler.new(sink, "example.com", 443, 1_i64)

--- a/spec/proxy/ws_spec.cr
+++ b/spec/proxy/ws_spec.cr
@@ -215,6 +215,47 @@ describe Gori::Proxy::WS do
       sink.messages.any? { |(_, _, s)| s.includes?("too large to capture") }.should be_true
       sink.messages.should contain({"in", 1, "yo"})
     end
+
+    it "preserves a small leading fragment when a LATER fragment is oversized (was dropped)" do
+      big = Gori::Proxy::WS::MAX_FRAME.to_i + 16
+      f1 = Bytes[0x01_u8, 0x03_u8, 0x61_u8, 0x62_u8, 0x63_u8] # OP_TEXT, no FIN, len 3, "abc"
+      hdr = IO::Memory.new
+      hdr.write_byte(0x80_u8) # FIN | OP_CONT(0x0)
+      hdr.write_byte(0x7f_u8)
+      len = big.to_u64
+      (0..7).each { |i| hdr.write_byte((len >> (56 - i * 8)).to_u8!) }
+      f2_hdr = hdr.to_slice
+      payload = Bytes.new(big, 0x41_u8)
+
+      client_side, relay_client = UNIXSocket.pair
+      origin_side, relay_upstream = UNIXSocket.pair
+
+      drain = Channel(Nil).new
+      spawn do
+        buf = Bytes.new(64 * 1024)
+        while (n = client_side.read(buf)) > 0
+        end
+      rescue IO::Error
+      ensure
+        drain.send(nil)
+      end
+      spawn do
+        origin_side.write(f1)
+        origin_side.write(f2_hdr)
+        origin_side.write(payload)
+        origin_side.close
+      end
+
+      sink = WsSink.new
+      Gori::Proxy::WS::Relay.run(relay_client, relay_upstream, 11_i64, sink)
+      drain.receive
+      client_side.close rescue nil
+
+      # The leading "abc" fragment reaches the sink (not silently discarded because the
+      # message's final fragment turned out to be oversized), plus the oversized marker.
+      sink.messages.should contain({"in", 1, "abc"})
+      sink.messages.any? { |(_, _, s)| s.includes?("too large to capture") }.should be_true
+    end
   end
 end
 

--- a/spec/store/entity_links_spec.cr
+++ b/spec/store/entity_links_spec.cr
@@ -70,6 +70,8 @@ describe "entity_links (V21)" do
       store.@db.exec("DROP INDEX idx_ws_messages_replay")              # V26
       store.@db.exec("ALTER TABLE ws_messages DROP COLUMN replay_id")  # V26
       store.@db.exec("DROP INDEX idx_h2_frames_created")               # V27
+      store.@db.exec("ALTER TABLE prism_issues DROP COLUMN sample_replay_id") # V28
+      store.@db.exec("DROP TABLE prism_suppressions")                  # V29
       store.@db.exec("PRAGMA user_version = 20")
       store.close
 

--- a/spec/store/store_spec.cr
+++ b/spec/store/store_spec.cr
@@ -50,6 +50,7 @@ describe Gori::Store do
       store.@db.exec("DROP INDEX idx_ws_messages_replay")              # V26
       store.@db.exec("ALTER TABLE ws_messages DROP COLUMN replay_id")  # V26
       store.@db.exec("DROP INDEX idx_h2_frames_created")               # V27
+      store.@db.exec("DROP TABLE prism_suppressions")                  # V29
       store.@db.exec("PRAGMA user_version = 17")
       store.close
 

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -713,17 +713,23 @@ module Gori
         end
 
         new_headers = [] of Proxy::Codec::Header
+        applied = Set(String).new # custom names whose FIRST occurrence was already replaced
         raw_req.headers.each do |hdr|
           lower_name = hdr.name.downcase
           if custom_headers.has_key?(lower_name)
+            # Replace the first matching line; DROP later duplicates (a captured h2 request
+            # can carry several `cookie:`/`set-cookie:` lines) so the override isn't left
+            # half-applied with a stale second occurrence.
+            next if applied.includes?(lower_name)
             new_headers << Proxy::Codec::Header.new(hdr.name, custom_headers[lower_name])
-            custom_headers.delete(lower_name)
+            applied << lower_name
           else
             new_headers << hdr
           end
         end
 
         custom_headers.each do |lower_name, val|
+          next if applied.includes?(lower_name) # already replaced an existing line
           orig_name = ""
           headers.each do |h_str|
             name, _, _ = h_str.partition(':')
@@ -761,7 +767,10 @@ module Gori
           end
         end
 
-        if override = target_override
+        # Sync Host from --target, UNLESS the user set an explicit `-H "Host: …"` — a
+        # host-header-confusion / vhost test deliberately pairs --target (where to connect)
+        # with a different claimed Host, so that override must win.
+        if (override = target_override) && !custom_headers.has_key?("host")
           scheme_part, host_part, port_part = Replay::FlowRequest.parse_target(override)
           default_port = scheme_part == "https" ? 443 : 80
           host_hdr_val = port_part == default_port ? host_part : "#{host_part}:#{port_part}"
@@ -812,7 +821,7 @@ module Gori
         if format == :json
           puts replay_json(result, diff)
         elsif result.ok?
-          STDERR.puts "→ #{result.response.try(&.status) || "?"} in #{CLI::Output.human_us(result.duration_us)}"
+          STDERR.puts "→ #{result.response.try(&.status) || "?"} in #{CLI::Output.human_us(result.duration_us)}#{result.incomplete? ? " (incomplete — origin closed before the framed body finished)" : ""}"
           if d = diff
             print_diff(d)
             n = Replay::Diff.change_count(d)
@@ -833,6 +842,7 @@ module Gori
             j.field "status", result.response.try(&.status)
             j.field "duration_us", result.duration_us
             j.field "error", result.error
+            j.field "incomplete", true if result.incomplete? # origin closed before the framed body finished
             j.field "head", scrub(result.head)
             emit_body_json(j, "body", result.head, result.body, false)
             if d = diff

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -689,7 +689,7 @@ module Gori
 
         raw_bytes = built.bytes
         crlf_crlf_idx = -1
-        limit = raw_bytes.size - 3
+        limit = raw_bytes.size - 4
         (0..limit).each do |i|
           if raw_bytes[i] == 0x0d_u8 && raw_bytes[i+1] == 0x0a_u8 && raw_bytes[i+2] == 0x0d_u8 && raw_bytes[i+3] == 0x0a_u8
             crlf_crlf_idx = i
@@ -743,7 +743,16 @@ module Gori
                      end
 
         has_cl = new_headers.any? { |h| h.name.compare("Content-Length", case_insensitive: true) == 0 }
-        if body_override || has_cl || final_body.size > 0
+        has_te = new_headers.any? { |h| h.name.compare("Transfer-Encoding", case_insensitive: true) == 0 }
+        # RFC 7230 §3.3.3 forbids sending Transfer-Encoding and Content-Length together.
+        # When the original request was chunked (TE present, no override), keep its wire
+        # framing byte-exact and don't inject a Content-Length. When the body is replaced
+        # via -b, drop Transfer-Encoding and self-frame the new bytes with Content-Length.
+        if has_te && body_override
+          new_headers.reject! { |h| h.name.compare("Transfer-Encoding", case_insensitive: true) == 0 }
+          has_te = false
+        end
+        if !has_te && (body_override || has_cl || final_body.size > 0)
           cl_idx = new_headers.index { |h| h.name.compare("Content-Length", case_insensitive: true) == 0 }
           if cl_idx
             new_headers[cl_idx] = Proxy::Codec::Header.new(new_headers[cl_idx].name, final_body.size.to_s)
@@ -753,8 +762,9 @@ module Gori
         end
 
         if override = target_override
-          _, host_part, port_part = Replay::FlowRequest.parse_target(override)
-          host_hdr_val = port_part == 80 || port_part == 443 ? host_part : "#{host_part}:#{port_part}"
+          scheme_part, host_part, port_part = Replay::FlowRequest.parse_target(override)
+          default_port = scheme_part == "https" ? 443 : 80
+          host_hdr_val = port_part == default_port ? host_part : "#{host_part}:#{port_part}"
           host_idx = new_headers.index { |h| h.name.compare("Host", case_insensitive: true) == 0 }
           if host_idx
             new_headers[host_idx] = Proxy::Codec::Header.new(new_headers[host_idx].name, host_hdr_val)

--- a/src/gori/convert/catalog.cr
+++ b/src/gori/convert/catalog.cr
@@ -75,14 +75,14 @@ module Gori::Convert
 
     # ---------------- TOKEN ----------------
     r.register encode("jwt-decode", "jwt",
-      category: Category::Token,
+      category: Category::Token, direction: Direction::Decode,
       description: "Decode JWT header+payload (no signature verify)") { |b| Codecs.jwt_decode(b) }
 
     # ---------------- HASH ----------------
-    r.register encode("md5", category: Category::Hash, description: "MD5 digest (hex)") { |b| Digest::MD5.hexdigest(b) }
-    r.register encode("sha1", category: Category::Hash, description: "SHA-1 digest (hex)") { |b| Digest::SHA1.hexdigest(b) }
-    r.register encode("sha256", category: Category::Hash, description: "SHA-256 digest (hex)") { |b| Digest::SHA256.hexdigest(b) }
-    r.register encode("sha512", category: Category::Hash, description: "SHA-512 digest (hex)") { |b| Digest::SHA512.hexdigest(b) }
+    r.register encode("md5", category: Category::Hash, direction: Direction::Hash, description: "MD5 digest (hex)") { |b| Digest::MD5.hexdigest(b) }
+    r.register encode("sha1", category: Category::Hash, direction: Direction::Hash, description: "SHA-1 digest (hex)") { |b| Digest::SHA1.hexdigest(b) }
+    r.register encode("sha256", category: Category::Hash, direction: Direction::Hash, description: "SHA-256 digest (hex)") { |b| Digest::SHA256.hexdigest(b) }
+    r.register encode("sha512", category: Category::Hash, direction: Direction::Hash, description: "SHA-512 digest (hex)") { |b| Digest::SHA512.hexdigest(b) }
 
     # ---------------- ESCAPE ----------------
     r.register text("html-escape", "html-encode", "htmlentities", "html",

--- a/src/gori/convert/codecs.cr
+++ b/src/gori/convert/codecs.cr
@@ -116,6 +116,9 @@ module Gori::Convert
     # (out-of-range) groups — garbage out, never a crash.
     private def flush_ascii85(sink : IO, group : Array(UInt8)) : Nil
       return if group.empty?
+      # A 1-char trailing group is structurally impossible (a partial group is ≥2 chars → ≥1
+      # byte); silently emitting 0 bytes would drop data — surface it like other malformed input.
+      raise ConvertError.new("truncated ascii85 group (1 leftover char is not decodable)") if group.size == 1
       v = 0_u32
       5.times { |k| v = v &* 85_u32 &+ (k < group.size ? group[k] : 84_u8).to_u32 }
       bytes = StaticArray(UInt8, 4).new(0_u8)
@@ -153,18 +156,23 @@ module Gori::Convert
       s = s.strip
       raise ConvertError.new("input too large for base58") if s.size > B58_MAX_IN * 2
       num = BigInt.new(0)
+      # Count leading '1' (zero) chars over the SAME whitespace-skipping pass as the value
+      # accumulation — a stray space inside the leading run would otherwise desync the two.
+      leading = 0
+      seen_nonzero = false
       s.each_char do |c|
         next if c.whitespace?
         v = B58.index(c) || raise ConvertError.new("invalid base58 char: #{c}")
+        if seen_nonzero || v != 0
+          seen_nonzero = true
+        else
+          leading += 1
+        end
         num = num * 58 + v
       end
       hex = num == 0 ? "" : num.to_s(16)
       hex = "0" + hex if hex.size.odd?
       body = hex.empty? ? Bytes.empty : hex.hexbytes
-      leading = 0
-      while leading < s.size && s[leading] == '1'
-        leading += 1
-      end
       sink = IO::Memory.new
       leading.times { sink.write_byte(0_u8) }
       sink.write(body)

--- a/src/gori/convert/codecs.cr
+++ b/src/gori/convert/codecs.cr
@@ -201,6 +201,9 @@ module Gori::Convert
               i += 12
               next
             elsif hi
+              # A lone/unpaired surrogate (0xD800..0xDFFF) is not a scalar value; Int#chr
+              # would raise a raw ArgumentError, so surface a clean ConvertError instead.
+              raise ConvertError.new("invalid unicode escape: unpaired surrogate \\u#{hi.to_s(16)}") if 0xD800 <= hi <= 0xDFFF
               io << hi.chr
               i += 6
               next

--- a/src/gori/convert/converter.cr
+++ b/src/gori/convert/converter.cr
@@ -94,9 +94,9 @@ module Gori
 
     # bytes-in / text-out (hashes, hex-encode, base64-encode).
     def self.encode(name : String, *aliases, category : Category,
-                    description : String, &fn : Bytes -> String) : Converter
+                    description : String, direction : Direction = Direction::Encode, &fn : Bytes -> String) : Converter
       wrapped = ->(input : Bytes) { fn.call(input).to_slice }
-      Converter.new(name, alias_list(aliases), category, Direction::Encode, description, wrapped)
+      Converter.new(name, alias_list(aliases), category, direction, description, wrapped)
     end
 
     # text-in / bytes-out (base64-decode, hex-decode). Decoders read text-encoded

--- a/src/gori/decoded_view.cr
+++ b/src/gori/decoded_view.cr
@@ -73,8 +73,10 @@ module Gori
     private def emit_text(j : JSON::Builder, name : String, text : String?, clip : Int32?) : Nil
       if text.nil?
         j.field name, nil
-      elsif clip && text.size > clip
-        j.field name, text[0, clip]
+      elsif clip && text.bytesize > clip
+        # clip is a BYTE budget (Serialize::DECODE_TEXT_MAX); compare/cut by bytes and scrub
+        # so a cut through a multi-byte UTF-8 sequence can't emit invalid JSON to the client.
+        j.field name, text.byte_slice(0, clip).scrub
         j.field "#{name}_truncated", true
       else
         j.field name, text

--- a/src/gori/external_editor.cr
+++ b/src/gori/external_editor.cr
@@ -53,7 +53,7 @@ module Gori
     # spurious empty last line. Strip exactly ONE trailing "\n" (or "\r\n").
     private def self.normalize(s : String) : String
       if s.ends_with?("\r\n")
-        s[0, s.bytesize - 2]
+        s.rchop.rchop # two single-byte ASCII chars; rchop avoids byte-vs-char arithmetic
       elsif s.ends_with?('\n')
         s.rchop
       else

--- a/src/gori/findings_export.cr
+++ b/src/gori/findings_export.cr
@@ -25,8 +25,11 @@ module Gori
             if fid = f.flow_id
               io << "- **Flow:** "
               if flow
-                loc = flow.row.target.starts_with?("http") ? flow.row.target : "#{flow.row.host}#{flow.row.target}"
-                io << flow.row.method << " " << loc << " → " << (flow.row.status || "-") << " (#" << fid << ")\n"
+                # method/target/host are captured (attacker/server-controlled) data — an embedded
+                # newline (reachable via an h2 :path/:method pseudo-header) would break the one-line
+                # structure, so sanitize them like f.title/f.host above.
+                loc = flow.row.target.starts_with?("http") ? one_line(flow.row.target) : "#{one_line(flow.row.host)}#{one_line(flow.row.target)}"
+                io << one_line(flow.row.method) << " " << loc << " → " << (flow.row.status || "-") << " (#" << fid << ")\n"
               else
                 io << "#" << fid << " (no longer captured)\n"
               end

--- a/src/gori/fuzz/engine.cr
+++ b/src/gori/fuzz/engine.cr
@@ -218,6 +218,7 @@ module Gori::Fuzz
     # final 3xx (no implicit off-target sends).
     private def follow_redirects(raw : Replay::Result) : Replay::Result
       current = raw
+      total_us = raw.duration_us
       hops = 0
       while hops < @config.max_redirects
         resp = current.response
@@ -227,10 +228,13 @@ module Gori::Fuzz
         nxt = redirect_request(loc)
         break unless nxt
         current = @backend.send(nxt)
+        total_us += current.duration_us
         hops += 1
         break unless current.error.nil?
       end
-      current
+      # Report the whole chain's end-to-end time, not just the final hop's — otherwise a
+      # slow original request that 3xx's to a fast resource masks a time-based signal.
+      hops > 0 ? Replay::Result.new(current.head, current.body, current.response, total_us, current.error, current.incomplete?) : current
     end
 
     private def redirect_request(loc : String) : Bytes?

--- a/src/gori/fuzz/template.cr
+++ b/src/gori/fuzz/template.cr
@@ -382,7 +382,10 @@ module Gori::Fuzz
       out = body.gsub(/("(?:[^"\\]|\\.)*"\s*:\s*")((?:[^"\\]|\\.)*)(")/) do |m|
         $2.empty? ? m : "#{$1}#{MARKER}#{$2}#{MARKER}#{$3}"
       end
-      out.gsub(/("(?:[^"\\]|\\.)*"\s*:\s*)(-?\d+(?:\.\d+)?)/) { "#{$1}#{MARKER}#{$2}#{MARKER}" }
+      out = out.gsub(/("(?:[^"\\]|\\.)*"\s*:\s*)(-?\d+(?:\.\d+)?)/) { "#{$1}#{MARKER}#{$2}#{MARKER}" }
+      # Also mark boolean/null scalar values so `--auto` exercises flag-style fields
+      # (e.g. "admin":true) as documented. (Array-element values are still unmarked.)
+      out.gsub(/("(?:[^"\\]|\\.)*"\s*:\s*)(true|false|null)\b/) { "#{$1}#{MARKER}#{$2}#{MARKER}" }
     end
 
     private def self.word_char?(c : Char) : Bool

--- a/src/gori/graphql.cr
+++ b/src/gori/graphql.cr
@@ -87,10 +87,25 @@ module Gori
     def parse_display(text : String) : {String?, String, String?}
       lines = text.split('\n')
       vi = nil.as(Int32?)
-      lines.each_with_index do |l, i|
-        next unless l.strip == "# variables"
-        trailing = lines[(i + 1)..].join('\n').strip
-        vi = i if !trailing.empty? && json?(trailing)
+      # Scan BACKWARD for the last "# variables" whose remainder parses as JSON, breaking on the
+      # first (from-end) match, and only attempt the parse when the trailing plausibly starts
+      # with '{'/'[' — a forward re-join+parse per candidate is O(n²) on a query full of literal
+      # "# variables" comment lines. `rev` holds the trailing lines in reverse (cheap push).
+      rev = [] of String
+      tail_first = nil.as(Char?) # first non-blank char of the accumulated trailing
+      (lines.size - 1).downto(0) do |i|
+        line = lines[i]
+        if line.strip == "# variables" && (tail_first == '{' || tail_first == '[')
+          trailing = rev.reverse.join('\n').strip
+          if !trailing.empty? && json?(trailing)
+            vi = i
+            break
+          end
+        end
+        rev << line
+        if fnb = line.each_char.find { |c| !c.whitespace? }
+          tail_first = fnb # a non-blank line becomes the new first-non-blank of the trailing
+        end
       end
       vars = vi ? lines[(vi + 1)..].join('\n').strip : nil
       body = vi ? lines[0...vi] : lines

--- a/src/gori/hotkeys.cr
+++ b/src/gori/hotkeys.cr
@@ -89,7 +89,7 @@ module Gori
     # The effective PRIMARY chord bound to `id` now (nil = unbound), honouring an optional
     # in-progress overrides map (the editor's working copy) and OS profile.
     def self.binding_for(registry : Verb::Registry, id : String,
-                         overrides : Hash(String, Array(Verb::Chord)) = chord_overrides,
+                         overrides : Hash(String, Array(Verb::Chord)) = rebindable_overrides(registry),
                          profile : String = Settings.keymap_os) : Verb::Chord?
       verb = registry[id]?
       return nil unless verb

--- a/src/gori/import/builder.cr
+++ b/src/gori/import/builder.cr
@@ -21,7 +21,8 @@ module Gori
 
       def self.normalize_url(url : String) : String
         u = url.strip
-        return u if u.starts_with?("http://") || u.starts_with?("https://")
+        down = u.downcase # schemes are case-insensitive (RFC 3986 §3.1)
+        return u if down.starts_with?("http://") || down.starts_with?("https://")
         raise Gori::Error.new("invalid URL (missing scheme): #{url}") if u.includes?("://")
         "https://#{u}"
       end
@@ -36,8 +37,13 @@ module Gori
         {scheme, host, port, target}
       end
 
+      # Headers are an ORDERED list of {name, value} pairs, not a map, so a repeated
+      # header (Set-Cookie, Via, …) survives import as its own line — a Hash would
+      # silently collapse duplicates to the last value.
+      alias Headers = Array({String, String})
+
       def self.request_head(method : String, target : String, http_version : String,
-                            host : String, headers : Hash(String, String),
+                            host : String, headers : Headers,
                             body : Bytes?) : Bytes
         String.build do |b|
           b << method.upcase << ' ' << target << ' ' << http_version << "\r\n"
@@ -47,7 +53,7 @@ module Gori
             b << k << ": " << v << "\r\n"
           end
           if body
-            unless headers.keys.any? { |k| k.downcase == "content-length" }
+            unless headers.any? { |(k, _)| k.downcase == "content-length" }
               b << "Content-Length: " << body.size << "\r\n"
             end
           end
@@ -56,11 +62,11 @@ module Gori
       end
 
       def self.response_head(http_version : String, status : Int32, reason : String,
-                             headers : Hash(String, String), body : Bytes?) : Bytes
+                             headers : Headers, body : Bytes?) : Bytes
         String.build do |b|
           b << http_version << ' ' << status << ' ' << reason << "\r\n"
           headers.each { |k, v| b << k << ": " << v << "\r\n" }
-          unless headers.keys.any? { |k| k.downcase == "content-length" }
+          unless headers.any? { |(k, _)| k.downcase == "content-length" }
             b << "Content-Length: " << (body.try(&.size) || 0) << "\r\n"
           end
           b << "\r\n"
@@ -68,7 +74,7 @@ module Gori
       end
 
       def self.pending_request(created_at : Int64, url : String, method : String = "GET",
-                               headers : Hash(String, String) = {} of String => String,
+                               headers : Headers = Headers.new,
                                body : Bytes? = nil, http_version : String = "HTTP/1.1") : FlowPair
         scheme, host, port, target = endpoint(url)
         head = request_head(method, target, http_version, host, headers, body)
@@ -81,10 +87,10 @@ module Gori
       end
 
       def self.complete_flow(created_at : Int64, url : String, method : String,
-                             req_headers : Hash(String, String),
+                             req_headers : Headers,
                              req_body : Bytes?, http_version : String,
                              status : Int32, reason : String,
-                             resp_headers : Hash(String, String),
+                             resp_headers : Headers,
                              resp_body : Bytes?, content_type : String?,
                              duration_us : Int64?) : FlowPair
         scheme, host, port, target = endpoint(url)

--- a/src/gori/import/har.cr
+++ b/src/gori/import/har.cr
@@ -44,34 +44,37 @@ module Gori
         created_at = parse_started(entry["startedDateTime"]?.to_s)
         duration_us = entry["time"]?.try { |t| (t.as_f * 1_000).to_i64 } # HAR time is ms → µs
 
-        req_headers = headers_hash(req["headers"]?)
+        req_headers = headers_list(req["headers"]?)
         req_body = post_body(req["postData"]?)
 
         resp = entry["response"]?
+        resp = nil if resp.try(&.raw).nil? # an explicit JSON `null` response is truthy as JSON::Any — treat it as absent
         return Builder.pending_request(created_at, url, method, req_headers, req_body, http_version) unless resp
 
         status = resp["status"]?.try(&.as_i).try(&.to_i32) || 0
         reason = resp["statusText"]?.to_s.presence || status_reason(status)
-        resp_headers = headers_hash(resp["headers"]?)
+        resp_headers = headers_list(resp["headers"]?)
         resp_body, content_type = response_body(resp)
-        content_type ||= resp_headers["Content-Type"]? || resp_headers["content-type"]?
+        content_type ||= resp_headers.find { |(k, _)| k.downcase == "content-type" }.try(&.[1])
 
         Builder.complete_flow(
           created_at, url, method, req_headers, req_body, http_version,
           status, reason, resp_headers, resp_body, content_type, duration_us)
       end
 
-      private def self.headers_hash(node : JSON::Any?) : Hash(String, String)
-        h = {} of String => String
+      # An ORDERED list of {name, value} — a HAR response commonly has several Set-Cookie
+      # entries (and Via/etc.); a Hash would keep only the last, dropping the rest.
+      private def self.headers_list(node : JSON::Any?) : Builder::Headers
+        list = Builder::Headers.new
         arr = node.try(&.as_a?)
-        return h unless arr
+        return list unless arr
         arr.each do |item|
           name = item["name"]?.to_s
           value = item["value"]?.to_s
           next if name.empty?
-          h[name] = value
+          list << {name, value}
         end
-        h
+        list
       end
 
       private def self.post_body(node : JSON::Any?) : Bytes?

--- a/src/gori/import/oas.cr
+++ b/src/gori/import/oas.cr
@@ -52,11 +52,13 @@ module Gori
       private def self.operation_to_flow(created_at : Int64, base : String, path : String,
                                          method : String, op : JSON::Any) : Builder::FlowPair
         url = join_url(base, path)
-        headers = {} of String => String
-        body = request_body(op)
-        if body
-          headers["Content-Type"] = body_content_type(op) || "application/json"
-        end
+        headers = Builder::Headers.new
+        ct = body_content_type(op) # nil when the operation declares no requestBody
+        # Only fabricate a JSON `{}` stub for a JSON media type — a `{}` body under a
+        # multipart/xml Content-Type is self-contradictory and useless as a seed request.
+        json = ct.try { |t| t == "application/json" || t.ends_with?("+json") } || false
+        body = json ? %({}).to_slice : nil
+        headers << {"Content-Type", ct} if ct
         Builder.pending_request(created_at, url, method.upcase, headers, body)
       end
 
@@ -64,15 +66,6 @@ module Gori
         b = base.chomp('/')
         p = path.starts_with?('/') ? path : "/#{path}"
         "#{b}#{p}"
-      end
-
-      private def self.request_body(op : JSON::Any) : Bytes?
-        rb = op["requestBody"]?
-        return nil unless rb
-        content = rb["content"]?
-        return nil unless content
-        return %({}).to_slice if content["application/json"]? || !content.as_h.empty?
-        nil
       end
 
       private def self.body_content_type(op : JSON::Any) : String?

--- a/src/gori/intercept_filter.cr
+++ b/src/gori/intercept_filter.cr
@@ -99,6 +99,9 @@ module Gori
       colon = token.index(':')
       if colon && colon > 0
         field = field_symbol(token[0...colon].downcase)
+        # An unknown field → free-text the WHOLE token (mirrors QL / Findings::Filter), so a
+        # typo'd field like `hsot:evil.com` searches literally instead of silently matching "evil.com".
+        return Term.new(:text, token, negate) if field == :text
         value = token[(colon + 1)..]
         return nil if value.empty?
         Term.new(field, value, negate)

--- a/src/gori/interceptor.cr
+++ b/src/gori/interceptor.cr
@@ -234,10 +234,16 @@ module Gori
       item.reply.send(Decision.new(Action::Drop, Bytes.empty))
     end
 
-    def forward_all : Nil
+    # `overrides` lets the caller supply edited bytes for specific held items (keyed by
+    # id) — e.g. an in-progress editor edit that would otherwise be lost when the whole
+    # queue is released at once. Items without an override forward their original bytes.
+    def forward_all(overrides : Hash(Int64, Bytes)? = nil) : Nil
       items = @mutex.synchronize { vals = @items.values; @items.clear; vals }
       @revision.add(1) unless items.empty?
-      items.each { |it| it.reply.send(Decision.new(Action::Forward, it.raw)) }
+      items.each do |it|
+        bytes = overrides.try(&.[it.id]?) || it.raw
+        it.reply.send(Decision.new(Action::Forward, bytes))
+      end
     end
 
     # Shutdown: latch so nothing re-enqueues, then auto-forward every held item

--- a/src/gori/mcp/request_builder.cr
+++ b/src/gori/mcp/request_builder.cr
@@ -30,12 +30,17 @@ module Gori
             raise Gori::Error.new("invalid url #{url.inspect}: #{ex.message}")
           end
         scheme = (uri.scheme || "http").downcase
-        raise Gori::Error.new("unsupported scheme: #{scheme} (only http/https)") unless scheme.in?("http", "https")
         host = uri.host
+        # Check the host BEFORE the scheme allowlist: a scheme-less "host:port/path" parses
+        # with the bare hostname as `scheme` and a nil host, so a nil host is itself the
+        # signal to emit the friendlier "include a scheme" hint rather than a misleading
+        # "unsupported scheme: <host>". A genuine ftp://host still has a host and reaches
+        # the scheme error below.
         if host.nil? || host.empty?
           hint = url.includes?("://") ? "" : " — include a scheme, e.g. https://#{url}"
           raise Gori::Error.new("url has no host: #{url}#{hint}")
         end
+        raise Gori::Error.new("unsupported scheme: #{scheme} (only http/https)") unless scheme.in?("http", "https")
         # URI.parse keeps a CR/LF embedded in the authority as part of `host`
         # (e.g. "http://h.com\r\nEvil: x/"), which would otherwise be written into
         # the auto-generated Host header and inject. Reject it on BOTH paths (raw

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -204,7 +204,7 @@ module Gori
               "When `flow_id` is set, url/method/headers/body/raw are ignored. " \
               "Host + Content-Length are auto-added when omitted on the url path." do |s|
               s.field "flow_id", intprop("replay a captured flow by id (no url needed; like TUI replay)")
-              s.field "url", strprop("absolute URL incl. scheme+host, e.g. https://api.example.com/v1/x"), required: true
+              s.field "url", strprop("absolute URL incl. scheme+host, e.g. https://api.example.com/v1/x (required unless flow_id is given)")
               s.field "method", strprop("HTTP method (default GET)")
               s.field "headers", objprop("header name->value map")
               s.field "body", strprop("request body, sent as-is")
@@ -998,7 +998,9 @@ module Gori
 
       private def create_replay(h) : Result
         finding_id = int(h, "finding_id")
+        return Result.new(id_error(h, "finding_id"), is_error: true) if finding_id.nil? && present?(h, "finding_id")
         flow_id = int(h, "flow_id")
+        return Result.new(id_error(h, "flow_id"), is_error: true) if flow_id.nil? && present?(h, "flow_id")
 
         if finding_id
           finding = @store.get_finding(finding_id)
@@ -1054,6 +1056,7 @@ module Gori
 
         position = int(h, "position")
         if position.nil?
+          return Result.new(id_error(h, "position"), is_error: true) if present?(h, "position") # present but non-integer
           position = @store.replays_meta.size.to_i64
         elsif position < Int32::MIN || position > Int32::MAX
           return Result.new("'position' out of range", is_error: true)
@@ -1753,7 +1756,17 @@ module Gori
       end
 
       private def bool(h, key : String) : Bool?
-        h[key]?.try(&.as_bool?)
+        v = h[key]?
+        return nil unless v
+        return v.as_bool? unless v.as_bool?.nil?
+        # Clients/LLMs often serialize tool args as strings (the schema's "boolean" is
+        # advisory, not enforced) — accept "true"/"false" so a stringified flag isn't
+        # silently coerced to false, mirroring int()'s leniency.
+        case v.as_s?.try(&.downcase)
+        when "true"  then true
+        when "false" then false
+        else              nil
+        end
       end
 
       private def clamp(n : Int64?, default : Int32, max : Int32) : Int32

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -681,8 +681,11 @@ module Gori
       end
 
       private def emit_capped_text(j : JSON::Builder, field : String, text : String) : Nil
-        if text.size > MCP_REPLAY_REQUEST_MAX
-          j.field field, text.byte_slice(0, MCP_REPLAY_REQUEST_MAX)
+        if text.bytesize > MCP_REPLAY_REQUEST_MAX
+          # Compare and cut by BYTES (the cap is a byte budget), then scrub — a slice
+          # through a multi-byte UTF-8 sequence would otherwise emit invalid UTF-8 into
+          # the JSON-RPC stream, which must be well-formed UTF-8 over the stdio transport.
+          j.field field, text.byte_slice(0, MCP_REPLAY_REQUEST_MAX).scrub
           j.field "#{field}_truncated", true
         else
           j.field field, text
@@ -1052,6 +1055,8 @@ module Gori
         position = int(h, "position")
         if position.nil?
           position = @store.replays_meta.size.to_i64
+        elsif position < Int32::MIN || position > Int32::MAX
+          return Result.new("'position' out of range", is_error: true)
         end
 
         # Apply Env.mask_secrets
@@ -1126,6 +1131,10 @@ module Gori
 
         target = str(h, "target") || existing.target
         request = str(h, "request") || existing.request
+        # An explicitly-passed empty string is truthy in Crystal, so guard it here to
+        # mirror create_replay's invariant — a blank target/request can't be sent.
+        return Result.new("target must not be empty", is_error: true) if target.empty?
+        return Result.new("request must not be empty", is_error: true) if request.empty?
 
         http2 = if present?(h, "http2")
                   bool(h, "http2") || false
@@ -1436,7 +1445,8 @@ module Gori
         config.max_requests = cap ? {cap, MINE_MAX_REQUESTS}.min : MINE_MAX_REQUESTS
         config.user_wordlist = str(h, "wordlist").presence
         if b = int(h, "bucket")
-          config.locations.each { |loc| config.bucket_size[loc] = b.to_i }
+          bucket = b.clamp(Int32::MIN.to_i64, Int32::MAX.to_i64).to_i # avoid Int64->Int32 overflow
+          config.locations.each { |loc| config.bucket_size[loc] = bucket }
         end
         names = Miner::Wordlist.load(config.user_wordlist)
         engine = Miner::Engine.new(bytes, use_h2, names, sender, config)

--- a/src/gori/miner/engine.cr
+++ b/src/gori/miner/engine.cr
@@ -248,11 +248,13 @@ module Gori::Miner
         raw = send_with_retries(Inject.apply(@base, location, [{name, c}], @config.add_content_length_when_missing?))
         next if raw.error
         probe = Fingerprint.probe(raw)
-        last_status = probe.metrics.status
-        last_delta = probe.metrics.length - r.base_length
         decision = Miner.decide(r, probe, {c => name}, location)
         if matches_evidence?(decision, evidence, name)
           hits += 1
+          # Only record status/delta from a round that actually reproduced the signal, so a
+          # Confirmed finding's reported evidence can't come from a non-matching (flaky) round.
+          last_status = probe.metrics.status
+          last_delta = probe.metrics.length - r.base_length
           last_canary = c if evidence.reflection?
         end
       end

--- a/src/gori/miner/wordlist.cr
+++ b/src/gori/miner/wordlist.cr
@@ -17,9 +17,9 @@ module Gori::Miner
     # preserved. A missing/unreadable user path raises File::Error → the frontend reports it.
     def self.load(user_path : String? = nil) : Array(String)
       names = builtin.dup
-      if path = user_path
-        unless path.strip.empty?
-          File.each_line(path) do |line|
+      if path = user_path.try(&.strip)
+        unless path.empty?
+          File.each_line(path) do |line| # open the STRIPPED path (the emptiness check used it too)
             stripped = line.strip
             names << stripped unless stripped.empty? || stripped.starts_with?('#')
           end

--- a/src/gori/prism/active/cors_reflection.cr
+++ b/src/gori/prism/active/cors_reflection.cr
@@ -31,7 +31,7 @@ module Gori
           resp = Proxy::Codec::Http1.parse_response_head(rhead)
           return nil unless resp.headers.get?("Access-Control-Allow-Origin")
           request = rebuild_with_origin(detail.request_head, detail.request_body, PROBE_ORIGIN)
-          key = "cors_reflection|#{detail.row.host}|#{req.method.upcase}|#{path_key(req.target)}"
+          key = "cors_reflection|#{detail.row.host}:#{detail.row.port}|#{req.method.upcase}|#{path_key(req.target)}"
           Plan.new(request, [] of Param, key)
         end
 

--- a/src/gori/prism/active/reflected_param.cr
+++ b/src/gori/prism/active/reflected_param.cr
@@ -50,10 +50,11 @@ module Gori
 
           return nil if params.empty? || params.size > MAX_PARAMS
           request = rebuild(detail.request_head, body, req.target, path, new_query, new_body)
-          # Key by rule + host + METHOD + path + (name@location) so the same path on a different
-          # method or parameter location is a distinct surface (no collision across rules either).
-          sig = params.map { |p| "#{p.name}@#{p.location}" }.sort!.join(",")
-          key = "reflected_param|#{detail.row.host}|#{req.method.upcase}|#{path}|#{sig}"
+          # Key by rule + host:PORT + METHOD + path + (name@location) so the same host on a
+          # different port/service is a distinct surface. Length-prefix each name so a param
+          # name containing '@'/','/':' can't collide with a different multi-param set.
+          sig = params.map { |p| "#{p.name.bytesize}:#{p.name}@#{p.location}" }.sort!.join(",")
+          key = "reflected_param|#{detail.row.host}:#{detail.row.port}|#{req.method.upcase}|#{path}|#{sig}"
           Plan.new(request, params, key)
         end
 

--- a/src/gori/prism/from_replay.cr
+++ b/src/gori/prism/from_replay.cr
@@ -15,7 +15,10 @@ module Gori
       return nil if host.empty?
 
       req_text = record.request
-      sep = req_text.index("\r\n\r\n") || req_text.index("\n\n")
+      # Take whichever blank-line boundary occurs FIRST — the editor uses bare-LF, so a
+      # literal "\r\n\r\n" inside the body must not win over the true earlier "\n\n" head
+      # boundary (the naive `crlf || lf` fallback would snap to the body's sequence).
+      sep = [req_text.index("\r\n\r\n"), req_text.index("\n\n")].compact.min?
       req_head_s = sep ? req_text[0, sep] : req_text
       req_body_s = if sep
                      n = req_text[sep, 4]? == "\r\n\r\n" ? 4 : 2

--- a/src/gori/prism/passive/auth.cr
+++ b/src/gori/prism/passive/auth.cr
@@ -16,7 +16,9 @@ module Gori
         def check(ctx : Context, acc : Array(Detection)) : Nil
           return unless ctx.scheme == "http" # over TLS the credentials are transport-protected
 
-          if (a = ctx.req.headers.get?("Authorization")) && basic?(a)
+          if ctx.req.headers.get_all("Authorization").any? { |v| basic?(v) }
+            # get_all, not get? (last-only): a duplicated Authorization header could hide the
+            # real Basic credential behind a later Bearer, mirroring the response-side WWW-Auth check.
             acc << det(ctx, "HTTP Basic credentials sent over cleartext HTTP",
               Store::Severity::High, "request Authorization: Basic")
             return # one finding per flow is enough; the request side is the stronger signal
@@ -34,7 +36,25 @@ module Gori
         # the first. (Auth-param values can also carry commas, but a real Basic challenge's scheme
         # token still opens one of the comma segments.)
         private def offers_basic?(value : String) : Bool
-          value.split(',').any? { |seg| basic?(seg) }
+          split_challenges(value).any? { |seg| basic?(seg) }
+        end
+
+        # Split on TOP-LEVEL commas only — a comma inside a quoted auth-param value (e.g.
+        # `Digest realm="a, basic mode off"`) must not spawn a bogus "basic …" challenge segment.
+        private def split_challenges(value : String) : Array(String)
+          segs = [] of String
+          in_quote = false
+          start = 0
+          value.each_char_with_index do |c, i|
+            if c == '"'
+              in_quote = !in_quote
+            elsif c == ',' && !in_quote
+              segs << value[start...i]
+              start = i + 1
+            end
+          end
+          segs << value[start..]
+          segs
         end
 
         # An auth header/challenge whose scheme token is `Basic` (case-insensitive, leading

--- a/src/gori/prism/passive/body_leaks.cr
+++ b/src/gori/prism/passive/body_leaks.cr
@@ -32,7 +32,9 @@ module Gori
           # A Java/.NET exception only counts as a disclosure when error-shaped: followed by a
           # `: message` or a newline-`at` frame — not when merely named in prose.
           {/\bjava\.lang\.[A-Z]\w+(?:Error|Exception)(?::|\r?\n\s*at )/, "Java exception"},
-          {/\bat org\.springframework\.[\w.]{4,}/, "Spring framework trace"},
+          # Require a real stack-frame shape (start-of-line `at …(` call site) like the sibling
+          # Java/Node frames — a bare "…at org.springframework.Foo…" in prose must NOT match.
+          {/(?:\n|\A)\s*at org\.springframework\.[\w.$]{4,}\(/, "Spring framework trace"},
           {/\bSystem\.[A-Z]\w+Exception(?::|\r?\n\s*at )/, ".NET exception"},
           # Rails: any ActiveRecord class, but only when error-shaped (`: message` / newline-
           # `at`), so a real error (RecordNotFound, Rollback, StatementInvalid, …) is caught
@@ -125,10 +127,14 @@ module Gori
         # sits immediately before it (within a short window of the text preceding the match), e.g.
         # `File version 10.0.1.2` or `{"version":"10.0.0.0"}`. Keeps a genuine leak (`backend at
         # 10.0.0.5`) flagged while dropping the ubiquitous 4-part-version false positive.
+        # The keyword must be the last token before the number (allowing quotes/`:`/`=`/space
+        # separators, as in `version: 10.0.1.2` or `{"version":"10.0.0.0"}`) — an incidental
+        # earlier mention ("Our firmware serves 10.0.0.5") must NOT suppress a genuine IP leak.
+        VERSION_CONTEXT = /(?:version|build|assembly|revision|firmware)["'\s:=]*\z/i
+
         private def version_context?(pre : String) : Bool
-          tail = (pre.size > 24 ? pre[(pre.size - 24)..] : pre).downcase
-          tail.includes?("version") || tail.includes?("build") || tail.includes?("assembly") ||
-            tail.includes?("revision") || tail.includes?("firmware")
+          tail = pre.size > 24 ? pre[(pre.size - 24)..] : pre
+          VERSION_CONTEXT.matches?(tail)
         end
       end
     end

--- a/src/gori/prism/passive/cookies.cr
+++ b/src/gori/prism/passive/cookies.cr
@@ -27,8 +27,11 @@ module Gori
             name = (eq ? nv[0...eq] : nv).strip
             value = (eq ? nv[(eq + 1)..] : "").strip
             flags = segs[1..].map(&.strip.downcase)
+            # Keep the ORIGINAL-case Expires value for date parsing (flags are lowercased above,
+            # which would break HTTP_DATE's month/day names).
+            expires_val = segs[1..].map(&.strip).find { |f| f.downcase.starts_with?("expires=") }.try { |f| f.partition('=')[2].strip }
             # A cookie being deleted holds no secret — skip its hygiene (avoids logout/reset FPs).
-            next if deletion?(value, flags)
+            next if deletion?(value, flags, expires_val)
 
             has_secure = flags.includes?("secure")
             prefixed = check_prefix(ctx, name, flags, has_secure, acc)
@@ -57,9 +60,19 @@ module Gori
         #     sets it, and frameworks clear with a sentinel value (PHP emits `sid=deleted;
         #     Max-Age=0`), so requiring an empty value would miss the common logout pattern.
         #   * Otherwise, an EMPTY value paired with an Expires attribute is the classic clear.
-        private def deletion?(value : String, flags : Array(String)) : Bool
+        private def deletion?(value : String, flags : Array(String), expires : String?) : Bool
           return true if flags.any? { |f| max_age_delete?(f) }
-          value.empty? && flags.any?(&.starts_with?("expires="))
+          return false unless value.empty? && expires
+          expires_past?(expires)
+        end
+
+        # An Expires already at/before now is a real clear. An UNparsable/odd date is treated as a
+        # deletion too, so a framework clearing a cookie with a sentinel date isn't spammed with
+        # hygiene findings — only a genuinely FUTURE-dated empty cookie keeps its hygiene checks.
+        private def expires_past?(expires : String) : Bool
+          Time::Format::HTTP_DATE.parse(expires) <= Time.utc
+        rescue
+          true
         end
 
         # Max-Age with a non-positive value (0 or negative) — an immediate deletion (RFC 6265).

--- a/src/gori/prism/passive/cors.cr
+++ b/src/gori/prism/passive/cors.cr
@@ -8,8 +8,12 @@ module Gori
       class Cors < Rule
         def check(ctx : Context, acc : Array(Detection)) : Nil
           return unless resp = ctx.response
-          acao = resp.headers.get?("Access-Control-Allow-Origin").try(&.strip)
-          return unless acao
+          # The CORS algorithm requires EXACTLY one ACAO header; with zero or several the
+          # browser fails the check and blocks the response, so any "finding" would be a
+          # non-exploitable false positive (a common proxy+app double-add misconfig).
+          acao_all = resp.headers.get_all("Access-Control-Allow-Origin")
+          return unless acao_all.size == 1
+          acao = acao_all.first.strip
           creds = resp.headers.get?("Access-Control-Allow-Credentials").try(&.downcase.strip) == "true"
           if acao == "*"
             # `*` + Allow-Credentials is REJECTED by browsers (the credentialed request fails),

--- a/src/gori/prism/passive/secrets.cr
+++ b/src/gori/prism/passive/secrets.cr
@@ -9,6 +9,7 @@ module Gori
           {/\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/, "AWS access key id"},
           {/\bAIza[0-9A-Za-z_\-]{35}\b/, "Google API key"},
           {/\bgh[pousr]_[0-9A-Za-z]{36}\b/, "GitHub token"},
+          {/\bgithub_pat_[0-9A-Za-z_]{22,}\b/, "GitHub fine-grained token"},
           {/\bglpat-[0-9A-Za-z_\-]{20}\b/, "GitLab token"},
           {/\bxox[baprs]-[0-9A-Za-z\-]{10,}/, "Slack token"},
           # Stripe LIVE keys only (test keys aren't sensitive); the prefix is distinctive.

--- a/src/gori/prism/passive/security_headers.cr
+++ b/src/gori/prism/passive/security_headers.cr
@@ -10,7 +10,7 @@ module Gori
         def check(ctx : Context, acc : Array(Detection)) : Nil
           return unless resp = ctx.response
           if ctx.scheme == "https"
-            hsts = resp.headers.get?("Strict-Transport-Security")
+            hsts = resp.headers.get_all("Strict-Transport-Security").first? # RFC 6797 §8.1: UA honours the FIRST STS header
             if hsts.nil? || hsts_disabled?(hsts)
               acc << hdr(ctx, "missing_hsts", "Missing or disabled HSTS header", Store::Severity::Medium)
             end

--- a/src/gori/prism/passive/tech.cr
+++ b/src/gori/prism/passive/tech.cr
@@ -98,7 +98,9 @@ module Gori
           return false unless req_ct.try(&.downcase.includes?("json"))
           body = ctx.detail.request_body
           return false unless body
-          text = String.new(body[0, {body.size, 8192}.min]).scrub
+          # 8 KB truncated mid-JSON on real GraphQL requests (a sizeable `variables` object),
+          # which then fails JSON.parse and mis-classified them as non-GraphQL; allow up to 256 KB.
+          text = String.new(body[0, {body.size, 256 * 1024}.min]).scrub
           q = begin
             JSON.parse(text).as_h?.try(&.["query"]?).try(&.as_s?)
           rescue JSON::ParseException

--- a/src/gori/project_registry.cr
+++ b/src/gori/project_registry.cr
@@ -68,6 +68,7 @@ module Gori
       display = name.strip
       slug = slugify(display)
       raise Gori::Error.new("invalid project name") if slug.empty?
+      slug = unique_slug(slug, display) # don't merge into a DIFFERENT project that slugifies alike
       dir = File.join(@root, slug)
       FileUtils.mkdir_p(dir)
       # Persist the verbatim display name so a later `list` shows "My Project", not
@@ -82,6 +83,28 @@ module Gori
         s.close
       end
       proj
+    end
+
+    # Keep `slug` when the directory is free OR already belongs to a project with the SAME
+    # display name (reopen-by-name, the documented behaviour); otherwise append -2/-3/… so two
+    # different names that slugify identically ("Test Project" vs "test!project") don't overwrite
+    # or merge each other's captured data.
+    private def unique_slug(slug : String, display : String) : String
+      candidate = slug
+      n = 2
+      while collides_with_other?(candidate, display)
+        candidate = "#{slug}-#{n}"
+        n += 1
+      end
+      candidate
+    end
+
+    # True when `slug` is an existing project WITH DATA (a real DB) whose stored display name
+    # differs from `display` — i.e. a genuine collision, not a same-name reopen or an empty dir.
+    private def collides_with_other?(slug : String, display : String) : Bool
+      dir = File.join(@root, slug)
+      return false unless Dir.exists?(dir) && File.exists?(File.join(dir, Project::DB_FILE))
+      display_name(dir, slug).downcase != display.downcase
     end
 
     # A throwaway workspace, deleted when its session closes.

--- a/src/gori/proxy/codec/body.cr
+++ b/src/gori/proxy/codec/body.cr
@@ -116,9 +116,16 @@ module Gori::Proxy::Codec
       s = resp.status
       return {BodyFraming::None, 0_i64} if (s >= 100 && s < 200) || s == 204 || s == 304
 
-      if chunked?(resp.headers.get_all("Transfer-Encoding"))
+      te = resp.headers.get_all("Transfer-Encoding")
+      if chunked?(te)
         reject_te_with_cl(resp.headers)
         {BodyFraming::Chunked, 0_i64}
+      elsif te_present?(te)
+        # RFC 7230 §3.3.3 rule 3: a response with a non-chunked Transfer-Encoding (e.g.
+        # `identity`/`gzip`) is close-delimited — TE takes precedence over any Content-Length
+        # (the CL.TE ambiguity). Framing by CL would leave the real body on the wire to
+        # misframe the next response on a reused upstream (a response-desync primitive).
+        {BodyFraming::CloseDelimited, 0_i64}
       elsif cl = content_length(resp.headers)
         {BodyFraming::Length, cl}
       else

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -94,7 +94,16 @@ module Gori::Proxy
 
       started = Time.instant
       created_at = now_us
-      host, port, scheme, forward_head = resolve_forward(req)
+      # A client-supplied absolute-form target with a bad/oversized port makes URI.parse
+      # raise; keep the malformed attempt visible in History instead of letting it unwind
+      # to run's blanket rescue (which would silently drop the flow and kill the connection).
+      begin
+        host, port, scheme, forward_head = resolve_forward(req)
+      rescue ex : URI::Error | OverflowError
+        record_error(req, @scheme, req.host? || "", 0, created_at, "malformed absolute-form target: #{ex.message}")
+        write_gateway_error
+        return false
+      end
 
       # Refuse to forward a request whose (override-resolved) target is gori's own
       # listener — otherwise gori dials itself, accepts that as a new client, and
@@ -285,7 +294,10 @@ module Gori::Proxy
       # Match&Replace (response head). Framing/keep-alive/upgrade stay on the
       # ORIGINAL response so the upstream body is read correctly.
       sent_resp_head, sent_resp = apply_response_rewrite(resp_head, resp)
-      framing = response_framing_or_close(resp, req.method, flow_id)
+      # Body framing must reflect the method the ORIGIN actually received (HEAD/CONNECT
+      # are bodyless per RFC 7230 §3.3.3). A Match&Replace / intercept edit can rewrite
+      # the request-line method, so key off sent_req, not the client's original req.
+      framing = response_framing_or_close(resp, sent_req.method, flow_id)
       return false unless framing
       resp_framing, resp_len = framing
 

--- a/src/gori/proxy/h2/assembler.cr
+++ b/src/gori/proxy/h2/assembler.cr
@@ -152,9 +152,15 @@ module Gori::Proxy::H2
     # initial headers rather than clobbering them.
     private def finish_header_block(side : Side, decoder : HPACK::Decoder) : Nil
       decoded = decoder.decode(side.header_buf.to_slice)
-      if existing = side.headers
+      if (existing = side.headers) && !decoded.any? { |(n, _)| n == ":status" }
+        # Trailers (no :status) append to the existing header list — grpc-status et al.
         existing.concat(decoded)
       else
+        # First block, OR a status-bearing response block. An interim 1xx (100/103)
+        # response precedes the final one on the same stream; the final status block
+        # REPLACES the interim rather than concatenating (which would leave the 1xx
+        # :status first and mis-report the flow's status). This also bounds a stream's
+        # header list against a flood of repeated interim HEADERS blocks.
         side.headers = decoded
       end
     ensure

--- a/src/gori/proxy/h2/grpc.cr
+++ b/src/gori/proxy/h2/grpc.cr
@@ -12,7 +12,7 @@ module Gori::Proxy::H2
     record Message, compressed : Bool, data : Bytes
 
     def self.grpc?(content_type : String?) : Bool
-      !!content_type.try(&.lstrip.starts_with?("application/grpc"))
+      !!content_type.try(&.lstrip.downcase.starts_with?("application/grpc")) # media types are case-insensitive
     end
 
     # gRPC status codes (https://grpc.io/docs/guides/status-codes/). 0 = OK; the

--- a/src/gori/proxy/tls/cert_builder.cr
+++ b/src/gori/proxy/tls/cert_builder.cr
@@ -1,3 +1,4 @@
+require "socket"
 require "./key_pair"
 
 module Gori::Proxy::Tls
@@ -74,7 +75,9 @@ module Gori::Proxy::Tls
     # anything else skip it (the cert then lacks a SAN and fails verification for
     # that bogus host — the safe outcome) rather than minting an injected cert.
     private def self.safe_san?(host : String) : Bool
-      !host.empty? && host.bytesize <= 253 && (host =~ /\A[A-Za-z0-9.\-*]+\z/) != nil
+      return false if host.empty? || host.bytesize > 253
+      return true if (host =~ /\A[A-Za-z0-9.\-*]+\z/) != nil # hostname / IPv4 / wildcard labels
+      ipv6?(host) # IPv6 literals contain ':' (rejected by the DNS charset above)
     end
 
     # An IP-literal CONNECT/SNI target must get an iPAddress SAN, not a dNSName:
@@ -83,7 +86,7 @@ module Gori::Proxy::Tls
     # MITM of any HTTPS target addressed by IP. The IPv4 character set is a subset
     # of safe_san?'s, so this stays injection-safe.
     private def self.san_value(host : String) : String
-      ipv4?(host) ? "IP:#{host}" : "DNS:#{host}"
+      ipv4?(host) || ipv6?(host) ? "IP:#{host}" : "DNS:#{host}"
     end
 
     # CANONICAL dotted-quad only. OpenSSL's IP-SAN parser (a2i_GENERAL_NAME) rejects
@@ -99,6 +102,16 @@ module Gori::Proxy::Tls
         next false if o.size > 1 && o[0] == '0' # no leading zeros
         o.to_u8? != nil                         # 0..255
       end
+    end
+
+    # Canonical IPv6 literal (bare, no brackets / no %zone). An IP-literal HTTPS target
+    # needs an iPAddress SAN just like IPv4, or RFC-6125 clients reject the leaf. The
+    # charset guard excludes ',' (X509v3 nconf entry separator) and '%' (zone id), so the
+    # value stays injection-safe and parseable by OpenSSL's a2i_IPADDRESS; anything else
+    # falls through to a DNS SAN (won't verify for that odd literal, but never crashes).
+    private def self.ipv6?(host : String) : Bool
+      return false unless (host =~ /\A[0-9A-Fa-f:.]+\z/) != nil
+      Socket::IPAddress.valid_v6?(host)
     end
 
     private def self.add_ext(x : LibCrypto::X509, nid : Int32, value : String) : Nil

--- a/src/gori/proxy/upstream.cr
+++ b/src/gori/proxy/upstream.cr
@@ -68,10 +68,17 @@ module Gori::Proxy
                                  connect_timeout : Time::Span = CONNECT_TIMEOUT,
                                  io_timeout : Time::Span = IO_TIMEOUT) : TCPSocket?
       sock = TCPSocket.new(host, port, connect_timeout: connect_timeout)
-      sock.sync = true # flush writes immediately (P6)
-      sock.tcp_nodelay = true
-      sock.read_timeout = io_timeout
-      sock.write_timeout = io_timeout
+      begin
+        sock.sync = true # flush writes immediately (P6)
+        sock.tcp_nodelay = true
+        sock.read_timeout = io_timeout
+        sock.write_timeout = io_timeout
+      rescue
+        # A peer RST between connect and option-setup would otherwise leak the open fd
+        # (the outer rescue returns nil without closing it) — close it first.
+        sock.close rescue nil
+        return nil
+      end
       sock
     rescue
       nil

--- a/src/gori/proxy/ws/relay.cr
+++ b/src/gori/proxy/ws/relay.cr
@@ -46,8 +46,15 @@ module Gori::Proxy::WS
         message_opcode = h.opcode if h.data? && h.opcode != OP_CONT
 
         if h.len > WS::MAX_FRAME
+          # Flush any buffered leading fragments of this message before the oversized-frame
+          # marker, so captured prefix bytes aren't dropped and a later small FIN fragment
+          # can't be surfaced as if it were the whole message.
+          if h.data? && assembling.size > 0
+            sink.on_ws_message(flow_id, direction, message_opcode.to_i, assembling.to_slice.dup)
+            assembling = assembling.size > RESET_THRESHOLD ? IO::Memory.new : assembling.tap(&.clear)
+          end
           break unless forward_oversized_frame(src, dst, h, direction, flow_id, sink, message_opcode, scratch)
-          assembling = assembling.size > RESET_THRESHOLD ? IO::Memory.new : assembling.tap(&.clear) if h.data? && h.fin?
+          break if h.close? # an oversized CLOSE still terminates the tunnel, like a normal one
           next
         end
 
@@ -80,8 +87,8 @@ module Gori::Proxy::WS
     # Forwards a frame whose payload exceeds MAX_FRAME byte-exact (P7) by streaming
     # it rather than buffering — the capture cap bounds the projection, not the
     # forward. Returns false if the peer died mid-payload (caller ends the
-    # direction). A data frame's final fragment is surfaced as a marker (its payload
-    # is too large to capture) so it isn't silently lost.
+    # direction). ANY oversized data frame (final or not) is surfaced as a marker so
+    # it isn't silently lost — a non-final oversized fragment would leave no trace.
     private def self.forward_oversized_frame(src : IO, dst : IO, h : WS::Header, direction : String,
                                              flow_id : Int64, sink : FlowSink, message_opcode : UInt8,
                                              scratch : Bytes) : Bool
@@ -89,7 +96,7 @@ module Gori::Proxy::WS
       forwarded = WS.stream_payload(src, dst, h.len, scratch)
       dst.flush
       return false unless forwarded # peer died mid-payload
-      if h.data? && h.fin?
+      if h.data?
         marker = "[gori] #{h.len}-byte WebSocket frame forwarded; too large to capture".to_slice
         sink.on_ws_message(flow_id, direction, message_opcode.to_i, marker)
       end

--- a/src/gori/replay/flow_request.cr
+++ b/src/gori/replay/flow_request.cr
@@ -40,13 +40,22 @@ module Gori
       # cut mid-stream) with a Content-Length over those bytes so the origin reads a complete
       # body. Case-insensitive header-name match; preserves each line's CRLF/LF terminator.
       private def self.resync_truncated_head(head : Bytes, length : Int32) : Bytes
+        cl_written = false
         String.build do |io|
           String.new(head).each_line(chomp: false) do |line|
             lname = line.lstrip
             eol = line.ends_with?("\r\n") ? "\r\n" : (line.ends_with?('\n') ? "\n" : "")
             if lname[0, 15]?.try(&.downcase) == "content-length:" ||
                lname[0, 18]?.try(&.downcase) == "transfer-encoding:"
-              io << "Content-Length: " << length << eol # RFC 7230 forbids TE+CL, so only one fires
+              # A truncated body is re-framed with ONE Content-Length. If the capture had
+              # BOTH CL and TE (a CL.TE/TE.CL smuggling probe), collapse them into a single
+              # Content-Length instead of emitting a duplicate — RFC 7230 forbids TE+CL.
+              if cl_written
+                next # drop the second framing header
+              else
+                io << "Content-Length: " << length << eol
+                cl_written = true
+              end
             else
               io << line
             end

--- a/src/gori/replay/h2_engine.cr
+++ b/src/gori/replay/h2_engine.cr
@@ -250,9 +250,15 @@ module Gori
                                      port : Int32) : {Array({String, String}), Bytes?}
         head_bytes, body = split_head_body(request)
         lines = String.new(head_bytes).split('\n').map(&.rstrip('\r'))
-        parts = (lines[0]? || "GET / HTTP/2").split(' ')
-        method = parts[0]? || "GET"
-        path = parts[1]? || "/"
+        # The path may contain a raw (unencoded) space — common in fuzzer / smuggling
+        # captures — so bound it by the FIRST and LAST space rather than taking the
+        # second whitespace-split token (which would truncate at the first inner space).
+        line = lines[0]? || "GET / HTTP/2"
+        first_sp = line.index(' ')
+        last_sp = line.rindex(' ')
+        method = first_sp ? line[0...first_sp] : line
+        path = (first_sp && last_sp && last_sp > first_sp) ? line[(first_sp + 1)...last_sp] : "/"
+        path = "/" if path.empty?
 
         headers = [{":method", method}, {":path", path}, {":scheme", scheme},
                    {":authority", authority(host, port, scheme)}]

--- a/src/gori/saml.cr
+++ b/src/gori/saml.cr
@@ -58,7 +58,10 @@ module Gori
     # The response side: an IdP auto-POST HTML form carrying the SAMLResponse back.
     private def from_response_html(resp_body : Bytes?) : Doc?
       return nil if resp_body.nil? || resp_body.empty? || resp_body.size > MAX_XML
-      s = String.new(resp_body)
+      # scrub: String.new does NOT validate UTF-8, and Regex#match (below, in from_html_form)
+      # raises on an invalid byte — a hostile/binary response body with "SAMLResponse" in it
+      # would otherwise crash every surface that decodes SAML (TUI detail, `run show`, MCP).
+      s = String.new(resp_body).scrub
       s.includes?("SAMLResponse") ? from_html_form(s) : nil
     end
 
@@ -146,7 +149,9 @@ module Gori
         end
       end
       return nil unless param && raw
-      value = URI.decode_www_form(raw) rescue raw
+      # plus_to_space: false — '+' is a standard base64 alphabet char here; treating it as a
+      # space (then stripped by decode_value's whitespace gsub) would corrupt the payload.
+      value = URI.decode_www_form(raw, plus_to_space: false) rescue raw
       dec = decode_value(value) || return nil
       Doc.new(param, dec[1], location, relay, dec[0])
     end

--- a/src/gori/session.cr
+++ b/src/gori/session.cr
@@ -174,7 +174,6 @@ module Gori
       # (which would leak the flock + writer fiber + fibers) or, via a caller's `ensure`,
       # replace the real exception being unwound.
       (CaptureStatus.clear(@project.dir) if capturing_lock_held?) rescue nil
-      @capture_lock.try(&.close) # release the flock so a later open of this project can capture
       # Stop Prism FIRST so its active workers wind down and its passive fiber stops issuing
       # get_flow against a live DB; this also closes the prism_events channel it consumes.
       @prism.stop
@@ -187,6 +186,10 @@ module Gori
       # channel as defense-in-depth — incl. the now-closed prism_events.)
       @store.close
       @flow_events.close
+      # Release the capture flock LAST — only after this session's store + prism have torn
+      # down — so a second instance racing to reopen the same project can't become
+      # concurrently live (its own analyzer/store touching shared state) while ours winds down.
+      @capture_lock.try(&.close)
       @project.cleanup
     end
   end

--- a/src/gori/session.cr
+++ b/src/gori/session.cr
@@ -161,13 +161,19 @@ module Gori
     def sync_capture_status! : Nil
       return unless capturing_lock_held?
       CaptureStatus.write(@project.dir, @proxy.host, @proxy.port, capturing?)
+    rescue
+      # The capture-status file is a purely informational sidecar; a write failure
+      # (disk full, dir vanished) must not abort session open / capture toggle / settings.
     end
 
     def close : Nil
       @interceptor.release_all # unblock held fibers FIRST so they can write final rows
       @proxy.stop
       @store.abandon_pending!("proxy stopped before response")
-      CaptureStatus.clear(@project.dir) if capturing_lock_held?
+      # Best-effort: a delete failure here must not skip the lock/prism/store teardown below
+      # (which would leak the flock + writer fiber + fibers) or, via a caller's `ensure`,
+      # replace the real exception being unwound.
+      (CaptureStatus.clear(@project.dir) if capturing_lock_held?) rescue nil
       @capture_lock.try(&.close) # release the flock so a later open of this project can capture
       # Stop Prism FIRST so its active workers wind down and its passive fiber stops issuing
       # get_flow against a live DB; this also closes the prism_events channel it consumes.

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -1511,7 +1511,10 @@ module Gori
           # branch can block or throw back into the loop.
           if committed
             deferred.each(&.call)
-            @inserts_since_prune += ops.count(&.is_a?(InsertFlow))
+            # Count bulk-import rows too — an InsertImportBatch inserts many flows in ONE op,
+            # so counting it as a single InsertFlow (or 0) let a large import bypass the
+            # retention sweep, keeping the DB far over its cap until enough live captures accrue.
+            @inserts_since_prune += ops.sum { |op| op.is_a?(InsertFlow) ? 1 : (op.is_a?(InsertImportBatch) ? op.pairs.size : 0) }
             if @inserts_since_prune >= @prune_interval
               prune(conn)
               @inserts_since_prune = 0

--- a/src/gori/store/schema.cr
+++ b/src/gori/store/schema.cr
@@ -7,7 +7,7 @@ module Gori
     # (FTS5 for QL, a tags table, a connections table) arrive as *later*
     # migrations — which is exactly why none of them exist in v1 (P0).
     module Schema
-      VERSION = 28
+      VERSION = 29
 
       # The migration that reclaims duplicated/low-value bytes already on disk (see V25).
       # Store.open runs a one-time VACUUM after an EXISTING db crosses this version so the

--- a/src/gori/tui/browser_picker.cr
+++ b/src/gori/tui/browser_picker.cr
@@ -13,6 +13,7 @@ module Gori::Tui
 
     def initialize(@browsers : Array(Browser::Found))
       @selected = 0
+      @scroll = 0
     end
 
     def move(delta : Int32) : Nil
@@ -42,7 +43,15 @@ module Gori::Tui
       i = my - list_top
       return nil if i < 0 || i >= list_h
       return nil if mx < box.x + 1 || mx >= box.right - 1
-      i < @browsers.size ? i : nil
+      ri = @scroll + i
+      ri < @browsers.size ? ri : nil
+    end
+
+    private def ensure_visible(list_h : Int32) : Nil
+      return if list_h <= 0
+      @scroll = @selected if @selected < @scroll
+      @scroll = @selected - list_h + 1 if @selected >= @scroll + list_h
+      @scroll = @scroll.clamp(0, {@browsers.size - list_h, 0}.max)
     end
 
     # Clamp + set the highlighted row (mirrors `move`'s clamp).
@@ -65,11 +74,13 @@ module Gori::Tui
 
       list_top = box.y + 3
       list_h = box.bottom - 1 - list_top
+      ensure_visible(list_h) # keep @selected on screen — the list can exceed list_h on a short terminal
       (0...list_h).each do |i|
-        break if i >= @browsers.size
-        b = @browsers[i]
+        ri = @scroll + i
+        break if ri >= @browsers.size
+        b = @browsers[ri]
         ry = list_top + i
-        active = i == @selected
+        active = ri == @selected
         bg = active ? Theme.accent_bg : Theme.panel
         screen.fill(Rect.new(box.x + 1, ry, w - 2, 1), bg)
         screen.cell(box.x + 1, ry, active ? '▎' : ' ', Theme.accent, bg)

--- a/src/gori/tui/choice_picker.cr
+++ b/src/gori/tui/choice_picker.cr
@@ -19,6 +19,7 @@ module Gori::Tui
     def initialize(@title : String, @choices : Array(Choice), @current : Int32, @kind : Symbol)
       # Open on the row that's currently set, so ↵ without moving is a no-op.
       @selected = @choices.index { |c| c.value == @current } || 0
+      @scroll = 0
     end
 
     # The coloured severity picker (Critical→Info), opened on the current level.
@@ -92,7 +93,15 @@ module Gori::Tui
       i = my - (box.y + 1)
       return nil if i < 0 || i >= rows
       return nil if mx <= box.x || mx >= box.right - 1
-      i
+      ci = @scroll + i
+      ci < @choices.size ? ci : nil
+    end
+
+    private def ensure_visible(rows : Int32) : Nil
+      return if rows <= 0
+      @scroll = @selected if @selected < @scroll
+      @scroll = @selected - rows + 1 if @selected >= @scroll + rows
+      @scroll = @scroll.clamp(0, {@choices.size - rows, 0}.max)
     end
 
     def render(screen : Screen, area : Rect) : Nil
@@ -102,10 +111,14 @@ module Gori::Tui
         return
       end
       Frame.card(screen, box, @title, border: Theme.border_focus)
-      @choices.each_with_index do |ch, i|
+      rows = {box.h - 2, @choices.size}.min
+      ensure_visible(rows) # keep the pre-selected 'current' row visible on a short terminal
+      (0...rows).each do |i|
+        ci = @scroll + i
+        break if ci >= @choices.size
+        ch = @choices[ci]
         ry = box.y + 1 + i
-        break if ry >= box.bottom - 1
-        active = i == @selected
+        active = ci == @selected
         bg = active ? Theme.accent_bg : Theme.panel
         screen.fill(Rect.new(box.x + 1, ry, box.w - 2, 1), bg)
         screen.cell(box.x + 1, ry, active ? '▎' : ' ', Theme.accent, bg)

--- a/src/gori/tui/controllers/comparer_controller.cr
+++ b/src/gori/tui/controllers/comparer_controller.cr
@@ -130,7 +130,10 @@ module Gori::Tui
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
       @host.focus_body
-      inner = rect.inset(1, 1)
+      # Carve the sub-tab strip too (like Convert/Notes), not just the border — the view
+      # renders the REQ/RES chips inside the strip-carved content rect, so a plain
+      # inset(1,1) would hit-test STRIP_H rows too high and never match the chips.
+      inner = BodyChrome.content_rect(rect, strip: subtab_strip_shown?)
       if pane = view.pane_chip_at(inner, mx, my)
         view.set_pane(pane)
       end

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -707,6 +707,13 @@ module Gori::Tui
     end
 
     private def start_run(v : FuzzerView, engine : Fuzz::Engine, total : Int64?) : Nil
+      # A peer may have closed this session (reconcile evicted the tab) while its RUN FUZZ
+      # confirm dialog was pending — don't launch an unstoppable engine fiber + orphaned job
+      # into a detached view whose events drain_events would then drop forever.
+      unless @fuzzers.any?(&.view.same?(v))
+        @host.status("fuzz session no longer open — run cancelled")
+        return
+      end
       save_current
       v.begin_run(total)
       v.job_id = @host.jobs.start(:fuzz, v.summary, goto: goto_for(v))

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -286,8 +286,8 @@ module Gori::Tui
 
     # Copy the selected flow's raw request (head + body, byte-exact P7) to the
     # system clipboard via OSC 52.
-    def copy_selection : Nil
-      id = @history.selected_id
+    def copy_selection(id : Int64? = nil) : Nil
+      id ||= @history.selected_id
       return unless id
       detail = @host.session.store.get_flow(id)
       unless detail

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -87,6 +87,12 @@ module Gori::Tui
         return true
       end
       @host.focus_body
+      # A click that selects a row / opens detail also exits QL edit mode (applying the query,
+      # like Enter) — otherwise @querying stays set and later keys are hijacked into the filter bar.
+      if @history.querying?
+        flush_query_reload
+        @history.stop_query
+      end
       # Preview pane click focuses that side (settings:layout).
       if pane = @history.preview_pane_at(inner, mx, my)
         @history.set_preview_focus(pane)

--- a/src/gori/tui/controllers/intercept_controller.cr
+++ b/src/gori/tui/controllers/intercept_controller.cr
@@ -265,7 +265,10 @@ module Gori::Tui
 
     def intercept_forward_all : Nil
       n = @host.session.interceptor.pending_count
-      @host.session.interceptor.forward_all
+      # Carry the currently-loaded item's in-progress edit into the bulk forward, so
+      # "forward all" doesn't send its stale original bytes (single-forward already does).
+      overrides = @intercept.pending_edit.try { |e| {e[0] => e[1]} }
+      @host.session.interceptor.forward_all(overrides)
       @intercept.reload(@host.session.interceptor)
       @host.status("forwarded all (#{n})")
     end

--- a/src/gori/tui/controllers/replay_controller.cr
+++ b/src/gori/tui/controllers/replay_controller.cr
@@ -892,6 +892,7 @@ module Gori::Tui
 
     def replay_send : Nil
       return unless (tab = current_replay_tab) && (view = tab.view).loaded?
+      view.commit_chain_pane # flush an in-progress CHAIN-pane edit so ^R can't send stale bytes (matches the SEND-chip click)
       if view.inflight? # one outstanding round-trip per view — don't pile up fibers on ^R mashing
         @host.status("replay already in flight…")
         return

--- a/src/gori/tui/fuzz_set_overlay.cr
+++ b/src/gori/tui/fuzz_set_overlay.cr
@@ -66,9 +66,16 @@ module Gori::Tui
       when :numbers
         @ptype = :numbers
         range, _, step = spec.value.partition(':')
-        from, _, to = range.partition('-')
-        @fields[:from].set(from)
-        @fields[:to].set(to)
+        # Parse two (possibly negative) integers so reopening a set with a negative From
+        # shows the real values, not a corrupted split on the leading '-'.
+        if m = range.match(/\A(-?\d+)-(-?\d+)\z/)
+          @fields[:from].set(m[1])
+          @fields[:to].set(m[2])
+        else
+          from, _, to = range.partition('-')
+          @fields[:from].set(from)
+          @fields[:to].set(to)
+        end
         @fields[:step].set(step.empty? ? "1" : step)
       when :file
         @ptype = :wordlist

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -557,12 +557,15 @@ module Gori::Tui
       @results << r
       if @results.size > RESULT_CAP
         @results.shift
-        # A front eviction shifts every remaining row's position down by one; pin the
-        # selection and scroll to the same logical rows (default index view) so an open
-        # detail doesn't silently swap to a different result under the user. Filtered /
-        # sorted views re-clamp @sel at render, so this never over-shoots.
-        @sel -= 1 if @sel > 0
-        @scroll -= 1 if @scroll > 0
+        # Only the raw index view (no filter, no re-sort) shifts 1:1 with @results, so only
+        # there does pinning selection/scroll by -1 keep the same logical rows. In a
+        # matched-only or re-sorted view the evicted (usually unmatched) front row isn't at
+        # this position — @sel should stay put (the render clamp bounds it); a blind -1 there
+        # would retarget the open detail to a different result.
+        if @sort == :index && !@matched_only
+          @sel -= 1 if @sel > 0
+          @scroll -= 1 if @scroll > 0
+        end
       end
       @results_rev += 1 # grow AND ring-evict both bump (size is pinned once full)
     end

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -94,6 +94,11 @@ module Gori::Tui
       @run_count_sig = ""
       @results = [] of Fuzz::Result
       @results_rev = 0_i64 # bumped on every @results mutation — the DIST cache key
+      # The template snapshot the CURRENT run's results were generated from — the RESULT
+      # detail must reconstruct each request against this, not the live @editor buffer,
+      # which the user may have edited (adding/removing §…§ markers) since the run.
+      @run_template = nil.as(Fuzz::Template?)
+      @pending_template = nil.as(Fuzz::Template?)
       @sel = 0
       @scroll = 0
       @sort = :index
@@ -525,6 +530,7 @@ module Gori::Tui
 
     def begin_run(total : Int64?) : Nil
       @results.clear
+      @run_template = @pending_template # freeze the template these results are rendered against
       @results_rev += 1
       # A fresh run reuses result indices from 0, so drop the {pane, index}-keyed detail
       # cache — otherwise an old row's lines could survive under a colliding new index.
@@ -549,7 +555,15 @@ module Gori::Tui
 
     def append_result(r : Fuzz::Result) : Nil
       @results << r
-      @results.shift if @results.size > RESULT_CAP
+      if @results.size > RESULT_CAP
+        @results.shift
+        # A front eviction shifts every remaining row's position down by one; pin the
+        # selection and scroll to the same logical rows (default index view) so an open
+        # detail doesn't silently swap to a different result under the user. Filtered /
+        # sorted views re-clamp @sel at render, so this never over-shoots.
+        @sel -= 1 if @sel > 0
+        @scroll -= 1 if @scroll > 0
+      end
       @results_rev += 1 # grow AND ring-evict both bump (size is pinned once full)
     end
 
@@ -778,6 +792,7 @@ module Gori::Tui
         return {nil, err} # don't silently run match-everything on a bad pattern
       end
       template = Fuzz::Template.parse(Env.expand(@editor.text), @http2)
+      @pending_template = template # committed to @run_template in begin_run (see detail_request_bytes)
       return {nil, "mark a position first — ^A params · ^K word"} if template.position_count == 0
       return {nil, "add a payload set — ^O config · + Add set (^L for a List)"} if @sets.empty?
       scheme, host, port = Replay::FlowRequest.parse_target(Env.expand(@target))
@@ -811,8 +826,12 @@ module Gori::Tui
 
     private def build_numbers(value : String) : Fuzz::NumberRange
       range, _, step = value.partition(':')
-      from, _, to = range.partition('-')
-      Fuzz::NumberRange.new(from.to_i64? || 0_i64, to.to_i64? || 0_i64, step.to_i64? || 1_i64)
+      # Match two (possibly negative) integers, so a leading '-' on From isn't mistaken
+      # for the from/to separator (partition('-') would split "-5-5" as "" / "5-5").
+      m = range.match(/\A(-?\d+)-(-?\d+)\z/)
+      from = (m.try(&.[1].to_i64?)) || 0_i64
+      to = (m.try(&.[2].to_i64?)) || 0_i64
+      Fuzz::NumberRange.new(from, to, step.to_i64? || 1_i64)
     end
 
     private def build_brute(value : String) : Fuzz::BruteForce
@@ -1479,9 +1498,13 @@ module Gori::Tui
         draw_add_row(screen, inner, y, focused)
       else
         visible = {set_rows - 1, 1}.max # 1 row for the overflow hint, 1 for Add
-        idx = current_set_index || 0
-        @cfg_scroll = idx if idx < @cfg_scroll
-        @cfg_scroll = idx - visible + 1 if idx >= @cfg_scroll + visible
+        # Only re-anchor scroll to the cursor when it's actually on a set row; on a tail
+        # row (Add/Mode/Advanced/Run) current_set_index is nil, and defaulting it to 0
+        # would snap a scrolled list back to the top on every render.
+        if idx = current_set_index
+          @cfg_scroll = idx if idx < @cfg_scroll
+          @cfg_scroll = idx - visible + 1 if idx >= @cfg_scroll + visible
+        end
         @cfg_scroll = @cfg_scroll.clamp(0, {@sets.size - visible, 0}.max)
         stop = {@cfg_scroll + visible, @sets.size}.min
         y = y0
@@ -1842,7 +1865,10 @@ module Gori::Tui
 
     # The reconstructed wire request for a result (template with its payloads spliced in).
     private def detail_request_bytes(r : Fuzz::Result) : Bytes
-      Fuzz::Template.parse(@editor.text, @http2).render(r.payloads)
+      # Render against the run's frozen template (env-expanded, as sent) so a post-run
+      # edit to the live buffer can't truncate/garble the reconstructed request.
+      tmpl = @run_template || Fuzz::Template.parse(Env.expand(@editor.text), @http2)
+      tmpl.render(r.payloads)
     end
 
     private def detail_request_lines(r : Fuzz::Result) : Array(String)

--- a/src/gori/tui/highlight.cr
+++ b/src/gori/tui/highlight.cr
@@ -409,18 +409,23 @@ module Gori::Tui
       ellipsis = overflow && limit > 1
 
       visual_col = 0
+      room = limit - (ellipsis ? 1 : 0)
+      done = false
       line.each do |span|
-        break if visual_col >= limit
+        break if done
         span.text.each_grapheme do |g|
           gw = Termisu::UnicodeWidth.grapheme_width(g.to_s)
-          room = limit - (ellipsis ? 1 : 0)
+          # The FIRST grapheme that doesn't fit terminates ALL rendering — a single
+          # continuous walk, so a later span can't resume into the leftover room and draw
+          # a narrower glyph in place of the skipped wide one (Screen#fit glyph parity).
           if visual_col + gw > room
+            done = true
             break
           end
           screen.cell(x + visual_col, y, g.to_s, span.fg, bg, span.attr)
           visual_col += gw
         end
-        break if visual_col >= limit
+        break if done || visual_col >= limit
       end
 
       if ellipsis && visual_col < limit

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -1295,7 +1295,9 @@ module Gori::Tui
       chip, chip_color = scope_on ? {"⇧S scope:#{@scope.try(&.size) || 0}", Theme.accent} : {"⇧S scope:off", Theme.muted}
       rx = rect.right - 1
       if filtering?
-        count = @rows.size.to_s
+        # @rows is capped at PAGE by the search LIMIT; show "N+" at the cap so the count
+        # isn't silently misread as the exact match total when more actually match.
+        count = @rows.size >= PAGE ? "#{PAGE}+" : @rows.size.to_s
         screen.text({rx - count.size, rect.x}.max, rect.y, count, Theme.muted)
         rx -= count.size + 2
       end

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -431,6 +431,9 @@ module Gori::Tui
       return false if @detail.nil?
       if idx = @rows.index { |r| r.id == id }
         @selected = idx
+        # A deep-linked OLDER flow must survive a live reload — otherwise follow mode snaps
+        # @selected back to the tail on the next data_version tick, losing the anchor.
+        @follow = false if idx != follow_index
       end
       # WebSocket flows (101) carry a captured message log; h2 flows link to their
       # connection's raw frame log. Both are loaded as a bounded most-recent window

--- a/src/gori/tui/hotkeys_overlay.cr
+++ b/src/gori/tui/hotkeys_overlay.cr
@@ -230,12 +230,15 @@ module Gori::Tui
         i = start + row
         break if i >= @rows.size
         r = @rows[i]
+        up = row == 0 && start > 0
+        down = row == cap - 1 && i < @rows.size - 1
         if r.kind == :header
           draw_header(screen, box, r, top + row)
+          # The boundary viewport row can land on a header; still show the ▲/▼ affordance
+          # (it was previously swallowed whenever the top/bottom row was a header).
+          draw_scroll_marker(screen, box.right - 2, top + row, Theme.panel, up: up, down: down)
         else
-          draw_binding(screen, box, i, top + row,
-            up: row == 0 && start > 0,
-            down: row == cap - 1 && i < @rows.size - 1)
+          draw_binding(screen, box, i, top + row, up: up, down: down)
         end
       end
       render_footer(screen, box)

--- a/src/gori/tui/hotkeys_overlay.cr
+++ b/src/gori/tui/hotkeys_overlay.cr
@@ -71,7 +71,10 @@ module Gori::Tui
 
     private def load_overrides : Hash(String, Verb::Chord?)
       out = {} of String => Verb::Chord?
-      Hotkeys.chord_overrides.each { |id, chords| out[id] = chords.first? }
+      # rebindable_overrides (not raw chord_overrides): drop stale overrides for now-FIXED/hidden
+      # verb ids that build_keymap ignores, so the editor's conflict check can't report a phantom
+      # "already bound" for a chord live dispatch never actually claims.
+      Hotkeys.rebindable_overrides(@registry).each { |id, chords| out[id] = chords.first? }
       out
     end
 

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -142,9 +142,14 @@ module Gori::Tui
       if @editing
         @editing = false
       elsif it = selected_item
-        @editor.set_text(String.new(it.raw))
+        # Only reload from pristine bytes when switching to a DIFFERENT held item; re-entering
+        # edit on the same item (Esc/Shift-Tab then back) must preserve the in-progress edit,
+        # mirroring detail_window_for's @detail_win_id guard.
+        if @loaded_id != it.id
+          @editor.set_text(String.new(it.raw))
+          @editor_dirty = false # freshly loaded — not yet modified
+        end
         @loaded_id = it.id
-        @editor_dirty = false # freshly loaded — not yet modified
         @editing = true
       end
     end
@@ -163,9 +168,19 @@ module Gori::Tui
     # update-CL decision lives here, in the human's editor, not the wire path. (An edit
     # still normalizes line endings — a text-editor limitation shared with Replay.)
     def forward_bytes(it : Interceptor::Item) : Bytes
-      return it.raw unless @loaded_id == it.id && @editor_dirty
+      edit = pending_edit
+      (edit && edit[0] == it.id) ? edit[1] : it.raw
+    end
+
+    # The {id, edited-bytes} of the currently-loaded held item IFF it has an unsaved edit,
+    # else nil. Keyed by @loaded_id (the item the editor holds) rather than the queue
+    # selection, so "forward all" can pick up an in-progress edit for whichever item is
+    # loaded even when the cursor has since moved to a different row.
+    def pending_edit : {Int64, Bytes}?
+      id = @loaded_id
+      return nil unless id && @editor_dirty
       raw = Env.expand(@editor.text).split('\n').join("\r\n").to_slice
-      Fuzz::ContentLength.sync(raw, add_when_missing: true)
+      {id, Fuzz::ContentLength.sync(raw, add_when_missing: true)}
     end
 
     # The method + target to DISPLAY for a held item — the EDITED values when this is

--- a/src/gori/tui/project_picker.cr
+++ b/src/gori/tui/project_picker.cr
@@ -236,7 +236,10 @@ module Gori::Tui
     # Description is optional and passed through to init the project metadata.
     private def safe_create(name : String, description : String = "") : Project?
       @registry.create(name, description)
-    rescue Gori::Error
+    rescue Gori::Error | IO::Error | DB::Error | SQLite3::Exception
+      # An invalid name (Gori::Error) OR a filesystem/DB failure — mkdir_p on an
+      # unwritable root, Store.open on a full/locked disk — must keep the picker up
+      # instead of unwinding to the event loop and crashing the whole TUI.
       nil
     end
 
@@ -266,6 +269,11 @@ module Gori::Tui
           @selected = 2
         rescue Gori::Error
           # became live between confirm and here — leave it in place
+        rescue IO::Error
+          # rm_rf hit a real filesystem failure (permission, locked file) — keep the TUI
+          # alive; refresh the list since the directory may be partially removed.
+          @projects = @registry.list
+          invalidate_running_cache
         end
       end
       cancel_confirm

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -221,7 +221,7 @@ module Gori::Tui
     end
 
     def focus_last : Nil
-      @pane = :desc
+      @pane = enabled_panes.last? || :settings # last pane in the ring (PROJECT SETTINGS)
     end
 
     # The 's' / scope.edit jump target: focus the SCOPE pane fresh (no half-open row in
@@ -611,7 +611,9 @@ module Gori::Tui
       ok = if id = @ov_edit_id
              @host_overrides.update(id, host, ip)
            else
-             @host_overrides.add(host, ip)
+             added = @host_overrides.add(host, ip)
+             @ov_sel = @host_overrides.entries.size - 1 if added # select the new row, like ENV add
+             added
            end
       return :dup unless ok
       cancel_ov_add

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -603,7 +603,10 @@ module Gori::Tui
     # ENVELOPE is always the authoritative wire request. Only when the payload changed.
     private def commit_decoded : Nil
       return unless @decode_kind && @decoded_dirty
-      @editor.set_text(sync_cl_text(splice_decoded_into(@editor.text)))
+      # Honour the Auto-Content-Length toggle like the plain / MARK send paths do; with
+      # Auto-CL off, an intentionally-desynced length (a smuggling test) must survive.
+      spliced = splice_decoded_into(@editor.text)
+      @editor.set_text(@auto_content_length ? sync_cl_text(spliced) : spliced)
       @decoded_dirty = false
     end
 
@@ -1150,7 +1153,10 @@ module Gori::Tui
       return if @req_hex_edit || @grpc_mode || @ws_mode
       return if @decode_kind && @req_pane == :decoded
 
-      raw = @editor.to_bytes
+      # Expand env tokens first (like the send path's expanded_editor_bytes) — a `$KEY`
+      # whose expansion changes the body length must reflect the SENT Content-Length, or
+      # the visible header goes stale and, once Auto-CL is toggled off, is sent mismatched.
+      raw = expanded_editor_bytes
       # In MARK-transform mode the CL that ^R actually sends is computed from the
       # RENDERED template (markers stripped, chains applied), not the raw marked text —
       # reflect THAT value so the visible header matches request_bytes.

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -624,6 +624,10 @@ module Gori::Tui
         end
       when :graphql
         if op = Graphql.from_flow(tgt, head, body)
+          # Recompute the re-encode target too (mirrors SAML): an envelope edit that moves the
+          # op from ?query=… (GET) to a JSON body (POST) must retarget the splice, else commit
+          # rewrites the wrong side and the origin reads the old, unedited query.
+          @graphql_location = Graphql.location(body)
           text = Graphql.display(op)
           @decoded.set_text(text) if text != @decoded.text
         end
@@ -1170,17 +1174,20 @@ module Gori::Tui
       synced_lines = synced_head.split("\r\n")
       cl_idx = synced_lines.index { |l| l.lstrip.downcase.starts_with?("content-length:") }
       return unless cl_idx
+      new_line = synced_lines[cl_idx]
 
       env_sep = @editor.text.index("\n\n")
       return unless env_sep
 
       head_lines = @editor.text[0, env_sep].split('\n')
-      return unless cl_idx < head_lines.size
+      # Locate the Content-Length line in the RAW editor head by CONTENT, not by transplanting
+      # the expanded-space index — a multi-line $KEY expansion earlier can shift the line count,
+      # so cl_idx would otherwise point at (and overwrite) an unrelated raw header line.
+      raw_cl_idx = head_lines.index { |l| l.lstrip.downcase.starts_with?("content-length:") }
+      return unless raw_cl_idx
+      return if head_lines[raw_cl_idx] == new_line
 
-      new_line = synced_lines[cl_idx]
-      return if head_lines[cl_idx] == new_line
-
-      @editor.replace_line(cl_idx, new_line)
+      @editor.replace_line(raw_cl_idx, new_line)
     end
 
     # {scheme, host, port} parsed from the target field.

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -3281,7 +3281,7 @@ module Gori::Tui
     # --- findings ExecContext ---
 
     def finding_create : Nil
-      id = history_controller.view.selected_id
+      id = history_target_flow_id
       return unless id
       if row = @session.store.flow_row(id)
         @finding_form = FindingForm.new("#{row.method} #{row.target}", row.host, id)
@@ -3422,6 +3422,14 @@ module Gori::Tui
       else
         history_controller.view.selected_id
       end
+    end
+
+    # The flow a History action targets: the one pinned in the OPEN detail overlay, else the
+    # list selection. Live capture can advance the list cursor (`@selected = 0` on a new flow)
+    # while the detail overlay stays on its flow, so detail.* verbs (replay/finding/fuzz/mine/
+    # comparer/copy/scope) must read the detail, not the cursor — or they act on the wrong flow.
+    def history_target_flow_id : Int64?
+      @overlay == :detail ? history_controller.view.detail_flow_id : history_controller.selected_flow_id
     end
 
     def link_replay_id : Int64?
@@ -3606,7 +3614,7 @@ module Gori::Tui
     end
 
     def scope_add_host : Nil
-      id = history_controller.view.selected_id
+      id = history_target_flow_id
       return unless id
       if row = @session.store.flow_row(id)
         @scope.add("include", "host", row.host)
@@ -3736,7 +3744,7 @@ module Gori::Tui
     end
 
     def copy_selection : Nil
-      history_controller.copy_selection
+      history_controller.copy_selection(history_target_flow_id)
     end
 
     def history_query : Nil
@@ -3770,7 +3778,7 @@ module Gori::Tui
     # --- Replay ExecContext --- (delegated to ReplayController; cross-tab mediators kept)
     # CROSS-TAB mediator: load History's selection into a new Replay tab.
     def replay_selected : Nil
-      id = history_controller.selected_flow_id
+      id = history_target_flow_id
       replay_controller.replay_flow(id) if id
     end
 
@@ -3890,7 +3898,7 @@ module Gori::Tui
     # --- Fuzzer ExecContext / cross-tab mediators ---
     # CROSS-TAB: open History's selection as a new Fuzzer session (⇧I).
     def fuzz_selected : Nil
-      id = history_controller.selected_flow_id
+      id = history_target_flow_id
       fuzzer_controller.fuzz_flow(id) if id
     end
 
@@ -3965,7 +3973,7 @@ module Gori::Tui
     # --- Miner ExecContext / cross-tab mediators ---
     # CROSS-TAB: open the config popup for History's selected flow (space → Mine params).
     def mine_selected : Nil
-      id = history_controller.selected_flow_id
+      id = history_target_flow_id
       return (@toast = "select a flow first") unless id
       open_mine_config(miner_controller.build_seed_from_flow(id))
     end
@@ -4198,7 +4206,7 @@ module Gori::Tui
     # CROSS-TAB mediator: send History's selected flow to the next Comparer slot
     # on the *active* comparison sub-tab (rings A → B → A).
     def comparer_add_selected : Nil
-      id = history_controller.selected_flow_id
+      id = history_target_flow_id
       return (@toast = "select a flow first") unless id
       detail = @session.store.get_flow(id)
       return (@toast = "flow no longer available") unless detail

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -587,7 +587,11 @@ module Gori::Tui
       # arms and hints in the status bar; any other key disarms. (Q no longer quits;
       # `q` still returns to the project picker.) Handled before everything else so
       # it works uniformly across tabs, editors and overlays.
-      if ev.ctrl_c? || (ev.ctrl? && ev.key.lower_d?)
+      # In hotkey CAPTURE mode ^C/^D are capturable chords (reserved.cr rejects them inline
+      # with "Ctrl-C/D quits gori" while staying in capture) — exclude them from the global
+      # quit-arm so a stray ^D during a rebind can't silently arm an app quit.
+      capturing_hotkey = @overlay == :hotkeys && @hotkeys_overlay.capturing?
+      if (ev.ctrl_c? || (ev.ctrl? && ev.key.lower_d?)) && !capturing_hotkey
         if @quit_armed
           quit!
         else
@@ -789,6 +793,15 @@ module Gori::Tui
     # Right-click: rename a Replay/Fuzzer/Convert/Miner sub-tab chip (the one context menu we have).
     # Only acts on the sub-tab strip; anywhere else is a no-op (no left-click side effects).
     private def handle_right_click(layout : Layout, mx : Int32, my : Int32) : Nil
+      if @goto_open || @search_open || @rename_open || @import_open
+        # A right-click dismisses an open bottom prompt (like left-click/esc), so it can't
+        # stack a second orthogonal prompt on top of the first.
+        close_goto if @goto_open
+        close_search if @search_open
+        close_rename if @rename_open
+        close_import if @import_open
+        return
+      end
       return unless renameable_subtabs? && @overlay == :none && !@space_menu_open && !@rename_open && subtabs_shown?
       sub_rect = BodyChrome.strip_rect(layout.body, strip: true)
       return unless sub_rect && sub_rect.contains?(mx, my)
@@ -2848,6 +2861,7 @@ module Gori::Tui
     # view_focus_first (which would reload/reset). For ^R/^N-style "open this and land
     # in it" jumps that manage their own view state.
     def goto_tab(tab : Symbol) : Nil
+      flush_active_tab_edits # cross-tab "open this and land in it" jumps must persist the outgoing edit too
       @active_tab = tab
       @focus = :body
     end
@@ -3190,15 +3204,21 @@ module Gori::Tui
     # Switch the active tab. `focus` is where focus lands: :menu for a tab "select"
     # gesture (tab-bar click, number-key jump) which lands on the bar without descending
     # into the body, :body for the named "Go to …" palette jumps which drill into content.
-    def focus_tab(tab : Symbol, focus : Symbol = :body) : Nil
-      if @active_tab == :project
-        project_controller.commit
-      end
-      replay_controller.save_current_replay if @active_tab == :replay # persist the outgoing replay tab
+    # Flush the OUTGOING tab's in-progress edit to the store before switching away, so a
+    # tab jump/cycle/select never leaves a dirty buffer unpersisted (invisible to peers /
+    # lost on an abnormal exit). Every dirty-holding tab is dirty-guarded in its own commit.
+    private def flush_active_tab_edits : Nil
+      project_controller.commit if @active_tab == :project
+      replay_controller.save_current_replay if @active_tab == :replay
       fuzzer_controller.save_current if @active_tab == :fuzzer
       miner_controller.save_current if @active_tab == :miner
-      convert_controller.commit if @active_tab == :convert # flush sub-tab edits/renames (dirty-guarded)
-      notes_controller.save_notes if @active_tab == :notes # flush unsaved note edits (dirty-guarded)
+      convert_controller.commit if @active_tab == :convert
+      notes_controller.save_notes if @active_tab == :notes
+      findings_controller.commit if @active_tab == :findings
+    end
+
+    def focus_tab(tab : Symbol, focus : Symbol = :body) : Nil
+      flush_active_tab_edits
       @active_tab = tab
       @focus = focus
       @overlay = :none
@@ -3224,14 +3244,7 @@ module Gori::Tui
     end
 
     def cycle_tab(delta : Int32) : Nil
-      if @active_tab == :project
-        project_controller.commit
-      end
-      replay_controller.save_current_replay if @active_tab == :replay # persist the outgoing replay tab
-      fuzzer_controller.save_current if @active_tab == :fuzzer
-      miner_controller.save_current if @active_tab == :miner
-      convert_controller.commit if @active_tab == :convert # flush sub-tab edits/renames (dirty-guarded)
-      notes_controller.save_notes if @active_tab == :notes # flush unsaved note edits (dirty-guarded)
+      flush_active_tab_edits
       # Cycle within the VISIBLE strip (skips hidden tabs); effective_tabs force-includes
       # the active tab so the index is always found and never falls back to 0.
       tabs = effective_tabs

--- a/src/gori/tui/screen.cr
+++ b/src/gori/tui/screen.cr
@@ -161,7 +161,7 @@ module Gori::Tui
     # pre-check walked the whole string first).
     def fit(str : String, w : Int32) : String
       return "" if w <= 0
-      return (str[0]? || "").to_s if w == 1
+      return (str.each_grapheme.first?.try(&.to_s) || "") if w == 1 # first GRAPHEME (not codepoint): keep flags/ZWJ/combining intact, matching Highlight.draw
       cur = 0   # width accumulated into `head` (the ellipsis prefix, within w-1)
       total = 0 # running total width, to detect overflow past `w`
       overflow = false

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -494,17 +494,19 @@ module Gori::Tui
 
     private def render_footer(screen : Screen, box : Rect) : Nil
       note_y = box.bottom - 2
+      iw = {box.right - (box.x + 3) - 1, 0}.max # interior width so long hints can't bleed past the box border
       if status = @status
         color = status.starts_with?("invalid") || status.starts_with?("save failed") ? Theme.yellow : Theme.green
-        screen.text(box.x + 3, note_y, "• #{status}", color, Theme.panel)
+        screen.text(box.x + 3, note_y, "• #{status}", color, Theme.panel, width: iw)
       elsif @section == :theme
         names = Theme.available
-        screen.text(box.x + 3, note_y, "theme #{(names.index(@values[0]) || 0) + 1}/#{names.size}", Theme.muted, Theme.panel)
+        screen.text(box.x + 3, note_y, "theme #{(names.index(@values[0]) || 0) + 1}/#{names.size}", Theme.muted, Theme.panel, width: iw)
       else
-        screen.text(box.x + 3, note_y, fields[@focused].hint, Theme.muted, Theme.panel)
+        screen.text(box.x + 3, note_y, fields[@focused].hint, Theme.muted, Theme.panel, width: iw)
       end
       hint = @section == :theme ? "↑/↓ select · ↵ apply · ^R reset · esc close" : "↑/↓ field · ↵ save · ^R reset · esc close"
-      screen.text(box.right - hint.size - 2, note_y, hint, Theme.muted, Theme.panel)
+      hx = {box.right - hint.size - 2, box.x + 1}.max # never start left of the box interior
+      screen.text(hx, note_y, hint, Theme.muted, Theme.panel, width: {box.right - hx - 1, 0}.max)
     end
   end
 end

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -125,8 +125,10 @@ module Gori::Tui
     end
 
     private def walk_collect_expand(node : Node, host : String, state : Hash({String, String}, Bool)) : Nil
-      return if node.grouped
-      state[{host, node.path}] = node.expanded unless node.leaf?
+      # Skip recording only the synthetic fold node's OWN (unkeyed) state, but still recurse
+      # into its children — real descendants under a grouped numeric fold have stable keys
+      # and their expand state must survive a reload (which fires ~1.3x/sec during capture).
+      state[{host, node.path}] = node.expanded if !node.grouped && !node.leaf?
       node.children.each { |c| walk_collect_expand(c, host, state) }
     end
 
@@ -136,9 +138,8 @@ module Gori::Tui
     end
 
     private def walk_reapply_expand(node : Node, host : String, prev : Hash({String, String}, Bool)) : Nil
-      return if node.grouped
       key = {host, node.path}
-      if !node.leaf? && prev.has_key?(key)
+      if !node.grouped && !node.leaf? && prev.has_key?(key)
         node.expanded = prev[key]
       end
       node.children.each { |c| walk_reapply_expand(c, host, prev) }

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -122,6 +122,7 @@ module Gori::Tui
     end
  
     def backspace : Nil
+      return if @cx == 0 && @cy == 0 # buffer start — nothing to delete, don't dirty (mirrors delete)
       if @cx > 0
         push_undo
         line = @lines[@cy]
@@ -431,12 +432,15 @@ module Gori::Tui
       return if cw <= 0
       line = @lines[@cy]
       pw = Screen.display_width(@preedit)
-      if Screen.display_width(line) + pw <= cw
+      # column_width (not display_width) to match the actual draw at line 363: a raw
+      # control char occupies one drawn cell, so measuring it as width 0 here would let
+      # the caret render outside the window (cursor detaches / no scroll-into-view).
+      if Screen.column_width(line) + pw <= cw
         @xscroll = 0
         return
       end
       cx = @cx.clamp(0, line.size)
-      curx = Screen.display_width(line[0, cx]) + pw     # caret's display column in the full line
+      curx = Screen.column_width(line[0, cx]) + pw      # caret's column in the full line
       @xscroll = curx if curx < @xscroll                # caret left of the window → snap left
       @xscroll = curx - cw + 1 if curx >= @xscroll + cw # caret past the right edge → snap right
       @xscroll = 0 if @xscroll < 0


### PR DESCRIPTION
A multi-round correctness audit of the codebase. Every finding was verified against the actual code before fixing, and regression tests were added for the highest-value ones. Full suite is green (1445 examples, 0 failures).

## Highlights

**proxy / RUN**
- **CRITICAL:** `response_framing` now returns close-delimited for a non-chunked `Transfer-Encoding` + `Content-Length` response (RFC 7230 §3.3.3 rule 3) instead of framing by CL — the latter left bytes on the wire to misframe the next response on a reused upstream (a response-desync/smuggling primitive).
- Replay: never emit `Transfer-Encoding` + `Content-Length` together for a chunked capture; response framing keys off the method actually sent upstream (HEAD/CONNECT after a rewrite); `--target` no longer clobbers an explicit `-H "Host:"`; `-H` replaces all matching header lines; malformed absolute-form targets stay visible in History; off-by-one CRLFCRLF scan.
- h2 assembler: an interim `1xx` no longer merges ahead of the final status; WebSocket relay preserves buffered fragments and marks oversized frames; IPv6-literal MITM targets get an IP SAN; origin socket leak on setsockopt failure.

**MCP**
- Byte-safe UTF-8 truncation (was emitting invalid JSON-RPC); `url` no longer wrongly schema-required; `bool()` accepts string encodings; `update_replay`/`create_replay` argument validation; `Int64→Int32` overflow guards.

**TUI**
- Editor edit-loss fixes (intercept re-entry & "forward all", CHAIN-pane commit on ^R, findings-notes flush on tab jump, Content-Length reflect header corruption); history-detail actions target the open detail, not the list cursor; two pickers gained scroll windowing; filesystem errors no longer crash the TUI on project create/delete; byte-vs-char cursor/truncation fixes; several state-machine/focus fixes.

**prism detection (FP/FN vs each rule's own stated intent)**
- Tightened the Spring stack-trace signature (was matching prose); anchored the private-IP version-context suppressor; check all `Authorization`/`WWW-Authenticate` headers; added the GitHub fine-grained token pattern; HSTS reads the first header (RFC 6797); CORS skips browser-blocked duplicate-ACAO; active-probe dedup keys include port.

**parsers / convert / import**
- SAML: scrub the response body before regex (a binary body with "SAMLResponse" crashed every decode surface); preserve a literal `+` in the base64 value. HAR: preserve duplicate response headers (Set-Cookie), import a request whose response is JSON null. base58 whitespace, ascii85 truncation, GraphQL O(n²) re-parse, unicode surrogate ConvertError.

**store**
- Fixed the pre-existing spec/store failures: `Schema::VERSION` was one behind the migration count. Retention prune now counts bulk-import rows. Capture flock released after store+prism teardown.

## Deferred (verified, noted for follow-up)
Shutdown fiber-join drain barriers; the >1024-concurrent-stream HPACK dynamic-table desync (capture-only — raw forwarding is byte-exact); and a few peer-race/niche TUI edges. A couple of findings were intentionally not changed as design/tuning judgments (documented in the diagnosis).

## Testing
`crystal build` type-checks clean; `crystal spec` is 1445 examples, 0 failures. New regression tests cover the TE+CL framing fix, h2 interim-status, WS oversized-fragment, HAR duplicate headers, base58 whitespace, unicode surrogate, and several prism detection changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)