### PR TITLE
feat(picker): compress a project from the space menu to reclaim disk

### DIFF
--- a/spec/store/compact_spec.cr
+++ b/spec/store/compact_spec.cr
@@ -1,0 +1,151 @@
+require "../spec_helper"
+require "file_utils"
+
+# A block of `n` printable bytes, big enough that dropping it visibly shrinks the file.
+private def big_body(n : Int32) : Bytes
+  Bytes.new(n) { |i| ((i % 26) + 65).to_u8 }
+end
+
+# Store.compact takes the per-project capture lock (`<dir>/.capture.lock`), so each
+# case needs its OWN dir — a bare tempfile would share one lock across the temp dir.
+private def with_project(&)
+  dir = File.tempname("gori-compact")
+  Dir.mkdir_p(dir)
+  path = File.join(dir, "gori.db")
+  begin
+    yield path
+  ensure
+    FileUtils.rm_rf(dir)
+  end
+end
+
+private def req_for(target : String) : Gori::Store::CapturedRequest
+  Gori::Store::CapturedRequest.new(
+    created_at: 1_000_i64, scheme: "http", host: "acme.test", port: 80,
+    method: "POST", target: target, http_version: "HTTP/1.1",
+    head: "POST #{target} HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice,
+    body: big_body(120_000))
+end
+
+private def seed_flow_with_bodies(store : Gori::Store, target : String) : Int64
+  id = store.insert_flow(req_for(target))
+  store.update_response(Gori::Store::CapturedResponse.new(
+    flow_id: id, status: 200,
+    head: "HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\n\r\n".to_slice,
+    body: big_body(300_000), content_type: "application/octet-stream"))
+  id
+end
+
+private def blob_len(store : Gori::Store, col : String, id : Int64) : Int64
+  store.@db.scalar("SELECT LENGTH(#{col}) FROM flows WHERE id = ?", id).as(Int64)
+end
+
+describe "Gori::Store.compact" do
+  it "strips selected data + VACUUMs while keeping the flow rows and their projection" do
+    with_project do |path|
+      ids = [] of Int64
+      store = Gori::Store.open(path)
+      begin
+        3.times { |i| ids << seed_flow_with_bodies(store, "/big/#{i}") }
+        store.insert_ws_message(ids.first, "out", 1, big_body(60_000)) # captured (repeater_id IS NULL)
+        # A raw h2 frame log to prove the h2 option clears it.
+        store.@db.exec("INSERT INTO h2_connections (created_at, host, port, alpn) VALUES (1, 'acme.test', 443, 'h2')")
+        cid = store.@db.scalar("SELECT last_insert_rowid()").as(Int64)
+        store.@db.exec("INSERT INTO h2_frames (conn_id, created_at, direction, stream_id, type, flags, length, payload) " \
+                       "VALUES (?, 1, 'out', 1, 0, 0, 3, X'414243')", cid)
+      ensure
+        store.close
+      end
+
+      before = File.info(path).size
+      plan = Gori::Store::CompactPlan.new(
+        response_bodies: true, request_bodies: true, h2_frames: true, ws_messages: true)
+      result = Gori::Store.compact(path, plan).not_nil!
+
+      result.before_bytes.should eq(before)
+      result.after_bytes.should be < before
+      result.reclaimed_bytes.should be > 0
+      File.info(path).size.should eq(result.after_bytes)
+
+      store = Gori::Store.open(path)
+      begin
+        store.count.should eq(3) # rows preserved — only the heavy blobs went
+        ids.each do |id|
+          blob_len(store, "response_body", id).should eq(0)
+          blob_len(store, "request_body", id).should eq(0)
+          store.@db.scalar("SELECT response_body_truncated FROM flows WHERE id = ?", id).as(Int64).should eq(1)
+          store.@db.scalar("SELECT request_body_truncated FROM flows WHERE id = ?", id).as(Int64).should eq(1)
+          # True wire size + status projection survive the drop.
+          store.@db.scalar("SELECT response_size FROM flows WHERE id = ?", id).as(Int64).should be > 300_000
+          store.@db.scalar("SELECT status FROM flows WHERE id = ?", id).as(Int64).should eq(200)
+        end
+        store.@db.scalar("SELECT COUNT(*) FROM ws_messages WHERE repeater_id IS NULL").as(Int64).should eq(0)
+        store.@db.scalar("SELECT COUNT(*) FROM h2_frames").as(Int64).should eq(0)
+        store.@db.scalar("SELECT COUNT(*) FROM h2_connections").as(Int64).should eq(0)
+      ensure
+        store.close
+      end
+    end
+  end
+
+  it "measure reports reclaimable byte estimates per category" do
+    with_project do |path|
+      store = Gori::Store.open(path)
+      begin
+        2.times { |i| seed_flow_with_bodies(store, "/m/#{i}") }
+      ensure
+        store.close
+      end
+
+      stats = Gori::Store.measure(path)
+      stats.flow_count.should eq(2)
+      stats.response_body_bytes.should be >= 600_000
+      stats.request_body_bytes.should be >= 240_000
+      stats.db_bytes.should be > 0
+    end
+  end
+
+  it "keep_flows deletes the oldest flows (cascading), keeping only the newest N" do
+    with_project do |path|
+      ids = [] of Int64
+      store = Gori::Store.open(path)
+      begin
+        10.times { |i| ids << store.insert_flow(req_for("/f/#{i}")) }
+      ensure
+        store.close
+      end
+
+      Gori::Store.compact(path, Gori::Store::CompactPlan.new(keep_flows: 3)).not_nil!
+
+      store = Gori::Store.open(path)
+      begin
+        store.count.should eq(3)
+        # The three newest ids survive; the oldest are gone.
+        store.get_flow(ids.last).should_not be_nil
+        store.get_flow(ids.first).should be_nil
+      ensure
+        store.close
+      end
+    end
+  end
+
+  it "refuses (returns nil) when another live instance holds the capture lock" do
+    with_project do |path|
+      store = Gori::Store.open(path)
+      begin
+        seed_flow_with_bodies(store, "/x")
+      ensure
+        store.close
+      end
+
+      lock = Gori::CaptureLock.try(File.dirname(path)).not_nil!
+      begin
+        Gori::Store.compact(path, Gori::Store::CompactPlan.new(response_bodies: true)).should be_nil
+        # The body is untouched because the run was refused.
+        Gori::Store.measure(path).response_body_bytes.should be > 0
+      ensure
+        lock.close
+      end
+    end
+  end
+end

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -5,6 +5,7 @@ require "json"
 require "./store/models"
 require "./store/safe_regexp"
 require "./store/schema"
