### PR TITLE
perf(comparer): peel + intern + flat-buffer the shared line diff

### DIFF
--- a/spec/repeater_spec.cr
+++ b/spec/repeater_spec.cr
@@ -1,6 +1,17 @@
 require "./spec_helper"
 require "socket"
 
+# Reference O(n*m) LCS length — the optimality yardstick the fast line diff must match.
+private def lcs_len(a : Array(String), b : Array(String)) : Int32
+  dp = Array.new(a.size + 1) { Array.new(b.size + 1, 0) }
+  a.size.times do |i|
+    b.size.times do |j|
+      dp[i + 1][j + 1] = a[i] == b[j] ? dp[i][j] + 1 : Math.max(dp[i][j + 1], dp[i + 1][j])
+    end
+  end
+  dp[a.size][b.size]
+end
+
 # Origin that records the exact request bytes it received and replies with `body`.
 private def start_origin(body : String, seen : Channel(String)) : Int32
   origin = TCPServer.new("127.0.0.1", 0)
@@ -164,5 +175,40 @@ describe Gori::Repeater::Diff do
     lines = ["a", "b", "c"]
     diff = Gori::Repeater::Diff.lines(lines, lines)
     Gori::Repeater::Diff.change_count(diff).should eq(0)
+  end
+
+  it "collapses a common prefix and suffix around a changed middle" do
+    a = ["h1", "h2", "old-a", "old-b", "t1", "t2"]
+    b = ["h1", "h2", "new-a", "t1", "t2"]
+    diff = Gori::Repeater::Diff.lines(a, b)
+    diff.first(2).map(&.text).should eq(["h1", "h2"])
+    diff.last(2).map(&.text).should eq(["t1", "t2"])
+    diff.first(2).all? { |d| d.kind.same? }.should be_true
+    diff.last(2).all? { |d| d.kind.same? }.should be_true
+  end
+
+  it "always emits a valid, minimal diff (prefix/suffix peeling stays optimal)" do
+    # Small alphabet + duplicated lines is the case where peeling could diverge from
+    # the plain LCS; sweep many shapes and assert each reconstructs both sides and
+    # hits the optimal Same-count. Deterministic (no RNG) so it can't flake.
+    pool = ["a", "b", "c", "a", "b", ""]
+    seeds = [3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41]
+    seeds.each do |sa|
+      seeds.each do |sb|
+        la = (sa % 6) + 1
+        lb = (sb % 6) + 1
+        a = Array.new(la) { |i| pool[(i * sa + sb) % pool.size] }
+        b = Array.new(lb) { |i| pool[(i * sb + sa) % pool.size] }
+        diff = Gori::Repeater::Diff.lines(a, b)
+
+        # Reconstruct: a = Same+Del in order, b = Same+Add in order.
+        got_a = diff.reject(&.kind.add?).map(&.text)
+        got_b = diff.reject(&.kind.del?).map(&.text)
+        got_a.should eq(a)
+        got_b.should eq(b)
+        # Minimal ⇔ Same-count equals the LCS length.
+        diff.count(&.kind.same?).should eq(lcs_len(a, b))
+      end
+    end
   end
 end

--- a/src/gori/repeater/diff.cr
+++ b/src/gori/repeater/diff.cr
@@ -11,6 +11,12 @@ module Gori
     # Minimal LCS line diff. `a` = original, `b` = new (repeater). Capped to keep
     # the O(n*m) table bounded; very long bodies are truncated (the cap is noted
     # by the caller). Good enough for response comparison this milestone.
+    #
+    # Two similar messages share long identical runs, so the table is kept small by
+    # (1) peeling the common prefix/suffix — the bulk of the lines for a near-match —
+    # down to just the changed middle, and (2) interning lines to Int32 ids so the DP
+    # compares integers on one flat, cache-friendly buffer instead of re-comparing
+    # strings across an array-of-arrays. The result is still a minimal (optimal) diff.
     module Diff
       MAX_LINES = 1500
 
@@ -20,33 +26,89 @@ module Gori
         m = a.size
         n = b.size
 
-        # dp[i][j] = LCS length of a[i..] and b[j..]
-        dp = Array.new(m + 1) { Array.new(n + 1, 0) }
-        (m - 1).downto(0) do |i|
-          (n - 1).downto(0) do |j|
-            dp[i][j] = a[i] == b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1])
-          end
+        # Intern each distinct line to a small Int32 id. Hashing pays once per line;
+        # the O(m*n) DP then compares ids (aid[i] == bid[j] iff a[i] == b[j]).
+        ids = {} of String => Int32
+        aid = a.map { |s| ids[s]? || (ids[s] = ids.size) }
+        bid = b.map { |s| ids[s]? || (ids[s] = ids.size) }
+
+        # Common prefix, then common suffix of what's left. Peeling the prefix is
+        # exactly what the greedy backtrack does; peeling the suffix likewise keeps
+        # the diff optimal (identical trailing lines are always Same).
+        p = 0
+        while p < m && p < n && aid[p] == bid[p]
+          p += 1
+        end
+        s = 0
+        while s < m - p && s < n - p && aid[m - 1 - s] == bid[n - 1 - s]
+          s += 1
         end
 
