### PR TITLE
Improve gori run CLI: consistency fixes, parsing bugs, notes writes, convert

### DIFF
--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -124,7 +124,7 @@ module Gori
         {"oast", "Listen for out-of-band callbacks (interactsh & friends); print payload + hits"},
         {"sitemap", "Print the host → path endpoint tree (text, json, paths)"},
         {"probe [QL]", "Passively scan captured flows for issues (zero requests)"},
-        {"notes [<n>]", "Read the project's notes (list, show one, or --all)"},
+        {"notes [<n>]", "Read or write the project's notes (list, show, --all, create, delete)"},
         {"issues", "List, export, create, or update issues (text, json, markdown)"},
         {"jwt [<token>]", "Decode, re-sign, or generate testing payloads for a JWT"},
         {"rewriter", "Manage Match & Replace rules (list, add, rm, enable/disable, preview)"},

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -44,6 +44,7 @@ require "./run/notes"
 require "./run/sitemap"
 require "./run/issues"
 require "./run/jwt"
+require "./run/convert"
 require "./run/rewriter"
 require "./run/project"
 
@@ -100,6 +101,7 @@ module Gori
         when "notes"    then cmd_notes(rest)
         when "issues"   then cmd_issues(rest)
         when "jwt"      then cmd_jwt(rest)
+        when "convert"  then cmd_convert(rest)
         when "rewriter" then cmd_rewriter(rest)
         when "project"  then cmd_project(rest)
         else
@@ -127,6 +129,7 @@ module Gori
         {"notes [<n>]", "Read or write the project's notes (list, show, --all, create, delete)"},
         {"issues", "List, export, create, or update issues (text, json, markdown)"},
         {"jwt [<token>]", "Decode, re-sign, or generate testing payloads for a JWT"},
+        {"convert <chain>", "Encode/decode/hash via the Decoder engine (base64, hex, url, gzip …)"},
         {"rewriter", "Manage Match & Replace rules (list, add, rm, enable/disable, preview)"},
         {"project [list]", "List known projects"},
         {"project scope", "Manage scope rules (list, add, delete, enable/disable)"},

--- a/src/gori/cli/run/capture.cr
+++ b/src/gori/cli/run/capture.cr
@@ -20,7 +20,10 @@ module Gori
           p.on("--project=NAME", "Capture into project NAME (created if missing; default 'default')") { |v| project_name = v }
           p.on("--db=PATH", "Capture into an explicit SQLite db file") { |v| db_path = v }
           p.on("-k", "--insecure-upstream", "Do not verify upstream TLS certificates") { insecure = true }
-          p.on("--format=FMT", "Output: text (default) | json (JSON-Lines)") { |v| format = parse_format(v, [:text, :json]) }
+          p.on("--format=FMT", "Output: text (default) | json | jsonl (both emit JSON-Lines)") do |v|
+            format = parse_format(v, [:text, :json, :jsonl])
+            format = :json if format == :jsonl # streamed output is JSON-Lines; accept the standard name too
+          end
           p.on("--for=DURATION", "Stop after DURATION (e.g. 30s, 5m, 1h)") { |v| every = parse_duration(v) }
           p.on("--max=N", "Stop after N completed flows") { |v| max = parse_count(v, "--max") }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }

