### PR TITLE
feat(tui): fuzzer CHAIN goes contextual + Run moves to the template border

### DIFF
--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -72,7 +72,7 @@ describe Gori::Tui::FuzzerView do
       backend.contains?("admin,root,guest").should be_true
     end
 
-    it "walks the single row cursor: sets → Add → Mode → Advanced → Run (clamped)" do
+    it "walks the single row cursor: sets → Add → Mode → Advanced (clamped)" do
       view = loaded_fuzzer
       view.apply_set(nil, Gori::Tui::SetSpec.new(:list, "a"))
       view.focus_config
@@ -81,8 +81,7 @@ describe Gori::Tui::FuzzerView do
       view.form_move(1); view.config_row.should eq(:add)
       view.form_move(1); view.config_row.should eq(:mode)
       view.form_move(1); view.config_row.should eq(:advanced)
-      view.form_move(1); view.config_row.should eq(:run)
-      view.form_move(1); view.config_row.should eq(:run) # clamped at the last row
+      view.form_move(1); view.config_row.should eq(:advanced) # clamped at the last row (Run moved to the TEMPLATE border)
     end
 
     it "←/→ only cycles Mode — a no-op on every other row (the de-overload)" do

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -127,10 +127,10 @@ module Gori::Tui
         else
           "i/↵ edit · #{read_common} · #{mark} params · ^O config · #{run} run · ↹ pane · esc tabs"
         end
-      when :config   then config_hint(v, run)
-      when :results  then "↑/↓ select · ↵ detail · o sort · m matched · v dist · #{run} run · #{stop} stop · space cmds · ↹ pane"
-      when :detail   then "↑/↓ move · #{read_common} · ←/→ pane · ⇧←/→ h-scroll · esc back"
-      else                "↹/esc tabs"
+      when :config  then config_hint(v, run)
+      when :results then "↑/↓ select · ↵ detail · o sort · m matched · v dist · #{run} run · #{stop} stop · space cmds · ↹ pane"
+      when :detail  then "↑/↓ move · #{read_common} · ←/→ pane · ⇧←/→ h-scroll · esc back"
+      else               "↹/esc tabs"
       end
     end
 
@@ -139,7 +139,6 @@ module Gori::Tui
       when :set  then "↑/↓ row · ↵ edit set · Del remove · #{run} run · ↹ pane"
       when :add  then "↵ add a payload set · ^L quick List · ↑/↓ row · #{run} run · ↹ pane"
       when :mode then "←/→ mode · ↵ open editor · ↑/↓ row · #{run} run · ↹ pane"
-      when :run  then "↵ run · ↑/↓ row · ^O sets · ↹ pane"
       else            "↵ open Advanced · ↑/↓ row · #{run} run · ↹ pane"
       end
     end
@@ -314,7 +313,7 @@ module Gori::Tui
       case
       when key.enter?, key.down? then v.pane_advance(1)
       when key.up?               then @host.request_focus(subtab_strip_shown? ? :subtabs : :menu)
-      else                          edit_target_common(ev, v)
+      else                            edit_target_common(ev, v)
       end
       true
     end
@@ -426,14 +425,14 @@ module Gori::Tui
       end
     end
 
-    # ↵ on a config row: drill into the Set / Advanced overlay, cycle Mode, or run.
+    # ↵ on a config row: drill into the Set / Advanced overlay, or cycle Mode. (Run is no
+    # longer a config row — it's the TEMPLATE border's ^R:RUN badge / the rebindable ^R verb.)
     private def activate_config_row(v : FuzzerView) : Nil
       case v.config_row
       when :set      then @host.open_fuzz_set_editor(v.current_set_index)
       when :add      then @host.open_fuzz_set_editor(nil)
       when :mode     then v.cycle_mode_forward
       when :advanced then @host.open_fuzz_advanced_editor
-      when :run      then fuzz_run
       end
     end
 
@@ -500,6 +499,15 @@ module Gori::Tui
         when :match then @host.status(v.toggle_matched_only)
         when :sort  then @host.status(v.cycle_sort)
         end
