### PR TITLE
feat: two-level focus in History detail (strip ↔ body) for text selection

### DIFF
--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -342,6 +342,57 @@ describe Gori::Tui::HistoryView do
     end
   end
 
+  it "opens in the body, flips to the strip level, and resets to the body on re-open" do
+    tmp_store do |store|
+      add_flow(store, "GET", "/api", 200)
+      view = HistoryView.new
+      view.reload(store)
+      view.open_detail(store).should be_true
+
+      view.detail_strip_focus?.should be_false # a fresh open lands in the BODY
+      view.set_detail_focus(:strip)            # ↑-at-top ascends to the chip strip
+      view.detail_strip_focus?.should be_true
+      view.open_detail(store).should be_true   # re-opening resets the sub-state
+      view.detail_strip_focus?.should be_false
+    end
+  end
+
+  it "follows the caret horizontally as ←/→ walk a long line (no explicit h-scroll)" do
+    tmp_store do |store|
+      id = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "https", host: "h.test", port: 443,
+        method: "GET", target: "/api", http_version: "HTTP/1.1",
+        head: "GET /api HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice, body: nil))
+      store.update_response(Gori::Store::CapturedResponse.new(
+        flow_id: id, status: 200,
+        head: "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n".to_slice,
+        body: ("HEAD" + ("." * 100) + "TAIL").to_slice, content_type: "text/plain"))
+
+      view = HistoryView.new
+      view.reload(store)
+      view.open_detail(store).should be_true
+      view.toggle_pane # request -> response
+
+      rect = Rect.new(0, 0, 80, 16)
+      # The first render records the body's content width so caret moves can follow-x.
+      b0 = MemoryBackend.new(80, 16)
+      view.render_detail(Screen.new(b0), rect)
+      b0.contains?("HEAD").should be_true
+      b0.contains?("TAIL").should be_false # off the right edge at xscroll 0
+
+      # Park the caret at the start of the long body line, then walk it to end-of-line
+      # (the body has no trailing newline, so moving past EOL clamps — it never wraps).
+      row = view.detail_search_lines("HEAD").first
+      view.goto_detail_line(row + 1)
+      130.times { view.detail_move(0, 1) } # plain ←/→ horizontal caret; ensure_detail_visible_x tracks it
+
+      b1 = MemoryBackend.new(80, 16)
+      view.render_detail(Screen.new(b1), rect)
+      b1.contains?("TAIL").should be_true  # caret-follow scrolled the tail into view
+      b1.contains?("HEAD").should be_false # the start slid off the left edge
+    end
+  end
+
   it "pretty-prints a JSON response body when enabled, and restores raw when off" do
     tmp_store do |store|
       id = store.insert_flow(Gori::Store::CapturedRequest.new(

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -44,7 +44,12 @@ module Gori::Tui
       # List (optionally + bottom Req/Res preview) or full detail drill-in.
       proxy = @host.session.proxy
       if @host.overlay == :detail
-        BodyChrome.framed(screen, rect, body_focused) { |inner| @history.render_detail(screen, inner, focused: body_focused) }
+        # Two-level detail focus: the STRIP (chip row) vs the BODY. When the strip holds
+        # focus the frame greys and the caret/selection stand down (gated on `focused`),
+        # while the active chip lights a gold pill (strip_focused).
+        strip_here = body_focused && @history.detail_strip_focus?
+        body_here = body_focused && !@history.detail_strip_focus?
+        BodyChrome.framed(screen, rect, body_here) { |inner| @history.render_detail(screen, inner, focused: body_here, strip_focused: strip_here) }
       else
         @history.refresh_preview(@host.session.store) if @history.preview_enabled?
         BodyChrome.framed(screen, rect, body_focused) do |inner|
@@ -73,8 +78,10 @@ module Gori::Tui
       if @host.overlay == :detail
         if pane = @history.detail_pane_at(inner, mx, my)
           @history.set_detail_pane_public(pane)
+          @history.set_detail_focus(:strip) # a chip click parks focus on the strip
         elsif mode = @history.detail_mode_at(inner, mx, my)
           @host.focus_body
+          @history.set_detail_focus(:strip) # the mode chips live on the strip row too
           case mode
           when :hex    then @history.toggle_detail_hex
           when :ws     then @host.toggle_reveal
@@ -83,6 +90,7 @@ module Gori::Tui
         elsif my >= inner.y + 2
           body = Rect.new(inner.x + 1, inner.y + 2, {inner.w - 2, 0}.max, {inner.bottom - (inner.y + 2), 0}.max)
           @host.focus_body
+          @history.set_detail_focus(:body) # a body click enters the caret/text level
           @history.detail_click_to_cursor(body, mx, my, focused: true)
         end
         return true
@@ -139,25 +147,70 @@ module Gori::Tui
       true
     end
 
+    # Two-level detail input, the direct analogue of Runner#handle_subtabs_key: the chip
+    # row (STRIP) switches panes / descends; the BODY moves the caret + selects. Runs
+    # BEFORE the HistoryDetail verb keymap, so returning true shadows the plain-arrow
+    # verbs; anything it returns false for (esc, Tab, ^X/b/p, ^R/⇧F, x select-line) falls
+    # through to the keymap.
     def handle_detail_key(ev : Termisu::Event::Key) : Bool
       return false unless @host.overlay == :detail
       if ev.key.space? && !ev.ctrl? && !ev.alt?
         @host.open_space_menu
         return true
       end
-      return true if handle_detail_hscroll(ev)
+      @history.detail_strip_focus? ? handle_detail_strip_key(ev) : handle_detail_body_key(ev)
+    end
+
+    # STRIP level: the chip row acts as a focusable sub-tab strip. ←/→ switch panes
+    # (clamped at both ends — no auto-close), ↓/↵/j descend into the body, ↑/k pop out
+    # (close detail → the tab bar). esc/Tab/toggles fall through (return false).
+    private def handle_detail_strip_key(ev : Termisu::Event::Key) : Bool
+      return false if ev.ctrl? || ev.alt?
       key = ev.key
-      selecting = ev.shift?
-      nav = @history.detail_navigable?
       case
-      when key.left? && selecting  then @history.detail_move(0, -1, selecting: true) if nav
-      when key.right? && selecting then @history.detail_move(0, 1, selecting: true) if nav
-      when key.up? && selecting, key.lower_k? && selecting
-        @history.detail_move(-1, 0, selecting: true) if nav
-      when key.down? && selecting, key.lower_j? && selecting
-        @history.detail_move(1, 0, selecting: true) if nav
-      when ev.char == 'y' || ev.key.lower_y?
-        detail_copy_selection
+      when key.left?, key.lower_h?             then @history.detail_pane_advance(-1)
+      when key.right?, key.lower_l?            then @history.detail_pane_advance(1)
+      when key.down?, key.lower_j?, key.enter? then @history.set_detail_focus(:body)
+      when key.up?, key.lower_k?               then close_detail; @host.request_focus(:menu)
+      else
+        return false
+      end
+      true
+    end
+
+    # BODY level: caret move + shift-selection (all four directions, incl. horizontal
+    # ⇧←/→), y copies. ↑/k at the very top ascends to the STRIP instead of scrolling.
+    # detail_move self-guards on detail_navigable? (a no-op in the hex dump), so plain
+    # ←/→ just do nothing there and no explicit gate is needed here.
+    private def handle_detail_body_key(ev : Termisu::Event::Key) : Bool
+      return true if ev.shift? && handle_detail_body_select(ev) # ⇧arrows extend the selection
+      key = ev.key
+      case
+      when key.left?, key.lower_h?        then @history.detail_move(0, -1) # plain horizontal caret
+      when key.right?, key.lower_l?       then @history.detail_move(0, 1)
+      when key.up?, key.lower_k?          then detail_body_up
+      when key.down?, key.lower_j?        then @history.scroll_detail(1)
+      when ev.char == 'y' || key.lower_y? then detail_copy_selection
+      else
+        return false
+      end
+      true
+    end
+
+    # ↑/k in the body: at the very top ascend to the STRIP, else move the caret up.
+    private def detail_body_up : Nil
+      @history.detail_at_top? ? @history.set_detail_focus(:strip) : @history.scroll_detail(-1)
+    end
+
+    # ⇧+arrow (or ⇧+h/j/k/l) extends the selection from the caret. Returns false for a
+    # non-arrow key so the caller falls through to the plain-nav case.
+    private def handle_detail_body_select(ev : Termisu::Event::Key) : Bool
+      key = ev.key
+      case
+      when key.up?, key.lower_k?    then @history.detail_move(-1, 0, selecting: true)
+      when key.down?, key.lower_j?  then @history.detail_move(1, 0, selecting: true)
+      when key.left?, key.lower_h?  then @history.detail_move(0, -1, selecting: true)
+      when key.right?, key.lower_l? then @history.detail_move(0, 1, selecting: true)
       else
         return false
       end
@@ -176,31 +229,20 @@ module Gori::Tui
       @history.detail_clear_selection
     end
 
-    private def handle_detail_hscroll(ev : Termisu::Event::Key) : Bool
-      key = ev.key
-      if key.left? && ev.shift?
-        @history.hscroll_detail(-1)
-        true
-      elsif key.right? && ev.shift?
-        @history.hscroll_detail(1)
-        true
-      else
-        false
-      end
-    end
-
     def body_hint(focus : Symbol) : String
       reg = @host.session.registry
-      y = Hotkeys.binding_label(reg, "history.copy", "y")
       repeater = Hotkeys.binding_label(reg, "history.repeater", "^R")
       issue = Hotkeys.binding_label(reg, "issue.create", "⇧F")
       follow = Hotkeys.binding_label(reg, "history.toggle-follow", "f")
       filter = Hotkeys.binding_label(reg, "history.query", "/")
       intercept = Hotkeys.binding_label(reg, "intercept.toggle", "i")
       if @host.overlay == :detail
-        nav = @history.detail_navigable? ? "↑/↓ move" : "↑/↓ scroll"
+        if @history.detail_strip_focus?
+          return "←/→ panes · ↓/↵ enter · ↑ tabs · ↹ pane · space cmds · esc back"
+        end
+        nav = @history.detail_navigable? ? "↑/↓ move · ←/→ caret" : "↑/↓ scroll"
         dy = Hotkeys.binding_label(reg, "detail.copy", "y")
-        return "←/→ panes · #{nav} · ⇧arrows select · #{dy} copy · ⇧←/→ h-scroll · space cmds · esc back"
+        return "#{nav} · ⇧arrows select · #{dy} copy · ↑ strip · ↹ pane · space cmds · esc back"
       end
       return "type query · ↹ complete · ↵ apply · esc clear" if @history.querying?
       if @history.preview_enabled?

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -89,8 +89,9 @@ module Gori::Tui
       @detail_form = nil.as(Array(FormData::Field)?) # form/multipart params → PARAMS pane
       @decoded_id = nil.as(Int64?)                   # flow the decoded panes above were parsed from (skip re-decode)
       @detail_scroll = 0
-      @detail_xscroll = 0 # horizontal scroll offset for the detail body (shift+←/→)
+      @detail_xscroll = 0 # horizontal scroll offset for the detail body (caret-follow)
       @detail_pane = initial_detail_pane
+      @detail_focus = :body                  # :strip (chip row) | :body (caret/text) — two-level detail focus
       @search_hl = ""                        # active ^F query → highlight in the detail body
       @reveal = false                        # 'w' shows whitespace/CR/LF as glyphs (smuggling)
       @reveal_lines = nil.as(Array(String)?) # cached revealed lines, keyed on the pane bytes ptr
@@ -111,6 +112,7 @@ module Gori::Tui
       @detail_cache_rev = Theme.revision # the theme the cached (colour-baked) head/notes were built under
       @detail_read = ReadCursor.new
       @detail_last_h = 0
+      @detail_last_cw = 0 # last body content width — drives horizontal caret-follow (ensure_detail_visible_x)
       # settings:layout History Req/Res preview (list page bottom pane) — separate from full detail.
       @preview_detail = nil.as(Store::FlowDetail?)
       @preview_id = nil.as(Int64?)
@@ -578,6 +580,7 @@ module Gori::Tui
       @detail_scroll = 0
       @detail_xscroll = 0
       @detail_pane = initial_detail_pane
+      @detail_focus = :body # open lands in the body (immediate read/scroll); the strip is one ↑-at-top away
       drop_detail_cache
       @detail_hex = false # hex is a deliberate per-open peek — don't carry it into the next flow
       @detail_hex_bytes = nil
@@ -733,6 +736,7 @@ module Gori::Tui
       return if size <= 0
       @detail_read.move(dr, dc, size, line_at, selecting)
       ensure_detail_visible(@detail_last_h) if @detail_last_h > 0
+      ensure_detail_visible_x(@detail_last_cw) if @detail_last_cw > 0
     end
 
     # Wheel: scroll the viewport without moving the caret (READ panes).
@@ -866,6 +870,25 @@ module Gori::Tui
       elsif cy >= @detail_scroll + view_h
         @detail_scroll = cy - view_h + 1
       end
+    end
+
+    # Horizontal companion to ensure_detail_visible: slide @detail_xscroll so the caret
+    # column stays inside the visible content width [xscroll, xscroll + cw). Mirrors
+    # TextArea#ensure_visible_x; uses Screen.column_width (the caret painter's measure).
+    private def ensure_detail_visible_x(cw : Int32) : Nil
+      return if cw <= 0
+      size, line_at = detail_line_source
+      return if size <= 0 || @detail_read.cy >= size
+      line = line_at.call(@detail_read.cy)
+      if Screen.column_width(line) <= cw
+        @detail_xscroll = 0
+        return
+      end
+      cx = @detail_read.cx.clamp(0, line.size)
+      curx = Screen.column_width(line[0, cx])
+      @detail_xscroll = curx if curx < @detail_xscroll
+      @detail_xscroll = curx - cw + 1 if curx >= @detail_xscroll + cw
+      @detail_xscroll = 0 if @detail_xscroll < 0
     end
 
     # Horizontal companion to `scroll_detail` (shift+←/→). Floored at 0 here; the
@@ -1032,6 +1055,17 @@ module Gori::Tui
     # panes from a chip click (it ignores an unknown/inactive pane symbol).
     def set_detail_pane_public(pane : Symbol) : Nil
       set_detail_pane(pane) if detail_panes.includes?(pane)
+    end
+
+    # Two-level detail focus: the chip row (:strip) vs the caret/text body (:body).
+    # ←/→ switch panes at the strip level and move the caret at the body level; the
+    # split is invisible to the verb layer (current_scope keys off @overlay only).
+    def detail_strip_focus? : Bool
+      @detail_focus == :strip
+    end
+
+    def set_detail_focus(f : Symbol) : Nil
+      @detail_focus = f
     end
 
     # Tab: cycle forward through the panes, wrapping back to REQUEST.
@@ -1364,7 +1398,7 @@ module Gori::Tui
       end
     end
 
-    def render_detail(screen : Screen, rect : Rect, focused : Bool = true) : Nil
+    def render_detail(screen : Screen, rect : Rect, focused : Bool = true, strip_focused : Bool = false) : Nil
       return if rect.empty?
       detail = @detail
       unless detail
@@ -1375,27 +1409,20 @@ module Gori::Tui
       Frame.list_back_hint(screen, rect)
       # Pane strip: show ALL panes as chips with the active one highlighted, so it's
       # obvious there's more behind (←/→ walk REQUEST → RESPONSE → FRAMES).
-      x = rect.x + 1
-      detail_panes.each do |pane|
-        active = pane == @detail_pane
-        x = screen.text(x, rect.y, " #{detail_pane_label(pane)} ",
-          active ? Theme.text_bright : Theme.muted,
-          active ? Theme.accent_bg : Theme.bg,
-          attr: active ? Attribute::Bold : Attribute::None) + 1
-      end
+      x = render_detail_chips(screen, rect, strip_focused)
       hex = detail_hex?(detail)
       dv = detail_view
       # A binary body is shown as a placeholder; the reveal-whitespace path renders raw
       # bytes as text, so gate it off there too — otherwise `b` re-triggers the very
       # cursor-desync corruption the placeholder exists to avoid. Pretty likewise n/a.
       ws = @reveal && !hex && !dv.binary
-      nav = detail_navigable? ? "↑/↓ · ⇧sel · y" : "↑/↓ scroll"
+      nav = detail_navigable? ? "↑/↓←/→ · ⇧sel · y" : "↑/↓ scroll"
       # Status word + mode toggle chips (mouse + same chords as keys), then muted nav.
       x = screen.text(x + 1, rect.y, detail_mode_status(hex, ws, dv), Theme.muted) + 1
       detail_mode_chips(hex, ws, dv).each do |(_, label, lit)|
         x = Frame.chip(screen, x, rect.y, label, lit) + 1
       end
-      screen.text(x + 1, rect.y, "· #{nav} · ⇧←/→ · space · esc", Theme.muted)
+      screen.text(x + 1, rect.y, "· #{nav} · space · esc", Theme.muted)
       Frame.inner_divider(screen, rect, rect.y + 1, border: Frame.pane_border(focused))
 
       body = Rect.new(rect.x + 1, rect.y + 2, {rect.w - 2, 0}.max, {rect.bottom - (rect.y + 2), 0}.max)
@@ -1411,6 +1438,22 @@ module Gori::Tui
       render_detail_body(screen, body, focused: focused)
     end
 
+    # Draws the pane chip strip and returns the x column just past the last chip. The
+    # active chip is a gold pill when the strip holds focus (same "gold = focus is here"
+    # cue as the sub-tab strips one level up), else the accent pill; body-focused keeps
+    # today's look.
+    private def render_detail_chips(screen : Screen, rect : Rect, strip_focused : Bool) : Int32
+      x = rect.x + 1
+      detail_panes.each do |pane|
+        active = pane == @detail_pane
+        fg = active ? (strip_focused ? Theme.ink_on(Theme.focus_gold) : Theme.text_bright) : Theme.muted
+        bg = active ? (strip_focused ? Theme.focus_gold : Theme.accent_bg) : Theme.bg
+        x = screen.text(x, rect.y, " #{detail_pane_label(pane)} ", fg, bg,
+          attr: active ? Attribute::Bold : Attribute::None) + 1
+      end
+      x
+    end
+
     # The normal (non-hex, non-reveal) detail body: request/response/decoded-pane text,
     # windowed + horizontally scrollable. Split out of render_detail to keep that
     # dispatch's cyclomatic complexity under ameba's threshold.
@@ -1423,6 +1466,7 @@ module Gori::Tui
       @detail_last_h = body.h
       gw = Settings.show_gutter ? {Gutter.width(total), body.w}.min : 0
       cw = {body.w - gw, 0}.max
+      @detail_last_cw = cw # remember for horizontal caret-follow (ensure_detail_visible_x)
       # Styles each visible line ONCE (into `rows`), then clamps/slices from that —
       # never re-styles just to measure width (mirrors RepeaterView#render_response_body).
       rows = (0...body.h).compact_map { |i| (li = @detail_scroll + i) < total ? styled_detail_line(dv, li) : nil }
@@ -1442,7 +1486,7 @@ module Gori::Tui
         Highlight.draw(screen, body.x + gw, body.y + i, shown, width: cw)
         need_plain = (focused && detail_navigable? && (li == @detail_read.cy || sel_spans)) || !@search_hl.empty?
         plain = need_plain ? dv.line_text(li) : nil
-        paint_detail_line_chrome(screen, body.x + gw, body.y + i, li, plain, focused, sel_spans)
+        paint_detail_line_chrome(screen, body.x + gw, body.y + i, li, plain, focused, cw, sel_spans)
         # The plain-text line + its left-slice feed ONLY the search overlay, so skip both
         # when no query is active (else every frame builds/scans discarded strings per row).
         if (text = plain) && !@search_hl.empty?
@@ -1459,6 +1503,7 @@ module Gori::Tui
       @detail_last_h = body.h
       gw = Settings.show_gutter ? {Gutter.width(total), body.w}.min : 0
       cw = {body.w - gw, 0}.max
+      @detail_last_cw = cw # remember for horizontal caret-follow (ensure_detail_visible_x)
       widest = (0...body.h).compact_map { |i| lines[@detail_scroll + i]? }.max_of? { |l| Screen.display_width_upto(l, @detail_xscroll + cw + 1) } || 0
       @detail_xscroll = @detail_xscroll.clamp(0, {widest - cw, 0}.max)
       ensure_detail_visible(body.h) if detail_navigable? && focused
@@ -1469,38 +1514,41 @@ module Gori::Tui
         styled = Reveal.styled(lines[li], li < total - 1, cw + @detail_xscroll)
         styled = Highlight.slice_left(styled, @detail_xscroll) if @detail_xscroll > 0
         Highlight.draw(screen, body.x + gw, body.y + i, styled, width: cw)
-        paint_detail_line_chrome(screen, body.x + gw, body.y + i, li, lines[li], focused)
+        paint_detail_line_chrome(screen, body.x + gw, body.y + i, li, lines[li], focused, cw)
         st = @detail_xscroll > 0 ? Highlight.slice_left_text(lines[li], @detail_xscroll) : lines[li]
         SearchHi.mark(screen, body.x + gw, body.y + i, st, @search_hl, body.x + gw + cw) unless @search_hl.empty?
       end
     end
 
+    # cw = visible content width; caret + selection are shifted by @detail_xscroll and
+    # clipped to [x, x + cw) so they stay aligned with the horizontally-scrolled body.
     private def paint_detail_line_chrome(screen : Screen, x : Int32, y : Int32, li : Int32,
-                                         line : String?, focused : Bool,
+                                         line : String?, focused : Bool, cw : Int32,
                                          sel_spans : Array({Int32, Int32, Int32})? = nil) : Nil
       return unless focused && detail_navigable? && line
       if spans = sel_spans
         spans.each do |(l, x0, x1)|
-          paint_char_span_bg(screen, x, y, line, x0, x1, Theme.accent_bg) if l == li
+          paint_char_span_bg(screen, x, y, line, x0, x1, cw, Theme.accent_bg) if l == li
         end
       end
       return unless li == @detail_read.cy
       cx = @detail_read.cx.clamp(0, line.size)
-      px = x + Screen.column_width(line[0, cx])
+      px = x + Screen.column_width(line[0, cx]) - @detail_xscroll
+      return if px < x || px >= x + cw # caret scrolled outside the visible content
       ch = cx < line.size ? line[cx] : ' '
       screen.cell(px, y, ch, Theme.bg, Theme.accent_bg)
       screen.cursor(px, y)
     end
 
     private def paint_char_span_bg(screen : Screen, x : Int32, y : Int32, line : String,
-                                   x0 : Int32, x1 : Int32, bg : Color) : Nil
-      return if x0 >= x1
-      px = x
-      (0...x0).each { |i| px += Screen.column_width(line[i].to_s) } if x0 > 0
+                                   x0 : Int32, x1 : Int32, cw : Int32, bg : Color) : Nil
+      return if x0 >= x1 || cw <= 0
+      # Start at the span's on-screen column: display width up to x0, shifted by xscroll.
+      px = x + Screen.column_width(line[0, {x0, line.size}.min]) - @detail_xscroll
       (x0...x1).each do |i|
         break if i >= line.size
         w = Screen.column_width(line[i].to_s)
-        screen.text(px, y, line[i].to_s, Theme.text, bg)
+        screen.text(px, y, line[i].to_s, Theme.text, bg) if px >= x && px + w <= x + cw
         px += w
       end
     end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -5364,18 +5364,11 @@ module Gori::Tui
     end
 
     def scroll_detail(delta : Int32) : Nil
-      # ↑ at the very top of the open detail pops focus up to the tab bar, mirroring
-      # the list's ↑-at-top → TABS. current_scope keys off @overlay before @focus, so
-      # the menu isn't reachable while :detail is open — close the detail first, then
-      # land on the bar. ↑ and ↓ aren't inverses here: ↵/↓ from the bar re-enters the
-      # LIST (not the detail), but the row selection is kept so re-opening is one key.
-      # Only the single-step detail.up/down verbs route here; PageUp (Runner) and the
-      # wheel (controller/view) bypass this, so paging/scrolling never ejects to TABS.
-      if delta < 0 && @overlay == :detail && history_controller.detail_at_top?
-        history_controller.close_detail
-        focus_pane(:menu)
-        return
-      end
+      # The two-level detail (HistoryController#handle_detail_body_key/strip_key) now owns
+      # the ↑/↓ ladder — ↑-at-top-of-body ascends to the STRIP, ↑-on-strip closes to the
+      # tab bar — so this ExecContext method (kept for the abstract def + the shadowed
+      # detail.up/down verbs) is a plain delegate. PageUp/Down still route here via the
+      # controller directly.
       history_controller.scroll_detail(delta)
     end
 

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -251,7 +251,7 @@ module Gori
         hidden: true) { |ctx| ctx.move_detail_pane(1); nil }
 
       r.register Verb::Definition.new(
-        "detail.prev-pane", "Previous pane ←", "Move to the previous detail pane (FRAMES → RES → REQ; past REQ returns to the list)",
+        "detail.prev-pane", "Previous pane ←", "Move to the previous detail pane (FRAMES → RES → REQ)",
         Verb::Scope::HistoryDetail, [Verb::Chord.new("left"), Verb::Chord.new("h")],
         hidden: true) { |ctx| ctx.move_detail_pane(-1); nil }
 
