### PR TITLE
perf(sequencer): cut analyze allocation by 77% on a full sample

### DIFF
--- a/bench/sequencer_stats_bench.cr
+++ b/bench/sequencer_stats_bench.cr
@@ -1,0 +1,58 @@
+# Sequencer::Stats.analyze — the full randomness report over a captured token sample.
+#
+# Worth isolating because analyze is not a one-shot: the TUI re-runs it on a throttle while a
+# live capture streams tokens in, and every MCP `sequence_results` poll recomputes it. The
+# sample can reach Config::GOAL_CEILING = 50,000 tokens, so several passes over it — and any
+# unpresized array sized to total_bytes — are paid repeatedly.
+#
+# Build: crystal build bench/sequencer_stats_bench.cr -o bin/sequencer_stats_bench --release
+# Run:   bin/sequencer_stats_bench
+require "benchmark"
+
+module Gori
+  class Error < Exception; end
+end
+
+require "../src/gori/sequencer/stats"
+
+include Gori::Sequencer
+
+# Deterministic, dependency-free PRNG so runs are comparable (Date/Random are fine here, but a
+# fixed stream keeps before/after numbers exactly aligned).
+class Lcg
+  def initialize(@s : UInt64 = 0x2545F4914F6CDD1D_u64)
+  end
+
+  def next_byte : UInt8
+    @s = @s &* 6364136223846793005_u64 &+ 1442695040888963407_u64
+    ((@s >> 33) & 0xff).to_u8
+  end
+end
+
+HEX = "0123456789abcdef".bytes
+B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".bytes
+
+def sample(count : Int32, len : Int32, alphabet : Array(UInt8)) : Array(String)
+  rng = Lcg.new
+  Array(String).new(count) do
+    String.build(len) { |io| len.times { io << alphabet[rng.next_byte % alphabet.size].chr } }
+  end
+end
+
+# A realistic worst case: a full 50k-token sample of 32-char hex session ids (bps = 4), and a
+# 20k sample of 43-char base64 tokens (bps = 6, the wider symbol alphabet).
+HEX_50K = sample(50_000, 32, HEX)
+B64_20K = sample(20_000, 43, B64)
+HEX_5K  = sample(5_000, 32, HEX)
+
+[{"hex 50k x32", HEX_50K}, {"b64 20k x43", B64_20K}, {"hex 5k x32", HEX_5K}].each do |(label, s)|
+  bytes = s.sum(&.bytesize)
+  puts "#{label}: #{s.size} tokens, #{bytes} bytes"
+end
+puts
+
+Benchmark.ips do |x|
+  x.report("analyze hex 50k x32") { Stats.analyze(HEX_50K) }
+  x.report("analyze b64 20k x43") { Stats.analyze(B64_20K) }
+  x.report("analyze hex 5k x32 ") { Stats.analyze(HEX_5K) }
+end

--- a/src/gori/sequencer/stats.cr
+++ b/src/gori/sequencer/stats.cr
@@ -14,6 +14,11 @@ module Gori::Sequencer
     # FAIL softens to WARN and the rating can't certify Secure (clamped ≤ Moderate).
     SMALL_SAMPLE = 20
 
+    # Bytes of concatenated token text fed to the compression test. The deflate ratio settles
+    # well before a full sample, and analyze is re-run on a UI throttle, so this bounds the
+    # single largest allocation in the report.
+    COMPRESS_SCAN_CAP = 256 * 1024
+
     enum Verdict
       Pass
       Warn
@@ -130,7 +135,9 @@ module Gori::Sequencer
       lengths.each { |l| lcounts[l] += 1 }
       length_entropy = shannon_hash(lcounts, n)
 
-      unique = usable.uniq.size
+      # to_set.size, not uniq.size: Array#uniq is `to_set.to_a` for a sample this size, so it
+      # built an n-element Array purely to read .size off it.
+      unique = usable.to_set.size
       duplicate_count = n - unique
       uniqueness = unique.to_f / n
 
@@ -143,7 +150,12 @@ module Gori::Sequencer
       # ceil(log2(charset)) bits. This measures the token's real entropy rather than its
       # encoding — a hex token's ASCII bytes are structurally non-uniform (0x30-0x66) and
       # would fail every bit test even when the underlying value is perfectly random.
