### PR TITLE
feat(filters): one shared query grammar with AND/OR/NOT, parens and quoting

### DIFF
--- a/docs/content/reference/query-language.ko.md
+++ b/docs/content/reference/query-language.ko.md
@@ -60,17 +60,34 @@ header~set-cookie
 
 ## 항목 결합 {#combining-terms}
 
-- 공백으로 구분된 항목들은 **AND**로 결합됩니다.
-- 필드 앞에 `-`를 붙이면 **부정**합니다.
-- `OR`는 서로 대안이 되는 AND 그룹을 나눕니다.
-- `field:`가 없는 단순 단어는 method, host, path를 대상으로 하는 자유 텍스트 검색입니다.
+- 공백으로 구분된 항목들은 **AND**로 결합됩니다. `AND`를 직접 써도 됩니다.
+- `OR`는 둘 중 하나를 매칭합니다. `NOT`과 `-` 접두사는 모두 부정입니다.
+- 괄호로 묶을 수 있습니다. 우선순위는 `NOT`, `AND`, `OR` 순입니다.
+- `field:`가 없는 단순 단어는 method, host, target을 대상으로 하는 자유 텍스트 검색입니다.
 
 ```text
 host:example.com status:5xx           둘 다 매칭되어야 함
+host:api AND status:5xx               같은 의미를 풀어 쓴 것
 method:POST -status:200               POST이지만 200은 아님
 host:a.com OR host:b.com              둘 중 하나의 호스트
+(host:a.com OR host:b.com) -path:/js  둘 중 하나의 호스트, /js 제외
+NOT (host:cdn OR host:static)         둘 다 아닌 것
 login                                 자유 텍스트 검색
 ```
+
+`AND`, `OR`, `NOT`은 대문자로 쓸 때만 연산자로 인식합니다. 따라서 "and", "or", "not"이라는
+단어를 검색하는 것도 그대로 됩니다. 대문자라도 따옴표로 감싸면 리터럴이 됩니다.
+
+큰따옴표는 공백이 포함된 값을 하나의 항목으로 유지합니다:
+
+```text
+host:"my host"                        공백까지 포함한 하나의 host 값
+"two words"                           구 전체를 자유 텍스트로
+"OR"                                  연산자가 아닌 단어 그대로
+```
+
+값 안의 괄호는 리터럴로 남으므로 `path:/a(b)`는 이스케이프가 필요 없습니다. `(`는 항목의
+맨 앞에서만 그룹을 열고, `)`는 맨 뒤에서만 그룹을 닫습니다.
 
 ## 예제 {#examples}
 

--- a/docs/content/reference/query-language.md
+++ b/docs/content/reference/query-language.md
@@ -60,17 +60,34 @@ header~set-cookie
 
 ## Combining Terms
 
-- Terms separated by spaces are **AND**-ed together.
-- Prefix a field with `-` to **negate** it.
-- `OR` separates alternative AND-groups.
-- A bare word (no `field:`) is free text over method, host, and path.
+- Terms separated by spaces are **AND**-ed together. `AND` may also be written out.
+- `OR` matches either side. `NOT` and a `-` prefix both negate.
+- Parentheses group. Precedence is `NOT` then `AND` then `OR`.
+- A bare word (no `field:`) is free text over method, host, and target.
 
 ```text
 host:example.com status:5xx           both must match
+host:api AND status:5xx               the same thing, spelled out
 method:POST -status:200               POST, but not 200
 host:a.com OR host:b.com              either host
+(host:a.com OR host:b.com) -path:/js  either host, no /js
+NOT (host:cdn OR host:static)         neither host
 login                                 free-text search
 ```
+
+`AND`, `OR` and `NOT` are recognised uppercase only, so searching for the words
+"and", "or" or "not" still works. Quote them to force a literal even in caps.
+
+Double quotes keep spaces inside one term:
+
+```text
+host:"my host"                        one host value, space and all
+"two words"                           free text for the whole phrase
+"OR"                                  the literal word, not the operator
+```
+
+A parenthesis inside a value stays literal, so `path:/a(b)` needs no escaping. A `(`
+only opens a group at the start of a term, and `)` only closes one at the end.
 
 ## Examples
 

--- a/spec/filter_ast_spec.cr
+++ b/spec/filter_ast_spec.cr
@@ -1,0 +1,122 @@
+require "./spec_helper"
+
+# Compact s-expression of a parsed tree, so a test reads as the shape it asserts.
+private def sexp(node : Gori::FilterAst::Node?) : String
+  case node
+  when Gori::FilterAst::TermNode
+    t = node.term
+    "#{t.negate? ? "-" : ""}#{t.text}"
+  when Gori::FilterAst::AndNode then "(and #{node.children.map { |c| sexp(c) }.join(" ")})"
+  when Gori::FilterAst::OrNode  then "(or #{node.children.map { |c| sexp(c) }.join(" ")})"
+  when Gori::FilterAst::NotNode then "(not #{sexp(node.child)})"
+  else                               "nil"
+  end
+end
+
+private def parse(query : String) : String
+  sexp(Gori::FilterAst.parse(query))
+end
+
+describe Gori::FilterAst do
+  it "ANDs adjacent terms and accepts the AND keyword for the same thing" do
+    parse("host:acme status:>=500").should eq(%((and host:acme status:>=500)))
+    parse("host:a AND host:b").should eq("(and host:a host:b)")
+  end
+
+  it "binds AND tighter than OR" do
+    parse("a b OR c d").should eq("(or (and a b) (and c d))")
+    parse("a OR b AND c").should eq("(or a (and b c))")
+  end
+
+  it "groups with parentheses" do
+    parse("(host:a OR host:b) -method:GET").should eq("(and (or host:a host:b) -method:GET)")
+    parse("((a OR b) c) OR d").should eq("(or (and (or a b) c) d)")
+  end
+
+  it "treats NOT on a single term as identical to the - prefix" do
+    parse("NOT host:cdn").should eq("-host:cdn")
+    parse("-host:cdn").should eq("-host:cdn")
+    parse("NOT NOT host:cdn").should eq("host:cdn")
+  end
+
+  it "wraps NOT around a group (which - cannot express)" do
+    parse("NOT (host:cdn OR host:static)").should eq("(not (or host:cdn host:static))")
+  end
+
+  it "keeps parentheses inside a value literal, so URL paths still parse" do
+    # The whole point of the boundary rule: `(` only opens at the start of a chunk and
+    # `)` only closes at the end AND only while a group is open. Regression guard for
+    # every `path:/a(b)`-shaped query that worked before the grammar grew parens.
+    parse("path:/a(b)").should eq("path:/a(b)")
+    parse("path:/a(b) OR host:x").should eq("(or path:/a(b) host:x)")
+    parse("(path:/a(b))").should eq("path:/a(b)")  # groups, inner parens survive
+    parse("host:a)").should eq("host:a)")          # stray close at depth 0
+    parse(%(path:"/a(b)")).should eq("path:/a(b)") # quoting always forces literal
+  end
+
+  it "recognises keywords only UPPERCASE and unquoted" do
+    parse("a or b and c").should eq("(and a or b and c)") # lowercase = free text
+    parse(%("OR")).should eq("OR")
+    parse(%(host:"AND")).should eq("host:AND")
+  end
+
+  it "keeps spaces inside a quoted value" do
+    parse(%(host:"my host")).should eq("host:my host")
+    parse(%("two words")).should eq("two words")
+    parse(%(a "b c" d)).should eq("(and a b c d)")
+  end
+
+  it "stays forgiving about half-typed structure (it re-parses per keystroke)" do
+    parse("(host:a").should eq("host:a") # unclosed group closes at end of input
+    parse("a OR").should eq("a")         # dangling operator
+    parse("a AND").should eq("a")
+    parse("").should eq("nil")
+    parse("   ").should eq("nil")
+    parse("()").should eq("nil")
+  end
+
+  it "negates only with something after the dash" do
+    parse("-host:a").should eq("-host:a")
+    parse("-").should eq("-") # a lone dash is a word, not a negation
+  end
+
+  describe "Term" do
+    it "carries the source as typed alongside the normalised text" do
+      # `text` keeps the field prefix — only the `-` and the quote marks come off; the
+      # backends do their own field/value split.
+      terms = Gori::FilterAst.terms(Gori::FilterAst.parse(%(-host:"my host" plain)))
+      terms.map(&.text).should eq(["host:my host", "plain"])
+      terms.map(&.source).should eq([%(-host:"my host"), "plain"])
+      terms.map(&.negate?).should eq([true, false])
+    end
+
+    it "collects leaves left to right through every combinator" do
+      node = Gori::FilterAst.parse("(a OR b) NOT (c AND d)")
+      Gori::FilterAst.terms(node).map(&.text).should eq(["a", "b", "c", "d"])
+    end
+  end
+
+  describe ".build" do
+    it "folds into a backend tree, dropping the leaves the backend rejects" do
+      # `leaf` returning nil DROPS a term; a combinator with no survivors drops too.
+      node = Gori::FilterAst.parse("keep drop OR drop")
+      tree = Gori::FilterAst.build(node) { |t| t.text == "keep" ? t.text : nil }
+      tree.should_not be_nil
+      tree.not_nil!.op.should eq(Gori::FilterAst::Op::Leaf)
+      tree.not_nil!.leaf.should eq("keep")
+    end
+
+    it "folds to nil when every leaf is dropped" do
+      node = Gori::FilterAst.parse("a b OR c")
+      Gori::FilterAst.build(node) { |_| nil }.should be_nil
+    end
+
+    it "preserves the combinator shape for surviving leaves" do
+      node = Gori::FilterAst.parse("a b OR c")
+      tree = Gori::FilterAst.build(node) { |t| t.text }.not_nil!
+      tree.op.should eq(Gori::FilterAst::Op::Or)
+      tree.children.map(&.op).should eq([Gori::FilterAst::Op::And, Gori::FilterAst::Op::Leaf])
+      tree.children[0].children.map(&.leaf).should eq(["a", "b"])
+    end
+  end
+end

--- a/spec/intercept_filter_spec.cr
+++ b/spec/intercept_filter_spec.cr
@@ -81,4 +81,58 @@ describe Gori::InterceptFilter do
     Gori::InterceptFilter.new("host:").blank?.should be_true
     Gori::InterceptFilter.new("host:").matches?(req).should be_true
   end
