### PR TITLE
fix(probe): cut passive-scan FP/FN and halve HTML/JS body decode

### DIFF
--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -548,6 +548,38 @@ describe "Gori::Probe::Passive (FP reduction)" do
     end
   end
 
+  it "does not flag loopback 127.0.0.1 as a private IP but still flags an RFC 1918 address" do
+    with_store do |store|
+      # Loopback aids no recon and is ubiquitous in bundles/configs (a near-pure FP source).
+      loopback = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n",
+        content_type: "text/html", body: "<p>dev server on http://127.0.0.1:3000/</p>")
+      codes_of(loopback).should_not contain("private_ip_leak")
+      # A real internal (RFC 1918) address is still surfaced.
+      internal = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n",
+        content_type: "text/html", body: "<p>proxy 192.168.1.20</p>")
+      internal.find(&.code.==("private_ip_leak")).not_nil!.evidence.should eq("192.168.1.20")
+    end
+  end
+
+  it "does not flag document headers on a 3xx redirect (not rendered), but still on an error page" do
+    with_store do |store|
+      # A 302 with text/html (the ubiquitous "Redirecting…" body) is FOLLOWED, never rendered,
+      # so its missing CSP/XFO/XCTO/Referrer are noise — the real target page is checked on its
+      # own flow. HSTS still applies to the HTTPS redirect response.
+      redirect = analyze(store, resp_head: "HTTP/1.1 302 Found\r\nLocation: /home\r\n\r\n",
+        status: 302, content_type: "text/html")
+      codes_of(redirect).should_not contain("missing_csp")
+      codes_of(redirect).should_not contain("missing_x_frame_options")
+      codes_of(redirect).should_not contain("missing_referrer_policy")
+      codes_of(redirect).should contain("missing_hsts")
+      # A 4xx/5xx error page IS a rendered document (framable / may reflect) — keep the checks.
+      error = analyze(store, resp_head: "HTTP/1.1 404 Not Found\r\n\r\n",
+        status: 404, content_type: "text/html")
+      codes_of(error).should contain("missing_csp")
+      codes_of(error).should contain("missing_x_frame_options")
+    end
+  end
+
   it "does not flag prose containing a bare '.rb:' but flags a real backtrace frame" do
     with_store do |store|
       prose = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n",
@@ -617,6 +649,23 @@ describe "Gori::Probe::Passive (FP reduction)" do
                                            "script-src 'self' data:\r\n\r\n",
         content_type: "text/html")
       codes_of(data_csp).should contain("weak_csp")
+    end
+  end
+
+  it "flags a bare https:/http: scheme source in script-src, but not a specific https host" do
+    with_store do |store|
+      # A bare 'https:' scheme source is an allowlist that permits ANY host over https to serve
+      # scripts — effectively allow-all, and flagged by CSP evaluators as weak (was a FN here).
+      scheme = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Security-Policy: " \
+                                         "script-src 'self' https:\r\n\r\n", content_type: "text/html")
+      codes_of(scheme).should contain("weak_csp")
+      http = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Security-Policy: " \
+                                       "default-src 'self'; script-src http:\r\n\r\n", content_type: "text/html")
+      codes_of(http).should contain("weak_csp")
+      # A SPECIFIC host over https is a distinct token — a normal, safe allowlist entry.
+      host = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Security-Policy: " \
+                                       "script-src 'self' https://cdn.example.com\r\n\r\n", content_type: "text/html")
+      codes_of(host).should_not contain("weak_csp")
     end
   end
 
@@ -1615,6 +1664,26 @@ end
 private def analyze_js(store, body : String)
   analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Type: application/javascript\r\n\r\n",
     content_type: "application/javascript", body: body)
+end
+
+describe "Gori::Probe::Passive (shared body decode)" do
+  it "decodes a compressed HTML body once yet feeds both body_text and the client rules" do
+    with_store do |store|
+      # An HTML document with a body-text finding (leaked AWS key → BodyLeaks, uses body_text)
+      # AND a client-rule finding (source→sink in an inline script → DomXss, uses client_body_text).
+      # Both must still fire when the body is gzip-encoded, proving the single shared inflate
+      # (Context#decoded_body) feeds both getters correctly.
+      plain = "<html><script>document.write(location.hash)</script>" \
+              "<p>key AKIAIOSFODNN7EXAMPLE here</p></html>"
+      gz = IO::Memory.new
+      Compress::Gzip::Writer.open(gz) { |w| w.write(plain.to_slice) }
+      dets = analyze(store,
+        resp_head: "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\n\r\n",
+        content_type: "text/html", body: String.new(gz.to_slice))
+      codes_of(dets).should contain("secret_in_body") # body_text path
+      codes_of(dets).should contain("dom_xss")         # client_body_text path
+    end
+  end
 end
 
 describe Gori::Probe::Passive::JsScan do

--- a/src/gori/probe/passive/body_leaks.cr
+++ b/src/gori/probe/passive/body_leaks.cr
@@ -14,10 +14,13 @@ module Gori
             Category::INFOLEAK)
         end
 
