### PR TITLE
Pre-release review: 16 verified bug fixes + 17 docs corrections

### DIFF
--- a/docs/content/getting-started/quick-start.md
+++ b/docs/content/getting-started/quick-start.md
@@ -98,7 +98,7 @@ The **Help** tab is a full key cheatsheet inside the app — use it when this pa
 
 ## 5. Watch flows in History
 
-Switch to **History** (`3`, or `[` / `]` until History is active). Every request/response is a *flow*: start line, headers, body (up to 8 MiB), plus HTTP/2 frames, WebSocket messages, and decoded JWT / SAML / GraphQL when present.
+Switch to **History** (`3`, or `[` / `]` until History is active). Every request/response is a *flow*: start line, headers, body (stored up to 2 MiB), plus HTTP/2 frames, WebSocket messages, and decoded JWT / SAML / GraphQL when present.
 
 <figure class="tui-shot">
   <img src="/images/tui/history.svg" alt="gori History tab listing captured HTTP flows with time, method, protocol, host, path, status, type, size and duration columns">
@@ -170,6 +170,7 @@ Keep this table nearby until the chords stick:
 | `Ctrl-R` | History | → Replay |
 | `Shift-I` | History | → Fuzzer |
 | `Ctrl-R` | Replay / Fuzzer | Send request / run fuzz |
+| `n` | Anywhere | Notification center (background-job results / alerts) |
 | `Esc` | Most places | Back out one level |
 
 ## First-run wizard

--- a/docs/content/guide/convert.md
+++ b/docs/content/guide/convert.md
@@ -17,7 +17,7 @@ Four cards stack top to bottom:
 | Pane | Role |
 |------|------|
 | **INPUT** | Source text (editable) |
-| **CHAIN** | Pipeline spec — converter names separated by `|` or `>` |
+| **CHAIN** | Pipeline spec — converter names separated by `|`, `>`, or `,` (all equivalent) |
 | **PIPELINE** | One row per step with its intermediate output |
 | **OUTPUT** | Final result (text / hex / base64 display modes) |
 

--- a/docs/content/guide/hotkeys.md
+++ b/docs/content/guide/hotkeys.md
@@ -70,7 +70,7 @@ An absent action uses the profile default. Unknown ids and unparseable chords ar
 ## Limitations
 
 - Only an action's **primary** chord is shown/edited; navigation aliases (e.g. the arrow-key duplicates of `j` / `k`) aren't listed.
