### PR TITLE
feat(tui): find & replace on the ^F prompt

### DIFF
--- a/docs/content/guide/hotkeys.ko.md
+++ b/docs/content/guide/hotkeys.ko.md
@@ -58,7 +58,7 @@ Ctrl-P → settings:hotkeys
 - **종료**: `Ctrl-C`, `Ctrl-D`.
 - **명명된 키와 구별 불가**: `Ctrl-M` / `Ctrl-J` (Enter), `Ctrl-I` (Tab), `Ctrl-H` (Backspace), `Ctrl-[` (Escape).
 - **구조적**: `Enter`, `Esc`, `Tab`, `Backspace`, 그리고 맨 `:`(명령줄).
-- **키맵보다 먼저 점유되는 gori 단축키**: `Ctrl-G` (go to line), `Ctrl-F` (find), `Ctrl-B` (reveal whitespace), `Ctrl-E` (external editor), `Ctrl-P` (command palette), `Ctrl-N` (new repeater/fuzz/note), `Ctrl-W` (close sub-tab), 그리고 `Ctrl-1`…`Ctrl-9` (switch sub-tab). 이들은 키맵보다 먼저 하드코딩된 가드로 처리되므로, 여기에 바인딩해도 절대 발동하지 않습니다. 같은 이유로 **Command palette**, **New repeater request**, **New fuzz session**은 에디터에 나열되지 않습니다. 그 키는 고정입니다.
+- **키맵보다 먼저 점유되는 gori 단축키**: `Ctrl-G` (go to line), `Ctrl-F` (find, `Tab`으로 find & replace), `Ctrl-B` (reveal whitespace), `Ctrl-E` (external editor), `Ctrl-P` (command palette), `Ctrl-N` (new repeater/fuzz/note), `Ctrl-W` (close sub-tab), 그리고 `Ctrl-1`…`Ctrl-9` (switch sub-tab). 이들은 키맵보다 먼저 하드코딩된 가드로 처리되므로, 여기에 바인딩해도 절대 발동하지 않습니다. 같은 이유로 **Command palette**, **New repeater request**, **New fuzz session**은 에디터에 나열되지 않습니다. 그 키는 고정입니다.
 
 `Ctrl-S` 같은 흐름 제어/시그널 코드는 예약되어 있지 **않습니다**. gori는 터미널을 raw 모드로 실행하므로 이들이 앱에 도달합니다(Repeater의 SNI 토글은 `Ctrl-S`로 제공됩니다).
 

--- a/docs/content/guide/hotkeys.md
+++ b/docs/content/guide/hotkeys.md
@@ -58,7 +58,7 @@ Some keys can't be rebound because the terminal or gori needs them:
 - **Quit**: `Ctrl-C`, `Ctrl-D`.
 - **Indistinguishable from named keys**: `Ctrl-M` / `Ctrl-J` (Enter), `Ctrl-I` (Tab), `Ctrl-H` (Backspace), `Ctrl-[` (Escape).
 - **Structural**: `Enter`, `Esc`, `Tab`, `Backspace`, and a bare `:` (the command line).
