### PR TITLE
feat(tui): tab-bar ⋯ dropdown for settings-hidden tabs

### DIFF
--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -29,6 +29,10 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def cycle_tab(delta : Int32) : Nil; end
 
+  def menu_left : Nil; end
+
+  def menu_right : Nil; end
+
   def move_selection(delta : Int32) : Nil; end
 
   def open_detail : Nil; end

--- a/spec/tui/chrome_tabs_spec.cr
+++ b/spec/tui/chrome_tabs_spec.cr
@@ -83,6 +83,55 @@ describe "Chrome.visible_tabs" do
   end
 end
 
+describe "Chrome.hidden_tabs" do
+  it "returns the tabs hidden from the bar (Miner by default) on empty prefs" do
+    hid = Chrome.hidden_tabs([] of {String, Bool}).map(&.first)
+    hid.should eq([:miner]) # only the default-hidden tab
+  end
+
+  it "excludes the active tab even when its stored visibility is false (it's force-shown)" do
+    # Miner is hidden by default but active → force-shown on the bar, so it must NOT
+    # also appear in the dropdown list.
+    Chrome.hidden_tabs([] of {String, Bool}, force: :miner).map(&.first).should_not contain(:miner)
+  end
+
+  it "lists a user-hidden tab and preserves catalog order" do
+    prefs = [{"replay", false}, {"convert", false}]
+    hid = Chrome.hidden_tabs(prefs).map(&.first)
+    hid.includes?(:replay).should be_true
+    hid.includes?(:convert).should be_true
+    hid.includes?(:miner).should be_true                                 # still default-hidden
+    hid.index(:replay).not_nil!.should be < hid.index(:convert).not_nil! # catalog order
+  end
+end
+
+describe "Chrome.more_button_rect" do
+  it "is nil when nothing is hidden" do
+    Chrome.more_button_rect(Rect.new(0, 0, 80, 1), hidden_count: 0).should be_nil
+  end
+
+  it "reserves a right-anchored pill sized to the ⋯ label when tabs are hidden" do
+    rect = Rect.new(0, 0, 80, 1)
+    mb = Chrome.more_button_rect(rect, hidden_count: 2).not_nil!
+    mb.right.should eq(rect.right)                # flush to the right edge
+    mb.w.should eq(Chrome.more_label(2).size + 2) # padded pill
+  end
+
+  it "is nil on a row too narrow to host the button" do
+    Chrome.more_button_rect(Rect.new(0, 0, 4, 1), hidden_count: 3).should be_nil
+  end
+end
+
+describe "Chrome.menu_segments" do
+  it "keeps tab segments clear of the reserved ⋯ button region" do
+    rect = Rect.new(0, 0, 80, 1)
+    tabs = Chrome.visible_tabs([] of {String, Bool})
+    mb = Chrome.more_button_rect(rect, hidden_count: 1).not_nil!
+    segs = Chrome.menu_segments(rect, :project, tabs: tabs, hidden_count: 1)
+    segs.each { |(_, seg)| seg.right.should be <= mb.x } # no segment overlaps the button
+  end
+end
+
 describe "Chrome.scroll_start" do
   it "scrolls active_idx to the end when no prev_start is provided and it doesn't fit" do
     widths = [10, 10, 10, 10, 10]
@@ -104,4 +153,3 @@ describe "Chrome.scroll_start" do
     Chrome.scroll_start(widths, active_idx: 4, avail: 25, prev_start: 1).should eq(3)
   end
 end
-

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -60,6 +60,14 @@ private class FakeContext < ExecContext
     @calls << :cycle_tab
   end
 
+  def menu_left : Nil
+    @calls << :menu_left
+  end
+
+  def menu_right : Nil
+    @calls << :menu_right
+  end
+
   def move_selection(delta : Int32) : Nil
     @calls << :move
   end

--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -98,6 +98,31 @@ module Gori::Tui
       vis
     end
 
