### PR TITLE
fix(tui): Tab types a space in the Host Override / Env entry rows

### DIFF
--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -483,6 +483,9 @@ module Gori::Tui
         @project_view.ov_move_cursor(1)
       elsif key.backspace?
         @project_view.cancel_ov_add unless @project_view.ov_backspace
+      elsif key.tab?
+        @project_view.ov_input(' ') # Tab types the IP/host separator, not a pane jump
+        @project_view.set_preedit("")
       elsif c && !ev.ctrl? && !ev.alt?
         @project_view.ov_input(c)
         @project_view.set_preedit("") # commit any preedit
@@ -584,6 +587,9 @@ module Gori::Tui
         @project_view.env_move_cursor(1)
       elsif key.backspace?
         @project_view.cancel_env_add unless @project_view.env_backspace
+      elsif key.tab?
+        @project_view.env_input(' ') # Tab types the KEY/VALUE separator, not a pane jump
+        @project_view.set_preedit("")
       elsif c && !ev.ctrl? && !ev.alt?
         @project_view.env_input(c)
         @project_view.set_preedit("")

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -2197,6 +2197,9 @@ module Gori::Tui
         @hosts_overlay.move_cursor(1)
       elsif key.backspace?
         @hosts_overlay.cancel_add unless @hosts_overlay.backspace
+      elsif key.tab?
+        @hosts_overlay.input(' ') # Tab types the IP/host separator, not a focus jump
+        @hosts_overlay.set_preedit("")
       elsif c && !ev.ctrl? && !ev.alt?
         @hosts_overlay.input(c)
         @hosts_overlay.set_preedit("")
@@ -2289,6 +2292,9 @@ module Gori::Tui
         @env_overlay.move_cursor(1)
       elsif key.backspace?
         @env_overlay.cancel_add unless @env_overlay.backspace
+      elsif key.tab?
+        @env_overlay.input(' ') # Tab types the KEY/VALUE separator, not a focus jump
+        @env_overlay.set_preedit("")
       elsif c && !ev.ctrl? && !ev.alt?
         @env_overlay.input(c)
         @env_overlay.set_preedit("")


### PR DESCRIPTION
## What

Follow-up to #140. In the inline **Host Override** (\`IP host\`) and **Env** (\`KEY VALUE\`) add/edit rows, the two fields are space-separated — so pressing **Tab** to hop between them is a natural reflex. But Tab there landed a stray focus/pane move (or inserted a literal tab char), an easy way to fumble the entry.

Tab now inserts a **real space** (the field separator) — same as typing space — in all four editors:
- global \`settings:hostnames\` overlay
- global \`settings:env\` overlay
- Project **HOST OVERRIDES** pane
- Project **ENV** pane

This is *not* autocomplete — just making Tab behave like the separator these rows already parse on (\`\s+\`), instead of a pane jump.

## Testing

- Full suite **1584 examples, 0 failures**; no new ameba warnings.
- **Live TUI (tmux)**, all four editors: type IP/KEY → Tab → host/VALUE → Enter commits the entry correctly (e.g. \`10.0.0.1 → example.com\`, \`TOKEN → secret123\`), and focus stays in the editor (no pane jump).