### PR TITLE
fix(mcp): harden gori mcp runtime against job-fiber crashes and dead pipes

### DIFF
--- a/spec/mcp_fuzz_spec.cr
+++ b/spec/mcp_fuzz_spec.cr
@@ -171,6 +171,39 @@ describe "MCP fuzz tools" do
     end
   end
 
+  it "always reaches a terminal state (never stuck :running) against a dead origin" do
+    # Bind then release a port so every connect is refused deterministically — the
+    # run_fuzz_job fiber must still land the job terminal (finalize_job guarantee),
+    # never leaving a poller to spin on :running forever.
+    probe = TCPServer.new("127.0.0.1", 0)
+    port = probe.local_address.port
+    probe.close
+    with_store do |store|
+      tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+      start = call_json(tools, "fuzz_start",
+        {"template"       => "GET /?q=§x§ HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+         "url"            => "http://127.0.0.1:#{port}",
+         "payloads"       => %([{"list":["a","b"]}]),
+         "retries"        => 0,
+         "allow_unscoped" => true}.to_json)
+      job_id = start["job_id"].as_s
+
+      terminal = nil.as(JSON::Any?)
+      100.times do
+        sleep 0.02.seconds
+        st = call_json(tools, "fuzz_status", %({"job_id":#{job_id.to_json}}))
+        next if st["status"].as_s == "running"
+        terminal = st
+        break
+      end
+      terminal.should_not be_nil
+      t = terminal.not_nil!
+      t["job_complete"].as_bool.should be_true
+      # finalize_job always stamps an end time on a terminal job (emitted in audit).
+      t["audit"]["ended_at"].raw.should_not be_nil
+    end
+  end
+
   it "records matched results to History with a redacted flow_id when record_history:matched" do
     port = start_origin
     with_store do |store|

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -108,7 +108,72 @@ end
 
 private INIT = %({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"t","version":"0"}}})
 
+# Output pipe that dies on the first write (client process vanished). Counts write
+# attempts so a test can prove the run loop STOPPED after the broken write rather
+# than continuing to process further requests.
+private class BrokenOutput < IO
+  getter writes = 0
+
+  def read(slice : Bytes) : Int32
+    0
+  end
+
+  def write(slice : Bytes) : Nil
+    @writes += 1
+    raise IO::Error.new("broken pipe")
+  end
+end
+
+# Input pipe that yields one chunk then raises mid-read (connection reset), to
+# prove the run loop treats a broken transport as a clean end of session.
+private class BrokenInput < IO
+  def initialize(@chunk : Bytes)
+    @pos = 0
+  end
+
+  def read(slice : Bytes) : Int32
+    # Serve the whole chunk (across as many reads as gets needs), then blow up on
+    # the read that would fetch the NEXT line — the transport died mid-session.
+    raise IO::Error.new("connection reset") if @pos >= @chunk.size
+    n = Math.min(slice.size, @chunk.size - @pos)
+    slice.copy_from(@chunk[@pos, n])
+    @pos += n
+    n
+  end
+
+  def write(slice : Bytes) : Nil
+  end
+end
+
 describe Gori::MCP::Server do
+  describe "transport resilience" do
+    it "shuts down cleanly (no unhandled error) when the output pipe breaks mid-write" do
+      with_store do |store|
+        # Two requests queued; the first response write breaks the pipe. The loop
+        # must stop — the second request is never processed (writes stays at 1).
+        input = IO::Memory.new("#{INIT}\n#{INIT}\n")
+        sink = BrokenOutput.new
+        Gori::MCP::Server.new(store,
+          allow_actions: true, verify_upstream: false,
+          input: input, output: sink).run
+        sink.writes.should eq(1)
+      end
+    end
+
+    it "ends the session cleanly when the input stream raises mid-read" do
+      with_store do |store|
+        sink = IO::Memory.new
+        Gori::MCP::Server.new(store,
+          allow_actions: true, verify_upstream: false,
+          input: BrokenInput.new("#{INIT}\n".to_slice), output: sink).run
+        # The one complete request before the read error was still answered.
+        lines = sink.to_s.each_line.reject(&.strip.empty?).to_a
+        lines.size.should eq(1)
+        JSON.parse(lines[0])["result"]["serverInfo"]["name"].should eq(JSON::Any.new("gori"))
+      end
+    end
+  end
+
   describe "handshake" do
     it "answers initialize with capabilities + serverInfo" do
       with_store do |store|

--- a/src/gori/mcp/server.cr
+++ b/src/gori/mcp/server.cr
@@ -38,16 +38,25 @@ module Gori
           selection_source: @selection_source, workspace_root: @workspace_root,
           project_id: @project_id)
         @initialized = false