+require "./store/compact"
 require "./ql"
 
 module Gori

--- a/src/gori/store/compact.cr
+++ b/src/gori/store/compact.cr
@@ -1,0 +1,180 @@
+require "db"
+require "sqlite3"
+require "../capture_lock"
+require "./schema"
+
+# On-demand project compaction: drop the less-important, space-dominating data
+# (captured bodies, the raw HTTP/2 frame log, WebSocket payloads, fuzzer result
+# captures, optionally the oldest flows) and then VACUUM to hand the freed pages
+# back to the OS — shrinking the on-disk `gori.db` while keeping each flow's
+# projection (URL/method/status/sizes/headers), the sitemap, findings, notes,
+# scope, repeaters and custom rules intact.
+#
+# This is the manual counterpart to the automatic one-time `reclaim_to_disk`
+# (run on a schema upgrade). It runs against a project that is NOT open in this
+# process — the ProjectPicker triggers it before any Store/session exists — so it
+# opens its own short-lived connection. It takes the per-project CAPTURE LOCK for
+# the duration, refusing (nil) if another live instance is capturing into the DB,
+# the same guard `ProjectRegistry#delete` uses before wiping a project.
+class Gori::Store
+  # Which categories the operator chose to strip. `keep_flows` (when set) also
+  # deletes whole flow rows older than the newest N — the only option that drops
+  # history rows rather than just their heavy blobs; nil keeps every flow.
+  record CompactPlan,
+    response_bodies : Bool = false,
+    request_bodies : Bool = false,
+    h2_frames : Bool = false,
+    ws_messages : Bool = false,
+    fuzz_bodies : Bool = false,
+    keep_flows : Int32? = nil do
+    # VACUUM alone (no category selected) still reclaims already-freed pages, so a
+    # plan is never a no-op; this just tells the UI whether any data is removed.
+    def removes_data? : Bool
+      response_bodies || request_bodies || h2_frames || ws_messages || fuzz_bodies || !keep_flows.nil?
+    end
+  end
+
+  # Reclaimable byte estimates per category (summed blob lengths) plus the current
+  # on-disk size and flow count — fed to the compress popup so each option shows
+  # roughly how much it would free. Estimates ignore per-row/page overhead, so the
+  # real post-VACUUM saving is usually a little larger.
+  record CompactStats,
+    db_bytes : Int64,
+    response_body_bytes : Int64,
+    request_body_bytes : Int64,
+    h2_bytes : Int64,
+    ws_bytes : Int64,
+    fuzz_bytes : Int64,
+    flow_count : Int64
+
+  # On-disk size before and after a compaction, for the picker's result line.
+  record CompactResult, before_bytes : Int64, after_bytes : Int64 do
+    def reclaimed_bytes : Int64
+      {before_bytes - after_bytes, 0_i64}.max
+    end
+  end
+
+  # SQLite connection URL for a project db (WAL, same pragmas as Store.open).
+  private def self.compact_url(path : String) : String
+    "sqlite3:#{path}?journal_mode=wal&synchronous=normal&busy_timeout=5000"
+  end
+
+  # Read-only measurement for the compress popup. Opens the db, sums the blob
+  # lengths per category, closes. Each aggregate is guarded so a project on an
+  # older schema (e.g. missing `ws_messages.repeater_id`) still measures the
+  # columns it does have rather than raising.
+  def self.measure(path : String) : CompactStats
+    db_bytes = File.exists?(path) ? File.info(path).size : 0_i64
+    return CompactStats.new(db_bytes, 0, 0, 0, 0, 0, 0) unless File.exists?(path)
+    db = DB.open(compact_url(path))
+    begin
+      resp = sum_len(db, "SELECT COALESCE(SUM(LENGTH(response_body)), 0) FROM flows")
+      req = sum_len(db, "SELECT COALESCE(SUM(LENGTH(request_body)), 0) FROM flows")
+      h2 = sum_len(db, "SELECT COALESCE(SUM(LENGTH(payload)), 0) FROM h2_frames")
+      ws = sum_len(db, "SELECT COALESCE(SUM(LENGTH(payload)), 0) FROM ws_messages WHERE repeater_id IS NULL")
+      fuzz = sum_len(db, "SELECT COALESCE(SUM(COALESCE(LENGTH(request), 0) + COALESCE(LENGTH(response_head), 0) + COALESCE(LENGTH(response_body), 0)), 0) FROM fuzz_results")
+      flows = sum_len(db, "SELECT COUNT(*) FROM flows")
+      CompactStats.new(db_bytes, resp, req, h2, ws, fuzz, flows)
+    ensure
+      db.close
+    end
+  end
+
+  # A single-scalar aggregate that returns 0 when the table/column is absent
+  # (old-schema project) instead of raising into the caller.
+  private def self.sum_len(db : DB::Database, sql : String) : Int64
+    db.scalar(sql).as(Int64)
+  rescue
+    0_i64
+  end
+
+  # Strip the selected data and VACUUM. Returns the before/after on-disk sizes, or
+  # nil when another live instance holds the capture lock (the project is being
+  # captured into — compaction would race its writer). Best-effort and atomic:
+  # every deletion runs in one transaction; a failure rolls it back and re-raises
+  # so the caller can surface it (the file is left fully usable).
+  def self.compact(path : String, plan : CompactPlan) : CompactResult?
+    return nil unless File.exists?(path)
+    dir = File.dirname(path)
+    lock = CaptureLock.try(dir)
+    return nil unless lock # another live instance is capturing into this project
+    begin
+      before = File.info(path).size
+      db = DB.open(compact_url(path))
+      begin
+        # Bring an older project up to the current schema so the table/column
+        # names below (issues/probe/repeater renames, repeater_id, truncated
+        # flags) are guaranteed present — same as opening it would.
+        Schema.migrate!(db)
+        db.transaction do |tx|
+          apply_plan(tx.connection, plan)
+        end
+        # VACUUM rewrites the whole file to reclaim freed pages; it is ILLEGAL
+        # inside a transaction (see schema.cr) so it runs after the commit.
+        db.exec("VACUUM")
+      ensure
+        db.close
+      end
+      # VACUUM may recreate the -wal/-shm sidecars; re-tighten them to 0600.
+      harden_permissions(path)
+      CompactResult.new(before, File.info(path).size)
+    ensure
+      lock.close
+    end
+  end
+
+  # Runs the chosen removals on `conn` inside the caller's transaction. Blobs are
+  # emptied to X'' (keeping the row + its projection columns) rather than the
+  # column nulled, so `*_body_truncated` reads as "captured but dropped".
+  private def self.apply_plan(conn : DB::Connection, plan : CompactPlan) : Nil
+    if plan.response_bodies
+      conn.exec("UPDATE flows SET response_body = X'', response_body_truncated = 1 " \
+                "WHERE response_body IS NOT NULL AND LENGTH(response_body) > 0")
+    end
+    if plan.request_bodies
+      conn.exec("UPDATE flows SET request_body = X'', request_body_truncated = 1 " \
+                "WHERE request_body IS NOT NULL AND LENGTH(request_body) > 0")
+    end
+    if plan.h2_frames
+      # The raw h2 frame log is a detail-view-only diagnostic; each flow rebuilds
+      # from its own request_head/response_head, so dropping it loses no traffic.
+      conn.exec("DELETE FROM h2_frames")
+      conn.exec("DELETE FROM h2_connections")
+    end
+    if plan.ws_messages
+      # Only CAPTURED ws frames (repeater_id IS NULL); WebSocket-Repeater output
+      # (keyed by repeater_id) is user-authored workbench state and is spared.
+      conn.exec("DELETE FROM ws_messages WHERE repeater_id IS NULL")
+    end
+    if plan.fuzz_bodies
+      # Drop the per-result captured bytes but keep status/length/words/lines/
+      # matched/extracted — the fuzzer table stays useful, just without payloads.
+      conn.exec("UPDATE fuzz_results SET request = X'', response_head = X'', response_body = X'' " \
+                "WHERE (COALESCE(LENGTH(request), 0) + COALESCE(LENGTH(response_head), 0) + COALESCE(LENGTH(response_body), 0)) > 0")
+    end
+    if keep = plan.keep_flows
+      prune_old_flows(conn, keep)
+    end
+  end
+
+  # Keep only the newest `keep` flows (by id, which is monotonic), cascading to
+  # their ws messages, FTS rows and orphaned h2 frames/connections — the same
+  # cascade the retention sweep (`prune`) uses, but with an explicit keep count.
+  private def self.prune_old_flows(conn : DB::Connection, keep : Int32) : Nil
+    return if keep <= 0
+    max_id = conn.query_one?("SELECT MAX(id) FROM flows", as: Int64?)
+    return unless max_id
+    cutoff = max_id - keep
+    return if cutoff <= 0
+    conn.exec("DELETE FROM ws_messages WHERE flow_id <= ? AND repeater_id IS NULL", cutoff)
+    conn.exec("DELETE FROM flows_fts WHERE rowid <= ?", cutoff)
+    conn.exec("DELETE FROM flows WHERE id <= ?", cutoff)
+    # Reap a connection's raw log only once it is neither referenced by a surviving
+    # flow nor still logging recent frames (identical guard to Store#prune).
+    oldest = conn.query_one?("SELECT MIN(created_at) FROM flows", as: Int64?) || Int64::MAX
+    stale = "id NOT IN (SELECT h2_conn_id FROM flows WHERE h2_conn_id IS NOT NULL) " \
+            "AND id NOT IN (SELECT conn_id FROM h2_frames WHERE created_at >= ?)"
+    conn.exec("DELETE FROM h2_frames WHERE conn_id IN (SELECT id FROM h2_connections WHERE #{stale})", oldest)
+    conn.exec("DELETE FROM h2_connections WHERE #{stale}", oldest)
+  end
+end

