### PR TITLE
feat(decoder): add 11 CHAIN codecs + show full list on empty field

### DIFF
--- a/spec/decoder_spec.cr
+++ b/spec/decoder_spec.cr
@@ -36,6 +36,11 @@ describe Gori::Decoder do
       names.first.should eq "url-encode"
       names.index("url-encode").not_nil!.should be < names.index("base64url-encode").not_nil!
     end
+
+    it "returns every converter (registration order) for an empty query" do
+      # Foundation for the Decoder tab's show-all-on-empty discovery popup.
+      REG.match("").map(&.name).should eq REG.names
+    end
   end
 
   describe "base64 / url / hex round-trips" do
@@ -59,6 +64,12 @@ describe Gori::Decoder do
     it "url encode/decode (form style)" do
       conv("url-encode", "a b+c").should eq "a+b%2Bc"
       conv("url-decode", "a+b%2Bc").should eq "a b+c"
+    end
+
+    it "url-encode-all percent-encodes every byte (uppercase)" do
+      conv("url-encode-all", "A/").should eq "%41%2F"
+      conv("url-encode-all", "hi").should eq "%68%69"
+      conv("url-decode", conv("url-encode-all", "a b+c")).should eq "a b+c" # round-trips via the std decoder
     end
 
     it "hex encode/decode (tolerant of 0x / ':' / spaces)" do
@@ -140,11 +151,49 @@ describe Gori::Decoder do
       String.new(conv_bytes("zlib-decompress", z)).should eq "hello world"
     end
 
+    it "raw deflate round-trips (RFC 1951, no zlib/gzip wrapper)" do
+      d = conv_bytes("raw-deflate", "hello world".to_slice)
+      String.new(conv_bytes("raw-inflate", d)).should eq "hello world"
+    end
+
     it "gzip-compress is deterministic (mtime pinned to epoch)" do
       a = conv_bytes("gzip-compress", "hello world".to_slice)
       b = conv_bytes("gzip-compress", "hello world".to_slice)
       a.should eq(b) # same input → identical bytes (no wall-clock mtime)
       String.new(conv_bytes("gzip-decompress", a)).should eq "hello world"
+    end
+  end
+
+  describe "number bases (byte-oriented, space-separated)" do
+    it "decimal encode/decode" do
+      conv("decimal-encode", "hi").should eq "104 105"
+      conv("decimal-decode", "104 105").should eq "hi"
+      conv("decimal-decode", "104,105").should eq "hi" # comma-separated tolerated
+    end
+
+    it "binary encode/decode (8-bit groups)" do
+      conv("binary-encode", "hi").should eq "01101000 01101001"
+      conv("binary-decode", "01101000 01101001").should eq "hi"
+    end
+
+    it "octal encode/decode" do
+      conv("octal-encode", "hi").should eq "150 151"
+      conv("octal-decode", "150 151").should eq "hi"
+    end
+
+    it "round-trips every byte value 0..255 in each base" do
+      bytes = Bytes.new(256) { |i| i.to_u8 }
+      {"decimal", "binary", "octal"}.each do |base|
+        rt = conv_bytes("#{base}-decode", conv_bytes("#{base}-encode", bytes).dup)
+        rt.should eq bytes
+      end
+    end
+
+    it "raises on out-of-range or non-numeric tokens" do
+      expect_raises(Gori::Decoder::DecoderError) { conv("decimal-decode", "256") }
+      expect_raises(Gori::Decoder::DecoderError) { conv("decimal-decode", "-1") }
+      expect_raises(Gori::Decoder::DecoderError) { conv("decimal-decode", "12x") }
+      expect_raises(Gori::Decoder::DecoderError) { conv("binary-decode", "012") } # '2' not a binary digit
     end
   end
 
@@ -154,6 +203,8 @@ describe Gori::Decoder do
       conv("sha1", "").should eq "da39a3ee5e6b4b0d3255bfef95601890afd80709"
       conv("sha256", "abc").should eq "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
       conv("sha512", "abc").should start_with "ddaf35a193617aba"
