### PR TITLE
perf(proxy): reuse copy buffers + drop store head re-parse; harden client-side timeouts

### DIFF
--- a/spec/proxy/codec/body_spec.cr
+++ b/spec/proxy/codec/body_spec.cr
@@ -322,6 +322,35 @@ describe Gori::Proxy::Codec::Body do
   end
 end
 
+describe "Body.stream reused buffers (perf: per-connection copy buffer + chunked size-line scratch)" do
+  it "streams two sequential bodies through ONE shared copy buffer byte-exactly" do
+    # The connection-lifetime buffer ClientConn threads in is reused across the request body
+    # then the response body; they run sequentially, so reuse must not corrupt either.
+    buf = Bytes.new(Body::BUFSIZE)
+    a = "A" * 200_000 # larger than BUFSIZE → multiple copy iterations
+    src_a, dst_a, tee_a = IO::Memory.new(a), IO::Memory.new, IO::Memory.new
+    Body.stream(src_a, dst_a, BodyFraming::Length, a.bytesize.to_i64, tee_a, buf).should be_true
+    b = "B" * 130_000
+    src_b, dst_b, tee_b = IO::Memory.new(b), IO::Memory.new, IO::Memory.new
+    Body.stream(src_b, dst_b, BodyFraming::Length, b.bytesize.to_i64, tee_b, buf).should be_true
+    dst_a.to_s.should eq(a); tee_a.to_s.should eq(a)
+    dst_b.to_s.should eq(b); tee_b.to_s.should eq(b)
+  end
+
+  it "forwards a MANY-chunk body byte-exactly with the reused size-line scratch + copy buffer" do
+    wire = String.build do |s|
+      500.times { s << "5\r\nhello\r\n" } # 500 size-line reads share one scratch IO::Memory
+      s << "0\r\nX-Sum: z\r\n\r\nNEXT"
+    end
+    src, dst, tee = IO::Memory.new(wire), IO::Memory.new, IO::Memory.new
+    Body.stream(src, dst, BodyFraming::Chunked, 0_i64, tee, Bytes.new(Body::BUFSIZE)).should be_true
+    expected = wire[0, wire.size - "NEXT".size]
+    dst.to_s.should eq(expected) # wire form forwarded byte-exact (framing + trailer intact)
+    tee.to_s.should eq(expected)
+    src.gets_to_end.should eq("NEXT") # next keep-alive message not consumed
+  end
+end
+
 describe Gori::Proxy::Codec::ContentDecode do
   head = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n".to_slice
 

--- a/spec/proxy/socket_tuning_spec.cr
+++ b/spec/proxy/socket_tuning_spec.cr
@@ -1,0 +1,111 @@
+require "../spec_helper"
+require "socket"
+
+alias ST = Gori::Proxy::SocketTuning
+
+describe Gori::Proxy::SocketTuning do
+  describe ".underlying_socket" do
+    it "returns a raw Socket unchanged" do
+      a, b = UNIXSocket.pair
+      begin
+        ST.underlying_socket(a).should be(a)
+      ensure
+        a.close; b.close
+      end
+    end
+
+    it "unwraps a PrefixIO to its inner socket" do
+      a, b = UNIXSocket.pair
+      begin
+        pio = Gori::Proxy::PrefixIO.new("PRI".to_slice, a)
+        ST.underlying_socket(pio).should be(a)
+      ensure
+        a.close; b.close
+      end
+    end
+
+    it "returns nil for a non-socket IO and for nil" do
+      ST.underlying_socket(IO::Memory.new).should be_nil
+      ST.underlying_socket(nil).should be_nil
+    end
+  end
+
+  describe ".arm / .relax" do
+    it "sets then clears the read+write timeout on the socket" do
+      a, b = UNIXSocket.pair
+      begin
+        ST.arm(a, 7.seconds)
+        a.read_timeout.should eq(7.seconds)
+        a.write_timeout.should eq(7.seconds)
+        ST.relax(a)
+        a.read_timeout.should be_nil
+        a.write_timeout.should be_nil
+      ensure
+        a.close; b.close
+      end
+    end
+
+    it "arms through a PrefixIO wrapper (reaches the underlying socket)" do
+      a, b = UNIXSocket.pair
+      begin
+        ST.arm(Gori::Proxy::PrefixIO.new(Bytes.empty, a), 3.seconds)
+        a.read_timeout.should eq(3.seconds)
+      ensure
+        a.close; b.close
+      end
+    end
+
+    it "no-ops (never raises) on a non-socket IO" do
+      ST.arm(IO::Memory.new, 5.seconds) # nothing to set — must not raise
+      ST.relax(IO::Memory.new)
+    end
+  end
+
+  describe ".enable_keepalive" do
+    it "never raises, even where the tunables are unsupported" do
+      a, b = UNIXSocket.pair
+      begin
+        ST.enable_keepalive(a) # a UNIX socket may reject SO_KEEPALIVE tunables — must be swallowed
+      ensure
+        a.close; b.close
+      end
+    end
+  end
+end
+
+describe "Http1.read_head with a head-completion deadline (drip-feed slowloris bound)" do
+  it "raises after the deadline when the head never completes" do
+    a, b = UNIXSocket.pair
+    begin
+      # A partial head (no terminating CRLFCRLF): the first bytes arrive, then the reader blocks.
+      a.write("GET / HTTP/1.1\r\nHost: x\r\n".to_slice)
+      a.flush
+      expect_raises(IO::TimeoutError) do
+        Gori::Proxy::Codec::Http1.read_head(b, deadline: 100.milliseconds, timeout_sock: b)
+      end
+    ensure
+      a.close; b.close
+    end
+  end
+
+  it "returns a complete head and RESTORES the baseline timeout for the body read" do
+    a, b = UNIXSocket.pair
+    begin
+      b.read_timeout = 5.seconds # caller's baseline (armed by `run`)
+      a.write("GET / HTTP/1.1\r\n\r\n".to_slice)
+      a.flush
+      head = Gori::Proxy::Codec::Http1.read_head(b, deadline: 2.seconds, timeout_sock: b)
+      String.new(head.not_nil!).should eq("GET / HTTP/1.1\r\n\r\n")
+      b.read_timeout.should eq(5.seconds) # restored, so the following body read isn't left on a shrunk budget
+    ensure
+      a.close; b.close
+    end
+  end
+
+  it "is byte-for-byte the original read_head when no deadline is armed" do
+    io = IO::Memory.new("GET /x HTTP/1.1\r\nA: b\r\n\r\nBODY")
+    head = Gori::Proxy::Codec::Http1.read_head(io)
+    String.new(head.not_nil!).should eq("GET /x HTTP/1.1\r\nA: b\r\n\r\n")
+    io.gets_to_end.should eq("BODY") # body boundary intact
+  end
+end

