### PR TITLE
feat(tui): guard CHAIN marker edits in INS mode

### DIFF
--- a/spec/fuzz_spec.cr
+++ b/spec/fuzz_spec.cr
@@ -198,6 +198,44 @@ describe F::Template do
     # chain-less marker: sep == close
     F::Template.marker_regions("a=§1§").should eq([{2, 4, 4}])
   end
+
+  it "structural_marker_at flags the delimiters/separator of a closed marker" do
+    text = "a=§1¦rot13§&b=§2§" # marker1 [2,11): §@2 ¦@4 §@10 ; marker2 [14,17): §@14 2@15 §@16
+    span1 = {2, 11}
+    span2 = {14, 17}
+    # opening §, the ¦ separator, and the closing § are all structural
+    F::Template.structural_marker_at(text, 2).should eq(span1)  # opening §
+    F::Template.structural_marker_at(text, 4).should eq(span1)  # ¦ separator
+    F::Template.structural_marker_at(text, 10).should eq(span1) # closing §
+    F::Template.structural_marker_at(text, 16).should eq(span2) # chain-less closing §
+    F::Template.structural_marker_at(text, 15).should be_nil    # the "2" value byte
+    # a value byte, a byte in the concealed chain, and text outside a marker are NOT structural
+    F::Template.structural_marker_at(text, 3).should be_nil  # the "1" value
+    F::Template.structural_marker_at(text, 5).should be_nil  # inside "rot13"
+    F::Template.structural_marker_at(text, 0).should be_nil  # "a"
+    F::Template.structural_marker_at(text, -1).should be_nil # buffer start (backspace guard)
+    # a §/¦ OUTSIDE every closed marker (escaped literal / unbalanced) folds to text
+    F::Template.structural_marker_at("a§§b", 1).should be_nil
+    F::Template.structural_marker_at("a§b", 1).should be_nil
+  end
+
+  it "insert_breaks_marker? escapes a §/¦ inside or flush against a marker, not in open text" do
+    text = "a=§1§&b"                                                # marker [2,5): §@2 1@3 §@4
+    F::Template.insert_breaks_marker?(text, 3, '§').should be_true  # strictly inside → escape
+    F::Template.insert_breaks_marker?(text, 3, '¦').should be_true  # separator inside → escape
+    F::Template.insert_breaks_marker?(text, 2, '§').should be_true  # flush against the opener (forms §§)
+    F::Template.insert_breaks_marker?(text, 5, '§').should be_true  # flush past the closer (forms §§)
+    F::Template.insert_breaks_marker?(text, 3, 'x').should be_false # a normal char is never escaped
+    F::Template.insert_breaks_marker?(text, 6, '§').should be_false # open text → let a fresh §…§ be typed
+    F::Template.insert_breaks_marker?("plain", 2, '§').should be_false
+  end
+
+  it "strip_marker drops the whole marker (both § and the ¦chain), leaving the raw value" do
+    # chained marker: value survives, ¦chain + both § are gone; caret lands past the value
+    F::Template.strip_marker("a=§secret¦base64-encode§&b", {2, 24}).should eq({"a=secret&b", 8})
+    # chain-less marker
+    F::Template.strip_marker("a=§1§&b", {2, 5}).should eq({"a=1&b", 3})
+  end
 end
 
 describe F::ContentLength do

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -43,6 +43,29 @@ describe Gori::Tui::FuzzerView do
     grid2.should_not contain("§x¦rot13§")
   end
 
+  describe "marker structure guard (INS editing)" do
+    it "auto-escapes a § typed inside a template marker (structure survives)" do
+      view = FuzzerView.new
+      view.load_request("https://a", "§ab§ HTTP/1.1\r\nHost: a\r\n\r\n", false, "")
+      view.focus_pane(:template)
+      view.template_move(0, 2) # caret between a and b
+      view.template_insert('§')
+      view.template_text.lines.first.should eq("§a§§b§ HTTP/1.1")
+      Gori::Fuzz::Template.marked_spans(view.template_text).size.should eq(1)
+    end
+
+    it "flags a delimiter delete and strips the whole marker to its value on confirm" do
+      view = FuzzerView.new
+      view.load_request("https://a", "§secret¦base64-encode§ HTTP/1.1\r\nHost: a\r\n\r\n", false, "")
+      view.focus_pane(:template)
+      view.template_move(0, 1) # caret just past the opening §
+      view.marker_break_on_backspace.should eq({0, 22})
+      view.strip_marker_span({0, 22})
+      view.template_text.lines.first.should eq("secret HTTP/1.1")
+      Gori::Fuzz::Template.marked_spans(view.template_text).should be_empty
+    end
+  end
+
   it "toggle_http2 flips the transport and retargets the template request-line version" do
     view = loaded_fuzzer
     view.http2?.should be_false

