### PR TITLE
perf: behavior-preserving hot-path optimizations (render / fuzz / decoder)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+### Performance — behavior-preserving hot-path optimizations
+
+A measured pass over the render / fuzz / decoder hot paths (micro-benchmarks in
+`bench/`, gated on a benchmark delta + the full spec suite staying green). No
+observable behavior changes — byte-exact forwarding, identical rendered glyphs,
+identical query/pretty output. Highlights:
+
+- **TUI render primitives** — `Highlight.draw` (the styled-line primitive behind
+  the History detail, Repeater, Intercept, Fuzzer, and Decoder panes) and
+  `Screen.display_width`/`column_width` gained the printable-ASCII fast path
+  `Screen#text` already had: an ASCII line (the common HTTP head/body) is drawn
+  by char at width 1 with interned cells instead of grapheme-clustering and
+  allocating a `String` per glyph. `Highlight.draw` over a styled viewport drops
+  ~21× (123 kB/op → 640 B/op); `display_width` on a frame's worth of labels drops
+  ~115× (0 B/op). Non-ASCII (CJK/emoji/combining) keeps the exact grapheme path.
+- **Tab bar** — the menu strip and the ⋯ hidden-count now come from ONE
+  `Chrome.split_tabs` reconcile per frame instead of two.
+- **Fuzzer** — `Template#render` pre-sizes its output buffer to the exact length,
+  dropping the default-64 B realloc chain on every emitted request.
+- **Pretty-print** — a JSON body is parsed ONCE (shared between the GraphQL sniff
+  and the pretty-print) instead of twice per detail-view rebuild.
+
+New benches: `highlight_draw_bench`, `display_width_bench`, `fuzz_render_bench`,
+`pretty_bench`. New parity/equivalence specs lock the behavior of each change.
+
 ### Changed — MCP server hardening & new tools
 
 A broad pass over the MCP surface based on an external assessment. Highlights:

--- a/bench/display_width_bench.cr
+++ b/bench/display_width_bench.cr
@@ -1,0 +1,36 @@
+# Screen.display_width micro-benchmark. display_width is the terminal-column measure used
+# ~36 places across the TUI (caret placement, label centring, tab widths, h-scroll clamps,
+# Highlight.line_width/slice_left) — many per frame on short strings. It grapheme-walked
+# every string with grapheme_width(g.to_s), allocating a String per glyph even on pure-ASCII
+# labels (the common case), where the width is just the char count. This drives realistic
+# short/medium ASCII strings + one CJK string (which must keep the grapheme path).
+#
+# Build: crystal build bench/display_width_bench.cr -o bin/display_width_bench --release
+# Run:   bin/display_width_bench
+require "benchmark"
+require "../src/gori/tui"
+
+include Gori::Tui
+
+LABEL = "History"                                            # a short tab label
+PATH  = "GET /api/v1/users/12345/profile?include=avatar,bio" # a request-line-ish string
+HOST  = "api.example.com:8443"                               # a host:port
+CJK   = "안녕하세요 세계 — 유니코드 폭 측정"                               # width-2 glyphs (grapheme path)
+
+puts "Screen.display_width (per call):"
+Benchmark.ips do |x|
+  x.report("ascii short label (#{LABEL.size}B)") { Screen.display_width(LABEL) }
+  x.report("ascii request-line (#{PATH.size}B)") { Screen.display_width(PATH) }
+  x.report("ascii host:port (#{HOST.size}B)") { Screen.display_width(HOST) }
+  x.report("cjk mixed (#{CJK.size} cp)") { Screen.display_width(CJK) }
+end
+
+# A representative frame's worth of measures (mix of labels + a couple of longer strings).
+puts "\nScreen.display_width x ~30 short + 4 long (a frame's worth):"
+Benchmark.ips do |x|
+  x.report("frame of display_width") do
+    30.times { Screen.display_width(LABEL) }
+    4.times { Screen.display_width(PATH) }
+    4.times { Screen.display_width(HOST) }
+  end
+end