--- a/src/gori/cli/run/convert.cr
+++ b/src/gori/cli/run/convert.cr
@@ -1,0 +1,149 @@
+# `gori run convert` — run a value through the Decoder engine's converter chain
+# (the same engine behind the TUI Convert tab): base64/hex/url/gzip/jwt/… encode,
+# decode, hash and transform, composed left-to-right. Exposes the whole catalog to
+# scripts, which previously only had the single-purpose `gori run jwt`.
+module Gori
+  module CLI
+    module Run
+      private def self.cmd_convert(args : Array(String)) : Nil
+        if args.first? == "list"
+          cmd_convert_list(args[1..])
+          return
+        end
+
+        output_mode : Decoder::RenderAs? = nil
+        input_flag : String? = nil
+        format = :text
+        positional = [] of String
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run convert <chain> [input] [options]\n\n" \
+                     "Run INPUT through a left-to-right converter CHAIN (separators: > | ,).\n" \
+                     "INPUT comes from the 2nd positional arg, --input, or STDIN (verbatim).\n\n" \
+                     "Examples:\n" \
+                     "  gori run convert base64-decode SGVsbG8=\n" \
+                     "  gori run convert 'url-decode > base64-decode' %53%47%56%73%62%47%38%3D\n" \
+                     "  printf hello | gori run convert sha256\n" \
+                     "  gori run convert base64-decode --output hex <base64-of-binary>\n\n" \
+                     "Run 'gori run convert list' for every converter name."
+          p.on("--input=STR", "Value to convert (else 2nd positional arg, else STDIN)") { |v| input_flag = v }
+          p.on("-oMODE", "--output=MODE", "Render final bytes: auto (default) | text | base64 | hex") { |v| output_mode = parse_render_mode(v) }
+          p.on("--format=FMT", "Output: text (default) | json (per-step detail)") { |v| format = parse_format(v, [:text, :json]) }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| positional = rest }
+          p.invalid_option { |f| abort "gori run convert: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run convert: missing value for #{f}" }
+        end
+        parser.parse(args)
+
+        abort "gori run convert: missing <chain> (e.g. 'base64-decode'; see 'gori run convert list')" if positional.empty?
+        abort "gori run convert: too many arguments (expected <chain> [input])" if positional.size > 2
+        chain = positional[0]
+
+        input_str = input_flag || positional[1]?
+        input_str ||= STDIN.gets_to_end unless STDIN.tty?
+        abort "gori run convert: no input (pass it as an argument, --input, or via STDIN)" if input_str.nil?
+
+        result = Decoder.run(Decoder.shared_registry, input_str.to_slice, chain)
+
+        if format == :json
+          puts convert_json(result, output_mode)
+        else
+          if final_bytes = result.output
+            rendered, _ = Decoder.display(final_bytes, output_mode)
+            STDOUT.puts rendered
+          end
+          unless result.ok?
+            report_convert_failure(result)
+            exit 1
+          end
+        end
+      end
+
+      # STDERR line for the first non-Ok step, so a failing chain is diagnosable in
+      # the text view (the JSON view carries the same via `failed_at` + step state).
+      private def self.report_convert_failure(result : Decoder::ChainResult) : Nil
+        i = result.failed_at
+        return unless i
+        s = result.steps[i]
+        reason = s.state.unknown? ? "is not a known converter (see 'gori run convert list')" : "failed"
+        STDERR.puts "gori run convert: step ##{i + 1} '#{s.token}' #{reason}#{s.error ? ": #{s.error}" : ""}"
+      end
+
+      private def self.convert_json(result : Decoder::ChainResult, mode : Decoder::RenderAs?) : String
+        JSON.build do |j|
+          j.object do
+            j.field "ok", result.ok?
+            j.field "steps" do
+              j.array do
+                result.steps.each do |s|
+                  j.object do
+                    j.field "token", s.token
+                    j.field "name", s.name
+                    j.field "state", s.state.to_s.downcase
+                    if o = s.output
+                      # Intermediate steps render as-is (auto); only the FINAL output
+                      # honors an explicit --output mode.
+                      rendered, render = Decoder.display(o, nil)
+                      j.field "render", render.to_s.downcase
+                      j.field "output", rendered
+                    end
+                    j.field "error", s.error if s.error
+                  end
+                end
+              end
+            end
+            if final_bytes = result.output
+              rendered, render = Decoder.display(final_bytes, mode)
+              j.field "render", render.to_s.downcase
+              j.field "output", rendered
+            end
+            j.field "failed_at", result.failed_at.try(&.+(1))
+          end
+        end
+      end
+
+      private def self.parse_render_mode(v : String) : Decoder::RenderAs?
+        case v.downcase
+        when "auto"   then nil
+        when "text"   then Decoder::RenderAs::Text
+        when "base64" then Decoder::RenderAs::Base64
+        when "hex"    then Decoder::RenderAs::Hex
+        else               abort "gori run convert: invalid --output '#{v}' (auto|text|base64|hex)"
+        end
+      end
+
+      private def self.cmd_convert_list(args : Array(String)) : Nil
+        format = :text
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run convert list [options]\n\nList every converter (name, category, direction)."
+          p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.invalid_option { |f| abort "gori run convert list: unknown option: #{f}\n#{p}" }
+        end
+        parser.parse(args)
+
+        registry = Decoder.shared_registry
+        if format == :json
+          puts(JSON.build do |j|
+            j.array do
+              registry.each do |c|
+                j.object do
+                  j.field "name", c.name
+                  j.field "aliases", c.aliases
+                  j.field "category", c.category.label
+                  j.field "direction", c.direction.to_s.downcase
+                  j.field "description", c.description
+                end
+              end
+            end
+          end)
+        else
+          registry.each do |c|
+            puts "#{c.name.ljust(22)}  #{c.category.label.ljust(11)}  #{c.direction.to_s.downcase.ljust(9)}  #{c.description}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/gori/cli/run/fuzz_args.cr
+++ b/src/gori/cli/run/fuzz_args.cr
@@ -6,9 +6,12 @@ module Gori
     module Run
       private def self.parse_numbers(v : String) : Fuzz::NumberRange
         range_part, _, step_part = v.partition(':')