+      conv("crc32", "hello world").should eq "0d4a1185"
+      conv("crc32", "").should eq "00000000" # empty input → zero, left-padded to 8 hex
     end
   end
 
@@ -212,6 +263,12 @@ describe Gori::Decoder do
       conv("upper", "abc").should eq "ABC"
       conv("lower", "ABC").should eq "abc"
       conv("reverse", "abc").should eq "cba"
+    end
+
+    it "rot47 rotates printable ASCII 33..126 and is self-inverse" do
+      conv("rot47", "Hello").should eq "w6==@"
+      conv("rot47", conv("rot47", "Hello, World! 123")).should eq "Hello, World! 123"
+      conv("rot47", " ").should eq " " # space (0x20) is below 33 → passes through unchanged
     end
   end
 

--- a/src/gori/decoder/catalog.cr
+++ b/src/gori/decoder/catalog.cr
@@ -6,6 +6,7 @@ require "digest/md5"
 require "digest/sha1"
 require "digest/sha256"
 require "digest/sha512"
+require "digest/crc32"
 
 module Gori::Decoder
   # Builds the default registry — every v1 converter, in autocomplete display
@@ -34,6 +35,9 @@ module Gori::Decoder
     r.register text("url-decode", "urldecode", "percent-decode",
       category: Category::Encoding, direction: Direction::Decode,
       description: "URL/percent decode ('+' -> space, %XX)") { |s| URI.decode_www_form(s) }
