### PR TITLE
feat(discover): add custom request headers on every surface

### DIFF
--- a/spec/discover/headers_spec.cr
+++ b/spec/discover/headers_spec.cr
@@ -1,0 +1,64 @@
+require "../spec_helper"
+
+private alias H = Gori::Discover::Headers
+
+describe Gori::Discover::Headers do
+  describe ".parse_lines" do
+    it "parses Name: Value lines and strips whitespace" do
+      H.parse_lines(["Authorization: Bearer t", "X-Env:  staging  "]).should eq(
+        [{"Authorization", "Bearer t"}, {"X-Env", "staging"}])
+    end
+
+    it "keeps colons in the value (splits on the first one only)" do
+      H.parse_lines(["X-Time: 10:30:00"]).should eq([{"X-Time", "10:30:00"}])
+    end
+
+    it "drops lines without a colon, an empty name, or an illegal token name" do
+      H.parse_lines(["nope", ": value", "Bad Name: v", "X-Ok: y"]).should eq([{"X-Ok", "y"}])
+    end
+
+    it "drops a value carrying CR/LF (header-injection guard)" do
+      H.parse_lines(["X-Inject: a\r\nEvil: y"]).should be_empty
+    end
+  end
+
+  describe ".merge" do
+    it "emits the Accept/User-Agent defaults with no user headers" do
+      H.merge([] of {String, String}).should eq([{"Accept", "*/*"}, {"User-Agent", "gori-discover"}])
+    end
+
+    it "replaces a default in place (case-insensitive), keeping the default's casing" do
+      H.merge([{"user-agent", "mycrawler"}]).should eq(
+        [{"Accept", "*/*"}, {"User-Agent", "mycrawler"}])
+    end
+
+    it "appends an extra user header after the defaults" do
+      H.merge([{"Authorization", "Bearer t"}]).should eq(
+        [{"Accept", "*/*"}, {"User-Agent", "gori-discover"}, {"Authorization", "Bearer t"}])
+    end
+
+    it "ignores forced Host/Connection headers from the user" do
+      H.merge([{"Host", "evil"}, {"Connection", "keep-alive"}]).should eq(
+        [{"Accept", "*/*"}, {"User-Agent", "gori-discover"}])
+    end
+  end
+
+  describe ".from_flow" do
+    it "keeps auth/cookie/UA headers and drops Host + framing headers" do
+      head = "GET /x HTTP/1.1\r\n" \
+             "Host: h.example\r\n" \
+             "Cookie: sid=1\r\n" \
+             "Authorization: Bearer t\r\n" \
+             "User-Agent: curl/8\r\n" \
+             "Content-Length: 5\r\n" \
+             "Connection: keep-alive\r\n\r\n"
+      H.from_flow(head.to_slice).should eq(
+        [{"Cookie", "sid=1"}, {"Authorization", "Bearer t"}, {"User-Agent", "curl/8"}])
+    end
+
+    it "returns no headers when the flow carries only framing headers" do
+      head = "GET / HTTP/1.1\r\nHost: h\r\nConnection: close\r\n\r\n"
+      H.from_flow(head.to_slice).should be_empty
+    end
+  end
+end

--- a/spec/tui/discover_config_overlay_spec.cr
+++ b/spec/tui/discover_config_overlay_spec.cr
@@ -1,0 +1,40 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+private def dseed : DiscoverSeed
+  DiscoverSeed.new([{"/", "http://h.test/"}], "h.test")
+end
+
+describe Gori::Tui::DiscoverConfigOverlay do
+  it "carries custom headers into the built config" do
+    ov = DiscoverConfigOverlay.new(dseed)
+    ov.set_headers([{"Authorization", "Bearer t"}, {"X-Env", "staging"}])
+    ov.headers.should eq([{"Authorization", "Bearer t"}, {"X-Env", "staging"}])
+    ov.build_config.headers.should eq([{"Authorization", "Bearer t"}, {"X-Env", "staging"}])
+  end
+
+  it "defaults to no custom headers" do
+    DiscoverConfigOverlay.new(dseed).build_config.headers.should be_empty
+  end
+
+  it "exposes a headers row before the start row" do
+    ov = DiscoverConfigOverlay.new(dseed)
+    (DiscoverConfigOverlay::ROW_HEADERS < DiscoverConfigOverlay::ROW_START).should be_true
+    ov.set_selected(DiscoverConfigOverlay::ROW_HEADERS)
+    ov.on_headers_row?.should be_true
+    ov.on_start_row?.should be_false
+  end
+
+  it "renders without crashing and maps a click to the headers row" do
+    ov = DiscoverConfigOverlay.new(dseed)
+    ov.set_headers([{"A", "b"}])
+    screen = Screen.new(MemoryBackend.new(80, 24))
+    area = Rect.new(0, 0, 80, 24)
+    ov.render(screen, area)
+    box = ov.overlay_box(area).not_nil!
+    ov.row_at(box, box.x + 3, box.y + 3 + DiscoverConfigOverlay::ROW_HEADERS)
+      .should eq(DiscoverConfigOverlay::ROW_HEADERS)
+  end
+end

