### PR TITLE
feat(tui): merge capture status into the top-bar listen address

### DIFF
--- a/spec/tui/foundation_spec.cr
+++ b/spec/tui/foundation_spec.cr
@@ -123,11 +123,11 @@ describe Gori::Tui::Chrome do
   it "renders the focus-area badge at the far left of the status bar" do
     backend = MemoryBackend.new(90, 1)
     Chrome.render_status(Screen.new(backend), Rect.new(0, 0, 90, 1),
-      focus: "BODY", hints: "↹ pane · esc tabs", capturing: true, insecure_upstream: false)
+      focus: "BODY", hints: "↹ pane · esc tabs", insecure_upstream: false)
     backend.contains?("BODY").should be_true
-    backend.fg_at(1, 0).should eq(Theme.text_bright) # badge text is bright (col 0 is the leading pad)
-    backend.contains?("↹ pane").should be_true       # hints still render to the right of the badge
-    backend.contains?("capture:on").should be_true   # chips still on the right
+    backend.fg_at(1, 0).should eq(Theme.text_bright)    # badge text is bright (col 0 is the leading pad)
+    backend.contains?("↹ pane").should be_true          # hints still render to the right of the badge
+    backend.contains?("upstream:verify").should be_true # chips still on the right
   end
 
   it "keeps the focus badge intact when chips would otherwise overflow a narrow bar" do
@@ -135,20 +135,10 @@ describe Gori::Tui::Chrome do
     # widest chip pair must not clobber the persistent focus badge.
     backend = MemoryBackend.new(36, 1)
     Chrome.render_status(Screen.new(backend), Rect.new(0, 0, 36, 1),
-      focus: "FINDING", hints: "type title · esc cancel", capturing: false, insecure_upstream: true)
+      focus: "FINDING", hints: "type title · esc cancel", insecure_upstream: true)
     backend.row(0)[0, 9].should eq(" FINDING ") # badge survives, no chip bled into it
     backend.fg_at(1, 0).should eq(Theme.text_bright)
-    backend.contains?("capture:off").should be_true # chips still present (truncated at the right edge)
-  end
-
-  it "shows a loud red capture-failing chip when writes are dropping" do
-    backend = MemoryBackend.new(90, 1)
-    Chrome.render_status(Screen.new(backend), Rect.new(0, 0, 90, 1),
-      focus: "BODY", hints: "x", capturing: true, insecure_upstream: false, write_failures: 4)
-    backend.contains?("capture:FAILING(4)").should be_true
-    fx = backend.row(0).index("capture:FAILING").not_nil!
-    backend.fg_at(fx, 0).should eq(Theme.red)
-    backend.contains?("capture:on").should be_false # replaced, not appended
+    backend.contains?("upstream:insecure").should be_true # chips still present (truncated at the right edge)
   end
 
   it "gilds the shell only for single-pane body focus" do
@@ -196,8 +186,8 @@ describe Gori::Tui::Chrome do
     backend.row(0).should contain("acme")
     backend.row(0).should contain("scope:2")
     backend.row(0).should contain("01:37 PM")
-    backend.row(0).should_not contain("rec")    # capture state moved to the bottom status bar
-    backend.row(0).should_not contain("notify") # no unread → badge omitted
+    backend.row(0).should contain("127.0.0.1:8080") # listen address always shown, capture state rides its colour
+    backend.row(0).should_not contain("notify")     # no unread → badge omitted
   end
 
   it "shows the unread notify badge on the top bar, left of scope" do
@@ -215,8 +205,36 @@ describe Gori::Tui::Chrome do
   it "omits the notify badge from the bottom status bar (it moved to the top bar)" do
     backend = MemoryBackend.new(90, 1)
     Chrome.render_status(Screen.new(backend), Rect.new(0, 0, 90, 1),
-      focus: "BODY", hints: "↹ pane · esc tabs", capturing: true, insecure_upstream: false)
+      focus: "BODY", hints: "↹ pane · esc tabs", insecure_upstream: false)
     backend.contains?("notify").should be_false
