### PR TITLE
perf: change-detection for live-capture paths + cap M&R body buffer + import FTS readback

### DIFF
--- a/spec/import/import_spec.cr
+++ b/spec/import/import_spec.cr
@@ -59,6 +59,47 @@ describe Gori::Import do
     end
   end
 
+  it "indexes the imported request body for FTS body: search (response-bearing entry)" do
+    har = File.tempname("gori", ".har")
+    begin
+      # A response is present, so the import writer takes the update_one path (which reuses
+      # the request FTS text computed at insert time instead of reading the row back). The
+      # distinctive token lives ONLY in the REQUEST body, so a body: hit proves the request
+      # FTS column was populated correctly through that path.
+      File.write(har, <<-JSON)
+        {
+          "log": {
+            "entries": [{
+              "startedDateTime": "2026-06-01T12:00:00+00:00",
+              "request": {
+                "method": "POST",
+                "url": "https://api.test/submit",
+                "httpVersion": "HTTP/1.1",
+                "postData": {"mimeType": "text/plain", "text": "hello zephyrquux world"}
+              },
+              "response": {
+                "status": 200, "statusText": "OK", "httpVersion": "HTTP/1.1",
+                "headers": [{"name": "Content-Type", "value": "text/html"}],
+                "content": {"mimeType": "text/html", "text": "<p>ok</p>"}
+              }
+            }]
+          }
+        }
+        JSON
+
+      with_store do |store|
+        Gori::Import.import_file(store, :har, har).count.should eq(1)
+        hits = store.search(Gori::QL.parse("body:zephyrquux"), 10)
+        hits.size.should eq(1)
+        hits.first.target.should eq("/submit")
+        # A token that appears in neither body must not match (guards a bogus index).
+        store.search(Gori::QL.parse("body:nonesuchtoken"), 10).size.should eq(0)
+      end
+    ensure
+      File.delete?(har)
+    end
+  end
+
   it "preserves duplicate response headers (multiple Set-Cookie) on HAR import" do
     har = File.tempname("gori", ".har")
     begin

--- a/spec/proxy/server_spec.cr
+++ b/spec/proxy/server_spec.cr
@@ -736,6 +736,65 @@ describe Gori::Proxy::Server do
     String.new(sink.responses.first.body.not_nil!).should eq("a [HIDDEN] here")
   end
 
+  it "leaves a response body over MAX_REWRITE_BODY byte-exact (rule no-ops, no unbounded buffer)" do
+    seen_body = Channel(String).new(1)
+    done = Channel(Nil).new(1)
+    # A Content-Length body one byte past the rewrite cap. "SECRET" sits at the FRONT so the
+    # rule WOULD match — proving the rule was SKIPPED (not that it just found nothing to change).
+    cap = Gori::Proxy::ClientConn::MAX_REWRITE_BODY
+    big = "SECRET" + ("x" * (cap + 1 - 6))
+    origin_port = start_body_origin(big, seen_body)
+
+    sink = RecordingSink.new(done)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink, rewriter: BodyRewriter.new)
+    proxy.start
+
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    client << "GET /big HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\n\r\n"
+    client.flush
+    response = client.gets_to_end
+    client.close
+
+    done.receive
+    proxy.stop
+    seen_body.receive # drain (GET carries no body)
+
+    # Over the cap the response-body rule is skipped: the body reaches the client byte-exact,
+    # with the ORIGINAL Content-Length (no re-frame) and "SECRET" NOT rewritten to "[HIDDEN]".
+    response.should contain("Content-Length: #{big.bytesize}")
+    response.should_not contain("[HIDDEN]")
+    response.bytesize.should be >= big.bytesize # whole body forwarded, not truncated
+  end
+
+  it "leaves a request body over MAX_REWRITE_BODY byte-exact (rule no-ops, no unbounded buffer)" do
+    seen_body = Channel(String).new(1)
+    done = Channel(Nil).new(1)
+    origin_port = start_body_origin("ok", seen_body)
+
+    sink = RecordingSink.new(done)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink, rewriter: BodyRewriter.new)
+    proxy.start
+
+    cap = Gori::Proxy::ClientConn::MAX_REWRITE_BODY
+    body = "ping" + ("x" * (cap + 1 - 4)) # one byte past the cap; "ping" → "PONG!" would match
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    client << "POST /submit HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\nContent-Length: #{body.bytesize}\r\n\r\n"
+    client << body
+    client.flush
+    client.gets_to_end
+    client.close
+
+    done.receive
+    proxy.stop
+
+    # The origin received the body byte-exact (full length, "ping" NOT rewritten to "PONG!") —
+    # the rule was skipped rather than buffering the whole oversized upload to rewrite it.
+    got = seen_body.receive
+    got.bytesize.should eq(body.bytesize)
+    got.starts_with?("ping").should be_true
+    got.should_not contain("PONG!")
+  end
+
   it "holds a request via the interceptor and forwards an edited version" do
     seen = Channel(String).new(1)
     done = Channel(Nil).new(1)

