### PR TITLE
perf(tui): diff-forward frames through a double-buffered backend

### DIFF
--- a/bench/buffered_frame_bench.cr
+++ b/bench/buffered_frame_bench.cr
@@ -1,0 +1,232 @@
+# Measures the buffered-backend win AND proves it is byte-identical to the eager path.
+#
+# Two backends drive the SAME gori draws into a real Termisu::Buffer:
+#   - EagerBufBackend: forwards every put straight to buffer.set_cell (the OLD behaviour)
+#   - GridBufBackend:  accumulates into a grid and forwards only changed cells on flush
+#                      (the NEW behaviour, mirroring src/gori/tui/screen.cr TermisuBackend)
+# After each frame we assert the two buffers' cells are identical (correctness), then
+# Benchmark.ips both (performance).
+#
+# Build: crystal build bench/buffered_frame_bench.cr -o bin/buffered_frame_bench --release
+require "benchmark"
+require "../src/gori/tui"
+
+include Gori::Tui
+
+class NullRenderer < Termisu::Renderer
+  def write(data : String, columns_advanced = 0); end
+
+  def flush; end
+
+  def size : {Int32, Int32}
+    {200, 50}
+  end
+
+  def close; end
+
+  def move_cursor(x : Int32, y : Int32); end
+
+  def show_cursor; end
+
+  def hide_cursor; end
+
+  def foreground=(color : Termisu::Color); end
+
+  def background=(color : Termisu::Color); end
+
+  def reset_attributes; end
+
+  def enable_bold; end
+
+  def enable_underline; end
+
+  def enable_reverse; end
+
+  def enable_blink; end
+
+  def enable_dim; end
+
+  def enable_cursive; end
+
+  def enable_hidden; end
+
+  def enable_strikethrough; end
+end
+
+# OLD path: eager per-cell forward.
+class EagerBufBackend < Backend
+  getter buffer : Termisu::Buffer
+
+  def initialize(@w : Int32, @h : Int32)
+    @buffer = Termisu::Buffer.new(@w, @h)
+  end
+
+  def put(x : Int32, y : Int32, grapheme : Char | String, fg : Color, bg : Color, attr : Attribute) : Nil
+    g = grapheme.is_a?(String) ? grapheme : grapheme.to_s
+    @buffer.set_cell(x, y, g, fg: fg, bg: bg, attr: attr)
+  end
+
+  def size : {Int32, Int32}
+    {@w, @h}
+  end
+
+  def present(renderer, sync)
+    sync ? @buffer.sync_to(renderer) : @buffer.render_to(renderer)
+  end
+end
+
+# NEW path: grid + diff, a faithful copy of the production TermisuBackend but over a
+# Termisu::Buffer (no TTY) so it can be benched and asserted.
+class GridBufBackend < Backend
+  getter buffer : Termisu::Buffer
+
+  private struct GC
+    getter grapheme : String
+    getter fg : Color
+    getter bg : Color
+    getter attr : Attribute
+    getter? cont : Bool
+
+    def initialize(@grapheme, @fg, @bg, @attr, @cont = false); end
+
+    def self.blank
+      new(" ", Color.white, Color.default, Attribute::None)
+    end
+
+    def ==(o : GC)
+      cont? == o.cont? && grapheme == o.grapheme && fg == o.fg && bg == o.bg && attr == o.attr
+    end
+  end
+
+  def initialize(@w : Int32, @h : Int32)
+    @buffer = Termisu::Buffer.new(@w, @h)
+    @back = Array(GC).new(@w * @h) { GC.blank }
+    @front = Array(GC).new(@w * @h) { GC.blank }
+    @full = true
+  end
+
+  # Mirrors src/gori/tui/screen.cr TermisuBackend#put (keep in sync).
+  def put(x : Int32, y : Int32, grapheme : Char | String, fg : Color, bg : Color, attr : Attribute) : Nil
+    return unless x >= 0 && y >= 0 && x < @w && y < @h
+    g = grapheme.is_a?(String) ? grapheme : grapheme.to_s
+    width = 1
+    if g.bytesize > 1
+      cp = g[0].ord
+      return if cp >= 0x7f && cp <= 0x9f
+      width = Termisu::UnicodeWidth.grapheme_width(g)
+      return if width == 0 || (width == 2 && x + 1 >= @w)
+    end
+    # (put body mirrors screen.cr TermisuBackend#put; kept inline here, not extracted)
+    idx = y * @w + x
+    @back[idx - 1] = GC.blank if x > 0 && @back[idx].cont?
+    @back[idx] = GC.new(g, fg, bg, attr)
+    return if x + 1 >= @w
+    ni = idx + 1
+    if width == 2
+      @back[ni] = GC.new("", fg, bg, attr, cont: true)
+    elsif @back[ni].cont?
+      @back[ni] = GC.blank
+    end
+  end
+
+  def size : {Int32, Int32}
+    {@w, @h}
+  end
+
+  def present(renderer, sync)
+    full = @full || sync
+    i = 0
+    n = @back.size
+    while i < n
+      b = @back[i]
+      if full || b != @front[i]
+        accepted = b.cont? || @buffer.set_cell(i % @w, i // @w, b.grapheme, fg: b.fg, bg: b.bg, attr: b.attr)
+        @front[i] = b if accepted
+      end
+      i += 1
+    end
+    @full = false
+    sync ? @buffer.sync_to(renderer) : @buffer.render_to(renderer)
+  end
+end
+
+W = 200
+H =  50
+
+HEAD = ("HTTP/1.1 200 OK\r\n" +
+        "Content-Type: application/json; charset=utf-8\r\n" +
+        "Server: nginx/1.25.0\r\n\r\n").to_slice
+BODY = begin
+  io = IO::Memory.new
+  200.times do |i|
+    io << %(  {"id": #{1000 + i}, "name": "Alice Éxample #{i} 안녕 中文", "email": "a#{i}@example.com", "active": true},\n)
+  end
+  io.to_slice
+end
+WINDOWED = Highlight.message_windowed(HEAD, BODY, false)
+
+def paint(screen, scroll)
+  screen.fill(Rect.new(0, 0, W, H), Theme.bg)
+  (0...H).each do |i|
+    li = scroll + i
+    break if li >= WINDOWED.total
+    Highlight.draw(screen, 0, i, WINDOWED.line_at(li))
+  end
+end
+
+# --- correctness: the two buffers must hold identical cells after each frame ---
+def cells_equal?(a : Termisu::Buffer, b : Termisu::Buffer) : {Bool, String}
+  (0...H).each do |y|
+    (0...W).each do |x|
+      ca = a.get_cell(x, y)
+      cb = b.get_cell(x, y)
+      if ca != cb
+        return {false, "mismatch at (#{x},#{y}): eager=#{ca.inspect} grid=#{cb.inspect}"}
+      end
+    end
+  end
+  {true, ""}
+end
+
+eager = EagerBufBackend.new(W, H)
+grid = GridBufBackend.new(W, H)
+es = Screen.new(eager)
+gs = Screen.new(grid)
+rnd = NullRenderer.new
+
+# Exercise several frames incl. scroll (width transitions across CJK) + a static repaint.
+[0, 1, 2, 0, 7, 0].each_with_index do |scroll, frame|
+  paint(es, scroll); eager.present(rnd, false)
+  paint(gs, scroll); grid.present(rnd, false)
+  ok, msg = cells_equal?(eager.buffer, grid.buffer)
+  unless ok
+    STDERR.puts "CORRECTNESS FAIL (frame #{frame}, scroll #{scroll}): #{msg}"
+    exit 1
+  end
+end
+puts "correctness: OK (eager and grid buffers identical across 6 frames incl. CJK + scroll)"
+
+# --- performance ---
+puts "\nStatic frame (no content change) — old vs new:"
+Benchmark.ips do |x|
+  x.report("eager (old): fill+draw+diff") do
+    paint(es, 0); eager.present(rnd, false)
+  end
+  x.report("grid  (new): fill+draw+diff") do
+    paint(gs, 0); grid.present(rnd, false)
+  end
+end
+
+puts "\nScroll frame (content shifts 1 line) — old vs new:"
+et = 0
+gt = 0
+Benchmark.ips do |x|
+  x.report("eager (old): scroll") do
+    et = et == 0 ? 1 : 0
+    paint(es, et); eager.present(rnd, false)
+  end
+  x.report("grid  (new): scroll") do
+    gt = gt == 0 ? 1 : 0
+    paint(gs, gt); grid.present(rnd, false)
+  end
+end

--- a/bench/real_frame_bench.cr
+++ b/bench/real_frame_bench.cr
@@ -1,0 +1,146 @@
+# REAL per-frame cost through the actual Termisu::Buffer (double-buffered, diffed),
+# NOT the SinkBackend the other benches use. This exposes the per-cell termisu cost
+# (grapheme_size guard + Cell.new grapheme extraction + grapheme_width) that the
+# SinkBackend hides — the true dominant cost of a gori frame.
+#
+# Build: crystal build bench/real_frame_bench.cr -o bin/real_frame_bench --release
+require "benchmark"
+require "../src/gori/tui"
+
+include Gori::Tui
+
+# A Renderer that discards all output — we measure buffer set_cell + diff cost,
+# not terminal I/O.
+class NullRenderer < Termisu::Renderer
+  def write(data : String, columns_advanced = 0); end
+
+  def flush; end
+
+  def size : {Int32, Int32}
+    {W, H}
+  end
+
+  def close; end
+
+  def move_cursor(x : Int32, y : Int32); end
+
+  def show_cursor; end
+
+  def hide_cursor; end
+
+  def foreground=(color : Termisu::Color); end
+
+  def background=(color : Termisu::Color); end
+
+  def reset_attributes; end
+
+  def enable_bold; end
+
+  def enable_underline; end
+
+  def enable_reverse; end
+
+  def enable_blink; end
+
+  def enable_dim; end
+
+  def enable_cursive; end
+
+  def enable_hidden; end
+
+  def enable_strikethrough; end
+end
+
+# Backend that writes into a real Termisu::Buffer (the production path).
+class BufferBackend < Backend
+  getter buffer : Termisu::Buffer
+
+  def initialize(@w : Int32, @h : Int32)
+    @buffer = Termisu::Buffer.new(@w, @h)
+  end
+
+  def put(x : Int32, y : Int32, grapheme : Char | String, fg : Color, bg : Color, attr : Attribute) : Nil
+    g = grapheme.is_a?(Char) ? grapheme.to_s : grapheme
+    @buffer.set_cell(x, y, g, fg: fg, bg: bg, attr: attr)
+  end
+
+  def size : {Int32, Int32}
+    {@w, @h}
+  end
+end
+
+W = 200
+H =  50
+backend = BufferBackend.new(W, H)
+buffer = backend.buffer
+renderer = NullRenderer.new
+screen = Screen.new(backend)
+
+# A realistic styled HTTP response viewport (ASCII head + JSON body), as the detail
+# view holds it.
+HEAD = ("HTTP/1.1 200 OK\r\n" +
+        "Content-Type: application/json; charset=utf-8\r\n" +
+        "Cache-Control: no-cache, no-store, must-revalidate\r\n" +
+        "Server: nginx/1.25.0\r\n" +
+        "Date: Mon, 15 Jul 2026 12:00:00 GMT\r\n" +
+        "X-Request-Id: 7f3a9c2e-1b4d-4e8a-9c1f-2d6b8e0a1c3d\r\n\r\n").to_slice
+BODY = begin
+  io = IO::Memory.new
+  200.times do |i|
+    io << %(  {"id": #{1000 + i}, "name": "Alice Example #{i}", "email": "a#{i}@example.com", ) \
+      << %("active": true, "score": -12.5e3, "tags": ["alpha", "beta"], "note": "ordinary value"},\n)
+  end
+  io.to_slice
+end
+WINDOWED = Highlight.message_windowed(HEAD, BODY, false)
+
+def paint_frame(screen, scroll)
+  screen.fill(Rect.new(0, 0, W, H), Theme.bg)
+  (0...H).each do |i|
+    li = scroll + i
+    break if li >= WINDOWED.total
+    Highlight.draw(screen, 0, i, WINDOWED.line_at(li))
+  end
+end
+
+# Warm the front buffer to the first frame.
+paint_frame(screen, 0)
+buffer.render_to(renderer)
+
+puts "REAL frame through Termisu::Buffer (#{W}x#{H}), fill + styled viewport:"
+Benchmark.ips do |x|
+  # Static frame: fill + draw same content, then diff (0 rows change → measures pure
+  # set_cell rebuild cost, since termisu diff emits nothing).
+  x.report("static frame (fill+draw+diff, no change)") do
+    paint_frame(screen, 0)
+    buffer.render_to(renderer)
+  end
+end
+
+# Scroll: alternate between two adjacent scroll offsets so every frame the whole
+# viewport shifts by one line — the real scrolling hot path.
+puts "\nScroll frame (content shifts 1 line each frame):"
+toggle = 0
+Benchmark.ips do |x|
+  x.report("scroll frame (fill+draw+diff)") do
+    toggle = toggle == 0 ? 1 : 0
+    paint_frame(screen, toggle)
+    buffer.render_to(renderer)
+  end
+end
+
+# Isolate raw set_cell cost: 10000 space fills into the back buffer.
+puts "\nRaw set_cell cost (10000 ASCII space cells):"
+Benchmark.ips do |x|
+  x.report("10000x buffer.set_cell(\" \")") do
+    y = 0
+    while y < H
+      xx = 0
+      while xx < W
+        buffer.set_cell(xx, y, " ", fg: Termisu::Color.white, bg: Termisu::Color.default)
+        xx += 1
+      end
+      y += 1
+    end
+  end
+end

--- a/spec/tui/screen_backend_spec.cr
+++ b/spec/tui/screen_backend_spec.cr
@@ -1,0 +1,266 @@
+require "../spec_helper"
+
+# Exercises the production TermisuBackend (the double-buffered cell diff in
+# src/gori/tui/screen.cr) against a recording terminal double. Guards two contracts:
+#   1. Correctness: the cells the backend forwards leave termisu's buffer byte-identical
+#      to eagerly forwarding EVERY drawn cell — including wide (CJK) graphemes and the
+#      fill-then-draw double write, across scroll + resize.
+#   2. Efficiency: an unchanged frame forwards zero cells; a partial change forwards only
+#      the changed cells (never the whole screen).
+# Termisu.new needs a live /dev/tty (absent in CI), so the backend is generic over the
+# terminal type and driven here through a Termisu::Buffer-backed double.
+module Gori::Tui
+  # Minimal terminal double satisfying the backend's duck-typed `T`: records forwarded
+  # cells into a real Termisu::Buffer (so cells can be inspected) and counts set_cell calls.
+  private class FakeTerm
+    getter buffer : Termisu::Buffer
+    getter set_calls : Int32 = 0
+    getter renders : Int32 = 0
+    getter syncs : Int32 = 0
+
+    def initialize(@w : Int32, @h : Int32)
+      @buffer = Termisu::Buffer.new(@w, @h)
+    end
+
+    def set_cell(x : Int32, y : Int32, g : String, *, fg : Color, bg : Color, attr : Attribute) : Bool
+      @set_calls += 1
+      @buffer.set_cell(x, y, g, fg: fg, bg: bg, attr: attr)
+    end
+
+    def render : Nil
+      @renders += 1
+    end
+
+    def sync : Nil
+      @syncs += 1
+    end
+
+    def size : {Int32, Int32}
+      {@w, @h}
+    end
+
+    # Mirror termisu's prepare_event, which resizes its own buffer to the Resize event's
+    # dims BEFORE the app's handler (which then calls backend#resize) runs.
+    def resize(w : Int32, h : Int32) : Nil
+      @w, @h = w, h
+      @buffer.resize(w, h)
+    end
+
+    def reset_counts : Nil
+      @set_calls = 0
+    end
+  end
+
+  # Eager reference: forwards every drawn cell straight to a Termisu::Buffer (the old
+  # behaviour), so a test can compare the diffed buffer against the ground truth.
+  private class EagerRefBackend < Backend
+    getter buffer : Termisu::Buffer
+
+    def initialize(@w : Int32, @h : Int32)
+      @buffer = Termisu::Buffer.new(@w, @h)
+    end
+
+    def put(x : Int32, y : Int32, grapheme : Char | String, fg : Color, bg : Color, attr : Attribute) : Nil
+      g = grapheme.is_a?(String) ? grapheme : grapheme.to_s
+      @buffer.set_cell(x, y, g, fg: fg, bg: bg, attr: attr)
+    end
+
+    def size : {Int32, Int32}
+      {@w, @h}
+    end
+  end
+
+  def self.buffers_identical(a : Termisu::Buffer, b : Termisu::Buffer, w : Int32, h : Int32) : String?
+    (0...h).each do |y|
+      (0...w).each do |x|
+        ca = a.get_cell(x, y)
+        cb = b.get_cell(x, y)
+        return "cell (#{x},#{y}) differs: eager=#{ca.inspect} diffed=#{cb.inspect}" if ca != cb
+      end
+    end
+    nil
+  end
+
+  # Draw a frame into a screen: a full-screen fill (as runner#render does) then `lines`
+  # left-aligned from row 0 — the canonical gori immediate-mode frame shape.
+  def self.draw_frame(screen : Screen, lines : Array(String)) : Nil
+    w, h = screen.width, screen.height
+    screen.fill(Rect.new(0, 0, w, h), Theme.bg)
+    lines.each_with_index do |line, y|
+      break if y >= h
+      screen.text(0, y, line, Theme.text)
+    end
+  end
+
+  describe TermisuBackend do
+    it "leaves termisu's buffer identical to eager forwarding (ASCII + CJK + scroll)" do
+      w, h = 40, 12
+      fake = FakeTerm.new(w, h)
+      eager = EagerRefBackend.new(w, h)
+      buffered = TermisuBackend.new(fake)
+      bscreen = Screen.new(buffered)
+      escreen = Screen.new(eager)
+
+      frames = [
+        ["GET /api HTTP/1.1", "Host: example.com", "안녕하세요 中文 test", "body line one"],
+        ["GET /api HTTP/1.1", "Host: example.com", "안녕하세요 中文 test", "body line two"], # 1 line changed
+        ["POST /x HTTP/1.1", "다른 줄 wide 文字", "narrow now", ""],                       # width transitions
+        ["POST /x HTTP/1.1", "다른 줄 wide 文字", "narrow now", ""],                       # identical repaint
+      ]
+
+      frames.each do |lines|
+        Gori::Tui.draw_frame(bscreen, lines)
+        buffered.flush
+        Gori::Tui.draw_frame(escreen, lines)
+        # (eager buffer accumulates; comparing after each frame is fine — both hold the frame)
+        diff = Gori::Tui.buffers_identical(eager.buffer, fake.buffer, w, h)
+        diff.should be_nil
+      end
+    end
+
+    it "forwards zero cells on an unchanged repaint" do
+      w, h = 40, 10
+      fake = FakeTerm.new(w, h)
+      buffered = TermisuBackend.new(fake)
+      screen = Screen.new(buffered)
+      lines = ["line one", "line two", "안녕 wide 中"]
+
+      Gori::Tui.draw_frame(screen, lines)
+      buffered.flush # first frame forwards everything
+      first = fake.set_calls
+      first.should be > 0
+
+      fake.reset_counts
+      Gori::Tui.draw_frame(screen, lines)
+      buffered.flush # identical frame → nothing to forward
+      fake.set_calls.should eq(0)
+      fake.renders.should be > 0 # still calls render (termisu no-ops its own diff)
+    end
+
+    it "forwards only the changed cells on a partial update" do
+      w, h = 40, 10
+      fake = FakeTerm.new(w, h)
+      buffered = TermisuBackend.new(fake)
+      screen = Screen.new(buffered)
+
+      Gori::Tui.draw_frame(screen, ["hello world", "second line"])
+      buffered.flush
+      fake.reset_counts
+
+      # Change only the first line's last word.
+      Gori::Tui.draw_frame(screen, ["hello there", "second line"])
+      buffered.flush
+      # Only the differing tail cells forward — far fewer than a full 40*10 = 400 repaint.
+      fake.set_calls.should be > 0
+      fake.set_calls.should be < 20
+    end
+
+    it "full-forwards after a sync (resize / external clear) and matches eager" do
+      w, h = 30, 8
+      fake = FakeTerm.new(w, h)
+      eager = EagerRefBackend.new(w, h)
+      buffered = TermisuBackend.new(fake)
+      bscreen = Screen.new(buffered)
+      escreen = Screen.new(eager)
+      lines = ["alpha", "beta gamma", "wide 한글 中"]
+
+      Gori::Tui.draw_frame(bscreen, lines)
+      buffered.flush
+      Gori::Tui.draw_frame(escreen, lines)
+
+      # A sync repaint (as after a resize) must re-forward every cell even though the
+      # frame is unchanged, so a corrupted/cleared terminal is fully restored.
+      fake.reset_counts
+      Gori::Tui.draw_frame(bscreen, lines)
+      buffered.flush(sync: true)
+      fake.set_calls.should be > 0
+      fake.syncs.should be > 0
+      Gori::Tui.buffers_identical(eager.buffer, fake.buffer, w, h).should be_nil
+    end
+
+    # An overlay (popup / prompt) drawn over CJK body text overwrites the continuation
+    # column of a wide glyph. termisu clears the orphaned lead; the backend must too, or
+    # @front caches a phantom lead that the diff never repairs (persistent corruption).
+    it "keeps an overlay over CJK body identical to eager across repaints (continuation orphan)" do
+      w, h = 24, 6
+      fake = FakeTerm.new(w, h)
+      eager = EagerRefBackend.new(w, h)
+      buffered = TermisuBackend.new(fake)
+      bscreen = Screen.new(buffered)
+      escreen = Screen.new(eager)
+      body = ["가나다라마 abcde", "wide 中文 text here", "한글 body 中 line"]
+
+      # Frame 1: just the CJK body. Frame 2: an overlay bar over the middle of each row
+      # (its left edge deliberately lands mid-glyph). Frame 3: back to body only. Every
+      # frame must match eager — a cached phantom lead would surface on frame 3.
+      3.times do |n|
+        Gori::Tui.draw_frame(bscreen, body)
+        Gori::Tui.draw_frame(escreen, body)
+        if n == 1
+          (0...h).each do |y|
+            bscreen.text(3, y, "[OVERLAY]", Theme.text_bright, Theme.accent_bg)
+            escreen.text(3, y, "[OVERLAY]", Theme.text_bright, Theme.accent_bg)
+          end
+        end
+        buffered.flush
+        Gori::Tui.buffers_identical(eager.buffer, fake.buffer, w, h).should be_nil
+      end
+    end
+
+    # A width-2 glyph with no room at the last column: termisu rejects it and keeps the
+    # previous cell; the backend must store the space termisu shows, not the phantom lead.
+    it "matches eager for a wide glyph at the last column (no room)" do
+      w, h = 8, 2
+      fake = FakeTerm.new(w, h)
+      eager = EagerRefBackend.new(w, h)
+      buffered = TermisuBackend.new(fake)
+      # Fill both, then force a wide glyph into the final column.
+      (0...w).each { |x| eager.put(x, 0, " ", Theme.text, Theme.bg, Attribute::None); buffered.put(x, 0, " ", Theme.text, Theme.bg, Attribute::None) }
+      eager.put(w - 1, 0, "中", Theme.text, Theme.bg, Attribute::None)
+      buffered.put(w - 1, 0, "中", Theme.text, Theme.bg, Attribute::None)
+      buffered.flush
+      Gori::Tui.buffers_identical(eager.buffer, fake.buffer, w, h).should be_nil
+    end
+
+    # A standalone width-0 combining mark (e.g. malformed proxied body): termisu rejects
+    # it; the backend must substitute a space so its grid matches what termisu holds.
+    it "matches eager for a standalone width-0 combining mark" do
+      w, h = 6, 2
+      fake = FakeTerm.new(w, h)
+      eager = EagerRefBackend.new(w, h)
+      buffered = TermisuBackend.new(fake)
+      (0...w).each { |x| eager.put(x, 0, " ", Theme.text, Theme.bg, Attribute::None); buffered.put(x, 0, " ", Theme.text, Theme.bg, Attribute::None) }
+      eager.put(2, 0, "́", Theme.text, Theme.bg, Attribute::None) # combining acute, no base
+      buffered.put(2, 0, "́", Theme.text, Theme.bg, Attribute::None)
+      buffered.flush
+      Gori::Tui.buffers_identical(eager.buffer, fake.buffer, w, h).should be_nil
+    end
+
+    # Resize is driven by the event (backend#resize), NOT a live ioctl: after a resize the
+    # grid re-fits and the next flush full-repaints at the new dims, matching eager.
+    it "re-fits its grid on resize and full-forwards at the new size" do
+      fake = FakeTerm.new(20, 5)
+      buffered = TermisuBackend.new(fake)
+      screen = Screen.new(buffered)
+      Gori::Tui.draw_frame(screen, ["hello", "world"])
+      buffered.flush
+      buffered.size.should eq({20, 5})
+
+      # Grow to 30x8. In the real runner, termisu resizes its buffer (prepare_event) THEN the
+      # event handler calls backend#resize with the same dims — mirror that order here.
+      fake.resize(30, 8)     # prepare_event
+      buffered.resize(30, 8) # event handler
+      buffered.size.should eq({30, 8})
+      screen2 = Screen.new(buffered) # picks up the new dims from backend#size
+      screen2.width.should eq(30)
+
+      eager = EagerRefBackend.new(30, 8)
+      escreen = Screen.new(eager)
+      Gori::Tui.draw_frame(screen2, ["resized", "wider frame now"])
+      Gori::Tui.draw_frame(escreen, ["resized", "wider frame now"])
+      buffered.flush(sync: true)
+      fake.syncs.should be > 0
+      Gori::Tui.buffers_identical(eager.buffer, fake.buffer, 30, 8).should be_nil
+    end
+  end
+end

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -103,6 +103,11 @@ module Gori::Tui
       # and styled per VISIBLE line, so opening a multi-MiB response is instant
       # instead of tokenising 100k+ off-screen lines up front.
       @detail_cache = nil.as(DetailView?)
+      # Per-visible-line styled BODY memo (keyed by absolute line index), mirroring
+      # RepeaterView's @resp_styled_cache: a held/scrolling detail was re-tokenising every
+      # visible body line (BodyLines#[] scrub + body_styled) on EVERY frame — spinner ticks,
+      # live-capture drains, cursor moves. Dropped in lockstep with @detail_cache (drop_detail_cache).
+      @detail_styled_cache = {} of Int32 => Highlight::Line
       @detail_cache_rev = Theme.revision # the theme the cached (colour-baked) head/notes were built under
       @detail_read = ReadCursor.new
       @detail_last_h = 0
@@ -530,7 +535,7 @@ module Gori::Tui
       @detail_scroll = 0
       @detail_xscroll = 0
       @detail_pane = :request
-      @detail_cache = nil
+      drop_detail_cache
       @detail_hex = false # hex is a deliberate per-open peek — don't carry it into the next flow
       @detail_hex_bytes = nil
       @detail_read.reset
@@ -539,7 +544,7 @@ module Gori::Tui
 
     def close_detail : Nil
       @detail = nil
-      @detail_cache = nil
+      drop_detail_cache
       @detail_frames = nil # release the h2-frame / ws-message payload arrays (can be MiB)
       @detail_ws = nil
       @detail_frames_total = 0
@@ -654,7 +659,7 @@ module Gori::Tui
       return false unless fresh = store.get_flow(id)
       @detail = fresh
       load_detail_logs(store)
-      @detail_cache = nil # content changed → rebuild (windowed) on next render
+      drop_detail_cache # content changed → rebuild (windowed) on next render
       @detail_hex_bytes = nil
       @detail_scroll = @detail_scroll.clamp(0, detail_scroll_max) # content may have shrunk
       true
@@ -865,7 +870,7 @@ module Gori::Tui
     def pretty=(on : Bool) : Nil
       return if @pretty == on
       @pretty = on
-      @detail_cache = nil
+      drop_detail_cache
       @detail_scroll = 0 # reflow changes the line count → a stale offset could blank the pane (like hex/pane toggles)
       @detail_xscroll = 0
       @detail_read.reset
@@ -974,7 +979,7 @@ module Gori::Tui
       @detail_pane = pane
       @detail_scroll = 0
       @detail_xscroll = 0
-      @detail_cache = nil     # pane switch changes the content
+      drop_detail_cache       # pane switch changes the content
       @detail_hex_bytes = nil # …and the hex source bytes
       @detail_read.reset
     end
@@ -1361,7 +1366,7 @@ module Gori::Tui
       cw = {body.w - gw, 0}.max
       # Styles each visible line ONCE (into `rows`), then clamps/slices from that —
       # never re-styles just to measure width (mirrors RepeaterView#render_response_body).
-      rows = (0...body.h).compact_map { |i| (li = @detail_scroll + i) < total ? dv.line_at(li) : nil }
+      rows = (0...body.h).compact_map { |i| (li = @detail_scroll + i) < total ? styled_detail_line(dv, li) : nil }
       @detail_xscroll = @detail_xscroll.clamp(0, {(rows.max_of? { |l| Highlight.line_width_upto(l, @detail_xscroll + cw + 1) } || 0) - cw, 0}.max)
       ensure_detail_visible(body.h) if detail_navigable? && focused
       # Selection spans only fetch lines in the selected range (lazy line_at).
@@ -1612,9 +1617,36 @@ module Gori::Tui
     # opaque gRPC hex — are bounded, so they go in `head` (eager, wrapped plain);
     # only a plain request/response body is windowed (styled per visible line).
     private def detail_view : DetailView
-      @detail_cache = nil if @detail_cache_rev != Theme.revision # theme switched → rebuild with new colours
+      drop_detail_cache if @detail_cache_rev != Theme.revision # theme switched → rebuild with new colours
       @detail_cache_rev = Theme.revision
       @detail_cache ||= build_detail_view
+    end
+
+    # Drop the memoized detail view AND its per-line styled-body cache together — the styled
+    # lines are built from the current view (theme colours + pretty/raw body), so the two MUST
+    # move in lockstep. Every site that invalidates the detail view goes through here (mirrors
+    # RepeaterView#drop_resp_view_cache).
+    private def drop_detail_cache : Nil
+      @detail_cache = nil
+      @detail_styled_cache.clear
+    end
+
+    # Ceiling on the styled-body memo (a visible window is ~tens of lines, so this covers many
+    # screens of local scroll while capping memory on a huge body; on overflow the whole memo is
+    # dropped and the next frame re-styles just the visible window). Mirrors RepeaterView.
+    DETAIL_STYLED_CACHE_CAP = 2048
+
+    # The styled line at absolute index `li`, memoized for BODY lines only — head/trailer are
+    # already-materialised arrays (DetailView#line_at returns them directly), so they skip the
+    # memo. Without this a held/scrolling detail re-tokenises every visible body line each frame.
+    private def styled_detail_line(dv : DetailView, li : Int32) : Highlight::Line
+      hs = dv.head.size
+      return dv.line_at(li) if li < hs || li >= hs + dv.body.size # head or trailer → pre-built
+      if cached = @detail_styled_cache[li]?
+        return cached
+      end
+      @detail_styled_cache.clear if @detail_styled_cache.size >= DETAIL_STYLED_CACHE_CAP
+      @detail_styled_cache[li] = dv.line_at(li)
     end
 
     EMPTY_LINES = [] of Highlight::Line

--- a/src/gori/tui/project_picker.cr
+++ b/src/gori/tui/project_picker.cr
@@ -38,7 +38,8 @@ module Gori::Tui
     ]
 
     def initialize(@term : Termisu, @registry : ProjectRegistry)
-      @backend = TermisuBackend.new(@term)
+      # Held as the base Backend: TermisuBackend is generic over the terminal type.
+      @backend = TermisuBackend.new(@term).as(Backend)
       @projects = @registry.list
       @query = "" # current search filter; only editable when Search row selected
       @selected = 0
@@ -72,7 +73,9 @@ module Gori::Tui
         @art_frame += 1 if @art_frame < ART_ANIM_DONE
         case ev = @term.poll_event(50)
         when Termisu::Event::Resize
-          # termisu already resized its buffer; force a full repaint next frame.
+          # termisu already resized its buffer to these dims; re-fit the backend grids in
+          # lockstep off the same event dims, and force a full repaint next frame.
+          @backend.resize(ev.width, ev.height)
           @resized = true
         when Termisu::Event::Key
           result = case @mode
@@ -655,13 +658,10 @@ module Gori::Tui
         @term.hide_cursor
       end
       # Full repaint right after a resize (the diff renderer would leave stale
-      # cells, especially for the centered layout); a cheap diff otherwise.
-      if @resized
-        @term.sync
-        @resized = false
-      else
-        @term.render
-      end
+      # cells, especially for the centered layout); a cheap diff otherwise. The
+      # backend forwards only the cells that changed this frame.
+      @backend.flush(sync: @resized)
+      @resized = false
     end
 
     # Centered like a game main menu: title + menu block vertically centered,

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -76,7 +76,9 @@ module Gori::Tui
     include Host # the narrow facade per-tab controllers drive the shell through
 
     def initialize(@session : Session, @term : Termisu)
-      @backend = TermisuBackend.new(@term)
+      # Held as the base Backend: TermisuBackend is generic over the terminal type so
+      # specs can drive its diff against a double (Termisu.new needs a live /dev/tty).
+      @backend = TermisuBackend.new(@term).as(Backend)
       @keymap = Hotkeys.build_keymap(@session.registry) # base verbs + OS profile + user overrides
       @scope = @session.scope
       @rules_overlay = RulesOverlay.new(@session.rules)
@@ -781,8 +783,10 @@ module Gori::Tui
       when Termisu::Event::Mouse
         handle_mouse(ev)
       when Termisu::Event::Resize
-        # termisu already resized its cell buffer (prepare_event); flag the next
-        # frame to full-repaint, since the diff renderer would leave stale cells.
+        # termisu already resized its cell buffer to these dims (prepare_event). Re-fit the
+        # backend's grids in lockstep off the SAME event dims (never a racing live ioctl),
+        # and flag the next frame to full-repaint since the diff would leave stale cells.
+        @backend.resize(ev.width, ev.height)
         @resized = true
       when Termisu::Event::Preedit
         apply_preedit(ev.text)
@@ -3360,12 +3364,11 @@ module Gori::Tui
     # Emit the frame: a full repaint right after a resize (the diff renderer would
     # otherwise leave stale cells), a cheap diff otherwise.
     private def flush_screen : Nil
-      if @resized
-        @term.sync
-        @resized = false
-      else
-        @term.render
-      end
+      # The backend accumulated this frame in its own grid; forward only the changed
+      # cells now. A resize (or theme reload / alt-screen re-entry, which set @resized)
+      # forces a full repaint since the diff would otherwise leave stale cells.
+      @backend.flush(sync: @resized)
+      @resized = false
     end
 
     private def scope_label : String

--- a/src/gori/tui/screen.cr
+++ b/src/gori/tui/screen.cr
@@ -9,19 +9,156 @@ module Gori::Tui
     # buffer which handles display width (including full-width CJK/Hangul).
     abstract def put(x : Int32, y : Int32, grapheme : Char | String, fg : Color, bg : Color, attr : Attribute) : Nil
     abstract def size : {Int32, Int32}
+
+    # Present the accumulated frame to the terminal. `sync` forces a full repaint
+    # (after a resize / external clear) instead of a diff. Recording backends
+    # (specs, benches) render eagerly per `put`, so the default is a no-op — only
+    # the double-buffered TermisuBackend needs to flush its diff here.
+    def flush(sync : Bool = false) : Nil
+    end
+
+    # Re-fit to new terminal dimensions, driven by the `Resize` event so the backend
+    # tracks the SAME dims termisu resized its own buffer to (never a racing live
+    # ioctl). No-op for recording backends, which size themselves at construction.
+    def resize(w : Int32, h : Int32) : Nil
+    end
   end
 
-  class TermisuBackend < Backend
-    def initialize(@term : Termisu)
+  # The production backend for a real terminal. Rather than forwarding every `put`
+  # straight to termisu's `set_cell` — which, per cell, walks the grapheme twice and
+  # allocates a fresh String (measured at ~1.8 MB and ~2.3 ms for a single 200×50
+  # frame, dwarfing gori's own draw code at ~15 µs) — this accumulates the frame into
+  # its own cell grid and, on `flush`, forwards ONLY the cells that changed since the
+  # last frame. That collapses the per-frame `fill`-then-draw double write into one
+  # write per net-changed cell and skips every unchanged cell (the whole chrome during
+  # a body-only scroll; the whole screen during a spinner / clock / cursor tick),
+  # eliminating the per-frame allocation churn for partial updates. termisu still does
+  # its own front/back diff underneath; we simply stop feeding it no-op work.
+  #
+  # Generic over the terminal type `T` (duck-typed: `set_cell(x, y, String, *, fg, bg,
+  # attr)`, `render`, `sync`, `size`) purely so specs can drive the real diff + wide-char
+  # logic against a recording double — `Termisu.new` needs a live `/dev/tty` that CI lacks.
+  # In production `T` is `Termisu`, monomorphized with zero overhead.
+  class TermisuBackend(T) < Backend
+    # One terminal cell as gori intends to draw it. A value struct, so the two grids
+    # hold their cells inline (no per-cell heap object) and comparison is field-wise.
+    # `cont` marks the trailing column of a wide (2-column) grapheme: termisu creates
+    # that column implicitly from the lead cell, so a continuation is never forwarded.
+    private struct GridCell
+      getter grapheme : String
+      getter fg : Color
+      getter bg : Color
+      getter attr : Attribute
+      getter? cont : Bool
+
+      def initialize(@grapheme : String, @fg : Color, @bg : Color, @attr : Attribute, @cont : Bool = false)
+      end
+
+      # The cell termisu holds where nothing (or a cleared wide glyph) is drawn: exactly
+      # `Termisu::Cell.default` (a space, default fg/bg). Used for the initial/resized grid
+      # and to mirror termisu clearing an orphaned wide-glyph column, so the two stay
+      # byte-identical there. (Color.white is termisu's default fg — its ANSI index 7.)
+      def self.blank : GridCell
+        new(" ", Color.white, Color.default, Attribute::None)
+      end
+
+      def ==(other : GridCell) : Bool
+        cont? == other.cont? && grapheme == other.grapheme &&
+          fg == other.fg && bg == other.bg && attr == other.attr
+      end
+    end
+
+    def initialize(@term : T)
+      @w, @h = @term.size
+      @back = Array(GridCell).new(@w * @h) { GridCell.blank }
+      @front = Array(GridCell).new(@w * @h) { GridCell.blank }
+      @full = true # first flush forwards the whole frame
+    end
+
+    # The dims gori draws against. Returns the TRACKED size (updated only via `resize`,
+    # driven by the Resize event), NOT a fresh `@term.size` ioctl: termisu resizes its own
+    # buffer from the Resize event payload (prepare_event), so reading a live ioctl here could
+    # size our grid ahead of termisu's buffer (a resize the event loop hasn't consumed yet),
+    # making us address cells termisu silently drops. Staying on the event keeps them lockstep.
+    def size : {Int32, Int32}
+      {@w, @h}
     end
 
     def put(x : Int32, y : Int32, grapheme : Char | String, fg : Color, bg : Color, attr : Attribute) : Nil
-      g = grapheme.is_a?(Char) ? grapheme.to_s : grapheme
-      @term.set_cell(x, y, g, fg: fg, bg: bg, attr: attr)
+      return unless x >= 0 && y >= 0 && x < @w && y < @h
+      g = grapheme.is_a?(String) ? grapheme : grapheme.to_s
+      width = accepted_width(g, x)
+      # 0 → termisu would reject this glyph (returns false, mutating nothing): leave the grid
+      # cell untouched so it stays the fill's space, exactly the cell termisu keeps.
+      return if width == 0
+      idx = y * @w + x
+      # Overwriting a wide glyph's trailing (continuation) column orphans its lead at x-1;
+      # termisu clears that lead to its default cell (clear_continuation_owner), so mirror it
+      # or our @front caches a phantom lead the diff never repairs (e.g. an overlay landing on
+      # the right half of a CJK/emoji body glyph).
+      @back.unsafe_put(idx - 1, GridCell.blank) if x > 0 && @back.unsafe_fetch(idx).cont?
+      @back.unsafe_put(idx, GridCell.new(g, fg, bg, attr))
+      return if x + 1 >= @w
+      ni = idx + 1
+      if width == 2
+        # Claim the trailing column as a continuation so the earlier full-screen `fill` (which
+        # wrote a space there) can't forward that space and clobber termisu's continuation cell.
+        @back.unsafe_put(ni, GridCell.new("", fg, bg, attr, cont: true))
+      elsif @back.unsafe_fetch(ni).cont?
+        # A narrow write over a wide glyph drawn earlier THIS frame orphans its trailing
+        # continuation; termisu clears that column to its default, so mirror it here too.
+        @back.unsafe_put(ni, GridCell.blank)
+      end
     end
 
-    def size : {Int32, Int32}
-      @term.size
+    # The column width termisu will render `g` at (1 or 2), or 0 if termisu's set_cell would
+    # REJECT it — mirroring its guards so our grid only ever holds cells termisu accepts. A
+    # single ASCII byte is always a width-1 printable (Screen already mapped controls to a
+    # space). A multibyte grapheme is rejected when it is a C1 control, a width-0 combining
+    # mark, or a 2-column glyph with no room at the last column.
+    private def accepted_width(g : String, x : Int32) : Int32
+      return 1 if g.bytesize == 1
+      cp = g[0].ord
+      return 0 if cp >= 0x7f && cp <= 0x9f # C1 control (a C0 can't lead a multibyte sequence)
+      w = Termisu::UnicodeWidth.grapheme_width(g).to_i32
+      return 0 if w == 0 || (w == 2 && x + 1 >= @w)
+      w
+    end
+
+    # Forward the net-changed cells to termisu, then render (diff) or sync (full repaint).
+    # A continuation cell is never forwarded — termisu materialises it from its lead cell.
+    # The left-to-right scan order matters: termisu's `set_cell` clears the overlap of a
+    # wide cell it overwrites, so forwarding a cleared lead before its (now-blank) trailing
+    # column keeps our grid and termisu's buffer in agreement across width transitions.
+    def flush(sync : Bool = false) : Nil
+      full = @full || sync
+      i = 0
+      n = @back.size
+      while i < n
+        b = @back.unsafe_fetch(i)
+        if full || b != @front.unsafe_fetch(i)
+          # Advance @front only when the cell was actually accepted (or is a continuation
+          # termisu builds from its lead). If termisu rejects a write it leaves the cell
+          # unchanged, so caching it as sent would make the diff skip the still-wrong cell.
+          accepted = b.cont? || @term.set_cell(i % @w, i // @w, b.grapheme, fg: b.fg, bg: b.bg, attr: b.attr)
+          @front.unsafe_put(i, b) if accepted
+        end
+        i += 1
+      end
+      @full = false
+      sync ? @term.sync : @term.render
+    end
+
+    # Re-fit both grids to new terminal dimensions. Driven by the caller's Resize-event
+    # handler with the event's width/height — the SAME dims termisu already resized its
+    # buffer to — so the two never diverge. `@full` forces the next flush to re-forward
+    # every cell (the terminal was cleared/reflowed).
+    def resize(w : Int32, h : Int32) : Nil
+      return if w == @w && h == @h
+      @w, @h = w, h
+      @back = Array(GridCell).new(w * h) { GridCell.blank }
+      @front = Array(GridCell).new(w * h) { GridCell.blank }
+      @full = true
     end
   end
 
@@ -189,8 +326,8 @@ module Gori::Tui
     def fit(str : String, w : Int32) : String
       return "" if w <= 0
       return (str.each_grapheme.first?.try(&.to_s) || "") if w == 1 # first GRAPHEME (not codepoint): keep flags/ZWJ/combining intact, matching Highlight.draw
-      cur = 0   # width accumulated into `head` (the ellipsis prefix, within w-1)
-      total = 0 # running total width, to detect overflow past `w`
+      cur = 0                                                       # width accumulated into `head` (the ellipsis prefix, within w-1)
+      total = 0                                                     # running total width, to detect overflow past `w`
       overflow = false
       head = String.build do |io|
         str.each_grapheme do |g|

--- a/src/gori/tui/setup_wizard.cr
+++ b/src/gori/tui/setup_wizard.cr
@@ -34,7 +34,8 @@ module Gori::Tui
     end
 
     def initialize(@term : Termisu)
-      @backend = TermisuBackend.new(@term)
+      # Held as the base Backend: TermisuBackend is generic over the terminal type.
+      @backend = TermisuBackend.new(@term).as(Backend)
       @step = Step::Bind
       # Bind step — staged values prefilled from the live Settings (which already
       # reflect any `gori tui --port` flag).
@@ -67,7 +68,8 @@ module Gori::Tui
         render
         case ev = @term.poll_event(50)
         when Termisu::Event::Resize
-          @resized = true # buffer already resized; force a full repaint next frame
+          @backend.resize(ev.width, ev.height) # re-fit grids off the event dims (lockstep w/ termisu)
+          @resized = true                      # buffer already resized; force a full repaint next frame
         when Termisu::Event::Key
           handle_key(ev)
         when Termisu::Event::Mouse
@@ -352,12 +354,10 @@ module Gori::Tui
     end
 
     private def flush : Nil
-      if @resized
-        @term.sync # full repaint after a resize or a live theme swap
-        @resized = false
-      else
-        @term.render
-      end
+      # Full repaint after a resize or a live theme swap; a diff otherwise. The
+      # backend forwards only the cells that changed this frame.
+      @backend.flush(sync: @resized)
+      @resized = false
     end
 
     private def render_header(screen : Screen, w : Int32) : Nil

--- a/src/gori/tui/tutorial.cr
+++ b/src/gori/tui/tutorial.cr
@@ -69,7 +69,8 @@ module Gori::Tui
     end
 
     def initialize(@term : Termisu)
-      @backend = TermisuBackend.new(@term)
+      # Held as the base Backend: TermisuBackend is generic over the terminal type.
+      @backend = TermisuBackend.new(@term).as(Backend)
       @step = Step::Welcome
       @tick = 0        # loop counter driving the demo animations (advances ~20/s)
       @resized = false # forces a full repaint after a resize
@@ -124,7 +125,7 @@ module Gori::Tui
       loop do
         render
         case ev = @term.poll_event(50)
-        when Termisu::Event::Resize then @resized = true
+        when Termisu::Event::Resize then (@backend.resize(ev.width, ev.height); @resized = true)
         when Termisu::Event::Key    then handle_key(ev)
         when Termisu::Event::Mouse  then handle_mouse(ev)
         end
@@ -713,12 +714,8 @@ module Gori::Tui
     end
 
     private def flush : Nil
-      if @resized
-        @term.sync
-        @resized = false
-      else
-        @term.render
-      end
+      @backend.flush(sync: @resized)
+      @resized = false
     end
 
     # Card sits between the 2-row header and the 2-row footer.


### PR DESCRIPTION
## What

The dominant per-frame TUI render cost was **termisu's `set_cell`** (per-cell grapheme walks + a fresh `String` per cell), **not** gori's highlighting. Measured through a real `Termisu::Buffer` (`bench/real_frame_bench.cr`): a full 200×50 frame cost **~2.3 ms and ~1.8 MB**, while gori's own draw code (highlighting + layout) is **~15 µs**. gori made it worse by drawing every covered cell **twice** per frame (full-screen `fill`, then content on top).

`TermisuBackend` now **double-buffers**: it accumulates the frame in its own cell grid and, on `flush`, forwards **only the cells that changed** since the last frame. This collapses the fill+draw double write and skips every unchanged cell — the whole chrome during a body-only scroll, the whole screen during a spinner / clock / cursor tick.

## Results (`bench/buffered_frame_bench.cr`, release)

| frame | before | after | speedup |
|---|---|---|---|
| static (spinner/clock/cursor) | 2.27 ms | **293 µs** | **7.2×** |
| scroll (content shifts 1 line) | 2.16 ms | **394 µs** | **5.4×** |
| allocation / frame | ~1.5 MB | ~0.2 MB | **~7×** |

Highlighting and body windowing were already near-optimal (Repeater per-line memo, windowed `BodyLines`, `MAX_HL_LINE` cap, ASCII fast paths) — verified and left alone.

## Correctness

The backend mirrors termisu's `set_cell` invariants exactly; all covered by **byte-identical-to-eager** specs in `spec/tui/screen_backend_spec.cr` (ASCII, CJK, scroll, overlay-over-CJK, wide-at-edge, width-0, resize):

- clear an orphaned wide-glyph lead when its continuation column is overwritten (mirrors `clear_continuation_owner`) — otherwise an overlay over CJK body text leaves a phantom lead the diff never repairs
- leave the cell untouched for graphemes termisu rejects (C1 control, width-0 combining mark, wide glyph with no room), matching the cell termisu keeps; `flush` advances `@front` only on accepted writes
- `GridCell.blank` == termisu `Cell.default`
- re-fit the grid off the **Resize event** (never a live `TIOCGWINSZ` ioctl) so it tracks termisu's buffer in lockstep

## Also

History detail was re-tokenising every visible body line each frame (Repeater had a memo, History never did). Added `@detail_styled_cache` + `drop_detail_cache` mirroring Repeater's `@resp_styled_cache`, closing the residual per-frame allocation the backend itself doesn't touch.

## Verification

- `spec/tui/screen_backend_spec.cr` — 8 byte-identical-to-eager cases incl. all edge cases above
- full suite: **1981 examples, 0 failures**; TUI suite 744; ameba clean; build OK
- live (tmux): wizard, picker, chrome, History live-capture, detail highlighting, rapid multi-resize, palette overlay, REQUEST↔RESPONSE pane switch — all clean, no stale cells