### PR TITLE
tui: default history detail focus to strip (subtabs)

### DIFF
--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -280,10 +280,10 @@ describe Gori::Tui::HistoryView do
       view.reload(store)
       view.open_detail(store).should be_true
 
-      view.detail_at_top?.should be_true  # fresh open → caret on row 0
-      view.scroll_detail(1)               # caret down one line
+      view.detail_at_top?.should be_true # fresh open → caret on row 0
+      view.scroll_detail(1)              # caret down one line
       view.detail_at_top?.should be_false
-      view.scroll_detail(-1)              # back to row 0
+      view.scroll_detail(-1) # back to row 0
       view.detail_at_top?.should be_true
     end
   end
@@ -342,18 +342,18 @@ describe Gori::Tui::HistoryView do
     end
   end
 
-  it "opens in the body, flips to the strip level, and resets to the body on re-open" do
+  it "opens on the strip, flips to the body level, and resets to the strip on re-open" do
     tmp_store do |store|
       add_flow(store, "GET", "/api", 200)
       view = HistoryView.new
       view.reload(store)
       view.open_detail(store).should be_true
 
-      view.detail_strip_focus?.should be_false # a fresh open lands in the BODY
-      view.set_detail_focus(:strip)            # ↑-at-top ascends to the chip strip
-      view.detail_strip_focus?.should be_true
-      view.open_detail(store).should be_true   # re-opening resets the sub-state
+      view.detail_strip_focus?.should be_true # a fresh open lands on the STRIP
+      view.set_detail_focus(:body)            # enters the body (caret/text)
       view.detail_strip_focus?.should be_false
+      view.open_detail(store).should be_true # re-opening resets the sub-state to STRIP
+      view.detail_strip_focus?.should be_true
     end
   end
 

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -91,7 +91,7 @@ module Gori::Tui
       @detail_scroll = 0
       @detail_xscroll = 0 # horizontal scroll offset for the detail body (caret-follow)
       @detail_pane = initial_detail_pane
-      @detail_focus = :body                  # :strip (chip row) | :body (caret/text) — two-level detail focus
+      @detail_focus = :strip                 # :strip (chip row) | :body (caret/text) — two-level detail focus
       @search_hl = ""                        # active ^F query → highlight in the detail body
       @reveal = false                        # 'w' shows whitespace/CR/LF as glyphs (smuggling)
       @reveal_lines = nil.as(Array(String)?) # cached revealed lines, keyed on the pane bytes ptr
@@ -580,7 +580,7 @@ module Gori::Tui
       @detail_scroll = 0
       @detail_xscroll = 0
       @detail_pane = initial_detail_pane
-      @detail_focus = :body # open lands in the body (immediate read/scroll); the strip is one ↑-at-top away
+      @detail_focus = :strip # open lands on the strip (sub-tabs/chips); down-arrow enters the body
       drop_detail_cache
       @detail_hex = false # hex is a deliberate per-open peek — don't carry it into the next flow
       @detail_hex_bytes = nil


### PR DESCRIPTION
This PR updates the default detail view focus in TUI > History to target the sub-tabs (chips strip) by default instead of the editor body.