--- a/src/gori/tui/compact_overlay.cr
+++ b/src/gori/tui/compact_overlay.cr
@@ -1,0 +1,176 @@
+require "./screen"
+require "./theme"
+require "./frame"
+require "./fmt"
+require "../store"
+
+module Gori::Tui
+  # The scope popup shown before a project is compacted from the ProjectPicker.
+  # Adaptive checkboxes (one per removable data category, each annotated with the
+  # bytes it would free) + a "keep newest flows" cycler + a Compress row. Pure
+  # state + rendering, self-contained like ConfirmDialog/SettingsView: the picker
+  # drives it (its own `:compress` mode) and reads `plan` on the Compress row.
+  #
+  # Response bodies + the raw HTTP/2 frame log default ON — the biggest, safest
+  # wins that keep every flow's projection intact; the rest are opt-in. The keep
+  # cycler is the only option that drops whole flow rows, so it defaults to "all".
+  class CompactOverlay
+    record Option, key : Symbol, label : String
+
+    OPTIONS = [
+      Option.new(:response_bodies, "Response bodies"),
+      Option.new(:request_bodies, "Request bodies"),
+      Option.new(:h2_frames, "HTTP/2 frame log"),
+      Option.new(:ws_messages, "WebSocket messages"),
+      Option.new(:fuzz_bodies, "Fuzzer responses"),
+    ]
+
+    # nil = keep every flow (no row deletion); the rest cap history to the newest N.
+    KEEP_CHOICES = [nil, 50_000, 10_000, 1_000]
+
+    getter project_name : String
+
+    def initialize(@project_name : String, @stats : Store::CompactStats)
+      @checked = {
+        :response_bodies => true,
+        :request_bodies  => false,
+        :h2_frames       => true,
+        :ws_messages     => false,
+        :fuzz_bodies     => false,
+      } of Symbol => Bool
+      @keep_idx = 0
+      @selected = 0
+    end
+
+    private def row_count : Int32
+      OPTIONS.size + 2 # options, keep-flows cycler, Compress row
+    end
+
+    private def keep_row : Int32
+      OPTIONS.size
+    end
+
+    private def run_row : Int32
+      OPTIONS.size + 1
+    end
+
+    def on_run_row? : Bool
+      @selected == run_row
+    end
+
+    def move(d : Int32) : Nil
+      @selected = (@selected + d).clamp(0, row_count - 1)
+    end
+
+    def set_selected(idx : Int32) : Nil
+      @selected = idx.clamp(0, row_count - 1)
+    end
+
+    # ‹/› cycles the keep-flows choice; a no-op elsewhere.
+    def adjust(d : Int32) : Nil
+      @keep_idx = (@keep_idx + d) % KEEP_CHOICES.size if @selected == keep_row
+    end
+
+    # Space/Enter flips a checkbox or advances the keep cycler. The Compress row is
+    # handled by the picker (it opens the confirm), not here.
+    def toggle : Nil
+      if @selected < OPTIONS.size
+        key = OPTIONS[@selected].key
+        @checked[key] = !@checked[key]
+      elsif @selected == keep_row
+        adjust(1)
+      end
+    end
+
+    def plan : Store::CompactPlan
+      Store::CompactPlan.new(
+        response_bodies: @checked[:response_bodies],
+        request_bodies: @checked[:request_bodies],
+        h2_frames: @checked[:h2_frames],
+        ws_messages: @checked[:ws_messages],
+        fuzz_bodies: @checked[:fuzz_bodies],
+        keep_flows: KEEP_CHOICES[@keep_idx],
+      )
+    end
+
+    # Summed reclaimable bytes for the CHECKED blob categories — the estimate shown
+    # in the confirm prompt. Old-flow deletion (keep cycler) isn't summed here
+    # (its saving depends on per-row sizes); VACUUM reclaims it plus overhead.
+    def estimated_bytes : Int64
+      total = 0_i64
+      OPTIONS.each do |opt|
+        total += bytes_for(opt.key) if @checked[opt.key]
+      end
+      total
+    end
+
+    private def bytes_for(key : Symbol) : Int64
+      case key
+      when :response_bodies then @stats.response_body_bytes
+      when :request_bodies  then @stats.request_body_bytes
+      when :h2_frames       then @stats.h2_bytes
+      when :ws_messages     then @stats.ws_bytes
+      when :fuzz_bodies     then @stats.fuzz_bytes
+      else                       0_i64
+      end
+    end
+
+    private def keep_label : String
+      KEEP_CHOICES[@keep_idx].try { |n| Fmt.count(n.to_i64) } || "all"
+    end
+
+    def overlay_box(area : Rect) : Rect?
+      w = {area.w - 4, 52}.min
+      h = {area.h - 2, row_count + 5}.min # title + summary + gap + rows + border
+      return nil if w < 34 || h < 6
+      Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
+    end
+
+    def render(screen : Screen, area : Rect) : Nil
+      box = overlay_box(area)
+      unless box
+        screen.text(area.x + 1, area.y, "compress needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        return
+      end
+      Frame.card(screen, box, "COMPRESS PROJECT", border: Theme.border_focus)
+      summary = "#{@project_name} · DB #{Fmt.size(@stats.db_bytes)}"
+      screen.text(box.x + 2, box.y + 1, summary, Theme.text_bright, Theme.panel, Attribute::Bold, width: box.w - 4)
+      first = box.y + 3
+      row_count.times do |i|
+        py = first + i
+        break if py >= box.bottom
+        draw_row(screen, box, i, py)
+      end
+    end
+
+    private def draw_row(screen : Screen, box : Rect, i : Int32, py : Int32) : Nil
+      sel = i == @selected
+      bg = sel ? Theme.accent_bg : Theme.panel
+      screen.fill(Rect.new(box.x + 1, py, box.w - 2, 1), bg)
+      screen.cell(box.x + 1, py, sel ? '▎' : ' ', Theme.accent, bg)
+      x = box.x + 3
+      if i < OPTIONS.size
+        opt = OPTIONS[i]
+        on = @checked[opt.key]
+        screen.text(x, py, on ? "[x]" : "[ ]", on ? Theme.green : Theme.muted, bg)
+        screen.text(x + 4, py, opt.label, sel ? Theme.text_bright : Theme.text, bg, width: box.w - 16)
+        bytes = bytes_for(opt.key)
+        size = bytes > 0 ? Fmt.size(bytes) : "—"
+        screen.text(box.right - size.size - 2, py, size, bytes > 0 ? Theme.muted : Theme.border, bg)
+      elsif i == keep_row
+        screen.text(x, py, "keep newest flows:", Theme.muted, bg)
+        screen.text(x + 19, py, "#{keep_label}  ‹/›", sel ? Theme.text_bright : Theme.text, bg)
+      else
+        screen.text(x, py, "[ Compress ]", Theme.accent, bg, Attribute::Bold)
+        hint = "↵ run"
+        screen.text(box.right - hint.size - 2, py, hint, Theme.muted, bg)
+      end
+    end
+
+    def row_at(box : Rect, mx : Int32, my : Int32) : Int32?
+      return nil unless box.contains?(mx, my)
+      i = my - (box.y + 3)
+      (0 <= i < row_count) ? i : nil
+    end
+  end
+end

--- a/src/gori/tui/project_picker.cr
+++ b/src/gori/tui/project_picker.cr
@@ -10,6 +10,7 @@ require "./theme"
 require "./frame"
 require "./confirm_dialog"
 require "./settings_view"
+require "./compact_overlay"
 
 module Gori::Tui
   # The startup screen: choose a project to open. New + Temp are always shown at
@@ -34,6 +35,7 @@ module Gori::Tui
     SPACE_ENTRIES = [
       SpaceEntry.new('o', "Open", :open),
       SpaceEntry.new('r', "Rename", :rename),
+      SpaceEntry.new('c', "Compress", :compress),
       SpaceEntry.new('d', "Delete", :delete),
     ]
 
@@ -44,7 +46,7 @@ module Gori::Tui
       @query = "" # current search filter; only editable when Search row selected
       @selected = 0
       @results_scroll = 0
-      @mode = :list # :list | :new | :confirm | :space | :rename | :settings
+      @mode = :list # :list | :new | :confirm | :space | :rename | :settings | :compress | :compressing
       @name = ""
       @desc = ""
       @new_field = :name # :name | :desc (only in :new mode)
@@ -53,9 +55,20 @@ module Gori::Tui
       # Delete confirmation (project deletion is irreversible — wipes its dir).
       @confirm = nil.as(ConfirmDialog?)
       @pending_delete = nil.as(Project?)
-      # Space menu over a project row (open/rename/delete).
+      # Space menu over a project row (open/rename/compress/delete).
       @space_selected = 0
       @space_project = nil.as(Project?)
+      # Compress scope popup (space → Compress): choose what to strip, confirm, VACUUM.
+      # The picker holds no open Store, so it acts on the project's db file directly.
+      @compact = nil.as(CompactOverlay?)
+      @compact_project = nil.as(Project?)
+      @pending_compact = nil.as(Store::CompactPlan?)
+      # Which action a shared ConfirmDialog commits (:delete wipes the dir, :compress runs Store.compact).
+      @confirm_kind = :delete
+      # Transient one-line result shown above the hint after a compaction (green ok / red fail),
+      # cleared on the next list keystroke.
+      @flash = nil.as(String?)
+      @flash_ok = true
       # Rename prompt (display name only — directory slug stays put).
       @pending_rename = nil.as(Project?)
       @rename_name = ""
@@ -84,6 +97,7 @@ module Gori::Tui
                    when :settings then handle_settings(ev)
                    when :space    then handle_space(ev)
                    when :rename   then handle_rename(ev)
+                   when :compress then handle_compress(ev)
                    else                handle_list(ev)
                    end
           case result
@@ -130,6 +144,7 @@ module Gori::Tui
     private def handle_list(ev : Termisu::Event::Key) : Project | Symbol | Nil
       key = ev.key
       @preedit = "" # any committed key ends an in-progress IME composition
+      @flash = nil  # a fresh keystroke dismisses the last compaction result line
       # Arrows are pure navigation (never filter). Typing a printable key jumps into
       # the Search row and filters — matching the "type to search" hint + the universal
       # picker expectation — so a user who lands on New/Temp and types a project name to
@@ -224,12 +239,21 @@ module Gori::Tui
       key = ev.key
       case
       when key.escape?, key.n?, ev.ctrl_c?                then cancel_confirm
-      when key.y?                                         then commit_delete
+      when key.y?                                         then commit_confirmed
       when key.left?, key.right?, key.tab?, key.back_tab? then dlg.try(&.move)
       when key.enter?
-        (dlg.try(&.confirm_selected?)) ? commit_delete : cancel_confirm
+        (dlg.try(&.confirm_selected?)) ? commit_confirmed : cancel_confirm
       end
       nil
+    end
+
+    # Runs the action the shared ConfirmDialog was opened for — delete wipes the
+    # project dir, compress strips + VACUUMs its db in place.
+    private def commit_confirmed : Nil
+      case @confirm_kind
+      when :compress then commit_compress
+      else                commit_delete
+      end
     end
 
     # Project-row space menu: ↑/↓ move, mnemonic key or ↵ run, esc dismiss.
@@ -330,6 +354,7 @@ module Gori::Tui
         %(Delete "#{target.name}"?\nThis permanently removes all of its captured data.),
         confirm_label: "delete", cancel_label: "cancel", danger: true)
       @pending_delete = target