--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -76,6 +76,41 @@ describe Gori::Tui::HistoryView do
     end
   end
 
+  it "re-fetches the preview of a still-pending flow after its response lands" do
+    # The refresh_preview cache guard skips the per-frame get_flow ONLY for a Complete,
+    # non-streaming flow (whose bytes are immutable). A pending flow must keep refreshing
+    # so the preview picks up the response once it arrives — a guard keyed on the wrong
+    # state would freeze the pane on "(empty)".
+    prev = Gori::Settings.history_preview
+    begin
+      Gori::Settings.history_preview = true
+      tmp_store do |store|
+        id = add_flow(store, "GET", "/pending") # no response yet → Pending
+        view = HistoryView.new
+        view.reload(store)
+        view.refresh_preview(store) # caches the pending detail (no RESPONSE body)
+
+        backend = MemoryBackend.new(100, 30)
+        view.render_list(Screen.new(backend), Rect.new(0, 0, 100, 30))
+        before = (0...30).map { |y| backend.row(y) }.join("\n")
+        before.should contain("(empty)") # RESPONSE side empty while pending
+        before.should_not contain("200")
+
+        store.update_response(Gori::Store::CapturedResponse.new(
+          flow_id: id, status: 200, head: "HTTP/1.1 200 OK\r\n\r\nhi".to_slice,
+          body: "hi".to_slice, content_type: "text/plain"))
+        view.refresh_preview(store) # NOT skipped: cached detail was pending → re-fetch
+
+        backend2 = MemoryBackend.new(100, 30)
+        view.render_list(Screen.new(backend2), Rect.new(0, 0, 100, 30))
+        after = (0...30).map { |y| backend2.row(y) }.join("\n")
+        after.should contain("200") # RESPONSE now shows the landed response
+      end
+    ensure
+      Gori::Settings.history_preview = prev
+    end
+  end
+
   it "loads flows newest-first with the newest selected (follow)" do
     tmp_store do |store|
       add_flow(store, "GET", "/a", 200)

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -177,8 +177,10 @@ module Gori::Proxy
       # Match&Replace (request body): a body rule can't stream — it must buffer the
       # whole body to rewrite it and re-frame the head (Content-Length). Only pay this
       # when a request-body rule is live AND there's a body to rewrite; the common path
-      # (no body rule) falls straight through to zero-buffer streaming below (P6).
-      if (rw = @rewriter) && rw.rewrites_request_body? && !req_framing.none?
+      # (no body rule) falls straight through to zero-buffer streaming below (P6). A body
+      # whose declared length exceeds MAX_REWRITE_BODY is left byte-exact (see the constant)
+      # so a huge upload can't grow the proxy heap while a rule is on.
+      if (rw = @rewriter) && rewrite_request_body?(rw, req_framing, req_len)
         return forward_request_rewriting_body(rw, req, sent_req, sent_head, host, port,
           scheme, created_at, started, req_framing, req_len)
       end
