### PR TITLE
fix(tui): three rendering/interaction bugs found in a manual QA pass

### DIFF
--- a/src/gori/tui/controllers/decoder_controller.cr
+++ b/src/gori/tui/controllers/decoder_controller.cr
@@ -639,8 +639,12 @@ module Gori::Tui
         @popup.close
       when key.down?
         if @popup.open?
-          @popup_engaged = true # dive into the passively-shown list; ↓ now navigates it
-          @popup.move(1)
+          # Dive into the passively-shown list. The engaging press must NOT also step:
+          # set() already selected row 0 and the popup renders it highlighted, so moving
+          # here skipped the very item the user can see picked ("↓ then ↵" handed back
+          # the SECOND converter). Once engaged, completing? routes further ↓ to
+          # handle_complete_key → @popup.move.
+          @popup_engaged = true
         else
           s.pane = :output # down from CHAIN drops into the OUTPUT pane
           @popup.close

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -3911,6 +3911,12 @@ module Gori::Tui
 
     private def render_body(screen : Screen, rect : Rect) : Nil
       @body_h = rect.h # remembered for PageUp/PageDown's screenful step (see page_nav_delta)
+      # Onboarding empty-state cards are drawn by the body but a modal lands on top of
+      # them a few lines later, so a dialog shorter than the card leaves its tail poking
+      # out (see TrafficEmptyState.suppressed?). Every overlay but the ⋯ dropdown centres
+      # itself in this same rect; tabs_more is anchored to its tab-bar chip and doesn't
+      # cover the card, so it keeps it.
+      TrafficEmptyState.suppressed = @overlay != :none && @overlay != :tabs_more
       # Every catalog tab has a controller that owns its body render; the `?` guard is
       # defensive (a blank body beats a crash if the active tab ever lacks one).
       @tabs[@active_tab]?.try(&.render_body(screen, rect, @focus))

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -657,8 +657,16 @@ module Gori::Tui
       screen.cell(x + 6, ry, ' ', pal.bg, pal.bg)
     end
 
+    # The two-row footer block: the note (save status / focused field's hint) on its OWN
+    # row, the keybind hint right-aligned on the row below. They MUST NOT share a row —
+    # a field hint is routinely wider than the gap left by the right-aligned keybinds, so
+    # drawing both on one row painted the hint under the keybind text and the two read as
+    # one garbled string ("which pane a fresh↑/↓ field · ↵ save · …"). overlay_box already
+    # budgets 3 footer rows (blank + note + keybinds — see content_rows + 6), so the note
+    # row costs no extra height and gets the full interior width.
     private def render_footer(screen : Screen, box : Rect) : Nil
-      note_y = box.bottom - 2
+      note_y = box.bottom - 3
+      hint_y = box.bottom - 2
       iw = {box.right - (box.x + 3) - 1, 0}.max # interior width so long hints can't bleed past the box border
       if status = @status
         color = status.starts_with?("invalid") || status.starts_with?("save failed") ? Theme.yellow : Theme.green
@@ -671,7 +679,7 @@ module Gori::Tui
       end
       hint = @section == :theme ? "↑/↓ select · ↵ apply · ^R reset · esc close" : "↑/↓ field · ↵ save · ^R reset · esc close"
       hx = {box.right - hint.size - 2, box.x + 1}.max # never start left of the box interior
-      screen.text(hx, note_y, hint, Theme.muted, Theme.panel, width: {box.right - hx - 1, 0}.max)
+      screen.text(hx, hint_y, hint, Theme.muted, Theme.panel, width: {box.right - hx - 1, 0}.max)
     end
   end
 end

--- a/src/gori/tui/traffic_empty_state.cr
+++ b/src/gori/tui/traffic_empty_state.cr
@@ -15,6 +15,15 @@ module Gori::Tui
     MED_MIN_H  =  5
     MED_MIN_W  = 30
 
+    # Set once per frame by the Runner (render_body), true while a body-centred modal is
+    # open. These cards are box art, and a dialog SHORTER than the card only covers part
+    # of it — the NEW ISSUE form (6 rows) over the Issues card (9) left the card's divider
+    # and bottom border orphaned below the dialog, reading as a corrupted frame. Gating
+    # the whole module here fixes every card/dialog pairing at one point instead of
+    # teaching 12 call sites about overlays, and is the right UX regardless: the card is
+    # a "how to start" hint, and a dialog means the user already has.
+    class_property? suppressed : Bool = false
+
     def render(screen : Screen, rect : Rect, *,
                variant : Symbol,
                listen : String? = nil,
@@ -23,6 +32,7 @@ module Gori::Tui
                running : Bool = false,
                scan_on : Bool = true,
                title : String? = nil) : Nil
