### PR TITLE
feat(mcp): live intercept loop + event feed (#123, #124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+### Added — MCP live intercept + event feed (#123, #124)
+
+Agents can sit in the intercept loop and tail job/agent activity without
+busy-polling History alone:
+
+- **`list_events`** — forward-cursor tail over an append-only `events` table
+  (V35) for miner/fuzzer/probe lifecycle and agent actions. Flows stay the
+  firehose via `list_history since:`; this table never duplicates flow rows.
+- **Live intercept bridge** — capture-lock holder mirrors held items into
+  `intercept_held` and drains agent commands from `intercept_commands` (V36).
+  New MCP verbs: `intercept_list` / `intercept_get` / `intercept_forward` /
+  `intercept_drop` / `intercept_forward_edit` / `intercept_toggle` /
+  `intercept_set_filter` / `intercept_set_direction` (mutating verbs gated
+  behind non-`--read-only`; refuse when no live capture holder).
+- **Human visibility** — agent intercept actions surface as notification notes
+  with `source: agent` (distinct overlay rendering); engine controllers tag
+  notes with miner/fuzzer/probe sources. Unwatched holds auto-forward only when
+  an agent has attached (pure-human sessions keep indefinite hold).
+
 ### Added — Param Miner covers more body types
 
 The Miner now injects candidate parameters into two body shapes it previously

--- a/spec/interceptor_spec.cr
+++ b/spec/interceptor_spec.cr
@@ -82,6 +82,23 @@ describe Gori::Interceptor do
     end
   end
 
+  it "get(id) returns the held item; held_at_ms is a stable wall-clock (#123 snapshot)" do
+    with_store do |store|
+      ic = Gori::Interceptor.new(Gori::Scope.load(store))
+      ic.toggle
+      result = Channel(Gori::Interceptor::Decision).new
+      spawn { result.send(req(ic, "GET / HTTP/1.1\r\nHost: acme.test\r\n\r\n")) }
+      Fiber.yield
+      item = ic.pending.first
+      ic.get(item.id).not_nil!.host.should eq("acme.test")
+      item.held_at_ms.should be > 0                       # wall-clock captured once at hold
+      ic.get(item.id).not_nil!.held_at_ms.should eq(item.held_at_ms) # never re-stamped
+      ic.forward(item.id)
+      result.receive
+      ic.get(item.id).should be_nil # gone after forward
+    end
+  end
+
   it "auto-forwards held items when toggled off" do
     with_store do |store|
       ic = Gori::Interceptor.new(Gori::Scope.load(store))
@@ -134,6 +151,20 @@ describe "Gori::Interceptor direction + condition gates" do
       ic.cycle_direction.should eq(Gori::Interceptor::Direction::RequestOnly)
       ic.cycle_direction.should eq(Gori::Interceptor::Direction::ResponseOnly)
       ic.cycle_direction.should eq(Gori::Interceptor::Direction::Both)
+    end
+  end
+
+  it "set_direction sets an explicit value idempotently, bumping revision only on change (#123)" do
+    with_store do |store|
+      ic = Gori::Interceptor.new(Gori::Scope.load(store))
+      ic.direction.should eq(Gori::Interceptor::Direction::Both)
+      r0 = ic.revision
+      ic.set_direction(Gori::Interceptor::Direction::ResponseOnly)
+      ic.direction.should eq(Gori::Interceptor::Direction::ResponseOnly)
+      (ic.revision > r0).should be_true
+      r1 = ic.revision
+      ic.set_direction(Gori::Interceptor::Direction::ResponseOnly) # unchanged
+      ic.revision.should eq(r1)                                    # idempotent: no bump
     end
   end
 

--- a/spec/store/entity_links_spec.cr
+++ b/spec/store/entity_links_spec.cr
@@ -90,6 +90,9 @@ describe "entity_links (V21)" do
       store.@db.exec("ALTER TABLE repeaters RENAME TO replays")                 # undo V32 so historical <V32 migrations replay against the old table name
       store.@db.exec("ALTER TABLE probe_issues RENAME TO prism_issues")         # undo V33 so historical <V33 migrations replay against the old table name
       store.@db.exec("ALTER TABLE issues RENAME TO findings")                   # undo V34 so historical <V34 migrations replay against the old table name
+      store.@db.exec("DROP TABLE events")                                       # V35
+      store.@db.exec("DROP TABLE intercept_held")                               # V36
+      store.@db.exec("DROP TABLE intercept_commands")                           # V36
       store.@db.exec("PRAGMA user_version = 20")
       store.close
 

--- a/spec/store/store_spec.cr
+++ b/spec/store/store_spec.cr
@@ -55,6 +55,9 @@ describe Gori::Store do
       store.@db.exec("ALTER TABLE repeaters DROP COLUMN tags")           # V31
       store.@db.exec("ALTER TABLE repeaters RENAME TO replays")          # undo V32 so historical <V32 migrations replay against the old table name
       store.@db.exec("ALTER TABLE issues RENAME TO findings")            # undo V34 (findings table predates V17, so it must carry the old name back)
+      store.@db.exec("DROP TABLE events")                                # V35
+      store.@db.exec("DROP TABLE intercept_held")                        # V36
+      store.@db.exec("DROP TABLE intercept_commands")                    # V36
       store.@db.exec("PRAGMA user_version = 17")
       store.close
 
@@ -95,6 +98,9 @@ describe Gori::Store do
               "VALUES (1, 1, 1, 'legacy', 2, 'x.test', NULL, '', 0)")
       db.exec("INSERT INTO entity_links (owner_kind, owner_id, ref_kind, ref_id, created_at) VALUES ('finding', 1, 'replay', ?, 1)", rid)
       db.exec("INSERT INTO settings (key, value) VALUES ('prism_mode', 'active')")
+      db.exec("DROP TABLE events")             # V35
+      db.exec("DROP TABLE intercept_held")     # V36
+      db.exec("DROP TABLE intercept_commands") # V36
       db.exec("PRAGMA user_version = 31")
       store.close
 
@@ -127,6 +133,84 @@ describe Gori::Store do
       rows[0].target.should eq("/second")
       rows[0].status.should be_nil
       rows[0].state.should eq(Gori::Store::FlowState::Pending)
+    end
+  end
+
+  it "appends events and tails them with a forward id cursor (list_events backing)" do
+    with_store do |store|
+      a = store.insert_event("miner", "job_done", "success", "found 3", goto_tab: "miner", goto_session_id: 7_i64)
+      b = store.insert_event("agent", "agent_action", "info", "send_request ok", payload: "send_request")
+      c = store.insert_event("fuzzer", "job_done", "error", "boom")
+      a.should be > 0
+      (b > a && c > b).should be_true # monotonic ids
+
+      all = store.events_after(0, 100)
+      all.map(&.id).should eq([a, b, c])                    # oldest-first
+      all.map(&.source).should eq(["miner", "agent", "fuzzer"])
+      all[0].goto_session_id.should eq(7_i64)
+      all[1].payload.should eq("send_request")
+
+      store.events_after(a, 100).map(&.id).should eq([b, c]) # strictly after the cursor
+      store.events_after(c, 100).should be_empty             # nothing past the newest
+    end
+  end
+
+  it "never reuses an event id after the newest row is deleted (AUTOINCREMENT)" do
+    with_store do |store|
+      x = store.insert_event("probe", "issue_found", "success", "one")
+      store.@db.exec("DELETE FROM events WHERE id = ?", x)
+      y = store.insert_event("probe", "issue_found", "success", "two")
+      y.should be > x # a since_id watermark can never silently skip a new row
+    end
+  end
+
+  it "mirrors held intercept items and round-trips the command queue (#123 bridge)" do
+    with_store do |store|
+      tok = "sess-abc"
+      raw = "GET /a HTTP/1.1\r\nHost: x.test\r\n\r\n".to_slice
+      store.publish_intercept_held(tok, [Gori::Store::HeldRow.new(tok, 1_i64, "request", "GET", "x.test", 80, "http", "/a", raw, 1_000_i64, nil, false)])
+      held = store.intercept_held(tok)
+      held.size.should eq(1)
+      held[0].item_id.should eq(1)
+      held[0].host.should eq("x.test")
+      held[0].raw.should eq(raw)
+      store.intercept_held("other-token").should be_empty
+
+      # A fresh session (different token) wipes the prior session's mirror on publish.
+      store.publish_intercept_held("sess-two", [Gori::Store::HeldRow.new("sess-two", 1_i64, "request", "GET", "y.test", 80, "http", "/b", raw, 2_000_i64, nil, false)])
+      store.intercept_held(tok).should be_empty
+      store.intercept_held("sess-two").size.should eq(1)
+
+      # Command queue: enqueue -> forward-cursor drain -> ack -> status.
+      cid = store.enqueue_intercept_command("sess-two", "forward", item_id: 1_i64)
+      cid.should be > 0
+      store.latest_intercept_command_id.should eq(cid)
+      cmds = store.intercept_commands_after(0_i64, 10)
+      cmds.size.should eq(1)
+      cmds[0].verb.should eq("forward")
+      cmds[0].item_id.should eq(1)
+      cmds[0].session_token.should eq("sess-two")
+      store.intercept_commands_after(cid, 10).should be_empty # forward cursor: nothing past it
+      store.command_status(cid).not_nil![0].should eq("pending")
+      store.ack_intercept_command(cid, "forwarded", "GET y.test/b")
+      st = store.command_status(cid).not_nil!
+      st[0].should eq("forwarded")
+      st[1].should eq("GET y.test/b")
+
+      # Empty publish clears the mirror; clear_intercept_state! wipes both tables.
+      store.publish_intercept_held("sess-two", [] of Gori::Store::HeldRow)
+      store.intercept_held("sess-two").should be_empty
+      store.clear_intercept_state!
+      store.intercept_commands_after(0_i64, 10).should be_empty
+    end
+  end
+
+  it "never reuses an intercept_commands id after a delete (AUTOINCREMENT watermark safety)" do
+    with_store do |store|
+      a = store.enqueue_intercept_command("t", "forward", item_id: 1_i64)
+      store.@db.exec("DELETE FROM intercept_commands WHERE id = ?", a)
+      b = store.enqueue_intercept_command("t", "drop", item_id: 2_i64)
+      b.should be > a # the TUI drain watermark can never silently skip a command
     end
   end
 