-- **gori shortcuts claimed before the keymap**: `Ctrl-G` (go to line), `Ctrl-F` (find), `Ctrl-B` (reveal whitespace), `Ctrl-E` (external editor), `Ctrl-P` (command palette), `Ctrl-N` (new repeater/fuzz/note), `Ctrl-W` (close sub-tab), and `Ctrl-1`…`Ctrl-9` (switch sub-tab). These are handled by a hardcoded guard before the keymap, so a binding on them would never fire. For the same reason **Command palette**, **New repeater request**, and **New fuzz session** aren't listed in the editor. Their key is fixed.
+- **gori shortcuts claimed before the keymap**: `Ctrl-G` (go to line), `Ctrl-F` (find, then `Tab` for find & replace), `Ctrl-B` (reveal whitespace), `Ctrl-E` (external editor), `Ctrl-P` (command palette), `Ctrl-N` (new repeater/fuzz/note), `Ctrl-W` (close sub-tab), and `Ctrl-1`…`Ctrl-9` (switch sub-tab). These are handled by a hardcoded guard before the keymap, so a binding on them would never fire. For the same reason **Command palette**, **New repeater request**, and **New fuzz session** aren't listed in the editor. Their key is fixed.
 
 Flow-control/signal chords like `Ctrl-S` are **not** reserved; gori runs the terminal in raw mode, so they reach the app (Repeater's SNI toggle ships on `Ctrl-S`).
 

--- a/spec/tui/text_area_spec.cr
+++ b/spec/tui/text_area_spec.cr
@@ -120,6 +120,45 @@ describe Gori::Tui::TextArea do
     end
   end
 
+  describe "#match_count / #replace_matches (^F find&replace)" do
+    it "counts and replaces every occurrence, case-insensitively like the search" do
+      ta = TextArea.new("Admin admin\nADMIN x")
+      ta.match_count("admin").should eq(3) # per occurrence, not per line
+      ta.replace_matches("admin", "root").should eq(3)
+      ta.text.should eq("root root\nroot x")
+    end
+
+    it "is one undo step" do
+      ta = TextArea.new("a a a")
+      ta.replace_matches("a", "b")
+      ta.text.should eq("b b b")
+      ta.undo
+      ta.text.should eq("a a a")
+    end
+
+    it "treats the replacement literally (no backreference expansion)" do
+      ta = TextArea.new("hello")
+      ta.replace_matches("hello", "\\1$0").should eq(1)
+      ta.text.should eq("\\1$0")
+    end
+
+    it "escapes regex metacharacters in the query" do
+      ta = TextArea.new("a.c abc")
+      ta.match_count("a.c").should eq(1) # the '.' is literal, so "abc" must not match
+      ta.replace_matches("a.c", "z").should eq(1)
+      ta.text.should eq("z abc")
+    end
+
+    it "deletes matches on an empty replacement, and no-ops when nothing matches" do
+      ta = TextArea.new("foo bar foo baz")
+      ta.replace_matches("foo ", "").should eq(2)
+      ta.text.should eq("bar baz")
+      ta.replace_matches("nope", "x").should eq(0)
+      ta.match_count("").should eq(0) # an empty query never matches
+      ta.text.should eq("bar baz")
+    end
+  end
+
   describe "#home / #end_of_line" do
     it "jumps the caret to the start / end of the current line (insert lands there)" do
       ta = TextArea.new("abc")

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -122,7 +122,8 @@ module Gori::Tui
         Item.new("Send to Comparer", "from History (space menu) — fills the active sub-tab"),
       ]},
       {"EDITORS", [
-        Item.new("^G · ^F", "go to line · find"),
+        Item.new("^G · ^F", "go to line · find (↵/↑↓ step)"),
+        Item.new("^F then tab", "find & replace — ↵ swaps every match (one undo step)"),
         Item.new("^E", "open the field in $EDITOR"),
         Item.new("^B", "reveal whitespace"),
       ]},

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -275,6 +275,17 @@ module Gori::Tui
       @editing ? @editor.search_lines(query) : [] of Int32
     end
 
+    def edit_match_count(query : String) : Int32
+      @editing ? @editor.match_count(query) : 0
+    end
+
+    def edit_replace_matches(query : String, replacement : String) : Int32
+      return 0 unless @editing
+      n = @editor.replace_matches(query, replacement)
+      @editor_dirty = true if n > 0
+      n
+    end
+
     def search_hl=(q : String) : Nil
       @editor.search_hl = q
     end

--- a/src/gori/tui/notes_view.cr
+++ b/src/gori/tui/notes_view.cr
@@ -273,6 +273,16 @@ module Gori::Tui
       current.area.search_lines(query)
     end
 
+    def match_count(query : String) : Int32
+      current.area.match_count(query)
+    end
+
+    def replace_matches(query : String, replacement : String) : Int32
+      n = current.area.replace_matches(query, replacement)
+      @dirty = true if n > 0
+      n
+    end
+
     def search_hl=(q : String) : Nil
       current.area.search_hl = q
     end

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -838,6 +838,16 @@ module Gori::Tui
       @desc_area.search_lines(query)
     end
 
+    def match_count(query : String) : Int32
+      @desc_area.match_count(query)
+    end
+
+    def replace_matches(query : String, replacement : String) : Int32
+      n = @desc_area.replace_matches(query, replacement)
+      @desc_dirty = true if n > 0
+      n
+    end
+
     def search_hl=(q : String) : Nil
       @desc_area.search_hl = q
     end

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -1841,6 +1841,20 @@ module Gori::Tui
       req_editor.search_lines(query)
     end
 
