### PR TITLE
feat(miner): mine multipart/form-data and nested/array JSON bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### Added — Param Miner covers more body types
+
+The Miner now injects candidate parameters into two body shapes it previously
+ignored:
+
+- **multipart/form-data** — a new `multipart` location splices candidate fields
+  into an existing multipart body (reusing the request's boundary, byte-exact
+  otherwise), instead of silently falling back to query-only mining. It's
+  *applicable but off by default* (a captured file part would be re-sent on every
+  request); enable it with `--locations multipart`, the MCP `locations` field, or
+  its overlay checkbox.
+- **Nested & array JSON** — JSON mining previously probed only the top-level
+  object's keys. It now injects candidate keys into every object node — nested
+  objects and objects inside a root array included — capped BFS shallow-first, so
+  `{"data":{…}}` and `[{…},{…}]` bodies are covered. Single-object bodies mine
+  exactly as before.
+
 ### Changed — upstream TLS verification moved to Settings: Network
 
 The bottom status bar no longer carries the `upstream:verify` / `upstream:insecure`

--- a/docs/content/guide/scanning.md
+++ b/docs/content/guide/scanning.md
@@ -38,7 +38,7 @@ gori run probe -q 'host:example.com' # filter History with QL (Repeater still sc
 
 ## Param Miner
 