-        out = [] of DiffLine
+        acc = Array(DiffLine).new(m + n)
+        p.times { |k| acc << DiffLine.new(DiffKind::Same, a[k]) }
+        emit_middle(acc, a, b, aid, bid, p, m - p - s, n - p - s)
+        s.times { |k| acc << DiffLine.new(DiffKind::Same, a[m - s + k]) }
+        acc
+      end
+
+      # Diff the changed middle a[p, mm] vs b[p, nn] (the prefix/suffix already peeled),
+      # appending its del/add/same rows to `acc`. A one-sided middle is a pure run.
+      private def self.emit_middle(acc : Array(DiffLine), a : Array(String), b : Array(String),
+                                   aid : Array(Int32), bid : Array(Int32),
+                                   p : Int32, mm : Int32, nn : Int32) : Nil
+        if mm == 0
+          nn.times { |j| acc << DiffLine.new(DiffKind::Add, b[p + j]) }
+        elsif nn == 0
+          mm.times { |i| acc << DiffLine.new(DiffKind::Del, a[p + i]) }
+        else
+          w = nn + 1
+          backtrack(acc, a, b, aid, bid, lcs_table(aid, bid, p, mm, nn, w), p, mm, nn, w)
+        end
+      end
+
+      # dp[i*w + j] = LCS length of amid[i..] and bmid[j..] (amid[i] = aid[p + i]), filled
+      # bottom-up in one flat zeroed buffer — the boundary row/col stay 0 — so the DP is
+      # one contiguous allocation the CPU can stream, not an array-of-arrays.
+      private def self.lcs_table(aid : Array(Int32), bid : Array(Int32),
+                                 p : Int32, mm : Int32, nn : Int32, w : Int32) : Slice(Int32)
+        dp = Slice(Int32).new((mm + 1) * w, 0)
+        i = mm - 1
+        while i >= 0
+          ai = aid[p + i]
+          row = i * w
+          nxt = row + w
+          j = nn - 1
+          while j >= 0
+            dp[row + j] = ai == bid[p + j] ? dp[nxt + j + 1] + 1 : Math.max(dp[nxt + j], dp[row + j + 1])
+            j -= 1
+          end
+          i -= 1
+        end
+        dp
+      end
+
+      # Walk the filled table top-down, emitting Same/Del/Add with the same tie-break as
+      # the classic backtrack (prefer Del on a length tie), then drain either surplus side.
+      private def self.backtrack(acc : Array(DiffLine), a : Array(String), b : Array(String),
+                                 aid : Array(Int32), bid : Array(Int32), dp : Slice(Int32),
+                                 p : Int32, mm : Int32, nn : Int32, w : Int32) : Nil
         i = 0
         j = 0
-        while i < m && j < n
-          if a[i] == b[j]
-            out << DiffLine.new(DiffKind::Same, a[i]); i += 1; j += 1
-          elsif dp[i + 1][j] >= dp[i][j + 1]
-            out << DiffLine.new(DiffKind::Del, a[i]); i += 1
+        while i < mm && j < nn
+          if aid[p + i] == bid[p + j]
+            acc << DiffLine.new(DiffKind::Same, a[p + i]); i += 1; j += 1
+          elsif dp[(i + 1) * w + j] >= dp[i * w + j + 1]
+            acc << DiffLine.new(DiffKind::Del, a[p + i]); i += 1
           else
-            out << DiffLine.new(DiffKind::Add, b[j]); j += 1
+            acc << DiffLine.new(DiffKind::Add, b[p + j]); j += 1
           end
         end
-        while i < m
-          out << DiffLine.new(DiffKind::Del, a[i]); i += 1
+        while i < mm
+          acc << DiffLine.new(DiffKind::Del, a[p + i]); i += 1
         end
-        while j < n
-          out << DiffLine.new(DiffKind::Add, b[j]); j += 1
+        while j < nn
+          acc << DiffLine.new(DiffKind::Add, b[p + j]); j += 1
         end
-        out
       end
 
       # Count of changed (added/removed) lines — for a quick summary.

--- a/src/gori/tui/comparer_view.cr
+++ b/src/gori/tui/comparer_view.cr
@@ -40,6 +40,10 @@ module Gori::Tui
       @styled_same_rev = 0_u32
       @truncated = false
       @change_count = 0 # cached with @rows_cache so the footer doesn't recount each frame
