### PR TITLE
perf(probe): lex all-ASCII scripts without building an Array(Char)

### DIFF
--- a/bench/probe_passive_bench.cr
+++ b/bench/probe_passive_bench.cr
@@ -76,11 +76,35 @@ HTML_FLOW = flow("GET", "/dashboard", "text/html; charset=utf-8",
   ("GET /dashboard HTTP/1.1\r\nHost: app.example.com\r\n\r\n").to_slice, nil,
   HTML_RESP_HEAD, HTML_BODY)
 
+# A minified-bundle-shaped JS response at the Context::CLIENT_BODY_CAP ceiling (256 KiB). This
+# is the worst case for the client-side rules: `client_scripts` is the WHOLE body, and both
+# strip (client_code) and strip_comments (client_scripts_nocomment) lex all of it.
+JS_BODY = begin
+  io = IO::Memory.new
+  i = 0
+  while io.bytesize < 256 * 1024
+    io << "function f" << i << "(a,b){var c=\"str" << i << "\",d=/*x*/a+b;return c+d};"
+    i += 1
+  end
+  io.to_slice.dup
+end
+
+JS_RESP_HEAD = ("HTTP/1.1 200 OK\r\nContent-Type: application/javascript\r\n" \
+                "Server: nginx/1.24.0\r\nCache-Control: max-age=31536000\r\n\r\n").to_slice
+
+JS_FLOW = flow("GET", "/static/app.min.js", "application/javascript",
+  ("GET /static/app.min.js HTTP/1.1\r\nHost: app.example.com\r\n\r\n").to_slice, nil,
+  JS_RESP_HEAD, JS_BODY)
+
 puts "Probe passive scan — full Passive.analyze per flow:"
 puts "  JSON POST body: #{JSON_BODY.size} bytes; HTML document: #{HTML_BODY.size} bytes"
-puts "  (detections: json=#{Gori::Probe::Passive.analyze(JSON_FLOW).size} html=#{Gori::Probe::Passive.analyze(HTML_FLOW).size})"
+puts "  JS bundle: #{JS_BODY.size} bytes (at the CLIENT_BODY_CAP ceiling)"
+puts "  (detections: json=#{Gori::Probe::Passive.analyze(JSON_FLOW).size}" \
+     " html=#{Gori::Probe::Passive.analyze(HTML_FLOW).size}" \
+     " js=#{Gori::Probe::Passive.analyze(JS_FLOW).size})"
 
 Benchmark.ips do |x|
   x.report("JSON API POST flow") { Gori::Probe::Passive.analyze(JSON_FLOW) }
   x.report("HTML document flow") { Gori::Probe::Passive.analyze(HTML_FLOW) }
+  x.report("JS bundle flow    ") { Gori::Probe::Passive.analyze(JS_FLOW) }
 end

--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -2312,3 +2312,48 @@ describe "Gori::Probe::Active::BackslashPowered" do
     end
   end
 end
