### PR TITLE
Fix History/Sitemap request-inspection bugs

### DIFF
--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -264,7 +264,7 @@ describe Gori::Tui::HistoryView do
       view = HistoryView.new
       view.reload(store)
       view.open_detail(store).should be_true
-      view.toggle_pane # request -> response
+      view.toggle_pane                                # request -> response
       line3 = view.detail_search_lines("LINE3").first # 0-based row of the body's 3rd line
 
       view.goto_detail_line(line3 + 1) # 1-based
@@ -630,6 +630,116 @@ describe Gori::Tui::HistoryView do
       backend.contains?("127.0.0.1:8070").should be_true
       backend.contains?("Open browser").should be_true
       backend.contains?("FLOW LOG").should be_true
+    end
+  end
+
+  it "does not fall back to the 101 handshake bytes for hex/reveal on the WS MESSAGES pane" do
+    tmp_store do |store|
+      id = add_flow(store, "GET", "/ws", 101) # response head = the 101 handshake
+      store.insert_ws_message(id, "out", 1, "hello".to_slice)
+      store.insert_ws_message(id, "in", 1, "world".to_slice)
+
+      view = HistoryView.new
+      view.reload(store)
+      view.open_detail(store).should be_true
+      view.toggle_pane # request -> response (= MESSAGES for a WS flow)
+
+      # x (hex) must be a no-op on a synthetic transcript — never a hex dump of the
+      # bare "HTTP/1.1 101" handshake (whose bytes hold neither "hello" nor "world").
+      view.toggle_detail_hex
+      hexb = MemoryBackend.new(80, 12)
+      view.render_detail(Screen.new(hexb), Rect.new(0, 0, 80, 12))
+      hexb.contains?("hello").should be_true
+      hexb.contains?("world").should be_true
+
+      # w (reveal) likewise stays on the message log, not the handshake.
+      view.toggle_detail_hex # back to text
+      view.reveal = true
+      wsb = MemoryBackend.new(80, 12)
+      view.render_detail(Screen.new(wsb), Rect.new(0, 0, 80, 12))
+      wsb.contains?("hello").should be_true
+      wsb.contains?("world").should be_true
+    end
+  end
+
+  it "gates reveal-whitespace on a gRPC body (keeps the framed view, avoids raw-protobuf desync)" do
+    tmp_store do |store|
+      id = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "https", host: "grpc.test", port: 443,
+        method: "POST", target: "/svc/Method", http_version: "HTTP/2",
+        head: "POST /svc/Method HTTP/2\r\ncontent-type: application/grpc\r\n\r\n".to_slice, body: nil))
+      gbody = IO::Memory.new
+      gbody.write(Bytes[0x00, 0x00, 0x00, 0x00, 0x02]) # flag 0 + len 2
+      gbody << "hi"
+      store.update_response(Gori::Store::CapturedResponse.new(
+        flow_id: id, status: 200,
+        head: "HTTP/2 200\r\ncontent-type: application/grpc\r\n\r\n".to_slice, body: gbody.to_slice))
+
+      view = HistoryView.new
+      view.reload(store)
+      view.open_detail(store).should be_true
+      view.toggle_pane # request -> response (gRPC body)
+
+      view.reveal = true # 'w' — must NOT swap the framed view for reveal-glyphed protobuf
+      backend = MemoryBackend.new(100, 14)
+      view.render_detail(Screen.new(backend), Rect.new(0, 0, 100, 14))
+      backend.contains?("message #1").should be_true # still the framed view
+    end
+  end
+
+  it "keeps the newest capture visible after a live insert while not following" do
+    tmp_store do |store|
+      add_flow(store, "GET", "/A", 200)
+      add_flow(store, "GET", "/B", 200)
+      view = HistoryView.new
+      view.reload(store) # newest-first [B, A], following (top)
+      view.select_row(1) # click the older row A → follow off, scroll 0
+      view.follow?.should be_false
+
+      cid = add_flow(store, "GET", "/C", 200)
+      view.on_event(Gori::Store::FlowEvent.new(cid, :inserted), store) # [C,B,A]; @scroll bumped to 1
+
+      backend = MemoryBackend.new(80, 30) # ample room for all 3 rows
+      view.render_list(Screen.new(backend), Rect.new(0, 0, 80, 30))
+      body = (0...30).map { |y| backend.row(y) }.join("\n")
+      body.should contain("/C") # newest row must not be stranded above the top
+      body.should contain("/A")
+    end
+  end
+
+  it "rejects an all-invalid QL query instead of matching every flow" do
+    tmp_store do |store|
+      3.times { |i| add_flow(store, "GET", "/#{i}", 200) }
+      view = HistoryView.new
+      view.reload(store)
+      view.rows.size.should eq(3)
+
+      view.start_query
+      "dur:>2sec".each_char { |c| view.query_insert(c) } # every term invalid → compiles to match-all EMPTY
+      view.reload(store)
+      view.rows.empty?.should be_true # must NOT show all flows behind an "active" filter
+
+      backend = MemoryBackend.new(80, 12)
+      view.render_list(Screen.new(backend), Rect.new(0, 0, 80, 12))
+      rows = (0...12).map { |y| backend.row(y) }.join("\n")
+      rows.should contain("invalid filter")
+    end
+  end
+
+  it "flags an invalid regex filter term in the empty-state (not a bare no-match)" do
+    tmp_store do |store|
+      add_flow(store, "GET", "/a", 200)
+      view = HistoryView.new
+      view.reload(store)
+      view.start_query
+      "body~[bad".each_char { |c| view.query_insert(c) } # unterminated class → never-match "0"
+      view.reload(store)
+      view.rows.empty?.should be_true
+
+      backend = MemoryBackend.new(80, 12)
+      view.render_list(Screen.new(backend), Rect.new(0, 0, 80, 12))
+      rows = (0...12).map { |y| backend.row(y) }.join("\n")
+      rows.should contain("invalid regex")
     end
   end
 

