### PR TITLE
feat(tui): Replay sub-tab tags + tag-filter the strip (#121)

### DIFF
--- a/spec/replay/subtab_filter_spec.cr
+++ b/spec/replay/subtab_filter_spec.cr
@@ -1,0 +1,76 @@
+require "../spec_helper"
+require "../../src/gori/replay/subtab_filter"
+
+include Gori
+
+private def subj(name : String?, summary : String, target : String, method : String, tags : Array(String)) : Replay::SubtabFilter::Subject
+  Replay::SubtabFilter::Subject.new(name, summary, target, method, tags)
+end
+
+private def filtered(query : String, list : Array(Replay::SubtabFilter::Subject)) : Array(Replay::SubtabFilter::Subject)
+  Replay::SubtabFilter.parse(query).apply(list)
+end
+
+describe Gori::Replay::Tags do
+  it "splits on whitespace and commas, strips a leading #, dedupes case-insensitively" do
+    Replay::Tags.parse("idor  #auth, IDOR").should eq(["idor", "auth"])
+    Replay::Tags.parse(nil).should eq([] of String)
+    Replay::Tags.parse("   ").should eq([] of String)
+  end
+
+  it "serializes to a space-joined string (nil when empty)" do
+    Replay::Tags.serialize(["idor", "auth"]).should eq("idor auth")
+    Replay::Tags.serialize([] of String).should be_nil
+  end
+
+  it "round-trips parse ∘ serialize" do
+    Replay::Tags.parse(Replay::Tags.serialize(["a", "b-c"])).should eq(["a", "b-c"])
+  end
+end
+
+describe Gori::Replay::SubtabFilter do
+  list = [
+    subj("orders probe", "GET /orders", "https://app.example.com/orders", "GET", ["idor", "auth"]),
+    subj(nil, "POST /login", "https://api.example.com/login", "POST", ["auth"]),
+    subj("done", "DELETE /cart", "https://app.example.com/cart", "DELETE", ["done"]),
+  ]
+
+  it "passes everything for an empty query" do
+    filtered("", list).size.should eq(3)
+    Replay::SubtabFilter.parse("").empty?.should be_true
+  end
+
+  it "filters by tag (case-insensitive substring over any tag)" do
+    filtered("tag:idor", list).map(&.summary).should eq(["GET /orders"])
+    filtered("tag:auth", list).size.should eq(2)
+    filtered("tag:AUTH", list).size.should eq(2)
+  end
+
+  it "filters by name, host/target and method" do
+    filtered("name:orders", list).map(&.summary).should eq(["GET /orders"])
+    filtered("host:api", list).map(&.summary).should eq(["POST /login"])
+    filtered("target:app.example", list).size.should eq(2)
+    filtered("method:post", list).map(&.summary).should eq(["POST /login"])
+  end
+
+  it "negates a field term with a leading -" do
+    filtered("-tag:done", list).map(&.summary).should eq(["GET /orders", "POST /login"])
+    filtered("tag:auth -host:api", list).map(&.summary).should eq(["GET /orders"])
+  end
+
+  it "treats an empty value as match-all (mid-type), and its negation as match-none" do
+    filtered("tag:", list).size.should eq(3)
+    filtered("-tag:", list).size.should eq(0)
+  end
+
+  it "matches bare words as free text over name/summary/target/tags" do
+    filtered("login", list).map(&.summary).should eq(["POST /login"]) # summary
+    filtered("idor", list).map(&.summary).should eq(["GET /orders"])  # tag
+    filtered("orders", list).size.should eq(1)                        # name + summary + target
+  end
+
+  it "AND-joins multiple terms" do
+    filtered("tag:auth method:get", list).map(&.summary).should eq(["GET /orders"])
+    filtered("tag:auth method:patch", list).should be_empty
+  end
+end

--- a/spec/store/entity_links_spec.cr
+++ b/spec/store/entity_links_spec.cr
@@ -73,6 +73,7 @@ describe "entity_links (V21)" do
       store.@db.exec("ALTER TABLE prism_issues DROP COLUMN sample_replay_id") # V28
       store.@db.exec("DROP TABLE prism_suppressions")                         # V29
       store.@db.exec("ALTER TABLE match_rules DROP COLUMN part")              # V30
+      store.@db.exec("ALTER TABLE replays DROP COLUMN tags")                  # V31
       store.@db.exec("PRAGMA user_version = 20")
       store.close
 

--- a/spec/store/store_spec.cr
+++ b/spec/store/store_spec.cr
@@ -52,6 +52,7 @@ describe Gori::Store do
       store.@db.exec("DROP INDEX idx_h2_frames_created")               # V27
       store.@db.exec("DROP TABLE prism_suppressions")                  # V29
       store.@db.exec("ALTER TABLE match_rules DROP COLUMN part")       # V30
+      store.@db.exec("ALTER TABLE replays DROP COLUMN tags")           # V31
       store.@db.exec("PRAGMA user_version = 17")
       store.close
 

--- a/spec/store_replays_spec.cr
+++ b/spec/store_replays_spec.cr
@@ -138,4 +138,20 @@ describe "Gori::Store replay tabs (v9)" do
       store.replays.find!(&.id.==(id)).mark_transform?.should be_true
     end
   end
+
+  it "round-trips the V31 tags column (default nil, set + clear)" do
+    with_store do |store|
+      id = store.insert_replay("https://a.test", "GET / HTTP/1.1\r\n\r\n", false, true, nil, 0)
+      store.replays.find!(&.id.==(id)).tags.should be_nil # untagged by default
+
+      store.set_replay_tags(id, "idor auth")
+      store.replays.find!(&.id.==(id)).tags.should eq("idor auth")
+
+      # tagging does not rewrite the request (its own narrow UPDATE, like the name)
+      store.replays.find!(&.id.==(id)).request.should eq("GET / HTTP/1.1\r\n\r\n")
+
+      store.set_replay_tags(id, nil) # blank clears the column back to NULL
+      store.replays.find!(&.id.==(id)).tags.should be_nil
+    end
+  end
 end

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -85,6 +85,10 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def replay_rename_subtab : Nil; end
 
+  def replay_tag_subtab : Nil; end
+
+  def replay_filter_subtabs : Nil; end
+
   def replay_close_subtab : Nil; end
 
   def replay_duplicate_subtab : Nil; end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -152,6 +152,14 @@ private class FakeContext < ExecContext
     @calls << :replay_rename_subtab
   end
 
+  def replay_tag_subtab : Nil
+    @calls << :replay_tag_subtab
+  end
+
+  def replay_filter_subtabs : Nil
+    @calls << :replay_filter_subtabs
+  end
+
   def replay_close_subtab : Nil
     @calls << :replay_close_subtab
   end

--- a/src/gori/replay/subtab_filter.cr
+++ b/src/gori/replay/subtab_filter.cr
@@ -1,0 +1,129 @@
+module Gori
+  module Replay
+    # Normalize the flat tag set a Replay session carries. Tags are whitespace-free
+    # tokens ("idor", "auth-bypass"); the editor accepts them space/comma separated
+    # and may prefix them with `#`. Stored as one space-joined column (V31); the
+    # multi-label set lives in memory as an Array.
+    module Tags
+      # Parse a raw editor string / stored column into a deduped token list. Splits on
+      # whitespace and commas, strips a leading `#`, drops blanks, and de-duplicates
+      # case-insensitively (keeping the first-seen casing).
+      def self.parse(raw : String?) : Array(String)
+        return [] of String unless raw
+        seen = Set(String).new
+        out = [] of String
+        raw.split(/[\s,]+/).each do |tok|
+          t = tok.strip.lstrip('#')
+          next if t.empty?
+          key = t.downcase
+          next if seen.includes?(key)
+          seen << key
+          out << t
+        end
+        out
+      end
+
+      # Space-joined column value for the store; nil when there are no tags (so an
+      # empty set clears the column, like a blank name).
+      def self.serialize(tags : Array(String)) : String?
+        tags.empty? ? nil : tags.join(' ')
+      end
+    end
+
+    # An in-memory predicate over Replay sub-tabs, parsed from a History-like filter
+    # string. Replay sessions live wholly in memory, so — unlike History's QL→SQL —
+    # this matches Crystal-side (the same shape as Findings::Filter). Terms are
+    # whitespace-separated and AND-joined; a leading `-` negates a field term; an
+    # unrecognised or bare token is free text over name + summary + target + tags.
+    #
+    #   idor                    → free text "idor" (name/summary/target/tag)
+    #   tag:idor method:post    → tagged "idor" AND a POST request
+    #   -tag:done host:api      → not tagged "done" AND target contains "api"
+    class SubtabFilter
+      # The searchable projection of one Replay session. Kept free of TUI types so the
+      # matcher is pure + unit-testable; the controller builds these from its views.
+      record Subject,
+        name : String?,
+        summary : String,
+        target : String,
+        method : String,
+        tags : Array(String)
+
+      private record Term, kind : Symbol, text : String, negate : Bool
+
+      def self.parse(query : String) : SubtabFilter
+        terms = [] of Term
+        query.split.each do |raw|
+          next if raw.empty?
+          negate = false
+          tok = raw
+          if tok.starts_with?('-') && tok.size > 1
+            negate = true
+            tok = tok[1..]
+          end
+          terms << build_term(tok, negate)
+        end
+        new(terms)
+      end
+
+      def initialize(@terms : Array(Term))
+      end
+
+      def empty? : Bool
+        @terms.empty?
+      end
+
+      # Keep input order; every term must match (AND). An empty filter passes all.
+      def apply(subjects : Array(Subject)) : Array(Subject)
+        return subjects if @terms.empty?
+        subjects.select { |s| matches?(s) }
+      end
+
+      def matches?(s : Subject) : Bool
+        @terms.all? { |t| match_term(t, s) }
+      end
+
+      # --- parsing -------------------------------------------------------------
+
+      private def self.build_term(tok : String, negate : Bool) : Term
+        if colon = tok.index(':')
+          field = tok[0...colon].downcase
+          value = tok[(colon + 1)..].downcase
+          case field
+          when "tag"            then return Term.new(:tag, value.lstrip('#'), negate)
+          when "name"           then return Term.new(:name, value, negate)
+          when "host", "target" then return Term.new(:target, value, negate)
+          when "method", "verb" then return Term.new(:method, value, negate)
+          end
+        end
+        # Unrecognised prefix or bare token → free text (name/summary/target/tags).
+        Term.new(:text, tok.downcase, negate)
+      end
+
+      # --- matching ------------------------------------------------------------
+
+      private def match_term(t : Term, s : Subject) : Bool
+        # An empty value (mid-type "tag:" / "method:") matches all, so the strip
+        # doesn't blank out until a value is typed — uniform across every field kind.
+        # Negation is honoured: `tag:` matches all, so `-tag:` matches none.
+        return !t.negate if t.text.empty?
+        hit = case t.kind
+              when :tag    then s.tags.any?(&.downcase.includes?(t.text))
+              when :name   then (s.name || "").downcase.includes?(t.text)
+              when :target then s.target.downcase.includes?(t.text)
+              when :method then s.method.downcase.includes?(t.text)
+              else              free_text(t.text, s)
+              end
+        t.negate ? !hit : hit
+      end
+
+      private def free_text(text : String, s : Subject) : Bool
+        return true if text.empty?
+        (s.name || "").downcase.includes?(text) ||
+          s.summary.downcase.includes?(text) ||
+          s.target.downcase.includes?(text) ||
+          s.tags.any?(&.downcase.includes?(text))
+      end
+    end
+  end
+end

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -804,13 +804,13 @@ module Gori
     # (potentially multi-MB) response on each cross-session commit.
     def replays : Array(ReplayRecord)
       list = [] of ReplayRecord
-      @db.query("SELECT id, target, request, http2, auto_content_length, flow_id, position, response_head, response_body, response_error, response_duration_us, name, sni, mark_transform FROM replays ORDER BY position, id") do |rs|
+      @db.query("SELECT id, target, request, http2, auto_content_length, flow_id, position, response_head, response_body, response_error, response_duration_us, name, sni, mark_transform, tags FROM replays ORDER BY position, id") do |rs|
         rs.each do
           list << ReplayRecord.new(
             rs.read(Int64), rs.read(String), rs.read(String),
             rs.read(Int32) != 0, rs.read(Int32) != 0, rs.read(Int64?), rs.read(Int32),
             rs.read(Bytes?), rs.read(Bytes?), rs.read(String?), rs.read(Int64?), rs.read(String?), rs.read(String?),
-            mark_transform: rs.read(Int32) != 0)
+            mark_transform: rs.read(Int32) != 0, tags: rs.read(String?))
         end
       end
       list
