### PR TITLE
perf(tui): build the fuzzer detail selection spans once per frame, not per row

### DIFF
--- a/bench/fuzz_view_frame_bench.cr
+++ b/bench/fuzz_view_frame_bench.cr
@@ -1,0 +1,86 @@
+# FuzzerView per-frame render cost during a LIVE run — the busiest moment in the tool: results
+# stream in, every one forces a redraw, and the results pane plus the open detail pane are both
+# redrawn in full each time.
+#
+# Two shapes that used to scale with the whole result set rather than the visible rows:
+#   * matched_count — a rev-keyed memo whose key bumped on every appended result, so the full
+#     count(&.matched?) scan over RESULT_CAP rows ran on every frame of a live run anyway.
+#   * the detail pane's selection spans — rebuilt once per DRAWN ROW inside the row loop, then
+#     all but the matching line discarded.
+#
+# Build: crystal build bench/fuzz_view_frame_bench.cr -o bin/fuzz_view_frame_bench --release
+# Run:   bin/fuzz_view_frame_bench
+require "benchmark"
+require "../src/gori/tui"
+require "../spec/support/memory_backend"
+
+include Gori::Tui
+
+W = 160
+H =  48
+
+def result(idx : Int32, matched : Bool, body_lines : Int32 = 40) : Gori::Fuzz::Result
+  head = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nServer: nginx\r\n\r\n".to_slice
+  body = String.build do |io|
+    body_lines.times { |i| io << %({"row":) << i << %(,"label":"value ) << i << "\"}\n" }
+  end.to_slice
+  Gori::Fuzz::Result.new(idx.to_i64, ["payload#{idx}"], nil, 200, body.size.to_i64, 120, 41,
+    (1000 + idx * 7).to_i64, nil, matched, false, nil,
+    head: matched ? head : nil, body: matched ? body : nil,
+    request: matched ? head : nil)
+end
+
+def build_view(n : Int32) : FuzzerView
+  view = FuzzerView.new
+  view.load_request("https://api.example.com",
+    "POST /api/v1/search?q=§term§ HTTP/1.1\r\nHost: api.example.com\r\n\r\n", false, "")
+  view.begin_run(n.to_i64)
+  n.times { |i| view.append_result(result(i, i % 7 == 0)) }
+  view
+end
+
+FULL = build_view(Gori::Tui::FuzzerView::RESULT_CAP)
+
+# Same view with the detail pane open on a matched row — exercises the per-row chrome path.
+DETAIL = begin
+  v = build_view(Gori::Tui::FuzzerView::RESULT_CAP)
+  v.focus_pane(:results)
+  v.open_detail
+  v
+end
+
+# Detail open on a LARGE response with a selection spanning the whole body. This is the shape
+# the per-row span rebuild punished: highlight_spans emits one tuple per selected line, and it
+# used to run once per DRAWN ROW, so the cost was rows x selected-lines per frame.
+BIG_SEL = begin
+  v = FuzzerView.new
+  v.load_request("https://api.example.com", "GET /big HTTP/1.1\r\nHost: api.example.com\r\n\r\n", false, "")
+  v.begin_run(1_i64)
+  v.append_result(result(0, true, body_lines: 3000))
+  v.focus_pane(:results)
+  v.open_detail
+  3000.times { v.detail_move(1, 0, selecting: true) } # select the whole body
+  v
+end
+
+backend = MemoryBackend.new(W, H)
+screen = Screen.new(backend)
+rect = Rect.new(0, 0, W, H)
+
+puts "FuzzerView frame render, #{Gori::Tui::FuzzerView::RESULT_CAP} results, #{W}x#{H}:"
+puts "  matched_count = #{FULL.matched_count} of #{FULL.result_count}"
+
+Benchmark.ips do |x|
+  # A live run appends a result between frames, so any cache keyed on the result revision is
+  # invalidated exactly the way it is in the real loop.
+  x.report("results pane, live (append + render)") do
+    FULL.append_result(result(0, false))
+    FULL.render(screen, rect)
+  end
+  x.report("detail open, live (append + render)") do
+    DETAIL.append_result(result(0, false))
+    DETAIL.render(screen, rect)
+  end
+  x.report("results pane, idle (render only)") { FULL.render(screen, rect) }
+  x.report("detail, 3000-line selection    ") { BIG_SEL.render(screen, rect) }
+end

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -592,3 +592,43 @@ describe "FuzzerView pretty-printing" do
     view.dirty?.should be_true
   end
 end
+
+describe "Gori::Tui::FuzzerView matched_count accounting" do
+  it "tracks matched results as they stream in" do
+    view = loaded_fuzzer
+    view.matched_count.should eq(0)
+    view.append_result(fuzz_result(0, 200, 100, matched: true))
+    view.append_result(fuzz_result(1, 404, 100, matched: false))
+    view.append_result(fuzz_result(2, 200, 100, matched: true))
+    view.matched_count.should eq(2)
+    view.result_count.should eq(3)
+  end
+
+  it "decrements when the ring evicts a matched row past RESULT_CAP" do
+    view = loaded_fuzzer
+    cap = Gori::Tui::FuzzerView::RESULT_CAP
+    # Fill exactly to the cap with matched rows, then push unmatched ones in: each append
+    # past the cap evicts a matched row off the front, so the count must fall in step.
+    cap.times { |i| view.append_result(fuzz_result(i, 200, 100, matched: true)) }
+    view.matched_count.should eq(cap)
+    view.result_count.should eq(cap)
+
+    10.times { |i| view.append_result(fuzz_result(cap + i, 404, 100, matched: false)) }
+    view.result_count.should eq(cap) # ring stays pinned
+    view.matched_count.should eq(cap - 10)
+
+    # Drain the rest of the matched rows out of the ring: the count must reach exactly 0 and
+    # not undershoot, which is what a decrement on the wrong branch would do.
+    (cap - 10).times { |i| view.append_result(fuzz_result(cap + 10 + i, 404, 100, matched: false)) }
+    view.matched_count.should eq(0)
+    view.result_count.should eq(cap)
+  end
+
+  it "resets on a new run" do
+    view = loaded_fuzzer
+    3.times { |i| view.append_result(fuzz_result(i, 200, 100, matched: true)) }
+    view.matched_count.should eq(3)
+    view.begin_run(10_i64)
+    view.matched_count.should eq(0)
+  end
+end

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -138,6 +138,13 @@ module Gori::Tui
       # ran EVERY frame — the busiest moment is a live run streaming results, each of
       # which forces a redraw). matched_count is rev-only; the sorted view also keys on
       # the sort order + matched-only toggle.
+      #
+      # NOTE on matched_count: during a live run @results_rev bumps per appended result, so
+      # this key never hits and the count(&.matched?) scan does run every frame. Maintaining
+      # the count incrementally in append_result instead was tried and benched at RESULT_CAP
+      # (bench/fuzz_view_frame_bench.cr) — no measurable difference, the frame is dominated by
+      # cell drawing. Left as a memo rather than trade a self-correcting recompute for state
+      # that three mutation sites must keep in sync for no gain.
       @matched_count_cache = 0
       @matched_count_rev = -1_i64
       @sorted_cache = nil.as(Array(Fuzz::Result)?)
@@ -1981,6 +1988,10 @@ module Gori::Tui
       cw = {inner.w - gw, 0}.max
       rows = (0...inner.h).compact_map { |i| lines[@detail_scroll + i]? }
       @detail_xscroll = @detail_xscroll.clamp(0, {(rows.max_of? { |l| Screen.display_width_upto(l, @detail_xscroll + cw + 1) } || 0) - cw, 0}.max)
+      # Selection spans for the WHOLE buffer, built once per frame. This used to sit inside
+      # paint_detail_line_chrome, i.e. rebuilt and thrown away once per drawn row — O(rows ×
+      # selection length) tuple appends, plus a fresh Array per row even with nothing selected.
+      spans = focused && detail_navigable? ? @detail_cursor.highlight_spans(lines) : nil
       rows.each_with_index do |line, i|
         li = @detail_scroll + i
         Gutter.draw(screen, inner.x, inner.y + i, li, gw, current: focused && li == @detail_cursor.cy)
@@ -1988,15 +1999,17 @@ module Gori::Tui
         sline = styled[li]? || [Highlight::Span.new(line, Theme.text)]
         sline = Highlight.slice_left(sline, @detail_xscroll) if @detail_xscroll > 0
         Highlight.draw(screen, inner.x + gw, inner.y + i, sline, bg: Theme.bg, width: cw)
-        paint_detail_line_chrome(screen, inner.x + gw, inner.y + i, li, line, focused, lines)
+        paint_detail_line_chrome(screen, inner.x + gw, inner.y + i, li, line, spans)
       end
       Frame.scroll_gauge(screen, inner, lines.size, @detail_scroll, focused)
     end
 
+    # `spans` is the frame's selection-span list (nil when the pane isn't focused/navigable),
+    # built once by render_detail rather than per row.
     private def paint_detail_line_chrome(screen : Screen, x : Int32, y : Int32, li : Int32, line : String,
-                                         focused : Bool, lines : Array(String)) : Nil
-      return unless focused && detail_navigable?
-      @detail_cursor.highlight_spans(lines).each do |(l, x0, x1)|
+                                         spans : Array({Int32, Int32, Int32})?) : Nil
+      return unless spans
+      spans.each do |(l, x0, x1)|
         paint_char_span_bg(screen, x, y, line, x0, x1, Theme.accent_bg) if l == li
       end
       return unless li == @detail_cursor.cy


### PR DESCRIPTION
Second of the two items I flagged after #263. (The first was #265 → #269.)

## The problem

`paint_detail_line_chrome` called `@detail_cursor.highlight_spans(lines)` on every **drawn row**, then discarded everything except the entry matching that line:

```crystal
@detail_cursor.highlight_spans(lines).each do |(l, x0, x1)|
  paint_char_span_bg(...) if l == li     # <- keeps one, throws away the rest
end
```

`highlight_spans` emits one tuple per selected line, so the cost was O(visible rows × selected lines) — the full list rebuilt ~48 times per frame.

## The fix

Hoist the call into `render_detail` and pass the result down. `focused` dropped from the helper's parameters, since `spans` is nil in exactly the cases it used to guard.

## Measured

New `bench/fuzz_view_frame_bench.cr`, 160×48, 5000 results:

| | before | after | |
|---|---|---|---|
| detail, 3000-line selection | 451 µs / **3.13 MB** | 154 µs / **181 kB** | **2.9× faster, −94% alloc** |
| results pane, live (append + render) | 145 µs / 46.0 kB | unchanged | |
| detail open, live | 76 µs / 18.6 kB | unchanged | |
| results pane, idle | 103 µs / 39.2 kB | unchanged | |

The win is entirely in the large-selection case, which is the shape the per-row rebuild punished. Everything else is untouched, as expected.

## Tried and not kept: incremental `matched_count`

The audit also flagged `matched_count`, and the diagnosis was right: it is a memo keyed on `@results_rev`, and `append_result` bumps that rev per result — so during a live run (the only time the number moves) the key never hits and the `count(&.matched?)` scan over `RESULT_CAP` rows really does run every frame.

But maintaining the count incrementally instead benched as **no measurable difference** at 5000 results; the frame is dominated by cell drawing. That is not worth trading a self-correcting recompute for state that three mutation sites (`append_result`, the ring evict, and two `@results.clear` calls) must keep in sync forever. Reverted, with a note at the declaration so the next reader doesn't re-derive it.

Same call as the `ContentLength.sync` gate in #263 — benched, didn't pay, didn't ship.

## Test

`matched_count` had no spec coverage at all. Added it while I was in there — streaming appends, the `RESULT_CAP` ring evicting matched rows off the front (including draining to exactly 0), and reset on a new run. These pass against the memo implementation that shipped.

`spec/tui`: **850 examples, 0 failures**.

> Note: the full suite currently shows 8 failures in `capture_status_spec` / `project_registry_spec`. They fail identically on a clean checkout of `main` — they bind `127.0.0.1:8070` and a `gori` TUI is holding it. Not related to this change.