### PR TITLE
feat(tui): editor-style Tab in Convert/Notes/Project-desc/Intercept + fix Intercept preview

### DIFF
--- a/src/gori/tui/controllers/convert_controller.cr
+++ b/src/gori/tui/controllers/convert_controller.cr
@@ -318,6 +318,22 @@ module Gori::Tui
       true
     end
 
+    # Editor-style Tab: while typing in the INPUT editor, forward Tab types a tab rather
+    # than advancing the focus ring (↓ / Shift-Tab still cross to the CHAIN + OUTPUT panes).
+    def editor_captures_tab? : Bool
+      s = cur
+      s.pane == :input && s.input_mode == InputMode::Insert
+    end
+
+    def handle_editor_tab(ev : Termisu::Event::Key) : Bool
+      return false unless editor_captures_tab?
+      s = cur
+      s.input.insert('\t')
+      s.input.set_preedit("")
+      touch
+      true
+    end
+
     # --- focus ring (Tab/Shift-Tab): menu ▸ input ▸ chain ▸ output ▸ menu ---
     # OUTPUT is read-only but joins the ring so it can be focused + scrolled.
     PANE_ORDER = [:input, :chain, :output]
@@ -354,7 +370,7 @@ module Gori::Tui
         "↑/↓ move · ⇧arrows select · y copy · ⇧←/→ h-scroll · ↑-top chain · space cmds · ^X mode · ^Y copy all · esc tabs"
       when :input
         if s.input_mode == InputMode::Insert
-          "type to edit · esc read · ↓/↹ chain · ^L clear · ^X mode · ^N new · ^W close · ↑ sub-tabs"
+          "type to edit · esc read · ↓ chain · ^L clear · ^X mode · ^N new · ^W close · ↑ sub-tabs"
         else
           "i/↵ edit · ⇧arrows select · y copy · space cmds · ↓/↹ chain · ^X mode · ^N new · esc tabs"
         end

--- a/src/gori/tui/controllers/intercept_controller.cr
+++ b/src/gori/tui/controllers/intercept_controller.cr
@@ -229,6 +229,18 @@ module Gori::Tui
       @intercept.reload(@host.session.interceptor)
     end
 
+    # Editor-style Tab: in the held-message editor, forward Tab types a tab rather than
+    # advancing the focus ring (Shift-Tab / esc still leave for the queue).
+    def editor_captures_tab? : Bool
+      @intercept.editing?
+    end
+
+    def handle_editor_tab(ev : Termisu::Event::Key) : Bool
+      return false unless @intercept.editing?
+      @intercept.edit_insert('\t')
+      true
+    end
+
     # --- focus ring (list ◂▸ detail editor) ---
     def pane_advance(dir : Int32) : Bool
       @intercept.pane_advance(dir)

--- a/src/gori/tui/controllers/notes_controller.cr
+++ b/src/gori/tui/controllers/notes_controller.cr
@@ -162,6 +162,19 @@ module Gori::Tui
       true
     end
 
+    # Editor-style Tab: while typing a note, forward Tab types a tab, not a focus jump to
+    # the sub-tab strip / tab bar (esc or ↑-at-top still leave; Shift-Tab steps focus back).
+    def editor_captures_tab? : Bool
+      @notes.insert_mode?
+    end
+
+    def handle_editor_tab(ev : Termisu::Event::Key) : Bool
+      return false unless @notes.insert_mode?
+      @notes.insert('\t')
+      @notes.set_preedit("")
+      true
+    end
+
     def notes_read_mode? : Bool
       !@notes.insert_mode?
     end

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -171,6 +171,19 @@ module Gori::Tui
       @project_view.desc_clear_selection
     end
 
+    # Editor-style Tab: while typing the DESCRIPTION, forward Tab types a tab rather than
+    # advancing the focus ring (esc / arrows at the edges still cross to the other panes).
+    def editor_captures_tab? : Bool
+      @project_view.pane == :desc && @project_view.desc_insert_mode?
+    end
+
+    def handle_editor_tab(ev : Termisu::Event::Key) : Bool
+      return false unless editor_captures_tab?
+      @project_view.insert('\t')
+      @project_view.set_preedit("")
+      true
+    end
+
     # --- focus ring (SCOPE ◂▸ HOST OVERRIDES ◂▸ DESCRIPTION ◂▸ PROJECT SETTINGS) ---
     def pane_advance(dir : Int32) : Bool
       # Tab-ing off the settings pane applies its pending network edit before the pane changes.

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -45,13 +45,16 @@ module Gori::Tui
       @preedit = ""
       @loaded_id = nil.as(Int64?) # which item the editor currently holds
       @editor_dirty = false       # whether the held bytes were actually edited (vs just viewed)
