### PR TITLE
fix(tui): show Issues severity in Project AT A GLANCE

### DIFF
--- a/spec/tui/project_view_spec.cr
+++ b/spec/tui/project_view_spec.cr
@@ -218,6 +218,36 @@ describe "ProjectView AT A GLANCE Technologies" do
   end
 end
 
+describe "ProjectView AT A GLANCE severity" do
+  # Severity bars draw from the human-confirmed `issues` table only — Probe hits
+  # must not inflate the glance pane (they belong on the Probe tab).
+  it "shows Issues severity and ignores Probe-only findings" do
+    tmp_store do |store|
+      store.insert_issue("XSS on /search", Gori::Store::Severity::Critical, "acme.test", nil)
+      store.insert_issue("Verbose error", Gori::Store::Severity::Low, "acme.test", nil)
+      store.upsert_probe_issue(Gori::Probe::Detection.new(
+        code: "cors_wildcard", category: "security", host: "acme.test",
+        url: "http://acme.test/api", title: "cors *", severity: Gori::Store::Severity::High))
+      store.upsert_probe_issue(Gori::Probe::Detection.new(
+        code: "missing_hsts", category: "security", host: "acme.test",
+        url: "http://acme.test/", title: "no hsts", severity: Gori::Store::Severity::Medium))
+      store.flush
+
+      project = Gori::Project.new("t", File.tempname("gori-projview-sev"))
+      view = ProjectView.new(Gori::Scope.load(store), Gori::HostOverrides.load(store))
+      view.reload(project, store)
+      b = MemoryBackend.new(120, 30)
+      view.render(Screen.new(b), Rect.new(0, 0, 120, 30), focused: false)
+
+      b.contains?("AT A GLANCE").should be_true
+      b.contains?("CRIT").should be_true # Issues Critical
+      b.contains?("LOW").should be_true  # Issues Low
+      b.contains?("HIGH").should be_false # Probe-only High must not appear
+      b.contains?("MED").should be_false  # Probe-only Medium must not appear
+    end
+  end
+end
+
 describe "ProjectView#pane_at" do
   it "hides the ENV pane on short terminals" do
     tmp_store do |store|

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -103,11 +103,10 @@ module Gori::Tui
       @probe_tech = scoped_tech(store.probe_tech_rows)
       @db_size = project.db_size
       @total_captured = store.total_size
-      # AT A GLANCE aggregates: status mix + combined issue/Probe severity tally.
+      # AT A GLANCE aggregates: traffic status mix + Issues severity (human-confirmed
+      # `issues` table only — Probe hits stay on the Probe tab, not here).
       @status_counts = store.flow_status_counts
-      f = store.issues_severity_counts
-      p = store.probe_severity_counts
-      @sev_tally = StaticArray(Int64, 5).new { |i| f[i] + p[i] }
+      @sev_tally = store.issues_severity_counts
       earliest = store.earliest_created_at
       # earliest_created_at is unix MICROSECONDS (the flows.created_at unit) — decoder
       # to seconds for Time.unix, like History's fmt_time does. (Passing micros makes
@@ -927,7 +926,7 @@ module Gori::Tui
 
     # AT A GLANCE viz pane riding the right of the OVERVIEW band (read-only, like OVERVIEW
     # — no focus/keys). Two stacked micro-charts an analyst wants without leaving the tab:
-    # the captured traffic's HTTP status mix, then the issue/Probe severity breakdown.
+    # the captured traffic's HTTP status mix, then the Issues severity breakdown (not Probe).
     # Degrades top-down by height (mirrors the Fuzzer DIST pane).
     private def render_analytics(screen : Screen, rect : Rect) : Nil
       return if rect.w < 2 || rect.h < 2
@@ -969,8 +968,8 @@ module Gori::Tui
       out
     end
 
-    # Severity rows (Critical first) with nonzero counts, from the combined issue+Probe
-    # tally. The Int value feeds Theme.severity_color.
+    # Severity rows (Critical first) with nonzero counts, from the Issues table only.
+    # The Int value feeds Theme.severity_color.
     private def severity_rows : Array({String, Int64, Int32})
       labels = { {4, "CRIT"}, {3, "HIGH"}, {2, "MED"}, {1, "LOW"}, {0, "INFO"} }
       out = [] of {String, Int64, Int32}


### PR DESCRIPTION
## Summary

- Project tab **AT A GLANCE** severity bars now count only human-confirmed **Issues** (`issues` table).
- Probe detections no longer inflate the glance severity tally (they remain on the Probe tab).
- HTTP status mix is unchanged; OVERVIEW Technologies is unchanged.

## Test plan

- [x] `crystal spec spec/tui/project_view_spec.cr` (17 examples, 0 failures)
- [ ] Open Project tab with Issues + Probe findings; confirm CRIT/HIGH/… bars match Issues only
- [ ] Confirm Probe-only findings do not appear in the glance severity section
