### PR TITLE
fix: 4-round review of today's new tabs + perf work (43 bugs)

### DIFF
--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -1429,7 +1429,7 @@ describe "Gori::Probe::Active::ForbiddenBypass" do
     end
   end
 
-  it "flags High only when the denied response flips to 2xx" do
+  it "flags a possible bypass (Medium) only when the denied response flips to 2xx" do
     with_store do |store|
       forbidden = capture_flow(store, "HTTP/1.1 403 Forbidden\r\n\r\n", target: "/admin", status: 403, content_type: nil)
       plan = probe.plan(forbidden).not_nil!
@@ -1438,7 +1438,8 @@ describe "Gori::Probe::Active::ForbiddenBypass" do
       dets = probe.detections(plan, bypassed, forbidden)
       dets.size.should eq(1)
       dets.first.code.should eq("forbidden_bypass")
-      dets.first.severity.should eq(Gori::Store::Severity::High)
+      # Single-shot flip vs the captured baseline (no control re-send) → Medium "possible", not High.
+      dets.first.severity.should eq(Gori::Store::Severity::Medium)
 
       # Still denied → the gate held → not flagged.
       still_denied = Gori::Repeater::Result.new("HTTP/1.1 403 Forbidden\r\n\r\n".to_slice, Bytes.empty, nil, 1_i64)

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -2852,7 +2852,7 @@ module Gori
         op = parse_rewriter_op(op_s)
         target = Store::RuleTarget.parse?(target_s) || abort("gori run rewriter add: invalid --target '#{target_s}'")
         part = Store::RulePart.parse?(part_s) || abort("gori run rewriter add: invalid --part '#{part_s}'")
-        match = Store::MatchKind.from_label(match_s.downcase)
+        match = Store::MatchKind.parse?(match_s) || abort("gori run rewriter add: invalid --match '#{match_s}' (literal|regex)")
         if op.replace? && match.regex? && !valid_regex?(f)
           abort "gori run rewriter add: invalid regex --find (failed to compile)"
         end
@@ -2971,7 +2971,7 @@ module Gori
         op = parse_rewriter_op(op_s)
         target = Store::RuleTarget.parse?(target_s) || abort("gori run rewriter preview: invalid --target '#{target_s}'")
         part = Store::RulePart.parse?(part_s) || abort("gori run rewriter preview: invalid --part '#{part_s}'")
-        match = Store::MatchKind.from_label(match_s.downcase)
+        match = Store::MatchKind.parse?(match_s) || abort("gori run rewriter preview: invalid --match '#{match_s}' (literal|regex)")
         part = Store::RulePart::Head if op.header?
 
         project = resolve_read_project(project_name, db_path)

--- a/src/gori/decoder/codecs.cr
+++ b/src/gori/decoder/codecs.cr
@@ -122,6 +122,11 @@ module Gori::Decoder
 
     def base32_decode(s : String) : Bytes
       bytes = s.to_slice
+      # A non-ASCII byte means the input may carry Unicode whitespace (nbsp, line/para
+      # separators) that the pre-rewrite char decoder skipped via Char#whitespace?. Take the
+      # tolerant char scan then, so a base32 blob pasted from a PDF/doc still decodes rather
+      # than raising on the whitespace's UTF-8 lead byte. Pure-ASCII keeps the fast byte loop.
+      return base32_decode_chars(s) if bytes.any? { |b| b >= 0x80 }
       buf = Bytes.new((bytes.size * 5) // 8 + 1) # upper bound (padding/ws over-counts)
       n = 0
       acc = 0_u32
@@ -130,6 +135,29 @@ module Gori::Decoder
         next if b == 0x3d_u8 || ascii_ws?(b) # '=' padding / whitespace
         v = B32_DEC[b]
         raise DecoderError.new("invalid base32 char: #{b.chr}") if v == 0xff_u8
+        acc = (acc << 5) | v.to_u32
+        bits += 5
+        if bits >= 8
+          bits -= 8
+          buf[n] = ((acc >> bits) & 0xff).to_u8
+          n += 1
+        end
+      end
+      buf[0, n]
+    end
+
+    # Unicode-whitespace-tolerant base32 decode (rare path): skips ANY whitespace char, not
+    # just ASCII, matching the decoder's behavior before the byte-level rewrite.
+    private def base32_decode_chars(s : String) : Bytes
+      buf = Bytes.new((s.bytesize * 5) // 8 + 1)
+      n = 0
+      acc = 0_u32
+      bits = 0
+      s.each_char do |c|
+        next if c == '=' || c.whitespace?
+        o = c.ord
+        v = o < 256 ? B32_DEC[o.to_u8] : 0xff_u8
+        raise DecoderError.new("invalid base32 char: #{c}") if v == 0xff_u8
         acc = (acc << 5) | v.to_u32
         bits += 5
         if bits >= 8

--- a/src/gori/discover/calibrate.cr
+++ b/src/gori/discover/calibrate.cr
@@ -98,7 +98,10 @@ module Gori::Discover
         case b.kind
         in BaselineKind::Normal           then 1.0
         in BaselineKind::WildcardRedirect then 0.8
-        in BaselineKind::WildcardOk       then 0.7
+        # A WildcardOk hit is gated on fp_novel && length_div (0.35 + 0.25 = 0.60); at 0.7 the
+        # product 0.42 could never clear the default 0.5 floor, so a genuinely content-divergent
+        # page on a 200-everything site was never reported. 0.85 → 0.51 lets a real divergence through.
+        in BaselineKind::WildcardOk       then 0.85
         in BaselineKind::Uncalibratable   then 0.6
         end
       {hit, (conf * penalty).clamp(0.0, 1.0)}

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -2800,6 +2800,17 @@ module Gori
         end)
       end
 
+      # Whether a rule's pattern is acceptable: only a Replace+Regex rule must compile; a
+      # literal or header-op rule is always fine. Mirrors the CLI's valid_regex? guard so the
+      # MCP surface rejects a bad pattern instead of persisting a rule that silently never fires.
+      private def valid_rule_regex?(op : Store::RuleOp, match_kind : Store::MatchKind, pattern : String) : Bool
+        return true unless op.replace? && match_kind.regex?
+        Regex.new(pattern)
+        true
+      rescue
+        false
+      end
+
       private def create_rule(h) : Result
         pattern = str(h, "pattern")
         return err("missing required 'pattern'", "INVALID_ARGUMENT", field: "pattern") if pattern.nil? || pattern.empty?
@@ -2810,6 +2821,11 @@ module Gori
         return ok if ok.is_a?(Result)
         op, match_kind = ok
         part = Store::RulePart::Head if op.header? # header ops are head-only
+        # Reject an uncompilable regex up front (the CLI does; the proxy would otherwise
+        # rescue the compile to passthrough and the rule would silently never fire).
+        unless valid_rule_regex?(op, match_kind, pattern)
+          return err("invalid regex pattern (failed to compile)", "INVALID_ARGUMENT", field: "pattern")
+        end
         replacement = str(h, "replacement") || ""
         name = str(h, "name") || ""
         host = str(h, "host") || ""
@@ -2846,6 +2862,9 @@ module Gori
         part = Store::RulePart::Head if op.header?
         pattern = present?(h, "pattern") ? str(h, "pattern") : existing.pattern
         return err("pattern must not be empty", "INVALID_ARGUMENT", field: "pattern") if pattern.nil? || pattern.empty?
+        unless valid_rule_regex?(op, match_kind, pattern)
+          return err("invalid regex pattern (failed to compile)", "INVALID_ARGUMENT", field: "pattern")
+        end
         replacement = present?(h, "replacement") ? (str(h, "replacement") || "") : existing.replacement
         name = present?(h, "name") ? (str(h, "name") || "") : existing.name
         host = present?(h, "host") ? (str(h, "host") || "") : existing.host

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -3622,7 +3622,10 @@ module Gori
         when Sequencer::DoneEvent
           sjob.collected = ev.collected
           sjob.sent = ev.sent
-          sjob.status = ev.stopped ? :stopped : :done
+          # A prior ErrorEvent (e.g. an invalid token regex) already set :error; the engine
+          # still emits a trailing DoneEvent, so preserve :error rather than reverting to :done
+          # (mirrors Fuzz/Miner terminal_status's `return :error if current == :error`).
+          sjob.status = ev.stopped ? :stopped : :done unless sjob.status == :error
           sjob.ended_at_ms = Time.utc.to_unix_ms
         when Sequencer::ErrorEvent
           sjob.status = :error

--- a/src/gori/probe/active/forbidden_bypass.cr
+++ b/src/gori/probe/active/forbidden_bypass.cr
@@ -8,12 +8,14 @@ module Gori
       # Active IP-header access-control bypass probe. Many gateways/apps gate a resource on the
       # *claimed* client IP (an allowlist, an "internal only" path, an admin panel), trusting a
       # proxy header like X-Forwarded-For instead of the real socket peer. Passive analysis can't
-      # tell such a control apart from any other 403/401; only re-sending the SAME request with a
-      # spoofed loopback IP in those headers proves the gate is header-controllable.
+      # tell such a control apart from any other 403/401; re-sending the SAME request with a
+      # spoofed loopback IP in those headers surfaces a candidate header-controllable gate.
       #
       # For one in-scope flow whose captured response was 401/403, it re-sends ONE request with the
-      # full IP-spoofing header set (all 127.0.0.1) and flags a High issue only when the response
-      # flips to 2xx — the definitive "access denied → granted by forging my IP" bypass. Gated to
+      # full IP-spoofing header set (all 127.0.0.1) and flags a Medium "possible bypass" when the
+      # response flips to 2xx. It is a single-shot probe against the CAPTURED baseline (no control
+      # re-send without the headers), so a transient/rate-limited 403 that later clears can also
+      # flip — hence "possible", to be confirmed by re-sending without the headers. Gated to
       # safe methods (GET/HEAD) so an automatic probe never mutates server state, and to originally-
       # denied responses so a normally-200 endpoint is never probed. A control that correctly keys
       # on the socket peer ignores the headers and still returns 401/403, so it is never flagged.
@@ -81,9 +83,13 @@ module Gori
           # ambiguous and would inflate false positives, so it is intentionally not flagged.
           return [] of Detection unless (200..299).includes?(status)
           orig = detail.row.status
+          # A single-shot flip against the CAPTURED baseline (no control re-send without the
+          # headers at probe time) can't prove the header caused it — a transient/rate-limited
+          # 403 that later clears looks identical. Report it as a Medium "possible" lead, not a
+          # confirmed High bypass, so a naturally-varying 403 doesn't produce a false High.
           [Detection.new("forbidden_bypass", Category::ACTIVE, detail.row.host, detail.row.url,
-            "Access control bypassed via spoofed client-IP header", Store::Severity::High,
-            "#{orig} → #{status} when X-Forwarded-For/X-Real-IP set to #{BYPASS_VALUE}", detail.row.id)]
+            "Possible access-control bypass via spoofed client-IP header", Store::Severity::Medium,
+            "#{orig} → #{status} with X-Forwarded-For/X-Real-IP=#{BYPASS_VALUE} (single-shot; confirm by re-sending WITHOUT the headers)", detail.row.id)]
         rescue
           [] of Detection
         end

--- a/src/gori/probe/passive/context.cr
+++ b/src/gori/probe/passive/context.cr
@@ -30,6 +30,7 @@ module Gori
         @client_body_text : String?
         @client_body_text_done = false
         @client_scripts : Array(String)?