@@ -889,6 +889,16 @@ module Gori
     def set_replay_name(id : Int64, name : String?) : Nil
       exec_task ->(c : DB::Connection) {
         c.exec("UPDATE replays SET name = ?, updated_at = ? WHERE id = ?", name, now_us, id)
+        nil
+      }
+    end
+
+    # Set (or clear, with nil) a replay tab's flat tags (V31) — its own narrow UPDATE,
+    # like set_replay_name, so tagging never rewrites the request. `tags` is the
+    # space-joined token set; nil/blank clears it.
+    def set_replay_tags(id : Int64, tags : String?) : Nil
+      exec_task ->(c : DB::Connection) {
+        c.exec("UPDATE replays SET tags = ?, updated_at = ? WHERE id = ?", tags, now_us, id)
         nil
       }
     end

--- a/src/gori/store/models.cr
+++ b/src/gori/store/models.cr
@@ -342,10 +342,12 @@ module Gori
       getter name : String?         # custom sub-tab label (nil = derive from the request)
       getter sni : String?          # custom TLS SNI host (nil = present the target host)
       getter? mark_transform : Bool # V22: apply §…§ inline Convert chains on send
+      getter tags : String?         # V31: space-joined flat tags (nil = untagged)
 
       def initialize(@id, @target, @request, @http2, @auto_content_length, @flow_id, @position,
                      @response_head = nil, @response_body = nil, @response_error = nil,
-                     @response_duration_us = nil, @name = nil, @sni = nil, @mark_transform = false)
+                     @response_duration_us = nil, @name = nil, @sni = nil, @mark_transform = false,
+                     @tags = nil)
       end
     end
 

