### PR TITLE
feat(tui): add sub-tab filter bar to Notes/Fuzzer/Decoder/Comparer/Miner

### DIFF
--- a/spec/repeater/subtab_filter_spec.cr
+++ b/spec/repeater/subtab_filter_spec.cr
@@ -104,6 +104,16 @@ describe Gori::Repeater::SubtabFilter do
       Repeater::SubtabFilter.suggestions("tag:idor ", 9, list).should be_empty
       Repeater::SubtabFilter.suggestions("", 0, list).should be_empty
     end
+
+    it "limits field-name completion to the given fields (adaptive per tab)" do
+      # A text tab passes %w(name): only name: is offered, never host:/method:/tag:.
+      Repeater::SubtabFilter.suggestions("na", 2, list, %w(name)).should eq(["name:"])
+      Repeater::SubtabFilter.suggestions("ta", 2, list, %w(name)).should be_empty
+      # An HTTP tab (no tags) advertises name/host/method.
+      Repeater::SubtabFilter.suggestions("", 0, list, %w(name host method)).should be_empty
+      Repeater::SubtabFilter.suggestions("me", 2, list, %w(name host method)).should eq(["method:"])
+      Repeater::SubtabFilter.suggestions("ta", 2, list, %w(name host method)).should be_empty
+    end
   end
 
   describe ".host_of" do

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -83,6 +83,8 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def subtab_search_open : Nil; end
 
+  def subtab_filter_open : Nil; end
+
   property subtab_search_tab_count : Int32 = 0
 
   def subtab_search_count : Int32

--- a/spec/tui/comparer_view_spec.cr
+++ b/spec/tui/comparer_view_spec.cr
@@ -50,6 +50,22 @@ describe ComparerView do
     v.label.should eq("empty")
   end
 
+  it "projects a sub-tab filter subject across both A/B slots (name + host/method)" do
+    v = ComparerView.new
+    v.set_slot(:a, flow("GET", "/orders", "app.test"))
+    v.set_slot(:b, flow("POST", "/login", "api.test"))
+    v.name = "auth pair"
+    s = v.filter_subject
+    s.name.should eq("auth pair")
+    s.target.should contain("app.test")
+    s.target.should contain("api.test")
+    # End-to-end through the matcher: host:/method: narrow either side; free text hits summary.
+    Gori::Repeater::SubtabFilter.parse("host:api").matches?(s).should be_true
+    Gori::Repeater::SubtabFilter.parse("method:post").matches?(s).should be_true
+    Gori::Repeater::SubtabFilter.parse("login").matches?(s).should be_true
+    Gori::Repeater::SubtabFilter.parse("host:nope").matches?(s).should be_false
+  end
+
   # Regression: the REQ/RES divider chips were hit-tested one column off the cells
   # they were drawn on — the RES chip's left edge was a dead click and a phantom
   # clickable column sat one past it. render + pane_chip_at now share one geometry

--- a/spec/tui/notes_view_spec.cr
+++ b/spec/tui/notes_view_spec.cr
@@ -114,6 +114,23 @@ describe Gori::Tui::NotesView do
     end
   end
 
+  it "projects sub-tab filter rows (title + body) per note in chip order" do
+    view = NotesView.new
+    type(view, "Alpha title\nbody about idor")
+    view.new_note
+    type(view, "Beta notes\nsecond body")
+    rows = view.filter_rows
+    rows.size.should eq(2)
+    rows[0][0].should eq("Alpha title") # name = the note's first non-blank line
+    rows[0][1].should contain("idor")   # body carries the searchable content
+    rows[1][0].should eq("Beta notes")
+    # End-to-end: free text matches the body, name: matches the title, else hidden.
+    subj0 = Gori::Repeater::SubtabFilter::Subject.new(rows[0][0], rows[0][1], "", "", [] of String)
+    Gori::Repeater::SubtabFilter.parse("idor").matches?(subj0).should be_true
+    Gori::Repeater::SubtabFilter.parse("name:alpha").matches?(subj0).should be_true
+    Gori::Repeater::SubtabFilter.parse("name:beta").matches?(subj0).should be_false
+  end
+
   it "keeps multiple notes as independent sub-tabs across a reload" do
     tmp_store do |store|
       view = NotesView.new

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -156,6 +156,10 @@ private class FakeContext < ExecContext
     @calls << :subtab_search_open
   end
 
+  def subtab_filter_open : Nil
+    @calls << :subtab_filter_open
+  end
+
   def subtab_search_count : Int32
     0
   end

--- a/src/gori/repeater/subtab_filter.cr
+++ b/src/gori/repeater/subtab_filter.cr
@@ -96,7 +96,10 @@ module Gori
       # Returns complete tokens for the whitespace-bounded token under `cx`. Empty
       # when the caret sits on blank space or nothing matches. Value pools for
       # tag/name/host/method come from `subjects` (cardinality is small — open tabs).
-      def self.suggestions(query : String, cx : Int32, subjects : Array(Subject)) : Array(String)
+      # `fields` limits which field NAMES a tab completes (a text tab passes %w(name) so
+      # it never suggests host:/method:); defaults to the full canonical set (Repeater).
+      def self.suggestions(query : String, cx : Int32, subjects : Array(Subject),
+                           fields : Array(String) = FIELDS) : Array(String)
         token, _, _ = token_at(query, cx)
         return [] of String if token.empty?
         neg = token.starts_with?('-') && token.size > 1
@@ -110,7 +113,7 @@ module Gori
           val_prefix = field == "tag" ? prefix.lstrip('#') : prefix
           suggest_values(field, val_prefix, subjects).map { |v| "#{neg_p}#{field_raw}:#{v}" }
         else
-          FIELDS.select(&.starts_with?(core.downcase)).map { |f| "#{neg_p}#{f}:" }
+          fields.select(&.starts_with?(core.downcase)).map { |f| "#{neg_p}#{f}:" }
         end
       end
 

--- a/src/gori/tui/comparer_view.cr
+++ b/src/gori/tui/comparer_view.cr
@@ -8,6 +8,7 @@ require "../store"
 require "../repeater/diff"
 require "../repeater/side_by_side"
 require "../repeater/message_lines"
+require "../repeater/subtab_filter"
 
 module Gori::Tui
   # The Comparer body: two flow "slots" (A, B) and a side-by-side line diff of
@@ -43,6 +44,17 @@ module Gori::Tui
               auto_label
             end
       raw.size > max ? raw[0, max - 1] + "…" : raw
+    end
+
+    # The sub-tab filter's searchable projection: the custom name + both slot summaries
+    # (free text) with each slot's URL/method folded into target/method so `host:`/
+    # `method:` narrow either side. See ComparerController#filter_subjects.
+    def filter_subject : Repeater::SubtabFilter::Subject
+      slots = [@slot_a, @slot_b].compact
+      summ = slots.map { |d| summary(d) }.join(" · ")
+      targets = slots.map(&.row.url).join(' ') # full URL → host: substring-matches the authority
+      methods = slots.map(&.row.method).join(' ')
+      Repeater::SubtabFilter::Subject.new(@name, summ, targets, methods, [] of String)
     end
 
     # Identity for rename/apply (view object, not content) — mirrors MinerView/RepeaterView.

--- a/src/gori/tui/controllers/comparer_controller.cr
+++ b/src/gori/tui/controllers/comparer_controller.cr
@@ -41,14 +41,31 @@ module Gori::Tui
       true # from the first session (Repeater/Notes style)
     end
 
+    # --- sub-tab filter (issue #121) ---
+    def subtab_filter_enabled? : Bool
+      true
+    end
+
+    def filter_fields : Array(String)
+      %w(name host method) # each session's A/B slots carry a target + method
+    end
+
+    def filter_subjects : Array(Repeater::SubtabFilter::Subject)
+      @sessions.map(&.filter_subject)
+    end
+
+    # Filter-aware strip nav: ←/→ skip hidden chips; ^1-9 to a hidden chip drops the
+    # filter (chip numbers are absolute). Sessions are in-memory, so no persist on switch.
     def move_subtab(dir : Int32) : Nil
