### PR TITLE
feat(tui): $ENV autocomplete + editor-style Tab in request editors

### DIFF
--- a/spec/tui/text_area_spec.cr
+++ b/spec/tui/text_area_spec.cr
@@ -2,6 +2,10 @@ require "../spec_helper"
 
 include Gori::Tui
 
+private def env_key(k : Termisu::Input::Key)
+  Termisu::Event::Key.new(k)
+end
+
 describe Gori::Tui::TextArea do
   describe "#home / #end_of_line" do
     it "jumps the caret to the start / end of the current line (insert lands there)" do
@@ -74,6 +78,83 @@ describe Gori::Tui::TextArea do
       ta.text.should eq("aX\nb\nc")
       ta.undo              # the X edit -> original
       ta.text.should eq("a\nb\nc")
+    end
+  end
+
+  describe "#env_complete ($ENV autocomplete)" do
+    before_each do
+      Gori::Settings.env_prefix = "$"
+      Gori::Settings.env_vars = [{"HOST", "api.test"}, {"TOKEN", "s3cr3t-value"}, {"TOKEN2", "other"}]
+      Gori::Settings.project_env_vars = [] of {String, String}
+    end
+
+    after_each do
+      Gori::Settings.env_vars = [] of {String, String}
+      Gori::Settings.project_env_vars = [] of {String, String}
+      Gori::Settings.env_prefix = "$"
+    end
+
+    it "stays inert until enabled" do
+      ta = TextArea.new
+      ta.insert('$')
+      ta.env_completing?.should be_false
+    end
+
+    it "opens on a bare prefix and offers every registered var" do
+      ta = TextArea.new
+      ta.env_complete = true
+      ta.insert('$')
+      ta.env_completing?.should be_true
+    end
+
+    it "filters as a partial key is typed and Tab accepts the selected var" do
+      ta = TextArea.new
+      ta.env_complete = true
+      "$TO".each_char { |c| ta.insert(c) } # matches TOKEN + TOKEN2
+      ta.env_completing?.should be_true
+      ta.handle_env_complete_key(env_key(Termisu::Input::Key::Tab)).should be_true
+      ta.text.should eq("$TOKEN") # first match (sorted), whole token rewritten
+      ta.env_completing?.should be_false
+    end
+
+    it "closes once the sole match is fully typed (nothing to complete)" do
+      ta = TextArea.new
+      ta.env_complete = true
+      "$HOST".each_char { |c| ta.insert(c) }
+      ta.env_completing?.should be_false
+    end
+
+    it "does not treat a non-key partial as an env token ($1 is literal)" do
+      ta = TextArea.new
+      ta.env_complete = true
+      "$1".each_char { |c| ta.insert(c) }
+      ta.env_completing?.should be_false
+    end
+
+    it "closes when the caret leaves the token (Home/arrow)" do
+      ta = TextArea.new
+      ta.env_complete = true
+      "$TOK".each_char { |c| ta.insert(c) }
+      ta.env_completing?.should be_true
+      ta.home
+      ta.env_completing?.should be_false
+    end
+
+    it "↓ then Enter accepts the second match" do
+      ta = TextArea.new
+      ta.env_complete = true
+      "$TO".each_char { |c| ta.insert(c) }
+      ta.handle_env_complete_key(env_key(Termisu::Input::Key::Down)).should be_true
+      ta.handle_env_complete_key(env_key(Termisu::Input::Key::Enter)).should be_true
+      ta.text.should eq("$TOKEN2")
+    end
+
+    it "opens nothing when no vars are registered" do
+      Gori::Settings.env_vars = [] of {String, String}
+      ta = TextArea.new
+      ta.env_complete = true
+      ta.insert('$')
+      ta.env_completing?.should be_false
     end
   end
 end

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -560,6 +560,25 @@ module Gori::Tui
         (@host.active_tab == :fuzzer && @host.focus == :body)
     end
 
