### PR TITLE
Keyboard accessibility: page-nav, j/k overlays, find-subtab, notes.clear confirm

### DIFF
--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -75,6 +75,14 @@ class FakeExecContext < Gori::Verb::ExecContext
     @replay_tab_count
   end
 
+  def subtab_search_open : Nil; end
+
+  property subtab_search_tab_count : Int32 = 0
+
+  def subtab_search_count : Int32
+    @subtab_search_tab_count
+  end
+
   def replay_rename_subtab : Nil; end
 
   def replay_close_subtab : Nil; end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -140,6 +140,14 @@ private class FakeContext < ExecContext
     0
   end
 
+  def subtab_search_open : Nil
+    @calls << :subtab_search_open
+  end
+
+  def subtab_search_count : Int32
+    0
+  end
+
   def replay_rename_subtab : Nil
     @calls << :replay_rename_subtab
   end

--- a/src/gori/tui/controllers/findings_controller.cr
+++ b/src/gori/tui/controllers/findings_controller.cr
@@ -29,6 +29,15 @@ module Gori::Tui
       @findings.detail_open? ? Verb::Scope::FindingsDetail : Verb::Scope::Findings
     end
 
+    # PageUp/PageDown/Home/End over the findings list (view clamps the selection). The
+    # detail view is a short title/notes/links form with no vertical body to page, so
+    # leave those keys untouched when it's open.
+    def body_scroll(delta : Int32) : Bool
+      return false if @findings.detail_open?
+      @findings.move(delta)
+      true
+    end
+
     def body_badge : Symbol
       @findings.notes_insert_mode? ? :editor : :body
     end
@@ -137,14 +146,14 @@ module Gori::Tui
         @findings.focus_links!
       when key.enter?, c == 'i'
         @findings.enter_notes_insert!
-      when key.up?   then @findings.notes_read_move(-1, 0, selecting: selecting)
-      when key.down? then @findings.notes_read_move(1, 0, selecting: selecting)
-      when key.left? && selecting  then @findings.notes_read_move(0, -1, selecting: true)
-      when key.right? && selecting then @findings.notes_read_move(0, 1, selecting: true)
+      when key.up?                  then @findings.notes_read_move(-1, 0, selecting: selecting)
+      when key.down?                then @findings.notes_read_move(1, 0, selecting: selecting)
+      when key.left? && selecting   then @findings.notes_read_move(0, -1, selecting: true)
+      when key.right? && selecting  then @findings.notes_read_move(0, 1, selecting: true)
       when key.left? && !selecting  then @findings.notes_read_move(0, -1)
       when key.right? && !selecting then @findings.notes_read_move(0, 1)
-      when c == 'x'                then @findings.notes_select_line
-      when c == 'y'                then findings_copy
+      when c == 'x'                 then @findings.notes_select_line
+      when c == 'y'                 then findings_copy
       else
         return false
       end

--- a/src/gori/tui/controllers/help_controller.cr
+++ b/src/gori/tui/controllers/help_controller.cr
@@ -27,6 +27,14 @@ module Gori::Tui
       Verb::Scope::Body
     end
 
+    # PageUp/PageDown/Home/End over the (long) Help cheat-sheet. move() clamps the top;
+    # the bottom is clamped at render (clamp_scroll), so the large Home/End magnitude is
+    # safe and lands on the last page.
+    def body_scroll(delta : Int32) : Bool
+      @help.move(delta)
+      true
+    end
+
     # --- fixed sub-tab strip (no new/close/rename) ---
     def subtab_labels : Array(String)
       PAGE_LABELS

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -130,6 +130,14 @@ module Gori::Tui
 
     # History detail drill-in: shift+arrows select, space opens the action menu.
     # Plain ↑/↓/j/k stay verb-driven (detail.up/down → detail_move).
+    # PageUp/PageDown/Home/End over the history list (detail paging is handled at the
+    # :detail overlay in the Runner). Uses the view's clamping move directly, so it
+    # never triggers move_selection's ↑-at-top focus pop mid-page.
+    def body_scroll(delta : Int32) : Bool
+      @history.move(delta)
+      true
+    end
+
     def handle_detail_key(ev : Termisu::Event::Key) : Bool
       return false unless @host.overlay == :detail
       if ev.key.space? && !ev.ctrl? && !ev.alt?

--- a/src/gori/tui/controllers/notes_controller.cr
+++ b/src/gori/tui/controllers/notes_controller.cr
@@ -97,8 +97,8 @@ module Gori::Tui
       key = ev.key
       selecting = ev.shift?
       case
-      when key.enter?              then @notes.enter_insert!
-      when c == 'i'                then @notes.enter_insert!
+      when key.enter? then @notes.enter_insert!
+      when c == 'i'   then @notes.enter_insert!
       when key.up?
         if @notes.at_top?
           save_notes
@@ -106,13 +106,13 @@ module Gori::Tui
         else
           @notes.read_move(-1, 0, selecting: selecting)
         end