+    # ^F find&replace over the request editor. Hex mode is excluded like the search
+    # above (the TextArea is stale there, so a write would clobber the real bytes).
+    def request_match_count(query : String) : Int32
+      return 0 if request_hex?
+      req_editor.match_count(query)
+    end
+
+    def request_replace_matches(query : String, replacement : String) : Int32
+      return 0 if request_hex?
+      n = req_editor.replace_matches(query, replacement)
+      mark_req_edit if n > 0
+      n
+    end
+
     # Whitespace reveal toggle — response renders from raw bytes; the request editor
     # shows within-line whitespace too.
     def reveal=(on : Bool) : Nil

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -129,12 +129,17 @@ module Gori::Tui
       @goto_target = :none
       # The ^F incremental search prompt — sibling of ^G; finds matching lines in the
       # focused view and steps through them (↑/↓/↵). @search_preedit carries IME text.
+      # Tab flips it into find&replace on the editable targets: a second row appears,
+      # typing feeds @search_replace_buffer, and ↵ swaps every match behind a confirm.
+      # ↑/↓ keep stepping in BOTH modes — that's why Tab, not an arrow, is the toggle.
       @search_open = false
       @search_buffer = ""
       @search_preedit = ""
       @search_target = :none
       @search_hits = [] of Int32
       @search_idx = 0
+      @search_replace = false
+      @search_replace_buffer = ""
       # The sub-tab rename prompt (Repeater + Fuzzer + Decoder + Miner) — orthogonal to
       # @overlay (floats over the bottom status row, like ^G/^F).
       @rename_open = false
@@ -982,10 +987,13 @@ module Gori::Tui
       return handle_copy_as_key(ev) if copy_as_shown?      # the copy-as picker is modal while up
       return handle_send_to_key(ev) if send_to_shown?      # the send-to picker is modal while up
       return handle_goto_key(ev) if @goto_open             # the ^G line prompt is modal while up
-      return handle_search_key(ev) if @search_open         # the ^F find prompt is modal while up
-      return handle_rename_key(ev) if @rename_open         # the sub-tab rename prompt is modal while up
-      return handle_tag_edit_key(ev) if @tag_edit_open     # the Repeater tag editor is modal while up
-      return handle_import_key(ev) if @import_open         # the import path prompt is modal while up
+      # The ^F find prompt is modal while up — EXCEPT under its own replace confirm,
+      # which must get the keys (the prompt stays open behind it so cancelling doesn't
+      # cost you the query you just typed).
+      return handle_search_key(ev) if @search_open && @overlay != :confirm
+      return handle_rename_key(ev) if @rename_open     # the sub-tab rename prompt is modal while up
+      return handle_tag_edit_key(ev) if @tag_edit_open # the Repeater tag editor is modal while up
+      return handle_import_key(ev) if @import_open     # the import path prompt is modal while up
       # ^G "go to line" / ^F "find" — both open a bottom prompt for the focused
       # multi-line view (editors move the cursor, read-only panes scroll). Modifier
       # keys, so they work inside text editors without conflicting with typing.
@@ -3517,26 +3525,112 @@ module Gori::Tui
       end
     end
 
-    # ^F incremental search: text input (IME via @search_preedit); ↑/↓/↵ step through
+    # ^F incremental search: text input (IME via @search_preedit); ↑/↓ step through
     # matching lines (wraps); esc closes. Recomputes + jumps on each edit.
+    # Tab flips to find&replace, where typing feeds the replacement row and ↵ swaps
+    # every match (behind a confirm) instead of stepping. ↑/↓ step in both modes.
     private def handle_search_key(ev : Termisu::Event::Key) : Nil
       key = ev.key
       c = ev.char || key.to_char
       if key.escape?
         close_search
-      elsif key.enter? || key.down?
+      elsif key.tab? || key.back_tab?
+        toggle_search_replace
+      elsif key.enter?
+        @search_replace ? request_replace_confirm : search_step(1)
+      elsif key.down?
         search_step(1)
       elsif key.up?
         search_step(-1)
       elsif key.backspace?
-        @search_buffer = @search_buffer[0, {@search_buffer.size - 1, 0}.max]
-        @search_preedit = ""
-        search_refresh
+        if @search_replace
+          @search_replace_buffer = @search_replace_buffer[0, {@search_replace_buffer.size - 1, 0}.max]
+          @search_preedit = ""
+        else
+          @search_buffer = @search_buffer[0, {@search_buffer.size - 1, 0}.max]
+          @search_preedit = ""
+          search_refresh
+        end
       elsif c && !c.control? && !ev.ctrl? && !ev.alt? # control? drops Tab/\n etc. (Space stays)
