### PR TITLE
feat(tui): top/status bar split, clickable chrome, centered import popup

### DIFF
--- a/spec/tui/foundation_spec.cr
+++ b/spec/tui/foundation_spec.cr
@@ -177,12 +177,12 @@ describe Gori::Tui::Chrome do
     backend = MemoryBackend.new(90, 1)
     Chrome.render_status(Screen.new(backend), Rect.new(0, 0, 90, 1),
       focus: "BODY", hints: "↹ pane · esc tabs",
-      activity: {"scanning", Theme.accent}, resource: "CPU  12% MEM 48M")
+      activity: {"scanning", Theme.accent}, resource: "CPU 12% MEM 48M")
     row = backend.row(0)
-    res_x = row.index("CPU  12%").not_nil!
+    res_x = row.index("CPU 12%").not_nil!
     row.index("scanning").not_nil!.should be < res_x # activity sits to its left
     # …and the readout ends flush against render_chips' one-column right pad.
-    (res_x + "CPU  12% MEM 48M".size).should eq(90 - 1)
+    (res_x + "CPU 12% MEM 48M".size).should eq(90 - 1)
     backend.fg_at(res_x, 0).should eq(Theme.muted) # a passive readout, not an alert
   end
 
@@ -192,6 +192,18 @@ describe Gori::Tui::Chrome do
       focus: "BODY", hints: "↹ pane · esc tabs", resource: nil)
     backend.contains?("CPU").should be_false
     backend.contains?("MEM").should be_false
+  end
+
+  it "anchors the clock at the far right of the status bar, right of the resource readout" do
+    backend = MemoryBackend.new(90, 1)
+    Chrome.render_status(Screen.new(backend), Rect.new(0, 0, 90, 1),
+      focus: "BODY", hints: "↹ pane · esc tabs", resource: "CPU 12% MEM 48M", time: "01:37 PM")
+    row = backend.row(0)
+    tx = row.index("01:37 PM").not_nil!
+    row.index("CPU 12%").not_nil!.should be < tx # the readout stays left of the clock
+    (tx + "01:37 PM".size).should eq(90 - 1)      # flush against the one-column right pad
+    backend.fg_at(tx, 0).should eq(Theme.muted)
+    backend.bg_at(tx, 0).should eq(Theme.panel) # nothing on this bar is a button
   end
 
   it "gilds the shell only for single-pane body focus" do
@@ -252,27 +264,51 @@ describe Gori::Tui::Chrome do
     backend.fg_at(9, 0).should eq(Theme.text_bright)    # active label ink on the band
   end
 
-  it "renders the top bar with project, scope, and the right-aligned clock" do
+  it "renders the top bar with project and scope, and no clock (it moved to the status bar)" do
     backend = MemoryBackend.new(80, 1)
     screen = Screen.new(backend)
     Chrome.render_top_bar(screen, Rect.new(0, 0, 80, 1),
-      project: "acme", listen: "127.0.0.1:8080", time: "01:37 PM", scope: "scope:2")
+      project: "acme", listen: "127.0.0.1:8080", scope: "scope:2")
     backend.row(0).should contain("𝓰𝓸𝓻𝓲")
     backend.row(0).should contain("acme")
     backend.row(0).should contain("scope:2")
-    backend.row(0).should contain("01:37 PM")
     backend.row(0).should contain("⌘")              # far-right palette affordance
     backend.row(0).should contain("127.0.0.1:8080") # listen address always shown, capture state rides its colour
     backend.row(0).should_not contain("notify")     # no unread → badge omitted
+    # The bar is actions-only now; a wall clock isn't pressable, so it lives on the status bar.
+    backend.contains?("PM").should be_false
+  end
+
+  it "leaves every top-bar chip flush on the bar background (no button tint)" do
+    # A lifted band on the clickable chips was tried and dropped — it only pays for itself
+    # alongside a hover highlight, which termisu can't report. Clickability is metadata for
+    # the hit-test, not a paint. This pins that so the tint doesn't creep back.
+    backend = MemoryBackend.new(80, 1)
+    Chrome.render_top_bar(Screen.new(backend), Rect.new(0, 0, 80, 1),
+      project: "acme", listen: "127.0.0.1:8080", scope: "scope:2", probe: "probe:passive",
+      sandbox: "sandbox")
     row = backend.row(0)
-    row.index("01:37 PM").not_nil!.should be < row.index("⌘").not_nil! # clock left of palette
+    {"scope:2", "probe:passive", "127.0.0.1:8080", "⌘", "⚙", "sandbox"}.each do |label|
+      x = row.index(label).not_nil!
+      backend.bg_at(x, 0).should eq(Theme.bg)
+    end
+  end
+
+  it "colours the probe chip by mode, mirroring the Probe tab's mode band" do
+    {"probe:off" => Theme.muted, "probe:passive" => Theme.accent, "probe:active" => Theme.orange}.each do |label, want|
+      backend = MemoryBackend.new(80, 1)
+      Chrome.render_top_bar(Screen.new(backend), Rect.new(0, 0, 80, 1),
+        project: "acme", listen: "127.0.0.1:8080", scope: "scope:2", probe: label)
+      x = backend.row(0).index(label).not_nil!
+      backend.fg_at(x, 0).should eq(want)
+    end
   end
 
   it "shows the unread notify badge on the top bar, left of scope" do
     backend = MemoryBackend.new(80, 1)
     screen = Screen.new(backend)
     Chrome.render_top_bar(screen, Rect.new(0, 0, 80, 1),
-      project: "acme", listen: "127.0.0.1:8080", time: "01:37 PM", scope: "scope:2", unread: 3)
+      project: "acme", listen: "127.0.0.1:8080", scope: "scope:2", unread: 3)
     backend.row(0).should contain("notify:3")
     row = backend.row(0)
     row.index("notify:3").not_nil!.should be < row.index("scope:2").not_nil!
@@ -290,7 +326,7 @@ describe Gori::Tui::Chrome do
   it "colours the top-bar listen chip green while capturing (address text unchanged)" do
     backend = MemoryBackend.new(80, 1)
     Chrome.render_top_bar(Screen.new(backend), Rect.new(0, 0, 80, 1),
-      project: "acme", listen: "127.0.0.1:8080", time: "01:37 PM", scope: "scope:2", capturing: true)
+      project: "acme", listen: "127.0.0.1:8080", scope: "scope:2", capturing: true)
     backend.row(0).should contain("127.0.0.1:8080")
     fx = backend.row(0).index("127.0.0.1:8080").not_nil!
     backend.fg_at(fx, 0).should eq(Theme.green)
@@ -300,7 +336,7 @@ describe Gori::Tui::Chrome do
   it "dims the top-bar listen chip when capture is paused" do
     backend = MemoryBackend.new(80, 1)
     Chrome.render_top_bar(Screen.new(backend), Rect.new(0, 0, 80, 1),
-      project: "acme", listen: "127.0.0.1:8080", time: "01:37 PM", scope: "scope:2", capturing: false)
+      project: "acme", listen: "127.0.0.1:8080", scope: "scope:2", capturing: false)
     fx = backend.row(0).index("127.0.0.1:8080").not_nil!
     backend.fg_at(fx, 0).should eq(Theme.muted)
   end
@@ -308,7 +344,7 @@ describe Gori::Tui::Chrome do
   it "turns the top-bar listen chip red with the drop count when writes are failing" do
     backend = MemoryBackend.new(80, 1)
     Chrome.render_top_bar(Screen.new(backend), Rect.new(0, 0, 80, 1),
-      project: "acme", listen: "127.0.0.1:8080", time: "01:37 PM", scope: "scope:2",
+      project: "acme", listen: "127.0.0.1:8080", scope: "scope:2",
       capturing: true, write_failures: 4)
     backend.row(0).should contain("127.0.0.1:8080 (4)")
     fx = backend.row(0).index("127.0.0.1:8080").not_nil!

--- a/spec/tui/import_overlay_spec.cr
+++ b/spec/tui/import_overlay_spec.cr
@@ -1,0 +1,89 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+private def key(k : Termisu::Input::Key, char : Char? = nil) : Termisu::Event::Key
+  Termisu::Event::Key.new(k, Termisu::Input::Modifier::None, char)
+end
+
+private def type(ov : ImportOverlay, text : String) : Nil
+  text.each_char { |c| ov.handle_key(key(Termisu::Input::Key::Unknown, c)) }
+end
+
+describe Gori::Tui::ImportOverlay do
+  it "titles and describes the card by import kind" do
+    {:har => "HAR", :urls => "URLs", :oas => "OpenAPI"}.each do |kind, want|
+      ov = ImportOverlay.new(kind)
+      ov.label.should eq(want)
+      backend = MemoryBackend.new(100, 30)
+      ov.render(Screen.new(backend), Rect.new(0, 0, 100, 30))
+      backend.contains?("IMPORT #{want.upcase}").should be_true
+    end
+  end
+
+  it "centers the card in the body area" do
+    ov = ImportOverlay.new(:har)
+    area = Rect.new(0, 0, 100, 30)
+    box = ov.overlay_box(area).not_nil!
+    # Equal slack either side (within a cell, for odd remainders) — i.e. actually centered,
+    # not merely inset. This is the whole point of the change: it used to be a status row.
+    (box.x - area.x).should eq(area.right - box.right)
+    (box.y - area.y).should eq(area.bottom - box.bottom)
+    box.y.should be > area.y # NOT anchored to an edge
+  end
+
+  it "declines to draw a phantom box when the window is too small" do
+    ov = ImportOverlay.new(:har)
+    ov.overlay_box(Rect.new(0, 0, 30, 30)).should be_nil # too narrow
+    ov.overlay_box(Rect.new(0, 0, 100, 8)).should be_nil # too short
+    ov.overlay_box(Rect.new(0, 0, 0, 0)).should be_nil
+  end
+
+  it "collects a typed path and submits it on enter" do
+    ov = ImportOverlay.new(:har)
+    type(ov, "/tmp/x.har")
+    ov.path.should eq("/tmp/x.har")
+    ov.handle_key(key(Termisu::Input::Key::Enter)).should eq(:submit)
+  end
+
+  it "cancels on esc" do
+    ov = ImportOverlay.new(:har)
+    ov.handle_key(key(Termisu::Input::Key::Escape)).should eq(:cancel)
+  end
+
+  it "renders the typed path inside the card" do
+    ov = ImportOverlay.new(:urls)
+    type(ov, "/tmp/urls.txt")
+    backend = MemoryBackend.new(100, 30)
+    ov.render(Screen.new(backend), Rect.new(0, 0, 100, 30))
+    backend.contains?("/tmp/urls.txt").should be_true
+    backend.contains?("Path").should be_true
+  end
+
+  it "leaves the caret at the end of a tab-completed path, so typing continues after it" do
+    # REGRESSION: the completion applied but the caret stayed where it was, mid-path, so
+    # the next keystroke landed inside the filename. Driven end-to-end through handle_key
+    # (not just TextField#set) so the whole accept path stays covered.
+    dir = File.join(Dir.tempdir, "gori-import-spec-#{Process.pid}")
+    Dir.mkdir_p(dir)
+    File.write(File.join(dir, "sample.har"), "{}")
+    begin
+      ov = ImportOverlay.new(:har)
+      type(ov, "#{dir}/")                              # opens the dropdown on sample.har
+      ov.handle_key(key(Termisu::Input::Key::Tab))     # accept the completion
+      ov.path.should eq(File.join(dir, "sample.har"))  # applied…
+      type(ov, "X")                                    # …and the caret is at the END
+      ov.path.should eq(File.join(dir, "sample.harX")) # not "sample.Xhar" or similar
+    ensure
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  it "consumes clicks inside the card but reports those outside (click-away dismisses)" do
+    ov = ImportOverlay.new(:har)
+    box = ov.overlay_box(Rect.new(0, 0, 100, 30)).not_nil!
+    ov.handle_click(box, box.x + 2, box.y + 3).should be_true
+    ov.handle_click(box, box.x - 1, box.y).should be_false
+  end
+end

