### PR TITLE
feat(history): delete/clear History from space menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Added — Delete / clear History from the space menu
+
+History can now drop captured flows without compacting the whole project:
+
+- **Delete flow** — Space → `X` on a selected list row (or the open detail) asks
+  once, then removes that flow plus its captured WS messages, FTS row, and flow
+  entity_links.
+- **Clear history** — Space → `C` asks once, then wipes every History flow for
+  the project (Repeater/Probe/Issues sessions stay; dangling sample-flow ids
+  resolve as “gone”).
+
+Both actions are space-menu only (no bare-key shortcut) and always confirm first.
+
 ### Added — Create issue/note while linking from History / Replay / …
 
 Space → **Link to issue** / **Link to note** (History, detail, Repeater, Fuzzer,

--- a/spec/store/store_spec.cr
+++ b/spec/store/store_spec.cr
@@ -255,6 +255,51 @@ describe Gori::Store do
     end
   end
 
+  it "delete_flow removes one flow and its captured WS/FTS/link dependents" do
+    with_store do |store|
+      keep = store.insert_flow(sample_request(target: "/keep"))
+      gone = store.insert_flow(sample_request(target: "/gone"))
+      store.insert_ws_message(gone, "client", 1, "hi".to_slice)
+      issue_id = store.insert_issue("t", Gori::Store::Severity::Info, nil, nil)
+      store.add_link(Gori::Store::LinkOwnerKind::Issue, issue_id,
+        Gori::Store::LinkRefKind::Flow, gone)
+      store.add_link(Gori::Store::LinkOwnerKind::Issue, issue_id,
+        Gori::Store::LinkRefKind::Flow, keep)
+
+      store.delete_flow(gone)
+
+      store.get_flow(gone).should be_nil
+      store.get_flow(keep).should_not be_nil
+      store.count.should eq(1)
+      store.count_ws_messages(gone).should eq(0)
+      store.list_links(Gori::Store::LinkOwnerKind::Issue, issue_id)
+        .map(&.ref_id).should eq([keep])
+    end
+  end
+
+  it "clear_flows wipes every History flow while sparing repeater-owned WS rows" do
+    with_store do |store|
+      a = store.insert_flow(sample_request(target: "/a"))
+      b = store.insert_flow(sample_request(target: "/b"))
+      store.insert_ws_message(a, "client", 1, "cap".to_slice)
+      # WebSocket-Repeater output: sentinel flow_id=0, keyed by repeater_id.
+      store.insert_ws_message(0_i64, "client", 1, "rep".to_slice, repeater_id: 9_i64)
+      issue_id = store.insert_issue("t", Gori::Store::Severity::Info, nil, nil)
+      store.add_link(Gori::Store::LinkOwnerKind::Issue, issue_id,
+        Gori::Store::LinkRefKind::Flow, a)
+
+      store.clear_flows
+
+      store.count.should eq(0)
+      store.get_flow(a).should be_nil
+      store.get_flow(b).should be_nil
+      store.count_ws_messages(a).should eq(0)
+      # Repeater-owned WS row survives (not keyed by a History flow).
+      store.@db.scalar("SELECT COUNT(*) FROM ws_messages WHERE repeater_id = 9").as(Int64).should eq(1)
+      store.list_links(Gori::Store::LinkOwnerKind::Issue, issue_id).should be_empty
+    end
+  end
+
   it "records a truncated body flag while keeping the TRUE wire size" do
     with_store do |store|
       stored = Bytes.new(8) { |i| (65 + i).to_u8 } # the capped 8-byte capture

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -49,6 +49,10 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def history_query : Nil; end
 
+  def history_delete : Nil; end
+
+  def history_clear : Nil; end
+
   def scroll_detail(delta : Int32) : Nil; end
 
   def detail_copy_selection : Nil; end

--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -885,6 +885,36 @@ describe Gori::Tui::HistoryView do
       rows.should_not contain("esc clears the filter") # would be misleading — esc won't unfilter
     end
   end
+
+  it "delete_by_id removes one flow and reloads the list" do
+    tmp_store do |store|
+      keep = add_flow(store, "GET", "/keep", 200)
+      gone = add_flow(store, "GET", "/gone", 200)
+      view = HistoryView.new
+      view.reload(store)
+      view.rows.size.should eq(2)
+      view.flow_summary(gone).should contain("GET")
+      view.flow_summary(gone).should contain("/gone")
+
+      view.delete_by_id(store, gone)
+      view.rows.map(&.id).should eq([keep])
+      store.get_flow(gone).should be_nil
+    end
+  end
+
+  it "clear wipes every flow and empties the list" do
+    tmp_store do |store|
+      add_flow(store, "GET", "/a", 200)
+      add_flow(store, "POST", "/b", 201)
+      view = HistoryView.new
+      view.reload(store)
+      view.rows.size.should eq(2)
+
+      view.clear(store)
+      view.empty?.should be_true
+      store.count.should eq(0)
+    end
+  end
 end
 
 describe Gori::Tui::Keybind do

--- a/spec/tui/space_menu_spec.cr
+++ b/spec/tui/space_menu_spec.cr
@@ -26,6 +26,8 @@ describe Gori::Tui::SpaceMenu do
 
     menu.verb_for('y').try(&.id).should eq("history.copy")
     menu.verb_for('r').try(&.id).should eq("history.repeater")
+    menu.verb_for('X').try(&.id).should eq("history.delete")
+    menu.verb_for('C').try(&.id).should eq("history.clear")
     menu.verb_for('Q').should be_nil # no entry bound to this key
   end
 
@@ -53,9 +55,11 @@ describe Gori::Tui::SpaceMenu do
     ids = menu.entries.map(&.id)
     ids.should contain("detail.repeater")     # flow action carried over from the list
     ids.should contain("detail.toggle-hex") # a detail-only view toggle
+    ids.should contain("detail.delete")     # destructive parity with the list menu
     menu.verb_for('r').try(&.id).should eq("detail.repeater")
     menu.verb_for('x').try(&.id).should eq("detail.select-line")
     menu.verb_for('e').try(&.id).should eq("detail.toggle-hex")
+    menu.verb_for('X').try(&.id).should eq("detail.delete")
   end
 
   it "lists the scope-rule actions in the Project scope pane (space replaced the lens toggle)" do

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -96,6 +96,14 @@ private class FakeContext < ExecContext
     @calls << :history_query
   end
 
+  def history_delete : Nil
+    @calls << :history_delete
+  end
+
+  def history_clear : Nil
+    @calls << :history_clear
+  end
+
   def scroll_detail(delta : Int32) : Nil
     @calls << :scroll_detail
   end

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -1624,6 +1624,46 @@ module Gori
       @db.scalar("SELECT COUNT(*) FROM flows").as(Int64)
     end
 
+    # Hard-delete one History flow and its captured dependents (WS messages, FTS row,
+    # entity_links that pointed at it). Issues/Probe/Repeater that referenced the id keep
+    # the dangling cross-ref — their resolvers already surface "gone". Writer-fiber only
+    # so it races cleanly with live capture; orphaned h2 frame logs are reaped by the
+    # retention prune (same as a single-id miss in keep_flows).
+    def delete_flow(id : Int64) : Nil
+      exec_task ->(c : DB::Connection) {
+        delete_flow_one(c, id)
+        nil
+      }
+    end
+
+    # Wipe every captured History flow in this project (and their WS/FTS/h2 logs and
+    # flow entity_links). Repeater-owned WS rows (repeater_id set) and workbench sessions
+    # are left intact. Issues/Probe keep dangling sample flow ids.
+    def clear_flows : Nil
+      exec_task ->(c : DB::Connection) {
+        # Captured WS only — WebSocket-Repeater output is keyed by repeater_id.
+        c.exec("DELETE FROM ws_messages WHERE repeater_id IS NULL")
+        # contentless FTS: per-row DELETE is a tombstone; wipe the whole index in one go
+        # so a large clear doesn't leave a full-size tombstone table behind.
+        c.exec("INSERT INTO flows_fts(flows_fts) VALUES('delete-all')")
+        c.exec("DELETE FROM entity_links WHERE ref_kind = 'flow'")
+        c.exec("DELETE FROM flows")
+        c.exec("DELETE FROM h2_frames")
+        c.exec("DELETE FROM h2_connections")
+        @pending_req_fts.clear
+        nil
+      }
+    end
+
+    # Cascade for one flow id (writer connection). Shared by delete_flow.
+    private def delete_flow_one(conn : DB::Connection, id : Int64) : Nil
+      conn.exec("DELETE FROM ws_messages WHERE flow_id = ? AND repeater_id IS NULL", id)
+      conn.exec("DELETE FROM flows_fts WHERE rowid = ?", id)
+      conn.exec("DELETE FROM entity_links WHERE ref_kind = 'flow' AND ref_id = ?", id)
+      conn.exec("DELETE FROM flows WHERE id = ?", id)
+      @pending_req_fts.delete(id)
+    end
+
     # Distinct host values for History QL Tab-complete (`host:`). Prefix-filtered
     # (case-insensitive), hard-capped so a huge capture history never materialises
     # the full DISTINCT set on every keystroke. Uses idx_flows_sitemap's leading

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -329,6 +329,36 @@ module Gori::Tui
       @host.status("filter: type a query · ↹ complete · ↵ apply · esc clear")
     end
 
+    # Space-menu delete: capture the flow id NOW so a live-capture reload between the
+    # confirm dialog open and confirm can't retarget the delete (same pattern as
+    # ProbeController#probe_delete). Works from the list or the open detail.
+    def history_delete : Nil
+      id = @host.overlay == :detail ? @history.detail_flow_id : @history.selected_id
+      return unless id
+      label = @history.flow_summary(id)
+      @host.confirm("DELETE FLOW", "Delete \"#{label}\"?\nThis can't be undone.",
+        confirm_label: "delete", danger: true) do
+        @history.delete_by_id(@host.session.store, id)
+        @host.request_overlay(:none) if @host.overlay == :detail
+        @host.status("deleted #{label}")
+      end
+    end
+
+    # Space-menu clear: wipe every History flow for this project after a confirm.
+    # Gates on the DB count (not the filtered list window) so a no-match QL filter
+    # doesn't hide the wipe when the project still has traffic.
+    def history_clear : Nil
+      n = @host.session.store.count
+      return if n <= 0
+      @host.confirm("CLEAR HISTORY",
+        "Delete ALL #{n} History flow#{n == 1 ? "" : "s"} for this project?\nThis can't be undone.",
+        confirm_label: "clear", danger: true) do
+        @history.clear(@host.session.store)
+        @host.request_overlay(:none) if @host.overlay == :detail
+        @host.status("history cleared")
+      end
+    end
+
     def scroll_detail(delta : Int32) : Nil
       @history.scroll_detail(delta)
     end

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -442,6 +442,44 @@ module Gori::Tui
       @rows[@selected]?.try(&.id)
     end
 
+    def empty? : Bool
+      @rows.empty?
+    end
+
+    # Selected list row (nil when empty) — used to name the flow in the delete confirm.
+    def selected_row : Store::FlowRow?
+      @rows[@selected]?
+    end
+
+    # Short "METHOD /path" label for confirm dialogs; falls back to "flow #id".
+    def flow_summary(id : Int64) : String
+      if (d = @detail) && d.row.id == id
+        return "#{d.row.method} #{Url.origin_path(d.row.target)}"
+      end
+      if (row = @rows.find { |r| r.id == id })
+        return "#{row.method} #{Url.origin_path(row.target)}"
+      end
+      "flow ##{id}"
+    end
+
+    # Hard-delete one flow by id, then re-anchor the list. Closes the detail if it was
+    # showing that flow. Id is captured by the controller at confirm-open time so a
+    # live-capture reload can't retarget the delete.
+    def delete_by_id(store : Store, id : Int64) : Nil
+      store.delete_flow(id)
+      close_detail if @detail.try(&.row.id) == id
+      clear_preview if @preview_id == id
+      reload(store)
+    end
+
+    # Wipe every History flow, close detail/preview, and reload the empty list.
+    def clear(store : Store) : Nil
+      store.clear_flows
+      close_detail
+      clear_preview
+      reload(store)
+    end
+
     # --- QL bar editing ------------------------------------------------------
 
     def start_query : Nil

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -5107,6 +5107,14 @@ module Gori::Tui
       history_controller.history_query
     end
 
+    def history_delete : Nil
+      history_controller.history_delete
+    end
+
+    def history_clear : Nil
+      history_controller.history_clear
+    end
+
     def scroll_detail(delta : Int32) : Nil
       # ↑ at the very top of the open detail pops focus up to the tab bar, mirroring
       # the list's ↑-at-top → TABS. current_scope keys off @overlay before @focus, so

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -49,6 +49,9 @@ module Gori
       abstract def selected_flow_id : Int64?
       abstract def copy_selection : Nil
       abstract def history_query : Nil # focus the QL filter bar
+      # History destructive actions (space-menu only; each opens a confirm first).
+      abstract def history_delete : Nil # delete the selected/open flow
+      abstract def history_clear : Nil  # wipe every History flow for this project
 
       # detail view
       abstract def scroll_detail(delta : Int32) : Nil

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -63,6 +63,18 @@ module Gori
         "history.probe-active", "Run active scan", "Run the Probe active checks against the selected flow (shows the request count first)",
         Verb::Scope::Body, available: history_selected, mnemonic: 'A') { |ctx| ctx.probe_active_selected; nil }
 