-      when key.down?               then @notes.read_move(1, 0, selecting: selecting)
-      when key.left?               then @notes.read_move(0, -1, selecting: selecting)
-      when key.right?              then @notes.read_move(0, 1, selecting: selecting)
-      when key.home?               then @notes.home
-      when key.end?                then @notes.end_of_line
-      when c == 'x'                then @notes.select_line
-      when c == 'y'                then notes_copy
+      when key.down?  then @notes.read_move(1, 0, selecting: selecting)
+      when key.left?  then @notes.read_move(0, -1, selecting: selecting)
+      when key.right? then @notes.read_move(0, 1, selecting: selecting)
+      when key.home?  then @notes.home
+      when key.end?   then @notes.end_of_line
+      when c == 'x'   then @notes.select_line
+      when c == 'y'   then notes_copy
       end
     end
 
@@ -129,12 +129,12 @@ module Gori::Tui
         else
           @notes.move(-1, 0)
         end
-      when key.down?      then @notes.move(1, 0)
-      when key.left?      then @notes.move(0, -1)
-      when key.right?     then @notes.move(0, 1)
-      when key.home?      then @notes.home
-      when key.end?       then @notes.end_of_line
-      when key.delete?    then @notes.delete
+      when key.down?   then @notes.move(1, 0)
+      when key.left?   then @notes.move(0, -1)
+      when key.right?  then @notes.move(0, 1)
+      when key.home?   then @notes.home
+      when key.end?    then @notes.end_of_line
+      when key.delete? then @notes.delete
       else
         if c && !ev.ctrl? && !ev.alt?
           @notes.insert(c)
@@ -303,10 +303,17 @@ module Gori::Tui
       @host.status(msg)
     end
 
-    # Wipe the current note's text (the sub-tab stays open).
+    # Wipe the current note's text (the sub-tab stays open). Confirm-gated like every
+    # other destructive action — clear_current resets the TextArea, which drops the
+    # undo stack, so a stray `c` would otherwise wipe authored text with no recovery.
+    # Skip the prompt when the note is already blank (nothing to lose).
     def notes_clear : Nil
-      @notes.clear_current
-      @host.status("note cleared")
+      return if @notes.current_blank?
+      @host.confirm("CLEAR NOTE", "Clear this note's text?\nThis can't be undone.",
+        confirm_label: "clear", danger: true) do
+        @notes.clear_current
+        @host.status("note cleared")
+      end
     end
   end
 end

--- a/src/gori/tui/controllers/prism_controller.cr
+++ b/src/gori/tui/controllers/prism_controller.cr
@@ -29,6 +29,14 @@ module Gori::Tui
       @prism.detail_open? ? Verb::Scope::PrismDetail : Verb::Scope::Prism
     end
 
+    # PageUp/PageDown/Home/End: page the open issue's detail body, else the issue list.
+    # Both the view's move and scroll_detail clamp (scroll_detail's ceiling lands at
+    # render), so the large Home/End magnitude is safe.
+    def body_scroll(delta : Int32) : Bool
+      @prism.detail_open? ? @prism.scroll_detail(delta) : @prism.move(delta)
+      true
+    end
+
     def body_badge : Symbol
       :body # read-only/navigable list + detail (no inline text editor)
     end

--- a/src/gori/tui/controllers/sitemap_controller.cr
+++ b/src/gori/tui/controllers/sitemap_controller.cr
@@ -28,6 +28,12 @@ module Gori::Tui
       Verb::Scope::Sitemap
     end
 
+    # PageUp/PageDown/Home/End over the sitemap tree (view clamps the selection).
+    def body_scroll(delta : Int32) : Bool
+      @sitemap.move(delta)
+      true
+    end
+
     def body_badge : Symbol # the QL filter bar / tag editor capture text; else the navigable tree
       @sitemap.querying? || @sitemap.tagging? ? :editor : :body
     end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -178,6 +178,7 @@ module Gori::Tui
       @outcome = :running              # :running | :quit | :back
       @quit_armed = false              # first ^D/^C arms quit; second confirms (avoids accidental exit)
       @resized = false                 # set on a Resize event → next frame full-repaints
+      @body_h = 24                     # last body rect height (captured at render); drives PageUp/Down step size
 
       # Per-tab controllers (strangler-fig: tabs migrate into this registry one at a
       # time; an unmigrated tab is absent and still runs through the case ladders
@@ -300,9 +301,9 @@ module Gori::Tui
       last_dv = @session.store.data_version # SQLite change counter for cross-process refresh
       last_dv_poll = Time.instant
       last_prism_gen = @session.store.prism_generation # committed prism_issues mutations
-      last_spin = Time.instant        # advances the background-job spinner frame
-      last_clock = clock_label        # top-bar wall clock; re-render only when the minute rolls over
-      last_ui_ident = nil.as(String?) # last-written ui-state identity (see UI_STATE_THROTTLE)
+      last_spin = Time.instant                         # advances the background-job spinner frame
+      last_clock = clock_label                         # top-bar wall clock; re-render only when the minute rolls over
+      last_ui_ident = nil.as(String?)                  # last-written ui-state identity (see UI_STATE_THROTTLE)
       last_ui_write = Time.instant
       loop do
         ev = @term.poll_event(50)
@@ -679,6 +680,12 @@ module Gori::Tui
       # History detail drill-in: shift+arrows select, space opens the action menu.
       if @active_tab == :history && @overlay == :detail && @focus == :body
         return if history_controller.handle_detail_key(ev)