--- a/spec/tui/discover_headers_overlay_spec.cr
+++ b/spec/tui/discover_headers_overlay_spec.cr
@@ -1,0 +1,24 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+describe Gori::Tui::DiscoverHeadersOverlay do
+  it "round-trips seeded headers through the editor buffer" do
+    ov = DiscoverHeadersOverlay.new([{"Authorization", "Bearer t"}, {"X-Env", "staging"}])
+    ov.headers.should eq([{"Authorization", "Bearer t"}, {"X-Env", "staging"}])
+  end
+
+  it "renders seeded headers without crashing" do
+    ov = DiscoverHeadersOverlay.new([{"A", "b"}])
+    screen = Screen.new(MemoryBackend.new(80, 24))
+    ov.render(screen, Rect.new(0, 0, 80, 24))
+  end
+
+  it "renders an empty editor without crashing" do
+    ov = DiscoverHeadersOverlay.new([] of {String, String})
+    ov.headers.should be_empty
+    screen = Screen.new(MemoryBackend.new(80, 24))
+    ov.render(screen, Rect.new(0, 0, 80, 24))
+  end
+end

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -1298,6 +1298,7 @@ module Gori
         force = false
         no_store = false
         format = :text
+        headers = [] of String
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run discover --target URL [options]"
@@ -1309,6 +1310,7 @@ module Gori
           p.on("--no-bruteforce", "Disable directory brute-forcing (crawl only)") { bruteforce = false }
           p.on("--wordlist=PATH", "Extra path wordlist (merged with the built-in list)") { |v| wordlist = v }
           p.on("--extensions=LIST", "Also probe these extensions (e.g. php,json,bak)") { |v| extensions = parse_extensions(v) }
+          p.on("-HHEADER", "--header=HEADER", "Custom request header on every probe, e.g. \"Authorization: Bearer …\" (repeatable)") { |v| headers << v }
           p.on("--containment=MODE", "same-origin | scope-aware (default) | host+subdomains") { |v| containment = parse_containment(v) }
           p.on("--concurrency=N", "Parallel requests (default 20)") { |v| concurrency = parse_count(v, "--concurrency") }
           p.on("--rate=RPS", "Cap requests/sec (0 = unlimited)") { |v| rate = parse_rate(v) }
@@ -1339,14 +1341,15 @@ module Gori
           config = Discover::Config.new(
             concurrency: concurrency, rps: rate, throttle_ms: throttle, timeout: timeout,
             retries: retries, max_requests: max_requests, spider: spider, bruteforce: bruteforce,
-            max_depth: max_depth, extensions: extensions, containment: containment)
+            max_depth: max_depth, extensions: extensions, containment: containment,
+            headers: Discover::Headers.parse_lines(headers))
           words = begin
             Discover::Wordlist.load(wordlist)
           rescue ex
             abort "gori run discover: wordlist error: #{ex.message}"
           end
           policy : Discover::ScopePolicy = scope.configured? ? Discover::StoreScope.new(scope) : Discover::OpenScope.new
-          sender = Discover::Sender.new(verify: !insecure, timeout: timeout)
+          sender = Discover::Sender.new(verify: !insecure, timeout: timeout, headers: config.headers)
           engine = Discover::Engine.new(seed_url, words, sender, config, policy)
           discover_preflight(seed_url, config, words.size, force)
           run_discover_stream(engine, store, format, no_store)

--- a/src/gori/discover.cr
+++ b/src/gori/discover.cr
@@ -1,4 +1,5 @@
 require "./discover/types"
+require "./discover/headers"
 require "./discover/url"
 require "./discover/fingerprint"
 require "./discover/extract"

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -41,7 +41,14 @@ module Gori::Discover
 
   # Production backend over the Repeater engine (fresh connection per send). GET only.
   class Sender < Backend
-    def initialize(@verify : Bool, @timeout : Time::Span? = nil, @http2 : Bool = false)
+    @header_block : String
+
+    def initialize(@verify : Bool, @timeout : Time::Span? = nil, @http2 : Bool = false,
+                   headers : Array({String, String}) = [] of {String, String})
+      # Merge the user headers over the defaults once — the block is identical for
+      # every send (only Host varies, per target). Host + Connection are emitted
+      # separately in build_get and never come from user input.
+      @header_block = Headers.merge(headers).map { |name, value| "#{name}: #{value}\r\n" }.join
     end
 
     def fetch(scheme : String, host : String, port : Int32, target : String) : Repeater::Result
