### PR TITLE
feat(tui): move notify:N badge to the top bar, make it + scope:N clickable

### DIFF
--- a/spec/tui/foundation_spec.cr
+++ b/spec/tui/foundation_spec.cr
@@ -196,7 +196,27 @@ describe Gori::Tui::Chrome do
     backend.row(0).should contain("acme")
     backend.row(0).should contain("scope:2")
     backend.row(0).should contain("01:37 PM")
-    backend.row(0).should_not contain("rec") # capture state moved to the bottom status bar
+    backend.row(0).should_not contain("rec")    # capture state moved to the bottom status bar
+    backend.row(0).should_not contain("notify") # no unread → badge omitted
+  end
+
+  it "shows the unread notify badge on the top bar, left of scope" do
+    backend = MemoryBackend.new(80, 1)
+    screen = Screen.new(backend)
+    Chrome.render_top_bar(screen, Rect.new(0, 0, 80, 1),
+      project: "acme", listen: "127.0.0.1:8080", time: "01:37 PM", scope: "scope:2", unread: 3)
+    backend.row(0).should contain("notify:3")
+    row = backend.row(0)
+    row.index("notify:3").not_nil!.should be < row.index("scope:2").not_nil!
+    fx = row.index("notify:3").not_nil!
+    backend.fg_at(fx, 0).should eq(Theme.accent)
+  end
+
+  it "omits the notify badge from the bottom status bar (it moved to the top bar)" do
+    backend = MemoryBackend.new(90, 1)
+    Chrome.render_status(Screen.new(backend), Rect.new(0, 0, 90, 1),
+      focus: "BODY", hints: "↹ pane · esc tabs", capturing: true, insecure_upstream: false)
+    backend.contains?("notify").should be_false
   end
 end
 

--- a/spec/tui/mouse_spec.cr
+++ b/spec/tui/mouse_spec.cr
@@ -308,6 +308,56 @@ describe "InterceptView#bar_zone_at" do
   end
 end
 
+describe "Chrome.top_bar_chip_rect" do
+  it "returns nil for :notify when there's no unread, and a rect matching the drawn badge otherwise" do
+    rect = Rect.new(0, 0, 80, 1)
+    Chrome.top_bar_chip_rect(rect, :notify, scope: "scope:2", listen: "127.0.0.1:8080",
+      time: "01:37 PM", unread: 0).should be_nil
+
+    backend = MemoryBackend.new(80, 1)
+    Chrome.render_top_bar(Screen.new(backend), rect,
+      project: "acme", listen: "127.0.0.1:8080", time: "01:37 PM", scope: "scope:2", unread: 3)
+    nrect = Chrome.top_bar_chip_rect(rect, :notify, scope: "scope:2", listen: "127.0.0.1:8080",
+      time: "01:37 PM", unread: 3).not_nil!
+    backend.row(0)[nrect.x, nrect.w].should eq("notify:3")
+  end
+
+  it "returns a rect matching the drawn scope chip whether it's on or off" do
+    rect = Rect.new(0, 0, 80, 1)
+    backend = MemoryBackend.new(80, 1)
+    Chrome.render_top_bar(Screen.new(backend), rect,
+      project: "acme", listen: "127.0.0.1:8080", time: "01:37 PM", scope: "scope:2")
+    srect = Chrome.top_bar_chip_rect(rect, :scope, scope: "scope:2", listen: "127.0.0.1:8080",
+      time: "01:37 PM").not_nil!
+    backend.row(0)[srect.x, srect.w].should eq("scope:2")
+
+    backend2 = MemoryBackend.new(80, 1)
+    Chrome.render_top_bar(Screen.new(backend2), rect,
+      project: "acme", listen: "127.0.0.1:8080", time: "01:37 PM", scope: "scope:off")
+    srect2 = Chrome.top_bar_chip_rect(rect, :scope, scope: "scope:off", listen: "127.0.0.1:8080",
+      time: "01:37 PM").not_nil!
+    backend2.row(0)[srect2.x, srect2.w].should eq("scope:off")
+  end
+
+  it "keeps notify/scope hit-test rects in sync with the drawn row even when the project name is squeezed" do
+    # Narrow rect: chips (notify:3 · scope:99 · 127.0.0.1:8080 · 01:37 PM) leave the
+    # project name almost no room — exercises the "name squeezed to zero width" branch.
+    rect = Rect.new(0, 0, 45, 1)
+    backend = MemoryBackend.new(45, 1)
+    Chrome.render_top_bar(Screen.new(backend), rect,
+      project: "a very long project name", listen: "127.0.0.1:8080", time: "01:37 PM",
+      scope: "scope:99", unread: 3)
+
+    nrect = Chrome.top_bar_chip_rect(rect, :notify, scope: "scope:99", listen: "127.0.0.1:8080",
+      time: "01:37 PM", unread: 3).not_nil!
+    backend.row(0)[nrect.x, nrect.w].should eq("notify:3")
+
+    srect = Chrome.top_bar_chip_rect(rect, :scope, scope: "scope:99", listen: "127.0.0.1:8080",
+      time: "01:37 PM", unread: 3).not_nil!
+    backend.row(0)[srect.x, srect.w].should eq("scope:99")
+  end
+end
+
 describe "ComparerView#pane_chip_at" do
   it "hits REQ / RES chips on the divider row" do
     view = ComparerView.new

