### PR TITLE
perf(oast): incremental reconcile + view caching; fix callback timestamp

### DIFF
--- a/spec/store/oast_spec.cr
+++ b/spec/store/oast_spec.cr
@@ -83,4 +83,24 @@ describe "OAST persistence (V39)" do
       store.oast_callbacks(sid, since_id: first_id).map(&.provider_uid).should eq(["uid-2"])
     end
   end
+
+  it "folds all sessions' new callbacks in one watermark query (oast_callbacks_since)" do
+    with_store do |store|
+      s1 = store.insert_oast_session(nil, "custom-http", "https://a/log", "c1", "", nil, nil)
+      s2 = store.insert_oast_session(nil, "custom-http", "https://b/log", "c2", "", nil, nil)
+      store.insert_oast_callback(s1, "u1", "http", "GET", "10.0.0.1", "a", "a".to_slice, nil, 10_i64)
+      store.insert_oast_callback(s2, "u2", "http", "GET", "10.0.0.2", "b", "b".to_slice, nil, 11_i64)
+
+      # from 0: both sessions' callbacks, oldest id first
+      first = store.oast_callbacks_since(0_i64)
+      first.map(&.provider_uid).should eq(["u1", "u2"])
+      first.map(&.session_id).should eq([s1, s2])
+
+      # watermark past the last row → nothing, until a new callback lands on EITHER session
+      watermark = first.last.id
+      store.oast_callbacks_since(watermark).should be_empty
+      store.insert_oast_callback(s1, "u3", "dns", "A", "10.0.0.3", "a", "c".to_slice, nil, 12_i64)
+      store.oast_callbacks_since(watermark).map(&.provider_uid).should eq(["u3"])
+    end
+  end
 end

--- a/src/gori/store/oast_sessions.cr
+++ b/src/gori/store/oast_sessions.cr
@@ -100,6 +100,21 @@ module Gori
       list
     end
 
+    # Watermark load across ALL sessions: callbacks with id > since_id, oldest first. One
+    # rowid-indexed query the OAST controller uses to fold new callbacks in on a soft-sync
+    # (reconcile) without re-selecting the whole table per session on every data_version bump.
+    def oast_callbacks_since(since_id : Int64) : Array(OastCallbackRecord)
+      list = [] of OastCallbackRecord
+      @db.query("SELECT id, session_id, created_at, provider_uid, protocol, method, source_ip, full_id, raw_request, raw_response FROM oast_callbacks WHERE id > ? ORDER BY id", since_id) do |rs|
+        rs.each do
+          list << OastCallbackRecord.new(
+            rs.read(Int64), rs.read(Int64), rs.read(Int64), rs.read(String), rs.read(String),
+            rs.read(String?), rs.read(String?), rs.read(String), rs.read(Bytes), rs.read(Bytes?))
+        end
+      end
+      list
+    end
+
     # INSERT OR IGNORE on the UNIQUE(session_id, provider_uid) dedup key. The DB enforces
     # dedup; the return (last_insert_rowid) is NOT a reliable new-vs-ignored signal, so the
     # controller dedups in memory (a seen-uid set) and treats this as a durable backstop.

--- a/src/gori/tui/controllers/oast_controller.cr
+++ b/src/gori/tui/controllers/oast_controller.cr
@@ -71,6 +71,12 @@ module Gori::Tui
       @oast_events = Channel(Oast::Event).new(256)
       @reg_events = Channel(RegResult).new(16)
       @registering = Set(Int64).new # provider ids with a register round-trip in flight (dedup g/^R)
+      @max_cb_id = 0_i64            # highest callback row id folded in (watermark for reconcile)
+      @cb_version = 0               # bumped on any @callbacks mutation → invalidates the view caches
+      @ordered_cache = nil.as(Array(CbRow)?)
+      @ordered_cache_key = nil.as({Int32, String}?)
+      @filtered_cache = nil.as(Array(CbRow)?)
+      @filtered_cache_key = nil.as({Int32, String}?)
       reload
     end
 
@@ -141,29 +147,53 @@ module Gori::Tui
     end
 
     # --- data ---
