### PR TITLE
fix(replay): align h1/h2/MCP/CLI replay behavior across surfaces

### DIFF
--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -807,6 +807,24 @@ describe Gori::MCP::Server do
       end
     end
 
+    it "honors an explicit http2:false to downgrade an h2-captured flow to HTTP/1.1" do
+      with_store do |store|
+        port = start_mcp_http_origin("downgraded")
+        # A flow captured over h2 (http_version HTTP/2). Sending it to this HTTP/1.1
+        # origin only succeeds if http2:false actually downgrades the transport — the
+        # bug was `http2 = bool(h,"http2") || flow.http2`, where an explicit false was
+        # OR'd away and the send stayed h2 (h2c to an h1 origin, which fails).
+        id = store.insert_flow(Gori::Store::CapturedRequest.new(
+          created_at: 1_i64, scheme: "http", host: "127.0.0.1", port: port,
+          method: "GET", target: "/h2flow", http_version: "HTTP/2",
+          head: "GET /h2flow HTTP/2\r\nHost: 127.0.0.1:#{port}\r\n\r\n".to_slice, body: nil))
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"send_request","arguments":{"flow_id":#{id},"http2":false}}})
+        resp = drive(store, call, verify_upstream: false)[0]
+        resp["result"]["isError"].as_bool.should be_false
+        tool_payload(resp)["status"].as_i.should eq(200)
+      end
+    end
+
     it "returns isError on a connection failure (port 1)" do
       with_store do |store|
         call = %({"jsonrpc":"2.0","id":12,"method":"tools/call","params":{"name":"send_request","arguments":{"url":"http://127.0.0.1:1/"}}})

--- a/spec/replay/h2_engine_spec.cr
+++ b/spec/replay/h2_engine_spec.cr
@@ -50,6 +50,39 @@ private def start_h2_origin(status : Int32, body : String, seen : Channel(String
   port
 end
 
+# A cleartext-h2 origin that records the decoded `:authority` pseudo-header of the
+# request (so a test can assert what authority the client actually put on the wire).
+private def start_h2_origin_authority(status : Int32, seen : Channel(String)) : Int32
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    next unless conn = origin.accept?
+    conn.read_timeout = 5.seconds
+    Frame.read_preface(conn)
+    dec = HPACK::Decoder.new
+    authority = "(none)"
+    loop do
+      f = Frame.read(conn)
+      break if f.nil?
+      if f.frame_type == Frame::Type::Headers && f.stream_id == 1 && f.end_headers?
+        dec.decode(f.payload).each { |(n, v)| authority = v if n == ":authority" }
+        break if f.end_stream?
+      elsif f.frame_type == Frame::Type::Data && f.end_stream?
+        break
+      end
+    end
+    seen.send(authority)
+    conn.write(Frame::Header.new(Frame::Type::Settings.value, 0_u8, 0_u32, Bytes.empty).to_bytes)
+    sb = HPACK::Encoder.new.encode([{":status", status.to_s}])
+    conn.write(Frame::Header.new(Frame::Type::Headers.value, Frame::END_HEADERS, 1_u32, sb).to_bytes)
+    conn.write(Frame::Header.new(Frame::Type::Data.value, Frame::END_STREAM, 1_u32, "ok".to_slice).to_bytes)
+    conn.flush
+    sleep 0.2.seconds
+    conn.close
+  end
+  port
+end
+
 # A cleartext-h2 origin that sends HEADERS(:status) + one DATA frame WITHOUT
 # END_STREAM, then drops the connection — a truncated response the client must
 # flag as incomplete (no END_STREAM ever arrives).
@@ -201,6 +234,30 @@ describe Gori::Replay::H2Engine do
     result.ok?.should be_true
     result.response.not_nil!.status.should eq(200)
     String.new(result.body.not_nil!).should eq("pong-ok")
+  end
+
+  it "maps an edited Host header to :authority (h1↔h2 parity for host-confusion probes)" do
+    seen = Channel(String).new(1)
+    port = start_h2_origin_authority(200, seen)
+
+    # Connect to 127.0.0.1 but CLAIM a different authority via the Host header — the
+    # h2 engine must send :authority = the edited Host, not the dialed target.
+    request = "GET / HTTP/2\r\nHost: victim.internal\r\n\r\n".to_slice
+    result = Gori::Replay::H2Engine.send(request, scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
+
+    seen.receive.should eq("victim.internal")
+    result.ok?.should be_true
+  end
+
+  it "falls back to the dialed host for :authority when no Host header is present" do
+    seen = Channel(String).new(1)
+    port = start_h2_origin_authority(200, seen)
+
+    result = Gori::Replay::H2Engine.send("GET / HTTP/2\r\n\r\n".to_slice,
+      scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
+
+    seen.receive.should eq("127.0.0.1:#{port}")
+    result.ok?.should be_true
   end
 
   it "reports an error when the origin is unreachable" do

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -15,6 +15,7 @@ require "../sitemap"
 require "../proxy/codec/content_decode"
 require "../replay/engine"
 require "../replay/h2_engine"
+require "../replay/ws_engine"
 require "../replay/flow_request"
 require "../replay/diff"
 require "../fuzz"
@@ -677,6 +678,15 @@ module Gori
           store.close
         end
         abort "gori run replay: no flow ##{id}" unless detail
+
+        # A WebSocket flow can't be replayed by a one-shot HTTP send: this path would only
+        # re-issue the upgrade request and report the 101 handshake, exchanging zero frames
+        # (a silently misleading "success"). Detect an upgrade that actually completed
+        # (status 101 + a WebSocket upgrade request) and refuse with an actionable pointer,
+        # rather than the plain h1/h2 engines that don't do the RFC 6455 framed exchange.
+        if detail.row.status == 101 && Replay::WsEngine.upgrade_request?(String.new(detail.request_head))
+          abort "gori run replay: flow ##{id} is a WebSocket session — `gori run replay` only re-sends the HTTP upgrade and captures the 101 handshake, not the framed messages. Replay it from the TUI Replay tab, or create a replay from it and use the MCP `send_websocket` tool for a real framed exchange."
+        end
 
         # The captured request body was capped at CAPTURE_MAX; FlowRequest.build re-syncs the
         # Content-Length to the stored bytes so the request stays well-formed, but warn that

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -947,10 +947,10 @@ module Gori
           return Result.new("no finding with id #{finding_id}", is_error: true) unless @store.get_finding(finding_id)
         end
 
-        built, http2 = build_send_request(h)
+        built, http2, sni = build_send_request(h)
         recorded_flow_id = record_history ? record_outbound_request(built, http2) : nil
         verify = @verify_upstream && !(bool(h, "insecure") || false)
-        result = send_built_request(built, http2, verify)
+        result = send_built_request(built, http2, verify, sni)
         record_outbound_response(recorded_flow_id, result) if recorded_flow_id
         # Audit trail on STDERR — never STDOUT (reserved for JSON-RPC).
         Log.info { "send_request #{built.scheme}://#{built.host}:#{built.port} http2=#{http2} flow_id=#{recorded_flow_id || "none"} -> #{result.ok? ? "ok" : result.error}" }
@@ -968,13 +968,13 @@ module Gori
       end
 
       private def send_built_request(built : RequestBuilder::Built, http2 : Bool,
-                                     verify_upstream : Bool) : Replay::Result
+                                     verify_upstream : Bool, sni : String? = nil) : Replay::Result
         if http2
           Replay::H2Engine.send(built.bytes, scheme: built.scheme, host: built.host,
-            port: built.port, verify_upstream: verify_upstream)
+            port: built.port, verify_upstream: verify_upstream, sni: sni)
         else
           Replay::Engine.send(built.bytes, scheme: built.scheme, host: built.host,
-            port: built.port, verify_upstream: verify_upstream)
+            port: built.port, verify_upstream: verify_upstream, sni: sni)
         end
       end
 
@@ -1214,7 +1214,8 @@ module Gori
       end
 
       # Either replays a captured flow (flow_id) or builds from url/raw/method args.
-      private def build_send_request(h) : {RequestBuilder::Built, Bool}
+      # Returns {request bytes + target, use-h2, captured TLS SNI (flow path only)}.
+      private def build_send_request(h) : {RequestBuilder::Built, Bool, String?}
         if present?(h, "flow_id")
           id = int(h, "flow_id")
           raise Gori::Error.new(id_error(h, "flow_id")) unless id
@@ -1226,11 +1227,17 @@ module Gori
           target = Env.expand(flow.target)
           scheme, host, port = Replay::FlowRequest.parse_target(target)
           raise Gori::Error.new("could not parse target from flow #{id}") if host.empty?
-          http2 = bool(h, "http2") || flow.http2
-          {RequestBuilder::Built.new(bytes, scheme, host, port), http2}
+          # Default to how the flow was captured, but honor an EXPLICIT http2 either way —
+          # `bool_arg` returns `flow.http2` only when the arg is absent, so `http2:false`
+          # can now downgrade an h2 capture to h1 (it used to be silently ignored because
+          # `false || flow.http2` kept h2). Carry the captured SNI so an origin where
+          # SNI ≠ Host (domain fronting / multi-cert vhost) presents the right certificate,
+          # matching `gori run replay`.
+          http2 = bool_arg(h, "http2", flow.http2)
+          {RequestBuilder::Built.new(bytes, scheme, host, port), http2, flow.sni}
         else
           built = RequestBuilder.build(h)
-          {built, bool(h, "http2") || false}
+          {built, bool_arg(h, "http2", false), nil}
         end
       end
 

--- a/src/gori/replay/h2_engine.cr
+++ b/src/gori/replay/h2_engine.cr
@@ -260,16 +260,33 @@ module Gori
         path = (first_sp && last_sp && last_sp > first_sp) ? line[(first_sp + 1)...last_sp] : "/"
         path = "/" if path.empty?
 
-        headers = [{":method", method}, {":path", path}, {":scheme", scheme},
-                   {":authority", authority(host, port, scheme)}]
+        # An explicit `Host:` header maps to `:authority` (RFC 9113 §8.3.1 — h2 has no
+        # Host field). Honor its value so editing the request's host (a vhost /
+        # host-header-confusion probe, in the TUI editor, MCP `headers`, or `gori run
+        # replay -H "Host: …"`) actually reaches the wire — matching the h1 engine, which
+        # sends the edited Host verbatim. Without this the edited Host was silently
+        # dropped and `:authority` always came from the dialed target. The connection
+        # target is unchanged: you still connect to `host`, but can CLAIM a different
+        # authority. Falls back to the dialed host when no Host line is present.
+        authority_override = nil
+        regular = [] of {String, String}
         lines[1..]?.try &.each do |line|
           next if line.empty?
           colon = line.index(':')
           next unless colon && colon > 0
           name = line[0...colon].strip.downcase
+          value = line[(colon + 1)..].strip
+          if name == "host"
+            authority_override = value unless value.empty?
+            next # folded into :authority below; a literal `host` header is illegal in h2
+          end
           next if FORBIDDEN.includes?(name)
-          headers << {name, line[(colon + 1)..].strip}
+          regular << {name, value}
         end
+
+        headers = [{":method", method}, {":path", path}, {":scheme", scheme},
+                   {":authority", authority_override || authority(host, port, scheme)}]
+        headers.concat(regular)
         {headers, body}
       end
 


### PR DESCRIPTION
Audited the Replay feature across the TUI, MCP, and `gori run` and fixed four cross-surface inconsistencies where the *same* captured flow replayed differently depending on which surface sent it.

## Fixes

1. **h2 `:authority` from an edited Host header** (`src/gori/replay/h2_engine.cr`)
   `H2Engine.parse_request` dropped the `Host` header (illegal in h2) and always derived `:authority` from the **dialed** host, so a Host edited in a Replay tab, `gori run replay -H "Host: x"`, or MCP `headers` was silently ignored over h2 — while the h1 engine sent it verbatim. Now an explicit `Host:` maps to `:authority` (RFC 9113 §8.3.1), so vhost / host-header-confusion probes work over h2. The connection target is unchanged; falls back to the dialed host when no Host line is present.

2. **MCP `http2:false` downgrade** (`src/gori/mcp/tools.cr`)
   `build_send_request` used `http2 = bool(h,"http2") || flow.http2`, so an explicit `http2:false` on an h2-captured flow was OR'd away and the send stayed h2. Now `bool_arg(h,"http2", flow.http2)` — honors an explicit value either way and raises on present-but-invalid input. This matches the TUI (which already toggles both directions).

3. **MCP captured-SNI passthrough** (`src/gori/mcp/tools.cr`)
   `send_request(flow_id)` never passed the flow's captured TLS SNI to the engines, so for an origin where SNI ≠ Host (domain fronting / multi-cert vhost) it presented a different cert/vhost than `gori run replay`, which already honored it. `build_send_request` now returns the captured SNI and threads it through.

4. **CLI `gori run replay` WebSocket guard** (`src/gori/cli/run.cr`)
   Replaying a WebSocket flow re-sent only the HTTP upgrade and reported `→ 101` with exit 0 — a silently misleading "success" that exchanged zero frames. Now detects an actually-upgraded WS flow (status 101 + upgrade request) and aborts with an actionable pointer (TUI Replay tab / MCP `send_websocket`).

## Tests
- `spec/replay/h2_engine_spec.cr`: new `:authority` override + fallback cases (via a new authority-capturing h2 origin).
- `spec/mcp_spec.cr`: `http2:false` downgrades an h2-captured flow to an h1 origin.
- All replay / MCP / CLI specs pass (199 examples). Full suite: only pre-existing, environment-related proxy-bind failures (unchanged from baseline).
- CLI WS guard verified end-to-end against a seeded DB with the real binary.

## Follow-up (not in this PR)
Binary (non-UTF-8) **request bodies** are corrupted on the MCP / CLI / TUI-text send paths because the send path round-trips bytes through `Env.expand`'s char iteration (invalid UTF-8 → U+FFFD). `FlowRequest.build` is byte-exact, but the corruption happens after. `Env.expand`/`expand_wire` are shared with Fuzzer/Miner/Intercept, so a careful byte-safe head/body-aware fix is tracked separately.