-        @search_buffer += c
-        @search_preedit = ""
-        search_refresh
+        if @search_replace
+          @search_replace_buffer += c
+          @search_preedit = ""
+        else
+          @search_buffer += c
+          @search_preedit = ""
+          search_refresh
+        end
       end
+    end
+
+    # Tab: find ⇄ find&replace. Only the TextArea-backed targets can be written to; on a
+    # read-only pane this is a no-op, and the prompt never offered it (see the hint in
+    # render_search_prompt) — a toast can't explain the refusal because the prompt is
+    # drawn OVER the status row that toasts render on.
+    private def toggle_search_replace : Nil
+      return unless @search_replace || replace_target?
+      @search_replace = !@search_replace
+      @search_preedit = "" # the composing text belongs to the row we just left
+    end
+
+    # Targets whose backing view is an editable TextArea. The read-only panes
+    # (:repeater_response, :detail) have no mutation path at all.
+    private def replace_target? : Bool
+      case @search_target
+      when :repeater_request, :notes, :project, :intercept then true
+      else                                                      false
+      end
+    end
+
+    # Occurrence count (not line count — a line with three hits counts three), so the
+    # confirm can quote exactly how much is about to change.
+    private def search_match_count : Int32
+      case @search_target
+      when :repeater_request then repeater_controller.current_view.try(&.request_match_count(@search_buffer)) || 0
+      when :notes            then notes_controller.view.match_count(@search_buffer)
+      when :project          then project_controller.view.match_count(@search_buffer)
+      when :intercept        then intercept_controller.view.edit_match_count(@search_buffer)
+      else                        0
+      end
+    end
+
+    # ↵ in replace mode: gate the bulk edit behind the standard confirm (the same
+    # pattern as the REMOVE MARKER guard). An empty replacement is a legitimate
+    # "delete every match", so it's worded that way rather than rejected.
+    private def request_replace_confirm : Nil
+      return unless replace_target?
+      # Nothing to confirm with an empty query or zero hits — and no toast to explain it,
+      # because the prompt covers the status row. The find row above already says so: it
+      # shows a blank count for an empty query and "no matches" for a fruitless one.
+      return if @search_buffer.empty?
+      n = search_match_count
+      return if n == 0
+      q, r = @search_buffer, @search_replace_buffer
+      plural = n == 1 ? "" : "s"
+      msg = if r.empty?
+              "Delete #{n} occurrence#{plural} of \"#{q}\"?"
+            else
+              "Replace #{n} occurrence#{plural} of \"#{q}\" with \"#{r}\"?"
+            end
+      confirm("REPLACE ALL", "#{msg}\nOne undo step — ^Z puts it back.",
+        confirm_label: r.empty? ? "delete" : "replace", danger: true) do
+        run_replace(q, r)
+      end
+    end
+
+    private def run_replace(query : String, replacement : String) : Nil
+      n = case @search_target
+          when :repeater_request then repeater_controller.current_view.try(&.request_replace_matches(query, replacement)) || 0
+          when :notes            then notes_controller.view.replace_matches(query, replacement)
+          when :project          then project_controller.view.replace_matches(query, replacement)
+          when :intercept        then intercept_controller.view.edit_replace_matches(query, replacement)
+          else                        0
+          end
+      # The replace is done, so drop the prompt: it would otherwise sit there advertising
+      # a now-stale query as "no matches", AND it covers the status row the toast needs.
+      # ^F reopens in one keystroke.
+      close_search
+      @toast = "replaced #{n} occurrence#{n == 1 ? "" : "s"}"
     end
 
     private def search_refresh : Nil
@@ -3572,6 +3666,8 @@ module Gori::Tui
       @search_preedit = ""
       @search_hits = [] of Int32
       @search_idx = 0
+      @search_replace = false
+      @search_replace_buffer = ""
       @search_open = true
     end
 
@@ -3579,6 +3675,7 @@ module Gori::Tui
       set_search_hl("") # clear the match highlight on the target view
       @search_open = false
       @search_preedit = ""
+      @search_replace = false
     end
 
     private def current_scope : Verb::Scope