@@ -58,7 +65,7 @@ module Gori::Discover
     private def build_get(scheme : String, host : String, port : Int32, target : String) : Bytes
       default = scheme == "https" ? 443 : 80
       hostline = port == default ? host : "#{host}:#{port}"
-      "GET #{target} HTTP/1.1\r\nHost: #{hostline}\r\nAccept: */*\r\nUser-Agent: gori-discover\r\nConnection: close\r\n\r\n".to_slice
+      "GET #{target} HTTP/1.1\r\nHost: #{hostline}\r\n#{@header_block}Connection: close\r\n\r\n".to_slice
     end
   end
 

--- a/src/gori/discover/headers.cr
+++ b/src/gori/discover/headers.cr
@@ -1,0 +1,86 @@
+require "../proxy/codec/http1"
+
+module Gori::Discover
+  # Custom request-header handling shared by every Discover surface (the TUI config
+  # overlay + editor, the CLI `-H` flag, the MCP `headers` map, and the History
+  # "reuse this flow's headers" prefill).
+  #
+  # Discover sends a fixed GET per URL, so the Sender builds ONE merged header block
+  # at construction. `Host` and `Connection` are always emitted by the Sender itself
+  # — Host must match each crawled origin (a crawl spans several in-scope hosts) and
+  # every send opens a fresh connection (`Connection: close`) — so they are never
+  # taken from user input. `Accept` and `User-Agent` are defaults the user MAY
+  # override; anything else the user supplies is appended.
+  module Headers
+    # Emitted defaults, in wire order; overridable by name (case-insensitive).
+    DEFAULTS = [{"Accept", "*/*"}, {"User-Agent", "gori-discover"}]
+
+    # Never taken from user/flow input — the Sender emits its own.
+    FORCED = Set{"host", "connection"}
+
+    # Framing / hop-by-hop headers dropped when reusing a captured flow's headers:
+    # they describe that flow's body/transport, not a fresh discovery GET.
+    DROP = Set{
+      "host", "connection", "content-length", "content-type",
+      "transfer-encoding", "te", "upgrade", "proxy-connection",
+      "expect", "keep-alive",
+    }
+
+    # Parse raw "Name: Value" lines (CLI `-H`, the TUI editor) into pairs, dropping
+    # anything malformed or unsafe: a value may not contain CR/LF (header injection),
+    # and a name must be a non-empty RFC 7230 token.
+    def self.parse_lines(lines : Array(String)) : Array({String, String})
+      out = [] of {String, String}
+      lines.each do |line|
+        name, sep, value = line.partition(':')
+        next if sep.empty?
+        name = name.strip
+        value = value.strip
+        next if name.empty? || !valid_name?(name)
+        next if value.includes?('\r') || value.includes?('\n')
+        out << {name, value}
+      end
+      out
+    end
+
+    # Headers reused from a captured History flow: parse the stored request head and
+    # keep only headers that make sense on a fresh discovery GET (drop `DROP`).
+    def self.from_flow(request_head : Bytes) : Array({String, String})
+      req = Proxy::Codec::Http1.parse_request_head(request_head)
+      out = [] of {String, String}
+      req.headers.each do |h|
+        next if DROP.includes?(h.name.downcase)
+        next if h.value.includes?('\r') || h.value.includes?('\n')
+        out << {h.name, h.value}
+      end
+      out
+    end
+
+    # The final ordered header list the Sender emits between `Host` and `Connection`:
+    # the defaults, with a same-named user header replacing the default's VALUE in
+    # place (keeping the default's casing, mirroring the CLI repeater merge), plus any
+    # extra user headers appended in order. Forced headers are skipped.
+    def self.merge(user : Array({String, String})) : Array({String, String})
+      result = DEFAULTS.dup
+      user.each do |name, value|
+        next if FORCED.includes?(name.downcase)
+        idx = result.index { |rn, _| rn.compare(name, case_insensitive: true) == 0 }
+        if idx
+          result[idx] = {result[idx][0], value}
+        else
+          result << {name, value}
+        end
+      end
+      result
+    end
+
+    # RFC 7230 token: no whitespace, control chars, or separators.
+    private def self.valid_name?(name : String) : Bool
+      name.each_char do |c|
+        return false if c.ascii_whitespace? || c.control?
+        return false if ":/()<>@,;\\\"[]?={}".includes?(c)
+      end
+      true
+    end
+  end
+end

--- a/src/gori/discover/types.cr
+++ b/src/gori/discover/types.cr
@@ -165,13 +165,19 @@ module Gori
       # boundary
       property containment : Containment
 