--- a/spec/tui/read_cursor_spec.cr
+++ b/spec/tui/read_cursor_spec.cr
@@ -1,0 +1,62 @@
+require "../spec_helper"
+
+include Gori::Tui
+
+# Regression coverage for ReadCursor's multi-line selection math. The read-only
+# panes (History detail, Replay/Fuzzer response, Notes, Convert) all share this,
+# so a wrongly-assigned boundary column corrupts copied text everywhere at once —
+# and, for an upward selection over a short top line, used to crash on copy.
+describe Gori::Tui::ReadCursor do
+  lines = ["short", "a much longer line here", "another line"]
+
+  describe "#selection_text over multiple lines" do
+    it "copies an UPWARD selection without crashing when the top line is short" do
+      rc = ReadCursor.new
+      rc.sync(1, 20)                         # caret on the long line, col 20 (like a click)
+      rc.move(-1, 0, lines, selecting: true) # Shift+Up → caret to line 0 (len 5), anchor stays (1,20)
+      # Previously: line0[20..] → IndexError (20 > 5). Must not raise.
+      txt = rc.selection_text(lines)
+      txt.should_not be_nil
+    end
+
+    it "copies a downward selection from the anchor column to the caret column" do
+      down = ReadCursor.new
+      down.sync(0, 2)                         # anchor at col 2 of the short top line
+      down.move(1, 0, lines, selecting: true) # Shift+Down → caret (1, EOL)
+      # Top line from col 2 to end, then the whole bottom line (caret parked at EOL).
+      down.selection_text(lines).should eq("#{lines[0][2..]}\n#{lines[1]}")
+    end
+
+    it "applies the CARET column to the top line for an upward selection (not the anchor's)" do
+      up = ReadCursor.new
+      up.sync(1, 3)                          # click at col 3 of the long middle line
+      up.move(-1, 0, lines, selecting: true) # Shift+Up → caret (0, EOL of the short line)
+      # Document order top→bottom is (0, EOL0) → (1, 3): the top line contributes nothing
+      # (caret at its EOL), the bottom line runs from col 0 to the anchor's col 3.
+      # The pre-fix code applied the anchor col (3) to line 0 and the caret col to line 1,
+      # copying "rt\na m" instead.
+      up.selection_text(lines).should eq("\n#{lines[1][0...3]}")
+    end
+
+    it "copies a clean full-line multi-line selection as whole lines" do
+      rc = ReadCursor.new
+      rc.sync(0, 0)                         # start at col 0
+      rc.move(1, 0, lines, selecting: true) # Shift+Down → (1, EOL)
+      rc.selection_text(lines).should eq("#{lines[0]}\n#{lines[1]}")
+    end
+  end
+
+  describe "#highlight_spans" do
+    it "paints the correct top-line span for an upward selection (no negative/oversized span)" do
+      rc = ReadCursor.new
+      rc.sync(1, 4)
+      rc.move(-1, 0, lines, selecting: true) # caret → line 0 (len 5), anchor (1,4)
+      spans = rc.highlight_spans(lines)
+      spans.each do |(li, x0, x1)|
+        x0.should be >= 0
+        x1.should be <= lines[li].size
+        x0.should be < x1
+      end
+    end
+  end
+end