-- The **Help** tab (digit `9`) and the status-bar hints show **default** chords, not your rebindings — if you remap something, those still advertise the original key.
+- The **Help** tab (the last tab — reach it with `[` / `]` or the palette's *Go to Help*; digits `1`–`9` only reach the first nine visible tabs) and the status-bar hints show **default** chords, not your rebindings — if you remap something, those still advertise the original key.
 
 ## Next Steps
 

--- a/docs/content/guide/mcp.md
+++ b/docs/content/guide/mcp.md
@@ -70,6 +70,8 @@ gori mcp --install-claude-code
 | `list_findings` / `get_finding` | Read triaged findings |
 | `list_scope` | Current scope include/exclude rules |
 | `list_notes` / `get_note` | Read project notes |
+| `list_rules` | List the project's Match & Replace rules in apply order |
+| `convert` | Run an encode/decode/hash/compress chain over `input` (pure transform; no network or state) |
 | `project_info` | Flow / finding counts and which database is served |
 | `get_current_context` | What the user is viewing in the TUI right now |
 | `get_replay_context` | Replay workbench state and saved sessions |
@@ -83,10 +85,11 @@ gori mcp --install-claude-code
 | `create_replay` / `update_replay` / `delete_replay` | Manage Replay sessions |
 | `create_finding` / `update_finding` | Record and update findings |
 | `create_note` / `update_note` / `delete_note` | Manage project notes |
+| `create_rule` / `set_rule_enabled` / `delete_rule` | Create, toggle, and delete Match & Replace rules (literal rewrites on in-flight request/response head or body) |
 | `fuzz_start` / `fuzz_status` / `fuzz_results` / `fuzz_stop` | Drive the fuzzer |
 | `mine_start` / `mine_status` / `mine_results` / `mine_stop` | Drive the param miner |
 
-> Action tools are capped for safety: fuzz and mine jobs are limited in total requests, concurrency, and stored results.
+> Action tools are capped for safety: fuzz and mine jobs are limited in total requests, concurrency, and stored results. A rule created via `create_rule` is picked up by `gori run` and newly opened TUIs; an already-running TUI applies it only after its rules reload.
 
 ## Why a Seam, Not a Chatbox
 

--- a/docs/content/guide/proxy.md
+++ b/docs/content/guide/proxy.md
@@ -9,7 +9,7 @@ The proxy is the heart of gori. It sits between your client and the upstream ser
 
 Start gori and point your client at `127.0.0.1:8070` (see the [Quick Start](/getting-started/quick-start/)). Toggle capture at any time with `c` — turning it off lets traffic pass through without being recorded, which is handy while you set up.
 
-Each flow records the full request and response: start line, headers, and body (captured up to 8 MiB). Bodies compressed with gzip, deflate, Brotli, or Zstd are decoded for display.
+Each flow records the full request and response: start line, headers, and body (the stored body is capped at 2 MiB; larger bodies still forward byte-exact and report their true size). Bodies compressed with gzip, deflate, Brotli, or Zstd are decoded for display.
 
 <figure class="tui-shot">
   <img src="/images/tui/response-detail.svg" alt="gori flow detail view on the RESPONSE sub-tab, showing an HTTP/2 200 status line and syntax-highlighted response headers">
@@ -55,6 +55,7 @@ On top of the wire protocols, gori decodes common payloads inline so you don't h
 - **JWT** — header and payload decoded from `Authorization`, cookies, URLs, and bodies (signatures are shown but never verified).
 - **SAML** — base64 (and DEFLATE for the redirect binding) decoded for `SAMLRequest` / `SAMLResponse`.
 - **GraphQL** — `query`, `operationName`, and `variables` parsed from POST bodies and `?query=` parameters.
+- **Form params** — `application/x-www-form-urlencoded` and `multipart/form-data` request bodies, plus the URL query string, decoded into a flat key=value list in the PARAMS pane (multipart file parts are summarised).
 
 ## Filtering History
 
@@ -65,7 +66,7 @@ status:5xx                  flows that errored
 host:api.example.com        a single host
 method:POST body:password   POST requests mentioning "password"
 dur:>500                    responses slower than 500 ms
-path:~/admin/               path matching a regex
+path~/admin/                path matching a regex
 ```
 
 Type a query in the History filter bar, or run it headless:

--- a/docs/content/guide/replay-and-fuzzer.md
+++ b/docs/content/guide/replay-and-fuzzer.md
@@ -19,7 +19,7 @@ Replay handles more than HTTP/1:
 - **HTTP/2** requests are re-sent over a real h2 connection.
 - **WebSocket** replay opens a handshake, then lets you send messages and watch the drained responses.
 - **gRPC** replay reuses the HTTP/2 engine for framed messages.
-- A **decode** mode re-encodes edited JWT / SAML / GraphQL payloads on send.
+- A **decode** mode re-encodes edited SAML / GraphQL payloads on send. (To decode or edit a JWT, use the [Convert](/guide/convert/) tab's `jwt-decode`.)
 
 Replay from the command line, optionally against a new target:
 
@@ -68,7 +68,7 @@ The Fuzzer is an Intruder-style engine: mark positions in a request, attach payl
 
 ### Positions and Payloads
 
-Mark positions with `§…§` markers in the request, or let gori place them automatically. Payload sets can be a wordlist, an explicit list, a numeric range, null bytes, or brute-force character sets. Processors let you transform each payload on the way out — prefix/suffix, URL/base64/hex encoding, case folding, hashing, or a regex replace.
+Mark positions with `§…§` markers in the request, or let gori place them automatically. Payload sets can be a wordlist, an explicit list, a numeric range, N empty (null) payloads, or brute-force character sets. Processors let you transform each payload on the way out — prefix/suffix, URL/base64/hex encoding, case folding, hashing, or a regex replace.
 
 ### Matching
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -56,13 +56,13 @@ gori run <subcommand> [options]
 | `capture` | Run the proxy and stream captured flows to STDOUT |
 | `history` (`ls`) | List / query captured flows |
 | `show <flow-id>` | Print one flow's request and response |
-| `replay <flow-id>` | Re-send a captured flow |
+| `replay <flow-id>` · `list` · `create` | Re-send a captured flow, or list / create Replay workbench sessions |
 | `fuzz [<flow-id>]` | Intruder-style fuzzer |
 | `mine [<flow-id>]` | Hidden-parameter discovery |
 | `prism [QL]` | Passive security scan (no requests) |
 | `sitemap [QL]` | Host → path endpoint tree |
 | `notes [<n>]` | Read project notes |
-| `findings` | List / export findings |
+| `findings` · `create` · `update` | List / export findings, or write findings |
 | `projects` | List known projects |
 | `scope` | List / add / delete / enable / disable scope rules |
 
@@ -106,6 +106,8 @@ gori run show <flow-id> --format raw
 
 ### run replay
 
+Re-send one captured flow, or manage the Replay workbench sessions shared with the TUI.
+
 ```bash
 gori run replay <flow-id> --target https://staging.example.com --http2 --diff
 ```
@@ -114,8 +116,31 @@ gori run replay <flow-id> --target https://staging.example.com --http2 --diff
 |--------|-------------|
 | `--target=URL` | Send to a different URL |
 | `--http2` | Use HTTP/2 |
+| `--sni=HOST` | TLS SNI override |
 | `-k`, `--insecure-upstream` | Skip upstream TLS verification |
+| `-H`, `--header=HEADER` | Overwrite/add a request header (repeatable) |
+| `-b`, `--body=BODY` | Request body override |
 | `--diff` | Diff against the original response |
+| `--format=FMT` | `text` (default) or `json` |
+
+**`replay list`** — list saved Replay sessions (`--format text|json`).
+
+**`replay create`** — create a Replay session:
+
+```bash
+gori run replay create --target https://api.example.com --request-file req.txt --name "login probe"
+gori run replay create --flow 42 --name "clone of 42"
+```
+
+| Option | Description |
+|--------|-------------|
+| `-t`, `--target=URL` | Target URL (required unless cloned from `--flow`) |
+| `-f`, `--request-file=FILE` | Read the raw HTTP request from FILE |
+| `-r`, `--request-raw=RAW` | Verbatim raw HTTP request string |
+| `--flow=ID` | Clone request / target / HTTP/2 from a captured flow |
+| `--name=NAME` | Custom tab name |
+| `--http2`, `--no-auto-cl`, `--sni=HOST` | HTTP/2, skip auto `Content-Length`, SNI override |
+| `--mark-transform` | Enable inline `§value¦chain§` substitution on send |
 
 ### run fuzz
 
@@ -123,6 +148,7 @@ Sources: `--flow=ID`, `--request=FILE`, or stdin. Positions: `§…§` markers, 
 
 | Group | Options |
 |-------|---------|
+| Transport | `--target=URL` (required for `--request`/stdin), `--http2`, `--sni=HOST`, `-k`/`--insecure-upstream` |
 | Mode | `--mode=` `sniper` (default), `batteringram`, `pitchfork`, `clusterbomb` |
 | Payloads | `-w`/`--wordlist`, `--payloads=LIST`, `--numbers=FROM-TO[:STEP]`, `--null=N`, `--brute=CHARSET:MIN-MAX` |
 | Processors | `--prefix`, `--suffix`, `--encode` (`url`\|`urlall`\|`base64`\|`hex`), `--case` (`upper`\|`lower`), `--hash` (`md5`\|`sha1`\|`sha256`), `--regex-replace=/pat/rep/` |
@@ -158,7 +184,7 @@ gori run prism --severity high --category cors
 gori run sitemap --in-scope --format paths
 ```
 
-`--in-scope` limits to in-scope hosts, `--no-group` disables numeric path folding, `--format` is `text` (tree), `json`, or `paths`.
+`-q`/`--query=QL` filters endpoints with the same QL as history (also positional), `-n`/`--limit=N` caps the endpoints scanned (default `SITEMAP_MAX`), `--in-scope` limits to in-scope hosts, `--no-group` disables numeric path folding, `--format` is `text` (tree), `json`, or `paths`.
 
 ### run findings / notes / projects
 
@@ -167,6 +193,18 @@ gori run findings --format markdown --export report.md
 gori run notes --all
 gori run projects --format json
 ```
+
+Write findings from scripts with `create` / `update`:
+
+```bash
+gori run findings create --title "Reflected XSS on /search" --severity high --host app.example.com --flow 42
+gori run findings update 7 --status confirmed --notes "Verified on staging" --severity critical
+```
+
+| Option | Description |
+|--------|-------------|
+| `create` | `-t`/`--title` (required), `-s`/`--severity` (`info`\|`low`\|`medium`\|`high`\|`critical`), `--host`, `--flow=ID` |
+| `update <id>` | `-t`/`--title`, `-s`/`--severity`, `-n`/`--notes`, `--status` (`open`\|`confirmed`\|`false-positive`\|`resolved`) |
 
 ### run scope
 

--- a/docs/content/reference/config.md
+++ b/docs/content/reference/config.md
@@ -167,4 +167,4 @@ A project can override the network settings without editing the global file. The
 
 ## Projects & Database
 
-Each project is a SQLite database (via `crystal-db` / `crystal-sqlite3`) holding flows, WebSocket messages, scope rules, findings, match rules, HTTP/2 frames, replay and fuzz sessions, host overrides, sitemap tags, miner sessions, and Prism issues, plus a full-text index over flow bodies. Request/response bodies are captured up to 8 MiB. Serve any project's database directly with `--db PATH`, or select a named project with `--project NAME`.
+Each project is a SQLite database (via `crystal-db` / `crystal-sqlite3`) holding flows, WebSocket messages, scope rules, findings, match rules, HTTP/2 frames, replay and fuzz sessions, host overrides, sitemap tags, miner sessions, and Prism issues, plus a full-text index over flow bodies. Stored request/response bodies are capped at 2 MiB; larger bodies are truncated in the database, but their true wire size is still recorded. Serve any project's database directly with `--db PATH`, or select a named project with `--project NAME`.

--- a/docs/content/reference/query-language.md
+++ b/docs/content/reference/query-language.md
@@ -50,12 +50,12 @@ dur:<2s             faster than 2 s (s / ms suffixes allowed)
 
 ## Regular Expressions
 
-Use `~` for a regex match on `host`, `path`, `url`, `header`, or `body`:
+Use `~` for a regex match on `host`, `path`, `url`, `header`, or `body`. The `~` is its own field/value separator — do **not** put a colon before it. Matching is case-sensitive; prefix `(?i)` for case-insensitive.
 
 ```text
-path:~/admin/
-host:~^api\.
-header:~set-cookie
+path~/admin/
+host~^api\.
+header~set-cookie
 ```
 
 ## Combining Terms
@@ -82,7 +82,7 @@ gori run history -q 'host:api.example.com status:5xx'
 gori run history -q 'method:POST dur:>1s body:token'
 
 # Admin paths, excluding static assets
-gori run history -q 'path:~/admin/ -path:~\.(css|js|png)$'
+gori run history -q 'path~/admin/ -path~\.(css|js|png)$'
 
 # Scope a passive scan
 gori run prism -q 'host:example.com'

--- a/spec/cli_run_spec.cr
+++ b/spec/cli_run_spec.cr
@@ -77,7 +77,7 @@ describe Gori::Replay::FlowRequest do
   end
 
   it "re-syncs Content-Length to the stored body when the capture was truncated" do
-    # Head over-promises CL: 9999 but only 3 bytes survived the 8 MiB cap — replaying the
+    # Head over-promises CL: 9999 but only 3 bytes survived the capture cap — replaying the
     # original CL would hang the origin. build() rewrites CL to the actual length.
     head = "POST /u HTTP/1.1\r\nHost: h\r\nContent-Length: 9999\r\nX-T: 1\r\n\r\n"
     body = Bytes[0x41, 0x42, 0x43] # "ABC"

--- a/spec/fuzz_spec.cr
+++ b/spec/fuzz_spec.cr
@@ -395,6 +395,32 @@ describe F::Engine do
     results.size.should eq(3) # all sent — a 0 cap must not break at @dispatched >= 0
   end
 
+  it "enforces max_requests as a hard cap on real sends (retries count)" do
+    # Each payload fails once then succeeds → 2 real sends per job without a hard cap.
+    # With max_requests=3, CappedBackend must refuse the 4th send even though only ~2 jobs
+    # were dispatched (the old dispatch-only check would have allowed 3 full jobs = 6 sends).
+    attempts = 0
+    set = F::PayloadSet.new(F::InlineList.new(["a", "b", "c", "d"]))
+    cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: 1, retries: 1, max_requests: 3_i64)
+    gen = F::Generator.new(base, [set], cfg)
+    backend = FakeBackend.new(F::Origin.new("http", "h", 80)) do |_b|
+      attempts += 1
+      # Odd attempts fail so each successful job burns 2 real sends.
+      attempts.odd? ? Gori::Replay::Result.new(Bytes.new(0), nil, nil, 0_i64, "boom") : ok_result(200, "ok")
+    end
+    drain(F::Engine.new(gen, F::Matcher.new, backend, cfg))
+    backend.sent.should be <= 3
+  end
+
+  it "does not overshoot max_requests under concurrency" do
+    set = F::PayloadSet.new(F::InlineList.new((1..40).map(&.to_s)))
+    cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: 8, max_requests: 12_i64)
+    gen = F::Generator.new(base, [set], cfg)
+    backend = FakeBackend.new(F::Origin.new("http", "h", 80)) { |_b| ok_result(200, "ok") }
+    drain(F::Engine.new(gen, F::Matcher.new, backend, cfg))
+    backend.sent.should be <= 12
+  end
+
   it "stops after the in-flight batch, not the buffered jobs" do
     gate = Channel(Nil).new        # unbuffered: each send blocks until released
     started = Channel(Nil).new(64) # buffered so a send-entry signal never blocks a worker

--- a/spec/import/import_spec.cr
+++ b/spec/import/import_spec.cr
@@ -186,6 +186,39 @@ describe Gori::Import do
     end
   end
 
+  it "reconstructs a form body from HAR postData.params when there is no text (Firefox/Safari shape)" do
+    har = File.tempname("gori", ".har")
+    begin
+      File.write(har, <<-JSON)
+        {
+          "log": {
+            "entries": [{
+              "startedDateTime": "2026-06-01T12:00:00+00:00",
+              "request": {
+                "method": "POST",
+                "url": "https://api.test/login",
+                "httpVersion": "HTTP/1.1",
+                "postData": {
+                  "mimeType": "application/x-www-form-urlencoded",
+                  "params": [{"name": "user", "value": "a b"}, {"name": "pw", "value": "s&t"}]
+                }
+              }
+            }]
+          }
+        }
+        JSON
+
+      with_store do |store|
+        result = Gori::Import.import_file(store, :har, har)
+        result.count.should eq(1)
+        detail = store.get_flow(store.search(Gori::QL::EMPTY, 1).first.id).not_nil!
+        String.new(detail.request_body.not_nil!).should eq("user=a+b&pw=s%26t")
+      end
+    ensure
+      File.delete?(har)
+    end
+  end
+
   it "prepends https:// to scheme-less URL list lines" do
     urls = File.tempname("gori", ".txt")
     begin

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -830,6 +830,16 @@ describe Gori::MCP::RequestBuilder do
       expect_raises(Gori::Error, /empty/) { Gori::MCP::RequestBuilder.build(args) }
     end
 
+    it "rejects a non-token char (':') in a header name (would emit a 2nd Content-Length)" do
+      # "Content-Length:0" evades the case-insensitive dedup and is written as
+      # `Content-Length:0: x` next to the auto Content-Length — two conflicting lines.
+      args = {"url"     => JSON::Any.new("http://h.test/"),
+              "method"  => JSON::Any.new("POST"),
+              "body"    => JSON::Any.new("hi"),
+              "headers" => JSON::Any.new({"Content-Length:0" => JSON::Any.new("x")})}
+      expect_raises(Gori::Error, /header name/) { Gori::MCP::RequestBuilder.build(args) }
+    end
+
     it "rejects whitespace/CRLF in the method (request-line forgery)" do
       args = {"url"    => JSON::Any.new("http://h.test/"),
               "method" => JSON::Any.new("GET /admin HTTP/1.1\r\nHost: a")}

--- a/spec/proxy/codec/body_spec.cr
+++ b/spec/proxy/codec/body_spec.cr
@@ -212,6 +212,16 @@ describe Gori::Proxy::Codec::Body do
       Http1.obfuscated_header?("GET / HTTP/1.1\r\nX : y\r\n\r\n".to_slice).should be_true
     end
 
+    it "rejects a bare LF used to hide a header from the CRLF-only framing scan" do
+      # `Foo: bar\nTransfer-Encoding: chunked` folds into one header for the CRLF-only
+      # parser, but an LF-lenient backend still reads the hidden TE — a smuggling vector.
+      Http1.obfuscated_header?(
+        "GET / HTTP/1.1\r\nHost: h\r\nFoo: bar\nTransfer-Encoding: chunked\r\n\r\n".to_slice).should be_true
+      req = Http1.parse_request_head(
+        "POST / HTTP/1.1\r\nHost: h\r\nFoo: bar\nTransfer-Encoding: chunked\r\n\r\n".to_slice)
+      expect_raises(Gori::Error) { Body.request_framing(req) }
+    end
+
     it "leaves a response with a non-chunked Transfer-Encoding as close-delimited (not rejected)" do
       # Responses may legitimately be close-delimited under a non-chunked TE — only the
       # request path (which must know the body boundary to keep-alive) rejects.

--- a/spec/verb/reserved_spec.cr
+++ b/spec/verb/reserved_spec.cr
@@ -16,7 +16,7 @@ describe Gori::Verb::Reserved do
 
   it "rejects bare structural keys" do
     {Chord.new("enter"), Chord.new("escape"), Chord.new("tab"), Chord.new("backspace"),
-     Chord.new(":")}.each do |c|
+     Chord.new("space"), Chord.new(":")}.each do |c|
       Reserved.reserved?(c).should_not be_nil
     end
   end

--- a/src/gori/cli/output.cr
+++ b/src/gori/cli/output.cr
@@ -48,6 +48,15 @@ module Gori
         String.build { |io| s.each_char { |c| io << (c.control? ? '·' : c) } }
       end
 
+      # Like `term_safe` but preserves '\n'/'\t', so a captured multi-line head/body keeps
+      # its layout while ANSI/OSC/CSI escapes and other control bytes are neutralized. Use
+      # for captured text written to a live terminal (the `show`/`replay` text views).
+      # `--format raw` stays the exact-bytes path for scripts/redirection.
+      def self.term_safe_multiline(s : String) : String
+        return s unless s.each_char.any? { |c| c.control? && c != '\n' && c != '\t' }
+        String.build { |io| s.each_char { |c| io << ((c.control? && c != '\n' && c != '\t') ? '·' : c) } }
+      end
+
       # "#42  GET   https  example.com:443/users  200  1.2kB  3ms  [Complete]"
       # Columns are padded for scannability; status/state make capture progress legible.
       def self.flow_row_text(row : Store::FlowRow) : String

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -325,7 +325,7 @@ module Gori
           io << " type=" << e.type if e.type
           io << " id=" << e.id if e.id
           io << " retry=" << e.retry if e.retry
-          e.data.each_line { |l| io << "\n  " << l.scrub }
+          e.data.each_line { |l| io << "\n  " << CLI::Output.term_safe_multiline(l.scrub) }
         end
       end
 
@@ -341,7 +341,7 @@ module Gori
         if doc = Saml.from_flow(tgt, rh, rb, sh, sb)
           puts ""
           puts "=== SAML (#{Saml.summary(doc)}) ==="
-          puts Saml.pretty_xml(doc.xml).scrub
+          puts CLI::Output.term_safe_multiline(Saml.pretty_xml(doc.xml).scrub)
         end
         jwts = Jwt.from_flow(tgt, rh, rb, sh, sb)
         unless jwts.empty?
@@ -349,18 +349,18 @@ module Gori
           puts "=== JWT (#{jwts.size}) ==="
           jwts.each do |f|
             puts "▸ #{f.location}#{(b = f.brief) ? " · #{b}" : ""}"
-            puts f.decoded.scrub
+            puts CLI::Output.term_safe_multiline(f.decoded.scrub)
           end
         end
         if op = Graphql.from_flow(tgt, rh, rb)
           puts ""
           puts "=== GRAPHQL ==="
-          puts Graphql.display(op).scrub
+          puts CLI::Output.term_safe_multiline(Graphql.display(op).scrub)
         end
         if fields = FormData.from_flow(tgt, rh, rb)
           puts ""
           puts "=== PARAMS (#{fields.size}) ==="
-          fields.each { |f| puts "#{f.source == :query ? "?" : " "} #{f.name} = #{(n = f.note) ? "(#{n})" : f.value}".scrub }
+          fields.each { |f| puts CLI::Output.term_safe_multiline("#{f.source == :query ? "?" : " "} #{f.name} = #{(n = f.note) ? "(#{n})" : f.value}".scrub) }
         end
       end
 
@@ -379,7 +379,7 @@ module Gori
       private def self.ws_message_text(m : Store::WsMessage) : String
         arrow = m.direction == "out" ? "→" : "←"
         if m.text?
-          "#{arrow} #{String.new(m.payload).scrub}"
+          "#{arrow} #{CLI::Output.term_safe_multiline(String.new(m.payload).scrub)}"
         else
           preview = m.payload[0, {m.payload.size, 16}.min].hexstring
           "#{arrow} [binary #{m.payload.size}B] #{preview}#{m.payload.size > 16 ? "…" : ""}"
@@ -2256,13 +2256,16 @@ module Gori
       end
 
       private def self.print_message_text(head : Bytes?, body : Bytes?) : Nil
-        STDOUT.puts(String.new(head || Bytes.empty).scrub.rstrip)
+        # Neutralize ANSI/OSC/CSI escapes in captured (attacker-controlled) head/body
+        # before writing to the live terminal; `binary_body?` only sniffs for NUL, so an
+        # escape-only payload would otherwise pass through. `--format raw` stays exact.
+        STDOUT.puts(CLI::Output.term_safe_multiline(String.new(head || Bytes.empty).scrub).rstrip)
         if body && !body.empty?
           STDOUT.puts ""
           if binary_body?(body)
             STDOUT.puts "[binary body, #{body.size} bytes — use --format raw for exact bytes, or view hex]"
           else
-            STDOUT.puts(String.new(body).scrub)
+            STDOUT.puts(CLI::Output.term_safe_multiline(String.new(body).scrub))
           end
         end
       end

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -678,11 +678,12 @@ module Gori
         end
         abort "gori run replay: no flow ##{id}" unless detail
 
-        # The captured request body was capped at 8 MiB; FlowRequest.build re-syncs the
+        # The captured request body was capped at CAPTURE_MAX; FlowRequest.build re-syncs the
         # Content-Length to the stored bytes so the request stays well-formed, but warn that
         # the resent body differs from what the origin originally received.
         if detail.request_body_truncated?
-          STDERR.puts "gori run replay: request body was truncated at the 8 MiB capture cap — resending the stored (shorter) body with a corrected Content-Length"
+          cap_mib = Proxy::Codec::Body::CAPTURE_MAX // (1024 * 1024)
+          STDERR.puts "gori run replay: request body was truncated at the #{cap_mib} MiB capture cap — resending the stored (shorter) body with a corrected Content-Length"
         end
 
         built = Replay::FlowRequest.build(detail)

--- a/src/gori/fuzz/engine.cr
+++ b/src/gori/fuzz/engine.cr
@@ -33,6 +33,32 @@ module Gori::Fuzz
     end
   end
 
+  # Enforces a HARD ceiling on the total number of real network sends. Wraps any Backend
+  # and, past the cap, returns a benign error Result WITHOUT touching the network — so
+  # retries, redirect hops, and baseline calibration all count against `max_requests`,
+  # unlike a dispatch-only check (which counts one-per-payload and overshoots). A nil or
+  # non-positive cap is a pass-through no-op. (Shared by the fuzzer and the param-miner.)
+  class CappedBackend < Backend
+    getter sent : Int64 = 0_i64
+
+    def initialize(@inner : Backend, @cap : Int64?)
+    end
+
+    def origin : Origin
+      @inner.origin
+    end
+
+    def cap_reached? : Bool
+      (c = @cap) && c > 0 ? @sent >= c : false
+    end
+
+    def send(bytes : Bytes) : Replay::Result
+      return Replay::Result.new(Bytes.new(0), nil, nil, 0_i64, "max-requests cap reached") if cap_reached?
+      @sent += 1
+      @inner.send(bytes)
+    end
+  end
+
   # Runs a generator's jobs concurrently and streams events. Concurrency model
   # (single-threaded fiber scheduler — no `-Dpreview_mt` — so plain ivars need no
   # locking):
@@ -60,6 +86,7 @@ module Gori::Fuzz
 
     getter events : Channel(Event)
 
+    @backend : Backend
     @concurrency : Int32
     @state : State
     @wake : Channel(Nil)
@@ -73,7 +100,10 @@ module Gori::Fuzz
     @total : Int64?
     @total_computed : Bool
 
-    def initialize(@generator : Generator, @matcher : Matcher, @backend : Backend, @config : Config)
+    def initialize(@generator : Generator, @matcher : Matcher, backend : Backend, @config : Config)
+      # Wrap so max_requests is a TRUE hard cap on real sends — retries, redirect hops and
+      # baseline calibration all count, not just one-per-dispatched-payload (nil cap = no-op).
+      @backend = CappedBackend.new(backend, @config.max_requests)
       # Clamp here (the deepest point) so no frontend can spawn an OOM-sized fiber +
       # channel fleet — the CLI's --concurrency is otherwise unbounded.
       conc = @config.concurrency.clamp(1, MAX_CONCURRENCY)

--- a/src/gori/fuzz/engine.cr
+++ b/src/gori/fuzz/engine.cr
@@ -39,6 +39,9 @@ module Gori::Fuzz
   # unlike a dispatch-only check (which counts one-per-payload and overshoots). A nil or
   # non-positive cap is a pass-through no-op. (Shared by the fuzzer and the param-miner.)
   class CappedBackend < Backend
+    # Stable error string so run_one can skip retries on a permanent budget stop.
+    CAP_ERROR = "max-requests cap reached"
+
     getter sent : Int64 = 0_i64
 
     def initialize(@inner : Backend, @cap : Int64?)
@@ -53,7 +56,7 @@ module Gori::Fuzz
     end
 
     def send(bytes : Bytes) : Replay::Result
-      return Replay::Result.new(Bytes.new(0), nil, nil, 0_i64, "max-requests cap reached") if cap_reached?
+      return Replay::Result.new(Bytes.new(0), nil, nil, 0_i64, CAP_ERROR) if cap_reached?
       @sent += 1
       @inner.send(bytes)
     end
@@ -189,7 +192,10 @@ module Gori::Fuzz
         raise Halt.new if @state == State::Stopped
         park_if_paused
         raise Halt.new if @state == State::Stopped
+        # Soft job-count check (cheap) plus the hard real-send ceiling: retries/redirects
+        # can exhaust CappedBackend mid-run while @dispatched is still under cap.
         raise Halt.new if (cap = @config.max_requests) && cap > 0 && @dispatched >= cap
+        raise Halt.new if (b = @backend).is_a?(CappedBackend) && b.cap_reached?
         pace(interval)
         @jobs.send(job)
         @dispatched += 1
@@ -233,7 +239,9 @@ module Gori::Fuzz
       attempts = 0
       loop do
         raw = @backend.send(job.bytes)
-        if raw.error && attempts < @config.retries
+        # Don't burn retries/sleep on a permanent max-requests stop — further send()s
+        # are also refused. Real network errors still retry as configured.
+        if raw.error && raw.error != CappedBackend::CAP_ERROR && attempts < @config.retries
           attempts += 1
           sleep @config.retry_pause
           next

--- a/src/gori/import/har.cr
+++ b/src/gori/import/har.cr
@@ -1,6 +1,7 @@
 require "json"
 require "base64"
 require "time"
+require "uri"
 require "./builder"
 
 module Gori
@@ -77,9 +78,24 @@ module Gori
         list
       end
 
+      # A HAR request body is recorded as EITHER postData.text OR an array of
+      # postData.params {name,value} — Firefox/Safari record x-www-form-urlencoded
+      # POSTs as params with no text. Fall back to reconstructing the urlencoded body
+      # from params so the body (and its Content-Length) aren't silently dropped.
       private def self.post_body(node : JSON::Any?) : Bytes?
         return nil unless node
-        encoded_body(node["text"]?.to_s, node["encoding"]?.to_s)
+        if body = encoded_body(node["text"]?.to_s, node["encoding"]?.to_s)
+          return body
+        end
+        if params = node["params"]?.try(&.as_a?)
+          pairs = params.compact_map do |p|
+            name = p["name"]?.to_s
+            next if name.empty?
+            "#{URI.encode_www_form(name)}=#{URI.encode_www_form(p["value"]?.to_s)}"
+          end
+          return pairs.join('&').to_slice unless pairs.empty?
+        end
+        nil
       end
 
       private def self.response_body(resp : JSON::Any) : {Bytes?, String?}

--- a/src/gori/mcp/request_builder.cr
+++ b/src/gori/mcp/request_builder.cr
@@ -122,6 +122,14 @@ module Gori
       private def self.validate_header(name : String, value : String) : Nil
         raise Gori::Error.new("header name must not be empty") if name.empty?
         reject_token_breakers(name, "header name #{name.inspect}")
+        # A header name is an RFC 7230 token (tchar only). reject_token_breakers stops
+        # whitespace/controls, but a printable non-token char — especially ':' — evades
+        # the case-insensitive Host/Content-Length dedup and puts a second, conflicting
+        # line on the wire (name "Content-Length:0" writes `Content-Length:0: x` next to
+        # the auto `Content-Length: <bodylen>`).
+        if name =~ /[^!#$%&'*+\-.^_`|~0-9A-Za-z]/
+          raise Gori::Error.new("illegal character in header name #{name.inspect} (must be an RFC 7230 token)")
+        end
         raise Gori::Error.new("illegal CR/LF/NUL in value of header #{name.inspect}") if injection_char?(value)
       end
 

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -743,7 +743,10 @@ module Gori
           j.field field, text.byte_slice(0, MCP_REPLAY_REQUEST_MAX).scrub
           j.field "#{field}_truncated", true
         else