-      return if @sessions.size < 2
-      nidx = (@idx + dir).clamp(0, @sessions.size - 1)
-      @idx = nidx unless nidx == @idx
+      if t = step_visible(@idx, dir)
+        @idx = t
+      end
     end
 
     def jump_subtab(idx : Int32) : Nil
-      @idx = idx if 0 <= idx < @sessions.size && idx != @idx
+      return unless 0 <= idx < @sessions.size
+      clear_subtab_filter if (h = subtab_hidden) && h.includes?(idx)
+      @idx = idx if idx != @idx
     end
 
     def comparer_new : Nil
@@ -94,8 +111,11 @@ module Gori::Tui
       body_focused = focus == :body
       labels = subtab_strip_shown? ? subtab_labels : nil
       shell = BodyChrome.shell_focused(focus, multi_pane: false)
-      @subtab_start = BodyChrome.framed_body(screen, rect, shell, focus == :subtabs, labels, @idx, @subtab_start) do |content|
-        view.render(screen, content, focused: body_focused)
+      subtabs_focused = focus == :subtabs
+      @subtab_start = BodyChrome.framed_body(screen, rect, shell, subtabs_focused, labels, @idx, @subtab_start, subtab_hidden, strip_divider: subtab_strip_divider?) do |content|
+        render_with_filter(screen, content, subtabs_focused) do |body|
+          view.render(screen, body, focused: body_focused)
+        end
       end
     end
 
@@ -131,10 +151,10 @@ module Gori::Tui
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
       @host.focus_body
-      # Carve the sub-tab strip too (like Decoder/Notes), not just the border — the view
-      # renders the REQ/RES chips inside the strip-carved content rect, so a plain
-      # inset(1,1) would hit-test STRIP_H rows too high and never match the chips.
-      inner = BodyChrome.content_rect(rect, strip: subtab_strip_shown?)
+      # Carve the sub-tab strip AND the filter bar too (like Repeater), not just the
+      # border — the view renders the REQ/RES chips inside that content rect, so a plain
+      # inset(1,1) would hit-test the chrome rows too high and never match the chips.
+      inner = body_rect_below_filter(rect)
       if pane = view.pane_chip_at(inner, mx, my)
         view.set_pane(pane)
       end

--- a/src/gori/tui/controllers/decoder_controller.cr
+++ b/src/gori/tui/controllers/decoder_controller.cr
@@ -112,6 +112,21 @@ module Gori::Tui
       true
     end
 
+    # --- sub-tab filter (issue #121) ---
+    def subtab_filter_enabled? : Bool
+      true
+    end
+
+    def filter_fields : Array(String)
+      %w(name) # a conversion has no HTTP context; free-text covers the chain + input
+    end
+
+    def filter_subjects : Array(Repeater::SubtabFilter::Subject)
+      @sessions.map do |s|
+        Repeater::SubtabFilter::Subject.new(s.view.name, "#{s.chain} #{s.input.text}", "", "", [] of String)
+      end
+    end
+
     # The chip label: the custom name if set, else a compact preview of the chain
     # spec (or "empty" when blank), capped to ~18 cols like Repeater/Notes.
     private def session_label(s : DecoderSession) : String
@@ -121,14 +136,17 @@ module Gori::Tui
 
     # Move the active sub-tab by ±1 (strip ←/→), clamped, no wrap. No persist needed:
     # every session keeps its own state in memory, so switching loses nothing.
+    # Filter-aware: ←/→ skip hidden chips; ^1-9 to a hidden chip escapes the filter.
     def move_subtab(dir : Int32) : Nil
-      return if @sessions.size < 2
-      nidx = (@idx + dir).clamp(0, @sessions.size - 1)
-      switch_to(nidx) unless nidx == @idx
+      if t = step_visible(@idx, dir)
+        switch_to(t)
+      end
     end
 
     def jump_subtab(idx : Int32) : Nil
-      switch_to(idx) if 0 <= idx < @sessions.size && idx != @idx
+      return unless 0 <= idx < @sessions.size
+      clear_subtab_filter if (h = subtab_hidden) && h.includes?(idx)
+      switch_to(idx) if idx != @idx
     end
 
     private def switch_to(idx : Int32) : Nil
@@ -196,13 +214,16 @@ module Gori::Tui
       labels = subtab_strip_shown? ? subtab_labels : nil
       s = cur
       shell = BodyChrome.shell_focused(focus, multi_pane: true)
-      @subtab_start = BodyChrome.framed_body(screen, rect, shell, focus == :subtabs, labels, @idx, @subtab_start) do |content|
-        # Each section frames its own card (per-pane focus border) inside the shell frame.
-        s.view.render(screen, content,
-          input: s.input, chain: s.chain, chain_cx: s.chain_cx, chain_pre: @chain_pre,
-          result: s.result, pane: s.pane, focused: body_focused,
-          popup: @popup, prompt: @prompt, prompt_buf: @prompt_buf,
-          input_mode: s.input_mode, input_read: s.input_read)
+      subtabs_focused = focus == :subtabs
+      @subtab_start = BodyChrome.framed_body(screen, rect, shell, subtabs_focused, labels, @idx, @subtab_start, subtab_hidden, strip_divider: subtab_strip_divider?) do |content|
+        render_with_filter(screen, content, subtabs_focused) do |body|
+          # Each section frames its own card (per-pane focus border) inside the shell frame.
+          s.view.render(screen, body,
+            input: s.input, chain: s.chain, chain_cx: s.chain_cx, chain_pre: @chain_pre,
+            result: s.result, pane: s.pane, focused: body_focused,
+            popup: @popup, prompt: @prompt, prompt_buf: @prompt_buf,
+            input_mode: s.input_mode, input_read: s.input_read)
+        end
       end
     end
 
@@ -273,7 +294,7 @@ module Gori::Tui
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
       @host.focus_body
-      body = BodyChrome.content_rect(rect, strip: subtab_strip_shown?)
+      body = body_rect_below_filter(rect)
       s = cur
       # The view frames each card itself; editable content lives one cell inside each card border.
       regions = s.view.layout(body)

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -79,6 +79,22 @@ module Gori::Tui
       !@fuzzers.empty?
     end
 
+    # --- sub-tab filter (issue #121) ---
+    def subtab_filter_enabled? : Bool
+      true
+    end
+
+    def filter_fields : Array(String)
+      %w(name host method) # fuzz sessions carry an HTTP template (target + method)
+    end
+
+    def filter_subjects : Array(Repeater::SubtabFilter::Subject)
+      @fuzzers.map do |t|
+        v = t.view
+        Repeater::SubtabFilter::Subject.new(v.name, v.summary(200), v.target, v.request_method, [] of String)
+      end
+    end
+
     def view_at(idx : Int32) : FuzzerView?
       (0 <= idx < @fuzzers.size) ? @fuzzers[idx].view : nil
     end
@@ -133,11 +149,14 @@ module Gori::Tui
       body_focused = focus == :body
       labels = subtab_strip_shown? ? subtab_labels : nil
       shell = BodyChrome.shell_focused(focus, multi_pane: !current_view.nil?)
-      @subtab_start = BodyChrome.framed_body(screen, rect, shell, focus == :subtabs, labels, @current_idx, @subtab_start) do |content|
-        if v = current_view
-          v.render(screen, content, focused: body_focused)
-        else
-          TrafficEmptyState.render(screen, content, variant: :fuzzer)
+      subtabs_focused = focus == :subtabs
+      @subtab_start = BodyChrome.framed_body(screen, rect, shell, subtabs_focused, labels, @current_idx, @subtab_start, subtab_hidden, strip_divider: subtab_strip_divider?) do |content|
+        render_with_filter(screen, content, subtabs_focused) do |body|
+          if v = current_view
+            v.render(screen, body, focused: body_focused)
+          else
+            TrafficEmptyState.render(screen, body, variant: :fuzzer)
+          end
         end
       end
     end
@@ -469,7 +488,7 @@ module Gori::Tui
     end
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
-      body = BodyChrome.content_rect(rect, strip: subtab_strip_shown?)
+      body = body_rect_below_filter(rect)
       return true unless v = current_view
       # RESULTS border badges (DIST / MATCH / sort) before row select.
       if chip = v.results_chrome_hit(body, mx, my)
@@ -620,17 +639,17 @@ module Gori::Tui
       current_view.try(&.focus_last)
     end
 
