### PR TITLE
fix(tui): Preferences modal — return path, unsaved-edit guard, modal chords

### DIFF
--- a/spec/tui/preferences_view_spec.cr
+++ b/spec/tui/preferences_view_spec.cr
@@ -1,0 +1,95 @@
+require "../spec_helper"
+
+include Gori::Tui
+
+private def pkey(k : Termisu::Input::Key, char : Char? = nil) : Termisu::Event::Key
+  Termisu::Event::Key.new(k, char: char)
+end
+
+private def pctrl(k : Termisu::Input::Key) : Termisu::Event::Key
+  Termisu::Event::Key.new(k, Termisu::Input::Modifier::Ctrl)
+end
+
+private ESC   = Termisu::Input::Key::Escape
+private DOWN  = Termisu::Input::Key::Down
+private RIGHT = Termisu::Input::Key::Right
+
+# Walk from the group strip into the first editable field of the current group.
+private def into_fields(v : PreferencesView) : Nil
+  v.handle_key(pkey(DOWN))
+end
+
+# The unified Preferences modal stacks several sections in one card but ↵ saves only the
+# focused one — so it owns the guard against silently discarding the others, plus the
+# overlay-wide chords (^P to the palette, Ctrl+, to toggle shut) every other modal has.
+describe Gori::Tui::PreferencesView do
+  it "closes straight away when nothing was edited" do
+    v = PreferencesView.new
+    v.open_default
+    v.handle_key(pkey(ESC)).kind.should eq(:close)
+  end
+
+  it "warns before discarding unsaved edits, and closes on the second esc" do
+    v = PreferencesView.new
+    v.open_default
+    into_fields(v)
+    v.handle_key(pkey(RIGHT)) # flip the focused General bool → the section is now dirty
+    v.dirty?.should be_true
+
+    v.handle_key(pkey(ESC)).kind.should eq(:none) # first esc warns instead of closing
+    v.handle_key(pkey(ESC)).kind.should eq(:close)
+  end
+
+  it "expires the warning after any other keystroke, so esc must warn again" do
+    v = PreferencesView.new
+    v.open_default
+    into_fields(v)
+    v.handle_key(pkey(RIGHT))
+    v.handle_key(pkey(ESC)).kind.should eq(:none) # armed
+    v.handle_key(pkey(DOWN))                      # …moving on disarms it
+    v.handle_key(pkey(ESC)).kind.should eq(:none) # so this esc warns rather than discarding
+  end
+
+  it "guards the group strip's esc/↑ close too" do
+    v = PreferencesView.new
+    v.open_default
+    into_fields(v)
+    v.handle_key(pkey(RIGHT))
+    v.handle_key(pkey(Termisu::Input::Key::Up)) # back onto the strip, still dirty
+    v.handle_key(pkey(ESC)).kind.should eq(:none)
+    v.handle_key(pkey(ESC)).kind.should eq(:close)
+  end
+
+  it "reopening reloads from disk, dropping the dirty state" do
+    v = PreferencesView.new
+    v.open_default
+    into_fields(v)
+    v.handle_key(pkey(RIGHT))
+    v.dirty?.should be_true
+    v.open_default
+    v.dirty?.should be_false
+    v.handle_key(pkey(ESC)).kind.should eq(:close)
+  end
+
+  it "hands ^P to the host so the palette is reachable from the modal" do
+    v = PreferencesView.new
+    v.open_default
+    v.handle_key(pctrl(Termisu::Input::Key::LowerP)).kind.should eq(:palette)
+  end
+
+  it "closes on Ctrl+, — the chord that opened it" do
+    v = PreferencesView.new
+    v.open_default
+    v.handle_key(pctrl(Termisu::Input::Key::Comma)).kind.should eq(:close)
+  end
+
+  it "blocks opener rows the host has no editor for instead of emitting :open" do
+    # The project picker passes Set{:theme}: Theme opens, everything else stays hidden and
+    # Network's Hostname-overrides field is inert rather than opening a dead overlay.
+    picker = PreferencesView.new(Set{:theme})
+    picker.open(:network)
+    # Network's last field is the "Hostname overrides" opener row.
+    12.times { picker.handle_key(pkey(DOWN)) }
+    picker.handle_key(pkey(Termisu::Input::Key::Enter)).kind.should_not eq(:open)
+  end
+end

--- a/src/gori/tui/preferences_view.cr
+++ b/src/gori/tui/preferences_view.cr
@@ -33,6 +33,7 @@ module Gori::Tui
     @on_strip : Bool = false # true = the group strip holds focus (←/→ switch groups)
     @strip_start : Int32 = 0
     @status : String? = nil
