### PR TITLE
feat(tui): add "Send selection to…" space command → Decoder

### DIFF
--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -443,8 +443,10 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def project_copy_all : Nil; end
 
+  property selection_active : Bool = false # settable so selection-gated verbs (send-to, clear-selection) can be exercised
+
   def read_selection_active? : Bool
-    false
+    selection_active
   end
 
   def read_select_line : Nil; end
@@ -454,6 +456,12 @@ class FakeExecContext < Gori::Verb::ExecContext
   def read_copy : Nil; end
 
   def copy_as_open : Nil; end
+
+  getter send_to_opened : Bool = false
+
+  def send_to_open : Nil
+    @send_to_opened = true
+  end
 
   property detail_navigable : Bool = false # settable so grouped-menu specs can exercise detail.select-line
 

--- a/spec/tui/send_picker_spec.cr
+++ b/spec/tui/send_picker_spec.cr
@@ -1,0 +1,57 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+private def sample_picker : SendPicker
+  SendPicker.new("Send selection to", "SGVsbG8=", [
+    SendMenu::Destination.new("Decoder", 'd', :decoder, "decode / encode input"),
+    SendMenu::Destination.new("Sequencer", 's', :sequencer, "analyze tokens"),
+  ])
+end
+
+describe Gori::Tui::SendPicker do
+  it "maps a mnemonic key to its row (case-insensitive), nil for a miss" do
+    p = sample_picker
+    p.index_for('d').should eq(0)
+    p.index_for('S').should eq(1)
+    p.index_for('z').should be_nil
+  end
+
+  it "returns the selected destination and shares one payload across rows" do
+    p = sample_picker
+    p.set_selected(p.index_for('d').not_nil!)
+    dest = p.selected_destination.not_nil!
+    dest.tab.should eq(:decoder)
+    p.payload.should eq("SGVsbG8=")
+  end
+
+  it "clamps movement at both ends" do
+    p = sample_picker
+    p.move(-5)
+    p.selected.should eq(0)
+    p.move(99)
+    p.selected.should eq(1)
+  end
+
+  it "reports empty for an empty destination list" do
+    SendPicker.new("Send selection to", "x", [] of SendMenu::Destination).empty?.should be_true
+    sample_picker.empty?.should be_false
+  end
+
+  it "renders the sized title, labels, and hints" do
+    backend = MemoryBackend.new(80, 24)
+    sample_picker.render(Screen.new(backend), Rect.new(0, 0, 80, 24))
+    backend.contains?("Send selection to").should be_true
+    backend.contains?("Decoder").should be_true
+    backend.contains?("decode / encode input").should be_true
+  end
+end
+
+describe Gori::Tui::SendMenu do
+  it "offers Decoder as a string-handling destination" do
+    dests = SendMenu.destinations
+    dests.any? { |d| d.tab == :decoder }.should be_true
+    dests.map(&.key).uniq.size.should eq(dests.size) # mnemonics are unique
+  end
+end

--- a/spec/tui/space_menu_spec.cr
+++ b/spec/tui/space_menu_spec.cr
@@ -551,3 +551,45 @@ describe Gori::Tui::SpaceMenu do
     end
   end
 end
+
+# "Send selection to…" is registered per selection-capable scope, gated on an active
+# selection, and shares the mnemonic 'S' — the parallel of the clear-selection verbs.
+describe "send-to verbs" do
+  # {verb id, scope} for every selection-capable source view.
+  send_to = {
+    "notes.send-to"    => Gori::Verb::Scope::Notes,
+    "repeater.send-to" => Gori::Verb::Scope::Repeater,
+    "fuzzer.send-to"   => Gori::Verb::Scope::Fuzzer,
+    "decoder.send-to"  => Gori::Verb::Scope::Decoder,
+    "issue.send-to"    => Gori::Verb::Scope::IssuesDetail,
+    "project.send-to"  => Gori::Verb::Scope::Body,
+    "detail.send-to"   => Gori::Verb::Scope::HistoryDetail,
+  }
+
+  it "registers a send-to verb (mnemonic 'S') in every selection-capable scope" do
+    registry = Gori::Verbs.registry
+    send_to.each do |id, scope|
+      v = registry.find { |d| d.id == id }
+      v.should_not be_nil
+      v.not_nil!.scope.should eq(scope)
+      v.not_nil!.menu_key.should eq('S')
+    end
+  end
+
+  it "shows only when a selection is active" do
+    registry = Gori::Verbs.registry
+    ctx = FakeExecContext.new
+    v = registry.find { |d| d.id == "notes.send-to" }.not_nil!
+    ctx.selection_active = false
+    v.available?(ctx).should be_false
+    ctx.selection_active = true
+    v.available?(ctx).should be_true
+  end
+
+  it "dispatches send_to_open when invoked" do
+    registry = Gori::Verbs.registry
+    ctx = FakeExecContext.new
+    registry.find { |d| d.id == "notes.send-to" }.not_nil!.call(ctx)
+    ctx.send_to_opened.should be_true
+  end
+end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -864,6 +864,10 @@ private class FakeContext < ExecContext
     @calls << :copy_as_open
   end
 