+
+  describe ".suggestions" do
+    it "completes field names, then that field's values" do
+      Gori::InterceptFilter.suggestions("me", 2).should eq(["method:"])
+      Gori::InterceptFilter.suggestions("s", 1).should eq(["scheme:", "status:"])
+      Gori::InterceptFilter.suggestions("method:P", 8).should eq(["method:POST", "method:PUT", "method:PATCH"])
+      Gori::InterceptFilter.suggestions("scheme:h", 8).should eq(["scheme:http", "scheme:https"])
+      Gori::InterceptFilter.suggestions("status:4", 8).should contain("status:4xx")
+    end
+
+    it "only offers fields this parser understands (no History-only body:/dur:)" do
+      Gori::InterceptFilter::FIELDS.should eq(%w(host path method scheme status))
+      Gori::InterceptFilter.suggestions("b", 1).should be_empty
+      Gori::InterceptFilter.suggestions("d", 1).should be_empty
+      # `path:` completes the field but has no value pool — paths are unbounded.
+      Gori::InterceptFilter.suggestions("pa", 2).should eq(["path:"])
+      Gori::InterceptFilter.suggestions("path:/ap", 8).should be_empty
+    end
+
+    it "takes host values from the injected pool and preserves a leading -" do
+      hosts = ["api.acme.test", "app.acme.test"]
+      Gori::InterceptFilter.suggestions("host:ap", 7, hosts).should eq(["host:api.acme.test", "host:app.acme.test"])
+      Gori::InterceptFilter.suggestions("-host:ap", 8, hosts).should eq(["-host:api.acme.test", "-host:app.acme.test"])
+      Gori::InterceptFilter.suggestions("-me", 3).should eq(["-method:"])
+    end
+
+    it "completes the token under the caret, not the whole query" do
+      # Caret sits inside "me" (offset 15), with a trailing term after it.
+      q = "host:acme.test me path:/x"
+      Gori::InterceptFilter.suggestions(q, 17).should eq(["method:"])
+      cur = Gori::FilterAst.token_at(q, 17)
+      {cur.core, cur.start, cur.stop}.should eq({"me", 15, 17})
+    end
+
+    it "carries an opening paren through the completion" do
+      # Grouping punctuation must survive Tab, or completing inside `(host:a OR (me`
+      # would silently drop the group the user just opened.
+      Gori::InterceptFilter.suggestions("(me", 3).should eq(["(method:"])
+      Gori::InterceptFilter.suggestions("(-me", 4).should eq(["(-method:"])
+      hosts = ["api.acme.test"]
+      Gori::InterceptFilter.suggestions("host:a OR (host:ap", 18, hosts).should eq(["(host:api.acme.test"])
+    end
+
+    it "completes through a half-typed opening quote" do
+      hosts = ["api.acme.test"]
+      Gori::InterceptFilter.suggestions(%(host:"ap), 8, hosts).should eq(["host:api.acme.test"])
+    end
+
+    it "stays quiet on blank space and on an unmatched free-text word" do
+      Gori::InterceptFilter.suggestions("", 0).should be_empty
+      Gori::InterceptFilter.suggestions("host:acme ", 10).should be_empty
+      Gori::InterceptFilter.suggestions("login", 5).should be_empty
+    end
+  end
 end

--- a/spec/ql_spec.cr
+++ b/spec/ql_spec.cr
@@ -53,8 +53,11 @@ describe Gori::QL do
   end
 
   it "compiles OR groups and negation" do
+    # The OR now parenthesises as a whole rather than wrapping each side (a shape
+    # change from the AST compiler; the predicate is identical). Every other clause
+    # shape is byte-for-byte what the old flat parser emitted.
     f = Gori::QL.parse("method:get OR -host:cdn")
-    f.sql.should eq("(upper(method) = ?) OR (NOT (lower(host) LIKE ? ESCAPE '\\'))")
+    f.sql.should eq("(upper(method) = ? OR NOT (lower(host) LIKE ? ESCAPE '\\'))")
     f.args.should eq(["GET", "%cdn%"])
   end
 
@@ -417,6 +420,68 @@ describe "Gori::Store#search (QL)" do
 
     it "flags each bad term across OR groups" do
       Gori::QL.invalid_regex_terms("body~[a OR path~[b").should eq(["body~[a", "path~[b"])
+    end
+
+    it "reaches terms nested inside parentheses and NOT" do
+      Gori::QL.invalid_regex_terms("(host:a OR body~[bad)").should eq(["body~[bad"])
+      Gori::QL.invalid_regex_terms("NOT (path~[bad)").should eq(["path~[bad"])
+    end
+  end
+
+  describe ".analyze" do
+    it "reports terms as applied or silently ignored" do
+      a = Gori::QL.analyze("host:beta status:>=foo")
+      a.applied.should eq(["host:beta"])
+      a.ignored.should eq(["status:>=foo"]) # a bad numeric is DROPPED, broadening the result
+      a.clean?.should be_false
+    end
+
+    it "counts operators and grouping as structure, not as terms" do
+      a = Gori::QL.analyze("(host:a AND host:b) OR NOT host:c")
+      a.applied.should eq(["host:a", "host:b", "host:c"])
+      a.ignored.should be_empty
+      a.clean?.should be_true
+    end
+
+    it "echoes a term exactly as typed, quotes and all" do
+      Gori::QL.analyze(%(-host:"my host")).applied.should eq([%(-host:"my host")])
+    end
+  end
+
+  describe "boolean structure" do
+    # Grouping has to change the ANSWER, not just the SQL text: without parens AND
+    # binds tighter, so the two queries below are genuinely different predicates.
+    it "binds AND tighter than OR unless parenthesised" do
+      loose = Gori::QL.parse("host:a OR host:b status:301")
+      loose.sql.should eq("(lower(host) LIKE ? ESCAPE '\\' OR " \
+                          "(lower(host) LIKE ? ESCAPE '\\' AND status = ?))")
+      grouped = Gori::QL.parse("(host:a OR host:b) status:301")
+      grouped.sql.should eq("((lower(host) LIKE ? ESCAPE '\\' OR lower(host) LIKE ? ESCAPE '\\') " \
+                            "AND status = ?)")
+    end
+
+    it "negates a whole group with NOT" do
+      f = Gori::QL.parse("NOT (host:a OR host:b)")
+      f.sql.should eq("(NOT ((lower(host) LIKE ? ESCAPE '\\' OR lower(host) LIKE ? ESCAPE '\\')))")
+      f.args.should eq(["%a%", "%b%"])
+    end
+
+    it "spells AND explicitly for the same predicate as whitespace" do
+      Gori::QL.parse("host:a AND status:301").sql.should eq(Gori::QL.parse("host:a status:301").sql)
+    end
+
+    it "keeps a quoted value in one term, spaces included" do
+      f = Gori::QL.parse(%(host:"my host"))
+      f.sql.should eq("(lower(host) LIKE ? ESCAPE '\\')")
+      f.args.should eq(["%my host%"])
+    end
+
+    it "leaves a parenthesis inside a value literal (no escaping needed)" do
+      # Regression guard: `path:/a(b)` parsed as one token before the grammar grew
+      # parens, and must keep doing so.
+      f = Gori::QL.parse("path:/a(b)")
+      f.sql.should eq("(lower(target) LIKE ? ESCAPE '\\')")
+      f.args.should eq(["%/a(b)%"])
     end
   end
 end

--- a/spec/repeater/subtab_filter_spec.cr
+++ b/spec/repeater/subtab_filter_spec.cr
@@ -83,7 +83,11 @@ describe Gori::Repeater::SubtabFilter do
     it "suggests tag/name/host values from open sessions" do
       Repeater::SubtabFilter.suggestions("tag:", 4, list).should eq(["tag:idor", "tag:auth", "tag:done"])
       Repeater::SubtabFilter.suggestions("tag:i", 5, list).should eq(["tag:idor"])
-      Repeater::SubtabFilter.suggestions("name:", 5, list).should contain("name:orders probe")
+      # A value with a space is quoted, because the completion has to survive being
+      # re-parsed: bare `name:orders probe` would split into `name:orders` AND a
+      # free-text `probe` and match nothing.
+      Repeater::SubtabFilter.suggestions("name:", 5, list).should contain(%(name:"orders probe"))
+      filtered(%(name:"orders probe"), list).map(&.name).should eq(["orders probe"])
       Repeater::SubtabFilter.suggestions("host:api", 8, list).should eq(["host:api.example.com"])
     end
 

--- a/spec/tui/intercept_view_spec.cr
+++ b/spec/tui/intercept_view_spec.cr
@@ -228,6 +228,97 @@ describe "Intercept filter bar" do
     end
   end
 
+  it "Tab-completes the condition and shows a suggestion row while editing" do
+    tmp_interceptor do |ic|
+      view = InterceptView.new
+      view.reload(ic)
+      view.start_query
+
+      # Cold start: nothing typed, so the row carries the standing field hint.
+      backend = MemoryBackend.new(100, 8)
+      view.render(Screen.new(backend), Rect.new(0, 0, 100, 8))
+      backend.row(1).includes?("fields:").should be_true
+
+      "me".each_char { |c| view.query_insert(c) }
+      view.query_suggestions.should eq(["method:"])
+      view.query_complete.should be_true
+      view.query.should eq("method:")
+
+      "P".each_char { |c| view.query_insert(c) }
+      backend = MemoryBackend.new(100, 8)
+      view.render(Screen.new(backend), Rect.new(0, 0, 100, 8))
+      backend.row(0).includes?("method:P").should be_true    # the input line
+      backend.row(1).includes?("method:POST").should be_true # the ↹ row below it
+      view.query_complete.should be_true
+      view.query.should eq("method:POST")
+    end
+  end
+
+  it "pushes the queue down by the suggestion row only while the condition is being edited" do
+    # The suggestion row grows the bar, so render() and every hit-test must agree on
+    # the offset — a stale FILTER_BAR_H would leave clicks selecting the wrong row.
+    tmp_interceptor do |ic|
+      hold_req(ic, "acme.test", "/login", "GET /login HTTP/1.1\r\nHost: acme.test\r\n\r\n")
+      view = InterceptView.new
+      view.reload(ic)
+
+      backend = MemoryBackend.new(100, 12)
+      view.render(Screen.new(backend), Rect.new(0, 0, 100, 12))
+      idle_row = (0...12).find { |y| backend.row(y).includes?("QUEUE (1)") }
+
+      view.start_query
+      backend = MemoryBackend.new(100, 12)
+      view.render(Screen.new(backend), Rect.new(0, 0, 100, 12))
+      query_row = (0...12).find { |y| backend.row(y).includes?("QUEUE (1)") }
+
+      idle_row.should_not be_nil
+      query_row.should eq(idle_row.not_nil! + 1)
+      # And the click hit-test follows the same offset (row 0 of the queue card).
+      view.list_row_at(Rect.new(0, 0, 100, 12), 3, query_row.not_nil! + 1).should eq(0)
+    end
+  end
+
+  it "highlights the condition's operators, fields and grouping while editing" do
+    tmp_interceptor do |ic|
+      view = InterceptView.new
+      view.reload(ic)
+      view.start_query
+      q = "(host:a OR host:b) -method:GET"
+      q.each_char { |c| view.query_insert(c) }
+
+      backend = MemoryBackend.new(100, 8)
+      view.render(Screen.new(backend), Rect.new(0, 0, 100, 8))
+      row = backend.row(0)
+      base = row.index(q).not_nil!
+      at = ->(needle : String) { backend.fg_at(base + q.index(needle).not_nil!, 0) }
+
+      at.call("(").should eq(Theme.syn_keyword)       # grouping
+      at.call("OR").should eq(Theme.syn_keyword)      # operator
+      at.call("-method").should eq(Theme.syn_keyword) # `-` is NOT, so it matches
+      at.call("host:").should eq(Theme.syn_header)    # field prefix
+      at.call("GET").should eq(Theme.text_bright)     # the value being matched
+    end
+  end
+
+  it "colours by how the query PARSES, not by how it looks" do
+    # A lowercase `or` and a paren inside a value are not operators, so they must not be
+    # painted as any. This is the property that makes the colour trustworthy.
+    tmp_interceptor do |ic|
+      view = InterceptView.new
+      view.reload(ic)
+      view.start_query
+      q = "path:/a(b) or x"
+      q.each_char { |c| view.query_insert(c) }
+
+      backend = MemoryBackend.new(100, 8)
+      view.render(Screen.new(backend), Rect.new(0, 0, 100, 8))
+      base = backend.row(0).index(q).not_nil!
+      backend.fg_at(base + q.index("(b)").not_nil!, 0).should eq(Theme.text_bright) # part of the value
+      backend.fg_at(base + q.index("or").not_nil!, 0).should eq(Theme.text_bright)  # free text, not OR
+      backend.fg_at(base + q.index("path:").not_nil!, 0).should eq(Theme.syn_header)
+    end
+  end
+
   it "keeps the queue rendered below the filter bar" do
     tmp_interceptor do |ic|
       hold_req(ic, "acme.test", "/login", "GET /login HTTP/1.1\r\nHost: acme.test\r\n\r\n")

--- a/src/gori/filter_ast.cr
+++ b/src/gori/filter_ast.cr
@@ -1,0 +1,466 @@
+module Gori
+  # The boolean grammar shared by every filter surface — History QL, Intercept catch
+  # rules, Repeater sub-tabs, Issues and Probe. It owns ONLY the shape of a query
+  # (how tokens are cut, grouped and combined); what a single token MEANS stays with
+  # each backend, because they legitimately differ (QL compiles to SQL and drops a bad
+  # numeric term, Probe keeps a half-typed `-host:` matching everything so the list
+  # doesn't blank out mid-keystroke). Backends fold a parsed tree into their own
+  # representation with `build`.
+  #
+  #   host:acme status:>=500          AND is implicit (whitespace)
+  #   host:a AND host:b               ...and also spellable, since typing AND and
+  #                                   having it silently free-text was a trap
+  #   host:a OR host:b                OR
+  #   (host:a OR host:b) -method:GET  parentheses group; `-` negates one term
+  #   NOT (host:cdn OR host:static)   NOT negates a term OR a whole group
+  #   host:"my host"  "two words"     quotes keep spaces inside one token
+  #
+  # `AND`/`OR`/`NOT` are recognised UPPERCASE-only and unquoted, so the far more
+  # common case of searching for the words "and"/"or"/"not" still works; quote them
+  # ("AND") to force a literal even in caps. Precedence is NOT > AND > OR.
+  module FilterAst
+    # One `field:value` / `field~value` / bare-word predicate — the leaf every backend
+    # parses for itself. `text` is normalised for matching (quotes and the leading `-`
+    # removed); `source` is the chunk exactly as typed, which diagnostics echo back
+    # (QL's `analyze`) and Tab-completion splices over.
+    #
+    # `negate` rides on the LEAF rather than becoming a NotNode because the backends
+    # disagree about negating an EMPTY value — `-host:` filters nothing in Probe but
+    # matches nothing in Issues — and that difference is deliberate and spec-pinned in
+    # both. A NotNode wrapper would silently unify them. `NOT term` desugars onto this
+    # same flag, so the keyword and the `-` prefix stay exactly equivalent.
+    struct Term
+      getter text : String
+      getter source : String
+      getter? negate : Bool
+
+      def initialize(@text : String, @source : String, @negate : Bool = false)
+      end
+
+      # `NOT` applied to a single term: flip the flag rather than nest, so
+      # `NOT host:a` and `-host:a` compile to the identical leaf.
+      def negated : Term
+        Term.new(@text, @source, !@negate)
+      end
+    end
+
+    abstract class Node
+    end
+
+    class TermNode < Node
+      getter term : Term
+
+      def initialize(@term : Term)
+      end
+    end
+
+    # AND / OR over two or more children (the parser never builds a 1-child group).
+    class AndNode < Node
+      getter children : Array(Node)
+
+      def initialize(@children : Array(Node))
+      end
+    end
+
+    class OrNode < Node
+      getter children : Array(Node)
+
+      def initialize(@children : Array(Node))
+      end
+    end
+
+    # `NOT (group)` only — `NOT term` desugars onto Term#negate above.
+    class NotNode < Node
+      getter child : Node
+
+      def initialize(@child : Node)
+      end
+    end
+
+    # --- lexing --------------------------------------------------------------
+
+    private enum Tok
+      Word
+      And
+      Or
+      Not
+      LParen
+      RParen
+    end
+
+    # `start`/`size` are the lexeme's character span in the ORIGINAL query (quotes
+    # included), which is what syntax highlighting paints over.
+    private record Lexeme, tok : Tok, term : Term?, start : Int32, size : Int32
+
+    # Cut the query into lexemes. Whitespace separates chunks unless it sits inside
+    # double quotes; a quote is a grouping device only (it never survives into `text`).
+    #
+    # PARENTHESES are position-sensitive on purpose. A URL path is full of them
+    # (`path:/a(b)`), and treating every paren as syntax would break queries that work
+    # today. So `(` opens a group only at the START of a chunk, and `)` closes one only
+    # at the END of a chunk AND only while a group is actually open. `path:/a(b)` is
+    # therefore one literal word, while `(host:a OR host:b)` groups as written. Quote
+    # the value (`path:"/a(b)"`) to force a literal in any position.
+    private def self.lex(query : String) : Array(Lexeme)
+      acc = [] of Lexeme
+      depth = 0
+      each_chunk(query) do |raw, chars, quoted_any, at|
+        lead = 0
+        while lead < chars.size && chars[lead][0] == '(' && !chars[lead][1]
+          lead += 1
+        end
+        trail = 0
+        # `depth + lead` — a chunk may open and close its own group (`(a)`).
+        while trail < chars.size - lead &&
+              chars[chars.size - 1 - trail][0] == ')' && !chars[chars.size - 1 - trail][1] &&
+              depth + lead - trail > 0
+          trail += 1
+        end
+
+        # `raw` is contiguous in the source (quoted whitespace is kept, unquoted
+        # whitespace ended the chunk), so a source position is just `at + index`.
+        lead.times { |k| acc << Lexeme.new(Tok::LParen, nil, at + k, 1) }
+        depth += lead
+
+        word_len = raw.size - lead - trail
+        text = String.build { |io| chars[lead, chars.size - lead - trail].each { |c| io << c[0] } }
+        unless text.empty?
+          acc << Lexeme.new(word_tok(text, quoted_any), word_term(text, raw[lead, word_len]),
+            at + lead, word_len)
+        end
+
+        trail.times { |k| acc << Lexeme.new(Tok::RParen, nil, at + lead + word_len + k, 1) }
+        depth -= trail
+      end
+      acc
+    end
+
+    # Keywords are UPPERCASE and unquoted; anything else is a searchable word.
+    private def self.word_tok(text : String, quoted_any : Bool) : Tok
+      return Tok::Word if quoted_any
+      case text
+      when "AND" then Tok::And
+      when "OR"  then Tok::Or
+      when "NOT" then Tok::Not
+      else            Tok::Word
+      end
+    end
+
+    # A leading `-` negates, but only with something after it — a lone `-` is a word
+    # (the backends that free-text it have always done so).
+    private def self.word_term(text : String, source : String) : Term
+      if text.starts_with?('-') && text.size > 1
+        Term.new(text[1..], source, true)
+      else
+        Term.new(text, source, false)
+      end
+    end
+
+    # Split on unquoted whitespace, yielding the chunk as typed (`raw`), its chars with
+    # the quote marks removed and each flagged as quoted-or-not, whether the chunk
+    # carried any quoting at all (which suppresses keyword recognition), and the chunk's
+    # starting character offset in `query`.
+    private def self.each_chunk(query : String, & : String, Array({Char, Bool}), Bool, Int32 ->) : Nil
+      raw = String::Builder.new
+      chars = [] of {Char, Bool}
+      quoted_any = false
+      in_quote = false
+      start = 0
+      pending = false
+
+      query.each_char_with_index do |ch, i|
+        if ch == '"'
+          start = i unless pending
+          in_quote = !in_quote
+          quoted_any = true
+          raw << ch
+          pending = true
+        elsif ch.whitespace? && !in_quote
+          if pending
+            yield raw.to_s, chars, quoted_any, start
+            raw = String::Builder.new
+            chars = [] of {Char, Bool}
+            quoted_any = false
+            pending = false
+          end
+        else
+          start = i unless pending
+          raw << ch
+          chars << {ch, in_quote}
+          pending = true
+        end
+      end
+      yield raw.to_s, chars, quoted_any, start if pending
+    end
+
+    # --- parsing -------------------------------------------------------------
+
+    # Parse a query into a tree, or nil when it holds nothing to match on. Deliberately
+    # FORGIVING about structure: these queries are re-parsed on every keystroke, so an
+    # unclosed `(` simply closes at end-of-input and a dangling operator is ignored,
+    # rather than blanking the list while the user is still typing.
+    def self.parse(query : String) : Node?
+      lexemes = lex(query)
+      return nil if lexemes.empty?
+      pos = 0
+      node, _ = parse_or(lexemes, pos)
+      node
+    end
+
+    private def self.parse_or(lx : Array(Lexeme), pos : Int32) : {Node?, Int32}
+      node, pos = parse_and(lx, pos)
+      children = node ? [node] : [] of Node
+      while pos < lx.size && lx[pos].tok.or?
+        pos += 1
+        rhs, pos = parse_and(lx, pos)
+        children << rhs if rhs
+      end
+      return {nil, pos} if children.empty?
+      {children.size == 1 ? children.first : OrNode.new(children), pos}
+    end
+
+    # AND binds tighter than OR. The operator is optional: adjacent terms combine with
+    # AND, which is what whitespace has always meant here.
+    private def self.parse_and(lx : Array(Lexeme), pos : Int32) : {Node?, Int32}
+      children = [] of Node
+      loop do
+        while pos < lx.size && lx[pos].tok.and? # explicit AND, or a stray one
+          pos += 1
+        end
+        break if pos >= lx.size || lx[pos].tok.or? || lx[pos].tok.r_paren?
+        node, pos = parse_unary(lx, pos)
+        break unless node
+        children << node
+      end
+      return {nil, pos} if children.empty?
+      {children.size == 1 ? children.first : AndNode.new(children), pos}
+    end
+
+    private def self.parse_unary(lx : Array(Lexeme), pos : Int32) : {Node?, Int32}
+      if pos < lx.size && lx[pos].tok.not?
+        node, pos = parse_unary(lx, pos + 1)
+        return {nil, pos} unless node
+        # A lone term flips its own flag; only a group needs a wrapper.
+        return {node.is_a?(TermNode) ? TermNode.new(node.term.negated) : NotNode.new(node), pos}
+      end
+      parse_primary(lx, pos)
+    end
+
+    private def self.parse_primary(lx : Array(Lexeme), pos : Int32) : {Node?, Int32}
+      return {nil, pos} if pos >= lx.size
+      lexeme = lx[pos]
+      if lexeme.tok.l_paren?
+        node, pos = parse_or(lx, pos + 1)
+        pos += 1 if pos < lx.size && lx[pos].tok.r_paren? # tolerate the unclosed group
+        return {node, pos}
+      end
+      if term = lexeme.term
+        return {TermNode.new(term), pos + 1}
+      end
+      # A `)` reached here only via a dangling `NOT )` — leave it for the enclosing
+      # group to consume, so the paren depth stays balanced.
+      {nil, pos}
+    end
+
+    # Every leaf, left to right, for callers that report on terms rather than match
+    # with them (QL's `analyze` / `invalid_regex_terms`).
+    def self.terms(node : Node?) : Array(Term)
+      acc = [] of Term
+      collect(node, acc)
+      acc
+    end
+
+    # NOTE: `out` is a Crystal keyword and cannot be passed as an argument — hence `acc`.
+    private def self.collect(node : Node?, acc : Array(Term)) : Nil
+      case node
+      when TermNode then acc << node.term
+      when NotNode  then collect(node.child, acc)
+      when AndNode  then node.children.each { |c| collect(c, acc) }
+      when OrNode   then node.children.each { |c| collect(c, acc) }
+      end
+    end
+
+    # --- syntax highlighting -------------------------------------------------
+
+    enum SpanKind
+      Operator # AND / OR / NOT, and the `-` prefix (which means the same thing)
+      Paren    # a `(`/`)` that actually groups
+      Field    # the `host:` / `body~` prefix, separator included
+      Value    # what follows a field separator
+      Quote    # the `"` marks themselves
+      Plain    # a bare free-text word
+    end
+
+    record Span, start : Int32, size : Int32, kind : SpanKind
+
+    # Classify a query for highlighting, driven by the SAME lexer the parser runs. That
+    # equivalence is the point: whatever is painted as an operator is exactly what ACTS
+    # as one, so a lowercase `or`, a quoted "AND", and a `(` inside a value all stay
+    # plain — the colour tells you how the query will really be read.
+    #
+    # Spans are ordered and non-overlapping, but need not cover every character
+    # (whitespace between terms is skipped); callers fill gaps with their base colour.
+    def self.spans(query : String) : Array(Span)
+      acc = [] of Span
+      lex(query).each do |lexeme|
+        case lexeme.tok
+        when .l_paren?, .r_paren?
+          acc << Span.new(lexeme.start, lexeme.size, SpanKind::Paren)
+        when .and?, .or?, .not?
+          acc << Span.new(lexeme.start, lexeme.size, SpanKind::Operator)
+        else
+          word_spans(query, lexeme, acc)
+        end
+      end
+      acc
+    end
+
+    # Index of the `:`/`~` that makes `[from, to)` a field term, or nil for free text.
+    # Needs at least one character of field name before it, and a quote appearing first
+    # means the whole thing is a quoted phrase rather than a `field:value`.
+    private def self.field_sep(query : String, from : Int32, to : Int32) : Int32?
+      j = from
+      while j < to
+        ch = query[j]
+        return nil if ch == '"'
+        return j if (ch == ':' || ch == '~') && j > from
+        j += 1
+      end
+      nil
+    end
+
+    # Sub-classify one word: an optional `-`, an optional `field:`/`field~` prefix, then
+    # the remainder with any quote marks called out.
+    private def self.word_spans(query : String, lexeme : Lexeme, acc : Array(Span)) : Nil
+      s = lexeme.start
+      e = s + lexeme.size
+      i = s
+      if query[i]? == '-' && lexeme.size > 1
+        acc << Span.new(i, 1, SpanKind::Operator) # `-x` is `NOT x`; colour them alike
+        i += 1
+      end
+
+      sep = field_sep(query, i, e)
+      if sep
+        acc << Span.new(i, sep - i + 1, SpanKind::Field)
+        i = sep + 1
+      end
+
+      kind = sep ? SpanKind::Value : SpanKind::Plain
+      run = i
+      while i < e
+        if query[i] == '"'
+          acc << Span.new(run, i - run, kind) if i > run
+          acc << Span.new(i, 1, SpanKind::Quote)
+          run = i + 1
+        end
+        i += 1
+      end
+      acc << Span.new(run, e - run, kind) if e > run
+    end
+
+    # --- Tab-completion support ----------------------------------------------
+
+    # The token under the caret, split so a completion can splice in place. `prefix` is
+    # the punctuation a candidate must carry over untouched — an opening `(`, then a `-`
+    # negation — and `core` is what actually gets matched and replaced. `start`/`stop`
+    # bound the whole token in the query. Shared by every filter bar so a leading paren
+    # or a negation behaves the same wherever you type it.
+    record Cursor, prefix : String, core : String, start : Int32, stop : Int32
+
+    def self.token_at(query : String, cx : Int32) : Cursor
+      cx = cx.clamp(0, query.size)
+      s = cx
+      while s > 0 && !query[s - 1].whitespace?
+        s -= 1
+      end
+      e = cx
+      while e < query.size && !query[e].whitespace?
+        e += 1
+      end
+      token = query[s...e]
+      i = 0
+      while i < token.size && token[i] == '('
+        i += 1
+      end
+      i += 1 if i < token.size - 1 && token[i] == '-' # `-` negates only with more after it
+      Cursor.new(token[0...i], token[i..], s, e)
+    end
+
+    # Strip a half-typed opening quote off a value prefix, so `host:"exa` still
+    # completes against `example.com`.
+    def self.unquote_prefix(value : String) : String
+      value.starts_with?('"') ? value[1..] : value
+    end
+
+    # Quote a completed value only when it needs it — an unquoted space would split the
+    # token in two the next time the query is parsed.
+    def self.quote(value : String) : String
+      value.each_char.any?(&.whitespace?) ? %("#{value}") : value
+    end
+
+    # --- folding into a backend tree -----------------------------------------
+
+    # Named for the operators rather than All/Any, both because it reads closer to the
+    # query and because `op.any?` would collide with Enumerable#any? for every reader
+    # (human and linter) of a `tree.children.any?` line right beside it.
+    enum Op
+      Leaf
+      And
+      Or
+      Not
+    end
+
+    # A parsed query compiled to one backend's leaves — a SQL fragment + bound args
+    # for QL, a pre-parsed predicate record for the in-memory filters. Building it once
+    # at parse time keeps matching allocation-free, which the Intercept hold gate needs
+    # (it evaluates one per in-flight message on the proxy path).
+    class Tree(T)
+      getter op : Op
+      getter children : Array(Tree(T))
+
+      def initialize(@op : Op, @leaf : T? = nil, @children : Array(Tree(T)) = [] of Tree(T))
+      end
+
+      # Only meaningful for Op::Leaf.
+      def leaf : T
+        @leaf.as(T)
+      end
+
+      # Every compiled leaf, left to right — for callers that INSPECT a query rather
+      # than match with it (e.g. Probe asking whether status is constrained at all).
+      def leaves : Array(T)
+        acc = [] of T
+        collect_leaves(acc)
+        acc
+      end
+
+      protected def collect_leaves(acc : Array(T)) : Nil
+        @op.leaf? ? (acc << leaf) : @children.each(&.collect_leaves(acc))
+      end
+    end
+
+    # Fold a parsed tree into a backend tree. `leaf` compiles one Term and may return
+    # nil to DROP it (a bad numeric, an empty value); a combinator left with no
+    # surviving children drops in turn, so a query whose every term was dropped folds
+    # to nil — which every backend already reads as "no constraint".
+    def self.build(node : Node?, &leaf : Term -> T?) : Tree(T)? forall T
+      node ? build_node(node, leaf) : nil
+    end
+
+    private def self.build_node(node : Node, leaf : Proc(Term, T?)) : Tree(T)? forall T
+      case node
+      when TermNode
+        (v = leaf.call(node.term)) ? Tree(T).new(Op::Leaf, v) : nil
+      when NotNode
+        (c = build_node(node.child, leaf)) ? Tree(T).new(Op::Not, nil, [c]) : nil
+      when AndNode, OrNode
+        kids = [] of Tree(T)
+        node.children.each { |child| (k = build_node(child, leaf)) && kids << k }
+        return nil if kids.empty?
+        return kids.first if kids.size == 1
+        Tree(T).new(node.is_a?(AndNode) ? Op::And : Op::Or, nil, kids)
+      end
+    end
+  end
+end

--- a/src/gori/intercept_filter.cr
+++ b/src/gori/intercept_filter.cr
@@ -1,9 +1,11 @@
+require "./filter_ast"
+
 module Gori
   # An in-memory boolean filter that NARROWS what the Interceptor holds — the
-  # "conditional intercept" lens. It mirrors the QL surface (`field:value`, `OR`
-  # groups, `-`negation, bare free-text) but evaluates against a LIVE in-flight
-  # message at the hold gate, BEFORE anything is captured — so QL's SQL compilation
-  # can't be reused (there's no row to query yet). Supported fields:
+  # "conditional intercept" lens. It shares QL's grammar (FilterAst: AND/OR/NOT,
+  # parentheses, `-`negation, quoting, bare free-text) but evaluates against a LIVE
+  # in-flight message at the hold gate, BEFORE anything is captured — so QL's SQL
+  # compilation can't be reused (there's no row to query yet). Supported fields:
   #
   #   host:acme        substring of the host
   #   path:/api        substring of the request target (path+query)
@@ -49,64 +51,98 @@ module Gori
 
     EMPTY = new("")
 
+    # Completable field names, in the order the suggestion row offers them. This list is
+    # deliberately a strict SUBSET of History's QL fields — a hold gate has no row to
+    # query, so `body:`/`header:`/`size:`/`dur:` have nothing to match against. It must
+    # stay in lockstep with field_symbol below: completing a field this parser doesn't
+    # know would silently degrade the whole token to free text (see parse_term).
+    FIELDS = %w(host path method scheme status)
+
+    # Static value pools for the low-cardinality fields (mirrors History's). `host:`
+    # has no static pool — its candidates are injected by the caller (the TUI passes
+    # the store's DISTINCT hosts); `path:` has none at all, since paths are unbounded.
+    METHOD_VAL = %w(GET POST PUT PATCH DELETE HEAD OPTIONS QUERY)
+    SCHEME_VAL = %w(http https)
+    STATUS_VAL = %w(2xx 3xx 4xx 5xx >=400 >=500 200 301 302 401 403 404 500 502 503)
+
+    # Tab-complete candidates for the token under `cx`: field names until a `:` is
+    # typed, then that field's values. The grammar's punctuation is carried through by
+    # FilterAst::Cursor, so `-ho` → `-host:` and `(ho` → `(host:`. `hosts` is the
+    # caller-supplied host pool (already prefix-filtered by the store query). Empty when
+    # the caret sits on blank space, or on a token nothing matches (the human is then
+    # deliberately free-texting a word).
+    def self.suggestions(query : String, cx : Int32, hosts : Array(String) = [] of String) : Array(String)
+      cur = FilterAst.token_at(query, cx)
+      return [] of String if cur.core.empty?
+      if (colon = cur.core.index(':')) && colon > 0
+        field = cur.core[0...colon].downcase
+        prefix = FilterAst.unquote_prefix(cur.core[(colon + 1)..])
+        suggest_values(field, prefix, hosts).map { |v| "#{cur.prefix}#{field}:#{FilterAst.quote(v)}" }
+      else
+        FIELDS.select(&.starts_with?(cur.core.downcase)).map { |f| "#{cur.prefix}#{f}:" }
+      end
+    end
+
+    private def self.suggest_values(field : String, prefix : String, hosts : Array(String)) : Array(String)
+      p = prefix.downcase
+      values = case field
+               when "host"   then hosts
+               when "method" then METHOD_VAL
+               when "scheme" then SCHEME_VAL
+               when "status" then STATUS_VAL
+               else               return [] of String
+               end
+      values.select(&.downcase.starts_with?(p))
+    end
+
     getter source : String
 
+    @tree : FilterAst::Tree(Term)?
+
     def initialize(@source : String)
-      @groups = InterceptFilter.compile(@source) # OR of AND-groups (Array(Array(Term)))
+      # Compiled once here, so matching walks a ready tree — the hold gate evaluates
+      # one per in-flight message on the proxy path.
+      @tree = FilterAst.build(FilterAst.parse(@source)) { |t| InterceptFilter.parse_term(t) }
     end
 
     # No effective predicates → matches everything (the default "hold all" behaviour).
     def blank? : Bool
-      @groups.empty?
+      @tree.nil?
     end
 
-    # Match: OR across groups, AND within a group (mirrors QL.parse's grouping). An
-    # empty filter matches all. Called on the proxy hot path, so it allocates nothing.
+    # An empty filter matches all. Allocates nothing.
     def matches?(s : Subject) : Bool
-      groups = @groups
-      return true if groups.empty?
-      groups.any? { |group| group.all?(&.matches?(s)) }
+      tree = @tree
+      return true unless tree
+      eval(tree, s)
     end
 
-    # Parse a query into OR-separated AND-groups of Terms (the same shape QL.parse
-    # builds before it emits SQL). Empty-valued / unparsable terms are dropped; a
-    # group with no surviving terms is dropped; no groups → match-all.
-    protected def self.compile(query : String) : Array(Array(Term))
-      tokens = query.split
-      return [] of Array(Term) if tokens.empty?
-
-      groups = [[] of String]
-      tokens.each { |tok| tok == "OR" ? (groups << [] of String) : groups.last << tok }
-
-      compiled = [] of Array(Term)
-      groups.each do |group|
-        terms = [] of Term
-        group.each do |tok|
-          if term = parse_term(tok)
-            terms << term
-          end
-        end
-        compiled << terms unless terms.empty?
+    private def eval(tree : FilterAst::Tree(Term), s : Subject) : Bool
+      case tree.op
+      in .leaf? then tree.leaf.matches?(s)
+      in .not?  then !eval(tree.children.first, s)
+      in .and?  then tree.children.all? { |c| eval(c, s) }
+      in .or?   then tree.children.any? { |c| eval(c, s) }
       end
-      compiled
     end
 
-    private def self.parse_term(token : String) : Term?
-      negate = token.starts_with?('-')
-      token = token[1..] if negate
-      return nil if token.empty?
+    # Compile one grammar term. nil DROPS it (an empty value, e.g. `host:` mid-type),
+    # which folds up to match-all — so the queue doesn't blank out while typing.
+    protected def self.parse_term(term : FilterAst::Term) : Term?
+      text = term.text
+      return nil if text.empty?
 
-      colon = token.index(':')
+      colon = text.index(':')
       if colon && colon > 0
-        field = field_symbol(token[0...colon].downcase)
+        field = field_symbol(text[0...colon].downcase)
         # An unknown field → free-text the WHOLE token (mirrors QL / Issues::Filter), so a
         # typo'd field like `hsot:evil.com` searches literally instead of silently matching "evil.com".
-        return Term.new(:text, token, negate) if field == :text
-        value = token[(colon + 1)..]
+        return Term.new(:text, text, term.negate?) if field == :text
+        value = text[(colon + 1)..]
         return nil if value.empty?
-        Term.new(field, value, negate)
+        Term.new(field, value, term.negate?)
       else
-        Term.new(:text, token, negate)
+        Term.new(:text, text, term.negate?)
       end
     end
 

--- a/src/gori/issues_query.cr
+++ b/src/gori/issues_query.cr
@@ -1,4 +1,5 @@
 require "./store"
+require "./filter_ast"
 
 module Gori
   module Issues
@@ -16,40 +17,45 @@ module Gori
       private record Term, kind : Symbol, op : Symbol, text : String, negate : Bool
 
       def self.parse(query : String) : Filter
-        terms = [] of Term
-        query.split.each do |raw|
-          next if raw.empty?
-          negate = false
-          tok = raw
-          if tok.starts_with?('-') && tok.size > 1
-            negate = true
-            tok = tok[1..]
-          end
-          terms << build_term(tok, negate)
-        end
-        new(terms)
+        new(FilterAst.build(FilterAst.parse(query)) { |t| build_term(t) })
       end
 
-      def initialize(@terms : Array(Term))
+      def initialize(@tree : FilterAst::Tree(Term)?)
       end
 
       def empty? : Bool
-        @terms.empty?
+        @tree.nil?
       end
 
-      # Keep store order; every term must match (AND). An empty filter passes all.
+      # Keep store order. An empty filter passes all.
       def apply(issues : Array(Store::Issue)) : Array(Store::Issue)
-        return issues if @terms.empty?
+        return issues if @tree.nil?
         issues.select { |f| matches?(f) }
       end
 
       def matches?(f : Store::Issue) : Bool
-        @terms.all? { |t| match_term(t, f) }
+        tree = @tree
+        return true unless tree
+        eval(tree, f)
+      end
+
+      private def eval(tree : FilterAst::Tree(Term), f : Store::Issue) : Bool
+        case tree.op
+        in .leaf? then match_term(tree.leaf, f)
+        in .not?  then !eval(tree.children.first, f)
+        in .and?  then tree.children.all? { |c| eval(c, f) }
+        in .or?   then tree.children.any? { |c| eval(c, f) }
+        end
       end
 
       # --- parsing -------------------------------------------------------------
 
-      private def self.build_term(tok : String, negate : Bool) : Term
+      # Never drops a term: an empty value is kept and resolved in match_term, which
+      # is where this filter's "`status:` matches all, `-status:` matches none" rule
+      # lives (Probe deliberately differs — see Probe::Filter#match_term).
+      private def self.build_term(t : FilterAst::Term) : Term
+        tok = t.text
+        negate = t.negate?
         if colon = tok.index(':')
           field = tok[0...colon].downcase
           value = tok[(colon + 1)..]

--- a/src/gori/probe_query.cr
+++ b/src/gori/probe_query.cr
@@ -1,4 +1,5 @@
 require "./store"
+require "./filter_ast"
 
 module Gori
   module Probe
@@ -17,44 +18,50 @@ module Gori
       private record Term, kind : Symbol, op : Symbol, text : String, negate : Bool
 
       def self.parse(query : String) : Filter
-        terms = [] of Term
-        query.split.each do |raw|
-          next if raw.empty?
-          negate = false
-          tok = raw
-          if tok.starts_with?('-') && tok.size > 1
-            negate = true
-            tok = tok[1..]
-          end
-          terms << build_term(tok, negate)
-        end
-        new(terms)
+        new(FilterAst.build(FilterAst.parse(query)) { |t| build_term(t) })
       end
 
-      def initialize(@terms : Array(Term))
+      def initialize(@tree : FilterAst::Tree(Term)?)
       end
 
       def empty? : Bool
-        @terms.empty?
+        @tree.nil?
       end
 
       # True when the query explicitly constrains status (status:/st:, possibly negated),
       # so the list view skips its default open-only restriction and honours the user's
-      # explicit choice of statuses instead.
+      # explicit choice of statuses instead. Anywhere in the tree counts — a status term
+      # inside an OR branch is still the user asking about status.
       def has_status_term? : Bool
-        @terms.any? { |t| t.kind == :status }
+        @tree.try(&.leaves.any? { |t| t.kind == :status }) || false
       end
 
       def apply(issues : Array(Store::ProbeIssue)) : Array(Store::ProbeIssue)
-        return issues if @terms.empty?
+        return issues if @tree.nil?
         issues.select { |i| matches?(i) }
       end
 
       def matches?(i : Store::ProbeIssue) : Bool
-        @terms.all? { |t| match_term(t, i) }
+        tree = @tree
+        return true unless tree
+        eval(tree, i)
       end
 
-      private def self.build_term(tok : String, negate : Bool) : Term
+      private def eval(tree : FilterAst::Tree(Term), i : Store::ProbeIssue) : Bool
+        case tree.op
+        in .leaf? then match_term(tree.leaf, i)
+        in .not?  then !eval(tree.children.first, i)
+        in .and?  then tree.children.all? { |c| eval(c, i) }
+        in .or?   then tree.children.any? { |c| eval(c, i) }
+        end
+      end
+
+      # Never drops a term; an empty value is resolved in match_term, which here makes
+      # even a NEGATED empty term (`-host:`) filter nothing — deliberately unlike
+      # Issues::Filter, so a half-typed negation can't blank the whole list.
+      private def self.build_term(t : FilterAst::Term) : Term
+        tok = t.text
+        negate = t.negate?
         if colon = tok.index(':')
           field = tok[0...colon].downcase
           value = tok[(colon + 1)..]

--- a/src/gori/ql.cr
+++ b/src/gori/ql.cr
@@ -1,4 +1,5 @@
 require "db"
+require "./filter_ast"
 
 module Gori
   # The query language (DESIGN.md §4): a Lucene/KQL-style boolean filter over the
@@ -6,8 +7,8 @@ module Gori
   # always parameterised — never interpolated — so the projection columns stay
   # injection-safe). The analysis surface; QL is how you find things (P8: pull).
   #
-  #   host:acme status:>=500            # AND of terms
-  #   method:post path:/api OR status:5xx # OR of AND-groups
+  #   host:acme status:>=500            # AND of terms (whitespace)
+  #   (host:a OR host:b) -method:GET    # OR, grouping, negation
   #   -host:cdn  status:5xx  login      # negation, status class, free text
   #   body:token                        # scan request/response body bytes
   #   size:>10000 dur:>=500 dur:<2s     # total bytes (req+resp) / latency (ms; ms|s)
@@ -28,13 +29,24 @@ module Gori
 
     EMPTY = Filter.new("1", [] of DB::Any)
 
+    # What one term compiles to: a SQL fragment plus the values bound into its `?`s.
+    alias SqlTerm = {String, Array(DB::Any)}
+
     # One-page reference for MCP clients / models. Kept in sync with the parser above.
     REFERENCE = <<-DOC
-      gori QL filters captured HTTP flows (AND within a group, OR between groups):
+      gori QL filters captured HTTP flows:
 
-        host:example.com status:>=500 method:POST   # AND of terms
-        host:api OR status:5xx                        # OR of AND-groups
-        -host:cdn login                               # negation + free-text search
+        host:example.com status:>=500 method:POST   # AND is implicit (whitespace)
+        host:api AND status:5xx                     # ...and can also be spelled out
+        host:api OR status:5xx                      # OR
+        (host:a OR host:b) -method:GET              # parentheses group
+        NOT (host:cdn OR host:static)               # NOT negates a term or a group
+        host:"my host"  "two words"                 # quotes keep spaces in one term
+        -host:cdn login                             # negation + free-text search
+
+      AND/OR/NOT are recognised UPPERCASE and unquoted, so searching for the words
+      and/or/not still works; quote them ("AND") to force a literal. Precedence is
+      NOT > AND > OR. `-term` and `NOT term` are equivalent.
 
       Fields (use : for value match, ~ for regex):
         host path method scheme proto status size reqsize respsize dur header body url
@@ -68,30 +80,37 @@ module Gori
       Filter.new("(#{a.sql}) AND (#{b.sql})", a.args + b.args)
     end
 
+    # Boolean structure (AND/OR/NOT, parentheses, quoting) comes from the shared
+    # FilterAst grammar; QL only says what a single term compiles to. A term the
+    # backend rejects (bad numeric, unknown proto) folds away, and a combinator left
+    # with nothing folds away in turn — so a query whose every term was dropped
+    # yields EMPTY, exactly as the old flat parser did.
     def self.parse(query : String) : Filter
-      tokens = query.split
-      return EMPTY if tokens.empty?
-
-      groups = [[] of String]
-      tokens.each do |tok|
-        tok == "OR" ? (groups << [] of String) : groups.last << tok
-      end
-
+      tree = FilterAst.build(FilterAst.parse(query)) { |t| term_to_sql(t) }
+      return EMPTY unless tree
       args = [] of DB::Any
-      clauses = [] of String
-      groups.each do |group|
-        conds = [] of String
-        group.each do |term|
-          if result = term_to_sql(term)
-            cond, cargs = result
-            conds << cond
-            args.concat(cargs)
-          end
-        end
-        clauses << "(#{conds.join(" AND ")})" unless conds.empty?
-      end
+      Filter.new(wrap_sql(tree, args), args)
+    end
 
-      clauses.empty? ? EMPTY : Filter.new(clauses.join(" OR "), args)
+    # A bare leaf/negation is parenthesised at the top so the fragment is always safe
+    # to splice after "WHERE " and to AND with the Scope lens (QL.and).
+    private def self.wrap_sql(tree : FilterAst::Tree(SqlTerm), args : Array(DB::Any)) : String
+      sql = tree_sql(tree, args)
+      tree.op.and? || tree.op.or? ? sql : "(#{sql})"
+    end
+
+    # Depth-first, left to right — `args` MUST be appended in the same order the `?`
+    # placeholders are emitted, or every bound value shifts by one.
+    private def self.tree_sql(tree : FilterAst::Tree(SqlTerm), args : Array(DB::Any)) : String
+      case tree.op
+      in .leaf?
+        cond, cargs = tree.leaf
+        args.concat(cargs)
+        cond
+      in .not? then "NOT (#{tree_sql(tree.children.first, args)})"
+      in .and? then "(#{tree.children.map { |c| tree_sql(c, args) }.join(" AND ")})"
+      in .or?  then "(#{tree.children.map { |c| tree_sql(c, args) }.join(" OR ")})"
+      end
     end
 
     # A `~` (regex) term whose pattern fails to compile silently degrades to a
@@ -104,23 +123,11 @@ module Gori
     # terms that would compile to the never-match clause — no more, no less.
     def self.invalid_regex_terms(query : String) : Array(String)
       bad = [] of String
-      query.split.each do |tok|
-        next if tok == "OR"
-        term = tok.starts_with?('-') ? tok[1..] : tok
-        next if term.empty?
-
-        ci = term.index(':')
-        ti = term.index('~')
-        sep = [ci, ti].compact.min?
-        next unless sep && sep > 0 && ti == sep # a regex op, not free text / field op
-
-        field = term[0...sep].downcase
-        next unless field.in?("host", "path", "url", "header", "body")
-
-        value = term[(sep + 1)..]
+      FilterAst.terms(FilterAst.parse(query)).each do |term|
+        field, value, op = split_field(term.text) || next
+        next unless op == :regex && field.in?(REGEX_FIELDS)
         next if value.empty?
-
-        bad << tok unless valid_regex?(value)
+        bad << term.source unless valid_regex?(value)
       end
       bad
     end
@@ -138,37 +145,43 @@ module Gori
     def self.analyze(query : String) : TermAnalysis
       applied = [] of String
       ignored = [] of String
-      query.split.each do |tok|
-        next if tok == "OR"
-        (term_to_sql(tok) ? applied : ignored) << tok
+      FilterAst.terms(FilterAst.parse(query)).each do |term|
+        (term_to_sql(term) ? applied : ignored) << term.source
       end
       TermAnalysis.new(applied, ignored, invalid_regex_terms(query))
     end
 
-    private def self.term_to_sql(term : String) : {String, Array(DB::Any)}?
-      negate = term.starts_with?('-')
-      term = term[1..] if negate
-      return nil if term.empty?
+    REGEX_FIELDS = %w(host path url header body)
 
-      # The field/operator separator is the first ':' (field op) or '~' (regex op) —
-      # whichever appears first wins, so a regex value may itself contain ':' (e.g.
-      # body~https?://x). A leading separator (`:foo` / `~foo`) is treated as free text.
-      ci = term.index(':')
-      ti = term.index('~')
+    # The field/operator split, shared by compilation and diagnosis so the two can't
+    # disagree about what counts as a term. The first ':' (field op) or '~' (regex op)
+    # wins — whichever appears first — so a regex value may itself contain ':' (e.g.
+    # body~https?://x). nil means free text: no separator, or a leading one (`:foo`).
+    private def self.split_field(text : String) : {String, String, Symbol}?
+      ci = text.index(':')
+      ti = text.index('~')
       sep = [ci, ti].compact.min?
+      return nil unless sep && sep > 0
+      {text[0...sep].downcase, text[(sep + 1)..], ti == sep ? :regex : :field}
+    end
+
+    # `term.text` arrives already stripped of its quotes and `-` prefix by the grammar;
+    # the negation rides on `term.negate?` and wraps whatever the field compiled to.
+    private def self.term_to_sql(term : FilterAst::Term) : SqlTerm?
+      text = term.text
+      return nil if text.empty?
 
       result =
-        if sep && sep > 0
-          field = term[0...sep].downcase
-          value = term[(sep + 1)..]
-          ti == sep ? regex_cond(field, value, term) : field_cond(field, value, term)
+        if split = split_field(text)
+          field, value, op = split
+          op == :regex ? regex_cond(field, value, text) : field_cond(field, value, text)
         else
-          free_text(term)
+          free_text(text)
         end
       return nil unless result
 
       cond, args = result
-      {negate ? "NOT (#{cond})" : cond, args}
+      {term.negate? ? "NOT (#{cond})" : cond, args}
     end
 
     private def self.field_cond(field : String, value : String, term : String) : {String, Array(DB::Any)}?
@@ -341,7 +354,7 @@ module Gori
       # the validity guard — otherwise `foo~[` (an unterminated char class) would compile to
       # the never-match clause instead of free-texting "foo~[".
       case field
-      when "host", "path", "url", "header", "body"
+      when "host", "path", "url", "header", "body" # = REGEX_FIELDS
         return nil if value.empty?
         # An invalid pattern would raise inside the SQLite REGEXP callback, so validate up
         # front and emit a never-matches clause instead.

--- a/src/gori/repeater/subtab_filter.cr
+++ b/src/gori/repeater/subtab_filter.cr
@@ -1,4 +1,5 @@
 require "uri"
+require "../filter_ast"
 
 module Gori
   module Repeater
@@ -61,35 +62,35 @@ module Gori
       private record Term, kind : Symbol, text : String, negate : Bool
 
       def self.parse(query : String) : SubtabFilter
-        terms = [] of Term
-        query.split.each do |raw|
-          next if raw.empty?
-          negate = false
-          tok = raw
-          if tok.starts_with?('-') && tok.size > 1
-            negate = true
-            tok = tok[1..]
-          end
-          terms << build_term(tok, negate)
-        end
-        new(terms)
+        new(FilterAst.build(FilterAst.parse(query)) { |t| build_term(t) })
       end
 
-      def initialize(@terms : Array(Term))
+      def initialize(@tree : FilterAst::Tree(Term)?)
       end
 
       def empty? : Bool
-        @terms.empty?
+        @tree.nil?
       end
 
-      # Keep input order; every term must match (AND). An empty filter passes all.
+      # An empty filter passes all; order is preserved.
       def apply(subjects : Array(Subject)) : Array(Subject)
-        return subjects if @terms.empty?
+        return subjects if @tree.nil?
         subjects.select { |s| matches?(s) }
       end
 
       def matches?(s : Subject) : Bool
-        @terms.all? { |t| match_term(t, s) }
+        tree = @tree
+        return true unless tree
+        eval(tree, s)
+      end
+
+      private def eval(tree : FilterAst::Tree(Term), s : Subject) : Bool
+        case tree.op
+        in .leaf? then match_term(tree.leaf, s)
+        in .not?  then !eval(tree.children.first, s)
+        in .and?  then tree.children.all? { |c| eval(c, s) }
+        in .or?   then tree.children.any? { |c| eval(c, s) }
+        end
       end
 
       # --- Tab-complete suggestions (History-style; in-memory over open sessions) ---
@@ -100,35 +101,19 @@ module Gori
       # it never suggests host:/method:); defaults to the full canonical set (Repeater).
       def self.suggestions(query : String, cx : Int32, subjects : Array(Subject),
                            fields : Array(String) = FIELDS) : Array(String)
-        token, _, _ = token_at(query, cx)
-        return [] of String if token.empty?
-        neg = token.starts_with?('-') && token.size > 1
-        core = neg ? token[1..] : token
-        neg_p = neg ? "-" : ""
-        if colon = core.index(':')
-          field_raw = core[0...colon]
+        cur = FilterAst.token_at(query, cx)
+        return [] of String if cur.core.empty?
+        if colon = cur.core.index(':')
+          field_raw = cur.core[0...colon]
           field = field_raw.downcase
-          prefix = core[(colon + 1)..]
+          prefix = FilterAst.unquote_prefix(cur.core[(colon + 1)..])
           # Strip a typed `#` on tags so `tag:#id` still suggests `tag:idor`.
           val_prefix = field == "tag" ? prefix.lstrip('#') : prefix
-          suggest_values(field, val_prefix, subjects).map { |v| "#{neg_p}#{field_raw}:#{v}" }
+          suggest_values(field, val_prefix, subjects)
+            .map { |v| "#{cur.prefix}#{field_raw}:#{FilterAst.quote(v)}" }
         else
-          fields.select(&.starts_with?(core.downcase)).map { |f| "#{neg_p}#{f}:" }
+          fields.select(&.starts_with?(cur.core.downcase)).map { |f| "#{cur.prefix}#{f}:" }
         end
-      end
-
-      # Bounds of the token under the caret (History's current_token_bounds shape).
-      def self.token_at(query : String, cx : Int32) : {String, Int32, Int32}
-        cx = cx.clamp(0, query.size)
-        s = cx
-        while s > 0 && query[s - 1] != ' '
-          s -= 1
-        end
-        e = cx
-        while e < query.size && query[e] != ' '
-          e += 1
-        end
-        {query[s...e], s, e}
       end
 
       # Host portion of a target URL for `host:` suggestions (falls back to the
@@ -157,7 +142,11 @@ module Gori
 
       # --- parsing -------------------------------------------------------------
 
-      private def self.build_term(tok : String, negate : Bool) : Term
+      # Never drops a term: an empty value (mid-typing `tag:`) stays and is handled by
+      # match_term, so the sub-tab strip doesn't blank out between keystrokes.
+      private def self.build_term(t : FilterAst::Term) : Term
+        tok = t.text
+        negate = t.negate?
         if colon = tok.index(':')
           field = tok[0...colon].downcase
           value = tok[(colon + 1)..].downcase

--- a/src/gori/tui/controllers/intercept_controller.cr
+++ b/src/gori/tui/controllers/intercept_controller.cr
@@ -37,7 +37,7 @@ module Gori::Tui
       if @intercept.editing?
         "type to edit · ^R forward · ⇧↹/esc queue"
       elsif @intercept.querying?
-        "type condition · ↵ apply · esc clear"
+        "type condition · ↹ complete · ↵ apply · esc clear"
       else
         f = Hotkeys.binding_label(reg, "intercept.forward", "f")
         d = Hotkeys.binding_label(reg, "intercept.drop", "d")
@@ -170,6 +170,7 @@ module Gori::Tui
       case
       when key.enter?     then @intercept.stop_query
       when key.escape?    then @intercept.cancel_query; ic.set_filter("")
+      when key.tab?       then ic.set_filter(@intercept.query) if @intercept.query_complete
       when key.backspace? then @intercept.query_backspace; ic.set_filter(@intercept.query)
       when key.left?      then @intercept.query_move(-1)
       when key.right?     then @intercept.query_move(1)
@@ -283,8 +284,8 @@ module Gori::Tui
 
     # Open the catch-condition filter bar (a query that narrows which messages hold).
     def intercept_query : Nil
-      @intercept.start_query
-      @host.status("catch condition: host: method: path: status: scheme: · ↵ apply · esc clear")
+      @intercept.start_query(@host.session.store) # store backs `host:` Tab-completion
+      @host.status("catch condition: host: method: path: status: scheme: · ↹ complete · ↵ apply · esc clear")
     end
 
     # Cycle which leg(s) to hold: all → requests → responses → all.

--- a/src/gori/tui/highlight.cr
+++ b/src/gori/tui/highlight.cr
@@ -194,6 +194,30 @@ module Gori::Tui
       request ? lines.map { |line| with_env_tokens(line) } : lines
     end
 
+    # Per-character colours for a filter/QL query, so its boolean structure reads apart
+    # from the values being matched — `(host:a OR host:b) -method:GET` should show at a
+    # glance which words are operators and where the group closes.
+    #
+    # Classification comes from FilterAst's own lexer, so the colour is a truthful
+    # preview of how the query will be PARSED: a lowercase `or`, a quoted "AND", and a
+    # `(` sitting inside a value all stay plain, because none of them group anything.
+    # Characters no span covers (the whitespace between terms) keep `base`.
+    def self.filter_query(query : String, base : Color = Theme.text) : Array(Color)
+      colors = Array(Color).new(query.size, base)
+      FilterAst.spans(query).each do |span|
+        fg = case span.kind
+             in .operator? then Theme.syn_keyword
+             in .paren?    then Theme.syn_keyword
+             in .field?    then Theme.syn_header
+             in .value?    then Theme.text_bright
+             in .quote?    then Theme.syn_string
+             in .plain?    then base
+             end
+        (span.start...(span.start + span.size)).each { |i| colors[i] = fg if i < colors.size }
+      end
+      colors
+    end
+
     # Single-line env overlay (TARGET fields, ENV pane values).
     def self.env_line(raw : String, base_fg : Color = Theme.text, attr : Attribute = Attribute::None) : Line
       with_env_tokens([Span.new(raw, base_fg, attr)])

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -48,7 +48,7 @@ module Gori::Tui
     # yet) and also spells out that bare words are a free-text search. Example values
     # double as syntax cues.
     FILTER_HINT = "/ filter  ·  host:  method:  status:>=500  proto:ws  path:  size:>10000  dur:>500  header:  body~regex"
-    QUERY_HINT  = "fields:  host:  method:  status:  proto:  path:  scheme:  size:  dur:  header:  body    ·    or type words to search"
+    QUERY_HINT  = "fields:  host:  method:  status:  proto:  path:  scheme:  size:  dur:  header:  body    ·    AND OR NOT ( ) combine  ·  or type words to search"
 
     getter rows : Array(Store::FlowRow)
     getter? follow : Bool
@@ -525,26 +525,24 @@ module Gori::Tui
     def query_complete : Bool
       sugg = query_suggestions
       return false if sugg.empty?
-      s, e = current_token_bounds
-      @query = "#{@query[0, s]}#{sugg.first}#{@query[e..]}"
-      @qcx = s + sugg.first.size
+      cur = FilterAst.token_at(@query, @qcx)
+      @query = "#{@query[0, cur.start]}#{sugg.first}#{@query[cur.stop..]}"
+      @qcx = cur.start + sugg.first.size
       true
     end
 
     # Suggestions for the token under the cursor: field names, then field values.
-    # Honours a leading `-` (QL negation) so `-ho` → `-host:` and `-host:a` → `-host:api…`.
+    # FilterAst::Cursor carries the grammar's punctuation through, so `-ho` → `-host:`
+    # and `(ho` → `(host:` — the same peeling every other filter bar uses.
     def query_suggestions : Array(String)
-      token = current_token
-      return [] of String if token.empty?
-      neg = token.starts_with?('-') && token.size > 1
-      core = neg ? token[1..] : token
-      neg_p = neg ? "-" : ""
-      if (colon = core.index(':'))
-        field = core[0...colon].downcase
-        prefix = core[(colon + 1)..]
-        suggest_values(field, prefix).map { |s| "#{neg_p}#{s}" }
+      cur = FilterAst.token_at(@query, @qcx)
+      return [] of String if cur.core.empty?
+      if (colon = cur.core.index(':'))
+        field = cur.core[0...colon].downcase
+        prefix = FilterAst.unquote_prefix(cur.core[(colon + 1)..])
+        suggest_values(field, prefix).map { |s| "#{cur.prefix}#{s}" }
       else
-        QL_FIELDS.select(&.starts_with?(core.downcase)).map { |f| "#{neg_p}#{f}:" }
+        QL_FIELDS.select(&.starts_with?(cur.core.downcase)).map { |f| "#{cur.prefix}#{f}:" }
       end
     end
 
@@ -1558,7 +1556,8 @@ module Gori::Tui
         prefix = "filter › "
         screen.text(rect.x + 1, rect.y, prefix, Theme.accent)
         base = rect.x + 1 + prefix.size
-        screen.input_line(base, rect.y, @query, @qcx, @preedit, Theme.text_bright, width: rect.w - prefix.size - 2)
+        screen.input_line(base, rect.y, @query, @qcx, @preedit, Theme.text_bright, width: rect.w - prefix.size - 2,
+          colors: Highlight.filter_query(@query, Theme.text_bright))
         return
       end
 
@@ -1587,7 +1586,11 @@ module Gori::Tui
 
       left_w = {(follow_shown ? fx : scope_x) - (rect.x + 1) - 1, 0}.max
       if !@query.blank?
-        screen.text(rect.x + 1, rect.y, ": #{@query}", Theme.text, width: left_w)
+        # The committed query stays highlighted — this readout is what you scan to
+        # check how the active filter is actually being read.
+        qx = screen.text(rect.x + 1, rect.y, ": ", Theme.muted, width: left_w)
+        screen.styled_text(qx, rect.y, @query, Highlight.filter_query(@query, Theme.text),
+          Theme.text, width: {rect.x + 1 + left_w - qx, 0}.max)
       else
         # No QL query typed — whether or not a Scope lens is active. Surface the filter
         # affordance + fields rather than a bare "(in-scope only)": the Scope lens is
@@ -1607,7 +1610,7 @@ module Gori::Tui
       # cursor sits just after a space) show a standing hint so the query language is
       # discoverable from the moment `/` opens; on a non-empty token with no match stay
       # quiet — the user is deliberately free-texting a word.
-      return unless current_token.empty?
+      return unless FilterAst.token_at(@query, @qcx).core.empty?
       screen.text(rect.x + 1, y, QUERY_HINT, Theme.muted, width: rect.w - 2)
     end
 
@@ -1627,7 +1630,7 @@ module Gori::Tui
                end
       # host_values_for is already prefix-filtered by SQL; still apply starts_with so a
       # stale cache entry can't surface a non-matching host if the key ever drifts.
-      values.select(&.downcase.starts_with?(p)).map { |v| "#{field}:#{v}" }
+      values.select(&.downcase.starts_with?(p)).map { |v| "#{field}:#{FilterAst.quote(v)}" }
     end
 
     # DISTINCT hosts for the typed prefix. Cached per prefix so Tab + suggestion
@@ -1646,23 +1649,6 @@ module Gori::Tui
     private def invalidate_host_suggest_cache : Nil
       @host_suggest_prefix = nil
       @host_suggest_values = [] of String
-    end
-
-    private def current_token : String
-      s, e = current_token_bounds
-      @query[s...e]
-    end
-
-    private def current_token_bounds : {Int32, Int32}
-      s = @qcx
-      while s > 0 && @query[s - 1] != ' '
-        s -= 1
-      end
-      e = @qcx
-      while e < @query.size && @query[e] != ' '
-        e += 1
-      end
-      {s, e}
     end
 
     private def ensure_visible(list_h : Int32) : Nil

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -7,6 +7,7 @@ require "./highlight"
 require "./text_area"
 require "./url"
 require "../interceptor"
+require "../store"
 require "../fuzz/content_length"
 require "../env"
 
@@ -19,8 +20,13 @@ module Gori::Tui
   # actual forward/drop. No diff (that's Repeater's job).
   class InterceptView
     # Height of the top filter bar (catch direction + condition), reserved above the
-    # queue|detail split — the Intercept tab's analogue of History's QL bar.
+    # queue|detail split — the Intercept tab's analogue of History's QL bar. While the
+    # condition is being edited a second row carries Tab suggestions (see bar_h).
     FILTER_BAR_H = 1
+    # Standing hint on the suggestion row at a cold start (editing, but nothing typed
+    # yet to complete), so the condition language is discoverable the moment `/` opens.
+    # Example values double as syntax cues; keep in sync with InterceptFilter::FIELDS.
+    QUERY_HINT = "fields:  host:  path:  method:  scheme:  status:    ·    AND OR NOT ( ) combine  ·  -term negates"
 
     getter? editing : Bool
     getter? querying : Bool
@@ -43,6 +49,12 @@ module Gori::Tui
       @query = ""
       @qcx = 0
       @preedit = ""
+      # Weak back-pointer for `host:` Tab suggestions, handed over when the bar opens.
+      # Nil until then — suggestions simply skip the host pool. The DISTINCT query is
+      # memoised on the typed prefix so a keystroke doesn't re-hit SQLite.
+      @suggest_store = nil.as(Store?)
+      @host_suggest_prefix = nil.as(String?)
+      @host_suggest_values = [] of String
       @loaded_id = nil.as(Int64?) # which item the editor currently holds
       @editor_dirty = false       # whether the held bytes were actually edited (vs just viewed)
       # Cached highlight of the selected held item's bytes (read-only detail pane).
@@ -113,9 +125,13 @@ module Gori::Tui
     end
 
     # --- catch-condition filter bar (a text sub-mode; mirrors History's QL bar) ---
-    def start_query : Nil
+    # `store` (optional) backs `host:` Tab-completion; without it every other field
+    # still completes from its static pool.
+    def start_query(store : Store? = nil) : Nil
       @querying = true
       @qcx = @query.size
+      @suggest_store = store
+      @host_suggest_prefix = nil # invalidate: peers may have captured new hosts since
     end
 
     def stop_query : Nil # Enter: keep the condition, leave edit mode
@@ -142,6 +158,35 @@ module Gori::Tui
 
     def query_move(d : Int32) : Nil
       @qcx = (@qcx + d).clamp(0, @query.size)
+    end
+
+    # Tab: splice the first suggestion over the token under the caret. False when there
+    # is nothing to complete, so the caller can leave the query untouched.
+    def query_complete : Bool
+      sugg = query_suggestions
+      return false if sugg.empty?
+      cur = FilterAst.token_at(@query, @qcx)
+      @query = "#{@query[0, cur.start]}#{sugg.first}#{@query[cur.stop..]}"
+      @qcx = cur.start + sugg.first.size
+      true
+    end
+
+    def query_suggestions : Array(String)
+      InterceptFilter.suggestions(@query, @qcx, host_suggestions)
+    end
+
+    # DISTINCT hosts for the `host:` pool, memoised on the typed prefix (single-entry,
+    # like History's) so holding a key doesn't issue a query per keystroke.
+    private def host_suggestions : Array(String)
+      core = FilterAst.token_at(@query, @qcx).core
+      return [] of String unless (colon = core.index(':')) && core[0...colon].downcase == "host"
+      prefix = FilterAst.unquote_prefix(core[(colon + 1)..])
+      key = prefix.downcase
+      return @host_suggest_values if @host_suggest_prefix == key
+      store = @suggest_store
+      @host_suggest_prefix = key
+      @host_suggest_values = store ? store.distinct_hosts(prefix: prefix, limit: 16) : [] of String
+      @host_suggest_values
     end
 
     # Live IME composition shown underlined ahead of the committed query; cleared
@@ -329,10 +374,17 @@ module Gori::Tui
 
     # --- mouse hit-testing (inverts render's offset math; coords are 0-based) ---
 
+    # Rows the bar occupies: one for the condition itself, plus a suggestion row while
+    # it's being edited. Both render() and every hit-test derive from this, so the two
+    # can't drift as the bar grows/shrinks under the caret.
+    private def bar_h : Int32
+      @querying ? FILTER_BAR_H + 1 : FILTER_BAR_H
+    end
+
     # The body (queue|detail split) sits BELOW the filter bar — every hit-test must
-    # subtract the bar row first, exactly as render() does.
+    # subtract the bar rows first, exactly as render() does.
     private def body_rect(rect : Rect) : Rect
-      Rect.new(rect.x, rect.y + FILTER_BAR_H, rect.w, {rect.h - FILTER_BAR_H, 0}.max)
+      Rect.new(rect.x, rect.y + bar_h, rect.w, {rect.h - bar_h, 0}.max)
     end
 
     # The w//3 split render() uses (render: `half = {body.w // 3, 1}.max`). `body` is
@@ -416,6 +468,7 @@ module Gori::Tui
                listen : String? = nil, capturing : Bool = true) : Nil
       return if rect.empty?
       render_filter_bar(screen, Rect.new(rect.x, rect.y, rect.w, FILTER_BAR_H), focused)
+      render_suggestions(screen, rect, rect.y + FILTER_BAR_H) if @querying
       body = body_rect(rect)
       return if body.empty?
 
@@ -440,7 +493,9 @@ module Gori::Tui
         prefix = "catch › "
         screen.text(rect.x + 1, rect.y, prefix, Theme.accent)
         base = rect.x + 1 + prefix.size
-        screen.input_line(base, rect.y, @query, @qcx, @preedit, Theme.text_bright, width: {rect.w - prefix.size - 2, 0}.max)
+        screen.input_line(base, rect.y, @query, @qcx, @preedit, Theme.text_bright,
+          width: {rect.w - prefix.size - 2, 0}.max,
+          colors: Highlight.filter_query(@query, Theme.text_bright))
         return
       end
 
@@ -462,8 +517,28 @@ module Gori::Tui
       if @query.blank?
         screen.text(x, rect.y, "/ condition  ·  host:  method:  path:  status:>=500  scheme:", Theme.muted, width: left_w)
       else
-        screen.text(x, rect.y, ": #{@query}", Theme.text, width: left_w)
+        # The committed condition stays highlighted — this readout is what you scan to
+        # check WHY something is (or isn't) being held.
+        x = screen.text(x, rect.y, ": ", Theme.muted, width: left_w)
+        screen.styled_text(x, rect.y, @query, Highlight.filter_query(@query, Theme.text),
+          Theme.text, width: {rect.right - 1 - x, 0}.max)
       end
+    end
+
+    # The Tab-completion row under the condition input: the leading candidate is what ↹
+    # takes, the rest preview what typing one more char would narrow to. With nothing to
+    # complete, a cold-start token (empty, or the caret just past a space) shows the
+    # standing field hint; a non-empty token with no match stays quiet, since the human
+    # is then deliberately typing a free-text word.
+    private def render_suggestions(screen : Screen, rect : Rect, y : Int32) : Nil
+      return if y >= rect.bottom
+      sugg = query_suggestions
+      unless sugg.empty?
+        screen.text(rect.x + 1, y, "↹ #{sugg.first(8).join("  ")}", Theme.muted, width: {rect.w - 2, 0}.max)
+        return
+      end
+      return unless FilterAst.token_at(@query, @qcx).core.empty?
+      screen.text(rect.x + 1, y, QUERY_HINT, Theme.muted, width: {rect.w - 2, 0}.max)
     end
 
     # The catch-direction chip: `c`-chord + which direction, coloured by enabled state.

--- a/src/gori/tui/issues_view.cr
+++ b/src/gori/tui/issues_view.cr
@@ -19,7 +19,7 @@ module Gori::Tui
     QUERY_FIELDS = %w(severity: status: host: title:)
 
     def initialize
-      @all = [] of Store::Issue      # the raw store list (severity-desc)
+      @all = [] of Store::Issue    # the raw store list (severity-desc)
       @issues = [] of Store::Issue # the filtered/visible subset
       @selected = 0
       @scroll = 0
@@ -134,8 +134,6 @@ module Gori::Tui
       enter_notes_insert!
       @notes.click_to_cursor(notes_rect, mx, my)
     end
-
-
 
     def select_index(idx : Int32) : Nil
       return if @issues.empty?
@@ -576,7 +574,8 @@ module Gori::Tui
         prefix = "filter › "
         screen.text(rect.x + 1, rect.y, prefix, Theme.accent)
         base = rect.x + 1 + prefix.size
-        screen.input_line(base, rect.y, @query, @qcx, @preedit_q, Theme.text_bright, width: {rect.w - prefix.size - 2, 0}.max)
+        screen.input_line(base, rect.y, @query, @qcx, @preedit_q, Theme.text_bright, width: {rect.w - prefix.size - 2, 0}.max,
+          colors: Highlight.filter_query(@query, Theme.text_bright))
         return
       end
       rx = rect.right - 1
@@ -587,7 +586,11 @@ module Gori::Tui
       end
       left_w = {rx - (rect.x + 1), 0}.max
       if filtering?
-        screen.text(rect.x + 1, rect.y, ": #{@query}", Theme.text, width: left_w)
+        # The committed query stays highlighted — this readout is what you scan to
+        # check how the active filter is actually being read.
+        qx = screen.text(rect.x + 1, rect.y, ": ", Theme.muted, width: left_w)
+        screen.styled_text(qx, rect.y, @query, Highlight.filter_query(@query, Theme.text),
+          Theme.text, width: {rect.x + 1 + left_w - qx, 0}.max)
       else
         screen.text(rect.x + 1, rect.y, "/ filter  ·  severity:  status:open  status:closed  host:", Theme.muted, width: left_w)
       end

--- a/src/gori/tui/probe_view.cr
+++ b/src/gori/tui/probe_view.cr
@@ -542,7 +542,8 @@ module Gori::Tui
         prefix = "filter › "
         screen.text(rect.x + 1, y, prefix, Theme.accent)
         base = rect.x + 1 + prefix.size
-        screen.input_line(base, y, @query, @qcx, @preedit_q, Theme.text_bright, width: {rect.w - prefix.size - 2, 0}.max)
+        screen.input_line(base, y, @query, @qcx, @preedit_q, Theme.text_bright, width: {rect.w - prefix.size - 2, 0}.max,
+          colors: Highlight.filter_query(@query, Theme.text_bright))
         return
       end
       # Right cluster: a scope-lens chip (always shown so the ⇧S toggle is discoverable,

--- a/src/gori/tui/screen.cr
+++ b/src/gori/tui/screen.cr
@@ -392,16 +392,21 @@ module Gori::Tui
     # rendering used by every single-line input (Scope/Rules/Palette/History
     # query) so they all show live composition identically to the multi-line
     # TextArea. `bg` is the field background; the caret always inverts onto ACCENT.
+    # `colors` (optional) gives a per-character colour for `value` — one entry per
+    # character — so a caller can syntax-highlight what is being typed. The live IME
+    # preedit always uses `fg`: it is not part of `value` yet, so nothing has classified
+    # it. A short/absent array simply falls back to `fg` for the uncovered tail.
     def input_line(x : Int32, y : Int32, value : String, cx : Int32, preedit : String,
-                   fg : Color, bg : Color = Theme.bg, width : Int32? = nil) : Nil
+                   fg : Color, bg : Color = Theme.bg, width : Int32? = nil,
+                   colors : Array(Color)? = nil) : Nil
       cx = cx.clamp(0, value.size)
       right = x + (width || (@width - x))
       prefix = value[0, cx]
       suffix = value[cx..]
       px = x
