### PR TITLE
feat(tui): add right-border scroll gauge across scrollable panes

### DIFF
--- a/spec/tui/foundation_spec.cr
+++ b/spec/tui/foundation_spec.cr
@@ -292,4 +292,29 @@ describe Gori::Tui::Frame do
     backend.grid[2][19].should eq('┤')
     backend.row(2).should contain("─")
   end
+
+  it "rides a right-border scroll gauge whose thumb tracks the scroll offset" do
+    box = Rect.new(0, 0, 20, 10)
+    inner = box.inset(1, 1) # interior height 8; border column 19
+    col = 19
+
+    top_b = MemoryBackend.new(30, 12)
+    Frame.card(Screen.new(top_b), box)
+    Frame.scroll_gauge(Screen.new(top_b), inner, total: 100, top: 0, focused: true)
+    top_b.grid[1][col].should eq('┃')                           # thumb sits at the top
+    top_b.grid[8][col].should eq('│')                           # track below it
+    (1..8).count { |y| top_b.grid[y][col] == '┃' }.should eq(1) # a huge body → a 1-row thumb
+
+    bot_b = MemoryBackend.new(30, 12)
+    Frame.card(Screen.new(bot_b), box)
+    Frame.scroll_gauge(Screen.new(bot_b), inner, total: 100, top: 92, focused: true) # max scroll
+    bot_b.grid[8][col].should eq('┃')                                                # thumb has ridden to the bottom
+    bot_b.grid[1][col].should eq('│')
+
+    # A body that fits the viewport draws no gauge — the plain hairline stays.
+    fit_b = MemoryBackend.new(30, 12)
+    Frame.card(Screen.new(fit_b), box)
+    Frame.scroll_gauge(Screen.new(fit_b), inner, total: 5, top: 0, focused: true)
+    (1..8).count { |y| fit_b.grid[y][col] == '┃' }.should eq(0)
+  end
 end

--- a/spec/tui/repeater_view_spec.cr
+++ b/spec/tui/repeater_view_spec.cr
@@ -21,6 +21,34 @@ describe Gori::Tui::RepeaterView do
   # off so a (future) valid-JSON/XML fixture can't silently reflow and shift assertions.
   before_each { Gori::Settings.pretty_bodies_default = false }
 
+  # The right-border scroll gauge: a heavy-vertical thumb rides the response card's
+  # right edge ONLY when the body overflows the viewport, so its height reads as
+  # "how big is this response" at a glance. A body that fits keeps the plain hairline.
+  it "draws a right-border scroll gauge only when the response overflows the viewport" do
+    view = RepeaterView.new
+    view.load_blank
+    view.focus_pane(:response)
+
+    big = String.build do |io|
+      io << "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n"
+      300.times { |i| io << "line #{i}\n" }
+    end
+    view.apply(Gori::Repeater::Result.new("HTTP/1.1 200 OK\r\n".to_slice, big.to_slice, nil, 1000_i64))
+
+    big_b = MemoryBackend.new(120, 20)
+    view.render(Screen.new(big_b), Rect.new(0, 0, 120, 20))
+    col = 119 # the response card's right border column (right half's right edge)
+    thumb_rows = (0...20).count { |y| big_b.grid[y][col] == '┃' }
+    thumb_rows.should be > 0  # a thumb segment is present
+    thumb_rows.should be < 18 # but not the whole track — content clearly exceeds the pane
+
+    # A tiny response fits the pane, so no gauge — the border stays a plain hairline.
+    view.apply(Gori::Repeater::Result.new("HTTP/1.1 200 OK\r\n\r\n".to_slice, "PONG".to_slice, nil, 1000_i64))
+    small_b = MemoryBackend.new(120, 20)
+    view.render(Screen.new(small_b), Rect.new(0, 0, 120, 20))
+    (0...20).count { |y| small_b.grid[y][col] == '┃' }.should eq(0)
+  end
+
   # The response pane's ^X hex dump: repeater_toggle_hex routes response-focus to
   # exactly this view toggle (the `x` key selects a line now — hex moved to ^X).
   it "toggle_resp_hex flips resp_hex? and renders a raw byte dump of the response" do

