### PR TITLE
feat(rules): Match & Replace body support

### DIFF
--- a/docs/content/getting-started/quick-start.md
+++ b/docs/content/getting-started/quick-start.md
@@ -73,7 +73,7 @@ Capture and intercept still have global toggles:
 | `c` | Toggle **capture** (off = traffic passes through without being stored) |
 | `i` | Toggle **intercept** (hold matching requests for forward / drop / edit) |
 | `s` | Toggle the **scope lens** (filter views to in-scope traffic) |
-| `m` | Open **Match & Replace** (rewrite request/response heads in flight) |
+| `m` | Open **Match & Replace** (rewrite request/response heads or bodies in flight) |
 
 ## 4. Move around the TUI
 

--- a/docs/content/guide/_index.md
+++ b/docs/content/guide/_index.md
@@ -35,4 +35,4 @@ gori is organized into tabs; move between them with `[` / `]` or jump with numbe
 | **Notes** | Per-project Markdown notes |
 | **Help** | Key bindings and links |
 
-Global lenses that are not tabs: **Match & Replace** (`m`) rewrites request/response heads in flight; **capture** (`c`), **intercept** (`i`), and the **scope lens** (`s`) toggle from anywhere.
+Global lenses that are not tabs: **Match & Replace** (`m`) rewrites request/response heads and bodies in flight; **capture** (`c`), **intercept** (`i`), and the **scope lens** (`s`) toggle from anywhere.

--- a/docs/content/guide/proxy.md
+++ b/docs/content/guide/proxy.md
@@ -61,21 +61,25 @@ gori run history -q 'status:5xx host:api.example.com'
 
 ## Match & Replace
 
-Press `m` (or `Ctrl-P` → **Match & Replace**) to open the rewrite editor. Rules rewrite request or response **heads** in flight — the request line and headers — while bodies stream through unchanged.
+Press `m` (or `Ctrl-P` → **Match & Replace**) to open the rewrite editor. Rules rewrite the **head** (request line + headers) or the **body** of a request/response in flight — a literal substring swap applied to live traffic.
 
 Syntax is one line per rule:
 
 ```text
 req: User-Agent: x => User-Agent: gori
 resp: Set-Cookie => X-Stripped
+reqbody: password => hunter2
+respbody: "debug":false => "debug":true
 ```
 
 | Prefix | Target |
 |--------|--------|
 | `req:` (default) | Request head |
 | `resp:` | Response head |
+| `reqbody:` | Request body |
+| `respbody:` | Response body |
 
-An empty replacement deletes the matched text. Rules are per-project, can be toggled on/off individually, and apply as soon as you add them — no restart. Use them to strip cookies, inject headers, or normalize noisy values before traffic hits History or the scanners.
+An empty replacement deletes the matched text. A **body** rule buffers the message to rewrite it and re-syncs `Content-Length` automatically (a chunked body is de-chunked and re-framed); head rules keep the body streaming untouched. Body rewriting works on the decoded transfer form — a compressed (`Content-Encoding: gzip`/`br`/…) body isn't decompressed, so a literal pattern simply won't match it — and streaming responses (SSE, close-delimited, WebSocket upgrades) are left to stream. Rules are per-project, can be toggled on/off individually, and apply as soon as you add them — no restart. Use them to strip cookies, inject headers, or rewrite body values before traffic hits History or the scanners.
 
 ## Import
 

--- a/spec/proxy/server_spec.cr
+++ b/spec/proxy/server_spec.cr
@@ -36,6 +36,35 @@ private class StubRewriter < Gori::Proxy::HeadRewriter
   end
 end
 
+# A Match&Replace rewriter that rewrites request AND response BODIES (the entity
+# form), for exercising the buffer + re-frame path. Both replacements CHANGE the
+# body length so the test can prove Content-Length is re-synced. Heads pass through.
+private class BodyRewriter < Gori::Proxy::HeadRewriter
+  def rewrite_request(head : Bytes) : Bytes
+    head
+  end
+
+  def rewrite_response(head : Bytes) : Bytes
+    head
+  end
+
+  def rewrites_request_body? : Bool
+    true
+  end
+
+  def rewrites_response_body? : Bool
+    true
+  end
+
+  def rewrite_request_body(entity : Bytes) : Bytes
+    String.new(entity).gsub("ping", "PONG!").to_slice
+  end
+
+  def rewrite_response_body(entity : Bytes) : Bytes
+    String.new(entity).gsub("SECRET", "[HIDDEN]").to_slice
+  end
+end
+
 # Reads from a socket until `marker` appears (or the read times out / EOFs),
 # returning everything read so far. Used to frame one response off a keep-alive
 # connection without consuming the next one.
@@ -64,6 +93,36 @@ private def start_origin(body : String, seen : Channel(String)) : Int32
       request_line = head ? String.new(head).lines.first : ""
       seen.send(request_line)
       conn << "HTTP/1.1 200 OK\r\nContent-Length: #{body.bytesize}\r\nConnection: close\r\n\r\n" << body
+      conn.flush
+      conn.close
+    end
+  end
+  port
+end
+
+# An origin that reads the request BODY (per its framing) and reports it on `seen_body`,
+# then replies with `resp_body`. `chunked` frames the reply as Transfer-Encoding: chunked
+# (one chunk) so the response-body M&R path exercises de-chunk → re-frame.
+private def start_body_origin(resp_body : String, seen_body : Channel(String), chunked : Bool = false) : Int32
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    while conn = origin.accept?
+      head = Gori::Proxy::Codec::Http1.read_head(conn)
+      if head
+        req = Gori::Proxy::Codec::Http1.parse_request_head(head)
+        framing, len = Gori::Proxy::Codec::Body.request_framing(req)
+        body = Gori::Proxy::Codec::Body.read(conn, framing, len)
+        seen_body.send(body ? String.new(body) : "")
+      else
+        seen_body.send("")
+      end
+      if chunked
+        conn << "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n"
+        conn << resp_body.bytesize.to_s(16) << "\r\n" << resp_body << "\r\n0\r\n\r\n"
+      else
+        conn << "HTTP/1.1 200 OK\r\nContent-Length: #{resp_body.bytesize}\r\nConnection: close\r\n\r\n" << resp_body
+      end
       conn.flush
       conn.close
     end
@@ -608,6 +667,73 @@ describe Gori::Proxy::Server do
 
     sink.requests.first.target.should eq("/hi")                    # capture = sent (modified) bytes
     String.new(sink.responses.first.head).should contain("200 YO") # capture = sent (modified) bytes
