### PR TITLE
feat(tui): expand Settings — Display/Notifications/General sections + network timeouts & caps

### DIFF
--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -141,6 +141,142 @@ describe Gori::Settings do
     end
   end
 
+  it "persists and reloads the network dial timeouts + capture cap; exposes the byte/span helpers" do
+    dir = File.tempname("gori-settings-net-dial")
+    Dir.mkdir_p(dir)
+    prev = ENV["GORI_HOME"]?
+    prev_net = {Gori::Settings.connect_timeout_secs, Gori::Settings.io_timeout_secs, Gori::Settings.capture_max_mib}
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.connect_timeout_secs = 5
+      Gori::Settings.io_timeout_secs = 7
+      Gori::Settings.capture_max_mib = 9
+      Gori::Settings.save.should be_true
+
+      Gori::Settings.connect_timeout_secs = 1
+      Gori::Settings.io_timeout_secs = 1
+      Gori::Settings.capture_max_mib = 1
+      Gori::Settings.load
+      Gori::Settings.connect_timeout_secs.should eq(5)
+      Gori::Settings.io_timeout_secs.should eq(7)
+      Gori::Settings.capture_max_mib.should eq(9)
+      # byte/span helpers derive from the stored ints
+      Gori::Settings.capture_max.should eq(9 * 1024 * 1024)
+      Gori::Settings.connect_timeout.should eq(5.seconds)
+      Gori::Settings.io_timeout.should eq(7.seconds)
+    ensure
+      prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(dir)
+      Gori::Settings.connect_timeout_secs, Gori::Settings.io_timeout_secs, Gori::Settings.capture_max_mib = prev_net
+    end
+  end
+
+  it "persists and reloads display prefs; omits the display section at factory defaults" do
+    dir = File.tempname("gori-settings-display")
+    Dir.mkdir_p(dir)
+    prev = ENV["GORI_HOME"]?
+    prev_display = {Gori::Settings.default_detail_pane, Gori::Settings.history_time_format,
+                    Gori::Settings.show_gutter, Gori::Settings.preview_body_kib}
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.default_detail_pane = "response"
+      Gori::Settings.history_time_format = "relative"
+      Gori::Settings.show_gutter = false
+      Gori::Settings.preview_body_kib = 128
+      Gori::Settings.save.should be_true
+      raw = File.read(Gori::Settings.path)
+      raw.should contain(%("display"))
+      raw.should contain(%("detail_pane":"response"))
+
+      Gori::Settings.default_detail_pane = "request"
+      Gori::Settings.history_time_format = "absolute"
+      Gori::Settings.show_gutter = true
+      Gori::Settings.preview_body_kib = 64
+      Gori::Settings.load
+      Gori::Settings.default_detail_pane.should eq("response")
+      Gori::Settings.history_time_format.should eq("relative")
+      Gori::Settings.show_gutter.should be_false # a stored false survives the reload
+      Gori::Settings.preview_body_kib.should eq(128)
+      Gori::Settings.preview_body_cap.should eq(128 * 1024) # byte helper derives from the KiB int
+
+      # Back to defaults → section omitted
+      Gori::Settings.default_detail_pane = Gori::Settings::DEFAULT_DETAIL_PANE
+      Gori::Settings.history_time_format = Gori::Settings::DEFAULT_HISTORY_TIME_FORMAT
+      Gori::Settings.show_gutter = Gori::Settings::DEFAULT_SHOW_GUTTER
+      Gori::Settings.preview_body_kib = Gori::Settings::DEFAULT_PREVIEW_BODY_KIB
+      Gori::Settings.save
+      File.read(Gori::Settings.path).should_not contain(%("display"))
+    ensure
+      prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(dir)
+      Gori::Settings.default_detail_pane, Gori::Settings.history_time_format, Gori::Settings.show_gutter, Gori::Settings.preview_body_kib = prev_display
+    end
+  end
+
+  it "persists and reloads notification prefs; omits the section at factory defaults (false survives)" do
+    dir = File.tempname("gori-settings-notif")
+    Dir.mkdir_p(dir)
+    prev = ENV["GORI_HOME"]?
+    prev_notif = {Gori::Settings.notify_bell?, Gori::Settings.notify_toast?, Gori::Settings.notify_retention}
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.notify_bell = true
+      Gori::Settings.notify_toast = false
+      Gori::Settings.notify_retention = 25
+      Gori::Settings.save.should be_true
+      File.read(Gori::Settings.path).should contain(%("notifications"))
+
+      Gori::Settings.notify_bell = false
+      Gori::Settings.notify_toast = true
+      Gori::Settings.notify_retention = 100
+      Gori::Settings.load
+      Gori::Settings.notify_bell?.should be_true
+      Gori::Settings.notify_toast?.should be_false # a stored false survives the reload
+      Gori::Settings.notify_retention.should eq(25)
+
+      # Back to defaults → section omitted
+      Gori::Settings.notify_bell = Gori::Settings::DEFAULT_NOTIFY_BELL
+      Gori::Settings.notify_toast = Gori::Settings::DEFAULT_NOTIFY_TOAST
+      Gori::Settings.notify_retention = Gori::Settings::DEFAULT_NOTIFY_RETENTION
+      Gori::Settings.save
+      File.read(Gori::Settings.path).should_not contain(%("notifications"))
+    ensure
+      prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(dir)
+      Gori::Settings.notify_bell, Gori::Settings.notify_toast, Gori::Settings.notify_retention = prev_notif
+    end
+  end
+
+  it "persists and reloads general prefs; omits the section at factory defaults (false survives)" do
+    dir = File.tempname("gori-settings-general")
+    Dir.mkdir_p(dir)
+    prev = ENV["GORI_HOME"]?
+    prev_gen = {Gori::Settings.clipboard_osc52?, Gori::Settings.confirm_quit?}
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.clipboard_osc52 = false
+      Gori::Settings.confirm_quit = true
+      Gori::Settings.save.should be_true
+      File.read(Gori::Settings.path).should contain(%("general"))
+
+      Gori::Settings.clipboard_osc52 = true
+      Gori::Settings.confirm_quit = false
+      Gori::Settings.load
+      Gori::Settings.clipboard_osc52?.should be_false # a stored false survives the reload
+      Gori::Settings.confirm_quit?.should be_true
+
+      # Back to defaults → section omitted
+      Gori::Settings.clipboard_osc52 = Gori::Settings::DEFAULT_CLIPBOARD_OSC52
+      Gori::Settings.confirm_quit = Gori::Settings::DEFAULT_CONFIRM_QUIT
+      Gori::Settings.save
+      File.read(Gori::Settings.path).should_not contain(%("general"))
+    ensure
+      prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(dir)
+      Gori::Settings.clipboard_osc52, Gori::Settings.confirm_quit = prev_gen
+    end
+  end
+
   it "normalizes invalid sitemap expand depths to the default" do
     Gori::Settings.normalize_sitemap_depth(-1).should eq(-1)
     Gori::Settings.normalize_sitemap_depth(0).should eq(0)

--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -660,8 +660,9 @@ describe Gori::Tui::HistoryView do
         backend.contains?("REQUEST").should be_true
         backend.contains?("RESPONSE").should be_true
         # Cap invariant: store API used by preview is body_max-aware
-        d = store.get_flow(id, body_max: HistoryView::PREVIEW_BODY_CAP + 1).not_nil!
-        d.response_body.not_nil!.size.should eq(HistoryView::PREVIEW_BODY_CAP + 1)
+        cap = Gori::Settings.preview_body_cap
+        d = store.get_flow(id, body_max: cap + 1).not_nil!
+        d.response_body.not_nil!.size.should eq(cap + 1)
       end
     ensure
       Gori::Settings.history_preview = prev

--- a/spec/tui/settings_view_spec.cr
+++ b/spec/tui/settings_view_spec.cr
@@ -3,6 +3,13 @@ require "file_utils"
 
 include Gori::Tui
 
+# Replace the focused TEXT field's contents with `s`: clear it to empty (backspace runs
+# from the caret, which sits at end after a move_field/set_field), then type each char.
+private def set_text(v : SettingsView, s : String) : Nil
+  60.times { v.backspace }
+  s.each_char { |c| v.insert(c) }
+end
+
 # SettingsView.reset_to_defaults reverts the working copy of the ACTIVE section to the
 # factory Settings::DEFAULT_* values. Like every other edit in the editor it touches the
 # working copy only — it lands in the live Settings on save (↵), not on the keypress.
@@ -94,7 +101,7 @@ describe SettingsView do
       # The Hostname-overrides opener must still be the focusable action row after the
       # inserted field (index shift didn't misalign fields/values).
       v.reload(:network)
-      5.times { v.move_field(1) } # → Hostname overrides (index 5, the opener)
+      8.times { v.move_field(1) } # → Hostname overrides (index 8: after Info page + 3 timeout/capture fields)
       v.focused_opener.should eq(:hosts)
     ensure
       prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
