### PR TITLE
fix: harden against invalid-UTF-8/regex panics and silent fiber death

### DIFF
--- a/spec/fuzz_spec.cr
+++ b/spec/fuzz_spec.cr
@@ -352,6 +352,23 @@ describe F::Matcher do
     m.match_words = ""
     m.build(job, ok_result(200, "abcdef")).matched?.should be_true
   end
+
+  it "survives a catastrophic-backtracking user regex instead of killing the worker" do
+    # A user --mr/--fr/--extract regex like /(a+)+$/ raises Regex::Error ('match limit
+    # exceeded') on a pathological body rather than returning false; unrescued it killed the
+    # fuzz worker fiber. build() must yield a Result (no match / no capture), not raise.
+    job = F::Job.new(0_i64, ["x"], nil, "".to_slice)
+    evil = "a" * 60 + "!"
+    m = F::Matcher.new
+    m.match_regex = /(a+)+$/
+    m.build(job, ok_result(200, evil)).matched?.should be_false
+    f = F::Matcher.new
+    f.filter_regex = /(a+)+$/
+    f.build(job, ok_result(200, evil)).matched?.should be_true # filter never fires → kept
+    e = F::Matcher.new
+    e.extract = /(a+)+$/
+    e.build(job, ok_result(200, evil)).extracted.should be_nil
+  end
 end
 
 describe F::Engine do

--- a/spec/issues_export_spec.cr
+++ b/spec/issues_export_spec.cr
@@ -41,6 +41,14 @@ describe Gori::Issues::Export do
       Gori::Issues::Export.one_line("a\r\n\tb").should eq("a b")
       Gori::Issues::Export.one_line("  clean  ").should eq("clean")
     end
+
+    it "does not raise on invalid UTF-8 (a captured target/host can carry a raw byte)" do
+      # The PCRE `gsub` inside one_line raises ArgumentError on invalid UTF-8; without the
+      # `.scrub` this crashed `gori run issues --format markdown/text`. Byte 0x80 → U+FFFD.
+      out = Gori::Issues::Export.one_line(String.new(Bytes[0x61, 0x80, 0x62]))
+      out.should_not be_empty
+      out.valid_encoding?.should be_true
+    end
   end
 
   describe ".markdown" do

--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -1583,3 +1583,16 @@ describe "Store#upsert_probe_issue (title stays consistent with severity)" do
     end
   end
 end
+
+describe "Gori::Probe.tech_summary" do
+  it "does not raise on invalid-UTF-8 evidence (a hostile Server header byte)" do
+    # tech_summary runs on the TUI render fiber (project_view / probe_view); a value-tech
+    # evidence with a raw 0x80-0xFF byte would make the PCRE split raise and crash the whole
+    # TUI. The `.scrub` keeps the first token instead. Byte 0x80 → U+FFFD, dropped by the split.
+    rows = [{"tech_server", String.new(Bytes[0x6e, 0x67, 0x69, 0x6e, 0x78, 0x80])}] of {String, String?}
+    out = Gori::Probe.tech_summary(rows)
+    out.size.should eq(1)
+    out[0].starts_with?("nginx").should be_true
+    out[0].valid_encoding?.should be_true
+  end
+end

--- a/src/gori/fuzz/matcher.cr
+++ b/src/gori/fuzz/matcher.cr
@@ -105,6 +105,11 @@ module Gori::Fuzz
 
     private def regex_pass?(re : Regex?, text : String, default : Bool) : Bool
       re ? re.matches?(text) : default
+    rescue Regex::Error
+      # A catastrophic-backtracking user regex (--mr / --fr) raises "match limit exceeded" on a
+      # large response body instead of returning false; treat an un-evaluable pattern as no-match
+      # so one runaway regex can't kill the fuzz worker fiber on every response.
+      false
     end
 
     private def header_pass?(raw : Repeater::Result) : Bool
@@ -134,6 +139,8 @@ module Gori::Fuzz
       md = re.match(text)
       return nil unless md
       md[1]? || md[0]