-    # --- sub-tab nav ---
+    # --- sub-tab nav (filter-aware: ←/→ skip hidden chips; ^1-9 escapes the filter) ---
     def move_subtab(dir : Int32) : Nil
-      return unless @fuzzers.size >= 2
-      nidx = (@current_idx + dir).clamp(0, @fuzzers.size - 1)
-      return if nidx == @current_idx
-      save_current
-      @current_idx = nidx
+      if t = step_visible(@current_idx, dir)
+        save_current
+        @current_idx = t
+      end
     end
 
     def jump_subtab(idx : Int32) : Nil
       return unless 0 <= idx < @fuzzers.size
+      clear_subtab_filter if (h = subtab_hidden) && h.includes?(idx)
       return if idx == @current_idx
       save_current
       @current_idx = idx

--- a/src/gori/tui/controllers/miner_controller.cr
+++ b/src/gori/tui/controllers/miner_controller.cr
@@ -98,12 +98,15 @@ module Gori::Tui
       body_focused = focus == :body
       labels = subtab_strip_shown? ? subtab_labels : nil
       shell = BodyChrome.shell_focused(focus, multi_pane: !current_view.nil?)
-      @subtab_start = BodyChrome.framed_body(screen, rect, shell, focus == :subtabs, labels, @current_idx, @subtab_start) do |content|
-        if v = current_view
-          v.render(screen, content, body_focused)
-        else
-          screen.text(content.x + 1, content.y,
-            "no mining sessions — from History/Repeater press space → \"Mine parameters\"", Theme.muted)
+      subtabs_focused = focus == :subtabs
+      @subtab_start = BodyChrome.framed_body(screen, rect, shell, subtabs_focused, labels, @current_idx, @subtab_start, subtab_hidden, strip_divider: subtab_strip_divider?) do |content|
+        render_with_filter(screen, content, subtabs_focused) do |body|
+          if v = current_view
+            v.render(screen, body, body_focused)
+          else
+            screen.text(body.x + 1, body.y,
+              "no mining sessions — from History/Repeater press space → \"Mine parameters\"", Theme.muted)
+          end
         end
       end
     end
@@ -207,7 +210,7 @@ module Gori::Tui
     end
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
-      body = BodyChrome.content_rect(rect, strip: subtab_strip_shown?)
+      body = body_rect_below_filter(rect)
       return true unless v = current_view
       if pane = v.pane_at(body, mx, my)
         v.focus_pane(pane) unless pane == :detail
@@ -248,14 +251,33 @@ module Gori::Tui
       current_view.try(&.focus_last)
     end
 
-    # --- sub-tab nav ---
+    # --- sub-tab filter (issue #121) ---
+    def subtab_filter_enabled? : Bool
+      true
+    end
+
+    def filter_fields : Array(String)
+      %w(name host method) # mining sessions carry an HTTP request (target + method)
+    end
+
+    def filter_subjects : Array(Repeater::SubtabFilter::Subject)
+      @miners.map do |t|
+        v = t.view
+        Repeater::SubtabFilter::Subject.new(v.name, v.summary(200), v.target, v.request_method, [] of String)
+      end
+    end
+
+    # --- sub-tab nav (filter-aware: ←/→ skip hidden chips; ^1-9 escapes the filter) ---
     def move_subtab(dir : Int32) : Nil
-      return unless subtab_strip_shown? && @miners.size >= 2
-      @current_idx = (@current_idx + dir).clamp(0, @miners.size - 1)
+      if t = step_visible(@current_idx, dir)
+        @current_idx = t
+      end
     end
 
     def jump_subtab(idx : Int32) : Nil
-      @current_idx = idx if 0 <= idx < @miners.size
+      return unless 0 <= idx < @miners.size
+      clear_subtab_filter if (h = subtab_hidden) && h.includes?(idx)
+      @current_idx = idx
     end
 
     # Notification "jump to result": focus the session row with this db_id.

--- a/src/gori/tui/controllers/notes_controller.cr
+++ b/src/gori/tui/controllers/notes_controller.cr
@@ -35,15 +35,18 @@ module Gori::Tui
       body_focused = focus == :body
       labels = subtab_strip_shown? ? @notes.subtab_labels : nil
       shell = BodyChrome.shell_focused(focus, multi_pane: false)
-      @subtab_start = BodyChrome.framed_body(screen, rect, shell, focus == :subtabs, labels, @notes.current_index, @subtab_start) do |content|
-        editor_rect = content
-        if !@notes.link_preview.empty?
-          links_rect, editor_rect = carve_links_row(content)
-          screen.text(links_rect.x + 1, links_rect.y, "links", Theme.accent, width: 6)
-          screen.text(links_rect.x + 8, links_rect.y, @notes.link_preview, Theme.muted,
-            width: {links_rect.w - 9, 0}.max)
+      subtabs_focused = focus == :subtabs
+      @subtab_start = BodyChrome.framed_body(screen, rect, shell, subtabs_focused, labels, @notes.current_index, @subtab_start, subtab_hidden, strip_divider: subtab_strip_divider?) do |content|
+        render_with_filter(screen, content, subtabs_focused) do |body|
+          editor_rect = body
+          if !@notes.link_preview.empty?
+            links_rect, editor_rect = carve_links_row(body)
+            screen.text(links_rect.x + 1, links_rect.y, "links", Theme.accent, width: 6)
+            screen.text(links_rect.x + 8, links_rect.y, @notes.link_preview, Theme.muted,
+              width: {links_rect.w - 9, 0}.max)
+          end
+          @notes.render(screen, editor_rect, focused: body_focused)
         end
-        @notes.render(screen, editor_rect, focused: body_focused)
       end
     end
 
@@ -148,7 +151,7 @@ module Gori::Tui
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
       @host.focus_body
-      body = BodyChrome.content_rect(rect, strip: subtab_strip_shown?)
+      body = body_rect_below_filter(rect)
       body = carve_links_row(body)[1] unless @notes.link_preview.empty?
       @notes.click_to_cursor(body, mx, my)
       true
@@ -210,6 +213,21 @@ module Gori::Tui
       true
     end
 
+    # --- sub-tab filter (issue #121) ---
+    def subtab_filter_enabled? : Bool
+      true
+    end
+
+    def filter_fields : Array(String)
+      %w(name) # notes have no HTTP context; free-text covers each note's body text
+    end
+
+    def filter_subjects : Array(Repeater::SubtabFilter::Subject)
+      @notes.filter_rows.map do |(title, body)|
+        Repeater::SubtabFilter::Subject.new(title, body, "", "", [] of String)
+      end
+    end
+
     def body_badge : Symbol
       @notes.insert_mode? ? :editor : :body
     end
@@ -227,17 +245,18 @@ module Gori::Tui
       :notes
     end
 
+    # Filter-aware: ←/→ skip hidden chips; ^1-9 to a hidden chip escapes the filter.
     def move_subtab(dir : Int32) : Nil
-      return unless @notes.count >= 2
-      nidx = (@notes.current_index + dir).clamp(0, @notes.count - 1)
-      return if nidx == @notes.current_index
-      save_notes
-      @notes.switch_note(nidx)
-      refresh_link_preview
+      if t = step_visible(@notes.current_index, dir)
+        save_notes
+        @notes.switch_note(t)
+        refresh_link_preview
+      end
     end
 
     def jump_subtab(idx : Int32) : Nil
       return unless 0 <= idx < @notes.count
+      clear_subtab_filter if (h = subtab_hidden) && h.includes?(idx)
       save_notes
       @notes.switch_note(idx)
       refresh_link_preview

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -52,12 +52,8 @@ module Gori::Tui
         @repeaters << RepeaterTab.new(view, r.flow_id, r.id)
       end
       @current_repeater_idx = @repeaters.empty? ? -1 : 0
-      # Sub-tab filter (issue #121): a live in-memory query (tag:/name:/host:/method: +
-      # free text) that narrows which chips the strip shows. "" = no filter (all shown).
-      @subtab_filter = ""
-      @subtab_filter_editing = false # the `/` bar is capturing keystrokes
-      @filter_cx = 0                 # caret within @subtab_filter
-      @filter_preedit = ""           # live IME composition in the bar
+      # Sub-tab filter state (issue #121) lives in TabController now (shared across the
+      # workbench tabs); Repeater opts in via subtab_filter_enabled? below.
       # Repeater round-trips run off the UI fiber and deliver their Result here; the run
       # loop applies it to the originating view on a later tick (buffered so a finished
       # repeater never blocks its background fiber).