+    # The tabs NOT on the bar — hidden via settings:tabs (Miner by default) — for the
+    # far-right "more" dropdown. Mirrors visible_tabs' force logic in reverse: the
+    # active tab is force-SHOWN on the bar, so it's excluded here even when its stored
+    # visibility is false (it would otherwise appear both on the bar and in the list).
+    def self.hidden_tabs(prefs : Array({String, Bool}), force : Symbol? = nil) : Array({Symbol, String})
+      reconcile(prefs).reject { |(s, _, v)| v || s == force }.map { |(s, l, _)| {s, l} }
+    end
+
+    # The "more" affordance label — a ⋯ ellipsis plus the hidden-tab count, so the bar
+    # reads "there are N tabs tucked away here" at a glance.
+    def self.more_label(hidden_count : Int32) : String
+      "⋯ #{hidden_count}"
+    end
+
+    # The far-right "more" button's cell rect on the menu row, or nil when nothing is
+    # hidden (no button) or the row is too narrow to host it. Shared by render + the
+    # click hit-test so they can't drift.
+    def self.more_button_rect(rect : Rect, hidden_count : Int32) : Rect?
+      return nil if hidden_count <= 0 || rect.empty?
+      w = more_label(hidden_count).size + 2 # a padded pill, like a tab segment
+      x = rect.right - w
+      return nil if x < rect.x + 1 # no room without colliding with the ‹ overflow cell
+      Rect.new(x, rect.y, w, 1)
+    end
+
     def self.render_top_bar(screen : Screen, rect : Rect, *, project : String,
                             listen : String, time : String,
                             scope : String, rules : String = "", intercept : String = "",
@@ -187,10 +212,15 @@ module Gori::Tui
     # held-intercept count rides inline as a `(N)` badge.
     def self.render_menu(screen : Screen, rect : Rect, *, active_tab : Symbol, focused : Bool,
                          tabs : Array({Symbol, String}) = TABS,
-                         intercept_count : Int32 = 0) : Nil
+                         intercept_count : Int32 = 0, hidden_count : Int32 = 0,
+                         more_focused : Bool = false) : Nil
       return if rect.empty?
 
-      segs, start = menu_layout(rect, active_tab, tabs, intercept_count)
+      # Carve the rightmost cells out for the "more" dropdown button (when tabs are
+      # hidden) so the segment layout never packs a tab over it. A one-col gutter sits
+      # between the last tab and the button.
+      more = more_button_rect(rect, hidden_count)
+      segs, start = menu_layout(tabs_area(rect, hidden_count), active_tab, tabs, intercept_count)
       screen.cell(rect.x, rect.y, '‹', Theme.muted, Theme.bg) if start > 0 # earlier tabs hidden
       segs.each do |(sym, label, seg)|
         if sym == active_tab
@@ -202,6 +232,22 @@ module Gori::Tui
           screen.text(seg.x + 1, seg.y, label, Theme.muted, Theme.bg)
         end
       end
+
+      render_more_button(screen, more, hidden_count, more_focused) if more
+    end
+
+    # The far-right "more" pill — a gold pill when it holds focus (mirroring the active
+    # tab), else a muted label. `more_focused` is only ever true when the menu bar has
+    # focus AND the affordance (not a tab) is the current stop.
+    private def self.render_more_button(screen : Screen, seg : Rect, hidden_count : Int32, focused : Bool) : Nil
+      label = more_label(hidden_count)
+      if focused
+        bg = Theme.focus_gold
+        screen.fill(seg, bg)
+        screen.text(seg.x + 1, seg.y, label, Theme.ink_on(bg), bg, Attribute::Bold)
+      else
+        screen.text(seg.x + 1, seg.y, label, Theme.muted, Theme.bg)
+      end
     end
 
     # Pure: the visible tab segments under the menu strip — {symbol, cell rect} —
@@ -209,10 +255,19 @@ module Gori::Tui
     # can never drift from what was drawn. Coords are 0-based cells.
     def self.menu_segments(rect : Rect, active_tab : Symbol, *,
                            tabs : Array({Symbol, String}) = TABS,
-                           intercept_count : Int32 = 0) : Array({Symbol, Rect})
+                           intercept_count : Int32 = 0, hidden_count : Int32 = 0) : Array({Symbol, Rect})
       return [] of {Symbol, Rect} if rect.empty?
-      menu_layout(rect, active_tab, tabs, intercept_count)[0]
+      menu_layout(tabs_area(rect, hidden_count), active_tab, tabs, intercept_count)[0]
         .map { |(sym, _, seg)| {sym, seg} }
