### PR TITLE
perf(tui): intern non-ASCII glyph cells to drop per-frame border allocations

### DIFF
--- a/spec/tui/foundation_spec.cr
+++ b/spec/tui/foundation_spec.cr
@@ -3,6 +3,23 @@ require "../support/memory_backend"
 
 include Gori::Tui
 
+# Records the exact String object handed to `put`, so a spec can prove Screen#cell
+# reuses one interned String for a repeated non-ASCII glyph instead of allocating per cell.
+private class CaptureBackend < Gori::Tui::Backend
+  getter drawn = [] of String
+
+  def initialize(@w : Int32, @h : Int32)
+  end
+
+  def put(x : Int32, y : Int32, grapheme : Char | String, fg : Gori::Tui::Color, bg : Gori::Tui::Color, attr : Gori::Tui::Attribute) : Nil
+    @drawn << (grapheme.is_a?(String) ? grapheme : grapheme.to_s)
+  end
+
+  def size : {Int32, Int32}
+    {@w, @h}
+  end
+end
+
 describe Gori::Tui::Rect do
   it "computes edges and containment" do
     r = Rect.new(2, 3, 10, 5)
@@ -36,6 +53,16 @@ describe Gori::Tui::Screen do
     screen.fit("abcdefgh", 5).should eq("abcd…") # overflows → 4 chars + ellipsis = width 5
     screen.fit("日本語テスト", 5).should eq("日本…")     # wide glyphs (2 cols): 2+2+ellipsis = 5
     screen.fit("x", 0).should eq("")
+  end
+
+  it "interns non-ASCII glyph cells so a repeated glyph reuses one String (no per-cell alloc)" do
+    cap = CaptureBackend.new(10, 2)
+    screen = Screen.new(cap)
+    screen.cell(0, 0, '┃', Theme.text) # box-drawing glyph — the scroll gauge thumb
+    screen.cell(1, 0, '┃', Theme.text)
+    cap.drawn.size.should eq(2)
+    cap.drawn[0].should eq("┃")                       # renders the correct glyph
+    cap.drawn[0].same?(cap.drawn[1]).should be_true   # …and the SAME interned instance, not a fresh String
   end
 end
 

--- a/src/gori/tui/screen.cr
+++ b/src/gori/tui/screen.cr
@@ -39,6 +39,16 @@ module Gori::Tui
     # termisu rejects are pre-substituted with a space here, folding the old runtime check in.
     ASCII_CELL = Array(String).new(128) { |i| (i < 0x20 || i == 0x7f) ? " " : i.unsafe_chr.to_s }
 
+    # The same interning for NON-ASCII single-cell glyphs — box-drawing borders (│ ─ ╭ ╮ …),
+    # the scroll gauge (┃), block/marker glyphs (█ ▎ ✓ ▲ ▼ …) — which ASCII_CELL can't cover yet
+    # are drawn across every frame's chrome, so `Char#to_s` per cell was a fresh String for each
+    # border/gauge cell each frame. Lazily interned + capped: a burst of distinct glyphs (e.g. the
+    # cursor parked over assorted CJK content) can't grow it unbounded — on overflow the whole map
+    # is dropped and re-warms next frame (cheap). A class-level constant map (like ASCII_CELL) so it
+    # survives Screen's per-frame rebuild; the binding is constant, the Hash it holds is the cache.
+    GLYPH_CELL_CAP   = 1024
+    GLYPH_CELL_CACHE = {} of Int32 => String
+
     def initialize(@backend : Backend)
       @width, @height = @backend.size
     end
@@ -119,12 +129,22 @@ module Gori::Tui
       if grapheme.is_a?(Char)
         o = grapheme.ord
         # ASCII → interned cell (control chars already mapped to a space in the table);
-        # non-ASCII control (C1) still substitutes a space; other non-ASCII stringifies.
-        g = o < 128 ? ASCII_CELL[o] : (grapheme.control? ? " " : grapheme.to_s)
+        # non-ASCII control (C1) still substitutes a space; other non-ASCII interns (glyph_cell).
+        g = o < 128 ? ASCII_CELL[o] : (grapheme.control? ? " " : glyph_cell(o, grapheme))
       else
         g = grapheme
       end
       @backend.put(x, y, g, fg, bg, attr)
+    end
+
+    # Interned String for a non-ASCII glyph codepoint (see GLYPH_CELL_CAP): returns the cached
+    # single-char String, allocating (and caching) only the first time a given glyph is drawn.
+    private def glyph_cell(o : Int32, ch : Char) : String
+      if s = GLYPH_CELL_CACHE[o]?
+        return s
+      end
+      GLYPH_CELL_CACHE.clear if GLYPH_CELL_CACHE.size >= GLYPH_CELL_CAP
+      GLYPH_CELL_CACHE[o] = ch.to_s
     end
 
     # Draws `str` at (x, y), truncating with an ellipsis if its *display width*


### PR DESCRIPTION
## Context

Reviewing the newly-added scroll gauge for perf, I found the gauge itself is negligible in time (~0.8% of a full render) — but it allocated ~1.19 kB **per frame**. Tracing it led to a broader, pre-existing gap.

## Root cause

`Screen#cell` interns only the **128 ASCII** codepoints (`ASCII_CELL`). Every non-ASCII glyph — i.e. **all box-drawing borders, dividers, gutters, and the new scroll gauge** (`│ ─ ╭ ╮ ┃ █ ▎ ✓ …`) — fell through to `Char#to_s`, allocating a fresh 1-char `String` on every cell, every frame. The interning comment already noted this pattern was a deliberate fix for ASCII; it just never covered non-ASCII.

## Fix

Extend the same interning to non-ASCII glyphs via a lazily-populated, **capped** class-level cache (`GLYPH_CELL_CACHE` / `GLYPH_CELL_CAP`), mirroring `ASCII_CELL`. The cap means a burst of distinct glyphs (e.g. the cursor parked over assorted CJK content, which also flows through `cell()`) can never grow it unbounded — on overflow it drops and re-warms next frame.

## Measured

120×40 render of a 5000-line response (`MemoryBackend`, `--release`):

| | before | after |
|---|--:|--:|
| `Frame.scroll_gauge` | 1.19 kB/op | **0.0 B/op** |
| full `RepeaterView#render` | 47.7 kB/op | **27.1 kB/op** (~43% fewer allocations) |

Render **time** is unchanged (within noise); the win is reduced GC pressure during fast scrolling, when the whole framed chrome is redrawn each frame. This helps every framed pane app-wide, not just the gauge.

## Tests

- New guard spec: a capturing backend proves a repeated non-ASCII glyph reuses **one interned String** instead of allocating per cell.
- Full suite: **1980 examples, 0 failures**.