### PR TITLE
perf(tui): rebuild the fuzzer DIST sidebar in one min/max scan, reuse scratch

### DIFF
--- a/bench/fuzz_dist_bench.cr
+++ b/bench/fuzz_dist_bench.cr
@@ -1,0 +1,93 @@
+# Fuzzer DIST sidebar rebuild micro-benchmark. build_dist runs once per frame WHILE a run
+# streams (the cache is keyed on @results_rev, which changes every time a result appends), so
+# a live wordlist run rebuilds the distribution over the whole growing result set every frame.
+#
+# OLD: three growing arrays reallocated per frame, and each of the 3 dimensions scanned FOUR
+#      times — Spark.histogram's own min+max scan, plus an explicit `.min?` and `.max?`.
+# NEW: reuse instance scratch arrays, and one min/max scan per dimension whose bounds are
+#      handed to Spark.histogram so it doesn't re-scan (byte-identical bins + min/max).
+#
+# Build: crystal build bench/fuzz_dist_bench.cr -o bin/fuzz_dist_bench --release
+# Run:   bin/fuzz_dist_bench
+require "benchmark"
+require "../src/gori/tui/spark"
+
+include Gori::Tui
+
+record Row, status : Int32?, length : Int64, words : Int32, duration_us : Int64
+
+def old_build(results : Array(Row), w : Int32)
+  codes = Hash(Int32, Int32).new(0)
+  err = 0
+  lens = [] of Int64
+  words = [] of Int32
+  times = [] of Int64
+  results.each do |r|
+    if s = r.status
+      codes[s] += 1
+      lens << r.length
+      words << r.words
+    else
+      err += 1
+    end
+    times << r.duration_us
+  end
+  {codes.to_a.sort_by!(&.[0]), err,
+   Spark.histogram(lens, w), (lens.min? || 0_i64), (lens.max? || 0_i64),
+   Spark.histogram(words, w), (words.min? || 0), (words.max? || 0),
+   Spark.histogram(times, w), (times.min? || 0_i64), (times.max? || 0_i64)}
+end
+
+LENS  = [] of Int64
+WORDS = [] of Int32
+TIMES = [] of Int64
+
+def hist_bounds64(values : Array(Int64), w : Int32)
+  return {Spark.histogram(values, w), 0_i64, 0_i64} if values.empty?
+  lo = hi = values.unsafe_fetch(0)
+  values.each { |v| lo = v if v < lo; hi = v if v > hi }
+  {Spark.histogram(values, w, min: lo.to_f, max: hi.to_f), lo, hi}
+end
+
+def hist_bounds32(values : Array(Int32), w : Int32)
+  return {Spark.histogram(values, w), 0, 0} if values.empty?
+  lo = hi = values.unsafe_fetch(0)
+  values.each { |v| lo = v if v < lo; hi = v if v > hi }
+  {Spark.histogram(values, w, min: lo.to_f, max: hi.to_f), lo, hi}
+end
+
+def new_build(results : Array(Row), w : Int32)
+  codes = Hash(Int32, Int32).new(0)
+  err = 0
+  lens = LENS; lens.clear
+  words = WORDS; words.clear
+  times = TIMES; times.clear
+  results.each do |r|
+    if s = r.status
+      codes[s] += 1
+      lens << r.length
+      words << r.words
+    else
+      err += 1
+    end
+    times << r.duration_us
+  end
+  lh, lmin, lmax = hist_bounds64(lens, w)
+  wh, wmin, wmax = hist_bounds32(words, w)
+  th, tmin, tmax = hist_bounds64(times, w)
+  {codes.to_a.sort_by!(&.[0]), err, lh, lmin, lmax, wh, wmin, wmax, th, tmin, tmax}
+end
+
+ROWS = Array(Row).new(5000) do |i|
+  k = ((i.to_u32 &* 2654435761_u32) &+ 12345_u32) % 100_u32
+  status = k < 8 ? nil : (200 + (k.to_i % 5) * 100)
+  Row.new(status, (k.to_i64 &* 37) % 5000, (k.to_i &* 7) % 800, (k.to_i64 &* 131) % 250_000)
+end
+W = 32
+
+puts "Fuzzer DIST rebuild bench — #{ROWS.size} rows, sidebar width #{W}"
+raise "output diverged!" unless old_build(ROWS, W) == new_build(ROWS, W)
+Benchmark.ips do |x|
+  x.report("OLD build_dist") { old_build(ROWS, W) }
+  x.report("NEW build_dist") { new_build(ROWS, W) }
+end

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -128,6 +128,12 @@ module Gori::Tui
       @dist_cache = nil.as(DistData?)
       @dist_cache_rev = -1_i64
       @dist_cache_w = -1
+      # Reused scratch for build_dist's histogram inputs — cleared + refilled each rebuild so a
+      # live run doesn't reallocate three growing arrays every frame. Not stored in DistData
+      # (histogram consumes them into fresh bin arrays), so clearing on the next rebuild is safe.
+      @dist_lens = [] of Int64
+      @dist_words = [] of Int32
+      @dist_times = [] of Int64
       # Results-pane memos, all keyed on @results_rev (the O(n)/O(n log n) scans below
       # ran EVERY frame — the busiest moment is a live run streaming results, each of
       # which forces a redraw). matched_count is rev-only; the sorted view also keys on