-      # Cached highlight of the selected held item's raw bytes (read-only detail
-      # pane). Held bytes are immutable and item ids are monotonic, so the id is a
-      # perfect cache key — recomputed only when the selection changes, not on
-      # every render (a held body was re-tokenised on each repaint).
+      # Cached highlight of the selected held item's bytes (read-only detail pane).
+      # Held bytes are immutable, so the item id + theme is the base cache key —
+      # recomputed only when the selection/theme changes, not every render. The loaded
+      # item's IN-PROGRESS edit is the exception: its preview must show the edited bytes
+      # (not the original), so @detail_win_edit_rev folds the editor's change counter into
+      # the key and the preview refreshes as those bytes change (same item id).
       @detail_win = nil.as(Highlight::Windowed?)
       @detail_win_id = nil.as(Int64?)
       @detail_win_rev = Theme.revision # the theme the cached (colour-baked) head was built under
+      @detail_win_edit_rev = -1        # @editor.edits the preview was built at (-1 = built from the pristine held bytes)
       @detail_xscroll = 0              # horizontal scroll offset for the read-only held-item preview
       @detail_scroll = 0               # vertical scroll offset (lines) for the read-only preview
     end
@@ -529,15 +532,23 @@ module Gori::Tui
     # and styled per visible line — a multi-MiB held body no longer freezes the UI
     # fiber on selection (mirrors the History/Replay windowing).
     private def detail_window_for(it : Interceptor::Item) : Highlight::Windowed
+      # When this is the item loaded in the editor AND it was modified, preview the EDITED
+      # bytes (mirrors forward_bytes / effective_method_target) rather than the pristine
+      # held bytes — so leaving the editor for the QUEUE doesn't snap the body back to the
+      # original. edit_rev keys the cache on the editor's change counter for that case.
+      edited = @loaded_id == it.id && @editor_dirty
+      edit_rev = edited ? @editor.edits : -1
       cached = @detail_win
-      return cached if cached && @detail_win_id == it.id && @detail_win_rev == Theme.revision
+      return cached if cached && @detail_win_id == it.id && @detail_win_rev == Theme.revision && @detail_win_edit_rev == edit_rev
       if @detail_win_id != it.id # a newly-previewed item resets both scroll axes
         @detail_xscroll = 0
         @detail_scroll = 0
       end
       @detail_win_id = it.id
       @detail_win_rev = Theme.revision
-      @detail_win = Highlight.from_lines_windowed(String.new(it.raw).split('\n').map(&.rstrip('\r')), it.kind.request?)
+      @detail_win_edit_rev = edit_rev
+      lines = edited ? @editor.lines_snapshot : String.new(it.raw).split('\n').map(&.rstrip('\r'))
+      @detail_win = Highlight.from_lines_windowed(lines, it.kind.request?)
     end
 
     private def ensure_visible(h : Int32) : Nil


### PR DESCRIPTION
## What

Two changes to the remaining held/scratch editors.

### 1. Editor-style Tab (insert-mode)
Extends the Replay/Fuzzer "Tab types a tab" behaviour to every other text editor:
- **Convert** INPUT pane
- **Notes**
- **Project → DESCRIPTION**
- **Intercept** held-message editor

While actively typing, forward **Tab** inserts a tab instead of advancing the pane focus ring. `Shift-Tab` / `esc` / edge arrows still move between panes, so there's always a way out. Implemented via the existing `TabController#editor_captures_tab?` / `#handle_editor_tab` hooks (gated on each editor's insert/edit state), which the runner already routes before the focus ring. Updated the Convert insert hint (`↓/↹ chain` → `↓ chain`).

### 2. Fix: Intercept preview reverted to the original body after an edit
After editing a held message, focusing the **QUEUE** snapped the read-only detail preview back to the *original* bytes. `detail_window_for` now previews the **edited** editor bytes when the loaded item is dirty (mirroring `forward_bytes` / `effective_method_target`), with the editor's change counter folded into the window cache key so the preview refreshes as you edit.

## Notes
- A literal tab renders as a visible space in the plain editors (Notes, Convert input) and invisibly in the syntax-highlighted ones (Project desc, Intercept, like Replay/Fuzzer) — a pre-existing shared `Highlight` behaviour, unchanged here.

## Testing
- Full suite **1584 examples, 0 failures**; no new ameba warnings.
- **Live TUI (tmux)**: verified Tab stays in the editor (no pane jump) and inserts a tab in all four editors; verified the Intercept preview now shows the edited body after Shift-Tab to the QUEUE.