+        # PageUp/PageDown/Home/End page the open response/request body (the :detail
+        # overlay is outside the @overlay == :none body-nav path below, so route here).
+        if delta = page_nav_delta(ev.key)
+          history_controller.scroll_detail(delta)
+          return
+        end
       end
       # The Convert chain autocomplete owns Tab/↵/↑/↓/Esc while its popup is up —
       # before the focus ring claims Tab. Non-popup keys fall through (return false).
@@ -747,6 +754,13 @@ module Gori::Tui
       # tab is absent from @tabs and falls through to the verb keymap / space menu below.
       if @overlay == :none && @focus == :body && (c = @tabs[@active_tab]?)
         return if c.handle_body_key(ev)
+        # PageUp/PageDown/Home/End: page/jump the focused list or read-only pane. These
+        # keys never reach the verb keymap (Keybind.from_event doesn't encode them), so
+        # route them straight to the controller's body_scroll. A tab with no navigable
+        # body returns false and the keys fall through harmlessly.
+        if (delta = page_nav_delta(ev.key)) && c.body_scroll(delta)
+          return
+        end
       end
 
       chord = Keybind.from_event(ev)
@@ -840,7 +854,7 @@ module Gori::Tui
     private def modal_overlay? : Bool
       case @overlay
       when :palette, :rules, :finding_new, :confirm, :browser, :choice, :comparer_pick, :replay_subtab, :links, :finding_pick, :note_pick, :settings, :tabs, :hotkeys, :notifications, :mine_config, :fuzz_set, :fuzz_advanced, :scope_rule then true
-      else                                                                                                                                                                                                                                      false
+      else                                                                                                                                                                                                                                       false
       end
     end
 
@@ -1323,10 +1337,10 @@ module Gori::Tui
     private def handle_browser_key(ev : Termisu::Event::Key) : Nil
       key = ev.key
       case
-      when key.escape? then close_browser_picker
-      when key.up?     then @browser_picker.try(&.move(-1))
-      when key.down?   then @browser_picker.try(&.move(1))
-      when key.enter?  then launch_selected_browser
+      when key.escape?             then close_browser_picker
+      when key.up?, key.lower_k?   then @browser_picker.try(&.move(-1))
+      when key.down?, key.lower_j? then @browser_picker.try(&.move(1))
+      when key.enter?              then launch_selected_browser
       end
     end
 
@@ -1347,9 +1361,18 @@ module Gori::Tui
       when key.down?   then p.move(1)
       when key.enter?  then apply_choice
       else
-        if (c = ev.char) && !ev.ctrl? && !ev.alt? && (idx = p.index_for(c))
-          p.set_selected(idx)
-          apply_choice
+        if (c = ev.char) && !ev.ctrl? && !ev.alt?
+          # A row mnemonic sets it directly (wins); j/k fall back to vim-style nav
+          # only when they aren't themselves a mnemonic, so the reflex keystroke moves
+          # the highlight instead of being ignored.
+          if idx = p.index_for(c)
+            p.set_selected(idx)
+            apply_choice
+          elsif c == 'j'
+            p.move(1)
+          elsif c == 'k'
+            p.move(-1)
+          end
         end
         # any other key is ignored (the picker stays up — a value pick is deliberate)
       end
@@ -1505,8 +1528,8 @@ module Gori::Tui
         return
       end
       if idx = sp.selected_index
-        replay_controller.jump_subtab(idx)
-        @focus = :body # land on the chosen session's content (we came from the response pane)
+        @tabs[@active_tab]?.try(&.jump_subtab(idx)) # active tab owns the strip (Replay/Fuzzer/Notes/Convert)
+        @focus = :body                              # land on the chosen session's content
       end
       close_subtab_picker
     end
@@ -1554,13 +1577,13 @@ module Gori::Tui
         return
       end
       case
-      when key.escape? then close_links_overlay
-      when key.up?     then lo.move(-1)
-      when key.down?   then lo.move(1)
-      when key.enter?  then open_selected_link(lo)
-      when c == 'o'    then open_selected_link(lo)
-      when c == 'd'    then remove_selected_link(lo)
-      when c == 'a'    then lo.start_add
+      when key.escape?             then close_links_overlay
+      when key.up?, key.lower_k?   then lo.move(-1)
+      when key.down?, key.lower_j? then lo.move(1)
+      when key.enter?              then open_selected_link(lo)
+      when c == 'o'                then open_selected_link(lo)
+      when c == 'd'                then remove_selected_link(lo)
+      when c == 'a'                then lo.start_add
       end
     end
 
@@ -1966,9 +1989,9 @@ module Gori::Tui
         open_palette
       elsif key.escape?
         @overlay = :none
-      elsif key.up?
+      elsif key.up? || key.lower_k?
         @hosts_overlay.select_move(-1)
-      elsif key.down?
+      elsif key.down? || key.lower_j?
         @hosts_overlay.select_move(1)
       elsif key.enter? || c == 'e'
         @hosts_overlay.edit_start
@@ -2033,9 +2056,9 @@ module Gori::Tui
         open_palette
       elsif key.escape?
         @overlay = :none
