### PR TITLE
feat(tui): create issue/note from link pickers with open/stay prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added — Create issue/note while linking from History / Replay / …
+
+Space → **Link to issue** / **Link to note** (History, detail, Repeater, Fuzzer,
+Miner) no longer requires a pre-existing owner: each picker pins **+ New issue…**
+/ **+ New note…** at the top. New issue opens the usual title/severity form and
+links the pending workbench ref on ↵; new note creates a blank note and links
+immediately. Existing rows keep default selection when any are present. After
+create, a **open / stay** confirm asks whether to jump to the new issue/note or
+remain on the current tab (default: stay).
+
 ### Added — MCP live intercept + event feed (#123, #124)
 
 Agents can sit in the intercept loop and tail job/agent activity without

--- a/spec/tui/issue_picker_spec.cr
+++ b/spec/tui/issue_picker_spec.cr
@@ -1,0 +1,77 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+private def sample_issue(id : Int64, title : String, host : String = "app.test") : Gori::Store::Issue
+  Gori::Store::Issue.new(id, 0_i64, 0_i64, title, Gori::Store::Severity::High, host, nil, "")
+end
+
+private def sample_picker : IssuePicker
+  IssuePicker.new([
+    sample_issue(1_i64, "Reflected XSS"),
+    sample_issue(2_i64, "SQL injection"),
+    sample_issue(3_i64, "Missing header"),
+  ])
+end
+
+describe Gori::Tui::IssuePicker do
+  it "pins create at index 0 and defaults selection to the first real issue" do
+    p = sample_picker
+    p.selected.should eq(1)
+    p.selected_create?.should be_false
+    p.selected_issue.try(&.id).should eq(1_i64)
+    p.entry_count.should eq(4) # create + 3 issues
+  end
+
+  it "selects create when the project has no issues" do
+    p = IssuePicker.new([] of Gori::Store::Issue)
+    p.selected.should eq(0)
+    p.selected_create?.should be_true
+    p.selected_issue.should be_nil
+    p.entry_count.should eq(1)
+  end
+
+  it "moves onto the create row and back onto issues" do
+    p = sample_picker
+    p.move(-1)
+    p.selected_create?.should be_true
+    p.selected_issue.should be_nil
+    p.move(1)
+    p.selected_issue.try(&.title).should eq("Reflected XSS")
+  end
+
+  it "keeps create pinned while filtering and lands on the first match" do
+    p = sample_picker
+    "sql".each_char { |c| p.query_char(c) }
+    p.selected_create?.should be_false
+    p.selected_issue.try(&.title).should eq("SQL injection")
+    p.move(-1)
+    p.selected_create?.should be_true
+  end
+
+  it "falls back to create when the filter matches nothing" do
+    p = sample_picker
+    "zzz".each_char { |c| p.query_char(c) }
+    p.selected_create?.should be_true
+    p.selected_issue.should be_nil
+    p.entry_count.should eq(1)
+  end
+
+  it "restores the list on backspace with selection on the first issue" do
+    p = sample_picker
+    "sql".each_char { |c| p.query_char(c) }
+    3.times { p.backspace }
+    p.selected.should eq(1)
+    p.selected_issue.try(&.id).should eq(1_i64)
+  end
+
+  it "renders the create row and issue titles" do
+    backend = MemoryBackend.new(100, 30)
+    sample_picker.render(Screen.new(backend), Rect.new(0, 0, 100, 30))
+    backend.contains?("PICK ISSUE").should be_true
+    backend.contains?("+ New issue…").should be_true
+    backend.contains?("Reflected XSS").should be_true
+    backend.contains?("SQL injection").should be_true
+  end
+end

--- a/spec/tui/issues_view_spec.cr
+++ b/spec/tui/issues_view_spec.cr
@@ -218,6 +218,17 @@ describe Gori::Tui::IssuesView do
       view.target_issue.not_nil!.title.should eq("low-row")
     end
   end