+      return if suppressed?
       return if rect.empty?
 
       addr = listen || "#{Settings.effective_bind_host}:#{Settings.effective_bind_port}"


### PR DESCRIPTION
Found by driving the built TUI live under tmux with real traffic. All three were invisible to the spec suite: `MemoryBackend` records chars without bg, and nothing asserts overlay layering.

## 1. Settings: field hint overwrote the keybind footer

The focused field's hint and the keybind footer were both drawn on `box.bottom - 2`. The hint spans nearly the full interior and the right-aligned keybinds are drawn *after* it, so they painted over the hint's tail:

```
│  which pane a fresh↑/↓ field · ↵ save · ^R reset · esc close…│
```

Hit **7 of 9 panels** (Display, Network, Editor, Layout, Statusline, General, Notifications). Theme escaped only because `theme N/26` is short; Tabs uses a different overlay.

The note now takes its own row at `box.bottom - 3`. **Costs no height** — `overlay_box` already budgets three footer rows (`content_rows + 6` = 2 borders + top pad + blank + note + keybinds) and that blank row was simply never used. Long hints now read in full instead of being cut to ~18 columns.

| before | after |
|---|---|
| `which pane a fresh↑/↓ field · ↵ save · ^R reset · esc close…` | `which pane a freshly-opened History flow shows first — ←/→ …`<br>`                    ↑/↓ field · ↵ save · ^R reset · esc close` |

## 2. Empty-state box art orphaned under short modals

`TrafficEmptyState` cards are box art painted by the body; overlays land on top a few lines later in the same frame. A dialog **shorter** than the card only covers part of it, so the 6-row `NEW ISSUE` form over the 9-row Issues card left the card's divider, two shortcut rows and bottom border dangling with no top border — reading as a corrupted frame rather than a dialog:

```
│                 ╭─ NEW ISSUE ──────────────────────────╮                 │
│                 │ title ›                              │                 │
│                 │ severity ‹ MEDIUM ›  (tab to change) │                 │
│                 ╰──────────────────────────────────────╯                 │
│                    ├───────────────────────────────┤                     │  ← orphaned
│                    │ ▸  ⇧F   issue from History flow│                     │
│                    ╰───────────────────────────────╯                     │
```

Gated the module behind a frame-scoped `suppressed` flag the Runner sets in `render_body`. That fixes every card/dialog pairing at one choke point instead of teaching all 12 call sites about overlays, and it is the right UX regardless: the card is a "how to start" hint, and a dialog means the user already has.

`tabs_more` is excluded because it is the only overlay anchored to its tab-bar chip rather than centred in the body rect, so it never covers the card. Tall overlays such as the palette never showed this because they hide the card outright.

## 3. Decoder chain-autocomplete skipped the highlighted row

Landing on CHAIN opens a passive converter list with row 0 (`base64-encode`) already rendered highlighted, but the first `↓` both engaged the popup **and** stepped it — so the obvious "↓ then ↵" handed back the *second* converter.

The engaging press now only engages; `set()` has already selected row 0. Once engaged, `completing?` routes further steps to `handle_complete_key`, so navigation past row 0 is unchanged. The typed-token path was never affected (a filtered list engages immediately, so `↵` always took row 0).

`↵` on a still-passive popup **stays inert on purpose** — the passive list is a browse-only discovery menu so Tab keeps navigating the focus ring, and `completing?` gates Tab and Enter together, so making Enter accept would hijack Tab too.

## Verification

Verified in the running TUI, not just by build:

- all 9 Settings panels, including the save-status and Theme paths
- the `NEW ISSUE` dialog over the Issues card, plus its restore on close, plus the `tabs_more` exception
- all three Decoder paths: passive `↓↵` → `base64-encode`, passive `↓↓↵` → `base64-decode`, typed `sha256` + `↵` → `sha256`
- smoke test with real traffic afterwards (History, Repeater h1+h2 send, Probe)

`crystal spec` green at **2206 examples, 0 failures**. `ameba` unchanged on the touched files (48 pre-existing findings, before == after).

> Note for anyone seeing a red suite locally: a leftover `gori` process holding the bind port makes 8 specs in `project_registry_spec` / `capture_status_spec` fail spuriously. `pgrep -x gori` and kill before trusting it.