+    rescue Regex::Error
+      nil # a runaway --extract regex yields no capture rather than a dead worker (see regex_pass?)
     end
 
     private def decode(raw : Repeater::Result) : Bytes

--- a/src/gori/fuzz/template.cr
+++ b/src/gori/fuzz/template.cr
@@ -393,6 +393,11 @@ module Gori::Fuzz
       # Also mark boolean/null scalar values so `--auto` exercises flag-style fields
       # (e.g. "admin":true) as documented. (Array-element values are still unmarked.)
       out.gsub(/("(?:[^"\\]|\\.)*"\s*:\s*)(true|false|null)\b/) { "#{$1}#{MARKER}#{$2}#{MARKER}" }
+    rescue ArgumentError
+      # An invalid-UTF-8 body (e.g. a repeater seeded from a captured non-UTF-8 JSON request) makes
+      # the PCRE gsub raise; leave it unmarked rather than crash the TUI auto-mark — and do NOT
+      # scrub, because this template is re-sent and its bytes must stay exact (P7).
+      body
     end
 
     private def self.word_char?(c : Char) : Bool

--- a/src/gori/issues_export.cr
+++ b/src/gori/issues_export.cr
@@ -72,7 +72,9 @@ module Gori
       # Markdown heading here, a one-row line in the text export. Shared with
       # `gori run issues --format text`.
       def self.one_line(s : String) : String
-        s.gsub(/[[:cntrl:]]+/, " ").strip
+        # scrub: captured values (target/host/method/title, e.g. an h2 :path with a raw byte) can
+        # be invalid UTF-8, which would make the PCRE gsub raise and crash the markdown/text export.
+        s.scrub.gsub(/[[:cntrl:]]+/, " ").strip
       end
 
       private def self.append_related_links(io : String::Builder, f : Store::Issue, store : Store) : Nil

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -1367,9 +1367,13 @@ module Gori
 
         filtered_repeaters = if rx = query_rx
                              all_repeaters.select do |r|
-                               r.target.matches?(rx) ||
-                                 r.name.try(&.matches?(rx)) ||
-                                 r.request.matches?(rx)
+                               # scrub: target/name/request can be invalid UTF-8 (seeded from a
+                               # captured request without scrubbing); an unscrubbed matches? raises
+                               # and fails the WHOLE list_repeaters response whenever a query filter
+                               # meets any such repeater. Scrub is lossless for a filter match.
+                               r.target.scrub.matches?(rx) ||
+                                 r.name.try(&.scrub.matches?(rx)) ||
+                                 r.request.scrub.matches?(rx)
                              end
                            else
                              all_repeaters

--- a/src/gori/probe/active/types.cr
+++ b/src/gori/probe/active/types.cr
@@ -34,7 +34,11 @@ module Gori
         return target unless target.starts_with?("http://") || target.starts_with?("https://")
         scheme_end = target.index("://") || return target
         rest = target[(scheme_end + 3)..]
