### PR TITLE
docs(prism): frame active scan as light-touch, not Burp-style

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ tool, so scripts and AI agents can drive the same engagement.
 - Inline JWT / SAML / GraphQL decoding, hex view, and pretty-printing
 
 ### Discover & Scan
-- Prism passive & active vulnerability scanner
+- Prism passive & light-touch active vulnerability scanner
 - Param Miner for hidden-parameter discovery
 - Findings triage with Markdown / JSON export
 

--- a/docs/content/guide/_index.md
+++ b/docs/content/guide/_index.md
@@ -30,7 +30,7 @@ gori is organized into tabs; move between them with `[` / `]` or jump with numbe
 | **Miner** | Hidden-parameter discovery (hidden by default) |
 | **Convert** | Encode / decode / hash pipeline |
 | **Comparer** | Side-by-side diff of two flows |
-| **Prism** | Passive & active security scanner |
+| **Prism** | Passive & light-touch active security scanner |
 | **Findings** | Triage results by severity and status |
 | **Notes** | Per-project Markdown notes |
 | **Help** | Key bindings and links |

--- a/docs/content/guide/scanning.md
+++ b/docs/content/guide/scanning.md
@@ -7,7 +7,9 @@ gori includes automated analysis that runs alongside your manual testing. **Pris
 
 ## Prism — the Scanner
 
-**Prism** groups security issues by type and severity. Its passive checks run as you browse — with zero extra requests — inspecting **History** flows and **Replay** send results. Active checks send a small, controlled number of probes only when you ask for them.
+**Prism** groups security issues by type and severity. Its passive checks run as you browse — with zero extra requests — inspecting **History** flows and **Replay** send results.
+
+Its **active** checks are deliberately *light-touch* — a handful of safe, low-volume probes over traffic you've already captured, not the flood of attack payloads a heavyweight scanner throws at a target. Only safe methods (`GET` / `HEAD`) are probed, each unique surface is tested once, and nothing goes out until you arm active mode. It's built to confirm a quick hunch — a parameter reflects, an origin is honored — while keeping your footprint quiet.
 
 <figure class="tui-shot">
   <img src="/images/tui/prism.svg" alt="gori Prism scanner listing passive findings grouped by severity and category: permissive CORS, missing CSP and HSTS, cookie flag issues, and cacheable responses, each with an affected host">
@@ -21,7 +23,7 @@ gori includes automated analysis that runs alongside your manual testing. **Pris
 | `tech` | Technology and protocol fingerprints (also surface on the Project tab) |
 | `infoleak` | Body disclosures, secrets in URLs / WS frames, GraphQL introspection |
 | `cors` | Wildcard / null origin / credentialed misconfigurations; active origin reflection |
-| `active` | Confirmed by a probe (for example reflected parameters) — TUI active scan only |
+| `active` | Confirmed by a light-touch probe (for example reflected parameters) — TUI active scan only |
 
 Severities run `info`, `low`, `medium`, `high`, `critical`. Headless `gori run prism` runs **passive** checks only (categories except `active`).
 

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -1353,8 +1353,9 @@ module Gori
                      "Passively scan captured History flows AND Replay responses (zero outbound\n" \
                      "requests) and report grouped issues — the headless equivalent of the TUI Prism\n" \
                      "tab. QL filters apply to History only; all Replay tabs with a stored response\n" \
-                     "are scanned. Active/reflected-param checks send requests and are intentionally\n" \
-                     "excluded (use the TUI or fuzz/mine)."
+                     "are scanned. The light-touch active checks (reflected params, …) send requests,\n" \
+                     "so they are intentionally excluded here — arm active mode in the TUI, or reach\n" \
+                     "for fuzz/mine."
           p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("-qQL", "--query=QL", "Only scan flows matching this QL query (host: status:>=500 size: …)") { |v| query = v }

--- a/src/gori/prism/mode.cr
+++ b/src/gori/prism/mode.cr
@@ -12,9 +12,11 @@ module Gori
     MODE_SETTING_KEY = "prism_mode"
 
     # Per-project scanning mode. Off = no analysis at all; Passive = zero-request checks on
-    # observed traffic (the safe default); Active = Passive plus the lightweight reflected-
-    # params probe (hosts/paths covered by Project scope rules only — the ⇧S display lens
-    # need not be on; one probe per unique target).
+    # observed traffic (the safe default); Active = Passive plus a set of light-touch probes
+    # (reflected params today) over hosts/paths covered by Project scope rules only — the ⇧S
+    # display lens need not be on; one probe per unique target. Keep active DELIBERATELY quiet:
+    # any new check must stay safe-method + low-volume (a handful of confirming probes), never a
+    # Burp-style flood of attack payloads.
     enum Mode
       Off
       Passive

--- a/src/gori/tui/choice_picker.cr
+++ b/src/gori/tui/choice_picker.cr
@@ -49,7 +49,7 @@ module Gori::Tui
       new("SET PRISM MODE", [
         Choice.new("OFF — no scanning", 'o', Theme.muted, 0),
         Choice.new("PASSIVE — observe only", 'p', Theme.accent, 1),
-        Choice.new("ACTIVE — passive + reflected-param probes (scope rules)", 'a', Theme.orange, 2),
+        Choice.new("ACTIVE — passive + light-touch probes (in-scope)", 'a', Theme.orange, 2),
       ], current, :prism_mode)
     end
 

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1580,7 +1580,7 @@ module Gori::Tui
         prism_controller.view.reload(@session.store)
         mode = @session.prism.mode
         @toast = if mode.active?
-                   "Prism mode: ACTIVE — probing recent in-scope traffic"
+                   "Prism mode: ACTIVE — light-touch probes over recent in-scope traffic"
                  else
                    "Prism mode: #{mode.title}"
                  end


### PR DESCRIPTION
## Summary

Prism's active scan is *already* implemented as light-touch (safe methods only, one probe per unique surface, arm-to-run), but the user-facing copy read like a generic "active scanner." This repositions it consistently as a deliberately **quiet, light-touch** active scan — a handful of safe, low-volume confirming probes — explicitly contrasted with a Burp-style flood of attack payloads.

The framing is future-proof: docs say "reflected params today", so adding more low-volume checks won't need a copy rewrite.

## Changes

**Docs**
- `docs/content/guide/scanning.md` — new paragraph explaining the light-touch philosophy; softened the `active` category row
- `README.md`, `docs/content/guide/_index.md` — "Passive & light-touch active … scanner"

**TUI copy**
- `choice_picker.cr` — mode picker: `ACTIVE — passive + light-touch probes (in-scope)` (kept short enough to avoid colliding with the `● current` marker on an 80-col terminal)
- `runner.cr` — arm toast: "light-touch probes over recent in-scope traffic"

**CLI + design intent**
- `cli/run.cr` — `gori run prism` help reframed
- `prism/mode.cr` — design comment now encodes the principle: new active checks must stay safe-method + low-volume, never a Burp-style flood

## Notes

Copy/tone only — no behavior change. `crystal build` passes.