### PR TITLE
perf(fuzz): scan Content-Length at the byte level

### DIFF
--- a/bench/fuzz_clsync_bench.cr
+++ b/bench/fuzz_clsync_bench.cr
@@ -1,0 +1,49 @@
+# ContentLength.sync micro-benchmark. sync() runs on EVERY dispatched fuzz request when
+# update_content_length is on (the default). The current implementation allocates a head
+# String (String.new(bytes[0, sep])), splits it into a per-line Array, scans each line with
+# index/strip/downcase, and separately re-walks the head in chunked?  — so even a GET query
+# fuzz (no body, no CL header) pays a String + Array allocation and two head passes only to
+# return the bytes unchanged.
+#
+# Build: crystal build bench/fuzz_clsync_bench.cr -o bin/fuzz_clsync_bench --release
+# Run:   bin/fuzz_clsync_bench
+require "benchmark"
+
+module Gori
+  class Error < Exception; end
+end
+
+require "../src/gori/fuzz/content_length"
+
+include Gori::Fuzz
+
+# 1) GET query fuzz — no body, no Content-Length header. The dominant fuzzing shape. sync
+#    must return the bytes unchanged; the fast path should allocate nothing.
+GET = ("GET /api/v1/search?q=hello+world&page=42&sort=relevance HTTP/1.1\r\n" +
+       "Host: api.example.com\r\n" +
+       "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36\r\n" +
+       "Accept: application/json\r\n" +
+       "Cookie: session=abcdef0123456789; csrf=0123456789abcdef; theme=dark; lang=en\r\n" +
+       "\r\n").to_slice
+
+# 2) POST JSON fuzz — Content-Length present, body changes each request so the value must be
+#    rewritten. The real rebuild path.
+POST = ("POST /api/v1/search HTTP/1.1\r\n" +
+        "Host: api.example.com\r\n" +
+        "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36\r\n" +
+        "Accept: application/json\r\n" +
+        "Cookie: session=abcdef0123456789; csrf=0123456789abcdef; theme=dark; lang=en\r\n" +
+        "Content-Type: application/json\r\n" +
+        "Content-Length: 12\r\n" +
+        "\r\n" +
+        %({"filter":"active-account-search-term","limit":50,"offset":0})).to_slice
+
+puts "ContentLength.sync bench"
+puts "  GET  input: #{GET.size} bytes (no CL, returns unchanged)"
+puts "  POST input: #{POST.size} bytes (CL 12 -> real body length)"
+puts
+
+Benchmark.ips do |x|
+  x.report("sync GET (no-op, common)") { ContentLength.sync(GET) }
+  x.report("sync POST (rewrite CL)  ") { ContentLength.sync(POST) }
+end

--- a/src/gori/fuzz/content_length.cr
+++ b/src/gori/fuzz/content_length.cr
@@ -8,7 +8,15 @@ module Gori::Fuzz
   # touches an existing header. This rewrites ONLY the head and splices the body slice
   # back byte-exact, so a binary payload survives. h1 and h2 are handled identically —
   # for h2 the header simply needs to agree with the DATA frames H2Engine emits.
+  #
+  # Runs on EVERY dispatched request (the dispatcher fiber is a single-threaded
+  # serialization point), so the head is scanned at the BYTE level: the common GET /
+  # no-Content-Length shape returns the input untouched with zero allocation, and the
+  # rewrite path never materializes a head String or a per-line Array. The output is
+  # byte-for-byte identical to the old split/rejoin implementation.
   module ContentLength
+    CL_CANON = "Content-Length: " # canonical header prefix the rewrite emits
+
     # Returns `bytes` with its `Content-Length` header set to the real body length.
     # No-ops when: there's no head/body boundary (a bare request), the body is
     # `Transfer-Encoding: chunked` (CL is unused — chunk re-framing is out of scope),
@@ -19,29 +27,152 @@ module Gori::Fuzz
 
       body_start = sep + sep_w
       body_len = bytes.size - body_start
-      head = String.new(bytes[0, sep])
-      # chunked? MUST tokenize on LF (see its comment), NOT on `eol` — so it can't share the
-      # `lines` array below (which splits on eol for a byte-exact rewrite). They diverge on a
-      # CRLF head carrying a bare internal LF, a framing the fuzzer deliberately crafts.
-      return bytes if chunked?(head)
+      cl = find_cl_line(bytes, sep, eol) # {line_start, line_end} of the CL header, or nil
 