@@ -174,6 +181,181 @@ describe SettingsView do
     ensure
       prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
       Gori::Settings.history_preview, Gori::Settings.probe_preview, Gori::Settings.issues_preview, Gori::Settings.history_list_order, Gori::Settings.sitemap_expand_depth = prev
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  it "saves and resets the extended NETWORK section (dial timeouts + capture limit)" do
+    dir = File.tempname("gori-settings-net-view")
+    Dir.mkdir_p(dir)
+    prev_home = ENV["GORI_HOME"]?
+    prev = {
+      Gori::Settings.bind_host, Gori::Settings.bind_port, Gori::Settings.upstream_proxy,
+      Gori::Settings.connect_timeout_secs, Gori::Settings.io_timeout_secs, Gori::Settings.capture_max_mib,
+    }
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.connect_timeout_secs = 30
+      Gori::Settings.io_timeout_secs = 30
+      Gori::Settings.capture_max_mib = 2
+      v = SettingsView.new
+      v.reload(:network)
+      # Bind IP → Port → Upstream → Verify → Info page → Connect timeout (index 5, text)
+      5.times { v.move_field(1) }
+      set_text(v, "5")
+      v.move_field(1) # → Idle timeout (index 6, text)
+      set_text(v, "7")
+      v.move_field(1) # → Capture body limit (index 7, text)
+      set_text(v, "9")
+      v.save
+      Gori::Settings.connect_timeout_secs.should eq(5)
+      Gori::Settings.io_timeout_secs.should eq(7)
+      Gori::Settings.capture_max_mib.should eq(9)
+
+      # The Hostname-overrides opener is still the focusable action row after the inserted fields.
+      v.reload(:network)
+      8.times { v.move_field(1) } # → Hostname overrides (index 8, the opener)
+      v.focused_opener.should eq(:hosts)
+
+      v.reset_to_defaults
+      v.save
+      Gori::Settings.connect_timeout_secs.should eq(Gori::Settings::DEFAULT_CONNECT_TIMEOUT_SECS)
+      Gori::Settings.io_timeout_secs.should eq(Gori::Settings::DEFAULT_IO_TIMEOUT_SECS)
+      Gori::Settings.capture_max_mib.should eq(Gori::Settings::DEFAULT_CAPTURE_MAX_MIB)
+    ensure
+      prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
+      Gori::Settings.bind_host, Gori::Settings.bind_port, Gori::Settings.upstream_proxy, Gori::Settings.connect_timeout_secs, Gori::Settings.io_timeout_secs, Gori::Settings.capture_max_mib = prev
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  it "saves and resets the DISPLAY section (detail pane, time format, gutter, preview cap)" do
+    dir = File.tempname("gori-settings-display-view")
+    Dir.mkdir_p(dir)
+    prev_home = ENV["GORI_HOME"]?
+    prev = {
+      Gori::Settings.default_detail_pane, Gori::Settings.history_time_format,
+      Gori::Settings.show_gutter, Gori::Settings.preview_body_kib,
+    }
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.default_detail_pane = "request"
+      Gori::Settings.history_time_format = "absolute"
+      Gori::Settings.show_gutter = true
+      Gori::Settings.preview_body_kib = 64
+      v = SettingsView.new
+      v.reload(:display)
+      v.section.should eq(:display)
+      v.toggle_or_move(1) # detail pane: request → response (choice)
+      v.move_field(1)
+      v.toggle_or_move(1) # history list time: absolute → relative (choice)
+      v.move_field(1)
+      v.toggle_or_move(1) # line numbers: on → off (bool)
+      v.move_field(1)
+      set_text(v, "128") # preview body limit (text)
+      v.save
+      Gori::Settings.default_detail_pane.should eq("response")
+      Gori::Settings.history_time_format.should eq("relative")
+      Gori::Settings.show_gutter.should be_false
+      Gori::Settings.preview_body_kib.should eq(128)
+
+      v.reset_to_defaults
+      v.save
+      Gori::Settings.default_detail_pane.should eq(Gori::Settings::DEFAULT_DETAIL_PANE)
+      Gori::Settings.history_time_format.should eq(Gori::Settings::DEFAULT_HISTORY_TIME_FORMAT)
+      Gori::Settings.show_gutter.should eq(Gori::Settings::DEFAULT_SHOW_GUTTER)
+      Gori::Settings.preview_body_kib.should eq(Gori::Settings::DEFAULT_PREVIEW_BODY_KIB)
+    ensure
+      prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
+      Gori::Settings.default_detail_pane, Gori::Settings.history_time_format, Gori::Settings.show_gutter, Gori::Settings.preview_body_kib = prev
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  it "saves and resets the NOTIFICATIONS section (bell, toast, retention)" do
+    dir = File.tempname("gori-settings-notif-view")
+    Dir.mkdir_p(dir)
+    prev_home = ENV["GORI_HOME"]?
+    prev = {Gori::Settings.notify_bell?, Gori::Settings.notify_toast?, Gori::Settings.notify_retention}
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.notify_bell = false
+      Gori::Settings.notify_toast = true
+      Gori::Settings.notify_retention = 100
+      v = SettingsView.new
+      v.reload(:notifications)
+      v.section.should eq(:notifications)
+      v.toggle_or_move(1) # bell: off → on (bool)
+      v.move_field(1)
+      v.toggle_or_move(1) # toast: on → off (bool)
+      v.move_field(1)
+      set_text(v, "25") # retention (text)
+      v.save
+      Gori::Settings.notify_bell?.should be_true
+      Gori::Settings.notify_toast?.should be_false
+      Gori::Settings.notify_retention.should eq(25)
+
+      v.reset_to_defaults
+      v.save
+      Gori::Settings.notify_bell?.should eq(Gori::Settings::DEFAULT_NOTIFY_BELL)
+      Gori::Settings.notify_toast?.should eq(Gori::Settings::DEFAULT_NOTIFY_TOAST)
+      Gori::Settings.notify_retention.should eq(Gori::Settings::DEFAULT_NOTIFY_RETENTION)
+    ensure
+      prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
+      Gori::Settings.notify_bell, Gori::Settings.notify_toast, Gori::Settings.notify_retention = prev
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  it "rejects an invalid notification retention on save (Settings unchanged, error string)" do
+    dir = File.tempname("gori-settings-notif-bad")
+    Dir.mkdir_p(dir)
+    prev_home = ENV["GORI_HOME"]?
+    prev = Gori::Settings.notify_retention
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.notify_retention = 42
+      v = SettingsView.new
+      v.reload(:notifications)
+      v.move_field(1)  # Bell → Toast
+      v.move_field(1)  # → Retention (index 2, text)
+      set_text(v, "0") # zero is below the min-1 floor
+      msg = v.save
+      msg.should start_with("settings:")            # a rejection message for the caller to toast
+      Gori::Settings.notify_retention.should eq(42) # rejected value is not applied
+    ensure
+      prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
+      Gori::Settings.notify_retention = prev
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  it "saves and resets the GENERAL section (clipboard, confirm quit)" do
+    dir = File.tempname("gori-settings-general-view")
+    Dir.mkdir_p(dir)
+    prev_home = ENV["GORI_HOME"]?
+    prev = {Gori::Settings.clipboard_osc52?, Gori::Settings.confirm_quit?}
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.clipboard_osc52 = true
+      Gori::Settings.confirm_quit = false
+      v = SettingsView.new
+      v.reload(:general)
+      v.section.should eq(:general)
+      v.toggle_or_move(1) # clipboard: on → off (bool)
+      v.move_field(1)
+      v.toggle_or_move(1) # confirm quit: off → on (bool)
+      v.save
+      Gori::Settings.clipboard_osc52?.should be_false
+      Gori::Settings.confirm_quit?.should be_true
+
+      v.reset_to_defaults
+      v.save
+      Gori::Settings.clipboard_osc52?.should eq(Gori::Settings::DEFAULT_CLIPBOARD_OSC52)
+      Gori::Settings.confirm_quit?.should eq(Gori::Settings::DEFAULT_CONFIRM_QUIT)
+    ensure
+      prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
+      Gori::Settings.clipboard_osc52, Gori::Settings.confirm_quit = prev
       FileUtils.rm_rf(dir)
     end
   end

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -703,7 +703,7 @@ module Gori
         # Content-Length to the stored bytes so the request stays well-formed, but warn that
         # the resent body differs from what the origin originally received.
         if detail.request_body_truncated?
-          cap_mib = Proxy::Codec::Body::CAPTURE_MAX // (1024 * 1024)
+          cap_mib = Settings.capture_max_mib
           STDERR.puts "gori run repeater: request body was truncated at the #{cap_mib} MiB capture cap — resending the stored (shorter) body with a corrected Content-Length"
         end
 

--- a/src/gori/import/builder.cr
+++ b/src/gori/import/builder.cr
@@ -14,7 +14,7 @@ module Gori
       def self.capped(body : Bytes?) : {Bytes?, Bool, Int64?}
         return {nil, false, nil} unless body
         size = body.size.to_i64
-        max = Proxy::Codec::Body::CAPTURE_MAX
+        max = Settings.capture_max
         return {body, false, size} if body.size <= max
         {body[0, max].dup, true, size}
       end

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -215,7 +215,7 @@ module Gori::Proxy
       # Repeater-safety keys on the ACTUALLY-SENT method (sent_req): an M&R rule that rewrites
       # the request line GET→POST must not leave a non-idempotent request marked retryable.
       retryable = retryable_request?(sent_req, req_framing.none?)