+  def send_to_open : Nil
+    @calls << :send_to_open
+  end
+
   def detail_navigable? : Bool
     false
   end

--- a/src/gori/tui/controllers/decoder_controller.cr
+++ b/src/gori/tui/controllers/decoder_controller.cr
@@ -166,6 +166,21 @@ module Gori::Tui
       @host.status("new conversion (#{@sessions.size} open)")
     end
 
+    # Seed a NEW conversion from an externally-supplied string (the "Send selection
+    # to → Decoder" flow) and jump into it. Mirrors decoder_new but pre-fills the
+    # input and, since the caller is on ANOTHER tab, switches tabs with goto_tab
+    # (like RepeaterController#repeater_from_request) rather than request_focus.
+    # make_session already runs the chain, so the output lands populated.
+    def decoder_from_text(text : String, name : String? = nil) : Nil
+      @sessions << make_session(text, "", name)
+      @idx = @sessions.size - 1
+      @popup.close
+      @chain_pre = ""
+      @dirty = true
+      @host.goto_tab(:decoder)
+      @host.status("sent selection to Decoder (#{text.bytesize}b)")
+    end
+
     # Content-only clone of the active conversion (input + chain + chip name).
     def decoder_duplicate : Nil
       s = cur
@@ -478,6 +493,17 @@ module Gori::Tui
         msg = "copied all (#{written}b)"
         msg += " — clipped from #{text.bytesize}b (64KB cap)" if written < text.bytesize
         @host.status(msg)
+      end
+    end
+
+    # The focused pane's selection (or current line) text without copying — for the
+    # "Send selection to" flow. Mirrors decoder_copy_selection's pane routing.
+    def decoder_selection_text : String
+      s = cur
+      case s.pane
+      when :output then s.view.output_copy_text(s.result)
+      when :input  then s.input_read.copy_text(s.input)
+      else              ""
       end
     end
 

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -585,6 +585,12 @@ module Gori::Tui
       @host.status("copied #{written}b to clipboard")
     end
 
+    # The focused pane's selection (or current line) text without copying — for the
+    # "Send selection to" flow.
+    def fuzzer_selection_text : String
+      (v = current_view) ? v.pane_copy_text : ""
+    end
+
     def fuzzer_copy_all : Nil
       v = current_view
       return unless v

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -349,6 +349,11 @@ module Gori::Tui
       @host.status("copied #{written}b to clipboard")
     end
 
+    # The detail pane's selection (or current line) text without copying — "Send selection to".
+    def detail_selection_text : String
+      @history.detail_copy_text
+    end
+
     # The focus-aware "copy as X" menu for the open detail pane ({title, options}).
     def detail_copy_as_menu : {String, Array(CopyMenu::Option)}
       @history.detail_copy_as_menu

--- a/src/gori/tui/controllers/issues_controller.cr
+++ b/src/gori/tui/controllers/issues_controller.cr
@@ -318,6 +318,11 @@ module Gori::Tui
       @host.status("copied #{written}b to clipboard")
     end
 
+    # The notes selection (or current line) text without copying — "Send selection to".
+    def issues_notes_selection_text : String
+      @issues.notes_copy_text
+    end
+
     def issues_copy_all : Nil
       text = @issues.notes_copy_all
       if text.empty?

