### PR TITLE
feat(tui): conceal marker chains inline with a tooltip + ^Y preview modal

### DIFF
--- a/spec/fuzz_spec.cr
+++ b/spec/fuzz_spec.cr
@@ -162,6 +162,16 @@ describe F::Template do
     F::Template.marked_spans(t).size.should eq(F::Template.parse(t).position_count)
   end
 
+  it "value_at / marker_start_at read the marker under the cursor (nil outside)" do
+    t = "x=§hi¦base64-encode§ y"                    # open § at 2, ¦ at 5, close § at 19
+    F::Template.value_at(t, 4).should eq("hi")      # cursor in the value
+    F::Template.value_at(t, 10).should eq("hi")     # cursor in the (concealed) chain
+    F::Template.marker_start_at(t, 10).should eq(2) # stable open-§ anchor for the ^Y commit
+    F::Template.marker_start_at(t, 19).should eq(2) # even from the closing §
+    F::Template.value_at(t, 0).should be_nil        # outside any marker
+    F::Template.marker_start_at(t, 0).should be_nil
+  end
+
   it "clear_markers drops the marker AND its chain" do
     F::Template.clear_markers("tok=§secret¦base64-encode§&x=1").should eq("tok=secret&x=1")
   end

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -26,9 +26,21 @@ describe Gori::Tui::FuzzerView do
     view.focus_chain_pane.should be_nil # in a marker → enters the pane
     view.chain_pane_active?.should be_true
     "rot13".each_char { |c| view.handle_chain_pane_key(Termisu::Event::Key.new(Termisu::Input::Key::LowerA, char: c)) }
+    # While the chain is focused, the ^Y modal renders over the tab with a transform preview.
+    b = MemoryBackend.new(120, 30)
+    view.render(Screen.new(b), Rect.new(0, 0, 120, 30))
+    grid = (0...30).map { |y| b.row(y) }.join("\n")
+    grid.should contain("CHAIN")
+    grid.should contain("PREVIEW")
     view.commit_chain_pane
     view.chain_pane_active?.should be_false
     view.template_text.should contain("§x¦rot13§")
+    # Committed: the ¦rot13 is concealed inline (only §x§ shows), never the full marker.
+    b2 = MemoryBackend.new(120, 30)
+    view.render(Screen.new(b2), Rect.new(0, 0, 120, 30))
+    grid2 = (0...30).map { |y| b2.row(y) }.join("\n")
+    grid2.should contain("§x§")
+    grid2.should_not contain("§x¦rot13§")
   end
 
   it "toggle_http2 flips the transport and retargets the template request-line version" do

--- a/spec/tui/highlight_spec.cr
+++ b/spec/tui/highlight_spec.cr
@@ -389,7 +389,7 @@ describe Gori::Tui::Highlight do
           spans << Highlight::Span.new(chars[i...j].join, Theme.muted)
           name = j
           while name < gt && (chars[name].ascii_letter? || chars[name].ascii_number? ||
-                chars[name] == '-' || chars[name] == '_' || chars[name] == ':')
+                              chars[name] == '-' || chars[name] == '_' || chars[name] == ':')
             name += 1
           end
           spans << Highlight::Span.new(chars[j...name].join, Theme.syn_header) if name > j
@@ -410,7 +410,7 @@ describe Gori::Tui::Highlight do
 
     # A varied byte/char pool: ASCII structural + hex + letters + multibyte (Korean, accented,
     # emoji), so tokens land next to multibyte content and near boundaries.