-        cut = rest.index(/[\/?#]/) || return "/"
+        # Find the authority terminator with Char index, not a regex: `target` derives from a
+        # captured request and can be invalid UTF-8, which would make a PCRE `index(/[\/?#]/)`
+        # raise on the active-probe planning path (only partly rescued). index(Char) is byte-safe
+        # and preserves the target's bytes for the re-sent probe. Mirrors from_repeater.cr's idiom.
+        cut = [rest.index('/'), rest.index('?'), rest.index('#')].compact.min? || return "/"
         seg = rest[cut..]
         seg.starts_with?('/') ? seg : "/#{seg}"
       end

--- a/src/gori/probe/from_repeater.cr
+++ b/src/gori/probe/from_repeater.cr
@@ -14,7 +14,11 @@ module Gori
       scheme, host, port = Repeater::FlowRequest.parse_target(record.target)
       return nil if host.empty?
 
-      req_text = record.request
+      # scrub: record.request can carry invalid UTF-8 (the repeater editor seeds from a captured
+      # request head+body without scrubbing), which would make the PCRE gsub below raise. This
+      # builds a synthetic FlowDetail for PASSIVE ANALYSIS only (never re-sent), so scrub is
+      # lossless here. Cf. secret_in_url.cr / issues_export.one_line.
+      req_text = record.request.scrub
       # Take whichever blank-line boundary occurs FIRST — the editor uses bare-LF, so a
       # literal "\r\n\r\n" inside the body must not win over the true earlier "\n\n" head
       # boundary (the naive `crlf || lf` fallback would snap to the body's sequence).

--- a/src/gori/probe/issue.cr
+++ b/src/gori/probe/issue.cr
@@ -94,8 +94,10 @@ module Gori
       out = [] of String
       rows.each do |(code, ev)|
         label = FIXED_TECH_LABELS[code]?
-        # Value names the product; keep the first token (drop version/URL suffixes).
-        label ||= ev.try(&.split(/[\/ ;(]/, 2)[0].strip) if VALUE_TECH_CODES.includes?(code)
+        # Value names the product; keep the first token (drop version/URL suffixes). scrub: a
+        # header value can carry a non-UTF-8 byte, which would make the PCRE split raise and
+        # crash the TUI render that calls tech_summary (project_view / probe_view). Cf. cors.cr.
+        label ||= ev.try(&.scrub.split(/[\/ ;(]/, 2)[0].strip) if VALUE_TECH_CODES.includes?(code)
         out << label if label && !label.empty? && !out.includes?(label)
       end
       out

--- a/src/gori/probe/passive/secret_in_url.cr
+++ b/src/gori/probe/passive/secret_in_url.cr
@@ -49,7 +49,11 @@ module Gori
         end
 
         private def decode(name : String) : String
-          URI.decode_www_form(name)
+          # scrub: percent-decoding RE-introduces invalid UTF-8 (e.g. `%80`) even when the raw
+          # target was already scrubbed in query_pairs, so normalize's gsub(/[-_]/) would raise.
+          # A real secret/param name is ASCII, so scrubbing can't hide a match. (rescue → `name`,
+          # which query_pairs already scrubbed, so both branches yield valid UTF-8.)
+          URI.decode_www_form(name).scrub
         rescue
           name
         end

--- a/src/gori/probe/passive/security_headers.cr
+++ b/src/gori/probe/passive/security_headers.cr
@@ -21,7 +21,7 @@ module Gori
         # HSTS with no max-age, or max-age=0 (RFC 6797: instructs the UA to DROP the policy), is
         # effectively disabled even though the header is present.
         private def hsts_disabled?(value : String) : Bool
-          m = value.downcase.match(/max-age\s*=\s*"?(\d+)/)
+          m = value.scrub.downcase.match(/max-age\s*=\s*"?(\d+)/) # scrub: a non-UTF-8 byte makes the PCRE match raise (cf. cors.cr)
           return true if m.nil?
           (m[1].to_i64? || 1_i64) == 0
         end
@@ -60,6 +60,7 @@ module Gori
         # ignored) — mirror what the browser enforces, so `script-src 'self'; script-src
         # 'unsafe-inline'` is judged on the first, safe `script-src` (not the last).
         private def parse_csp(csp : String) : Hash(String, Array(String))
+          csp = csp.scrub # a non-UTF-8 byte would make the PCRE split below raise (cf. cors.cr)
           dirs = {} of String => Array(String)
           csp.split(';').each do |segment|
             toks = segment.strip.downcase.split(/\s+/).reject(&.empty?)

--- a/src/gori/proxy/server.cr
+++ b/src/gori/proxy/server.cr
@@ -92,8 +92,24 @@ module Gori::Proxy
 
     private def accept_loop(server : TCPServer) : Nil
       while @running
-        client = server.accept? || break
-        @slots.send(nil) # acquire a slot — blocks (pausing accept) when MAX_CONNECTIONS are in flight
+        client =
+          begin
+            server.accept?
+          rescue IO::Error
+            # A transient accept error must NOT kill the accept loop and wedge the whole proxy
+            # (an unrescued raise silently stops the only fiber that accepts new connections, and
+            # nothing restarts it — @running stays true but no connection is ever accepted again).
+            # Reachable without an attacker: EMFILE/ENFILE once open fds near the OS limit (gori
+            # sets no RLIMIT_NOFILE, and the @slots cap of MAX_CONNECTIONS sits far above the
+            # default ~256/1024), or a hostile connect-then-RST → ECONNABORTED. On persistent
+            # EMFILE the pending connection stays in the backlog and accept keeps raising at once,
+            # so back off briefly (else a bare retry busy-spins) then retry — the loop self-recovers
+            # once fds free / the flood subsides. A clean close (stop/rebind) still surfaces as nil.
+            sleep 10.milliseconds
+            next
+          end
+        break unless client # nil ⇒ listener closed (stop / rebind) ⇒ exit the loop cleanly
+        @slots.send(nil)    # acquire a slot — blocks (pausing accept) when MAX_CONNECTIONS are in flight
         # Hand the socket to a per-connection method so the spawned fiber closes
         # over that method's `client` PARAMETER (a fresh binding per call), NOT
         # the `client` loop variable. The loop variable is reassigned by the next

--- a/src/gori/proxy/tls/cert_builder.cr
+++ b/src/gori/proxy/tls/cert_builder.cr
@@ -76,7 +76,10 @@ module Gori::Proxy::Tls
     # that bogus host — the safe outcome) rather than minting an injected cert.
     private def self.safe_san?(host : String) : Bool
       return false if host.empty? || host.bytesize > 253
-      return true if (host =~ /\A[A-Za-z0-9.\-*]+\z/) != nil # hostname / IPv4 / wildcard labels
+      # scrub: host is the attacker-supplied CONNECT/SNI authority kept byte-exact; an invalid
+      # UTF-8 byte would make this PCRE match raise on the proxy path. Scrubbed bytes (U+FFFD)
+      # fall outside the charset → SAN skipped (the designed graceful outcome), never a raise.
+      return true if (host.scrub =~ /\A[A-Za-z0-9.\-*]+\z/) != nil # hostname / IPv4 / wildcard labels
       ipv6?(host) # IPv6 literals contain ':' (rejected by the DNS charset above)
     end
 
@@ -110,7 +113,9 @@ module Gori::Proxy::Tls
     # value stays injection-safe and parseable by OpenSSL's a2i_IPADDRESS; anything else
     # falls through to a DNS SAN (won't verify for that odd literal, but never crashes).
     private def self.ipv6?(host : String) : Bool
-      return false unless (host =~ /\A[0-9A-Fa-f:.]+\z/) != nil
+      # scrub: independent raise site — safe_san? also reaches here with the raw (unscrubbed)
+      # host, so this PCRE match must scrub too or an invalid-UTF-8 CONNECT authority raises.
+      return false unless (host.scrub =~ /\A[0-9A-Fa-f:.]+\z/) != nil
       Socket::IPAddress.valid_v6?(host)
     end
 

--- a/src/gori/repeater/subtab_filter.cr
+++ b/src/gori/repeater/subtab_filter.cr
@@ -131,7 +131,10 @@ module Gori
       # Host portion of a target URL for `host:` suggestions (falls back to the
       # authority-ish first path segment when URI.parse fails).
       def self.host_of(target : String) : String?
-        t = target.strip
+        # scrub: target derives from a captured request; URI.parse returns an EMPTY host for an
+        # invalid-UTF-8 authority (falling through past the guard below), so the bare-host sub
+        # would then raise. Scrub once here — host_of only produces a display/suggestion string.
+        t = target.scrub.strip
         return nil if t.empty?
         begin
           if h = URI.parse(t).host

--- a/src/gori/repeater/ws_engine.cr
+++ b/src/gori/repeater/ws_engine.cr
@@ -43,7 +43,11 @@ module Gori
       UPGRADE_HEADER = /(?:^|\n)upgrade:[ \t]*websocket/i
 
       def self.upgrade_request?(request : String) : Bool
-        request.matches?(UPGRADE_HEADER)
+        # scrub: `request` is a captured request head+body kept byte-exact (never scrubbed, P7);
+        # an obs-text byte in a header value would make PCRE matches? raise. This is a read-only
+        # classification (the request is never re-sent from it), so scrub is lossless and fixes
+        # all callers (cli/run.cr's `gori run` path is otherwise unrescued).
+        request.scrub.matches?(UPGRADE_HEADER)
       end
 
       # An outbound message to resend (opcode 1=text, 2=binary).

--- a/src/gori/tui/copy_menu.cr
+++ b/src/gori/tui/copy_menu.cr
@@ -18,7 +18,10 @@ module Gori::Tui
     def self.request_options(wire : String, target : String, *,
                              websocket_messages : Array(String)? = nil) : Array(Option)
       head, body = split_message(wire)
-      lines = head.split(/\r?\n/)
+      # scrub: `wire` is a captured request kept byte-exact; an obs-text/binary byte in the head
+      # would make the PCRE split raise and crash the TUI copy menu. Scrub only the head we parse
+      # into lines — the "Raw request" row below still copies the untouched `wire`.
+      lines = head.scrub.split(/\r?\n/)
       request_line = lines.first? || ""
       header_lines = lines.size > 1 ? lines[1..] : [] of String
       method, req_target, _ = parse_request_line(request_line)
@@ -47,7 +50,9 @@ module Gori::Tui
     # offered ONLY when both parts are present, since with just one it would be a
     # byte-identical duplicate of the Status+headers (empty body) or Body (empty head) row.
     def self.response_options(head : String, body : String) : Array(Option)
-      head_clean = head.sub(/\r?\n\r?\n\z/, "")
+      # scrub: server response head bytes can carry obs-text (0x80-0xFF); the PCRE sub would
+      # otherwise raise and crash the TUI copy menu. (Clipboard content is text anyway.)
+      head_clean = head.scrub.sub(/\r?\n\r?\n\z/, "")
       opts = [] of Option
       opts << Option.new("Status + headers", 'h', head_clean) unless head_clean.strip.empty?
       opts << Option.new("Body", 'b', body) unless body.empty?

--- a/src/gori/tui/notes_view.cr
+++ b/src/gori/tui/notes_view.cr
@@ -374,6 +374,12 @@ module Gori::Tui
       return unless focused
       lines = ed.lines_snapshot
       return if lines.empty?
+      # Re-sync the read cursor from the editor before painting. A peer edit (2nd session or MCP
+      # update_note) can reload a shorter note via soft_merge_from, which resets the editor's
+      # clamped caret but deliberately leaves @read alone — a stale @read.cursor.cy past the new
+      # end would make the lines[cy] below raise IndexError and crash the TUI render. Mirrors
+      # RepeaterView#paint_request_read_chrome.
+      @read.sync_from(ed)
       scr = ed.scroll
       sel_bg = Theme.accent_bg
       @read.cursor.highlight_spans(lines).each do |(li, x0, x1)|

--- a/src/gori/tui/probe_view.cr
+++ b/src/gori/tui/probe_view.cr
@@ -94,7 +94,13 @@ module Gori::Tui
 
     private def recount(base : Array(Store::ProbeIssue)) : Nil
       @counts = StaticArray(Int32, 5).new(0)
-      base.each { |i| @counts[i.severity.value] += 1 }
+      base.each do |i|
+        v = i.severity.value
+        # Enum.new doesn't validate, so a probe_issues row from a foreign/newer/corrupt DB can
+        # carry a severity outside 0..4; guard the fixed-size tally so an out-of-range value
+        # can't raise IndexError and crash the TUI render.
+        @counts[v] += 1 if v >= 0 && v < @counts.size
+      end
     end
 
     # The default lens shows only OPEN issues; triaged (dismissed/confirmed/resolved) rows

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -1276,6 +1276,11 @@ module Gori::Tui
       return unless active
       lines = @desc_area.lines_snapshot
       return if lines.empty?
+      # Re-sync the read cursor from the editor before painting: replace_desc (^E external editor)
+      # can shrink the description without touching @desc_read, leaving a stale cursor past the new
+      # end so the lines[cy] below would raise IndexError and crash the TUI render. Mirrors the
+      # notes_view / repeater_view / fuzzer_view read-chrome paint paths.
+      @desc_read.sync_from(@desc_area)
       scr = @desc_area.scroll
       sel_bg = Theme.accent_bg
       @desc_read.cursor.highlight_spans(lines).each do |(li, x0, x1)|


### PR DESCRIPTION
## Summary

An audit-driven runtime-stability pass across the **proxy, probe, fuzz, TUI, MCP, and repeater** subsystems. It closes two reachable panic classes on attacker-controlled data plus several silent-fiber-death / crash gaps. Every fix matches an idiom the codebase already uses elsewhere (`.scrub` before a PCRE op — cf. `cors.cr`/`secret_in_url.cr`; convert-error-to-value; read-cursor `sync_from` in-paint — cf. `repeater_view`/`fuzzer_view`).

The core paths were already well-hardened; the fixes are mostly places where that hardening wasn't applied **consistently** to sibling code.

## What was fixed

**Proxy stays up (HIGH)**
- `proxy/server.cr` `accept_loop`: `server.accept?` raises a non-EAGAIN `Socket::Error` on `EMFILE`/`ENFILE` fd exhaustion (no `RLIMIT_NOFILE` is set; the `@slots` cap sits above the OS default) or a hostile connect-then-`RST` (`ECONNABORTED`). Unrescued, that silently killed the only accept fiber — the proxy stopped accepting **all** new connections until restart. Now `rescue IO::Error` + a 10 ms backoff, so the loop self-recovers; the clean-close `break` stays outside the rescue.

**invalid-UTF-8 (RFC7230 obs-text / binary bodies) → PCRE `ArgumentError`**

Captured HTTP data is kept byte-exact (P7), so header values / bodies / targets can be invalid UTF-8, and a regex op on them raises. Scrubbed at the op (lossless for display/analysis/filter values):
- `probe/issue.cr` `tech_summary` (TUI render crash), `probe/passive/security_headers.cr` (CSP/HSTS), `probe/passive/secret_in_url.cr` (post-percent-decode), `issues_export.cr` `one_line` (export crash), `probe/from_repeater.cr`, `tui/copy_menu.cr` (×2, copy-menu crash), `repeater/ws_engine.cr`, `repeater/subtab_filter.cr`, `mcp/tools.cr` `list_repeaters` filter, `proxy/tls/cert_builder.cr` (×2, MITM SAN checks on the CONNECT authority).
- Kept **byte-exact** where the value is re-sent: `fuzz/template.cr` auto-mark (rescue → unmarked) and `probe/active/types.cr` `origin_form` (non-regex `index(Char)` form).

**ReDoS (MED)**
- `fuzz/matcher.cr`: a catastrophic-backtracking user regex (`--mr`/`--fr`/`--extract`) raises `Regex::Error` ("match limit exceeded") instead of returning false, which killed the fuzz worker fiber. Now `rescue Regex::Error` → no-match / no-capture.

**TUI render crashes (MED)**
- `tui/notes_view.cr` + `tui/project_view.cr`: a stale read cursor after a peer (2nd session / MCP) shrinks the text made `lines[cy]` raise `IndexError`. Now `sync_from` in-paint, mirroring the repeater/fuzzer siblings.
- `tui/probe_view.cr` `recount`: an out-of-range severity (foreign/corrupt DB; `Enum.new` doesn't validate) raised `IndexError` on a fixed-size tally — now bounds-guarded.

## Not affected (verified)
SQL `REGEXP` (`body~`/`header~`/regex-scope) is already scrub+rescue-wrapped by `store/safe_regexp.cr`; scope regex is rescued; match&replace uses literal `String#gsub`; MCP JSON arg coercion uses nilable `.as_*?` helpers; DB scalar casts are query-typed. The reachable panics were UTF-8/PCRE + `IndexError`, not `.as()`/`not_nil!`.

## Testing
- `shards build` ✅
- `crystal spec` — **1870 examples, 0 failures** (1867 baseline + 3 new regression specs: `one_line` on invalid UTF-8, `Probe.tech_summary` on invalid-UTF-8 evidence, fuzz `Matcher` ReDoS).
- No new `ameba` findings on changed lines.