### PR TITLE
fix(discover): parse sitemaps by response content, not discovery source

### DIFF
--- a/spec/discover/engine_spec.cr
+++ b/spec/discover/engine_spec.cr
@@ -172,6 +172,24 @@ describe Gori::Discover::Engine do
     kinds.should_not contain(:done) # a trailing Done would let a consumer settle "0 found" over the error
   end
 
+  it "follows a robots.txt Sitemap: URL at a non-standard path and extracts its <loc>s" do
+    cfg = D::Config.new(spider: true, bruteforce: false, max_depth: 5, concurrency: 1, retries: 0)
+    findings, _ = run_discover("http://t/", %w(), cfg) do |t|
+      case t
+      when "/"           then html("home, no links")
+      when "/robots.txt" then make(200, "User-agent: *\nSitemap: http://t/custom/sm.xml\n", "text/plain")
+      when "/sitemap.xml" then notfound # the well-known path is absent; only robots knows the real one
+      when "/custom/sm.xml"
+        make(200, %(<?xml version="1.0"?><urlset><url><loc>http://t/only-in-sitemap</loc></url></urlset>), "application/xml")
+      when "/only-in-sitemap" then html("the page only the sitemap knew about")
+      else                    notfound
+      end
+    end
+    # Under source-label parsing the custom sitemap was parsed as robots (no <loc>s) and this
+    # URL was lost; content-aware parsing recovers it.
+    findings.map(&.url).should contain("http://t/only-in-sitemap")
+  end
+
   it "confines a path-scoped run to the seed subtree" do
     cfg = D::Config.new(spider: true, bruteforce: false, max_depth: 4, concurrency: 1, retries: 0)
     findings, _ = run_discover("http://t/app/", %w(), cfg) do |t|

--- a/spec/discover/extract_spec.cr
+++ b/spec/discover/extract_spec.cr
@@ -31,4 +31,11 @@ describe Gori::Discover::Extract do
     links.should contain("http://h/page1")
     links.should contain("http://h/page2")
   end
+
+  it "sniffs sitemap bodies (urlset / sitemapindex / loc) apart from html and robots" do
+    E.sitemap_body?(%(<?xml version="1.0"?><urlset><url><loc>http://h/p</loc></url></urlset>).to_slice).should be_true
+    E.sitemap_body?(%(<sitemapindex><sitemap><loc>http://h/sm2.xml</loc></sitemap></sitemapindex>).to_slice).should be_true
+    E.sitemap_body?(%(<html><body><a href="/loc">not a sitemap</a></body></html>).to_slice).should be_false
+    E.sitemap_body?("User-agent: *\nDisallow: /admin\n".to_slice).should be_false
+  end
 end

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -516,18 +516,27 @@ module Gori::Discover
       raw = send_with_retries(task.url)
       body = decode_body(raw)
       fetched = distill(raw, body)
-      links = [] of RawLink
-      if raw.error.nil?
-        case task.source
-        when Source::Robots
-          Extract.from_robots(body).each { |h| links << RawLink.new(h, Source::Robots) }
-        when Source::Sitemap
-          Extract.from_sitemap(body).each { |h| links << RawLink.new(h, Source::Sitemap) }
-        else
-          Extract.from_html(body).each { |h| links << RawLink.new(h, Source::Crawled) } if html_like?(fetched.content_type)
-        end
-      end
+      links = raw.error.nil? ? extract_links(task, fetched, body) : EMPTY_LINKS
       Outcome.new(task, fetched, links, nil, false, 0.0)
+    end
+
+    # Pick the link extractor from the RESPONSE, not from how the URL was found. Only the
+    # well-known robots.txt (fetched by role at its fixed path) is parsed by label — it is
+    # plain text and never sniffable. Everything else defers to the body: a <loc>-bearing
+    # payload is a sitemap (the well-known /sitemap.xml, a <sitemapindex> child, OR a
+    # robots.txt `Sitemap:` URL at any path), and only genuine HTML is parsed as HTML. This
+    # stops a non-standard-path sitemap from being wrongly parsed as HTML and lost.
+    private def extract_links(task : Task, fetched : Calibrate::Fetched, body : Bytes) : Array(RawLink)
+      if task.kind.fetch? && task.source.robots?
+        return Extract.from_robots(body).map { |h| RawLink.new(h, Source::Robots) }
+      end
+      if Extract.sitemap_body?(body)
+        Extract.from_sitemap(body).map { |h| RawLink.new(h, Source::Sitemap) }
+      elsif html_like?(fetched.content_type)
+        Extract.from_html(body).map { |h| RawLink.new(h, Source::Crawled) }
+      else
+        EMPTY_LINKS
+      end
     end
 
     private def process_calibrate(task : Task) : Outcome

--- a/src/gori/discover/extract.cr
+++ b/src/gori/discover/extract.cr
@@ -42,7 +42,8 @@ module Gori::Discover
       out
     end
 
-    # sitemap.xml <loc> URLs.
+    # sitemap.xml <loc> URLs. Handles both a <urlset> (page URLs) and a <sitemapindex>
+    # (child-sitemap URLs) — both use <loc>, so index recursion falls out for free.
     def self.from_sitemap(body : Bytes) : Array(String)
       out = [] of String
       scan_text(body).scan(LOC) do |m|
@@ -50,6 +51,18 @@ module Gori::Discover
         out << v if v && !v.empty?
       end
       out
+    end
+
+    SNIFF_MAX     = 8192 # a sitemap's root element sits at the top; no need to read further
+    SITEMAP_ROOT = /<(?:urlset|sitemapindex|loc)\b/i
+
+    # Does this body look like an XML sitemap? Lets the engine pick the sitemap parser from
+    # the RESPONSE rather than from how the URL was found — so a sitemap served off the
+    # well-known /sitemap.xml path (a robots.txt `Sitemap:` URL, or a <sitemapindex> child)
+    # still gets its <loc> URLs extracted instead of being wrongly parsed as HTML/robots.
+    def self.sitemap_body?(body : Bytes) : Bool
+      slice = body.size > SNIFF_MAX ? body[0, SNIFF_MAX] : body
+      String.new(slice).scrub.matches?(SITEMAP_ROOT)
     end
 
     private def self.scan_text(body : Bytes) : String


### PR DESCRIPTION
## Summary

Discover picked its link extractor from **how a URL was found** (the discovery source label), not from the actual response. As a result a `robots.txt` `Sitemap:` directive pointing at a **non-standard path** (e.g. `/custom/sm.xml`) was crawled as `Source::Robots` and run through the robots parser — its `<loc>` entries were never read, so **every page that only the sitemap knew about was silently lost**.

## Fix

Choose the parser from the **response body**, not the source label:

- Only the well-known `robots.txt` (fixed path, plain text, un-sniffable) is parsed by role.
- Everything else defers to `Extract.sitemap_body?`: a `<loc>`-bearing payload is treated as a sitemap — covering the well-known `/sitemap.xml`, a `<sitemapindex>` child, **and** a `robots.txt` `Sitemap:` URL at any path — and only genuine HTML is parsed as HTML.

Side benefits from the same change:
- `<sitemapindex>` → child-sitemap recursion is now content-driven, not label-driven.
- HTML pages discovered via sitemap/robots used to hit the wrong parser and lose their links; they now parse as HTML correctly.

Note: this sitemap/robots seeding runs whenever spider mode is on (fetched at the origin root), not only when the seed path is `/`; this PR just makes the parsing correct.

## Tests
- New engine E2E: robots → non-standard-path sitemap → `<loc>` URL is discovered.
- New unit: `Extract.sitemap_body?` distinguishes `<urlset>` / `<sitemapindex>` / `<loc>` from HTML and robots.
- `crystal spec spec/discover/` → 38 examples, 0 failures. Full build green; no new ameba findings.