+    # Authoritative full rebuild (init + on_enter): re-read providers/sessions, then fold the
+    # whole callback table in one rowid-ordered query (id order == chronological, so no sort).
+    # Also reflects any peer-process deletions. Live/soft-sync updates go through reconcile.
     def reload : Nil
       store = @host.session.store
       @providers = store.oast_providers
       @callbacks.clear
       @seen.clear
       @session_label.clear
+      @max_cb_id = 0_i64
       store.oast_sessions.each do |s|
-        label = provider_label_for(s)
-        @session_label[s.id] = label
-        seen = (@seen[s.id] ||= Set(String).new)
-        store.oast_callbacks(s.id).each do |cb|
-          next if seen.includes?(cb.provider_uid)
-          seen << cb.provider_uid
-          @callbacks << cb_row(cb, label)
-        end
+        @session_label[s.id] = provider_label_for(s)
+        @seen[s.id] ||= Set(String).new
       end
-      @callbacks.sort_by!(&.at)
+      store.oast_callbacks_since(0_i64).each { |cb| fold_callback(cb) }
+      @cb_version += 1
       clamp_selection
     end
 
-    # Soft-sync on an external DB change: reload config + history, keep live pollers.
+    # Soft-sync on an external DB change (own commits OR a peer process): refresh the cheap
+    # config (providers/sessions/labels), then fold in ONLY callbacks past the watermark. This
+    # runs on every data_version bump — up to ~1.3×/sec during capture, even off-tab — so it
+    # must stay incremental; the full-table reload lives in reload (init + on_enter).
     def reconcile : Nil
-      reload
+      store = @host.session.store
+      @providers = store.oast_providers
+      store.oast_sessions.each do |s|
+        @session_label[s.id] = provider_label_for(s)
+        @seen[s.id] ||= Set(String).new
+      end
+      inserted = false
+      store.oast_callbacks_since(@max_cb_id).each { |cb| inserted = true if fold_callback(cb) }
+      @cb_version += 1 if inserted
+      clamp_selection
+    end
+
+    # Add one persisted callback to the in-memory view, advancing the watermark. Returns true
+    # if it was new (not a dedup hit). Rows arrive id-ascending, so the watermark only grows;
+    # a callback the live drain already appended is read once here, skipped, and its id clears
+    # the watermark so it is never re-read again (bounds reconcile to new-since-last rows).
+    private def fold_callback(cb : Store::OastCallbackRecord) : Bool
+      @max_cb_id = cb.id if cb.id > @max_cb_id
+      seen = (@seen[cb.session_id] ||= Set(String).new)
+      return false if seen.includes?(cb.provider_uid)
+      seen << cb.provider_uid
+      @callbacks << cb_row(cb, @session_label[cb.session_id]? || "oast")
+      true
     end
 
     def on_enter : Nil
@@ -533,16 +563,31 @@ module Gori::Tui
       ordered_callbacks[@cb_sel]?
     end
 
-    # The callbacks in display order (newest first), narrowed by the filter. `@callbacks`
-    # stays the master store so live inserts still land and simply re-filter next render.
+    # The callbacks in display order (newest first), narrowed by the filter. Memoized on
+    # (callbacks version, filter) so the per-render reverse — and the filter scan below — run
+    # once per change instead of several times each render frame + drain tick. `@callbacks`
+    # stays the master store so live inserts still land and simply re-filter next version.
     private def ordered_callbacks : Array(CbRow)
-      filtered_callbacks.reverse
+      key = {@cb_version, @filter.value}
+      if (cached = @ordered_cache) && @ordered_cache_key == key
+        return cached
+      end
+      result = filtered_callbacks.reverse
+      @ordered_cache = result
+      @ordered_cache_key = key
+      result
     end
 
     private def filtered_callbacks : Array(CbRow)
+      key = {@cb_version, @filter.value}
+      if (cached = @filtered_cache) && @filtered_cache_key == key
+        return cached
+      end
       q = @filter.value.strip.downcase
