### PR TITLE
feat(tui): "Copy as…" format picker (url/header/body/cookie/curl/raw)

### DIFF
--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -407,6 +407,8 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def read_copy : Nil; end
 
+  def copy_as_open : Nil; end
+
   def detail_navigable? : Bool
     false
   end

--- a/spec/tui/copy_menu_spec.cr
+++ b/spec/tui/copy_menu_spec.cr
@@ -1,0 +1,124 @@
+require "../spec_helper"
+
+include Gori::Tui
+
+private def opt(opts : Array(CopyMenu::Option), key : Char) : CopyMenu::Option?
+  opts.find { |o| o.key == key }
+end
+
+describe Gori::Tui::CopyMenu do
+  describe ".request_options" do
+    wire = "POST /api/login?next=/home HTTP/1.1\r\n" \
+           "Host: example.com\r\n" \
+           "Content-Type: application/json\r\n" \
+           "Cookie: sid=abc; theme=dark\r\n" \
+           "Content-Length: 21\r\n" \
+           "\r\n" \
+           "{\"user\":\"neo\"}"
+    target = "https://example.com"
+
+    it "resolves the full URL from an origin-form request line + target" do
+      opt(CopyMenu.request_options(wire, target), 'u').not_nil!.text.should eq("https://example.com/api/login?next=/home")
+    end
+
+    it "copies the header block only (no request line, no body)" do
+      headers = opt(CopyMenu.request_options(wire, target), 'h').not_nil!.text
+      headers.should contain("Host: example.com")
+      headers.should contain("Content-Type: application/json")
+      headers.should_not contain("POST /api/login")
+      headers.should_not contain("neo")
+    end
+
+    it "copies the body" do
+      opt(CopyMenu.request_options(wire, target), 'b').not_nil!.text.should eq("{\"user\":\"neo\"}")
+    end
+
+    it "extracts the cookie value" do
+      opt(CopyMenu.request_options(wire, target), 'c').not_nil!.text.should eq("sid=abc; theme=dark")
+    end
+
+    it "builds a shell-safe curl dropping Host/Content-Length, with method + body" do
+      curl = opt(CopyMenu.request_options(wire, target), 'l').not_nil!.text
+      curl.should contain("curl 'https://example.com/api/login?next=/home'")
+      curl.should contain("-X POST")
+      curl.should contain("-H 'Content-Type: application/json'")
+      curl.should_not contain("-H 'Host:")
+      curl.should_not contain("-H 'Content-Length:")
+      curl.should contain("--data-raw '{\"user\":\"neo\"}'")
+    end
+
+    it "keeps the raw request verbatim" do
+      opt(CopyMenu.request_options(wire, target), 'r').not_nil!.text.should eq(wire)
+    end
+
+    it "omits body/cookie rows when the request has neither (GET, no cookie)" do
+      get = "GET /health HTTP/1.1\r\nHost: h\r\n\r\n"
+      opts = CopyMenu.request_options(get, "http://h")
+      opt(opts, 'b').should be_nil
+      opt(opts, 'c').should be_nil
+      opt(opts, 'u').not_nil!.text.should eq("http://h/health")
+      # a GET curl carries no -X and no --data-raw
+      curl = opt(opts, 'l').not_nil!.text
+      curl.should_not contain("-X")
+      curl.should_not contain("--data-raw")
+    end
+
+    it "uses an absolute-form request line as the URL directly" do
+      abs = "GET http://plain.test/x HTTP/1.1\r\nHost: plain.test\r\n\r\n"
+      opt(CopyMenu.request_options(abs, ""), 'u').not_nil!.text.should eq("http://plain.test/x")
+    end
+
+    it "keeps -X GET on a GET that carries a body (curl would else promote it to POST)" do
+      req = "GET /q HTTP/1.1\r\nHost: h\r\n\r\nbodydata"
+      curl = opt(CopyMenu.request_options(req, "http://h"), 'l').not_nil!.text
+      curl.should contain("-X GET")
+      curl.should contain("--data-raw 'bodydata'")
+    end
+
+    it "strips a path pasted into the target base so the request path isn't doubled" do
+      req = "GET /real/path HTTP/1.1\r\nHost: h\r\n\r\n"
+      opt(CopyMenu.request_options(req, "https://h:8443/leftover"), 'u').not_nil!.text
+        .should eq("https://h:8443/real/path")
+    end
+
+    it "falls back to the Host header when no target base is set" do
+      req = "GET /p HTTP/1.1\r\nHost: fromhost.test\r\n\r\n"
+      opt(CopyMenu.request_options(req, ""), 'u').not_nil!.text.should eq("http://fromhost.test/p")
+    end
+
+    it "shell-escapes an embedded single quote in curl" do
+      req = "GET /p HTTP/1.1\r\nHost: h\r\nX-Note: it's here\r\n\r\n"
+      curl = opt(CopyMenu.request_options(req, "http://h"), 'l').not_nil!.text
+      curl.should contain("-H 'X-Note: it'\\''s here'")
+    end
+  end
+
+  describe ".response_options" do
+    head = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n"
+    body = "<h1>hi</h1>"
+
+    it "copies status+headers with the trailing blank line stripped" do
+      h = opt(CopyMenu.response_options(head, body), 'h').not_nil!.text
+      h.should eq("HTTP/1.1 200 OK\r\nContent-Type: text/html")
+    end
+
+    it "copies the body" do
+      opt(CopyMenu.response_options(head, body), 'b').not_nil!.text.should eq("<h1>hi</h1>")
+    end
+
+    it "rejoins head+body with exactly one separator for raw" do
+      opt(CopyMenu.response_options(head, body), 'r').not_nil!.text
+        .should eq("HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n<h1>hi</h1>")
+    end
+
+    it "omits the body row for an empty body" do
+      opt(CopyMenu.response_options(head, ""), 'b').should be_nil
+    end
+
+    it "omits the Raw response row for an empty body (it would duplicate Status + headers)" do
+      opts = CopyMenu.response_options(head, "")
+      opt(opts, 'r').should be_nil
+      opt(opts, 'h').not_nil!.text.should eq("HTTP/1.1 200 OK\r\nContent-Type: text/html")
+    end
+  end
+end

