### PR TITLE
feat(tui): add clickable ⌘ palette button on the top bar

### DIFF
--- a/spec/tui/foundation_spec.cr
+++ b/spec/tui/foundation_spec.cr
@@ -208,8 +208,11 @@ describe Gori::Tui::Chrome do
     backend.row(0).should contain("acme")
     backend.row(0).should contain("scope:2")
     backend.row(0).should contain("01:37 PM")
+    backend.row(0).should contain("⌘")              # far-right palette affordance
     backend.row(0).should contain("127.0.0.1:8080") # listen address always shown, capture state rides its colour
     backend.row(0).should_not contain("notify")     # no unread → badge omitted
+    row = backend.row(0)
+    row.index("01:37 PM").not_nil!.should be < row.index("⌘").not_nil! # clock left of palette
   end
 
   it "shows the unread notify badge on the top bar, left of scope" do

--- a/spec/tui/mouse_spec.cr
+++ b/spec/tui/mouse_spec.cr
@@ -340,7 +340,7 @@ describe "Chrome.top_bar_chip_rect" do
   end
 
   it "keeps notify/scope hit-test rects in sync with the drawn row even when the project name is squeezed" do
-    # Narrow rect: chips (notify:3 · scope:99 · 127.0.0.1:8080 · 01:37 PM) leave the
+    # Narrow rect: chips (notify:3 · scope:99 · 127.0.0.1:8080 · 01:37 PM · ⌘) leave the
     # project name almost no room — exercises the "name squeezed to zero width" branch.
     rect = Rect.new(0, 0, 45, 1)
     backend = MemoryBackend.new(45, 1)
@@ -355,6 +355,20 @@ describe "Chrome.top_bar_chip_rect" do
     srect = Chrome.top_bar_chip_rect(rect, :scope, scope: "scope:99", listen: "127.0.0.1:8080",
       time: "01:37 PM", unread: 3).not_nil!
     backend.row(0)[srect.x, srect.w].should eq("scope:99")
+  end
+
+  it "returns a rect matching the drawn far-right palette chip (⌘)" do
+    rect = Rect.new(0, 0, 80, 1)
+    backend = MemoryBackend.new(80, 1)
+    Chrome.render_top_bar(Screen.new(backend), rect,
+      project: "acme", listen: "127.0.0.1:8080", time: "01:37 PM", scope: "scope:2")
+    prect = Chrome.top_bar_chip_rect(rect, :palette, scope: "scope:2", listen: "127.0.0.1:8080",
+      time: "01:37 PM").not_nil!
+    backend.row(0)[prect.x, prect.w].should eq("⌘")
+    # Right of the clock chip.
+    trect = Chrome.top_bar_chip_rect(rect, :time, scope: "scope:2", listen: "127.0.0.1:8080",
+      time: "01:37 PM").not_nil!
+    prect.x.should be > trect.x
   end
 end
 

--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -153,12 +153,14 @@ module Gori::Tui
       name_x = x + 1
 
       # right-aligned status chips: notify:N · scope:N · rules:N · intercept:on(N) ·
-      # ●listen · h:MM AM/PM — value-emphasized, dim · separators; the hot intercept
-      # state in RED. The clock is the rightmost anchor. `unread` rides just left of
-      # scope so a background-job ping surfaces beside the state it's most likely to
-      # affect. The listen chip's address text never changes — capture on/off/failing
-      # rides as the leading dot + label colour (green/muted/red), so the one address
-      # a user glances at doubles as the capture indicator instead of a separate chip.
+      # ●listen · h:MM AM/PM · ⌘ — value-emphasized, dim · separators; the hot
+      # intercept state in RED. The clock is the penultimate anchor; the palette
+      # glyph (`⌘`, click → open palette) is rightmost. `unread` rides just left
+      # of scope so a background-job ping surfaces beside the state it's most
+      # likely to affect. The listen chip's address text never changes — capture
+      # on/off/failing rides as the leading dot + label colour (green/muted/red),
+      # so the one address a user glances at doubles as the capture indicator
+      # instead of a separate chip.
       tagged = top_bar_chips(scope: scope, rules: rules, intercept: intercept, sandbox: sandbox,
         listen: listen, time: time, unread: unread, capturing: capturing,
         write_failures: write_failures)
@@ -189,6 +191,9 @@ module Gori::Tui
       label, color = listen_chip(listen, capturing, write_failures)
       chips << {:listen, label, color}
       chips << {:time, time, Theme.muted}
+      # Far-right command-palette affordance — same action as Ctrl/Cmd-P. Always
+      # present so a mouse user can open the palette without knowing the chord.
+      chips << {:palette, "⌘", Theme.text}
       chips
     end
 

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1274,7 +1274,8 @@ module Gori::Tui
 
     # Click a top-bar chip: the notification badge (`notify:N`, left of scope) opens
     # the center; the scope chip (`scope:N` / `scope:off`) flips the lens — the same
-    # action as the global `s` chord. Returns true when consumed. Each rect is
+    # action as the global `s` chord; the far-right `⌘` glyph opens the command
+    # palette (same as Ctrl/Cmd-P). Returns true when consumed. Each rect is
     # rebuilt from the same tagged source render uses, so a click can't drift.
     private def click_top_bar(rect : Rect, mx : Int32, my : Int32) : Bool
       return false unless rect.contains?(mx, my)
@@ -1296,6 +1297,14 @@ module Gori::Tui
         unread: unread, capturing: capturing, write_failures: write_failures)
       if srect && srect.contains?(mx, my)
         scope_toggle_lens
+        return true
+      end
+
+      prect = Chrome.top_bar_chip_rect(rect, :palette, scope: scope_label, rules: rules_label,
+        intercept: intercept_label, sandbox: sandbox_label, listen: listen, time: clock_label,
+        unread: unread, capturing: capturing, write_failures: write_failures)
+      if prect && prect.contains?(mx, my)
+        open_palette
         return true
       end
 


### PR DESCRIPTION
## Summary
- Add a far-right `⌘` chip on the TUI top bar (to the right of the clock).
- Clicking it opens the command palette — same action as Ctrl/Cmd-P.
- Hit-test reuses the tagged top-bar chip layout so the click target stays aligned with the drawn glyph.

## Test plan
- [x] `crystal spec spec/tui/foundation_spec.cr spec/tui/mouse_spec.cr`
- [ ] Manually: click `⌘` on the top bar and confirm the palette opens
- [ ] Confirm notify/scope chips still work as before