@@ -120,134 +116,32 @@ module Gori::Tui
       end
     end
 
-    # --- sub-tab tag filter (issue #121) ---
+    # --- sub-tab tag filter (issue #121; machinery lifted to TabController) ---
+    # Repeater opts in with the full field language (incl. tags) and, unlike the ≥2
+    # default, shows the guidance bar from the FIRST session (its History-style
+    # discoverability row, documented on subtab_filter_shown? below).
+    def subtab_filter_enabled? : Bool
+      true
+    end
+
+    def filter_fields : Array(String)
+      %w(tag name host method)
+    end
+
+    # The filter bar occupies a body row whenever the strip is up (from the first session),
+    # so idle users see `/ filter · tag: name: …` without having to discover `/` first.
+    def subtab_filter_shown? : Bool
+      subtab_filter_enabled? && subtab_strip_shown?
+    end
+
     # The searchable projection of a session for the in-memory matcher (TUI-free).
     private def filter_subject(v : RepeaterView) : Repeater::SubtabFilter::Subject
       Repeater::SubtabFilter::Subject.new(v.name, v.summary(200), v.target, v.request_method, v.tags)
     end
 
-    # Absolute chip indices hidden by the active filter; nil when no filter is set.
-    def subtab_hidden : Set(Int32)?
-      return nil if @subtab_filter.blank?
-      f = Repeater::SubtabFilter.parse(@subtab_filter)
-      hidden = Set(Int32).new
-      @repeaters.each_with_index { |t, i| hidden << i unless f.matches?(filter_subject(t.view)) }
-      hidden
-    end
-
-    # Absolute indices of the sessions the filter keeps visible (all when unfiltered).
-    def visible_indices : Array(Int32)
-      h = subtab_hidden
-      return (0...@repeaters.size).to_a unless h
-      (0...@repeaters.size).reject { |i| h.includes?(i) }
-    end
-
-    # Cold-start hint shown on the suggestion row while editing with nothing typed
-    # yet — spells out the fields and that bare words are a free-text search, so the
-    # filter language is discoverable the moment `/` opens (mirrors History).
-    FILTER_EDIT_HINT = "fields:  tag:  name:  host:  method:    ·    or type words to search"
-
-    # The `/` bar is currently capturing keystrokes (the shell routes keys here).
-    def subtab_filter_editing? : Bool
-      @subtab_filter_editing
-    end
-
-    # True at a cold start (nothing typed, or the caret sits just after a space) — used
-    # to decide whether the suggestion row shows the standing FILTER_EDIT_HINT.
-    private def filter_token_empty? : Bool
-      Repeater::SubtabFilter.token_at(@subtab_filter, @filter_cx)[0].empty?
-    end
-
-    # The filter bar always occupies a body row when the strip is up (History-style
-    # guidance), so idle users see `/ filter · tag: name: …` without having to discover
-    # `/` first. Empty Repeater (no sessions) keeps the full body for the empty state.
-    def subtab_filter_shown? : Bool
-      subtab_strip_shown?
-    end
-
-    # Open the `/` filter bar (from the strip or the space menu), seeding the caret.
-    def start_subtab_filter : Nil
-      @subtab_filter_editing = true
-      @filter_cx = @subtab_filter.size
-      @filter_preedit = ""
-    end
-
-    # Enter: keep the (possibly blank) filter and leave edit mode; re-anchor the current
-    # session onto a still-visible chip so the body matches the narrowed strip.
-    def commit_subtab_filter : Nil
-      @subtab_filter_editing = false
-      @filter_preedit = ""
-      reanchor_current
-    end
-
-    # Esc: drop the filter entirely and leave edit mode (every chip returns; idle
-    # guidance row stays visible under the strip).
-    def clear_subtab_filter : Nil
-      @subtab_filter = ""
-      @subtab_filter_editing = false
-      @filter_cx = 0
-      @filter_preedit = ""
-    end
-
-    def set_subtab_filter_preedit(text : String) : Nil
-      @filter_preedit = text
-    end
-
-    def handle_subtab_filter_key(ev : Termisu::Event::Key) : Nil
-      key = ev.key
-      c = ev.char || key.to_char
-      if key.escape?
-        clear_subtab_filter
-      elsif key.enter?
-        commit_subtab_filter
-      elsif key.tab?
-        complete_subtab_filter # History-style Tab: first suggestion for the token
-      elsif key.backspace?
-        if @filter_cx > 0
-          @subtab_filter = @subtab_filter[0, @filter_cx - 1] + @subtab_filter[@filter_cx..]
-          @filter_cx -= 1
-        end
-        @filter_preedit = ""
-      elsif key.left?
-        @filter_cx = {@filter_cx - 1, 0}.max
-      elsif key.right?
-        @filter_cx = {@filter_cx + 1, @subtab_filter.size}.min
-      elsif c && !ev.ctrl? && !ev.alt? && !c.control?
-        @subtab_filter = @subtab_filter[0, @filter_cx] + c + @subtab_filter[@filter_cx..]
-        @filter_cx += 1
-        @filter_preedit = ""
-      end
-    end
-
-    # Subjects for the in-memory filter matcher + Tab suggestions (all open sessions).
-    private def filter_subjects : Array(Repeater::SubtabFilter::Subject)
+    # One Subject per open session, in chip order (the base's filter projection hook).
+    def filter_subjects : Array(Repeater::SubtabFilter::Subject)
       @repeaters.map { |t| filter_subject(t.view) }
-    end
-
-    def filter_suggestions : Array(String)
-      return [] of String unless @subtab_filter_editing
-      Repeater::SubtabFilter.suggestions(@subtab_filter, @filter_cx, filter_subjects)
-    end
-
-    # Replace the token under the caret with the first suggestion (History query_complete).
-    def complete_subtab_filter : Bool
-      sugg = filter_suggestions
-      return false if sugg.empty?
-      _, s, e = Repeater::SubtabFilter.token_at(@subtab_filter, @filter_cx)
-      first = sugg.first
-      @subtab_filter = "#{@subtab_filter[0, s]}#{first}#{@subtab_filter[e..]}"
-      @filter_cx = s + first.size
-      @filter_preedit = ""
-      true
-    end
-
-    # Keep the current session on a visible chip: if the filter hid it, jump to the
-    # first still-visible session (never while empty — clearing the filter restores it).
-    private def reanchor_current : Nil
-      vis = visible_indices
-      return if vis.empty? || vis.includes?(@current_repeater_idx)
-      save_current_repeater
-      @current_repeater_idx = vis.first
     end
 
     def subtab_index : Int32
@@ -291,12 +185,6 @@ module Gori::Tui
     # no strip (the "no repeaters" placeholder takes the full body).
     def subtab_strip_shown? : Bool
       !@repeaters.empty?
-    end
-
-    # Filter bar owns the hairline under chips+filter so the divider sits below the
-    # guidance row, not between chips and filter.
-    def subtab_strip_divider? : Bool
-      false
     end
 
     def body_badge : Symbol # :editor only while INS (or hex/chain/SNI sub-modes)
@@ -369,10 +257,6 @@ module Gori::Tui
     end
 
     # --- rendering ---
-    # Filter chrome base height: guidance/input row + hairline (owns the strip divider).
-    # While editing, an optional suggestion row sits between input and hairline.
-    FILTER_BAR_H = 2
-
     def render_body(screen : Screen, rect : Rect, focus : Symbol) : Nil
       body_focused = focus == :body
       current_repeater_tab.try { |t| t.view.reveal = @host.reveal?; t.view.pretty = @host.pretty? }
@@ -380,77 +264,14 @@ module Gori::Tui
       shell = BodyChrome.shell_focused(focus, multi_pane: !current_view.nil?)
       subtabs_focused = focus == :subtabs
       @subtab_start = BodyChrome.framed_body(screen, rect, shell, subtabs_focused, labels, @current_repeater_idx, @subtab_start, subtab_hidden, strip_divider: subtab_strip_divider?) do |content|