--- a/spec/tui/sitemap_view_spec.cr
+++ b/spec/tui/sitemap_view_spec.cr
@@ -106,6 +106,63 @@ describe Gori::Tui::SitemapView do
     end
   end
 
+  it "rejects an all-invalid QL query instead of showing the whole tree" do
+    tmp_store do |store|
+      capture(store, "api.acme.test", "GET", "/v1/users")
+      capture(store, "cdn.acme.test", "GET", "/assets/app.js")
+
+      view = SitemapView.new
+      view.reload(store)
+      view.start_query
+      "dur:>2sec".each_char { |c| view.query_insert(c) } # every term invalid → match-all EMPTY
+      view.reload(store)
+
+      b = MemoryBackend.new(70, 20)
+      view.render(Screen.new(b), Rect.new(0, 0, 70, 20))
+      b.contains?("api.acme.test").should be_false # must NOT show the whole tree behind an "active" filter
+      b.contains?("cdn.acme.test").should be_false
+      rows = (0...20).map { |y| b.row(y) }.join("\n")
+      rows.should contain("invalid filter")
+    end
+  end
+
+  it "does NOT reject a tag:-only query (its QL residual is blank)" do
+    tmp_store do |store|
+      capture(store, "acme.test", "GET", "/api/users")
+      capture(store, "acme.test", "GET", "/static/app.js")
+      store.set_sitemap_tag("acme.test", "/api", "payment")
+
+      view = SitemapView.new
+      view.reload(store)
+      view.start_query
+      "tag:pay".each_char { |c| view.query_insert(c) } # residual "" → EMPTY, but valid (tag filter)
+      view.reload(store)
+
+      b = MemoryBackend.new(70, 20)
+      view.render(Screen.new(b), Rect.new(0, 0, 70, 20))
+      b.contains?("acme.test").should be_true # the tag filter applies; NOT rejected as invalid
+      b.contains?("users").should be_true
+      rows = (0...20).map { |y| b.row(y) }.join("\n")
+      rows.should_not contain("invalid filter")
+    end
+  end
+
+  it "flags an invalid regex filter term in the empty-state" do
+    tmp_store do |store|
+      capture(store, "acme.test", "GET", "/")
+      view = SitemapView.new
+      view.reload(store)
+      view.start_query
+      "path~[bad".each_char { |c| view.query_insert(c) } # unterminated class → never-match "0"
+      view.reload(store)
+
+      b = MemoryBackend.new(70, 20)
+      view.render(Screen.new(b), Rect.new(0, 0, 70, 20))
+      rows = (0...20).map { |y| b.row(y) }.join("\n")
+      rows.should contain("invalid regex")
+    end
+  end
+
   it "renders the filter bar: scope chip + hint, then the filter prompt" do
     tmp_store do |store|
       capture(store, "acme.test", "GET", "/")

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -60,6 +60,7 @@ module Gori::Tui
       @qcx = 0
       @preedit = ""
       @querying = false
