### PR TITLE
fix(tui): 4 Fuzzer bugs — set-overlay first-line drop, words persistence, Int64 numbers, detail crash

### DIFF
--- a/spec/tui/fuzz_set_overlay_spec.cr
+++ b/spec/tui/fuzz_set_overlay_spec.cr
@@ -23,6 +23,24 @@ describe Gori::Tui::FuzzSetOverlay do
     spec.value.should eq("admin,root")
   end
 
+  it "List: typing on the Type row (before any nav) drops into the values editor" do
+    # ^L opens focused on the Type selector; the first keystroke/paste must not be lost.
+    ov = FuzzSetOverlay.for_list
+    otype(ov, "admin")
+    ov.handle_key(okey(Termisu::Input::Key::Enter))
+    otype(ov, "root")
+    ov.build_spec.not_nil!.value.should eq("admin,root")
+  end
+
+  it "Numbers: bounds above Int32::MAX survive build_spec (Int64 range)" do
+    ov = FuzzSetOverlay.for_list
+    ov.handle_key(okey(Termisu::Input::Key::Right))                 # List → Numbers
+    ov.handle_key(okey(Termisu::Input::Key::Down))                  # Type row → From
+    5.times { ov.handle_key(okey(Termisu::Input::Key::Backspace)) } # clear "1"
+    otype(ov, "3000000000")
+    ov.build_spec.not_nil!.value.should eq("3000000000-100:1")
+  end
+
   it "seeds an existing List set (comma → lines) and round-trips back to commas" do
     ov = FuzzSetOverlay.editing(Gori::Tui::SetSpec.new(:list, "a,b,c"), 0)
     ov.edit_index.should eq(0)

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -128,6 +128,21 @@ describe Gori::Tui::FuzzerView do
       back.follow.should be_true
       back.m_status.should eq("200,500")
     end
+
+    it "persists match/filter words across a config_json round-trip" do
+      src = loaded_fuzzer
+      snap = src.advanced_snapshot
+      src.apply_advanced(Gori::Tui::AdvancedSnapshot.new(
+        conc: snap.conc, rate: snap.rate, timeout: snap.timeout, retries: snap.retries,
+        follow: snap.follow, calibrate: snap.calibrate,
+        m_status: snap.m_status, m_size: snap.m_size, m_words: "42", m_regex: snap.m_regex,
+        f_status: snap.f_status, f_size: snap.f_size, f_words: "7", f_regex: snap.f_regex))
+      dst = FuzzerView.new
+      dst.duplicate_from(src) # duplicate_from restores via apply_config_json(config_json)
+      back = dst.advanced_snapshot
+      back.m_words.should eq("42")
+      back.f_words.should eq("7")
+    end
   end
 
   it "verifies vertical navigation boundaries (template/config/results at_top)" do

--- a/src/gori/tui/fuzz_set_overlay.cr
+++ b/src/gori/tui/fuzz_set_overlay.cr
@@ -141,17 +141,27 @@ module Gori::Tui
         move_row(-1); return :stay
       end
 
-      return handle_type_row(key) if f == :type
+      return handle_type_row(ev) if f == :type
       return handle_values(ev) if f == :values
       handle_field(ev, f)
     end
 
-    private def handle_type_row(key : Termisu::Input::Key) : Symbol
+    private def handle_type_row(ev : Termisu::Event::Key) : Symbol
+      key = ev.key
       case
       when key.left?             then cycle_ptype(-1)
       when key.right?            then cycle_ptype(1)
       when key.up?               then move_row(-1)
       when key.down?, key.enter? then move_row(1)
+      else
+        # A printable typed (or pasted) on the Type row while it's a List drops straight
+        # into the values editor and is captured there. Without this the Type selector
+        # silently swallowed it — losing the whole first line of a pasted wordlist (the
+        # ^L quick-List path opens focused on this row). →/← still cycle the type.
+        if @ptype == :list && (ch = ev.char) && !ev.ctrl? && !ev.alt?
+          @sel = rows.index(:values) || @sel
+          @values.insert(ch)
+        end
       end
       :stay
     end
@@ -242,7 +252,7 @@ module Gori::Tui
         vals = list_values
         vals.empty? ? nil : SetSpec.new(:list, vals.join(","))
       when :numbers
-        SetSpec.new(:numbers, "#{num(:from)}-#{num(:to)}:#{num(:step, 1)}")
+        SetSpec.new(:numbers, "#{num64(:from)}-#{num64(:to)}:#{num64(:step, 1_i64)}")
       when :wordlist
         p = @fields[:path].value.strip
         p.empty? ? nil : SetSpec.new(:file, p)
@@ -260,6 +270,13 @@ module Gori::Tui
 
     private def num(f : Symbol, default : Int32 = 0) : Int32
       @fields[f].value.to_i? || default
+    end
+
+    # From/To/Step round-trip through the Int64 engine (Fuzz::NumberRange), so parse
+    # them wide: `num` (Int32) truncated any bound above 2³¹−1 to the default, silently
+    # collapsing e.g. a post-2038 timestamp or large-ID range to `0` on the first apply.
+    private def num64(f : Symbol, default : Int64 = 0_i64) : Int64
+      @fields[f].value.to_i64? || default
     end
 
     private def ptype_label(t : Symbol) : String

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -74,7 +74,7 @@ module Gori::Tui
       @editor.gutter = true
       @editor.follow_x = true     # long lines (headers, URLs, §-marked params) scroll horizontally to keep the cursor visible
       @editor.env_complete = true # `$KEY` autocomplete against the registered env vars (expanded on send)
