### PR TITLE
feat(probe): manual active scan with request estimate + notify modes

### DIFF
--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -2020,3 +2020,70 @@ describe "Gori::Probe::Passive::SecretInUrl (JWT tightening)" do
     end
   end
 end
+
+describe "Gori::Probe::Active (manual run estimate)" do
+  it "requests_per_flow is 1..1 for every built-in active rule" do
+    Gori::Probe::Active::RULES.each(&.requests_per_flow.should(eq(1..1)))
+  end
+
+  it "estimate_label renders a fixed count and a range" do
+    Gori::Probe::Active.estimate_label(1..1).should eq("1 req/flow")
+    Gori::Probe::Active.estimate_label(1..3).should eq("1–3 req/flow")
+  end
+
+  it "estimates one request per applicable rule (reflected param + CORS = 2)" do
+    with_store do |store|
+      detail = capture_flow(store,
+        "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: https://evil.test\r\nContent-Type: text/html\r\n\r\n",
+        target: "/search?q=hi", body: "<p>hi</p>")
+      a = Gori::Probe::Analyzer.new(store, Gori::Scope.load(store),
+        Channel(Gori::Store::FlowEvent).new(1), Gori::Probe::Mode::Passive, true)
+      est = a.active_estimate(detail)
+      est.map(&.info.id).sort.should eq(["cors_reflection", "reflected_param"])
+      est.sum { |e| e.requests.end }.should eq(2)
+    end
+  end
+
+  it "omits a disabled active rule from the estimate" do
+    with_store do |store|
+      store.set_probe_disabled_rules(Set{"cors_reflection"})
+      detail = capture_flow(store,
+        "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: https://evil.test\r\nContent-Type: text/html\r\n\r\n",
+        target: "/search?q=hi")
+      a = Gori::Probe::Analyzer.new(store, Gori::Scope.load(store),
+        Channel(Gori::Store::FlowEvent).new(1), Gori::Probe::Mode::Passive, true)
+      a.active_estimate(detail).map(&.info.id).should eq(["reflected_param"])
+    end
+  end
+
+  it "estimates zero for an unsafe-method / paramless / non-CORS flow" do
+    with_store do |store|
+      a = Gori::Probe::Analyzer.new(store, Gori::Scope.load(store),
+        Channel(Gori::Store::FlowEvent).new(1), Gori::Probe::Mode::Passive, true)
+      # POST is never probed (no safe method).
+      post = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/x?q=1", method: "POST")
+      a.active_estimate(post).should be_empty
+      # GET with no params + no ACAO has nothing to test.
+      bare = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/nothing")
+      a.active_estimate(bare).should be_empty
+    end
+  end
+
+  it "run_active_now runs regardless of mode / notify choice without raising" do
+    with_store do |store|
+      detail = capture_flow(store,
+        "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: https://evil.test\r\n\r\n",
+        target: "/search?q=hi")
+      scope = Gori::Scope.load(store)
+      {Gori::Probe::Mode::Passive, Gori::Probe::Mode::Off}.each do |mode|
+        a = Gori::Probe::Analyzer.new(store, scope, Channel(Gori::Store::FlowEvent).new(1), mode, true)
+        a.start
+        # Every notify mode; sends to acme.test won't resolve, so the error is swallowed and the
+        # Always completion is suppressed (errored run — verified by not raising).
+        Gori::Miner::NotifyMode.values.each { |n| a.run_active_now(detail, notify: n) }
+        sleep 50.milliseconds
+        a.stop
+      end
+    end
+  end
+end

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -104,6 +104,25 @@ describe Gori::Settings do
     end
   end
 
+  it "persists and reloads the active-scan notification mode" do
+    dir = File.tempname("gori-settings-probe")
+    Dir.mkdir_p(dir)
+    prev = ENV["GORI_HOME"]?
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.save_probe_active_notify("off")
+      File.read(Gori::Settings.path).should contain(%("active_notify"))
+
+      Gori::Settings.probe_active_notify = "when-found"
+      Gori::Settings.load
+      Gori::Settings.probe_active_notify.should eq("off")
+    ensure
+      prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(dir)
+      Gori::Settings.probe_active_notify = "when-found"
+    end
+  end
+
   it "persists and reloads layout prefs; omits the layout section at factory defaults" do
     dir = File.tempname("gori-settings-layout")
     Dir.mkdir_p(dir)

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -341,6 +341,12 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def probe_promote : Nil; end
 
+  def probe_active_selected : Nil; end
+
+  def probe_active_rescan : Nil; end
+
+  def probe_active_from_repeater : Nil; end
+
   def toggle_capture : Nil; end
 
   def intercept_toggle : Nil; end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -660,6 +660,18 @@ private class FakeContext < ExecContext
     @calls << :probe_promote
   end
 
+  def probe_active_selected : Nil
+    @calls << :probe_active_selected
+  end
+
+  def probe_active_rescan : Nil
+    @calls << :probe_active_rescan
+  end
+
+  def probe_active_from_repeater : Nil
+    @calls << :probe_active_from_repeater
+  end
+
   def toggle_capture : Nil
     @calls << :toggle_capture
   end

--- a/src/gori/probe/active.cr
+++ b/src/gori/probe/active.cr
@@ -27,6 +27,12 @@ module Gori
       def self.detections(plan : Plan, result : Repeater::Result, detail : Store::FlowDetail) : Array(Detection)
         PRIMARY.detections(plan, result, detail)
       end