--- a/spec/store/fts_spec.cr
+++ b/spec/store/fts_spec.cr
@@ -106,7 +106,7 @@ describe "contentless FTS (V24)" do
       store.update_response(Gori::Store::CapturedResponse.new(
         flow_id: id, status: 200,
         head: "HTTP/1.1 200 OK\r\ncontent-type: text/html\r\ncontent-encoding: gzip\r\n\r\n".to_slice,
-        body: "compressedbodytoken".to_slice, content_type: "text/html"))
+        body: "compressedbodytoken".to_slice, content_type: "text/html", content_encoding: "gzip"))
       store.flush
       body_hits(store, "compressedbodytoken").should be_empty
     end
@@ -130,7 +130,7 @@ describe "contentless FTS (V24)" do
       store.update_response(Gori::Store::CapturedResponse.new(
         flow_id: id, status: 200,
         head: "HTTP/1.1 200 OK\r\ncontent-type: text/html\r\ncontent-encoding: identity\r\n\r\n".to_slice,
-        body: "identitybodytoken".to_slice, content_type: "text/html"))
+        body: "identitybodytoken".to_slice, content_type: "text/html", content_encoding: "identity"))
       store.flush
       body_hits(store, "identitybodytoken").should eq([id]) # identity ⇒ NOT skipped
     end

--- a/src/gori/flow_mapper.cr
+++ b/src/gori/flow_mapper.cr
@@ -44,6 +44,7 @@ module Gori
         body: body,
         reason: resp.reason.presence,
         content_type: resp.headers.get?("Content-Type"),
+        content_encoding: resp.headers.get?("Content-Encoding"),
         ttfb_us: ttfb_us,
         duration_us: duration_us,
         state: state,

--- a/src/gori/import/builder.cr
+++ b/src/gori/import/builder.cr
@@ -112,8 +112,10 @@ module Gori
           head: req_head, body: req_stored, body_truncated: req_trunc, body_size: req_size)
         resp_head = response_head(http_version, status, reason, resp_headers, resp_body)
         resp_stored, resp_trunc, resp_size = capped(resp_body)
+        content_encoding = resp_headers.find { |(k, _)| k.compare("content-encoding", case_insensitive: true) == 0 }.try(&.[1])
         resp = Store::CapturedResponse.new(
           flow_id: 0, status: status, reason: reason.presence, content_type: content_type,
+          content_encoding: content_encoding,
           head: resp_head, body: resp_stored, body_truncated: resp_trunc, body_size: resp_size,
           duration_us: duration_us, state: Store::FlowState::Complete)
         FlowPair.new(req, resp)

--- a/src/gori/proxy/codec/body.cr
+++ b/src/gori/proxy/codec/body.cr
@@ -200,13 +200,21 @@ module Gori::Proxy::Codec
     # the body completed: false means a Content-Length/chunked body was cut short,
     # so the caller must close the connection (a half-delivered body can't be
     # followed by a keep-alive request without desyncing the peer).
-    def self.stream(src : IO, dst : IO, framing : BodyFraming, length : Int64, tee : IO) : Bool
+    #
+    # `buf` is the scratch copy buffer. When nil (Replay/Fuzz/Miner callers) a body
+    # allocates a fresh 64 KiB slice, as before. A caller that forwards many bodies on
+    # one connection (ClientConn) passes ONE reused buffer so a keep-alive stream stops
+    # churning a large-object 64 KiB allocation per body — safe because a body is pumped
+    # one direction on one fiber, so the request and response bodies copy sequentially,
+    # never overlapping (the same argument copy_chunked already uses across its chunks).
+    # A body-less frame (None) never touches the buffer, so a bodyless request never allocates.
+    def self.stream(src : IO, dst : IO, framing : BodyFraming, length : Int64, tee : IO, buf : Bytes? = nil) : Bool
       complete =
         case framing
         in BodyFraming::None           then true
-        in BodyFraming::Length         then copy_n(src, dst, tee, length)
-        in BodyFraming::CloseDelimited then (copy_until_eof(src, dst, tee); true) # EOF is the framing
-        in BodyFraming::Chunked        then copy_chunked(src, dst, tee)
+        in BodyFraming::Length         then copy_n(src, dst, tee, length, buf)
+        in BodyFraming::CloseDelimited then (copy_until_eof(src, dst, tee, buf); true) # EOF is the framing
+        in BodyFraming::Chunked        then copy_chunked(src, dst, tee, buf)
         end
       dst.flush
       complete
@@ -290,18 +298,19 @@ module Gori::Proxy::Codec
 
     # Copies exactly `n` bytes; returns false if the source EOF'd early (a
     # truncated Content-Length body), true once all `n` were transferred.
-    # `buf` is the scratch copy buffer. The Length-framing caller lets it default to a
-    # fresh 64 KiB slice (one alloc per body); copy_chunked passes ONE buffer reused
-    # across every chunk (a chunked body used to allocate a fresh 64 KiB per chunk — a
-    # 100 MB response in 16 KB chunks churned ~400 MB of throwaway buffers). Safe to
-    # share: a body is pumped one direction on one fiber, so chunks copy sequentially.
-    private def self.copy_n(src : IO, dst : IO, tee : IO, n : Int64, buf : Bytes = Bytes.new(BUFSIZE)) : Bool
+    # `buf` is the scratch copy buffer. When nil a fresh 64 KiB slice is allocated (one
+    # alloc per body); a caller that reuses one buffer across a whole connection or across
+    # copy_chunked's chunks passes it in (a chunked body used to allocate a fresh 64 KiB
+    # per chunk — a 100 MB response in 16 KB chunks churned ~400 MB of throwaway buffers).
+    # Safe to share: a body is pumped one direction on one fiber, so chunks copy sequentially.
+    private def self.copy_n(src : IO, dst : IO, tee : IO, n : Int64, buf : Bytes? = nil) : Bool
+      cbuf = buf || Bytes.new(BUFSIZE)
       remaining = n
       while remaining > 0
         want = remaining < BUFSIZE ? remaining.to_i : BUFSIZE