+      # custom request headers ({name, value}) added to every GET; overrides the
+      # default Accept/User-Agent, appended otherwise. Host/Connection are forced by
+      # the Sender and ignored here (see Discover::Headers).
+      property headers : Array({String, String})
+
       def initialize(@concurrency = 20, @rps = nil, @throttle_ms = nil, @jitter_ms = 0,
                      @timeout = nil, @retries = 1, @retry_pause = 500.milliseconds, @max_requests = nil,
                      @spider = true, @bruteforce = true,
                      @max_depth = 4, @max_pages = 5000, @follow_redirects = true, @template_saturation = 20,
                      @user_wordlist = nil, @extensions = [] of String, @per_dir_cap = 0, @calibrate_probes = 3,
                      @cluster_saturation = 15, @simhash_distance = 3,
-                     @confidence_floor = 0.5, @containment = Containment::ScopeAware)
+                     @confidence_floor = 0.5, @containment = Containment::ScopeAware,
+                     @headers = [] of {String, String})
       end
     end
   end

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -722,6 +722,7 @@ module Gori
               s.field "max_depth", intprop("spider depth from the seed (default 4, max #{DISCOVER_MAX_DEPTH})")
               s.field "wordlist", strprop("path to an extra path wordlist (merged with the built-in list)")
               s.field "extensions", strprop("comma list of extensions to also probe (e.g. php,json,bak)")
+              s.field "headers", objprop("custom request-header name->value map added to every probe (e.g. Authorization/Cookie); overrides Accept/User-Agent, Host/Connection are ignored")
               s.field "containment", strprop("boundary: same-origin | scope-aware (default) | host+subdomains")
               s.field "concurrency", intprop("parallel requests (default 20, max #{DISCOVER_MAX_CONCURRENCY})")
               s.field "rate", intprop("requests/sec cap (0 = unlimited)")
@@ -3298,6 +3299,10 @@ module Gori
           tok = t.strip.lchop('.')
           tok.empty? ? nil : tok
         end
+        header_lines = [] of String
+        if hm = h["headers"]?.try(&.as_h?)
+          hm.each { |k, v| header_lines << "#{k}: #{Env.expand(v.as_s? || v.to_s)}" }
+        end
         cap = int(h, "max_requests")
         config = Discover::Config.new(
           concurrency: clamp(int(h, "concurrency"), 20, DISCOVER_MAX_CONCURRENCY),
@@ -3307,11 +3312,13 @@ module Gori
           max_requests: cap ? {cap, DISCOVER_MAX_REQUESTS}.min : DISCOVER_MAX_REQUESTS,
           spider: spider, bruteforce: bruteforce,
           max_depth: clamp(int(h, "max_depth"), 4, DISCOVER_MAX_DEPTH),
-          extensions: extensions, containment: containment)
+          extensions: extensions, containment: containment,
+          headers: Discover::Headers.parse_lines(header_lines))
         words = Discover::Wordlist.load(str(h, "wordlist").presence)
         scope = Scope.load(@store)
         policy : Discover::ScopePolicy = scope.configured? ? Discover::StoreScope.new(scope) : Discover::OpenScope.new
-        sender = Discover::Sender.new(verify: @verify_upstream && !(bool(h, "insecure") || false), timeout: discover_timeout(h))
+        sender = Discover::Sender.new(verify: @verify_upstream && !(bool(h, "insecure") || false), timeout: discover_timeout(h),
+          headers: config.headers)
         engine = Discover::Engine.new(seed, words, sender, config, policy)
         {engine, seed, parts.host}
       rescue ex : File::Error

--- a/src/gori/tui/controllers/discover_controller.cr
+++ b/src/gori/tui/controllers/discover_controller.cr
@@ -186,7 +186,8 @@ module Gori::Tui
       words = Discover::Wordlist.load(run.config.user_wordlist)
       scope = @host.session.scope
       policy : Discover::ScopePolicy = scope.configured? ? Discover::StoreScope.new(scope) : Discover::OpenScope.new
-      sender = Discover::Sender.new(verify: !@host.session.config.insecure_upstream?, timeout: run.config.timeout)
+      sender = Discover::Sender.new(verify: !@host.session.config.insecure_upstream?, timeout: run.config.timeout,
+        headers: run.config.headers)
       {Discover::Engine.new(run.target, words, sender, run.config, policy), nil}
     rescue ex
       {nil, "config error: #{ex.message}"}

--- a/src/gori/tui/discover_config_overlay.cr
+++ b/src/gori/tui/discover_config_overlay.cr
@@ -29,10 +29,14 @@ module Gori::Tui
     ROW_CONTAIN = 4
     ROW_CONC    = 5
     ROW_EXT     = 6
-    ROW_START   = 7
-    ROWS        = 8
+    ROW_HEADERS = 7
+    ROW_START   = 8
+    ROWS        = 9
 
     getter seed : DiscoverSeed