+      # Delete the selected flow (confirm-gated). Menu-only — L3 destructive; 'X' is free
+      # across Body COMMON (lowercase 'x' is select-line). Mirrors probe.delete-selected.
+      r.register Verb::Definition.new(
+        "history.delete", "Delete flow", "Delete the selected flow from History (asks first)",
+        Verb::Scope::Body, available: history_selected, mnemonic: 'X') { |ctx| ctx.history_delete; nil }
+
+      # Wipe the project's entire History (confirm-gated). Menu-only; 'C' is free across
+      # Body COMMON (lowercase 'c' is compare). Available whenever History has any rows.
+      r.register Verb::Definition.new(
+        "history.clear", "Clear history", "Delete ALL History flows for this project (asks first)",
+        Verb::Scope::Body, available: in_history, mnemonic: 'C') { |ctx| ctx.history_clear; nil }
+
       # --- repeater workbench (request editing is inline; these power the palette
       # and show their key hints — actual keys are handled directly by the TUI) ---
       in_repeater = ->(ctx : Verb::ExecContext) { ctx.current_tab == :repeater }
@@ -339,6 +351,13 @@ module Gori
       r.register Verb::Definition.new(
         "detail.probe-active", "Run active scan", "Run the Probe active checks against this flow (shows the request count first)",
         Verb::Scope::HistoryDetail, mnemonic: 'A') { |ctx| ctx.close_detail; ctx.probe_active_selected; nil }
+
+      # Delete the open flow (mirrors history.delete). Menu-only 'X' — free in HistoryDetail
+      # (lowercase 'x' is select-line). Confirm runs after the menu closes; the controller
+      # captures the id so a live reload can't retarget the delete.
+      r.register Verb::Definition.new(
+        "detail.delete", "Delete flow", "Delete this flow from History (asks first)",
+        Verb::Scope::HistoryDetail, mnemonic: 'X') { |ctx| ctx.history_delete; nil }
     end
 
     # Fuzzer/Intruder verbs: the cross-tab "send to Fuzzer" (⇧I from History, palette


### PR DESCRIPTION
## Summary
- History Space menu: **X** deletes the selected (or open) flow after confirm
- History Space menu: **C** clears all project History flows after confirm
- Store cascade removes captured WS messages, FTS rows, and flow entity_links; Repeater/Probe/Issues sessions stay

## Test plan
- [x] `crystal spec` for store delete/clear, history_view, space_menu mnemonics, verb registry
- [ ] Manual: History → Space → X on a row → confirm → row gone
- [ ] Manual: History → Space → C → confirm → list empty; Repeater sessions still present
- [ ] Manual: open detail → Space → X → confirm → detail closes, list updated