-      elsif key.up?
+      elsif key.up? || key.lower_k?
         @env_overlay.select_move(-1)
-      elsif key.down?
+      elsif key.down? || key.lower_j?
         @env_overlay.select_move(1)
       elsif key.enter? || c == 'e'
         @env_overlay.edit_start
@@ -2230,11 +2253,11 @@ module Gori::Tui
     # body_hint never advertises it). Rename/close still work.
     private def subtab_new : Nil
       case @active_tab
-      when :replay    then replay_controller.replay_new
-      when :fuzzer    then fuzzer_controller.fuzz_new
-      when :convert   then convert_controller.convert_new
-      when :notes     then notes_controller.notes_new
-      when :comparer  then comparer_controller.comparer_new
+      when :replay   then replay_controller.replay_new
+      when :fuzzer   then fuzzer_controller.fuzz_new
+      when :convert  then convert_controller.convert_new
+      when :notes    then notes_controller.notes_new
+      when :comparer then comparer_controller.comparer_new
       end
     end
 
@@ -2243,18 +2266,18 @@ module Gori::Tui
     private def subtab_new_supported? : Bool
       case @active_tab
       when :replay, :fuzzer, :convert, :notes, :comparer then true
-      else                                                   false
+      else                                                    false
       end
     end
 
     private def subtab_close : Nil
       case @active_tab
-      when :replay    then replay_controller.request_close
-      when :fuzzer    then fuzzer_controller.request_close
-      when :miner     then miner_controller.request_close
-      when :convert   then convert_controller.convert_close
-      when :notes     then notes_controller.notes_close
-      when :comparer  then comparer_controller.comparer_close
+      when :replay   then replay_controller.request_close
+      when :fuzzer   then fuzzer_controller.request_close
+      when :miner    then miner_controller.request_close
+      when :convert  then convert_controller.convert_close
+      when :notes    then notes_controller.notes_close
+      when :comparer then comparer_controller.comparer_close
       end
     end
 
@@ -2359,10 +2382,21 @@ module Gori::Tui
       elsif key.enter?
         run_space_verb(@space_menu.selected_verb)
       elsif (c = ev.char) && !ev.ctrl? && !ev.alt?
-        verb = @space_menu.verb_for(c)
-        verb ? run_space_verb(verb) : close_space_menu
+        # A bound mnemonic always wins (helix leader). Only when j/k are NOT a live
+        # mnemonic in this menu do they fall back to vim-style nav — so the reflex
+        # keystroke moves the selection instead of dismissing the menu, while scopes
+        # that bind 'k' (e.g. link-to-finding) keep their mnemonic.
+        if verb = @space_menu.verb_for(c)
+          run_space_verb(verb)
+        elsif c == 'j'
+          @space_menu.move(1)
+        elsif c == 'k'
+          @space_menu.move(-1)
+        else
+          close_space_menu # an unmapped leader key dismisses (helix feel)
+        end
       else
-        close_space_menu # an unmapped leader key dismisses (helix feel)
+        close_space_menu
       end
     end
 
@@ -2786,9 +2820,27 @@ module Gori::Tui
     end
 
     private def render_body(screen : Screen, rect : Rect) : Nil
+      @body_h = rect.h # remembered for PageUp/PageDown's screenful step (see page_nav_delta)
       # Every catalog tab has a controller that owns its body render; the `?` guard is
       # defensive (a blank body beats a crash if the active tab ever lacks one).
       @tabs[@active_tab]?.try(&.render_body(screen, rect, @focus))
+    end
+
+    # A row delta for a page/jump key, or nil if `key` isn't one. PageUp/PageDown step
+    # by ~one screenful (the last body height, minus a couple rows of overlap); Home/End
+    # pass a large magnitude that the target view clamps to its top/bottom. Shared by the
+    # in-body list dispatch (TabController#body_scroll) and the History detail overlay.
+    JUMP_ROWS = 100_000
+
+    private def page_nav_delta(key : Termisu::Input::Key) : Int32?
+      page = {@body_h - 3, 3}.max
+      case
+      when key.page_down? then page
+      when key.page_up?   then -page
+      when key.home?      then -JUMP_ROWS
+      when key.end?       then JUMP_ROWS
+      else                     nil
+      end
     end
 
     # --- ExecContext (verbs drive the UI through these) ----------------------
@@ -3015,11 +3067,11 @@ module Gori::Tui
     # redirect it.
     private def open_rename(idx : Int32) : Nil
       view = case @active_tab
-             when :replay    then replay_controller.view_at(idx)
-             when :fuzzer    then fuzzer_controller.view_at(idx)
-             when :convert   then convert_controller.view_at(idx)
-             when :miner     then miner_controller.view_at(idx)
-             when :comparer  then comparer_controller.view_at(idx)
+             when :replay   then replay_controller.view_at(idx)
+             when :fuzzer   then fuzzer_controller.view_at(idx)
+             when :convert  then convert_controller.view_at(idx)
+             when :miner    then miner_controller.view_at(idx)
+             when :comparer then comparer_controller.view_at(idx)
              end
       return unless view
       @rename_view = view
@@ -3040,11 +3092,11 @@ module Gori::Tui
     # (the chip reverts to the request/template-derived summary).
     private def apply_rename(name : String) : Nil
       case v = @rename_view
