### PR TITLE
fix(tui): unify x=select-line / hex=^X across body panes

### DIFF
--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -135,8 +135,10 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def repeater_copy_all : Nil; end
 
+  property repeater_read_mode : Bool = false # settable so grouped-menu specs can exercise the read-mode verbs
+
   def repeater_read_mode? : Bool
-    false
+    @repeater_read_mode
   end
 
   def fuzz_selected : Nil; end
@@ -425,8 +427,10 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def copy_as_open : Nil; end
 
+  property detail_navigable : Bool = false # settable so grouped-menu specs can exercise detail.select-line
+
   def detail_navigable? : Bool
-    false
+    @detail_navigable
   end
 
   def space_menu_title(verb_id : String) : String?

--- a/spec/tui/mouse_spec.cr
+++ b/spec/tui/mouse_spec.cr
@@ -278,7 +278,7 @@ describe "RepeaterView#chrome_hit" do
     # RESPONSE chips start at resp.x + 12
     view.chrome_hit(rect, resp.x + 12, resp.y).should eq(:diff)
     view.chrome_hit(rect, resp.x + 12 + 9, resp.y).should eq(:hex) # past " d:diff " + gap
-    view.chrome_hit(rect, resp.x + 12 + 9 + 8, resp.y).should eq(:pretty)
+    view.chrome_hit(rect, resp.x + 12 + 9 + 9, resp.y).should eq(:pretty)
 
     # REQUEST right-chain: rightmost is SEND, then CL, MARK, PRETTY
     send_label = " ^R:SEND "

--- a/spec/tui/repeater_view_spec.cr
+++ b/spec/tui/repeater_view_spec.cr
@@ -21,6 +21,29 @@ describe Gori::Tui::RepeaterView do
   # off so a (future) valid-JSON/XML fixture can't silently reflow and shift assertions.
   before_each { Gori::Settings.pretty_bodies_default = false }
 
+  # The response pane's ^X hex dump: repeater_toggle_hex routes response-focus to
+  # exactly this view toggle (the `x` key selects a line now — hex moved to ^X).
+  it "toggle_resp_hex flips resp_hex? and renders a raw byte dump of the response" do
+    view = RepeaterView.new
+    view.load_blank
+    view.apply(Gori::Repeater::Result.new("HTTP/1.1 200 OK\r\n\r\n".to_slice, "PONG".to_slice, nil, 1000_i64))
+    view.focus_pane(:response)
+    view.resp_hex?.should be_false # plain response mode by default
+
+    view.toggle_resp_hex
+    view.resp_hex?.should be_true
+    hexb = MemoryBackend.new(120, 20)
+    view.render(Screen.new(hexb), Rect.new(0, 0, 120, 20))
+    hexb.contains?("00000000").should be_true    # hex dump offset column
+    hexb.contains?("50 4f 4e 47").should be_true # "PONG" as raw bytes
+
+    view.toggle_resp_hex # ^X again exits back to the decoded body
+    view.resp_hex?.should be_false
+    plain = MemoryBackend.new(120, 20)
+    view.render(Screen.new(plain), Rect.new(0, 0, 120, 20))
+    plain.contains?("PONG").should be_true
+  end
+
   it "load_blank seeds an editable, sendable scaffold (no source flow)" do
     view = RepeaterView.new
     view.load_blank

--- a/spec/tui/space_menu_spec.cr
+++ b/spec/tui/space_menu_spec.cr
@@ -44,6 +44,7 @@ describe Gori::Tui::SpaceMenu do
   it "lists the open flow's actions in the History detail scope (mirrors the list menu)" do
     ctx = FakeExecContext.new
     ctx.selected = 5_i64
+    ctx.detail_navigable = true # so detail.select-line ('x') is available in the menu
     menu = SpaceMenu.new(Gori::Verbs.registry)
     menu.open(Gori::Verb::Scope::HistoryDetail, :common, ctx) # detail drill-in is navigable now
 
