### PR TITLE
feat(proxy): serve a welcome + CA-download page on direct listener access

### DIFF
--- a/spec/proxy/self_page_spec.cr
+++ b/spec/proxy/self_page_spec.cr
@@ -1,0 +1,215 @@
+require "../spec_helper"
+require "socket"
+require "file_utils"
+
+# Records captured flows in memory so the proxy can be driven without a DB. A
+# self-page hit records NOTHING (it's a local UI response, not proxied traffic),
+# so `responses` staying empty is itself an assertion.
+private class RecordingSink < Gori::Proxy::FlowSink
+  getter requests = [] of Gori::Store::CapturedRequest
+  getter responses = [] of Gori::Store::CapturedResponse
+
+  def initialize(@done : Channel(Nil))
+    @next_id = 0_i64
+  end
+
+  def on_request(req : Gori::Store::CapturedRequest) : Int64
+    @requests << req
+    @next_id += 1
+  end
+
+  def on_response(resp : Gori::Store::CapturedResponse) : Nil
+    @responses << resp
+    @done.send(nil)
+  end
+
+  def on_ws_message(flow_id : Int64, direction : String, opcode : Int32, payload : Bytes) : Nil
+  end
+end
+
+# Read a whole response (the server sends `Connection: close`, so the socket EOFs)
+# as raw bytes, robust to a binary DER body.
+private def read_all(io : IO) : Bytes
+  buf = IO::Memory.new
+  IO.copy(io, buf)
+  buf.to_slice
+end
+
+# Split an HTTP response into its header text and body bytes at CRLFCRLF.
+private def split_response(resp : Bytes) : {String, Bytes}
+  i = 0
+  while i + 3 < resp.size
+    if resp[i] == 0x0d && resp[i + 1] == 0x0a && resp[i + 2] == 0x0d && resp[i + 3] == 0x0a
+      return {String.new(resp[0, i]), resp[(i + 4)..]}
+    end
+    i += 1
+  end
+  {String.new(resp), Bytes.empty}
+end
+
+# Stand up a live proxy whose TLS tunnel carries a real CA, so the self-page can
+# hand out the cert. Yields {proxy, ca, sink, done}.
+private def with_landing_proxy(serve_landing : Bool, &)
+  dir = File.tempname("gori-selfpage-ca")
+  Dir.mkdir_p(dir)
+  ca = Gori::Proxy::Tls::CertAuthority.load_or_create(dir)
+  tunnel = Gori::Proxy::Tls::Tunnel.new(ca, serve_landing: serve_landing)
+  done = Channel(Nil).new(4)
+  sink = RecordingSink.new(done)
+  proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink, tls: tunnel)
+  proxy.start
+  begin
+    yield proxy, ca, sink, done
+  ensure
+    proxy.stop
+    FileUtils.rm_rf(dir)
+  end
+end
+
+describe Gori::Proxy::SelfPage do
+  describe ".route" do
+    it "maps known paths and strips query/fragment" do
+      Gori::Proxy::SelfPage.route("").should eq(:index)
+      Gori::Proxy::SelfPage.route("/").should eq(:index)
+      Gori::Proxy::SelfPage.route("/ca.pem").should eq(:pem)
+      Gori::Proxy::SelfPage.route("/ca.pem?x=1").should eq(:pem)
+      Gori::Proxy::SelfPage.route("/ca.der").should eq(:der)
+      Gori::Proxy::SelfPage.route("/ca.crt").should eq(:der)
+      Gori::Proxy::SelfPage.route("/favicon.ico").should eq(:favicon)
+      Gori::Proxy::SelfPage.route("/nope").should eq(:not_found)
+    end
+  end
+
+  describe ".respond" do
+    pem = "-----BEGIN CERTIFICATE-----\nQUJD\n-----END CERTIFICATE-----\n"
+    der = Bytes[0x30, 0x82, 0x01, 0x02]
+    listen = {"127.0.0.1", 8070}
+
+    it "serves the HTML info page for /" do
+      resp = Gori::Proxy::SelfPage.respond("/", pem: pem, der: der, spki: "SPKI==",
+        ca_path: "/home/u/.gori/ca/root.crt.pem", listen: listen, version: "9.9.9", head_only: false)
+      head, body = split_response(resp)
+      head.should contain("200 OK")
+      head.should contain("text/html")
+      text = String.new(body)
+      text.should contain("gori")
+      text.should contain("127.0.0.1:8070")
+      text.should contain("9.9.9")
+      text.should contain("/ca.der")
+      text.should contain("/ca.pem")
+    end
+
+    it "serves the PEM with an attachment disposition" do
+      resp = Gori::Proxy::SelfPage.respond("/ca.pem", pem: pem, der: der, spki: nil,
+        ca_path: nil, listen: listen, version: "1", head_only: false)
+      head, body = split_response(resp)
+      head.should contain("200 OK")
+      head.should contain("application/x-pem-file")
+      head.should contain(%(Content-Disposition: attachment; filename="gori-ca.pem"))
+      String.new(body).should eq(pem)
+    end
+
+    it "serves the DER bytes verbatim" do
+      resp = Gori::Proxy::SelfPage.respond("/ca.der", pem: pem, der: der, spki: nil,
+        ca_path: nil, listen: listen, version: "1", head_only: false)
+      head, body = split_response(resp)
+      head.should contain("200 OK")
+      head.should contain("application/x-x509-ca-cert")
+      head.should contain(%(filename="gori-ca.der"))
+      body.should eq(der)
+    end
+
+    it "404s a cert download when there is no CA (MITM off)" do
+      resp = Gori::Proxy::SelfPage.respond("/ca.pem", pem: nil, der: nil, spki: nil,
+        ca_path: nil, listen: listen, version: "1", head_only: false)
+      String.new(resp).should contain("404 Not Found")
+    end
+
+    it "204s the favicon and 404s an unknown path" do
+      String.new(Gori::Proxy::SelfPage.respond("/favicon.ico", pem: pem, der: der, spki: nil,
+        ca_path: nil, listen: listen, version: "1", head_only: false)).should contain("204 No Content")
+      String.new(Gori::Proxy::SelfPage.respond("/nope", pem: pem, der: der, spki: nil,
+        ca_path: nil, listen: listen, version: "1", head_only: false)).should contain("404 Not Found")
+    end
+
+    it "omits the body for a HEAD request but keeps the headers" do
+      resp = Gori::Proxy::SelfPage.respond("/", pem: pem, der: der, spki: nil,
+        ca_path: nil, listen: listen, version: "1", head_only: true)
+      head, body = split_response(resp)
+      head.should contain("200 OK")
+      head.should contain("Content-Length:")
+      body.empty?.should be_true
+    end
+  end
+end
+
+describe "direct listener access (self-page)" do
+  it "serves the info page for a direct GET / and records no flow" do
+    with_landing_proxy(serve_landing: true) do |proxy, _ca, sink, _done|
+      client = TCPSocket.new("127.0.0.1", proxy.port)
+      client << "GET / HTTP/1.1\r\nHost: 127.0.0.1:#{proxy.port}\r\n\r\n"
+      client.flush
+      resp = String.new(read_all(client))
+      client.close
+
+      resp.should contain("200 OK")
+      resp.should contain("text/html")
+      resp.should contain("gori")
+      sink.responses.size.should eq(0) # a local UI hit is never captured as a flow
+    end
+  end
+
+  it "serves the CA certificate as PEM on /ca.pem" do
+    with_landing_proxy(serve_landing: true) do |proxy, ca, _sink, _done|
+      client = TCPSocket.new("127.0.0.1", proxy.port)
+      client << "GET /ca.pem HTTP/1.1\r\nHost: 127.0.0.1:#{proxy.port}\r\n\r\n"
+      client.flush
+      head, body = split_response(read_all(client))
+      client.close
+
+      head.should contain("application/x-pem-file")
+      String.new(body).should eq(ca.ca_cert_pem)
+    end
+  end
+
+  it "serves the CA certificate as DER on /ca.der" do
+    with_landing_proxy(serve_landing: true) do |proxy, ca, _sink, _done|
+      client = TCPSocket.new("127.0.0.1", proxy.port)
+      client << "GET /ca.der HTTP/1.1\r\nHost: 127.0.0.1:#{proxy.port}\r\n\r\n"
+      client.flush
+      head, body = split_response(read_all(client))
+      client.close
+
+      head.should contain("application/x-x509-ca-cert")
+      body.should eq(ca.ca_cert_der)
+    end
+  end
+
+  it "still refuses (502) a direct hit when the info page is disabled" do
+    with_landing_proxy(serve_landing: false) do |proxy, _ca, sink, done|
+      client = TCPSocket.new("127.0.0.1", proxy.port)
+      client << "GET / HTTP/1.1\r\nHost: 127.0.0.1:#{proxy.port}\r\n\r\n"
+      client.flush
+      client.gets_to_end
+      client.close
+
+      done.receive
+      sink.responses.size.should eq(1)
+      sink.responses.first.state.should eq(Gori::Store::FlowState::Error)
+    end
+  end
+
+  it "still refuses (502) a non-GET direct hit even with the info page enabled" do
+    with_landing_proxy(serve_landing: true) do |proxy, _ca, sink, done|
+      client = TCPSocket.new("127.0.0.1", proxy.port)
+      client << "POST / HTTP/1.1\r\nHost: 127.0.0.1:#{proxy.port}\r\nContent-Length: 0\r\n\r\n"
+      client.flush
+      client.gets_to_end
+      client.close
+
+      done.receive
+      sink.responses.size.should eq(1)
+      sink.responses.first.state.should eq(Gori::Store::FlowState::Error)
+    end
+  end
+end