+      @query_note = nil.as(String?) # why an active filter is empty when it's INVALID (not just no-match)
       @scope = nil.as(Scope?)
       @detail = nil.as(Store::FlowDetail?)
       @detail_ws = nil.as(Array(Store::WsMessage)?)
@@ -203,7 +204,21 @@ module Gori::Tui
     # newest-first (ORDER BY id DESC); reverse when the layout pref is oldest-first.
     def reload(store : Store) : Nil
       prev_id = @rows[@selected]?.try(&.id) # anchor the highlight to the flow, not the index
-      combined = QL.and(@scope.try(&.filter) || QL::EMPTY, QL.parse(@query))
+      query_filter = QL.parse(@query)
+      @query_note = query_note_for(query_filter)
+      # A non-blank query that compiles to EMPTY (every term invalid — a typo'd field,
+      # a bad numeric like dur:>2sec, an unterminated value) must NOT fall through to a
+      # match-all search: that would show EVERY flow while the bar claims a filter is
+      # active — the opposite of the ask, and dangerous on a security proxy. Reject it
+      # (empty list + a note), mirroring the MCP/CLI surfaces which both reject_empty?.
+      if QL.reject_empty?(@query, query_filter)
+        @rows = [] of Store::FlowRow
+        @filter_dirty = false
+        @selected = 0
+        @scroll = 0
+        return
+      end
+      combined = QL.and(@scope.try(&.filter) || QL::EMPTY, query_filter)
       @rows = store.search(combined, PAGE)
       @rows.reverse! unless newest_first?
       @filter_dirty = false
@@ -215,6 +230,16 @@ module Gori::Tui
         else
           @selected.clamp(0, {@rows.size - 1, 0}.max)
         end
+    end
+
+    # A short note explaining a filter that matches nothing because it is INVALID (vs a
+    # valid filter that genuinely has no matches) — surfaced in the empty-state hint so a
+    # typo'd status:/dur:/size: or a broken body~[regex isn't misread as "no traffic".
+    private def query_note_for(filter : QL::Filter) : String?
+      return nil if @query.blank?
+      return "invalid filter — no valid terms" if QL.reject_empty?(@query, filter)
+      bad = QL.invalid_regex_terms(@query)
+      bad.empty? ? nil : "invalid regex in #{bad.first}"
     end
 
     # settings:layout History list order — newest first (default) or oldest first.
@@ -525,12 +550,22 @@ module Gori::Tui
     end
 
     # The synthetic log panes (FRAMES / EVENTS) and the decoded-protocol panes render
-    # as text and have no raw-byte hex view, unlike REQUEST/RESPONSE.
+    # as text and have no raw-byte hex view, unlike REQUEST/RESPONSE. The WebSocket
+    # MESSAGES pane reuses the :response slot but is also a synthetic transcript (its
+    # bytes live in the ws_messages table, NOT response_body), so it belongs here too —
+    # otherwise x/w would fall back to hex/reveal of the bare 101 handshake head.
     private def log_pane? : Bool
+      return true if ws_messages_pane?
       case @detail_pane
       when :frames, :events, :saml, :jwt, :graphql, :params then true
       else                                                       false
       end
+    end
+
+    # The :response pane renders the WebSocket message transcript (not the handshake
+    # bytes) for a 101 flow — a synthetic log with no raw-byte hex/reveal view.
+    private def ws_messages_pane? : Bool
+      @detail_pane == :response && !@detail_ws.nil?
     end
 
     # 'x' toggles a raw hex dump of the current pane (request/response bytes).
@@ -815,9 +850,9 @@ module Gori::Tui
       detail = @detail
       return nil unless detail
       head, body = case @detail_pane
-                   when :response then {detail.response_head, detail.response_body}
+                   when :response then ws_messages_pane? ? {nil, nil} : {detail.response_head, detail.response_body}
                    when :request  then {detail.request_head, detail.request_body}
-                   else                {nil, nil} # frames: no raw-bytes hex
+                   else                {nil, nil} # frames/messages: no raw-bytes hex
                    end
       @detail_hex_bytes = combine_bytes(head, body)
     end