-        # Private-IP ranges with valid 0-255 octets, required to stand alone (not embedded in a
-        # longer dotted/word token). The leading/trailing guards keep multi-segment version
-        # strings such as "10.1.2.3.4" or "v10.1.2.3" out of the match.
-        PRIVATE_IP = /(?<![\w.])(?:10(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}|172\.(?:1[6-9]|2\d|3[01])(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){2}|192\.168(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){2}|127\.0\.0\.1)(?![\w.])/
+        # RFC 1918 private-IP ranges with valid 0-255 octets, required to stand alone (not
+        # embedded in a longer dotted/word token). The leading/trailing guards keep multi-segment
+        # version strings such as "10.1.2.3.4" or "v10.1.2.3" out of the match. Loopback
+        # (127.0.0.1) is DELIBERATELY excluded: it is not an internal-network address, aids no
+        # reconnaissance (everyone knows localhost), and is ubiquitous in JS bundles, source maps,
+        # dev configs, and CSP report URIs — flagging it was almost pure false positive.
+        PRIVATE_IP = /(?<![\w.])(?:10(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}|172\.(?:1[6-9]|2\d|3[01])(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){2}|192\.168(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){2})(?![\w.])/
 
         # Server-side error / stack-trace signatures, each tightened to a specific frame or
         # exception shape so a mere SYMBOL MENTION in documentation / tutorials / package

--- a/src/gori/probe/passive/context.cr
+++ b/src/gori/probe/passive/context.cr
@@ -23,6 +23,8 @@ module Gori
         @resp : Proxy::Codec::RawResponse?
         @resp_done = false
         @url : String?
+        @decoded_body : Bytes?
+        @decoded_body_done = false
         @body_text : String?
         @body_text_done = false
         @client_body_text : String?
@@ -104,27 +106,39 @@ module Gori
           r
         end
 
+        # Response body inflated ONCE at the largest cap any rule needs, then shared by both
+        # body_text (a BODY_CAP prefix) and client_body_text (a CLIENT_BODY_CAP prefix). For an
+        # HTML/JS document BOTH getters are live, so decoding here — at CLIENT_BODY_CAP — content-
+        # decodes the body a single time instead of twice: the deterministic first BODY_CAP bytes
+        # of the larger inflate are byte-identical to a BODY_CAP-capped inflate, so body_text is
+        # unchanged. A non-document flow needs only BODY_CAP, so it caps there and never over-
+        # inflates. An unencoded body returns its raw bytes verbatim (the per-getter slice caps it).
+        private def decoded_body : Bytes?
+          return @decoded_body if @decoded_body_done
+          @decoded_body_done = true
+          cap = (html? || js?) ? CLIENT_BODY_CAP : BODY_CAP
+          decoded, _ = Proxy::Codec::ContentDecode.decode(@detail.response_head, @detail.response_body, cap)
+          @decoded_body = decoded || @detail.response_body
+        end
+
         # Decoded, capped, scrubbed response body text — computed once and shared by the rules
-        # that scan the body. nil when there is no body.
+        # that scan the body. nil when there is no body. Slices the shared `decoded_body` buffer
+        # to its first BODY_CAP bytes.
         def body_text : String?
           return @body_text if @body_text_done
           @body_text_done = true
-          # Only the first BODY_CAP bytes are scanned, so cap the inflate too: a large
-          # compressed body stops decoding at the prefix instead of expanding in full.
-          decoded, _ = Proxy::Codec::ContentDecode.decode(@detail.response_head, @detail.response_body, BODY_CAP)
-          bytes = decoded || @detail.response_body
+          bytes = decoded_body
           @body_text = (bytes && !bytes.empty?) ? String.new(bytes[0, {bytes.size, BODY_CAP}.min]).scrub : nil
         end
 
         # Decoded, larger-capped (CLIENT_BODY_CAP), scrubbed body — computed once and shared by
         # the client-side rules. Only materialised for an HTML or JS response (a non-document
-        # flow pays nothing); reuses the same content-decoder as body_text.
+        # flow pays nothing); slices the same shared `decoded_body` buffer as body_text.
         def client_body_text : String?
           return @client_body_text if @client_body_text_done
           @client_body_text_done = true
           return @client_body_text = nil unless html? || js?
-          decoded, _ = Proxy::Codec::ContentDecode.decode(@detail.response_head, @detail.response_body, CLIENT_BODY_CAP)
-          bytes = decoded || @detail.response_body
+          bytes = decoded_body
           @client_body_text = (bytes && !bytes.empty?) ? String.new(bytes[0, {bytes.size, CLIENT_BODY_CAP}.min]).scrub : nil
         end
 

--- a/src/gori/probe/passive/security_headers.cr
+++ b/src/gori/probe/passive/security_headers.cr
@@ -21,7 +21,17 @@ module Gori
               acc << hdr(ctx, "missing_hsts", "Missing or disabled HSTS header", Store::Severity::Medium)
             end
           end
