### PR TITLE
docs: logo mark, structure art, and landing hero copy

### DIFF
--- a/docs/i18n/en.toml
+++ b/docs/i18n/en.toml
@@ -35,7 +35,7 @@ home_link = "Return to home"
 
 [home]
 kicker = "HTTP intercepting proxy · TUI"
-title = "Intercept the web from your terminal."
+title = "Hack from the terminal."
 lede = "A fast, keyboard-driven HTTP/HTTPS proxy and security toolkit. Capture, repeater, fuzz, scan, or drive it all from an AI agent."
 cta_start = "Get started"
 cta_github = "View on GitHub"

--- a/docs/i18n/ko.toml
+++ b/docs/i18n/ko.toml
@@ -35,7 +35,7 @@ home_link = "홈으로 돌아가기"
 
 [home]
 kicker = "HTTP 인터셉트 프록시 · TUI"
-title = "터미널에서 웹을 인터셉트하세요."
+title = "터미널에서 해킹하세요."
 lede = "빠르고 키보드로 움직이는 HTTP/HTTPS 프록시이자 보안 툴킷. 캡처하고, 다시 보내고, 퍼징하고, 스캔하고, 필요하면 AI 에이전트에 통째로 맡길 수도 있습니다."
 cta_start = "시작하기"
 cta_github = "GitHub에서 보기"

--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -254,8 +254,8 @@ img {
    theme (warmer leaf on dark, deepened gold on light), so the mark stays legible
    in both. --logo-src is set inline in the template to carry base_url. */
 .logo-mark {
-  width: 2rem;
-  height: 1.8rem;
+  width: 2.75rem;
+  height: 2.5rem;
   background: var(--grad-gold-leaf);
   -webkit-mask: var(--logo-src) center / contain no-repeat;
   mask: var(--logo-src) center / contain no-repeat;
@@ -929,7 +929,7 @@ kbd {
   border-radius: 50%;
   background:
     radial-gradient(circle at 50% 46%, transparent 30%, rgb(4 5 10 / 0.55) 78%),
-    #0a0a0b url("../images/wallpaper.jpg") center / cover;
+    #0a0a0b url("../images/wallpaper.jpg") left / cover;
   box-shadow: var(--shadow-soft);
   outline: 1px solid rgb(var(--accent-rgb) / 0.2);
   outline-offset: 1.5rem;


### PR DESCRIPTION
## Summary
- Enlarge `.logo-mark` in the docs header (`2rem`/`1.8rem` → `2.75rem`/`2.5rem`)
- Set `.structure-art` wallpaper `background-position` to `left`
- Replace landing hero title with **Hack from the terminal.** (EN + KO)

## Test plan
- [ ] Open docs site header and confirm logo mark size looks balanced
- [ ] Check structure section circle art anchors left on the wallpaper
- [ ] Confirm EN/KO landing titles render the new copy