-        read = src.read(buf[0, want])
+        read = src.read(cbuf[0, want])
         break if read == 0 # premature EOF
-        slice = buf[0, read]
+        slice = cbuf[0, read]
         dst.write(slice)
         tee.write(slice)
         remaining -= read
@@ -309,10 +318,10 @@ module Gori::Proxy::Codec
       remaining == 0
     end
 
-    private def self.copy_until_eof(src : IO, dst : IO, tee : IO) : Nil
-      buf = Bytes.new(BUFSIZE)
-      while (read = src.read(buf)) > 0
-        slice = buf[0, read]
+    private def self.copy_until_eof(src : IO, dst : IO, tee : IO, buf : Bytes? = nil) : Nil
+      cbuf = buf || Bytes.new(BUFSIZE)
+      while (read = src.read(cbuf)) > 0
+        slice = cbuf[0, read]
         dst.write(slice)
         tee.write(slice)
       end
@@ -320,10 +329,15 @@ module Gori::Proxy::Codec
 
     # Returns true once the terminating 0-length chunk is seen; false if the
     # source EOF'd mid-stream (a truncated chunked body).
-    private def self.copy_chunked(src : IO, dst : IO, tee : IO) : Bool
-      buf = Bytes.new(BUFSIZE) # reused across every chunk's copy_n (see copy_n)
+    private def self.copy_chunked(src : IO, dst : IO, tee : IO, buf : Bytes? = nil) : Bool
+      cbuf = buf || Bytes.new(BUFSIZE) # reused across every chunk's copy_n (see copy_n)
+      # ONE reused scratch for every chunk-size + trailer line of this body: read_crlf_line
+      # fills+returns a view into it instead of a fresh IO::Memory + dup per line (a long
+      # chunked/SSE stream has one size line per chunk). Safe: each line is emitted (and the
+      # size line parsed) before the next read_crlf_line clears+refills the scratch.
+      line_buf = IO::Memory.new
       loop do
-        size_line = read_crlf_line(src)
+        size_line = read_crlf_line(src, line_buf)
         # EOF before any byte → truncated mid-stream. A line that hit MAX_LINE_BYTES WITHOUT an
         # LF is also unterminated: parse_chunk_size could still read a valid-looking size from the
         # partial (all-'0' → 0 terminating chunk; '5;<oversized ext>' → 5), leaving the rest of the
@@ -343,7 +357,7 @@ module Gori::Proxy::Codec
           # trailer lines) can't pin/forward unboundedly — abort (→ close) on overrun.
           trailer_total = 0_i64
           loop do
-            trailer = read_crlf_line(src)
+            trailer = read_crlf_line(src, line_buf)
             # Clean EOF after the 0-chunk → tolerate (as before). But an unterminated (LF-less,
             # cap-truncated) trailer line is a framing error: forwarding it and keeping the
             # connection alive would leak the line remainder onto the wire to misframe the next
@@ -357,8 +371,8 @@ module Gori::Proxy::Codec
           end
           return true # terminating chunk reached
         end
-        return false unless copy_n(src, dst, tee, size, buf) # truncated mid-chunk
-        if crlf = read_exact(src, 2)                         # the CRLF terminating the chunk data
+        return false unless copy_n(src, dst, tee, size, cbuf) # truncated mid-chunk
+        if crlf = read_exact(src, 2)                          # the CRLF terminating the chunk data
           emit(dst, tee, crlf)
         end
       end
@@ -373,14 +387,22 @@ module Gori::Proxy::Codec
     # Stops buffering at `max_size` even without an LF, so a pathological line with
     # no terminator can't grow memory unbounded; the partial (LF-less) line then
     # fails the caller's framing check (bad chunk-size / never-blank trailer → close).
-    private def self.read_crlf_line(io : IO, max_size : Int32 = MAX_LINE_BYTES) : Bytes?
-      buf = IO::Memory.new
+    #
+    # With a `scratch` IO::Memory the line is read into (and returned as a VIEW over)
+    # that reused buffer — no per-line IO::Memory + dup. The caller MUST consume the
+    # returned slice before the next read_crlf_line call clears+refills the scratch
+    # (copy_chunked emits/parses each line immediately, so this holds). Without a scratch
+    # the line is returned as an owned copy that outlives the call.
+    private def self.read_crlf_line(io : IO, scratch : IO::Memory? = nil, max_size : Int32 = MAX_LINE_BYTES) : Bytes?
+      buf = scratch || IO::Memory.new
+      buf.clear if scratch
       while byte = io.read_byte
         buf.write_byte(byte)
         break if byte == 0x0a_u8 # LF
         break if buf.bytesize >= max_size
       end
-      buf.bytesize == 0 ? nil : buf.to_slice.dup
+      return nil if buf.bytesize == 0
+      scratch ? buf.to_slice : buf.to_slice.dup
     end
 
     private def self.read_exact(io : IO, n : Int32) : Bytes?

--- a/src/gori/proxy/codec/http1.cr
+++ b/src/gori/proxy/codec/http1.cr
@@ -1,3 +1,4 @@
+require "socket"
 require "./message"
 
 # Pure, byte-exact HTTP/1.1 head codec (sans-IO).
@@ -23,7 +24,19 @@ module Gori::Proxy::Codec::Http1
   # in the socket and get consumed as the body, desyncing keep-alive — so we treat
   # an oversized head as an unusable connection (caller drops it). A head cut short
   # by EOF still returns its bytes (the connection is closing; P7 keeps the octets).