+    @confirm_discard : Bool = false # an esc landed on unsaved edits; the next one discards
 
     def initialize(@allowed_openers : Set(Symbol)? = nil)
       # One SettingsView per form section, reloaded from live Settings.
@@ -76,6 +77,29 @@ module Gori::Tui
     private def reload_all : Nil
       @forms.each { |sym, v| v.reload(sym) }
       @status = nil
+      @confirm_discard = false
+    end
+
+    # Re-pull ONE section from Settings, leaving every other section's working copy alone.
+    # Used when a dedicated editor changed something a form row summarizes (the Hostnames
+    # editor and Network's "N entries" row), so returning to the modal doesn't show a lie.
+    def refresh(section : Symbol) : Nil
+      return unless v = @forms[section]?
+      return if v.dirty? # never clobber unsaved edits — a stale summary beats losing typed input
+      v.reload(section)
+      sync_focus
+    end
+
+    # The titles of sections edited but not yet saved (↵ saves the focused section only).
+    private def dirty_titles : Array(String)
+      SettingsCatalog.all.compact_map do |s|
+        f = @forms[s.sym]?
+        s.title if f && f.dirty?
+      end
+    end
+
+    def dirty? : Bool
+      @forms.each_value.any?(&.dirty?)
     end
 
     # --- input: returns an Outcome the host acts on ---
@@ -83,11 +107,18 @@ module Gori::Tui
       key = ev.key
       c = ev.char || key.to_char
       @status = nil # clear stale save/reset feedback; activate_focus/reset_focused re-set it
-      return handle_strip_key(key) if @on_strip
+      # A discard warning survives exactly one keystroke: the esc that would confirm it.
+      confirming, @confirm_discard = @confirm_discard, false
+      # Modal-wide chords, claimed before the strip/body split so they work on both:
+      # ^P jumps to the palette (as it does from every other overlay), Ctrl+, closes the
+      # modal the same chord opened.
+      return Outcome.new(:palette) if ev.ctrl? && key.lower_p?
+      return close_or_warn(confirming) if ev.ctrl? && key.comma?
+      return handle_strip_key(key, confirming) if @on_strip
 
       case
       when key.escape?
-        return Outcome.new(:close)
+        return close_or_warn(confirming)
       when key.up?
         if @focus <= 0
           @on_strip = true # step up to the group strip
@@ -125,13 +156,24 @@ module Gori::Tui
       NONE
     end
 
-    private def handle_strip_key(key : Termisu::Input::Key) : Outcome
+    private def handle_strip_key(key : Termisu::Input::Key, confirming : Bool) : Outcome
       case
-      when key.escape?, key.up?  then return Outcome.new(:close)
+      when key.escape?, key.up?  then return close_or_warn(confirming)
       when key.left?             then set_group(@group - 1)
       when key.right?            then set_group(@group + 1)
       when key.down?, key.enter? then @on_strip = false
       end
+      NONE
+    end
+
+    # Closing throws away every unsaved section, and the modal stacks several of them while
+    # ↵ saves only the focused one — so a first esc names what would be lost and a second
+    # esc discards. Clean (or already-warned) → close straight away.
+    private def close_or_warn(confirming : Bool) : Outcome
+      dirty = dirty_titles
+      return Outcome.new(:close) if confirming || dirty.empty?
+      @confirm_discard = true
+      @status = "unsaved: #{dirty.join(", ")} — ↵ saves the focused section, esc again discards"
       NONE
     end
 
@@ -152,7 +194,13 @@ module Gori::Tui
 
     def click(area : Rect, mx : Int32, my : Int32) : Outcome
       box = overlay_box(area)
-      return Outcome.new(:close) unless box.contains?(mx, my) # click outside the card → close
+      # Click outside the card → close, through the same unsaved-edits guard as esc (a
+      # stray click must not silently drop what was typed; the second click confirms).
+      unless box.contains?(mx, my)
+        confirming, @confirm_discard = @confirm_discard, false
+        return close_or_warn(confirming)
+      end
+      @confirm_discard = false
       strip = Rect.new(box.x + 2, box.y + 2, box.w - 4, 1)
       if strip.contains?(mx, my)
         if seg = Chrome.strip_segments(strip, GROUP_LABELS, @group, @strip_start, nil).find { |(_, r)| r.contains?(mx, my) }