--- a/src/gori/store/schema.cr
+++ b/src/gori/store/schema.cr
@@ -7,7 +7,7 @@ module Gori
     # (FTS5 for QL, a tags table, a connections table) arrive as *later*
     # migrations — which is exactly why none of them exist in v1 (P0).
     module Schema
-      VERSION = 30
+      VERSION = 31
 
       # The migration that reclaims duplicated/low-value bytes already on disk (see V25).
       # Store.open runs a one-time VACUUM after an EXISTING db crosses this version so the
@@ -526,7 +526,16 @@ module Gori
         "ALTER TABLE match_rules ADD COLUMN part TEXT NOT NULL DEFAULT 'head'",
       ]
 
-      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21, V22, V23, V24, V25, V26, V27, V28, V29, V30]
+      # Replay tabs gain flat multi-label TAGS: a space-joined set of free-text tokens
+      # ("idor", "auth-bypass") for organizing and filtering the sub-tab strip. Stored
+      # as one delimited column (tags are few per session; the multi-label set lives
+      # in-memory as an Array). NULL = untagged; additive, so existing rows keep their
+      # exact meaning. Persist + restore-on-open only (like `name`) — not reconciled.
+      V31 = [
+        "ALTER TABLE replays ADD COLUMN tags TEXT",
+      ]
+
+      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21, V22, V23, V24, V25, V26, V27, V28, V29, V30, V31]
 
       def self.migrate!(db : DB::Database) : Nil
         db.using_connection do |conn|

--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -202,11 +202,14 @@ module Gori::Tui
     # top tab menu: no row fill — inactive labels are muted on the canvas, the active
     # chip is FOCUS_GOLD when the strip holds focus else a dim SELECTION_DIM band.
     # `‹` / `›` flag overflow.
+    # `hidden` (Replay's tag filter) drops those absolute chip indices from the strip —
+    # they keep their absolute number, so the visible chips read with gaps (2, 5, 7).
     def self.render_tab_strip(screen : Screen, rect : Rect, labels : Array(String),
-                              active : Int32, focused : Bool, prev_start : Int32 = 0) : Int32
+                              active : Int32, focused : Bool, prev_start : Int32 = 0,
+                              hidden : Set(Int32)? = nil) : Int32
       return prev_start if rect.empty? || labels.empty?
       active = active.clamp(0, labels.size - 1)
-      segs, start, last = strip_layout(rect, labels, active, prev_start)
+      segs, start, last, vis_last = strip_layout(rect, labels, active, prev_start, hidden)
       segs.each do |(i, label, seg)|
         if i == active
           abg = focused ? Theme.focus_gold : Theme.selection_dim
@@ -218,40 +221,47 @@ module Gori::Tui
         end
       end
       screen.cell(rect.x, rect.y, '‹', Theme.muted, Theme.bg) if start > 0
-      screen.cell(rect.right - 1, rect.y, '›', Theme.muted, Theme.bg) if last < labels.size - 1
+      screen.cell(rect.right - 1, rect.y, '›', Theme.muted, Theme.bg) if last < vis_last
       start
     end
 
     # Pure: the visible sub-tab chips — {index, cell rect} — computed IDENTICALLY to
     # render_tab_strip (shares strip_layout) so a click hit-test can't drift. Used by
-    # the Replay/Notes sub-tab strips.
-    def self.strip_segments(rect : Rect, labels : Array(String), active : Int32, prev_start : Int32 = 0) : Array({Int32, Rect})
+    # the Replay/Notes sub-tab strips. Each `index` is the ABSOLUTE chip index, even
+    # when `hidden` filters intervening chips out.
+    def self.strip_segments(rect : Rect, labels : Array(String), active : Int32,
+                            prev_start : Int32 = 0, hidden : Set(Int32)? = nil) : Array({Int32, Rect})
       return [] of {Int32, Rect} if rect.empty? || labels.empty?
-      strip_layout(rect, labels, active.clamp(0, labels.size - 1), prev_start)[0].map { |(i, _, seg)| {i, seg} }
+      strip_layout(rect, labels, active.clamp(0, labels.size - 1), prev_start, hidden)[0].map { |(i, _, seg)| {i, seg} }
     end
 
     # The single source of sub-tab-chip geometry: each visible chip's {index, label,
-    # rect} plus the window `start` and `last` drawn index (so render can flag the
-    # ‹ / › overflow markers). Mirrors the old inline render_tab_strip loop exactly —
-    # reserves a column each edge (the `> rect.right - 1` break) for the markers.
-    private def self.strip_layout(rect : Rect, labels : Array(String),
-                                  active : Int32, prev_start : Int32 = 0) : {Array({Int32, String, Rect}), Int32, Int32}
+    # rect} plus the window `start` / `last` position and the last visible position
+    # (so render can flag the ‹ / › overflow markers). `hidden` chips are excluded
+    # from layout entirely but retain their absolute index in the segment tuple.
+    # Reserves a column each edge (the `> rect.right - 1` break) for the markers.
+    private def self.strip_layout(rect : Rect, labels : Array(String), active : Int32,
+                                  prev_start : Int32 = 0, hidden : Set(Int32)? = nil) : {Array({Int32, String, Rect}), Int32, Int32, Int32}
       segs = [] of {Int32, String, Rect}
+      # The absolute indices actually shown, in order (filtered chips skipped).
+      vis = (0...labels.size).select { |i| hidden.nil? || !hidden.includes?(i) }
+      return {segs, 0, -1, -1} if vis.empty?
       widths = labels.map(&.size.+(2)) # one space of padding each side of the segment
-      # Reserve a column on each edge for the ‹ / › overflow markers, then advance
-      # the start until the segments [start..active] fit in what remains.
-      start = scroll_start(widths, active, {rect.w - 2, 0}.max, prev_start)
+      # Window over the VISIBLE positions so the active chip stays on-screen; reserve a
+      # column on each edge for the ‹ / › overflow markers.
+      apos = vis.index(active) || 0
+      start = scroll_start(vis.map { |i| widths[i] }, apos, {rect.w - 2, 0}.max, prev_start)
       x = rect.x + 1
       last = start - 1
