### PR TITLE
feat(tui): move upstream TLS verify from status chip to Settings: Network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Changed — upstream TLS verification moved to Settings: Network
+
+The bottom status bar no longer carries the `upstream:verify` / `upstream:insecure`
+chip. Upstream TLS certificate verification is now a live toggle in **Settings:
+Network** (command palette → `settings:network` → "Verify upstream TLS"). Toggling
+it re-syncs the running capture proxy, the active-probe sender, and the Repeater/
+Fuzzer/Miner senders without a restart, and the choice persists globally in
+`settings.json` (`network.verify_upstream`). The `--insecure-upstream` launch flag
+still works: it seeds the toggle off for that session (and the editor reflects it).
+`gori run` / MCP keep their own `--insecure-upstream` flag.
+
 ### Performance — behavior-preserving hot-path optimizations
 
 A measured pass over the render / fuzz / decoder hot paths (micro-benchmarks in

--- a/spec/project_registry_spec.cr
+++ b/spec/project_registry_spec.cr
@@ -132,6 +132,35 @@ describe Gori::Session do
     end
   end
 
+  it "flips upstream TLS verification live across config, tunnel, and probe" do
+    with_root do |root|
+      ca = Gori::Proxy::Tls::CertAuthority.load_or_create(File.join(root, "ca"))
+      registry = Gori::Verbs.registry
+      config = Gori::Config.new(listen: "127.0.0.1", port: 0) # insecure_upstream defaults false → verify on
+      project = Gori::ProjectRegistry.new(root).temp("verify")
+
+      session = Gori::Session.open(config, ca, registry, project)
+      begin
+        # Baseline: verify on everywhere the toggle reaches.
+        session.config.insecure_upstream?.should be_false
+        session.tunnel.verify_upstream?.should be_true
+        session.probe.verify_upstream?.should be_true
+
+        session.set_verify_upstream(false)
+        session.config.insecure_upstream?.should be_true # repeater/fuzzer/miner read this per send
+        session.tunnel.verify_upstream?.should be_false  # next CONNECT skips verification
+        session.probe.verify_upstream?.should be_false   # next active probe skips verification
+
+        session.set_verify_upstream(true) # and back on
+        session.config.insecure_upstream?.should be_false
+        session.tunnel.verify_upstream?.should be_true
+        session.probe.verify_upstream?.should be_true
+      ensure
+        session.close
+      end
+    end
+  end
+
   it "opens in capture-off mode (non-fatal) when the bind port is already taken" do
     with_root do |root|
       ca = Gori::Proxy::Tls::CertAuthority.load_or_create(File.join(root, "ca"))

--- a/spec/tui/foundation_spec.cr
+++ b/spec/tui/foundation_spec.cr
@@ -123,22 +123,25 @@ describe Gori::Tui::Chrome do
   it "renders the focus-area badge at the far left of the status bar" do
     backend = MemoryBackend.new(90, 1)
     Chrome.render_status(Screen.new(backend), Rect.new(0, 0, 90, 1),
-      focus: "BODY", hints: "↹ pane · esc tabs", insecure_upstream: false)
+      focus: "BODY", hints: "↹ pane · esc tabs", activity: {"scanning", Theme.accent})
     backend.contains?("BODY").should be_true
-    backend.fg_at(1, 0).should eq(Theme.text_bright)    # badge text is bright (col 0 is the leading pad)
-    backend.contains?("↹ pane").should be_true          # hints still render to the right of the badge
-    backend.contains?("upstream:verify").should be_true # chips still on the right
+    backend.fg_at(1, 0).should eq(Theme.text_bright) # badge text is bright (col 0 is the leading pad)
+    backend.contains?("↹ pane").should be_true       # hints still render to the right of the badge
+    backend.contains?("scanning").should be_true     # the activity chip renders on the right
   end
 
-  it "keeps the focus badge intact when chips would otherwise overflow a narrow bar" do
-    # 36-col status rect ≈ a 40-col terminal (the minimum supported size). The
-    # widest chip pair must not clobber the persistent focus badge.
+  it "keeps the focus badge intact when a chip would otherwise overflow a narrow bar" do
+    # 36-col status rect ≈ a 40-col terminal (the minimum supported size). The activity
+    # label here is wide enough (>27 cols) that its natural right-aligned x falls left of
+    # the hint start, so the min_x floor MUST clamp it — proving the clamp protects the
+    # persistent focus badge rather than the chip merely happening to fit.
     backend = MemoryBackend.new(36, 1)
     Chrome.render_status(Screen.new(backend), Rect.new(0, 0, 36, 1),
-      focus: "ISSUE", hints: "type title · esc cancel", insecure_upstream: true)
-    backend.row(0)[0, 7].should eq(" ISSUE ") # badge survives, no chip bled into it
+      focus: "ISSUE", hints: "type title · esc cancel",
+      activity: {"scanning a very long-running background job", Theme.accent})
+    backend.row(0)[0, 7].should eq(" ISSUE ")     # badge survives, no chip bled into it
     backend.fg_at(1, 0).should eq(Theme.text_bright)