+    # --- editor $ENV autocomplete + tab-as-text (template pane in insert mode) ---
+    def editor_completing? : Bool
+      current_view.try(&.template_env_completing?) || false
+    end
+
+    def handle_editor_complete_key(ev : Termisu::Event::Key) : Bool
+      current_view.try(&.handle_template_env_complete_key(ev)) || false
+    end
+
+    def editor_captures_tab? : Bool
+      current_view.try(&.template_text_editing?) || false
+    end
+
+    def handle_editor_tab(ev : Termisu::Event::Key) : Bool
+      return false unless editor_captures_tab?
+      current_view.try(&.template_tab_insert)
+      true
+    end
+
     # --- focus ring ---
     def pane_advance(dir : Int32) : Bool
       current_view.try(&.pane_advance(dir)) || false

--- a/src/gori/tui/controllers/replay_controller.cr
+++ b/src/gori/tui/controllers/replay_controller.cr
@@ -713,6 +713,25 @@ module Gori::Tui
       save_current_replay
     end
 
+    # --- editor $ENV autocomplete + tab-as-text (request pane in insert mode) ---
+    def editor_completing? : Bool
+      current_view.try(&.request_env_completing?) || false
+    end
+
+    def handle_editor_complete_key(ev : Termisu::Event::Key) : Bool
+      current_view.try(&.handle_request_env_complete_key(ev)) || false
+    end
+
+    def editor_captures_tab? : Bool
+      current_view.try(&.request_text_editing?) || false
+    end
+
+    def handle_editor_tab(ev : Termisu::Event::Key) : Bool
+      return false unless editor_captures_tab?
+      current_view.try(&.request_tab_insert)
+      true
+    end
+
     # --- focus ring (target ◂▸ request ◂▸ response, within the active sub-tab) ---
     def pane_advance(dir : Int32) : Bool
       current_view.try(&.pane_advance(dir)) || false

