### PR TITLE
perf(fuzz,repeater): cut per-response allocations on the send/match hot path

### DIFF
--- a/bench/fuzz_repeater_perf_bench.cr
+++ b/bench/fuzz_repeater_perf_bench.cr
@@ -1,0 +1,105 @@
+# Per-response hot-path micro-benchmarks for the fuzzer + repeater send/match path. Three
+# always-on costs the engines pay once per response (worker fibers, up to tens of thousands
+# per run), each measured OLD vs NEW:
+#
+#   1. Body.read_complete — OLD allocated a default-growth capture (doubling-realloc chain),
+#      a fresh 64 KiB scratch, AND dup'd the whole body a second time. NEW presizes the
+#      capture for a known length, right-sizes the scratch, and returns the capture view (no dup).
+#   2. ContentDecode.decode — OLD built String.new(head) + per-line substrings on EVERY
+#      response before discovering there's no encoding. NEW gates on a zero-alloc byte scan.
+#   3. Matcher --mh header test — OLD built String.new(head).scrub.downcase per response.
+#      NEW byte-scans the raw head (ASCII case-insensitive).
+#
+# Build: crystal build bench/fuzz_repeater_perf_bench.cr -o bin/fuzz_repeater_perf_bench --release
+# Run:   bin/fuzz_repeater_perf_bench
+require "benchmark"
+
+module Gori
+  class Error < Exception; end
+end
+
+require "../src/gori/proxy/codec/body"
+require "../src/gori/proxy/codec/content_decode"
+require "../src/gori/ascii_bytes"
+
+include Gori::Proxy::Codec
+
+# ── 1) Body.read_complete: OLD (default capture + fresh 64 KiB scratch + dup) vs NEW ──────────
+def old_read_complete(src : IO, framing : BodyFraming, length : Int64) : {Bytes?, Bool}
+  return {nil, true} if framing.none?
+  capture = IO::Memory.new
+  complete = Body.stream(src, capture, framing, length, DiscardIO.new) # nil buf => fresh 64 KiB
+  {capture.to_slice.dup, complete}
+end
+
+BODY_SMALL = Bytes.new(2 * 1024, 0x61_u8)   # 2 KiB Content-Length body
+BODY_LARGE = Bytes.new(512 * 1024, 0x61_u8) # 512 KiB Content-Length body
+
+puts "1) Body.read_complete (Length framing)"
+{"2 KiB" => BODY_SMALL, "512 KiB" => BODY_LARGE}.each do |name, body|
+  n = body.size.to_i64
+  Benchmark.ips do |x|
+    x.report("OLD read_complete #{name}") { old_read_complete(IO::Memory.new(body), BodyFraming::Length, n) }
+    x.report("NEW read_complete #{name}") { Body.read_complete(IO::Memory.new(body), BodyFraming::Length, n) }
+  end
+  puts
+end
+
+# ── 2) ContentDecode.decode over a realistic NO-ENCODING response head ────────────────────────
+BODY_JSON  = %({"ok":true,"items":[1,2,3]}).to_slice
+HEAD_NOENC = ("HTTP/1.1 200 OK\r\n" +
+              "Date: Mon, 17 Jul 2026 00:00:00 GMT\r\n" +
+              "Server: nginx/1.25.3\r\n" +
+              "Content-Type: application/json; charset=utf-8\r\n" +
+              "Cache-Control: no-cache, no-store\r\n" +
+              "X-Request-Id: 0123456789abcdef0123456789abcdef\r\n" +
+              "Content-Length: 27\r\n\r\n").to_slice
+# The ubiquitous cacheable-content head: carries `Vary: Accept-Encoding` (which contains
+# "-Encoding") but NO real content/transfer-encoding — the tightened two-name gate must
+# still short-circuit it (a "-encoding" gate would have false-positived here).
+HEAD_VARY = ("HTTP/1.1 200 OK\r\n" +
+             "Server: nginx/1.25.3\r\n" +
+             "Content-Type: text/html; charset=utf-8\r\n" +
+             "Vary: Accept-Encoding\r\n" +
+             "Cache-Control: public, max-age=3600\r\n" +
+             "Content-Length: 27\r\n\r\n").to_slice
+
+# The OLD decode's no-encoding path: build the head String + per-line scan, then return nil.
+def old_decode_noenc(head : Bytes, body : Bytes) : {Bytes?, String?}
+  return {nil, nil} if body.empty?
+  te = false
+  ce = false
+  String.new(head).each_line do |raw|
+    line = raw.chomp
+    break if line.empty?
+    idx = line.index(':')
+    next unless idx
+    name = line[0...idx].strip.downcase
+    te = true if name == "transfer-encoding"
+    ce = true if name == "content-encoding"
+  end
+  (te || ce) ? {body, "…"} : {nil, nil}
+end
+
+puts "2) ContentDecode.decode over no-encoding heads (per response)"
+{"plain" => HEAD_NOENC, "Vary: Accept-Encoding" => HEAD_VARY}.each do |name, head|
+  Benchmark.ips do |x|
+    x.report("OLD decode #{name}") { old_decode_noenc(head, BODY_JSON) }
+    x.report("NEW decode #{name}") { ContentDecode.decode(head, BODY_JSON) }
+  end
+  puts
+end
+
+# ── 3) Matcher --mh header substring test: OLD downcased-head String vs NEW byte scan ─────────
+NEEDLE    = "x-powered-by"
+NEEDLE_SL = NEEDLE.to_slice
+
+def old_header_pass(head : Bytes, needle : String) : Bool
+  String.new(head).scrub.downcase.includes?(needle.downcase)
+end
+
+puts "3) Matcher header_pass? (--mh set) over the head"
+Benchmark.ips do |x|
+  x.report("OLD String downcase   ") { old_header_pass(HEAD_NOENC, NEEDLE) }
+  x.report("NEW AsciiBytes byte    ") { Gori::AsciiBytes.contains_ci?(HEAD_NOENC, NEEDLE_SL) }
+end

