### PR TITLE
fix(tui): prevent oast provider overlay type selection from overflowing

### DIFF
--- a/spec/tui/oast_provider_overlay_spec.cr
+++ b/spec/tui/oast_provider_overlay_spec.cr
@@ -1,0 +1,49 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+private def skey(k : Termisu::Input::Key, char : Char? = nil) : Termisu::Event::Key
+  Termisu::Event::Key.new(k, char: char)
+end
+
+private def stype(ov : OastProviderOverlay, s : String) : Nil
+  s.each_char { |c| ov.handle_key(skey(Termisu::Input::Key::LowerA, c)) }
+end
+
+describe Gori::Tui::OastProviderOverlay do
+  it "defaults to Interactsh and cycles type with ←/→" do
+    ov = OastProviderOverlay.adding
+    ov.kind.should eq(Gori::Oast::ProviderKind::Interactsh)
+    ov.editing?.should be_false
+
+    ov.handle_key(skey(Termisu::Input::Key::Down)).should eq(:stay)  # type row
+    ov.handle_key(skey(Termisu::Input::Key::Right)).should eq(:stay) # Interactsh -> CustomHttp
+    ov.kind.should eq(Gori::Oast::ProviderKind::CustomHttp)
+    ov.handle_key(skey(Termisu::Input::Key::Right)).should eq(:stay) # CustomHttp -> WebhookSite
+    ov.kind.should eq(Gori::Oast::ProviderKind::WebhookSite)
+    ov.handle_key(skey(Termisu::Input::Key::Left)).should eq(:stay) # WebhookSite -> CustomHttp
+    ov.kind.should eq(Gori::Oast::ProviderKind::CustomHttp)
+  end
+
+  it "seeds edit mode from an existing provider" do
+    ov = OastProviderOverlay.editing(42_i64, "My Provider", Gori::Oast::ProviderKind::Boast, "https://boast.example", "my-token")
+    ov.editing?.should be_true
+    ov.edit_id.should eq(42_i64)
+    ov.provider_name.should eq("My Provider")
+    ov.kind.should eq(Gori::Oast::ProviderKind::Boast)
+    ov.host.should eq("https://boast.example")
+    ov.token.should eq("my-token")
+  end
+
+  it "renders without crashing and maps a click to a row" do
+    ov = OastProviderOverlay.adding
+    screen = Screen.new(MemoryBackend.new(80, 24))
+    area = Rect.new(0, 0, 80, 24)
+    ov.render(screen, area)
+    box = ov.overlay_box(area).not_nil!
+    ov.row_at(box, box.x + 3, box.y + 2).should eq(0) # name row
+    ov.row_at(box, box.x + 3, box.y + 3).should eq(1) # type row
+    ov.row_at(box, box.x + 3, box.y + 6).should eq(4) # save row
+  end
+end

--- a/src/gori/tui/oast_provider_overlay.cr
+++ b/src/gori/tui/oast_provider_overlay.cr
@@ -33,7 +33,7 @@ module Gori::Tui
       @host = TextField.new(host)
       @token = TextField.new(token)
       @host_dirty = !@edit_id.nil? # editing keeps its host; adding auto-syncs to the type default
-      @sel = 0 # 0 name · 1 type · 2 host · 3 token · 4 save
+      @sel = 0                     # 0 name · 1 type · 2 host · 3 token · 4 save
     end
 
     def self.adding : OastProviderOverlay
@@ -180,13 +180,9 @@ module Gori::Tui
       when 0 then draw_field(screen, box, py, "name:", @name, sel, bg, fg)
       when 1
         screen.text(x, py, "type:", Theme.muted, bg)
-        tx = x + 6
-        KINDS.each_with_index do |k, ki|
-          lit = ki == @kind_idx
-          col = lit ? (sel ? Theme.text_bright : Theme.accent) : Theme.muted
-          tx = screen.text(tx, py, " #{k.label} ", col, bg, lit ? Attribute::Bold : Attribute::None)
-        end
-        screen.text(tx, py, " ‹/›", Theme.muted, bg)
+        col = sel ? Theme.text_bright : Theme.accent
+        tx = screen.text(x + 6, py, kind.label, col, bg, Attribute::Bold)
+        screen.text(tx, py, "  ‹/›", Theme.muted, bg)
       when 2 then draw_field(screen, box, py, "host:", @host, sel, bg, fg)
       when 3 then draw_field(screen, box, py, "token:", @token, sel, bg, fg)
       else


### PR DESCRIPTION
Only display the currently selected provider type with ‹/› cycle indicators in the OAST Providers add/edit popup, rather than all type labels inline.