--- a/src/gori/tui/env_complete.cr
+++ b/src/gori/tui/env_complete.cr
@@ -1,0 +1,102 @@
+require "./screen"
+require "./theme"
+
+module Gori::Tui
+  # A caret-anchored autocomplete dropdown for `$ENV` variable references typed inside a
+  # text editor (the Replay request, the Fuzzer template, …). The owning TextArea computes
+  # the `$partial` token span under the caret + the matching {key, value} pairs and feeds
+  # them via `set`; this holds only the open/selection/scroll state and the rendering.
+  # Accepting rewrites the `$partial` back to the full `$KEY`. Modelled on ChainComplete,
+  # but anchored at the caret CELL (not a fixed field row) and showing a dim value preview.
+  class EnvComplete
+    getter? open : Bool = false
+    getter selected : Int32 = 0
+    @matches = [] of {String, String} # {key, value-preview}
+    @tok_start = 0                    # FULL-line char offset of the token's prefix sigil
+    @tok_end = 0                      # FULL-line char offset just past the token's key run
+    @prefix = "$"
+    @scroll = 0 # top visible row — keeps the selection on-screen past the fold
+
+    MAX_ROWS = 8
+
+    # Replace the current match set (opens iff non-empty). tok_start/tok_end are the
+    # caret line's char offsets of the `$partial` token; prefix is the active env sigil so
+    # accept can rebuild `prefix + key`.
+    def set(matches : Array({String, String}), tok_start : Int32, tok_end : Int32, prefix : String) : Nil
+      @matches = matches
+      @tok_start = tok_start
+      @tok_end = tok_end
+      @prefix = prefix
+      @selected = 0
+      @scroll = 0
+      @open = !matches.empty?
+    end
+
+    def move(d : Int32) : Nil
+      return if @matches.empty?
+      @selected = (@selected + d).clamp(0, @matches.size - 1)
+    end
+
+    def close : Nil
+      @open = false
+    end
+
+    # Rewrite the `$partial` under the caret in `line` to the selected `prefix + KEY`,
+    # returning {new_line, new_cx}. Identity ({line, cx}) when nothing is selected.
+    def accept(line : String, cx : Int32) : {String, Int32}
+      key = @matches[@selected]?.try(&.[0]) || return {line, cx}
+      repl = "#{@prefix}#{key}"
+      head = line[0...@tok_start.clamp(0, line.size)]
+      tail = line[@tok_end.clamp(0, line.size)..]
+      {"#{head}#{repl}#{tail}", @tok_start + repl.size}
+    end
+
+    # Draw the dropdown anchored at the caret cell (ax, ay). Prefers to open DOWNWARD
+    # (row ay+1); flips ABOVE the caret when there's more room there. Clamped inside
+    # `bounds` (the editor's content rect) so it never paints past the pane.
+    def render(screen : Screen, ax : Int32, ay : Int32, bounds : Rect) : Nil
+      return if !@open || @matches.empty? || bounds.w < 4 || bounds.h < 2
+      down, h = placement(ay, bounds)
+      return if h <= 0
+      w = box_width(bounds)
+      sync_scroll(h)
+      x = ax.clamp(bounds.x, {bounds.right - w, bounds.x}.max)
+      y0 = down ? ay + 1 : ay - h
+      h.times { |i| draw_row(screen, x, y0 + i, w, @scroll + i) }
+    end
+
+    # Whether to open below (vs above) the caret + how many rows fit — the popup grows
+    # into whichever side of the caret has more room within `bounds`.
+    private def placement(ay : Int32, bounds : Rect) : {Bool, Int32}
+      below = bounds.bottom - (ay + 1) # rows available under the caret
+      above = ay - bounds.y            # rows available over the caret
+      down = below >= above
+      {down, {@matches.size, MAX_ROWS, {down ? below : above, 0}.max}.min}
+    end
+
+    # Box width = the widest `$KEY` + its value preview, floored at 14, clamped to bounds.
+    private def box_width(bounds : Rect) : Int32
+      key_w = @matches.max_of { |(k, _)| @prefix.size + k.size }
+      val_w = @matches.max_of { |(_, v)| Screen.display_width(v) }
+      ({key_w + (val_w > 0 ? val_w + 2 : 0) + 2, 14}.max).clamp(1, bounds.w)
+    end
+
+    # Slide the visible window so the selected row is always painted.
+    private def sync_scroll(h : Int32) : Nil
+      @scroll = @selected if @selected < @scroll
+      @scroll = @selected - h + 1 if @selected >= @scroll + h
+      @scroll = @scroll.clamp(0, {@matches.size - h, 0}.max)
+    end
+
+    # One dropdown row: a fill band, a selection bar, the `$KEY`, then the dim value hint.
+    private def draw_row(screen : Screen, x : Int32, y : Int32, w : Int32, idx : Int32) : Nil
+      key, val = @matches[idx]? || return
+      active = idx == @selected
+      bg = active ? Theme.accent_bg : Theme.elevated
+      screen.fill(Rect.new(x, y, w, 1), bg)
+      screen.cell(x, y, active ? '▎' : ' ', Theme.accent, bg)
+      kx = screen.text(x + 1, y, "#{@prefix}#{key}", active ? Theme.text_bright : Theme.env_known, bg, width: {w - 1, 1}.max)
+      screen.text(kx + 1, y, val, Theme.muted, bg, width: {x + w - kx - 1, 0}.max) if kx + 1 < x + w
+    end
+  end
+end

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -72,7 +72,8 @@ module Gori::Tui
       @http2 = false
       @editor = TextArea.new
       @editor.gutter = true
-      @editor.follow_x = true # long lines (headers, URLs, §-marked params) scroll horizontally to keep the cursor visible
+      @editor.follow_x = true     # long lines (headers, URLs, §-marked params) scroll horizontally to keep the cursor visible
+      @editor.env_complete = true # `$KEY` autocomplete against the registered env vars (expanded on send)
       @last_synced_config = "" # last store config blob applied (reconcile equality)
       @config = Fuzz::Config.new(keep_bodies: :matched)
       @sets = [] of SetSpec