+        @client_scripts_nocomment : Array(String)?
         @client_code : Array(String)?
 
         def initialize(@detail : Store::FlowDetail, @ws_messages = [] of Store::WsMessage)
@@ -154,6 +155,14 @@ module Gori
         # string or comment. Memoised so the lex runs at most once per flow.
         def client_code : Array(String)
           @client_code ||= client_scripts.map { |s| JsScan.strip(s) }
+        end
+
+        # The fragments with ONLY comments blanked (string/template CONTENTS kept). The
+        # string-literal-keyed rules (postMessage, prototype pollution) scan these so a
+        # "message"/"__proto__" inside a live string is still seen, but the same keyword in a
+        # commented-out example/debug line no longer false-matches. Memoised per flow.
+        def client_scripts_nocomment : Array(String)
+          @client_scripts_nocomment ||= client_scripts.map { |s| JsScan.strip_comments(s) }
         end
 
         # --- region text for user-defined custom match rules ---------------------------------

--- a/src/gori/probe/passive/dom_clobbering.cr
+++ b/src/gori/probe/passive/dom_clobbering.cr
@@ -21,7 +21,12 @@ module Gori
         end
 
         # Named member access into a live collection that HTML id/name attributes populate.
-        NAMED_COLLECTION = /\bdocument\.(?:forms|images|embeds|links|anchors|scripts|applets|all)\s*(?:\[|\.namedItem\b)/
+        # The bracket form requires a QUOTED string key (`['login']`) — a numeric/variable
+        # index (`[0]`, `[i]`) cannot be shadowed by an id/name element, so matching bare `[`
+        # fired on ubiquitous benign iteration like `document.images[0]`. Runs over stripped
+        # client_code, which blanks a string's contents but KEEPS its opening quote, so the
+        # quoted form still matches post-strip (`document.forms['x']` → `document.forms['']`).
+        NAMED_COLLECTION = /\bdocument\.(?:forms|images|embeds|links|anchors|scripts|applets|all)\s*(?:\[\s*["'`]|\.namedItem\b)/
         # `window.foo = window.foo || …` — reads a global back before defining it; a clobbering
         # element with that id/name can have already set it. Backreference pins both sides.
         CLOBBER_GUARD = /\bwindow\.([A-Za-z_$][\w$]*)\s*=\s*window\.\1\s*\|\|/

--- a/src/gori/probe/passive/js_scan.cr
+++ b/src/gori/probe/passive/js_scan.cr
@@ -100,19 +100,118 @@ module Gori
           String.build(js.bytesize) do |io|
             i = 0
             while i < n
+              if j = blank_token_at(chars, i, n, io)
+                i = j
+              else
+                io << chars[i]
+                i += 1
+              end
+            end
+          end
+        end
+
+        # If chars[i] starts a // or /* */ comment, blank it (→ spaces, offsets preserved) and
+        # return the index just past it; else nil. Shared by the string- and comment-strip lexers.
+        private def self.blank_comment_at(chars : Array(Char), i : Int32, n : Int32, io : IO) : Int32?
+          c = chars[i]
+          if c == '/' && i + 1 < n && chars[i + 1] == '/'
+            blank_line_comment(chars, i, n, io)
+          elsif c == '/' && i + 1 < n && chars[i + 1] == '*'
+            blank_block_comment(chars, i, n, io)
+          end
+        end
+
+        # If chars[i] starts a // comment, /* */ comment, or a '…'/"…"/`…` string, blank it
+        # (contents → spaces, offsets preserved) and return the index just past it; else nil.
+        # Shared by strip and emit_interpolation so the token lexing lives in one place.
+        private def self.blank_token_at(chars : Array(Char), i : Int32, n : Int32, io : IO) : Int32?
+          if j = blank_comment_at(chars, i, n, io)
+            j
+          else
+            c = chars[i]
+            (c == '\'' || c == '"' || c == '`') ? blank_string(chars, i, n, io) : nil
+          end
+        end
+
+        # Blank ONLY // and /* */ comments, keeping string/template CONTENTS intact (offsets
+        # preserved). For the string-literal-keyed rules (postMessage "message"/"*", prototype
+        # pollution "__proto__") that need those literals visible but must NOT match keywords
+        # inside commented-out example/debug code. Strings are copied verbatim so an embedded
+        # `//` or `/*` (e.g. in a URL literal) is not mistaken for a comment.
+        def self.strip_comments(js : String) : String
+          return js if js.empty?
+          chars = js.chars
+          n = chars.size
+          String.build(js.bytesize) do |io|
+            i = 0
+            while i < n
               c = chars[i]
               i = if c == '/' && i + 1 < n && chars[i + 1] == '/'
                     blank_line_comment(chars, i, n, io)
                   elsif c == '/' && i + 1 < n && chars[i + 1] == '*'
                     blank_block_comment(chars, i, n, io)
                   elsif c == '\'' || c == '"' || c == '`'
-                    blank_string(chars, i, n, io)
+                    copy_string(chars, i, n, io)
                   else
                     io << c
                     i + 1
                   end
             end
           end
+        end
+
+        # Copy a '…'/"…"/`…` literal verbatim (contents kept), consuming it so an embedded
+        # // or /* inside the string is not treated as a comment. Honors \\ escapes. For a
+        # template literal, a ${…} interpolation is CODE, not string content — it is consumed
+        # via copy_interpolation so a NESTED template's backtick inside ${…} is not mistaken
+        # for this template's closing delimiter (which would terminate early and re-lex the
+        # real remainder, blanking a URL's // as a comment).
+        private def self.copy_string(chars : Array(Char), i : Int32, n : Int32, io : IO) : Int32
+          quote = chars[i]
+          io << quote
+          i += 1
+          while i < n
+            ch = chars[i]
+            if ch == '\\' && i + 1 < n
+              io << ch << chars[i + 1]
+              i += 2
+              next
+            end
+            if quote == '`' && ch == '$' && i + 1 < n && chars[i + 1] == '{'
+              i = copy_interpolation(chars, i, n, io)
+              next
+            end
+            io << ch
+            i += 1
+            break if ch == quote
+          end
+          i
+        end
+
+        # Consume a template ${…} interpolation for the comment-only strip: blank real code
+        # comments inside it, but COPY string literals verbatim (so their contents stay for the
+        # string-key rules), tracking brace depth to find the matching `}`. Recurses through
+        # copy_string for nested strings/templates. `i` points at `$`. Offset-preserving.
+        private def self.copy_interpolation(chars : Array(Char), i : Int32, n : Int32, io : IO) : Int32
+          io << '$' << '{'
+          i += 2
+          depth = 1
+          while i < n && depth > 0
+            ch = chars[i]
+            if ch == '{' || ch == '}'
+              depth += ch == '{' ? 1 : -1
+              io << ch
+              i += 1
+            elsif j = blank_comment_at(chars, i, n, io) # real code comment inside ${…} → blank
+              i = j
+            elsif ch == '\'' || ch == '"' || ch == '`'
+              i = copy_string(chars, i, n, io) # string content kept
+            else
+              io << ch
+              i += 1
+            end
+          end
+          i
         end
 
         # Blank a // comment through end-of-line (the terminating newline is left to the caller).
@@ -142,6 +241,10 @@ module Gori
         end
 
         # Blank a '…' / "…" / `…` literal's CONTENTS (delimiters kept), honoring \\ escapes.
+        # For a template literal a `${…}` interpolation is CODE, not string content, so its
+        # expression is emitted (via emit_interpolation) instead of blanked — otherwise the
+        # common template-literal sink shape (innerHTML = `${location.hash}`) would lose its
+        # source and DOM-XSS would miss it.
         private def self.blank_string(chars : Array(Char), i : Int32, n : Int32, io : IO) : Int32
           quote = chars[i]
           io << quote # opening delimiter kept
@@ -158,8 +261,36 @@ module Gori
               i += 1
               break
             end
+            if quote == '`' && ch == '$' && i + 1 < n && chars[i + 1] == '{'
+              i = emit_interpolation(chars, i, n, io) # ${…} expression kept as code
+              next
+            end
             io << ' ' # content blanked (incl. newlines inside a template)
             i += 1
+          end
+          i
+        end
+
+        # Emit a template-literal `${…}` interpolation as CODE: keep the expression visible so
+        # source/sink keywords inside it survive, but blank nested strings/comments (so their
+        # CONTENTS can't false-match) and track brace depth to find the matching `}`. Every
+        # consumed char emits exactly one char, so offsets stay aligned. `i` points at `$`.
+        private def self.emit_interpolation(chars : Array(Char), i : Int32, n : Int32, io : IO) : Int32
+          io << '$' << '{'
+          i += 2
+          depth = 1
+          while i < n && depth > 0
+            ch = chars[i]
+            if ch == '{' || ch == '}'
+              depth += ch == '{' ? 1 : -1
+              io << ch
+              i += 1
+            elsif j = blank_token_at(chars, i, n, io) # nested string/comment (recurses for a nested template)
+              i = j
+            else
+              io << ch
+              i += 1
+            end
           end
           i
         end

--- a/src/gori/probe/passive/js_scan.cr
+++ b/src/gori/probe/passive/js_scan.cr
@@ -276,14 +276,17 @@ module Gori
         # CONTENTS can't false-match) and track brace depth to find the matching `}`. Every
         # consumed char emits exactly one char, so offsets stay aligned. `i` points at `$`.
         private def self.emit_interpolation(chars : Array(Char), i : Int32, n : Int32, io : IO) : Int32
-          io << '$' << '{'
+          io << "  " # blank the '${' delimiter (2 spaces, offset-preserved): keeps the inner
+          #            expression as code but removes the '{' so source_in_window's /[;{}\n]/
+          #            statement-boundary scan doesn't truncate the window at the interpolation
+          #            (else `innerHTML = `${location.hash}`` loses its source and DOM-XSS misses it)
           i += 2
           depth = 1
           while i < n && depth > 0
             ch = chars[i]
             if ch == '{' || ch == '}'
               depth += ch == '{' ? 1 : -1
-              io << ch
+              io << (ch == '}' && depth == 0 ? ' ' : ch) # blank the OUTER closing '}'; keep inner braces
               i += 1
             elsif j = blank_token_at(chars, i, n, io) # nested string/comment (recurses for a nested template)
               i = j

--- a/src/gori/probe/passive/post_message.cr
+++ b/src/gori/probe/passive/post_message.cr
@@ -4,8 +4,9 @@ module Gori
   module Probe
     module Passive
       # Cross-origin messaging weaknesses (category "client") — the "other client-side sink
-      # points" family, centred on window.postMessage. Three signals, over the RAW fragments
-      # (Context#client_scripts) because two of them key on string literals ("message", "*"):
+      # points" family, centred on window.postMessage. Three signals, over the comment-stripped
+      # fragments (Context#client_scripts_nocomment): string literals ("message", "*") stay
+      # visible for the string-key form, but commented-out example code no longer false-matches:
       #   * a message handler that never consults an origin (no `.origin` anywhere in the
       #     script) — the classic missing sender check that lets any frame drive the handler;
       #   * postMessage(data, "*") — a wildcard target origin, leaking the message to any
@@ -29,7 +30,7 @@ module Gori
         DOMAIN_SET = /\bdocument\.domain\s*=(?!=)/
 
         def check(ctx : Context, acc : Array(Detection)) : Nil
-          scripts = ctx.client_scripts
+          scripts = ctx.client_scripts_nocomment # keep string literals, drop comments (no commented-out-code FPs)
           return if scripts.empty?
           emitted = Set(String).new
           scripts.each do |code|

--- a/src/gori/probe/passive/prototype_pollution.cr
+++ b/src/gori/probe/passive/prototype_pollution.cr
@@ -9,9 +9,10 @@ module Gori
       #     that is classically pollution-prone ($.extend(true,…), lodash merge/set); and
       #   * a request whose query/body carries a `__proto__` / `constructor[prototype]` key — a
       #     real pollution surface, or an in-flight probe against a nested-param parser.
-      # Scans the RAW fragments (Context#client_scripts) because the string-key form keeps the
-      # "__proto__" inside a string literal. Kept Low: the JS shapes appear in benign library
-      # code too, so these are leads, not confirmations.
+      # Scans the comment-stripped fragments (Context#client_scripts_nocomment): string literals
+      # stay visible so the "__proto__" string-key form is kept, but a commented-out example
+      # no longer false-matches. Kept Low: the JS shapes appear in benign library code too, so
+      # these are leads, not confirmations.
       class PrototypePollution < Rule
         def info : RuleInfo
           RuleInfo.new("prototype_pollution", "Prototype pollution (suspected)",
@@ -36,7 +37,7 @@ module Gori
         def check(ctx : Context, acc : Array(Detection)) : Nil
           check_request(ctx, acc)
           seen = Set(String).new
-          ctx.client_scripts.each do |code|
+          ctx.client_scripts_nocomment.each do |code| # keep string keys, drop comments (no commented-out-code FPs)
             SINK_PATTERNS.each do |(re, label)|
               next unless re.matches?(code)
               next unless seen.add?(label)

--- a/src/gori/repeater/minimize.cr
+++ b/src/gori/repeater/minimize.cr
@@ -69,7 +69,11 @@ module Gori::Repeater
     private record Baseline,
       status : Int32?,
       length : Int64, words : Int32, lines : Int32,
-      length_tol : Int64, words_tol : Int32, lines_tol : Int32
+      length_tol : Int64, words_tol : Int32, lines_tol : Int32,
+      # Behavior-relevant response headers that stayed STABLE across the calibration rounds.
+      # A variant that changes any of these is treated as CHANGED (kept), so a param whose
+      # only effect is on headers (redirect target, Set-Cookie, CORS, auth) is not false-stripped.
+      stable_headers : Hash(String, String)
 
     # One removable item + how to excise it from the working text (nil = it no longer
     # applies, e.g. an earlier removal already took it). Holding the excision as a closure
@@ -94,10 +98,14 @@ module Gori::Repeater
       sends = 0
       # --- calibrate a FROZEN baseline from the original request ---
       metrics = [] of Fuzz::Metrics
+      sigs = [] of Hash(String, String)
       CALIBRATION_ROUNDS.times do
         r = backend.send(resolve.call(base_text))
         sends += 1
-        metrics << Miner::Fingerprint.probe(r).metrics if r.error.nil? && !r.incomplete?
+        if r.error.nil? && !r.incomplete?
+          metrics << Miner::Fingerprint.probe(r).metrics
+          sigs << behavior_signature(r.head)
+        end
       end
       return Report.new(base_text, [] of Removed, sends, true, "baseline unreachable — request left unchanged") if metrics.empty?
       statuses = metrics.compact_map(&.status).uniq!
@@ -105,7 +113,7 @@ module Gori::Repeater
         return Report.new(base_text, [] of Removed, sends, true,
           "baseline response unstable (status #{statuses.join("/")}) — request left unchanged")
       end
-      baseline = calibrate(metrics)
+      baseline = calibrate(metrics, sigs)
 
       # --- greedy: try each candidate against the CURRENT working text, keep the removal
       # only if the response is still within tolerance of the frozen baseline ---
@@ -232,7 +240,46 @@ module Gori::Repeater
 
     # ── comparison ─────────────────────────────────────────────────────────────────────
 
-    private def self.calibrate(metrics : Array(Fuzz::Metrics)) : Baseline
+    # Behavior-relevant response headers whose value carries request semantics beyond the
+    # body — a param that only moves these (a redirect target, a Set-Cookie, CORS/auth) must
+    # not be silently stripped. Set-Cookie is handled separately (by cookie NAME, since its
+    # value rotates); the rest compare by value. Only ones stable across calibration are used.
+    BEHAVIOR_HEADERS = %w(location content-type content-disposition
+      access-control-allow-origin access-control-allow-credentials www-authenticate)
+
+    # Normalized signature of a response's behavior-relevant headers (empty when the head
+    # can't be parsed). Set-Cookie reduces to its sorted cookie NAMES so a rotating session/
+    # CSRF value doesn't itself read as a change.
+    private def self.behavior_signature(head : Bytes) : Hash(String, String)
+      sig = {} of String => String
+      return sig if head.empty?
+      resp = (Proxy::Codec::Http1.parse_response_head(head) rescue nil)
+      return sig unless resp
+      BEHAVIOR_HEADERS.each do |h|
+        if v = resp.headers.get?(h)
+          sig[h] = v.strip
+        end
+      end
+      names = resp.headers.get_all("set-cookie").compact_map { |sc| (eq = sc.index('=')) ? sc[0...eq].strip : nil }
+      sig["set-cookie-names"] = names.uniq!.sort!.join(",") unless names.empty?
+      sig
+    end
+
+    # The subset of behavior headers that held an identical value across EVERY calibration
+    # round — a naturally-rotating header (per-request token in Location, a Date-y header)
+    # varies across rounds and is dropped, so it can't cause a false "changed". Require ≥2
+    # successful samples: a single sample would mark EVERY header "stable" (all? is vacuously
+    # true), gating a rotating header as changed and regressing minimize to remove-nothing.
+    private def self.stable_headers(sigs : Array(Hash(String, String))) : Hash(String, String)
+      return {} of String => String if sigs.size < 2
+      stable = {} of String => String
+      sigs.first.each do |k, v|
+        stable[k] = v if sigs.all? { |s| s[k]? == v }
+      end
+      stable
+    end
+
+    private def self.calibrate(metrics : Array(Fuzz::Metrics), sigs : Array(Hash(String, String))) : Baseline
       base = metrics.first
       lengths = metrics.map(&.length)
       words = metrics.map(&.words)
@@ -242,19 +289,24 @@ module Gori::Repeater
       length_tol = {(lengths.max - lengths.min) * 2, {8_i64, base.length // 100}.max}.max
       words_tol = {(words.max - words.min) * 2, {3, base.words // 100}.max}.max
       lines_tol = {(lines.max - lines.min) * 2, {2, base.lines // 100}.max}.max
-      Baseline.new(base.status, base.length, base.words, base.lines, length_tol, words_tol, lines_tol)
+      Baseline.new(base.status, base.length, base.words, base.lines, length_tol, words_tol, lines_tol, stable_headers(sigs))
     end
 
-    # A variant's response is "unchanged" when the status matches and every metric is within
-    # its tolerance band. An errored or truncated send is treated as CHANGED (its metrics are
-    # unreliable), so the candidate is kept.
+    # A variant's response is "unchanged" when the status matches, every body metric is within
+    # its tolerance band, AND every stable behavior header still holds its baseline value. An
+    # errored or truncated send is treated as CHANGED (its metrics are unreliable), so the
+    # candidate is kept.
     private def self.unchanged?(r : Result, b : Baseline) : Bool
       return false unless r.error.nil? && !r.incomplete?
       m = Miner::Fingerprint.probe(r).metrics
-      m.status == b.status &&
-        (m.length - b.length).abs <= b.length_tol &&
-        (m.words - b.words).abs <= b.words_tol &&
-        (m.lines - b.lines).abs <= b.lines_tol
+      return false unless m.status == b.status &&
+                          (m.length - b.length).abs <= b.length_tol &&
+                          (m.words - b.words).abs <= b.words_tol &&
+                          (m.lines - b.lines).abs <= b.lines_tol
+      # A variant that moved any stable behavior header (redirect target, Set-Cookie set,
+      # CORS/auth) is CHANGED — keep the param even though the body/status matched.
+      sig = behavior_signature(r.head)
+      b.stable_headers.all? { |k, v| sig[k]? == v }
     end
 
     # ── text helpers (operate on the LF editor form; resolve() handles CRLF for the wire) ─

--- a/src/gori/rules.cr
+++ b/src/gori/rules.cr
@@ -17,10 +17,12 @@ module Gori
       @mutex = Mutex.new
       # Lock-free fast-path flags: rewrite_* run on EVERY message, but the common case
       # is no rule for that side/part. These let the hot path skip the mutex + select-
-      # array allocation entirely when nothing would match. `@head_count` gates the head
-      # rewrite (replace-head AND the header ops, which all act on the head); the two body
-      # counts also gate whether ClientConn buffers a body at all.
-      @head_count = Atomic(Int32).new(active_count(@rules, part: Store::RulePart::Head))
+      # array allocation entirely when nothing would match. The head counts gate the head
+      # rewrite (replace-head AND the header ops, which all act on the head), split PER
+      # DIRECTION like the body counts so a request-only rule doesn't tax every response
+      # (and vice versa); the body counts also gate whether ClientConn buffers a body at all.
+      @req_head_count = Atomic(Int32).new(active_count(@rules, Store::RuleTarget::Request, part: Store::RulePart::Head))
+      @resp_head_count = Atomic(Int32).new(active_count(@rules, Store::RuleTarget::Response, part: Store::RulePart::Head))
       @req_body_count = Atomic(Int32).new(active_count(@rules, Store::RuleTarget::Request, part: Store::RulePart::Body))
       @resp_body_count = Atomic(Int32).new(active_count(@rules, Store::RuleTarget::Response, part: Store::RulePart::Body))
     end
@@ -98,11 +100,11 @@ module Gori
     # --- HeadRewriter (called from proxy fibers) -----------------------------
 
     def rewrite_request(head : Bytes, host : String) : Bytes
-      apply(head, Store::RuleTarget::Request, Store::RulePart::Head, @head_count, host)
+      apply(head, Store::RuleTarget::Request, Store::RulePart::Head, @req_head_count, host)
     end
 
     def rewrite_response(head : Bytes, host : String) : Bytes
-      apply(head, Store::RuleTarget::Response, Store::RulePart::Head, @head_count, host)
+      apply(head, Store::RuleTarget::Response, Store::RulePart::Head, @resp_head_count, host)
     end
 
     # A body rule is live iff at least one enabled, non-empty rule targets that side's
@@ -319,7 +321,8 @@ module Gori
     private def refresh : Nil
       fresh = @store.match_rules
       @mutex.synchronize { @rules = fresh }
-      @head_count.set(active_count(fresh, part: Store::RulePart::Head))
+      @req_head_count.set(active_count(fresh, Store::RuleTarget::Request, part: Store::RulePart::Head))
+      @resp_head_count.set(active_count(fresh, Store::RuleTarget::Response, part: Store::RulePart::Head))
       @req_body_count.set(active_count(fresh, Store::RuleTarget::Request, part: Store::RulePart::Body))
       @resp_body_count.set(active_count(fresh, Store::RuleTarget::Response, part: Store::RulePart::Body))
     end

--- a/src/gori/rules.cr
+++ b/src/gori/rules.cr
@@ -252,9 +252,13 @@ module Gori
       h = host.downcase
       g = glob.downcase
       if g.includes?('*')
+        # Compile the glob→regex ONCE per distinct glob, not per proxied head. host_matches?
+        # runs on the hot path for EVERY request/response head while any head rule is active
+        # (including messages the rule doesn't target — the scope test is what decides that),
+        # so an uncached Regex.new here was a PCRE2 compile per message. SafeRegexp memoises.
         rx = "^#{Regex.escape(g).gsub("\\*", ".*")}$"
         begin
-          Regex.new(rx).matches?(h)
+          SafeRegexp.compile(rx).matches?(h)
         rescue
           false
         end
@@ -267,6 +271,12 @@ module Gori
 
     RULE_PREVIEW_SCAN = 500
 
+    # Cap the body bytes pulled per flow for a BODY rule preview: this runs on the
+    # interactive keystroke path, so never fetch multi-MiB bodies. Head/header rules read
+    # no body at all (body_max: 0). A body match past the cap is missed — acceptable since
+    # the preview is already documented as approximate.
+    RULE_PREVIEW_BODY_MAX = 64 * 1024
+
     record Preview, scanned : Int32, matched : Int32, total : Int64
 
     # How many of up to `limit` recent stored flows a candidate rule WOULD affect, by
@@ -276,8 +286,12 @@ module Gori
     def preview(rule : Store::MatchRule, limit : Int32 = RULE_PREVIEW_SCAN) : Preview
       scanned = 0
       matched = 0
+      # Head/header rules never touch the body, so fetch head-only; body rules cap the
+      # fetched bytes. Without this the preview pulled every flow's FULL request+response
+      # body into memory per keystroke, stalling proportionally to stored body size.
+      body_max = rule.part.body? ? RULE_PREVIEW_BODY_MAX : 0
       @store.recent_flows(limit, nil).each do |row|
-        detail = @store.get_flow(row.id)
+        detail = @store.get_flow(row.id, body_max: body_max)
         next unless detail
         scanned += 1
         matched += 1 if rule_affects?(rule, detail)

--- a/src/gori/sequencer/engine.cr
+++ b/src/gori/sequencer/engine.cr
@@ -35,6 +35,7 @@ module Gori::Sequencer
     @idx : Int32
     @dispatched : Int32
     @last_dispatch : Time::Instant
+    @token_re : Regex? = nil # Regex token descriptor compiled ONCE per run (see run_live)
 
     def initialize(@request : Bytes, @http2 : Bool, backend : Fuzz::Backend, @config : Config)
       @backend = Fuzz::CappedBackend.new(backend, @config.max_requests)
@@ -112,6 +113,20 @@ module Gori::Sequencer
     end
 
     private def run_live : Nil
+      # Compile the Regex token descriptor ONCE up front instead of per response. A bad
+      # pattern is reported to the operator as a clean error (via orchestrate's ErrorEvent
+      # + DoneEvent) rather than raising per-sample inside a worker fiber — which would dump
+      # an "Unhandled exception in spawn" trace over the TUI alt-screen and leak the
+      # dispatcher fiber blocked on `jobs.send`. Crystal raises ArgumentError (not only
+      # Regex::Error) for an invalid pattern, so catch both.
+      if @config.token_loc.kind.regex? && !@config.token_loc.selector.empty?
+        begin
+          @token_re = Regex.new(@config.token_loc.selector)
+        rescue ex : ArgumentError | Regex::Error
+          @events.send(ErrorEvent.new("invalid token regex: #{ex.message}"))
+          return
+        end
+      end
       interval = pace_interval
       # Int32 job tokens (not Channel(Nil)): with a Nil channel, `receive?` returns nil
       # for BOTH a sent value and a closed channel, so the worker loop can't tell a job
@@ -157,7 +172,7 @@ module Gori::Sequencer
     private def process_one : Nil
       raw = send_with_retries(@request)
       @sent += 1
-      token = Extract.extract(raw, @config.token_loc)
+      token = Extract.extract(raw, @config.token_loc, @token_re)
       idx = (@idx += 1)
       status = raw.response.try(&.status)
       len = token.try(&.bytesize) || 0

--- a/src/gori/sequencer/extract.cr
+++ b/src/gori/sequencer/extract.cr
@@ -11,12 +11,14 @@ module Gori::Sequencer
   # miss (no match / out of range / no such header) rather than raising, so one bad
   # descriptor yields empty samples instead of killing the collection fiber.
   module Extract
-    def self.extract(raw : Repeater::Result, loc : TokenLoc) : String?
+    # `re` is the token regex compiled ONCE by the engine (see Engine#run_live); when given
+    # it is reused per response instead of recompiling the pattern every sample.
+    def self.extract(raw : Repeater::Result, loc : TokenLoc, re : Regex? = nil) : String?
       return nil unless raw.error.nil?
       case loc.kind
       in ExtractKind::Cookie   then cookie(raw, loc.selector)
       in ExtractKind::Header   then header(raw, loc.selector)
-      in ExtractKind::Regex    then regex(raw, loc.selector)
+      in ExtractKind::Regex    then regex(raw, loc.selector, re)
       in ExtractKind::Position then position(raw, loc.pos_start, loc.pos_end)
       in ExtractKind::JsonPath then json_path(raw, loc.selector)
       end
@@ -45,16 +47,20 @@ module Gori::Sequencer
     end
 
     # Capture group 1 (else the whole match) of `pattern` over the decoded body —
-    # same semantics as Fuzz::Matcher#extract_value. A runaway regex yields nil.
-    def self.regex(raw : Repeater::Result, pattern : String) : String?
+    # same semantics as Fuzz::Matcher#extract_value. `re`, when passed, is the pattern
+    # precompiled once by the engine; otherwise it is compiled here (fallback path for
+    # any direct caller). A malformed pattern raises ArgumentError (not only Regex::Error)
+    # on Crystal — catch both so one bad descriptor yields empty samples, never a crash,
+    # honouring this module's "returns nil on a miss rather than raising" contract.
+    def self.regex(raw : Repeater::Result, pattern : String, re : Regex? = nil) : String?
       return nil if pattern.empty?
-      re = Regex.new(pattern)
+      re ||= Regex.new(pattern)
       text = decoded_text(raw)
       return nil if text.empty?
       md = re.match(text)
       return nil unless md
       md[1]? || md[0]
-    rescue Regex::Error
+    rescue ArgumentError | Regex::Error
       nil
     end
 

--- a/src/gori/sequencer/stats.cr
+++ b/src/gori/sequencer/stats.cr
@@ -146,6 +146,11 @@ module Gori::Sequencer
       idx_of = Hash(UInt8, Int32).new
       present.each_with_index { |b, i| idx_of[b] = i }
       bps = charset_size <= 1 ? 0 : Math.log2(charset_size.to_f).ceil.to_i
+      # The fixed-width symbol-bit encoding is only unbiased when the alphabet size is a
+      # power of two (hex=16, base64=64). For a non-power-of-2 alphabet (decimal=10,
+      # base62, …) the unused high index bits are structurally starved of 1s, so the raw
+      # bit tests would FAIL a genuinely-random token. Gate their FAIL contribution below.
+      pow2 = charset_size > 0 && (charset_size & (charset_size - 1)) == 0
 
       # Per-symbol-bit bias over the fixed common prefix (feeds the chart + a test).
       prefix_bits = min_len * bps
@@ -169,14 +174,14 @@ module Gori::Sequencer
       tests << uniqueness_test(unique, n, duplicate_count)
       tests << TestRow.new("Sequential", seq ? "detected" : "none", seq_detail,
         seq ? Verdict::Fail : Verdict::Pass)
-      tests << monobit_test(bits, small)
-      tests << poker_test(bits, small)
-      tests << runs_test(bits, small)
-      tests << longrun_test(bits, small)
+      tests << gate_bits(monobit_test(bits, small), pow2)
+      tests << gate_bits(poker_test(bits, small), pow2)
+      tests << gate_bits(runs_test(bits, small), pow2)
+      tests << gate_bits(longrun_test(bits, small), pow2)
       tests << chi_square_test(gcounts, present, total_bytes, small)
       tests << serial_test(sym_seq, small)
       tests << compression_test(usable, total_bytes, charset_size, small)
-      tests << bit_bias_test(ones_at, n, small)
+      tests << gate_bits(bit_bias_test(ones_at, n, small), pow2)
 
       rating = rate(effective, duplicate_count, seq, tests, small)
 
@@ -190,6 +195,17 @@ module Gori::Sequencer
         sequential: seq, rating: rating, tests: tests,
         char_counts: char_counts, len_hist: len_hist, len_min: len_min, len_max: len_max,
         per_pos_entropy: per_pos, bit_bias: bit_bias)
+    end
+
+    # A raw fixed-width bit test (monobit/poker/runs/long-run/bit-bias) only measures true
+    # randomness for a power-of-two alphabet. For any other alphabet a genuinely-random token
+    # fails spuriously, so a FAIL is downgraded to INFO — it no longer penalizes the rating
+    # (rate counts only .fail?) and is labelled as not applicable. The encoding-neutral tests
+    # (chi-square on byte frequencies, serial on symbol indices, compression vs the log2(charset)
+    # floor) stay active, so real weakness is still caught.
+    private def self.gate_bits(row : TestRow, pow2 : Bool) : TestRow
+      return row if pow2 || !row.verdict.fail?
+      TestRow.new(row.name, row.value, "#{row.detail} · n/a for non-power-of-2 alphabet", Verdict::Info)
     end
 
     # ── rating ────────────────────────────────────────────────────────────────────

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -30,7 +30,11 @@ module Gori
     # How many body bytes the proxy CAPTURES + stores per request/response (settings:network).
     # A change only affects flows captured AFTER it (buffers allocate at request start). MiB, min 1.
     DEFAULT_CAPTURE_MAX_MIB = 2
-    DEFAULT_EDITOR          = ""
+    # Upper bound on the capture cap: the byte product (mib*1024*1024) MUST stay within
+    # Int32 or every read on the proxy hot path raises OverflowError and drops the
+    # connection. 2047 MiB = 2_146_435_072 bytes < Int32::MAX. Clamped at read AND input.
+    MAX_CAPTURE_MAX_MIB = 2047
+    DEFAULT_EDITOR      = ""
     DEFAULT_EDITOR_MARKDOWN = true
     DEFAULT_THEME           = "goridark"
     DEFAULT_MOUSE           = true
@@ -55,6 +59,9 @@ module Gori
     DEFAULT_HISTORY_TIME_FORMAT = "absolute" # "absolute" | "relative"
     DEFAULT_SHOW_GUTTER         = true
     DEFAULT_PREVIEW_BODY_KIB    = 64
+    # Upper bound on the preview cap (KiB): kib*1024 must stay within Int32 or
+    # preview_body_cap raises on the History navigation path. 65536 KiB = 64 MiB.
+    MAX_PREVIEW_BODY_KIB = 65536
     # Notifications (settings:notifications): bell = terminal beep on a background result/alert;
     # toast = also flash a bottom-bar toast for fuzzer/probe/discover results; retention = ring
     # buffer size. All opt-in-friendly defaults (bell off; toast on; 100 kept).
@@ -97,8 +104,10 @@ module Gori
     end
 
     # The capture cap in BYTES — the value CaptureBuffer/import bound a body to.
+    # Clamped so a large (or hand-edited) MiB value can never overflow Int32 and break
+    # the proxy hot path (see MAX_CAPTURE_MAX_MIB).
     def self.capture_max : Int32
-      capture_max_mib * 1024 * 1024
+      capture_max_mib.clamp(1, MAX_CAPTURE_MAX_MIB) * 1024 * 1024
     end
 
     # Per-project network overrides — a RUNTIME layer set by Session.open from the OPEN
@@ -191,9 +200,10 @@ module Gori
     class_property? clipboard_osc52 : Bool = DEFAULT_CLIPBOARD_OSC52
     class_property? confirm_quit : Bool = DEFAULT_CONFIRM_QUIT
 
-    # The History-list preview body cap in BYTES (stored as KiB above).
+    # The History-list preview body cap in BYTES (stored as KiB above). Clamped so a
+    # large (or hand-edited) KiB value can never overflow Int32 (see MAX_PREVIEW_BODY_KIB).
     def self.preview_body_cap : Int32
-      preview_body_kib * 1024
+      preview_body_kib.clamp(1, MAX_PREVIEW_BODY_KIB) * 1024
     end
 
     def self.history_newest_first? : Bool
@@ -272,7 +282,7 @@ module Gori
         self.serve_landing = load_bool(net, "serve_landing", serve_landing?)
         net["connect_timeout_secs"]?.try(&.as_i?).try { |v| self.connect_timeout_secs = {v, 1}.max }
         net["io_timeout_secs"]?.try(&.as_i?).try { |v| self.io_timeout_secs = {v, 1}.max }
-        net["capture_max_mib"]?.try(&.as_i?).try { |v| self.capture_max_mib = {v, 1}.max }
+        net["capture_max_mib"]?.try(&.as_i?).try { |v| self.capture_max_mib = v.clamp(1, MAX_CAPTURE_MAX_MIB) }
       end
       self.theme = root["theme"]?.try(&.as_s?) || theme # validated against the known themes by Theme.apply
       self.mouse = load_bool(root, "mouse", mouse)
@@ -346,7 +356,7 @@ module Gori
       end
       self.show_gutter = load_bool_h(o, "show_gutter", show_gutter)
       if v = o["preview_body_kib"]?.try(&.as_i?)
-        self.preview_body_kib = {v, 1}.max
+        self.preview_body_kib = v.clamp(1, MAX_PREVIEW_BODY_KIB)
       end
     end
 

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -1827,10 +1827,10 @@ module Gori
     end
 
     # Hard-delete one History flow and its captured dependents (WS messages, FTS row,
-    # entity_links that pointed at it). Issues/Probe/Repeater that referenced the id keep
-    # the dangling cross-ref — their resolvers already surface "gone". Writer-fiber only
-    # so it races cleanly with live capture; orphaned h2 frame logs are reaped by the
-    # retention prune (same as a single-id miss in keep_flows).
+    # entity_links that pointed at it, and its h2 frame log when no sibling flow still shares
+    # the connection). Issues/Probe/Repeater that referenced the id keep the dangling
+    # cross-ref — their resolvers already surface "gone". Writer-fiber only so it races
+    # cleanly with live capture.
     def delete_flow(id : Int64) : Nil
       exec_task ->(c : DB::Connection) {
         delete_flow_one(c, id)
@@ -1862,7 +1862,18 @@ module Gori
       conn.exec("DELETE FROM ws_messages WHERE flow_id = ? AND repeater_id IS NULL", id)
       conn.exec("DELETE FROM flows_fts WHERE rowid = ?", id)
       conn.exec("DELETE FROM entity_links WHERE ref_kind = 'flow' AND ref_id = ?", id)
+      # The h2 frame log (often the flow's bulk bytes) — capture the conn BEFORE deleting
+      # the flow row so we can reclaim it if this was the last flow on that connection.
+      h2_conn = conn.query_one?("SELECT h2_conn_id FROM flows WHERE id = ?", id, as: Int64?)
       conn.exec("DELETE FROM flows WHERE id = ?", id)
+      # An HTTP/2 connection multiplexes many flows/streams, so only drop its log once NO
+      # surviving flow still references it. The retention prune's activity gate would keep
+      # a recent flow's log unreclaimed until later captures advance the floor, so an
+      # explicit user delete reclaims it directly here (no activity gate — this flow is gone).
+      if cid = h2_conn
+        conn.exec("DELETE FROM h2_frames WHERE conn_id = ? AND ? NOT IN (SELECT h2_conn_id FROM flows WHERE h2_conn_id IS NOT NULL)", cid, cid)
+        conn.exec("DELETE FROM h2_connections WHERE id = ? AND id NOT IN (SELECT h2_conn_id FROM flows WHERE h2_conn_id IS NOT NULL)", cid, cid)
+      end
       @pending_req_fts.delete(id)
     end
 

--- a/src/gori/store/compact.cr
+++ b/src/gori/store/compact.cr
@@ -47,8 +47,11 @@ class Gori::Store
     fuzz_bytes : Int64,
     flow_count : Int64
 
-  # On-disk size before and after a compaction, for the picker's result line.
-  record CompactResult, before_bytes : Int64, after_bytes : Int64 do
+  # On-disk size before and after a compaction, for the picker's result line. `vacuumed`
+  # is false when the strip committed but VACUUM (which needs ~db-size scratch) failed — the
+  # data WAS removed, only the OS-level reclaim was skipped, so the caller must not report
+  # "compress failed".
+  record CompactResult, before_bytes : Int64, after_bytes : Int64, vacuumed : Bool = true do
     def reclaimed_bytes : Int64
       {before_bytes - after_bytes, 0_i64}.max
     end
@@ -68,12 +71,15 @@ class Gori::Store
     return CompactStats.new(db_bytes, 0, 0, 0, 0, 0, 0) unless File.exists?(path)
     db = DB.open(compact_url(path))
     begin
-      resp = sum_len(db, "SELECT COALESCE(SUM(LENGTH(response_body)), 0) FROM flows")
-      req = sum_len(db, "SELECT COALESCE(SUM(LENGTH(request_body)), 0) FROM flows")
+      # One scan of the (large) flows table for both body sums + the count, instead of three.
+      resp, req, flows = begin
+        db.query_one("SELECT COALESCE(SUM(LENGTH(response_body)), 0), COALESCE(SUM(LENGTH(request_body)), 0), COUNT(*) FROM flows", as: {Int64, Int64, Int64})
+      rescue
+        {0_i64, 0_i64, 0_i64}
+      end
       h2 = sum_len(db, "SELECT COALESCE(SUM(LENGTH(payload)), 0) FROM h2_frames")
       ws = sum_len(db, "SELECT COALESCE(SUM(LENGTH(payload)), 0) FROM ws_messages WHERE repeater_id IS NULL")
       fuzz = sum_len(db, "SELECT COALESCE(SUM(COALESCE(LENGTH(request), 0) + COALESCE(LENGTH(response_head), 0) + COALESCE(LENGTH(response_body), 0)), 0) FROM fuzz_results")
-      flows = sum_len(db, "SELECT COUNT(*) FROM flows")
       CompactStats.new(db_bytes, resp, req, h2, ws, fuzz, flows)
     ensure
       db.close
@@ -90,9 +96,12 @@ class Gori::Store
 
   # Strip the selected data and VACUUM. Returns the before/after on-disk sizes, or
   # nil when another live instance holds the capture lock (the project is being
-  # captured into — compaction would race its writer). Best-effort and atomic:
-  # every deletion runs in one transaction; a failure rolls it back and re-raises
-  # so the caller can surface it (the file is left fully usable).
+  # captured into — compaction would race its writer). The DELETE step is atomic:
+  # every deletion runs in one transaction; a failure there rolls it back and re-raises
+  # so the caller can surface it (the file is left fully usable). VACUUM runs AFTER that
+  # commit (it is illegal inside a transaction) and CANNOT be rolled back, so its failure
+  # is caught and reported via CompactResult#vacuumed=false rather than re-raised — the
+  # data is already gone, only the disk reclaim was skipped.
   def self.compact(path : String, plan : CompactPlan) : CompactResult?
     return nil unless File.exists?(path)
     dir = File.dirname(path)
@@ -110,14 +119,21 @@ class Gori::Store
           apply_plan(tx.connection, plan)
         end
         # VACUUM rewrites the whole file to reclaim freed pages; it is ILLEGAL
-        # inside a transaction (see schema.cr) so it runs after the commit.
-        db.exec("VACUUM")
+        # inside a transaction (see schema.cr) so it runs after the commit. The strip
+        # is now durable, so a VACUUM failure (e.g. SQLITE_FULL — it needs ~db-size
+        # scratch) must NOT re-raise as "compress failed": the data is already removed.
+        vacuumed = true
+        begin
+          db.exec("VACUUM")
+        rescue
+          vacuumed = false
+        end
       ensure
         db.close
       end
       # VACUUM may recreate the -wal/-shm sidecars; re-tighten them to 0600.
       harden_permissions(path)
-      CompactResult.new(before, File.info(path).size)
+      CompactResult.new(before, File.info(path).size, vacuumed)
     ensure
       lock.close
     end

--- a/src/gori/tui/controllers/discover_controller.cr
+++ b/src/gori/tui/controllers/discover_controller.cr
@@ -43,7 +43,7 @@ module Gori::Tui
 
     def body_hint(focus : Symbol) : String
       return "start from Sitemap/History (space → \"Discover here\")" if @view.empty?
-      "↑/↓ nav · [ / ] runs · ^R run · ^X stop · ^P pause · space cmds · esc tabs"
+      "↑/↓ nav · [ / ] runs · ^R run · ^X stop · p pause · space cmds · esc tabs"
     end
 
     # --- rendering (frameless seam for TargetController) ---
@@ -69,7 +69,7 @@ module Gori::Tui
       key = ev.key
       if @view.empty?
         if key.escape? || key.up? || key.lower_k?
-          @host.request_focus(:menu)
+          @host.request_focus(:subtabs) # pop to Target's Sitemap|Discover strip (self-downgrades to :menu with no strip)
           return true
         end
         return false
@@ -81,8 +81,8 @@ module Gori::Tui
       return false if (ev.ctrl? || ev.alt?) && !key.escape? # ^R/^X/^P fall through to the verb keymap
       c = ev.char || key.to_char
       case
-      when key.escape?             then @host.request_focus(:menu)
-      when key.up?, key.lower_k?   then @view.at_top? ? @host.request_focus(:menu) : @view.move(-1)
+      when key.escape?             then @host.request_focus(:subtabs)
+      when key.up?, key.lower_k?   then @view.at_top? ? @host.request_focus(:subtabs) : @view.move(-1)
       when key.down?, key.lower_j? then @view.move(1)
       when c == '['                then @view.switch(-1)
       when c == ']'                then @view.switch(1)
@@ -130,7 +130,7 @@ module Gori::Tui
         @host.status("resumed")
       elsif run.running?
         run.pause
-        @host.status("paused — ^P to resume")
+        @host.status("paused — p to resume")
       end
     end
 

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -769,6 +769,8 @@ module Gori::Tui
     end
 
     private def finish_job(v : FuzzerView, ev : Fuzz::DoneEvent) : Nil
+      return if @host.jobs.errored?(v.job_id) # an ErrorEvent already finalized this run — the
+      #                                         engine's trailing DoneEvent must not log/notify success
       n = v.matched_count
       @host.jobs.finish(v.job_id, :done, "#{n} hit")
       level = n > 0 ? :success : :info

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -333,11 +333,15 @@ module Gori::Tui
     # confirm dialog open and confirm can't retarget the delete (same pattern as
     # ProbeController#probe_delete). Works from the list or the open detail.
     def history_delete : Nil
-      id = @host.overlay == :detail ? @history.detail_flow_id : @history.selected_id
+      from_detail = @host.overlay == :detail
+      id = from_detail ? @history.detail_flow_id : @history.selected_id
       return unless id
       label = @history.flow_summary(id)
+      # return_to: :detail when launched from the open flow detail, so CANCEL restores the
+      # detail (instead of dropping to the list) and the guard below still fires on accept
+      # (the flow is gone, so :detail → :none).
       @host.confirm("DELETE FLOW", "Delete \"#{label}\"?\nThis can't be undone.",
-        confirm_label: "delete", danger: true) do
+        confirm_label: "delete", danger: true, return_to: from_detail ? :detail : :none) do
         @history.delete_by_id(@host.session.store, id)
         @host.request_overlay(:none) if @host.overlay == :detail
         @host.status("deleted #{label}")
@@ -352,7 +356,7 @@ module Gori::Tui
       return if n <= 0
       @host.confirm("CLEAR HISTORY",
         "Delete ALL #{n} History flow#{n == 1 ? "" : "s"} for this project?\nThis can't be undone.",
-        confirm_label: "clear", danger: true) do
+        confirm_label: "clear", danger: true, return_to: @host.overlay == :detail ? :detail : :none) do
         @history.clear(@host.session.store)
         @host.request_overlay(:none) if @host.overlay == :detail
         @host.status("history cleared")

--- a/src/gori/tui/controllers/jwt_controller.cr
+++ b/src/gori/tui/controllers/jwt_controller.cr
@@ -68,6 +68,13 @@ module Gori::Tui
       Verb::Scope::Jwt
     end
 
+    # The focused pane, so section-tagged verbs (jwt.copy-token on :output, jwt.copy-attack
+    # on :attacks, jwt.select-line on :input) surface in the space menu's CONTEXT group.
+    # Without this the default :common hides every pane-scoped verb (mirrors DecoderController).
+    def command_section : Symbol
+      cur.pane
+    end
+
     # INS editors (input-insert / header / payload / secret) show the EDITOR badge;
     # everything else is navigable body.
     def body_badge : Symbol

--- a/src/gori/tui/controllers/miner_controller.cr
+++ b/src/gori/tui/controllers/miner_controller.cr
@@ -485,6 +485,8 @@ module Gori::Tui
     end
 
     private def finish_job(v : MinerView, ev : Miner::DoneEvent) : Nil
+      return if @host.jobs.errored?(v.job_id) # an ErrorEvent already finalized this run — the
+      #                                         engine's trailing DoneEvent must not log/notify success
       n = v.found_count
       @host.jobs.finish(v.job_id, :done, "#{n} found")
       msg = "Miner: #{n} param#{n == 1 ? "" : "s"} found on #{v.summary}#{ev.stopped ? " (stopped)" : ""}"

--- a/src/gori/tui/controllers/oast_controller.cr
+++ b/src/gori/tui/controllers/oast_controller.cr
@@ -705,13 +705,28 @@ module Gori::Tui
     def drain_events : Bool
       applied = false
       applied = true if drain_registrations
+      # Pin the callback selection to the SAME callback across live inserts: each new callback
+      # prepends to the newest-first display and shifts every index down, so a bare @cb_sel would
+      # silently slide onto a neighbor (and flip an open detail). Capture its stable key, re-resolve.
+      sel_key = selected_callback.try { |c| {c.session_id, c.uid} }
       n = 0
+      inserted = false
       while n < DRAIN_CAP && (ev = nonblocking_callback)
         n += 1
         apply_callback(ev)
         applied = true
+        inserted = true
       end
+      reanchor_callback_selection(sel_key) if inserted && sel_key
       applied
+    end
+
+    # Move @cb_sel back onto the callback identified by `key` after live inserts shifted the
+    # display indices. No-op if it was filtered out (the clamp in render keeps @cb_sel in range).
+    private def reanchor_callback_selection(key : {Int64, String}) : Nil
+      if idx = ordered_callbacks.index { |c| {c.session_id, c.uid} == key }
+        @cb_sel = idx
+      end
     end
 
     private def drain_registrations : Bool

--- a/src/gori/tui/controllers/oast_controller.cr
+++ b/src/gori/tui/controllers/oast_controller.cr
@@ -47,7 +47,7 @@ module Gori::Tui
     # the main fiber; persistence + poller start happen here on drain).
     record RegOk, session : Oast::Session, provider : Oast::Provider, provider_id : Int64?,
       provider_label : String, want_payload : Bool
-    record RegErr, message : String, provider_label : String
+    record RegErr, message : String, provider_label : String, provider_id : Int64?
     alias RegResult = RegOk | RegErr
 
     def initialize(host : Host)
@@ -65,10 +65,12 @@ module Gori::Tui
       @filter = TextField.new       # Callbacks free-text filter (`/`)
       @filter_editing = false
       @prov_sel = 0
+      @prov_scroll = 0
       @payload_pick = 0
       @last_payload = nil.as(String?)
       @oast_events = Channel(Oast::Event).new(256)
       @reg_events = Channel(RegResult).new(16)
+      @registering = Set(Int64).new # provider ids with a register round-trip in flight (dedup g/^R)
       reload
     end
 
@@ -239,19 +241,25 @@ module Gori::Tui
     end
 
     private def start_listening(prov : Store::OastProviderRecord, want_payload : Bool) : Nil
+      # A register round-trip takes a few seconds and only appends the Listener on the
+      # drain tick AFTER it returns, so listener_for is nil the whole time. Without an
+      # in-flight guard a second g/^R spawns a duplicate register → two sessions, two
+      # Listeners and two poller fibers for one provider. Dedup on the provider id.
+      pid = prov.id
+      return @host.status("already registering with #{prov.name}…") if pid && @registering.includes?(pid)
       kind = Oast::ProviderKind.parse?(prov.kind)
       return @host.status("unknown provider type #{prov.kind}") unless kind
       provider = Oast::Provider.build(kind, prov.host, prov.token)
       http = Oast::HttpClient.new(verify_tls: !@host.session.config.insecure_upstream?)
       reg = @reg_events
       label = prov.name
-      pid = prov.id
+      @registering << pid if pid
       spawn(name: "gori-oast-register") do
         begin
           session = provider.register(http)
           reg.send(RegOk.new(session, provider, pid, label, want_payload))
         rescue ex
-          reg.send(RegErr.new(ex.message || "register failed", label))
+          reg.send(RegErr.new(ex.message || "register failed", label, pid))
         end
       end
       @host.status("registering with #{label}…")
@@ -430,6 +438,11 @@ module Gori::Tui
       screen.text(inner.right - 18, header_y, "PROVIDER", Theme.muted, Theme.bg)
       rows_rect = Rect.new(inner.x, inner.y + 1, inner.w, inner.h - 1)
       visible = rows_rect.h
+      return if visible <= 0 # a collapsed pane (tiny terminal) has no rows to draw; a negative slice count would raise
+      # Keep the selection in view in BOTH directions (@cb_sel may have moved via keys or
+      # the wheel, neither of which advances the viewport downward on its own).
+      @cb_scroll = @cb_sel if @cb_sel < @cb_scroll
+      @cb_scroll = @cb_sel - visible + 1 if @cb_sel >= @cb_scroll + visible
       @cb_scroll = @cb_scroll.clamp(0, {ordered.size - visible, 0}.max)
       ordered[@cb_scroll, visible]?.try &.each_with_index do |row, i|
         py = rows_rect.y + i
@@ -465,6 +478,7 @@ module Gori::Tui
       meta = "from #{row.source || "?"} · provider #{row.provider} · #{row.at.to_rfc3339}"
       screen.text(inner.x + 1, inner.y, meta, Theme.muted, Theme.bg, width: inner.w - 2)
       body = Rect.new(inner.x, inner.y + 2, inner.w, inner.h - 2)
+      return if body.h <= 0 # collapsed pane (tiny terminal): a negative slice count would raise
       text = row.raw_response ? "#{row.raw_request}\n\n--- response ---\n#{row.raw_response}" : row.raw_request
       lines = text.split('\n')
       @cb_detail_scroll = @cb_detail_scroll.clamp(0, {lines.size - body.h, 0}.max)
@@ -485,10 +499,12 @@ module Gori::Tui
       screen.text(inner.x + 38, inner.y, "HOST", Theme.muted, Theme.bg)
       screen.text(inner.right - 8, inner.y, "ENABLED", Theme.muted, Theme.bg)
       rows = Rect.new(inner.x, inner.y + 1, inner.w, inner.h - 1)
-      @providers.each_with_index do |p, i|
-        break if i >= rows.h
+      return if rows.h <= 0 # collapsed pane (tiny terminal): a negative slice count would raise
+      sync_prov_scroll(rows.h)
+      @providers[@prov_scroll, rows.h]?.try &.each_with_index do |p, i|
         py = rows.y + i
-        sel = i == @prov_sel
+        abs = @prov_scroll + i
+        sel = abs == @prov_sel
         bg = sel ? (focused ? Theme.accent_bg : Theme.selection_dim) : Theme.bg
         screen.fill(Rect.new(rows.x, py, rows.w, 1), bg)
         screen.cell(rows.x, py, sel ? '▎' : ' ', Theme.accent, bg)
@@ -501,6 +517,16 @@ module Gori::Tui
         badge = p.enabled? ? (listening ? "● live" : "on") : "off"
         screen.text(rows.right - 8, py, badge, p.enabled? ? Theme.green : Theme.muted, bg)
       end
+    end
+
+    # Keep @prov_sel within the visible provider window (both directions), then clamp — so a
+    # selection taller than the pane scrolls into view instead of vanishing off the bottom.
+    private def sync_prov_scroll(visible : Int32) : Nil
+      if visible > 0
+        @prov_scroll = @prov_sel if @prov_sel < @prov_scroll
+        @prov_scroll = @prov_sel - visible + 1 if @prov_sel >= @prov_scroll + visible
+      end
+      @prov_scroll = @prov_scroll.clamp(0, {@providers.size - visible, 0}.max)
     end
 
     private def selected_callback : CbRow?
@@ -716,6 +742,9 @@ module Gori::Tui
     end
 
     private def apply_registration(reg : RegResult) : Nil
+      if pid = reg.provider_id
+        @registering.delete(pid) # registration resolved (ok or err) — clear the in-flight guard
+      end
       case reg
       when RegErr
         @host.status("OAST register failed (#{reg.provider_label}): #{reg.message}")

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -70,7 +70,9 @@ module Gori::Tui
       # pings and one terminal Report back here (a union type — Progress or Report), drained
       # by drain_results. Only one minimize runs at a time (tracked by @minimize_job).
       @minimize_events = Channel({RepeaterView, Repeater::Minimize::Progress | Repeater::Minimize::Report}).new(256)
-      @minimize_job = nil.as({RepeaterView, Int32}?) # the {view, Jobs id} of a running minimize
+      # {view, Jobs id, start-of-run request snapshot} of a running minimize. The snapshot
+      # guards the writeback: if the user edited the request mid-run we must not overwrite it.
+      @minimize_job = nil.as({RepeaterView, Int32, String}?)
     end
 
     def tab : Symbol
@@ -828,17 +830,30 @@ module Gori::Tui
     # already dropped by the drain, and close_repeater_tab finished its job.
     private def apply_minimize_report(tab : RepeaterTab, report : Repeater::Minimize::Report) : Nil
       view = tab.view
-      job = (mj = @minimize_job) && mj[0].same?(view) ? mj[1] : nil
-      @minimize_job = nil if job
-      unless report.aborted || report.removed.empty?
+      mj = @minimize_job
+      if mj && mj[0].same?(view)
+        job = mj[1]
+        snapshot = mj[2]
+        @minimize_job = nil
+      else
+        job = nil
+        snapshot = nil
+      end
+      # The run does NOT lock the editor, so the user may have typed into the request while
+      # it ran. Only auto-install the trimmed request when the editor still holds the exact
+      # bytes the run started from; otherwise skip the overwrite and surface the result so
+      # the user's mid-run edits are never silently discarded.
+      edited_mid_run = snapshot && view.request_text != snapshot
+      if !report.aborted && !report.removed.empty? && !edited_mid_run
         view.replace_request(report.minimized_text)
         persist_repeater_tab(tab) # persist even if the user switched sub-tabs while it ran
       end
-      level = report.aborted ? :warning : (report.removed.empty? ? :info : :success)
-      @host.jobs.finish(job, report.aborted ? :error : :done, report.note) if job
-      @host.notifications.push(level, "Minimize: #{report.note} on #{view.summary}",
+      note = edited_mid_run ? "#{report.note} — request edited meanwhile, not applied" : report.note
+      level = edited_mid_run ? :warning : (report.aborted ? :warning : (report.removed.empty? ? :info : :success))
+      @host.jobs.finish(job, report.aborted ? :error : :done, note) if job
+      @host.notifications.push(level, "Minimize: #{note} on #{view.summary}",
         Jobs::Goto.new(:repeater, tab.db_id), source: "minimize")
-      @host.status(report.note)
+      @host.status(note)
     end
 
     # Persist a specific tab's request edits (minimize can land on a tab that isn't current).
@@ -1235,7 +1250,7 @@ module Gori::Tui
           !@host.session.config.insecure_upstream?, view.sni_override, timeout: 10.seconds),
         MINIMIZE_SEND_CAP)
       job = @host.jobs.start(:minimize, view.summary, goto: Jobs::Goto.new(:repeater, tab.db_id))
-      @minimize_job = {view, job}
+      @minimize_job = {view, job, text} # `text` is the snapshot the run minimizes; see apply_minimize_report
       events = @minimize_events
       @host.status("minimizing #{view.summary} in the background — watch the bottom bar / notifications")
       spawn(name: "gori-minimize") do
@@ -1367,6 +1382,11 @@ module Gori::Tui
     # round-trip, or holding unsaved local edits.
     private def repeater_tab_locked?(tab : RepeaterTab) : Bool
       v = tab.view
+      # A running minimize tracks its tab only by @minimize_job (not view.inflight?), so a
+      # clean minimizing tab would otherwise be droppable/overwritable by a cross-session
+      # reconcile — orphaning @minimize_job (phantom spinner + minimize blocked until restart).
+      # Lock it until the terminal Report lands and clears @minimize_job.
+      return true if (mj = @minimize_job) && mj[0].same?(v)
       # request_hex? too: a hex-edit session isn't necessarily dirty, and request_text
       # reads CRLF in hex mode vs the LF-persisted row, so the reconcile compare would
       # wrongly see a change and restore() — wiping the hex buffer. Lock it.

--- a/src/gori/tui/controllers/sequencer_controller.cr
+++ b/src/gori/tui/controllers/sequencer_controller.cr
@@ -505,6 +505,8 @@ module Gori::Tui
     end
 
     private def finish_job(v : SequencerView, ev : Sequencer::DoneEvent) : Nil
+      return if @host.jobs.errored?(v.job_id) # an ErrorEvent already finalized this run — the
+      #                                         engine's trailing DoneEvent must not log/notify success
       rep = v.report
       n = rep.usable_count
       @host.jobs.finish(v.job_id, :done, "#{n} · #{rep.rating.label.downcase}")

--- a/src/gori/tui/controllers/sequencer_controller.cr
+++ b/src/gori/tui/controllers/sequencer_controller.cr
@@ -368,7 +368,10 @@ module Gori::Tui
     def sequence_from_text(payload : String) : Nil
       tokens = payload.split(/\r?\n/).map(&.strip).reject(&.empty?)
       return @host.status("nothing to analyze") if tokens.empty?
-      if (v = current_view) && v.config.mode.manual? && @host.active_tab == :sequencer
+      # Append into the current manual session only when it is NOT still collecting — starting
+      # a run under a live fiber would spawn a second concurrent engine feeding the same view
+      # (corrupted stats + orphaned job). A running session instead gets a fresh session below.
+      if (v = current_view) && v.config.mode.manual? && !v.running? && @host.active_tab == :sequencer
         v.append_manual_tokens(tokens)
         save_current
         drain_events
@@ -395,6 +398,12 @@ module Gori::Tui
 
     def reconfigure_current(config : Sequencer::Config) : Nil
       return unless v = current_view
+      # Restarting under a live collection would spawn a second engine fiber feeding the same
+      # view (interleaved samples → corrupted randomness stats, orphaned job). Require a stop first.
+      if v.running?
+        @host.status("stop the collection first (^X) to reconfigure")
+        return
+      end
       v.set_config(config)
       save_current
       drain_events

--- a/src/gori/tui/controllers/sitemap_controller.cr
+++ b/src/gori/tui/controllers/sitemap_controller.cr
@@ -209,7 +209,7 @@ module Gori::Tui
     # --- verbs (delegated from the Runner's ExecContext) ---
     def sitemap_move(delta : Int32) : Nil
       if delta < 0 && @sitemap.at_top?
-        @host.request_focus(:menu) # ↑ at the top node pops up to the tab bar
+        @host.request_focus(:subtabs) # ↑ at the top node pops to Target's Sitemap|Discover strip (downgrades to :menu with no strip)
       else
         @sitemap.move(delta)
       end

--- a/src/gori/tui/jobs.cr
+++ b/src/gori/tui/jobs.cr
@@ -61,6 +61,8 @@ module Gori::Tui
 
     def finish(id : Int32, state : Symbol, summary : String? = nil) : Nil
       return unless j = find(id)
+      return unless j.running? # first terminal state wins: an engine that emits ErrorEvent
+      #                          then a trailing DoneEvent must stay :error, not flip to :done
       j.state = state
       j.note = summary if summary
     end

--- a/src/gori/tui/jobs.cr
+++ b/src/gori/tui/jobs.cr
@@ -67,6 +67,12 @@ module Gori::Tui
       j.note = summary if summary
     end
 
+    # True once a job has been finished with :error — lets a controller's DoneEvent handler
+    # skip its success side effects (log/notification/status) when an ErrorEvent already fired.
+    def errored?(id : Int32) : Bool
+      (j = find(id)) ? j.state == :error : false
+    end
+
     def active : Array(Job)
       @jobs.select(&.running?)
     end

--- a/src/gori/tui/project_picker.cr
+++ b/src/gori/tui/project_picker.cr
@@ -46,7 +46,7 @@ module Gori::Tui
       @query = "" # current search filter; only editable when Search row selected
       @selected = 0
       @results_scroll = 0
-      @mode = :list # :list | :new | :confirm | :space | :rename | :settings | :compress | :compressing
+      @mode = :list # :list | :new | :confirm | :space | :rename | :settings | :compress | :measuring | :compressing
       @name = ""
       @desc = ""
       @new_field = :name # :name | :desc (only in :new mode)
@@ -473,9 +473,15 @@ module Gori::Tui
         set_flash(%(can't compress "#{project.name}" — it's open in another window), ok: false)
         return
       end
+      # measure runs several full-table scans synchronously on this event loop; on a large
+      # project that blocks repaint/input for a beat, so paint a busy card first (mirrors the
+      # VACUUM path) instead of freezing on the stale frame.
+      @mode = :measuring
+      render
       stats = begin
         Store.measure(project.db_path)
       rescue Gori::Error | IO::Error | DB::Error | SQLite3::Exception
+        @mode = :list
         set_flash(%(can't read "#{project.name}" to compress), ok: false)
         return
       end
@@ -539,8 +545,14 @@ module Gori::Tui
         render # paint the busy card before the blocking VACUUM
         begin
           if result = Store.compact(project.db_path, plan)
-            reclaimed = result.reclaimed_bytes > 0 ? "  (−#{Fmt.size(result.reclaimed_bytes)})" : ""
-            set_flash(%(compressed "#{project.name}"  #{Fmt.size(result.before_bytes)} → #{Fmt.size(result.after_bytes)}#{reclaimed}), ok: true)
+            if result.vacuumed
+              reclaimed = result.reclaimed_bytes > 0 ? "  (−#{Fmt.size(result.reclaimed_bytes)})" : ""
+              set_flash(%(compressed "#{project.name}"  #{Fmt.size(result.before_bytes)} → #{Fmt.size(result.after_bytes)}#{reclaimed}), ok: true)
+            else
+              # The strip committed but VACUUM failed (often low disk — it needs ~db-size
+              # scratch). Data WAS removed; only the OS reclaim was skipped.
+              set_flash(%(compressed "#{project.name}" — data removed, but disk not reclaimed (free up space and compress again)), ok: true)
+            end
           else
             set_flash(%(can't compress "#{project.name}" — it's open in another window), ok: false)
           end
@@ -801,7 +813,7 @@ module Gori::Tui
         @settings.render(screen, Rect.new(0, 0, w, h)) if @mode == :settings
         render_space_menu(screen, w, h) if @mode == :space
         @compact.try(&.render(screen, Rect.new(0, 0, w, h))) if @mode == :compress
-        render_compressing(screen, w, h) if @mode == :compressing
+        render_compressing(screen, w, h) if @mode == :compressing || @mode == :measuring
       end
       # Sync the terminal hardware cursor to the focused caret so the terminal's
       # own IME composition UI (jamo/candidate popup) anchors at the right cell —
@@ -963,10 +975,11 @@ module Gori::Tui
       end
     end
 
-    # A small centered "Compressing …" card painted while the synchronous VACUUM
-    # runs (the picker has no background jobs / spinner), so the freeze reads as work.
+    # A small centered busy card painted while a synchronous blocking step runs (the picker
+    # has no background jobs / spinner), so the freeze reads as work — the measure scan on a
+    # multi-GB project, then the VACUUM.
     private def render_compressing(screen : Screen, w : Int32, h : Int32) : Nil
-      msg = " Compressing … "
+      msg = @mode == :measuring ? " Measuring … " : " Compressing … "
       bw = {msg.size + 4, 22}.max
       bh = 3
       box = Rect.new({(w - bw) // 2, 0}.max, {(h - bh) // 2, 0}.max, bw, bh)

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -2257,15 +2257,12 @@ module Gori::Tui
       when key.down?   then p.move(1)
       when key.enter?  then apply_send_to
       else
-        if (c = ev.char) && !ev.ctrl? && !ev.alt?
-          if idx = p.index_for(c)
-            p.set_selected(idx)
-            apply_send_to
-          elsif c == 'j'
-            p.move(1)
-          elsif c == 'k'
-            p.move(-1)
-          end
+        # Mnemonic → immediate send. No j/k vim fallback: destination mnemonics now
+        # include 'j' (JWT), so a j/k nav fallback both shadowed that mnemonic and was
+        # asymmetric (k moved up, j sent). Arrows handle navigation.
+        if (c = ev.char) && !ev.ctrl? && !ev.alt? && (idx = p.index_for(c))
+          p.set_selected(idx)
+          apply_send_to
         end
       end
     end
@@ -6456,6 +6453,12 @@ module Gori::Tui
         status
       end
       @resized = true # alt-screen re-entered → force a full repaint via the resize path
+      # The child editor may have set its own OS window title. termisu memoizes the last
+      # title it wrote (still "Gori - <tab>"), so a plain re-emit is suppressed — bust its
+      # memo with a throwaway write, then invalidate gori's memo so the next render
+      # re-emits "Gori - <tab>" and restores our title over whatever the editor left.
+      @term.title = ""
+      @title_tab = nil
       case result.outcome
       in ExternalEditor::Outcome::Changed
         yield result.text.not_nil!

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -3995,6 +3995,8 @@ module Gori::Tui
       flush_active_tab_edits # cross-tab "open this and land in it" jumps must persist the outgoing edit too
       @active_tab = tab
       @focus = :body
+      @overlay = :none # clear any launching overlay (e.g. History :detail) so the destination
+      #                  tab's body keys/scope aren't deadened by a stale overlay gate
     end
 
     def session : Session

--- a/src/gori/tui/screen.cr
+++ b/src/gori/tui/screen.cr
@@ -113,11 +113,18 @@ module Gori::Tui
 
     # The column width termisu will render `g` at (1 or 2), or 0 if termisu's set_cell would
     # REJECT it — mirroring its guards so our grid only ever holds cells termisu accepts. A
-    # single ASCII byte is always a width-1 printable (Screen already mapped controls to a
-    # space). A multibyte grapheme is rejected when it is a C1 control, a width-0 combining
-    # mark, or a 2-column glyph with no room at the last column.
+    # single byte is width-1 EXCEPT a C0 control / DEL, which termisu rejects (buffer's
+    # control_char? guard); returning 0 there leaves the fill's space in @back so no stale
+    # ghost cell survives when a raw control byte is drawn (e.g. an embedded tab in a body
+    # line via the String-grapheme path, which is NOT space-substituted like the Char path).
+    # A multibyte grapheme is rejected when it is a C1 control, a width-0 combining mark, or a
+    # 2-column glyph with no room at the last column.
     private def accepted_width(g : String, x : Int32) : Int32
-      return 1 if g.bytesize == 1
+      if g.bytesize == 1
+        b = g.to_slice[0]
+        return 0 if b < 0x20_u8 || b == 0x7f_u8 # C0 control / DEL — termisu rejects it
+        return 1
+      end
       cp = g[0].ord
       return 0 if cp >= 0x7f && cp <= 0x9f # C1 control (a C0 can't lead a multibyte sequence)
       w = Termisu::UnicodeWidth.grapheme_width(g).to_i32

--- a/src/gori/tui/sequencer_view.cr
+++ b/src/gori/tui/sequencer_view.cr
@@ -290,7 +290,12 @@ module Gori::Tui
     def report : Sequencer::Stats::Report
       cached = @report
       return cached if cached && @report_rev == @samples_rev
-      return cached if cached && @running && (@samples_rev - @report_rev) < REPORT_THROTTLE
+      # Analyze is O(n) with large transient allocations (a full symbol bitstream), so scale
+      # the mid-run recompute cadence with corpus size: a several-thousand-token paste rebuilds
+      # only a handful of times instead of every 25 samples. The post-run path (!@running) below
+      # still recomputes an exact final report.
+      throttle = {REPORT_THROTTLE, @samples.size // 20}.max
+      return cached if cached && @running && (@samples_rev - @report_rev) < throttle
       fresh = Sequencer::Stats.analyze(@samples.compact_map(&.token))
       @report = fresh
       @report_rev = @samples_rev

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -390,6 +390,7 @@ module Gori::Tui
           @status = "invalid preview limit"
           return "settings: invalid preview body limit #{@values[3].inspect} (KiB, min 1)"
         end
+        kib = kib.clamp(1, Settings::MAX_PREVIEW_BODY_KIB) # keep kib*1024 within Int32
         Settings.default_detail_pane = @values[0] == "response" ? "response" : "request"
         Settings.history_time_format = @values[1] == "relative" ? "relative" : "absolute"
         Settings.show_gutter = @values[2] == "on"
@@ -440,6 +441,7 @@ module Gori::Tui
         @status = "invalid capture limit"
         return "settings: invalid capture limit #{@values[7].inspect} (MiB, min 1)"
       end
+      cap = cap.clamp(1, Settings::MAX_CAPTURE_MAX_MIB) # keep cap*1024*1024 within Int32 (never break the proxy)
       Settings.bind_host = @values[0].strip
       Settings.bind_port = port
       Settings.upstream_proxy = up

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -41,8 +41,10 @@ module Gori::Tui
     # Open the OAST provider add/edit popup (nil edit_id = add; else edit that provider).
     # `kind` is a ProviderKind label; seeds the form when editing (defaults for add).
     abstract def open_oast_provider_editor(edit_id : Int64?, name : String, kind : String, host : String, token : String) : Nil
-    # Destructive-action confirmation modal; `action` runs on confirm.
-    abstract def confirm(title : String, message : String, *, confirm_label : String, danger : Bool, &action : -> Nil) : Nil
+    # Destructive-action confirmation modal; `action` runs on confirm. `return_to` is the
+    # overlay restored on cancel/accept (default :none) — pass the launching overlay (e.g.
+    # :detail) when raising the confirm from inside another overlay so cancel returns there.
+    abstract def confirm(title : String, message : String, *, confirm_label : String, danger : Bool, return_to : Symbol = :none, &action : -> Nil) : Nil
     abstract def session : Session             # store / scope / proxy / registry / interceptor
     abstract def overlay : Symbol              # read the overlay state (e.g. History reads :detail)
     abstract def active_tab : Symbol           # read the active tab (Repeater reconcile gates on it)

--- a/src/gori/verbs/discover.cr
+++ b/src/gori/verbs/discover.cr
@@ -20,8 +20,8 @@ module Gori
         Verb::Scope::Discover, [] of Verb::Chord, mnemonic: 'p') { |ctx| ctx.discover_toggle_pause; nil }
 
       r.register Verb::Definition.new(
-        "discover.to-menu", "Back to menu", "Move focus up to the tab menu", Verb::Scope::Discover,
-        [Verb::Chord.new("escape")], hidden: true) { |ctx| ctx.focus_pane(:menu); nil }
+        "discover.to-menu", "Back to sub-tabs", "Move focus up to the Sitemap/Discover strip", Verb::Scope::Discover,
+        [Verb::Chord.new("escape")], hidden: true) { |ctx| ctx.focus_pane(:subtabs); nil }
     end
   end
 end

--- a/src/gori/verbs/sequencer.cr
+++ b/src/gori/verbs/sequencer.cr
@@ -11,7 +11,6 @@ module Gori
       history_selected = ->(ctx : Verb::ExecContext) { ctx.current_tab == :history && !ctx.selected_flow_id.nil? }
       in_sequencer = ->(ctx : Verb::ExecContext) { ctx.current_tab == :sequencer }
       in_repeater = ->(ctx : Verb::ExecContext) { ctx.current_tab == :repeater }
-      in_sitemap = ->(ctx : Verb::ExecContext) { ctx.current_tab == :sitemap }
 
       r.register Verb::Definition.new(
         "history.sequence", "Send to Sequencer", "Collect this flow's token and analyze its randomness",
@@ -22,9 +21,12 @@ module Gori
       r.register Verb::Definition.new(
         "repeater.sequence", "Send to Sequencer", "Collect this request's token repeatedly and analyze randomness",
         Verb::Scope::Repeater, available: in_repeater, mnemonic: 'q') { |ctx| ctx.sequence_from_repeater; nil }
+      # Scope::Sitemap already gates this to the Target/Sitemap sub-tab (command_scope
+      # returns Sitemap only then) — no current_tab predicate, which would check the
+      # retired :sitemap top-level symbol and never fire (Sitemap is now a Target sub-tab).
       r.register Verb::Definition.new(
         "sitemap.sequence", "Send to Sequencer", "Collect the selected endpoint's token and analyze randomness",
-        Verb::Scope::Sitemap, available: in_sitemap, mnemonic: 'q') { |ctx| ctx.sequence_from_sitemap; nil }
+        Verb::Scope::Sitemap, mnemonic: 'q') { |ctx| ctx.sequence_from_sitemap; nil }
 
       r.register Verb::Definition.new(
         "sequence.run", "Run collection", "Re-run token collection for this session", Verb::Scope::Sequencer,

--- a/src/gori/verbs/sitemap.cr
+++ b/src/gori/verbs/sitemap.cr
@@ -58,8 +58,8 @@ module Gori
         Verb::Scope::Sitemap, [Verb::Chord.new("r")], mnemonic: 'r') { |ctx| ctx.sitemap_repeater; nil }
 
       r.register Verb::Definition.new(
-        "sitemap.to-menu", "Back to menu", "Move focus up to the tab menu", Verb::Scope::Sitemap,
-        [Verb::Chord.new("escape")], hidden: true) { |ctx| ctx.focus_pane(:menu); nil }
+        "sitemap.to-menu", "Back to sub-tabs", "Move focus up to the Sitemap/Discover strip", Verb::Scope::Sitemap,
+        [Verb::Chord.new("escape")], hidden: true) { |ctx| ctx.focus_pane(:subtabs); nil }
     end
   end
 end


### PR DESCRIPTION
Four adversarial review + fix rounds over today's merged work (5 new tabs — Target/Discover, Rewriter, OAST, Sequencer, JWT — plus perf rewrites), focused on the three concerns raised: **performance regressions, TUI arrow-key/focus flow across new tabs, and feature malfunction**. Every finding was verified before fixing, and each round re-reviewed the previous round's fixes (which is how the process caught a HIGH crash and a defeated fix that I'd introduced).

**43 confirmed bugs fixed** across 3 commits. `crystal build` clean · `crystal spec` 2187 examples, 0 failures · ameba: zero net-new findings. New-tab navigation verified end-to-end in a live TUI (tmux).

### Highlights

**Crashes**
- settings: a capture/preview limit ≥ 2 GiB overflowed Int32 and broke the whole proxy → clamped at read + input
- sequencer: an invalid token regex raised an uncaught `ArgumentError` that killed the worker fiber → compile once, surface a clean error
- oast: providers/callbacks render slices raised `Negative count` at tiny terminal heights → guarded

**TUI focus flow (the #1 concern)**
- Target's Sitemap/Discover sub-tabs escaped up-at-top to `:menu`, skipping the sub-tab strip → route to `:subtabs` like sibling OAST (verified live)
- "Send to Sequencer" was dead from Sitemap (stale `:sitemap` gate); JWT pane-scoped space-menu verbs were hidden; `goto_tab` left a stale overlay that deadened the destination tab
- verified live: Target/OAST body↑→SUBTABS→TABS with strip switching, JWT esc→SUBTABS + Tab pane-ring + `^E` lens

**Correctness**
- repeater minimize: mid-minimize tab drop, concurrent-edit clobber, header-only-param false-strip
- probe passive: template-literal `${...}` DOM-XSS was missed (two iterations to fully fix — the source survived the strip but the window scanner truncated at the interpolation braces); comment-only-code and numeric-index false positives
- sequencer stats: false FAILs on non-power-of-2 alphabets (decimal/base62 tokens) → gate the bit tests
- sequencer: reconfigure/append while collecting spawned a second engine that corrupted the randomness stats
- decoder base32 Unicode-whitespace tolerance; history h2-flow frame-log cascade; compress VACUUM-failure messaging

**Performance**
- rewriter: keystroke-path full-body preview scan → head-only; per-request wildcard-glob regex recompile → memoized; head-rewrite fast-path counter split per direction

### Commits
- `c47337a` — rounds 1–2 (35 bugs; round 2 caught a HIGH crash regression from round 1)
- `d2600a4` — round 3 (8 bugs; caught that round 2's template fix was defeated downstream)
- `a62a845` — round 4 (2 bugs; completeness critic + fresh-eyes sweeps otherwise clean → converged)

Severity trend across rounds (28 → 7 → 8 → 2, HIGH crashes early → MEDIUM/LOW late) indicates convergence.