+        return true
+      end
+      # The TEMPLATE border's ^R:RUN badge — the primary action, clickable like a button
+      # (mirrors the Repeater's ^R:SEND). Consumes the click (no caret move / focus race).
+      if v.template_chrome_hit(body, mx, my) == :run
+        save_current
+        @host.focus_body
+        v.focus_pane(:template)
+        fuzz_run
         return true
       end
       return true unless pane = v.pane_at(body, mx, my)
@@ -581,7 +589,7 @@ module Gori::Tui
       when :target   then !v.pane_insert?(:target)
       when :detail   then true
       when :results  then true
-      else               false
+      else                false
       end
     end
 

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -665,18 +665,20 @@ module Gori::Tui
 
     # --- config pane (calm summary) ------------------------------------------
     # A single row cursor @cfg_row (↑/↓) walks: one row per payload set, then the
-    # Add / Mode / Advanced / Run rows. There is NO text field and NO caret in-pane —
-    # all text entry lives in the Set / Advanced overlays — so ←/→ can only ever cycle
-    # (Mode), which removes the old caret-vs-cycle overload and the axis mismatch.
-    CONFIG_TAIL = [:add, :mode, :advanced, :run]
+    # Add / Mode / Advanced rows (Run is the TEMPLATE border's ^R:RUN badge now, not a
+    # cursor row). There is NO text field and NO caret in-pane — all text entry lives in the
+    # Set / Advanced overlays — so ←/→ can only ever cycle (Mode), which removes the old
+    # caret-vs-cycle overload and the axis mismatch.
+    CONFIG_TAIL = [:add, :mode, :advanced]
 
     private def config_row_count : Int32
       @sets.size + CONFIG_TAIL.size
     end
 
-    # The kind of row under the cursor: :set | :add | :mode | :advanced | :run.
+    # The kind of row under the cursor: :set | :add | :mode | :advanced. (Run is no longer a
+    # config row — it moved to the TEMPLATE border's ^R:RUN badge.)
     def config_row : Symbol
-      @cfg_row < @sets.size ? :set : (CONFIG_TAIL[@cfg_row - @sets.size]? || :run)
+      @cfg_row < @sets.size ? :set : (CONFIG_TAIL[@cfg_row - @sets.size]? || :advanced)
     end
 
     # The payload-set index under the cursor, or nil when the cursor is on a tail row.
@@ -1355,10 +1357,22 @@ module Gori::Tui
       left = Rect.new(rect.x, rect.y, half, rect.h)
       right = Rect.new(rect.x + half + 1, rect.y, {rect.w - half - 1, 0}.max, rect.h)
       tmpl_focused = focused && @focus == :template
-      tmpl, chain = template_chain_split(left)
-      render_template(screen, tmpl, tmpl_focused && !@chain_focused)
-      render_chain_pane(screen, chain, tmpl_focused && @chain_focused)
+      if chain_split_visible? # cursor is in a §…§ marker → split TEMPLATE (top) + CHAIN (bottom)
+        tmpl, chain = template_chain_split(left)
+        render_template(screen, tmpl, tmpl_focused && !@chain_focused)
+        render_chain_pane(screen, chain, tmpl_focused && @chain_focused)
+      else
+        render_template(screen, left, tmpl_focused)
+      end
       render_config(screen, right, focused && @focus == :config)
+    end
+
+    # Whether the TEMPLATE column is currently split into TEMPLATE (top) + CHAIN (bottom).
+    # Contextual, mirroring the Repeater (no mode): only while the cursor sits inside a §…§
+    # marker (chain_under_cursor) or the CHAIN pane is being edited — so an unmarked cursor
+    # keeps the full-height editor and the strip appears exactly when the transform matters.
+    private def chain_split_visible? : Bool
+      @chain_focused || !chain_under_cursor.nil?
     end
 
     # TEMPLATE (top) + CHAIN (bottom) split — a slim 3-row CHAIN strip that grows (≥8, for
@@ -1471,7 +1485,12 @@ module Gori::Tui
       Frame.card(screen, rect, label, bg: Theme.bg, border: pane_border(focused, insert: ins))
       badge = " §#{pc} "
       min_x = rect.x + label.size + 4
