### PR TITLE
fix: 20 correctness & security bugs across proxy, store, Prism, MCP, and lifecycle

### DIFF
--- a/spec/convert_spec.cr
+++ b/spec/convert_spec.cr
@@ -135,6 +135,14 @@ describe Gori::Convert do
       conv("unicode-unescape", conv("unicode-escape", "x🎉y")).should eq "x🎉y"
     end
 
+    it "unicode-unescape leaves a truncated \\u escape at end-of-string literal" do
+      # `\uAB` has only 2 hex digits — it must stay literal (like the mid-string case
+      # `\uABX`), not decode the short slice to U+00AB.
+      conv("unicode-unescape", "x\\uAB").should eq "x\\uAB"
+      conv("unicode-unescape", "\\uABC").should eq "\\uABC"
+      conv("unicode-unescape", "\\u00e9x").should eq "éx" # a full 4-digit escape still decodes
+    end
+
     it "unicode-unescape reports a lone/unpaired surrogate as a ConvertError (not a raw ArgumentError)" do
       expect_raises(Gori::Convert::ConvertError) { conv("unicode-unescape", "\\ud800") }
       expect_raises(Gori::Convert::ConvertError) { conv("unicode-unescape", "\\udc00") }

--- a/spec/fuzz_spec.cr
+++ b/spec/fuzz_spec.cr
@@ -340,6 +340,18 @@ describe F::Matcher do
     res = m.build(job, ok_result(200, "<x id=hunter2 />"))
     res.extracted.should eq("hunter2")
   end
+
+  it "treats a blank match spec as unconstrained (CLI --ms= etc.), not 'reject everything'" do
+    m = F::Matcher.new
+    job = F::Job.new(0_i64, ["x"], nil, "".to_slice)
+    # The CLI/MCP set the property to "" (not nil). A blank spec must mean 'no
+    # constraint' — the old code ran it through Predicate (no terms → false) and
+    # dropped every result.
+    m.match_size = ""
+    m.match_status = ""
+    m.match_words = ""
+    m.build(job, ok_result(200, "abcdef")).matched?.should be_true
+  end
 end
 
 describe F::Engine do

--- a/spec/import/import_spec.cr
+++ b/spec/import/import_spec.cr
@@ -302,4 +302,44 @@ describe Gori::Import do
       File.delete?(har)
     end
   end
+
+  it "imports a HAR entry whose startedDateTime has fractional seconds AND a numeric offset" do
+    har = File.tempname("gori", ".har")
+    begin
+      # Firefox/Safari-style timestamp (numeric offset + fraction) — the old
+      # strptime-only parser dropped this entry entirely.
+      File.write(har, <<-JSON)
+        {"log":{"entries":[
+          {"startedDateTime":"2024-06-01T10:20:30.123-07:00","time":1,
+           "request":{"method":"GET","url":"https://tz.test/x"},
+           "response":{"status":200,"content":{"text":"ok"}}}
+        ]}}
+        JSON
+      with_store do |store|
+        result = Gori::Import.import_file(store, :har, har)
+        result.count.should eq(1) # imported, not silently skipped
+        row = store.search(Gori::QL::EMPTY, 1).first
+        row.host.should eq("tz.test")
+        row.created_at.should eq(1_717_262_430_000_000_i64) # parsed absolute time, not "now"
+      end
+    ensure
+      File.delete?(har)
+    end
+  end
+
+  it "imports a scheme-less URL whose query contains :// (not treated as a bad scheme)" do
+    urls = File.tempname("gori", ".txt")
+    begin
+      File.write(urls, "example.test/redirect?next=http://inner.test/x\n")
+      with_store do |store|
+        result = Gori::Import.import_file(store, :urls, urls)
+        result.count.should eq(1) # was rejected as "missing scheme" by a naive :// check
+        row = store.search(Gori::QL::EMPTY, 1).first
+        row.host.should eq("example.test")
+        row.target.should eq("/redirect?next=http://inner.test/x")
+      end
+    ensure
+      File.delete?(urls)
+    end
+  end
 end

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -459,6 +459,25 @@ describe Gori::MCP::Server do
       end
     end
 
+    it "base64-encodes a binary WebSocket frame (keeps the JSON-RPC stream valid UTF-8)" do
+      with_store do |store|
+        store.insert_replay("wss://ex.test/ws",
+          "GET /ws HTTP/1.1\r\nHost: ex.test\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n", false, true, nil, 0)
+        id = store.replays_meta.last.id
+        store.insert_ws_message(0_i64, "out", 1, "ping".to_slice, replay_id: id)        # text frame
+        store.insert_ws_message(0_i64, "in", 2, Bytes[0x00, 0xff, 0x80], replay_id: id) # binary (invalid UTF-8)
+        store.flush
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_replay_context","arguments":{}}})
+        msgs = tool_payload(drive(store, call)[0])["sessions"][0]["ws_messages"].as_a
+        text = msgs.find { |m| m["opcode"].as_i == 1 }.not_nil!
+        text["payload"].as_s.should eq("ping")
+        bin = msgs.find { |m| m["opcode"].as_i == 2 }.not_nil!
+        bin["binary"].as_bool.should be_true
+        bin["payload_base64"].as_s.should eq(Base64.strict_encode(Bytes[0x00, 0xff, 0x80]))
+        bin.as_h.has_key?("payload").should be_false # raw bytes never emitted as a string
+      end
+    end
+
     it "includes the live TUI replay snapshot when ui_state carries it" do
       with_store do |store|
         ui = JSON.build do |j|

--- a/spec/miner/engine_spec.cr
+++ b/spec/miner/engine_spec.cr
@@ -51,6 +51,21 @@ private class HiddenParamBackend < F::Backend
   end
 end
 
+# Returns one fixed (large) body regardless of input — for exercising the baseline
+# tolerance floors on a big page.
+private class FixedBodyBackend < F::Backend
+  getter origin : F::Origin
+
+  def initialize(@origin : F::Origin, @body : String)
+  end
+
+  def send(bytes : Bytes) : Gori::Replay::Result
+    head = "HTTP/1.1 200 OK\r\nContent-Length: #{@body.bytesize}\r\n\r\n".to_slice
+    resp = Gori::Proxy::Codec::Http1.parse_response_head(head)
+    Gori::Replay::Result.new(head, @body.to_slice, resp, 1000_i64)
+  end
+end
+
 private def mine(backend : F::Backend, names : Array(String), config : M::Config) : Array(M::Finding)
   base = "GET /api HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
   engine = M::Engine.new(base, http2: false, names: names, backend: backend, config: config)
@@ -149,6 +164,18 @@ describe Gori::Miner::Engine do
     # entirely and mining overshot it by ~2x concurrency.
     backend.sent.should eq(2)
     findings.should be_empty