+  end
+
+  it "rewrites request/response BODIES and re-frames Content-Length" do
+    seen_body = Channel(String).new(1)
+    done = Channel(Nil).new(1)
+    origin_port = start_body_origin("the SECRET value", seen_body)
+
+    sink = RecordingSink.new(done)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink, rewriter: BodyRewriter.new)
+    proxy.start
+
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    body = "ping-data" # 9 bytes; "ping" → "PONG!" makes it 10
+    client << "POST /submit HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\nContent-Length: #{body.bytesize}\r\n\r\n" << body
+    client.flush
+    response = client.gets_to_end
+    client.close
+
+    done.receive
+    proxy.stop
+
+    # The origin read EXACTLY the rewritten body — proof the forwarded Content-Length
+    # was re-synced to the new length (10), else it would frame 9 bytes and stall/misread.
+    seen_body.receive.should eq("PONG!-data")
+
+    # The client got the rewritten response body with a re-synced Content-Length (18).
+    response.should contain("the [HIDDEN] value")
+    response.should contain("Content-Length: 18")
+    response.should_not contain("SECRET")
+
+    # Capture reflects the sent (rewritten) bytes on both sides.
+    req = sink.requests.first
+    String.new(req.body.not_nil!).should eq("PONG!-data")
+    String.new(req.head).should contain("Content-Length: 10")
+    resp = sink.responses.first
+    resp.status.should eq(200)
+    resp.state.should eq(Gori::Store::FlowState::Complete)
+    String.new(resp.body.not_nil!).should eq("the [HIDDEN] value")
+    String.new(resp.head).should contain("Content-Length: 18")
+  end
+
+  it "de-chunks, rewrites, and re-frames a chunked response body to Content-Length" do
+    seen_body = Channel(String).new(1)
+    done = Channel(Nil).new(1)
+    origin_port = start_body_origin("a SECRET here", seen_body, chunked: true)
+
+    sink = RecordingSink.new(done)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink, rewriter: BodyRewriter.new)
+    proxy.start
+
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    client << "GET /page HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\n\r\n"
+    client.flush
+    response = client.gets_to_end
+    client.close
+
+    done.receive
+    proxy.stop
+    seen_body.receive # drain
+
+    # The chunked body was de-chunked, rewritten, and re-framed as Content-Length (15) —
+    # the client sees no chunk framing and no Transfer-Encoding.
+    response.should contain("a [HIDDEN] here")
+    response.should contain("Content-Length: 15")
+    response.should_not contain("Transfer-Encoding")
+    response.should_not contain("SECRET")
+    String.new(sink.responses.first.body.not_nil!).should eq("a [HIDDEN] here")
   end
 
   it "holds a request via the interceptor and forwards an edited version" do

--- a/spec/proxy/tls/tunnel_spec.cr
+++ b/spec/proxy/tls/tunnel_spec.cr
@@ -113,7 +113,7 @@ describe Gori::Proxy::Tls::Tunnel do
       ca = CertAuthority.load_or_create(dir)
       store = Gori::Store.open(dbpath)
       rules = Gori::Rules.load(store.not_nil!)
-      rules.add(Gori::Store::RuleTarget::Request, "/secret", "/rewritten") # one enabled rule → active
+      rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head, "/secret", "/rewritten") # one enabled rule → active
       rules.active?.should be_true
 
       sink = RecordingSink.new(done)

--- a/spec/rules_spec.cr
+++ b/spec/rules_spec.cr
@@ -26,8 +26,8 @@ describe Gori::Rules do
   it "rewrites only the targeted side, and only enabled rules" do
     with_store do |store|
       rules = Gori::Rules.load(store)
-      rules.add(Gori::Store::RuleTarget::Request, "Host: acme.test", "Host: evil.test")
-      rules.add(Gori::Store::RuleTarget::Response, "Server: nginx", "Server: gori")
+      rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head, "Host: acme.test", "Host: evil.test")
+      rules.add(Gori::Store::RuleTarget::Response, Gori::Store::RulePart::Head, "Server: nginx", "Server: gori")
       rules.active?.should be_true
       rules.enabled_count.should eq(2)
 
@@ -42,10 +42,42 @@ describe Gori::Rules do
     end
   end
 
+  it "keeps head and body rules on separate seams" do
+    with_store do |store|
+      rules = Gori::Rules.load(store)
+      rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Body, "password", "hunter2")
+      rules.add(Gori::Store::RuleTarget::Response, Gori::Store::RulePart::Body, "SECRET", "REDACT")
+
+      rules.rewrites_request_body?.should be_true
+      rules.rewrites_response_body?.should be_true
+
+      # a body rule never touches the head seam...
+      head = "POST / HTTP/1.1\r\nX-Note: password\r\n\r\n".to_slice
+      rules.rewrite_request(head).should eq(head)
+      # ...and rewrites the entity body
+      String.new(rules.rewrite_request_body("user=admin&password=x".to_slice)).should eq("user=admin&hunter2=x")
+      String.new(rules.rewrite_response_body("the SECRET value".to_slice)).should eq("the REDACT value")
+
+      # each side's body rule stays on its own side
+      rules.rewrite_response_body("password".to_slice).should eq("password".to_slice)
+    end
+  end
+
+  it "reports no body rewrite when only head rules exist" do
+    with_store do |store|
+      rules = Gori::Rules.load(store)
+      rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head, "A", "B")
+      rules.rewrites_request_body?.should be_false
+      rules.rewrites_response_body?.should be_false
+      body = "A body with A".to_slice
+      rules.rewrite_request_body(body).should eq(body) # inert fast path
+    end
+  end
+
   it "returns the same bytes when nothing matches (P7)" do
     with_store do |store|
       rules = Gori::Rules.load(store)
-      rules.add(Gori::Store::RuleTarget::Request, "absent", "x")
+      rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head, "absent", "x")
       head = "GET / HTTP/1.1\r\nHost: a\r\n\r\n".to_slice
       rules.rewrite_request(head).should eq(head)
     end
@@ -54,18 +86,21 @@ describe Gori::Rules do
   it "persists, toggles, and removes rules across reload" do
     with_store do |store|
       r1 = Gori::Rules.load(store)
-      r1.add(Gori::Store::RuleTarget::Request, "A", "B")
+      r1.add(Gori::Store::RuleTarget::Response, Gori::Store::RulePart::Body, "A", "B")
       id = r1.rules.first.id
 
       r2 = Gori::Rules.load(store)
       r2.rules.size.should eq(1)
       r2.rules.first.enabled?.should be_true
-      r2.rules.first.target.should eq(Gori::Store::RuleTarget::Request)
+      r2.rules.first.target.should eq(Gori::Store::RuleTarget::Response)
+      r2.rules.first.part.should eq(Gori::Store::RulePart::Body)
+      r2.rewrites_response_body?.should be_true
 
       r2.toggle(id)
       r2.active?.should be_false # disabled → lens inert
-      head = "A".to_slice
-      r2.rewrite_request(head).should eq(head)
+      r2.rewrites_response_body?.should be_false
+      body = "A".to_slice
+      r2.rewrite_response_body(body).should eq(body)
       Gori::Rules.load(store).rules.first.enabled?.should be_false
 
       r2.remove(id)

