### PR TITLE
feat(project): stable short id with git-style prefix matching

### DIFF
--- a/spec/mcp_project_resolver_spec.cr
+++ b/spec/mcp_project_resolver_spec.cr
@@ -38,6 +38,7 @@ describe Gori::MCP::ProjectResolver do
 
       selected.project_name.should eq("zaps-rest")
       selected.project_slug.should eq("zaps-rest")
+      selected.project_id.not_nil!.should match(/\A[0-9a-f]{8}\z/) # stable short id
       selected.workspace_root.should eq(File.realpath(workspace))
       selected.source.should eq("workspace-created")
       selected.db_path.should_not eq(active.db_path)
@@ -102,6 +103,13 @@ describe Gori::MCP::ProjectResolver do
       first_by_slug = Gori::MCP::ProjectResolver.resolve(nil, "api", cwd: second_root,
         env_db: nil, env_project: nil)
       first_by_slug.db_path.should eq(first.db_path)
+
+      # --project also resolves by the stable short id, decoupled from the ambiguous
+      # "api" display name shared by both workspaces. (Unique-PREFIX matching is
+      # covered deterministically with pinned ids in project_registry_spec.)
+      first_by_id = Gori::MCP::ProjectResolver.resolve(nil, first.project_id.not_nil!,
+        cwd: second_root, env_db: nil, env_project: nil)
+      first_by_id.db_path.should eq(first.db_path)
     end
   end
 

--- a/spec/project_registry_spec.cr
+++ b/spec/project_registry_spec.cr
@@ -49,6 +49,96 @@ describe Gori::ProjectRegistry do
     end
   end
 
+  it "assigns a stable short id at create time and resolves it exactly (case-insensitively)" do
+    with_root do |root|
+      reg = Gori::ProjectRegistry.new(root)
+      p = reg.create("api")
+      Gori::Store.open(p.db_path).close
+      id = reg.id_of(p).not_nil!
+      id.should match(/\A[0-9a-f]{8}\z/) # Random::Secure.hex(4)
+      reg.find(id).try(&.dir).should eq(p.dir)
+      reg.find(id.upcase).try(&.dir).should eq(p.dir)
+    end
+  end
+
+  it "resolves a project by a unique id prefix (git-style abbreviation)" do
+    with_root do |root|
+      reg = Gori::ProjectRegistry.new(root)
+      p = reg.create("api")
+      Gori::Store.open(p.db_path).close
+      id = reg.id_of(p).not_nil!
+      reg.find(id[0, 4]).try(&.dir).should eq(p.dir)
+      reg.find(id[0, 1]).try(&.dir).should eq(p.dir) # any prefix, while it stays unique
+    end
+  end
+
+  it "returns nil for an ambiguous id prefix rather than guessing" do
+    with_root do |root|
+      reg = Gori::ProjectRegistry.new(root)
+      a = reg.create("alpha")
+      Gori::Store.open(a.db_path).close
+      b = reg.create("beta")
+      Gori::Store.open(b.db_path).close
+      # Pin colliding ids so the prefix is deterministically shared.
+      File.write(File.join(a.dir, Gori::ProjectRegistry::ID_FILE), "abcd1111")
+      File.write(File.join(b.dir, Gori::ProjectRegistry::ID_FILE), "abcd2222")
+      reg.find("abcd").should be_nil                  # shared prefix → ambiguous → nil
+      reg.find("abcd1").try(&.dir).should eq(a.dir)    # now unique
+      reg.find("abcd2222").try(&.dir).should eq(b.dir) # exact id
+    end
+  end
+
+  it "prefers an exact slug/name over another project's id prefix (no hex-name shadowing)" do
+    with_root do |root|
+      reg = Gori::ProjectRegistry.new(root)
+      a = reg.create("alpha")
+      Gori::Store.open(a.db_path).close
+      File.write(File.join(a.dir, Gori::ProjectRegistry::ID_FILE), "cafe1234")
+      # A hex-like display name that also equals a prefix of a's id.
+      b = reg.create("cafe")
+      Gori::Store.open(b.db_path).close
+      reg.find("cafe").try(&.dir).should eq(b.dir) # exact slug/name wins over the id prefix
+    end
+  end
+
+  it "keeps the short id stable and resolvable across a rename that drifts the slug" do
+    with_root do |root|
+      reg = Gori::ProjectRegistry.new(root)
+      p = reg.create("api")
+      Gori::Store.open(p.db_path).close
+      id = reg.id_of(p).not_nil!
+      renamed = reg.rename(p, "Payment API")
+      reg.id_of(renamed).should eq(id)                    # rename never touches .id
+      reg.find(id).try(&.dir).should eq(p.dir)            # same opaque handle still resolves
+      reg.find("api").try(&.dir).should eq(p.dir)         # frozen slug still resolves
+      reg.find("Payment API").try(&.dir).should eq(p.dir) # and the new display name
+    end
+  end
+
+  it "keeps the id when create reopens an existing same-name project (write-if-absent)" do
+    with_root do |root|
+      reg = Gori::ProjectRegistry.new(root)
+      first = reg.create("api")
+      Gori::Store.open(first.db_path).close
+      id = reg.id_of(first).not_nil!
+      again = reg.create("api") # same slug → reopen, must not re-roll the id
+      reg.id_of(again).should eq(id)
+    end
+  end
+
+  it "resolves a legacy project (no .id) by slug/name and never backfills one" do
+    with_root do |root|
+      reg = Gori::ProjectRegistry.new(root)
+      p = reg.create("legacy")
+      Gori::Store.open(p.db_path).close
+      File.delete(File.join(p.dir, Gori::ProjectRegistry::ID_FILE)) # created before ids existed
+      reg.id_of(p).should be_nil
+      reg.find("legacy").try(&.dir).should eq(p.dir) # display name / slug still resolve
+      reg.find(reg.slug_of(p)).try(&.dir).should eq(p.dir)
+      reg.id_of(p).should be_nil # find/list are read-only — no write-on-read backfill
+    end
+  end
+
   it "lists created projects (and ignores temp/hidden dirs)" do
     with_root do |root|
       reg = Gori::ProjectRegistry.new(root)

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -473,6 +473,7 @@ module Gori
       resolved = selection.db_path
       project_name = selection.project_name
       project_slug = selection.project_slug