-    backend.contains?("upstream:insecure").should be_true # chips still present (truncated at the right edge)
+    backend.contains?("scanning").should be_true # chip still present (floored at the hint start, truncated at the right edge)
   end
 
   it "gilds the shell only for single-pane body focus" do
@@ -224,7 +227,7 @@ describe Gori::Tui::Chrome do
   it "omits the notify badge from the bottom status bar (it moved to the top bar)" do
     backend = MemoryBackend.new(90, 1)
     Chrome.render_status(Screen.new(backend), Rect.new(0, 0, 90, 1),
-      focus: "BODY", hints: "↹ pane · esc tabs", insecure_upstream: false)
+      focus: "BODY", hints: "↹ pane · esc tabs")
     backend.contains?("notify").should be_false
   end
 

--- a/spec/tui/settings_view_spec.cr
+++ b/spec/tui/settings_view_spec.cr
@@ -45,6 +45,33 @@ describe SettingsView do
     end
   end
 
+  it "toggles Verify upstream TLS off, then resets it to the default on save" do
+    dir = File.tempname("gori-settings-verify")
+    Dir.mkdir_p(dir)
+    prev_home = ENV["GORI_HOME"]?
+    prev = Gori::Settings.verify_upstream?
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.verify_upstream = true
+      v = SettingsView.new
+      v.reload(:network)
+      v.move_field(1)      # Bind IP → Bind Port
+      v.move_field(1)      # → Upstream proxy
+      v.move_field(1)      # → Verify upstream TLS (index 3, the bool)
+      v.toggle_or_move(-1) # flip the bool off
+      v.save               # persists the working copy back to the live Settings
+      Gori::Settings.verify_upstream?.should be_false
+
+      v.reset_to_defaults
+      v.save
+      Gori::Settings.verify_upstream?.should eq(Gori::Settings::DEFAULT_VERIFY_UPSTREAM)
+    ensure
+      prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
+      Gori::Settings.verify_upstream = prev
+      FileUtils.rm_rf(dir)
+    end
+  end
+
   it "reverts the EDITOR section toggles to their defaults on save" do
     dir = File.tempname("gori-settings-reset-ed")
     Dir.mkdir_p(dir)

--- a/src/gori/app.cr
+++ b/src/gori/app.cr
@@ -115,10 +115,11 @@ module Gori
     end
 
     private def open_and_run(project : Project, term : Termisu) : Symbol
-      # Pick up any bind address changed via Settings since startup (the previous
-      # session kept its bind; this one opens on the new one).
+      # Pick up any bind address / verify-upstream toggle changed via Settings since startup
+      # (the previous session kept its values; this one opens on the new ones).
       @config.listen = Settings.bind_host
       @config.port = Settings.bind_port
+      @config.insecure_upstream = !Settings.verify_upstream?
       session =
         begin
           # Interactive: auto-fall-back to a free port if the configured one is

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -117,7 +117,11 @@ module Gori
       # upstream proxy was already loaded by Settings.load.
       Settings.bind_host = listen
       Settings.bind_port = port
-      config = Config.new(listen, port, db_path, ca_dir, headless, insecure)
+      # --insecure-upstream is a launch override of the persisted verify toggle (mirrors the
+      # bind override above): force verify off for this session so the settings:network editor
+      # reflects the active state; toggling it there re-syncs the live proxy + persists.
+      Settings.verify_upstream = false if insecure
+      config = Config.new(listen, port, db_path, ca_dir, headless, !Settings.verify_upstream?)
       app = App.new(config)
 
       if config.headless?

--- a/src/gori/probe/analyzer.cr
+++ b/src/gori/probe/analyzer.cr
@@ -29,6 +29,10 @@ module Gori
       CATCHUP_SCAN     =    500     # recent flows the catch-up sweep re-checks each tick
 
       getter events : Channel(Event)
