### PR TITLE
feat(tui): env value peek, always-on § markers, CHAIN Tab-accept

### DIFF
--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -1115,7 +1115,7 @@ describe Gori::MCP::Server do
         port = start_mcp_http_origin("repeater-ok")
         rid = store.insert_repeater(target: "http://127.0.0.1:#{port}",
           request: "GET /rep HTTP/1.1\r\nHost: 127.0.0.1:#{port}\r\n\r\n",
-          http2: false, auto_cl: true, flow_id: nil, position: 0, sni: nil, mark_transform: false)
+          http2: false, auto_cl: true, flow_id: nil, position: 0, sni: nil)
         call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"send_request","arguments":{"repeater_id":#{rid},"allow_unscoped":true}}})
         p = tool_payload(drive(store, call, verify_upstream: false)[0])
         p["status"].as_i.should eq(200)
@@ -1128,7 +1128,7 @@ describe Gori::MCP::Server do
       with_store do |store|
         rid = store.insert_repeater(target: "http://127.0.0.1:9",
           request: "GET /ws HTTP/1.1\r\nHost: 127.0.0.1:9\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: x\r\nSec-WebSocket-Version: 13\r\n\r\n",
-          http2: false, auto_cl: true, flow_id: nil, position: 0, sni: nil, mark_transform: false)
+          http2: false, auto_cl: true, flow_id: nil, position: 0, sni: nil)
         call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"send_request","arguments":{"repeater_id":#{rid},"allow_unscoped":true}}})
         resp = drive(store, call)[0]["result"]
         resp["isError"].as_bool.should be_true
@@ -1392,7 +1392,7 @@ describe Gori::MCP::Server do
       with_store do |store|
         rid = store.insert_repeater(target: "https://h.test",
           request: "GET / HTTP/1.1\r\nHost: h.test\r\nAuthorization: Bearer topsecret\r\n\r\n",
-          http2: false, auto_cl: true, flow_id: nil, position: 0, sni: nil, mark_transform: false)
+          http2: false, auto_cl: true, flow_id: nil, position: 0, sni: nil)
         call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_repeater_context","arguments":{"id":#{rid},"include_content":true}}})
         p = tool_payload(drive(store, call)[0])
         p["sensitive_headers_redacted"].as_bool.should be_true

--- a/spec/store/entity_links_spec.cr
+++ b/spec/store/entity_links_spec.cr
@@ -78,7 +78,6 @@ describe "entity_links (V21)" do
         "INSERT INTO issues (id, created_at, updated_at, title, severity, host, flow_id, notes, status) " \
         "VALUES (1, 5, 5, 'legacy', 2, 'a.test', ?, '', 0)", fid)
       store.@db.exec("DROP TABLE entity_links")
-      store.@db.exec("ALTER TABLE repeaters DROP COLUMN mark_transform")        # V22 (added a column to a pre-V17 table)
       store.@db.exec("DROP INDEX idx_flows_sizes")                            # V23
       store.@db.exec("DROP INDEX idx_ws_messages_replay")                      # V26 (index keeps its historical name)
       store.@db.exec("ALTER TABLE ws_messages DROP COLUMN repeater_id")         # V26

--- a/spec/store/store_spec.cr
+++ b/spec/store/store_spec.cr
@@ -45,7 +45,6 @@ describe Gori::Store do
       store.@db.exec("DROP TABLE miner_sessions")                      # V19
       store.@db.exec("DROP TABLE probe_issues")                        # V20
       store.@db.exec("DROP TABLE entity_links")                        # V21
-      store.@db.exec("ALTER TABLE repeaters DROP COLUMN mark_transform") # V22 (added a column to a pre-V17 table)
       store.@db.exec("DROP INDEX idx_flows_sizes")                     # V23
       store.@db.exec("DROP INDEX idx_ws_messages_replay")               # V26 (index keeps its historical name)
       store.@db.exec("ALTER TABLE ws_messages DROP COLUMN repeater_id")  # V26
@@ -84,6 +83,7 @@ describe Gori::Store do
       store = Gori::Store.open(path)
       db = store.@db
       db.exec("ALTER TABLE repeaters RENAME TO replays")
+      db.exec("ALTER TABLE replays ADD COLUMN mark_transform INTEGER NOT NULL DEFAULT 0") # V22 col (dropped by V37 on the fresh open) — restore the faithful pre-V32 schema
       db.exec("ALTER TABLE ws_messages RENAME COLUMN repeater_id TO replay_id")
       db.exec("ALTER TABLE probe_issues RENAME COLUMN sample_repeater_id TO sample_replay_id")
       db.exec("ALTER TABLE probe_issues RENAME TO prism_issues")

--- a/spec/store_repeaters_spec.cr
+++ b/spec/store_repeaters_spec.cr
@@ -121,24 +121,6 @@ describe "Gori::Store repeater tabs (v9)" do
     end
   end
 
-  it "round-trips the V22 mark_transform flag (default off, insert + update)" do
-    with_store do |store|
-      # defaults to false when the arg is omitted (existing call sites keep working)
-      id = store.insert_repeater("https://a.test", "GET / HTTP/1.1\r\n\r\n", false, true, nil, 0)
-      store.repeaters.find!(&.id.==(id)).mark_transform?.should be_false
-      store.get_repeater(id).not_nil!.mark_transform?.should be_false
-
-      # explicit on via insert
-      on = store.insert_repeater("https://b.test", "GET / HTTP/1.1\r\n\r\n", false, true, nil, 1, mark_transform: true)
-      store.repeaters.find!(&.id.==(on)).mark_transform?.should be_true
-      store.repeaters_meta.find!(&.id.==(on)).mark_transform?.should be_true
-
-      # flip it via update
-      store.update_repeater(id, "https://a.test", "GET / HTTP/1.1\r\n\r\n", false, true, mark_transform: true)
-      store.repeaters.find!(&.id.==(id)).mark_transform?.should be_true
-    end
-  end
-
   it "round-trips the V31 tags column (default nil, set + clear)" do
     with_store do |store|
       id = store.insert_repeater("https://a.test", "GET / HTTP/1.1\r\n\r\n", false, true, nil, 0)

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -113,8 +113,6 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def repeater_toggle_resp_hex : Nil; end
 
-  def repeater_toggle_mark_transform : Nil; end
-
   def repeater_pretty_request : Nil; end
 
   def fuzz_pretty_template : Nil; end

--- a/spec/tui/chain_pane_spec.cr
+++ b/spec/tui/chain_pane_spec.cr
@@ -40,4 +40,15 @@ describe Gori::Tui::ChainPane do
     pane.handle_key(key(Termisu::Input::Key::Up)).should be_false
     pane.handle_key(key(Termisu::Input::Key::Escape)).should be_false
   end
+
+  it "accepts the converter suggestion on Tab while the popup is open (Tab = ↵ parity)" do
+    pane = ChainPane.new
+    pane.load("")
+    "base64-en".each_char { |c| pane.handle_key(char_key(c)) } # partial → popup opens on base64-encode
+    # Popup open → Tab is OWNED (consumed) and accepts, not left for the focus ring to steal.
+    pane.handle_key(key(Termisu::Input::Key::Tab)).should be_true
+    pane.value.should eq("base64-encode > ") # accepted + chain separator, ready for the next step
+    # Popup now closed → Tab reverts to a focus-exit key (false), so there's still a way out.
+    pane.handle_key(key(Termisu::Input::Key::Tab)).should be_false
+  end
 end

--- a/spec/tui/mouse_spec.cr
+++ b/spec/tui/mouse_spec.cr
@@ -263,7 +263,7 @@ describe "Frame.left_chip_hit / right_badge_hit" do
 end
 
 describe "RepeaterView#chrome_hit" do
-  it "hits response d/x/p chips and request SEND/CL/MARK badges on the border row" do
+  it "hits response d/x/p chips and request SEND/CL/PRETTY badges on the border row" do
     view = RepeaterView.new
     view.load_blank
     rect = Rect.new(0, 0, 100, 24)
@@ -280,16 +280,16 @@ describe "RepeaterView#chrome_hit" do
     view.chrome_hit(rect, resp.x + 12 + 9, resp.y).should eq(:hex) # past " d:diff " + gap
     view.chrome_hit(rect, resp.x + 12 + 9 + 9, resp.y).should eq(:pretty)
 
-    # REQUEST right-chain: rightmost is SEND, then CL, MARK, PRETTY
+    # REQUEST right-chain: rightmost is SEND, then CL, PRETTY
     send_label = " ^R:SEND "
     send_x = (req.right - 1) - send_label.size
     view.chrome_hit(rect, send_x + 1, req.y).should eq(:send)
     cl_label = " ^L:CL "
     cl_x = send_x - cl_label.size
     view.chrome_hit(rect, cl_x + 1, req.y).should eq(:cl)
-    mark_label = " ^K:MARK "
-    mark_x = cl_x - mark_label.size
-    view.chrome_hit(rect, mark_x + 1, req.y).should eq(:mark)
+    pretty_label = " ^U:PRETTY "
+    pretty_x = cl_x - pretty_label.size
+    view.chrome_hit(rect, pretty_x + 1, req.y).should eq(:pretty_req)
 
     # Body click (not on border chrome) → nil so caret path still runs
     view.chrome_hit(rect, resp.x + 2, resp.y + 2).should be_nil

--- a/spec/tui/repeater_view_spec.cr
+++ b/spec/tui/repeater_view_spec.cr
@@ -217,12 +217,12 @@ describe Gori::Tui::RepeaterView do
     view.request_text.includes?("Content-Length: 99").should be_false
   end
 
-  it "reflects the RENDERED Content-Length when MARK transform + auto-CL are both on" do
+  it "reflects the RENDERED Content-Length when a §…§ marker + auto-CL are both on" do
     view = RepeaterView.new
-    # auto-CL (^L) on and MARK transform (^K) on. Body q=§hi§ is 8 raw bytes but renders
-    # to q=hi (4 bytes) — the value ^R actually sends.
+    # auto-CL (^L) on; §…§ markers are always active (no mode). Body q=§hi§ is 8 raw bytes
+    # but renders to q=hi (4 bytes) — the value ^R actually sends.
     view.restore("https://a.test",
-      "POST /x HTTP/1.1\nHost: a.test\nContent-Length: 0\n\nq=§hi§", false, true, mark_transform: true)
+      "POST /x HTTP/1.1\nHost: a.test\nContent-Length: 0\n\nq=§hi§", false, true)
     String.new(view.request_bytes).includes?("Content-Length: 4").should be_true # what ^R sends
     view.request_text.includes?("Content-Length: 4").should be_true              # editor matches (was 8)
     view.request_text.includes?("Content-Length: 8").should be_false