--- a/spec/store/entity_links_spec.cr
+++ b/spec/store/entity_links_spec.cr
@@ -65,13 +65,14 @@ describe "entity_links (V21)" do
         "INSERT INTO findings (id, created_at, updated_at, title, severity, host, flow_id, notes, status) " \
         "VALUES (1, 5, 5, 'legacy', 2, 'a.test', ?, '', 0)", fid)
       store.@db.exec("DROP TABLE entity_links")
-      store.@db.exec("ALTER TABLE replays DROP COLUMN mark_transform") # V22 (added a column to a pre-V17 table)
-      store.@db.exec("DROP INDEX idx_flows_sizes")                     # V23
-      store.@db.exec("DROP INDEX idx_ws_messages_replay")              # V26
-      store.@db.exec("ALTER TABLE ws_messages DROP COLUMN replay_id")  # V26
-      store.@db.exec("DROP INDEX idx_h2_frames_created")               # V27
+      store.@db.exec("ALTER TABLE replays DROP COLUMN mark_transform")        # V22 (added a column to a pre-V17 table)
+      store.@db.exec("DROP INDEX idx_flows_sizes")                            # V23
+      store.@db.exec("DROP INDEX idx_ws_messages_replay")                     # V26
+      store.@db.exec("ALTER TABLE ws_messages DROP COLUMN replay_id")         # V26
+      store.@db.exec("DROP INDEX idx_h2_frames_created")                      # V27
       store.@db.exec("ALTER TABLE prism_issues DROP COLUMN sample_replay_id") # V28
-      store.@db.exec("DROP TABLE prism_suppressions")                  # V29
+      store.@db.exec("DROP TABLE prism_suppressions")                         # V29
+      store.@db.exec("ALTER TABLE match_rules DROP COLUMN part")              # V30
       store.@db.exec("PRAGMA user_version = 20")
       store.close
 

--- a/spec/store/store_spec.cr
+++ b/spec/store/store_spec.cr
@@ -51,6 +51,7 @@ describe Gori::Store do
       store.@db.exec("ALTER TABLE ws_messages DROP COLUMN replay_id")  # V26
       store.@db.exec("DROP INDEX idx_h2_frames_created")               # V27
       store.@db.exec("DROP TABLE prism_suppressions")                  # V29
+      store.@db.exec("ALTER TABLE match_rules DROP COLUMN part")       # V30
       store.@db.exec("PRAGMA user_version = 17")
       store.close
 

--- a/spec/store_extras_spec.cr
+++ b/spec/store_extras_spec.cr
@@ -108,16 +108,19 @@ describe "Gori::Store match rules (v4)" do
   it "creates, lists, toggles, and deletes rules" do
     with_store do |store|
       store.match_rules.should be_empty
-      id = store.insert_rule(Gori::Store::RuleTarget::Response, "Server: nginx", "Server: gori")
-      store.insert_rule(Gori::Store::RuleTarget::Request, "secret", "")
+      id = store.insert_rule(Gori::Store::RuleTarget::Response, Gori::Store::RulePart::Head, "Server: nginx", "Server: gori")
+      body_id = store.insert_rule(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Body, "secret", "")
 
       rules = store.match_rules
       rules.size.should eq(2)
       first = store.match_rules.find!(&.id.==(id))
       first.target.should eq(Gori::Store::RuleTarget::Response)
+      first.part.should eq(Gori::Store::RulePart::Head)
       first.pattern.should eq("Server: nginx")
       first.replacement.should eq("Server: gori")
       first.enabled?.should be_true
+      # the body rule round-trips its part (V30 column)
+      store.match_rules.find!(&.id.==(body_id)).part.should eq(Gori::Store::RulePart::Body)
 
       store.set_rule_enabled(id, false)
       store.match_rules.find!(&.id.==(id)).enabled?.should be_false

--- a/spec/tui/rules_overlay_spec.cr
+++ b/spec/tui/rules_overlay_spec.cr
@@ -17,29 +17,38 @@ private def tmp_store(&)
 end
 
 describe Gori::Tui::RulesOverlay do
-  it "parses the `[req:|resp:] pattern => replacement` syntax" do
+  it "parses the `[req:|resp:|reqbody:|respbody:] pattern => replacement` syntax" do
     tmp_store do |store|
       ov = RulesOverlay.new(Gori::Rules.load(store))
-      ov.parse("resp: Old => New").should eq({Gori::Store::RuleTarget::Response, "Old", "New"})
-      ov.parse("req: A => B").should eq({Gori::Store::RuleTarget::Request, "A", "B"})
-      ov.parse("bare host").should eq({Gori::Store::RuleTarget::Request, "bare host", ""})
-      ov.parse("X-Token: a =>").should eq({Gori::Store::RuleTarget::Request, "X-Token: a", ""})
+      head = Gori::Store::RulePart::Head
+      body = Gori::Store::RulePart::Body
+      req = Gori::Store::RuleTarget::Request
+      resp = Gori::Store::RuleTarget::Response
+      ov.parse("resp: Old => New").should eq({resp, head, "Old", "New"})
+      ov.parse("req: A => B").should eq({req, head, "A", "B"})
+      ov.parse("bare host").should eq({req, head, "bare host", ""})
+      ov.parse("X-Token: a =>").should eq({req, head, "X-Token: a", ""})
+      # body prefixes (tested before the shorter req:/resp: so they aren't mis-split)
+      ov.parse("reqbody: pw => hunter2").should eq({req, body, "pw", "hunter2"})
+      ov.parse("respbody: SECRET =>").should eq({resp, body, "SECRET", ""})
     end
   end
 
-  it "adds a rule via typed input and renders it" do
+  it "adds a body rule via typed input and renders its tag" do
     tmp_store do |store|
       rules = Gori::Rules.load(store)
       ov = RulesOverlay.new(rules)
-      "resp: nginx => gori".each_char { |c| ov.insert(c) }
+      "respbody: nginx => gori".each_char { |c| ov.insert(c) }
       ov.submit.should be_true
       rules.rules.size.should eq(1)
       rules.rules.first.target.should eq(Gori::Store::RuleTarget::Response)
+      rules.rules.first.part.should eq(Gori::Store::RulePart::Body)
+      rules.rewrites_response_body?.should be_true
 
       backend = MemoryBackend.new(80, 14)
       ov.render(Screen.new(backend), Rect.new(0, 0, 80, 14))
       backend.contains?("MATCH & REPLACE").should be_true
-      backend.contains?("RES").should be_true
+      backend.contains?("RES B").should be_true # side + body part tag
       backend.contains?("nginx → gori").should be_true
     end
   end

--- a/src/gori/proxy/codec/content_decode.cr
+++ b/src/gori/proxy/codec/content_decode.cr
@@ -109,7 +109,8 @@ module Gori::Proxy::Codec
     # Recover the entity body from a stored h1 chunked wire form
     # ("<hex>[;ext]\r\n<data>\r\n...0\r\n"). Tolerant: stops at the terminating
     # 0-chunk, EOF, or a malformed size line, returning bytes recovered so far.
