### PR TITLE
feat(probe): add IP-header access-control bypass active rule

### DIFF
--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -1380,6 +1380,99 @@ describe "Gori::Probe::Active::CorsReflection" do
   end
 end
 
+describe "Gori::Probe::Active::ForbiddenBypass" do
+  probe = Gori::Probe::Active::ForbiddenBypass.new
+
+  it "only probes originally-denied (401/403) responses with a safe method" do
+    with_store do |store|
+      # A normally-served endpoint has no gate to bypass.
+      ok = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/admin", status: 200, content_type: nil)
+      probe.plan(ok).should be_nil
+      # 404/5xx are not access-control denials.
+      missing = capture_flow(store, "HTTP/1.1 404 Not Found\r\n\r\n", target: "/admin", status: 404, content_type: nil)
+      probe.plan(missing).should be_nil
+      # A denied GET/HEAD → a probe is built.
+      forbidden = capture_flow(store, "HTTP/1.1 403 Forbidden\r\n\r\n", target: "/admin", status: 403, content_type: nil)
+      probe.plan(forbidden).should_not be_nil
+      unauth = capture_flow(store, "HTTP/1.1 401 Unauthorized\r\n\r\n", target: "/admin", status: 401, content_type: nil)
+      probe.plan(unauth).should_not be_nil
+      # A POST is never probed (no auto state mutation) even when denied.
+      post = capture_flow(store, "HTTP/1.1 403 Forbidden\r\n\r\n", target: "/admin", status: 403,
+        method: "POST", content_type: nil)
+      probe.plan(post).should be_nil
+    end
+  end
+
+  it "inserts the full IP-spoof header set once each, dropping any the browser sent" do
+    with_store do |store|
+      forbidden = capture_flow(store, "HTTP/1.1 403 Forbidden\r\n\r\n", target: "/admin", status: 403,
+        req_headers: "X-Forwarded-For: 9.9.9.9\r\n", content_type: nil)
+      plan = probe.plan(forbidden).not_nil!
+      text = String.new(plan.request)
+      Gori::Probe::Active::ForbiddenBypass::BYPASS_HEADERS.each do |name|
+        # Anchor to the CRLF + exact value so a shorter name (Client-IP) isn't counted inside a
+        # longer one (X-Client-IP).
+        text.scan("\r\n#{name}: 127.0.0.1").size.should eq(1), "expected exactly one #{name}"
+      end
+      text.should_not contain("9.9.9.9") # the browser's original X-Forwarded-For was replaced
+    end
+  end
+
+  it "sends an ORIGIN-FORM request line even for an absolute-form (forward-proxy) flow" do
+    with_store do |store|
+      forbidden = capture_flow(store, "HTTP/1.1 403 Forbidden\r\n\r\n", scheme: "http", host: "target.com",
+        target: "http://target.com/admin?x=1", status: 403, content_type: nil)
+      plan = probe.plan(forbidden).not_nil!
+      line = String.new(plan.request).each_line.first
+      line.should start_with("GET /admin?x=1 ")
+      line.should_not contain("http://target.com")
+    end
+  end
+
+  it "flags High only when the denied response flips to 2xx" do
+    with_store do |store|
+      forbidden = capture_flow(store, "HTTP/1.1 403 Forbidden\r\n\r\n", target: "/admin", status: 403, content_type: nil)
+      plan = probe.plan(forbidden).not_nil!
+
+      bypassed = Gori::Repeater::Result.new("HTTP/1.1 200 OK\r\n\r\n".to_slice, Bytes.empty, nil, 1_i64)
+      dets = probe.detections(plan, bypassed, forbidden)
+      dets.size.should eq(1)
+      dets.first.code.should eq("forbidden_bypass")
+      dets.first.severity.should eq(Gori::Store::Severity::High)
+
+      # Still denied → the gate held → not flagged.
+      still_denied = Gori::Repeater::Result.new("HTTP/1.1 403 Forbidden\r\n\r\n".to_slice, Bytes.empty, nil, 1_i64)
+      probe.detections(plan, still_denied, forbidden).should be_empty
+      # A redirect (e.g. to login) is ambiguous → not flagged.
+      redirect = Gori::Repeater::Result.new("HTTP/1.1 302 Found\r\nLocation: /login\r\n\r\n".to_slice, Bytes.empty, nil, 1_i64)
+      probe.detections(plan, redirect, forbidden).should be_empty
+      # A send failure never flags.
+      errored = Gori::Repeater::Result.new(Bytes.empty, nil, nil, 1_i64, "connection refused")
+      probe.detections(plan, errored, forbidden).should be_empty
+    end
+  end
+
+  it "dedup_key equals plan.dedup_key across denied/allowed/method/absolute-form flows" do
+    with_store do |store|
+      cases = [
+        {target: "/admin", method: "GET", status: 403},                 # denied GET
+        {target: "/admin?id=1", method: "GET", status: 403},            # denied GET + query (stripped in key)
+        {target: "/admin", method: "HEAD", status: 401},                # denied HEAD is safe
+        {target: "/admin", method: "GET", status: 200},                 # allowed → nil
+        {target: "/admin", method: "GET", status: 404},                 # not a denial → nil
+        {target: "/admin", method: "POST", status: 403},                # unsafe method → nil
+        {target: "http://t.example/admin", method: "GET", status: 403}, # absolute-form
+        {target: "/has space", method: "GET", status: 403},             # malformed start-line → nil
+      ]
+      cases.each do |c|
+        d = capture_flow(store, "HTTP/1.1 #{c[:status]} X\r\n\r\n", scheme: "http", host: "t.example",
+          target: c[:target], method: c[:method], status: c[:status], content_type: nil)
+        probe.dedup_key(d).should eq(probe.plan(d).try(&.dedup_key)), "forbidden_bypass #{c[:target]} #{c[:method]} #{c[:status]}"
+      end
+    end
+  end
+end
+
 describe "Gori::Probe::Active (safety + coverage)" do
   it "does not probe mutating methods (POST), only safe ones (GET)" do
     with_store do |store|