@@ -239,11 +239,11 @@ describe Gori::Tui::RepeaterView do
     view.request_text.includes?("Content-Length: 99").should be_false
   end
 
-  it "MARK transform off (default) sends § verbatim — byte-identical to today" do
+  it "sends a lone § (no complete §…§ region) verbatim — byte-identical to today" do
     view = RepeaterView.new
-    view.restore("https://a.test", "POST /x HTTP/1.1\nHost: a.test\n\nq=§hi§", false, false)
-    view.mark_transform?.should be_false
-    String.new(view.request_bytes).should eq("POST /x HTTP/1.1\r\nHost: a.test\r\n\r\nq=§hi§")
+    # a single § doesn't form a §…§ region, so there's nothing to render — sent as typed.
+    view.restore("https://a.test", "POST /x HTTP/1.1\nHost: a.test\n\nq=§hi", false, false)
+    String.new(view.request_bytes).should eq("POST /x HTTP/1.1\r\nHost: a.test\r\n\r\nq=§hi")
   end
 
   it "does not double CRLF when a $KEY value carries its own CRLF" do
@@ -263,29 +263,20 @@ describe Gori::Tui::RepeaterView do
     end
   end
 
-  it "MARK transform on applies a marker's inline chain on send + resyncs Content-Length" do
+  it "applies a §…§ marker's inline chain on send + resyncs Content-Length" do
     view = RepeaterView.new
     view.restore("https://a.test",
       "POST /x HTTP/1.1\nHost: a.test\nContent-Length: 99\n\ntok=§secret¦base64-encode§", false, true)
-    view.toggle_mark_transform
-    view.mark_transform?.should be_true
     sent = String.new(view.request_bytes)
     sent.includes?("tok=c2VjcmV0").should be_true       # base64("secret") == c2VjcmV0
     sent.includes?("Content-Length: 12").should be_true # body "tok=c2VjcmV0" is 12 bytes
     sent.includes?("Content-Length: 99").should be_false
   end
 
-  it "restore round-trips the MARK transform flag" do
-    view = RepeaterView.new
-    view.restore("https://a.test", "GET / HTTP/1.1\n\n", false, true, mark_transform: true)
-    view.mark_transform?.should be_true
-  end
-
-  it "MARK CHAIN pane: focus a marker, type a chain, commit writes it back" do
+  it "CHAIN pane: focus a marker, type a chain, commit writes it back" do
     view = RepeaterView.new
     # marker at offset 0 → set_text zeroes the cursor, so it sits inside §v§
     view.restore("https://a.test", "§v§ HTTP/1.1\nHost: a.test\n\n", false, false)
-    view.toggle_mark_transform
     view.chain_pane_active?.should be_false
     view.focus_pane(:request)
     view.focus_chain_pane.should be_nil # in a marker → enters the pane (no hint)
@@ -296,15 +287,28 @@ describe Gori::Tui::RepeaterView do
     view.request_text.should contain("§v¦md5§")
   end
 
-  it "MARK CHAIN pane hints when MARK is off or the cursor isn't in a marker" do
+  it "CHAIN pane hints when the cursor isn't in a §…§ marker" do
     view = RepeaterView.new
     view.restore("https://a.test", "GET / HTTP/1.1\n\n", false, false)
     view.focus_pane(:request)
-    view.focus_chain_pane.should_not be_nil # MARK off → hint, not activated
+    view.focus_chain_pane.should_not be_nil # no marker under the cursor → hint, not activated
     view.chain_pane_active?.should be_false
-    view.toggle_mark_transform
-    view.focus_chain_pane.should_not be_nil # MARK on but no marker under the cursor → hint
-    view.chain_pane_active?.should be_false
+  end
+
+  it "shows the CHAIN pane only while the cursor is inside a §…§ marker (no mode toggle)" do
+    # Cursor at offset 0 sits INSIDE the leading §v§ marker → CHAIN pane is split in.
+    inside = RepeaterView.new
+    inside.restore("https://a.test", "§v§ HTTP/1.1\nHost: a.test\n\n", false, false)
+    b_in = MemoryBackend.new(120, 24)
+    inside.render(Screen.new(b_in), Rect.new(0, 0, 120, 24))
+    b_in.contains?("CHAIN").should be_true
+
+    # Same buffer shape, but the marker is past the caret (offset 0 is on 'G') → no CHAIN pane.
+    outside = RepeaterView.new
+    outside.restore("https://a.test", "GET §v§ HTTP/1.1\nHost: a.test\n\n", false, false)
+    b_out = MemoryBackend.new(120, 24)
+    outside.render(Screen.new(b_out), Rect.new(0, 0, 120, 24))
+    b_out.contains?("CHAIN").should be_false
   end
 
   it "load_grpc keeps the framed body byte-exact and the head editable" do
@@ -832,7 +836,7 @@ describe Gori::Tui::RepeaterView do
     view.focus_pane(:response)
 
     view.apply_peer_request("https://peer.example", "GET /peer HTTP/1.1\nHost: peer.example\n\n",
-      false, true, sni: "", mark_transform: false)
+      false, true, sni: "")
 
     view.focus.should eq(:response)
     view.target.should eq("https://peer.example")
@@ -848,11 +852,11 @@ describe Gori::Tui::RepeaterView do
     view = RepeaterView.new
     view.load_blank
     view.request_side_matches?(view.target, view.request_text, view.http2?,
-      view.auto_content_length?, view.mark_transform?, nil).should be_true
+      view.auto_content_length?, nil).should be_true
     view.request_side_matches?(view.target, view.request_text, view.http2?,
-      view.auto_content_length?, view.mark_transform?, "").should be_true
+      view.auto_content_length?, "").should be_true
     view.request_side_matches?(view.target, view.request_text, view.http2?,
-      view.auto_content_length?, view.mark_transform?, "evil.com").should be_false
+      view.auto_content_length?, "evil.com").should be_false
   end
 
   it "post-send store response write + peer request sync keeps the applied result" do
@@ -864,7 +868,7 @@ describe Gori::Tui::RepeaterView do
       view = RepeaterView.new
       view.load_blank
       rid = store.insert_repeater(view.target, view.request_text, view.http2?, view.auto_content_length?,
-        nil, 0, view.sni_override, mark_transform: view.mark_transform?)
+        nil, 0, view.sni_override)
       view.clear_dirty
       ok = Gori::Repeater::Result.new("HTTP/1.1 200 OK\r\n\r\n".to_slice, "KEEPME".to_slice, nil, 500_i64)
       view.apply(ok)
@@ -875,14 +879,14 @@ describe Gori::Tui::RepeaterView do
       row = store.repeaters_meta.find { |r| r.id == rid }.not_nil!
       # Own row still matches → reconcile would skip. Force a peer-like request edit.
       store.update_repeater(rid, "https://peer.test", "GET /from-peer HTTP/1.1\nHost: peer.test\n\n",
-        false, true, nil, false)
+        false, true, nil)
       store.flush
       row = store.repeaters_meta.find { |r| r.id == rid }.not_nil!
       view.request_side_matches?(row.target, row.request, row.http2?,
-        row.auto_content_length?, row.mark_transform?, row.sni).should be_false
+        row.auto_content_length?, row.sni).should be_false
 
       view.apply_peer_request(row.target, row.request, row.http2?, row.auto_content_length?,
-        sni: row.sni || "", mark_transform: row.mark_transform?)
+        sni: row.sni || "")
       view.focus.should eq(:response)
       view.target.should eq("https://peer.test")
       backend = MemoryBackend.new(120, 20)

--- a/spec/tui/text_area_spec.cr
+++ b/spec/tui/text_area_spec.cr
@@ -1,9 +1,22 @@
 require "../spec_helper"
+require "../support/memory_backend"
 
 include Gori::Tui
 
 private def env_key(k : Termisu::Input::Key)
   Termisu::Event::Key.new(k)
+end
+
+# Render `text` with the caret parked `cx` columns in and env-peek enabled, then return
+# the painted screen (cursor = INSERT mode, peek = the read-mode value-peek flag).
+private def render_peek(text : String, cx : Int32, cursor : Bool, peek : Bool) : MemoryBackend
+  ta = Gori::Tui::TextArea.new(text)
+  ta.env_complete = true # enables the paired value peek too
+  ta.move(0, cx)         # slide the caret into the token
+  backend = MemoryBackend.new(60, 8)
+  ta.render(Gori::Tui::Screen.new(backend), Gori::Tui::Rect.new(0, 0, 60, 8),
+    cursor: cursor, highlight: :request, peek: peek)
+  backend
 end
 
 describe Gori::Tui::TextArea do
@@ -155,6 +168,44 @@ describe Gori::Tui::TextArea do
       ta.env_complete = true
       ta.insert('$')
       ta.env_completing?.should be_false
+    end
+  end
+
+  describe "#env_peek ($ENV value peek)" do
+    before_each do
+      Gori::Settings.env_prefix = "$"
+      Gori::Settings.env_vars = [{"HOST", "api.test"}, {"TOKEN", "s3cr3t-value"}]
+      Gori::Settings.project_env_vars = [] of {String, String}
+    end
+
+    after_each do
+      Gori::Settings.env_vars = [] of {String, String}
+      Gori::Settings.project_env_vars = [] of {String, String}
+      Gori::Settings.env_prefix = "$"
+    end
+
+    it "reveals a complete $KEY's resolved value under the caret in NORMAL mode (peek)" do
+      # "k=$TOKEN" — caret at col 4 sits inside the TOKEN key run; not insert (cursor:false).
+      render_peek("k=$TOKEN", 4, false, true).contains?("s3cr3t-value").should be_true
+    end
+
+    it "also reveals the value in INSERT mode when the autocomplete isn't offering matches" do
+      # Caret at col 8 = end of a fully-typed unique $TOKEN → the dropdown closes, peek shows.
+      render_peek("k=$TOKEN", 8, true, false).contains?("s3cr3t-value").should be_true
+    end
+
+    it "stays hidden for an unregistered $KEY (a literal $word is just text, not a var)" do
+      # $NOPE isn't a registered var → no peek row; row 1 (below the caret) stays blank.
+      # The literal "k=$NOPE" still paints on row 0 as ordinary editor text.
+      render_peek("k=$NOPE", 4, false, true).row(1).strip.should be_empty
+    end
+
+    it "stays hidden when the pane is neither focused-insert nor peeking" do
+      render_peek("k=$TOKEN", 4, false, false).contains?("s3cr3t-value").should be_false
+    end
+
+    it "stays hidden when the caret isn't on an env token" do
+      render_peek("k=$TOKEN", 1, false, true).contains?("s3cr3t-value").should be_false
     end
   end
 end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -208,10 +208,6 @@ private class FakeContext < ExecContext
     @calls << :repeater_toggle_resp_hex
   end
 