--- a/spec/proxy/tls/cert_authority_spec.cr
+++ b/spec/proxy/tls/cert_authority_spec.cr
@@ -30,6 +30,19 @@ describe Gori::Proxy::Tls::CertAuthority do
     end
   end
 
+  it "exports the root CA as DER matching its PEM body" do
+    with_ca_dir do |dir|
+      ca = Gori::Proxy::Tls::CertAuthority.load_or_create(dir)
+      der = ca.ca_cert_der
+      der.empty?.should be_false
+      der[0].should eq(0x30_u8) # ASN.1 SEQUENCE tag — a well-formed DER cert
+
+      # PEM is base64(DER) inside the armor lines — decoding the body must reproduce the DER.
+      b64 = ca.ca_cert_pem.lines.reject(&.starts_with?("-----")).join
+      Base64.decode(b64).should eq(der)
+    end
+  end
+
   it "mints a leaf that a client verifies against the CA over a real handshake" do
     with_ca_dir do |dir|
       ca = Gori::Proxy::Tls::CertAuthority.load_or_create(dir)

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -82,21 +82,25 @@ describe Gori::Settings do
       Gori::Settings.bind_host = "0.0.0.0"
       Gori::Settings.bind_port = 9999
       Gori::Settings.upstream_proxy = "up:1234"
+      Gori::Settings.serve_landing = false
       Gori::Settings.save.should be_true
 
       Gori::Settings.bind_host = "x"
       Gori::Settings.bind_port = 1
       Gori::Settings.upstream_proxy = ""
+      Gori::Settings.serve_landing = true
       Gori::Settings.load
       Gori::Settings.bind_host.should eq("0.0.0.0")
       Gori::Settings.bind_port.should eq(9999)
       Gori::Settings.upstream_proxy.should eq("up:1234")
+      Gori::Settings.serve_landing?.should be_false # a stored false survives the reload
     ensure
       prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
       FileUtils.rm_rf(dir)
       Gori::Settings.bind_host = "127.0.0.1"
       Gori::Settings.bind_port = 8070
       Gori::Settings.upstream_proxy = ""
+      Gori::Settings.serve_landing = true
     end
   end
 
@@ -162,20 +166,18 @@ describe Gori::Settings do
       File.write(Gori::Settings.path, legacy.to_json)
       Gori::Settings.load
 
-      Gori::Settings.probe_preview.should be_true                       # layout "prism_preview" -> probe_preview
-      Gori::Settings.issues_preview.should be_true                      # layout "findings_preview" -> issues_preview
-      Gori::Settings.decoder_input.should eq("aGk=")                    # "convert" section -> decoder_*
-      Gori::Settings.tab_prefs.should contain({"repeater", false})      # tab id replay -> repeater (hidden kept)
-      Gori::Settings.tab_prefs.should contain({"decoder", true})        # tab id convert -> decoder
-      Gori::Settings.keymap_overrides.has_key?("repeater.send").should be_true   # verb id replay.send -> repeater.send
+      Gori::Settings.probe_preview.should be_true                                    # layout "prism_preview" -> probe_preview
+      Gori::Settings.issues_preview.should be_true                                   # layout "findings_preview" -> issues_preview
+      Gori::Settings.decoder_input.should eq("aGk=")                                 # "convert" section -> decoder_*
+      Gori::Settings.tab_prefs.should contain({"repeater", false})                   # tab id replay -> repeater (hidden kept)
+      Gori::Settings.tab_prefs.should contain({"decoder", true})                     # tab id convert -> decoder
+      Gori::Settings.keymap_overrides.has_key?("repeater.send").should be_true       # verb id replay.send -> repeater.send
       Gori::Settings.keymap_overrides.has_key?("issue.repeater-flow").should be_true # compound finding.replay-flow -> issue.repeater-flow