-      labels.each_with_index do |label, i|
-        next if i < start
+      vis.each_with_index do |i, pos|
+        next if pos < start
         seg_w = widths[i]
         break if x + seg_w > rect.right - 1 # leave the last column for the › marker
-        segs << {i, label, Rect.new(x, rect.y, seg_w, 1)}
+        segs << {i, labels[i], Rect.new(x, rect.y, seg_w, 1)}
         x += seg_w + 1
-        last = i
+        last = pos
       end
-      {segs, start, last}
+      {segs, start, last, vis.size - 1}
     end
 
     # The header hairline (row 1) under the logo row, above the tab menu.

--- a/src/gori/tui/controllers/replay_controller.cr
+++ b/src/gori/tui/controllers/replay_controller.cr
@@ -45,11 +45,18 @@ module Gori::Tui
         view.restore(r.target, r.request, r.http2?, r.auto_content_length?,
           r.response_head, r.response_body, r.response_error, r.response_duration_us,
           sni: r.sni || "", mark_transform: r.mark_transform?, ws_messages: ws_msgs)
-        view.name = r.name # custom sub-tab label survives reopen
+        view.name = r.name                    # custom sub-tab label survives reopen
+        view.tags = Replay::Tags.parse(r.tags) # flat tags survive reopen (V31)
         seed_replay_original(view, r.flow_id)
         @replays << ReplayTab.new(view, r.flow_id, r.id)
       end
       @current_replay_idx = @replays.empty? ? -1 : 0
+      # Sub-tab filter (issue #121): a live in-memory query (tag:/name:/host:/method: +
+      # free text) that narrows which chips the strip shows. "" = no filter (all shown).
+      @subtab_filter = ""
+      @subtab_filter_editing = false # the `/` bar is capturing keystrokes
+      @filter_cx = 0                 # caret within @subtab_filter
+      @filter_preedit = ""           # live IME composition in the bar
       # Replay round-trips run off the UI fiber and deliver their Result here; the run
       # loop applies it to the originating view on a later tick (buffered so a finished
       # replay never blocks its background fiber).
@@ -95,17 +102,110 @@ module Gori::Tui
     end
 
     def subtab_labels : Array(String)
-      @replays.map_with_index { |tab, i| "#{i + 1}:#{tab.view.label(18)}" }
+      @replays.map_with_index { |tab, i| "#{i + 1}:#{tab.view.label(18)}#{tab.view.tags_label(12)}" }
     end
 
     # Rows for the sub-tab search picker (space → s): the chip label plus a dim,
-    # searchable request line (method/path + target URL) so a session is findable
-    # by host/path even when a custom name hides its summary.
+    # searchable request line (method/path + target URL + tags) so a session is
+    # findable by host/path/tag even when a custom name hides its summary.
     def subtab_search_rows : Array(SubtabPicker::Row)
       @replays.map_with_index do |tab, i|
         v = tab.view
-        SubtabPicker::Row.new(i, v.label(40), "#{v.summary(60)} #{v.target}".strip)
+        tags = v.tags.empty? ? "" : " #{v.tags.map { |t| "##{t}" }.join(' ')}"
+        SubtabPicker::Row.new(i, v.label(40), "#{v.summary(60)} #{v.target}#{tags}".strip)
       end
+    end
+
+    # --- sub-tab tag filter (issue #121) ---
+    # The searchable projection of a session for the in-memory matcher (TUI-free).
+    private def filter_subject(v : ReplayView) : Replay::SubtabFilter::Subject
+      Replay::SubtabFilter::Subject.new(v.name, v.summary(200), v.target, v.request_method, v.tags)
+    end
+
+    # Absolute chip indices hidden by the active filter; nil when no filter is set.
+    def subtab_hidden : Set(Int32)?
+      return nil if @subtab_filter.blank?
+      f = Replay::SubtabFilter.parse(@subtab_filter)
+      hidden = Set(Int32).new
+      @replays.each_with_index { |t, i| hidden << i unless f.matches?(filter_subject(t.view)) }
+      hidden
+    end
+
+    # Absolute indices of the sessions the filter keeps visible (all when unfiltered).
+    def visible_indices : Array(Int32)
+      h = subtab_hidden
+      return (0...@replays.size).to_a unless h
+      (0...@replays.size).reject { |i| h.includes?(i) }
+    end
+
+    # The `/` bar is currently capturing keystrokes (the shell routes keys here).
+    def subtab_filter_editing? : Bool
+      @subtab_filter_editing
+    end
+
+    # The filter bar occupies a body row (editing, or a set filter that narrows chips).
+    def subtab_filter_shown? : Bool
+      @subtab_filter_editing || !@subtab_filter.blank?
+    end
+
+    # Open the `/` filter bar (from the strip or the space menu), seeding the caret.
+    def start_subtab_filter : Nil
+      @subtab_filter_editing = true
+      @filter_cx = @subtab_filter.size
+      @filter_preedit = ""
+    end
+
+    # Enter: keep the (possibly blank) filter and close the bar; re-anchor the current
+    # session onto a still-visible chip so the body matches the narrowed strip.
+    def commit_subtab_filter : Nil
+      @subtab_filter_editing = false
+      @filter_preedit = ""
+      reanchor_current
+    end
+
+    # Esc: drop the filter entirely and close the bar (every chip returns).
+    def clear_subtab_filter : Nil
+      @subtab_filter = ""
+      @subtab_filter_editing = false
+      @filter_cx = 0
+      @filter_preedit = ""
+    end
+
+    def set_subtab_filter_preedit(text : String) : Nil
+      @filter_preedit = text
+    end
+
+    def handle_subtab_filter_key(ev : Termisu::Event::Key) : Nil
+      key = ev.key
+      c = ev.char || key.to_char
+      if key.escape?
+        clear_subtab_filter
+      elsif key.enter?
+        commit_subtab_filter
+      elsif key.backspace?
+        if @filter_cx > 0
+          @subtab_filter = @subtab_filter[0, @filter_cx - 1] + @subtab_filter[@filter_cx..]
+          @filter_cx -= 1
+        end
+        @filter_preedit = ""
+      elsif key.left?
+        @filter_cx = {@filter_cx - 1, 0}.max
+      elsif key.right?
+        @filter_cx = {@filter_cx + 1, @subtab_filter.size}.min
+      elsif c && !ev.ctrl? && !ev.alt? && !c.control?
+        @subtab_filter = @subtab_filter[0, @filter_cx] + c + @subtab_filter[@filter_cx..]
+        @filter_cx += 1
+        @filter_preedit = ""
+      end
+    end
+
+    # Keep the current session on a visible chip: if the filter hid it, jump to the
+    # first still-visible session (never while empty — clearing the filter restores it).
+    private def reanchor_current : Nil
+      vis = visible_indices
+      return if vis.empty? || vis.includes?(@current_replay_idx)
+      save_current_replay
+      @current_replay_idx = vis.first
     end
 
     def subtab_index : Int32