@@ -389,6 +390,35 @@ module Gori::Tui
 
     def exit_template_insert! : Nil
       @template_mode = InputMode::Read
+      @editor.env_complete_close # no dangling $ENV dropdown once we leave insert mode
+    end
+
+    # --- $ENV autocomplete in the template editor ---
+    # True while the template is a live text editor (insert mode, not the CHAIN sub-pane) —
+    # the state in which the $ENV dropdown and editor-style Tab apply (controller reads it too).
+    def template_text_editing? : Bool
+      @focus == :template && template_insert? && !chain_pane_active?
+    end
+
+    def template_env_completing? : Bool
+      template_text_editing? && @editor.env_completing?
+    end
+
+    # The popup owns tab/↵/↑/↓/esc while open; accepting edits the buffer → mark dirty.
+    def handle_template_env_complete_key(ev : Termisu::Event::Key) : Bool
+      return false unless template_text_editing?
+      before = @editor.edits
+      handled = @editor.handle_env_complete_key(ev)
+      @dirty = true if handled && @editor.edits != before
+      handled
+    end
+
+    # Editor-style Tab: insert a literal tab into the template (no focus move).
+    def template_tab_insert : Nil
+      return unless template_text_editing?
+      @editor.insert('\t')
+      @editor.set_preedit("")
+      @dirty = true
     end
 
     def detail_navigable? : Bool

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -61,8 +61,9 @@ module Gori::Tui
       @scx = 0             # SNI cursor
       @target_field = :url # which field the TARGET pane edits: :url | :sni
       @editor = TextArea.new
-      @editor.gutter = true   # line numbers in the request body (pairs with ^G)
-      @editor.follow_x = true # long lines (headers, URLs, base64 params) scroll horizontally to keep the cursor visible
+      @editor.gutter = true       # line numbers in the request body (pairs with ^G)
+      @editor.follow_x = true     # long lines (headers, URLs, base64 params) scroll horizontally to keep the cursor visible
+      @editor.env_complete = true # `$KEY` autocomplete against the registered env vars (expanded on send)
       @search_hl = ""         # active ^F query → highlight in the response pane (request is via @editor)
       @reveal = false         # 'w' shows whitespace/CR/LF as glyphs (response from raw bytes, request via @editor)
       @reveal_lines = nil.as(Array(String)?)
@@ -114,9 +115,10 @@ module Gori::Tui
       # Content-Length resynced; otherwise the envelope is sent as captured. Sent as a
       # NORMAL request (ordinary response pane). Session-only (db_id nil) like WS/gRPC.
       @decode_kind = nil.as(Symbol?) # nil | :saml | :graphql
-      @decoded = TextArea.new        # the payload editor (lower split)
+      @decoded = TextArea.new         # the payload editor (lower split)
       @decoded.gutter = true
-      @decoded.follow_x = true # long decoded payload lines (SAML XML, GraphQL query) scroll horizontally
+      @decoded.follow_x = true        # long decoded payload lines (SAML XML, GraphQL query) scroll horizontally
+      @decoded.env_complete = true    # env tokens re-encode into the request on send here too (WS messages, decoded payload)
       @req_pane = :envelope    # :envelope | :decoded — which split sub-pane is active
       @decoded_dirty = false   # the decoded payload was edited → re-encode on send
       @saml_param = "SAMLResponse"
@@ -239,6 +241,37 @@ module Gori::Tui
 
     def exit_request_insert! : Nil
       @request_mode = InputMode::Read
