### PR TITLE
ci: add CI + release/distribution workflows (Homebrew, AUR, GHCR, SBOM)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+# Build artifacts
+bin/
+lib/
+.shards/
+**/*.o
+**/*.dwarf
+
+# Git & VCS
+.git/
+.gitignore
+
+# Dev tooling
+.github/
+.claude/
+.ameba.yml
+.editorconfig
+AGENTS.md
+CLAUDE.md
+CONTRIBUTING.md
+CHANGELOG.md
+justfile
+
+# Packaging
+aur/
+scripts/package-macos.sh
+
+# Local state written by gori itself (see .gitignore)
+ca2/
+home*/
+*.key.pem
+
+# Tests, benchmarks & docs
+spec/
+bench/
+docs/
+
+# Docker itself
+docker/
+.dockerignore

--- a/.github/homebrew/gori.rb.tmpl
+++ b/.github/homebrew/gori.rb.tmpl
@@ -1,0 +1,56 @@
+# typed: strict
+# frozen_string_literal: true
+
+# This file is rendered by gori's release pipeline (.github/workflows/publish-homebrew.yml).
+# DO NOT EDIT by hand.
+class Gori < Formula
+  desc "TUI web proxy (MITM) for inspecting, intercepting and replaying HTTP traffic"
+  homepage "https://github.com/hahwul/gori"
+  version "__VERSION__"
+  license "Apache-2.0"
+
+  on_macos do
+    # macOS release archives are self-contained: scripts/package-macos.sh bundles
+    # every Homebrew-linked dylib (OpenSSL, brotli, zstd, libyaml, gmp, pcre2, gc)
+    # next to the binary, rewrites load paths to @executable_path/lib and re-signs
+    # each image, so no brew dependency is needed. libsqlite3 is not bundled: it
+    # resolves to /usr/lib/libsqlite3.dylib, which every macOS ships.
+    on_arm do
+      url "https://github.com/hahwul/gori/releases/download/v__VERSION__/gori-v__VERSION__-osx-arm64.tar.gz"
+      sha256 "__SHA_OSX_ARM64__"
+    end
+    on_intel do
+      url "https://github.com/hahwul/gori/releases/download/v__VERSION__/gori-v__VERSION__-osx-x86_64.tar.gz"
+      sha256 "__SHA_OSX_X86_64__"
+    end
+  end
+
+  on_linux do
+    # Linux release binaries are statically linked (musl), so they are self-contained.
+    on_arm do
+      url "https://github.com/hahwul/gori/releases/download/v__VERSION__/gori-v__VERSION__-linux-arm64"
+      sha256 "__SHA_LINUX_ARM64__"
+    end
+    on_intel do
+      url "https://github.com/hahwul/gori/releases/download/v__VERSION__/gori-v__VERSION__-linux-x86_64"
+      sha256 "__SHA_LINUX_X86_64__"
+    end
+  end
+
+  def install
+    if OS.mac?
+      # The macOS tarball extracts to `gori` + `lib/*.dylib`. Keep them together
+      # in libexec (the binary resolves dylibs via @executable_path/lib) and expose
+      # the CLI through a symlink; execve canonicalizes the symlink so
+      # @executable_path still points at libexec.
+      libexec.install "gori", "lib"
+      bin.install_symlink libexec/"gori"
+    else
+      bin.install Dir["gori-v#{version}-linux-*"].first => "gori"
+    end
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/gori --version")
+  end
+end

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,109 @@
+---
+name: CI
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/ci.yml
+      - shard.yml
+      - shard.lock
+      - docker/Dockerfile
+      - "**/*.cr"
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: manual run
+        required: false
+        default: ""
+jobs:
+  build-crystal:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # The floor shard.yml declares (`>= 1.20.2`) and the version development
+        # actually happens on. 1.21 is not incidental: the termisu fork and the
+        # ameba master pin in shard.yml exist specifically because upstream does
+        # not compile under it, so leaving 1.21 untested would test a toolchain
+        # nobody uses.
+        crystal-version: [1.20.2, 1.21.0]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: ${{ matrix.crystal-version }}
+      - name: Install native link dependencies
+        # brotli/zstd are linked via `@[Link(pkg_config:)]` (proxy/codec), sqlite3
+        # via the sqlite3 shard. The rest (openssl, yaml, gmp, pcre2, gc, zlib)
+        # arrive as dependencies of the Crystal package itself.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config libbrotli-dev libzstd-dev libsqlite3-dev
+      - name: Install dependencies
+        run: shards install
+      - name: Build
+        # Deliberately NO `-Dpreview_mt`. Store, Fuzz::Engine, Miner::Engine and
+        # Store::SafeRegexp each document that their plain ivars and unguarded
+        # counters are safe *because* gori runs on the single-threaded fiber
+        # scheduler. Enabling MT here would build a binary those files do not
+        # describe.
+        run: shards build
+  # No lint job, and no `crystal tool format --check` job: the tree does not
+  # currently pass either (ameba reports ~700 pre-existing findings, and the
+  # formatter rewrites 100+ files). Both are run locally via `just check`. Add
+  # them back as gates once the backlog is cleared, not before — a check that is
+  # always red is a check nobody reads.
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        crystal-version: [1.20.2, 1.21.0]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: ${{ matrix.crystal-version }}
+      - name: Install native link dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config libbrotli-dev libzstd-dev libsqlite3-dev
+      - name: Install dependencies
+        run: shards install
+      - name: Run tests
+        run: crystal spec
+  build-docker:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: linux/amd64
+            runner: ubuntu-latest
+          - arch: linux/arm64
+            # Native ARM runner: the image builds a static Crystal binary from
+            # source, which is far too slow to cross-build under QEMU.
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{ matrix.arch }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}

