### PR TITLE
MCP: fix silent rule fallback, unpredictable OAST ids, structured fuzz payloads

### DIFF
--- a/spec/mcp_fuzz_spec.cr
+++ b/spec/mcp_fuzz_spec.cr
@@ -98,6 +98,30 @@ describe "MCP fuzz tools" do
     end
   end
 
+  it "accepts structured object payload sets for numbers and brute" do
+    port = start_origin
+    with_store do |store|
+      tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+      base = {
+        "template"       => "GET /?q=§x§ HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+        "url"            => "http://127.0.0.1:#{port}",
+        "allow_unscoped" => true,
+      }
+      # numbers {from,to,step} == the "1-100:2" string form (50 candidates).
+      nums = call_json(tools, "fuzz_start",
+        base.merge({"payloads" => [{"numbers" => {"from" => 1, "to" => 100, "step" => 2}}]}).to_json)
+      nums["total"].as_i.should eq(50)
+      # brute {charset,min,max} == the "ab:1-2" string form (2 + 4 = 6 candidates).
+      brute = call_json(tools, "fuzz_start",
+        base.merge({"payloads" => [{"brute" => {"charset" => "ab", "min" => 1, "max" => 2}}]}).to_json)
+      brute["total"].as_i.should eq(6)
+      # A malformed object fails cleanly (is_error), not a generic "tool error".
+      _, bad = call_raw(tools, "fuzz_start",
+        base.merge({"payloads" => %([{"numbers":{"to":100}}])}).to_json)
+      bad.should be_true
+    end
+  end
+
   it "rejects bad args, and gates the tool under --read-only" do
     with_store do |store|
       tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -849,6 +849,25 @@ describe Gori::MCP::Server do
       end
     end
 
+    it "rejects an unrecognized match kind instead of silently coercing to literal" do
+      with_store do |store|
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"create_rule","arguments":{"pattern":"x","match":"regex-ignorecase"}}})
+        resp = drive(store, call)[0]["result"]
+        resp["isError"].as_bool.should be_true
+        resp["structuredContent"]["error_code"].as_s.should eq("INVALID_ARGUMENT")
+        resp["structuredContent"]["field"].as_s.should eq("match")
+        store.match_rules.should be_empty # not coerced into a stray literal rule
+      end
+    end
+
+    it "still accepts the valid regex/literal match kinds" do
+      with_store do |store|
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"create_rule","arguments":{"pattern":"a\\\\d+","replacement":"x","match":"regex"}}})
+        tool_payload(drive(store, call)[0])["match"].as_s.should eq("regex")
+        store.match_rules[0].match_kind.regex?.should be_true
+      end
+    end
+
     it "creates a rule already disabled (atomic) with enabled:false" do
       with_store do |store|
         create = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"create_rule","arguments":{"pattern":"x","enabled":false}}})

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -1015,7 +1015,11 @@ module Gori
         prov = Oast::Provider.build(kind, host, str(h, "token"))
         http = Oast::HttpClient.new(@verify_upstream)
         session = prov.register(http)
-        sid = "oast-#{@job_seq += 1}"
+        # Unpredictable session id: a sequential "oast-N" is trivially guessable, so
+        # a co-tenant sharing this process could poll another agent's out-of-band
+        # callbacks. Secure-random hex removes the guessing surface (mirrors the
+        # delete_project confirmation tokens).
+        sid = "oast_#{Random::Secure.hex(8)}"
         @oast_mcp[sid] = OastMcpSession.new(prov, session, http, kind.label)
         payload = prov.generate_payload(session)
         Result.new({session_id: sid, provider: kind.label, payload_url: payload}.to_json)

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -780,7 +780,7 @@ module Gori
               s.field "auto", boolprop("auto-mark every query/cookie/body param when the template has no § markers")
               s.field "marks", strarrprop("literal tokens to mark as §…§ positions (each occurrence, mirrors CLI --mark); alternative to embedding §…§ in template")
               s.field "mode", strprop("sniper (default) | batteringram | pitchfork | clusterbomb")
-              s.field "payloads", arrprop(%(array of payload sets, e.g. [{"list":["a","b"]},{"numbers":"1-100"},{"wordlist":"/p.txt"},{"null":5},{"brute":"abc:1-3"}] — JSON array, NOT a string))
+              s.field "payloads", arrprop(%(array of payload sets, e.g. [{"list":["a","b"]},{"numbers":"1-100"},{"wordlist":"/p.txt"},{"null":5},{"brute":"abc:1-3"}] — JSON array, NOT a string. numbers/brute also accept a structured object: {"numbers":{"from":1,"to":100,"step":2}}, {"brute":{"charset":"abc","min":1,"max":3}}))
               s.field "match", jsonprop(%(keep only responses matching, e.g. {"status":"200,500-599","size":">1000","regex":"err"} — object or JSON string))
               s.field "filter", jsonprop(%(drop responses matching, same shape as match — object or JSON string))
               s.field "extract", strprop("regex; grep a value (capture group 1) from each response")

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -802,9 +802,10 @@ module Gori
             end
 
             tool j, "fuzz_results",
