### PR TITLE
feat(decoder): add sha224 and sha384 hashing support

### DIFF
--- a/spec/decoder_spec.cr
+++ b/spec/decoder_spec.cr
@@ -201,7 +201,9 @@ describe Gori::Decoder do
     it "matches NIST/RFC vectors" do
       conv("md5", "").should eq "d41d8cd98f00b204e9800998ecf8427e"
       conv("sha1", "").should eq "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+      conv("sha224", "abc").should eq "23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7"
       conv("sha256", "abc").should eq "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+      conv("sha384", "abc").should eq "cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7"
       conv("sha512", "abc").should start_with "ddaf35a193617aba"
       conv("crc32", "hello world").should eq "0d4a1185"
       conv("crc32", "").should eq "00000000" # empty input → zero, left-padded to 8 hex

--- a/src/gori/decoder/catalog.cr
+++ b/src/gori/decoder/catalog.cr
@@ -7,6 +7,7 @@ require "digest/sha1"
 require "digest/sha256"
 require "digest/sha512"
 require "digest/crc32"
+require "openssl"
 
 module Gori::Decoder
   # Builds the default registry — every v1 converter, in autocomplete display
@@ -107,7 +108,9 @@ module Gori::Decoder
     # ---------------- HASH ----------------
     r.register encode("md5", category: Category::Hash, direction: Direction::Hash, description: "MD5 digest (hex)") { |b| Digest::MD5.hexdigest(b) }
     r.register encode("sha1", category: Category::Hash, direction: Direction::Hash, description: "SHA-1 digest (hex)") { |b| Digest::SHA1.hexdigest(b) }
+    r.register encode("sha224", category: Category::Hash, direction: Direction::Hash, description: "SHA-224 digest (hex)") { |b| OpenSSL::Digest.new("SHA224").update(b).final.hexstring }
     r.register encode("sha256", category: Category::Hash, direction: Direction::Hash, description: "SHA-256 digest (hex)") { |b| Digest::SHA256.hexdigest(b) }
+    r.register encode("sha384", category: Category::Hash, direction: Direction::Hash, description: "SHA-384 digest (hex)") { |b| OpenSSL::Digest.new("SHA384").update(b).final.hexstring }
     r.register encode("sha512", category: Category::Hash, direction: Direction::Hash, description: "SHA-512 digest (hex)") { |b| Digest::SHA512.hexdigest(b) }
     r.register encode("crc32", category: Category::Hash, direction: Direction::Hash, description: "CRC-32 checksum (hex)") { |b| Digest::CRC32.checksum(b).to_s(16).rjust(8, '0') }
 

--- a/src/gori/decoder/converter.cr
+++ b/src/gori/decoder/converter.cr
@@ -17,7 +17,7 @@ module Gori
     enum Category
       Encoding    # base64, url, hex, base32, ascii85, base58
       Compression # gzip, zlib
-      Hash        # md5, sha1, sha256, sha512
+      Hash        # md5, sha1, sha224, sha256, sha384, sha512
       Token       # jwt-decode
       Escape      # html, json-string, unicode
       Text        # rot13, upper, lower, reverse


### PR DESCRIPTION
This PR adds support for SHA-224 and SHA-384 hashing algorithms in the Decoder tab, leveraging OpenSSL::Digest from the standard library.