--- a/spec/tui/repeater_view_spec.cr
+++ b/spec/tui/repeater_view_spec.cr
@@ -343,6 +343,39 @@ describe Gori::Tui::RepeaterView do
     view.request_text.should contain("§v¦md5§")
   end
 
+  describe "marker structure guard (INS editing)" do
+    it "auto-escapes a § typed inside a marker so the ¦chain never leaks" do
+      view = RepeaterView.new
+      view.restore("https://a.test", "§ab§ HTTP/1.1\nHost: a.test\n\n", false, false)
+      view.focus_pane(:request)
+      view.edit_move(0, 2) # caret between a and b, inside the value
+      view.edit_insert('§')
+      view.request_text.lines.first.should eq("§a§§b§ HTTP/1.1")             # §§ escaped literal
+      Gori::Fuzz::Template.marked_spans(view.request_text).size.should eq(1) # still ONE marker
+    end
+
+    it "flags a backspace/forward-delete that would remove a marker delimiter" do
+      view = RepeaterView.new
+      view.restore("https://a.test", "§secret¦base64-encode§ HTTP/1.1\nHost: a.test\n\n", false, false)
+      view.focus_pane(:request)
+      view.edit_move(0, 1) # caret just past the opening §
+      view.marker_break_on_backspace.should eq({0, 22})
+      view.edit_move(0, 6)                           # caret on the ¦ separator (offset 7)
+      view.marker_break_on_delete.should eq({0, 22}) # forward-delete of ¦ would break it
+      view.edit_move(0, -4)                          # caret inside "secret" (offset 3)
+      view.marker_break_on_backspace.should be_nil   # a value byte is not a delimiter
+    end
+
+    it "strips the WHOLE marker (both § and ¦chain) on confirm, keeping only the value" do
+      view = RepeaterView.new
+      view.restore("https://a.test", "§secret¦base64-encode§ HTTP/1.1\nHost: a.test\n\n", false, false)
+      view.focus_pane(:request)
+      view.strip_marker_span({0, 22})
+      view.request_text.lines.first.should eq("secret HTTP/1.1")
+      Gori::Fuzz::Template.marked_spans(view.request_text).should be_empty
+    end
+  end
+
   it "CHAIN pane hints when the cursor isn't in a §…§ marker" do
     view = RepeaterView.new
     view.restore("https://a.test", "GET / HTTP/1.1\n\n", false, false)

--- a/spec/tui/text_area_spec.cr
+++ b/spec/tui/text_area_spec.cr
@@ -94,6 +94,32 @@ describe Gori::Tui::TextArea do
     end
   end
 
+  describe "#insert_pair (marker escape §§/¦¦)" do
+    it "inserts the char twice as one undoable unit, caret past both" do
+      ta = TextArea.new("ab")
+      ta.end_of_line
+      ta.insert_pair('§')
+      ta.text.should eq("ab§§")
+      ta.cx.should eq(4)
+      ta.undo # a single undo removes the whole pair
+      ta.text.should eq("ab")
+    end
+  end
+
+  describe "#replace_all (undoable full-buffer swap)" do
+    it "swaps the buffer, places the caret, and stays undoable (unlike set_text)" do
+      ta = TextArea.new("q=§secret¦base64-encode§")
+      ta.insert('X') # a prior edit that must survive as undoable
+      ta.replace_all("q=secretX", 9)
+      ta.text.should eq("q=secretX")
+      ta.cx.should eq(9)
+      ta.undo # reverts the strip...
+      ta.text.should eq("Xq=§secret¦base64-encode§")
+      ta.undo # ...and the earlier insert is still on the stack
+      ta.text.should eq("q=§secret¦base64-encode§")
+    end
+  end
+
   describe "#home / #end_of_line" do
     it "jumps the caret to the start / end of the current line (insert lands there)" do
       ta = TextArea.new("abc")

--- a/src/gori/fuzz/template.cr
+++ b/src/gori/fuzz/template.cr
@@ -297,6 +297,48 @@ module Gori::Fuzz
       "#{chars[0, a + 1].join}#{interior}#{chars[close..].join}"
     end
 