@@ -215,13 +315,44 @@ module Gori::Tui
       current_replay_tab.try { |t| t.view.reveal = @host.reveal?; t.view.pretty = @host.pretty? }
       labels = subtab_strip_shown? ? subtab_labels : nil
       shell = BodyChrome.shell_focused(focus, multi_pane: !current_view.nil?)
-      @subtab_start = BodyChrome.framed_body(screen, rect, shell, focus == :subtabs, labels, @current_replay_idx, @subtab_start) do |content|
+      @subtab_start = BodyChrome.framed_body(screen, rect, shell, focus == :subtabs, labels, @current_replay_idx, @subtab_start, subtab_hidden) do |content|
+        bar, body = carve_filter_bar(content)
+        render_subtab_filter_bar(screen, bar) if bar
         if v = current_view
-          v.render(screen, content, focused: body_focused)
+          v.render(screen, body, focused: body_focused)
         else
-          TrafficEmptyState.render(screen, content, variant: :replay)
+          TrafficEmptyState.render(screen, body, variant: :replay)
         end
       end
+    end
+
+    # The filter-bar row carved off the body top when the `/` filter is shown — used
+    # by BOTH render_body and handle_click so the body geometry never drifts. Returns
+    # {bar_rect | nil, body_rect}.
+    private def carve_filter_bar(content : Rect) : {Rect?, Rect}
+      return {nil, content} unless subtab_filter_shown? && content.h > 1
+      bar = Rect.new(content.x, content.y, content.w, 1)
+      body = Rect.new(content.x, content.y + 1, content.w, content.h - 1)
+      {bar, body}
+    end
+
+    private def render_subtab_filter_bar(screen : Screen, rect : Rect) : Nil
+      return if rect.w < 8
+      screen.fill(rect, Theme.panel)
+      px = screen.text(rect.x, rect.y, "filter › ", Theme.accent, Theme.panel)
+      vis = visible_indices.size
+      count = "#{vis}/#{@replays.size}"
+      count_x = rect.right - count.size
+      field_w = {count_x - 1 - px, 1}.max
+      if @subtab_filter_editing
+        screen.input_line(px, rect.y, @subtab_filter, @filter_cx, @filter_preedit,
+          Theme.text_bright, Theme.panel, width: field_w)
+      elsif @subtab_filter.blank?
+        screen.text(px, rect.y, "tag:  name:  host:  method:  (esc clears)", Theme.muted, Theme.panel, width: field_w)
+      else
+        screen.text(px, rect.y, @subtab_filter, Theme.text, Theme.panel, width: field_w)
+      end
+      screen.text(count_x, rect.y, count, vis == 0 ? Theme.red : Theme.muted, Theme.panel)
     end
 
     # --- input ---
@@ -231,12 +362,9 @@ module Gori::Tui
         save_current_replay # persist the tab before the palette takes over
         @host.open_palette
       elsif ev.ctrl? && (c = ev.char || key.to_char) && '1' <= c <= '9'
-        # Switch replay sub-tab (works even while editing fields because of the ctrl check).
-        idx = c.to_i - 1
-        if idx < @replays.size
-          save_current_replay # persist the tab we're leaving before switching
-          @current_replay_idx = idx
-        end
+        # Switch replay sub-tab by its (absolute) chip number — works even while editing
+        # fields because of the ctrl check. jump_subtab reveals a filtered-out target.
+        jump_subtab(c.to_i - 1)
       elsif ev.ctrl? && key.lower_w?
         request_close
       elsif ev.ctrl_z? && (view = current_view) && view.focus == :request
@@ -432,6 +560,7 @@ module Gori::Tui
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
       body = BodyChrome.content_rect(rect, strip: subtab_strip_shown?)
+      _, body = carve_filter_bar(body) # keep body clicks aligned when the filter bar is up
       return true unless v = current_view
       # Border chips/badges consume the click (no caret move) — same toggles as keys.
       if chip = v.chrome_hit(body, mx, my)
@@ -598,18 +727,29 @@ module Gori::Tui
     end
 
     # --- sub-tab nav (the shell's shared strip machinery drives these for Replay) ---
-    # Move the active sub-tab by ±1 (clamped, no wrap), saving the outgoing tab first.
+    # Move the active sub-tab by ±1 (strip ←/→) among the VISIBLE (filtered) chips, so
+    # h/l walks exactly the chips shown; clamped, no wrap, saving the outgoing tab first.
     def move_subtab(dir : Int32) : Nil
-      return unless @replays.size >= 2
-      nidx = (@current_replay_idx + dir).clamp(0, @replays.size - 1)
-      return if nidx == @current_replay_idx
+      vis = visible_indices
+      return if vis.size < 2
+      cur = vis.index(@current_replay_idx)
+      target = if cur
+                 vis[(cur + dir).clamp(0, vis.size - 1)]
+               else
+                 dir < 0 ? vis.first : vis.last # current filtered out → step onto an edge
+               end
+      return if target == @current_replay_idx
       save_current_replay
-      @current_replay_idx = nidx
+      @current_replay_idx = target
     end
 
-    # Jump to an absolute sub-tab index (^1-9 on the strip) and STAY on the strip.
+    # Jump to an absolute sub-tab index (^1-9 on the strip, a strip click, or a picked
+    # search result) and STAY on the strip. A jump to a filtered-out tab drops the
+    # filter so the target is actually visible (chip numbers are absolute, so ^N by the
+    # number shown always lands right).
     def jump_subtab(idx : Int32) : Nil
       return unless 0 <= idx < @replays.size
+      clear_subtab_filter if (h = subtab_hidden) && h.includes?(idx)
       return if idx == @current_replay_idx
       save_current_replay
       @current_replay_idx = idx
@@ -624,6 +764,17 @@ module Gori::Tui
       view.name = clean.empty? ? nil : clean
       if id = tab.db_id
         @host.session.store.set_replay_name(id, view.name)
+      end
+    end
+
+    # Apply the typed tags to the captured tab + persist. Re-find by VIEW identity (a
+    # reconcile may have reordered/removed it) — gone → no-op. Mirrors apply_rename;
+    # blank clears every tag. The raw string is normalized (ws/comma split, dedupe).
+    def apply_tags(view : ReplayView, raw : String) : Nil
+      return unless tab = @replays.find { |t| t.view.same?(view) }
+      view.tags = Replay::Tags.parse(raw)
+      if id = tab.db_id
+        @host.session.store.set_replay_tags(id, Replay::Tags.serialize(view.tags))
       end
     end
 

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -19,6 +19,7 @@ require "../replay/h2_engine"
 require "../replay/ws_engine"
 require "../replay/diff"
 require "../replay/flow_request"
+require "../replay/subtab_filter"
 require "../fuzz"
 require "../convert"
 require "./chain_pane"