-      lines = head.split(eol)
-      idx = lines.index { |l| header_name?(l, "content-length") }
-      if idx
-        return bytes if lines[idx] == "Content-Length: #{body_len}" # already correct
-        lines[idx] = "Content-Length: #{body_len}"
-      elsif add_when_missing && body_len > 0
-        lines << "Content-Length: #{body_len}"
-      else
-        return bytes
+      if cl.nil?
+        # No Content-Length header. Both the "leave GETs clean" default and a chunked
+        # request return the input unchanged, so we never build a head String or run the
+        # chunked scan on this (dominant) path — only when actually adding a header.
+        return bytes unless add_when_missing && body_len > 0
+        return bytes if chunked?(bytes, sep, eol)
+        return append_cl(bytes, sep, body_start, body_len, eol)
       end
 
+      # CL present: a chunked request keeps its (unused) header verbatim (out of scope).
+      return bytes if chunked?(bytes, sep, eol)
+      ls, le = cl
+      # Skip the rebuild when the line is already exactly the canonical form we'd emit —
+      # same early-out as the old `lines[idx] == "Content-Length: #{body_len}"` guard.
+      canon = "#{CL_CANON}#{body_len}"
+      return bytes if line_eq?(bytes, ls, le, canon)
+      replace_cl(bytes, ls, le, sep, body_start, body_len, eol, canon)
+    end
+
+    # ── head scanning (byte level, no String/Array allocation) ────────────────────
+
+    # Byte range `{line_start, line_end}` of the Content-Length header line within the
+    # head `[0, sep)`, or nil when absent. `line_end` is the index of the terminating
+    # `eol` (or `sep` for the last header line). Header lines split on `eol`; the name is
+    # matched case-insensitively with leading/trailing ASCII whitespace stripped and a
+    # colon required past the line start — 1:1 with the old `header_name?`.
+    private def self.find_cl_line(bytes : Bytes, sep : Int32, eol : String) : {Int32, Int32}?
+      a = 0
+      while a < sep
+        le = line_end(bytes, a, sep, eol)
+        return {a, le} if cl_line?(bytes, a, le)
+        a = le >= sep ? sep : le + eol.bytesize
+      end
+      nil
+    end
+
+    # Index of the `eol` sequence starting at or after `a` (bounded by `sep`), or `sep`
+    # when the line runs to the head boundary. Splits on the SAME `eol` the boundary
+    # picked, so a bare LF inside a CRLF head stays part of one line (as split(eol) did).
+    private def self.line_end(bytes : Bytes, a : Int32, sep : Int32, eol : String) : Int32
+      if eol.bytesize == 2 # "\r\n"
+        i = a
+        while i + 1 < sep
+          return i if bytes[i] == 0x0d_u8 && bytes[i + 1] == 0x0a_u8
+          i += 1
+        end
+        sep
+      else # "\n"
+        i = a
+        while i < sep
+          return i if bytes[i] == 0x0a_u8
+          i += 1
+        end
+        sep
+      end
+    end
+
+    # True when the line `[a, le)` is the `content-length` header (case-insensitive,
+    # ignoring surrounding ASCII whitespace, colon required past the line start).
+    private def self.cl_line?(bytes : Bytes, a : Int32, le : Int32) : Bool
+      colon = colon_of(bytes, a, le)
+      return false unless colon > a
+      ns, ne = trim_range(bytes, a, colon)
+      name_eq_ci?(bytes, ns, ne, "content-length")
+    end
+
+    # Index of the first `:` in `[a, e)`, or -1 when absent.
+    private def self.colon_of(bytes : Bytes, a : Int32, e : Int32) : Int32
+      i = a
+      while i < e
+        return i if bytes[i] == 0x3a_u8 # ':'
+        i += 1
+      end
+      -1
+    end
+
+    # `[a, e)` with leading/trailing ASCII whitespace removed (mirrors String#strip).
+    private def self.trim_range(bytes : Bytes, a : Int32, e : Int32) : {Int32, Int32}
+      s = a
+      t = e
+      while s < t && ws?(bytes[s])
+        s += 1
+      end
+      while t > s && ws?(bytes[t - 1])
+        t -= 1
+      end
+      {s, t}
+    end
+
+    # Case-insensitive ASCII compare of `bytes[s, e)` to `name` (already lowercase).
+    private def self.name_eq_ci?(bytes : Bytes, s : Int32, e : Int32, name : String) : Bool
+      return false unless e - s == name.bytesize
+      k = 0
+      while k < name.bytesize
+        b = bytes[s + k]
+        b |= 0x20_u8 if b >= 0x41_u8 && b <= 0x5a_u8 # A-Z → a-z
+        return false unless b == name.to_unsafe[k]
+        k += 1
+      end
+      true
+    end
+
+    # True when the head line `[ls, le)` equals `canon` byte-for-byte.
+    private def self.line_eq?(bytes : Bytes, ls : Int32, le : Int32, canon : String) : Bool
+      return false unless le - ls == canon.bytesize
+      k = 0
+      while k < canon.bytesize
+        return false unless bytes[ls + k] == canon.to_unsafe[k]
+        k += 1
+      end
+      true
+    end
+
+    private def self.ws?(b : UInt8) : Bool
+      b == 0x20_u8 || b == 0x09_u8 || b == 0x0a_u8 || b == 0x0d_u8 || b == 0x0b_u8 || b == 0x0c_u8
+    end
+
+    # ── rebuild (only when the value actually changes) ────────────────────────────
+
+    # Replace the CL header line in place with the canonical form, keeping every other
+    # head byte and the body slice exact. Equivalent to the old split/replace/rejoin.
+    private def self.replace_cl(bytes : Bytes, ls : Int32, le : Int32, sep : Int32,
+                                body_start : Int32, body_len : Int32, eol : String, canon : String) : Bytes
       io = IO::Memory.new(bytes.size + 16)