+    # Custom request headers ({name, value}) prefilled from a History flow and/or
+    # edited in the headers overlay. NOT persisted to prefs — they can carry secrets.
+    getter headers : Array({String, String}) = [] of {String, String}
 
     def initialize(@seed : DiscoverSeed)
       @target_idx = 0
@@ -44,6 +48,14 @@ module Gori::Tui
       @ext = false
       @selected = 0
       restore_saved_prefs
+    end
+
+    def set_headers(headers : Array({String, String})) : Nil
+      @headers = headers
+    end
+
+    def on_headers_row? : Bool
+      @selected == ROW_HEADERS
     end
 
     # The chosen start URL + its display path.
@@ -112,7 +124,8 @@ module Gori::Tui
         spider: @spider, bruteforce: @bruteforce,
         max_depth: DEPTHS[@depth_idx], concurrency: CONCS[@conc_idx],
         containment: CONTAINMENTS[@contain_idx],
-        extensions: @ext ? COMMON_EXT.dup : [] of String)
+        extensions: @ext ? COMMON_EXT.dup : [] of String,
+        headers: @headers)
     end
 
     def overlay_box(area : Rect) : Rect?
@@ -152,15 +165,28 @@ module Gori::Tui
       when ROW_DEPTH   then cyc(screen, x, py, bg, sel, "max depth:", DEPTHS[@depth_idx].to_s)
       when ROW_CONTAIN then cyc(screen, x, py, bg, sel, "scope:", CONTAINMENTS[@contain_idx].label)
       when ROW_CONC    then cyc(screen, x, py, bg, sel, "concurrency:", CONCS[@conc_idx].to_s)
-      else
-        label = valid? ? "[ Start discovery ]" : "[ enable spider or bruteforce ]"
-        screen.text(x, py, label, valid? ? Theme.accent : Theme.muted, bg, Attribute::Bold)
+      when ROW_HEADERS then headers_row(screen, x, py, bg, sel)
+      else                  start_row(screen, x, py, bg)
       end
+    end
+
+    private def start_row(screen : Screen, x : Int32, py : Int32, bg : Color) : Nil
+      label = valid? ? "[ Start discovery ]" : "[ enable spider or bruteforce ]"
+      screen.text(x, py, label, valid? ? Theme.accent : Theme.muted, bg, Attribute::Bold)
     end
 
     private def check(screen : Screen, x : Int32, py : Int32, bg : Color, sel : Bool, on : Bool, label : String) : Nil
       screen.text(x, py, on ? "[x]" : "[ ]", on ? Theme.green : Theme.muted, bg)
       screen.text(x + 4, py, label, sel ? Theme.text_bright : Theme.text, bg)
+    end
+
+    private def headers_row(screen : Screen, x : Int32, py : Int32, bg : Color, sel : Bool) : Nil
+      label = "custom headers:"
+      screen.text(x, py, label, Theme.muted, bg)
+      val = @headers.empty? ? "none" : "#{@headers.size} set"
+      vx = x + label.size + 1
+      screen.text(vx, py, val, sel ? Theme.text_bright : Theme.text, bg)
+      screen.text(vx + val.size + 2, py, "↵ edit", Theme.muted, bg)
     end
 
     private def cyc(screen : Screen, x : Int32, py : Int32, bg : Color, sel : Bool, label : String, val : String, cyclable : Bool = true) : Nil

