### PR TITLE
feat(tui): fill the active sub-tab with a two-tone gold pill

### DIFF
--- a/spec/tui/foundation_spec.cr
+++ b/spec/tui/foundation_spec.cr
@@ -95,7 +95,7 @@ describe Gori::Tui::Chrome do
     backend.contains?("History").should be_true
     backend.contains?("Intercept").should be_true
     backend.contains?("Sitemap").should be_true
-    backend.contains?("(3)").should be_true        # held-message badge on Intercept (the only tab-bar count)
+    backend.contains?("(3)").should be_true      # held-message badge on Intercept (the only tab-bar count)
     backend.contains?("Issues(").should be_false # issues/repeater/notes carry no count badge
     # active segment ` Project ` (now first tab) starts at col 2 (rect.x+1 fill, +1 pad); FOCUS_GOLD pill.
     backend.fg_at(2, 1).should eq(Theme.ink_on(Theme.focus_gold))
@@ -139,7 +139,7 @@ describe Gori::Tui::Chrome do
     Chrome.render_status(Screen.new(backend), Rect.new(0, 0, 36, 1),
       focus: "ISSUE", hints: "type title · esc cancel",
       activity: {"scanning a very long-running background job", Theme.accent})
-    backend.row(0)[0, 7].should eq(" ISSUE ")     # badge survives, no chip bled into it
+    backend.row(0)[0, 7].should eq(" ISSUE ") # badge survives, no chip bled into it
     backend.fg_at(1, 0).should eq(Theme.text_bright)
     backend.contains?("scanning").should be_true # chip still present (floored at the hint start, truncated at the right edge)
   end
@@ -169,14 +169,14 @@ describe Gori::Tui::Chrome do
     content.h.should eq(outer.h - 2 - BodyChrome::CHIPS_H)
   end
 
-  it "renders the sub-tab strip without a row fill and a divider hairline" do
+  it "renders the active sub-tab chip as a filled pill with a divider hairline" do
     backend = MemoryBackend.new(60, 2)
     screen = Screen.new(backend)
     BodyChrome.render_subtab_strip(screen, Rect.new(0, 0, 60, 2),
       ["1:alpha", "2:beta"], 0, focused: true)
 
-    backend.bg_at(12, 0).should eq(Theme.bg) # inactive label, no pill
-    backend.bg_at(12, 0).should_not eq(Theme.elevated)
+    backend.bg_at(13, 0).should eq(Theme.bg) # inactive label sits on the canvas, no pill
+    backend.bg_at(13, 0).should_not eq(Theme.elevated)
     backend.bg_at(2, 0).should eq(Theme.focus_gold) # active pill when focused
     backend.row(1).should contain("─")              # hairline under the chips
   end
@@ -191,12 +191,15 @@ describe Gori::Tui::Chrome do
     backend.row(0).should_not contain("─")
   end
 
-  it "settles the active sub-tab chip to selection_dim when the strip is unfocused" do
+  it "settles the active sub-tab chip to a calmer receded gold when the strip is unfocused" do
     backend = MemoryBackend.new(60, 1)
     Chrome.render_tab_strip(Screen.new(backend), Rect.new(0, 0, 60, 1),
       ["one", "two"], 1, focused: false)
-    backend.bg_at(8, 0).should eq(Theme.selection_dim)
-    backend.fg_at(8, 0).should eq(Theme.text)
+    dim_gold = Theme.blend(Theme.focus_gold, Theme.bg, Chrome::SUBTAB_DIM_GOLD)
+    backend.bg_at(8, 0).should eq(dim_gold)             # the whole chip fills the receded gold, edge to edge
+    backend.bg_at(9, 0).should eq(dim_gold)             # band body under the label
+    backend.bg_at(9, 0).should_not eq(Theme.focus_gold) # a step below the bright focus pill
+    backend.fg_at(9, 0).should eq(Theme.text_bright)    # active label ink on the band
   end
 
   it "renders the top bar with project, scope, and the right-aligned clock" do

--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -29,6 +29,11 @@ module Gori::Tui
 
     WORDMARK = "𝓰𝓸𝓻𝓲"
 
+    # How far the unfocused active sub-tab's receded gold sits between the canvas (0.0)
+    # and the bright focus_gold pill (1.0). 0.7 keeps it a definite gold — a step below
+    # the focus pill — in every palette (blended against that theme's own bg).
+    SUBTAB_DIM_GOLD = 0.7
+
     # Draw WORDMARK left-aligned at (x, y), or horizontally centred when `center_w`
     # is set. Returns the x just past the drawn wordmark. Defaults to the theme's
     # gold (focus_gold) so the brand mark reads gold in every palette; `fg` exists
@@ -336,12 +341,14 @@ module Gori::Tui
       start
     end
 