+    end
+
+    # The drawable region for tab segments: the menu row minus the far-right "more"
+    # button (plus a one-col gutter) when tabs are hidden. Shared by render_menu +
+    # menu_segments so the drawn segments and the click hit-test can never drift.
+    private def self.tabs_area(rect : Rect, hidden_count : Int32) : Rect
+      more = more_button_rect(rect, hidden_count)
+      return rect unless more
+      Rect.new(rect.x, rect.y, {more.x - 1 - rect.x, 0}.max, 1)
     end
 
     # The single source of menu-segment geometry: each visible tab's {symbol, label,

--- a/src/gori/tui/more_menu.cr
+++ b/src/gori/tui/more_menu.cr
@@ -1,0 +1,98 @@
+require "./screen"
+require "./theme"
+require "./frame"
+
+module Gori::Tui
+  # The tab-bar "more" dropdown: the tabs hidden via settings:tabs (Miner by default),
+  # listed in a small card that drops DOWN from the ⋯ affordance at the far right of the
+  # tab menu. Opening it selects the first row; ↵ switches to that tab — force-shown on
+  # the bar while active, exactly like the palette's "Go to …". Pure state + rendering,
+  # a twin of ChoicePicker; the Runner owns open/close/apply and the anchor geometry.
+  class MoreMenu
+    getter selected : Int32
+
+    def initialize(@items : Array({Symbol, String}))
+      @selected = 0
+      @scroll = 0
+    end
+
+    def empty? : Bool
+      @items.empty?
+    end
+
+    def move(delta : Int32) : Nil
+      return if @items.empty?
+      @selected = (@selected + delta).clamp(0, @items.size - 1)
+    end
+
+    def set_selected(idx : Int32) : Nil
+      return if @items.empty?
+      @selected = idx.clamp(0, @items.size - 1)
+    end
+
+    def selected_sym : Symbol?
+      @items[@selected]?.try(&.first)
+    end
+
+    # The dropdown card, right-aligned to the `anchor` (the ⋯ button) and dropping down
+    # from the top of `body` (the first row under the menu). Width fits the widest label;
+    # height fits the list (capped to the body, scrolling on a short terminal). nil when
+    # there's nothing to show or it can't fit.
+    def overlay_box(anchor : Rect, body : Rect) : Rect?
+      return nil if @items.empty? || body.empty?
+      label_w = @items.max_of { |(_, l)| l.size }
+      w = {label_w + 4, body.w}.min     # left border + ▎ + label + right border
+      h = {@items.size + 2, body.h}.min # top border + rows + bottom border
+      return nil if w < 8 || h < 3
+      right = {anchor.right, body.right}.min
+      x = {right - w, body.x}.max
+      Rect.new(x, body.y, w, h)
+    end
+
+    def render(screen : Screen, anchor : Rect, body : Rect) : Nil
+      box = overlay_box(anchor, body)
+      return unless box
+      Frame.card(screen, box, "TABS", border: Theme.border_focus)
+      rows = list_capacity(box)
+      ensure_visible(rows)
+      (0...rows).each do |i|
+        ci = @scroll + i
+        break if ci >= @items.size
+        _, label = @items[ci]
+        ry = box.y + 1 + i
+        active = ci == @selected
+        bg = active ? Theme.accent_bg : Theme.panel
+        screen.fill(Rect.new(box.x + 1, ry, box.w - 2, 1), bg)
+        screen.cell(box.x + 1, ry, active ? '▎' : ' ', Theme.accent, bg)
+        fg = active ? Theme.text_bright : Theme.text
+        screen.text(box.x + 3, ry, label, fg, bg, width: {box.w - 4, 0}.max)
+      end
+    end
+
+    # Row index under (mx,my), inverting render's windowed layout so a click maps to the
+    # same row that was drawn; nil outside the card interior.
+    def row_at(anchor : Rect, body : Rect, mx : Int32, my : Int32) : Int32?
+      box = overlay_box(anchor, body)
+      return nil unless box
+      rows = list_capacity(box)
+      i = my - (box.y + 1)
+      return nil if i < 0 || i >= rows
+      return nil if mx <= box.x || mx >= box.right - 1
+      ci = @scroll + i
+      ci < @items.size ? ci : nil
+    end
+
+    private def list_capacity(box : Rect) : Int32
+      {box.h - 2, @items.size}.min
+    end
+
+    # Keep the selection on-screen when the list is taller than the card (short
+    # terminals). Mirrors ChoicePicker#ensure_visible.
+    private def ensure_visible(rows : Int32) : Nil
+      return if rows <= 0
+      @scroll = @selected if @selected < @scroll
+      @scroll = @selected - rows + 1 if @selected >= @scroll + rows
+      @scroll = @scroll.clamp(0, {@items.size - rows, 0}.max)
+    end
+  end
+end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -33,6 +33,7 @@ require "./rules_overlay"
 require "./confirm_dialog"
 require "./browser_picker"
 require "./choice_picker"
