### PR TITLE
chore: scaffold AI-parallel refactor — docs + test isolation (1/13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,134 @@
+# CLAUDE.md — working in the gori codebase
+
+gori (고리, Korean for *ring / link / loop*) is a keyboard-first TUI web proxy for
+authorized penetration testing: it sits between a client and its target, capturing
+every request/response as a *flow* you can intercept, replay, fuzz, and scan across
+HTTP/1.1, HTTP/2, WebSocket, gRPC, and SSE. Every capability is exposed on three
+surfaces: the TUI, the `gori run` CLI, and the `gori mcp` MCP server.
+
+It is written in **Crystal** and runs on the single-threaded fiber scheduler
+(**never build with `-Dpreview_mt`** — Store, Fuzz::Engine, Miner::Engine and
+Store::SafeRegexp document plain ivars/unguarded counters that are only safe under
+cooperative scheduling).
+
+## Build / test / lint
+
+Use `just` (see `justfile`):
+
+| Command | What |
+|---|---|
+| `just build` (`shards build`) | build `bin/gori` |
+| `just dev` | build + run the TUI |
+| `just test` (`crystal spec`) | full suite (~148 files, sequential, one binary) |
+| `just test-<area>` | one `spec/` subdir, e.g. `just test-tui`, `just test-store` |
+| `just test-file path=spec/foo_spec.cr` | a single file (also: `crystal spec spec/foo_spec.cr`) |
+| `just check` | `crystal tool format --check` + ameba |
+| `just fix` | auto-format + ameba `--fix` |
+
+**Never run `crystal tool format` across the whole tree.** The pinned Crystal version
+drifts from the one the tree was last formatted with, so a blanket format reformats
+~40 unrelated files. Format only files you changed (`crystal tool format <files>`) and
+otherwise match the surrounding style by hand. ameba config lives in `.ameba.yml`
+(cyclomatic complexity cap is 12).
+
+## Module map (`src/gori/`)
+
+| Path | Responsibility |
+|---|---|
+| `proxy/` | MITM proxy: `codec/` (HTTP/1 + body), `h2/` (HTTP/2, HPACK, gRPC), `tls/` (CA, tunnel), `conn/`, `server.cr` |
+| `store.cr` + `store/` | SQLite persistence. Single-writer-fiber + `Channel`; reads via WAL pool. `store/{models,schema,compact,safe_regexp}.cr` are class-reopening partials |
+| `repeater/` | replay engines (`engine`, `h2_engine`, `ws_engine`, `diff`) shared by all three surfaces |
+| `fuzz/` `miner/` `sequencer/` `discover/` `oast/` `probe/` | pure engines for each tool tab (Intruder-style fuzzing, param mining, token randomness, spider/brute, out-of-band, passive+active scan) |
+| `scope.cr` `rules.cr` `host_overrides.cr` `interceptor.cr` | mutex-guarded domain wrappers over a Store slice; read on the proxy hot path, written from the TUI |
+| `ql.cr` | the History query language (see DESIGN.md §4) |
+| `verb.cr` + `verb/` + `verbs/` | the TUI action/command system (keybinding + palette + space-menu, one code path) |
+| `mcp.cr` + `mcp/` | MCP server; `mcp/tools.cr` is the tool surface |
+| `cli.cr` + `cli/` | CLI entry + `cli/run.cr` (the `gori run` headless suite) |
+| `tui/` | terminal UI (see below) |
+| `settings.cr` + `settings/` | persisted config (module-level, no mutex — TUI-fiber only) |
+| `decoder.cr` `jwt.cr` `saml.cr` `graphql.cr` `pretty.cr` `sse.cr` `proto.cr` | payload decode / pretty-print helpers |
+
+### The TUI seams (`src/gori/tui/`)
+
+The shell (`runner.cr`) owns the event loop, tab bar, and modal overlays. Everything
+tab-specific lives behind two clean seams — **respect them; do not reach around them**:
+
+- **`TabController`** (`tab_controller.cr`) — one per top-level tab, built once in
+  `Runner#initialize`. Reaches the shell **only** through the **`Host`** module
+  (defined in `runner.cr`); it never touches another controller or `Runner` directly.
+  Override `tab` / `command_scope` / `render_body` + optional hooks. A tab's rendering
+  and ephemeral edit state live in a plain `*_view.cr` class the controller drives.
+- **`Overlay`** (`tui/overlay.cr`, *arriving in the overlay-refactor PRs*) — the same
+  idea for modal popups, reached through `OverlayHost`. Until then, overlays are still
+  hand-wired in `runner.cr`'s dispatch ladders.
+
+## Design principles (P0–P8)
+
+Cited inline throughout the source as `(P4 — ...)`. Defined once in **DESIGN.md §1**.
+Short form:
+
+- **P0** — minimal. Don't build speculative abstraction or hierarchy; add structure
+  only when a concrete need forces it.
+- **P1** — one execution path. A keybinding, a palette entry, and a space-menu item
+  all fire the *same* `Verb::Definition#call`; there is no parallel dispatch.
+- **P3** — no premature generalization of the data model (e.g. every distinct URL
+  segment is its own sitemap node; no path templating).
+- **P4** — the human decides. Intercept holds an in-flight message indefinitely for a
+  human decision; scope gates are explicit, never inferred.
+- **P5** — state changes are mediated through a narrow facade (`Host` / `OverlayHost`
+  / `Verb::ExecContext`), never by touching raw TUI/proxy/store state.
+- **P6** — never stall the data path. Batch/stream on the proxy and writer hot paths
+  (amortize fsync, immediate socket writes).
+- **P7** — the raw wire bytes are the truth. Parsed/pretty views are derived and are
+  never round-tripped back onto the wire lossily.
+- **P8** — pull, not push. No ranking or queueing; History/analysis is query-driven
+  (QL), fetched lazily per on-screen row.
+
+(There is no P2 — inline `CSP2` references are an unrelated version string.)
+
+## How to add a feature
+
+> The steps marked **[shared]** edit a central file that other in-flight features also
+> touch. The de-collision PRs are converting these to per-feature self-registration;
+> this section is updated as each lands. When two of you add features at once, expect
+> the [shared] edits to conflict and keep them to a pure tail-append.
+
+**A new tab** (pure engine → TUI → CLI → MCP):
+
+1. Pure engine + persistence: a `src/gori/<feature>.cr` (or `<feature>/`) module and,
+   if it stores data, a new migration appended to `store/schema.cr`'s `MIGRATIONS`
+   **[shared, and strictly ordered — coordinate the version number]** plus a
+   `store/<feature>.cr` concern partial.
+2. TUI: `tui/controllers/<feature>_controller.cr` (+ a `*_view.cr`), registered in
+   `Runner#initialize` **[shared]**; `chrome.cr` `TABS`/`DEFAULT_HIDDEN` **[shared]**;
+   a `Verb::Scope` member appended at the **tail** of the enum in `verb.cr` **[shared]**
+   (append-only — never reorder; exhaustive `case`s depend on it); `verbs/<feature>.cr`
+   with a `register_<feature>` added to the chain in `verbs/history.cr` **[shared]**;
+   the tab-jump hash in `verbs/core.cr` **[shared]**.
+3. CLI (if scriptable): a `cmd_<feature>` in `cli/run.cr` + its `dispatch_subcommand`
+   case + the `SUBCOMMANDS` help array **[shared]**.
+4. MCP (if agent-facing): schema in `list(j)`, a `read_tool`/`action_tool` case, and
+   `AGENT_ACTION_TOOLS` if it mutates — all in `mcp/tools.cr` **[shared]**.
+5. `require` the new files (`src/gori.cr`, `app.cr`) **[shared]**.
+6. Specs mirroring the source under `spec/`.
+
+**A new overlay** (modal popup): today, add its ivar and thread it through every
+`case @overlay` ladder in `runner.cr` (`modal_overlay?`, `apply_preedit`,
+`handle_overlay_click`, `wheel_overlay`, `focus_label`, `key_hints`, the `handle_key`
+chain, the render ladder) **[shared, ~8 sites — keep them identical]**. After the
+overlay-refactor PRs this becomes: one `tui/overlays/<feature>_overlay.cr` subclassing
+`Overlay`, opened via `open_overlay(...)`, no `runner.cr` edit.
+
+## Tests
+
+- The suite compiles into one binary and runs sequentially; specs self-isolate with
+  tempfile DBs (`File.tempname`).
+- **`spec/spec_helper.cr` points `ENV["GORI_HOME"]` at a per-run temp dir** and cleans
+  it up after the suite. **Never read or write the real `~/.gori` from a spec, and
+  don't hand-roll a per-`it` `ENV["GORI_HOME"]` save/restore** — that older convention
+  (still present in ~7 specs, harmless now) is why two parallel `crystal spec` runs
+  could otherwise stomp a real home directory.
+- Prefer `just test-<area>` while iterating; run full `just test` before finishing.
+
+See **DESIGN.md** for the architecture and the numbered design sections referenced in
+source comments, and **CONTRIBUTING.md** for the contribution flow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing to gori
+
+Thanks for helping improve gori. This is a security tool for **authorized** testing
+only — please keep contributions aligned with that purpose.
+
+## Getting set up
+
+Requires [Crystal](https://crystal-lang.org) `>= 1.20.2` and the native libraries used
+for HTTP body decode:
+
+- macOS: `brew install crystal brotli zstd sqlite`
+- Debian/Ubuntu: `apt install crystal libbrotli-dev libzstd-dev libsqlite3-dev`
+
+Then:
+
+```sh
+shards install   # fetch dependencies (incl. ameba, into lib/)
+just build       # → bin/gori
+just test        # run the spec suite
+```
+
+`just --list` shows every task. Build without the native codecs (gzip/deflate still
+work via stdlib) with `crystal build -Dwithout_native_codecs`.
+
+## Before you open a PR
+
+- **`just check`** must pass — `crystal tool format --check` and ameba. Format only the
+  files you changed (`crystal tool format <files>`); never run a whole-tree format (it
+  reformats dozens of unrelated files due to Crystal version drift).
+- **`just test`** must be green. Add or update specs under `spec/` mirroring the source
+  you touched; `just test-<area>` runs a single subdir while iterating.
+- Never build or benchmark with `-Dpreview_mt` — gori assumes the single-threaded fiber
+  scheduler (see DESIGN.md §2).
+- Keep changes scoped and behavior-preserving unless the PR is explicitly a behavior
+  change; note any intentional behavior change in the PR description.
+
+## Where things live
+
+Read **CLAUDE.md** for the module map, the build/test/lint commands, the TUI seams
+(`TabController`/`Host`, `Overlay`/`OverlayHost`), and the "how to add a feature"
+checklist. Read **DESIGN.md** for the architecture and the P0–P8 design principles the
+code cites inline.
+
+## Licensing
+
+By contributing you agree that your contributions are licensed under the project's
+[Apache-2.0](LICENSE) license.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,119 @@
+# DESIGN.md — gori architecture & principles
+
+This document is the target of the `DESIGN.md §N` references scattered through the
+source comments. It was reconstructed from those comments and the code; treat any
+wording you find thin as an invitation to tighten it against the implementation, not
+as settled scripture.
+
+## §1 Principles (P0–P8)
+
+gori's code cites these inline as `(P4 — the human decides)` etc.
+
+- **P0 — Minimal.** Don't build a hierarchy or abstraction speculatively. A single
+  base `Gori::Error`; subtype only when a `rescue` must discriminate. Add structure
+  when a concrete second caller forces it, not before.
+- **P1 — One execution path.** A `Verb::Definition` is the single source of truth: the
+  same `#call` runs whether fired by a keybinding, the command palette, or the space
+  menu. No feature gets a private dispatch path.
+- **P3 — No premature generalization of data.** Model what is actually there. The
+  sitemap makes every distinct URL segment its own node rather than inventing path
+  templates; folding is an explicit, reversible view choice.
+- **P4 — The human decides.** Intercept holds an in-flight message *indefinitely* for a
+  human forward/edit/drop decision. Scope, match&replace, and active-scan gates are
+  explicit and auditable, never inferred or auto-applied behind the operator's back.
+- **P5 — Mediated state.** Mutable state is reached only through a narrow facade —
+  `Verb::ExecContext` for verbs, `Host` for tab controllers, `OverlayHost` for
+  overlays. A controller never touches another controller, `Runner`, or raw
+  proxy/store state directly.
+- **P6 — Never stall the data path.** The proxy and the Store writer are hot paths:
+  batch bursts into one transaction to amortize fsync, keep socket writes immediate,
+  stream bodies untouched. Persistence and analysis happen off the critical path.
+- **P7 — Raw bytes are the truth.** The captured wire bytes are canonical. Pretty
+  views, decodes, and highlights are derived and display-only; they are never written
+  back onto the wire lossily. A message the codec can't fully parse still yields its
+  octets.
+- **P8 — Pull, not push.** There is no queue, inbox, or ranking. History is a flat log;
+  you *find* things with a query (QL), and per-row signals are fetched lazily when a
+  row is on screen.
+
+(There is no P2; `CSP2` in `probe/` is a Content-Security-Policy version, not a
+principle.)
+
+## §2 Architecture & data flow
+
+```
+client ──▶ Proxy (proxy/) ──▶ target
+             │  intercept (P4), scope, match&replace, host-overrides
+             ▼
+          Store (store.cr)         single-writer fiber + Channel (P6)
+             │  flows / ws msgs / h2 frames / findings / notes / sessions
+             ▼
+   ┌─────────┴───────────┬────────────────────┐
+  TUI (tui/)          CLI (cli/run.cr)     MCP (mcp/tools.cr)
+   verbs + tabs        gori run …           agent tools
+```
+
+Three surfaces, one engine layer. The TUI, the `gori run` CLI, and the `gori mcp`
+server all build on the same lower-level engines (`Repeater::*`, `Fuzz`, `Miner`,
+`Sequencer`, `Discover`, `Probe`, `QL`, `Store`); they do **not** share a dispatcher.
+Surface parity ("every action is also a CLI subcommand and an MCP tool") is a
+convention, achieved by each surface calling the shared engines — not by one code path.
+Keeping the surfaces thin over fat shared engines is what makes that convention cheap
+to hold.
+
+Concurrency: gori runs on Crystal's cooperative fiber scheduler (no `-Dpreview_mt`).
+`Store` funnels all writes through one fiber fed by a buffered `Channel`; reads use the
+WAL connection pool directly. `Scope` / `Rules` / `HostOverrides` / `Interceptor` each
+guard an in-memory snapshot with a `Mutex` and keep a lock-free fast path (`Atomic`
+counters) for the common no-op case on the proxy hot path. Cross-*process*
+coordination (a second `gori mcp` process driving intercept decisions, or capture
+ownership of a project) goes through flock-based `CaptureLock` and Store bridge tables,
+not shared memory.
+
+## §3 Scope
+
+The Scope lens is an ordered include/exclude rule set (host / string / regex) that
+decides which flows are "in scope". It gates capture, intercept, and active probing so
+the operator only ever acts on authorized targets (P4). Rules live in the Store and are
+mirrored into an in-memory `Scope` snapshot (`scope.cr`) read on the proxy hot path;
+SQL-side and in-memory evaluation are kept in parity. The sitemap and History surface
+in-scope vs out-of-scope inline.
+
+## §4 Query language (QL)
+
+QL (`ql.cr`) is a Lucene/KQL-style boolean filter over captured flows: bare terms,
+`field:value` predicates (`host:`, `status:`, `method:`, `size:`, `dur:`, `header:`,
+`proto:` …), `~`-prefixed regex, and `AND`/`OR`/`NOT`/grouping. It compiles to a
+byte-safe SQL predicate (regex via a `SafeRegexp` override so invalid patterns fail
+closed, not injection-open). QL is the only way you navigate History — there is no
+queue or ranking (P8). It backs the History `/` filter bar, `gori run history`, and the
+MCP `list_history`/`ql_*` tools identically.
+
+## §5 Rendering & chrome
+
+The TUI builds gori's chrome (tab bar, panes, overlays) and its views, nothing more
+(P0 — minimal). Rendering is a pure function of state onto a double-buffered `Screen`
+that diffs against the previous frame and emits only changed cells (the cost was
+`set_cell`, not highlighting). Views hold ephemeral display/edit state and expose
+`render(screen, rect, focused)`; controllers interpret input and own persistence
+through `Host` (P5). Overlays are modal cards centered over the body. Theming is a
+`Palette` record with built-in and user themes, switched at runtime.
+
+## §6 Data model (summary)
+
+The Store's domain types live in `store/models.cr`; the schema and its ordered
+migrations in `store/schema.cr`.
+
+- **Flow** — one captured request/response exchange (plus WS messages / h2 frames /
+  SSE events for streaming protocols). Raw request/response bytes are stored verbatim
+  (P7); FTS text is derived for search.
+- **Sitemap node** — one node per distinct URL segment (P3), with operator path tags.
+- **Issue** — the final output: a human-confirmed finding, triaged, optionally linked
+  to the flow/note/session that evidences it.
+- **Note** — the running scratchpad / report.
+- **Sessions** — persisted Repeater / Fuzzer / Miner / Sequencer / OAST workbench state.
+
+---
+
+*Keep this document honest against the code. When you change a subsystem it describes,
+update the matching section; when you cite a principle inline, use the numbers above.*

--- a/justfile
+++ b/justfile
@@ -25,6 +25,52 @@ build:
 test:
     crystal spec
 
+# Run one spec file (or dir), e.g. `just test-file spec/store_spec.cr`.
+[group('development')]
+test-file path:
+    crystal spec {{path}}
+
+# Run every spec under one `spec/<area>` dir for fast feedback while iterating.
+[group('development')]
+test-tui:
+    crystal spec spec/tui
+
+[group('development')]
+test-store:
+    crystal spec spec/store
+
+[group('development')]
+test-proxy:
+    crystal spec spec/proxy
+
+[group('development')]
+test-verb:
+    crystal spec spec/verb
+
+[group('development')]
+test-repeater:
+    crystal spec spec/repeater
+
+[group('development')]
+test-discover:
+    crystal spec spec/discover
+
+[group('development')]
+test-miner:
+    crystal spec spec/miner
+
+[group('development')]
+test-oast:
+    crystal spec spec/oast
+
+[group('development')]
+test-sequencer:
+    crystal spec spec/sequencer
+
+[group('development')]
+test-import:
+    crystal spec spec/import
+
 # Check code format and lint without changing files.
 [group('development')]
 check:

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,2 +1,17 @@
 require "spec"
+require "file_utils"
+
+# Isolate the whole suite from the developer's real ~/.gori. Paths.home_dir falls
+# back to ~/.gori unless GORI_HOME is set, and Settings is a process-wide singleton;
+# without this, a spec that calls Settings.load / Paths.* would read and write the
+# real home, and two parallel `crystal spec` runs (e.g. AI agents in sibling
+# worktrees) could stomp each other. Set once, before src/gori is required, so any
+# load-time path resolution already sees the temp home. Individual specs that still
+# save/restore ENV["GORI_HOME"] per-example keep working (redundant but harmless).
+GORI_TEST_HOME = File.tempname("gori-spec-home")
+Dir.mkdir_p(GORI_TEST_HOME)
+ENV["GORI_HOME"] = GORI_TEST_HOME
+
 require "../src/gori"
+
+Spec.after_suite { FileUtils.rm_rf(GORI_TEST_HOME) }


### PR DESCRIPTION
**Foundation PR (1 of a staged series)** making gori robust to parallel AI-agent work. **No source-behavior change.**

## What & why
The project is built by AI agents adding a whole feature tab across TUI+CLI+MCP per PR, then hardening over review rounds. That loop is bottlenecked by structural coupling (every feature edits ~13 shared god/registry files) and by missing scaffolding: no agent-guidance doc and specs that can touch the real `~/.gori`. This PR lands the scaffolding that protects every later refactor step.

## Contents
- **`CLAUDE.md`** — module map, build/test/lint commands, the "never run `crystal tool format` on the whole tree" rule (version-drift churn), the **P0–P8** principles defined once, a "how to add a feature/overlay" checklist, and the spec `GORI_HOME` rule.
- **`DESIGN.md`** — reconstructs the design doc that 7 source files reference via `DESIGN.md §N` but that **never existed** (fixes the dangling links). Reconstructed from source comments — please sanity-check the wording.
- **`CONTRIBUTING.md`** — the target of the README badge (also never existed).
- **`spec/spec_helper.cr`** — forces `ENV["GORI_HOME"]` to a per-run temp dir so specs never touch the real `~/.gori` and parallel `crystal spec` runs in sibling worktrees can't collide.
- **`justfile`** — `test-file` + per-area `test-<area>` targets for fast feedback.

_CI intentionally omitted — that's handled separately via #114, and kept out of this series to protect dev velocity._

## Verification
`crystal spec` → **2189 examples, 0 failures, 0 errors, 0 pending**; `crystal tool format --check` + ameba clean on changed source.

## Note
`P2` intentionally omitted from the principles list — the lone inline `P2`-looking hit is `CSP2` (a CSP version string), not a design principle. Flagging for confirmation.