### PR TITLE
feat(probe): NGINX alias-traversal active-scan rule

### DIFF
--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -1474,6 +1474,104 @@ describe "Gori::Probe::Active::ForbiddenBypass" do
   end
 end
 
+describe "Gori::Probe::Active::NginxAliasTraversal" do
+  probe = Gori::Probe::Active::NginxAliasTraversal.new
+
+  it "only probes a 2xx non-HTML GET whose path is /<seg>/<more>" do
+    with_store do |store|
+      # The classic case: a static asset under a leading location segment.
+      css = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/static/main.css",
+        status: 200, content_type: "text/css")
+      probe.plan(css).should_not be_nil
+
+      # HTML baseline is skipped (a SPA catch-all would byte-match the traversal probe with no bug).
+      html = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/app/index",
+        status: 200, content_type: "text/html")
+      probe.plan(html).should be_nil
+      # A non-2xx resource has nothing to re-fetch.
+      missing = capture_flow(store, "HTTP/1.1 404 Not Found\r\n\r\n", target: "/static/x.js",
+        status: 404, content_type: "application/javascript")
+      probe.plan(missing).should be_nil
+      # Single-segment / directory paths have no resource under a location to fold `..` after.
+      root = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/favicon.ico",
+        status: 200, content_type: "image/x-icon")
+      probe.plan(root).should be_nil
+      dir = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/static/",
+        status: 200, content_type: "text/css")
+      probe.plan(dir).should be_nil
+      # HEAD is excluded — the confirmation compares bodies and HEAD returns none.
+      head = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/static/main.css",
+        status: 200, method: "HEAD", content_type: "text/css")
+      probe.plan(head).should be_nil
+    end
+  end
+
+  it "folds `..` after the leading segment, keeping the query, and stays origin-form" do
+    with_store do |store|
+      css = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/static/js/app.js?v=3",
+        status: 200, content_type: "application/javascript")
+      plan = probe.plan(css).not_nil!
+      String.new(plan.request).each_line.first.should start_with("GET /static../static/js/app.js?v=3 ")
+
+      # A forward-proxy absolute-form flow is normalized to origin-form before the fold.
+      abs = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", scheme: "http", host: "t.example",
+        target: "http://t.example/assets/style.css", status: 200, content_type: "text/css")
+      line = String.new(probe.plan(abs).not_nil!.request).each_line.first
+      line.should start_with("GET /assets../assets/style.css ")
+      line.should_not contain("http://t.example")
+    end
+  end
+
+  it "flags High only when the folded path returns byte-identical content" do
+    with_store do |store|
+      css = capture_flow(store, "HTTP/1.1 200 OK\r\nContent-Type: text/css\r\n\r\n",
+        target: "/static/main.css", status: 200, content_type: "text/css", body: "body{color:red}")
+      plan = probe.plan(css).not_nil!
+
+      # Vulnerable: the same file comes back through the fold → confirmed.
+      hit = Gori::Repeater::Result.new(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/css\r\n\r\n".to_slice, "body{color:red}".to_slice, nil, 1_i64)
+      dets = probe.detections(plan, hit, css)
+      dets.size.should eq(1)
+      dets.first.code.should eq("nginx_alias_traversal")
+      dets.first.severity.should eq(Gori::Store::Severity::High)
+
+      # Not vulnerable: the folded path 404s → not flagged.
+      not_found = Gori::Repeater::Result.new(
+        "HTTP/1.1 404 Not Found\r\n\r\n".to_slice, "nope".to_slice, nil, 1_i64)
+      probe.detections(plan, not_found, css).should be_empty
+      # A 200 with a DIFFERENT body (e.g. a catch-all page) is not the same resource → not flagged.
+      other = Gori::Repeater::Result.new(
+        "HTTP/1.1 200 OK\r\n\r\n".to_slice, "something else".to_slice, nil, 1_i64)
+      probe.detections(plan, other, css).should be_empty
+      # A send failure never flags.
+      errored = Gori::Repeater::Result.new(Bytes.empty, nil, nil, 1_i64, "connection refused")
+      probe.detections(plan, errored, css).should be_empty
+    end
+  end
+
+  it "dedup_key equals plan.dedup_key across eligible/ineligible flows" do
+    with_store do |store|
+      cases = [
+        {target: "/static/main.css", method: "GET", status: 200, ct: "text/css"},       # eligible
+        {target: "/static/main.css?v=1", method: "GET", status: 200, ct: "text/css"},    # query stripped in key
+        {target: "/a/b/c.js", method: "GET", status: 200, ct: "application/javascript"}, # deep path
+        {target: "/static/main.css", method: "GET", status: 200, ct: "text/html"},       # HTML → nil
+        {target: "/static/main.css", method: "GET", status: 404, ct: "text/css"},        # non-2xx → nil
+        {target: "/static/main.css", method: "HEAD", status: 200, ct: "text/css"},       # HEAD → nil
+        {target: "/favicon.ico", method: "GET", status: 200, ct: "image/x-icon"},        # single segment → nil
+        {target: "/has space", method: "GET", status: 200, ct: "text/css"},              # malformed → nil
+      ]
+      cases.each do |c|
+        d = capture_flow(store, "HTTP/1.1 #{c[:status]} X\r\n\r\n", scheme: "http", host: "t.example",
+          target: c[:target], method: c[:method], status: c[:status], content_type: c[:ct])
+        probe.dedup_key(d).should eq(probe.plan(d).try(&.dedup_key)),
+          "nginx_alias_traversal #{c[:target]} #{c[:method]} #{c[:status]} #{c[:ct]}"
+      end
+    end
+  end
+end
+
 describe "Gori::Probe::Active (safety + coverage)" do
   it "does not probe mutating methods (POST), only safe ones (GET)" do
     with_store do |store|

--- a/src/gori/probe/active.cr
+++ b/src/gori/probe/active.cr
@@ -2,6 +2,7 @@ require "./active/types"
 require "./active/reflected_param"
 require "./active/cors_reflection"
 require "./active/forbidden_bypass"
+require "./active/nginx_alias_traversal"
 
 module Gori
   module Probe
@@ -12,7 +13,7 @@ module Gori
       # The primary rule, reused for the registry AND the module-level facade.
       PRIMARY = ReflectedParam.new
 
-      RULES = [PRIMARY, CorsReflection.new, ForbiddenBypass.new] of Rule
+      RULES = [PRIMARY, CorsReflection.new, ForbiddenBypass.new, NginxAliasTraversal.new] of Rule
 
       # Convenience facade over the primary (reflected-param) rule. The analyzer drives the
       # whole RULES list; these keep a stable single-rule entry point for callers/tests.

--- a/src/gori/probe/active/nginx_alias_traversal.cr
+++ b/src/gori/probe/active/nginx_alias_traversal.cr
@@ -1,0 +1,186 @@
+require "./types"
+require "../../miner/inject"
+require "../../proxy/codec/http1"
+require "../../proxy/codec/content_decode"
+
+module Gori
+  module Probe
+    module Active
+      # Active NGINX alias-traversal probe. A classic NGINX misconfiguration serves a static
+      # directory with an off-by-one `location` prefix:
+      #
+      #     location /static { alias /var/www/app/static/; }   # NOTE: no trailing slash on `location`
+      #
+      # Because the `location` prefix lacks a trailing slash, a URI like `/static../` is still a
+      # prefix match and resolves to `/var/www/app/static/../` — one directory ABOVE the alias
+      # root — letting an attacker read files outside the intended tree (Orange Tsai, BlackHat
+      # USA 2018; PortSwigger BApp "NGINX Alias Traversal").
+      #
+      # For one in-scope flow whose captured response was a successful (2xx) NON-HTML asset, this
+      # re-fetches THE SAME resource through the alias boundary: `/static/main.css` is re-requested
+      # as `/static../static/main.css`. On a correctly-configured server that path 404s — the `..`
+      # is part of a literal segment `static..`, not a collapsed `../`, so no `location` matches and
+      # nothing is served. On the vulnerable config it resolves right back to the very same file and
+      # returns byte-identical content. That byte-for-byte match against the CAPTURED baseline is
+      # the confirmation, so a normal 404/redirect/different-page can't produce a false positive.
+      #
+      # Gated hard to stay quiet and low-FP:
+      #   * GET only — the confirmation compares response BODIES, and HEAD returns none. (A safe,
+      #     idempotent re-read of a resource the browser already fetched — never a mutation.)
+      #   * 2xx captured status — there must be a real served resource to re-fetch.
+      #   * Non-HTML content type — a SPA / framework catch-all returns the SAME index.html for
+      #     ANY path, so an HTML baseline could byte-match the traversal path WITHOUT any alias
+      #     bug. Alias directives serve static file trees (css/js/images/fonts/…) anyway, so
+      #     restricting to non-HTML kills that dominant false positive at negligible coverage cost.
+      #   * A path shaped `/<seg>/<more>` — we need a leading location segment to fold `..` after,
+      #     plus a real resource under it to re-fetch.
+      class NginxAliasTraversal < Rule
+        def info : RuleInfo
+          RuleInfo.new("nginx_alias_traversal", "NGINX alias traversal",
+            "Re-fetches a static asset through a folded `..` (/static../static/…) and flags a byte-identical hit.",
+            Category::ACTIVE)
+        end
+
+        # The dedup key WITHOUT rebuilding the probe — same gates as `plan`, same key (nil in
+        # exactly the same cases). Both funnel through `gate`, so the two paths cannot drift.
+        def dedup_key(detail : Store::FlowDetail) : String?
+          g = gate(detail) || return nil
+          key_string(detail, g[0], g[1])
+        end
+
+        def plan(detail : Store::FlowDetail) : Plan?
+          g = gate(detail) || return nil
+          method_up, path_key = g
+          # Rebuild from the ORIGIN-FORM target (query kept, so we re-fetch the exact resource);
+          # `traversal_target` re-derives the same leading segment `gate` validated.
+          _, target, _ = Proxy::Codec::Http1.parse_request_line(detail.request_head)
+          tt = traversal_target(Active.origin_form(target)) || return nil
+          request = rebuild(detail.request_head, detail.request_body, tt)
+          Plan.new(request, [] of Param, key_string(detail, method_up, path_key))
+        end
+
+        def detections(plan : Plan, result : Repeater::Result, detail : Store::FlowDetail) : Array(Detection)
+          return [] of Detection unless result.ok?
+          # Only a 2xx traversal hit matters — a normal server answers the folded path with 404
+          # (literal `static..` segment) or a redirect; either is "not vulnerable".
+          return [] of Detection unless (200..299).includes?(probe_status(result))
+          base = decoded_body(detail.response_head, detail.response_body)
+          # No baseline body to compare against (empty / HEAD-like) → nothing to confirm.
+          return [] of Detection if base.nil? || base.empty?
+          probe = decoded_body(result.head, result.body)
+          # Byte-identical content proves the folded path resolved back to the SAME file — the
+          # alias boundary was crossed. A catch-all/normal 404 body differs, so it never matches.
+          return [] of Detection unless probe && base == probe
+
+          _, target, _ = Proxy::Codec::Http1.parse_request_line(detail.request_head)
+          tt = traversal_target(Active.origin_form(target))
+          orig_path = path_only(Active.origin_form(target))
+          [Detection.new("nginx_alias_traversal", Category::ACTIVE, detail.row.host, detail.row.url,
+            "NGINX alias traversal (path normalization)", Store::Severity::High,
+            "#{orig_path} also served via #{tt || "folded .."} (byte-identical) — `location` prefix lacks a trailing slash",
+            detail.row.id)]
+        rescue
+          [] of Detection
+        end
+
+        # The shared gate both `plan` and `dedup_key` funnel through, returning
+        # {method_upcase, path-without-query} or nil. Cheap: only the start line + FlowRow fields
+        # (status / content_type), no header re-parse.
+        private def gate(detail : Store::FlowDetail) : {String, String}?
+          method, target, malformed = Proxy::Codec::Http1.parse_request_line(detail.request_head)
+          return nil if malformed
+          method_up = method.upcase
+          return nil unless method_up == "GET" # need a body to byte-compare; HEAD has none
+          status = detail.row.status
+          return nil unless status && (200..299).includes?(status)
+          ct = detail.row.content_type
+          # Non-HTML only — a SPA/framework catch-all returns the same index.html for any path and
+          # would byte-match the traversal probe with no alias bug. nil type → treat as ineligible.
+          return nil unless ct && !ct.downcase.includes?("html")
+          path = path_only(Active.origin_form(target))
+          return nil unless first_segment(path) # path must be /<seg>/<more>
+          {method_up, path}
+        end
+
+        # rule + host:PORT + METHOD + PATH (no query — alias resolution is per-path, not per-value),
+        # so the same host on another port/service is a distinct surface. One probe per path.
+        private def key_string(detail : Store::FlowDetail, method_upcase : String, path : String) : String
+          "nginx_alias_traversal|#{detail.row.host}:#{detail.row.port}|#{method_upcase}|#{path}"
+        end
+
+        # The leading path segment to fold `..` after, or nil unless the path is `/<seg>/<more>`:
+        # a non-empty first segment AND at least one character under it (the resource to re-fetch).
+        # A `.`/`..`/`..`-bearing segment is rejected (degenerate / already-traversing traffic).
+        private def first_segment(path : String) : String?
+          return nil unless path.starts_with?('/')
+          rest = path[1..]
+          slash = rest.index('/')
+          return nil unless slash && slash > 0
+          seg = rest[0...slash]
+          return nil if rest[(slash + 1)..].empty?
+          return nil if seg == "." || seg == ".." || seg.includes?("..")
+          seg
+        end
+
+        # `/static/main.css` → `/static../static/main.css`, preserving any query so the SAME
+        # resource is re-fetched. nil when the path doesn't qualify (mirrors `first_segment`).
+        private def traversal_target(origin_target : String) : String?
+          qi = origin_target.index('?')
+          path = qi ? origin_target[0...qi] : origin_target
+          query = qi ? origin_target[qi..] : ""
+          seg = first_segment(path) || return nil
+          "/#{seg}..#{path}#{query}"
+        end
+
+        private def path_only(origin_target : String) : String
+          qi = origin_target.index('?')
+          qi ? origin_target[0...qi] : origin_target
+        end
+
+        private def probe_status(result : Repeater::Result) : Int32
+          if r = result.response
+            return r.status
+          end
+          Proxy::Codec::Http1.parse_response_head(result.head).status
+        rescue
+          0
+        end
+
+        # Inflate (Content-Encoding) and cap at BODY_CAP for a byte-comparable buffer. Capping BOTH
+        # sides at the same bound sidesteps capture-truncation skew: only the first BODY_CAP bytes
+        # are ever compared. nil when there is no body.
+        private def decoded_body(head : Bytes?, body : Bytes?) : Bytes?
+          return nil if body.nil? || body.empty?
+          decoded, _ = Proxy::Codec::ContentDecode.decode(head, body, BODY_CAP)
+          b = decoded || body
+          b[0, {b.size, BODY_CAP}.min]
+        end
+
+        # Rebuild the request with the traversal target in the request line; headers and body are
+        # untouched (GET carries no Content-Length-affecting change), so no resync is needed. The
+        # target is already origin-form (built from `Active.origin_form`), so a forward-proxy
+        # absolute-form flow is sent DIRECT to the origin like the other active probes.
+        private def rebuild(head : Bytes, body : Bytes?, new_target : String) : Bytes
+          combined = if body && !body.empty?
+                       io = IO::Memory.new(head.size + body.size)
+                       io.write(head)
+                       io.write(body)
+                       io.to_slice
+                     else
+                       head
+                     end
+          hbytes, bbytes, eol = Miner::Inject.split(combined)
+          lines = String.new(hbytes).split(eol)
+          unless lines.empty?
+            parts = lines[0].split(' ')
+            lines[0] = "#{parts[0]} #{new_target} #{parts[2]}" if parts.size == 3
+          end
+          io = IO::Memory.new
+          io << lines.join(eol) << eol << eol
+          io.write(bbytes) unless bbytes.empty?
+          io.to_slice
+        end
+      end
+    end
+  end
+end

--- a/src/gori/probe/issue.cr
+++ b/src/gori/probe/issue.cr
@@ -73,6 +73,7 @@ module Gori
       "cors_reflected_origin"          => "Don't blindly reflect the Origin with Allow-Credentials: true; validate it against a strict allowlist.",
       "cors_arbitrary_origin"          => "A probe confirmed the server echoes ANY Origin with Allow-Credentials: true — any site can read authenticated responses. Validate the Origin against a strict allowlist.",
       "forbidden_bypass"               => "A probe turned a 401/403 into a 2xx by forging client-IP headers (X-Forwarded-For, X-Real-IP, …). Derive the client IP from the trusted socket peer / a fixed number of known proxy hops, not from arbitrary request headers, and strip these headers at the edge.",
+      "nginx_alias_traversal"          => "A probe re-fetched the same file through a folded `..` (e.g. /static../static/app.js returned byte-identical content), confirming an NGINX alias-traversal misconfiguration that reads files above the intended directory. Give the `location` a trailing slash (location /static/ { alias …; }) or use `root` instead of `alias`, and reject/normalize `..` in request paths at the edge.",
       "private_ip_leak"                => "Strip internal hostnames/IPs from responses; they aid network reconnaissance.",
       "error_stack_leak"               => "Return generic errors to clients; log stack traces server-side only.",
       "secret_in_body"                 => "Rotate the exposed credential and remove it from the response; never ship keys/tokens to clients.",


### PR DESCRIPTION
Adds a Probe **active-scan** rule that detects NGINX alias-traversal misconfigurations, porting the PortSwigger [NGINX Alias Traversal](https://portswigger.net/bappstore/a5fdd2cdffa6410eb530de5a4c294d3a) BApp (Orange Tsai, BlackHat USA 2018).

## How it works

The bug: `location /static { alias /var/www/app/static/; }` — with **no trailing slash on `location`**, a URI like `/static../` prefix-matches and resolves one directory *above* the alias root.

Fitting gori's one-request-per-flow active engine, this ports the BApp's self-contained confirmation step: for a captured 2xx non-HTML GET at `/<seg>/<more>`, re-fetch the same resource through a folded `..`:

```
/static/main.css  ->  GET /static../static/main.css
```

- **Correct server** -> `404` (the `..` sits inside a literal `static..` segment, never collapsed)
- **Vulnerable server** -> returns the byte-identical file

Detection = the probe body **byte-equals the captured baseline** (`detail.response_body`), so no extra request is needed. Reported **High**.

## Gates (quiet + low-FP)

- **HTML excluded** — a SPA/framework catch-all returns the same `index.html` for any path and would byte-match with no bug; alias directives serve static trees anyway.
- **GET only** — the confirmation compares response *bodies*; HEAD has none.
- Both bodies capped at `BODY_CAP` so capture-truncation can't cause a false mismatch.
- `plan`/`dedup_key` funnel through one `gate` predicate (the equivalence-spec invariant the other active rules follow); `requests_per_flow` stays `1..1`.

## Changes

- `src/gori/probe/active/nginx_alias_traversal.cr` — new `NginxAliasTraversal < Active::Rule`
- `active.cr` — require + registered in `Active::RULES`
- `issue.cr` — remediation hint
- `spec/probe_spec.cr` — 4 test cases (gating, `..` fold + query/origin-form, byte-equal confirmation, dedup_key equivalence)

Auto-appears in the Probe **Rules** sub-tab and is per-project toggleable like the other rules.

## Verification

- `crystal build src/main.cr` — clean
- `crystal spec spec/probe_spec.cr` — 141 examples, 0 failures
- TUI probe specs — 25 examples, 0 failures