+  end
+
+  it "colours the top-bar listen chip green while capturing (address text unchanged)" do
+    backend = MemoryBackend.new(80, 1)
+    Chrome.render_top_bar(Screen.new(backend), Rect.new(0, 0, 80, 1),
+      project: "acme", listen: "127.0.0.1:8080", time: "01:37 PM", scope: "scope:2", capturing: true)
+    backend.row(0).should contain("127.0.0.1:8080")
+    fx = backend.row(0).index("127.0.0.1:8080").not_nil!
+    backend.fg_at(fx, 0).should eq(Theme.green)
+    backend.contains?("capture:on").should be_false # merged into the listen chip, not a separate label
+  end
+
+  it "dims the top-bar listen chip when capture is paused" do
+    backend = MemoryBackend.new(80, 1)
+    Chrome.render_top_bar(Screen.new(backend), Rect.new(0, 0, 80, 1),
+      project: "acme", listen: "127.0.0.1:8080", time: "01:37 PM", scope: "scope:2", capturing: false)
+    fx = backend.row(0).index("127.0.0.1:8080").not_nil!
+    backend.fg_at(fx, 0).should eq(Theme.muted)
+  end
+
+  it "turns the top-bar listen chip red with the drop count when writes are failing" do
+    backend = MemoryBackend.new(80, 1)
+    Chrome.render_top_bar(Screen.new(backend), Rect.new(0, 0, 80, 1),
+      project: "acme", listen: "127.0.0.1:8080", time: "01:37 PM", scope: "scope:2",
+      capturing: true, write_failures: 4)
+    backend.row(0).should contain("127.0.0.1:8080 (4)")
+    fx = backend.row(0).index("127.0.0.1:8080").not_nil!
+    backend.fg_at(fx, 0).should eq(Theme.red)
   end
 end
 

--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -100,19 +100,23 @@ module Gori::Tui
     def self.render_top_bar(screen : Screen, rect : Rect, *, project : String,
                             listen : String, time : String,
                             scope : String, rules : String = "", intercept : String = "",
-                            unread : Int32 = 0) : Nil
+                            unread : Int32 = 0, capturing : Bool = true,
+                            write_failures : Int32 = 0) : Nil
       # Logo row sits flush on the canvas — no lifted panel band (tabs/status keep panel).
       screen.fill(rect, Theme.bg)
       x = render_wordmark(screen, rect.x + 1, rect.y, bg: Theme.bg)
       name_x = x + 1
 
       # right-aligned status chips: notify:N · scope:N · rules:N · intercept:on(N) ·
-      # listen · h:MM AM/PM — value-emphasized, dim · separators; the hot intercept
-      # state in RED. The clock is the rightmost anchor. (Capture state lives on the
-      # bottom status bar.) `unread` rides just left of scope so a background-job ping
-      # surfaces beside the state it's most likely to affect.
+      # ●listen · h:MM AM/PM — value-emphasized, dim · separators; the hot intercept
+      # state in RED. The clock is the rightmost anchor. `unread` rides just left of
+      # scope so a background-job ping surfaces beside the state it's most likely to
+      # affect. The listen chip's address text never changes — capture on/off/failing
+      # rides as the leading dot + label colour (green/muted/red), so the one address
+      # a user glances at doubles as the capture indicator instead of a separate chip.
       tagged = top_bar_chips(scope: scope, rules: rules, intercept: intercept,
-        listen: listen, time: time, unread: unread)
+        listen: listen, time: time, unread: unread, capturing: capturing,
+        write_failures: write_failures)
       chips = tagged.map { |(_, l, c)| {l, c} }
 
       # Bound the project name and floor the chips past it, so neither overwrites the
@@ -127,15 +131,27 @@ module Gori::Tui
     # The right-aligned top-bar chips, TAGGED so render and the click hit-test share
     # one ordered source (the geometry can't drift). Mirrors `status_chips` below.
     private def self.top_bar_chips(*, scope : String, rules : String, intercept : String,
-                                   listen : String, time : String, unread : Int32) : Array({Symbol, String, Color})
+                                   listen : String, time : String, unread : Int32,
+                                   capturing : Bool, write_failures : Int32) : Array({Symbol, String, Color})
       chips = [] of {Symbol, String, Color}
       chips << {:notify, "notify:#{unread}", Theme.accent} if unread > 0
       chips << {:scope, scope, scope.ends_with?(":off") ? Theme.muted : Theme.text} unless scope.empty?
       chips << {:rules, rules, Theme.text} unless rules.empty?
       chips << {:intercept, intercept, Theme.red} unless intercept.empty?