+
+      # Compact per-flow request-count label for the Rules sub-tab + manual-run estimate:
+      # "1 req/flow" for the fixed-cost rules today, "1–3 req/flow" for a future multi-probe rule.
+      def self.estimate_label(rng : Range(Int32, Int32)) : String
+        rng.begin == rng.end ? "#{rng.begin} req/flow" : "#{rng.begin}–#{rng.end} req/flow"
+      end
     end
   end
 end

--- a/src/gori/probe/active/types.cr
+++ b/src/gori/probe/active/types.cr
@@ -58,6 +58,14 @@ module Gori
         # Static identity for the Rules sub-tab (list + per-rule enable/disable). One RuleInfo
         # per class; the analyzer skips a rule when its `info.id` is in the project disabled set.
         abstract def info : RuleInfo
+
+        # How many probe requests this rule sends for ONE qualifying flow — drives the manual
+        # "Run active scan" estimate and the Rules sub-tab annotation. Every rule today sends
+        # exactly one (a rule that tests many params stuffs them all into a single request); a
+        # future multi-probe rule overrides this with its own (possibly wider) range.
+        def requests_per_flow : Range(Int32, Int32)
+          1..1
+        end
       end
     end
   end

--- a/src/gori/probe/analyzer.cr
+++ b/src/gori/probe/analyzer.cr
@@ -37,6 +37,11 @@ module Gori
       @disabled : Set(String) # RuleInfo#id of built-ins the operator turned off (Rules sub-tab)
       @custom : Array(CustomRule) # merged global+project user match rules
 