+      req_editor.env_complete_close # no dangling $ENV dropdown once we leave insert mode
+    end
+
+    # --- $ENV autocomplete in the request editor (delegates to the active req editor) ---
+    # True while the request pane is a live text editor (insert mode, not hex) — the state
+    # in which the $ENV dropdown and editor-style Tab apply (read by the controller too).
+    def request_text_editing? : Bool
+      @focus == :request && request_insert? && !request_hex?
+    end
+
+    def request_env_completing? : Bool
+      request_text_editing? && req_editor.env_completing?
+    end
+
+    # The popup owns tab/↵/↑/↓/esc while open; accepting a key edits the buffer, so mirror
+    # the dirty-marking edit_* helpers do. Returns true when the key was consumed.
+    def handle_request_env_complete_key(ev : Termisu::Event::Key) : Bool
+      return false unless request_text_editing?
+      ed = req_editor
+      before = ed.edits
+      handled = ed.handle_env_complete_key(ev)
+      mark_req_edit if handled && ed.edits != before
+      handled
+    end
+
+    # Editor-style Tab: insert a literal tab into the request editor (no focus move).
+    def request_tab_insert : Nil
+      return unless request_text_editing?
+      req_editor.insert('\t')
+      req_editor.set_preedit("") # commit any preedit (termisu dup-guard)
+      mark_req_edit
     end
 
     def enter_target_insert! : Nil

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -733,6 +733,18 @@ module Gori::Tui
       if @active_tab == :convert && @overlay == :none && @focus == :body && convert_controller.completing?
         return if convert_controller.handle_complete_key(ev)
       end
+      # The $ENV autocomplete popup in an editor (Replay request, Fuzzer template) owns
+      # Tab/↵/↑/↓/Esc while open — before the focus ring claims Tab, so Tab accepts the
+      # suggestion. Non-popup keys fall through (return false) so editing + refilter flow on.
+      if @overlay == :none && @focus == :body && (ac = @tabs[@active_tab]?) && ac.editor_completing?
+        return if ac.handle_editor_complete_key(ev)
+      end
+      # Editor-style Tab: while actively typing in a text editor, forward Tab inserts a tab
+      # (or accepts a suggestion) instead of advancing the focus ring. Shift-Tab (back_tab)
+      # is left to the focus ring below, so there's always a keyboard way out of the pane.
+      if @overlay == :none && @focus == :body && ev.key.tab? && (at = @tabs[@active_tab]?) && at.editor_captures_tab?
+        return if at.handle_editor_tab(ev)
+      end
       # Focusable sub-tab strip (Replay/Notes): ←/→ switch sub-tabs, ↓/↵ drop into
       # the editor, ↑/esc pop to the tab bar. Claimed BEFORE the Tab ring + ^N so the
       # strip owns Tab and its own ^N. @focus is only ever :subtabs for Replay/Notes.

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -272,6 +272,30 @@ module Gori::Tui
       nil
     end
 
+    # --- editor autocomplete + tab-as-text (opt-in; default off) -------------
+    # An `$ENV` completion popup is open in the focused editor → it owns Tab/↵/↑/↓/Esc,
+    # claimed BEFORE the global focus ring so Tab accepts the suggestion instead of moving
+    # focus. Return true from handle_editor_complete_key when the key was consumed; false
+    # falls through so normal editing continues and the popup refilters.
+    def editor_completing? : Bool
+      false
+    end
+
+    def handle_editor_complete_key(ev : Termisu::Event::Key) : Bool
+      false
+    end
+
+    # The focused pane is an actively-editing text editor → forward Tab types a tab (real
+    # editor feel) rather than advancing the focus ring. Shift-Tab still steps focus back,
+    # so there is always a keyboard way out of the pane.
+    def editor_captures_tab? : Bool
+      false
+    end
+
+    def handle_editor_tab(ev : Termisu::Event::Key) : Bool
+      false
+    end
+
     # --- focus ring (Tab/Shift-Tab across panes); false = no further pane ---
     def pane_advance(dir : Int32) : Bool
       false

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -2,9 +2,11 @@ require "./screen"
 require "./theme"
 require "./highlight"
 require "../env"
+require "../settings"
 require "./gutter"
 require "./search_hi"
 require "./reveal"
+require "./env_complete"
 
 module Gori::Tui
   # A minimal multi-line text editor for inline editing (e.g. the Replay
@@ -46,6 +48,10 @@ module Gori::Tui
       # widget knows nothing about §-markers; the owner supplies offsets + resolved colours.
       @bg_regions = [] of {Int32, Int32, Color}
       @undo_stack = [] of UndoState