-      pretty_x = Frame.toggle_badge(screen, rect.right - 1, rect.y, min_x, "^U", "PRETTY", false)
+      # ^R:RUN rides the TEMPLATE border as the primary action — rightmost, mirroring the
+      # Repeater's ^R:SEND so the muscle memory transfers. Lit while idle, muted while a run
+      # streams (^X stops it). The old CONFIG "Run" row is gone; the request-count estimate
+      # stays there as a passive summary (render_run_summary).
+      run_x = Frame.toggle_badge(screen, rect.right - 1, rect.y, min_x, "^R", "RUN", !running?)
+      pretty_x = Frame.toggle_badge(screen, run_x, rect.y, min_x, "^U", "PRETTY", false)
       render_mode_badge(screen, pretty_x, rect.y, min_x, ins)
       screen.text({pretty_x - badge.size, min_x}.max, rect.y, badge,
         pc > 0 ? Theme.text_bright : Theme.muted, pc > 0 ? Theme.accent_bg : Theme.bg)
@@ -1542,9 +1561,9 @@ module Gori::Tui
     end
 
     # The calm CONFIG summary: a header, the payload-set rows + an Add row, then the
-    # Mode / Advanced / Run rows anchored at the bottom. One row cursor (@cfg_row), no
-    # text field, no caret — so ←/→ can only cycle Mode. All editing drills into the
-    # Set / Advanced overlays.
+    # Mode / Advanced rows + a passive run-size read-out anchored at the bottom. One row
+    # cursor (@cfg_row), no text field, no caret — so ←/→ can only cycle Mode. All editing
+    # drills into the Set / Advanced overlays; the run itself is the TEMPLATE's ^R:RUN badge.
     private def render_config(screen : Screen, rect : Rect, focused : Bool) : Nil
       return if rect.w < 2 || rect.h < 2
       Frame.card(screen, rect, "CONFIG", bg: Theme.bg, border: Frame.pane_border(focused))
@@ -1559,13 +1578,13 @@ module Gori::Tui
         screen.text(hx, inner.y, sets_hint(mcount, @sets.size), Theme.muted, Theme.bg, width: {mx - hx, 1}.max)
       end
 
-      # Mode / Advanced / Run anchor to the bottom 3 rows; the sets list + Add row fill
-      # the space between the header and that tail (windowed if they overflow).
+      # Mode / Advanced + the run-size read-out anchor to the bottom 3 rows; the sets list +
+      # Add row fill the space between the header and that tail (windowed if they overflow).
       tail_top = {inner.bottom - 3, inner.y + 1}.max
       render_sets(screen, inner, inner.y + 1, focused, tail_top)
       render_mode_row(screen, inner, tail_top, focused)
       render_advanced_row(screen, inner, tail_top + 1, focused)
-      render_run_row(screen, inner, tail_top + 2, focused)
+      render_run_summary(screen, inner, tail_top + 2)
     end
 
     # Payload-set rows within [y0, limit), followed by the "+ Add payload set…" row.
@@ -1642,14 +1661,23 @@ module Gori::Tui
       screen.text(dx, y, "Engine · Match · Filter  ⏎", Theme.muted, bg, width: {inner.right - dx, 1}.max) if dx < inner.right
     end
 
-    private def render_run_row(screen, inner : Rect, y : Int32, focused : Bool) : Nil
+    # A passive read-out of the run size (mode × sets × markers) at the CONFIG foot. NOT a
+    # cursor row — the run action lives on the TEMPLATE border's ^R:RUN badge now; this just
+    # reports what that badge will send, updating live as the config changes. Muted so it
+    # reads as a summary, not a button. Blank when there are no sets yet (the empty-sets
+    # guidance already fills that space); "unknown" when a set's size can't be sized cheaply.
+    private def render_run_summary(screen, inner : Rect, y : Int32) : Nil
       return if y >= inner.bottom
