### PR TITLE
docs: expand installation guide with all distribution channels

### DIFF
--- a/docs/content/getting-started/_index.md
+++ b/docs/content/getting-started/_index.md
@@ -22,6 +22,6 @@ It understands **HTTP/1.1, HTTP/2, WebSocket, gRPC, and Server-Sent Events**, an
 
 ## Next Steps
 
-- [Installation](/getting-started/installation/) — build gori from source
+- [Installation](/getting-started/installation/) — Homebrew, the AUR, Docker, a binary, or from source
 - [Quick Start](/getting-started/quick-start/) — capture, keys, and your first Replay
 - [Configuration](/getting-started/configuration/) — settings, storage, and the CA

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -1,17 +1,101 @@
 +++
 title = "Installation"
-description = "Build gori from source with Crystal."
+description = "Install gori via Homebrew, the AUR, Docker, a pre-built binary, or from source."
 +++
 
-gori is written in [Crystal](https://crystal-lang.org/) and is installed by building from source.
+gori is written in [Crystal](https://crystal-lang.org/). Pick a pre-built channel below, or [build from source](#build-from-source) if none fits your platform. Every channel installs the same `gori` binary — once it's on your `PATH`, jump to [Verify the Installation](#verify-the-installation).
 
-## Prerequisites
+## Homebrew
+
+Works on **macOS** (Apple Silicon & Intel) and **Linux** (x86_64 & arm64):
+
+```bash
+brew install hahwul/gori/gori
+```
+
+That is shorthand for tapping first, which you can also do explicitly:
+
+```bash
+brew tap hahwul/gori
+brew install gori
+```
+
+The macOS bottle is a self-contained tarball with every linked dylib bundled next to the binary, and the Linux bottle is a static build — neither pulls extra Homebrew dependencies.
+
+## Arch Linux (AUR)
+
+A binary package is published to the [AUR](https://aur.archlinux.org/packages/gori) for **x86_64**. Install it with your favorite AUR helper:
+
+```bash
+yay -S gori
+# or
+paru -S gori
+```
+
+## Docker
+
+Multi-arch images (x86_64 & arm64) are published to the GitHub Container Registry as [`ghcr.io/hahwul/gori`](https://github.com/hahwul/gori/pkgs/container/gori).
+
+The TUI needs a terminal, so run it interactively. Mount a volume at `/data` (that's `GORI_HOME` inside the container) so your settings and root CA survive restarts, and bind to `0.0.0.0` so the proxy is reachable from your host:
+
+```bash
+docker run --rm -it \
+  -v gori:/data \
+  -p 8070:8070 \
+  ghcr.io/hahwul/gori --listen 0.0.0.0
+```
+
+> Without a mounted `/data` volume the root CA is regenerated on every run — and must be re-trusted each time. The default bind host is `127.0.0.1`, which is not reachable from outside the container, hence `--listen 0.0.0.0`.
+
+Headless subcommands don't need a TTY:
+
+```bash
+docker run --rm    -v gori:/data ghcr.io/hahwul/gori run history
+docker run --rm -i -v gori:/data ghcr.io/hahwul/gori mcp
+```
+
+## Pre-built Binary
+
+Standalone binaries for macOS and Linux are attached to every [GitHub Release](https://github.com/hahwul/gori/releases/latest).
+
+| Platform | Asset |
+|----------|-------|
+| Linux x86_64 | `gori-v*-linux-x86_64` |
+| Linux arm64 | `gori-v*-linux-arm64` |
+| macOS Apple Silicon | `gori-v*-osx-arm64.tar.gz` |
+| macOS Intel | `gori-v*-osx-x86_64.tar.gz` |
+
+### Linux
+
+The Linux binaries are statically linked (musl) and self-contained. Download one, make it executable, and move it onto your `PATH`:
+
+```bash
+chmod +x gori-v*-linux-x86_64
+sudo mv gori-v*-linux-x86_64 /usr/local/bin/gori
+```
+
+### macOS
+
+The macOS archive is self-contained — it bundles every dependent dylib in a `lib/` folder next to the binary, which resolves them relative to itself. **Keep `gori` and `lib/` together.** Extract it into a stable location and link the binary onto your `PATH`:
+
+```bash
+tar xzf gori-v*-osx-arm64.tar.gz          # extracts `gori` + `lib/`
+sudo mkdir -p /usr/local/opt/gori
+sudo cp -R gori lib /usr/local/opt/gori/
+sudo ln -sf /usr/local/opt/gori/gori /usr/local/bin/gori
+```
+
+> The binaries are ad-hoc signed. If Gatekeeper blocks the download, clear the quarantine flag: `xattr -dr com.apple.quarantine /usr/local/opt/gori`. Installing via [Homebrew](#homebrew) avoids this.
+
+## Build from Source
+
+### Prerequisites
 
 - **Crystal** `>= 1.20.2`
 - **pkg-config**
 - **Git**, to clone the repository
 
-### System libraries (Brotli / Zstd)
+#### System libraries (Brotli / Zstd)
 
 By default gori links against native decoders so it can display HTTP bodies sent with `Content-Encoding: br` (Brotli) and `zstd`. Install them before building:
 
@@ -20,7 +104,7 @@ By default gori links against native decoders so it can display HTTP bodies sent
 | macOS (Homebrew) | `brew install brotli zstd` |
 | Debian / Ubuntu | `sudo apt install libbrotli-dev libzstd-dev` |
 
-## Build from Source
+### Build
 
 ```bash
 git clone https://github.com/hahwul/gori


### PR DESCRIPTION
## What

Rewrites the getting-started **Installation** page from a source-only guide into a full multi-channel one, matching the scope of the [hwaro installation page](https://hwaro.hahwul.com/start/installation/) but scoped to the distribution channels gori actually ships in #114.

## Channels documented

| Channel | Command / asset |
|---|---|
| **Homebrew** (macOS + Linux, both arches) | `brew install hahwul/gori/gori` |
| **Arch Linux (AUR)** (x86_64) | `yay -S gori` |
| **Docker / GHCR** (multi-arch) | `ghcr.io/hahwul/gori` |
| **Pre-built binary** | Linux static musl + macOS bundled-`lib/` tarball |
| **From source** | `shards build --release` (unchanged, now its own section) |

## Notes

- Based on what #114 **actually** provides, not blindly copied from hwaro — gori has no snap/apk/deb/rpm/nix, so those are omitted; gori's Docker image (which hwaro's page doesn't cover) is added.
- Details pulled straight from the pipeline source: exact release asset names, the Docker `/data` volume + `--listen 0.0.0.0` caveats, and the macOS bundled-`lib/` tarball / ad-hoc-signing Gatekeeper `xattr` notes.
- Forward-looking: assumes the first tagged release exists (the binaries/tap/AUR package land once #114 merges and a release is cut).
- Verified with `hwaro build` (17 pages, 0 errors); all in-page anchors resolve.

Depends on #114 for the channels to exist.