-        from_s, _, to_s = range_part.partition('-')
-        from = from_s.to_i64?
-        to = to_s.to_i64?
+        # A plain `partition('-')` splits on the FIRST hyphen, so a negative FROM
+        # (e.g. `-10--5`) would leave an empty `from_s`. Match both bounds — each
+        # optionally signed — so negative ranges (common in offset/ID fuzzing) work.
+        m = range_part.match(/\A(-?\d+)-(-?\d+)\z/)
+        from = m.try(&.[1].to_i64?)
+        to = m.try(&.[2].to_i64?)
         abort "gori run fuzz: invalid --numbers '#{v}' (use FROM-TO[:STEP])" unless from && to
         step = step_part.empty? ? 1_i64 : (step_part.to_i64? || abort("gori run fuzz: invalid --numbers step '#{step_part}'"))
         Fuzz::NumberRange.new(from, to, step)
@@ -72,9 +75,15 @@ module Gori
       private def self.parse_regex_replace(v : String) : Fuzz::RegexReplace
         abort "gori run fuzz: --regex-replace needs /pattern/replacement/" if v.size < 3
         delim = v[0]
-        parts = v[1..].split(delim)
-        abort "gori run fuzz: --regex-replace must be #{delim}pattern#{delim}replacement#{delim}" if parts.size < 2
-        Fuzz::RegexReplace.new(parse_regex(parts[0]), parts[1])
+        # Splitting on every delimiter dropped any part of the replacement past a
+        # second delimiter (e.g. `/foo//bar/` lost `/bar`). Take the pattern up to
+        # the first delimiter, then treat the REST as the replacement — stripping one
+        # trailing delimiter (the documented `/pattern/replacement/` terminator) so a
+        # delimiter inside the replacement survives.
+        pattern, sep, rest = v[1..].partition(delim)
+        abort "gori run fuzz: --regex-replace must be #{delim}pattern#{delim}replacement#{delim}" if sep.empty?
+        replacement = rest.ends_with?(delim) ? rest[0...-1] : rest
+        Fuzz::RegexReplace.new(parse_regex(pattern), replacement)
       end
     end
   end

--- a/src/gori/cli/run/history.cr
+++ b/src/gori/cli/run/history.cr
@@ -17,7 +17,10 @@ module Gori
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("-qQL", "--query=QL", "Filter with a QL query (host: status:>=500 size:>10000 dur:>500 header: body~rx …)") { |v| query = v }
           p.on("-nN", "--limit=N", "Max rows, newest first (default 50)") { |v| limit = parse_count(v, "--limit") }