-      lines.join(io, eol) # stream lines straight into the pre-sized buffer (no joined-head String)
+      io.write(bytes[0, ls])        # head up to the CL line
+      io << canon                   # canonical "Content-Length: N"
+      io.write(bytes[le, sep - le]) # the CL line's eol through the rest of the head
       io << eol << eol
       io.write(bytes[body_start, body_len]) if body_len > 0
       io.to_slice
     end
+
+    # Append a fresh CL header line to a head that lacks one.
+    private def self.append_cl(bytes : Bytes, sep : Int32, body_start : Int32,
+                               body_len : Int32, eol : String) : Bytes
+      io = IO::Memory.new(bytes.size + 32)
+      io.write(bytes[0, sep])
+      io << eol << CL_CANON << body_len
+      io << eol << eol
+      io.write(bytes[body_start, body_len]) if body_len > 0
+      io.to_slice
+    end
+
+    # ── boundary + chunked ────────────────────────────────────────────────────────
 
     # Locate the head/body separator = the FIRST blank line, whether CRLFCRLF or
     # LFLF. Returns its start index (nil if none), width, and line ending. A single
@@ -62,29 +193,58 @@ module Gori::Fuzz
       {nil, 0, "\r\n"}
     end
 
-    # True when `line` is the named header (case-insensitive, ignoring leading space).
-    private def self.header_name?(line : String, name : String) : Bool
-      colon = line.index(':')
-      return false unless colon && colon > 0
-      line[0...colon].strip.downcase == name
-    end
-
     # True when the final transfer-coding is `chunked` (RFC 7230 §3.3.1) — mirrors