@@ -969,7 +1004,9 @@ module Gori::Tui
         # would mislead (⇧S clears the lens). Mirrors sitemap_view's ordering.
         msg, hint =
           if !@query.blank?
-            {"no flows match", @querying ? "esc clears the filter" : "/ to edit the filter"}
+            # An INVALID query (all terms bad, or a broken regex) reads as "no flows match"
+            # unless we say why — @query_note distinguishes it from a genuine empty result.
+            {@query_note || "no flows match", @querying ? "esc clears the filter" : "/ to edit the filter"}
           elsif filtering? # in-scope subset is empty (Scope lens, no QL query)
             {"no flows in scope", "⇧S clears the scope lens"}
           else
@@ -1403,6 +1440,10 @@ module Gori::Tui
       return if list_h <= 0
       @scroll = @selected if @selected < @scroll
       @scroll = @selected - list_h + 1 if @selected >= @scroll + list_h
+      # Never scroll past what fits: on_event's `@scroll += 1` (not-following) and the
+      # trim clamp can leave @scroll above (rows.size - list_h), stranding the newest
+      # rows off the top with blank space below. Pull it back when the list underfills.
+      @scroll = {@scroll, {@rows.size - list_h, 0}.max}.min
       @scroll = 0 if @scroll < 0
     end
 
@@ -1511,12 +1552,15 @@ module Gori::Tui
         trailer << [Highlight::Span.new("— body truncated at capture limit (#{Proxy::Codec::Body::CAPTURE_MAX // (1024 * 1024)} MiB); full size in the list —", Theme.yellow)]
       end
 
-      # gRPC: bounded framed hex view — style eagerly into `head`.
+      # gRPC: bounded framed hex view — style eagerly into `head`. Flagged binary so the
+      # reveal-whitespace path is gated off (like any other binary body): a gRPC body is
+      # opaque protobuf whose bytes would desync the terminal if rendered as text (the
+      # very 잔상 the binary placeholder avoids). Hex (x) stays available on this pane.
       if (body && !body.empty?) && grpc_body?(head)
         ls = Highlight.message(head, nil, request)
         ls << Highlight::Line.new
         ls.concat(wrap(grpc_lines(body)))
-        return DetailView.new(ls, EMPTY_BODY, :text, trailer)
+        return DetailView.new(ls, EMPTY_BODY, :text, trailer, binary: true)
       end
 
       # Plain body → WINDOWED. Decode compressed/chunked bodies for display

--- a/src/gori/tui/read_cursor.cr
+++ b/src/gori/tui/read_cursor.cr
@@ -148,28 +148,28 @@ module Gori::Tui
         x0, x1 = {ax, @cx}.min, {ax, @cx}.max
         line = line_at.call(y0)
         return "" if x0 >= x1 && x0 >= line.size
-        return line[x0...x1]
+        return line[x0.clamp(0, line.size)...x1.clamp(0, line.size)]
       end
-      # Multi-line: if anchor and caret share a line column pattern for pure line
-      # selection (ax==0 and cx at line end), copy full lines; else copy char rects.
-      cy_line = line_at.call(@cy)
-      full_lines = ax == 0 && @cx >= cy_line.size && (ay != @cy || ax == 0)
-      if full_lines && @cx == cy_line.size && ax == 0
-        parts = Array(String).new(y1 - y0 + 1)
-        (y0..y1).each { |yi| parts << line_at.call(yi) }
-        parts.join("\n")
-      else
-        parts = [] of String
-        (y0..y1).each do |yi|
-          line = line_at.call(yi)
-          parts << case yi
-                   when y0 then line[ax..]
-                   when y1 then line[0...@cx]
-                   else         line
-                   end
+      # Multi-line char rectangle. Assign the boundary columns to the lines they
+      # actually belong to in DOCUMENT order: an upward selection (caret above the
+      # anchor) has the CARET column on the top line and the ANCHOR column on the
+      # bottom — the reverse of a downward one. The old code assumed y0==anchor /
+      # y1==caret unconditionally, so an upward selection copied the wrong text AND
+      # sliced a short top line past its end (`line[ax..]` with ax > size → IndexError,
+      # crashing the copy). Each column is clamped to its line's length because a
+      # vertical select parks the caret at EOL, which can exceed a shorter neighbour.
+      # A clean full-line selection (top col 0, bottom col ≥ EOL) falls out as whole lines.
+      top_x, bot_x = @cy < ay ? {@cx, ax} : {ax, @cx}
+      parts = Array(String).new(y1 - y0 + 1)
+      (y0..y1).each do |yi|
+        line = line_at.call(yi)
+        parts << case yi
+        when y0 then line[top_x.clamp(0, line.size)..]
+        when y1 then line[0...bot_x.clamp(0, line.size)]
+        else         line
         end
