### PR TITLE
Fix TUI usability bugs + input gaps (tutorial nav, CHAIN esc, Del key, Bind IP validation)

### DIFF
--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -763,4 +763,23 @@ describe Gori::Settings do
       Gori::Settings.upstream_proxy_port_error("proxy:99999").should_not be_nil
     end
   end
+
+  describe ".bind_host_error" do
+    it "accepts blank, IPv4/IPv6 literals, and plausible hostnames" do
+      Gori::Settings.bind_host_error("").should be_nil          # caller defaults blank
+      Gori::Settings.bind_host_error("127.0.0.1").should be_nil
+      Gori::Settings.bind_host_error("0.0.0.0").should be_nil
+      Gori::Settings.bind_host_error("::").should be_nil
+      Gori::Settings.bind_host_error("::1").should be_nil
+      Gori::Settings.bind_host_error("localhost").should be_nil
+      Gori::Settings.bind_host_error("proxy.example.com").should be_nil
+    end
+
+    it "rejects a malformed IP typo and a string no host can contain" do
+      Gori::Settings.bind_host_error("999.999.999.999").should_not be_nil
+      Gori::Settings.bind_host_error("invalid_ip").should_not be_nil
+      Gori::Settings.bind_host_error("1.2.3").should_not be_nil
+      Gori::Settings.bind_host_error("gg::1").should_not be_nil
+    end
+  end
 end

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -43,6 +43,19 @@ describe Gori::Tui::FuzzerView do
     grid2.should_not contain("§x¦rot13§")
   end
 