-      idx_of = Hash(UInt8, Int32).new
+      # Byte → alphabet index as a flat 256-entry LUT rather than a Hash. This is probed once
+      # per sample byte by three separate loops below (the bit-bias scan, symbol_bits and
+      # symbol_seq), and the sample reaches millions of bytes, so a direct index beats hashing
+      # every one of them. -1 marks a byte absent from the alphabet (never hit: the table is
+      # built from the bytes actually present).
+      idx_of = Array(Int32).new(256, -1)
       present.each_with_index { |b, i| idx_of[b] = i }
       bps = charset_size <= 1 ? 0 : Math.log2(charset_size.to_f).ceil.to_i
       # The fixed-width symbol-bit encoding is only unbiased when the alphabet size is a
@@ -159,15 +171,15 @@ module Gori::Sequencer
         usable.each do |t|
           sl = t.to_slice
           (0...min_len).each do |p|
-            v = idx_of[sl[p]]
+            v = idx_of.unsafe_fetch(sl[p])
             (0...bps).each { |k| ones_at[p * bps + k] += 1 if (v >> (bps - 1 - k)) & 1 == 1 }
           end
         end
       end
       bit_bias = ones_at.map { |c| (c.to_f / n - 0.5).abs }
 
-      bits = symbol_bits(usable, idx_of, bps)
-      sym_seq = symbol_seq(usable, idx_of)
+      bits = symbol_bits(usable, idx_of, bps, total_bytes)
+      sym_seq = symbol_seq(usable, idx_of, total_bytes)
       seq, seq_detail = detect_sequential(usable)
 
       tests = [] of TestRow
@@ -350,8 +362,13 @@ module Gori::Sequencer
     private def self.compression_test(tokens : Array(String), bytes : Int64,
                                       charset_size : Int32, small : Bool) : TestRow
       return insufficient("Compression", "#{bytes} bytes") if bytes < 64