-  def repeater_toggle_mark_transform : Nil
-    @calls << :repeater_toggle_mark_transform
-  end
-
   def repeater_pretty_request : Nil
     @calls << :repeater_pretty_request
   end

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -521,7 +521,6 @@ module Gori
                     j.field "auto_content_length", r.auto_content_length?
                     j.field "flow_id", r.flow_id
                     j.field "sni", r.sni
-                    j.field "mark_transform", r.mark_transform?
                     j.field "last_error", r.response_error
                     j.field "last_duration_us", r.response_duration_us
                   end
@@ -556,7 +555,6 @@ module Gori
         auto_cl = true
         flow_id : Int64? = nil
         sni : String? = nil
-        mark_transform = false
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run repeater create [options]"
@@ -570,7 +568,6 @@ module Gori
           p.on("--no-auto-cl", "Do not auto-calculate Content-Length header") { auto_cl = false }
           p.on("--flow=ID", "Optional original flow ID this repeater stems from") { |v| flow_id = parse_flow_id(v) }
           p.on("--sni=HOST", "TLS SNI override") { |v| sni = v }
-          p.on("--mark-transform", "Enable token substitution replacement (default: false)") { mark_transform = true }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.invalid_option { |f| abort "gori run repeater create: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run repeater create: missing value for #{f}" }
@@ -628,8 +625,7 @@ module Gori
             auto_cl: auto_cl,
             flow_id: flow_id,
             position: pos.to_i32,
-            sni: sni,
-            mark_transform: mark_transform
+            sni: sni
           )
 
           abort "gori run repeater create: failed to create repeater session" if id == 0

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -549,7 +549,6 @@ module Gori
               s.field "issue_id", intprop("optional issue id to populate target/request/messages from")
               s.field "position", intprop("tab position order index (optional, defaults to appending at end)")
               s.field "sni", strprop("optional TLS Server Name Indication override")
-              s.field "mark_transform", boolprop("optional boolean indicating token substitution replacement is active (default false)")
               s.field "name", strprop("optional custom name for the repeater tab")
               s.field "ws_out_messages", arr_or_str_prop("optional array of strings (or a newline-separated string) representing outbound WebSocket messages")
             end
@@ -561,7 +560,6 @@ module Gori
               s.field "http2", boolprop("use HTTP/2")
               s.field "auto_content_length", boolprop("auto-calculate Content-Length")
               s.field "sni", strprop("TLS SNI override")
-              s.field "mark_transform", boolprop("token substitution replacement active")
               s.field "name", strprop("custom name for the repeater tab")
               s.field "ws_out_messages", arr_or_str_prop("optional array of strings (or a newline-separated string) representing outbound WebSocket messages")
             end
@@ -1451,7 +1449,6 @@ module Gori
           j.field "target", r.target
           j.field "http2", r.http2?
           j.field "auto_content_length", r.auto_content_length?
-          j.field "mark_transform", r.mark_transform?
           j.field "flow_id", r.flow_id if r.flow_id
           j.field "name", r.name if r.name
           j.field "sni", r.sni if r.sni
@@ -1902,8 +1899,7 @@ module Gori
           auto_cl: true,
           flow_id: flow_id,
           position: @store.repeaters_meta.size.to_i32,
-          sni: nil,
-          mark_transform: false
+          sni: nil
         )
         return nil unless repeater_id > 0
 
@@ -2636,7 +2632,6 @@ module Gori
         return Result.new("missing required 'request'", is_error: true) if request.nil? || request.empty?
 
         sni = str(h, "sni")
-        mark_transform = bool(h, "mark_transform") || false
 
         position = int(h, "position")
         if position.nil?
@@ -2662,8 +2657,7 @@ module Gori
           auto_cl: auto_cl,
           flow_id: flow_id,
           position: position.to_i32,
-          sni: masked_sni,
-          mark_transform: mark_transform
+          sni: masked_sni
         )
 
         return busy("failed to persist repeater (store busy or unwritable)") if id == 0
@@ -2742,12 +2736,6 @@ module Gori
 
         sni = present?(h, "sni") ? str(h, "sni") : existing.sni
 
-        mark_transform = if present?(h, "mark_transform")
-                           bool(h, "mark_transform") || false
-                         else
-                           existing.mark_transform?
-                         end
-
         masked_target = Env.mask_secrets(target)
         masked_request = Env.mask_secrets(request)
         masked_sni = sni.try { |s| Env.mask_secrets(s) }
@@ -2759,8 +2747,7 @@ module Gori
           request: masked_request,
           http2: http2,
           auto_cl: auto_cl,
-          sni: masked_sni,
-          mark_transform: mark_transform
+          sni: masked_sni
         )
 
         if present?(h, "name")
@@ -3780,7 +3767,7 @@ module Gori
         return if head.empty?
         rec = Store::RepeaterRecord.new(
           repeater_id, target, request, http2, true, flow_id, 0,
-          head, body, nil, duration_us, nil, nil, false)
+          head, body, nil, duration_us, nil, nil)
         return unless detail = Probe.detail_from_repeater(rec)
         Probe::Passive.analyze(detail).each do |d|
           @store.upsert_probe_issue(Probe.with_source(d, flow_id: flow_id, repeater_id: repeater_id))

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -815,13 +815,13 @@ module Gori
     # (potentially multi-MB) response on each cross-session commit.
     def repeaters : Array(RepeaterRecord)
       list = [] of RepeaterRecord
-      @db.query("SELECT id, target, request, http2, auto_content_length, flow_id, position, response_head, response_body, response_error, response_duration_us, name, sni, mark_transform, tags FROM repeaters ORDER BY position, id") do |rs|
+      @db.query("SELECT id, target, request, http2, auto_content_length, flow_id, position, response_head, response_body, response_error, response_duration_us, name, sni, tags FROM repeaters ORDER BY position, id") do |rs|
         rs.each do
           list << RepeaterRecord.new(
             rs.read(Int64), rs.read(String), rs.read(String),
             rs.read(Int32) != 0, rs.read(Int32) != 0, rs.read(Int64?), rs.read(Int32),
             rs.read(Bytes?), rs.read(Bytes?), rs.read(String?), rs.read(Int64?), rs.read(String?), rs.read(String?),
-            mark_transform: rs.read(Int32) != 0, tags: rs.read(String?))
+            tags: rs.read(String?))
         end
       end
       list
@@ -832,12 +832,12 @@ module Gori
     # response (responses are personal per session). Response fields stay nil.
     def get_repeater(id : Int64) : RepeaterRecord?
       @db.query(
-        "SELECT id, target, request, http2, auto_content_length, flow_id, position, sni, mark_transform, name FROM repeaters WHERE id = ?",
+        "SELECT id, target, request, http2, auto_content_length, flow_id, position, sni, name FROM repeaters WHERE id = ?",
         id) do |rs|
         return RepeaterRecord.new(
           rs.read(Int64), rs.read(String), rs.read(String),
           rs.read(Int32) != 0, rs.read(Int32) != 0, rs.read(Int64?), rs.read(Int32),
-          sni: rs.read(String?), mark_transform: rs.read(Int32) != 0, name: rs.read(String?)) if rs.move_next
+          sni: rs.read(String?), name: rs.read(String?)) if rs.move_next
       end
       nil
     end
@@ -848,14 +848,14 @@ module Gori
     def get_repeater_full(id : Int64) : RepeaterRecord?
       @db.query(
         "SELECT id, target, request, http2, auto_content_length, flow_id, position, " \
-        "response_head, response_body, response_error, response_duration_us, name, sni, mark_transform, tags " \
+        "response_head, response_body, response_error, response_duration_us, name, sni, tags " \
         "FROM repeaters WHERE id = ?", id) do |rs|
         if rs.move_next
           return RepeaterRecord.new(
             rs.read(Int64), rs.read(String), rs.read(String),
             rs.read(Int32) != 0, rs.read(Int32) != 0, rs.read(Int64?), rs.read(Int32),
             rs.read(Bytes?), rs.read(Bytes?), rs.read(String?), rs.read(Int64?), rs.read(String?), rs.read(String?),
-            mark_transform: rs.read(Int32) != 0, tags: rs.read(String?))
+            tags: rs.read(String?))
         end
       end
       nil
@@ -863,12 +863,12 @@ module Gori
 
     def repeaters_meta : Array(RepeaterRecord)
       list = [] of RepeaterRecord
-      @db.query("SELECT id, target, request, http2, auto_content_length, flow_id, position, sni, mark_transform FROM repeaters ORDER BY position, id") do |rs|
+      @db.query("SELECT id, target, request, http2, auto_content_length, flow_id, position, sni FROM repeaters ORDER BY position, id") do |rs|
         rs.each do
           list << RepeaterRecord.new(
             rs.read(Int64), rs.read(String), rs.read(String),
             rs.read(Int32) != 0, rs.read(Int32) != 0, rs.read(Int64?), rs.read(Int32),
-            sni: rs.read(String?), mark_transform: rs.read(Int32) != 0)
+            sni: rs.read(String?))
         end
       end
       list
@@ -879,13 +879,13 @@ module Gori
     def repeaters_mcp : Array(RepeaterRecord)
       list = [] of RepeaterRecord
       @db.query(
-        "SELECT id, target, request, http2, auto_content_length, flow_id, position, sni, mark_transform, " \
+        "SELECT id, target, request, http2, auto_content_length, flow_id, position, sni, " \
         "name, response_head, response_error, response_duration_us FROM repeaters ORDER BY position, id") do |rs|
         rs.each do
           list << RepeaterRecord.new(
             rs.read(Int64), rs.read(String), rs.read(String),
             rs.read(Int32) != 0, rs.read(Int32) != 0, rs.read(Int64?), rs.read(Int32),
-            sni: rs.read(String?), mark_transform: rs.read(Int32) != 0, name: rs.read(String?),
+            sni: rs.read(String?), name: rs.read(String?),
             response_head: rs.read(Bytes?), response_error: rs.read(String?), response_duration_us: rs.read(Int64?))
         end
       end