-      req_capture = Codec::CaptureBuffer.new(Codec::Body::CAPTURE_MAX, capture_hint(req_framing, req_len))
+      req_capture = Codec::CaptureBuffer.new(Settings.capture_max, capture_hint(req_framing, req_len))
       req_complete = true
       upstream, reused, sent = acquire_and_send(host, port, retryable) do |up|
         up.write(sent_head)
@@ -343,12 +343,12 @@ module Gori::Proxy
       # Re-arm the per-request upstream timeout: a REUSED socket may carry a relaxed (untimed)
       # state from a prior streamed (SSE/chunked) response. A freshly dialed one already has it
       # (direct_dial), so this is an idempotent set there.
-      SocketTuning.arm(upstream, Upstream::IO_TIMEOUT)
+      SocketTuning.arm(upstream, Settings.io_timeout)
       ok = send_guard { yield upstream }
       if !ok && reused && retryable
         release_upstream
         upstream, reused = acquire_upstream(host, port)
-        SocketTuning.arm(upstream, Upstream::IO_TIMEOUT) if upstream
+        SocketTuning.arm(upstream, Settings.io_timeout) if upstream
         ok = upstream ? send_guard { yield upstream } : false
       end
       {upstream, reused, ok}
@@ -433,7 +433,7 @@ module Gori::Proxy
       # Non-hold path: stream the response body byte-for-byte (P6) and record the
       # flow. `completed` is true only when the whole body was delivered cleanly; a
       # client abort or upstream truncation is recorded Aborted (see the helper).
-      resp_capture = Codec::CaptureBuffer.new(Codec::Body::CAPTURE_MAX, capture_hint(resp_framing, resp_len))
+      resp_capture = Codec::CaptureBuffer.new(Settings.capture_max, capture_hint(resp_framing, resp_len))
       completed = stream_nonhold_response(upstream, sent_resp, sent_resp_head,
         resp_framing, resp_len, resp_capture, flow_id, ttfb, started)
 
@@ -883,8 +883,8 @@ module Gori::Proxy
     # in-scope giant body can't bloat its row. Returns {stored, truncated, size}.
     private def capped(body : Bytes?) : {Bytes?, Bool, Int64?}
       return {nil, false, nil} unless body
-      return {body, false, nil} if body.size <= Codec::Body::CAPTURE_MAX
-      {body[0, Codec::Body::CAPTURE_MAX].dup, true, body.size.to_i64}
+      return {body, false, nil} if body.size <= Settings.capture_max
+      {body[0, Settings.capture_max].dup, true, body.size.to_i64}
     end
 
     private def record_error(req, scheme, host, port, created_at, message) : Nil

--- a/src/gori/proxy/h2/assembler.cr
+++ b/src/gori/proxy/h2/assembler.cr
@@ -37,7 +37,7 @@ module Gori::Proxy::H2
       getter header_buf = IO::Memory.new
       # DATA frames accumulate here, capped (like h1) so a huge streamed body
       # can't grow per-connection memory without bound. Raw frames stay the truth.
-      getter body = Codec::CaptureBuffer.new(Codec::Body::CAPTURE_MAX)
+      getter body = Codec::CaptureBuffer.new(Settings.capture_max)
       property headers : Array({String, String})? = nil
       # Cumulative decoded-header bytesize across all merged blocks on this side, so a
       # flood of repeated non-status HEADERS blocks (fake trailers, never END_STREAM)

--- a/src/gori/proxy/upstream.cr
+++ b/src/gori/proxy/upstream.cr
@@ -18,8 +18,8 @@ module Gori::Proxy
     # tunnel). The returned socket is positioned at the start of the origin stream
     # either way, so callers (dial_tls / the request forwarder) are unaffected.
     def self.dial(host : String, port : Int32,
-                  connect_timeout : Time::Span = CONNECT_TIMEOUT,
-                  io_timeout : Time::Span = IO_TIMEOUT,
+                  connect_timeout : Time::Span = Settings.connect_timeout,
+                  io_timeout : Time::Span = Settings.io_timeout,
                   *, overrides : Gori::HostOverrides? = nil) : TCPSocket?
       target = connect_target(host, overrides)
       if proxy = Settings.upstream_proxy_addr
@@ -80,8 +80,8 @@ module Gori::Proxy
     end
 
     private def self.direct_dial(host : String, port : Int32,
-                                 connect_timeout : Time::Span = CONNECT_TIMEOUT,
-                                 io_timeout : Time::Span = IO_TIMEOUT) : TCPSocket?
+                                 connect_timeout : Time::Span = Settings.connect_timeout,
+                                 io_timeout : Time::Span = Settings.io_timeout) : TCPSocket?
       sock = TCPSocket.new(host, port, connect_timeout: connect_timeout)
       begin
         sock.sync = true # flush writes immediately (P6)
@@ -108,8 +108,8 @@ module Gori::Proxy
     # CONNECT to the target port.
     private def self.dial_via_proxy(proxy_host : String, proxy_port : Int32,
                                     host : String, port : Int32,
-                                    connect_timeout : Time::Span = CONNECT_TIMEOUT,
-                                    io_timeout : Time::Span = IO_TIMEOUT) : TCPSocket?
+                                    connect_timeout : Time::Span = Settings.connect_timeout,
+                                    io_timeout : Time::Span = Settings.io_timeout) : TCPSocket?
       sock = direct_dial(proxy_host, proxy_port, connect_timeout, io_timeout)
       return nil unless sock
       # An IPv6 literal host must be bracketed in the CONNECT request-target / Host header
@@ -179,8 +179,8 @@ module Gori::Proxy
     # the repeater workbench uses it for domain-fronting / vhost-confusion / IP-direct
     # sends. nil → the dialed host is used (the usual case).
     def self.dial_tls(host : String, port : Int32, verify : Bool, alpn : String? = nil, sni : String? = nil,
-                      connect_timeout : Time::Span = CONNECT_TIMEOUT,
-                      io_timeout : Time::Span = IO_TIMEOUT,
+                      connect_timeout : Time::Span = Settings.connect_timeout,
+                      io_timeout : Time::Span = Settings.io_timeout,
                       *, overrides : Gori::HostOverrides? = nil) : OpenSSL::SSL::Socket::Client?
       tcp = dial(host, port, connect_timeout, io_timeout, overrides: overrides)
       return nil unless tcp

--- a/src/gori/repeater/engine.cr
+++ b/src/gori/repeater/engine.cr
@@ -38,8 +38,8 @@ module Gori
         # `timeout` is a PER-OPERATION bound (connect, and idle between reads/writes),
         # not a total request deadline — same model as the proxy's IO_TIMEOUT. A true
         # whole-request deadline would need a timer fiber racing a socket close.
-        ct = timeout || Proxy::Upstream::CONNECT_TIMEOUT
-        it = timeout || Proxy::Upstream::IO_TIMEOUT
+        ct = timeout || Settings.connect_timeout
+        it = timeout || Settings.io_timeout
         upstream = scheme == "https" ? Proxy::Upstream.dial_tls(host, port, verify: verify_upstream, sni: sni, connect_timeout: ct, io_timeout: it) : Proxy::Upstream.dial(host, port, connect_timeout: ct, io_timeout: it)
         return error(connect_error(scheme, host, port, verify_upstream), started) unless upstream
 
@@ -66,8 +66,8 @@ module Gori
                              timeout : Time::Span? = nil) : Array(Result)
         results = [] of Result
         return results if requests.empty?
-        ct = timeout || Proxy::Upstream::CONNECT_TIMEOUT
-        it = timeout || Proxy::Upstream::IO_TIMEOUT
+        ct = timeout || Settings.connect_timeout
+        it = timeout || Settings.io_timeout
         upstream = scheme == "https" ? Proxy::Upstream.dial_tls(host, port, verify: verify_upstream, sni: sni, connect_timeout: ct, io_timeout: it) : Proxy::Upstream.dial(host, port, connect_timeout: ct, io_timeout: it)
         unless upstream
           msg = connect_error(scheme, host, port, verify_upstream)

--- a/src/gori/repeater/h2_engine.cr
+++ b/src/gori/repeater/h2_engine.cr
@@ -62,8 +62,8 @@ module Gori
 
       private def self.open(scheme : String, host : String, port : Int32, verify : Bool,
                             sni : String? = nil, timeout : Time::Span? = nil) : IO?
-        ct = timeout || Proxy::Upstream::CONNECT_TIMEOUT
-        it = timeout || Proxy::Upstream::IO_TIMEOUT
+        ct = timeout || Settings.connect_timeout
+        it = timeout || Settings.io_timeout
         if scheme == "https"
           ssl = Proxy::Upstream.dial_tls(host, port, verify: verify, alpn: "h2", sni: sni, connect_timeout: ct, io_timeout: it)
           return nil unless ssl

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -22,6 +22,14 @@ module Gori
     DEFAULT_UPSTREAM_PROXY  = ""
     DEFAULT_VERIFY_UPSTREAM = true
     DEFAULT_SERVE_LANDING   = true