--- a/spec/tui/copy_picker_spec.cr
+++ b/spec/tui/copy_picker_spec.cr
@@ -1,0 +1,48 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+private def sample_picker : CopyPicker
+  CopyPicker.new("COPY REQUEST AS", [
+    CopyMenu::Option.new("URL", 'u', "https://h/p"),
+    CopyMenu::Option.new("Headers", 'h', "Host: h"),
+    CopyMenu::Option.new("cURL", 'l', "curl 'https://h/p'"),
+  ])
+end
+
+describe Gori::Tui::CopyPicker do
+  it "maps a mnemonic key to its row (case-insensitive), nil for a miss" do
+    p = sample_picker
+    p.index_for('h').should eq(1)
+    p.index_for('L').should eq(2)
+    p.index_for('z').should be_nil
+  end
+
+  it "returns the selected option's payload" do
+    p = sample_picker
+    p.set_selected(p.index_for('l').not_nil!)
+    p.selected_option.not_nil!.text.should eq("curl 'https://h/p'")
+  end
+
+  it "clamps movement at both ends" do
+    p = sample_picker
+    p.move(-5)
+    p.selected.should eq(0)
+    p.move(99)
+    p.selected.should eq(2)
+  end
+
+  it "reports empty for an empty option list" do
+    CopyPicker.new("COPY AS", [] of CopyMenu::Option).empty?.should be_true
+    sample_picker.empty?.should be_false
+  end
+
+  it "renders the title, labels, and byte sizes" do
+    backend = MemoryBackend.new(80, 24)
+    sample_picker.render(Screen.new(backend), Rect.new(0, 0, 80, 24))
+    backend.contains?("COPY REQUEST AS").should be_true
+    backend.contains?("URL").should be_true
+    backend.contains?("cURL").should be_true
+  end
+end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -780,6 +780,10 @@ private class FakeContext < ExecContext
     @calls << :read_copy
   end
 
+  def copy_as_open : Nil
+    @calls << :copy_as_open
+  end
+
   def detail_navigable? : Bool
     false
   end

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -336,6 +336,11 @@ module Gori::Tui
       @host.status("copied #{written}b to clipboard")
     end
 
+    # The focus-aware "copy as X" menu for the open detail pane ({title, options}).
+    def detail_copy_as_menu : {String, Array(CopyMenu::Option)}
+      @history.detail_copy_as_menu
+    end
+
     def hscroll_detail(delta : Int32) : Nil
       @history.hscroll_detail(delta)
     end

--- a/src/gori/tui/controllers/replay_controller.cr
+++ b/src/gori/tui/controllers/replay_controller.cr
@@ -2,7 +2,9 @@ require "../tab_controller"
 require "../traffic_empty_state"
 require "../replay_view"
 require "../clipboard"
+require "../copy_menu"
 require "../subtab_picker"
+require "../../env"
 require "../../store"
 require "../../prism"
 require "../../replay/engine"
@@ -533,6 +535,36 @@ module Gori::Tui
       when :target   then !v.pane_insert?(:target)
       when :response then true
       else               false
+      end
+    end
+
+    # The "copy as X" menu for the focused pane: {picker title, options}. The RESPONSE
+    # pane offers status+headers/body/raw (or the whole transcript in WS/gRPC mode);
+    # the REQUEST and TARGET panes offer url/headers/body/cookies/curl/raw parsed from
+    # the request as it'd be sent (env-expanded wire bytes + the resolved target URL).
+    def copy_as_menu : {String, Array(CopyMenu::Option)}
+      v = current_view
+      return {"COPY AS", [] of CopyMenu::Option} unless v
+      if v.focus == :response
+        {"COPY RESPONSE AS", replay_response_options(v)}
+      else
+        {"COPY REQUEST AS", replay_request_options(v)}
+      end
+    end
+
+    private def replay_request_options(v : ReplayView) : Array(CopyMenu::Option)
+      wire = String.new(v.request_bytes)
+      target = Env.expand(v.target)
+      CopyMenu.request_options(wire, target)
+    end
+
+    private def replay_response_options(v : ReplayView) : Array(CopyMenu::Option)
+      if parts = v.response_parts
+        CopyMenu.response_options(parts[0], parts[1])
+      else
+        # WS/gRPC transcript (or no HTTP head+body to split) — offer the rendered pane.
+        text = v.resp_copy_all_text
+        text.empty? ? [] of CopyMenu::Option : [CopyMenu::Option.new("Raw response", 'r', text)]
       end
     end
 