-        bar, body = carve_filter_bar(content)
-        render_subtab_filter_bar(screen, bar, subtabs_focused: subtabs_focused) if bar
-        if v = current_view
-          v.render(screen, body, focused: body_focused)
-        else
-          TrafficEmptyState.render(screen, body, variant: :repeater)
+        render_with_filter(screen, content, subtabs_focused) do |body|
+          if v = current_view
+            v.render(screen, body, focused: body_focused)
+          else
+            TrafficEmptyState.render(screen, body, variant: :repeater)
+          end
         end
       end
-    end
-
-    # Filter (+ optional suggestions) + hairline carved off the body top. Height is
-    # FILTER_BAR_H idle/active, +1 while editing when there are Tab suggestions.
-    private def carve_filter_bar(content : Rect) : {Rect?, Rect}
-      return {nil, content} unless subtab_filter_shown? && content.h > 0
-      h = filter_bar_height
-      h = {h, content.h}.min
-      bar = Rect.new(content.x, content.y, content.w, h)
-      body = content.h > h ? Rect.new(content.x, content.y + h, content.w, content.h - h) : Rect.new(content.x, content.y + h, content.w, 0)
-      {bar, body}
-    end
-
-    private def filter_bar_height : Int32
-      base = FILTER_BAR_H
-      return base unless @subtab_filter_editing
-      # Reserve the extra row for the suggestion/hint line: live ↹ completions, OR the
-      # cold-start FILTER_EDIT_HINT shown while the token is empty. A non-empty token
-      # with no completions keeps the compact height (nothing to show there).
-      (!filter_suggestions.empty? || filter_token_empty?) ? base + 1 : base
-    end
-
-    # History-style 3-state bar under the sub-tab chips, with the strip hairline
-    # drawn BELOW the filter so chips+filter read as one chrome group:
-    #   editing  → `filter › <input>` [+ `↹ tag:…` suggestions]
-    #   active   → `: <query>`
-    #   idle     → `/ filter  ·  tag:  name:  host:  method:`
-    # Right side always shows visible/total chip counts.
-    private def render_subtab_filter_bar(screen : Screen, rect : Rect, *, subtabs_focused : Bool) : Nil
-      return if rect.w < 8 || rect.h < 1
-      row_y = rect.y
-      screen.fill(Rect.new(rect.x, row_y, rect.w, 1), Theme.panel)
-      vis = visible_indices.size
-      count = "#{vis}/#{@repeaters.size}"
-      count_x = rect.right - count.size
-      left_w = {count_x - 1 - rect.x, 1}.max
-      if @subtab_filter_editing
-        px = screen.text(rect.x, row_y, "filter › ", Theme.accent, Theme.panel)
-        field_w = {count_x - 1 - px, 1}.max
-        screen.input_line(px, row_y, @subtab_filter, @filter_cx, @filter_preedit,
-          Theme.text_bright, Theme.panel, width: field_w)
-      elsif !@subtab_filter.blank?
-        screen.text(rect.x, row_y, ": #{@subtab_filter}", Theme.text, Theme.panel, width: left_w)
-      else
-        screen.text(rect.x, row_y, "/ filter  ·  tag:  name:  host:  method:", Theme.muted, Theme.panel, width: left_w)
-      end
-      screen.text(count_x, row_y, count, vis == 0 ? Theme.red : Theme.muted, Theme.panel)
-
-      div_y = row_y + 1
-      if @subtab_filter_editing && rect.h >= 3
-        sugg = filter_suggestions
-        # Live completions to Tab through, else (at a cold start) the standing hint so the
-        # row isn't blank the instant `/` opens; a non-empty no-match token stays quiet.
-        hint = !sugg.empty? ? "↹ #{sugg.first(8).join("  ")}" : (FILTER_EDIT_HINT if filter_token_empty?)
-        if hint
-          screen.fill(Rect.new(rect.x, row_y + 1, rect.w, 1), Theme.panel)
-          screen.text(rect.x, row_y + 1, hint, Theme.muted, Theme.panel, width: rect.w)
-          div_y = row_y + 2
-        end
-      end
-      return if div_y >= rect.y + rect.h
-      border = subtabs_focused ? Theme.focus_gold : Theme.border
-      screen.hline(rect.x, div_y, rect.w, fg: border, bg: Theme.bg)
     end
 
     # --- input ---
@@ -683,8 +504,7 @@ module Gori::Tui
     end
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
-      body = BodyChrome.content_rect(rect, strip: subtab_strip_shown?, strip_divider: subtab_strip_divider?)
-      _, body = carve_filter_bar(body) # keep body clicks aligned when the filter bar is up
+      body = body_rect_below_filter(rect) # below the strip + filter bar (shared with render)
       return true unless v = current_view
       # Border chips/badges consume the click (no caret move) — same toggles as keys.
       if chip = v.chrome_hit(body, mx, my)

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -281,6 +281,11 @@ module Gori::Tui
       s.size > max ? "#{s[0, max - 1]}…" : s
     end
 
+    # HTTP method from the template's request line — feeds the sub-tab filter's `method:`.
+    def request_method : String
+      (@editor.first_nonblank_line || "").strip.split(' ').first? || ""
+    end
+
     def label(max : Int32 = 18) : String
       if (n = @name) && !(t = n.strip).empty?
         t.size > max ? "#{t[0, max - 1]}…" : t

--- a/src/gori/tui/miner_view.cr
+++ b/src/gori/tui/miner_view.cr
@@ -145,6 +145,11 @@ module Gori::Tui
       String.new(@request[0, {@request.size, 256}.min]).each_line.first? || ""
     end
 
+    # HTTP method from the request line — feeds the sub-tab filter's `method:`.
+    def request_method : String
+      request_line.strip.split(' ').first? || ""
+    end
+
     def summary(max : Int32 = 32) : String
       parts = request_line.strip.split(' ')
       s = "#{parts[0]?} #{parts[1]?}".strip

--- a/src/gori/tui/notes_view.cr
+++ b/src/gori/tui/notes_view.cr
@@ -420,6 +420,13 @@ module Gori::Tui
       @notes.map_with_index { |note, i| "#{i + 1}:#{note.label(i)}" }
     end
 
+    # The sub-tab filter's searchable projection (one per note, in chip order): the note's
+    # title (nil when blank) + its full body text, so a note is findable by title or by
+    # any content it holds. See NotesController#filter_subjects.
+    def filter_rows : Array({String?, String})
+      @notes.map { |note| {Notes.title(note.area.text), note.area.text} }
+    end
+
     # The note currently being edited; @current is kept in range by every mutator.
     private def current : Note
       @notes[@current.clamp(0, @notes.size - 1)]

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -807,8 +807,8 @@ module Gori::Tui
         @import_preedit = text
         return
       end
-      if @active_tab == :repeater && repeater_controller.subtab_filter_editing?
-        repeater_controller.set_subtab_filter_preedit(text)
+      if (ctl = @tabs[@active_tab]?) && ctl.subtab_filter_editing?
+        ctl.set_subtab_filter_preedit(text)
         return
       end
       # Route preedit to whichever input is active so composing text (e.g. Hangul
@@ -934,10 +934,11 @@ module Gori::Tui
       if @active_tab == :probe && @overlay == :none && @focus == :body && probe_controller.view.querying?
         return if probe_controller.handle_query_key(ev)
       end
-      # Repeater sub-tab filter (issue #121): the `/` bar captures keys until Enter/Esc.
-      # Opened from the strip (not the body), so it's not gated on @focus.
-      if @active_tab == :repeater && @overlay == :none && repeater_controller.subtab_filter_editing?
-        repeater_controller.handle_subtab_filter_key(ev)
+      # Sub-tab filter (issue #121): the `/` bar captures keys until Enter/Esc. Opened
+      # from the strip (not the body), so it's not gated on @focus. Generic across the
+      # workbench tabs — only the active tab's controller can be in filter-edit mode.
+      if @overlay == :none && (ctl = @tabs[@active_tab]?) && ctl.subtab_filter_editing?
+        ctl.handle_subtab_filter_key(ev)
         return
       end
       if @active_tab == :issues && @overlay == :none && @focus == :body && issues_controller.view.detail_open?
