### PR TITLE
fix(security): lock gori data tree to 0700 / capture DBs to 0600

### DIFF
--- a/src/gori/paths.cr
+++ b/src/gori/paths.cr
@@ -62,15 +62,29 @@ module Gori
 
     def self.ensure_dirs : Nil
       ensure_dir(home_dir)
+      ensure_dir(projects_dir) # lock the projects ROOT too (registry only mkdir's leaves)
       ensure_dir(wordlists_dir)
     end
 
-    # Race-tolerant `mkdir -p`: two gori instances can start simultaneously and
-    # both create a fresh dir — one wins the mkdir, the other must not crash.
+    # gori's tree holds captured traffic (per-project DBs), the CA private key, and
+    # settings.json — secrets other local users on a shared host must not read. So
+    # every gori dir is owner-only 0700, NOT left at the umask default (a fresh
+    # `~/.gori` was 0755 = world-traversable, exposing world-readable project DBs
+    # underneath). 0700 has no group/other bits for any umask to strip, so
+    # `mkdir_p(mode)` yields it exactly; the explicit chmod additionally tightens a
+    # pre-existing 0755 dir from an older install. Mirrors cert_authority.cr locking
+    # the CA key to 0600 rather than trusting umask.
+    DIR_MODE = 0o700
+
+    # Race-tolerant `mkdir -p` at 0700 (see DIR_MODE): two gori instances can start
+    # simultaneously and both create a fresh dir — one wins the mkdir, the other must
+    # not crash.
     def self.ensure_dir(path : String) : Nil
-      Dir.mkdir_p(path)
+      Dir.mkdir_p(path, DIR_MODE)
+      File.chmod(path, DIR_MODE) rescue nil # tighten a pre-0700 dir from an older install
     rescue File::AlreadyExistsError
       # created concurrently by another instance — it exists now, fine
+      File.chmod(path, DIR_MODE) rescue nil
     end
   end
 end

--- a/src/gori/project_registry.cr
+++ b/src/gori/project_registry.cr
@@ -70,7 +70,7 @@ module Gori
       raise Gori::Error.new("invalid project name") if slug.empty?
       slug = unique_slug(slug, display) # don't merge into a DIFFERENT project that slugifies alike
       dir = File.join(@root, slug)
-      FileUtils.mkdir_p(dir)
+      Paths.ensure_dir(dir) # 0700 — the project dir holds a DB of captured secrets
       # Persist the verbatim display name so a later `list` shows "My Project", not
       # the lossy slug "my-project".
       File.write(File.join(dir, NAME_FILE), display) rescue nil
@@ -110,7 +110,7 @@ module Gori
     # A throwaway workspace, deleted when its session closes.
     def temp(token : String) : Project
       dir = File.join(@root, "#{TEMP_PREFIX}#{token}")
-      FileUtils.mkdir_p(dir)
+      Paths.ensure_dir(dir) # 0700 — even a throwaway workspace holds captured secrets
       Project.new("temp", File.join(dir, Project::DB_FILE), ephemeral: true)
     end
 

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -127,6 +127,7 @@ module Gori
                   retention_flows : Int32 = RETENTION_DEFAULT) : Store
       url = "sqlite3:#{path}?journal_mode=wal&synchronous=normal&busy_timeout=5000"
       db = DB.open(url)
+      harden_permissions(path)
       # Make REGEXP byte-safe on every connection before any query runs (so a binary
       # body can't crash a `body~`/`header~` scan or a regex scope rule). See SafeRegexp.
       SafeRegexp.install(db)
@@ -138,6 +139,18 @@ module Gori
       # already at/after it won't re-run.
       reclaim_to_disk(db) if pre_version >= 1 && pre_version < Schema::RECLAIM_VERSION
       new(db, events, prism_events, retention_flows)
+    end
+
+    # The db (and its WAL/SHM sidecars) hold captured request/response bytes — cookies,
+    # Authorization headers, credentials in POST bodies. Lock them to 0600 so the secret
+    # store isn't world-readable even if the enclosing dir's perms are ever loosened or the
+    # file is copied out. Best-effort (the owner-only 0700 project dir is the primary guard,
+    # and it covers a sidecar SQLite may (re)create later that we can't chmod here); mirrors
+    # cert_authority.cr locking the CA key. `:memory:`/absent paths just no-op via the rescue.
+    private def self.harden_permissions(path : String) : Nil
+      File.chmod(path, 0o600) rescue nil
+      File.chmod("#{path}-wal", 0o600) rescue nil
+      File.chmod("#{path}-shm", 0o600) rescue nil
     end
 
     # Ceiling on the db we auto-VACUUM on the boot path. VACUUM rewrites the WHOLE file


### PR DESCRIPTION
## Security fix — local information disclosure

Per-project SQLite DBs hold captured request/response bytes — cookies, `Authorization` headers, credentials in POST bodies — yet were created **world-readable (0644)** under a **world-traversable `~/.gori` (0755, the umask default)**. On a shared/multi-user host any local user could read another user's captured secrets:

```
sqlite3 ~victim/.gori/projects/*/gori.db 'SELECT * FROM flows'
```

The CA private key was the *only* protected secret (`cert_authority.cr` chmod 0600); the DB — arguably the more valuable store — was left at the umask default. Confirmed on a real install: `gori.db`, `gori.db-wal`, `gori.db-shm` all `-rw-r--r--`.

## Fix

- **`Paths.ensure_dir`**: `mkdir_p(0700)` + best-effort `chmod 0700`. The explicit chmod also **migrates an existing 0755 install → 0700** on next startup. `ensure_dirs` now locks `projects_dir` too.
- **`ProjectRegistry#create` / `#temp`**: create project dirs via `Paths.ensure_dir` (0700) instead of raw `FileUtils.mkdir_p`.
- **`Store.open`**: `harden_permissions` chmods the db + `-wal` + `-shm` to 0600 (defense-in-depth; the 0700 dir is the primary guard and covers sidecars SQLite may recreate later).

The 0700 dir transitively protects `settings.json`, `gori.log`, the CA cert, and browser profiles too. `0700` has no group/other bits, so `mkdir_p(mode)` yields it exactly under any umask.

## Verification

- Fresh install → home/projects/project dirs `0700`, db+wal+shm `0600`.
- Pre-0700 (0755) install tightened to `0700` on next startup.
- `crystal build` OK; **full spec suite: 1510 examples, 0 failures**.

Found during a broader security review of the branch; no other real flaws surfaced (proxy HTTP/1 framing & smuggling defenses, h2/ws/HPACK bounds, TLS/CA, QL→SQL parameterization, terminal-escape sanitization, MCP read-only gating, and slug path-traversal were all audited and are solid; a flagged JWT/SAML ReDoS was empirically refuted — PCRE2 auto-possessification keeps it linear).