-          j.field field, text
+          # Scrub here too: a replay request built from a binary/non-UTF-8 body round-trips
+          # invalid UTF-8 through the store, and JSON::Builder emits it verbatim — which
+          # corrupts the stdio JSON-RPC stream (must be well-formed UTF-8).
+          j.field field, text.scrub
         end
       end
 

--- a/src/gori/miner/engine.cr
+++ b/src/gori/miner/engine.cr
@@ -6,33 +6,8 @@ require "./baseline"
 require "../fuzz/engine"
 
 module Gori::Miner
-  # Enforces a HARD ceiling on the total number of real network sends across a whole
-  # mining run — baseline calibration + bucket probes + confirmation rounds all count.
-  # Past the cap, send() returns a benign error Result without touching the network, so
-  # `--max-requests` is a true hard cap. Previously it was a soft/racy check in the
-  # dispatcher only: it overshot by ~2x concurrency (the check `@sent >= cap` lagged the
-  # workers' post-round-trip increment across a buffered channel) AND skipped baseline
-  # traffic entirely (Baseline called the backend directly, uncounted).
-  class CappedBackend < Fuzz::Backend
-    getter sent : Int64 = 0_i64
-
-    def initialize(@inner : Fuzz::Backend, @cap : Int64?)
-    end
-
-    def origin : Fuzz::Origin
-      @inner.origin
-    end
-
-    def cap_reached? : Bool
-      (c = @cap) && c > 0 ? @sent >= c : false
-    end
-
-    def send(bytes : Bytes) : Replay::Result
-      return Replay::Result.new(Bytes.new(0), nil, nil, 0_i64, "max-requests cap reached") if cap_reached?
-      @sent += 1
-      @inner.send(bytes)
-    end
-  end
+  # The hard-cap wrapper (baseline calibration + bucket probes + confirmation rounds all
+  # count against `--max-requests`) lives with the send seam it wraps: Fuzz::CappedBackend.
 
   # Drives a parameter-mining run: calibrate a baseline, then for each location stuff
   # candidate names into buckets, diff vs baseline, and BINARY-SEARCH each interesting