+
+  it "open_by_id reloads, selects, and opens detail for a known issue" do
+    tmp_store do |store|
+      id = store.insert_issue("target", Gori::Store::Severity::High, "acme.test", nil)
+      store.insert_issue("other", Gori::Store::Severity::Low, "acme.test", nil)
+      view = IssuesView.new
+      view.open_by_id(store, id).should be_true
+      view.detail_open?.should be_true
+      view.detail_issue.try(&.id).should eq(id)
+    end
+  end
 end
 
 describe "IssueForm" do

--- a/spec/tui/note_picker_spec.cr
+++ b/spec/tui/note_picker_spec.cr
@@ -1,0 +1,62 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+private def sample_picker : NotePicker
+  NotePicker.new([
+    NotePicker::Row.new(10_i64, "1:XSS notes", "payload details"),
+    NotePicker::Row.new(11_i64, "2:Auth flow", "token reuse"),
+    NotePicker::Row.new(12_i64, "3:Recon", "subdomains"),
+  ])
+end
+
+describe Gori::Tui::NotePicker do
+  it "pins create at index 0 and defaults selection to the first real note" do
+    p = sample_picker
+    p.selected.should eq(1)
+    p.selected_create?.should be_false
+    p.selected_row.try(&.id).should eq(10_i64)
+    p.entry_count.should eq(4)
+  end
+
+  it "selects create when there are no notes" do
+    p = NotePicker.new([] of NotePicker::Row)
+    p.selected.should eq(0)
+    p.selected_create?.should be_true
+    p.selected_row.should be_nil
+    p.entry_count.should eq(1)
+  end
+
+  it "moves onto the create row and back onto notes" do
+    p = sample_picker
+    p.move(-1)
+    p.selected_create?.should be_true
+    p.move(1)
+    p.selected_row.try(&.label).should eq("1:XSS notes")
+  end
+
+  it "keeps create pinned while filtering" do
+    p = sample_picker
+    "auth".each_char { |c| p.query_char(c) }
+    p.selected_row.try(&.id).should eq(11_i64)
+    p.move(-1)
+    p.selected_create?.should be_true
+  end
+
+  it "falls back to create when the filter matches nothing" do
+    p = sample_picker
+    "zzz".each_char { |c| p.query_char(c) }
+    p.selected_create?.should be_true
+    p.entry_count.should eq(1)
+  end
+
+  it "renders the create row and note labels" do
+    backend = MemoryBackend.new(100, 30)
+    sample_picker.render(Screen.new(backend), Rect.new(0, 0, 100, 30))
+    backend.contains?("PICK NOTE").should be_true
+    backend.contains?("+ New note…").should be_true
+    backend.contains?("1:XSS notes").should be_true
+    backend.contains?("2:Auth flow").should be_true
+  end
+end

--- a/spec/tui/notes_view_spec.cr
+++ b/spec/tui/notes_view_spec.cr
@@ -212,6 +212,24 @@ describe Gori::Tui::NotesView do
     end
   end
 
+  it "switch_note_by_id selects the matching note" do
+    tmp_store do |store|
+      view = NotesView.new
+      view.reload(store)
+      type(view, "one")
+      view.new_note
+      type(view, "two")
+      id0 = view.current_note_id # still on "two" after new_note
+      view.switch_note(0)
+      id_one = view.current_note_id
+      view.switch_note_by_id(id0).should be_true
+      view.current_text.should eq("two")
+      view.switch_note_by_id(id_one).should be_true
+      view.current_text.should eq("one")
+      view.switch_note_by_id(999_999_i64).should be_false
+    end
+  end
+
   it "duplicate_current clones the active note's text into a new sibling (new id)" do
     tmp_store do |store|
       view = NotesView.new

--- a/src/gori/tui/controllers/notes_controller.cr
+++ b/src/gori/tui/controllers/notes_controller.cr
@@ -268,6 +268,15 @@ module Gori::Tui
       @host.status("new note (#{@notes.count}) — ^1-9 switch · ^W close · esc tabs")
     end
 
+    # Create a blank note without focusing the Notes tab (link-picker "create +
+    # link" path). Persists immediately and returns the new note's stable id.
+    def create_blank_note_id : Int64
+      save_notes
+      @notes.new_note
+      save_notes
+      @notes.current_note_id
+    end
+
     # Content-only clone of the active note (new id; entity_links not copied).
     def notes_duplicate : Nil
       save_notes