-          p.on("--format=FMT", "Output: text (default) | json (JSON-Lines)") { |v| format = parse_format(v, [:text, :json]) }
+          p.on("--format=FMT", "Output: text (default) | json | jsonl (both emit JSON-Lines)") do |v|
+            format = parse_format(v, [:text, :json, :jsonl])
+            format = :json if format == :jsonl # this listing's json IS JSON-Lines; accept the standard name too
+          end
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args { |rest, _| positional = rest }
           p.invalid_option { |f| abort "gori run history: unknown option: #{f}\n#{p}" }

--- a/src/gori/cli/run/notes.cr
+++ b/src/gori/cli/run/notes.cr
@@ -1,8 +1,20 @@
-# `gori run notes` — read the project's notes (list, show one, or --all).
+# `gori run notes` — read the project's notes (list, show one, or --all),
+# or write them (create, delete). Notes are addressed by their 1-based list
+# position <n> (the same number `notes <n>` and the listing show), not the
+# internal stable id.
 module Gori
   module CLI
     module Run
       private def self.cmd_notes(args : Array(String)) : Nil
+        case args.first?
+        when "create"       then cmd_notes_create(args[1..])
+        when "delete", "rm" then cmd_notes_delete(args[1..])
+        when "list"         then cmd_notes_read(args[1..])
+        else                     cmd_notes_read(args)
+        end
+      end
+
+      private def self.cmd_notes_read(args : Array(String)) : Nil
         db_path : String? = nil
         project_name : String? = nil
         format = :text
@@ -40,6 +52,77 @@ module Gori
           show_all_notes(doc, format)
         else
           list_notes(doc, format)
+        end
+      end
+
+      private def self.cmd_notes_create(args : Array(String)) : Nil
+        db_path : String? = nil
+        project_name : String? = nil
+        text : String? = nil
+        positional = [] of String
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run notes create [--text TEXT] [options]\n\n" \
+                     "Create a note. Body comes from --text, else the positional args,\n" \
+                     "else STDIN (e.g. `some-tool | gori run notes create`)."
+          p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
+          p.on("--text=TEXT", "Note body (else positional args, else STDIN)") { |v| text = v }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| positional = rest }
+          p.invalid_option { |f| abort "gori run notes create: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run notes create: missing value for #{f}" }
+        end
+        parser.parse(args)
+
+        body = text || (positional.empty? ? nil : positional.join(' '))
+        body ||= STDIN.gets_to_end unless STDIN.tty?
+        abort "gori run notes create: no note text (use --text, positional args, or pipe via STDIN)" if body.nil? || body.empty?
+
+        store = open_store(resolve_read_project(project_name, db_path))
+        begin
+          doc = Notes.load(store)
+          new_id = doc.next_id
+          new_notes = doc.notes + [Notes::NoteEntry.new(new_id, body)]
+          store.set_setting(Notes::DOCS_KEY, Notes.serialize(new_notes.size - 1, new_notes, new_id + 1))
+          puts "Note ##{new_notes.size} created."
+        ensure
+          store.close
+        end
+      end
+
+      private def self.cmd_notes_delete(args : Array(String)) : Nil
+        db_path : String? = nil
+        project_name : String? = nil
+        positional = [] of String
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run notes delete <n> [options]\n\n" \
+                     "Delete the note at 1-based list position <n> (as shown by `notes`)."
+          p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| positional = rest }
+          p.invalid_option { |f| abort "gori run notes delete: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run notes delete: missing value for #{f}" }
+        end
+        parser.parse(args)
+
+        abort "gori run notes delete: missing <n>" if positional.empty?
+        abort "gori run notes delete: too many arguments (expected one note number)" if positional.size > 1
+        n = parse_note_index(positional.first).not_nil!
+
+        store = open_store(resolve_read_project(project_name, db_path))
+        begin
+          doc = Notes.load(store)
+          abort "gori run notes delete: no note ##{n} (this project has #{doc.size} note#{doc.size == 1 ? "" : "s"})" unless n <= doc.size
+          new_notes = doc.notes.dup
+          new_notes.delete_at(n - 1)
+          new_cur = doc.cur.clamp(0, {new_notes.size - 1, 0}.max)
+          store.set_setting(Notes::DOCS_KEY, Notes.serialize(new_cur, new_notes, doc.next_id))
+          puts "Note ##{n} deleted."
+        ensure
+          store.close
         end
       end
 