@@ -4398,23 +4495,65 @@ module Gori::Tui
 
     private def render_search_prompt(screen : Screen, rect : Rect) : Nil
       return if rect.w < 8
+      # Replace mode needs a second row, taken from the body ABOVE the status row (the
+      # prompts float over whatever's underneath). If there's no row to take, fall back
+      # to the one-row find bar rather than drawing off-screen.
+      return render_replace_prompt(screen, rect) if @search_replace && rect.y > 0
       screen.fill(rect, Theme.panel)
       prefix = "find: "
       screen.text(rect.x, rect.y, prefix, Theme.accent, Theme.panel)
       x = rect.x + prefix.size
-      # match count (or "no matches") right-aligned; dim "esc done · ↑↓ next" hint after the input
-      count = if @search_buffer.empty? && @search_preedit.empty?
+      # match count (or "no matches") right-aligned; dim "esc done · ↑↓ next" hint after
+      # the input. Only advertise tab where replace can actually commit — on the
+      # read-only panes the key is a no-op, so offering it would just mislead.
+      suffix = hint_with_count(replace_target? ? "↵/↑↓ step · tab replace · esc done" : "↵/↑↓ step · esc done")
+      sx = {rect.right - suffix.size, x}.max
+      iw = {sx - x - 1, 0}.max
+      screen.input_line(x, rect.y, @search_buffer, @search_buffer.size, @search_preedit, Theme.text_bright, Theme.panel, width: iw)
+      screen.text(sx, rect.y, suffix, no_matches? ? Theme.yellow : Theme.muted, Theme.panel)
+    end
+
+    # find&replace: the query row (read-only here — tab back to edit it) stacked over
+    # the replacement row, which owns the caret. ↵ commits, ↑/↓ still step matches.
+    private def render_replace_prompt(screen : Screen, rect : Rect) : Nil
+      top = Rect.new(rect.x, rect.y - 1, rect.w, 1)
+      screen.fill(top, Theme.panel)
+      screen.fill(rect, Theme.panel)
+      screen.text(rect.x, top.y, "find:    ", Theme.muted, Theme.panel)
+      screen.text(rect.x, rect.y, "replace: ", Theme.accent, Theme.panel)
+      x = rect.x + 9 # both labels padded to the same width so the two fields line up
+
+      # Top row: the query plus the live match count, dimmed — it isn't focused.
+      qsuffix = hint_with_count("↑↓ step · tab edit find")
+      qsx = {top.right - qsuffix.size, x}.max
+      screen.text(x, top.y, @search_buffer, Theme.text, Theme.panel, width: {qsx - x - 1, 0}.max)
+      screen.text(qsx, top.y, qsuffix, no_matches? ? Theme.yellow : Theme.muted, Theme.panel)
+
+      # Bottom row: the focused field — input_line syncs the hardware cursor here.
+      rsuffix = "↵ replace all · esc done"
+      rsx = {rect.right - rsuffix.size, x}.max
+      screen.input_line(x, rect.y, @search_replace_buffer, @search_replace_buffer.size, @search_preedit, Theme.text_bright, Theme.panel, width: {rsx - x - 1, 0}.max)
+      screen.text(rsx, rect.y, rsuffix, Theme.muted, Theme.panel)
+    end
+
+    private def no_matches? : Bool
+      @search_hits.empty? && !@search_buffer.empty?
+    end
+
+    # Blank until something is typed, then the hit count (or "no matches"). @search_preedit
+    # counts as typing ONLY in find mode — in replace mode the composing text belongs to
+    # the replacement row, so an empty query must not read "no matches" just because
+    # you're mid-Hangul in the box below.
+    private def hint_with_count(hint : String) : String
+      pending = @search_replace ? "" : @search_preedit
+      count = if @search_buffer.empty? && pending.empty?
                 ""
               elsif @search_hits.empty?
                 "no matches"
               else
                 "#{@search_idx + 1}/#{@search_hits.size}"
               end
-      suffix = count.empty? ? "↵/↑↓ step · esc done" : "#{count}  ↵/↑↓ step · esc done"
-      sx = {rect.right - suffix.size, x}.max
-      iw = {sx - x - 1, 0}.max
-      screen.input_line(x, rect.y, @search_buffer, @search_buffer.size, @search_preedit, Theme.text_bright, Theme.panel, width: iw)
-      screen.text(sx, rect.y, suffix, @search_hits.empty? && !@search_buffer.empty? ? Theme.yellow : Theme.muted, Theme.panel)
+      count.empty? ? hint : "#{count}  #{hint}"
     end
 
     def current_tab : Symbol

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -420,6 +420,35 @@ module Gori::Tui
       @lc_lines
     end
 
