### PR TITLE
feat(tui): enrich Request/Response syntax highlighting

### DIFF
--- a/spec/pretty_spec.cr
+++ b/spec/pretty_spec.cr
@@ -53,10 +53,10 @@ describe Gori::Pretty do
   end
 
   describe "GraphQL" do
-    it "presents operationName + query + variables, kind :text" do
+    it "presents operationName + query + variables, kind :graphql" do
       body = %({"operationName":"Q","query":"query Q { me { id } }","variables":{"x":1}})
       res = pretty("application/json", body)
-      res.not_nil!.kind.should eq(:text)
+      res.not_nil!.kind.should eq(:graphql)
       t = text(res)
       t.should contain("# operationName: Q")
       t.should contain("query Q { me { id } }")
@@ -89,9 +89,9 @@ describe Gori::Pretty do
   end
 
   describe "JWT" do
-    it "decodes header/payload (signature not verified), kind :text" do
+    it "decodes header/payload (signature not verified), kind :json" do
       res = pretty("text/plain", jwt_token)
-      res.not_nil!.kind.should eq(:text)
+      res.not_nil!.kind.should eq(:json)
       t = text(res)
       t.should contain("// header")
       t.should contain(%("alg": "HS256"))

--- a/spec/tui/highlight_spec.cr
+++ b/spec/tui/highlight_spec.cr
@@ -211,6 +211,91 @@ describe Gori::Tui::Highlight do
       has_span?(spans, "<", Theme.muted).should be_true
       has_span?(spans, ">", Theme.muted).should be_true
     end
+
+    it "tokenises attribute names (syn_number) and quoted values (syn_string)" do
+      spans = body_spans("text/html", %(<a href="/x" data-id='5'>), request: false)
+      spans.map(&.text).join.should eq(%(<a href="/x" data-id='5'>))
+      has_span?(spans, "href", Theme.syn_number).should be_true
+      has_span?(spans, %("/x"), Theme.syn_string).should be_true
+      has_span?(spans, "data-id", Theme.syn_number).should be_true
+    end
+
+    it "colours comments and declarations" do
+      c = body_spans("text/html", "<!-- hi -->", request: false)
+      has_span?(c, "<!-- hi -->", Theme.syn_comment).should be_true
+      d = body_spans("text/html", "<!DOCTYPE html>", request: false)
+      has_span?(d, "DOCTYPE", Theme.syn_keyword).should be_true
+    end
+  end
+
+  describe "request-line query string" do
+    it "breaks path / ? / query params" do
+      line = Highlight.from_lines(["GET /api/users?id=42&sort=name HTTP/1.1"], request: true).first
+      line.map(&.text).join.should eq("GET /api/users?id=42&sort=name HTTP/1.1")
+      has_span?(line, "/api/users", Theme.text_bright).should be_true
+      has_span?(line, "?", Theme.muted).should be_true
+      has_span?(line, "id", Theme.syn_header).should be_true
+      has_span?(line, "&", Theme.muted).should be_true
+    end
+
+    it "leaves a query-less target as a single bright span" do
+      line = Highlight.from_lines(["GET /plain/path HTTP/1.1"], request: true).first
+      has_span?(line, "/plain/path", Theme.text_bright).should be_true
+    end
+  end
+
+  describe "header values" do
+    it "tokenises Set-Cookie name/value and attributes" do
+      line = Highlight.from_lines(["HTTP/1.1 200 OK", "Set-Cookie: sid=abc; Path=/; HttpOnly"], false)[1]
+      line.map(&.text).join.should eq("Set-Cookie: sid=abc; Path=/; HttpOnly")
+      has_span?(line, " sid", Theme.syn_header).should be_true
+      has_span?(line, "abc", Theme.text).should be_true
+      has_span?(line, " Path", Theme.syn_keyword).should be_true
+      has_span?(line, " HttpOnly", Theme.syn_keyword).should be_true
+    end
+
+    it "colours the Authorization scheme distinctly from the credential" do
+      line = Highlight.from_lines(["GET / HTTP/1.1", "Authorization: Bearer eyJhbGc"], request: true)[1]
+      line.map(&.text).join.should eq("Authorization: Bearer eyJhbGc")
+      has_span?(line, "Bearer", Theme.syn_keyword).should be_true
+      has_span?(line, " eyJhbGc", Theme.syn_string).should be_true
+    end
+
+    it "keeps a structureless value as one plain span (Host / Date)" do
+      line = Highlight.from_lines(["GET / HTTP/1.1", "Host: h.test"], request: true)[1]
+      has_span?(line, " h.test", Theme.text).should be_true
+      dline = Highlight.from_lines(["GET / HTTP/1.1", "Date: Mon 01:02:03"], request: true)[1]
+      has_span?(dline, " Mon 01:02:03", Theme.text).should be_true
+    end
+
+    it "accents param keys in a generic value" do
+      line = Highlight.from_lines(["HTTP/1.1 200 OK", "Content-Type: text/html; charset=utf-8"], false)[1]
+      has_span?(line, " charset", Theme.syn_header).should be_true
+      has_span?(line, "=", Theme.muted).should be_true
+    end
+  end
+
+  describe "JSONC comments" do
+    it "styles a leading // line as a comment (JWT markers)" do
+      has_span?(body_spans("application/json", "// header"), "// header", Theme.syn_comment).should be_true
+      has_span?(body_spans("application/json", "  // payload"), "  // payload", Theme.syn_comment).should be_true
+      # a real JSON line is unaffected
+      has_span?(body_spans("application/json", %({"a": 1})), %("a"), Theme.syn_header).should be_true
+    end
+  end
+
+  describe "GraphQL bodies" do
+    it "colours keywords, fields, and variables" do
+      spans = Highlight.body_styled("query Q($id: ID!) { user(id: $id) { name } }", :graphql)
+      spans.map(&.text).join.should eq("query Q($id: ID!) { user(id: $id) { name } }")
+      has_span?(spans, "query", Theme.syn_keyword).should be_true
+      has_span?(spans, "$id", Theme.syn_literal).should be_true
+      has_span?(spans, "user", Theme.syn_header).should be_true
+    end
+
+    it "styles # comments" do
+      has_span?(Highlight.body_styled("# operationName: Q", :graphql), "# operationName: Q", Theme.syn_comment).should be_true
+    end
   end
 
   describe ".draw" do
@@ -289,7 +374,13 @@ describe Gori::Tui::Highlight do
       spans = [] of Highlight::Span
       chars = raw.chars
       n = chars.size
-      i = 0
+      ws = 0
+      while ws < n && chars[ws].ascii_whitespace?
+        ws += 1
+      end
+      comment = ws + 1 < n && chars[ws] == '/' && chars[ws + 1] == '/' # JSONC line comment
+      spans << Highlight::Span.new(raw, Theme.syn_comment) if comment
+      i = comment ? n : 0 # a comment line skips the tokenizer loop
       while i < n
         c = chars[i]
         if c == '"'
@@ -372,6 +463,56 @@ describe Gori::Tui::Highlight do
       spans
     end
 
+    name_char = ->(c : Char) { c.ascii_letter? || c.ascii_number? || c == '-' || c == '_' || c == ':' }
+
+    ref_attr = ->(seg : String) do
+      spans = [] of Highlight::Span
+      chars = seg.chars
+      n = chars.size
+      i = 0
+      after_eq = false
+      while i < n
+        c = chars[i]
+        if c == '"' || c == '\''
+          quote = c
+          start = i
+          i += 1
+          while i < n && chars[i] != quote
+            i += 1
+          end
+          i += 1 if i < n
+          spans << Highlight::Span.new(chars[start...i].join, Theme.syn_string)
+          after_eq = false
+        elsif c == '='
+          spans << Highlight::Span.new("=", Theme.muted)
+          i += 1
+          after_eq = true
+        elsif c == '/'
+          spans << Highlight::Span.new("/", Theme.muted)
+          i += 1
+        elsif name_char.call(c)
+          start = i
+          i += 1
+          while i < n && name_char.call(chars[i])
+            i += 1
+          end
+          spans << Highlight::Span.new(chars[start...i].join, after_eq ? Theme.text : Theme.syn_number)
+          after_eq = false
+        else
+          start = i
+          i += 1
+          while i < n
+            d = chars[i]
+            break if d == '"' || d == '\'' || d == '=' || d == '/' || name_char.call(d)
+            i += 1
+          end
+          spans << Highlight::Span.new(chars[start...i].join, Theme.text)
+          after_eq = false
+        end
+      end
+      spans
+    end
+
     ref_markup = ->(raw : String) do
       spans = [] of Highlight::Span
       chars = raw.chars