-        parts.join("\n")
       end
+      parts.join("\n")
     end
 
     def current_line(lines : Array(String)) : String
@@ -195,6 +195,10 @@ module Gori::Tui
       y0, y1 = {ay, @cy}.min, {ay, @cy}.max
       y0 = y0.clamp(0, size - 1)
       y1 = y1.clamp(0, size - 1)
+      # Boundary columns belong to their DOCUMENT-order lines (see selection_text):
+      # an upward selection puts the caret column on the top line, the anchor on the
+      # bottom — so the highlight matches the text a copy would produce.
+      top_x, bot_x = @cy < ay ? {@cx, ax} : {ax, @cx}
       spans = [] of {Int32, Int32, Int32}
       (y0..y1).each do |yi|
         line = line_at.call(yi)
@@ -203,9 +207,9 @@ module Gori::Tui
                    xb = {ax, @cx}.max
                    {xa, xb}
                  elsif yi == y0
-                   {ax, line.size}
+                   {top_x.clamp(0, line.size), line.size}
                  elsif yi == y1
-                   {0, @cx}
+                   {0, bot_x.clamp(0, line.size)}
                  else
                    {0, line.size}
                  end

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -52,8 +52,9 @@ module Gori::Tui
       @scope = nil.as(Scope?)
       @query = ""
       @querying = false
-      @qcx = 0      # caret position within @query
-      @preedit = "" # IME composition, drawn at the caret
+      @qcx = 0                      # caret position within @query
+      @preedit = ""                 # IME composition, drawn at the caret
+      @query_note = nil.as(String?) # why an active filter is empty when its QL residual is INVALID
       # Numeric-sequence folding (Feature: path-param explosion). On by default; `g`
       # toggles it for the rare case of wanting every literal id.
       @grouping = true
@@ -86,7 +87,22 @@ module Gori::Tui
       # `tag:`/`-tag:` are Sitemap-local (the shared QL has no tag column): split them
       # out, hand the residual to QL.parse, and apply the tag filter to the built tree.
       positives, negatives, residual = split_tag_terms(@query)
-      combined = QL.and(@scope.try(&.filter) || QL::EMPTY, QL.parse(residual))
+      residual_filter = QL.parse(residual)
+      @query_note = query_note_for(residual, residual_filter)
+      # A non-blank QL residual that compiles to EMPTY means every QL term was invalid
+      # (typo'd field, bad numeric, unterminated value). Mirror HistoryView / MCP / CLI:
+      # reject it (empty tree + a note) rather than fall through to a match-all search
+      # that shows the WHOLE sitemap behind an "active" filter. A tag-only query has a
+      # blank residual, so reject_empty? is false and the tag filter still applies below.
+      if QL.reject_empty?(residual, residual_filter)
+        @hosts = [] of Node
+        @visible_cache = nil
+        @selected = 0
+        @scroll = 0
+        @loaded = true
+        return
+      end
+      combined = QL.and(@scope.try(&.filter) || QL::EMPTY, residual_filter)
       @hosts = Sitemap.build(store.sitemap_entries(combined))
       Sitemap.stamp_tags!(@hosts, store.sitemap_tags)
       filter_by_tags(positives, negatives)