+    # Outbound dial timeouts (settings:network). connect = how long a TCP/upstream connect
+    # may take; io = the initial read/write timeout on the upstream socket (relaxed to nil
+    # for long-lived streaming tunnels — that clearing is orthogonal). Seconds, min 1.
+    DEFAULT_CONNECT_TIMEOUT_SECS = 30
+    DEFAULT_IO_TIMEOUT_SECS      = 30
+    # How many body bytes the proxy CAPTURES + stores per request/response (settings:network).
+    # A change only affects flows captured AFTER it (buffers allocate at request start). MiB, min 1.
+    DEFAULT_CAPTURE_MAX_MIB = 2
     DEFAULT_EDITOR          = ""
     DEFAULT_EDITOR_MARKDOWN = true
     DEFAULT_THEME           = "goridark"
@@ -39,6 +47,25 @@ module Gori
     DEFAULT_STATUSLINE_ENABLED  = false
     DEFAULT_STATUSLINE_COMMAND  = ""
     DEFAULT_STATUSLINE_INTERVAL = 3 # seconds between runs (min 1)
+    # Display (settings:display): message-body rendering prefs. detail_pane = which pane a
+    # freshly-opened History flow shows first; history_time_format = list time column;
+    # show_gutter = line-number gutter on the message body views; preview_body_kib = how many
+    # body bytes the History list PREVIEW reads/shows (display-only, not the capture limit).
+    DEFAULT_DETAIL_PANE         = "request"  # "request" | "response"
+    DEFAULT_HISTORY_TIME_FORMAT = "absolute" # "absolute" | "relative"
+    DEFAULT_SHOW_GUTTER         = true
+    DEFAULT_PREVIEW_BODY_KIB    = 64
+    # Notifications (settings:notifications): bell = terminal beep on a background result/alert;
+    # toast = also flash a bottom-bar toast for fuzzer/probe/discover results; retention = ring
+    # buffer size. All opt-in-friendly defaults (bell off; toast on; 100 kept).
+    DEFAULT_NOTIFY_BELL      = false
+    DEFAULT_NOTIFY_TOAST     = true
+    DEFAULT_NOTIFY_RETENTION = 100
+    # General (settings:general): clipboard_osc52 = OSC 52 terminal clipboard integration (the
+    # only copy mechanism — off means copies no-op); confirm_quit = require a confirm modal to
+    # quit instead of the double-press ^D.
+    DEFAULT_CLIPBOARD_OSC52 = true
+    DEFAULT_CONFIRM_QUIT    = false
 
     class_property bind_host : String = DEFAULT_BIND_HOST
     class_property bind_port : Int32 = DEFAULT_BIND_PORT
@@ -53,6 +80,26 @@ module Gori
     # refusal. Global-only; the settings:network editor toggles it live via
     # Session#set_serve_landing (pushed to the TLS tunnel, read per-request).
     class_property? serve_landing : Bool = DEFAULT_SERVE_LANDING
+    # Outbound dial timeouts, stored in seconds; read live by Upstream.dial (and the repeater/
+    # fuzz/discover engines) via the connect_timeout/io_timeout helpers below. Global-only.
+    class_property connect_timeout_secs : Int32 = DEFAULT_CONNECT_TIMEOUT_SECS
+    class_property io_timeout_secs : Int32 = DEFAULT_IO_TIMEOUT_SECS
+    # Body capture cap, stored in MiB; the proxy/import read it in bytes via capture_max. Global-only.
+    class_property capture_max_mib : Int32 = DEFAULT_CAPTURE_MAX_MIB
+
+    # The dial timeouts as a Time::Span (what Upstream/the engines actually pass to the socket).
+    def self.connect_timeout : Time::Span
+      connect_timeout_secs.seconds
+    end
+
+    def self.io_timeout : Time::Span
+      io_timeout_secs.seconds
+    end
+
+    # The capture cap in BYTES — the value CaptureBuffer/import bound a body to.
+    def self.capture_max : Int32
+      capture_max_mib * 1024 * 1024
+    end
 
     # Per-project network overrides — a RUNTIME layer set by Session.open from the OPEN
     # project's DB and NEVER persisted to settings.json (the project's own DB is the source
@@ -128,6 +175,26 @@ module Gori
     class_property? statusline_enabled : Bool = DEFAULT_STATUSLINE_ENABLED
     class_property statusline_command : String = DEFAULT_STATUSLINE_COMMAND
     class_property statusline_interval : Int32 = DEFAULT_STATUSLINE_INTERVAL
+    # Display prefs (settings:display). detail_pane/history_time_format are validated to their
+    # two-value sets on load; show_gutter follows the LAYOUT bools (plain accessor); the History
+    # list preview reads preview_body_cap (bytes) so the preview never pulls a multi-MiB body.
+    class_property default_detail_pane : String = DEFAULT_DETAIL_PANE
+    class_property history_time_format : String = DEFAULT_HISTORY_TIME_FORMAT
+    class_property show_gutter : Bool = DEFAULT_SHOW_GUTTER
+    class_property preview_body_kib : Int32 = DEFAULT_PREVIEW_BODY_KIB
+    # Notification prefs (settings:notifications). bell/toast are `?` toggles read live at the
+    # emit sites; retention bounds the ring buffer (read live by Notifications#push).
+    class_property? notify_bell : Bool = DEFAULT_NOTIFY_BELL
+    class_property? notify_toast : Bool = DEFAULT_NOTIFY_TOAST
+    class_property notify_retention : Int32 = DEFAULT_NOTIFY_RETENTION
+    # General prefs (settings:general). Both `?` toggles read live (Clipboard.copy / quit handler).
+    class_property? clipboard_osc52 : Bool = DEFAULT_CLIPBOARD_OSC52
+    class_property? confirm_quit : Bool = DEFAULT_CONFIRM_QUIT
+
+    # The History-list preview body cap in BYTES (stored as KiB above).
+    def self.preview_body_cap : Int32
+      preview_body_kib * 1024
+    end
 
     def self.history_newest_first? : Bool
       history_list_order != "oldest"
@@ -199,6 +266,9 @@ module Gori
         self.upstream_proxy = net["upstream_proxy"]?.try(&.as_s?) || upstream_proxy
         self.verify_upstream = load_bool(net, "verify_upstream", verify_upstream?)
         self.serve_landing = load_bool(net, "serve_landing", serve_landing?)
+        net["connect_timeout_secs"]?.try(&.as_i?).try { |v| self.connect_timeout_secs = {v, 1}.max }
+        net["io_timeout_secs"]?.try(&.as_i?).try { |v| self.io_timeout_secs = {v, 1}.max }
+        net["capture_max_mib"]?.try(&.as_i?).try { |v| self.capture_max_mib = {v, 1}.max }
       end
       self.theme = root["theme"]?.try(&.as_s?) || theme # validated against the known themes by Theme.apply
       self.mouse = load_bool(root, "mouse", mouse)
@@ -222,6 +292,9 @@ module Gori
       parse_discover_prefs(root["discover"]?)
       parse_layout(root["layout"]?)
       parse_statusline(root["statusline"]?)
+      parse_display(root["display"]?)
+      parse_notifications(root["notifications"]?)
+      parse_general(root["general"]?)
       Env.bump_highlight_rev
     rescue
       # no file yet / unreadable / bad JSON — keep current values
@@ -252,6 +325,39 @@ module Gori
       if iv = o["interval"]?.try(&.as_i?)
         self.statusline_interval = {iv, 1}.max
       end
+    end
+
+    # Tolerant display section: absent/non-object keeps current; enums clamped to their
+    # two-value sets; preview cap floored at 1 KiB.
+    private def self.parse_display(node : JSON::Any?) : Nil
+      return unless o = node.try(&.as_h?)
+      if v = o["detail_pane"]?.try(&.as_s?)
+        self.default_detail_pane = v == "response" ? "response" : "request"
+      end
+      if v = o["history_time_format"]?.try(&.as_s?)
+        self.history_time_format = v == "relative" ? "relative" : "absolute"
+      end
+      self.show_gutter = load_bool_h(o, "show_gutter", show_gutter)
+      if v = o["preview_body_kib"]?.try(&.as_i?)
+        self.preview_body_kib = {v, 1}.max
+      end
+    end
+
+    # Tolerant notifications section: absent/non-object keeps current; retention floored at 1.
+    private def self.parse_notifications(node : JSON::Any?) : Nil
+      return unless o = node.try(&.as_h?)
+      self.notify_bell = load_bool_h(o, "bell", notify_bell?)
+      self.notify_toast = load_bool_h(o, "toast", notify_toast?)
+      if v = o["retention"]?.try(&.as_i?)
+        self.notify_retention = {v, 1}.max
+      end
+    end
+
+    # Tolerant general section: absent/non-object keeps current.
+    private def self.parse_general(node : JSON::Any?) : Nil
+      return unless o = node.try(&.as_h?)
+      self.clipboard_osc52 = load_bool_h(o, "clipboard_osc52", clipboard_osc52?)
+      self.confirm_quit = load_bool_h(o, "confirm_quit", confirm_quit?)
     end
 
     # Allowed depths: -1 (all) or 0..3. Anything else falls back to default.
@@ -617,6 +723,40 @@ module Gori
               end
             end
           end