-    private def self.dechunk(body : Bytes) : Bytes
+    # Public so the Match&Replace body path can rewrite the entity, not the wire form.
+    def self.dechunk(body : Bytes) : Bytes
       out = IO::Memory.new
       pos = 0
       while pos < body.size

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -1,6 +1,7 @@
 require "uri"
 require "../codec/http1"
 require "../codec/body"
+require "../codec/content_decode"
 require "../sink"
 require "../head_rewriter"
 require "../../interceptor"
@@ -153,6 +154,15 @@ module Gori::Proxy
           created_at, started, req_framing, req_len)
       end
 
+      # Match&Replace (request body): a body rule can't stream — it must buffer the
+      # whole body to rewrite it and re-frame the head (Content-Length). Only pay this
+      # when a request-body rule is live AND there's a body to rewrite; the common path
+      # (no body rule) falls straight through to zero-buffer streaming below (P6).
+      if (rw = @rewriter) && rw.rewrites_request_body? && !req_framing.none?
+        return forward_request_rewriting_body(rw, req, sent_req, sent_head, host, port,
+          scheme, created_at, started, req_framing, req_len)
+      end
+
       # Non-hold path: stream the request body byte-for-byte (P6), unchanged.
       # Replay-safety keys on the ACTUALLY-SENT method (sent_req): an M&R rule that rewrites
       # the request line GET→POST must not leave a non-idempotent request marked retryable.
@@ -199,6 +209,13 @@ module Gori::Proxy
         record_error(sent_req, scheme, host, port, created_at, "client truncated request body")
         return false
       end
+      # Match&Replace (request body) BEFORE the human sees it — mirroring the head, which is
+      # already M&R'd into `sent_head`. A body rule re-frames to Content-Length, so re-parse
+      # the (possibly rewritten) head for the hold metadata + capture.
+      if (rw = @rewriter) && rw.rewrites_request_body?
+        sent_head, buffered = apply_body_rewrite(sent_head, buffered, req_framing) { |e| rw.rewrite_request_body(e) }
+        sent_req = Codec::Http1.parse_request_head(sent_head)
+      end
       decision = ic.hold_request(build_message(sent_head, buffered),
         method: sent_req.method, target: sent_req.target,
         host: host, port: port, scheme: scheme)
@@ -230,6 +247,39 @@ module Gori::Proxy
         body: stored, body_truncated: trunc, body_size: size))
       handle_response(upstream, req, flow_id, started, host, port, scheme,
         reused: reused, sent_head: sent_head, can_retry: retryable, sent_req: sent_req)
+    end
+
+    # The Match&Replace request-body path (no intercept): buffer the whole body,
+    # rewrite the entity, re-frame the head (Content-Length), and forward. A body was
+    # sent, so the request is never auto-retryable. Structurally this is the hold path
+    # minus the human — same buffer + capped-capture + reused-upstream forwarding.
+    private def forward_request_rewriting_body(rw : HeadRewriter, req : Codec::RawRequest,
+                                               sent_req : Codec::RawRequest, sent_head : Bytes,
+                                               host : String, port : Int32, scheme : String,
+                                               created_at : Int64, started : Time::Instant,
+                                               req_framing : Codec::BodyFraming, req_len : Int64) : Bool
+      buffered, body_complete = Codec::Body.read_complete(@io, req_framing, req_len)
+      unless body_complete
+        # Client cut the body short — forwarding it under the original length would desync
+        # the upstream (mirrors the streaming path's req_complete guard). Record + close.
+        record_error(sent_req, scheme, host, port, created_at, "client truncated request body")
+        return false
+      end
+      sent_head, fwd_body = apply_body_rewrite(sent_head, buffered, req_framing) { |e| rw.rewrite_request_body(e) }
+      sent_req = Codec::Http1.parse_request_head(sent_head) # head may have been re-framed
+      upstream, reused, sent = acquire_and_send(host, port, false) { |up| write_request(up, sent_head, fwd_body) }
+      unless upstream && sent
+        release_upstream
+        record_error(sent_req, scheme, host, port, created_at, "upstream connect/write failed: #{host}:#{port}")
+        write_gateway_error
+        return false
+      end
+      stored, trunc, size = capped(fwd_body)
+      flow_id = @sink.on_request(FlowMapper.request(sent_req,
+        scheme: scheme, host: host, port: port, created_at: created_at,
+        body: stored, body_truncated: trunc, body_size: size))
+      handle_response(upstream, req, flow_id, started, host, port, scheme,
+        reused: reused, sent_head: sent_head, can_retry: false, sent_req: sent_req)
     end
 
     # Acquires the (reused-or-fresh) upstream and runs `send` on it. If a REUSED
@@ -312,6 +362,16 @@ module Gori::Proxy
          !resp_framing.close_delimited? && !sse?(resp) && resp.status != 101
         return handle_held_response(ic, upstream, req, sent_req, flow_id, host, port, scheme,
           resp, sent_resp_head, resp_framing, resp_len, ttfb, started)
+      end
+
+      # Match&Replace (response body): buffer + rewrite a bounded (Length/chunked),
+      # non-streaming response when a response-body rule is live. SSE / close-delimited
+      # / 101-upgrade bodies would buffer forever, so they fall through to streaming and
+      # the body rule no-ops on them (matching the intercept-hold exclusions above).
+      if (rw = @rewriter) && rw.rewrites_response_body? &&
+         (resp_framing.length? || resp_framing.chunked?) && !sse?(resp) && resp.status != 101
+        return forward_response_rewriting_body(rw, upstream, req, sent_req, flow_id, host, port,
+          scheme, resp, sent_resp_head, resp_framing, resp_len, ttfb, started)
       end
 
       # Non-hold path: stream the response body byte-for-byte (P6) and record the
@@ -455,6 +515,47 @@ module Gori::Proxy
         state: state, error: error))
     end
 
