### PR TITLE
perf: cut per-flow and per-poll allocation in the testing paths (Probe, Sitemap, Discover, Fuzzer)

### DIFF
--- a/bench/miner_reflect_bench.cr
+++ b/bench/miner_reflect_bench.cr
@@ -39,9 +39,9 @@ INV = begin
   h
 end
 
-# A minimal Replay::Result stand-in via Fingerprint.probe's input shape.
-def make_result : Gori::Replay::Result
-  Gori::Replay::Result.new(HEAD, BODY, nil, 1000_i64)
+# A minimal Repeater::Result stand-in via Fingerprint.probe's input shape.
+def make_result : Gori::Repeater::Result
+  Gori::Repeater::Result.new(HEAD, BODY, nil, 1000_i64)
 end
 
 puts "Miner reflection over a 128-canary bucket, 100KB body (3 reflected):"

--- a/bench/probe_passive_bench.cr
+++ b/bench/probe_passive_bench.cr
@@ -1,0 +1,86 @@
+# Probe passive-scan micro-benchmark: the FULL per-flow cost of `Passive.analyze` (every
+# built-in rule over one captured flow). This is the path the passive fiber runs for every
+# captured flow, sharing a core with the proxy, so its per-flow allocation is what caps
+# capture throughput on a busy browse.
+#
+# Two shapes, both extremely common in real traffic:
+#   * a JSON API POST  — the request-body path (the GraphQL classifier lives here)
+#   * an HTML document — the response-body path (client-side rules, header rules)
+#
+# Build: crystal build bench/probe_passive_bench.cr -o bin/probe_passive_bench --release
+# Run:   bin/probe_passive_bench
+require "benchmark"
+
+module Gori
+  class Error < Exception; end
+end
+
+require "../src/gori/probe/passive"
+
+# A realistic non-GraphQL JSON POST body — an ordinary API payload. The GraphQL classifier
+# has to decide "not GraphQL" for every one of these.
+JSON_BODY = begin
+  io = IO::Memory.new
+  io << %({"filters":{"status":"active","tags":["a","b","c"]},"items":[)
+  400.times do |i|
+    io << "," if i > 0
+    io << %({"id":) << i << %(,"name":"item) << i << %(","qty":) << (i % 50) << %(,"note":"ordinary text value ) << i << "\"}"
+  end
+  io << "]}"
+  io.to_slice.dup
+end
+
+JSON_REQ_HEAD = ("POST /api/v1/search?q=widgets&lang=en&page=2&sort=desc HTTP/1.1\r\n" \
+                 "Host: api.example.com\r\nContent-Type: application/json\r\n" \
+                 "Accept: application/json\r\nOrigin: https://app.example.com\r\n\r\n").to_slice
+
+JSON_RESP_HEAD = ("HTTP/1.1 200 OK\r\nContent-Type: application/json; charset=utf-8\r\n" \
+                  "Server: nginx/1.24.0\r\nCache-Control: max-age=60, public\r\n" \
+                  "Strict-Transport-Security: max-age=31536000\r\n" \
+                  "Set-Cookie: sid=abc123; Path=/; HttpOnly; Secure; SameSite=Lax\r\n\r\n").to_slice
+
+JSON_RESP_BODY = %({"ok":true,"results":[],"total":0}).to_slice
+
+# A modest HTML document with a couple of inline scripts — drives the client-side rules.
+HTML_BODY = begin
+  io = IO::Memory.new
+  io << "<!doctype html><html><head><title>Dashboard</title></head><body>\n"
+  io << %(<div id="root"></div>\n)
+  io << "<script>\n"
+  200.times { |i| io << %(  var item) << i << %( = {id: ) << i << %(, label: "row ) << i << %("};) << "\n" }
+  io << %(  window.addEventListener("load", function () { console.log("ready"); });) << "\n"
+  io << "</script>\n"
+  400.times { |i| io << %(<p class="row">ordinary paragraph text number ) << i << "</p>\n" }
+  io << "</body></html>\n"
+  io.to_slice.dup
+end
+
+HTML_RESP_HEAD = ("HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\n" \
+                  "Server: nginx/1.24.0\r\n" \
+                  "Strict-Transport-Security: max-age=31536000; includeSubDomains\r\n\r\n").to_slice
+
+def flow(method : String, target : String, ct : String?,
+         req_head : Bytes, req_body : Bytes?,
+         resp_head : Bytes, resp_body : Bytes?) : Gori::Store::FlowDetail
+  row = Gori::Store::FlowRow.new(
+    1_i64, 1_i64, "https", method, "app.example.com", 443, target,
+    200, (resp_body.try(&.size) || 0).to_i64, Gori::Store::FlowState::Complete,
+    content_type: ct)
+  Gori::Store::FlowDetail.new(row, "HTTP/1.1", req_head, req_body, resp_head, resp_body)
+end
+
+JSON_FLOW = flow("POST", "/api/v1/search?q=widgets&lang=en&page=2&sort=desc",
+  "application/json; charset=utf-8", JSON_REQ_HEAD, JSON_BODY, JSON_RESP_HEAD, JSON_RESP_BODY)
+
+HTML_FLOW = flow("GET", "/dashboard", "text/html; charset=utf-8",
+  ("GET /dashboard HTTP/1.1\r\nHost: app.example.com\r\n\r\n").to_slice, nil,
+  HTML_RESP_HEAD, HTML_BODY)
+
+puts "Probe passive scan — full Passive.analyze per flow:"
+puts "  JSON POST body: #{JSON_BODY.size} bytes; HTML document: #{HTML_BODY.size} bytes"
+puts "  (detections: json=#{Gori::Probe::Passive.analyze(JSON_FLOW).size} html=#{Gori::Probe::Passive.analyze(HTML_FLOW).size})"
+
+Benchmark.ips do |x|
+  x.report("JSON API POST flow") { Gori::Probe::Passive.analyze(JSON_FLOW) }
+  x.report("HTML document flow") { Gori::Probe::Passive.analyze(HTML_FLOW) }
+end

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -594,7 +594,11 @@ module Gori::Discover
     end
 
     private def decode_body(raw : Repeater::Result) : Bytes
-      decoded, _ = Proxy::Codec::ContentDecode.decode(raw.head, raw.body)
+      # Cap the INFLATE at MAX_BODY, not just the result. Without the cap ContentDecode expands a
+      # compressed response up to its 32 MB anti-bomb ceiling and we then throw away everything
+      # past 2 MB on the next line — so a highly-compressible response allocated and inflated up
+      # to 30 MB per request, on a path multiplied by the whole wordlist.
+      decoded, _ = Proxy::Codec::ContentDecode.decode(raw.head, raw.body, MAX_BODY)
       body = decoded || raw.body || Bytes.new(0)
       body.size > MAX_BODY ? body[0, MAX_BODY] : body
     end

--- a/src/gori/fuzz/matcher.cr
+++ b/src/gori/fuzz/matcher.cr
@@ -129,8 +129,11 @@ module Gori::Fuzz
         num_pass?(@match_size_c, length, default: true) &&
         num_pass?(@match_words_c, words.to_i64, default: true) &&
         num_pass?(@match_lines_c, lines.to_i64, default: true) &&
-        regex_pass?(@match_regex, text, default: true) &&
-        header_pass?(raw)
+        # header_pass? (an allocation-free byte scan over the short head) before regex_pass?
+        # (a PCRE match over the whole body): both are pure predicates, so `&&` short-circuits
+        # identically either way, but this order lets a failing --mh skip the body match.
+        header_pass?(raw) &&
+        regex_pass?(@match_regex, text, default: true)
     end
 
     # Any filter dimension that passes removes the result.

--- a/src/gori/probe/analyzer.cr
+++ b/src/gori/probe/analyzer.cr
@@ -490,6 +490,10 @@ module Gori
       end
 
       private def suppressed?(code : String, host : String) : Bool
+        # Called per Detection (a typical flow yields 8-15), so build the composite key only when
+        # there is something to look it up in. The set is empty unless the operator hard-deleted
+        # an issue this session, i.e. empty on the overwhelmingly common path.
+        return false if @suppressed.empty?
         @suppressed.includes?("#{code}|#{host}")
       end
 

--- a/src/gori/probe/passive/cacheable_api.cr
+++ b/src/gori/probe/passive/cacheable_api.cr
@@ -69,19 +69,22 @@ module Gori
             return nil if expires_disables?(expires) && pragma_no_cache?(pragma)
             return "missing Cache-Control"
           end
-          low = cc.downcase
-          return "Cache-Control: public" if directive?(low, "public")
-          if (n = directive_int(low, "s-maxage")) && n > 0
+          # Split the header into stripped directive tokens ONCE. directive?/directive_int each
+          # used to re-split the whole value, and this method calls them up to six times (max-age
+          # twice), so a cacheable JSON response re-split the same string six times over.
+          parts = cc.downcase.split(',').map!(&.strip)
+          return "Cache-Control: public" if directive?(parts, "public")
+          if (n = directive_int(parts, "s-maxage")) && n > 0
             return "s-maxage=#{n}"
           end
-          if (n = directive_int(low, "max-age")) && n > 0
+          max_age = directive_int(parts, "max-age")
+          if (n = max_age) && n > 0
             return "max-age=#{n}"
           end
           # private/no-cache alone still lets a browser keep a copy (must revalidate at
           # best). For JSON APIs we want no-store; flag when neither no-cache nor max-age=0
           # is present either — pure `private` or empty directives.
-          if directive?(low, "private") && !directive?(low, "no-cache") &&
-             !(directive_int(low, "max-age") == 0)
+          if directive?(parts, "private") && !directive?(parts, "no-cache") && max_age != 0
             return "private without no-store/no-cache"
           end
           nil
@@ -103,13 +106,13 @@ module Gori
         end
 
         # Token present as a full Cache-Control directive (not a substring of another word).
-        private def directive?(low : String, name : String) : Bool
-          low.split(',').any? { |part| part.strip.split('=').first?.try(&.strip) == name }
+        # `parts` are the already-stripped, already-downcased directive tokens.
+        private def directive?(parts : Array(String), name : String) : Bool
+          parts.any? { |part| part.split('=').first?.try(&.strip) == name }
         end
 
-        private def directive_int(low : String, name : String) : Int64?
-          low.split(',').each do |part|
-            p = part.strip
+        private def directive_int(parts : Array(String), name : String) : Int64?
+          parts.each do |p|
             next unless p.starts_with?("#{name}=") || p.starts_with?("#{name} =")
             eq = p.index('=')
             next unless eq

--- a/src/gori/probe/passive/context.cr
+++ b/src/gori/probe/passive/context.cr
@@ -32,6 +32,10 @@ module Gori
         @client_scripts : Array(String)?
         @client_scripts_nocomment : Array(String)?
         @client_code : Array(String)?
+        @ct_low : String?
+        @ct_low_done = false
+        @html : Bool?
+        @js : Bool?
 
         def initialize(@detail : Store::FlowDetail, @ws_messages = [] of Store::WsMessage)
         end
@@ -73,17 +77,31 @@ module Gori
           row.content_type
         end
 
+        # The response Content-Type, downcased ONCE per flow. html?/js? are each called from
+        # several rules plus the body getters (~12 calls per flow between them), and every call
+        # used to allocate its own throwaway downcased copy of the same header value. Rules that
+        # need to run their own substring tests should read this rather than downcase again.
+        def ct_low : String?
+          return @ct_low if @ct_low_done
+          @ct_low_done = true
+          @ct_low = content_type.try(&.downcase)
+        end
+
+        # Memoised: the answer cannot change for a given flow, and both getters sit on the
+        # per-flow path that the passive fiber shares with the proxy.
         def html? : Bool
-          !!content_type.try(&.downcase.includes?("text/html"))
+          h = @html
+          return h unless h.nil?
+          @html = !!ct_low.try(&.includes?("text/html"))
         end
 
         # A JavaScript response (external bundle / module), distinct from an HTML document with
         # inline scripts. Used to gate the client-side rules alongside html?.
         def js? : Bool
-          ct = content_type
-          return false if ct.nil?
-          low = ct.downcase
-          low.includes?("javascript") || low.includes?("ecmascript")
+          j = @js
+          return j unless j.nil?
+          low = ct_low
+          @js = low.nil? ? false : (low.includes?("javascript") || low.includes?("ecmascript"))
         end
 
         def request_origin : String?

--- a/src/gori/probe/passive/secret_in_url.cr
+++ b/src/gori/probe/passive/secret_in_url.cr
@@ -42,9 +42,13 @@ module Gori
             return emit(acc, ctx, hit[0], Store::Severity::High)
           end
           # Otherwise rank by the name tier (High > Medium > Low); the highest present wins.
+          # Normalize each name ONCE up front: the tier loop used to re-normalize every param
+          # for every tier, so a URL with no sensitive name (the common case) ran `normalize` —
+          # a decode + downcase + character strip — three times per parameter.
+          norms = pairs.map { |(n, _)| normalize(n) }
           TIERS.each do |(sev, names)|
-            if hit = pairs.find { |(n, _)| names.includes?(normalize(n)) }
-              return emit(acc, ctx, hit[0], sev)
+            if idx = norms.index { |nm| names.includes?(nm) }
+              return emit(acc, ctx, pairs[idx][0], sev)
             end
           end
         end
@@ -55,8 +59,10 @@ module Gori
         end
 
         # Lowercase + strip '-'/'_' so hyphen/underscore/case variants collapse to one form.
+        # `delete` takes a char SET and is exactly equivalent to the old `gsub(/[-_]/, "")`,
+        # without spinning up a PCRE match per parameter name.
         private def normalize(name : String) : String
-          decode(name).downcase.gsub(/[-_]/, "")
+          decode(name).downcase.delete("-_")
         end
 
         private def display_name(name : String) : String

--- a/src/gori/probe/passive/security_headers.cr
+++ b/src/gori/probe/passive/security_headers.cr
@@ -29,11 +29,15 @@ module Gori
           return unless resp = ctx.response
           if ctx.scheme == "https"
             hsts = resp.headers.get_all("Strict-Transport-Security").first? # RFC 6797 §8.1: UA honours the FIRST STS header
-            if hsts.nil? || hsts_disabled?(hsts)
+            # Parse max-age ONCE and branch on the Int64? — the disabled/short/evidence path used
+            # to call hsts_max_age up to three times for the same value, and each call scrubs,
+            # downcases, and runs a PCRE match. Every HTTPS response with HSTS reaches this.
+            age = hsts.try { |v| hsts_max_age(v) }
+            if hsts.nil? || age.nil? || age == 0
               acc << hdr(ctx, "missing_hsts", "Missing or disabled HSTS header", Store::Severity::Medium)
-            elsif short_hsts?(hsts)
+            elsif age < SHORT_HSTS_MAX_AGE
               acc << hdr(ctx, "short_hsts", "HSTS max-age is under 1 day", Store::Severity::Low,
-                "max-age=#{hsts_max_age(hsts)}")
+                "max-age=#{age}")
             end
           end
           check_doc_headers(ctx, resp.headers, acc) if ctx.html? && rendered_document?(resp.status)
@@ -50,17 +54,8 @@ module Gori
         end
 
         # HSTS with no max-age, or max-age=0 (RFC 6797: instructs the UA to DROP the policy), is
-        # effectively disabled even though the header is present.
-        private def hsts_disabled?(value : String) : Bool
-          age = hsts_max_age(value)
-          age.nil? || age == 0
-        end
-
-        private def short_hsts?(value : String) : Bool
-          age = hsts_max_age(value)
-          !age.nil? && age > 0 && age < SHORT_HSTS_MAX_AGE
-        end
-
+        # effectively disabled even though the header is present — `check` treats a nil/0 age as
+        # disabled and anything under SHORT_HSTS_MAX_AGE as short, off this single parse.
         private def hsts_max_age(value : String) : Int64?
           m = value.scrub.downcase.match(/max-age\s*=\s*"?(\d+)/) # scrub: a non-UTF-8 byte makes the PCRE match raise (cf. cors.cr)
           return nil if m.nil?

--- a/src/gori/probe/passive/tech.cr
+++ b/src/gori/probe/passive/tech.cr
@@ -1,5 +1,6 @@
 require "json"
 require "./rule"
+require "../../ascii_bytes"
 require "../../proxy/h2/grpc"
 require "../../sse"
 
@@ -10,6 +11,13 @@ module Gori
       # project's "representative technologies" summary. Runs on every flow (not response-gated):
       # several signals live on the request side or on a 101 upgrade.
       class Tech < Rule
+        # Lowercase needles for the allocation-free byte gates in graphql? (AsciiBytes.contains_ci?
+        # requires an already-lowercase needle). Held as constants so the slices are built once
+        # for the process, not per flow.
+        private GRAPHQL_PATH = "/graphql".to_slice
+        private JSON_CT      = "json".to_slice
+        private QUERY_KEY    = %("query").to_slice
+
         def info : RuleInfo
           RuleInfo.new("tech", "Technology fingerprints",
             "Identifies server software, frameworks, and protocols (WebSocket, gRPC, GraphQL, SSE, HTTP/2) from headers and bodies.",
@@ -42,7 +50,11 @@ module Gori
             acc << tech(ctx, "tech_grpc", "gRPC service")
           end
           acc << tech(ctx, "tech_graphql", "GraphQL endpoint") if graphql?(ctx, req_ct)
-          acc << tech(ctx, "tech_sse", "Server-Sent Events stream") if Sse.event_stream?(detail.response_head)
+          # `resp_ct` is the response Content-Type the capture already parsed out of the head
+          # (the same value grpc? consumes above), so ask Sse directly instead of re-parsing the
+          # raw head bytes: event_stream? would copy the whole head to a String and split it into
+          # per-header Strings on EVERY flow just to read a header we are already holding.
+          acc << tech(ctx, "tech_sse", "Server-Sent Events stream") if Sse.sse?(resp_ct)
           if detail.http_version.starts_with?("HTTP/2") || !detail.h2_conn_id.nil?
             acc << tech(ctx, "tech_http2", "HTTP/2")
           end
@@ -101,18 +113,30 @@ module Gori
         # STRING holding a GraphQL document. Requiring a string value keeps Elasticsearch /
         # OpenSearch query DSL bodies (where `query` is an OBJECT) out of the match.
         private def graphql?(ctx : Context, req_ct : String?) : Bool
-          return true if ctx.req.target.downcase.includes?("/graphql")
-          return false unless req_ct.try(&.downcase.includes?("json"))
+          # Byte scans over the borrowed slices (String#to_slice is a view): the target can carry
+          # a multi-KB query string, and downcasing it — plus the Content-Type — allocated a full
+          # copy of each on every flow just to run two case-insensitive substring tests.
+          return true if AsciiBytes.contains_ci?(ctx.req.target.to_slice, GRAPHQL_PATH)
+          return false unless req_ct && AsciiBytes.contains_ci?(req_ct.to_slice, JSON_CT)
           body = ctx.detail.request_body
           return false unless body
           # 8 KB truncated mid-JSON on real GraphQL requests (a sizeable `variables` object),
           # which then fails JSON.parse and mis-classified them as non-GraphQL; allow up to 256 KB.
-          text = String.new(body[0, {body.size, 256 * 1024}.min]).scrub
+          capped = body[0, {body.size, 256 * 1024}.min]
           # A GraphQL request body always carries a top-level `"query"` key; a cheap substring
           # check lets the overwhelming majority of non-GraphQL JSON POSTs skip the full
           # JSON.parse (a tree build over ≤256 KB) on the shared passive-scan fiber. Conservative:
           # a `"query"` appearing only inside a value still parses, then the as_h?/as_s? guards reject.
-          return false unless text.includes?(%("query"))
+          #
+          # Scan the RAW BYTES, before materialising `text`. The gate was already here, but it ran
+          # against a String that had just been copied+scrubbed out of those same ≤256 KB — so an
+          # ordinary JSON API POST still paid a full-body copy and a UTF-8 validation pass to be
+          # told "not GraphQL". Gating first makes the common case allocation-free. Byte-scanning
+          # is case-insensitive where `includes?` was exact, which only ever opens the gate wider
+          # (scrub cannot create or destroy an ASCII `"query"`), and the as_h?/as_s? guards below
+          # still decide the outcome — so no detection is lost.
+          return false unless AsciiBytes.contains_ci?(capped, QUERY_KEY)
+          text = String.new(capped).scrub
           q = begin
             JSON.parse(text).as_h?.try(&.["query"]?).try(&.as_s?)
           rescue JSON::ParseException

--- a/src/gori/sitemap.cr
+++ b/src/gori/sitemap.cr
@@ -305,10 +305,18 @@ module Gori
       # its own children (without this, a {hex} fold of long numerics grows a nested
       # [1000… +N] inside it, and a second call nests one more level).
       return if node.grouped
-      numeric = node.children.select { |c| !c.grouped && numeric_label?(c.label) }
-      return if numeric.size <= SEQUENCE_GROUP_THRESHOLD
+      # Count first, materialise second. The overwhelming majority of nodes have no numeric
+      # children at all, and `select` used to allocate the result Array for every one of them
+      # before the threshold check below could reject it — on a tree rebuilt each poll frame.
+      count = 0
+      node.children.each { |c| count += 1 if !c.grouped && numeric_label?(c.label) }
+      return if count <= SEQUENCE_GROUP_THRESHOLD
+      numeric = Array(Node).new(count)
+      rest = Array(Node).new(node.children.size - count)
+      node.children.each do |c|
+        (!c.grouped && numeric_label?(c.label)) ? (numeric << c) : (rest << c)
+      end
       numeric.sort_by! { |c| p = path_part(c.label); {p.size, p} }
-      rest = node.children.select { |c| c.grouped || !numeric_label?(c.label) }
       group = Node.new(group_label(numeric))
       group.grouped = true
       group.expanded = false
@@ -330,7 +338,14 @@ module Gori
 
     def self.numeric_label?(label : String) : Bool
       s = path_part(label)
-      !s.empty? && s.each_char.all?(&.ascii_number?)
+      return false if s.empty?
+      # Byte loop rather than `each_char.all?`: the block-less each_char returns a CharIterator,
+      # which is a CLASS, so that form heap-allocated an iterator per call — and this runs a few
+      # times per node on a tree that is rebuilt from scratch on every sitemap poll. ASCII digits
+      # are single-byte, and any multi-byte char has all bytes >= 0x80, so a byte test rejects
+      # non-digits exactly as the char test did.
+      s.each_byte { |b| return false unless 0x30_u8 <= b <= 0x39_u8 }
+      true
     end
 
     # "[1, 2, 3 … +47]" — the first three values then a remainder count.


### PR DESCRIPTION
Audit of the testing-purpose subsystems (Fuzzer, Probe, Miner, Sequencer, Discover, Sitemap) for hot-path waste, then fixes for what benched as a real win.

The wins concentrate in two places:

- the **Probe passive scan**, which runs per captured flow on the fiber sharing a core with the proxy
- the **Sitemap tree**, rebuilt from scratch on the ~750ms UI poll

## Measured

`bench/probe_passive_bench.cr` (new) — full `Passive.analyze` per flow:

| flow | before | after | |
|---|---|---|---|
| JSON API POST | 291 µs / 61.7 kB per op | **173 µs / 33.9 kB** | 1.69× faster, 45% less alloc |
| HTML document | 1.06 ms / 158 kB | 1.04 ms / 157 kB | ~unchanged (see below) |

`bench/sitemap_bench.cr`, 10k endpoints:

| | before | after |
|---|---|---|
| `group_sequences!` | 3.37 ms / 11.3 MB | **2.53 ms / 9.43 MB** |
| `fold_templates!` | 3.59 ms / 10.9 MB | **2.92 ms / 10.0 MB** |

Detection output is byte-identical (the bench asserts the same detection counts).

## Probe passive scan

- **`tech.cr` `graphql?`** — the `"query"` pre-gate was already there, but it ran against a String that had just been copied and scrubbed out of the same ≤256 KB. So every ordinary JSON POST still paid a full-body copy plus a UTF-8 validation pass just to be told "not GraphQL". Gate on the raw bytes first. Also byte-scans the request target and Content-Type rather than downcasing copies of them.
- **`tech.cr`** — ask `Sse.sse?` with the Content-Type the capture already parsed, instead of `Sse.event_stream?` re-copying and re-splitting the whole response head on every flow.
- **`context.cr`** — memoise the downcased Content-Type. `html?`/`js?` are called ~12 times per flow between the rules and the body getters, and each call allocated its own throwaway copy.
- **`security_headers.cr`** — parse HSTS `max-age` once rather than up to 3 times; each call scrubs, downcases and runs a PCRE match.
- **`cacheable_api.cr`** — split `Cache-Control` into directive tokens once instead of re-splitting on each of up to 6 `directive?`/`directive_int` calls.
- **`secret_in_url.cr`** — normalise each param name once instead of once per tier; `delete("-_")` in place of an equivalent PCRE `gsub`.
- **`analyzer.cr`** — skip building the `"code|host"` key per detection when the suppression set is empty (the common case).

## Sitemap

- **`numeric_label?`** — byte loop instead of `each_char.all?`. The block-less `each_char` returns a `CharIterator`, which is a *class*, so it heap-allocated per call, a few times per node per poll.
- **`group_sequences!`** — count numeric children before materialising them, so the majority of nodes that have none stop allocating an Array only to discard it.

## Discover

- **`decode_body`** — cap the inflate at `MAX_BODY`. It was inflating a compressed response up to the 32 MB anti-bomb ceiling and then discarding everything past 2 MB, on a path multiplied by the whole wordlist.

## Fuzzer

- **`matcher.cr`** — order `header_pass?` (allocation-free byte scan over the short head) before `regex_pass?` (PCRE over the whole body), so a failing `--mh` short-circuits the body match. Both are pure predicates, so results are unchanged.

## Benches

- new `bench/probe_passive_bench.cr` driving the full per-flow `Passive.analyze`.
- `bench/miner_reflect_bench.cr` referenced `Gori::Replay::Result` and had not compiled since the `Replay` → `Repeater` rename. Fixed. It confirms the previously-deferred Miner "reflection O(K×body)" issue is already solved (single byte-scan into a Set, 51 µs / 240 B per 128-canary bucket over a 100 KB body).

## Not taken

Gating `ContentLength.sync` on a head scan for `content-length` sped the no-CL GET path 398 ns → 336 ns but cost the CL-present POST path 850 ns → 1.05 µs, since the scan is pure added work whenever the header is present. Benched, judged a wash, reverted rather than shipped.

## Biggest remaining item (not in this PR)

`Probe::Passive::JsScan.strip` / `strip_comments` call `js.chars`, materialising an `Array(Char)` of the whole script — up to 256 KB → ~1 MiB, twice per document flow. That is why the HTML row above barely moved: document flows cost 6× a JSON flow and allocate 157 kB. Fixing it means moving the lexers to bytes, which trades the currently-documented *char*-offset-preserving invariant for a *byte*-offset one, so it wants its own PR with the offset consumers (`source_in_window`, the DOM-XSS source→sink correlation) checked carefully. An ASCII fast path would be exactly equivalent and is probably the safe form.

## Test

Full suite: **2347 examples, 0 failures**.

> Note: `crystal tool format` reports pre-existing alignment drift in `analyzer.cr`, `discover/engine.cr` and `miner_reflect_bench.cr` — present at HEAD, unrelated to these edits, and left alone to avoid tree churn. `ameba` could not be run: its postinstall fails to build under Crystal 1.21 (`next_string_array_token` undefined).