### PR TITLE
fix(tui): sync caret to the ^G target line in response/history-detail panes

### DIFF
--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -250,6 +250,30 @@ describe Gori::Tui::HistoryView do
     end
   end
 
+  it "^G go-to-line in the detail view also moves the caret (not just the scroll)" do
+    tmp_store do |store|
+      id = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "https", host: "h.test", port: 443,
+        method: "GET", target: "/api", http_version: "HTTP/1.1",
+        head: "GET /api HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice, body: nil))
+      store.update_response(Gori::Store::CapturedResponse.new(
+        flow_id: id, status: 200,
+        head: "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n".to_slice,
+        body: "LINE1\nLINE2\nLINE3\nLINE4".to_slice, content_type: "text/plain"))
+
+      view = HistoryView.new
+      view.reload(store)
+      view.open_detail(store).should be_true
+      view.toggle_pane # request -> response
+      line3 = view.detail_search_lines("LINE3").first # 0-based row of the body's 3rd line
+
+      view.goto_detail_line(line3 + 1) # 1-based
+      view.detail_copy_text.should eq("LINE3")
+      view.detail_move(-1, 0) # ↑ should step to LINE2, not jump from a stale pre-goto caret
+      view.detail_copy_text.should eq("LINE2")
+    end
+  end
+
   it "pretty-prints a JSON response body when enabled, and restores raw when off" do
     tmp_store do |store|
       id = store.insert_flow(Gori::Store::CapturedRequest.new(

--- a/spec/tui/replay_view_spec.cr
+++ b/spec/tui/replay_view_spec.cr
@@ -628,6 +628,21 @@ describe Gori::Tui::ReplayView do
     view.resp_copy_text.should eq(lines[0][0, 4])
   end
 
+  it "^G go-to-line in the response pane also moves the caret (not just the scroll)" do
+    view = ReplayView.new
+    view.load_blank
+    ok = Gori::Replay::Result.new(
+      "HTTP/1.1 200 OK\r\n\r\n".to_slice, "LINE1\nLINE2\nLINE3\nLINE4".to_slice, nil, 1000_i64)
+    view.apply(ok)
+    view.focus_pane(:response)
+    line3 = view.response_search_lines("LINE3").first # 0-based row of the body's 3rd line
+
+    view.goto_response_line(line3 + 1) # 1-based
+    view.resp_copy_text.should eq("LINE3")
+    view.resp_move(-1, 0) # ↑ should step to LINE2, not jump from a stale pre-goto caret
+    view.resp_copy_text.should eq("LINE2")
+  end
+
   it "apply_peer_request keeps live response + focus (reconcile must not wipe a send)" do
     # Regression: reconcile used full restore() for request-side sync. restore() always
     # sets focus=:target and clears @result when no response BLOBs are passed — so a

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -717,9 +717,20 @@ module Gori::Tui
     end
 
     # ^G go-to-line in the detail view: scroll so 1-based line `n` is at the top
-    # (interpreted in the active pane/mode — request/response/frames/hex row).
+    # (interpreted in the active pane/mode — request/response/frames/hex row). Hex
+    # has no caret; in navigable (cursor-tracked) modes, sync @detail_read too —
+    # otherwise the first ↑/↓ after the jump moves from the caret's stale pre-jump
+    # position instead of the line just jumped to.
     def goto_detail_line(n : Int32) : Nil
-      @detail_scroll = (n - 1).clamp(0, detail_scroll_max)
+      if detail_navigable?
+        size, _ = detail_line_source
+        return if size <= 0
+        cy = (n - 1).clamp(0, size - 1)
+        @detail_read.sync(cy, 0)
+        @detail_scroll = cy
+      else
+        @detail_scroll = (n - 1).clamp(0, detail_scroll_max)
+      end
     end
 
     # ^F search: 0-based indices of the detail text lines containing `query` (case-

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -1911,9 +1911,20 @@ module Gori::Tui
     end
 
     # ^G go-to-line in the response pane: scroll so 1-based line `n` is at the top
-    # (interpreted in the currently-shown mode — response/diff/hex row).
+    # (interpreted in the currently-shown mode — response/diff/hex row). Hex mode has
+    # no caret to move; in navigable (cursor-tracked) modes, sync @resp_cursor too —
+    # otherwise the first ↑/↓ after the jump moves from the caret's stale pre-jump
+    # position instead of the line just jumped to.
     def goto_response_line(n : Int32) : Nil
-      @scroll = (n - 1).clamp(0, {resp_line_count - 1, 0}.max)
+      if resp_navigable?
+        size, _ = resp_line_source
+        return if size <= 0
+        cy = (n - 1).clamp(0, size - 1)
+        @resp_cursor.sync(cy, 0)
+        @scroll = cy
+      else
+        @scroll = (n - 1).clamp(0, {resp_line_count - 1, 0}.max)
+      end
     end
 
     # ^F search in the response pane: 0-based line indices containing `query` in the


### PR DESCRIPTION
## Summary
- `^G` go-to-line in the Replay Response pane and History detail pane only scrolled the viewport (`@scroll`), leaving the `ReadCursor` caret at its old position — so the first ↑/↓ after jumping moved from the stale spot instead of the line just jumped to.
- Fixed `goto_response_line` and `goto_detail_line` to sync the caret alongside the scroll in navigable (non-hex) modes, mirroring the pattern mouse-wheel scrolling already used.
- Editors backed by `TextArea` (Notes/Project/Intercept/request editor) were already correct — `@cy`/`@cx` are a single source of truth there.

## Test plan
- [x] Added regression specs in `spec/tui/replay_view_spec.cr` and `spec/tui/history_view_spec.cr`; verified both fail on the pre-fix code and pass after the fix.
- [x] `crystal spec` — full suite passes except 8 pre-existing, unrelated failures (proxy port binding in this sandbox), confirmed to fail identically on `main`.