@@ -217,13 +265,23 @@ module Gori::Tui
     # --- rendering ---
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
-      return if box.w < 24 || box.h < 10
+      # Too small for the grouped form. The modal still HOLDS input, so it must not render
+      # nothing — that reads as a frozen app. Say why and how to get out instead.
+      return render_too_small(screen, area) if box.w < 24 || box.h < 10
       Frame.card(screen, box, "PREFERENCES", border: Theme.border_focus)
       strip = Rect.new(box.x + 2, box.y + 2, box.w - 4, 1)
       @strip_start = Chrome.render_tab_strip(screen, strip, GROUP_LABELS, @group, @on_strip, @strip_start)
       screen.hline(box.x + 1, box.y + 3, box.w - 2, fg: @on_strip ? Theme.focus_gold : Theme.border, bg: Theme.panel)
       render_group(screen, content_rect(box), !@on_strip)
       render_footer(screen, box)
+    end
+
+    private def render_too_small(screen : Screen, area : Rect) : Nil
+      return if area.w < 4 || area.h < 3
+      w = {area.w - 2, 34}.min
+      box = Rect.new(area.x + (area.w - w) // 2, area.y + area.h // 2 - 1, w, 3)
+      Frame.card(screen, box, "PREFERENCES", border: Theme.border_focus)
+      screen.text(box.x + 2, box.y + 1, "terminal too small · esc", Theme.muted, Theme.panel, width: {w - 4, 1}.max)
     end
 
     # The centred modal card. Height fits the tallest group's content (so switching groups
@@ -255,7 +313,7 @@ module Gori::Tui
       end
       y = content.y - @scroll
       group_sections.each do |sec|
-        draw_subheader(screen, content, sec.title, y)
+        draw_subheader(screen, content, sec.title, y, dirty: @forms[sec.sym]?.try(&.dirty?) || false)
         y += 1
         if sec.kind == :form
           fc = field_count(sec.sym)
@@ -270,10 +328,13 @@ module Gori::Tui
       end
     end
 
-    private def draw_subheader(screen : Screen, content : Rect, title : String, y : Int32) : Nil
+    # `dirty` appends a ● so an edited-but-unsaved section is visible while you are still in
+    # the modal, not only in the esc warning.
+    private def draw_subheader(screen : Screen, content : Rect, title : String, y : Int32, dirty : Bool) : Nil
       return unless content.y <= y < content.bottom
       screen.fill(Rect.new(content.x, y, content.w, 1), Theme.panel)
       screen.text(content.x, y, title.upcase, Theme.focus_gold, Theme.panel, Attribute::Bold, width: content.w)
+      screen.text(content.x + title.size + 1, y, "● unsaved", Theme.yellow, Theme.panel, width: {content.right - content.x - title.size - 1, 1}.max) if dirty
     end
 
     private def draw_opener(screen : Screen, content : Rect, sec : SettingsCatalog::Section, y : Int32, focused : Bool) : Nil

--- a/src/gori/tui/project_picker.cr
+++ b/src/gori/tui/project_picker.cr
@@ -219,9 +219,11 @@ module Gori::Tui
     # pre-project). ^C still quits the picker.
     private def handle_preferences(ev : Termisu::Event::Key) : Project | Symbol | Nil
       return :quit if ev.ctrl_c?
+      @preedit = "" # a committed key ends any in-progress IME composition (the modal owns its own)
       outcome = @preferences.handle_key(ev)
       case outcome.kind
       when :close then @mode = :list
+      when :saved then @resized = true # a saved Display/Layout pref may change how the picker draws
       when :open
         if outcome.section == :theme
           @theme_card.reload(:theme)

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -207,6 +207,7 @@ module Gori::Tui
       # The settings editor (palette → settings:network); @overlay is :settings.
       @settings_view = SettingsView.new
       @preferences = PreferencesView.new # the unified grouped settings modal (Ctrl+, / ⚙ / palette)
+      @prefs_return = false              # a dedicated editor was opened FROM the modal → return to it on close
       # The tab-bar customizer (palette → settings:tabs); @overlay is :tabs. Distinct
       # from @tabs (the controller registry built below).
       @tabs_overlay = TabsOverlay.new
@@ -1026,11 +1027,17 @@ module Gori::Tui
       return handle_issue_picker_key(ev) if @overlay == :issue_pick
       return handle_note_picker_key(ev) if @overlay == :note_pick
       return handle_preferences_key(ev) if @overlay == :preferences
-      return handle_settings_key(ev) if @overlay == :settings
-      return handle_tabs_key(ev) if @overlay == :tabs
-      return handle_hosts_key(ev) if @overlay == :hosts
-      return handle_env_key(ev) if @overlay == :env
-      return handle_hotkeys_key(ev) if @overlay == :hotkeys
+      if PREFS_SUB_EDITORS.includes?(@overlay)
+        case @overlay
+        when :settings then handle_settings_key(ev)
+        when :tabs     then handle_tabs_key(ev)
+        when :hosts    then handle_hosts_key(ev)
+        when :env      then handle_env_key(ev)
+        when :hotkeys  then handle_hotkeys_key(ev)
+        end
+        settle_sub_editor # closing one opened from Preferences lands back in the modal
+        return
+      end
       return handle_notifications_key(ev) if @overlay == :notifications
       return handle_mine_config_key(ev) if @overlay == :mine_config
       return handle_probe_active_key(ev) if @overlay == :probe_active
@@ -1398,11 +1405,11 @@ module Gori::Tui
       when :note_pick        then click_note_picker(area, mx, my)
       when :confirm          then click_confirm(area, mx, my)
       when :preferences      then apply_preferences_outcome(@preferences.click(area, mx, my))
-      when :settings         then click_settings(area, mx, my)
-      when :tabs             then click_tabs(area, mx, my)
-      when :hosts            then click_hosts(area, mx, my)
-      when :env              then click_env(area, mx, my)
-      when :hotkeys          then click_hotkeys(area, mx, my)
+      when :settings         then (click_settings(area, mx, my); settle_sub_editor)
+      when :tabs             then (click_tabs(area, mx, my); settle_sub_editor)
+      when :hosts            then (click_hosts(area, mx, my); settle_sub_editor)
+      when :env              then (click_env(area, mx, my); settle_sub_editor)
+      when :hotkeys          then (click_hotkeys(area, mx, my); settle_sub_editor)
       when :notifications    then click_notifications(area, mx, my)
       when :mine_config      then click_mine_config(area, mx, my)
       when :probe_active     then click_probe_active(area, mx, my)
@@ -5451,6 +5458,7 @@ module Gori::Tui
     # editors from opener rows, so the picker builds its view with allow_openers: false.
     def open_preferences(section : Symbol? = nil) : Nil
       section ? @preferences.open(section) : @preferences.open_default
+      @prefs_return = false # a fresh open — not a hop out to a sub-editor and back
       @overlay = :preferences
     end
 
@@ -5458,14 +5466,35 @@ module Gori::Tui
       apply_preferences_outcome(@preferences.handle_key(ev))
     end
 
-    # Act on what the modal asked for: close, live-apply a save (via the shared
-    # apply_settings_saved seam), or open a dedicated editor (theme/tabs/hosts/env/hotkeys).
+    # Act on what the modal asked for: close, jump to the palette, live-apply a save (via
+    # the shared apply_settings_saved seam), or open a dedicated editor
+    # (theme/tabs/hosts/env/hotkeys) — flagged so that editor returns INTO the modal.
     private def apply_preferences_outcome(outcome : PreferencesView::Outcome) : Nil
       case outcome.kind
-      when :close then @overlay = :none
-      when :saved then @toast = apply_settings_saved(outcome.section.not_nil!, outcome.message || "")
-      when :open  then open_settings(outcome.section.not_nil!)
+      when :close   then @overlay = :none
+      when :palette then (@overlay = :none; open_palette)
+      when :saved   then @toast = apply_settings_saved(outcome.section.not_nil!, outcome.message || "")
+      when :open
+        @prefs_return = true
+        open_settings(outcome.section.not_nil!)
       end
+    end
+
+    # The dedicated editors reachable from a Preferences opener row. Each closes by setting
+    # @overlay = :none from a handful of places, so rather than patch every close site the
+    # dispatch chokepoints below redirect that :none back INTO the modal it was opened from
+    # — otherwise ↵-ing into Theme and pressing esc drops you out of settings entirely,
+    # while the project picker (which does return to the modal) behaves differently.
+    PREFS_SUB_EDITORS = {:settings, :tabs, :hosts, :env, :hotkeys}
+
+    private def settle_sub_editor : Nil
+      return unless @prefs_return
+      # Still editing, chained into another editor, or raising a confirm the editor set a
+      # `return_to:` for (^R reset / tab-bar reset) — the flag has to survive all three.
+      return if PREFS_SUB_EDITORS.includes?(@overlay) || @overlay == :confirm
+      @overlay = :preferences if @overlay == :none # a ^P jump to the palette still wins
+      @preferences.refresh(:network)               # the Hostnames editor moves Network's "N entries" row
+      @prefs_return = false
     end
 
     # Live-apply a just-saved settings section and return the toast to show. The ONE seam

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -139,6 +139,7 @@ module Gori::Tui
 
     def initialize
       @values = ["", "", ""]
+      @baseline = [] of String # last persisted/loaded values — @values != @baseline means unsaved
       @focused = 0
       @cursor = 0
       @preedit = ""
@@ -171,7 +172,15 @@ module Gori::Tui
       @preedit = ""
       @status = nil
       @saved = false
+      @baseline = @values.dup
       @theme_scroll = 0 # render scrolls to the selected theme on the first frame
+    end
+
+    # True when the working copy differs from what was last loaded/persisted. The
+    # Preferences modal stacks several sections but ↵ saves only the focused one, so it
+    # needs this to flag an edited-but-unsaved section instead of dropping it on esc.
+    def dirty? : Bool
+      @values != @baseline
     end
 
     # Revert the working copy of the CURRENT section to its factory defaults (the values a
@@ -506,6 +515,7 @@ module Gori::Tui
     private def persist : String
       ok = Settings.save
       @saved = ok
+      @baseline = @values.dup if ok # the working copy IS the persisted state now → no longer dirty
       @status = ok ? "saved" : "save failed"
       ok ? "settings saved" : "settings: save failed (could not write #{Settings.path})"
     end


### PR DESCRIPTION
Five bugs found reviewing #255 (the unified Preferences modal).

### 1. No way back from a dedicated editor

↵ on an opener row (Theme / Tabs / Env / Hotkeys, and Network's Hostname-overrides field) handed off to the dedicated overlay, which closes with `@overlay = :none` — dropping you out of settings entirely. The project picker *already* returned to the modal, so the two surfaces #255 set out to unify behaved differently.

Rather than patch the dozen close sites, the key/click dispatch chokepoints now redirect that `:none` back into the modal when `@prefs_return` says it was opened from there. The flag survives editor→editor chaining and the `return_to:` confirms (^R reset / tab-bar reset); a `^P` jump to the palette still wins.

### 2. Unsaved edits were dropped silently

The modal stacks several sections but ↵ saves only the focused one — so editing General, arrowing into Notifications and pressing esc lost the first section with no signal. A hazard the old single-section overlay didn't have.

Sections now carry a dirty flag (`SettingsView#dirty?`, baseline captured on `reload`/`persist`): an edited section shows `● unsaved` in its subheader, and the first esc (or click-outside) names what would be lost while the second discards.

### 3. `^P` was dead in the modal

Every other overlay jumps to the palette with it; this one swallowed it. Now returns a `:palette` Outcome the host acts on.

### 4. `Ctrl+,` only opened, never closed

The chord now toggles.

### 5. Invisible-but-input-capturing modal on a short terminal

Under ~12 rows the modal rendered nothing while still holding all input — indistinguishable from a frozen app. Draws a minimal `terminal too small · esc` card instead.

---

Also: returning from the Hostnames editor refreshes Network's "N entries" summary row (skipped when that form is dirty, so it can't clobber typed input), and the picker repaints after a save + clears any stale IME preedit.

## Gotchas worth knowing

- `^P`/`Ctrl+,` must be claimed **before** the `return handle_strip_key … if @on_strip` line or they're dead on the group strip. Caught by spec, not by eye.
- `settle_sub_editor` must treat `@overlay == :confirm` as transparent — the ^R-reset and tab-bar-reset confirms use `return_to:`, so clearing the flag there would break the return path.

## Testing

New `spec/tui/preferences_view_spec.cr` (8 examples) covers the discard guard, its one-keystroke expiry, the strip's esc/↑ path, reopen-clears-dirty, both chords, and opener gating. `PreferencesView` turns out to be unit-testable — it needs no host, only `Settings`/`Theme`.

Verified end-to-end in tmux: theme card returns to the modal with focus intact, the Hostnames chain returns *and* refreshes the summary row, the esc guard warns then discards, `Ctrl+,` toggles.

`2243 examples, 8 failures` — the 8 are the pre-existing sandbox port-binding ones (`project_registry_spec` / `capture_status_spec`), reproduced on a clean tree first. `ameba` count unchanged (66 before and after).

## Follow-up

`docs/content/guide/settings.md` documents the modal's keys, and three of these fixes change them (^P, Ctrl+,, the esc guard). That page lives on `hahwul/docs-settings-modal-guide` and isn't merged yet, so it needs an edit once that branch lands.