+      # Live-mutable so the TUI's settings:network toggle (Session#set_verify_upstream) can
+      # flip upstream TLS verification without a restart; read when each active probe builds
+      # its Fuzz::Sender, so the next probe picks up the change.
+      property? verify_upstream : Bool
 
       private record ActiveTask, rule : Active::Rule, plan : Active::Plan, detail : Store::FlowDetail
 

--- a/src/gori/proxy/tls/tunnel.cr
+++ b/src/gori/proxy/tls/tunnel.cr
@@ -16,6 +16,11 @@ module Gori::Proxy::Tls
   # loop with the upstream pinned to the CONNECT target over a TLS client
   # connection — so the same codec/capture path serves decrypted traffic.
   class Tunnel < Proxy::TlsMitm
+    # Live-mutable so the TUI's settings:network toggle (Session#set_verify_upstream) can
+    # flip upstream TLS verification without a restart; read per-CONNECT in `intercept`, so
+    # the next tunnelled connection picks up the change.
+    property? verify_upstream : Bool
+
     def initialize(@ca : CertAuthority, @verify_upstream : Bool = true,
                    @rewriter : Proxy::HeadRewriter? = nil,
                    @interceptor : Gori::Interceptor? = nil,

--- a/src/gori/session.cr
+++ b/src/gori/session.cr
@@ -26,6 +26,7 @@ module Gori
     getter project : Project
     getter store : Store
     getter proxy : Proxy::Server
+    getter tunnel : Proxy::Tls::Tunnel
     getter flow_events : Channel(Store::FlowEvent)
     # The passive/active scanner. Subscribes to the store's parallel probe_events feed and
     # writes grouped issues; runs for both the TUI and headless capture.
@@ -112,7 +113,7 @@ module Gori
           store.abandon_pending!("orphaned by a previous session")
           probe.start
         end
-        session = new(config, ca, registry, project, store, proxy, events, probe, rules, scope, host_overrides, interceptor, bind_error, lock)
+        session = new(config, ca, registry, project, store, proxy, tunnel, events, probe, rules, scope, host_overrides, interceptor, bind_error, lock)
         session.sync_capture_status!
         session
       rescue ex
@@ -128,9 +129,19 @@ module Gori
       end
     end
 
-    def initialize(@config, @ca, @registry, @project, @store, @proxy, @flow_events, @probe,
+    def initialize(@config, @ca, @registry, @project, @store, @proxy, @tunnel, @flow_events, @probe,
                    @rules, @scope, @host_overrides, @interceptor, @bind_error : String? = nil,
                    @capture_lock : CaptureLock? = nil)
+    end
+
+    # Flip upstream TLS verification live (settings:network toggle). Updates the runtime
+    # config (repeater/fuzzer/miner read config.insecure_upstream? per send), the capture
+    # proxy's TLS tunnel (next CONNECT), and the active-probe sender (next probe). Global —
+    # the persisted Settings.verify_upstream is the source of truth across restarts.
+    def set_verify_upstream(verify : Bool) : Nil
+      @config.insecure_upstream = !verify
+      @tunnel.verify_upstream = verify
+      @probe.verify_upstream = verify
     end
 
     def capturing? : Bool

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -20,6 +20,7 @@ module Gori
     DEFAULT_BIND_HOST       = "127.0.0.1"
     DEFAULT_BIND_PORT       = 8070
     DEFAULT_UPSTREAM_PROXY  = ""
+    DEFAULT_VERIFY_UPSTREAM = true
     DEFAULT_EDITOR          = ""
     DEFAULT_EDITOR_MARKDOWN = true
     DEFAULT_THEME           = "goridark"
@@ -41,6 +42,11 @@ module Gori
     class_property bind_host : String = DEFAULT_BIND_HOST
     class_property bind_port : Int32 = DEFAULT_BIND_PORT
     class_property upstream_proxy : String = DEFAULT_UPSTREAM_PROXY # "host:port" HTTP proxy; "" = connect directly
+    # Whether the proxy/probe/repeater verify the UPSTREAM TLS certificate. The launch
+    # flag --insecure-upstream seeds this false for the session (see CLI.run_tui); the
+    # settings:network editor toggles it live via Session#set_verify_upstream. Global-only
+    # (no per-project override). CLI `run`/MCP paths keep their own --insecure-upstream flag.
+    class_property? verify_upstream : Bool = DEFAULT_VERIFY_UPSTREAM
 
     # Per-project network overrides — a RUNTIME layer set by Session.open from the OPEN
     # project's DB and NEVER persisted to settings.json (the project's own DB is the source
@@ -154,6 +160,7 @@ module Gori
         self.bind_host = net["bind_host"]?.try(&.as_s?) || bind_host
         self.bind_port = net["bind_port"]?.try(&.as_i?) || bind_port
         self.upstream_proxy = net["upstream_proxy"]?.try(&.as_s?) || upstream_proxy
+        self.verify_upstream = load_bool(net, "verify_upstream", verify_upstream?)
       end
       self.theme = root["theme"]?.try(&.as_s?) || theme # validated against the known themes by Theme.apply
       self.mouse = load_bool(root, "mouse", mouse)
@@ -488,6 +495,7 @@ module Gori
               j.field "bind_host", bind_host
               j.field "bind_port", bind_port
               j.field "upstream_proxy", upstream_proxy
+              j.field "verify_upstream", verify_upstream?
             end
           end
           j.field "editor" do

--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -428,19 +428,20 @@ module Gori::Tui
       ""
     end
 
-    # Bottom row: a focus-area badge (far left) + contextual key hints + an upstream
-    # state chip (right). The badge — TABS / BODY / an overlay name — is a lifted
-    # chip so the user always knows which region the keys drive. (The notification
-    # unread badge lives on the top bar, next to scope; capture on/off/failing now
-    # rides the top bar's listen chip instead of a dedicated chip here.)
+    # Bottom row: a focus-area badge (far left) + contextual key hints + an optional
+    # background-activity chip (right). The badge — TABS / BODY / an overlay name — is a
+    # lifted chip so the user always knows which region the keys drive. (The notification
+    # unread badge lives on the top bar, next to scope; capture on/off/failing rides the
+    # top bar's listen chip; upstream TLS verification is now a settings:network toggle,
+    # not a status chip.)
     def self.render_status(screen : Screen, rect : Rect, *, focus : String, hints : String,
-                           insecure_upstream : Bool, activity : {String, Color}? = nil) : Nil
+                           activity : {String, Color}? = nil) : Nil
       screen.fill(rect, Theme.panel)
       badge = " #{focus} "
       screen.text(rect.x, rect.y, badge, Theme.text_bright, Theme.elevated, Attribute::Bold)
       hint_x = rect.x + badge.size + 1
 
-      chips = status_chips(insecure_upstream: insecure_upstream, activity: activity).map { |(_, l, c)| {l, c} }
+      chips = status_chips(activity: activity).map { |(_, l, c)| {l, c} }
       hint_w = {rect.right - hint_x - chips_width(chips) - 2, 1}.max
       screen.text(hint_x, rect.y, hints, Theme.muted, Theme.panel, width: hint_w)
       # Floor the chips at the hint start so they can never overwrite the badge.
@@ -466,14 +467,12 @@ module Gori::Tui
     end
 
     # The right-aligned status chips, TAGGED so render and (were there a clickable
-    # chip here) a hit-test would share one ordered source. A background-activity
-    # chip (spinner + label) precedes the upstream chip.
-    private def self.status_chips(*, insecure_upstream : Bool,
-                                  activity : {String, Color}?) : Array({Symbol, String, Color})
+    # chip here) a hit-test would share one ordered source. Currently just the optional
+    # background-activity chip (spinner + label); the tagged-tuple shape is kept so more
+    # chips can be added later without touching the render / hit-test split.
+    private def self.status_chips(*, activity : {String, Color}?) : Array({Symbol, String, Color})
       chips = [] of {Symbol, String, Color}
       chips << {:activity, activity[0], activity[1]} if activity
-      # an insecure upstream is a security warning — the one allowed non-status colour.
-      chips << (insecure_upstream ? {:upstream, "upstream:insecure", Theme.yellow} : {:upstream, "upstream:verify", Theme.muted})
       chips
     end
 

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -2142,7 +2142,7 @@ module Gori::Tui
         # rest just persist (the value is read live or only matters next session).
         msg = @settings_view.save
         @toast = case @settings_view.section
-                 when :network then apply_settings(msg).tap { project_controller.refresh_network } # re-sync the Project pane's inherited fields to the new global
+                 when :network then apply_settings(msg).tap { @session.set_verify_upstream(Settings.verify_upstream?); project_controller.refresh_network } # push the verify toggle to the live proxy/probe, then re-sync the Project pane's inherited fields to the new global
                  when :theme   then apply_theme(msg)
                  when :layout  then apply_layout(msg)
                  else               msg
@@ -2939,7 +2939,6 @@ module Gori::Tui
         hidden_count: hid_tabs.size, more_focused: @focus == :menu && @menu_more)
       render_body(screen, layout.body)
       Chrome.render_status(screen, layout.status, focus: focus_label, hints: format_status_message(@toast) || key_hints,
-        insecure_upstream: @session.config.insecure_upstream?,
         activity: activity_chip)
       Chrome.render_statusline(screen, layout.statusline, @statusline.segments) unless layout.statusline.empty?
       @palette.render(screen, layout.body) if @overlay == :palette

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -25,6 +25,7 @@ module Gori::Tui
       Field.new("Bind IP", "global default listen address — projects may pin their own"),
       Field.new("Bind Port", "global default port (0-65535) — project overrides win when set"),
       Field.new("Upstream proxy", "host:port — blank = connect directly; projects may override"),