--- a/src/gori/cli/run/project.cr
+++ b/src/gori/cli/run/project.cr
@@ -97,12 +97,14 @@ module Gori
         case sub
         when "add"
           cmd_scope_add(args[1..])
-        when "delete"
+        when "delete", "rm"
           cmd_scope_delete(args[1..])
         when "enable"
           cmd_scope_set_enabled(true, args[1..])
         when "disable"
           cmd_scope_set_enabled(false, args[1..])
+        when "list"
+          cmd_scope_list(args[1..])
         when nil
           cmd_scope_list(args)
         else
@@ -110,7 +112,7 @@ module Gori
             cmd_scope_list(args)
           else
             STDERR.puts "gori run project scope: unknown subcommand '#{sub}'"
-            STDERR.puts "Usage: gori run project scope [list options] | add | delete | enable | disable"
+            STDERR.puts "Usage: gori run project scope [list options] | add | delete|rm | enable | disable"
             exit 1
           end
         end
@@ -125,7 +127,7 @@ module Gori
           p.banner = "Usage: gori run project scope [options]\n\n" \
                      "Or run with a subcommand:\n" \
                      "  gori run project scope add --kind=include/exclude --type=host/string/regex --pattern=...\n" \
-                     "  gori run project scope delete <rule-id>\n" \
+                     "  gori run project scope delete|rm <rule-id>\n" \
                      "  gori run project scope enable\n" \
                      "  gori run project scope disable"
           p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
@@ -218,7 +220,7 @@ module Gori
         project_name : String? = nil
 
         parser = OptionParser.new do |p|
-          p.banner = "Usage: gori run project scope delete <rule-id> [options]"
+          p.banner = "Usage: gori run project scope delete|rm <rule-id> [options]"
           p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
@@ -285,8 +287,10 @@ module Gori
         case sub
         when "set"
           cmd_env_set(args[1..])
-        when "delete"
+        when "delete", "rm"
           cmd_env_delete(args[1..])
+        when "list"
+          cmd_env_list(args[1..])
         when nil
           cmd_env_list(args)
         else
@@ -294,7 +298,7 @@ module Gori
             cmd_env_list(args)
           else
             STDERR.puts "gori run project env: unknown subcommand '#{sub}'"
-            STDERR.puts "Usage: gori run project env [list options] | set KEY=value | delete KEY"
+            STDERR.puts "Usage: gori run project env [list options] | set KEY=value | delete|rm KEY"
             exit 1
           end
         end
@@ -311,7 +315,7 @@ module Gori
                      "Or run with a subcommand:\n" \
                      "  gori run project env set KEY=value\n" \
                      "  gori run project env set KEY value\n" \
-                     "  gori run project env delete KEY"
+                     "  gori run project env delete|rm KEY"
           p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
@@ -391,7 +395,7 @@ module Gori
         positional = [] of String
 
         parser = OptionParser.new do |p|
-          p.banner = "Usage: gori run project env delete KEY [options]"
+          p.banner = "Usage: gori run project env delete|rm KEY [options]"
           p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
@@ -430,8 +434,10 @@ module Gori
           cmd_host_override_add(args[1..])
         when "update"
           cmd_host_override_update(args[1..])
-        when "delete"
+        when "delete", "rm"
           cmd_host_override_delete(args[1..])
+        when "list"
+          cmd_host_override_list(args[1..])
         when nil
           cmd_host_override_list(args)
         else
