### PR TITLE
fix(tui): stop Replay/Intercept doubling CRLF from a $KEY value

### DIFF
--- a/spec/tui/replay_view_spec.cr
+++ b/spec/tui/replay_view_spec.cr
@@ -223,6 +223,23 @@ describe Gori::Tui::ReplayView do
     String.new(view.request_bytes).should eq("POST /x HTTP/1.1\r\nHost: a.test\r\n\r\nq=§hi§")
   end
 
+  it "does not double CRLF when a $KEY value carries its own CRLF" do
+    # A var value with an embedded CRLF must land in the wire request as a single CRLF,
+    # not `\r\r\n` — parity with Env.expand_wire (the CLI/MCP send path). The old
+    # split('\n').join("\r\n") over already-expanded text doubled it, corrupting the line.
+    prev = Gori::Settings.env_vars
+    begin
+      Gori::Settings.env_vars = [{"MULTI", "a\r\nb"}]
+      view = ReplayView.new
+      view.restore("https://h.test", "POST /x HTTP/1.1\nHost: h.test\n\n$MULTI", false, false)
+      sent = String.new(view.request_bytes)
+      sent.should eq("POST /x HTTP/1.1\r\nHost: h.test\r\n\r\na\r\nb")
+      sent.includes?("\r\r\n").should be_false
+    ensure
+      Gori::Settings.env_vars = prev
+    end
+  end
+
   it "MARK transform on applies a marker's inline chain on send + resyncs Content-Length" do
     view = ReplayView.new
     view.restore("https://a.test",

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -182,7 +182,9 @@ module Gori::Tui
     def pending_edit : {Int64, Bytes}?
       id = @loaded_id
       return nil unless id && @editor_dirty
-      raw = Env.expand(@editor.text).split('\n').join("\r\n").to_slice
+      # `Env.expand_wire` (gsub `/\r?\n/`) not `split('\n').join("\r\n")`: a `$KEY` value
+      # carrying a CRLF would otherwise double into `\r\r\n` and corrupt the forwarded bytes.
+      raw = Env.expand_wire(@editor.text)
       {id, Fuzz::ContentLength.sync(raw, add_when_missing: true)}
     end
 

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -1029,8 +1029,13 @@ module Gori::Tui
       expanded_text_to_bytes(@editor.text)
     end
 
+    # Env-expand the LF editor text and normalize to CRLF wire form. Uses
+    # `Env.expand_wire` (gsub `/\r?\n/`) — NOT `split('\n').join("\r\n")` — so a `$KEY`
+    # whose value itself carries a CRLF isn't doubled into `\r\r\n`, which would corrupt
+    # the header line (or the head/body separator). Shared logic with the CLI/MCP replay
+    # send paths so the TUI can't disagree with them on the bytes it puts on the wire.
     private def expanded_text_to_bytes(text : String) : Bytes
-      Env.expand(text).split('\n').join("\r\n").to_slice
+      Env.expand_wire(text)
     end
 
     # MARK-transform mode: parse the CRLF wire form as a Fuzz template and render each


### PR DESCRIPTION
## What

The Replay send path (`ReplayView#expanded_text_to_bytes`) and the Intercept forward-edit path (`InterceptView#pending_edit`) turned the LF editor text into CRLF wire bytes with:

```crystal
Env.expand(text).split('\n').join("\r\n").to_slice
```

`env.cr` already documents that `split('\n').join("\r\n")` **doubles** a pre-existing CRLF into `\r\r\n` — that's exactly why `Env.expand_wire` (gsub `/\r?\n/`) exists and is used on the CLI/MCP/miner paths. The TUI sites were assumed safe because `@editor.text` is LF-only, but that overlooked that `Env.expand` runs *after* the editor text: a `$KEY` **value** can itself carry a CRLF (e.g. a multi-line project var imported via JSON `parse_vars_json`). That CRLF lands in the post-expansion string and gets doubled, corrupting the header line or the head/body separator.

### Repro (before)

```
$MULTI = "a\r\nb"
POST /x HTTP/1.1
Host: h.test

$MULTI
```
sent → `POST /x HTTP/1.1\r\nHost: h.test\r\n\r\na\r\r\nb`  ← doubled CR

### After

sent → `POST /x HTTP/1.1\r\nHost: h.test\r\n\r\na\r\nb`  ✓

## Fix

Switch both TUI sites to the safe, centralized `Env.expand_wire`, unifying them with the CLI/MCP/miner send paths so they can't disagree on the wire bytes.

## Test

- Adds a regression test in `spec/tui/replay_view_spec.cr`.
- Replay / intercept / env / flow_request / decode specs pass (128 examples).
- The only full-suite failures are pre-existing proxy port-binding tests that fail identically on `main` in the sandbox — unrelated to this change.