--- a/src/gori/tui/controllers/notes_controller.cr
+++ b/src/gori/tui/controllers/notes_controller.cr
@@ -335,6 +335,12 @@ module Gori::Tui
       @host.status("copied #{written}b to clipboard")
     end
 
+    # The selection (or current line) text without the clipboard write — for the
+    # "Send selection to" flow. Gated upstream by read_selection_active?.
+    def notes_selection_text : String
+      @notes.copy_text
+    end
+
     # Copy the entire current note (space menu).
     def notes_copy_all : Nil
       text = @notes.current_text

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -341,6 +341,11 @@ module Gori::Tui
       @host.status("copied #{written}b to clipboard")
     end
 
+    # The description selection (or current line) text without copying — "Send selection to".
+    def project_desc_selection_text : String
+      @project_view.desc_copy_text
+    end
+
     def project_copy_all : Nil
       text = @project_view.desc_copy_all
       if text.empty?

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -573,6 +573,12 @@ module Gori::Tui
       @host.status("copied #{written}b to clipboard")
     end
 
+    # The focused pane's selection (or current line) text without copying — for the
+    # "Send selection to" flow.
+    def repeater_selection_text : String
+      (v = current_view) ? v.pane_copy_text : ""
+    end
+
     def repeater_copy_all : Nil
       v = current_view
       return unless v

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -35,6 +35,7 @@ require "./browser_picker"
 require "./choice_picker"
 require "./more_menu"
 require "./copy_picker"
+require "./send_picker"
 require "./flow_picker"
 require "./subtab_picker"
 require "./links_overlay"
@@ -157,6 +158,9 @@ module Gori::Tui
       # Repeater body (@overlay :none) OR the History detail drill-in (@overlay :detail) —
       # without disturbing that state. Non-nil ⇔ shown (see copy_as_shown?).
       @copy_picker = nil.as(CopyPicker?)
+      # The "send selection to X" destination picker (space → S); same orthogonal-to-
+      # @overlay lifetime as @copy_picker. Non-nil ⇔ shown (see send_to_shown?).
+      @send_picker = nil.as(SendPicker?)
       # The Comparer flow picker (a/b → choose flow A/B); @overlay is :comparer_pick.
       @flow_picker = nil.as(FlowPicker?)
       # The Repeater sub-tab search picker (space → s); @overlay is :repeater_subtab.
@@ -889,6 +893,7 @@ module Gori::Tui
       return handle_hotkeys_key(ev) if @overlay == :hotkeys && @hotkeys_overlay.capturing?
       return handle_space_menu_key(ev) if @space_menu_open # the space menu is modal while up
       return handle_copy_as_key(ev) if copy_as_shown?      # the copy-as picker is modal while up
+      return handle_send_to_key(ev) if send_to_shown?      # the send-to picker is modal while up
       return handle_goto_key(ev) if @goto_open             # the ^G line prompt is modal while up
       return handle_search_key(ev) if @search_open         # the ^F find prompt is modal while up
       return handle_rename_key(ev) if @rename_open         # the sub-tab rename prompt is modal while up
@@ -1159,6 +1164,7 @@ module Gori::Tui
     private def dispatch_click(layout : Layout, mx : Int32, my : Int32) : Nil
       return if @space_menu_open && click_space_menu(layout, mx, my)
       return if copy_as_shown? && click_copy_as(layout.body, mx, my) # modal while up — floats over @overlay
+      return if send_to_shown? && click_send_to(layout.body, mx, my) # ditto
       if @goto_open || @search_open || @rename_open || @tag_edit_open || @import_open
         close_goto if @goto_open # a click anywhere dismisses the bottom prompt (like esc)
         close_search if @search_open
@@ -1518,6 +1524,7 @@ module Gori::Tui
       step = dir * 3
       return @space_menu.move(step) if @space_menu_open
       return @copy_picker.try(&.move(step)) if copy_as_shown?
+      return @send_picker.try(&.move(step)) if send_to_shown?
       return wheel_overlay(step) if modal_overlay?
       return unless layout.body.contains?(mx, my)
       # Pass the pointer + body rect so a multi-pane tab (Project) scrolls the pane