-    # ContentDecode's strict check, not a loose substring scan. Tokenizes on LF (each_line +
-    # chomp), NOT the boundary `eol`: a CRLF head can still carry a bare-LF-separated header
-    # (a smuggling/desync vector the fuzzer deliberately crafts), and an LF-lenient backend
-    # reads those as distinct lines — so chunked detection must split them the same way, even
-    # though the byte-exact Content-Length rewrite above splits on `eol` to preserve the wire form.
-    private def self.chunked?(head : String) : Bool
-      head.each_line do |raw|
-        line = raw.chomp
-        break if line.empty?
-        next unless (colon = line.index(':')) && colon > 0
-        next unless line[0...colon].strip.downcase == "transfer-encoding"
-        last = line[(colon + 1)..].split(',').map(&.strip.downcase).reject(&.empty?).last?
-        return last == "chunked"
+    # ContentDecode's strict check, not a loose substring scan. Tokenizes the head on
+    # LF (NOT the boundary `eol`): a CRLF head can still carry a bare-LF-separated
+    # header (a smuggling/desync vector the fuzzer deliberately crafts), and an
+    # LF-lenient backend reads those as distinct lines — so chunked detection must split
+    # them the same way, even though the byte-exact rewrite above splits on `eol` to
+    # preserve the wire form. Scans the head bytes `[0, sep)` directly (no head String).
+    private def self.chunked?(bytes : Bytes, sep : Int32, eol : String) : Bool
+      a = 0
+      while a < sep
+        nl = a
+        while nl < sep && bytes[nl] != 0x0a_u8
+          nl += 1
+        end
+        # Line content is [a, e) with any trailing CR chomped (each_line + chomp).
+        e = nl
+        e -= 1 if e > a && bytes[e - 1] == 0x0d_u8
+        break if e == a # blank line ends the head
+        if te = transfer_encoding_last(bytes, a, e)
+          return te == "chunked"
+        end
+        a = nl + 1
       end
       false
+    end
+
+    # For the header line `[a, e)`, when it is `Transfer-Encoding`, return the last
+    # comma-separated coding (stripped, lowercased) — else nil. Mirrors the old
+    # `line[(colon+1)..].split(',').map(&.strip.downcase).reject(&.empty?).last?`.
+    private def self.transfer_encoding_last(bytes : Bytes, a : Int32, e : Int32) : String?
+      colon = colon_of(bytes, a, e)
+      return nil unless colon > a
+      ns, ne = trim_range(bytes, a, colon)
+      return nil unless name_eq_ci?(bytes, ns, ne, "transfer-encoding")
+      last_ci_token(bytes, colon + 1, e)
+    end
+
+    # The last non-empty comma-separated token of `[from, to)`, stripped + lowercased,
+    # or nil when every token is blank.
+    private def self.last_ci_token(bytes : Bytes, from : Int32, to : Int32) : String?
+      last : String? = nil
+      ts = from
+      while ts < to
+        te = ts
+        while te < to && bytes[te] != 0x2c_u8 # ','
+          te += 1
+        end
+        cs, ce = trim_range(bytes, ts, te)
+        last = String.new(bytes[cs, ce - cs]).downcase if ce > cs
+        ts = te + 1
+      end
+      last
     end
   end
 end


### PR DESCRIPTION
## Summary

`ContentLength.sync` recomputes a fuzz request's `Content-Length` after a payload is spliced into the body. It runs on **every dispatched request** when `update_content_length` is on (the default), on the single-threaded dispatcher fiber — so it's a per-request serialization cost.

The old implementation materialized a head `String` (`String.new(bytes[0, sep])`), split it into a per-line `Array`, scanned each line with `index`/`strip`/`downcase`, and re-walked the head a second time in `chunked?`. Even a **GET query fuzz** (no body, no CL header) paid a `String` + `Array` allocation and two head passes just to return the bytes unchanged.

This rewrites the head scan at the **byte level**:
- The common no-`Content-Length` shape returns the input untouched with **zero allocation**.
- The rewrite path never builds a head `String` or a lines `Array` — it splices the canonical CL line in place and writes the body slice back byte-exact.
- Output is **byte-for-byte identical** to the old split/rejoin, including the LF-lenient `chunked?` smuggling/desync detection.

## Correctness

- Existing `spec/fuzz_spec.cr` `ContentLength` cases pass (binary body splice, CRLF/LF boundary, chunked-across-bare-LF, add-when-missing).
- Full fuzz suite: **64 examples, 0 failures** (`fuzz_spec`, `mcp_fuzz_spec`, `fuzz_store_spec`).
- **1134-case differential** (`old` vs `new` output across EOL variants, mixed-case/whitespace CL headers, `Transfer-Encoding` coding lists, weird framings, GET/body-less/no-boundary) → **0 mismatches**.

## Benchmark

`bench/fuzz_clsync_bench.cr` (`--release`):

| case | before | after | speedup | alloc before → after |
|------|--------|-------|---------|----------------------|
| GET no-op (dominant) | 1.69 µs | 348 ns | **4.9×** | 1.62 kB → **0 B** |
| POST rewrite CL | 2.00 µs | 649 ns | **3.1×** | 2.84 kB → 624 B |

No public API change; `sync` keeps the same signature and output contract.