@@ -895,21 +895,20 @@ module Gori
     # Returns the new row id (or 0 if the store is closing — the caller normalizes
     # 0 → nil so a later update never targets a bogus row).
     def insert_repeater(target : String, request : String, http2 : Bool,
-                      auto_cl : Bool, flow_id : Int64?, position : Int32, sni : String? = nil,
-                      mark_transform : Bool = false) : Int64
+                      auto_cl : Bool, flow_id : Int64?, position : Int32, sni : String? = nil) : Int64
       ts = now_us
       exec_task ->(c : DB::Connection) {
-        c.exec("INSERT INTO repeaters (created_at, updated_at, target, request, http2, auto_content_length, flow_id, position, sni, mark_transform) VALUES (?,?,?,?,?,?,?,?,?,?)",
-          ts, ts, target, request, http2 ? 1 : 0, auto_cl ? 1 : 0, flow_id, position, sni, mark_transform ? 1 : 0)
+        c.exec("INSERT INTO repeaters (created_at, updated_at, target, request, http2, auto_content_length, flow_id, position, sni) VALUES (?,?,?,?,?,?,?,?,?)",
+          ts, ts, target, request, http2 ? 1 : 0, auto_cl ? 1 : 0, flow_id, position, sni)
         nil
       }
     end
 
     def update_repeater(id : Int64, target : String, request : String, http2 : Bool, auto_cl : Bool,
-                      sni : String? = nil, mark_transform : Bool = false) : Nil
+                      sni : String? = nil) : Nil
       exec_task ->(c : DB::Connection) {
-        c.exec("UPDATE repeaters SET target = ?, request = ?, http2 = ?, auto_content_length = ?, sni = ?, mark_transform = ?, updated_at = ? WHERE id = ?",
-          target, request, http2 ? 1 : 0, auto_cl ? 1 : 0, sni, mark_transform ? 1 : 0, now_us, id)
+        c.exec("UPDATE repeaters SET target = ?, request = ?, http2 = ?, auto_content_length = ?, sni = ?, updated_at = ? WHERE id = ?",
+          target, request, http2 ? 1 : 0, auto_cl ? 1 : 0, sni, now_us, id)
         nil
       }
     end

--- a/src/gori/store/models.cr
+++ b/src/gori/store/models.cr
@@ -345,12 +345,11 @@ module Gori
       getter response_duration_us : Int64?
       getter name : String?         # custom sub-tab label (nil = derive from the request)
       getter sni : String?          # custom TLS SNI host (nil = present the target host)
-      getter? mark_transform : Bool # V22: apply §…§ inline Decoder chains on send
       getter tags : String?         # V31: space-joined flat tags (nil = untagged)
 
       def initialize(@id, @target, @request, @http2, @auto_content_length, @flow_id, @position,
                      @response_head = nil, @response_body = nil, @response_error = nil,
-                     @response_duration_us = nil, @name = nil, @sni = nil, @mark_transform = false,
+                     @response_duration_us = nil, @name = nil, @sni = nil,
                      @tags = nil)
       end
     end

--- a/src/gori/store/schema.cr
+++ b/src/gori/store/schema.cr
@@ -7,7 +7,7 @@ module Gori
     # (FTS5 for QL, a tags table, a connections table) arrive as *later*
     # migrations — which is exactly why none of them exist in v1 (P0).
     module Schema
-      VERSION = 36
+      VERSION = 37
 
       # The migration that reclaims duplicated/low-value bytes already on disk (see V25).
       # Store.open runs a one-time VACUUM after an EXISTING db crosses this version so the
@@ -637,7 +637,15 @@ module Gori
         SQL
       ]
 
-      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21, V22, V23, V24, V25, V26, V27, V28, V29, V30, V31, V32, V33, V34, V35, V36]
+      # Drop the per-repeater MARK-transform toggle: `§…§` markers are now always active
+      # in the Repeater (like the Fuzzer), so the flag no longer gates send behaviour — the
+      # request carries markers or it doesn't. SQLite (>= 3.35, ours is 3.51) supports
+      # ALTER TABLE ... DROP COLUMN; existing rows just lose the (unused) column.
+      V37 = [
+        "ALTER TABLE repeaters DROP COLUMN mark_transform",
+      ]
+
+      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21, V22, V23, V24, V25, V26, V27, V28, V29, V30, V31, V32, V33, V34, V35, V36, V37]
 
       def self.migrate!(db : DB::Database) : Nil
         db.using_connection do |conn|

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -589,8 +589,14 @@ module Gori::Tui
     end
 
     # --- editor $ENV autocomplete + tab-as-text (template pane in insert mode) ---
+    # The CHAIN sub-pane owns Tab while it's focused (like a text editor), so ↹ accepts its
+    # converter suggestion (parity with ↵) instead of the focus ring stealing Tab to switch
+    # panes. Its own converter popup handles ↑/↓/↵/Esc via handle_chain_pane_key already.
     def editor_completing? : Bool
-      current_view.try(&.template_env_completing?) || false
+      v = current_view
+      return false unless v
+      return false if v.chain_pane_active? # CHAIN popup is routed via editor_captures_tab?/handle_editor_tab
+      v.template_env_completing?
     end
 
     def handle_editor_complete_key(ev : Termisu::Event::Key) : Bool
@@ -598,12 +604,20 @@ module Gori::Tui
     end
 
     def editor_captures_tab? : Bool
-      current_view.try(&.template_text_editing?) || false
+      v = current_view
+      return false unless v
+      v.chain_pane_active? || v.template_text_editing?
     end
 
     def handle_editor_tab(ev : Termisu::Event::Key) : Bool
-      return false unless editor_captures_tab?
-      current_view.try(&.template_tab_insert)
+      v = current_view
+      return false unless v
+      if v.chain_pane_active?
+        v.handle_chain_pane_key(ev) # popup open → accept the suggestion (like ↵); closed → commit + leave
+        return true
+      end
+      return false unless v.template_text_editing?
+      v.template_tab_insert
       true
     end
 

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -45,7 +45,7 @@ module Gori::Tui
         end
         view.restore(r.target, r.request, r.http2?, r.auto_content_length?,
           r.response_head, r.response_body, r.response_error, r.response_duration_us,
-          sni: r.sni || "", mark_transform: r.mark_transform?, ws_messages: ws_msgs)
+          sni: r.sni || "", ws_messages: ws_msgs)
         view.name = r.name                     # custom sub-tab label survives reopen
         view.tags = Repeater::Tags.parse(r.tags) # flat tags survive reopen (V31)
         seed_repeater_original(view, r.flow_id)
@@ -548,8 +548,9 @@ module Gori::Tui
       Graphql.from_flow(detail.row.target, detail.request_head, detail.request_body)
     end
 
-    # ^T is context-sensitive: a decode tab or WS tab toggles the envelope/decoded split; a MARK tab
-    # drops a single § at the cursor (Fuzzer parity — the direct-marker keystroke).
+    # ^T is context-sensitive: a decode tab or WS tab toggles the envelope/decoded split;
+    # otherwise it drops a single § marker at the cursor (Fuzzer parity — the direct-marker
+    # keystroke; wrap a value in §…§ to give it an inline Decoder chain, applied on send).
     def repeater_toggle_decoded : Nil
       view = current_view
       return @host.status("no repeater open") unless view
@@ -562,10 +563,8 @@ module Gori::Tui
         else
           @host.status(pane == :decoded ? "editing the decoded payload — edits re-encode into the request on ^R send" : "editing the request envelope (headers · target · params)")
         end
-      elsif view.mark_transform?
-        @host.status(view.insert_marker)
       else
-        @host.status("not a decode/WS flow — ^T inserts a § when MARK is on, or switches the split pane")
+        @host.status(view.insert_marker)
       end
     end
 
@@ -641,18 +640,6 @@ module Gori::Tui
       end
     end
 
-    # MARK transform mode: mark request values (§…§) and attach Decoder chains applied on
-    # send. Off by default so a plain request is byte-identical (a captured § is literal).
-    def repeater_toggle_mark_transform : Nil
-      return unless view = current_view
-      if view.request_hex? || view.grpc_mode? || view.decode_mode? || view.ws_mode?
-        @host.status("MARK transform isn't available in this request mode")
-      else
-        on = view.toggle_mark_transform
-        @host.status(on ? "MARK on · ^A mark all · ^T insert § · ^Y edit chain · ^R send" : "MARK transform: off")
-      end
-    end
-
     def repeater_pretty_request : Nil
       return unless view = current_view
       if err = view.pretty_print_request
@@ -710,7 +697,7 @@ module Gori::Tui
     end
 
     # Map a RepeaterView#chrome_hit id onto the same controller methods keyboard verbs use
-    # (toasts, guards for hex/MARK, host-level pretty).
+    # (toasts, guards for hex, host-level pretty).
     private def apply_chrome_click(view : RepeaterView, chip : Symbol) : Nil
       case chip
       when :diff
@@ -725,9 +712,6 @@ module Gori::Tui
       when :cl
         view.focus_pane(:request)
         repeater_toggle_auto_content_length
-      when :mark
-        view.focus_pane(:request)
-        repeater_toggle_mark_transform
       when :pretty_req
         view.focus_pane(:request)
         repeater_pretty_request
@@ -842,8 +826,14 @@ module Gori::Tui
     end
 
     # --- editor $ENV autocomplete + tab-as-text (request pane in insert mode) ---
+    # The CHAIN sub-pane owns Tab while it's focused (like a text editor), so ↹ accepts its
+    # converter suggestion (parity with ↵) instead of the focus ring stealing Tab to switch
+    # panes. Its own converter popup handles ↑/↓/↵/Esc via handle_chain_pane_key already.
     def editor_completing? : Bool
-      current_view.try(&.request_env_completing?) || false
+      v = current_view
+      return false unless v
+      return false if v.chain_pane_active? # CHAIN popup is routed via editor_captures_tab?/handle_editor_tab
+      v.request_env_completing?
     end
 
     def handle_editor_complete_key(ev : Termisu::Event::Key) : Bool