+      project_id = selection.project_id
       Log.info { "mcp: serving #{resolved}#{" (#{project_name})" if project_name}#{" [#{project_slug}]" if project_slug} source=#{selection.source} (actions=#{!read_only})" }
       if selection.auto_created
         Log.warn { "mcp: created an isolated project for workspace #{selection.workspace_root}; use --project/--db to override" }
@@ -492,7 +493,8 @@ module Gori
       begin
         server = MCP::Server.new(store, allow_actions: !read_only, verify_upstream: !insecure_upstream,
           project_name: project_name, project_slug: project_slug, db_path: resolved,
-          selection_source: selection.source, workspace_root: selection.workspace_root)
+          selection_source: selection.source, workspace_root: selection.workspace_root,
+          project_id: project_id)
         server.run # blocks until STDIN EOF (client closed)
       ensure
         store.close

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -1936,13 +1936,16 @@ module Gori
         end
         parser.parse(args)
 
-        projects = ProjectRegistry.new(Paths.projects_dir).list
+        registry = ProjectRegistry.new(Paths.projects_dir)
+        projects = registry.list
         if format == :json
           puts(JSON.build do |j|
             j.array do
               projects.each do |pr|
                 j.object do
                   j.field "name", pr.name
+                  j.field "id", registry.id_of(pr)
+                  j.field "slug", registry.slug_of(pr)
                   j.field "db_path", pr.db_path
                   j.field "db_size", pr.db_size
                   j.field "last_modified", pr.last_modified.try(&.to_unix)
@@ -1956,7 +1959,8 @@ module Gori
         else
           projects.each do |pr|
             ts = pr.last_modified.try(&.to_local.to_s("%Y-%m-%d %H:%M")) || "—"
-            puts "#{pr.name.ljust(24)}  #{ts}  #{CLI::Output.human_size(pr.db_size)}"
+            id = registry.id_of(pr) || "—"
+            puts "#{pr.name.ljust(24)}  #{id.ljust(8)}  #{ts}  #{CLI::Output.human_size(pr.db_size)}"
           end
         end
       end
@@ -2508,19 +2512,25 @@ module Gori
 
       # --- shared helpers ----------------------------------------------------
 
-      # --db wins → else --project (matched case-insensitively on the dir slug) →
-      # else the most-recently-active project. Aborts when nothing resolves.
+      # --db wins → else --project resolved via ProjectRegistry#find (exact short id
+      # → exact dir slug → exact display name → unique id-prefix, all
+      # case-insensitive) → else the most-recently-active project. Aborts when
+      # nothing resolves. Routing through #find is what lets a read command finally
+      # select by slug/id, not display name alone (parity with MCP --project).
       private def self.resolve_read_project(project_name : String?, db_path : String?) : Project
         if path = db_path
           abort "gori run: --db is not a readable file: #{path}" unless File.file?(path)
           return Project.new(File.basename(File.dirname(path)), path)
         end
-        projects = ProjectRegistry.new(Paths.projects_dir).list
+        registry = ProjectRegistry.new(Paths.projects_dir)
         if name = project_name
-          found = projects.find { |pr| pr.name.downcase == name.downcase }
-          abort "gori run: no project named '#{name}'#{projects.empty? ? "" : " (have: #{projects.map(&.name).join(", ")})"}" unless found
-          return found
+          if found = registry.find(name)
+            return found
+          end
+          projects = registry.list
+          abort "gori run: no project matching '#{name}'#{projects.empty? ? "" : " (have: #{projects.map(&.name).join(", ")})"}"
         end
+        projects = registry.list
         abort "gori run: no projects yet — capture some traffic first, or pass --db PATH" if projects.empty?
         projects.first
       end

--- a/src/gori/mcp/project_resolver.cr
+++ b/src/gori/mcp/project_resolver.cr
@@ -16,7 +16,8 @@ module Gori
         project_slug : String?,
         source : String,
         workspace_root : String? = nil,
-        auto_created : Bool = false
+        auto_created : Bool = false,
+        project_id : String? = nil
 
       class Error < Exception
       end
@@ -82,7 +83,8 @@ module Gori
         raise Error.new("#{source} directory does not exist: #{parent}") unless Dir.exists?(parent)
         project = registry.list.find { |candidate| candidate.db_path == expanded }
         Selection.new(expanded, project.try(&.name),
-          project.try { |candidate| registry.slug_of(candidate) }, source)
+          project.try { |candidate| registry.slug_of(candidate) }, source,
+          project_id: project.try { |candidate| registry.id_of(candidate) })
       end
 
       private def self.active_fallback(registry : ProjectRegistry) : Selection
@@ -90,7 +92,8 @@ module Gori
           if File.file?(path)
             project_for_path = registry.list.find { |candidate| candidate.db_path == path }
             return Selection.new(path, project_for_path.try(&.name),
-              project_for_path.try { |candidate| registry.slug_of(candidate) }, "active-tui")
+              project_for_path.try { |candidate| registry.slug_of(candidate) }, "active-tui",
+              project_id: project_for_path.try { |candidate| registry.id_of(candidate) })
           end
         end
         if mru = registry.list.first?
@@ -102,7 +105,7 @@ module Gori
       private def self.select_project(name : String, source : String,
                                       registry : ProjectRegistry) : Selection
         project = registry.find(name)
-        raise Error.new("no such project: #{name} (match display name or directory slug)") unless project
+        raise Error.new("no such project: #{name} (match short id, id prefix, dir slug, or display name)") unless project
         from_project(project, registry, source)
       end
 
@@ -110,7 +113,7 @@ module Gori
                                     source : String, workspace_root : String? = nil,
                                     auto_created : Bool = false) : Selection
         Selection.new(project.db_path, project.name, registry.slug_of(project), source,
-          workspace_root, auto_created)
+          workspace_root, auto_created, project_id: registry.id_of(project))
       end
 
       private def self.canonical(path : String) : String