--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -99,21 +99,21 @@ module Gori::Tui
 
     def self.render_top_bar(screen : Screen, rect : Rect, *, project : String,
                             listen : String, time : String,
-                            scope : String, rules : String = "", intercept : String = "") : Nil
+                            scope : String, rules : String = "", intercept : String = "",
+                            unread : Int32 = 0) : Nil
       # Logo row sits flush on the canvas — no lifted panel band (tabs/status keep panel).
       screen.fill(rect, Theme.bg)
       x = render_wordmark(screen, rect.x + 1, rect.y, bg: Theme.bg)
       name_x = x + 1
 
-      # right-aligned status chips: scope:N · rules:N · intercept:on(N) · listen · h:MM AM/PM
-      # value-emphasized, dim · separators; the hot intercept state in RED. The clock
-      # is the rightmost anchor. (Capture state lives on the bottom status bar.)
-      chips = [] of {String, Color}
-      chips << {scope, scope.ends_with?(":off") ? Theme.muted : Theme.text} unless scope.empty?
-      chips << {rules, Theme.text} unless rules.empty?
-      chips << {intercept, Theme.red} unless intercept.empty?
-      chips << {listen, Theme.muted}
-      chips << {time, Theme.muted}
+      # right-aligned status chips: notify:N · scope:N · rules:N · intercept:on(N) ·
+      # listen · h:MM AM/PM — value-emphasized, dim · separators; the hot intercept
+      # state in RED. The clock is the rightmost anchor. (Capture state lives on the
+      # bottom status bar.) `unread` rides just left of scope so a background-job ping
+      # surfaces beside the state it's most likely to affect.
+      tagged = top_bar_chips(scope: scope, rules: rules, intercept: intercept,
+        listen: listen, time: time, unread: unread)
+      chips = tagged.map { |(_, l, c)| {l, c} }
 
       # Bound the project name and floor the chips past it, so neither overwrites the
       # other at narrow widths (previously the name was unbounded and render_chips got
@@ -122,6 +122,43 @@ module Gori::Tui
       name_end = screen.text(name_x, rect.y, "· #{project}", Theme.muted, Theme.bg,
         width: {chips_left - name_x - 1, 0}.max)
       render_chips(screen, rect, chips, bg: Theme.bg, min_x: name_end + 1)
