### PR TITLE
fix(tui): separate the sub-tab strip from the filter bar with its own hairline

### DIFF
--- a/src/gori/tui/controllers/jwt_controller.cr
+++ b/src/gori/tui/controllers/jwt_controller.cr
@@ -212,7 +212,7 @@ module Gori::Tui
       s = cur
       shell = BodyChrome.shell_focused(focus, multi_pane: true)
       subtabs_focused = focus == :subtabs
-      @subtab_start = BodyChrome.framed_body(screen, rect, shell, subtabs_focused, labels, @idx, @subtab_start, subtab_hidden) do |content|
+      @subtab_start = BodyChrome.framed_body(screen, rect, shell, subtabs_focused, labels, @idx, @subtab_start, subtab_hidden, strip_divider: subtab_strip_divider?) do |content|
         render_with_filter(screen, content, subtabs_focused) do |body|
           if s.mode == :decode
             s.view.render_decode(screen, body,

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -89,9 +89,9 @@ module Gori::Tui
 
     # Frame the tab body, carve the sub-tab strip from the interior top when
     # `labels` is given, then yield the remaining content rect.
-    # `strip_divider: false` carves chips only (height 1) so a sibling row — e.g.
-    # Repeater's always-visible filter bar — can own the hairline underneath the
-    # whole chrome group instead of splitting chips from that row.
+    # `strip_divider: false` carves chips only (height 1), leaving a sibling row to own
+    # the hairline underneath instead of splitting chips from that row. All current tabs
+    # pass `true` (see subtab_strip_divider?); the false path is kept for flexibility.
     def framed_body(screen : Screen, rect : Rect, shell_focused : Bool,
                     subtabs_focused : Bool, labels : Array(String)?, active : Int32,
                     prev_start : Int32 = 0, hidden : Set(Int32)? = nil, *,
@@ -288,11 +288,14 @@ module Gori::Tui
       (0...subtab_count).reject { |i| h.includes?(i) }
     end
 
-    # Whether BodyChrome carves the hairline under the chip row. When a filter bar is
-    # shown the bar owns the hairline (draws it under chips+filter as one chrome group),
-    # so this is false; otherwise true. Runner strip hit-tests read the same flag.
+    # The sub-tab strip always carves its own hairline under the chip row. When a filter
+    # bar is also shown it draws a SECOND hairline below itself, so the chrome reads
+    # chips › ─── › filter › ─── › body (matching Target/Sitemap) instead of gluing the
+    # chips straight onto the filter. Render (framed_body), body geometry
+    # (body_rect_below_filter), and the Runner's strip hit-tests all read this one flag,
+    # so they stay in sync.
     def subtab_strip_divider? : Bool
-      !subtab_filter_shown?
+      true
     end
 
     # ===== sub-tab filter subsystem (issue #121) =============================
@@ -469,8 +472,8 @@ module Gori::Tui
       (!filter_suggestions.empty? || filter_token_empty?) ? base + 1 : base
     end
 
-    # History-style 3-state bar under the sub-tab chips, with the strip hairline drawn
-    # BELOW the filter so chips+filter read as one chrome group:
+    # History-style 3-state bar, sitting under the chips + their own hairline, with its
+    # own hairline drawn BELOW it (chips ─── filter ─── body, matching Target/Sitemap):
     #   editing  → `filter › <input>` [+ `↹ name:…` suggestions]
     #   active   → `: <query>`
     #   idle     → `/ filter  ·  name:  host:  method:` (this tab's advertised fields)


### PR DESCRIPTION
## What

Tabs with **both** a sub-tab strip and a `/` filter bar rendered the chrome as **subtab > filter > separator** — the chips flowed straight into the filter with no divider between them. Target > Sitemap, the reference layout, instead reads **subtab > separator > filter > separator**.

This makes all 8 filter-enabled workbench tabs match Sitemap:

```
before                          after
[ chips        ]                [ chips        ]
[ / filter row ]                [ ──────────── ]   ← new: strip's own hairline
[ ──────────── ]                [ / filter row ]
[ body …       ]                [ ──────────── ]
                                [ body …       ]
```

Affected tabs: **Repeater, Notes, Fuzzer, Convert, Comparer, Sequencer, Miner, JWT**.

## How

The whole thing hinges on one shared predicate, `TabController#subtab_strip_divider?` (`src/gori/tui/tab_controller.cr`), which used to return `!subtab_filter_shown?` — suppressing the strip's hairline whenever a filter was shown. It now always returns `true`. The filter bar already draws its own hairline below itself, so the strip simply gets its own back.

Because that one flag is read by render (`framed_body`), body geometry (`body_rect_below_filter`), and the runner's click hit-tests (`runner.cr`), flipping it keeps them coupled and applies uniformly with no per-controller `render_body` edits.

Side effects:
- Aligned `jwt_controller.cr`'s `framed_body` call with the other 7 (it omitted `strip_divider:`, defaulting to `true` in render but reading the flag in click geometry — a latent off-by-one when its filter was shown). Now consistent.
- Refreshed three now-stale doc comments.

## Notes on scope

Separator styling is unchanged: the newly-surfaced strip hairline is the same plain `─` run Sitemap uses for *its* first separator, so separator #1 matches exactly. Sitemap's second divider is a tee `├───┤` only because it sits below a column-header row inside the view; the workbench filter bar has always drawn a plain `─` for its own divider, left untouched.

## Verification

- `shards build` clean.
- `spec/tui/` — 775 examples, 0 failures (the `foundation_spec` `strip_divider: false` primitive tests still pass; only the policy changed).
- Live TUI (isolated tmux/GORI_HOME): confirmed on **Notes** (2 notes) and **Repeater** (1 session) that the layout renders `chips ─── filter ─── body`, matching **Target > Sitemap** side-by-side.