-      chips << {:listen, listen, Theme.muted}
+      label, color = listen_chip(listen, capturing, write_failures)
+      chips << {:listen, label, color}
       chips << {:time, time, Theme.muted}
       chips
+    end
+
+    # Label + colour for the merged listen/capture chip. The address (`listen`)
+    # itself is always shown verbatim — capture state rides on the leading dot and
+    # the chip's colour: green while capturing, muted while paused, and red (with
+    # the drop count appended) when writes are silently failing — that last case is
+    # the one an operator can't afford to miss, so it outranks plain on/off.
+    private def self.listen_chip(listen : String, capturing : Bool, write_failures : Int32) : {String, Color}
+      return {"● #{listen} (#{write_failures})", Theme.red} if write_failures > 0
+      {"● #{listen}", capturing ? Theme.green : Theme.muted}
     end
 
     # The drawn rect of a tagged top-bar chip (or nil if absent) — rebuilds the SAME
@@ -152,9 +168,11 @@ module Gori::Tui
     # exactly regardless of the actual project string or its truncation.
     def self.top_bar_chip_rect(rect : Rect, tag : Symbol, *, scope : String, rules : String = "",
                                intercept : String = "", listen : String, time : String,
-                               unread : Int32 = 0) : Rect?
+                               unread : Int32 = 0, capturing : Bool = true,
+                               write_failures : Int32 = 0) : Rect?
       tagged = top_bar_chips(scope: scope, rules: rules, intercept: intercept,
-        listen: listen, time: time, unread: unread)
+        listen: listen, time: time, unread: unread, capturing: capturing,
+        write_failures: write_failures)
       idx = tagged.index { |(t, _, _)| t == tag }
       return nil unless idx
       name_x = rect.x + 1 + Screen.display_width(WORDMARK) + 1
@@ -336,20 +354,19 @@ module Gori::Tui
       ""
     end
 
-    # Bottom row: a focus-area badge (far left) + contextual key hints + capture/
-    # upstream state chips (right). The badge — TABS / BODY / an overlay name —
-    # is a lifted chip so the user always knows which region the keys drive.
-    # (The notification unread badge lives on the top bar, next to scope.)
+    # Bottom row: a focus-area badge (far left) + contextual key hints + an upstream
+    # state chip (right). The badge — TABS / BODY / an overlay name — is a lifted
+    # chip so the user always knows which region the keys drive. (The notification
+    # unread badge lives on the top bar, next to scope; capture on/off/failing now
+    # rides the top bar's listen chip instead of a dedicated chip here.)
     def self.render_status(screen : Screen, rect : Rect, *, focus : String, hints : String,
-                           capturing : Bool, insecure_upstream : Bool, write_failures : Int32 = 0,
-                           activity : {String, Color}? = nil) : Nil
+                           insecure_upstream : Bool, activity : {String, Color}? = nil) : Nil
       screen.fill(rect, Theme.panel)
       badge = " #{focus} "
       screen.text(rect.x, rect.y, badge, Theme.text_bright, Theme.elevated, Attribute::Bold)
       hint_x = rect.x + badge.size + 1
 
-      chips = status_chips(capturing: capturing, insecure_upstream: insecure_upstream,
-        write_failures: write_failures, activity: activity).map { |(_, l, c)| {l, c} }
+      chips = status_chips(insecure_upstream: insecure_upstream, activity: activity).map { |(_, l, c)| {l, c} }
       hint_w = {rect.right - hint_x - chips_width(chips) - 2, 1}.max
       screen.text(hint_x, rect.y, hints, Theme.muted, Theme.panel, width: hint_w)
       # Floor the chips at the hint start so they can never overwrite the badge.
@@ -376,18 +393,11 @@ module Gori::Tui
 
     # The right-aligned status chips, TAGGED so render and (were there a clickable
     # chip here) a hit-test would share one ordered source. A background-activity