@@ -851,12 +841,20 @@ module Gori::Tui
     end
 
     def editor_captures_tab? : Bool
-      current_view.try(&.request_text_editing?) || false
+      v = current_view
+      return false unless v
+      v.chain_pane_active? || v.request_text_editing?
     end
 
     def handle_editor_tab(ev : Termisu::Event::Key) : Bool
-      return false unless editor_captures_tab?
-      current_view.try(&.request_tab_insert)
+      v = current_view
+      return false unless v
+      if v.chain_pane_active?
+        v.handle_chain_pane_key(ev) # popup open → accept the suggestion (like ↵); closed → commit + leave
+        return true
+      end
+      return false unless v.request_text_editing?
+      v.request_tab_insert
       true
     end
 
@@ -980,7 +978,7 @@ module Gori::Tui
       return if head.empty?
       rec = Store::RepeaterRecord.new(
         repeater_id, view.target, view.request_text, view.http2?, view.auto_content_length?,
-        flow_id, 0, head, body, nil, duration_us, view.name, view.sni_override, view.mark_transform?)
+        flow_id, 0, head, body, nil, duration_us, view.name, view.sni_override)
       return unless detail = Probe.detail_from_repeater(rec)
       @host.session.probe.scan_detail(detail, repeater_id: repeater_id)
     rescue
@@ -996,7 +994,7 @@ module Gori::Tui
       req_text = upgrade.empty? ? view.request_text : String.new(upgrade).scrub
       rec = Store::RepeaterRecord.new(
         repeater_id, view.target, req_text, false, false,
-        flow_id, 0, head, Bytes.empty, nil, result.duration_us, view.name, view.sni_override, false)
+        flow_id, 0, head, Bytes.empty, nil, result.duration_us, view.name, view.sni_override)
       return unless detail = Probe.detail_from_repeater(rec)
       # Synthetic WsMessage rows (id unused by the rule; opcode 1 = text).
       now = Time.utc.to_unix_ms * 1000
@@ -1060,7 +1058,7 @@ module Gori::Tui
         # Only re-apply when the PERSISTED request side actually changed (data_version
         # also bumps on capture/response writes, so most polls touch an identical row).
         next if v.request_side_matches?(row.target, row.request, row.http2?,
-                  row.auto_content_length?, row.mark_transform?, row.sni)
+                  row.auto_content_length?, row.sni)
         # Soft sync: request/target/flags only. Full restore() would reset focus to
         # :target and clear @result (no response BLOBs on this path) — that is the
         # "send then response vanishes / focus jumps to Target" bug.
@@ -1071,7 +1069,7 @@ module Gori::Tui
           end
         end
         v.apply_peer_request(row.target, row.request, row.http2?, row.auto_content_length?,
-          sni: row.sni || "", mark_transform: row.mark_transform?, ws_messages: ws_msgs)
+          sni: row.sni || "", ws_messages: ws_msgs)
         seed_repeater_original(v, row.flow_id) # baseline may need re-seed if it was empty
       end
 
@@ -1086,7 +1084,7 @@ module Gori::Tui
           end
         end
         view.restore(row.target, row.request, row.http2?, row.auto_content_length?,
-          sni: row.sni || "", mark_transform: row.mark_transform?, ws_messages: ws_msgs)
+          sni: row.sni || "", ws_messages: ws_msgs)
         seed_repeater_original(view, row.flow_id)
         @repeaters << RepeaterTab.new(view, row.flow_id, row.id)
       end
@@ -1214,8 +1212,7 @@ module Gori::Tui
     # reconcile key). A closing store returns 0 → nil, leaving the tab unsaved.
     private def persist_new_repeater(view : RepeaterView, flow_id : Int64?) : Int64?
       id = @host.session.store.insert_repeater(view.target, view.request_text, view.http2?,
-        view.auto_content_length?, flow_id, @repeaters.size, view.sni_override,
-        mark_transform: view.mark_transform?)
+        view.auto_content_length?, flow_id, @repeaters.size, view.sni_override)
       id == 0 ? nil : id
     end
 
@@ -1381,12 +1378,12 @@ module Gori::Tui
         # NOT ws_upgrade_bytes (env-expanded + CRLF): baking the expanded form in would
         # write secrets to the DB and defeat the reconcile guard (which compares LF text).
         @host.session.store.update_repeater(id, v.target, v.request_text, v.http2?, v.auto_content_length?,
-          v.sni_override, mark_transform: v.mark_transform?)
+          v.sni_override)
         # Raw message lines too — the store masks secrets; env tokens re-expand on send.
         @host.session.store.update_repeater_ws_messages(id, v.ws_out_texts_raw)
       else
         @host.session.store.update_repeater(id, v.target, v.request_text, v.http2?, v.auto_content_length?,
-          v.sni_override, mark_transform: v.mark_transform?)
+          v.sni_override)
       end
       v.clear_dirty
     end

--- a/src/gori/tui/env_peek.cr
+++ b/src/gori/tui/env_peek.cr
@@ -1,0 +1,62 @@
+require "./screen"
+require "./theme"
+
+module Gori::Tui
+  # A caret-anchored, single-row tooltip that reveals the resolved value of the
+  # `$KEY` env token UNDER THE CURSOR — the read-mode (and past-typing) counterpart
+  # to EnvComplete's typing-time autocomplete. The owning TextArea resolves the
+  # {key, value} for the REGISTERED token spanning the caret and feeds it via `set`
+  # (an unknown `$word` gets no peek); this holds only open state + rendering.
+  # Non-interactive (no selection or accept): a pure value peek. Anchored at the
+  # caret CELL, like EnvComplete.
+  class EnvPeek
+    getter? open : Bool = false
+    @key = ""
+    @value = ""
+    @prefix = "$"
+
+    # Replace the shown token (opens the peek). Only registered `$KEY`s reach here — the
+    # owner passes the resolved value; an unknown `$word` gets no peek (it's just text).
+    def set(key : String, value : String, prefix : String) : Nil
+      @key = key
+      @value = value
+      @prefix = prefix
+      @open = true
+    end
+
+    def close : Nil
+      @open = false
+    end
+
+    # Draw the tooltip anchored at the caret cell (ax, ay). Prefers to open BELOW the
+    # caret (row ay+1); flips ABOVE (ay-1) when there's more room there. Clamped inside
+    # `bounds` (the editor's content rect) so it never paints past the pane.
+    def render(screen : Screen, ax : Int32, ay : Int32, bounds : Rect) : Nil
+      return if !@open || bounds.w < 4 || bounds.h < 2
+      below = bounds.bottom - (ay + 1) # rows available under the caret
+      above = ay - bounds.y            # rows available over the caret
+      return if below <= 0 && above <= 0
+      down = below >= above
+      w = box_width(bounds)
+      x = ax.clamp(bounds.x, {bounds.right - w, bounds.x}.max)
+      y = down ? ay + 1 : ay - 1
+      draw_row(screen, x, y, w)
+    end
+
+    # Box width = `$KEY` + a space + the value, floored at 10, clamped to bounds.
+    private def box_width(bounds : Rect) : Int32
+      key_w = @prefix.size + @key.size
+      val_w = Screen.display_width(@value)
+      ({key_w + val_w + 3, 10}.max).clamp(1, bounds.w)
+    end
+
+    # One tooltip row: a fill band, the `$KEY`, then the dim value (mirrors an EnvComplete
+    # row so the peek reads as the same surface).
+    private def draw_row(screen : Screen, x : Int32, y : Int32, w : Int32) : Nil
+      bg = Theme.elevated
+      screen.fill(Rect.new(x, y, w, 1), bg)
+      kx = screen.text(x + 1, y, "#{@prefix}#{@key}", Theme.env_known, bg, width: {w - 1, 1}.max)
+      screen.text(kx + 1, y, @value, Theme.muted, bg, width: {x + w - kx - 1, 0}.max) if kx + 1 < x + w
+    end
+  end
+end

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -1483,7 +1483,7 @@ module Gori::Tui
       @editor.bg_regions = bg
       inner = rect.inset(1, 1)
       read_active = focused && !ins
-      @editor.render(screen, inner, cursor: ins, highlight: :request)
+      @editor.render(screen, inner, cursor: ins, highlight: :request, peek: focused)
       paint_template_read_chrome(screen, inner, read_active)
     end
 

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -140,24 +140,24 @@ module Gori::Tui
       @inflight = false           # a repeater round-trip is outstanding — gates re-send (^R mashing)
       @diffable = false           # true only when loaded from a captured flow (has an original to diff)
       @auto_content_length = true # recompute Content-Length from the edited body on send
-      # Mark-transform mode (V22, opt-in, default off): when on, `§…§` markers in the
-      # request carry inline Decoder chains applied on send (mark a value, attach
-      # base64-encode → it's encoded on the wire). Off = byte-identical to a plain send,
-      # so a captured `§` is never reinterpreted unless the user turns this on.
-      @mark_transform = false
+      # `§…§` markers carry inline Decoder chains applied on send (mark a value, attach
+      # base64-encode → it's encoded on the wire). Always active (like the Fuzzer): a request
+      # that contains a marker region renders it on send, a marker-free request is byte-
+      # identical to a plain send. Highlighting + the CHAIN pane surface contextually — no mode.
       @marker_regions_rev = -1
       @marker_regions_cache = [] of {Int32, Int32, Int32}
       # §…§ spans + the chain under the cursor, cached on the editor revision (marked_spans)
       # and on {revision, cursor} (chain_at) — both re-join the whole buffer, so an unchanged
-      # MARK/CHAIN pane shouldn't recompute them every frame (mirrors marker_regions).
+      # request/CHAIN pane shouldn't recompute them every frame (mirrors marker_regions).
       @marker_spans_rev = -1
       @marker_spans_cache = [] of {Int32, Int32}
       @chain_rev = -1
       @chain_cursor = -1
       @chain_cache = nil.as(String?)
-      # The CHAIN sub-pane (MARK mode): a visible editor for the chain of the §…§ marker
-      # under the request cursor. @chain_focused = editing it (split enlarges + keys route
-      # there); @chain_marker_cursor remembers which marker to write back to on commit.
+      # The CHAIN sub-pane: a visible editor for the chain of the §…§ marker under the
+      # request cursor, split in only while the cursor is in a marker. @chain_focused =
+      # editing it (split enlarges + keys route there); @chain_marker_cursor remembers which
+      # marker to write back to on commit.
       @chain_pane = ChainPane.new
       @chain_focused = false
       @chain_marker_cursor = 0