--- a/src/gori/tui/issue_picker.cr
+++ b/src/gori/tui/issue_picker.cr
@@ -5,8 +5,11 @@ require "../store"
 
 module Gori::Tui
   # Pick an issue to attach the current workbench ref to. Mirrors FlowPicker's
-  # in-memory filter; the Runner owns the overlay lifecycle.
+  # in-memory filter; the Runner owns the overlay lifecycle. A pinned
+  # "+ New issue…" row (always first) opens create-and-link via the issue form.
   class IssuePicker
+    CREATE_LABEL = "+ New issue…"
+
     getter selected : Int32
     @indexed : Array({Store::Issue, String})
 
@@ -15,7 +18,8 @@ module Gori::Tui
       @preedit = ""
       @indexed = @rows.map { |f| {f, haystack(f)} }
       @filtered = @rows
-      @selected = 0
+      # Prefer the first existing issue when present (create is always index 0).
+      @selected = @rows.empty? ? 0 : 1
       @scroll = 0
     end
 
@@ -23,18 +27,30 @@ module Gori::Tui
       @preedit = text
     end
 
+    # Total navigable rows: create action + filtered issues.
+    def entry_count : Int32
+      1 + @filtered.size
+    end
+
+    def selected_create? : Bool
+      @selected == 0
+    end
+
     def selected_issue : Store::Issue?
-      @filtered[@selected]?
+      return nil if selected_create?
+      @filtered[@selected - 1]?
     end
 
     def move(delta : Int32) : Nil
-      return if @filtered.empty?
-      @selected = (@selected + delta).clamp(0, @filtered.size - 1)
+      n = entry_count
+      return if n == 0
+      @selected = (@selected + delta).clamp(0, n - 1)
     end
 
     def set_selected(idx : Int32) : Nil
-      return if @filtered.empty?
-      @selected = idx.clamp(0, @filtered.size - 1)
+      n = entry_count
+      return if n == 0
+      @selected = idx.clamp(0, n - 1)
     end
 
     def query_char(ch : Char) : Nil
@@ -54,7 +70,8 @@ module Gori::Tui
     private def refilter : Nil
       terms = @query.downcase.split
       @filtered = terms.empty? ? @rows : @indexed.select { |(_, hay)| terms.all? { |t| hay.includes?(t) } }.map(&.first)
-      @selected = 0
+      # Keep create at 0; land on first match when any, else the create row.
+      @selected = @filtered.empty? ? 0 : 1
       @scroll = 0
     end
 
@@ -78,7 +95,7 @@ module Gori::Tui
       return nil if i < 0 || i >= list_h
       return nil if mx < box.x + 1 || mx >= box.right - 1
       ri = @scroll + i
-      ri < @filtered.size ? ri : nil
+      ri < entry_count ? ri : nil
     end
 
     def render(screen : Screen, area : Rect) : Nil
@@ -86,7 +103,7 @@ module Gori::Tui
       return unless box
       Frame.card(screen, box, "PICK ISSUE", border: Theme.border_focus)
       if @query.empty? && @preedit.empty?