--- a/spec/fuzz_spec.cr
+++ b/spec/fuzz_spec.cr
@@ -411,6 +411,24 @@ describe F::Matcher do
     m.build(job, ok_result(200, "abcdef")).matched?.should be_true
   end
 
+  it "matches --mh as a case-insensitive substring over the response head (no head String)" do
+    m = F::Matcher.new
+    job = F::Job.new(0_i64, ["x"], nil, "".to_slice)
+    head = "HTTP/1.1 200 OK\r\nServer: nginx/1.25\r\nX-Powered-By: PHP/8.2\r\nContent-Length: 2\r\n\r\n".to_slice
+    resp = Gori::Proxy::Codec::Http1.parse_response_head(head)
+    res = Gori::Repeater::Result.new(head, "ok".to_slice, resp, 1_i64)
+    # Needle case need not match the head's case (old path downcased both).
+    m.match_header = "SERVER: NGINX"
+    m.build(job, res).matched?.should be_true
+    m.match_header = "x-powered-by: php"
+    m.build(job, res).matched?.should be_true
+    m.match_header = "x-frame-options"
+    m.build(job, res).matched?.should be_false # header absent
+    # A blank/nil needle is unconstrained (matcher passes), not "reject everything".
+    m.match_header = nil
+    m.build(job, res).matched?.should be_true
+  end
+
   it "survives a catastrophic-backtracking user regex instead of killing the worker" do
     # A user --mr/--fr/--extract regex like /(a+)+$/ raises Regex::Error ('match limit
     # exceeded') on a pathological body rather than returning false; unrescued it killed the

--- a/spec/proxy/codec/content_decode_spec.cr
+++ b/spec/proxy/codec/content_decode_spec.cr
@@ -104,6 +104,32 @@ describe Gori::Proxy::Codec::ContentDecode do
     String.new(decoded.not_nil!).should eq("zstd round trip works")
     note.should eq("decoded: zstd")
   end