@@ -59,7 +34,7 @@ module Gori::Miner
     @concurrency : Int32
     @state : State
     @wake : Channel(Nil)
-    @backend : CappedBackend
+    @backend : Fuzz::CappedBackend
     @report : Baseline::Report?
     @seen : Set({Location, String})
     @found : Int32
@@ -72,7 +47,7 @@ module Gori::Miner
                    backend : Fuzz::Backend, @config : Config)
       # Wrap the backend so max_requests is enforced at every real send (baseline,
       # bucket, and confirm), not just as a racy pre-dispatch check.
-      @backend = CappedBackend.new(backend, @config.max_requests)
+      @backend = Fuzz::CappedBackend.new(backend, @config.max_requests)
       @concurrency = @config.concurrency.clamp(1, MAX_CONCURRENCY)
       @state = State::Running
       @wake = Channel(Nil).new(1)

--- a/src/gori/prism/passive/cors.cr
+++ b/src/gori/prism/passive/cors.cr
@@ -43,7 +43,9 @@ module Gori
         private def cross_origin?(origin : String, ctx : Context) : Bool
           # Host is a bracketed IPv6 literal ([::1]) OR a normal reg-name/IPv4; either with an
           # optional port. Strip the IPv6 brackets to compare against the bare stored host.
-          m = origin.strip.downcase.match(%r{\A(https?)://(\[[^\]]+\]|[^/:]+)(?::(\d+))?\z}) || return true
+          # scrub: a non-UTF-8 Origin byte would make PCRE raise and drop the whole flow's
+          # detections (see secret_in_url); a real origin is ASCII so scrubbing is lossless here.
+          m = origin.strip.scrub.downcase.match(%r{\A(https?)://(\[[^\]]+\]|[^/:]+)(?::(\d+))?\z}) || return true
           scheme = m[1]
           host = m[2].lchop('[').rchop(']')
           port = m[3]?.try(&.to_i?) || (scheme == "https" ? 443 : 80)

--- a/src/gori/prism/passive/secret_in_url.cr
+++ b/src/gori/prism/passive/secret_in_url.cr
@@ -56,6 +56,12 @@ module Gori
 
         # {name, raw value} for each query pair; bare flags carry an empty value.
         private def query_pairs(target : String) : Array({String, String})
+          # The target comes from parse_request_head unscrubbed, so it can carry invalid
+          # UTF-8 (legacy Shift-JIS/Latin-1 GET forms, binary tokens, mojibake). PCRE
+          # raises on the first illegal byte, which would propagate up and make the whole
+          # flow's passive+active scan silently skip. Scrub once here (a JWT/secret is
+          # ASCII, so dropping non-UTF-8 bytes elsewhere can't hide a real match).
+          target = target.scrub
           qi = target.index('?')
           return [] of {String, String} unless qi
           target[(qi + 1)..].split('&').compact_map do |pair|

--- a/src/gori/proxy/codec/body.cr
+++ b/src/gori/proxy/codec/body.cr
@@ -145,7 +145,7 @@ module Gori::Proxy::Codec
       # obs-folded is invisible to the exact-match framing lookups below, yet a lenient
       # backend still honours it — a CL/TE request-smuggling primitive. Reject up front,
       # like CL+TE, rather than framing on a header we can't see (RFC 7230 §3.2.4).
-      raise Gori::Error.new("obfuscated request header (whitespace before colon or obs-fold)") if Http1.obfuscated_header?(req.raw_head)
+      raise Gori::Error.new("obfuscated request header (whitespace before colon, obs-fold, or bare LF)") if Http1.obfuscated_header?(req.raw_head)
       # Skip the get_all Array allocation when Transfer-Encoding is absent (the common case);
       # an empty list means neither chunked? nor te_present? — fall straight to Content-Length.
       te = req.headers.has?("Transfer-Encoding") ? req.headers.get_all("Transfer-Encoding") : EMPTY_TE

--- a/src/gori/proxy/codec/http1.cr
+++ b/src/gori/proxy/codec/http1.cr
@@ -165,7 +165,19 @@ module Gori::Proxy::Codec::Http1
   # smuggles a request past the proxy. Return true when the header block contains
   # whitespace before a colon or an obs-fold continuation line, so the caller can reject
   # the message (record + close) exactly like the other ambiguous-framing vectors.
+  #
+  # A bare LF (0x0a not immediately preceded by 0x0d) used as an in-head line terminator
+  # is the same class of vector: the CRLF-only index_crlf/parse_headers scan misses the
+  # header after it (folding it into the previous value), yet an LF-lenient backend
+  # (RFC 7230 §3.5) still reads it — a hidden Transfer-Encoding/Content-Length. read_head
+  # only ever returns a head ending in CRLFCRLF, so a well-formed head has every LF
+  # CR-preceded; reject any that doesn't.
   def self.obfuscated_header?(raw : Bytes) : Bool
+    i = 0
+    while i < raw.size
+      return true if raw.unsafe_fetch(i) == 0x0a_u8 && (i == 0 || raw.unsafe_fetch(i - 1) != 0x0d_u8)
+      i += 1
+    end
     start_crlf = index_crlf(raw, 0)
     return false if start_crlf.nil?
     pos = start_crlf + 2 # first byte after the start-line's CRLF

--- a/src/gori/proxy/h2/assembler.cr
+++ b/src/gori/proxy/h2/assembler.cr
@@ -39,6 +39,11 @@ module Gori::Proxy::H2
       # can't grow per-connection memory without bound. Raw frames stay the truth.
       getter body = Codec::CaptureBuffer.new(Codec::Body::CAPTURE_MAX)
       property headers : Array({String, String})? = nil
+      # Cumulative decoded-header bytesize across all merged blocks on this side, so a
+      # flood of repeated non-status HEADERS blocks (fake trailers, never END_STREAM)
+      # can't grow `headers` without bound. Per-block caps (MAX_HEADER_BLOCK, HPACK
+      # MAX_HEADER_LIST) only bound ONE block; this bounds the accumulation.
+      property header_bytes = 0
       property ended = false
     end
 
@@ -152,8 +157,16 @@ module Gori::Proxy::H2
     # initial headers rather than clobbering them.
     private def finish_header_block(side : Side, decoder : HPACK::Decoder) : Nil
       decoded = decoder.decode(side.header_buf.to_slice)
+      added = decoded.sum { |(n, v)| n.bytesize + v.bytesize + HPACK::Decoder::ENTRY_OVERHEAD }
       if (existing = side.headers) && !decoded.any? { |(n, _)| n == ":status" }
         # Trailers (no :status) append to the existing header list — grpc-status et al.
+        # Bound the CUMULATIVE list: the per-decode MAX_HEADER_LIST caps ONE block, but a
+        # flood of repeated non-status HEADERS blocks (fake trailers on a stream held open
+        # past END_STREAM) would otherwise grow `headers` without limit (memory DoS). The
+        # raise unwinds into feed's rescue, which drops the projection and keeps the raw
+        # frame log authoritative; the ensure below still clears header_buf.
+        raise Gori::Error.new("h2 cumulative header list too large") if side.header_bytes + added > HPACK::Decoder::MAX_HEADER_LIST
+        side.header_bytes += added
         existing.concat(decoded)
       else
         # First block, OR a status-bearing response block. An interim 1xx (100/103)
@@ -162,6 +175,7 @@ module Gori::Proxy::H2
         # :status first and mis-report the flow's status). This also bounds a stream's
         # header list against a flood of repeated interim HEADERS blocks.
         side.headers = decoded
+        side.header_bytes = added
       end
     ensure
       # Always reset, even if decode raised (feed rescues HPACK/framing errors and

--- a/src/gori/tui/findings_view.cr
+++ b/src/gori/tui/findings_view.cr
@@ -433,9 +433,10 @@ module Gori::Tui
       return unless finding = @detail
       store.update_finding(finding.id, notes: String.new(@notes.to_bytes))
       exit_notes_insert!
+      # refresh_detail already re-syncs @notes from the re-fetched @detail (now that
+      # notes-insert mode is off), and it nil-guards a peer-deleted finding — so no
+      # separate (unsafe) set_text here.
       refresh_detail(store)
-      @notes.set_text(@detail.not_nil!.notes)
-      @notes_read.sync_from(@notes)
     end
 
     # Leave the notes editor WITHOUT persisting (^W) — discards the in-buffer
@@ -730,8 +731,11 @@ module Gori::Tui
         @detail = store.get_finding(finding.id)
         @detail_flow = @detail.try { |f| f.flow_id.try { |fid| store.flow_row(fid) } }
         reload_detail_links(store)
-        unless notes_insert_mode?
-          @notes.set_text(@detail.not_nil!.notes)
+        # get_finding returns nil when the row was deleted by a peer session (supported
+        # cross-session scenario) — guard the deref, mirroring PrismView#refresh_detail.
+        # When @detail is nil the render path already falls back to the list view.
+        if !notes_insert_mode? && (d = @detail)
+          @notes.set_text(d.notes)
           @notes_read.sync_from(@notes)
         end
       end

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -673,6 +673,12 @@ module Gori::Tui
         target = Replay::FlowRequest.build_target(row.scheme, row.host, row.port)
         {"COPY REQUEST AS", CopyMenu.request_options(wire, target)}
       when :response
+        # The WS MESSAGES pane reuses the :response slot but renders the transcript
+        # (ws_messages), NOT the bare 101 handshake that response_head/body still hold —
+        # offering head/body variants here would copy the handshake (the same leak x/w
+        # had before log_pane? gating). Empty list ⇒ copy_as falls back to the plain
+        # selection copy, which yields the visible transcript via detail_copy_text.
+        return {"COPY RESPONSE AS", [] of CopyMenu::Option} if ws_messages_pane?
         head = detail.response_head
         opts = if head
                  body = detail.response_body

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -205,10 +205,16 @@ module Gori::Tui
       end
     end
 
+    # backspace/delete/undo are no-ops at buffer start / end-of-buffer / empty undo
+    # stack (TextArea returns early without bumping @edits). A no-op here must NOT set
+    # @editor_dirty: once dirty, forward_bytes recomputes Content-Length and normalizes
+    # line endings, so a held message the user only *looked* at would forward as
+    # different bytes — breaking the byte-exact hold contract (P7). Gate on a real edit.
     def edit_undo : Nil
       return unless @editing
+      before = @editor.edits
       @editor.undo
-      @editor_dirty = true
+      @editor_dirty = true if @editor.edits != before
     end
 
     def edit_insert(ch : Char) : Nil
@@ -225,8 +231,9 @@ module Gori::Tui
 
     def edit_backspace : Nil
       return unless @editing
+      before = @editor.edits
       @editor.backspace
-      @editor_dirty = true
+      @editor_dirty = true if @editor.edits != before
     end
 
     def edit_move(dr : Int32, dc : Int32) : Nil
@@ -242,11 +249,12 @@ module Gori::Tui
       @editor.end_of_line if @editing
     end
 
-    # Forward-delete the char under the caret — a content edit.
+    # Forward-delete the char under the caret — a content edit (no-op at end-of-buffer).
     def edit_delete : Nil
       return unless @editing
+      before = @editor.edits
       @editor.delete
-      @editor_dirty = true
+      @editor_dirty = true if @editor.edits != before
     end
 
     # ^G go-to-line / ^F search in the held-message editor (only while editing).

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -1487,7 +1487,11 @@ module Gori::Tui
         else
           @editor.at_top?
         end
-      when :response then @scroll == 0
+        # Cursor-aware for navigable modes (mirrors fuzzer_view's detail_cursor_at_top?) so
+        # ↑/⇧↑ move/extend the read cursor upward until it reaches line 0 with scroll at top,
+        # instead of ejecting the pane whenever the response fits on screen (@scroll stays 0).
+        # The non-navigable hex dump has no caret, so keep scroll-based ejection there.
+      when :response then resp_navigable? ? (@resp_cursor.cy == 0 && @scroll == 0) : @scroll == 0
       else                false
       end
     end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -2132,9 +2132,11 @@ module Gori::Tui
       # decision — effective_tabs force-includes the active tab, which would mask the hide.
       vis = Chrome.visible_tabs(Settings.tab_prefs)
       unless vis.any? { |(s, _)| s == @active_tab }
-        project_controller.commit if @active_tab == :project
-        replay_controller.save_current_replay if @active_tab == :replay
-        convert_controller.commit if @active_tab == :convert # now a hideable default tab — flush before snapping off
+        # Persist the outgoing tab's dirty buffer before snapping off — @active_tab still
+        # names the tab being hidden here. flush_active_tab_edits covers all hideable tabs
+        # (Notes/Fuzzer/Findings/Miner included), unlike the old project/replay/convert-only
+        # flush which silently dropped the others at hide-time.
+        flush_active_tab_edits
         @active_tab = vis.first[0]
         on_enter_tab
         @focus = :menu

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -809,6 +809,11 @@ module Gori::Tui
       return if h <= 0
       @scroll = @selected if @selected < @scroll
       @scroll = @selected - h + 1 if @selected >= @scroll + h
+      # Never scroll past what fits: reload's `prev_scroll.clamp(0, rows.size-1)` can
+      # leave @scroll above (total - h) after the tree shrinks, stranding rows off the
+      # top with blank space below. Pull it back when the list underfills (mirrors
+      # HistoryView#ensure_visible).
+      @scroll = {@scroll, {total - h, 0}.max}.min
       @scroll = 0 if @scroll < 0
     end
   end

--- a/src/gori/verb/reserved.cr
+++ b/src/gori/verb/reserved.cr
@@ -37,6 +37,11 @@ module Gori
         when "escape"    then "Escape is reserved (back / close)"
         when "tab"       then "Tab is reserved (focus ring)"
         when "backspace" then "Backspace is reserved (delete)"
+          # Space is the action-menu leader (open_space_menu), dispatched AFTER the scoped
+          # keymap lookup in runner.cr — binding a verb to it shadows the leader (app-wide
+          # if the verb is Global). Keyed on chord.key, so this also covers shift+space,
+          # which the leader dispatch treats identically (it only excludes ctrl/alt).
+        when "space"     then "Space is reserved (action menu)"
           # ':' opens the command line in dispatch regardless of the shift modifier (the
           # `ev.char == ':'` guard ignores shift), so reserve it unconditionally.
         when ":" then "':' is reserved (command line)"


### PR DESCRIPTION
Final pre-release pass. An exhaustive multi-agent review swept every code domain (proxy, store, fuzz/miner, prism, convert/replay, cli, mcp, the full TUI) and every doc area; each reported issue was adversarially re-verified against the real code before it made this PR.

**Baseline & result:** `shards build` ✓ · `crystal spec` → **1606 examples, 0 failures** (added 3 regression cases).

## Bug fixes (16, each with a concrete repro)

| Sev | Area | Fix |
|-----|------|-----|
| High | mcp | `get_replay_context` scrubs invalid UTF-8 (a binary replay body corrupted the JSON-RPC stdout stream) |
| Med | proxy/http1 | reject a bare LF in the request head — hid `Transfer-Encoding`/`Content-Length` from the CRLF-only framing scan (request smuggling/desync) |
| Med | proxy/h2 | bound the cumulative decoded header list per side (repeated non-status HEADERS blocks → memory DoS) |
| Med | prism | scrub query string / `Origin` before regex (a non-UTF-8 byte silently skipped the whole flow's scan) |
| Med | import/har | reconstruct a form body from `postData.params` (Firefox/Safari shape — body was silently dropped) |
| Med | cli | neutralize ANSI/OSC/CSI escapes in captured bytes printed by `run show`/`replay` (`binary_body?` only sniffed for NUL) |
| Med | tui/history | WS MESSAGES copy-as copied the 101 handshake, not the transcript |
| Med | tui/replay | response ↑/⇧↑ ejected the pane instead of moving the read cursor when the response fits on screen |
| Med | tui/findings | crash (`NilAssertionError`) on a peer-deleted finding |
| Med | tui/intercept | no-op backspace/delete/undo dirtied a held message → forwarded different bytes (broke byte-exact hold) |
| Med | verbs | reserve `space` in the hotkey editor (binding it killed the action-menu leader) |
| Low | fuzz | `--max-requests` is now a true hard cap on real sends (retries/redirects/baseline bypassed the dispatch-only check); shared `CappedBackend` hoisted into `Fuzz` (Miner reuses it) |
| Low | prism | scrub non-UTF-8 `Origin` in `Cors.cross_origin?` |
| Low | mcp | reject `:`/non-token chars in header names (evaded the `Content-Length` dedup → conflicting length on the wire) |
| Low | tui/runner | `save_tabs` now flushes Notes/Fuzzer/Findings edits when hiding the active tab |
| Low | tui/sitemap | pull `@scroll` back when the tree shrinks (rows no longer stranded off-screen) |

Regression specs added: bare-LF guard, MCP header-name token rule, HAR `postData.params` body, reserved `space`.

## Docs (17)

- **cli reference** — document `run replay list`/`create`, `run findings create`/`update`, and missing flags on `run replay` (`-H`/`-b`/`--sni`/`--format`), `run fuzz` (`--target`/`--http2`/`--sni`/`-k`), `run sitemap` (`-q`/`-n`).
- **query-language + proxy** — fix the `~` regex operator: **no leading colon** (`path~/admin/`, not `path:~/admin/`, which matched nothing); note case-sensitivity.
- **mcp** — add the `convert` / `list_rules` read tools and `create_rule`/`set_rule_enabled`/`delete_rule` action tools.
- **proxy + quick-start + config** — correct the captured-body cap (**2 MiB**, not 8 MiB).
- **hotkeys** — Help is the last tab, not digit 9. **quick-start** — add the `n` notification key.
- **proxy** — document the PARAMS inline-decode pane.
- **replay-and-fuzzer** — Replay decode is SAML/GraphQL only (not JWT); the null set is N empty payloads.
- **convert** — `,` is also a chain-step separator.