@@ -53,7 +54,8 @@ describe Gori::Tui::SpaceMenu do
     ids.should contain("detail.repeater")     # flow action carried over from the list
     ids.should contain("detail.toggle-hex") # a detail-only view toggle
     menu.verb_for('r').try(&.id).should eq("detail.repeater")
-    menu.verb_for('x').try(&.id).should eq("detail.toggle-hex")
+    menu.verb_for('x').try(&.id).should eq("detail.select-line")
+    menu.verb_for('e').try(&.id).should eq("detail.toggle-hex")
   end
 
   it "lists the scope-rule actions in the Project scope pane (space replaced the lens toggle)" do
@@ -281,6 +283,7 @@ describe Gori::Tui::SpaceMenu do
   it "populates Repeater's :response group with diff/hex alongside pretty (Round 4 — was raw key-dispatch)" do
     ctx = FakeExecContext.new
     ctx.current_tab = :repeater
+    ctx.repeater_read_mode = true # so repeater.select-line ('x') is available in the menu
     menu = SpaceMenu.new(Gori::Verbs.registry)
 
     menu.open(Gori::Verb::Scope::Repeater, :response, ctx)
@@ -291,7 +294,8 @@ describe Gori::Tui::SpaceMenu do
     ids.should contain("repeater.toggle-resp-hex") # :response
     menu.verb_for('p').try(&.id).should eq("repeater.toggle-pretty")
     menu.verb_for('d').try(&.id).should eq("repeater.toggle-diff")
-    menu.verb_for('x').try(&.id).should eq("repeater.toggle-resp-hex")
+    menu.verb_for('x').try(&.id).should eq("repeater.select-line")
+    menu.verb_for('h').try(&.id).should eq("repeater.toggle-resp-hex")
   end
 
   it "populates Fuzzer's :subtab group with rename/close/duplicate (Round 4 — was raw key-dispatch)" do

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -869,7 +869,8 @@ describe Gori::Verb do
       # ←/→ in HistoryDetail walk the panes (left no longer just closes)
       keymap.lookup(Chord.new("right"), Scope::HistoryDetail).should eq("detail.next-pane")
       keymap.lookup(Chord.new("left"), Scope::HistoryDetail).should eq("detail.prev-pane")
-      keymap.lookup(Chord.new("x"), Scope::HistoryDetail).should eq("detail.toggle-hex")
+      keymap.lookup(Chord.new("x"), Scope::HistoryDetail).should eq("detail.select-line")
+      keymap.lookup(Chord.new("x", ctrl: true), Scope::HistoryDetail).should eq("detail.toggle-hex")
       # ^U in the Fuzzer pretty-prints the template (must NOT be intercepted as clear-marks
       # anymore — clear-marks moved to the space menu as fuzz.clear-marks).
       keymap.lookup(Chord.new("u", ctrl: true), Scope::Fuzzer).should eq("fuzz.pretty-template")

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -156,8 +156,6 @@ module Gori::Tui
         @history.detail_move(-1, 0, selecting: true) if nav
       when key.down? && selecting, key.lower_j? && selecting
         @history.detail_move(1, 0, selecting: true) if nav
-      when ev.key.lower_x? && nav
-        @history.detail_select_line
       when ev.char == 'y' || ev.key.lower_y?
         detail_copy_selection
       else

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -335,7 +335,7 @@ module Gori::Tui
         end
       when :response
         nav = v.resp_navigable? ? "↑/↓ move" : "↑/↓ scroll"
-        "#{nav} · #{read_common} · #{diff} diff · ⇧←/→ h-scroll · x hex · #{pretty} pretty · ^F find · ↵/#{send} send · ↹ pane · esc tabs"
+        "#{nav} · #{read_common} · #{diff} diff · ⇧←/→ h-scroll · #{hex} hex · #{pretty} pretty · ^F find · ↵/#{send} send · ↹ pane · esc tabs"
       when :request
         if v.request_insert?
           "type to edit · ^G goto · ^F find · #{hex} hex · esc read · ↹ pane"