+        # Set when the output pipe breaks (client vanished mid-write): the loop then
+        # stops rather than thrashing on a dead stream or raising an unhandled error.
+        @closed = false
       end
 
       # Reads until EOF on `input` (client closed the pipe). Each line is parsed
-      # and dispatched independently; a bad line never stops the loop.
+      # and dispatched independently; a bad line never stops the loop. A broken
+      # transport (the client process died) ends the session cleanly — a normal
+      # shutdown, not a crash to surface as an unhandled backtrace.
       def run : Nil
         @input.each_line do |line|
+          break if @closed
           line = line.strip
           next if line.empty?
           handle_line(line)
+          break if @closed
         end
+      rescue ex : IO::Error
+        Log.info { "mcp: input stream closed (#{ex.message})" }
       end
 
       private def handle_line(line : String) : Nil
@@ -238,8 +247,14 @@ module Gori
       end
 
       private def send(payload : String) : Nil
+        return if @closed
         @output.puts(payload) # newline framing
         @output.flush         # or the client blocks on the unterminated line
+      rescue ex : IO::Error
+        # The client is gone (broken pipe). Stop writing and let the run loop end
+        # cleanly instead of unwinding an unhandled exception out of a handler.
+        @closed = true
+        Log.info { "mcp: output stream closed (#{ex.message})" }
       end
     end
   end

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -2823,23 +2823,52 @@ module Gori
       end
 
       # Background drain (runs during the stdio loop's blocking read). Stores
-      # matched results only, capped, never touches STDOUT.
+      # matched results only, capped, never touches STDOUT. Robustness: a per-event
+      # rescue keeps the drain alive on a callback failure (so the engine's worker
+      # fibers, parked on @events.send, still finish and exit instead of leaking),
+      # and the ensure GUARANTEES a terminal state — a fiber that dies here must
+      # never leave the job wedged at :running, which would hang a polling client
+      # forever and keep jobs_running? true (blocking switch_project/delete_project).
       private def run_fuzz_job(fjob : FuzzJob, engine : Fuzz::Engine) : Nil
-        engine.run do |ev|
-          case ev
-          when Fuzz::ProgressEvent then apply_fuzz_progress(fjob, ev.progress)
-          when Fuzz::ResultEvent
-            flow_id = maybe_record_fuzz_flow(fjob, ev.result)
-            store_fuzz_result(fjob, ev.result, flow_id)
-          when Fuzz::DoneEvent
-            apply_fuzz_progress(fjob, ev.progress)
-            fjob.status = terminal_status(fjob.status, ev.stopped, fjob.sent, fjob.total)
-            fjob.ended_at_ms = Time.utc.to_unix_ms
-          when Fuzz::ErrorEvent
-            fjob.status = :error
-            fjob.error_msg = ev.message
-          end
+        engine.run { |ev| drain_fuzz_event(fjob, ev) }
+      rescue ex
+        Log.error(exception: ex) { "fuzz job #{fjob.id} crashed" }
+        fjob.error_msg ||= ex.message || "internal fuzz job error"
+      ensure
+        finalize_job(fjob)
+      end
+
+      # Apply one fuzz event to the job, contained: a callback failure records the
+      # error and marks the job but never unwinds out of engine.run (see above).
+      private def drain_fuzz_event(fjob : FuzzJob, ev : Fuzz::Event) : Nil
+        case ev
+        when Fuzz::ProgressEvent then apply_fuzz_progress(fjob, ev.progress)
+        when Fuzz::ResultEvent
+          flow_id = maybe_record_fuzz_flow(fjob, ev.result)
+          store_fuzz_result(fjob, ev.result, flow_id)
+        when Fuzz::DoneEvent
+          apply_fuzz_progress(fjob, ev.progress)
+          fjob.status = terminal_status(fjob.status, ev.stopped, fjob.sent, fjob.total)
+          fjob.ended_at_ms = Time.utc.to_unix_ms
+        when Fuzz::ErrorEvent
+          fjob.status = :error
+          fjob.error_msg = ev.message
+          fjob.ended_at_ms ||= Time.utc.to_unix_ms
         end
+      rescue ex
+        Log.error(exception: ex) { "fuzz job #{fjob.id} drain error" }
+        fjob.status = :error if fjob.status == :running
+        fjob.error_msg ||= ex.message || "internal fuzz drain error"
+      end
+
+      # A background job's fiber must never exit with the job still :running — that
+      # hangs every poller and permanently trips jobs_running?. Land it terminal.
+      private def finalize_job(job : FuzzJob | MineJob) : Nil
+        if job.status == :running
+          job.status = :error
+          job.error_msg ||= "job ended without a terminal event"
+        end
+        job.ended_at_ms ||= Time.utc.to_unix_ms
       end
 
       # Record a fuzz result's rendered request + response as a History flow when