+  it "CHAIN pane: esc discards the edit instead of committing it" do
+    view = FuzzerView.new
+    view.load_request("https://h", "§x§ HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
+    view.focus_pane(:template)
+    view.focus_chain_pane.should be_nil
+    view.chain_pane_active?.should be_true
+    "rot13".each_char { |c| view.handle_chain_pane_key(Termisu::Event::Key.new(Termisu::Input::Key::LowerA, char: c)) }
+    view.discard_chain_pane # esc path
+    view.chain_pane_active?.should be_false
+    view.template_text.should contain("§x§")       # unchanged — no ¦chain written
+    view.template_text.should_not contain("rot13") # the typed chain was dropped
+  end
+
   describe "marker structure guard (INS editing)" do
     it "auto-escapes a § typed inside a template marker (structure survives)" do
       view = FuzzerView.new

--- a/spec/tui/repeater_view_spec.cr
+++ b/spec/tui/repeater_view_spec.cr
@@ -371,6 +371,19 @@ describe Gori::Tui::RepeaterView do
     view.request_text.should contain("§v¦md5§")
   end
 
+  it "CHAIN pane: esc discards the edit instead of committing it" do
+    view = RepeaterView.new
+    view.restore("https://a.test", "§v§ HTTP/1.1\nHost: a.test\n\n", false, false)
+    view.focus_pane(:request)
+    view.focus_chain_pane.should be_nil
+    view.chain_pane_active?.should be_true
+    "md5".each_char { |c| view.handle_chain_pane_key(Termisu::Event::Key.new(Termisu::Input::Key::LowerA, char: c)) }
+    view.discard_chain_pane # esc path
+    view.chain_pane_active?.should be_false
+    view.request_text.should contain("§v§")     # unchanged — no ¦chain written
+    view.request_text.should_not contain("md5") # the typed chain was dropped
+  end
+
   describe "marker structure guard (INS editing)" do
     it "auto-escapes a § typed inside a marker so the ¦chain never leaks" do
       view = RepeaterView.new

--- a/src/gori/settings/network.cr
+++ b/src/gori/settings/network.cr
@@ -1,4 +1,5 @@
 require "json"
+require "socket"
 
 # NETWORK section (settings:network): proxy bind, upstream proxy, dial timeouts,
 # body capture cap, and per-project overrides of the same. See settings.cr for the
@@ -125,6 +126,28 @@ module Gori::Settings
     return nil if host.empty?
     return {value, 8080} if host.includes?(':') # unbracketed IPv6 literal → no port
     {host, value[(idx + 1)..].to_i? || 8080}
+  end
+
+  # nil if `host` is an acceptable proxy BIND address; an error message otherwise. Accepts
+  # any IPv4/IPv6 literal (0.0.0.0, ::, 127.0.0.1, ::1, a specific NIC address) and a
+  # plausible hostname (localhost, a.example.com); rejects a malformed IP typo like
+  # "999.999.999.999" and a string carrying characters no host can hold ("invalid_ip").
+  # Blank is caller-defaulted (SetupWizard#effective_ip → 127.0.0.1), so it passes here.
+  # Shared by settings:network AND the setup wizard so a bad address is caught at save
+  # time instead of surfacing later as an opaque bind/socket failure at launch.
+  def self.bind_host_error(host : String) : String?
+    h = host.strip
+    return nil if h.empty?
+    return nil if Socket::IPAddress.valid_v4?(h) || Socket::IPAddress.valid_v6?(h)
+    # Looks like an IP literal attempt (only digits+dots, or an unbracketed hex+colon
+    # v6) yet didn't parse as one → a typo'd address, not a hostname.
+    if h.matches?(/\A[0-9.]+\z/) || (h.includes?(':') && h.matches?(/\A[0-9a-fA-F:.]+\z/))
+      return "settings: invalid bind IP #{h.inspect}"
+    end
+    # Otherwise treat it as a hostname; reject anything a DNS label may not contain
+    # (underscores, spaces, …) — labels are alphanumeric, dot/hyphen separated.
+    return nil if h.matches?(/\A[A-Za-z0-9]([A-Za-z0-9.\-]*[A-Za-z0-9])?\z/)
+    "settings: invalid bind address #{h.inspect}"
   end
 
   # nil if `value` is an acceptable upstream-proxy string; an error message if its explicit

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -218,7 +218,7 @@ module Gori::Tui
     end
 
     private def handle_escape(v : FuzzerView) : Nil
-      return v.commit_chain_pane if v.chain_pane_active? # esc in the CHAIN pane → save + back
+      return v.discard_chain_pane if v.chain_pane_active? # esc in the CHAIN pane → cancel + back (^Y again saves)
       if v.focus == :template && v.template_insert?
         v.exit_template_insert!
       elsif v.focus == :target && v.target_insert?
@@ -239,7 +239,7 @@ module Gori::Tui
         @host.status("chain saved")
       else
         msg = view.focus_chain_pane
-        @host.status(msg || "type the chain · Tab completes · ↵/esc saves")
+        @host.status(msg || "type the chain · Tab completes · ↵ saves · esc cancels")
       end
     end
 

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -307,7 +307,7 @@ module Gori::Tui
         view.edit_undo
       elsif key.escape?
         if (view = current_view) && view.chain_pane_active?
-          view.commit_chain_pane # esc in the CHAIN pane → save + back to the request editor
+          view.discard_chain_pane # esc in the CHAIN pane → cancel + back to the request editor (^Y again saves)
         elsif (view = current_view) && view.focus == :target && view.editing_sni?
           view.exit_sni_field # leave the SNI field, back to the URL (value kept)
         elsif (view = current_view) && view.focus == :request && view.request_hex?
@@ -412,7 +412,7 @@ module Gori::Tui
         @host.status("chain saved")
       else
         msg = view.focus_chain_pane
-        @host.status(msg || "type the chain · Tab completes · ↵/esc saves")
+        @host.status(msg || "type the chain · Tab completes · ↵ saves · esc cancels")
       end
     end
 

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -483,12 +483,27 @@ module Gori::Tui
       @chain_focused = false
     end
 
-    # Route a key while the CHAIN pane is focused (typing/autocomplete stays; a focus-exit
-    # key commits + returns to the template editor).
+    # Leave the CHAIN pane WITHOUT writing its edits back to the marker (esc = cancel,
+    # matching the pane's own "esc cancel" hint). The template text is only touched by
+    # commit_chain_pane, so dropping focus is a clean discard; restore the cursor onto
+    # the marker so its tooltip stays up.
+    def discard_chain_pane : Nil
+      return unless @chain_focused
+      anchor = Fuzz::Template.marker_start_at(@editor.text, @chain_marker_cursor) || @chain_marker_cursor
+      @editor.place_at_offset(anchor)
+      @chain_focused = false
+    end
+
+    # Route a key while the CHAIN pane is focused (typing/autocomplete stays; ↵/tab/↑
+    # commit + return to the template editor, while esc cancels — discards the edit).
     def handle_chain_pane_key(ev : Termisu::Event::Key) : Nil
       return if @chain_pane.handle_key(ev)
       key = ev.key
-      commit_chain_pane if key.escape? || key.enter? || key.tab? || key.up?
+      if key.escape?
+        discard_chain_pane
+      elsif key.enter? || key.tab? || key.up?
+        commit_chain_pane
+      end
     end
 
     # "§N" label for the marker under the template cursor (1-based), or "§" when not in one.

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -1335,12 +1335,28 @@ module Gori::Tui
       @chain_focused = false
     end
 
-    # Route a key while the CHAIN pane is focused: typing/autocomplete stays in the pane;
-    # a focus-exit key (esc/↵/tab/↑) commits + returns to the request editor.
+    # Leave the CHAIN pane WITHOUT writing its edits back to the marker (esc =
+    # cancel, the universal editor convention). The editor text was never touched
+    # while the pane had focus — only commit_chain_pane writes — so dropping focus
+    # is a clean discard; restore the cursor onto the marker so its tooltip stays up.
+    def discard_chain_pane : Nil
+      return unless @chain_focused
+      anchor = Fuzz::Template.marker_start_at(@editor.text, @chain_marker_cursor) || @chain_marker_cursor
+      @editor.place_at_offset(anchor)
+      @chain_focused = false
+    end
+
+    # Route a key while the CHAIN pane is focused: typing/autocomplete stays in the
+    # pane; ↵/tab/↑ commit the edit and return to the request editor, while esc
+    # cancels (discards the edit) — matching how esc backs out elsewhere.
     def handle_chain_pane_key(ev : Termisu::Event::Key) : Nil
       return if @chain_pane.handle_key(ev) # consumed by the pane (edit / completion nav)
       key = ev.key
-      commit_chain_pane if key.escape? || key.enter? || key.tab? || key.up?
+      if key.escape?
+        discard_chain_pane
+      elsif key.enter? || key.tab? || key.up?
+        commit_chain_pane
+      end
     end
 
     # --- marking (§…§ Decoder-chain positions) -------------------------------

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -2878,6 +2878,8 @@ module Gori::Tui
         preview_theme
       elsif key.backspace?
         @settings_view.backspace
+      elsif key.delete?
+        @settings_view.delete
       elsif ev.ctrl? && key.lower_r?
         # ^R (not a bare letter — those are typed into the focused field) reverts the
         # section to its factory defaults, gated behind a confirm like the tab-bar reset.

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -278,6 +278,18 @@ module Gori::Tui
       @status = nil
     end
 
+    # Forward-delete (the Del key): remove the character UNDER the caret, leaving the
+    # caret where it is — the natural complement to backspace after ←/→ caret moves.
+    # No-op on toggle/choice/action rows or with the caret already at end-of-line.
+    def delete : Nil
+      return if bool_field? || choice_field? || opener_field?
+      v = @values[@focused]
+      c = @cursor.clamp(0, v.size)
+      return if c >= v.size
+      @values[@focused] = "#{v[0, c]}#{v[(c + 1)..]}"
+      @status = nil
+    end
+
     # ←/→: a toggle field flips, a choice field cycles, a text field moves the caret.
     def toggle_or_move(delta : Int32) : Nil
       if bool_field?

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -428,6 +428,10 @@ module Gori::Tui
         @values = [Settings.clipboard_osc52? ? "on" : "off", Settings.confirm_quit? ? "on" : "off"]
         return persist
       end
+      if err = Settings.bind_host_error(@values[0])
+        @status = "invalid bind IP"
+        return err
+      end
       port = @values[1].strip.to_i?
       unless port && 0 <= port <= 65535
         @status = "invalid port"

--- a/src/gori/tui/setup_wizard.cr
+++ b/src/gori/tui/setup_wizard.cr
@@ -116,6 +116,8 @@ module Gori::Tui
         move_cursor(1)
       elsif key.backspace?
         bind_backspace
+      elsif key.delete?
+        bind_delete
       elsif c = typed_char(ev)
         bind_insert(c)
       end
@@ -207,6 +209,16 @@ module Gori::Tui
       c = @cursor.clamp(0, v.size)
       set_bind_value("#{v[0, c - 1]}#{v[c..]}")
       @cursor = c - 1
+      @status = nil
+    end
+
+    # Forward-delete (the Del key): drop the character under the caret, caret unmoved.
+    # No-op with the caret at end-of-line — complements bind_backspace after caret moves.
+    private def bind_delete : Nil
+      v = bind_value
+      c = @cursor.clamp(0, v.size)
+      return if c >= v.size
+      set_bind_value("#{v[0, c]}#{v[(c + 1)..]}")
       @status = nil
     end
 

--- a/src/gori/tui/setup_wizard.cr
+++ b/src/gori/tui/setup_wizard.cr
@@ -164,6 +164,10 @@ module Gori::Tui
     end
 
     private def advance_from_bind : Nil
+      if Settings.bind_host_error(@ip)
+        @status = "invalid bind IP (e.g. 127.0.0.1)"
+        return
+      end
       unless valid_port?(@port)
         @status = "invalid port (0-65535)"
         return

--- a/src/gori/tui/tutorial.cr
+++ b/src/gori/tui/tutorial.cr
@@ -217,11 +217,14 @@ module Gori::Tui
     # lessons can never trap the user. Uses letter keys every keyboard has:
     #   n = next · b = back · ⇧⇥ = back
     # (⇥ alone stays free for pane cycle in the mock.)
-    # While typing in INS or the palette filter, n/b are normal characters.
+    # While typing in INS or with ANY overlay open (palette filter, or the space
+    # menu that owns its own keys), n/b are NOT tour nav — the overlay consumes
+    # them (the palette types them; the space menu ignores non-mnemonics) instead
+    # of snapping the lesson forward/back. ⇧⇥ still escapes (checked first).
     private def tour_nav_key?(ev : Termisu::Event::Key) : Bool
       return true if ev.key.back_tab?
       return false if @edit_insert
-      return false if @overlay == :palette
+      return false unless @overlay == :none
       return false if ev.ctrl? || ev.alt? # leave ^P etc. alone
       ch = ev.char
       ch == 'n' || ch == 'N' || ch == 'b' || ch == 'B'


### PR DESCRIPTION
Reviewed an accumulated list of TUI complaints, fixed the ones that were real, and deliberately skipped the ones that were already correct or intentional. Each fix is its own commit.

## Fixed

- **`fix(tutorial)`** — With the space (action-menu) overlay open, pressing `n`/`b` snapped the tutorial to the next/prev lesson instead of being handled by the modal overlay. `tour_nav_key?` already exempted the command palette; now it exempts *any* open overlay uniformly (⇧⇥ still escapes, checked first).
- **`fix(repeater,fuzzer)`** — The `^Y` CHAIN editor drew its own hint *"↵ save · esc cancel · Tab completes"* but `esc` actually ran `commit_chain_pane` — it **saved** instead of cancelling, the opposite of every other `esc` and of the hint. Added `discard_chain_pane` (drops focus without writing the edit back to the `§…§` marker); `↵`/`tab`/`↑` still commit, `^Y`-again still saves. Fixed in both the Repeater and Fuzzer controllers (both intercept `esc` before the view) and refreshed the status hints. Covered by new specs.
- **`feat(tui)`** — Added forward-delete (`Del`) to the settings editor and setup wizard text fields; previously only backspace could remove text, so editing a character mid-field after a caret move was awkward.
- **`feat(settings)`** — The proxy **Bind IP** was saved unvalidated (`999.999.999.999`, `invalid_ip` persisted verbatim → opaque bind failure at launch). Added `Settings.bind_host_error` (accepts any IPv4/IPv6 literal or plausible hostname; rejects malformed IP typos / illegal host chars) and gated both editors' save paths on it. Covered by new specs.

## Reviewed and intentionally skipped

- **Space-menu vim `j`/`k`** — reported as inverted; the code is already correct (`k`=up, `j`=down).
- **Space-menu duplicate-mnemonic shadowing** — already prevented at boot by `Verb::Registry#validate_menu_keys!`, which raises on any menu-key collision within a displayable view.
- **History list "dancing" under high traffic** — the reported code already *is* the stabilizer: when a new flow is prepended (newest-first) and not following, `@selected`/`@scroll` are bumped by 1 to keep the same flows in the same on-screen position.
- **Space-menu wrap-around** — clamping matches the app-wide list-nav convention (`settings_view#move_field`, `history_view#move` also clamp; only *choice-value* cycling wraps).
- **`--insecure-upstream` persisting on an unrelated save** — the current behavior is documented as intentional in `cli.cr` (the launch flag seeds the live session so `settings:network` reflects the active state). Separating a one-shot session override from persisted settings is an architectural change (the same applies to `--listen`/`--port`) and out of scope here; left as-is.
- **Digit-only input filtering, Help-tab search, tutorial `Shift+Tab`/`Esc`/min-size** — UX preferences rather than defects (numeric fields are already validated on save with clear messages); skipped to keep this focused.

## Verification

- New specs for the CHAIN discard-on-esc paths (repeater + fuzzer) and `bind_host_error`.
- Affected suites green: `repeater_view`, `fuzzer_view`, `settings_view`, `settings` — 150 examples, 0 failures.
- Full `crystal build` links clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)