@@ -379,21 +520,48 @@ describe Gori::Tui::Highlight do
       i = 0
       while i < n
         if chars[i] == '<'
+          # comment '<!-- … -->' (line-local)
+          if i + 3 < n && chars[i + 1] == '!' && chars[i + 2] == '-' && chars[i + 3] == '-'
+            close = nil.as(Int32?)
+            k = i + 4
+            while k + 2 < n
+              if chars[k] == '-' && chars[k + 1] == '-' && chars[k + 2] == '>'
+                close = k
+                break
+              end
+              k += 1
+            end
+            stop = close ? close + 3 : n
+            spans << Highlight::Span.new(chars[i...stop].join, Theme.syn_comment)
+            i = stop
+            next
+          end
           gt = i + 1
           while gt < n && chars[gt] != '>'
             gt += 1
           end
           closed = gt < n
           j = i + 1
-          j += 1 if j < n && chars[j] == '/'
+          decl = false
+          if j < n && (chars[j] == '!' || chars[j] == '?')
+            decl = true
+            j += 1
+          elsif j < n && chars[j] == '/'
+            j += 1
+          end
           spans << Highlight::Span.new(chars[i...j].join, Theme.muted)
           name = j
-          while name < gt && (chars[name].ascii_letter? || chars[name].ascii_number? ||
-                              chars[name] == '-' || chars[name] == '_' || chars[name] == ':')
+          while name < gt && name_char.call(chars[name])
             name += 1
           end
-          spans << Highlight::Span.new(chars[j...name].join, Theme.syn_header) if name > j
-          spans << Highlight::Span.new(chars[name...gt].join, Theme.text) if name < gt
+          spans << Highlight::Span.new(chars[j...name].join, decl ? Theme.syn_keyword : Theme.syn_header) if name > j
+          if name < gt
+            if decl
+              spans << Highlight::Span.new(chars[name...gt].join, Theme.text)
+            else
+              ref_attr.call(chars[name...gt].join).each { |s| spans << s }
+            end
+          end
           spans << Highlight::Span.new(">", Theme.muted) if closed
           i = closed ? gt + 1 : gt
         else

--- a/spec/tui/theme_spec.cr
+++ b/spec/tui/theme_spec.cr
@@ -117,13 +117,17 @@ describe Gori::Tui::Theme do
         "syn_string"  => Theme.syn_string,
         "syn_number"  => Theme.syn_number,
         "syn_literal" => Theme.syn_literal,
+        "syn_keyword" => Theme.syn_keyword,
       }
       functional.each do |label, color|
         ratio = wcag_contrast(color, bg)
         fail "#{name}/#{label} contrast #{ratio.round(2)}:1 < 4.5:1 on bg" if ratio < 4.5
       end
-      muted_ratio = wcag_contrast(Theme.muted, bg)
-      fail "#{name}/muted contrast #{muted_ratio.round(2)}:1 < 3.5:1 on bg" if muted_ratio < 3.5
+      # muted and syn_comment are deliberately dimmer secondary tiers (≥3.5:1).
+      {"muted" => Theme.muted, "syn_comment" => Theme.syn_comment}.each do |label, color|
+        dim_ratio = wcag_contrast(color, bg)
+        fail "#{name}/#{label} contrast #{dim_ratio.round(2)}:1 < 3.5:1 on bg" if dim_ratio < 3.5
+      end
     end
   end
 

--- a/src/gori/pretty.cr
+++ b/src/gori/pretty.cr
@@ -129,7 +129,7 @@ module Gori
       end
       ob = text.to_slice
       return nil if ob.size > MAX_OUT_PRETTY
-      Result.new(ob, "pretty: graphql", :text)
+      Result.new(ob, "pretty: graphql", :graphql)
     end
 
     # ---- JWT (reuses Decoder::Codecs.jwt_decode) ---------------------------
@@ -143,7 +143,9 @@ module Gori
       decoded = Decoder::Codecs.jwt_decode(t.to_slice)
       slice = decoded.to_slice
       return nil if slice.size > MAX_OUT_PRETTY
-      Result.new(slice, "pretty: jwt (decoded · signature not verified)", :text)
+      # The decoded form is JSONC (`// header` / `// payload` markers + JSON segments);
+      # the JSON tokenizer styles the `//` markers as comments (see Highlight.json_line).
+      Result.new(slice, "pretty: jwt (decoded · signature not verified)", :json)
     rescue
       nil
     end

--- a/src/gori/tui/comparer_view.cr
+++ b/src/gori/tui/comparer_view.cr
@@ -1,6 +1,7 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./highlight"
 require "./url"
 require "./flow_status"
 require "./subtab_clone"
@@ -19,7 +20,7 @@ module Gori::Tui
   # Multiple views are held as session sub-tabs by ComparerController (in-memory;
   # no project DB) so History handoffs don't clobber prior pairs.
   class ComparerView
-    getter pane : Symbol # :request | :response — which half of the two flows we diff
+    getter pane : Symbol    # :request | :response — which half of the two flows we diff
     property name : String? # custom sub-tab chip label (nil = auto from slots)
 
     SEP_W = 3 # the centre marker band between the A and B columns
@@ -32,6 +33,11 @@ module Gori::Tui
       @scroll = 0
       @fill_next = :a # the slot the next "Send to Comparer" fills (rings A → B → A …)
       @rows_cache = nil.as(Array(Repeater::SideBySide::Row)?)
+      # Styled overlay for the UNCHANGED (same) rows only — parallel to @rows_cache, nil
+      # per changed/del/add row (those keep their diff colours). Rebuilt with the rows and
+      # on a theme switch. See build_rows / draw_diff_row.
+      @styled_same = nil.as(Array(Highlight::Line?)?)
+      @styled_same_rev = 0_u32
       @truncated = false
       @change_count = 0 # cached with @rows_cache so the footer doesn't recount each frame
     end
@@ -181,6 +187,7 @@ module Gori::Tui
 
     private def invalidate : Nil
       @rows_cache = nil
+      @styled_same = nil
     end
 
     private def rows : Array(Repeater::SideBySide::Row)
@@ -197,6 +204,34 @@ module Gori::Tui
       result = Repeater::SideBySide.rows(Repeater::Diff.lines(al, bl))
       @change_count = Repeater::SideBySide.change_count(result)
       result
+    end
+
+    # Syntax-highlighted lines for the UNCHANGED rows, parallel to `rows` (nil per
+    # changed/del/add row). The A message is styled as a whole via `Highlight.from_lines`
+    # (so header vs body + content-type styling is correct), then mapped to rows by
+    # replaying SideBySide's advance rule: a Same/Changed/DelOnly row consumes one A line.
+    # Cached with the rows and rebuilt on a theme switch. The input is capped to
+    # `Diff::MAX_LINES` — the diff (and thus every row index) is already truncated there,
+    # so styling past it would colour lines that can never be displayed.
+    private def styled_same : Array(Highlight::Line?)
+      cached = @styled_same
+      return cached if cached && @styled_same_rev == Theme.revision
+      rs = rows
+      out = Array(Highlight::Line?).new(rs.size, nil)
+      if a = @slot_a
+        al = lines_for(a)
+        al = al.first(Repeater::Diff::MAX_LINES) if al.size > Repeater::Diff::MAX_LINES
+        al_styled = Highlight.from_lines(al, request: @pane == :request)
+        ai = 0
+        rs.each_with_index do |r, idx|
+          out[idx] = al_styled[ai]? if r.kind.same?
+          # DelOnly/Changed/Same all consume one A (left) line; AddOnly consumes none.
+          ai += 1 unless r.kind.add_only?
+        end
+      end
+      @styled_same = out
+      @styled_same_rev = Theme.revision
+      out
     end
 
     private def lines_for(d : Store::FlowDetail) : Array(String)