@@ -46,9 +47,13 @@ module Gori::Tui
     end
 
     property name : String? # custom sub-tab chip label (nil = derive from the request); set separately from restore()
+    # Flat multi-label tags (V31) for organizing/filtering the sub-tab strip. Set
+    # separately from restore() — like @name, the reconcile clobber never touches it.
+    property tags : Array(String) = [] of String
 
     def initialize
       @name = nil
+      @tags = [] of String
       @flow = nil.as(Store::FlowDetail?)
       @target = ""
       @tcx = 0             # target (URL) cursor
@@ -286,6 +291,20 @@ module Gori::Tui
       else
         summary(max)
       end
+    end
+
+    # A compact ` #tag #tag` suffix for the sub-tab chip, fit within `budget` columns
+    # (leading space included, trailing `…` when it overflows). Empty when untagged.
+    def tags_label(budget : Int32 = 12) : String
+      return "" if @tags.empty? || budget <= 2
+      s = @tags.map { |t| "##{t}" }.join(' ')
+      s = "#{s[0, budget - 2]}…" if s.size > budget - 1
+      " #{s}"
+    end
+
+    # The leading METHOD token of the request line (for the sub-tab filter's `method:`).
+    def request_method : String
+      (@editor.first_nonblank_line || "").strip.split(' ').first? || ""
     end
 
     # Replace the request body (e.g. from the external editor); marks dirty so the

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -111,6 +111,12 @@ module Gori::Tui
       # reconcile can reorder/remove replay tabs while the prompt is open, so the
       # controller's apply_rename re-finds the tab by its view — never a shifted neighbour.
       @rename_view = nil.as(ReplayView | FuzzerView | ConvertView | MinerView | ComparerView | Nil)
+      # The Replay sub-tab TAG editor (issue #121) — a bottom prompt mirroring rename,
+      # space-separated tags. Held by VIEW identity for the same reconcile-race reason.
+      @tag_edit_open = false
+      @tag_buffer = ""
+      @tag_preedit = ""
+      @tag_view = nil.as(ReplayView?)
       # The import path prompt (palette → import:har/urls/oas) — bottom-anchored like
       # ^G/^F, with filesystem tab-completion via PathComplete.
       @import_open = false
@@ -571,8 +577,16 @@ module Gori::Tui
         @rename_preedit = text
         return
       end
+      if @tag_edit_open # sub-tab tag editor — IME composing text (e.g. Hangul tags)
+        @tag_preedit = text
+        return
+      end
       if @import_open
         @import_preedit = text
+        return
+      end
+      if @active_tab == :replay && replay_controller.subtab_filter_editing?
+        replay_controller.set_subtab_filter_preedit(text)
         return
       end
       # Route preedit to whichever input is active so composing text (e.g. Hangul
@@ -635,6 +649,7 @@ module Gori::Tui
       return handle_goto_key(ev) if @goto_open             # the ^G line prompt is modal while up
       return handle_search_key(ev) if @search_open         # the ^F find prompt is modal while up
       return handle_rename_key(ev) if @rename_open         # the sub-tab rename prompt is modal while up
+      return handle_tag_edit_key(ev) if @tag_edit_open     # the Replay tag editor is modal while up
       return handle_import_key(ev) if @import_open         # the import path prompt is modal while up
       # ^G "go to line" / ^F "find" — both open a bottom prompt for the focused
       # multi-line view (editors move the cursor, read-only panes scroll). Modifier
@@ -693,6 +708,12 @@ module Gori::Tui
       end
       if @active_tab == :prism && @overlay == :none && @focus == :body && prism_controller.view.querying?
         return if prism_controller.handle_query_key(ev)
+      end
+      # Replay sub-tab filter (issue #121): the `/` bar captures keys until Enter/Esc.
+      # Opened from the strip (not the body), so it's not gated on @focus.
+      if @active_tab == :replay && @overlay == :none && replay_controller.subtab_filter_editing?
+        replay_controller.handle_subtab_filter_key(ev)
+        return
       end
       if @active_tab == :findings && @overlay == :none && @focus == :body && findings_controller.view.detail_open?
         return if findings_controller.handle_detail_key(ev)
@@ -831,19 +852,20 @@ module Gori::Tui
     # Right-click: rename a Replay/Fuzzer/Convert/Miner sub-tab chip (the one context menu we have).
     # Only acts on the sub-tab strip; anywhere else is a no-op (no left-click side effects).
     private def handle_right_click(layout : Layout, mx : Int32, my : Int32) : Nil
-      if @goto_open || @search_open || @rename_open || @import_open
+      if @goto_open || @search_open || @rename_open || @tag_edit_open || @import_open
         # A right-click dismisses an open bottom prompt (like left-click/esc), so it can't
         # stack a second orthogonal prompt on top of the first.
         close_goto if @goto_open
         close_search if @search_open
         close_rename if @rename_open
+        close_tag_edit if @tag_edit_open
         close_import if @import_open
         return
       end
-      return unless renameable_subtabs? && @overlay == :none && !@space_menu_open && !copy_as_shown? && !@rename_open && subtabs_shown?
+      return unless renameable_subtabs? && @overlay == :none && !@space_menu_open && !copy_as_shown? && !@rename_open && !@tag_edit_open && subtabs_shown?
       sub_rect = BodyChrome.strip_rect(layout.body, strip: true)
       return unless sub_rect && sub_rect.contains?(mx, my)
-      if seg = Chrome.strip_segments(BodyChrome.tab_row(sub_rect), subtab_labels, current_subtab_index, current_subtab_start).find { |(_, r)| r.contains?(mx, my) }
+      if seg = Chrome.strip_segments(BodyChrome.tab_row(sub_rect), subtab_labels, current_subtab_index, current_subtab_start, current_subtab_hidden).find { |(_, r)| r.contains?(mx, my) }
         open_rename(seg[0])
       end
     end
@@ -854,10 +876,11 @@ module Gori::Tui
     private def dispatch_click(layout : Layout, mx : Int32, my : Int32) : Nil
       return if @space_menu_open && click_space_menu(layout, mx, my)
       return if copy_as_shown? && click_copy_as(layout.body, mx, my) # modal while up — floats over @overlay
-      if @goto_open || @search_open || @rename_open || @import_open
+      if @goto_open || @search_open || @rename_open || @tag_edit_open || @import_open
         close_goto if @goto_open # a click anywhere dismisses the bottom prompt (like esc)
         close_search if @search_open
         close_rename if @rename_open
+        close_tag_edit if @tag_edit_open
         close_import if @import_open
         return
       end
@@ -896,7 +919,7 @@ module Gori::Tui
     private def click_subtab_strip(body : Rect, mx : Int32, my : Int32) : Bool
       sub_rect = BodyChrome.strip_rect(body, strip: subtabs_shown?)
       return false unless sub_rect && sub_rect.contains?(mx, my)
