### PR TITLE
fix(tui): Comparer REQ/RES chip click was one column off

### DIFF
--- a/spec/tui/comparer_view_spec.cr
+++ b/spec/tui/comparer_view_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "../support/memory_backend"
 require "../../src/gori/tui/comparer_view"
 
 include Gori::Tui
@@ -47,5 +48,34 @@ describe ComparerView do
     v.name.should be_nil
     v.both_set?.should be_false
     v.label.should eq("empty")
+  end
+
+  # Regression: the REQ/RES divider chips were hit-tested one column off the cells
+  # they were drawn on — the RES chip's left edge was a dead click and a phantom
+  # clickable column sat one past it. render + pane_chip_at now share one geometry
+  # helper, so every drawn chip column maps back to its pane.
+  it "pane_chip_at lands on exactly the drawn REQ/RES chip columns" do
+    w, h = 80, 20
+    backend = MemoryBackend.new(w, h)
+    rect = Rect.new(0, 0, w, h)
+    v = ComparerView.new
+    v.render(Screen.new(backend), rect, focused: true)
+
+    divider_y = rect.y + 1
+    row = backend.row(divider_y)
+    req = row.index("REQ").not_nil!
+    res = row.index("RES").not_nil!
+
+    # " REQ " / " RES " each span one leading + 3 letters + one trailing column.
+    (req - 1..req + 3).each do |c|
+      v.pane_chip_at(rect, c, divider_y).should eq(:request)
+    end
+    (res - 1..res + 3).each do |c|
+      v.pane_chip_at(rect, c, divider_y).should eq(:response)
+    end
+    # No phantom hit one column past the RES chip.
+    v.pane_chip_at(rect, res + 4, divider_y).should be_nil
+    # Wrong row never hits.
+    v.pane_chip_at(rect, req, divider_y + 1).should be_nil
   end
 end

--- a/src/gori/tui/comparer_view.cr
+++ b/src/gori/tui/comparer_view.cr
@@ -140,11 +140,9 @@ module Gori::Tui
     # Hit-test the REQ / RES chips on the divider row (render_pane_selector geometry).
     def pane_chip_at(rect : Rect, mx : Int32, my : Int32) : Symbol?
       return nil if rect.h <= 2 || my != rect.y + 1
-      hint = "←/→ "
-      total = Screen.display_width(hint) + 10 # " REQ " + " RES "
-      sx = rect.right - total - 1
-      return nil if sx <= rect.x + 1
-      start = sx + Screen.display_width(hint)
+      geom = pane_selector_geom(rect)
+      return nil unless geom
+      _, start = geom
       Frame.left_chip_hit(mx, my, rect.y + 1, start, [
         {:request, " REQ "},
         {:response, " RES "},
@@ -245,13 +243,25 @@ module Gori::Tui
     # half of the two flows is diffed; the active side is lit, the other muted — so the
     # mode + its keys ride the chrome instead of only the footer prose.
     private def render_pane_selector(screen : Screen, rect : Rect) : Nil
-      hint = "←/→ "
-      total = Screen.display_width(hint) + 10 # " REQ " + " RES "
-      sx = rect.right - total - 1
-      return if sx <= rect.x + 1
-      x = screen.text(sx, rect.y + 1, hint, Theme.muted, Theme.bg)
-      x = Frame.chip(screen, x, rect.y + 1, " REQ ", @pane == :request)
+      geom = pane_selector_geom(rect)
+      return unless geom
+      sx, _ = geom
+      x = screen.text(sx, rect.y + 1, "←/→ ", Theme.muted, Theme.bg)
+      # `+ 1` after each chip matches Frame.left_chip_hit's 1-col gap contract (as
+      # Replay/History/Intercept do) so pane_chip_at lands on the drawn cells.
+      x = Frame.chip(screen, x, rect.y + 1, " REQ ", @pane == :request) + 1
       Frame.chip(screen, x, rect.y + 1, " RES ", @pane == :response)
+    end
+
+    # Divider-row geometry of the REQ/RES selector, shared by render + hit-test so the
+    # two can't drift (they did — the RES chip's click zone was one column off). Returns
+    # {hint x, first chip x}, or nil when the frame is too narrow for the selector.
+    private def pane_selector_geom(rect : Rect) : {Int32, Int32}?
+      hint_w = Screen.display_width("←/→ ")
+      total = hint_w + 11 # " REQ " + 1-col gap + " RES "
+      sx = rect.right - total - 1
+      return nil if sx <= rect.x + 1
+      {sx, sx + hint_w}
     end
 
     private def header_label(tag : String, d : Store::FlowDetail?) : String


### PR DESCRIPTION
## What

Testing the Comparer with various content surfaced a mouse hit-test bug on the divider-row **REQ/RES** pane selector (which switches between diffing the two requests vs. the two responses).

## The bug

`render_pane_selector` drew the two chips **adjacent** (no gap), but the click hit-test `pane_chip_at` → `Frame.left_chip_hit` assumes the **1-column gap** that every other chip caller honors (`replay_view`, `history_view`, `intercept_view`, `traffic_empty_state` all do `Frame.chip(...) + 1`). So the RES chip's clickable zone was shifted one column right of where it was drawn:

- Clicking the **left edge of the RES chip** did nothing (dead zone).
- A **phantom clickable column** sat one cell to the right of the visible chip.

Root cause: the selector geometry was **duplicated** across the render and hit-test methods and had drifted.

## The fix

- Extract one shared `pane_selector_geom` helper that both render and hit-test derive from, so they can't drift again.
- Add the standard `+ 1` chip gap in render to match `Frame.left_chip_hit`'s contract (and the visual spacing of Replay's chip runs).

After the fix, every drawn column of both chips maps back to the correct pane — no dead zone, no phantom column.

## Verification

- New render + hit-test round-trip regression spec in `comparer_view_spec.cr`.
- Full project compiles; all **600 TUI specs pass**.