### PR TITLE
docs: core brand copy — "Sit in the loop." tagline across README & docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,30 @@
 # 𝓰𝓸𝓻𝓲
 
-TODO: Write a description here
+> **Sit in the loop.**
+> A fast, keyboard-driven HTTP intercepting proxy and web-hacking toolkit for the terminal.
+
+**gori** (고리 — Korean for *ring, link, loop*) is a keyboard-driven HTTP/HTTPS intercepting
+proxy and web-hacking workbench that runs entirely in your terminal. Point a browser or client
+at it and gori sits in the loop between you and your target, recording every request and
+response as a *flow*. From there it is your pentest workbench: intercept and edit traffic in
+flight, replay and fuzz requests, mine hidden parameters, and scan for vulnerabilities —
+across HTTP/1.1, HTTP/2, WebSocket, gRPC, and Server-Sent Events, with JWT / SAML / GraphQL
+decoded inline.
+
+Everything the TUI does is also a `gori run` subcommand and a Model Context Protocol (MCP)
+tool, so scripts and AI agents can drive the same engagement.
+
+> ⚠️ **Test only what you are authorized to.** gori is for penetration testing and security
+> research against systems you own or have explicit permission to assess.
+
+## Features
+
+- **Intercepting proxy & History** — capture HTTP/1.1, HTTP/2, WebSocket, gRPC, and SSE; hold, edit, forward, or drop traffic in flight.
+- **Replay & Fuzzer** — a request workbench (incl. WebSocket & gRPC) and an Intruder-style fuzzer with four attack modes.
+- **Prism scanner & Param Miner** — passive and active vulnerability scanning plus hidden-parameter discovery, triaged into Findings.
+- **Convert & Comparer** — a chained encode / decode / hash pipeline and side-by-side flow diffing.
+- **Keyboard-first** — a command palette (`Ctrl-P`) and a context space menu (`Space`) reach every action; rebindable hotkeys and colour themes.
+- **Headless & scriptable** — drive the same project from `gori run` or an MCP-connected agent.
 
 ## Installation
 
@@ -32,7 +56,32 @@ shards build -Dwithout_native_codecs
 
 ## Usage
 
-TODO: Write usage instructions here
+Start the proxy and open the TUI — no subcommand needed:
+
+```bash
+gori
+```
+
+The proxy listens on `127.0.0.1:8070` by default, and a short first-run wizard picks the bind
+address and theme. To intercept HTTPS, trust gori's root CA — the quickest path is the
+palette's **Open browser** (`Ctrl-P`), which launches a browser already trusted and proxied.
+Captured traffic lands in **History**; press `Ctrl-P` for the command palette or `Space` for
+context actions.
+
+Choose a different bind address or port:
+
+```bash
+gori --listen 0.0.0.0 --port 8080
+```
+
+Run non-interactively, or expose gori to an agent:
+
+```bash
+gori run --help    # non-interactive subcommands over the same project
+gori mcp           # Model Context Protocol server (stdio)
+```
+
+See the [documentation](docs/) for the full guide, or open the **Help** tab in the app.
 
 ## Development
 
@@ -47,7 +96,7 @@ use `-Dwithout_native_codecs`.
 
 ## Contributing
 
-1. Fork it (<https://github.com/your-github-user/gori/fork>)
+1. Fork it (<https://github.com/hahwul/gori/fork>)
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
@@ -55,4 +104,4 @@ use `-Dwithout_native_codecs`.
 
 ## Contributors
 
-- [hahwul](https://github.com/your-github-user) - creator and maintainer
+- [hahwul](https://github.com/hahwul) - creator and maintainer

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,5 +1,5 @@
 title = "gori"
-description = "A fast, keyboard-driven HTTP intercepting proxy and web-security toolkit for the terminal."
+description = "Sit in the loop — a fast, keyboard-driven HTTP intercepting proxy and web-hacking toolkit for the terminal."
 base_url = "http://localhost:3000"
 [plugins]
 processors = ["markdown"]

--- a/docs/content/getting-started/_index.md
+++ b/docs/content/getting-started/_index.md
@@ -16,7 +16,7 @@ Welcome to gori. This section takes you from a clean machine to a live proxy ses
 
 ## What Is gori?
 
-gori is a keyboard-driven HTTP/HTTPS **intercepting proxy** and web-security toolkit that runs entirely in your terminal. It sits between your client and the server, records every request/response as a *flow*, and gives you a workbench to inspect, replay, fuzz, and scan that traffic.
+gori (고리 — Korean for *ring, link, loop*) is a keyboard-driven HTTP/HTTPS **intercepting proxy** and web-hacking toolkit that runs entirely in your terminal. It sits *in the loop* between your client and the target, records every request/response as a *flow*, and gives you a pentest workbench to inspect, replay, fuzz, and scan that traffic — a full assessment without leaving the shell.
 
 It understands **HTTP/1.1, HTTP/2, WebSocket, gRPC, and Server-Sent Events**, and decodes common formats like JWT, SAML, and GraphQL inline. Everything you can do in the TUI is also reachable non-interactively through `gori run` and the built-in [MCP server](/guide/mcp/), so agents and scripts can drive the same project.
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,6 +1,8 @@
 +++
 title = "gori"
-description = "A fast, keyboard-driven HTTP intercepting proxy and web-security toolkit for the terminal."
+description = "Sit in the loop — a fast, keyboard-driven HTTP intercepting proxy and web-hacking toolkit for the terminal."
 +++
 
-gori is a terminal HTTP intercepting proxy for web-security testing — capture, intercept, replay, fuzz, and scan without leaving the shell.
+**Sit in the loop.**
+
+gori (고리 — Korean for *ring, link, loop*) is a keyboard-driven HTTP/HTTPS intercepting proxy and web-hacking workbench that runs entirely in your terminal. It sits in the loop between your client and the target, turns every request into a pentest surface, and lets you capture, intercept, replay, fuzz, and scan — without leaving the shell.


### PR DESCRIPTION
## Summary

Establishes gori's central copywriting concept and carries it consistently through the README and docs sources.

**Core concept — "In the loop / 고리":** gori (고리 = Korean for *ring, link, loop*, echoed by the orbital-ring logo) is the loop between client and server, and the work loop of capture → replay → fuzz → scan. The purpose is framed explicitly as **web-hacking / pentesting**.

- **Tagline:** `Sit in the loop.`
- **One-liner:** `A fast, keyboard-driven HTTP intercepting proxy and web-hacking toolkit for the terminal.`

## Changes

- **README.md** — replace the `TODO` description with tagline + brand story + feature list + authorized-testing-only note; fill the `Usage` `TODO` with real instructions (`gori`, default `127.0.0.1:8070`, `--listen/--port`, `gori run`, `gori mcp`); fix stale template repo URLs (`your-github-user` → `hahwul`).
- **docs/config.toml** — site-wide meta/OG `description`.
- **docs/content/index.md** — home hero + front-matter description.
- **docs/content/getting-started/_index.md** — "What Is gori?" intro adopts the loop metaphor + pentest voice.

`docs/public/` is build output and regenerates from these sources, so it is intentionally untouched.