@@ -3041,21 +3070,35 @@ module Gori
         Result.new(ex.message || "invalid mine arguments", is_error: true)
       end
 
+      # Same robustness contract as run_fuzz_job: contained per-event, terminal-state
+      # guaranteed by finalize_job so a dead fiber can never wedge the job at :running.
       private def run_mine_job(mjob : MineJob, engine : Miner::Engine) : Nil
-        engine.run do |ev|
-          case ev
-          when Miner::BaselineEvent then mjob.baseline_stable = ev.stable
-          when Miner::ProgressEvent then apply_mine_progress(mjob, ev.progress)
-          when Miner::FindingEvent  then store_mine_finding(mjob, ev.finding)
-          when Miner::DoneEvent
-            apply_mine_progress(mjob, ev.progress)
-            mjob.status = terminal_status(mjob.status, ev.stopped, mjob.names_done, mjob.total)
-            mjob.ended_at_ms = Time.utc.to_unix_ms
-          when Miner::ErrorEvent
-            mjob.status = :error
-            mjob.error_msg = ev.message
-          end
+        engine.run { |ev| drain_mine_event(mjob, ev) }
+      rescue ex
+        Log.error(exception: ex) { "mine job #{mjob.id} crashed" }
+        mjob.error_msg ||= ex.message || "internal mine job error"
+      ensure
+        finalize_job(mjob)
+      end
+
+      private def drain_mine_event(mjob : MineJob, ev : Miner::Event) : Nil
+        case ev
+        when Miner::BaselineEvent then mjob.baseline_stable = ev.stable
+        when Miner::ProgressEvent then apply_mine_progress(mjob, ev.progress)
+        when Miner::FindingEvent  then store_mine_finding(mjob, ev.finding)
+        when Miner::DoneEvent
+          apply_mine_progress(mjob, ev.progress)
+          mjob.status = terminal_status(mjob.status, ev.stopped, mjob.names_done, mjob.total)
+          mjob.ended_at_ms = Time.utc.to_unix_ms
+        when Miner::ErrorEvent
+          mjob.status = :error
+          mjob.error_msg = ev.message
+          mjob.ended_at_ms ||= Time.utc.to_unix_ms
         end
+      rescue ex
+        Log.error(exception: ex) { "mine job #{mjob.id} drain error" }
+        mjob.status = :error if mjob.status == :running
+        mjob.error_msg ||= ex.message || "internal mine drain error"
       end
 
       private def apply_mine_progress(mjob : MineJob, p : Miner::Progress) : Nil


### PR DESCRIPTION
## Summary

Stability hardening for the `gori mcp` stdio server runtime. Two gaps that
could leave the server in a wedged or crashing state:

### 1. Background job fibers could wedge a job at `:running` forever
`fuzz_start` / `mine_start` run the engine in a `spawn`ed fiber (`run_fuzz_job` /
`run_mine_job`). The drain block could raise (a store write, or a future
callback change), which kills the fiber and leaves the job stuck at `:running`:

- every `fuzz_status` / `mine_status` / `get_job` poll reports `running` forever,
- `jobs_running?` stays true, permanently blocking `switch_project` /
  `delete_project`,
- the engine's worker fibers, parked on the event channel, leak.

Now each event is applied under a **per-event rescue** (keeps the drain alive so
the engine fibers finish and exit) and an **`ensure` (`finalize_job`)** that
guarantees a terminal state + end timestamp on every exit path.

### 2. A broken stdio pipe crashed the session with a backtrace
If the client process died mid-session, a write raised an unhandled `IO::Error`
out of a handler / the run loop, ending with an ugly backtrace. The server now
treats a broken input or output pipe as a **clean end of session** (`@closed`
flag; `IO::Error` rescued in `run` and `send`).

## Tests
- Dead-origin fuzz job always reaches a terminal state with an end time (never
  stuck `:running`).
- Broken output pipe stops the loop after a single write (no further processing).
- Broken input mid-read ends the session cleanly after answering the completed
  request.

## Verification
- Full suite green (`1976` examples pre-rebase; `141` MCP examples post-rebase, 0 failures).
- `ameba` on changed files: no new findings (identical count to base).
- Live stdio smoke test of the built binary: handshake + `tools/list` + EOF exit 0,
  STDOUT pure JSON, logs on STDERR; broken output pipe logs a clean
  `output stream closed` and exits without a backtrace.