-          check_doc_headers(ctx, resp.headers, acc) if ctx.html?
+          check_doc_headers(ctx, resp.headers, acc) if ctx.html? && rendered_document?(resp.status)
+        end
+
+        # CSP / X-Frame-Options / X-Content-Type-Options / Referrer-Policy all govern how a
+        # browser RENDERS a document. A 3xx redirect is never rendered — the UA follows it — and
+        # a 204/304 carries no body, so their "missing" document headers are pure noise (the real
+        # target 200 / error page is captured as its own flow and checked there). A 4xx/5xx error
+        # page IS a rendered document (framable, may reflect XSS), so it keeps the checks. HSTS is
+        # unaffected: it applies to any HTTPS response, redirects included, and is checked above.
+        private def rendered_document?(status : Int32) : Bool
+          !((300..399).includes?(status) || status == 204)
         end
 
         # HSTS with no max-age, or max-age=0 (RFC 6797: instructs the UA to DROP the policy), is
@@ -89,8 +99,11 @@ module Gori
         #   * 'unsafe-inline' ⇒ weak ONLY when no nonce/hash source AND no 'strict-dynamic':
         #     browsers IGNORE 'unsafe-inline' in the presence of either, so a nonce-based CSP
         #     that keeps 'unsafe-inline' for CSP2-browser fallback is safe, not weak.
-        #   * a bare '*' or a 'data:' script source ⇒ any-origin / data-URI scripts (XSS), weak
-        #     UNLESS 'strict-dynamic' is present (it makes host/scheme sources be ignored).
+        #   * a bare '*', 'data:', or a bare 'http:'/'https:' SCHEME source ⇒ any-origin (an
+        #     allowlist that is effectively allow-all: any host over that scheme can serve
+        #     scripts) / data-URI scripts (XSS), weak UNLESS 'strict-dynamic' is present (it makes
+        #     host/scheme sources be ignored). A specific host like 'https://cdn.example.com' is a
+        #     distinct token and does NOT trip this — only the bare scheme does.
         # (`unsafe-inline` confined to style-src is a common, low-risk pattern; only the SCRIPT
         # context is inspected, so it still does NOT trip this.)
         private def weak_csp?(dirs : Hash(String, Array(String))) : Bool
@@ -100,7 +113,7 @@ module Gori
           nonce_or_hash = script.any? { |s| SCRIPT_NONCE_HASH.matches?(s) }
           strict_dynamic = script.includes?("'strict-dynamic'")
           return true if !nonce_or_hash && !strict_dynamic && script.any?(&.includes?("unsafe-inline"))
-          return true if !strict_dynamic && script.any? { |s| s == "*" || s == "data:" }
+          return true if !strict_dynamic && script.any? { |s| s == "*" || s == "data:" || s == "http:" || s == "https:" }
           false
         end
 


### PR DESCRIPTION
Four targeted improvements to the passive Probe rules, each addressing false-positives, false-negatives, or scan load. All respect the existing documented FP/FN tuning (e.g. `cacheable no-cache` stays a deliberate non-flag).

## Changes

### 🏎️ Load — one body decode for HTML/JS (`passive/context.cr`)
`body_text` (64 KiB) and `client_body_text` (256 KiB) each called `ContentDecode.decode`, so every HTML/JS response was content-decoded **twice**. A shared `decoded_body` now inflates once at the larger cap; the first 64 KiB of that inflate is byte-identical to a 64 KiB-capped inflate, so behaviour is unchanged and the decode cost halves on the most expensive responses (large gzip'd bundles).

### 🎯 FP + Load — skip document headers on non-rendered responses (`passive/security_headers.cr`)
CSP / X-Frame-Options / X-Content-Type-Options / Referrer-Policy govern how a browser **renders** a document. A 3xx redirect is followed (never rendered) and 204/304 carry no body, so their "missing" document headers were pure noise — the real target page is captured and checked as its own flow. Now skipped for 3xx/204; **4xx/5xx error pages stay checked** (they are rendered, framable, may reflect XSS). HSTS is unaffected. Also drops a per-redirect CSP parse.

### 🎯 FP — drop loopback `127.0.0.1` from the private-IP scan (`passive/body_leaks.cr`)
Loopback is not an internal-network address, aids no reconnaissance, and is ubiquitous in JS bundles, source maps, dev configs, and CSP `report-uri` — flagging it was almost pure false positive. RFC 1918 ranges (10/8, 172.16/12, 192.168/16) are unchanged.

### 🔎 FN — flag a bare `http:`/`https:` scheme source as weak CSP (`passive/security_headers.cr`)
`script-src 'self' https:` is effectively allow-all (any host over https can serve scripts) and is flagged by CSP evaluators, but was missed here. Now flagged, guarded by `strict-dynamic` (which nullifies scheme sources). A **specific host** like `https://cdn.example.com` is a distinct token and is **not** flagged.

## Tests
- Adds specs for all four, including a gzip round-trip proving the shared decode still feeds both `body_text` and the client rules.
- Full probe suite green (132 examples, incl. 4 new).
- The 8 unrelated `capture_status` / `project_registry` failures reproduce on `main` without this change (sandbox TCP port-binding), not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)