-      px = text(px, y, prefix, fg, bg, width: {right - px, 0}.max) unless prefix.empty?
+      px = styled_run(px, y, prefix, 0, colors, fg, bg, right) unless prefix.empty?
       px = text(px, y, preedit, fg, bg, attr: Attribute::Underline, width: {right - px, 0}.max) unless preedit.empty?
-      text(px, y, suffix, fg, bg, width: {right - px, 0}.max) unless suffix.empty?
+      styled_run(px, y, suffix, cx, colors, fg, bg, right) unless suffix.empty?
       # Block caret sits just after prefix+preedit, over the suffix's first cell
       # (or a space). The terminal's own IME UI anchors at the hardware cursor.
       caret_x = x + Screen.display_width(prefix) + Screen.display_width(preedit)
@@ -410,6 +415,34 @@ module Gori::Tui
         cell(caret_x, y, caret_ch, Theme.bg, Theme.accent)
         cursor(caret_x, y)
       end
+    end
+
+    # Per-character-coloured text with no caret — the static counterpart to input_line,
+    # for readouts like a committed filter query. Returns the x after the last cell.
+    def styled_text(x : Int32, y : Int32, str : String, colors : Array(Color)?,
+                    fg : Color, bg : Color = Theme.bg, width : Int32? = nil) : Int32
+      styled_run(x, y, str, 0, colors, fg, bg, x + (width || (@width - x)))
+    end
+
+    # Draw `str` (whose first character is `value[offset]`) in same-colour runs, so a
+    # highlighted line still goes through the normal `text` path — one call per run
+    # rather than per character, which keeps wide-glyph handling and clipping intact.
+    private def styled_run(x : Int32, y : Int32, str : String, offset : Int32,
+                           colors : Array(Color)?, fg : Color, bg : Color, right : Int32) : Int32
+      return text(x, y, str, fg, bg, width: {right - x, 0}.max) unless colors
+      px = x
+      i = 0
+      while i < str.size
+        c = colors[offset + i]? || fg
+        j = i + 1
+        while j < str.size && (colors[offset + j]? || fg) == c
+          j += 1
+        end
+        px = text(px, y, str[i...j], c, bg, width: {right - px, 0}.max)
+        break if px >= right
+        i = j
+      end
+      px
     end
   end
 end

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -33,7 +33,7 @@ module Gori::Tui
     # suggestion row at a cold start (already editing, nothing to Tab-complete yet) and
     # spells out that bare words are a free-text search. Example values double as cues.
     FILTER_HINT = "/ filter  ·  host:  method:  path:  status:>=500  proto:ws  size:>10000  dur:>500  header:  body~regex  tag:"