+          # Omit each opt-in section when every field is factory default (quiet install; merge-safe).
+          unless default_detail_pane == DEFAULT_DETAIL_PANE &&
+                 history_time_format == DEFAULT_HISTORY_TIME_FORMAT &&
+                 show_gutter == DEFAULT_SHOW_GUTTER &&
+                 preview_body_kib == DEFAULT_PREVIEW_BODY_KIB
+            j.field "display" do
+              j.object do
+                j.field "detail_pane", default_detail_pane
+                j.field "history_time_format", history_time_format
+                j.field "show_gutter", show_gutter
+                j.field "preview_body_kib", preview_body_kib
+              end
+            end
+          end
+          unless notify_bell? == DEFAULT_NOTIFY_BELL &&
+                 notify_toast? == DEFAULT_NOTIFY_TOAST &&
+                 notify_retention == DEFAULT_NOTIFY_RETENTION
+            j.field "notifications" do
+              j.object do
+                j.field "bell", notify_bell?
+                j.field "toast", notify_toast?
+                j.field "retention", notify_retention
+              end
+            end
+          end
+          unless clipboard_osc52? == DEFAULT_CLIPBOARD_OSC52 &&
+                 confirm_quit? == DEFAULT_CONFIRM_QUIT
+            j.field "general" do
+              j.object do
+                j.field "clipboard_osc52", clipboard_osc52?
+                j.field "confirm_quit", confirm_quit?
+              end
+            end
+          end
           j.field "network" do
             j.object do
               j.field "bind_host", bind_host
@@ -624,6 +764,9 @@ module Gori
               j.field "upstream_proxy", upstream_proxy
               j.field "verify_upstream", verify_upstream?
               j.field "serve_landing", serve_landing?
+              j.field "connect_timeout_secs", connect_timeout_secs
+              j.field "io_timeout_secs", io_timeout_secs
+              j.field "capture_max_mib", capture_max_mib
             end
           end
           j.field "editor" do

--- a/src/gori/tui/clipboard.cr
+++ b/src/gori/tui/clipboard.cr
@@ -1,4 +1,5 @@
 require "base64"
+require "../settings"
 
 module Gori::Tui
   # System-clipboard access via the OSC 52 terminal escape. Unlike shelling out
@@ -31,6 +32,8 @@ module Gori::Tui
     # Returns the number of bytes actually placed on the clipboard (≤ MAX_CLIP), so
     # callers can compare against the source size and report when the copy was clipped.
     def self.copy(data : String, io : IO = STDOUT) : Int32
+      # Clipboard disabled by the user: write nothing to the tty, report 0 copied.
+      return 0 unless Settings.clipboard_osc52?
       # Clip by BYTES (not chars): MAX_CLIP bounds the OSC 52 tty write, and the
       # returned count is a byte count the caller compares to the source byte size.
       # `byte_slice` may sever a trailing multi-byte codepoint, but the sequence is

--- a/src/gori/tui/controllers/discover_controller.cr
+++ b/src/gori/tui/controllers/discover_controller.cr
@@ -256,7 +256,7 @@ module Gori::Tui
       level = n > 0 ? :success : :info
       log_event(run, level, msg)
       push_notification(run, level, msg)
-      @host.status(msg)
+      @host.status(msg) if Settings.notify_toast?
     end
 
     private def push_notification(run : DiscoverRun, level : Symbol, msg : String) : Nil

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -764,7 +764,7 @@ module Gori::Tui
       msg = "Fuzzer: #{n} hit#{n == 1 ? "" : "s"} / #{v.result_count} sent on #{v.summary}#{ev.stopped ? " (stopped)" : ""}"
       log_event(v, level, msg)
       @host.notifications.push(level, msg, goto_for(v), source: "fuzzer")
-      @host.status(msg)
+      @host.status(msg) if Settings.notify_toast?
     end
 
     # #124: append every fuzz completion/error to the store event feed UNCONDITIONALLY

--- a/src/gori/tui/controllers/probe_controller.cr
+++ b/src/gori/tui/controllers/probe_controller.cr
@@ -257,7 +257,7 @@ module Gori::Tui
             @host.session.store.insert_event("probe", "issue_found", "success", "Probe: #{summary}", goto_tab: "probe")
             @host.notifications.push(:success, "Probe: #{summary}", source: "probe")
             # Status toast is visible on every tab and pairs with the list paint.
-            @host.status("Probe: #{summary}")
+            @host.status("Probe: #{summary}") if Settings.notify_toast?
           end
         when Probe::ErrorEvent
           # Bottom bar only — a scan error is operational noise, not a result to push

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -90,7 +90,7 @@ module Gori::Tui
       @decoded_id = nil.as(Int64?)                   # flow the decoded panes above were parsed from (skip re-decode)
       @detail_scroll = 0
       @detail_xscroll = 0 # horizontal scroll offset for the detail body (shift+←/→)
-      @detail_pane = :request
+      @detail_pane = initial_detail_pane
       @search_hl = ""                        # active ^F query → highlight in the detail body
       @reveal = false                        # 'w' shows whitespace/CR/LF as glyphs (smuggling)
       @reveal_lines = nil.as(Array(String)?) # cached revealed lines, keyed on the pane bytes ptr
@@ -132,7 +132,7 @@ module Gori::Tui
     getter preview_focus : Symbol
 
     # Load/refresh the preview cache for the selected flow (no-op when preview is off).
-    # Uses a capped body read (PREVIEW_BODY_CAP+1) so selecting through the list never
+    # Uses a capped body read (Settings.preview_body_cap+1) so selecting through the list never
     # pulls multi-MiB BLOBs from SQLite for a pane that only shows a short prefix.
     def refresh_preview(store : Store) : Nil
       return clear_preview unless preview_enabled?
@@ -148,7 +148,7 @@ module Gori::Tui
         # (mirrors refresh_detail's guard). A pending / 101 / h2 flow still re-fetches.
         return
       end
-      detail = store.get_flow(id, body_max: PREVIEW_BODY_CAP + 1)
+      detail = store.get_flow(id, body_max: Settings.preview_body_cap + 1)
       @preview_detail = detail
       @preview_id = id
       # Split the (bounded) preview text once, here — render reads the cached arrays.
@@ -510,6 +510,11 @@ module Gori::Tui
 
     # --- detail view ---------------------------------------------------------
 
+    # settings:display — which detail pane opens first: request (default) or response.
+    private def initial_detail_pane : Symbol
+      Settings.default_detail_pane == "response" ? :response : :request
+    end
+
     def open_detail(store : Store) : Bool
       id = selected_id
       return false unless id
@@ -534,7 +539,7 @@ module Gori::Tui
       load_detail_logs(store)
       @detail_scroll = 0
       @detail_xscroll = 0
-      @detail_pane = :request
+      @detail_pane = initial_detail_pane
       drop_detail_cache
       @detail_hex = false # hex is a deliberate per-open peek — don't carry it into the next flow
       @detail_hex_bytes = nil
@@ -811,6 +816,7 @@ module Gori::Tui
     end
 
     private def detail_gutter_w(body : Rect, total : Int32) : Int32
+      return 0 unless Settings.show_gutter # keep click→cursor mapping aligned with the gutter-less render
       {Gutter.width(total), body.w}.min
     end
 
@@ -1196,24 +1202,39 @@ module Gori::Tui
       end
     end
 
-    PREVIEW_BODY_CAP = 64 * 1024
-
     private def preview_text_lines(head : Bytes?, body : Bytes?) : Array(String)
       return ["(empty)"] if head.nil? || head.empty?
+      cap = Settings.preview_body_cap
       io = IO::Memory.new
       io.write(head)
       if body && !body.empty?
-        n = {body.size, PREVIEW_BODY_CAP}.min
+        n = {body.size, cap}.min
         io.write(body[0, n])
-        io << "\n… [truncated]" if body.size > PREVIEW_BODY_CAP
+        io << "\n… [truncated]" if body.size > cap
       end
       String.new(io.to_slice).scrub.split('\n').map(&.rstrip('\r'))
     end
 
-    # Local MM-DD HH:MM:SS for the captured-at micros (created_at is unix microseconds).
-    # The brief date makes flows captured across days/sessions legible at a glance.
+    # The captured-at column: an absolute local MM-DD HH:MM:SS timestamp, or a compact
+    # relative age per Settings.history_time_format. The absolute date makes flows
+    # captured across days/sessions legible at a glance; relative is handier during a
+    # live session. created_at is unix microseconds.
     private def fmt_time(created_at : Int64) : String
