### PR TITLE
chore(seed_demo): refresh for current tabs and fix stale APIs

### DIFF
--- a/scripts/seed_demo.cr
+++ b/scripts/seed_demo.cr
@@ -1,11 +1,19 @@
-# Seeds a "demo" registry project with a realistic, varied dataset so the TUI
-# (History / Sitemap / Findings / Notes / Scope) has something to explore.
+# Seeds a "demo" registry project with a realistic, varied dataset so every tab in
+# the TUI has something real to explore:
+#
+#   History / Target(Sitemap+Discover) / Issues / Notes / Scope       — captured traffic
+#   Repeater / Fuzzer / Miner / Sequencer                             — pre-seeded workbench sessions
+#   Rewriter                                                          — match&replace rules
+#   OAST                                                              — an out-of-band listener with callbacks
+#   Probe                                                             — passive scan + a custom rule
+#   Decoder / JWT / Comparer                                          — data to send into the ephemeral tools
 #
 #   crystal run scripts/seed_demo.cr
 #
 # Re-runnable: it wipes any existing "demo" project first, then recreates it.
 require "file_utils"
 require "base64"
+require "openssl/hmac"
 require "uri"
 require "../src/gori"
 require "../src/gori/project_registry"
@@ -120,6 +128,25 @@ def grpc_frame(msg : Bytes) : Bytes
   io.to_slice
 end
 
+# base64url without padding (the JWT segment encoding).
+def b64url(data : String | Bytes) : String
+  Base64.urlsafe_encode(data, padding: false)
+end
+
+# Build a real, decodable HS256 JWT so the JWT tab genuinely works on this demo:
+# decode shows the claims, "weak secret" cracks WEAK_SECRET, and the alg:none /
+# header-inject attacks re-forge from the real header/payload. Deliberately signed
+# with a guessable secret so the weak-secret attack (and the matching Issue) land.
+WEAK_SECRET = "secret"
+
+def make_jwt(secret : String) : String
+  header = %({"alg":"HS256","typ":"JWT"})
+  payload = %({"sub":"1","name":"alice","role":"customer","iss":"api.demo.test","iat":1718787600,"exp":1718791200})
+  signing_input = "#{b64url(header)}.#{b64url(payload)}"
+  sig = b64url(OpenSSL::HMAC.digest(:sha256, secret, signing_input))
+  "#{signing_input}.#{sig}"
+end
+
 Paths.ensure_dirs
 registry = ProjectRegistry.new(Paths.projects_dir)
 
@@ -132,10 +159,16 @@ end
 project = registry.create("demo",
   "Demo target for exploring gori's TUI — a fictional shop + JSON API, plus a real, " \
   "replayable capture of www.hahwul.com. Captured browsing of shop.demo.test / " \
-  "api.demo.test / cdn.demo.test / www.hahwul.com with planted findings, replay/fuzz/miner " \
-  "sessions, and entity links tying findings and notes to related workbench items.")
+  "api.demo.test / cdn.demo.test / www.hahwul.com with planted issues; Repeater/Fuzzer/" \
+  "Miner/Sequencer sessions; Rewriter rules; an OAST listener with callbacks; and entity " \
+  "links tying issues and notes to related workbench items.")
 store = S.open(project.db_path)
 puts "• created project 'demo' at #{project.db_path}"
+
+# The shared bearer token used across the API flows below — a REAL HS256 JWT (weakly
+# signed) so the JWT tab can decode/crack/re-forge it and the Sequencer/Decoder have
+# something genuine to chew on.
+jwt = make_jwt(WEAK_SECRET)
 
 # Timeline: spread flows over the last ~95 minutes so History reads like a session.
 base = Time.utc.to_unix * 1_000_000_i64 - 95_i64 * US_PER_MIN
@@ -167,10 +200,10 @@ ids[:login] = add_flow(store, t.call(6), host: "shop.demo.test", target: "/api/l
   method: "POST", req_body: %({"username":"alice","password":"hunter2"}),
   status: 200, reason: "OK", ctype: "application/json",
   resp_headers: {"Set-Cookie" => "sid=8f3a..; Path=/"},
-  resp_body: %({"ok":true,"token":"eyJhbGciOiJIUzI1NiJ9.demo.token","user_id":1}))
+  resp_body: %({"ok":true,"token":"#{jwt}","user_id":1}))
 
 add_flow(store, t.call(9), host: "api.demo.test", target: "/v1/products",
-  req_headers: {"Authorization" => "Bearer eyJhbGciOiJIUzI1NiJ9.demo.token"},
+  req_headers: {"Authorization" => "Bearer #{jwt}"},
   status: 200, reason: "OK", ctype: "application/json",
   resp_body: %([{"id":42,"name":"Blue Widget","price":1999},{"id":43,"name":"Red Widget","price":2499}]))
 
@@ -179,7 +212,7 @@ add_flow(store, t.call(11), host: "api.demo.test", target: "/v1/products/42",
   resp_body: %({"id":42,"name":"Blue Widget","price":1999,"stock":17,"sku":"BW-0042"}))
 
 add_flow(store, t.call(13), host: "api.demo.test", target: "/v1/cart", method: "POST",
-  req_headers: {"Authorization" => "Bearer eyJhbGciOiJIUzI1NiJ9.demo.token"},
+  req_headers: {"Authorization" => "Bearer #{jwt}"},
   req_body: %({"product_id":42,"qty":2}),
   status: 201, reason: "Created", ctype: "application/json",
   resp_body: %({"cart_id":9,"items":[{"product_id":42,"qty":2}],"total":3998}))