--- a/src/gori/mcp/server.cr
+++ b/src/gori/mcp/server.cr
@@ -30,12 +30,13 @@ module Gori
       def initialize(@store : Store, *, allow_actions : Bool, verify_upstream : Bool,
                      @project_name : String? = nil, @project_slug : String? = nil,
                      @db_path : String? = nil, @selection_source : String? = nil,
-                     @workspace_root : String? = nil,
+                     @workspace_root : String? = nil, @project_id : String? = nil,
                      @input : IO = STDIN, @output : IO = STDOUT)
         @allow_actions = allow_actions
         @tools = Tools.new(@store, allow_actions, verify_upstream,
           project_name: @project_name, project_slug: @project_slug, db_path: @db_path,
-          selection_source: @selection_source, workspace_root: @workspace_root)
+          selection_source: @selection_source, workspace_root: @workspace_root,
+          project_id: @project_id)
         @initialized = false
       end
 

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -95,7 +95,7 @@ module Gori
       def initialize(@store : Store, @allow_actions : Bool, @verify_upstream : Bool,
                      @project_name : String? = nil, @project_slug : String? = nil,
                      @db_path : String? = nil, @selection_source : String? = nil,
-                     @workspace_root : String? = nil)
+                     @workspace_root : String? = nil, @project_id : String? = nil)
         Env.load_project(@store)
         @jobs = {} of String => FuzzJob
         @mine_jobs = {} of String => MineJob