@@ -2822,8 +2823,8 @@ module Gori::Tui
         repeater_controller.repeater_send # send from the strip too — not just :body focus
       when @active_tab == :repeater && !ev.ctrl? && !ev.alt? && key.lower_t?
         open_tag_edit(current_subtab_index) # tag the active Repeater sub-tab (issue #121)
-      when @active_tab == :repeater && !ev.ctrl? && !ev.alt? && c == '/'
-        repeater_controller.start_subtab_filter # open the `/` tag-filter bar
+      when !ev.ctrl? && !ev.alt? && c == '/' && @tabs[@active_tab]?.try(&.subtab_filter_shown?)
+        @tabs[@active_tab]?.try(&.start_subtab_filter) # open the `/` sub-tab filter bar
       when key.left?, key.lower_h?
         move_subtab(-1)
       when key.right?, key.lower_l?
@@ -4727,6 +4728,13 @@ module Gori::Tui
 
     def subtab_search_count : Int32
       @tabs[@active_tab]?.try(&.subtab_count) || 0
+    end
+
+    # Open the `/` sub-tab filter bar over the ACTIVE tab's strip (generic sibling of
+    # subtab_search_open). Each opt-in controller owns the bar; a no-op on tabs that
+    # don't support filtering (start_subtab_filter guards on subtab_filter_enabled?).
+    def subtab_filter_open : Nil
+      @tabs[@active_tab]?.try(&.start_subtab_filter)
     end
 
     def repeater_subtab_count : Int32

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -1,6 +1,7 @@
 require "termisu"
 require "../verb"
 require "../session"
+require "../repeater/subtab_filter"
 require "./screen"
 require "./geometry"
 require "./frame"
@@ -152,6 +153,15 @@ module Gori::Tui
   abstract class TabController
     property subtab_start : Int32 = 0
 
+    # --- sub-tab filter (issue #121; shared across the multi-session workbench tabs) ---
+    # A live in-memory query (tag:/name:/host:/method: + free text) that narrows which
+    # chips the strip shows. Opt-in per tab via subtab_filter_enabled? + filter_subjects;
+    # non-participating tabs (History, Help, …) leave these at their inert defaults.
+    @subtab_filter = ""            # the live query string ("" = no filter, all shown)
+    @subtab_filter_editing = false # the `/` bar is capturing keystrokes
+    @filter_cx = 0                 # caret index within @subtab_filter
+    @filter_preedit = ""           # live IME composition in the bar
+
     def initialize(@host : Host)
     end
 
@@ -247,19 +257,251 @@ module Gori::Tui
       subtab_labels.try(&.size) || 0
     end
 
-    # Absolute chip indices to hide from the strip (Repeater's tag filter); nil = show
-    # all. Rendering + click hit-tests skip these, but the indices stay absolute so
-    # jump/rename/^N keep working unchanged.
+    # Absolute chip indices hidden by the active sub-tab filter; nil = show all (also nil
+    # for tabs that don't opt into filtering). Rendering + click hit-tests skip these, but
+    # the indices stay absolute so jump/rename/^N keep working unchanged.
     def subtab_hidden : Set(Int32)?
-      nil
+      return nil unless subtab_filter_enabled?
+      return nil if @subtab_filter.blank?
+      f = Repeater::SubtabFilter.parse(@subtab_filter)
+      subjects = filter_subjects
+      hidden = Set(Int32).new
+      subjects.each_with_index { |s, i| hidden << i unless f.matches?(s) }
+      hidden
     end
 
-    # Whether BodyChrome carves the hairline under the chip row. Default true.
-    # Repeater returns false so its filter bar can draw the divider under chips+filter
-    # as one chrome group (runner strip hit-tests must use the same flag).
+    # Absolute indices of the sub-tabs the filter keeps visible (all when unfiltered).
+    def visible_indices : Array(Int32)
+      h = subtab_hidden
+      return (0...subtab_count).to_a unless h
+      (0...subtab_count).reject { |i| h.includes?(i) }
+    end
+
+    # Whether BodyChrome carves the hairline under the chip row. When a filter bar is
+    # shown the bar owns the hairline (draws it under chips+filter as one chrome group),
+    # so this is false; otherwise true. Runner strip hit-tests read the same flag.
     def subtab_strip_divider? : Bool
+      !subtab_filter_shown?
+    end
+
+    # ===== sub-tab filter subsystem (issue #121) =============================
+    # Opt-in switch: this tab supports the `/` sub-tab filter bar. Default off — History,
+    # Help, … never show it. The five workbench tabs + Repeater override to true.
+    def subtab_filter_enabled? : Bool
+      false
+    end
+
+    # The searchable projection of each sub-tab, in chip order (one Subject per label).
+    # The matcher + Tab suggestions run over these. Default empty (nothing to filter).
+    def filter_subjects : Array(Repeater::SubtabFilter::Subject)
+      [] of Repeater::SubtabFilter::Subject
+    end
+
+    # The field names this tab advertises in the filter bar guidance/hint rows (and the
+    # only fields Tab-completes). HTTP tabs override to name/host/method; Repeater adds tag.
+    def filter_fields : Array(String)
+      %w(name)
+    end
+
+    # The filter bar occupies a body row whenever there are ≥2 sub-tabs to filter (below
+    # that there is nothing to narrow). Repeater overrides to show it from the first
+    # session (its own History-style discoverability row).
+    def subtab_filter_shown? : Bool
+      subtab_filter_enabled? && subtab_count >= 2
+    end
+
+    # The `/` bar is currently capturing keystrokes (the shell routes keys here).
+    def subtab_filter_editing? : Bool
+      @subtab_filter_editing
+    end
+
+    # True at a cold start (nothing typed, or the caret sits just after a space) — decides
+    # whether the suggestion row shows the standing field hint.
+    private def filter_token_empty? : Bool
+      Repeater::SubtabFilter.token_at(@subtab_filter, @filter_cx)[0].empty?
+    end
+
+    # Open the `/` filter bar (from the strip or the space menu), seeding the caret.
+    def start_subtab_filter : Nil
+      return unless subtab_filter_enabled?
+      @subtab_filter_editing = true
+      @filter_cx = @subtab_filter.size
+      @filter_preedit = ""
+    end
+
+    # Enter: keep the (possibly blank) filter and leave edit mode; re-anchor the current
+    # session onto a still-visible chip so the body matches the narrowed strip.
+    def commit_subtab_filter : Nil
+      @subtab_filter_editing = false
+      @filter_preedit = ""
+      reanchor_current
+    end
+
+    # Esc: drop the filter entirely and leave edit mode (every chip returns).
+    def clear_subtab_filter : Nil
+      @subtab_filter = ""
+      @subtab_filter_editing = false
+      @filter_cx = 0
+      @filter_preedit = ""
+    end
+
+    def set_subtab_filter_preedit(text : String) : Nil
+      @filter_preedit = text
+    end
+
+    def handle_subtab_filter_key(ev : Termisu::Event::Key) : Nil
+      key = ev.key
+      c = ev.char || key.to_char
+      if key.escape?
+        clear_subtab_filter
+      elsif key.enter?
+        commit_subtab_filter
+      elsif key.tab?
+        complete_subtab_filter # History-style Tab: first suggestion for the token
+      elsif key.backspace?
+        if @filter_cx > 0
+          @subtab_filter = @subtab_filter[0, @filter_cx - 1] + @subtab_filter[@filter_cx..]
+          @filter_cx -= 1
+        end
+        @filter_preedit = ""
+      elsif key.left?
+        @filter_cx = {@filter_cx - 1, 0}.max
+      elsif key.right?
+        @filter_cx = {@filter_cx + 1, @subtab_filter.size}.min
+      elsif c && !ev.ctrl? && !ev.alt? && !c.control?
+        @subtab_filter = @subtab_filter[0, @filter_cx] + c + @subtab_filter[@filter_cx..]
+        @filter_cx += 1
+        @filter_preedit = ""
+      end
+    end
+
+    def filter_suggestions : Array(String)
+      return [] of String unless @subtab_filter_editing
+      Repeater::SubtabFilter.suggestions(@subtab_filter, @filter_cx, filter_subjects, filter_fields)
+    end
+
+    # Replace the token under the caret with the first suggestion (History query_complete).
+    def complete_subtab_filter : Bool
+      sugg = filter_suggestions
+      return false if sugg.empty?
+      _, s, e = Repeater::SubtabFilter.token_at(@subtab_filter, @filter_cx)
+      first = sugg.first
+      @subtab_filter = "#{@subtab_filter[0, s]}#{first}#{@subtab_filter[e..]}"
+      @filter_cx = s + first.size
+      @filter_preedit = ""
       true
     end