-      Time.unix(created_at // 1_000_000).to_local.to_s("%m-%d %H:%M:%S")
+      t = Time.unix(created_at // 1_000_000)
+      return fmt_time_relative(t) if Settings.history_time_format == "relative"
+      t.to_local.to_s("%m-%d %H:%M:%S")
+    end
+
+    # Compact relative age from now: "3s" / "5m" / "2h" / "1d" (mirrors
+    # notifications_overlay#ago). Clamped at 0 so clock skew never shows a negative age.
+    private def fmt_time_relative(t : Time) : String
+      secs = {(Time.local - t).total_seconds.to_i, 0}.max
+      return "#{secs}s" if secs < 60
+      mins = secs // 60
+      return "#{mins}m" if mins < 60
+      hours = mins // 60
+      return "#{hours}h" if hours < 24
+      "#{hours // 24}d"
     end
 
     # Compact response size (B/KB/MB/GB), bounded to ≤6 cols. "—" until the response
@@ -1362,7 +1383,7 @@ module Gori::Tui
       dv = detail_view
       total = dv.total
       @detail_last_h = body.h
-      gw = {Gutter.width(total), body.w}.min
+      gw = Settings.show_gutter ? {Gutter.width(total), body.w}.min : 0
       cw = {body.w - gw, 0}.max
       # Styles each visible line ONCE (into `rows`), then clamps/slices from that —
       # never re-styles just to measure width (mirrors RepeaterView#render_response_body).
@@ -1378,7 +1399,7 @@ module Gori::Tui
                   end
       rows.each_with_index do |styled, i|
         li = @detail_scroll + i
-        Gutter.draw(screen, body.x, body.y + i, li, gw, current: focused && li == @detail_read.cy)
+        Gutter.draw(screen, body.x, body.y + i, li, gw, current: focused && li == @detail_read.cy) if gw > 0
         shown = @detail_xscroll > 0 ? Highlight.slice_left(styled, @detail_xscroll) : styled
         Highlight.draw(screen, body.x + gw, body.y + i, shown, width: cw)
         need_plain = (focused && detail_navigable? && (li == @detail_read.cy || sel_spans)) || !@search_hl.empty?
@@ -1398,7 +1419,7 @@ module Gori::Tui
     private def render_reveal(screen : Screen, body : Rect, lines : Array(String), focused : Bool = true) : Nil
       total = lines.size
       @detail_last_h = body.h
-      gw = {Gutter.width(total), body.w}.min
+      gw = Settings.show_gutter ? {Gutter.width(total), body.w}.min : 0
       cw = {body.w - gw, 0}.max
       widest = (0...body.h).compact_map { |i| lines[@detail_scroll + i]? }.max_of? { |l| Screen.display_width_upto(l, @detail_xscroll + cw + 1) } || 0
       @detail_xscroll = @detail_xscroll.clamp(0, {widest - cw, 0}.max)
@@ -1406,7 +1427,7 @@ module Gori::Tui
       (0...body.h).each do |i|
         li = @detail_scroll + i
         break if li >= total
-        Gutter.draw(screen, body.x, body.y + i, li, gw, current: focused && li == @detail_read.cy)
+        Gutter.draw(screen, body.x, body.y + i, li, gw, current: focused && li == @detail_read.cy) if gw > 0
         styled = Reveal.styled(lines[li], li < total - 1, cw + @detail_xscroll)
         styled = Highlight.slice_left(styled, @detail_xscroll) if @detail_xscroll > 0
         Highlight.draw(screen, body.x + gw, body.y + i, styled, width: cw)
@@ -1698,7 +1719,7 @@ module Gori::Tui
       trailer = [] of Highlight::Line
       if truncated
         trailer << Highlight::Line.new
-        trailer << [Highlight::Span.new("— body truncated at capture limit (#{Proxy::Codec::Body::CAPTURE_MAX // (1024 * 1024)} MiB); full size in the list —", Theme.yellow)]
+        trailer << [Highlight::Span.new("— body truncated at capture limit (#{Settings.capture_max_mib} MiB); full size in the list —", Theme.yellow)]
       end
 
       # gRPC: bounded framed hex view — style eagerly into `head`. Flagged binary so the

--- a/src/gori/tui/notifications.cr
+++ b/src/gori/tui/notifications.cr
@@ -41,7 +41,16 @@ module Gori::Tui
     def push(level : Symbol, message : String, goto : Jobs::Goto? = nil, source : String = "app") : Note
       n = Note.new((@next_id += 1), level, message, goto, source)
       @notes << n
-      @notes.shift if @notes.size > CAP
+      # Drain to the live retention setting (CAP is the default; user may lower it).
+      while @notes.size > Settings.notify_retention
+        @notes.shift
+      end
+      # Terminal bell on non-info notes when enabled — a state-neutral `\a` tty write,
+      # like the clipboard's OSC52. This is the app's only bell emit point.
+      if Settings.notify_bell? && level != :info
+        STDOUT.print("\a")
+        STDOUT.flush
+      end
       n
     end
 

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -2139,6 +2139,7 @@ module Gori::Tui
     end
 
     private def resp_gutter_w(body : Rect) : Int32
+      return 0 unless Settings.show_gutter # keep click→cursor mapping aligned with the gutter-less render
       {Gutter.width(resp_line_count), body.w}.min
     end
 
@@ -2512,11 +2513,11 @@ module Gori::Tui
       body = rect.inset(1, 1)
       rv = resp_view
       total = rv.total
-      gw = {Gutter.width(total), body.w}.min
+      gw = Settings.show_gutter ? {Gutter.width(total), body.w}.min : 0
       cw = {body.w - gw, 0}.max
       rows = (0...body.h).compact_map { |i| i < total ? styled_resp_line(rv, i) : nil }
       rows.each_with_index do |styled, i|
-        Gutter.draw(screen, body.x, body.y + i, i, gw)
+        Gutter.draw(screen, body.x, body.y + i, i, gw) if gw > 0
         shown = @xscroll > 0 ? Highlight.slice_left(styled, @xscroll) : styled
         Highlight.draw(screen, body.x + gw, body.y + i, shown, width: cw)
       end
@@ -2571,7 +2572,7 @@ module Gori::Tui
         screen.text(body.x, body.y, "— not sent — press ^R to resend —", Theme.muted)
         return
       end
-      gw = {Gutter.width(lines.size), body.w}.min
+      gw = Settings.show_gutter ? {Gutter.width(lines.size), body.w}.min : 0
       cw = {body.w - gw, 0}.max
       widest = (0...body.h).compact_map { |i| lines[@scroll + i]? }.max_of? { |(t, _)| Screen.display_width(t) } || 0
       @xscroll = @xscroll.clamp(0, {widest - cw, 0}.max)
@@ -2581,7 +2582,7 @@ module Gori::Tui
         li = @scroll + i
         break if li >= lines.size
         text, color = lines[li]
-        Gutter.draw(screen, body.x, body.y + i, li, gw, current: focused && li == @resp_cursor.cy)
+        Gutter.draw(screen, body.x, body.y + i, li, gw, current: focused && li == @resp_cursor.cy) if gw > 0
         shown = @xscroll > 0 ? Highlight.slice_left_text(text, @xscroll) : text
         screen.text(body.x + gw, body.y + i, shown, color, width: cw)
         paint_resp_line_chrome(screen, body.x + gw, body.y + i, li, text, focused, sel_spans)
@@ -2724,7 +2725,7 @@ module Gori::Tui
     private def render_reveal(screen : Screen, rect : Rect, lines : Array(String), focused : Bool) : Nil
       total = lines.size
       @resp_last_h = rect.h
-      gw = {Gutter.width(total), rect.w}.min
+      gw = Settings.show_gutter ? {Gutter.width(total), rect.w}.min : 0
       cw = {rect.w - gw, 0}.max
       widest = (0...rect.h).compact_map { |i| lines[@scroll + i]? }.max_of? { |l| Screen.display_width_upto(l, @xscroll + cw + 1) } || 0
       @xscroll = @xscroll.clamp(0, {widest - cw, 0}.max)
@@ -2732,7 +2733,7 @@ module Gori::Tui
       (0...rect.h).each do |i|
         li = @scroll + i
         break if li >= total
-        Gutter.draw(screen, rect.x, rect.y + i, li, gw, current: focused && li == @resp_cursor.cy)
+        Gutter.draw(screen, rect.x, rect.y + i, li, gw, current: focused && li == @resp_cursor.cy) if gw > 0
         styled = Reveal.styled(lines[li], li < total - 1, cw + @xscroll)
         styled = Highlight.slice_left(styled, @xscroll) if @xscroll > 0
         Highlight.draw(screen, rect.x + gw, rect.y + i, styled, width: cw)
@@ -2774,7 +2775,7 @@ module Gori::Tui
       rv = resp_view
       total = rv.total
       @resp_last_h = rect.h
-      gw = {Gutter.width(total), rect.w}.min
+      gw = Settings.show_gutter ? {Gutter.width(total), rect.w}.min : 0
       cw = {rect.w - gw, 0}.max
       rows = (0...rect.h).compact_map { |i| (li = @scroll + i) < total ? styled_resp_line(rv, li) : nil }
       @xscroll = @xscroll.clamp(0, {(rows.max_of? { |l| Highlight.line_width_upto(l, @xscroll + cw + 1) } || 0) - cw, 0}.max)
@@ -2783,7 +2784,7 @@ module Gori::Tui
         li = @scroll + i
         need_plain = (focused && resp_navigable? && (li == @resp_cursor.cy || sel_spans)) || !@search_hl.empty?
         text = need_plain ? rv.line_text(li) : nil
-        Gutter.draw(screen, rect.x, rect.y + i, li, gw, current: focused && li == @resp_cursor.cy)
+        Gutter.draw(screen, rect.x, rect.y + i, li, gw, current: focused && li == @resp_cursor.cy) if gw > 0
         shown = @xscroll > 0 ? Highlight.slice_left(styled, @xscroll) : styled
         Highlight.draw(screen, rect.x + gw, rect.y + i, shown, width: cw)
         paint_resp_line_chrome(screen, rect.x + gw, rect.y + i, li, text, focused, sel_spans) if text
@@ -2819,7 +2820,7 @@ module Gori::Tui
 
     private def render_diff(screen : Screen, rect : Rect, focused : Bool) : Nil
       data = diff_lines
-      gw = {Gutter.width(data.size), rect.w}.min
+      gw = Settings.show_gutter ? {Gutter.width(data.size), rect.w}.min : 0
       cw = {rect.w - gw, 0}.max
       rows = (0...rect.h).compact_map do |i|
         di = @scroll + i
@@ -2836,7 +2837,7 @@ module Gori::Tui
       @resp_last_h = rect.h
       sel_spans = resp_sel_spans_if(focused)
       rows.each_with_index do |(di, full, color, text), i|
-        Gutter.draw(screen, rect.x, rect.y + i, di, gw, current: focused && di == @resp_cursor.cy)
+        Gutter.draw(screen, rect.x, rect.y + i, di, gw, current: focused && di == @resp_cursor.cy) if gw > 0
         shown = @xscroll > 0 ? Highlight.slice_left_text(full, @xscroll) : full
         screen.text(rect.x + gw, rect.y + i, shown, color, width: cw)
         paint_resp_line_chrome(screen, rect.x + gw + 2, rect.y + i, di, text, focused, sel_spans)

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -873,7 +873,12 @@ module Gori::Tui
       # quit-arm so a stray ^D during a rebind can't silently arm an app quit.
       capturing_hotkey = @overlay == :hotkeys && @hotkeys_overlay.capturing?
       if (ev.ctrl_c? || (ev.ctrl? && ev.key.lower_d?)) && !capturing_hotkey
-        if @quit_armed
+        if Settings.confirm_quit?
+          # Opt-in (settings:general): a confirm modal replaces the double-press arm. Skip
+          # re-opening if the quit confirm is already up (^D then just waits for y/n/esc).
+          confirm("QUIT GORI", "Quit gori? (pending edits are committed first)",
+            confirm_label: "quit", danger: true) { quit! } unless @overlay == :confirm
+        elsif @quit_armed
           quit!
         else
           @quit_armed = true
@@ -2538,6 +2543,7 @@ module Gori::Tui
                  when :network then apply_settings(msg).tap { @session.set_verify_upstream(Settings.verify_upstream?); @session.set_serve_landing(Settings.serve_landing?); project_controller.refresh_network } # push the verify + info-page toggles to the live proxy/probe, then re-sync the Project pane's inherited fields to the new global
                  when :theme   then apply_theme(msg)
                  when :layout  then apply_layout(msg)
+                 when :display then apply_display(msg)
                  else               msg
                  end
         @theme_restore = Settings.theme if @settings_view.section == :theme # saved → don't revert this on esc
@@ -5655,7 +5661,7 @@ module Gori::Tui
 
     def open_settings(section : Symbol) : Nil
       case section
-      when :network, :editor, :theme, :layout, :statusline
+      when :network, :editor, :theme, :layout, :statusline, :display, :notifications, :general
         @settings_view.reload(section)       # :theme reloads custom themes — may reconcile the live palette
         @resized = true if section == :theme # so force a full repaint (an edited/removed active theme just changed)
         @overlay = :settings
@@ -5683,6 +5689,14 @@ module Gori::Tui
       history_controller.view.reload(@session.store)
       history_controller.refresh_preview
       sitemap_controller.view.reload(@session.store) if sitemap_controller.view.loaded?
+      save_msg
+    end
+
+    # Display prefs apply live on the next frame — the gutter, list time format and default
+    # pane are read at render time. Only the preview body cap needs a nudge: refresh the
+    # History preview so a new cap (or default pane) is reflected on the current selection now.
+    private def apply_display(save_msg : String) : String
+      history_controller.refresh_preview
       save_msg
     end
 

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -27,6 +27,9 @@ module Gori::Tui
       Field.new("Upstream proxy", "host:port — blank = connect directly; projects may override"),
       Field.new("Verify upstream TLS", "check the upstream server's certificate — off accepts any cert (MITM/testing); ←/→/space toggles", bool: true),
       Field.new("Info page on direct access", "serve a gori welcome + CA-download page to browsers that hit the listen address directly — ←/→/space toggles", bool: true),
+      Field.new("Connect timeout (s)", "how long an upstream TCP/proxy connect may take before giving up — seconds (min 1)"),
+      Field.new("Idle timeout (s)", "initial read/write timeout on the upstream socket — seconds (min 1)"),
+      Field.new("Capture body limit (MiB)", "max body bytes captured + stored per flow — MiB (min 1); applies to NEW flows only"),
       Field.new("Hostname overrides", "↵ to edit the global IP→host map (a /etc/hosts for this proxy)", opener: :hosts),
     ]
     EDITOR_FIELDS = [
@@ -72,12 +75,51 @@ module Gori::Tui
       Field.new("Interval (s)",
         "how often to re-run the command — seconds (min 1)"),
     ]
+    # Display: message-body rendering prefs (two choice fields + a bool + a text cap).
+    DISPLAY_PANE_CHOICES = ["request", "response"]
+    DISPLAY_TIME_CHOICES = ["absolute", "relative"]
+    DISPLAY_FIELDS       = [
+      Field.new("Default detail pane",
+        "which pane a freshly-opened History flow shows first — ←/→ cycles",
+        choices: DISPLAY_PANE_CHOICES),
+      Field.new("History list time",
+        "list time column: absolute (MM-DD HH:MM:SS) or relative (3s/5m/2h) — ←/→ cycles",
+        choices: DISPLAY_TIME_CHOICES),
+      Field.new("Line numbers",
+        "show the line-number gutter on the message body views — ←/→/space toggles",
+        bool: true),
+      Field.new("Preview body limit (KiB)",
+        "how many body bytes the History list preview reads/shows — KiB (min 1)"),
+    ]
+    # Notifications: bell/toast toggles + ring-buffer retention.
+    NOTIFICATIONS_FIELDS = [
+      Field.new("Bell on result",
+        "ring the terminal bell on a background result/alert (miner/fuzzer/probe/discover) — ←/→/space toggles",
+        bool: true),
+      Field.new("Toast on result",
+        "also flash a bottom-bar toast for fuzzer/probe/discover results — ←/→/space toggles",
+        bool: true),
+      Field.new("Retention (count)",
+        "how many notifications the ring buffer keeps — count (min 1)"),
+    ]
+    # General: clipboard + quit-confirm toggles.
+    GENERAL_FIELDS = [
+      Field.new("Clipboard (OSC 52)",
+        "copy to the system clipboard via the OSC 52 terminal escape — off makes copies no-op — ←/→/space toggles",
+        bool: true),
+      Field.new("Confirm before quit",
+        "require a confirm modal to quit (instead of double-press ^D) — ←/→/space toggles",
+        bool: true),
+    ]
     SECTIONS = {
-      :network    => NETWORK_FIELDS,
-      :editor     => EDITOR_FIELDS,
-      :theme      => THEME_FIELDS,
-      :layout     => LAYOUT_FIELDS,
-      :statusline => STATUSLINE_FIELDS,
+      :network       => NETWORK_FIELDS,
+      :editor        => EDITOR_FIELDS,
+      :theme         => THEME_FIELDS,
+      :layout        => LAYOUT_FIELDS,
+      :statusline    => STATUSLINE_FIELDS,
+      :display       => DISPLAY_FIELDS,
+      :notifications => NOTIFICATIONS_FIELDS,
+      :general       => GENERAL_FIELDS,
     }
 
     # Max theme rows shown at once before the list scrolls (the box also shrinks to the
@@ -107,11 +149,14 @@ module Gori::Tui
       @section = section
       Theme.load_custom if section == :theme # pick up theme files dropped since startup
       @values = case section
-                when :editor     then [Settings.editor, Settings.editor_markdown ? "on" : "off", Settings.mouse ? "on" : "off", Settings.pretty_bodies_default ? "on" : "off"]
-                when :theme      then [Theme.canonical(Settings.theme)]
-                when :layout     then layout_values
-                when :statusline then [Settings.statusline_enabled? ? "on" : "off", Settings.statusline_command, Settings.statusline_interval.to_s]
-                else                  [Settings.bind_host, Settings.bind_port.to_s, Settings.upstream_proxy, Settings.verify_upstream? ? "on" : "off", Settings.serve_landing? ? "on" : "off", hostnames_summary]
+                when :editor        then [Settings.editor, Settings.editor_markdown ? "on" : "off", Settings.mouse ? "on" : "off", Settings.pretty_bodies_default ? "on" : "off"]
+                when :theme         then [Theme.canonical(Settings.theme)]
+                when :layout        then layout_values
+                when :statusline    then [Settings.statusline_enabled? ? "on" : "off", Settings.statusline_command, Settings.statusline_interval.to_s]
+                when :display       then [Settings.default_detail_pane, Settings.history_time_format, Settings.show_gutter ? "on" : "off", Settings.preview_body_kib.to_s]
+                when :notifications then [Settings.notify_bell? ? "on" : "off", Settings.notify_toast? ? "on" : "off", Settings.notify_retention.to_s]
+                when :general       then [Settings.clipboard_osc52? ? "on" : "off", Settings.confirm_quit? ? "on" : "off"]
+                else                     [Settings.bind_host, Settings.bind_port.to_s, Settings.upstream_proxy, Settings.verify_upstream? ? "on" : "off", Settings.serve_landing? ? "on" : "off", Settings.connect_timeout_secs.to_s, Settings.io_timeout_secs.to_s, Settings.capture_max_mib.to_s, hostnames_summary]
                 end
       @focused = 0
       @cursor = @values[0].size
@@ -141,7 +186,22 @@ module Gori::Tui
                   Settings::DEFAULT_STATUSLINE_COMMAND,
                   Settings::DEFAULT_STATUSLINE_INTERVAL.to_s,
                 ]