@@ -2004,6 +2011,87 @@ module Gori::Tui
     # exactly where they invoked it.
     private def close_copy_picker : Nil
       @copy_picker = nil
+    end
+
+    # Non-nil ⇔ the send-to picker is up (orthogonal to @overlay, mirrors copy_as_shown?).
+    private def send_to_shown? : Bool
+      !@send_picker.nil?
+    end
+
+    # "Send selection to X" (space → S): capture the focused pane's current selection
+    # and open a centered picker of string-handling destinations (Decoder for now).
+    # Gated upstream by read_selection_active?, so a selection is normally present; if
+    # it came back empty the verb just no-ops with a toast rather than opening an empty
+    # send.
+    def send_to_open : Nil
+      payload = read_selection_text
+      if payload.empty?
+        @toast = "nothing selected to send"
+        return
+      end
+      @send_picker = SendPicker.new("Send selection to", payload, SendMenu.destinations)
+    end
+
+    # Send-to picker input: ↑/↓ move, ↵ or a row mnemonic sends, esc cancels (mirrors
+    # the copy-as picker so the two feel identical).
+    private def handle_send_to_key(ev : Termisu::Event::Key) : Nil
+      key = ev.key
+      p = @send_picker
+      return close_send_picker unless p
+      case
+      when key.escape? then close_send_picker
+      when key.up?     then p.move(-1)
+      when key.down?   then p.move(1)
+      when key.enter?  then apply_send_to
+      else
+        if (c = ev.char) && !ev.ctrl? && !ev.alt?
+          if idx = p.index_for(c)
+            p.set_selected(idx)
+            apply_send_to
+          elsif c == 'j'
+            p.move(1)
+          elsif c == 'k'
+            p.move(-1)
+          end
+        end
+      end
+    end
+
+    # Always consumes the click (returns true) so it never leaks to the pane below —
+    # a click on a row sends, a click outside dismisses.
+    private def click_send_to(area : Rect, mx : Int32, my : Int32) : Bool
+      p = @send_picker
+      box = p.try(&.overlay_box(area))
+      if p.nil? || box.nil? || dismiss_zone?(box, mx, my)
+        close_send_picker
+        return true
+      end
+      if idx = p.row_at(box, mx, my)
+        p.set_selected(idx)
+        apply_send_to
+      end
+      true
+    end
+
+    # Route the captured selection to the chosen destination, then close. Each
+    # destination controller owns the seeding (a new pre-filled session + goto_tab), so
+    # adding a target is a `when` branch here plus a SendMenu.destinations entry.
+    private def apply_send_to : Nil
+      p = @send_picker
+      return close_send_picker unless p
+      if dest = p.selected_destination
+        payload = p.payload
+        case dest.tab
+        when :decoder then decoder_controller.decoder_from_text(payload)
+        end
+      end
+      close_send_picker
+    end
+
+    # Orthogonal to @overlay — closing just drops the picker; whatever was underneath
+    # is untouched, so the user returns exactly where they invoked it.
+    private def close_send_picker : Nil
+      @send_picker = nil
     end
 
     # Comparer flow picker (a/b → choose flow A/B): type to filter, ↑/↓ select,
@@ -3400,6 +3488,7 @@ module Gori::Tui
     # they float over whatever's underneath (a tab body or the History detail).
     private def render_prompts(screen : Screen, layout : Layout) : Nil
       @copy_picker.try(&.render(screen, layout.body)) if copy_as_shown?
+      @send_picker.try(&.render(screen, layout.body)) if send_to_shown?
       @space_menu.render(screen, layout.body) if @space_menu_open
       render_goto_prompt(screen, layout.status) if @goto_open
       render_search_prompt(screen, layout.status) if @search_open
@@ -3457,6 +3546,7 @@ module Gori::Tui
     private def focus_label : String
       return "SPACE" if @space_menu_open                              # orthogonal to @overlay — floats over it
       return @copy_picker.try(&.title) || "COPY AS" if copy_as_shown? # ditto
+      return "SEND TO" if send_to_shown?                              # ditto
       case @overlay
       when :palette       then "PALETTE"
       when :rules         then "RULES"
