### PR TITLE
fix(replay): allow ^R send from the sub-tab strip focus

### DIFF
--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -2387,6 +2387,8 @@ module Gori::Tui
         jump_subtab(c.to_i - 1) # switch + stay on the strip
       when rename_chord?(ev)
         open_rename(current_subtab_index) # rename the active sub-tab (Replay/Fuzzer/Convert/Miner)
+      when @active_tab == :replay && ev.ctrl? && key.lower_r?
+        replay_controller.replay_send # send from the strip too — not just :body focus
       when @active_tab == :replay && !ev.ctrl? && !ev.alt? && key.lower_t?
         open_tag_edit(current_subtab_index) # tag the active Replay sub-tab (issue #121)
       when @active_tab == :replay && !ev.ctrl? && !ev.alt? && c == '/'


### PR DESCRIPTION
## Summary
- Ctrl+R (send replay) only fired when Replay's focus was `:body`; the sub-tab strip's key handler (`handle_subtabs_key`) had no branch for it, so the chord was silently swallowed while focus was on the strip.
- Added a `@active_tab == :replay && ev.ctrl? && key.lower_r?` branch that calls `replay_controller.replay_send`, matching the strip's other Replay-only shortcuts (`t` tag, `/` filter). Plain `r` (rename) is unaffected since `rename_chord?` already excludes ctrl.

## Test plan
- [x] `shards build` succeeds
- [x] Verified live in tmux TUI: created a blank replay (target `https://example.com`), moved focus to the sub-tab strip (confirmed via gold highlight = `:subtabs` focus), pressed Ctrl+R — got a real `200 OK` response back
- [x] Confirmed plain `r` still opens the rename overlay from the strip (no regression)