-      when ReplayView    then replay_controller.apply_rename(v, name)
-      when FuzzerView    then fuzzer_controller.apply_rename(v, name)
-      when ConvertView   then convert_controller.apply_rename(v, name)
-      when MinerView     then miner_controller.apply_rename(v, name)
-      when ComparerView  then comparer_controller.apply_rename(v, name)
+      when ReplayView   then replay_controller.apply_rename(v, name)
+      when FuzzerView   then fuzzer_controller.apply_rename(v, name)
+      when ConvertView  then convert_controller.apply_rename(v, name)
+      when MinerView    then miner_controller.apply_rename(v, name)
+      when ComparerView then comparer_controller.apply_rename(v, name)
       end
     end
 
@@ -3816,10 +3868,22 @@ module Gori::Tui
     # Open the Replay sub-tab search picker (space → s). Snapshots the open
     # sessions; the picker filters them in memory and jumps on ↵.
     def replay_find_subtab : Nil
-      rows = replay_controller.subtab_search_rows
-      return @toast = "no other replay open to search" if rows.size < 2
+      subtab_search_open
+    end
+
+    # Generic sub-tab search — opens the fuzzy picker over the ACTIVE tab's sub-tabs
+    # (Replay/Fuzzer/Notes/Convert). commit_subtab_picker jumps on the active controller,
+    # so one path serves every strip. Gives Fuzzer/Notes/Convert a search-and-jump that
+    # doesn't rely on Ctrl+digit (undeliverable on many terminals).
+    def subtab_search_open : Nil
+      rows = @tabs[@active_tab]?.try(&.subtab_search_rows) || [] of SubtabPicker::Row
+      return @toast = "no other sub-tab to search" if rows.size < 2
       @subtab_picker = SubtabPicker.new("FIND SUB-TAB", rows)
       @overlay = :replay_subtab
+    end
+
+    def subtab_search_count : Int32
+      @tabs[@active_tab]?.try(&.subtab_count) || 0
     end
 
     def replay_subtab_count : Int32

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -179,6 +179,15 @@ module Gori::Tui
       false
     end
 
+    # Page/jump keyboard nav (PageUp/PageDown → ±one screenful; Home/End → top/bottom).
+    # `delta` is a signed row count; Home/End pass a large magnitude and rely on the
+    # view's own clamping (so the exact value only needs to exceed the list length).
+    # Return true if this tab has a navigable body that consumed it. Default: not
+    # navigable — editors leave this false so the physical keys fall through untouched.
+    def body_scroll(delta : Int32) : Bool
+      false
+    end
+
     # Same notch, but with the pointer position + body rect — lets a multi-pane tab
     # (Project) scroll the pane UNDER the cursor instead of the focused one. Defaults
     # to the coordinate-free handle_wheel, so single-target tabs need no change.
@@ -214,6 +223,21 @@ module Gori::Tui
     end
 
     def jump_subtab(idx : Int32) : Nil
+    end
+
+    # Rows for the "find sub-tab" search picker (space → search). Default: one row per
+    # strip label — good enough for Fuzzer/Notes/Convert. Replay overrides to add a
+    # summary/URL detail line. Only meaningful when there are ≥2 sub-tabs (the verb gates
+    # on subtab_count), so jumping to a sub-tab never needs the Ctrl+digit chord.
+    def subtab_search_rows : Array(SubtabPicker::Row)
+      (subtab_labels || [] of String).map_with_index do |label, i|
+        SubtabPicker::Row.new(i, label, "")
+      end
+    end
+
+    # Open sub-tab count — gates the search entry. Derived from the strip labels.
+    def subtab_count : Int32
+      subtab_labels.try(&.size) || 0
     end
 
     # A FIXED strip (Help): the chip set is constant — no ^N/^W create/close and the

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -65,11 +65,16 @@ module Gori
 
       # replay workbench (text editing + focus/pane nav stay inline; these request-pane
       # toggles are verbs so they're keymap-driven and rebindable)
-      abstract def replay_selected : Nil                   # load History's selection into Replay
-      abstract def replay_new : Nil                        # open a blank, hand-authored replay request
-      abstract def replay_send : Nil                       # resend the (edited) request to the target
-      abstract def replay_find_subtab : Nil                # open the sub-tab search picker (filter + jump)
-      abstract def replay_subtab_count : Int32             # open replay session count (gates the search menu entry)
+      abstract def replay_selected : Nil       # load History's selection into Replay
+      abstract def replay_new : Nil            # open a blank, hand-authored replay request
+      abstract def replay_send : Nil           # resend the (edited) request to the target
+      abstract def replay_find_subtab : Nil    # open the sub-tab search picker (filter + jump)
+      abstract def replay_subtab_count : Int32 # open replay session count (gates the search menu entry)
+      # Generic sub-tab search — the Replay picker generalised to Fuzzer/Notes/Convert so
+      # jumping to a sub-tab never depends on the fragile Ctrl+digit chord (which many
+      # terminals can't deliver). Operate on the active tab; count gates the menu entry.
+      abstract def subtab_search_open : Nil                # open the sub-tab search picker for the active tab
+      abstract def subtab_search_count : Int32             # active tab's open sub-tab count (gates the search entry)
       abstract def replay_rename_subtab : Nil              # open the rename prompt for the active sub-tab
       abstract def replay_close_subtab : Nil               # close the active sub-tab (confirm-gated)
       abstract def replay_duplicate_subtab : Nil           # clone the active sub-tab's content into a new sibling
