### PR TITLE
perf(repeater): memoize per-line response styling on the render hot path

### DIFF
--- a/spec/tui/repeater_view_spec.cr
+++ b/spec/tui/repeater_view_spec.cr
@@ -59,6 +59,62 @@ describe Gori::Tui::RepeaterView do
     backend.contains?("— not sent — press ^R to resend —").should be_true
   end
 
+  # The response body is styled one visible line at a time and memoized (per-line) so an
+  # unrelated re-render (a keystroke in the request editor) doesn't re-tokenize the pane.
+  # The memo must be dropped in lockstep with the response view — a new send, or a pretty
+  # toggle — or a stale styled line would keep showing the OLD response.
+  it "styled-line memo re-renders an unchanged response identically, but drops on a new send" do
+    view = RepeaterView.new
+    view.load_blank
+    view.focus_pane(:response)
+    hdr = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n"
+    view.apply(Gori::Repeater::Result.new(hdr.to_slice, %({"tag":"alpha"}).to_slice, nil, 1000_i64))
+
+    first = MemoryBackend.new(120, 20)
+    view.render(Screen.new(first), Rect.new(0, 0, 120, 20))
+    first.contains?("alpha").should be_true
+
+    # A second render with nothing changed is served from the memo — same output.
+    again = MemoryBackend.new(120, 20)
+    view.render(Screen.new(again), Rect.new(0, 0, 120, 20))
+    again.contains?("alpha").should be_true
+
+    # A new send must invalidate the memo: the pane shows the NEW body, not the cached one.
+    view.apply(Gori::Repeater::Result.new(hdr.to_slice, %({"tag":"bravo"}).to_slice, nil, 1000_i64))
+    after = MemoryBackend.new(120, 20)
+    view.render(Screen.new(after), Rect.new(0, 0, 120, 20))
+    after.contains?("bravo").should be_true
+    after.contains?("alpha").should be_false
+  end
+
+  # The memo reuses the SAME styled Line object across frames — safe only because every
+  # downstream consumer (Highlight.draw / slice_left / line_width_upto) is read-only. Guard
+  # that: style a wide line (frame 1), scroll it sideways so slice_left runs on the cached
+  # Line (frame 2), then scroll back — the head must be intact (a slice_left that mutated
+  # its input in place would have corrupted the cached Line).
+  it "styled-line memo survives a horizontal-scroll round-trip without corrupting the cached line" do
+    view = RepeaterView.new
+    view.load_blank
+    view.focus_pane(:response)
+    hdr = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n"
+    body = %({"a":"ALPHATOKEN#{"_" * 90}OMEGATOKEN"})
+    view.apply(Gori::Repeater::Result.new(hdr.to_slice, body.to_slice, nil, 1000_i64))
+
+    at0 = MemoryBackend.new(50, 12)
+    view.render(Screen.new(at0), Rect.new(0, 0, 50, 12))
+    at0.contains?("ALPHATOKEN").should be_true # left edge visible, memo populated
+
+    view.hscroll(10) # slide the pane right → slice_left runs on the cached Line
+    scrolled = MemoryBackend.new(50, 12)
+    view.render(Screen.new(scrolled), Rect.new(0, 0, 50, 12))
+    scrolled.contains?("ALPHATOKEN").should be_false # scrolled past the head (proves the slice took effect)
+
+    view.hscroll(-10) # back to the left edge
+    back = MemoryBackend.new(50, 12)
+    view.render(Screen.new(back), Rect.new(0, 0, 50, 12))
+    back.contains?("ALPHATOKEN").should be_true # cached Line uncorrupted by the intervening slice
+  end
+
   it "duplicate_from copies request content, flags, and last response (no source flow)" do
     src = RepeaterView.new
     src.load_blank

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -77,6 +77,14 @@ module Gori::Tui
       # and the LCS diff lines.
       @resp_view_cache = nil.as(RespView?)
       @resp_view_rev = Theme.revision # the theme the cached (colour-baked) response head was built under
+      # Per-visible-line styled BODY memo (keyed by absolute line index). RespView keeps the
+      # body RAW and styles each visible line lazily so a multi-MiB response opens instantly —
+      # but render() fires on EVERY input event (a keystroke in the request editor, a 1-line
+      # scroll), re-styling the whole visible response window each time even when the response
+      # didn't change. Memoize so an unchanged response pane re-renders for free. Bounded
+      # (RESP_STYLED_CACHE_CAP) so scrolling a huge body can't materialise every line — the very
+      # property RespView's laziness exists to protect. Dropped in lockstep with @resp_view_cache.
+      @resp_styled_cache = {} of Int32 => Highlight::Line
       @diff_lines_cache = nil.as(Array(Repeater::DiffLine)?)
       @resp_hex = false                        # 'x' toggles a raw hex dump of the response bytes
       @resp_hex_bytes = nil.as(Bytes?)         # cached combined head+body of the last result (hex source)
@@ -1790,7 +1798,7 @@ module Gori::Tui
     def pretty=(on : Bool) : Nil
       return if @pretty == on
       @pretty = on
-      @resp_view_cache = nil
+      drop_resp_view_cache
       @scroll = 0 # reflow changes the line count → a stale offset could blank the pane (like x/d toggles)
       @xscroll = 0
     end
@@ -2503,7 +2511,7 @@ module Gori::Tui
       total = rv.total
       gw = {Gutter.width(total), body.w}.min
       cw = {body.w - gw, 0}.max