+      Field.new("Verify upstream TLS", "check the upstream server's certificate — off accepts any cert (MITM/testing); ←/→/space toggles", bool: true),
       Field.new("Hostname overrides", "↵ to edit the global IP→host map (a /etc/hosts for this proxy)", opener: :hosts),
     ]
     EDITOR_FIELDS = [
@@ -109,7 +110,7 @@ module Gori::Tui
                 when :theme      then [Theme.canonical(Settings.theme)]
                 when :layout     then layout_values
                 when :statusline then [Settings.statusline_enabled? ? "on" : "off", Settings.statusline_command, Settings.statusline_interval.to_s]
-                else                  [Settings.bind_host, Settings.bind_port.to_s, Settings.upstream_proxy, hostnames_summary]
+                else                  [Settings.bind_host, Settings.bind_port.to_s, Settings.upstream_proxy, Settings.verify_upstream? ? "on" : "off", hostnames_summary]
                 end
       @focused = 0
       @cursor = @values[0].size
@@ -139,7 +140,7 @@ module Gori::Tui
                   Settings::DEFAULT_STATUSLINE_COMMAND,
                   Settings::DEFAULT_STATUSLINE_INTERVAL.to_s,
                 ]
-                else [Settings::DEFAULT_BIND_HOST, Settings::DEFAULT_BIND_PORT.to_s, Settings::DEFAULT_UPSTREAM_PROXY, hostnames_summary]
+                else [Settings::DEFAULT_BIND_HOST, Settings::DEFAULT_BIND_PORT.to_s, Settings::DEFAULT_UPSTREAM_PROXY, Settings::DEFAULT_VERIFY_UPSTREAM ? "on" : "off", hostnames_summary]
                 end
       @focused = 0
       @cursor = @values[0].size