+require "./more_menu"
 require "./copy_picker"
 require "./flow_picker"
 require "./subtab_picker"
@@ -85,7 +86,7 @@ module Gori::Tui
       # Miner is hidden by default). Settings is loaded (cli.cr) before Runner.new.
       vis = Chrome.visible_tabs(Settings.tab_prefs).map(&.first)
       @active_tab = vis.includes?(:project) ? :project : vis.first
-      @overlay = :none # :none | :palette | :detail | :rules | :finding_new | :confirm | :browser | :choice | :comparer_pick | :replay_subtab | :links | :finding_pick | :note_pick | :settings | :tabs | :hosts | :env | :hotkeys | :notifications | :mine_config | :fuzz_set | :fuzz_advanced | :scope_rule | :ca_import
+      @overlay = :none # :none | :palette | :detail | :rules | :finding_new | :confirm | :browser | :choice | :tabs_more | :comparer_pick | :replay_subtab | :links | :finding_pick | :note_pick | :settings | :tabs | :hosts | :env | :hotkeys | :notifications | :mine_config | :fuzz_set | :fuzz_advanced | :scope_rule | :ca_import
       # The "space" action menu (helix-style leader popup, bottom-right). Orthogonal
       # to @overlay so it floats over WHATEVER is underneath (the History list, an
       # open detail …) without disturbing that state; the scope is captured at open.
@@ -143,6 +144,10 @@ module Gori::Tui
       @browser_picker = nil.as(BrowserPicker?)
       # The severity/status value picker (Findings detail → space); @overlay is :choice.
       @choice_picker = nil.as(ChoicePicker?)
+      # The tab-bar "more" dropdown (the ⋯ affordance → ↵/↓): lists the settings-hidden
+      # tabs (Miner by default). @overlay is :tabs_more while it's open; built fresh each
+      # time from the current hidden set.
+      @more_menu = nil.as(MoreMenu?)
       # The "copy as X" format picker (Replay/History detail → space Y). ORTHOGONAL to
       # @overlay (like @space_menu_open) so it floats over whatever's underneath — the
       # Replay body (@overlay :none) OR the History detail drill-in (@overlay :detail) —
@@ -194,6 +199,7 @@ module Gori::Tui
       @ca_import_overlay = nil.as(CAImportOverlay?)
       @theme_restore = nil.as(String?) # theme to revert to if the theme settings are cancelled (live preview)
       @focus = :menu                   # default focus on the tab bar (TABS) on project entry; :body for content
+      @menu_more = false               # tab-bar focus is on the far-right ⋯ "more" affordance (only meaningful when @focus == :menu)
       @toast = nil.as(String?)         # transient action feedback; nil → show key hints
       @outcome = :running              # :running | :quit | :back
       @quit_armed = false              # first ^D/^C arms quit; second confirms (avoids accidental exit)
@@ -683,6 +689,7 @@ module Gori::Tui
       return handle_confirm_key(ev) if @overlay == :confirm
       return handle_browser_key(ev) if @overlay == :browser
       return handle_choice_key(ev) if @overlay == :choice
+      return handle_more_menu_key(ev) if @overlay == :tabs_more
       return handle_flow_picker_key(ev) if @overlay == :comparer_pick
       return handle_subtab_picker_key(ev) if @overlay == :replay_subtab
       return handle_links_key(ev) if @overlay == :links
@@ -942,16 +949,22 @@ module Gori::Tui
     # The overlays that fully capture input (a centered card); :detail and :none do not.
     private def modal_overlay? : Bool
       case @overlay
