### PR TITLE
perf: cut per-op CPU/allocation across proxy, store, Prism, and TUI hot paths

### DIFF
--- a/bench/capture_bench.cr
+++ b/bench/capture_bench.cr
@@ -1,0 +1,84 @@
+# Isolated CaptureBuffer / Body.stream micro-benchmark.
+#
+# proxy_bench measures a full loopback round-trip, whose socket + scheduler noise
+# (±40% run-to-run) drowns out a per-request allocation change. This drives the
+# body codec's tee path directly over IO::Memory (no sockets), so Benchmark.ips
+# isolates the CaptureBuffer allocation/copy cost with stable ns/op + bytes/op.
+#
+# Build: crystal build bench/capture_bench.cr -o bin/capture_bench --release
+# Run:   bin/capture_bench
+require "benchmark"
+
+module Gori
+  class Error < Exception; end
+end
+
+require "../src/gori/proxy/codec/body"
+
+include Gori::Proxy::Codec
+
+CAP = Gori::Proxy::Codec::Body::CAPTURE_MAX
+
+def len_body(n : Int32) : Bytes
+  b = Bytes.new(n)
+  n.times { |i| b[i] = (32 + (i % 90)).to_u8 }
+  b
+end
+
+def chunked_wire(n : Int32, chunk : Int32) : Bytes
+  io = IO::Memory.new
+  off = 0
+  while off < n
+    sz = {chunk, n - off}.min
+    io << sz.to_s(16) << "\r\n"
+    io.write(len_body(sz))
+    io << "\r\n"
+    off += sz
+  end
+  io << "0\r\n\r\n"
+  io.to_slice.dup
+end
+
+BODY_64K   = len_body(64 * 1024)
+BODY_1M    = len_body(1024 * 1024)
+CHUNK_64K  = chunked_wire(64 * 1024, 16 * 1024)
+CHUNK_1M   = chunked_wire(1024 * 1024, 16 * 1024)
+
+# Drive one Content-Length body through Body.stream, teeing into a fresh
+# CaptureBuffer sized by `hint`, and return the captured slice (so DCE can't
+# drop the work).
+def run_length(body : Bytes, hint : Int64) : Bytes
+  src = IO::Memory.new(body, writeable: false)
+  dst = IO::Memory.new(body.size)
+  cap = CaptureBuffer.new(CAP, hint)
+  Body.stream(src, dst, BodyFraming::Length, body.size.to_i64, cap)
+  cap.to_slice
+end
+
+def run_chunked(wire : Bytes) : Bytes
+  src = IO::Memory.new(wire, writeable: false)
+  dst = IO::Memory.new(wire.size)
+  cap = CaptureBuffer.new(CAP)
+  Body.stream(src, dst, BodyFraming::Chunked, 0_i64, cap)
+  cap.to_slice
+end
+
+# A bodyless GET: None framing, capture never written — measures the wasted
+# per-flow CaptureBuffer allocation on the dominant traffic shape.
+def run_none : Int32
+  cap = CaptureBuffer.new(CAP)
+  Body.stream(IO::Memory.new, IO::Memory.new, BodyFraming::None, 0_i64, cap)
+  cap.to_slice.size
+end
+
+puts "CaptureBuffer / Body.stream isolated (ips):"
+puts "(hint) = presized to Content-Length; (nohint) = old default-growth path"
+Benchmark.ips do |x|
+  x.report("none (bodyless GET)")    { run_none }
+  x.report("length 64K (hint)")      { run_length(BODY_64K, BODY_64K.size.to_i64) }
+  x.report("length 64K (nohint)")    { run_length(BODY_64K, 0_i64) }
+  x.report("length 1M  (hint)")      { run_length(BODY_1M, BODY_1M.size.to_i64) }
+  x.report("length 1M  (nohint)")    { run_length(BODY_1M, 0_i64) }
+  x.report("chunked 64K")            { run_chunked(CHUNK_64K) }
+  x.report("chunked 1M")             { run_chunked(CHUNK_1M) }
+end

--- a/bench/h2frame_bench.cr
+++ b/bench/h2frame_bench.cr
@@ -1,0 +1,50 @@
+# h2 Frame.read allocation micro-benchmark. The relay pump calls Frame.read once per
+# frame (every DATA/HEADERS/WINDOW_UPDATE/PING/SETTINGS, both directions), so the 9-byte
+# header buffer it allocated per frame was pure GC churn. This drives Frame.read over a
+# stream of small frames (the WINDOW_UPDATE/PING/SETTINGS shape that dominates a busy h2
+# connection) and reports bytes/op.
+#
+# Build: crystal build bench/h2frame_bench.cr -o bin/h2frame_bench --release
+# Run:   bin/h2frame_bench
+require "benchmark"
+
+module Gori
+  class Error < Exception; end
+end
+
+require "../src/gori/proxy/h2/frame"
+
+include Gori::Proxy::H2
+
+# Build a wire buffer of many tiny frames (8-byte WINDOW_UPDATE payload = the busiest shape).
+def frame_stream(count : Int32, payload_len : Int32) : Bytes
+  io = IO::Memory.new
+  count.times do
+    io.write_byte(((payload_len >> 16) & 0xff).to_u8)
+    io.write_byte(((payload_len >> 8) & 0xff).to_u8)
+    io.write_byte((payload_len & 0xff).to_u8)
+    io.write_byte(0x08_u8) # type WINDOW_UPDATE
+    io.write_byte(0x00_u8) # flags
+    io.write_byte(0x00_u8); io.write_byte(0x00_u8); io.write_byte(0x00_u8); io.write_byte(0x01_u8) # stream 1
+    payload_len.times { |i| io.write_byte((i & 0xff).to_u8) }
+  end
+  io.to_slice.dup
+end
+
+SMALL = frame_stream(1000, 4)    # 1000 tiny frames (WINDOW_UPDATE-ish)
+DATA  = frame_stream(500, 16384) # 500 x 16KB DATA frames
+
+def drain(wire : Bytes) : Int32
+  io = IO::Memory.new(wire, writeable: false)
+  n = 0
+  while f = Frame.read(io)
+    n += f.payload.size
+  end
+  n
+end
+
+puts "h2 Frame.read over a frame stream (bytes/op = per whole stream):"
+Benchmark.ips do |x|
+  x.report("1000 tiny frames (4B payload)") { drain(SMALL) }
+  x.report("500 DATA frames (16KB payload)") { drain(DATA) }
+end

--- a/bench/highlight_bench.cr
+++ b/bench/highlight_bench.cr
@@ -1,0 +1,28 @@
+# Body-tokenizer micro-benchmark. body_styled runs per visible body line per render (up to
+# ~40 lines × 20fps during capture/scroll). The old path allocated a whole-line Array(Char)
+# + a per-span sub-array + join; the byte-scan slices the source directly.
+#
+# Build: crystal build bench/highlight_bench.cr -o bin/highlight_bench --release
+# Run:   bin/highlight_bench
+require "benchmark"
+require "../src/gori/tui"
+
+include Gori::Tui
+
+JSON_LINE = %(  {"id": 12345, "name": "Alice Example", "email": "a@example.com", "active": true, "score": -12.5e3, "tags": ["alpha", "beta", "gamma"], "note": "ordinary value"},)
+HTML_LINE = %(<div class="card" id="main"><span class="label">Hello</span><a href="http://x/y">link</a><br/><b>bold</b> and some plain text here</div>)
+FORM_LINE = "username=alice&password=hunter2&csrf=abcdef0123456789&remember=true&redirect=%2Fdashboard&locale=en-US&theme=dark"
+
+# A ~40-line viewport of each, styled per render.
+def frame(line : String, kind : Symbol) : Int32
+  total = 0
+  40.times { total += Highlight.body_styled(line, kind).size }
+  total
+end
+
+puts "body_styled over a 40-line viewport (per render):"
+Benchmark.ips do |x|
+  x.report("json (#{JSON_LINE.bytesize}B/line)") { frame(JSON_LINE, :json) }
+  x.report("html (#{HTML_LINE.bytesize}B/line)") { frame(HTML_LINE, :html) }
+  x.report("form (#{FORM_LINE.bytesize}B/line)") { frame(FORM_LINE, :form) }
+end

--- a/bench/jwt_bench.cr
+++ b/bench/jwt_bench.cr
@@ -1,0 +1,26 @@
+# Jwt.from_flow micro-benchmark: scan_body runs on every flow's request+response body
+# (up to 2MiB) even with no token. The `eyJ` raw-byte pre-gate skips the whole-body
+# String.new+scrub+regex when no JWT is present (the common case).
+require "benchmark"
+
+module Gori
+  class Error < Exception; end
+end
+require "../src/gori/convert/converter"
+require "../src/gori/jwt"
+
+# A 200KB JSON response body with NO JWT (the dominant shape).
+NO_TOKEN = begin
+  io = IO::Memory.new
+  400.times { |i| io << %({"id":) << i << %(,"name":"user) << i << %(","email":"u) << i << %(@example.com"}\n) }
+  io.to_slice.dup
+end
+
+HEAD = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n".to_slice
+
+puts "Jwt.from_flow over a #{NO_TOKEN.size}-byte body with NO token:"
+Benchmark.ips do |x|
+  x.report("from_flow (resp body, no jwt)") do
+    Gori::Jwt.from_flow("/api", HEAD, nil, HEAD, NO_TOKEN).size
+  end
+end

--- a/bench/miner_reflect_bench.cr
+++ b/bench/miner_reflect_bench.cr
@@ -1,0 +1,56 @@
+# Miner reflection micro-benchmark: the K-canary reflection test per bucket probe.
+# Old path ran K full-body `includes?` scans + two String.new(body/head).scrub allocations
+# per probe; the new path scans body+head ONCE into a Set. This drives Baseline.decide over
+# a realistic bucket (128 canaries) against a 100 KB response with a few reflected.
+#
+# Build: crystal build bench/miner_reflect_bench.cr -o bin/miner_reflect_bench --release
+# Run:   bin/miner_reflect_bench
+require "benchmark"
+
+module Gori
+  class Error < Exception; end
+end
+
+require "../src/gori/miner/types"
+require "../src/gori/miner/fingerprint"
+
+include Gori::Miner
+
+# A 100 KB response body that echoes 3 of the bucket's canaries somewhere inside it.
+def body_with(canaries : Array(String)) : Bytes
+  io = IO::Memory.new
+  200.times do |i|
+    io << %({"row":) << i << %(,"label":"ordinary value number ) << i << %(","tags":["a","b","c"]}\n)
+  end
+  # sprinkle 3 reflected canaries
+  io << "reflected1=" << canaries[3] << " reflected2=" << canaries[40] << " x" << canaries[120] << "y\n"
+  400.times { |i| io << %(filler line with lorem ipsum dolor sit amet consectetur ) << i << "\n" }
+  io.to_slice.dup
+end
+
+HEAD = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nServer: nginx\r\n\r\n".to_slice
+
+# Build a bucket of 128 canaries + the reflected body once.
+CANARIES = Array.new(128) { Canary.fresh }
+BODY = body_with(CANARIES)
+INV = begin
+  h = Hash(String, String).new
+  CANARIES.each_with_index { |c, i| h[c] = "param#{i}" }
+  h
+end
+
+# A minimal Replay::Result stand-in via Fingerprint.probe's input shape.
+def make_result : Gori::Replay::Result
+  Gori::Replay::Result.new(HEAD, BODY, nil, 1000_i64)
+end
+
+puts "Miner reflection over a 128-canary bucket, 100KB body (3 reflected):"
+res = make_result
+Benchmark.ips do |x|
+  x.report("probe + decide (scan-once)") do
+    probe = Fingerprint.probe(res)
+    n = 0
+    INV.each { |c, _| n += 1 if probe.reflects?(c) }
+    n
+  end
+end

--- a/bench/prism_active_bench.cr
+++ b/bench/prism_active_bench.cr
@@ -1,0 +1,46 @@
+# Prism active dedup_key vs plan micro-benchmark. The analyzer now checks rule.dedup_key BEFORE
+# building the full plan; on a repeat surface (the norm in steady browsing) it skips plan's
+# canary generation (Random::Secure per param) + JSON re-serialize + request rebuild. This
+# measures the cost saved on each such hit.
+#
+# Build: crystal build bench/prism_active_bench.cr -o bin/prism_active_bench --release
+# Run:   bin/prism_active_bench
+require "benchmark"
+
+module Gori
+  class Error < Exception; end
+end
+
+require "../src/gori/fuzz"
+require "../src/gori/prism/active/reflected_param"
+
+include Gori::Prism::Active
+
+def detail(target : String, req_head : String, body : Bytes?) : Gori::Store::FlowDetail
+  row = Gori::Store::FlowRow.new(
+    1_i64, 1_i64, "http", "GET", "api.example.com", 80, target,
+    200, 100_i64, Gori::Store::FlowState::Complete)
+  Gori::Store::FlowDetail.new(row, "HTTP/1.1", req_head.to_slice, body, nil, nil)
+end
+
+# A GET with 6 query params — plan generates 6 canaries + rebuilds the request.
+QUERY = detail(
+  "/api/search?q=hello&lang=en&page=2&sort=desc&filter=active&ref=homepage",
+  "GET /api/search?q=hello&lang=en&page=2&sort=desc&filter=active&ref=homepage HTTP/1.1\r\nHost: api.example.com\r\n\r\n",
+  nil)
+
+# A GET with a JSON body — plan parses, canaries each string field, re-serializes, rebuilds.
+JSON_BODY = %({"name":"alice","email":"a@x.com","role":"admin","note":"hello world","n":42}).to_slice
+JSON_FLOW = detail(
+  "/api/user",
+  "GET /api/user HTTP/1.1\r\nHost: api.example.com\r\nContent-Type: application/json\r\n\r\n",
+  JSON_BODY)
+
+rule = ReflectedParam.new
+puts "ReflectedParam: dedup_key (new, on a repeat) vs plan (old, always):"
+Benchmark.ips do |x|
+  x.report("query: dedup_key") { rule.dedup_key(QUERY) }
+  x.report("query: plan     ") { rule.plan(QUERY) }
+  x.report("json:  dedup_key") { rule.dedup_key(JSON_FLOW) }
+  x.report("json:  plan     ") { rule.plan(JSON_FLOW) }
+end

