### PR TITLE
feat(tui): set terminal title to "Gori - <tab>" per active tab

### DIFF
--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -27,6 +27,13 @@ module Gori::Tui
     # this no longer applies.
     DEFAULT_HIDDEN = [:miner]
 
+    # The human sidebar label for a tab symbol (the catalog name), used off the render
+    # path too — e.g. the terminal-window title. Falls back to a capitalized symbol for
+    # an unknown key so a future tab is never blank.
+    def self.tab_label(sym : Symbol) : String
+      TABS.find { |(s, _)| s == sym }.try(&.[1]) || sym.to_s.capitalize
+    end
+
     WORDMARK = "𝓰𝓸𝓻𝓲"
 
     # How far the unfocused active sub-tab's receded gold sits between the canvas (0.0)

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -227,6 +227,7 @@ module Gori::Tui
       @quit_armed = false              # first ^D/^C arms quit; second confirms (avoids accidental exit)
       @resized = false                 # set on a Resize event → next frame full-repaints
       @body_h = 24                     # last body rect height (captured at render); drives PageUp/Down step size
+      @title_tab = nil.as(Symbol?)     # last tab reflected into the terminal-window title (memo; see sync_terminal_title)
 
       # Per-tab controllers (strangler-fig: tabs migrate into this registry one at a
       # time; an unmigrated tab is absent and still runs through the case ladders
@@ -489,6 +490,10 @@ module Gori::Tui
       ensure
         # Wind down the statusline worker fiber so it doesn't outlive this project's Runner.
         @statusline.stop
+        # Drop the per-tab window title back to a neutral "gori" on leave — the shared term
+        # outlives this Runner (project picker + the next session reuse it), so a stale
+        # "Gori - Notes" mustn't linger. The shell's prompt overwrites it again after quit.
+        @term.title = "gori"
       end
       @outcome
     end
@@ -3414,7 +3419,19 @@ module Gori::Tui
       Settings.statusline_enabled?
     end
 
+    # Reflect the active tab in the terminal-window title ("Gori - History"), so a
+    # terminal tab/window running gori is identifiable at a glance (and multiple open
+    # projects can be told apart by which tab each is on). Driven from render — not
+    # threaded through each @active_tab write site — so every switch path is covered;
+    # memoized on the tab so the OSC sequence is emitted only when it actually changes.
+    private def sync_terminal_title : Nil
+      return if @title_tab == @active_tab
+      @title_tab = @active_tab
+      @term.title = "Gori - #{Chrome.tab_label(@active_tab)}"
+    end
+
     private def render : Nil
+      sync_terminal_title
       screen = Screen.new(@backend)
       w, h = screen.width, screen.height
       screen.fill(Rect.new(0, 0, w, h), Theme.bg)


### PR DESCRIPTION
## What

Reflect the active top-level tab in the terminal/window title as **`Gori - <tab>`** while the TUI is running (e.g. `Gori - History`, `Gori - Repeater`), so a terminal tab or window running gori is identifiable at a glance — and multiple open projects can be told apart by which tab each is on.

## How

- `Chrome.tab_label(sym)` — small helper mapping a tab symbol to its catalog label, reused off the render path.
- `Runner#sync_terminal_title` — sets `@term.title` via termisu's `title=` (standard OSC-0 `ESC]0;…BEL`). Called from `render` and memoized on the active tab, so the escape is emitted only when the tab actually changes. Driving it from `render` (instead of hooking each `@active_tab` write site) means **every** switch path is covered: `←/→`, `1-9` jump, click, and notification "jump to result".
- On Runner exit the title drops back to a neutral `gori` — the `Termisu` instance is shared across the project picker and subsequent sessions, so a stale `Gori - Notes` shouldn't linger; the shell's prompt overwrites it again after quit.

No new dependency — termisu already exposes `title=`.

## Verification

- Full project type-check passes; `chrome_tabs_spec` (27 examples) passes.
- Drove the built binary end-to-end via a pty + pyte harness (pyte captures the OSC title):

  | action | captured title |
  |---|---|
  | enter Runner | `Gori - Project` |
  | `→` / `→` | `Gori - Target`, `Gori - History` |
  | `5` jump | `Gori - Repeater` |
  | `8` jump | `Gori - Comparer` |
  | `←` | `Gori - Decoder` |
  | `q` (back to picker) | `gori` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)