-    QUERY_HINT  = "fields:  host:  method:  path:  status:  proto:  scheme:  size:  dur:  header:  body:  tag:    ·    or type words to search"
+    QUERY_HINT  = "fields:  host:  method:  path:  status:  proto:  scheme:  size:  dur:  header:  body:  tag:    ·    AND OR NOT ( ) combine  ·  or type words to search"
 
     # Right-aligned column widths: path memo sits left of the method/aside cluster.
     TAG_COL_W     = 16
@@ -716,7 +716,8 @@ module Gori::Tui
         prefix = "filter › "
         screen.text(rect.x + 1, rect.y, prefix, Theme.accent)
         base = rect.x + 1 + prefix.size
-        screen.input_line(base, rect.y, @query, @qcx, @preedit, Theme.text_bright, width: rect.w - prefix.size - 2)
+        screen.input_line(base, rect.y, @query, @qcx, @preedit, Theme.text_bright, width: rect.w - prefix.size - 2,
+          colors: Highlight.filter_query(@query, Theme.text_bright))
         return
       end
 
@@ -743,7 +744,11 @@ module Gori::Tui
 
       left_w = {(group_shown ? gx : scope_x) - (rect.x + 1) - 1, 0}.max
       if !@query.blank?
-        screen.text(rect.x + 1, rect.y, ": #{@query}", Theme.text, width: left_w)
+        # The committed query stays highlighted — this readout is what you scan to
+        # check how the active filter is actually being read.
+        qx = screen.text(rect.x + 1, rect.y, ": ", Theme.muted, width: left_w)
+        screen.styled_text(qx, rect.y, @query, Highlight.filter_query(@query, Theme.text),
+          Theme.text, width: {rect.x + 1 + left_w - qx, 0}.max)
       else
         # No QL query typed — whether or not a Scope lens is active. Surface the filter
         # affordance + fields rather than a bare "(in-scope only)": the Scope lens is

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -332,7 +332,7 @@ module Gori::Tui
     # True at a cold start (nothing typed, or the caret sits just after a space) — decides
     # whether the suggestion row shows the standing field hint.
     private def filter_token_empty? : Bool