-    # chip (spinner + label) precedes the capture/upstream chips.
-    private def self.status_chips(*, capturing : Bool, insecure_upstream : Bool, write_failures : Int32,
+    # chip (spinner + label) precedes the upstream chip.
+    private def self.status_chips(*, insecure_upstream : Bool,
                                   activity : {String, Color}?) : Array({Symbol, String, Color})
       chips = [] of {Symbol, String, Color}
       chips << {:activity, activity[0], activity[1]} if activity
-      # A persistent capture-write failure (e.g. disk full) is louder than the
-      # normal on/off chip — the operator must know rows are being dropped.
-      chips << if write_failures > 0
-        {:capture, "capture:FAILING(#{write_failures})", Theme.red}
-      else
-        {:capture, capturing ? "capture:on" : "capture:off", capturing ? Theme.text : Theme.muted}
-      end
       # an insecure upstream is a security warning — the one allowed non-status colour.
       chips << (insecure_upstream ? {:upstream, "upstream:insecure", Theme.yellow} : {:upstream, "upstream:verify", Theme.muted})
       chips

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1010,16 +1010,20 @@ module Gori::Tui
       return false unless rect.contains?(mx, my)
       unread = @notifications.unread
       listen = "#{@session.proxy.host}:#{@session.proxy.port}"
+      capturing = @session.capturing?
+      write_failures = @session.store.write_failures
 
       nrect = Chrome.top_bar_chip_rect(rect, :notify, scope: scope_label, rules: rules_label,
-        intercept: intercept_label, listen: listen, time: clock_label, unread: unread)
+        intercept: intercept_label, listen: listen, time: clock_label, unread: unread,
+        capturing: capturing, write_failures: write_failures)
       if nrect && nrect.contains?(mx, my)
         open_notifications
         return true
       end
 
       srect = Chrome.top_bar_chip_rect(rect, :scope, scope: scope_label, rules: rules_label,
-        intercept: intercept_label, listen: listen, time: clock_label, unread: unread)
+        intercept: intercept_label, listen: listen, time: clock_label, unread: unread,
+        capturing: capturing, write_failures: write_failures)
       if srect && srect.contains?(mx, my)
         scope_toggle_lens
         return true
@@ -2787,14 +2791,14 @@ module Gori::Tui
       Chrome.render_top_bar(screen, layout.topbar, project: @session.project.name,
         listen: "#{@session.proxy.host}:#{@session.proxy.port}", time: clock_label,
         scope: scope_label, rules: rules_label, intercept: intercept_label,
-        unread: @notifications.unread)
+        unread: @notifications.unread, capturing: @session.capturing?,
+        write_failures: @session.store.write_failures)
       Chrome.render_rule(screen, layout.rule)
       Chrome.render_menu(screen, layout.menu, active_tab: @active_tab, focused: @focus == :menu,
         tabs: effective_tabs, intercept_count: @session.interceptor.pending_count)
       render_body(screen, layout.body)
       Chrome.render_status(screen, layout.status, focus: focus_label, hints: format_status_message(@toast) || key_hints,
-        capturing: @session.capturing?, insecure_upstream: @session.config.insecure_upstream?,
-        write_failures: @session.store.write_failures,
+        insecure_upstream: @session.config.insecure_upstream?,
         activity: activity_chip)
       Chrome.render_statusline(screen, layout.statusline, @statusline.segments) unless layout.statusline.empty?
       @palette.render(screen, layout.body) if @overlay == :palette


### PR DESCRIPTION
## Summary
- Fold the bottom status bar's `capture:on`/`capture:off`/`capture:FAILING(N)` chip into the top bar's listen-address chip: the address text (`host:port`) stays exactly as before, but a leading `●` and the chip's colour now convey capture state — green while capturing, muted while paused, red with the drop count appended (`● host:port (N)`) when writes are silently failing.
- Bottom status bar keeps only the upstream/activity chips; the dedicated capture chip is removed.
- Threaded `capturing`/`write_failures` through `Chrome.render_top_bar`/`top_bar_chip_rect` and the `click_top_bar` hit-test so geometry can't drift from what's drawn.

## Test plan
- [x] `crystal spec` — 1564 examples, 0 failures
- [x] `crystal tool format --check` on touched files
- [x] `shards build` succeeds
- [x] Manually verified in a live TUI session (tmux): listen chip renders green while capturing, dims to muted on `c` (capture off), returns to green on `c` again; bottom bar shows only `upstream:verify`