### PR TITLE
feat(ca): import an externally-created root CA (CLI + palette)

### DIFF
--- a/docs/content/getting-started/configuration.md
+++ b/docs/content/getting-started/configuration.md
@@ -95,6 +95,18 @@ gori ca regenerate --yes      # replace the root CA (scripts/CI; voids prior tru
 
 You can also rotate the CA from the TUI command palette (**Regenerate CA certificate**), or interactively with `gori ca regenerate` (type `regenerate` to confirm). Both paths are confirm-gated because rotation invalidates all previously issued trust; any already-running gori keeps the old CA until restarted.
 
+### Bring your own CA
+
+To reuse one CA across a team or machines, generate a root externally and import it (cert **and** key — gori signs leaf certificates with the key; clients trust only the cert):
+
+```bash
+openssl ecparam -genkey -name prime256v1 -out root.key.pem
+openssl req -x509 -new -key root.key.pem -days 3650 -subj "/CN=my ca" -out root.crt.pem
+gori ca import --cert root.crt.pem --key root.key.pem --yes
+```
+
+The same action is available from the palette (**Import CA certificate**). gori checks the key matches the cert and that it is a CA before adopting it. Distribute only `root.crt.pem` to trust; keep `root.key.pem` secret. See [`gori ca import`](/reference/cli/#gori-ca-import).
+
 The palette's **Open browser** action launches an installed browser with an isolated profile that already trusts the CA and routes through the proxy — the fastest path on a fresh machine (see the [Quick Start](/getting-started/quick-start/)).
 
 ## Full Reference

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -14,7 +14,7 @@ gori [command] [options]
 | `tui` | Start the proxy and terminal UI (default) |
 | `run` | Non-interactive suite over a project |
 | `mcp` | Model Context Protocol stdio server |
-| `ca` | Print the root CA path / PEM, or regenerate the CA |
+| `ca` | Print the root CA path / PEM, or regenerate / import the CA |
 | `settings` | Show or edit `settings.json` |
 | `wizard` | Interactive first-run setup |
 | `tutorial` | Guided TUI tour (navigation, palette, space menu, edit mode) |
@@ -246,6 +246,7 @@ gori ca --pem
 gori ca --ca-dir=DIR
 gori ca regenerate
 gori ca regenerate --yes
+gori ca import --cert root.crt.pem --key root.key.pem --yes
 ```
 
 Prints the path to gori's root CA certificate (creates it on first use). Use this when trusting the CA in a browser or system store, or when pointing a client at `--cacert`.
@@ -265,6 +266,29 @@ Replaces the on-disk root CA with a freshly minted one. **Destructive** — ever
 | `--ca-dir=DIR` | CA directory to regenerate |
 
 Without `--yes`, the command prompts on a tty and expects you to type `regenerate` (same word as the TUI confirm). Scripts and CI should pass `--yes`. On success the new cert path is printed to stdout.
+
+### gori ca import
+
+Adopts an **externally-created** root CA (a certificate + matching private key, both PEM) in place of gori's own — for sharing one CA across a team or machines, or reusing an organization CA. gori needs both files because it signs per-host leaf certificates on the fly; clients trust only the certificate. **Destructive**, like `regenerate` — it replaces the on-disk root and voids prior trust.
+
+| Option | Description |
+|--------|-------------|
+| `--cert FILE` | Root CA certificate PEM to adopt (required) |
+| `--key FILE` | Matching private key PEM (required) |
+| `--yes`, `-y` | Skip the interactive confirm (required when stdin is not a tty) |
+| `--ca-dir=DIR` | CA directory to install into |
+
+The pair is validated before anything is written: the key must match the certificate and the certificate must be a CA (`basicConstraints CA:TRUE`) — a bad pair aborts without touching the current CA. An expired or not-yet-valid certificate imports with a warning. Confirm by typing `import` on a tty, or pass `--yes`. The same action is available from the TUI palette (**Import CA certificate**).
+
+Generate a root with OpenSSL, then import it:
+
+```bash
+openssl ecparam -genkey -name prime256v1 -out root.key.pem
+openssl req -x509 -new -key root.key.pem -days 3650 -subj "/CN=my ca" -out root.crt.pem
+gori ca import --cert root.crt.pem --key root.key.pem --yes
+```
+
+Trust only `root.crt.pem` in your clients — never distribute the private key.
 
 ## gori settings
 

--- a/spec/proxy/tls/cert_authority_import_spec.cr
+++ b/spec/proxy/tls/cert_authority_import_spec.cr
@@ -1,0 +1,144 @@
+require "../../spec_helper"
+require "socket"
+require "file_utils"
+
+private def with_ca_dir(&)
+  dir = File.tempname("gori-ca")
+  begin
+    yield dir
+  ensure
+    FileUtils.rm_rf(dir) if Dir.exists?(dir)
+  end
+end
+
+# Build an "externally-created" root CA (or, with is_ca: false, a leaf) and write
+# its cert + key to PEM files under `dir`, returning their paths — the input a
+# `gori ca import` caller supplies.
+private def external_pair(dir : String, cn : String = "external ca") : {String, String}
+  Dir.mkdir_p(dir)
+  cert, key = Gori::Proxy::Tls::CertBuilder.build_root(cn)
+  cert_path = File.join(dir, "#{cn.gsub(' ', '_')}.crt.pem")
+  key_path = File.join(dir, "#{cn.gsub(' ', '_')}.key.pem")
+  cert.write_pem(cert_path)
+  key.write_pem(key_path)
+  {cert_path, key_path}
+end
+
+describe "Gori::Proxy::Tls::CertAuthority#import!" do
+  it "adopts an external root in place — persisted, replaces the old root, key 0600" do
+    with_ca_dir do |dir|
+      ca = Gori::Proxy::Tls::CertAuthority.load_or_create(dir)
+      auto_pem = ca.ca_cert_pem
+      ca.context_for("a.test") # warm the per-host leaf cache
+
+      with_ca_dir do |src|
+        cert_path, key_path = external_pair(src)
+        imported_pem = File.read(cert_path)
+
+        ca.import!(cert_path, key_path).should be_nil # no time warning for a fresh root
+
+        ca.ca_cert_pem.should_not eq(auto_pem) # the auto-generated root is gone
+        ca.ca_cert_pem.should eq(imported_pem) # ...replaced by the imported one
+        # The swap is persisted: a reload reads the IMPORTED root off disk.
+        Gori::Proxy::Tls::CertAuthority.load_or_create(dir).ca_cert_pem.should eq(imported_pem)
+        File.info(File.join(dir, "root.key.pem")).permissions.value.should eq(0o600)
+      end
+    end
+  end
+
+  it "mints a leaf a client verifies under the IMPORTED root over a real handshake" do
+    with_ca_dir do |dir|
+      ca = Gori::Proxy::Tls::CertAuthority.load_or_create(dir)
+      with_ca_dir do |src|
+        cert_path, key_path = external_pair(src)
+        ca.import!(cert_path, key_path)
+      end
+      server_ctx = ca.context_for("localhost")
+
+      # The client trusts ONLY the imported root, read fresh off disk.
+      client_ctx = OpenSSL::SSL::Context::Client.new
+      ca_cert = Gori::Proxy::Tls::Cert.read_pem(File.join(dir, "root.crt.pem"))
+      store = LibSSL.ssl_ctx_get_cert_store(client_ctx.to_unsafe)
+      LibCrypto.x509_store_add_cert(store, ca_cert.handle).should eq(1)
+
+      tcp_server = TCPServer.new("127.0.0.1", 0)
+      port = tcp_server.local_address.port
+      result = Channel(String).new
+
+      spawn do
+        conn = tcp_server.accept
+        ssl = OpenSSL::SSL::Socket::Server.new(conn, server_ctx, sync_close: true)
+        ssl.puts(ssl.gets)
+        ssl.flush
+        ssl.close
+      rescue ex
+        result.send("server-error: #{ex.message}")
+      end
+
+      spawn do
+        tcp = TCPSocket.new("127.0.0.1", port)
+        ssl = OpenSSL::SSL::Socket::Client.new(tcp, context: client_ctx, sync_close: true, hostname: "localhost")
+        ssl.puts("ping")
+        ssl.flush
+        echo = ssl.gets
+        ssl.close
+        result.send(echo || "nil")
+      rescue ex
+        result.send("client-error: #{ex.message}")
+      end
+
+      result.receive.should eq("ping") # handshake + echo succeeded under the imported root
+      tcp_server.close
+    end
+  end
+
+  it "rejects a private key that does not match the certificate (CA untouched)" do
+    with_ca_dir do |dir|
+      ca = Gori::Proxy::Tls::CertAuthority.load_or_create(dir)
+      before = ca.ca_cert_pem
+      with_ca_dir do |src|
+        cert_path, _ = external_pair(src, "cert one")
+        _, other_key = external_pair(src, "cert two") # a DIFFERENT pair's key
+
+        expect_raises(Gori::Error, /does not match/) do
+          ca.import!(cert_path, other_key)
+        end
+      end
+      ca.ca_cert_pem.should eq(before) # the working CA is left intact
+    end
+  end
+
+  it "rejects a certificate that is not a CA (basicConstraints CA:FALSE)" do
+    with_ca_dir do |dir|
+      ca = Gori::Proxy::Tls::CertAuthority.load_or_create(dir)
+      before = ca.ca_cert_pem
+      with_ca_dir do |src|
+        # A leaf cert (CA:FALSE) plus its own key: a matching pair, but not a CA.
+        root_cert, root_key = Gori::Proxy::Tls::CertBuilder.build_root("signing root")
+        leaf_cert, leaf_key = Gori::Proxy::Tls::CertBuilder.build_leaf("leaf.example", root_cert, root_key)
+        cert_path = File.join(src, "leaf.crt.pem")
+        key_path = File.join(src, "leaf.key.pem")
+        Dir.mkdir_p(src)
+        leaf_cert.write_pem(cert_path)
+        leaf_key.write_pem(key_path)
+
+        expect_raises(Gori::Error, /not a CA/) do
+          ca.import!(cert_path, key_path)
+        end
+      end
+      ca.ca_cert_pem.should eq(before)
+    end
+  end
+
+  it "validate_pem_pair accepts a good pair and rejects a bad one without writing" do
+    with_ca_dir do |src|
+      cert_path, key_path = external_pair(src, "good ca")
+      Gori::Proxy::Tls::CertAuthority.validate_pem_pair(cert_path, key_path).should be_nil
+
+      _, other_key = external_pair(src, "other ca")
+      expect_raises(Gori::Error, /does not match/) do
+        Gori::Proxy::Tls::CertAuthority.validate_pem_pair(cert_path, other_key)
+      end
+    end
+  end
+end

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -329,6 +329,8 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def regenerate_ca : Nil; end
 
+  def import_ca : Nil; end
+
   def open_browser_picker : Nil; end
 
   def comparer_pick(slot : Symbol) : Nil; end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -644,6 +644,10 @@ private class FakeContext < ExecContext
     @calls << :regenerate_ca
   end
 
+  def import_ca : Nil
+    @calls << :import_ca
+  end
+
   def open_browser_picker : Nil
     @calls << :open_browser_picker
   end

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -170,11 +170,14 @@ module Gori
     # `gori ca` is the CA utility surface:
     # - bare / flags  → print path (default) or PEM (`--pem`); creates CA on first use
     # - `regenerate`  → replace the root CA (destructive; needs --yes or an interactive confirm)
+    # - `import`      → adopt an externally-created root CA (cert + key PEM); destructive
     private def self.run_ca(args : Array(String)) : Nil
       if (first = args[0]?) && !first.starts_with?("-")
         case first
         when "regenerate"
           run_ca_regenerate(args[1..])
+        when "import"
+          run_ca_import(args[1..])
         else
           STDERR.puts "unknown ca subcommand: #{first}"
           print_ca_usage(STDERR)
@@ -188,9 +191,11 @@ module Gori
     private def self.print_ca_usage(io : IO) : Nil
       io.puts "Usage: gori ca [options]"
       io.puts "       gori ca regenerate [--yes] [--ca-dir=DIR]"
+      io.puts "       gori ca import --cert FILE --key FILE [--yes] [--ca-dir=DIR]"
       io.puts ""
-      io.puts "Print the root CA certificate path (default), create it on first use, or"
-      io.puts "regenerate it (invalidates existing client trust)."
+      io.puts "Print the root CA certificate path (default), create it on first use,"
+      io.puts "regenerate it, or import an externally-created root CA (both invalidate"
+      io.puts "existing client trust)."
       io.puts ""
       io.puts "Options:"
       io.puts "  --ca-dir=DIR   CA directory (default ~/.gori/ca or $GORI_HOME/ca)"
@@ -200,6 +205,12 @@ module Gori
       io.puts "Regenerate options:"
       io.puts "  --yes, -y      Skip the interactive confirm (required when stdin is not a tty)"
       io.puts "  --ca-dir=DIR   CA directory to regenerate"
+      io.puts ""
+      io.puts "Import options:"
+      io.puts "  --cert FILE    Root CA certificate PEM to adopt (required)"
+      io.puts "  --key FILE     Matching private key PEM (required)"
+      io.puts "  --yes, -y      Skip the interactive confirm (required when stdin is not a tty)"
+      io.puts "  --ca-dir=DIR   CA directory to install into"
     end
 
     # Path / PEM print path (the default `gori ca` action).
@@ -273,6 +284,69 @@ module Gori
       STDERR.flush
       line = (STDIN.gets || "").strip
       abort "gori ca regenerate: cancelled" unless line == "regenerate"
+    end
+
+    # Adopt an externally-created root CA (cert + key PEM) in place of gori's own.
+    # Destructive like regenerate — it overwrites the on-disk root and voids prior
+    # client trust — so it shares the confirm gate. Validation (key↔cert match, CA
+    # flag) happens inside import! BEFORE anything is written, so a bad pair aborts
+    # without touching the current CA.
+    private def self.run_ca_import(args : Array(String)) : Nil
+      ca_dir = Paths.default_ca_dir
+      cert_path = nil.as(String?)
+      key_path = nil.as(String?)
+      yes = false
+      parser = OptionParser.new do |p|
+        p.banner = "Usage: gori ca import --cert FILE --key FILE [--yes] [--ca-dir=DIR]"
+        p.on("--cert FILE", "Root CA certificate PEM to adopt") { |v| cert_path = v }
+        p.on("--key FILE", "Matching private key PEM") { |v| key_path = v }
+        p.on("--ca-dir=DIR", "Directory for the root CA") { |v| ca_dir = v }
+        p.on("-y", "--yes", "Skip the interactive confirm") { yes = true }
+        p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+        p.invalid_option { |flag| abort "unknown option: #{flag}\n#{p}" }
+        p.missing_option { |flag| abort "missing value for #{flag}" }
+      end
+      parser.parse(args)
+
+      cert = cert_path
+      key = key_path
+      abort "gori ca import: --cert and --key are both required\n#{parser}" unless cert && key
+
+      # Validate the pair up front so a bad --cert/--key aborts BEFORE we touch (or,
+      # in a fresh dir, auto-create) any CA — the user asked for THEIR cert, not a
+      # surprise gori-generated one.
+      begin
+        Proxy::Tls::CertAuthority.validate_pem_pair(cert, key)
+      rescue ex
+        abort "gori ca import: #{ex.message}"
+      end
+
+      confirm_ca_import!(ca_dir) unless yes
+
+      begin
+        Paths.ensure_dirs
+        ca = Proxy::Tls::CertAuthority.load_or_create(ca_dir)
+        warning = ca.import!(cert, key)
+        puts ca.ca_cert_path
+        STDERR.puts "gori ca: WARNING — #{warning}" if warning
+        STDERR.puts "gori ca: imported — re-trust the imported cert; restart any running gori"
+      rescue ex
+        abort "gori ca import: could not install the CA in #{ca_dir}: #{ex.message}"
+      end
+    end
+
+    # Interactive gate for import (skipped when --yes). Same non-tty rule as regenerate.
+    private def self.confirm_ca_import!(ca_dir : String) : Nil
+      unless STDIN.tty?
+        abort "gori ca import: stdin is not a terminal; re-run with --yes to confirm"
+      end
+      STDERR.puts "Replace the root CA in #{ca_dir} with the imported cert/key?"
+      STDERR.puts "This invalidates existing client trust."
+      STDERR.puts "Running gori instances keep the old CA until restarted."
+      STDERR.print "Type 'import' to confirm: "
+      STDERR.flush
+      line = (STDIN.gets || "").strip
+      abort "gori ca import: cancelled" unless line == "import"
     end
 
     # Handler for `gori run` (the non-interactive CLI mode). Named run_run to match

--- a/src/gori/proxy/tls/cert_authority.cr
+++ b/src/gori/proxy/tls/cert_authority.cr
@@ -82,13 +82,60 @@ module Gori::Proxy::Tls
     # key+identity, so any client that trusted the OLD CA must re-trust it.
     def regenerate!(common_name : String = DEFAULT_CN) : Nil
       cert, key = CertBuilder.build_root(common_name)
+      install!(cert, key)
+    end
+
+    # Adopt an externally-created root CA (`gori ca import`): read the cert + key
+    # PEMs, verify they are a usable CA pair, then swap them in over the current
+    # root exactly like `regenerate!`. Returns a human warning (expired / not-yet-
+    # valid) if the cert is time-invalid but otherwise usable, else nil. Raises
+    # Gori::Error (leaving the current CA untouched) if a PEM won't parse or the
+    # pair is unusable — validation runs BEFORE anything is written.
+    def import!(cert_path : String, key_path : String) : String?
+      cert = Cert.read_pem(cert_path)
+      key = KeyPair.read_pem(key_path)
+      warning = CertAuthority.validate_ca_pair!(cert, key)
+      install!(cert, key)
+      warning
+    end
+
+    # Read + validate an external CA pair WITHOUT installing it. Lets a caller (the
+    # CLI) reject a bad import BEFORE creating or loading any CA, so a failed import
+    # never leaves a spurious auto-generated CA behind. Same checks as import!.
+    def self.validate_pem_pair(cert_path : String, key_path : String) : String?
+      validate_ca_pair!(Cert.read_pem(cert_path), KeyPair.read_pem(key_path))
+    end
+
+    # Reject an imported pair that can't serve as a signing root; return a soft
+    # warning for a time-invalid-but-usable cert. A mismatched key would make every
+    # minted leaf fail verification, and a non-CA cert (basicConstraints CA:FALSE)
+    # makes clients reject any leaf it signs — both are hard errors we catch up front.
+    # A class method: it inspects the two handles via the FFI, no instance state.
+    def self.validate_ca_pair!(cert : Cert, key : KeyPair) : String?
+      if LibCrypto.x509_check_private_key(cert.handle, key.handle) != 1
+        raise Gori::Error.new("private key does not match the certificate")
+      end
+      if LibCrypto.x509_check_ca(cert.handle) == 0
+        raise Gori::Error.new("certificate is not a CA (basicConstraints CA:TRUE required)")
+      end
+      if LibCrypto.x509_cmp_time(LibCrypto.x509_getm_not_after(cert.handle), Pointer(Void).null) < 0
+        return "certificate is expired"
+      end
+      if LibCrypto.x509_cmp_time(LibCrypto.x509_getm_not_before(cert.handle), Pointer(Void).null) > 0
+        return "certificate is not valid yet"
+      end
+      nil
+    end
+
+    # Persist a cert/key pair over the on-disk root and swap it live. Shared by
+    # regenerate! and import!. Overwriting a WORKING CA means a half-written pair
+    # (disk full, a permission error) must not corrupt it: stage both PEMs in full
+    # to temp files, then rename into place (atomic on POSIX; both temps already
+    # exist, so the on-disk cert/key never disagree past the gap between renames).
+    private def install!(cert : Cert, key : KeyPair) : Nil
       dir = File.dirname(@ca_cert_path)
       Gori::Paths.ensure_dir(dir) # parity with load_or_create: the dir may have been removed at runtime
       key_path = File.join(dir, CA_KEY_FILE)
-      # Regenerating overwrites a WORKING CA, so a half-written cert/key pair (disk
-      # full, a permission error) must not corrupt it: stage both PEMs in full to
-      # temp files, then rename into place (atomic on POSIX; both temps already
-      # exist, so the on-disk cert/key never disagree past the gap between renames).
       cert_tmp = "#{@ca_cert_path}.tmp"
       key_tmp = "#{key_path}.tmp"
       begin

--- a/src/gori/proxy/tls/ffi.cr
+++ b/src/gori/proxy/tls/ffi.cr
@@ -30,6 +30,17 @@ lib LibCrypto
   fun x509_store_add_cert = X509_STORE_add_cert(store : X509_STORE, x : X509) : Int
   fun x509_up_ref = X509_up_ref(x : X509) : Int
 
+  # Validating an externally-supplied root CA before we adopt it (gori ca import):
+  # the private key must match the certificate's public key (else every minted leaf
+  # fails verification), and the certificate must actually be a CA (basicConstraints
+  # CA:TRUE, else clients reject any leaf it signs during path validation).
+  fun x509_check_private_key = X509_check_private_key(x : X509, pkey : EVP_PKEY) : Int
+  fun x509_check_ca = X509_check_ca(x : X509) : Int
+  # Compare an ASN1_TIME to now (t == NULL): <0 if the cert time is in the past,
+  # >0 if in the future, 0 on parse error. Used to warn (not block) on an imported
+  # CA that is expired or not-yet-valid.
+  fun x509_cmp_time = X509_cmp_time(s : ASN1_TIME, t : Void*) : Int
+
   # SubjectPublicKeyInfo (for the browser's --ignore-certificate-errors-spki-list
   # pin): grab the SPKI structure, then DER-encode it (pp == NULL returns the
   # length so we can size the buffer first).

--- a/src/gori/tui/ca_import_overlay.cr
+++ b/src/gori/tui/ca_import_overlay.cr
@@ -1,0 +1,158 @@
+require "./screen"
+require "./theme"
+require "./frame"
+require "./text_field"
+require "./path_complete"
+
+module Gori::Tui
+  # Full-area popup collecting an externally-created root CA's certificate + private
+  # key PEM paths for `gori ca import` (palette → "Import CA certificate"). Two path
+  # fields with an inline PathComplete dropdown, modeled on FuzzSetOverlay's
+  # field+dropdown pattern but far simpler (no payload grammar).
+  #
+  # Surfaces used by the Runner: handle_key returns :submit when the user commits
+  # (↵ on the Key row), :cancel on esc, :stay otherwise. On :submit the Runner reads
+  # cert_path / key_path and runs the destructive-CA confirm before calling
+  # CertAuthority#import!. set_preedit routes composing (IME) text to the focused row.
+  class CAImportOverlay
+    ROWS = [:cert, :key]
+
+    def initialize
+      @sel = 0 # row cursor: 0 = Certificate, 1 = Private key
+      @fields = {
+        :cert => TextField.new(""),
+        :key  => TextField.new(""),
+      }
+      @path_complete = PathComplete.new
+    end
+
+    def cert_path : String
+      @fields[:cert].value.strip
+    end
+
+    def key_path : String
+      @fields[:key].value.strip
+    end
+
+    private def focused : Symbol
+      ROWS[@sel]? || :cert
+    end
+
+    private def on_last_row? : Bool
+      @sel == ROWS.size - 1
+    end
+
+    # --- input ---------------------------------------------------------------
+    # :submit when the user commits (↵ on the last row), :cancel on esc, else :stay.
+    def handle_key(ev : Termisu::Event::Key) : Symbol
+      key = ev.key
+
+      # The path dropdown owns navigation keys while it's open.
+      if @path_complete.open?
+        case
+        when key.tab?, key.enter?   then return accept_path
+        when key.back_tab?, key.up? then @path_complete.move(-1); return :stay
+        when key.down?              then @path_complete.move(1); return :stay
+        when key.escape?            then @path_complete.close; return :stay
+        else # printables fall through → edit + refilter
+        end
+      end
+
+      return :cancel if key.escape?
+      if key.tab? || key.down?
+        move_row(1); return :stay
+      elsif key.back_tab? || key.up?
+        move_row(-1); return :stay
+      elsif key.enter?
+        return :submit if on_last_row?
+        move_row(1); return :stay
+      end
+
+      @fields[focused].handle_edit_key(ev)
+      @path_complete.refresh(@fields[focused].value) # keep the dropdown in lockstep
+      :stay
+    end
+
+    # Switching rows closes the dropdown (it reopens as the user types), so opening
+    # the overlay doesn't immediately bury the form under a directory listing.
+    private def move_row(d : Int32) : Nil
+      @sel = (@sel + d).clamp(0, ROWS.size - 1)
+      @path_complete.close
+    end
+
+    private def accept_path : Symbol
+      res = @path_complete.accept
+      return :stay unless res
+      path, is_dir = res
+      @fields[focused].set(path)
+      is_dir ? @path_complete.refresh(path) : @path_complete.close
+      :stay
+    end
+
+    def set_preedit(text : String) : Nil
+      @fields[focused]?.try(&.set_preedit(text))
+    end
+
+    def move(d : Int32) : Nil
+      move_row(d)
+    end
+
+    # --- rendering -----------------------------------------------------------
+    LABEL_W = 14 # value column offset (widest label "Private key" + padding)
+
+    def overlay_box(area : Rect) : Rect?
+      w = {area.w - 6, 72}.min
+      h = {area.h - 4, 11}.min
+      return nil if w < 40 || h < 8
+      Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
+    end
+
+    def render(screen : Screen, area : Rect) : Nil
+      box = overlay_box(area)
+      unless box
+        screen.text(area.x + 1, area.y, "CA import needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        return
+      end
+      Frame.card(screen, box, "IMPORT CA · cert + key PEM", bg: Theme.bg, border: Theme.border_focus)
+      screen.text(box.x + 2, box.y + 1,
+        "Adopt an external root CA. Both files must be a matching pair.",
+        Theme.muted, Theme.bg, width: box.w - 4)
+      render_field(screen, box, :cert, "Certificate", 0)
+      render_field(screen, box, :key, "Private key", 1)
+      screen.text(box.x + 2, box.bottom - 2,
+        "type to complete · ↹/↵ pick · ⇥/↑↓ field · ↵ submits · esc cancels",
+        Theme.muted, Theme.bg, width: box.w - 4)
+      render_dropdown(screen, box)
+    end
+
+    private def render_field(screen : Screen, box : Rect, f : Symbol, label : String, i : Int32) : Nil
+      y = box.y + 3 + i
+      foc = @sel == i
+      bg = foc ? Theme.accent_bg : Theme.bg
+      screen.fill(Rect.new(box.x + 1, y, box.w - 2, 1), bg) if foc
+      screen.text(box.x + 2, y, label, foc ? Theme.text_bright : Theme.muted, bg)
+      vx = box.x + 2 + LABEL_W
+      vw = {box.right - 2 - vx, 1}.max
+      @fields[f].render(screen, vx, y, vw, foc, foc ? Theme.text_bright : Theme.text, bg)
+    end
+
+    private def render_dropdown(screen : Screen, box : Rect) : Nil
+      return unless @path_complete.open?
+      vx = box.x + 2 + LABEL_W
+      y = box.y + 3 + @sel + 1
+      @path_complete.render(screen, vx, y, box.inset(1, 1))
+    end
+
+    # --- mouse ---------------------------------------------------------------
+    # Focus the field row under a click. Returns true when the click was inside the box.
+    def handle_click(box : Rect, mx : Int32, my : Int32) : Bool
+      return false unless box.contains?(mx, my)
+      i = my - (box.y + 3)
+      if 0 <= i < ROWS.size
+        @sel = i
+        @path_complete.close
+      end
+      true
+    end
+  end
+end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -55,6 +55,7 @@ require "./path_complete"
 require "./fuzz_set_overlay"
 require "./fuzz_advanced_overlay"
 require "./scope_rule_overlay"
+require "./ca_import_overlay"
 require "../paths"
 require "../browser"
 require "../external_editor"
@@ -84,7 +85,7 @@ module Gori::Tui
       # Miner is hidden by default). Settings is loaded (cli.cr) before Runner.new.
       vis = Chrome.visible_tabs(Settings.tab_prefs).map(&.first)
       @active_tab = vis.includes?(:project) ? :project : vis.first
-      @overlay = :none # :none | :palette | :detail | :rules | :finding_new | :confirm | :browser | :choice | :comparer_pick | :replay_subtab | :links | :finding_pick | :note_pick | :settings | :tabs | :hosts | :env | :hotkeys | :notifications | :mine_config | :fuzz_set | :fuzz_advanced | :scope_rule
+      @overlay = :none # :none | :palette | :detail | :rules | :finding_new | :confirm | :browser | :choice | :comparer_pick | :replay_subtab | :links | :finding_pick | :note_pick | :settings | :tabs | :hosts | :env | :hotkeys | :notifications | :mine_config | :fuzz_set | :fuzz_advanced | :scope_rule | :ca_import
       # The "space" action menu (helix-style leader popup, bottom-right). Orthogonal
       # to @overlay so it floats over WHATEVER is underneath (the History list, an
       # open detail …) without disturbing that state; the scope is captured at open.
@@ -188,6 +189,9 @@ module Gori::Tui
       @fuzz_advanced_overlay = nil.as(FuzzAdvancedOverlay?)
       # Project SCOPE add/edit popup (a/e on the rule list). Built fresh each open.
       @scope_rule_overlay = nil.as(ScopeRuleOverlay?)
+      # The "Import CA certificate" popup (palette → ca.import): collects the cert +
+      # key PEM paths, then hands off to the destructive-CA confirm. @overlay is :ca_import.
+      @ca_import_overlay = nil.as(CAImportOverlay?)
       @theme_restore = nil.as(String?) # theme to revert to if the theme settings are cancelled (live preview)
       @focus = :menu                   # default focus on the tab bar (TABS) on project entry; :body for content
       @toast = nil.as(String?)         # transient action feedback; nil → show key hints
@@ -613,6 +617,7 @@ module Gori::Tui
       when :fuzz_set      then @fuzz_set_overlay.try(&.set_preedit(text))
       when :fuzz_advanced then @fuzz_advanced_overlay.try(&.set_preedit(text))
       when :scope_rule    then @scope_rule_overlay.try(&.set_preedit(text))
+      when :ca_import     then @ca_import_overlay.try(&.set_preedit(text))
       when :none          then apply_preedit_body(text)
       end
     end
@@ -693,6 +698,7 @@ module Gori::Tui
       return handle_fuzz_set_key(ev) if @overlay == :fuzz_set
       return handle_fuzz_advanced_key(ev) if @overlay == :fuzz_advanced
       return handle_scope_rule_key(ev) if @overlay == :scope_rule
+      return handle_ca_import_key(ev) if @overlay == :ca_import
       # Text-entry modes own Tab (complete) + Esc within themselves — let them run
       # before the global focus ring claims Tab.
       if @active_tab == :history && @overlay == :none && @focus == :body && history_controller.view.querying?
@@ -936,7 +942,7 @@ module Gori::Tui
     # The overlays that fully capture input (a centered card); :detail and :none do not.
     private def modal_overlay? : Bool
       case @overlay
-      when :palette, :rules, :finding_new, :confirm, :browser, :choice, :comparer_pick, :replay_subtab, :links, :finding_pick, :note_pick, :settings, :tabs, :hotkeys, :notifications, :mine_config, :fuzz_set, :fuzz_advanced, :scope_rule then true
+      when :palette, :rules, :finding_new, :confirm, :browser, :choice, :comparer_pick, :replay_subtab, :links, :finding_pick, :note_pick, :settings, :tabs, :hotkeys, :notifications, :mine_config, :fuzz_set, :fuzz_advanced, :scope_rule, :ca_import then true
       else                                                                                                                                                                                                                                       false
       end
     end
@@ -1037,6 +1043,7 @@ module Gori::Tui
       when :fuzz_set      then click_fuzz_set(area, mx, my)
       when :fuzz_advanced then click_fuzz_advanced(area, mx, my)
       when :scope_rule    then click_scope_rule(area, mx, my)
+      when :ca_import     then click_ca_import(area, mx, my)
         # :finding_new is a text form — keyboard-only in Phase 1 (cursor placement is Phase 2)
       end
     end
@@ -1102,6 +1109,13 @@ module Gori::Tui
       ov = @fuzz_advanced_overlay || return
       box = ov.overlay_box(area)
       return apply_close_fuzz_advanced(ov) if box.nil? || dismiss_zone?(box, mx, my)
+      ov.handle_click(box, mx, my)
+    end
+
+    private def click_ca_import(area : Rect, mx : Int32, my : Int32) : Nil
+      ov = @ca_import_overlay || return
+      box = ov.overlay_box(area)
+      return close_ca_import if box.nil? || dismiss_zone?(box, mx, my) # click-away = cancel (destructive: never auto-submit)
       ov.handle_click(box, mx, my)
     end
 
@@ -1265,6 +1279,7 @@ module Gori::Tui
       when :fuzz_set      then @fuzz_set_overlay.try(&.move(step))
       when :fuzz_advanced then @fuzz_advanced_overlay.try(&.move(step))
       when :scope_rule    then @scope_rule_overlay.try(&.move(step))
+      when :ca_import     then @ca_import_overlay.try(&.move(step))
       end
     end
 
@@ -1328,6 +1343,50 @@ module Gori::Tui
       case ov.handle_key(ev)
       when :cancel then close_scope_rule
       when :commit then commit_scope_rule_overlay(ov)
+      end
+    end
+
+    # CA import popup: collect cert + key paths, then hand off to the destructive
+    # confirm on :submit. esc cancels without touching the CA.
+    private def handle_ca_import_key(ev : Termisu::Event::Key) : Nil
+      ov = @ca_import_overlay || return
+      case ov.handle_key(ev)
+      when :cancel then close_ca_import
+      when :submit then submit_ca_import(ov)
+      end
+    end
+
+    private def close_ca_import : Nil
+      @overlay = :none
+      @ca_import_overlay = nil
+    end
+
+    # Validate the two paths are filled, close the overlay, then run the same danger
+    # confirm as regenerate before adopting the imported CA. import! does the heavy
+    # validation (pair match, CA flag) and leaves the current CA untouched on failure.
+    private def submit_ca_import(ov : CAImportOverlay) : Nil
+      cert = ov.cert_path
+      key = ov.key_path
+      if cert.empty? || key.empty?
+        @toast = "CA import: both certificate and key paths are required"
+        return
+      end
+      path = @session.ca.ca_cert_path
+      close_ca_import
+      confirm("IMPORT CA",
+        "Replace the current root CA with the imported one?\n\n" \
+        "The old CA becomes untrusted — re-trust the imported\n" \
+        "certificate in your clients (gori ca / path copied).\n" \
+        "New connections use it immediately.",
+        confirm_label: "import", danger: true) do
+        begin
+          warning = @session.ca.import!(cert, key)
+          Clipboard.copy(path)
+          note = warning ? " (warning: #{warning})" : ""
+          @toast = "root CA imported#{note} — re-trust it (path copied): #{path}"
+        rescue ex
+          @toast = "CA import failed: #{ex.message}"
+        end
       end
     end
 
@@ -2873,6 +2932,7 @@ module Gori::Tui
       @fuzz_set_overlay.try(&.render(screen, layout.body)) if @overlay == :fuzz_set
       @fuzz_advanced_overlay.try(&.render(screen, layout.body)) if @overlay == :fuzz_advanced
       @scope_rule_overlay.try(&.render(screen, layout.body)) if @overlay == :scope_rule
+      @ca_import_overlay.try(&.render(screen, layout.body)) if @overlay == :ca_import
       # The space menu + bottom prompts float over everything else (drawn last).
       render_prompts(screen, layout)
 
@@ -2972,6 +3032,7 @@ module Gori::Tui
       when :fuzz_set      then "PAYLOAD SET"
       when :fuzz_advanced then "ADVANCED"
       when :scope_rule    then "SCOPE RULE"
+      when :ca_import     then "IMPORT CA"
       else
         case @focus
         when :menu    then "TABS"
@@ -3018,6 +3079,7 @@ module Gori::Tui
       when :fuzz_set      then "↑/↓/⇥ field · ←/→ type/caret · ↵ new value/next · esc applies & closes"
       when :fuzz_advanced then "↑/↓/⇥ field · ←/→ edit · ␣ toggle · ↵ next · esc applies & closes"
       when :scope_rule    then "↑/↓ field · ←/→ kind·type · type pattern · ↵ save · esc cancel"
+      when :ca_import     then "type to complete · ↹/↵ pick · ⇥/↑↓ field · ↵ submits · esc cancels"
       when :detail        then history_controller.body_hint(:body)
       else
         # Focus on the tab bar: ←/→ pick the tab, Tab/↵ drop into the body.
@@ -4538,6 +4600,14 @@ module Gori::Tui
           @toast = "CA regeneration failed: #{ex.message}"
         end
       end
+    end
+
+    # Open the "Import CA certificate" popup (palette → ca.import): collect the
+    # cert + key PEM paths. The destructive swap happens later, on submit, behind
+    # the same confirm as regenerate (see submit_ca_import).
+    def import_ca : Nil
+      @ca_import_overlay = CAImportOverlay.new
+      @overlay = :ca_import
     end
 
     # --- browser (open a pre-trusted system browser) ---

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -232,6 +232,7 @@ module Gori
       # certificate authority
       abstract def export_ca : Nil
       abstract def regenerate_ca : Nil # mint a fresh root CA (after a confirm)
+      abstract def import_ca : Nil     # adopt an externally-created root CA (cert + key PEM)
 
       # browser: open a system browser pre-trusting gori's CA + routed via the proxy
       abstract def open_browser_picker : Nil

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -60,6 +60,12 @@ module Gori
         "ca.regenerate", "Regenerate CA certificate", "Replace gori's root CA with a fresh one (old trust is invalidated)",
         Verb::Scope::Global) { |ctx| ctx.regenerate_ca; nil }
 
+      # Palette-only (destructive — gated behind a confirm in the Runner): adopt an
+      # externally-created root CA (cert + key PEM) instead of gori's own.
+      r.register Verb::Definition.new(
+        "ca.import", "Import CA certificate", "Use an externally-created root CA (cert + key) instead of gori's own",
+        Verb::Scope::Global) { |ctx| ctx.import_ca; nil }
+
       # Palette-only (no chord — used rarely): open a system browser pre-trusting
       # gori's CA and routed through the proxy, like Burp/Caido's embedded browser.
       r.register Verb::Definition.new(


### PR DESCRIPTION
## Summary

Adds **`gori ca import`** (CLI) and the palette verb **"Import CA certificate"** (TUI) so users can adopt their **own** root CA (openssl-generated or an organization CA) instead of gori's auto-generated one — sharing one trusted CA across a team or machines, persisting trust across reinstalls, or using a policy-managed key. Standard in mitmproxy / Burp / Caido.

A root CA is a **certificate + private key**, and gori needs *both* (it signs per-host leaf certs with the key on the fly). Clients trust only the certificate — the private key never leaves gori.

## Usage

```bash
openssl ecparam -genkey -name prime256v1 -out root.key.pem
openssl req -x509 -new -key root.key.pem -days 3650 -subj "/CN=my ca" -out root.crt.pem
gori ca import --cert root.crt.pem --key root.key.pem --yes
```

Or from the TUI: palette → **Import CA certificate** → enter cert + key paths (with path completion) → danger confirm → live swap (no restart).

## What's inside

- **`CertAuthority`**: extracted `regenerate!`'s atomic persist + live-swap into `install!`; added `import!` and class-level `validate_ca_pair!` / `validate_pem_pair`. Key↔cert mismatch and non-CA (`basicConstraints CA:FALSE`) **hard-fail**; expired / not-yet-valid **warn** but import. RSA roots supported.
- **FFI**: `X509_check_private_key`, `X509_check_ca`, `X509_cmp_time`.
- **CLI**: `ca import` subcommand, confirm-gated (type `import`, or `--yes`). Pre-validates **before** `load_or_create`, so a bad import never leaves a spurious auto-generated CA behind.
- **TUI**: new `CAImportOverlay` (two path fields, reuses `TextField` + `PathComplete`); submit runs the same danger confirm as regenerate, then `import!` + copies the path.
- **Docs**: `reference/cli.md` + `getting-started/configuration.md`.

## Testing

- New `spec/proxy/tls/cert_authority_import_spec.cr` (5 examples): happy import + **real TLS handshake under the imported root**, mismatched-key reject, non-CA reject, `validate_pem_pair`. `import_ca` test doubles added (verb-registry compile gate).
- CLI e2e: EC **and** RSA roots imported; mismatched-key / non-CA / missing-arg rejected; no spurious CA on a failed fresh-dir import.
- TUI e2e (tmux): palette → overlay → fill → confirm → on-disk `root.crt.pem` becomes the imported cert; esc cancels cleanly.