### PR TITLE
feat(cli): nest scope/env under gori run project

### DIFF
--- a/docs/content/guide/proxy.ko.md
+++ b/docs/content/guide/proxy.ko.md
@@ -145,7 +145,7 @@ respbody: "debug":false => "debug":true
 | **DESCRIPTION** | 자유 형식 프로젝트 노트 |
 | **NETWORK** | scope 렌즈 + **샌드박스** 토글, 그리고 전역 Settings 기본값을 재정의하는 프로젝트별 네트워크 고정(bind / upstream) |
 
-스코프 규칙은 스크립트로도 다룰 수 있습니다: `gori run scope add --kind=include --type=host --pattern=api.example.com` — 전체 플래그는 [CLI Reference](/ko/reference/cli/#run-scope)에 있습니다.
+스코프 규칙은 스크립트로도 다룰 수 있습니다: `gori run project scope add --kind=include --type=host --pattern=api.example.com` — 전체 플래그는 [CLI Reference](/ko/reference/cli/#run-project)에 있습니다.
 
 ## 다음 단계 {#next-steps}
 

--- a/docs/content/guide/proxy.md
+++ b/docs/content/guide/proxy.md
@@ -145,7 +145,7 @@ The **Project** home tab is more than a summary. Focusable panes (cycle with `Ta
 | **DESCRIPTION** | Free-form project notes |
 | **NETWORK** | Scope-lens + **sandbox** toggles, plus per-project network pins (bind / upstream) that override the global Settings default |
 
-Scope rules are also scriptable: `gori run scope add --kind=include --type=host --pattern=api.example.com` — full flags in the [CLI Reference](/reference/cli/#run-scope).
+Scope rules are also scriptable: `gori run project scope add --kind=include --type=host --pattern=api.example.com` — full flags in the [CLI Reference](/reference/cli/#run-project).
 
 ## Next Steps
 

--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -62,8 +62,9 @@ gori run <subcommand> [options]
 | `sitemap [QL]` | 호스트 → 경로 엔드포인트 트리 |
 | `notes [<n>]` | 프로젝트 노트 읽기 |
 | `issues` · `create` · `update` | 이슈 목록 / 내보내기, 또는 이슈 작성 |
-| `projects` | 알려진 프로젝트 목록 |
-| `scope` | 스코프 규칙 목록 / 추가 / 삭제 / 활성화 / 비활성화 |
+| `project [list]` | 알려진 프로젝트 목록 |
+| `project scope` | 스코프 규칙 목록 / 추가 / 삭제 / 활성화 / 비활성화 |
+| `project env` | 프로젝트 env 변수 목록 / 설정 / 삭제 (`$KEY` 치환) |
 
 읽기 서브커맨드에 공통인 플래그: `--project=NAME`, `--db=PATH`, `--format=FMT` (보통 `text` 또는 `json`).
 
@@ -185,12 +186,11 @@ gori run sitemap --in-scope --format paths
 
 `-q`/`--query=QL`는 history와 같은 QL로 엔드포인트를 거릅니다(위치 인자로도 넘길 수 있습니다). `-n`/`--limit=N`은 스캔할 엔드포인트 수를 제한합니다(기본값 `SITEMAP_MAX`). `--in-scope`는 스코프 내 호스트로 한정하고, `--no-group`은 숫자 경로 접기를 끕니다. `--format`은 `text`(트리), `json`, `paths` 중에서 고릅니다.
 
-### run issues / notes / projects {#run-issues-notes-projects}
+### run issues / notes {#run-issues-notes}
 
 ```bash
 gori run issues --format markdown --export report.md
 gori run notes --all
-gori run projects --format json
 ```
 
 스크립트에서 `create` / `update`로 이슈를 작성합니다:
@@ -205,18 +205,27 @@ gori run issues update 7 --status confirmed --notes "Verified on staging" --seve
 | `create` | `-t`/`--title` (필수), `-s`/`--severity` (`info`\|`low`\|`medium`\|`high`\|`critical`), `--host`, `--flow=ID` |
 | `update <id>` | `-t`/`--title`, `-s`/`--severity`, `-n`/`--notes`, `--status` (`open`\|`confirmed`\|`false-positive`\|`resolved`) |
 
-### run scope {#run-scope}
+### run project {#run-project}
+
+알려진 프로젝트 목록, 또는 프로젝트 스코프 설정(스코프 규칙, env 변수) 관리:
+
+```bash
+gori run project --format json
+gori run project list
+```
+
+#### project scope {#run-project-scope}
 
 프로젝트의 include/exclude 스코프 규칙을 스크립트에서 관리합니다:
 
 ```bash
-gori run scope                                          # list rules + enabled state
-gori run scope --format json
-gori run scope add --kind=include --type=host --pattern=api.example.com
-gori run scope add --kind=exclude --type=regex --pattern='.*\.(css|js)$'
-gori run scope delete 3
-gori run scope enable
-gori run scope disable
+gori run project scope                                          # list rules + enabled state
+gori run project scope --format json
+gori run project scope add --kind=include --type=host --pattern=api.example.com
+gori run project scope add --kind=exclude --type=regex --pattern='.*\.(css|js)$'
+gori run project scope delete 3
+gori run project scope enable
+gori run project scope disable
 ```
 
 | Option / subcommand | Description |
@@ -225,6 +234,24 @@ gori run scope disable
 | `add` | `--kind=include\|exclude`, `--type=host\|string\|regex`, `--pattern=…` |
 | `delete <rule-id>` | id로 규칙 제거 |
 | `enable` / `disable` | 스코프 필터링 적용 여부 토글 |
+
+#### project env {#run-project-env}
+
+아웃바운드 요청의 `$KEY` 치환에 쓰이는 **프로젝트** env 변수를 관리합니다. 전역 변수는 `settings.json` / TUI Settings에 있고, 이 명령은 프로젝트 레이어만 다룹니다.
+
+```bash
+gori run project env                              # list KEY=value
+gori run project env --format json
+gori run project env set TOKEN=secret
+gori run project env set HOST api.example.com
+gori run project env delete TOKEN
+```
+
+| Option / subcommand | Description |
+|---------------------|-------------|
+| (default) | 프로젝트 변수 목록; `--format`은 `text` 또는 `json` |
+| `set KEY=value` · `set KEY value` | 프로젝트 변수 upsert (KEY는 `[A-Za-z_][A-Za-z0-9_]*`) |
+| `delete KEY` | 프로젝트 변수 제거 |
 
 ## gori mcp {#gori-mcp}
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -62,8 +62,9 @@ gori run <subcommand> [options]
 | `sitemap [QL]` | Host → path endpoint tree |
 | `notes [<n>]` | Read project notes |
 | `issues` · `create` · `update` | List / export issues, or write issues |
-| `projects` | List known projects |
-| `scope` | List / add / delete / enable / disable scope rules |
+| `project [list]` | List known projects |
+| `project scope` | List / add / delete / enable / disable scope rules |
+| `project env` | List / set / delete project env vars (`$KEY` substitution) |
 
 Common flags across read subcommands: `--project=NAME`, `--db=PATH`, `--format=FMT` (usually `text` or `json`).
 
@@ -185,12 +186,11 @@ gori run sitemap --in-scope --format paths
 
 `-q`/`--query=QL` filters endpoints with the same QL as history (also positional), `-n`/`--limit=N` caps the endpoints scanned (default `SITEMAP_MAX`), `--in-scope` limits to in-scope hosts, `--no-group` disables numeric path folding, `--format` is `text` (tree), `json`, or `paths`.
 
-### run issues / notes / projects
+### run issues / notes
 
 ```bash
 gori run issues --format markdown --export report.md
 gori run notes --all
-gori run projects --format json
 ```
 
 Write issues from scripts with `create` / `update`:
@@ -205,18 +205,27 @@ gori run issues update 7 --status confirmed --notes "Verified on staging" --seve
 | `create` | `-t`/`--title` (required), `-s`/`--severity` (`info`\|`low`\|`medium`\|`high`\|`critical`), `--host`, `--flow=ID` |
 | `update <id>` | `-t`/`--title`, `-s`/`--severity`, `-n`/`--notes`, `--status` (`open`\|`confirmed`\|`false-positive`\|`resolved`) |
 
-### run scope
+### run project
+
+List known projects, or manage project-scoped config (scope rules, env vars):
+
+```bash
+gori run project --format json
+gori run project list
+```
+
+#### project scope
 
 Manage the project's include/exclude scope rules from scripts:
 
 ```bash
-gori run scope                                          # list rules + enabled state
-gori run scope --format json
-gori run scope add --kind=include --type=host --pattern=api.example.com
-gori run scope add --kind=exclude --type=regex --pattern='.*\.(css|js)$'
-gori run scope delete 3
-gori run scope enable
-gori run scope disable
+gori run project scope                                          # list rules + enabled state
+gori run project scope --format json
+gori run project scope add --kind=include --type=host --pattern=api.example.com
+gori run project scope add --kind=exclude --type=regex --pattern='.*\.(css|js)$'
+gori run project scope delete 3
+gori run project scope enable
+gori run project scope disable
 ```
 
 | Option / subcommand | Description |
@@ -225,6 +234,24 @@ gori run scope disable
 | `add` | `--kind=include\|exclude`, `--type=host\|string\|regex`, `--pattern=…` |
 | `delete <rule-id>` | Remove a rule by id |
 | `enable` / `disable` | Toggle whether scope filtering is applied |
+
+#### project env
+
+Manage **project** env vars used for `$KEY` substitution in outbound requests (Repeater, Fuzzer, Miner, CLI, MCP). Global vars live in `settings.json` / the TUI Settings — this command only touches the per-project layer.
+
+```bash
+gori run project env                              # list KEY=value
+gori run project env --format json
+gori run project env set TOKEN=secret
+gori run project env set HOST api.example.com
+gori run project env delete TOKEN
+```
+
+| Option / subcommand | Description |
+|---------------------|-------------|
+| (default) | List project vars; `--format` is `text` or `json` |
+| `set KEY=value` · `set KEY value` | Upsert a project var (KEY must match `[A-Za-z_][A-Za-z0-9_]*`) |
+| `delete KEY` | Remove a project var |
 
 ## gori mcp
 

--- a/spec/env_spec.cr
+++ b/spec/env_spec.cr
@@ -65,4 +65,34 @@ describe Gori::Env do
     Gori::Env.mask_secrets("x=secret_value", vars, "$").should eq("x=$LONG")
     Gori::Env.mask_secrets("x=secret!", vars, "$").should eq("x=$SHORT!")
   end
+
+  # Persistence path used by `gori run project env set|delete` (and the Project tab).
+  it "save_project / load_project round-trips and upserts by key" do
+    path = File.tempname("gori-env", ".db")
+    store = Gori::Store.open(path)
+    begin
+      Gori::Settings.project_env_vars = [] of {String, String}
+      Gori::Env.save_project(store, [{"TOKEN", "secret"}, {"HOST", "api.test"}])
+      Gori::Settings.project_env_vars = [] of {String, String}
+      Gori::Env.load_project(store)
+      Gori::Settings.project_env_vars.should eq([{"TOKEN", "secret"}, {"HOST", "api.test"}])
+
+      # Upsert TOKEN (CLI set) and drop HOST (CLI delete)
+      vars = Gori::Settings.project_env_vars.dup
+      if idx = vars.index { |(k, _)| k == "TOKEN" }
+        vars[idx] = {"TOKEN", "new"}
+      end
+      vars.reject! { |(k, _)| k == "HOST" }
+      Gori::Env.save_project(store, vars)
+      Gori::Settings.project_env_vars = [] of {String, String}
+      Gori::Env.load_project(store)
+      Gori::Settings.project_env_vars.should eq([{"TOKEN", "new"}])
+    ensure
+      store.close
+      File.delete?(path)
+      File.delete?("#{path}-wal")
+      File.delete?("#{path}-shm")
+      Gori::Settings.project_env_vars = [] of {String, String}
+    end
+  end
 end

--- a/spec/project_registry_spec.cr
+++ b/spec/project_registry_spec.cr
@@ -89,7 +89,7 @@ describe Gori::ProjectRegistry do
       reg = Gori::ProjectRegistry.new(root)
       p = reg.create("ACME Red Team!")
       Gori::Store.open(p.db_path).close
-      # A fresh registry (as on TUI restart / `gori run projects`) must still show the
+      # A fresh registry (as on TUI restart / `gori run project`) must still show the
       # verbatim name, not the lossy directory slug "acme-red-team".
       Gori::ProjectRegistry.new(root).list.map(&.name).should contain("ACME Red Team!")
     end

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -73,7 +73,7 @@ module Gori
       puts "  tui       Start the interactive TUI (default when no command)"
       puts "  settings  Show the settings.json path (or --edit to open it)"
       puts "  ca        Print the root CA path, or regenerate it (see gori ca --help)"
-      puts "  run       Non-interactive CLI: capture, history, show, repeater, issues, projects"
+      puts "  run       Non-interactive CLI: capture, history, show, repeater, issues, project"
       puts "  wizard    Interactive setup wizard (bind, theme) — also runs on first launch"
       puts "  tutorial  Guided TUI tour with try-it steps (nav, palette, menu, edit)"
       puts "  mcp       Start an MCP server over stdio (AI/tool integration)"

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -60,7 +60,7 @@ module Gori
         when "capture"           then cmd_capture(args[1..])
         when "history", "ls"     then cmd_history(args[1..])
         when "show"              then cmd_show(args[1..])
-        when "repeater"            then cmd_repeater(args[1..])
+        when "repeater"          then cmd_repeater(args[1..])
         when "fuzz"              then cmd_fuzz(args[1..])
         when "mine"              then cmd_mine(args[1..])
         else                          dispatch_subcommand2(sub, args[1..])
@@ -72,12 +72,11 @@ module Gori
       # empty/-h/--help case is handled above.
       private def self.dispatch_subcommand2(sub : String?, rest : Array(String)) : Nil
         case sub
-        when "probe"    then cmd_probe(rest)
-        when "sitemap"  then cmd_sitemap(rest)
-        when "notes"    then cmd_notes(rest)
-        when "issues" then cmd_issues(rest)
-        when "projects" then cmd_projects(rest)
-        when "scope"    then cmd_scope(rest)
+        when "probe"   then cmd_probe(rest)
+        when "sitemap" then cmd_sitemap(rest)
+        when "notes"   then cmd_notes(rest)
+        when "issues"  then cmd_issues(rest)
+        when "project" then cmd_project(rest)
         else
           STDERR.puts "gori run: unknown subcommand '#{sub}'"
           print_help
@@ -101,9 +100,10 @@ module Gori
           sitemap            Print the host → path endpoint tree (text, json, paths)
           probe [QL]         Passively scan captured flows for issues (zero requests)
           notes [<n>]        Read the project's notes (list, show one, or --all)
-          issues           List, export, create, or update issues (text, json, markdown)
-          projects           List known projects
-          scope              Manage the project's scope rules (list, add, delete, enable/disable)
+          issues             List, export, create, or update issues (text, json, markdown)
+          project [list]     List known projects
+          project scope      Manage scope rules (list, add, delete, enable/disable)
+          project env        Manage project env vars ($KEY substitution)
 
         Most read subcommands accept --project NAME or --db PATH; with neither they
         use the most-recently-active project. See 'gori run <subcommand> --help'.
@@ -609,7 +609,7 @@ module Gori
           abort "gori run repeater create: --target is required" if tgt_str.empty?
 
           pos = store.repeaters_meta.size
-          
+
           id = store.insert_repeater(
             target: Env.mask_secrets(tgt_str),
             request: Env.mask_secrets(req_content),
@@ -620,9 +620,9 @@ module Gori
             sni: sni,
             mark_transform: mark_transform
           )
-          
+
           abort "gori run repeater create: failed to create repeater session" if id == 0
-          
+
           if n = name
             store.set_repeater_name(id, Env.mask_secrets(n))
           end
@@ -637,37 +637,37 @@ module Gori
         end
       end
 
-       private def self.cmd_repeater_single(args : Array(String)) : Nil
-         db_path : String? = nil
-         project_name : String? = nil
-         target_override : String? = nil
-         sni_override : String? = nil
-         force_h2 = false
-         insecure = false
-         do_diff = false
-         format = :text
-         headers = [] of String
-         body_override : String? = nil
-         positional = [] of String
+      private def self.cmd_repeater_single(args : Array(String)) : Nil
+        db_path : String? = nil
+        project_name : String? = nil
+        target_override : String? = nil
+        sni_override : String? = nil
+        force_h2 = false
+        insecure = false
+        do_diff = false
+        format = :text
+        headers = [] of String
+        body_override : String? = nil
+        positional = [] of String
 
-         parser = OptionParser.new do |p|
-           p.banner = "Usage: gori run repeater <flow-id> [options]"
-           p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
-           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
-           p.on("--target=URL", "Send to this origin (scheme://host[:port]) instead of the captured one; path/query kept") { |v| target_override = v }
-           p.on("--http2", "Force HTTP/2 (default follows how the flow was captured)") { force_h2 = true }
-           p.on("--sni=HOST", "TLS SNI override") { |v| sni_override = v }
-           p.on("-k", "--insecure-upstream", "Do not verify the upstream TLS certificate") { insecure = true }
-           p.on("--diff", "Diff the new response against the captured one") { do_diff = true }
-           p.on("-HHEADER", "--header=HEADER", "Custom header to overwrite/add (repeatable)") { |v| headers << v }
-           p.on("-bBODY", "--body=BODY", "Request body override") { |v| body_override = v }
-           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
-           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
-           p.unknown_args { |rest, _| positional = rest }
-           p.invalid_option { |f| abort "gori run repeater: unknown option: #{f}\n#{p}" }
-           p.missing_option { |f| abort "gori run repeater: missing value for #{f}" }
-         end
-         parser.parse(args)
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run repeater <flow-id> [options]"
+          p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
+          p.on("--target=URL", "Send to this origin (scheme://host[:port]) instead of the captured one; path/query kept") { |v| target_override = v }
+          p.on("--http2", "Force HTTP/2 (default follows how the flow was captured)") { force_h2 = true }
+          p.on("--sni=HOST", "TLS SNI override") { |v| sni_override = v }
+          p.on("-k", "--insecure-upstream", "Do not verify the upstream TLS certificate") { insecure = true }
+          p.on("--diff", "Diff the new response against the captured one") { do_diff = true }
+          p.on("-HHEADER", "--header=HEADER", "Custom header to overwrite/add (repeatable)") { |v| headers << v }
+          p.on("-bBODY", "--body=BODY", "Request body override") { |v| body_override = v }
+          p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| positional = rest }
+          p.invalid_option { |f| abort "gori run repeater: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run repeater: missing value for #{f}" }
+        end
+        parser.parse(args)
         id = take_flow_id(positional, "repeater")
 
         # get_flow loads all the BLOBs, so the store can close before the send.
@@ -702,7 +702,7 @@ module Gori
         crlf_crlf_idx = -1
         limit = raw_bytes.size - 4
         (0..limit).each do |i|
-          if raw_bytes[i] == 0x0d_u8 && raw_bytes[i+1] == 0x0a_u8 && raw_bytes[i+2] == 0x0d_u8 && raw_bytes[i+3] == 0x0a_u8
+          if raw_bytes[i] == 0x0d_u8 && raw_bytes[i + 1] == 0x0a_u8 && raw_bytes[i + 2] == 0x0d_u8 && raw_bytes[i + 3] == 0x0a_u8
             crlf_crlf_idx = i
             break
           end
@@ -714,7 +714,7 @@ module Gori
         body_bytes = raw_bytes[crlf_crlf_idx + 4..]
 
         raw_req = Proxy::Codec::Http1.parse_request_head(head_bytes)
-        
+
         custom_headers = {} of String => String
         headers.each do |h_str|
           next unless h_str.includes?(':')
@@ -811,12 +811,10 @@ module Gori
         scheme, host, port = Repeater::FlowRequest.parse_target(target)
         abort "gori run repeater: could not determine a target host" if host.empty?
         abort "gori run repeater: unsupported target scheme #{scheme.inspect} (use http:// or https://)" unless scheme.in?("http", "https")
-         use_h2 = force_h2 || built.http2
-         verify = !insecure
-         sni_val = sni_override.presence || built.sni
-         result = use_h2 ?
-           Repeater::H2Engine.send(bytes, scheme: scheme, host: host, port: port, verify_upstream: verify, sni: sni_val) :
-           Repeater::Engine.send(bytes, scheme: scheme, host: host, port: port, verify_upstream: verify, sni: sni_val)
+        use_h2 = force_h2 || built.http2
+        verify = !insecure
+        sni_val = sni_override.presence || built.sni
+        result = use_h2 ? Repeater::H2Engine.send(bytes, scheme: scheme, host: host, port: port, verify_upstream: verify, sni: sni_val) : Repeater::Engine.send(bytes, scheme: scheme, host: host, port: port, verify_upstream: verify, sni: sni_val)
 
         # Decode the response body once for TEXT display (--diff / plain print); only
         # build the diff lines when --diff asked for them (decoding the captured
@@ -1778,7 +1776,7 @@ module Gori
         abort "gori run issues create: --title is required" if (t = title).nil? || t.empty?
 
         severity = Store::Severity.parse?(sev_s.strip) || abort("gori run issues create: invalid severity '#{sev_s}' (info|low|medium|high|critical)")
-        
+
         project = resolve_read_project(project_name, db_path)
         store = open_store(project)
         begin
@@ -1813,7 +1811,7 @@ module Gori
           p.invalid_option { |f| abort "gori run issues update: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run issues update: missing value for #{f}" }
         end
-        
+
         positional = [] of String
         parser.unknown_args { |rest, _| positional = rest }
         parser.parse(args)
@@ -1837,7 +1835,7 @@ module Gori
         store = open_store(project)
         begin
           abort "gori run issues update: no issue with id #{id}" unless store.get_issue(id)
-          
+
           if title.nil? && severity.nil? && notes.nil? && status.nil?
             abort "gori run issues update: no fields to update (provide at least one of --title/--severity/--notes/--status)"
           end
@@ -1865,16 +1863,61 @@ module Gori
         end.rstrip('\n')
       end
 
-      # --- projects ----------------------------------------------------------
+      # --- project (list / scope / env) --------------------------------------
 
-      private def self.cmd_projects(args : Array(String)) : Nil
+      private def self.cmd_project(args : Array(String)) : Nil
+        sub = args.first?
+        case sub
+        when nil
+          cmd_project_list(args)
+        when "-h", "--help"
+          print_project_help
+        when "list"
+          cmd_project_list(args[1..])
+        when "scope"
+          cmd_project_scope(args[1..])
+        when "env"
+          cmd_project_env(args[1..])
+        else
+          # Flags only (e.g. --format json) → list projects
+          if (s = sub) && s.starts_with?('-')
+            cmd_project_list(args)
+          else
+            STDERR.puts "gori run project: unknown subcommand '#{sub}'"
+            print_project_help
+            exit 1
+          end
+        end
+      end
+
+      private def self.print_project_help : Nil
+        puts <<-HELP
+        gori run project — list projects, or manage project-scoped config
+
+        Usage: gori run project [<subcommand>] [options]
+
+        Subcommands:
+          list               List known projects (default when no subcommand)
+          scope              Manage scope rules (list, add, delete, enable/disable)
+          env                Manage project env vars ($KEY substitution)
+
+        Examples:
+          gori run project --format json
+          gori run project scope add --kind=include --type=host --pattern=api.example.com
+          gori run project env set TOKEN=secret
+
+        See 'gori run project <subcommand> --help' for more.
+        HELP
+      end
+
+      private def self.cmd_project_list(args : Array(String)) : Nil
         format = :text
         parser = OptionParser.new do |p|
-          p.banner = "Usage: gori run projects [options]"
+          p.banner = "Usage: gori run project [list] [options]"
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
-          p.invalid_option { |f| abort "gori run projects: unknown option: #{f}\n#{p}" }
-          p.missing_option { |f| abort "gori run projects: missing value for #{f}" }
+          p.invalid_option { |f| abort "gori run project: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run project: missing value for #{f}" }
         end
         parser.parse(args)
 
@@ -1903,25 +1946,30 @@ module Gori
         end
       end
 
-      # --- scope -------------------------------------------------------------
+      # --- project scope -----------------------------------------------------
 
-      private def self.cmd_scope(args : Array(String)) : Nil
+      private def self.cmd_project_scope(args : Array(String)) : Nil
         sub = args.first?
-        if sub == "add"
+        case sub
+        when "add"
           cmd_scope_add(args[1..])
-          return
-        elsif sub == "delete"
+        when "delete"
           cmd_scope_delete(args[1..])
-          return
-        elsif sub == "enable"
+        when "enable"
           cmd_scope_set_enabled(true, args[1..])
-          return
-        elsif sub == "disable"
+        when "disable"
           cmd_scope_set_enabled(false, args[1..])
-          return
+        when nil
+          cmd_scope_list(args)
+        else
+          if (s = sub) && s.starts_with?('-')
+            cmd_scope_list(args)
+          else
+            STDERR.puts "gori run project scope: unknown subcommand '#{sub}'"
+            STDERR.puts "Usage: gori run project scope [list options] | add | delete | enable | disable"
+            exit 1
+          end
         end
-
-        cmd_scope_list(args)
       end
 
       private def self.cmd_scope_list(args : Array(String)) : Nil
@@ -1930,18 +1978,18 @@ module Gori
         format = :text
 
         parser = OptionParser.new do |p|
-          p.banner = "Usage: gori run scope [options]\n\n" \
+          p.banner = "Usage: gori run project scope [options]\n\n" \
                      "Or run with a subcommand:\n" \
-                     "  gori run scope add --kind=include/exclude --type=host/string/regex --pattern=...\n" \
-                     "  gori run scope delete <rule-id>\n" \
-                     "  gori run scope enable\n" \
-                     "  gori run scope disable"
+                     "  gori run project scope add --kind=include/exclude --type=host/string/regex --pattern=...\n" \
+                     "  gori run project scope delete <rule-id>\n" \
+                     "  gori run project scope enable\n" \
+                     "  gori run project scope disable"
           p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
-          p.invalid_option { |f| abort "gori run scope: unknown option: #{f}\n#{p}" }
-          p.missing_option { |f| abort "gori run scope: missing value for #{f}" }
+          p.invalid_option { |f| abort "gori run project scope: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run project scope: missing value for #{f}" }
         end
         parser.parse(args)
 
@@ -1990,33 +2038,32 @@ module Gori
         pattern : String? = nil
 
         parser = OptionParser.new do |p|
-          p.banner = "Usage: gori run scope add [options]"
+          p.banner = "Usage: gori run project scope add [options]"
           p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
           p.on("-kKIND", "--kind=KIND", "Rule kind: include|exclude (default: include)") { |v| kind = v }
           p.on("-tTYPE", "--type=TYPE", "Match type: host|string|regex (default: host)") { |v| match_type = v }
           p.on("-pPATTERN", "--pattern=PATTERN", "Pattern to match (required)") { |v| pattern = v }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
-          p.invalid_option { |f| abort "gori run scope add: unknown option: #{f}\n#{p}" }
-          p.missing_option { |f| abort "gori run scope add: missing value for #{f}" }
+          p.invalid_option { |f| abort "gori run project scope add: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run project scope add: missing value for #{f}" }
         end
         parser.parse(args)
 
-        abort "gori run scope add: --pattern is required" if (pat = pattern).nil? || pat.empty?
-        abort "gori run scope add: invalid kind '#{kind}' (must be include or exclude)" unless kind.in?(Scope::KINDS)
-        abort "gori run scope add: invalid type '#{match_type}' (must be host, string, or regex)" unless match_type.in?(Scope::TYPES)
-        abort "gori run scope add: invalid pattern for regex (failed to compile)" if match_type == "regex" && !Scope.valid?(match_type, pat)
+        abort "gori run project scope add: --pattern is required" if (pat = pattern).nil? || pat.empty?
+        abort "gori run project scope add: invalid kind '#{kind}' (must be include or exclude)" unless kind.in?(Scope::KINDS)
+        abort "gori run project scope add: invalid type '#{match_type}' (must be host, string, or regex)" unless match_type.in?(Scope::TYPES)
+        abort "gori run project scope add: invalid pattern for regex (failed to compile)" if match_type == "regex" && !Scope.valid?(match_type, pat)
 
         project = resolve_read_project(project_name, db_path)
         store = open_store(project)
         begin
           scope = Scope.load(store)
-          success = scope.add(kind, match_type, pat)
-          if success
-            puts "Scope rule added successfully."
-          else
-            abort "gori run scope add: failed to add rule (duplicate, empty, or invalid)"
+          unless scope.add(kind, match_type, pat)
+            store.close
+            abort "gori run project scope add: failed to add rule (duplicate, empty, or invalid)"
           end
+          puts "Scope rule added successfully."
         ensure
           store.close
         end
@@ -2025,30 +2072,32 @@ module Gori
       private def self.cmd_scope_delete(args : Array(String)) : Nil
         db_path : String? = nil
         project_name : String? = nil
-        id : Int64? = nil
 
         parser = OptionParser.new do |p|
-          p.banner = "Usage: gori run scope delete <rule-id> [options]"
+          p.banner = "Usage: gori run project scope delete <rule-id> [options]"
           p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
-          p.invalid_option { |f| abort "gori run scope delete: unknown option: #{f}\n#{p}" }
-          p.missing_option { |f| abort "gori run scope delete: missing value for #{f}" }
+          p.invalid_option { |f| abort "gori run project scope delete: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run project scope delete: missing value for #{f}" }
         end
 
         positional = [] of String
         parser.unknown_args { |rest, _| positional = rest }
         parser.parse(args)
 
-        abort "gori run scope delete: missing <rule-id>" if positional.empty?
-        abort "gori run scope delete: too many arguments (expected one <rule-id>)" if positional.size > 1
-        id = positional[0].to_i64? || abort("gori run scope delete: invalid rule id '#{positional[0]}'")
+        abort "gori run project scope delete: missing <rule-id>" if positional.empty?
+        abort "gori run project scope delete: too many arguments (expected one <rule-id>)" if positional.size > 1
+        id = positional[0].to_i64? || abort("gori run project scope delete: invalid rule id '#{positional[0]}'")
 
         project = resolve_read_project(project_name, db_path)
         store = open_store(project)
         begin
           scope = Scope.load(store)
-          abort "gori run scope delete: no scope rule with id #{id}" unless scope.rules.any? { |r| r.id == id }
+          unless scope.rules.any? { |r| r.id == id }
+            store.close
+            abort "gori run project scope delete: no scope rule with id #{id}"
+          end
           scope.remove(id)
           puts "Scope rule ##{id} deleted successfully."
         ensure
@@ -2059,14 +2108,15 @@ module Gori
       private def self.cmd_scope_set_enabled(enable : Bool, args : Array(String)) : Nil
         db_path : String? = nil
         project_name : String? = nil
+        action = enable ? "enable" : "disable"
 
         parser = OptionParser.new do |p|
-          p.banner = "Usage: gori run scope #{enable ? "enable" : "disable"} [options]"
+          p.banner = "Usage: gori run project scope #{action} [options]"
           p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
-          p.invalid_option { |f| abort "gori run scope #{enable ? "enable" : "disable"}: unknown option: #{f}\n#{p}" }
-          p.missing_option { |f| abort "gori run scope #{enable ? "enable" : "disable"}: missing value for #{f}" }
+          p.invalid_option { |f| abort "gori run project scope #{action}: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run project scope #{action}: missing value for #{f}" }
         end
         parser.parse(args)
 
@@ -2081,6 +2131,151 @@ module Gori
             scope.disable
             puts "Scope filtering disabled."
           end
+        ensure
+          store.close
+        end
+      end
+
+      # --- project env -------------------------------------------------------
+
+      private def self.cmd_project_env(args : Array(String)) : Nil
+        sub = args.first?
+        case sub
+        when "set"
+          cmd_env_set(args[1..])
+        when "delete"
+          cmd_env_delete(args[1..])
+        when nil
+          cmd_env_list(args)
+        else
+          if (s = sub) && s.starts_with?('-')
+            cmd_env_list(args)
+          else
+            STDERR.puts "gori run project env: unknown subcommand '#{sub}'"
+            STDERR.puts "Usage: gori run project env [list options] | set KEY=value | delete KEY"
+            exit 1
+          end
+        end
+      end
+
+      private def self.cmd_env_list(args : Array(String)) : Nil
+        db_path : String? = nil
+        project_name : String? = nil
+        format = :text
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run project env [options]\n\n" \
+                     "List project env vars used for $KEY substitution in outbound requests.\n" \
+                     "Or run with a subcommand:\n" \
+                     "  gori run project env set KEY=value\n" \
+                     "  gori run project env set KEY value\n" \
+                     "  gori run project env delete KEY"
+          p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
+          p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.invalid_option { |f| abort "gori run project env: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run project env: missing value for #{f}" }
+        end
+        parser.parse(args)
+
+        project = resolve_read_project(project_name, db_path)
+        store = open_store(project)
+        begin
+          vars = Settings.project_env_vars
+          if format == :json
+            puts(JSON.build do |j|
+              j.array do
+                vars.each do |(key, val)|
+                  j.object do
+                    j.field "key", key
+                    j.field "value", val
+                  end
+                end
+              end
+            end)
+          elsif vars.empty?
+            STDERR.puts "no project env vars configured"
+          else
+            vars.each { |(key, val)| puts "#{key}=#{val}" }
+          end
+        ensure
+          store.close
+        end
+      end
+
+      private def self.cmd_env_set(args : Array(String)) : Nil
+        db_path : String? = nil
+        project_name : String? = nil
+        positional = [] of String
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run project env set KEY=value [options]\n" \
+                     "       gori run project env set KEY value [options]"
+          p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| positional = rest }
+          p.invalid_option { |f| abort "gori run project env set: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run project env set: missing value for #{f}" }
+        end
+        parser.parse(args)
+
+        abort "gori run project env set: missing KEY=value (or KEY value)" if positional.empty?
+        line = positional.join(' ')
+        parsed = Env.parse_line(line)
+        abort "gori run project env set: invalid KEY (use [A-Za-z_][A-Za-z0-9_]*)" unless parsed
+        key, val = parsed
+
+        project = resolve_read_project(project_name, db_path)
+        store = open_store(project)
+        begin
+          vars = Settings.project_env_vars.dup
+          if idx = vars.index { |(k, _)| k == key }
+            vars[idx] = {key, val}
+          else
+            vars << {key, val}
+          end
+          Env.save_project(store, vars)
+          puts "Env var #{key} set."
+        ensure
+          store.close
+        end
+      end
+
+      private def self.cmd_env_delete(args : Array(String)) : Nil
+        db_path : String? = nil
+        project_name : String? = nil
+        positional = [] of String
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run project env delete KEY [options]"
+          p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| positional = rest }
+          p.invalid_option { |f| abort "gori run project env delete: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run project env delete: missing value for #{f}" }
+        end
+        parser.parse(args)
+
+        abort "gori run project env delete: missing KEY" if positional.empty?
+        abort "gori run project env delete: too many arguments (expected one KEY)" if positional.size > 1
+        key = positional[0]
+        abort "gori run project env delete: invalid KEY '#{key}'" unless Env.valid_key?(key)
+
+        project = resolve_read_project(project_name, db_path)
+        store = open_store(project)
+        begin
+          vars = Settings.project_env_vars.dup
+          before = vars.size
+          vars.reject! { |(k, _)| k == key }
+          if vars.size == before
+            store.close
+            abort "gori run project env delete: no env var named '#{key}'"
+          end
+          Env.save_project(store, vars)
+          puts "Env var #{key} deleted."
         ensure
           store.close
         end


### PR DESCRIPTION
## Summary

- Replace top-level `gori run projects` and `gori run scope` with a single `gori run project` parent for project-scoped config.
- Keep list projects as the default (`gori run project` / `project list`).
- Move scope management to `gori run project scope` (list/add/delete/enable/disable).
- Add `gori run project env` for per-project `$KEY` env vars (list/set/delete).
- Pre-open break: no compatibility aliases for the old subcommands.
- Update EN/KO CLI and proxy docs; cover env save/load upsert in specs.

## Command map

| Before | After |
|--------|--------|
| `gori run projects` | `gori run project` / `project list` |
| `gori run scope …` | `gori run project scope …` |
| — | `gori run project env set\|delete …` |

## Test plan

- [x] `crystal spec spec/env_spec.cr spec/scope_spec.cr`
- [x] Smoke: `project scope add/list/enable`, `project env set/list/delete`, `project --format json`
- [x] Old entry points fail: `gori run scope`, `gori run projects`
- [x] Unknown nested subcommands rejected (`project scope typo`, `project env typo`)