+    # ^F find&replace: how many times `query` occurs — same matching as search_lines
+    # but counted per OCCURRENCE, not per line (a line with three hits counts three).
+    # The confirm prompt quotes this before the edit commits.
+    def match_count(query : String) : Int32
+      return 0 if query.empty?
+      text.scan(search_regex(query)).size
+    end
+
+    # Swap every occurrence of `query` for `replacement` as ONE undoable edit (so a
+    # surprise result is one ^Z away), returning how many landed. `replacement` is
+    # inserted literally — the block form of gsub skips \1 backreference expansion,
+    # which the user did not ask for by typing a `\1`. The caret keeps its old offset
+    # (clamped): a bulk edit has no single site to land on.
+    def replace_matches(query : String, replacement : String) : Int32
+      return 0 if query.empty?
+      n = 0
+      swapped = text.gsub(search_regex(query)) { n += 1; replacement }
+      return 0 if n == 0
+      replace_all(swapped, cursor_offset)
+      n
+    end
+
+    # Literal `query`, matched case-insensitively to mirror what ^F highlights. Regex
+    # rather than a downcase scan because downcasing can change a string's LENGTH for
+    # some Unicode (e.g. 'İ'), which would skew the offsets a manual scan splices on.
+    private def search_regex(query : String) : Regex
+      Regex.new(Regex.escape(query), Regex::Options::IGNORE_CASE)
+    end
+
     # `highlight` overlays request/response syntax colours on the buffer while
     # keeping it fully editable: pass `:request` or `:response` for the held
     # HTTP message editors (Repeater, Intercept), nil for plain prose (Notes,


### PR DESCRIPTION
`Tab` flips the `^F` find bar into find & replace. A second row appears for the replacement, and `↵` swaps every match behind a confirm.

```
find:    admin          1/3  ↑↓ step · tab edit find
replace: root                ↵ replace all · esc done
        ╭─ REPLACE ALL ──────────────────────────────╮
        │  Replace 3 occurrences of "admin" with "root"?
        │  One undo step — ^Z puts it back.
```

`↑`/`↓`/`↵` keep stepping matches exactly as before, which is why `Tab` is the toggle rather than an arrow.

### Notes

- **One undo step.** `TextArea#replace_matches` builds the new buffer and commits through the existing `replace_all`, so `^Z` reverts the whole swap. Case-insensitive to match what `^F` highlights; the replacement is inserted literally (block-form `gsub`, no `\1` expansion), and the query is `Regex.escape`d.
- **Counted per occurrence, not per line.** `search_lines` returns line indices, so the find row can read `1/1` where three hits sit on one line. The confirm counts independently and reports the real number.
- **Editable targets only** — Repeater request, Notes, Project description, Intercept. The read-only panes (`:repeater_response`, `:detail`) have no mutation path, and never advertise `tab replace` in the hint: a toast cannot explain the refusal there, because the prompt is drawn over the status row toasts render on. Same reason a successful replace closes the prompt, so its result toast is actually visible.
- The prompt stays open underneath its own confirm (`@overlay != :confirm` guard in `handle_key`), so cancelling does not cost you the query you just typed.

### Verification

Full suite 2215/2215, build and format clean. Driven live in a tmux TTY rather than only unit-tested: 3-way replace including a case-insensitive `Admin`, Hangul replacement (`비밀`), one-line/three-hit counting, cancel-preserves-buffers, `^Z` single-step undo, and read-only refusal.

Lint is +1 `CyclomaticComplexity 16/12` on `handle_search_key`, in a file already carrying entries at 168, 43 and 39 — matched the surrounding code instead of refactoring for a warning the project carries 434 of.

### Unrelated pre-existing bug found while testing

The block caret **erases any double-width character it sits on**: a Hangul line renders `  밀=1` with the caret at column 0, and `비밀=1` with it at the end. Reproduced on a pre-change binary with nothing but typing and `Home`, so it predates this branch. Left alone here since it lives in core caret/wide-char rendering; worth its own fix.