+    # The closed `§…§` span `{a, b}` (b == closing-§ index + 1) whose STRUCTURE the
+    # char at char-index `idx` belongs to — an opening/closing `§`, the `¦` value|chain
+    # separator, or an escaped `§§`/`¦¦` delimiter half inside — or nil when `idx` isn't
+    # such a char. Deleting any of these unbalances the marker (and exposes its concealed
+    # `¦chain`), so the TUI editor guards a backspace/forward-delete of them behind a
+    # confirm. A normal value byte, or a `§`/`¦` OUTSIDE every closed marker (e.g. an
+    # escaped literal that folds to plain text), returns nil. `spans` defaults to a fresh
+    # `marked_spans`; pass the view's cached one to skip a re-scan.
+    def self.structural_marker_at(text : String, idx : Int32,
+                                  spans : Array({Int32, Int32}) = marked_spans(text)) : {Int32, Int32}?
+      return nil if idx < 0
+      c = text[idx]?
+      return nil unless c == MARKER || c == CHAIN_SEP
+      spans.find { |(a, b)| a <= idx && idx < b } # b == close + 1, so this covers [a, close]
+    end
+
+    # Whether inserting `ch` at char-index `cursor` would drop a NEW `§`/`¦` into (or
+    # flush against) an existing closed marker `[a, b]` — i.e. `a <= cursor <= b` — which a
+    # plain insert would turn into a "marker in marker" / stray escape and unbalance the
+    # structure. The editor escapes such a char (`§§`/`¦¦`) so it survives as a literal in
+    # the value instead. Chars that can't be delimiters, and inserts in the open space
+    # BETWEEN markers, return false (so typing a fresh `§…§` by hand still works). `spans`
+    # defaults to a fresh scan; pass the cached one to skip it.
+    def self.insert_breaks_marker?(text : String, cursor : Int32, ch : Char,
+                                   spans : Array({Int32, Int32}) = marked_spans(text)) : Bool
+      return false unless ch == MARKER || ch == CHAIN_SEP
+      spans.any? { |(a, b)| a <= cursor && cursor <= b }
+    end
+
+    # Remove the closed marker at `span` (`{a, b}`: a = opening §, b-1 = closing §),
+    # leaving ONLY its raw value — both `§` delimiters AND any `¦chain` are dropped
+    # (mirrors `mark_word`'s unmark branch). Returns `{new_text, caret}` with the caret at
+    # the char offset just past the freed value. Fed by the delimiter-delete confirm.
+    def self.strip_marker(text : String, span : {Int32, Int32}) : {String, Int32}
+      chars = text.chars
+      a, b = span
+      close = b - 1
+      value, _ = split_raw_interior(chars[(a + 1)...close])
+      new_text = "#{chars[0, a].join}#{value.join}#{chars[b..].join}"
+      {new_text, a + value.size}
+    end
+
     # Per closed marker: {open, sep, close} char offsets — `open`/`close` index the two
     # `§`, and `sep` is the value|chain boundary `¦` (== `close` when there's no chain).
     # Lets the views tint the value and the (dimmer) chain separately; 1:1 with

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -360,16 +360,31 @@ module Gori::Tui
       key = ev.key
       case
       when key.enter?     then v.template_newline
-      when key.backspace? then v.template_backspace
+      when key.backspace? then v.template_backspace unless guard_marker_delete(v, v.marker_break_on_backspace)
       when key.up?        then template_up(v)
       when key.down?      then v.template_move(1, 0)
       when key.left?      then v.template_move(0, -1)
       when key.right?     then v.template_move(0, 1)
       when key.home?      then v.template_home
       when key.end?       then v.template_end
-      when key.delete?    then v.template_delete
+      when key.delete?    then v.template_delete unless guard_marker_delete(v, v.marker_break_on_delete)
       else
         printable(ev).try { |ch| v.template_insert(ch) }
+      end
+      true
+    end
+
+    # A backspace/forward-delete of a marker delimiter (§/¦) would unbalance the marker and
+    # expose its concealed ¦chain. Confirm first; on accept, strip the WHOLE marker down to
+    # its raw value. Returns true when it intercepted (a confirm was raised), so the caller
+    # skips the plain edit; false to let the edit through.
+    private def guard_marker_delete(v : FuzzerView, span : {Int32, Int32}?) : Bool
+      return false unless span
+      n = v.marker_ordinal(span)
+      @host.confirm("REMOVE MARKER",
+        "Deleting this character breaks marker §#{n}.\nRemove the whole marker and keep only its value?",
+        confirm_label: "remove marker", danger: true) do
+        v.strip_marker_span(span)
       end
       true
     end

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -46,7 +46,7 @@ module Gori::Tui
         view.restore(r.target, r.request, r.http2?, r.auto_content_length?,
           r.response_head, r.response_body, r.response_error, r.response_duration_us,
           sni: r.sni || "", ws_messages: ws_msgs)