@@ -439,7 +445,7 @@ module Gori
             cmd_host_override_list(args)
           else
             STDERR.puts "gori run project host-override: unknown subcommand '#{sub}'"
-            STDERR.puts "Usage: gori run project host-override [list options] | add | update | delete"
+            STDERR.puts "Usage: gori run project host-override [list options] | add | update | delete|rm"
             exit 1
           end
         end
@@ -458,7 +464,7 @@ module Gori
                      "  gori run project host-override add --host=api.example.com --ip=10.0.0.1\n" \
                      "  gori run project host-override add 10.0.0.1 api.example.com\n" \
                      "  gori run project host-override update <id> --host=... --ip=...\n" \
-                     "  gori run project host-override delete <id>"
+                     "  gori run project host-override delete|rm <id>"
           p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
@@ -602,7 +608,7 @@ module Gori
         positional = [] of String
 
         parser = OptionParser.new do |p|
-          p.banner = "Usage: gori run project host-override delete <id> [options]"
+          p.banner = "Usage: gori run project host-override delete|rm <id> [options]"
           p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }

--- a/src/gori/cli/run/repeater.cr
+++ b/src/gori/cli/run/repeater.cr
@@ -185,7 +185,11 @@ module Gori
         positional = [] of String
 
         parser = OptionParser.new do |p|
-          p.banner = "Usage: gori run repeater <flow-id> [options]"
+          p.banner = "Usage: gori run repeater <flow-id> [options]\n\n" \
+                     "Re-send a captured flow. Or manage repeater sessions:\n" \
+                     "  gori run repeater list                List repeater sessions in the workbench\n" \
+                     "  gori run repeater create [options]    Create a repeater session (--flow/--request-file/--request-raw)\n\n" \
+                     "Options (single-flow replay):"
           p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("--target=URL", "Send to this origin (scheme://host[:port]) instead of the captured one; path/query kept") { |v| target_override = v }

--- a/src/gori/cli/run/rewriter.cr
+++ b/src/gori/cli/run/rewriter.cr
@@ -9,13 +9,14 @@ module Gori
         when "enable"       then cmd_rewriter_set_enabled(true, args[1..])
         when "disable"      then cmd_rewriter_set_enabled(false, args[1..])
         when "preview"      then cmd_rewriter_preview(args[1..])
+        when "list"         then cmd_rewriter_list(args[1..])
         when nil            then cmd_rewriter_list(args)
         else
           if (s = sub) && s.starts_with?('-')
             cmd_rewriter_list(args)
           else
             STDERR.puts "gori run rewriter: unknown subcommand '#{sub}'"
-            STDERR.puts "Usage: gori run rewriter [list options] | add | rm <id> | enable <id> | disable <id> | preview"
+            STDERR.puts "Usage: gori run rewriter [list options] | add | rm|delete <id> | enable <id> | disable <id> | preview"
             exit 1
           end
         end
@@ -47,7 +48,7 @@ module Gori
                      "Or run with a subcommand:\n" \
                      "  gori run rewriter add --op=replace --target=request --find=OLD --value=NEW\n" \
                      "  gori run rewriter add --op=add_header --find=X-Trace --value=on\n" \
-                     "  gori run rewriter rm <id> | enable <id> | disable <id> | preview ..."
+                     "  gori run rewriter rm|delete <id> | enable <id> | disable <id> | preview ..."
           p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
@@ -167,7 +168,7 @@ module Gori
         db_path : String? = nil
         project_name : String? = nil
         parser = OptionParser.new do |p|
-          p.banner = "Usage: gori run rewriter rm <id> [options]"
+          p.banner = "Usage: gori run rewriter rm|delete <id> [options]"
           p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
@@ -177,6 +178,7 @@ module Gori
         parser.unknown_args { |rest, _| positional = rest }
         parser.parse(args)
         abort "gori run rewriter rm: missing <id>" if positional.empty?
+        abort "gori run rewriter rm: too many arguments (expected one <id>)" if positional.size > 1
         id = positional[0].to_i64? || abort("gori run rewriter rm: invalid rule id '#{positional[0]}'")
 
         project = resolve_read_project(project_name, db_path)