+
+  # The zero-alloc `-encoding` gate must be ASCII case-insensitive: an all-caps header
+  # name still reaches the decoder (a false gate-negative here would silently pass a gzip
+  # body through as garbage).
+  it "gates case-insensitively: an UPPERCASE Content-Encoding still decodes" do
+    decoded, note = decode(head("HTTP/1.1 200 OK", "CONTENT-ENCODING: GZIP"), gzip("caps work"))
+    String.new(decoded.not_nil!).should eq("caps work")
+    note.should eq("decoded: gzip")
+  end
+
+  # A head that CONTAINS the "-encoding" substring only in an unrelated value (Vary:
+  # Accept-Encoding) but carries no real content/transfer-encoding: the gate lets it
+  # through, and the full parse correctly finds nothing to do → passthrough (nil).
+  it "gate false-positive (Vary: Accept-Encoding) still resolves to passthrough" do
+    decoded, note = decode(head("HTTP/1.1 200 OK", "Vary: Accept-Encoding", "Content-Type: text/plain"), "plain".to_slice)
+    decoded.should be_nil
+    note.should be_nil
+  end
+
+  # No "-encoding" anywhere in the head → the gate short-circuits before building any
+  # head String, and the result is the same passthrough as an unmatched full parse.
+  it "no encoding header at all → passthrough (gate short-circuits)" do
+    decoded, note = decode(head("HTTP/1.1 200 OK", "Content-Type: application/json", "Server: nginx"), %({"ok":true}).to_slice)
+    decoded.should be_nil
+    note.should be_nil
+  end
 end
 
 # Compress via the system CLI (decoder-only libs are linked; encoders aren't).

--- a/src/gori/ascii_bytes.cr
+++ b/src/gori/ascii_bytes.cr
@@ -1,0 +1,30 @@
+module Gori
+  # Small, allocation-free ASCII byte helpers for the per-response hot paths (fuzz
+  # matcher, content-decode gate). Folds ONLY A-Z → a-z, matching `String#downcase`
+  # for ASCII header names/values (HTTP header field tokens are ASCII); a non-ASCII
+  # byte is compared verbatim. Keeps the case-folding semantics in one reviewed place.
+  module AsciiBytes
+    # Does `hay` contain `needle` (ASCII case-insensitive)? `needle` MUST already be
+    # lowercase. Non-allocating O(hay·needle) scan — hot-path callers pass a short head
+    # and a short needle, so this stays cheaper than materializing a downcased String.
+    def self.contains_ci?(hay : Bytes, needle : Bytes) : Bool
+      n = needle.size
+      return true if n == 0
+      return false if hay.size < n
+      limit = hay.size - n
+      i = 0
+      while i <= limit
+        j = 0
+        while j < n
+          b = hay.unsafe_fetch(i + j)
+          b |= 0x20_u8 if b >= 0x41_u8 && b <= 0x5a_u8 # A-Z → a-z
+          break unless b == needle.unsafe_fetch(j)
+          j += 1
+        end
+        return true if j == n
+        i += 1
+      end
+      false
+    end
+  end
+end

--- a/src/gori/fuzz/matcher.cr
+++ b/src/gori/fuzz/matcher.cr
@@ -1,6 +1,7 @@
 require "../proxy/codec/content_decode"
 require "../intercept_filter"
 require "../repeater/engine"
+require "../ascii_bytes"
 
 module Gori::Fuzz
   # Decoded-response metrics for one send.
@@ -57,7 +58,17 @@ module Gori::Fuzz
 
     property match_regex : Regex?
     property filter_regex : Regex?
-    property match_header : String? # substring over the response head
+    # Substring over the response head. Cache the lowercased needle ONCE on assignment
+    # (like the num_spec/status_spec setters) so the per-response check neither re-lowercases
+    # the needle nor materializes a downcased head String — it byte-scans the raw head.
+    getter match_header : String?
+    @match_header_lc : Bytes?
+
+    def match_header=(v : String?)
+      @match_header = v
+      @match_header_lc = (v && !v.empty?) ? v.downcase.to_slice : nil
+    end
+
     property extract : Regex?
     property baseline : Metrics?
     property? auto_calibrate : Bool