+  end
+
+  it "floors word/line tolerance proportionally to page size (not a fixed 3/2)" do
+    # A large, perfectly stable page: calibration jitter is 0, so each tolerance is
+    # its FLOOR. The floor must scale with page size, or a big page's natural word/line
+    # churn during mining trips a false Words/Lines finding that the length band absorbs.
+    body = (["word"] * 600).join("\n") # 600 words across 600 lines
+    backend = FixedBodyBackend.new(F::Origin.new("http", "h", 80), body)
+    base = "GET /api HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+    report = M::Baseline.new(backend, base, cfg).calibrate([M::Location::Query])
+    report.words_tol.should be > 3 # was fixed 3; now max(3, 600//100) = 6
+    report.lines_tol.should be > 2 # was fixed 2; now max(2, ~600//100)
   end
 
   it "does not overshoot max_requests under concurrency" do

--- a/spec/prism_spec.cr
+++ b/spec/prism_spec.cr
@@ -953,6 +953,57 @@ describe "Gori::Prism::Passive (insecure form action)" do
   end
 end
 
+describe "Gori::Prism::Passive (round-2 detection fixes)" do
+  it "does not flag a data-src lazy-loading placeholder as active mixed content" do
+    with_store do |store|
+      # A hyphenated data-* attribute is not the real src attribute; `\b` alone treated
+      # the hyphen as a word boundary and false-matched `data-src="http://…"`.
+      lazy = analyze(store, scheme: "https", content_type: "text/html",
+        resp_head: "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n",
+        body: %(<iframe data-src="http://cdn.acme.test/lazy" src="https://cdn.acme.test/ok"></iframe>))
+      codes_of(lazy).should_not contain("mixed_content")
+      # …a genuine active http:// sub-resource still trips it.
+      real = analyze(store, scheme: "https", content_type: "text/html",
+        resp_head: "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n",
+        body: %(<script src="http://cdn.acme.test/evil.js"></script>))
+      codes_of(real).should contain("mixed_content")
+    end
+  end
+
+  it "does not flag a data-action attribute as an insecure form action" do
+    with_store do |store|
+      lazy = analyze(store, scheme: "https", content_type: "text/html",
+        resp_head: "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n",
+        body: %(<form data-action="http://acme.test/track" action="https://acme.test/login"></form>))
+      codes_of(lazy).should_not contain("insecure_form_action")
+    end
+  end
+
+  it "treats a cookie cleared with a non-empty sentinel value and a past Expires as a deletion" do
+    with_store do |store|
+      # `auth=deleted; Expires=<past>` (no Max-Age, non-empty value) is a logout clear —
+      # its missing flags are noise, not hygiene findings.
+      cleared = analyze(store,
+        resp_head: "HTTP/1.1 200 OK\r\nSet-Cookie: auth=deleted; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT\r\n\r\n",
+        content_type: "text/html")
+      codes_of(cleared).should_not contain("cookie_no_secure")
+      codes_of(cleared).should_not contain("cookie_no_httponly")
+    end
+  end
+
+  it "flags a present-but-ineffective X-Frame-Options value (obsolete ALLOW-FROM)" do
+    with_store do |store|
+      ineffective = analyze(store, content_type: "text/html",
+        resp_head: "HTTP/1.1 200 OK\r\nX-Frame-Options: ALLOW-FROM https://x.test\r\n\r\n")
+      codes_of(ineffective).should contain("missing_x_frame_options")
+      # DENY / SAMEORIGIN actually restrict framing → no finding.
+      deny = analyze(store, content_type: "text/html",
+        resp_head: "HTTP/1.1 200 OK\r\nX-Frame-Options: DENY\r\n\r\n")
+      codes_of(deny).should_not contain("missing_x_frame_options")
+    end
+  end
+end
+
 describe "Gori::Prism::Passive (insecure Basic auth)" do
   it "flags request Basic credentials over cleartext HTTP as High" do
     with_store do |store|
@@ -990,11 +1041,11 @@ describe "Gori::Prism::Passive (Round-1 hardening)" do
     with_store do |store|
       # First script-src is safe; the duplicate must be IGNORED, so this is not weak.
       safe = analyze(store, content_type: "text/html", resp_head: "HTTP/1.1 200 OK\r\n" \
-        "Content-Security-Policy: script-src 'self'; script-src 'unsafe-inline'\r\n\r\n")
+                                                                  "Content-Security-Policy: script-src 'self'; script-src 'unsafe-inline'\r\n\r\n")
       codes_of(safe).should_not contain("weak_csp")
       # First script-src is unsafe-inline; a later 'self' duplicate must not mask it.
       weak = analyze(store, content_type: "text/html", resp_head: "HTTP/1.1 200 OK\r\n" \
-        "Content-Security-Policy: script-src 'unsafe-inline'; script-src 'self'\r\n\r\n")
+                                                                  "Content-Security-Policy: script-src 'unsafe-inline'; script-src 'self'\r\n\r\n")
       codes_of(weak).should contain("weak_csp")
     end
   end