--- a/spec/tui/mouse_spec.cr
+++ b/spec/tui/mouse_spec.cr
@@ -308,17 +308,17 @@ describe "InterceptView#bar_zone_at" do
   end
 end
 
-describe "Chrome.top_bar_chip_rect" do
+describe "Chrome top-bar chip hit-testing" do
   it "returns nil for :notify when there's no unread, and a rect matching the drawn badge otherwise" do
     rect = Rect.new(0, 0, 80, 1)
     Chrome.top_bar_chip_rect(rect, :notify, scope: "scope:2", listen: "127.0.0.1:8080",
-      time: "01:37 PM", unread: 0).should be_nil
+      unread: 0).should be_nil
 
     backend = MemoryBackend.new(80, 1)
     Chrome.render_top_bar(Screen.new(backend), rect,
-      project: "acme", listen: "127.0.0.1:8080", time: "01:37 PM", scope: "scope:2", unread: 3)
+      project: "acme", listen: "127.0.0.1:8080", scope: "scope:2", unread: 3)
     nrect = Chrome.top_bar_chip_rect(rect, :notify, scope: "scope:2", listen: "127.0.0.1:8080",
-      time: "01:37 PM", unread: 3).not_nil!
+      unread: 3).not_nil!
     backend.row(0)[nrect.x, nrect.w].should eq("notify:3")
   end
 
@@ -326,62 +326,96 @@ describe "Chrome.top_bar_chip_rect" do
     rect = Rect.new(0, 0, 80, 1)
     backend = MemoryBackend.new(80, 1)
     Chrome.render_top_bar(Screen.new(backend), rect,
-      project: "acme", listen: "127.0.0.1:8080", time: "01:37 PM", scope: "scope:2")
-    srect = Chrome.top_bar_chip_rect(rect, :scope, scope: "scope:2", listen: "127.0.0.1:8080",
-      time: "01:37 PM").not_nil!
+      project: "acme", listen: "127.0.0.1:8080", scope: "scope:2")
+    srect = Chrome.top_bar_chip_rect(rect, :scope, scope: "scope:2",
+      listen: "127.0.0.1:8080").not_nil!
     backend.row(0)[srect.x, srect.w].should eq("scope:2")
 
     backend2 = MemoryBackend.new(80, 1)
     Chrome.render_top_bar(Screen.new(backend2), rect,
-      project: "acme", listen: "127.0.0.1:8080", time: "01:37 PM", scope: "scope:off")
-    srect2 = Chrome.top_bar_chip_rect(rect, :scope, scope: "scope:off", listen: "127.0.0.1:8080",
-      time: "01:37 PM").not_nil!
+      project: "acme", listen: "127.0.0.1:8080", scope: "scope:off")
+    srect2 = Chrome.top_bar_chip_rect(rect, :scope, scope: "scope:off",
+      listen: "127.0.0.1:8080").not_nil!
     backend2.row(0)[srect2.x, srect2.w].should eq("scope:off")
   end
 
   it "keeps notify/scope hit-test rects in sync with the drawn row even when the project name is squeezed" do
-    # Narrow rect: chips (notify:3 · scope:99 · 127.0.0.1:8080 · 01:37 PM · ⌘) leave the
+    # Narrow rect: chips (notify:3 · scope:99 · 127.0.0.1:8080 · ⌘ · ⚙) leave the
     # project name almost no room — exercises the "name squeezed to zero width" branch.
     rect = Rect.new(0, 0, 45, 1)
     backend = MemoryBackend.new(45, 1)
     Chrome.render_top_bar(Screen.new(backend), rect,
-      project: "a very long project name", listen: "127.0.0.1:8080", time: "01:37 PM",
+      project: "a very long project name", listen: "127.0.0.1:8080",
       scope: "scope:99", unread: 3)
 
     nrect = Chrome.top_bar_chip_rect(rect, :notify, scope: "scope:99", listen: "127.0.0.1:8080",
-      time: "01:37 PM", unread: 3).not_nil!
+      unread: 3).not_nil!
     backend.row(0)[nrect.x, nrect.w].should eq("notify:3")
 
     srect = Chrome.top_bar_chip_rect(rect, :scope, scope: "scope:99", listen: "127.0.0.1:8080",
-      time: "01:37 PM", unread: 3).not_nil!
+      unread: 3).not_nil!
     backend.row(0)[srect.x, srect.w].should eq("scope:99")
   end
 
-  it "returns a rect matching the drawn far-right palette chip (⌘)" do
+  it "returns a rect matching the drawn far-right palette chip (⌘), right of the listen chip" do
     rect = Rect.new(0, 0, 80, 1)
     backend = MemoryBackend.new(80, 1)
     Chrome.render_top_bar(Screen.new(backend), rect,
-      project: "acme", listen: "127.0.0.1:8080", time: "01:37 PM", scope: "scope:2")
-    prect = Chrome.top_bar_chip_rect(rect, :palette, scope: "scope:2", listen: "127.0.0.1:8080",
-      time: "01:37 PM").not_nil!
-    backend.row(0)[prect.x, prect.w].should eq("⌘")
-    # Right of the clock chip.
-    trect = Chrome.top_bar_chip_rect(rect, :time, scope: "scope:2", listen: "127.0.0.1:8080",
-      time: "01:37 PM").not_nil!
-    prect.x.should be > trect.x
+      project: "acme", listen: "127.0.0.1:8080", scope: "scope:2")
+    prect = Chrome.top_bar_chip_rect(rect, :palette, scope: "scope:2",
+      listen: "127.0.0.1:8080").not_nil!
+    backend.row(0)[prect.x, prect.w].should contain("⌘")
+    lrect = Chrome.top_bar_chip_rect(rect, :listen, scope: "scope:2",
+      listen: "127.0.0.1:8080").not_nil!
+    prect.x.should be > lrect.x
   end
 
   it "returns a rect matching the drawn far-right settings chip (⚙), right of ⌘" do
     rect = Rect.new(0, 0, 80, 1)
     backend = MemoryBackend.new(80, 1)
     Chrome.render_top_bar(Screen.new(backend), rect,
-      project: "acme", listen: "127.0.0.1:8080", time: "01:37 PM", scope: "scope:2")
-    grect = Chrome.top_bar_chip_rect(rect, :settings, scope: "scope:2", listen: "127.0.0.1:8080",
-      time: "01:37 PM").not_nil!
+      project: "acme", listen: "127.0.0.1:8080", scope: "scope:2")
+    grect = Chrome.top_bar_chip_rect(rect, :settings, scope: "scope:2",
+      listen: "127.0.0.1:8080").not_nil!
     backend.row(0)[grect.x, grect.w].should contain("⚙")
-    prect = Chrome.top_bar_chip_rect(rect, :palette, scope: "scope:2", listen: "127.0.0.1:8080",
-      time: "01:37 PM").not_nil!
+    prect = Chrome.top_bar_chip_rect(rect, :palette, scope: "scope:2",
+      listen: "127.0.0.1:8080").not_nil!
     grect.x.should be > prect.x # ⚙ sits to the right of ⌘
+  end
+
+  it "resolves a click to the chip's tag, and ignores passive readouts" do
+    # 110 cols: every optional chip is present at once here (notify + sandbox on top of the
+    # always-on ones), which overflows an 80-col bar — see the overflow spec below.
+    rect = Rect.new(0, 0, 110, 1)
+    args = {scope: "scope:2", probe: "probe:passive", sandbox: "sandbox",
+            listen: "127.0.0.1:8080", unread: 3}
+    {:notify, :scope, :probe, :listen, :palette, :settings}.each do |tag|
+      r = Chrome.top_bar_chip_rect(rect, tag, **args).not_nil!
+      Chrome.top_bar_chip_at(rect, r.x, 0, **args).should eq(tag)
+      # The whole label responds, not just its first cell.
+      Chrome.top_bar_chip_at(rect, r.right - 1, 0, **args).should eq(tag)
+    end
+    # The sandbox chip is a display-only warning — clicking it must fall through.
+    srect = Chrome.top_bar_chip_rect(rect, :sandbox, **args).not_nil!
+    Chrome.top_bar_chip_at(rect, srect.x, 0, **args).should be_nil
+    # Off the bar entirely.
+    Chrome.top_bar_chip_at(rect, 0, 1, **args).should be_nil
+  end
+
+  # The chip run is right-anchored but drawn left-to-right, so when it overflows it's the
+  # RIGHTMOST chips that fall off — i.e. ⌘ and ⚙, the two affordances a mouse user most
+  # needs. That's tolerable only because the steady state fits: this pins the everyday
+  # layout (no notify, no sandbox) inside a plain 80-col terminal.
+  it "keeps the ⌘/⚙ buttons on-bar at 80 cols in the steady state" do
+    rect = Rect.new(0, 0, 80, 1)
+    args = {scope: "scope:2", probe: "probe:passive", listen: "127.0.0.1:8080"}
+    backend = MemoryBackend.new(80, 1)
+    Chrome.render_top_bar(Screen.new(backend), rect, project: "acme",
+      scope: "scope:2", probe: "probe:passive", listen: "127.0.0.1:8080")
+    backend.row(0).should contain("⌘")
+    backend.row(0).should contain("⚙")
+    Chrome.top_bar_chip_at(rect, Chrome.top_bar_chip_rect(rect, :settings, **args).not_nil!.x, 0,
+      **args).should eq(:settings)
   end
 end
 