@@ -491,7 +491,6 @@ module Gori::Tui
       j.field "summary", summary(80)
       j.field "http2", @http2
       j.field "auto_content_length", @auto_content_length
-      j.field "mark_transform", @mark_transform
       j.field "ws_mode", @ws_mode
       j.field "grpc_mode", @grpc_mode
       j.field "decode_mode", decode_mode?
@@ -965,10 +964,10 @@ module Gori::Tui
     def restore(target : String, request : String, http2 : Bool, auto_cl : Bool,
                 response_head : Bytes? = nil, response_body : Bytes? = nil,
                 response_error : String? = nil, response_duration_us : Int64? = nil,
-                sni : String = "", mark_transform : Bool = false,
+                sni : String = "",
                 ws_messages : Array(String)? = nil) : Nil
       @flow = nil
-      apply_request_fields(target, request, http2, auto_cl, sni, mark_transform, ws_messages)
+      apply_request_fields(target, request, http2, auto_cl, sni, ws_messages)
 
       @original_lines = [] of String
       # Rebuild the persisted result: a head (success) or an error (failed send)
@@ -996,9 +995,9 @@ module Gori::Tui
     # @result (reconcile never carries response BLOBs), so a post-send data_version
     # bump or a peer request edit looked like "send reset the response to Target".
     def apply_peer_request(target : String, request : String, http2 : Bool, auto_cl : Bool,
-                           sni : String = "", mark_transform : Bool = false,
+                           sni : String = "",
                            ws_messages : Array(String)? = nil) : Nil
-      apply_request_fields(target, request, http2, auto_cl, sni, mark_transform, ws_messages)
+      apply_request_fields(target, request, http2, auto_cl, sni, ws_messages)
       @req_hex_edit = nil
       # Leave @result / @prev_result / @focus / @scroll / @resp_mode / @original_lines alone.
       reflect_content_length_in_editor if @auto_content_length
@@ -1008,16 +1007,15 @@ module Gori::Tui
     # Normalizes empty SNI: view.sni_override is nil when blank, but older/peer rows
     # may store "" — those must compare equal or every poll re-applies needlessly.
     def request_side_matches?(target : String, request : String, http2 : Bool, auto_cl : Bool,
-                              mark_transform : Bool, sni : String?) : Bool
+                              sni : String?) : Bool
       @target == target && request_text == request &&
         @http2 == http2 && @auto_content_length == auto_cl &&
-        @mark_transform == mark_transform &&
         (sni_override || "") == (sni || "")
     end
 
     # Shared request/target/flag write used by restore (full) and apply_peer_request (soft).
     private def apply_request_fields(target : String, request : String, http2 : Bool, auto_cl : Bool,
-                                     sni : String, mark_transform : Bool,
+                                     sni : String,
                                      ws_messages : Array(String)?) : Nil
       @http2 = http2
       @target = target
@@ -1040,7 +1038,6 @@ module Gori::Tui
       end
 
       @auto_content_length = auto_cl
-      @mark_transform = mark_transform
       @loaded = true
       @dirty = false
     end
@@ -1098,7 +1095,6 @@ module Gori::Tui
       @scx = @sni.size
       @target_field = :url
       @auto_content_length = src.@auto_content_length
-      @mark_transform = src.@mark_transform
       @name = SubtabClone.copy_name(src.@name)
 
       @ws_mode = src.@ws_mode
@@ -1168,7 +1164,7 @@ module Gori::Tui
       return grpc_request_bytes if @grpc_mode                 # edited head + reframed body (owns its own hex buffer)
       return @req_hex_edit.not_nil!.to_bytes if @req_hex_edit # byte-exact; NO auto-CL in hex mode
       return decoded_request_bytes if @decode_kind            # envelope + re-encoded decoded payload
-      return marked_request_bytes if @mark_transform          # §…§ inline Decoder chains applied on send
+      return marked_request_bytes unless marker_regions.empty? # §…§ inline Decoder chains applied on send
       raw = expanded_editor_bytes
       @auto_content_length ? sync_content_length(raw) : raw
     end
@@ -1186,22 +1182,21 @@ module Gori::Tui
       Env.expand_wire(text)
     end
 
-    # MARK-transform mode: parse the CRLF wire form as a Fuzz template and render each
-    # marked position's default through its inline Decoder chain (Template#apply_chains),
-    # then resync Content-Length as usual. Parsing the CRLF form (not @editor.text, which
-    # is LF) keeps render's output in wire form so the existing CRLF-based
-    # sync_content_length works unchanged. A chain-less `§v§` renders `v`; a failing chain
-    # passes the value through untransformed.
+    # §…§ marker send: parse the CRLF wire form as a Fuzz template and render each marked
+    # position's default through its inline Decoder chain (Template#apply_chains), then
+    # resync Content-Length as usual. Parsing the CRLF form (not @editor.text, which is LF)
+    # keeps render's output in wire form so the existing CRLF-based sync_content_length works
+    # unchanged. A chain-less `§v§` renders `v`; a failing chain passes the value through.
     private def marked_request_bytes : Bytes
       raw = render_marked(expanded_editor_bytes)
       @auto_content_length ? sync_content_length(raw) : raw
     end
 
     # Render the §…§ template in `raw` (each marked default through its inline Decoder
-    # chain), returning wire-form bytes with the markers stripped. Shared by the
-    # MARK-transform send AND the CL reflection so both derive Content-Length from the
-    # SAME rendered body — otherwise the visible header showed a CL for the raw marked
-    # text while ^R sent one for the rendered body.
+    # chain), returning wire-form bytes with the markers stripped. Shared by the marker
+    # send AND the CL reflection so both derive Content-Length from the SAME rendered body —
+    # otherwise the visible header showed a CL for the raw marked text while ^R sent one for
+    # the rendered body.
     private def render_marked(raw : Bytes) : Bytes
       tmpl = Fuzz::Template.parse(String.new(raw))
       tmpl.render(tmpl.apply_chains(tmpl.default_payloads, Decoder.shared_registry))
@@ -1252,18 +1247,6 @@ module Gori::Tui
       reflect_content_length_in_editor if @auto_content_length
     end
 
-    getter? mark_transform : Bool
-
-    # Toggle MARK-transform mode. Refused in the alternate request modes (hex / gRPC /
-    # decode / WS) where `§…§` templating doesn't apply — their request_bytes paths take
-    # precedence over the marked path anyway. Dirties so the flag persists.
-    def toggle_mark_transform : Bool
-      return @mark_transform if request_hex? || @grpc_mode || @decode_kind || @ws_mode
-      commit_chain_pane if @chain_focused # leaving MARK mode → save any pending chain edit
-      @dirty = true
-      @mark_transform = !@mark_transform
-    end
-
     def pretty_print_request : String?
       return "hex mode active" if request_hex?
       if @ws_mode && @req_pane == :decoded
@@ -1291,16 +1274,25 @@ module Gori::Tui
 
     CHAIN_PLACEHOLDER = "put the cursor in a §…§ marker, then ^Y to add an encode chain (e.g. base64-encode)"
 
-    # Whether the CHAIN sub-pane currently owns keyboard input (MARK mode + focused +
-    # actually on the request column). The controller routes body keys here when true.
+    # Whether the CHAIN sub-pane currently owns keyboard input (focused + actually on the
+    # request column). The controller routes body keys here when true.
     def chain_pane_active? : Bool
-      @mark_transform && @chain_focused && @focus == :request && !request_hex?
+      @chain_focused && @focus == :request && !request_hex?
+    end
+
+    # Whether the request column is currently split into REQUEST (top) + CHAIN (bottom).
+    # Contextual (no mode): only while the cursor sits inside a §…§ marker (chain_under_cursor)
+    # or the CHAIN pane is being edited. Never in the hex/gRPC/decode/WS request modes, which
+    # own the request column with their own splits. render/hit-test/click all read this so the
+    # visible layout, the badge geometry, and the click targets stay in agreement.
+    private def chain_split_visible? : Bool
+      return false if @req_hex_edit || @grpc_mode || @decode_kind || @ws_mode
+      @chain_focused || !chain_under_cursor.nil?
     end
 
     # ^Y: drop focus into the CHAIN pane for the marker under the request cursor. Returns
     # a hint string when it can't (surfaced by the controller), nil on success.
     def focus_chain_pane : String?
-      return "enable MARK mode first (^K)" unless @mark_transform
       return "not available in hex edit" if request_hex?
       return "move to the REQUEST pane first (↹)" unless @focus == :request
       chain = Fuzz::Template.chain_at(@editor.text, @editor.cursor_offset)
@@ -1330,10 +1322,10 @@ module Gori::Tui
       commit_chain_pane if key.escape? || key.enter? || key.tab? || key.up?
     end
 
-    # --- marking (MARK-transform mode) ---------------------------------------
-    # These mirror the Fuzzer's marking helpers but are gated on MARK mode + the REQUEST
-    # pane: a § is only special on send when MARK is on, so marking is pointless (and the
-    # tint hidden) otherwise. All delegate to the shared Fuzz::Template helpers.
+    # --- marking (§…§ Decoder-chain positions) -------------------------------
+    # These mirror the Fuzzer's marking helpers, gated on the REQUEST pane (markers are
+    # always meaningful on send now — a marked value renders through its chain). All
+    # delegate to the shared Fuzz::Template helpers.
     def auto_mark : String
       return mark_hint unless markable?
       @editor.set_text(Fuzz::Template.auto_mark(@editor.text))
@@ -1373,11 +1365,10 @@ module Gori::Tui
     end
 
     private def markable? : Bool
-      @mark_transform && @focus == :request && !request_hex?
+      @focus == :request && !request_hex?
     end
 
     private def mark_hint : String
-      return "enable MARK mode first (toggle it on)" unless @mark_transform
       return "marking isn't available in hex edit" if request_hex?
       "marking works on the REQUEST pane — ↹ to it"
     end
@@ -1403,10 +1394,10 @@ module Gori::Tui
       # whose expansion changes the body length must reflect the SENT Content-Length, or
       # the visible header goes stale and, once Auto-CL is toggled off, is sent mismatched.
       raw = expanded_editor_bytes
-      # In MARK-transform mode the CL that ^R actually sends is computed from the
+      # With §…§ markers present the CL that ^R actually sends is computed from the
       # RENDERED template (markers stripped, chains applied), not the raw marked text —
       # reflect THAT value so the visible header matches request_bytes.