@@ -1003,7 +1054,7 @@ describe "Gori::Prism::Passive (Round-1 hardening)" do
     with_store do |store|
       # PHP clears cookies with the literal value "deleted" (not empty) + Max-Age=0.
       php = analyze(store, content_type: "text/html", resp_head: "HTTP/1.1 200 OK\r\n" \
-        "Set-Cookie: PHPSESSID=deleted; Max-Age=0; expires=Thu, 01-Jan-1970 00:00:00 GMT; path=/\r\n\r\n")
+                                                                 "Set-Cookie: PHPSESSID=deleted; Max-Age=0; expires=Thu, 01-Jan-1970 00:00:00 GMT; path=/\r\n\r\n")
       codes_of(php).should_not contain("cookie_no_secure")
       codes_of(php).should_not contain("cookie_no_httponly")
       neg = analyze(store, content_type: "text/html",
@@ -1391,7 +1442,7 @@ describe Gori::Prism, "WebSocket + Replay sources" do
       detail = Gori::Prism.detail_from_replay(rec).not_nil!
       detail.row.method.should eq("POST")
       codes = Gori::Prism::Passive.analyze(detail).map(&.code)
-      codes.should contain("insecure_basic_auth")  # Authorization header now visible over http
+      codes.should contain("insecure_basic_auth")   # Authorization header now visible over http
       codes.should contain("cors_reflected_origin") # Origin header now visible
     end
   end

--- a/spec/proxy/codec/body_spec.cr
+++ b/spec/proxy/codec/body_spec.cr
@@ -258,3 +258,21 @@ describe Gori::Proxy::Codec::Body do
     end
   end
 end
+
+describe Gori::Proxy::Codec::ContentDecode do
+  head = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n".to_slice
+
+  it "de-chunks a conformant CRLF chunked body" do
+    body = "5\r\nHELLO\r\n6\r\n WORLD\r\n0\r\n\r\n".to_slice
+    decoded, _ = ContentDecode.decode(head, body)
+    String.new(decoded.not_nil!).should eq("HELLO WORLD")
+  end
+
+  it "de-chunks a bare-LF chunked body without misaligning later chunks" do
+    # Non-conformant lone-LF delimiters: the old blind 2-byte skip ate the first byte
+    # of the next chunk-size line, dropping/garbling every chunk after the first.
+    body = "5\nHELLO\n6\n WORLD\n0\n\n".to_slice
+    decoded, _ = ContentDecode.decode(head, body)
+    String.new(decoded.not_nil!).should eq("HELLO WORLD")
+  end
+end

--- a/spec/proxy/codec/body_spec.cr
+++ b/spec/proxy/codec/body_spec.cr
@@ -149,6 +149,33 @@ describe Gori::Proxy::Codec::Body do
       expect_raises(Gori::Error) { Body.request_framing(req) }
     end
 
+    it "rejects a request with whitespace before a header colon (TE hidden from framing → smuggling)" do
+      # `Transfer-Encoding : chunked` (space before colon) is invisible to the exact-match TE
+      # lookup, so the proxy would frame by CL and forward the head to a lenient backend that
+      # reads chunked — a CL.TE desync. Reject it like an explicit CL+TE conflict.
+      req = Http1.parse_request_head(
+        "POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\nTransfer-Encoding : chunked\r\n\r\n".to_slice)
+      expect_raises(Gori::Error) { Body.request_framing(req) }
+    end
+
+    it "rejects a request using an obs-fold header continuation line" do
+      # An obs-folded `Transfer-Encoding:\r\n chunked` hides the value from the framing lookup
+      # while a lenient backend unfolds it — RFC 7230 §3.2.4 forbids obs-fold in requests.
+      req = Http1.parse_request_head(
+        "POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\nTransfer-Encoding:\r\n chunked\r\n\r\n".to_slice)
+      expect_raises(Gori::Error) { Body.request_framing(req) }
+    end
+
+    it "accepts an ordinary request whose header value contains a colon or spaces" do
+      # The rejection targets whitespace BEFORE the colon / obs-fold only — a normal header
+      # (colon in the value, spaces after the colon) must still frame cleanly.
+      req = Http1.parse_request_head(
+        "GET / HTTP/1.1\r\nHost: example.com:443\r\nUser-Agent: Mozilla/5.0 (X)\r\n\r\n".to_slice)
+      Body.request_framing(req).should eq({BodyFraming::None, 0_i64})
+      Http1.obfuscated_header?("GET / HTTP/1.1\r\nHost: example.com:443\r\n\r\n".to_slice).should be_false
+      Http1.obfuscated_header?("GET / HTTP/1.1\r\nX : y\r\n\r\n".to_slice).should be_true
+    end
+
     it "leaves a response with a non-chunked Transfer-Encoding as close-delimited (not rejected)" do
       # Responses may legitimately be close-delimited under a non-chunked TE — only the
       # request path (which must know the body boundary to keep-alive) rejects.

--- a/spec/proxy/server_spec.cr
+++ b/spec/proxy/server_spec.cr
@@ -486,6 +486,35 @@ describe Gori::Proxy::Server do
     resp.error.not_nil!.should contain("framing")
   end
 
+  it "rejects a request with whitespace before a header colon (obfuscated-TE smuggling)" do
+    seen = Channel(String).new(1)
+    done = Channel(Nil).new(1)
+    origin_port = start_origin("never", seen)
+
+    sink = RecordingSink.new(done)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink)
+    proxy.start
+
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    # `Transfer-Encoding : chunked` (space before the colon) hides the TE from the
+    # exact-match framing lookup; a lenient backend would still chunk-frame it → smuggling.
+    # gori must reject the attempt (record + close), not forward it framed by Content-Length.
+    client << "POST /obf HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\n"
+    client << "Content-Length: 5\r\nTransfer-Encoding : chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n"
+    client.flush
+    client.gets_to_end
+    client.close
+
+    done.receive
+    proxy.stop
+
+    sink.requests.size.should eq(1)
+    sink.responses.size.should eq(1)
+    resp = sink.responses.first
+    resp.state.should eq(Gori::Store::FlowState::Error)
+    resp.error.not_nil!.should contain("obfuscated")
+  end
+
   it "records a visible error flow for a CL+TE response instead of leaving it Pending" do
     done = Channel(Nil).new(1)
     # Raw origin that replies with BOTH Content-Length and Transfer-Encoding.

--- a/spec/store/store_spec.cr
+++ b/spec/store/store_spec.cr
@@ -208,6 +208,33 @@ describe Gori::Store do
     end
   end
 
+  it "stores a zero-length WebSocket frame without aborting the write batch (empty payload → X'', not NULL)" do
+    with_store do |store|
+      fid = store.insert_flow(sample_request(target: "/ws"))
+      # A valid empty WS text frame (RFC 6455): payload BLOB NOT NULL used to bind SQL
+      # NULL from an empty slice, aborting the whole transaction and losing the
+      # co-batched non-empty frame too. Both must survive with write_failures == 0.
+      store.insert_ws_message(fid, "out", 1, Bytes.empty)
+      store.insert_ws_message(fid, "in", 1, "hello".to_slice)
+      store.flush
+      msgs = store.ws_messages(fid)
+      msgs.size.should eq(2)
+      msgs[0].payload.empty?.should be_true
+      msgs[1].payload.should eq("hello".to_slice)
+      store.write_failures.should eq(0)
+    end
+  end
+
+  it "update_replay_ws_messages stores an empty frame text without aborting the batch" do
+    with_store do |store|
+      rid = store.insert_replay("wss://acme.test/ws", "GET /ws HTTP/1.1\r\n\r\n", false, false, nil, 0)
+      store.update_replay_ws_messages(rid, ["", "frame"])
+      store.flush
+      store.ws_messages_for_replay(rid).size.should eq(2)
+      store.write_failures.should eq(0)
+    end
+  end
+
   it "insert_finding returns the finding's own id, not the entity_links row id, when linked to a flow" do
     with_store do |store|
       fid = store.insert_flow(sample_request(target: "/f"))

--- a/src/gori/app.cr
+++ b/src/gori/app.cr
@@ -51,10 +51,13 @@ module Gori
       # first-run wizard auto-launched below, so a no-tty run (CI/detached) gets a clean
       # message instead of a raw backtrace.
       term = Tui.open_terminal("run it directly, not under CI or a detached/background job, or use --headless for non-interactive capture")
-      term.enable_enhanced_keyboard       # Kitty 17u (disambig + report_text) for better IME/Unicode; avoids report_all_keys(31u) which can split Hangul jamo. Committed text via raw UTF-8 bytes (IME composed syllables) + CSI for specials; Preedit via 0-code CSI if terminal provides.
-      term.enable_mouse if Settings.mouse # SGR-1006 click + scroll-wheel nav; one enable covers both the picker and the runner (same term). Runner reconciles live on settings save; term.close disables on exit.
 
       begin