--- a/spec/tui/resource_spec.cr
+++ b/spec/tui/resource_spec.cr
@@ -28,8 +28,9 @@ describe Gori::Tui::ResourceMeter do
       m.tick(Time.instant).should be_true
       label = m.label
       label.should_not be_nil
-      # Fixed-width CPU field, integer percent, then a rounded MiB/GiB memory figure.
-      label.not_nil!.should match(/\ACPU\s{1,3}\d{1,3}% MEM \d+(\.\d)?[MG]\z/)
+      # Unpadded integer percent (one space after CPU, always), then a rounded MiB/GiB
+      # memory figure.
+      label.not_nil!.should match(/\ACPU \d{1,3}% MEM \d+(\.\d)?[MG]\z/)
     end
   end
 
@@ -39,7 +40,7 @@ describe Gori::Tui::ResourceMeter do
       m.tick(Time.instant)
       # No previous sample to difference against, so the window is undefined → 0%, not a
       # startup spike computed from process-lifetime CPU.
-      m.label.not_nil!.should start_with("CPU   0%")
+      m.label.not_nil!.should start_with("CPU 0%")
     end
   end
 
@@ -84,7 +85,7 @@ describe Gori::Tui::ResourceMeter do
     with_meter(false) { m.tick(t0 + 1.second) }
     with_meter(true) do
       m.tick(t0 + 1.hour).should be_true
-      m.label.not_nil!.should start_with("CPU   0%")
+      m.label.not_nil!.should start_with("CPU 0%")
     end
   end
 end

--- a/spec/tui/text_field_spec.cr
+++ b/spec/tui/text_field_spec.cr
@@ -1,0 +1,37 @@
+require "../spec_helper"
+
+include Gori::Tui
+
+describe Gori::Tui::TextField do
+  it "parks the caret at the end when the value is replaced" do
+    # REGRESSION: `set` used to CLAMP the old caret into the new string
+    # (`{@caret, v.size}.min`). Replacing a value wholesale makes an offset into the
+    # PREVIOUS string meaningless, and it broke every path-completion overlay: Tab on
+    # "/tmp/imp/" → "/tmp/imp/sample.har" left the caret at 9, so the next keystroke
+    # landed mid-filename.
+    f = TextField.new("/tmp/imp/")
+    f.caret.should eq(9) # caret starts at the end of the seeded value
+    f.set("/tmp/imp/sample.har")
+    f.caret.should eq("/tmp/imp/sample.har".size)
+  end
+
+  it "parks the caret at the end even when the caret was left short of it" do
+    f = TextField.new("abcdef")
+    f.home
+    f.caret.should eq(0)
+    f.set("xyz")
+    f.caret.should eq(3) # NOT 0 — typing continues after the new value
+  end
+
+  it "keeps typing appending after a replace" do
+    f = TextField.new("/tmp/")
+    f.set("/tmp/dir/")
+    f.insert('a')
+    f.value.should eq("/tmp/dir/a") # not "/tmp/adir/" or similar mid-string damage
+  end
+
+  it "seeds the caret at the end on construction" do
+    TextField.new("hello").caret.should eq(5)
+    TextField.new.caret.should eq(0)
+  end
+end

--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -160,8 +160,15 @@ module Gori::Tui
       Rect.new(x, rect.y, w, 1)
     end
 