@@ -142,9 +153,12 @@ module Gori::Fuzz
     end
 
     private def header_pass?(raw : Repeater::Result) : Bool
-      h = @match_header
-      return true unless h
-      String.new(raw.head).scrub.downcase.includes?(h.downcase)
+      needle = @match_header_lc
+      return true unless needle
+      # ASCII case-insensitive substring scan over the raw head bytes — no per-response
+      # `String.new(raw.head).scrub.downcase` allocation. Header field tokens are ASCII, so
+      # this equals the old downcased-substring test for any ASCII/ISO-8859-1 head + needle.
+      AsciiBytes.contains_ci?(raw.head, needle)
     end
 
     # `default` is returned when the spec is absent (compiled == nil, i.e. the raw spec was

--- a/src/gori/proxy/codec/body.cr
+++ b/src/gori/proxy/codec/body.cr
@@ -231,12 +231,37 @@ module Gori::Proxy::Codec
     # flag a half-delivered response instead of presenting it as whole.
     def self.read_complete(src : IO, framing : BodyFraming, length : Int64) : {Bytes?, Bool}
       return {nil, true} if framing.none?
-      capture = IO::Memory.new
-      # The body is already buffered once in `capture`; tee into a discard sink rather than
-      # a second IO::Memory so a large response isn't held in memory TWICE (the old
-      # `IO::Memory.new` tee doubled peak RAM on every repeater/read_complete).
-      complete = stream(src, capture, framing, length, DiscardIO.new)
-      {capture.to_slice.dup, complete}
+      # Presize the capture for a KNOWN Content-Length so it doesn't climb IO::Memory's
+      # 64→128→…→N doubling-realloc chain (each step copies everything captured so far);
+      # bounded by PRESIZE_CAP so a lying Content-Length can't force a huge up-front alloc.
+      # Chunked / close-delimited length is unknown → default growth (as before).
+      capture = presized_capture(framing, length)
+      # Right-size the scratch read buffer too: a small Length body drops a 64 KiB
+      # large-object scratch to a body-sized small-object alloc (copy_n/copy_until_eof
+      # re-key their read size off the buffer's own size, so a sub-BUFSIZE buffer stays
+      # in-bounds). The body is already buffered once in `capture`; tee into a discard
+      # sink rather than a second IO::Memory so a large response isn't held in memory
+      # TWICE (the old `IO::Memory.new` tee doubled peak RAM on every read_complete).
+      complete = stream(src, capture, framing, length, DiscardIO.new, read_buffer(framing, length))
+      # `capture` is a fresh local, never stored in a field/closure and unreachable after
+      # return, so the returned view is its SOLE owner (the slice's pointer keeps the backing
+      # buffer alive) — no defensive `.dup` of the whole body (mirrors CaptureBuffer#to_slice).
+      {capture.to_slice, complete}
+    end
+
+    # A capture buffer presized to a known Length body (bounded by PRESIZE_CAP); default
+    # growth for unknown-length (chunked / close-delimited) framings.
+    private def self.presized_capture(framing : BodyFraming, length : Int64) : IO::Memory
+      return IO::Memory.new unless framing.length? && length > 0
+      cap = length > CaptureBuffer::PRESIZE_CAP ? CaptureBuffer::PRESIZE_CAP : length.to_i
+      IO::Memory.new(cap)
+    end
+
+    # A scratch read buffer sized to a small known Length body (so it lands on the small-
+    # object heap, not the 64 KiB large-object path); full BUFSIZE otherwise.
+    private def self.read_buffer(framing : BodyFraming, length : Int64) : Bytes
+      return Bytes.new(BUFSIZE) unless framing.length? && length > 0 && length < BUFSIZE
+      Bytes.new(length.to_i)
     end
 
     # RFC 7230 §3.3.1: `chunked` must be the FINAL transfer-coding. Accept it only
@@ -305,9 +330,10 @@ module Gori::Proxy::Codec
     # Safe to share: a body is pumped one direction on one fiber, so chunks copy sequentially.
     private def self.copy_n(src : IO, dst : IO, tee : IO, n : Int64, buf : Bytes? = nil) : Bool
       cbuf = buf || Bytes.new(BUFSIZE)
