### PR TITLE
fix(convert): keep \u escape with sign/space literal in unicode-unescape

### DIFF
--- a/spec/convert_spec.cr
+++ b/spec/convert_spec.cr
@@ -147,6 +147,17 @@ describe Gori::Convert do
       expect_raises(Gori::Convert::ConvertError) { conv("unicode-unescape", "\\ud800") }
       expect_raises(Gori::Convert::ConvertError) { conv("unicode-unescape", "\\udc00") }
     end
+
+    it "unicode-unescape treats a \\u run with a sign/space (not 4 hex digits) as literal" do
+      # `to_i?(16)` also accepts a leading sign/whitespace, so without an explicit
+      # hex-digit guard `\u+ABC`/`\u 1FF` silently mis-decode and `\u-1FF` reaches
+      # `Int#chr` with a NEGATIVE value → a raw ArgumentError. All four must stay literal.
+      conv("unicode-unescape", "\\u+ABC").should eq "\\u+ABC"
+      conv("unicode-unescape", "\\u 1FF").should eq "\\u 1FF"
+      conv("unicode-unescape", "\\u-1FF").should eq "\\u-1FF" # was: raw "0x-1ff out of char range"
+      conv("unicode-unescape", "\\u_ABC").should eq "\\u_ABC"
+      conv("unicode-unescape", "\\uABCD").should eq "ꯍ" # a genuine 4-hex-digit escape still decodes
+    end
   end
 
   describe "text transforms" do

--- a/src/gori/convert/codecs.cr
+++ b/src/gori/convert/codecs.cr
@@ -199,10 +199,15 @@ module Gori::Convert
 
     # Parse EXACTLY 4 hex digits at `at`, or nil. A short slice near end-of-string
     # (e.g. `\uAB`) must NOT decode — it stays literal, matching the mid-string case
-    # where `\uABX` is left alone because `to_i?` rejects the non-hex char.
+    # where `\uABX` is left alone because `X` is not a hex digit. The explicit
+    # `hex?` guard is load-bearing: `to_i?(16)` also accepts a leading sign or
+    # whitespace, so `\u+ABC`/`\u 1FF` would silently mis-decode and `\u-1FF` would
+    # even reach `Int#chr` with a negative value (a raw ArgumentError). Requiring all
+    # four chars to be hex digits keeps those literal, as intended.
     private def hex4(s : String, at : Int32) : Int32?
       h = s[at, 4]?
-      (h && h.size == 4) ? h.to_i?(16) : nil
+      return nil unless h && h.size == 4 && h.each_char.all?(&.hex?)
+      h.to_i?(16)
     end
 
     def unicode_unescape(s : String) : String


### PR DESCRIPTION
## What

While fuzzing the **Convert** tab's codecs with round-trip and malformed inputs, I found a parsing bug in `unicode-unescape`.

`Codecs.hex4` is supposed to parse *exactly 4 hex digits* after `\u`, but it used `String#to_i?(16)`, which by default also accepts a **leading sign and whitespace**. That caused three misbehaviors:

| Input | Before | Correct |
|-------|--------|---------|
| `\u-1FF` | **raw `ArgumentError`** (`Int#chr` on -511) | stays literal |
| `\u+ABC` | silently mis-decodes to `U+0ABC` | stays literal |
| `\u 1FF` | silently mis-decodes to `U+01FF` | stays literal |

`\u-1FF` was caught by the chain executor's generic rescue (no TUI crash), but surfaced an ugly internal message instead of a clean `ConvertError`. The `+`/space cases were worse — they returned a **wrong character with no error**, contradicting the helper's own comment ("Parse EXACTLY 4 hex digits").

## Fix

Gate all four chars on `Char#hex?` before `to_i?(16)`:

```crystal
return nil unless h && h.size == 4 && h.each_char.all?(&.hex?)
h.to_i?(16)
```

`Char#hex?` rejects `+`/`-`/space, so those runs stay literal while genuine escapes (`ꯍ`) and surrogate pairs (`🎉` → 🎉) still decode.

## Verification

- Round-trip fuzz across every encoder↔decoder pair (base64/base64url/hex/base32/ascii85/base58/gzip/zlib) over all 0–255 byte values + edge inputs — all pass.
- `\u` + 784 char-combination fuzz — **0 raw exceptions** after the fix.
- Added a regression spec. `spec/convert_spec.cr` (31) and `spec/tui/convert_view_spec.cr` (13) all green.