-      rows = (0...body.h).compact_map { |i| i < total ? rv.line_at(i) : nil }
+      rows = (0...body.h).compact_map { |i| i < total ? styled_resp_line(rv, i) : nil }
       rows.each_with_index do |styled, i|
         Gutter.draw(screen, body.x, body.y + i, i, gw)
         shown = @xscroll > 0 ? Highlight.slice_left(styled, @xscroll) : styled
@@ -2739,6 +2747,22 @@ module Gori::Tui
       @reveal_lines = Reveal.lines(bytes)
     end
 
+    # Ceiling on the styled-body memo. A visible window is ~tens of lines, so this covers
+    # many screens of local scroll while capping memory on a huge response; on overflow the
+    # whole memo is dropped (the next frame re-styles just the visible window — cheap).
+    RESP_STYLED_CACHE_CAP = 2048
+
+    # The styled line at absolute index `li`, memoized for BODY lines. Head lines are already
+    # materialised (RespView#line_at returns the pre-built array), so they skip the memo.
+    private def styled_resp_line(rv : RespView, li : Int32) : Highlight::Line
+      return rv.line_at(li) if li < rv.head.size
+      if cached = @resp_styled_cache[li]?
+        return cached
+      end
+      @resp_styled_cache.clear if @resp_styled_cache.size >= RESP_STYLED_CACHE_CAP
+      @resp_styled_cache[li] = rv.line_at(li)
+    end
+
     # Steady-scroll hot path: only materialises/styles VISIBLE lines. Selection spans
     # are computed once per frame (lazy line_at over the selected range only).
     private def render_response_body(screen : Screen, rect : Rect, focused : Bool) : Nil
@@ -2747,7 +2771,7 @@ module Gori::Tui
       @resp_last_h = rect.h
       gw = {Gutter.width(total), rect.w}.min
       cw = {rect.w - gw, 0}.max
-      rows = (0...rect.h).compact_map { |i| (li = @scroll + i) < total ? rv.line_at(li) : nil }
+      rows = (0...rect.h).compact_map { |i| (li = @scroll + i) < total ? styled_resp_line(rv, li) : nil }
       @xscroll = @xscroll.clamp(0, {(rows.max_of? { |l| Highlight.line_width_upto(l, @xscroll + cw + 1) } || 0) - cw, 0}.max)
       sel_spans = resp_sel_spans_if(focused)
       rows.each_with_index do |styled, i|
@@ -2866,7 +2890,7 @@ module Gori::Tui
     # Memoized + dropped only when a new result is applied (reset_result_caches), so
     # a held Repeater tab isn't re-parsed / re-highlighted / re-diffed 20×/sec.
     private def reset_result_caches : Nil
-      @resp_view_cache = nil
+      drop_resp_view_cache
       @diff_lines_cache = nil
       @resp_hex_bytes = nil
       @ws_lines_cache = nil
@@ -2884,8 +2908,16 @@ module Gori::Tui
       @transcript_rev = Theme.revision
     end
 
+    # Drop the styled response view AND the per-line styled-body memo together — the memo
+    # holds Lines built from the current view (theme colours + pretty/raw body), so the two
+    # MUST move in lockstep. Every site that invalidates the response view goes through here.
+    private def drop_resp_view_cache : Nil
+      @resp_view_cache = nil
+      @resp_styled_cache.clear
+    end
+
     private def resp_view : RespView
-      @resp_view_cache = nil if @resp_view_rev != Theme.revision # theme switched → rebuild with new colours
+      drop_resp_view_cache if @resp_view_rev != Theme.revision # theme switched → rebuild with new colours
       @resp_view_rev = Theme.revision
       @resp_view_cache ||= begin
         result = @result


### PR DESCRIPTION
## What

The Repeater response pane styles its body one visible line at a time (lazy, so a multi-MiB response opens instantly). But `render()` fires on **every** input event — a keystroke in the request editor, a cursor move, a 1-line scroll — and re-renders the whole view, re-styling every visible response body line each time **even when the response is unchanged**.

`bench/highlight_bench.cr` puts that at **~37µs + ~237kB of garbage per frame** for a 40-line JSON window. Previously that cost was paid on every unrelated re-render.

## Change

Add a bounded per-line styled-body memo (`@resp_styled_cache`), keyed by absolute line index, so an unchanged response pane re-renders for ~free (hash lookups, no allocation).

- Dropped in lockstep with `@resp_view_cache` through a single `drop_resp_view_cache` helper — `pretty=` invalidates the view directly (bypassing `reset_result_caches`), so all three invalidation sites now funnel through one place and can't drift.
- Bounded by `RESP_STYLED_CACHE_CAP` (clear-on-overflow) so scrolling a huge body can't materialise every line — the very property the lazy `BodyLines` exists to protect.
- Both the plain response and the WS-handshake renderers route through it.

## Why it's safe

The memo reuses the same `Highlight::Line` object across frames. That's only correct because every downstream consumer is read-only: `Highlight.draw` only writes to the screen, `slice_left` builds a fresh `Line` (or returns identity without mutating), and `line_width_upto` only reads.

## Send path

Reviewed `Repeater::Engine` / `Upstream` / codec too — already tight (off-UI-fiber send, buffered socket IO, shared TLS contexts, single-copy body capture). Deliberately did **not** presize the response capture buffer to `Content-Length` — a hostile `Content-Length: 999999999` would force a ~1GB allocation the on-demand growth currently avoids. Fresh-connection-per-send semantics are unchanged.

## Tests

- New: unchanged response re-renders identically, and the memo drops on a new send (no stale body).
- New: horizontal-scroll round-trip leaves the cached line uncorrupted (locks in the read-only-consumer invariant against a future `slice_left` regression).
- Full `spec/tui` + repeater suites pass (763 examples, 0 failures).