+        # enable_* run INSIDE the begin so `ensure term.close` restores the tty if either
+        # raises after open_terminal already switched it into raw mode (else the user's shell
+        # is left in raw/no-echo).
+        term.enable_enhanced_keyboard       # Kitty 17u (disambig + report_text) for better IME/Unicode; avoids report_all_keys(31u) which can split Hangul jamo. Committed text via raw UTF-8 bytes (IME composed syllables) + CSI for specials; Preedit via 0-code CSI if terminal provides.
+        term.enable_mouse if Settings.mouse # SGR-1006 click + scroll-wheel nav; one enable covers both the picker and the runner (same term). Runner reconciles live on settings save; term.close disables on exit.
         # First-run onboarding: no settings.json yet → walk the user through bind /
         # theme setup once. Inside `begin` so the `ensure term.close` restores
         # the terminal if it raises. The wizard persists settings.json (even on skip),

--- a/src/gori/convert/codecs.cr
+++ b/src/gori/convert/codecs.cr
@@ -197,14 +197,22 @@ module Gori::Convert
       end
     end
 
+    # Parse EXACTLY 4 hex digits at `at`, or nil. A short slice near end-of-string
+    # (e.g. `\uAB`) must NOT decode — it stays literal, matching the mid-string case
+    # where `\uABX` is left alone because `to_i?` rejects the non-hex char.
+    private def hex4(s : String, at : Int32) : Int32?
+      h = s[at, 4]?
+      (h && h.size == 4) ? h.to_i?(16) : nil
+    end
+
     def unicode_unescape(s : String) : String
       String.build do |io|
         chars = s.chars
         i = 0
         while i < chars.size
           if chars[i] == '\\' && i + 1 < chars.size && chars[i + 1] == 'u'
-            hi = s[i + 2, 4]?.try(&.to_i?(16))
-            if hi && 0xD800 <= hi <= 0xDBFF && s[i + 6, 2]? == "\\u" && (lo = s[i + 8, 4]?.try(&.to_i?(16))) && 0xDC00 <= lo <= 0xDFFF
+            hi = hex4(s, i + 2)
+            if hi && 0xD800 <= hi <= 0xDBFF && s[i + 6, 2]? == "\\u" && (lo = hex4(s, i + 8)) && 0xDC00 <= lo <= 0xDFFF
               io << (0x10000 + ((hi - 0xD800) << 10) + (lo - 0xDC00)).chr
               i += 12
               next

--- a/src/gori/fuzz/generator.cr
+++ b/src/gori/fuzz/generator.cr
@@ -79,9 +79,13 @@ module Gori::Fuzz
     private def pitchfork(emit_to : Job ->) : Nil
       count = @template.position_count
       return if count == 0
-      iters = (0...count).map { |p| set_for(p).open_iterator }
+      # Open inside the begin so a raise on the k-th open_iterator (e.g. a wordlist file
+      # removed after preflight) still closes the 0..k-1 already opened, rather than
+      # leaking their file descriptors.
+      iters = [] of SetIterator
       idx = 0_i64
       begin
+        (0...count).each { |p| iters << set_for(p).open_iterator }
         loop do
           payloads = [] of String
           iters.each do |it|

--- a/src/gori/fuzz/matcher.cr
+++ b/src/gori/fuzz/matcher.cr
@@ -113,14 +113,17 @@ module Gori::Fuzz
     end
 
     # `default` is returned when the spec is absent (a matcher with no spec passes;
-    # a filter with no spec never fires).
+    # a filter with no spec never fires). A BLANK spec ("" — the CLI/MCP `--ms=` etc.
+    # set the property to an empty string, unlike the TUI's blank_nil) counts as absent:
+    # otherwise `Predicate.any?("")` has no terms → false → a match dimension flips from
+    # "unconstrained" to "reject everything", silently returning zero matches.
     private def status_pass?(spec : String?, status : Int32?, default : Bool) : Bool
-      return default if spec.nil?
+      return default if spec.nil? || spec.blank?
       (s = status) ? Predicate.status_any?(spec, s) : false
     end
 
     private def num_pass?(spec : String?, value : Int64, default : Bool) : Bool
-      return default if spec.nil?
+      return default if spec.nil? || spec.blank?
       Predicate.any?(spec, value)
     end
 

--- a/src/gori/import/builder.cr
+++ b/src/gori/import/builder.cr
@@ -19,11 +19,17 @@ module Gori
         {body[0, max].dup, true, size}
       end
 
+      # A scheme is `scheme://` at the very START of the string (RFC 3986 §3.1); a
+      # `://` later on (e.g. inside a query, `?next=http://x`) is NOT a scheme, so
+      # match the leading scheme only — else a scheme-less endpoint carrying a URL in
+      # its query was wrongly rejected as "missing scheme" and dropped from the import.
+      LEADING_SCHEME = /\A[a-z][a-z0-9+.-]*:\/\//
+
       def self.normalize_url(url : String) : String
         u = url.strip
         down = u.downcase # schemes are case-insensitive (RFC 3986 §3.1)
         return u if down.starts_with?("http://") || down.starts_with?("https://")
-        raise Gori::Error.new("invalid URL (missing scheme): #{url}") if u.includes?("://")
+        raise Gori::Error.new("invalid URL (missing scheme): #{url}") if down.matches?(LEADING_SCHEME)
         "https://#{u}"
       end
 

--- a/src/gori/import/har.cr
+++ b/src/gori/import/har.cr
@@ -103,14 +103,26 @@ module Gori
         end
       end
 
+      # HAR startedDateTime is ISO 8601 / RFC 3339. Chrome emits `…596Z`, but
+      # Firefox/Safari/curl-style tools emit a numeric offset (`…596-07:00`) AND
+      # fractional seconds — a shape no single strptime format below covered, so
+      # those entries were silently dropped. Time.parse_rfc3339 handles both the `Z`
+      # and numeric-offset forms with or without fractional seconds; fall back to a
+      # bare offset-less datetime, then to "now", so a parse failure never drops the
+      # whole request.
       private def self.parse_started(s : String) : Int64
         return Time.utc.to_unix * 1_000_000 unless s.presence
-        Time.parse(s, "%FT%T%z", Time::Location::UTC).to_unix * 1_000_000
-      rescue Time::Format::Error
-        trimmed = s.gsub(/\.\d+/, "")
-        Time.parse(trimmed, "%Y-%m-%dT%H:%M:%SZ", Time::Location::UTC).to_unix * 1_000_000
-      rescue Time::Format::Error
-        Time.utc.to_unix * 1_000_000
+        time =
+          begin
+            Time.parse_rfc3339(s)
+          rescue Time::Format::Error
+            begin
+              Time.parse(s.gsub(/\.\d+/, ""), "%FT%T", Time::Location::UTC)
+            rescue Time::Format::Error
+              Time.utc
+            end
+          end
+        time.to_unix * 1_000_000
       end
 
       private def self.status_reason(status : Int32) : String

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -1,4 +1,5 @@
 require "json"
+require "base64"
 require "log"
 require "../store"
 require "../ql"
@@ -652,7 +653,15 @@ module Gori
                   j.object do
                     j.field "direction", m.direction
                     j.field "opcode", m.opcode
