### PR TITLE
Review of 2026-07-19: 13 fixes across filters, sitemap, preferences and TUI chrome

### DIFF
--- a/spec/filter_ast_spec.cr
+++ b/spec/filter_ast_spec.cr
@@ -77,7 +77,24 @@ describe Gori::FilterAst do
 
   it "negates only with something after the dash" do
     parse("-host:a").should eq("-host:a")
-    parse("-").should eq("-") # a lone dash is a word, not a negation
+    parse("-").should eq("-")   # a lone dash is a word, not a negation
+    parse(%(-")).should eq("-") # ...and a dash followed only by a quote mark is too
+  end
+
+  it "treats a QUOTED leading dash as literal text, like a quoted keyword" do
+    # Quoting forces a literal, and that has to hold for `-` exactly as it does for
+    # AND/OR/NOT — otherwise there is no way to search for a token that starts with a
+    # dash. `sexp` renders both of these as "-a", so assert the parts.
+    quoted = Gori::FilterAst.terms(Gori::FilterAst.parse(%("-a"))).first
+    {quoted.text, quoted.negate?}.should eq({"-a", false})
+
+    # The test is the quoting of the DASH, not of the chunk — a quoted VALUE on a
+    # negated field still negates.
+    bare = Gori::FilterAst.terms(Gori::FilterAst.parse(%(-"a"))).first
+    {bare.text, bare.negate?}.should eq({"a", true})
+
+    field = Gori::FilterAst.terms(Gori::FilterAst.parse(%(-host:"my host"))).first
+    {field.text, field.negate?}.should eq({"host:my host", true})
   end
 
   describe "Term" do
@@ -117,6 +134,26 @@ describe Gori::FilterAst do
       tree.op.should eq(Gori::FilterAst::Op::Or)
       tree.children.map(&.op).should eq([Gori::FilterAst::Op::And, Gori::FilterAst::Op::Leaf])
       tree.children[0].children.map(&.leaf).should eq(["a", "b"])
+    end
+  end
+
+  describe ".spans" do
+    # The promise of the highlighter is that colour is a truthful preview of the parse.
+    # Negation is the one place both sides could compute the answer separately, so pin
+    # the agreement rather than a hand-written span list per query. (The `NOT` KEYWORD
+    # is excluded: it is its own lexeme, painted straight off `Tok::Not`, so it has no
+    # second derivation to drift from — only the `-` prefix ever did.)
+    it "paints a dash operator exactly when the parser negated that term" do
+      [
+        "-host:a", "-", %(-"), %(-""), %("-a"), %(-"a"), %(-host:"my host"),
+        "a -b", "-(a OR b)", "(-a OR -b)", "--", "a-b", "path:/a-b",
+      ].each do |query|
+        dashes = Gori::FilterAst.spans(query).count do |span|
+          span.kind.operator? && query[span.start, span.size] == "-"
+        end
+        negated = Gori::FilterAst.terms(Gori::FilterAst.parse(query)).count(&.negate?)
+        dashes.should eq(negated), "#{query.inspect}: #{dashes} dash spans vs #{negated} negated terms"
+      end
     end
   end
 end

--- a/spec/filter_ast_spec.cr
+++ b/spec/filter_ast_spec.cr
@@ -149,6 +149,21 @@ describe Gori::FilterAst do
   end
 
   describe ".spans" do
+    it "only treats `~` as a field separator for backends that implement it" do
+      # QL has a regex operator; Issues/Probe/Intercept/Subtab do not and free-text the
+      # whole token. Painting `title~admin` as field+value there would promise a match
+      # that never happens.
+      regex_ok = Gori::FilterAst.spans("title~admin", Gori::FilterAst::SEPS_FIELD_REGEX)
+      regex_ok.map(&.kind).should eq([Gori::FilterAst::SpanKind::Field, Gori::FilterAst::SpanKind::Value])
+
+      colon_only = Gori::FilterAst.spans("title~admin", Gori::FilterAst::SEPS_FIELD)
+      colon_only.map(&.kind).should eq([Gori::FilterAst::SpanKind::Plain])
+
+      # `:` still splits for everyone.
+      both = Gori::FilterAst.spans("title:admin", Gori::FilterAst::SEPS_FIELD)
+      both.map(&.kind).should eq([Gori::FilterAst::SpanKind::Field, Gori::FilterAst::SpanKind::Value])
+    end
+
     # The promise of the highlighter is that colour is a truthful preview of the parse.
     # Negation is the one place both sides could compute the answer separately, so pin
     # the agreement rather than a hand-written span list per query. (The `NOT` KEYWORD

--- a/spec/filter_ast_spec.cr
+++ b/spec/filter_ast_spec.cr
@@ -148,6 +148,43 @@ describe Gori::FilterAst do
     end
   end
 
+  describe ".partition" do
+    # For a surface owning a field the shared backend knows nothing about (Sitemap's
+    # `tag:`, which filters the built tree, not the rows). Cutting from the same lexer is
+    # what gives that hand-rolled field the grammar's quoting and negation.
+    it "cuts matching terms out and hands back the residual" do
+      taken, residual = Gori::FilterAst.partition("host:a tag:x status:200") { |t| t.text.starts_with?("tag:") }
+      taken.map(&.text).should eq(["tag:x"])
+      residual.should eq("host:a status:200")
+    end
+
+    it "keeps a quoted value whole" do
+      taken, residual = Gori::FilterAst.partition(%(tag:"my flow" host:a)) { |t| t.text.starts_with?("tag:") }
+      taken.map(&.text).should eq(["tag:my flow"]) # not torn at the space
+      residual.should eq("host:a")
+    end
+
+    it "carries a NOT keyword onto the term it negates, leaving no dangling operator" do
+      # NOT desugars at PARSE time, so a lexeme-level scan would miss it and strand the
+      # bare `NOT` in the residual — where it means the opposite of what was asked.
+      taken, residual = Gori::FilterAst.partition("NOT tag:done") { |t| t.text.starts_with?("tag:") }
+      taken.map(&.negate?).should eq([true])
+      residual.should eq("")
+    end
+
+    it "treats -tag:x and NOT tag:x identically" do
+      dash, _ = Gori::FilterAst.partition("-tag:x") { |t| t.text.starts_with?("tag:") }
+      word, _ = Gori::FilterAst.partition("NOT tag:x") { |t| t.text.starts_with?("tag:") }
+      dash.map { |t| {t.text, t.negate?} }.should eq(word.map { |t| {t.text, t.negate?} })
+    end
+
+    it "leaves a NOT that does not precede a taken term alone" do
+      taken, residual = Gori::FilterAst.partition("NOT host:a tag:x") { |t| t.text.starts_with?("tag:") }
+      taken.map(&.negate?).should eq([false])
+      residual.should eq("NOT host:a")
+    end
+  end
+
   describe ".spans" do
     it "only treats `~` as a field separator for backends that implement it" do
       # QL has a regex operator; Issues/Probe/Intercept/Subtab do not and free-text the

--- a/spec/filter_ast_spec.cr
+++ b/spec/filter_ast_spec.cr
@@ -75,6 +75,17 @@ describe Gori::FilterAst do
     parse("()").should eq("nil")
   end
 
+  it "steps over an empty group instead of dropping the rest of the chain" do
+    # An empty group contributes nothing, but it must not swallow its neighbours:
+    # everything after it used to vanish, and because the lexemes never reached a
+    # term the diagnostics reported the query as clean while it matched far more.
+    parse("host:a () status:200").should eq("(and host:a status:200)")
+    parse("a (AND) b").should eq("(and a b)")
+    parse(%(a ("") b)).should eq("(and a b)")
+    parse("host:a NOT () status:200").should eq("(and host:a status:200)")
+    parse("a () () b").should eq("(and a b)")
+  end
+
   it "negates only with something after the dash" do
     parse("-host:a").should eq("-host:a")
     parse("-").should eq("-")   # a lone dash is a word, not a negation

--- a/spec/intercept_filter_spec.cr
+++ b/spec/intercept_filter_spec.cr
@@ -51,6 +51,8 @@ describe Gori::InterceptFilter do
     Gori::InterceptFilter.new("status:>=500").matches?(res(404)).should be_false
     Gori::InterceptFilter.new("status:5xx").matches?(res(500)).should be_true
     Gori::InterceptFilter.new("status:5xx").matches?(res(499)).should be_false
+    # status_match? tests a literal lowercase 'x', so an upcased class used to match nothing.
+    Gori::InterceptFilter.new("status:5XX").matches?(res(500)).should be_true
     Gori::InterceptFilter.new("status:<400").matches?(res(200)).should be_true
   end
 

--- a/spec/sitemap_spec.cr
+++ b/spec/sitemap_spec.cr
@@ -273,6 +273,21 @@ describe Gori::Sitemap do
   end
 
   describe ".group_sequences!" do
+    it "folds numeric ids that carry a query, and labels the group by the path part" do
+      # `add` appends the query to the LAST segment, so a listing page's links arrive as
+      # `7?ref=home`. Both passes tested the raw label, so precisely the case that
+      # explodes the tree — a paginated list — was the one that never folded.
+      rows = (1..12).map { |i| {"acme.test", "GET", "/items/#{i}?ref=home"} }
+      hosts = Gori::Sitemap.build(rows)
+      Gori::Sitemap.group_sequences!(hosts.first)
+      items = hosts.first.children.first
+      items.children.size.should eq(1)
+      fold = items.children.first
+      fold.grouped.should be_true
+      fold.label.should eq("[1, 2, 3 … +9]") # not "[1?ref=home, 2?ref=home, …]"
+      fold.children.size.should eq(12)
+    end
+
     it "folds a pure-numeric run beyond the threshold into one collapsed group" do
       hosts = Gori::Sitemap.build((1001..1012).map { |i| {"h", "GET", "/p/#{i}"} })
       Gori::Sitemap.group_sequences!(hosts.first)

--- a/spec/sitemap_spec.cr
+++ b/spec/sitemap_spec.cr
@@ -98,6 +98,16 @@ describe Gori::Sitemap do
       Gori::Sitemap.template_class("?q=1").should be_nil # bare root + query
     end
 
+    it "does not label a date-shaped non-date {date}" do
+      # Url::DATE checks the SHAPE only, so these matched and got a label that lied about
+      # what the segment is. They are still opaque ids — just not dates.
+      Gori::Sitemap.template_class("1234-56-78").should be_nil
+      Gori::Sitemap.template_class("9999-99-99").should be_nil
+      Gori::Sitemap.template_class("2026-00-10").should be_nil
+      Gori::Sitemap.template_class("2026-07-19").should eq("{date}") # still a real one
+      Gori::Sitemap.template_class("2026-12-31").should eq("{date}")
+    end
+
     it "does not downcase-merge (the reason Url.fold_segment is not reused)" do
       Gori::Sitemap.template_class("Users").should be_nil
     end

--- a/spec/sitemap_spec.cr
+++ b/spec/sitemap_spec.cr
@@ -101,6 +101,27 @@ describe Gori::Sitemap do
     it "does not downcase-merge (the reason Url.fold_segment is not reused)" do
       Gori::Sitemap.template_class("Users").should be_nil
     end
+
+    it "survives a segment that is not valid UTF-8" do
+      # A captured target is raw bytes: a legacy-encoded (EUC-KR, latin-1) or fuzzed path
+      # arrives as invalid UTF-8, and PCRE2 RAISES on such a subject instead of returning
+      # false. Unguarded, one such request crashed the whole TUI from the sitemap poll.
+      # Each of these is sized to clear a different regex's length gate.
+      Gori::Sitemap.template_class(String.new(Bytes.new(10) { 0xFF_u8 })).should be_nil  # {date}
+      Gori::Sitemap.template_class(String.new(Bytes.new(36) { 0xFF_u8 })).should be_nil  # {uuid}
+      Gori::Sitemap.template_class(String.new(Bytes.new(12) { 0xFF_u8 })).should be_nil  # {hex}
+      latin1 = Bytes[0x63, 0x61, 0x66, 0xE9, 0x63, 0x61, 0x66, 0xE9, 0x63, 0x61, 0x66, 0xE9]
+      Gori::Sitemap.template_class(String.new(latin1)).should be_nil # "café" ×3, latin-1
+    end
+
+    it "still classifies through a whole-tree fold when a host serves invalid UTF-8" do
+      # The end-to-end path the crash actually took: build → fold_templates!.
+      bad = String.new(Bytes.new(12) { 0xFF_u8 })
+      rows = (1..4).map { |i| {"https", "acme.test", 443, "h2", "GET", "/a/#{bad}/#{i}"} }
+      hosts = Gori::Sitemap.build(rows.map { |r| {r[1], r[4], r[5]} })
+      Gori::Sitemap.fold_templates!(hosts.first)
+      hosts.first.children.map(&.label).should contain("a")
+    end
   end
 
   describe ".fold_templates!" do

--- a/spec/tui/preferences_view_spec.cr
+++ b/spec/tui/preferences_view_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "../support/memory_backend"
 
 include Gori::Tui
 
@@ -75,6 +76,46 @@ describe Gori::Tui::PreferencesView do
     v = PreferencesView.new
     v.open_default
     v.handle_key(pctrl(Termisu::Input::Key::LowerP)).kind.should eq(:palette)
+  end
+
+  it "puts ^P through the same unsaved-edit guard as esc" do
+    # ^P closes the modal just as surely (the host sets @overlay = :none), so skipping the
+    # guard meant this one exit silently discarded pending edits at the next reload_all.
+    v = PreferencesView.new
+    v.open_default
+    into_fields(v)
+    v.handle_key(pkey(RIGHT))
+    v.dirty?.should be_true
+
+    v.handle_key(pctrl(Termisu::Input::Key::LowerP)).kind.should eq(:none) # warns first
+    v.handle_key(pctrl(Termisu::Input::Key::LowerP)).kind.should eq(:palette)
+  end
+
+  it "does not report a rejected save as saved" do
+    # A failed validation persists nothing, so a :saved outcome would have the host
+    # live-apply — rebinding the proxy — for input that was just refused.
+    v = PreferencesView.new
+    v.open(:network)
+    v.handle_key(pkey(DOWN)) # Bind Host -> Bind Port
+    8.times { v.handle_key(pkey(Termisu::Input::Key::Backspace)) }
+    "abc".each_char { |ch| v.handle_key(pkey(Termisu::Input::Key::Space, ch)) }
+    v.handle_key(pkey(Termisu::Input::Key::Enter)).kind.should eq(:none)
+  end
+
+  it "keeps the modal's focus and the section's focus together across ^R" do
+    # `reset_to_defaults` snaps the FORM's own cursor back to field 0 while the modal keeps
+    # its separate flat index, so without a re-sync the row drawn as focused and the row
+    # that receives the next keystroke are different rows. Typing after ^R proves which.
+    v = PreferencesView.new
+    v.open(:network)
+    v.handle_key(pkey(DOWN)) # Bind Host -> Bind Port
+    v.handle_key(pctrl(Termisu::Input::Key::LowerR))
+    v.handle_key(pkey(Termisu::Input::Key::Space, '9'))
+
+    backend = MemoryBackend.new(100, 40)
+    v.render(Screen.new(backend), Rect.new(0, 0, 100, 40))
+    backend.contains?("#{Gori::Settings::DEFAULT_BIND_PORT}9").should be_true
+    backend.contains?("#{Gori::Settings::DEFAULT_BIND_HOST}9").should be_false
   end
 
   it "closes on Ctrl+, — the chord that opened it" do

--- a/spec/tui/sitemap_view_spec.cr
+++ b/spec/tui/sitemap_view_spec.cr
@@ -470,6 +470,66 @@ describe Gori::Tui::SitemapView do
     end
   end
 
+  it "cuts tag: terms with the shared lexer, so quoting and NOT work" do
+    tmp_store do |store|
+      capture(store, "acme.test", "GET", "/api/users")
+      capture(store, "acme.test", "GET", "/static/app.js")
+      store.set_sitemap_tag("acme.test", "/api", "my flow")
+
+      # `String#split` tore this into `tag:"my` + `flow"`, so the tag never matched.
+      view = SitemapView.new
+      view.reload(store)
+      view.start_query
+      %(tag:"my flow").each_char { |c| view.query_insert(c) }
+      view.reload(store)
+
+      b = MemoryBackend.new(70, 20)
+      view.render(Screen.new(b), Rect.new(0, 0, 70, 20))
+      b.contains?("users").should be_true
+      b.contains?("static").should be_false
+    end
+  end
+
+  it "treats NOT tag:x as exclusion, like -tag:x" do
+    tmp_store do |store|
+      capture(store, "acme.test", "GET", "/api/users")
+      capture(store, "acme.test", "GET", "/static/app.js")
+      store.set_sitemap_tag("acme.test", "/api", "done")
+
+      # Hand-tokenising filed `tag:done` as a POSITIVE and then blanked the tree on the
+      # leftover bare `NOT` — the exact inverse of what was asked.
+      view = SitemapView.new
+      view.reload(store)
+      view.start_query
+      "NOT tag:done".each_char { |c| view.query_insert(c) }
+      view.reload(store)
+
+      b = MemoryBackend.new(70, 20)
+      view.render(Screen.new(b), Rect.new(0, 0, 70, 20))
+      b.contains?("static").should be_true # the untagged sibling survives
+      b.contains?("users").should be_false # the tagged subtree is excluded
+    end
+  end
+
+  it "does not blank the tree when cutting tags leaves only an operator" do
+    tmp_store do |store|
+      capture(store, "acme.test", "GET", "/api/users")
+      store.set_sitemap_tag("acme.test", "/api", "payment")
+
+      # `tag:a OR tag:b` hands QL the residual `OR`. That has no terms, so it cannot be
+      # "every term was invalid" — it used to blank the whole sitemap behind that note.
+      view = SitemapView.new
+      view.reload(store)
+      view.start_query
+      "tag:payment OR tag:payment".each_char { |c| view.query_insert(c) }
+      view.reload(store)
+
+      b = MemoryBackend.new(70, 20)
+      view.render(Screen.new(b), Rect.new(0, 0, 70, 20))
+      b.contains?("users").should be_true
+    end
+  end
+
   it "re-anchors selection, scroll, and manual collapse across reload (live capture poll)" do
     # Regression: data_version polls used to zero @selected/@scroll every rebuild,
     # so navigating deep under live traffic kept jumping back to the top host.

--- a/spec/tui/text_field_spec.cr
+++ b/spec/tui/text_field_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "../support/memory_backend"
 
 include Gori::Tui
 
@@ -28,6 +29,36 @@ describe Gori::Tui::TextField do
     f.set("/tmp/dir/")
     f.insert('a')
     f.value.should eq("/tmp/dir/a") # not "/tmp/adir/" or similar mid-string damage
+  end
+
+  it "draws the IME preedit at the caret" do
+    # The field STORED composing text but rendered with a plain `text` call, so every
+    # TextField overlay dropped it: a Hangul/CJK name typed into the import popup was
+    # invisible until each syllable committed.
+    f = TextField.new("ab")
+    f.set_preedit("\uD55C")
+    backend = MemoryBackend.new(40, 3)
+    f.render(Screen.new(backend), 0, 0, 20, true, Theme.text, Theme.bg)
+    backend.contains?("ab\uD55C").should be_true
+  end
+
+  it "scrolls horizontally to keep the caret visible" do
+    # The import card's field is at most 64 columns; an absolute path easily exceeds it.
+    # Rendering always started at index 0, so past the width the tail, the caret and the
+    # hardware-cursor sync all disappeared.
+    long = "/very/long/path/segment/that/exceeds/the/field/width/file.har"
+    f = TextField.new(long)
+    backend = MemoryBackend.new(40, 3)
+    f.render(Screen.new(backend), 0, 0, 20, true, Theme.text, Theme.bg)
+    backend.contains?("file.har").should be_true # the caret end, not the "/very/long" head
+    backend.contains?("/very/long").should be_false
+  end
+
+  it "does not scroll while the value still fits" do
+    f = TextField.new("/tmp/x")
+    backend = MemoryBackend.new(40, 3)
+    f.render(Screen.new(backend), 0, 0, 20, true, Theme.text, Theme.bg)
+    backend.contains?("/tmp/x").should be_true
   end
 
   it "seeds the caret at the end on construction" do

--- a/src/gori/filter_ast.cr
+++ b/src/gori/filter_ast.cr
@@ -299,6 +299,52 @@ module Gori
       end
     end
 
+    # Pull the terms a backend handles ITSELF out of a query, returning them plus the
+    # residual for the normal parser. For a surface that owns a field the shared backend
+    # knows nothing about — Sitemap's `tag:`, which has no SQL column and filters the
+    # built TREE rather than the rows — the alternative is re-tokenising with
+    # `String#split`, which sees no quotes, no parens and no `-`/`NOT`, so `tag:"my tag"`
+    # tore in half and `NOT tag:done` INCLUDED what it was asked to exclude.
+    #
+    # Cutting from the same lexer means a hand-rolled field gets the grammar's quoting
+    # and negation for free. It does NOT get the boolean structure: the residual is
+    # rejoined with spaces, so extracted terms end up ANDed with whatever is left.
+    # Callers that care must say so (see SitemapView's tag note).
+    #
+    # NOTE: iterated by index rather than `each` — `yield` inside a block is what the
+    # Crystal compiler refuses here.
+    def self.partition(query : String, & : Term -> Bool) : {Array(Term), String}
+      taken = [] of Term
+      kept = [] of String
+      lexemes = lex(query)
+      i = 0
+      while i < lexemes.size
+        # A run of NOT keywords sitting directly before a term desugars ONTO that term —
+        # `parse_unary` does exactly this — and the desugaring happens at parse time, not
+        # in the lexer, so a lexeme-level scan would hand back `tag:done` unnegated and
+        # leave a bare `NOT` dangling in the residual. Take the run with the term.
+        run = 0
+        while i + run < lexemes.size && lexemes[i + run].tok.not?
+          run += 1
+        end
+        nxt = lexemes[i + run]?
+        if run > 0 && nxt && (nt = nxt.term) && yield nt
+          taken << (run.odd? ? nt.negated : nt)
+          i += run + 1
+          next
+        end
+        lx = lexemes[i]
+        t = lx.term
+        if t && yield t
+          taken << t
+        else
+          kept << query[lx.start, lx.size]
+        end
+        i += 1
+      end
+      {taken, kept.join(' ')}
+    end
+
     # --- syntax highlighting -------------------------------------------------
 
     enum SpanKind

--- a/src/gori/filter_ast.cr
+++ b/src/gori/filter_ast.cr
@@ -235,9 +235,21 @@ module Gori
           pos += 1
         end
         break if pos >= lx.size || lx[pos].tok.or? || lx[pos].tok.r_paren?
+        before = pos
         node, pos = parse_unary(lx, pos)
-        break unless node
-        children << node
+        if node
+          children << node
+        elsif pos == before
+          # No node AND no progress: the dangling-`)` case parse_primary leaves for the
+          # enclosing group. Anything else would spin here.
+          break
+        end
+        # A nil node that DID consume input is an empty group (`()`, `("")`, `(AND)`) or
+        # a `NOT` over one. Skip just that group and keep going — breaking here would
+        # silently discard every remaining term in the chain, turning `host:a () x:1`
+        # into a bare `host:a` that no diagnostic could see (the dropped lexemes never
+        # reach `analyze`, so it still reported `clean?`). On a security proxy a filter
+        # that quietly BROADENS is the dangerous direction.
       end
       return {nil, pos} if children.empty?
       {children.size == 1 ? children.first : AndNode.new(children), pos}

--- a/src/gori/filter_ast.cr
+++ b/src/gori/filter_ast.cr
@@ -319,7 +319,16 @@ module Gori
     #
     # Spans are ordered and non-overlapping, but need not cover every character
     # (whitespace between terms is skipped); callers fill gaps with their base colour.
-    def self.spans(query : String) : Array(Span)
+    #
+    # `seps` is which characters this BACKEND accepts as a field separator, and it is
+    # not decoration: only QL implements the `~` regex operator, so painting `title~x`
+    # as a field in the Issues bar would advertise a match that backend will never
+    # perform (it free-texts the whole token instead). Structure is shared; the operator
+    # set is not, so the caller states it. See `SEPS_FIELD` / `SEPS_FIELD_REGEX`.
+    SEPS_FIELD       = ":"
+    SEPS_FIELD_REGEX = ":~"
+
+    def self.spans(query : String, seps : String = SEPS_FIELD_REGEX) : Array(Span)
       acc = [] of Span
       lex(query).each do |lexeme|
         case lexeme.tok
@@ -328,21 +337,21 @@ module Gori
         when .and?, .or?, .not?
           acc << Span.new(lexeme.start, lexeme.size, SpanKind::Operator)
         else
-          word_spans(query, lexeme, acc)
+          word_spans(query, lexeme, acc, seps)
         end
       end
       acc
     end
 
-    # Index of the `:`/`~` that makes `[from, to)` a field term, or nil for free text.
+    # Index of the separator that makes `[from, to)` a field term, or nil for free text.
     # Needs at least one character of field name before it, and a quote appearing first
     # means the whole thing is a quoted phrase rather than a `field:value`.
-    private def self.field_sep(query : String, from : Int32, to : Int32) : Int32?
+    private def self.field_sep(query : String, from : Int32, to : Int32, seps : String) : Int32?
       j = from
       while j < to
         ch = query[j]
         return nil if ch == '"'
-        return j if (ch == ':' || ch == '~') && j > from
+        return j if seps.includes?(ch) && j > from
         j += 1
       end
       nil
@@ -350,7 +359,7 @@ module Gori
 
     # Sub-classify one word: an optional `-`, an optional `field:`/`field~` prefix, then
     # the remainder with any quote marks called out.
-    private def self.word_spans(query : String, lexeme : Lexeme, acc : Array(Span)) : Nil
+    private def self.word_spans(query : String, lexeme : Lexeme, acc : Array(Span), seps : String) : Nil
       s = lexeme.start
       e = s + lexeme.size
       i = s
@@ -362,7 +371,7 @@ module Gori
         i += 1
       end
 
-      sep = field_sep(query, i, e)
+      sep = field_sep(query, i, e, seps)
       if sep
         acc << Span.new(i, sep - i + 1, SpanKind::Field)
         i = sep + 1

--- a/src/gori/filter_ast.cr
+++ b/src/gori/filter_ast.cr
@@ -125,7 +125,8 @@ module Gori
         word_len = raw.size - lead - trail
         text = String.build { |io| chars[lead, chars.size - lead - trail].each { |c| io << c[0] } }
         unless text.empty?
-          acc << Lexeme.new(word_tok(text, quoted_any), word_term(text, raw[lead, word_len]),
+          acc << Lexeme.new(word_tok(text, quoted_any),
+            word_term(text, raw[lead, word_len], chars[lead][1]),
             at + lead, word_len)
         end
 
@@ -147,9 +148,15 @@ module Gori
     end
 
     # A leading `-` negates, but only with something after it — a lone `-` is a word
-    # (the backends that free-text it have always done so).
-    private def self.word_term(text : String, source : String) : Term
-      if text.starts_with?('-') && text.size > 1
+    # (the backends that free-text it have always done so) — and only when the `-`
+    # itself was typed OUTSIDE quotes, so `"-a"` searches for the literal text `-a`
+    # exactly as `"AND"` searches for the literal word. The test is the QUOTED FLAG OF
+    # THAT ONE CHARACTER, not `quoted_any`: `-host:"my host"` quotes only the value and
+    # must still negate. This is the single place negation is decided — `word_spans`
+    # paints from the Term it produces rather than re-deriving the rule, so the colour
+    # cannot drift from the parse.
+    private def self.word_term(text : String, source : String, lead_quoted : Bool) : Term
+      if !lead_quoted && text.starts_with?('-') && text.size > 1
         Term.new(text[1..], source, true)
       else
         Term.new(text, source, false)
@@ -335,7 +342,10 @@ module Gori
       s = lexeme.start
       e = s + lexeme.size
       i = s
-      if query[i]? == '-' && lexeme.size > 1
+      # Ask the lexeme whether it negated rather than re-reading the `-` off the source:
+      # re-deriving is how the colour drifts from the parse (`-"` looks negated but is a
+      # literal dash; `"-a"` looks literal but used to negate).
+      if lexeme.term.try(&.negate?)
         acc << Span.new(i, 1, SpanKind::Operator) # `-x` is `NOT x`; colour them alike
         i += 1
       end

--- a/src/gori/intercept_filter.cr
+++ b/src/gori/intercept_filter.cr
@@ -35,16 +35,22 @@ module Gori
         negate ? !hit : hit
       end
 
+      # `value` arrives already case-folded from `parse_term` (downcased, or UPCASED for
+      # :method), so nothing here re-folds the pattern. It used to `.downcase` it on every
+      # call — allocating a fresh String per in-flight message on the proxy hold path, for
+      # a pattern that cannot change after parse. The two equality fields compare
+      # case-insensitively so the SUBJECT need not be folded either; the substring fields
+      # still fold their subject, which is why `matches?` no longer claims zero allocation.
       private def raw_match?(s : Subject) : Bool
         case field
-        when :host   then s.host.downcase.includes?(value.downcase)
-        when :path   then s.target.downcase.includes?(value.downcase)
-        when :method then s.method.upcase == value.upcase
-        when :scheme then s.scheme.downcase == value.downcase
+        when :host   then s.host.downcase.includes?(value)
+        when :path   then s.target.downcase.includes?(value)
+        when :method then s.method.compare(value, case_insensitive: true) == 0
+        when :scheme then s.scheme.compare(value, case_insensitive: true) == 0
         when :status then (st = s.status) ? InterceptFilter.status_match?(st, value) : false
         else # :text — free-text substring over method/host/target
-          v = value.downcase
-          s.method.downcase.includes?(v) || s.host.downcase.includes?(v) || s.target.downcase.includes?(v)
+          s.method.downcase.includes?(value) || s.host.downcase.includes?(value) ||
+            s.target.downcase.includes?(value)
         end
       end
     end
@@ -110,7 +116,8 @@ module Gori
       @tree.nil?
     end
 
-    # An empty filter matches all. Allocates nothing.
+    # An empty filter matches all. Patterns are pre-folded at parse time, so matching a
+    # host/path/free-text term costs one `downcase` of the subject and nothing else.
     def matches?(s : Subject) : Bool
       tree = @tree
       return true unless tree
@@ -137,13 +144,20 @@ module Gori
         field = field_symbol(text[0...colon].downcase)
         # An unknown field → free-text the WHOLE token (mirrors QL / Issues::Filter), so a
         # typo'd field like `hsot:evil.com` searches literally instead of silently matching "evil.com".
-        return Term.new(:text, text, term.negate?) if field == :text
+        return Term.new(:text, text.downcase, term.negate?) if field == :text
         value = text[(colon + 1)..]
         return nil if value.empty?
-        Term.new(field, value, term.negate?)
+        Term.new(field, fold(field, value), term.negate?)
       else
-        Term.new(:text, text, term.negate?)
+        Term.new(:text, text.downcase, term.negate?)
       end
+    end
+
+    # Case-fold a term's value ONCE, at parse time, into the form `raw_match?` compares
+    # against. `:status` is folded too — `status_match?` tests a literal lowercase 'x',
+    # so `status:5XX` matched nothing at all before this.
+    private def self.fold(field : Symbol, value : String) : String
+      field == :method ? value.upcase : value.downcase
     end
 
     # Map a field name to its Term symbol. An unknown field is treated as free text

--- a/src/gori/sitemap.cr
+++ b/src/gori/sitemap.cr
@@ -269,7 +269,16 @@ module Gori
       s = (qi = label.index('?')) ? label[0, qi] : label
       return nil if s.empty? # a bare-root request with a query → the leaf label is "?q=1"
       return nil if numeric_label?(s)
-      # Size gates first: most real segments ("api", "users") never reach a regex.
+      # A captured target is raw bytes off the wire — `Http1.parse_request_head` builds it
+      # with `String.new(Bytes)`, which does NOT validate — so a legacy-encoded (EUC-KR,
+      # latin-1) or fuzzed path reaches here as invalid UTF-8. PCRE2 RAISES on such a
+      # subject rather than returning false, and this runs on the sitemap poll with no
+      # rescue between here and the run loop, so one such request tore down the TUI. All
+      # three patterns below are ASCII-only, so a non-ASCII segment could never match
+      # anyway: the guard is exact, and it also keeps every CJK path off PCRE2 entirely.
+      # (`Gori::SafeRegexp` exists for this same reason on the store side.)
+      return nil unless s.ascii_only?
+      # Size gates next: most real segments ("api", "users") never reach a regex.
       return "{date}" if s.size == DATE_LEN && Discover::Url::DATE.matches?(s)
       return "{uuid}" if s.size == UUID_LEN && Discover::Url::UUID.matches?(s)
       return "{hex}" if s.size >= HEX_MIN && Discover::Url::HEX.matches?(s)

--- a/src/gori/sitemap.cr
+++ b/src/gori/sitemap.cr
@@ -279,10 +279,20 @@ module Gori
       # (`Gori::SafeRegexp` exists for this same reason on the store side.)
       return nil unless s.ascii_only?
       # Size gates next: most real segments ("api", "users") never reach a regex.
-      return "{date}" if s.size == DATE_LEN && Discover::Url::DATE.matches?(s)
+      return "{date}" if s.size == DATE_LEN && Discover::Url::DATE.matches?(s) && real_date?(s)
       return "{uuid}" if s.size == UUID_LEN && Discover::Url::UUID.matches?(s)
       return "{hex}" if s.size >= HEX_MIN && Discover::Url::HEX.matches?(s)
       nil
+    end
+
+    # `Url::DATE` is only a SHAPE (\d{4}-\d{2}-\d{2}), so `1234-56-78` and `9999-99-99`
+    # matched it. Folding those is arguably right — they are opaque ids — but labelling
+    # them `{date}` tells the reader something false about the route. Range-check the
+    # parts and let a non-date fall through to `{hex}`/literal instead.
+    private def self.real_date?(s : String) : Bool
+      month = s[5, 2].to_i
+      day = s[8, 2].to_i
+      1 <= month <= 12 && 1 <= day <= 31
     end
 
     # Fold a node's pure-numeric children into one collapsed `[1, 2, 3 … +N]` group

--- a/src/gori/sitemap.cr
+++ b/src/gori/sitemap.cr
@@ -148,9 +148,9 @@ module Gori
       # must not fabricate path-tree nodes. The query rides on the leaf so /x?a=1 and
       # /x?a=2 stay distinct endpoints without corrupting the tree.
       qidx = path.index('?')
-      path_part = qidx ? path[0...qidx] : path
+      path_only = qidx ? path[0...qidx] : path # local, not the `path_part` helper below
       suffix = qidx ? path[qidx..] : ""
-      segments = path_part.split('/')
+      segments = path_only.split('/')
       segments.shift if segments.first? == "" # the mandatory leading-slash empty
       segments.pop if segments.last? == ""    # a trailing slash → same endpoint (normalized)
       # An INTERIOR empty (a literal "//") is kept, so //dup/a stays distinct from /dup/a.
@@ -266,7 +266,7 @@ module Gori
     # `group_sequences!` — `fold_segment` only escapes that by testing NUM first.
     def self.template_class(label : String) : String?
       # A leaf carries its query on the last segment (see `add`), so classify the path part.
-      s = (qi = label.index('?')) ? label[0, qi] : label
+      s = path_part(label)
       return nil if s.empty? # a bare-root request with a query → the leaf label is "?q=1"
       return nil if numeric_label?(s)
       # A captured target is raw bytes off the wire — `Http1.parse_request_head` builds it
@@ -297,7 +297,7 @@ module Gori
       return if node.grouped
       numeric = node.children.select { |c| !c.grouped && numeric_label?(c.label) }
       return if numeric.size <= SEQUENCE_GROUP_THRESHOLD
-      numeric.sort_by! { |c| {c.label.size, c.label} }
+      numeric.sort_by! { |c| p = path_part(c.label); {p.size, p} }
       rest = node.children.select { |c| c.grouped || !numeric_label?(c.label) }
       group = Node.new(group_label(numeric))
       group.grouped = true
@@ -310,13 +310,22 @@ module Gori
       node.children << group
     end
 
+    # The path side of a leaf label. `add` appends the query to the LAST segment, so
+    # `/items/7?ref=home` arrives here as the label `7?ref=home`. Every classifier has to
+    # look past that or an id stops being recognisable the moment it carries a query —
+    # which is exactly when a listing page explodes the tree.
+    def self.path_part(label : String) : String
+      (qi = label.index('?')) ? label[0, qi] : label
+    end
+
     def self.numeric_label?(label : String) : Bool
-      !label.empty? && label.each_char.all?(&.ascii_number?)
+      s = path_part(label)
+      !s.empty? && s.each_char.all?(&.ascii_number?)
     end
 
     # "[1, 2, 3 … +47]" — the first three values then a remainder count.
     def self.group_label(nodes : Array(Node)) : String
-      head = nodes.first(3).map(&.label).join(", ")
+      head = nodes.first(3).map { |n| path_part(n.label) }.join(", ")
       nodes.size > 3 ? "[#{head} … +#{nodes.size - 3}]" : "[#{head}]"
     end
 

--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -589,10 +589,12 @@ module Gori::Tui
     end
 
     # The right-aligned status chips, TAGGED so render and (were there a clickable
-    # chip here) a hit-test would share one ordered source. The resource readout is drawn
-    # LAST (rightmost) on purpose: it is fixed-width, so anchoring it to the right edge keeps
-    # the transient activity chip from shifting the readout every time a job starts or ends.
-    # It renders in `muted` — a passive readout, not a state the operator must act on.
+    # chip here) a hit-test would share one ordered source. Ordered least-stable first, so
+    # the fixed-width CLOCK anchors the right edge and the transient activity chip shifts
+    # only what is to its right. The resource readout is NOT fixed-width — `human_bytes`
+    # grows on a digit or GiB boundary (see Resource#format) — so it cannot hold that
+    # anchor; it sits between the two. Both render in `muted`: passive readouts, not states
+    # the operator must act on.
     private def self.status_chips(*, activity : {String, Color}?, resource : String? = nil,
                                   time : String? = nil) : Array(Chip)
       chips = [] of Chip

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -30,6 +30,7 @@ module Gori::Tui
         Item.new("s", "toggle scope lens (or click scope:N)", "scope.toggle-lens"),
         Item.new("^P", "Match & Replace → Rewriter tab (palette)", "rules.edit"),
         Item.new("badge / ^P", "notification center (palette; rebindable)", "app.notifications"),
+        Item.new("^, / ⚙", "preferences — every setting (also ^P → Settings)", "settings.open"),
         Item.new("^B", "reveal whitespace (·→␍␊)", "view.reveal-ws"),
         Item.new("^D / ^C ×2", "quit gori"),
         Item.new("q", "back to projects (on the tab bar)"),

--- a/src/gori/tui/highlight.cr
+++ b/src/gori/tui/highlight.cr
@@ -202,9 +202,13 @@ module Gori::Tui
     # preview of how the query will be PARSED: a lowercase `or`, a quoted "AND", and a
     # `(` sitting inside a value all stay plain, because none of them group anything.
     # Characters no span covers (the whitespace between terms) keep `base`.
-    def self.filter_query(query : String, base : Color = Theme.text) : Array(Color)
+    # `seps` must match what the BACKEND behind this bar actually splits on — only QL
+    # implements `~`, so the four bars that don't pass `SEPS_FIELD` and `title~admin`
+    # stays plain there, because that is how it will be matched (as free text).
+    def self.filter_query(query : String, base : Color = Theme.text,
+                          seps : String = FilterAst::SEPS_FIELD_REGEX) : Array(Color)
       colors = Array(Color).new(query.size, base)
-      FilterAst.spans(query).each do |span|
+      FilterAst.spans(query, seps).each do |span|
         fg = case span.kind
              in .operator? then Theme.syn_keyword
              in .paren?    then Theme.syn_keyword

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -495,7 +495,7 @@ module Gori::Tui
         base = rect.x + 1 + prefix.size
         screen.input_line(base, rect.y, @query, @qcx, @preedit, Theme.text_bright,
           width: {rect.w - prefix.size - 2, 0}.max,
-          colors: Highlight.filter_query(@query, Theme.text_bright))
+          colors: Highlight.filter_query(@query, Theme.text_bright, FilterAst::SEPS_FIELD))
         return
       end
 
@@ -520,7 +520,7 @@ module Gori::Tui
         # The committed condition stays highlighted — this readout is what you scan to
         # check WHY something is (or isn't) being held.
         x = screen.text(x, rect.y, ": ", Theme.muted, width: left_w)
-        screen.styled_text(x, rect.y, @query, Highlight.filter_query(@query, Theme.text),
+        screen.styled_text(x, rect.y, @query, Highlight.filter_query(@query, Theme.text, FilterAst::SEPS_FIELD),
           Theme.text, width: {rect.right - 1 - x, 0}.max)
       end
     end

--- a/src/gori/tui/issues_view.cr
+++ b/src/gori/tui/issues_view.cr
@@ -575,7 +575,7 @@ module Gori::Tui
         screen.text(rect.x + 1, rect.y, prefix, Theme.accent)
         base = rect.x + 1 + prefix.size
         screen.input_line(base, rect.y, @query, @qcx, @preedit_q, Theme.text_bright, width: {rect.w - prefix.size - 2, 0}.max,
-          colors: Highlight.filter_query(@query, Theme.text_bright))
+          colors: Highlight.filter_query(@query, Theme.text_bright, FilterAst::SEPS_FIELD))
         return
       end
       rx = rect.right - 1
@@ -589,7 +589,7 @@ module Gori::Tui
         # The committed query stays highlighted — this readout is what you scan to
         # check how the active filter is actually being read.
         qx = screen.text(rect.x + 1, rect.y, ": ", Theme.muted, width: left_w)
-        screen.styled_text(qx, rect.y, @query, Highlight.filter_query(@query, Theme.text),
+        screen.styled_text(qx, rect.y, @query, Highlight.filter_query(@query, Theme.text, FilterAst::SEPS_FIELD),
           Theme.text, width: {rect.x + 1 + left_w - qx, 0}.max)
       else
         screen.text(rect.x + 1, rect.y, "/ filter  ·  severity:  status:open  status:closed  host:", Theme.muted, width: left_w)

--- a/src/gori/tui/preferences_view.cr
+++ b/src/gori/tui/preferences_view.cr
@@ -33,6 +33,12 @@ module Gori::Tui
     @on_strip : Bool = false # true = the group strip holds focus (←/→ switch groups)
     @strip_start : Int32 = 0
     @status : String? = nil
+    # Whether @status reports a FAILURE (rejected save, blocked opener, unsaved-edit
+    # warning) rather than a success. Kept as a flag rather than re-sniffing the string:
+    # SettingsView can match on its own short internal status ("invalid port"), but what
+    # lands here is `save`'s RETURN message ("settings: invalid bind port …"), so the
+    # prefixes it looks for are not present and every failure rendered green.
+    @status_warn : Bool = false
     @confirm_discard : Bool = false # an esc landed on unsaved edits; the next one discards
 
     def initialize(@allowed_openers : Set(Symbol)? = nil)
@@ -107,12 +113,19 @@ module Gori::Tui
       key = ev.key
       c = ev.char || key.to_char
       @status = nil # clear stale save/reset feedback; activate_focus/reset_focused re-set it
+      @status_warn = false
       # A discard warning survives exactly one keystroke: the esc that would confirm it.
       confirming, @confirm_discard = @confirm_discard, false
       # Modal-wide chords, claimed before the strip/body split so they work on both:
       # ^P jumps to the palette (as it does from every other overlay), Ctrl+, closes the
       # modal the same chord opened.
-      return Outcome.new(:palette) if ev.ctrl? && key.lower_p?
+      # ^P leaves the modal just as surely as esc does — the host sets @overlay = :none —
+      # so it has to pass the same unsaved-edits guard. It was the one exit that didn't,
+      # and the pending edits then died silently at the next open's reload_all.
+      if ev.ctrl? && key.lower_p?
+        return NONE unless close_or_warn(confirming).kind == :close
+        return Outcome.new(:palette)
+      end
       return close_or_warn(confirming) if ev.ctrl? && key.comma?
       return handle_strip_key(key, confirming) if @on_strip
 
@@ -174,6 +187,7 @@ module Gori::Tui
       return Outcome.new(:close) if confirming || dirty.empty?
       @confirm_discard = true
       @status = "unsaved: #{dirty.join(", ")} — ↵ saves the focused section, esc again discards"
+      @status_warn = true
       NONE
     end
 
@@ -240,6 +254,12 @@ module Gori::Tui
       end
       msg = form.save
       @status = msg # reflect the save in the footer (self-contained feedback for the picker)
+      @status_warn = !form.saved?
+      # `save` returns its error message and persists NOTHING when validation fails, so a
+      # :saved outcome there would be a lie the host acts on — apply_settings_saved
+      # rebinds the live proxy and re-pushes upstream/landing settings for input that was
+      # just rejected. Report the failure in the footer only.
+      return NONE unless form.saved?
       Outcome.new(:saved, sec.sym, msg)
     end
 
@@ -248,6 +268,7 @@ module Gori::Tui
     private def open_or_block(sym : Symbol) : Outcome
       return Outcome.new(:open, sym) if opener_allowed?(sym)
       @status = "open a project to edit this"
+      @status_warn = true
       NONE
     end
 
@@ -258,6 +279,10 @@ module Gori::Tui
     private def reset_focused : Nil
       if f = focused_form
         f.reset_to_defaults # working copy only — still needs ↵ to persist, so no confirm
+        # reset_to_defaults snaps the FORM's own cursor back to field 0, but the modal
+        # tracks focus in its own flat index. Without this the highlighted row and the
+        # row that actually receives edits drift apart until the next ↑/↓/click.
+        sync_focus
         @status = "section reset to defaults — ↵ to save"
       end
     end
@@ -376,7 +401,10 @@ module Gori::Tui
       hint_y = box.bottom - 2
       iw = {box.w - 4, 0}.max
       note = @status || focused_hint
-      screen.text(box.x + 2, note_y, note, @status ? Theme.green : Theme.muted, Theme.panel, width: iw)
+      # Same green/yellow split SettingsView uses — a rejected save must not read as a
+      # successful one just because it came through the modal.
+      note_fg = @status ? (@status_warn ? Theme.yellow : Theme.green) : Theme.muted
+      screen.text(box.x + 2, note_y, note, note_fg, Theme.panel, width: iw)
       hint = @on_strip ? "←/→ group · ↓/↵ enter · esc close" : "↑/↓ field · ←/→ edit · ↵ save · ^R reset · esc close"
       hx = {box.right - hint.size - 2, box.x + 2}.max
       screen.text(hx, hint_y, hint, Theme.muted, Theme.panel, width: {box.right - hx - 1, 0}.max)

--- a/src/gori/tui/probe_view.cr
+++ b/src/gori/tui/probe_view.cr
@@ -543,7 +543,7 @@ module Gori::Tui
         screen.text(rect.x + 1, y, prefix, Theme.accent)
         base = rect.x + 1 + prefix.size
         screen.input_line(base, y, @query, @qcx, @preedit_q, Theme.text_bright, width: {rect.w - prefix.size - 2, 0}.max,
-          colors: Highlight.filter_query(@query, Theme.text_bright))
+          colors: Highlight.filter_query(@query, Theme.text_bright, FilterAst::SEPS_FIELD))
         return
       end
       # Right cluster: a scope-lens chip (always shown so the ⇧S toggle is discoverable,

--- a/src/gori/tui/project_picker.cr
+++ b/src/gori/tui/project_picker.cr
@@ -1121,7 +1121,10 @@ module Gori::Tui
     # rather than opening the form with it retyped.
     private def run_hint_action(action : Symbol) : Project | Symbol | Nil
       case action
-      when :open  then activate
+      # `return`, not a bare call: `activate`'s Project IS how the picker says "open
+      # this" (see `run`). Without it the footer button did nothing, and on the Temp row
+      # it silently created a project directory on disk and abandoned it, once per click.
+      when :open  then return activate
       when :space then open_space_menu
       when :temp  then return open_temp
       when :quit  then return :quit

--- a/src/gori/tui/project_picker.cr
+++ b/src/gori/tui/project_picker.cr
@@ -231,7 +231,13 @@ module Gori::Tui
       outcome = @preferences.handle_key(ev)
       case outcome.kind
       when :close then @mode = :list
-      when :saved then @resized = true # a saved Display/Layout pref may change how the picker draws
+      when :saved
+        @resized = true # a saved Display/Layout pref may change how the picker draws
+        # Mouse capture is armed once for the whole process in `App` and reconciled only
+        # by the in-app save seam, so toggling it here used to persist and do nothing —
+        # not even after opening a project — leaving native text selection broken for the
+        # rest of the session with no hint that a restart was needed.
+        Settings.mouse ? @term.enable_mouse : @term.disable_mouse
       when :open
         if outcome.section == :theme
           @theme_card.reload(:theme)

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1299,8 +1299,8 @@ module Gori::Tui
     # The overlays that fully capture input (a centered card); :detail and :none do not.
     private def modal_overlay? : Bool
       case @overlay
-      when :palette, :issue_new, :confirm, :browser, :choice, :tabs_more, :comparer_pick, :repeater_subtab, :links, :issue_pick, :note_pick, :preferences, :settings, :tabs, :hotkeys, :notifications, :mine_config, :sequence_config, :probe_active, :discover_config, :discover_headers, :fuzz_set, :fuzz_advanced, :scope_rule, :oast_provider, :probe_rule, :rewriter_rule, :ca_import, :import then true
-      else                                                                                                                                                                                                                                                                                                                                                                                               false
+      when :palette, :issue_new, :confirm, :browser, :choice, :tabs_more, :comparer_pick, :repeater_subtab, :links, :issue_pick, :note_pick, :preferences, :settings, :tabs, :hosts, :env, :hotkeys, :notifications, :mine_config, :sequence_config, :probe_active, :discover_config, :discover_headers, :fuzz_set, :fuzz_advanced, :scope_rule, :oast_provider, :probe_rule, :rewriter_rule, :ca_import, :import then true
+      else                                                                                                                                                                                                                                                                                                                                                                                                             false
       end
     end
 

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -101,7 +101,7 @@ module Gori::Tui
       # reject it (empty tree + a note) rather than fall through to a match-all search
       # that shows the WHOLE sitemap behind an "active" filter. A tag-only query has a
       # blank residual, so reject_empty? is false and the tag filter still applies below.
-      if QL.reject_empty?(residual, residual_filter)
+      if residual_has_terms?(residual) && QL.reject_empty?(residual, residual_filter)
         @hosts = [] of Node
         @visible_cache = nil
         @selected = 0
@@ -219,32 +219,41 @@ module Gori::Tui
     # as "no endpoints". Operates on the residual (tag: terms are handled separately).
     private def query_note_for(residual : String, filter : QL::Filter) : String?
       return nil if residual.blank?
-      return "invalid filter — no valid terms" if QL.reject_empty?(residual, filter)
+      return "invalid filter — no valid terms" if residual_has_terms?(residual) && QL.reject_empty?(residual, filter)
       bad = QL.invalid_regex_terms(residual)
       bad.empty? ? nil : "invalid regex in #{bad.first}"
     end
 
-    # Split `tag:`/`-tag:` tokens out of the query (whitespace-tokenised, matching
-    # QL.parse). Returns positive + negative keywords (lowercased) and the residual
-    # query for QL.parse.
+    # Split `tag:` terms out of the query. Cut with the SHARED lexer, not `String#split`:
+    # hand-tokenising saw no quotes (`tag:"my tag"` became `tag:"my` + `tag"`) and no
+    # `NOT` (`NOT tag:done` filed `done` as a POSITIVE and then blanked the tree on the
+    # leftover `NOT`), while the bar above it was already highlighting all of that as
+    # real grammar. Negation now rides the same `Term#negate?` every other filter uses,
+    # so `-tag:x` and `NOT tag:x` are finally the same thing here too.
     private def split_tag_terms(query : String) : {Array(String), Array(String), String}
       positives = [] of String
       negatives = [] of String
-      residual = [] of String
-      query.split.each do |tok|
-        if (v = tag_token_value(tok, "tag:")) && !v.empty?
-          positives << v.downcase
-        elsif (v = tag_token_value(tok, "-tag:")) && !v.empty?
-          negatives << v.downcase
-        else
-          residual << tok
-        end
-      end
-      {positives, negatives, residual.join(' ')}
+      # A half-typed `tag:` (no value yet) stays in the residual, exactly as before, so
+      # the tree doesn't blank out mid-keystroke.
+      taken, residual = FilterAst.partition(query) { |t| !tag_token_value(t.text).nil? }
+      taken.each { |t| (t.negate? ? negatives : positives) << tag_token_value(t.text).not_nil! }
+      {positives, negatives, residual}
     end
 
-    private def tag_token_value(tok : String, prefix : String) : String?
-      tok.downcase.starts_with?(prefix) ? tok[prefix.size..] : nil
+    # `reject_empty?` reads a non-blank query that compiled to nothing as "every term was
+    # invalid". That is right for what the USER typed, but the residual here is what is
+    # LEFT after the tag terms were cut out, so `tag:a OR tag:b` handed it the bare word
+    # `OR` — no terms at all — and the whole sitemap blanked behind an "invalid filter"
+    # note. Only a residual that still carries a term can be invalid.
+    private def residual_has_terms?(residual : String) : Bool
+      !FilterAst.terms(FilterAst.parse(residual)).empty?
+    end
+
+    # The keyword of a `tag:x` term, or nil if this isn't one (or has no value yet).
+    private def tag_token_value(text : String) : String?
+      return nil unless text.downcase.starts_with?("tag:")
+      v = text[4..].downcase
+      v.empty? ? nil : v
     end
 
     # Prune the tree to tag matches: a node survives a positive term if it (or an

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -195,13 +195,22 @@ module Gori::Tui
       return nil unless target
       want_host, want_path = target
       return nil if want_path.empty? || want_path.includes?(Sitemap::FOLD_SEP)
-      return nil unless idx = want_path.rindex('/')
-      parent = want_path[0, idx] # "" for a top-level node: its parent is the host row
       rows.each_with_index do |row, i|
-        next unless row.node.grouped && row.node.fold_parent == parent
+        # Ask which fold actually SWALLOWED this row, rather than which folds share its
+        # parent. A parent commonly holds both an id fold and a numeric fold, and
+        # `fold_templates!` appends before `group_sequences!` does — so matching on the
+        # parent alone landed the cursor on the {hex} fold when a numeric run collapsed.
+        next unless row.node.grouped && row.node.children.any? { |c| encloses?(c.path, want_path) }
         return i if host_label_for_row(rows, i) == want_host
       end
       nil
+    end
+
+    # Is `want` the folded node itself, or something beneath it? (Prefix-compared without
+    # building a "#{path}/" string per candidate — this runs per row on every reload.)
+    private def encloses?(path : String, want : String) : Bool
+      return true if path == want
+      want.starts_with?(path) && want[path.size]? == '/'
     end
 
     private def host_label_for_row(rows : Array(VisibleRow), idx : Int32) : String

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -491,11 +491,11 @@ module Gori::Tui
         field_w = {count_x - 1 - px, 1}.max
         screen.input_line(px, row_y, @subtab_filter, @filter_cx, @filter_preedit,
           Theme.text_bright, Theme.panel, width: field_w,
-          colors: Highlight.filter_query(@subtab_filter, Theme.text_bright))
+          colors: Highlight.filter_query(@subtab_filter, Theme.text_bright, FilterAst::SEPS_FIELD))
       elsif !@subtab_filter.blank?
         px = screen.text(rect.x, row_y, ": ", Theme.muted, Theme.panel, width: left_w)
         screen.styled_text(px, row_y, @subtab_filter,
-          Highlight.filter_query(@subtab_filter, Theme.text),
+          Highlight.filter_query(@subtab_filter, Theme.text, FilterAst::SEPS_FIELD),
           Theme.text, Theme.panel, width: {count_x - 1 - px, 0}.max)
       else
         screen.text(rect.x, row_y, "/ filter  ·  #{filter_fields.map { |f| "#{f}:" }.join("  ")}", Theme.muted, Theme.panel, width: left_w)

--- a/src/gori/tui/text_field.cr
+++ b/src/gori/tui/text_field.cr
@@ -103,17 +103,47 @@ module Gori::Tui
 
     # Draw the value at (x, y) within `width`, painting the block caret + terminal
     # cursor when `focused`. `bg`/`fg` set the base colours (the caret always inverts).
+    #
+    # Focused rendering goes through `Screen#input_line`, which is what draws the IME
+    # PREEDIT (underlined, at the caret) and syncs the hardware cursor the terminal
+    # anchors its own IME UI to. Painting the value with a plain `text` call instead
+    # meant every TextField-based overlay stored composing text and never showed it —
+    # in the import popup a Hangul/CJK name stayed invisible until each syllable
+    # committed. One primitive, so the import / CA-import / fuzzer overlays are all
+    # fixed together.
+    #
+    # The view scrolls horizontally with the caret. Without it the field simply stopped
+    # at `width` (64 columns in the import card) and the caret, the tail of the path and
+    # the cursor sync all vanished past that — on a field whose whole purpose is holding
+    # a long absolute path.
     def render(screen : Screen, x : Int32, y : Int32, width : Int32, focused : Bool,
                fg : Color, bg : Color) : Nil
       return if width <= 0
-      screen.text(x, y, @value, fg, bg, width: width)
-      return unless focused
+      unless focused
+        screen.text(x, y, @value, fg, bg, width: width)
+        return
+      end
+      start = window_start(width)
+      screen.input_line(x, y, @value[start..], @caret.clamp(0, @value.size) - start,
+        @preedit, fg, bg, width: width)
+    end
+
+    # First visible character index: 0 until the caret (plus any preedit, plus the caret
+    # cell itself) would overflow `width`, then far enough right to keep it on screen.
+    # Walks by DISPLAY width so a CJK path scrolls by columns, not by characters.
+    private def window_start(width : Int32) : Int32
       c = @caret.clamp(0, @value.size)
-      cx = x + Screen.display_width(@value[0, c])
-      return if cx >= x + width
-      ch = c < @value.size ? @value[c] : ' '
-      screen.cell(cx, y, ch, Theme.bg, Theme.accent)
-      screen.cursor(cx, y)
+      used = Screen.display_width(@value[0, c]) + Screen.display_width(@preedit) + 1
+      return 0 if used <= width
+      used = Screen.display_width(@preedit) + 1 # the caret cell always stays visible
+      start = c
+      while start > 0
+        w = Screen.display_width(@value[start - 1].to_s)
+        break if used + w > width
+        used += w
+        start -= 1
+      end
+      start
     end
 
     private def push_undo : Nil


### PR DESCRIPTION
Review of everything merged on 2026-07-19 (#255–#260, ~4,300 lines): the unified
Preferences modal, the top/status bar split + import popup, sitemap id folding,
and the shared filter grammar. 13 fixes, one commit each.

Suite: **2,347 examples, 0 failures** (baseline 2,325). Every behavioural fix has
a spec; the three Preferences specs and both TextField specs were verified to
fail without their change.

## Crash

**A non-UTF-8 path segment tore down the TUI** (`04486e1`). `template_class` ran
PCRE2 over raw captured path segments. A target is built with `String.new(Bytes)`,
which does not validate, so a latin-1/EUC-KR or fuzzed path arrives as invalid
UTF-8 — and PCRE2 *raises* rather than returning false. Nothing rescues between
there and the run loop, on the ~1.3/s sitemap poll. New exposure from #259
(sitemap.cr had no regex before it); `Gori::SafeRegexp` already exists for this
exact bug class on the store side.

## Filters that quietly matched the wrong thing

- **An empty group swallowed the rest of an AND chain** (`6ec8241`).
  `host:a () status:200` → `host:a`. Worse than an ordinary dropped term: the
  lexemes never became terms, so `analyze` still answered `clean?` and
  `reject_empty?` never fired — MCP strict mode and the CLI both passed a query
  that had **broadened**.
- **Negation was derived twice and disagreed** (`69786a4`). `"-a"`, quoted to force
  a literal, parsed as negated while being painted plain; `-"` painted an operator
  over a literal dash. Quoting now suppresses `-` exactly as it already did
  AND/OR/NOT, and the highlighter paints from the Term the lexer built.
- **`~` painted as a field operator in bars with no regex support** (`a0638c0`).
  Only QL implements it; Issues/Probe/Intercept/Subtab free-text the token, so
  `title~admin` advertised a match that never happens.
- **Sitemap `tag:` never joined the grammar** (`c75abbc`). It was re-tokenised with
  `String#split`: `NOT tag:done` filed `done` as a POSITIVE and then blanked the
  tree, `tag:"my flow"` tore at the space, `tag:a OR tag:b` tripped "invalid
  filter" on the whole sitemap. Adds `FilterAst.partition` so a backend-local
  field inherits the grammar's quoting and negation.
- **Numeric ids carrying a query never folded** (`7f727ad`). `add` appends the query
  to the last segment, so a paginated list arrived as `1?ref=home` … — inverting
  the feature, since the case that most explodes the tree was the one left
  expanded.

## Things that did nothing, or lied about what they did

- **The picker's `↵ open` footer button was inert** (`61bd177`) — a `case` used as a
  statement discarded `activate`'s result. On the Temp row it created a 0700
  project directory per click and abandoned it.
- **Three Preferences bugs** (`c337383`): `^R` desynced the modal's focus from the
  section's, so the lit row and the edited row differed; `^P` was the one exit
  skipping the unsaved-edit guard; and a *rejected* save returned `:saved`, so the
  host rebound the live proxy for refused input — and rendered the error green.
- **Mouse never reached the hosts/env editors** (`08a24c7`) — `modal_overlay?` omitted
  both, so their click arms were unreachable and clicks fell through to the tab
  bar behind the open card. Also: a Mouse toggle saved from the picker did nothing
  for the rest of the session.
- **TextField dropped its IME preedit** (`011c1cf`) — a regression from the centered
  import card. A Hangul/CJK path was invisible until each syllable committed. The
  same method never scrolled, so past 64 columns the tail, caret and cursor-sync
  all vanished — on the one field built to hold a long path. Fixed in the
  primitive, so import / CA-import / fuzzer all get it.
- **`matches?` claimed to allocate nothing** (`b7e223a`) while re-folding its pattern
  per in-flight message on the proxy hold path. Folding at parse time also fixes
  `status:5XX`, which matched nothing because `status_match?` tests a literal
  lowercase `x`.
- **Stale docs** (`7ae64e0`): Help never listed `Ctrl+,` though the modal became the
  primary settings entry point; and `status_chips` still claimed the resource
  readout is last and fixed-width, contradicting `Resource#format` in the same PR.

## Deliberately not fixed

- Extracted `tag:` terms still AND with the QL residual. `tag:x OR host:a` is not
  expressible while tags filter the tree and QL filters the rows — that is
  architecture, not a review fix. Documented on `partition` rather than
  half-fixed.
- Top-bar overflow drops the pressable `⌘`/`⚙` chips first (needs a chip priority
  scheme), and four copy-pasted tree evaluators / `field:value` splitters with
  three different rules. Both real, both worth their own PR.

## Heads-up, unrelated to this branch

Homebrew replaced Crystal 1.20 with 1.21.0 mid-session. termisu 0.5.0 requires
`crystal/thread_local_value`, which 1.21 removed, so a clean checkout will not
build. I worked around it locally with a shim in the gitignored `lib/` — **nothing
in this branch depends on it and it is not committed.** The fix is upstream in
termisu or a pin back to 1.20.