+    end
+
+    # The right-aligned top-bar chips, TAGGED so render and the click hit-test share
+    # one ordered source (the geometry can't drift). Mirrors `status_chips` below.
+    private def self.top_bar_chips(*, scope : String, rules : String, intercept : String,
+                                   listen : String, time : String, unread : Int32) : Array({Symbol, String, Color})
+      chips = [] of {Symbol, String, Color}
+      chips << {:notify, "notify:#{unread}", Theme.accent} if unread > 0
+      chips << {:scope, scope, scope.ends_with?(":off") ? Theme.muted : Theme.text} unless scope.empty?
+      chips << {:rules, rules, Theme.text} unless rules.empty?
+      chips << {:intercept, intercept, Theme.red} unless intercept.empty?
+      chips << {:listen, listen, Theme.muted}
+      chips << {:time, time, Theme.muted}
+      chips
+    end
+
+    # The drawn rect of a tagged top-bar chip (or nil if absent) — rebuilds the SAME
+    # chip list + layout render_top_bar uses, so a click on `notify:N` can't drift
+    # from the glyph. Used by the Runner to make the badge clickable.
+    #
+    # `min_x` reproduces render_top_bar's project-name floor WITHOUT a live Screen:
+    # that floor only ever resolves to one of two values — `rect.right -
+    # chips_width - 1` (chips have room; the name gets whatever's left) or `name_x +
+    # 1` (chips are wider than available space, so the name is squeezed to zero
+    # width) — never something in between, since the name's own drawn width is
+    # itself bounded by the same floor. `chip_layout`'s `{A, min_x}.max` picks the
+    # right one either way, so passing `name_x + 1` here matches the real render
+    # exactly regardless of the actual project string or its truncation.
+    def self.top_bar_chip_rect(rect : Rect, tag : Symbol, *, scope : String, rules : String = "",
+                               intercept : String = "", listen : String, time : String,
+                               unread : Int32 = 0) : Rect?
+      tagged = top_bar_chips(scope: scope, rules: rules, intercept: intercept,
+        listen: listen, time: time, unread: unread)
+      idx = tagged.index { |(t, _, _)| t == tag }
+      return nil unless idx
+      name_x = rect.x + 1 + Screen.display_width(WORDMARK) + 1
+      chip_layout(rect, tagged.map { |(_, l, c)| {l, c} }, name_x + 1)[idx]?
     end
 
     # A horizontal tab menu (row 2) styled as a segmented control. The active tab
@@ -292,16 +329,17 @@ module Gori::Tui
     # Bottom row: a focus-area badge (far left) + contextual key hints + capture/
     # upstream state chips (right). The badge — TABS / BODY / an overlay name —
     # is a lifted chip so the user always knows which region the keys drive.
+    # (The notification unread badge lives on the top bar, next to scope.)
     def self.render_status(screen : Screen, rect : Rect, *, focus : String, hints : String,
                            capturing : Bool, insecure_upstream : Bool, write_failures : Int32 = 0,
-                           activity : {String, Color}? = nil, unread : Int32 = 0) : Nil
+                           activity : {String, Color}? = nil) : Nil
       screen.fill(rect, Theme.panel)
       badge = " #{focus} "
       screen.text(rect.x, rect.y, badge, Theme.text_bright, Theme.elevated, Attribute::Bold)
       hint_x = rect.x + badge.size + 1
 
       chips = status_chips(capturing: capturing, insecure_upstream: insecure_upstream,
-        write_failures: write_failures, activity: activity, unread: unread).map { |(_, l, c)| {l, c} }
+        write_failures: write_failures, activity: activity).map { |(_, l, c)| {l, c} }
       hint_w = {rect.right - hint_x - chips_width(chips) - 2, 1}.max
       screen.text(hint_x, rect.y, hints, Theme.muted, Theme.panel, width: hint_w)
       # Floor the chips at the hint start so they can never overwrite the badge.
@@ -326,14 +364,13 @@ module Gori::Tui
       end
     end
 
-    # The right-aligned status chips, TAGGED so render and the click hit-test share one
-    # ordered source (the geometry can't drift). A background-activity chip (spinner +
-    # label) and a notification unread badge precede the capture/upstream chips.
+    # The right-aligned status chips, TAGGED so render and (were there a clickable
+    # chip here) a hit-test would share one ordered source. A background-activity
+    # chip (spinner + label) precedes the capture/upstream chips.
     private def self.status_chips(*, capturing : Bool, insecure_upstream : Bool, write_failures : Int32,
-                                  activity : {String, Color}?, unread : Int32) : Array({Symbol, String, Color})
+                                  activity : {String, Color}?) : Array({Symbol, String, Color})
       chips = [] of {Symbol, String, Color}
       chips << {:activity, activity[0], activity[1]} if activity
-      chips << {:notify, "notify:#{unread}", Theme.accent} if unread > 0
       # A persistent capture-write failure (e.g. disk full) is louder than the
       # normal on/off chip — the operator must know rows are being dropped.
       chips << if write_failures > 0
@@ -344,22 +381,6 @@ module Gori::Tui
       # an insecure upstream is a security warning — the one allowed non-status colour.
       chips << (insecure_upstream ? {:upstream, "upstream:insecure", Theme.yellow} : {:upstream, "upstream:verify", Theme.muted})
       chips