@@ -93,30 +98,30 @@ module Gori
       abstract def replay_read_mode? : Bool   # focused pane is READ (y/copy verbs gate on this)
 
       # fuzzer workbench (run/stop/marking handled inline; these power the palette + cross-tab)
-      abstract def fuzz_selected : Nil        # send History's selection to the Fuzzer tab
-      abstract def fuzz_from_replay : Nil     # turn the current Replay request into a fuzz template
-      abstract def fuzz_run : Nil             # start the fuzz run
-      abstract def fuzz_stop : Nil            # stop the running fuzz
-      abstract def fuzz_new : Nil             # open a blank fuzz session
-      abstract def fuzz_automark : Nil        # auto-mark every request parameter
-      abstract def fuzz_attach_chain : Nil    # open the chain-edit prompt for the marker at the template cursor
-      abstract def fuzz_list_paste : Nil      # open the payload-set editor pre-seeded to a List (multi-line, one value per line)
-      abstract def fuzz_clear_marks : Nil     # strip all §…§ markers (and their chains) from the template
+      abstract def fuzz_selected : Nil           # send History's selection to the Fuzzer tab
+      abstract def fuzz_from_replay : Nil        # turn the current Replay request into a fuzz template
+      abstract def fuzz_run : Nil                # start the fuzz run
+      abstract def fuzz_stop : Nil               # stop the running fuzz
+      abstract def fuzz_new : Nil                # open a blank fuzz session
+      abstract def fuzz_automark : Nil           # auto-mark every request parameter
+      abstract def fuzz_attach_chain : Nil       # open the chain-edit prompt for the marker at the template cursor
+      abstract def fuzz_list_paste : Nil         # open the payload-set editor pre-seeded to a List (multi-line, one value per line)
+      abstract def fuzz_clear_marks : Nil        # strip all §…§ markers (and their chains) from the template
       abstract def fuzzer_rename_subtab : Nil    # open the rename prompt for the active sub-tab
       abstract def fuzzer_close_subtab : Nil     # close the active sub-tab (confirm-gated)
       abstract def fuzzer_duplicate_subtab : Nil # clone the active sub-tab's content into a new sibling
-      abstract def fuzzer_copy : Nil          # copy selection or current line (READ panes)
-      abstract def fuzzer_copy_all : Nil      # copy the whole focused pane text
-      abstract def fuzzer_read_mode? : Bool   # focused pane is READ (y/copy verbs gate on this)
+      abstract def fuzzer_copy : Nil             # copy selection or current line (READ panes)
+      abstract def fuzzer_copy_all : Nil         # copy the whole focused pane text
+      abstract def fuzzer_read_mode? : Bool      # focused pane is READ (y/copy verbs gate on this)
 
       # param miner (cross-tab seeds open a config popup, then mining runs in background)
-      abstract def mine_selected : Nil           # mine History's selected flow (opens the config popup)
-      abstract def mine_from_replay : Nil        # mine the current Replay request
-      abstract def mine_run : Nil                # re-run mining for the focused Miner session
-      abstract def mine_stop : Nil               # stop the running mine
-      abstract def miner_duplicate_subtab : Nil  # clone the active miner sub-tab's content into a new sibling
+      abstract def mine_selected : Nil            # mine History's selected flow (opens the config popup)
+      abstract def mine_from_replay : Nil         # mine the current Replay request
+      abstract def mine_run : Nil                 # re-run mining for the focused Miner session
+      abstract def mine_stop : Nil                # stop the running mine
+      abstract def miner_duplicate_subtab : Nil   # clone the active miner sub-tab's content into a new sibling
       abstract def miner_finding_selected? : Bool # a finding is selected in the focused miner session
-      abstract def mine_replay_selected : Nil    # send the selected miner finding to Replay
+      abstract def mine_replay_selected : Nil     # send the selected miner finding to Replay
 
       # sitemap tree
       abstract def sitemap_move(delta : Int32) : Nil
@@ -133,8 +138,8 @@ module Gori
       abstract def scope_toggle_lens : Nil # toggle the scope display lens on/off (filters History/Sitemap)
 
       # scope rule editing (Project tab SCOPE pane — also drives its "space" action menu)
-      abstract def scope_add_rule : Nil  # open the SCOPE rule popup to add a rule
-      abstract def scope_edit_rule : Nil # open the SCOPE rule popup to edit the selected rule
+      abstract def scope_add_rule : Nil        # open the SCOPE rule popup to add a rule
+      abstract def scope_edit_rule : Nil       # open the SCOPE rule popup to edit the selected rule
       abstract def scope_delete_rule : Nil     # remove the selected rule
       abstract def scope_rule_selected? : Bool # a scope rule is selected (gates edit/delete in the menu)
 