-      Gori::Settings.keymap_overrides.has_key?("probe.open").should be_true      # prism.open -> probe.open
+      Gori::Settings.keymap_overrides.has_key?("probe.open").should be_true          # prism.open -> probe.open
     ensure
       prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
       FileUtils.rm_rf(dir)
-      Gori::Settings.tab_prefs, Gori::Settings.keymap_overrides,
-        Gori::Settings.probe_preview, Gori::Settings.issues_preview,
-        Gori::Settings.decoder_input, Gori::Settings.decoder_sessions, Gori::Settings.decoder_chains = saved
+      Gori::Settings.tab_prefs, Gori::Settings.keymap_overrides, Gori::Settings.probe_preview, Gori::Settings.issues_preview, Gori::Settings.decoder_input, Gori::Settings.decoder_sessions, Gori::Settings.decoder_chains = saved
     end
   end
 

--- a/spec/tui/settings_view_spec.cr
+++ b/spec/tui/settings_view_spec.cr
@@ -72,6 +72,37 @@ describe SettingsView do
     end
   end
 
+  it "toggles Info page on direct access off, then resets it on save; opener still intact" do
+    dir = File.tempname("gori-settings-landing")
+    Dir.mkdir_p(dir)
+    prev_home = ENV["GORI_HOME"]?
+    prev = Gori::Settings.serve_landing?
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.serve_landing = true
+      v = SettingsView.new
+      v.reload(:network)
+      4.times { v.move_field(1) } # Bind IP → Port → Upstream → Verify → Info page (index 4)
+      v.toggle_or_move(-1)        # flip the Info-page bool off
+      v.save
+      Gori::Settings.serve_landing?.should be_false
+
+      v.reset_to_defaults
+      v.save
+      Gori::Settings.serve_landing?.should eq(Gori::Settings::DEFAULT_SERVE_LANDING)
+
+      # The Hostname-overrides opener must still be the focusable action row after the
+      # inserted field (index shift didn't misalign fields/values).
+      v.reload(:network)
+      5.times { v.move_field(1) } # → Hostname overrides (index 5, the opener)
+      v.focused_opener.should eq(:hosts)
+    ensure
+      prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
+      Gori::Settings.serve_landing = prev
+      FileUtils.rm_rf(dir)
+    end
+  end
+
   it "reverts the EDITOR section toggles to their defaults on save" do
     dir = File.tempname("gori-settings-reset-ed")
     Dir.mkdir_p(dir)
@@ -142,8 +173,7 @@ describe SettingsView do
       Gori::Settings.sitemap_expand_depth.should eq(Gori::Settings::DEFAULT_SITEMAP_EXPAND_DEPTH)
     ensure
       prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
-      Gori::Settings.history_preview, Gori::Settings.probe_preview, Gori::Settings.issues_preview,
-        Gori::Settings.history_list_order, Gori::Settings.sitemap_expand_depth = prev
+      Gori::Settings.history_preview, Gori::Settings.probe_preview, Gori::Settings.issues_preview, Gori::Settings.history_list_order, Gori::Settings.sitemap_expand_depth = prev
       FileUtils.rm_rf(dir)
     end
   end

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -14,6 +14,7 @@ require "../upstream"
 require "../pump"
 require "../ws/relay"
 require "../../flow_mapper"
+require "./self_page"
 
 module Gori::Proxy
   # Handles one client connection over an `IO` (a plaintext TCPSocket, or — after
@@ -123,6 +124,18 @@ module Gori::Proxy
       rescue ex : URI::Error | OverflowError
         record_error(req, @scheme, req.host? || "", 0, created_at, "malformed absolute-form target: #{ex.message}")
         write_gateway_error
+        return false
+      end
+
+      # A browser pointed STRAIGHT at the listener (origin-form request to gori's own
+      # address, no proxy configured) gets the self-serve welcome + CA-download page
+      # instead of the 502 self-loop refusal below — but only for a plain GET/HEAD and
+      # only while the setting is on. Origin-form only: an absolute-form request (a
+      # proxy-configured browser) that targets self is a genuine loop and still 502s.
+      # Not recorded as a flow — it's a local UI hit, not proxied traffic.
+      if (sa = @self_addr) && (tls = @tls) && tls.serve_landing? &&
+         origin_form?(req) && get_or_head?(req) && Upstream.addresses_self?(host, port, sa)
+        serve_self_page(req, tls, sa)
         return false
       end
 
@@ -1027,6 +1040,32 @@ module Gori::Proxy
 
     private def write_gateway_error : Nil
       @io.write("HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n\r\n".to_slice)
+      @io.flush
+    rescue
+    end
+
+    # An origin-form request-target (path-only, e.g. `/` or `/ca.pem`) — i.e. a browser
+    # that hit us DIRECTLY, not via a proxy config (which sends an absolute-form URI).
+    private def origin_form?(req : Codec::RawRequest) : Bool
+      t = req.target
+      !t.starts_with?("http://") && !t.starts_with?("https://")
+    end
+
+    private def get_or_head?(req : Codec::RawRequest) : Bool
+      req.method.compare("GET", case_insensitive: true) == 0 ||
+        req.method.compare("HEAD", case_insensitive: true) == 0
+    end
+
+    # Serve the direct-access welcome + CA-download page (see the guard in handle_request).
+    # The CA bytes/fingerprint/path come through the TlsMitm seam so this stays decoupled
+    # from the FFI cert code; a HEAD request gets headers only. Best-effort — a write error
+    # just drops the connection like every other canned response here.
+    private def serve_self_page(req : Codec::RawRequest, tls : TlsMitm, self_addr : {String, Int32}) : Nil
+      head_only = req.method.compare("HEAD", case_insensitive: true) == 0
+      resp = SelfPage.respond(req.target,
+        pem: tls.ca_cert_pem, der: tls.ca_cert_der, spki: tls.ca_spki_sha256,
+        ca_path: tls.ca_cert_path, listen: self_addr, version: Gori::VERSION, head_only: head_only)
+      @io.write(resp)
       @io.flush
     rescue
     end