--- a/src/gori/tui/discover_headers_overlay.cr
+++ b/src/gori/tui/discover_headers_overlay.cr
@@ -1,0 +1,85 @@
+require "./screen"
+require "./theme"
+require "./frame"
+require "./text_area"
+require "../discover"
+
+module Gori::Tui
+  # The custom-headers editor for a Discover run: a plain multi-line text editor,
+  # one "Name: Value" per line. Opened from the Discover config popup's headers row;
+  # esc saves (parsing the lines, dropping malformed ones) and returns to the popup.
+  # Host/Connection are always emitted by the engine, so entering them here is a
+  # no-op (dropped on parse).
+  class DiscoverHeadersOverlay
+    def initialize(headers : Array({String, String}))
+      text = headers.map { |name, value| "#{name}: #{value}" }.join("\n")
+      @editor = TextArea.new(text)
+    end
+
+    # Current headers parsed from the editor buffer (invalid/forced lines dropped).
+    def headers : Array({String, String})
+      Discover::Headers.parse_lines(@editor.text.split('\n'))
+    end
+
+    # esc = save & close (:commit); every other key edits the buffer (:stay).
+    def handle_key(ev : Termisu::Event::Key) : Symbol
+      key = ev.key
+      case
+      when key.escape? then return :commit
+      when key.up?     then @editor.move(-1, 0)
+      when key.down?   then @editor.move(1, 0)
+      else                  edit(ev)
+      end
+      :stay
+    end
+
+    # ⏎ inserts a new header line; the rest are the usual TextArea editing/caret keys.
+    private def edit(ev : Termisu::Event::Key) : Nil
+      key = ev.key
+      case
+      when key.enter?     then @editor.insert_newline
+      when key.backspace? then @editor.backspace
+      when key.delete?    then @editor.delete
+      when key.left?      then @editor.move(0, -1)
+      when key.right?     then @editor.move(0, 1)
+      when key.home?      then @editor.home
+      when key.end?       then @editor.end_of_line
+      else
+        ch = ev.char || key.to_char
+        @editor.insert(ch) if ch && !ev.ctrl? && !ev.alt?
+      end
+    end
+
+    def set_preedit(text : String) : Nil
+      @editor.set_preedit(text)
+    end
+
+    def overlay_box(area : Rect) : Rect?
+      w = {area.w - 6, 64}.min
+      h = {area.h - 4, 16}.min
+      return nil if w < 34 || h < 8
+      Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
+    end
+
+    def render(screen : Screen, area : Rect) : Nil
+      box = overlay_box(area)
+      unless box
+        screen.text(area.x + 1, area.y, "headers editor needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        return
+      end
+      # bg: Theme.bg (not the card default panel) so the embedded editor, which paints
+      # on Theme.bg, doesn't two-tone against the card interior.
+      Frame.card(screen, box, "CUSTOM HEADERS", bg: Theme.bg, border: Theme.border_focus)
+      top = box.y + 1
+      hintline = box.bottom - 2
+      editor = Rect.new(box.x + 2, top, box.w - 4, {hintline - top, 1}.max)
+      if @editor.line_count == 1 && @editor.text.empty?
+        screen.text(editor.x, editor.y, "one header per line — e.g. Authorization: Bearer …", Theme.muted, Theme.bg, width: editor.w)
+        screen.cursor(editor.x, editor.y)
+      else
+        @editor.render(screen, editor, cursor: true)
+      end
+      screen.text(box.x + 2, hintline, "one per line · Host/Connection ignored · esc saves & closes", Theme.muted, Theme.bg, width: box.w - 4)
+    end
+  end
+end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -57,6 +57,7 @@ require "./path_complete"
 require "./fuzz_set_overlay"
 require "./fuzz_advanced_overlay"
 require "./discover_config_overlay"
+require "./discover_headers_overlay"
 require "./scope_rule_overlay"
 require "./custom_rule_overlay"
 require "./ca_import_overlay"
@@ -208,6 +209,7 @@ module Gori::Tui
       # :mine_config while it's up. Built fresh each time it opens (holds the seed request).
       @mine_config_overlay = nil.as(MineConfigOverlay?)
       @discover_config_overlay = nil.as(DiscoverConfigOverlay?)
+      @discover_headers_overlay = nil.as(DiscoverHeadersOverlay?)
       # The Fuzzer config overlays (CONFIG pane → ↵ on a set / Add / Advanced): a payload-set
       # editor and the advanced-settings form. @overlay is :fuzz_set / :fuzz_advanced while up;
       # built fresh from the current fuzz session each time they open.
@@ -851,6 +853,7 @@ module Gori::Tui
       when :settings      then @settings_view.set_preedit(text)
       when :hosts         then @hosts_overlay.set_preedit(text)
       when :env           then @env_overlay.set_preedit(text)
+      when :discover_headers then @discover_headers_overlay.try(&.set_preedit(text))
       when :fuzz_set      then @fuzz_set_overlay.try(&.set_preedit(text))
       when :fuzz_advanced then @fuzz_advanced_overlay.try(&.set_preedit(text))
       when :scope_rule    then @scope_rule_overlay.try(&.set_preedit(text))
@@ -941,6 +944,7 @@ module Gori::Tui
       return handle_notifications_key(ev) if @overlay == :notifications
       return handle_mine_config_key(ev) if @overlay == :mine_config
       return handle_discover_config_key(ev) if @overlay == :discover_config
+      return handle_discover_headers_key(ev) if @overlay == :discover_headers
       return handle_fuzz_set_key(ev) if @overlay == :fuzz_set
       return handle_fuzz_advanced_key(ev) if @overlay == :fuzz_advanced
       return handle_scope_rule_key(ev) if @overlay == :scope_rule
@@ -1191,7 +1195,7 @@ module Gori::Tui
     # The overlays that fully capture input (a centered card); :detail and :none do not.
     private def modal_overlay? : Bool
       case @overlay
-      when :palette, :rules, :issue_new, :confirm, :browser, :choice, :tabs_more, :comparer_pick, :repeater_subtab, :links, :issue_pick, :note_pick, :settings, :tabs, :hotkeys, :notifications, :mine_config, :discover_config, :fuzz_set, :fuzz_advanced, :scope_rule, :probe_rule, :ca_import then true
+      when :palette, :rules, :issue_new, :confirm, :browser, :choice, :tabs_more, :comparer_pick, :repeater_subtab, :links, :issue_pick, :note_pick, :settings, :tabs, :hotkeys, :notifications, :mine_config, :discover_config, :discover_headers, :fuzz_set, :fuzz_advanced, :scope_rule, :probe_rule, :ca_import then true
       else                                                                                                                                                                                                                                                               false
       end
     end
@@ -1298,6 +1302,7 @@ module Gori::Tui
       when :notifications then click_notifications(area, mx, my)
       when :mine_config   then click_mine_config(area, mx, my)
       when :discover_config then click_discover_config(area, mx, my)
+      when :discover_headers then click_discover_headers(area, mx, my)
       when :fuzz_set      then click_fuzz_set(area, mx, my)
       when :fuzz_advanced then click_fuzz_advanced(area, mx, my)
       when :scope_rule    then click_scope_rule(area, mx, my)
@@ -1373,8 +1378,20 @@ module Gori::Tui
       return close_discover_config if box.nil? || dismiss_zone?(box, mx, my)
       if idx = ov.row_at(box, mx, my)
         ov.set_selected(idx)
-        ov.on_start_row? ? start_discover(ov) : ov.toggle
+        if ov.on_start_row?
+          start_discover(ov)
+        elsif ov.on_headers_row?
+          open_discover_headers(ov)
+        else
+          ov.toggle
+        end
       end
+    end
+
+    private def click_discover_headers(area : Rect, mx : Int32, my : Int32) : Nil
+      ov = @discover_headers_overlay || return
+      box = ov.overlay_box(area)
+      commit_discover_headers if box.nil? || dismiss_zone?(box, mx, my) # click-away saves (esc semantics)
     end
 
     private def click_fuzz_set(area : Rect, mx : Int32, my : Int32) : Nil
@@ -1622,7 +1639,13 @@ module Gori::Tui
       elsif key.right?
         ov.adjust(1)
       elsif key.enter? || key.space?
-        ov.on_start_row? ? start_discover(ov) : ov.toggle
+        if ov.on_start_row?
+          start_discover(ov)
+        elsif ov.on_headers_row?
+          open_discover_headers(ov)
+        else
+          ov.toggle
+        end
       end
     end
 
@@ -3464,6 +3487,7 @@ module Gori::Tui
       @notifications_overlay.render(screen, layout.body) if @overlay == :notifications
       @mine_config_overlay.try(&.render(screen, layout.body)) if @overlay == :mine_config
       @discover_config_overlay.try(&.render(screen, layout.body)) if @overlay == :discover_config
+      @discover_headers_overlay.try(&.render(screen, layout.body)) if @overlay == :discover_headers
       @fuzz_set_overlay.try(&.render(screen, layout.body)) if @overlay == :fuzz_set
       @fuzz_advanced_overlay.try(&.render(screen, layout.body)) if @overlay == :fuzz_advanced
       @scope_rule_overlay.try(&.render(screen, layout.body)) if @overlay == :scope_rule
@@ -3574,6 +3598,7 @@ module Gori::Tui
       when :notifications then "NOTIFICATIONS"
       when :mine_config   then "MINE PARAMS"
       when :discover_config then "DISCOVER"
+      when :discover_headers then "CUSTOM HEADERS"
       when :fuzz_set      then "PAYLOAD SET"
       when :fuzz_advanced then "ADVANCED"
       when :scope_rule    then "SCOPE RULE"
@@ -3623,7 +3648,8 @@ module Gori::Tui
       when :hotkeys       then @hotkeys_overlay.capturing? ? "press a key to bind · esc cancel" : "↑/↓ select · e/␣ rebind · x unbind · r reset · ⇧R reset all · ←/→ profile · ↵ save · esc"
       when :notifications then "↑/↓ select · ↵ open · c clear · esc close"
       when :mine_config   then "↑/↓ field · ←/→ adjust · ␣ toggle · ↵ start · esc cancel"
-      when :discover_config then "↑/↓ field · ←/→ adjust · ␣ toggle · ↵ start · esc cancel"
+      when :discover_config then "↑/↓ field · ←/→ adjust · ␣ toggle · ↵ start/edit · esc cancel"
+      when :discover_headers then "one header per line · Host/Connection ignored · esc saves & closes"
       when :fuzz_set      then "↑/↓/⇥ field · ←/→ type/caret · ↵ new value/next · esc applies & closes"
       when :fuzz_advanced then "↑/↓/⇥ field · ←/→ edit · ␣ toggle · ↵ next · esc applies & closes"
       when :scope_rule    then "↑/↓ field · ←/→ kind·type · type pattern · ↵ save · esc cancel"
@@ -4877,15 +4903,33 @@ module Gori::Tui
 
     def history_discover : Nil
       id = history_target_flow_id
-      unless id && (row = @session.store.flow_row(id))
+      # get_flow (not flow_row) so we also have the request head to offer its headers.
+      unless id && (detail = @session.store.get_flow(id))
         @toast = "select a flow to discover"
         return
       end
-      unless p = Discover::Url.parse(row.url)
+      unless p = Discover::Url.parse(detail.row.url)
         @toast = "flow has no discoverable URL"
         return
       end
       open_discover_config(build_discover_seed(Discover::Url.origin(p), p.host, p.path))
+      offer_flow_headers(id, detail.request_head)
+    end
+
+    # After the config popup opens on a History flow, offer to reuse that flow's own
+    # request headers (auth/cookies) — filtered to what makes sense on a discovery GET.
+    # Accept prefills the popup's headers; cancel leaves it empty. Skipped when the flow
+    # carries no reusable headers.
+    private def offer_flow_headers(id : Int64, request_head : Bytes) : Nil
+      hdrs = Discover::Headers.from_flow(request_head)
+      return if hdrs.empty?
+      ov = @discover_config_overlay
+      names = hdrs.first(3).map { |n, _| n }.join(", ")
+      names += ", …" if hdrs.size > 3
+      confirm("Use this flow's headers?",
+        "#{hdrs.size} header(s) from flow ##{id}: #{names}",
+        confirm_label: "use", cancel_label: "start clean",
+        danger: false, return_to: :discover_config) { ov.try(&.set_headers(hdrs)) }
     end
 
     def discover_run : Nil
@@ -5302,6 +5346,26 @@ module Gori::Tui
     private def close_discover_config : Nil
       @overlay = :none
       @discover_config_overlay = nil
+    end
+
+    # --- Discover custom-headers editor (opened from the config popup's headers row) ---
+    private def open_discover_headers(ov : DiscoverConfigOverlay) : Nil
+      @discover_headers_overlay = DiscoverHeadersOverlay.new(ov.headers)
+      @overlay = :discover_headers
+    end
+
+    # esc / click-away: parse the edited lines back onto the config popup and reopen it.
+    private def commit_discover_headers : Nil
+      if (hov = @discover_headers_overlay) && (ov = @discover_config_overlay)
+        ov.set_headers(hov.headers)
+      end
+      @discover_headers_overlay = nil
+      @overlay = :discover_config
+    end
+
+    private def handle_discover_headers_key(ev : Termisu::Event::Key) : Nil
+      ov = @discover_headers_overlay || return
+      commit_discover_headers if ov.handle_key(ev) == :commit
     end
 
     # Host: open the Fuzzer payload-set editor (nil = add, else edit that index) and


### PR DESCRIPTION
## Summary

Discover previously sent a fixed header set (`Host`/`Accept`/`User-Agent`/`Connection`), so it couldn't crawl anything behind auth or a custom-header gate. This adds custom request headers to **all three surfaces** (CLI, MCP, TUI), plus a *"reuse this flow's headers?"* prompt when launching Discover from a captured History flow.

## What changed

- **`discover/headers.cr`** — shared helper (`parse_lines` / `from_flow` / `merge`), one parse convention reused everywhere. `Host` and `Connection: close` stay forced by the Sender (Host must match each crawled origin; fresh connection per send); `Accept`/`User-Agent` are overridable defaults, extras appended. Values carrying CR/LF are rejected (header-injection guard).
- **Engine** — `Discover::Config` carries `headers`; `Sender` builds the merged block once and emits it in `build_get`.
- **CLI** — `-H/--header` (repeatable), same flag shape as `run repeater`.
- **MCP** — a `headers` name→value map on `discover_start`.
- **TUI** — a `custom headers: N set  ↵ edit` row in the config popup opens a dedicated multi-line editor overlay (one `Name: Value` per line), modeled on `FuzzSetOverlay`. Launching from a History flow shows a `Use this flow's headers?` prompt (`[use]` / `[start clean]`); reused headers are filtered (auth/cookie kept, `Host`/framing dropped). Headers are **not** persisted to settings (they can carry secrets).

## Verification

- Full project type-checks clean.
- Specs: header helper (parse/filter/merge) + TUI overlay render/round-trip; existing Discover + verb-registry specs green.
- CLI end-to-end against a local echo server: `User-Agent` override replaced in place (no duplicate), `Authorization`/`X-Env` appended, exactly one correct `Host`, trailing `Connection: close` — on the seed, `robots.txt`, and `sitemap.xml` probes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)