-                else [Settings::DEFAULT_BIND_HOST, Settings::DEFAULT_BIND_PORT.to_s, Settings::DEFAULT_UPSTREAM_PROXY, Settings::DEFAULT_VERIFY_UPSTREAM ? "on" : "off", Settings::DEFAULT_SERVE_LANDING ? "on" : "off", hostnames_summary]
+                when :display then [
+                  Settings::DEFAULT_DETAIL_PANE,
+                  Settings::DEFAULT_HISTORY_TIME_FORMAT,
+                  Settings::DEFAULT_SHOW_GUTTER ? "on" : "off",
+                  Settings::DEFAULT_PREVIEW_BODY_KIB.to_s,
+                ]
+                when :notifications then [
+                  Settings::DEFAULT_NOTIFY_BELL ? "on" : "off",
+                  Settings::DEFAULT_NOTIFY_TOAST ? "on" : "off",
+                  Settings::DEFAULT_NOTIFY_RETENTION.to_s,
+                ]
+                when :general then [
+                  Settings::DEFAULT_CLIPBOARD_OSC52 ? "on" : "off",
+                  Settings::DEFAULT_CONFIRM_QUIT ? "on" : "off",
+                ]
+                else [Settings::DEFAULT_BIND_HOST, Settings::DEFAULT_BIND_PORT.to_s, Settings::DEFAULT_UPSTREAM_PROXY, Settings::DEFAULT_VERIFY_UPSTREAM ? "on" : "off", Settings::DEFAULT_SERVE_LANDING ? "on" : "off", Settings::DEFAULT_CONNECT_TIMEOUT_SECS.to_s, Settings::DEFAULT_IO_TIMEOUT_SECS.to_s, Settings::DEFAULT_CAPTURE_MAX_MIB.to_s, hostnames_summary]
                 end
       @focused = 0
       @cursor = @values[0].size