+      cap = cbuf.size # a caller may pass a right-sized (sub-BUFSIZE) buffer — bound the read to IT, not the constant
       remaining = n
       while remaining > 0
-        want = remaining < BUFSIZE ? remaining.to_i : BUFSIZE
+        want = remaining < cap ? remaining.to_i : cap
         read = src.read(cbuf[0, want])
         break if read == 0 # premature EOF
         slice = cbuf[0, read]

--- a/src/gori/proxy/codec/content_decode.cr
+++ b/src/gori/proxy/codec/content_decode.cr
@@ -3,6 +3,7 @@ require "compress/deflate"
 require "compress/zlib"
 require "./brotli"
 require "./zstd"
+require "../../ascii_bytes"
 
 module Gori::Proxy::Codec
   # Decodes a captured body for DISPLAY: de-chunks the h1 wire form (the stored
@@ -13,6 +14,14 @@ module Gori::Proxy::Codec
   # raise) and output is capped to guard against decompression bombs.
   module ContentDecode
     MAX_OUT = 32 * 1024 * 1024 # decompression-bomb ceiling for the decoded view
+
+    # The two header NAMES whose presence is the necessary condition for `decode` to do any
+    # work. The byte-level gate scans the head for either (case-insensitively) to skip the
+    # head String on the dominant no-encoding response. Full names (not just "-encoding") so
+    # the ubiquitous `Vary: Accept-Encoding` doesn't false-positive the gate open. Lowercase;
+    # the scan folds the head.
+    CE_NEEDLE = "content-encoding".to_slice
+    TE_NEEDLE = "transfer-encoding".to_slice
 
     # Returns {decoded | nil, note | nil}. nil decoded => the caller should show the
     # raw body unchanged (no transfer/content coding, or nothing to do). A note
@@ -26,6 +35,15 @@ module Gori::Proxy::Codec
     # that prefix; a rare multi-coding body yields a valid, decode-tolerant prefix.
     def self.decode(head : Bytes?, body : Bytes?, max_out : Int32 = MAX_OUT) : {Bytes?, String?}
       return {nil, nil} if body.nil? || body.empty? || head.nil?
+      # Zero-alloc gate before the head String: `encoding_headers` only ever populates its
+      # lists from a `content-encoding` / `transfer-encoding` header, and BOTH names contain
+      # the ASCII substring "-encoding". If the head bytes don't contain it (the dominant
+      # uncompressed, unchunked response), the full parse below would return {nil, nil}
+      # anyway — so skip building `String.new(head)` + its per-line substrings entirely.
+      # A rare false positive (a header VALUE literally containing "content-encoding", e.g.
+      # `Vary: Content-Encoding`) simply falls through to the correct parse; only a true
+      # absence is short-circuited. Byte-identical result either way.
+      return {nil, nil} unless head_has_encoding?(head)
       te_values, ce_values = encoding_headers(head)
       te_chunked = transfer_encoding_chunked?(te_values)
       encodings = ce_values
@@ -46,6 +64,12 @@ module Gori::Proxy::Codec
         entity = decoded
       end
       {entity, notes.empty? ? nil : notes.join(" · ")}
+    end
+
+    # Zero-alloc necessary-condition gate: does the head carry a content/transfer-encoding
+    # header at all? (Byte scan for either full name, case-insensitively.)
+    private def self.head_has_encoding?(head : Bytes) : Bool
+      AsciiBytes.contains_ci?(head, CE_NEEDLE) || AsciiBytes.contains_ci?(head, TE_NEEDLE)
     end
 
     # `chunked` frames the body only when it's the FINAL transfer-coding (RFC 7230


### PR DESCRIPTION
## Summary

A follow-up perf pass on the **fuzzer + repeater** hot paths, driven by an adversarially-verified multi-agent audit (6 findings confirmed, 21 rejected). This ships the five byte-exact / behavior-identical allocation wins that all sit on the **per-response** path — worker fibers run these once per response, tens of thousands of times per fuzz run — plus `Body.read_complete`, which is also on the **proxy request-buffering** path.