--- a/src/gori/probe/active.cr
+++ b/src/gori/probe/active.cr
@@ -1,6 +1,7 @@
 require "./active/types"
 require "./active/reflected_param"
 require "./active/cors_reflection"
+require "./active/forbidden_bypass"
 
 module Gori
   module Probe
@@ -11,7 +12,7 @@ module Gori
       # The primary rule, reused for the registry AND the module-level facade.
       PRIMARY = ReflectedParam.new
 
-      RULES = [PRIMARY, CorsReflection.new] of Rule
+      RULES = [PRIMARY, CorsReflection.new, ForbiddenBypass.new] of Rule
 
       # Convenience facade over the primary (reflected-param) rule. The analyzer drives the
       # whole RULES list; these keep a stable single-rule entry point for callers/tests.

--- a/src/gori/probe/active/forbidden_bypass.cr
+++ b/src/gori/probe/active/forbidden_bypass.cr
@@ -1,0 +1,161 @@
+require "./types"
+require "../../miner/inject"
+require "../../proxy/codec/http1"
+
+module Gori
+  module Probe
+    module Active
+      # Active IP-header access-control bypass probe. Many gateways/apps gate a resource on the
+      # *claimed* client IP (an allowlist, an "internal only" path, an admin panel), trusting a
+      # proxy header like X-Forwarded-For instead of the real socket peer. Passive analysis can't
+      # tell such a control apart from any other 403/401; only re-sending the SAME request with a
+      # spoofed loopback IP in those headers proves the gate is header-controllable.
+      #
+      # For one in-scope flow whose captured response was 401/403, it re-sends ONE request with the
+      # full IP-spoofing header set (all 127.0.0.1) and flags a High issue only when the response
+      # flips to 2xx — the definitive "access denied → granted by forging my IP" bypass. Gated to
+      # safe methods (GET/HEAD) so an automatic probe never mutates server state, and to originally-
+      # denied responses so a normally-200 endpoint is never probed. A control that correctly keys
+      # on the socket peer ignores the headers and still returns 401/403, so it is never flagged.
+      #
+      # Header set + loopback value follow https://www.hahwul.com/blog/2021/bypass-403/.
+      class ForbiddenBypass < Rule
+        def info : RuleInfo
+          RuleInfo.new("forbidden_bypass", "Access-control bypass (IP headers)",
+            "Re-sends a denied (401/403) request with spoofed client-IP headers and flags a 2xx bypass.",
+            Category::ACTIVE)
+        end
+
+        # The value every spoofing header carries: loopback is the strongest "I am the server /
+        # an internal client" claim an IP allowlist can be tricked by.
+        BYPASS_VALUE = "127.0.0.1"
+
+        # IP-spoofing request headers a client-IP gate may trust in place of the socket peer. Order
+        # is stable so the built probe is deterministic across runs (dedup + reproducibility).
+        BYPASS_HEADERS = %w[
+          X-Forwarded-For
+          X-Forwarded
+          X-Forward-For
+          X-Forwarded-By
+          X-Real-IP
+          X-Originating-IP
+          X-Remote-IP
+          X-Remote-Addr
+          X-Client-IP
+          X-Cluster-Client-IP
+          Client-IP
+          True-Client-IP
+          X-True-IP
+          X-ProxyUser-Ip
+          X-Custom-IP-Authorization
+        ]
+
+        # Downcased names, for dropping any the browser already sent (so we insert exactly one of
+        # each and the forged value can't be diluted by a second header line).
+        BYPASS_HEADER_SET = BYPASS_HEADERS.map(&.downcase).to_set
+
+        # The dedup key WITHOUT rebuilding the probe — same gates as `plan` (safe method, response
+        # was 401/403), same key. nil exactly when `plan` returns nil. Both gates read
+        # detail.row.status (not a header re-parse), so the two paths cannot drift.
+        def dedup_key(detail : Store::FlowDetail) : String?
+          method, target, malformed = Proxy::Codec::Http1.parse_request_line(detail.request_head)
+          return nil if malformed
+          return nil unless SAFE_METHODS.includes?(method.upcase)
+          return nil unless denied_status?(detail.row.status)
+          key_string(detail, method.upcase, target)
+        end
+
+        def plan(detail : Store::FlowDetail) : Plan?
+          req = Proxy::Codec::Http1.parse_request_head(detail.request_head)
+          return nil if req.malformed?
+          return nil unless SAFE_METHODS.includes?(req.method.upcase)
+          return nil unless denied_status?(detail.row.status)
+          request = rebuild_with_bypass_headers(detail.request_head, detail.request_body)
+          Plan.new(request, [] of Param, key_string(detail, req.method.upcase, req.target))
+        end
+
+        def detections(plan : Plan, result : Repeater::Result, detail : Store::FlowDetail) : Array(Detection)
+          return [] of Detection unless result.ok?
+          status = probe_status(result)
+          # Only a flip INTO 2xx is a confirmed bypass. A 3xx (login redirect) or another 4xx is
+          # ambiguous and would inflate false positives, so it is intentionally not flagged.
+          return [] of Detection unless (200..299).includes?(status)
+          orig = detail.row.status
+          [Detection.new("forbidden_bypass", Category::ACTIVE, detail.row.host, detail.row.url,
+            "Access control bypassed via spoofed client-IP header", Store::Severity::High,
+            "#{orig} → #{status} when X-Forwarded-For/X-Real-IP set to #{BYPASS_VALUE}", detail.row.id)]
+        rescue
+          [] of Detection
+        end
+
+        # Only responses that DENIED access are worth probing: a normally-served (2xx) endpoint has
+        # no gate to bypass, and 404/5xx aren't access-control denials. 401 (auth challenge) is
+        # included alongside 403 because IP allowlists front some auth gateways with a 401.
+        private def denied_status?(status : Int32?) : Bool
+          status == 401 || status == 403
+        end
+
+        # The single key expression both `plan` and `dedup_key` use, so they can't drift. Query is
+        # stripped (a client-IP gate is per-endpoint, not per-query-value) → one probe per
+        # (host, method, path); host:PORT so the same host on another service is a distinct surface.
+        private def key_string(detail : Store::FlowDetail, method_upcase : String, target : String) : String
+          "forbidden_bypass|#{detail.row.host}:#{detail.row.port}|#{method_upcase}|#{path_key(target)}"
+        end
+
+        private def path_key(target : String) : String
+          t = Active.origin_form(target)
+          qi = t.index('?')
+          qi ? t[0...qi] : t
+        end
+
+        private def probe_status(result : Repeater::Result) : Int32
+          if r = result.response
+            return r.status
+          end
+          Proxy::Codec::Http1.parse_response_head(result.head).status
+        rescue
+          0
+        end
+
+        # Rebuild the request with the full IP-spoofing header set inserted right after the request
+        # line: first drop any of those headers the browser already sent (so exactly one authoritative
+        # copy of each remains), then insert ours. The body is untouched — none of the inserted names
+        # is Content-Length — so no resync is needed.
+        private def rebuild_with_bypass_headers(head : Bytes, body : Bytes?) : Bytes
+          combined = if body && !body.empty?
+                       io = IO::Memory.new(head.size + body.size)
+                       io.write(head)
+                       io.write(body)
+                       io.to_slice
+                     else
+                       head
+                     end
+          hbytes, bbytes, eol = Miner::Inject.split(combined)
+          lines = String.new(hbytes).split(eol)
+          kept = [] of String
+          lines.each_with_index do |l, i|
+            next if i > 0 && bypass_header?(l) # request line (i == 0) is normalized below
+            kept << l
+          end
+          # Normalize an absolute-form (forward-proxy) request line to origin-form: like the other
+          # active probes this is sent DIRECT to the origin (no proxy rewrite), and some origins
+          # reject an absolute-form target on a non-proxied request — which would make the bypass
+          # probe silently miss a real header-controllable gate. Origin-form passes through.
+          unless kept.empty?
+            rl = kept[0].split(' ')
+            kept[0] = "#{rl[0]} #{Active.origin_form(rl[1])} #{rl[2]}" if rl.size == 3
+            BYPASS_HEADERS.each_with_index { |name, i| kept.insert(1 + i, "#{name}: #{BYPASS_VALUE}") }
+          end
+          io = IO::Memory.new
+          io << kept.join(eol) << eol << eol
+          io.write(bbytes) unless bbytes.empty?
+          io.to_slice
+        end
+
+        private def bypass_header?(line : String) : Bool
+          (c = line.index(':')) ? BYPASS_HEADER_SET.includes?(line[0...c].strip.downcase) : false
+        end
+      end
+    end
+  end
+end