@@ -236,11 +271,12 @@ module Gori::Tui
       end
 
       data = rows
+      sr = styled_same
       clamp_scroll(body_h, data.size)
       (0...body_h).each do |i|
         di = @scroll + i
         break if di >= data.size
-        draw_diff_row(screen, rect.x, body_top + i, left_w, sep_x, right_x, right_w, data[di])
+        draw_diff_row(screen, rect.x, body_top + i, left_w, sep_x, right_x, right_w, data[di], sr[di]?)
       end
       draw_footer(screen, rect, footer_y)
     end
@@ -287,16 +323,24 @@ module Gori::Tui
 
     private def draw_diff_row(screen : Screen, x : Int32, y : Int32, left_w : Int32,
                               sep_x : Int32, right_x : Int32, right_w : Int32,
-                              r : Repeater::SideBySide::Row) : Nil
+                              r : Repeater::SideBySide::Row, styled : Highlight::Line?) : Nil
       lcolor, rcolor, glyph, gcolor = case r.kind
                                       when .same?     then {Theme.text, Theme.text, '│', Theme.border}
                                       when .changed?  then {Theme.red, Theme.green, '~', Theme.yellow}
                                       when .del_only? then {Theme.red, Theme.muted, '-', Theme.red}
                                       else                 {Theme.muted, Theme.green, '+', Theme.green} # add_only
                                       end
-      screen.text(x, y, r.left || "", lcolor, width: left_w) if left_w > 0
-      screen.cell(sep_x + 1, y, glyph, gcolor)
-      screen.text(right_x, y, r.right || "", rcolor, width: right_w) if right_w > 0
+      # Unchanged rows get syntax highlighting (both columns hold identical text); changed/
+      # added/deleted rows keep the red/green diff colours so the diff signal stays legible.
+      if styled && r.kind.same?
+        Highlight.draw(screen, x, y, styled, bg: Theme.bg, width: left_w) if left_w > 0
+        screen.cell(sep_x + 1, y, glyph, gcolor)
+        Highlight.draw(screen, right_x, y, styled, bg: Theme.bg, width: right_w) if right_w > 0
+      else
+        screen.text(x, y, r.left || "", lcolor, width: left_w) if left_w > 0
+        screen.cell(sep_x + 1, y, glyph, gcolor)
+        screen.text(right_x, y, r.right || "", rcolor, width: right_w) if right_w > 0
+      end
     end
 
     private def draw_footer(screen : Screen, rect : Rect, y : Int32) : Nil

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -166,6 +166,12 @@ module Gori::Tui
       # (same invariant @decoded_index relies on), so this only recomputes on pane/row change.
       @detail_lines_cache = nil.as(Array(String)?)
       @detail_lines_key = nil.as({Symbol, Int64}?)
+      # Styled overlay for the detail lines (syntax highlighting), keyed by pane/row +
+      # theme revision so a palette switch rebuilds it. Held in lockstep with the plain
+      # @detail_lines_cache; the plain lines still back the gutter/cursor/selection math.
+      @detail_styled_cache = nil.as(Array(Highlight::Line)?)
+      @detail_styled_key = nil.as({Symbol, Int64}?)
+      @detail_styled_rev = 0_u32
       @focus = :template
       @loaded = false
       @dirty = false
@@ -622,6 +628,8 @@ module Gori::Tui
       # cache — otherwise an old row's lines could survive under a colliding new index.
       @detail_lines_cache = nil
       @detail_lines_key = nil
+      @detail_styled_cache = nil
+      @detail_styled_key = nil
       @sel = 0
       @scroll = 0
       @running = true
@@ -1035,6 +1043,8 @@ module Gori::Tui
       @detail_cursor.reset
       @detail_lines_cache = nil
       @detail_lines_key = nil
+      @detail_styled_cache = nil
+      @detail_styled_key = nil
     end
 
     # Parse the OPEN result's request/response into the optional protocol panes
@@ -1870,6 +1880,7 @@ module Gori::Tui
       render_detail_chips(screen, rect, panes)
       inner = rect.inset(1, 1)
       lines = detail_lines(r)
+      styled = detail_styled(r, lines)
       @detail_last_h = inner.h
       ensure_detail_visible(inner.h) if focused
       @detail_scroll = @detail_scroll.clamp(0, {lines.size - inner.h, 0}.max)
@@ -1880,8 +1891,10 @@ module Gori::Tui
       rows.each_with_index do |line, i|
         li = @detail_scroll + i
         Gutter.draw(screen, inner.x, inner.y + i, li, gw, current: focused && li == @detail_cursor.cy)
-        shown = @detail_xscroll > 0 ? Highlight.slice_left_text(line, @detail_xscroll) : line
-        screen.text(inner.x + gw, inner.y + i, shown, Theme.text, Theme.bg, width: cw)
+        # Draw the styled overlay; the plain `line` still drives the cursor/selection chrome.
+        sline = styled[li]? || [Highlight::Span.new(line, Theme.text)]
+        sline = Highlight.slice_left(sline, @detail_xscroll) if @detail_xscroll > 0
+        Highlight.draw(screen, inner.x + gw, inner.y + i, sline, bg: Theme.bg, width: cw)
         paint_detail_line_chrome(screen, inner.x + gw, inner.y + i, li, line, focused, lines)
       end
     end
@@ -1952,6 +1965,30 @@ module Gori::Tui
       @detail_lines_cache = lines
       @detail_lines_key = key
       lines
+    end
+
+    # Syntax-highlighted overlay for the detail `lines`, cached in lockstep with the
+    # plain @detail_lines_cache (+ theme revision). Request/response panes go through the
+    # full message highlighter; the decoded panes style per line with their body kind.
+    # 1:1 with `lines`, so the plain strings still drive the gutter/cursor/selection.
+    private def detail_styled(r : Fuzz::Result, lines : Array(String)) : Array(Highlight::Line)
+      key = {@detail_pane, r.index}
+      if (c = @detail_styled_cache) && @detail_styled_key == key && @detail_styled_rev == Theme.revision
+        return c
+      end
+      styled =
+        case @detail_pane
+        when :request  then Highlight.from_lines(lines, request: true)
+        when :response then Highlight.from_lines(lines, request: false)
+        when :graphql  then lines.map { |ln| Highlight.body_styled(ln, :graphql) }
+        when :jwt      then lines.map { |ln| Highlight.body_styled(ln, :json) }
+        when :saml     then lines.map { |ln| Highlight.body_styled(ln, :xml) }
+        else                lines.map { |ln| Highlight.body_styled(ln, :text) }
+        end
+      @detail_styled_cache = styled
+      @detail_styled_key = key
+      @detail_styled_rev = Theme.revision
+      styled
     end
 
     # The reconstructed wire request for a result (template with its payloads spliced in).

--- a/src/gori/tui/highlight.cr
+++ b/src/gori/tui/highlight.cr
@@ -586,9 +586,10 @@ module Gori::Tui
       request ? request_line(raw) : status_line(raw)
     end
 
-    # `METHOD target HTTP/x.x` — method coloured by verb, the target bright, the
-    # version muted. Spaces are preserved verbatim as their own muted spans so
-    # the partition is exact regardless of odd spacing.
+    # `METHOD target HTTP/x.x` — method coloured by verb, the target broken into
+    # path + query (see `target_spans`), the version muted. Spaces are preserved
+    # verbatim as their own muted spans so the partition is exact regardless of odd
+    # spacing.
     private def self.request_line(raw : String) : Line
       first = raw.index(' ')
       return [Span.new(raw, Theme.method_color(raw), Attribute::Bold)] unless first