@@ -3506,6 +3596,7 @@ module Gori::Tui
     private def key_hints : String
       return "press a key · ↑/↓ select · ↵ run · esc close" if @space_menu_open
       return "↑/↓ select · ↵ copy · key picks · esc cancel" if copy_as_shown?
+      return "↑/↓ select · ↵ send · key picks · esc cancel" if send_to_shown?
       case @overlay
       when :palette       then "↑/↓ select · ↵ run · ⌫ · esc close · type to filter"
       when :rules         then "type rule · ↵ add · ⌫ del · ↑/↓ select · tab on/off · esc done"
@@ -5521,6 +5612,25 @@ module Gori::Tui
         @overlay == :detail && history_controller.detail_selection_active?
       else
         false
+      end
+    end
+
+    # The focused pane's current selection (or current line) as a string, without the
+    # clipboard write — the payload for "Send selection to". Mirrors
+    # read_selection_active?'s per-@active_tab dispatch, reusing each controller's
+    # *_selection_text getter. "" when the active tab has no selection surface.
+    def read_selection_text : String
+      case @active_tab
+      when :notes    then notes_controller.notes_selection_text
+      when :repeater then repeater_controller.repeater_selection_text
+      when :fuzzer   then fuzzer_controller.fuzzer_selection_text
+      when :decoder  then decoder_controller.decoder_selection_text
+      when :issues   then issues_controller.issues_notes_selection_text
+      when :project  then project_controller.project_desc_selection_text
+      when :history
+        @overlay == :detail ? history_controller.detail_selection_text : ""
+      else
+        ""
       end
     end
 

--- a/src/gori/tui/send_menu.cr
+++ b/src/gori/tui/send_menu.cr
@@ -1,0 +1,24 @@
+module Gori::Tui
+  # The catalog of destinations the "Send selection to…" picker (space → S) offers:
+  # string-handling tools that accept a raw selected string as their input. The
+  # SendPicker overlay renders these rows; the Runner routes the chosen one's `tab`
+  # to that controller's seeding method (apply_send_to). No TUI/state deps, so the
+  # list stays a single trivially-extensible source of truth.
+  #
+  # Adding a target later (e.g. a Sequencer or Encryption tab) is one line here plus
+  # a `when :<tab>` branch in Runner#apply_send_to — no other wiring.
+  module SendMenu
+    # One offered destination: the row `label`, its mnemonic `key` (unique within the
+    # list — the picker dispatches on it), the `tab` symbol the Runner routes to, and
+    # a short muted `hint` describing what the target does with the string.
+    record Destination, label : String, key : Char, tab : Symbol, hint : String
+
+    # The current string-handling destinations, in display order. First (and only)
+    # target for now is the Decoder — the selection becomes a new conversion's input.
+    def self.destinations : Array(Destination)
+      [
+        Destination.new("Decoder", 'd', :decoder, "decode / encode input"),
+      ]
+    end
+  end
+end