-  def self.read_head(io : IO, max_bytes : Int32 = 1024 * 256) : Bytes?
+  # `deadline` + `timeout_sock` (both required to arm it) bound the total time to assemble a
+  # head AFTER its first byte — the drip-feed slowloris defense a per-read timeout can't provide
+  # (a byte-at-a-time trickle keeps resetting a per-read timer). The socket's read_timeout is
+  # shrunk toward the deadline before each read and RESTORED on exit, so the body read that
+  # follows sees the caller's baseline, not the leftover head budget. With `deadline`/`timeout_sock`
+  # nil (every caller but the client request-head read) the loop is byte-for-byte the original.
+  def self.read_head(io : IO, max_bytes : Int32 = 1024 * 256, *,
+                     deadline : Time::Span? = nil, timeout_sock : ::Socket? = nil) : Bytes?
+    # Deadline path only when BOTH are provided (the client request-head read); every other
+    # caller takes the byte-for-byte original fast path.
+    if (sock = timeout_sock) && (dl = deadline)
+      return read_head_deadlined(io, sock, dl, max_bytes)
+    end
     buf = IO::Memory.new(512) # presized: covers a typical head without regrowing
     while buf.bytesize < max_bytes
       byte = io.read_byte
@@ -33,14 +46,43 @@ module Gori::Proxy::Codec::Http1
       # — skip the 4-byte tail compare on every other byte.
       break if byte == 0x0a_u8 && buf.bytesize >= 4 && ends_with_crlf_crlf?(buf)
     end
+    finalize_head(buf, max_bytes)
+  end
+
+  # As read_head, but bounds the total time to assemble a head AFTER its first byte — the
+  # drip-feed slowloris defense a per-read timeout can't provide (a byte-at-a-time trickle keeps
+  # resetting a per-read timer). `sock`'s read_timeout is shrunk toward `deadline` before each
+  # read and RESTORED on exit, so the body read that follows sees the caller's baseline.
+  private def self.read_head_deadlined(io : IO, sock : ::Socket, deadline : Time::Span, max_bytes : Int32) : Bytes?
+    buf = IO::Memory.new(512)
+    saved_timeout = sock.read_timeout
+    head_started = nil.as(Time::Instant?)
+    begin
+      while buf.bytesize < max_bytes
+        if hs = head_started
+          remaining = deadline - (Time.instant - hs)
+          raise IO::TimeoutError.new("request head incomplete before deadline") if remaining <= Time::Span.zero
+          sock.read_timeout = remaining
+        end
+        byte = io.read_byte
+        break if byte.nil?            # EOF
+        head_started ||= Time.instant # start the head clock at the first received byte
+        buf.write_byte(byte)
+        break if byte == 0x0a_u8 && buf.bytesize >= 4 && ends_with_crlf_crlf?(buf)
+      end
+    ensure
+      sock.read_timeout = saved_timeout # restore the baseline for the following body read
+    end
+    finalize_head(buf, max_bytes)
+  end
+
+  # Turn a read head buffer into the returned bytes (or nil). A `buf` that hit the cap without a
+  # terminator is an oversized/hostile head — returning it would misframe the body (the real
+  # CRLFCRLF is still on the wire), so drop it. Otherwise the view (length = bytesize) is the
+  # head's sole owner: it becomes an immutable `raw_head` (P7), so no defensive copy is made.
+  private def self.finalize_head(buf : IO::Memory, max_bytes : Int32) : Bytes?
     return nil if buf.bytesize == 0
-    # Hit the cap without a terminator → oversized/hostile head; don't misframe.
     return nil if buf.bytesize >= max_bytes && !ends_with_crlf_crlf?(buf)
-    # `buf` is a local, discarded here, so the returned view (length = bytesize) is the head's
-    # sole owner — no defensive copy. It becomes an immutable `raw_head` (P7: forwarding emits
-    # it verbatim, the rewriter builds fresh buffers), so nothing writes through it. Trades a
-    # per-head copy (2×/flow on the 100% path) for briefly retaining the buffer's slack capacity
-    # until capture.
     buf.to_slice
   end
 

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -7,6 +7,7 @@ require "../head_rewriter"
 require "../../interceptor"
 require "../../host_overrides"
 require "../prefix_io"
+require "../socket_tuning"
 require "../h2/relay"
 require "../connect"
 require "../upstream"
@@ -40,10 +41,25 @@ module Gori::Proxy
       @upstream = nil.as(IO?)
       @up_host = nil.as(String?)
       @up_port = 0
+      # One 64 KiB copy buffer reused across every request AND response body forwarded on
+      # this connection (see `copy_buf`), so a keep-alive stream stops churning a large-object
+      # allocation per body. Lazily allocated on the first body copy.
+      @copy_buf = nil.as(Bytes?)
+    end
+
+    # The connection-lifetime scratch buffer for body forwarding, allocated on first use.
+    # Safe to share across the request and response streams because they run sequentially on
+    # this one fiber (the request body is fully forwarded before the response head is read).
+    private def copy_buf : Bytes
+      @copy_buf ||= Bytes.new(Codec::Body::BUFSIZE)
     end
 
     def run : Nil
       loop do
+        # Re-arm the client read/write timeout at the START of every keep-alive request, so a
+        # prior request that RELAXED the socket for a streamed (SSE/chunked) response then kept
+        # the connection alive can't carry that relaxed (untimed) state into the next request.
+        SocketTuning.arm(@io, SocketTuning::CLIENT_IO_TIMEOUT)
         break unless handle_request
       end
     rescue
@@ -87,7 +103,11 @@ module Gori::Proxy
 
     # Returns true to keep the connection alive for another request.
     private def handle_request : Bool
-      head = Codec::Http1.read_head(@io)
+      # The client request head is the slowloris surface: bound total head-assembly time after
+      # its first byte (a drip-feed that a per-read timeout can't catch). The first-byte (idle
+      # keep-alive) wait stays bounded by the baseline timeout armed in `run`.
+      head = Codec::Http1.read_head(@io,
+        deadline: SocketTuning::HEAD_DEADLINE, timeout_sock: SocketTuning.underlying_socket(@io))
       return false if head.nil? # client closed / keep-alive idle end
 
       req = Codec::Http1.parse_request_head(head)