-    # A windowed horizontal sub-tab strip (Repeater / Notes / Fuzzer / …). No row fill:
-    # the active chip is marked by a FOCUS_GOLD `▎` bar + a bold, underlined label
-    # (TEXT_BRIGHT at rest, FOCUS_GOLD when the strip holds focus) so it reads as the
-    # selected tab whether or not the strip has focus; inactive chips are plain TEXT.
-    # A leading "N:" index is dimmed (MUTED) and a trailing " #tag" run is tinted
-    # (SYN_HEADER) so the eye lands on the label. `‹` / `›` flag overflow.
+    # A windowed horizontal sub-tab strip (Repeater / Notes / Fuzzer / …). The active chip
+    # fills a gold pill (mirroring the main tab bar): a bright FOCUS_GOLD pill with auto-
+    # contrast ink when the strip holds focus, else a calmer receded gold (FOCUS_GOLD blended
+    # 70% over the canvas) with TEXT_BRIGHT ink — a definite gold both ways, a step below the
+    # focus pill, so the active session reads clearly while the strip is unfocused (the common
+    # case, editing the body) rather than fading into a faint grey band. Inactive chips are
+    # unfilled with a leading "N:" index dimmed (MUTED), a plain TEXT label, and a trailing
+    # " #tag" run tinted (SYN_HEADER) so the eye lands on the label. `‹` / `›` flag overflow.
     # `hidden` (Repeater's tag filter) drops those absolute chip indices from the strip —
     # they keep their absolute number, so the visible chips read with gaps (2, 5, 7).
     def self.render_tab_strip(screen : Screen, rect : Rect, labels : Array(String),
@@ -351,19 +358,26 @@ module Gori::Tui
       active = active.clamp(0, labels.size - 1)
       segs, start, last, vis_last = strip_layout(rect, labels, active, prev_start, hidden)
       segs.each do |(i, label, seg)|
-        num_end, tag_start = chip_zones(label)
         if i == active
-          screen.cell(seg.x, seg.y, '▎', Theme.focus_gold, Theme.bg)
-          mid_fg = focused ? Theme.focus_gold : Theme.text_bright
-          attr = Attribute::Bold | Attribute::Underline
+          if focused
+            bg = Theme.focus_gold
+            screen.fill(seg, bg)
+            screen.text(seg.x + 1, seg.y, label, Theme.ink_on(bg), bg, Attribute::Bold)
+          else
+            # Unfocused: a calmer, receded gold (FOCUS_GOLD 70% over the canvas) — still
+            # unmistakably a gold chip, a step below the bright focus pill, never the
+            # near-invisible ACCENT_BG grey band.
+            bg = Theme.blend(Theme.focus_gold, Theme.bg, SUBTAB_DIM_GOLD)
+            screen.fill(seg, bg)
+            screen.text(seg.x + 1, seg.y, label, Theme.text_bright, bg, Attribute::Bold)
+          end
         else
-          mid_fg = Theme.text
-          attr = Attribute::None
+          num_end, tag_start = chip_zones(label)
+          x = seg.x + 1
+          x = screen.text(x, seg.y, label[0, num_end], Theme.muted, Theme.bg) if num_end > 0
+          x = screen.text(x, seg.y, label[num_end...tag_start], Theme.text, Theme.bg)
+          screen.text(x, seg.y, label[tag_start..], Theme.syn_header, Theme.bg) if tag_start < label.size
         end
-        x = seg.x + 1
-        x = screen.text(x, seg.y, label[0, num_end], Theme.muted, Theme.bg, attr) if num_end > 0
-        x = screen.text(x, seg.y, label[num_end...tag_start], mid_fg, Theme.bg, attr)
-        screen.text(x, seg.y, label[tag_start..], Theme.syn_header, Theme.bg, attr) if tag_start < label.size
       end
       screen.cell(rect.x, rect.y, '‹', Theme.muted, Theme.bg) if start > 0
       screen.cell(rect.right - 1, rect.y, '›', Theme.muted, Theme.bg) if last < vis_last


### PR DESCRIPTION
## Why

The sub-tab strips marked the active chip with an underline + `▎` gold bar. It was legible but plain — the main tab bar's **background-fill gold pill** reads better, and @hahwul wanted that idiom on the sub-tabs too.

The reason the fill was dropped before: the strip is **unfocused most of the time** (focus lives in the request/body pane while you edit), and the main bar's unfocused fill (`SELECTION_DIM`, ~1.15:1) is invisible at the sub-tab level. Falling back to `ACCENT_BG` (~1.3:1) read as an awkward faint grey; a gold-capped accent band was too fiddly.

## What

The active chip is now **always gold**, two-tone by focus:

| State | Fill | Ink |
|---|---|---|
| Strip **focused** | bright `FOCUS_GOLD` pill | `ink_on(focus_gold)` (auto-contrast) + bold |
| Strip **unfocused** | receded gold — `blend(focus_gold, bg, 0.7)` | `text_bright` + bold |

A definite gold in both states — never a grey band — a step below the focus pill, so the active session reads at a glance and focus still registers as a brightness change.

Everything derives from the live palette (`blend` + `ink_on` + `text_bright`), so all **21 themes** get a themed gold on their own canvas (light or dark) with no per-theme constants. Inactive chips keep their zone tinting (muted `N:` index, plain label, `SYN_HEADER " #tag"`).

`Chrome.render_tab_strip` is the single chokepoint for all seven strips (Repeater / Fuzzer / Miner / Convert / Comparer / Notes / Help), so they all restyle together. `strip_layout` geometry is untouched, so click hit-tests can't drift.

## Verification

- `crystal spec spec/tui/` → **697 examples, 0 failures** (incl. the theme contrast guards).
- `crystal tool format --check` clean.
- Drove the real TUI (isolated `GORI_HOME`, Decoder with two sub-tabs) and confirmed via ANSI capture:
  - **Focused** active chip → bg `(194,160,90)` = `focus_gold`, bold dark ink `(17,17,17)`.
  - **Unfocused** active chip → bg `(139,115,66)` = `blend(focus_gold, bg, 0.7)`, bold `text_bright` `(250,250,250)`, edge to edge.
  - Inactive → no fill, muted `(110,110,118)` index + `(200,200,204)` label.