-        screen.text(box.x + 2, box.y + 1, "type to filter · ↑/↓ select · ↵ link · esc cancel",
+        screen.text(box.x + 2, box.y + 1, "type to filter · ↑/↓ select · ↵ link / create · esc cancel",
           Theme.muted, Theme.panel, width: box.w - 4)
       else
         px = screen.text(box.x + 2, box.y + 1, "filter: ", Theme.muted, Theme.panel)
@@ -97,16 +114,23 @@ module Gori::Tui
       list_top = box.y + 3
       list_h = box.bottom - 1 - list_top
       ensure_visible(list_h)
-      if @filtered.empty?
-        msg = @rows.empty? ? "no issues yet" : "no issues match"
-        screen.text(box.x + 3, list_top, msg, Theme.muted, Theme.panel)
-        return
-      end
       (0...list_h).each do |i|
         ri = @scroll + i
-        break if ri >= @filtered.size
-        draw_row(screen, box, list_top + i, @filtered[ri], ri == @selected)
+        break if ri >= entry_count
+        if ri == 0
+          draw_create(screen, box, list_top + i, ri == @selected)
+        else
+          draw_row(screen, box, list_top + i, @filtered[ri - 1], ri == @selected)
+        end
       end
+    end
+
+    private def draw_create(screen : Screen, box : Rect, ry : Int32, active : Bool) : Nil
+      bg = active ? Theme.accent_bg : Theme.panel
+      fg = active ? Theme.text_bright : Theme.accent
+      screen.fill(Rect.new(box.x + 1, ry, box.w - 2, 1), bg)
+      screen.cell(box.x + 1, ry, active ? '▎' : ' ', Theme.accent, bg)
+      screen.text(box.x + 3, ry, CREATE_LABEL, fg, bg, width: box.w - 5)
     end
 
     private def draw_row(screen : Screen, box : Rect, ry : Int32, f : Store::Issue, active : Bool) : Nil
@@ -122,7 +146,7 @@ module Gori::Tui
       return if list_h <= 0
       @scroll = @selected if @selected < @scroll
       @scroll = @selected - list_h + 1 if @selected >= @scroll + list_h
-      @scroll = @scroll.clamp(0, {@filtered.size - list_h, 0}.max)
+      @scroll = @scroll.clamp(0, {entry_count - list_h, 0}.max)
     end
   end
 end

--- a/src/gori/tui/issues_view.cr
+++ b/src/gori/tui/issues_view.cr
@@ -260,6 +260,18 @@ module Gori::Tui
       true
     end
 
+    # Jump to a specific issue (create-and-link "open" path). Reloads, clears a
+    # filter that would hide the id, selects the row, and opens detail.
+    def open_by_id(store : Store, id : Int64) : Bool
+      reload(store)
+      unless @issues.index { |f| f.id == id }
+        cancel_query # drop any filter that would hide the freshly created issue
+      end
+      return false unless idx = @issues.index { |f| f.id == id }
+      select_index(idx)
+      open_detail(store)
+    end
+
     # Nudge the notes viewport sideways (shift+←/→ in READ). Pans by moving the read
     # cursor so follow_x keeps the window aligned (TextArea ensure_visible_x otherwise
     # resets a bare @xscroll when the caret sits at column 0).

--- a/src/gori/tui/note_picker.cr
+++ b/src/gori/tui/note_picker.cr
@@ -4,8 +4,11 @@ require "./frame"
 require "../notes"
 
 module Gori::Tui
-  # Pick a note sub-tab to attach the current workbench ref to.
+  # Pick a note sub-tab to attach the current workbench ref to. A pinned
+  # "+ New note…" row (always first) creates a blank note and links it.
   class NotePicker
+    CREATE_LABEL = "+ New note…"
+
     record Row, id : Int64, label : String, detail : String
 
     getter selected : Int32
@@ -16,7 +19,8 @@ module Gori::Tui
       @preedit = ""
       @indexed = @rows.map { |row| {row, "#{row.label} #{row.detail}".downcase} }
       @filtered = @rows
-      @selected = 0
+      # Prefer the first existing note when present (create is always index 0).
+      @selected = @rows.empty? ? 0 : 1
       @scroll = 0
     end
 
@@ -24,18 +28,30 @@ module Gori::Tui
       @preedit = text
     end
 
+    # Total navigable rows: create action + filtered notes.
+    def entry_count : Int32
+      1 + @filtered.size
+    end
+
+    def selected_create? : Bool
+      @selected == 0
+    end
+
     def selected_row : Row?
-      @filtered[@selected]?
+      return nil if selected_create?
+      @filtered[@selected - 1]?
     end
 
     def move(delta : Int32) : Nil
-      return if @filtered.empty?
-      @selected = (@selected + delta).clamp(0, @filtered.size - 1)
+      n = entry_count
+      return if n == 0
+      @selected = (@selected + delta).clamp(0, n - 1)
     end
 
     def set_selected(idx : Int32) : Nil
-      return if @filtered.empty?
-      @selected = idx.clamp(0, @filtered.size - 1)
+      n = entry_count
+      return if n == 0
+      @selected = idx.clamp(0, n - 1)
     end
 
     def query_char(ch : Char) : Nil
@@ -55,7 +71,7 @@ module Gori::Tui
     private def refilter : Nil
       terms = @query.downcase.split
       @filtered = terms.empty? ? @rows : @indexed.select { |(_, hay)| terms.all? { |t| hay.includes?(t) } }.map(&.first)
-      @selected = 0
+      @selected = @filtered.empty? ? 0 : 1
       @scroll = 0
     end
 
@@ -75,7 +91,7 @@ module Gori::Tui
       return nil if i < 0 || i >= list_h
       return nil if mx < box.x + 1 || mx >= box.right - 1
       ri = @scroll + i
-      ri < @filtered.size ? ri : nil
+      ri < entry_count ? ri : nil
     end
 
     def render(screen : Screen, area : Rect) : Nil
@@ -83,7 +99,7 @@ module Gori::Tui
       return unless box
       Frame.card(screen, box, "PICK NOTE", border: Theme.border_focus)
       if @query.empty? && @preedit.empty?
-        screen.text(box.x + 2, box.y + 1, "type to filter · ↑/↓ select · ↵ link · esc cancel",
+        screen.text(box.x + 2, box.y + 1, "type to filter · ↑/↓ select · ↵ link / create · esc cancel",
           Theme.muted, Theme.panel, width: box.w - 4)
       else
         px = screen.text(box.x + 2, box.y + 1, "filter: ", Theme.muted, Theme.panel)
@@ -94,16 +110,23 @@ module Gori::Tui
       list_top = box.y + 3
       list_h = box.bottom - 1 - list_top
       ensure_visible(list_h)
-      if @filtered.empty?
-        msg = @rows.empty? ? "no notes yet" : "no notes match"
-        screen.text(box.x + 3, list_top, msg, Theme.muted, Theme.panel)
-        return
-      end
       (0...list_h).each do |i|
         ri = @scroll + i
-        break if ri >= @filtered.size
-        draw_row(screen, box, list_top + i, @filtered[ri], ri == @selected)
+        break if ri >= entry_count
+        if ri == 0
+          draw_create(screen, box, list_top + i, ri == @selected)
+        else
+          draw_row(screen, box, list_top + i, @filtered[ri - 1], ri == @selected)
+        end
       end
+    end
+
+    private def draw_create(screen : Screen, box : Rect, ry : Int32, active : Bool) : Nil
+      bg = active ? Theme.accent_bg : Theme.panel
+      fg = active ? Theme.text_bright : Theme.accent
+      screen.fill(Rect.new(box.x + 1, ry, box.w - 2, 1), bg)
+      screen.cell(box.x + 1, ry, active ? '▎' : ' ', Theme.accent, bg)
+      screen.text(box.x + 3, ry, CREATE_LABEL, fg, bg, width: box.w - 5)
     end
 
     private def draw_row(screen : Screen, box : Rect, ry : Int32, row : Row, active : Bool) : Nil
@@ -118,7 +141,7 @@ module Gori::Tui
       return if list_h <= 0
       @scroll = @selected if @selected < @scroll
       @scroll = @selected - list_h + 1 if @selected >= @scroll + list_h
-      @scroll = @scroll.clamp(0, {@filtered.size - list_h, 0}.max)
+      @scroll = @scroll.clamp(0, {entry_count - list_h, 0}.max)
     end
   end
 end

--- a/src/gori/tui/notes_view.cr
+++ b/src/gori/tui/notes_view.cr
@@ -320,6 +320,14 @@ module Gori::Tui
       @dirty = true
     end
 
+    # Switch to the note with stable id `id` (create-and-link "open" path).
+    # Returns false when that note is not in this session's list.
+    def switch_note_by_id(id : Int64) : Bool
+      return false unless idx = @notes.index { |n| n.id == id }
+      switch_note(idx)
+      true
+    end
+
     # Persist iff edited (no-op otherwise — cheap to call on every exit path). Merges
     # against the currently-persisted set first, so a second TUI session on the same
     # project doesn't clobber this session's notes (and vice-versa): peer notes are

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1665,7 +1665,11 @@ module Gori::Tui
       key = ev.key
       c = ev.char || key.to_char
       case
-      when key.escape?    then @overlay = :none
+      when key.escape?
+        # Drop a pending link-from-picker ref so a later standalone create doesn't
+        # silently attach the stale workbench item.
+        @link_pending_ref = nil
+        @overlay = :none
       when key.enter?     then create_issue_from_form
       when key.tab?       then @issue_form.severity_cycle(1)
       when key.back_tab?  then @issue_form.severity_cycle(-1)
@@ -1695,14 +1699,17 @@ module Gori::Tui
       end
     end
 
-    # Open the confirmation modal for a destructive action; `action` runs only if
-    # the user accepts. Defaults to a red "danger" confirm button. `return_to` is the
-    # overlay restored on close — leave it :none for a palette-launched confirm, or pass
-    # the parent modal (e.g. :tabs) when raising the confirm from inside another overlay.
+    # Open the confirmation modal; `action` runs only if the user accepts.
+    # Defaults to a red "danger" confirm button (destructive deletes). Pass
+    # `danger: false` and custom labels for non-destructive choices (e.g. open
+    # vs stay after create-and-link). `return_to` is the overlay restored on
+    # close — leave it :none for a palette-launched confirm, or pass the parent
+    # modal (e.g. :tabs) when raising the confirm from inside another overlay.
     def confirm(title : String, message : String, *, confirm_label : String = "delete",
+                cancel_label : String = "cancel",
                 danger : Bool = true, return_to : Symbol = :none, &action : -> Nil) : Nil
       @confirm = ConfirmDialog.new(title, message, confirm_label: confirm_label,
-        cancel_label: "cancel", danger: danger)
+        cancel_label: cancel_label, danger: danger)
       @confirm_action = action
       @confirm_return = return_to
       @overlay = :confirm
@@ -2194,12 +2201,32 @@ module Gori::Tui
     private def commit_issue_picker : Nil
       fp = @issue_picker
       return close_issue_picker if fp.nil?
+      if fp.selected_create?
+        open_issue_form_for_link
+        return
+      end
       if f = fp.selected_issue
         if ref = @link_pending_ref
           commit_link_to_owner(Store::LinkOwnerKind::Issue, f.id, ref[0], ref[1])
         end
       end
       close_issue_picker
+    end
+
+    # Transition from the issue picker into NEW ISSUE form while keeping the
+    # pending workbench ref so form ↵ creates + links without leaving the tab.
+    private def open_issue_form_for_link : Nil
+      ref = @link_pending_ref
+      @issue_picker = nil
+      if ref && ref[0].flow?
+        if row = @session.store.flow_row(ref[1])
+          @issue_form = IssueForm.new("#{row.method} #{row.target}", row.host, ref[1])
+          @overlay = :issue_new
+          return
+        end
+      end
+      @issue_form = IssueForm.new
+      @overlay = :issue_new
     end
 
     private def click_issue_picker(area : Rect, mx : Int32, my : Int32) : Nil
@@ -2236,12 +2263,74 @@ module Gori::Tui
     private def commit_note_picker : Nil
       np = @note_picker
       return close_note_picker if np.nil?
+      if np.selected_create?
+        create_note_and_link
+        return
+      end
       if row = np.selected_row
         if ref = @link_pending_ref
           commit_link_to_owner(Store::LinkOwnerKind::Note, row.id, ref[0], ref[1])
         end
       end
       close_note_picker
+    end
+
+    # Blank note + link the pending workbench ref, then ask open vs stay.
+    private def create_note_and_link : Nil
+      ref = @link_pending_ref
+      return close_note_picker if ref.nil?
+      note_id = notes_controller.create_blank_note_id
+      commit_link_to_owner(Store::LinkOwnerKind::Note, note_id, ref[0], ref[1])
+      @toast = "note created and linked"
+      @note_picker = nil
+      @link_pending_ref = nil
+      offer_open_created(:note, note_id)
+    end
+
+    # After create-and-link from a workbench picker: offer to jump to the new
+    # owner, or stay on the caller tab. Default selection is stay (cancel) so a
+    # reflexive ↵ doesn't yank focus away mid-recon.
+    private def offer_open_created(kind : Symbol, id : Int64) : Nil
+      case kind
+      when :issue
+        confirm("ISSUE CREATED",
+          "issue ##{id} created and linked.\nOpen it now, or stay here?",
+          confirm_label: "open", cancel_label: "stay", danger: false) do
+          navigate_to_created_issue(id)
+        end
+      when :note
+        confirm("NOTE CREATED",
+          "note created and linked.\nOpen it now, or stay here?",
+          confirm_label: "open", cancel_label: "stay", danger: false) do
+          navigate_to_created_note(id)
+        end
+      else
+        @overlay = :none
+      end
+    end
+
+    private def navigate_to_created_issue(id : Int64) : Nil
+      @active_tab = :issues
+      @focus = :body
+      @overlay = :none
+      if issues_controller.view.open_by_id(@session.store, id)
+        @toast = "opened issue ##{id}"
+      else
+        issues_controller.view.reload(@session.store)
+        @toast = "issue ##{id} created"
+      end
+    end
+
+    private def navigate_to_created_note(id : Int64) : Nil
+      @active_tab = :notes
+      @focus = :body
+      @overlay = :none
+      if notes_controller.view.switch_note_by_id(id)
+        notes_controller.refresh_link_preview
+        @toast = "opened note"
+      else
+        @toast = "note created"
+      end
     end
 
     private def click_note_picker(area : Rect, mx : Int32, my : Int32) : Nil
@@ -2842,11 +2931,26 @@ module Gori::Tui
         issues_controller.view.resync(@session.store)
         @toast = "issue updated"
       else
-        @session.store.insert_issue(title, form.severity, form.host, form.flow_id)
-        @active_tab = :issues
-        @focus = :body
-        issues_controller.view.reload(@session.store)
-        @toast = "issue created"
+        new_id = @session.store.insert_issue(title, form.severity, form.host, form.flow_id)
+        if ref = @link_pending_ref
+          # insert_issue already entity-links flow when form.flow_id matches; other
+          # ref kinds (repeater/fuzz/miner) still need an explicit add_link.
+          already_flow = ref[0].flow? && form.flow_id == ref[1]
+          unless already_flow
+            commit_link_to_owner(Store::LinkOwnerKind::Issue, new_id, ref[0], ref[1])
+          end
+          @toast = "issue ##{new_id} created and linked"
+          @link_pending_ref = nil
+          # Ask open-vs-stay (default stay). Do not fall through to @overlay=:none —
+          # offer_open_created sets :confirm.
+          offer_open_created(:issue, new_id)
+          return
+        else
+          @active_tab = :issues
+          @focus = :body
+          issues_controller.view.reload(@session.store)
+          @toast = "issue created"
+        end
       end
       @overlay = :none
     end


### PR DESCRIPTION
## Summary
- Space → **Link to issue** / **Link to note** (History, detail, Repeater, Fuzzer, Miner) can create a new owner in-place via a pinned **+ New issue…** / **+ New note…** row.
- New issue opens the usual title/severity form and links the pending workbench ref; new note creates a blank note and links immediately.
- After create, an **open / stay** confirm asks whether to jump to the new issue/note or remain on the current tab (default: stay).

## Test plan
- [x] `crystal spec spec/tui/issue_picker_spec.cr spec/tui/note_picker_spec.cr spec/tui/issues_view_spec.cr spec/tui/notes_view_spec.cr`
- [ ] Manual: empty project → History Space → `k` → + New issue → form → open/stay
- [ ] Manual: Space → `u` → + New note → open/stay
- [ ] Manual: with existing items, default selection is first real row; create still at top
- [ ] Manual: Repeater/Fuzzer/Miner create links the correct ref kind