-      if seg = Chrome.strip_segments(BodyChrome.tab_row(sub_rect), subtab_labels, current_subtab_index, current_subtab_start).find { |(_, r)| r.contains?(mx, my) }
+      if seg = Chrome.strip_segments(BodyChrome.tab_row(sub_rect), subtab_labels, current_subtab_index, current_subtab_start, current_subtab_hidden).find { |(_, r)| r.contains?(mx, my) }
         jump_subtab(seg[0])
         focus_pane(:subtabs)
       end
@@ -914,6 +937,13 @@ module Gori::Tui
 
     private def current_subtab_start : Int32
       @tabs[@active_tab]?.try(&.subtab_start) || 0
+    end
+
+    # Absolute chip indices hidden by the active tab's sub-tab filter (Replay only);
+    # nil = show all. Threaded into every strip_segments/render call so click hit-tests
+    # skip filtered chips exactly like rendering does.
+    private def current_subtab_hidden : Set(Int32)?
+      @tabs[@active_tab]?.try(&.subtab_hidden)
     end
 
     # Per-tab body click. Every tab has a controller; the fallback just takes focus
@@ -2343,6 +2373,10 @@ module Gori::Tui
         jump_subtab(c.to_i - 1) # switch + stay on the strip
       when rename_chord?(ev)
         open_rename(current_subtab_index) # rename the active sub-tab (Replay/Fuzzer/Convert/Miner)
+      when @active_tab == :replay && !ev.ctrl? && !ev.alt? && key.lower_t?
+        open_tag_edit(current_subtab_index) # tag the active Replay sub-tab (issue #121)
+      when @active_tab == :replay && !ev.ctrl? && !ev.alt? && c == '/'
+        replay_controller.start_subtab_filter # open the `/` tag-filter bar
       when key.left?, key.lower_h?
         move_subtab(-1)
       when key.right?, key.lower_l?
@@ -2802,6 +2836,7 @@ module Gori::Tui
       render_goto_prompt(screen, layout.status) if @goto_open
       render_search_prompt(screen, layout.status) if @search_open
       render_rename_prompt(screen, layout.status) if @rename_open
+      render_tag_prompt(screen, layout.status) if @tag_edit_open
       render_import_prompt(screen, layout.status) if @import_open
     end
 
@@ -3235,6 +3270,60 @@ module Gori::Tui
       x = rect.x + prefix.size
       iw = {rect.right - x - hint.size - 2, 4}.max
       screen.input_line(x, rect.y, @rename_buffer, @rename_buffer.size, @rename_preedit, Theme.text_bright, Theme.panel, width: iw)
+      screen.text({rect.right - hint.size - 1, x + iw}.max, rect.y, hint, Theme.muted, Theme.panel)
+    end
+
+    # --- Replay sub-tab TAG editor (issue #121) ---------------------------------
+    # A bottom prompt mirroring rename: space-separated flat tags for the active Replay
+    # sub-tab. The target is held by VIEW identity (the reconcile may reorder/remove
+    # tabs while the prompt is open) — apply_tags re-finds it, never a shifted neighbour.
+
+    private def open_tag_edit(idx : Int32) : Nil
+      return unless @active_tab == :replay
+      return unless view = replay_controller.view_at(idx)
+      @tag_view = view
+      @tag_buffer = view.tags.join(" ")
+      @tag_preedit = ""
+      @tag_edit_open = true
+    end
+
+    private def close_tag_edit : Nil
+      @tag_edit_open = false
+      @tag_preedit = ""
+      @tag_view = nil
+    end
+
+    private def handle_tag_edit_key(ev : Termisu::Event::Key) : Nil
+      key = ev.key
+      c = ev.char || key.to_char
+      if key.escape?
+        close_tag_edit
+      elsif key.enter?
+        apply_tag_edit(@tag_buffer)
+        close_tag_edit
+      elsif key.backspace?
+        @tag_buffer = @tag_buffer[0, {@tag_buffer.size - 1, 0}.max]
+      elsif c && !ev.ctrl? && !ev.alt?
+        @tag_buffer += c
+        @tag_preedit = "" # commit any IME preedit
+      end
+    end
+
+    private def apply_tag_edit(raw : String) : Nil
+      if v = @tag_view
+        replay_controller.apply_tags(v, raw)
+      end
+    end
+
+    private def render_tag_prompt(screen : Screen, rect : Rect) : Nil
+      return if rect.w < 6
+      screen.fill(rect, Theme.panel)
+      prefix = "tags: "
+      screen.text(rect.x, rect.y, prefix, Theme.accent, Theme.panel)
+      hint = "↵ save · esc cancel · #tags space-separated"
+      x = rect.x + prefix.size
+      iw = {rect.right - x - hint.size - 2, 4}.max
+      screen.input_line(x, rect.y, @tag_buffer, @tag_buffer.size, @tag_preedit, Theme.text_bright, Theme.panel, width: iw)
       screen.text({rect.right - hint.size - 1, x + iw}.max, rect.y, hint, Theme.muted, Theme.panel)
     end
 
@@ -4020,6 +4109,16 @@ module Gori::Tui
     # reuse the SAME shell-owned rename prompt / confirm-gated close, not a new path.
     def replay_rename_subtab : Nil
       open_rename(current_subtab_index)
+    end
+
+    # Space-menu counterparts of the strip's `t` tag chord / `/` filter chord (issue
+    # #121) — reuse the SAME shell-owned tag prompt / controller-owned filter bar.
+    def replay_tag_subtab : Nil
+      open_tag_edit(current_subtab_index)
+    end
+
+    def replay_filter_subtabs : Nil
+      replay_controller.start_subtab_filter
     end
 
     def replay_close_subtab : Nil

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -78,12 +78,12 @@ module Gori::Tui
     # `labels` is given, then yield the remaining content rect.
     def framed_body(screen : Screen, rect : Rect, shell_focused : Bool,
                     subtabs_focused : Bool, labels : Array(String)?, active : Int32,
-                    prev_start : Int32 = 0, & : Rect ->) : Int32
+                    prev_start : Int32 = 0, hidden : Set(Int32)? = nil, & : Rect ->) : Int32
       new_start = prev_start
       framed(screen, rect, shell_focused) do |inner|
         if labels
           sub_rect, content = carve_subtab_row(inner)
-          new_start = render_subtab_strip(screen, sub_rect, labels, active, subtabs_focused, prev_start)
+          new_start = render_subtab_strip(screen, sub_rect, labels, active, subtabs_focused, prev_start, hidden)
           yield content
         else
           yield inner
@@ -127,9 +127,10 @@ module Gori::Tui
     # the strip itself holds focus (←/→ switch) → active chip lights FOCUS_GOLD and the
     # divider hairline matches.
     def render_subtab_strip(screen : Screen, rect : Rect, labels : Array(String),
-                            active : Int32, focused : Bool, prev_start : Int32 = 0) : Int32
+                            active : Int32, focused : Bool, prev_start : Int32 = 0,
+                            hidden : Set(Int32)? = nil) : Int32
       return prev_start if rect.empty?