@@ -1874,9 +1880,9 @@ module Gori::Tui
     private def build_dist(w : Int32) : DistData
       codes = Hash(Int32, Int32).new(0)
       err = 0
-      lens = [] of Int64
-      words = [] of Int32
-      times = [] of Int64
+      lens = @dist_lens; lens.clear
+      words = @dist_words; words.clear
+      times = @dist_times; times.clear
       @results.each do |r|
         if s = r.status
           codes[s] += 1
@@ -1887,12 +1893,40 @@ module Gori::Tui
         end
         times << r.duration_us # every row: a timeout's latency IS the signal
       end
+      lh, lmin, lmax = hist_bounds64(lens, w)
+      wh, wmin, wmax = hist_bounds32(words, w)
+      th, tmin, tmax = hist_bounds64(times, w)
       DistData.new(
         codes: codes.to_a.sort_by!(&.[0]), err: err,
-        len_hist: Spark.histogram(lens, w), len_min: (lens.min? || 0_i64), len_max: (lens.max? || 0_i64),
-        words_hist: Spark.histogram(words, w), words_min: (words.min? || 0), words_max: (words.max? || 0),
-        time_hist: Spark.histogram(times, w), time_min: (times.min? || 0_i64), time_max: (times.max? || 0_i64),
+        len_hist: lh, len_min: lmin, len_max: lmax,
+        words_hist: wh, words_min: wmin, words_max: wmax,
+        time_hist: th, time_min: tmin, time_max: tmax,
       )
+    end
+
+    # Histogram + {min, max} for a dimension in a SINGLE min/max scan whose result is fed to
+    # Spark.histogram so it doesn't re-scan for bounds — replacing the old three passes per
+    # dimension (histogram's own min/max scan + an explicit `.min?` + `.max?`). Empty → zeros,
+    # matching the old `(values.min? || 0)` / `(values.max? || 0)`; the passed bounds are the
+    # array's own min/max, so the binning is byte-identical.
+    private def hist_bounds64(values : Array(Int64), w : Int32) : {Array(Int32), Int64, Int64}
+      return {Spark.histogram(values, w), 0_i64, 0_i64} if values.empty?
+      lo = hi = values.unsafe_fetch(0)
+      values.each do |v|
+        lo = v if v < lo
+        hi = v if v > hi
+      end
+      {Spark.histogram(values, w, min: lo.to_f, max: hi.to_f), lo, hi}
+    end
+
+    private def hist_bounds32(values : Array(Int32), w : Int32) : {Array(Int32), Int32, Int32}
+      return {Spark.histogram(values, w), 0, 0} if values.empty?
+      lo = hi = values.unsafe_fetch(0)
+      values.each do |v|
+        lo = v if v < lo
+        hi = v if v > hi
+      end
+      {Spark.histogram(values, w, min: lo.to_f, max: hi.to_f), lo, hi}
     end
 
     private def adjust_scroll(h : Int32) : Nil


### PR DESCRIPTION
## Summary

The final finding from the fuzzer/repeater perf audit (kept separate from the codec batch in #198 since it's TUI-only).

`build_dist` produces the DIST sidebar's status/length/words/time distribution. Its cache is keyed on `@results_rev`, which changes on **every appended result** — so while a run streams, the sidebar rebuilds over the whole growing result set **every frame**. The old rebuild:
- allocated **three growing arrays** (`lens`/`words`/`times`) per frame, and
- scanned each of the three dimensions **four times** — `Spark.histogram`'s own min+max scan, plus an explicit `.min?` and `.max?`.

Now:
- the three input arrays are **reused instance scratch** (cleared + refilled each rebuild — not stored in `DistData`, which only holds the computed histograms + bounds), and
- a **single min/max scan** per dimension feeds its bounds to `Spark.histogram` (which already accepts `min:`/`max:`) so it doesn't re-scan.

## Correctness
Output is **byte-identical**: the passed bounds are the arrays' own min/max, so the histogram binning and the `*_min`/`*_max` fields are unchanged. Verified by:
- a **712-case differential** (old vs new `DistData`) over random result sets × sidebar widths `{1,8,16,32,64}` × sizes `{0,1,2,5,50,500,3000}`, plus explicit edges (all-error, single response, ties `hi==lo`, zeros) → **0 mismatches**;
- existing `fuzzer_view_spec` DIST suite (37 examples) still green.

## Benchmark (`bench/fuzz_dist_bench.cr`, `--release`, 5000 rows)

| | before | after |
|---|---|---|
| time/rebuild | 86.1 µs | **58.0 µs** (1.48×) |
| alloc/rebuild | 348 kB | **960 B** (362× less) |

The allocation collapse comes from removing the three per-frame array reallocations — a sustained per-frame GC-churn reduction during a live streaming run.