@@ -335,7 +336,8 @@ module Gori::Tui
       Settings.bind_host = @values[0].strip
       Settings.bind_port = port
       Settings.upstream_proxy = up
-      @values = [Settings.bind_host, Settings.bind_port.to_s, Settings.upstream_proxy, hostnames_summary]
+      Settings.verify_upstream = @values[3] == "on"
+      @values = [Settings.bind_host, Settings.bind_port.to_s, Settings.upstream_proxy, Settings.verify_upstream? ? "on" : "off", hostnames_summary]
       persist
     end
 


### PR DESCRIPTION
## What

The bottom status bar no longer carries the `upstream:verify` / `upstream:insecure` chip. Upstream TLS certificate verification is now a **live, persisted toggle** in **Settings: Network** (command palette → `settings:network` → "Verify upstream TLS").

## Why

The permanent `upstream:verify` chip was noise for the default (secure) state, and verification is a network setting — it belongs alongside the other `settings:network` fields (bind, upstream proxy, hostname overrides), toggleable at runtime like Burp exposes it.

## Behavior

- Persisted globally as `network.verify_upstream` (default `true`); global-only, no per-project override.
- Toggling re-syncs the live capture proxy tunnel (next CONNECT), the active-probe sender (next probe), and the Repeater/Fuzzer/Miner senders — no restart (`Session#set_verify_upstream`).
- `--insecure-upstream` stays a launch override: it seeds the toggle off for that session and the editor reflects it.
- `gori run` / MCP keep their own `--insecure-upstream` flag (unchanged).

## Verification

- Full spec suite green (1812 examples). New tests: `Session#set_verify_upstream` flips config/tunnel/probe both ways; the `settings:network` verify toggle round-trips.
- Full codegen build links.
- Drove the boot/persistence path headlessly: banner reports `verify-upstream` by default, `insecure-upstream` when `network.verify_upstream:false` is persisted (no flag), and `--insecure-upstream` overrides a persisted `true`.

## Follow-up (not in this PR)

Generated TUI screenshots under `docs/static/images/tui/*.svg` still show the old `upstream:verify` chip — regenerate with `just docs-shots`.