### PR TITLE
feat(tui): put the project in the terminal title, configurable in Settings

### DIFF
--- a/docs/content/reference/config.ko.md
+++ b/docs/content/reference/config.ko.md
@@ -111,6 +111,32 @@ TUI 맨 아래에 선택적으로 추가되는 행입니다 (커맨드 팔레트
 | `proxy.host` / `proxy.port` / `proxy.addr` | string / integer / string | 프록시가 실제로 리스닝 중인 주소 |
 | `upstream` | string | 업스트림 프록시 `host:port`, 직접 연결이면 비어 있음 |
 
+### display {#display}
+
+메시지 본문과 화면 요소 설정입니다 (커맨드 팔레트 → **Settings: Display**). 모든 값이 기본값이면 섹션이 생략됩니다.
+
+```json
+{
+  "display": {
+    "detail_pane": "request",
+    "history_time_format": "absolute",
+    "show_gutter": true,
+    "preview_body_kib": 64,
+    "resource_meter": true,
+    "terminal_title": "project"
+  }
+}
+```
+
+| 키 | 타입 | 기본값 | 설명 |
+|-----|------|---------|-------------|
+| `detail_pane` | string | `"request"` | History 플로우를 열었을 때 먼저 보여줄 페인: `"request"` 또는 `"response"` |
+| `history_time_format` | string | `"absolute"` | History 목록의 시간 열: `"absolute"`(MM-DD HH:MM:SS) 또는 `"relative"`(3s/5m/2h) |
+| `show_gutter` | bool | `true` | 메시지 본문 뷰의 줄번호 거터 |
+| `preview_body_kib` | integer | `64` | History 목록 미리보기가 읽는 본문 바이트 수 (표시 전용이며 캡처 상한과는 별개) |
+| `resource_meter` | bool | `true` | 하단 바 맨 오른쪽에 표시되는 gori 자신의 CPU/메모리 |
+| `terminal_title` | string | `"project"` | 터미널 창 제목: `"project"` → `Gori - <프로젝트> - <탭>`, `"tab"` → `Gori - <탭>`, `"off"` → gori가 제목을 건드리지 않음 (셸이나 tmux에 맡김) |
+
 ### hostname_overrides {#hostname-overrides}
 
 전역 다이얼 맵(충돌 시 프로젝트 레벨 오버라이드가 우선). `/etc/hosts`와 같은 개념입니다:
@@ -162,7 +188,7 @@ TUI 맨 아래에 선택적으로 추가되는 행입니다 (커맨드 팔레트
 | `decoder` / `mine` | Decoder 도구와 Param Miner의 저장된 기본값 |
 | `layout` | History / Probe / Issues 미리보기 + Sitemap 펼침 깊이. 위의 [layout](#layout) 참고 |
 | `statusline` | 일정 간격으로 명령을 실행하는 하단 상태 행. 위의 [statusline](#statusline) 참고 |
-| `display` | 기본 상세 페인, 목록 시간 형식, 줄번호 거터, 미리보기 본문 상한, 그리고 `resource_meter`(하단 바 맨 오른쪽 CPU/메모리 표시, 기본 켜짐) |
+| `display` | 기본 상세 페인, 목록 시간 형식, 줄번호 거터, 미리보기 본문 상한, `resource_meter`(하단 바 맨 오른쪽 CPU/메모리 표시, 기본 켜짐), 그리고 `terminal_title` |
 
 ## 프로젝트별 오버라이드 {#per-project-overrides}
 

--- a/docs/content/reference/config.md
+++ b/docs/content/reference/config.md
@@ -111,6 +111,32 @@ Each run receives a JSON context on stdin describing the live session, so script
 | `proxy.host` / `proxy.port` / `proxy.addr` | string / integer / string | The address the proxy is actually listening on |
 | `upstream` | string | Upstream proxy `host:port`, or empty when connecting directly |
 
+### display
+
+Message-body and chrome prefs (command palette → **Settings: Display**). Omitted when every value is a factory default.
+
+```json
+{
+  "display": {
+    "detail_pane": "request",
+    "history_time_format": "absolute",
+    "show_gutter": true,
+    "preview_body_kib": 64,
+    "resource_meter": true,
+    "terminal_title": "project"
+  }
+}
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `detail_pane` | string | `"request"` | Which pane a freshly-opened History flow shows first: `"request"` or `"response"` |
+| `history_time_format` | string | `"absolute"` | History list time column: `"absolute"` (MM-DD HH:MM:SS) or `"relative"` (3s/5m/2h) |
+| `show_gutter` | bool | `true` | Line-number gutter on the message body views |
+| `preview_body_kib` | integer | `64` | How many body bytes the History list preview reads (display only, not the capture limit) |
+| `resource_meter` | bool | `true` | CPU/memory readout for gori's own process, at the far right of the bottom bar |
+| `terminal_title` | string | `"project"` | Terminal window title: `"project"` → `Gori - <project> - <tab>`, `"tab"` → `Gori - <tab>`, `"off"` → gori never writes the title (leave it to your shell or tmux) |
+
 ### hostname_overrides
 
 Global dial map (project-level overrides win on collision). Same idea as `/etc/hosts`:
@@ -162,7 +188,7 @@ See [Environment Variables](/guide/repeater-and-fuzzer/#environment-variables).
 | `decoder` / `mine` | Saved defaults for the Decoder tool and Param Miner |
 | `layout` | History / Probe / Issues previews + Sitemap expand depth. See [layout](#layout) above |
 | `statusline` | Bottom status row that runs a command on an interval. See [statusline](#statusline) above |
-| `display` | Default detail pane, list time format, line-number gutter, preview body cap, and `resource_meter` (the CPU/memory readout at the far right of the bottom bar, on by default) |
+| `display` | Default detail pane, list time format, line-number gutter, preview body cap, `resource_meter` (the CPU/memory readout at the far right of the bottom bar, on by default), and `terminal_title` |
 
 ## Per-Project Overrides
 

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -195,40 +195,52 @@ describe Gori::Settings do
     Dir.mkdir_p(dir)
     prev = ENV["GORI_HOME"]?
     prev_display = {Gori::Settings.default_detail_pane, Gori::Settings.history_time_format,
-                    Gori::Settings.show_gutter, Gori::Settings.preview_body_kib}
+                    Gori::Settings.show_gutter, Gori::Settings.preview_body_kib,
+                    Gori::Settings.terminal_title}
     begin
       ENV["GORI_HOME"] = dir
       Gori::Settings.default_detail_pane = "response"
       Gori::Settings.history_time_format = "relative"
       Gori::Settings.show_gutter = false
       Gori::Settings.preview_body_kib = 128
+      Gori::Settings.terminal_title = "off"
       Gori::Settings.save.should be_true
       raw = File.read(Gori::Settings.path)
       raw.should contain(%("display"))
       raw.should contain(%("detail_pane":"response"))
+      raw.should contain(%("terminal_title":"off"))
 
       Gori::Settings.default_detail_pane = "request"
       Gori::Settings.history_time_format = "absolute"
       Gori::Settings.show_gutter = true
       Gori::Settings.preview_body_kib = 64
+      Gori::Settings.terminal_title = "project"
       Gori::Settings.load
       Gori::Settings.default_detail_pane.should eq("response")
       Gori::Settings.history_time_format.should eq("relative")
       Gori::Settings.show_gutter.should be_false # a stored false survives the reload
       Gori::Settings.preview_body_kib.should eq(128)
       Gori::Settings.preview_body_cap.should eq(128 * 1024) # byte helper derives from the KiB int
+      Gori::Settings.terminal_title.should eq("off")
+
+      # An unknown mode (hand-edited config) falls back to the default rather than
+      # leaving the Runner with a value it has no branch for.
+      File.write(Gori::Settings.path, %({"display":{"terminal_title":"bogus"}}))
+      Gori::Settings.load
+      Gori::Settings.terminal_title.should eq(Gori::Settings::DEFAULT_TERMINAL_TITLE)
 
       # Back to defaults → section omitted
       Gori::Settings.default_detail_pane = Gori::Settings::DEFAULT_DETAIL_PANE
       Gori::Settings.history_time_format = Gori::Settings::DEFAULT_HISTORY_TIME_FORMAT
       Gori::Settings.show_gutter = Gori::Settings::DEFAULT_SHOW_GUTTER
       Gori::Settings.preview_body_kib = Gori::Settings::DEFAULT_PREVIEW_BODY_KIB
+      Gori::Settings.terminal_title = Gori::Settings::DEFAULT_TERMINAL_TITLE
       Gori::Settings.save
       File.read(Gori::Settings.path).should_not contain(%("display"))
     ensure
       prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
       FileUtils.rm_rf(dir)
-      Gori::Settings.default_detail_pane, Gori::Settings.history_time_format, Gori::Settings.show_gutter, Gori::Settings.preview_body_kib = prev_display
+      Gori::Settings.default_detail_pane, Gori::Settings.history_time_format, Gori::Settings.show_gutter, Gori::Settings.preview_body_kib, Gori::Settings.terminal_title = prev_display
     end
   end
 

--- a/spec/tui/settings_view_spec.cr
+++ b/spec/tui/settings_view_spec.cr
@@ -229,14 +229,14 @@ describe SettingsView do
     end
   end
 
-  it "saves and resets the DISPLAY section (detail pane, time format, gutter, preview cap, resource meter)" do
+  it "saves and resets the DISPLAY section (detail pane, time format, gutter, preview cap, resource meter, terminal title)" do
     dir = File.tempname("gori-settings-display-view")
     Dir.mkdir_p(dir)
     prev_home = ENV["GORI_HOME"]?
     prev = {
       Gori::Settings.default_detail_pane, Gori::Settings.history_time_format,
       Gori::Settings.show_gutter, Gori::Settings.preview_body_kib,
-      Gori::Settings.resource_meter?,
+      Gori::Settings.resource_meter?, Gori::Settings.terminal_title,
     }
     begin
       ENV["GORI_HOME"] = dir
@@ -245,6 +245,7 @@ describe SettingsView do
       Gori::Settings.show_gutter = true
       Gori::Settings.preview_body_kib = 64
       Gori::Settings.resource_meter = true
+      Gori::Settings.terminal_title = "project"
       v = SettingsView.new
       v.reload(:display)
       v.section.should eq(:display)
@@ -257,12 +258,15 @@ describe SettingsView do
       set_text(v, "128") # preview body limit (text)
       v.move_field(1)
       v.toggle_or_move(1) # resource meter: on → off (bool)
+      v.move_field(1)
+      v.toggle_or_move(1) # terminal title: project + tab → tab (choice)
       v.save
       Gori::Settings.default_detail_pane.should eq("response")
       Gori::Settings.history_time_format.should eq("relative")
       Gori::Settings.show_gutter.should be_false
       Gori::Settings.preview_body_kib.should eq(128)
       Gori::Settings.resource_meter?.should be_false
+      Gori::Settings.terminal_title.should eq("tab")
 
       v.reset_to_defaults
       v.save
@@ -271,9 +275,10 @@ describe SettingsView do
       Gori::Settings.show_gutter.should eq(Gori::Settings::DEFAULT_SHOW_GUTTER)
       Gori::Settings.preview_body_kib.should eq(Gori::Settings::DEFAULT_PREVIEW_BODY_KIB)
       Gori::Settings.resource_meter?.should eq(Gori::Settings::DEFAULT_RESOURCE_METER)
+      Gori::Settings.terminal_title.should eq(Gori::Settings::DEFAULT_TERMINAL_TITLE)
     ensure
       prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
-      Gori::Settings.default_detail_pane, Gori::Settings.history_time_format, Gori::Settings.show_gutter, Gori::Settings.preview_body_kib, Gori::Settings.resource_meter = prev
+      Gori::Settings.default_detail_pane, Gori::Settings.history_time_format, Gori::Settings.show_gutter, Gori::Settings.preview_body_kib, Gori::Settings.resource_meter, Gori::Settings.terminal_title = prev
       FileUtils.rm_rf(dir)
     end
   end

--- a/src/gori/settings/display.cr
+++ b/src/gori/settings/display.cr
@@ -26,11 +26,15 @@ module Gori::Settings
   # show_gutter = line-number gutter on the message body views; preview_body_kib = how many
   # body bytes the History list PREVIEW reads/shows (display-only, not the capture limit).
   # resource_meter = the bottom bar's far-right CPU/MEM readout for gori's own process.
+  # terminal_title = what gori writes into the OS terminal-window title (OSC): the project
+  # and active tab, the tab alone, or nothing at all ("off" leaves the title untouched,
+  # for shells/multiplexers that manage it themselves).
   DEFAULT_DETAIL_PANE         = "request"  # "request" | "response"
   DEFAULT_HISTORY_TIME_FORMAT = "absolute" # "absolute" | "relative"
   DEFAULT_SHOW_GUTTER         = true
   DEFAULT_PREVIEW_BODY_KIB    = 64
   DEFAULT_RESOURCE_METER      = true
+  DEFAULT_TERMINAL_TITLE      = "project" # "project" | "tab" | "off"
   # Upper bound on the preview cap (KiB): kib*1024 must stay within Int32 or
   # preview_body_cap raises on the History navigation path. 65536 KiB = 64 MiB.
   MAX_PREVIEW_BODY_KIB = 65536
@@ -72,6 +76,8 @@ module Gori::Settings
   class_property preview_body_kib : Int32 = DEFAULT_PREVIEW_BODY_KIB
   # `?` toggle read live by the status bar's ResourceMeter; off means it never samples.
   class_property? resource_meter : Bool = DEFAULT_RESOURCE_METER
+  # Read live by the Runner's sync_terminal_title; validated to its three-value set on load.
+  class_property terminal_title : String = DEFAULT_TERMINAL_TITLE
   # Notification prefs (settings:notifications). bell/toast are `?` toggles read live at the
   # emit sites; retention bounds the ring buffer (read live by Notifications#push).
   class_property? notify_bell : Bool = DEFAULT_NOTIFY_BELL
@@ -137,6 +143,14 @@ module Gori::Settings
       self.preview_body_kib = v.clamp(1, MAX_PREVIEW_BODY_KIB)
     end
     self.resource_meter = load_bool_h(o, "resource_meter", resource_meter?)
+    if v = o["terminal_title"]?.try(&.as_s?)
+      self.terminal_title = normalize_terminal_title(v)
+    end
+  end
+
+  # Allowed terminal-title modes; anything else falls back to the default.
+  def self.normalize_terminal_title(s : String) : String
+    {"project", "tab", "off"}.includes?(s) ? s : DEFAULT_TERMINAL_TITLE
   end
 
   # Tolerant notifications section: absent/non-object keeps current; retention floored at 1.
@@ -208,7 +222,8 @@ module Gori::Settings
            history_time_format == DEFAULT_HISTORY_TIME_FORMAT &&
            show_gutter == DEFAULT_SHOW_GUTTER &&
            preview_body_kib == DEFAULT_PREVIEW_BODY_KIB &&
-           resource_meter? == DEFAULT_RESOURCE_METER
+           resource_meter? == DEFAULT_RESOURCE_METER &&
+           terminal_title == DEFAULT_TERMINAL_TITLE
       j.field "display" do
         j.object do
           j.field "detail_pane", default_detail_pane
@@ -216,6 +231,7 @@ module Gori::Settings
           j.field "show_gutter", show_gutter
           j.field "preview_body_kib", preview_body_kib
           j.field "resource_meter", resource_meter?
+          j.field "terminal_title", terminal_title
         end
       end
     end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -271,7 +271,8 @@ module Gori::Tui
       @quit_armed = false              # first ^D/^C arms quit; second confirms (avoids accidental exit)
       @resized = false                 # set on a Resize event → next frame full-repaints
       @body_h = 24                     # last body rect height (captured at render); drives PageUp/Down step size
-      @title_tab = nil.as(Symbol?)     # last tab reflected into the terminal-window title (memo; see sync_terminal_title)
+      @title_text = nil.as(String?)    # last string emitted as the terminal-window title (memo; see sync_terminal_title)
+      @title_written = false           # have we ever written a title? gates the neutral restore on leave when the pref is "off"
 
       # Per-tab controllers (strangler-fig: tabs migrate into this registry one at a
       # time; an unmigrated tab is absent and still runs through the case ladders
@@ -562,8 +563,10 @@ module Gori::Tui
         @statusline.stop
         # Drop the per-tab window title back to a neutral "gori" on leave — the shared term
         # outlives this Runner (project picker + the next session reuse it), so a stale
-        # "Gori - Notes" mustn't linger. The shell's prompt overwrites it again after quit.
-        @term.title = "gori"
+        # "Gori - acme - Notes" mustn't linger. The shell's prompt overwrites it again after
+        # quit. Skipped when we never wrote a title (pref "off"), so gori leaves the
+        # terminal's own title alone end to end.
+        @term.title = "gori" if @title_written
       end
       @outcome
     end
@@ -3641,15 +3644,38 @@ module Gori::Tui
       Settings.statusline_enabled?
     end
 
-    # Reflect the active tab in the terminal-window title ("Gori - History"), so a
-    # terminal tab/window running gori is identifiable at a glance (and multiple open
-    # projects can be told apart by which tab each is on). Driven from render — not
-    # threaded through each @active_tab write site — so every switch path is covered;
-    # memoized on the tab so the OSC sequence is emitted only when it actually changes.
+    # Reflect the open project and active tab in the terminal-window title
+    # ("Gori - acme - History"), so a terminal tab/window running gori is identifiable at
+    # a glance and several concurrently open projects can be told apart. Driven from
+    # render — not threaded through each @active_tab write site — so every switch path is
+    # covered (a project rename lands the same way); memoized on the composed string so
+    # the OSC sequence is emitted only when it actually changes.
+    #
+    # Mode comes from settings:display (`terminal_title`). "off" writes nothing at all —
+    # for shells and multiplexers that own the title themselves — so we must not even
+    # emit the neutral title on leave unless we've previously written one (@title_written).
+    # Switching to "off" mid-session is the one exception: a title we put there would
+    # otherwise freeze on whatever tab was active, so we release it to the neutral "gori"
+    # once and go quiet from there.
     private def sync_terminal_title : Nil
-      return if @title_tab == @active_tab
-      @title_tab = @active_tab
-      @term.title = "Gori - #{Chrome.tab_label(@active_tab)}"
+      title = case Settings.terminal_title
+              when "off" then @title_text.nil? ? return : "gori"
+              when "tab" then "Gori - #{Chrome.tab_label(@active_tab)}"
+              else            "Gori - #{title_safe(@session.project.name)} - #{Chrome.tab_label(@active_tab)}"
+              end
+      return if @title_text == title
+      @title_text = title
+      @title_written = true
+      @term.title = title
+    end
+
+    # Project names are user-supplied and go out inside an OSC string, where a raw ESC or
+    # BEL would terminate the sequence early and let the rest through as terminal input.
+    # Drop the control bytes and cap the length so a pathological name can't eat the title.
+    private def title_safe(name : String) : String
+      cleaned = name.gsub { |c| c.control? ? "" : c }.strip
+      return "untitled" if cleaned.empty?
+      cleaned.size > 40 ? "#{cleaned[0, 39]}…" : cleaned
     end
 
     private def render : Nil
@@ -5313,11 +5339,14 @@ module Gori::Tui
       end
       @resized = true # alt-screen re-entered → force a full repaint via the resize path
       # The child editor may have set its own OS window title. termisu memoizes the last
-      # title it wrote (still "Gori - <tab>"), so a plain re-emit is suppressed — bust its
-      # memo with a throwaway write, then invalidate gori's memo so the next render
-      # re-emits "Gori - <tab>" and restores our title over whatever the editor left.
-      @term.title = ""
-      @title_tab = nil
+      # title it wrote (still "Gori - <project> - <tab>"), so a plain re-emit is suppressed
+      # — bust its memo with a throwaway write, then invalidate gori's memo so the next
+      # render re-emits our title over whatever the editor left. Skipped when we own no
+      # title (pref "off"): there's nothing of ours to restore, so leave the editor's be.
+      if @title_written && Settings.terminal_title != "off"
+        @term.title = ""
+        @title_text = nil
+      end
       case result.outcome
       in ExternalEditor::Outcome::Changed
         yield result.text.not_nil!

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -75,10 +75,12 @@ module Gori::Tui
       Field.new("Interval (s)",
         "how often to re-run the command — seconds (min 1)"),
     ]
-    # Display: message-body rendering prefs (two choice fields + a bool + a text cap).
-    DISPLAY_PANE_CHOICES = ["request", "response"]
-    DISPLAY_TIME_CHOICES = ["absolute", "relative"]
-    DISPLAY_FIELDS       = [
+    # Display: message-body + chrome prefs (three choice fields, two bools, a text cap).
+    DISPLAY_PANE_CHOICES  = ["request", "response"]
+    DISPLAY_TIME_CHOICES  = ["absolute", "relative"]
+    # Kept short: all three render inline on one row inside the settings box.
+    DISPLAY_TITLE_CHOICES = ["project + tab", "tab", "off"]
+    DISPLAY_FIELDS        = [
       Field.new("Default detail pane",
         "which pane a freshly-opened History flow shows first — ←/→ cycles",
         choices: DISPLAY_PANE_CHOICES),
@@ -93,6 +95,9 @@ module Gori::Tui
       Field.new("Resource meter",
         "show gori's own CPU/memory at the far right of the bottom bar — ←/→/space toggles",
         bool: true),
+      Field.new("Terminal title",
+        "what gori writes into the terminal window title — off leaves it to your shell/tmux — ←/→ cycles",
+        choices: DISPLAY_TITLE_CHOICES),
     ]
     # Notifications: bell/toast toggles + ring-buffer retention.
     NOTIFICATIONS_FIELDS = [
@@ -156,7 +161,7 @@ module Gori::Tui
                 when :theme         then [Theme.canonical(Settings.theme)]
                 when :layout        then layout_values
                 when :statusline    then [Settings.statusline_enabled? ? "on" : "off", Settings.statusline_command, Settings.statusline_interval.to_s]
-                when :display       then [Settings.default_detail_pane, Settings.history_time_format, Settings.show_gutter ? "on" : "off", Settings.preview_body_kib.to_s, Settings.resource_meter? ? "on" : "off"]
+                when :display       then display_values
                 when :notifications then [Settings.notify_bell? ? "on" : "off", Settings.notify_toast? ? "on" : "off", Settings.notify_retention.to_s]
                 when :general       then [Settings.clipboard_osc52? ? "on" : "off", Settings.confirm_quit? ? "on" : "off"]
                 else                     [Settings.bind_host, Settings.bind_port.to_s, Settings.upstream_proxy, Settings.verify_upstream? ? "on" : "off", Settings.serve_landing? ? "on" : "off", Settings.connect_timeout_secs.to_s, Settings.io_timeout_secs.to_s, Settings.capture_max_mib.to_s, hostnames_summary]
@@ -195,6 +200,7 @@ module Gori::Tui
                   Settings::DEFAULT_SHOW_GUTTER ? "on" : "off",
                   Settings::DEFAULT_PREVIEW_BODY_KIB.to_s,
                   Settings::DEFAULT_RESOURCE_METER ? "on" : "off",
+                  title_label(Settings::DEFAULT_TERMINAL_TITLE),
                 ]
                 when :notifications then [
                   Settings::DEFAULT_NOTIFY_BELL ? "on" : "off",
@@ -237,6 +243,27 @@ module Gori::Tui
 
     private def order_from_label(s : String) : String
       s.starts_with?("oldest") ? "oldest" : "newest"
+    end
+
+    private def display_values : Array(String)
+      [
+        Settings.default_detail_pane,
+        Settings.history_time_format,
+        Settings.show_gutter ? "on" : "off",
+        Settings.preview_body_kib.to_s,
+        Settings.resource_meter? ? "on" : "off",
+        title_label(Settings.terminal_title),
+      ]
+    end
+
+    # "tab"/"off" label as themselves; only the default mode reads differently in the UI
+    # ("project" stored, "project + tab" shown) since the title carries both.
+    private def title_label(mode : String) : String
+      mode == "project" ? "project + tab" : mode
+    end
+
+    private def title_from_label(s : String) : String
+      DISPLAY_TITLE_CHOICES.includes?(s) && s != "project + tab" ? s : "project"
     end
 
     # ↑/↓: move between fields — except in the THEME section, whose single field IS a
@@ -412,7 +439,8 @@ module Gori::Tui
         Settings.show_gutter = @values[2] == "on"
         Settings.preview_body_kib = kib
         Settings.resource_meter = @values[4] == "on"
-        @values = [Settings.default_detail_pane, Settings.history_time_format, Settings.show_gutter ? "on" : "off", Settings.preview_body_kib.to_s, Settings.resource_meter? ? "on" : "off"]
+        Settings.terminal_title = title_from_label(@values[5])
+        @values = display_values
         return persist
       end
       if @section == :notifications


### PR DESCRIPTION
## What

The terminal-window title was `Gori - <tab>`, which told you nothing about which project a window had open. It now reads `Gori - <project> - <tab>`, so several concurrently open projects can be told apart at a glance.

The mode is a new `settings:display` pref (`terminal_title`), cycled with ←/→:

| Mode | Title |
|---|---|
| `project` (default) | `Gori - acme - History` |
| `tab` | `Gori - History` |
| `off` | nothing, gori never writes the title |

```
│  Resource meter           › ◉ on                             │
│▎ Terminal title           › ◉ project + tab  ◯ tab  ◯ off    │
```

## Notes

- The memo moves from the active tab symbol to the composed string, so a **project rename** re-emits the title too, not only a tab switch. It stays driven from `render` rather than each `@active_tab` write site, so every switch path is covered.
- Project names are user-supplied and now go out inside an OSC string, where a raw `ESC` or `BEL` would terminate the sequence early and let the remainder land as terminal input. `title_safe` strips control bytes and caps the length. The old title was a constant, so this exposure is new.
- `off` is hands-off end to end: the neutral title on leave and the external-editor memo bust are both gated on our having written a title. Flipping to `off` mid-session releases the title we already put there to the neutral `gori` once, rather than freezing it on a stale tab name.
- Added a `display` subsection to `config.md` / `config.ko.md`; there wasn't one, so the other display keys were undocumented too.

## Verification

Full suite passes (2206 examples, 0 failures). Driven live under tmux, reading `pane_title` at each step:

- open project → `Gori - titletest - Project`; `→` to next tab → `Gori - titletest - Target`
- `tab` mode → `Gori - Project`, and `terminal_title":"tab"` lands in `settings.json`
- `off` from startup → gori never touches the title (stayed as the host name)
- `off` mid-session → releases to `gori`; switching back on restores the full title
- back to picker → `gori`

The choice labels are width-constrained: `tab only` rendered truncated as `◯ o…` at the box edge, so they were shortened to fit on one row.