@@ -596,13 +597,32 @@ module Gori::Tui
       spans = [Span.new(method, Theme.method_color(method), Attribute::Bold)]
       last = raw.rindex(' ')
       if last && last > first
-        spans << Span.new(raw[first...first + 1], Theme.muted)      # space
-        spans << Span.new(raw[first + 1...last], Theme.text_bright) # target
-        spans << Span.new(raw[last...last + 1], Theme.muted)        # space
-        spans << Span.new(raw[last + 1..], Theme.muted)             # version
+        spans << Span.new(raw[first...first + 1], Theme.muted) # space
+        target_spans(raw[first + 1...last]).each { |s| spans << s }
+        spans << Span.new(raw[last...last + 1], Theme.muted) # space
+        spans << Span.new(raw[last + 1..], Theme.muted)      # version
       else
-        spans << Span.new(raw[first..], Theme.text_bright)
+        spans << Span.new(raw[first...first + 1], Theme.muted) # space
+        target_spans(raw[first + 1..]).each { |s| spans << s }
       end
+      spans
+    end
+
+    # Break a request target into `path[?query][#fragment]`: the path (incl. any
+    # absolute-form `scheme://host`) stays bright; `?`/`#` and the query's `&`/`=`
+    # mute; query keys accent (syn_header), values body text — reusing `form_line`.
+    # Byte/index-based so the spans still concatenate to the exact target. Identity
+    # (one bright span) when there's no query string — the common case.
+    private def self.target_spans(t : String) : Line
+      qi = t.index('?')
+      return [Span.new(t, Theme.text_bright)] unless qi
+      spans = [] of Span
+      spans << Span.new(t[0...qi], Theme.text_bright) if qi > 0 # path
+      spans << Span.new("?", Theme.muted)
+      fi = t.index('#', qi + 1)
+      query = fi ? t[(qi + 1)...fi] : t[(qi + 1)..]
+      form_line(query).each { |s| spans << s } unless query.empty?
+      spans << Span.new(t[fi..], Theme.muted) if fi # '#fragment'
       spans
     end
 
@@ -626,15 +646,128 @@ module Gori::Tui
       spans
     end
 
-    # `Name: value` — field name accented, the colon muted, the value in body
-    # text. The first colon is the separator (values may themselves contain ':').
+    # `Name: value` — field name accented, the colon muted, the value tokenised by
+    # `header_value_spans`. The first colon is the separator (values may themselves
+    # contain ':').
     private def self.header_line(raw : String) : Line
       colon = raw.index(':')
       return plain(raw) unless colon
       spans = [Span.new(raw[0...colon], Theme.syn_header)]
       spans << Span.new(raw[colon...colon + 1], Theme.muted) # ":"
       rest = raw[colon + 1..]
-      spans << Span.new(rest, Theme.text) unless rest.empty?
+      unless rest.empty?
+        header_value_spans(raw[0...colon].downcase, rest).each { |s| spans << s }
+      end
+      spans
+    end
+
+    # Well-known Set-Cookie attribute names (lowercased) — coloured as keywords so the
+    # cookie's own name/value pairs stand out from the flags that follow.
+    COOKIE_ATTRS = %w(path domain expires max-age samesite secure httponly partitioned priority)
+
+    # Colour a header value by header name: cookies and auth get dedicated tokenisers,
+    # everything else a light param lexer. `v` keeps the leading space after the colon
+    # so the spans concatenate back to the exact value. Guarded against a pathological
+    # multi-KB header the same way body lines are.
+    private def self.header_value_spans(name_lc : String, v : String) : Line
+      return [Span.new(v, Theme.text)] if v.bytesize > MAX_HL_LINE
+      case name_lc
+      when "cookie", "set-cookie"                 then cookie_value_spans(v)
+      when "authorization", "proxy-authorization" then auth_value_spans(v)
+      else                                             generic_value_spans(v)
+      end
+    end
+
+    # `scheme credential` (Bearer …, Basic …, Digest …): the scheme keyword-coloured,
+    # the credential as a string. Leading whitespace kept as its own muted span.
+    private def self.auth_value_spans(v : String) : Line
+      n = v.size
+      i = 0
+      while i < n && v[i] == ' '
+        i += 1
+      end
+      return [Span.new(v, Theme.text)] if i >= n
+      s0 = i
+      while i < n && v[i] != ' '
+        i += 1
+      end
+      spans = [] of Span
+      spans << Span.new(v[0...s0], Theme.muted) if s0 > 0  # leading space(s)
+      spans << Span.new(v[s0...i], Theme.syn_keyword)      # scheme
+      spans << Span.new(v[i..], Theme.syn_string) if i < n # space + credential
+      spans
+    end
+
+    # `name=value; name=value; Attr` (Cookie / Set-Cookie): names accented, values
+    # body text, `=`/`;` muted, known Set-Cookie attributes keyword-coloured.
+    private def self.cookie_value_spans(v : String) : Line
+      spans = [] of Span
+      b = v.to_slice
+      n = b.size
+      i = 0
+      expect_name = true
+      while i < n
+        c = b.unsafe_fetch(i)
+        if c == 0x3b_u8 # ';'
+          spans << Span.new(v.byte_slice(i, 1), Theme.muted)
+          i += 1
+          expect_name = true
+        elsif c == 0x3d_u8 # '='
+          spans << Span.new(v.byte_slice(i, 1), Theme.muted)
+          i += 1
+          expect_name = false
+        else
+          start = i
+          while i < n && b.unsafe_fetch(i) != 0x3b_u8 && b.unsafe_fetch(i) != 0x3d_u8
+            i += 1
+          end
+          tok = v.byte_slice(start, i - start)
+          color = if expect_name
+                    COOKIE_ATTRS.includes?(tok.strip.downcase) ? Theme.syn_keyword : Theme.syn_header
+                  else
+                    Theme.text
+                  end
+          spans << Span.new(tok, color)
+        end
+      end
+      spans
+    end
+
+    # Generic header value: a single plain span when there's no structure (Host, Date,
+    # User-Agent, …), else a light param lexer — quoted strings syn_string, param keys
+    # (a token immediately before '=') syn_header, `=`/`;`/`,` muted, the rest body text.
+    # Bare numbers/dates are intentionally NOT highlighted (too noisy across headers).
+    private def self.generic_value_spans(v : String) : Line
+      return [Span.new(v, Theme.text)] unless v.includes?('=') || v.includes?('"')
+      spans = [] of Span
+      b = v.to_slice
+      n = b.size
+      i = 0
+      while i < n
+        c = b.unsafe_fetch(i)
+        if c == 0x22_u8 # '"' — quoted string (to the next quote or EOL)
+          start = i
+          i += 1
+          while i < n
+            d = b.unsafe_fetch(i)
+            i += 1
+            break if d == 0x22_u8
+          end
+          spans << Span.new(v.byte_slice(start, {i, n}.min - start), Theme.syn_string)
+        elsif c == 0x3d_u8 || c == 0x3b_u8 || c == 0x2c_u8 # '=' ';' ','
+          spans << Span.new(v.byte_slice(i, 1), Theme.muted)
+          i += 1
+        else
+          start = i
+          while i < n
+            d = b.unsafe_fetch(i)
+            break if d == 0x22_u8 || d == 0x3d_u8 || d == 0x3b_u8 || d == 0x2c_u8
+            i += 1
+          end
+          key = i < n && b.unsafe_fetch(i) == 0x3d_u8 # a token right before '=' is a param key
+          spans << Span.new(v.byte_slice(start, i - start), key ? Theme.syn_header : Theme.text)
+        end
+      end
       spans
     end
 