@@ -324,6 +384,37 @@ module Gori::Tui
         @values = [Settings.statusline_enabled? ? "on" : "off", Settings.statusline_command, iv.to_s]
         return persist
       end
+      if @section == :display
+        kib = @values[3].strip.to_i?
+        unless kib && kib >= 1
+          @status = "invalid preview limit"
+          return "settings: invalid preview body limit #{@values[3].inspect} (KiB, min 1)"
+        end
+        Settings.default_detail_pane = @values[0] == "response" ? "response" : "request"
+        Settings.history_time_format = @values[1] == "relative" ? "relative" : "absolute"
+        Settings.show_gutter = @values[2] == "on"
+        Settings.preview_body_kib = kib
+        @values = [Settings.default_detail_pane, Settings.history_time_format, Settings.show_gutter ? "on" : "off", Settings.preview_body_kib.to_s]
+        return persist
+      end
+      if @section == :notifications
+        ret = @values[2].strip.to_i?
+        unless ret && ret >= 1
+          @status = "invalid retention"
+          return "settings: invalid notification retention #{@values[2].inspect} (count, min 1)"
+        end
+        Settings.notify_bell = @values[0] == "on"
+        Settings.notify_toast = @values[1] == "on"
+        Settings.notify_retention = ret
+        @values = [Settings.notify_bell? ? "on" : "off", Settings.notify_toast? ? "on" : "off", ret.to_s]
+        return persist
+      end
+      if @section == :general
+        Settings.clipboard_osc52 = @values[0] == "on"
+        Settings.confirm_quit = @values[1] == "on"
+        @values = [Settings.clipboard_osc52? ? "on" : "off", Settings.confirm_quit? ? "on" : "off"]
+        return persist
+      end
       port = @values[1].strip.to_i?
       unless port && 0 <= port <= 65535
         @status = "invalid port"
@@ -334,12 +425,30 @@ module Gori::Tui
         @status = "invalid upstream port"
         return err
       end
+      ct = @values[5].strip.to_i?
+      unless ct && ct >= 1
+        @status = "invalid connect timeout"
+        return "settings: invalid connect timeout #{@values[5].inspect} (seconds, min 1)"
+      end
+      it = @values[6].strip.to_i?
+      unless it && it >= 1
+        @status = "invalid idle timeout"
+        return "settings: invalid idle timeout #{@values[6].inspect} (seconds, min 1)"
+      end
+      cap = @values[7].strip.to_i?
+      unless cap && cap >= 1
+        @status = "invalid capture limit"
+        return "settings: invalid capture limit #{@values[7].inspect} (MiB, min 1)"
+      end
       Settings.bind_host = @values[0].strip
       Settings.bind_port = port
       Settings.upstream_proxy = up
       Settings.verify_upstream = @values[3] == "on"
       Settings.serve_landing = @values[4] == "on"
-      @values = [Settings.bind_host, Settings.bind_port.to_s, Settings.upstream_proxy, Settings.verify_upstream? ? "on" : "off", Settings.serve_landing? ? "on" : "off", hostnames_summary]
+      Settings.connect_timeout_secs = ct
+      Settings.io_timeout_secs = it
+      Settings.capture_max_mib = cap
+      @values = [Settings.bind_host, Settings.bind_port.to_s, Settings.upstream_proxy, Settings.verify_upstream? ? "on" : "off", Settings.serve_landing? ? "on" : "off", Settings.connect_timeout_secs.to_s, Settings.io_timeout_secs.to_s, Settings.capture_max_mib.to_s, hostnames_summary]
       persist
     end
 

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -101,6 +101,15 @@ module Gori
       r.register Verb::Definition.new(
         "settings.statusline", "Settings: Statusline", "Run a command periodically and show its output as a bottom status line",
         Verb::Scope::Global, category: Verb::Category::Settings) { |ctx| ctx.open_settings(:statusline); nil }
+      r.register Verb::Definition.new(
+        "settings.display", "Settings: Display", "Message-body rendering: default detail pane, list time format, line numbers, preview size",
+        Verb::Scope::Global, category: Verb::Category::Settings) { |ctx| ctx.open_settings(:display); nil }
+      r.register Verb::Definition.new(
+        "settings.notifications", "Settings: Notifications", "Terminal bell + toast on background results, and how many notifications are kept",
+        Verb::Scope::Global, category: Verb::Category::Settings) { |ctx| ctx.open_settings(:notifications); nil }
+      r.register Verb::Definition.new(
+        "settings.general", "Settings: General", "Clipboard (OSC 52) integration and confirm-before-quit",
+        Verb::Scope::Global, category: Verb::Category::Settings) { |ctx| ctx.open_settings(:general); nil }
 
       # `s` toggles the scope lens from anywhere (its original behavior — this used to jump to
       # the Project scope editor). Jumping there is now the palette-only `scope.edit` below.


### PR DESCRIPTION
## What & why

Expands the TUI Settings surface with user-facing controls for behaviors that were
hardcoded constants or had no home in the settings UI, reusing the existing section
pattern (DEFAULT_* + class_property + tolerant parse_* + omit-when-default serialize)
end-to-end. Discoverable via Ctrl-P and persisted to `settings.json`.

## New / extended sections

**Network** (extend existing) — Connect timeout (s), Upstream idle timeout (s), Capture body limit (MiB).

**Settings: Display** (new) — default detail pane (request/response), History list time format (absolute/relative), line-number gutter toggle, preview body limit (KiB).

**Settings: Notifications** (new) — terminal bell on result, toast-on-result gate, ring-buffer retention.

**Settings: General** (new) — OSC 52 clipboard toggle, confirm-before-quit.

## How it's wired

- `settings.cr` / `settings_view.cr` / `verbs/core.cr` / `runner.cr` — the section plumbing (accessors, fields, palette verbs, `open_settings` whitelist, `apply_display`, quit-confirm).
- Consumers read the new `Settings.*` accessors **live**: upstream dial timeouts (`upstream.cr`, repeater engines), capture buffers (`client_conn.cr`, `assembler.cr`, `import/builder.cr`), history + repeater gutter, `fmt_time`, `clipboard.cr`, and the quit handler.

## Notable decisions

- **Toast-on-result** gates the *existing* unconditional toast in fuzzer/probe/discover (default on → no behavior change; off silences them). The Miner keeps its own per-run `NotifyMode`.
- **Gutter toggle** applies to all read-only message-body render paths in both History and Repeater (the editable request-editor's own gutter flag is untouched).
- **Capture limit** changes apply to *new* flows only (buffers allocate at request start).
- `Codec::Body::CAPTURE_MAX` and the `Upstream::*_TIMEOUT` consts are retained (still referenced by specs/comments; values aligned with the new defaults).
- ASCII-glyph fallback and soft-wrap were intentionally scoped out of this batch.

## Verification

- `crystal build` clean.
- Full suite: **2056 examples, only the 8 pre-existing sandbox TCP-bind failures** (`project_registry_spec` / `capture_status_spec` — unrelated to this change).
- Added round-trip, validation, false-survival, and omit-when-default specs for all new sections + network fields.
- Rebased onto current `main` (past #202–#205) and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