@@ -238,32 +243,32 @@ module Gori
 
       # convert: the encode/decode/hash workbench (sub-tab + output actions; the body's
       # text editing + focus nav stay inline, these power the space menu + palette)
-      abstract def convert_new : Nil               # open a fresh blank conversion sub-tab
-      abstract def convert_close : Nil             # close the active conversion sub-tab (keeps ≥1)
-      abstract def convert_rename_subtab : Nil     # open the rename prompt for the active sub-tab
-      abstract def convert_duplicate_subtab : Nil  # clone the active conversion into a new sibling
-      abstract def convert_clear : Nil          # clear the current input + chain
-      abstract def convert_copy : Nil           # copy the entire current output to the clipboard
-      abstract def convert_copy_selection : Nil # copy selection from INPUT/OUTPUT (READ)
-      abstract def convert_copy_all : Nil       # copy the whole focused pane text (space menu / palette fallback)
-      abstract def convert_read_mode? : Bool    # INPUT READ or OUTPUT pane (gates y/copy)
-      abstract def convert_cycle_mode : Nil     # cycle the output display (text/hex/base64)
-      abstract def convert_save : Nil           # save the current chain by name (in-body prompt)
-      abstract def convert_load : Nil           # load a saved chain by name (in-body prompt)
+      abstract def convert_new : Nil              # open a fresh blank conversion sub-tab
+      abstract def convert_close : Nil            # close the active conversion sub-tab (keeps ≥1)
+      abstract def convert_rename_subtab : Nil    # open the rename prompt for the active sub-tab
+      abstract def convert_duplicate_subtab : Nil # clone the active conversion into a new sibling
+      abstract def convert_clear : Nil            # clear the current input + chain
+      abstract def convert_copy : Nil             # copy the entire current output to the clipboard
+      abstract def convert_copy_selection : Nil   # copy selection from INPUT/OUTPUT (READ)
+      abstract def convert_copy_all : Nil         # copy the whole focused pane text (space menu / palette fallback)
+      abstract def convert_read_mode? : Bool      # INPUT READ or OUTPUT pane (gates y/copy)
+      abstract def convert_cycle_mode : Nil       # cycle the output display (text/hex/base64)
+      abstract def convert_save : Nil             # save the current chain by name (in-body prompt)
+      abstract def convert_load : Nil             # load a saved chain by name (in-body prompt)
 
       # notes: the multi-note scratchpad (sub-tab actions; the body's text editing
       # stays inline, these power the space menu reachable from the sub-tab strip)
       abstract def notes_new : Nil              # open a fresh blank note sub-tab
       abstract def notes_close : Nil            # close the active note sub-tab (keeps ≥1)
       abstract def notes_duplicate_subtab : Nil # clone the active note's text into a new sibling
-      abstract def notes_copy : Nil        # copy selection or current line (READ mode)
-      abstract def notes_copy_all : Nil    # copy the entire current note to the clipboard
-      abstract def notes_read_mode? : Bool # READ vs INS (gates y/copy verbs)
-      abstract def notes_clear : Nil       # clear the current note's text
-      abstract def notes_edit : Nil        # open the current note in the external editor
-      abstract def notes_goto : Nil        # open the go-to-line prompt
-      abstract def notes_find : Nil        # open the find-in-note prompt
-      abstract def notes_links : Nil       # open the links overlay for the current note
+      abstract def notes_copy : Nil             # copy selection or current line (READ mode)
+      abstract def notes_copy_all : Nil         # copy the entire current note to the clipboard
+      abstract def notes_read_mode? : Bool      # READ vs INS (gates y/copy verbs)
+      abstract def notes_clear : Nil            # clear the current note's text
+      abstract def notes_edit : Nil             # open the current note in the external editor
+      abstract def notes_goto : Nil             # open the go-to-line prompt
+      abstract def notes_find : Nil             # open the find-in-note prompt
+      abstract def notes_links : Nil            # open the links overlay for the current note
 
       # project: description pane copy actions (READ mode on the DESCRIPTION card)
       abstract def project_desc_read_mode? : Bool

--- a/src/gori/verbs/convert.cr
+++ b/src/gori/verbs/convert.cr
@@ -65,6 +65,15 @@ module Gori
       r.register Verb::Definition.new(
         "convert.load", "Load a saved chain", "Load a previously saved chain spec by name",
         Verb::Scope::Convert, available: in_convert, mnemonic: 'o', section: :tab) { |ctx| ctx.convert_load; nil }
+
+      # Search-and-jump across conversion sub-tabs (section :tab — like replay.find-subtab)
+      # so jumping never needs Ctrl+digit. 'f' (find) since 's'/'o' are taken here by
+      # Save/Load in the same :tab group.
+      r.register Verb::Definition.new(
+        "convert.find-subtab", "Search sub-tabs", "Filter the open conversions and jump to one",
+        Verb::Scope::Convert,
+        available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :convert && ctx.subtab_search_count >= 2 },
+        mnemonic: 'f', section: :tab) { |ctx| ctx.subtab_search_open; nil }
     end
   end
 end

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -312,6 +312,16 @@ module Gori
         [Verb::Chord.new("n", ctrl: true)],
         available: in_fuzzer, mnemonic: 'n') { |ctx| ctx.fuzz_new; nil }
 