-      Repeater::SubtabFilter.token_at(@subtab_filter, @filter_cx)[0].empty?
+      FilterAst.token_at(@subtab_filter, @filter_cx).core.empty?
     end
 
     # Open the `/` filter bar (from the strip or the space menu), seeding the caret.
@@ -398,10 +398,10 @@ module Gori::Tui
     def complete_subtab_filter : Bool
       sugg = filter_suggestions
       return false if sugg.empty?
-      _, s, e = Repeater::SubtabFilter.token_at(@subtab_filter, @filter_cx)
+      cur = FilterAst.token_at(@subtab_filter, @filter_cx)
       first = sugg.first
-      @subtab_filter = "#{@subtab_filter[0, s]}#{first}#{@subtab_filter[e..]}"
-      @filter_cx = s + first.size
+      @subtab_filter = "#{@subtab_filter[0, cur.start]}#{first}#{@subtab_filter[cur.stop..]}"
+      @filter_cx = cur.start + first.size
       @filter_preedit = ""
       true
     end
@@ -490,9 +490,13 @@ module Gori::Tui
         px = screen.text(rect.x, row_y, "filter › ", Theme.accent, Theme.panel)
         field_w = {count_x - 1 - px, 1}.max
         screen.input_line(px, row_y, @subtab_filter, @filter_cx, @filter_preedit,
-          Theme.text_bright, Theme.panel, width: field_w)
+          Theme.text_bright, Theme.panel, width: field_w,
+          colors: Highlight.filter_query(@subtab_filter, Theme.text_bright))
       elsif !@subtab_filter.blank?