+    # One right-aligned bar chip. `clickable` marks the chips that act on a click; it is
+    # HIT-TEST METADATA ONLY and carries no styling. A lifted band was tried here as a
+    # "this is pressable" cue and dropped: it only earns its keep paired with a hover
+    # highlight, and termisu can't report hover (mode 1000 = press/release, no motion — see
+    # `enable_mouse`), so a permanent tint was noise rather than an affordance.
+    record Chip, tag : Symbol, label : String, color : Color, clickable : Bool = false
+
     def self.render_top_bar(screen : Screen, rect : Rect, *, project : String,
-                            listen : String, time : String,
+                            listen : String, probe : String = "",
                             scope : String, rules : String = "", intercept : String = "",
                             sandbox : String = "",
                             unread : Int32 = 0, capturing : Bool = true,
@@ -171,19 +178,20 @@ module Gori::Tui
       x = render_wordmark(screen, rect.x + 1, rect.y, bg: Theme.bg)
       name_x = x + 1
 
-      # right-aligned status chips: notify:N · scope:N · rules:N · intercept:on(N) ·
-      # ●listen · h:MM AM/PM · ⌘ — value-emphasized, dim · separators; the hot
-      # intercept state in RED. The clock is the penultimate anchor; the palette
-      # glyph (`⌘`, click → open palette) is rightmost. `unread` rides just left
-      # of scope so a background-job ping surfaces beside the state it's most
-      # likely to affect. The listen chip's address text never changes — capture
-      # on/off/failing rides as the leading dot + label colour (green/muted/red),
-      # so the one address a user glances at doubles as the capture indicator
-      # instead of a separate chip.
-      tagged = top_bar_chips(scope: scope, rules: rules, intercept: intercept, sandbox: sandbox,
-        listen: listen, time: time, unread: unread, capturing: capturing,
+      # right-aligned status chips: notify:N · scope:N · probe:MODE · rules:N ·
+      # intercept:on(N) · ●listen · ⌘ · ⚙ — value-emphasized, dim · separators; the
+      # hot intercept state in RED. `unread` rides just left of scope so a
+      # background-job ping surfaces beside the state it's most likely to affect. The
+      # listen chip's address text never changes — capture on/off/failing rides as the
+      # leading dot + label colour (green/muted/red), so the one address a user glances
+      # at doubles as the capture indicator instead of a separate chip.
+      #
+      # The bar is now ACTIONS ONLY — the passive clock moved down to the status bar (see
+      # `status_chips`), so "top-right = things you can press, bottom-right = things you can
+      # only read" holds by POSITION. Nothing here is tinted to advertise that: see `Chip`.
+      chips = top_bar_chips(scope: scope, probe: probe, rules: rules, intercept: intercept,
+        sandbox: sandbox, listen: listen, unread: unread, capturing: capturing,
         write_failures: write_failures)
-      chips = tagged.map { |(_, l, c)| {l, c} }
 
       # Bound the project name and floor the chips past it, so neither overwrites the
       # other at narrow widths (previously the name was unbounded and render_chips got
@@ -196,26 +204,47 @@ module Gori::Tui
 
     # The right-aligned top-bar chips, TAGGED so render and the click hit-test share
     # one ordered source (the geometry can't drift). Mirrors `status_chips` below.
-    private def self.top_bar_chips(*, scope : String, rules : String, intercept : String,
-                                   sandbox : String, listen : String, time : String, unread : Int32,
-                                   capturing : Bool, write_failures : Int32) : Array({Symbol, String, Color})
-      chips = [] of {Symbol, String, Color}
-      chips << {:notify, "notify:#{unread}", Theme.accent} if unread > 0
-      chips << {:scope, scope, scope.ends_with?(":off") ? Theme.muted : Theme.text} unless scope.empty?
+    private def self.top_bar_chips(*, scope : String, probe : String, rules : String,
+                                   intercept : String, sandbox : String, listen : String,
+                                   unread : Int32, capturing : Bool,
+                                   write_failures : Int32) : Array(Chip)
+      chips = [] of Chip
+      chips << Chip.new(:notify, "notify:#{unread}", Theme.accent, clickable: true) if unread > 0
+      unless scope.empty?
+        chips << Chip.new(:scope, scope, scope.ends_with?(":off") ? Theme.muted : Theme.text,
+          clickable: true)
+      end
       # Sandbox rides right of scope (they're the same lens' policy) and in RED — a block gate
       # must read as hot, like intercept.
-      chips << {:sandbox, sandbox, Theme.red} unless sandbox.empty?
-      chips << {:rules, rules, Theme.text} unless rules.empty?
-      chips << {:intercept, intercept, Theme.red} unless intercept.empty?
+      chips << Chip.new(:sandbox, sandbox, Theme.red) unless sandbox.empty?
+      # Probe mode mirrors scope: it's a global lens over captured traffic, so it belongs
+      # beside scope on the bar rather than only inside the Probe tab's mode band. Click
+      # opens the same SET PROBE MODE picker the `m` chord does. Muted when off (nothing is
+      # scanning), accent while passive, orange once active probes are in flight — the same
+      # colour ladder ProbeView#mode_color uses, so the two readouts can't disagree.
+      chips << Chip.new(:probe, probe, probe_chip_color(probe), clickable: true) unless probe.empty?
+      chips << Chip.new(:rules, rules, Theme.text) unless rules.empty?
+      chips << Chip.new(:intercept, intercept, Theme.red) unless intercept.empty?
       label, color = listen_chip(listen, capturing, write_failures)
-      chips << {:listen, label, color}
-      chips << {:time, time, Theme.muted}
+      # Clickable: toggles capture on/off, the same action as the `bind`/capture verb — the
+      # dot the user is already reading for capture state is the natural thing to press.
+      chips << Chip.new(:listen, label, color, clickable: true)
       # Far-right affordances — same actions as their chords, always present so a mouse
       # user can reach them without knowing the keys: ⌘ opens the command palette
       # (Ctrl/Cmd-P), ⚙ opens the unified Preferences modal (Ctrl+,).
-      chips << {:palette, "⌘", Theme.text}
-      chips << {:settings, "⚙", Theme.text}
+      chips << Chip.new(:palette, "⌘", Theme.text, clickable: true)
+      chips << Chip.new(:settings, "⚙", Theme.text, clickable: true)
       chips
+    end
+
+    # The probe chip's colour ladder, keyed off the label's mode suffix so it stays in
+    # lockstep with `ProbeView#mode_color` without reaching into the Probe module here.
+    private def self.probe_chip_color(probe : String) : Color
+      case
+      when probe.ends_with?(":off")    then Theme.muted
+      when probe.ends_with?(":active") then Theme.orange
+      else                                  Theme.accent
+      end
     end
 
     # Label + colour for the merged listen/capture chip. The address (`listen`)
@@ -240,17 +269,39 @@ module Gori::Tui
     # itself bounded by the same floor. `chip_layout`'s `{A, min_x}.max` picks the
     # right one either way, so passing `name_x + 1` here matches the real render
     # exactly regardless of the actual project string or its truncation.
-    def self.top_bar_chip_rect(rect : Rect, tag : Symbol, *, scope : String, rules : String = "",
-                               intercept : String = "", sandbox : String = "", listen : String, time : String,
-                               unread : Int32 = 0, capturing : Bool = true,
+    def self.top_bar_chip_rect(rect : Rect, tag : Symbol, *, scope : String, probe : String = "",
+                               rules : String = "", intercept : String = "", sandbox : String = "",
+                               listen : String, unread : Int32 = 0, capturing : Bool = true,
                                write_failures : Int32 = 0) : Rect?
-      tagged = top_bar_chips(scope: scope, rules: rules, intercept: intercept, sandbox: sandbox,
-        listen: listen, time: time, unread: unread, capturing: capturing,
+      chips = top_bar_chips(scope: scope, probe: probe, rules: rules, intercept: intercept,
+        sandbox: sandbox, listen: listen, unread: unread, capturing: capturing,
         write_failures: write_failures)
-      idx = tagged.index { |(t, _, _)| t == tag }
+      idx = chips.index { |c| c.tag == tag }
       return nil unless idx
       name_x = rect.x + 1 + Screen.display_width(WORDMARK) + 1
-      chip_layout(rect, tagged.map { |(_, l, c)| {l, c} }, name_x + 1)[idx]?
+      chip_layout(rect, chips, name_x + 1)[idx]?
+    end
+
+    # Which clickable top-bar chip (if any) covers `mx,my` — ONE pass over the same
+    # tagged list, replacing the per-tag `top_bar_chip_rect` calls the runner used to
+    # make (one full rebuild per candidate tag). Non-clickable chips are skipped so a
+    # click on the sandbox/rules readout falls through instead of being swallowed.
+    def self.top_bar_chip_at(rect : Rect, mx : Int32, my : Int32, *, scope : String,
+                             probe : String = "", rules : String = "", intercept : String = "",
+                             sandbox : String = "", listen : String, unread : Int32 = 0,
+                             capturing : Bool = true, write_failures : Int32 = 0) : Symbol?
+      return nil unless rect.contains?(mx, my)
+      chips = top_bar_chips(scope: scope, probe: probe, rules: rules, intercept: intercept,
+        sandbox: sandbox, listen: listen, unread: unread, capturing: capturing,
+        write_failures: write_failures)
+      name_x = rect.x + 1 + Screen.display_width(WORDMARK) + 1
+      rects = chip_layout(rect, chips, name_x + 1)
+      chips.each_with_index do |chip, i|
+        next unless chip.clickable
+        r = rects[i]?
+        return chip.tag if r && r.contains?(mx, my)
+      end
+      nil
     end
 
     # A horizontal tab menu (row 2) styled as a segmented control. The active tab
@@ -470,21 +521,25 @@ module Gori::Tui
     # intact at narrow widths); each draw is clipped to `rect.right` so an
     # over-wide chip row truncates with an ellipsis instead of bleeding past it.
     private def self.render_chips(screen : Screen, rect : Rect,
-                                  chips : Array({String, Color}), bg : Color = Theme.panel,
+                                  chips : Array(Chip), bg : Color = Theme.panel,
                                   min_x : Int32? = nil) : Nil
       return if chips.empty?
       x = {rect.right - chips_width(chips) - 1, min_x || rect.x}.max
-      chips.each_with_index do |(label, color), i|
+      chips.each_with_index do |chip, i|
         break if x >= rect.right
-        x = screen.text(x, rect.y, label, color, bg, width: {rect.right - x, 1}.max)
+        x = screen.text(x, rect.y, chip.label, chip.color, bg, width: {rect.right - x, 1}.max)
         if i < chips.size - 1 && x < rect.right
           x = screen.text(x, rect.y, " · ", Theme.muted, bg, width: {rect.right - x, 1}.max)
         end
       end
     end
 
-    private def self.chips_width(chips : Array({String, Color})) : Int32
-      chips.sum { |(label, _)| label.size } + 3 * {chips.size - 1, 0}.max
+    # Total drawn width. Uses DISPLAY width, not `String#size`: the bar carries non-ASCII
+    # glyphs (`⌘`, `⚙`, the listen dot) whose codepoint count and column count can differ,
+    # and `screen.text` advances by display width — measuring any other way would drift the
+    # right-anchor (and every hit rect with it) by a cell per wide glyph.
+    private def self.chips_width(chips : Array(Chip)) : Int32
+      chips.sum { |c| Screen.display_width(c.label) } + 3 * {chips.size - 1, 0}.max
     end
 
     # Inline badge for the held-intercept count — the one hot state worth flagging
@@ -501,13 +556,14 @@ module Gori::Tui
     # rides the top bar's listen chip; upstream TLS verification is now a settings:network
     # toggle, not a status chip.)
     def self.render_status(screen : Screen, rect : Rect, *, focus : String, hints : String,
-                           activity : {String, Color}? = nil, resource : String? = nil) : Nil
+                           activity : {String, Color}? = nil, resource : String? = nil,
+                           time : String? = nil) : Nil
       screen.fill(rect, Theme.panel)
       badge = " #{focus} "
       screen.text(rect.x, rect.y, badge, Theme.text_bright, Theme.elevated, Attribute::Bold)
       hint_x = rect.x + badge.size + 1
 
-      chips = status_chips(activity: activity, resource: resource).map { |(_, l, c)| {l, c} }
+      chips = status_chips(activity: activity, resource: resource, time: time)
       hint_w = {rect.right - hint_x - chips_width(chips) - 2, 1}.max
       screen.text(hint_x, rect.y, hints, Theme.muted, Theme.panel, width: hint_w)
       # Floor the chips at the hint start so they can never overwrite the badge.
@@ -537,22 +593,27 @@ module Gori::Tui
     # LAST (rightmost) on purpose: it is fixed-width, so anchoring it to the right edge keeps
     # the transient activity chip from shifting the readout every time a job starts or ends.
     # It renders in `muted` — a passive readout, not a state the operator must act on.
-    private def self.status_chips(*, activity : {String, Color}?,
-                                  resource : String? = nil) : Array({Symbol, String, Color})
-      chips = [] of {Symbol, String, Color}
-      chips << {:activity, activity[0], activity[1]} if activity
-      chips << {:resource, resource, Theme.muted} if resource
+    private def self.status_chips(*, activity : {String, Color}?, resource : String? = nil,
+                                  time : String? = nil) : Array(Chip)
+      chips = [] of Chip
+      chips << Chip.new(:activity, activity[0], activity[1]) if activity
+      chips << Chip.new(:resource, resource, Theme.muted) if resource
+      # The clock anchors the far right. It moved off the top bar so that row can be read as
+      # "everything here is pressable" — a wall clock never is. Fixed-width (%I:%M %p is always
+      # 8 cells) so, like the resource readout, it never shifts the chips to its left.
+      chips << Chip.new(:time, time, Theme.muted) if time
       chips
     end
 
     # The drawn rect of each chip, computed IDENTICALLY to render_chips' x-advance, so a
-    # hit-test maps to the same cells. ASCII chips → width == label size.
-    private def self.chip_layout(rect : Rect, chips : Array({String, Color}), min_x : Int32?) : Array(Rect)
+    # hit-test maps to the same cells.
+    private def self.chip_layout(rect : Rect, chips : Array(Chip), min_x : Int32?) : Array(Rect)
       rects = [] of Rect
       x = {rect.right - chips_width(chips) - 1, min_x || rect.x}.max
-      chips.each_with_index do |(label, _), i|
-        rects << Rect.new(x, rect.y, label.size, 1)
-        x += label.size
+      chips.each_with_index do |chip, i|
+        w = Screen.display_width(chip.label)
+        rects << Rect.new(x, rect.y, w, 1)
+        x += w
         x += 3 if i < chips.size - 1 # the " · " separator
       end
       rects

--- a/src/gori/tui/import_overlay.cr
+++ b/src/gori/tui/import_overlay.cr
@@ -1,0 +1,176 @@
+require "./screen"
+require "./theme"
+require "./frame"
+require "./text_field"
+require "./path_complete"
+
+module Gori::Tui
+  # Centered popup collecting the source path for palette → "Import: HAR / URLs /
+  # OpenAPI". One path field with an inline PathComplete dropdown — CAImportOverlay's
+  # shape minus its second field.
+  #
+  # This REPLACED a one-row prompt on the status bar. A filesystem path is long and the
+  # status row is the dimmest, most cramped strip in the UI: the input got whatever was
+  # left after the prefix and hint, and the completion dropdown had to be drawn ABOVE
+  # the row (`rect.y - 9`) because there was nothing below it. Centered, the path gets a
+  # full card width and the dropdown hangs under the field where it belongs.
+  #
+  # Surfaces used by the Runner: `handle_key` returns :submit on ↵, :cancel on esc,
+  # :stay otherwise. On :submit the Runner reads `path` and runs the import.
+  class ImportOverlay
+    getter kind : Symbol
+
+    def initialize(@kind : Symbol)
+      @field = TextField.new("")
+      @path_complete = PathComplete.new
+    end
+
+    def path : String
+      @field.value.strip
+    end
+
+    # The source format, for the card title and the Runner's result toast — one source
+    # so the popup and the toast can't disagree about what was imported.
+    def label : String
+      case @kind
+      when :har  then "HAR"
+      when :urls then "URLs"
+      when :oas  then "OpenAPI"
+      else            "file"
+      end
+    end
+
+    private def blurb : String
+      case @kind
+      when :har  then "Load flows from a browser or proxy HAR export into History."
+      when :urls then "Load a text file of URLs into History — one URL per line."
+      when :oas  then "Build request templates from an OpenAPI spec into History."
+      else            "Load flows into History."
+      end
+    end
+
+    # --- input ---------------------------------------------------------------
+    # :submit when the user commits, :cancel on esc, else :stay.
+    def handle_key(ev : Termisu::Event::Key) : Symbol
+      key = ev.key
+
+      # esc peels one layer at a time: the dropdown first, the popup only once it's
+      # down — so a stray esc can't discard a long path the user just typed.
+      if key.escape?
+        return :cancel unless @path_complete.open?
+        @path_complete.close
+        return :stay
+      end
+
+      return commit_or_complete(key) if key.tab? || key.enter?
+
+      if key.back_tab? || key.up?
+        @path_complete.move(-1) if @path_complete.open?
+        return :stay
+      end
+      if key.down?
+        @path_complete.move(1) if @path_complete.open?
+        return :stay
+      end
+
+      @field.handle_edit_key(ev)
+      @path_complete.refresh(@field.value) # keep the dropdown in lockstep
+      :stay
+    end
+
+    # ↹/↵ with the dropdown up accepts the highlighted entry: a directory keeps the list
+    # open so the user can keep drilling, a file closes it — and ↵ landing on a file
+    # commits in that same keystroke rather than making the user press it twice (carried
+    # over from the old bottom prompt). With no dropdown up, ↵ submits what was typed.
+    private def commit_or_complete(key : Termisu::Input::Key) : Symbol
+      if @path_complete.open? && (res = @path_complete.accept)
+        insert, is_dir = res
+        @field.set(insert)
+        if is_dir
+          @path_complete.refresh(insert)
+        else
+          @path_complete.close
+          return :submit if key.enter?
+        end
+        return :stay
+      end
+      key.enter? ? :submit : :stay
+    end
+
+    def set_preedit(text : String) : Nil
+      @field.set_preedit(text)
+    end
+
+    # Wheel support — the Runner routes a scroll here, and the only scrollable thing is
+    # the completion list.
+    def move(d : Int32) : Nil
+      @path_complete.move(d) if @path_complete.open?
+    end
+
+    # --- rendering -----------------------------------------------------------
+    LABEL_W = 8 # value column offset ("Path" + padding)
+
+    # Tall enough (14) that PathComplete's 8-row cap fits under the field instead of
+    # being clipped; `area` still wins on a short terminal.
+    def overlay_box(area : Rect) : Rect?
+      w = {area.w - 6, 76}.min
+      h = {area.h - 4, 14}.min
+      return nil if w < 40 || h < 8
+      Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
+    end
+
+    def render(screen : Screen, area : Rect) : Nil
+      box = overlay_box(area)
+      unless box
+        unless area.empty?
+          screen.text(area.x + 1, area.y, "import needs a larger window · esc to close",
+            Theme.muted, Theme.bg)
+        end
+        return
+      end
+      Frame.card(screen, box, "IMPORT #{label.upcase} · source path", bg: Theme.bg,
+        border: Theme.border_focus)
+      screen.text(box.x + 2, box.y + 1, blurb, Theme.muted, Theme.bg, width: box.w - 4)
+      render_field(screen, box)
+      screen.text(box.x + 2, box.bottom - 2,
+        "type to complete · ↹ pick · ↑↓ browse · ↵ import · esc cancel",
+        Theme.muted, Theme.bg, width: box.w - 4)
+      render_dropdown(screen, box)
+    end
+
+    # The single field is always focused (there's nowhere else to go), so it always
+    # carries the focus band — no "which row am I on?" ambiguity to resolve.
+    private def render_field(screen : Screen, box : Rect) : Nil
+      y = field_y(box)
+      screen.fill(Rect.new(box.x + 1, y, box.w - 2, 1), Theme.accent_bg)
+      screen.text(box.x + 2, y, "Path", Theme.text_bright, Theme.accent_bg)
+      vx = value_x(box)
+      vw = {box.right - 2 - vx, 1}.max
+      @field.render(screen, vx, y, vw, true, Theme.text_bright, Theme.accent_bg)
+    end
+
+    private def render_dropdown(screen : Screen, box : Rect) : Nil
+      return unless @path_complete.open?
+      @path_complete.render(screen, value_x(box), field_y(box) + 1, box.inset(1, 1))
+    end
+
+    private def field_y(box : Rect) : Int32
+      box.y + 3
+    end
+
+    private def value_x(box : Rect) : Int32
+      box.x + 2 + LABEL_W
+    end
+
+    # --- mouse ---------------------------------------------------------------
+    # A click inside the card is inert but CONSUMED — there's one field and it already
+    # holds focus, so there's nothing to select; returning true just stops the Runner
+    # reading it as a click-away dismiss. (Picking a dropdown row by mouse would mean
+    # inverting PathComplete's private scroll window; it's keyboard-only there for the
+    # CA import popup too, so this stays consistent rather than special-casing one call
+    # site of a shared widget.)
+    def handle_click(box : Rect, mx : Int32, my : Int32) : Bool
+      box.contains?(mx, my)
+    end
+  end
+end

--- a/src/gori/tui/project_picker.cr
+++ b/src/gori/tui/project_picker.cr
@@ -33,6 +33,14 @@ module Gori::Tui
     # One row in the project-list space menu (mnemonic key → action).
     record SpaceEntry, key : Char, label : String, action : Symbol
 
+    # One token of the footer hint row. `action` non-nil → a click on the token runs it;
+    # inert tokens ("↑/↓ select", "type to search") describe a gesture with no single thing
+    # to press, so they swallow no clicks. `action` is HIT-TEST METADATA ONLY — the row
+    # paints exactly as it always did. (A lifted band marking the pressable tokens was
+    # tried and dropped for the same reason as the top bar's: it only earns its keep next
+    # to a hover highlight, which termisu can't report. See `Chrome::Chip`.)
+    record HintToken, label : String, action : Symbol? = nil
+
     SPACE_ENTRIES = [
       SpaceEntry.new('o', "Open", :open),
       SpaceEntry.new('r', "Rename", :rename),
@@ -707,7 +715,13 @@ module Gori::Tui
 
     # List click: SELECT-FIRST — first click highlights the entry, a second click on
     # the already-selected entry activates it (same model as the History/Issues list).
+    # The footer hint's buttons are checked first and fire on a SINGLE click: they're
+    # commands, not a selection, so select-first would just make them feel broken.
     private def handle_list_mouse(mx : Int32, my : Int32) : Project | Symbol | Nil
+      w, h = @backend.size
+      if action = hint_action_at(mx, my, w, h)
+        return run_hint_action(action)
+      end
       return nil unless idx = entry_at(mx, my)
       if idx == @selected
         activate
@@ -1022,19 +1036,105 @@ module Gori::Tui
         centered(screen, h - 3, flash, @flash_ok ? Theme.green : Theme.red, w)
       end
 
-      hint = case
-             when @mode == :compress
-               "↑/↓ select   ‹/› keep   space toggle   ↵ compress   esc close"
-             when @mode == :compressing
-               "compressing …"
-             when @mode == :space
-               "↑/↓ select   ↵ run   o open   r rename   c compress   d delete   esc close"
-             when @selected >= 3
-               "↑/↓ select   ↵ open   space actions   type to search   ctrl-d delete   ctrl-, settings   ctrl-c quit"
-             else
-               "↑/↓ select   ↵ open   type to search   ctrl-n new   ctrl-t temp   ctrl-d delete   ctrl-, settings   ctrl-c quit"
-             end
-      centered(screen, h - 2, hint, Theme.muted, w)
+      if tokens = list_hint_tokens
+        render_hint(screen, tokens, h - 2, w)
+      else
+        hint = case
+               when @mode == :compress
+                 "↑/↓ select   ‹/› keep   space toggle   ↵ compress   esc close"
+               when @mode == :compressing
+                 "compressing …"
+               else # :space
+                 "↑/↓ select   ↵ run   o open   r rename   c compress   d delete   esc close"
+               end
+        centered(screen, h - 2, hint, Theme.muted, w)
+      end
+    end
+
+    # Gap between footer-hint tokens — the same three cells the flat hint string used, so
+    # tokenizing the row for click support left it pixel-identical to before.
+    HINT_GAP = 3
+
+    # The footer hint for the project LIST, split into tokens so the pressable ones can be
+    # tinted and hit-tested. nil in the modal modes (:compress/:compressing/:space), which
+    # keep the old flat string — their hints describe keys inside an overlay that already
+    # owns the mouse, so there's nothing here to press.
+    private def list_hint_tokens : Array(HintToken)?
+      return nil unless @mode == :list
+      tokens = [
+        HintToken.new("↑/↓ select"),
+        HintToken.new("↵ open", :open),
+      ]
+      # A project row is selected → `space` opens its action menu; on the New/Temp/Search
+      # rows that chord does something else entirely, so the token (and its button) is
+      # offered only where it applies, exactly as the flat hint used to switch.
+      tokens << HintToken.new("space actions", :space) if @selected >= 3
+      tokens << HintToken.new("type to search")
+      if @selected < 3
+        tokens << HintToken.new("ctrl-n new", :new)
+        tokens << HintToken.new("ctrl-t temp", :temp)
+      end
+      tokens << HintToken.new("ctrl-d delete", :delete)
+      tokens << HintToken.new("ctrl-, settings", :settings)
+      tokens << HintToken.new("ctrl-c quit", :quit)
+      tokens
+    end
+
+    # The tokens' cell rects, centered on row `y`. THE single geometry source — `render_hint`
+    # draws from it and `hint_action_at` hit-tests against it, so the cells a token occupies
+    # and the cells that respond to a click are the same cells by construction.
+    private def hint_rects(tokens : Array(HintToken), y : Int32, w : Int32) : Array(Rect)
+      total = tokens.sum { |t| Screen.display_width(t.label) } + HINT_GAP * {tokens.size - 1, 0}.max
+      x = {(w - total) // 2, 0}.max
+      tokens.map do |t|
+        tw = Screen.display_width(t.label)
+        rect = Rect.new(x, y, tw, 1)
+        x += tw + HINT_GAP
+        rect
+      end
+    end
+
+    private def render_hint(screen : Screen, tokens : Array(HintToken), y : Int32, w : Int32) : Nil
+      rects = hint_rects(tokens, y, w)
+      tokens.each_with_index do |token, i|
+        rect = rects[i]
+        break if rect.x >= w
+        screen.text(rect.x, y, token.label, Theme.muted, Theme.bg, width: {w - rect.x, 1}.max)
+      end
+    end
+
+    # The action under a footer click, or nil (not the hint row / an inert token / a mode
+    # whose hint isn't tokenized).
+    private def hint_action_at(mx : Int32, my : Int32, w : Int32, h : Int32) : Symbol?
+      return nil unless my == h - 2
+      return nil unless tokens = list_hint_tokens
+      rects = hint_rects(tokens, h - 2, w)
+      tokens.each_with_index do |token, i|
+        action = token.action
+        return action if action && rects[i].contains?(mx, my)
+      end
+      nil
+    end
+
+    # Run a footer button. Each arm mirrors its chord in `handle_list_key` exactly — notably
+    # `:new`, which (like ctrl-n) direct-creates when the search box already holds a name
+    # rather than opening the form with it retyped.
+    private def run_hint_action(action : Symbol) : Project | Symbol | Nil
+      case action
+      when :open  then activate
+      when :space then open_space_menu
+      when :temp  then return open_temp
+      when :quit  then return :quit
+      when :new
+        name = @query.strip
+        return safe_create(name) unless name.empty?
+        start_new
+      when :delete then request_delete
+      when :settings
+        @preferences.open_default
+        @mode = :settings
+      end
+      nil
     end
 
     # Bottom-right space menu over the project list — open / rename / delete.

--- a/src/gori/tui/resource.cr
+++ b/src/gori/tui/resource.cr
@@ -90,12 +90,15 @@ module Gori::Tui
       true
     end
 
-    # Fixed-width CPU field (`%3d`) so the chip — and therefore everything anchored to its
-    # left — never jitters as the number crosses a digit boundary.
+    # UNPADDED CPU field — one space before the number, always. Any fixed width wider than
+    # the common case leaves a gap that reads as a rendering glitch, and padding to the
+    # widest case can't be justified by stability anyway: `human_bytes` is variable-width,
+    # so MEM already shifts the right-anchored chip's left edge whenever RSS crosses a digit
+    # or 1 GiB. Let the number be its own width and accept the same shift on 9→10.
     private def format(percent : Float64, rss : UInt64) : String
       pct = percent.clamp(0.0, 100.0).round.to_i
       String.build do |io|
-        io << "CPU " << pct.to_s.rjust(3) << "% MEM " << human_bytes(rss)
+        io << "CPU " << pct << "% MEM " << human_bytes(rss)
       end
     end
 

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -68,6 +68,7 @@ require "./scope_rule_overlay"
 require "./custom_rule_overlay"
 require "./oast_provider_overlay"
 require "./ca_import_overlay"
+require "./import_overlay"
 require "../paths"
 require "../browser"
 require "../external_editor"
@@ -118,7 +119,7 @@ module Gori::Tui
       # Miner is hidden by default). Settings is loaded (cli.cr) before Runner.new.
       vis = Chrome.visible_tabs(Settings.tab_prefs).map(&.first)
       @active_tab = vis.includes?(:project) ? :project : vis.first
-      @overlay = :none # :none | :palette | :detail | :issue_new | :confirm | :browser | :choice | :tabs_more | :comparer_pick | :repeater_subtab | :links | :issue_pick | :note_pick | :settings | :tabs | :hosts | :env | :hotkeys | :notifications | :mine_config | :sequence_config | :probe_active | :fuzz_set | :fuzz_advanced | :scope_rule | :probe_rule | :rewriter_rule | :ca_import
+      @overlay = :none # :none | :palette | :detail | :issue_new | :confirm | :browser | :choice | :tabs_more | :comparer_pick | :repeater_subtab | :links | :issue_pick | :note_pick | :settings | :tabs | :hosts | :env | :hotkeys | :notifications | :mine_config | :sequence_config | :probe_active | :fuzz_set | :fuzz_advanced | :scope_rule | :probe_rule | :rewriter_rule | :ca_import | :import
       # The "space" action menu (helix-style leader popup, bottom-right). Orthogonal
       # to @overlay so it floats over WHATEVER is underneath (the History list, an
       # open detail …) without disturbing that state; the scope is captured at open.
@@ -156,13 +157,10 @@ module Gori::Tui
       @tag_buffer = ""
       @tag_preedit = ""
       @tag_view = nil.as(RepeaterView?)
-      # The import path prompt (palette → import:har/urls/oas) — bottom-anchored like
-      # ^G/^F, with filesystem tab-completion via PathComplete.
-      @import_open = false
-      @import_kind = :har
-      @import_buffer = ""
-      @import_preedit = ""
-      @import_path_complete = PathComplete.new
+      # The import path popup (palette → import:har/urls/oas) — a CENTERED modal
+      # (@overlay is :import), not a bottom prompt: a path is long and the status row
+      # couldn't host it or its completion dropdown legibly. See ImportOverlay.
+      @import_overlay = nil.as(ImportOverlay?)
       # Whitespace reveal (·→␍␊) toggle for the req/res views — global view pref,
       # propagated to the focused view in render_body. Handy for smuggling tests.
       @reveal = false
@@ -914,10 +912,6 @@ module Gori::Tui
         @tag_preedit = text
         return
       end
-      if @import_open
-        @import_preedit = text
-        return
-      end
       if (ctl = @tabs[@active_tab]?) && ctl.subtab_filter_editing?
         ctl.set_subtab_filter_preedit(text)
         return
@@ -947,6 +941,7 @@ module Gori::Tui
       when :probe_rule       then @custom_rule_overlay.try(&.set_preedit(text))
       when :rewriter_rule    then @rewriter_rule_overlay.try(&.set_preedit(text))
       when :ca_import        then @ca_import_overlay.try(&.set_preedit(text))
+      when :import           then @import_overlay.try(&.set_preedit(text))
       when :none             then apply_preedit_body(text)
       end
     end
@@ -997,7 +992,6 @@ module Gori::Tui
       return handle_search_key(ev) if @search_open && @overlay != :confirm
       return handle_rename_key(ev) if @rename_open     # the sub-tab rename prompt is modal while up
       return handle_tag_edit_key(ev) if @tag_edit_open # the Repeater tag editor is modal while up
-      return handle_import_key(ev) if @import_open     # the import path prompt is modal while up
       # ^G "go to line" / ^F "find" — both open a bottom prompt for the focused
       # multi-line view (editors move the cursor, read-only panes scroll). Modifier
       # keys, so they work inside text editors without conflicting with typing.
@@ -1051,6 +1045,7 @@ module Gori::Tui
       return handle_custom_rule_key(ev) if @overlay == :probe_rule
       return handle_rewriter_rule_key(ev) if @overlay == :rewriter_rule
       return handle_ca_import_key(ev) if @overlay == :ca_import
+      return handle_import_key(ev) if @overlay == :import
       # Text-entry modes own Tab (complete) + Esc within themselves — let them run
       # before the global focus ring claims Tab.
       if @active_tab == :history && @overlay == :none && @focus == :body && history_controller.view.querying?
@@ -1260,14 +1255,13 @@ module Gori::Tui
     # Right-click: rename a Repeater/Fuzzer/Decoder/Miner sub-tab chip (the one context menu we have).
     # Only acts on the sub-tab strip; anywhere else is a no-op (no left-click side effects).
     private def handle_right_click(layout : Layout, mx : Int32, my : Int32) : Nil
-      if @goto_open || @search_open || @rename_open || @tag_edit_open || @import_open
+      if @goto_open || @search_open || @rename_open || @tag_edit_open
         # A right-click dismisses an open bottom prompt (like left-click/esc), so it can't
         # stack a second orthogonal prompt on top of the first.
         close_goto if @goto_open
         close_search if @search_open
         close_rename if @rename_open
         close_tag_edit if @tag_edit_open
-        close_import if @import_open
         return
       end
       return unless renameable_subtabs? && @overlay == :none && !@space_menu_open && !copy_as_shown? && !@rename_open && !@tag_edit_open && subtabs_shown?
@@ -1285,12 +1279,11 @@ module Gori::Tui
       return if @space_menu_open && click_space_menu(layout, mx, my)
       return if copy_as_shown? && click_copy_as(layout.body, mx, my) # modal while up — floats over @overlay
       return if send_to_shown? && click_send_to(layout.body, mx, my) # ditto
-      if @goto_open || @search_open || @rename_open || @tag_edit_open || @import_open
+      if @goto_open || @search_open || @rename_open || @tag_edit_open
         close_goto if @goto_open # a click anywhere dismisses the bottom prompt (like esc)
         close_search if @search_open
         close_rename if @rename_open
         close_tag_edit if @tag_edit_open
-        close_import if @import_open
         return
       end
       if modal_overlay?
@@ -1306,8 +1299,8 @@ module Gori::Tui
     # The overlays that fully capture input (a centered card); :detail and :none do not.
     private def modal_overlay? : Bool
       case @overlay
-      when :palette, :issue_new, :confirm, :browser, :choice, :tabs_more, :comparer_pick, :repeater_subtab, :links, :issue_pick, :note_pick, :preferences, :settings, :tabs, :hotkeys, :notifications, :mine_config, :sequence_config, :probe_active, :discover_config, :discover_headers, :fuzz_set, :fuzz_advanced, :scope_rule, :oast_provider, :probe_rule, :rewriter_rule, :ca_import then true
-      else                                                                                                                                                                                                                                                                                                                                                                        false
+      when :palette, :issue_new, :confirm, :browser, :choice, :tabs_more, :comparer_pick, :repeater_subtab, :links, :issue_pick, :note_pick, :preferences, :settings, :tabs, :hotkeys, :notifications, :mine_config, :sequence_config, :probe_active, :discover_config, :discover_headers, :fuzz_set, :fuzz_advanced, :scope_rule, :oast_provider, :probe_rule, :rewriter_rule, :ca_import, :import then true
+      else                                                                                                                                                                                                                                                                                                                                                                                               false
       end
     end
 
@@ -1423,55 +1416,38 @@ module Gori::Tui
       when :probe_rule       then click_custom_rule(area, mx, my)
       when :rewriter_rule    then click_rewriter_rule(area, mx, my)
       when :ca_import        then click_ca_import(area, mx, my)
+      when :import           then click_import(area, mx, my)
         # :issue_new is a text form — keyboard-only in Phase 1 (cursor placement is Phase 2)
       end
     end
 
     # Click a top-bar chip: the notification badge (`notify:N`, left of scope) opens
     # the center; the scope chip (`scope:N` / `scope:off`) flips the lens — the same
-    # action as the global `s` chord; the far-right `⌘`/`⚙` glyphs open the command
-    # palette (Ctrl/Cmd-P) / the Preferences modal (Ctrl+,). Returns true when consumed.
-    # Each rect is rebuilt from the same tagged source render uses, so a click can't drift.
+    # action as the global `s` chord; the probe chip opens the SET PROBE MODE picker
+    # (the `m` chord inside the Probe tab); the listen chip toggles capture; the
+    # far-right `⌘`/`⚙` glyphs open the command palette (Ctrl/Cmd-P) / the Preferences
+    # modal (Ctrl+,). Returns true when consumed.
+    #
+    # One `top_bar_chip_at` pass resolves the tag from the SAME tagged source render
+    # uses (so a click can't drift), replacing the four full chip-list rebuilds this
+    # used to do — one per candidate tag.
     private def click_top_bar(rect : Rect, mx : Int32, my : Int32) : Bool
-      return false unless rect.contains?(mx, my)
-      unread = @notifications.unread
-      listen = "#{@session.proxy.host}:#{@session.proxy.port}"
-      capturing = @session.capturing?
-      write_failures = @session.store.write_failures
+      tag = Chrome.top_bar_chip_at(rect, mx, my, scope: scope_label, probe: probe_label,
+        rules: rules_label, intercept: intercept_label, sandbox: sandbox_label,
+        listen: "#{@session.proxy.host}:#{@session.proxy.port}",
+        unread: @notifications.unread, capturing: @session.capturing?,
+        write_failures: @session.store.write_failures)
+      return false unless tag
 
-      nrect = Chrome.top_bar_chip_rect(rect, :notify, scope: scope_label, rules: rules_label,
-        intercept: intercept_label, sandbox: sandbox_label, listen: listen, time: clock_label,
-        unread: unread, capturing: capturing, write_failures: write_failures)
-      if nrect && nrect.contains?(mx, my)
-        open_notifications
-        return true
+      case tag
+      when :notify   then open_notifications
+      when :scope    then scope_toggle_lens
+      when :probe    then probe_set_mode
+      when :listen   then toggle_capture
+      when :palette  then open_palette
+      when :settings then open_preferences
       end
-
-      srect = Chrome.top_bar_chip_rect(rect, :scope, scope: scope_label, rules: rules_label,
-        intercept: intercept_label, sandbox: sandbox_label, listen: listen, time: clock_label,
-        unread: unread, capturing: capturing, write_failures: write_failures)
-      if srect && srect.contains?(mx, my)
-        scope_toggle_lens
-        return true
-      end
-
-      prect = Chrome.top_bar_chip_rect(rect, :palette, scope: scope_label, rules: rules_label,
-        intercept: intercept_label, sandbox: sandbox_label, listen: listen, time: clock_label,
-        unread: unread, capturing: capturing, write_failures: write_failures)
-      if prect && prect.contains?(mx, my)
-        open_palette
-        return true
-      end
-
-      grect = Chrome.top_bar_chip_rect(rect, :settings, scope: scope_label, rules: rules_label,
-        intercept: intercept_label, sandbox: sandbox_label, listen: listen, time: clock_label,
-        unread: unread, capturing: capturing, write_failures: write_failures)
-      if grect && grect.contains?(mx, my)
-        open_preferences
-        return true
-      end
-
-      false
+      true
     end
 
     private def click_notifications(area : Rect, mx : Int32, my : Int32) : Nil
@@ -1557,6 +1533,13 @@ module Gori::Tui
       ov = @ca_import_overlay || return
       box = ov.overlay_box(area)
       return close_ca_import if box.nil? || dismiss_zone?(box, mx, my) # click-away = cancel (destructive: never auto-submit)
+      ov.handle_click(box, mx, my)
+    end
+
+    private def click_import(area : Rect, mx : Int32, my : Int32) : Nil
+      ov = @import_overlay || return
+      box = ov.overlay_box(area)
+      return close_import if box.nil? || dismiss_zone?(box, mx, my) # click-away = cancel
       ov.handle_click(box, mx, my)
     end
 
@@ -1731,6 +1714,7 @@ module Gori::Tui
       when :probe_rule      then @custom_rule_overlay.try(&.move(step))
       when :rewriter_rule   then @rewriter_rule_overlay.try(&.move(step))
       when :ca_import       then @ca_import_overlay.try(&.move(step))
+      when :import          then @import_overlay.try(&.move(step))
       end
     end
 
@@ -3810,8 +3794,8 @@ module Gori::Tui
 
       layout = Layout.compute(w, h, statusline_active?)
       Chrome.render_top_bar(screen, layout.topbar, project: @session.project.name,
-        listen: "#{@session.proxy.host}:#{@session.proxy.port}", time: clock_label,
-        scope: scope_label, rules: rules_label, intercept: intercept_label,
+        listen: "#{@session.proxy.host}:#{@session.proxy.port}",
+        scope: scope_label, probe: probe_label, rules: rules_label, intercept: intercept_label,
         sandbox: sandbox_label,
         unread: @notifications.unread, capturing: @session.capturing?,
         write_failures: @session.store.write_failures)
@@ -3825,7 +3809,7 @@ module Gori::Tui
         hidden_count: hid_tabs.size, more_focused: @focus == :menu && @menu_more)
       render_body(screen, layout.body)
       Chrome.render_status(screen, layout.status, focus: focus_label, hints: format_status_message(@toast) || key_hints,
-        activity: activity_chip, resource: @resource.label)
+        activity: activity_chip, resource: @resource.label, time: clock_label)
       Chrome.render_statusline(screen, layout.statusline, @statusline.segments) unless layout.statusline.empty?
       @palette.render(screen, layout.body) if @overlay == :palette
       @issue_form.render(screen, layout.body) if @overlay == :issue_new
@@ -3857,6 +3841,7 @@ module Gori::Tui
       @custom_rule_overlay.try(&.render(screen, layout.body)) if @overlay == :probe_rule
       @rewriter_rule_overlay.try(&.render(screen, layout.body)) if @overlay == :rewriter_rule
       @ca_import_overlay.try(&.render(screen, layout.body)) if @overlay == :ca_import
+      @import_overlay.try(&.render(screen, layout.body)) if @overlay == :import
       # The space menu + bottom prompts float over everything else (drawn last).
       render_prompts(screen, layout)
 
@@ -3888,7 +3873,6 @@ module Gori::Tui
       render_search_prompt(screen, layout.status) if @search_open
       render_rename_prompt(screen, layout.status) if @rename_open
       render_tag_prompt(screen, layout.status) if @tag_edit_open
-      render_import_prompt(screen, layout.status) if @import_open
     end
 
     # Emit the frame: a full repaint right after a resize (the diff renderer would
@@ -3905,6 +3889,14 @@ module Gori::Tui
       @scope.active? ? "scope:#{@scope.size}" : "scope:off"
     end
 
+    # The probe chip, always present like scope: passive scanning is on by default, so an
+    # empty chip would read as "no probing configured" rather than "probing is idle". The
+    # mode label is the enum's own lowercase form, which `Chrome.probe_chip_color` keys its
+    # colour off — keep the `probe:<mode>` shape if you change this.
+    private def probe_label : String
+      "probe:#{@session.probe.mode.label}"
+    end
+
     # A red top-bar chip whenever the sandbox is on — a hard block gate MUST stay visible
     # everywhere, so an operator never wonders why traffic isn't being captured. Empty (no
     # chip) when off. Display-only, unlike the clickable scope chip.
@@ -3912,11 +3904,14 @@ module Gori::Tui
       @scope.sandbox? ? "sandbox" : ""
     end
 
-    # The wall clock shown at the far right of the top bar. Minute granularity — the
+    # The wall clock shown at the far right of the STATUS bar. Minute granularity — the
     # event loop only bumps `dirty` when this string changes (see `last_clock`), so
     # an idle TUI re-renders once a minute, not every second (preserves idle-zero-CPU).
+    #
+    # GOTCHA `%P`, not `%p`: Crystal INVERTS the strftime convention — here `%p` is the
+    # lowercase "pm" and `%P` the uppercase "PM" (GNU date has them the other way round).
     private def clock_label : String
-      Time.local.to_s("%I:%M %p")
+      Time.local.to_s("%I:%M %P")
     end
 
     private def rules_label : String
@@ -3971,6 +3966,7 @@ module Gori::Tui
       when :rewriter_rule    then "REWRITER RULE"
       when :oast_provider    then "OAST PROVIDER"
       when :ca_import        then "IMPORT CA"
+      when :import           then "IMPORT #{@import_overlay.try(&.label) || "FILE"}"
       else
         case @focus
         when :menu    then "TABS"
@@ -4026,6 +4022,7 @@ module Gori::Tui
       when :rewriter_rule    then "↑/↓ field · ←/→ options · type find/value · ↵ save · esc cancel"
       when :oast_provider    then "↑/↓ field · ←/→ type · type name/host/token · ↵ save · esc cancel"
       when :ca_import        then "type to complete · ↹/↵ pick · ⇥/↑↓ field · ↵ submits · esc cancels"
+      when :import           then "type to complete · ↹ pick · ↑↓ browse · ↵ import · esc cancel"
       when :detail           then history_controller.body_hint(:body)
       else
         # Focus on the far-right ⋯ "more" affordance: ↵/↓ expands the hidden-tabs list.
@@ -4419,102 +4416,48 @@ module Gori::Tui
       screen.text({rect.right - hint.size - 1, x + iw}.max, rect.y, hint, Theme.muted, Theme.panel)
     end
 
-    # --- Import path prompt (palette → import:har/urls/oas) ------------------
+    # --- Import path popup (palette → import:har/urls/oas) -------------------
 
     private def open_import(kind : Symbol) : Nil
-      @import_kind = kind
-      @import_buffer = ""
-      @import_preedit = ""
-      @import_path_complete.close
-      @import_open = true
+      @import_overlay = ImportOverlay.new(kind)
+      @overlay = :import
     end
 
     private def close_import : Nil
-      @import_open = false
-      @import_preedit = ""
-      @import_path_complete.close
+      @overlay = :none
+      @import_overlay = nil
     end
 
     private def handle_import_key(ev : Termisu::Event::Key) : Nil
-      key = ev.key
-      c = ev.char || key.to_char
-      if key.escape?
-        close_import
-      elsif key.tab? || key.enter?
-        if @import_path_complete.open? && (res = @import_path_complete.accept)
-          insert, is_dir = res
-          @import_buffer = insert
-          if is_dir
-            @import_path_complete.refresh(@import_buffer)
-          else
-            @import_path_complete.close
-            if key.enter?
-              apply_import(@import_buffer)
-              close_import
-            end
-          end
-        elsif key.enter?
-          apply_import(@import_buffer)
-          close_import
-        end
-      elsif key.back_tab? || key.up?
-        @import_path_complete.move(-1) if @import_path_complete.open?
-      elsif key.down?
-        @import_path_complete.move(1) if @import_path_complete.open?
-      elsif key.backspace?
-        @import_buffer = @import_buffer[0, {@import_buffer.size - 1, 0}.max]
-        @import_path_complete.refresh(@import_buffer)
-      elsif c && !ev.ctrl? && !ev.alt?
-        @import_buffer += c
-        @import_preedit = ""
-        @import_path_complete.refresh(@import_buffer)
+      ov = @import_overlay || return
+      case ov.handle_key(ev)
+      when :cancel then close_import
+      when :submit then submit_import(ov)
       end
     end
 
-    private def apply_import(path : String) : Nil
-      trimmed = path.strip
-      if trimmed.empty?
+    # Read the path off the popup, close it, THEN import — so the card is gone before a
+    # slow parse blocks the loop, and the resulting toast isn't drawn behind the modal.
+    private def submit_import(ov : ImportOverlay) : Nil
+      path = ov.path
+      label = ov.label
+      kind = ov.kind
+      close_import
+      if path.empty?
         @toast = "import cancelled — path is empty"
-        close_import
         return
       end
-      result = Import.import_file(@session.store, @import_kind, trimmed)
+      apply_import(kind, label, path)
+    end
+
+    private def apply_import(kind : Symbol, label : String, path : String) : Nil
+      result = Import.import_file(@session.store, kind, path)
       sitemap_controller.reload
-      label = case @import_kind
-              when :har  then "HAR"
-              when :urls then "URLs"
-              when :oas  then "OpenAPI"
-              else            "file"
-              end
-      msg = "imported #{result.count} flow#{result.count == 1 ? "" : "s"} from #{label} · #{trimmed}"
+      msg = "imported #{result.count} flow#{result.count == 1 ? "" : "s"} from #{label} · #{path}"
       msg += " (#{result.skipped} entries skipped)" if result.skipped > 0
       @toast = msg
     rescue ex
       @toast = "import failed: #{ex.message}"
-    end
-
-    private def import_prompt_prefix : String
-      case @import_kind
-      when :har  then "import HAR: "
-      when :urls then "import URLs: "
-      when :oas  then "import OpenAPI: "
-      else            "import: "
-      end
-    end
-
-    private def render_import_prompt(screen : Screen, rect : Rect) : Nil
-      return if rect.w < 6
-      screen.fill(rect, Theme.panel)
-      prefix = import_prompt_prefix
-      screen.text(rect.x, rect.y, prefix, Theme.accent, Theme.panel)
-      hint = "↵ import · tab complete · esc cancel"
-      x = rect.x + prefix.size
-      iw = {rect.right - x - hint.size - 2, 4}.max
-      screen.input_line(x, rect.y, @import_buffer, @import_buffer.size, @import_preedit, Theme.text_bright, Theme.panel, width: iw)
-      screen.text({rect.right - hint.size - 1, x + iw}.max, rect.y, hint, Theme.muted, Theme.panel)
-      if @import_path_complete.open?
-        @import_path_complete.render(screen, x, rect.y - 1, Rect.new(rect.x, rect.y - 9, rect.w, 9))
-      end
     end
 
     private def render_search_prompt(screen : Screen, rect : Rect) : Nil
@@ -4739,13 +4682,19 @@ module Gori::Tui
 
     # ↑/↓ (or j/k) move · ↵ switch to the hidden tab (force-shown on the bar, like a
     # palette "Go to …") · esc/← dismiss back to the ⋯ affordance.
+    #
+    # ↑ ON THE FIRST ROW dismisses too, in the same spirit as ←: the dropdown drops DOWN
+    # out of the tab bar, so "up past the top" is a walk back onto the bar. Clamping there
+    # instead (the old behaviour) left ↑ looking dead at the one spot a user is most likely
+    # to press it — the list opens with row 0 already selected.
     private def handle_more_menu_key(ev : Termisu::Event::Key) : Nil
       key = ev.key
       mm = @more_menu
       return close_more_menu unless mm
       case
-      when key.escape?, key.left?  then close_more_menu
-      when key.up?, key.lower_k?   then mm.move(-1)
+      when key.escape?, key.left? then close_more_menu
+      when key.up?, key.lower_k?
+        mm.selected == 0 ? close_more_menu : mm.move(-1)
       when key.down?, key.lower_j? then mm.move(1)
       when key.enter?, key.space?  then apply_more_menu
       end

--- a/src/gori/tui/text_field.cr
+++ b/src/gori/tui/text_field.cr
@@ -20,10 +20,19 @@ module Gori::Tui
       @undo_stack = [] of UndoState
     end
 
-    # Replace the whole value, clamping the caret to the new end.
+    # Replace the whole value and park the caret at its END.
+    #
+    # This CLAMPED the old caret (`{@caret, v.size}.min`) and that was wrong for every
+    # caller: `set` replaces the value wholesale, so an offset into the *previous* string
+    # means nothing in the new one. The visible bug was path completion — Tab-completing
+    # `/tmp/imp/` to `/tmp/imp/sample.har` left the caret back at column 9, mid-path, so
+    # the next keystroke typed into the middle of the name. Every caller (path completion
+    # in the import / CA-import / fuzzer-wordlist overlays, and the fuzzer + sequence
+    # overlays populating fields from a parsed spec) wants "value in, ready to keep
+    # typing at the end" — same as `initialize`.
     def set(v : String) : Nil
       @value = v
-      @caret = {@caret, v.size}.min
+      @caret = v.size
       @preedit = ""
       @undo_stack.clear
     end


### PR DESCRIPTION
Top-right is now **actions**, bottom-right is **readouts**.

## Chrome

- **Probe chip** on the top bar mirroring scope (`probe:off|passive|active`, colour ladder matching the Probe tab's mode band). Click opens the same `SET PROBE MODE` picker as `m`.
- **Listen chip toggles capture** on click — the dot you already read for capture state is the natural thing to press.
- Chips became a tagged `Chip` record, and `Chrome.top_bar_chip_at` resolves a click in **one** pass over the shared list, replacing four full chip-list rebuilds (one per candidate tag).
- **Clock moved** to the far right of the status bar. A wall clock isn't pressable, so it belongs with the readouts. Uppercase AM/PM — note `%P`, since Crystal inverts strftime and `%p` is the *lowercase* one.

## Fixes

- **Chip geometry measured with `String#size` instead of display width.** The bar carries non-ASCII glyphs (`⌘ ⚙ ●`) and `screen.text` advances by display width, so hit rects drifted a cell per wide glyph. Now uses `Screen.display_width`.
- **`TextField#set` parked the caret mid-string.** It clamped the old caret instead of moving to the end, so tab-completing `/tmp/x/` → `/tmp/x/f.har` left the caret at col 8 and the next keystroke landed inside the filename. Fixed in the primitive, which covers all three path-completion overlays (import, CA import, fuzzer wordlist). `EnvComplete`/`ChainComplete` already returned an explicit caret and were unaffected.
- **`⋯` dropdown: `↑` on the first row now dismisses**, mirroring `←`. It opens with row 0 selected, so `↑` looked dead exactly where users press it first.
- **CPU field padding dropped.** Any fixed width leaves a gap that reads as a glitch, and the "never jitters" rationale was already void since `human_bytes` is variable-width.

## Import popup

Palette → `import:har/urls/oas` moved from a one-row status-bar prompt to a centered `ImportOverlay`. A filesystem path is long, and `PathComplete`'s dropdown had to be drawn *above* the status row because nothing sits below it. The card gives the path full width and hangs the dropdown under the field.

Kept: `↵` onto a completed file imports in one keystroke. Changed: `esc` now peels dropdown → popup, instead of discarding a long typed path in one press (matches `CAImportOverlay`).

## Project picker

Footer hints are clickable (single click runs the action, since they're commands not selections), via a `HintToken` record whose rects are shared by the draw and the hit-test. Renders identically to the old flat string.

## On hover

The original intent was a hover highlight on clickable chrome. That isn't achievable: termisu only enables mouse mode `1000` (press/release, **no motion**) and exposes no API for `1003`. A resting tint was built, reviewed, and reverted — it only earns its keep paired with hover. `clickable` survives as hit-test metadata carrying no styling, pinned by a spec.

## Verification

Full suite **2260 examples, 0 new failures** (the 8 `capture_status`/`project_registry` failures are pre-existing port-binding ones, confirmed by stashing onto a clean tree). 12 new specs; the caret regressions were confirmed to **fail** with the old clamping restored.

Exercised end-to-end in tmux: probe chip → picker → `probe:active`; listen chip → capture off/on with the dot round-tripping green↔muted; `⋯` `↑`/`↓` close/reopen; picker footer clicks; a real 2-entry HAR imported and verified in History; tab-completion caret checked in all three overlays. Re-verified after rebasing onto the new Preferences work — `⚙` still opens it.