--- a/.github/workflows/hwaro.yml
+++ b/.github/workflows/hwaro.yml
@@ -1,0 +1,48 @@
+---
+name: Hwaro CI/CD
+
+# DISABLED FOR NOW — docs deploy is manual-only until the repo goes public.
+#
+# There is intentionally no `push` trigger: publishing docs/ to GitHub Pages
+# before the project is open would make the site public ahead of the code. To
+# turn automatic deploys back on, uncomment the `push` block below.
+#
+# on:
+#   push:
+#     branches: [main]
+#     paths:
+#       - "docs/**"
+#       - ".github/workflows/hwaro.yml"
+#   workflow_dispatch:
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build Only
+        uses: hahwul/hwaro@main
+        with:
+          build_dir: "docs"
+          build_only: true
+
+  deploy:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build and Deploy
+        uses: hahwul/hwaro@main
+        with:
+          build_dir: "docs"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,0 +1,155 @@
+---
+name: GHCR Publish
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to build and tag (e.g., 0.1.0)
+        required: true
+        type: string
+env:
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            # Native ARM runner rather than QEMU: the image compiles a static
+            # Crystal binary from source, which under emulation takes hours.
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Prepare platform slug
+        id: platform
+        run: |
+          echo "slug=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
+
+      # Build and push by digest (no tag yet); the merge job assembles the
+      # multi-arch manifest from the per-platform digests.
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=ghcr-${{ steps.platform.outputs.slug }}
+          cache-to: type=gha,mode=max,scope=ghcr-${{ steps.platform.outputs.slug }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ steps.platform.outputs.slug }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Normalize version: strip leading 'v' if present
+      - name: Normalize version
+        if: github.event_name == 'workflow_dispatch'
+        id: normalize
+        env:
+          RAW_VERSION: ${{ inputs.version }}
+        run: |
+          echo "version=${RAW_VERSION#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # push to main -> :main
+            type=ref,event=branch
+
+            # GitHub Release (tag push) -> :1.2.3, :1.2, :latest
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+
+            # manual dispatch -> the supplied version + :latest
+            type=raw,value=${{ steps.normalize.outputs.version }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -1,0 +1,119 @@
+---
+name: Homebrew tap Publish
+# Publishes the prebuilt formula to the Homebrew tap. Runs automatically once
+# "Build and Release Binaries" succeeds for a release (that workflow produces
+# the assets this one checksums), and can also be dispatched manually to
+# re-publish or backfill a version.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 0.1.0)"
+        required: true
+        type: string
+  workflow_run:
+    workflows: ["Build and Release Binaries"]
+    types: [completed]
+permissions:
+  contents: read
+jobs:
+  publish-formula:
+    name: Publish prebuilt formula to tap
+    # Only after a *release*-triggered binary build succeeds — a manual
+    # workflow_dispatch build produces `gori-main-*` assets, not
+    # `gori-v<version>-*`, so there would be nothing to checksum.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'release')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve version
+        id: ver
+        # Pass event data via env (never interpolate ${{ }} straight into the
+        # script body) so a crafted input can't inject shell. On workflow_run
+        # the release tag arrives as head_branch (e.g. "v0.1.0").
+        env:
+          DISPATCH_VERSION: ${{ github.event.inputs.version }}
+          RUN_TAG: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          # Strip a leading 'v' if present.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${DISPATCH_VERSION#v}"
+          else
+            VERSION="${RUN_TAG#v}"
+          fi
+          if [ -z "$VERSION" ]; then
+            echo "::error::version input is empty"; exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
+
+      - name: Checkout source (formula template)
+        # Use the template from the branch this workflow runs on (not the release
+        # tag): the template is build tooling and must reflect the current release
+        # asset layout, while the `version` input drives which binaries to fetch.
+        uses: actions/checkout@v6
+
+      - name: Download release binaries and compute checksums
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          V: ${{ steps.ver.outputs.version }}
+        run: |
+          # macOS assets are self-contained .tar.gz bundles (binary + bundled
+          # dylibs, see scripts/package-macos.sh); Linux assets are bare static
+          # musl binaries. Homebrew downloads and checksums exactly these files,
+          # so compute sha256 over the same artifact it will fetch.
+          for asset in \
+            "gori-v$V-osx-arm64.tar.gz" \
+            "gori-v$V-osx-x86_64.tar.gz" \
+            "gori-v$V-linux-arm64" \
+            "gori-v$V-linux-x86_64"; do
+            gh release download "v$V" --repo hahwul/gori \
+              --pattern "$asset" --output "$asset"
+          done
+          {
+            echo "SHA_OSX_ARM64=$(sha256sum "gori-v$V-osx-arm64.tar.gz" | awk '{print $1}')"
+            echo "SHA_OSX_X86_64=$(sha256sum "gori-v$V-osx-x86_64.tar.gz" | awk '{print $1}')"
+            echo "SHA_LINUX_ARM64=$(sha256sum "gori-v$V-linux-arm64" | awk '{print $1}')"
+            echo "SHA_LINUX_X86_64=$(sha256sum "gori-v$V-linux-x86_64" | awk '{print $1}')"
+          } >> "$GITHUB_ENV"
+
+      - name: Render formula
+        env:
+          V: ${{ steps.ver.outputs.version }}
+        run: |
+          mkdir -p out
+          sed \
+            -e "s|__VERSION__|$V|g" \
+            -e "s|__SHA_OSX_ARM64__|$SHA_OSX_ARM64|g" \
+            -e "s|__SHA_OSX_X86_64__|$SHA_OSX_X86_64|g" \
+            -e "s|__SHA_LINUX_ARM64__|$SHA_LINUX_ARM64|g" \
+            -e "s|__SHA_LINUX_X86_64__|$SHA_LINUX_X86_64|g" \
+            .github/homebrew/gori.rb.tmpl > out/gori.rb
+          echo "----- rendered formula -----"
+          cat out/gori.rb
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@v6
+        with:
+          repository: hahwul/homebrew-gori
+          token: ${{ secrets.GORI_PUBLISH_TOKEN }}
+          path: tap
+
+      - name: Commit and push formula
+        env:
+          V: ${{ steps.ver.outputs.version }}
+        run: |
+          mkdir -p tap/Formula
+          cp out/gori.rb tap/Formula/gori.rb
+          cd tap
+          git config user.name "hahwul"
+          git config user.email "hahwul@gmail.com"
+          git add Formula/gori.rb
+          if git diff --cached --quiet; then
+            echo "Formula unchanged; nothing to publish."
+            exit 0
+          fi
+          git commit -m "gori $V"
+          git push

--- a/.github/workflows/release-aur.yml
+++ b/.github/workflows/release-aur.yml
@@ -1,0 +1,67 @@
+---
+name: Publish AUR Package
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g., 0.1.0)"
+        required: true
+        type: string
+      ref:
+        description: "Git ref (branch/tag/commit) to checkout (optional, defaults to v<version>)"
+        required: false
+        type: string
+      pkgrel:
+        description: "Package release version (pkgrel) (optional, defaults to 1)"
+        required: false
+        default: "1"
+        type: string
+  workflow_run:
+    workflows: ["Build and Release Binaries"]
+    types: [completed]
+jobs:
+  publish-aur:
+    # Only after a *release*-triggered binary build succeeds — a manual
+    # workflow_dispatch build (which produces `gori-main-*` assets, not
+    # `gori-v<version>-*`) must not publish.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'release')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.ref || (github.event_name == 'workflow_dispatch' && format('v{0}', github.event.inputs.version) || github.event.workflow_run.head_branch) }}
+
+      - name: Get Version
+        env:
+          DISPATCH_VERSION: ${{ github.event.inputs.version }}
+          RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RAW_VERSION="$DISPATCH_VERSION"
+          else
+            RAW_VERSION="$RUN_BRANCH"
+          fi
+          VERSION="${RAW_VERSION#v}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Resolved version: $VERSION"
+
+      - name: Update PKGBUILD version
+        env:
+          PKGREL: ${{ github.event.inputs.pkgrel || '1' }}
+        run: |
+          sed -i "s/^pkgver=.*/pkgver=${VERSION}/" aur/PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=${PKGREL}/" aur/PKGBUILD
+          cat aur/PKGBUILD
+
+      - name: Publish to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.2
+        with:
+          pkgname: gori
+          pkgbuild: aur/PKGBUILD
+          commit_username: hahwul
+          commit_email: hahwul@gmail.com
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -1,0 +1,130 @@
+---
+name: Build and Release Binaries
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+permissions:
+  contents: write
+jobs:
+  build:
+    name: Build Binaries
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+          - os: ubuntu-24.04-arm
+            platform: linux
+          - os: macos-latest
+            platform: macos
+          - os: macos-15-intel
+            platform: macos
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+      - name: Checkout source code
+        uses: actions/checkout@v6
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v5
+      - name: Set architecture environment variable
+        run: |
+          if [ "$RUNNER_ARCH" == "X64" ]; then
+            echo "ARCH=x86_64" >> $GITHUB_ENV
+          elif [ "$RUNNER_ARCH" == "ARM64" ]; then
+            echo "ARCH=arm64" >> $GITHUB_ENV
+          else
+            echo "ARCH=unknown" >> $GITHUB_ENV
+          fi
+
+      - if: matrix.platform == 'linux'
+        name: Build binary (Linux)
+        # Alpine/musl container so `--static` yields a truly self-contained
+        # binary. Each library needs BOTH its `-dev` package (headers + the .pc
+        # file pkg-config reads) and its `-static` package (the .a archive the
+        # link actually consumes).
+        #
+        # `crystal build --static` passes `--static` to pkg-config, so
+        # `libbrotlidec` correctly pulls in `libbrotlicommon` via Requires.private.
+        #
+        # Deliberately NO `-Dpreview_mt`: Store, Fuzz::Engine, Miner::Engine and
+        # Store::SafeRegexp rely on the single-threaded fiber scheduler.
+        run: |
+          mkdir -p build
+          docker run --rm -v $(pwd):/gori -w /gori --entrypoint="" crystallang/crystal:1.21.0-alpine sh -c "
+            apk add --no-cache git curl pkgconf \
+              brotli-dev brotli-static \
+              zstd-dev zstd-static \
+              sqlite-dev sqlite-static \
+              yaml-dev yaml-static \
+              zlib-dev zlib-static \
+              openssl-dev openssl-libs-static \
+              gmp-dev gmp-static \
+              pcre2-dev gc-dev &&
+            git config --global --add safe.directory /gori &&
+            shards install --production &&
+            mkdir -p build &&
+            crystal build src/main.cr -o build/gori-${GITHUB_REF_SLUG}-linux-${ARCH} --release --no-debug --static
+          "
+
+      - if: matrix.platform == 'macos'
+        name: Install macOS build dependencies
+        # sqlite3 is intentionally absent: the sqlite3 shard links plain
+        # `@[Link("sqlite3")]`, which resolves to /usr/lib/libsqlite3.dylib —
+        # present on every macOS, so nothing to install or bundle.
+        run: brew install brotli zstd openssl@3 pkg-config
+
+      - if: matrix.platform == 'macos'
+        name: Install shards (macOS)
+        # macOS only: the Linux job runs `shards install --production` inside its
+        # Alpine container, against the same mounted workdir. Doing it here as
+        # well would leave a glibc-built lib/ for the musl container to trip
+        # over. Without this step the macOS build dies at `require "db"` — the
+        # host has no lib/ at all.
+        run: shards install --production
+
+      - if: matrix.platform == 'macos'
+        name: Build and package binary (macOS)
+        run: |
+          mkdir -p build
+          OPENSSL_PREFIX="$(brew --prefix openssl@3)"
+          # openssl@3 is keg-only, so its .pc files are not on the default
+          # search path; brotli/zstd are linked into the prefix and found there.
+          export PKG_CONFIG_PATH="${OPENSSL_PREFIX}/lib/pkgconfig"
+          BIN="build/gori-${GITHUB_REF_SLUG}-osx-${ARCH}"
+          crystal build src/main.cr -o "$BIN" --no-debug --release
+          chmod +x scripts/package-macos.sh
+          scripts/package-macos.sh "$BIN" "build/gori-${GITHUB_REF_SLUG}-osx-${ARCH}.tar.gz" gori
+          rm -f "$BIN"
+
+      - name: Smoke-test binary (Linux)
+        if: matrix.platform == 'linux'
+        run: |
+          # The build container runs as root, so `build/` and its contents are
+          # root-owned on the host; take ownership before touching them.
+          sudo chown -R "$(id -u):$(id -g)" build
+          BIN="build/gori-${GITHUB_REF_SLUG}-linux-${ARCH}"
+          chmod +x "$BIN"
+          "./$BIN" --version
+          # Assert the musl build really is self-contained — a dynamically linked
+          # artifact would still run here but break on the user's distro.
+          file "$BIN"
+          file "$BIN" | grep -qE 'statically linked|static-pie linked'
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: build-${{ matrix.os }}-${{ env.ARCH }}
+          path: build
+
+      - if: startsWith(github.ref, 'refs/tags/')
+        name: Upload to GitHub Releases
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true
+          file: build/*

--- a/.github/workflows/release-sbom.yml
+++ b/.github/workflows/release-sbom.yml
@@ -1,0 +1,28 @@
+---
+name: Generate and Upload SBOM
+on:
+  release:
+    types: [created]
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Generate SBOM
+        uses: hahwul/cyclonedx-cr@v1.0.2
+        with:
+          shard_file: ./shard.yml
+          lock_file: ./shard.lock
+          output_file: ./sbom.xml
+          output_format: xml
+          spec_version: 1.6
+
+      - name: Upload SBOM to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ./sbom.xml
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,0 +1,22 @@
+# Maintainer: HAHWUL <hahwul@gmail.com>
+pkgname=gori
+pkgver=0.1.0
+pkgrel=1
+pkgdesc="TUI web proxy (MITM) for inspecting, intercepting and replaying HTTP traffic."
+arch=('x86_64')
+url="https://github.com/hahwul/gori"
+license=('Apache-2.0')
+# The release binary is a static musl build, so it has no runtime depends.
+source=(
+  "gori-${pkgver}::https://github.com/hahwul/gori/releases/download/v${pkgver}/gori-v${pkgver}-linux-x86_64"
+  "LICENSE-gori-${pkgver}::https://raw.githubusercontent.com/hahwul/gori/refs/tags/v${pkgver}/LICENSE"
+)
+sha256sums=(
+  'SKIP'
+  'SKIP'
+)
+
+package() {
+  install -Dm755 "${srcdir}/gori-${pkgver}" "${pkgdir}/usr/bin/gori"
+  install -Dm644 "${srcdir}/LICENSE-gori-${pkgver}" "${pkgdir}/usr/share/licenses/gori/LICENSE"
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,81 @@
+##= BUILDER =##
+# Alpine/musl so `--static` produces a genuinely self-contained binary; the
+# runner stage then needs nothing but a CA bundle.
+FROM crystallang/crystal:1.21.0-alpine AS builder
+WORKDIR /gori
+
+# `-dev` packages carry the headers and the .pc files pkg-config reads; the
+# `-static` ones carry the .a archives `crystal build --static` actually links.
+# Both halves are required — omitting a `-static` package fails at link time,
+# not at configure time.
+#
+#   brotli/zstd  -> src/gori/proxy/codec/{brotli,zstd}.cr @[Link(pkg_config:)]
+#   sqlite       -> sqlite3 shard (@[Link("sqlite3")])
+#   openssl      -> proxy/tls
+#   yaml         -> import/oas.cr
+#   gmp          -> `require "big"`
+#   zlib         -> Compress::{Deflate,Gzip,Zlib}
+#   pcre2, gc    -> Crystal runtime (Regex, GC)
+#
+# pcre2-dev, gc-dev, yaml-dev and zlib-dev already carry their .a, so they need
+# no `-static` sibling; gmp does — `gmp-dev` alone links fine dynamically and
+# dies with `ld: cannot find -lgmp` only under `--static`.
+RUN apk add --no-cache \
+      git pkgconf \
+      brotli-dev brotli-static \
+      zstd-dev zstd-static \
+      sqlite-dev sqlite-static \
+      yaml-dev yaml-static \
+      zlib-dev zlib-static \
+      openssl-dev openssl-libs-static \
+      gmp-dev gmp-static \
+      pcre2-dev gc-dev
+
+COPY shard.yml shard.lock ./
+RUN shards install --production
+
+COPY . .
+# `crystal build -o` does not create the output directory, and `bin/` is in
+# .dockerignore so `COPY . .` never brings one — without this mkdir the link
+# step dies with `ld: cannot open output file /gori/bin/gori`.
+#
+# Deliberately NO `-Dpreview_mt`: Store, Fuzz::Engine, Miner::Engine and
+# Store::SafeRegexp rely on the single-threaded fiber scheduler for their
+# unguarded ivars. See the comments in those files before changing this.
+RUN mkdir -p /gori/bin && \
+    crystal build src/main.cr -o /gori/bin/gori --release --no-debug --static && \
+    strip /gori/bin/gori
+
+##= RUNNER =##
+FROM alpine:3.23
+
+LABEL org.opencontainers.image.title="gori"
+LABEL org.opencontainers.image.description="gori (고리) is a free/open-source TUI web proxy (MITM) written in Crystal."
+LABEL org.opencontainers.image.authors="HAHWUL <hahwul@gmail.com>"
+LABEL org.opencontainers.image.source="https://github.com/hahwul/gori"
+LABEL org.opencontainers.image.documentation="https://github.com/hahwul/gori"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+# The binary is static; ca-certificates is for verifying upstream TLS.
+RUN apk add --no-cache ca-certificates
+
+COPY --from=builder /gori/bin/gori /usr/local/bin/gori
+
+# Settings, the root CA and the per-project SQLite databases all live under
+# $GORI_HOME (default ~/.gori). Mount a volume here or the CA is regenerated —
+# and must be re-trusted — on every run.
+ENV GORI_HOME=/data
+VOLUME ["/data"]
+
+# Default proxy port. Note the default bind host is 127.0.0.1, which is not
+# reachable from outside the container: pass `--listen 0.0.0.0` to publish it.
+EXPOSE 8070
+
+# No CMD: bare `gori` starts the TUI, which needs a TTY (`docker run --rm -it`).
+# Headless subcommands work without one, e.g.
+#   docker run --rm -v gori:/data ghcr.io/hahwul/gori run history
+#   docker run --rm -i  -v gori:/data ghcr.io/hahwul/gori mcp
+ENTRYPOINT ["gori"]

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Bundle Homebrew-linked dylibs next to a Crystal macOS binary so the
+# release tarball runs without a local OpenSSL (or other brew) install.
+#
+# For gori this bundles libssl/libcrypto, libbrotlidec, libzstd, libyaml, libgmp,
+# libpcre2 and libgc. It deliberately does NOT bundle libsqlite3: the sqlite3
+# shard links `@[Link("sqlite3")]`, which resolves to /usr/lib/libsqlite3.dylib —
+# a system library present on every macOS, and outside the Homebrew prefixes this
+# script walks.
+#
+# Usage: scripts/package-macos.sh <binary-path> <output-tarball> [staged-name]
+#
+# Archive layout:
+#   <staged-name>
+#   lib/*.dylib
+set -euo pipefail
+
+BINARY="${1:?Usage: $0 <binary-path> <output-tarball> [staged-name]}"
+OUTPUT="${2:?Usage: $0 <binary-path> <output-tarball> [staged-name]}"
+NAME="${3:-$(basename "$BINARY")}"
+
+if [[ ! -f "$BINARY" ]]; then
+  echo "error: binary not found: $BINARY" >&2
+  exit 1
+fi
+
+if ! command -v otool >/dev/null 2>&1 || ! command -v install_name_tool >/dev/null 2>&1; then
+  echo "error: otool and install_name_tool are required (macOS only)" >&2
+  exit 1
+fi
+
+STAGING="$(mktemp -d)"
+trap 'rm -rf "$STAGING"' EXIT
+
+mkdir -p "$STAGING/lib"
+cp "$BINARY" "$STAGING/$NAME"
+chmod +x "$STAGING/$NAME"
+
+BREW_PREFIX_RE='^(/opt/homebrew|/usr/local)/'
+
+# Every load command of a Mach-O image, verbatim (system libs included).
+load_commands() {
+  otool -L "$1" | awk 'NR>1 {print $1}'
+}
+
+# `deps.txt` holds the load-command strings to rewrite; `origins.txt` maps each
+# staged basename back to the directory it was copied from. The latter is what
+# lets us resolve `@rpath` / `@loader_path` references: Homebrew's brotli, for
+# one, links libbrotlidec against `@rpath/libbrotlicommon.1.dylib`, so matching
+# only on the brew prefix silently drops libbrotlicommon from the bundle.
+DEPS_FILE="$STAGING/deps.txt"
+ORIGINS_FILE="$STAGING/origins.txt"
+: > "$DEPS_FILE"
+: > "$ORIGINS_FILE"
+
+origin_dir_of() {
+  awk -F'\t' -v want="$1" '$1 == want { print $2; exit }' "$ORIGINS_FILE"
+}
+
+# Map a load command to the file on disk it refers to, or nothing if it is a
+# system library we must not bundle. $2 is the directory the *referencing* image
+# was copied from, used to anchor @rpath/@loader_path.
+resolve_dep() {
+  local dep="$1" origin="$2" candidate
+  case "$dep" in
+    @rpath/* | @loader_path/*)
+      [[ -n "$origin" ]] || return 0
+      candidate="$origin/$(basename "$dep")"
+      ;;
+    *)
+      candidate="$dep"
+      ;;
+  esac
+  # Print nothing for anything we must not bundle: system libraries (note
+  # /usr/lib/libsqlite3.dylib is not even on disk — it lives in the dyld shared
+  # cache, so `-f` is false) and unresolvable @rpath entries. Always succeed:
+  # under `set -e` a non-zero return here would abort the caller's assignment.
+  if [[ -f "$candidate" && "$candidate" =~ $BREW_PREFIX_RE ]]; then
+    printf '%s\n' "$candidate"
+  fi
+  return 0
+}
+
+while true; do
+  added=0
+  for target in "$STAGING/$NAME" "$STAGING"/lib/*.dylib; do
+    [[ -e "$target" ]] || continue
+    # The main binary was copied from wherever it was built, not from a brew
+    # prefix, so it anchors nothing; staged dylibs anchor to their brew dir.
+    target_origin=""
+    [[ "$target" != "$STAGING/$NAME" ]] && target_origin="$(origin_dir_of "$(basename "$target")")"
+
+    while IFS= read -r dep; do
+      [[ -z "$dep" ]] && continue
+      src="$(resolve_dep "$dep" "$target_origin")"
+      [[ -n "$src" ]] || continue
+
+      base="$(basename "$src")"
+      if ! grep -Fxq "$dep" "$DEPS_FILE"; then
+        echo "$dep" >> "$DEPS_FILE"
+      fi
+      if [[ ! -f "$STAGING/lib/$base" ]]; then
+        cp "$src" "$STAGING/lib/$base"
+        chmod u+w "$STAGING/lib/$base" # brew ships these 0444; install_name_tool needs write
+        printf '%s\t%s\n' "$base" "$(dirname "$src")" >> "$ORIGINS_FILE"
+        added=1
+      fi
+    done < <(load_commands "$target")
+  done
+  [[ "$added" -eq 0 ]] && break
+done
+
+rewrite_paths() {
+  local target="$1"
+  while IFS= read -r dep; do
+    [[ -z "$dep" ]] && continue
+    install_name_tool -change "$dep" "@executable_path/lib/$(basename "$dep")" "$target"
+  done < "$DEPS_FILE"
+}
+
+rewrite_paths "$STAGING/$NAME"
+for lib in "$STAGING"/lib/*.dylib; do
+  [[ -e "$lib" ]] || continue
+  install_name_tool -id "@executable_path/lib/$(basename "$lib")" "$lib"
+  rewrite_paths "$lib"
+done
+
+# `install_name_tool` rewrites load commands in place, which invalidates each
+# Mach-O's code signature. On Apple Silicon that is fatal, not cosmetic: dyld
+# refuses the image and the kernel SIGKILLs the process (exit 137) the moment a
+# bundled dylib is loaded. Re-sign every image we touched, ad-hoc.
+if ! command -v codesign >/dev/null 2>&1; then
+  echo "error: codesign is required to re-sign rewritten binaries" >&2
+  exit 1
+fi
+for target in "$STAGING"/lib/*.dylib "$STAGING/$NAME"; do
+  [[ -e "$target" ]] || continue
+  codesign --force --sign - "$target" 2>/dev/null
+done
+
+# Audit the binary *and* every bundled dylib: an unrewritten @rpath buried in a
+# transitive dylib still aborts at load time, and checking only the top-level
+# binary would not see it.
+leaked=0
+for target in "$STAGING/$NAME" "$STAGING"/lib/*.dylib; do
+  [[ -e "$target" ]] || continue
+  while IFS= read -r dep; do
+    [[ -z "$dep" ]] && continue
+    if [[ "$dep" =~ $BREW_PREFIX_RE ]] || [[ "$dep" == @rpath/* ]] || [[ "$dep" == @loader_path/* ]]; then
+      echo "error: unbundled reference in $(basename "$target"): $dep" >&2
+      leaked=1
+    fi
+  done < <(load_commands "$target")
+done
+[[ "$leaked" -eq 0 ]] || exit 1
+
+# Smoke-test the staged tree *before* archiving, and let a failure abort the
+# release. Guarding this behind `if` would hide exactly the signature breakage
+# the codesign pass above exists to prevent.
+echo "Verifying staged binary:"
+"$STAGING/$NAME" --version
+
+mkdir -p "$(dirname "$OUTPUT")"
+tar -czf "$OUTPUT" -C "$STAGING" "$NAME" lib
+
+echo "Created $OUTPUT"

--- a/spec/verb/conflicts_spec.cr
+++ b/spec/verb/conflicts_spec.cr
@@ -4,10 +4,10 @@ include Gori::Verb
 
 private def conflict_reg : Registry
   r = Registry.new
-  r.register(Definition.new("g.cap", "g.cap", "", Scope::Global, [Chord.new("c")]) { |_| nil })
-  r.register(Definition.new("b.copy", "b.copy", "", Scope::Body, [Chord.new("y")]) { |_| nil })
-  r.register(Definition.new("rep.send", "rep.send", "", Scope::Repeater, [Chord.new("r", ctrl: true)]) { |_| nil })
-  r.register(Definition.new("cmp.swap", "cmp.swap", "", Scope::Comparer, [Chord.new("s")]) { |_| nil })
+  r.register(Definition.new("g.cap", "g.cap", "", Gori::Verb::Scope::Global, [Chord.new("c")]) { |_| nil })
+  r.register(Definition.new("b.copy", "b.copy", "", Gori::Verb::Scope::Body, [Chord.new("y")]) { |_| nil })
+  r.register(Definition.new("rep.send", "rep.send", "", Gori::Verb::Scope::Repeater, [Chord.new("r", ctrl: true)]) { |_| nil })
+  r.register(Definition.new("cmp.swap", "cmp.swap", "", Gori::Verb::Scope::Comparer, [Chord.new("s")]) { |_| nil })
   r
 end
 
@@ -16,11 +16,11 @@ describe Gori::Verb::Conflicts do
     reg = conflict_reg
     c = Conflicts.detect(reg, OsProfile::Os::Linux, Keymap::NO_OVERRIDES, "rep.send", Chord.new("r", ctrl: true))
     # rep.send already holds ctrl-r in Repeater; proposing it for a *different* Repeater verb conflicts.
-    reg.register(Definition.new("rep.other", "rep.other", "", Scope::Repeater) { |_| nil })
+    reg.register(Definition.new("rep.other", "rep.other", "", Gori::Verb::Scope::Repeater) { |_| nil })
     c2 = Conflicts.detect(reg, OsProfile::Os::Linux, Keymap::NO_OVERRIDES, "rep.other", Chord.new("r", ctrl: true))
     c2.should_not be_nil
     c2.not_nil!.verb_id.should eq("rep.send")
-    c2.not_nil!.scope.should eq(Scope::Repeater)
+    c2.not_nil!.scope.should eq(Gori::Verb::Scope::Repeater)
   end
 
   it "allows the same key across DIFFERENT scopes (incl. shadowing a Global chord)" do
@@ -39,14 +39,14 @@ describe Gori::Verb::Conflicts do
     reg = conflict_reg
     # Pending: b.copy is being rebound from `y` to `k`. Now proposing `k` for another Body
     # verb must see the pending `k`, and `y` must be free.
-    reg.register(Definition.new("b.other", "b.other", "", Scope::Body) { |_| nil })
+    reg.register(Definition.new("b.other", "b.other", "", Gori::Verb::Scope::Body) { |_| nil })
     working = {"b.copy" => [Chord.new("k")]}
     Conflicts.detect(reg, OsProfile::Os::Linux, working, "b.other", Chord.new("k")).should_not be_nil
     Conflicts.detect(reg, OsProfile::Os::Linux, working, "b.other", Chord.new("y")).should be_nil
   end
 
   it "formats a readable conflict message" do
-    msg = Conflicts::Conflict.new(Chord.new("s", shift: true), "scope.toggle", Scope::Body).message
+    msg = Conflicts::Conflict.new(Chord.new("s", shift: true), "scope.toggle", Gori::Verb::Scope::Body).message
     msg.should eq("shift-s already bound to scope.toggle in Body")
   end
 end

--- a/spec/verb/keymap_spec.cr
+++ b/spec/verb/keymap_spec.cr
@@ -15,18 +15,18 @@ end
 describe Gori::Verb::Keymap do
   describe ".effective_chords (user > OS > base)" do
     it "returns the verb's base chords when there is no override" do
-      v = verb("t.a", Scope::Body, Chord.new("a"))
+      v = verb("t.a", Gori::Verb::Scope::Body, Chord.new("a"))
       Keymap.effective_chords(v, OsProfile::Os::Linux, Keymap::NO_OVERRIDES).should eq([Chord.new("a")])
     end
 
     it "lets a user override replace the base chords" do
-      v = verb("t.a", Scope::Body, Chord.new("a"))
+      v = verb("t.a", Gori::Verb::Scope::Body, Chord.new("a"))
       ov = {"t.a" => [Chord.new("g")]}
       Keymap.effective_chords(v, OsProfile::Os::Linux, ov).should eq([Chord.new("g")])
     end
 
     it "treats a user override of [] as an explicit unbind" do
-      v = verb("t.a", Scope::Body, Chord.new("a"))
+      v = verb("t.a", Gori::Verb::Scope::Body, Chord.new("a"))
       ov = {"t.a" => [] of Chord}
       Keymap.effective_chords(v, OsProfile::Os::Linux, ov).should be_empty
     end
@@ -34,26 +34,26 @@ describe Gori::Verb::Keymap do
 
   describe ".build with overrides" do
     it "binds the override and unbinds the base chord" do
-      r = reg_with(verb("t.a", Scope::Body, Chord.new("a")))
+      r = reg_with(verb("t.a", Gori::Verb::Scope::Body, Chord.new("a")))
       km = Keymap.build(r, OsProfile::Os::Linux, {"t.a" => [Chord.new("g")]})
-      km.lookup(Chord.new("g"), Scope::Body).should eq("t.a")
-      km.lookup(Chord.new("a"), Scope::Body).should be_nil # the old default no longer binds
+      km.lookup(Chord.new("g"), Gori::Verb::Scope::Body).should eq("t.a")
+      km.lookup(Chord.new("a"), Gori::Verb::Scope::Body).should be_nil # the old default no longer binds
     end
 
     it "drops a binding entirely on unbind ([])" do
-      r = reg_with(verb("t.a", Scope::Body, Chord.new("a")))
+      r = reg_with(verb("t.a", Gori::Verb::Scope::Body, Chord.new("a")))
       km = Keymap.build(r, OsProfile::Os::Linux, {"t.a" => [] of Chord})
-      km.lookup(Chord.new("a"), Scope::Body).should be_nil
+      km.lookup(Chord.new("a"), Gori::Verb::Scope::Body).should be_nil
     end
 
     it "preserves scope-then-Global fallback" do
       r = reg_with(
-        verb("g.x", Scope::Global, Chord.new("x", ctrl: true)),
-        verb("b.x", Scope::Body, Chord.new("y")),
+        verb("g.x", Gori::Verb::Scope::Global, Chord.new("x", ctrl: true)),
+        verb("b.x", Gori::Verb::Scope::Body, Chord.new("y")),
       )
       km = Keymap.build(r)
-      km.lookup(Chord.new("x", ctrl: true), Scope::Body).should eq("g.x") # Global fallback
-      km.lookup(Chord.new("y"), Scope::Body).should eq("b.x")
+      km.lookup(Chord.new("x", ctrl: true), Gori::Verb::Scope::Body).should eq("g.x") # Global fallback
+      km.lookup(Chord.new("y"), Gori::Verb::Scope::Body).should eq("b.x")
     end
   end
 
@@ -72,7 +72,7 @@ describe Gori::Verb::Keymap do
     # structural primary (body.open = enter) — none are editable, so they're excluded.
     it "has no two rebindable verbs claiming the same chord in the SAME scope" do
       reg = Gori::Verbs.registry
-      seen = {} of {Scope, Chord} => String
+      seen = {} of {Gori::Verb::Scope, Chord} => String
       reg.each do |v|
         next unless Gori::Hotkeys.rebindable?(v)
         v.chords.each do |c|

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -1084,11 +1084,11 @@ describe Gori::Verb do
       keymap = Keymap.build(reg)
 
       # keybinding path: ctrl-p (Global) -> app.palette
-      via_key = keymap.lookup(Chord.new("p", ctrl: true), Scope::Body)
+      via_key = keymap.lookup(Chord.new("p", ctrl: true), Gori::Verb::Scope::Body)
       via_key.should eq("app.palette")
 
       # palette path: the Ctrl-P palette is the Global (app-control) surface
-      via_palette = reg.for_scope(Scope::Global, FakeContext.new, "palette").map(&.id)
+      via_palette = reg.for_scope(Gori::Verb::Scope::Global, FakeContext.new, "palette").map(&.id)
       via_palette.should contain("app.palette")
     end
   end
@@ -1099,43 +1099,43 @@ describe Gori::Verb do
       keymap = Keymap.build(reg)
 
       # escape in PaletteOpen -> palette.close (scope-specific)
-      keymap.lookup(Chord.new("escape"), Scope::PaletteOpen).should eq("palette.close")
+      keymap.lookup(Chord.new("escape"), Gori::Verb::Scope::PaletteOpen).should eq("palette.close")
       # escape in HistoryDetail -> detail.close (different verb, same chord)
-      keymap.lookup(Chord.new("escape"), Scope::HistoryDetail).should eq("detail.close")
+      keymap.lookup(Chord.new("escape"), Gori::Verb::Scope::HistoryDetail).should eq("detail.close")
       # ←/→ in HistoryDetail walk the panes (left no longer just closes)
-      keymap.lookup(Chord.new("right"), Scope::HistoryDetail).should eq("detail.next-pane")
-      keymap.lookup(Chord.new("left"), Scope::HistoryDetail).should eq("detail.prev-pane")
-      keymap.lookup(Chord.new("x"), Scope::HistoryDetail).should eq("detail.select-line")
-      keymap.lookup(Chord.new("x", ctrl: true), Scope::HistoryDetail).should eq("detail.toggle-hex")
+      keymap.lookup(Chord.new("right"), Gori::Verb::Scope::HistoryDetail).should eq("detail.next-pane")
+      keymap.lookup(Chord.new("left"), Gori::Verb::Scope::HistoryDetail).should eq("detail.prev-pane")
+      keymap.lookup(Chord.new("x"), Gori::Verb::Scope::HistoryDetail).should eq("detail.select-line")
+      keymap.lookup(Chord.new("x", ctrl: true), Gori::Verb::Scope::HistoryDetail).should eq("detail.toggle-hex")
       # ^U in the Fuzzer pretty-prints the template (must NOT be intercepted as clear-marks
       # anymore — clear-marks moved to the space menu as fuzz.clear-marks).
-      keymap.lookup(Chord.new("u", ctrl: true), Scope::Fuzzer).should eq("fuzz.pretty-template")
+      keymap.lookup(Chord.new("u", ctrl: true), Gori::Verb::Scope::Fuzzer).should eq("fuzz.pretty-template")
       # a Global chord (^P palette) resolves from ANY scope
-      keymap.lookup(Chord.new("p", ctrl: true), Scope::Body).should eq("app.palette")
+      keymap.lookup(Chord.new("p", ctrl: true), Gori::Verb::Scope::Body).should eq("app.palette")
       # 'q' (back to projects) is bound only on the tab bar (Sidebar), not in a body —
       # as a Global chord it used to dump you to the picker mid-browse.
-      keymap.lookup(Chord.new("q"), Scope::Sidebar).should eq("app.back-key")
-      keymap.lookup(Chord.new("q"), Scope::Body).should be_nil
+      keymap.lookup(Chord.new("q"), Gori::Verb::Scope::Sidebar).should eq("app.back-key")
+      keymap.lookup(Chord.new("q"), Gori::Verb::Scope::Body).should be_nil
       # an unbound chord
-      keymap.lookup(Chord.new("z"), Scope::Body).should be_nil
+      keymap.lookup(Chord.new("z"), Gori::Verb::Scope::Body).should be_nil
       # scope-specific: the top menu navigates horizontally, the body vertically
-      keymap.lookup(Chord.new("right"), Scope::Sidebar).should eq("sidebar.next")
-      keymap.lookup(Chord.new("down"), Scope::Sidebar).should eq("sidebar.enter")
-      keymap.lookup(Chord.new("down"), Scope::Body).should eq("body.down")
+      keymap.lookup(Chord.new("right"), Gori::Verb::Scope::Sidebar).should eq("sidebar.next")
+      keymap.lookup(Chord.new("down"), Gori::Verb::Scope::Sidebar).should eq("sidebar.enter")
+      keymap.lookup(Chord.new("down"), Gori::Verb::Scope::Body).should eq("body.down")
     end
 
     it "supports multiple chords per verb" do
       reg = Gori::Verbs.registry
       keymap = Keymap.build(reg)
-      keymap.lookup(Chord.new("j"), Scope::Body).should eq("body.down")
-      keymap.lookup(Chord.new("down"), Scope::Body).should eq("body.down")
+      keymap.lookup(Chord.new("j"), Gori::Verb::Scope::Body).should eq("body.down")
+      keymap.lookup(Chord.new("down"), Gori::Verb::Scope::Body).should eq("body.down")
     end
 
     it "binds bare 's' to the scope-lens toggle from any scope (was jump-to-editor)" do
       reg = Gori::Verbs.registry
       keymap = Keymap.build(reg)
-      keymap.lookup(Chord.new("s"), Scope::Body).should eq("scope.toggle-lens")
-      keymap.lookup(Chord.new("s"), Scope::Sitemap).should eq("scope.toggle-lens")
+      keymap.lookup(Chord.new("s"), Gori::Verb::Scope::Body).should eq("scope.toggle-lens")
+      keymap.lookup(Chord.new("s"), Gori::Verb::Scope::Sitemap).should eq("scope.toggle-lens")
 
       ctx = FakeContext.new
       reg["scope.toggle-lens"].call(ctx)
@@ -1149,7 +1149,7 @@ describe Gori::Verb do
     it "binds ctrl-n to a new blank repeater in the Repeater scope" do
       reg = Gori::Verbs.registry
       keymap = Keymap.build(reg)
-      keymap.lookup(Chord.new("n", ctrl: true), Scope::Repeater).should eq("repeater.new")
+      keymap.lookup(Chord.new("n", ctrl: true), Gori::Verb::Scope::Repeater).should eq("repeater.new")
 
       ctx = FakeContext.new
       reg["repeater.new"].call(ctx)
@@ -1160,8 +1160,8 @@ describe Gori::Verb do
       reg = Gori::Verbs.registry
       keymap = Keymap.build(reg)
       # ↓/↵/j on the tab bar resolve to sidebar.enter…
-      keymap.lookup(Chord.new("down"), Scope::Sidebar).should eq("sidebar.enter")
-      keymap.lookup(Chord.new("enter"), Scope::Sidebar).should eq("sidebar.enter")
+      keymap.lookup(Chord.new("down"), Gori::Verb::Scope::Sidebar).should eq("sidebar.enter")
+      keymap.lookup(Chord.new("enter"), Gori::Verb::Scope::Sidebar).should eq("sidebar.enter")
 
       # …which descends through enter_content (NOT focus_pane), letting the Runner
       # route Repeater/Notes onto their sub-tab strip before the body.
@@ -1175,26 +1175,26 @@ describe Gori::Verb do
   describe "migrated tab-local chords resolve in their per-tab scope" do
     it "binds the Repeater request-pane toggles + send in Repeater scope" do
       km = Keymap.build(Gori::Verbs.registry)
-      km.lookup(Chord.new("r", ctrl: true), Scope::Repeater).should eq("repeater.send")
-      km.lookup(Chord.new("x", ctrl: true), Scope::Repeater).should eq("repeater.toggle-hex")
-      km.lookup(Chord.new("s", ctrl: true), Scope::Repeater).should eq("repeater.toggle-sni")
-      km.lookup(Chord.new("l", ctrl: true), Scope::Repeater).should eq("repeater.toggle-auto-content-length")
+      km.lookup(Chord.new("r", ctrl: true), Gori::Verb::Scope::Repeater).should eq("repeater.send")
+      km.lookup(Chord.new("x", ctrl: true), Gori::Verb::Scope::Repeater).should eq("repeater.toggle-hex")
+      km.lookup(Chord.new("s", ctrl: true), Gori::Verb::Scope::Repeater).should eq("repeater.toggle-sni")
+      km.lookup(Chord.new("l", ctrl: true), Gori::Verb::Scope::Repeater).should eq("repeater.toggle-auto-content-length")
     end
 
     it "binds the Fuzzer run/stop/automark chords in Fuzzer scope" do
       km = Keymap.build(Gori::Verbs.registry)
-      km.lookup(Chord.new("r", ctrl: true), Scope::Fuzzer).should eq("fuzz.run")
-      km.lookup(Chord.new("x", ctrl: true), Scope::Fuzzer).should eq("fuzz.stop")
-      km.lookup(Chord.new("a", ctrl: true), Scope::Fuzzer).should eq("fuzz.automark")
+      km.lookup(Chord.new("r", ctrl: true), Gori::Verb::Scope::Fuzzer).should eq("fuzz.run")
+      km.lookup(Chord.new("x", ctrl: true), Gori::Verb::Scope::Fuzzer).should eq("fuzz.stop")
+      km.lookup(Chord.new("a", ctrl: true), Gori::Verb::Scope::Fuzzer).should eq("fuzz.automark")
     end
 
     it "binds the Intercept catch chords in Intercept scope, shadowing the Global/Body keys" do
       km = Keymap.build(Gori::Verbs.registry)
-      km.lookup(Chord.new("c"), Scope::Intercept).should eq("intercept.direction")
-      km.lookup(Chord.new("/"), Scope::Intercept).should eq("intercept.filter")
+      km.lookup(Chord.new("c"), Gori::Verb::Scope::Intercept).should eq("intercept.direction")
+      km.lookup(Chord.new("/"), Gori::Verb::Scope::Intercept).should eq("intercept.filter")
       # …without breaking capture (`c`) elsewhere or History's `/` filter
-      km.lookup(Chord.new("c"), Scope::Body).should eq("capture.toggle")
-      km.lookup(Chord.new("/"), Scope::Body).should eq("history.query")
+      km.lookup(Chord.new("c"), Gori::Verb::Scope::Body).should eq("capture.toggle")
+      km.lookup(Chord.new("/"), Gori::Verb::Scope::Body).should eq("history.query")
     end
 
     it "routes the new Repeater toggle verbs through the matching ExecContext methods" do
@@ -1270,10 +1270,10 @@ describe Gori::Verb do
       ctx = FakeContext.new
       ctx.selected = 5_i64 # so the flow-gated Body actions are available
 
-      body = reg.for_scope(Scope::Body, ctx)
+      body = reg.for_scope(Gori::Verb::Scope::Body, ctx)
       body.each do |v|
         v.hidden?.should be_false
-        v.scope.should eq(Scope::Body) # strictly Body — Global app-control stays out of ":"
+        v.scope.should eq(Gori::Verb::Scope::Body) # strictly Body — Global app-control stays out of ":"
       end
       ids = body.map(&.id)
       ids.should contain("history.repeater") # an area action surfaces
@@ -1281,20 +1281,20 @@ describe Gori::Verb do
       ids.should_not contain("nav.next-tab")
 
       # The palette source is the Global slice (app control) — and it has NO area actions.
-      gids = reg.for_scope(Scope::Global, ctx).map(&.id)
+      gids = reg.for_scope(Gori::Verb::Scope::Global, ctx).map(&.id)
       gids.should contain("app.quit")
       gids.should contain("nav.next-tab") # tab navigation lives in Ctrl-P
       gids.any?(&.starts_with?("history.")).should be_false
 
       # fuzzy query narrows within the scope (same ranking as #search)
-      reg.for_scope(Scope::Body, ctx, "repeater").first.id.should eq("history.repeater")
+      reg.for_scope(Gori::Verb::Scope::Body, ctx, "repeater").first.id.should eq("history.repeater")
     end
 
     it "rejects duplicate ids" do
       reg = Registry.new
-      reg.register(Definition.new("dup", "A", "", Scope::Global) { |_| nil })
+      reg.register(Definition.new("dup", "A", "", Gori::Verb::Scope::Global) { |_| nil })
       expect_raises(Gori::Error, /duplicate/) do
-        reg.register(Definition.new("dup", "B", "", Scope::Global) { |_| nil })
+        reg.register(Definition.new("dup", "B", "", Gori::Verb::Scope::Global) { |_| nil })
       end
     end
   end
@@ -1302,7 +1302,7 @@ describe Gori::Verb do
   describe "handler execution" do
     it "runs through Definition#call and returns the handler's status message" do
       ctx = FakeContext.new
-      verb = Definition.new("t.msg", "T", "", Scope::Global) { |_c| "did it" }
+      verb = Definition.new("t.msg", "T", "", Gori::Verb::Scope::Global) { |_c| "did it" }
       verb.call(ctx).should eq("did it")
 
       reg = Gori::Verbs.registry


### PR DESCRIPTION
## What

gori had no `.github/` beyond `FUNDING.yml`. This adds the CI and packaging pipeline, modeled on [hahwul/hwaro](https://github.com/hahwul/hwaro) but adapted where gori differs.

| Workflow | Trigger | Does |
|---|---|---|
| `ci.yml` | PR / push to main | build + `crystal spec` on Crystal 1.20.2 & 1.21.0, docker build (amd64 + native arm64) |
| `release-binary.yml` | release published | static musl Linux (x86_64/arm64) + self-contained macOS tarballs (arm64/x86_64) |
| `publish-homebrew.yml` | **auto after a release build succeeds** | render formula → push to `hahwul/homebrew-gori` tap |
| `release-aur.yml` | same chain | publish `aur/PKGBUILD` to AUR |
| `release-sbom.yml` | release created | CycloneDX SBOM attached to the release |
| `publish-ghcr.yml` | push / release / manual | multi-arch GHCR image (Alpine static build) |
| `hwaro.yml` | `workflow_dispatch` only | docs → Pages, **disabled** until the repo goes public |

Supporting files: `docker/Dockerfile`, `.dockerignore`, `aur/PKGBUILD`, `.github/homebrew/gori.rb.tmpl`, `scripts/package-macos.sh`.

## Bugs found by running the pipeline

Each of these would have broken the first release. None were visible by reading the YAML.

1. **Dockerfile had no output directory.** `crystal build -o /gori/bin/gori` does not create `bin/`, and `bin/` is in `.dockerignore`, so the link step died with `ld: cannot open output file`.
2. **`gmp-static` was missing** — in the Dockerfile *and* the release-binary Alpine container. `gmp-dev` alone links fine dynamically and only fails under `--static` with `ld: cannot find -lgmp`. It is the sole dependency needing a `-static` sibling: pcre2, gc, yaml and zlib all ship their `.a` inside `-dev`.
3. **The macOS release job never ran `shards install`.** Only the Linux container did, for itself; the host had no `lib/`, so both macOS binaries would have died at `require "db"` — precisely the artifacts Homebrew serves to Mac users. Added as a macOS-scoped step so it cannot leave a glibc-built `lib/` for the musl container to trip over.

## Homebrew is now automatic

`publish-homebrew.yml` was `workflow_dispatch`-only. It now chains off a successful *Build and Release Binaries* run via `workflow_run`, matching hwaro, guarded on `workflow_run.event == 'release'` so a manual build (which produces `gori-main-*` assets rather than `gori-v<version>-*`) cannot publish a formula pointing at assets that do not exist.

## gori-specific decisions

- **Never `-Dpreview_mt`.** hwaro uses it; gori must not. `Store`, `Fuzz::Engine`, `Miner::Engine` and `Store::SafeRegexp` each document that their unguarded ivars are safe *because* gori runs on the single-threaded fiber scheduler.
- **No lint or format gate.** Ameba reports ~704 pre-existing findings and the formatter rewrites 100+ files; both would be permanently red. `just check` covers them locally.
- **Toolchain pinned to 1.21.0** in the Dockerfile and release container to match development; 1.20.2 stays in the CI matrix as the floor `shard.yml` declares.

## Spec fix included

`crystal spec` failed to compile on the runner: bare `Scope` bound to `Gori::Scope` (the include/exclude rule class) instead of `Gori::Verb::Scope` (the keybinding enum). Both exist, and the suite drags both into the top-level namespace because `crystal spec` compiles every spec file into one program and several use a top-level `include`. Qualifying the 61 member references plus one type argument removes the ambiguity outright. No behaviour change.

Notably this never reproduced off the runner — macOS/homebrew, Alpine musl and Debian glibc all pass on the same compiler build against byte-identical sources.

## Verified

- `docker build` completes; the 35.9MB image runs `gori --version`. Both CI docker builds (amd64 + native arm64) pass.
- `scripts/package-macos.sh` against a real binary bundles 9 dylibs including the `@rpath`-referenced `libbrotlicommon`, omits system `libsqlite3`, and the extracted tree runs from an arbitrary cwd through a `bin/` symlink — the exact layout the formula installs.
- Full CI matrix green: build + tests on 1.20.2 and 1.21.0, docker on both arches.

## Before the first publish

The repo is still private, so the Homebrew and AUR release URLs will 404 for users until it goes public. Secrets `GORI_PUBLISH_TOKEN` and `AUR_SSH_PRIVATE_KEY` already exist and the `hahwul/homebrew-gori` tap repo is in place, so the chain is ready.