--- a/src/gori/tui/copy_menu.cr
+++ b/src/gori/tui/copy_menu.cr
@@ -1,0 +1,152 @@
+module Gori::Tui
+  # Pure helpers that turn an HTTP message into the "copy as X" option set the
+  # CopyPicker overlay shows — split a request into url/headers/body/cookies/curl,
+  # a response into status+headers/body/raw. No TUI/state deps (Screen/Theme), so
+  # the parsing is unit-testable on its own; the Runner wraps the result in a
+  # CopyPicker and the controllers feed it the focused pane's bytes.
+  module CopyMenu
+    # One offered copy format: the row `label`, its mnemonic `key` (unique within a
+    # single option list — the picker dispatches on it), and the `text` placed on
+    # the clipboard when chosen.
+    record Option, label : String, key : Char, text : String
+
+    # Options for a REQUEST pane. `wire` is the request as it'd be sent (CRLF-framed,
+    # env-expanded — the bytes replay uses), `target` the "scheme://host[:port]" base
+    # that resolves an origin-form request line ("GET /p HTTP/1.1") into a full URL.
+    # Empty formats (no body, no Cookie header) drop out so every row is meaningful.
+    def self.request_options(wire : String, target : String) : Array(Option)
+      head, body = split_message(wire)
+      lines = head.split(/\r?\n/)
+      request_line = lines.first? || ""
+      header_lines = lines.size > 1 ? lines[1..] : [] of String
+      method, req_target, _ = parse_request_line(request_line)
+      url = resolve_url(req_target, target, header_lines)
+
+      opts = [] of Option
+      opts << Option.new("URL", 'u', url) unless url.empty?
+      headers_text = header_lines.reject(&.strip.empty?).join("\n")
+      opts << Option.new("Headers", 'h', headers_text) unless headers_text.empty?
+      opts << Option.new("Body", 'b', body) unless body.empty?
+      if cookie = cookie_value(header_lines)
+        opts << Option.new("Cookies", 'c', cookie)
+      end
+      opts << Option.new("cURL", 'l', curl_command(method, url, header_lines, body)) unless url.empty?
+      opts << Option.new("Raw request", 'r', wire) unless wire.strip.empty?
+      opts
+    end
+
+    # Options for a RESPONSE pane, built from the raw head bytes (with or without a
+    # trailing blank line) and body. "Raw response" re-joins them with a single CRLF
+    # separator so a doubled/absent separator in `head` never leaks through — and is
+    # offered ONLY when both parts are present, since with just one it would be a
+    # byte-identical duplicate of the Status+headers (empty body) or Body (empty head) row.
+    def self.response_options(head : String, body : String) : Array(Option)
+      head_clean = head.sub(/\r?\n\r?\n\z/, "")
+      opts = [] of Option
+      opts << Option.new("Status + headers", 'h', head_clean) unless head_clean.strip.empty?
+      opts << Option.new("Body", 'b', body) unless body.empty?
+      unless body.empty? || head_clean.strip.empty?
+        opts << Option.new("Raw response", 'r', "#{head_clean}\r\n\r\n#{body}")
+      end
+      opts
+    end
+
+    # Split an HTTP message into {head, body} on the first blank line — CRLF wire
+    # form first, bare-LF (an editor snapshot) as a fallback.
+    def self.split_message(text : String) : {String, String}
+      if idx = text.index("\r\n\r\n")
+        {text[0, idx], text[(idx + 4)..]}
+      elsif idx = text.index("\n\n")
+        {text[0, idx], text[(idx + 2)..]}
+      else
+        {text, ""}
+      end
+    end
+
+    # {method, request-target, version} from a request line, best-effort (missing
+    # tokens come back empty rather than raising on a hand-typed partial request).
+    private def self.parse_request_line(line : String) : {String, String, String}
+      parts = line.strip.split(' ')
+      {parts[0]? || "", parts[1]? || "", parts[2]? || ""}
+    end
+
+    # The full URL for the request: an absolute-form request target as-is, else the
+    # target base joined with the origin-form path (falling back to the Host header
+    # when no target base is set — a hand-authored request). "" when unresolvable.
+    private def self.resolve_url(req_target : String, target : String, header_lines : Array(String)) : String
+      return req_target if req_target.starts_with?("http://") || req_target.starts_with?("https://")
+      base = authority_base(target.strip)
+      if base.empty?
+        host = header_value(header_lines, "host")
+        base = host ? "http://#{host}" : ""
+      end
+      return "" if base.empty?
+      base = base.rstrip('/')
+      return base if req_target.empty? || req_target == "*"
+      req_target.starts_with?('/') ? "#{base}#{req_target}" : "#{base}/#{req_target}"
+    end
+
+    # scheme://host[:port] with any path/query the user may have pasted into the target
+    # field stripped — the send path (FlowRequest.parse_target) uses only scheme/host/port,
+    # so the copied URL must too, else it doubles the request-line path onto the target's.
+    private def self.authority_base(target : String) : String
+      sep = target.index("://")
+      return target unless sep
+      slash = target.index('/', sep + 3)
+      slash ? target[0, slash] : target
+    end
+
+    # The combined Cookie header value(s), or nil when the request carries none.
+    # Multiple Cookie lines are joined with "; " (the wire pair-separator).
+    private def self.cookie_value(header_lines : Array(String)) : String?
+      cookies = [] of String
+      each_header(header_lines) { |name, value| cookies << value if name.downcase == "cookie" }
+      cookies.empty? ? nil : cookies.join("; ")
+    end
+
+    # The first matching header's value (case-insensitive name), or nil.
+    private def self.header_value(header_lines : Array(String), name : String) : String?
+      want = name.downcase
+      each_header(header_lines) { |hname, value| return value if hname.downcase == want }
+      nil
+    end
+
+    # Yield each well-formed header line as {stripped name, stripped value}; lines
+    # without a colon (blank/continuation) are skipped. ONE parse convention shared by
+    # cookie_value / header_value / curl_command so they can't drift.
+    private def self.each_header(header_lines : Array(String), & : String, String ->) : Nil
+      header_lines.each do |line|
+        name, sep, value = line.partition(":")
+        next if sep.empty?
+        n = name.strip
+        next if n.empty?
+        yield n, value.strip
+      end
+    end
+
+    # A copy-pasteable `curl` invocation reproducing the request. URL first (browser
+    # "Copy as cURL" convention), then -X for the method, each header as -H (dropping
+    # Host/Content-Length — curl derives those), then --data-raw for a body. Every
+    # argument is single-quoted with embedded quotes escaped, so it survives a paste
+    # into any POSIX shell verbatim. Continuation lines keep it readable.
+    private def self.curl_command(method : String, url : String, header_lines : Array(String), body : String) : String
+      parts = ["curl #{shell_quote(url)}"]
+      # Emit -X unless it's a plain bodyless GET (curl's default). A GET *with* a body
+      # still needs -X GET, else curl silently promotes the request to POST.
+      parts << "-X #{method}" unless method.empty? || (method == "GET" && body.empty?)
+      each_header(header_lines) do |name, value|
+        down = name.downcase
+        next if down == "host" || down == "content-length"
+        parts << "-H #{shell_quote("#{name}: #{value}")}"
+      end
+      parts << "--data-raw #{shell_quote(body)}" unless body.empty?
+      parts.join(" \\\n  ")
+    end
+
+    # POSIX single-quote: wrap in '…' and rewrite each embedded ' as '\'' so the
+    # result is one safe shell word regardless of what's inside (incl. newlines).
+    private def self.shell_quote(s : String) : String
+      "'" + s.gsub("'", "'\\''") + "'"
+    end
+  end
+end