+    r.register encode("url-encode-all", "url-encode-full", "percent-encode-all",
+      category: Category::Encoding,
+      description: "Percent-encode every byte (%XX, uppercase) — WAF-bypass style") { |b| Codecs.url_encode_all(b) }
 
     # ---------------- ENCODING: hex ----------------
     r.register encode("hex-encode", "hex", "tohex",
@@ -59,6 +63,22 @@ module Gori::Decoder
     r.register decode("base58-decode", "unbase58",
       category: Category::Encoding, description: "Base58 decode (Bitcoin alphabet)") { |s| Codecs.base58_decode(s) }
 
+    # ---------------- ENCODING: number bases (byte-oriented, space-separated) ----------------
+    r.register encode("decimal-encode", "decimal", "to-decimal", "dec",
+      category: Category::Encoding, description: "Bytes to space-separated decimal (0-255)") { |b| Codecs.decimal_encode(b) }
+    r.register decode("decimal-decode", "from-decimal", "undecimal",
+      category: Category::Encoding, description: "Space/comma-separated decimal to bytes") { |s| Codecs.decimal_decode(s) }
+
+    r.register encode("binary-encode", "binary", "to-binary", "bin",
+      category: Category::Encoding, description: "Bytes to space-separated 8-bit binary") { |b| Codecs.binary_encode(b) }
+    r.register decode("binary-decode", "from-binary", "unbinary",
+      category: Category::Encoding, description: "Space/comma-separated binary to bytes") { |s| Codecs.binary_decode(s) }
+
+    r.register encode("octal-encode", "octal", "to-octal", "oct",
+      category: Category::Encoding, description: "Bytes to space-separated octal") { |b| Codecs.octal_encode(b) }
+    r.register decode("octal-decode", "from-octal", "unoctal",
+      category: Category::Encoding, description: "Space/comma-separated octal to bytes") { |s| Codecs.octal_decode(s) }
+
     # ---------------- COMPRESSION ----------------
     r.register bytes("gzip-compress", "gzip", "gz",
       category: Category::Compression, direction: Direction::Encode,
@@ -72,6 +92,12 @@ module Gori::Decoder
     r.register bytes("zlib-decompress", "inflate",
       category: Category::Compression, direction: Direction::Decode,
       description: "Zlib/deflate decompress (32 MiB cap)") { |b| Codecs.zlib_decompress(b) }
+    r.register bytes("raw-deflate", "deflate-raw",
+      category: Category::Compression, direction: Direction::Encode,
+      description: "Raw DEFLATE compress (RFC 1951, no zlib/gzip header)") { |b| Codecs.deflate_raw(b) }
+    r.register bytes("raw-inflate", "inflate-raw",
+      category: Category::Compression, direction: Direction::Decode,
+      description: "Raw DEFLATE decompress (RFC 1951, 32 MiB cap)") { |b| Codecs.inflate_raw(b) }
 
     # ---------------- TOKEN ----------------
     r.register encode("jwt-decode", "jwt",
@@ -83,6 +109,7 @@ module Gori::Decoder
     r.register encode("sha1", category: Category::Hash, direction: Direction::Hash, description: "SHA-1 digest (hex)") { |b| Digest::SHA1.hexdigest(b) }
     r.register encode("sha256", category: Category::Hash, direction: Direction::Hash, description: "SHA-256 digest (hex)") { |b| Digest::SHA256.hexdigest(b) }
     r.register encode("sha512", category: Category::Hash, direction: Direction::Hash, description: "SHA-512 digest (hex)") { |b| Digest::SHA512.hexdigest(b) }
+    r.register encode("crc32", category: Category::Hash, direction: Direction::Hash, description: "CRC-32 checksum (hex)") { |b| Digest::CRC32.checksum(b).to_s(16).rjust(8, '0') }
 
     # ---------------- ESCAPE ----------------
     r.register text("html-escape", "html-encode", "htmlentities", "html",
@@ -115,6 +142,8 @@ module Gori::Decoder
       description: "Lowercase") { |s| s.downcase }
     r.register text("reverse", category: Category::Text, direction: Direction::Transform,
       description: "Reverse characters") { |s| s.reverse }
+    r.register text("rot47", category: Category::Text, direction: Direction::Transform,
+      description: "ROT47 (printable ASCII 33-126, self-inverse)") { |s| Codecs.rot47(s) }
 
     r
   end

--- a/src/gori/decoder/codecs.cr
+++ b/src/gori/decoder/codecs.cr
@@ -2,6 +2,7 @@ require "base64"
 require "json"
 require "compress/gzip"
 require "compress/zlib"
+require "compress/deflate"
 require "big"
 
 module Gori::Decoder
@@ -415,6 +416,19 @@ module Gori::Decoder
       drain(Compress::Zlib::Reader.new(IO::Memory.new(data)))
     end
 
+    # Raw DEFLATE (RFC 1951) — no zlib/gzip wrapper. Common on the wire: many servers
+    # send `Content-Encoding: deflate` as raw deflate, and websocket permessage-deflate
+    # is raw. Mirrors zlib_compress/zlib_decompress; reuses the bounded drain.
+    def deflate_raw(data : Bytes) : Bytes
+      io = IO::Memory.new
+      Compress::Deflate::Writer.open(io, &.write(data))
+      io.to_slice
+    end
+
+    def inflate_raw(data : Bytes) : Bytes
+      drain(Compress::Deflate::Reader.new(IO::Memory.new(data)))
+    end
+
     # Drain a decompression reader into memory, capped at MAX_OUT (no zip-bombs).
     # Tolerant: a mid-stream error keeps whatever was decoded; an immediate failure
     # (nothing decoded) raises a DecoderError. Mirrors content_decode.cr's read_all.
@@ -430,6 +444,81 @@ module Gori::Decoder
         raise DecoderError.new("decompress failed: #{ex.message}") if sink.bytesize == 0
       end
       sink.to_slice
+    end
+
+    # ---- byte-oriented number bases (space-separated, matches CyberChef To/From) ----
+    def decimal_encode(data : Bytes) : String
+      String.build do |io|
+        data.each_with_index do |b, i|
+          io << ' ' if i > 0
+          io << b
+        end
+      end
+    end
+
+    def binary_encode(data : Bytes) : String
+      String.build do |io|
+        data.each_with_index do |b, i|
+          io << ' ' if i > 0
+          io << b.to_s(2).rjust(8, '0')
+        end
+      end
+    end
+
+    def octal_encode(data : Bytes) : String
+      String.build do |io|
+        data.each_with_index do |b, i|
+          io << ' ' if i > 0
+          io << b.to_s(8)
+        end
+      end
+    end
+
+    def decimal_decode(s : String) : Bytes
+      parse_numbers(s, 10)
+    end
+
+    def binary_decode(s : String) : Bytes
+      parse_numbers(s, 2)
+    end
+
+    def octal_decode(s : String) : Bytes
+      parse_numbers(s, 8)
+    end
+
+    # Split on whitespace/commas; every token must parse in `base` and fit a byte.
+    private def parse_numbers(s : String, base : Int32) : Bytes
+      toks = s.split(/[\s,]+/).reject(&.empty?)
+      out = Bytes.new(toks.size)
+      toks.each_with_index do |t, i|
+        v = t.to_i?(base)
+        raise DecoderError.new("invalid base-#{base} value: #{t.inspect}") unless v && 0 <= v <= 255
+        out[i] = v.to_u8
+      end
+      out
+    end
+
+    # Percent-encode EVERY byte (%XX, uppercase) — WAF-bypass style. Contrast with the
+    # url-encode converter (URI.encode_www_form), which only escapes reserved chars.
+    def url_encode_all(data : Bytes) : String
+      String.build(data.size * 3) do |io|
+        data.each { |b| io << ("%%%02X" % b) }
+      end
+    end
+
+    # ROT47: rotate printable ASCII 33..126 by 47 (mod 94); all else passes through.
+    # Self-inverse — applying it twice restores the original.
+    def rot47(s : String) : String
+      String.build do |io|
+        s.each_char do |c|
+          o = c.ord
+          if 33 <= o <= 126
+            io << ((o - 33 + 47) % 94 + 33).chr
+          else
+            io << c
+          end
+        end
+      end
     end
   end
 end

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -389,8 +389,9 @@ module Gori
             "result — the same engine as the TUI Decoder tab. Pure transform: no network, no state. " \
             "`spec` is converter tokens separated by '>', '|' or ',' applied left-to-right, e.g. " \
             "'base64-decode > gunzip', 'url-encode', 'sha256'. Common converters: base64, " \
-            "base64-decode, url-encode, url-decode, hex, hex-decode, gzip, gunzip, deflate, inflate, " \
-            "jwt-decode, html-encode, md5, sha1, sha256. An unknown token returns the full list." do |s|
+            "base64-decode, url-encode, url-encode-all, url-decode, hex, hex-decode, gzip, gunzip, " \
+            "deflate, inflate, raw-deflate, raw-inflate, jwt-decode, html-encode, md5, sha256, crc32, " \
+            "decimal, binary, rot47. An unknown token returns the full list." do |s|
             s.field "input", strprop("the value to transform (UTF-8 text unless input_base64 is set)"), required: true
             s.field "spec", strprop("converter chain, e.g. 'base64-decode > gunzip'"), required: true
             s.field "input_base64", boolprop("treat `input` as base64 and decode it to raw bytes first (for binary input)")

--- a/src/gori/tui/controllers/decoder_controller.cr
+++ b/src/gori/tui/controllers/decoder_controller.cr
@@ -51,6 +51,7 @@ module Gori::Tui
       super(host)
       @registry = Decoder.default_registry
       @popup = ChainComplete.new
+      @popup_engaged = false # false = passive full-list menu (Tab still navigates panes)
       @prompt = nil # :save_as | :load inline mini-prompt (else nil)
       @prompt_buf = ""
       @chain_pre = "" # IME preedit for the focused CHAIN field
@@ -278,7 +279,7 @@ module Gori::Tui
     # via a pre-ring guard (gated on `completing?`). Returns false for any other key
     # so normal chain editing still flows down to handle_body_key + refilters.
     def completing? : Bool
-      cur.pane == :chain && @popup.open?
+      cur.pane == :chain && @popup.open? && @popup_engaged
     end
 
     def handle_complete_key(ev : Termisu::Event::Key) : Bool
@@ -363,11 +364,12 @@ module Gori::Tui
 
     def pane_advance(dir : Int32) : Bool
       s = cur
-      @popup.close
       i = PANE_ORDER.index(s.pane) || 0
       ni = i + dir
       return false if ni < 0 || ni >= PANE_ORDER.size
       s.pane = PANE_ORDER[ni]
+      # Surface the converter list when landing on CHAIN (discovery); close it otherwise.
+      s.pane == :chain ? surface_chain_list : @popup.close
       true
     end
 
@@ -381,6 +383,22 @@ module Gori::Tui
       @popup.close
     end
 
+    # Focus the CHAIN field and surface the converter list (used by ↓ from INPUT and ↑
+    # from OUTPUT, mirroring the Tab focus ring).
+    private def focus_chain : Nil
+      cur.pane = :chain
+      surface_chain_list
+    end
+
+    # Discovery aid: when the token under the caret is empty, pop the FULL converter list
+    # as a *passive* menu (Tab still navigates the focus ring; ↓ dives in). With a real
+    # token present, leave the popup closed so merely focusing never hijacks Tab.
+    private def surface_chain_list : Nil
+      s = cur
+      ts, te = token_span(s.chain, s.chain_cx)
+      s.chain[ts...te].strip.empty? ? refilter_popup : @popup.close
+    end
+
     def body_hint(focus : Symbol) : String
       return "type a name · ↵ save · esc cancel" if @prompt == :save_as
       return "type a name · ↵ load · esc cancel" if @prompt == :load
@@ -388,7 +406,9 @@ module Gori::Tui
       y = Hotkeys.binding_label(@host.session.registry, "decoder.copy", "y")
       case s.pane
       when :chain
-        return "↑/↓ pick · ↹/↵ complete · esc close · type to filter" if @popup.open?
+        if @popup.open?
+          return @popup_engaged ? "↑/↓ pick · ↹/↵ complete · esc close · type to filter" : "↓ browse · type to filter · ⇥ output · esc tabs"
+        end
         "chain (> | ,) · ↑ input · ↓ output · ^Y copy · ^X mode · ^S save · ^O load · esc tabs"
       when :output
         "↑/↓ move · ⇧arrows select · #{y} copy · ⇧←/→ h-scroll · ↑-top chain · space cmds · ^X mode · ^Y copy all · esc tabs"
@@ -531,7 +551,7 @@ module Gori::Tui
           s.input.move(-1, 0)
         end
       when key.down?
-        s.input.at_bottom? ? (s.pane = :chain) : s.input.move(1, 0)
+        s.input.at_bottom? ? focus_chain : s.input.move(1, 0)
       else
         edit_input_caret(ev, s, c) # ←/→/Home/End/Delete + literal insert
       end
@@ -553,7 +573,7 @@ module Gori::Tui
         else
           s.input_read.move(s.input, -1, 0, selecting: selecting)
         end
-      when key.down?  then s.input.at_bottom? ? (s.pane = :chain) : s.input_read.move(s.input, 1, 0, selecting: selecting)
+      when key.down?  then s.input.at_bottom? ? focus_chain : s.input_read.move(s.input, 1, 0, selecting: selecting)
       when key.left?  then s.input_read.move(s.input, 0, -1, selecting: selecting)
       when key.right? then s.input_read.move(s.input, 0, 1, selecting: selecting)
       when key.home?  then s.input.home
@@ -592,8 +612,13 @@ module Gori::Tui
         s.pane = :input
         @popup.close
       when key.down?
-        s.pane = :output # down from CHAIN drops into the OUTPUT pane (popup owns ↓ while open)
-        @popup.close
+        if @popup.open?
+          @popup_engaged = true # dive into the passively-shown list; ↓ now navigates it
+          @popup.move(1)
+        else
+          s.pane = :output # down from CHAIN drops into the OUTPUT pane
+          @popup.close
+        end
       when key.backspace?
         if s.chain_cx > 0
           s.chain = s.chain[0, s.chain_cx - 1] + s.chain[s.chain_cx..]
@@ -633,7 +658,7 @@ module Gori::Tui
       selecting = ev.shift?
       case
       when key.up?, key.lower_k?
-        s.view.output_at_top? ? (s.pane = :chain) : out_nav_step(s, -1, 0, selecting)
+        s.view.output_at_top? ? focus_chain : out_nav_step(s, -1, 0, selecting)
       when key.down?, key.lower_j? then out_nav_step(s, 1, 0, selecting)
       when key.left?               then out_nav_step(s, 0, -1, selecting)
       when key.right?              then out_nav_step(s, 0, 1, selecting)
@@ -664,6 +689,7 @@ module Gori::Tui
       s = cur
       s.chain, s.chain_cx = @popup.accept(s.chain, s.chain_cx)
       @popup.close
+      @popup_engaged = false
       touch
     end
 
@@ -671,12 +697,13 @@ module Gori::Tui
       s = cur
       ts, te = token_span(s.chain, s.chain_cx)
       tok = s.chain[ts...te].strip
-      if tok.empty?
-        @popup.close
-      else
-        matches = @registry.match(tok).map(&.name).uniq
-        @popup.set(matches.first(40), ts, te)
-      end
+      # match("") returns EVERY converter, so an empty token surfaces the full list as a
+      # passive discovery menu (engaged? = false → Tab keeps navigating the focus ring,
+      # ↓ dives in). A typed token filters AND engages it (Tab/↵ accept). set() opens the
+      # popup iff the match list is non-empty.
+      matches = @registry.match(tok).map(&.name).uniq
+      @popup.set(matches.first(64), ts, te)
+      @popup_engaged = !tok.empty?
     end
 
     # The token under the caret = the run of non-separator chars around it.


### PR DESCRIPTION
## What

Two Decoder improvements, both about **coverage + discoverability** for security/HTTP work.

### 1) 11 new CHAIN converters (32 → 43)

Closes common Burp Decoder / CyberChef gaps:

| Converter | Aliases | Why |
|---|---|---|
| `raw-deflate` / `raw-inflate` | `deflate-raw` / `inflate-raw` | RFC 1951, no wrapper — HTTP `Content-Encoding: deflate` & websocket permessage-deflate are frequently raw; only gzip/zlib existed |
| `url-encode-all` | `url-encode-full`, `percent-encode-all` | `%XX` for **every** byte (WAF-bypass / fuzzing) |
| `decimal-encode` / `-decode` | `decimal`, `dec`, `to-decimal`… | byte-oriented, space/comma separated |
| `binary-encode` / `-decode` | `binary`, `bin`… | 8-bit groups |
| `octal-encode` / `-decode` | `octal`, `oct`… | |
| `rot47` | — | pairs with `rot13`, self-inverse |
| `crc32` | — | CRC-32 checksum (hex) |

All decode paths raise a clean `DecoderError` on bad input. They auto-appear in TUI autocomplete, MCP `decode` enumeration, and fuzz inline chains; the MCP tool's "common converters" hint was refreshed too.

Deliberately excluded: key-taking codecs (XOR / Caesar-N) — the chain spec is parameterless, so they can't fit the engine.

### 2) Show the full converter list when the CHAIN field is empty (Decoder tab)

Focusing the empty CHAIN field now surfaces **all** converters as suggestions (previously it showed nothing). To avoid hijacking Tab-navigation, the auto-shown list is a **passive** discovery menu — Tab still navigates panes, `↓` dives into the list, and typing (or `↓`) **engages** it so Tab/Enter accept as before. The `^Y` Repeater/Fuzzer overlay is unchanged.

## Verification
- `crystal build src/main.cr` — compiles; binary runs.
- `spec/decoder_spec.cr` — 46 pass (9 new: known-answer vectors for crc32, rot47, number bases, url-encode-all).
- Decoder + all TUI + MCP specs — **919 pass, 0 failures**; fuzz specs — 66 pass.
- End-to-end via the real chain engine: all new codecs and multi-step chains (`raw-deflate > raw-inflate`, `rot47 > rot47`, `url-encode-all > url-decode`) round-trip; unknown tokens fail gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)