@@ -171,7 +191,7 @@ module Gori::Proxy
       req_complete = true
       upstream, reused, sent = acquire_and_send(host, port, retryable) do |up|
         up.write(sent_head)
-        req_complete = Codec::Body.stream(@io, up, req_framing, req_len, req_capture)
+        req_complete = Codec::Body.stream(@io, up, req_framing, req_len, req_capture, copy_buf)
         up.flush
         true
       end
@@ -292,10 +312,15 @@ module Gori::Proxy
     private def acquire_and_send(host : String, port : Int32, retryable : Bool, & : IO -> Bool) : {IO?, Bool, Bool}
       upstream, reused = acquire_upstream(host, port)
       return {nil, false, false} unless upstream
+      # Re-arm the per-request upstream timeout: a REUSED socket may carry a relaxed (untimed)
+      # state from a prior streamed (SSE/chunked) response. A freshly dialed one already has it
+      # (direct_dial), so this is an idempotent set there.
+      SocketTuning.arm(upstream, Upstream::IO_TIMEOUT)
       ok = send_guard { yield upstream }
       if !ok && reused && retryable
         release_upstream
         upstream, reused = acquire_upstream(host, port)
+        SocketTuning.arm(upstream, Upstream::IO_TIMEOUT) if upstream
         ok = upstream ? send_guard { yield upstream } : false
       end
       {upstream, reused, ok}
@@ -374,6 +399,8 @@ module Gori::Proxy
           scheme, resp, sent_resp_head, resp_framing, resp_len, ttfb, started)
       end
 
+      relax_for_streaming_response(resp, resp_framing, upstream)
+
       # Non-hold path: stream the response body byte-for-byte (P6) and record the
       # flow. `completed` is true only when the whole body was delivered cleanly; a
       # client abort or upstream truncation is recorded Aborted (see the helper).
@@ -393,6 +420,11 @@ module Gori::Proxy
         @upstream = nil
         @up_host = nil
         @up_port = 0
+        # Entering a long-lived bidirectional tunnel: relax both legs' timeouts so an idle
+        # WebSocket/tunnel isn't reaped by a wall-clock cutoff (the 30 s upstream io_timeout would
+        # otherwise tear a quiet tunnel down). Keepalive (both legs) reaps a truly dead peer.
+        SocketTuning.relax(@io)
+        SocketTuning.relax(upstream)
         if websocket_upgrade?(resp)
           WS::Relay.run(@io, upstream, flow_id, @sink) # frames until close (P6/P7)
         else
@@ -491,7 +523,7 @@ module Gori::Proxy
       begin
         @io.write(sent_resp_head)
         @io.flush
-        resp_complete = Codec::Body.stream(upstream, @io, resp_framing, resp_len, resp_capture)
+        resp_complete = Codec::Body.stream(upstream, @io, resp_framing, resp_len, resp_capture, copy_buf)
       rescue
         record_streamed_response(sent_resp, resp_framing, resp_capture, flow_id, ttfb, started,
           state: Store::FlowState::Aborted, error: "connection closed mid-response")
@@ -528,7 +560,7 @@ module Gori::Proxy
                                                 resp_framing : Codec::BodyFraming, resp_len : Int64,
                                                 ttfb : Int64, started : Time::Instant) : Bool
       buf = IO::Memory.new
-      resp_complete = Codec::Body.stream(upstream, buf, resp_framing, resp_len, Codec::DiscardIO.new)
+      resp_complete = Codec::Body.stream(upstream, buf, resp_framing, resp_len, Codec::DiscardIO.new, copy_buf)
       sent_resp_head, fwd_body = apply_body_rewrite(sent_resp_head, buf.to_slice, resp_framing) { |e| rw.rewrite_response_body(e) }
       sent_resp = Codec::Http1.parse_response_head(sent_resp_head) # head may have been re-framed
       stored, trunc, size = capped(fwd_body)
@@ -599,7 +631,7 @@ module Gori::Proxy
       buf = IO::Memory.new
       # tee into a discard sink, not a second IO::Memory — the body is already buffered in
       # `buf`; a throwaway IO::Memory would hold the whole response a second time.
-      resp_complete = Codec::Body.stream(upstream, buf, resp_framing, resp_len, Codec::DiscardIO.new)
+      resp_complete = Codec::Body.stream(upstream, buf, resp_framing, resp_len, Codec::DiscardIO.new, copy_buf)
       body = resp_framing.none? ? nil : buf.to_slice.dup
       # Match&Replace (response body) BEFORE the human sees it, like the head. A body rule
       # re-frames the head to Content-Length; `resp` (status/version/Connection) is
@@ -658,12 +690,26 @@ module Gori::Proxy
       release_upstream unless origin_keep_alive
     end
 
+    # A close-delimited or SSE (event-stream) response streams for an unbounded, idle-prone time;
+    # relax BOTH legs' read/write timeouts so a legitimately-idle stream isn't torn down mid-flight
+    # (keepalive reaps a genuinely dead peer). A normal Length/chunked response keeps the baseline
+    # timeout, and the `run`/`acquire_and_send` re-arm restores it for any later keep-alive request.
+    private def relax_for_streaming_response(resp : Codec::RawResponse, resp_framing : Codec::BodyFraming, upstream : IO) : Nil
+      return unless resp_framing.close_delimited? || sse?(resp)
+      SocketTuning.relax(@io)
+      SocketTuning.relax(upstream)
+    end
+
     # Cleartext HTTP/2 (h2c) tunnelled inside a CONNECT: the target is the
     # CONNECT authority, so we dial it plaintext and run the same h2 relay (no
     # :authority routing / HPACK coupling needed). The origin must speak h2c.
     private def intercept_h2c(host : String, port : Int32, client : IO) : Nil
       upstream = Upstream.dial(host, port, overrides: @host_overrides)
       return unless upstream