-      @last_synced_config = "" # last store config blob applied (reconcile equality)
+      @last_synced_config = ""    # last store config blob applied (reconcile equality)
       @config = Fuzz::Config.new(keep_bodies: :matched)
       @sets = [] of SetSpec
       @matcher = Fuzz::Matcher.new(keep_bodies: :matched)
@@ -372,7 +372,7 @@ module Gori::Tui
       case pane
       when :template then template_insert? || chain_pane_active?
       when :target   then target_insert?
-      else               false
+      else                false
       end
     end
 
@@ -948,9 +948,11 @@ module Gori::Tui
       @detail_scroll = (@detail_scroll + step).clamp(0, max)
       lo = @detail_scroll
       hi = {@detail_scroll + @detail_last_h - 1, lines.size - 1}.min
-      @detail_cursor.sync(
-        @detail_cursor.cy.clamp(lo, hi),
-        @detail_cursor.cx.clamp(0, lines[@detail_cursor.cy].size))
+      # Clamp cy into range BEFORE indexing `lines`: while a run streams, a live re-sort
+      # (non-index sort) can swap the fixed @sel onto a shorter result, leaving cy stale
+      # and larger than the new `lines` — a bare `lines[cy]` would then raise IndexError.
+      cy = @detail_cursor.cy.clamp(lo, hi)
+      @detail_cursor.sync(cy, @detail_cursor.cx.clamp(0, lines[cy].size))
     end
 
     def detail_plain_lines : Array(String)
@@ -1183,7 +1185,7 @@ module Gori::Tui
       when :template then !pane_insert?(:template) && @template_read.selection?
       when :target   then !pane_insert?(:target) && @target_read.selection?
       when :detail   then detail_navigable? && @detail_cursor.selection?
-      else               false
+      else                false
       end
     end
 
@@ -1232,6 +1234,8 @@ module Gori::Tui
           j.field "filter_status", @matcher.filter_status
           j.field "match_size", @matcher.match_size
           j.field "filter_size", @matcher.filter_size
+          j.field "match_words", @matcher.match_words
+          j.field "filter_words", @matcher.filter_words
           j.field "match_regex", @matcher.match_regex.try(&.source)
           j.field "filter_regex", @matcher.filter_regex.try(&.source)
           j.field "extract", @matcher.extract.try(&.source)
@@ -1257,6 +1261,8 @@ module Gori::Tui
       @matcher.filter_status = obj["filter_status"]?.try(&.as_s?)
       @matcher.match_size = obj["match_size"]?.try(&.as_s?)
       @matcher.filter_size = obj["filter_size"]?.try(&.as_s?)
+      @matcher.match_words = obj["match_words"]?.try(&.as_s?)
+      @matcher.filter_words = obj["filter_words"]?.try(&.as_s?)
       @matcher.match_regex = obj["match_regex"]?.try(&.as_s?).try { |s| Regex.new(s) rescue nil }
       @matcher.filter_regex = obj["filter_regex"]?.try(&.as_s?).try { |s| Regex.new(s) rescue nil }
       @matcher.extract = obj["extract"]?.try(&.as_s?).try { |s| Regex.new(s) rescue nil }
@@ -1842,7 +1848,7 @@ module Gori::Tui
     end
 
     private def paint_detail_line_chrome(screen : Screen, x : Int32, y : Int32, li : Int32, line : String,
-                                           focused : Bool, lines : Array(String)) : Nil
+                                         focused : Bool, lines : Array(String)) : Nil
       return unless focused && detail_navigable?
       @detail_cursor.highlight_spans(lines).each do |(l, x0, x1)|
         paint_char_span_bg(screen, x, y, line, x0, x1, Theme.accent_bg) if l == li


### PR DESCRIPTION
Hands-on Fuzzer bug-hunt (drove real `gori run fuzz` on a local echo server + live tmux TUI). The engine (`src/gori/fuzz/`) held up across every scenario — sniper/pitchfork/cluster-bomb, Content-Length sync, inline `§v¦chain§` chains, url_all/base64/brute, JSON auto-mark, status/size/word matchers. **All 4 defects were in the TUI/overlay layer.**

## Fixes

**1. Payload-set overlay drops the first pasted/typed line (data loss)**
The Set overlay opens focused on the *Type selector* row, which ignores printable input. On the `^L` quick-List / `+ Add` path (whose whole point is to type/paste values immediately), everything up to the first newline was swallowed — a pasted wordlist `admin\nroot\nguest` produced `root,guest`. Now a printable typed on the List Type row drops into the values editor; `→`/`←` still cycle the type.

**2. `Match words` / `Filter words` not persisted (data loss)**
`config_json` serialized status/size/regex/extract but not the words matchers, though the Advanced overlay edits them — lost on save/reopen and on sub-tab Duplicate. Added to `config_json` + `apply_config_json`.

**3. Numbers From/To/Step truncated to 0 above Int32::MAX**
The overlay parsed bounds with Int32 `.to_i?` while the engine's `NumberRange` is Int64 end-to-end, so a large-ID / post-2038-timestamp range (e.g. `3000000000`) collapsed to `0` on the first apply. Added an Int64 `num64` parse for the numbers branch.

**4. `IndexError` crash in `detail_scroll_view`**
It indexed `lines[cy]` with a pre-clamp cursor. During a live run with a non-index sort, streaming results re-sort under the fixed selection, swapping in a shorter response → stale `cy` → crash on wheel-scroll. Clamp `cy` before indexing.

## Verification
- **1587 specs pass, 0 failures** (+3 new: paste-on-Type-row, Int64 numbers, words round-trip)
- `crystal tool format` clean; ameba clean apart from the 2 pre-existing tolerated `set_preedit` lints
- Live TUI + CLI reproductions confirm each fix