-                    j.field "payload", String.new(m.payload)
+                    if m.text?
+                      j.field "payload", String.new(m.payload).scrub
+                    else
+                      # A binary frame carries arbitrary octets; emitting them as a raw
+                      # string would put invalid UTF-8 on the stdio JSON-RPC stream (which
+                      # must be well-formed UTF-8). Base64 it, like Serialize.emit_ws_messages.
+                      j.field "binary", true
+                      j.field "payload_base64", Base64.strict_encode(m.payload)
+                    end
                   end
                 end
               end
@@ -1443,7 +1452,7 @@ module Gori
         config.concurrency = clamp(int(h, "concurrency"), 10, MINE_MAX_CONCURRENCY)
         config.rps = int(h, "rate").try(&.to_f64)
         config.timeout = fuzz_timeout(h)
-        config.retries = (int(h, "retries") || 1_i64).to_i
+        config.retries = (int(h, "retries") || 1_i64).clamp(0_i64, 1000_i64).to_i # clamp before .to_i (Int32) so a huge value can't OverflowError past the clean-error handler
         cap = int(h, "max_requests")
         config.max_requests = cap ? {cap, MINE_MAX_REQUESTS}.min : MINE_MAX_REQUESTS
         config.user_wordlist = str(h, "wordlist").presence
@@ -1586,7 +1595,7 @@ module Gori
         elsif nums = obj["numbers"]?.try(&.as_s?)
           fuzz_numbers(nums)
         elsif (nul = obj["null"]?) && (n = (nul.as_i64? || nul.as_s?.try(&.to_i64?)))
-          Fuzz::NullPayloads.new(n.to_i)
+          Fuzz::NullPayloads.new(n.clamp(0_i64, FUZZ_MAX_REQUESTS).to_i) # clamp before .to_i so a huge count can't OverflowError past the clean-error handler
         elsif br = obj["brute"]?.try(&.as_s?)
           fuzz_brute(br)
         else