--- a/bench/fuzz_render_bench.cr
+++ b/bench/fuzz_render_bench.cr
@@ -1,0 +1,36 @@
+# Template#render micro-benchmark. render() splices payloads into the marked template on
+# EVERY emitted fuzz request (Generator#emit). The output IO::Memory started at the default
+# 64B and regrew 64→128→…→N for a KB-scale request each emit; pre-sizing to the exact output
+# length removes that realloc chain. For GET query fuzz the render output IS the wire bytes.
+#
+# Build: crystal build bench/fuzz_render_bench.cr -o bin/fuzz_render_bench --release
+# Run:   bin/fuzz_render_bench
+require "benchmark"
+
+module Gori
+  class Error < Exception; end
+end
+
+require "../src/gori/fuzz/template"
+
+include Gori::Fuzz
+
+# A realistic marked request: long query line + Cookie header + small JSON body, 4 positions.
+RAW = ("POST /api/v1/search?q=§term§&page=§page§ HTTP/1.1\r\n" +
+       "Host: api.example.com\r\n" +
+       "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36\r\n" +
+       "Accept: application/json\r\n" +
+       "Cookie: session=§sid§; csrf=abcdef0123456789; theme=dark; lang=en\r\n" +
+       "Content-Type: application/json\r\n" +
+       "\r\n" +
+       %({"filter":"§filter§","limit":50,"offset":0,"sort":"relevance"}))
+
+TEMPLATE = Template.parse(RAW, http2: false)
+PAYLOADS = ["hello world query string", "42", "deadbeefcafebabe0123456789abcdef", "active"]
+
+# Sanity: show the produced size.
+OUT = TEMPLATE.render(PAYLOADS)
+puts "template render: #{TEMPLATE.position_count} positions, output = #{OUT.size} bytes"
+Benchmark.ips do |x|
+  x.report("Template#render") { TEMPLATE.render(PAYLOADS) }
+end