--- a/src/gori/probe/issue.cr
+++ b/src/gori/probe/issue.cr
@@ -72,6 +72,7 @@ module Gori
       "cors_null_origin"               => "Never allow the null origin; it is sent by sandboxed iframes and redirects and is trivially forgeable.",
       "cors_reflected_origin"          => "Don't blindly reflect the Origin with Allow-Credentials: true; validate it against a strict allowlist.",
       "cors_arbitrary_origin"          => "A probe confirmed the server echoes ANY Origin with Allow-Credentials: true — any site can read authenticated responses. Validate the Origin against a strict allowlist.",
+      "forbidden_bypass"               => "A probe turned a 401/403 into a 2xx by forging client-IP headers (X-Forwarded-For, X-Real-IP, …). Derive the client IP from the trusted socket peer / a fixed number of known proxy hops, not from arbitrary request headers, and strip these headers at the edge.",
       "private_ip_leak"                => "Strip internal hostnames/IPs from responses; they aid network reconnaissance.",
       "error_stack_leak"               => "Return generic errors to clients; log stack traces server-side only.",
       "secret_in_body"                 => "Rotate the exposed credential and remove it from the response; never ship keys/tokens to clients.",


### PR DESCRIPTION
## Summary

Adds a new Probe **active** rule, `forbidden_bypass`, that detects client-IP–based access-control bypasses (the classic 403-bypass-via-`X-Forwarded-For` technique).