-      source = @mark_transform ? render_marked(raw) : raw
+      source = marker_regions.empty? ? raw : render_marked(raw)
       synced = sync_content_length(source)
       return if synced == source
 
@@ -1540,11 +1531,11 @@ module Gori::Tui
         end
       end
 
-      # REQUEST badges: ^R:SEND is always rightmost (primary action). Then CL/MARK/
-      # PRETTY (or HEX) when drawn. Decode/MARK splits keep chrome on the top card.
+      # REQUEST badges: ^R:SEND is always rightmost (primary action). Then CL/PRETTY (or
+      # HEX) when drawn. Decode / CHAIN splits keep chrome on the top card.
       req_card = if @decode_kind || @ws_mode
                    decode_split(left)[0]
-                 elsif @mark_transform
+                 elsif chain_split_visible?
                    req_chain_split(left)[0]
                  else
                    left
@@ -1565,7 +1556,6 @@ module Gori::Tui
             badges << {:req_hex, "^X", "HEX"}
           else
             badges << {:cl, "^L", "CL"}
-            badges << {:mark, "^K", "MARK"}
             badges << {:pretty_req, "^U", "PRETTY"}
           end
         end
@@ -1597,7 +1587,7 @@ module Gori::Tui
         end
         return
       end
-      if @mark_transform # split: click the CHAIN strip to edit it, else place the request caret
+      if chain_split_visible? # split: click the CHAIN strip to edit it, else place the request caret
         req, chain = req_chain_split(col)
         if my >= chain.y
           focus_chain_pane # binds to the marker at the current request cursor (hint ignored on a click)
@@ -2215,7 +2205,7 @@ module Gori::Tui
         env, dec = decode_split(left)
         render_request(screen, env, req_focused && @req_pane == :envelope)
         render_decoded(screen, dec, req_focused && @req_pane == :decoded)
-      elsif @mark_transform # split into REQUEST (top) + CHAIN pane (bottom)
+      elsif chain_split_visible? # cursor is in a §…§ marker → split REQUEST (top) + CHAIN (bottom)
         req, chain = req_chain_split(left)
         render_request(screen, req, req_focused && !@chain_focused)
         render_chain_pane(screen, chain, req_focused && @chain_focused)
@@ -2225,7 +2215,7 @@ module Gori::Tui
       render_response(screen, right, focused && @focus == :response)
     end
 
-    # REQUEST (top) + CHAIN (bottom) split for a MARK tab. The CHAIN strip is a slim 3
+    # REQUEST (top) + CHAIN (bottom) split. The CHAIN strip is a slim 3
     # rows normally and grows (≥8, for the autocomplete dropdown) while it's focused; the
     # request editor keeps the rest (≥1 row).
     private def req_chain_split(col : Rect) : {Rect, Rect}
@@ -2307,7 +2297,7 @@ module Gori::Tui
         screen.text(bx, rect.y, badge, Theme.text_bright, Theme.accent_bg) if bx > rect.x + label.size + 4
       end
       # XML/JSON-ish payload / WS messages → plain editing (no HTTP request/header colouring).
-      @decoded.render(screen, rect.inset(1, 1), cursor: focused, highlight: nil)
+      @decoded.render(screen, rect.inset(1, 1), cursor: focused, highlight: nil, peek: focused)
     end
 
     private def pane_border(focused : Bool, insert : Bool = false) : Color
@@ -2414,12 +2404,12 @@ module Gori::Tui
           @scroll_req = h.render(screen, rect.inset(1, 1), focused, @scroll_req)
         else
           Frame.toggle_badge(screen, send_edge, rect.y, min_x, "^X", "MSG", false) if @grpc_reframable
-          @editor.render(screen, rect.inset(1, 1), cursor: focused && request_insert?, highlight: :request)
+          @editor.render(screen, rect.inset(1, 1), cursor: focused && request_insert?, highlight: :request, peek: focused)
         end
         return
       end
       if @ws_mode
-        @editor.render(screen, rect.inset(1, 1), cursor: focused && request_insert?, highlight: :request)
+        @editor.render(screen, rect.inset(1, 1), cursor: focused && request_insert?, highlight: :request, peek: focused)
         return
       end
       if h = @req_hex_edit
@@ -2428,12 +2418,11 @@ module Gori::Tui
         return
       end
       cl_x = Frame.toggle_badge(screen, send_edge, rect.y, min_x, "^L", "CL", @auto_content_length)
-      mark_x = Frame.toggle_badge(screen, cl_x, rect.y, min_x, "^K", "MARK", @mark_transform)
-      mode_x = Frame.toggle_badge(screen, mark_x, rect.y, min_x, "^U", "PRETTY", false)
+      mode_x = Frame.toggle_badge(screen, cl_x, rect.y, min_x, "^U", "PRETTY", false)
       render_mode_badge(screen, mode_x, rect.y, min_x, ins)
-      update_request_mark_tint
+      update_request_marker_tint
       inner = rect.inset(1, 1)
-      @editor.render(screen, inner, cursor: ins, highlight: :request)
+      @editor.render(screen, inner, cursor: ins, highlight: :request, peek: focused)
       paint_request_read_chrome(screen, inner, focused && !ins)
     end
 
@@ -2477,15 +2466,10 @@ module Gori::Tui
       end
     end
 
-    # MARK-transform tinting: colour each §…§ marker in the request editor — the value in
-    # the position hue, the ¦chain segment over-painted dimmer. Off = clear the regions so
-    # a toggled-off tab paints untinted (empty = no-op paint). The MARK toggle badge itself
-    # rides the top border (see render_request).
-    private def update_request_mark_tint : Nil
-      unless @mark_transform
-        @editor.bg_regions = [] of {Int32, Int32, Color}
-        return
-      end
+    # §…§ marker tinting: colour each marker in the request editor — the value in the
+    # position hue, the ¦chain segment over-painted dimmer. Always on (like the Fuzzer):
+    # a marker-free request yields no regions, so this is a no-op paint then.
+    private def update_request_marker_tint : Nil
       bg = [] of {Int32, Int32, Color}
       marker_regions.each_with_index do |region, i|
         a, sep, close = region
@@ -2495,9 +2479,9 @@ module Gori::Tui
       @editor.bg_regions = bg
     end
 
-    # {open, sep, close} marker regions cached on the editor revision — update_request_mark_tint
-    # runs every render; the cache skips marker_regions' 2× whole-buffer `text.chars` on an
-    # unchanged request buffer.
+    # {open, sep, close} marker regions cached on the editor revision — update_request_marker_tint
+    # (and request_bytes / chain_split_visible?) read it every render; the cache skips
+    # marker_regions' 2× whole-buffer `text.chars` on an unchanged request buffer.
     private def marker_regions : Array({Int32, Int32, Int32})
       if @editor.edits != @marker_regions_rev
         @marker_regions_rev = @editor.edits

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -4790,10 +4790,6 @@ module Gori::Tui
       v.toggle_resp_hex
     end
 
-    def repeater_toggle_mark_transform : Nil
-      repeater_controller.repeater_toggle_mark_transform
-    end
-
     def repeater_pretty_request : Nil
       repeater_controller.repeater_pretty_request
     end
@@ -4815,7 +4811,7 @@ module Gori::Tui
     end
 
     # ^Y: jump focus DOWN into the visible CHAIN pane (the marker under the cursor). The
-    # controller gates on MARK mode + cursor-in-marker and toasts otherwise.
+    # controller gates on the request pane + cursor-in-marker and toasts otherwise.
     def repeater_attach_chain : Nil
       repeater_controller.repeater_focus_chain_pane
     end

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -7,6 +7,7 @@ require "./gutter"
 require "./search_hi"
 require "./reveal"
 require "./env_complete"
+require "./env_peek"
 
 module Gori::Tui
   # A minimal multi-line text editor for inline editing (e.g. the Repeater
@@ -52,6 +53,10 @@ module Gori::Tui
       # request editors (Repeater request, Fuzzer template) where env tokens are expanded on
       # send; every other editor keeps it nil so its edit path is byte-for-byte unchanged.
       @env_complete = nil.as(EnvComplete?)
+      # Opt-in `$ENV` value peek (nil = disabled). Paired with @env_complete — the same
+      # request editors get it. Shows the resolved value of a COMPLETE `$KEY` token under
+      # the caret (NORMAL or INSERT) once the autocomplete dropdown isn't offering matches.
+      @env_peek = nil.as(EnvPeek?)
       set_text(text)
     end
 
@@ -336,7 +341,7 @@ module Gori::Tui
     # HTTP message editors (Repeater, Intercept), nil for plain prose (Notes,
     # Issue notes). The styled lines are 1:1 with `@lines`, so the cursor —
     # drawn last, on top — still lands on the right column.
-    def render(screen : Screen, rect : Rect, cursor : Bool, highlight : Symbol? = nil) : Nil
+    def render(screen : Screen, rect : Rect, cursor : Bool, highlight : Symbol? = nil, peek : Bool = false) : Nil
       return if rect.empty?
       @last_h = rect.h # remembered for scroll_view (wheel) clamping
       ensure_visible(rect.h)
@@ -394,7 +399,10 @@ module Gori::Tui
           st = @xscroll > 0 ? slice_left(line, @xscroll) : line
           SearchHi.mark(screen, cx0, rect.y + i, st, @search_hl, cx0 + cw)
         end
-        next unless cursor && li == @cy
+        # The caret cell is captured for the caret line whether or not the block cursor
+        # is drawn (cursor=false in NORMAL) — the value peek anchors to it in read mode too.
+        # The block-cursor GLYPH itself still paints only when `cursor` (insert mode).
+        next unless li == @cy
         # column_width (not display_width): a raw control char in the prefix occupies a
         # cell and click-to-cursor counts it, so the caret must too — else it sits one
         # column left of the real position and paints over a glyph.
@@ -403,20 +411,45 @@ module Gori::Tui
         cxs = cx0 + prefix_w + preedit_w - @xscroll
         if cxs >= cx0 && cxs < cx0 + cw
           caret_cell = {cxs, rect.y + i}