@@ -601,8 +601,11 @@ module Gori::Tui
       elsif view.focus == :request
         on = view.toggle_request_hex
         @host.status(on ? "hex edit: on — sends exact bytes (^X/esc exit; not text-safe)" : "hex edit: off")
+      elsif view.focus == :response
+        view.toggle_resp_hex
+        @host.status(view.resp_hex? ? "response hex dump: on — raw bytes (^X exit)" : "response hex dump: off")
       else
-        @host.status("hex edit (^X) applies to the REQUEST pane — ↹ to it")
+        @host.status("hex edit (^X) applies to the REQUEST or RESPONSE pane — ↹ to one")
       end
     end
 
@@ -1577,7 +1580,7 @@ module Gori::Tui
       when transcript
         # Transcript: no d/x/p tools; still let Global breath / copy through.
         return false if c && !ev.ctrl? && !ev.alt? && !c.control?
-      when key.lower_x? then view.toggle_resp_hex # pane-local (select-line owns `x` on req/tgt)
+      when key.lower_x? then view.pane_select_line # 'x' selects the line everywhere (hex is ^X)
       when key.lower_b? then @host.toggle_reveal  # bare `b` (Global reveal is ^B)
       when c && !ev.ctrl? && !ev.alt? && !c.control?
         return false # d diff, p pretty, y copy, Global c/i/s, …

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -61,8 +61,8 @@ module Gori::Tui
         Item.new("/", "filter (query language)", "history.query"),
         Item.new("y", "copy flow", "history.copy"),
         Item.new("i", "toggle intercept hold-mode", "intercept.toggle"),