### 1. `Body.read_complete` — presize, right-size, no dup (`body.cr`)
The old code allocated a default-growth capture (`IO::Memory`'s 64→128→…→N doubling-realloc chain), a fresh 64 KiB scratch read buffer, **and** `dup`'d the whole body a second time. Now it:
- presizes the capture for a known `Content-Length` (bounded by `PRESIZE_CAP`, so a lying header can't force a huge alloc — mirrors `CaptureBuffer#initial_capacity`),
- right-sizes the scratch buffer for a small `Length` body (off the 64 KiB large-object path),
- returns the capture view directly — the local `IO::Memory` is the slice's sole owner, so the defensive `.dup` is dropped (same pattern `CaptureBuffer#to_slice` already trusts).

`copy_n` re-keys its per-read size off the **passed buffer's own size** instead of the `BUFSIZE` constant, so a sub-`BUFSIZE` scratch stays in-bounds (this is what makes the right-size safe).

### 2. `ContentDecode.decode` — zero-alloc no-encoding gate (`content_decode.cr`)
`decode` is called on **every** fuzz response (and by History/Repeater display, Probe, Miner, SSE, MCP, CLI). It built `String.new(head)` + per-line substrings just to discover most responses carry no encoding. A zero-alloc byte-level gate now short-circuits that: it scans the head (case-insensitive) for the **full** `content-encoding` / `transfer-encoding` names. Using the full names (not `-encoding`) means the ubiquitous `Vary: Accept-Encoding` no longer false-positives the gate open.

### 3. `Matcher` `--mh` header test — cache needle + byte-scan (`matcher.cr`)
`header_pass?` built `String.new(raw.head).scrub.downcase` per response and re-lowercased the needle each call. The needle is now lowercased **once** on assignment (like the existing `num_spec`/`status_spec` setters), and the raw head is byte-scanned (ASCII case-insensitive).

The ASCII case-insensitive substring scan is factored into `Gori::AsciiBytes` so the case-folding semantics live in one reviewed place.

## Correctness
- **Byte-exact / behavior-identical**: no wire, framing, or smuggling/desync surface changes. `read_complete` alters only response-READ buffering (framing decided in `stream()`, untouched); `decode`/matcher operate on a derived display/scan projection that never touches stored/forwarded/resent bytes.
- **30-case `read_complete` harness** (throwaway): every framing × size boundary — Length exact/truncated/with-trailer across 0, 1, `BUFSIZE±1`, `>PRESIZE_CAP`; chunked wire + truncated; close-delimited; none — returned bytes + completeness all exact, no over-read.
- Added specs: content-decode gate (uppercase name, `Vary: Accept-Encoding` false-positive, no-encoding short-circuit); matcher `--mh` case-insensitivity + absent-header + nil-needle.
- Green: `content_decode_spec` (14), `body_spec` (45), `fuzz_spec` (52), `repeater_spec` (9), plus all `ContentDecode` callers — `probe_spec` (99), `sse_spec` (19), `miner/engine` (9), `history_view` (39), `mcp_spec` (123), `repeater_view` (62), proxy `server`/`concurrency_reuse` (33).

## Benchmark (`bench/fuzz_repeater_perf_bench.cr`, `--release`)

| hot path | before | after | speedup | alloc before → after |
|---|---|---|---|---|
| `read_complete` 2 KiB | 2.19 µs | 401 ns | **5.4×** | 68.4 kB → 4.28 kB |
| `read_complete` 512 KiB | 49.3 µs | 26.7 µs | **1.85×** | 1.5 MB → 832 kB |
| `decode` no-encoding | 415 ns | 241 ns | **1.7×** | 992 B → **0 B** |
| `decode` `Vary: Accept-Encoding` | 324 ns | 172 ns | **1.9×** | 784 B → **0 B** |
| matcher `--mh` | 1.15 µs | 176 ns | **6.6×** | 544 B → **0 B** |

No public API change. (A separate finding — single-pass DIST rebuild in the TUI fuzzer view — will follow as its own PR.)