--- a/bench/prism_bench.cr
+++ b/bench/prism_bench.cr
@@ -1,0 +1,47 @@
+# Prism Tech-rule GraphQL-detection micro-benchmark. The Tech rule parses every JSON
+# request body (≤256 KB) to test for a GraphQL shape; a cheap `"query"` substring pre-gate
+# lets non-GraphQL JSON POSTs skip the full JSON.parse (a tree build). This isolates that.
+#
+# Build: crystal build bench/prism_bench.cr -o bin/prism_bench --release
+# Run:   bin/prism_bench
+require "benchmark"
+require "json"
+
+# A realistic non-GraphQL JSON POST body (an ordinary API request payload — the common shape
+# that used to pay a full JSON.parse just to be classified "not GraphQL").
+NON_GQL = begin
+  io = IO::Memory.new
+  io << %({"filters":{"status":"active","tags":["a","b","c"]},"items":[)
+  400.times do |i|
+    io << "," if i > 0
+    io << %({"id":) << i << %(,"name":"item) << i << %(","qty":) << (i % 50) << %(,"note":"ordinary text value ) << i << "\"}"
+  end
+  io << "]}"
+  String.new(io.to_slice).scrub
+end
+
+# The pre-gate the Tech rule now runs before parsing.
+def has_query_gate?(text : String) : Bool
+  text.includes?(%("query"))
+end
+
+# The old path: always parse.
+def parse_for_query(text : String) : String?
+  JSON.parse(text).as_h?.try(&.["query"]?).try(&.as_s?)
+rescue JSON::ParseException
+  nil
+end
+
+puts "Tech GraphQL-detection gate bench (non-GraphQL JSON POST = the common shape):"
+puts "body = #{NON_GQL.bytesize} bytes; gate says query? #{has_query_gate?(NON_GQL)}"
+
+Benchmark.ips do |x|
+  x.report("OLD: JSON.parse every JSON body") { parse_for_query(NON_GQL) }
+  x.report("NEW: substring pre-gate then skip") do
+    if has_query_gate?(NON_GQL)
+      parse_for_query(NON_GQL)
+    else
+      nil
+    end
+  end
+end

--- a/bench/screen_cell_bench.cr
+++ b/bench/screen_cell_bench.cr
@@ -1,0 +1,41 @@
+# Screen#cell allocation micro-benchmark. `cell` is the universal draw primitive; a
+# per-Char `to_s` allocated a fresh 1-char String on every cell. This drives a realistic
+# frame (full-screen fill + text rows) and reports bytes/op so the interning win is visible.
+#
+# Build: crystal build bench/screen_cell_bench.cr -o bin/screen_cell_bench --release
+# Run:   bin/screen_cell_bench
+require "benchmark"
+require "../src/gori/tui"
+
+include Gori::Tui
+
+# A minimal recording backend that keeps only the last glyph (no per-cell grid alloc that
+# would dwarf the measurement) — we're measuring Screen#cell's own allocation, not storage.
+class SinkBackend < Backend
+  @last = ' '.as(Char | String)
+
+  def initialize(@w : Int32, @h : Int32)
+  end
+
+  def put(x : Int32, y : Int32, grapheme : Char | String, fg : Color, bg : Color, attr : Attribute) : Nil
+    @last = grapheme
+  end
+
+  def size : {Int32, Int32}
+    {@w, @h}
+  end
+end
+
+W = 200
+H = 50
+backend = SinkBackend.new(W, H)
+screen = Screen.new(backend)
+LINE = "GET /api/v1/users/12345/profile?include=avatar HTTP/1.1  200  1.4kB  api.example.com"
+
+puts "Screen frame draw (fill #{W}x#{H} + #{H} text rows):"
+Benchmark.ips do |x|
+  x.report("full-frame fill + text rows") do
+    screen.fill(Rect.new(0, 0, W, H), Theme.bg)
+    H.times { |y| screen.text(2, y, LINE, Theme.text) }
+  end
+end

--- a/bench/sitemap_bench.cr
+++ b/bench/sitemap_bench.cr
@@ -1,0 +1,25 @@
+# Sitemap.build micro-benchmark: the path-param-explosion case that makes Node#child's
+# linear sibling scan O(n²). Drives build over many numeric siblings under one parent.
+#
+# Build: crystal build bench/sitemap_bench.cr -o bin/sitemap_bench --release
+# Run:   bin/sitemap_bench
+require "benchmark"
+require "../src/gori/sitemap"
+
+# N distinct endpoints /users/<id>/profile — all siblings under /users, the shape that
+# collides in Node#child before group_sequences! folds them.
+def entries(n : Int32) : Array({String, String, String})
+  rows = [] of {String, String, String}
+  n.times { |i| rows << {"api.example.com", "GET", "/users/#{i}/profile"} }
+  # a few other hosts/paths so host lookup + varied segments are exercised too
+  n.times { |i| rows << {"cdn.example.com", "GET", "/assets/img/#{i}.png"} }
+  rows
+end
+
+{2000, 5000}.each do |n|
+  data = entries(n)
+  puts "\n#{data.size} endpoints (#{n} siblings under /users, #{n} under /assets/img):"
+  Benchmark.ips do |x|
+    x.report("Sitemap.build") { Gori::Sitemap.build(data) }
+  end
+end

--- a/bench/ws_unmask_bench.cr
+++ b/bench/ws_unmask_bench.cr
@@ -1,0 +1,28 @@
+# WS unmask micro-benchmark. Every client→server WS frame is masked, so the unmask runs
+# over the whole payload of every upload. Compares the word-XOR against the old scalar loop.
+#
+# Build: crystal build bench/ws_unmask_bench.cr -o bin/ws_unmask_bench --release
+# Run:   bin/ws_unmask_bench
+require "benchmark"
+
+module Gori
+  class Error < Exception; end
+end
+
+require "../src/gori/proxy/ws/frame"
+
+KEY = Bytes[0xAA, 0xBB, 0xCC, 0xDD]
+
+def scalar(src : Bytes, key : Bytes, dst : Bytes) : Nil
+  src.size.times { |i| dst[i] = src[i] ^ key[i & 3] }
+end
+
+{64, 4096, 65536}.each do |n|
+  src = Bytes.new(n) { |i| (i & 0xff).to_u8 }
+  dst = Bytes.new(n)
+  puts "\npayload = #{n} bytes:"
+  Benchmark.ips do |x|
+    x.report("scalar byte XOR") { scalar(src, KEY, dst) }
+    x.report("word XOR (Frame.unmask)") { Gori::Proxy::WS.unmask(src, KEY, dst) }
+  end
+end

--- a/spec/interceptor_spec.cr
+++ b/spec/interceptor_spec.cr
@@ -141,8 +141,8 @@ describe "Gori::Interceptor direction + condition gates" do
     with_store do |store|
       ic = Gori::Interceptor.new(Gori::Scope.load(store))
       ic.toggle # enable (default Both)
-      req_ok = -> { ic.intercepts_request?("http://acme.test/x", method: "GET", host: "acme.test", target: "/x", scheme: "http") }
-      res_ok = -> { ic.intercepts_response?("http://acme.test/x", method: "GET", host: "acme.test", target: "/x", scheme: "http", status: 200) }
+      req_ok = -> { ic.intercepts_request?(method: "GET", host: "acme.test", target: "/x", scheme: "http") }
+      res_ok = -> { ic.intercepts_response?(method: "GET", host: "acme.test", target: "/x", scheme: "http", status: 200) }
 
       req_ok.call.should be_true
       res_ok.call.should be_true
@@ -160,8 +160,8 @@ describe "Gori::Interceptor direction + condition gates" do
   it "disabled → both gates closed regardless of direction" do
     with_store do |store|
       ic = Gori::Interceptor.new(Gori::Scope.load(store))
-      ic.intercepts_request?("http://acme.test/x", method: "GET", host: "acme.test", target: "/x", scheme: "http").should be_false
-      ic.intercepts_response?("http://acme.test/x", method: "GET", host: "acme.test", target: "/x", scheme: "http", status: 200).should be_false
+      ic.intercepts_request?(method: "GET", host: "acme.test", target: "/x", scheme: "http").should be_false
+      ic.intercepts_response?(method: "GET", host: "acme.test", target: "/x", scheme: "http", status: 200).should be_false
     end
   end
 
@@ -170,8 +170,8 @@ describe "Gori::Interceptor direction + condition gates" do
       ic = Gori::Interceptor.new(Gori::Scope.load(store))
       ic.toggle
       ic.set_filter("method:POST")
-      ic.intercepts_request?("http://acme.test/x", method: "POST", host: "acme.test", target: "/x", scheme: "http").should be_true
-      ic.intercepts_request?("http://acme.test/x", method: "GET", host: "acme.test", target: "/x", scheme: "http").should be_false
+      ic.intercepts_request?(method: "POST", host: "acme.test", target: "/x", scheme: "http").should be_true
+      ic.intercepts_request?(method: "GET", host: "acme.test", target: "/x", scheme: "http").should be_false
     end
   end
 
@@ -180,9 +180,9 @@ describe "Gori::Interceptor direction + condition gates" do
       ic = Gori::Interceptor.new(Gori::Scope.load(store))
       ic.toggle
       ic.set_filter("status:>=500")
-      ic.intercepts_response?("http://acme.test/x", method: "GET", host: "acme.test", target: "/x", scheme: "http", status: 503).should be_true
-      ic.intercepts_response?("http://acme.test/x", method: "GET", host: "acme.test", target: "/x", scheme: "http", status: 200).should be_false
-      ic.intercepts_request?("http://acme.test/x", method: "GET", host: "acme.test", target: "/x", scheme: "http").should be_false
+      ic.intercepts_response?(method: "GET", host: "acme.test", target: "/x", scheme: "http", status: 503).should be_true
+      ic.intercepts_response?(method: "GET", host: "acme.test", target: "/x", scheme: "http", status: 200).should be_false
+      ic.intercepts_request?(method: "GET", host: "acme.test", target: "/x", scheme: "http").should be_false
     end
   end
 
@@ -206,8 +206,8 @@ describe "Gori::Interceptor direction + condition gates" do
       scope.add("include", "host", "acme.test")
       scope.enable
       ic.set_filter("method:GET")
-      ic.intercepts_request?("http://acme.test/x", method: "GET", host: "acme.test", target: "/x", scheme: "http").should be_true
-      ic.intercepts_request?("http://evil.test/x", method: "GET", host: "evil.test", target: "/x", scheme: "http").should be_false # out of scope
+      ic.intercepts_request?(method: "GET", host: "acme.test", target: "/x", scheme: "http").should be_true
+      ic.intercepts_request?(method: "GET", host: "evil.test", target: "/x", scheme: "http").should be_false # out of scope
     end
   end
 end

--- a/spec/prism_spec.cr
+++ b/spec/prism_spec.cr
@@ -251,6 +251,50 @@ describe Gori::Prism::Active do
     end
   end
 
+  # The analyzer now checks `rule.dedup_key(detail)` BEFORE building the full `plan`, to skip the
+  # canary generation + request rebuild on a repeat surface. This is only correct if the cheap key
+  # is IDENTICAL to `plan(detail).dedup_key` (and nil in exactly the same cases) — otherwise the
+  # seen-set would re-probe or wrongly suppress. Assert that equivalence across a broad corpus.
+  it "dedup_key equals plan.dedup_key across query/form/json/edge-case flows (both rules)" do
+    with_store do |store|
+      form_ct = "Content-Type: application/x-www-form-urlencoded\r\n"
+      json_ct = "Content-Type: application/json\r\n"
+      cors_resp = "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: https://app.example\r\n\r\n"
+      plain_resp = "HTTP/1.1 200 OK\r\n\r\n"
+      many = (0..50).map { |i| "p#{i}=v" }.join("&") # 51 params → over MAX_PARAMS
+
+      cases = [
+        {target: "/search?q=hello&lang=en", method: "GET", rh: "", rb: nil, resp: plain_resp},
+        {target: "/a?x=1&x=2", method: "GET", rh: "", rb: nil, resp: plain_resp},            # duplicate name
+        {target: "/a?%6eame=v&z=2", method: "GET", rh: "", rb: nil, resp: plain_resp},       # URL-encoded name
+        {target: "/a?flag&y=2&=nope&w=3", method: "GET", rh: "", rb: nil, resp: plain_resp}, # bare flag / empty name
+        {target: "/nothing", method: "GET", rh: "", rb: nil, resp: plain_resp},              # no params → nil
+        {target: "/a?x=1", method: "POST", rh: "", rb: nil, resp: plain_resp},               # unsafe method → nil
+        {target: "/a?x=1", method: "HEAD", rh: "", rb: nil, resp: plain_resp},               # HEAD is safe
+        {target: "/submit", method: "GET", rh: form_ct, rb: "user=alice&pass=x&token=", resp: plain_resp},
+        {target: "/j", method: "GET", rh: json_ct, rb: %({"a":"s","b":2,"c":"t","d":null}), resp: plain_resp}, # str fields a,c
+        {target: "/j", method: "GET", rh: json_ct, rb: %({"a":1,"b":2}), resp: plain_resp},                    # no string field → nil
+        {target: "/j?q=1", method: "GET", rh: json_ct, rb: %({"a":1}), resp: plain_resp},                      # query only (json no str)
+        {target: "/j?q=1", method: "GET", rh: "", rb: %({"a":"s"}), resp: plain_resp},                         # body but non-json/form ct
+        {target: "/many?#{many}", method: "GET", rh: "", rb: nil, resp: plain_resp},                           # > MAX_PARAMS → nil
+        {target: "http://target.com/s?q=hello", method: "GET", rh: "", rb: nil, resp: plain_resp},             # absolute-form
+        {target: "/cors", method: "GET", rh: "", rb: nil, resp: cors_resp},                                    # CORS present
+        {target: "/cors?q=1", method: "GET", rh: "", rb: nil, resp: cors_resp},                                # CORS + query
+        {target: "/nocors", method: "GET", rh: "", rb: nil, resp: plain_resp},                                 # CORS absent → nil
+        {target: "/cors", method: "POST", rh: "", rb: nil, resp: cors_resp},                                   # CORS unsafe method → nil
+      ]
+
+      reflected = Gori::Prism::Active::ReflectedParam.new
+      cors = Gori::Prism::Active::CorsReflection.new
+      cases.each do |c|
+        d = capture_flow(store, c[:resp], scheme: "http", host: "t.example",
+          target: c[:target], method: c[:method], req_headers: c[:rh], req_body: c[:rb], content_type: nil)
+        reflected.dedup_key(d).should eq(reflected.plan(d).try(&.dedup_key)), "reflected_param #{c[:target]} #{c[:method]}"
+        cors.dedup_key(d).should eq(cors.plan(d).try(&.dedup_key)), "cors #{c[:target]} #{c[:method]}"
+      end
+    end
+  end
+
   it "normalizes an absolute-form target to origin-form, preserving a query on a PATHLESS URI" do
     # The authority ends at the first '/', '?' or '#': a pathless absolute-URI carrying a query
     # must keep it (was collapsed to "/", silently dropping the reflectable surface), and a '/'

--- a/spec/prism_spec.cr
+++ b/spec/prism_spec.cr
@@ -638,6 +638,15 @@ describe "Gori::Prism::Passive (FP reduction)" do
       codes_of(gql).should contain("tech_graphql")
     end
   end
+
+  it "does not fingerprint an ordinary JSON POST with no query field as GraphQL" do
+    with_store do |store|
+      plain = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", target: "/api/orders",
+        method: "POST", req_headers: "Content-Type: application/json\r\n",
+        req_body: %({"items":[{"id":1,"qty":2}],"note":"ship fast"}), content_type: nil)
+      codes_of(plain).should_not contain("tech_graphql")
+    end
+  end
 end
 
 describe "Gori::Prism::Passive (secret in URL)" do

--- a/spec/proxy/codec/body_spec.cr
+++ b/spec/proxy/codec/body_spec.cr
@@ -33,6 +33,42 @@ describe Gori::Proxy::Codec::CaptureBuffer do
     cap.truncated?.should be_true
     cap.total.should eq(5000)
   end
+
+  it "captures nothing (no backing store) for a bodyless message" do
+    cap = CaptureBuffer.new(16)
+    cap.total.should eq(0)
+    cap.truncated?.should be_false
+    cap.to_slice.size.should eq(0) # empty, never allocated
+  end
+
+  it "is byte-exact whether or not a length hint presizes the store" do
+    body = Bytes.new(300 * 1024) { |i| (i % 251).to_u8 } # exceeds PRESIZE_CAP so growth still runs
+    hinted = CaptureBuffer.new(Body::CAPTURE_MAX, body.size.to_i64)
+    plain = CaptureBuffer.new(Body::CAPTURE_MAX)
+    hinted.write(body)
+    plain.write(body)
+    hinted.to_slice.should eq(body)
+    plain.to_slice.should eq(plain.to_slice) # stable
+    hinted.to_slice.should eq(plain.to_slice)
+    hinted.truncated?.should be_false
+  end
+
+  it "an over-large length hint does not force an over-large allocation, still correct" do
+    cap = CaptureBuffer.new(Body::CAPTURE_MAX, 8_i64 * 1024 * 1024) # lies: 8 MiB claimed
+    cap.write("tiny".to_slice)
+    String.new(cap.to_slice).should eq("tiny")
+    cap.total.should eq(4)
+  end
+
+  it "keeps an already-returned slice stable across a later write (copy-on-write)" do
+    cap = CaptureBuffer.new(64)
+    cap.write("first".to_slice)
+    published = cap.to_slice
+    String.new(published).should eq("first")
+    cap.write("-more".to_slice)                      # write after the read
+    String.new(published).should eq("first")         # the handed-out slice is untouched
+    String.new(cap.to_slice).should eq("first-more") # the live capture kept growing
+  end
 end
 
 describe "Gori::Proxy::Codec::Body.read_complete" do

--- a/spec/proxy/ws_spec.cr
+++ b/spec/proxy/ws_spec.cr
@@ -83,6 +83,29 @@ describe Gori::Proxy::WS do
     end
   end
 
+  describe ".unmask" do
+    it "is byte-identical to the scalar RFC 6455 mask across every length + offset (word-XOR)" do
+      key = Bytes[0xAA, 0xBB, 0xCC, 0xDD]
+      # Cover 0..40 so every tail remainder (n % 4 ∈ 0,1,2,3) and multi-word bodies run.
+      (0..40).each do |n|
+        src = Bytes.new(n) { |i| ((i * 37 + 11) & 0xff).to_u8 }
+        want = Bytes.new(n) { |i| src[i] ^ key[i & 3] } # scalar reference
+        got = Bytes.new(n)
+        Gori::Proxy::WS.unmask(src, key, got)
+        got.should eq(want)
+      end
+    end
+
+    it "round-trips: unmask(mask(x)) == x for a non-word-aligned length" do
+      key = Bytes[0x01, 0x7f, 0x80, 0xFE]
+      x = "the quick brown fox — 27 bytes!".to_slice # 31 bytes (tail = 3)
+      masked = Bytes.new(x.size) { |i| x[i] ^ key[i & 3] }
+      back = Bytes.new(x.size)
+      Gori::Proxy::WS.unmask(masked, key, back)
+      back.should eq(x)
+    end
+  end
+
   describe ".read_header" do
     it "parses a masked header exposing len and mask key without the payload" do
       h = Gori::Proxy::WS.read_header(IO::Memory.new(MASKED_HI)).not_nil!

--- a/spec/tui/highlight_spec.cr
+++ b/spec/tui/highlight_spec.cr
@@ -261,4 +261,169 @@ describe Gori::Tui::Highlight do
       b.row(0).strip.should eq("")
     end
   end
+
+  # The body tokenizers were rewritten from `raw.chars` + `.join` to a byte-scan. These
+  # reference impls are the ORIGINAL char-based tokenizers, kept here to fuzz-verify the byte
+  # version is span-for-span identical (text + colour) across ASCII + multibyte inputs.
+  describe "body tokenizer byte-scan equivalence" do
+    ref_json = ->(raw : String) do
+      spans = [] of Highlight::Span
+      chars = raw.chars
+      n = chars.size
+      i = 0
+      while i < n
+        c = chars[i]
+        if c == '"'
+          start = i
+          i += 1
+          while i < n
+            if chars[i] == '\\'
+              i += 2
+            elsif chars[i] == '"'
+              i += 1
+              break
+            else
+              i += 1
+            end
+          end
+          str = chars[start...i].join
+          k = i
+          while k < n && chars[k].ascii_whitespace?
+            k += 1
+          end
+          key = k < n && chars[k] == ':'
+          spans << Highlight::Span.new(str, key ? Theme.syn_header : Theme.syn_string)
+        elsif c.ascii_number? || (c == '-' && i + 1 < n && chars[i + 1].ascii_number?)
+          start = i
+          i += 1
+          while i < n && (chars[i].ascii_number? || "+-.eE".includes?(chars[i]))
+            i += 1
+          end
+          spans << Highlight::Span.new(chars[start...i].join, Theme.syn_number)
+        elsif c.ascii_letter?
+          start = i
+          i += 1
+          while i < n && chars[i].ascii_letter?
+            i += 1
+          end
+          word = chars[start...i].join
+          spans << Highlight::Span.new(word, %w(true false null).includes?(word) ? Theme.syn_literal : Theme.text)
+        elsif "{}[]:,".includes?(c)
+          spans << Highlight::Span.new(c.to_s, Theme.muted)
+          i += 1
+        else
+          start = i
+          i += 1
+          while i < n
+            d = chars[i]
+            break if d == '"' || d.ascii_letter? || d.ascii_number? || "{}[]:,".includes?(d) ||
+                     (d == '-' && i + 1 < n && chars[i + 1].ascii_number?)
+            i += 1
+          end
+          spans << Highlight::Span.new(chars[start...i].join, Theme.text)
+        end
+      end
+      spans
+    end
+
+    ref_form = ->(raw : String) do
+      spans = [] of Highlight::Span
+      chars = raw.chars
+      n = chars.size
+      i = 0
+      expect_key = true
+      while i < n
+        c = chars[i]
+        if c == '&'
+          spans << Highlight::Span.new("&", Theme.muted)
+          i += 1
+          expect_key = true
+        elsif c == '='
+          spans << Highlight::Span.new("=", Theme.muted)
+          i += 1
+          expect_key = false
+        else
+          start = i
+          while i < n && chars[i] != '&' && chars[i] != '='
+            i += 1
+          end
+          spans << Highlight::Span.new(chars[start...i].join, expect_key ? Theme.syn_header : Theme.text)
+        end
+      end
+      spans
+    end
+
+    ref_markup = ->(raw : String) do
+      spans = [] of Highlight::Span
+      chars = raw.chars
+      n = chars.size
+      i = 0
+      while i < n
+        if chars[i] == '<'
+          gt = i + 1
+          while gt < n && chars[gt] != '>'
+            gt += 1
+          end
+          closed = gt < n
+          j = i + 1
+          j += 1 if j < n && chars[j] == '/'
+          spans << Highlight::Span.new(chars[i...j].join, Theme.muted)
+          name = j
+          while name < gt && (chars[name].ascii_letter? || chars[name].ascii_number? ||
+                chars[name] == '-' || chars[name] == '_' || chars[name] == ':')
+            name += 1
+          end
+          spans << Highlight::Span.new(chars[j...name].join, Theme.syn_header) if name > j
+          spans << Highlight::Span.new(chars[name...gt].join, Theme.text) if name < gt
+          spans << Highlight::Span.new(">", Theme.muted) if closed
+          i = closed ? gt + 1 : gt
+        else
+          start = i
+          i += 1
+          while i < n && chars[i] != '<'
+            i += 1
+          end
+          spans << Highlight::Span.new(chars[start...i].join, Theme.text)
+        end
+      end
+      spans
+    end
+
+    # A varied byte/char pool: ASCII structural + hex + letters + multibyte (Korean, accented,
+    # emoji), so tokens land next to multibyte content and near boundaries.
+    pool = %w(" \\ { } [ ] : , & = < > / - _ + . e E a Z 0 9 x   가 é 🚀 t r u e n l s f) + ["\t"]
+
+    it "matches the reference char tokenizer for :json / :form / :html over a fuzz corpus" do
+      rng = Random.new(0x9051) # fixed seed → deterministic
+      2000.times do
+        len = rng.rand(0..40)
+        raw = String.build { |io| len.times { io << pool[rng.rand(pool.size)] } }
+        Highlight.body_styled(raw, :json).should eq(ref_json.call(raw))
+        Highlight.body_styled(raw, :form).should eq(ref_form.call(raw))
+        Highlight.body_styled(raw, :html).should eq(ref_markup.call(raw))
+        # the load-bearing invariant: spans concat back to the exact line
+        Highlight.body_styled(raw, :json).map(&.text).join.should eq(raw)
+        Highlight.body_styled(raw, :html).map(&.text).join.should eq(raw)
+        Highlight.body_styled(raw, :form).map(&.text).join.should eq(raw)
+      end
+    end
+
+    it "matches on hand-picked edge cases (multibyte, trailing escape, unclosed tag)" do
+      cases = [
+        %({"이름": "값🚀", "n": -12.5e3, "ok": true}),
+        %(a=가&b=é🚀&=x&flag),
+        %(<div class="x">가나다</div><br/><b>té</b>),
+        %("trailing backslash\\),      # overshoot case
+        %(<unclosed tag 가),           # no '>'
+        "",                            # empty
+        "{}[],:",                      # all structural
+        "가나다라",                     # pure multibyte, no ASCII
+      ]
+      cases.each do |raw|
+        Highlight.body_styled(raw, :json).should eq(ref_json.call(raw))
+        Highlight.body_styled(raw, :form).should eq(ref_form.call(raw))
+        Highlight.body_styled(raw, :html).should eq(ref_markup.call(raw))
+      end
+    end
+  end
 end

--- a/spec/tui/text_area_spec.cr
+++ b/spec/tui/text_area_spec.cr
@@ -37,4 +37,43 @@ describe Gori::Tui::TextArea do
       ta.edits.should eq(before)
     end
   end
+
+  describe "#undo (array-snapshot)" do
+    it "reverts a single-char insert" do
+      ta = TextArea.new("ab")
+      ta.end_of_line
+      ta.insert('c')
+      ta.text.should eq("abc")
+      ta.undo
+      ta.text.should eq("ab")
+    end
+
+    it "reverts a newline split and a subsequent line-join independently (multi-line ops)" do
+      ta = TextArea.new("hello world")
+      ta.move(0, 5)        # caret after "hello"
+      ta.insert_newline    # -> "hello\n world"
+      ta.text.should eq("hello\n world")
+      ta.backspace         # join back -> "hello world"
+      ta.text.should eq("hello world")
+      ta.undo              # undo the join -> split again
+      ta.text.should eq("hello\n world")
+      ta.undo              # undo the split -> original
+      ta.text.should eq("hello world")
+    end
+
+    it "keeps earlier snapshots intact after editing a restored buffer (no shared-array corruption)" do
+      ta = TextArea.new("a\nb\nc")
+      ta.end_of_line
+      ta.insert('X')       # "aX\nb\nc"
+      ta.insert('Y')       # "aXY\nb\nc"
+      ta.undo              # back to "aX\nb\nc"
+      ta.text.should eq("aX\nb\nc")
+      ta.insert('Z')       # edit the restored buffer -> "aXZ\nb\nc"
+      ta.text.should eq("aXZ\nb\nc")
+      ta.undo              # the Z edit
+      ta.text.should eq("aX\nb\nc")
+      ta.undo              # the X edit -> original
+      ta.text.should eq("a\nb\nc")
+    end
+  end
 end

--- a/src/gori/fuzz/template.cr
+++ b/src/gori/fuzz/template.cr
@@ -280,9 +280,11 @@ module Gori::Fuzz
     # `§`, and `sep` is the value|chain boundary `¦` (== `close` when there's no chain).
     # Lets the views tint the value and the (dimmer) chain separately; 1:1 with
     # `positions` / `marked_spans`.
-    def self.marker_regions(text : String) : Array({Int32, Int32, Int32})
+    # `spans` defaults to a fresh `marked_spans(text)`; pass a cached one (views memoize it on
+    # the editor revision) so a cache-miss here does ONE `text.chars` instead of two.
+    def self.marker_regions(text : String, spans : Array({Int32, Int32}) = marked_spans(text)) : Array({Int32, Int32, Int32})
       chars = text.chars
-      marked_spans(text).map do |(a, b)|
+      spans.map do |(a, b)|
         close = b - 1
         value, chain = split_raw_interior(chars[(a + 1)...close])
         sep = chain.nil? ? close : (a + 1 + value.size)

--- a/src/gori/import/builder.cr
+++ b/src/gori/import/builder.cr
@@ -23,13 +23,14 @@ module Gori
       # `://` later on (e.g. inside a query, `?next=http://x`) is NOT a scheme, so
       # match the leading scheme only — else a scheme-less endpoint carrying a URL in
       # its query was wrongly rejected as "missing scheme" and dropped from the import.
-      LEADING_SCHEME = /\A[a-z][a-z0-9+.-]*:\/\//
+      # Case-insensitive (schemes are, RFC 3986 §3.1) so no per-URL `.downcase` allocation.
+      LEADING_SCHEME = /\A[a-z][a-z0-9+.-]*:\/\//i
+      HTTP_SCHEME    = /\Ahttps?:\/\//i
 
       def self.normalize_url(url : String) : String
         u = url.strip
-        down = u.downcase # schemes are case-insensitive (RFC 3986 §3.1)
-        return u if down.starts_with?("http://") || down.starts_with?("https://")
-        raise Gori::Error.new("invalid URL (missing scheme): #{url}") if down.matches?(LEADING_SCHEME)
+        return u if u.starts_with?(HTTP_SCHEME)
+        raise Gori::Error.new("invalid URL (missing scheme): #{url}") if u.matches?(LEADING_SCHEME)
         "https://#{u}"
       end
 
@@ -54,15 +55,16 @@ module Gori
         String.build do |b|
           b << method.upcase << ' ' << target << ' ' << http_version << "\r\n"
           b << "Host: " << host << "\r\n"
+          # One pass, allocation-free case-insensitive compares: skip the Host line and note
+          # whether a Content-Length is already present (was a `.downcase` per header + a
+          # second `headers.any?` scan — hundreds of throwaway Strings on a large HAR).
+          has_cl = false
           headers.each do |k, v|
-            next if k.downcase == "host"
+            has_cl = true if !has_cl && k.compare("content-length", case_insensitive: true) == 0
+            next if k.compare("host", case_insensitive: true) == 0
             b << k << ": " << v << "\r\n"
           end
-          if body
-            unless headers.any? { |(k, _)| k.downcase == "content-length" }
-              b << "Content-Length: " << body.size << "\r\n"
-            end
-          end
+          b << "Content-Length: " << body.size << "\r\n" if body && !has_cl
           b << "\r\n"
         end.to_slice
       end
@@ -71,10 +73,12 @@ module Gori
                              headers : Headers, body : Bytes?) : Bytes
         String.build do |b|
           b << http_version << ' ' << status << ' ' << reason << "\r\n"
-          headers.each { |k, v| b << k << ": " << v << "\r\n" }
-          unless headers.any? { |(k, _)| k.downcase == "content-length" }
-            b << "Content-Length: " << (body.try(&.size) || 0) << "\r\n"
+          has_cl = false
+          headers.each do |k, v|
+            has_cl = true if !has_cl && k.compare("content-length", case_insensitive: true) == 0
+            b << k << ": " << v << "\r\n"
           end
+          b << "Content-Length: " << (body.try(&.size) || 0) << "\r\n" unless has_cl
           b << "\r\n"
         end.to_slice
       end

--- a/src/gori/import/har.cr
+++ b/src/gori/import/har.cr
@@ -55,7 +55,7 @@ module Gori
         reason = resp["statusText"]?.to_s.presence || status_reason(status)
         resp_headers = headers_list(resp["headers"]?)
         resp_body, content_type = response_body(resp)
-        content_type ||= resp_headers.find { |(k, _)| k.downcase == "content-type" }.try(&.[1])
+        content_type ||= resp_headers.find { |(k, _)| k.compare("content-type", case_insensitive: true) == 0 }.try(&.[1])
 
         Builder.complete_flow(
           created_at, url, method, req_headers, req_body, http_version,

--- a/src/gori/interceptor.cr
+++ b/src/gori/interceptor.cr
@@ -152,26 +152,28 @@ module Gori
     end
 
     # Precise per-REQUEST gate, used by ClientConn (which has the full request): hold
-    # this exact request? `url` is `scheme://host/target` — the same value the Scope
-    # SQL filter builds, so a held request is exactly an in-scope History row. Folds
-    # in the catch direction (skip when responses-only) and the conditional filter.
-    def intercepts_request?(url : String, *, method : String, host : String,
+    # this exact request? The scope URL (`scheme://host/target` — the same value the
+    # Scope SQL filter builds, so a held request is exactly an in-scope History row) is
+    # built LAZILY here, only after the enabled/direction gates pass AND only when Scope
+    # is active, so the common capture-only (intercept-off) path never allocates it.
+    # Folds in the catch direction (skip when responses-only) and the conditional filter.
+    def intercepts_request?(*, method : String, host : String,
                             target : String, scheme : String) : Bool
       enabled, dir, filter = gate_snapshot
       return false unless enabled
       return false if dir.response_only?
-      return false unless scope_allows?(url, host)
+      return false unless scope_allows?(scheme, host, target)
       filter.matches?(Subject.new(method: method, host: host, target: target, scheme: scheme))
     end
 
     # Precise per-RESPONSE gate (same shape as the request gate). Skips when
     # requests-only; the condition can also test `status:` here (a response has one).
-    def intercepts_response?(url : String, *, method : String, host : String,
+    def intercepts_response?(*, method : String, host : String,
                              target : String, scheme : String, status : Int32) : Bool
       enabled, dir, filter = gate_snapshot
       return false unless enabled
       return false if dir.request_only?
-      return false unless scope_allows?(url, host)
+      return false unless scope_allows?(scheme, host, target)
       filter.matches?(Subject.new(method: method, host: host, target: target, scheme: scheme, status: status))
     end
 
@@ -181,8 +183,12 @@ module Gori
       @mutex.synchronize { {@enabled && !@shutting_down, @direction, @filter} }
     end
 
-    private def scope_allows?(url : String, host : String) : Bool
-      @scope.active? ? @scope.in_scope_url?(url, host) : true
+    # Build the scope URL only when Scope is active (an inactive scope allows everything
+    # without inspecting the URL), so a passing gate on an intercept-enabled/scope-off
+    # setup still skips the interpolation.
+    private def scope_allows?(scheme : String, host : String, target : String) : Bool
+      return true unless @scope.active?
+      @scope.in_scope_url?("#{scheme}://#{host}#{target}", host)
     end
 
     # --- proxy fiber side (BLOCKS until a decision) --------------------------

--- a/src/gori/jwt.cr
+++ b/src/gori/jwt.cr
@@ -139,7 +139,27 @@ module Gori
     private def scan_body(label : String, body : Bytes?, & : String, String ->)
       return unless body
       return if body.size > MAX_SCAN
+      # SCAN_RE anchors on `eyJ`; a body without those 3 ASCII bytes can't match, so a cheap
+      # raw-byte scan skips the whole-body `String.new(...).scrub` + regex for the vast majority
+      # of flows (which carry no JWT). Equivalent: `eyJ` is ASCII, and scrub never alters ASCII
+      # bytes nor synthesizes them, so its presence in the raw bytes == presence in the string.
+      return unless contains_eyj?(body)
       String.new(body).scrub.scan(SCAN_RE) { |m| yield label, m[0] }
+    end
+
+    # Raw-byte search for the ASCII sequence `eyJ` (0x65 0x79 0x4a) — the JWT header anchor.
+    private def contains_eyj?(body : Bytes) : Bool
+      n = body.size
+      return false if n < 3
+      last = n - 3
+      i = 0
+      while i <= last
+        if body.unsafe_fetch(i) == 0x65_u8 && body.unsafe_fetch(i + 1) == 0x79_u8 && body.unsafe_fetch(i + 2) == 0x4a_u8
+          return true
+        end
+        i += 1
+      end
+      false
     end
   end
 end

--- a/src/gori/miner/fingerprint.cr
+++ b/src/gori/miner/fingerprint.cr
@@ -3,20 +3,21 @@ require "../fuzz/matcher"
 require "../replay/engine"
 
 module Gori::Miner
-  # A decoded view of one response: metrics + the decoded body text + the head text,
-  # computed in a SINGLE decode pass (the reflection search reuses the same buffers).
+  # A decoded view of one response: metrics + the SET of canary tokens that appear in the
+  # decoded body or head, collected in a SINGLE byte-scan (reflection membership is then a
+  # hash lookup, not a fresh full-body substring search per candidate).
   # Reuses Fuzz::Metrics (the record), but computes word/line counts here because the
   # Matcher's counters are private — and we want one decode, not two.
   record Probe,
     metrics : Fuzz::Metrics,
-    body_text : String,
-    head_text : String do
-    # Whether `needle` appears verbatim in the decoded body or head text. The ONE place
-    # reflection membership is decided — both decide() (candidate detection) and the
-    # Baseline echo-API control call this, so the suppression control can't drift from
-    # the detection it gates.
+    canaries : Set(String) do
+    # Whether `needle` (a `gq`+8-hex canary) was reflected. The ONE place reflection
+    # membership is decided — both decide() (candidate detection) and the Baseline echo-API
+    # control call this, so the suppression control can't drift from the detection it gates.
+    # Old code ran an O(body) `includes?` PER candidate (K = 128–256 per bucket); now the
+    # body+head are scanned ONCE into `canaries` and this is an O(1) set lookup.
     def reflects?(needle : String) : Bool
-      body_text.includes?(needle) || head_text.includes?(needle)
+      canaries.includes?(needle)
     end
   end
 
@@ -27,7 +28,40 @@ module Gori::Miner
       metrics = Fuzz::Metrics.new(
         raw.response.try(&.status), body.size.to_i64,
         count_words(body), count_lines(body), raw.duration_us)
-      Probe.new(metrics, String.new(body).scrub, String.new(raw.head).scrub)
+      # One scan of body + head collects every canary-shaped token, replacing both the K
+      # per-candidate `includes?` passes AND the two `String.new(...).scrub` allocations the
+      # old body_text/head_text strings required (they fed only `reflects?`).
+      found = Set(String).new
+      scan_canaries(body, found)
+      scan_canaries(raw.head, found)
+      Probe.new(metrics, found)
+    end
+
+    # Collect every `gq`+8-lower-hex token (Canary.fresh's exact shape, LEN=10) present in
+    # `bytes` into `into`. A verbatim canary occurrence lands at its own start offset, so the
+    # set holds exactly the tokens the old per-canary `includes?` would have matched — same
+    # reflected set, same echo-control result. No canary can be a substring of another (fixed
+    # length), and no lower-hex byte is `g` (0x67), so tokens never overlap.
+    private def self.scan_canaries(bytes : Bytes, into : Set(String)) : Nil
+      return if bytes.size < Canary::LEN
+      last = bytes.size - Canary::LEN
+      i = 0
+      while i <= last
+        if bytes.unsafe_fetch(i) == 0x67_u8 && bytes.unsafe_fetch(i + 1) == 0x71_u8 && canary_tail?(bytes, i + 2)
+          into << String.new(bytes[i, Canary::LEN])
+        end
+        i += 1
+      end
+    end
+
+    # The 8 bytes after `gq` are all lower-hex (0-9 a-f). `from` + 8 is in bounds by the
+    # `i <= last` invariant in scan_canaries, so unsafe_fetch is safe.
+    private def self.canary_tail?(bytes : Bytes, from : Int32) : Bool
+      8.times do |k|
+        b = bytes.unsafe_fetch(from + k)
+        return false unless (b >= 0x30_u8 && b <= 0x39_u8) || (b >= 0x61_u8 && b <= 0x66_u8)
+      end
+      true
     end
 
     # Word count over decoded bytes, allocation-free (whitespace transitions) — lifted

--- a/src/gori/prism/active.cr
+++ b/src/gori/prism/active.cr
@@ -15,6 +15,10 @@ module Gori
 
       # Convenience facade over the primary (reflected-param) rule. The analyzer drives the
       # whole RULES list; these keep a stable single-rule entry point for callers/tests.
+      def self.dedup_key(detail : Store::FlowDetail) : String?
+        PRIMARY.dedup_key(detail)
+      end
+
       def self.plan(detail : Store::FlowDetail) : Plan?
         PRIMARY.plan(detail)
       end

--- a/src/gori/prism/active/cors_reflection.cr
+++ b/src/gori/prism/active/cors_reflection.cr
@@ -21,6 +21,19 @@ module Gori
         # dialed. If the server reflects THIS, it reflects anything.
         PROBE_ORIGIN = "https://gori-cors-probe.example"
 
+        # The dedup key WITHOUT rebuilding the probe request — same gates as `plan` (safe method,
+        # response already did CORS), same key. nil exactly when `plan` returns nil.
+        def dedup_key(detail : Store::FlowDetail) : String?
+          req = Proxy::Codec::Http1.parse_request_head(detail.request_head)
+          return nil if req.malformed?
+          return nil unless SAFE_METHODS.includes?(req.method.upcase)
+          rhead = detail.response_head
+          return nil unless rhead
+          resp = Proxy::Codec::Http1.parse_response_head(rhead)
+          return nil unless resp.headers.get?("Access-Control-Allow-Origin")
+          key_string(detail, req.method.upcase, req.target)
+        end
+
         def plan(detail : Store::FlowDetail) : Plan?
           req = Proxy::Codec::Http1.parse_request_head(detail.request_head)
           return nil if req.malformed?
@@ -31,8 +44,12 @@ module Gori
           resp = Proxy::Codec::Http1.parse_response_head(rhead)
           return nil unless resp.headers.get?("Access-Control-Allow-Origin")
           request = rebuild_with_origin(detail.request_head, detail.request_body, PROBE_ORIGIN)
-          key = "cors_reflection|#{detail.row.host}:#{detail.row.port}|#{req.method.upcase}|#{path_key(req.target)}"
-          Plan.new(request, [] of Param, key)
+          Plan.new(request, [] of Param, key_string(detail, req.method.upcase, req.target))
+        end
+
+        # The single key expression both `plan` and `dedup_key` use, so they can't drift.
+        private def key_string(detail : Store::FlowDetail, method_upcase : String, target : String) : String
+          "cors_reflection|#{detail.row.host}:#{detail.row.port}|#{method_upcase}|#{path_key(target)}"
         end
 
         def detections(plan : Plan, result : Replay::Result, detail : Store::FlowDetail) : Array(Detection)

--- a/src/gori/prism/active/reflected_param.cr
+++ b/src/gori/prism/active/reflected_param.cr
@@ -16,6 +16,31 @@ module Gori
       # parameters whose canary echoes back unencoded (XSS candidates). Gated to safe methods
       # so an automatic probe never mutates server state.
       class ReflectedParam < Rule
+        # The dedup key WITHOUT generating canaries or rebuilding the request — extracts the same
+        # (name, location) set `plan` derives from canary_pairs/canary_json (same skip rules), so
+        # the key is byte-identical to `plan(detail).dedup_key`. Returns nil in exactly the cases
+        # `plan` does (malformed / unsafe method / no params / too many). Verified against `plan`
+        # by the equivalence spec.
+        def dedup_key(detail : Store::FlowDetail) : String?
+          req = Proxy::Codec::Http1.parse_request_head(detail.request_head)
+          return nil if req.malformed?
+          return nil unless SAFE_METHODS.includes?(req.method.upcase)
+          path, query = split_target(Active.origin_form(req.target))
+          names = [] of {String, String} # {name, location}, matching Param.{name, location}
+          each_param_name(query) { |raw| names << {decode_name(raw), "query"} }
+          body = detail.request_body
+          if body && !body.empty?
+            ct = (req.headers.get?("Content-Type") || "").downcase
+            if ct.includes?("x-www-form-urlencoded")
+              each_param_name(String.new(body).scrub) { |raw| names << {decode_name(raw), "form"} }
+            elsif ct.includes?("json")
+              each_json_string_key(body) { |k| names << {k, "json"} }
+            end
+          end
+          return nil if names.empty? || names.size > MAX_PARAMS
+          build_dedup_key(detail, req.method.upcase, path, names)
+        end
+
         # Build a probe from a captured flow, or nil if there is nothing reflectable.
         def plan(detail : Store::FlowDetail) : Plan?
           req = Proxy::Codec::Http1.parse_request_head(detail.request_head)
@@ -50,12 +75,44 @@ module Gori
 
           return nil if params.empty? || params.size > MAX_PARAMS
           request = rebuild(detail.request_head, body, req.target, path, new_query, new_body)
-          # Key by rule + host:PORT + METHOD + path + (name@location) so the same host on a
-          # different port/service is a distinct surface. Length-prefix each name so a param
-          # name containing '@'/','/':' can't collide with a different multi-param set.
-          sig = params.map { |p| "#{p.name.bytesize}:#{p.name}@#{p.location}" }.sort!.join(",")
-          key = "reflected_param|#{detail.row.host}:#{detail.row.port}|#{req.method.upcase}|#{path}|#{sig}"
+          # Same key builder `dedup_key` uses, fed the built params — so the pre-build dedup key
+          # and this one can't drift.
+          key = build_dedup_key(detail, req.method.upcase, path, params.map { |p| {p.name, p.location} })
           Plan.new(request, params, key)
+        end
+
+        # Key by rule + host:PORT + METHOD + path + (name@location) so the same host on a different
+        # port/service is a distinct surface. Length-prefix each name so a param name containing
+        # '@'/','/':' can't collide with a different multi-param set. Sorted → order-independent.
+        private def build_dedup_key(detail : Store::FlowDetail, method_upcase : String, path : String,
+                                    names : Array({String, String})) : String
+          sig = names.map { |(name, loc)| "#{name.bytesize}:#{name}@#{loc}" }.sort!.join(",")
+          "reflected_param|#{detail.row.host}:#{detail.row.port}|#{method_upcase}|#{path}|#{sig}"
+        end
+
+        # The valid k=v names of an &-joined string — the SAME skip rules canary_pairs applies
+        # (empty pair / no '=' / empty name are skipped), yielding the RAW (pre-decode) name.
+        private def each_param_name(text : String, & : String ->)
+          return if text.empty?
+          text.split('&').each do |pair|
+            next if pair.empty?
+            eq = pair.index('=')
+            next unless eq
+            name = pair[0...eq]
+            next if name.empty?
+            yield name
+          end
+        end
+
+        # The top-level JSON keys with a STRING value — the SAME fields canary_json canaries.
+        private def each_json_string_key(body : Bytes, & : String ->)
+          h = begin
+            JSON.parse(String.new(body).scrub).as_h?
+          rescue JSON::ParseException
+            nil
+          end
+          return unless h
+          h.each { |k, v| yield k if v.as_s? }
         end
 
         # Interpret the probe's response: any reflected-parameter Detection (one grouped row per host).

--- a/src/gori/prism/active/types.cr
+++ b/src/gori/prism/active/types.cr
@@ -42,6 +42,12 @@ module Gori
       # An active rule: build a probe for one flow (nil if nothing to test), then turn the
       # probe's response into Detections. The analyzer owns the send between the two calls.
       abstract class Rule
+        # The probe's dedup key WITHOUT building the probe — same value as `plan(detail).dedup_key`
+        # (nil exactly when `plan` returns nil). The analyzer checks this against the seen-set
+        # BEFORE calling `plan`, so a repeat surface (the common case in steady browsing) skips
+        # the expensive canary generation + request rebuild that `plan` does. MUST stay identical
+        # to the key `plan` produces or the seen-set would re-probe / skip (see the equivalence spec).
+        abstract def dedup_key(detail : Store::FlowDetail) : String?
         abstract def plan(detail : Store::FlowDetail) : Plan?
         abstract def detections(plan : Plan, result : Replay::Result, detail : Store::FlowDetail) : Array(Detection)
       end

--- a/src/gori/prism/analyzer.cr
+++ b/src/gori/prism/analyzer.cr
@@ -294,9 +294,13 @@ module Gori
       end
 
       private def enqueue_probe(rule : Active::Rule, detail : Store::FlowDetail) : Nil
+        # Cheap dedup key FIRST: a repeat surface (the norm in steady browsing) is rejected here
+        # WITHOUT the full plan build (canary generation, JSON re-serialize, request rebuild).
+        key = rule.dedup_key(detail)
+        return unless key
+        return if @active_seen.includes?(key)
         plan = rule.plan(detail)
         return unless plan
-        return if @active_seen.includes?(plan.dedup_key)
         select
         when @active_jobs.send(ActiveTask.new(rule, plan, detail))
           # Record the dedup key ONLY once the task is actually queued, so a target dropped on

--- a/src/gori/prism/analyzer.cr
+++ b/src/gori/prism/analyzer.cr
@@ -36,6 +36,10 @@ module Gori
                      @mode : Mode, @verify_upstream : Bool)
         @analyzed = Set(Int64).new
         @ws_hwm = {} of Int64 => Int64 # per-101-flow high-water-mark: max ws_message id already scanned
+        # Cache each 101 flow's handshake FlowDetail — it NEVER changes frame-to-frame, but
+        # InsertWs republishes :updated per frame, so rescan_ws re-read it from SQLite (heads +
+        # bodies) on every frame of a chatty socket. Evicted in lock-step with @ws_hwm.
+        @ws_detail = {} of Int64 => Store::FlowDetail
         @active_seen = Set(String).new
         @active_error_hosts = Set(String).new # rate-limit probe-failure notifications per host
         @suppressed = Set(String).new         # "code|host" hard-deleted this session
@@ -142,7 +146,7 @@ module Gori
             # gap-free rescan_ws so a 101 flow evicted from @analyzed and re-scanned (or one with a
             # backlog > WS_MSG_CAP) never re-detects already-scanned frames or skips a band of them.
             scan_detail(detail, enqueue_active: true)
-            rescan_ws(ev.id) if detail.row.status == 101
+            rescan_ws(ev.id, detail) if detail.row.status == 101 # reuse the detail just loaded
           rescue DB::Error | SQLite3::Exception
             # A transient store error (e.g. SQLITE_BUSY) must NOT kill the scanner for the rest
             # of the session — skip this flow and keep draining. On real shutdown the input
@@ -180,7 +184,7 @@ module Gori
           @analyzed << row.id
           trim(@analyzed, ANALYZED_CAP)
           scan_detail(detail, enqueue_active: true)
-          rescan_ws(row.id) if detail.row.status == 101
+          rescan_ws(row.id, detail) if detail.row.status == 101 # reuse the detail just loaded
         end
       rescue DB::Error | SQLite3::Exception
       rescue Channel::ClosedError
@@ -193,10 +197,17 @@ module Gori
       # last scanned id: with a hwm it reads the OLDEST unscanned frames (so a >WS_MSG_CAP backlog
       # from a dropped-event burst is covered without skipping a band, and an evicted-then-re-
       # scanned flow doesn't re-detect old frames); the first pass (no hwm) reads the last window.
-      private def rescan_ws(flow_id : Int64) : Nil
-        detail = @store.get_flow(flow_id)
-        return unless detail
+      private def rescan_ws(flow_id : Int64, detail : Store::FlowDetail? = nil) : Nil
+        # Reuse a detail the caller already loaded, else the per-flow cache, else read it once
+        # and cache it — the 101 handshake is immutable, so subsequent frames skip the DB read.
+        d = detail || @ws_detail[flow_id]? || @store.get_flow(flow_id)
+        return unless d
+        detail = d
         return unless detail.row.status == 101
+        # Cache the immutable handshake; note_ws_scanned evicts it with @ws_hwm, but a 101 flow
+        # that never delivers a new frame wouldn't hit that path, so bound it here too.
+        @ws_detail[flow_id] = detail
+        @ws_detail.delete(@ws_detail.first_key) if @ws_detail.size > ANALYZED_CAP
         # Page forward from the high-water-mark (0 on the first scan) through EVERY unscanned
         # frame in WS_MSG_CAP-sized batches. Starting from the OLDEST unscanned id — not the last
         # window — means a flow first scanned late (e.g. via catch_up) with a large buffered
@@ -224,7 +235,10 @@ module Gori
         @ws_hwm.delete(flow_id)
         @ws_hwm[flow_id] = msgs.max_of(&.id)
         return if @ws_hwm.size <= ANALYZED_CAP
-        @ws_hwm.keys.first(@ws_hwm.size - ANALYZED_CAP).each { |k| @ws_hwm.delete(k) }
+        @ws_hwm.keys.first(@ws_hwm.size - ANALYZED_CAP).each do |k|
+          @ws_hwm.delete(k)
+          @ws_detail.delete(k) # drop the cached handshake for evicted flows in lock-step
+        end
       end
 
       private def persist(detections : Array(Detection), *, flow_id : Int64, replay_id : Int64?) : Nil

--- a/src/gori/prism/passive/body_leaks.cr
+++ b/src/gori/prism/passive/body_leaks.cr
@@ -91,6 +91,11 @@ module Gori
           # first: a body leaking both a Java exception and a Go panic (or an AWS key
           # AND a GitHub token) previously surfaced only the earliest array entry, so
           # every other distinct disclosure in the same body was silently missed.
+          # NOTE: each pattern is scanned individually on purpose — every one carries a
+          # distinctive literal anchor (AKIA / -----BEGIN / Traceback / ORA- / goroutine …)
+          # that PCRE's first-byte optimization uses to skip a clean body in ~memchr time.
+          # A single `Regex.union` alternation is ~5× SLOWER (measured, bench/prism_bench):
+          # it defeats that per-pattern prefilter, so the loop stays.
           ERROR_SIGNATURES.each do |(pat, label)|
             acc << leak(ctx, "error_stack_leak", "Error/stack trace disclosed", Store::Severity::Medium, label) if pat.matches?(text)
           end

--- a/src/gori/prism/passive/tech.cr
+++ b/src/gori/prism/passive/tech.cr
@@ -101,6 +101,11 @@ module Gori
           # 8 KB truncated mid-JSON on real GraphQL requests (a sizeable `variables` object),
           # which then fails JSON.parse and mis-classified them as non-GraphQL; allow up to 256 KB.
           text = String.new(body[0, {body.size, 256 * 1024}.min]).scrub
+          # A GraphQL request body always carries a top-level `"query"` key; a cheap substring
+          # check lets the overwhelming majority of non-GraphQL JSON POSTs skip the full
+          # JSON.parse (a tree build over ≤256 KB) on the shared passive-scan fiber. Conservative:
+          # a `"query"` appearing only inside a value still parses, then the as_h?/as_s? guards reject.
+          return false unless text.includes?(%("query"))
           q = begin
             JSON.parse(text).as_h?.try(&.["query"]?).try(&.as_s?)
           rescue JSON::ParseException

--- a/src/gori/proxy/codec/body.cr
+++ b/src/gori/proxy/codec/body.cr
@@ -24,22 +24,37 @@ module Gori::Proxy::Codec
     getter total : Int64 = 0_i64
     getter? truncated : Bool = false
 
-    def initialize(@limit : Int32)
-      @mem = IO::Memory.new
+    # The backing store is created LAZILY on the first byte, so a bodyless message
+    # (the common GET / 204 / 304 — which streams with `None` framing and never tees)
+    # allocates nothing at all. `hint` is the body's KNOWN length (a Content-Length):
+    # the store is then sized once to fit, instead of climbing IO::Memory's doubling-
+    # realloc chain — each step copies everything captured so far and, past the large-
+    # object threshold, can trip a GC cycle on the single proxy thread.
+    def initialize(@limit : Int32, @hint : Int64 = 0_i64)
+      @mem = nil.as(IO::Memory?)
+      @sealed = false
     end
 
     def write(slice : Bytes) : Nil
       @total += slice.size
-      stored = @mem.bytesize
+      return if slice.empty?
+      # A prior `to_slice` handed out a view over @mem; a further write (only reachable via a
+      # protocol-violating h2 DATA-after-END_STREAM frame, since the codec reads capture once
+      # after streaming) must not mutate those already-published bytes. Snapshot into a fresh
+      # store first so the handed-out slice stays a stable copy — copy-on-write, paid only in
+      # that adversarial case, never on the normal read-once path.
+      reseat_after_seal if @sealed
+      mem = (@mem ||= IO::Memory.new(initial_capacity))
+      stored = mem.bytesize
       if stored < @limit
         room = @limit - stored
         if slice.size <= room
-          @mem.write(slice)
+          mem.write(slice)
         else
-          @mem.write(slice[0, room])
+          mem.write(slice[0, room])
           @truncated = true
         end
-      elsif !slice.empty?
+      else
         @truncated = true
       end
     end
@@ -49,9 +64,40 @@ module Gori::Proxy::Codec
       raise NotImplementedError.new("CaptureBuffer is write-only")
     end
 
-    # The captured (possibly truncated) bytes — a fresh copy safe to persist.
+    # The captured (possibly truncated) bytes, safe to persist. Returns a view (length =
+    # bytesize) over @mem's backing buffer — no defensive copy: this CaptureBuffer is read
+    # once after streaming and then discarded, so the slice is the store's sole owner. A later
+    # write (see `write`) does copy-on-write, so the returned slice never changes underfoot.
     def to_slice : Bytes
-      @mem.to_slice.dup
+      mem = @mem
+      return Bytes.empty unless mem
+      @sealed = true
+      mem.to_slice
+    end
+
+    private def reseat_after_seal : Nil
+      old = @mem
+      @sealed = false
+      return unless old
+      fresh = IO::Memory.new(old.bytesize > 0 ? old.bytesize : 64)
+      fresh.write(old.to_slice)
+      @mem = fresh
+    end
+
+    # Bound on the up-front presize. A known Content-Length sizes the store to fit in one
+    # allocation — but the length is an unverified client/origin claim, so a request that
+    # declares a huge body and sends almost none would otherwise let a tiny message force a
+    # multi-MB allocation (a cheap amplification). Cap the eager reservation here; a genuinely
+    # larger body still grows on demand from this size (a couple of reallocs, not a chain from
+    # 64 bytes), while a lying header wastes at most this much.
+    PRESIZE_CAP = 256 * 1024
+
+    # A known length sizes the store to fit (bounded by PRESIZE_CAP and the capture limit);
+    # an unknown length (chunked / close-delimited) falls back to IO::Memory's default growth.
+    private def initial_capacity : Int32
+      return 64 if @hint <= 0
+      cap = @hint > @limit ? @limit : @hint.to_i
+      cap > PRESIZE_CAP ? PRESIZE_CAP : cap
     end
   end
 
@@ -69,6 +115,11 @@ module Gori::Proxy::Codec
 
   module Body
     BUFSIZE = 64 * 1024
+
+    # Shared read-only empty list returned by the framing lookups when Transfer-Encoding is
+    # absent — avoids allocating a throwaway Array on the (common) no-TE path. Never mutated:
+    # chunked?/te_present? only read it.
+    EMPTY_TE = [] of String
 
     # Bounds on chunked framing lines so a hostile peer can't make us buffer/forward
     # unboundedly after the terminating 0-chunk: a single size/trailer line is capped
@@ -95,7 +146,9 @@ module Gori::Proxy::Codec
       # backend still honours it — a CL/TE request-smuggling primitive. Reject up front,
       # like CL+TE, rather than framing on a header we can't see (RFC 7230 §3.2.4).
       raise Gori::Error.new("obfuscated request header (whitespace before colon or obs-fold)") if Http1.obfuscated_header?(req.raw_head)
-      te = req.headers.get_all("Transfer-Encoding")
+      # Skip the get_all Array allocation when Transfer-Encoding is absent (the common case);
+      # an empty list means neither chunked? nor te_present? — fall straight to Content-Length.
+      te = req.headers.has?("Transfer-Encoding") ? req.headers.get_all("Transfer-Encoding") : EMPTY_TE
       if chunked?(te)
         reject_te_with_cl(req.headers)
         {BodyFraming::Chunked, 0_i64}
@@ -117,12 +170,15 @@ module Gori::Proxy::Codec
 
     # RFC 7230 §3.3.3 framing for a response body, given the request method.
     def self.response_framing(resp : RawResponse, request_method : String) : {BodyFraming, Int64}
-      m = request_method.upcase
-      return {BodyFraming::None, 0_i64} if m == "HEAD" || m == "CONNECT"
+      # Allocation-free case-insensitive match (per response); `.upcase` allocated a String.
+      if request_method.compare("HEAD", case_insensitive: true) == 0 ||
+         request_method.compare("CONNECT", case_insensitive: true) == 0
+        return {BodyFraming::None, 0_i64}
+      end
       s = resp.status
       return {BodyFraming::None, 0_i64} if (s >= 100 && s < 200) || s == 204 || s == 304
 
-      te = resp.headers.get_all("Transfer-Encoding")
+      te = resp.headers.has?("Transfer-Encoding") ? resp.headers.get_all("Transfer-Encoding") : EMPTY_TE
       if chunked?(te)
         reject_te_with_cl(resp.headers)
         {BodyFraming::Chunked, 0_i64}
@@ -200,11 +256,12 @@ module Gori::Proxy::Codec
     # a framing ambiguity (the classic CL.TE / TE.CL smuggling primitive). gori
     # never strips a header (P7), so reject and close instead of choosing one.
     private def self.reject_te_with_cl(headers : HeaderList) : Nil
-      return if headers.get_all("Content-Length").empty?
+      return unless headers.has?("Content-Length")
       raise Gori::Error.new("Transfer-Encoding and Content-Length both present")
     end
 
     private def self.content_length(headers : HeaderList) : Int64?
+      return nil unless headers.has?("Content-Length")
       values = headers.get_all("Content-Length")
       return nil if values.empty?
       # A header line may itself be a comma list ("5, 5"); split + parse each token.

--- a/src/gori/proxy/codec/http1.cr
+++ b/src/gori/proxy/codec/http1.cr
@@ -36,7 +36,12 @@ module Gori::Proxy::Codec::Http1
     return nil if buf.bytesize == 0
     # Hit the cap without a terminator → oversized/hostile head; don't misframe.
     return nil if buf.bytesize >= max_bytes && !ends_with_crlf_crlf?(buf)
-    buf.to_slice.dup
+    # `buf` is a local, discarded here, so the returned view (length = bytesize) is the head's
+    # sole owner — no defensive copy. It becomes an immutable `raw_head` (P7: forwarding emits
+    # it verbatim, the rewriter builds fresh buffers), so nothing writes through it. Trades a
+    # per-head copy (2×/flow on the 100% path) for briefly retaining the buffer's slack capacity
+    # until capture.
+    buf.to_slice
   end
 
   private def self.ends_with_crlf_crlf?(buf : IO::Memory) : Bool

--- a/src/gori/proxy/codec/message.cr
+++ b/src/gori/proxy/codec/message.cr
@@ -49,6 +49,13 @@ module Gori::Proxy::Codec
       @entries.each { |h| result << h.value if h.name.compare(name, case_insensitive: true) == 0 }
       result
     end
+
+    # Whether any header carries this name (case-insensitive), allocation-free. Lets the
+    # framing hot path skip `get_all` — which always allocates an Array even when the
+    # header is absent — for the common no-Transfer-Encoding / no-Content-Length message.
+    def has?(name : String) : Bool
+      @entries.any? { |h| h.name.compare(name, case_insensitive: true) == 0 }
+    end
   end
 
   # A captured HTTP/1.1 request. `raw_head` is the byte-exact request-line +

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -90,7 +90,7 @@ module Gori::Proxy
       return false if head.nil? # client closed / keep-alive idle end
 
       req = Codec::Http1.parse_request_head(head)
-      return handle_connect(req) if req.method.upcase == "CONNECT"
+      return handle_connect(req) if req.method.compare("CONNECT", case_insensitive: true) == 0
 
       started = Time.instant
       created_at = now_us
@@ -143,12 +143,11 @@ module Gori::Proxy
 
       # Intercept (request): hold only when enabled AND in scope. Holding buffers
       # the full body (vs streaming) so the human can see/edit it; the non-hold
-      # path keeps zero-buffer streaming (P6). The scope URL is built exactly as the
-      # Scope SQL filter does — scheme || '://' || host || <stored target> — over the
-      # SAME target that gets captured (sent_req.target, used at the insert below), so a
-      # held request is precisely an in-scope History row with no live/SQL divergence.
-      scope_url = "#{scheme}://#{host}#{sent_req.target}"
-      if (ic = @interceptor) && ic.intercepts_request?(scope_url,
+      # path keeps zero-buffer streaming (P6). The gate builds the scope URL lazily
+      # (scheme || '://' || host || <stored target>, matching the Scope SQL filter over
+      # the SAME captured target) only when intercept + Scope are both on, so the common
+      # capture-only path spends nothing here.
+      if (ic = @interceptor) && ic.intercepts_request?(
            method: sent_req.method, host: host, target: sent_req.target, scheme: scheme)
         return handle_held_request(ic, req, sent_req, sent_head, host, port, scheme,
           created_at, started, req_framing, req_len)
@@ -158,7 +157,7 @@ module Gori::Proxy
       # Replay-safety keys on the ACTUALLY-SENT method (sent_req): an M&R rule that rewrites
       # the request line GET→POST must not leave a non-idempotent request marked retryable.
       retryable = retryable_request?(sent_req, req_framing.none?)
-      req_capture = Codec::CaptureBuffer.new(Codec::Body::CAPTURE_MAX)
+      req_capture = Codec::CaptureBuffer.new(Codec::Body::CAPTURE_MAX, capture_hint(req_framing, req_len))
       req_complete = true
       upstream, reused, sent = acquire_and_send(host, port, retryable) do |up|
         up.write(sent_head)
@@ -182,7 +181,7 @@ module Gori::Proxy
         return false
       end
       handle_response(upstream, req, flow_id, started, host, port, scheme,
-        reused: reused, sent_head: sent_head, can_retry: retryable, scope_url: scope_url, sent_req: sent_req)
+        reused: reused, sent_head: sent_head, can_retry: retryable, sent_req: sent_req)
     end
 
     # The intercept-hold request path: buffer the body, let the human edit/drop
@@ -230,8 +229,7 @@ module Gori::Proxy
         scheme: scheme, host: host, port: port, created_at: created_at,
         body: stored, body_truncated: trunc, body_size: size))
       handle_response(upstream, req, flow_id, started, host, port, scheme,
-        reused: reused, sent_head: sent_head, can_retry: retryable,
-        scope_url: "#{scheme}://#{host}#{sent_req.target}", sent_req: sent_req)
+        reused: reused, sent_head: sent_head, can_retry: retryable, sent_req: sent_req)
     end
 
     # Acquires the (reused-or-fresh) upstream and runs `send` on it. If a REUSED
@@ -276,7 +274,7 @@ module Gori::Proxy
     # keep the connection alive.
     private def handle_response(upstream : IO, req : Codec::RawRequest, flow_id : Int64,
                                 started : Time::Instant, host : String, port : Int32, scheme : String,
-                                *, reused : Bool, sent_head : Bytes, can_retry : Bool, scope_url : String,
+                                *, reused : Bool, sent_head : Bytes, can_retry : Bool,
                                 sent_req : Codec::RawRequest) : Bool
       resp_head, upstream = read_response_head(upstream, host, port, reused, sent_head, can_retry)
       if resp_head.nil?
@@ -303,13 +301,13 @@ module Gori::Proxy
 
       # Intercept (response): hold only in-scope, non-streaming responses. SSE /
       # close-delimited / WebSocket bodies would buffer forever, so they bypass.
-      # Use the SAME precise URL gate as the request hold (scope_url built above), so a
-      # string/regex-excluded flow whose request wasn't held doesn't get its response held.
-      # The response gate also honours the catch direction + can test `status:`. Match the
-      # CONDITION against `sent_req` (the rewritten/edited request that was captured + scope-
-      # gated), not the original `req`, so a `method:`/`path:` rule that holds the request
-      # also holds its response when a Match&Replace rule changed the request line.
-      if (ic = @interceptor) && ic.intercepts_response?(scope_url,
+      # The gate rebuilds the SAME precise scope URL the request hold uses (lazily, only
+      # when intercept + Scope are on), so a string/regex-excluded flow whose request wasn't
+      # held doesn't get its response held. The response gate also honours the catch direction
+      # + can test `status:`. Match the CONDITION against `sent_req` (the rewritten/edited
+      # request that was captured + scope-gated), not the original `req`, so a `method:`/`path:`
+      # rule that holds the request also holds its response when M&R changed the request line.
+      if (ic = @interceptor) && ic.intercepts_response?(
            method: sent_req.method, host: host, target: sent_req.target, scheme: scheme, status: resp.status) &&
          !resp_framing.close_delimited? && !sse?(resp) && resp.status != 101
         return handle_held_response(ic, upstream, req, sent_req, flow_id, host, port, scheme,
@@ -319,7 +317,7 @@ module Gori::Proxy
       # Non-hold path: stream the response body byte-for-byte (P6) and record the
       # flow. `completed` is true only when the whole body was delivered cleanly; a
       # client abort or upstream truncation is recorded Aborted (see the helper).
-      resp_capture = Codec::CaptureBuffer.new(Codec::Body::CAPTURE_MAX)
+      resp_capture = Codec::CaptureBuffer.new(Codec::Body::CAPTURE_MAX, capture_hint(resp_framing, resp_len))
       completed = stream_nonhold_response(upstream, sent_resp, sent_resp_head,
         resp_framing, resp_len, resp_capture, flow_id, ttfb, started)
 
@@ -786,6 +784,13 @@ module Gori::Proxy
       when "GET", "HEAD", "OPTIONS", "TRACE" then true
       else                                        false
       end
+    end
+
+    # Presize hint for a body capture: a Content-Length body's length is known, so the
+    # store is sized once. Chunked/close-delimited length is 0 (unknown → grow on demand);
+    # a bodyless framing keeps the capture unallocated.
+    private def capture_hint(framing : Codec::BodyFraming, length : Int64) : Int64
+      framing.length? ? length : 0_i64
     end
 
     # True when a Connection header field lists `token` (case-insensitive) as one of its

--- a/src/gori/proxy/h2/assembler.cr
+++ b/src/gori/proxy/h2/assembler.cr
@@ -351,7 +351,7 @@ module Gori::Proxy::H2
     private def synth_request_head(method : String, path : String, headers : Array({String, String}), authority : String) : Bytes
       String.build do |io|
         io << method << ' ' << path << " HTTP/2\r\n"
-        has_host = headers.any? { |(n, _)| n.downcase == "host" }
+        has_host = headers.any? { |(n, _)| n.compare("host", case_insensitive: true) == 0 }
         io << "Host: " << authority << "\r\n" if !authority.empty? && !has_host
         headers.each { |(n, v)| io << n << ": " << v << "\r\n" unless n.starts_with?(':') }
         io << "\r\n"

--- a/src/gori/proxy/h2/frame.cr
+++ b/src/gori/proxy/h2/frame.cr
@@ -110,10 +110,16 @@ module Gori::Proxy::H2
     # byte (peer closed). Raises Gori::Error on a truncated frame or a length
     # exceeding `max_payload` (malformed / abusive).
     def self.read(io : IO, max_payload : Int32 = MAX_PAYLOAD) : Header?
-      header = Bytes.new(HEADER_SIZE)
-      first = io.read(header)
+      # The 9-byte frame header reads into a STACK buffer — this runs once per h2 frame
+      # (every DATA/HEADERS/WINDOW_UPDATE/PING/SETTINGS, both directions), so a heap
+      # `Bytes.new(9)` per frame was pure GC churn on the shared single thread. The
+      # contiguous `buf` (header + payload, forwarded verbatim as wire_bytes) is still the
+      # one unavoidable allocation; the header's 9 bytes are copied into its front below.
+      header = uninitialized UInt8[HEADER_SIZE]
+      hslice = header.to_slice
+      first = io.read(hslice)
       return nil if first == 0 # clean EOF at a frame boundary
-      read_exact(io, header + first) if first < HEADER_SIZE
+      read_exact(io, hslice + first) if first < HEADER_SIZE
 
       len = (header[0].to_i32 << 16) | (header[1].to_i32 << 8) | header[2].to_i32
       raise Gori::Error.new("h2 frame too large: #{len}") if len > max_payload
@@ -126,7 +132,7 @@ module Gori::Proxy::H2
       # frame verbatim (wire_bytes) without a second alloc + payload memcpy.
       # `payload` is a view into it (read directly into buf[9..]).
       buf = Bytes.new(HEADER_SIZE + len)
-      header.copy_to(buf)
+      hslice.copy_to(buf)
       payload = buf[HEADER_SIZE, len]
       read_exact(io, payload) if len > 0
       Header.new(type, flags, stream_id, payload, buf)

--- a/src/gori/proxy/ws/frame.cr
+++ b/src/gori/proxy/ws/frame.cr
@@ -118,15 +118,39 @@ module Gori::Proxy::WS
 
     payload =
       if h.masked?
-        key = h.mask_key
-        out = Bytes.new(n) # unmask into a separate buffer; keep `raw` masked for byte-exact relay
-        n.times { |i| out[i] = buf[hlen + i] ^ key[i & 3] }
-        out
+        unmasked = Bytes.new(n) # separate buffer; keep `raw` masked for byte-exact relay
+        unmask(buf[hlen, n], h.mask_key, unmasked) if n > 0
+        unmasked
       else
         buf[hlen, n] # zero-copy view into the wire buffer (already unmasked)
       end
 
     Frame.new(h.fin?, h.opcode, payload, buf)
+  end
+
+  # Unmask `src` into `dst` (RFC 6455 §5.3: `dst[i] = src[i] ^ key[i % 4]`). Every
+  # client→server frame is masked, so this runs over the whole payload of every WS upload —
+  # the byte-at-a-time loop was the dominant WS-capture CPU cost. The mask period is 4 and
+  # aligned to payload offset 0, so a 32-bit word XOR is byte-identical to the scalar form:
+  # load 4 src bytes and the 4 key bytes as words in the SAME native order, XOR, store — the
+  # result's byte layout is `[s0^k0, s1^k1, s2^k2, s3^k3]` on either endianness. A ≤3-byte
+  # tail finishes scalar. `dst` must be exactly `src.size`. Only the CAPTURE copy is unmasked;
+  # `raw`/forward bytes stay masked (byte-exact, P7).
+  def self.unmask(src : Bytes, key : Bytes, dst : Bytes) : Nil
+    n = src.size
+    sp = src.to_unsafe
+    dp = dst.to_unsafe
+    key32 = key.to_unsafe.as(UInt32*).value # the 4 key bytes as one native-order word
+    i = 0
+    while i + 4 <= n
+      (dp + i).as(UInt32*).value = (sp + i).as(UInt32*).value ^ key32
+      i += 4
+    end
+    kp = key.to_unsafe
+    while i < n
+      dp[i] = sp[i] ^ kp[i & 3]
+      i += 1
+    end
   end
 
   # Copies exactly `len` payload bytes from `src` to `dst` in bounded chunks,

--- a/src/gori/sitemap.cr
+++ b/src/gori/sitemap.cr
@@ -36,8 +36,14 @@ module Gori
       # collapsed by `group_sequences!`. Not a real path — never tagged, never keyed.
       property grouped : Bool
 
+      # Build-time label→child index so `child` is O(1) instead of a linear sibling scan —
+      # a path-param explosion (thousands of `/users/<id>` siblings under one parent) made
+      # the old `@children.find` O(n²) over a whole build. `@children` stays an ordered Array
+      # (insertion order = render order, unchanged), so the index only accelerates lookup and
+      # is never read after `build` (group_sequences! reshapes @children directly).
       def initialize(@label : String)
         @children = [] of Node
+        @child_index = {} of String => Node
         @methods = [] of String
         @expanded = true
         @in_scope = false
@@ -48,7 +54,7 @@ module Gori
       end
 
       def child(label : String) : Node
-        @children.find { |c| c.label == label } || begin
+        @child_index[label] ||= begin
           node = Node.new(label)
           @children << node
           node
@@ -65,18 +71,30 @@ module Gori
     # ID templating; numeric folding is a separate opt-in step (`group_sequences!`).
     def self.build(entries : Enumerable({String, String, String})) : Array(Node)
       hosts = [] of Node
-      entries.each { |(host, method, target)| add(hosts, host, normalize_path(target), method) }
+      host_index = {} of String => Node # O(1) host lookup (a scan can surface thousands of hosts)
+      entries.each { |(host, method, target)| add(hosts, host, normalize_path(target), method, host_index) }
       hosts
     end
 
     # Insert one endpoint into `hosts`, creating host/segment nodes as needed. The
-    # accumulated absolute path is stamped on each node (the durable tag key).
-    def self.add(hosts : Array(Node), host : String, path : String, method : String) : Nil
-      host_node = hosts.find { |h| h.label == host } || begin
-        node = Node.new(host)
-        hosts << node
-        node
-      end
+    # accumulated absolute path is stamped on each node (the durable tag key). `host_index`
+    # (optional) accelerates the host lookup to O(1); without it the host is found by scan.
+    def self.add(hosts : Array(Node), host : String, path : String, method : String,
+                 host_index : Hash(String, Node)? = nil) : Nil
+      host_node =
+        if host_index
+          host_index[host] ||= begin
+            node = Node.new(host)
+            hosts << node
+            node
+          end
+        else
+          hosts.find { |h| h.label == host } || begin
+            node = Node.new(host)
+            hosts << node
+            node
+          end
+        end
       # Segment the PATH only: an unencoded '/' in a query VALUE (e.g. ?redirect=/a/b)
       # must not fabricate path-tree nodes. The query rides on the leaf so /x?a=1 and
       # /x?a=2 stay distinct endpoints without corrupting the tree.

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -95,6 +95,12 @@ module Gori
 
     BATCH_MAX = 128
 
+    # Cap on @pending_req_fts (see initialize). Far above the in-flight (request sent,
+    # response pending) flow count under any real load, since each entry lives only until
+    # its response lands; overflow (a flood of never-answered requests) clears the memo so
+    # update_one transparently falls back to the readback.
+    PENDING_FTS_MAX = 8192
+
     # Keep at most this many newest flows; older ones (and their ws/h2 rows) are
     # pruned so the DB plateaus instead of growing forever (freed pages are
     # reused by later inserts). 0 disables retention. Tunable per Store.open.
@@ -176,6 +182,13 @@ module Gori
       @write_failures = Atomic(Int32).new(0)
       @h2_frames_dropped = Atomic(Int32).new(0)
       @inserts_since_prune = 0
+      # Writer-fiber-only memo of the request-side FTS text keyed by a just-inserted flow id,
+      # so update_one (the response side) reuses it instead of reading the request head +
+      # body back out of the row it just wrote. Populated ONLY post-commit (a rolled-back insert
+      # never enters, so its id can't feed a stale response); bounded so abandoned Pending flows
+      # (a request whose response never arrives) can't grow it without limit — an evicted id
+      # simply falls back to the readback. Single writer fiber ⇒ no lock.
+      @pending_req_fts = {} of Int64 => String
       # Bumped after every committed prism_issues mutation (upsert/delete/status).
       # The TUI polls this every main-loop tick — more reliable than PRAGMA data_version
       # (same-process writer visibility is flaky) or the droppable Prism event channel.
@@ -1455,13 +1468,16 @@ module Gori
                 case op
                 when InsertFlow
                   ins_reply = op.reply
-                  id = insert_one(c, op.req)
-                  deferred << -> { ins_reply.send(id); publish(FlowEvent.new(id, :inserted)) }
+                  id, req_fts = insert_one(c, op.req)
+                  # Remember the request-side FTS text so this flow's later response update
+                  # skips the row readback. Merged only in the post-commit deferred block, so
+                  # a rolled-back insert leaves no entry behind.
+                  deferred << -> { remember_req_fts(id, req_fts); ins_reply.send(id); publish(FlowEvent.new(id, :inserted)) }
                 when InsertImportBatch
                   batch_reply = op.reply
                   inserted = [] of {Int64, Bool}
                   op.pairs.each do |req, resp|
-                    id = insert_one(c, req)
+                    id, _req_fts = insert_one(c, req)
                     has_resp = !resp.nil?
                     if resp
                       update_one(c, Store::CapturedResponse.new(
@@ -1619,11 +1635,14 @@ module Gori
       nil
     end
 
-    private def insert_one(conn : DB::Connection, req : CapturedRequest) : Int64
+    # Inserts the request row + its FTS entry, returning {id, req_fts} so the caller can
+    # hand the already-computed request-side FTS text to update_one (post-commit) instead of
+    # reading the head+body back out of the row.
+    private def insert_one(conn : DB::Connection, req : CapturedRequest) : {Int64, String}
       # request_size is the TRUE wire size (body_size when the BLOB was truncated),
       # so the History size column stays honest even for a capped body.
       body_size = req.body_size || req.body.try(&.size.to_i64) || 0_i64
-      conn.exec(
+      res = conn.exec(
         <<-SQL,
         INSERT INTO flows
           (created_at, scheme, host, port, method, target, http_version,
@@ -1637,11 +1656,13 @@ module Gori
         req.head.size.to_i64 + body_size,
         FlowState::Pending.value, req.h2_conn_id, req.h2_stream_id,
         req.body_truncated? ? 1 : 0)
-      id = conn.scalar("SELECT last_insert_rowid()").as(Int64)
+      # The INSERT's own result carries the rowid — no separate `SELECT last_insert_rowid()`.
+      id = res.last_insert_id
       # Index the request body text now; the response side is filled in by
       # update_one. Same transaction, so FTS and the row commit together.
-      conn.exec("INSERT INTO flows_fts(rowid, req, resp) VALUES (?, ?, '')", id, request_fts(req))
-      id
+      req_fts = request_fts(req)
+      conn.exec("INSERT INTO flows_fts(rowid, req, resp) VALUES (?, ?, '')", id, req_fts)
+      {id, req_fts}
     end
 
     private def update_one(conn : DB::Connection, resp : CapturedResponse) : Nil
@@ -1664,14 +1685,24 @@ module Gori
         resp.body_truncated? ? 1 : 0, resp.flow_id)
       # flows_fts is contentless (V24): FTS5 forbids UPDATE there, so re-write the whole
       # row. insert_one indexed the request side (searchable while Pending); DELETE that
-      # row and re-INSERT with BOTH sides. The request text is re-derived from the stored
-      # row (update_one only carries the response), capped in SQL so a multi-MB upload
-      # isn't pulled back whole. DELETE is a cheap tombstone (contentless_delete=1) and
-      # also makes a double update_response idempotent (last write wins).
+      # row and re-INSERT with BOTH sides. The request text was computed at insert time and
+      # memoized (@pending_req_fts) — reuse it rather than reading the head + (capped) body
+      # back from the row on every response; a miss (evicted, an import, or a cross-process
+      # write) falls back to that readback. DELETE is a cheap tombstone (contentless_delete=1)
+      # and also makes a double update_response idempotent (last write wins).
       resp_fts = (binary_content?(resp.content_type) || encoded?(head_markers(resp.head)[1])) ? "" : fts_text(resp.body)
-      req_fts = request_fts_from_row(conn, resp.flow_id)
+      req_fts = @pending_req_fts.delete(resp.flow_id) || request_fts_from_row(conn, resp.flow_id)
       conn.exec("DELETE FROM flows_fts WHERE rowid = ?", resp.flow_id)
       conn.exec("INSERT INTO flows_fts(rowid, req, resp) VALUES (?, ?, ?)", resp.flow_id, req_fts, resp_fts)
+    end
+
+    # Record a flow's request-side FTS text for its pending response update (writer fiber
+    # only). Clears the memo on overflow rather than growing unbounded — a burst of requests
+    # whose responses never land would otherwise pin memory; after a clear, those responses
+    # take the readback path.
+    private def remember_req_fts(id : Int64, req_fts : String) : Nil
+      @pending_req_fts.clear if @pending_req_fts.size >= PENDING_FTS_MAX
+      @pending_req_fts[id] = req_fts
     end
 
     # The request-side FTS text for an already-stored flow, recomputed the same way

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -1815,9 +1815,17 @@ module Gori
       args = [op.conn_id, op.created_at, op.direction, op.stream_id,
               op.type_octet, op.flags, op.payload.size] of DB::Any
       args << op.payload unless data
-      conn.exec("INSERT INTO h2_frames (conn_id, created_at, direction, stream_id, type, flags, length, payload) " \
-                "VALUES (?,?,?,?,?,?,?,#{data ? "X''" : "?"})", args: args)
+      # Precomputed SQL (one of two fixed texts) — this runs once per h2 frame on the writer
+      # fiber, so string-interpolating the statement every call was pure churn on the shared core.
+      conn.exec(data ? SQL_INSERT_H2_FRAME_DATA : SQL_INSERT_H2_FRAME_PAYLOAD, args: args)
     end
+
+    private SQL_INSERT_H2_FRAME_DATA =
+      "INSERT INTO h2_frames (conn_id, created_at, direction, stream_id, type, flags, length, payload) " \
+      "VALUES (?,?,?,?,?,?,?,X'')"
+    private SQL_INSERT_H2_FRAME_PAYLOAD =
+      "INSERT INTO h2_frames (conn_id, created_at, direction, stream_id, type, flags, length, payload) " \
+      "VALUES (?,?,?,?,?,?,?,?)"
 
     # Runs a write closure on the writer connection; returns last_insert_rowid.
     private def exec_task(run : DB::Connection -> Nil) : Int64

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -107,6 +107,8 @@ module Gori::Tui
       # Backs BOTH the template tint colours and the Sets→marker chips, so they can't disagree.
       @marker_text_rev = -1
       @marker_spans = [] of {Int32, Int32}
+      @marker_regions_rev = -1
+      @marker_regions_cache = [] of {Int32, Int32, Int32}
       # The CHAIN sub-pane: a visible editor for the Convert chain of the §…§ marker under
       # the TEMPLATE cursor (transform applied to each payload on send). @chain_focused =
       # editing it; @chain_marker_cursor remembers which marker to commit back to.
@@ -517,6 +519,17 @@ module Gori::Tui
         @marker_spans = Fuzz::Template.marked_spans(@editor.text)
       end
       @marker_spans
+    end
+
+    # {open, sep, close} regions cached on the editor revision — the template tint runs it
+    # every render; without the cache marker_regions did 2× whole-buffer `text.chars` per
+    # frame (its own + marked_spans'). Reuses the already-cached `marker_spans`.
+    private def marker_regions : Array({Int32, Int32, Int32})
+      if @editor.edits != @marker_regions_rev
+        @marker_regions_rev = @editor.edits
+        @marker_regions_cache = Fuzz::Template.marker_regions(@editor.text, marker_spans)
+      end
+      @marker_regions_cache
     end
 
     # --- run lifecycle -------------------------------------------------------
@@ -1392,7 +1405,7 @@ module Gori::Tui
       # it reads as metadata, not payload. Colours resolved fresh each frame (offsets are
       # colour-free); marker_regions is 1:1 with `spans`, so the config chips stay in sync.
       bg = [] of {Int32, Int32, Color}
-      Fuzz::Template.marker_regions(@editor.text).each_with_index do |region, i|
+      marker_regions.each_with_index do |region, i|
         a, sep, close = region
         bg << {a, close + 1, Theme.marker_bg(i)}
         bg << {sep, close + 1, Theme.elevated} if sep < close # dim the ¦chain segment

--- a/src/gori/tui/highlight.cr
+++ b/src/gori/tui/highlight.cr
@@ -605,90 +605,120 @@ module Gori::Tui
     # newline, so a line-local pass is sufficient for both pretty and minified
     # bodies). Object keys (a string immediately followed by ':') are accented
     # distinctly from string values.
+    # Byte-scanned (not `raw.chars`): all token boundaries are ASCII bytes, and every UTF-8
+    # multibyte byte is ≥0x80 (never a boundary byte), so it falls into the text/value/else
+    # runs exactly as a non-ASCII Char did — output is byte-identical, spans still concat to
+    # the exact line (a cut only ever lands on an ASCII byte = a char boundary, so byte_slice
+    # never splits a codepoint). Removes the per-line Array(Char) + the per-span sub-array+join.
     private def self.json_line(raw : String) : Line
       spans = [] of Span
-      chars = raw.chars
-      n = chars.size
+      b = raw.to_slice # view over the UTF-8 bytes, no copy
+      n = b.size
       i = 0
       while i < n
-        c = chars[i]
-        if c == '"'
+        c = b.unsafe_fetch(i)
+        if c == 0x22_u8 # '"'
           start = i
           i += 1
           while i < n
-            if chars[i] == '\\'
+            d = b.unsafe_fetch(i)
+            if d == 0x5c_u8 # backslash: skip the escaped byte
               i += 2
-            elsif chars[i] == '"'
+            elsif d == 0x22_u8
               i += 1
               break
             else
               i += 1
             end
           end
-          str = chars[start...i].join
+          str = raw.byte_slice(start, {i, n}.min - start) # i may overshoot on a trailing '\'
           k = i
-          while k < n && chars[k].ascii_whitespace?
+          while k < n && ascii_ws?(b.unsafe_fetch(k))
             k += 1
           end
-          key = k < n && chars[k] == ':'
+          key = k < n && b.unsafe_fetch(k) == 0x3a_u8 # ':'
           spans << Span.new(str, key ? Theme.syn_header : Theme.syn_string)
-        elsif c.ascii_number? || (c == '-' && i + 1 < n && chars[i + 1].ascii_number?)
+        elsif ascii_digit?(c) || (c == 0x2d_u8 && i + 1 < n && ascii_digit?(b.unsafe_fetch(i + 1)))
           start = i
           i += 1
-          while i < n && (chars[i].ascii_number? || "+-.eE".includes?(chars[i]))
+          while i < n && (ascii_digit?(b.unsafe_fetch(i)) || num_cont?(b.unsafe_fetch(i)))
             i += 1
           end
-          spans << Span.new(chars[start...i].join, Theme.syn_number)
-        elsif c.ascii_letter?
+          spans << Span.new(raw.byte_slice(start, i - start), Theme.syn_number)
+        elsif ascii_letter?(c)
           start = i
           i += 1
-          while i < n && chars[i].ascii_letter?
+          while i < n && ascii_letter?(b.unsafe_fetch(i))
             i += 1
           end
-          word = chars[start...i].join
+          word = raw.byte_slice(start, i - start)
           spans << Span.new(word, %w(true false null).includes?(word) ? Theme.syn_literal : Theme.text)
-        elsif "{}[]:,".includes?(c)
-          spans << Span.new(c.to_s, Theme.muted)
+        elsif json_struct?(c)
+          spans << Span.new(raw.byte_slice(i, 1), Theme.muted)
           i += 1
         else
           start = i
           i += 1
           while i < n
-            d = chars[i]
-            break if d == '"' || d.ascii_letter? || d.ascii_number? || "{}[]:,".includes?(d) ||
-                     (d == '-' && i + 1 < n && chars[i + 1].ascii_number?)
+            d = b.unsafe_fetch(i)
+            break if d == 0x22_u8 || ascii_letter?(d) || ascii_digit?(d) || json_struct?(d) ||
+                     (d == 0x2d_u8 && i + 1 < n && ascii_digit?(b.unsafe_fetch(i + 1)))
             i += 1
           end
-          spans << Span.new(chars[start...i].join, Theme.text)
+          spans << Span.new(raw.byte_slice(start, i - start), Theme.text)
         end
       end
       spans
+    end
+
+    # ASCII byte classifiers (mirror the Char#ascii_* predicates the tokenizers used).
+    private def self.ascii_digit?(x : UInt8) : Bool
+      x >= 0x30_u8 && x <= 0x39_u8
+    end
+
+    private def self.ascii_letter?(x : UInt8) : Bool
+      (x >= 0x41_u8 && x <= 0x5a_u8) || (x >= 0x61_u8 && x <= 0x7a_u8)
+    end
+
+    # Char#ascii_whitespace?: space or 0x09..0x0d.
+    private def self.ascii_ws?(x : UInt8) : Bool
+      x == 0x20_u8 || (x >= 0x09_u8 && x <= 0x0d_u8)
+    end
+
+    # JSON number continuation: one of `+ - . e E`.
+    private def self.num_cont?(x : UInt8) : Bool
+      x == 0x2b_u8 || x == 0x2d_u8 || x == 0x2e_u8 || x == 0x65_u8 || x == 0x45_u8
+    end
+
+    # JSON structural punctuation: one of `{ } [ ] : ,`.
+    private def self.json_struct?(x : UInt8) : Bool
+      x == 0x7b_u8 || x == 0x7d_u8 || x == 0x5b_u8 || x == 0x5d_u8 || x == 0x3a_u8 || x == 0x2c_u8
     end
 
     # `application/x-www-form-urlencoded` — keys accented, `=`/`&` muted, values
     # in body text.
     private def self.form_line(raw : String) : Line
       spans = [] of Span
-      chars = raw.chars
-      n = chars.size
+      b = raw.to_slice
+      n = b.size
       i = 0
       expect_key = true
       while i < n
-        c = chars[i]
-        if c == '&'
-          spans << Span.new("&", Theme.muted)
+        c = b.unsafe_fetch(i)
+        if c == 0x26_u8 # '&'
+          spans << Span.new(raw.byte_slice(i, 1), Theme.muted)
           i += 1
           expect_key = true
-        elsif c == '='
-          spans << Span.new("=", Theme.muted)
+        elsif c == 0x3d_u8 # '='
+          spans << Span.new(raw.byte_slice(i, 1), Theme.muted)
           i += 1
           expect_key = false
         else
           start = i
-          while i < n && chars[i] != '&' && chars[i] != '='
+          while i < n && b.unsafe_fetch(i) != 0x26_u8 && b.unsafe_fetch(i) != 0x3d_u8
             i += 1
           end
-          spans << Span.new(chars[start...i].join, expect_key ? Theme.syn_header : Theme.text)
+          spans << Span.new(raw.byte_slice(start, i - start), expect_key ? Theme.syn_header : Theme.text)
         end
       end
       spans
@@ -699,38 +729,42 @@ module Gori::Tui
     # the continuation line (cosmetic only; text is never altered).
     private def self.markup_line(raw : String) : Line
       spans = [] of Span
-      chars = raw.chars
-      n = chars.size
+      b = raw.to_slice
+      n = b.size
       i = 0
       while i < n
-        if chars[i] == '<'
+        if b.unsafe_fetch(i) == 0x3c_u8 # '<'
           gt = i + 1
-          while gt < n && chars[gt] != '>'
+          while gt < n && b.unsafe_fetch(gt) != 0x3e_u8 # '>'
             gt += 1
           end
           closed = gt < n # found a '>'
           j = i + 1
-          j += 1 if j < n && chars[j] == '/'                # closing tag
-          spans << Span.new(chars[i...j].join, Theme.muted) # '<' or '</'
+          j += 1 if j < n && b.unsafe_fetch(j) == 0x2f_u8          # '/' closing tag
+          spans << Span.new(raw.byte_slice(i, j - i), Theme.muted) # '<' or '</'
           name = j
-          while name < gt && (chars[name].ascii_letter? || chars[name].ascii_number? ||
-                chars[name] == '-' || chars[name] == '_' || chars[name] == ':')
+          while name < gt && tag_name?(b.unsafe_fetch(name))
             name += 1
           end
-          spans << Span.new(chars[j...name].join, Theme.syn_header) if name > j
-          spans << Span.new(chars[name...gt].join, Theme.text) if name < gt
-          spans << Span.new(">", Theme.muted) if closed
+          spans << Span.new(raw.byte_slice(j, name - j), Theme.syn_header) if name > j
+          spans << Span.new(raw.byte_slice(name, gt - name), Theme.text) if name < gt
+          spans << Span.new(raw.byte_slice(gt, 1), Theme.muted) if closed # '>'
           i = closed ? gt + 1 : gt
         else
           start = i
           i += 1
-          while i < n && chars[i] != '<'
+          while i < n && b.unsafe_fetch(i) != 0x3c_u8
             i += 1
           end
-          spans << Span.new(chars[start...i].join, Theme.text)
+          spans << Span.new(raw.byte_slice(start, i - start), Theme.text)
         end
       end
       spans
+    end
+
+    # A tag-name byte: ASCII letter/digit or one of `- _ :`.
+    private def self.tag_name?(x : UInt8) : Bool
+      ascii_letter?(x) || ascii_digit?(x) || x == 0x2d_u8 || x == 0x5f_u8 || x == 0x3a_u8
     end
 
     # --- helpers -------------------------------------------------------------

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -126,6 +126,8 @@ module Gori::Tui
       # base64-encode → it's encoded on the wire). Off = byte-identical to a plain send,
       # so a captured `§` is never reinterpreted unless the user turns this on.
       @mark_transform = false
+      @marker_regions_rev = -1
+      @marker_regions_cache = [] of {Int32, Int32, Int32}
       # The CHAIN sub-pane (MARK mode): a visible editor for the chain of the §…§ marker
       # under the request cursor. @chain_focused = editing it (split enlarges + keys route
       # there); @chain_marker_cursor remembers which marker to write back to on commit.
@@ -2192,12 +2194,23 @@ module Gori::Tui
         return
       end
       bg = [] of {Int32, Int32, Color}
-      Fuzz::Template.marker_regions(@editor.text).each_with_index do |region, i|
+      marker_regions.each_with_index do |region, i|
         a, sep, close = region
         bg << {a, close + 1, Theme.marker_bg(i)}
         bg << {sep, close + 1, Theme.elevated} if sep < close # dim the ¦chain segment
       end
       @editor.bg_regions = bg
+    end
+
+    # {open, sep, close} marker regions cached on the editor revision — update_request_mark_tint
+    # runs every render; the cache skips marker_regions' 2× whole-buffer `text.chars` on an
+    # unchanged request buffer.
+    private def marker_regions : Array({Int32, Int32, Int32})
+      if @editor.edits != @marker_regions_rev
+        @marker_regions_rev = @editor.edits
+        @marker_regions_cache = Fuzz::Template.marker_regions(@editor.text)
+      end
+      @marker_regions_cache
     end
 
     private def render_ws_handshake(screen : Screen, rect : Rect, focused : Bool) : Nil

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -338,12 +338,16 @@ module Gori::Tui
         # Prism list live refresh: Store#prism_generation increments after every
         # committed prism_issues write (upsert/delete/status). Poll every tick —
         # do NOT rely on the droppable analyzer event channel or PRAGMA data_version.
+        # Reload the (full-table SELECT + filter) list ONLY when Prism is the active tab:
+        # nothing in the always-visible chrome reads it (toasts arrive via drain_events),
+        # and on_enter reloads on tab switch, so an off-tab bump is caught up on return.
+        # `last_prism_gen` still advances so returning to Prism doesn't reload redundantly.
         # When Prism is visible, force a full terminal sync (not just cell-diff) so a
         # new/removed row cannot stick as a stale paint.
         if (pgen = @session.store.prism_generation) != last_prism_gen
           last_prism_gen = pgen
-          prism_controller.refresh_from_store
           if @active_tab == :prism
+            prism_controller.refresh_from_store
             dirty = true
             @resized = true
           end

--- a/src/gori/tui/screen.cr
+++ b/src/gori/tui/screen.cr
@@ -32,6 +32,13 @@ module Gori::Tui
     getter width : Int32
     getter height : Int32
 
+    # Interned single-cell Strings for the 128 ASCII codepoints, so drawing a Char never
+    # allocates a fresh 1-char String — `cell` is the universal draw primitive (a full-screen
+    # fill alone is width×height calls, thousands more from text()), so `Char#to_s` per cell
+    # was tens of thousands of throwaway Strings per frame. C0/C1-style control chars that
+    # termisu rejects are pre-substituted with a space here, folding the old runtime check in.
+    ASCII_CELL = Array(String).new(128) { |i| (i < 0x20 || i == 0x7f) ? " " : i.unsafe_chr.to_s }
+
     def initialize(@backend : Backend)
       @width, @height = @backend.size
     end
@@ -92,10 +99,13 @@ module Gori::Tui
     def cell(x : Int32, y : Int32, grapheme : Char | String, fg : Color, bg : Color = Theme.bg,
              attr : Attribute = Attribute::None) : Nil
       return unless x >= 0 && y >= 0 && x < @width && y < @height
-      g = grapheme.is_a?(Char) ? grapheme.to_s : grapheme
-      # termisu rejects C0/C1 control chars; substitute a space to stay aligned.
-      if grapheme.is_a?(Char) && grapheme.control?
-        g = " "
+      if grapheme.is_a?(Char)
+        o = grapheme.ord
+        # ASCII → interned cell (control chars already mapped to a space in the table);
+        # non-ASCII control (C1) still substitutes a space; other non-ASCII stringifies.
+        g = o < 128 ? ASCII_CELL[o] : (grapheme.control? ? " " : grapheme.to_s)
+      else
+        g = grapheme
       end
       @backend.put(x, y, g, fg, bg, attr)
     end

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -11,7 +11,12 @@ module Gori::Tui
   # request). Holds lines + a cursor; no modes — typing edits directly. Converts
   # back to bytes with CRLF line endings (HTTP wire form).
   class TextArea
-    record UndoState, text : String, cy : Int32, cx : Int32
+    # Snapshot for undo. Holds the LINE ARRAY (a shallow copy), not a joined-buffer String:
+    # line Strings are immutable and every edit REPLACES `@lines[i]` (never mutates in place),
+    # so unchanged lines are structurally shared across all 100 snapshots. This turns push_undo
+    # from a whole-buffer String copy per keystroke (and up to 100 full-buffer copies retained)
+    # into an Array-of-pointers copy that shares the line data.
+    record UndoState, lines : Array(String), cy : Int32, cx : Int32
 
     def initialize(text : String = "")
       @lines = [""]
@@ -33,6 +38,8 @@ module Gori::Tui
       @search_hl = "" # active ^F query → matches highlighted in render
       @reveal = false # show whitespace (space ·, tab →) instead of syntax colours
       @edits = 0      # monotonic content-change counter — cheap cache key for owners
+      @lc_lines = [] of String # downcased lines for ^F search, memoized on @edits
+      @lc_lines_rev = -1
       # Opt-in background tints: [start, end) FULL-buffer char offsets + colour, painted
       # UNDER the text (over syntax/plain, beneath search + cursor). Empty for every editor
       # except the Fuzzer template — Replay/Notes never set it, so they're unaffected. The
@@ -286,13 +293,24 @@ module Gori::Tui
       off + @cx.clamp(0, @lines[@cy].size)
     end
 
-    # ^F search: 0-based indices of lines containing `query` (case-insensitive).
+    # ^F search: 0-based indices of lines containing `query` (case-insensitive). The
+    # downcased lines are cached on @edits, so each keystroke of an incremental search (and
+    # the re-scans on drain/poll while the prompt is open) reuses them instead of allocating a
+    # fresh `.downcase` per line every time — the buffer doesn't change while you type a query.
     def search_lines(query : String) : Array(Int32)
       hits = [] of Int32
       return hits if query.empty?
       q = query.downcase
-      @lines.each_with_index { |l, i| hits << i if l.downcase.includes?(q) }
+      lowercased_lines.each_with_index { |l, i| hits << i if l.includes?(q) }
       hits
+    end
+
+    private def lowercased_lines : Array(String)
+      if @edits != @lc_lines_rev
+        @lc_lines_rev = @edits
+        @lc_lines = @lines.map(&.downcase)
+      end
+      @lc_lines
     end
 
     # `highlight` overlays request/response syntax colours on the buffer while
@@ -476,14 +494,14 @@ module Gori::Tui
     end
 
     private def push_undo : Nil
-      @undo_stack << UndoState.new(text, @cy, @cx)
+      @undo_stack << UndoState.new(@lines.dup, @cy, @cx) # shallow: shares the immutable line Strings
       @undo_stack.shift if @undo_stack.size > 100
     end
 
     def undo : Nil
       return if @undo_stack.empty?
       state = @undo_stack.pop
-      @lines = state.text.split('\n')
+      @lines = state.lines           # the snapshot is popped/unreferenced, so no defensive dup
       @lines = [""] if @lines.empty?
       @cy = state.cy.clamp(0, @lines.size - 1)
       @cx = state.cx.clamp(0, @lines[@cy].size)


### PR DESCRIPTION
Four profile-driven perf rounds on the single-threaded hot paths (gori runs single-thread, so per-op CPU/allocation directly caps throughput). Every fix is benched (Benchmark.ips, bytes/op) or spec-verified; behavior is preserved throughout.

## Headline wins (all measured)
- **Screen#cell ASCII interning** — full-frame draw 64.5µs/222kB → 14.2µs/**0B per frame** (4.5×). Kills ~4.4 MB/s render GC churn.
- **Miner reflection** — K per-canary body scans → one `gq`-shape byte-scan into a Set: **5.63ms → 46µs per probe (122×, −32× alloc)**.
- **WS unmask** — byte-loop → 32-bit word XOR (SIMD): **12–38×** per masked client frame.
- **Highlight body tokenizers** — `raw.chars`+`.join` → byte-scan (`byte_slice`): json 2.9× / html 3.6× / form 3.0×, per visible line per frame. Verified span-identical vs the char impl over a 2000-case fuzz.
- **Sitemap build** — O(n²) sibling/host scans → Hash index: 10k endpoints **40.4ms → 1.9ms (21×)** (rebuilds ~1.3×/s during capture).
- **JWT scan** — raw-byte `eyJ` pre-gate before the 2 MiB regex: no-token body **10× / −31× alloc**.
- **CaptureBuffer** — lazy + Content-Length presize + copy-on-write no-dup (+256 KB presize cap defending a lying CL); **h2 Frame.read** stack header; **TextArea undo** whole-buffer-copy/keystroke → shallow shared-line snapshot; **Prism active** dedup-key-before-build (3.2×); store per-response FTS readback → memo; import per-header downcase → case-insensitive compare; and more.

## Correctness
Byte-exactness preserved on the proxy path; detection results unchanged for Prism/Miner (equivalence specs added for the byte-scan tokenizers, the Prism active dedup key, and CaptureBuffer COW). One optimization (combining BodyLeaks' regexes via `Regex.union`) was **reverted** after benching showed it 5× slower — it defeats PCRE's per-pattern literal-prefix skip.

## Verify
- Full suite **1477 examples / 0 failures** (was 1464; +13 new tests).
- ameba unchanged (no new violations); format clean on touched files.
- E2E via real `gori run capture`: bodyless GET, 48B POST (byte-exact + FTS hit), 300 KB POST.
- Release binary builds clean. New permanent benches under `bench/`.

## Profiling note
Real `sample` profiling of all three single-thread consumers after these rounds: the **proxy is at its I/O/memcpy floor** (GC no longer a hotspot), the **TUI render is windowed + sub-ms**, and the **store writer is FTS-trigram-bound but off the client-latency path** (a throughput ceiling only — deferred as it needs a search-scope or async-staleness tradeoff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)