-      when :palette, :rules, :finding_new, :confirm, :browser, :choice, :comparer_pick, :replay_subtab, :links, :finding_pick, :note_pick, :settings, :tabs, :hotkeys, :notifications, :mine_config, :fuzz_set, :fuzz_advanced, :scope_rule, :ca_import then true
-      else                                                                                                                                                                                                                                       false
+      when :palette, :rules, :finding_new, :confirm, :browser, :choice, :tabs_more, :comparer_pick, :replay_subtab, :links, :finding_pick, :note_pick, :settings, :tabs, :hotkeys, :notifications, :mine_config, :fuzz_set, :fuzz_advanced, :scope_rule, :ca_import then true
+      else                                                                                                                                                                                                                                                               false
       end
     end
 
     # Click the top tab bar: switch to the clicked tab and land focus on the bar
     # (TABS level) — clicking a tab selects the tab, it does not drill into the body.
     private def click_menu(rect : Rect, mx : Int32, my : Int32) : Nil
+      # The far-right ⋯ "more" affordance opens the hidden-tabs dropdown.
+      if (mb = Chrome.more_button_rect(rect, hidden_tab_count)) && mb.contains?(mx, my)
+        focus_pane(:menu) # land on the bar (clears any stale overlay / saves edits)
+        open_more_menu
+        return
+      end
       seg = Chrome.menu_segments(rect, @active_tab, tabs: effective_tabs,
-        intercept_count: @session.interceptor.pending_count).find { |(_, r)| r.contains?(mx, my) }
+        intercept_count: @session.interceptor.pending_count, hidden_count: hidden_tab_count).find { |(_, r)| r.contains?(mx, my) }
       if seg
         seg[0] == @active_tab ? focus_pane(:menu) : focus_tab(seg[0], focus: :menu)
       else
@@ -1027,6 +1040,7 @@ module Gori::Tui
       when :rules         then click_rules(area, mx, my)
       when :browser       then click_browser(area, mx, my)
       when :choice        then click_choice(area, mx, my)
+      when :tabs_more     then click_more_menu(layout, mx, my)
       when :comparer_pick then click_flow_picker(area, mx, my)
       when :replay_subtab then click_subtab_picker(area, mx, my)
       when :links         then click_links(area, mx, my)
@@ -1264,6 +1278,7 @@ module Gori::Tui
       when :rules         then @rules_overlay.select_move(step)
       when :browser       then @browser_picker.try(&.move(step))
       when :choice        then @choice_picker.try(&.move(step))
+      when :tabs_more     then @more_menu.try(&.move(step))
       when :comparer_pick then @flow_picker.try(&.move(step))
       when :replay_subtab then @subtab_picker.try(&.move(step))
       when :links         then @links_overlay.try(&.move(step))
@@ -2904,8 +2919,10 @@ module Gori::Tui
         unread: @notifications.unread, capturing: @session.capturing?,
         write_failures: @session.store.write_failures)
       Chrome.render_rule(screen, layout.rule)