@@ -655,6 +788,7 @@ module Gori::Tui
       when :json       then json_line(raw)
       when :form       then form_line(raw)
       when :xml, :html then markup_line(raw)
+      when :graphql    then graphql_line(raw)
       else                  plain(raw)
       end
     end
@@ -672,6 +806,16 @@ module Gori::Tui
       spans = [] of Span
       b = raw.to_slice # view over the UTF-8 bytes, no copy
       n = b.size
+      # JSONC line comment: a line whose first non-space bytes are `//` is a comment
+      # (the JWT decoder emits `// header` / `// payload` markers around JSON segments).
+      # Real JSON never starts a line with `//`, so this is safe for genuine bodies.
+      ws = 0
+      while ws < n && ascii_ws?(b.unsafe_fetch(ws))
+        ws += 1
+      end
+      if ws + 1 < n && b.unsafe_fetch(ws) == 0x2f_u8 && b.unsafe_fetch(ws + 1) == 0x2f_u8
+        return [Span.new(raw, Theme.syn_comment)]
+      end
       i = 0
       while i < n
         c = b.unsafe_fetch(i)
@@ -753,6 +897,117 @@ module Gori::Tui
       x == 0x7b_u8 || x == 0x7d_u8 || x == 0x5b_u8 || x == 0x5d_u8 || x == 0x3a_u8 || x == 0x2c_u8
     end
 
+    # GraphQL operation keywords (styled distinctly from `true`/`false`/`null` literals).
+    GRAPHQL_KEYWORDS = %w(query mutation subscription fragment on)
+
+    # GraphQL query language (the Pretty/decoded display form): `#` comments, operation
+    # keywords, `$variables`, `@directives`, strings, numbers, and field/type names (an
+    # identifier immediately before `:` / `(` / `{`). Byte-scanned and line-local like
+    # the other body tokenizers, so the spans concatenate back to the exact line.
+    private def self.graphql_line(raw : String) : Line
+      spans = [] of Span
+      b = raw.to_slice
+      n = b.size
+      i = 0
+      while i < n
+        c = b.unsafe_fetch(i)
+        if c == 0x23_u8 # '#' — comment to end of line
+          spans << Span.new(raw.byte_slice(i, n - i), Theme.syn_comment)
+          i = n
+        elsif c == 0x22_u8 # '"' — string (to the next unescaped quote or EOL)
+          start = i
+          i += 1
+          while i < n
+            d = b.unsafe_fetch(i)
+            if d == 0x5c_u8
+              i += 2
+            elsif d == 0x22_u8
+              i += 1
+              break
+            else
+              i += 1
+            end
+          end
+          spans << Span.new(raw.byte_slice(start, {i, n}.min - start), Theme.syn_string)
+        elsif c == 0x24_u8 # '$' — variable
+          start = i
+          i += 1
+          while i < n && gql_name?(b.unsafe_fetch(i))
+            i += 1
+          end
+          spans << Span.new(raw.byte_slice(start, i - start), Theme.syn_literal)
+        elsif c == 0x40_u8 # '@' — directive
+          start = i
+          i += 1
+          while i < n && gql_name?(b.unsafe_fetch(i))
+            i += 1
+          end
+          spans << Span.new(raw.byte_slice(start, i - start), Theme.syn_keyword)
+        elsif ascii_digit?(c) || (c == 0x2d_u8 && i + 1 < n && ascii_digit?(b.unsafe_fetch(i + 1)))
+          start = i
+          i += 1
+          while i < n && (ascii_digit?(b.unsafe_fetch(i)) || num_cont?(b.unsafe_fetch(i)))
+            i += 1
+          end
+          spans << Span.new(raw.byte_slice(start, i - start), Theme.syn_number)
+        elsif gql_name_start?(c)
+          start = i
+          i += 1
+          while i < n && gql_name?(b.unsafe_fetch(i))
+            i += 1
+          end
+          word = raw.byte_slice(start, i - start)
+          k = i
+          while k < n && ascii_ws?(b.unsafe_fetch(k))
+            k += 1
+          end
+          nxt = k < n ? b.unsafe_fetch(k) : 0_u8
+          color = if GRAPHQL_KEYWORDS.includes?(word)
+                    Theme.syn_keyword
+                  elsif word == "true" || word == "false" || word == "null"
+                    Theme.syn_literal
+                  elsif nxt == 0x3a_u8 || nxt == 0x28_u8 || nxt == 0x7b_u8 # ':' '(' '{' → field/arg/type
+                    Theme.syn_header
+                  else
+                    Theme.text
+                  end
+          spans << Span.new(word, color)
+        elsif gql_punct?(c)
+          spans << Span.new(raw.byte_slice(i, 1), Theme.muted)
+          i += 1
+        else
+          start = i
+          i += 1
+          while i < n
+            d = b.unsafe_fetch(i)
+            break if d == 0x23_u8 || d == 0x22_u8 || d == 0x24_u8 || d == 0x40_u8 ||
+                     gql_name_start?(d) || ascii_digit?(d) || gql_punct?(d) ||
+                     (d == 0x2d_u8 && i + 1 < n && ascii_digit?(b.unsafe_fetch(i + 1)))
+            i += 1
+          end
+          spans << Span.new(raw.byte_slice(start, i - start), Theme.text)
+        end
+      end
+      spans
+    end
+
+    # GraphQL name start byte: ASCII letter or `_`.
+    private def self.gql_name_start?(x : UInt8) : Bool
+      ascii_letter?(x) || x == 0x5f_u8
+    end
+
+    # GraphQL name continuation byte: letter, digit, or `_`.
+    private def self.gql_name?(x : UInt8) : Bool
+      ascii_letter?(x) || ascii_digit?(x) || x == 0x5f_u8
+    end
+
+    # GraphQL punctuation: one of `{ } ( ) [ ] : ! = , |`.
+    private def self.gql_punct?(x : UInt8) : Bool
+      x == 0x7b_u8 || x == 0x7d_u8 || x == 0x28_u8 || x == 0x29_u8 ||
+        x == 0x5b_u8 || x == 0x5d_u8 || x == 0x3a_u8 || x == 0x21_u8 ||
+        x == 0x3d_u8 || x == 0x2c_u8 || x == 0x7c_u8
+    end
+
     # `application/x-www-form-urlencoded` — keys accented, `=`/`&` muted, values
     # in body text.
     private def self.form_line(raw : String) : Line
@@ -782,9 +1037,11 @@ module Gori::Tui
       spans
     end
 
-    # HTML/XML — tag delimiters muted, tag names accented, attributes/text in
-    # body text. Line-local: a tag split across lines simply isn't recognised on
-    # the continuation line (cosmetic only; text is never altered).
+    # HTML/XML — tag delimiters muted, tag names accented, attributes tokenised (see
+    # `attr_spans`), text in body colour. `<!-- -->` comments and `<!DOCTYPE>`/`<?xml?>`
+    # declarations get their own colours. Line-local: a tag (or comment) split across
+    # lines simply isn't recognised on the continuation line (cosmetic only; text is
+    # never altered).
     private def self.markup_line(raw : String) : Line
       spans = [] of Span
       b = raw.to_slice
@@ -792,20 +1049,42 @@ module Gori::Tui
       i = 0
       while i < n
         if b.unsafe_fetch(i) == 0x3c_u8 # '<'
+          # Comment: '<!-- … -->' (line-local — an unterminated comment runs to EOL).
+          if i + 3 < n && b.unsafe_fetch(i + 1) == 0x21_u8 && b.unsafe_fetch(i + 2) == 0x2d_u8 && b.unsafe_fetch(i + 3) == 0x2d_u8
+            close = find_seq(b, i + 4, n)
+            stop = close ? close + 3 : n
+            spans << Span.new(raw.byte_slice(i, stop - i), Theme.syn_comment)
+            i = stop
+            next
+          end
           gt = i + 1
           while gt < n && b.unsafe_fetch(gt) != 0x3e_u8 # '>'
             gt += 1
           end
           closed = gt < n # found a '>'
           j = i + 1