When a captured flow's response was **401/403** (and the method is safe — GET/HEAD), the rule re-sends the same request with the full IP-spoofing header set — all `127.0.0.1` — and flags a **High** issue only when the response flips to **2xx**: the definitive "access denied → granted by forging my IP" signal. A control that correctly keys on the socket peer ignores the headers and stays 401/403, so it is never flagged.

Header set + loopback value follow https://www.hahwul.com/blog/2021/bypass-403/:
`X-Forwarded-For`, `X-Forwarded`, `X-Forward-For`, `X-Forwarded-By`, `X-Real-IP`, `X-Originating-IP`, `X-Remote-IP`, `X-Remote-Addr`, `X-Client-IP`, `X-Cluster-Client-IP`, `Client-IP`, `True-Client-IP`, `X-True-IP`, `X-ProxyUser-Ip`, `X-Custom-IP-Authorization`.

## Design notes

- **Gated to safe methods** (GET/HEAD) so the automatic active scan never mutates server state, and **to originally-denied responses** so a normally-served endpoint (with no gate to bypass) is never probed.
- Any of these headers the browser already sent are **dropped and re-inserted once** so the forged value can't be diluted.
- Only a flip **into 2xx** is flagged; a 3xx (login redirect) or another 4xx is ambiguous and intentionally not reported, to keep false positives low.
- Follows the existing one-probe-per-rule `Active::Rule` contract (like `ReflectedParam`/`CorsReflection`). Consequence: all headers ship in one request, so the finding confirms *that* the gate is bypassable but not *which* header did it — the operator bisects in Repeater. Per-header attribution would need a multi-Plan framework extension, left out of scope here.
- The Rules sub-tab lists/toggles it automatically via `Active::RULES` — no TUI change needed.

## Test plan

- New `ForbiddenBypass` specs: gate (401/403 + safe method only), full header-set insertion + dedup of a browser-sent header, origin-form request line for absolute-form flows, 2xx-flip detection (403→200 flags High; still-403 / 302 / send-error do not), and `dedup_key` ⇔ `plan.dedup_key` equivalence across denied/allowed/method/absolute-form cases.
- `crystal spec spec/probe_spec.cr spec/probe_custom_rule_spec.cr spec/tui/probe_view_spec.cr` → 153 examples, 0 failures.
- Full `crystal build src/gori.cr` succeeds; `ameba` clean on the new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)