--- a/bench/highlight_draw_bench.cr
+++ b/bench/highlight_draw_bench.cr
@@ -1,0 +1,69 @@
+# Highlight.draw micro-benchmark. `draw` renders a styled Line (spans) into Screen
+# cells and is the per-visible-line render primitive for the History detail, Repeater,
+# Intercept, Fuzzer, Decoder, and Project message panes (16 call sites). It runs for
+# every on-screen line per frame during scroll/capture. Unlike Screen#text it walked
+# every span with each_grapheme + grapheme_width(g.to_s) + cell(g.to_s) — a String per
+# grapheme, even on pure-ASCII HTTP lines (the common case). This drives a realistic
+# ~45-line styled viewport and reports bytes/op so the ASCII fast-path win is visible.
+#
+# Build: crystal build bench/highlight_draw_bench.cr -o bin/highlight_draw_bench --release
+# Run:   bin/highlight_draw_bench
+require "benchmark"
+require "../src/gori/tui"
+
+include Gori::Tui
+
+# Recording backend that keeps only the last glyph (no per-cell grid alloc that would
+# dwarf the measurement). We measure Highlight.draw's own cost, not cell storage.
+class SinkBackend < Backend
+  @last = ' '.as(Char | String)
+
+  def initialize(@w : Int32, @h : Int32)
+  end
+
+  def put(x : Int32, y : Int32, grapheme : Char | String, fg : Color, bg : Color, attr : Attribute) : Nil
+    @last = grapheme
+  end
+
+  def size : {Int32, Int32}
+    {@w, @h}
+  end
+end
+
+W = 120
+H =  50
+backend = SinkBackend.new(W, H)
+screen = Screen.new(backend)
+
+# A realistic captured HTTP/1.1 exchange (ASCII head + JSON body), styled once into
+# `Line`s the way the detail view holds them, then drawn every frame.
+HEAD = ("HTTP/1.1 200 OK\r\n" +
+        "Content-Type: application/json; charset=utf-8\r\n" +
+        "Cache-Control: no-cache, no-store, must-revalidate\r\n" +
+        "Server: nginx/1.25.0\r\n" +
+        "Date: Mon, 15 Jul 2026 12:00:00 GMT\r\n" +
+        "X-Request-Id: 7f3a9c2e-1b4d-4e8a-9c1f-2d6b8e0a1c3d\r\n\r\n").to_slice
+BODY = begin
+  io = IO::Memory.new
+  20.times do |i|
+    io << %(  {"id": #{1000 + i}, "name": "Alice Example #{i}", "email": "a#{i}@example.com", ) \
+      << %("active": true, "score": -12.5e3, "tags": ["alpha", "beta"], "note": "ordinary value"},\n)
+  end
+  io.to_slice
+end
+
+WINDOWED = Highlight.message_windowed(HEAD, BODY, false)
+# Materialize the styled Lines for the whole viewport once (open cost isn't measured).
+LINES = (0...{WINDOWED.total, H}.min).map { |i| WINDOWED.line_at(i) }
+# Reference: the plain (unstyled) glyphs Screen#text draws for the same lines.
+PLAIN = LINES.map { |l| l.map(&.text).join }
+
+puts "Highlight.draw over a #{LINES.size}-line ASCII styled viewport (per frame):"
+Benchmark.ips do |x|
+  x.report("draw viewport (styled)") do
+    LINES.each_with_index { |line, y| Highlight.draw(screen, 0, y, line) }
+  end
+  x.report("ref: screen.text (plain)") do
+    PLAIN.each_with_index { |s, y| screen.text(0, y, s, Theme.text) }
+  end
+end

--- a/bench/pretty_bench.cr
+++ b/bench/pretty_bench.cr
@@ -1,0 +1,43 @@
+# Pretty.format micro-benchmark. A JSON response body used to be JSON.parse'd TWICE per
+# detail-view cache rebuild — once for the GraphQL sniff (try_graphql), once for the pretty
+# print (try_json). For the dominant shape (non-GraphQL REST JSON) that built the whole tree
+# twice. The shared-parse version parses once. Case A = non-GraphQL JSON (the win); Case B =
+# a real GraphQL envelope (must be unchanged); Case C = invalid JSON (both → raw/nil).
+#
+# Build: crystal build bench/pretty_bench.cr -o bin/pretty_bench --release
+# Run:   bin/pretty_bench
+require "benchmark"
+
+module Gori
+  class Error < Exception; end
+end
+
+require "../src/gori/decoder"
+require "../src/gori/pretty"
+
+HEAD = "HTTP/1.1 200 OK\r\nContent-Type: application/json; charset=utf-8\r\n\r\n".to_slice
+
+# ~30KB non-GraphQL nested JSON (no top-level "query"): the double-parse case.
+JSON_BODY = begin
+  io = IO::Memory.new
+  io << %({"users":[)
+  200.times do |i|
+    io << "," if i > 0
+    io << %({"id":#{i},"name":"User #{i}","email":"u#{i}@example.com","active":true,) \
+      << %("roles":["admin","user"],"meta":{"score":#{i * 3},"note":"ordinary value here"}})
+  end
+  io << %(],"page":1,"total":200})
+  io.to_slice
+end
+
+GRAPHQL_BODY = %({"operationName":"GetUser","query":"query GetUser($id:ID!){ user(id:$id){ id name email } }","variables":{"id":"42"}}).to_slice
+INVALID_BODY = ("{not valid json at all, " + "x" * 2000).to_slice
+
+puts "pretty: json body=#{JSON_BODY.size}B, graphql=#{GRAPHQL_BODY.size}B"
+r = Gori::Pretty.format(HEAD, JSON_BODY); puts "  json  -> #{r.try(&.note) || "nil"} (#{r.try(&.bytes.size) || 0}B)"
+r = Gori::Pretty.format(HEAD, GRAPHQL_BODY); puts "  gql   -> #{r.try(&.note) || "nil"}"
+r = Gori::Pretty.format(HEAD, INVALID_BODY); puts "  bad   -> #{r.try(&.note) || "nil"}"
+Benchmark.ips do |x|
+  x.report("format non-graphql json (#{JSON_BODY.size}B)") { Gori::Pretty.format(HEAD, JSON_BODY) }
+  x.report("format graphql envelope") { Gori::Pretty.format(HEAD, GRAPHQL_BODY) }
+end

--- a/spec/pretty_spec.cr
+++ b/spec/pretty_spec.cr
@@ -42,6 +42,14 @@ describe Gori::Pretty do
     it "guards deep-nesting DoS via JSON max_nesting" do
       pretty("application/json", "[" * 1000 + "]" * 1000).should be_nil
     end
+
+    it "reflows a top-level array and no-ops a scalar (shared-parse path, non-object roots)" do
+      arr = pretty("application/json", "[1,2,3]").not_nil!
+      arr.kind.should be_nil
+      text(arr).lines.size.should be > 1                # array pretty-printed, not GraphQL-hijacked
+      pretty("application/json", "42").should be_nil    # scalar → already-"pretty" → nil
+      pretty("application/json", %("hi")).should be_nil # string scalar → nil
+    end
   end
 
   describe "GraphQL" do

--- a/spec/tui/chrome_tabs_spec.cr
+++ b/spec/tui/chrome_tabs_spec.cr
@@ -153,3 +153,26 @@ describe "Chrome.scroll_start" do
     Chrome.scroll_start(widths, active_idx: 4, avail: 25, prev_start: 1).should eq(3)
   end
 end
+
+# split_tabs folds visible_tabs + hidden_tabs into ONE reconcile pass (the render path needs
+# both every frame). It MUST return exactly what calling the two separately returns — this
+# locks that hand-merged equivalence across the force/all-hidden edge cases.
+describe "Chrome.split_tabs" do
+  user_hidden = [{"repeater", false}, {"decoder", false}]
+  all_hidden = Chrome::TABS.map { |(sym, _)| {sym.to_s, false} }
+  configs = {
+    "empty"                => {[] of {String, Bool}, nil.as(Symbol?)},
+    "force visible active" => {[] of {String, Bool}, :project.as(Symbol?)},
+    "force hidden active"  => {[] of {String, Bool}, :miner.as(Symbol?)},
+    "user-hidden"          => {user_hidden, nil.as(Symbol?)},
+    "user-hidden + force"  => {user_hidden, :repeater.as(Symbol?)},
+    "all-hidden"           => {all_hidden, nil.as(Symbol?)},
+    "all-hidden + force"   => {all_hidden, :issues.as(Symbol?)},
+  }
+  configs.each do |name, (prefs, force)|
+    it "equals {visible_tabs, hidden_tabs} for #{name}" do
+      Chrome.split_tabs(prefs, force: force).should eq(
+        {Chrome.visible_tabs(prefs, force: force), Chrome.hidden_tabs(prefs, force: force)})
+    end
+  end
+end

--- a/spec/tui/highlight_spec.cr
+++ b/spec/tui/highlight_spec.cr
@@ -255,6 +255,25 @@ describe Gori::Tui::Highlight do
       b.row(0)[0, 1].should eq("h")
     end
 
+    it "matches Screen#text across a MIXED ascii+wide multi-span line at every width" do
+      # draw's ASCII fast path (width-1 char draw) and its grapheme path must compose:
+      # width accumulates continuously across a span boundary where the branch flips, so a
+      # line split into an ASCII prefix span + a wide (CJK) suffix span renders and advances
+      # exactly like Screen#text over the concatenated string — truncation/ellipsis included.
+      full = "id=42 값" # "id=42 " is printable ASCII (fast path), "값" is width-2 (grapheme path)
+      {["id=42 ", "값"], ["id", "=42 값"], ["id=42", " 값"]}.each do |parts|
+        line = parts.map { |p| Highlight::Span.new(p, Theme.text) }
+        (0..10).each do |w|
+          plain = MemoryBackend.new(12, 1)
+          px = Screen.new(plain).text(0, 0, full, Theme.text, width: w)
+          hl = MemoryBackend.new(12, 1)
+          hx = Highlight.draw(Screen.new(hl), 0, 0, line, width: w)
+          hl.row(0).should eq(plain.row(0)) # same glyphs (parts=#{parts.inspect}, w=#{w})
+          hx.should eq(px)                  # same advance
+        end
+      end
+    end
+
     it "draws nothing for a zero/negative width" do
       b = MemoryBackend.new(10, 1)
       Highlight.draw(Screen.new(b), 0, 0, [Highlight::Span.new("hi", Theme.text)], width: 0)

--- a/src/gori/fuzz/template.cr
+++ b/src/gori/fuzz/template.cr
@@ -160,7 +160,12 @@ module Gori::Fuzz
     # Splice payloads into the marked positions. `payloads.size` must equal
     # `position_count`. Bytes are returned BEFORE any Content-Length sync.
     def render(payloads : Array(String)) : Bytes
-      io = IO::Memory.new
+      # Pre-size to the exact output length (segments + payloads, both written once) so a
+      # KB-scale request doesn't regrow the default 64B buffer 64→128→…→N every emit on the
+      # fuzz build path. bytesize is O(1) and both arrays are tiny (position_count+1); on the
+      # parse contract (segments.size == positions.size + 1) the sum is exact, and off-contract
+      # it can only OVER-estimate (fewer segments written) — never under, so never a truncation.
+      io = IO::Memory.new(@segments.sum(&.bytesize) + payloads.sum(&.bytesize))
       io << @segments[0]
       payloads.each_with_index do |p, k|
         io << p

--- a/src/gori/pretty.cr
+++ b/src/gori/pretty.cr
@@ -52,10 +52,7 @@ module Gori
         return r
       end
       if ctl && ctl.includes?("json")
-        if r = try_graphql(str)
-          return r
-        end
-        return try_json(str)
+        return try_json_or_graphql(str)
       end
       return try_form(str) if ctl && ctl.includes?("x-www-form-urlencoded")
       return try_multipart(body, ct) if ctl && ct && ctl.starts_with?("multipart/")
@@ -82,22 +79,36 @@ module Gori
 
     # ---- JSON --------------------------------------------------------------
 
-    private def try_json(str : String) : Result?
+    # A JSON body is EITHER a GraphQL envelope (operationName + query + variables) or plain
+    # JSON to pretty-print. Both used to JSON.parse the SAME body independently (try_graphql
+    # then try_json), so a non-GraphQL REST-JSON response — the dominant shape — built the
+    # whole JSON tree TWICE per detail-view cache rebuild. Parse ONCE, sniff GraphQL off the
+    # tree, else pretty-print the tree. Byte-identical to the old two-call dispatch on every
+    # input: invalid/empty JSON → nil via the parse rescue (as both did); a GraphQL shape →
+    # the graphql result; anything else → the pretty result (or nil for already-pretty/scalar).
+    private def try_json_or_graphql(str : String) : Result?
       s = strip_bom(str).strip
-      return nil if s.empty?
-      pretty = JSON.parse(s).to_pretty_json
+      json = JSON.parse(s)
+      # GraphQL sniff in its OWN rescue so a shape-check failure falls through to pretty-print
+      # exactly as the old try_graphql(rescue→nil)-then-try_json path did.
+      if r = (graphql_from(json) rescue nil)
+        return r
+      end
+      pretty = json.to_pretty_json
       return nil if pretty == s # already pretty / scalar → no-op, show raw
       slice = pretty.to_slice
       return nil if slice.size > MAX_OUT_PRETTY
       Result.new(slice, "pretty: json")
     rescue
-      nil
+      nil # invalid JSON (both try_graphql and try_json returned nil here before)
     end
 
     # ---- GraphQL (operationName + un-escaped query + pretty variables) ------
 
-    private def try_graphql(str : String) : Result?
-      json = JSON.parse(strip_bom(str).strip)
+    # GraphQL envelope over an ALREADY-PARSED body (no second parse). Same guards as the old
+    # try_graphql minus the JSON.parse; nil for any non-GraphQL object/array/scalar so the
+    # caller falls through to plain JSON pretty-printing.
+    private def graphql_from(json : JSON::Any) : Result?
       h = json.as_h?
       return nil unless h
       q = h["query"]?.try(&.as_s?)
@@ -119,8 +130,6 @@ module Gori
       ob = text.to_slice
       return nil if ob.size > MAX_OUT_PRETTY
       Result.new(ob, "pretty: graphql", :text)
-    rescue
-      nil
     end
 
     # ---- JWT (reuses Decoder::Codecs.jwt_decode) ---------------------------

--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -106,6 +106,24 @@ module Gori::Tui
       reconcile(prefs).reject { |(s, _, v)| v || s == force }.map { |(s, l, _)| {s, l} }
     end
 
+    # The visible strip AND the hidden list from ONE reconcile pass — {visible, hidden},
+    # each identical to what visible_tabs / hidden_tabs return alone. The render path needs
+    # both every frame (the menu strip + the ⋯ hidden count); calling visible_tabs and
+    # hidden_tabs separately rebuilt reconcile's catalog hashes twice per frame for the same
+    # output. Pure function of prefs, so folding the two into one pass is byte-identical.
+    def self.split_tabs(prefs : Array({String, Bool}), force : Symbol? = nil) : {Array({Symbol, String}), Array({Symbol, String})}
+      ann = reconcile(prefs)
+      vis = ann.select { |(_, _, v)| v }.map { |(s, l, _)| {s, l} }
+      if force && vis.none? { |(s, _)| s == force }
+        if idx = ann.index { |(s, _, _)| s == force }
+          at = ann[0...idx].count { |(_, _, v)| v }
+          vis.insert(at, {ann[idx][0], ann[idx][1]})
+        end
+      end
+      hidden = ann.reject { |(s, _, v)| v || s == force }.map { |(s, l, _)| {s, l} }
+      {vis, hidden}
+    end
+
     # The "more" affordance label — a ⋯ ellipsis plus the hidden-tab count, so the bar
     # reads "there are N tabs tucked away here" at a glance.
     def self.more_label(hidden_count : Int32) : String

--- a/src/gori/tui/highlight.cr
+++ b/src/gori/tui/highlight.cr
@@ -394,17 +394,30 @@ module Gori::Tui
 
       # Does the line exceed `limit`? Stop measuring as soon as it does — never walk a
       # huge (e.g. minified-JSON, multi-KB header) line in full just to set a boolean.
+      # A printable-ASCII span (the common case — HTTP heads/bodies) is all width-1
+      # glyphs, so its width is its char count: skip the grapheme walk (and its per-glyph
+      # `g.to_s` String) entirely, mirroring Screen#text's ASCII fast path. Mixed lines
+      # stay correct — width accumulates across spans regardless of which branch each takes.
       overflow = false
       acc = 0
       line.each do |span|
-        span.text.each_grapheme do |g|
-          acc += Termisu::UnicodeWidth.grapheme_width(g.to_s)
-          if acc > limit
+        t = span.text
+        if printable_ascii?(t)
+          if acc + t.size > limit
             overflow = true
             break
           end
+          acc += t.size
+        else
+          t.each_grapheme do |g|
+            acc += Termisu::UnicodeWidth.grapheme_width(g.to_s)
+            if acc > limit
+              overflow = true
+              break
+            end
+          end
+          break if overflow
         end
-        break if overflow
       end
       ellipsis = overflow && limit > 1
 
@@ -413,17 +426,31 @@ module Gori::Tui
       done = false
       line.each do |span|
         break if done
-        span.text.each_grapheme do |g|
-          gw = Termisu::UnicodeWidth.grapheme_width(g.to_s)
-          # The FIRST grapheme that doesn't fit terminates ALL rendering — a single
-          # continuous walk, so a later span can't resume into the leftover room and draw
-          # a narrower glyph in place of the skipped wide one (Screen#fit glyph parity).
-          if visual_col + gw > room
-            done = true
-            break
+        t = span.text
+        if printable_ascii?(t)
+          # Each printable-ASCII char is one width-1 cell; pass the Char to `cell` (interned
+          # via Screen::ASCII_CELL — zero allocation) instead of a fresh `g.to_s` String.
+          t.each_char do |ch|
+            if visual_col + 1 > room
+              done = true
+              break
+            end
+            screen.cell(x + visual_col, y, ch, span.fg, bg, span.attr)
+            visual_col += 1
           end
-          screen.cell(x + visual_col, y, g.to_s, span.fg, bg, span.attr)
-          visual_col += gw
+        else
+          t.each_grapheme do |g|
+            gw = Termisu::UnicodeWidth.grapheme_width(g.to_s)
+            # The FIRST grapheme that doesn't fit terminates ALL rendering — a single
+            # continuous walk, so a later span can't resume into the leftover room and draw
+            # a narrower glyph in place of the skipped wide one (Screen#fit glyph parity).
+            if visual_col + gw > room
+              done = true
+              break
+            end
+            screen.cell(x + visual_col, y, g.to_s, span.fg, bg, span.attr)
+            visual_col += gw
+          end
         end
         break if done || visual_col >= limit
       end
@@ -768,6 +795,16 @@ module Gori::Tui
     end
 
     # --- helpers -------------------------------------------------------------
+
+    # Whether every byte is printable ASCII (0x20..0x7e), so the string is all width-1
+    # glyphs with one byte per displayed cell. Lets `draw` skip grapheme clustering +
+    # `grapheme_width` + per-glyph `g.to_s` on the common HTTP-text span. A control byte
+    # (< 0x20 / 0x7f) or any byte >= 0x80 (a multibyte lead/continuation, or a codepoint
+    # whose display width may be 0/2) falls through to the exact grapheme-walk path. Empty
+    # string is trivially true (the fast path then draws nothing, matching each_grapheme).
+    private def self.printable_ascii?(s : String) : Bool
+      s.to_slice.all? { |b| b >= 0x20_u8 && b <= 0x7e_u8 }
+    end
 
     private def self.plain(raw : String) : Line
       [Span.new(raw, Theme.text)]

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -2930,10 +2930,13 @@ module Gori::Tui
         unread: @notifications.unread, capturing: @session.capturing?,
         write_failures: @session.store.write_failures)
       Chrome.render_rule(screen, layout.rule)
+      # One reconcile per frame: the menu strip AND the ⋯ hidden count both derive from the
+      # same tab reconcile — split_tabs computes both in a single pass (was two per frame).
+      vis_tabs, hid_tabs = Chrome.split_tabs(Settings.tab_prefs, force: @active_tab)
       Chrome.render_menu(screen, layout.menu, active_tab: @active_tab,
         focused: @focus == :menu && !@menu_more,
-        tabs: effective_tabs, intercept_count: @session.interceptor.pending_count,
-        hidden_count: hidden_tab_count, more_focused: @focus == :menu && @menu_more)
+        tabs: vis_tabs, intercept_count: @session.interceptor.pending_count,
+        hidden_count: hid_tabs.size, more_focused: @focus == :menu && @menu_more)
       render_body(screen, layout.body)
       Chrome.render_status(screen, layout.status, focus: focus_label, hints: format_status_message(@toast) || key_hints,
         insecure_upstream: @session.config.insecure_upstream?,

--- a/src/gori/tui/screen.cr
+++ b/src/gori/tui/screen.cr
@@ -46,12 +46,23 @@ module Gori::Tui
     # Display width in terminal columns for `str`, using full Unicode East-Asian
     # + emoji rules (Hangul syllables, CJK, etc. are 2 columns).
     def self.display_width(str : String) : Int32
-      return 0 if str.empty?
+      # Printable-ASCII fast path (the common case — labels, host/path, header lines):
+      # every 0x20..0x7e byte is exactly one width-1 cell, so the column count IS the byte
+      # count. Skips grapheme clustering + the per-glyph `g.to_s` String each call. A control
+      # byte (width 0, e.g. \t/\r) or any >=0x80 byte (a multibyte lead/continuation) falls
+      # through to the exact grapheme walk. Empty string → bytesize 0 (old early return).
+      return str.bytesize if printable_ascii?(str)
       w = 0
       str.each_grapheme do |g|
         w += Termisu::UnicodeWidth.grapheme_width(g.to_s)
       end
       w
+    end
+
+    # Whether every byte is printable ASCII (0x20..0x7e) — one byte, one width-1 cell.
+    # Lets display_width skip grapheme walking on the common label/header string.
+    private def self.printable_ascii?(str : String) : Bool
+      str.to_slice.all? { |b| b >= 0x20_u8 && b <= 0x7e_u8 }
     end
 
     # As `display_width`, but stops as soon as the running width reaches `limit`
@@ -91,6 +102,12 @@ module Gori::Tui
     # cursor / Reveal count it as ≥1, so cursor placement must too or it lands one
     # column short and overwrites a glyph.
     def self.column_width(str : String) : Int32
+      # ASCII fast path: every ASCII char counts as exactly 1 column here — a printable is
+      # width 1, and a control char (width 0) is floored to 1 by the max below — so the span
+      # is just the char count. Skips the per-char `display_width(ch.to_s)` grapheme walk +
+      # String on the common case (all-ASCII fields). Non-ASCII keeps the exact per-char loop
+      # (wide glyphs via display_width, combining marks floored to 1).
+      return str.size if str.ascii_only?
       w = 0
       str.each_char { |ch| w += {display_width(ch.to_s), 1}.max }
       w


### PR DESCRIPTION
A **measure-first** pass over the hottest interactive paths. Every change is gated on a benchmark delta AND the full spec suite staying green, with **no observable behavior change** — byte-exact forwarding, identical rendered glyphs, identical query/pretty output.

## Changes

| change | before → after |
|---|---|
| **`Highlight.draw`** ASCII fast path — styled-line render primitive (16 call sites: History detail, Repeater, Intercept, Fuzzer, Decoder) | **217.7µs → 10.2µs (21×)**, 123 kB → **640 B/op** |
| **`Screen.display_width` / `column_width`** ASCII fast path (~36 call sites, many per-frame) | frame's-worth **17.2µs → 149 ns (115×)**, 7.66 kB → **0 B/op** |
| **`Chrome.split_tabs`** — reconcile the tab bar **once** per frame (was twice) | 1 reconcile/frame vs 2 |
| **`Template#render`** — pre-size the output buffer (per fuzz request) | **99.7ns → 75.5ns (1.32×)**, 1.0 kB → 480 B/op |
| **`Pretty.format`** — parse a JSON body **once** (GraphQL sniff + pretty share the tree) | 28.6 KB body **340µs → 232µs (1.47×)**, 582 kB → 369 kB/op |

The headline is the render primitive: the TUI panes drew every visible styled line by grapheme-clustering and allocating a `String` per glyph — even on pure-ASCII HTTP text — where `Screen#text` already had an ASCII fast path. Extending that fast path drops per-frame allocation to near-zero on the common case; non-ASCII (CJK/emoji/combining) keeps the exact grapheme path.

## Behavior preservation (the hard constraint)
- Specs **1800 → 1809, 0 failures** (9 new tests).
- `Highlight.draw`: new test locks glyph-for-glyph + advance parity with `Screen#text` across widths — mixed ASCII+CJK spans, ellipsis, width-1, zero-width.
- `display_width`: printable-ASCII (0x20–0x7e) is `grapheme_width == 1`; control bytes (width 0) correctly stay on the grapheme path.
- `Chrome.split_tabs`: test locks `split_tabs == {visible_tabs, hidden_tabs}` across the force / all-hidden edge cases.
- `Pretty.format`: golden over plain object / scalar / array / already-pretty / invalid / empty / GraphQL / query-vs-REST.
- `crystal tool format --check` clean; ameba introduces zero new findings.

## Not included (deliberate)
Micro-cleanups an adversarial review rated low-value on already-tight paths (count-pass merges, a double head scan, huffman `String.build`), a medium-risk styled-window cache that misses during scroll, and the FTS/SQL scan cost (needs index/schema changes — out of a behavior-preserving code pass).

## Benchmarks added
`highlight_draw_bench`, `display_width_bench`, `fuzz_render_bench`, `pretty_bench`.