-        view.name = r.name                     # custom sub-tab label survives reopen
+        view.name = r.name                       # custom sub-tab label survives reopen
         view.tags = Repeater::Tags.parse(r.tags) # flat tags survive reopen (V31)
         seed_repeater_original(view, r.flow_id)
         @repeaters << RepeaterTab.new(view, r.flow_id, r.id)
@@ -794,7 +794,7 @@ module Gori::Tui
 
     # Passive-scan a successful HTTP Repeater send into Probe (mode-gated by the analyzer).
     private def probe_scan_repeater(repeater_id : Int64, head : Bytes, body : Bytes?,
-                                  duration_us : Int64, flow_id : Int64?, view : RepeaterView) : Nil
+                                    duration_us : Int64, flow_id : Int64?, view : RepeaterView) : Nil
       return if head.empty?
       rec = Store::RepeaterRecord.new(
         repeater_id, view.target, view.request_text, view.http2?, view.auto_content_length?,
@@ -807,7 +807,7 @@ module Gori::Tui
 
     # Passive-scan a successful WebSocket Repeater transcript (handshake + text frames).
     private def probe_scan_ws_repeater(repeater_id : Int64, result : Repeater::WsEngine::Result,
-                                     flow_id : Int64?, view : RepeaterView) : Nil
+                                       flow_id : Int64?, view : RepeaterView) : Nil
       head = result.handshake_head
       return if head.empty?
       upgrade = view.ws_upgrade_bytes
@@ -990,7 +990,7 @@ module Gori::Tui
     # No source flow_id — the request is the seed; same persistence path as ^N.
     # `name` is an optional sub-tab chip label (e.g. the Miner param that was injected).
     def repeater_from_request(target : String, request_text : String, http2 : Bool, sni : String?,
-                            name : String? = nil) : Nil
+                              name : String? = nil) : Nil
       view = RepeaterView.new
       view.restore(target, request_text, http2, true, sni: sni || "")
       # restore leaves focus on :target (placeholder-friendly); a fully-built request
@@ -1247,19 +1247,34 @@ module Gori::Tui
       case
       when ev.ctrl_z?     then view.edit_undo
       when key.enter?     then view.edit_newline
-      when key.backspace? then view.edit_backspace
+      when key.backspace? then view.edit_backspace unless guard_marker_delete(view, view.marker_break_on_backspace)
       when key.up?        then view.at_top? ? view.focus_first : view.edit_move(-1, 0) # ↑-at-top → target field above
       when key.down?      then view.edit_move(1, 0)
       when key.left?      then view.edit_move(0, -1)
       when key.right?     then view.edit_move(0, 1)
       when key.home?      then view.edit_home
       when key.end?       then view.edit_end
-      when key.delete?    then view.edit_delete
+      when key.delete?    then view.edit_delete unless guard_marker_delete(view, view.marker_break_on_delete)
       else
         if c && !ev.ctrl? && !ev.alt?
           view.edit_insert(c)
           view.set_preedit("") # commit preedit
         end
+      end
+      true
+    end
+
+    # A backspace/forward-delete of a marker delimiter (§/¦) would unbalance the marker
+    # and expose its concealed ¦chain. Confirm first; on accept, strip the WHOLE marker
+    # down to its raw value. Returns true when it intercepted (a confirm was raised), so
+    # the caller skips the plain edit; false to let the edit through.
+    private def guard_marker_delete(view : RepeaterView, span : {Int32, Int32}?) : Bool
+      return false unless span
+      n = view.marker_ordinal(span)
+      @host.confirm("REMOVE MARKER",
+        "Deleting this character breaks marker §#{n}.\nRemove the whole marker and keep only its value?",
+        confirm_label: "remove marker", danger: true) do
+        view.strip_marker_span(span)
       end
       true
     end
@@ -1398,7 +1413,7 @@ module Gori::Tui
         # Transcript: no d/x/p tools; still let Global breath / copy through.
         return false if c && !ev.ctrl? && !ev.alt? && !c.control?
       when key.lower_x? then view.pane_select_line # 'x' selects the line everywhere (hex is ^X)