--- a/src/gori/tui/send_picker.cr
+++ b/src/gori/tui/send_picker.cr
@@ -1,0 +1,114 @@
+require "./screen"
+require "./theme"
+require "./frame"
+require "./fmt"
+require "./send_menu"
+
+module Gori::Tui
+  # A small centered picker for the "send selection to X" action (space → S): pick a
+  # string-handling destination for the current text selection. Structurally a twin
+  # of CopyPicker (pure state + rendering; the Runner owns open/close and performs
+  # the send), but every row shares ONE `@payload` (the selection) and differs only
+  # by destination — so rows show the target's `hint` (not a per-row byte size), and
+  # the card title carries the payload size once. Rows are fronted by a mnemonic key.
+  class SendPicker
+    getter selected : Int32
+    getter title : String
+    getter payload : String
+
+    def initialize(@title : String, @payload : String, @destinations : Array(SendMenu::Destination))
+      @selected = 0
+      @scroll = 0
+    end
+
+    def empty? : Bool
+      @destinations.empty?
+    end
+
+    def move(delta : Int32) : Nil
+      return if @destinations.empty?
+      @selected = (@selected + delta).clamp(0, @destinations.size - 1)
+    end
+
+    def selected_destination : SendMenu::Destination?
+      @destinations[@selected]?
+    end
+
+    def set_selected(idx : Int32) : Nil
+      return if @destinations.empty?
+      @selected = idx.clamp(0, @destinations.size - 1)
+    end
+
+    # The row whose mnemonic matches `c` (case-insensitive), or nil for a miss.
+    def index_for(c : Char) : Int32?
+      lc = c.downcase
+      @destinations.index { |d| d.key.downcase == lc }
+    end
+
+    # Centered card geometry over `area` — inverse of render's offset math. nil when
+    # render would draw nothing (mirrors the w/h guard). Width fits the widest of the
+    # rows (label + hint) and the sized title.
+    def overlay_box(area : Rect) : Rect?
+      w = {area.w - 4, content_w + 10}.min
+      h = {@destinations.size + 2, area.h - 2}.min
+      return nil if w < 18 || area.h < 5
+      x = area.x + (area.w - w) // 2
+      y = area.y + (area.h - h) // 2
+      Rect.new(x, y, w, h)
+    end
+
+    # Row index under (mx,my), mirroring render's list loop; nil outside. Bound to the
+    # ACTUALLY rendered rows so a click on a height-clamped card's bottom border can't
+    # pick a row that was never drawn.
+    def row_at(box : Rect, mx : Int32, my : Int32) : Int32?
+      rows = {box.h - 2, @destinations.size}.min
+      i = my - (box.y + 1)
+      return nil if i < 0 || i >= rows
+      return nil if mx <= box.x || mx >= box.right - 1
+      ci = @scroll + i
+      ci < @destinations.size ? ci : nil
+    end
+
+    private def ensure_visible(rows : Int32) : Nil
+      return if rows <= 0
+      @scroll = @selected if @selected < @scroll
+      @scroll = @selected - rows + 1 if @selected >= @scroll + rows
+      @scroll = @scroll.clamp(0, {@destinations.size - rows, 0}.max)
+    end
+
+    def render(screen : Screen, area : Rect) : Nil
+      box = overlay_box(area)
+      unless box
+        screen.text(area.x + 1, area.y, "picker needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        return
+      end
+      Frame.card(screen, box, card_title, border: Theme.border_focus)
+      rows = {box.h - 2, @destinations.size}.min
+      ensure_visible(rows)
+      (0...rows).each do |i|
+        ci = @scroll + i
+        break if ci >= @destinations.size
+        d = @destinations[ci]
+        ry = box.y + 1 + i
+        active = ci == @selected
+        bg = active ? Theme.accent_bg : Theme.panel
+        screen.fill(Rect.new(box.x + 1, ry, box.w - 2, 1), bg)
+        screen.cell(box.x + 1, ry, active ? '▎' : ' ', Theme.accent, bg)
+        screen.text(box.x + 3, ry, d.key.to_s, Theme.accent, bg, Attribute::Bold)
+        screen.text(box.x + 6, ry, d.label, active ? Theme.text_bright : Theme.text, bg, Attribute::Bold)
+        screen.text(box.right - d.hint.size - 2, ry, d.hint, Theme.muted, bg)
+      end
+    end
+
+    # The title with the shared payload's size appended once (e.g. "Send selection to · 128 B").
+    private def card_title : String
+      "#{@title} · #{Fmt.size(@payload.bytesize.to_i64)}"
+    end
+
+    # Widest row (label + hint) and the sized title, driving the card width.
+    private def content_w : Int32
+      rows = @destinations.max_of { |d| d.label.size + d.hint.size + 4 }
+      {rows, card_title.size}.max
+    end
+  end
+end

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -311,6 +311,10 @@ module Gori
       # (url/headers/body/cookies/curl/raw). Focus-aware — the offered set follows the
       # active pane; degrades to read_copy when the context has no format variants.
       abstract def copy_as_open : Nil
+      # "Send selection to X": open a centered picker of string-handling destinations
+      # (Decoder for now) and route the current selection into the chosen one's input.
+      # Gated by read_selection_active?; the payload comes from read_selection_text.
+      abstract def send_to_open : Nil
       abstract def detail_navigable? : Bool # History detail text pane (not hex)
       # Override a verb's space-menu title (nil → use the registered default).
       abstract def space_menu_title(verb_id : String) : String?

--- a/src/gori/verbs/read_edit.cr
+++ b/src/gori/verbs/read_edit.cr
@@ -26,6 +26,9 @@ module Gori
       r.register Verb::Definition.new(
         "notes.clear-selection", "Clear selection", "Clear the text selection",
         Verb::Scope::Notes, available: in_sel, mnemonic: 'v') { |ctx| ctx.read_clear_selection; nil }
+      r.register Verb::Definition.new(
+        "notes.send-to", "Send selection to…", "Send the selected text to another tool (Decoder, …)",
+        Verb::Scope::Notes, available: in_sel, mnemonic: 'S') { |ctx| ctx.send_to_open; nil }
 
       # Plain 'x' = select-line in every Repeater read-mode pane (request/target/response),
       # now that hex is ^X everywhere (the old x=resp-hex collision is gone). Tagged
@@ -40,6 +43,15 @@ module Gori
       r.register Verb::Definition.new(
         "repeater.clear-selection", "Clear selection", "Clear the text selection",
         Verb::Scope::Repeater, available: in_sel, mnemonic: 'v', section: :response) { |ctx| ctx.read_clear_selection; nil }
+      # send-to stays in COMMON (not :response like clear-selection): it's menu-only
+      # (no keybinding fallback), so it must be listed in EVERY read pane's space menu.
+      # command_section is the focused pane (:request/:response/:target), and the menu
+      # shows only COMMON ∪ that one section — a :response tag would hide send-to while
+      # selecting in the request pane, leaving no way to invoke it. in_sel keeps COMMON
+      # uncluttered when nothing is selected.
+      r.register Verb::Definition.new(
+        "repeater.send-to", "Send selection to…", "Send the selected text to another tool (Decoder, …)",
+        Verb::Scope::Repeater, available: in_sel, mnemonic: 'S') { |ctx| ctx.send_to_open; nil }
 
       # Tagged :input (Decoder's read-mode panes are INPUT-read and OUTPUT; :input is
       # the more relevant "editing" pane — OUTPUT keeps 'x' reachable by keybinding).
@@ -51,6 +63,11 @@ module Gori
       r.register Verb::Definition.new(
         "decoder.clear-selection", "Clear selection", "Clear the text selection",
         Verb::Scope::Decoder, available: in_sel, mnemonic: 'v', section: :input) { |ctx| ctx.read_clear_selection; nil }
+      # COMMON, not :input — menu-only verb must show in both the INPUT and OUTPUT read
+      # panes (command_section is cur.pane); see the repeater.send-to note above.
+      r.register Verb::Definition.new(
+        "decoder.send-to", "Send selection to…", "Send the selected text to another tool (Decoder, …)",
+        Verb::Scope::Decoder, available: in_sel, mnemonic: 'S') { |ctx| ctx.send_to_open; nil }
 
       # Tagged :template (Fuzzer's only section named for this in Round 5's spec —
       # :target/:results/:detail are also read-mode-gated, but :template is the one
@@ -63,6 +80,11 @@ module Gori
       r.register Verb::Definition.new(
         "fuzzer.clear-selection", "Clear selection", "Clear the text selection",
         Verb::Scope::Fuzzer, available: in_sel, mnemonic: 'v', section: :template) { |ctx| ctx.read_clear_selection; nil }
+      # COMMON, not :template — menu-only verb must show in every Fuzzer read pane
+      # (command_section follows the focused pane); see the repeater.send-to note above.
+      r.register Verb::Definition.new(
+        "fuzzer.send-to", "Send selection to…", "Send the selected text to another tool (Decoder, …)",
+        Verb::Scope::Fuzzer, available: in_sel, mnemonic: 'S') { |ctx| ctx.send_to_open; nil }
 
       in_issues_notes = ->(ctx : Verb::ExecContext) { ctx.issues_notes_read_mode? }
       r.register Verb::Definition.new(
@@ -72,6 +94,9 @@ module Gori
       r.register Verb::Definition.new(
         "issue.clear-selection", "Clear selection", "Clear the notes text selection",
         Verb::Scope::IssuesDetail, available: in_sel, mnemonic: 'v') { |ctx| ctx.read_clear_selection; nil }
+      r.register Verb::Definition.new(
+        "issue.send-to", "Send selection to…", "Send the selected text to another tool (Decoder, …)",
+        Verb::Scope::IssuesDetail, available: in_sel, mnemonic: 'S') { |ctx| ctx.send_to_open; nil }
 
       in_project_desc = ->(ctx : Verb::ExecContext) { ctx.project_desc_read_mode? }
       r.register Verb::Definition.new(
@@ -81,6 +106,9 @@ module Gori
       r.register Verb::Definition.new(
         "project.clear-selection", "Clear selection", "Clear the text selection",
         Verb::Scope::Body, available: in_sel, mnemonic: 'v') { |ctx| ctx.read_clear_selection; nil }
+      r.register Verb::Definition.new(
+        "project.send-to", "Send selection to…", "Send the selected text to another tool (Decoder, …)",
+        Verb::Scope::Body, available: in_sel, mnemonic: 'S') { |ctx| ctx.send_to_open; nil }
 
       in_detail_nav = ->(ctx : Verb::ExecContext) { ctx.detail_navigable? }
       r.register Verb::Definition.new(
@@ -90,6 +118,9 @@ module Gori
       r.register Verb::Definition.new(
         "detail.clear-selection", "Clear selection", "Clear the text selection",
         Verb::Scope::HistoryDetail, available: in_sel, mnemonic: 'v') { |ctx| ctx.read_clear_selection; nil }
+      r.register Verb::Definition.new(
+        "detail.send-to", "Send selection to…", "Send the selected text to another tool (Decoder, …)",
+        Verb::Scope::HistoryDetail, available: in_sel, mnemonic: 'S') { |ctx| ctx.send_to_open; nil }
     end
   end
 end


### PR DESCRIPTION
## What

Adds a selection-scoped space command that mirrors the existing **Copy as…** pattern. When a text selection is active, the space menu shows **`S Send selection to…`**, which opens a picker of *string-handling* destinations and routes the selected string into the chosen tool.

First (and currently only) destination is the **Decoder** — the selection becomes a new Decoder conversion's input, with the decode chain run immediately.

## How

- **New** `SendMenu` (`src/gori/tui/send_menu.cr`) — the destination catalog (`Destination` record + `destinations` list). Single extension point for future targets.
- **New** `SendPicker` (`src/gori/tui/send_picker.cr`) — overlay, a twin of `CopyPicker` (shows each destination's hint + the shared payload size in the title).
- `DecoderController#decoder_from_text` — seeds a new conversion and `goto_tab(:decoder)`.
- A thin `*_selection_text` getter on each of the 7 selection-capable controllers (reuses the existing `*_copy_text`, no clipboard write).
- Runner: `read_selection_text` dispatcher, `@send_picker` state + `send_to_open`/`handle_send_to_key`/`click_send_to`/`apply_send_to`/`close_send_picker`, and input/mouse/wheel/render/status routing — paralleling the copy-as machinery.
- `send_to_open` abstract intent on `ExecContext`; a `<scope>.send-to` verb registered across **all 7** selection-capable scopes (Notes, Repeater, Fuzzer, Decoder, Issues, Project, History detail), gated `available: read_selection_active?`, mnemonic `S`.

On the multi-section tabs (Repeater/Decoder/Fuzzer) the verb lives in **COMMON** — it's menu-only with no keybinding fallback, so it must show in every read pane when a selection is active (the space menu only renders `COMMON ∪ the focused pane's section`). `in_sel` keeps COMMON uncluttered when nothing is selected.

Adding a later destination is one `SendMenu::Destination` entry + a `when :<tab>` branch in `Runner#apply_send_to`.

## Testing

- New `spec/tui/send_picker_spec.cr` (picker behavior + `SendMenu`); `space_menu_spec.cr` asserts the `send-to` verbs register across scopes, gate on selection, and dispatch `send_to_open`.
- Full suite green apart from the pre-existing sandbox TCP-bind specs.
- Driven end-to-end against the real binary: **Decoder→Decoder**, cross-tab **Notes→Decoder**, and **Repeater→Decoder** (request/target pane) — verb appears only with a selection, picker shows the Decoder destination, selecting it jumps to Decoder with the input seeded and a confirming status line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)