--- a/spec/tui/text_area_spec.cr
+++ b/spec/tui/text_area_spec.cr
@@ -282,4 +282,20 @@ describe Gori::Tui::TextArea do
       render_peek("k=$TOKEN", 1, false, true).contains?("s3cr3t-value").should be_false
     end
   end
+
+  describe "right-border scroll gauge (opt-in)" do
+    it "rides a thumb on the border when the buffer overflows, and only when enabled" do
+      ta = Gori::Tui::TextArea.new((0...50).map { |i| "line #{i}" }.join("\n"))
+      col = 20 # rect.right of a 20-wide pane — where a framing card's hairline sits
+
+      on = MemoryBackend.new(30, 10)
+      ta.render(Screen.new(on), Rect.new(0, 0, 20, 8), cursor: false, gauge: true, gauge_focused: true)
+      on.grid[0][col].should eq('┃') # 50 lines ≫ 8 rows → thumb pinned at the top (scroll 0)
+      (0...8).count { |y| on.grid[y][col] == '┃' }.should be > 0
+
+      off = MemoryBackend.new(30, 10)
+      ta.render(Screen.new(off), Rect.new(0, 0, 20, 8), cursor: false) # gauge defaults off
+      (0...8).count { |y| off.grid[y][col] == '┃' }.should eq(0)
+    end
+  end
 end

--- a/src/gori/tui/decoder_view.cr
+++ b/src/gori/tui/decoder_view.cr
@@ -111,7 +111,7 @@ module Gori::Tui
         render_mode_badge(screen, card.right - 1, card.y, card.x + 6, mode == InputMode::Insert)
       end
       body = card.inset(1, 1)
-      input.render(screen, body, cursor: active)
+      input.render(screen, body, cursor: active, gauge: true, gauge_focused: active)
       paint_input_read_chrome(screen, body, input, read, reading) if reading && read
     end
 
@@ -227,6 +227,7 @@ module Gori::Tui
         screen.text(rect.x + gw, rect.y + i, shown, fg, Theme.bg, width: cw)
         paint_out_line_chrome(screen, rect.x + gw, rect.y + i, li, line, lines, focused)
       end
+      Frame.scroll_gauge(screen, rect, lines.size, @out_scroll, focused)
     end
 
     def output_move(dr : Int32, dc : Int32, result : Decoder::ChainResult, selecting : Bool = false) : Nil

--- a/src/gori/tui/frame.cr
+++ b/src/gori/tui/frame.cr
@@ -62,6 +62,30 @@ module Gori::Tui
       screen.text(inner.x + 1, y, " ‹ list ", Theme.accent, bg, Attribute::Bold)
     end
 