-      when key.lower_b? then @host.toggle_reveal  # bare `b` (Global reveal is ^B)
+      when key.lower_b? then @host.toggle_reveal   # bare `b` (Global reveal is ^B)
       when c && !ev.ctrl? && !ev.alt? && !c.control?
         return false # d diff, p pretty, y copy, Global c/i/s, …
       end

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -1165,8 +1165,39 @@ module Gori::Tui
 
     # --- template editing ----------------------------------------------------
     def template_insert(ch : Char) : Nil
-      @editor.insert(ch)
+      # Marker-in-marker guard: a §/¦ typed inside (or flush against) a closed marker is
+      # auto-escaped to a §§/¦¦ literal so the structure survives (Template.insert_breaks_marker?).
+      if Fuzz::Template.insert_breaks_marker?(@editor.text, @editor.cursor_offset, ch, marker_spans)
+        @editor.insert_pair(ch)
+      else
+        @editor.insert(ch)
+      end
       @editor.set_preedit("")
+      @dirty = true
+    end
+
+    # --- marker structure guards (delimiter delete / nesting) --------------------
+    # When a backspace here would delete a §/¦ that structures a closed marker, the {a, b}
+    # span of that marker (fed to the strip-confirm) — else nil.
+    def marker_break_on_backspace : {Int32, Int32}?
+      Fuzz::Template.structural_marker_at(@editor.text, @editor.cursor_offset - 1, marker_spans)
+    end
+
+    # Same, for a forward-delete (the char UNDER the caret).
+    def marker_break_on_delete : {Int32, Int32}?
+      Fuzz::Template.structural_marker_at(@editor.text, @editor.cursor_offset, marker_spans)
+    end
+
+    # 1-based ordinal of the closed marker at `span` — for the confirm copy ("marker §N").
+    def marker_ordinal(span : {Int32, Int32}) : Int32
+      (marker_spans.index(span) || 0) + 1
+    end
+
+    # Confirmed strip: drop the whole marker at `span`, keeping only its raw value; caret to
+    # the freed value's end. One undoable edit, so prior edits stay undoable. Dirties the tab.
+    def strip_marker_span(span : {Int32, Int32}) : Nil
+      new_text, caret = Fuzz::Template.strip_marker(@editor.text, span)
+      @editor.replace_all(new_text, caret)
       @dirty = true
     end
 

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -1691,7 +1691,14 @@ module Gori::Tui
 
     def edit_insert(ch : Char) : Nil
       return unless @focus == :request
-      req_editor.insert(ch)
+      # Marker-in-marker guard: a §/¦ typed inside (or flush against) a closed marker is
+      # auto-escaped to a §§/¦¦ literal so the structure survives (Template.insert_breaks_marker?).
+      if req_marker_editable? &&
+         Fuzz::Template.insert_breaks_marker?(@editor.text, @editor.cursor_offset, ch, marker_spans)
+        @editor.insert_pair(ch)
+      else
+        req_editor.insert(ch)
+      end
       mark_req_edit
     end
 
@@ -1744,6 +1751,35 @@ module Gori::Tui
     def edit_delete : Nil
       return unless @focus == :request
       req_editor.delete
+      mark_req_edit
+    end
+
+    # --- marker structure guards (delimiter delete / nesting) --------------------
+    # When a backspace here would delete a §/¦ that structures a closed marker, the {a, b}
+    # span of that marker (fed to the strip-confirm) — else nil. Only in the plain-HTTP
+    # request envelope, where §…§ markers render + conceal.
+    def marker_break_on_backspace : {Int32, Int32}?
+      return nil unless req_marker_editable?
+      Fuzz::Template.structural_marker_at(@editor.text, @editor.cursor_offset - 1, marker_spans)
+    end
+
+    # Same, for a forward-delete (the char UNDER the caret).
+    def marker_break_on_delete : {Int32, Int32}?
+      return nil unless req_marker_editable?
+      Fuzz::Template.structural_marker_at(@editor.text, @editor.cursor_offset, marker_spans)
+    end
+
+    # 1-based ordinal of the closed marker at `span` — for the confirm copy ("marker §N").
+    def marker_ordinal(span : {Int32, Int32}) : Int32
+      (marker_spans.index(span) || 0) + 1
+    end
+
+    # Confirmed strip: drop the whole marker at `span`, keeping only its raw value; caret to
+    # the freed value's end. One undoable edit, so prior edits stay undoable. Dirties the tab.
+    def strip_marker_span(span : {Int32, Int32}) : Nil
+      return unless @focus == :request
+      new_text, caret = Fuzz::Template.strip_marker(@editor.text, span)
+      @editor.replace_all(new_text, caret)
       mark_req_edit
     end
 