-      return @callbacks if q.empty?
-      @callbacks.select { |r| callback_matches?(r, q) }
+      result = q.empty? ? @callbacks : @callbacks.select { |r| callback_matches?(r, q) }
+      @filtered_cache = result
+      @filtered_cache_key = key
+      result
     end
 
     private def callback_matches?(r : CbRow, q : String) : Bool
@@ -809,10 +854,13 @@ module Gori::Tui
         seen << i.unique_id
         label = @session_label[sid]? || "oast"
         store = @host.session.store
+        # Persist the interaction's OWN time (not now) so a callback shows the same timestamp
+        # live and after a reload (created_at is microseconds; cb_row divides back to seconds).
         store.insert_oast_callback(sid, i.unique_id, i.protocol, i.method, i.source_ip,
-          i.full_id, i.raw_request.to_slice, i.raw_response.try(&.to_slice), now_us)
+          i.full_id, i.raw_request.to_slice, i.raw_response.try(&.to_slice), i.at.to_unix_ms * 1000)
         @callbacks << CbRow.new(sid, i.unique_id, i.protocol, i.method, i.source_ip, i.full_id,
           label, i.at, i.raw_request, i.raw_response)
+        @cb_version += 1
         n = @listeners.find { |l| l.session.id == sid }
         @host.jobs.progress(n.job_id, nil, nil, "#{callbacks_for(sid)} hits") if n
         @host.notifications.push(:success, "OAST #{i.protocol.upcase} hit on #{label} (#{i.source_ip || "?"})",
@@ -820,16 +868,14 @@ module Gori::Tui
       end
     end
 
+    # @seen[sid] holds exactly the distinct provider_uids folded in for that session (one per
+    # CbRow), so its size is the hit count — O(1), vs. an O(n) scan of the whole list per hit.
     private def callbacks_for(sid : Int64) : Int32
-      @callbacks.count { |c| c.session_id == sid }
+      @seen[sid]?.try(&.size) || 0
     end
 
     private def poll_http : Oast::Http
       Oast::HttpClient.new(verify_tls: !@host.session.config.insecure_upstream?)
-    end
-
-    private def now_us : Int64
-      Time.utc.to_unix_ms * 1000
     end
 
     # Notification "jump to result" lands on this tab (no per-row reveal needed).


### PR DESCRIPTION
## Summary

Improves OAST tab performance and fixes a latent timestamp bug.

### Performance

**Incremental `reconcile` (headline).** `OastController#reconcile` called `reload`, which re-selected the *entire* `oast_callbacks` table for every session. `reconcile` fires on every SQLite `data_version` bump — up to ~1.3×/sec during any capture, **even when the OAST tab isn't active** — so it was O(total callbacks) per DB write, i.e. O(n²) over a listening session.

- New `Store#oast_callbacks_since(since_id)`: a single rowid-indexed query across all sessions.
- `reconcile` now folds in only callbacks past the `@max_cb_id` watermark. Full `reload` is kept for init/on_enter (authoritative; reflects peer-process deletions).
- `fold_callback` advances the watermark even on a dedup-skip, so a row the live drain already appended is re-read at most once and then skipped forever — bounding reconcile to new-since-last rows.

**O(1) hit count.** `callbacks_for` now uses `@seen[sid].size` (one uid per CbRow) instead of an O(n) `@callbacks` scan per callback.

**Memoized display list.** `filtered/ordered_callbacks` are cached on `{@cb_version, @filter.value}`, removing the per-render `reverse` + filter scan repeated several times each frame/drain tick. The now-redundant `sort_by!(&.at)` is dropped (rows arrive id-ascending == chronological).

### Bug fix

`apply_callback` persisted `now_us` (insert time) as `created_at`, so a callback showed the server interaction time when live but the insert time after a reload/restart. It now persists `i.at`, so the timestamp matches in both.

## Test

- Adds a cross-session watermark spec (`oast_callbacks_since`).
- `crystal spec spec/store/ spec/oast/` → 68 examples, 0 failures.
- `crystal spec spec/tui/ spec/mcp_spec.cr` → 907 examples, 0 failures.
- `shards build gori` → clean.