+    # The Match&Replace response-body path (no intercept): buffer the whole body,
+    # rewrite the entity, re-frame the head (Content-Length), forward, and capture.
+    # Returns the CLIENT keep-alive decision; the upstream is reused iff we read the
+    # whole body cleanly AND the origin kept its side. Mirrors stream_nonhold_response
+    # + the reuse tail of handle_response, minus the 101/close-delimited cases (excluded
+    # at the call site so the buffer is always bounded).
+    private def forward_response_rewriting_body(rw : HeadRewriter, upstream : IO, req : Codec::RawRequest,
+                                                sent_req : Codec::RawRequest, flow_id : Int64,
+                                                host : String, port : Int32, scheme : String,
+                                                resp : Codec::RawResponse, sent_resp_head : Bytes,
+                                                resp_framing : Codec::BodyFraming, resp_len : Int64,
+                                                ttfb : Int64, started : Time::Instant) : Bool
+      buf = IO::Memory.new
+      resp_complete = Codec::Body.stream(upstream, buf, resp_framing, resp_len, Codec::DiscardIO.new)
+      sent_resp_head, fwd_body = apply_body_rewrite(sent_resp_head, buf.to_slice, resp_framing) { |e| rw.rewrite_response_body(e) }
+      sent_resp = Codec::Http1.parse_response_head(sent_resp_head) # head may have been re-framed
+      stored, trunc, size = capped(fwd_body)
+      state = resp_complete ? Store::FlowState::Complete : Store::FlowState::Aborted
+      error = resp_complete ? nil : "upstream closed before response body complete"
+      begin
+        @io.write(sent_resp_head)
+        @io.write(fwd_body) if fwd_body
+        @io.flush
+      rescue
+        # Client aborted its read mid-response — record what we have, then close.
+        state = Store::FlowState::Aborted
+        error = "connection closed mid-response"
+        resp_complete = false
+      end
+      duration = (Time.instant - started).total_microseconds.to_i64
+      @sink.on_response(FlowMapper.response(sent_resp,
+        flow_id: flow_id, body: stored, ttfb_us: ttfb, duration_us: duration,
+        body_truncated: trunc, body_size: size, state: state, error: error))
+      # Reuse iff the origin kept its side AND we read the whole body; a truncated body
+      # was forwarded short, so close the client connection (return false) rather than
+      # block its next keep-alive request on the missing bytes.
+      update_upstream_reuse(resp_complete && origin_keep_alive?(sent_req, resp, resp_framing))
+      return false unless resp_complete
+      keep_alive?(req, resp, resp_framing)
+    end
+
     # Reads the response head, transparently redialing + resending ONCE if a
     # REUSED idle keep-alive turned out stale (immediate EOF) and the request is
     # replayable (body-less). Returns {head, upstream} — `upstream` may be a fresh
@@ -500,6 +601,12 @@ module Gori::Proxy
       # `buf`; a throwaway IO::Memory would hold the whole response a second time.
       resp_complete = Codec::Body.stream(upstream, buf, resp_framing, resp_len, Codec::DiscardIO.new)
       body = resp_framing.none? ? nil : buf.to_slice.dup
+      # Match&Replace (response body) BEFORE the human sees it, like the head. A body rule
+      # re-frames the head to Content-Length; `resp` (status/version/Connection) is
+      # untouched by that, so keep it as the origin's framing/keep-alive truth.
+      if (rw = @rewriter) && rw.rewrites_response_body?
+        sent_resp_head, body = apply_body_rewrite(sent_resp_head, body, resp_framing) { |e| rw.rewrite_response_body(e) }
+      end
       decision = ic.hold_response(build_message(sent_resp_head, body),
         flow_id: flow_id, method: req.method, target: "#{resp.status} #{resp.reason}",
         host: host, port: port, scheme: scheme)
@@ -730,6 +837,51 @@ module Gori::Proxy
         i += 1
       end
       nil
+    end
+
+    # Apply a body Match&Replace to a buffered wire body and return {head, forward_body}.
+    # `wire_body` is the on-the-wire form (chunk framing preserved for chunked bodies);
+    # it is de-chunked to the entity before matching. `yield entity` runs the rule engine
+    # (rewrite_request_body / rewrite_response_body), which returns the SAME bytes when
+    # nothing matched. On no change we return the ORIGINAL head + wire body byte-exact
+    # (P7) — so an unmatched flow, including a compressed body a literal pattern can't
+    # touch, is never re-framed. On a change we re-frame the head to Content-Length (the
+    # new entity length, Transfer-Encoding dropped) and forward the rewritten entity.
+    private def apply_body_rewrite(head : Bytes, wire_body : Bytes?, framing : Codec::BodyFraming,
+                                   & : Bytes -> Bytes) : {Bytes, Bytes?}
+      return {head, wire_body} if wire_body.nil? || wire_body.empty?
+      entity = framing.chunked? ? Codec::ContentDecode.dechunk(wire_body) : wire_body
+      rewritten = yield entity
+      return {head, wire_body} if rewritten == entity # nothing matched → byte-exact (P7)
+      {reframe_to_length(head, rewritten.size), rewritten}
+    end
+
+    # Rebuild a message head framed as `Content-Length: len`: drop any Transfer-Encoding
+    # and Content-Length header (a rewritten body invalidates both), append the fresh
+    # Content-Length, and keep every other header verbatim in order. Preserves the head's
+    # own line ending (CRLF or bare LF) so the re-parsed head stays well-formed.
+    private def reframe_to_length(head : Bytes, len : Int32) : Bytes
+      text = String.new(head)
+      eol = text.index("\r\n") ? "\r\n" : "\n"
+      section = text.split(eol + eol, 2).first # headers up to the blank line
+      lines = section.split(eol)
+      io = IO::Memory.new(head.size + 32)
+      io << lines.first << eol # request / status line, untouched
+      lines[1..].each do |line|
+        next if header_line_named?(line, "transfer-encoding") || header_line_named?(line, "content-length")
+        io << line << eol
+      end
+      io << "Content-Length: " << len << eol << eol
+      io.to_slice
+    end
+
+    # True when a header line's field-name (case-insensitive, ignoring leading space) is
+    # `name`. The request/status line has no ':' before its first space-token, so it never
+    # matches a header name here.
+    private def header_line_named?(line : String, name : String) : Bool
+      colon = line.index(':')
+      return false unless colon && colon > 0
+      line[0...colon].strip.downcase == name
     end
 
     private def sse?(resp : Codec::RawResponse) : Bool

--- a/src/gori/proxy/head_rewriter.cr
+++ b/src/gori/proxy/head_rewriter.cr
@@ -1,10 +1,14 @@
 module Gori::Proxy
-  # The seam where the Match&Replace lens rewrites message HEAD bytes in flight.
-  # Kept abstract (like FlowSink) so ClientConn stays decoupled from the rule
-  # engine and testable with a stub. Bodies are never passed here — they stream
-  # untouched (P6). An impl MUST return the SAME bytes when it changes nothing,
-  # so the caller can tell a rewrite happened and preserve byte-fidelity (P7)
-  # for unmodified flows.
+  # The seam where the Match&Replace lens rewrites messages in flight. Kept abstract
+  # (like FlowSink) so ClientConn stays decoupled from the rule engine and testable
+  # with a stub. HEAD rewrites (`rewrite_request`/`rewrite_response`) run on every
+  # message while its body streams untouched (P6). BODY rewrites are opt-in and cost
+  # a buffer: ClientConn only calls `rewrite_request_body`/`rewrite_response_body`
+  # (and only after `rewrites_*_body?` says a body rule is live), passing the ENTITY
+  # body — de-chunked, decompression left to the impl to skip — and re-frames the
+  # message (Content-Length synced) itself. Every rewrite MUST return the SAME bytes
+  # when it changes nothing, so the caller can tell a rewrite happened and preserve
+  # byte-fidelity (P7) for unmodified flows.
   abstract class HeadRewriter
     abstract def rewrite_request(head : Bytes) : Bytes
     abstract def rewrite_response(head : Bytes) : Bytes
@@ -15,6 +19,28 @@ module Gori::Proxy
     # Replace rule would silently no-op on every h2 flow. Default false (a no-op stub).
     def active? : Bool
       false