+    # A slim vertical scroll gauge riding the right border of a framed content area.
+    # The thumb's height is proportional to how much of the content is on screen, so a
+    # glance reads as "roughly how big is this", and its position tracks the scroll
+    # offset. Draws on the border column immediately right of `content` (`content.right`),
+    # so pass the FRAMED INTERIOR rect (the `rect.inset(1, 1)` the body renders into) — the
+    # frame's right hairline sits exactly there. No-op unless the content overflows the
+    # viewport, so a fully-visible body keeps its plain hairline. `total` = total rows,
+    # `top` = the first visible row; `focused` brightens the thumb (gold) vs muted at rest.
+    def self.scroll_gauge(screen : Screen, content : Rect, total : Int32, top : Int32,
+                          focused : Bool, bg : Color = Theme.bg) : Nil
+      track = content.h # interior rows == the windowed viewport height
+      return if track < 2 || total <= track
+      x = content.right # the frame's right border column, one past the content
+      thumb = (track.to_i64 * track // total).to_i.clamp(1, track - 1)
+      max_top = total - track
+      off = ((track - thumb).to_i64 * top.clamp(0, max_top) // max_top).to_i.clamp(0, track - thumb)
+      thumb_fg = focused ? Theme.focus_gold : Theme.muted
+      track_fg = Theme.blend(Theme.border, bg, 0.5)
+      (0...track).each do |i|
+        on = i >= off && i < off + thumb
+        screen.cell(x, content.y + i, on ? '┃' : '│', on ? thumb_fg : track_fg, bg)
+      end
+    end
+
     # A `├───┤` divider across a card's interior at absolute row `y` — the seam
     # between an input/header band and the list below it.
     def self.tee_divider(screen : Screen, rect : Rect, y : Int32, bg : Color = Theme.panel) : Nil

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -1489,7 +1489,7 @@ module Gori::Tui
       @editor.chain_peek_text = (chain && !chain.empty?) ? chain : nil # tooltip only for a concealed (non-empty) chain
       inner = rect.inset(1, 1)
       read_active = focused && !ins
-      @editor.render(screen, inner, cursor: ins, highlight: :request, peek: focused)
+      @editor.render(screen, inner, cursor: ins, highlight: :request, peek: focused, gauge: true, gauge_focused: focused)
       paint_template_read_chrome(screen, inner, read_active)
     end
 
@@ -1729,6 +1729,9 @@ module Gori::Tui
         body = Rect.new(inner.x, inner.y + 1, inner.w, {inner.h - 1, 0}.max)
         TrafficEmptyState.render(screen, body, variant: :fuzzer_results, running: @running)
       end
+      # Gauge rides the rows region (below the header row), so its track lines up with
+      # what @scroll actually windows.
+      Frame.scroll_gauge(screen, Rect.new(inner.x, inner.y + 1, inner.w, rows_h), view.size, @scroll, focused)
     end
 
     private def render_result_row(screen : Screen, inner : Rect, y : Int32, r : Fuzz::Result, selected : Bool) : Nil
@@ -1897,6 +1900,7 @@ module Gori::Tui
         Highlight.draw(screen, inner.x + gw, inner.y + i, sline, bg: Theme.bg, width: cw)
         paint_detail_line_chrome(screen, inner.x + gw, inner.y + i, li, line, focused, lines)
       end
+      Frame.scroll_gauge(screen, inner, lines.size, @detail_scroll, focused)
     end
 
     private def paint_detail_line_chrome(screen : Screen, x : Int32, y : Int32, li : Int32, line : String,

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -494,6 +494,7 @@ module Gori::Tui
         label = it.kind.request? ? "#{method} #{it.host}#{target}" : "#{it.host} #{target}"
         screen.text(inner.x + 5, y, label, selected ? Theme.text_bright : Theme.text, bg, width: {inner.w - 6, 1}.max)
       end
+      Frame.scroll_gauge(screen, inner, @items.size, @scroll, focused)
     end
 
     private def render_detail(screen : Screen, rect : Rect, focused : Bool) : Nil
@@ -511,7 +512,7 @@ module Gori::Tui
       end
       mode = it.kind.request? ? :request : :response
       if @editing && @loaded_id == it.id
-        @editor.render(screen, inner, cursor: focused, highlight: mode)
+        @editor.render(screen, inner, cursor: focused, highlight: mode, gauge: true, gauge_focused: focused)
       else
         win = detail_window_for(it)
         total = win.total
@@ -528,6 +529,7 @@ module Gori::Tui
           shown = @detail_xscroll > 0 ? Highlight.slice_left(styled, @detail_xscroll) : styled
           Highlight.draw(screen, inner.x, inner.y + i, shown, width: inner.w)
         end
+        Frame.scroll_gauge(screen, inner, total, @detail_scroll, focused)
       end
     end
 

--- a/src/gori/tui/issues_view.cr
+++ b/src/gori/tui/issues_view.cr
@@ -672,7 +672,7 @@ module Gori::Tui
       end
       body = card.inset(1, 1)
       return if body.empty?
-      @notes.render(screen, body, cursor: ins)
+      @notes.render(screen, body, cursor: ins, gauge: true, gauge_focused: notes_active)
       paint_notes_read_chrome(screen, body, notes_active && !notes_insert_mode?)
     end
 

--- a/src/gori/tui/miner_view.cr
+++ b/src/gori/tui/miner_view.cr
@@ -411,6 +411,8 @@ module Gori::Tui
         break if idx >= @results.size
         draw_result(screen, inner, idx, inner.y + 1 + i, focused)
       end
+      # Gauge over the rows region (below the header), aligned to what @scroll windows.
+      Frame.scroll_gauge(screen, Rect.new(inner.x, inner.y + 1, inner.w, cap), @results.size, @scroll, focused)
     end
 
     private def header_row(screen : Screen, inner : Rect) : Nil

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -1253,7 +1253,7 @@ module Gori::Tui
       end
       inner = rect.inset(1, 1)
       @desc_area.render(screen, inner, cursor: ins,
-        highlight: Settings.editor_markdown ? :markdown : nil)
+        highlight: Settings.editor_markdown ? :markdown : nil, gauge: true, gauge_focused: focused)
       paint_desc_read_chrome(screen, inner, focused && !ins)
     end
 

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -2255,7 +2255,7 @@ module Gori::Tui
         screen.text(bx, rect.y, badge, Theme.text_bright, Theme.accent_bg) if bx > rect.x + label.size + 4
       end
       # XML/JSON-ish payload / WS messages → plain editing (no HTTP request/header colouring).
-      @decoded.render(screen, rect.inset(1, 1), cursor: focused, highlight: nil, peek: focused)
+      @decoded.render(screen, rect.inset(1, 1), cursor: focused, highlight: nil, peek: focused, gauge: true, gauge_focused: focused)
     end
 
     private def pane_border(focused : Bool, insert : Bool = false) : Color
@@ -2364,14 +2364,14 @@ module Gori::Tui
           Frame.toggle_badge(screen, send_edge, rect.y, min_x, "^X", "MSG", false) if @grpc_reframable
           @editor.conceal_spans = [] of {Int32, Int32} # gRPC frames aren't §-marker HTTP text — no stale concealment
           @editor.chain_peek_text = nil
-          @editor.render(screen, rect.inset(1, 1), cursor: focused && request_insert?, highlight: :request, peek: focused)
+          @editor.render(screen, rect.inset(1, 1), cursor: focused && request_insert?, highlight: :request, peek: focused, gauge: true, gauge_focused: focused)
         end
         return
       end
       if @ws_mode
         @editor.conceal_spans = [] of {Int32, Int32} # WS messages aren't §-marker HTTP text — no stale concealment
         @editor.chain_peek_text = nil
-        @editor.render(screen, rect.inset(1, 1), cursor: focused && request_insert?, highlight: :request, peek: focused)
+        @editor.render(screen, rect.inset(1, 1), cursor: focused && request_insert?, highlight: :request, peek: focused, gauge: true, gauge_focused: focused)
         return
       end
       if h = @req_hex_edit
@@ -2384,7 +2384,7 @@ module Gori::Tui
       render_mode_badge(screen, mode_x, rect.y, min_x, ins)
       update_request_marker_tint
       inner = rect.inset(1, 1)
-      @editor.render(screen, inner, cursor: ins, highlight: :request, peek: focused)
+      @editor.render(screen, inner, cursor: ins, highlight: :request, peek: focused, gauge: true, gauge_focused: focused)
       paint_request_read_chrome(screen, inner, focused && !ins)
     end
 
@@ -2507,6 +2507,7 @@ module Gori::Tui
       else
         render_response_body(screen, body, focused)
       end
+      Frame.scroll_gauge(screen, body, resp_line_count, @scroll, focused)
     end
 
     # Shared windowed renderer for the WS / gRPC transcript panes (a list of
@@ -2541,6 +2542,7 @@ module Gori::Tui
         paint_resp_line_chrome(screen, body.x + gw, body.y + i, li, text, focused, sel_spans)
         SearchHi.mark(screen, body.x + gw, body.y + i, shown, @search_hl, body.x + gw + cw) unless @search_hl.empty?
       end
+      Frame.scroll_gauge(screen, body, lines.size, @scroll, focused)
     end
 
     # The transcript as {text, colour} rows (cached; rebuilt only when a new result

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -1,5 +1,6 @@
 require "./screen"
 require "./theme"
+require "./frame"
 require "./highlight"
 require "../env"
 require "../settings"
@@ -381,7 +382,11 @@ module Gori::Tui
     # HTTP message editors (Repeater, Intercept), nil for plain prose (Notes,
     # Issue notes). The styled lines are 1:1 with `@lines`, so the cursor —
     # drawn last, on top — still lands on the right column.
-    def render(screen : Screen, rect : Rect, cursor : Bool, highlight : Symbol? = nil, peek : Bool = false) : Nil
+    # `gauge` rides a right-border scroll gauge on the frame the CALLER drew (pass it
+    # only when this editor fills a card's `rect.inset(1, 1)`, so `rect.right` lands on
+    # the hairline); `gauge_focused` brightens the thumb when this pane holds focus.
+    def render(screen : Screen, rect : Rect, cursor : Bool, highlight : Symbol? = nil, peek : Bool = false,
+               gauge : Bool = false, gauge_focused : Bool = false) : Nil
       return if rect.empty?
       @last_h = rect.h # remembered for scroll_view (wheel) clamping
       ensure_visible(rect.h)
@@ -474,6 +479,7 @@ module Gori::Tui
           end
         end
       end
+      Frame.scroll_gauge(screen, rect, @lines.size, @scroll, gauge_focused) if gauge
       # The env-complete dropdown + value peek paint LAST (over the text, anchored at the
       # caret) so they never render when the caret is off-screen.
       render_env_popups(screen, caret_cell, rect, cursor, peek)


### PR DESCRIPTION
## What

Adds a slim vertical **scroll gauge** on the right border of scrollable card panes. The thumb's height is proportional to how much of the content fits on screen — so its size reads as *"how big is this"* at a glance — and its position tracks the scroll offset. It's **overflow-gated**: a body that fits the viewport keeps a plain hairline border, so nothing changes for short content.

Motivation: mouse-wheel scrolling already works, but there was no visual cue for how large a Response (or request/result/output) actually is.

## How

- Shared helper `Frame.scroll_gauge(content, total, top, focused)` draws a `┃` thumb over a `│` track on the frame's right hairline (`content.right`), across the content rows. Pass the framed interior rect; header-row lists pass just their rows sub-rect so the track lines up with what `@scroll` windows.
- `TextArea#render` grows an opt-in `gauge:` / `gauge_focused:` pair so every held editor gets it with a one-arg change at the call site.

## Surfaces

- **Repeater** — Request, Decoded, Response (+ WS/gRPC/group transcript)
- **Fuzzer** — Results, Result detail, Template
- **Intercept** — Queue, Detail preview, Detail edit
- **Decoder** — Output, Input
- **Miner** — Findings
- **Project** — Description · **Issues** — Notes

Single top-level tab panes (Help, Notes, Sitemap, Comparer, Issues/Probe lists) and poor structural fits (History detail/list, Miner finding detail) are intentionally left out.

## Tests

- `Frame.scroll_gauge` geometry unit spec, `TextArea` gauge opt-in spec, and the Repeater response integration spec — all assert exact border-column cells.
- Full suite: **1966 examples, 0 failures**. No new ameba findings.