### PR TITLE
perf(probe): lex all-ASCII scripts without building an Array(Char)

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -6,3 +6,26 @@ Naming/BlockParameterName:
 
 Metrics/CyclomaticComplexity:
   MaxComplexity: 12
+
+# --- rules introduced by ameba 1.7 -------------------------------------------
+# These fired ~1240 times the moment we moved off 1.6.4, none of it new debt.
+# Everything they flag predates the bump; the rest of 1.7's new rules are left on.
+
+# `.not_nil!` is how a spec asserts a value is present — 508 of the 548 uses in
+# the tree are under spec/. Still linted in src/, where it is a real smell.
+Lint/NotNil:
+  Excluded:
+    - spec/**/*.cr
+Lint/NotNilAfterNoBang:
+  Excluded:
+    - spec/**/*.cr
+
+# `return nil if ...` is deliberate: the explicit nil documents at the call site
+# that the method returns T?. ~509 sites, no behavioural content in changing them.
+Style/RedundantNilInControlExpression:
+  Enabled: false
+
+# Duplicate signal — `just check` already runs `crystal tool format --check`, and
+# this rule reports the same files a second time.
+Lint/Formatting:
+  Enabled: false

--- a/bench/conc_diag.cr
+++ b/bench/conc_diag.cr
@@ -5,6 +5,11 @@ require "socket"
 
 module Gori
   class Error < Exception; end
+
+  # client_conn stamps this into the CONNECT-failure page; the real value lives in
+  # src/gori.cr, which these benches deliberately do not require (they pull only the
+  # proxy, not the whole app).
+  VERSION = "0.0.0-bench"
 end
 
 require "../src/gori/proxy/server"

--- a/bench/jwt_bench.cr
+++ b/bench/jwt_bench.cr
@@ -6,7 +6,8 @@ require "benchmark"
 module Gori
   class Error < Exception; end
 end
-require "../src/gori/convert/converter"
+
+require "../src/gori/decoder/converter"
 require "../src/gori/jwt"
 
 # A 200KB JSON response body with NO JWT (the dominant shape).

--- a/bench/miner_reflect_bench.cr
+++ b/bench/miner_reflect_bench.cr
@@ -39,9 +39,9 @@ INV = begin
   h
 end
 
-# A minimal Replay::Result stand-in via Fingerprint.probe's input shape.
-def make_result : Gori::Replay::Result
-  Gori::Replay::Result.new(HEAD, BODY, nil, 1000_i64)
+# A minimal Repeater::Result stand-in via Fingerprint.probe's input shape.
+def make_result : Gori::Repeater::Result
+  Gori::Repeater::Result.new(HEAD, BODY, nil, 1000_i64)
 end
 
 puts "Miner reflection over a 128-canary bucket, 100KB body (3 reflected):"