@@ -263,16 +263,9 @@ module Gori
         "detail.up", "Move detail up", "Move the detail caret up (scroll in hex mode)", Verb::Scope::HistoryDetail,
         [Verb::Chord.new("k"), Verb::Chord.new("up")], hidden: true) { |ctx| ctx.scroll_detail(-1); nil }
 
-      # Shift+←/→ scroll a long line sideways instead of walking panes (plain ←/→,
-      # registered above as detail.next-pane/detail.prev-pane) — distinct chords
-      # (shift: true), so they coexist without collision.
-      r.register Verb::Definition.new(
-        "detail.hscroll-right", "Scroll detail right", "Scroll a long line right", Verb::Scope::HistoryDetail,
-        [Verb::Chord.new("right", shift: true)], hidden: true) { |ctx| ctx.hscroll_detail(1); nil }
-
-      r.register Verb::Definition.new(
-        "detail.hscroll-left", "Scroll detail left", "Scroll a long line left", Verb::Scope::HistoryDetail,
-        [Verb::Chord.new("left", shift: true)], hidden: true) { |ctx| ctx.hscroll_detail(-1); nil }
+      # Shift+←/→ now extends a horizontal selection (handled inline in
+      # HistoryController#handle_detail_body_key), so there is no dedicated h-scroll
+      # binding — the caret follows the viewport instead (ensure_detail_visible_x).
 
       r.register Verb::Definition.new(
         "detail.toggle-pane", "Switch pane (cycle)", "Cycle REQ → RES → FRAMES",


### PR DESCRIPTION
## What

Restructures the History **DETAIL** drill-in into a two-level focus model: the REQ/RES/FRAMES chip row is now a focusable **STRIP** (sub-tab style) and the body is a separate **BODY** level — mirroring the app's sub-tabs→body descent (`handle_subtabs_key`).

## Why

In the detail view the arrow keys were overloaded (pane-switch + scroll + shift-line-select), so there was no "in the pane" mode and **horizontal/partial keyboard selection was impossible** — `Shift+←/→` was intercepted as h-scroll before the selection branches ever ran. This gives a clean place to select text in the read-only panes.

## Behavior

- **STRIP**: `←/→` (`h/l`) switch panes, `↓`/`↵` descend into the body, `↑` closes to the tab bar, `Tab` cycles. Active chip lights a gold pill.
- **BODY** (default on open — immediate read/scroll preserved): `←/→` move the caret horizontally (viewport follows), `Shift`+any arrow selects (incl. horizontal `Shift+←/→`), `y` copies, `↑`-at-top ascends to the strip.
- Mouse: click a chip → strip focus + that pane; click the body → body focus + caret.

Scope is **focus-model only — no mouse-drag** (per design decision; drag would need SGR mode 1002 + motion wiring, out of scope here).

## Notable

- New `HistoryView#ensure_detail_visible_x` (mirrors `TextArea#ensure_visible_x`) so the caret follows horizontally; `detail.hscroll-*` verbs dropped.
- **Caret/selection painters fixed** to offset by `@detail_xscroll` and clip to the content width — they previously assumed no horizontal scroll, which would have detached the caret/highlight on long lines.

## Testing

- `crystal spec spec/tui spec/verb` → **823 pass**, incl. 2 new `history_view_spec` cases (strip-focus default/flip/reset; horizontal caret-follow).
- Typecheck clean; ameba clean on the changed files (no `crystal tool format`, hand-matched).
- Verified end-to-end via tmux: all focus transitions, gold strip chip, `HEAD…`→`…TAIL` caret-follow, `Shift+←`+`y` copy, and mouse chip/body focus.