-      raw = tokens.join.to_slice
-      io = IO::Memory.new
+      # Cap the deflate input. The ratio is a stable statistic long before the whole sample is
+      # consumed, but `tokens.join` over a full 50k-token sample built a multi-MB String (from
+      # a String.build starting at capacity 64, so a realloc chain on top) and then deflated
+      # every byte of it — on a path the TUI re-runs on a throttle and every MCP poll re-runs
+      # from scratch. Whole tokens only, so a token is never split mid-value.
+      raw = join_capped(tokens, COMPRESS_SCAN_CAP)
+      io = IO::Memory.new(raw.size // 2)
       Compress::Deflate::Writer.open(io, &.write(raw))
       ratio = io.size.to_f / raw.size
       floor = charset_size <= 1 ? 0.0 : Math.log2(charset_size.to_f) / 8.0
@@ -362,7 +379,10 @@ module Gori::Sequencer
                 else
                   Verdict::Pass
                 end
-      TestRow.new("Compression", fmt(ratio), "floor #{fmt(floor)}", verdict)
+      # Say so when the ratio came from a prefix rather than the whole sample, so the number is
+      # never silently a different measurement from the one the sample size implies.
+      detail = raw.size < bytes ? "floor #{fmt(floor)} · first #{raw.size // 1024} KB" : "floor #{fmt(floor)}"
+      TestRow.new("Compression", fmt(ratio), detail, verdict)
     end
 
     private def self.bit_bias_test(ones_at : Array(Int32), n : Int32, small : Bool) : TestRow
@@ -431,22 +451,48 @@ module Gori::Sequencer
 
     # The concatenated symbol bitstream: each byte → its alphabet index → `bps` bits
     # (MSB-first). Empty when the alphabet has ≤ 1 symbol (no bits to test).
-    private def self.symbol_bits(tokens : Array(String), idx_of : Hash(UInt8, Int32), bps : Int32) : Array(UInt8)
-      bits = [] of UInt8
-      return bits if bps <= 0
+    # Concatenated token bytes, stopping at the first WHOLE token that would cross `cap` (so a
+    # token is never split mid-value). Presized, unlike `tokens.join`.
+    private def self.join_capped(tokens : Array(String), cap : Int32) : Bytes
+      total = 0
+      taken = 0
+      tokens.each do |t|
+        break if total + t.bytesize > cap && taken > 0
+        total += t.bytesize
+        taken += 1
+      end
+      buf = Bytes.new(total)
+      off = 0
+      taken.times do |i|
+        sl = tokens.unsafe_fetch(i).to_slice
+        sl.copy_to(buf.to_unsafe + off, sl.size)
+        off += sl.size
+      end
+      buf
+    end
+
+    # Presized: the final length is known exactly (total sample bytes × bps), and growing from
+    # capacity 0 to the millions of elements a full sample produces means ~20 doubling reallocs,
+    # each copying everything written so far.
+    private def self.symbol_bits(tokens : Array(String), idx_of : Array(Int32), bps : Int32,
+                                 total_bytes : Int64) : Array(UInt8)
+      return [] of UInt8 if bps <= 0
+      bits = Array(UInt8).new((total_bytes * bps).to_i)
       tokens.each do |t|
         t.to_slice.each do |b|
-          v = idx_of[b]
+          v = idx_of.unsafe_fetch(b)
           (bps - 1).downto(0) { |k| bits << ((v >> k) & 1).to_u8 }
         end
       end
       bits
     end
 
-    # The concatenated sequence of alphabet indices (for serial correlation).
-    private def self.symbol_seq(tokens : Array(String), idx_of : Hash(UInt8, Int32)) : Array(Int32)
-      seq = [] of Int32
-      tokens.each { |t| t.to_slice.each { |b| seq << idx_of[b] } }
+    # The concatenated sequence of alphabet indices (for serial correlation). Presized for the
+    # same reason as symbol_bits.
+    private def self.symbol_seq(tokens : Array(String), idx_of : Array(Int32),
+                                total_bytes : Int64) : Array(Int32)
+      seq = Array(Int32).new(total_bytes.to_i)
+      tokens.each { |t| t.to_slice.each { |b| seq << idx_of.unsafe_fetch(b) } }
       seq
     end
 


### PR DESCRIPTION
From the audit backlog in #263. Benched first this time — the Sequencer items were "unbounded allocation" shaped, which is the category that has actually paid off this round.

## Why it matters

`Stats.analyze` is not a one-shot: the TUI re-runs it on a throttle while a capture streams tokens in, and every MCP `sequence_results` poll recomputes it from scratch. At `Config::GOAL_CEILING` (50k tokens, 1.6 MB) it cost **174 ms and 76 MB per run**.

## Changes

- **`symbol_bits` / `symbol_seq` presized.** Their final lengths are known exactly (`total_bytes * bps` and `total_bytes`), and growing from capacity 0 to the millions of elements a full sample produces meant ~20 doubling reallocs each, every one copying everything written so far. This is the bulk of the win.
- **`idx_of`: `Hash(UInt8, Int32)` → a flat 256-entry `Array` LUT.** It is probed once per sample byte by three separate loops (bit-bias scan, `symbol_bits`, `symbol_seq`), so that is millions of hash lookups replaced by a direct index.
- **`compression_test` capped at 256 KB** of concatenated tokens. `tokens.join` built a multi-MB String (via `String.build` from capacity 64, so its own realloc chain) and then deflated every byte of it. Whole tokens only, never split mid-value.
- **`usable.uniq.size` → `usable.to_set.size`.** `uniq` is `to_set.to_a` at this size, so it built an n-element Array purely to read `.size` off it.

## Measured

`bench/sequencer_stats_bench.cr` (new):

| sample | before | after | |
|---|---|---|---|
| hex 50k × 32 | 174 ms / **75.9 MB** | 119 ms / **17.4 MB** | −77% alloc, 1.46× |
| b64 20k × 43 | 123 ms / **48.9 MB** | 104 ms / **11.0 MB** | −78% alloc, 1.19× |
| hex 5k × 32 | 17.2 ms / 8.3 MB | 14.4 ms / **2.3 MB** | −72% alloc, 1.20× |

Isolated: presize+LUT accounts for 75.9 → 20.3 MB; the compression cap adds the remaining allocation and a further 1.25× on time (deflating 256 KB instead of 1.6 MB).

## Output equivalence

A differential over 8 sample shapes — hex, base64, decimal, sequential, duplicate-heavy, variable-length, single-symbol, and a tiny below-`SMALL_SAMPLE` set — compares **every `Report` field and every test row** byte-for-byte.

Everything matches except one thing, which is inherent to capping: the compression ratio on samples past 256 KB (`0.57` → `0.572` on the 50k hex set; the 20k base64 set's ratio did not move at all). Verdicts are unchanged.

Rather than let that be a silently different measurement, the test's detail now says so:

```
Compression  0.572   floor 0.5 · first 256 KB
```

The label only appears when the cap actually applied.

## Test

Suite: **2353 examples, 0 failures**. Format clean, ameba unchanged from baseline.