+    end
+
+    # Whether a BODY rule is live for the request/response side. ClientConn checks
+    # this before paying to buffer a body — the common (head-only / no-rule) case
+    # keeps zero-buffer streaming (P6). Default false so a stub never buffers.
+    def rewrites_request_body? : Bool
+      false
+    end
+
+    def rewrites_response_body? : Bool
+      false
+    end
+
+    # Rewrite the ENTITY body (de-chunked, not decompressed). MUST return the SAME
+    # bytes when nothing matched so ClientConn can passthrough byte-exact (P7); a
+    # compressed body simply won't match a literal pattern and returns unchanged.
+    def rewrite_request_body(entity : Bytes) : Bytes
+      entity
+    end
+
+    def rewrite_response_body(entity : Bytes) : Bytes
+      entity
     end
   end
 end

--- a/src/gori/rules.cr
+++ b/src/gori/rules.cr
@@ -12,14 +12,21 @@ module Gori
   class Rules < Proxy::HeadRewriter
     def initialize(@store : Store, @rules : Array(Store::MatchRule))
       @mutex = Mutex.new
-      # Lock-free fast-path flag: rewrite_request/response run on EVERY head, but
-      # the common case is no rules. This lets apply() skip the mutex + select-array
-      # allocation entirely when nothing would match.
-      @active_count = Atomic(Int32).new(active_rule_count(@rules))
+      # Lock-free fast-path flags: rewrite_* run on EVERY message, but the common case
+      # is no rule for that side/part. These let the hot path skip the mutex + select-
+      # array allocation entirely when nothing would match. `@head_count` gates the head
+      # rewrite; the two body counts also gate whether ClientConn buffers a body at all.
+      @head_count = Atomic(Int32).new(active_count(@rules, part: Store::RulePart::Head))
+      @req_body_count = Atomic(Int32).new(active_count(@rules, Store::RuleTarget::Request, part: Store::RulePart::Body))
+      @resp_body_count = Atomic(Int32).new(active_count(@rules, Store::RuleTarget::Response, part: Store::RulePart::Body))
     end
 
-    private def active_rule_count(rules : Array(Store::MatchRule)) : Int32
-      rules.count { |r| r.enabled? && !r.pattern.empty? }
+    # Count enabled, non-empty-pattern rules matching an optional target + a part.
+    private def active_count(rules : Array(Store::MatchRule), target : Store::RuleTarget? = nil,
+                             *, part : Store::RulePart) : Int32
+      rules.count do |r|
+        r.enabled? && !r.pattern.empty? && r.part == part && (target.nil? || r.target == target)
+      end
     end
 
     def self.load(store : Store) : Rules
@@ -42,9 +49,9 @@ module Gori
 
     # --- editing (persists, then refreshes the snapshot) ---------------------
 
-    def add(target : Store::RuleTarget, pattern : String, replacement : String) : Nil
+    def add(target : Store::RuleTarget, part : Store::RulePart, pattern : String, replacement : String) : Nil
       return if pattern.empty?
-      @store.insert_rule(target, pattern, replacement)
+      @store.insert_rule(target, part, pattern, replacement)
       refresh
     end
 
@@ -63,22 +70,43 @@ module Gori
     # --- HeadRewriter (called from proxy fibers) -----------------------------
 
     def rewrite_request(head : Bytes) : Bytes
-      apply(head, Store::RuleTarget::Request)
+      apply(head, Store::RuleTarget::Request, Store::RulePart::Head, @head_count)
     end
 
     def rewrite_response(head : Bytes) : Bytes
-      apply(head, Store::RuleTarget::Response)
+      apply(head, Store::RuleTarget::Response, Store::RulePart::Head, @head_count)
     end
 
-    private def apply(head : Bytes, target : Store::RuleTarget) : Bytes
-      return head if @active_count.get == 0 # lock-free fast path: no rules to apply
+    # A body rule is live iff at least one enabled, non-empty rule targets that side's
+    # body — ClientConn keys the (expensive) body buffer on these.
+    def rewrites_request_body? : Bool
+      @req_body_count.get > 0
+    end
+
+    def rewrites_response_body? : Bool
+      @resp_body_count.get > 0
+    end
+
+    def rewrite_request_body(entity : Bytes) : Bytes
+      apply(entity, Store::RuleTarget::Request, Store::RulePart::Body, @req_body_count)
+    end
+
+    def rewrite_response_body(entity : Bytes) : Bytes
+      apply(entity, Store::RuleTarget::Response, Store::RulePart::Body, @resp_body_count)
+    end
+
+    # gsub every enabled rule for {target, part} over the bytes. Returns the SAME
+    # bytes when nothing is configured or nothing matches (byte-fidelity, P7).
+    private def apply(bytes : Bytes, target : Store::RuleTarget, part : Store::RulePart,
+                      count : Atomic(Int32)) : Bytes
+      return bytes if count.get == 0 # lock-free fast path: no rules to apply
       # An empty pattern is excluded here too (not just at add-time): String#gsub
-      # with "" would splice the replacement between every byte and wreck the head.
+      # with "" would splice the replacement between every byte and wreck the bytes.
       active = @mutex.synchronize do
-        @rules.select { |r| r.enabled? && r.target == target && !r.pattern.empty? }
+        @rules.select { |r| r.enabled? && r.target == target && r.part == part && !r.pattern.empty? }
       end
-      return head if active.empty? # unchanged → same bytes, byte-fidelity preserved
-      text = String.new(head)
+      return bytes if active.empty? # unchanged → same bytes, byte-fidelity preserved
+      text = String.new(bytes)
       active.each { |r| text = text.gsub(r.pattern, r.replacement) }
       text.to_slice
     end
@@ -86,7 +114,9 @@ module Gori
     private def refresh : Nil
       fresh = @store.match_rules
       @mutex.synchronize { @rules = fresh }
-      @active_count.set(active_rule_count(fresh))
+      @head_count.set(active_count(fresh, part: Store::RulePart::Head))
+      @req_body_count.set(active_count(fresh, Store::RuleTarget::Request, part: Store::RulePart::Body))
+      @resp_body_count.set(active_count(fresh, Store::RuleTarget::Response, part: Store::RulePart::Body))
     end
   end
 end

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -764,20 +764,21 @@ module Gori
 
     def match_rules : Array(MatchRule)
       list = [] of MatchRule
-      @db.query("SELECT id, enabled, target, pattern, replacement FROM match_rules ORDER BY position, id") do |rs|
+      @db.query("SELECT id, enabled, target, part, pattern, replacement FROM match_rules ORDER BY position, id") do |rs|
         rs.each do
           list << MatchRule.new(
             rs.read(Int64), rs.read(Int32) != 0,
-            RuleTarget.from_label(rs.read(String)), rs.read(String), rs.read(String))
+            RuleTarget.from_label(rs.read(String)), RulePart.from_label(rs.read(String)),
+            rs.read(String), rs.read(String))
         end
       end
       list
     end
 