-      new_start = Chrome.render_tab_strip(screen, tab_row(rect), labels, active, focused, prev_start)
+      new_start = Chrome.render_tab_strip(screen, tab_row(rect), labels, active, focused, prev_start, hidden)
       return prev_start if rect.h < 2
       border = focused ? Theme.focus_gold : Theme.border
       screen.hline(rect.x, rect.y + 1, rect.w, fg: border, bg: Theme.bg)
@@ -238,6 +239,13 @@ module Gori::Tui
     # Open sub-tab count — gates the search entry. Derived from the strip labels.
     def subtab_count : Int32
       subtab_labels.try(&.size) || 0
+    end
+
+    # Absolute chip indices to hide from the strip (Replay's tag filter); nil = show
+    # all. Rendering + click hit-tests skip these, but the indices stay absolute so
+    # jump/rename/^N keep working unchanged.
+    def subtab_hidden : Set(Int32)?
+      nil
     end
 
     # A FIXED strip (Help): the chip set is constant — no ^N/^W create/close and the

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -76,6 +76,8 @@ module Gori
       abstract def subtab_search_open : Nil                # open the sub-tab search picker for the active tab
       abstract def subtab_search_count : Int32             # active tab's open sub-tab count (gates the search entry)
       abstract def replay_rename_subtab : Nil              # open the rename prompt for the active sub-tab
+      abstract def replay_tag_subtab : Nil                 # open the tag editor for the active sub-tab (issue #121)
+      abstract def replay_filter_subtabs : Nil             # open the `/` tag-filter bar over the sub-tab strip
       abstract def replay_close_subtab : Nil               # close the active sub-tab (confirm-gated)
       abstract def replay_duplicate_subtab : Nil           # clone the active sub-tab's content into a new sibling
       abstract def replay_toggle_hex : Nil                 # toggle byte-exact hex editing of the request pane

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -104,6 +104,17 @@ module Gori
       r.register Verb::Definition.new(
         "replay.rename-subtab", "Rename subtab", "Rename the active replay sub-tab's chip",
         Verb::Scope::Replay, available: in_replay, mnemonic: 'e', section: :subtab) { |ctx| ctx.replay_rename_subtab; nil }
+      # Tag / filter the sub-tab strip (issue #121). `t` tags the active session, `/`
+      # opens the tag-filter bar. 't' is free in COMMON ∪ :subtab (COMMON: r/y/n/f/m/k/u;
+      # :subtab: e/w/d); the filter uses '/' (the shared filter idiom, unique here).
+      r.register Verb::Definition.new(
+        "replay.tag-subtab", "Tag subtab", "Add/edit flat tags on the active replay sub-tab",
+        Verb::Scope::Replay, available: in_replay, mnemonic: 't', section: :subtab) { |ctx| ctx.replay_tag_subtab; nil }
+      r.register Verb::Definition.new(
+        "replay.filter-subtabs", "Filter sub-tabs", "Filter the sub-tab strip by tag / name / host",
+        Verb::Scope::Replay,
+        available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :replay && ctx.replay_subtab_count >= 2 },
+        mnemonic: '/', section: :tab) { |ctx| ctx.replay_filter_subtabs; nil }
       r.register Verb::Definition.new(
         "replay.close-subtab", "Close subtab", "Close the active replay sub-tab",
         Verb::Scope::Replay, available: in_replay, mnemonic: 'w', section: :subtab) { |ctx| ctx.replay_close_subtab; nil }


### PR DESCRIPTION
Closes #121.

## What

Replay sessions gain flat, **multi-label tags** (persisted) and a Replay-level **`/` filter bar** that hides non-matching sub-tab chips. As the strip accumulates sessions, you can now narrow it by `tag:` / `name:` / `host:` / `method:` instead of scrolling an ever-growing strip. Tags relate sessions across lines of inquiry (e.g. every `idor` probe) without forcing a single-parent folder hierarchy.

## How

- **Storage** — `schema.cr` V31 adds a delimited `replays.tags` column (space-joined tokens). Restored on project open like the custom `name`; **not** reconciled cross-session. `Store#set_replay_tags` is its own narrow UPDATE (twin of `set_replay_name`), so tagging never rewrites the request.
- **Chip surface** — tags render inline on the chip (`1:GET /orders #idor #auth`), folded into `subtab_labels` + the search-picker detail. No shared-chrome change for the surface.
- **Filter that hides chips (the structural piece)** — `Chrome.render_tab_strip` / `strip_segments` / `strip_layout` gain a `hidden : Set(Int32)?` param that skips filtered chip indices during **both** layout and click hit-test. Chip indices stay **absolute** everywhere (`seg[0]`, `current_subtab_index`, `view_at`, `^N`), so the visible strip reads with gaps (`2  5  7`) and every existing nav path is unchanged. `ReplayController` owns the filter state + `visible_indices`; `move_subtab` walks the visible set, `jump_subtab` reveals a filtered-out target. The bar is carved off the body top via a helper shared by render + click so geometry never drifts.
- **Matcher** — `Gori::Replay::SubtabFilter` (`src/gori/replay/subtab_filter.cr`), in-memory, modeled on `Findings::Filter`, matching a TUI-free `Subject` record. Fields `tag:`/`name:`/`host:`/`method:` + negation + free text. QL was deliberately **not** reused — it compiles to SQL over the flows table and can't match in-memory sessions.
- **Editing / triggers** — `t` opens a bottom tag prompt (mirrors the rename prompt, held by view identity for the reconcile race); `/` opens the filter bar. Space-menu verbs `replay.tag-subtab` (`t`) and `replay.filter-subtabs` (`/`).

## Reviewer notes

- **Migration-replay fixtures**: the V18/V20 rollback specs now `ALTER TABLE replays DROP COLUMN tags` — otherwise V31's `ADD COLUMN` duplicates on replay (same pattern as `part`/`mark_transform`).
- Cross-session sync intentionally follows `name` (persist + restore-on-open only), so a peer session sees new tags on its next open — not live. Called out so it's a deliberate choice, not an oversight.
- `runner.cr` / `replay_controller.cr` / `replay_view.cr` are format-dirty on `main`; only feature lines were touched (verified the formatter leaves the added code unchanged).

## Testing

- New `spec/replay/subtab_filter_spec.cr` (matcher + tag normalizer) and a V31 persistence test in `spec/store_replays_spec.cr`.
- Full suite green apart from pre-existing proxy port-bind failures (`project_registry` / `capture_status`), confirmed unrelated by stashing this change.
- tmux E2E: chip tags render + restore across reopen; `/ tag:idor` narrows to matching chips (absolute-gap numbering + `N/M` count); Esc restores; `t` editor persists to the DB and survives a quit+reopen; `h`/`l` walk only the visible chips.