### PR TITLE
fix(docs): footer/sidebar overlap on doc pages

### DIFF
--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -1908,6 +1908,14 @@ nav.pagination a:hover,
   font-size: 0.9rem;
 }
 
+/* Doc pages keep the sidebar fixed for the full viewport height, so the
+   footer (a flow sibling after .docs-container closes) needs its own
+   left offset to clear it — otherwise the two overlap once the page is
+   scrolled to the bottom. */
+.is-doc .docs-footer {
+  padding-left: calc(var(--sidebar-w) + 3rem);
+}
+
 .docs-footer p {
   margin: 0;
 }
@@ -2307,6 +2315,10 @@ nav.pagination a:hover,
   .docs-container {
     display: block;
     padding-left: 0;
+  }
+
+  .is-doc .docs-footer {
+    padding-left: 1.25rem;
   }
 
   .docs-main {


### PR DESCRIPTION
## Summary
- The docs sidebar is `position: fixed` and spans the full viewport height, but the footer (rendered after `.docs-container` closes) had no matching left offset — so on desktop widths its text ran underneath the sidebar once a doc page was scrolled to the bottom.
- Doc pages (`.is-doc`) now offset the footer's left padding by `var(--sidebar-w) + 3rem` to clear the sidebar; this resets to `1.25rem` at the ≤860px breakpoint where the sidebar is hidden. The home page footer (no sidebar) is unaffected.

## Test plan
- [x] Verified via `hwaro serve` + computed styles: doc page footer `padding-left` = 332px (sidebar width + gap) on desktop, 20px on mobile (≤860px) and on the home page.