+
+    # Keep the current session on a visible chip: if the filter hid it, jump to the first
+    # still-visible session (jump_subtab saves the outgoing session as each tab requires).
+    private def reanchor_current : Nil
+      return unless subtab_filter_enabled?
+      vis = visible_indices
+      return if vis.empty? || vis.includes?(subtab_index)
+      jump_subtab(vis.first)
+    end
+
+    # The next VISIBLE absolute index stepping `dir` from `current` (filter-aware strip
+    # nav), or nil when there is nowhere to move. Controllers use this in move_subtab so
+    # ←/→ skip hidden chips. A current index that was filtered out steps onto an edge.
+    protected def step_visible(current : Int32, dir : Int32) : Int32?
+      vis = visible_indices
+      return nil if vis.size < 2
+      cur = vis.index(current)
+      target = cur ? vis[(cur + dir).clamp(0, vis.size - 1)] : (dir < 0 ? vis.first : vis.last)
+      target == current ? nil : target
+    end
+
+    # --- filter bar rendering (shared by every opt-in tab's render_body) ---
+    # Base height: guidance/input row + hairline (the bar owns the strip divider). While
+    # editing, an optional suggestion row sits between the input and the hairline.
+    FILTER_BAR_H = 2
+
+    # Cold-start hint (nothing typed) — spells out the tab's advertised fields + that bare
+    # words are a free-text search, so the language is discoverable the moment `/` opens.
+    private def filter_edit_hint : String
+      "fields:  #{filter_fields.map { |f| "#{f}:" }.join("  ")}    ·    or type words to search"
+    end
+
+    # Opt-in tabs call this inside their framed_body block: carve the filter bar off the
+    # content top, draw it, and yield the body rect below (unchanged content when no bar).
+    protected def render_with_filter(screen : Screen, content : Rect, subtabs_focused : Bool, & : Rect ->) : Nil
+      bar, body = carve_filter_bar(content)
+      render_subtab_filter_bar(screen, bar, subtabs_focused: subtabs_focused) if bar
+      yield body
+    end
+
+    # The body rect below the sub-tab strip AND the filter bar — shared by render + click
+    # hit-tests so body clicks land where the body is actually drawn.
+    protected def body_rect_below_filter(rect : Rect) : Rect
+      content = BodyChrome.content_rect(rect, strip: subtab_strip_shown?, strip_divider: subtab_strip_divider?)
+      carve_filter_bar(content)[1]
+    end
+
+    # Filter (+ optional suggestion row) + hairline carved off the body top. Height is
+    # FILTER_BAR_H idle/active, +1 while editing when there are Tab suggestions/a hint.
+    private def carve_filter_bar(content : Rect) : {Rect?, Rect}
+      return {nil, content} unless subtab_filter_shown? && content.h > 0
+      h = filter_bar_height
+      h = {h, content.h}.min
+      bar = Rect.new(content.x, content.y, content.w, h)
+      body = content.h > h ? Rect.new(content.x, content.y + h, content.w, content.h - h) : Rect.new(content.x, content.y + h, content.w, 0)
+      {bar, body}
+    end
+
+    private def filter_bar_height : Int32
+      base = FILTER_BAR_H
+      return base unless @subtab_filter_editing
+      # Reserve the extra row for the suggestion/hint line: live ↹ completions, OR the
+      # cold-start field hint shown while the token is empty. A non-empty token with no
+      # completions keeps the compact height (nothing to show there).
+      (!filter_suggestions.empty? || filter_token_empty?) ? base + 1 : base
+    end
+
+    # History-style 3-state bar under the sub-tab chips, with the strip hairline drawn
+    # BELOW the filter so chips+filter read as one chrome group:
+    #   editing  → `filter › <input>` [+ `↹ name:…` suggestions]
+    #   active   → `: <query>`
+    #   idle     → `/ filter  ·  name:  host:  method:` (this tab's advertised fields)
+    # Right side always shows visible/total chip counts.
+    private def render_subtab_filter_bar(screen : Screen, rect : Rect, *, subtabs_focused : Bool) : Nil
+      return if rect.w < 8 || rect.h < 1
+      row_y = rect.y
+      screen.fill(Rect.new(rect.x, row_y, rect.w, 1), Theme.panel)
+      vis = visible_indices.size
+      count = "#{vis}/#{subtab_count}"
+      count_x = rect.right - count.size
+      left_w = {count_x - 1 - rect.x, 1}.max
+      if @subtab_filter_editing
+        px = screen.text(rect.x, row_y, "filter › ", Theme.accent, Theme.panel)
+        field_w = {count_x - 1 - px, 1}.max
+        screen.input_line(px, row_y, @subtab_filter, @filter_cx, @filter_preedit,
+          Theme.text_bright, Theme.panel, width: field_w)
+      elsif !@subtab_filter.blank?
+        screen.text(rect.x, row_y, ": #{@subtab_filter}", Theme.text, Theme.panel, width: left_w)
+      else
+        screen.text(rect.x, row_y, "/ filter  ·  #{filter_fields.map { |f| "#{f}:" }.join("  ")}", Theme.muted, Theme.panel, width: left_w)
+      end
+      screen.text(count_x, row_y, count, vis == 0 ? Theme.red : Theme.muted, Theme.panel)
+
+      div_y = row_y + 1
+      if @subtab_filter_editing && rect.h >= 3
+        sugg = filter_suggestions
+        # Live completions to Tab through, else (at a cold start) the standing hint so the
+        # row isn't blank the instant `/` opens; a non-empty no-match token stays quiet.
+        hint = !sugg.empty? ? "↹ #{sugg.first(8).join("  ")}" : (filter_edit_hint if filter_token_empty?)
+        if hint
+          screen.fill(Rect.new(rect.x, row_y + 1, rect.w, 1), Theme.panel)
+          screen.text(rect.x, row_y + 1, hint, Theme.muted, Theme.panel, width: rect.w)
+          div_y = row_y + 2
+        end
+      end
+      return if div_y >= rect.y + rect.h
+      border = subtabs_focused ? Theme.focus_gold : Theme.border
+      screen.hline(rect.x, div_y, rect.w, fg: border, bg: Theme.bg)
+    end
+
+    # ===== end sub-tab filter subsystem =====================================
 
     # A FIXED strip (Help): the chip set is constant — no ^N/^W create/close and the
     # body is read-only. The shell drops "new/close/edit" from the strip hint for it.

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -81,6 +81,7 @@ module Gori
       # terminals can't deliver). Operate on the active tab; count gates the menu entry.
       abstract def subtab_search_open : Nil                # open the sub-tab search picker for the active tab
       abstract def subtab_search_count : Int32             # active tab's open sub-tab count (gates the search entry)
+      abstract def subtab_filter_open : Nil                # open the `/` sub-tab filter bar for the active tab (issue #121)
       abstract def repeater_rename_subtab : Nil              # open the rename prompt for the active sub-tab
       abstract def repeater_tag_subtab : Nil                 # open the tag editor for the active sub-tab (issue #121)
       abstract def repeater_filter_subtabs : Nil             # open the `/` tag-filter bar over the sub-tab strip

--- a/src/gori/verbs/comparer.cr
+++ b/src/gori/verbs/comparer.cr
@@ -45,6 +45,20 @@ module Gori
         "comparer.duplicate-subtab", "Duplicate comparison", "Clone the active A/B pair into a new sub-tab",
         Verb::Scope::Comparer, available: in_comparer, mnemonic: 'd',
         section: :subtab) { |ctx| ctx.comparer_duplicate_subtab; nil }