+      # Opt-in `$ENV` autocomplete popup (nil = disabled). Enabled only on the outbound
+      # request editors (Replay request, Fuzzer template) where env tokens are expanded on
+      # send; every other editor keeps it nil so its edit path is byte-for-byte unchanged.
+      @env_complete = nil.as(EnvComplete?)
       set_text(text)
     end
 
@@ -73,6 +79,7 @@ module Gori::Tui
       @styled = nil
       @edits += 1
       @undo_stack.clear
+      env_complete_close
     end
 
     # Preedit/composing text from IME (e.g. current Hangul syllable while typing jamo).
@@ -114,8 +121,9 @@ module Gori::Tui
       @cx = cx + 1
       @styled = nil
       @edits += 1
+      refresh_env_complete
     end
- 
+
     def insert_newline : Nil
       push_undo
       line = @lines[@cy]
@@ -126,8 +134,9 @@ module Gori::Tui
       @cx = 0
       @styled = nil
       @edits += 1
+      refresh_env_complete
     end
- 
+
     def backspace : Nil
       return if @cx == 0 && @cy == 0 # buffer start — nothing to delete, don't dirty (mirrors delete)
       if @cx > 0
@@ -146,16 +155,19 @@ module Gori::Tui
       end
       @styled = nil
       @edits += 1
+      refresh_env_complete
     end
 
     # Home / End: jump the cursor to the start / end of the current line. Pure navigation
     # (no buffer change), so @styled/@edits are untouched — mirrors `move`.
     def home : Nil
       @cx = 0
+      env_complete_close
     end
 
     def end_of_line : Nil
       @cx = @lines[@cy].size
+      env_complete_close
     end
 
     # Forward delete: remove the char under the cursor, or join the next line when at EOL.
@@ -176,6 +188,7 @@ module Gori::Tui
       @cx = cx
       @styled = nil
       @edits += 1
+      refresh_env_complete
     end
 
     def move(dr : Int32, dc : Int32) : Nil
@@ -200,6 +213,7 @@ module Gori::Tui
           @cx = @lines[@cy].size
         end
       end
+      refresh_env_complete
     end
 
     # Cursor is on the first line — the Runner pops focus to the tab bar when ↑
@@ -235,6 +249,7 @@ module Gori::Tui
       # + @xscroll: the click lands at display column (mx - content_x) WITHIN the
       # visible window, which is @xscroll columns into the full line.
       @cx = Screen.column_for(@lines[@cy], mx - (rect.x + gw) + @xscroll)
+      env_complete_close
     end
 
     # Viewport scroll by `step` lines (the mouse wheel), INDEPENDENT of the cursor:
@@ -248,6 +263,7 @@ module Gori::Tui
       @scroll = (@scroll + step).clamp(0, max)
       @cy = @cy.clamp(@scroll, {@scroll + @last_h - 1, @lines.size - 1}.min)
       @cx = @cx.clamp(0, @lines[@cy].size)
+      env_complete_close
     end
 
     # Horizontal viewport nudge (shift+←/→ in READ panes). No-op unless @follow_x.
@@ -261,12 +277,14 @@ module Gori::Tui
     def goto_line(n : Int32) : Nil
       @cy = (n - 1).clamp(0, @lines.size - 1)
       @cx = 0
+      env_complete_close
     end
 
     # Place the caret without pushing undo (read-mode navigation / click-to-cursor).
     def place_cursor(cy : Int32, cx : Int32) : Nil
       @cy = cy.clamp(0, @lines.size - 1)
       @cx = cx.clamp(0, @lines[@cy].size)
+      env_complete_close
     end
 
     def line_count : Int32
@@ -333,6 +351,7 @@ module Gori::Tui
       # Replay/Notes (no regions) skip it so their hot path is unchanged.
       line_off = 0
       (0...@scroll).each { |k| line_off += @lines[k].size + 1 } unless @bg_regions.empty? # +1 for '\n'
