### PR TITLE
fix(tui): stop tab-bar left-wrap, add detail ↑→TABS + '‹ list' back marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ Fuzzer/Miner senders without a restart, and the choice persists globally in
 still works: it seeds the toggle off for that session (and the editor reflects it).
 `gori run` / MCP keep their own `--insecure-upstream` flag.
 
+### Fixed — TUI navigation & detail affordances
+
+- **Tab bar left edge no longer wraps** — `←` (or `h`) on the leftmost tab
+  (Project) is now inert instead of jumping to the far-right tab, mirroring
+  `→`'s existing no-wrap at the right edge. A stray `←` on Project was almost
+  always accidental. `[`/`]` keep their from-anywhere wrap.
+- **History detail: `↑` at the top escapes to the tab bar** — matching the
+  list's `↑`-at-top → TABS. The detail closes (the scope model can't focus the
+  bar with the detail open) and the row selection is kept, so re-opening is one
+  keypress. Paging (PageUp) and the wheel are unaffected — only a single `↑` at
+  the very top pops focus up.
+- **Detail drill-ins advertise the way back** — a `‹ list` marker now rides the
+  top-left frame border of the History, Probe, and Issues detail views, making
+  the `←`/`esc` return-to-list gesture discoverable instead of buried in the
+  status hint.
+
 ### Performance — behavior-preserving hot-path optimizations
 
 A measured pass over the render / fuzz / decoder hot paths (micro-benchmarks in

--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -255,6 +255,39 @@ describe Gori::Tui::HistoryView do
     end
   end
 
+  it "renders the '‹ list' back marker on the detail's top frame border (framed path)" do
+    tmp_store do |store|
+      add_flow(store, "GET", "/api", 200)
+      view = HistoryView.new
+      view.reload(store)
+      view.open_detail(store).should be_true
+
+      backend = MemoryBackend.new(80, 16)
+      screen = Screen.new(backend)
+      # Render via the real framed path so inner.y - 1 lands on the drawn top border
+      # (existing detail specs render at rect.y == 0, where the marker is correctly skipped).
+      BodyChrome.framed(screen, Rect.new(0, 0, 80, 16), true) do |inner|
+        view.render_detail(screen, inner, focused: true)
+      end
+      backend.row(0).includes?("‹ list").should be_true
+    end
+  end
+
+  it "detail_at_top? tracks the caret so ↑ escapes to the tab bar only at the very top" do
+    tmp_store do |store|
+      add_flow(store, "GET", "/api", 200) # multi-line request head → caret can move
+      view = HistoryView.new
+      view.reload(store)
+      view.open_detail(store).should be_true
+
+      view.detail_at_top?.should be_true  # fresh open → caret on row 0
+      view.scroll_detail(1)               # caret down one line
+      view.detail_at_top?.should be_false
+      view.scroll_detail(-1)              # back to row 0
+      view.detail_at_top?.should be_true
+    end
+  end
+
   it "hscroll_detail scrolls a long response body line sideways into view (shift+←/→)" do
     tmp_store do |store|
       id = store.insert_flow(Gori::Store::CapturedRequest.new(

--- a/spec/tui/issues_view_spec.cr
+++ b/spec/tui/issues_view_spec.cr
@@ -37,6 +37,22 @@ describe Gori::Tui::IssuesView do
     end
   end
 
+  it "renders the '‹ list' back marker on the detail's top frame border (framed path)" do
+    tmp_store do |store|
+      store.insert_issue("SQL injection", Gori::Store::Severity::Critical, "acme.test", nil)
+      view = IssuesView.new
+      view.reload(store)
+      view.open_detail(store).should be_true
+
+      backend = MemoryBackend.new(80, 16)
+      screen = Screen.new(backend)
+      BodyChrome.framed(screen, Rect.new(0, 0, 80, 16), true) do |inner|
+        view.render(screen, inner, focused: true)
+      end
+      backend.row(0).includes?("‹ list").should be_true
+    end
+  end
+
   it "renders an empty-state when there are no issues" do
     tmp_store do |store|
       view = IssuesView.new

--- a/spec/tui/probe_view_spec.cr
+++ b/spec/tui/probe_view_spec.cr
@@ -54,6 +54,22 @@ describe Gori::Tui::ProbeView do
     end
   end
 
+  it "renders the '‹ list' back marker on the detail's top frame border (framed path)" do
+    view_store do |store|
+      seed(store, "missing_hsts", "a.test")
+      view = Gori::Tui::ProbeView.new
+      view.reload(store)
+      view.open_detail(store).should be_true
+
+      backend = MemoryBackend.new(80, 16)
+      screen = Gori::Tui::Screen.new(backend)
+      Gori::Tui::BodyChrome.framed(screen, Gori::Tui::Rect.new(0, 0, 80, 16), true) do |inner|
+        view.render(screen, inner)
+      end
+      backend.row(0).includes?("‹ list").should be_true
+    end
+  end
+
   it "honours an explicit status: filter even with the open-only lens (bypasses the default)" do
     view_store do |store|
       seed(store, "missing_hsts", "a.test")

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -333,6 +333,12 @@ module Gori::Tui
       @history.scroll_detail(delta)
     end
 
+    # The open detail is scrolled/caret'd to its very top — the boundary where a further
+    # ↑ escapes up to the tab bar (Runner#scroll_detail reads this).
+    def detail_at_top? : Bool
+      @history.detail_at_top?
+    end
+
     def detail_copy_selection : Nil
       text = @history.detail_copy_text
       if text.empty?

--- a/src/gori/tui/frame.cr
+++ b/src/gori/tui/frame.cr
@@ -48,6 +48,20 @@ module Gori::Tui
       end
     end
 
+    # A "‹ list" back affordance riding the top-left border of a detail drill-in, where
+    # `inner` is the framed interior (the frame sits one column outside it, as produced
+    # by BodyChrome.framed / rect.inset(1, 1)). Advertises that ←/esc return to the list
+    # behind the detail — the whole point being discoverability, since users miss the
+    # status-bar "esc back". Rides the border at Frame.card's title column so it reads as
+    # a control on the frame; call it AFTER the frame so it overwrites the hairline cleanly.
+    def self.list_back_hint(screen : Screen, inner : Rect, bg : Color = Theme.bg) : Nil
+      y = inner.y - 1
+      # ` ‹ list ` is 8 cells from inner.x + 1; require inner.w > 8 so its trailing cell
+      # stays left of the frame's top-right ╮ (at inner.x + inner.w) — never clobber it.
+      return if y < 0 || inner.w <= 8
+      screen.text(inner.x + 1, y, " ‹ list ", Theme.accent, bg, Attribute::Bold)
+    end
+
     # A `├───┤` divider across a card's interior at absolute row `y` — the seam
     # between an input/header band and the list below it.
     def self.tee_divider(screen : Screen, rect : Rect, y : Int32, bg : Color = Theme.panel) : Nil

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -668,6 +668,13 @@ module Gori::Tui
       end
     end
 
+    # True when the detail is at its very top: caret on row 0 (navigable text) or the
+    # scroll offset pinned to 0 (hex dump). Mirrors the list's at_top? so a ↑ here pops
+    # focus to the tab bar exactly as it does from the list's first row.
+    def detail_at_top? : Bool
+      detail_navigable? ? @detail_read.cy == 0 : @detail_scroll == 0
+    end
+
     # READ-mode caret move (+ optional shift selection). Arrow keys / detail.up/down
     # route here when the pane is navigable text (not a raw hex dump).
     # Lazy (size + line_at): a vertical step only materialises the destination line —
@@ -1300,6 +1307,8 @@ module Gori::Tui
         screen.text(rect.x + 1, rect.y, "no flow selected", Theme.muted)
         return
       end
+      # Back-to-list affordance on the top border (← past REQUEST / esc → the list).
+      Frame.list_back_hint(screen, rect)
       # Pane strip: show ALL panes as chips with the active one highlighted, so it's
       # obvious there's more behind (←/→ walk REQUEST → RESPONSE → FRAMES).
       x = rect.x + 1

--- a/src/gori/tui/issues_view.cr
+++ b/src/gori/tui/issues_view.cr
@@ -583,6 +583,8 @@ module Gori::Tui
 
     private def render_detail(screen : Screen, rect : Rect, focused : Bool) : Nil
       issue = @detail.not_nil!
+      # Back-to-list affordance on the top border (←/esc → the issue list).
+      Frame.list_back_hint(screen, rect)
       w = {rect.w - 2, 0}.max
 
       # y0 — title row: a severity-coloured bullet + the bright title; #id at the right.

--- a/src/gori/tui/probe_view.cr
+++ b/src/gori/tui/probe_view.cr
@@ -557,6 +557,8 @@ module Gori::Tui
 
     private def render_detail(screen : Screen, rect : Rect, focused : Bool) : Nil
       issue = @detail || return
+      # Back-to-list affordance on the top border (←/esc → the issue list).
+      Frame.list_back_hint(screen, rect)
       w = {rect.w - 2, 0}.max
       code_label = "##{issue.code}"
       screen.text(rect.right - code_label.size - 1, rect.y, code_label, Theme.muted)

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -3709,7 +3709,15 @@ module Gori::Tui
     end
 
     def menu_left : Nil
-      @menu_more ? (@menu_more = false) : cycle_tab(-1)
+      # ← off the ⋯ affordance steps back onto the bar; otherwise cycle left. The
+      # LEFTMOST tab is a hard stop — no wrap to the far end (mirrors menu_right's
+      # no-wrap at the right edge). A stray ← on Project used to jump to the last tab,
+      # which was almost always accidental, so the left edge is now inert.
+      if @menu_more
+        @menu_more = false
+      elsif !first_visible_tab?
+        cycle_tab(-1)
+      end
     end
 
     # The tabs hidden from the bar right now — the ⋯ dropdown's contents. The active tab
@@ -3724,6 +3732,10 @@ module Gori::Tui
 
     private def last_visible_tab? : Bool
       effective_tabs.last?.try(&.first) == @active_tab
+    end
+
+    private def first_visible_tab? : Bool
+      effective_tabs.first?.try(&.first) == @active_tab
     end
 
     # The anchor the dropdown drops down from — the ⋯ button's cell rect, or (defensively,
@@ -4298,6 +4310,18 @@ module Gori::Tui
     end
 
     def scroll_detail(delta : Int32) : Nil
+      # ↑ at the very top of the open detail pops focus up to the tab bar, mirroring
+      # the list's ↑-at-top → TABS. current_scope keys off @overlay before @focus, so
+      # the menu isn't reachable while :detail is open — close the detail first, then
+      # land on the bar. ↑ and ↓ aren't inverses here: ↵/↓ from the bar re-enters the
+      # LIST (not the detail), but the row selection is kept so re-opening is one key.
+      # Only the single-step detail.up/down verbs route here; PageUp (Runner) and the
+      # wheel (controller/view) bypass this, so paging/scrolling never ejects to TABS.
+      if delta < 0 && @overlay == :detail && history_controller.detail_at_top?
+        history_controller.close_detail
+        focus_pane(:menu)
+        return
+      end
       history_controller.scroll_detail(delta)
     end
 


### PR DESCRIPTION
Three TUI navigation / affordance fixes reported from daily use.

## 1. Tab bar no longer wraps at the left edge
`←` (or `h`) on the **leftmost** tab (Project) is now inert instead of jumping to the far-right tab — mirroring `→`'s existing no-wrap at the right edge. A stray `←` on Project was almost always accidental. Generalized to `first_visible_tab?` (not hardcoded to Project) so it respects a reordered tab bar. `[` / `]` keep their from-anywhere wrap.

## 2. History detail: `↑` at the top escapes to the tab bar
Matching the list's `↑`-at-top → TABS. Because `current_scope` keys off `@overlay` before `@focus`, the menu isn't focusable while the detail is open, so the detail **closes** on the way out and focus lands on the bar. `↑`/`↓` therefore aren't exact inverses (coming back down lands on the list), but the row selection is preserved so re-opening is one keypress. PageUp and the wheel bypass this path, so paging/scrolling never ejects to TABS.

## 3. Detail drill-ins advertise the way back
A `‹ list` marker now rides the top-left frame border of the **History / Probe / Issues** detail views (shared `Frame.list_back_hint`), making the `←`/`esc` return-to-list gesture discoverable instead of buried in the status hint. Follows the app's existing card-title style (`╭─ ‹ list ─…╮`).

Scoped to the views where **both** `←` and `esc` return to the list. Miner (esc-only) and Fuzzer (`←` = pane nav) are intentionally excluded, since a `‹` chevron would imply `←` works there.

## Verification
- Full build links; `crystal spec` → **1814/1814** green.
- New specs cover the `‹ list` marker via the real framed path (History/Probe/Issues) and `detail_at_top?` caret tracking. Existing detail specs render at `rect.y == 0`, where the marker is correctly skipped — so they didn't cover the new behavior.
- Runner-level pieces (`menu_left` no-op, the `scroll_detail` guard) are verified by reasoning (no Runner harness); they mirror the existing `menu_right` no-wrap and `move_selection` at-top patterns.