@@ -392,9 +394,10 @@ module Gori::Proxy
       # Match&Replace (response body): buffer + rewrite a bounded (Length/chunked),
       # non-streaming response when a response-body rule is live. SSE / close-delimited
       # / 101-upgrade bodies would buffer forever, so they fall through to streaming and
-      # the body rule no-ops on them (matching the intercept-hold exclusions above).
-      if (rw = @rewriter) && rw.rewrites_response_body? &&
-         (resp_framing.length? || resp_framing.chunked?) && !sse?(resp) && resp.status != 101
+      # the body rule no-ops on them (matching the intercept-hold exclusions above). A body
+      # whose declared length exceeds MAX_REWRITE_BODY is likewise left byte-exact (see the
+      # constant) so one huge download can't grow the proxy heap while a rule is on.
+      if (rw = @rewriter) && rewrite_response_body?(rw, resp, resp_framing, resp_len)
         return forward_response_rewriting_body(rw, upstream, req, sent_req, flow_id, host, port,
           scheme, resp, sent_resp_head, resp_framing, resp_len, ttfb, started)
       end
@@ -632,7 +635,10 @@ module Gori::Proxy
       # tee into a discard sink, not a second IO::Memory — the body is already buffered in
       # `buf`; a throwaway IO::Memory would hold the whole response a second time.
       resp_complete = Codec::Body.stream(upstream, buf, resp_framing, resp_len, Codec::DiscardIO.new, copy_buf)
-      body = resp_framing.none? ? nil : buf.to_slice.dup
+      # `buf` is filled once and never written again, and build_message copies head+body into
+      # a fresh buffer, so `buf.to_slice` is a stable view — no defensive dup (which would hold
+      # the whole body a second time). Mirrors the non-hold M&R path above.
+      body = resp_framing.none? ? nil : buf.to_slice
       # Match&Replace (response body) BEFORE the human sees it, like the head. A body rule
       # re-frames the head to Content-Length; `resp` (status/version/Connection) is
       # untouched by that, so keep it as the origin's framing/keep-alive truth.
@@ -887,6 +893,40 @@ module Gori::Proxy
         i += 1
       end
       nil
+    end
+
+    # Ceiling on a body Match&Replace will buffer to rewrite. A body rule can't stream —
+    # it must hold the whole entity to gsub + re-frame (Content-Length), and rewriting
+    # allocates a few more full copies (dechunk, String round-trip, gsub). Left uncapped,
+    # one large download/upload with a body rule live would grow the proxy heap without
+    # bound (a per-connection OOM). Above this size the rule no-ops and the body is
+    # forwarded byte-exact, exactly as it already does for SSE / compressed / 101 bodies —
+    # correctness costs nothing but the rule not applying to a body too big to safely hold.
+    # Only gates KNOWN-length (Content-Length) bodies; a chunked body has no declared size
+    # to check here and still buffers (bounded only by the peer) — capping that streams a
+    # follow-up.
+    MAX_REWRITE_BODY = 16 * 1024 * 1024 # 16 MiB
+
+    # Whether a body of this framing/declared-length is small enough to buffer + rewrite.
+    # Chunked/unknown-length has no size to gate on, so it isn't blocked here.
+    private def rewritable_body_size?(framing : Codec::BodyFraming, len : Int64) : Bool
+      !framing.length? || len <= MAX_REWRITE_BODY
+    end
+
+    # Whether the response-body Match&Replace path applies: a body rule is live, the body is
+    # bounded (Length/chunked, not SSE / close-delimited / 101), and small enough to buffer.
+    # Extracted from handle_response so the dispatch stays flat (it just tests + branches).
+    private def rewrite_response_body?(rw : HeadRewriter, resp : Codec::RawResponse,
+                                       framing : Codec::BodyFraming, len : Int64) : Bool
+      rw.rewrites_response_body? &&
+        (framing.length? || framing.chunked?) && !sse?(resp) && resp.status != 101 &&
+        rewritable_body_size?(framing, len)
+    end
+
+    # Whether the request-body Match&Replace path applies: a body rule is live, there IS a
+    # body, and it's small enough to buffer. Extracted from handle_request (see above).
+    private def rewrite_request_body?(rw : HeadRewriter, framing : Codec::BodyFraming, len : Int64) : Bool
+      rw.rewrites_request_body? && !framing.none? && rewritable_body_size?(framing, len)
     end
 
     # Apply a body Match&Replace to a buffered wire body and return {head, forward_body}.

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -1501,9 +1501,14 @@ module Gori
                   batch_reply = op.reply
                   inserted = [] of {Int64, Bool}
                   op.pairs.each do |req, resp|