+      # Long-lived h2c relay: relax both legs so an idle h2 connection isn't reaped by the
+      # baseline/io timeouts; keepalive (both legs) handles a dead peer.
+      SocketTuning.relax(client)
+      SocketTuning.relax(upstream)
       begin
         H2::Relay.run(client, upstream, host, port, @sink)
       ensure
@@ -724,6 +770,10 @@ module Gori::Proxy
         begin
           @io.write("HTTP/1.1 200 Connection Established\r\n\r\n".to_slice)
           @io.flush
+          # Blind CONNECT tunnel: relax both legs so an idle tunnel (IMAP IDLE, long-poll, a quiet
+          # TLS session) isn't reaped by the 30 s io_timeout; keepalive reaps a genuinely dead peer.
+          SocketTuning.relax(@io)
+          SocketTuning.relax(upstream)
           Pump.blind_tunnel(@io, upstream)
         ensure
           upstream.close rescue nil

--- a/src/gori/proxy/h2/assembler.cr
+++ b/src/gori/proxy/h2/assembler.cr
@@ -282,6 +282,7 @@ module Gori::Proxy::H2
       cap = stream.resp.body
       body = cap.total == 0 ? nil : cap.to_slice
       content_type = header_value(headers, "content-type")
+      content_encoding = header_value(headers, "content-encoding")
       head = synth_response_head(status, headers)
       now = Time.instant
       duration_us = (now - stream.started_at).total_microseconds.to_i64
@@ -289,7 +290,7 @@ module Gori::Proxy::H2
       @sink.on_response(Store::CapturedResponse.new(
         flow_id: flow_id, status: status, head: head, body: body,
         body_truncated: cap.truncated?, body_size: cap.total,
-        content_type: content_type, state: state, error: error,
+        content_type: content_type, content_encoding: content_encoding, state: state, error: error,
         ttfb_us: ttfb_us, duration_us: duration_us))
     end
 

--- a/src/gori/proxy/prefix_io.cr
+++ b/src/gori/proxy/prefix_io.cr
@@ -4,6 +4,10 @@ module Gori::Proxy
   # ClientHello from an HTTP/2 cleartext preface after a CONNECT, so the chosen
   # handler (TLS MITM or h2c relay) still sees the complete byte stream (P7).
   class PrefixIO < IO
+    # The wrapped transport IO — exposed so SocketTuning can reach the underlying socket
+    # (a PrefixIO over the raw client socket is what the TLS-MITM server socket wraps).
+    getter inner : IO
+
     def initialize(@prefix : Bytes, @inner : IO)
       @pos = 0
     end

--- a/src/gori/proxy/server.cr
+++ b/src/gori/proxy/server.cr
@@ -4,6 +4,7 @@ require "./connect"
 require "./head_rewriter"
 require "../interceptor"
 require "../host_overrides"
+require "./socket_tuning"
 require "./conn/client_conn"
 
 module Gori::Proxy
@@ -112,6 +113,11 @@ module Gori::Proxy
       spawn do
         client.sync = true # immediate writes (P6)
         client.tcp_nodelay = true
+        # Baseline read/write timeout (defeats silent slowloris + RUDY on the client leg) and
+        # keepalive (reaps a dead peer on a later relaxed tunnel). ClientConn re-arms per request
+        # and relaxes both on entering a WS/SSE/CONNECT/h2 tunnel.
+        SocketTuning.enable_keepalive(client)
+        SocketTuning.arm(client, SocketTuning::CLIENT_IO_TIMEOUT)
         ClientConn.new(client, "http", @sink, @tls, rewriter: @rewriter, interceptor: @interceptor,
           host_overrides: @host_overrides, self_addr: {@host, @port}).run
       rescue

--- a/src/gori/proxy/socket_tuning.cr
+++ b/src/gori/proxy/socket_tuning.cr
@@ -1,0 +1,93 @@
+require "socket"
+require "openssl"
+require "./prefix_io"
+
+# Expose the transport socket an SSL wrapper drives, so proxy tunnels can set fd-level
+# socket options (read/write timeouts, keepalive) that OpenSSL::SSL::Socket does not forward
+# to the underlying socket. `#bio` is private on the class, but `OpenSSL::BIO#io` is public;
+# calling it from a method reopened onto the class is allowed. Guarded so a future stdlib
+# change degrades to "can't reach the socket" (the baseline timeout stays) instead of breaking.
+class OpenSSL::SSL::Socket
+  def gori_underlying_io : IO?
+    bio.io
+  rescue
+    nil
+  end
+end
+
+module Gori::Proxy
+  # Centralizes read/write timeouts and TCP keepalive for the proxy's client and upstream
+  # legs. A per-read timeout while reading a request head/body or writing a response defeats
+  # silent slowloris (a peer that connects then stalls) and RUDY (a client that stops reading
+  # the response). Once a connection becomes a long-lived tunnel/relay (WebSocket / SSE /
+  # blind CONNECT / h2), the timeout is RELAXED so a legitimately-idle tunnel isn't torn down,
+  # and SO_KEEPALIVE takes over reaping a dead (half-open) peer without a wall-clock cutoff on
+  # live-but-idle traffic. Resolving the underlying Socket through the TLS/PrefixIO wrappers lets
+  # every seam relax by handle (`SocketTuning.relax(@io)`) without threading raw sockets through
+  # ClientConn/TlsMitm signatures.
+  module SocketTuning
+    # Per-read/write timeout while reading a request head/body or writing a response. Matches
+    # the upstream leg's existing 30 s (Upstream::IO_TIMEOUT) — a stall THIS long between reads
+    # is treated as a dead/hostile peer. It is per-read (per 64 KiB copy iteration), not a
+    # whole-body budget, so only a ≥30 s stall trips it, never a genuinely slow-but-progressing
+    # transfer.
+    CLIENT_IO_TIMEOUT = 30.seconds
+
+    # Overall wall-clock budget for a full request head to arrive AFTER its first byte. A per-read
+    # timeout alone can't catch a byte-at-a-time drip that keeps resetting it; this bounds the
+    # total head-assembly time regardless of drip rate. The first-byte (idle keep-alive) wait is
+    # bounded separately by CLIENT_IO_TIMEOUT.
+    HEAD_DEADLINE = 30.seconds
+
+    # TCP keepalive so a half-open peer on a RELAXED tunnel is still eventually reaped
+    # (~idle + interval×count ≈ 2 min). Best-effort: the tunables are silently skipped where the
+    # platform doesn't expose them (keepalive itself still enables with the OS default idle).
+    KEEPALIVE_IDLE     = 60 # seconds idle before the first probe
+    KEEPALIVE_INTERVAL = 15 # seconds between probes
+    KEEPALIVE_COUNT    =  4 # unacked probes before the fd errors
+
+    # The underlying Socket for `io`, unwrapping the TLS (OpenSSL::SSL::Socket) and PrefixIO
+    # wrappers the proxy stacks. nil when it can't be resolved (never raises — callers no-op).
+    def self.underlying_socket(io : IO?) : ::Socket?
+      case io
+      when ::Socket
+        io
+      when OpenSSL::SSL::Socket
+        underlying_socket(io.gori_underlying_io)
+      when PrefixIO
+        underlying_socket(io.inner)
+      else
+        nil
+      end
+    end
+
+    # Set the read+write timeout on `io`'s socket. No-op if the socket can't be resolved.
+    def self.arm(io : IO?, timeout : Time::Span) : Nil
+      sock = underlying_socket(io) || return
+      sock.read_timeout = timeout
+      sock.write_timeout = timeout
+    rescue
+      # Setting a timeout must never take down a connection.
+    end
+
+    # Clear the read+write timeout on `io`'s socket, for entering a long-lived tunnel/relay.
+    def self.relax(io : IO?) : Nil
+      sock = underlying_socket(io) || return
+      sock.read_timeout = nil
+      sock.write_timeout = nil
+    rescue
+    end
+
+    # Enable TCP keepalive on a socket (best-effort tunables). Never fails the connection over
+    # an unsupported sockopt — keepalive is a backstop, not a correctness requirement.
+    def self.enable_keepalive(sock : ::Socket) : Nil
+      sock.keepalive = true
+      if sock.is_a?(TCPSocket)
+        sock.tcp_keepalive_idle = KEEPALIVE_IDLE rescue nil
+        sock.tcp_keepalive_interval = KEEPALIVE_INTERVAL rescue nil
+        sock.tcp_keepalive_count = KEEPALIVE_COUNT rescue nil
+      end
+    rescue
+    end
+  end
+end