@@ -208,6 +210,7 @@ module Gori
         parser.unknown_args { |rest, _| positional = rest }
         parser.parse(args)
         abort "gori run rewriter #{action}: missing <id>" if positional.empty?
+        abort "gori run rewriter #{action}: too many arguments (expected one <id>)" if positional.size > 1
         id = positional[0].to_i64? || abort("gori run rewriter #{action}: invalid rule id '#{positional[0]}'")
 
         project = resolve_read_project(project_name, db_path)
@@ -259,6 +262,12 @@ module Gori
         target = Store::RuleTarget.parse?(target_s) || abort("gori run rewriter preview: invalid --target '#{target_s}'")
         part = Store::RulePart.parse?(part_s) || abort("gori run rewriter preview: invalid --part '#{part_s}'")
         match = Store::MatchKind.parse?(match_s) || abort("gori run rewriter preview: invalid --match '#{match_s}' (literal|regex)")
+        # Validate the regex up front (like `add` does) — otherwise a bad pattern is
+        # swallowed and reported as "0 flows", indistinguishable from a valid rule
+        # that simply matched nothing.
+        if op.replace? && match.regex? && !valid_regex?(f)
+          abort "gori run rewriter preview: invalid regex --find (failed to compile)"
+        end
         part = Store::RulePart::Head if op.header?
 
         project = resolve_read_project(project_name, db_path)


### PR DESCRIPTION
Reviewed the `gori run` CLI inconveniences/bugs collected by an agent and fixed the ones worth fixing, one work-unit per commit. Each change is verified against a real project DB; full spec suite (`crystal spec`) passes (2190 examples, 0 failures).

## Fixed

**Parsing bugs (`fuzz_args.cr`)**
- `--regex-replace` split on *every* delimiter, dropping any part of the replacement past a second delimiter (`/foo//bar/` lost `/bar`). Now takes the pattern up to the first delimiter and the rest as the replacement, stripping one trailing terminator delimiter.
- `--numbers` used `partition('-')`, splitting on the first hyphen, so negative ranges like `-10--5` (common in offset/ID fuzzing) were rejected. Now matched with a regex allowing signed bounds.

**Consistency: `list` subcommand** — `rewriter`, `project scope/env/host-override`, and `notes` now accept an explicit `list` (parity with `project list` / `repeater list`). `notes list` previously errored trying to parse `"list"` as a note number.

**Consistency: `delete`/`rm` aliases** — `project scope/env/host-override` now accept `rm` as an alias for `delete` (matching `rewriter`), documented in the banners. `rewriter`'s existing `delete` alias is now documented too.

**Consistency: extra-arg validation** — `rewriter rm/enable/disable` now reject extra positional args (parity with `project scope delete`) so a typo can't silently target only the first id.

**`rewriter preview` regex validation** — a bad regex is now a clear error instead of a misleading "0 flows" (matching `rewriter add`).

**`repeater --help`** — now documents the `list` and `create` subcommands (previously only single-flow replay).

**`jsonl` format alias** — `history` and `capture` both stream newline-delimited JSON but rejected `--format jsonl`; it's now accepted and mapped to `json`.

## Added

**`notes create` / `notes delete`** — the CLI was read-only for notes while scope/env/host-override/issues all support writes. Mirrors the MCP notes write path. Body comes from `--text`, positional args, or STDIN; delete addresses notes by their 1-based list position.

**`gori run convert`** — exposes the full Decoder engine (the TUI Convert tab's `base64`/`hex`/`url`/`gzip`/`jwt`/… encode/decode/hash/transform) as a scriptable chain: `gori run convert <chain> [input]`, input from arg/`--input`/STDIN, `--output text|base64|hex`, `--format json` for per-step detail. `gori run convert list` enumerates converters.

## Intentionally skipped
- Demo-data active-scan guide (item 3) — an infra/docs suggestion (mock server / `/etc/hosts`), not a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