-    def insert_rule(target : RuleTarget, pattern : String, replacement : String) : Int64
+    def insert_rule(target : RuleTarget, part : RulePart, pattern : String, replacement : String) : Int64
       exec_task ->(c : DB::Connection) {
-        c.exec("INSERT INTO match_rules (enabled, target, pattern, replacement) VALUES (1, ?, ?, ?)",
-          target.label, pattern, replacement)
+        c.exec("INSERT INTO match_rules (enabled, target, part, pattern, replacement) VALUES (1, ?, ?, ?, ?)",
+          target.label, part.label, pattern, replacement)
         nil
       }
     end

--- a/src/gori/store/models.cr
+++ b/src/gori/store/models.cr
@@ -97,25 +97,25 @@ module Gori
     end
 
     # Full detail incl. truth bytes — loaded lazily when a row is selected.
-     struct FlowDetail
-       getter row : FlowRow
-       getter http_version : String
-       getter request_head : Bytes
-       getter request_body : Bytes?
-       getter response_head : Bytes?
-       getter response_body : Bytes?
-       getter? request_body_truncated : Bool
-       getter? response_body_truncated : Bool
-       getter h2_conn_id : Int64?
-       getter h2_stream_id : Int64?
-       getter error : String? # upstream/parse/tls failure message for Error/Aborted flows (response side is empty)
-       getter sni : String?
+    struct FlowDetail
+      getter row : FlowRow
+      getter http_version : String
+      getter request_head : Bytes
+      getter request_body : Bytes?
+      getter response_head : Bytes?
+      getter response_body : Bytes?
+      getter? request_body_truncated : Bool
+      getter? response_body_truncated : Bool
+      getter h2_conn_id : Int64?
+      getter h2_stream_id : Int64?
+      getter error : String? # upstream/parse/tls failure message for Error/Aborted flows (response side is empty)
+      getter sni : String?
 
-       def initialize(@row, @http_version, @request_head, @request_body,
-                      @response_head, @response_body, @h2_conn_id = nil, @h2_stream_id = nil,
-                      @request_body_truncated = false, @response_body_truncated = false, @error = nil, @sni = nil)
-       end
-     end
+      def initialize(@row, @http_version, @request_head, @request_body,
+                     @response_head, @response_body, @h2_conn_id = nil, @h2_stream_id = nil,
+                     @request_body_truncated = false, @response_body_truncated = false, @error = nil, @sni = nil)
+      end
+    end
 
     # A captured WebSocket message belonging to a (101) flow. `direction` is
     # "out" (client→server) or "in" (server→client); opcode 1=text, 2=binary.
@@ -289,17 +289,37 @@ module Gori
       end
     end
 
-    # A Match&Replace rule: a literal substring rewrite of a request/response
-    # HEAD (request line + headers; bodies are never touched, P6). Human-authored
-    # (P4), persisted per project. `replacement` may be empty (delete `pattern`).
+    # Which PART of a message a Match&Replace rule rewrites: the HEAD (request/
+    # status line + headers) or the BODY (the entity — de-chunked, but not
+    # decompressed). Stored as the lowercase member name ("head"/"body"); pre-body
+    # rules migrate to `head` (V30 default), so old rows keep their exact meaning.
+    enum RulePart
+      Head
+      Body
+
+      def label : String
+        to_s.downcase
+      end
+
+      def self.from_label(s : String) : RulePart
+        parse(s)
+      end
+    end
+
+    # A Match&Replace rule: a literal substring rewrite of a request/response HEAD
+    # (request line + headers) or BODY (the entity body). Human-authored (P4),
+    # persisted per project. `replacement` may be empty (delete `pattern`). A body
+    # rule buffers + re-frames the message in flight (Content-Length synced); a head
+    # rule streams the body untouched (P6). See `Rules` / `ClientConn`.
     struct MatchRule
       getter id : Int64
       getter? enabled : Bool
       getter target : RuleTarget
+      getter part : RulePart
       getter pattern : String
       getter replacement : String
 
-      def initialize(@id, @enabled, @target, @pattern, @replacement)
+      def initialize(@id, @enabled, @target, @part, @pattern, @replacement)
       end
     end
 

--- a/src/gori/store/schema.cr
+++ b/src/gori/store/schema.cr
@@ -7,7 +7,7 @@ module Gori
     # (FTS5 for QL, a tags table, a connections table) arrive as *later*
     # migrations — which is exactly why none of them exist in v1 (P0).
     module Schema
-      VERSION = 29
+      VERSION = 30
 
       # The migration that reclaims duplicated/low-value bytes already on disk (see V25).
       # Store.open runs a one-time VACUUM after an EXISTING db crosses this version so the
@@ -519,7 +519,14 @@ module Gori
         SQL
       ]
 
-      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21, V22, V23, V24, V25, V26, V27, V28, V29]
+      # Match&Replace rules gain a PART axis (head/body): a rule now targets either the
+      # message HEAD (the original behaviour) or its BODY (buffer + re-frame in flight).
+      # Additive, backfilled to 'head' so every existing rule keeps its exact meaning.
+      V30 = [
+        "ALTER TABLE match_rules ADD COLUMN part TEXT NOT NULL DEFAULT 'head'",
+      ]
+
+      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21, V22, V23, V24, V25, V26, V27, V28, V29, V30]
 
       def self.migrate!(db : DB::Database) : Nil
         db.using_connection do |conn|

--- a/src/gori/tui/rules_overlay.cr
+++ b/src/gori/tui/rules_overlay.cr
@@ -4,13 +4,15 @@ require "./frame"
 require "../rules"
 
 module Gori::Tui
-  # Overlay editor for the Match&Replace lens. One input line with a compact
-  # syntax — `[req:|resp:] pattern => replacement` — mirroring the Scope editor's
-  # interaction (type, ↵ add, ⌫ del, ↑/↓ select, tab on/off). Mutations persist
-  # through the shared Rules instance, which the proxy reads live.
+  # Overlay editor for the Match&Replace lens. One input line with a compact syntax
+  # — `[req:|resp:|reqbody:|respbody:] pattern => replacement` — mirroring the Scope
+  # editor's interaction (type, ↵ add, ⌫ del, ↑/↓ select, tab on/off). Mutations
+  # persist through the shared Rules instance, which the proxy reads live.
   #
-  #   req: User-Agent: x => User-Agent: gori    # rewrite a request header
+  #   req: User-Agent: x => User-Agent: gori    # rewrite a request HEADER
   #   resp: Set-Cookie => X-Stripped            # blank replacement deletes text
+  #   reqbody: password => hunter2              # rewrite the request BODY
+  #   respbody: "debug":false => "debug":true   # rewrite the response BODY
   class RulesOverlay
     def initialize(@rules : Rules)
       @selected = 0
@@ -57,9 +59,9 @@ module Gori::Tui
     end
 
     def submit : Bool
-      target, pattern, replacement = parse(@input)
+      target, part, pattern, replacement = parse(@input)
       return false if pattern.empty?