-        screen.text(rect.x, row_y, ": #{@subtab_filter}", Theme.text, Theme.panel, width: left_w)
+        px = screen.text(rect.x, row_y, ": ", Theme.muted, Theme.panel, width: left_w)
+        screen.styled_text(px, row_y, @subtab_filter,
+          Highlight.filter_query(@subtab_filter, Theme.text),
+          Theme.text, Theme.panel, width: {count_x - 1 - px, 0}.max)
       else
         screen.text(rect.x, row_y, "/ filter  ·  #{filter_fields.map { |f| "#{f}:" }.join("  ")}", Theme.muted, Theme.panel, width: left_w)
       end


### PR DESCRIPTION
## Why

Five filter surfaces each carried their own hand-rolled parser for the same flat grammar — QL (plus **two more** tokenizer copies inside `ql.cr` itself), Intercept catch rules, Repeater sub-tabs, Issues and Probe. They had already drifted, and the language couldn't express anything needing real structure. Typing `AND` didn't error — it silently became a free-text search for the word "and".

## The split that makes it work

`Gori::FilterAst` owns only the **shape** of a query (lexing, grouping, precedence). What a term *means* stays with each backend, because they genuinely differ: QL drops a bad numeric term, while Probe deliberately keeps a half-typed `-host:` matching everything so the list doesn't blank out mid-keystroke. Backends fold a parsed tree into their own representation via `FilterAst.build`.

Consequence worth knowing: `negate` rides on the **leaf**, not on a `NotNode`. Issues (`-status:` → match none) and Probe (`-host:` → match all) disagree on purpose and are spec-pinned in both; a wrapper node would have silently unified them. `NOT term` desugars onto that same flag, so `-x` ≡ `NOT x`.

## New syntax

```
host:a status:200          AND is implicit (unchanged)
host:a AND status:200      ...and now spellable
host:a OR host:b           OR
(host:a OR host:b) -m:GET  parentheses group
NOT (host:cdn OR host:s)   negate a whole group (`-` cannot)
host:"my host"             quotes keep spaces in one term
```

Precedence `NOT > AND > OR`. Keywords are recognised **UPPERCASE and unquoted only**, so searching for the words "and"/"or"/"not" still works; quote them to force a literal.

## Backward compatibility

Parens are **position-sensitive**: `(` opens a group only at the start of a term, `)` closes one only at the end and only while a group is open. So `path:/a(b)` stays a literal token and needs no escaping. Regression-guarded in both `filter_ast_spec` and `ql_spec`.

QL's emitted SQL is **byte-identical except for queries containing `OR`**, which now parenthesise as a whole rather than wrapping each side. Exactly one assertion needed updating.

## Also here

- **Intercept `/` catch-condition bar gains Tab suggestions**, matching History. `host:` values come from the store's DISTINCT hosts — a catch rule is written *before* traffic arrives, so the queue is the wrong source. The completable field list lives beside the parser so it can't advertise a field the parser would silently free-text (History's `QL_FIELDS` has exactly that drift today with `flag:`).
- **Tab-completion tokenizing is shared** (`FilterAst.token_at` → `Cursor`), so a leading `(` or `-` survives completion everywhere. This fixed a real bug: Repeater suggested `name:orders probe`, which re-parsed as two terms and matched nothing. Values containing spaces are now quoted automatically.
- **Filter queries are syntax-highlighted** in all six bars, both while editing and for the committed readout. Classification runs through the parser's own lexer, so the colour is a truthful preview of the parse — a lowercase `or`, a quoted `"AND"` and a `(` inside a value all stay plain.

## Verification

- `crystal spec` — 2295 examples, 0 new failures. The 8 failures in `project_registry_spec`/`capture_status_spec` are **pre-existing**: they reproduce identically on a clean stashed tree and are all proxy/port-binding, untouched by this change.
- Behavioural end-to-end against a real capture, not just SQL text. Grouping has to change the *answer*: `(host:a OR host:b) AND status:301` returns 0 rows while the unparenthesized form returns 1, which is precedence actually working.
- Intercept verified on the live proxy: a grouped catch rule `(host:a OR host:b) -method:GET` let GET through and held POST.
- Highlighting verified in a real terminal via `tmux capture-pane -ep` truecolor codes, not just spec assertions.
- `ameba` clean on the new file; no new findings in any modified file.