+
+      # Sub-tab search + inline filter (issue #121), section :tab — like the other
+      # workbench tabs. Both gate on ≥2 open comparisons. 'f'/'/' are free in this scope.
+      r.register Verb::Definition.new(
+        "comparer.find-subtab", "Search sub-tabs", "Filter the open comparisons and jump to one",
+        Verb::Scope::Comparer,
+        available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :comparer && ctx.subtab_search_count >= 2 },
+        mnemonic: 'f', section: :tab) { |ctx| ctx.subtab_search_open; nil }
+
+      r.register Verb::Definition.new(
+        "comparer.filter-subtabs", "Filter sub-tabs", "Filter the comparison sub-tab strip by name / host / method",
+        Verb::Scope::Comparer,
+        available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :comparer && ctx.subtab_search_count >= 2 },
+        mnemonic: '/', section: :tab) { |ctx| ctx.subtab_filter_open; nil }
     end
   end
 end

--- a/src/gori/verbs/decoder.cr
+++ b/src/gori/verbs/decoder.cr
@@ -74,6 +74,14 @@ module Gori
         Verb::Scope::Decoder,
         available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :decoder && ctx.subtab_search_count >= 2 },
         mnemonic: 'f', section: :tab) { |ctx| ctx.subtab_search_open; nil }
+
+      # Inline `/` filter bar over the conversion sub-tab strip (issue #121) — narrows
+      # chips by name / free-text over the chain + input. '/' is the shared filter idiom.
+      r.register Verb::Definition.new(
+        "decoder.filter-subtabs", "Filter sub-tabs", "Filter the conversion sub-tab strip by name / text",
+        Verb::Scope::Decoder,
+        available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :decoder && ctx.subtab_search_count >= 2 },
+        mnemonic: '/', section: :tab) { |ctx| ctx.subtab_filter_open; nil }
     end
   end
 end

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -358,6 +358,14 @@ module Gori
         available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :fuzzer && ctx.subtab_search_count >= 2 },
         mnemonic: 'f', section: :tab) { |ctx| ctx.subtab_search_open; nil }
 
+      # Inline `/` filter bar over the fuzz sub-tab strip (issue #121) — narrows chips by
+      # name / host / method + free text. '/' is the shared filter idiom (unique in :tab).
+      r.register Verb::Definition.new(
+        "fuzz.filter-subtabs", "Filter sub-tabs", "Filter the fuzz sub-tab strip by name / host / method",
+        Verb::Scope::Fuzzer,
+        available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :fuzzer && ctx.subtab_search_count >= 2 },
+        mnemonic: '/', section: :tab) { |ctx| ctx.subtab_filter_open; nil }
+
       # Sub-tab rename/close — mirrors repeater.rename-subtab/repeater.close-subtab above:
       # the strip's raw `r` rename / ^W close, promoted to verbs so :subtab isn't
       # empty. 'e'/'w' are free in COMMON ∪ :subtab (Fuzzer COMMON keys: r/s/y/k/u/S/v).
@@ -439,6 +447,20 @@ module Gori
       r.register Verb::Definition.new(
         "mine.duplicate-subtab", "Duplicate subtab", "Open a new miner session with the same request and config",
         Verb::Scope::Miner, available: in_miner, mnemonic: 'd', section: :subtab) { |ctx| ctx.miner_duplicate_subtab; nil }
+
+      # Sub-tab search + inline filter (issue #121), section :tab — brings Miner to full
+      # sub-tab parity (it had neither). Both gate on ≥2 sessions. 'f'/'/' are free here.
+      r.register Verb::Definition.new(
+        "mine.find-subtab", "Search sub-tabs", "Filter the open mining sessions and jump to one",
+        Verb::Scope::Miner,
+        available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :miner && ctx.subtab_search_count >= 2 },
+        mnemonic: 'f', section: :tab) { |ctx| ctx.subtab_search_open; nil }
+
+      r.register Verb::Definition.new(
+        "mine.filter-subtabs", "Filter sub-tabs", "Filter the mining sub-tab strip by name / host / method",
+        Verb::Scope::Miner,
+        available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :miner && ctx.subtab_search_count >= 2 },
+        mnemonic: '/', section: :tab) { |ctx| ctx.subtab_filter_open; nil }
 
       # Repeater's/Fuzzer's "Link to issue/note" (Round 5 — relocated OUT of
       # register_links, which registers before register_fuzz/register_miner in

--- a/src/gori/verbs/notes.cr
+++ b/src/gori/verbs/notes.cr
@@ -32,6 +32,14 @@ module Gori
         available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :notes && ctx.subtab_search_count >= 2 },
         mnemonic: 's', section: :tab) { |ctx| ctx.subtab_search_open; nil }
 
+      # Inline `/` filter bar over the note sub-tab strip (issue #121) — narrows chips by
+      # name / free-text over the body. '/' is the shared filter idiom (unique in :tab).
+      r.register Verb::Definition.new(
+        "notes.filter-subtabs", "Filter sub-tabs", "Filter the note sub-tab strip by name / text",
+        Verb::Scope::Notes,
+        available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :notes && ctx.subtab_search_count >= 2 },
+        mnemonic: '/', section: :tab) { |ctx| ctx.subtab_filter_open; nil }
+
       # The single smart Copy (see repeater.copy in verbs/history.cr) — copy-all is gone.
       in_notes_read = ->(ctx : Verb::ExecContext) { ctx.current_tab == :notes && ctx.notes_read_mode? }
       r.register Verb::Definition.new(


### PR DESCRIPTION
## Summary

Brings Repeater's `/` sub-tab filter bar (issue #121) to the other five multi-session workbench tabs — **Notes, Fuzzer, Decoder, Comparer, Miner** — so a user with many open sub-tabs can narrow the strip the same way everywhere.

The filter machinery is **lifted out of `RepeaterController` into the shared `TabController` base**, since the runner's strip chrome (chip clicks, right-click menu, rendering) already dispatches through the base hooks `subtab_hidden` / `subtab_strip_divider?`. Each tab opts in with three small hooks; the three `@active_tab == :repeater` gates in the runner are generalised to dispatch on the active tab controller.

## Behaviour

- `/` on the focused sub-tab strip (or `space → "Filter sub-tabs"`) opens a live query bar that narrows the chips.
- Enter commits (re-anchors onto a visible chip), Esc clears, Tab completes, `←/→` skip hidden chips, `^1-9` escapes the filter. Right side shows `visible/total`.
- **Adaptive fields per tab**: HTTP-backed tabs (Fuzzer/Miner/Comparer) advertise `name: host: method:`; text tabs (Notes/Decoder) advertise `name:` + free-text over their content (note body / chain+input). Repeater keeps `tag: name: host: method:` unchanged.
- Also adds the simpler **find-subtab picker** (`space → "Search sub-tabs"`) to **Comparer** and **Miner**, which lacked it, for full sub-tab parity.

## Implementation

- `tab_controller.cr` (+256): filter state, lifecycle/key-handling, suggestions, hidden-index computation, filter-aware nav helpers, and the bar rendering — all shared. New opt-in hooks: `subtab_filter_enabled?`, `filter_subjects`, `filter_fields`.
- `repeater_controller.cr` (−230 net): collapsed onto the base; keeps only its projection + tag-inclusive `filter_fields` + ≥1-session bar override.
- Five controllers: opt in + filter-aware `render_body`/`handle_click`/`move_subtab`/`jump_subtab`.
- View projections: `NotesView#filter_rows`, `ComparerView#filter_subject`, `Fuzzer/MinerView#request_method`.
- Engine: additive `fields` param on `SubtabFilter.suggestions` for adaptive completion (backward compatible).
- Verbs: `<tab>.filter-subtabs` for the five tabs + `comparer.find-subtab` / `mine.find-subtab`.

## Testing

- `crystal build` (codegen) + type-check clean.
- Full spec suite **1880 examples, 0 failures** (added: engine `fields` case, `NotesView#filter_rows` and `ComparerView#filter_subject` projection specs).
- Drove a live `ComparerController` through the real render + key path via `MemoryBackend`: idle bar renders `/ filter · name: host: method:` + `2/2`; typing `host:api` hides the non-matching chip (`1/2`, `: host:api`) and commit re-anchors to the visible session; clear restores all chips.
- Regression: Repeater's bar still shows from a single session and reads `tag: name: host: method:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)