-    end
-
-    # The drawn rect of a tagged status chip (or nil if absent) — rebuilds the SAME chip
-    # list + layout render_status uses, so a click can't drift from the glyph. Used by
-    # the Runner to make the `notify:N` badge clickable.
-    # `min_x` MUST be the same floor render_status passes to render_chips (the hint start),
-    # or the hit-test rect drifts left of the drawn chip on a narrow row where the chips are
-    # floored. The Runner computes it identically from the focus badge.
-    def self.status_chip_rect(rect : Rect, tag : Symbol, *, capturing : Bool, insecure_upstream : Bool,
-                              write_failures : Int32, activity : {String, Color}?, unread : Int32,
-                              min_x : Int32) : Rect?
-      tagged = status_chips(capturing: capturing, insecure_upstream: insecure_upstream,
-        write_failures: write_failures, activity: activity, unread: unread)
-      idx = tagged.index { |(t, _, _)| t == tag }
-      return nil unless idx
-      chip_layout(rect, tagged.map { |(_, l, c)| {l, c} }, min_x)[idx]?
     end
 
     # The drawn rect of each chip, computed IDENTICALLY to render_chips' x-advance, so a

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -20,7 +20,7 @@ module Gori::Tui
         {"^P", "command palette"},
         {"space", "focus-area action menu"},
         {"c", "toggle capture"},
-        {"s · m", "toggle scope lens · Match & Replace rules"},
+        {"s · m", "toggle scope lens (or click scope:N) · Match & Replace rules"},
         {"n", "notification center (or click the notify:N badge)"},
         {"^B", "reveal whitespace (·→␍␊)"},
         {"^D / ^C ×2", "quit gori"},

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -865,7 +865,7 @@ module Gori::Tui
         handle_overlay_click(layout, mx, my)
         return
       end
-      return if click_status(layout.status, mx, my)
+      return if click_top_bar(layout.topbar, mx, my)
       return click_menu(layout.menu, mx, my) if layout.menu.contains?(mx, my)
       return if subtabs_shown? && click_subtab_strip(layout.body, mx, my)
       click_body(layout.body, mx, my) if layout.body.contains?(mx, my)
@@ -972,20 +972,30 @@ module Gori::Tui
       end
     end
 
-    # Click the bottom-bar notification badge (`notify:N`) → open the center. Returns
-    # true when consumed. The chip rect is rebuilt from the same source render uses.
-    private def click_status(rect : Rect, mx : Int32, my : Int32) : Bool
+    # Click a top-bar chip: the notification badge (`notify:N`, left of scope) opens
+    # the center; the scope chip (`scope:N` / `scope:off`) flips the lens — the same
+    # action as the global `s` chord. Returns true when consumed. Each rect is
+    # rebuilt from the same tagged source render uses, so a click can't drift.
+    private def click_top_bar(rect : Rect, mx : Int32, my : Int32) : Bool
       return false unless rect.contains?(mx, my)
-      # Mirror render_status's chip floor (the hint start, right of the focus badge) so the
-      # clickable rect lands exactly on the drawn badge even on a narrow row.
-      hint_x = rect.x + " #{focus_label} ".size + 1
-      nrect = Chrome.status_chip_rect(rect, :notify,
-        capturing: @session.capturing?, insecure_upstream: @session.config.insecure_upstream?,
-        write_failures: @session.store.write_failures, activity: activity_chip,
-        unread: @notifications.unread, min_x: hint_x)
-      return false unless nrect && nrect.contains?(mx, my)
-      open_notifications
-      true
+      unread = @notifications.unread
+      listen = "#{@session.proxy.host}:#{@session.proxy.port}"
+
+      nrect = Chrome.top_bar_chip_rect(rect, :notify, scope: scope_label, rules: rules_label,
+        intercept: intercept_label, listen: listen, time: clock_label, unread: unread)
+      if nrect && nrect.contains?(mx, my)
+        open_notifications
+        return true
+      end
+
+      srect = Chrome.top_bar_chip_rect(rect, :scope, scope: scope_label, rules: rules_label,
+        intercept: intercept_label, listen: listen, time: clock_label, unread: unread)
+      if srect && srect.contains?(mx, my)
+        scope_toggle_lens
+        return true
+      end
+
+      false
     end
 
     private def click_notifications(area : Rect, mx : Int32, my : Int32) : Nil