--- a/src/gori/proxy/tls/tunnel.cr
+++ b/src/gori/proxy/tls/tunnel.cr
@@ -4,6 +4,7 @@ require "../head_rewriter"
 require "../../interceptor"
 require "../conn/client_conn"
 require "../upstream"
+require "../socket_tuning"
 require "../h2/relay"
 require "../../host_overrides"
 require "./cert_authority"
@@ -70,6 +71,10 @@ module Gori::Proxy::Tls
       upstream = Proxy::Upstream.dial_tls(host, port, verify: @verify_upstream, alpn: "h2", overrides: @host_overrides)
       if upstream && upstream.alpn_protocol == "h2"
         upstream.sync = true
+        # Long-lived end-to-end h2 relay: relax both legs so an idle h2 connection isn't reaped
+        # (keepalive on both underlying sockets reaps a dead peer). Resolves through the TLS wrap.
+        Proxy::SocketTuning.relax(client_tls)
+        Proxy::SocketTuning.relax(upstream)
         Proxy::H2::Relay.run(client_tls, upstream, host, port, sink)
       end
     ensure

--- a/src/gori/proxy/upstream.cr
+++ b/src/gori/proxy/upstream.cr
@@ -2,13 +2,14 @@ require "socket"
 require "openssl"
 require "../settings"
 require "../host_overrides"
+require "./socket_tuning"
 
 module Gori::Proxy
-  # Dials origin servers and parses authorities. We open one upstream per flow and
-  # close it after the response (no pooling — correctness first; pooling is a
-  # deferred optimization). When an upstream proxy is configured (Settings), every
-  # dial is tunnelled through it via CONNECT (so both TLS-wrapping and plaintext
-  # forwarding run unchanged over the tunnel).
+  # Dials origin servers and parses authorities. A dialed upstream is reused across a
+  # single client connection's keep-alive requests (see ClientConn#acquire_upstream) and
+  # closed when that connection ends; there is no cross-connection pool. When an upstream
+  # proxy is configured (Settings), every dial is tunnelled through it via CONNECT (so both
+  # TLS-wrapping and plaintext forwarding run unchanged over the tunnel).
   module Upstream
     CONNECT_TIMEOUT = 30.seconds
     IO_TIMEOUT      = 30.seconds
@@ -73,6 +74,9 @@ module Gori::Proxy
         sock.tcp_nodelay = true
         sock.read_timeout = io_timeout
         sock.write_timeout = io_timeout
+        # Keepalive reaps a dead origin on a later relaxed tunnel (WS/SSE/CONNECT/h2 relay),
+        # where the io_timeout above is cleared so a legitimately-idle tunnel survives.
+        SocketTuning.enable_keepalive(sock)
       rescue
         # A peer RST between connect and option-setup would otherwise leak the open fd
         # (the outer rescue returns nil without closing it) — close it first.

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -1503,14 +1503,15 @@ module Gori
                   op.pairs.each do |req, resp|
                     id, _req_fts = insert_one(c, req)
                     has_resp = !resp.nil?
-                    if resp
+                    if r = resp
                       update_one(c, Store::CapturedResponse.new(
-                        flow_id: id, status: resp.not_nil!.status, head: resp.not_nil!.head,
-                        body: resp.not_nil!.body, reason: resp.not_nil!.reason,
-                        content_type: resp.not_nil!.content_type, ttfb_us: resp.not_nil!.ttfb_us,
-                        duration_us: resp.not_nil!.duration_us, state: resp.not_nil!.state,
-                        error: resp.not_nil!.error, body_truncated: resp.not_nil!.body_truncated?,
-                        body_size: resp.not_nil!.body_size))
+                        flow_id: id, status: r.status, head: r.head,
+                        body: r.body, reason: r.reason,
+                        content_type: r.content_type,
+                        content_encoding: r.content_encoding, ttfb_us: r.ttfb_us,
+                        duration_us: r.duration_us, state: r.state,
+                        error: r.error, body_truncated: r.body_truncated?,
+                        body_size: r.body_size))
                     end
                     inserted << {id, has_resp}
                   end