-        Item.new("detail", "↑/↓ move · ⇧arrows select · y copy · space cmds · ⇧←/→ h-scroll"),
-        Item.new("x · b · p", "in detail: hex · whitespace · pretty bodies"),
+        Item.new("detail", "↑/↓ move · x line · ⇧arrows select · y copy · space cmds · ⇧←/→ h-scroll"),
+        Item.new("^X · b · p", "in detail: hex · whitespace · pretty bodies"),
       ]},
       {"REPEATER", [
         Item.new("^R", "send the request", "repeater.send"),
@@ -74,7 +74,7 @@ module Gori::Tui
         Item.new("i / ↵", "enter INS (edit) on request/target · esc back to READ"),
         Item.new("space", "command menu (READ mode on request/target/response)"),
         Item.new("y", "copy selection/line (READ)", "repeater.copy"),
-        Item.new("⇧arrows", "select text (line or char)"),
+        Item.new("x · ⇧arrows", "select the current line · extend selection"),
         Item.new("^X", "hex-edit the request", "repeater.toggle-hex"),
         Item.new("^S", "SNI override (on the target)", "repeater.toggle-sni"),
         Item.new("^L", "toggle auto Content-Length", "repeater.toggle-auto-content-length"),
@@ -83,7 +83,7 @@ module Gori::Tui
         Item.new("↹", "cycle target → request → response"),
         Item.new("d", "response: toggle diff", "repeater.toggle-diff"),
         Item.new("p", "response: pretty bodies", "repeater.toggle-pretty"),
-        Item.new("x", "response: hex dump (pane-local)"),
+        Item.new("^X", "response: hex dump (pane-local)"),
         Item.new("⇧←/→", "response: scroll a long line sideways"),
       ]},
       {"FUZZER", [

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -1279,14 +1279,14 @@ module Gori::Tui
     # Mode toggle chips for the detail strip: {id, label, lit}.
     private def detail_mode_chips(hex : Bool, ws : Bool, dv : DetailView) : Array({Symbol, String, Bool})
       if hex
-        [{:hex, " x:text ", true}] of {Symbol, String, Bool}
+        [{:hex, " ^X:text ", true}] of {Symbol, String, Bool}
       elsif ws
         [{:ws, " b:raw ", true}] of {Symbol, String, Bool}
       elsif dv.binary
-        [{:hex, " x:hex ", false}] of {Symbol, String, Bool}
+        [{:hex, " ^X:hex ", false}] of {Symbol, String, Bool}
       else
         [
-          {:hex, " x:hex ", false},
+          {:hex, " ^X:hex ", false},
           {:ws, " b:ws ", false},
           {:pretty, dv.pretty ? " p:raw " : " p:pretty ", dv.pretty},
         ] of {Symbol, String, Bool}

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -1532,7 +1532,7 @@ module Gori::Tui
         if right.w >= 2 && my == right.y
           if hit = Frame.left_chip_hit(mx, my, right.y, right.x + 12, [
                {:diff, " d:diff "},
-               {:hex, " x:hex "},
+               {:hex, " ^X:hex "},
                {:pretty, " p:pretty "},
              ] of {Symbol, String})
             return hit
@@ -2375,7 +2375,7 @@ module Gori::Tui
       diff_lit = !@resp_hex && @resp_mode == :diff
       pretty_lit = resp_plain && !@reveal && resp_pretty_applied?
       x = Frame.chip(screen, rect.x + 12, rect.y, " d:diff ", diff_lit) + 1
-      x = Frame.chip(screen, x, rect.y, " x:hex ", @resp_hex) + 1
+      x = Frame.chip(screen, x, rect.y, " ^X:hex ", @resp_hex) + 1
       chips_end = Frame.chip(screen, x, rect.y, " p:pretty ", pretty_lit)
       if result = @result
         meta = result.ok? ? "#{Fmt.dur(result.duration_us)} · #{Fmt.size((result.head.size + (result.body.try(&.size) || 0)).to_i64)}" : Fmt.dur(result.duration_us)

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -160,7 +160,7 @@ module Gori
       r.register Verb::Definition.new(
         "repeater.toggle-hex", "Toggle hex edit", "Edit the request as raw bytes — sends exactly what you type",
         Verb::Scope::Repeater, [Verb::Chord.new("x", ctrl: true)],
-        available: in_repeater, mnemonic: 'x', section: :request) { |ctx| ctx.repeater_toggle_hex; nil }
+        available: in_repeater, mnemonic: 'b', section: :request) { |ctx| ctx.repeater_toggle_hex; nil }
       r.register Verb::Definition.new(
         "repeater.toggle-decoded", "Switch envelope/decoded", "SAML/GraphQL flow: switch envelope/decoded · in MARK mode: insert a § at the cursor",
         Verb::Scope::Repeater, [Verb::Chord.new("t", ctrl: true)],
@@ -201,7 +201,7 @@ module Gori
         available: in_repeater, mnemonic: 'd', section: :response) { |ctx| ctx.repeater_toggle_resp_diff; nil }
       r.register Verb::Definition.new(
         "repeater.toggle-resp-hex", "Hex dump", "Toggle a raw hex dump of the response bytes",
-        Verb::Scope::Repeater, available: in_repeater, mnemonic: 'x', section: :response) { |ctx| ctx.repeater_toggle_resp_hex; nil }
+        Verb::Scope::Repeater, available: in_repeater, mnemonic: 'h', section: :response) { |ctx| ctx.repeater_toggle_resp_hex; nil }
       r.register Verb::Definition.new(
         "repeater.toggle-pretty", "Pretty bodies", "Pretty-print JSON/XML/form/… response bodies (display only)",
         Verb::Scope::Repeater, [Verb::Chord.new("p")],
@@ -249,11 +249,12 @@ module Gori
         Verb::Scope::HistoryDetail, [Verb::Chord.new("tab")], hidden: true) { |ctx| ctx.toggle_detail_pane; nil }
 
       # The view-toggles are NON-hidden so they front the detail's "space" action menu
