### PR TITLE
feat(mcp): Convert + Match/Replace rules over MCP; drop noisy job-error notifications

### DIFF
--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -422,6 +422,15 @@ describe Gori::MCP::Server do
         tool_payload(resp)["output"].as_s.size.should eq(64)
       end
     end
+
+    it "rejects a separator-only spec instead of echoing the input as a phantom success" do
+      with_store do |store|
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"convert","arguments":{"input":"hello","spec":">"}}})
+        resp = drive(store, call)[0]
+        resp["result"]["isError"].as_bool.should be_true
+        resp["result"]["content"][0]["text"].as_s.should contain("no converter tokens")
+      end
+    end
   end
 
   describe "match&replace rules" do

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -392,6 +392,91 @@ describe Gori::MCP::Server do
     end
   end
 
+  describe "convert" do
+    it "runs a converter chain and returns the decoded output" do
+      with_store do |store|
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"convert","arguments":{"input":"aGVsbG8=","spec":"base64-decode"}}})
+        payload = tool_payload(drive(store, call)[0])
+        payload["output"].as_s.should eq("hello")
+        payload["output_encoding"].as_s.should eq("text")
+        payload["steps"].as_a.size.should eq(1)
+      end
+    end
+
+    it "reports an unknown converter as an error and enumerates the registry" do
+      with_store do |store|
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"convert","arguments":{"input":"x","spec":"nope-bogus"}}})
+        resp = drive(store, call)[0]
+        resp["result"]["isError"].as_bool.should be_true
+        text = resp["result"]["content"][0]["text"].as_s
+        text.should contain("unknown converter")
+        text.should contain("base64-decode")
+      end
+    end
+
+    it "is available in read-only mode (pure transform, no gating)" do
+      with_store do |store|
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"convert","arguments":{"input":"hi","spec":"sha256"}}})
+        resp = drive(store, call, allow_actions: false)[0]
+        resp["result"]["isError"]?.should_not eq(true)
+        tool_payload(resp)["output"].as_s.size.should eq(64)
+      end
+    end
+  end
+
+  describe "match&replace rules" do
+    it "creates, lists, toggles, and deletes a rule" do
+      with_store do |store|
+        create = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"create_rule","arguments":{"pattern":"secret","replacement":"REDACTED","target":"response","part":"body"}}})
+        id = tool_payload(drive(store, create)[0])["id"].as_i64
+        id.should_not eq(0)
+
+        listed = tool_payload(drive(store, %({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_rules"}}))[0])
+        listed["count"].as_i64.should eq(1)
+        rule = listed["rules"][0]
+        rule["pattern"].as_s.should eq("secret")
+        rule["target"].as_s.should eq("response")
+        rule["part"].as_s.should eq("body")
+        rule["enabled"].as_bool.should be_true
+
+        toggle = %({"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"set_rule_enabled","arguments":{"id":#{id},"enabled":false}}})
+        tool_payload(drive(store, toggle)[0])["enabled"].as_bool.should be_false
+        store.match_rules[0].enabled?.should be_false
+
+        del = %({"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"delete_rule","arguments":{"id":#{id}}}})
+        tool_payload(drive(store, del)[0])["deleted"].as_bool.should be_true
+        store.match_rules.should be_empty
+      end
+    end
+
+    it "rejects an invalid target on create (persists nothing)" do
+      with_store do |store|
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"create_rule","arguments":{"pattern":"x","target":"sideways"}}})
+        resp = drive(store, call)[0]
+        resp["result"]["isError"].as_bool.should be_true
+        store.match_rules.should be_empty
+      end
+    end
+
+    it "reports an error for delete/toggle of an unknown rule id" do
+      with_store do |store|
+        del = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"delete_rule","arguments":{"id":999}}})
+        drive(store, del)[0]["result"]["isError"].as_bool.should be_true
+      end
+    end
+
+    it "gates rule write tools in read-only mode but keeps list_rules" do
+      with_store do |store|
+        create = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"create_rule","arguments":{"pattern":"x"}}})
+        drive(store, create, allow_actions: false)[0]["result"]["isError"].as_bool.should be_true
+        store.match_rules.should be_empty
+
+        listed = tool_payload(drive(store, %({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_rules"}}), allow_actions: false)[0])
+        listed["count"].as_i64.should eq(0)
+      end
+    end
+  end
+
   describe "create_replay and update_replay" do
     it "creates a new replay from raw payload and returns context fields" do
       with_store do |store|

--- a/src/gori/mcp/server.cr
+++ b/src/gori/mcp/server.cr
@@ -119,15 +119,17 @@ module Gori
       # disabled by read-only mode, rather than discovering it only on a rejected call.
       private def instructions_text : String
         base = "gori MCP exposes the active project's captured HTTP traffic " \
-               "(history, flows, sitemap, scope, findings). Call ql_reference before " \
+               "(history, flows, sitemap, scope, findings, notes, match&replace rules), plus a " \
+               "pure `convert` encode/decode/hash tool. Call ql_reference before " \
                "writing list_history/list_sitemap queries. Timestamps include unix " \
                "microseconds plus *_iso RFC3339 fields where available."
         if @allow_actions
           "#{base} Action tools are enabled: send_request (supports flow_id replay), " \
-          "fuzz_*, mine_*, and create/update_finding make real outbound requests or mutate findings."
+          "fuzz_*, mine_*, create/update_finding, and create/delete_rule + set_rule_enabled " \
+          "make real outbound requests or mutate findings/rules."
         else
           "#{base} Read-only mode: action tools (send_request, fuzz_*, mine_*, " \
-          "create/update_finding) are disabled — restart without --read-only to enable them."
+          "create/update_finding, create/delete_rule) are disabled — restart without --read-only to enable them."
         end
       end
 

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -1057,6 +1057,10 @@ module Gori
       private def convert(h) : Result
         spec = str(h, "spec")
         return Result.new("missing required 'spec'", is_error: true) if spec.nil? || spec.strip.empty?
+        # A spec that is only separators (">", ",", "|") parses to zero tokens, which
+        # Chain.run treats as identity — reject it rather than reporting a phantom
+        # "success" that echoes the input back unchanged.
+        return Result.new("'spec' has no converter tokens (e.g. 'base64-decode > gunzip')", is_error: true) if Convert.parse_spec(spec).empty?
         raw = str(h, "input")
         return Result.new("missing required 'input'", is_error: true) if raw.nil?
 
@@ -1137,12 +1141,12 @@ module Gori
         pattern = str(h, "pattern")
         return Result.new("missing required 'pattern'", is_error: true) if pattern.nil? || pattern.empty?
 
-        tgt_s = str(h, "target")
-        target = tgt_s && !tgt_s.strip.empty? ? Store::RuleTarget.parse?(tgt_s.strip) : Store::RuleTarget::Request
+        tgt_s = str(h, "target").try(&.strip)
+        target = tgt_s.nil? || tgt_s.empty? ? Store::RuleTarget::Request : Store::RuleTarget.parse?(tgt_s)
         return Result.new("invalid 'target' (expected request|response)", is_error: true) unless target
 
-        part_s = str(h, "part")
-        part = part_s && !part_s.strip.empty? ? Store::RulePart.parse?(part_s.strip) : Store::RulePart::Head
+        part_s = str(h, "part").try(&.strip)
+        part = part_s.nil? || part_s.empty? ? Store::RulePart::Head : Store::RulePart.parse?(part_s)
         return Result.new("invalid 'part' (expected head|body)", is_error: true) unless part
 
         replacement = str(h, "replacement") || ""
@@ -1162,7 +1166,7 @@ module Gori
         return Result.new(id_error(h, "id"), is_error: true) unless id
         enabled = bool(h, "enabled")
         return Result.new("missing required 'enabled' (true|false)", is_error: true) if enabled.nil?
-        return Result.new("no rule with id #{id}", is_error: true) unless @store.match_rules.any? { |r| r.id == id }
+        return Result.new("no rule with id #{id}", is_error: true) unless rule_exists?(id)
         @store.set_rule_enabled(id, enabled)
         Result.new(JSON.build { |j| j.object { j.field "id", id; j.field "enabled", enabled } })
       end
@@ -1170,9 +1174,16 @@ module Gori
       private def delete_rule(h) : Result
         id = int(h, "id")
         return Result.new(id_error(h, "id"), is_error: true) unless id
-        return Result.new("no rule with id #{id}", is_error: true) unless @store.match_rules.any? { |r| r.id == id }
+        return Result.new("no rule with id #{id}", is_error: true) unless rule_exists?(id)
         @store.delete_rule(id)
         Result.new(JSON.build { |j| j.object { j.field "id", id; j.field "deleted", true } })
+      end
+
+      # Whether a Match&Replace rule id exists. A full read (the store has no
+      # single-row rule fetch), but the rule set is tiny and enable/disable/delete
+      # are low-frequency actions.
+      private def rule_exists?(id : Int64) : Bool
+        @store.match_rules.any? { |r| r.id == id }
       end
 
       private def create_replay(h) : Result

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -45,6 +45,11 @@ module Gori
 
       MCP_REPLAY_REQUEST_MAX = 16 * 1024
 
+      # Ceiling on the `convert` tool's returned output string. A Convert step can
+      # produce up to 32 MiB (Convert::MAX_OUT); returning that inline would swamp
+      # the JSON-RPC channel, so truncate the display string and flag it.
+      CONVERT_MAX_OUTPUT = 256 * 1024
+
       def initialize(@store : Store, @allow_actions : Bool, @verify_upstream : Bool,
                      @project_name : String? = nil, @project_slug : String? = nil,
                      @db_path : String? = nil)
@@ -183,7 +188,43 @@ module Gori
             s.field "id", intprop("database note ID"), required: true
           end
 
+          tool j, "convert",
+            "Run a gori Convert chain (encode/decode/hash/compress) over `input` and return the " \
+            "result — the same engine as the TUI Convert tab. Pure transform: no network, no state. " \
+            "`spec` is converter tokens separated by '>', '|' or ',' applied left-to-right, e.g. " \
+            "'base64-decode > gunzip', 'url-encode', 'sha256'. Common converters: base64, " \
+            "base64-decode, url-encode, url-decode, hex, hex-decode, gzip, gunzip, deflate, inflate, " \
+            "jwt-decode, html-encode, md5, sha1, sha256. An unknown token returns the full list." do |s|
+            s.field "input", strprop("the value to transform (UTF-8 text unless input_base64 is set)"), required: true
+            s.field "spec", strprop("converter chain, e.g. 'base64-decode > gunzip'"), required: true
+            s.field "input_base64", boolprop("treat `input` as base64 and decode it to raw bytes first (for binary input)")
+          end
+
+          tool j, "list_rules",
+            "List the project's Match & Replace rules (literal substring rewrites applied to " \
+            "in-flight request/response HEAD or BODY), in apply order." { }
+
           if @allow_actions
+            tool j, "create_rule",
+              "Add a Match & Replace rule (a literal substring rewrite applied to in-flight traffic). " \
+              "Persisted to the project. Note: a gori TUI already running applies it only after its " \
+              "rules reload (reopen the rules editor or restart); `gori run` and newly opened TUIs " \
+              "pick it up immediately." do |s|
+              s.field "pattern", strprop("literal substring to match"), required: true
+              s.field "replacement", strprop("literal replacement (empty = delete the pattern; default empty)")
+              s.field "target", strprop("request|response (default request)")
+              s.field "part", strprop("head|body — head = request/status line + headers, body = entity body (default head)")
+            end
+
+            tool j, "set_rule_enabled", "Enable or disable a Match & Replace rule by id." do |s|
+              s.field "id", intprop("rule id from list_rules"), required: true
+              s.field "enabled", boolprop("true to enable, false to disable"), required: true
+            end
+
+            tool j, "delete_rule", "Delete a Match & Replace rule by id." do |s|
+              s.field "id", intprop("rule id from list_rules"), required: true
+            end
+
             tool j, "create_note", "Create a new note with optional text content." do |s|
               s.field "text", strprop("initial text content for the new note")
             end
@@ -371,6 +412,8 @@ module Gori
         when "ql_reference"        then ql_reference
         when "list_notes"          then list_notes
         when "get_note"            then get_note(h)
+        when "convert"             then convert(h)
+        when "list_rules"          then list_rules
         end
       end
 
@@ -395,6 +438,9 @@ module Gori
         when "create_note"    then gated { create_note(h) }
         when "update_note"    then gated { update_note(h) }
         when "delete_note"    then gated { delete_note(h) }
+        when "create_rule"       then gated { create_rule(h) }
+        when "set_rule_enabled"  then gated { set_rule_enabled(h) }
+        when "delete_rule"       then gated { delete_rule(h) }
         end
       end
 
@@ -1003,6 +1049,130 @@ module Gori
             j.field "message", "Note deleted successfully"
           end
         end)
+      end
+
+      # Run a Convert chain over caller-supplied bytes. Pure: no store, no network,
+      # so it's a read tool (always exposed). A failed/unknown step is a tool-level
+      # error; an unknown token also enumerates the registry so the model can retry.
+      private def convert(h) : Result
+        spec = str(h, "spec")
+        return Result.new("missing required 'spec'", is_error: true) if spec.nil? || spec.strip.empty?
+        raw = str(h, "input")
+        return Result.new("missing required 'input'", is_error: true) if raw.nil?
+
+        input =
+          if bool(h, "input_base64")
+            begin
+              Base64.decode(raw)
+            rescue
+              return Result.new("invalid 'input': input_base64 is set but the value is not valid base64", is_error: true)
+            end
+          else
+            raw.to_slice
+          end
+
+        reg = Convert.shared_registry
+        result = Convert.run(reg, input, spec)
+
+        if (idx = result.failed_at)
+          step = result.steps[idx]
+          msg = "convert failed at step #{idx + 1} '#{step.token}': #{step.error || "failed"}"
+          msg += " — available converters: #{reg.names.join(", ")}" if step.state.unknown?
+          return Result.new(msg, is_error: true)
+        end
+
+        out_bytes = result.output || Bytes.empty
+        text, mode = Convert.display(out_bytes)
+        # Bound the channel: Chain.run caps a step at 32 MiB, far too large to return
+        # inline. Truncate on a byte budget and scrub so a split multibyte char can't
+        # emit invalid UTF-8 into the JSON string; `output_bytes` keeps the true size.
+        truncated = text.bytesize > CONVERT_MAX_OUTPUT
+        text = text.byte_slice(0, CONVERT_MAX_OUTPUT).scrub if truncated
+
+        Result.new(JSON.build do |j|
+          j.object do
+            j.field "spec", spec
+            j.field "output", text
+            j.field "output_encoding", mode.to_s.downcase
+            j.field "output_bytes", out_bytes.size
+            j.field("output_truncated", true) if truncated
+            j.field "steps" do
+              j.array do
+                result.steps.each do |s|
+                  j.object do
+                    j.field "converter", s.name
+                    j.field "state", s.state.to_s.downcase
+                  end
+                end
+              end
+            end
+          end
+        end)
+      end
+
+      private def list_rules : Result
+        rules = @store.match_rules
+        Result.new(JSON.build do |j|
+          j.object do
+            j.field "count", rules.size
+            j.field "rules" do
+              j.array do
+                rules.each do |r|
+                  j.object do
+                    j.field "id", r.id
+                    j.field "enabled", r.enabled?
+                    j.field "target", r.target.label
+                    j.field "part", r.part.label
+                    j.field "pattern", r.pattern
+                    j.field "replacement", r.replacement
+                  end
+                end
+              end
+            end
+          end
+        end)
+      end
+
+      private def create_rule(h) : Result
+        pattern = str(h, "pattern")
+        return Result.new("missing required 'pattern'", is_error: true) if pattern.nil? || pattern.empty?
+
+        tgt_s = str(h, "target")
+        target = tgt_s && !tgt_s.strip.empty? ? Store::RuleTarget.parse?(tgt_s.strip) : Store::RuleTarget::Request
+        return Result.new("invalid 'target' (expected request|response)", is_error: true) unless target
+
+        part_s = str(h, "part")
+        part = part_s && !part_s.strip.empty? ? Store::RulePart.parse?(part_s.strip) : Store::RulePart::Head
+        return Result.new("invalid 'part' (expected head|body)", is_error: true) unless part
+
+        replacement = str(h, "replacement") || ""
+        id = @store.insert_rule(target, part, pattern, replacement)
+        return Result.new("failed to persist rule (store busy or unwritable)", is_error: true) if id == 0
+        Result.new(JSON.build do |j|
+          j.object do
+            j.field "id", id
+            j.field "target", target.label
+            j.field "part", part.label
+          end
+        end)
+      end
+
+      private def set_rule_enabled(h) : Result
+        id = int(h, "id")
+        return Result.new(id_error(h, "id"), is_error: true) unless id
+        enabled = bool(h, "enabled")
+        return Result.new("missing required 'enabled' (true|false)", is_error: true) if enabled.nil?
+        return Result.new("no rule with id #{id}", is_error: true) unless @store.match_rules.any? { |r| r.id == id }
+        @store.set_rule_enabled(id, enabled)
+        Result.new(JSON.build { |j| j.object { j.field "id", id; j.field "enabled", enabled } })
+      end
+
+      private def delete_rule(h) : Result
+        id = int(h, "id")
+        return Result.new(id_error(h, "id"), is_error: true) unless id
+        return Result.new("no rule with id #{id}", is_error: true) unless @store.match_rules.any? { |r| r.id == id }
+        @store.delete_rule(id)
+        Result.new(JSON.build { |j| j.object { j.field "id", id; j.field "deleted", true } })
       end
 
       private def create_replay(h) : Result

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -643,10 +643,11 @@ module Gori::Tui
         finish_job(v, ev)
       when Fuzz::ErrorEvent
         v.finish_run
-        # Persist the failure in the bottom bar + notification center so it survives the
-        # next keystroke (a transient toast alone is cleared on the very next key).
+        # The failure persists in the jobs center (survives the next keystroke) and shows
+        # in the bottom bar. It is deliberately NOT pushed to the notification center: a
+        # job error is an operational failure, not a result the human wants surfaced there
+        # (and it already had two other surfaces) — see #127.
         @host.jobs.finish(v.job_id, :error, ev.message)
-        @host.notifications.push(:error, "Fuzzer: #{ev.message} on #{v.summary}", goto_for(v))
         @host.status("fuzz error: #{ev.message}")
       end
     end

--- a/src/gori/tui/controllers/prism_controller.cr
+++ b/src/gori/tui/controllers/prism_controller.cr
@@ -178,7 +178,8 @@ module Gori::Tui
             @host.status("Prism: #{summary}")
           end
         when Prism::ErrorEvent
-          @host.notifications.push(:warn, ev.message)
+          # Bottom bar only — a scan error is operational noise, not a result to push
+          # into the notification center (#127).
           @host.status(ev.message)
         end
       end


### PR DESCRIPTION
Extends the MCP seam so an agent can transform bytes and manage Match & Replace rules through the same headless surface, and de-noises the human notification center. Part of the manual-first + AI-seam direction (issues #125, #127).

## What

**#125 — Convert + Match/Replace over MCP** (`src/gori/mcp/tools.cr`)
- `convert` (read tool, always available): runs a gori Convert chain over caller-supplied bytes — the same engine as the TUI Convert tab. Pure transform, no store/network. `spec` is converter tokens (`base64-decode > gunzip`, `url-encode`, `sha256`); an unknown token errors and enumerates the registry so the model can retry. Output is bounded (`CONVERT_MAX_OUTPUT`, scrubbed to stay valid UTF-8) with the true byte size reported.
- `list_rules` (read), `create_rule` / `set_rule_enabled` / `delete_rule` (gated behind `allow_actions`): list/add/toggle/remove Match & Replace rules, including the `head`/`body` part (V30). Rules persist to the store; a running TUI applies them after its rules reload — noted in the tool description.
- Handshake `instructions` updated to advertise the new surface.

**#127 — drop noisy job-error notifications** (`fuzzer_controller.cr`, `prism_controller.cr`)
- Background-job **errors** no longer push into the human notification center. They already surface in the jobs center (`jobs.finish`) and the bottom status bar; the notification ring is for results the human wants to perceive (miner params, fuzzer hits, prism issues), not operational failures.

## Not here (deliberately deferred)

`#123` (drive live intercept from MCP) and the **producer** half of `#124` (agent → human notification) both need a new cross-process signal into the live TUI/proxy process — the intercept hold queue and notification ring are in-memory/ephemeral, and MCP is a separate headless process. That is a correctness-critical change to the intercept hot path and belongs in its own PR after a design decision (store-backed queue driven by the existing `data_version` poll vs a control socket).

## Tests

- New `mcp_spec` coverage: convert (chain, unknown-token enumeration, read-only availability, separator-only-spec rejection) and rules (CRUD, invalid target, unknown id, read-only gating).
- Full suite green: `1547 examples, 0 failures`.

## Review

Self-reviewed at high effort (8 finder angles). Fixed: separator-only `spec` was returning the input as a phantom success. Refuted: a claim that `Base64.decode` is lenient (it raises on invalid input, verified). Tidied rule enum parsing and deduped the id-existence check.

## KO

MCP(헤드리스)에 순수 `convert` 체인 툴과 Match/Replace 룰 툴을 노출(#125), fuzzer/prism 잡 **에러**를 사람용 notification에서 제거(#127 — 이미 jobs 센터+상태바에 뜨는 중복 노이즈). #123·#124 producer는 라이브 프록시로의 크로스프로세스 시그널이 필요해 별도 PR로 분리.