+      # One enabled active rule that WOULD run against a given flow, plus the request count it
+      # sends. `active_estimate` returns these (empty when nothing applies) so the manual "Run
+      # active scan" confirm can show a per-rule breakdown + total before any request goes out.
+      record ActiveEstimate, info : RuleInfo, requests : Range(Int32, Int32)
+
       private record ActiveTask, rule : Active::Rule, plan : Active::Plan, detail : Store::FlowDetail
 
       def initialize(@store : Store, @scope : Scope, @input : Channel(Store::FlowEvent),
@@ -154,6 +159,52 @@ module Gori
         raise ex
       rescue
         # a single detail's analysis blew up — skip it
+      end
+
+      # Per-flow active-scan estimate for the manual "Run active scan" action: every ENABLED
+      # active rule that applies to `detail` (dedup_key non-nil ⇔ plan non-nil, per the equivalence
+      # spec), with the requests it sends. Cheap — dedup_key never builds canaries and nothing is
+      # sent — so it's safe on the render path. Matches exactly what run_active_now will fire.
+      def active_estimate(detail : Store::FlowDetail) : Array(ActiveEstimate)
+        Active::RULES.compact_map do |rule|
+          next if @disabled.includes?(rule.info.id)
+          next unless rule.dedup_key(detail)
+          ActiveEstimate.new(rule.info, rule.requests_per_flow)
+        end
+      end
+
+      # Manual, on-demand active scan of ONE flow (the History / Probe / Repeater "Run active
+      # scan" action). Unlike the automatic pipeline this BYPASSES the mode gate (runs even in
+      # Off/Passive), the scope gate, and the @active_seen dedup (the operator deliberately asked
+      # to re-run) — but still honours @disabled (Rules sub-tab) and @suppressed (hard-deletes).
+      # Runs in the background so the sends never block the render loop; findings land via the
+      # usual upsert (probe_generation poll) + IssueEvent notification path. `repeater_id` stamps
+      # detections for evidence linking back to a Repeater tab. `notify` (the run popup's choice)
+      # gates the tray: Off is silent, WhenFound posts per finding, Always also posts a completion
+      # note when the scan came back clean.
+      def run_active_now(detail : Store::FlowDetail, *, repeater_id : Int64? = nil,
+                         notify : Miner::NotifyMode = Miner::NotifyMode::WhenFound) : Nil
+        return if @stopped
+        spawn(name: "gori-probe-active-manual") do
+          found = 0
+          errored = false
+          Active::RULES.each do |rule|
+            break if @stopped
+            next if @disabled.includes?(rule.info.id)
+            plan = rule.plan(detail)
+            next unless plan
+            if wrote = execute_active(rule, plan, detail, repeater_id: repeater_id, notify: notify)
+              found += wrote
+            else
+              errored = true # send failure already posted its own error notification
+            end
+          end
+          # Always mode wants a "done, nothing found" note — but only for a scan that actually
+          # completed cleanly (WhenFound/Off stay quiet; a real finding or an error already posted).
+          if notify.always? && found == 0 && !errored && !@stopped
+            emit(CompleteEvent.new(detail.row.host, "active scan on #{detail.row.host}: no issues"))
+          end
+        end
       end
 
       # --- passive fiber ----------------------------------------------------------------
@@ -369,27 +420,43 @@ module Gori
           @active_seen.delete(task.plan.dedup_key)
           return
         end
-        row = task.detail.row
+        execute_active(task.rule, task.plan, task.detail)
+      end
+
+      # Send ONE built probe and fold its response into issues + a notification. Shared by the
+      # automatic queue worker (run_active) and the manual run_active_now — so both paths dedup,
+      # persist, and notify identically. Stamps flow/repeater source like the passive `persist`,
+      # so a Repeater-sourced manual run links its findings back to the Repeater tab (flow id 0 →
+      # nil), while a History flow keeps its real flow id. Returns the number of issues written
+      # (0 = a clean send with no finding), or nil when the probe ERRORED (send failed / store
+      # closing) — so a manual run doesn't post an "all clean" completion over a failed scan.
+      # `notify` gates the per-finding notification: Off emits the list-refresh IssueEvent WITHOUT
+      # a summary (no tray post); WhenFound/Always attach it (the automatic path stays WhenFound).
+      private def execute_active(rule : Active::Rule, plan : Active::Plan, detail : Store::FlowDetail,
+                                 repeater_id : Int64? = nil,
+                                 notify : Miner::NotifyMode = Miner::NotifyMode::WhenFound) : Int32?
+        row = detail.row
         origin = Fuzz::Origin.new(row.scheme, row.host, row.port)
-        http2 = task.detail.http_version.starts_with?("HTTP/2")
+        http2 = detail.http_version.starts_with?("HTTP/2")
         sender = Fuzz::Sender.new(origin, http2, @verify_upstream, timeout: ACTIVE_TIMEOUT)
-        result = sender.send(task.plan.request)
+        result = sender.send(plan.request)
         # Surface send failures (TLS/DNS/timeout) so Active never fails silently — but
         # only ONCE per host: a flapping origin with many distinct param sets would
         # otherwise flood the notification tray (one event per unique plan.dedup_key).
         unless result.ok?
           emit_active_error(row.host, result.error || "send failed")
-          return
+          return nil
         end
-        detections = task.rule.detections(task.plan, result, task.detail)
-        return if detections.empty?
-        wrote = false
+        detections = rule.detections(plan, result, detail)
+        return 0 if detections.empty?
+        wrote = 0
         detections.each do |d|
           next if suppressed?(d.code, d.host)
-          @store.upsert_probe_issue(d)
-          wrote = true
+          stamped = Probe.with_source(d, flow_id: (row.id > 0 ? row.id : nil), repeater_id: repeater_id)
+          @store.upsert_probe_issue(stamped)
+          wrote += 1
         end
-        return unless wrote
+        return 0 if wrote == 0
         # Store#upsert already bumps probe_generation (TUI polls that). Event is for
         # notifications; may be dropped when the channel is full.
         # Notification wording is rule-agnostic: the detection's own title + evidence (so a CORS
@@ -397,11 +464,14 @@ module Gori
         first = detections.first
         msg = "#{first.title} on #{row.host}"
         msg = "#{msg}: #{first.evidence}" if first.evidence
-        emit(IssueEvent.new(row.host, msg))
+        emit(IssueEvent.new(row.host, notify.off? ? nil : msg))
+        wrote
       rescue DB::Error | SQLite3::Exception
         # store closing — stop quietly (the worker will exit when the queue closes)
+        nil
       rescue ex
-        emit_active_error(task.detail.row.host, ex.message || "error")
+        emit_active_error(detail.row.host, ex.message || "error")
+        nil
       end
 
       # First failure per host only (see run_active). Cap the set so a long-lived project

--- a/src/gori/probe/event.cr
+++ b/src/gori/probe/event.cr
@@ -8,7 +8,10 @@ module Gori
     # reflection was confirmed) the controller also raises a notification.
     record IssueEvent, host : String, summary : String? = nil
     record ErrorEvent, message : String
+    # A manual "Run active scan" finished with something worth announcing on its own (not a
+    # per-finding IssueEvent): today only the Always-mode "scan complete — no issues" note.
+    record CompleteEvent, host : String, message : String
 
-    alias Event = IssueEvent | ErrorEvent
+    alias Event = IssueEvent | ErrorEvent | CompleteEvent
   end
 end

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -235,6 +235,10 @@ module Gori
     class_property mine_notify : String = "when-found"
     class_property? mine_prefs_saved : Bool = false
 
+    # Last "Run active scan" notification choice (global scratch — the run popup's cycler
+    # default). Mirrors mine_notify's token set ("when-found"/"off"/"always").
+    class_property probe_active_notify : String = "when-found"
+
     # Last Discover overlay choices (global scratch — not project data).
     class_property discover_containment : String = "scope-aware"
     class_property discover_max_depth : Int32 = 4
@@ -289,6 +293,9 @@ module Gori
         self.decoder_chains = parse_decoder_chains(cv["chains"]?)
       end
       parse_mine_prefs(root["mine"]?)
+      if pr = root["probe"]?.try(&.as_h?)
+        pr["active_notify"]?.try(&.as_s?).try { |s| self.probe_active_notify = s }
+      end
       parse_discover_prefs(root["discover"]?)
       parse_layout(root["layout"]?)
       parse_statusline(root["statusline"]?)
@@ -586,6 +593,12 @@ module Gori
       save
     end
 
+    # Persist the "Run active scan" popup's last notification choice.
+    def self.save_probe_active_notify(notify : String) : Nil
+      self.probe_active_notify = notify
+      save
+    end
+
     private def self.parse_discover_prefs(node : JSON::Any?) : Nil
       obj = node.try(&.as_h?)
       unless obj
@@ -861,6 +874,9 @@ module Gori
                 j.field "notify", mine_notify
               end
             end
+          end
+          j.field "probe" do
+            j.object { j.field "active_notify", probe_active_notify }
           end
           if discover_prefs_saved?
             j.field "discover" do

--- a/src/gori/tui/controllers/probe_controller.cr
+++ b/src/gori/tui/controllers/probe_controller.cr
@@ -265,6 +265,12 @@ module Gori::Tui
           # (the AI firehose logs freely; only the human center suppresses it).
           @host.session.store.insert_event("probe", "error", "error", "Probe: #{ev.message}", goto_tab: "probe")
           @host.status(ev.message)
+        when Probe::CompleteEvent
+          # A manual "Run active scan" in Always mode came back clean — the analyzer only emits
+          # this when the operator asked to be told either way, so it always posts to the tray.
+          @host.session.store.insert_event("probe", "scan_complete", "info", "Probe: #{ev.message}", goto_tab: "probe")
+          @host.notifications.push(:info, "Probe: #{ev.message}", source: "probe")
+          @host.status("Probe: #{ev.message}") if Settings.notify_toast?
         end
       end
       drained

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -798,6 +798,23 @@ module Gori::Tui
       applied
     end
 
+    # Build a synthetic FlowDetail from the active session's last HTTP send (the request as
+    # currently edited + its captured response), for the manual "Run active scan" action. nil
+    # when there's no session, no captured HTTP response yet, or the session is WS/gRPC. Mirrors
+    # the RepeaterRecord shape probe_scan_repeater builds for the passive path.
+    def active_scan_detail : Store::FlowDetail?
+      return unless tab = current_repeater_tab
+      view = tab.view
+      return unless resp = view.last_http_response
+      head, body = resp
+      rec = Store::RepeaterRecord.new(
+        tab.db_id || 0_i64, view.target, view.request_text, view.http2?, view.auto_content_length?,
+        tab.flow_id, 0, head, body, nil, 0_i64, view.name, view.sni_override)
+      Probe.detail_from_repeater(rec)
+    rescue
+      nil
+    end
+
     # Passive-scan a successful HTTP Repeater send into Probe (mode-gated by the analyzer).
     private def probe_scan_repeater(repeater_id : Int64, head : Bytes, body : Bytes?,
                                     duration_us : Int64, flow_id : Int64?, view : RepeaterView) : Nil

--- a/src/gori/tui/probe_active_overlay.cr
+++ b/src/gori/tui/probe_active_overlay.cr
@@ -1,0 +1,146 @@
+require "./screen"
+require "./theme"
+require "./frame"
+require "../probe/analyzer"
+require "../miner/types"
+require "../store"
+require "../settings"
+
+module Gori::Tui
+  # The small popup shown before a manual "Run active scan" fires. A read-only header (the target
+  # request, the per-rule request estimate, and the total), then two interactive rows: a
+  # notification-mode cycler (‹/›, mirroring the Mine popup) and a Run row. The Runner reads
+  # notify_mode + detail/repeater_id on Run and persists the notify choice. Pure state + render.
+  class ProbeActiveOverlay
+    NOTIFY_CHOICES = Miner::NotifyMode.values
+
+    getter detail : Store::FlowDetail
+    getter repeater_id : Int64?
+
+    @selected : Int32
+    @notify_idx : Int32
+    @info : Array(String)
+
+    def initialize(@detail : Store::FlowDetail,
+                   @estimate : Array(Probe::Analyzer::ActiveEstimate),
+                   @repeater_id : Int64? = nil)
+      @notify_idx = NOTIFY_CHOICES.index(Miner::NotifyMode::WhenFound) || 0
+      if mode = Miner::NotifyMode.parse?(Settings.probe_active_notify)
+        @notify_idx = NOTIFY_CHOICES.index(mode) || @notify_idx
+      end
+      @selected = run_row # start on Run so a reflexive ↵ fires with the saved default
+      @info = build_info
+    end
+
+    def notify_mode : Miner::NotifyMode
+      NOTIFY_CHOICES[@notify_idx]
+    end
+
+    # The "N request(s)" summary the Runner reuses in its post-run toast.
+    def total_label : String
+      min = @estimate.sum { |e| e.requests.begin }
+      max = @estimate.sum { |e| e.requests.end }
+      min == max ? "#{min} request#{min == 1 ? "" : "s"}" : "#{min}–#{max} requests"
+    end
+
+    private def notify_row : Int32
+      0
+    end
+
+    private def run_row : Int32
+      1
+    end
+
+    private def row_count : Int32
+      2
+    end
+
+    def on_run_row? : Bool
+      @selected == run_row
+    end
+
+    def move(d : Int32) : Nil
+      @selected = (@selected + d).clamp(0, row_count - 1)
+    end
+
+    def set_selected(idx : Int32) : Nil
+      @selected = idx.clamp(0, row_count - 1)
+    end
+
+    def adjust(d : Int32) : Nil
+      @notify_idx = (@notify_idx + d) % NOTIFY_CHOICES.size if @selected == notify_row
+    end
+
+    # ␣/↵ on the notify row cycles it; the Run row is handled by the Runner.
+    def toggle : Nil
+      adjust(1) if @selected == notify_row
+    end
+
+    private def build_info : Array(String)
+      lines = [] of String
+      url = @detail.row.url
+      url = "#{url[0, 51]}…" if url.size > 52
+      lines << "#{@detail.row.method} #{url}"
+      lines << ""
+      @estimate.each { |e| lines << "  #{e.info.name} — #{req_label(e.requests)}" }
+      lines << ""
+      lines << "#{total_label} → #{@detail.row.host}"
+      lines
+    end
+
+    private def req_label(rng : Range(Int32, Int32)) : String
+      rng.begin == rng.end ? "#{rng.begin} req" : "#{rng.begin}–#{rng.end} req"
+    end
+
+    def overlay_box(area : Rect) : Rect?
+      longest = @info.max_of { |l| Screen.display_width(l) }
+      w = {area.w - 4, {longest + 6, 54}.max.clamp(30, 60)}.min
+      h = {area.h - 2, @info.size + row_count + 4}.min # title + info + gap + rows + border
+      return nil if w < 30 || h < 6
+      Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
+    end
+
+    # First interactive row's y: below the header block + a blank spacer line.
+    private def first_row_y(box : Rect) : Int32
+      box.y + 1 + @info.size + 1
+    end
+
+    def render(screen : Screen, area : Rect) : Nil
+      box = overlay_box(area)
+      unless box
+        screen.text(area.x + 1, area.y, "window too small · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        return
+      end
+      Frame.card(screen, box, "RUN ACTIVE SCAN", border: Theme.border_focus)
+      @info.each_with_index do |line, i|
+        py = box.y + 1 + i
+        break if py >= box.bottom - 2
+        fg = i == 0 ? Theme.text_bright : Theme.text
+        screen.text(box.x + 2, py, line, fg, Theme.panel, width: box.w - 4)
+      end
+      row_count.times { |i| draw_row(screen, box, i) }
+    end
+
+    private def draw_row(screen : Screen, box : Rect, i : Int32) : Nil
+      py = first_row_y(box) + i
+      return if py >= box.bottom
+      sel = i == @selected
+      bg = sel ? Theme.accent_bg : Theme.panel
+      screen.fill(Rect.new(box.x + 1, py, box.w - 2, 1), bg)
+      screen.cell(box.x + 1, py, sel ? '▎' : ' ', Theme.accent, bg)
+      x = box.x + 3
+      if i == notify_row
+        screen.text(x, py, "notification:", Theme.muted, bg)
+        screen.text(x + 14, py, "#{notify_mode.label}  ‹/›", sel ? Theme.text_bright : Theme.text, bg)
+      else
+        screen.text(x, py, "[ Run active scan ]", Theme.accent, bg, Attribute::Bold)
+      end
+    end
+
+    def row_at(box : Rect, mx : Int32, my : Int32) : Int32?
+      return nil unless box.contains?(mx, my)
+      i = my - first_row_y(box)
+      (0 <= i < row_count) ? i : nil
+    end
+  end
+end

--- a/src/gori/tui/probe_rules_view.cr
+++ b/src/gori/tui/probe_rules_view.cr
@@ -43,7 +43,7 @@ module Gori::Tui
       rows << Row.new(:header, "PASSIVE RULES")
       Probe::Passive::RULES.each { |r| rows << builtin_row(r.info, disabled) }
       rows << Row.new(:header, "ACTIVE RULES")
-      Probe::Active::RULES.each { |r| rows << builtin_row(r.info, disabled) }
+      Probe::Active::RULES.each { |r| rows << active_builtin_row(r, disabled) }
       rows << Row.new(:header, "CUSTOM RULES")
       custom = Probe.custom_rules(store)
       if custom.empty?
@@ -57,6 +57,14 @@ module Gori::Tui
 
     private def builtin_row(info : Probe::RuleInfo, disabled : Set(String)) : Row
       Row.new(:builtin, info.name, info.category, !disabled.includes?(info.id), info.id)
+    end
+
+    # An active rule's row carries its per-flow request estimate next to the category, e.g.
+    # "active · 1 req/flow" — the request cost the user asked to see for each active-scan item.
+    private def active_builtin_row(rule : Probe::Active::Rule, disabled : Set(String)) : Row
+      info = rule.info
+      meta = "#{info.category} · #{Probe::Active.estimate_label(rule.requests_per_flow)}"
+      Row.new(:builtin, info.name, meta, !disabled.includes?(info.id), info.id)
     end
 
     private def custom_row(c : Probe::CustomRule) : Row

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -1170,6 +1170,17 @@ module Gori::Tui
       {String.new(res.head), (b = res.body) ? String.new(b) : ""}
     end
 
+    # The last HTTP response's raw {head, body} bytes — for the manual "Run active scan" action,
+    # which rebuilds a synthetic flow from the current request + this response. nil until a send
+    # lands (a response head is required), or in WS/gRPC mode where the active rules don't apply.
+    def last_http_response : {Bytes, Bytes?}?
+      return nil if @ws_mode || @grpc_mode
+      res = @result
+      return nil unless res
+      return nil if res.head.empty?
+      {res.head, res.body}
+    end
+
     def request_bytes : Bytes
       return grpc_request_bytes if @grpc_mode                  # edited head + reframed body (owns its own hex buffer)
       return @req_hex_edit.not_nil!.to_bytes if @req_hex_edit  # byte-exact; NO auto-CL in hex mode

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -58,6 +58,7 @@ require "./fuzz_set_overlay"
 require "./fuzz_advanced_overlay"
 require "./discover_config_overlay"
 require "./discover_headers_overlay"
+require "./probe_active_overlay"
 require "./scope_rule_overlay"
 require "./custom_rule_overlay"
 require "./ca_import_overlay"
@@ -92,7 +93,7 @@ module Gori::Tui
       # Miner is hidden by default). Settings is loaded (cli.cr) before Runner.new.
       vis = Chrome.visible_tabs(Settings.tab_prefs).map(&.first)
       @active_tab = vis.includes?(:project) ? :project : vis.first
-      @overlay = :none # :none | :palette | :detail | :rules | :issue_new | :confirm | :browser | :choice | :tabs_more | :comparer_pick | :repeater_subtab | :links | :issue_pick | :note_pick | :settings | :tabs | :hosts | :env | :hotkeys | :notifications | :mine_config | :fuzz_set | :fuzz_advanced | :scope_rule | :probe_rule | :ca_import
+      @overlay = :none # :none | :palette | :detail | :rules | :issue_new | :confirm | :browser | :choice | :tabs_more | :comparer_pick | :repeater_subtab | :links | :issue_pick | :note_pick | :settings | :tabs | :hosts | :env | :hotkeys | :notifications | :mine_config | :probe_active | :fuzz_set | :fuzz_advanced | :scope_rule | :probe_rule | :ca_import
       # The "space" action menu (helix-style leader popup, bottom-right). Orthogonal
       # to @overlay so it floats over WHATEVER is underneath (the History list, an
       # open detail …) without disturbing that state; the scope is captured at open.
@@ -210,6 +211,8 @@ module Gori::Tui
       @mine_config_overlay = nil.as(MineConfigOverlay?)
       @discover_config_overlay = nil.as(DiscoverConfigOverlay?)
       @discover_headers_overlay = nil.as(DiscoverHeadersOverlay?)
+      # :probe_active while the "Run active scan" popup is up (holds the seed flow + estimate).
+      @probe_active_overlay = nil.as(ProbeActiveOverlay?)
       # The Fuzzer config overlays (CONFIG pane → ↵ on a set / Add / Advanced): a payload-set
       # editor and the advanced-settings form. @overlay is :fuzz_set / :fuzz_advanced while up;
       # built fresh from the current fuzz session each time they open.
@@ -948,6 +951,7 @@ module Gori::Tui
       return handle_hotkeys_key(ev) if @overlay == :hotkeys
       return handle_notifications_key(ev) if @overlay == :notifications
       return handle_mine_config_key(ev) if @overlay == :mine_config
+      return handle_probe_active_key(ev) if @overlay == :probe_active
       return handle_discover_config_key(ev) if @overlay == :discover_config
       return handle_discover_headers_key(ev) if @overlay == :discover_headers
       return handle_fuzz_set_key(ev) if @overlay == :fuzz_set
@@ -1200,7 +1204,7 @@ module Gori::Tui
     # The overlays that fully capture input (a centered card); :detail and :none do not.
     private def modal_overlay? : Bool
       case @overlay
-      when :palette, :rules, :issue_new, :confirm, :browser, :choice, :tabs_more, :comparer_pick, :repeater_subtab, :links, :issue_pick, :note_pick, :settings, :tabs, :hotkeys, :notifications, :mine_config, :discover_config, :discover_headers, :fuzz_set, :fuzz_advanced, :scope_rule, :probe_rule, :ca_import then true
+      when :palette, :rules, :issue_new, :confirm, :browser, :choice, :tabs_more, :comparer_pick, :repeater_subtab, :links, :issue_pick, :note_pick, :settings, :tabs, :hotkeys, :notifications, :mine_config, :probe_active, :discover_config, :discover_headers, :fuzz_set, :fuzz_advanced, :scope_rule, :probe_rule, :ca_import then true
       else                                                                                                                                                                                                                                                               false
       end
     end
@@ -1306,6 +1310,7 @@ module Gori::Tui
       when :hotkeys       then click_hotkeys(area, mx, my)
       when :notifications then click_notifications(area, mx, my)
       when :mine_config   then click_mine_config(area, mx, my)
+      when :probe_active  then click_probe_active(area, mx, my)
       when :discover_config then click_discover_config(area, mx, my)
       when :discover_headers then click_discover_headers(area, mx, my)
       when :fuzz_set      then click_fuzz_set(area, mx, my)
@@ -1373,6 +1378,17 @@ module Gori::Tui
       if idx = ov.row_at(box, mx, my)
         ov.set_selected(idx)
         ov.on_start_row? ? start_mining(ov) : ov.toggle
+      end
+    end
+
+    private def click_probe_active(area : Rect, mx : Int32, my : Int32) : Nil
+      ov = @probe_active_overlay
+      return unless ov
+      box = ov.overlay_box(area)
+      return close_probe_active if box.nil? || dismiss_zone?(box, mx, my)
+      if idx = ov.row_at(box, mx, my)
+        ov.set_selected(idx)
+        ov.on_run_row? ? start_probe_active(ov) : ov.toggle
       end
     end
 
@@ -1579,6 +1595,7 @@ module Gori::Tui
       when :hotkeys       then @hotkeys_overlay.select_move(step)
       when :notifications then @notifications_overlay.select_move(step)
       when :mine_config   then @mine_config_overlay.try(&.move(step))
+      when :probe_active  then @probe_active_overlay.try(&.move(step))
       when :discover_config then @discover_config_overlay.try(&.move(step))
       when :fuzz_set      then @fuzz_set_overlay.try(&.move(step))
       when :fuzz_advanced then @fuzz_advanced_overlay.try(&.move(step))
@@ -1626,6 +1643,26 @@ module Gori::Tui
         ov.adjust(1)
       elsif key.enter? || key.space?
         ov.on_start_row? ? start_mining(ov) : ov.toggle
+      end
+    end
+
+    # Run-active-scan popup: ↑/↓ field · ←/→ notify · ↵ run · esc cancel.
+    private def handle_probe_active_key(ev : Termisu::Event::Key) : Nil
+      ov = @probe_active_overlay
+      return unless ov
+      key = ev.key
+      if key.escape?
+        close_probe_active
+      elsif key.up?
+        ov.move(-1)
+      elsif key.down?
+        ov.move(1)
+      elsif key.left?
+        ov.adjust(-1)
+      elsif key.right?
+        ov.adjust(1)
+      elsif key.enter? || key.space?
+        ov.on_run_row? ? start_probe_active(ov) : ov.toggle
       end
     end
 
@@ -3503,6 +3540,7 @@ module Gori::Tui
       @hotkeys_overlay.render(screen, layout.body) if @overlay == :hotkeys
       @notifications_overlay.render(screen, layout.body) if @overlay == :notifications
       @mine_config_overlay.try(&.render(screen, layout.body)) if @overlay == :mine_config
+      @probe_active_overlay.try(&.render(screen, layout.body)) if @overlay == :probe_active
       @discover_config_overlay.try(&.render(screen, layout.body)) if @overlay == :discover_config
       @discover_headers_overlay.try(&.render(screen, layout.body)) if @overlay == :discover_headers
       @fuzz_set_overlay.try(&.render(screen, layout.body)) if @overlay == :fuzz_set
@@ -3614,6 +3652,7 @@ module Gori::Tui
       when :hotkeys       then "HOTKEYS"
       when :notifications then "NOTIFICATIONS"
       when :mine_config   then "MINE PARAMS"
+      when :probe_active  then "ACTIVE SCAN"
       when :discover_config then "DISCOVER"
       when :discover_headers then "CUSTOM HEADERS"
       when :fuzz_set      then "PAYLOAD SET"
@@ -3665,6 +3704,7 @@ module Gori::Tui
       when :hotkeys       then @hotkeys_overlay.capturing? ? "press a key to bind · esc cancel" : "↑/↓ select · e/␣ rebind · x unbind · r reset · ⇧R reset all · ←/→ profile · ↵ save · esc"
       when :notifications then "↑/↓ select · ↵ open · c clear · esc close"
       when :mine_config   then "↑/↓ field · ←/→ adjust · ␣ toggle · ↵ start · esc cancel"
+      when :probe_active  then "↑/↓ field · ←/→ notify · ↵ run · esc cancel"
       when :discover_config then "↑/↓ field · ←/→ adjust · ␣ toggle · ↵ start/edit · esc cancel"
       when :discover_headers then "one header per line · Host/Connection ignored · esc saves & closes"
       when :fuzz_set      then "↑/↓/⇥ field · ←/→ type/caret · ↵ new value/next · esc applies & closes"
@@ -4692,6 +4732,67 @@ module Gori::Tui
         return
       end
       @toast = "this issue has no sample evidence"
+    end
+
+    # --- manual active scan (History list / detail, Probe findings, Repeater) ---
+    # On-demand run of the Probe ACTIVE checks against one flow, regardless of the Probe mode.
+    # Each source resolves a FlowDetail, then open_probe_active_overlay shows the expected
+    # request count before anything is sent.
+
+    # History list / open detail → the selected (or open) flow.
+    def probe_active_selected : Nil
+      id = history_target_flow_id
+      return (@toast = "select a flow first") unless id
+      detail = @session.store.get_flow(id)
+      return (@toast = "flow no longer available") unless detail
+      open_probe_active_overlay(detail)
+    end
+
+    # Probe findings list → the selected issue's sample flow (re-test the evidence in place).
+    def probe_active_rescan : Nil
+      return (@toast = "select an issue first") unless i = probe_controller.view.target_issue
+      fid = i.sample_flow_id
+      return (@toast = "this issue has no captured flow to re-scan") unless fid
+      detail = @session.store.get_flow(fid)
+      return (@toast = "evidence no longer captured (pruned)") unless detail
+      open_probe_active_overlay(detail)
+    end
+
+    # Repeater → the current session's last HTTP send (request as edited + its response).
+    def probe_active_from_repeater : Nil
+      detail = repeater_controller.active_scan_detail
+      return (@toast = "send the request first (an active scan needs a response)") unless detail
+      open_probe_active_overlay(detail, repeater_id: repeater_controller.current_session_db_id)
+    end
+
+    # Estimate the active-scan request count for `detail`, then open the "Run active scan" popup
+    # (per-rule breakdown + total + a notification-mode cycler). Running is deferred to
+    # start_probe_active so the operator can pick the notify mode first.
+    private def open_probe_active_overlay(detail : Store::FlowDetail, repeater_id : Int64? = nil) : Nil
+      est = @session.probe.active_estimate(detail)
+      if est.empty?
+        @toast = "no active checks apply (needs a GET/HEAD with reflectable params, or a CORS response)"
+        return
+      end
+      @probe_active_overlay = ProbeActiveOverlay.new(detail, est, repeater_id)
+      @overlay = :probe_active
+    end
+
+    # Confirm the popup: run the probes in the BACKGROUND (mode-independent), persist the chosen
+    # notify mode as the next default, and toast the request count. Findings land in the Probe tab
+    # via the usual probe_generation poll + event drain.
+    private def start_probe_active(ov : ProbeActiveOverlay) : Nil
+      notify = ov.notify_mode
+      Settings.save_probe_active_notify(notify.token)
+      host = ov.detail.row.host
+      @session.probe.run_active_now(ov.detail, repeater_id: ov.repeater_id, notify: notify)
+      @toast = "active scan → #{host}: #{ov.total_label} sent (see the Probe tab)"
+      close_probe_active
+    end
+
+    private def close_probe_active : Nil
+      @overlay = :none
+      @probe_active_overlay = nil
     end
 
     # Promote a machine-found Probe issue to a human-confirmed Issue (the bridge to the

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -235,6 +235,13 @@ module Gori
       abstract def probe_repeater_flow : Nil   # send the issue's sample flow to Repeater
       abstract def probe_promote : Nil       # create a Issue from the open issue
 
+      # probe active scan — manual, on-demand run of the request-sending active rules against ONE
+      # flow, regardless of the current Probe mode. Each opens a confirm dialog showing the
+      # expected request count, then runs the probes in the background.
+      abstract def probe_active_selected : Nil      # active-scan History's selected (or open) flow
+      abstract def probe_active_rescan : Nil        # re-active-scan the selected Probe issue's sample flow
+      abstract def probe_active_from_repeater : Nil # active-scan the current Repeater session's last send
+
       # intercept (hold-and-decide; P4)
       abstract def intercept_toggle : Nil          # toggle the hold queue on/off
       abstract def intercept_forward : Nil         # forward the selected held message (edited bytes)

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -56,6 +56,13 @@ module Gori
         "history.compare", "Send to Comparer", "Send the selected flow to the Comparer (next slot A/B)",
         Verb::Scope::Body, available: history_selected, mnemonic: 'c') { |ctx| ctx.comparer_add_selected; nil }
 
+      # Manually run the Probe ACTIVE checks (reflected params, CORS) against the selected flow,
+      # regardless of the Probe mode — opens a confirm dialog with the expected request count.
+      # Menu-only ('A'); mirrors detail.probe-active in the drill-in.
+      r.register Verb::Definition.new(
+        "history.probe-active", "Run active scan", "Run the Probe active checks against the selected flow (shows the request count first)",
+        Verb::Scope::Body, available: history_selected, mnemonic: 'A') { |ctx| ctx.probe_active_selected; nil }
+
       # --- repeater workbench (request editing is inline; these power the palette
       # and show their key hints — actual keys are handled directly by the TUI) ---
       in_repeater = ->(ctx : Verb::ExecContext) { ctx.current_tab == :repeater }
@@ -317,6 +324,12 @@ module Gori
       r.register Verb::Definition.new(
         "detail.add-host", "Add host to scope", "Add this flow's host to the scope lens",
         Verb::Scope::HistoryDetail, mnemonic: 'h') { |ctx| ctx.scope_add_host; nil }
+
+      # Run the Probe active checks against the open flow (mirrors history.probe-active 'A' from
+      # the list) — close the detail first so the confirm dialog isn't buried under it.
+      r.register Verb::Definition.new(
+        "detail.probe-active", "Run active scan", "Run the Probe active checks against this flow (shows the request count first)",
+        Verb::Scope::HistoryDetail, mnemonic: 'A') { |ctx| ctx.close_detail; ctx.probe_active_selected; nil }
     end
 
     # Fuzzer/Intruder verbs: the cross-tab "send to Fuzzer" (⇧I from History, palette
@@ -429,6 +442,12 @@ module Gori
       r.register Verb::Definition.new(
         "repeater.mine", "Mine parameters", "Discover hidden parameters for this repeater request",
         Verb::Scope::Repeater, available: in_repeater, mnemonic: 'm') { |ctx| ctx.mine_from_repeater; nil }
+
+      # Run the Probe active checks against the current Repeater request's last send (COMMON, so
+      # it's reachable from any Repeater pane) — opens a confirm with the expected request count.
+      r.register Verb::Definition.new(
+        "repeater.probe-active", "Run active scan", "Run the Probe active checks against this Repeater request (needs a prior send)",
+        Verb::Scope::Repeater, available: in_repeater, mnemonic: 'A') { |ctx| ctx.probe_active_from_repeater; nil }
 
       r.register Verb::Definition.new(
         "mine.run", "Run mining", "Re-run parameter mining for this session", Verb::Scope::Miner,

--- a/src/gori/verbs/probe.cr
+++ b/src/gori/verbs/probe.cr
@@ -70,6 +70,12 @@ module Gori
         "probe.repeater-evidence", "Repeater evidence", "Send the selected issue's sample flow to Repeater",
         Verb::Scope::Probe, [Verb::Chord.new("r")]) { |ctx| ctx.probe_repeater_flow; nil }
 
+      # Re-run the ACTIVE checks against the selected issue's sample flow (menu-only 'A') — opens
+      # a confirm with the expected request count. 'a' is toggle-closed; capital 'A' is free.
+      r.register Verb::Definition.new(
+        "probe.active-rescan", "Run active scan", "Re-run the Probe active checks against the selected issue's sample flow",
+        Verb::Scope::Probe, mnemonic: 'A') { |ctx| ctx.probe_active_rescan; nil }
+
       r.register Verb::Definition.new(
         "probe.promote-selected", "Promote to issue", "Create a Issue from the selected issue",
         Verb::Scope::Probe, [Verb::Chord.new("p")]) { |ctx| ctx.probe_promote; nil }


### PR DESCRIPTION
## Summary

Adds an on-demand **Run active scan** action so the Probe active checks can be fired against a chosen flow **regardless of the Probe mode** (works in Off / Passive / Active), plus an **expected-request-count** display and a miner-style **notification-mode** choice.

### Manual trigger
Launchable from four places, all routing through one confirm-then-run popup:
- **History list** and **flow detail** (`A` in the space menu)
- **Probe findings** — re-scan the selected issue's sample flow
- **Repeater** — scan the current session's last send

`Analyzer#run_active_now` runs the active rules in the background, bypassing the mode/scope/dedup gates (still honouring disabled + suppressed rules). Findings land in the Probe tab via the usual `probe_generation` poll + event drain.

### Expected request count
Each active `Rule` reports `requests_per_flow` (`1..1` today, range-ready). `Analyzer#active_estimate` lists the rules that apply to a flow — surfaced as a per-rule breakdown + total in the run popup, and annotated per active rule in the **Rules** sub-tab (`active · 1 req/flow`).

### Notification modes (like the miner)
The run popup mirrors the Mine popup with a `‹/›` notification cycler, reusing `Miner::NotifyMode`:
- **off** — silent (findings still land in the list)
- **when found** — notify per finding (default)
- **always** — also posts a "scan complete — no issues" note on a clean run (suppressed on a send error)

The choice persists as the next default (`Settings.probe_active_notify`).

## Verification
- `crystal spec` green for the touched suites (probe / settings / verb registry / hotkeys); added estimate + notify-mode + settings round-trip specs. Full `shards build` passes.
- Driven end-to-end in a headless TUI: the popup + cycler render, cycling/persistence work, and against a live local server the scan produces a real `Reflected parameter` finding + notification — with **off** suppressing the toast/badge and **always** posting the clean-run completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)