### PR TITLE
feat(tui): add confirmation popup when leaving project

### DIFF
--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -3925,8 +3925,11 @@ module Gori::Tui
     end
 
     def leave_project : Nil
-      commit_pending_edits
-      @outcome = :back
+      confirm("LEAVE PROJECT", "Close this project and return to the picker?",
+        confirm_label: "leave", danger: false, return_to: @overlay) do
+        commit_pending_edits
+        @outcome = :back
+      end
     end
 
     # Flush any in-progress editor before leaving/quitting (quit is now centralized,


### PR DESCRIPTION
Adds a confirmation popup before returning to the project picker (with 'q' or via the Command Palette) to avoid accidental exits.