-          j += 1 if j < n && b.unsafe_fetch(j) == 0x2f_u8          # '/' closing tag
-          spans << Span.new(raw.byte_slice(i, j - i), Theme.muted) # '<' or '</'
+          # A declaration ('<!DOCTYPE …') or processing instruction ('<?xml …?>'): the
+          # name reads as a keyword; a closing tag keeps the '/' in the delimiter.
+          decl = false
+          if j < n && (b.unsafe_fetch(j) == 0x21_u8 || b.unsafe_fetch(j) == 0x3f_u8) # '!' or '?'
+            decl = true
+            j += 1
+          elsif j < n && b.unsafe_fetch(j) == 0x2f_u8 # '/' closing tag
+            j += 1
+          end
+          spans << Span.new(raw.byte_slice(i, j - i), Theme.muted) # '<' / '</' / '<!' / '<?'
           name = j
           while name < gt && tag_name?(b.unsafe_fetch(name))
             name += 1
           end
-          spans << Span.new(raw.byte_slice(j, name - j), Theme.syn_header) if name > j
-          spans << Span.new(raw.byte_slice(name, gt - name), Theme.text) if name < gt
+          spans << Span.new(raw.byte_slice(j, name - j), decl ? Theme.syn_keyword : Theme.syn_header) if name > j
+          if name < gt
+            if decl
+              spans << Span.new(raw.byte_slice(name, gt - name), Theme.text)
+            else
+              attr_spans(raw.byte_slice(name, gt - name)).each { |s| spans << s }
+            end
+          end
           spans << Span.new(raw.byte_slice(gt, 1), Theme.muted) if closed # '>'
           i = closed ? gt + 1 : gt
         else
@@ -815,6 +1094,68 @@ module Gori::Tui
             i += 1
           end
           spans << Span.new(raw.byte_slice(start, i - start), Theme.text)
+        end
+      end
+      spans
+    end
+
+    # Byte offset of the first `-->` at or after `from` (comment terminator), or nil.
+    private def self.find_seq(b : Bytes, from : Int32, n : Int32) : Int32?
+      k = from
+      while k + 2 < n
+        return k if b.unsafe_fetch(k) == 0x2d_u8 && b.unsafe_fetch(k + 1) == 0x2d_u8 && b.unsafe_fetch(k + 2) == 0x3e_u8
+        k += 1
+      end
+      nil
+    end
+
+    # The attribute region between a tag name and '>': attribute names → syn_number (the
+    # palette's reserved "tag attribute names" slot), '=' muted, quoted values ("…"/'…')
+    # → syn_string, '/' (self-close) muted, whitespace/other → body text. `after_eq`
+    # keeps an UNQUOTED value (e.g. `type=text`) body-coloured rather than as a name.
+    private def self.attr_spans(seg : String) : Line
+      spans = [] of Span
+      b = seg.to_slice
+      n = b.size
+      i = 0
+      after_eq = false
+      while i < n
+        c = b.unsafe_fetch(i)
+        if c == 0x22_u8 || c == 0x27_u8 # '"' / '\'' quoted value (to the matching quote or EOL)
+          quote = c
+          start = i
+          i += 1
+          while i < n && b.unsafe_fetch(i) != quote
+            i += 1
+          end
+          i += 1 if i < n # include the closing quote
+          spans << Span.new(seg.byte_slice(start, {i, n}.min - start), Theme.syn_string)
+          after_eq = false
+        elsif c == 0x3d_u8 # '='
+          spans << Span.new(seg.byte_slice(i, 1), Theme.muted)
+          i += 1
+          after_eq = true
+        elsif c == 0x2f_u8 # '/' self-closing
+          spans << Span.new(seg.byte_slice(i, 1), Theme.muted)
+          i += 1
+        elsif tag_name?(c)
+          start = i
+          i += 1
+          while i < n && tag_name?(b.unsafe_fetch(i))
+            i += 1
+          end
+          spans << Span.new(seg.byte_slice(start, i - start), after_eq ? Theme.text : Theme.syn_number)
+          after_eq = false
+        else
+          start = i
+          i += 1
+          while i < n
+            d = b.unsafe_fetch(i)
+            break if d == 0x22_u8 || d == 0x27_u8 || d == 0x3d_u8 || d == 0x2f_u8 || tag_name?(d)
+            i += 1
+          end
+          spans << Span.new(seg.byte_slice(start, i - start), Theme.text)
+          after_eq = false
         end
       end
       spans

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -1895,7 +1895,7 @@ module Gori::Tui
 
     private def graphql_detail_lines(op : Graphql::Op) : Array(Highlight::Line)
       lines = [] of Highlight::Line
-      append_styled(lines, Graphql.display(op), :text)
+      append_styled(lines, Graphql.display(op), :graphql)
       lines
     end
 

--- a/src/gori/tui/theme.cr
+++ b/src/gori/tui/theme.cr
@@ -37,7 +37,8 @@ module Gori::Tui
       focus_gold : Color, accent : Color, accent_bg : Color, selection_dim : Color,
       text : Color, text_bright : Color, muted : Color,
       green : Color, yellow : Color, red : Color, orange : Color,
-      syn_header : Color, syn_string : Color, syn_number : Color, syn_literal : Color
+      syn_header : Color, syn_string : Color, syn_number : Color, syn_literal : Color,
+      syn_comment : Color, syn_keyword : Color
 
     GORIDARK = Palette.new(
       bg: Color.from_hex("#0a0a0b"),            # near-black canvas
@@ -61,6 +62,8 @@ module Gori::Tui
       syn_string: Color.from_hex("#8fb87a"),  # quoted strings
       syn_number: Color.from_hex("#ca9b6a"),  # numbers, tag attribute names
       syn_literal: Color.from_hex("#b08ec2"), # true / false / null
+      syn_comment: Color.from_hex("#6f8172"), # comments (GraphQL #, JSONC //, HTML <!-- -->)
+      syn_keyword: Color.from_hex("#d08c9a"), # language keywords / auth schemes
     )
 
     # The GORIDARK relationships inverted onto an off-white canvas: BG lightest,
@@ -88,6 +91,8 @@ module Gori::Tui
       syn_string: Color.from_hex("#2f7a30"),    # quoted strings (AA: 5.1:1)
       syn_number: Color.from_hex("#9c5d1f"),    # numbers, tag attribute names
       syn_literal: Color.from_hex("#864f9e"),   # true / false / null
+      syn_comment: Color.from_hex("#6d774f"),   # comments (GraphQL #, JSONC //, HTML <!-- -->)
+      syn_keyword: Color.from_hex("#a8386a"),   # language keywords / auth schemes
     )
 
     # A soft, cool light palette inspired by Catppuccin Latte: a lavender-grey
@@ -116,6 +121,8 @@ module Gori::Tui
       syn_string: Color.from_hex("#2f7d1f"),    # quoted strings (green)
       syn_number: Color.from_hex("#bd2f43"),    # numbers, tag attribute names (maroon)
       syn_literal: Color.from_hex("#7a30d6"),   # true / false / null (mauve)
+      syn_comment: Color.from_hex("#616a4d"),   # comments (green-grey)
+      syn_keyword: Color.from_hex("#b83a8f"),   # language keywords / auth schemes (magenta)
     )
 
     # A warm, slightly muddy dark-brown palette: espresso-brown canvas, tan body
@@ -142,6 +149,8 @@ module Gori::Tui
       syn_string: Color.from_hex("#a3b16a"),  # quoted strings (olive)
       syn_number: Color.from_hex("#d99356"),  # numbers, tag attribute names (warm orange)
       syn_literal: Color.from_hex("#c79bc0"), # true / false / null (dusty mauve)