+      # Search-and-jump across open fuzz sessions — the Replay find-subtab picker,
+      # generalised (section :tab so it shows in the tab-bar space menu, like replay).
+      # Gives Fuzzer a sub-tab jump that doesn't depend on Ctrl+digit. 'f' (find) since
+      # 's' is taken by fuzz.stop in Fuzzer COMMON.
+      r.register Verb::Definition.new(
+        "fuzz.find-subtab", "Search sub-tabs", "Filter the open fuzz sessions and jump to one",
+        Verb::Scope::Fuzzer,
+        available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :fuzzer && ctx.subtab_search_count >= 2 },
+        mnemonic: 'f', section: :tab) { |ctx| ctx.subtab_search_open; nil }
+
       # Sub-tab rename/close — mirrors replay.rename-subtab/replay.close-subtab above:
       # the strip's raw `r` rename / ^W close, promoted to verbs so :subtab isn't
       # empty. 'e'/'w' are free in COMMON ∪ :subtab (Fuzzer COMMON keys: r/s/y/k/u/S/v).

--- a/src/gori/verbs/notes.cr
+++ b/src/gori/verbs/notes.cr
@@ -23,6 +23,15 @@ module Gori
         "notes.duplicate-subtab", "Duplicate subtab", "Open a new note sub-tab with the same text",
         Verb::Scope::Notes, available: in_notes, mnemonic: 'd', section: :subtab) { |ctx| ctx.notes_duplicate_subtab; nil }
 
+      # Search-and-jump across note sub-tabs (section :tab, tab-bar space menu — like
+      # replay.find-subtab). A jump path that doesn't need Ctrl+digit. 's' is free in
+      # Notes COMMON ∪ :tab.
+      r.register Verb::Definition.new(
+        "notes.find-subtab", "Search sub-tabs", "Filter the open notes and jump to one",
+        Verb::Scope::Notes,
+        available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :notes && ctx.subtab_search_count >= 2 },
+        mnemonic: 's', section: :tab) { |ctx| ctx.subtab_search_open; nil }
+
       # The single smart Copy (see replay.copy in verbs/history.cr) — copy-all is gone.
       in_notes_read = ->(ctx : Verb::ExecContext) { ctx.current_tab == :notes && ctx.notes_read_mode? }
       r.register Verb::Definition.new(


### PR DESCRIPTION
## Why

Keyboard-input review of gori for **standard keyboards / laptops / macOS Terminal.app**. The tool was built on **macOS + HHKB** (Ctrl on the home row, Fn-arrows), which hides several gaps that bite everyone else. Three areas were confirmed already-good and left alone: no Alt/Option chords, `§` markers inserted via `^T`/`^A` (never typed), destructive data actions already confirm-gated, and full arrow+j/k parity on the main content tabs.

## What changed

- **`notes.clear` confirm** — a one-key `c` wiped the note **and** cleared the undo stack (`TextArea#set_text` drops `@undo_stack`), so it was unrecoverable. Now `danger:true` confirm-gated (skipped when the note is blank) — matching every other destructive action, which was already gated.
- **List/detail page navigation** — new `TabController#body_scroll(delta)` hook + Runner `page_nav_delta`. `PageUp`/`PageDown` step one screenful; `Home`/`End` jump to top/bottom. Wired for History (list + detail), Sitemap, Findings, Prism (list + detail), and Help. Previously every long list/pane was line-by-line (mouse wheel only).
- **`j`/`k` in overlays** — the space menu (mnemonic wins; `j`/`k` fall back to nav only when unbound, so `k` no longer fires *link-to-finding* or dismisses the menu), plus ChoicePicker, LinksOverlay, BrowserPicker, and the Hosts/Env editors. Type-ahead pickers left untouched (letters are filter text there).
- **`find-subtab` for Fuzzer/Notes/Convert** — generalised Replay's `SubtabPicker` (`TabController#subtab_search_rows`/`#subtab_count`, Runner `subtab_search_open`, active-tab jump on commit) so jumping to a sub-tab no longer depends on the `Ctrl+digit` chord, which many terminals can't deliver.

## Verification

- `crystal spec` → **1477 examples, 0 failures**
- `ameba` → no new offenses (runner.cr 34 at HEAD = 34 now)
- `crystal tool format` clean
- tmux end-to-end: page-nav (End→bottom, Home→top, PageDown one screenful), the clear confirm (+ cancel preserves text), the find-subtab picker (filter + jump), and space-menu / Env-overlay `j`/`k`.

## Deferred (documented follow-ups, not in this PR)

- `^1`–`^9` sub-tab jump is undeliverable on non-Kitty terminals (Terminal.app, default iTerm2, …) — gori's `\e[>17u` omits the flag that would surface `Ctrl+digit`. find-subtab is now the portable path everywhere; the chord itself should be replaced (needs a terminal-matrix test).
- No word-wise cursor motion; `Ctrl+Left/Right` silently does a 1-char move.
- Readline chords hijacked in editors (`^A`/`^B`/`^W`/`^K`/`^D`) — low priority (Home/End/Delete all work).
- Fuzzer/Miner results + Findings detail page-nav (their `handle_body_key` consumes page keys; multi-pane focus needs in-controller handling).