--- a/src/gori/interceptor.cr
+++ b/src/gori/interceptor.cr
@@ -54,10 +54,15 @@ module Gori
       getter flow_id : Int64?
       getter raw : Bytes
       getter held_at : Time::Instant
+      # Wall-clock (unix ms) captured ONCE at hold time. `held_at` is a monotonic Instant
+      # (meaningless across processes); the #123 store snapshot needs a stable wall-clock so
+      # the MCP process can render a correct age that does NOT reset on every republish.
+      getter held_at_ms : Int64
       getter reply : Channel(Decision)
 
       def initialize(@id, @kind, @method, @host, @target, @port, @scheme, @raw, @held_at, @flow_id = nil)
         @reply = Channel(Decision).new(1)
+        @held_at_ms = Time.utc.to_unix_ms
       end
     end
 
@@ -113,6 +118,21 @@ module Gori
       end
       @revision.add(1)
       now
+    end
+
+    # Set the catch direction to an explicit value (idempotent — no-op if already there).
+    # Unlike cycle_direction, this lets a remote MCP agent request a DESIRED state without
+    # blind-cycling; the #123 drain applies it exactly once via the command watermark.
+    def set_direction(dir : Direction) : Nil
+      changed = @mutex.synchronize do
+        if @direction != dir
+          @direction = dir
+          true
+        else
+          false
+        end
+      end
+      @revision.add(1) if changed
     end
 
     # Replace the conditional-intercept filter (parsed from a QL-like query). Cheap
@@ -244,6 +264,12 @@ module Gori
 
     def pending : Array(Item)
       @mutex.synchronize { @items.values }
+    end
+
+    # One held item by id (nil if already forwarded/dropped). Used by the #123 apply-loop to
+    # describe an agent action + touch recency before forwarding/dropping cross-process.
+    def get(id : Int64) : Item?
+      @mutex.synchronize { @items[id]? }
     end
 
     def pending_count : Int32

--- a/src/gori/mcp/serialize.cr
+++ b/src/gori/mcp/serialize.cr
@@ -76,6 +76,102 @@ module Gori
         end
       end
 