-              "Paged matched results for a fuzz job (metrics only — status/length/words/" \
-              "extracted; no raw bodies and no per-result flow id). To inspect a hit, " \
-              "re-issue it with send_request, substituting the payload into your template." do |s|
+              "Paged matched results for a fuzz job (status/length/words/lines/duration/" \
+              "extracted, plus a per-result flow_id when the run used record_history). No raw " \
+              "bodies are inlined: fetch a hit's full request+response with get_flow(flow_id), " \
+              "or re-issue it with send_request by substituting the payload into your template." do |s|
               s.field "job_id", strprop("id from fuzz_start"), required: true
               s.field "offset", intprop("start row (default 0)")
               s.field "limit", intprop("max rows (default 100, max 1000)")

--- a/src/gori/mcp/tools/fuzz.cr
+++ b/src/gori/mcp/tools/fuzz.cr
@@ -318,19 +318,43 @@ module Gori
           Fuzz::InlineList.new(list.map { |x| x.as_s? || x.to_s })
         elsif wl = obj["wordlist"]?.try(&.as_s?)
           Fuzz::WordlistFile.new(wl)
-        elsif nums = obj["numbers"]?.try(&.as_s?)
+        elsif nums = obj["numbers"]?
           fuzz_numbers(nums)
         elsif (nul = obj["null"]?) && (n = (nul.as_i64? || nul.as_s?.try(&.to_i64?)))
           Fuzz::NullPayloads.new(n.clamp(0_i64, FUZZ_MAX_REQUESTS).to_i) # clamp before .to_i so a huge count can't OverflowError past the clean-error handler
-        elsif br = obj["brute"]?.try(&.as_s?)
+        elsif br = obj["brute"]?
           fuzz_brute(br)
         else
           raise FuzzArgError.new("unknown payload set #{spec} (use list/wordlist/numbers/null/brute)")
         end
       end
 
-      private def fuzz_numbers(v : String) : Fuzz::NumberRange
-        range_part, _, step_part = v.partition(':')
+      # An integer from a JSON scalar — a real number, or a numeric string (LLMs
+      # sometimes quote numbers). nil when it is neither.
+      private def fuzz_int(v : JSON::Any?) : Int64?
+        return nil unless v
+        v.as_i64? || v.as_s?.try(&.to_i64?)
+      end
+
+      # Clamp a length to Int32 so an absurd value from the object form can't
+      # OverflowError past the clean-error handler (the run is still capped by
+      # FUZZ_MAX_REQUESTS regardless).
+      private def clamp_brute_len(n : Int64) : Int32
+        n.clamp(0_i64, Int64.new(Int32::MAX)).to_i
+      end
+
+      # numbers set: the compact "FROM-TO[:STEP]" string OR a structured object
+      # {"from":N,"to":N,"step":N}. Agents emit structured JSON more reliably than
+      # partitioned strings, so both are accepted (#4).
+      private def fuzz_numbers(v : JSON::Any) : Fuzz::NumberRange
+        if obj = v.as_h?
+          from = fuzz_int(obj["from"]?)
+          to = fuzz_int(obj["to"]?)
+          raise FuzzArgError.new(%(numbers object needs integer 'from' and 'to', e.g. {"from":1,"to":100,"step":2})) unless from && to
+          return Fuzz::NumberRange.new(from, to, fuzz_int(obj["step"]?) || 1_i64)
+        end
+        s = v.as_s? || raise FuzzArgError.new(%('numbers' must be a string 'FROM-TO[:STEP]' or an object {from,to,step}))
+        range_part, _, step_part = s.partition(':')
         if md = range_part.match(/^(-?\d+)-(-?\d+)$/)
           from = md[1].to_i64?
           to = md[2].to_i64?
@@ -338,14 +362,25 @@ module Gori
           from = nil
           to = nil
         end
-        raise FuzzArgError.new("invalid numbers '#{v}' (use FROM-TO[:STEP])") unless from && to
+        raise FuzzArgError.new("invalid numbers '#{s}' (use FROM-TO[:STEP])") unless from && to
         step = step_part.empty? ? 1_i64 : (step_part.to_i64? || raise FuzzArgError.new("invalid numbers step '#{step_part}'"))
         Fuzz::NumberRange.new(from, to, step)
       end
 