-          screen.cursor(cxs, rect.y + i)
-          cgw = [Screen.display_width((@preedit.empty? ? (@cx < line.size ? line[@cx] : ' ') : @preedit[0]).to_s), 1].max
-          ch = @preedit.empty? ? (@cx < line.size ? line[@cx] : ' ') : @preedit[0]
-          (0...cgw).each do |off|
-            break if cxs + off >= cx0 + cw # a wide-glyph caret at the last column must not spill its 2nd cell onto the pane border
-            cch = (off == 0 ? ch : ' ')
-            screen.cell(cxs + off, rect.y + i, cch, Theme.bg, Theme.accent)
+          if cursor
+            screen.cursor(cxs, rect.y + i)
+            cgw = [Screen.display_width((@preedit.empty? ? (@cx < line.size ? line[@cx] : ' ') : @preedit[0]).to_s), 1].max
+            ch = @preedit.empty? ? (@cx < line.size ? line[@cx] : ' ') : @preedit[0]
+            (0...cgw).each do |off|
+              break if cxs + off >= cx0 + cw # a wide-glyph caret at the last column must not spill its 2nd cell onto the pane border
+              cch = (off == 0 ? ch : ' ')
+              screen.cell(cxs + off, rect.y + i, cch, Theme.bg, Theme.accent)
+            end
           end
         end
       end
-      # The env-complete dropdown paints LAST (over the text, anchored at the caret) so it
-      # never renders when the caret is off-screen or the editor is unfocused (cursor=false).
-      if cursor && (cc = caret_cell) && (ec = @env_complete)
+      # The env-complete dropdown + value peek paint LAST (over the text, anchored at the
+      # caret) so they never render when the caret is off-screen.
+      render_env_popups(screen, caret_cell, rect, cursor, peek)
+    end
+
+    # The caret-anchored `$ENV` overlays, drawn after the text. The autocomplete dropdown
+    # shows only in INSERT (cursor) while a `$partial` is typed; the value peek shows the
+    # resolved value of a COMPLETE token under the caret in NORMAL (peek) OR INSERT, but
+    # never while the dropdown owns the caret. The peek is re-derived each frame from
+    # @cx/@cy, so moving the cursor off the token closes it without any explicit event.
+    private def render_env_popups(screen : Screen, caret_cell : {Int32, Int32}?,
+                                  rect : Rect, cursor : Bool, peek : Bool) : Nil
+      ec = @env_complete
+      if cursor && (cc = caret_cell) && ec
         ec.render(screen, cc[0], cc[1], rect)
+      end
+      ep = @env_peek
+      return unless ep
+      # Suppress the peek only while the autocomplete dropdown is ACTUALLY on screen (insert
+      # mode + open). In NORMAL mode the dropdown never renders, so a stale-open `ec` (left by
+      # a cursor move mid-token) must not hide the peek.
+      dropdown_visible = cursor && ec && ec.open?
+      if (cursor || peek) && (cc = caret_cell) && !dropdown_visible && (tok = env_token_at_cursor)
+        ep.set(tok[0], tok[1], Settings.env_prefix)
+        ep.render(screen, cc[0], cc[1], rect)
+      else
+        ep.close
       end
     end
 
@@ -541,6 +574,7 @@ module Gori::Tui
     # keep @env_complete nil and every edit-path guard below short-circuits.
     def env_complete=(on : Bool) : Nil
       @env_complete = on ? (@env_complete || EnvComplete.new) : nil
+      @env_peek = on ? (@env_peek || EnvPeek.new) : nil # the value peek rides the same opt-in
     end
 
     def env_completing? : Bool
@@ -631,6 +665,36 @@ module Gori::Tui
     private def env_value_preview(v : String) : String
       s = v.gsub(/\s+/, " ").strip
       s.size > 20 ? "#{s[0, 19]}…" : s
+    end
+
+    # The COMPLETE, REGISTERED `$KEY` env token the caret currently sits inside (or
+    # immediately after), as {key, value-preview} — for the value peek. Scans the key run
+    # around @cx, requires the prefix sigil right before it, and looks the key up in the
+    # effective env vars. nil when the caret isn't on a token OR the key isn't registered —
+    # an unknown `$word` (e.g. a literal `$` typed during testing) is just text, no peek.
+    private def env_token_at_cursor : {String, String}?
+      prefix = Settings.env_prefix
+      return nil if prefix.empty?
+      line = @lines[@cy]?
+      return nil unless line
+      cx = @cx.clamp(0, line.size)
+      plen = prefix.size
+      ks = cx
+      while ks > 0 && env_key_tail?(line[ks - 1]) # walk left to the key run's start
+        ks -= 1
+      end
+      # The prefix sigil must sit immediately before the key run (else it isn't an env token).
+      return nil unless ks - plen >= 0 && line[(ks - plen)...ks] == prefix
+      ke = cx
+      while ke < line.size && env_key_tail?(line[ke]) # extend right over the rest of the key
+        ke += 1
+      end
+      key = line[ks...ke]
+      # A valid identifier: non-empty and starting with a key head (`$1` never expands).
+      return nil if key.empty? || !env_key_head?(key[0])
+      val = Env.effective_vars[key]?
+      return nil unless val # unregistered → just a literal string, not an env reference
+      {key, env_value_preview(val)}
     end
   end
 end

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -93,8 +93,6 @@ module Gori
       abstract def repeater_toggle_http2 : Nil               # flip the request transport h1↔h2 (override captured protocol)
       abstract def repeater_toggle_resp_diff : Nil           # switch the response pane between raw and diff-vs-previous
       abstract def repeater_toggle_resp_hex : Nil            # toggle a raw hex dump of the response bytes
-      # mark-transform mode: mark request values (§…§) and attach Decoder chains applied on send
-      abstract def repeater_toggle_mark_transform : Nil # toggle MARK mode on/off
       abstract def repeater_pretty_request : Nil
       abstract def fuzz_pretty_template : Nil
       abstract def fuzz_toggle_http2 : Nil    # flip the fuzz transport h1↔h2 (override seed protocol)

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -126,14 +126,9 @@ module Gori
         available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :repeater && ctx.repeater_subtab_count >= 1 },
         mnemonic: 'd', section: :subtab) { |ctx| ctx.repeater_duplicate_subtab; nil }
 
-      # --- REQUEST pane, mark-transform (mark request values, attach Decoder chains
-      # applied on send) — Round 5 order: the marker actions the user reaches for
-      # most (toggle the mode, then insert/mark/auto/clear/attach), THEN the view
-      # toggles (hex/decoded/pretty) below.
-      r.register Verb::Definition.new(
-        "repeater.toggle-mark-transform", "Toggle MARK transform", "Mark request values (§…§) and apply Decoder chains on send",
-        Verb::Scope::Repeater, [Verb::Chord.new("k", ctrl: true)],
-        available: in_repeater, mnemonic: 't', section: :request) { |ctx| ctx.repeater_toggle_mark_transform; nil }
+      # --- REQUEST pane, §…§ markers (mark request values, attach Decoder chains applied
+      # on send — always active, no mode). The marker actions the user reaches for most
+      # (insert/mark/auto/clear/attach), THEN the view toggles (hex/decoded/pretty) below.
       r.register Verb::Definition.new(
         "repeater.insert-marker", "Insert marker", "Drop a single § at the cursor to bracket a region by hand",
         Verb::Scope::Repeater, available: in_repeater, mnemonic: 'i', section: :request) { |ctx| ctx.repeater_insert_marker; nil }
@@ -162,7 +157,7 @@ module Gori
         Verb::Scope::Repeater, [Verb::Chord.new("x", ctrl: true)],
         available: in_repeater, mnemonic: 'b', section: :request) { |ctx| ctx.repeater_toggle_hex; nil }
       r.register Verb::Definition.new(
-        "repeater.toggle-decoded", "Switch envelope/decoded", "SAML/GraphQL flow: switch envelope/decoded · in MARK mode: insert a § at the cursor",
+        "repeater.toggle-decoded", "Switch envelope/decoded", "SAML/GraphQL/WS flow: switch envelope/decoded · otherwise: insert a § marker at the cursor",
         Verb::Scope::Repeater, [Verb::Chord.new("t", ctrl: true)],
         available: in_repeater, mnemonic: 'd', section: :request) { |ctx| ctx.repeater_toggle_decoded; nil }
       r.register Verb::Definition.new(


### PR DESCRIPTION
## Summary

Repeater/Fuzzer editor UX improvements, in three parts.

### 1. ENV value peek (NORMAL + INSERT)
Parking the cursor on a **registered** `$KEY` now reveals its resolved value in a caret-anchored tooltip — in NORMAL mode too, not just the typing-time autocomplete dropdown. An unregistered `$word` (e.g. a literal `$` typed during testing) shows nothing; it's just text.

New `EnvPeek` component (`src/gori/tui/env_peek.cr`), wired through `TextArea#render(..., peek:)`; the caret cell is captured regardless of insert mode so the peek anchors in read mode too.

### 2. `§…§` markers always active — MARK mode removed
The `§…§` marker workflow is no longer hidden behind a per-tab MARK mode (`^K`), matching how the Fuzzer already works:

- Marker regions are **always highlighted**.
- The **CHAIN sub-pane appears only while the cursor is inside a marker** (contextual), and edits with `^Y`.
- On send, a request that contains a marker region renders it (inline Decoder chains applied, delimiters stripped); a marker-free request is byte-identical.
- The persisted `mark_transform` flag is removed **end to end** — DB column (migration **V37** `DROP COLUMN`), CLI `--mark-transform`, and the MCP tool field. Headless send never rendered markers, so this changes no headless behavior.

### 3. CHAIN pane accepts its suggestion on Tab
While typing a converter in the CHAIN pane, **Tab** now accepts the autocomplete suggestion (parity with **↵**) instead of the global focus ring stealing Tab to switch panes. Fixed symmetrically in the Repeater and Fuzzer controllers (`editor_captures_tab?` / `handle_editor_tab` + an `editor_completing?` guard). **BackTab** remains the pane-exit hatch.

## Verification
- Full suite green: **1882 examples, 0 failures**; `shards build` compiles.
- New coverage: ENV peek render tests (NORMAL/INSERT/unregistered-hidden), contextual CHAIN pane, marker send rendering, and `ChainPane` Tab-accept (open → accept, closed → focus-exit).
- Migration specs adjusted for V37.
- The Tab-routing change (high-blast-radius global key dispatch) was reviewed by three independent adversarial verifiers — all confirmed correct with no regressions to `$ENV` autocomplete, literal-tab insertion, the BackTab escape hatch, or nil-view safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