@@ -2216,6 +2252,15 @@ module Gori::Tui
 
     # §…§ char-offset spans for the current request buffer, cached on the editor revision —
     # marker_label + the CHAIN title both read it, so an unchanged buffer joins/scans once.
+    # The request editor is the plain-HTTP envelope where §…§ markers render + conceal —
+    # the only place the delimiter-delete / nesting guards apply. Hex, gRPC, WS and the
+    # decoded split pane all have their own byte semantics and CLEAR concealment, so a §
+    # there is literal payload, not a marker.
+    private def req_marker_editable? : Bool
+      @focus == :request && !request_hex? && !@grpc_mode && !@ws_mode &&
+        @decode_kind.nil? && req_editor.same?(@editor)
+    end
+
     private def marker_spans : Array({Int32, Int32})
       if @editor.edits != @marker_spans_rev
         @marker_spans_rev = @editor.edits

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -146,6 +146,34 @@ module Gori::Tui
       refresh_env_complete
     end
 
+    # Insert `ch` TWICE as one undo unit — the `§§`/`¦¦` escaped-literal pair the marker
+    # guard produces when a `§`/`¦` would otherwise nest inside (or flush against) a marker.
+    # Caret ends past both, so the literal sits behind it like a normal keystroke.
+    def insert_pair(ch : Char) : Nil
+      push_undo
+      line = @lines[@cy]
+      cx = @cx.clamp(0, line.size)
+      @lines[@cy] = "#{line[0, cx]}#{ch}#{ch}#{line[cx..]}"
+      @cx = cx + 2
+      @styled = nil
+      @edits += 1
+      refresh_env_complete
+    end
+
+    # Swap the ENTIRE buffer for `new_text` as ONE undoable edit — unlike set_text, which
+    # hard-resets and CLEARS the undo stack. Used by the marker-strip confirm so the edits
+    # made before it stay undoable. Places the caret at char offset `caret`; stale conceal
+    # offsets are dropped (the owner re-feeds fresh ones next render).
+    def replace_all(new_text : String, caret : Int32) : Nil
+      push_undo
+      @lines = new_text.split('\n').map(&.rstrip('\r'))
+      @lines = [""] if @lines.empty?
+      @conceal_spans = [] of {Int32, Int32} unless @conceal_spans.empty?
+      @styled = nil
+      @edits += 1
+      place_at_offset(caret)
+    end
+
     def insert_newline : Nil
       push_undo
       line = @lines[@cy]


### PR DESCRIPTION
## What

Editing a `§value¦chain§` marker in the Repeater request / Fuzzer template editor could unbalance it and leak the concealed `¦chain` into the body. This adds an INS-mode guard for the two ways a marker structure breaks.

### Behaviour
- **Delimiter delete** — a backspace / forward-delete of a `§`/`¦` that structures a closed marker pops a `REMOVE MARKER` confirm. Accept → the **whole** marker is stripped to its raw value (both `§` and the `¦chain` go); cancel → the edit is dropped. Applies to every marker, chained or not.
- **Marker-in-marker** — a `§`/`¦` typed inside (or flush against) a marker is **auto-escaped to `§§`/`¦¦`** so it lands as a literal in the value and the structure survives — no popup. The open space *between* markers is left alone, so a fresh `§…§` can still be typed by hand.

## How
- New `Fuzz::Template` statics: `structural_marker_at`, `insert_breaks_marker?`, `strip_marker`.
- New `TextArea` helpers: `insert_pair` (the `§§`/`¦¦` escape as one undo unit) and `replace_all` (an undoable full-buffer swap — unlike `set_text` it keeps the undo stack, so the strip stays undoable).
- Confirm reuses the existing `@host.confirm` modal — no new verb / migration / FakeContext.
- The RepeaterView guard is gated to the plain-HTTP envelope editor (hex / gRPC / WS / decoded panes clear concealment); the Fuzzer template is always plain HTTP.

## Test
- New specs: `Fuzz::Template` helpers, `TextArea#insert_pair`/`#replace_all`, and both view round-trips (auto-escape, break detection, strip). All green.
- Live tmux (Repeater): `§` backspace → popup, `y` → strips to value, `§`-inside → `§a§§b§`, `esc` → intact.

## Note
The escaped `§§` renders literally (only the `¦chain` conceals). A display-conceal of `§§`→`§` was deliberately deferred — a lone middle `§` reads like a delimiter, arguably worse.