+      syn_comment: Color.from_hex("#9c8c6c"), # comments (dim tan)
+      syn_keyword: Color.from_hex("#db9aa8"), # language keywords / auth schemes (dusty rose)
     )
 
     # The popular Tokyo Night palette: deep blue-purple canvas with bright,
@@ -169,6 +178,8 @@ module Gori::Tui
       syn_string: Color.from_hex("#9ece6a"),  # quoted strings (green)
       syn_number: Color.from_hex("#ff9e64"),  # numbers, tag attribute names (orange)
       syn_literal: Color.from_hex("#bb9af7"), # true / false / null (magenta)
+      syn_comment: Color.from_hex("#6b74a3"), # comments (lifted blue-grey)
+      syn_keyword: Color.from_hex("#f294a4"), # language keywords / auth schemes (rose)
     )
 
     # The warm retro Gruvbox (dark, medium) palette: a muddy brown-grey canvas with
@@ -195,6 +206,8 @@ module Gori::Tui
       syn_string: Color.from_hex("#b8bb26"),    # quoted strings (green)
       syn_number: Color.from_hex("#d3869b"),    # numbers, tag attribute names (purple)
       syn_literal: Color.from_hex("#8ec07c"),   # true / false / null (aqua)
+      syn_comment: Color.from_hex("#928374"),   # comments (gruvbox gray)
+      syn_keyword: Color.from_hex("#f2846b"),   # language keywords / auth schemes (red-orange)
     )
 
     # The cool arctic Nord palette: a desaturated blue-grey (Polar Night) canvas with
@@ -221,6 +234,8 @@ module Gori::Tui
       syn_string: Color.from_hex("#a3be8c"),    # quoted strings (green)
       syn_number: Color.from_hex("#d3a3b3"),    # numbers, tag attribute names (soft maroon)
       syn_literal: Color.from_hex("#c49bc0"),   # true / false / null (lifted purple)
+      syn_comment: Color.from_hex("#859bb0"),   # comments (frost grey)
+      syn_keyword: Color.from_hex("#8fb0d6"),   # language keywords / auth schemes (frost blue)
     )
 
     # The popular high-contrast Dracula palette: a blue-tinted charcoal canvas with
@@ -248,6 +263,8 @@ module Gori::Tui
       syn_string: Color.from_hex("#f1fa8c"),  # quoted strings (yellow)
       syn_number: Color.from_hex("#bd93f9"),  # numbers, tag attribute names (purple)
       syn_literal: Color.from_hex("#ff79c6"), # true / false / null (pink)
+      syn_comment: Color.from_hex("#7d8ac2"), # comments (lifted dracula comment)
+      syn_keyword: Color.from_hex("#bd93f9"), # language keywords / auth schemes (purple)
     )
 
     # The iconic Solarized Light palette: a warm cream/beige "paper" canvas (base3)
@@ -276,6 +293,8 @@ module Gori::Tui
       syn_string: Color.from_hex("#5e6b00"),    # quoted strings (green)
       syn_number: Color.from_hex("#167068"),    # numbers, tag attribute names (cyan)
       syn_literal: Color.from_hex("#6455bd"),   # true / false / null (violet)
+      syn_comment: Color.from_hex("#6b7266"),   # comments (base grey)
+      syn_keyword: Color.from_hex("#b32d6e"),   # language keywords / auth schemes (magenta)
     )
 
     # The Rosé Pine Dawn palette: a soft rosy "paper" canvas with muted blue-violet
@@ -302,6 +321,8 @@ module Gori::Tui
       syn_string: Color.from_hex("#467730"),    # quoted strings (sage green)
       syn_number: Color.from_hex("#96611e"),    # numbers, tag attribute names (warm brown)
       syn_literal: Color.from_hex("#7a5fa0"),   # true / false / null (dawn iris)
+      syn_comment: Color.from_hex("#6f6a54"),   # comments (muted olive)
+      syn_keyword: Color.from_hex("#a5445f"),   # language keywords / auth schemes (dawn rose)
     )
 
     # The popular Catppuccin Mocha palette: a dark blue-purple canvas with the
@@ -328,6 +349,8 @@ module Gori::Tui
       syn_string: Color.from_hex("#a6e3a1"),    # quoted strings (green)
       syn_number: Color.from_hex("#fab387"),    # numbers, tag attribute names (peach)
       syn_literal: Color.from_hex("#cba6f7"),   # true / false / null (mauve)
+      syn_comment: Color.from_hex("#787c94"),   # comments (overlay grey)
+      syn_keyword: Color.from_hex("#f2a0bd"),   # language keywords / auth schemes (pink)
     )
 
     # The classic Monokai code-editor palette: an olive-dark canvas with the
@@ -355,6 +378,8 @@ module Gori::Tui
       syn_string: Color.from_hex("#e6db74"),    # quoted strings (yellow)
       syn_number: Color.from_hex("#fd971f"),    # numbers, tag attribute names (orange)
       syn_literal: Color.from_hex("#ae81ff"),   # true / false / null (purple)
+      syn_comment: Color.from_hex("#8f8b76"),   # comments (lifted monokai comment)
+      syn_keyword: Color.from_hex("#f76ea0"),   # language keywords / auth schemes (pink)
     )
 
     # A muted, forest-green-toned dark palette inspired by Everforest: a soft
@@ -382,6 +407,8 @@ module Gori::Tui
       syn_string: Color.from_hex("#a7c080"),    # quoted strings (green)
       syn_number: Color.from_hex("#e69875"),    # numbers, tag attribute names (orange)
       syn_literal: Color.from_hex("#d699b6"),   # true / false / null (purple)
+      syn_comment: Color.from_hex("#87968b"),   # comments (everforest grey)
+      syn_keyword: Color.from_hex("#e59aa0"),   # language keywords / auth schemes (soft red)
     )
 
     # The Atom/VS Code One Dark palette: a blue-grey canvas with the recognizable
@@ -409,6 +436,8 @@ module Gori::Tui
       syn_string: Color.from_hex("#98c379"),  # quoted strings (green)
       syn_number: Color.from_hex("#d19a66"),  # numbers, tag attribute names (orange)
       syn_literal: Color.from_hex("#c678dd"), # true / false / null (purple)
+      syn_comment: Color.from_hex("#848e81"), # comments (lifted comment grey)
+      syn_keyword: Color.from_hex("#e08b93"), # language keywords / auth schemes (rose)
     )
 
     # The Kanagawa (Wave) palette, after Hokusai's Great Wave: a sumi-ink canvas
@@ -435,6 +464,8 @@ module Gori::Tui
       syn_string: Color.from_hex("#98bb6c"),    # quoted strings (spring green)
       syn_number: Color.from_hex("#d27e99"),    # numbers, tag attribute names (sakura pink)
       syn_literal: Color.from_hex("#957fb8"),   # true / false / null (oni violet, 4.7:1)
+      syn_comment: Color.from_hex("#847f74"),   # comments (lifted fuji grey)
+      syn_keyword: Color.from_hex("#e0899a"),   # language keywords / auth schemes (wave red)
     )
 
     # The GitHub (Primer) dark palette: the near-black canvas of github.com's dark
@@ -461,6 +492,8 @@ module Gori::Tui
       syn_string: Color.from_hex("#a5d6ff"),  # quoted strings (GitHub's light-blue strings)
       syn_number: Color.from_hex("#ffa657"),  # numbers, tag attribute names (orange)
       syn_literal: Color.from_hex("#d2a8ff"), # true / false / null (purple)
+      syn_comment: Color.from_hex("#7d8590"), # comments (primer fg muted)
+      syn_keyword: Color.from_hex("#ff7b72"), # language keywords / auth schemes (coral)
     )
 
     # The classic Zenburn palette: the famously easy-on-the-eyes mid-grey canvas
@@ -487,6 +520,8 @@ module Gori::Tui
       syn_string: Color.from_hex("#dca3a3"),  # quoted strings (zenburn's rose strings)
       syn_number: Color.from_hex("#dfaf8f"),  # numbers, tag attribute names (variable orange)
       syn_literal: Color.from_hex("#e39ccd"), # true / false / null (lifted magenta, 5.0:1)