--- a/src/gori/proxy/conn/self_page.cr
+++ b/src/gori/proxy/conn/self_page.cr
@@ -1,0 +1,244 @@
+require "html"
+
+module Gori::Proxy
+  # The self-serve landing page ClientConn returns when a browser hits the proxy
+  # listener DIRECTLY (origin-form request to gori's own address, no proxy config) —
+  # the Caido/Burp-style welcome + CA-certificate download that replaces the bare
+  # 502 self-loop refusal. Pure request->response bytes (no IO, no capture) so it is
+  # trivially testable; ClientConn just writes what `respond` returns and closes.
+  #
+  # A light landing treatment in gori's own brand (docs/static/css/style.css): the
+  # indigo night + gold accent, dark-first with a warm-paper light variant, and the
+  # "gori" wordmark set in Unicode script glyphs so it reads as a display face with
+  # NO external font. Everything is inlined — the page is written straight to the raw
+  # proxy socket, so it can pull nothing remote (no fonts, images, or scripts).
+  module SelfPage
+    # The wordmark, in Mathematical Bold Script glyphs (U+1D4F0 g, U+1D4F8 o,
+    # U+1D4FB r, U+1D4F2 i). A self-contained display face — no webfont needed —
+    # paired with a visually-hidden "gori" so assistive tech reads it correctly.
+    WORDMARK = %(<span aria-hidden="true">𝓰𝓸𝓻𝓲</span><span class="sr">gori</span>)
+
+    # Map a request-target path to the resource it serves. Query/fragment are
+    # stripped so `/ca.pem?x=1` still downloads. Unknown paths 404 (so a browser's
+    # incidental probes don't masquerade as certs).
+    def self.route(target : String) : Symbol
+      path = target
+      if q = path.index('?')
+        path = path[0, q]
+      end
+      if h = path.index('#')
+        path = path[0, h]
+      end
+      case path
+      when "", "/"                   then :index
+      when "/ca.pem", "/gori-ca.pem" then :pem
+      when "/ca.der", "/ca.crt",
+           "/gori-ca.der" then :der
+      when "/favicon.ico" then :favicon
+      else                     :not_found
+      end
+    end
+
+    # Build the complete HTTP/1.1 response bytes for `target`. `pem`/`der` are nil
+    # when there's no MITM CA to hand out (blind-tunnel mode) — the download routes
+    # then 404 and the page hides its download buttons. `head_only` (a HEAD request)
+    # keeps the headers but drops the body.
+    def self.respond(target : String, *, pem : String?, der : Bytes?, spki : String?,
+                     ca_path : String?, listen : {String, Int32}, version : String,
+                     head_only : Bool) : Bytes
+      case route(target)
+      when :pem
+        if pem
+          build(200, "OK", "application/x-pem-file", pem.to_slice, head_only,
+            disposition: %(attachment; filename="gori-ca.pem"))
+        else
+          unavailable(head_only)
+        end
+      when :der
+        if der
+          build(200, "OK", "application/x-x509-ca-cert", der, head_only,
+            disposition: %(attachment; filename="gori-ca.der"))
+        else
+          unavailable(head_only)
+        end
+      when :favicon
+        no_content
+      when :not_found
+        build(404, "Not Found", "text/html; charset=utf-8",
+          simple_html("Not found", "That path isn't served here. Try <a href=\"/\">the gori info page</a>.").to_slice,
+          head_only)
+      else # :index
+        build(200, "OK", "text/html; charset=utf-8",
+          index_html(ca_available: !pem.nil?, spki: spki, ca_path: ca_path, listen: listen, version: version).to_slice,
+          head_only)
+      end
+    end
+
+    # ── response framing ──────────────────────────────────────────────────────
+
+    private def self.build(status : Int32, reason : String, content_type : String,
+                           body : Bytes, head_only : Bool, disposition : String? = nil) : Bytes
+      io = IO::Memory.new(body.size + 256)
+      io << "HTTP/1.1 " << status << ' ' << reason << "\r\n"
+      io << "Content-Type: " << content_type << "\r\n"
+      io << "Content-Length: " << body.size << "\r\n"
+      io << "Content-Disposition: " << disposition << "\r\n" if disposition
+      io << "Cache-Control: no-store\r\n"
+      io << "Connection: close\r\n"
+      io << "\r\n"
+      io.write(body) unless head_only
+      io.to_slice
+    end
+
+    # 204 carries no body by definition — no Content-Type/Length.
+    private def self.no_content : Bytes
+      "HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n".to_slice
+    end
+
+    private def self.unavailable(head_only : Bool) : Bytes
+      build(404, "Not Found", "text/html; charset=utf-8",
+        simple_html("Certificate unavailable",
+          "gori isn't intercepting HTTPS right now, so there's no CA certificate to install.").to_slice,
+        head_only)
+    end
+
+    # ── HTML ──────────────────────────────────────────────────────────────────
+
+    private def self.simple_html(title : String, body : String) : String
+      <<-HTML
+      <!doctype html><html lang="en"><head><meta charset="utf-8">
+      <meta name="viewport" content="width=device-width,initial-scale=1">
+      <title>gori - #{HTML.escape(title)}</title>#{STYLE}</head>
+      <body><main class="page"><section class="hero">
+        <p class="mark">#{WORDMARK}</p>
+        <h1>#{HTML.escape(title)}</h1>
+        <p class="lead">#{body}</p>
+      </section></main></body></html>
+      HTML
+    end
+
+    private def self.index_html(*, ca_available : Bool, spki : String?, ca_path : String?,
+                                listen : {String, Int32}, version : String) : String
+      listen_s = HTML.escape("#{listen[0]}:#{listen[1]}")
+      ver = HTML.escape(version)
+      path = HTML.escape(ca_path || "unknown")
+      fp = spki ? HTML.escape(spki) : nil
+
+      cta =
+        if ca_available
+          <<-HTML
+          <div class="cta">
+            <a class="btn primary" href="/ca.der" download>Download CA (DER)</a>
+            <a class="btn ghost" href="/ca.pem" download>Download PEM</a>
+          </div>
+          <p class="hint">DER (<code>.der</code>/<code>.crt</code>) installs by double-click on macOS and Windows.
+          PEM (<code>.pem</code>) suits Firefox and most Linux tooling.</p>
+          HTML
+        else
+          %(<p class="hint">HTTPS interception is off right now, so there's no CA certificate to download.</p>)
+        end
+
+      fingerprint = fp ? %(<div><span class="k">Fingerprint</span><code>#{fp}</code></div>) : ""
+
+      <<-HTML
+      <!doctype html><html lang="en"><head><meta charset="utf-8">
+      <meta name="viewport" content="width=device-width,initial-scale=1">
+      <title>gori proxy</title>#{STYLE}</head>
+      <body><main class="page">
+        <section class="hero">
+          <p class="mark">#{WORDMARK}</p>
+          <h1>You've reached the proxy</h1>
+          <p class="lead">gori captures and inspects HTTP traffic between your browser and the web.
+          Install its CA certificate to read HTTPS.</p>
+          #{cta}
+        </section>
+
+        <section class="details">
+          <h2>Trust the certificate</h2>
+          <dl class="steps">
+            <div><dt>Firefox</dt><dd>Settings → Certificates → Authorities → Import the <code>.pem</code>, then trust it for websites.</dd></div>
+            <div><dt>macOS</dt><dd>Open the <code>.der</code> in Keychain Access, then set it to Always Trust.</dd></div>
+            <div><dt>Windows</dt><dd>Open the <code>.der</code>, then install to Trusted Root Certification Authorities.</dd></div>
+          </dl>
+
+          <div class="meta">
+            <div><span class="k">Listening on</span><code>#{listen_s}</code></div>
+            <div><span class="k">CA file</span><code>#{path}</code></div>
+            #{fingerprint}
+            <div><span class="k">Version</span><code>v#{ver}</code></div>
+          </div>
+
+          <p class="warn">Only install this CA on a machine you control, for testing. A trusted root CA can decrypt your HTTPS traffic.</p>
+        </section>
+      </main></body></html>
+      HTML
+    end
+
+    # gori's palette + type, self-contained. Dark-first (the indigo night) with a
+    # warm-paper light variant under prefers-color-scheme: light. Tokens are lifted
+    # from docs/static/css/style.css.
+    STYLE = <<-CSS
+    <style>
+    :root{
+      color-scheme:dark;
+      --bg:#0b0e16;--text:#c6c8d4;--heading:#f6f5f1;--muted:#8d90a2;--quiet:#6a6d7e;
+      --accent:#c8a860;--accent-strong:#e6cf92;
+      --accent-rgb:200 168 96;--cloud-rgb:108 126 178;--hair:rgb(250 250 250 /.12);
+    }
+    @media (prefers-color-scheme:light){
+      :root{
+        color-scheme:light;
+        --bg:#faf9f7;--text:#33322f;--heading:#141210;--muted:#6b6454;--quiet:#8a8272;
+        --accent:#a8791f;--accent-strong:#8a5d0a;
+        --accent-rgb:168 121 31;--cloud-rgb:150 132 96;--hair:rgb(26 22 14 /.14);
+      }
+    }
+    *{box-sizing:border-box;margin:0;padding:0}
+    body{min-height:100dvh;background:var(--bg);color:var(--text);
+      font:16px/1.62 ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans KR","Apple SD Gothic Neo",Arial,sans-serif;
+      -webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
+    .sr{position:absolute;width:1px;height:1px;margin:-1px;padding:0;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+    .page{max-width:44rem;margin:0 auto;padding:2rem 1.5rem 3.5rem}
+    .hero{position:relative;min-height:min(80dvh,660px);display:flex;flex-direction:column;justify-content:center;padding:1.5rem 0}
+    .hero::before{content:"";position:absolute;z-index:0;top:-2rem;left:-14%;width:66%;height:66%;pointer-events:none;
+      background:radial-gradient(60% 60% at 32% 30%,rgb(var(--accent-rgb)/.12),transparent 70%),
+        radial-gradient(52% 60% at 62% 52%,rgb(var(--cloud-rgb)/.11),transparent 72%)}
+    .hero>*{position:relative;z-index:1}
+    .mark{font-family:"STIX Two Math","Cambria Math","Noto Sans Math",Georgia,"Times New Roman",serif;
+      font-size:clamp(3.4rem,13vw,6rem);line-height:1;color:var(--accent-strong);letter-spacing:.02em;margin-bottom:1.05rem}
+    h1{color:var(--heading);font-size:clamp(1.55rem,4.5vw,2.15rem);line-height:1.16;font-weight:760;letter-spacing:-.015em;
+      max-width:18ch;text-wrap:balance;margin-bottom:.7rem}
+    .lead{color:var(--muted);font-size:1.06rem;max-width:44ch;margin-bottom:1.5rem}
+    .cta{display:flex;flex-wrap:wrap;gap:.7rem}
+    .btn{display:inline-flex;align-items:center;min-height:2.9rem;padding:.72rem 1.25rem;border-radius:10px;
+      font-weight:650;font-size:.95rem;text-decoration:none;
+      transition:transform .15s,filter .15s,border-color .15s,background .15s,color .15s}
+    .btn:active{transform:translateY(1px)}
+    .btn:focus-visible{outline:2px solid var(--accent);outline-offset:3px}
+    .btn.primary{background:var(--accent);color:#17130a}
+    .btn.primary:hover{filter:brightness(1.06)}
+    .btn.ghost{border:1px solid var(--hair);color:var(--heading)}
+    .btn.ghost:hover{border-color:var(--accent)}
+    .hint{margin-top:1.05rem;color:var(--muted);font-size:.86rem;max-width:48ch}
+    .details{border-top:1px solid var(--hair);padding-top:2rem}
+    h2{color:var(--heading);font-size:1.05rem;font-weight:720;margin-bottom:1rem}
+    .steps{display:grid;gap:.9rem;margin-bottom:1.9rem}
+    .steps dt{color:var(--heading);font-weight:650;font-size:.92rem;margin-bottom:.15rem}
+    .steps dd{color:var(--muted);font-size:.9rem}
+    a{color:var(--accent-strong);text-decoration:underline;text-underline-offset:.2em;text-decoration-color:rgb(var(--accent-rgb)/.45)}
+    a:hover{color:var(--heading);text-decoration-color:currentColor}
+    code{font-family:ui-monospace,"SF Mono",Menlo,Consolas,monospace;font-size:.85em;color:var(--accent-strong);word-break:break-all}
+    .meta{border-top:1px solid var(--hair);padding-top:1.2rem;display:grid;gap:.42rem;font-size:.85rem}
+    .meta .k{color:var(--quiet);display:inline-block;min-width:8.5rem}
+    .meta code{color:var(--text)}
+    .warn{margin-top:1.35rem;color:var(--quiet);font-size:.82rem;max-width:54ch}
+    @media (prefers-reduced-motion:no-preference){
+      .hero>.mark,.hero>h1,.hero>.lead,.hero>.cta,.hero>.hint{animation:rise .7s cubic-bezier(.16,1,.3,1) both}
+      .hero>h1{animation-delay:.08s}.hero>.lead{animation-delay:.16s}
+      .hero>.cta{animation-delay:.24s}.hero>.hint{animation-delay:.32s}
+    }
+    @keyframes rise{from{opacity:0;transform:translateY(14px)}to{opacity:1;transform:none}}
+    </style>
+    CSS
+  end
+end

--- a/src/gori/proxy/connect.cr
+++ b/src/gori/proxy/connect.cr
@@ -12,5 +12,30 @@ module Gori::Proxy
     # per-host leaf, dial host:port as a TLS client, and run the decrypted
     # HTTP/1.1 request loop, capturing flows to `sink`.
     abstract def intercept(host : String, port : Int32, client : IO, sink : FlowSink) : Nil
+
+    # Root-CA accessors for the self-serve landing page ClientConn serves when a
+    # browser hits the listener directly. Defined here (returning plain types, not
+    # the FFI CertAuthority) so the connection loop stays decoupled from the TLS
+    # subsystem; Tunnel overrides them from its @ca. Defaults mean "no MITM CA to
+    # hand out" — a nil @tls or a bare TlsMitm just omits the certificate download.
+    def serve_landing? : Bool
+      false
+    end
+
+    def ca_cert_pem : String?
+      nil
+    end
+
+    def ca_cert_der : Bytes?
+      nil
+    end
+
+    def ca_cert_path : String?
+      nil
+    end
+
+    def ca_spki_sha256 : String?
+      nil
+    end
   end
 end

--- a/src/gori/proxy/tls/cert_authority.cr
+++ b/src/gori/proxy/tls/cert_authority.cr
@@ -75,6 +75,13 @@ module Gori::Proxy::Tls
       File.read(@ca_cert_path)
     end
 
+    # DER bytes of the root certificate, for the self-serve CA download page's .der
+    # form. Encoded from the live in-memory cert (so it tracks regenerate!/import!),
+    # unlike ca_cert_pem which reads the on-disk file.
+    def ca_cert_der : Bytes
+      @cert.to_der
+    end
+
     # Regenerate the root CA in place: mint a brand-new self-signed root, persist
     # it over the existing PEM files, and drop the per-host leaf cache so every
     # subsequent connection is signed by the NEW root. The Tunnel/proxy hold THIS

--- a/src/gori/proxy/tls/ffi.cr
+++ b/src/gori/proxy/tls/ffi.cr
@@ -47,6 +47,11 @@ lib LibCrypto
   fun x509_get_x509_pubkey = X509_get_X509_PUBKEY(x : X509) : X509_PUBKEY
   fun i2d_x509_pubkey = i2d_X509_PUBKEY(a : X509_PUBKEY, pp : UInt8**) : Int
 
+  # DER-encode the whole certificate (for the self-serve CA download page's .der
+  # form). Like i2d_X509_PUBKEY, a null `pp` returns the length so we can size the
+  # buffer before encoding.
+  fun i2d_x509 = i2d_X509(x : X509, pp : UInt8**) : Int
+
   # PEM persistence via file BIOs (root CA only; leaves stay in memory)
   fun bio_new_file = BIO_new_file(filename : Char*, mode : Char*) : Bio*
   fun pem_write_bio_x509 = PEM_write_bio_X509(bio : Bio*, x : X509) : Int

--- a/src/gori/proxy/tls/key_pair.cr
+++ b/src/gori/proxy/tls/key_pair.cr
@@ -91,6 +91,20 @@ module Gori::Proxy::Tls
       end
     end
 
+    # DER (binary ASN.1) encoding of the certificate — the form OS/browser trust
+    # stores accept for a double-click install (the self-serve CA download page's
+    # .der/.crt route). A null `pp` first sizes the buffer, then i2d writes into it
+    # and ADVANCES the pointer (hence a local copy of `der.to_unsafe`), mirroring
+    # CertAuthority#spki_sha256_base64.
+    def to_der : Bytes
+      len = LibCrypto.i2d_x509(@handle, Pointer(Pointer(UInt8)).null)
+      raise Gori::Error.new("i2d_X509 sizing failed") if len <= 0
+      der = Bytes.new(len)
+      ptr = der.to_unsafe
+      LibCrypto.i2d_x509(@handle, pointerof(ptr))
+      der
+    end
+
     def finalize
       LibCrypto.x509_free(@handle)
     end

--- a/src/gori/proxy/tls/tunnel.cr
+++ b/src/gori/proxy/tls/tunnel.cr
@@ -21,10 +21,34 @@ module Gori::Proxy::Tls
     # the next tunnelled connection picks up the change.
     property? verify_upstream : Bool
 
+    # Live-mutable too: Session#set_serve_landing flips whether a direct browser hit to the
+    # listener gets the gori welcome + CA-download page (vs the 502 self-loop refusal). Read
+    # per-request in ClientConn via the TlsMitm seam below, so the next request picks it up.
+    property? serve_landing : Bool
+
     def initialize(@ca : CertAuthority, @verify_upstream : Bool = true,
                    @rewriter : Proxy::HeadRewriter? = nil,
                    @interceptor : Gori::Interceptor? = nil,
-                   @host_overrides : Gori::HostOverrides? = nil)
+                   @host_overrides : Gori::HostOverrides? = nil,
+                   @serve_landing : Bool = true)
+    end
+
+    # TlsMitm seam: hand the connection loop the root CA (for the self-serve download
+    # page) without coupling it to the FFI CertAuthority type.
+    def ca_cert_pem : String?
+      @ca.ca_cert_pem
+    end
+
+    def ca_cert_der : Bytes?
+      @ca.ca_cert_der
+    end
+
+    def ca_cert_path : String?
+      @ca.ca_cert_path
+    end
+
+    def ca_spki_sha256 : String?
+      @ca.spki_sha256_base64
     end
 
     def intercept(host : String, port : Int32, client : IO, sink : Proxy::FlowSink) : Nil
@@ -35,7 +59,7 @@ module Gori::Proxy::Tls
       # them. Sandbox forces h1 for EVERY MITM'd host so the per-request block always runs;
       # out-of-scope, sandbox-off, intercept-off, rule-less hosts keep the fast h2 relay.
       advertise_h2 = !(@interceptor.try(&.sandbox_enabled?) ||
-        @interceptor.try(&.intercepts_host?(host)) || @rewriter.try(&.active?))
+                       @interceptor.try(&.intercepts_host?(host)) || @rewriter.try(&.active?))
       server_ctx = @ca.context_for(host, advertise_h2: advertise_h2)
       # sync_close: true is REQUIRED, not cosmetic. The h2/ws relays tear down by
       # closing the socket the *other* pump fiber is mid-read on, to unblock it.

--- a/src/gori/proxy/upstream.cr
+++ b/src/gori/proxy/upstream.cr
@@ -52,6 +52,20 @@ module Gori::Proxy
       loopback?(target) && (loopback?(bind) || wildcard?(bind))
     end
 
+    # True when the request LITERALLY targets gori's own listener `self_addr` — the
+    # "someone pointed a browser straight at the proxy" case that serves the self-page.
+    # Same loopback/wildcard/port-scoped test as loops_to_self? but WITHOUT the hostname-
+    # override step, so an override that happens to point a real domain at the bind still
+    # falls through to the 502 self-loop refusal (the user meant that mapped host, not the
+    # welcome page) rather than getting the landing page.
+    def self.addresses_self?(host : String, port : Int32, self_addr : {String, Int32}) : Bool
+      return false unless port == self_addr[1]
+      target = normalize_host(host)
+      bind = normalize_host(self_addr[0])
+      return true if target == bind
+      loopback?(target) && (loopback?(bind) || wildcard?(bind))
+    end
+
     private def self.normalize_host(h : String) : String
       h = h[1...-1] if h.starts_with?('[') && h.ends_with?(']') # strip IPv6 brackets
       h.downcase

--- a/src/gori/session.cr
+++ b/src/gori/session.cr
@@ -72,7 +72,8 @@ module Gori
         # targets and race issue-writes on the shared DB against the real capturer).
         probe = Probe::Analyzer.new(store, scope, probe_events, store.probe_mode, !config.insecure_upstream?)
         tunnel = Proxy::Tls::Tunnel.new(ca, verify_upstream: !config.insecure_upstream?,
-          rewriter: rules, interceptor: interceptor, host_overrides: host_overrides)
+          rewriter: rules, interceptor: interceptor, host_overrides: host_overrides,
+          serve_landing: Settings.serve_landing?)
         proxy = Proxy::Server.new(config.listen, config.port, sink, tls: tunnel,
           rewriter: rules, interceptor: interceptor, host_overrides: host_overrides)
         # Per-PROJECT capture lock decides whether THIS instance captures. A 2nd
@@ -151,6 +152,14 @@ module Gori
       @config.insecure_upstream = !verify
       @tunnel.verify_upstream = verify
       @probe.verify_upstream = verify
+    end
+
+    # Flip the direct-access info page live (settings:network toggle). Pushed to the
+    # capture proxy's TLS tunnel, which ClientConn reads per request via the TlsMitm
+    # seam — so the next direct hit picks it up with no restart. Global; the persisted
+    # Settings.serve_landing is the source of truth across restarts.
+    def set_serve_landing(enabled : Bool) : Nil
+      @tunnel.serve_landing = enabled
     end
 
     def capturing? : Bool

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -21,6 +21,7 @@ module Gori
     DEFAULT_BIND_PORT       = 8070
     DEFAULT_UPSTREAM_PROXY  = ""
     DEFAULT_VERIFY_UPSTREAM = true
+    DEFAULT_SERVE_LANDING   = true
     DEFAULT_EDITOR          = ""
     DEFAULT_EDITOR_MARKDOWN = true
     DEFAULT_THEME           = "goridark"
@@ -30,7 +31,7 @@ module Gori
     # Layout (settings:layout): list previews off by default; Sitemap fully expanded.
     DEFAULT_HISTORY_PREVIEW      = false
     DEFAULT_PROBE_PREVIEW        = false
-    DEFAULT_ISSUES_PREVIEW     = false
+    DEFAULT_ISSUES_PREVIEW       = false
     DEFAULT_HISTORY_LIST_ORDER   = "newest" # "newest" | "oldest" — list sort direction
     DEFAULT_SITEMAP_EXPAND_DEPTH = -1       # -1 = all
     # Statusline (settings:statusline): opt-in bottom row that runs a command on an
@@ -47,6 +48,11 @@ module Gori
     # settings:network editor toggles it live via Session#set_verify_upstream. Global-only
     # (no per-project override). CLI `run`/MCP paths keep their own --insecure-upstream flag.
     class_property? verify_upstream : Bool = DEFAULT_VERIFY_UPSTREAM
+    # Whether a browser that hits the proxy listener DIRECTLY (origin-form, no proxy
+    # config) gets the gori welcome + CA-download page instead of the 502 self-loop
+    # refusal. Global-only; the settings:network editor toggles it live via
+    # Session#set_serve_landing (pushed to the TLS tunnel, read per-request).
+    class_property? serve_landing : Bool = DEFAULT_SERVE_LANDING
 
     # Per-project network overrides — a RUNTIME layer set by Session.open from the OPEN
     # project's DB and NEVER persisted to settings.json (the project's own DB is the source
@@ -109,6 +115,7 @@ module Gori
     def self.normalize_history_list_order(s : String) : String
       s == "oldest" ? "oldest" : "newest"
     end
+
     # Top tab-bar layout: ordered {tab-id, visible?}. Empty = never customized → Chrome
     # reconciles to catalog defaults. Opaque String ids (Crystal has no runtime String→Symbol);
     # Chrome maps ids→catalog symbols. Only an EXPLICIT false hides a tab.
@@ -161,6 +168,7 @@ module Gori
         self.bind_port = net["bind_port"]?.try(&.as_i?) || bind_port
         self.upstream_proxy = net["upstream_proxy"]?.try(&.as_s?) || upstream_proxy
         self.verify_upstream = load_bool(net, "verify_upstream", verify_upstream?)
+        self.serve_landing = load_bool(net, "serve_landing", serve_landing?)
       end
       self.theme = root["theme"]?.try(&.as_s?) || theme # validated against the known themes by Theme.apply
       self.mouse = load_bool(root, "mouse", mouse)
@@ -496,6 +504,7 @@ module Gori
               j.field "bind_port", bind_port
               j.field "upstream_proxy", upstream_proxy
               j.field "verify_upstream", verify_upstream?
+              j.field "serve_landing", serve_landing?
             end
           end
           j.field "editor" do

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -2439,7 +2439,7 @@ module Gori::Tui
         # rest just persist (the value is read live or only matters next session).
         msg = @settings_view.save
         @toast = case @settings_view.section
-                 when :network then apply_settings(msg).tap { @session.set_verify_upstream(Settings.verify_upstream?); project_controller.refresh_network } # push the verify toggle to the live proxy/probe, then re-sync the Project pane's inherited fields to the new global
+                 when :network then apply_settings(msg).tap { @session.set_verify_upstream(Settings.verify_upstream?); @session.set_serve_landing(Settings.serve_landing?); project_controller.refresh_network } # push the verify + info-page toggles to the live proxy/probe, then re-sync the Project pane's inherited fields to the new global
                  when :theme   then apply_theme(msg)
                  when :layout  then apply_layout(msg)
                  else               msg

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -26,6 +26,7 @@ module Gori::Tui
       Field.new("Bind Port", "global default port (0-65535) — project overrides win when set"),
       Field.new("Upstream proxy", "host:port — blank = connect directly; projects may override"),
       Field.new("Verify upstream TLS", "check the upstream server's certificate — off accepts any cert (MITM/testing); ←/→/space toggles", bool: true),
+      Field.new("Info page on direct access", "serve a gori welcome + CA-download page to browsers that hit the listen address directly — ←/→/space toggles", bool: true),
       Field.new("Hostname overrides", "↵ to edit the global IP→host map (a /etc/hosts for this proxy)", opener: :hosts),
     ]
     EDITOR_FIELDS = [
@@ -44,7 +45,7 @@ module Gori::Tui
     # Layout: vertical list of per-area prefs (extend by appending fields + Settings keys).
     LAYOUT_DEPTH_CHOICES = ["all", "0", "1", "2", "3"]
     LAYOUT_ORDER_CHOICES = ["newest first", "oldest first"]
-    LAYOUT_FIELDS = [
+    LAYOUT_FIELDS        = [
       Field.new("History Req/Res preview",
         "list page: bottom pane shows selected flow request + response — ←/→/space toggles",
         bool: true),
@@ -110,7 +111,7 @@ module Gori::Tui
                 when :theme      then [Theme.canonical(Settings.theme)]
                 when :layout     then layout_values
                 when :statusline then [Settings.statusline_enabled? ? "on" : "off", Settings.statusline_command, Settings.statusline_interval.to_s]
-                else                  [Settings.bind_host, Settings.bind_port.to_s, Settings.upstream_proxy, Settings.verify_upstream? ? "on" : "off", hostnames_summary]
+                else                  [Settings.bind_host, Settings.bind_port.to_s, Settings.upstream_proxy, Settings.verify_upstream? ? "on" : "off", Settings.serve_landing? ? "on" : "off", hostnames_summary]
                 end
       @focused = 0
       @cursor = @values[0].size
@@ -140,7 +141,7 @@ module Gori::Tui
                   Settings::DEFAULT_STATUSLINE_COMMAND,
                   Settings::DEFAULT_STATUSLINE_INTERVAL.to_s,
                 ]
-                else [Settings::DEFAULT_BIND_HOST, Settings::DEFAULT_BIND_PORT.to_s, Settings::DEFAULT_UPSTREAM_PROXY, Settings::DEFAULT_VERIFY_UPSTREAM ? "on" : "off", hostnames_summary]
+                else [Settings::DEFAULT_BIND_HOST, Settings::DEFAULT_BIND_PORT.to_s, Settings::DEFAULT_UPSTREAM_PROXY, Settings::DEFAULT_VERIFY_UPSTREAM ? "on" : "off", Settings::DEFAULT_SERVE_LANDING ? "on" : "off", hostnames_summary]
                 end
       @focused = 0
       @cursor = @values[0].size
@@ -337,7 +338,8 @@ module Gori::Tui
       Settings.bind_port = port
       Settings.upstream_proxy = up
       Settings.verify_upstream = @values[3] == "on"
-      @values = [Settings.bind_host, Settings.bind_port.to_s, Settings.upstream_proxy, Settings.verify_upstream? ? "on" : "off", hostnames_summary]
+      Settings.serve_landing = @values[4] == "on"
+      @values = [Settings.bind_host, Settings.bind_port.to_s, Settings.upstream_proxy, Settings.verify_upstream? ? "on" : "off", Settings.serve_landing? ? "on" : "off", hostnames_summary]
       persist
     end
 


### PR DESCRIPTION
## What

When a browser hits the proxy listener **directly** (an origin-form request to gori's own address, no proxy configured), gori now serves a self-contained **welcome + CA-download page** instead of the bare `502` self-loop refusal. This is the Caido/Burp-style direct-access page: a browser pointed at `http://127.0.0.1:8070/` gets a short intro plus the root-CA download it needs to intercept HTTPS.

## How

- **`Gori::Proxy::SelfPage`** (new) renders the page and builds the PEM/DER/HTML responses. Routes: `/`, `/ca.pem`, `/ca.der` (+ `/ca.crt`), `/favicon.ico`; unknown paths `404`.
- **CA over the existing `TlsMitm` seam** — default-nil accessors on the abstract class, overridden in `Tunnel`, so the connection loop stays decoupled from the FFI cert code (no new CA param threaded through `Server`).
- **CA DER export** — new `i2d_X509` FFI binding, `Cert#to_der`, `CertAuthority#ca_cert_der` (PEM already existed).
- **Detection** via new `Upstream.addresses_self?` (literal self-match, without host-override resolution). Origin-form `GET`/`HEAD` only, so genuine override-induced loops and non-GET requests still get the `502`.
- **Setting** — new `settings:network` toggle **"Info page on direct access"** (default **on**), applied live via `Session#set_serve_landing` (mirrors the `set_verify_upstream` pattern).
- **Design** — gori's own indigo-night / gold-leaf palette with the script `𝓰𝓸𝓻𝓲` wordmark, dark-first with a warm-paper light variant, fully self-contained (no external fonts/images/scripts, since it's written to a raw socket).

## Safety

- Only the **public** CA certificate is served, never the private key.
- Port-scoped literal self-match only; forwarding of real origins and the existing self-loop `502` are untouched.
- Self-page hits are not recorded as flows (local UI, not proxied traffic).

## Tests

`SelfPage` unit + live-proxy integration (page served, PEM/DER match the real CA, `502` when disabled or non-GET), `ca_cert_der`, settings round-trip, and the TUI toggle. Full suite green (1907 examples, 0 failures). Verified end-to-end against a running `gori run capture`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)