@@ -2742,7 +2752,8 @@ module Gori::Tui
       layout = Layout.compute(w, h, statusline_active?)
       Chrome.render_top_bar(screen, layout.topbar, project: @session.project.name,
         listen: "#{@session.proxy.host}:#{@session.proxy.port}", time: clock_label,
-        scope: scope_label, rules: rules_label, intercept: intercept_label)
+        scope: scope_label, rules: rules_label, intercept: intercept_label,
+        unread: @notifications.unread)
       Chrome.render_rule(screen, layout.rule)
       Chrome.render_menu(screen, layout.menu, active_tab: @active_tab, focused: @focus == :menu,
         tabs: effective_tabs, intercept_count: @session.interceptor.pending_count)
@@ -2750,7 +2761,7 @@ module Gori::Tui
       Chrome.render_status(screen, layout.status, focus: focus_label, hints: format_status_message(@toast) || key_hints,
         capturing: @session.capturing?, insecure_upstream: @session.config.insecure_upstream?,
         write_failures: @session.store.write_failures,
-        activity: activity_chip, unread: @notifications.unread)
+        activity: activity_chip)
       Chrome.render_statusline(screen, layout.statusline, @statusline.segments) unless layout.statusline.empty?
       @palette.render(screen, layout.body) if @overlay == :palette
       @rules_overlay.render(screen, layout.body) if @overlay == :rules
@@ -3082,7 +3093,7 @@ module Gori::Tui
       @notifications
     end
 
-    # Open the notification center (the app.notifications verb + the clickable bottom-bar
+    # Open the notification center (the app.notifications verb + the clickable top-bar
     # badge). Marks everything read, clearing the unread badge.
     def open_notifications : Nil
       @overlay = :notifications

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -29,8 +29,8 @@ module Gori
       # The notification center (background-job results, alerts). `n` is a Global
       # fallback chord — scope-local `n` (e.g. findings.new on Findings) still wins
       # where bound, exactly like Global `c` (capture) yields to Intercept's `c`. The
-      # clickable bottom-bar `notify:N` badge is the mouse path; both are rebindable
-      # via settings:hotkeys.
+      # clickable top-bar `notify:N` badge (left of scope) is the mouse path; both
+      # are rebindable via settings:hotkeys.
       r.register Verb::Definition.new(
         "app.notifications", "Notifications", "Open the notification center (background-job results)",
         Verb::Scope::Global, [Verb::Chord.new("n")], category: Verb::Category::System) { |ctx| ctx.open_notifications; nil }


### PR DESCRIPTION
## Summary
- Moves the unread notification badge (`notify:N`) from the bottom status bar to the top bar, positioned immediately left of `scope:N`, so it's more prominent and grouped with other "state" chips.
- Makes both `notify:N` and `scope:N`/`scope:off` clickable:
  - `notify:N` opens the notification center (previously only reachable via `n` or the old bottom-bar badge).
  - `scope:N` toggles the scope lens on/off — the same action as the global `s` chord (identical toast/behavior).
- Adds `Chrome.top_bar_chips`/`Chrome.top_bar_chip_rect`, mirroring the existing `status_chips`/`status_chip_rect` tagged-chip pattern used for hit-testing. The hit-test is pure (no live `Screen` needed) despite the top bar's variable-width, truncatable project name — see the comment on `top_bar_chip_rect` for the proof that the project-name floor only ever resolves to one of two deterministic values.
- Removes the notify chip from the bottom status bar and the now-dead `status_chip_rect` helper.
- Updates the Help tab text to mention the new click affordances.

## Test plan
- [x] `crystal spec spec/tui/` — 589 examples, 0 failures (added new coverage in `foundation_spec.cr` and `mouse_spec.cr` for chip rendering/position and click hit-testing, including narrow-terminal edge cases).
- [x] Full `crystal spec` run — only 8 pre-existing failures, all unrelated (port-binding/session specs that also fail on a clean checkout in this sandbox).
- [x] Manual E2E via tmux: generated a real unread notification (Miner job), confirmed `notify:1` renders top-right left of `scope:off` with nothing left in the bottom bar, then simulated a mouse click on the badge to open/clear it.
- [x] Manual E2E via tmux: added a scope rule, clicked `scope:1` → toggled off with the same toast the `s` key produces, clicked again → toggled back on with History reloading to in-scope-only.