-      private def fuzz_brute(v : String) : Fuzz::BruteForce
-        charset, _, lens = v.rpartition(':')
-        raise FuzzArgError.new("invalid brute '#{v}' (use CHARSET:MIN-MAX)") if charset.empty? || lens.empty?
+      # brute set: the compact "CHARSET:MIN-MAX" string OR a structured object
+      # {"charset":"abc","min":1,"max":3} (max defaults to min).
+      private def fuzz_brute(v : JSON::Any) : Fuzz::BruteForce
+        if obj = v.as_h?
+          charset = obj["charset"]?.try(&.as_s?)
+          raise FuzzArgError.new(%(brute object needs a non-empty 'charset', e.g. {"charset":"abc","min":1,"max":3})) if charset.nil? || charset.empty?
+          min = fuzz_int(obj["min"]?)
+          raise FuzzArgError.new("brute object needs an integer 'min'") unless min
+          max = fuzz_int(obj["max"]?) || min
+          return Fuzz::BruteForce.new(charset, clamp_brute_len(min), clamp_brute_len(max))
+        end
+        s = v.as_s? || raise FuzzArgError.new(%('brute' must be a string 'CHARSET:MIN-MAX' or an object {charset,min,max}))
+        charset, _, lens = s.rpartition(':')
+        raise FuzzArgError.new("invalid brute '#{s}' (use CHARSET:MIN-MAX)") if charset.empty? || lens.empty?
         min_s, _, max_s = lens.partition('-')
         min = min_s.to_i?
         max = max_s.empty? ? min : max_s.to_i?

--- a/src/gori/mcp/tools/rules.cr
+++ b/src/gori/mcp/tools/rules.cr
@@ -180,8 +180,21 @@ module Gori
                end
              end
         return err("invalid 'op' (expected replace|add_header|set_header|remove_header)", "INVALID_ARGUMENT", field: "op") unless op
+        # Validate `match` explicitly instead of leaning on MatchKind.from_label
+        # (which coerces any unknown label to Literal). A silent literal fallback
+        # would mislead a caller into thinking a `regex` rule was applied while the
+        # proxy actually did a literal match — so an unrecognized label is rejected.
         kind_s = str(h, "match").try(&.strip)
-        kind = kind_s.nil? || kind_s.empty? ? dft_kind : Store::MatchKind.from_label(kind_s.downcase)
+        kind = if kind_s.nil? || kind_s.empty?
+                 dft_kind
+               else
+                 case kind_s.downcase
+                 when "literal" then Store::MatchKind::Literal
+                 when "regex"   then Store::MatchKind::Regex
+                 else                nil
+                 end
+               end
+        return err("invalid 'match' (expected literal|regex)", "INVALID_ARGUMENT", field: "match") unless kind
         {op, kind}
       end
 


### PR DESCRIPTION
Reviewed a batch of MCP usability/bug reports collected from driving `gori mcp` in agent environments and implemented the ones with real merit; skipped the rest with reasons below.

## Changes

- **fix(mcp) #2 — invalid rule match kind no longer silently falls back to literal.** `create_rule`/`update_rule`/`preview_rule` fed `match` through `MatchKind.from_label`, which coerces any unrecognized label (e.g. `regex-ignorecase`) to `Literal`. A caller would believe a regex rule was applied while the proxy did a literal match. Now validated → `INVALID_ARGUMENT`.
- **fix(mcp) #11 — secure-random OAST session ids.** `oast_start` minted sequential `oast-N` ids; within a shared process those are guessable, so a co-tenant could poll another agent's callbacks. Now `oast_<hex>` via `Random::Secure` (matches the delete_project token scheme).
- **feat(mcp) #4 — structured object payload sets for fuzz.** `fuzz_start` only understood partitioned strings (`"1-100:2"`, `"abc:1-3"`); structured sets fell through to a cryptic "unknown payload set". Now `numbers` accepts `{from,to,step}` and `brute` accepts `{charset,min,max}` alongside the strings.
- **docs(mcp) #9 — corrected `fuzz_results` description.** It claimed results carry "no per-result flow id", but the serializer emits `flow_id` whenever `record_history` was on. Fixed so agents fetch full detail via `get_flow(flow_id)` instead of re-issuing every hit.

## Skipped (with reasons)

- **#1** structuredContent already carries the machine-readable view; swapping `content[0].text` to Markdown risks breaking JSON-parsing clients.
- **#3 / #5 / #7 / #8** large features needing on-disk persistence or bidirectional protocol work, out of scope for this pass.
- **#6** intercept genuinely requires a live capturing proxy to drain commands.
- **#10** env masking is reversible (`$KEY` expands on send) and `include_sensitive` already exists on `get_flow`; resend-by-id uses stored bytes, so nothing is fed back masked.
- **#12** already emits `error_code: "NETWORK_ERROR"` in the send payload.
- **#13** per-tool `insecure` flags already exist on send/fuzz/mine/sequence/discover.
- **#14** `list_history` returns a bare JSON array (no clean place for a warning); a lenient `since`/`before_id` would need a breaking shape change or a silent wrong-direction result. The current hard error is clearer.

## Tests

New specs for #2 (reject + still-accept valid kinds) and #4 (numbers/brute object totals + malformed-object error). Full suites green: `mcp_spec` + `mcp_fuzz_spec` (143), `fuzz_spec` (52).

🤖 Generated with [Claude Code](https://claude.com/claude-code)