@@ -207,24 +240,24 @@ ids[:xss] = add_flow(store, t.call(26), host: "shop.demo.test",
   resp_body: html.call("Search", "<p>Results for <b><script>alert(1)</script></b>: 0 found</p>"))
 
 add_flow(store, t.call(31), host: "api.demo.test", target: "/v1/users/1",
-  req_headers: {"Authorization" => "Bearer eyJhbGciOiJIUzI1NiJ9.demo.token"},
+  req_headers: {"Authorization" => "Bearer #{jwt}"},
   status: 200, reason: "OK", ctype: "application/json",
   resp_body: %({"id":1,"name":"Alice","email":"alice@demo.test","role":"customer"}))
 
 # IDOR candidate: same token reads another user's record.
 ids[:idor] = add_flow(store, t.call(33), host: "api.demo.test", target: "/v1/users/2",
-  req_headers: {"Authorization" => "Bearer eyJhbGciOiJIUzI1NiJ9.demo.token"},
+  req_headers: {"Authorization" => "Bearer #{jwt}"},
   status: 200, reason: "OK", ctype: "application/json",
   resp_body: %({"id":2,"name":"Bob","email":"bob@demo.test","role":"admin","phone":"+1-555-0102"}))
 
 add_flow(store, t.call(36), host: "api.demo.test", target: "/v1/profile", method: "PUT",
-  req_headers: {"Authorization" => "Bearer eyJhbGciOiJIUzI1NiJ9.demo.token"},
+  req_headers: {"Authorization" => "Bearer #{jwt}"},
   req_body: %({"name":"Alice A.","newsletter":true}),
   status: 200, reason: "OK", ctype: "application/json",
   resp_body: %({"id":1,"name":"Alice A.","newsletter":true}))
 
 add_flow(store, t.call(38), host: "api.demo.test", target: "/v1/cart/9", method: "DELETE",
-  req_headers: {"Authorization" => "Bearer eyJhbGciOiJIUzI1NiJ9.demo.token"},
+  req_headers: {"Authorization" => "Bearer #{jwt}"},
   status: 204, reason: "No Content")
 
 add_flow(store, t.call(41), host: "shop.demo.test", target: "/missing-page",
@@ -235,6 +268,15 @@ add_flow(store, t.call(41), host: "shop.demo.test", target: "/missing-page",
 ids[:err500] = add_flow(store, t.call(44), host: "api.demo.test", target: "/v1/debug",
   status: 500, reason: "Internal Server Error", ctype: "text/html; charset=utf-8",
   resp_body: "<h1>RuntimeError at /v1/debug</h1><pre>NoMethodError: undefined method 'each' for nil\n  app/controllers/debug_controller.rb:14\n  rack (3.0.8) lib/rack/handler.rb:88\nDemoFramework 4.2.1</pre>")
+
+# Blind SSRF: an "import from URL" endpoint fetches an operator-supplied URL server-side.
+# The response is generic success (no reflected content), so it's confirmed OUT OF BAND —
+# the OAST listener seeded below received the resulting DNS + HTTP callback (see its tab).
+ids[:ssrf] = add_flow(store, t.call(43), host: "api.demo.test", target: "/v1/import", method: "POST",
+  req_headers: {"Authorization" => "Bearer #{jwt}"},
+  req_body: %({"url":"https://a1b2c3d4.oast.demo.test/hook?from=api.demo.test"}),
+  status: 200, reason: "OK", ctype: "application/json",
+  resp_body: %({"status":"ok","imported":true,"bytes":0}))
 
 # Rate limiting: same products listing, second page, throttled.
 add_flow(store, t.call(45), host: "api.demo.test", target: "/v1/products?page=2",
@@ -248,7 +290,7 @@ add_flow(store, t.call(46), host: "shop.demo.test", target: "/old-promo",
   resp_headers: {"Location" => "/promo"})
 
 add_flow(store, t.call(47), host: "api.demo.test", target: "/v1/profile/notifications", method: "PATCH",
-  req_headers: {"Authorization" => "Bearer eyJhbGciOiJIUzI1NiJ9.demo.token"},
+  req_headers: {"Authorization" => "Bearer #{jwt}"},
   req_body: %({"emailAlerts":false}),
   status: 200, reason: "OK", ctype: "application/json",
   resp_body: %({"emailAlerts":false}))
@@ -388,13 +430,13 @@ raw_flow(store, t.call(53), host: "api.demo.test", method: "GET", target: "/v1/s
 # GraphQL: ordinary application/json POSTs to /graphql (query, mutation, and a
 # revealing introspection). No special handling — the JSON body is highlighted.
 add_flow(store, t.call(56), host: "api.demo.test", target: "/graphql", method: "POST",
-  req_headers: {"Authorization" => "Bearer eyJhbGciOiJIUzI1NiJ9.demo.token"},
+  req_headers: {"Authorization" => "Bearer #{jwt}"},
   req_body: %({"operationName":"GetProducts","query":"query GetProducts($first: Int!) { products(first: $first) { id name price } }","variables":{"first":2}}),
   status: 200, reason: "OK", ctype: "application/json",
   resp_body: %({"data":{"products":[{"id":"42","name":"Blue Widget","price":1999},{"id":"43","name":"Red Widget","price":2499}]}}))
 
 add_flow(store, t.call(58), host: "api.demo.test", target: "/graphql", method: "POST",
-  req_headers: {"Authorization" => "Bearer eyJhbGciOiJIUzI1NiJ9.demo.token"},
+  req_headers: {"Authorization" => "Bearer #{jwt}"},
   req_body: %({"operationName":"AddToCart","query":"mutation AddToCart($id: ID!, $qty: Int!) { addToCart(productId: $id, qty: $qty) { cartId total } }","variables":{"id":"42","qty":2}}),
   status: 200, reason: "OK", ctype: "application/json",
   resp_body: %({"data":{"addToCart":{"cartId":"9","total":3998}}}))
@@ -405,7 +447,7 @@ ids[:gql] = add_flow(store, t.call(60), host: "api.demo.test", target: "/graphql
   resp_body: %({"data":{"__schema":{"queryType":{"name":"Query"},"types":[{"name":"Query","kind":"OBJECT"},{"name":"Product","kind":"OBJECT"},{"name":"User","kind":"OBJECT"},{"name":"Mutation","kind":"OBJECT"},{"name":"CartItem","kind":"OBJECT"}]}}}))
 
 # SAML: an SP-initiated SSO assertion POSTed to the ACS. The SAMLResponse is a
-# url-encoded base64 XML blob — decode it in the Convert tab: url-decode → base64-decode.
+# url-encoded base64 XML blob — decode it in the Decoder tab: url-decode → base64-decode.
 saml_xml = <<-XML
   <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_demo123" Version="2.0" IssueInstant="2026-06-26T09:00:00Z" Destination="https://shop.demo.test/saml/acs">
     <saml:Issuer>https://idp.demo.test/metadata</saml:Issuer>
@@ -446,13 +488,13 @@ raw_flow(store, t.call(62), host: "shop.demo.test", method: "POST", target: "/sa
 
 puts "• inserted protocol showcase: websocket(#{ws_msgs.size} msgs) + grpc + sse + 3×graphql + saml"
 
-# --- Real target: www.hahwul.com (live — Replay ^R genuinely hits it) ------
+# --- Real target: www.hahwul.com (live — Repeater ^R genuinely hits it) ----
 # Every flow below reflects an actual response captured from the real
 # https://www.hahwul.com (GitHub Pages behind Fastly/Varnish) — titles, status
 # codes and headers are accurate, bodies are trimmed. Unlike the fictional
-# hosts above, sending one of these from Replay really goes out over the
-# network and comes back with a live response: good for trying Replay/Diff/
-# Prism against genuine traffic instead of only synthetic data.
+# hosts above, sending one of these from Repeater really goes out over the
+# network and comes back with a live response: good for trying Repeater/Diff/
+# Probe against genuine traffic instead of only synthetic data.
 gh_req_head = ->(method : String, target : String) {
   String.build do |b|
     b << method << ' ' << target << " HTTP/2\r\n"
@@ -575,106 +617,207 @@ raw_flow(store, t.call(89), host: "www.hahwul.com", method: "GET", target: "/thi
 
 puts "• inserted 9 real, replayable flows against www.hahwul.com"
 
-# --- Findings (a few planted vulns, linked to the flows above) -------------
-f1 = store.insert_finding("Reflected XSS in /search `q` parameter", S::Severity::High,
+# --- Issues (a few planted vulns, linked to the flows above) ----------------
+f1 = store.insert_issue("Reflected XSS in /search `q` parameter", S::Severity::High,
   "shop.demo.test", ids[:xss])
-store.update_finding(f1, notes: "The `q` query parameter is reflected into the HTML " \
-                                "response without output encoding.\n\nPoC: /search?q=<script>alert(1)</script>\n\n" \
-                                "Impact: session theft via document.cookie (token is also exposed in the login JSON — see related finding).\n" \
-                                "Fix: HTML-encode user input on output; add a CSP.")
+store.update_issue(f1, notes: "The `q` query parameter is reflected into the HTML " \
+                              "response without output encoding.\n\nPoC: /search?q=<script>alert(1)</script>\n\n" \
+                              "Impact: session theft via document.cookie (token is also exposed in the login JSON — see related issue).\n" \
+                              "Fix: HTML-encode user input on output; add a CSP.", status: S::Status::Confirmed)
 
-f2 = store.insert_finding("IDOR: /v1/users/{id} exposes other users' PII", S::Severity::High,
+f2 = store.insert_issue("IDOR: /v1/users/{id} exposes other users' PII", S::Severity::High,
   "api.demo.test", ids[:idor])
-store.update_finding(f2, notes: "A customer token (user_id=1) can read /v1/users/2 and " \
-                                "receives Bob's email, role=admin and phone.\n\nNo object-level authorization check.\n" \
-                                "Fix: verify the authenticated subject owns (or may access) the requested id.")
+store.update_issue(f2, notes: "A customer token (user_id=1) can read /v1/users/2 and " \
+                              "receives Bob's email, role=admin and phone.\n\nNo object-level authorization check.\n" \
+                              "Fix: verify the authenticated subject owns (or may access) the requested id.", status: S::Status::Confirmed)
 
-f3 = store.insert_finding("Verbose 500 leaks stack trace & framework version", S::Severity::Medium,
+f3 = store.insert_issue("Verbose 500 leaks stack trace & framework version", S::Severity::Medium,
   "api.demo.test", ids[:err500])
-store.update_finding(f3, notes: "/v1/debug returns a full stack trace and 'DemoFramework 4.2.1' " \
-                                "in the response body. Aids targeted exploitation.\nFix: disable debug error pages in production.")
+store.update_issue(f3, notes: "/v1/debug returns a full stack trace and 'DemoFramework 4.2.1' " \
+                              "in the response body. Aids targeted exploitation.\nFix: disable debug error pages in production.")
 
-f4 = store.insert_finding("Session token returned in JSON body", S::Severity::Low,
+f4 = store.insert_issue("Session token returned in JSON body", S::Severity::Low,
   "shop.demo.test", ids[:login])
-store.update_finding(f4, notes: "POST /api/login returns the bearer token in the JSON body in " \
-                                "addition to the Set-Cookie. JS-readable tokens are exfiltratable via the XSS above.\n" \
-                                "Fix: keep the session in an HttpOnly, Secure cookie only.")
+store.update_issue(f4, notes: "POST /api/login returns the bearer token in the JSON body in " \
+                              "addition to the Set-Cookie. JS-readable tokens are exfiltratable via the XSS above.\n" \
+                              "Fix: keep the session in an HttpOnly, Secure cookie only.")
 
-store.insert_finding("Inconsistent authz: /v1/orders 401 but /v1/cart open", S::Severity::Info,
+store.insert_issue("Inconsistent authz: /v1/orders 401 but /v1/cart open", S::Severity::Info,
   "api.demo.test", ids[:cart])
 
-f6 = store.insert_finding("GraphQL introspection enabled in production", S::Severity::Medium,
+f6 = store.insert_issue("GraphQL introspection enabled in production", S::Severity::Medium,
   "api.demo.test", ids[:gql])
-store.update_finding(f6, notes: "POST /graphql answers a full `__schema` introspection query for " \
-                                "anonymous clients, exposing the entire type system (queries, mutations, types).\n\n" \
-                                "Impact: accelerates API mapping and discovery of hidden/abusable mutations.\n" \
-                                "Fix: disable introspection in production, or gate it behind authentication.")
+store.update_issue(f6, notes: "POST /graphql answers a full `__schema` introspection query for " \
+                              "anonymous clients, exposing the entire type system (queries, mutations, types).\n\n" \
+                              "Impact: accelerates API mapping and discovery of hidden/abusable mutations.\n" \
+                              "Fix: disable introspection in production, or gate it behind authentication.")
 
-puts "• inserted 6 findings"
+f7 = store.insert_issue("Blind SSRF in /v1/import `url` (confirmed via OAST)", S::Severity::High,
+  "api.demo.test", ids[:ssrf])
+store.update_issue(f7, notes: "POST /v1/import fetches an operator-supplied URL server-side. The response " \
+                              "is generic success, so it's blind — confirmed OUT OF BAND: the OAST tab received a " \
+                              "DNS lookup then an HTTP GET from the server for a1b2c3d4.oast.demo.test.\n\n" \
+                              "PoC: {\"url\":\"https://<your-oast-host>/hook\"}\n" \
+                              "Impact: reach internal services / cloud metadata (169.254.169.254).\n" \
+                              "Fix: allowlist destination hosts; block link-local + private ranges.", status: S::Status::Confirmed)
 
-# --- Workbench sessions (Replay / Fuzzer / Miner) ----------------------------
-# Pre-seed sub-tabs so entity links have replay/fuzz/miner targets to jump to.
-xss_replay_req = replay_req("GET", "shop.demo.test",
+f8 = store.insert_issue("JWT signed with a weak, guessable secret", S::Severity::High,
+  "api.demo.test", ids[:login])
+store.update_issue(f8, notes: "The HS256 session JWT is signed with the secret \"#{WEAK_SECRET}\".\n\n" \
+                              "Reproduce in the JWT tab: send the login token there (Space → send selection to JWT), " \
+                              "run the weak-secret attack — it recovers the key — then re-sign a forged {\"role\":\"admin\"} " \
+                              "payload, or try the alg:none attack.\n" \
+                              "Fix: use a long random secret (or RS256 with a rotated keypair).")
+
+puts "• inserted 8 issues"
+
+# --- Workbench sessions (Repeater / Fuzzer / Miner) -------------------------
+# Pre-seed sub-tabs so entity links have repeater/fuzz/miner targets to jump to.
+xss_req = replay_req("GET", "shop.demo.test",
   "/search?q=%3Cscript%3Ealert(1)%3C%2Fscript%3E")
-ids[:replay_xss] = store.insert_replay("https://shop.demo.test", xss_replay_req,
+ids[:repeater_xss] = store.insert_repeater("https://shop.demo.test", xss_req,
   false, true, ids[:xss], 0)
-store.set_replay_name(ids[:replay_xss], "XSS PoC")
+store.set_repeater_name(ids[:repeater_xss], "XSS PoC")
 
-idor_replay_req = replay_req("GET", "api.demo.test", "/v1/users/2",
-  {"Authorization" => "Bearer eyJhbGciOiJIUzI1NiJ9.demo.token"})
-ids[:replay_idor] = store.insert_replay("https://api.demo.test", idor_replay_req,
+idor_req = replay_req("GET", "api.demo.test", "/v1/users/2",
+  {"Authorization" => "Bearer #{jwt}"})
+ids[:repeater_idor] = store.insert_repeater("https://api.demo.test", idor_req,
   false, true, ids[:idor], 1)
-store.set_replay_name(ids[:replay_idor], "IDOR probe")
+store.set_repeater_name(ids[:repeater_idor], "IDOR probe")
 
-hahwul_replay_req = "GET / HTTP/2\r\nhost: www.hahwul.com\r\naccept: text/html\r\n\r\n"
-ids[:replay_hahwul] = store.insert_replay("https://www.hahwul.com", hahwul_replay_req,
-  true, true, ids[:hahwul_home], 2)
-store.set_replay_name(ids[:replay_hahwul], "hahwul home")
+ssrf_req = replay_req("POST", "api.demo.test", "/v1/import",
+  {"Authorization" => "Bearer #{jwt}", "Content-Type" => "application/json"},
+  %({"url":"https://a1b2c3d4.oast.demo.test/hook?from=api.demo.test"}))
+ids[:repeater_ssrf] = store.insert_repeater("https://api.demo.test", ssrf_req,
+  false, true, ids[:ssrf], 2)
+store.set_repeater_name(ids[:repeater_ssrf], "SSRF → OAST")
+
+hahwul_req = "GET / HTTP/2\r\nhost: www.hahwul.com\r\naccept: text/html\r\n\r\n"
+ids[:repeater_hahwul] = store.insert_repeater("https://www.hahwul.com", hahwul_req,
+  true, true, ids[:hahwul_home], 3)
+store.set_repeater_name(ids[:repeater_hahwul], "hahwul home")
 
 fuzz_template = replay_req("GET", "api.demo.test", "/v1/users/§1§",
-  {"Authorization" => "Bearer eyJhbGciOiJIUzI1NiJ9.demo.token"})
+  {"Authorization" => "Bearer #{jwt}"})
 ids[:fuzz_users] = store.insert_fuzz_session("https://api.demo.test", fuzz_template,
   false, nil, %({"mode":"sniper","sets":[{"kind":"numbers","value":"1-10"}]}),
   ids[:idor], 0, "user id enum")
 
 miner_req = replay_req("GET", "api.demo.test", "/v1/users/1",
-  {"Authorization" => "Bearer eyJhbGciOiJIUzI1NiJ9.demo.token"}).to_slice
+  {"Authorization" => "Bearer #{jwt}"}).to_slice
 ids[:miner_users] = store.insert_miner_session("https://api.demo.test", miner_req,
   false, nil,
   %({"locations":["query"],"concurrency":4,"notify":"off","stability_rounds":2,"confirm_rounds":1,"buckets":{"query":50}}),
   ids[:idor], 0, "users path mine")
 
-puts "• inserted 3 replay + 1 fuzz + 1 miner sessions"
+# Sequencer: analyze the randomness of the `sid` session cookie minted by /api/login.
+# Collected tokens are never persisted — the session stores only the request + descriptor.
+seq_req = replay_req("POST", "shop.demo.test", "/api/login",
+  {"Content-Type" => "application/json"}, %({"username":"alice","password":"hunter2"})).to_slice
+ids[:seq_sid] = store.insert_sequencer_session("https://shop.demo.test", seq_req,
+  false, nil,
+  %({"mode":"manual","kind":"cookie","selector":"sid","pos_start":0,"pos_end":0,"goal":500,"concurrency":4,"notify":"off"}),
+  ids[:login], 0, "sid randomness")
 
-# --- Entity links (findings + notes → history / replay / fuzz / miner) -------
-# insert_finding already auto-links the primary flow_id; add cross-workbench refs.
-store.add_link(S::LinkOwnerKind::Finding, f1, S::LinkRefKind::Replay, ids[:replay_xss])
-store.add_link(S::LinkOwnerKind::Finding, f1, S::LinkRefKind::Fuzz, ids[:fuzz_users])
-store.add_link(S::LinkOwnerKind::Finding, f1, S::LinkRefKind::Flow, ids[:login])
+puts "• inserted 4 repeater + 1 fuzz + 1 miner + 1 sequencer sessions"
 
-store.add_link(S::LinkOwnerKind::Finding, f2, S::LinkRefKind::Replay, ids[:replay_idor])
-store.add_link(S::LinkOwnerKind::Finding, f2, S::LinkRefKind::Fuzz, ids[:fuzz_users])
-store.add_link(S::LinkOwnerKind::Finding, f2, S::LinkRefKind::Miner, ids[:miner_users])
+# --- Rewriter (Match & Replace rules applied to in-flight traffic) -----------
+# A few illustrative rules — the security-hardening two are ON; the rest are OFF so
+# they don't silently alter traffic, but are one keystroke (toggle) from live so you
+# can flip one on and re-send from Repeater to watch it take effect.
+store.insert_rule(S::RuleTarget::Response, S::RulePart::Head, "X-Frame-Options", "DENY",
+  op: S::RuleOp::AddHeader, name: "Add X-Frame-Options", enabled: true)
+store.insert_rule(S::RuleTarget::Response, S::RulePart::Head, "Server", "",
+  op: S::RuleOp::RemoveHeader, name: "Strip Server banner", enabled: true)
+store.insert_rule(S::RuleTarget::Request, S::RulePart::Head, "Bearer [A-Za-z0-9._-]+", "Bearer «redacted»",
+  op: S::RuleOp::Replace, match_kind: S::MatchKind::Regex, name: "Redact bearer token (regex)", enabled: false)
+store.insert_rule(S::RuleTarget::Response, S::RulePart::Body,
+  "Welcome to Demo Shop", "Welcome to Demo Shop [rewritten by gori]",
+  op: S::RuleOp::Replace, match_kind: S::MatchKind::Literal,
+  name: "Brand tag (body-rewrite proof)", host: "shop.demo.test", enabled: false)
+puts "• inserted 4 rewriter rules (2 active, 2 staged)"
 
-store.add_link(S::LinkOwnerKind::Finding, f4, S::LinkRefKind::Replay, ids[:replay_xss])
+# --- OAST (out-of-band listener) — provider + session + received callbacks ---
+# Seeded to prove the SSRF above out of band. Polling never auto-resumes (see the
+# OAST controller), so these are inert historical rows: the tab opens showing the
+# two callbacks the server made when it fetched our payload host.
+oast_provider = store.insert_oast_provider("Demo OAST (oast.demo.test)",
+  Oast::ProviderKind::CustomHttp.label, "https://oast.demo.test", nil, true, 0)
+oast_session = store.insert_oast_session(oast_provider,
+  Oast::ProviderKind::CustomHttp.label, "https://oast.demo.test",
+  "demo7a3f9c2b41d", "s3cr3t-demo-oast", nil, nil)
 
-store.add_link(S::LinkOwnerKind::Finding, f6, S::LinkRefKind::Flow, ws_id)
+oast_dns_req = "a1b2c3d4.oast.demo.test.  IN  A\n; recursive lookup from 203.0.113.10 (api.demo.test egress)\n"
+store.insert_oast_callback(oast_session, "cb-dns-0001", "dns", nil, "203.0.113.10",
+  "a1b2c3d4.oast.demo.test", oast_dns_req.to_slice, nil, t.call(43))
+
+oast_http_req = String.build do |b|
+  b << "GET /hook?from=api.demo.test HTTP/1.1\r\n"
+  b << "Host: a1b2c3d4.oast.demo.test\r\n"
+  b << "User-Agent: DemoFramework/4.2.1 (url-import)\r\n"
+  b << "Accept: */*\r\n\r\n"
+end
+oast_http_resp = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok"
+store.insert_oast_callback(oast_session, "cb-http-0002", "http", "GET", "203.0.113.10",
+  "a1b2c3d4.oast.demo.test", oast_http_req.to_slice, oast_http_resp.to_slice, t.call(43) + 900_000_i64)
+store.flush
+puts "• inserted OAST provider + session + 2 callbacks (dns, http)"
+
+# --- Hostname overrides (per-project /etc/hosts) ----------------------------
+# The fictional .test hosts resolve to loopback (they don't exist in real DNS); this
+# documents that and shows the override feature. www.hahwul.com is left untouched so
+# its flows stay genuinely replayable.
+store.add_host_override("shop.demo.test", "127.0.0.1")
+store.add_host_override("api.demo.test", "127.0.0.1")
+store.add_host_override("cdn.demo.test", "127.0.0.1")
+
+# --- Sitemap tags (persisted per (host, path)) ------------------------------
+store.set_sitemap_tag("shop.demo.test", "/search", "xss")
+store.set_sitemap_tag("shop.demo.test", "/admin", "authz")
+store.set_sitemap_tag("api.demo.test", "/v1/debug", "leak")
+store.set_sitemap_tag("api.demo.test", "/v1/import", "ssrf")
+store.set_sitemap_tag("api.demo.test", "/graphql", "introspection")
+
+# --- Probe custom rule (project-scoped) — folded into the passive scan below --
+store.insert_probe_custom_rule("Framework version banner",
+  "Detects the DemoFramework version string leaked in response bodies.",
+  "response", "body", "regex", "DemoFramework \\d+\\.\\d+\\.\\d+", S::Severity::Low)
+puts "• inserted 3 host overrides + 5 sitemap tags + 1 custom probe rule"
+
+# --- Entity links (issues + notes → history / repeater / fuzz / miner) ------
+# insert_issue already auto-links the primary flow_id; add cross-workbench refs.
+store.add_link(S::LinkOwnerKind::Issue, f1, S::LinkRefKind::Repeater, ids[:repeater_xss])
+store.add_link(S::LinkOwnerKind::Issue, f1, S::LinkRefKind::Fuzz, ids[:fuzz_users])
+store.add_link(S::LinkOwnerKind::Issue, f1, S::LinkRefKind::Flow, ids[:login])
+
+store.add_link(S::LinkOwnerKind::Issue, f2, S::LinkRefKind::Repeater, ids[:repeater_idor])
+store.add_link(S::LinkOwnerKind::Issue, f2, S::LinkRefKind::Fuzz, ids[:fuzz_users])
+store.add_link(S::LinkOwnerKind::Issue, f2, S::LinkRefKind::Miner, ids[:miner_users])
+
+store.add_link(S::LinkOwnerKind::Issue, f4, S::LinkRefKind::Repeater, ids[:repeater_xss])
+
+store.add_link(S::LinkOwnerKind::Issue, f6, S::LinkRefKind::Flow, ws_id)
+
+store.add_link(S::LinkOwnerKind::Issue, f7, S::LinkRefKind::Repeater, ids[:repeater_ssrf])
+store.add_link(S::LinkOwnerKind::Issue, f7, S::LinkRefKind::Flow, ids[:ssrf])
 
 NOTE_MAIN  = 1_i64 # stable note id (entity_links.owner_id)
 NOTE_LINKS = 2_i64
 
-store.add_link(S::LinkOwnerKind::Note, NOTE_MAIN, S::LinkRefKind::Replay, ids[:replay_xss])
+store.add_link(S::LinkOwnerKind::Note, NOTE_MAIN, S::LinkRefKind::Repeater, ids[:repeater_xss])
 store.add_link(S::LinkOwnerKind::Note, NOTE_MAIN, S::LinkRefKind::Fuzz, ids[:fuzz_users])
 store.add_link(S::LinkOwnerKind::Note, NOTE_MAIN, S::LinkRefKind::Flow, ids[:cart])
 
-store.add_link(S::LinkOwnerKind::Note, NOTE_LINKS, S::LinkRefKind::Replay, ids[:replay_idor])
+store.add_link(S::LinkOwnerKind::Note, NOTE_LINKS, S::LinkRefKind::Repeater, ids[:repeater_idor])
 store.add_link(S::LinkOwnerKind::Note, NOTE_LINKS, S::LinkRefKind::Miner, ids[:miner_users])
 store.add_link(S::LinkOwnerKind::Note, NOTE_LINKS, S::LinkRefKind::Flow, ws_id)
-store.add_link(S::LinkOwnerKind::Note, NOTE_LINKS, S::LinkRefKind::Replay, ids[:replay_hahwul])
+store.add_link(S::LinkOwnerKind::Note, NOTE_LINKS, S::LinkRefKind::Repeater, ids[:repeater_hahwul])
 
-puts "• inserted entity links on findings + notes"
+puts "• inserted entity links on issues + notes"
 
 # --- Notes doc (multi-tab, stable ids for entity_links) --------------------
+NOTE_TOOLS = 3_i64
+
 note_main = <<-NOTES
 # Demo engagement — recon notes
 
@@ -682,85 +825,114 @@ note_main = <<-NOTES
 - shop.demo.test  — storefront (HTML)
 - api.demo.test   — JSON API (/v1)
 - cdn.demo.test   — static assets
+- www.hahwul.com  — REAL, live site (replayable)
 
 ## Auth
 - POST /api/login -> bearer token (ALSO leaked in JSON body, not just cookie)
 - token used as `Authorization: Bearer ...` on /v1/*
+- the token is a real HS256 JWT — weakly signed (see the JWT lead below)
 
 ## Leads
 - [x] reflected XSS on /search?q=
 - [x] IDOR on /v1/users/{id}  (customer token reads admin's PII)
+- [x] blind SSRF on POST /v1/import  (confirmed out-of-band, see OAST tab)
+- [x] JWT signed with a guessable secret  (crack + re-forge in the JWT tab)
 - [x] verbose 500 on /v1/debug
 - [ ] check /admin (403) for auth bypass / header tricks
-- [ ] enumerate /v1/users/{id} range
+- [ ] enumerate /v1/users/{id} range (Fuzzer session "user id enum" is staged)
 
 ## Protocols on this target
 - **WebSocket** GET /ws/chat (101) — open it and switch to the MESSAGES pane (→ sent, ← received).
 - **gRPC** POST /demo.Greeter/SayHello (HTTP/2) — FRAMES pane shows the raw h2 frame log;
   the application/grpc body deframes into length-prefixed protobuf messages (hex — opaque without the .proto).
 - **SSE** GET /v1/stream/prices (text/event-stream) — captured as one streamed body, not split per event.
-- **GraphQL** POST /graphql — plain JSON (query / mutation / introspection). Introspection is ON (see findings).
+- **GraphQL** POST /graphql — plain JSON (query / mutation / introspection). Introspection is ON (see Issues).
 - **SAML** POST /saml/acs — SAMLResponse is url-encoded base64 XML.
-  Decode in the Convert tab: url-decode → base64-decode (→ XML assertion for alice@demo.test).
+  Decode in the Decoder tab: url-decode → base64-decode (→ XML assertion for alice@demo.test).
 
 ## Live target (real, replayable)
 - **www.hahwul.com** is a real, live site (unlike the shop/api hosts above) — every
-  captured flow is a genuine response, so Replay (^R) actually re-sends it over the
-  network and gets a live response back. Good for trying Replay/Diff/Prism against
+  captured flow is a genuine response, so Repeater (^R) actually re-sends it over the
+  network and gets a live response back. Good for trying Repeater/Diff/Probe against
   real traffic instead of only synthetic data.
 - Recon flow: /robots.txt -> /sitemap.xml -> / -> a css asset -> /posts/ -> an
   article -> a note -> /about/, plus one guessed path that 404s.
 
 ## Entity links
-- **Finding detail** → Space → `l` opens the links overlay; `↵` opens the selected ref
+- **Issue detail** → Space → `l` opens the links overlay; `↵` opens the selected ref
   (`↑/↓`·`j/k` navigate the RELATED list). The RELATED pane lists cross-links
-  (replay/fuzz/miner/history) beyond the primary evidence flow.
+  (repeater/fuzz/miner/history) beyond the primary evidence flow.
 - **Notes sub-tab** → Space → `l` opens links for the active note (preview strip at the bottom).
-- **History / Replay / Fuzzer / Miner** → Space → `k` link to a finding, `u` link to a note.
-- This demo project already has links seeded — try the XSS finding or switch to the
+- **History / Repeater / Fuzzer / Miner** → Space → `k` link to an issue, `u` link to a note.
+- This demo project already has links seeded — try the XSS or SSRF issue, or switch to the
   "Workbench cross-links" note sub-tab.
-
-## Notes
-Token is the same JWT across requests — replayable in Replay (^R).
 NOTES
 
 note_links = <<-NOTES2
 # Workbench cross-links
 
-Pointers to the replay/fuzz/miner sessions tied to this engagement.
+Pointers to the repeater/fuzz/miner/sequencer sessions tied to this engagement.
 Space → `l` (links) on this sub-tab opens the overlay; `↵`/`o` jumps to the linked session or flow.
 
-- **XSS PoC** replay — re-send the reflected /search payload
-- **IDOR probe** replay — GET /v1/users/2 with the customer token
+- **XSS PoC** repeater — re-send the reflected /search payload
+- **IDOR probe** repeater — GET /v1/users/2 with the customer token
+- **SSRF → OAST** repeater — POST /v1/import with an OAST payload host
 - **user id enum** fuzz — sweep /v1/users/{id} (positions marked §1§)
-- **users path mine** — parameter reflection probe on /v1/users/
+- **users path mine** — hidden-parameter probe on /v1/users/
+- **sid randomness** sequencer — grade the /api/login session-cookie entropy
 - **WebSocket chat** flow — MESSAGES pane for the 101 upgrade
-- **hahwul home** replay — live, replayable traffic against www.hahwul.com
+- **hahwul home** repeater — live, replayable traffic against www.hahwul.com
 NOTES2
+
+note_tools = <<-NOTES3
+# Tooling cheatsheet
+
+Which tab does what on this demo (send a selection to a tool with Space → the tool's key).
+
+- **Rewriter** — 4 match&replace rules are seeded. Two are ON (add `X-Frame-Options`,
+  strip the `Server` banner); two are staged OFF (redact `Bearer …` via regex; a
+  body-rewrite proof on shop.demo.test). Toggle one on, then re-send from Repeater.
+- **OAST** — the out-of-band listener. It holds the DNS + HTTP callbacks the server made
+  when it fetched our payload host (proof of the blind SSRF). Polling is paused on load.
+- **Sequencer** — the "sid randomness" session re-collects the login cookie and grades
+  its entropy (collected tokens are never persisted).
+- **JWT** — send the login token here: decode the claims, run the weak-secret attack
+  (it recovers the key), then re-forge `{"role":"admin"}` or try alg:none.
+- **Decoder** — chain encoders/decoders. Try the SAMLResponse (url-decode → base64-decode)
+  or the JWT (base64url-decode each segment).
+- **Comparer** — diff two flows side by side (e.g. /v1/users/1 vs /v1/users/2 for the IDOR).
+- **Probe** — passive scan results (incl. a project custom rule catching the DemoFramework
+  banner). Mode is Passive; active probing needs live traffic.
+- **Target** — Sitemap (a few paths tagged: xss / authz / leak / ssrf / introspection) + Discover.
+- **Settings → network** — 3 hostname overrides point the fictional .test hosts at loopback.
+NOTES3
 
 store.set_setting(Notes::DOCS_KEY, Notes.serialize(0, [
   Notes::NoteEntry.new(NOTE_MAIN, note_main),
   Notes::NoteEntry.new(NOTE_LINKS, note_links),
-], 3_i64))
+  Notes::NoteEntry.new(NOTE_TOOLS, note_tools),
+], 4_i64))
 
 # --- Scope (seed patterns, left OFF so History shows everything) ------------
 store.add_scope_rule("include", "host", "shop.demo.test")
 store.add_scope_rule("include", "host", "api.demo.test")
 store.add_scope_rule("include", "host", "www.hahwul.com")
 
-# --- Prism passive scan: run the analyzer over every seeded flow so the Prism tab
-# opens populated (and the Project tab shows the detected technologies). This mirrors
-# what the live Prism::Analyzer does on captured traffic — no extra requests. MODE is
-# left at the safe default (Passive); active reflected-param probing needs live traffic.
+# --- Probe passive scan: run the analyzer (built-ins + this project's custom rule) over
+# every seeded flow so the Probe tab opens populated (and the Project tab shows the
+# detected technologies). This mirrors what the live Probe::Analyzer does on captured
+# traffic — no extra requests. MODE is left at the safe default (Passive); active
+# reflected-param probing needs live traffic.
+custom_rules = Probe.custom_rules(store)
 store.recent_flows(1000).each do |row|
   if detail = store.get_flow(row.id)
-    Prism::Passive.analyze(detail).each { |d| store.upsert_prism_issue(d) }
+    Probe::Passive.analyze(detail, custom: custom_rules).each { |d| store.upsert_probe_issue(d) }
   end
 end
-store.set_prism_mode(Prism::Mode::Passive)
-puts "• prism: #{store.count_prism_issues} passive issues; tech=#{store.prism_tech_summary.join(", ")}"
+store.set_probe_mode(Probe::Mode::Passive)
+puts "• probe: #{store.count_probe_issues} passive issues; tech=#{store.probe_tech_summary.join(", ")}"
 
 store.close
-puts "• notes (2 tabs, stable ids) + 3 scope patterns written"
+puts "• notes (3 tabs, stable ids) + 3 scope patterns written"
 puts "\n✓ demo project ready — launch ./bin/gori and pick 'demo'."
-puts "  Try: XSS finding → RELATED pane / Space→l; Notes → 'Workbench cross-links' sub-tab."
+puts "  Try: SSRF issue → OAST tab; JWT lead → JWT tab (weak-secret attack); Notes → 'Tooling cheatsheet'."


### PR DESCRIPTION
## Why

`scripts/seed_demo.cr` no longer compiled — it predated the codebase-wide `Finding`→`Issue`, `Replay`→`Repeater`, and `Prism`→`Probe` renames (plus `Convert`→`Decoder`). Running it errored out on the first stale call.

## What

Fixed every stale API call, then expanded coverage so **every current tab** has something real to explore:

- **Rewriter** — 4 match&replace rules (add `X-Frame-Options` + strip `Server` are active; regex bearer-redact + body-rewrite proof are staged off)
- **OAST** — a custom-http provider + session + DNS/HTTP callbacks that prove a new blind-SSRF flow out-of-band (polling never auto-resumes, so the rows are inert)
- **Sequencer** — a session grading the `/api/login` `sid`-cookie entropy
- **Probe** — a project custom rule that actually fires on the `DemoFramework` banner
- **Host overrides** (fictional `.test` hosts → loopback) + **Sitemap tags**
- **Real, decodable HS256 JWT** signed with a weak secret (`secret`) as the shared bearer token — so the JWT tab genuinely decodes/cracks/re-forges it, and the Decoder/Sequencer have real input
- New **SSRF flow + Issue** and a **weak-JWT Issue**, wired into entity links
- **Notes** rewritten to 3 tabs (recon / workbench cross-links / tooling cheatsheet) with current tab names & keys

## Verification

- `crystal run scripts/seed_demo.cr` — clean run (8 issues, 4 repeater/1 fuzz/1 miner/1 sequencer sessions, 4 rewriter rules, 2 OAST callbacks, 39 passive probe issues)
- `ameba` — 0 failures · `crystal tool format --check` — clean
- DB inspected: all new tables populated; JWT signature verified against the weak secret

All test runs used an isolated `GORI_HOME`; no real project touched.