@@ -1840,8 +1849,8 @@ module Gori
 
       # Passive-scan a just-saved Replay send into prism_issues when mode is Passive/Active.
       private def prism_scan_saved_replay(replay_id : Int64, target : String, request : String,
-                                         http2 : Bool, flow_id : Int64?, head : Bytes, body : Bytes?,
-                                         duration_us : Int64) : Nil
+                                          http2 : Bool, flow_id : Int64?, head : Bytes, body : Bytes?,
+                                          duration_us : Int64) : Nil
         return unless @store.prism_mode.scanning?
         return if head.empty?
         rec = Store::ReplayRecord.new(

--- a/src/gori/miner/baseline.cr
+++ b/src/gori/miner/baseline.cr
@@ -54,9 +54,14 @@ module Gori::Miner
       lengths = probes.map(&.metrics.length)
       words = probes.map(&.metrics.words)
       lines = probes.map(&.metrics.lines)
+      # Each band = 2× the observed calibration jitter, floored so a near-static page
+      # still tolerates small natural churn. The floor is size-PROPORTIONAL for all three
+      # metrics (not just length): a 50 KB / 8k-word page has word/line jitter that a fixed
+      # floor of 3/2 is far too tight for, so an ad slot or a "results: N" counter tripped a
+      # false Words/Lines finding while the proportional length band absorbed the same change.
       length_tol = {(lengths.max - lengths.min) * 2, {8_i64, base.metrics.length // 100}.max}.max
-      words_tol = {(words.max - words.min) * 2, 3}.max
-      lines_tol = {(lines.max - lines.min) * 2, 2}.max
+      words_tol = {(words.max - words.min) * 2, {3, base.metrics.words // 100}.max}.max
+      lines_tol = {(lines.max - lines.min) * 2, {2, base.metrics.lines // 100}.max}.max
 
       statuses = probes.compact_map(&.metrics.status).uniq!
       stable = statuses.size <= 1

--- a/src/gori/prism/passive/body_leaks.cr
+++ b/src/gori/prism/passive/body_leaks.cr
@@ -56,12 +56,15 @@ module Gori
 
         # An active sub-resource (script/iframe) loaded over plain http on an https page —
         # genuine active mixed content (browsers block it; it signals an insecure dependency).
-        MIXED_ACTIVE = /<(?:script|iframe)\b[^>]*\bsrc\s*=\s*["']?http:\/\//i
+        # The (?<![-\w]) guard requires a real attribute boundary before `src`, so a hyphenated
+        # data attribute (`data-src="http://…"`, a lazy-loading placeholder) doesn't false-match
+        # — `\b` alone treated the hyphen as a boundary.
+        MIXED_ACTIVE = /<(?:script|iframe)\b[^>]*(?<![-\w])src\s*=\s*["']?http:\/\//i
 
         # A form on an HTTPS page that SUBMITS to a plain-http action: everything the user types
         # (credentials included) is sent in cleartext. Browsers flag this for password fields;
         # it's a distinct, higher-impact case than a passively-loaded sub-resource.
-        INSECURE_FORM = /<form\b[^>]*\baction\s*=\s*["']?http:\/\//i
+        INSECURE_FORM = /<form\b[^>]*(?<![-\w])action\s*=\s*["']?http:\/\//i
 
         def check(ctx : Context, acc : Array(Detection)) : Nil
           return unless ctx.response

--- a/src/gori/prism/passive/cookies.cr
+++ b/src/gori/prism/passive/cookies.cr
@@ -59,10 +59,12 @@ module Gori
         #   * Max-Age <= 0 is an UNCONDITIONAL delete regardless of value — a live cookie never
         #     sets it, and frameworks clear with a sentinel value (PHP emits `sid=deleted;
         #     Max-Age=0`), so requiring an empty value would miss the common logout pattern.
-        #   * Otherwise, an EMPTY value paired with an Expires attribute is the classic clear.
+        #   * A past Expires deletes the cookie regardless of value too — a logout that uses a
+        #     sentinel value (`auth=deleted; Expires=<past>`, no Max-Age) is still a clear, so
+        #     the value need not be empty (a live cookie never sets an already-expired date).
         private def deletion?(value : String, flags : Array(String), expires : String?) : Bool
           return true if flags.any? { |f| max_age_delete?(f) }
-          return false unless value.empty? && expires
+          return false unless expires
           expires_past?(expires)
         end
 

--- a/src/gori/prism/passive/security_headers.cr
+++ b/src/gori/prism/passive/security_headers.cr
@@ -39,8 +39,13 @@ module Gori
           # actually restrictive (not '*').
           fa = dirs.try(&.["frame-ancestors"]?)
           framed_ok = fa && !fa.empty? && !fa.includes?("*")
-          if h.get?("X-Frame-Options").nil? && !framed_ok
-            acc << hdr(ctx, "missing_x_frame_options", "Missing X-Frame-Options", Store::Severity::Low)
+          # Only DENY / SAMEORIGIN actually restrict framing; the obsolete ALLOW-FROM (and any
+          # other value) is ignored by modern browsers, so a present-but-ineffective XFO is no
+          # protection — flag it too, not just a missing header (validate the value like XCTO).
+          xfo = h.get?("X-Frame-Options").try(&.downcase.strip)
+          xfo_ok = xfo == "deny" || xfo == "sameorigin"
+          if !xfo_ok && !framed_ok
+            acc << hdr(ctx, "missing_x_frame_options", "Missing or ineffective X-Frame-Options", Store::Severity::Low)
           end
           if h.get?("X-Content-Type-Options").try(&.downcase.strip) != "nosniff"
             acc << hdr(ctx, "missing_x_content_type_options", "Missing X-Content-Type-Options: nosniff", Store::Severity::Low)

--- a/src/gori/proxy/codec/body.cr
+++ b/src/gori/proxy/codec/body.cr
@@ -1,4 +1,5 @@
 require "./message"
+require "./http1"
 
 # Byte-exact HTTP/1.1 message-body framing + streaming (P6/P7).
 #
@@ -89,6 +90,11 @@ module Gori::Proxy::Codec
 
     # RFC 7230 §3.3.3 framing for a request body.
     def self.request_framing(req : RawRequest) : {BodyFraming, Int64}
+      # A header written as `Transfer-Encoding : chunked` (whitespace before colon) or
+      # obs-folded is invisible to the exact-match framing lookups below, yet a lenient
+      # backend still honours it — a CL/TE request-smuggling primitive. Reject up front,
+      # like CL+TE, rather than framing on a header we can't see (RFC 7230 §3.2.4).
+      raise Gori::Error.new("obfuscated request header (whitespace before colon or obs-fold)") if Http1.obfuscated_header?(req.raw_head)
       te = req.headers.get_all("Transfer-Encoding")
       if chunked?(te)
         reject_te_with_cl(req.headers)

--- a/src/gori/proxy/codec/content_decode.cr
+++ b/src/gori/proxy/codec/content_decode.cr
@@ -125,7 +125,12 @@ module Gori::Proxy::Codec
         out.write(body[pos, avail])
         break if avail < size # truncated mid-chunk
         pos += size
-        pos += 2 if pos + 2 <= body.size # skip the CRLF after the chunk data
+        # Skip the chunk-data terminator byte-accurately: an OPTIONAL CR then the LF.
+        # A blind 2-byte skip eats the first byte of the next chunk-size line when the
+        # wire form uses a bare LF (non-conformant but seen), misaligning every later
+        # chunk in this display/scan projection.
+        pos += 1 if pos < body.size && body[pos] == 0x0d_u8 # CR (optional)
+        pos += 1 if pos < body.size && body[pos] == 0x0a_u8 # LF
       end
       out.to_slice
     end

--- a/src/gori/proxy/codec/http1.cr
+++ b/src/gori/proxy/codec/http1.cr
@@ -110,6 +110,39 @@ module Gori::Proxy::Codec::Http1
   # old `String.new(raw).split(CRLF)` projection: name is bytes-before-colon
   # (unstripped), value is bytes-after-colon stripped; an empty line ends headers;
   # a colon-less line is skipped (raw_head still keeps it).
+  # RFC 7230 §3.2.4: a field-name must be followed IMMEDIATELY by ':' with NO
+  # whitespace, and obs-fold (a header line beginning with SP/HTAB) is obsolete and
+  # forbidden in a request. Either form hides a header from parse_headers (whose name
+  # match is exact) while a whitespace-lenient backend still reads it — so `Transfer-
+  # Encoding : chunked` or an obs-folded TE slips past gori's CL/TE framing checks and
+  # smuggles a request past the proxy. Return true when the header block contains
+  # whitespace before a colon or an obs-fold continuation line, so the caller can reject
+  # the message (record + close) exactly like the other ambiguous-framing vectors.
+  def self.obfuscated_header?(raw : Bytes) : Bool
+    start_crlf = index_crlf(raw, 0)
+    return false if start_crlf.nil?
+    pos = start_crlf + 2 # first byte after the start-line's CRLF
+    while pos < raw.size
+      crlf = index_crlf(raw, pos)
+      line_end = crlf || raw.size
+      break if line_end == pos # empty line → end of headers
+      first = raw.unsafe_fetch(pos)
+      return true if first == 0x20_u8 || first == 0x09_u8 # obs-fold continuation line
+      # Whitespace between field-name and colon: the byte just before the first ':' is SP/HTAB.
+      i = pos
+      while i < line_end && raw.unsafe_fetch(i) != 0x3a_u8 # ':'
+        i += 1
+      end
+      if i < line_end && i > pos
+        prev = raw.unsafe_fetch(i - 1)
+        return true if prev == 0x20_u8 || prev == 0x09_u8
+      end
+      break if crlf.nil?
+      pos = crlf + 2
+    end
+    false
+  end
+
   private def self.parse_headers(raw : Bytes, start_crlf : Int32?) : HeaderList
     list = HeaderList.new
     return list if start_crlf.nil? # no CRLF → no header block

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -312,7 +312,7 @@ module Gori::Proxy
       if (ic = @interceptor) && ic.intercepts_response?(scope_url,
            method: sent_req.method, host: host, target: sent_req.target, scheme: scheme, status: resp.status) &&
          !resp_framing.close_delimited? && !sse?(resp) && resp.status != 101
-        return handle_held_response(ic, upstream, req, flow_id, host, port, scheme,
+        return handle_held_response(ic, upstream, req, sent_req, flow_id, host, port, scheme,
           resp, sent_resp_head, resp_framing, resp_len, ttfb, started)
       end
 
@@ -352,7 +352,8 @@ module Gori::Proxy
       end
       # Reuse this upstream for the next request iff the ORIGIN keeps its side
       # open; the return value is the CLIENT keep-alive decision (separate sides).
-      update_upstream_reuse(origin_keep_alive?(req, resp, resp_framing))
+      # The origin side keys on sent_req (what it received); the client side on req.
+      update_upstream_reuse(origin_keep_alive?(sent_req, resp, resp_framing))
       keep_alive?(req, resp, resp_framing)
     end
 
@@ -488,6 +489,7 @@ module Gori::Proxy
     # human edit/drop it, forward the result, and capture. Returns the CLIENT
     # keep-alive decision; the upstream is reused iff the ORIGIN kept its side.
     private def handle_held_response(ic : Gori::Interceptor, upstream : IO, req : Codec::RawRequest,
+                                     sent_req : Codec::RawRequest,
                                      flow_id : Int64, host : String, port : Int32, scheme : String,
                                      resp : Codec::RawResponse, sent_resp_head : Bytes,
                                      resp_framing : Codec::BodyFraming, resp_len : Int64,
@@ -524,14 +526,25 @@ module Gori::Proxy
       @sink.on_response(FlowMapper.response(sent_resp,
         flow_id: flow_id, body: stored, ttfb_us: ttfb, duration_us: duration,
         body_truncated: trunc, body_size: size))
-      # Reuse the upstream iff we read the WHOLE body cleanly AND the origin kept
-      # its side alive. The CLIENT keep-alive (return value) uses the edited resp.
-      update_upstream_reuse(resp_complete && origin_keep_alive?(req, resp, resp_framing))
+      # Reuse the upstream iff we read the WHOLE body cleanly AND the origin kept its
+      # side alive. Origin side keys on sent_req (what the origin received); the CLIENT
+      # keep-alive (return value) uses the edited resp.
+      update_upstream_reuse(resp_complete && origin_keep_alive?(sent_req, resp, resp_framing))
       # A truncated upstream body was forwarded short — close the client connection so it
       # sees end-of-response instead of blocking for the missing bytes while we read its
       # next keep-alive request (mirrors the non-held path's resp_complete guard).
       return false unless resp_complete
-      keep_alive?(req, sent_resp, Codec::Body.response_framing(sent_resp, req.method)[0])
+      # The human may have edited the held response into conflicting framing (CL+TE); the
+      # response was already forwarded + recorded above, so recompute the client-side framing
+      # defensively — a raw response_framing raise here would unwind to run's blanket rescue
+      # and drop the client connection abruptly instead of a clean keep-alive decision.
+      client_framing =
+        begin
+          Codec::Body.response_framing(sent_resp, req.method)[0]
+        rescue Gori::Error
+          Codec::BodyFraming::CloseDelimited # unknowable framing → don't keep-alive
+        end
+      keep_alive?(req, sent_resp, client_framing)
     end
 
     # After a complete response, decide whether the live upstream can serve the
@@ -735,9 +748,9 @@ module Gori::Proxy
     private def keep_alive?(req : Codec::RawRequest, resp : Codec::RawResponse,
                             resp_framing : Codec::BodyFraming) : Bool
       return false if resp_framing.close_delimited? # body ends at close
-      return false if header_token(req.headers.get?("Connection")) == "close"
-      return false if header_token(resp.headers.get?("Connection")) == "close"
-      req.version == "HTTP/1.1" || header_token(req.headers.get?("Connection")) == "keep-alive"
+      return false if connection_lists?(req.headers.get?("Connection"), "close")
+      return false if connection_lists?(resp.headers.get?("Connection"), "close")
+      req.version == "HTTP/1.1" || connection_lists?(req.headers.get?("Connection"), "keep-alive")
     end
 
     # Whether the ORIGIN will keep its connection open after this response, so its
@@ -748,12 +761,15 @@ module Gori::Proxy
     # `Connection: close` on the request we forwarded upstream OR on the response,
     # all mean the origin closes. Parking a connection the origin will close just
     # wastes one stale-retry on the next request, so err toward NOT reusing.
-    private def origin_keep_alive?(req : Codec::RawRequest, resp : Codec::RawResponse,
+    # `sent_req` is the request ACTUALLY forwarded upstream (post Match&Replace /
+    # intercept edit), not the client's original — a rule that adds `Connection: close`
+    # to the upstream request means the origin closes, even if the client's request didn't.
+    private def origin_keep_alive?(sent_req : Codec::RawRequest, resp : Codec::RawResponse,
                                    resp_framing : Codec::BodyFraming) : Bool
       return false if resp_framing.close_delimited?
-      return false if header_token(req.headers.get?("Connection")) == "close"
-      return false if header_token(resp.headers.get?("Connection")) == "close"
-      resp.version == "HTTP/1.1" || header_token(resp.headers.get?("Connection")) == "keep-alive"
+      return false if connection_lists?(sent_req.headers.get?("Connection"), "close")
+      return false if connection_lists?(resp.headers.get?("Connection"), "close")
+      resp.version == "HTTP/1.1" || connection_lists?(resp.headers.get?("Connection"), "keep-alive")
     end
 
     # Whether a request may be transparently REPLAYED on a fresh connection after a
@@ -772,8 +788,13 @@ module Gori::Proxy
       end
     end
 
-    private def header_token(value : String?) : String?
-      value.try(&.downcase.strip)
+    # True when a Connection header field lists `token` (case-insensitive) as one of its
+    # comma-separated connection-options — e.g. `Connection: keep-alive, close` carries BOTH
+    # `keep-alive` and `close`. Comparing the whole value (the old header_token) missed a
+    # token embedded in such a list, so a peer signalling close would be parked as persistent.
+    private def connection_lists?(value : String?, token : String) : Bool
+      return false unless value
+      value.downcase.split(',').any? { |t| t.strip == token }
     end
 
     private def now_us : Int64

--- a/src/gori/replay/engine.cr
+++ b/src/gori/replay/engine.cr
@@ -71,9 +71,17 @@ module Gori
             return error("upstream closed after interim 1xx from #{host}:#{port}", started) unless head
             resp = Proxy::Codec::Http1.parse_response_head(head)
           end
-          framing, len = Proxy::Codec::Body.response_framing(resp, request_method(request))
-          body, complete = Proxy::Codec::Body.read_complete(upstream, framing, len)
-          Result.new(head, body, resp, elapsed(started), incomplete: !complete)
+          begin
+            framing, len = Proxy::Codec::Body.response_framing(resp, request_method(request))
+            body, complete = Proxy::Codec::Body.read_complete(upstream, framing, len)
+            Result.new(head, body, resp, elapsed(started), incomplete: !complete)
+          rescue ex
+            # The head was already read + parsed. A framing rejection (CL+TE — precisely the
+            # ambiguous response a smuggling/desync probe is hunting) or a mid-body read error
+            # must NOT throw the head away as a bare error string. Keep the head + parsed
+            # response, flag incomplete, and carry the reason so the workbench shows both.
+            Result.new(head, nil, resp, elapsed(started), error: ex.message || "response read failed", incomplete: true)
+          end
         rescue ex
           error(ex.message || "replay error", started)
         ensure

--- a/src/gori/session.cr
+++ b/src/gori/session.cr
@@ -66,9 +66,10 @@ module Gori
         host_overrides = HostOverrides.load(store) # per-project /etc/hosts; proxy reads, TUI edits (Mutex-guarded)
         interceptor = Interceptor.new(scope)       # shared: proxy fibers hold, TUI decides
         # Passive/active scanner: reads the parallel prism_events feed, gates active probes on
-        # the shared Scope. Starts now (idle until flows arrive); runs headless too.
+        # the shared Scope. Runs headless too — but ONLY on the capture-lock holder (started
+        # below), never on a view-only 2nd instance (which would send duplicate active probes to
+        # targets and race issue-writes on the shared DB against the real capturer).
         prism = Prism::Analyzer.new(store, scope, prism_events, store.prism_mode, !config.insecure_upstream?)
-        prism.start
         tunnel = Proxy::Tls::Tunnel.new(ca, verify_upstream: !config.insecure_upstream?,
           rewriter: rules, interceptor: interceptor, host_overrides: host_overrides)
         proxy = Proxy::Server.new(config.listen, config.port, sink, tls: tunnel,
@@ -103,6 +104,14 @@ module Gori
             lock = nil
             ex.message || "could not open the project capture lock"
           end
+        if lock
+          # Sole capturer for this project: clear any Pending rows orphaned by a previous
+          # session's crash/kill (nothing else will ever resolve them) before we capture, then
+          # run the scanner. Both are gated on the lock so a view-only 2nd instance touches
+          # neither the shared Pending rows nor the shared issue set.
+          store.abandon_pending!("orphaned by a previous session")
+          prism.start
+        end
         session = new(config, ca, registry, project, store, proxy, events, prism, rules, scope, host_overrides, interceptor, bind_error, lock)
         session.sync_capture_status!
         session
@@ -149,6 +158,7 @@ module Gori
         else
           @capture_lock ||= CaptureLock.try(@project.dir) # reuse if held, else try to take over
           return false unless @capture_lock               # still held by another instance
+          @prism.start                                    # we now hold the lock → run the scanner (idempotent if already running)
           @proxy.start(fallback: true)                    # cover a DIFFERENT project's port on resume
           true
         end

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -893,9 +893,15 @@ module Gori
         messages.each do |msg_text|
           masked_msg = Env.mask_secrets(msg_text)
           ts = now_us
+          # See insert_ws_one: an empty payload binds SQL NULL and violates the NOT NULL
+          # column (an empty replay message text hits this), so store X'' for it.
+          slice = masked_msg.to_slice
+          empty = slice.empty?
+          args = [0_i64, id, ts, "out", 1] of DB::Any
+          args << slice unless empty
           conn.exec(
-            "INSERT INTO ws_messages (flow_id, replay_id, created_at, direction, opcode, payload) VALUES (?,?,?,?,?,?)",
-            0_i64, id, ts, "out", 1, masked_msg.to_slice
+            "INSERT INTO ws_messages (flow_id, replay_id, created_at, direction, opcode, payload) " \
+            "VALUES (?,?,?,?,?,#{empty ? "X''" : "?"})", args: args
           )
         end
         nil
@@ -1747,9 +1753,17 @@ module Gori
     end
 
     private def insert_ws_one(conn : DB::Connection, op : InsertWs) : Nil
+      # payload is BLOB NOT NULL; binding an empty Bytes binds SQL NULL (empty slice ⇒
+      # null pointer) and violates the constraint, aborting the whole write batch. A
+      # zero-length WS text/binary frame (valid per RFC 6455 — e.g. an empty heartbeat)
+      # reaches here with an empty payload, so use the SQL literal X'' for it, mirroring
+      # insert_h2_frame_one's empty-DATA handling.
+      empty = op.payload.empty?
+      args = [op.flow_id, op.replay_id, op.created_at, op.direction, op.opcode] of DB::Any
+      args << op.payload unless empty
       conn.exec(
-        "INSERT INTO ws_messages (flow_id, replay_id, created_at, direction, opcode, payload) VALUES (?,?,?,?,?,?)",
-        op.flow_id, op.replay_id, op.created_at, op.direction, op.opcode, op.payload)
+        "INSERT INTO ws_messages (flow_id, replay_id, created_at, direction, opcode, payload) " \
+        "VALUES (?,?,?,?,?,#{empty ? "X''" : "?"})", args: args)
     end
 
     private def now_us : Int64


### PR DESCRIPTION
Three source-audit rounds across the codebase. Every finding was verified against the actual code before changing anything, each fix has a regression test, and the full spec suite (1464 examples, 0 failures), formatter, and linter were green before each commit.

**20 real bugs fixed** across 3 commits.

## Highlights
- **HTTP request-smuggling gap**: a header written `Transfer-Encoding : chunked` (whitespace before the colon) or obs-folded was invisible to the exact-match CL/TE framing lookups but forwarded byte-exact to a lenient backend — a classic CL.TE primitive. Now rejected like a CL+TE conflict (`Http1.obfuscated_header?` + `request_framing`), recorded as a visible error flow and closed.
- **Store data loss**: an empty WebSocket frame bound SQL `NULL` against a `NOT NULL` column, aborting the whole batched write transaction and losing co-batched flows. Guarded with `X''` like the h2 path.
- **MCP stdout purity**: `get_replay_context` emitted binary WebSocket bytes as a raw JSON string, corrupting the stdio JSON-RPC stream (must be valid UTF-8). Now base64-encoded.
- **View-only Prism**: a second (view-only) instance of a project still ran a full analyzer — duplicate active probes to targets + racing issue-writes on the shared DB. Now gated on holding the capture lock.

## By commit

### `93410a3` store / import / codec / miner / fuzz / convert (8)
- Empty WS frame → `NULL` → write-batch rollback (data loss).
- HAR timestamps with fractional seconds + numeric offset silently dropped the whole entry.
- `normalize_url` rejected scheme-less URLs merely containing `://`.
- De-chunk misaligned bare-LF chunked bodies (blind 2-byte skip).
- Miner baseline word/line tolerance floors weren't size-proportional → false findings on large pages.
- Blank fuzz match spec (`--ms=`) rejected everything instead of being unconstrained.
- `unicode_unescape` decoded a truncated `\uAB` instead of leaving it literal.
- Pitchfork fuzz iterators leaked FDs on a mid-open failure.

### `a741b9a` smuggling gap / Prism FPs / replay / MCP (6)
- Request-smuggling rejection (see Highlights).
- Prism FPs: `data-src`/`data-action` as mixed content; cookie clears with a non-empty sentinel + past `Expires`; ineffective `X-Frame-Options` values.
- Replay engine discarded an already-read response head on a framing rejection.
- MCP binary WS base64 + two int-overflow error-shape fixes.

### `3f2f11f` proxy keep-alive / lifecycle (6)
- `origin_keep_alive?` keyed on the original request, not the forwarded one; comma-list `Connection: keep-alive, close` ignored; held-response framing recompute could raise and drop the client abruptly.
- View-only Prism gated on the capture lock.
- Orphan `Pending` rows from a crashed session cleaned up on open (lock-gated).
- Terminal-enable calls moved inside the restore guard so a failure can't leave the shell in raw mode.

## Deliberately deferred
Three findings left untouched because they need dedicated, careful work rather than a broad sweep (most safety-critical code): Match&Replace rewriting a response `Content-Length` can forward a body/CL mismatch while keeping the connection alive; `Expect: 100-continue` defeated by eager request-body forwarding; `flock` conflating contention with other `IO::Error`s on exotic mounts.

## Test plan
- `crystal spec` — 1464 examples, 0 failures (each round).
- `crystal tool format --check` clean on changed files.
- `./bin/ameba src` — 317 (below the 318 baseline; no new lint).
- New regression tests: store WS empty-payload, HAR/URL import edges, dechunk bare-LF, fuzz matcher blank-spec, `unicode_unescape` truncation, Prism FP cases, MCP binary-WS, and an end-to-end proxy smuggling-rejection test.