+      caret_cell = nil.as({Int32, Int32}?) # the drawn caret's screen cell — anchors the env-complete popup
       (0...rect.h).each do |i|
         li = @scroll + i
         break if li >= @lines.size
@@ -383,6 +402,7 @@ module Gori::Tui
         preedit_w = Screen.display_width(@preedit)
         cxs = cx0 + prefix_w + preedit_w - @xscroll
         if cxs >= cx0 && cxs < cx0 + cw
+          caret_cell = {cxs, rect.y + i}
           screen.cursor(cxs, rect.y + i)
           cgw = [Screen.display_width((@preedit.empty? ? (@cx < line.size ? line[@cx] : ' ') : @preedit[0]).to_s), 1].max
           ch = @preedit.empty? ? (@cx < line.size ? line[@cx] : ' ') : @preedit[0]
@@ -392,6 +412,11 @@ module Gori::Tui
             screen.cell(cxs + off, rect.y + i, cch, Theme.bg, Theme.accent)
           end
         end
+      end
+      # The env-complete dropdown paints LAST (over the text, anchored at the caret) so it
+      # never renders when the caret is off-screen or the editor is unfocused (cursor=false).
+      if cursor && (cc = caret_cell) && (ec = @env_complete)
+        ec.render(screen, cc[0], cc[1], rect)
       end
     end
 
@@ -507,6 +532,105 @@ module Gori::Tui
       @cx = state.cx.clamp(0, @lines[@cy].size)
       @styled = nil
       @edits += 1
+      refresh_env_complete
+    end
+
+    # --- `$ENV` autocomplete (opt-in) ----------------------------------------
+    # Enable/disable the completion popup. Enabled editors get a live dropdown of
+    # matching env vars while a `$partial` token is under the caret; disabled editors
+    # keep @env_complete nil and every edit-path guard below short-circuits.
+    def env_complete=(on : Bool) : Nil
+      @env_complete = on ? (@env_complete || EnvComplete.new) : nil
+    end
+
+    def env_completing? : Bool
+      (ec = @env_complete) ? ec.open? : false
+    end
+
+    def env_complete_close : Nil
+      @env_complete.try(&.close)
+    end
+
+    # While the popup owns the keyboard: Tab/↵ accept, ↑/↓ (+ Shift-Tab) move the
+    # selection, Esc closes. Returns true when consumed (the caller stops routing the key).
+    def handle_env_complete_key(ev : Termisu::Event::Key) : Bool
+      ec = @env_complete
+      return false unless ec && ec.open?
+      key = ev.key
+      case
+      when key.tab?, key.enter?   then env_accept(ec)
+      when key.up?, key.back_tab? then ec.move(-1)
+      when key.down?              then ec.move(1)
+      when key.escape?            then ec.close
+      else                             return false
+      end
+      true
+    end
+
+    private def env_accept(ec : EnvComplete) : Nil
+      push_undo
+      line = @lines[@cy]
+      newline, ncx = ec.accept(line, @cx.clamp(0, line.size))
+      @lines[@cy] = newline
+      @cx = ncx.clamp(0, newline.size)
+      ec.close
+      @styled = nil
+      @edits += 1
+    end
+
+    # Recompute the match set for the `$partial` token the caret sits in — the run of
+    # env-key chars immediately left of the caret, which must be preceded by the prefix
+    # sigil. Closes when there's no token, no registered vars, or the sole match is already
+    # fully typed. Called after every insert-mode edit; a cheap no-op when disabled.
+    private def refresh_env_complete : Nil
+      ec = @env_complete
+      return unless ec
+      prefix = Settings.env_prefix
+      return ec.close if prefix.empty?
+      vars = Env.effective_vars
+      return ec.close if vars.empty?
+      line = @lines[@cy]
+      cx = @cx.clamp(0, line.size)
+      plen = prefix.size
+      ks = cx
+      while ks > 0 && env_key_tail?(line[ks - 1])
+        ks -= 1
+      end
+      # A prefix sigil must sit immediately before the key run (else it isn't an env token).
+      return ec.close unless ks - plen >= 0 && line[(ks - plen)...ks] == prefix
+      partial = line[ks...cx]
+      # A non-empty partial must start with a valid key head — `$1` etc. never expand.
+      return ec.close if !partial.empty? && !env_key_head?(partial[0])
+      # Extend right over the rest of the key run so accepting replaces the whole identifier.
+      ke = cx
+      while ke < line.size && env_key_tail?(line[ke])
+        ke += 1
+      end
+      pl = partial.downcase
+      matches = vars.keys
+        .select { |k| pl.empty? || k.downcase.starts_with?(pl) }
+        .sort!
+        .first(40)
+        .map { |k| {k, env_value_preview(vars[k])} }
+      if matches.empty? || (matches.size == 1 && matches[0][0] == partial)
+        ec.close # nothing to offer, or already fully typed
+      else
+        ec.set(matches, ks - plen, ke, prefix)
+      end
+    end
+
+    private def env_key_head?(c : Char) : Bool
+      c.ascii_letter? || c == '_'
+    end
+
+    private def env_key_tail?(c : Char) : Bool
+      c.ascii_alphanumeric? || c == '_'
+    end
+
+    # A one-line, whitespace-collapsed, length-capped value hint for the dropdown row.
+    private def env_value_preview(v : String) : String
+      s = v.gsub(/\s+/, " ").strip
+      s.size > 20 ? "#{s[0, 19]}…" : s
     end
   end
 end