+      # --- event feed row (#124) — the light projection list_events returns -----
+      def self.event_row(j : JSON::Builder, row : Store::EventRow) : Nil
+        j.object do
+          j.field "id", row.id
+          j.field "created_at", row.created_at
+          j.field "created_at_iso", unix_micros_iso(row.created_at)
+          j.field "source", row.source
+          j.field "kind", row.kind
+          j.field "level", row.level
+          j.field "message", row.message
+          j.field "goto_tab", row.goto_tab
+          j.field "goto_session_id", row.goto_session_id
+          j.field "flow_id", row.flow_id
+          j.field "payload", row.payload
+        end
+      end
+
+      # --- #123 held intercept item projections --------------------------------
+
+      # Offset of the CRLFCRLF head/body separator in a raw HTTP message, or nil.
+      def self.head_body_split(raw : Bytes) : Int32?
+        i = 0
+        while i + 3 < raw.size
+          return i if raw[i] == 13 && raw[i + 1] == 10 && raw[i + 2] == 13 && raw[i + 3] == 10
+          i += 1
+        end
+        nil
+      end
+
+      # {scrubbed head text, body bytes} for a held raw message; whole message as head
+      # (empty body) when there is no separator.
+      def self.head_and_body(raw : Bytes) : {String, Bytes}
+        if sep = head_body_split(raw)
+          {String.new(raw[0, sep]).scrub, raw[(sep + 4)..]}
+        else
+          {String.new(raw).scrub, Bytes.empty}
+        end
+      end
+
+      # List projection: metadata + a redacted, truncated head preview (no body). age_seconds
+      # is derived from the wall-clock held_at_ms (stable across snapshot republishes).
+      def self.intercept_item_row(j : JSON::Builder, row : Store::HeldRow, include_sensitive : Bool, now_ms : Int64) : Nil
+        head, body = head_and_body(row.raw)
+        preview = redact_head(head, include_sensitive)
+        preview = "#{preview[0, 1024]}…" if preview.size > 1024
+        j.object do
+          j.field "item_id", row.item_id
+          j.field "kind", row.kind
+          j.field "method", row.method
+          j.field "host", row.host
+          j.field "port", row.port
+          j.field "scheme", row.scheme
+          j.field "target", row.target
+          j.field "flow_id", row.flow_id if row.flow_id
+          j.field "held_at_ms", row.held_at_ms
+          j.field "held_at_iso", unix_micros_iso(row.held_at_ms * 1000)
+          j.field "age_seconds", ((now_ms - row.held_at_ms) // 1000)
+          j.field "edited", row.edited
+          j.field "body_size", body.size
+          j.field "head_preview", preview
+        end
+      end
+
+      # Detail projection: full redacted head + body size. The FULL raw message base64 (for
+      # byte-exact edit → intercept_forward_edit) is emitted ONLY when include_sensitive:true —
+      # base64 is encoding, not redaction, so returning raw by default would leak Authorization/
+      # Cookie header bytes the `head` field carefully redacts. Redacting inside raw is NOT an
+      # option (it would corrupt the bytes the agent round-trips), so we gate instead.
+      def self.intercept_item_detail(j : JSON::Builder, row : Store::HeldRow, include_sensitive : Bool, now_ms : Int64) : Nil
+        head, body = head_and_body(row.raw)
+        j.object do
+          j.field "item_id", row.item_id
+          j.field "kind", row.kind
+          j.field "method", row.method
+          j.field "host", row.host
+          j.field "port", row.port
+          j.field "scheme", row.scheme
+          j.field "target", row.target
+          j.field "flow_id", row.flow_id if row.flow_id
+          j.field "held_at_ms", row.held_at_ms
+          j.field "age_seconds", ((now_ms - row.held_at_ms) // 1000)
+          j.field "edited", row.edited
+          j.field "head", redact_head(head, include_sensitive)
+          j.field "body_size", body.size
+          j.field "raw_size", row.raw.size
+          if include_sensitive
+            raw_sample = row.raw.size > MAX_B64 ? row.raw[0, MAX_B64] : row.raw
+            j.field "raw_base64", Base64.strict_encode(raw_sample)
+            j.field "raw_truncated", row.raw.size > MAX_B64
+          else
+            # raw carries UNREDACTED header bytes — opt in with include_sensitive to fetch it.
+            j.field "raw_redacted", true
+          end
+        end
+      end
+
       # --- fuzz result (metrics only — no raw bodies; full detail stays behind
       # get_flow/send_request, shrinking the injected-content surface) -----------
       def self.fuzz_result(j : JSON::Builder, r : Fuzz::Result, flow_id : Int64? = nil) : Nil

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -53,6 +53,21 @@ module Gori
 
       EMPTY_HASH = {} of String => JSON::Any
 
+      # #124 — MCP tools whose SUCCESSFUL (or failed) execution is a real mutation or
+      # outbound send worth recording in the event feed as a visible "agent action", so the
+      # human can see (via list_events, and later the notification ring) what the AI did.
+      # Deliberately EXCLUDES gated READ tools (fuzz_status/results, mine_status/results,
+      # list_jobs, get_job, preview_rule) and project-management tools (switch_project reopens
+      # @store, so a post-hoc append would land in the wrong DB) — only in-project side effects.
+      AGENT_ACTION_TOOLS = Set{
+        "send_request", "send_websocket",
+        "fuzz_start", "fuzz_stop", "mine_start", "mine_stop", "stop_job",
+        "create_issue", "update_issue",
+        "create_rule", "update_rule", "delete_rule", "set_rule_enabled",
+        "create_note", "update_note", "delete_note",
+        "create_repeater", "update_repeater", "delete_repeater",
+      }
+
       # Fuzz-run safety rails (a single tool call must never launch an unbounded
       # flood, and the in-memory result buffer can't grow without bound).
       FUZZ_MAX_REQUESTS    = 100_000_i64
@@ -191,11 +206,52 @@ module Gori
             "empty query returns the most recent. Returns light rows (no bodies); " \
             "use get_flow for full detail. Paginate by passing the oldest id seen as " \
             "`before_id` (rows are newest-first); a page shorter than `limit` means no older rows. " \
+            "To TAIL new flows instead, pass `since` (the largest id you've seen): rows come back " \
+            "OLDEST-first; tail by passing the last id as the next `since`; an empty page means no " \
+            "new flows (keep your cursor). `since` and `before_id` are mutually exclusive. " \
             "Call ql_reference for full QL syntax." do |s|
             s.field "query", strprop("gori QL filter; empty = most recent")
             s.field "limit", intprop("max rows (default 50, max 500)")
-            s.field "before_id", intprop("cursor: only flows with id < this (pagination; works with query too)")
+            s.field "before_id", intprop("cursor: page OLDER — only flows with id < this (newest-first; works with query too)")
+            s.field "since", intprop("forward cursor: tail NEWER — only flows with id > this, oldest-first (mutually exclusive with before_id)")
             s.field "strict", boolprop("reject the query if any term is unrecognized/invalid instead of silently dropping it (default false; use ql_explain to see which terms would drop)")
+          end
+
+          tool j, "list_events",
+            "Tail the AI event feed: an append-only log of job lifecycle (miner/fuzzer/probe) and " \
+            "agent actions, forward-cursored so you never see the same event twice. This is the " \
+            "AI-facing firehose complement to list_history (which tails captured flows). Pass " \
+            "`since` = the last cursor you saw (0 or omitted starts from the oldest); the response " \
+            "carries `next_cursor` — pass it as the next `since`. `next_cursor` never moves backward " \
+            "and echoes your input on an empty page, so a poll that returns no events keeps your place. " \
+            "Optional `source`/`kind` filters do NOT affect `next_cursor` (it is the max SCANNED id)." do |s|
+            s.field "since", intprop("forward cursor: only events with id > this (default 0 = from oldest). Pass back the response's next_cursor to tail.")
+            s.field "limit", intprop("max events scanned (default 100, max 500)")
+            s.field "source", strprop("filter to one source: miner | fuzzer | probe | agent")
+            s.field "kind", strprop("filter to one kind (e.g. job_done, agent_action)")
+          end
+
+          tool j, "intercept_list",
+            "List HTTP messages currently HELD by the live intercept queue of the capturing " \
+            "gori instance, plus intercept state (enabled/direction/filter) and a liveness " \
+            "heartbeat. This is how an agent 'sits in the loop' alongside the human — inspect " \
+            "held requests/responses, then forward/drop/edit them (see intercept_forward etc). " \
+            "available:false when no bridge has ever been published; capturing:false (with a " \
+            "growing heartbeat_age_seconds) when the last capturing instance is no longer live, " \
+            "in which case mutating verbs refuse. Header values redacted unless " \
+            "include_sensitive:true." do |s|
+            s.field "include_sensitive", boolprop("show Authorization/Cookie/etc header values instead of [REDACTED] (default false)")
+          end
+
+          tool j, "intercept_get",
+            "Full detail for ONE held intercept item (redacted head + body size). Pass " \
+            "include_sensitive:true to ALSO get the full raw message base64 (unredacted, for " \
+            "byte-exact editing with intercept_forward_edit) — otherwise raw is withheld " \
+            "(raw_redacted:true) since base64 is not redaction. NOT_FOUND if the item was " \
+            "already forwarded/dropped or never held. Header values redacted unless " \
+            "include_sensitive:true." do |s|
+            s.field "item_id", intprop("held item id from intercept_list"), required: true
+            s.field "include_sensitive", boolprop("show sensitive header values instead of [REDACTED] (default false)")
           end
 
           tool j, "ql_reference",
@@ -315,6 +371,53 @@ module Gori
             "Use switch_project to change the active project." { }
 
           if @allow_actions
+            tool j, "intercept_forward",
+              "Forward a currently-held intercept item (from intercept_list) byte-exact, letting " \
+              "the request/response continue. The action is applied by the capturing gori instance " \
+              "and surfaced as a visible notification to the human operator. Returns the outcome " \
+              "(forwarded | no_such_item if it was already released | not_confirmed to retry)." do |s|
+              s.field "item_id", intprop("held item id from intercept_list"), required: true
+            end
+
+            tool j, "intercept_drop",
+              "Drop a currently-held intercept item: the proxy answers the client a canned 502 and " \
+              "the message never reaches its destination. Applied by the capturing instance and " \
+              "surfaced to the human. Returns dropped | no_such_item | not_confirmed." do |s|
+              s.field "item_id", intprop("held item id from intercept_list"), required: true
+            end
+
+            tool j, "intercept_forward_edit",
+              "Forward a held intercept item with EDITED bytes. Supply the full replacement wire " \
+              "message in `raw` (fetch the current bytes from intercept_get with " \
+              "include_sensitive:true → raw_base64, edit, send back). Content-Length is recomputed " \
+              "to match the body; otherwise the bytes are " \
+              "forwarded byte-exact (NO variable expansion — a security tool forwards exactly what " \
+              "you send). Applied by the capturing instance + surfaced to the human. Returns " \
+              "forwarded (edited:true) | no_such_item | not_confirmed." do |s|
+              s.field "item_id", intprop("held item id from intercept_list"), required: true
+              s.field "raw", strprop("the full edited HTTP wire message (request/status line + headers + body)"), required: true
+            end
+
+            tool j, "intercept_toggle",
+              "Enable or disable the live intercept catch (desired state — idempotent). NOTE: " \
+              "enabling only affects NEW connections; an already-established HTTP/2 connection " \
+              "stays un-held. Applied by the capturing instance. Returns toggled | busy." do |s|
+              s.field "enable", boolprop("true = start holding matching traffic; false = stop (auto-forwards anything currently held)"), required: true
+            end
+
+            tool j, "intercept_set_filter",
+              "Set the conditional-intercept filter — a gori-QL-like query that NARROWS which " \
+              "in-flight messages are held (e.g. 'host:api.example.com method:POST'). Empty " \
+              "clears it (hold everything in scope). Applied by the capturing instance." do |s|
+              s.field "query", strprop("filter query; empty string clears the filter"), required: true
+            end
+
+            tool j, "intercept_set_direction",
+              "Set which leg(s) intercept holds: both | request | response. Applied by the " \
+              "capturing instance." do |s|
+              s.field "direction", strprop("both | request | response"), required: true
+            end
+
             tool j, "create_rule",
               "Add a Match & Replace rule (a literal substring rewrite applied to in-flight traffic). " \
               "Persisted to the project. Note: a gori TUI already running applies it only after its " \
@@ -599,10 +702,26 @@ module Gori
         h = args.as_h? || EMPTY_HASH
         result = read_tool(name, h) || action_tool(name, h) ||
           err("unknown tool: #{name}", "UNKNOWN_TOOL")
-        classify(result)
+        result = classify(result)
+        log_agent_action(name, result) if @allow_actions && AGENT_ACTION_TOOLS.includes?(name)
+        result
       rescue ex
         Log.warn(exception: ex) { "tool #{name} failed" }
         err("tool error: #{ex.message}", "INTERNAL")
+      end
+
+      # #124 — record a completed agent mutation/send into the store event feed so the AI's
+      # activity is visible to the human (and tailable via list_events). A failure is logged
+      # too (warn) — a scope-blocked or errored send is exactly what an operator wants to see.
+      # A read-only-disabled attempt (TOOL_DISABLED) executed nothing, so it is not logged.
+      # Best-effort: feed logging never breaks the tool call it describes.
+      private def log_agent_action(name : String, result : Result) : Nil
+        return if result.error_code == "TOOL_DISABLED"
+        level = result.is_error ? "warn" : "info"
+        outcome = result.is_error ? "failed (#{result.error_code || "error"})" : "ok"
+        @store.insert_event("agent", "agent_action", level, "#{name} #{outcome}", payload: name)
+      rescue ex
+        Log.warn(exception: ex) { "event feed: failed to log agent action #{name}" }
       end
 
       # Guarantees every error Result carries a stable `error_code`. Explicitly
@@ -621,6 +740,9 @@ module Gori
       private def read_tool(name : String, h) : Result?
         case name
         when "list_history"            then list_history(h)
+        when "list_events"             then list_events(h)
+        when "intercept_list"          then intercept_list(h)
+        when "intercept_get"           then intercept_get(h)
         when "get_flow"                then get_flow(h)
         when "get_response_body_chunk" then get_response_body_chunk(h)
         when "list_sitemap"            then list_sitemap(h)
@@ -646,6 +768,12 @@ module Gori
         case name
         when "send_request"     then gated { send_request(h) }
         when "send_websocket"   then gated { send_websocket(h) }
+        when "intercept_forward"       then gated { intercept_forward(h) }
+        when "intercept_drop"          then gated { intercept_drop(h) }
+        when "intercept_forward_edit"  then gated { intercept_forward_edit(h) }
+        when "intercept_toggle"        then gated { intercept_toggle(h) }
+        when "intercept_set_filter"    then gated { intercept_set_filter(h) }
+        when "intercept_set_direction" then gated { intercept_set_direction(h) }
         when "create_repeater"    then gated { create_repeater(h) }
         when "update_repeater"    then gated { update_repeater(h) }
         when "delete_repeater"    then gated { delete_repeater(h) }
@@ -681,11 +809,205 @@ module Gori
       private def list_history(h) : Result
         limit = clamp(int(h, "limit"), 50, 500)
         before_id = int(h, "before_id")
+        since_id = int(h, "since")
+        if before_id && since_id
+          return err("pass only one of 'since' (tail newer, oldest-first) or 'before_id' (page older, newest-first)",
+            "INVALID_ARGUMENT", field: "since")
+        end
         query = str(h, "query")
         filter = ql_filter_or_error(h, query)
         return filter if filter.is_a?(Result)
-        rows = (query && !query.strip.empty?) ? @store.search(filter, limit, before_id) : @store.recent_flows(limit, before_id)
+        rows = (query && !query.strip.empty?) ? @store.search(filter, limit, before_id, since_id) : @store.recent_flows(limit, before_id, since_id)
         Result.new(JSON.build { |j| j.array { rows.each { |r| Serialize.flow_row(j, r) } } })
+      end
+
+      # #124 AI event feed. Forward-cursored (id > since, oldest-first). next_cursor is the
+      # max id SCANNED this page (NOT the max matched id), so source/kind filters never make
+      # the agent re-scan or skip; on an empty page it echoes the input `since` (never 0,
+      # never max-of-empty) so a no-new-events poll keeps the caller's place.
+      private def list_events(h) : Result
+        since = int(h, "since") || 0_i64
+        limit = clamp(int(h, "limit"), 100, 500)
+        source = str(h, "source")
+        kind = str(h, "kind")
+        scanned = @store.events_after(since, limit)
+        next_cursor = scanned.empty? ? since : scanned.last.id
+        rows = scanned
+        rows = rows.select { |r| r.source == source } if source && !source.empty?
+        rows = rows.select { |r| r.kind == kind } if kind && !kind.empty?
+        Result.new(JSON.build do |j|
+          j.object do
+            j.field("events") { j.array { rows.each { |r| Serialize.event_row(j, r) } } }
+            j.field "next_cursor", next_cursor
+          end
+        end)
+      end
+
+      # --- #123 live intercept (read side) ------------------------------------
+
+      # Parse the bridge blob the capturing TUI publishes (nil when no capturing instance is
+      # live / has ever published). See Runner#publish_intercept_bridge.
+      private def intercept_bridge_state : Hash(String, JSON::Any)?
+        raw = @store.intercept_bridge
+        return nil unless raw
+        JSON.parse(raw).as_h?
+      rescue
+        nil
+      end
+
+      private def intercept_list(h) : Result
+        include_sensitive = bool_arg(h, "include_sensitive", false)
+        bridge = intercept_bridge_state
+        unless bridge
+          return Result.new(JSON.build do |j|
+            j.object do
+              j.field "available", false
+              j.field "reason", "no capturing gori instance is publishing intercept state (open the project's TUI to intercept)"
+            end
+          end)
+        end
+        token = bridge["session_token"]?.try(&.as_s?) || ""
+        hb = bridge["heartbeat_ms"]?.try(&.as_i64?) || 0_i64
+        now_ms = Time.utc.to_unix_ms
+        items = token.empty? ? [] of Store::HeldRow : @store.intercept_held(token)
+        # Stamp viewed_ms so the capturing instance's auto-forward reaper sees the agent is
+        # watching (only meaningful when we can actually act; skip in read-only mode).
+        @store.touch_intercept_held(token, items.map(&.item_id), now_ms) if @allow_actions && !items.empty?
+        Result.new(JSON.build do |j|
+          j.object do
+            j.field "available", true
+            # Derive `capturing` from LIVENESS, not the blob's static true: a crashed/closed
+            # instance leaves a stale blob behind (nothing writes capturing:false, and cleanup
+            # only runs at the NEXT session's startup), so echoing it would report a dead session
+            # as live. intercept_live? (heartbeat < 10s) is the authoritative freshness signal.
+            j.field "capturing", intercept_live?(bridge)
+            j.field "enabled", bridge["enabled"]?.try(&.as_bool?) || false
+            j.field "direction", bridge["direction"]?.try(&.as_s?) || "both"
+            j.field "filter", bridge["filter"]?.try(&.as_s?) || ""
+            j.field "heartbeat_age_seconds", (hb > 0 ? ((now_ms - hb) // 1000) : nil)
+            j.field "pending_count", items.size
+            j.field("items") { j.array { items.each { |r| Serialize.intercept_item_row(j, r, include_sensitive, now_ms) } } }
+          end
+        end)
+      end
+
+      private def intercept_get(h) : Result
+        item_id = int(h, "item_id")
+        return err(id_error(h, "item_id"), "INVALID_ARGUMENT", field: "item_id") unless item_id
+        include_sensitive = bool_arg(h, "include_sensitive", false)
+        bridge = intercept_bridge_state
+        return not_found("no capturing gori instance is publishing intercept state") unless bridge
+        token = bridge["session_token"]?.try(&.as_s?) || ""
+        row = token.empty? ? nil : @store.intercept_held(token).find { |r| r.item_id == item_id }
+        return not_found("held item #{item_id} is not currently held (already forwarded/dropped, or never held)") unless row
+        @store.touch_intercept_held(token, [row.item_id], Time.utc.to_unix_ms) if @allow_actions
+        Result.new(JSON.build { |j| Serialize.intercept_item_detail(j, row, include_sensitive, Time.utc.to_unix_ms) })
+      end
+
+      # --- #123 live intercept (write side; gated behind allow_actions) -------
+
+      # A capturing instance is "live" only if its bridge says capturing AND the heartbeat is
+      # recent — otherwise a queued command would never be applied (leaving a hung hold), so a
+      # mutating verb refuses up front instead of enqueuing into the void.
+      INTERCEPT_LIVE_MS   = 10_000_i64
+      INTERCEPT_ACK_POLLS =         30
+      INTERCEPT_ACK_SLEEP = 100.milliseconds
+
+      private def intercept_live?(bridge : Hash(String, JSON::Any)) : Bool
+        return false unless bridge["capturing"]?.try(&.as_bool?)
+        hb = bridge["heartbeat_ms"]?.try(&.as_i64?) || 0_i64
+        hb > 0 && (Time.utc.to_unix_ms - hb) < INTERCEPT_LIVE_MS
+      end
+
+      private def intercept_forward(h) : Result
+        id = int(h, "item_id")
+        return err(id_error(h, "item_id"), "INVALID_ARGUMENT", field: "item_id") unless id
+        enqueue_intercept("forward", item_id: id)
+      end
+
+      private def intercept_drop(h) : Result
+        id = int(h, "item_id")
+        return err(id_error(h, "item_id"), "INVALID_ARGUMENT", field: "item_id") unless id
+        enqueue_intercept("drop", item_id: id)
+      end
+
+      private def intercept_forward_edit(h) : Result
+        id = int(h, "item_id")
+        return err(id_error(h, "item_id"), "INVALID_ARGUMENT", field: "item_id") unless id
+        raw = str(h, "raw")
+        return err("missing required 'raw' (the full edited wire message)", "INVALID_ARGUMENT", field: "raw") if raw.nil? || raw.empty?
+        # Normalize line endings to CRLF (like the human intercept editor), then sync
+        # Content-Length to the edited body. Bytes are LITERAL — no Env.expand_wire, so a remote
+        # agent's $SECRET references are never expanded into forwarded traffic; and no smuggling
+        # guard, because byte-exact forwarding of arbitrary edits is the whole point of an
+        # intercept editor in a security tool (matches the human forward_bytes contract).
+        wire = raw.gsub(/\r?\n/, "\r\n")
+        bytes = Fuzz::ContentLength.sync(wire.to_slice, add_when_missing: true)
+        enqueue_intercept("forward_edit", item_id: id, bytes: bytes)
+      end
+
+      private def intercept_toggle(h) : Result
+        want = bool(h, "enable")
+        return err("missing required 'enable' (true or false)", "INVALID_ARGUMENT", field: "enable") if want.nil?
+        enqueue_intercept("toggle", arg: want ? "true" : "false")
+      end
+
+      private def intercept_set_filter(h) : Result
+        q = str(h, "query")
+        return err("missing required 'query' (empty string to clear)", "INVALID_ARGUMENT", field: "query") if q.nil?
+        enqueue_intercept("set_filter", arg: q)
+      end
+
+      private def intercept_set_direction(h) : Result
+        dir = str(h, "direction").try(&.downcase)
+        unless dir && {"both", "request", "response"}.includes?(dir)
+          return err("invalid 'direction' (expected both | request | response)", "INVALID_ARGUMENT", field: "direction")
+        end
+        enqueue_intercept("set_direction", arg: dir)
+      end
+
+      # Enqueue one command for the live capturing instance, then bounded-poll its ack so the
+      # agent gets a real outcome (forwarded/dropped/no_such_item/…) rather than assuming success
+      # on a write that may have been dropped or never drained.
+      private def enqueue_intercept(verb : String, *, item_id : Int64? = nil, bytes : Bytes? = nil, arg : String? = nil) : Result
+        bridge = intercept_bridge_state
+        unless bridge && intercept_live?(bridge)
+          return busy("no live capturing gori instance is draining intercept commands (open the project's TUI with intercept on)")
+        end
+        token = bridge["session_token"]?.try(&.as_s?)
+        id = @store.enqueue_intercept_command(token, verb, item_id: item_id, bytes: bytes, arg: arg)
+        return busy("could not enqueue intercept command (store write dropped); retry") if id == 0
+        await_intercept_ack(id)
+      end
+
+      private def await_intercept_ack(id : Int64) : Result
+        INTERCEPT_ACK_POLLS.times do
+          if st = @store.command_status(id)
+            return intercept_ack_result(st[0], st[1]) unless st[0] == "pending"
+          end
+          sleep INTERCEPT_ACK_SLEEP
+        end
+        err("intercept command not confirmed within #{(INTERCEPT_ACK_POLLS * INTERCEPT_ACK_SLEEP.total_milliseconds).to_i}ms — the capturing instance may be busy; retry",
+          "NOT_CONFIRMED", retryable: true)
+      end
+
+      private def intercept_ack_result(status : String, detail : String?) : Result
+        case status
+        when "forwarded"
+          Result.new(JSON.build { |j| j.object { j.field "status", "forwarded"; j.field "detail", detail } })
+        when "dropped"
+          Result.new(JSON.build { |j| j.object { j.field "status", "dropped"; j.field "detail", detail } })
+        when "edited"
+          Result.new(JSON.build { |j| j.object { j.field "status", "forwarded"; j.field "edited", true; j.field "detail", detail } })
+        when "toggled", "filter_set", "direction_set"
+          Result.new(JSON.build { |j| j.object { j.field "status", status; j.field "detail", detail } })
+        when "no_such_item"
+          not_found(detail || "the held item is no longer held (already forwarded/dropped)")
+        when "stale"
+          err(detail || "command targeted a previous capture session; re-list held items", "SESSION_CHANGED")
+        else
+          err("intercept command #{status}: #{detail}", "INTERNAL")
+        end
       end
 
       # Parse + validate a QL query for a list tool. Returns the compiled Filter, or

--- a/src/gori/session.cr
+++ b/src/gori/session.cr
@@ -111,6 +111,9 @@ module Gori
           # run the scanner. Both are gated on the lock so a view-only 2nd instance touches
           # neither the shared Pending rows nor the shared issue set.
           store.abandon_pending!("orphaned by a previous session")
+          # #123: wipe any live-intercept snapshot / command rows a dead session left behind
+          # (their per-session item ids no longer mean anything) before we start publishing.
+          store.clear_intercept_state!
           probe.start
         end
         session = new(config, ca, registry, project, store, proxy, tunnel, events, probe, rules, scope, host_overrides, interceptor, bind_error, lock)
@@ -129,9 +132,15 @@ module Gori
       end
     end
 
+    # A random per-session token stamped on every #123 intercept snapshot/command row, so a
+    # stale command from a prior session (whose interceptor item ids reset to 0) can never be
+    # applied against a different new held item — the drain acks a token mismatch as stale.
+    getter intercept_token : String
+
     def initialize(@config, @ca, @registry, @project, @store, @proxy, @tunnel, @flow_events, @probe,
                    @rules, @scope, @host_overrides, @interceptor, @bind_error : String? = nil,
                    @capture_lock : CaptureLock? = nil)
+      @intercept_token = Random::Secure.hex(8)
     end
 
     # Flip upstream TLS verification live (settings:network toggle). Updates the runtime

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -1132,6 +1132,143 @@ module Gori
       }
     end
 
+    # Append one row to the #124 event feed (the AI firehose). Goes through the writer
+    # fiber like every other insert; returns last_insert_rowid (0 on a dropped/closed-store
+    # write — the caller decides whether a lost event matters). NEVER used for flow rows
+    # (flows are the firehose via list_history); this is job-lifecycle + agent-action events.
+    def insert_event(source : String, kind : String, level : String, message : String, *,
+                     goto_tab : String? = nil, goto_session_id : Int64? = nil,
+                     flow_id : Int64? = nil, payload : String? = nil) : Int64
+      exec_task ->(c : DB::Connection) {
+        c.exec("INSERT INTO events (created_at, source, kind, level, message, goto_tab, goto_session_id, flow_id, payload) VALUES (?,?,?,?,?,?,?,?,?)",
+          now_us, source, kind, level, message, goto_tab, goto_session_id, flow_id, payload)
+        nil
+      }
+    end
+
+    # --- #123 live-intercept bridge (cross-process: MCP writes, the capturing TUI drains) ---
+
+    INTERCEPT_BRIDGE_KEY = "intercept_bridge"
+
+    # Mirror the currently-held intercept queue for `token` into intercept_held so the MCP
+    # process can list/get it. INSERT OR IGNORE writes each item's raw BLOB exactly ONCE (held
+    # bytes are immutable), DELETEs items no longer held, and DELETEs rows from any other
+    # (dead-session) token — all in one writer transaction, so a rapid hold/forward cycle
+    # doesn't re-write large bodies every publish.
+    def publish_intercept_held(token : String, rows : Array(HeldRow)) : Nil
+      exec_task ->(c : DB::Connection) {
+        c.exec("DELETE FROM intercept_held WHERE session_token <> ?", token)
+        if rows.empty?
+          c.exec("DELETE FROM intercept_held WHERE session_token = ?", token)
+        else
+          keep = [token.as(DB::Any)]
+          rows.each { |r| keep << r.item_id }
+          placeholders = Array.new(rows.size, "?").join(",")
+          c.exec("DELETE FROM intercept_held WHERE session_token = ? AND item_id NOT IN (#{placeholders})", args: keep)
+          rows.each do |r|
+            c.exec("INSERT OR IGNORE INTO intercept_held (session_token, item_id, kind, method, host, port, scheme, target, flow_id, raw, held_at_ms, edited) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+              token, r.item_id, r.kind, r.method, r.host, r.port, r.scheme, r.target, r.flow_id, r.raw, r.held_at_ms, r.edited ? 1 : 0)
+          end
+        end
+        nil
+      }
+    end
+
+    def intercept_held(token : String) : Array(HeldRow)
+      rows = [] of HeldRow
+      @db.query("SELECT session_token, item_id, kind, method, host, port, scheme, target, flow_id, raw, held_at_ms, edited, viewed_ms FROM intercept_held WHERE session_token = ? ORDER BY item_id", token) do |rs|
+        rs.each { rows << read_held(rs) }
+      end
+      rows
+    end
+
+    # Stamp `viewed_ms` on held items an MCP intercept_list/get just returned — the agent's
+    # liveness signal for the auto-forward reaper. Best-effort (no-op if a row was released).
+    def touch_intercept_held(token : String, item_ids : Array(Int64), now_ms : Int64) : Nil
+      return if item_ids.empty?
+      exec_task ->(c : DB::Connection) {
+        args = [now_ms.as(DB::Any), token.as(DB::Any)]
+        item_ids.each { |i| args << i }
+        placeholders = Array.new(item_ids.size, "?").join(",")
+        c.exec("UPDATE intercept_held SET viewed_ms = ? WHERE session_token = ? AND item_id IN (#{placeholders})", args: args)
+        nil
+      }
+    end
+
+    private def read_held(rs : DB::ResultSet) : HeldRow
+      token = rs.read(String); item_id = rs.read(Int64); kind = rs.read(String)
+      method = rs.read(String); host = rs.read(String); port = rs.read(Int32)
+      scheme = rs.read(String); target = rs.read(String); flow_id = rs.read(Int64?)
+      raw = rs.read(Bytes); held_at_ms = rs.read(Int64); edited = rs.read(Int32) != 0
+      viewed_ms = rs.read(Int64)
+      HeldRow.new(token, item_id, kind, method, host, port, scheme, target, raw, held_at_ms, flow_id, edited, viewed_ms)
+    end
+
+    # Append one MCP->TUI intercept command. Returns last_insert_rowid (0 on a dropped write —
+    # the MCP verb treats 0 as retryable rather than assuming the command was queued).
+    def enqueue_intercept_command(token : String?, verb : String, *, item_id : Int64? = nil,
+                                  bytes : Bytes? = nil, arg : String? = nil) : Int64
+      exec_task ->(c : DB::Connection) {
+        c.exec("INSERT INTO intercept_commands (created_at, session_token, verb, item_id, bytes, arg) VALUES (?,?,?,?,?,?)",
+          now_us, token, verb, item_id, bytes, arg)
+        nil
+      }
+    end
+
+    # Forward cursor over the command queue (id > after_id, oldest-first) — the TUI drain
+    # watermark. AUTOINCREMENT ids are never reused, so this can't silently skip a row.
+    def intercept_commands_after(after_id : Int64, limit : Int32) : Array(CommandRow)
+      rows = [] of CommandRow
+      @db.query("SELECT id, session_token, verb, item_id, bytes, arg FROM intercept_commands WHERE id > ? ORDER BY id ASC LIMIT ?",
+        args: [after_id, limit.to_i64] of DB::Any) do |rs|
+        rs.each do
+          rows << CommandRow.new(rs.read(Int64), rs.read(String?), rs.read(String),
+            rs.read(Int64?), rs.read(Bytes?), rs.read(String?))
+        end
+      end
+      rows
+    end
+
+    def latest_intercept_command_id : Int64
+      @db.scalar("SELECT COALESCE(MAX(id), 0) FROM intercept_commands").as(Int64)
+    end
+
+    def ack_intercept_command(id : Int64, status : String, result : String? = nil) : Nil
+      exec_task ->(c : DB::Connection) {
+        c.exec("UPDATE intercept_commands SET status = ?, applied_at = ?, result = ? WHERE id = ?", status, now_us, result, id)
+        nil
+      }
+    end
+
+    # {status, result} for one command — the MCP verb bounded-polls this to resolve
+    # forwarded/dropped/no_such_item/… instead of assuming success on a possibly-dropped write.
+    def command_status(id : Int64) : {String, String?}?
+      @db.query("SELECT status, result FROM intercept_commands WHERE id = ?", id) do |rs|
+        return {rs.read(String), rs.read(String?)} if rs.move_next
+      end
+      nil
+    end
+
+    # Wipe the bridge state a prior (now-dead) capture session left behind, so no stale snapshot
+    # or command can be acted on. Called by the fresh lock holder before it starts publishing.
+    def clear_intercept_state! : Nil
+      exec_task ->(c : DB::Connection) {
+        c.exec("DELETE FROM intercept_held")
+        c.exec("DELETE FROM intercept_commands")
+        nil
+      }
+    end
+
+    # The bridge blob (enabled/direction/filter/session_token/pending_count/heartbeat_ms) — a
+    # single settings row the lock holder republishes; the config mirror + liveness heartbeat.
+    def set_intercept_bridge(json : String) : Nil
+      set_setting(INTERCEPT_BRIDGE_KEY, json)
+    end
+
+    def intercept_bridge : String?
+      setting(INTERCEPT_BRIDGE_KEY)
+    end
+
     def fuzz_results(run_id : Int64, limit : Int32 = 200, offset : Int32 = 0) : Array(FuzzResultRecord)
       list = [] of FuzzResultRecord
       @db.query("SELECT id, run_id, idx, payloads, status, length, words, lines, duration_us, error, matched, extracted, request, response_head, response_body FROM fuzz_results WHERE run_id = ? ORDER BY idx LIMIT ? OFFSET ?", run_id, limit, offset) do |rs|
@@ -1277,11 +1414,19 @@ module Gori
       SQL
 
     # Newest-first page of the History list. `before_id` is a cursor for paging
-    # into older rows (stable as new rows append, unlike OFFSET).
-    def recent_flows(limit : Int32, before_id : Int64? = nil) : Array(FlowRow)
+    # into older rows (stable as new rows append, unlike OFFSET). `since_id` is the
+    # opposite FORWARD cursor (id > since_id, OLDEST-first) so a caller — e.g. the #124
+    # MCP feed — can tail NEW flows exactly-once. The two are mutually exclusive; when
+    # both are given since_id wins (the MCP layer rejects the combination up front).
+    def recent_flows(limit : Int32, before_id : Int64? = nil, since_id : Int64? = nil) : Array(FlowRow)
       rows = [] of FlowRow
-      sql = before_id ? "#{SELECT_ROW} WHERE id < ? ORDER BY id DESC LIMIT ?" : "#{SELECT_ROW} ORDER BY id DESC LIMIT ?"
-      args = before_id ? [before_id, limit] of DB::Any : [limit] of DB::Any
+      sql, args = if since_id
+                    {"#{SELECT_ROW} WHERE id > ? ORDER BY id ASC LIMIT ?", [since_id, limit] of DB::Any}
+                  elsif before_id
+                    {"#{SELECT_ROW} WHERE id < ? ORDER BY id DESC LIMIT ?", [before_id, limit] of DB::Any}
+                  else
+                    {"#{SELECT_ROW} ORDER BY id DESC LIMIT ?", [limit] of DB::Any}
+                  end
       @db.query(sql, args: args) do |rs|
         rs.each { rows << read_row(rs) }
       end
@@ -1295,11 +1440,15 @@ module Gori
     # degrading to no matches. The TUI keeps the default (never crash the live run
     # loop); one-shot CLI callers pass true so a failed query is reported distinctly
     # from a genuinely empty result rather than as a clean "no flows match".
-    def search(filter : QL::Filter, limit : Int32, before_id : Int64? = nil, *,
+    def search(filter : QL::Filter, limit : Int32, before_id : Int64? = nil, since_id : Int64? = nil, *,
                raise_on_error : Bool = false) : Array(FlowRow)
       rows = [] of FlowRow
       args = filter.args.dup
-      if before_id
+      if since_id
+        args << since_id
+        args << limit
+        sql = "#{SELECT_ROW} WHERE (#{filter.sql}) AND id > ? ORDER BY id ASC LIMIT ?"
+      elsif before_id
         args << before_id
         args << limit
         sql = "#{SELECT_ROW} WHERE (#{filter.sql}) AND id < ? ORDER BY id DESC LIMIT ?"
@@ -1315,6 +1464,20 @@ module Gori
       raise ex if raise_on_error
       STDERR.puts "gori: search failed (#{ex.message})"
       [] of FlowRow
+    end
+
+    EVENT_COLS = "id, created_at, source, kind, level, message, goto_tab, goto_session_id, flow_id, payload"
+
+    # #124 forward cursor: events with id strictly AFTER `since_id`, OLDEST-first, up to
+    # `limit`. Mirrors ws_messages_after — the AI tails the feed exactly-once from a
+    # monotonic high-water-mark (id is the never-reused AUTOINCREMENT key).
+    def events_after(since_id : Int64, limit : Int32) : Array(EventRow)
+      rows = [] of EventRow
+      @db.query("SELECT #{EVENT_COLS} FROM events WHERE id > ? ORDER BY id ASC LIMIT ?",
+        args: [since_id, limit.to_i64] of DB::Any) do |rs|
+        rs.each { rows << read_event(rs) }
+      end
+      rows
     end
 
     # Single-row projection, e.g. to refresh a row after an :inserted/:updated
@@ -1999,6 +2162,14 @@ module Gori
       content_type = rs.read(String?)
       FlowRow.new(id, created_at, scheme, method, host, port, target,
         status, req_size + (resp_size || 0_i64), state, resp_size, duration_us, content_type)
+    end
+
+    # Column order MUST match EVENT_COLS.
+    private def read_event(rs : DB::ResultSet) : EventRow
+      EventRow.new(
+        rs.read(Int64), rs.read(Int64), rs.read(String), rs.read(String),
+        rs.read(String), rs.read(String), rs.read(String?), rs.read(Int64?),
+        rs.read(Int64?), rs.read(String?))
     end
 
     # Non-blocking best-effort publish: if the TUI is behind and the channel is

--- a/src/gori/store/models.cr
+++ b/src/gori/store/models.cr
@@ -470,5 +470,66 @@ module Gori
 
     # Best-effort notification that a flow row changed. Published AFTER commit.
     record FlowEvent, id : Int64, kind : Symbol # :inserted | :updated
+
+    # One row of the #124 append-only event feed (the AI firehose the MCP process tails).
+    # `id` is the forward cursor key (monotonic AUTOINCREMENT); `created_at` is unix micros
+    # for display. `goto_tab`/`goto_session_id` mirror Jobs::Goto so a promoted event can
+    # jump to its result; `flow_id` is an optional cross-ref to a captured flow.
+    struct EventRow
+      getter id : Int64
+      getter created_at : Int64
+      getter source : String
+      getter kind : String
+      getter level : String
+      getter message : String
+      getter goto_tab : String?
+      getter goto_session_id : Int64?
+      getter flow_id : Int64?
+      getter payload : String?
+
+      def initialize(@id, @created_at, @source, @kind, @level, @message,
+                     @goto_tab = nil, @goto_session_id = nil, @flow_id = nil, @payload = nil)
+      end
+    end
+
+    # One currently-held intercept item, MIRRORED into intercept_held by the capturing
+    # process so the MCP process can list/get it (#123). `item_id` is the Interceptor's
+    # per-session id; `held_at_ms` is a WALL-CLOCK stamp captured once at hold time (the
+    # in-memory Item.held_at is a monotonic Instant, meaningless across processes).
+    struct HeldRow
+      getter session_token : String
+      getter item_id : Int64
+      getter kind : String
+      getter method : String
+      getter host : String
+      getter port : Int32
+      getter scheme : String
+      getter target : String
+      getter flow_id : Int64?
+      getter raw : Bytes
+      getter held_at_ms : Int64
+      getter edited : Bool
+      # Wall-clock of the last MCP intercept_list/get that returned this item — the agent's
+      # "I'm still watching" signal for the auto-forward reaper (0 = never viewed by an agent).
+      getter viewed_ms : Int64
+
+      def initialize(@session_token, @item_id, @kind, @method, @host, @port, @scheme,
+                     @target, @raw, @held_at_ms, @flow_id = nil, @edited = false, @viewed_ms = 0_i64)
+      end
+    end
+
+    # One row of the intercept_commands queue (MCP -> TUI). Drained forward-cursored and
+    # applied by the lock-holding TUI (#123).
+    struct CommandRow
+      getter id : Int64
+      getter session_token : String?
+      getter verb : String
+      getter item_id : Int64?
+      getter bytes : Bytes?
+      getter arg : String?
+
+      def initialize(@id, @session_token, @verb, @item_id = nil, @bytes = nil, @arg = nil)
+      end
+    end
   end
 end

--- a/src/gori/store/schema.cr
+++ b/src/gori/store/schema.cr
@@ -7,7 +7,7 @@ module Gori
     # (FTS5 for QL, a tags table, a connections table) arrive as *later*
     # migrations — which is exactly why none of them exist in v1 (P0).
     module Schema
-      VERSION = 34
+      VERSION = 36
 
       # The migration that reclaims duplicated/low-value bytes already on disk (see V25).
       # Store.open runs a one-time VACUUM after an EXISTING db crosses this version so the
@@ -569,7 +569,75 @@ module Gori
         "UPDATE entity_links SET owner_kind = 'issue' WHERE owner_kind = 'finding'",
       ]
 
-      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21, V22, V23, V24, V25, V26, V27, V28, V29, V30, V31, V32, V33, V34]
+      # #124 — the AI-facing event feed. An append-only log of job lifecycle (miner/fuzzer/
+      # probe) and agent actions that the MCP process tails via a forward `id > cursor`
+      # cursor (list_events). Flows stay the flow firehose (list_history since:) — this table
+      # NEVER duplicates flow rows; `flow_id` is only an optional cross-ref. AUTOINCREMENT is
+      # mandatory (not a bare rowid): a never-reused id guarantees a since_id watermark
+      # consumer can't silently skip a row even if a future retention sweep deletes rows.
+      # created_at is unix micros for display only — the cursor key is always `id`.
+      V35 = [
+        <<-SQL,
+        CREATE TABLE events (
+          id              INTEGER PRIMARY KEY AUTOINCREMENT,
+          created_at      INTEGER NOT NULL,
+          source          TEXT    NOT NULL,
+          kind            TEXT    NOT NULL,
+          level           TEXT    NOT NULL,
+          message         TEXT    NOT NULL,
+          goto_tab        TEXT,
+          goto_session_id INTEGER,
+          flow_id         INTEGER,
+          payload         TEXT
+        )
+        SQL
+      ]
+
+      # #123 — the cross-process live-intercept bridge. The MCP process (Store only, no live
+      # Interceptor) drives hold/forward/drop/edit through the DB: the capturing TUI publishes a
+      # MIRROR of the currently-held queue into intercept_held, and the MCP process appends
+      # decisions to the intercept_commands queue which the TUI drains + applies. intercept_held
+      # is keyed by (session_token, item_id) — a snapshot mirror, NOT a cursor log, so the id-reuse
+      # hazard doesn't apply. intercept_commands IS a forward-cursored queue, so its id MUST be
+      # AUTOINCREMENT (a recycled rowid would let the TUI's drain watermark silently skip a row).
+      # session_token defeats cross-session reuse of the interceptor's per-session item ids.
+      V36 = [
+        <<-SQL,
+        CREATE TABLE intercept_held (
+          session_token TEXT    NOT NULL,
+          item_id       INTEGER NOT NULL,
+          kind          TEXT    NOT NULL,
+          method        TEXT    NOT NULL,
+          host          TEXT    NOT NULL,
+          port          INTEGER NOT NULL,
+          scheme        TEXT    NOT NULL,
+          target        TEXT    NOT NULL,
+          flow_id       INTEGER,
+          raw           BLOB    NOT NULL,
+          held_at_ms    INTEGER NOT NULL,
+          edited        INTEGER NOT NULL DEFAULT 0,
+          viewed_ms     INTEGER NOT NULL DEFAULT 0,
+          PRIMARY KEY (session_token, item_id)
+        )
+        SQL
+        <<-SQL,
+        CREATE TABLE intercept_commands (
+          id            INTEGER PRIMARY KEY AUTOINCREMENT,
+          created_at    INTEGER NOT NULL,
+          session_token TEXT,
+          verb          TEXT    NOT NULL,
+          item_id       INTEGER,
+          bytes         BLOB,
+          arg           TEXT,
+          status        TEXT    NOT NULL DEFAULT 'pending',
+          applied_at    INTEGER,
+          result        TEXT,
+          origin        TEXT
+        )
+        SQL
+      ]
+
+      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21, V22, V23, V24, V25, V26, V27, V28, V29, V30, V31, V32, V33, V34, V35, V36]
 
       def self.migrate!(db : DB::Database) : Nil
         db.using_connection do |conn|

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -693,8 +693,10 @@ module Gori::Tui
         # The failure persists in the jobs center (survives the next keystroke) and shows
         # in the bottom bar. It is deliberately NOT pushed to the notification center: a
         # job error is an operational failure, not a result the human wants surfaced there
-        # (and it already had two other surfaces) — see #127.
+        # (and it already had two other surfaces) — see #127. It IS logged to the #124 event
+        # feed (the AI firehose logs freely; only the human center suppresses it).
         @host.jobs.finish(v.job_id, :error, ev.message)
+        log_event(v, :error, "Fuzzer: #{ev.message} on #{v.summary}")
         @host.status("fuzz error: #{ev.message}")
       end
     end
@@ -704,8 +706,17 @@ module Gori::Tui
       @host.jobs.finish(v.job_id, :done, "#{n} hit")
       level = n > 0 ? :success : :info
       msg = "Fuzzer: #{n} hit#{n == 1 ? "" : "s"} / #{v.result_count} sent on #{v.summary}#{ev.stopped ? " (stopped)" : ""}"
-      @host.notifications.push(level, msg, goto_for(v))
+      log_event(v, level, msg)
+      @host.notifications.push(level, msg, goto_for(v), source: "fuzzer")
       @host.status(msg)
+    end
+
+    # #124: append every fuzz completion/error to the store event feed UNCONDITIONALLY
+    # (the AI firehose — see the ErrorEvent note above re: #127).
+    private def log_event(v : FuzzerView, level : Symbol, msg : String) : Nil
+      g = goto_for(v)
+      @host.session.store.insert_event("fuzzer", "job_done", level.to_s, msg,
+        goto_tab: g.try(&.tab.to_s), goto_session_id: g.try(&.session_id))
     end
 
     private def goto_for(v : FuzzerView) : Jobs::Goto?

--- a/src/gori/tui/controllers/miner_controller.cr
+++ b/src/gori/tui/controllers/miner_controller.cr
@@ -455,7 +455,9 @@ module Gori::Tui
       when Miner::ErrorEvent
         v.finish_run
         @host.jobs.finish(v.job_id, :error, ev.message)
-        push_mine_notification(v, :error, "Miner: #{ev.message} on #{v.summary}")
+        msg = "Miner: #{ev.message} on #{v.summary}"
+        log_event(v, :error, msg)
+        push_mine_notification(v, :error, msg)
         @host.status("miner error: #{ev.message}") if v.config.notify.posts_notification?(0, error: true)
       end
     end
@@ -465,13 +467,22 @@ module Gori::Tui
       @host.jobs.finish(v.job_id, :done, "#{n} found")
       msg = "Miner: #{n} param#{n == 1 ? "" : "s"} found on #{v.summary}#{ev.stopped ? " (stopped)" : ""}"
       level = n > 0 ? :success : :info
+      log_event(v, level, msg)
       push_mine_notification(v, level, msg, found: n)
       @host.status(msg) if v.config.notify.posts_notification?(n)
     end
 
     private def push_mine_notification(v : MinerView, level : Symbol, msg : String, found : Int32 = 0) : Nil
       return unless v.config.notify.posts_notification?(found, error: level == :error)
-      @host.notifications.push(level, msg, goto_for(v))
+      @host.notifications.push(level, msg, goto_for(v), source: "miner")
+    end
+
+    # #124: append every mine completion/error to the store event feed UNCONDITIONALLY —
+    # independent of the human NotifyMode gate above ("log freely, interrupt deliberately").
+    private def log_event(v : MinerView, level : Symbol, msg : String) : Nil
+      g = goto_for(v)
+      @host.session.store.insert_event("miner", "job_done", level.to_s, msg,
+        goto_tab: g.try(&.tab.to_s), goto_session_id: g.try(&.session_id))
     end
 
     private def goto_for(v : MinerView) : Jobs::Goto?

--- a/src/gori/tui/controllers/probe_controller.cr
+++ b/src/gori/tui/controllers/probe_controller.cr
@@ -177,13 +177,17 @@ module Gori::Tui
         when Probe::IssueEvent
           refresh_from_store
           if summary = ev.summary
-            @host.notifications.push(:success, "Probe: #{summary}")
+            # #124: log to the AI event feed regardless of the human notification.
+            @host.session.store.insert_event("probe", "issue_found", "success", "Probe: #{summary}", goto_tab: "probe")
+            @host.notifications.push(:success, "Probe: #{summary}", source: "probe")
             # Status toast is visible on every tab and pairs with the list paint.
             @host.status("Probe: #{summary}")
           end
         when Probe::ErrorEvent
           # Bottom bar only — a scan error is operational noise, not a result to push
-          # into the notification center (#127).
+          # into the notification center (#127). Still logged to the #124 event feed
+          # (the AI firehose logs freely; only the human center suppresses it).
+          @host.session.store.insert_event("probe", "error", "error", "Probe: #{ev.message}", goto_tab: "probe")
           @host.status(ev.message)
         end
       end

--- a/src/gori/tui/notifications.cr
+++ b/src/gori/tui/notifications.cr
@@ -15,11 +15,21 @@ module Gori::Tui
       getter message : String
       getter created_at : Time::Instant
       getter goto : Jobs::Goto?
+      # Who produced this note: "app" (default), "miner"/"fuzzer"/"probe" (background
+      # engines), or "agent"/"agent:<name>" (an MCP co-pilot — rendered distinctly so the
+      # human can see what the AI did). A String (not a Symbol like `level`) to carry the
+      # open-ended agent:<name> form. (#124)
+      getter source : String
       property read : Bool
 
-      def initialize(@id, @level, @message, @goto = nil)
+      def initialize(@id, @level, @message, @goto = nil, @source = "app")
         @created_at = Time.instant
         @read = false
+      end
+
+      # AI/agent-originated notes get a distinct marker in the overlay.
+      def agent? : Bool
+        @source.starts_with?("agent")
       end
     end
 
@@ -28,8 +38,8 @@ module Gori::Tui
       @next_id = 0
     end
 
-    def push(level : Symbol, message : String, goto : Jobs::Goto? = nil) : Note
-      n = Note.new((@next_id += 1), level, message, goto)
+    def push(level : Symbol, message : String, goto : Jobs::Goto? = nil, source : String = "app") : Note
+      n = Note.new((@next_id += 1), level, message, goto, source)
       @notes << n
       @notes.shift if @notes.size > CAP
       n

--- a/src/gori/tui/notifications_overlay.cr
+++ b/src/gori/tui/notifications_overlay.cr
@@ -81,8 +81,17 @@ module Gori::Tui
       bold = note.read ? Attribute::None : Attribute::Bold
       fg = sel ? Theme.text_bright : Theme.text
       stamp = ago(note.created_at)
-      msg_w = {box.right - 1 - (box.x + 5) - (stamp.size + 1), 1}.max
-      screen.text(box.x + 5, py, note.message, fg, bg, bold, width: msg_w)
+      # Agent-originated notes (an MCP co-pilot acting in the loop) get a distinct "ai"
+      # tag so the human can see at a glance which entries the AI produced. Other sources
+      # already name themselves in the message ("Miner: …", "Probe: …"), so no tag.
+      msg_x = box.x + 5
+      if note.agent?
+        tag = "ai"
+        screen.text(msg_x, py, tag, Theme.accent, bg, Attribute::Bold)
+        msg_x += tag.size + 1
+      end
+      msg_w = {box.right - 1 - msg_x - (stamp.size + 1), 1}.max
+      screen.text(msg_x, py, note.message, fg, bg, bold, width: msg_w)
       screen.text(box.right - 1 - stamp.size, py, stamp, Theme.muted, bg)
     end
 

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -180,6 +180,18 @@ module Gori::Tui
       @jobs = Jobs.new
       @notifications = Notifications.new
       @notifications_overlay = NotificationsOverlay.new(@notifications)
+      # #123: high-water-mark of intercept_commands drained + applied to the live interceptor
+      # (agent forward/drop/edit/toggle). Seeded to the current max at run start so a fresh
+      # session never replays a prior command; advances monotonically as commands are consumed.
+      @intercept_cmd_watermark = 0_i64
+      # #123 safety net: auto-forward a held item nobody is watching after this many ms, so a
+      # dead MCP client (hold() has no timeout) can't wedge a connection forever. 0 disables it.
+      @intercept_max_hold_ms = 30_000_i64
+      # …but the reaper ONLY arms once an MCP/agent consumer has actually attached this session
+      # (drained a command or polled the queue). A pure-human intercept session must keep the
+      # base P4 contract — a held item waits INDEFINITELY for the human decision, never
+      # auto-forwarded just because the operator glanced at another tab.
+      @intercept_agent_seen = false
       # Optional bottom statusline: runs a user script on an interval and shows its
       # ANSI-coloured stdout. Disabled by default (no fiber, no reserved row until on).
       @statusline = StatuslineController.new(@session)
@@ -335,6 +347,9 @@ module Gori::Tui
       last_clock = clock_label                         # top-bar wall clock; re-render only when the minute rolls over
       last_ui_ident = nil.as(String?)                  # last-written ui-state identity (see UI_STATE_THROTTLE)
       last_ui_write = Time.instant
+      last_pub_rev = -1                                 # #123: last interceptor revision mirrored to the store (-1 = publish on first tick)
+      last_bridge_pub = Time.instant                    # #123: last bridge-heartbeat write (throttled so idle never churns the WAL)
+      @intercept_cmd_watermark = @session.store.latest_intercept_command_id # tail agent commands from now
       begin
       loop do
         ev = @term.poll_event(50)
@@ -395,6 +410,28 @@ module Gori::Tui
             apply_external_change
             dirty = true
           end
+          # #123: keep the store-backed intercept bridge fresh for the MCP process, but ONLY in
+          # the capture-lock holder (a view-only 2nd instance has an empty queue and must not
+          # clobber the real holder's snapshot). Re-mirror the held queue only when it actually
+          # changed (revision), but refresh the tiny bridge heartbeat every cadence so liveness
+          # stays current. The command drain (Phase 2) runs here too, before the republish.
+          if @session.capturing_lock_held?
+            ic = @session.interceptor
+            # Order (per plan): drain+apply agent commands, THEN re-mirror the (now-updated)
+            # queue, THEN refresh the heartbeat. forward/drop bump revision, so a drained
+            # command triggers the snapshot republish below in the same tick.
+            dirty = true if drain_intercept_commands
+            dirty = true if reap_stale_holds
+            if (prev = ic.revision) != last_pub_rev
+              last_pub_rev = prev
+              publish_intercept_snapshot(ic)   # queue changed → re-mirror held rows
+              publish_intercept_bridge(ic)     # and refresh config/heartbeat immediately
+              last_bridge_pub = now
+            elsif now - last_bridge_pub >= INTERCEPT_HEARTBEAT_INTERVAL
+              publish_intercept_bridge(ic)     # periodic liveness heartbeat (throttled)
+              last_bridge_pub = now
+            end
+          end
         end
         # Animate the bottom-bar background-job spinner: while any job runs, advance the
         # frame on a fixed cadence and force a redraw. The any_active? guard keeps idle
@@ -435,11 +472,182 @@ module Gori::Tui
       @outcome
     end
 
+    # --- #123 live-intercept bridge (capture-lock holder publishes for the MCP process) ------
+
+    # Mirror the currently-held intercept queue into the store so the separate `gori mcp`
+    # process can list/get held items. Called only when the queue changed (revision) and only
+    # in the lock holder. Maps each in-memory Item to a HeldRow (wall-clock held_at_ms so the
+    # MCP-side age is stable across republishes).
+    private def publish_intercept_snapshot(ic : Interceptor) : Nil
+      token = @session.intercept_token
+      rows = ic.pending.map do |it|
+        Store::HeldRow.new(token, it.id, it.kind.to_s.downcase, it.method, it.host, it.port,
+          it.scheme, it.target, it.raw, it.held_at_ms, it.flow_id, false)
+      end
+      @session.store.publish_intercept_held(token, rows)
+    end
+
+    # Drain agent-written intercept commands past the watermark and apply each to the live
+    # interceptor exactly once (ascending id). Runs ONLY in the lock holder (caller-gated).
+    # A command whose session_token != ours targets a prior session's item ids → acked stale,
+    # never applied. Returns true if any command was applied (forces a re-render). #123 Phase 2.
+    private def drain_intercept_commands : Bool
+      store = @session.store
+      cmds = store.intercept_commands_after(@intercept_cmd_watermark, 50)
+      return false if cmds.empty?
+      ic = @session.interceptor
+      applied = false
+      cmds.each do |cmd|
+        @intercept_cmd_watermark = cmd.id # exactly-once: advance even for stale/failed commands
+        if cmd.session_token != @session.intercept_token
+          store.ack_intercept_command(cmd.id, "stale", "command targeted a previous capture session")
+          next
+        end
+        @intercept_agent_seen = true # a command for OUR session ⇒ an agent is/was here
+        applied = true if apply_intercept_command(ic, store, cmd)
+      end
+      applied
+    end
+
+    # Apply one agent command to the live interceptor and ack the outcome. forward/drop
+    # self-guard (a no-longer-held id is a no-op), so we look the item up first to (a) ack
+    # no_such_item precisely and (b) describe the action in the visible agent Note.
+    private def apply_intercept_command(ic : Interceptor, store : Store, cmd : Store::CommandRow) : Bool
+      case cmd.verb
+      when "forward", "drop", "forward_edit"
+        item_id = cmd.item_id
+        unless item_id
+          store.ack_intercept_command(cmd.id, "error", "#{cmd.verb} missing item_id"); return false
+        end
+        item = ic.get(item_id)
+        unless item
+          store.ack_intercept_command(cmd.id, "no_such_item", "item #{item_id} is no longer held")
+          return false
+        end
+        desc = "#{item.method} #{item.host}#{item.target}"
+        case cmd.verb
+        when "forward"
+          ic.forward(item_id)
+          store.ack_intercept_command(cmd.id, "forwarded", desc)
+          push_agent_note(:success, "forwarded #{desc}", item)
+        when "drop"
+          ic.drop(item_id)
+          store.ack_intercept_command(cmd.id, "dropped", desc)
+          push_agent_note(:warn, "dropped #{desc}", item)
+        when "forward_edit"
+          bytes = cmd.bytes
+          unless bytes
+            store.ack_intercept_command(cmd.id, "error", "forward_edit missing bytes"); return false
+          end
+          # Forward the AGENT's edited bytes DIRECTLY — never through view.forward_bytes, which
+          # would pull the human editor buffer and re-expand $VARS (wrong bytes + secret leak).
+          ic.forward(item_id, bytes)
+          store.ack_intercept_command(cmd.id, "edited", desc)
+          push_agent_note(:success, "forwarded (edited) #{desc}", item)
+        end
+        true
+      when "toggle"
+        # Desired-state (idempotent): flip only if current != requested, so a re-applied command
+        # can't oscillate. NOTE: enabling only affects NEW connections (h2→h1 downgrade gate).
+        want = cmd.arg == "true"
+        ic.toggle if ic.enabled? != want
+        store.ack_intercept_command(cmd.id, "toggled", "enabled=#{ic.enabled?}")
+        push_config_note("agent #{ic.enabled? ? "enabled" : "disabled"} intercept")
+        true
+      when "set_filter"
+        q = cmd.arg || ""
+        ic.set_filter(q)
+        store.ack_intercept_command(cmd.id, "filter_set", q.empty? ? "(cleared)" : q)
+        push_config_note(q.empty? ? "agent cleared intercept filter" : "agent set intercept filter: #{q}")
+        true
+      when "set_direction"
+        dir = case cmd.arg
+              when "request"  then Interceptor::Direction::RequestOnly
+              when "response" then Interceptor::Direction::ResponseOnly
+              else                 Interceptor::Direction::Both
+              end
+        ic.set_direction(dir)
+        store.ack_intercept_command(cmd.id, "direction_set", dir.to_s.downcase)
+        push_config_note("agent set intercept direction: #{dir.to_s.downcase}")
+        true
+      else
+        store.ack_intercept_command(cmd.id, "error", "unknown verb #{cmd.verb}")
+        false
+      end
+    end
+
+    # An agent config action (toggle/filter/direction) has no held item, so it jumps to the
+    # intercept tab rather than a flow.
+    private def push_config_note(msg : String) : Nil
+      @notifications.push(:info, msg, Jobs::Goto.new(:intercept), source: "agent")
+    end
+
+    # #123 safety net: auto-forward (original bytes, fail-open) any item held past max_hold that
+    # NOBODY is watching — neither the human (not on the intercept tab) nor an agent (no recent
+    # MCP intercept_list/get, tracked via viewed_ms). hold() has no timeout, so this stops a dead
+    # MCP client from wedging a proxy connection forever. CRITICAL: only fires in a session where
+    # an agent has actually attached (@intercept_agent_seen) — a pure-human session keeps the base
+    # P4 contract (indefinite hold). Disabled when @intercept_max_hold_ms <= 0. Returns true if
+    # anything was released.
+    private def reap_stale_holds : Bool
+      return false if @intercept_max_hold_ms <= 0
+      return false if @active_tab == :intercept # human is watching the queue → never clobber
+      ic = @session.interceptor
+      pending = ic.pending
+      return false if pending.empty?
+      viewed = {} of Int64 => Int64
+      @session.store.intercept_held(@session.intercept_token).each { |r| viewed[r.item_id] = r.viewed_ms }
+      @intercept_agent_seen = true if viewed.each_value.any? { |v| v > 0 } # an agent polled the queue
+      return false unless @intercept_agent_seen # no agent ever attached → P4: hold indefinitely
+      now_ms = Time.utc.to_unix_ms
+      reaped = false
+      pending.each do |it|
+        watched = {it.held_at_ms, viewed[it.id]? || 0_i64}.max
+        next if now_ms - watched < @intercept_max_hold_ms
+        ic.forward(it.id) # original bytes (fail-open), same as toggle-off / release_all
+        secs = @intercept_max_hold_ms // 1000
+        goto = (fid = it.flow_id) ? Jobs::Goto.new(:history, fid) : nil
+        @notifications.push(:warn, "auto-forwarded held #{it.method} #{it.host}#{it.target} (no decision after #{secs}s)", goto, source: "app")
+        reaped = true
+      end
+      reaped
+    end
+
+    # Surface an agent intercept action in the human notification center (source :agent, so it
+    # renders distinctly). A held response jumps to its captured flow; a held request (no flow
+    # row yet) jumps to the intercept queue.
+    private def push_agent_note(level : Symbol, msg : String, item : Interceptor::Item) : Nil
+      goto = (fid = item.flow_id) ? Jobs::Goto.new(:history, fid) : Jobs::Goto.new(:intercept)
+      @notifications.push(level, msg, goto, source: "agent")
+    end
+
+    # Refresh the bridge blob (config mirror + liveness heartbeat). Tiny single-row upsert kept
+    # fresh every cross-process cadence so a mutating MCP verb can refuse when no live holder.
+    private def publish_intercept_bridge(ic : Interceptor) : Nil
+      json = JSON.build do |j|
+        j.object do
+          j.field "session_token", @session.intercept_token
+          j.field "capturing", true
+          j.field "enabled", ic.enabled?
+          j.field "direction", ic.direction.to_s.downcase
+          j.field "filter", ic.filter_source
+          j.field "pending_count", ic.pending_count
+          j.field "heartbeat_ms", Time.utc.to_unix_ms
+        end
+      end
+      @session.store.set_intercept_bridge(json)
+    end
+
     # --- main loop helpers ---------------------------------------------------
 
     # How often to poll SQLite's data_version (own writer commits + peer processes).
     # Cheap; ~sub-second freshness is plenty — not every 50ms tick.
     DV_POLL_INTERVAL = 750.milliseconds
+
+    # #123: how often the capture-lock holder refreshes the intercept bridge heartbeat when the
+    # queue is otherwise unchanged. Well inside the MCP-side liveness threshold (10s) while
+    # keeping idle WAL churn low; a real queue change publishes immediately regardless.
+    INTERCEPT_HEARTBEAT_INTERVAL = 3.seconds
 
     # Minimum spacing between ui-state writes (get_current_context). Coalesces a fast
     # focus/scroll burst into ≤1 write per window so the WAL never churns per frame.


### PR DESCRIPTION
## Summary

Closes #123 and #124.

- **#123 — sit in the intercept loop**: MCP can list/get held items and forward/drop/edit (plus toggle/filter/direction) via a store-backed bridge. The capture-lock holder mirrors `intercept_held`, drains `intercept_commands`, and surfaces agent actions as human-visible notifications (`source: agent`). Mutating verbs stay behind non-`--read-only` and refuse when no live capture holder is heartbeat-fresh.
- **#124 — event feed**: append-only `events` table (V35) + `list_events` forward-cursor tail for miner/fuzzer/probe lifecycle and agent actions. Flows remain the firehose via `list_history since:`; the event log never duplicates flow rows. Notification notes gain a `source` field so AI promotions stay distinct from the human interrupt ring.

## Implementation notes

- Schema V35 `events`, V36 `intercept_held` + `intercept_commands` (AUTOINCREMENT watermarks).
- Per-session `intercept_token` so stale commands from a prior capture session never apply to recycled item ids.
- Agent-only stale-hold auto-forward safety net; pure-human sessions keep indefinite hold (P4).
- `forward_edit` sends agent bytes directly (no view-buffer / `$VARS` re-expansion).

## Test plan

- [x] `crystal spec spec/interceptor_spec.cr spec/store/store_spec.cr spec/store/entity_links_spec.cr` (52 examples, 0 failures)
- [ ] Manual: open TUI with intercept on, run MCP `intercept_list` / `forward` / `drop` and confirm human notifications + live release
- [ ] Manual: `list_events` after miner/fuzzer/agent actions advances a `since_id` cursor correctly