### PR TITLE
feat(tui): dress Repeater SEND / Fuzzer RUN as gold primary-action buttons

### DIFF
--- a/src/gori/tui/frame.cr
+++ b/src/gori/tui/frame.cr
@@ -116,6 +116,27 @@ module Gori::Tui
       x
     end
 
+    # The one PRIMARY-action badge on a pane's top border — the button that actually fires
+    # the request: Repeater's ` ^R:SEND `, Fuzzer's ` ^R:RUN `. Geometry + text are identical
+    # to `toggle_badge` (same " chord:NAME " string), so a click still hit-tests through
+    # `right_badge_hit` and neighbours chain off the returned left x unchanged. Only the
+    # dress differs: a solid gold pill with auto-contrast ink + bold when `ready`, so the
+    # trigger reads as a filled button that stands apart from the muted toggles beside it;
+    # a recessed accent-band pill (shortcut still legible) while the action is in flight, so
+    # ^R/^X stay discoverable. Returns the badge's left x, or `right_edge` when it doesn't fit.
+    def self.action_badge(screen : Screen, right_edge : Int32, y : Int32, min_x : Int32,
+                          chord : String, name : String, ready : Bool) : Int32
+      text = " #{chord}:#{name} "
+      x = right_edge - text.size
+      return right_edge if x < min_x
+      if ready
+        screen.text(x, y, text, Theme.ink_on(Theme.focus_gold), Theme.focus_gold, Attribute::Bold)
+      else
+        screen.text(x, y, text, Theme.muted, Theme.accent_bg)
+      end
+      x
+    end
+
     # Hit-test for a left-to-right run of `Frame.chip` labels. `chips` is
     # `{id, label}` in draw order; each chip is followed by a 1-col gap (matching
     # the `+ 1` callers use after `Frame.chip`). Miss → nil. Pure geometry — no Screen.

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -1486,10 +1486,10 @@ module Gori::Tui
       badge = " §#{pc} "
       min_x = rect.x + label.size + 4
       # ^R:RUN rides the TEMPLATE border as the primary action — rightmost, mirroring the
-      # Repeater's ^R:SEND so the muscle memory transfers. Lit while idle, muted while a run
-      # streams (^X stops it). The old CONFIG "Run" row is gone; the request-count estimate
-      # stays there as a passive summary (render_run_summary).
-      run_x = Frame.toggle_badge(screen, rect.right - 1, rect.y, min_x, "^R", "RUN", !running?)
+      # Repeater's ^R:SEND so the muscle memory transfers. A gold button while idle, recessed
+      # while a run streams (^X stops it). The old CONFIG "Run" row is gone; the request-count
+      # estimate stays there as a passive summary (render_run_summary).
+      run_x = Frame.action_badge(screen, rect.right - 1, rect.y, min_x, "^R", "RUN", !running?)
       pretty_x = Frame.toggle_badge(screen, run_x, rect.y, min_x, "^U", "PRETTY", false)
       render_mode_badge(screen, pretty_x, rect.y, min_x, ins)
       screen.text({pretty_x - badge.size, min_x}.max, rect.y, badge,

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -2404,8 +2404,8 @@ module Gori::Tui
       min_x = rect.x + label.size + 4 # keep clear of the pane title on the top border
       right_edge = rect.right - 1     # leave the right border cell untouched
       # Primary action rides the REQUEST border (discoverable without the footer chord):
-      # rightmost, lit while idle, muted while a send is in flight.
-      send_edge = Frame.toggle_badge(screen, right_edge, rect.y, min_x, "^R", "SEND", !@inflight)
+      # rightmost, a gold button while idle, recessed while a send is in flight.
+      send_edge = Frame.action_badge(screen, right_edge, rect.y, min_x, "^R", "SEND", !@inflight)
       if @grpc_mode # head as text; a unary call's payload is hex-editable (^X → MSG/HEX)
         if h = @req_hex_edit
           Frame.toggle_badge(screen, send_edge, rect.y, min_x, "^X", "HEX", true)


### PR DESCRIPTION
## What

The two buttons that actually fire a request — Repeater's `^R:SEND` and Fuzzer's `^R:RUN` — were drawn with the same `Frame.toggle_badge` as the muted toggles beside them (`CL` / `PRETTY` / `HEX` / `DIST`), so the primary action didn't visually stand out.

This adds `Frame.action_badge` and points both at it:

- **Idle / ready** → a solid **gold pill** with bold, auto-contrast ink (`Theme.ink_on` on `Theme.focus_gold` — the same treatment as the focused sub-tab pill, so it reads correctly across all 21 themes, light and dark).
- **In flight (sending / running)** → a recessed accent-band pill so it visibly "presses in" while working, with the `^R` / `^X` shortcut still legible.

## Why it's safe

Badge text stays byte-identical (`" ^R:SEND "` / `" ^R:RUN "`), so `right_badge_hit` mouse hit-testing and neighbour-badge chaining are untouched — only the styling differs.

## Verification

- `crystal build` passes.
- `mouse_spec` + repeater/fuzzer specs (114 examples) green — geometry-based hit-test still holds.
- Direct render probe confirmed the cells: ready → `focus_gold` bg + `ink_on` fg; busy → `accent_bg` bg + `muted` fg.