### PR DESCRIPTION
## What

Two editor-UX improvements for the outbound-request editors (Replay request incl. the decoded/WS split, and the Fuzzer template):

1. **`$ENV` autocomplete** — typing `$` (or `$partial`) pops a caret-anchored dropdown of the registered env vars (key + dim value preview), filtered as you type. `Tab`/`Enter` accepts (rewrites `$partial` → `$KEY`), `↑`/`↓` move, `Esc` closes. It reuses the same env rules as highlighting/expansion, so what you complete is exactly what gets substituted on send.
2. **Editor-style Tab** — while actively typing (insert mode), forward `Tab` no longer jumps pane focus. It accepts the highlighted suggestion if the popup is open, otherwise inserts a literal tab. `Shift-Tab` still steps focus back (escape hatch), and read-mode `Tab` keeps cycling panes.

## How

- New reusable `EnvComplete` dropdown (`src/gori/tui/env_complete.cr`), anchored at the caret cell (flips above/below by available room).
- Opt-in on `TextArea` via `env_complete = true` — nil everywhere else, so every other editor (Notes, Convert, Project desc, Intercept) keeps its hot path and focus-ring Tab unchanged. `TextArea` owns the whole lifecycle: refilters the `$token` under the caret on each insert-mode edit, closes on cursor jumps, renders only when focused.
- `TabController` base gains `editor_completing?` / `handle_editor_complete_key` (popup owns `Tab`/`↵`/`↑`/`↓`/`Esc`) and `editor_captures_tab?` / `handle_editor_tab` (Tab-as-text). The runner routes both **before** the focus ring.
- Replay/Fuzzer views + controllers wire it in, gated on insert mode (not hex / not the CHAIN pane).

Scoped to the two editors where `$ENV` is actually expanded on send; the single-line Target URL field and the Intercept editor use different (non-`TextArea`) widgets and were left out to keep the change tight.

## Testing

- Build clean; full suite **1584 examples, 0 failures**.
- **8 new unit tests** covering open / filter / accept / close / non-key-partial (`$1`) / caret-leaves-token / no-vars.
- **Live TUI (tmux)** in both Replay and Fuzzer: popup appears on `$`, filters `$TO` → `TOKEN`/`TOKEN2`, `↓`+`Tab` accepts `$TOKEN2` and stays in the editor; a bare `Tab` inserts a real tab (confirmed with `^B` reveal showing `→`) without switching panes.
- ameba: new file clean; edited files stay at their pre-existing baseline.