### PR TITLE
fix: reveal a force-shown hidden tab at the far right of the tab bar

### DIFF
--- a/spec/tui/chrome_tabs_spec.cr
+++ b/spec/tui/chrome_tabs_spec.cr
@@ -61,13 +61,13 @@ describe "Chrome.visible_tabs" do
     vis.size.should eq(Chrome::TABS.size - Chrome::DEFAULT_HIDDEN.size)
   end
 
-  it "force-includes a hidden active tab at its catalog-relative position" do
-    # Miner hidden by default; forcing it must slot it where it sits in the catalog
-    # (between Fuzzer and Decoder).
+  it "force-includes a hidden active tab at the far right of the strip" do
+    # Miner hidden by default; forcing it (a jump to a hidden tab) must append it at the
+    # END of the visible strip — right next to the ⋯ list — not splice it mid-strip at its
+    # catalog position between Fuzzer and Decoder.
     vis = Chrome.visible_tabs([] of {String, Bool}, force: :miner).map(&.first)
-    vis.includes?(:miner).should be_true
-    vis.index(:miner).not_nil!.should be > vis.index(:fuzzer).not_nil!
-    vis.index(:miner).not_nil!.should be < vis.index(:decoder).not_nil!
+    vis.last.should eq(:miner)
+    vis.index(:miner).not_nil!.should be > vis.index(:decoder).not_nil!
   end
 
   it "places the default-visible Decoder tab between Fuzzer and Comparer" do

--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -99,19 +99,27 @@ module Gori::Tui
     end
 
     # The rendered/navigation strip: visible, ordered {symbol, label}. `force` (the active
-    # tab) is ALWAYS present at its catalog-relative position even when hidden — so a jump
-    # to a hidden tab is never stranded off-bar and menu_layout's active_idx lookup always
-    # succeeds (instead of silently falling back to 0).
+    # tab) is ALWAYS present even when hidden — so a jump to a hidden tab is never stranded
+    # off-bar and menu_layout's active_idx lookup always succeeds (instead of silently
+    # falling back to 0). A force-shown hidden tab is APPENDED at the far right (just left of
+    # the ⋯ list), not spliced into its catalog position mid-strip.
     def self.visible_tabs(prefs : Array({String, Bool}), force : Symbol? = nil) : Array({Symbol, String})
       ann = reconcile(prefs)
       vis = ann.select { |(_, _, v)| v }.map { |(s, l, _)| {s, l} }
-      if force && vis.none? { |(s, _)| s == force }
-        if idx = ann.index { |(s, _, _)| s == force }
-          at = ann[0...idx].count { |(_, _, v)| v }
-          vis.insert(at, {ann[idx][0], ann[idx][1]})
-        end
-      end
+      append_forced(ann, vis, force)
       vis
+    end
+
+    # Append the force-shown active tab (a hidden tab jumped to) to the far right of the
+    # visible strip — right next to the ⋯ hidden list — so opening a hidden tab reveals it at
+    # the end of the bar rather than splicing it into the middle at its catalog position. A
+    # no-op when `force` is absent or the tab is already on the bar. Shared by visible_tabs
+    # and split_tabs so the render strip and the nav strip can never drift.
+    private def self.append_forced(ann : Array({Symbol, String, Bool}), vis : Array({Symbol, String}), force : Symbol?) : Nil
+      return unless force && vis.none? { |(s, _)| s == force }
+      if idx = ann.index { |(s, _, _)| s == force }
+        vis << {ann[idx][0], ann[idx][1]}
+      end
     end
 
     # The tabs NOT on the bar — hidden via settings:tabs (Miner by default) — for the
@@ -130,12 +138,7 @@ module Gori::Tui
     def self.split_tabs(prefs : Array({String, Bool}), force : Symbol? = nil) : {Array({Symbol, String}), Array({Symbol, String})}
       ann = reconcile(prefs)
       vis = ann.select { |(_, _, v)| v }.map { |(s, l, _)| {s, l} }
-      if force && vis.none? { |(s, _)| s == force }
-        if idx = ann.index { |(s, _, _)| s == force }
-          at = ann[0...idx].count { |(_, _, v)| v }
-          vis.insert(at, {ann[idx][0], ann[idx][1]})
-        end
-      end
+      append_forced(ann, vis, force)
       hidden = ann.reject { |(s, _, v)| v || s == force }.map { |(s, l, _)| {s, l} }
       {vis, hidden}
     end


### PR DESCRIPTION
## Summary

Jumping to a hidden tab (via the ⋯ dropdown, palette, or a shortcut) force-shows it on the tab bar. But the force-show logic in \`Chrome.visible_tabs\`/\`split_tabs\` spliced the tab in at its **catalog-relative position** (mid-strip) — e.g. Miner landed between Fuzzer and Decoder — so an opened hidden tab appeared arbitrarily in the middle.

Now the force-shown hidden tab is **appended at the far right** of the visible strip, right next to the collapsed-tabs (⋯) list.

## Changes

- Extract the duplicated force-insert logic from \`visible_tabs\` and \`split_tabs\` into one shared \`append_forced\` helper (the nav strip and render strip can no longer drift).
- Change \`vis.insert(at, …)\` (catalog position) → \`vis << …\` (append to end).
- \`hidden_tabs\` is unchanged; the \`split_tabs\` ↔ \`{visible_tabs, hidden_tabs}\` equivalence still holds since both call the shared helper.
- Update the one spec that asserted the old mid-strip placement to assert far-right placement.

## Test

- \`crystal spec spec/tui/chrome_tabs_spec.cr spec/tui/tabs_overlay_spec.cr\` → 31 examples, 0 failures
- \`crystal build src/main.cr\` → OK