--- a/src/gori/tui/copy_picker.cr
+++ b/src/gori/tui/copy_picker.cr
@@ -1,0 +1,108 @@
+require "./screen"
+require "./theme"
+require "./frame"
+require "./fmt"
+require "./copy_menu"
+
+module Gori::Tui
+  # A small centered picker for the "copy as X" action (space → Y): pick which slice
+  # of the focused HTTP message to copy — url / headers / body / cookies / curl / raw.
+  # Structurally a twin of ChoicePicker (pure state + rendering; the Runner owns
+  # open/close and performs the clipboard write), but each row carries the payload
+  # `text` outright and shows its byte size rather than a "current" marker — there's
+  # no persisted value here, just a one-shot copy. Rows are fronted by a mnemonic key.
+  class CopyPicker
+    getter selected : Int32
+    getter title : String
+
+    def initialize(@title : String, @options : Array(CopyMenu::Option))
+      @selected = 0
+      @scroll = 0
+    end
+
+    def empty? : Bool
+      @options.empty?
+    end
+
+    def move(delta : Int32) : Nil
+      return if @options.empty?
+      @selected = (@selected + delta).clamp(0, @options.size - 1)
+    end
+
+    def selected_option : CopyMenu::Option?
+      @options[@selected]?
+    end
+
+    def set_selected(idx : Int32) : Nil
+      return if @options.empty?
+      @selected = idx.clamp(0, @options.size - 1)
+    end
+
+    # The row whose mnemonic matches `c` (case-insensitive), or nil for a miss.
+    def index_for(c : Char) : Int32?
+      lc = c.downcase
+      @options.index { |o| o.key.downcase == lc }
+    end
+
+    # Centered card geometry over `area` — inverse of render's offset math. nil when
+    # render would draw nothing (mirrors the w/h guard). Width leaves room for the
+    # right-aligned size hint.
+    def overlay_box(area : Rect) : Rect?
+      w = {area.w - 4, content_w + 10}.min
+      h = {@options.size + 2, area.h - 2}.min
+      return nil if w < 18 || area.h < 5
+      x = area.x + (area.w - w) // 2
+      y = area.y + (area.h - h) // 2
+      Rect.new(x, y, w, h)
+    end
+
+    # Row index under (mx,my), mirroring render's list loop; nil outside. Bound to
+    # the ACTUALLY rendered rows so a click on a height-clamped card's bottom border
+    # can't pick a row that was never drawn.
+    def row_at(box : Rect, mx : Int32, my : Int32) : Int32?
+      rows = {box.h - 2, @options.size}.min
+      i = my - (box.y + 1)
+      return nil if i < 0 || i >= rows
+      return nil if mx <= box.x || mx >= box.right - 1
+      ci = @scroll + i
+      ci < @options.size ? ci : nil
+    end
+
+    private def ensure_visible(rows : Int32) : Nil
+      return if rows <= 0
+      @scroll = @selected if @selected < @scroll
+      @scroll = @selected - rows + 1 if @selected >= @scroll + rows
+      @scroll = @scroll.clamp(0, {@options.size - rows, 0}.max)
+    end
+
+    def render(screen : Screen, area : Rect) : Nil
+      box = overlay_box(area)
+      unless box
+        screen.text(area.x + 1, area.y, "picker needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        return
+      end
+      Frame.card(screen, box, @title, border: Theme.border_focus)
+      rows = {box.h - 2, @options.size}.min
+      ensure_visible(rows)
+      (0...rows).each do |i|
+        ci = @scroll + i
+        break if ci >= @options.size
+        o = @options[ci]
+        ry = box.y + 1 + i
+        active = ci == @selected
+        bg = active ? Theme.accent_bg : Theme.panel
+        screen.fill(Rect.new(box.x + 1, ry, box.w - 2, 1), bg)
+        screen.cell(box.x + 1, ry, active ? '▎' : ' ', Theme.accent, bg)
+        screen.text(box.x + 3, ry, o.key.to_s, Theme.accent, bg, Attribute::Bold)
+        screen.text(box.x + 6, ry, o.label, active ? Theme.text_bright : Theme.text, bg, Attribute::Bold)
+        size = Fmt.size(o.text.bytesize.to_i64)
+        screen.text(box.right - size.size - 2, ry, size, Theme.muted, bg)
+      end
+    end
+
+    # Widest row (label + size hint), driving the card width.
+    private def content_w : Int32
+      @options.max_of { |o| o.label.size + Fmt.size(o.text.bytesize.to_i64).size + 4 }
+    end
+  end
+end

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -12,7 +12,9 @@ require "./url"
 require "./fmt"
 require "./flow_status"
 require "./read_cursor"
+require "./copy_menu"
 require "../store"
+require "../replay/flow_request"
 require "../ql"
 require "../scope"
 require "../proxy/h2/frame"
@@ -619,6 +621,34 @@ module Gori::Tui
       size, line_at = detail_line_source
       return "" if size <= 0
       @detail_read.selection_text(size, line_at) || @detail_read.current_line(size, line_at)
+    end
+
+    # The "copy as X" menu for the open detail pane: {picker title, options}. REQUEST
+    # offers url/headers/body/cookies/curl/raw (parsed from the captured bytes + the
+    # flow's target URL); RESPONSE offers status+headers/body/raw. Decoded panes
+    # (SAML/JWT/…) and the hex dump have no format variants — an empty list there lets
+    # the runner fall back to the plain selection copy.
+    def detail_copy_as_menu : {String, Array(CopyMenu::Option)}
+      detail = @detail
+      return {"COPY AS", [] of CopyMenu::Option} unless detail
+      case @detail_pane
+      when :request
+        wire = String.new(combine_bytes(detail.request_head, detail.request_body) || Bytes.empty)
+        row = detail.row
+        target = Replay::FlowRequest.build_target(row.scheme, row.host, row.port)
+        {"COPY REQUEST AS", CopyMenu.request_options(wire, target)}
+      when :response
+        head = detail.response_head
+        opts = if head
+                 body = detail.response_body
+                 CopyMenu.response_options(String.new(head), body ? String.new(body) : "")
+               else
+                 [] of CopyMenu::Option
+               end
+        {"COPY RESPONSE AS", opts}
+      else
+        {"COPY AS", [] of CopyMenu::Option}
+      end
     end
 
     def detail_selection? : Bool

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -954,6 +954,16 @@ module Gori::Tui
       @target_mode = InputMode::Read
     end
 
+    # {head, body} strings of the last HTTP response (nil until a send lands, or in
+    # WS/gRPC mode where the "response" is a transcript, not raw head+body bytes).
+    # Feeds the RESPONSE pane's "copy as X" options (status+headers / body / raw).
+    def response_parts : {String, String}?
+      return nil if @ws_mode || @grpc_mode
+      res = @result
+      return nil unless res
+      {String.new(res.head), (b = res.body) ? String.new(b) : ""}
+    end
+
     def request_bytes : Bytes
       return @req_hex_edit.not_nil!.to_bytes if @req_hex_edit # byte-exact; NO auto-CL in hex mode
       return grpc_request_bytes if @grpc_mode                 # edited head + verbatim framed body

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -33,6 +33,7 @@ require "./rules_overlay"
 require "./confirm_dialog"
 require "./browser_picker"
 require "./choice_picker"
+require "./copy_picker"
 require "./flow_picker"
 require "./subtab_picker"
 require "./links_overlay"
@@ -135,6 +136,11 @@ module Gori::Tui
       @browser_picker = nil.as(BrowserPicker?)
       # The severity/status value picker (Findings detail → space); @overlay is :choice.
       @choice_picker = nil.as(ChoicePicker?)
+      # The "copy as X" format picker (Replay/History detail → space Y). ORTHOGONAL to
+      # @overlay (like @space_menu_open) so it floats over whatever's underneath — the
+      # Replay body (@overlay :none) OR the History detail drill-in (@overlay :detail) —
+      # without disturbing that state. Non-nil ⇔ shown (see copy_as_shown?).
+      @copy_picker = nil.as(CopyPicker?)
       # The Comparer flow picker (a/b → choose flow A/B); @overlay is :comparer_pick.
       @flow_picker = nil.as(FlowPicker?)
       # The Replay sub-tab search picker (space → s); @overlay is :replay_subtab.
@@ -555,6 +561,7 @@ module Gori::Tui
 
     private def apply_preedit(text : String) : Nil
       return if @space_menu_open # the space menu has no text field — swallow IME while modal
+      return if copy_as_shown?   # copy-as picker is mnemonic-only — swallow IME while modal
       return if @goto_open       # ^G is digits-only; swallow IME (don't leak to the editor)
       if @search_open            # ^F find — IME composing text
         @search_preedit = text
@@ -624,6 +631,7 @@ module Gori::Tui
       # ^G/^F/^B guards (and everything else) so those chords can be recorded.
       return handle_hotkeys_key(ev) if @overlay == :hotkeys && @hotkeys_overlay.capturing?
       return handle_space_menu_key(ev) if @space_menu_open # the space menu is modal while up
+      return handle_copy_as_key(ev) if copy_as_shown?      # the copy-as picker is modal while up
       return handle_goto_key(ev) if @goto_open             # the ^G line prompt is modal while up
       return handle_search_key(ev) if @search_open         # the ^F find prompt is modal while up
       return handle_rename_key(ev) if @rename_open         # the sub-tab rename prompt is modal while up
@@ -832,7 +840,7 @@ module Gori::Tui
         close_import if @import_open
         return
       end
-      return unless renameable_subtabs? && @overlay == :none && !@space_menu_open && !@rename_open && subtabs_shown?
+      return unless renameable_subtabs? && @overlay == :none && !@space_menu_open && !copy_as_shown? && !@rename_open && subtabs_shown?
       sub_rect = BodyChrome.strip_rect(layout.body, strip: true)
       return unless sub_rect && sub_rect.contains?(mx, my)
       if seg = Chrome.strip_segments(BodyChrome.tab_row(sub_rect), subtab_labels, current_subtab_index, current_subtab_start).find { |(_, r)| r.contains?(mx, my) }
@@ -845,6 +853,7 @@ module Gori::Tui
     # like the keyboard). Centered modals capture every click (outside → dismiss).
     private def dispatch_click(layout : Layout, mx : Int32, my : Int32) : Nil
       return if @space_menu_open && click_space_menu(layout, mx, my)
+      return if copy_as_shown? && click_copy_as(layout.body, mx, my) # modal while up — floats over @overlay
       if @goto_open || @search_open || @rename_open || @import_open
         close_goto if @goto_open # a click anywhere dismisses the bottom prompt (like esc)
         close_search if @search_open
@@ -1143,6 +1152,7 @@ module Gori::Tui
     private def handle_wheel(layout : Layout, mx : Int32, my : Int32, dir : Int32) : Nil
       step = dir * 3
       return @space_menu.move(step) if @space_menu_open
+      return @copy_picker.try(&.move(step)) if copy_as_shown?
       return wheel_overlay(step) if modal_overlay?
       return unless layout.body.contains?(mx, my)
       # Pass the pointer + body rect so a multi-pane tab (Project) scrolls the pane
@@ -1433,6 +1443,98 @@ module Gori::Tui
     private def close_choice_picker : Nil
       @overlay = :none
       @choice_picker = nil
+    end
+
+    # Non-nil ⇔ the copy-as picker is up (orthogonal to @overlay, mirrors @space_menu_open).
+    private def copy_as_shown? : Bool
+      !@copy_picker.nil?
+    end
+
+    # "Copy as X" (space → Y): open a centered picker of the focused HTTP message's
+    # copy formats (url/headers/body/cookies/curl/raw), built from the active tab's
+    # current focus. Falls back to the plain smart-copy when the context has no format
+    # variants (a decoded/hex pane), so the verb never dead-ends.
+    def copy_as_open : Nil
+      title, options = copy_as_menu
+      if options.empty?
+        # No format variants here — degrade to the existing "Copy" behaviour.
+        return read_copy
+      end
+      @copy_picker = CopyPicker.new(title, options)
+    end
+
+    # The focus-aware option set for the active context (empty ⇒ no copy-as variants).
+    private def copy_as_menu : {String, Array(CopyMenu::Option)}
+      case @active_tab
+      when :replay
+        replay_controller.copy_as_menu
+      when :history
+        @overlay == :detail ? history_controller.detail_copy_as_menu : {"COPY AS", [] of CopyMenu::Option}
+      else
+        {"COPY AS", [] of CopyMenu::Option}
+      end
+    end
+
+    # Copy-as picker input: ↑/↓ move, ↵ or a row mnemonic copies, esc cancels (mirrors
+    # the choice picker so the two feel identical).
+    private def handle_copy_as_key(ev : Termisu::Event::Key) : Nil
+      key = ev.key
+      p = @copy_picker
+      return close_copy_picker unless p
+      case
+      when key.escape? then close_copy_picker
+      when key.up?     then p.move(-1)
+      when key.down?   then p.move(1)
+      when key.enter?  then apply_copy_as
+      else
+        if (c = ev.char) && !ev.ctrl? && !ev.alt?
+          if idx = p.index_for(c)
+            p.set_selected(idx)
+            apply_copy_as
+          elsif c == 'j'
+            p.move(1)
+          elsif c == 'k'
+            p.move(-1)
+          end
+        end
+      end
+    end
+
+    # Always consumes the click (returns true) so it never leaks to the pane below —
+    # a click on a row copies, a click outside dismisses.
+    private def click_copy_as(area : Rect, mx : Int32, my : Int32) : Bool
+      p = @copy_picker
+      box = p.try(&.overlay_box(area))
+      if p.nil? || box.nil? || dismiss_zone?(box, mx, my)
+        close_copy_picker
+        return true
+      end
+      if idx = p.row_at(box, mx, my)
+        p.set_selected(idx)
+        apply_copy_as
+      end
+      true
+    end
+
+    # Place the picked format on the clipboard, then close. Reports the label + bytes,
+    # and flags a clip when the 64KB cap truncated the payload.
+    private def apply_copy_as : Nil
+      p = @copy_picker
+      return close_copy_picker unless p
+      if opt = p.selected_option
+        written = Clipboard.copy(opt.text)
+        msg = "copied #{opt.label.downcase} (#{written}b)"
+        msg += " — clipped from #{opt.text.bytesize}b (64KB cap)" if written < opt.text.bytesize
+        @toast = msg
+      end
+      close_copy_picker
+    end
+
+    # Orthogonal to @overlay — closing just drops the picker; whatever was underneath
+    # (Replay body or the History detail drill-in) is untouched, so the user returns
+    # exactly where they invoked it.
+    private def close_copy_picker : Nil
+      @copy_picker = nil
     end
 
     # Comparer flow picker (a/b → choose flow A/B): type to filter, ↑/↓ select,
@@ -2691,9 +2793,11 @@ module Gori::Tui
       flush_screen
     end
 
-    # The space menu (bottom-right popup) + the bottom-anchored input prompts, all
-    # drawn last and orthogonal to @overlay so they float over whatever's underneath.
+    # The space menu (bottom-right popup) + the copy-as picker (centered) + the
+    # bottom-anchored input prompts, all drawn last and orthogonal to @overlay so
+    # they float over whatever's underneath (a tab body or the History detail).
     private def render_prompts(screen : Screen, layout : Layout) : Nil
+      @copy_picker.try(&.render(screen, layout.body)) if copy_as_shown?
       @space_menu.render(screen, layout.body) if @space_menu_open
       render_goto_prompt(screen, layout.status) if @goto_open
       render_search_prompt(screen, layout.status) if @search_open
@@ -2742,7 +2846,8 @@ module Gori::Tui
     # always knows which region the keys drive: an open overlay wins, else the
     # tab bar (TABS) vs the content pane (BODY).
     private def focus_label : String
-      return "SPACE" if @space_menu_open # orthogonal to @overlay — floats over it
+      return "SPACE" if @space_menu_open                             # orthogonal to @overlay — floats over it
+      return @copy_picker.try(&.title) || "COPY AS" if copy_as_shown? # ditto
       case @overlay
       when :palette       then "PALETTE"
       when :rules         then "RULES"
@@ -2789,6 +2894,7 @@ module Gori::Tui
     # under their fingers do right now).
     private def key_hints : String
       return "press a key · ↑/↓ select · ↵ run · esc close" if @space_menu_open
+      return "↑/↓ select · ↵ copy · key picks · esc cancel" if copy_as_shown?
       case @overlay
       when :palette       then "↑/↓ select · ↵ run · ⌫ · esc close · type to filter"
       when :rules         then "type rule · ↵ add · ⌫ del · ↑/↓ select · tab on/off · esc done"

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -283,6 +283,10 @@ module Gori
       # whole focused pane. Routes to the active tab's existing copy delegators
       # (not new copy logic) — mirrors read_selection_active?'s per-tab dispatch.
       abstract def read_copy : Nil
+      # "Copy as X": open a centered picker of the focused HTTP message's copy formats
+      # (url/headers/body/cookies/curl/raw). Focus-aware — the offered set follows the
+      # active pane; degrades to read_copy when the context has no format variants.
+      abstract def copy_as_open : Nil
       abstract def detail_navigable? : Bool # History detail text pane (not hex)
       # Override a verb's space-menu title (nil → use the registered default).
       abstract def space_menu_title(verb_id : String) : String?

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -69,6 +69,15 @@ module Gori
         Verb::Scope::Replay, [Verb::Chord.new("y")],
         available: in_replay_read, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
 
+      # "Copy as X": a picker of focus-aware copy formats (REQUEST → url/headers/body/
+      # cookies/curl/raw · RESPONSE → status+headers/body/raw). Sits beside Copy in
+      # COMMON so it's reachable from any Replay pane; the picker's contents adapt to
+      # the pane focused when it opens. Menu key 'Y' pairs with Copy's 'y' and is free
+      # across COMMON ∪ every Replay section (all-lowercase keys there).
+      r.register Verb::Definition.new(
+        "replay.copy-as", "Copy as…", "Pick a copy format for the focused pane (url/headers/body/cookies/curl/raw)",
+        Verb::Scope::Replay, available: in_replay_read, mnemonic: 'Y') { |ctx| ctx.copy_as_open; nil }
+
       r.register Verb::Definition.new(
         "replay.new", "New replay request", "Open a blank request in Replay to author and send",
         Verb::Scope::Replay, [Verb::Chord.new("n", ctrl: true)],
@@ -262,6 +271,13 @@ module Gori
         "detail.copy", "Copy selection", "Copy the selected text (or current line) to the clipboard",
         Verb::Scope::HistoryDetail, [Verb::Chord.new("y")],
         mnemonic: 'y') { |ctx| ctx.detail_copy_selection; nil }
+
+      # "Copy as X" for the drill-in: same focus-aware format picker as Replay, over the
+      # REQUEST/RESPONSE pane bytes. Menu key 'Y' pairs with copy's 'y' (free in the
+      # HistoryDetail menu, whose keys are y/O/r/a/c/z/h/x/b/p).
+      r.register Verb::Definition.new(
+        "detail.copy-as", "Copy as…", "Pick a copy format for this pane (url/headers/body/cookies/curl/raw)",
+        Verb::Scope::HistoryDetail, mnemonic: 'Y') { |ctx| ctx.copy_as_open; nil }
 
       r.register Verb::Definition.new(
         "detail.copy-flow", "Copy flow", "Copy this flow's raw request to the clipboard",


### PR DESCRIPTION
## What

Adds a space-menu action — **`space` → `Y`** (pairs with `y` = Copy) — that opens a **centered picker** of focus-aware copy formats for the focused HTTP message.

| Focused pane | Picker offers |
|---|---|
| Replay/Detail **REQUEST** (or TARGET) | URL · Headers · Body · Cookies · cURL · Raw request |
| Replay/Detail **RESPONSE** | Status + headers · Body · Raw response |

Works in the **Replay** tab and the **History detail** drill-in. The offered set follows the focused pane; empty formats (no body, no cookie) drop out; each row shows its byte size. Selecting one copies via OSC 52 and toasts the label + bytes (flagging the 64 KB clip). If a pane has no format variants (decoded/hex), it degrades to the plain `y` copy so the verb never dead-ends.

## How

- **`src/gori/tui/copy_menu.cr`** — pure HTTP-message → options parser (no TUI deps, fully unit-tested).
- **`src/gori/tui/copy_picker.cr`** — centered overlay, a structural twin of `ChoicePicker`.
- **Runner** wires the picker **orthogonal to `@overlay`** (same pattern as the space menu) so it floats over the Replay body *or* the History detail without disturbing either state — invoking it from a detail drill-in returns you to the detail, not the flow list.
- New verbs `replay.copy-as` / `detail.copy-as`; new `ExecContext#copy_as_open`.

The generated **cURL** emits `-X` even for a GET-with-body (curl would otherwise silently promote it to POST), drops `Host`/`Content-Length` (curl derives them), and POSIX-single-quote-escapes every argument.

## Review notes

A thorough multi-angle review ran before this PR and its findings are folded in:
- **[fixed]** Invoking Copy-as from History detail no longer ejects the user back to the flow list (overlay clobber) — the picker is now orthogonal to `@overlay`.
- **[fixed]** Mouse clicks (and wheel) now hit the picker instead of leaking to the pane below; status-bar label/hints reflect the picker.
- **[fixed]** cURL GET-with-body, empty-body "Raw response" duplicate, and a pasted-path-in-target URL-doubling edge.

## Test

- New specs: `spec/tui/copy_menu_spec.cr`, `spec/tui/copy_picker_spec.cr`.
- Full suite green except 8 pre-existing proxy-bind tests that fail in this sandbox (no listening sockets) — confirmed failing on the base commit too.
- Verified end-to-end in a live TUI (tmux): picker renders & adapts per focus, keyboard + mouse select, esc/outside-click dismiss, detail preserved.