+      syn_comment: Color.from_hex("#8faf8f"), # comments (zenburn green-grey)
+      syn_keyword: Color.from_hex("#efb3b3"), # language keywords / auth schemes (rose)
     )
 
     # The GitHub (Primer) light palette: github.com's light mode on a pure-white
@@ -513,6 +548,8 @@ module Gori::Tui
       syn_string: Color.from_hex("#116329"),    # quoted strings (markup green)
       syn_number: Color.from_hex("#953800"),    # numbers, tag attribute names (severe orange)
       syn_literal: Color.from_hex("#8250df"),   # true / false / null (done purple, 5.1:1)
+      syn_comment: Color.from_hex("#5f6a52"),   # comments (green-grey, 5.7:1)
+      syn_keyword: Color.from_hex("#99286e"),   # language keywords / auth schemes (deep pink, 7.3:1)
     )
 
     # The Gruvbox light palette — GRUVBOX's warm cream counterpart: bg0 paper with
@@ -540,6 +577,8 @@ module Gori::Tui
       syn_string: Color.from_hex("#6d680c"),    # quoted strings (green)
       syn_number: Color.from_hex("#af3a03"),    # numbers, tag attribute names (orange)
       syn_literal: Color.from_hex("#8f3f71"),   # true / false / null (faded purple, 5.9:1)
+      syn_comment: Color.from_hex("#6f6a4a"),   # comments (olive, 4.8:1)
+      syn_keyword: Color.from_hex("#9d0658"),   # language keywords / auth schemes (berry, 7.1:1)
     )
 
     # The Atom One Light palette: a soft grey-white canvas with ONEDARK's accent
@@ -566,6 +605,8 @@ module Gori::Tui
       syn_string: Color.from_hex("#3f7d3e"),    # quoted strings (green)
       syn_number: Color.from_hex("#986801"),    # numbers, tag attribute names (gold)
       syn_literal: Color.from_hex("#a626a4"),   # true / false / null (magenta, 5.9:1)
+      syn_comment: Color.from_hex("#5f6a4f"),   # comments (green-grey, 5.5:1)
+      syn_keyword: Color.from_hex("#b02a6e"),   # language keywords / auth schemes (rose, 5.9:1)
     )
 
     # The Ayu Light palette: a bright near-white canvas with Ayu's signature warm
@@ -592,6 +633,8 @@ module Gori::Tui
       syn_string: Color.from_hex("#547a00"),    # quoted strings (lime)
       syn_number: Color.from_hex("#ab5510"),    # numbers, tag attribute names (orange)
       syn_literal: Color.from_hex("#8054b8"),   # true / false / null (darkened constant purple, 5.3:1)
+      syn_comment: Color.from_hex("#6a7250"),   # comments (green-grey, 5.0:1)
+      syn_keyword: Color.from_hex("#9c3a86"),   # language keywords / auth schemes (magenta, 6.1:1)
     )
 
     BUILTIN_THEMES = {"goridark" => GORIDARK, "goriday" => GORIDAY, "latte" => LATTE, "espresso" => ESPRESSO, "tokyonight" => TOKYONIGHT, "gruvbox" => GRUVBOX, "nord" => NORD, "dracula" => DRACULA, "solarized_light" => SOLARIZED_LIGHT, "rosepine_dawn" => ROSEPINE_DAWN, "catppuccin_mocha" => CATPPUCCIN_MOCHA, "monokai" => MONOKAI, "everforest" => EVERFOREST, "onedark" => ONEDARK, "kanagawa" => KANAGAWA, "github_dark" => GITHUB_DARK, "zenburn" => ZENBURN, "github_light" => GITHUB_LIGHT, "gruvbox_light" => GRUVBOX_LIGHT, "one_light" => ONE_LIGHT, "ayu_light" => AYU_LIGHT}
@@ -720,7 +763,7 @@ module Gori::Tui
     private def self.merge_palette(base : Palette, root : JSON::Any) : Palette
       {% begin %}
         Palette.new(
-          {% for f in %w(bg panel elevated border border_focus focus_gold accent accent_bg selection_dim text text_bright muted green yellow red orange syn_header syn_string syn_number syn_literal) %}
+          {% for f in %w(bg panel elevated border border_focus focus_gold accent accent_bg selection_dim text text_bright muted green yellow red orange syn_header syn_string syn_number syn_literal syn_comment syn_keyword) %}
             {{ f.id }}: color_field(root, {{ f }}, base.{{ f.id }}),
           {% end %}
         )
@@ -741,7 +784,7 @@ module Gori::Tui
 
     # Colour accessors generated from the Palette fields. Each reads the active
     # palette, so call sites (`Theme.bg`, `Theme.accent`, …) re-theme automatically.
-    {% for name in %w(bg panel elevated border border_focus focus_gold accent accent_bg selection_dim text text_bright muted green yellow red orange syn_header syn_string syn_number syn_literal) %}
+    {% for name in %w(bg panel elevated border border_focus focus_gold accent accent_bg selection_dim text text_bright muted green yellow red orange syn_header syn_string syn_number syn_literal syn_comment syn_keyword) %}
       def self.{{ name.id }} : Color
         @@active.{{ name.id }}
       end


### PR DESCRIPTION
## What

The Request/Response viewers only highlighted the message *skeleton* (request/status line, header names, and four body languages). Everything else fell flat to `Theme.text`. This deepens the shared `Highlight` tokenizers so the panes read like a real editor, and extends coverage to the Fuzzer and Comparer.

All highlighting flows through one seam (`Gori::Tui::Highlight`), so History / Repeater / Intercept / request editors get these for free; Fuzzer and Comparer are wired explicitly.

### Highlighting
- **Request line** — break the target into `path` + `?query` (keys `syn_header`, `&`/`=` muted).
- **Header values** — cookies (`name=value` + `Path`/`HttpOnly`/… attrs), `Authorization` (scheme vs credential), generic param keys. A structureless value (Host/Date) stays a single `text` span.
- **HTML/XML** — attribute names → `syn_number` (realises the palette's reserved intent), quoted values `syn_string`, `<!-- -->` comments, `<!DOCTYPE>`/`<?xml?>` declarations.
- **JSON** — JSONC `//` line comments (colours the JWT `// header` / `// payload` markers).
- **GraphQL** — new `:graphql` lexer (keywords, `$vars`, `@directives`, field/type names, `#` comments).
- **Pretty** — JWT decoded body → `:json`, GraphQL → `:graphql` (were `:text`).

### Palette
Two themeable syntax colours (`syn_comment`, `syn_keyword`) across all 21 built-in palettes, guarded by the theme contrast spec (`syn_keyword` ≥ 4.5:1, `syn_comment` ≥ 3.5:1 dim tier).

### New surfaces
- **Fuzzer** result detail pane (`detail_styled`, cached per pane/row/theme).
- **Comparer** — unchanged (`same`) rows only; changed rows keep their red/green diff colours. Styling is capped to `Diff::MAX_LINES` so never-shown lines aren't coloured.

## Invariants preserved
- Styled output stays 1:1 in line count with `split('\n')`; span texts concatenate back to the exact line.
- Byte-scan tokenizers, per line, `MAX_HL_LINE` fallback intact.
- All new tokenization is memoized on the render hot path; benchmark: per-line tokenizers 540–610ns, one-time eager styling 0.3–1.2ms typical.

## Testing
- `crystal spec` — **1953 examples, 0 failures**. Added 11 highlight specs (query, cookie, auth, HTML attrs, JSONC, GraphQL) + updated the byte-vs-char fuzz reference and the pretty/theme kind+contrast assertions.
- Live TUI (tmux + ANSI): verified request query/auth/cookie, response HTML attrs/`<!doctype>`, Comparer same-row header/attr colours, Fuzzer template.