### PR TITLE
feat(cli): add gori run project host-override

### DIFF
--- a/docs/content/guide/proxy.ko.md
+++ b/docs/content/guide/proxy.ko.md
@@ -145,7 +145,7 @@ respbody: "debug":false => "debug":true
 | **DESCRIPTION** | 자유 형식 프로젝트 노트 |
 | **NETWORK** | scope 렌즈 + **샌드박스** 토글, 그리고 전역 Settings 기본값을 재정의하는 프로젝트별 네트워크 고정(bind / upstream) |
 
-스코프 규칙은 스크립트로도 다룰 수 있습니다: `gori run project scope add --kind=include --type=host --pattern=api.example.com`. 전체 플래그는 [CLI Reference](/ko/reference/cli/#run-project)에 있습니다.
+스코프 규칙과 호스트 오버라이드는 스크립트로도 다룰 수 있습니다: `gori run project scope add --kind=include --type=host --pattern=api.example.com`, `gori run project host-override add --host=api.example.com --ip=10.0.0.1`. 전체 플래그는 [CLI Reference](/ko/reference/cli/#run-project)에 있습니다.
 
 ## 다음 단계 {#next-steps}
 

--- a/docs/content/guide/proxy.md
+++ b/docs/content/guide/proxy.md
@@ -145,7 +145,7 @@ The **Project** home tab is more than a summary. Focusable panes (cycle with `Ta
 | **DESCRIPTION** | Free-form project notes |
 | **NETWORK** | Scope-lens + **sandbox** toggles, plus per-project network pins (bind / upstream) that override the global Settings default |
 
-Scope rules are also scriptable: `gori run project scope add --kind=include --type=host --pattern=api.example.com`. Full flags are in the [CLI Reference](/reference/cli/#run-project).
+Scope rules and host overrides are also scriptable: `gori run project scope add --kind=include --type=host --pattern=api.example.com`, `gori run project host-override add --host=api.example.com --ip=10.0.0.1`. Full flags are in the [CLI Reference](/reference/cli/#run-project).
 
 ## Next Steps
 

--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -207,7 +207,7 @@ gori run issues update 7 --status confirmed --notes "Verified on staging" --seve
 
 ### run project {#run-project}
 
-알려진 프로젝트 목록, 또는 프로젝트 스코프 설정(스코프 규칙, env 변수) 관리:
+알려진 프로젝트 목록, 또는 프로젝트 스코프 설정(스코프 규칙, env 변수, 호스트 오버라이드) 관리:
 
 ```bash
 gori run project --format json
@@ -252,6 +252,26 @@ gori run project env delete TOKEN
 | (default) | 프로젝트 변수 목록; `--format`은 `text` 또는 `json` |
 | `set KEY=value` · `set KEY value` | 프로젝트 변수 upsert (KEY는 `[A-Za-z_][A-Za-z0-9_]*`) |
 | `delete KEY` | 프로젝트 변수 제거 |
+
+#### project host-override {#run-project-host-override}
+
+**프로젝트** 호스트 오버라이드를 관리합니다. `/etc/hosts`처럼 호스트명에 대해 dial할 IP만 바꾸고, SNI·인증서 호스트·`Host` 헤더는 원래 이름을 유지합니다. 충돌 시 프로젝트 항목이 전역 `Settings: Hostnames`보다 우선합니다. 별칭: `host-overrides`.
+
+```bash
+gori run project host-override                              # list
+gori run project host-override --format json
+gori run project host-override add --host=api.example.com --ip=10.0.0.1
+gori run project host-override add 10.0.0.1 api.example.com   # /etc/hosts 순서
+gori run project host-override update 1 --host=api.example.com --ip=10.0.0.9
+gori run project host-override delete 1
+```
+
+| Option / subcommand | Description |
+|---------------------|-------------|
+| (default) | 오버라이드 목록; `--format`은 `text` 또는 `json` |
+| `add` | `--host=…` + `--ip=…`, 또는 positional `IP HOST` |
+| `update <id>` | `--host=…` + `--ip=…` (둘 다 필수) |
+| `delete <id>` | id로 오버라이드 제거 |
 
 ## gori mcp {#gori-mcp}
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -207,7 +207,7 @@ gori run issues update 7 --status confirmed --notes "Verified on staging" --seve
 
 ### run project
 
-List known projects, or manage project-scoped config (scope rules, env vars):
+List known projects, or manage project-scoped config (scope rules, env vars, host overrides):
 
 ```bash
 gori run project --format json
@@ -252,6 +252,26 @@ gori run project env delete TOKEN
 | (default) | List project vars; `--format` is `text` or `json` |
 | `set KEY=value` · `set KEY value` | Upsert a project var (KEY must match `[A-Za-z_][A-Za-z0-9_]*`) |
 | `delete KEY` | Remove a project var |
+
+#### project host-override
+
+Manage **project** host overrides — `/etc/hosts`-style maps that change only the TCP dial target (SNI, certificate hostname, and `Host` header stay the original name). Project entries win over global `Settings: Hostnames` on collision. Alias: `host-overrides`.
+
+```bash
+gori run project host-override                              # list
+gori run project host-override --format json
+gori run project host-override add --host=api.example.com --ip=10.0.0.1
+gori run project host-override add 10.0.0.1 api.example.com   # /etc/hosts order
+gori run project host-override update 1 --host=api.example.com --ip=10.0.0.9
+gori run project host-override delete 1
+```
+
+| Option / subcommand | Description |
+|---------------------|-------------|
+| (default) | List overrides; `--format` is `text` or `json` |
+| `add` | `--host=…` + `--ip=…`, or positional `IP HOST` |
+| `update <id>` | `--host=…` + `--ip=…` (both required) |
+| `delete <id>` | Remove an override by id |
 
 ## gori mcp
 

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -11,6 +11,7 @@ require "../project"
 require "../project_registry"
 require "../ql"
 require "../scope"
+require "../host_overrides"
 require "../sitemap"
 require "../proxy/codec/content_decode"
 require "../repeater/engine"
@@ -84,8 +85,8 @@ module Gori
         end
       end
 
-      # Left column width for `gori run -h` subcommand names (longest: "project [list]").
-      SUBCMD_COL_W = 20
+      # Left column width for `gori run -h` subcommand names (longest: "project host-override").
+      SUBCMD_COL_W = 22
 
       SUBCOMMANDS = [
         {"capture", "Start the proxy and stream captured flows to STDOUT"},
@@ -101,6 +102,7 @@ module Gori
         {"project [list]", "List known projects"},
         {"project scope", "Manage scope rules (list, add, delete, enable/disable)"},
         {"project env", "Manage project env vars ($KEY substitution)"},
+        {"project host-override", "Manage host overrides (list, add, update, delete)"},
       ]
 
       private def self.print_help : Nil
@@ -1872,7 +1874,7 @@ module Gori
         end.rstrip('\n')
       end
 
-      # --- project (list / scope / env) --------------------------------------
+      # --- project (list / scope / env / host-override) -----------------------
 
       private def self.cmd_project(args : Array(String)) : Nil
         sub = args.first?
@@ -1887,6 +1889,8 @@ module Gori
           cmd_project_scope(args[1..])
         when "env"
           cmd_project_env(args[1..])
+        when "host-override", "host-overrides"
+          cmd_project_host_override(args[1..])
         else
           # Flags only (e.g. --format json) → list projects
           if (s = sub) && s.starts_with?('-')
@@ -1909,11 +1913,13 @@ module Gori
           list               List known projects (default when no subcommand)
           scope              Manage scope rules (list, add, delete, enable/disable)
           env                Manage project env vars ($KEY substitution)
+          host-override      Manage host overrides (list, add, update, delete)
 
         Examples:
           gori run project --format json
           gori run project scope add --kind=include --type=host --pattern=api.example.com
           gori run project env set TOKEN=secret
+          gori run project host-override add --host=api.example.com --ip=10.0.0.1
 
         See 'gori run project <subcommand> --help' for more.
         HELP
@@ -2285,6 +2291,216 @@ module Gori
           end
           Env.save_project(store, vars)
           puts "Env var #{key} deleted."
+        ensure
+          store.close
+        end
+      end
+
+      # --- project host-override ---------------------------------------------
+
+      private def self.cmd_project_host_override(args : Array(String)) : Nil
+        sub = args.first?
+        case sub
+        when "add"
+          cmd_host_override_add(args[1..])
+        when "update"
+          cmd_host_override_update(args[1..])
+        when "delete"
+          cmd_host_override_delete(args[1..])
+        when nil
+          cmd_host_override_list(args)
+        else
+          if (s = sub) && s.starts_with?('-')
+            cmd_host_override_list(args)
+          else
+            STDERR.puts "gori run project host-override: unknown subcommand '#{sub}'"
+            STDERR.puts "Usage: gori run project host-override [list options] | add | update | delete"
+            exit 1
+          end
+        end
+      end
+
+      private def self.cmd_host_override_list(args : Array(String)) : Nil
+        db_path : String? = nil
+        project_name : String? = nil
+        format = :text
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run project host-override [options]\n\n" \
+                     "List project host overrides (/etc/hosts-style: dial IP for hostname).\n" \
+                     "Project overrides win over global Settings: Hostnames on collision.\n" \
+                     "Or run with a subcommand:\n" \
+                     "  gori run project host-override add --host=api.example.com --ip=10.0.0.1\n" \
+                     "  gori run project host-override add 10.0.0.1 api.example.com\n" \
+                     "  gori run project host-override update <id> --host=... --ip=...\n" \
+                     "  gori run project host-override delete <id>"
+          p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
+          p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.invalid_option { |f| abort "gori run project host-override: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run project host-override: missing value for #{f}" }
+        end
+        parser.parse(args)
+
+        project = resolve_read_project(project_name, db_path)
+        store = open_store(project)
+        begin
+          ov = HostOverrides.load(store)
+          if format == :json
+            puts(JSON.build do |j|
+              j.array do
+                ov.entries.each do |e|
+                  j.object do
+                    j.field "id", e.id
+                    j.field "host", e.host
+                    j.field "ip", e.ip
+                  end
+                end
+              end
+            end)
+          elsif ov.entries.empty?
+            STDERR.puts "no host overrides configured"
+          else
+            ov.entries.each do |e|
+              puts "##{e.id}  #{e.ip.ljust(15)}  #{e.host}"
+            end
+          end
+        ensure
+          store.close
+        end
+      end
+
+      private def self.cmd_host_override_add(args : Array(String)) : Nil
+        db_path : String? = nil
+        project_name : String? = nil
+        host : String? = nil
+        ip : String? = nil
+        positional = [] of String
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run project host-override add --host=HOST --ip=IP [options]\n" \
+                     "       gori run project host-override add IP HOST [options]\n\n" \
+                     "Add a project host override (dial IP for HOST; SNI/Host header unchanged)."
+          p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
+          p.on("--host=HOST", "Hostname to override (case-insensitive)") { |v| host = v }
+          p.on("--ip=IP", "IPv4/IPv6 literal to dial") { |v| ip = v }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| positional = rest }
+          p.invalid_option { |f| abort "gori run project host-override add: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run project host-override add: missing value for #{f}" }
+        end
+        parser.parse(args)
+
+        # Flags win when both are given; otherwise accept /etc/hosts-style "IP HOST".
+        pair =
+          if (h_flag = host) && (i_flag = ip)
+            {h_flag, i_flag}
+          else
+            abort "gori run project host-override add: need --host and --ip, or positional IP HOST" if positional.empty?
+            parsed = HostOverrides.parse_line(positional.join(' '))
+            abort "gori run project host-override add: invalid entry (expected IP HOST; IP must be a literal)" unless parsed
+            parsed
+          end
+        h, i = pair
+        abort "gori run project host-override add: invalid host/ip (host hostname-shaped, ip an IPv4/IPv6 literal)" unless HostOverrides.valid?(h, i)
+
+        project = resolve_read_project(project_name, db_path)
+        store = open_store(project)
+        begin
+          ov = HostOverrides.load(store)
+          unless ov.add(h, i)
+            store.close
+            abort "gori run project host-override add: failed to add override (duplicate host, empty, or invalid)"
+          end
+          entry = ov.entries.find { |e| e.host == h.strip.downcase }
+          if e = entry
+            puts "Host override ##{e.id} added: #{e.ip} → #{e.host}"
+          else
+            puts "Host override added: #{i} → #{h.strip.downcase}"
+          end
+        ensure
+          store.close
+        end
+      end
+
+      private def self.cmd_host_override_update(args : Array(String)) : Nil
+        db_path : String? = nil
+        project_name : String? = nil
+        host : String? = nil
+        ip : String? = nil
+        positional = [] of String
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run project host-override update <id> --host=HOST --ip=IP [options]"
+          p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
+          p.on("--host=HOST", "New hostname (case-insensitive)") { |v| host = v }
+          p.on("--ip=IP", "New IPv4/IPv6 literal to dial") { |v| ip = v }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| positional = rest }
+          p.invalid_option { |f| abort "gori run project host-override update: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run project host-override update: missing value for #{f}" }
+        end
+        parser.parse(args)
+
+        abort "gori run project host-override update: missing <id>" if positional.empty?
+        abort "gori run project host-override update: too many arguments (expected one <id>)" if positional.size > 1
+        id = positional[0].to_i64? || abort("gori run project host-override update: invalid id '#{positional[0]}'")
+        h = host
+        i = ip
+        abort "gori run project host-override update: --host and --ip are both required" unless h && i
+        abort "gori run project host-override update: invalid host/ip (host hostname-shaped, ip an IPv4/IPv6 literal)" unless HostOverrides.valid?(h, i)
+
+        project = resolve_read_project(project_name, db_path)
+        store = open_store(project)
+        begin
+          ov = HostOverrides.load(store)
+          unless ov.entries.any? { |e| e.id == id }
+            store.close
+            abort "gori run project host-override update: no override with id #{id}"
+          end
+          unless ov.update(id, h, i)
+            store.close
+            abort "gori run project host-override update: failed (duplicate host, empty, or invalid)"
+          end
+          puts "Host override ##{id} updated: #{i} → #{h.strip.downcase}"
+        ensure
+          store.close
+        end
+      end
+
+      private def self.cmd_host_override_delete(args : Array(String)) : Nil
+        db_path : String? = nil
+        project_name : String? = nil
+        positional = [] of String
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run project host-override delete <id> [options]"
+          p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| positional = rest }
+          p.invalid_option { |f| abort "gori run project host-override delete: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run project host-override delete: missing value for #{f}" }
+        end
+        parser.parse(args)
+
+        abort "gori run project host-override delete: missing <id>" if positional.empty?
+        abort "gori run project host-override delete: too many arguments (expected one <id>)" if positional.size > 1
+        id = positional[0].to_i64? || abort("gori run project host-override delete: invalid id '#{positional[0]}'")
+
+        project = resolve_read_project(project_name, db_path)
+        store = open_store(project)
+        begin
+          ov = HostOverrides.load(store)
+          unless ov.entries.any? { |e| e.id == id }
+            store.close
+            abort "gori run project host-override delete: no override with id #{id}"
+          end
+          ov.remove(id)
+          puts "Host override ##{id} deleted."
         ensure
           store.close
         end


### PR DESCRIPTION
## Summary

- Add `gori run project host-override` (alias `host-overrides`) to manage project host overrides from scripts — list, add, update, delete
- Mirror the existing `project scope` / `project env` CLI shape; reuse the project `HostOverrides` store model
- Document the subcommand in EN/KO CLI reference and the Proxy guide

## Usage

```bash
gori run project host-override
gori run project host-override add --host=api.example.com --ip=10.0.0.1
gori run project host-override add 10.0.0.1 api.example.com
gori run project host-override update 1 --host=api.example.com --ip=10.0.0.9
gori run project host-override delete 1
```

## Test plan

- [x] `crystal build` succeeds
- [x] `crystal spec spec/host_overrides_spec.cr` passes
- [x] Smoke-tested list/add/update/delete with `--db` (flags + `/etc/hosts` positional, IPv6, plural alias, duplicate/invalid rejected)
- [ ] `gori run project host-override --help` shows usage