@@ -165,6 +181,17 @@ module Gori::Tui
     end
 
     # --- tags: filter (stamping lives in Gori::Sitemap.stamp_tags!) ----------
+
+    # A short note explaining a filter that matches nothing because its QL residual is
+    # INVALID (vs a valid filter that genuinely has no matches) — surfaced in the
+    # empty-state so a typo'd status:/dur:/size: or a broken body~[regex isn't misread
+    # as "no endpoints". Operates on the residual (tag: terms are handled separately).
+    private def query_note_for(residual : String, filter : QL::Filter) : String?
+      return nil if residual.blank?
+      return "invalid filter — no valid terms" if QL.reject_empty?(residual, filter)
+      bad = QL.invalid_regex_terms(residual)
+      bad.empty? ? nil : "invalid regex in #{bad.first}"
+    end
 
     # Split `tag:`/`-tag:` tokens out of the query (whitespace-tokenised, matching
     # QL.parse). Returns positive + negative keywords (lowercased) and the residual
@@ -465,7 +492,9 @@ module Gori::Tui
         # real `/` query — a Scope-lens-only empty set isn't cleared with esc//.
         msg, hint =
           if !@query.blank?
-            {"no endpoints match", querying? ? "esc clears the filter" : "/ to edit the filter"}
+            # An INVALID QL residual (all terms bad, or a broken regex) reads as "no
+            # endpoints match" unless we say why — @query_note distinguishes it.
+            {@query_note || "no endpoints match", querying? ? "esc clears the filter" : "/ to edit the filter"}
           elsif filtering? # in-scope subset is empty (Scope lens, no QL query)
             {"no endpoints in scope", nil}
           else


### PR DESCRIPTION
A bug-hunt pass over the **History** tab (collecting/viewing captured requests) and the read-only panes it shares. **7 fixes**, each with a before/after regression spec (proven to fail on the old code, pass on the new).

## Fixes

| # | Severity | Area | Bug |
|---|----------|------|-----|
| 1 | 🔴 crash | `read_cursor.cr` | An **upward** multi-line selection swapped the boundary columns → wrong copied text, and `line[ax..]` past a short top line's end → `IndexError` **crash on copy** (press `y` after Shift+↑). Shared by History detail, Replay/Fuzzer response, Notes, Convert. |
| 2 | 🟠 | `history_view.cr` | WS **MESSAGES** pane: `x` (hex) / `w` (reveal) fell back to the bare `101` handshake bytes instead of the message transcript. |
| 3 | 🟡 | `history_view.cr` | gRPC body + `w` (reveal) rendered raw protobuf as text → terminal desync (잔상). |
| 4 | 🟡 | `history_view.cr` | `@scroll` never bottom-clamped: a live insert while not-following stranded the newest rows above a half-blank viewport. |
| 5 | 🟠 | `history_view.cr` + `sitemap_view.cr` | An **all-invalid QL query** (e.g. `dur:>2sec`) compiled to match-all and showed **every** flow/endpoint behind an "active" filter — dangerous on a security proxy. Now rejected (empty + note), mirroring the MCP/CLI surfaces. Sitemap runs the check on the QL **residual** so a `tag:`-only query isn't wrongly rejected. |
| 6 | 🟡 | `history_view.cr` + `sitemap_view.cr` | An invalid regex term now surfaces `invalid regex in …` in the empty-state instead of a silent empty result. |

## How they were found
3 parallel read-only explore agents over the History QL filter, detail panes, and list/store paths, plus manual review. Bug #1 (the crash) was reproduced end-to-end through the real `ReadCursor` API before fixing.

## Testing
- New `spec/tui/read_cursor_spec.cr` + regression specs added to `history_view_spec.cr` and `sitemap_view_spec.cr`.
- All touched-area specs green (`read_cursor`, `history_view`, `sitemap_view`, `ql`, `sitemap`): **109 examples, 0 failures**.
- `crystal tool format --check` clean; no new ameba findings.

_Note: `capture_status_spec` / `project_registry_spec` failures seen locally are pre-existing proxy-port-binding flakiness (fail identically on a clean `main`), unrelated to this change._