-    pool = %w(" \\ { } [ ] : , & = < > / - _ + . e E a Z 0 9 x   가 é 🚀 t r u e n l s f) + ["\t"]
+    pool = %w(" \\ { } [ ] : , & = < > / - _ + . e E a Z 0 9 x 가 é 🚀 t r u e n l s f) + ["\t"]
 
     it "matches the reference char tokenizer for :json / :form / :html over a fuzz corpus" do
       rng = Random.new(0x9051) # fixed seed → deterministic
@@ -432,17 +432,48 @@ describe Gori::Tui::Highlight do
         %({"이름": "값🚀", "n": -12.5e3, "ok": true}),
         %(a=가&b=é🚀&=x&flag),
         %(<div class="x">가나다</div><br/><b>té</b>),
-        %("trailing backslash\\),      # overshoot case
-        %(<unclosed tag 가),           # no '>'
-        "",                            # empty
-        "{}[],:",                      # all structural
-        "가나다라",                     # pure multibyte, no ASCII
+        %("trailing backslash\\), # overshoot case
+        %(<unclosed tag 가),       # no '>'
+        "",                       # empty
+        "{}[],:",                 # all structural
+        "가나다라",                   # pure multibyte, no ASCII
       ]
       cases.each do |raw|
         Highlight.body_styled(raw, :json).should eq(ref_json.call(raw))
         Highlight.body_styled(raw, :form).should eq(ref_form.call(raw))
         Highlight.body_styled(raw, :html).should eq(ref_markup.call(raw))
       end
+    end
+  end
+
+  describe ".conceal" do
+    red = Gori::Tui::Color.from_hex("#ff0000")
+    blue = Gori::Tui::Color.from_hex("#0000ff")
+
+    it "is the identity when there are no ranges" do
+      line = [Highlight::Span.new("hello", red)]
+      Highlight.conceal(line, [] of {Int32, Int32}).should eq(line)
+    end
+
+    it "deletes a range from a single span, preserving styling" do
+      line = [Highlight::Span.new("§data¦base64-encode§", red)]
+      res = Highlight.conceal(line, [{5, 19}]) # hide ¦base64-encode, keep the closing §
+      res.map(&.text).join.should eq("§data§")
+      res.all? { |s| s.fg == red }.should be_true
+    end
+
+    it "deletes a range spanning multiple spans, keeping each survivor's style" do
+      # "§data" (red) + "¦b64§" (blue); conceal chars [5,9) = "¦b64", keep the trailing §.
+      line = [Highlight::Span.new("§data", red), Highlight::Span.new("¦b64§", blue)]
+      res = Highlight.conceal(line, [{5, 9}])
+      res.map(&.text).join.should eq("§data§")
+      has_span?(res, "§data", red).should be_true
+      has_span?(res, "§", blue).should be_true
+    end
+
+    it "keeps the concatenation equal to the source minus the deleted chars" do
+      line = [Highlight::Span.new("abc", red), Highlight::Span.new("defg", blue)]
+      Highlight.conceal(line, [{1, 3}, {4, 6}]).map(&.text).join.should eq("a" + "dg")
     end
   end
 end

--- a/spec/tui/repeater_view_spec.cr
+++ b/spec/tui/repeater_view_spec.cr
@@ -351,20 +351,32 @@ describe Gori::Tui::RepeaterView do
     view.chain_pane_active?.should be_false
   end
 
-  it "shows the CHAIN pane only while the cursor is inside a §…§ marker (no mode toggle)" do
-    # Cursor at offset 0 sits INSIDE the leading §v§ marker → CHAIN pane is split in.
-    inside = RepeaterView.new
-    inside.restore("https://a.test", "§v§ HTTP/1.1\nHost: a.test\n\n", false, false)
-    b_in = MemoryBackend.new(120, 24)
-    inside.render(Screen.new(b_in), Rect.new(0, 0, 120, 24))
-    b_in.contains?("CHAIN").should be_true
+  it "conceals the ¦chain inline and reveals it in the caret tooltip (only §value§ shows)" do
+    view = RepeaterView.new
+    view.restore("https://a.test", "§v¦md5§ HTTP/1.1\nHost: a.test\n\n", false, false)
+    view.focus_pane(:request) # cursor at offset 0 sits inside the §v¦md5§ marker
+    b = MemoryBackend.new(120, 24)
+    view.render(Screen.new(b), Rect.new(0, 0, 120, 24))
+    grid = (0...24).map { |y| b.row(y) }.join("\n")
+    # The request line renders §v§ (the ¦md5 hidden inline), never the full §v¦md5§.
+    grid.should contain("§v§ HTTP/1.1")
+    grid.should_not contain("§v¦md5§")
+    # ...but the caret tooltip reveals the concealed chain + the ^Y edit affordance.
+    grid.should contain("md5")         # chain shown in the tooltip
+    grid.should contain("^Y edit")     # edit affordance
+    grid.should_not contain("PREVIEW") # the ^Y modal is NOT auto-shown
+  end
 
-    # Same buffer shape, but the marker is past the caret (offset 0 is on 'G') → no CHAIN pane.
-    outside = RepeaterView.new
-    outside.restore("https://a.test", "GET §v§ HTTP/1.1\nHost: a.test\n\n", false, false)
-    b_out = MemoryBackend.new(120, 24)
-    outside.render(Screen.new(b_out), Rect.new(0, 0, 120, 24))
-    b_out.contains?("CHAIN").should be_false
+  it "opens the CHAIN modal (with a transform preview) only after ^Y" do
+    view = RepeaterView.new
+    view.restore("https://a.test", "§v¦md5§ HTTP/1.1\nHost: a.test\n\n", false, false)
+    view.focus_pane(:request)
+    view.focus_chain_pane.should be_nil # in a marker → opens the editor (no hint)
+    b = MemoryBackend.new(120, 24)
+    view.render(Screen.new(b), Rect.new(0, 0, 120, 24))
+    grid = (0...24).map { |y| b.row(y) }.join("\n")
+    grid.should contain("CHAIN")   # modal title
+    grid.should contain("PREVIEW") # live transform preview
   end
 
   it "load_grpc keeps the framed body byte-exact and the head editable" do

--- a/spec/tui/text_area_spec.cr
+++ b/spec/tui/text_area_spec.cr
@@ -19,7 +19,71 @@ private def render_peek(text : String, cx : Int32, cursor : Bool, peek : Bool) :
   backend
 end
 
+# Render `text` with the given conceal spans and caret column, returning the screen.
+private def render_concealed(text : String, conceal : Array({Int32, Int32}), cx : Int32 = 0) : MemoryBackend
+  ta = Gori::Tui::TextArea.new(text)
+  ta.conceal_spans = conceal
+  ta.move(0, cx)
+  backend = MemoryBackend.new(60, 8)
+  ta.render(Gori::Tui::Screen.new(backend), Gori::Tui::Rect.new(0, 0, 60, 8),
+    cursor: true, highlight: :request)
+  backend
+end
+
 describe Gori::Tui::TextArea do
+  describe "display concealment (@conceal_spans)" do
+    # "q=§data¦base64-encode§ x": open § at 2, ¦ at 7, closing § at 21.
+    text = "q=§data¦base64-encode§ x"
+
+    it "hides the concealed span inline while keeping it in the buffer" do
+      backend = render_concealed(text, [{7, 21}])
+      backend.row(0).rstrip.should eq("q=§data§ x") # ¦base64-encode gone from the screen
+      # the buffer (and thus the wire bytes) still carry the full marker + chain
+    end
+
+    it "is a no-op with no conceal spans (full marker shows)" do
+      backend = render_concealed(text, [] of {Int32, Int32})
+      backend.row(0).rstrip.should eq(text)
+    end
+
+    it "snaps the caret out of a concealed run on horizontal move (never rests hidden)" do
+      ta = TextArea.new(text)
+      ta.conceal_spans = [{7, 21}]
+      ta.move(0, 7) # land on the ¦ (start of the hidden run)
+      ta.move(0, 1) # step right into the hidden run → snaps to its end (the closing §)
+      ta.cx.should eq(21)
+      ta.move(0, -1) # left off the run's far edge → snaps to its start
+      ta.cx.should eq(7)
+    end
+
+    it "keeps concealment from corrupting the buffer text" do
+      ta = TextArea.new(text)
+      ta.conceal_spans = [{7, 21}]
+      ta.text.should eq(text) # concealment is display-only
+    end
+
+    it "bands the visible marker and accents the closing § (chain-attached signal)" do
+      # Displayed "q=§data§ x": § at col 2, data 3..6, closing § at col 7.
+      ta = TextArea.new(text)
+      ta.conceal_spans = [{7, 21}]
+      ta.bg_regions = [{2, 22, Theme.marker_bg(0)}] # whole marker; the conceal-aware paint skips hidden cells
+      b = MemoryBackend.new(60, 8)
+      ta.render(Screen.new(b), Rect.new(0, 0, 60, 8), cursor: false, highlight: :request)
+      b.row(0).rstrip.should eq("q=§data§ x")
+      # The band bg covers the visible marker cells only (cols 2..7), not the surrounding text.
+      b.bg_at(2, 0).should eq(Theme.marker_bg(0))
+      b.bg_at(7, 0).should eq(Theme.marker_bg(0))
+      b.bg_at(0, 0).should_not eq(Theme.marker_bg(0)) # "q" before the marker
+      b.bg_at(8, 0).should_not eq(Theme.marker_bg(0)) # space after the marker
+      # The closing § is accented (chain attached); the opening § keeps plain marker_fg.
+      b.fg_at(7, 0).should eq(Theme.marker_accent)
+      b.fg_at(2, 0).should eq(Theme.marker_fg)
+      # The accent MUST differ from marker_fg or the signal is invisible (in monochrome
+      # palettes accent == text_bright == marker_fg, which is exactly the trap to avoid).
+      Theme.marker_accent.should_not eq(Theme.marker_fg)
+    end
+  end
+
   describe "#home / #end_of_line" do
     it "jumps the caret to the start / end of the current line (insert lands there)" do
       ta = TextArea.new("abc")
@@ -67,29 +131,29 @@ describe Gori::Tui::TextArea do
 
     it "reverts a newline split and a subsequent line-join independently (multi-line ops)" do
       ta = TextArea.new("hello world")
-      ta.move(0, 5)        # caret after "hello"
-      ta.insert_newline    # -> "hello\n world"
+      ta.move(0, 5)     # caret after "hello"
+      ta.insert_newline # -> "hello\n world"
       ta.text.should eq("hello\n world")
-      ta.backspace         # join back -> "hello world"
+      ta.backspace # join back -> "hello world"
       ta.text.should eq("hello world")
-      ta.undo              # undo the join -> split again
+      ta.undo # undo the join -> split again
       ta.text.should eq("hello\n world")
-      ta.undo              # undo the split -> original
+      ta.undo # undo the split -> original
       ta.text.should eq("hello world")
     end
 
     it "keeps earlier snapshots intact after editing a restored buffer (no shared-array corruption)" do
       ta = TextArea.new("a\nb\nc")
       ta.end_of_line
-      ta.insert('X')       # "aX\nb\nc"
-      ta.insert('Y')       # "aXY\nb\nc"
-      ta.undo              # back to "aX\nb\nc"
+      ta.insert('X') # "aX\nb\nc"
+      ta.insert('Y') # "aXY\nb\nc"
+      ta.undo        # back to "aX\nb\nc"
       ta.text.should eq("aX\nb\nc")
-      ta.insert('Z')       # edit the restored buffer -> "aXZ\nb\nc"
+      ta.insert('Z') # edit the restored buffer -> "aXZ\nb\nc"
       ta.text.should eq("aXZ\nb\nc")
-      ta.undo              # the Z edit
+      ta.undo # the Z edit
       ta.text.should eq("aX\nb\nc")
-      ta.undo              # the X edit -> original
+      ta.undo # the X edit -> original
       ta.text.should eq("a\nb\nc")
     end
   end

--- a/spec/tui/text_area_spec.cr
+++ b/spec/tui/text_area_spec.cr
@@ -46,14 +46,24 @@ describe Gori::Tui::TextArea do
       backend.row(0).rstrip.should eq(text)
     end
 
-    it "snaps the caret out of a concealed run on horizontal move (never rests hidden)" do
+    it "treats a concealed run as atomic on horizontal move (one keypress each way, no hidden rest)" do
+      # run [7,21) = ¦base64-encode; the closing § is at index 21, the trailing " x" after it.
       ta = TextArea.new(text)
       ta.conceal_spans = [{7, 21}]
-      ta.move(0, 7) # land on the ¦ (start of the hidden run)
-      ta.move(0, 1) # step right into the hidden run → snaps to its end (the closing §)
-      ta.cx.should eq(21)
-      ta.move(0, -1) # left off the run's far edge → snaps to its start
+      ta.move(0, 7) # left edge of the run (offset 7), on the visible value
       ta.cx.should eq(7)
+      ta.move(0, 1)       # right: skips the whole run AND the closing § in one press
+      ta.cx.should eq(22) # past the § (b+1) — NOT 21, where a backspace would hit a hidden byte
+      ta.move(0, -1)      # left: back across it in one press
+      ta.cx.should eq(7)
+    end
+
+    it "never lets an edit at the run boundary touch a hidden byte" do
+      ta = TextArea.new(text)
+      ta.conceal_spans = [{7, 21}]
+      ta.move(0, 7) # the only legal rest at the value/chain seam is on the VISIBLE value side
+      ta.backspace  # deletes the last value char, never a concealed chain byte
+      ta.text.should eq("q=§dat¦base64-encode§ x")
     end
 
     it "keeps concealment from corrupting the buffer text" do

--- a/src/gori/fuzz/template.cr
+++ b/src/gori/fuzz/template.cr
@@ -265,6 +265,15 @@ module Gori::Fuzz
       parse(text).positions[idx]?.try(&.chain)
     end
 
+    # The DEFAULT value (the `§value§` payload, unescaped) of the marker enclosing char
+    # index `cursor`, or nil when the cursor isn't in a closed marker. Feeds the ^Y chain
+    # overlay's transform preview (value → chain → output).
+    def self.value_at(text : String, cursor : Int32) : String?
+      idx = marked_spans(text).index { |(a, b)| a <= cursor && cursor <= b }
+      return nil unless idx
+      parse(text).positions[idx]?.try(&.default)
+    end
+
     # Replace/insert/remove the chain of the marker enclosing `cursor`, returning the
     # new text (nil when the cursor isn't inside a marker). An empty `chain` removes
     # the `¦…` entirely. The raw default bytes are kept verbatim; the new chain has any

--- a/src/gori/fuzz/template.cr
+++ b/src/gori/fuzz/template.cr
@@ -274,6 +274,13 @@ module Gori::Fuzz
       parse(text).positions[idx]?.try(&.default)
     end
 
+    # Char index of the OPEN `§` of the marker enclosing `cursor`, or nil. The value region
+    # [open, ¦) is untouched by a chain edit, so this is a stable, edit-safe anchor to
+    # restore the caret to after the ^Y overlay rewrites the chain.
+    def self.marker_start_at(text : String, cursor : Int32) : Int32?
+      marked_spans(text).find { |(a, b)| a <= cursor && cursor <= b }.try(&.[0])
+    end
+
     # Replace/insert/remove the chain of the marker enclosing `cursor`, returning the
     # new text (nil when the cursor isn't inside a marker). An empty `chain` removes
     # the `¦…` entirely. The raw default bytes are kept verbatim; the new chain has any

--- a/src/gori/tui/chain_overlay.cr
+++ b/src/gori/tui/chain_overlay.cr
@@ -1,0 +1,120 @@
+require "./screen"
+require "./theme"
+require "./frame"
+require "./chain_pane"
+require "../decoder"
+
+module Gori::Tui
+  # The ^Y chain editor: a centered modal that edits a §…§ marker's Decoder chain AND
+  # previews how the marker's value transforms through it (value → each step → output).
+  # Replaces the old bottom CHAIN split — the inline chain is concealed now, so the
+  # editing surface became a focused popup that can show the wire result before you send.
+  # Stateless: the owning view holds the ChainPane (edit state) + the marker's value and
+  # calls `render`; keys still flow through ChainPane via the controller.
+  module ChainOverlay
+    MAX_STEPS = 8
+    HINT      = "↵ save · esc cancel · Tab completes"
+    LABEL_W   = 7 # "value"/"chain" gutter
+
+    # Draw the modal over `area`. `header` is the card title ("CHAIN · §N"), `value` the
+    # marker's default payload, `pane` the live chain editor.
+    def self.render(screen : Screen, area : Rect, header : String, value : String, pane : ChainPane) : Nil
+      return if area.w < 24 || area.h < 8
+      chain = pane.value.strip
+      result = chain.empty? ? nil : Decoder.run(Decoder.shared_registry, value.to_slice, chain)
+      nsteps = result ? result.steps.size : 0
+      box = overlay_box(area, nsteps)
+      return if box.nil?
+
+      Frame.card(screen, box, header, bg: Theme.panel, border: Theme.border_focus)
+      ix = box.x + 2
+      vx = ix + LABEL_W
+      vw = {box.right - 1 - vx, 1}.max
+      y = box.y + 1
+
+      screen.text(ix, y, "value", Theme.muted, Theme.panel)
+      screen.text(vx, y, oneline(value, vw), Theme.text, Theme.panel, width: vw)
+      y += 1
+
+      screen.text(ix, y, "chain", Theme.marker_accent, Theme.panel)
+      field = Rect.new(vx, y, vw, 1)
+      pane.render_input(screen, field, focused: true)
+      y += 1
+
+      Frame.tee_divider(screen, box, y, bg: Theme.panel)
+      y += 1
+      screen.text(ix, y, "PREVIEW", Theme.accent, Theme.panel, Attribute::Bold)
+      y += 1
+
+      hint_y = box.bottom - 2
+      render_preview(screen, ix, vx, y, hint_y, box.right - 1, value, result)
+      screen.text(ix, hint_y, HINT, Theme.muted, Theme.panel, width: {box.right - 1 - ix, 1}.max)
+
+      # Dropdown LAST so an open completion list overlays the preview cleanly.
+      pane.render_dropdown(screen, field, box)
+    end
+
+    # Content rows: value + chain, the divider, the PREVIEW header, the preview body
+    # (input + one row per step, capped), and the hint — plus the two border rows. Clamped
+    # to the available height so a short window still opens (the preview just truncates).
+    private def self.overlay_box(area : Rect, nsteps : Int32) : Rect?
+      preview_rows = 1 + (nsteps == 0 ? 1 : {nsteps, MAX_STEPS}.min)
+      rows = 2 + 1 + 1 + preview_rows + 1
+      w = {area.w - 4, 72}.min
+      h = {rows + 2, area.h - 2}.min
+      return nil if w < 28 || h < 9
+      Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
+    end
+
+    # Draw the transform: an `in` row (the value), then one row per chain step with its
+    # output — green while the pipeline is live, red at the first failed/unknown step and
+    # dim for steps skipped after it. Stops at `y_end` (exclusive) so it never hits the hint.
+    private def self.render_preview(screen : Screen, ix : Int32, vx : Int32, y : Int32, y_end : Int32,
+                                    right : Int32, value : String, result : Decoder::ChainResult?) : Nil
+      vw = {right - vx, 1}.max
+      return if y >= y_end
+      screen.text(ix, y, "in", Theme.muted, Theme.panel)
+      screen.text(vx, y, oneline(value, vw), Theme.text, Theme.panel, width: vw)
+      y += 1
+
+      if result.nil?
+        screen.text(ix, y, "(no chain — value is sent unchanged)", Theme.muted, Theme.panel, width: {right - ix, 1}.max) if y < y_end
+        return
+      end
+
+      nx = ix + 2 # step number gutter
+      lx = nx + 3 # converter name
+      name_w = 15
+      ox = lx + name_w + 1 # step output
+      ow = {right - ox, 1}.max
+      result.steps.each_with_index do |step, i|
+        break if y >= y_end
+        num_col, out_col, text = step_row(step)
+        screen.text(nx, y, "#{i + 1}", Theme.muted, Theme.panel)
+        screen.text(lx, y, oneline(step.name, name_w), num_col, Theme.panel, width: name_w)
+        screen.text(ox, y, oneline(text, ow), out_col, Theme.panel, width: ow)
+        y += 1
+      end
+    end
+
+    # {name colour, output colour, output text} for one step's row.
+    private def self.step_row(step : Decoder::StepResult) : {Color, Color, String}
+      case step.state
+      when .ok?
+        bytes = step.output
+        shown = bytes ? Decoder.display(bytes)[0] : ""
+        {Theme.text, Theme.green, shown}
+      when .skipped?
+        {Theme.muted, Theme.muted, "(skipped)"}
+      else # failed / unknown
+        {Theme.red, Theme.red, step.error || "error"}
+      end
+    end
+
+    # Collapse whitespace to single spaces (multi-line values/outputs render on one row)
+    # and let screen.text ellipsize to width — keeps the preview to exactly one line/row.
+    private def self.oneline(s : String, _w : Int32) : String
+      s.gsub(/[\r\n\t]+/, " ")
+    end
+  end
+end

--- a/src/gori/tui/chain_pane.cr
+++ b/src/gori/tui/chain_pane.cr
@@ -1,6 +1,5 @@
 require "./screen"
 require "./theme"
-require "./frame"
 require "./decoder_view" # ChainComplete lives here
 require "../decoder"
 
@@ -61,19 +60,18 @@ module Gori::Tui
       true
     end
 
-    def render(screen : Screen, rect : Rect, focused : Bool, header : String, placeholder : String) : Nil
-      return if rect.w < 2 || rect.h < 2
-      Frame.card(screen, rect, header, bg: Theme.bg, border: Frame.pane_border(focused))
-      inner = rect.inset(1, 1)
-      if @chain.empty? && !focused
-        screen.text(inner.x, inner.y, placeholder, Theme.muted, width: {inner.w, 1}.max)
-      else
-        fg = focused ? Theme.text_bright : Theme.text
-        screen.input_line(inner.x, inner.y, @chain, @caret, @pre, fg, Theme.bg, width: {inner.w, 1}.max)
-      end
-      # Dropdown renders DOWNWARD from the input row into the pane body — the pane is
-      # enlarged while focused, so there's room (mirrors the Decoder tab).
-      @complete.render(screen, inner, rect) if focused && @complete.open?
+    # Just the editable chain line at `field` (the ^Y modal composes its own frame + a
+    # transform preview around it, so it can't use `render`'s card). Caret + IME preedit
+    # ride along; `bg` is the card's fill so the field blends into the modal.
+    def render_input(screen : Screen, field : Rect, focused : Bool, bg : Color = Theme.panel) : Nil
+      fg = focused ? Theme.text_bright : Theme.text
+      screen.input_line(field.x, field.y, @chain, @caret, @pre, fg, bg, width: {field.w, 1}.max)
+    end
+
+    # The converter autocomplete dropdown for the modal — drawn LAST (over the preview) so
+    # an open completion list is never hidden behind it. `bounds` clamps it to the card.
+    def render_dropdown(screen : Screen, field : Rect, bounds : Rect) : Nil
+      @complete.render(screen, field, bounds) if @complete.open?
     end
 
     # --- editing primitives ---------------------------------------------------

--- a/src/gori/tui/chain_peek.cr
+++ b/src/gori/tui/chain_peek.cr
@@ -1,0 +1,66 @@
+require "./screen"
+require "./theme"
+
+module Gori::Tui
+  # A caret-anchored tooltip that reveals the CONCEALED `¦chain` of the §…§ marker under
+  # the cursor — the read-time counterpart to inline concealment (only `§value§` is drawn
+  # in the editor; the transform chain rides here). Modelled on EnvPeek: anchored at the
+  # caret cell, flipping above/below by available room. Adds a `^Y edit` affordance so the
+  # (otherwise hidden) edit path stays discoverable. The owning TextArea decides whether
+  # the caret sits in a chained marker and feeds the chain via `set`; this holds only open
+  # state + drawing.
+  class ChainPeek
+    getter? open : Bool = false
+    @chain = ""
+
+    HINT = "^Y edit"
+
+    # Show the chain of the marker under the caret (opens the peek). An empty chain still
+    # opens — the marker is concealment-eligible, the hint invites attaching a chain.
+    def set(chain : String) : Nil
+      @chain = chain
+      @open = true
+    end
+
+    def close : Nil
+      @open = false
+    end
+
+    # Draw the tooltip anchored at the caret cell (ax, ay), preferring the row below and
+    # flipping above when there's more room, clamped inside `bounds` (the editor content
+    # rect) so it never paints past the pane.
+    def render(screen : Screen, ax : Int32, ay : Int32, bounds : Rect) : Nil
+      return if !@open || bounds.w < 8 || bounds.h < 2
+      below = bounds.bottom - (ay + 1)
+      above = ay - bounds.y
+      return if below <= 0 && above <= 0
+      down = below >= above
+      w = box_width(bounds)
+      x = ax.clamp(bounds.x, {bounds.right - w, bounds.x}.max)
+      y = down ? ay + 1 : ay - 1
+      draw_row(screen, x, y, w)
+    end
+
+    private def shown : String
+      @chain.empty? ? "no chain yet" : @chain
+    end
+
+    # Box width = ▸ + chain + the right-aligned hint, floored so short chains still read.
+    private def box_width(bounds : Rect) : Int32
+      ({Screen.display_width(shown) + HINT.size + 6, 16}.max).clamp(1, bounds.w)
+    end
+
+    # One tooltip row: a fill band, the accent ▸ chain glyph, the chain spec, then the
+    # muted `^Y edit` hint pushed to the right edge (mirrors an EnvComplete/EnvPeek row so
+    # the peek reads as the same surface).
+    private def draw_row(screen : Screen, x : Int32, y : Int32, w : Int32) : Nil
+      bg = Theme.elevated
+      screen.fill(Rect.new(x, y, w, 1), bg)
+      cx = screen.text(x + 1, y, "▸ ", Theme.marker_accent, bg, width: {w - 1, 1}.max)
+      hint_x = x + w - HINT.size - 1
+      chain_room = {hint_x - 1 - cx, 0}.max
+      cx = screen.text(cx, y, shown, @chain.empty? ? Theme.muted : Theme.text_bright, bg, width: chain_room)
+      screen.text(hint_x, y, HINT, Theme.muted, bg) if hint_x > cx
+    end
+  end
+end

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -460,9 +460,12 @@ module Gori::Tui
     # Idempotent so the focus changers above can call it freely.
     def commit_chain_pane : Nil
       return unless @chain_focused
+      # The marker's open § (value region) is unchanged by the chain edit, so it's a stable
+      # anchor — restoring the raw cursor could land inside a now-longer hidden chain.
+      anchor = Fuzz::Template.marker_start_at(@editor.text, @chain_marker_cursor) || @chain_marker_cursor
       if updated = Fuzz::Template.set_chain(@editor.text, @chain_marker_cursor, @chain_pane.value)
         @editor.set_text(updated)
-        @editor.place_at_offset(@chain_marker_cursor) # back into the marker (set_text reset it) → tooltip stays up
+        @editor.place_at_offset(anchor) # back into the marker (set_text reset it) → tooltip stays up
         @dirty = true
       end
       @chain_focused = false

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -12,6 +12,7 @@ require "./text_area"
 require "./fmt"
 require "./spark"
 require "./chain_pane"
+require "./chain_overlay"
 require "../store"
 require "../fuzz"
 require "../decoder"
@@ -74,6 +75,7 @@ module Gori::Tui
       @editor.gutter = true
       @editor.follow_x = true     # long lines (headers, URLs, §-marked params) scroll horizontally to keep the cursor visible
       @editor.env_complete = true # `$KEY` autocomplete against the registered env vars (expanded on send)
+      @editor.chain_peek = true   # tooltip revealing the concealed ¦chain of the §…§ marker under the caret
       @last_synced_config = ""    # last store config blob applied (reconcile equality)
       @config = Fuzz::Config.new(keep_bodies: :matched)
       @sets = [] of SetSpec
@@ -436,8 +438,6 @@ module Gori::Tui
       @focus == :detail
     end
 
-    CHAIN_PLACEHOLDER = "put the cursor in a §…§ marker, then ^Y to add an encode chain (e.g. base64-encode)"
-
     # The CHAIN sub-pane owns keyboard input (focused on the TEMPLATE column). The
     # controller routes template keys here when true.
     def chain_pane_active? : Bool
@@ -462,6 +462,7 @@ module Gori::Tui
       return unless @chain_focused
       if updated = Fuzz::Template.set_chain(@editor.text, @chain_marker_cursor, @chain_pane.value)
         @editor.set_text(updated)
+        @editor.place_at_offset(@chain_marker_cursor) # back into the marker (set_text reset it) → tooltip stays up
         @dirty = true
       end
       @chain_focused = false
@@ -1350,6 +1351,7 @@ module Gori::Tui
       bottom = Rect.new(rest.x, rest.y + top_h, rest.w, {rest.h - top_h, 0}.max)
       render_top(screen, top, focused)
       render_bottom(screen, bottom, focused) if bottom.h > 0
+      render_chain_overlay(screen, rect) if @chain_focused # centered ^Y modal ON TOP (replaces the old split)
     end
 
     private def render_top(screen : Screen, rect : Rect, focused : Bool) : Nil
@@ -1357,53 +1359,16 @@ module Gori::Tui
       left = Rect.new(rect.x, rect.y, half, rect.h)
       right = Rect.new(rect.x + half + 1, rect.y, {rect.w - half - 1, 0}.max, rect.h)
       tmpl_focused = focused && @focus == :template
-      if chain_split_visible? # cursor is in a §…§ marker → split TEMPLATE (top) + CHAIN (bottom)
-        tmpl, chain = template_chain_split(left)
-        render_template(screen, tmpl, tmpl_focused && !@chain_focused)
-        render_chain_pane(screen, chain, tmpl_focused && @chain_focused)
-      else
-        render_template(screen, left, tmpl_focused)
-      end
+      render_template(screen, left, tmpl_focused && !@chain_focused) # dimmed while the ^Y modal owns focus
       render_config(screen, right, focused && @focus == :config)
     end
 
-    # Whether the TEMPLATE column is currently split into TEMPLATE (top) + CHAIN (bottom).
-    # Contextual, mirroring the Repeater (no mode): only while the cursor sits inside a §…§
-    # marker (chain_under_cursor) or the CHAIN pane is being edited — so an unmarked cursor
-    # keeps the full-height editor and the strip appears exactly when the transform matters.
-    private def chain_split_visible? : Bool
-      @chain_focused || !chain_under_cursor.nil?
-    end
-
-    # TEMPLATE (top) + CHAIN (bottom) split — a slim 3-row CHAIN strip that grows (≥8, for
-    # the autocomplete dropdown) while focused; the template editor keeps the rest (≥1).
-    private def template_chain_split(col : Rect) : {Rect, Rect}
-      want = @chain_focused ? {col.h // 2, 8}.max : 3
-      chain_h = want.clamp(1, {col.h - 1, 1}.max)
-      tmpl_h = {col.h - chain_h, 1}.max
-      {Rect.new(col.x, col.y, col.w, tmpl_h),
-       Rect.new(col.x, col.y + tmpl_h, col.w, {col.h - tmpl_h, 0}.max)}
-    end
-
-    # The CHAIN sub-pane. Focused → the live editor (autocomplete); else a read-only view
-    # of the chain of the marker UNDER THE CURSOR (or a hint), so it's always visible.
-    private def render_chain_pane(screen : Screen, rect : Rect, focused : Bool) : Nil
-      return if rect.w < 2 || rect.h < 2
-      if focused
-        @chain_pane.render(screen, rect, true, "CHAIN · #{marker_label}", CHAIN_PLACEHOLDER)
-        return
-      end
-      chain = chain_under_cursor
-      Frame.card(screen, rect, chain ? "CHAIN · #{marker_label}" : "CHAIN", bg: Theme.bg, border: Frame.pane_border(false))
-      inner = rect.inset(1, 1)
-      w = {inner.w, 1}.max
-      if chain.nil?
-        screen.text(inner.x, inner.y, "put the cursor in a §…§ marker · ^Y to edit", Theme.muted, width: w)
-      elsif chain.empty?
-        screen.text(inner.x, inner.y, "^Y to add an encode chain (e.g. base64-encode)", Theme.muted, width: w)
-      else
-        screen.text(inner.x, inner.y, chain, Theme.text, width: w)
-      end
+    # The ^Y chain editor modal over the whole tab, bound to the marker the cursor sat in
+    # when ^Y was pressed. Shows the value, the editable chain, and a live transform
+    # preview. Keys route here via the controller (chain_pane_active?).
+    private def render_chain_overlay(screen : Screen, area : Rect) : Nil
+      value = Fuzz::Template.value_at(@editor.text, @chain_marker_cursor) || ""
+      ChainOverlay.render(screen, area, "CHAIN · #{marker_label}", value, @chain_pane)
     end
 
     private def render_bottom(screen : Screen, rect : Rect, focused : Bool) : Nil
@@ -1499,12 +1464,16 @@ module Gori::Tui
       # it reads as metadata, not payload. Colours resolved fresh each frame (offsets are
       # colour-free); marker_regions is 1:1 with `spans`, so the config chips stay in sync.
       bg = [] of {Int32, Int32, Color}
+      conceal = [] of {Int32, Int32}
       marker_regions.each_with_index do |region, i|
         a, sep, close = region
-        bg << {a, close + 1, Theme.marker_bg(i)}
-        bg << {sep, close + 1, Theme.elevated} if sep < close # dim the ¦chain segment
+        bg << {a, close + 1, Theme.marker_bg(i)} # band spans the whole marker; the conceal-aware paint skips hidden cells
+        conceal << {sep, close} if sep < close   # hide the ¦chain inline (kept in the buffer → tooltip + ^Y overlay)
       end
       @editor.bg_regions = bg
+      @editor.conceal_spans = conceal
+      chain = chain_under_cursor
+      @editor.chain_peek_text = (chain && !chain.empty?) ? chain : nil # tooltip only for a concealed (non-empty) chain
       inner = rect.inset(1, 1)
       read_active = focused && !ins
       @editor.render(screen, inner, cursor: ins, highlight: :request, peek: focused)
@@ -2070,6 +2039,7 @@ module Gori::Tui
       top_h = rest.h if rest.h < 6
       half = {(rest.w - 1) // 2, 1}.max
       left = Rect.new(rest.x, rest.y, half, top_h)
+      commit_chain_pane if @chain_focused # a click outside the ^Y modal commits + dismisses it
       @editor.click_to_cursor(left.inset(1, 1), mx, my)
     end
 

--- a/src/gori/tui/highlight.cr
+++ b/src/gori/tui/highlight.cr
@@ -530,6 +530,37 @@ module Gori::Tui
       end
     end
 
+    # Delete the character ranges `ranges` (line-LOCAL char offsets, each `[a, b)`
+    # within `[0, line-char-count]`, sorted ascending and non-overlapping) from a
+    # styled line, keeping every surviving character's exact styling. The result's
+    # span texts concatenate to the source line with those ranges removed — the
+    # concealment counterpart to the module's 1:1 invariant. Used by TextArea to hide
+    # the `¦chain` segment of a §…§ marker inline while the chain stays in the editable
+    # buffer. Identity when `ranges` is empty (the hot path for every other line).
+    def self.conceal(line : Line, ranges : Array({Int32, Int32})) : Line
+      return line if ranges.empty?
+      out = Line.new
+      off = 0 # char offset of the current span's first char within the whole line
+      line.each do |span|
+        t = span.text
+        len = t.size
+        pos = 0 # local index of the next unemitted char in `t`
+        ranges.each do |(a, b)|
+          la = a - off
+          lb = b - off
+          next if lb <= pos || la >= len # range fully behind the cursor / after this span
+          la = {la, pos}.max
+          lb = {lb, len}.min
+          next if la >= lb
+          out << Span.new(t[pos...la], span.fg, span.attr) if la > pos
+          pos = lb
+        end
+        out << Span.new(t[pos...len], span.fg, span.attr) if pos < len
+        off += len
+      end
+      out
+    end
+
     # Total display width of a styled line (sum of its spans) — used to clamp a
     # horizontal scroll offset against the widest currently-visible row.
     def self.line_width(line : Line) : Int32

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -23,6 +23,7 @@ require "../repeater/subtab_filter"
 require "../fuzz"
 require "../decoder"
 require "./chain_pane"
+require "./chain_overlay"
 require "./input_mode"
 require "./read_cursor"
 require "./text_read_state"
@@ -64,6 +65,7 @@ module Gori::Tui
       @editor.gutter = true       # line numbers in the request body (pairs with ^G)
       @editor.follow_x = true     # long lines (headers, URLs, base64 params) scroll horizontally to keep the cursor visible
       @editor.env_complete = true # `$KEY` autocomplete against the registered env vars (expanded on send)
+      @editor.chain_peek = true   # tooltip revealing the concealed ¦chain of the §…§ marker under the caret
       @search_hl = ""             # active ^F query → highlight in the response pane (request is via @editor)
       @reveal = false             # 'w' shows whitespace/CR/LF as glyphs (response from raw bytes, request via @editor)
       @reveal_lines = nil.as(Array(String)?)
@@ -135,7 +137,7 @@ module Gori::Tui
       # Content-Length resynced; otherwise the envelope is sent as captured. Sent as a
       # NORMAL request (ordinary response pane). Session-only (db_id nil) like WS/gRPC.
       @decode_kind = nil.as(Symbol?) # nil | :saml | :graphql
-      @decoded = TextArea.new         # the payload editor (lower split)
+      @decoded = TextArea.new        # the payload editor (lower split)
       @decoded.gutter = true
       @decoded.follow_x = true     # long decoded payload lines (SAML XML, GraphQL query) scroll horizontally
       @decoded.env_complete = true # env tokens re-encode into the request on send here too (WS messages, decoded payload)
@@ -269,7 +271,7 @@ module Gori::Tui
     def pane_insert?(pane : Symbol) : Bool
       case pane
       when :request then request_insert? || request_hex? || chain_pane_active?
-      when :target   then target_insert? || editing_sni?
+      when :target  then target_insert? || editing_sni?
       else               false
       end
     end
@@ -1169,9 +1171,9 @@ module Gori::Tui
     end
 
     def request_bytes : Bytes
-      return grpc_request_bytes if @grpc_mode                 # edited head + reframed body (owns its own hex buffer)
-      return @req_hex_edit.not_nil!.to_bytes if @req_hex_edit # byte-exact; NO auto-CL in hex mode
-      return decoded_request_bytes if @decode_kind            # envelope + re-encoded decoded payload
+      return grpc_request_bytes if @grpc_mode                  # edited head + reframed body (owns its own hex buffer)
+      return @req_hex_edit.not_nil!.to_bytes if @req_hex_edit  # byte-exact; NO auto-CL in hex mode
+      return decoded_request_bytes if @decode_kind             # envelope + re-encoded decoded payload
       return marked_request_bytes unless marker_regions.empty? # §…§ inline Decoder chains applied on send
       raw = expanded_editor_bytes
       @auto_content_length ? sync_content_length(raw) : raw
@@ -1280,22 +1282,10 @@ module Gori::Tui
       end
     end
 
-    CHAIN_PLACEHOLDER = "put the cursor in a §…§ marker, then ^Y to add an encode chain (e.g. base64-encode)"
-
     # Whether the CHAIN sub-pane currently owns keyboard input (focused + actually on the
     # request column). The controller routes body keys here when true.
     def chain_pane_active? : Bool
       @chain_focused && @focus == :request && !request_hex?
-    end
-
-    # Whether the request column is currently split into REQUEST (top) + CHAIN (bottom).
-    # Contextual (no mode): only while the cursor sits inside a §…§ marker (chain_under_cursor)
-    # or the CHAIN pane is being edited. Never in the hex/gRPC/decode/WS request modes, which
-    # own the request column with their own splits. render/hit-test/click all read this so the
-    # visible layout, the badge geometry, and the click targets stay in agreement.
-    private def chain_split_visible? : Bool
-      return false if @req_hex_edit || @grpc_mode || @decode_kind || @ws_mode
-      @chain_focused || !chain_under_cursor.nil?
     end
 
     # ^Y: drop focus into the CHAIN pane for the marker under the request cursor. Returns
@@ -1317,6 +1307,7 @@ module Gori::Tui
       return unless @chain_focused
       if updated = Fuzz::Template.set_chain(@editor.text, @chain_marker_cursor, @chain_pane.value)
         @editor.set_text(updated)
+        @editor.place_at_offset(@chain_marker_cursor) # back into the marker (set_text reset it) → tooltip stays up
         @dirty = true
       end
       @chain_focused = false
@@ -1541,13 +1532,7 @@ module Gori::Tui
 
       # REQUEST badges: ^R:SEND is always rightmost (primary action). Then CL/PRETTY (or
       # HEX) when drawn. Decode / CHAIN splits keep chrome on the top card.
-      req_card = if @decode_kind || @ws_mode
-                   decode_split(left)[0]
-                 elsif chain_split_visible?
-                   req_chain_split(left)[0]
-                 else
-                   left
-                 end
+      req_card = (@decode_kind || @ws_mode) ? decode_split(left)[0] : left
       if req_card.w >= 2 && my == req_card.y
         label = render_request_label
         min_x = req_card.x + label.size + 4
@@ -1595,16 +1580,7 @@ module Gori::Tui
         end
         return
       end
-      if chain_split_visible? # split: click the CHAIN strip to edit it, else place the request caret
-        req, chain = req_chain_split(col)
-        if my >= chain.y
-          focus_chain_pane # binds to the marker at the current request cursor (hint ignored on a click)
-        else
-          commit_chain_pane if @chain_focused
-          @editor.click_to_cursor(req.inset(1, 1), mx, my)
-        end
-        return
-      end
+      commit_chain_pane if @chain_focused # a click outside the ^Y modal commits + dismisses it, then places the caret
       inner = col.inset(1, 1)
       if h = @req_hex_edit
         h.click_to_nibble(inner, mx, my, @scroll_req) # hex mode: place the nibble cursor
@@ -1669,7 +1645,7 @@ module Gori::Tui
         # instead of ejecting the pane whenever the response fits on screen (@scroll stays 0).
         # The non-navigable hex dump has no caret, so keep scroll-based ejection there.
       when :response then resp_navigable? ? (@resp_cursor.cy == 0 && @scroll == 0) : @scroll == 0
-      else               false
+      else                false
       end
     end
 
@@ -2093,7 +2069,7 @@ module Gori::Tui
       when :request  then !pane_insert?(:request) && @req_read.selection?
       when :response then @resp_cursor.selection?
       when :target   then !pane_insert?(:target) && @target_read.selection?
-      else               false
+      else                false
       end
     end
 
@@ -2213,48 +2189,19 @@ module Gori::Tui
         env, dec = decode_split(left)
         render_request(screen, env, req_focused && @req_pane == :envelope)
         render_decoded(screen, dec, req_focused && @req_pane == :decoded)
-      elsif chain_split_visible? # cursor is in a §…§ marker → split REQUEST (top) + CHAIN (bottom)
-        req, chain = req_chain_split(left)
-        render_request(screen, req, req_focused && !@chain_focused)
-        render_chain_pane(screen, chain, req_focused && @chain_focused)
       else
-        render_request(screen, left, req_focused)
+        render_request(screen, left, req_focused && !@chain_focused) # dimmed while the ^Y modal owns focus
       end
       render_response(screen, right, focused && @focus == :response)
+      render_chain_overlay(screen, rect) if @chain_focused # centered modal ON TOP (replaces the old split)
     end
 
-    # REQUEST (top) + CHAIN (bottom) split. The CHAIN strip is a slim 3
-    # rows normally and grows (≥8, for the autocomplete dropdown) while it's focused; the
-    # request editor keeps the rest (≥1 row).
-    private def req_chain_split(col : Rect) : {Rect, Rect}
-      want = @chain_focused ? {col.h // 2, 8}.max : 3
-      chain_h = want.clamp(1, {col.h - 1, 1}.max)
-      req_h = {col.h - chain_h, 1}.max
-      {Rect.new(col.x, col.y, col.w, req_h),
-       Rect.new(col.x, col.y + req_h, col.w, {col.h - req_h, 0}.max)}
-    end
-
-    # The CHAIN sub-pane. Focused → the live ChainPane editor (with autocomplete). Not
-    # focused → a read-only view of the chain of the marker UNDER THE CURSOR (updates as
-    # you move), or a hint when the cursor isn't in a marker — so the transform is always
-    # visible without entering the pane.
-    private def render_chain_pane(screen : Screen, rect : Rect, focused : Bool) : Nil
-      return if rect.w < 2 || rect.h < 2
-      if focused
-        @chain_pane.render(screen, rect, true, "CHAIN · #{marker_label}", CHAIN_PLACEHOLDER)
-        return
-      end
-      chain = chain_under_cursor
-      Frame.card(screen, rect, chain ? "CHAIN · #{marker_label}" : "CHAIN", bg: Theme.bg, border: pane_border(false))
-      inner = rect.inset(1, 1)
-      w = {inner.w, 1}.max
-      if chain.nil?
-        screen.text(inner.x, inner.y, "put the cursor in a §…§ marker · ^Y to edit", Theme.muted, width: w)
-      elsif chain.empty?
-        screen.text(inner.x, inner.y, "^Y to add an encode chain (e.g. base64-encode)", Theme.muted, width: w)
-      else
-        screen.text(inner.x, inner.y, chain, Theme.text, width: w)
-      end
+    # The ^Y chain editor: a centered modal over the whole tab, bound to the marker the
+    # cursor sat in when ^Y was pressed. Shows the marker's value, the editable chain, and
+    # a live transform preview. Keys route here via the controller (chain_pane_active?).
+    private def render_chain_overlay(screen : Screen, area : Rect) : Nil
+      value = Fuzz::Template.value_at(@editor.text, @chain_marker_cursor) || ""
+      ChainOverlay.render(screen, area, "CHAIN · #{marker_label}", value, @chain_pane)
     end
 
     # "§N" label for the marker under the cursor (1-based), or "§" when not in one.
@@ -2412,11 +2359,15 @@ module Gori::Tui
           @scroll_req = h.render(screen, rect.inset(1, 1), focused, @scroll_req)
         else
           Frame.toggle_badge(screen, send_edge, rect.y, min_x, "^X", "MSG", false) if @grpc_reframable
+          @editor.conceal_spans = [] of {Int32, Int32} # gRPC frames aren't §-marker HTTP text — no stale concealment
+          @editor.chain_peek_text = nil
           @editor.render(screen, rect.inset(1, 1), cursor: focused && request_insert?, highlight: :request, peek: focused)
         end
         return
       end
       if @ws_mode
+        @editor.conceal_spans = [] of {Int32, Int32} # WS messages aren't §-marker HTTP text — no stale concealment
+        @editor.chain_peek_text = nil
         @editor.render(screen, rect.inset(1, 1), cursor: focused && request_insert?, highlight: :request, peek: focused)
         return
       end
@@ -2479,12 +2430,16 @@ module Gori::Tui
     # a marker-free request yields no regions, so this is a no-op paint then.
     private def update_request_marker_tint : Nil
       bg = [] of {Int32, Int32, Color}
+      conceal = [] of {Int32, Int32}
       marker_regions.each_with_index do |region, i|
         a, sep, close = region
-        bg << {a, close + 1, Theme.marker_bg(i)}
-        bg << {sep, close + 1, Theme.elevated} if sep < close # dim the ¦chain segment
+        bg << {a, close + 1, Theme.marker_bg(i)} # band spans the whole marker; the conceal-aware paint skips hidden cells
+        conceal << {sep, close} if sep < close   # hide the ¦chain inline (kept in the buffer → tooltip + ^Y overlay)
       end
       @editor.bg_regions = bg
+      @editor.conceal_spans = conceal
+      chain = chain_under_cursor
+      @editor.chain_peek_text = (chain && !chain.empty?) ? chain : nil # tooltip only for a concealed (non-empty) chain
     end
 
     # {open, sep, close} marker regions cached on the editor revision — update_request_marker_tint

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -1305,9 +1305,12 @@ module Gori::Tui
     # Idempotent — a no-op when the pane isn't focused (so set_focus can call it freely).
     def commit_chain_pane : Nil
       return unless @chain_focused
+      # The marker's open § (value region) is unchanged by the chain edit, so it's a stable
+      # anchor — restoring the raw cursor could land inside a now-longer hidden chain.
+      anchor = Fuzz::Template.marker_start_at(@editor.text, @chain_marker_cursor) || @chain_marker_cursor
       if updated = Fuzz::Template.set_chain(@editor.text, @chain_marker_cursor, @chain_pane.value)
         @editor.set_text(updated)
-        @editor.place_at_offset(@chain_marker_cursor) # back into the marker (set_text reset it) → tooltip stays up
+        @editor.place_at_offset(anchor) # back into the marker (set_text reset it) → tooltip stays up
         @dirty = true
       end
       @chain_focused = false

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -98,6 +98,9 @@ module Gori::Tui
       @styled = nil
       @edits += 1
       @undo_stack.clear
+      # Drop stale conceal offsets — they index the OLD buffer; the owner re-feeds fresh
+      # ones next render. Guards any move/place between now and that render.
+      @conceal_spans = [] of {Int32, Int32} unless @conceal_spans.empty?
       env_complete_close
     end
 
@@ -275,6 +278,7 @@ module Gori::Tui
       # On a concealed line the click column is in concealed space; map it back through
       # the hidden runs so a click never lands the caret on an unseen ¦chain char.
       @cx = (cr && !cr.empty?) ? concealed_col_to_raw(line, cr, target) : Screen.column_for(line, target)
+      snap_cx_out_of_conceal(0) # a click on the closing-§ column resolves to it; nudge to a legal rest
       env_complete_close
     end
 
@@ -660,19 +664,24 @@ module Gori::Tui
       n
     end
 
-    # After a horizontal cursor move, pull @cx off any hidden char so the caret never
-    # rests inside a concealed run (where it would be invisible / edit unseen bytes).
-    # `dir` is the travel sign: land on the run's far edge in the direction of motion.
+    # Pull @cx out of the "no-rest zone" `(a, b]` of a concealed run so the caret can't
+    # land where an edit would touch UNSEEN bytes: the interior chars AND the boundary
+    # `@cx == b` (just before the visible closing glyph, where backspace would delete the
+    # last hidden char and typing would insert into the hidden run). Only `a` (the run's
+    # left edge, on visible bytes) and `b + 1` (past the closing glyph) are legal rests —
+    # and they sit at the same column / the next column, so crossing the whole run is one
+    # keypress in each direction (no dead press). `dir` is the travel sign.
     private def snap_cx_out_of_conceal(dir : Int32) : Nil
       return if @conceal_spans.empty?
       line_conceal(line_start_offset(@cy), @lines[@cy].size).each do |(a, b)|
-        next unless @cx > a && @cx < b
+        next unless @cx > a && @cx <= b
+        right = {b + 1, @lines[@cy].size}.min
         @cx = if dir > 0
-                b
+                right
               elsif dir < 0
                 a
               else
-                (@cx - a <= b - @cx) ? a : b # vertical move: snap to the nearer edge
+                (@cx - a <= right - @cx) ? a : right # vertical move / click: nearer legal edge
               end
         return
       end

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -8,6 +8,7 @@ require "./search_hi"
 require "./reveal"
 require "./env_complete"
 require "./env_peek"
+require "./chain_peek"
 
 module Gori::Tui
   # A minimal multi-line text editor for inline editing (e.g. the Repeater
@@ -37,10 +38,10 @@ module Gori::Tui
       @styled_kind = nil.as(Symbol?)
       @styled_rev = Theme.revision
       @styled_env_rev = Env.highlight_rev
-      @gutter = false # left line-number gutter (on for the Repeater request body)
-      @search_hl = "" # active ^F query → matches highlighted in render
-      @reveal = false # show whitespace (space ·, tab →) instead of syntax colours
-      @edits = 0      # monotonic content-change counter — cheap cache key for owners
+      @gutter = false          # left line-number gutter (on for the Repeater request body)
+      @search_hl = ""          # active ^F query → matches highlighted in render
+      @reveal = false          # show whitespace (space ·, tab →) instead of syntax colours
+      @edits = 0               # monotonic content-change counter — cheap cache key for owners
       @lc_lines = [] of String # downcased lines for ^F search, memoized on @edits
       @lc_lines_rev = -1
       # Opt-in background tints: [start, end) FULL-buffer char offsets + colour, painted
@@ -48,6 +49,13 @@ module Gori::Tui
       # except the Fuzzer template — Repeater/Notes never set it, so they're unaffected. The
       # widget knows nothing about §-markers; the owner supplies offsets + resolved colours.
       @bg_regions = [] of {Int32, Int32, Color}
+      # Opt-in DISPLAY concealment: [start, end) FULL-buffer char offsets hidden from the
+      # rendered line while kept verbatim in the buffer (so `to_bytes`/send are unchanged).
+      # Empty for every editor except the Repeater/Fuzzer request editors, which hide the
+      # `¦chain` segment of a §…§ marker (only `§value§` shows; the chain rides a tooltip +
+      # the ^Y overlay). All column math (caret, click, h-scroll, marker band) is remapped
+      # to the concealed line; when empty the widget is byte-for-byte unchanged.
+      @conceal_spans = [] of {Int32, Int32}
       @undo_stack = [] of UndoState
       # Opt-in `$ENV` autocomplete popup (nil = disabled). Enabled only on the outbound
       # request editors (Repeater request, Fuzzer template) where env tokens are expanded on
@@ -57,6 +65,11 @@ module Gori::Tui
       # request editors get it. Shows the resolved value of a COMPLETE `$KEY` token under
       # the caret (NORMAL or INSERT) once the autocomplete dropdown isn't offering matches.
       @env_peek = nil.as(EnvPeek?)
+      # Opt-in chain tooltip (nil = disabled). Paired with @conceal_spans on the request
+      # editors: reveals the hidden ¦chain of the §…§ marker under the caret. @chain_peek_text
+      # is fed by the owner each frame (nil = caret not in a chained marker → no tooltip).
+      @chain_peek = nil.as(ChainPeek?)
+      @chain_peek_text = nil.as(String?)
       set_text(text)
     end
 
@@ -64,6 +77,7 @@ module Gori::Tui
     setter search_hl : String
     setter reveal : Bool
     setter bg_regions : Array({Int32, Int32, Color})
+    setter conceal_spans : Array({Int32, Int32})
     # Enable horizontal cursor-following (the Project description); off everywhere
     # else, so those editors keep @xscroll == 0 and their hot render path unchanged.
     setter follow_x : Bool
@@ -201,23 +215,25 @@ module Gori::Tui
         @cy = (@cy + dr).clamp(0, @lines.size - 1)
         @cx = @cx.clamp(0, @lines[@cy].size)
       end
-      return if dc == 0
-      @cx += dc
-      if @cx < 0
-        if @cy > 0
-          @cy -= 1
-          @cx = @lines[@cy].size
-        else
-          @cx = 0
-        end
-      elsif @cx > @lines[@cy].size
-        if @cy < @lines.size - 1
-          @cy += 1
-          @cx = 0
-        else
-          @cx = @lines[@cy].size
+      if dc != 0
+        @cx += dc
+        if @cx < 0
+          if @cy > 0
+            @cy -= 1
+            @cx = @lines[@cy].size
+          else
+            @cx = 0
+          end
+        elsif @cx > @lines[@cy].size
+          if @cy < @lines.size - 1
+            @cy += 1
+            @cx = 0
+          else
+            @cx = @lines[@cy].size
+          end
         end
       end
+      snap_cx_out_of_conceal(dc) unless @conceal_spans.empty? # never rest on a hidden ¦chain char
       refresh_env_complete
     end
 
@@ -253,7 +269,12 @@ module Gori::Tui
       gw = @gutter ? {Gutter.width(@lines.size), rect.w}.min : 0
       # + @xscroll: the click lands at display column (mx - content_x) WITHIN the
       # visible window, which is @xscroll columns into the full line.
-      @cx = Screen.column_for(@lines[@cy], mx - (rect.x + gw) + @xscroll)
+      target = mx - (rect.x + gw) + @xscroll
+      line = @lines[@cy]
+      cr = @conceal_spans.empty? ? nil : line_conceal(line_start_offset(@cy), line.size)
+      # On a concealed line the click column is in concealed space; map it back through
+      # the hidden runs so a click never lands the caret on an unseen ¦chain char.
+      @cx = (cr && !cr.empty?) ? concealed_col_to_raw(line, cr, target) : Screen.column_for(line, target)
       env_complete_close
     end
 
@@ -316,6 +337,21 @@ module Gori::Tui
       off + @cx.clamp(0, @lines[@cy].size)
     end
 
+    # Inverse of cursor_offset: place the caret at a flat char offset into the LF-joined
+    # buffer. Used to restore the caret to a §…§ marker after a set_text that rebuilt the
+    # buffer (e.g. committing the ^Y chain edit) so the marker tooltip keeps showing.
+    def place_at_offset(offset : Int32) : Nil
+      off = {offset, 0}.max
+      cy = 0
+      while cy < @lines.size - 1 && off > @lines[cy].size
+        off -= @lines[cy].size + 1
+        cy += 1
+      end
+      @cy = cy
+      @cx = off.clamp(0, @lines[cy].size)
+      env_complete_close
+    end
+
     # ^F search: 0-based indices of lines containing `query` (case-insensitive). The
     # downcased lines are cached on @edits, so each keystroke of an incremental search (and
     # the re-scans on drain/poll while the prompt is open) reuses them instead of allocating a
@@ -355,14 +391,20 @@ module Gori::Tui
       # opt-in bg_regions consumer (the Fuzzer template) pays the O(@scroll) prefix sum;
       # Repeater/Notes (no regions) skip it so their hot path is unchanged.
       line_off = 0
-      (0...@scroll).each { |k| line_off += @lines[k].size + 1 } unless @bg_regions.empty? # +1 for '\n'
-      caret_cell = nil.as({Int32, Int32}?) # the drawn caret's screen cell — anchors the env-complete popup
+      (0...@scroll).each { |k| line_off += @lines[k].size + 1 } unless @bg_regions.empty? && @conceal_spans.empty? # +1 for '\n'
+      caret_cell = nil.as({Int32, Int32}?)                                                                         # the drawn caret's screen cell — anchors the env-complete popup
       (0...rect.h).each do |i|
         li = @scroll + i
         break if li >= @lines.size
         Gutter.draw(screen, rect.x, rect.y + i, li, gw, current: li == @cy) if @gutter
         line = @lines[li]
-        if @xscroll > 0
+        # Concealed lines (a §…§ marker with a hidden ¦chain) go through a dedicated draw:
+        # delete the concealed chars from the styled line, then h-scroll-slice + draw. The
+        # IME-preedit caret line is left raw (its columns shift with the composing text).
+        cr = (@conceal_spans.empty? || (li == @cy && !@preedit.empty?)) ? nil : line_conceal(line_off, line.size)
+        if cr && !cr.empty? && !@reveal
+          draw_concealed_line(screen, cx0, rect.y + i, li, line, styled, cr, cw)
+        elsif @xscroll > 0
           draw_scrolled(screen, cx0, rect.y + i, li, line, styled, cw)
         elsif @reveal
           Highlight.draw(screen, cx0, rect.y + i, Reveal.styled(line, false, cw), width: cw)
@@ -391,7 +433,7 @@ module Gori::Tui
         # Marker tint UNDER search/cursor — skip the IME-preedit line (its columns are
         # shifted by the composing text, which isn't in `line`). paint_bg_regions itself
         # no-ops when there are no regions or in reveal mode.
-        paint_bg_regions(screen, cx0, rect.y + i, line_off, line, cw) unless li == @cy && !@preedit.empty?
+        paint_bg_regions(screen, cx0, rect.y + i, line_off, line, cw, cr) unless li == @cy && !@preedit.empty?
         line_off += line.size + 1 # advance BEFORE the cursor `next` so it can't desync
         unless @search_hl.empty?
           # Mark on the visible (left-sliced) text so the highlight columns line up
@@ -406,15 +448,20 @@ module Gori::Tui
         # column_width (not display_width): a raw control char in the prefix occupies a
         # cell and click-to-cursor counts it, so the caret must too — else it sits one
         # column left of the real position and paints over a glyph.
-        prefix_w = Screen.column_width(line[0, @cx])
+        prefix_w = (cr && !cr.empty?) ? concealed_col(line, cr, @cx) : Screen.column_width(line[0, @cx])
         preedit_w = Screen.display_width(@preedit)
         cxs = cx0 + prefix_w + preedit_w - @xscroll
         if cxs >= cx0 && cxs < cx0 + cw
           caret_cell = {cxs, rect.y + i}
           if cursor
             screen.cursor(cxs, rect.y + i)
-            cgw = [Screen.display_width((@preedit.empty? ? (@cx < line.size ? line[@cx] : ' ') : @preedit[0]).to_s), 1].max
-            ch = @preedit.empty? ? (@cx < line.size ? line[@cx] : ' ') : @preedit[0]
+            # The cell under the block caret is the first VISIBLE glyph at/after @cx: on a
+            # concealed line the raw char there may be a hidden `¦chain` byte, so skip past
+            # any concealed run to the glyph the user actually sees (the closing §).
+            r = @cx
+            cr.each { |(a, b)| r = b if r >= a && r < b } if cr && !cr.empty?
+            ch = @preedit.empty? ? (r < line.size ? line[r] : ' ') : @preedit[0]
+            cgw = [Screen.display_width(ch.to_s), 1].max
             (0...cgw).each do |off|
               break if cxs + off >= cx0 + cw # a wide-glyph caret at the last column must not spill its 2nd cell onto the pane border
               cch = (off == 0 ? ch : ' ')
@@ -439,6 +486,8 @@ module Gori::Tui
       if cursor && (cc = caret_cell) && ec
         ec.render(screen, cc[0], cc[1], rect)
       end
+      # Chain tooltip takes precedence over the env peek (a §…§ marker is never also a $KEY).
+      return if render_chain_peek(screen, caret_cell, rect, cursor, peek, ec)
       ep = @env_peek
       return unless ep
       # Suppress the peek only while the autocomplete dropdown is ACTUALLY on screen (insert
@@ -453,6 +502,25 @@ module Gori::Tui
       end
     end
 
+    # The chain tooltip pass: when the caret sits in a chained §…§ marker (owner-fed via
+    # @chain_peek_text) and the editor is focused, reveal the concealed chain at the caret
+    # and suppress the env peek. Returns true when it took over (the caller then skips the
+    # env peek). No-op (false) when the tooltip is disabled or the caret isn't in a marker.
+    private def render_chain_peek(screen : Screen, caret_cell : {Int32, Int32}?, rect : Rect,
+                                  cursor : Bool, peek : Bool, ec : EnvComplete?) : Bool
+      cp = @chain_peek
+      return false unless cp
+      chain = @chain_peek_text
+      if chain && (cursor || peek) && (cc = caret_cell) && !(cursor && ec && ec.open?)
+        cp.set(chain)
+        cp.render(screen, cc[0], cc[1], rect)
+        @env_peek.try(&.close)
+        return true
+      end
+      cp.close
+      false
+    end
+
     # Overlay the bg_regions intersecting THIS line. `off0` is the line's start offset
     # in the full LF-joined buffer. Column math mirrors SearchHi.mark (same
     # Screen.display_width as the base draw, so an ambiguous-width glyph can't drift the
@@ -462,8 +530,9 @@ module Gori::Tui
     # @xscroll and clipped to the visible window — a no-op when @xscroll == 0 (the common
     # case, since only the Fuzzer template sets bg_regions and it doesn't enable follow_x).
     private def paint_bg_regions(screen : Screen, cx0 : Int32, y : Int32, off0 : Int32,
-                                 line : String, cw : Int32) : Nil
+                                 line : String, cw : Int32, cr : Array({Int32, Int32})? = nil) : Nil
       return if @bg_regions.empty? || @reveal # opt-in; reveal rewrites the glyphs
+      return paint_bg_regions_concealed(screen, cx0, y, off0, line, cw, cr) if cr && !cr.empty?
       line_end = off0 + line.size
       @bg_regions.each do |(a, b, color)|
         next if b <= off0 || a >= line_end # region doesn't touch this line
@@ -477,6 +546,135 @@ module Gori::Tui
         next if draw_from >= draw_to
         seg = slice_left(line[la, lb - la], draw_from - start_col)
         screen.text(cx0 + draw_from, y, seg, Theme.marker_fg, color, width: draw_to - draw_from)
+      end
+    end
+
+    # Band over-paint for a line whose §…§ markers hide a ¦chain: re-draw only the VISIBLE
+    # marker glyphs (concealed chars occupy no cell) at their concealed display columns,
+    # matching what the base Highlight.draw already put on screen. The glyph right after
+    # each concealed run — the closing § — is accented so a chained marker reads distinctly
+    # from a plain one; the rest keep Theme.marker_fg.
+    private def paint_bg_regions_concealed(screen : Screen, cx0 : Int32, y : Int32, off0 : Int32,
+                                           line : String, cw : Int32, cr : Array({Int32, Int32})) : Nil
+      line_end = off0 + line.size
+      @bg_regions.each do |(a, b, color)|
+        next if b <= off0 || a >= line_end
+        la = (a - off0).clamp(0, line.size)
+        lb = (b - off0).clamp(0, line.size)
+        next if la >= lb
+        col = concealed_display_prefix(line, cr, la) # display columns before the first drawn char
+        i = la
+        while i < lb
+          hit = cr.find { |(ra, rb)| i >= ra && i < rb }
+          if hit
+            i = hit[1] # skip the hidden run in one hop
+            next
+          end
+          w = Screen.display_width(line[i].to_s)
+          sx = cx0 + col - @xscroll
+          if sx >= cx0 && sx < cx0 + cw
+            accent = cr.any? { |(_, rb)| rb == i } # char immediately after a concealed run = closing §
+            screen.text(sx, y, line[i].to_s, accent ? Theme.marker_accent : Theme.marker_fg, color, width: {cx0 + cw - sx, 1}.max)
+          end
+          col += w
+          i += 1
+        end
+      end
+    end
+
+    # --- display concealment (opt-in @conceal_spans) -------------------------
+    # Everything below no-ops (or isn't reached) when @conceal_spans is empty, so every
+    # editor but the Repeater/Fuzzer request editors keeps its exact column math.
+
+    # Line-LOCAL conceal ranges for the line spanning full-buffer offsets [off0, off0+size),
+    # sorted, clamped to [0, size). Empty when no span touches this line.
+    private def line_conceal(off0 : Int32, size : Int32) : Array({Int32, Int32})
+      out = [] of {Int32, Int32}
+      line_end = off0 + size
+      @conceal_spans.each do |(a, b)|
+        next if b <= off0 || a >= line_end
+        la = (a - off0).clamp(0, size)
+        lb = (b - off0).clamp(0, size)
+        out << {la, lb} if la < lb
+      end
+      out.sort_by!(&.[0]) if out.size > 1
+      out
+    end
+
+    # Full-buffer char offset of line `cy`'s first char (only walked when concealing).
+    private def line_start_offset(cy : Int32) : Int32
+      off = 0
+      (0...cy).each { |i| off += @lines[i].size + 1 } # +1 for the joining '\n'
+      off
+    end
+
+    # Display column (column_width semantics, matching the caret) of raw caret index `cx`
+    # on a concealed line: the width of the surviving chars in [0, cx). A cx inside a
+    # concealed run collapses to that run's start column (both edges share the cell).
+    private def concealed_col(line : String, ranges : Array({Int32, Int32}), cx : Int32) : Int32
+      cx = cx.clamp(0, line.size)
+      w = 0
+      pos = 0
+      ranges.each do |(a, b)|
+        break if a >= cx
+        w += Screen.column_width(line[pos...a]) if a > pos
+        return w if b >= cx # cx lands inside/at this run → column at the run's start
+        pos = b
+      end
+      w + Screen.column_width(line[pos...cx])
+    end
+
+    # As `concealed_col` but in display_width columns (no ≥1 floor) — used by the band
+    # over-paint so its glyph columns line up with Highlight.draw's advance.
+    private def concealed_display_prefix(line : String, ranges : Array({Int32, Int32}), cx : Int32) : Int32
+      w = 0
+      pos = 0
+      ranges.each do |(a, b)|
+        break if a >= cx
+        w += Screen.display_width(line[pos...a]) if a > pos
+        return w if b >= cx
+        pos = b
+      end
+      w + Screen.display_width(line[pos...cx])
+    end
+
+    # Inverse of `concealed_col` for click-to-cursor: the raw char index whose concealed
+    # display cell holds column `target`. Never returns an index inside a concealed run
+    # (those cells aren't drawn), so a click can't land the caret on a hidden char.
+    private def concealed_col_to_raw(line : String, ranges : Array({Int32, Int32}), target : Int32) : Int32
+      return 0 if target <= 0
+      col = 0
+      i = 0
+      n = line.size
+      while i < n
+        hit = ranges.find { |(a, b)| i >= a && i < b }
+        if hit
+          i = hit[1]
+          next
+        end
+        w = {Screen.display_width(line[i].to_s), 1}.max
+        return i if target < col + w
+        col += w
+        i += 1
+      end
+      n
+    end
+
+    # After a horizontal cursor move, pull @cx off any hidden char so the caret never
+    # rests inside a concealed run (where it would be invisible / edit unseen bytes).
+    # `dir` is the travel sign: land on the run's far edge in the direction of motion.
+    private def snap_cx_out_of_conceal(dir : Int32) : Nil
+      return if @conceal_spans.empty?
+      line_conceal(line_start_offset(@cy), @lines[@cy].size).each do |(a, b)|
+        next unless @cx > a && @cx < b
+        @cx = if dir > 0
+                b
+              elsif dir < 0
+                a
+              else
+                (@cx - a <= b - @cx) ? a : b # vertical move: snap to the nearer edge
+              end
+        return
       end
     end
 
@@ -508,18 +706,36 @@ module Gori::Tui
       return if cw <= 0
       line = @lines[@cy]
       pw = Screen.display_width(@preedit)
-      # column_width (not display_width) to match the actual draw at line 363: a raw
-      # control char occupies one drawn cell, so measuring it as width 0 here would let
-      # the caret render outside the window (cursor detaches / no scroll-into-view).
-      if Screen.column_width(line) + pw <= cw
+      # On a concealed line, measure in CONCEALED columns — the hidden ¦chain doesn't take
+      # cells, so the caret window must be sized/positioned against what's actually drawn.
+      cr = @conceal_spans.empty? ? nil : line_conceal(line_start_offset(@cy), line.size)
+      concealed = cr && !cr.empty?
+      # column_width (not display_width) to match the actual draw: a raw control char
+      # occupies one drawn cell, so measuring it as width 0 here would let the caret render
+      # outside the window (cursor detaches / no scroll-into-view).
+      full = concealed ? concealed_col(line, cr.not_nil!, line.size) : Screen.column_width(line)
+      if full + pw <= cw
         @xscroll = 0
         return
       end
       cx = @cx.clamp(0, line.size)
-      curx = Screen.column_width(line[0, cx]) + pw      # caret's column in the full line
+      curx = (concealed ? concealed_col(line, cr.not_nil!, cx) : Screen.column_width(line[0, cx])) + pw
       @xscroll = curx if curx < @xscroll                # caret left of the window → snap left
       @xscroll = curx - cw + 1 if curx >= @xscroll + cw # caret past the right edge → snap right
       @xscroll = 0 if @xscroll < 0
+    end
+
+    # Draw a line whose §…§ markers hide a ¦chain: delete the concealed chars from the
+    # styled line (a single plain span when highlighting is off), then h-scroll-slice and
+    # draw. The marker band + accented closing § are over-painted afterwards by
+    # paint_bg_regions (concealment-aware). Only reached when the line has conceal ranges.
+    private def draw_concealed_line(screen : Screen, cx0 : Int32, y : Int32, li : Int32,
+                                    line : String, styled : Array(Highlight::Line)?,
+                                    cr : Array({Int32, Int32}), cw : Int32) : Nil
+      base = (styled && styled[li]?) || [Highlight::Span.new(line, Theme.text)]
+      cl = Highlight.conceal(base, cr)
+      cl = Highlight.slice_left(cl, @xscroll) if @xscroll > 0
+      Highlight.draw(screen, cx0, y, cl, width: cw)
     end
 
     # The horizontally-scrolled per-line draw (only when @xscroll > 0): left-slice
@@ -559,7 +775,7 @@ module Gori::Tui
     def undo : Nil
       return if @undo_stack.empty?
       state = @undo_stack.pop
-      @lines = state.lines           # the snapshot is popped/unreferenced, so no defensive dup
+      @lines = state.lines # the snapshot is popped/unreferenced, so no defensive dup
       @lines = [""] if @lines.empty?
       @cy = state.cy.clamp(0, @lines.size - 1)
       @cx = state.cx.clamp(0, @lines[@cy].size)
@@ -575,6 +791,17 @@ module Gori::Tui
     def env_complete=(on : Bool) : Nil
       @env_complete = on ? (@env_complete || EnvComplete.new) : nil
       @env_peek = on ? (@env_peek || EnvPeek.new) : nil # the value peek rides the same opt-in
+    end
+
+    # Enable the chain tooltip (paired with @conceal_spans on the request editors).
+    def chain_peek=(on : Bool) : Nil
+      @chain_peek = on ? (@chain_peek || ChainPeek.new) : nil
+    end
+
+    # Per-frame feed: the chain of the §…§ marker under the caret, or nil when the caret
+    # isn't in a chained marker. The owner resolves it (it knows the §-marker layout).
+    def chain_peek_text=(chain : String?) : Nil
+      @chain_peek_text = chain
     end
 
     def env_completing? : Bool

--- a/src/gori/tui/theme.cr
+++ b/src/gori/tui/theme.cr
@@ -405,10 +405,10 @@ module Gori::Tui
       yellow: Color.from_hex("#e5c07b"),        # 4xx
       red: Color.from_hex("#e2757e"),           # 5xx / error (lifted, 4.7:1)
       orange: Color.from_hex("#d19a66"),
-      syn_header: Color.from_hex("#61afef"),    # header/field names, JSON keys, tag names (blue)
-      syn_string: Color.from_hex("#98c379"),    # quoted strings (green)
-      syn_number: Color.from_hex("#d19a66"),    # numbers, tag attribute names (orange)
-      syn_literal: Color.from_hex("#c678dd"),   # true / false / null (purple)
+      syn_header: Color.from_hex("#61afef"),  # header/field names, JSON keys, tag names (blue)
+      syn_string: Color.from_hex("#98c379"),  # quoted strings (green)
+      syn_number: Color.from_hex("#d19a66"),  # numbers, tag attribute names (orange)
+      syn_literal: Color.from_hex("#c678dd"), # true / false / null (purple)
     )
 
     # The Kanagawa (Wave) palette, after Hokusai's Great Wave: a sumi-ink canvas
@@ -457,10 +457,10 @@ module Gori::Tui
       yellow: Color.from_hex("#d29922"),        # 4xx
       red: Color.from_hex("#f85149"),           # 5xx / error
       orange: Color.from_hex("#ffa657"),
-      syn_header: Color.from_hex("#79c0ff"),    # header/field names, JSON keys, tag names (constant blue)
-      syn_string: Color.from_hex("#a5d6ff"),    # quoted strings (GitHub's light-blue strings)
-      syn_number: Color.from_hex("#ffa657"),    # numbers, tag attribute names (orange)
-      syn_literal: Color.from_hex("#d2a8ff"),   # true / false / null (purple)
+      syn_header: Color.from_hex("#79c0ff"),  # header/field names, JSON keys, tag names (constant blue)
+      syn_string: Color.from_hex("#a5d6ff"),  # quoted strings (GitHub's light-blue strings)
+      syn_number: Color.from_hex("#ffa657"),  # numbers, tag attribute names (orange)
+      syn_literal: Color.from_hex("#d2a8ff"), # true / false / null (purple)
     )
 
     # The classic Zenburn palette: the famously easy-on-the-eyes mid-grey canvas
@@ -483,10 +483,10 @@ module Gori::Tui
       yellow: Color.from_hex("#f0dfaf"),        # 4xx
       red: Color.from_hex("#dca3a3"),           # 5xx / error (red+1, 4.9:1 — the base rose is 4.1)
       orange: Color.from_hex("#dfaf8f"),
-      syn_header: Color.from_hex("#93e0e3"),    # header/field names, JSON keys, tag names (function cyan)
-      syn_string: Color.from_hex("#dca3a3"),    # quoted strings (zenburn's rose strings)
-      syn_number: Color.from_hex("#dfaf8f"),    # numbers, tag attribute names (variable orange)
-      syn_literal: Color.from_hex("#e39ccd"),   # true / false / null (lifted magenta, 5.0:1)
+      syn_header: Color.from_hex("#93e0e3"),  # header/field names, JSON keys, tag names (function cyan)
+      syn_string: Color.from_hex("#dca3a3"),  # quoted strings (zenburn's rose strings)
+      syn_number: Color.from_hex("#dfaf8f"),  # numbers, tag attribute names (variable orange)
+      syn_literal: Color.from_hex("#e39ccd"), # true / false / null (lifted magenta, 5.0:1)
     )
 
     # The GitHub (Primer) light palette: github.com's light mode on a pure-white
@@ -778,6 +778,15 @@ module Gori::Tui
     # Foreground for tinted marker text — near-max contrast on the subtle band across themes.
     def self.marker_fg : Color
       text_bright
+    end
+
+    # Foreground for the closing § of a marker that hides a ¦chain — a "chain attached"
+    # signal set apart from the plain marker_fg. Uses focus_gold (NOT accent): in the
+    # monochrome palettes accent == text_bright == marker_fg, so an accent § would be
+    # invisible against the rest of the marker. focus_gold is a distinct, contrast-guarded
+    # gold in every palette, and reads as actionable (matches the ^Y edit affordance).
+    def self.marker_accent : Color
+      focus_gold
     end
 
     # Linear RGB blend of `hue` toward `base` by ratio t (0 = base, 1 = hue).


### PR DESCRIPTION
## What

A `§value¦chain§` marker used to render its whole encode chain inline (`§data¦base64-encode > url-encode§`), cluttering the Repeater/Fuzzer body. Now only `§data§` shows; the `¦chain` is **concealed** (still in the buffer, so the wire bytes are unchanged), **revealed on the caret as an ENV-style tooltip**, and **edited in a dedicated `^Y` modal with a live transform preview**.

| before | after |
|---|---|
| `§data¦base64-encode > url-encode§` inline | `§data§` inline · `▸ base64-encode > url-encode  ^Y edit` tooltip on the caret |

## How

- **`Highlight.conceal` + `TextArea#conceal_spans`** — generic, opt-in display concealment threaded through the line draw, caret column, horizontal scroll (`follow_x`), the marker band over-paint, click-to-cursor (inverse mapping), and cursor motion (snaps the caret out of hidden runs). Early-outs when unset, so every other editor is byte-for-byte unchanged.
- **Sharper band + chain signal** — the `§data§` band is over-painted at concealed columns; the **closing `§` is accented in `focus_gold`** to signal a chain is attached. (`accent == text_bright == marker_fg` in the monochrome themes, so it deliberately does *not* use `accent` — locked by a spec assertion.)
- **`ChainPeek`** — caret-anchored tooltip revealing the concealed chain + a `^Y edit` affordance (flips above/below by room, like the `$ENV` peek).
- **`ChainOverlay`** — the `^Y` modal editor that **replaces the auto-splitting CHAIN pane**. Edits the chain (with converter autocomplete) and **previews the transform** (`value → each step → output` via `Decoder.run`). The caret returns into the marker on commit so the tooltip stays up.

Applied symmetrically to **Repeater** and **Fuzzer**.

## Verification

- Full suite **green** (added specs for conceal / band bg / gold accent / tooltip / modal + preview / cursor-snap / buffer integrity).
- `crystal tool format` applied; new files ameba-clean.
- Verified live in tmux: concealed `§hello§` inline, gold closing `§`, tooltip, and the `^Y` modal preview computing `hello → aGVsbG8= → aGVsbG8%3D`.

The chain lives inline in the buffer as the source of truth, so headless `gori run fuzz` / MCP / send paths are unaffected — concealment is display-only.