+      @confirm_kind = :delete
       @mode = :confirm
     end
 
@@ -355,7 +380,10 @@ module Gori::Tui
     private def cancel_confirm : Nil
       @mode = :list
       @confirm = nil
+      @confirm_kind = :delete
       @pending_delete = nil
+      @pending_compact = nil
+      @compact_project = nil
     end
 
     # --- space menu (project row actions) ------------------------------------
@@ -387,6 +415,9 @@ module Gori::Tui
         project
       when :rename
         start_rename(project)
+        nil
+      when :compress
+        start_compress(project)
         nil
       when :delete
         request_delete(project)
@@ -429,6 +460,108 @@ module Gori::Tui
       @pending_rename = nil
       @rename_name = ""
       @preedit = ""
+    end
+
+    # --- compress (space → Compress) -----------------------------------------
+
+    # Open the compress-scope popup for `project`. Refuses one another live
+    # instance is capturing into (VACUUM/deletes would race its writer — the green
+    # "● on" dot already flags it), flashing why. Measures reclaimable sizes up
+    # front so each option shows roughly what it would free.
+    private def start_compress(project : Project) : Nil
+      if probe_running(project)[0]
+        set_flash(%(can't compress "#{project.name}" — it's open in another window), ok: false)
+        return
+      end
+      stats = begin
+        Store.measure(project.db_path)
+      rescue Gori::Error | IO::Error | DB::Error | SQLite3::Exception
+        set_flash(%(can't read "#{project.name}" to compress), ok: false)
+        return
+      end
+      @compact_project = project
+      @compact = CompactOverlay.new(project.name, stats)
+      @mode = :compress
+    end
+
+    # Compress popup: ↑/↓ move, ‹/› cycle keep-flows, space toggle, ↵/space on the
+    # Compress row opens the confirm (else toggles the focused row), esc dismiss.
+    private def handle_compress(ev : Termisu::Event::Key) : Project | Symbol | Nil
+      ov = @compact
+      return nil unless ov
+      key = ev.key
+      @preedit = ""
+      if key.escape? || ev.ctrl_c?
+        close_compact
+      elsif key.up?
+        ov.move(-1)
+      elsif key.down?
+        ov.move(1)
+      elsif key.left?
+        ov.adjust(-1)
+      elsif key.right?
+        ov.adjust(1)
+      elsif (key.enter? || key.space?) && !ev.ctrl? && !ev.alt?
+        ov.on_run_row? ? request_compress(ov) : ov.toggle
+      end
+      nil
+    end
+
+    # Confirm before the destructive run (compaction can't be undone). Stashes the
+    # plan, then reuses the shared danger ConfirmDialog (committed via @confirm_kind).
+    private def request_compress(ov : CompactOverlay) : Nil
+      return unless @compact_project
+      plan = ov.plan
+      est = ov.estimated_bytes
+      detail = if plan.removes_data?
+                 amount = est > 0 ? "~#{Fmt.size(est)} of data" : "the selected data"
+                 "Remove #{amount} and reclaim disk?"
+               else
+                 "Reclaim free space (VACUUM only)?"
+               end
+      @pending_compact = plan
+      @confirm = ConfirmDialog.new("COMPRESS PROJECT",
+        %(#{detail}\nThis permanently drops the selected data.),
+        confirm_label: "compress", cancel_label: "cancel", danger: true)
+      @confirm_kind = :compress
+      @compact = nil
+      @mode = :confirm
+    end
+
+    # Run the compaction synchronously (the picker has no background jobs — mirrors
+    # the synchronous delete). Paints a brief "Compressing …" frame first since a
+    # VACUUM on a large db can block, then flashes the reclaimed size (or failure).
+    private def commit_compress : Nil
+      project = @compact_project
+      plan = @pending_compact
+      if project && plan
+        @mode = :compressing
+        render # paint the busy card before the blocking VACUUM
+        begin
+          if result = Store.compact(project.db_path, plan)
+            reclaimed = result.reclaimed_bytes > 0 ? "  (−#{Fmt.size(result.reclaimed_bytes)})" : ""
+            set_flash(%(compressed "#{project.name}"  #{Fmt.size(result.before_bytes)} → #{Fmt.size(result.after_bytes)}#{reclaimed}), ok: true)
+          else
+            set_flash(%(can't compress "#{project.name}" — it's open in another window), ok: false)
+          end
+        rescue ex : Gori::Error | IO::Error | DB::Error | SQLite3::Exception
+          set_flash("compress failed: #{ex.message}", ok: false)
+        end
+        @projects = @registry.list
+        invalidate_running_cache
+      end
+      cancel_confirm # resets mode → :list and clears the confirm/compress state
+    end
+
+    private def close_compact : Nil
+      @mode = :list
+      @compact = nil
+      @compact_project = nil
+    end
+
+    private def set_flash(msg : String, *, ok : Bool) : Nil
+      @flash = msg
+      @flash_ok = ok
     end
 
     private def handle_new(ev : Termisu::Event::Key) : Project | Symbol | Nil
@@ -499,9 +632,28 @@ module Gori::Tui
       when :confirm  then handle_confirm_mouse(w, h, mx, my)
       when :settings then handle_settings_mouse(w, h, mx, my)
       when :space    then handle_space_mouse(w, h, mx, my)
+      when :compress then handle_compress_mouse(w, h, mx, my)
+      when :compressing  then nil # blocking VACUUM in progress — ignore clicks
       when :new, :rename then nil # text form — keyboard only (cursor placement is Phase 2)
       else                handle_list_mouse(mx, my)
       end
+    end
+
+    # Click a compress-popup row to focus + toggle it (or open the confirm on the
+    # Compress row); a click outside the card dismisses, like the other overlays.
+    private def handle_compress_mouse(w : Int32, h : Int32, mx : Int32, my : Int32) : Project | Symbol | Nil
+      ov = @compact
+      return nil if ov.nil?
+      box = ov.overlay_box(Rect.new(0, 0, w, h))
+      if box.nil? || !box.contains?(mx, my)
+        close_compact
+        return nil
+      end
+      if idx = ov.row_at(box, mx, my)
+        ov.set_selected(idx)
+        ov.on_run_row? ? request_compress(ov) : ov.toggle
+      end
+      nil
     end
 
     # List click: SELECT-FIRST — first click highlights the entry, a second click on
@@ -521,7 +673,8 @@ module Gori::Tui
       case @mode
       when :settings                then @settings.move_field(delta)
       when :space                   then @space_selected = (@space_selected + delta.sign).clamp(0, SPACE_ENTRIES.size - 1)
-      when :new, :confirm, :rename then nil # nothing to scroll
+      when :compress                then @compact.try(&.move(delta.sign))
+      when :new, :confirm, :rename, :compressing then nil # nothing to scroll
       else                              @selected = (@selected + delta).clamp(0, entry_count - 1)
       end
     end
@@ -532,7 +685,7 @@ module Gori::Tui
       box = dlg.overlay_box(Rect.new(0, 0, w, h))
       return cancel_confirm unless box.contains?(mx, my) # click away → cancel
       case dlg.button_at(box, mx, my)
-      when :confirm then commit_delete
+      when :confirm then commit_confirmed
       when :cancel  then cancel_confirm
       end
     end
@@ -647,6 +800,8 @@ module Gori::Tui
         @confirm.try(&.render(screen, Rect.new(0, 0, w, h))) if @mode == :confirm
         @settings.render(screen, Rect.new(0, 0, w, h)) if @mode == :settings
         render_space_menu(screen, w, h) if @mode == :space
+        @compact.try(&.render(screen, Rect.new(0, 0, w, h))) if @mode == :compress
+        render_compressing(screen, w, h) if @mode == :compressing
       end
       # Sync the terminal hardware cursor to the focused caret so the terminal's
       # own IME composition UI (jamo/candidate popup) anchors at the right cell —
@@ -755,9 +910,19 @@ module Gori::Tui
         end
       end
 
-      hint = if @mode == :space
-               "↑/↓ select   ↵ run   o open   r rename   d delete   esc close"
-             elsif @selected >= 3
+      # Transient result of the last compaction, one row above the hint.
+      if flash = @flash
+        centered(screen, h - 3, flash, @flash_ok ? Theme.green : Theme.red, w)
+      end
+
+      hint = case
+             when @mode == :compress
+               "↑/↓ select   ‹/› keep   space toggle   ↵ compress   esc close"
+             when @mode == :compressing
+               "compressing …"
+             when @mode == :space
+               "↑/↓ select   ↵ run   o open   r rename   c compress   d delete   esc close"
+             when @selected >= 3
                "↑/↓ select   ↵ open   space actions   type to search   ctrl-d delete   ctrl-, settings   ctrl-c quit"
              else
                "↑/↓ select   ↵ open   type to search   ctrl-n new   ctrl-t temp   ctrl-d delete   ctrl-, settings   ctrl-c quit"
@@ -796,6 +961,17 @@ module Gori::Tui
         screen.text(box.x + 4, ry, entry.label, active ? Theme.text_bright : Theme.text, bg,
           width: {box.w - 5, 0}.max)
       end
+    end
+
+    # A small centered "Compressing …" card painted while the synchronous VACUUM
+    # runs (the picker has no background jobs / spinner), so the freeze reads as work.
+    private def render_compressing(screen : Screen, w : Int32, h : Int32) : Nil
+      msg = " Compressing … "
+      bw = {msg.size + 4, 22}.max
+      bh = 3
+      box = Rect.new({(w - bw) // 2, 0}.max, {(h - bh) // 2, 0}.max, bw, bh)
+      Frame.card(screen, box, border: Theme.border_focus)
+      screen.text(box.x + (box.w - msg.size) // 2, box.y + 1, msg, Theme.text_bright, Theme.panel, Attribute::Bold)
     end
 
     private def render_rename(screen : Screen, cx : Int32, cw : Int32, w : Int32, h : Int32) : Nil


### PR DESCRIPTION
## Summary

Adds a **Compress** action to the startup Projects picker space menu (`space → c`). It shrinks a not-yet-open project's `gori.db` by stripping the space-dominating data and running `VACUUM`, while keeping each flow's projection (URL/method/status/sizes/headers), the sitemap, issues, notes, scope and repeaters intact.

Picker-only and self-contained: the picker runs before any project opens, so the target is guaranteed not open in this process, and `CaptureLock.try` refuses when another live instance is capturing (same guard `ProjectRegistry#delete` uses).

## What's included

- **`src/gori/store/compact.cr`** (reopens `Gori::Store`):
  - `Store.measure(path)` — read-only per-category reclaimable-byte estimates for the popup.
  - `Store.compact(path, plan)` — capture-lock guarded; `Schema.migrate!`; strip in one transaction; `VACUUM` *outside* it (illegal inside a txn); re-harden `-wal`/`-shm` perms. Removes response/request bodies (→ `X''` + `*_body_truncated=1`, keeping true sizes), the raw HTTP/2 frame log, captured WebSocket payloads (`repeater_id IS NULL`), fuzzer result captures, and optionally the oldest flows (reusing `Store#prune`'s cascade).
- **`src/gori/tui/compact_overlay.cr`** — self-contained `CompactOverlay` scope popup modeled on `MineConfigOverlay`: checkboxes (Response bodies + HTTP/2 log default ON; request/ws/fuzz off) with measured sizes, a `keep newest flows` cycler, and a `[ Compress ]` row.
- **`src/gori/tui/project_picker.cr`** — `:compress`/`:compressing` modes, `space → c` entry, shared `ConfirmDialog` dispatched via `@confirm_kind`, and a green/red result flash.

## Test plan

- `crystal build src/main.cr -o bin/gori` — green.
- `crystal spec spec/store/compact_spec.cr` — 4/4 (rows preserved, bodies emptied + truncated flag, file shrank, `keep_flows` cascade, busy-refusal under the capture lock).
- `crystal spec spec/store spec/tui/space_menu_spec.cr` — 86/86, no regressions.
- TUI E2E (tmux, isolated `GORI_HOME`): captured ~1.4 MB of traffic into a `demo` project, then `space → c` → popup measured 394 KB of response bodies → confirm → **`compressed "demo"  676KB → 276KB  (−400KB)`**; re-measure confirmed bodies gone with the project intact.

> Note: `Project#db_size` counts only the main `gori.db` file, not the `-wal` sidecar — a live session can show a small "DB Size" while MBs sit in the WAL until it checkpoints on close.