+      # Decoded display lines per slot, cached so a rebuild (build_rows + styled_same)
+      # and a theme reshade don't re-decode/-scrub/-split the same body more than once.
+      @lines_a = nil.as(Array(String)?)
+      @lines_b = nil.as(Array(String)?)
     end
 
     # Chip label (custom name, or a compact A ⇄ B summary). Capped like Repeater/Decoder.
@@ -188,6 +192,8 @@ module Gori::Tui
     private def invalidate : Nil
       @rows_cache = nil
       @styled_same = nil
+      @lines_a = nil
+      @lines_b = nil
     end
 
     private def rows : Array(Repeater::SideBySide::Row)
@@ -195,11 +201,9 @@ module Gori::Tui
     end
 
     private def build_rows : Array(Repeater::SideBySide::Row)
-      a = @slot_a
-      b = @slot_b
-      return [] of Repeater::SideBySide::Row unless a && b
-      al = lines_for(a)
-      bl = lines_for(b)
+      return [] of Repeater::SideBySide::Row unless @slot_a && @slot_b
+      al = lines_a
+      bl = lines_b
       @truncated = al.size > Repeater::Diff::MAX_LINES || bl.size > Repeater::Diff::MAX_LINES
       result = Repeater::SideBySide.rows(Repeater::Diff.lines(al, bl))
       @change_count = Repeater::SideBySide.change_count(result)
@@ -218,8 +222,8 @@ module Gori::Tui
       return cached if cached && @styled_same_rev == Theme.revision
       rs = rows
       out = Array(Highlight::Line?).new(rs.size, nil)
-      if a = @slot_a
-        al = lines_for(a)
+      if @slot_a
+        al = lines_a
         al = al.first(Repeater::Diff::MAX_LINES) if al.size > Repeater::Diff::MAX_LINES
         al_styled = Highlight.from_lines(al, request: @pane == :request)
         ai = 0
@@ -232,6 +236,18 @@ module Gori::Tui
       @styled_same = out
       @styled_same_rev = Theme.revision
       out
+    end
+
+    private def lines_a : Array(String)
+      a = @slot_a
+      return [] of String unless a
+      @lines_a ||= lines_for(a)
+    end
+
+    private def lines_b : Array(String)
+      b = @slot_b
+      return [] of String unless b
+      @lines_b ||= lines_for(b)
     end
 
     private def lines_for(d : Store::FlowDetail) : Array(String)


### PR DESCRIPTION
## What

Speeds up the **Comparer** by optimizing its diff engine, `Repeater::Diff.lines` — the shared hot path behind the Comparer tab (`ComparerView#build_rows`), the Repeater response diff, and `cli/run.cr`'s JSON diff.

The old O(m·n) LCS used an **array-of-arrays** DP table (~1502 heap arrays and ~m·n **string** comparisons for a 1500-line body), stalling the single-threaded fiber loop whenever the diff rebuilt (a slot pick / pane toggle / swap).

## How

`Diff.lines` rewritten to:
1. **Peel the common prefix + suffix** down to just the changed middle — for two similar messages that's the bulk of the lines.
2. **Intern lines to `Int32` ids** so the DP compares integers, not strings.
3. Fill **one flat, zeroed `Slice(Int32)`** instead of an array-of-arrays (contiguous, cache-friendly, one allocation).

Also caches `ComparerView`'s decoded line arrays (`@lines_a`/`@lines_b`) so `build_rows` + `styled_same` stop decoding/scrubbing/splitting slot A twice per rebuild.

The method is split into `emit_middle` / `lcs_table` / `backtrack` to stay under the repo's ameba complexity bar.

## Results (release, old-vs-new in one process)

| Case | Speed | Alloc |
|---|---|---|
| 1500 lines / ~10 edits (typical) | **4.9× faster** (7.5ms → 1.5ms) | 8.78MB → 3.11MB/op |
| 800 lines / 40 edits | 1.8× faster | 2.54MB → 2.4MB |
| fully-scattered (worst, trim can't help) | 1.3× faster | ~equal |

`change_count` is byte-identical old-vs-new — the diff stays **minimal (optimal)**.

## Correctness note

Suffix-peeling can place an add/del block on the *other* side of a repeated identical trailing line vs the naive forward LCS — a **different but equally minimal** diff, which is fine for a viewer. Guarded by a new deterministic property sweep in `spec/repeater_spec.cr` that reconstructs both inputs and checks the Same-count against an independent LCS-length reference.

## Testing

- New property spec + existing diff/side-by-side/comparer specs pass.
- Broader TUI + repeater suites: **818 examples, 0 failures**.
- ameba clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)