-      foc = focused && config_row == :run
-      bg = foc ? Theme.accent_bg : Theme.bg
-      screen.fill(Rect.new(inner.x, y, inner.w, 1), bg) if foc
-      n = run_request_count
-      label = n ? "▶ Run · #{Fmt.count(n)} request#{n == 1 ? "" : "s"}" : "▶ Run"
-      screen.text(inner.x, y, label, foc ? Theme.text_bright : Theme.accent, bg, width: {inner.w, 1}.max)
+      text =
+        if n = run_request_count
+          "↳ #{Fmt.count(n)} request#{n == 1 ? "" : "s"}"
+        elsif @sets.empty?
+          ""
+        else
+          "↳ run size unknown"
+        end
+      return if text.empty?
+      screen.text(inner.x, y, text, Theme.muted, Theme.bg, width: {inner.w, 1}.max)
     end
 
     # One Sets row. In per-position modes (pp) it carries a marker-coloured swatch + →N
@@ -2092,6 +2120,27 @@ module Gori::Tui
         {:dist, "v", "DIST"},
         {:match, "m", "MATCH"},
         {:sort, "o", @sort.to_s},
+      ] of {Symbol, String, String})
+    end
+
+    # Hit-test the TEMPLATE border's ^R:RUN badge (rightmost, drawn by render_template).
+    # Returns :run when the click lands on it, else nil (caller falls through to caret/focus).
+    # Geometry mirrors render → render_top's left-column top border; the CHAIN split hangs
+    # below, so the border row is unaffected by whether the strip is shown.
+    def template_chrome_hit(rect : Rect, mx : Int32, my : Int32) : Symbol?
+      return nil unless @loaded
+      target_h = {rect.h, 3}.min
+      rest = Rect.new(rect.x, rect.y + target_h, rect.w, {rect.h - target_h, 0}.max)
+      return nil if rest.h <= 0
+      top_h = {rest.h * 45 // 100, 5}.max
+      top_h = rest.h if rest.h < 6
+      half = {(rest.w - 1) // 2, 1}.max
+      left = Rect.new(rest.x, rest.y, half, top_h)
+      return nil if left.w < 2 || my != left.y
+      label = @http2 ? "TEMPLATE (h2)" : "TEMPLATE"
+      min_x = left.x + label.size + 4
+      Frame.right_badge_hit(mx, my, left.y, left.right - 1, min_x, [
+        {:run, "^R", "RUN"},
       ] of {Symbol, String, String})
     end
 


### PR DESCRIPTION
## Summary

Brings the **Fuzzer** tab's two rough edges in line with the Repeater's shape.

### 1. CHAIN — now contextual (like Repeater)
Previously the CHAIN pane was always docked as a 3-row strip below the template. Now a new `chain_split_visible?` (`@chain_focused || cursor inside a §…§ marker`) gates the split — the strip appears only when the transform matters, and an unmarked cursor keeps the full-height template editor. Identical behavior to the Repeater's request/CHAIN split.

### 2. Run — moves to the top of the Template pane
- Added a **`^R:RUN` badge on the TEMPLATE border** (rightmost, lit while idle, muted while a run streams) — exactly where the Repeater's `^R:SEND` lives, so the muscle memory transfers.
- **Removed the `:run` row** from the CONFIG pane (`CONFIG_TAIL` is now `[:add, :mode, :advanced]`); updated `config_row`, `activate_config_row`, `config_hint`, and the row-walk spec.
- The **request-count estimate is preserved** as a passive, muted `↳ N requests` read-out at the CONFIG foot.
- Wired a **mouse hit-test** (`template_chrome_hit`) so clicking the badge runs — mouse parity with the Repeater's clickable SEND.

The rebindable `^R` verb is unchanged. Geometry stays consistent with the new sub-tab filter bar (PR #177) because the view hit-tests the same carved body rect that render receives.

## Verification
- Rebased onto current `main` (on top of #177's filter-bar changes); clean auto-merge, re-verified.
- Headless `MemoryBackend` render harness confirms all states: CHAIN hidden / appearing on marker entry / passive count summary / muted badge while running.
- `crystal spec spec/tui spec/fuzz_spec.cr spec/fuzz_store_spec.cr spec/repeater/subtab_filter_spec.cr` → **759 examples, 0 failures**.
- `crystal tool format --check` clean; ameba introduces zero new findings; full `shards build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)