--- a/bench/probe_passive_bench.cr
+++ b/bench/probe_passive_bench.cr
@@ -1,0 +1,86 @@
+# Probe passive-scan micro-benchmark: the FULL per-flow cost of `Passive.analyze` (every
+# built-in rule over one captured flow). This is the path the passive fiber runs for every
+# captured flow, sharing a core with the proxy, so its per-flow allocation is what caps
+# capture throughput on a busy browse.
+#
+# Two shapes, both extremely common in real traffic:
+#   * a JSON API POST  — the request-body path (the GraphQL classifier lives here)
+#   * an HTML document — the response-body path (client-side rules, header rules)
+#
+# Build: crystal build bench/probe_passive_bench.cr -o bin/probe_passive_bench --release
+# Run:   bin/probe_passive_bench
+require "benchmark"
+
+module Gori
+  class Error < Exception; end
+end
+
+require "../src/gori/probe/passive"
+
+# A realistic non-GraphQL JSON POST body — an ordinary API payload. The GraphQL classifier
+# has to decide "not GraphQL" for every one of these.
+JSON_BODY = begin
+  io = IO::Memory.new
+  io << %({"filters":{"status":"active","tags":["a","b","c"]},"items":[)
+  400.times do |i|
+    io << "," if i > 0
+    io << %({"id":) << i << %(,"name":"item) << i << %(","qty":) << (i % 50) << %(,"note":"ordinary text value ) << i << "\"}"
+  end
+  io << "]}"
+  io.to_slice.dup
+end
+
+JSON_REQ_HEAD = ("POST /api/v1/search?q=widgets&lang=en&page=2&sort=desc HTTP/1.1\r\n" \
+                 "Host: api.example.com\r\nContent-Type: application/json\r\n" \
+                 "Accept: application/json\r\nOrigin: https://app.example.com\r\n\r\n").to_slice
+
+JSON_RESP_HEAD = ("HTTP/1.1 200 OK\r\nContent-Type: application/json; charset=utf-8\r\n" \
+                  "Server: nginx/1.24.0\r\nCache-Control: max-age=60, public\r\n" \
+                  "Strict-Transport-Security: max-age=31536000\r\n" \
+                  "Set-Cookie: sid=abc123; Path=/; HttpOnly; Secure; SameSite=Lax\r\n\r\n").to_slice
+
+JSON_RESP_BODY = %({"ok":true,"results":[],"total":0}).to_slice
+
+# A modest HTML document with a couple of inline scripts — drives the client-side rules.
+HTML_BODY = begin
+  io = IO::Memory.new
+  io << "<!doctype html><html><head><title>Dashboard</title></head><body>\n"
+  io << %(<div id="root"></div>\n)
+  io << "<script>\n"
+  200.times { |i| io << %(  var item) << i << %( = {id: ) << i << %(, label: "row ) << i << %("};) << "\n" }
+  io << %(  window.addEventListener("load", function () { console.log("ready"); });) << "\n"
+  io << "</script>\n"
+  400.times { |i| io << %(<p class="row">ordinary paragraph text number ) << i << "</p>\n" }
+  io << "</body></html>\n"
+  io.to_slice.dup
+end
+
+HTML_RESP_HEAD = ("HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\n" \
+                  "Server: nginx/1.24.0\r\n" \
+                  "Strict-Transport-Security: max-age=31536000; includeSubDomains\r\n\r\n").to_slice
+
+def flow(method : String, target : String, ct : String?,
+         req_head : Bytes, req_body : Bytes?,
+         resp_head : Bytes, resp_body : Bytes?) : Gori::Store::FlowDetail
+  row = Gori::Store::FlowRow.new(
+    1_i64, 1_i64, "https", method, "app.example.com", 443, target,
+    200, (resp_body.try(&.size) || 0).to_i64, Gori::Store::FlowState::Complete,
+    content_type: ct)
+  Gori::Store::FlowDetail.new(row, "HTTP/1.1", req_head, req_body, resp_head, resp_body)
+end
+
+JSON_FLOW = flow("POST", "/api/v1/search?q=widgets&lang=en&page=2&sort=desc",
+  "application/json; charset=utf-8", JSON_REQ_HEAD, JSON_BODY, JSON_RESP_HEAD, JSON_RESP_BODY)
+
+HTML_FLOW = flow("GET", "/dashboard", "text/html; charset=utf-8",
+  ("GET /dashboard HTTP/1.1\r\nHost: app.example.com\r\n\r\n").to_slice, nil,
+  HTML_RESP_HEAD, HTML_BODY)
+
+puts "Probe passive scan — full Passive.analyze per flow:"
+puts "  JSON POST body: #{JSON_BODY.size} bytes; HTML document: #{HTML_BODY.size} bytes"
+puts "  (detections: json=#{Gori::Probe::Passive.analyze(JSON_FLOW).size} html=#{Gori::Probe::Passive.analyze(HTML_FLOW).size})"
+
+Benchmark.ips do |x|
+  x.report("JSON API POST flow") { Gori::Probe::Passive.analyze(JSON_FLOW) }
+  x.report("HTML document flow") { Gori::Probe::Passive.analyze(HTML_FLOW) }
+end

--- a/bench/probe_passive_bench.cr
+++ b/bench/probe_passive_bench.cr
@@ -76,11 +76,35 @@ HTML_FLOW = flow("GET", "/dashboard", "text/html; charset=utf-8",
   ("GET /dashboard HTTP/1.1\r\nHost: app.example.com\r\n\r\n").to_slice, nil,
   HTML_RESP_HEAD, HTML_BODY)
 
+# A minified-bundle-shaped JS response at the Context::CLIENT_BODY_CAP ceiling (256 KiB). This
+# is the worst case for the client-side rules: `client_scripts` is the WHOLE body, and both
+# strip (client_code) and strip_comments (client_scripts_nocomment) lex all of it.
+JS_BODY = begin
+  io = IO::Memory.new
+  i = 0
+  while io.bytesize < 256 * 1024
+    io << "function f" << i << "(a,b){var c=\"str" << i << "\",d=/*x*/a+b;return c+d};"
+    i += 1
+  end
+  io.to_slice.dup
+end
+
+JS_RESP_HEAD = ("HTTP/1.1 200 OK\r\nContent-Type: application/javascript\r\n" \
+                "Server: nginx/1.24.0\r\nCache-Control: max-age=31536000\r\n\r\n").to_slice
+
+JS_FLOW = flow("GET", "/static/app.min.js", "application/javascript",
+  ("GET /static/app.min.js HTTP/1.1\r\nHost: app.example.com\r\n\r\n").to_slice, nil,
+  JS_RESP_HEAD, JS_BODY)
+
 puts "Probe passive scan — full Passive.analyze per flow:"
 puts "  JSON POST body: #{JSON_BODY.size} bytes; HTML document: #{HTML_BODY.size} bytes"
-puts "  (detections: json=#{Gori::Probe::Passive.analyze(JSON_FLOW).size} html=#{Gori::Probe::Passive.analyze(HTML_FLOW).size})"
+puts "  JS bundle: #{JS_BODY.size} bytes (at the CLIENT_BODY_CAP ceiling)"
+puts "  (detections: json=#{Gori::Probe::Passive.analyze(JSON_FLOW).size}" \
+     " html=#{Gori::Probe::Passive.analyze(HTML_FLOW).size}" \
+     " js=#{Gori::Probe::Passive.analyze(JS_FLOW).size})"
 
 Benchmark.ips do |x|
   x.report("JSON API POST flow") { Gori::Probe::Passive.analyze(JSON_FLOW) }
   x.report("HTML document flow") { Gori::Probe::Passive.analyze(HTML_FLOW) }
+  x.report("JS bundle flow    ") { Gori::Probe::Passive.analyze(JS_FLOW) }
 end

--- a/bench/proxy_bench.cr
+++ b/bench/proxy_bench.cr
@@ -12,6 +12,11 @@ require "socket"
 
 module Gori
   class Error < Exception; end
+
+  # client_conn stamps this into the CONNECT-failure page; the real value lives in
+  # src/gori.cr, which these benches deliberately do not require (they pull only the
+  # proxy, not the whole app).
+  VERSION = "0.0.0-bench"
 end
 
 require "../src/gori/proxy/server"

--- a/shard.lock
+++ b/shard.lock
@@ -13,6 +13,6 @@ shards:
     version: 0.23.0
 
   termisu:
-    git: https://github.com/omarluq/termisu.git
-    version: 0.5.0
+    git: https://github.com/hahwul/termisu.git
+    version: 0.5.1+git.commit.825b6f37fd550807120499334b50a3a5367b248f
 

--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 1.6.4
+    version: 1.7.0-dev+git.commit.fcbd5703c50b47a5f280a11ab1c3416f5f3a9ea9
 
   db:
     git: https://github.com/crystal-lang/crystal-db.git

--- a/shard.yml
+++ b/shard.yml
@@ -20,11 +20,17 @@ license: Apache-2.0
 
 dependencies:
   termisu:
-    github: omarluq/termisu
-    version: ~> 0.5
-    # Back on upstream: the input/preedit fixes we forked for (double-English +
-    # jamo-separation: protocol_active dup-guard + Preedit for key=0 text events)
-    # are merged upstream as of v0.5.0.
+    github: hahwul/termisu
+    branch: main
+    # Temporarily on the fork again. Upstream 0.5.0/0.5.1 still `require`s
+    # `crystal/thread_local_value`, which Crystal 1.21 removed from the stdlib, so
+    # upstream does not compile on 1.21 at all. The fork carries only that fix
+    # (thread-keyed Hash in Termisu::FFI::ErrorState, no API change); it is queued
+    # for upstream. Go back to `omarluq/termisu` once it lands in a release.
+    #
+    # The earlier fork — input/preedit (double-English + jamo-separation:
+    # protocol_active dup-guard + Preedit for key=0 text events) — is upstream as of
+    # v0.5.0 and is included here via the fork's synced main.
 
   db:
     github: crystal-lang/crystal-db

--- a/shard.yml
+++ b/shard.yml
@@ -42,3 +42,8 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
+    branch: master
+    # master (1.7.0-dev) rather than the 1.6.4 release: 1.6.4's postinstall does not
+    # compile under Crystal 1.21 (`next_string_array_token` undefined for
+    # Crystal::Lexer), and that failure aborts `shards build` for the whole project.
+    # Move back to a version constraint once 1.7.0 is released.

--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -2312,3 +2312,48 @@ describe "Gori::Probe::Active::BackslashPowered" do
     end
   end
 end
+
+# JsScan lexes an all-ASCII script through a zero-allocation AsciiChars view and anything else
+# through String#chars. The two must stay byte-identical — the fast path is an optimisation, not
+# a behaviour change, and a silent divergence here is a missed finding, not a crash.
+describe "Gori::Probe::Passive::JsScan (ASCII fast path)" do
+  samples = [
+    %(var a = "hello"; // comment here\nfoo.innerHTML = location.hash;),
+    %(/* block\n comment */ eval("x" + location.search);),
+    %(const t = `pre ${location.hash} post`; el.innerHTML = t;),
+    %(s = 'it\\'s escaped'; u = "http://x/y//z"; document.write(u);),
+    %(a = `outer ${ `inner ${x}` } end`;),
+    %(o = {"__proto__": 1}; window.addEventListener("message", function(e){ el.innerHTML = e.data; });),
+    %(x = 1 / 2; y = a // trailing\n + b;),
+    %(`unterminated template),
+    %("unterminated string),
+    %(/* unterminated block),
+  ]
+
+  it "produces identical output on both paths" do
+    samples.each do |src|
+      src.ascii_only?.should be_true # these drive the fast path
+
+      # Appending a non-ASCII char forces the chars path; compare the shared prefix.
+      forced_strip = Gori::Probe::Passive::JsScan.strip(src + "é")
+      forced_comments = Gori::Probe::Passive::JsScan.strip_comments(src + "é")
+
+      Gori::Probe::Passive::JsScan.strip(src).should eq(forced_strip[0, src.size])
+      Gori::Probe::Passive::JsScan.strip_comments(src).should eq(forced_comments[0, src.size])
+    end
+  end
+
+  it "preserves char count on both paths" do
+    (samples + ["日本語 = \"文字列\"; // コメント\nel.innerHTML = location.hash;"]).each do |src|
+      Gori::Probe::Passive::JsScan.strip(src).size.should eq(src.size)
+      Gori::Probe::Passive::JsScan.strip_comments(src).size.should eq(src.size)
+    end
+  end
+
+  it "still correlates source to sink, and still ignores commented-out code" do
+    code = Gori::Probe::Passive::JsScan.strip(
+      "el.innerHTML = location.hash;\n// el.innerHTML = document.cookie;\n")
+    Gori::Probe::Passive::JsScan.source_sink_pairs(code)
+      .should eq([{"location.hash", "innerHTML"}])
+  end
+end

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -594,7 +594,11 @@ module Gori::Discover
     end
 
     private def decode_body(raw : Repeater::Result) : Bytes
-      decoded, _ = Proxy::Codec::ContentDecode.decode(raw.head, raw.body)
+      # Cap the INFLATE at MAX_BODY, not just the result. Without the cap ContentDecode expands a
+      # compressed response up to its 32 MB anti-bomb ceiling and we then throw away everything
+      # past 2 MB on the next line — so a highly-compressible response allocated and inflated up
+      # to 30 MB per request, on a path multiplied by the whole wordlist.
+      decoded, _ = Proxy::Codec::ContentDecode.decode(raw.head, raw.body, MAX_BODY)
       body = decoded || raw.body || Bytes.new(0)
       body.size > MAX_BODY ? body[0, MAX_BODY] : body
     end

--- a/src/gori/fuzz/matcher.cr
+++ b/src/gori/fuzz/matcher.cr
@@ -129,8 +129,11 @@ module Gori::Fuzz
         num_pass?(@match_size_c, length, default: true) &&
         num_pass?(@match_words_c, words.to_i64, default: true) &&
         num_pass?(@match_lines_c, lines.to_i64, default: true) &&
-        regex_pass?(@match_regex, text, default: true) &&
-        header_pass?(raw)
+        # header_pass? (an allocation-free byte scan over the short head) before regex_pass?
+        # (a PCRE match over the whole body): both are pure predicates, so `&&` short-circuits
+        # identically either way, but this order lets a failing --mh skip the body match.
+        header_pass?(raw) &&
+        regex_pass?(@match_regex, text, default: true)
     end
 
     # Any filter dimension that passes removes the result.

--- a/src/gori/probe/analyzer.cr
+++ b/src/gori/probe/analyzer.cr
@@ -490,6 +490,10 @@ module Gori
       end
 
       private def suppressed?(code : String, host : String) : Bool
+        # Called per Detection (a typical flow yields 8-15), so build the composite key only when
+        # there is something to look it up in. The set is empty unless the operator hard-deleted
+        # an issue this session, i.e. empty on the overwhelmingly common path.
+        return false if @suppressed.empty?
         @suppressed.includes?("#{code}|#{host}")
       end
 

--- a/src/gori/probe/passive/cacheable_api.cr
+++ b/src/gori/probe/passive/cacheable_api.cr
@@ -69,19 +69,22 @@ module Gori
             return nil if expires_disables?(expires) && pragma_no_cache?(pragma)
             return "missing Cache-Control"
           end
-          low = cc.downcase
-          return "Cache-Control: public" if directive?(low, "public")
-          if (n = directive_int(low, "s-maxage")) && n > 0
+          # Split the header into stripped directive tokens ONCE. directive?/directive_int each
+          # used to re-split the whole value, and this method calls them up to six times (max-age
+          # twice), so a cacheable JSON response re-split the same string six times over.
+          parts = cc.downcase.split(',').map!(&.strip)
+          return "Cache-Control: public" if directive?(parts, "public")
+          if (n = directive_int(parts, "s-maxage")) && n > 0
             return "s-maxage=#{n}"
           end
-          if (n = directive_int(low, "max-age")) && n > 0
+          max_age = directive_int(parts, "max-age")
+          if (n = max_age) && n > 0
             return "max-age=#{n}"
           end
           # private/no-cache alone still lets a browser keep a copy (must revalidate at
           # best). For JSON APIs we want no-store; flag when neither no-cache nor max-age=0
           # is present either — pure `private` or empty directives.
-          if directive?(low, "private") && !directive?(low, "no-cache") &&
-             !(directive_int(low, "max-age") == 0)
+          if directive?(parts, "private") && !directive?(parts, "no-cache") && max_age != 0
             return "private without no-store/no-cache"
           end
           nil
@@ -103,13 +106,13 @@ module Gori
         end
 
         # Token present as a full Cache-Control directive (not a substring of another word).
-        private def directive?(low : String, name : String) : Bool
-          low.split(',').any? { |part| part.strip.split('=').first?.try(&.strip) == name }
+        # `parts` are the already-stripped, already-downcased directive tokens.
+        private def directive?(parts : Array(String), name : String) : Bool
+          parts.any? { |part| part.split('=').first?.try(&.strip) == name }
         end
 
-        private def directive_int(low : String, name : String) : Int64?
-          low.split(',').each do |part|
-            p = part.strip
+        private def directive_int(parts : Array(String), name : String) : Int64?
+          parts.each do |p|
             next unless p.starts_with?("#{name}=") || p.starts_with?("#{name} =")
             eq = p.index('=')
             next unless eq

--- a/src/gori/probe/passive/context.cr
+++ b/src/gori/probe/passive/context.cr
@@ -32,6 +32,10 @@ module Gori
         @client_scripts : Array(String)?
         @client_scripts_nocomment : Array(String)?
         @client_code : Array(String)?
+        @ct_low : String?
+        @ct_low_done = false
+        @html : Bool?
+        @js : Bool?
 
         def initialize(@detail : Store::FlowDetail, @ws_messages = [] of Store::WsMessage)
         end
@@ -73,17 +77,31 @@ module Gori
           row.content_type
         end
 
+        # The response Content-Type, downcased ONCE per flow. html?/js? are each called from
+        # several rules plus the body getters (~12 calls per flow between them), and every call
+        # used to allocate its own throwaway downcased copy of the same header value. Rules that
+        # need to run their own substring tests should read this rather than downcase again.
+        def ct_low : String?
+          return @ct_low if @ct_low_done
+          @ct_low_done = true
+          @ct_low = content_type.try(&.downcase)
+        end
+
+        # Memoised: the answer cannot change for a given flow, and both getters sit on the
+        # per-flow path that the passive fiber shares with the proxy.
         def html? : Bool
-          !!content_type.try(&.downcase.includes?("text/html"))
+          h = @html
+          return h unless h.nil?
+          @html = !!ct_low.try(&.includes?("text/html"))
         end
 
         # A JavaScript response (external bundle / module), distinct from an HTML document with
         # inline scripts. Used to gate the client-side rules alongside html?.
         def js? : Bool
-          ct = content_type
-          return false if ct.nil?
-          low = ct.downcase
-          low.includes?("javascript") || low.includes?("ecmascript")
+          j = @js
+          return j unless j.nil?
+          low = ct_low
+          @js = low.nil? ? false : (low.includes?("javascript") || low.includes?("ecmascript"))
         end
 
         def request_origin : String?

--- a/src/gori/probe/passive/js_scan.cr
+++ b/src/gori/probe/passive/js_scan.cr
@@ -68,6 +68,31 @@ module Gori
           {/\.html\s*\(/, "jQuery.html()"},
         ] of {Regex, String}
 
+        # A random-access `Char` view over ASCII bytes, used instead of `String#chars` on the
+        # (overwhelmingly common) all-ASCII script. `chars` builds an `Array(Char)` sized to the
+        # script — for a 256 KiB minified bundle that is a ~1 MiB heap allocation, and both strip
+        # and strip_comments used to build their own, on every HTML/JS flow, on the fiber the
+        # passive scan shares with the proxy.
+        #
+        # This is a struct wrapping a borrowed slice, so it allocates nothing. For ASCII the two
+        # are isomorphic: byte index == char index and `unsafe_chr` on a byte < 0x80 is exactly
+        # the Char `chars` would have held, so the lexers below produce byte-identical output.
+        # A script with any non-ASCII byte still takes the `chars` path, which keeps this file's
+        # char-offset-preserving invariant exactly as documented (blanking a multi-byte char to a
+        # single space) rather than trading it for a byte-offset one.
+        private struct AsciiChars
+          def initialize(@bytes : Bytes)
+          end
+
+          def size : Int32
+            @bytes.size
+          end
+
+          def [](index : Int32) : Char
+            @bytes[index].unsafe_chr
+          end
+        end
+
         # Executable JS fragments in a response body, RAW (not yet stripped). `html`/`js` come
         # from the Context content-type gates.
         def self.scripts(text : String?, html : Bool, js : Bool) : Array(String)
@@ -95,24 +120,39 @@ module Gori
         # tokens. Every consumed char emits exactly one char, so indices stay aligned.
         def self.strip(js : String) : String
           return js if js.empty?
-          chars = js.chars
-          n = chars.size
-          String.build(js.bytesize) do |io|
-            i = 0
-            while i < n
-              if j = blank_token_at(chars, i, n, io)
-                i = j
-              else
-                io << chars[i]
-                i += 1
+          scan_source(js) do |chars, n|
+            String.build(js.bytesize) do |io|
+              i = 0
+              while i < n
+                if j = blank_token_at(chars, i, n, io)
+                  i = j
+                else
+                  io << chars[i]
+                  i += 1
+                end
               end
             end
           end
         end
 
+        # Yields the random-access char source for `js` plus its length: a zero-allocation
+        # AsciiChars view when the script is all-ASCII, else the `Array(Char)` the lexers have
+        # always used. Both satisfy the same `size`/`[]` shape, so the lexers below are compiled
+        # for each and neither is special-cased. `ascii_only?` is a single byte pass, far cheaper
+        # than the array it avoids.
+        private def self.scan_source(js : String, &)
+          if js.ascii_only?
+            view = AsciiChars.new(js.to_slice)
+            yield view, view.size
+          else
+            chars = js.chars
+            yield chars, chars.size
+          end
+        end
+
         # If chars[i] starts a // or /* */ comment, blank it (→ spaces, offsets preserved) and
         # return the index just past it; else nil. Shared by the string- and comment-strip lexers.
-        private def self.blank_comment_at(chars : Array(Char), i : Int32, n : Int32, io : IO) : Int32?
+        private def self.blank_comment_at(chars, i : Int32, n : Int32, io : IO) : Int32?
           c = chars[i]
           if c == '/' && i + 1 < n && chars[i + 1] == '/'
             blank_line_comment(chars, i, n, io)
@@ -124,7 +164,7 @@ module Gori
         # If chars[i] starts a // comment, /* */ comment, or a '…'/"…"/`…` string, blank it
         # (contents → spaces, offsets preserved) and return the index just past it; else nil.
         # Shared by strip and emit_interpolation so the token lexing lives in one place.
-        private def self.blank_token_at(chars : Array(Char), i : Int32, n : Int32, io : IO) : Int32?
+        private def self.blank_token_at(chars, i : Int32, n : Int32, io : IO) : Int32?
           if j = blank_comment_at(chars, i, n, io)
             j
           else
@@ -140,22 +180,22 @@ module Gori
         # `//` or `/*` (e.g. in a URL literal) is not mistaken for a comment.
         def self.strip_comments(js : String) : String
           return js if js.empty?
-          chars = js.chars
-          n = chars.size
-          String.build(js.bytesize) do |io|
-            i = 0
-            while i < n
-              c = chars[i]
-              i = if c == '/' && i + 1 < n && chars[i + 1] == '/'
-                    blank_line_comment(chars, i, n, io)
-                  elsif c == '/' && i + 1 < n && chars[i + 1] == '*'
-                    blank_block_comment(chars, i, n, io)
-                  elsif c == '\'' || c == '"' || c == '`'
-                    copy_string(chars, i, n, io)
-                  else
-                    io << c
-                    i + 1
-                  end
+          scan_source(js) do |chars, n|
+            String.build(js.bytesize) do |io|
+              i = 0
+              while i < n
+                c = chars[i]
+                i = if c == '/' && i + 1 < n && chars[i + 1] == '/'
+                      blank_line_comment(chars, i, n, io)
+                    elsif c == '/' && i + 1 < n && chars[i + 1] == '*'
+                      blank_block_comment(chars, i, n, io)
+                    elsif c == '\'' || c == '"' || c == '`'
+                      copy_string(chars, i, n, io)
+                    else
+                      io << c
+                      i + 1
+                    end
+              end
             end
           end
         end
@@ -166,7 +206,7 @@ module Gori
         # via copy_interpolation so a NESTED template's backtick inside ${…} is not mistaken
         # for this template's closing delimiter (which would terminate early and re-lex the
         # real remainder, blanking a URL's // as a comment).
-        private def self.copy_string(chars : Array(Char), i : Int32, n : Int32, io : IO) : Int32
+        private def self.copy_string(chars, i : Int32, n : Int32, io : IO) : Int32
           quote = chars[i]
           io << quote
           i += 1
@@ -192,7 +232,7 @@ module Gori
         # comments inside it, but COPY string literals verbatim (so their contents stay for the
         # string-key rules), tracking brace depth to find the matching `}`. Recurses through
         # copy_string for nested strings/templates. `i` points at `$`. Offset-preserving.
-        private def self.copy_interpolation(chars : Array(Char), i : Int32, n : Int32, io : IO) : Int32
+        private def self.copy_interpolation(chars, i : Int32, n : Int32, io : IO) : Int32
           io << '$' << '{'
           i += 2
           depth = 1
@@ -215,7 +255,7 @@ module Gori
         end
 
         # Blank a // comment through end-of-line (the terminating newline is left to the caller).
-        private def self.blank_line_comment(chars : Array(Char), i : Int32, n : Int32, io : IO) : Int32
+        private def self.blank_line_comment(chars, i : Int32, n : Int32, io : IO) : Int32
           io << "  "
           i += 2
           while i < n && chars[i] != '\n'
@@ -226,7 +266,7 @@ module Gori
         end
 
         # Blank a /* … */ comment, delimiters included.
-        private def self.blank_block_comment(chars : Array(Char), i : Int32, n : Int32, io : IO) : Int32
+        private def self.blank_block_comment(chars, i : Int32, n : Int32, io : IO) : Int32
           io << "  "
           i += 2
           while i < n && !(chars[i] == '*' && i + 1 < n && chars[i + 1] == '/')
@@ -245,7 +285,7 @@ module Gori
         # expression is emitted (via emit_interpolation) instead of blanked — otherwise the
         # common template-literal sink shape (innerHTML = `${location.hash}`) would lose its
         # source and DOM-XSS would miss it.
-        private def self.blank_string(chars : Array(Char), i : Int32, n : Int32, io : IO) : Int32
+        private def self.blank_string(chars, i : Int32, n : Int32, io : IO) : Int32
           quote = chars[i]
           io << quote # opening delimiter kept
           i += 1
@@ -275,7 +315,7 @@ module Gori
         # source/sink keywords inside it survive, but blank nested strings/comments (so their
         # CONTENTS can't false-match) and track brace depth to find the matching `}`. Every
         # consumed char emits exactly one char, so offsets stay aligned. `i` points at `$`.
-        private def self.emit_interpolation(chars : Array(Char), i : Int32, n : Int32, io : IO) : Int32
+        private def self.emit_interpolation(chars, i : Int32, n : Int32, io : IO) : Int32
           io << "  " # blank the '${' delimiter (2 spaces, offset-preserved): keeps the inner
           #            expression as code but removes the '{' so source_in_window's /[;{}\n]/
           #            statement-boundary scan doesn't truncate the window at the interpolation

--- a/src/gori/probe/passive/secret_in_url.cr
+++ b/src/gori/probe/passive/secret_in_url.cr
@@ -42,9 +42,13 @@ module Gori
             return emit(acc, ctx, hit[0], Store::Severity::High)
           end
           # Otherwise rank by the name tier (High > Medium > Low); the highest present wins.
+          # Normalize each name ONCE up front: the tier loop used to re-normalize every param
+          # for every tier, so a URL with no sensitive name (the common case) ran `normalize` —
+          # a decode + downcase + character strip — three times per parameter.
+          norms = pairs.map { |(n, _)| normalize(n) }
           TIERS.each do |(sev, names)|
-            if hit = pairs.find { |(n, _)| names.includes?(normalize(n)) }
-              return emit(acc, ctx, hit[0], sev)
+            if idx = norms.index { |nm| names.includes?(nm) }
+              return emit(acc, ctx, pairs[idx][0], sev)
             end
           end
         end
@@ -55,8 +59,10 @@ module Gori
         end
 
         # Lowercase + strip '-'/'_' so hyphen/underscore/case variants collapse to one form.
+        # `delete` takes a char SET and is exactly equivalent to the old `gsub(/[-_]/, "")`,
+        # without spinning up a PCRE match per parameter name.
         private def normalize(name : String) : String
-          decode(name).downcase.gsub(/[-_]/, "")
+          decode(name).downcase.delete("-_")
         end
 
         private def display_name(name : String) : String

--- a/src/gori/probe/passive/security_headers.cr
+++ b/src/gori/probe/passive/security_headers.cr
@@ -29,11 +29,15 @@ module Gori
           return unless resp = ctx.response
           if ctx.scheme == "https"
             hsts = resp.headers.get_all("Strict-Transport-Security").first? # RFC 6797 §8.1: UA honours the FIRST STS header
-            if hsts.nil? || hsts_disabled?(hsts)
+            # Parse max-age ONCE and branch on the Int64? — the disabled/short/evidence path used
+            # to call hsts_max_age up to three times for the same value, and each call scrubs,
+            # downcases, and runs a PCRE match. Every HTTPS response with HSTS reaches this.
+            age = hsts.try { |v| hsts_max_age(v) }
+            if hsts.nil? || age.nil? || age == 0
               acc << hdr(ctx, "missing_hsts", "Missing or disabled HSTS header", Store::Severity::Medium)
-            elsif short_hsts?(hsts)
+            elsif age < SHORT_HSTS_MAX_AGE
               acc << hdr(ctx, "short_hsts", "HSTS max-age is under 1 day", Store::Severity::Low,
-                "max-age=#{hsts_max_age(hsts)}")
+                "max-age=#{age}")
             end
           end
           check_doc_headers(ctx, resp.headers, acc) if ctx.html? && rendered_document?(resp.status)
@@ -50,17 +54,8 @@ module Gori
         end
 
         # HSTS with no max-age, or max-age=0 (RFC 6797: instructs the UA to DROP the policy), is
-        # effectively disabled even though the header is present.
-        private def hsts_disabled?(value : String) : Bool
-          age = hsts_max_age(value)
-          age.nil? || age == 0
-        end
-
-        private def short_hsts?(value : String) : Bool
-          age = hsts_max_age(value)
-          !age.nil? && age > 0 && age < SHORT_HSTS_MAX_AGE
-        end
-
+        # effectively disabled even though the header is present — `check` treats a nil/0 age as
+        # disabled and anything under SHORT_HSTS_MAX_AGE as short, off this single parse.
         private def hsts_max_age(value : String) : Int64?
           m = value.scrub.downcase.match(/max-age\s*=\s*"?(\d+)/) # scrub: a non-UTF-8 byte makes the PCRE match raise (cf. cors.cr)
           return nil if m.nil?

--- a/src/gori/probe/passive/tech.cr
+++ b/src/gori/probe/passive/tech.cr
@@ -1,5 +1,6 @@
 require "json"
 require "./rule"
+require "../../ascii_bytes"
 require "../../proxy/h2/grpc"
 require "../../sse"
 
@@ -10,6 +11,13 @@ module Gori
       # project's "representative technologies" summary. Runs on every flow (not response-gated):
       # several signals live on the request side or on a 101 upgrade.
       class Tech < Rule
+        # Lowercase needles for the allocation-free byte gates in graphql? (AsciiBytes.contains_ci?
+        # requires an already-lowercase needle). Held as constants so the slices are built once
+        # for the process, not per flow.
+        private GRAPHQL_PATH = "/graphql".to_slice
+        private JSON_CT      = "json".to_slice
+        private QUERY_KEY    = %("query").to_slice
+
         def info : RuleInfo
           RuleInfo.new("tech", "Technology fingerprints",
             "Identifies server software, frameworks, and protocols (WebSocket, gRPC, GraphQL, SSE, HTTP/2) from headers and bodies.",
@@ -42,7 +50,11 @@ module Gori
             acc << tech(ctx, "tech_grpc", "gRPC service")
           end
           acc << tech(ctx, "tech_graphql", "GraphQL endpoint") if graphql?(ctx, req_ct)
-          acc << tech(ctx, "tech_sse", "Server-Sent Events stream") if Sse.event_stream?(detail.response_head)
+          # `resp_ct` is the response Content-Type the capture already parsed out of the head
+          # (the same value grpc? consumes above), so ask Sse directly instead of re-parsing the
+          # raw head bytes: event_stream? would copy the whole head to a String and split it into
+          # per-header Strings on EVERY flow just to read a header we are already holding.
+          acc << tech(ctx, "tech_sse", "Server-Sent Events stream") if Sse.sse?(resp_ct)
           if detail.http_version.starts_with?("HTTP/2") || !detail.h2_conn_id.nil?
             acc << tech(ctx, "tech_http2", "HTTP/2")
           end
@@ -101,18 +113,30 @@ module Gori
         # STRING holding a GraphQL document. Requiring a string value keeps Elasticsearch /
         # OpenSearch query DSL bodies (where `query` is an OBJECT) out of the match.
         private def graphql?(ctx : Context, req_ct : String?) : Bool
-          return true if ctx.req.target.downcase.includes?("/graphql")
-          return false unless req_ct.try(&.downcase.includes?("json"))
+          # Byte scans over the borrowed slices (String#to_slice is a view): the target can carry
+          # a multi-KB query string, and downcasing it — plus the Content-Type — allocated a full
+          # copy of each on every flow just to run two case-insensitive substring tests.
+          return true if AsciiBytes.contains_ci?(ctx.req.target.to_slice, GRAPHQL_PATH)
+          return false unless req_ct && AsciiBytes.contains_ci?(req_ct.to_slice, JSON_CT)
           body = ctx.detail.request_body
           return false unless body
           # 8 KB truncated mid-JSON on real GraphQL requests (a sizeable `variables` object),
           # which then fails JSON.parse and mis-classified them as non-GraphQL; allow up to 256 KB.
-          text = String.new(body[0, {body.size, 256 * 1024}.min]).scrub
+          capped = body[0, {body.size, 256 * 1024}.min]
           # A GraphQL request body always carries a top-level `"query"` key; a cheap substring
           # check lets the overwhelming majority of non-GraphQL JSON POSTs skip the full
           # JSON.parse (a tree build over ≤256 KB) on the shared passive-scan fiber. Conservative:
           # a `"query"` appearing only inside a value still parses, then the as_h?/as_s? guards reject.
-          return false unless text.includes?(%("query"))
+          #
+          # Scan the RAW BYTES, before materialising `text`. The gate was already here, but it ran
+          # against a String that had just been copied+scrubbed out of those same ≤256 KB — so an
+          # ordinary JSON API POST still paid a full-body copy and a UTF-8 validation pass to be
+          # told "not GraphQL". Gating first makes the common case allocation-free. Byte-scanning
+          # is case-insensitive where `includes?` was exact, which only ever opens the gate wider
+          # (scrub cannot create or destroy an ASCII `"query"`), and the as_h?/as_s? guards below
+          # still decide the outcome — so no detection is lost.
+          return false unless AsciiBytes.contains_ci?(capped, QUERY_KEY)
+          text = String.new(capped).scrub
           q = begin
             JSON.parse(text).as_h?.try(&.["query"]?).try(&.as_s?)
           rescue JSON::ParseException

--- a/src/gori/ql.cr
+++ b/src/gori/ql.cr
@@ -1,5 +1,6 @@
 require "db"
 require "./filter_ast"
+require "./proto" # Proto::Kind, used by the `proto:` term below
 
 module Gori
   # The query language (DESIGN.md §4): a Lucene/KQL-style boolean filter over the

--- a/src/gori/sitemap.cr
+++ b/src/gori/sitemap.cr
@@ -305,10 +305,18 @@ module Gori
       # its own children (without this, a {hex} fold of long numerics grows a nested
       # [1000… +N] inside it, and a second call nests one more level).
       return if node.grouped
-      numeric = node.children.select { |c| !c.grouped && numeric_label?(c.label) }
-      return if numeric.size <= SEQUENCE_GROUP_THRESHOLD
+      # Count first, materialise second. The overwhelming majority of nodes have no numeric
+      # children at all, and `select` used to allocate the result Array for every one of them
+      # before the threshold check below could reject it — on a tree rebuilt each poll frame.
+      count = 0
+      node.children.each { |c| count += 1 if !c.grouped && numeric_label?(c.label) }
+      return if count <= SEQUENCE_GROUP_THRESHOLD
+      numeric = Array(Node).new(count)
+      rest = Array(Node).new(node.children.size - count)
+      node.children.each do |c|
+        (!c.grouped && numeric_label?(c.label)) ? (numeric << c) : (rest << c)
+      end
       numeric.sort_by! { |c| p = path_part(c.label); {p.size, p} }
-      rest = node.children.select { |c| c.grouped || !numeric_label?(c.label) }
       group = Node.new(group_label(numeric))
       group.grouped = true
       group.expanded = false
@@ -330,7 +338,14 @@ module Gori
 
     def self.numeric_label?(label : String) : Bool
       s = path_part(label)
-      !s.empty? && s.each_char.all?(&.ascii_number?)
+      return false if s.empty?
+      # Byte loop rather than `each_char.all?`: the block-less each_char returns a CharIterator,
+      # which is a CLASS, so that form heap-allocated an iterator per call — and this runs a few
+      # times per node on a tree that is rebuilt from scratch on every sitemap poll. ASCII digits
+      # are single-byte, and any multi-byte char has all bytes >= 0x80, so a byte test rejects
+      # non-digits exactly as the char test did.
+      s.each_byte { |b| return false unless 0x30_u8 <= b <= 0x39_u8 }
+      true
     end
 
     # "[1, 2, 3 … +47]" — the first three values then a remainder count.


### PR DESCRIPTION
Closes #265. Follow-up to #263, which fixed the JSON-flow side of the passive scan and left this one flagged as the biggest remaining item.

## The cost

`JsScan.strip` and `.strip_comments` both opened with `js.chars`, which allocates an `Array(Char)` sized to the script — ~1 MiB for a 256 KiB bundle. Both run on every HTML/JS response and neither is optional: `client_code` forces `strip` for DOM-XSS and DOM-clobbering, `client_scripts_nocomment` forces `strip_comments` for postMessage and prototype-pollution. So a document flow built it twice, on the fiber the passive scan shares with the proxy.

## The fix

An all-ASCII script now lexes through `AsciiChars` — a struct wrapping the borrowed byte slice that returns `Char` from `[]`. It allocates nothing, and for ASCII it is isomorphic to the array: byte index == char index, and `unsafe_chr` on a byte `< 0x80` is exactly the `Char` that was there before, so output is byte-identical.

The lexer methods dropped their `Array(Char)` restriction and are compiled for both sources, so there is **one implementation, not two**.

## Why not just move the lexers to bytes

That was the tempting version, and I benched toward it, but it trades this file's documented invariant —

> Every consumed char emits exactly one char, so indices stay aligned.

— for a byte-offset one, because blanking a multi-byte char would emit N spaces instead of one. No current consumer cross-references raw vs stripped offsets (I checked all four client rules), so it would not have been *wrong* today, but it silently shifts what `WINDOW = 250` covers in multi-byte text, and the failure mode here is a missed finding rather than a crash. A script with any non-ASCII byte therefore still takes the `chars` path, unchanged. Minified bundles — the case that actually costs 256 KiB — are essentially always ASCII, so the fast path captures the win without touching the contract.

## Measured

`bench/probe_passive_bench.cr`, per flow, detections identical (`json=2 html=6 js=2`):

| flow | before | after | |
|---|---|---|---|
| JS bundle (256 KiB) | 6.88 ms / **2.81 MB** | 6.03 ms / **835 kB** | −70% alloc, 1.14× faster |
| HTML document | 0.98 ms / 157 kB | 0.98 ms / **89.1 kB** | −43% alloc |
| JSON API POST | 164 µs / 33.9 kB | unchanged | path not touched |

Allocation is the headline rather than wall-time, which is the point: gori is single-threaded and GC has profiled at ~4× memcpy, so 2 MB less garbage per bundle flow is throughput the microbench does not model well.

Added the JS-bundle row to the bench — the worst case, where `client_scripts` is the whole body at the `CLIENT_BODY_CAP` ceiling.

## Test

- New specs pin the two paths byte-identical across nested templates, escapes, and unterminated string/template/block-comment constructs, plus the char-count invariant on both paths (including a CJK sample), plus source→sink correlation still ignoring commented-out code.
- Suite: **2350 examples, 0 failures**. ameba clean on the touched files.