### PR TITLE
fix(spec): read the full tunnel response in the 101-upgrade desync test

### DIFF
--- a/spec/proxy/ws_spec.cr
+++ b/spec/proxy/ws_spec.cr
@@ -364,9 +364,13 @@ describe "WebSocket through the proxy (end-to-end)" do
     # so it never reached the origin and no SRV:PING ever came back.
     client.write("PING".to_slice)
     client.flush
-    buf = Bytes.new(64)
-    n = client.read(buf)
-    String.new(buf[0, n]).should eq("SRV:PING")
+    # read_fully, not read: the origin answers with TWO writes ("SRV:" then the echo), and
+    # nothing guarantees they land in one segment. macOS usually coalesces them, Linux
+    # reliably does not — a single read there returns just "SRV:". The 3s read_timeout above
+    # still makes a genuinely broken tunnel fail fast rather than hang.
+    buf = Bytes.new("SRV:PING".bytesize)
+    client.read_fully(buf)
+    String.new(buf).should eq("SRV:PING")
 
     client.close
     proxy.stop


### PR DESCRIPTION
`spec/proxy/ws_spec.cr:330` fails on Linux — deterministically — and intermittently on macOS. Same spec, same assertion, same symptom: one bug surfacing at two very different rates, not two separate flakes.

```
Failure/Error: String.new(buf[0, n]).should eq("SRV:PING")
  Expected: "SRV:PING"
       got: "SRV:"
```

## Cause

The test's origin answers with **two** writes:

```crystal
conn.write("SRV:".to_slice)
conn.write(buf[0, n])
```

while the client asserted on a **single** `read`:

```crystal
n = client.read(buf)
String.new(buf[0, n]).should eq("SRV:PING")
```

`read` returns whatever has arrived, not the full 8 bytes. Nothing guarantees the two writes land in one TCP segment. macOS usually coalesces them and passes; Linux reliably does not, so the read comes back with only `"SRV:"`.

The proxy is fine — it tunnels correctly. Only the assertion's framing assumption was wrong.

## Fix

`read_fully` over the exact expected length. The `read_timeout = 3.seconds` set earlier in the test still makes a genuinely broken tunnel fail fast rather than hang the suite, which is what the original single `read` was protecting.

## Verification

| | before | after |
|---|---|---|
| linux/arm64 `ws_spec` | 5/5 failing | **5/5 passing** |
| darwin/arm64 `ws_spec` | ~1/20 failing | **0/30 failing** |
| darwin/arm64 full suite | — | 2206 examples, 0 failures |

Linux via `crystallang/crystal:1.20` container. The pre-existing failure was confirmed against clean `main` (68d9727) with no other changes applied, so it is not a regression from anything recent.

Worth noting the repo has no CI, so this has been showing up as a permanently red suite for anyone developing on Linux.