-      # (the palette stays Global-only, so un-hiding doesn't leak there). The shown
-      # menu key derives from each plain chord — exactly the key you'd press directly.
+      # (the palette stays Global-only, so un-hiding doesn't leak there). ws/pretty take
+      # their menu key from their plain chord (b/p) — exactly the key you'd press. Hex is
+      # ^X (plain `x` = select-line), so it carries an explicit 'e' mnemonic for the menu.
       r.register Verb::Definition.new(
         "detail.toggle-hex", "Hex view", "Toggle a raw hex dump of the request/response bytes",
-        Verb::Scope::HistoryDetail, [Verb::Chord.new("x")]) { |ctx| ctx.toggle_detail_hex; nil }
+        Verb::Scope::HistoryDetail, [Verb::Chord.new("x", ctrl: true)], mnemonic: 'e') { |ctx| ctx.toggle_detail_hex; nil }
 
       r.register Verb::Definition.new(
         "detail.toggle-ws", "Reveal whitespace", "Show whitespace/CR/LF as glyphs (·→␍␊)",
@@ -392,7 +393,7 @@ module Gori
         available: in_fuzzer, mnemonic: 'h', section: :template) { |ctx| ctx.fuzz_toggle_http2; nil }
       r.register Verb::Definition.new(
         "fuzz.clear-marks", "Clear markers", "Strip every §…§ marker (and its attached chain) from the template",
-        Verb::Scope::Fuzzer, available: in_fuzzer, mnemonic: 'x', section: :template) { |ctx| ctx.fuzz_clear_marks; nil }
+        Verb::Scope::Fuzzer, available: in_fuzzer, mnemonic: 'e', section: :template) { |ctx| ctx.fuzz_clear_marks; nil }
       in_fuzzer_read = ->(ctx : Verb::ExecContext) { ctx.current_tab == :fuzzer && ctx.fuzzer_read_mode? }
       # The single smart Copy (see repeater.copy above) — copy-all is gone.
       r.register Verb::Definition.new(

--- a/src/gori/verbs/read_edit.cr
+++ b/src/gori/verbs/read_edit.cr
@@ -27,17 +27,16 @@ module Gori
         "notes.clear-selection", "Clear selection", "Clear the text selection",
         Verb::Scope::Notes, available: in_sel, mnemonic: 'v') { |ctx| ctx.read_clear_selection; nil }
 
-      # Tagged :response (not :common): select/clear are equally available in the
-      # REQUEST/TARGET panes (in_repeater_read covers all three), but :response is
-      # where reading-then-copying a snippet is the natural flow, and :request is
-      # already the busiest section (9 marker/view-toggle actions) — keeping these
-      # out of it (and out of COMMON) keeps both lean. The plain 'x' keybinding still
-      # works in every read-mode pane regardless of where the menu lists it.
+      # Plain 'x' = select-line in every Repeater read-mode pane (request/target/response),
+      # now that hex is ^X everywhere (the old x=resp-hex collision is gone). Tagged
+      # :response (not :common) so the busy :request section and lean COMMON stay
+      # uncluttered — and so 'x' never surfaces in the tab-bar/:subtab menus; the 'x'
+      # keybinding still works in all three read panes regardless of where it's listed.
       in_repeater_read = ->(ctx : Verb::ExecContext) { ctx.current_tab == :repeater && ctx.repeater_read_mode? }
       r.register Verb::Definition.new(
         "repeater.select-line", "Select line", "Select the entire current line",
         Verb::Scope::Repeater, [Verb::Chord.new("x")],
-        available: in_repeater_read, mnemonic: 'l', section: :response) { |ctx| ctx.read_select_line; nil }
+        available: in_repeater_read, mnemonic: 'x', section: :response) { |ctx| ctx.read_select_line; nil }
       r.register Verb::Definition.new(
         "repeater.clear-selection", "Clear selection", "Clear the text selection",
         Verb::Scope::Repeater, available: in_sel, mnemonic: 'v', section: :response) { |ctx| ctx.read_clear_selection; nil }