-      @rules.add(target, pattern, replacement)
+      @rules.add(target, part, pattern, replacement)
       @input = ""
       @icx = 0
       @preedit = ""
@@ -79,21 +81,27 @@ module Gori::Tui
       @rules.toggle(rule.id) if rule
     end
 
-    # `[req:|resp:] pattern => replacement` → {target, pattern, replacement}.
-    # No prefix defaults to request; no `=>` means delete `pattern` (empty repl).
-    def parse(line : String) : {Store::RuleTarget, String, String}
+    # `[req:|resp:|reqbody:|respbody:] pattern => replacement`
+    #   → {target, part, pattern, replacement}.
+    # No prefix defaults to a request HEAD rule; no `=>` means delete `pattern` (empty
+    # repl). Longer `*body:` prefixes are tested first so `reqbody:` isn't mis-split.
+    def parse(line : String) : {Store::RuleTarget, Store::RulePart, String, String}
       body = line.strip
       target = Store::RuleTarget::Request
-      if body.starts_with?("resp:")
-        target = Store::RuleTarget::Response
-        body = body[5..].lstrip
+      part = Store::RulePart::Head
+      if body.starts_with?("respbody:")
+        target, part, body = Store::RuleTarget::Response, Store::RulePart::Body, body[9..].lstrip
+      elsif body.starts_with?("reqbody:")
+        part, body = Store::RulePart::Body, body[8..].lstrip
+      elsif body.starts_with?("resp:")
+        target, body = Store::RuleTarget::Response, body[5..].lstrip
       elsif body.starts_with?("req:")
         body = body[4..].lstrip
       end
       if (sep = body.index("=>"))
-        {target, body[0...sep].strip, body[(sep + 2)..].strip}
+        {target, part, body[0...sep].strip, body[(sep + 2)..].strip}
       else
-        {target, body.strip, ""}
+        {target, part, body.strip, ""}
       end
     end
 
@@ -131,7 +139,7 @@ module Gori::Tui
       list_top = box.y + 3
       list_h = box.bottom - 1 - list_top
       if rules.empty?
-        screen.text(box.x + 3, list_top, "(none — e.g.  resp: Old => New )", Theme.muted, Theme.panel)
+        screen.text(box.x + 3, list_top, "(none — e.g.  respbody: Old => New )", Theme.muted, Theme.panel)
       else
         ensure_visible(list_h)
         (0...list_h).each do |i|
@@ -153,7 +161,8 @@ module Gori::Tui
       @scroll = @scroll.clamp(0, {@rules.rules.size - list_h, 0}.max)
     end
 
-    # One row in the rule list: selection bar, enabled `✓`/`·`, REQ/RES tag, rule.
+    # One row in the rule list: selection bar, enabled `✓`/`·`, side+part tag, rule.
+    # The tag reads `REQ H` / `REQ B` / `RES H` / `RES B` (H = head, B = body).
     private def render_rule_row(screen : Screen, box : Rect, rule : Store::MatchRule,
                                 py : Int32, w : Int32, selected : Bool) : Nil
       bg = selected ? Theme.accent_bg : Theme.panel
@@ -161,10 +170,10 @@ module Gori::Tui
       screen.cell(box.x + 1, py, selected ? '▎' : ' ', Theme.accent, bg)
       mark = rule.enabled? ? '✓' : '·'
       screen.cell(box.x + 3, py, mark, rule.enabled? ? Theme.accent : Theme.muted, bg)
-      tag = rule.target.request? ? "REQ" : "RES"
+      tag = "#{rule.target.request? ? "REQ" : "RES"} #{rule.part.body? ? 'B' : 'H'}"
       screen.text(box.x + 5, py, tag, rule.enabled? ? Theme.text : Theme.muted, bg)
       desc = "#{rule.pattern} → #{rule.replacement}"
-      screen.text(box.x + 9, py, desc, selected ? Theme.text_bright : Theme.text, bg, width: w - 11)
+      screen.text(box.x + 11, py, desc, selected ? Theme.text_bright : Theme.text, bg, width: w - 13)
     end
 
     # Rule-row index under (mx,my) — inverts the list loop: input line sits at

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1260,7 +1260,7 @@ module Gori::Tui
       @fuzz_advanced_overlay = nil
     end
 
-    # Match&Replace overlay: type a `[req:|resp:] pattern => replacement` rule;
+    # Match&Replace overlay: type a `[req:|resp:|reqbody:|respbody:] pattern => replacement` rule;
     # ↵ add, ⌫ edit/remove, ↑/↓ select, tab on/off, esc close. No view reload —
     # rules act on the live proxy, not on already-captured flows.
     private def handle_rules_key(ev : Termisu::Event::Key) : Nil


### PR DESCRIPTION
## Summary

Match & Replace previously rewrote only request/response **heads** (request line + headers) while bodies streamed through untouched. This adds a **body** dimension so rules can rewrite the message body in flight too.

New overlay syntax (press `m`):

```text
req:      User-Agent: x => User-Agent: gori   # request head (default)
resp:     Set-Cookie => X-Stripped            # response head
reqbody:  password => hunter2                 # request body
respbody: "debug":false => "debug":true       # response body
```

## How it works

- **Model** — new `Store::RulePart` (Head/Body) axis on `MatchRule`; schema **V30** adds a `part` column defaulting to `'head'`, so every existing rule keeps its exact meaning.
- **Engine** (`rules.cr`) — head rules stay head-only; body rules `gsub` the *entity* body. Lock-free `rewrites_{request,response}_body?` predicates gate whether the proxy buffers at all (the no-body-rule path keeps zero-buffer streaming, P6).
- **Proxy** (`client_conn.cr`) — when a body rule is live, the body is buffered, de-chunked to its entity, and rewritten. **Only if the pattern matched** is the message re-framed to `Content-Length` (Transfer-Encoding dropped, length synced); otherwise the original head+body pass through **byte-exact** (P7 holds even for chunked). Applies on both the streaming and intercept-hold paths so head and body M&R stay consistent.

## Deliberate scope

- **Compressed bodies aren't decompressed** — a literal pattern won't match gzip/br bytes, so it's an honest byte-exact no-op.
- **Streaming responses** (SSE, close-delimited, WebSocket upgrades) keep streaming — buffering them would hang forever.
- **Known limitation:** the forward buffer is unbounded, matching the existing intercept-hold pattern — an active response-body rule buffers each Length/chunked response fully in RAM. A size-cap-then-stream guard is the obvious follow-up.

## Tests

- Engine (part filtering, body gsub, predicates, persistence of `part`), overlay parse/render for the new prefixes, store round-trip, and **three proxy integration tests**: request+response body rewrite with `Content-Length` re-sync, and a chunked→CL reframe.
- Migration-replay fixtures updated to drop the `part` column when downgrading.
- `crystal tool format` clean; typechecks. Full suite green except 8 pre-existing `Session`/port-binding tests that fail identically on the base branch (sandbox can't bind the proxy port).

🤖 Generated with [Claude Code](https://claude.com/claude-code)