-                    id, _req_fts = insert_one(c, req)
+                    id, req_fts = insert_one(c, req)
                     has_resp = !resp.nil?
                     if r = resp
+                      # Hand update_one the request FTS text we just computed so its memo
+                      # lookup HITS instead of reading the row back (a per-entry SELECT +
+                      # up-to-64KiB body re-materialization on every imported pair with a
+                      # response). delete-on-read in update_one keeps the memo from growing.
+                      remember_req_fts(id, req_fts)
                       update_one(c, Store::CapturedResponse.new(
                         flow_id: id, status: r.status, head: r.head,
                         body: r.body, reason: r.reason,

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -110,6 +110,12 @@ module Gori::Tui
       @marker_spans = [] of {Int32, Int32}
       @marker_regions_rev = -1
       @marker_regions_cache = [] of {Int32, Int32, Int32}
+      # The chain under the cursor, cached on {editor revision, cursor} — render_chain_pane
+      # reads it every frame the pane is visible, so a stationary cursor mustn't re-join +
+      # re-scan the whole template buffer each frame (mirrors marker_spans).
+      @chain_rev = -1
+      @chain_cursor = -1
+      @chain_cache = nil.as(String?)
       # The CHAIN sub-pane: a visible editor for the Convert chain of the §…§ marker under
       # the TEMPLATE cursor (transform applied to each payload on send). @chain_focused =
       # editing it; @chain_marker_cursor remembers which marker to commit back to.
@@ -564,6 +570,19 @@ module Gori::Tui
         @marker_spans = Fuzz::Template.marked_spans(@editor.text)
       end
       @marker_spans
+    end
+
+    # The chain (`¦…`) of the marker under the cursor, or nil (not in a marker) / "" (marker,
+    # no chain). Cached on {editor revision, cursor} so a stationary cursor doesn't re-join +
+    # re-scan the whole template buffer every render frame the CHAIN pane is visible.
+    private def chain_under_cursor : String?
+      cur = @editor.cursor_offset
+      if @editor.edits != @chain_rev || cur != @chain_cursor
+        @chain_rev = @editor.edits
+        @chain_cursor = cur
+        @chain_cache = Fuzz::Template.chain_at(@editor.text, cur)
+      end
+      @chain_cache
     end
 
     # {open, sep, close} regions cached on the editor revision — the template tint runs it
@@ -1355,7 +1374,7 @@ module Gori::Tui
         @chain_pane.render(screen, rect, true, "CHAIN · #{marker_label}", CHAIN_PLACEHOLDER)
         return
       end
-      chain = Fuzz::Template.chain_at(@editor.text, @editor.cursor_offset)
+      chain = chain_under_cursor
       Frame.card(screen, rect, chain ? "CHAIN · #{marker_label}" : "CHAIN", bg: Theme.bg, border: Frame.pane_border(false))
       inner = rect.inset(1, 1)
       w = {inner.w, 1}.max

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -55,7 +55,8 @@ module Gori::Tui
       @selected = 0
       @scroll = 0
       @follow = true
-      @filter_dirty = false # a filtered view needs a coalesced reload after draining
+      @filter_dirty = false                       # a filtered view needs a coalesced reload after draining
+      @last_filter_flush = nil.as(Time::Instant?) # debounce clock for flush_filter (nil ⇒ first flush is immediate)
       @query = ""
       @qcx = 0
       @preedit = ""
@@ -96,6 +97,11 @@ module Gori::Tui
       # settings:layout History Req/Res preview (list page bottom pane) — separate from full detail.
       @preview_detail = nil.as(Store::FlowDetail?)
       @preview_id = nil.as(Int64?)
+      # Split preview lines, computed once per (re)fetched @preview_detail — NOT per frame.
+      # A ≤64 KiB body scrub+split+array is wasteful to redo every render tick while the
+      # selected flow is unchanged (which is every captured flow under live capture).
+      @preview_req_lines = nil.as(Array(String)?)
+      @preview_res_lines = nil.as(Array(String)?)
       @preview_scroll_req = 0
       @preview_scroll_res = 0
       @preview_focus = :list # :list | :req | :res
@@ -118,14 +124,31 @@ module Gori::Tui
       if @preview_id != id
         @preview_scroll_req = 0
         @preview_scroll_res = 0
+      elsif (d = @preview_detail) && d.row.state.complete? && d.row.status != 101 && d.h2_conn_id.nil?
+        # Same flow, already cached, and its captured bytes are immutable (Complete,
+        # non-streaming) — a data_version poke from OTHER flows committing has nothing
+        # to pick up here. Skip the SQLite round-trip + body re-split every render tick
+        # (mirrors refresh_detail's guard). A pending / 101 / h2 flow still re-fetches.
+        return
       end
-      @preview_detail = store.get_flow(id, body_max: PREVIEW_BODY_CAP + 1)
+      detail = store.get_flow(id, body_max: PREVIEW_BODY_CAP + 1)
+      @preview_detail = detail
       @preview_id = id
+      # Split the (bounded) preview text once, here — render reads the cached arrays.
+      if detail
+        @preview_req_lines = preview_text_lines(detail.request_head, detail.request_body)
+        @preview_res_lines = preview_text_lines(detail.response_head, detail.response_body)
+      else
+        @preview_req_lines = nil
+        @preview_res_lines = nil
+      end
     end
 
     def clear_preview : Nil
       @preview_detail = nil
       @preview_id = nil
+      @preview_req_lines = nil
+      @preview_res_lines = nil
       @preview_scroll_req = 0
       @preview_scroll_res = 0
     end
@@ -253,10 +276,28 @@ module Gori::Tui
       newest_first? ? 0 : @rows.size - 1
     end
 
+    # Minimum spacing between live-capture filter reloads. A filtered / Scope-lens list
+    # can't update incrementally, so every captured flow flags @filter_dirty and would
+    # otherwise re-run the FULL-table search + reverse (up to PAGE rows) on each drain
+    # tick — ~20×/sec under sustained capture, and a Scope lens alone puts every session
+    # in this state. Coalescing to this cadence drops the frequency ~10-40× with no
+    # correctness loss (@filter_dirty just accumulates until the window elapses). The
+    # FIRST dirtying still reloads immediately (last-flush is nil), so the view stays live.
+    FILTER_FLUSH_INTERVAL = 250.milliseconds
+
     # Apply any filtered-view staleness accumulated during a drain cycle in ONE
-    # reload (vs reloading per flow event — a search+reverse of up to PAGE rows).
-    def flush_filter(store : Store) : Nil
-      reload(store) if @filter_dirty
+    # reload (vs reloading per flow event — a search+reverse of up to PAGE rows),
+    # debounced to FILTER_FLUSH_INTERVAL so a busy capture can't thrash the search.
+    # Returns true if it actually reloaded (so the caller can mark the frame dirty).
+    def flush_filter(store : Store) : Bool
+      return false unless @filter_dirty
+      now = Time.instant
+      if (last = @last_filter_flush) && now - last < FILTER_FLUSH_INTERVAL
+        return false
+      end
+      @last_filter_flush = now
+      reload(store)
+      true
     end
 
     def on_event(event : Store::FlowEvent, store : Store) : Nil
@@ -1075,9 +1116,9 @@ module Gori::Tui
         # Vertical hairline between Req and Res; top cell sits on the horizontal seam as ┬.
         screen.cell(body.x + half, rect.y, '┬', border)
         (0...body.h).each { |i| screen.cell(body.x + half, body.y + i, '│', border) }
-        render_preview_side(screen, left, "REQUEST", detail.request_head, detail.request_body,
+        render_preview_side(screen, left, "REQUEST", @preview_req_lines,
           @preview_scroll_req, active: focused && @preview_focus == :req)
-        render_preview_side(screen, right, "RESPONSE", detail.response_head, detail.response_body,
+        render_preview_side(screen, right, "RESPONSE", @preview_res_lines,
           @preview_scroll_res, active: focused && @preview_focus == :res)
       else
         # Stack Req above Res; reserve one row for a tee-joined mid seam when height allows.
@@ -1087,25 +1128,25 @@ module Gori::Tui
           top = Rect.new(body.x, body.y, body.w, half_h)
           bot = Rect.new(body.x, mid_y + 1, body.w, body.h - half_h - 1)
           Frame.inner_divider(screen, rect, mid_y, border: border)
-          render_preview_side(screen, top, "REQUEST", detail.request_head, detail.request_body,
+          render_preview_side(screen, top, "REQUEST", @preview_req_lines,
             @preview_scroll_req, active: focused && @preview_focus == :req)
-          render_preview_side(screen, bot, "RESPONSE", detail.response_head, detail.response_body,
+          render_preview_side(screen, bot, "RESPONSE", @preview_res_lines,
             @preview_scroll_res, active: focused && @preview_focus == :res) if bot.h > 0
         else
-          render_preview_side(screen, body, "REQUEST", detail.request_head, detail.request_body,
+          render_preview_side(screen, body, "REQUEST", @preview_req_lines,
             @preview_scroll_req, active: focused && @preview_focus == :req)
         end
       end
     end
 
     private def render_preview_side(screen : Screen, rect : Rect, title : String,
-                                    head : Bytes?, body : Bytes?, scroll : Int32, *, active : Bool) : Nil
+                                    lines : Array(String)?, scroll : Int32, *, active : Bool) : Nil
       return if rect.empty?
       bg = active ? Theme.selection_dim : Theme.bg
       screen.fill(rect, bg) if active
       label = active ? " #{title} ▎" : " #{title} "
       screen.text(rect.x + 1, rect.y, label, active ? Theme.accent : Theme.muted, bg, attr: Attribute::Bold)
-      lines = preview_text_lines(head, body)
+      lines ||= ["(empty)"]
       content_y = rect.y + 1
       content_h = {rect.bottom - content_y, 0}.max
       return if content_h <= 0

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -57,13 +57,22 @@ module Gori::Tui
       @detail_win_edit_rev = -1        # @editor.edits the preview was built at (-1 = built from the pristine held bytes)
       @detail_xscroll = 0              # horizontal scroll offset for the read-only held-item preview
       @detail_scroll = 0               # vertical scroll offset (lines) for the read-only preview
+      @reload_rev = -1                 # Interceptor#revision the queue snapshot was last taken at (-1 ⇒ never)
     end
 
-    # Fresh snapshot (cheap; called on enter AND every frame via the 50ms loop).
+    # Fresh snapshot (called on enter AND every frame via the 50ms loop). Gated on the
+    # Interceptor's lock-free revision counter: every mutation that changes what this
+    # method reads — a hold/forward/drop/clear, or an enable/direction/filter change —
+    # bumps it, so an unchanged counter means the queue snapshot + @enabled/@direction
+    # are still current. Skipping then avoids a per-frame mutex lock + Array alloc +
+    # linear re-anchor scan on the common idle frame (spinner tick, clock, unrelated key).
     # Re-anchors selection by item id (not index) so forward/drop of an earlier
     # queue entry does not silently move the highlight onto a different hold.
     # If the edited item vanished (forwarded/dropped/released), drop edit mode.
     def reload(interceptor : Interceptor) : Nil
+      rev = interceptor.revision
+      return if rev == @reload_rev
+      @reload_rev = rev
       prev_id = @items[@selected]?.try(&.id)
       @items = interceptor.pending
       @selected =

--- a/src/gori/tui/replay_view.cr
+++ b/src/gori/tui/replay_view.cr
@@ -147,6 +147,14 @@ module Gori::Tui
       @mark_transform = false
       @marker_regions_rev = -1
       @marker_regions_cache = [] of {Int32, Int32, Int32}
+      # §…§ spans + the chain under the cursor, cached on the editor revision (marked_spans)
+      # and on {revision, cursor} (chain_at) — both re-join the whole buffer, so an unchanged
+      # MARK/CHAIN pane shouldn't recompute them every frame (mirrors marker_regions).
+      @marker_spans_rev = -1
+      @marker_spans_cache = [] of {Int32, Int32}
+      @chain_rev = -1
+      @chain_cursor = -1
+      @chain_cache = nil.as(String?)
       # The CHAIN sub-pane (MARK mode): a visible editor for the chain of the §…§ marker
       # under the request cursor. @chain_focused = editing it (split enlarges + keys route
       # there); @chain_marker_cursor remembers which marker to write back to on commit.
@@ -2238,7 +2246,7 @@ module Gori::Tui
         @chain_pane.render(screen, rect, true, "CHAIN · #{marker_label}", CHAIN_PLACEHOLDER)
         return
       end
-      chain = Fuzz::Template.chain_at(@editor.text, @editor.cursor_offset)
+      chain = chain_under_cursor
       Frame.card(screen, rect, chain ? "CHAIN · #{marker_label}" : "CHAIN", bg: Theme.bg, border: pane_border(false))
       inner = rect.inset(1, 1)
       w = {inner.w, 1}.max
@@ -2253,10 +2261,32 @@ module Gori::Tui
 
     # "§N" label for the marker under the cursor (1-based), or "§" when not in one.
     private def marker_label : String
-      spans = Fuzz::Template.marked_spans(@editor.text)
       cur = @editor.cursor_offset
-      idx = spans.index { |(a, b)| a <= cur && cur <= b }
+      idx = marker_spans.index { |(a, b)| a <= cur && cur <= b }
       idx ? "§#{idx + 1}" : "§"
+    end
+
+    # §…§ char-offset spans for the current request buffer, cached on the editor revision —
+    # marker_label + the CHAIN title both read it, so an unchanged buffer joins/scans once.
+    private def marker_spans : Array({Int32, Int32})
+      if @editor.edits != @marker_spans_rev
+        @marker_spans_rev = @editor.edits
+        @marker_spans_cache = Fuzz::Template.marked_spans(@editor.text)
+      end
+      @marker_spans_cache
+    end
+
+    # The chain (`¦…`) of the marker under the cursor, or nil (not in a marker) / "" (marker,
+    # no chain). Cached on {editor revision, cursor} so a stationary cursor doesn't re-join +
+    # re-scan the whole buffer every render frame the CHAIN pane is visible.
+    private def chain_under_cursor : String?
+      cur = @editor.cursor_offset
+      if @editor.edits != @chain_rev || cur != @chain_cursor
+        @chain_rev = @editor.edits
+        @chain_cursor = cur
+        @chain_cache = Fuzz::Template.chain_at(@editor.text, cur)
+      end
+      @chain_cache
     end
 
     # The DECODED split sub-pane: the editable payload (SAML XML / GraphQL query+vars),

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -524,7 +524,7 @@ module Gori::Tui
       # accumulated @filter_dirty makes it catch up on the first drain after History
       # becomes active, and on_enter reloads on entry — so the list is never shown stale.
       # (Mirrors apply_external_change, which already only reloads the active tab.)
-      history_controller.view.flush_filter(@session.store) if @active_tab == :history
+      drained = true if @active_tab == :history && history_controller.view.flush_filter(@session.store)
       drained
     end
 


### PR DESCRIPTION
Performance pass driven by a multi-agent audit of the render loop, SQLite polling, proxy data-plane, large-list views, and (a lighter second pass) the compute engines and CLI/one-shot paths. The core event loop was already dirty-gated and well-optimized; the real wins were **live-capture poll/render paths that redid full work with no change-detection**, plus the long-deferred unbounded Match&Replace body buffer.

## TUI — per-frame / per-tick waste under live capture
- **History preview pane**: `refresh_preview` re-fetched `get_flow` + re-split ~128 KiB of body text on *every render tick* even when the selection was unchanged (fires on every captured flow under live capture). Now guards the fetch (mirrors the already-guarded `refresh_detail`: skip when the cached detail is Complete/non-101/non-h2, so a pending→complete flow still refreshes) and memoizes the split preview lines.
- **Filtered / Scope-lens History**: `flush_filter` re-ran the full 1000-row search on *every drain tick* (~20×/s under capture; a Scope lens alone triggers it). Debounced to 250 ms (first flush stays immediate).
- **Intercept view**: gated the per-frame pending-queue snapshot (mutex + Array alloc + re-anchor scan) on `Interceptor#revision`.
- **Replay/Fuzzer CHAIN pane**: cache `marked_spans` (Replay parity with Fuzzer) and `chain_at` on `{editor revision, cursor}` instead of re-joining the whole buffer every frame.

## Proxy — cap the Match&Replace body buffer
- A body rule must buffer the whole entity to rewrite + re-frame; left uncapped, one large download/upload with a body rule live grew the proxy heap without bound. A **known-length** body over `MAX_REWRITE_BODY` (16 MiB) now skips the rewrite and streams byte-exact — the rule no-ops, exactly as it already does for SSE/compressed/101 bodies. (Chunked/unknown-length still buffers — a noted follow-up.)
- Dropped a redundant whole-body `.dup` in `handle_held_response` (`buf` is stable; `build_message` copies).
- Extracted `rewrite_request_body?`/`rewrite_response_body?` predicates, lowering `handle_request`/`handle_response` cyclomatic complexity *below* main.

## Store — import FTS readback
- The batched import writer discarded the request FTS text `insert_one` already returns, so `update_one` re-`SELECT`ed the head + up to 64 KiB of the request body *back out of the same transaction* for every response-bearing entry. On a multi-thousand-entry HAR/OAS import that's thousands of wasted lookups + body re-materializations. Now feeds the in-hand value into the memo (behavior-identical FTS text).

## Tests
- +2 proxy specs: over-cap request/response bodies forwarded byte-exact (rule skipped).
- +1 history spec: a pending preview refreshes once its response lands.
- +1 import spec: `body:` FTS search finds a response-bearing HAR import (no FTS-after-import coverage existed before).
- Full suite green when run in a clean environment.

## Deferred (with rationale)
- Chunked (unknown-length) M&R body cap — needs a spill-forward IO; separate PR with protocol tests.
- Sitemap rebuild / unfiltered-History reload / Complete-h2 detail watermarks — each would regress cross-process live-sync or the shared h2 connection frame-log; low reward.
- `gori run prism` BLOB load for response-less flows; `matcher.cr` per-response spec re-split — both low impact, one-shot/sub-profile-noise.