@@ -1714,7 +1715,13 @@ module Gori
       # back from the row on every response; a miss (evicted, an import, or a cross-process
       # write) falls back to that readback. DELETE is a cheap tombstone (contentless_delete=1)
       # and also makes a double update_response idempotent (last write wins).
-      resp_fts = (binary_content?(resp.content_type) || encoded?(head_markers(resp.head)[1])) ? "" : fts_text(resp.body)
+      # Skip the FTS body text for a binary content type or a compressed (non-identity
+      # Content-Encoding) body. Both markers now ride on CapturedResponse (extracted once
+      # by the proxy where the headers are already parsed), so this no longer copies the
+      # raw head into a String + scans it per flow. A body-less response (204/304/redirect)
+      # has no text to index and short-circuits before the marker checks.
+      resp_body = resp.body
+      resp_fts = (resp_body.nil? || resp_body.empty? || binary_content?(resp.content_type) || encoded?(resp.content_encoding)) ? "" : fts_text(resp_body)
       req_fts = @pending_req_fts.delete(resp.flow_id) || request_fts_from_row(conn, resp.flow_id)
       conn.exec("DELETE FROM flows_fts WHERE rowid = ?", resp.flow_id)
       conn.exec("INSERT INTO flows_fts(rowid, req, resp) VALUES (?, ?, ?)", resp.flow_id, req_fts, resp_fts)

--- a/src/gori/store/models.cr
+++ b/src/gori/store/models.cr
@@ -44,6 +44,10 @@ module Gori
       getter status : Int32
       getter reason : String?
       getter content_type : String?
+      # Content-Encoding header value (nil = none/identity). Extracted once by the proxy
+      # where the response headers are already parsed, so the store writer can decide FTS
+      # skipping without re-parsing the raw head per flow.
+      getter content_encoding : String?
       getter head : Bytes
       getter body : Bytes? # captured body, possibly truncated to the capture cap
       getter? body_truncated : Bool
@@ -56,7 +60,7 @@ module Gori
       def initialize(@flow_id, @status, @head, @body = nil, @reason = nil,
                      @content_type = nil, @ttfb_us = nil, @duration_us = nil,
                      @state = FlowState::Complete, @error = nil,
-                     @body_truncated = false, @body_size = nil)
+                     @body_truncated = false, @body_size = nil, @content_encoding = nil)
       end
     end
 


### PR DESCRIPTION
Source-verified performance & stability audit of the proxy/store hot paths. Two independent bundles (some files carry both, so they land in one commit).

## Bundle A — performance hot-path (throughput / GC)
- **Per-connection copy buffer.** `Body.stream`/`copy_n`/`copy_until_eof`/`copy_chunked` take an optional buffer; `ClientConn` owns one lazy `@copy_buf` reused across every request+response body, replacing a **64 KiB large-object allocation per body** on the forwarding fiber. Safe because bodies stream sequentially on one fiber (the same argument `copy_chunked` already used across its chunks).
- **Chunked size-line scratch.** `read_crlf_line` reuses one `IO::Memory` per chunked body instead of an `IO::Memory` + `dup` per size/trailer line (thousands of tiny allocs on long chunked/SSE streams).
- **Drop the per-flow response-head re-parse.** New `CapturedResponse#content_encoding` (extracted once by the proxy where the headers are already parsed) lets `Store#update_one` skip copying + scanning the raw head as a String for every text response on the writer fiber. `content_encoding` is authoritative (nil = none): `FlowMapper`, the h2 assembler, and the import builder all populate it.

## Bundle B — client-side slowloris / RUDY + tunnel-relax + keepalive
- New **`SocketTuning`** helper resolves the underlying socket through the TLS / `PrefixIO` wrappers to `arm`/`relax` read+write timeouts and enable TCP keepalive.
- Client leg now gets a baseline read/write timeout (defeats silent slowloris + RUDY, which it previously had **no** defense against) plus a post-first-byte **head-completion deadline** in `Http1.read_head` — the drip-feed bound a per-read timeout can't provide.
- Both legs **relax** their timeouts at every long-lived seam (WS relay, SSE/close-delimited stream, blind CONNECT, h2c, TLS-MITM h2 relay), so a legitimately idle tunnel isn't torn down. This also fixes the pre-existing bug where the 30 s upstream timeout tore down idle WS/SSE/CONNECT tunnels. Keepalive reaps dead half-open peers; `ClientConn` re-arms per request so a relaxed reuse-pool socket can't carry an untimed state into the next request.

## Reviewer notes
- **content_encoding is authoritative** — a nil-fallback to re-parsing the head would defeat the optimization for the common no-encoding case, so every producer sets it. FTS compressed-skip specs now pass `content_encoding:` (not just put it in the head bytes).
- Relax seams touch the delicate relay/teardown code — the `sync_close: true` SIGSEGV invariant is preserved; the e2e h2/ws/tls relay specs pass unchanged.
- `read_head`'s deadline path is fully gated: with no `deadline`/`timeout_sock` (every caller but the client request-head read) the loop is byte-for-byte the original.

## Verification
- Full codegen build; all 16 touched files format-clean; **ameba: zero new issues** (and removes 11 `not_nil!` by hoisting `if r = resp`).
- New specs: `spec/proxy/socket_tuning_spec.cr` drives real sockets (unwrap / arm / relax / keepalive + live `read_head` deadline & baseline restore); `body_spec` reused-buffer byte-exactness; `fts_spec` content_encoding gate.
- Full suite **green apart from 8 pre-existing failures** (`project_registry`/`capture_status`) that need real port-binding this environment blocks — verified identical on the clean base. The 171 e2e proxy specs (real server + origin + client, incl. the SSE relax seam) all pass.

## Not included (verified, deferred)
Match&Replace unbounded-body OOM cap and the zstd decode-window cap — both low-risk and design-ready; can follow up on request.