@@ -60,7 +59,7 @@ module Gori
       r.register Verb::Definition.new(
         "fuzzer.select-line", "Select line", "Select the entire current line",
         Verb::Scope::Fuzzer, [Verb::Chord.new("x")],
-        available: in_fuzzer_read, mnemonic: 'S', section: :template) { |ctx| ctx.read_select_line; nil }
+        available: in_fuzzer_read, mnemonic: 'x', section: :template) { |ctx| ctx.read_select_line; nil }
       r.register Verb::Definition.new(
         "fuzzer.clear-selection", "Clear selection", "Clear the text selection",
         Verb::Scope::Fuzzer, available: in_sel, mnemonic: 'v', section: :template) { |ctx| ctx.read_clear_selection; nil }
@@ -86,8 +85,8 @@ module Gori
       in_detail_nav = ->(ctx : Verb::ExecContext) { ctx.detail_navigable? }
       r.register Verb::Definition.new(
         "detail.select-line", "Select line", "Select the entire current line",
-        Verb::Scope::HistoryDetail,
-        available: in_detail_nav, mnemonic: 'L') { |ctx| ctx.read_select_line; nil }
+        Verb::Scope::HistoryDetail, [Verb::Chord.new("x")],
+        available: in_detail_nav, mnemonic: 'x') { |ctx| ctx.read_select_line; nil }
       r.register Verb::Definition.new(
         "detail.clear-selection", "Clear selection", "Clear the text selection",
         Verb::Scope::HistoryDetail, available: in_sel, mnemonic: 'v') { |ctx| ctx.read_clear_selection; nil }


### PR DESCRIPTION
## What & why

Audited the TUI for places where the on-screen **notation (표기)** disagreed with the
**actual key behavior (입력)**. The trigger: the History-detail / Repeater-response panes show
a ` x:hex ` chip, but plain `x` actually selects the current line on a navigable body — the same
`x` collision (hex vs select-line) was resolved two different ways across areas.

Standardized on the read-mode convention already used in 7 of 8 panes:

| | before | after |
|---|---|---|
| plain `x` (read mode) | mixed: hex on response/detail, select-line elsewhere | **select-line everywhere** |
| hex | mixed: `x` on response/detail, `^X` on request/decoder | **`^X` everywhere** |
| chip | ` x:hex ` | ` ^X:hex ` |

## Changes (scope: the 3 real mismatches — F1/F2/F3)

- **History-detail** — `x` → `detail.select-line` (via keymap), `^X` → `detail.toggle-hex`; removed the
  controller's local `x` interception; relabeled the detail chips.
- **Repeater response** — `x` → select-line, `^X` → response hex dump (`repeater_toggle_hex` is now
  pane-aware); `repeater.select-line`'s section/mnemonic now match where `x` fires; fixed a false comment.
- **Space-menu accelerators** — select-line mnemonic → `x`; the hex verbs and `fuzz.clear-marks` move
  off `x` (`e`/`b`/`h`) to avoid `validate_menu_keys!` collisions. The `^X` chord + chips stay uniform.
- **help_view** — now teaches `^X` = hex and `x` = select-line for detail/response (was still saying `x`=hex).

## Verification

- `crystal spec` — **1801 examples, 0 failures** (incl. a new `toggle_resp_hex` view test). The real
  registry runs `validate_menu_keys!` at boot, so mnemonic collisions would raise.
- Compiles; format-clean edits; no new ameba findings (`handle_detail_key` complexity 23 → 21).

## Out of scope (documented for a follow-up)

Low-severity polish surfaced by the audit but not fixed here: Sitemap `↵/→ expand` wording, Project
copy `y`/`Y` case, `i:INS` badge, hardcoded chips going stale under rebind, hotkeys-overlay chord
format, and the intercept "catch" wording.