@@ -1271,6 +1271,7 @@ module Gori
           j.object do
             j.field "project", @project_name
             j.field "project_slug", @project_slug
+            j.field "project_id", @project_id
             j.field "db_path", @db_path
             j.field "selection_source", @selection_source
             j.field "workspace_root", @workspace_root
@@ -1315,6 +1316,7 @@ module Gori
               j.field "available", true
               j.field "project", @project_name
               j.field "project_slug", @project_slug
+              j.field "project_id", @project_id
               j.field "active_tab", parsed["active_tab"]?.try(&.as_s?)
               j.field "focus_pane", parsed["focus_pane"]?.try(&.as_s?)
               if fid = parsed["selected_flow_id"]?.try(&.as_i64?)
@@ -1604,6 +1606,7 @@ module Gori
                 projects.each do |p|
                   j.object do
                     j.field "name", p.name
+                    j.field "id", reg.id_of(p)
                     j.field "slug", reg.slug_of(p)
                     j.field "db_path", p.db_path
                     j.field "db_size", p.db_size
@@ -1634,6 +1637,7 @@ module Gori
         Result.new(JSON.build do |j|
           j.object do
             j.field "name", proj.name
+            j.field "id", reg.id_of(proj)
             j.field "slug", reg.slug_of(proj)
             j.field "db_path", proj.db_path
             j.field "created", !existed # false = reopened an existing same-name project
@@ -1648,7 +1652,7 @@ module Gori
         return err("missing required 'project'", "INVALID_ARGUMENT", field: "project") if name.nil? || name.strip.empty?
         reg = registry
         proj = reg.find(name)
-        return not_found("no such project: #{name} (match display name or directory slug)") unless proj
+        return not_found("no such project: #{name} (match short id, id prefix, dir slug, or display name)") unless proj
         return busy("cannot switch project while a fuzz/mine job is running; stop it first") if jobs_running?
 
         new_store = begin
@@ -1661,6 +1665,7 @@ module Gori
         @owns_store = true
         @project_name = proj.name
         @project_slug = reg.slug_of(proj)
+        @project_id = reg.id_of(proj)
         @db_path = proj.db_path
         @workspace_root = reg.workspace_of(proj)
         @selection_source = "switch_project"
@@ -1670,6 +1675,7 @@ module Gori
             j.field "switched", true
             j.field "project", @project_name
             j.field "project_slug", @project_slug
+            j.field "project_id", @project_id
             j.field "db_path", @db_path
             j.field "flows", @store.count
             j.field "issues", @store.count_issues
@@ -1682,7 +1688,7 @@ module Gori
         return err("missing required 'project'", "INVALID_ARGUMENT", field: "project") if name.nil? || name.strip.empty?
         reg = registry
         proj = reg.find(name)
-        return not_found("no such project: #{name} (match display name or directory slug)") unless proj
+        return not_found("no such project: #{name} (match short id, id prefix, dir slug, or display name)") unless proj
         return busy("cannot delete the project this server is currently serving; switch away first") if proj.db_path == @db_path
         return busy("cannot delete a project while a fuzz/mine job is running") if jobs_running?
 
@@ -1701,6 +1707,7 @@ module Gori
           j.object do
             j.field "dry_run", true
             j.field "name", proj.name
+            j.field "id", reg.id_of(proj)
             j.field "slug", reg.slug_of(proj)
             j.field "db_path", proj.db_path
             j.field "dir", proj.dir
@@ -1735,6 +1742,7 @@ module Gori
           j.object do
             j.field "deleted", true
             j.field "name", proj.name
+            j.field "id", reg.id_of(proj)
             j.field "slug", reg.slug_of(proj)
             j.field "db_path", proj.db_path
           end

--- a/src/gori/project_registry.cr
+++ b/src/gori/project_registry.cr
@@ -18,27 +18,56 @@ module Gori
     # share the same basename, and the globally active TUI project can belong to
     # an entirely different repository.
     WORKSPACE_FILE = ".workspace"
+    # Stable, opaque, NAME-INDEPENDENT short id (8 hex chars, like a git short SHA).
+    # Written once at create time so a project stays addressable by a unique id
+    # prefix even after a rename drifts its display name away from its frozen dir
+    # slug. Optional: legacy projects created before this sidecar have none and
+    # stay addressable by slug/name (see #find) — no backfill, no write-on-read.
+    # Lives inside the project dir, so it is never itself listed as a project.
+    ID_FILE = ".id"
 
     def initialize(@root : String)
     end
 
-    # Resolve a project by its verbatim display name OR its directory slug (both
-    # case-insensitive). Lets `gori mcp --project=api` work when the display name
-    # is a non-ASCII phrase stored in `.name`.
+    # Resolve a project by (case-insensitively, in priority order): its exact short
+    # id, its exact directory slug, its exact verbatim display name, or a UNIQUE
+    # PREFIX of its short id — git-style abbreviation. Lets `gori mcp --project=api`
+    # work when the display name is a non-ASCII phrase stored in `.name`, and
+    # `--project=a1b2` work as a short handle decoupled from the (renamable) name.
+    #
+    # Order matters: all three EXACT matches are tried before the id-prefix, so a
+    # hex-like display name can never be shadowed by another project's id prefix.
+    # An ambiguous prefix (2+ ids share it) resolves to nothing rather than guessing.
     def find(name_or_slug : String) : Project?
       q = name_or_slug.strip.downcase
       return nil if q.empty?
-      projects = list
+      # Read each id once (a small sidecar per project) and reuse across the passes.
+      entries = list.map { |project| {project, id_of(project).try(&.downcase)} }
+
+      # Exact short id — the opaque, name-independent handle; most specific, so first.
+      entries.each { |project, id| return project if id == q }
       # A slug is unique while display names need not be (two workspaces with the
       # same basename deliberately share a display name). Prefer an exact slug so
       # `--project=api` cannot resolve the newer `api-2` merely due to MRU order.
-      projects.find { |project| slug_of(project).downcase == q } ||
-        projects.find { |project| project.name.downcase == q }
+      entries.each { |project, _| return project if slug_of(project).downcase == q }
+      entries.each { |project, _| return project if project.name.downcase == q }
+      # Git-style abbreviation: a prefix that uniquely identifies ONE project's id.
+      prefixed = entries.select { |_, id| id && id.starts_with?(q) }
+      prefixed.size == 1 ? prefixed.first[0] : nil
     end
 
     # The on-disk directory name for a project (the slugified workspace dir).
     def slug_of(project : Project) : String
       File.basename(project.dir)
+    end
+
+    # The stable short id from the `.id` sidecar, or nil for a legacy project
+    # created before ids existed (which stays addressable by slug/name). Parallels
+    # workspace_of — a small sidecar read, never an open of the project DB.
+    def id_of(project : Project) : String?
+      File.read(File.join(project.dir, ID_FILE)).strip.presence
+    rescue
+      nil
     end
 
     # Resolve a project by the workspace path it was explicitly bound to.
@@ -104,6 +133,7 @@ module Gori
       # Persist the verbatim display name so a later `list` shows "My Project", not
       # the lossy slug "my-project".
       File.write(File.join(dir, NAME_FILE), display) rescue nil
+      write_id_if_absent(dir) # a fresh project gets a stable short id; a reopen keeps its own
       proj = Project.new(display, File.join(dir, Project::DB_FILE))
       desc = description.strip
       unless desc.empty?
@@ -142,6 +172,7 @@ module Gori
             File.chmod(dir, Paths::DIR_MODE) rescue nil
             File.write(File.join(dir, WORKSPACE_FILE), workspace)
             File.write(File.join(dir, NAME_FILE), display) rescue nil
+            write_id_if_absent(dir)
             return Project.new(display, db)
           rescue File::AlreadyExistsError
             # Another process claimed it after the exists? check; inspect below.
@@ -179,6 +210,32 @@ module Gori
       dir = File.join(@root, slug)
       return false unless Dir.exists?(dir) && File.exists?(File.join(dir, Project::DB_FILE))
       display_name(dir, slug).downcase != display.downcase
+    end
+
+    # Assign a stable short id to a freshly created project. WRITE-IF-ABSENT: never
+    # overwrites an existing id (it must stay stable across reopens), and it is only
+    # ever called from create/create_for_workspace — never from read/list — so
+    # legacy projects keep resolving by slug/name until explicitly (re)created.
+    # Best-effort like NAME_FILE: an unwritable id sidecar just leaves the project
+    # id-less, still fully addressable by slug/name.
+    private def write_id_if_absent(dir : String) : Nil
+      path = File.join(dir, ID_FILE)
+      return if File.exists?(path)
+      File.write(path, generate_id) rescue nil
+    end
+
+    # A short, opaque id (8 hex chars → 2^32 space) that no existing project already
+    # holds. Collisions are astronomically unlikely for the small project counts
+    # gori sees; we still re-roll on the off chance, capped so a corrupt tree can't
+    # spin forever (after which a duplicate is harmless — exact-id still resolves,
+    # only the prefix of a genuine twin turns ambiguous).
+    private def generate_id : String
+      taken = list.compact_map { |project| id_of(project).try(&.downcase) }
+      10.times do
+        candidate = Random::Secure.hex(4)
+        return candidate unless taken.includes?(candidate)
+      end
+      Random::Secure.hex(4)
     end
 
     private def normalized_workspace(path : String) : String


### PR DESCRIPTION
Closes #173

## Problem

A project was selectable only by **name**, with two human-facing failure modes:

1. **Rename → slug drift.** `rename` writes the `.name` sidecar but deliberately freezes the directory slug. After renaming `api` → `Payment API`, the picker shows *"Payment API"* but you still had to type **`api`** — what you see and what you type diverge.
2. **Two inconsistent resolution paths.** `ProjectRegistry#find` matched slug→name, while `CLI::Run.resolve_read_project` matched **display name only** (its comment even claimed it matched the slug). So `gori run --project=api-2` couldn't resolve by slug.

## Proposal implemented

Give each project a stable, opaque, **name-independent** short id, resolvable by unique prefix like a git short SHA.

- **`.id` sidecar** (parallel to `.name`/`.workspace`) — a small file read, never a DB open. Written **write-if-absent at create time**; `id_of` returns `nil` for legacy projects.
- **Centralized resolution in `ProjectRegistry#find`**: `exact id → exact slug → exact display name → unique id-prefix`. Exact matches precede the prefix pass, so a hex-like display name can never be shadowed by another project's id-prefix; an ambiguous prefix resolves to nothing rather than guessing.
- **`CLI::Run.resolve_read_project` routed through `find`** — fixes the comment/behavior mismatch; `gori run --project` now resolves by id / id-prefix / slug / name (parity with MCP).
- **Surfaced the id**: `gori run project list` (text + json), MCP `list/create/switch/delete_project` results, and `project_info` / `get_current_context` (`project_id`, threaded `Selection → Server → Tools`).

### Decisions (per issue)

- **ID format:** short hex, `Random::Secure.hex(4)` → 8 chars (collision-checked, re-rolled).
- **Legacy backfill:** none — `.id`-less projects stay addressable by slug/name, zero migration, no write-on-read.

## Verification

- Full suite **1877 examples, 0 failures** (7 new registry specs + 2 resolver assertions: exact-id, unique-prefix, ambiguous→nil, hex-name-no-shadow, rename-stable, reopen-stable, legacy-no-backfill).
- Drove the real binary: resolution picks the **correct** project by id-prefix / slug / exact id / display name; reproduced the rename-drift case (`api` → `Payment API`, slug frozen at `api`) where all of `Payment API` / `api` / `<id>` / `<id-prefix>` resolve to the same project; `gori mcp --project=<id-prefix>` → `project_info` reports the stable `project_id`.
- Zero new ameba findings (complexity numbers identical to `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)