-The **Miner** discovers parameters a server accepts but doesn't advertise. Point it at a flow and it probes candidate names across locations — query string, form body, JSON, headers, and cookies — bucketing guesses efficiently and reporting the ones that change the response.
+The **Miner** discovers parameters a server accepts but doesn't advertise. Point it at a flow and it probes candidate names across locations — query string, form body, multipart/form-data, JSON (including nested objects and array roots), headers, and cookies — bucketing guesses efficiently and reporting the ones that change the response. Multipart is applicable but off by default (a captured file part would be re-sent on every request); enable it with `--locations multipart` or its checkbox.
 
 ```bash
 gori run mine <flow-id> \

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -164,7 +164,7 @@ gori run mine <flow-id> --locations query,headers --wordlist params.txt
 | Option | Description |
 |--------|-------------|
 | `--flow`, `--request`, `--target`, `--sni`, `--http2`, `-k` | Request source and transport |
-| `--locations=LIST` | `query`, `form`, `json`, `headers`, `cookies` |
+| `--locations=LIST` | `query`, `form`, `multipart`, `json`, `headers`, `cookies` (multipart off by default — pass it explicitly) |
 | `--wordlist`, `--bucket=N` | Candidate names and bucket size |
 | `--concurrency` (10), `--rate`, `--throttle`, `--timeout`, `--retries` (1), `--max-requests=N` | Rate control |
 | `--format` | `text`, `json`, or `jsonl` |

--- a/spec/miner/inject_spec.cr
+++ b/spec/miner/inject_spec.cr
@@ -10,6 +10,21 @@ private def text(bytes : Bytes) : String
   String.new(bytes)
 end
 
+# True when `needle` appears as a contiguous byte subsequence of `hay` (for asserting a binary
+# part survived injection byte-exact — String matching would mangle non-UTF-8 bytes).
+private def subseq?(hay : Bytes, needle : Bytes) : Bool
+  return true if needle.empty?
+  return false if needle.size > hay.size
+  (0..hay.size - needle.size).any? { |i| hay[i, needle.size] == needle }
+end
+
+# The body (bytes after the first blank line) of a request.
+private def body_of(bytes : Bytes) : Bytes
+  s = text(bytes)
+  i = s.index("\r\n\r\n")
+  i ? bytes[i + 4, bytes.size - (i + 4)] : Bytes.empty
+end
+
 describe Gori::Miner::Inject do
   it "appends a query param when there is no query string" do
     res = M::Inject.apply(req("GET /a HTTP/1.1\r\nHost: h\r\n\r\n"), M::Location::Query, [{"p", "v"}])
@@ -46,6 +61,118 @@ describe Gori::Miner::Inject do
     base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\nContent-Length: 5\r\n\r\n[1,2]"
     res = M::Inject.apply(req(base), M::Location::Json, [{"p", "v"}])
     text(res).should eq(base)
+  end
+
+  it "injects a candidate key into a NESTED JSON object as well as the root" do
+    # Parse the result and assert BOTH nodes carry the key — a `contain(%("p":"v"))` check would
+    # pass even if nested injection were broken, because the root always gets the key.
+    base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\nContent-Length: 15\r\n\r\n{\"data\":{\"a\":1}}"
+    res = M::Inject.apply(req(base), M::Location::Json, [{"p", "v"}])
+    parsed = JSON.parse(text(body_of(res)))
+    parsed.as_h.has_key?("p").should be_true         # root object
+    parsed["data"].as_h.has_key?("p").should be_true # nested object
+    parsed["data"]["p"].as_s.should eq("v")
+  end
+
+  it "injects into each object element of a JSON array root" do
+    base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\nContent-Length: 17\r\n\r\n[{\"a\":1},{\"b\":2}]"
+    res = M::Inject.apply(req(base), M::Location::Json, [{"p", "v"}])
+    parsed = JSON.parse(text(body_of(res))).as_a
+    parsed.size.should eq(2)
+    parsed.all? { |e| e.as_h.has_key?("p") }.should be_true
+  end
+
+  it "leaves an array of scalars unchanged (no object node)" do
+    base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\nContent-Length: 7\r\n\r\n[1,2,3]"
+    res = M::Inject.apply(req(base), M::Location::Json, [{"p", "v"}])
+    text(res).should eq(base)
+  end
+
+  it "leaves a scalar JSON root unchanged" do
+    base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\nContent-Length: 3\r\n\r\n\"x\""
+    res = M::Inject.apply(req(base), M::Location::Json, [{"p", "v"}])
+    text(res).should eq(base)
+  end
+
+  it "caps JSON injection at MAX_JSON_NODES object nodes (BFS shallow-first)" do
+    cap = M::Inject::MAX_JSON_NODES
+    elems = Array.new(cap + 8) { |i| %({"i":#{i}}) }.join(',')
+    base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\n\r\n[#{elems}]"
+    res = M::Inject.apply(req(base), M::Location::Json, [{"p", "v"}])
+    parsed = JSON.parse(text(body_of(res))).as_a
+    parsed.count { |e| e.as_h.has_key?("p") }.should eq(cap)
+  end
+
+  it "splices a field into an existing multipart body before the close delimiter" do
+    body = "--B\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\n1\r\n--B--\r\n"
+    base = "POST /u HTTP/1.1\r\nHost: h\r\nContent-Type: multipart/form-data; boundary=B\r\nContent-Length: #{body.bytesize}\r\n\r\n#{body}"
+    res = M::Inject.apply(req(base), M::Location::Multipart, [{"p", "v"}])
+    expected = "--B\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\n1\r\n" \
+               "--B\r\nContent-Disposition: form-data; name=\"p\"\r\n\r\nv\r\n" \
+               "--B--\r\n"
+    text(body_of(res)).should eq(expected)
+    text(res).should contain("Content-Length: #{expected.bytesize}")
+  end
+
+  it "preserves an epilogue after the multipart close delimiter" do
+    body = "--B\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\n1\r\n--B--\r\nEPILOGUE"
+    base = "POST /u HTTP/1.1\r\nHost: h\r\nContent-Type: multipart/form-data; boundary=B\r\nContent-Length: #{body.bytesize}\r\n\r\n#{body}"
+    res = M::Inject.apply(req(base), M::Location::Multipart, [{"p", "v"}])
+    nb = text(body_of(res))
+    nb.should contain(%(name="p"))
+    nb.should end_with("--B--\r\nEPILOGUE")
+    nb.index(%(name="p")).not_nil!.should be < nb.index("--B--").not_nil!
+  end
+
+  it "preserves a binary file part byte-exact" do
+    marker = Bytes[0xff_u8, 0xfe_u8, 0x00_u8, 0x10_u8]
+    b = IO::Memory.new
+    b << "--B\r\nContent-Disposition: form-data; name=\"f\"; filename=\"x.bin\"\r\nContent-Type: application/octet-stream\r\n\r\n"
+    b.write(marker)
+    b << "\r\n--B--\r\n"
+    body = b.to_slice
+    base = IO::Memory.new
+    base << "POST /u HTTP/1.1\r\nHost: h\r\nContent-Type: multipart/form-data; boundary=B\r\nContent-Length: #{body.size}\r\n\r\n"
+    base.write(body)
+    res = M::Inject.apply(base.to_slice, M::Location::Multipart, [{"p", "v"}])
+    subseq?(res, marker).should be_true
+    text(res).scrub.should contain(%(name="p"))
+  end
+
+  it "synthesises a well-formed multipart body when the original is empty" do
+    base = "POST /u HTTP/1.1\r\nHost: h\r\nContent-Type: multipart/form-data; boundary=B\r\nContent-Length: 0\r\n\r\n"
+    res = M::Inject.apply(req(base), M::Location::Multipart, [{"p", "v"}])
+    expected = "--B\r\nContent-Disposition: form-data; name=\"p\"\r\n\r\nv\r\n--B--\r\n"
+    text(body_of(res)).should eq(expected)
+    text(res).should contain("Content-Length: #{expected.bytesize}")
+  end
+
+  it "appends a close delimiter when the multipart body has none" do
+    body = "--B\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\n1\r\n"
+    base = "POST /u HTTP/1.1\r\nHost: h\r\nContent-Type: multipart/form-data; boundary=B\r\nContent-Length: #{body.bytesize}\r\n\r\n#{body}"
+    res = M::Inject.apply(req(base), M::Location::Multipart, [{"p", "v"}])
+    nb = text(body_of(res))
+    nb.should contain(%(name="a"))
+    nb.should contain(%(name="p"))
+    nb.should end_with("--B--\r\n")
+  end
+
+  it "does not inject multipart when the Content-Type has no boundary" do
+    body = "raw-body-without-boundary"
+    base = "POST /u HTTP/1.1\r\nHost: h\r\nContent-Type: multipart/form-data\r\nContent-Length: #{body.bytesize}\r\n\r\n#{body}"
+    res = M::Inject.apply(req(base), M::Location::Multipart, [{"p", "v"}])
+    text(res).should_not contain(%(name="p"))
+  end
+
+  it "rejects invalid multipart field names" do
+    body = "--B\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\n1\r\n--B--\r\n"
+    base = "POST /u HTTP/1.1\r\nHost: h\r\nContent-Type: multipart/form-data; boundary=B\r\nContent-Length: #{body.bytesize}\r\n\r\n#{body}"
+    res = M::Inject.apply(req(base), M::Location::Multipart,
+      [{"ok", "v"}, {"bad\"", "v"}, {"bad;", "v"}, {"a\r\nb", "v"}, {"", "v"}])
+    nb = text(body_of(res))
+    nb.should contain(%(name="ok"))
+    nb.should_not contain("bad")
+    nb.scan(/Content-Disposition/).size.should eq(2) # original `a` + injected `ok`
   end
 
   it "adds header lines before the blank line" do
@@ -95,5 +222,32 @@ describe Gori::Miner::Detect do
     appl = M::Detect.detect(req("GET /a HTTP/1.1\r\nHost: h\r\n\r\n"))
     appl.applicable.should eq([M::Location::Query, M::Location::Headers, M::Location::Cookies])
     appl.default.should eq([M::Location::Query])
+  end
+
+  it "offers multipart (applicable, default OFF) for a multipart/form-data body" do
+    body = "--B\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\n1\r\n--B--\r\n"
+    base = "POST /u HTTP/1.1\r\nHost: h\r\nContent-Type: multipart/form-data; boundary=B\r\nContent-Length: #{body.bytesize}\r\n\r\n#{body}"
+    appl = M::Detect.detect(req(base))
+    appl.applicable.should contain(M::Location::Multipart)
+    appl.default.should_not contain(M::Location::Multipart)
+    appl.applicable.should_not contain(M::Location::Form)
+    appl.applicable.should_not contain(M::Location::Json)
+  end
+
+  it "does not offer multipart without an extractable boundary" do
+    base = "POST /u HTTP/1.1\r\nHost: h\r\nContent-Type: multipart/form-data\r\nContent-Length: 3\r\n\r\nabc"
+    M::Detect.detect(req(base)).applicable.should_not contain(M::Location::Multipart)
+  end
+
+  it "offers json for a JSON array-of-objects body" do
+    base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\nContent-Length: 9\r\n\r\n[{\"a\":1}]"
+    M::Detect.detect(req(base)).applicable.should contain(M::Location::Json)
+  end
+
+  it "does not offer json for an array of scalars or a scalar root" do
+    scalars = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\nContent-Length: 7\r\n\r\n[1,2,3]"
+    M::Detect.detect(req(scalars)).applicable.should_not contain(M::Location::Json)
+    scalar = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\nContent-Length: 3\r\n\r\n\"x\""
+    M::Detect.detect(req(scalar)).applicable.should_not contain(M::Location::Json)
   end
 end

--- a/src/gori/cli/output.cr
+++ b/src/gori/cli/output.cr
@@ -130,7 +130,7 @@ module Gori
         String.build do |io|
           io << (f.confidence.confirmed? ? "[+] " : "[?] ")
           io << f.name.ljust(24)
-          io << "  " << f.location.label.ljust(8)
+          io << "  " << f.location.label.ljust(9)
           io << "· " << f.evidence.label
         end
       end

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -97,7 +97,7 @@ module Gori
           show <id>          Print a flow's request/response (text, json, or raw bytes)
           repeater             Re-send a captured flow, or list/create repeater sessions
           fuzz [<id>]        Fuzz/intrude a request: mark §…§ positions, sweep payloads
-          mine [<id>]        Discover hidden parameters (query/body/json/header/cookie)
+          mine [<id>]        Discover hidden parameters (query/form/multipart/json/header/cookie)
           sitemap            Print the host → path endpoint tree (text, json, paths)
           probe [QL]         Passively scan captured flows for issues (zero requests)
           notes [<n>]        Read the project's notes (list, show one, or --all)
@@ -1134,7 +1134,7 @@ module Gori
           p.on("--http2", "Force HTTP/2") { force_h2 = true }
           p.on("--sni=HOST", "TLS SNI override") { |v| sni = v }
           p.on("-k", "--insecure-upstream", "Do not verify upstream TLS certificates") { insecure = true }
-          p.on("--locations=LIST", "Where to mine: query,form,json,headers,cookies (default: auto-detect)") { |v| locations = parse_mine_locations(v) }
+          p.on("--locations=LIST", "Where to mine: query,form,multipart,json,headers,cookies (default: auto-detect)") { |v| locations = parse_mine_locations(v) }
           p.on("--wordlist=PATH", "Extra param-name wordlist (merged with the built-in list)") { |v| wordlist = v }
           p.on("--bucket=N", "Names stuffed per request before bisection (per location)") { |v| bucket = parse_count(v, "--bucket") }
           p.on("--concurrency=N", "Parallel requests (default 10)") { |v| concurrency = parse_count(v, "--concurrency") }
@@ -1217,7 +1217,7 @@ module Gori
       private def self.parse_mine_locations(v : String) : Array(Miner::Location)
         v.split(',').compact_map do |tok|
           next if tok.strip.empty?
-          Miner::Location.parse?(tok) || abort("gori run mine: unknown location '#{tok}' (query|form|json|headers|cookies)")
+          Miner::Location.parse?(tok) || abort("gori run mine: unknown location '#{tok}' (query|form|multipart|json|headers|cookies)")
         end
       end
 

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -542,7 +542,7 @@ module Gori
               s.field "template", strprop("raw HTTP request to mine")
               s.field "flow_id", intprop("seed the request from a captured flow id (instead of template)")
               s.field "url", strprop("absolute target URL (scheme+host); required unless flow_id carries one")
-              s.field "locations", strprop("comma list of where to mine: query,form,json,headers,cookies (default: auto-detect)")
+              s.field "locations", strprop("comma list of where to mine: query,form,multipart,json,headers,cookies (default: auto-detect; multipart is applicable but off by default — pass it explicitly)")
               s.field "wordlist", strprop("path to an extra param-name wordlist (merged with the built-in list)")
               s.field "bucket", intprop("names stuffed per request before bisection (per location)")
               s.field "concurrency", intprop("parallel requests (default 10, max #{MINE_MAX_CONCURRENCY})")
@@ -2970,7 +2970,7 @@ module Gori
         if raw && !raw.strip.empty?
           raw.split(',').compact_map do |tok|
             next if tok.strip.empty?
-            Miner::Location.parse?(tok) || raise FuzzArgError.new("unknown location '#{tok}' (query|form|json|headers|cookies)")
+            Miner::Location.parse?(tok) || raise FuzzArgError.new("unknown location '#{tok}' (query|form|multipart|json|headers|cookies)")
           end
         else
           Miner::Detect.detect(bytes).default

--- a/src/gori/miner/detect.cr
+++ b/src/gori/miner/detect.cr
@@ -1,4 +1,5 @@
 require "json"
+require "mime/multipart"
 require "./types"
 require "./inject"
 
@@ -21,7 +22,12 @@ module Gori::Miner
         applicable << Location::Form
         default << Location::Form
       end
-      if has_body && json_object?(ct, body)
+      # Multipart is applicable but default OFF: a captured file-upload re-sends its (possibly
+      # multi-MB) file part on every bucket/bisect/confirm request. Opt in — as with Headers/Cookies.
+      if has_body && multipart_form?(request, ct)
+        applicable << Location::Multipart
+      end
+      if has_body && json_injectable?(ct, body)
         applicable << Location::Json
         default << Location::Json
       end
@@ -34,17 +40,27 @@ module Gori::Miner
       Applicability.new(applicable, default)
     end
 
-    # JSON location only when the ROOT is an object (named keys are injectable).
-    private def self.json_object?(ct : String, body : Bytes) : Bool
-      looks = ct.includes?("json") || body_looks_object?(body)
-      return false unless looks
-      !JSON.parse(String.new(body).scrub).as_h?.nil?
-    rescue JSON::ParseException
-      false
+    # JSON location when the body carries at least one injectable object node — a root object,
+    # an object inside a root array, or a nested object. Shares Inject's node counter so Detect
+    # and the injector never disagree about whether Json is applicable.
+    private def self.json_injectable?(ct : String, body : Bytes) : Bool
+      return false unless ct.includes?("json") || body_looks_json?(body)
+      Inject.json_object_node_count(body, Inject::MAX_JSON_NODES) > 0
     end
 
-    private def self.body_looks_object?(body : Bytes) : Bool
-      String.new(body[0, {body.size, 64}.min]).scrub.lstrip.starts_with?('{')
+    private def self.body_looks_json?(body : Bytes) : Bool
+      head = String.new(body[0, {body.size, 64}.min]).scrub.lstrip
+      head.starts_with?('{') || head.starts_with?('[')
+    end
+
+    # Multipart location when the body is multipart/form-data AND a boundary is extractable.
+    # `ct_lower` is already down-cased; the boundary is re-read from the ORIGINAL-case header.
+    private def self.multipart_form?(request : Bytes, ct_lower : String) : Bool
+      return false unless ct_lower.lstrip.starts_with?("multipart/form-data")
+      raw = Inject.header_value(request, "content-type")
+      return false unless raw
+      b = MIME::Multipart.parse_boundary(raw)
+      !b.nil? && !b.empty?
     end
   end
 end

--- a/src/gori/miner/engine.cr
+++ b/src/gori/miner/engine.cr
@@ -20,6 +20,12 @@ module Gori::Miner
   class Engine
     MAX_CONCURRENCY = 100
 
+    # Per-request growth ceiling for the Json location. A JSON candidate is injected into EVERY
+    # object node, so a deeply-nested body could otherwise balloon one request to megabytes; this
+    # shrinks Json buckets (in initial_buckets) instead. A single-object body (node count 1) is
+    # unaffected and buckets exactly as before.
+    MAX_JSON_INJECT_BYTES = 128 * 1024
+
     enum State : UInt8
       Running
       Paused
@@ -276,15 +282,26 @@ module Gori::Miner
     private def initial_buckets(loc : Location, names : Array(String)) : Array(Task)
       cap = @config.bucket_for(loc)
       url_loc = loc.query? || loc.form?
-      byte_budget = url_loc ? Inject::MAX_URL_BYTES : Int32::MAX
+      # JSON injects each candidate into EVERY object node, so a name's real byte cost is the
+      # per-name cost × node count. Derive the count ONCE from @base (fixed → the node set never
+      # varies with bucket size, so bisection/confirm stay valid) and bound per-request growth.
+      json_nodes = loc.json? ? {Inject.json_object_node_count(Inject.split(@base)[1], Inject::MAX_JSON_NODES), 1}.max : 1
+      byte_budget = if url_loc
+                      Inject::MAX_URL_BYTES
+                    elsif loc.json?
+                      MAX_JSON_INJECT_BYTES
+                    else
+                      Int32::MAX
+                    end
       buckets = [] of Task
       cur = [] of String
       cur_bytes = 0
       names.each do |n|
         # Count the ENCODED size for query/form — a name with reserved chars (e.g. "v2/x")
         # expands under URI.encode_www_form, so the raw bytesize would under-budget the URL
-        # and a bucket could overflow MAX_URL_BYTES → 414. (One-time cost during bucketing.)
-        nb = (url_loc ? URI.encode_www_form(n).bytesize : n.bytesize) + Canary::LEN + 2
+        # and a bucket could overflow MAX_URL_BYTES → 414. For Json, multiply by the node count.
+        # (One-time cost during bucketing.)
+        nb = ((url_loc ? URI.encode_www_form(n).bytesize : n.bytesize) + Canary::LEN + 2) * (loc.json? ? json_nodes : 1)
         if !cur.empty? && (cur.size >= cap || cur_bytes + nb > byte_budget)
           buckets << Task.new(loc, cur)
           cur = [] of String
@@ -299,9 +316,10 @@ module Gori::Miner
 
     private def valid_names_for(loc : Location) : Array(String)
       case loc
-      when Location::Headers then @names.select { |n| Inject.valid_header_name?(n) }
-      when Location::Cookies then @names.select { |n| Inject.valid_cookie_name?(n) }
-      else                        @names
+      when Location::Headers   then @names.select { |n| Inject.valid_header_name?(n) }
+      when Location::Cookies   then @names.select { |n| Inject.valid_cookie_name?(n) }
+      when Location::Multipart then @names.select { |n| Inject.valid_multipart_name?(n) }
+      else                          @names
       end
     end
 

--- a/src/gori/miner/inject.cr
+++ b/src/gori/miner/inject.cr
@@ -1,5 +1,6 @@
 require "uri"
 require "json"
+require "mime/multipart"
 require "../fuzz/content_length"
 
 module Gori::Miner
@@ -11,6 +12,12 @@ module Gori::Miner
     # Query/form length guard — origins and intermediaries cap request-line/URL bytes.
     # The engine pre-splits buckets to respect this; this is the per-call ceiling.
     MAX_URL_BYTES = 8 * 1024
+
+    # JSON candidate keys are injected into EVERY object node in the body (see
+    # inject_json_text). The node set is capped (BFS shallow-first) and derived once from the
+    # BASE body — a fixed count independent of the current bucket, so a name always hits the same
+    # nodes across the initial bucket, its bisection halves, and confirmation (coverage invariance).
+    MAX_JSON_NODES = 32
 
     # Hop-by-hop / framing headers a candidate name must never become.
     FORBIDDEN_HEADERS = Set{
@@ -24,11 +31,12 @@ module Gori::Miner
                    add_cl_when_missing : Bool = false) : Bytes
       return request if params.empty?
       case location
-      in Location::Query   then inject_query(request, params)
-      in Location::Form    then Fuzz::ContentLength.sync(inject_form(request, params), add_cl_when_missing)
-      in Location::Json    then Fuzz::ContentLength.sync(inject_json(request, params), add_cl_when_missing)
-      in Location::Headers then inject_headers(request, params)
-      in Location::Cookies then inject_cookies(request, params)
+      in Location::Query     then inject_query(request, params)
+      in Location::Form      then Fuzz::ContentLength.sync(inject_form(request, params), add_cl_when_missing)
+      in Location::Multipart then Fuzz::ContentLength.sync(inject_multipart(request, params), add_cl_when_missing)
+      in Location::Json      then Fuzz::ContentLength.sync(inject_json(request, params), add_cl_when_missing)
+      in Location::Headers   then inject_headers(request, params)
+      in Location::Cookies   then inject_cookies(request, params)
       end
     end
 
@@ -130,7 +138,78 @@ module Gori::Miner
       params.map { |(n, v)| "#{URI.encode_www_form(n)}=#{URI.encode_www_form(v)}" }.join('&')
     end
 
-    # ── json (object root only) ──────────────────────────────────────────────────────
+    # ── multipart/form-data ──────────────────────────────────────────────────────────
+
+    # Append candidate fields to a multipart body, byte-exact otherwise. We REUSE the
+    # request's existing boundary and splice the new parts in just before the LAST
+    # `--boundary--` close delimiter (not MIME::Multipart::Builder, which would mint a fresh
+    # boundary and force a Content-Type rewrite + re-serialization that mangles binary parts).
+    # Multipart is ALWAYS CRLF internally (RFC 7578), regardless of the head's EOL.
+    private def self.inject_multipart(request : Bytes, params : Array({String, String})) : Bytes
+      raw_ct = header_value(request, "content-type") # ORIGINAL case — the boundary is case-sensitive
+      return request unless raw_ct
+      boundary = MIME::Multipart.parse_boundary(raw_ct)
+      return request if boundary.nil? || boundary.empty?
+
+      additions = build_multipart_parts(boundary, params)
+      return request if additions.empty?
+
+      head, body, eol = split(request)
+      io = IO::Memory.new(head.size + body.size + additions.bytesize + eol.bytesize * 2 + 16)
+      io.write(head)
+      io << eol << eol
+
+      close = "--#{boundary}--".to_slice
+      if ci = last_index_of(body, close)
+        io.write(body[0, ci])
+        # A boundary delimiter must be preceded by CRLF; a well-formed body already ends the
+        # prior part with it (so this no-ops), but a synthesised/edited body might not.
+        io << "\r\n" unless ci >= 2 && body[ci - 2] == 0x0d_u8 && body[ci - 1] == 0x0a_u8
+        io << additions                    # each appended part already ends with CRLF
+        io.write(body[ci, body.size - ci]) # the close delimiter + any epilogue, verbatim
+      else
+        # Malformed (no close delimiter) or empty body: synthesise a well-formed tail so the
+        # baseline and test requests differ only by the injected fields.
+        unless body.empty?
+          io.write(body)
+          io << "\r\n" unless ends_with_crlf?(body)
+        end
+        io << additions
+        io << "--" << boundary << "--\r\n"
+      end
+      io.to_slice
+    end
+
+    private def self.build_multipart_parts(boundary : String, params : Array({String, String})) : String
+      String.build do |sb|
+        params.each do |(n, v)|
+          next unless valid_multipart_name?(n)
+          sb << "--" << boundary << "\r\n"
+          sb << "Content-Disposition: form-data; name=\"" << n << "\"\r\n"
+          sb << "\r\n"
+          sb << sanitize_value(v) << "\r\n"
+        end
+      end
+    end
+
+    # Last occurrence of `needle` in `haystack`, byte-wise (String#rindex would corrupt a
+    # non-UTF-8 body). Taking the LAST match makes a boundary literal inside binary part data
+    # harmless — only a trailing epilogue can follow the real close delimiter.
+    private def self.last_index_of(haystack : Bytes, needle : Bytes) : Int32?
+      return nil if needle.empty? || needle.size > haystack.size
+      i = haystack.size - needle.size
+      while i >= 0
+        return i if haystack[i, needle.size] == needle
+        i -= 1
+      end
+      nil
+    end
+
+    private def self.ends_with_crlf?(body : Bytes) : Bool
+      body.size >= 2 && body[body.size - 2] == 0x0d_u8 && body[body.size - 1] == 0x0a_u8
+    end
+
+    # ── json (object + nested objects + array roots) ─────────────────────────────────
 
     private def self.inject_json(request : Bytes, params : Array({String, String})) : Bytes
       head, body, eol = split(request)
@@ -142,19 +221,20 @@ module Gori::Miner
       io.to_slice
     end
 
-    # Merge keys into a top-level JSON object. Falls back to a string-splice when the
-    # body parses loosely as `{…}`; returns nil for non-object roots (Detect won't offer
-    # Json there, so this only guards a hand-driven call).
+    # Inject candidate keys into EVERY object node of the JSON body — the root object, objects
+    # inside a root array, and nested objects — capped BFS shallow-first (MAX_JSON_NODES). Returns
+    # nil when the body carries no object node (array-of-scalars / scalar / bool / null root),
+    # leaving it unchanged (Detect won't offer Json there; this only guards a hand-driven call).
+    # A body that doesn't cleanly parse falls back to the top-level textual `{`-splice.
     def self.inject_json_text(btext : String, params : Array({String, String})) : String?
       begin
         any = JSON.parse(btext)
-        if h = any.as_h?
-          merged = h.dup
-          params.each { |(n, v)| merged[n] = JSON::Any.new(v) }
-          return merged.to_json
-        end
+        nodes = collect_object_nodes(any, MAX_JSON_NODES)
+        return nil if nodes.empty?
+        nodes.each { |node| params.each { |(n, v)| node[n] = JSON::Any.new(v) } }
+        return any.to_json
       rescue JSON::ParseException
-        # fall through to the textual splice
+        # fall through to the textual splice (nested/array injection needs a real parse)
       end
       bi = btext.index('{')
       return nil unless bi
@@ -162,6 +242,32 @@ module Gori::Miner
       sep = after.lstrip.starts_with?('}') ? "" : ","
       inserts = params.map { |(n, v)| "#{n.to_json}:#{v.to_json}" }.join(',')
       "#{btext[0..bi]}#{inserts}#{sep}#{after}"
+    end
+
+    # Object-hash nodes reachable from `any`, BFS (shallow-first), capped at `cap`. Each returned
+    # hash is the BACKING store of a JSON::Any (a reference), so mutating it in place persists
+    # through `any.to_json`. Iterative (Deque) so an adversarially deep body can't blow the stack.
+    private def self.collect_object_nodes(any : JSON::Any, cap : Int32) : Array(Hash(String, JSON::Any))
+      out = [] of Hash(String, JSON::Any)
+      queue = Deque(JSON::Any){any}
+      until queue.empty? || out.size >= cap
+        node = queue.shift
+        if h = node.as_h?
+          out << h
+          h.each_value { |v| queue << v }
+        elsif a = node.as_a?
+          a.each { |v| queue << v }
+        end
+      end
+      out
+    end
+
+    # How many injectable object nodes the body carries (capped). Shared by Detect (is Json
+    # applicable?) and the engine (per-name bucket byte-budget), so the two never drift.
+    def self.json_object_node_count(body : Bytes, cap : Int32) : Int32
+      collect_object_nodes(JSON.parse(String.new(body).scrub), cap).size
+    rescue JSON::ParseException
+      0
     end
 
     # ── headers ──────────────────────────────────────────────────────────────────────
@@ -205,6 +311,20 @@ module Gori::Miner
     def self.valid_cookie_name?(name : String) : Bool
       return false if name.empty? || name.size > 64
       name.each_char { |c| return false unless token_char?(c) }
+      true
+    end
+
+    # A multipart field name sits in a quoted `name="…"`, so it may contain far more than an HTTP
+    # token (real params like `user[id]`, `a/b`, `x:y` are common) — token_char? is intentionally
+    # NOT reused. Reject only what breaks the Content-Disposition line or smuggles frames: the
+    # quote itself, a backslash escape (RFC 7578 discourages it; naive parsers mishandle), the CD
+    # param separator `;`, and any control char (covers CR/LF).
+    def self.valid_multipart_name?(name : String) : Bool
+      return false if name.empty? || name.bytesize > 256
+      name.each_char do |c|
+        return false if c == '"' || c == '\\' || c == ';'
+        return false if c.ord < 0x20 || c.ord == 0x7f
+      end
       true
     end
 

--- a/src/gori/miner/types.cr
+++ b/src/gori/miner/types.cr
@@ -15,17 +15,19 @@ module Gori
     enum Location
       Query
       Form
+      Multipart
       Json
       Headers
       Cookies
 
       def label : String
         case self
-        in Query   then "query"
-        in Form    then "form"
-        in Json    then "json"
-        in Headers then "headers"
-        in Cookies then "cookies"
+        in Query     then "query"
+        in Form      then "form"
+        in Multipart then "multipart"
+        in Json      then "json"
+        in Headers   then "headers"
+        in Cookies   then "cookies"
         end
       end
 
@@ -34,6 +36,7 @@ module Gori
         case token.downcase.strip
         when "query", "q"             then Query
         when "form", "body", "f"      then Form
+        when "multipart", "mp"        then Multipart
         when "json", "j"              then Json
         when "header", "headers", "h" then Headers
         when "cookie", "cookies", "c" then Cookies
@@ -181,11 +184,12 @@ module Gori
       # Per-Burp ceilings; query/form are additionally clamped by the URL byte budget
       # in Inject so a stuffed line can't exceed common request-line limits.
       DEFAULT_BUCKETS = Hash(Location, Int32){
-        Location::Json    => 256,
-        Location::Query   => 128,
-        Location::Form    => 128,
-        Location::Headers => 64,
-        Location::Cookies => 64,
+        Location::Json      => 256,
+        Location::Query     => 128,
+        Location::Form      => 128,
+        Location::Multipart => 128,
+        Location::Headers   => 64,
+        Location::Cookies   => 64,
       }
 
       def initialize(@locations = [Location::Query],


### PR DESCRIPTION
## Summary

The Param Miner discovered hidden parameters in **query, form (urlencoded), top-level-object JSON, headers, and cookies**. Two common request-body shapes were unreachable — this PR closes both.

### multipart/form-data (new `multipart` location)

Splices candidate fields in before the body's existing `--boundary--` close delimiter, **reusing the request's own boundary** and staying byte-exact otherwise (binary file parts and epilogues survive). Deliberately **not** `MIME::Multipart::Builder`, which would mint a new boundary and re-serialize existing parts.

**Applicable but default OFF** (like headers/cookies) — a captured file part would otherwise be re-sent on every bucket/bisect/confirm request. Opt in via `--locations multipart`, the MCP `locations` field, or the overlay checkbox.

### Nested & array JSON

JSON injection reached only the root object's keys. It now walks **every object node** — root, nested objects, and objects inside a root array — BFS shallow-first, capped at `MAX_JSON_NODES` (32).

The injected node-set is derived **once from the base request** (a fixed count independent of bucket size), so bucketing → bisection → confirm stay correct ("coverage invariance"). Per-request growth is bounded by `MAX_JSON_INJECT_BYTES` (128 KiB) through the existing bucket byte-budget. A single top-level object buckets exactly as before.

## Findings semantics

Findings still report `(location, name)` only — a JSON finding means "the server accepts this name *somewhere* in the body." No changes to `Finding`, the `Location` dedup key, or any renderer. `Location` is persisted by label everywhere (session config, findings), so the new mid-enum member is safe.

## Verification

- **1826 specs pass** (added 15 miner specs, incl. a nested-injection test that *parses* the result rather than substring-matching).
- Build clean; `ameba` + `crystal tool format` clean on changed files.
- **End-to-end**: against a live server, the miner discovered a hidden `debug` param at `location=multipart` and inside a **nested** JSON `data` object — both previously undiscoverable.

## Known limitation (pre-existing, out of scope)

A `Transfer-Encoding: chunked` request body can't have Content-Length re-synced, so body injection would break chunk framing. Uncommon for request bodies and shared with the existing Form/JSON injectors — left as-is.