+
+# JsScan lexes an all-ASCII script through a zero-allocation AsciiChars view and anything else
+# through String#chars. The two must stay byte-identical — the fast path is an optimisation, not
+# a behaviour change, and a silent divergence here is a missed finding, not a crash.
+describe "Gori::Probe::Passive::JsScan (ASCII fast path)" do
+  samples = [
+    %(var a = "hello"; // comment here\nfoo.innerHTML = location.hash;),
+    %(/* block\n comment */ eval("x" + location.search);),
+    %(const t = `pre ${location.hash} post`; el.innerHTML = t;),
+    %(s = 'it\\'s escaped'; u = "http://x/y//z"; document.write(u);),
+    %(a = `outer ${ `inner ${x}` } end`;),
+    %(o = {"__proto__": 1}; window.addEventListener("message", function(e){ el.innerHTML = e.data; });),
+    %(x = 1 / 2; y = a // trailing\n + b;),
+    %(`unterminated template),
+    %("unterminated string),
+    %(/* unterminated block),
+  ]
+
+  it "produces identical output on both paths" do
+    samples.each do |src|
+      src.ascii_only?.should be_true # these drive the fast path
+
+      # Appending a non-ASCII char forces the chars path; compare the shared prefix.
+      forced_strip = Gori::Probe::Passive::JsScan.strip(src + "é")
+      forced_comments = Gori::Probe::Passive::JsScan.strip_comments(src + "é")
+
+      Gori::Probe::Passive::JsScan.strip(src).should eq(forced_strip[0, src.size])
+      Gori::Probe::Passive::JsScan.strip_comments(src).should eq(forced_comments[0, src.size])
+    end
+  end
+
+  it "preserves char count on both paths" do
+    (samples + ["日本語 = \"文字列\"; // コメント\nel.innerHTML = location.hash;"]).each do |src|
+      Gori::Probe::Passive::JsScan.strip(src).size.should eq(src.size)
+      Gori::Probe::Passive::JsScan.strip_comments(src).size.should eq(src.size)
+    end
+  end
+
+  it "still correlates source to sink, and still ignores commented-out code" do
+    code = Gori::Probe::Passive::JsScan.strip(
+      "el.innerHTML = location.hash;\n// el.innerHTML = document.cookie;\n")
+    Gori::Probe::Passive::JsScan.source_sink_pairs(code)
+      .should eq([{"location.hash", "innerHTML"}])
+  end
+end

--- a/src/gori/probe/passive/js_scan.cr
+++ b/src/gori/probe/passive/js_scan.cr
@@ -68,6 +68,31 @@ module Gori
           {/\.html\s*\(/, "jQuery.html()"},
         ] of {Regex, String}
 
+        # A random-access `Char` view over ASCII bytes, used instead of `String#chars` on the
+        # (overwhelmingly common) all-ASCII script. `chars` builds an `Array(Char)` sized to the
+        # script — for a 256 KiB minified bundle that is a ~1 MiB heap allocation, and both strip
+        # and strip_comments used to build their own, on every HTML/JS flow, on the fiber the
+        # passive scan shares with the proxy.
+        #
+        # This is a struct wrapping a borrowed slice, so it allocates nothing. For ASCII the two
+        # are isomorphic: byte index == char index and `unsafe_chr` on a byte < 0x80 is exactly
+        # the Char `chars` would have held, so the lexers below produce byte-identical output.
+        # A script with any non-ASCII byte still takes the `chars` path, which keeps this file's
+        # char-offset-preserving invariant exactly as documented (blanking a multi-byte char to a
+        # single space) rather than trading it for a byte-offset one.
+        private struct AsciiChars
+          def initialize(@bytes : Bytes)
+          end
+
+          def size : Int32
+            @bytes.size
+          end
+
+          def [](index : Int32) : Char
+            @bytes[index].unsafe_chr
+          end
+        end
+
         # Executable JS fragments in a response body, RAW (not yet stripped). `html`/`js` come
         # from the Context content-type gates.
         def self.scripts(text : String?, html : Bool, js : Bool) : Array(String)
@@ -95,24 +120,39 @@ module Gori
         # tokens. Every consumed char emits exactly one char, so indices stay aligned.
         def self.strip(js : String) : String
           return js if js.empty?
-          chars = js.chars
-          n = chars.size
-          String.build(js.bytesize) do |io|
-            i = 0
-            while i < n
-              if j = blank_token_at(chars, i, n, io)
-                i = j
-              else
-                io << chars[i]
-                i += 1
+          scan_source(js) do |chars, n|
+            String.build(js.bytesize) do |io|
+              i = 0
+              while i < n
+                if j = blank_token_at(chars, i, n, io)
+                  i = j
+                else
+                  io << chars[i]
+                  i += 1
+                end
               end
             end
           end
         end
 
+        # Yields the random-access char source for `js` plus its length: a zero-allocation
+        # AsciiChars view when the script is all-ASCII, else the `Array(Char)` the lexers have
+        # always used. Both satisfy the same `size`/`[]` shape, so the lexers below are compiled
+        # for each and neither is special-cased. `ascii_only?` is a single byte pass, far cheaper
+        # than the array it avoids.
+        private def self.scan_source(js : String, &)
+          if js.ascii_only?
+            view = AsciiChars.new(js.to_slice)
+            yield view, view.size
+          else
+            chars = js.chars
+            yield chars, chars.size
+          end
+        end
+
         # If chars[i] starts a // or /* */ comment, blank it (→ spaces, offsets preserved) and
         # return the index just past it; else nil. Shared by the string- and comment-strip lexers.
-        private def self.blank_comment_at(chars : Array(Char), i : Int32, n : Int32, io : IO) : Int32?
+        private def self.blank_comment_at(chars, i : Int32, n : Int32, io : IO) : Int32?
           c = chars[i]
           if c == '/' && i + 1 < n && chars[i + 1] == '/'
             blank_line_comment(chars, i, n, io)
@@ -124,7 +164,7 @@ module Gori
         # If chars[i] starts a // comment, /* */ comment, or a '…'/"…"/`…` string, blank it
         # (contents → spaces, offsets preserved) and return the index just past it; else nil.
         # Shared by strip and emit_interpolation so the token lexing lives in one place.
-        private def self.blank_token_at(chars : Array(Char), i : Int32, n : Int32, io : IO) : Int32?
+        private def self.blank_token_at(chars, i : Int32, n : Int32, io : IO) : Int32?
           if j = blank_comment_at(chars, i, n, io)
             j
           else
@@ -140,22 +180,22 @@ module Gori
         # `//` or `/*` (e.g. in a URL literal) is not mistaken for a comment.
         def self.strip_comments(js : String) : String
           return js if js.empty?
-          chars = js.chars
-          n = chars.size
-          String.build(js.bytesize) do |io|
-            i = 0
-            while i < n
-              c = chars[i]
-              i = if c == '/' && i + 1 < n && chars[i + 1] == '/'
-                    blank_line_comment(chars, i, n, io)
-                  elsif c == '/' && i + 1 < n && chars[i + 1] == '*'
-                    blank_block_comment(chars, i, n, io)
-                  elsif c == '\'' || c == '"' || c == '`'
-                    copy_string(chars, i, n, io)
-                  else
-                    io << c
-                    i + 1
-                  end
+          scan_source(js) do |chars, n|
+            String.build(js.bytesize) do |io|
+              i = 0
+              while i < n
+                c = chars[i]
+                i = if c == '/' && i + 1 < n && chars[i + 1] == '/'
+                      blank_line_comment(chars, i, n, io)
+                    elsif c == '/' && i + 1 < n && chars[i + 1] == '*'
+                      blank_block_comment(chars, i, n, io)
+                    elsif c == '\'' || c == '"' || c == '`'
+                      copy_string(chars, i, n, io)
+                    else
+                      io << c
+                      i + 1
+                    end
+              end
             end
           end
         end
@@ -166,7 +206,7 @@ module Gori
         # via copy_interpolation so a NESTED template's backtick inside ${…} is not mistaken
         # for this template's closing delimiter (which would terminate early and re-lex the
         # real remainder, blanking a URL's // as a comment).
-        private def self.copy_string(chars : Array(Char), i : Int32, n : Int32, io : IO) : Int32
+        private def self.copy_string(chars, i : Int32, n : Int32, io : IO) : Int32
           quote = chars[i]
           io << quote
           i += 1
@@ -192,7 +232,7 @@ module Gori
         # comments inside it, but COPY string literals verbatim (so their contents stay for the
         # string-key rules), tracking brace depth to find the matching `}`. Recurses through
         # copy_string for nested strings/templates. `i` points at `$`. Offset-preserving.
-        private def self.copy_interpolation(chars : Array(Char), i : Int32, n : Int32, io : IO) : Int32
+        private def self.copy_interpolation(chars, i : Int32, n : Int32, io : IO) : Int32
           io << '$' << '{'
           i += 2
           depth = 1
@@ -215,7 +255,7 @@ module Gori
         end
 
         # Blank a // comment through end-of-line (the terminating newline is left to the caller).
-        private def self.blank_line_comment(chars : Array(Char), i : Int32, n : Int32, io : IO) : Int32
+        private def self.blank_line_comment(chars, i : Int32, n : Int32, io : IO) : Int32
           io << "  "
           i += 2
           while i < n && chars[i] != '\n'
@@ -226,7 +266,7 @@ module Gori
         end
 
         # Blank a /* … */ comment, delimiters included.
-        private def self.blank_block_comment(chars : Array(Char), i : Int32, n : Int32, io : IO) : Int32
+        private def self.blank_block_comment(chars, i : Int32, n : Int32, io : IO) : Int32
           io << "  "
           i += 2
           while i < n && !(chars[i] == '*' && i + 1 < n && chars[i + 1] == '/')
@@ -245,7 +285,7 @@ module Gori
         # expression is emitted (via emit_interpolation) instead of blanked — otherwise the
         # common template-literal sink shape (innerHTML = `${location.hash}`) would lose its
         # source and DOM-XSS would miss it.
-        private def self.blank_string(chars : Array(Char), i : Int32, n : Int32, io : IO) : Int32
+        private def self.blank_string(chars, i : Int32, n : Int32, io : IO) : Int32
           quote = chars[i]
           io << quote # opening delimiter kept
           i += 1
@@ -275,7 +315,7 @@ module Gori
         # source/sink keywords inside it survive, but blank nested strings/comments (so their
         # CONTENTS can't false-match) and track brace depth to find the matching `}`. Every
         # consumed char emits exactly one char, so offsets stay aligned. `i` points at `$`.
-        private def self.emit_interpolation(chars : Array(Char), i : Int32, n : Int32, io : IO) : Int32
+        private def self.emit_interpolation(chars, i : Int32, n : Int32, io : IO) : Int32
           io << "  " # blank the '${' delimiter (2 spaces, offset-preserved): keeps the inner
           #            expression as code but removes the '{' so source_in_window's /[;{}\n]/
           #            statement-boundary scan doesn't truncate the window at the interpolation


### PR DESCRIPTION
Closes #265. Follow-up to #263, which fixed the JSON-flow side of the passive scan and left this one flagged as the biggest remaining item.

*(Supersedes #268 — I deleted its branch by accident mid-merge, which closed it and could not be reopened. Same commit, rebased onto current main.)*

## The cost

`JsScan.strip` and `.strip_comments` both opened with `js.chars`, which allocates an `Array(Char)` sized to the script — ~1 MiB for a 256 KiB bundle. Both run on every HTML/JS response and neither is optional: `client_code` forces `strip` for DOM-XSS and DOM-clobbering, `client_scripts_nocomment` forces `strip_comments` for postMessage and prototype-pollution. So a document flow built it twice, on the fiber the passive scan shares with the proxy.

## The fix

An all-ASCII script now lexes through `AsciiChars` — a struct wrapping the borrowed byte slice that returns `Char` from `[]`. It allocates nothing, and for ASCII it is isomorphic to the array: byte index == char index, and `unsafe_chr` on a byte `< 0x80` is exactly the `Char` that was there before, so output is byte-identical.

The lexer methods dropped their `Array(Char)` restriction and are compiled for both sources, so there is **one implementation, not two**.

## Why not just move the lexers to bytes

That was the tempting version, but it trades this file's documented invariant —

> Every consumed char emits exactly one char, so indices stay aligned.

— for a byte-offset one, because blanking a multi-byte char would emit N spaces instead of one. No current consumer cross-references raw vs stripped offsets (I checked all four client rules), so it would not have been *wrong* today, but it silently shifts what `WINDOW = 250` covers in multi-byte text, and the failure mode here is a missed finding rather than a crash. A script with any non-ASCII byte therefore still takes the `chars` path, unchanged. Minified bundles — the case that actually costs 256 KiB — are essentially always ASCII, so the fast path captures the win without touching the contract.

## Measured

`bench/probe_passive_bench.cr`, per flow, detections identical (`json=2 html=6 js=2`):

| flow | before | after | |
|---|---|---|---|
| JS bundle (256 KiB) | 6.88 ms / **2.81 MB** | 6.03 ms / **835 kB** | −70% alloc, 1.14× faster |
| HTML document | 0.98 ms / 157 kB | 0.98 ms / **89.1 kB** | −43% alloc |
| JSON API POST | 164 µs / 33.9 kB | unchanged | path not touched |

Allocation is the headline rather than wall-time, which is the point: gori is single-threaded and GC has profiled at ~4× memcpy, so 2 MB less garbage per bundle flow is throughput the microbench does not model well.

Added the JS-bundle row to the bench — the worst case, where `client_scripts` is the whole body at the `CLIENT_BODY_CAP` ceiling.

## Test

- New specs pin the two paths byte-identical across nested templates, escapes, and unterminated string/template/block-comment constructs, plus the char-count invariant on both paths (including a CJK sample), plus source→sink correlation still ignoring commented-out code.
- Suite: **2350 examples, 0 failures**. ameba clean on the touched files.