-      Chrome.render_menu(screen, layout.menu, active_tab: @active_tab, focused: @focus == :menu,
-        tabs: effective_tabs, intercept_count: @session.interceptor.pending_count)
+      Chrome.render_menu(screen, layout.menu, active_tab: @active_tab,
+        focused: @focus == :menu && !@menu_more,
+        tabs: effective_tabs, intercept_count: @session.interceptor.pending_count,
+        hidden_count: hidden_tab_count, more_focused: @focus == :menu && @menu_more)
       render_body(screen, layout.body)
       Chrome.render_status(screen, layout.status, focus: focus_label, hints: format_status_message(@toast) || key_hints,
         insecure_upstream: @session.config.insecure_upstream?,
@@ -2917,6 +2934,7 @@ module Gori::Tui
       @confirm.try(&.render(screen, layout.body)) if @overlay == :confirm
       @browser_picker.try(&.render(screen, layout.body)) if @overlay == :browser
       @choice_picker.try(&.render(screen, layout.body)) if @overlay == :choice
+      @more_menu.try(&.render(screen, more_anchor_rect(layout), layout.body)) if @overlay == :tabs_more
       @flow_picker.try(&.render(screen, layout.body)) if @overlay == :comparer_pick
       @subtab_picker.try(&.render(screen, layout.body)) if @overlay == :replay_subtab
       @links_overlay.try(&.render(screen, layout.body)) if @overlay == :links
@@ -3007,7 +3025,7 @@ module Gori::Tui
     # always knows which region the keys drive: an open overlay wins, else the
     # tab bar (TABS) vs the content pane (BODY).
     private def focus_label : String
-      return "SPACE" if @space_menu_open                             # orthogonal to @overlay — floats over it
+      return "SPACE" if @space_menu_open                              # orthogonal to @overlay — floats over it
       return @copy_picker.try(&.title) || "COPY AS" if copy_as_shown? # ditto
       case @overlay
       when :palette       then "PALETTE"
@@ -3064,6 +3082,7 @@ module Gori::Tui
       when :confirm       then "←/→ choose · y confirm · n/esc cancel · ↵ select"
       when :browser       then "↑/↓ select · ↵ open · esc cancel"
       when :choice        then "↑/↓ select · ↵ set · key picks · esc cancel"
+      when :tabs_more     then "↑/↓ select · ↵ open tab · ←/esc close"
       when :comparer_pick then "type to filter · ↑/↓ select · ↵ choose · esc cancel"
       when :replay_subtab then "type to filter · ↑/↓ select · ↵ #{@subtab_picker.try(&.action) || "jump"} · esc cancel"
       when :links         then @links_overlay.try(&.adding?) ? "f/r/z/m pick type · esc back" : "↑/↓ · ↵/o open · a add · d remove · esc close"
@@ -3082,6 +3101,8 @@ module Gori::Tui
       when :ca_import     then "type to complete · ↹/↵ pick · ⇥/↑↓ field · ↵ submits · esc cancels"
       when :detail        then history_controller.body_hint(:body)
       else
+        # Focus on the far-right ⋯ "more" affordance: ↵/↓ expands the hidden-tabs list.
+        return "↵/↓ show hidden tabs · ← back · ^P cmds · q projects" if @focus == :menu && @menu_more
         # Focus on the tab bar: ←/→ pick the tab, Tab/↵ drop into the body.
         return "←/→ switch tab · ↹/↵ enter · 1-9 jump · ^P cmds · q projects · ^D quit" if @focus == :menu
         if @focus == :subtabs
@@ -3587,16 +3608,19 @@ module Gori::Tui
       convert_controller.commit if @active_tab == :convert && @focus == :body && pane != :body
       notes_controller.save_notes if @active_tab == :notes && @focus == :body && pane != :body
       @focus = pane
+      @menu_more = false # any focus change lands on a real tab, not the ⋯ affordance
       @overlay = :none
       view_focus_first if pane == :body
     end
 
-    # Descend from the tab menu (↓/↵/j on the tab bar). Tabs with a navigable
-    # sub-tab strip (Replay/Notes/Convert) land on the STRIP first so ←/→ can
-    # switch sub-tabs; ↓/↵ again drops into the editor. Other tabs go straight to
-    # the body. (`focus_pane`'s guard would otherwise route an absent strip to the
-    # menu, so the active tab is checked here.)
+    # Descend from the tab menu (↓/↵/j on the tab bar). When focus is on the far-right
+    # ⋯ "more" affordance, ↓/↵ EXPANDS the hidden-tabs dropdown instead. Otherwise: tabs
+    # with a navigable sub-tab strip (Replay/Notes/Convert) land on the STRIP first so
+    # ←/→ can switch sub-tabs; ↓/↵ again drops into the editor. Other tabs go straight to
+    # the body. (`focus_pane`'s guard would otherwise route an absent strip to the menu,
+    # so the active tab is checked here.)
     def enter_content : Nil
+      return open_more_menu if @menu_more
       focus_pane(subtabs_shown? ? :subtabs : :body)
     end
 
@@ -3620,6 +3644,7 @@ module Gori::Tui
       flush_active_tab_edits
       @active_tab = tab
       @focus = focus
+      @menu_more = false
       @overlay = :none
       on_enter_tab
       view_focus_first
@@ -3649,6 +3674,7 @@ module Gori::Tui
       tabs = effective_tabs
       idx = tabs.index { |(s, _)| s == @active_tab } || 0
       @active_tab = tabs[(idx + delta) % tabs.size][0]
+      @menu_more = false
       @overlay = :none
       on_enter_tab
       # Switching tabs on the bar (menu focus) just moves the highlight; switching
@@ -3656,11 +3682,106 @@ module Gori::Tui
       view_focus_first if @focus == :body
     end
 
+    # ←/→ on the tab bar. → past the last visible tab lands on the far-right ⋯ "more"
+    # affordance (when tabs are hidden) rather than wrapping; ← steps back off it onto
+    # the last tab. Everywhere else these are plain cycle_tab(±1). (`[`/`]` keep the
+    # from-anywhere wrap via cycle_tab — the ⋯ stop is menu-bar-only.)
+    def menu_right : Nil
+      return if @menu_more
+      if last_visible_tab? && hidden_tab_count > 0
+        @menu_more = true
+      else
+        cycle_tab(1)
+      end
+    end
+
+    def menu_left : Nil
+      @menu_more ? (@menu_more = false) : cycle_tab(-1)
+    end
+
+    # The tabs hidden from the bar right now — the ⋯ dropdown's contents. The active tab
+    # is force-shown on the bar, so it's never listed here.
+    private def hidden_tabs_now : Array({Symbol, String})
+      Chrome.hidden_tabs(Settings.tab_prefs, force: @active_tab)
+    end
+
+    private def hidden_tab_count : Int32
+      hidden_tabs_now.size
+    end
+
+    private def last_visible_tab? : Bool
+      effective_tabs.last?.try(&.first) == @active_tab
+    end
+
+    # The anchor the dropdown drops down from — the ⋯ button's cell rect, or (defensively,
+    # on a terminal too narrow to draw the button) a zero-width rect flush with the menu's
+    # right edge, so the dropdown never becomes an invisible-but-input-capturing modal.
+    private def more_anchor_rect(layout : Layout) : Rect
+      Chrome.more_button_rect(layout.menu, hidden_tab_count) ||
+        Rect.new(layout.menu.right, layout.menu.y, 0, 1)
+    end
+
+    # Open the hidden-tabs dropdown from the ⋯ affordance (↵/↓ on it, or a click).
+    # No-op when nothing is hidden. Keeps @menu_more set so a dismiss returns to the ⋯.
+    def open_more_menu : Nil
+      items = hidden_tabs_now
+      return if items.empty?
+      @focus = :menu
+      @menu_more = true
+      @more_menu = MoreMenu.new(items)
+      @overlay = :tabs_more
+    end
+
+    # Dismiss the dropdown back to the ⋯ affordance (esc / ← / click-outside). Focus
+    # stays on the bar with @menu_more set, so ←/→ keep navigating from there.
+    private def close_more_menu : Nil
+      @overlay = :none
+      @more_menu = nil
+    end
+
+    # ↑/↓ (or j/k) move · ↵ switch to the hidden tab (force-shown on the bar, like a
+    # palette "Go to …") · esc/← dismiss back to the ⋯ affordance.
+    private def handle_more_menu_key(ev : Termisu::Event::Key) : Nil
+      key = ev.key
+      mm = @more_menu
+      return close_more_menu unless mm
+      case
+      when key.escape?, key.left?  then close_more_menu
+      when key.up?, key.lower_k?   then mm.move(-1)
+      when key.down?, key.lower_j? then mm.move(1)
+      when key.enter?, key.space?  then apply_more_menu
+      end
+    end
+
+    # Switch to the selected hidden tab and drill into its content (like "Go to …").
+    private def apply_more_menu : Nil
+      mm = @more_menu
+      return close_more_menu unless mm
+      if sym = mm.selected_sym
+        close_more_menu
+        focus_tab(sym) # :body — the deliberate pick drills in; force-shows the tab on the bar
+      else
+        close_more_menu
+      end
+    end
+
+    private def click_more_menu(layout : Layout, mx : Int32, my : Int32) : Nil
+      mm = @more_menu
+      return close_more_menu unless mm
+      if idx = mm.row_at(more_anchor_rect(layout), layout.body, mx, my)
+        mm.set_selected(idx)
+        apply_more_menu
+      else
+        close_more_menu # click outside the list → dismiss (back to the ⋯ affordance)
+      end
+    end
+
     # --- unified focus ring (tab-bar ◂▸ body panes) --------------------------
 
     # Tab (+1) / Shift-Tab (-1) move focus one step around the ring: from the tab
     # bar into the body's first/last pane, between panes, then back to the bar.
     private def focus_advance(dir : Int32) : Nil
+      @menu_more = false # the ring lands on a tab / body pane, never the ⋯ affordance
       if @focus == :menu
         @focus = :body
         dir > 0 ? view_focus_first : view_focus_last

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -31,6 +31,11 @@ module Gori
       # follows the user's settings:tabs order/visibility. Out-of-range n is a no-op.
       abstract def focus_visible_tab(n : Int32) : Nil
       abstract def cycle_tab(delta : Int32) : Nil
+      # Horizontal tab-bar navigation (←/→ on the menu). Like cycle_tab(±1), but → past
+      # the last visible tab lands on the far-right "more" dropdown affordance (holding
+      # the settings-hidden tabs) instead of wrapping; ← steps back off it.
+      abstract def menu_left : Nil
+      abstract def menu_right : Nil
       # Descend from the tab menu into the active tab's content. Tabs with a
       # navigable sub-tab strip (Replay/Notes) land on the STRIP first; others go
       # straight to the body. (The strip then descends into the editor itself.)

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -242,11 +242,11 @@ module Gori
       # --- top menu focus navigation (horizontal) ---
       r.register Verb::Definition.new(
         "sidebar.prev", "Previous tab", "Select the tab to the left", Verb::Scope::Sidebar,
-        [Verb::Chord.new("left"), Verb::Chord.new("h")], hidden: true) { |ctx| ctx.cycle_tab(-1); nil }
+        [Verb::Chord.new("left"), Verb::Chord.new("h")], hidden: true) { |ctx| ctx.menu_left; nil }
 
       r.register Verb::Definition.new(
         "sidebar.next", "Next tab", "Select the tab to the right", Verb::Scope::Sidebar,
-        [Verb::Chord.new("right"), Verb::Chord.new("l")], hidden: true) { |ctx| ctx.cycle_tab(1); nil }
+        [Verb::Chord.new("right"), Verb::Chord.new("l")], hidden: true) { |ctx| ctx.menu_right; nil }
 
       r.register Verb::Definition.new(
         "sidebar.enter", "Enter tab", "Move focus into the content pane", Verb::Scope::Sidebar,


### PR DESCRIPTION
## What

Adds a far-right **⋯ dropdown** to the TUI tab bar that holds the tabs hidden via `settings:tabs` (Miner is hidden by default). It gives hidden tabs a discoverable, keyboard- and mouse-reachable home instead of being palette-only.

```
  Project  Sitemap  History  …  Notes  Help                    ⋯ 1
                                                                 └─▎ Miner
```

## Behavior

- **Badge** `⋯ N` shows only when tabs are actually hidden (nothing hidden → no button).
- **Keyboard:** `←/→` walk the tab bar; `→` past the last visible tab focuses the `⋯` (gold pill, like the active tab). `↵`/`↓` expands the dropdown; `←`/`esc` steps back off it. In the dropdown, `↑/↓` (or `j/k`) select, `↵` switches to the tab (force-shown on the bar while active, like the palette's "Go to …").
- **Mouse:** click the `⋯` to open, click a row to switch, click-outside/`esc` to dismiss.

## Implementation

- `Chrome.hidden_tabs` + `more_button_rect` + a shared `tabs_area` so `render_menu` and the click hit-test reserve the **same** region for the button (geometry can't drift).
- New `MoreMenu` widget (`src/gori/tui/more_menu.cr`) — an anchored twin of `ChoicePicker`; new `:tabs_more` overlay wired through the standard overlay checklist.
- Runner `@menu_more` focus sub-state (reset in every focus mutator); new `menu_left`/`menu_right` `Verb::ExecContext` methods that `sidebar.prev`/`.next` route to (`[`/`]` keep their from-anywhere wrap via `cycle_tab`).

## Tests

- New specs for `Chrome.hidden_tabs`, `more_button_rect`, and segment/button non-overlap.
- 652 TUI + verb specs pass.
- Verified end-to-end in a live TUI (tmux): badge render, keyboard reach → expand → select, mouse open + row-select, dismiss-to-affordance.