### PR TITLE
perf(miner): stop copying the head and body to splice params into a probe

### DIFF
--- a/bench/miner_inject_bench.cr
+++ b/bench/miner_inject_bench.cr
@@ -1,0 +1,67 @@
+# Miner::Inject.apply — building one probe request for a bucket of candidate parameter names.
+#
+# Multiplied hard: the engine sends the initial bucket, then bisects it (~log2(K) levels), then
+# confirms each survivor, for every location and every seed request. Default bucket sizes are
+# 128 (Query/Form/Multipart), 256 (Json) and 64 (Headers/Cookies), and this runs on the
+# orchestrator fiber ahead of the send.
+#
+# Build: crystal build bench/miner_inject_bench.cr -o bin/miner_inject_bench --release
+# Run:   bin/miner_inject_bench
+require "benchmark"
+
+module Gori
+  class Error < Exception; end
+end
+
+require "../src/gori/miner/inject"
+
+include Gori::Miner
+
+def params(k : Int32) : Array({String, String})
+  Array({String, String}).new(k) { |i| {"candidate_param_#{i}", "canary#{i}zz"} }
+end
+
+P128 = params(128)
+P64  = params(64)
+
+# A realistic seed request with a normal header block.
+HEAD_LINES = [
+  "Host: api.example.com",
+  "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+  "Accept: application/json, text/plain, */*",
+  "Accept-Language: en-US,en;q=0.9",
+  "Referer: https://app.example.com/dashboard",
+  "Origin: https://app.example.com",
+  "Cookie: session=abc123def456; csrf=xyz789; theme=dark; tz=Asia%2FSeoul",
+  "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.sig",
+]
+
+def request_with(first : String, body : String, ct : String?) : Bytes
+  io = IO::Memory.new
+  io << first << "\r\n"
+  HEAD_LINES.each { |l| io << l << "\r\n" }
+  io << "Content-Type: " << ct << "\r\n" if ct
+  io << "Content-Length: " << body.bytesize << "\r\n" unless body.empty?
+  io << "\r\n" << body
+  io.to_slice.dup
+end
+
+FORM_BODY = String.build { |io| 30.times { |i| io << "&" if i > 0; io << "field" << i << "=value" << i } }
+
+GET_REQ  = request_with("GET /api/v1/search?q=widgets&page=2 HTTP/1.1", "", nil)
+FORM_REQ = request_with("POST /api/v1/submit HTTP/1.1", FORM_BODY, "application/x-www-form-urlencoded")
+
+puts "Miner::Inject.apply — one probe request per bucket:"
+puts "  GET  seed: #{GET_REQ.size} bytes; FORM seed: #{FORM_REQ.size} bytes (body #{FORM_BODY.bytesize})"
+puts "  bucket sizes: headers/cookies 64, query/form 128"
+puts "  outputs: headers=#{Inject.apply(GET_REQ, Gori::Miner::Location::Headers, P64).size}" \
+     " cookies=#{Inject.apply(GET_REQ, Gori::Miner::Location::Cookies, P64).size}" \
+     " query=#{Inject.apply(GET_REQ, Gori::Miner::Location::Query, P128).size}" \
+     " form=#{Inject.apply(FORM_REQ, Gori::Miner::Location::Form, P128).size}"
+
+Benchmark.ips do |x|
+  x.report("Headers  x64 ") { Inject.apply(GET_REQ, Gori::Miner::Location::Headers, P64) }
+  x.report("Cookies  x64 ") { Inject.apply(GET_REQ, Gori::Miner::Location::Cookies, P64) }
+  x.report("Query    x128") { Inject.apply(GET_REQ, Gori::Miner::Location::Query, P128) }
+  x.report("Form     x128") { Inject.apply(FORM_REQ, Gori::Miner::Location::Form, P128) }
+end

--- a/src/gori/miner/inject.cr
+++ b/src/gori/miner/inject.cr
@@ -1,6 +1,7 @@
 require "uri"
 require "json"
 require "mime/multipart"
+require "./types" # Location, which apply's own signature names
 require "../fuzz/content_length"
 
 module Gori::Miner
@@ -120,22 +121,32 @@ module Gori::Miner
     private def self.inject_form(request : Bytes, params : Array({String, String})) : Bytes
       head, body, eol = split(request)
       extra = encode_pairs(params)
-      btext = String.new(body)
-      new_body = if body.empty?
-                   extra
-                 elsif btext.ends_with?('&')
-                   "#{btext}#{extra}"
-                 else
-                   "#{btext}&#{extra}"
-                 end
-      io = IO::Memory.new(head.size + new_body.bytesize + eol.bytesize * 2)
+      # The body is spliced through as bytes. It used to be copied into a String, then again by
+      # the interpolation that joined it to `extra`, then a third time into the IO — and the
+      # trailing-'&' test is a single byte compare that needs no String at all.
+      io = IO::Memory.new(head.size + body.size + extra.bytesize + eol.bytesize * 2 + 1)
       io.write(head)
-      io << eol << eol << new_body
+      io << eol << eol
+      unless body.empty?
+        io.write(body)
+        io << '&' unless body[body.size - 1] == 0x26_u8 # '&'
+      end
+      io << extra
       io.to_slice
     end
 
+    # Encoded straight into one builder. The map/join form allocated two encoded Strings plus an
+    # interpolated third PER PAIR, plus the intermediate Array, before join copied them all again
+    # — and a bucket is up to 256 pairs, rebuilt for every probe the bisection sends.
     private def self.encode_pairs(params : Array({String, String})) : String
-      params.map { |(n, v)| "#{URI.encode_www_form(n)}=#{URI.encode_www_form(v)}" }.join('&')
+      String.build do |io|
+        params.each_with_index do |(n, v), i|
+          io << '&' if i > 0
+          URI.encode_www_form(n, io)
+          io << '='
+          URI.encode_www_form(v, io)
+        end
+      end
     end
 
     # ── multipart/form-data ──────────────────────────────────────────────────────────
@@ -272,11 +283,20 @@ module Gori::Miner
 
     # ── headers ──────────────────────────────────────────────────────────────────────
 
+    # Appending header lines needs no head parsing: the new lines go at the END, so the existing
+    # head bytes are copied through verbatim. The old path took String.new(head) (a full copy),
+    # split it into a String per line, then rebuild joined them back into another full copy
+    # before writing — three passes over the head to append to it.
     private def self.inject_headers(request : Bytes, params : Array({String, String})) : Bytes
       head, body, eol = split(request)
-      lines = String.new(head).split(eol)
-      params.each { |(n, v)| lines << "#{n}: #{sanitize_value(v)}" if valid_header_name?(n) }
-      rebuild(lines, eol, body)
+      io = IO::Memory.new(head.size + params.size * 48 + body.size + eol.bytesize * 2)
+      io.write(head)
+      params.each do |(n, v)|
+        io << eol << n << ": " << sanitize_value(v) if valid_header_name?(n)
+      end
+      io << eol << eol
+      io.write(body) unless body.empty?
+      io.to_slice
     end
 
     # ── cookies ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Next item from the #263 backlog. Benched first, as with #271.

## Why it matters

`Inject.apply` builds one request per probe, and the engine sends a lot of them: the initial bucket, ~log2(K) bisection levels, then a confirm round — for every location and every seed request. Default buckets are 128 (Query/Form/Multipart), 256 (Json), 64 (Headers/Cookies).

## Changes

- **`encode_pairs`** built two encoded Strings plus an interpolated third *per pair*, plus the intermediate Array, then `join` copied them all again. Encodes straight into one builder now (`URI.encode_www_form` has an IO overload). This is the cost Query and Form were both paying.
- **`inject_headers`** appends lines at the *end* of the head — but reached them via `String.new(head)` → `split(eol)` → `rebuild`'s `join(eol)` → write: three passes over the head plus a String per existing line, in order to append to it. Writes the head bytes through verbatim now.
- **`inject_form`** copied the body three times (`String.new`, the interpolation joining it to `extra`, then into the IO). Splices the body as bytes; the trailing-`&` test is a single byte compare.

## Measured

`bench/miner_inject_bench.cr` (new), one probe request per bucket:

| location | before | after | |
|---|---|---|---|
| Query ×128 | 36.95 µs / 76.0 kB | 14.49 µs / **24.7 kB** | **2.55×, −68% alloc** |
| Form ×128 | 35.61 µs / 78.2 kB | 13.91 µs / **22.3 kB** | **2.56×, −71% alloc** |
| Headers ×64 | 14.66 µs / 22.7 kB | 10.84 µs / **13.6 kB** | 1.35×, −40% alloc |
| Cookies ×64 | 15.3 µs / 25.3 kB | unchanged | path not touched |

`inject_cookies` is deliberately left alone — it has to locate and edit an existing `Cookie:` header, so it genuinely needs the parse. It appeared ~10% slower in the combined run, but allocation was byte-identical and isolating it gave 13.76 → 13.91 µs (within noise): that was the cross-report heap-state artifact, not a regression.

## Byte-exactness

Differential over **14 request shapes × 4 locations = 56 combinations**, comparing full output hex: empty and trailing-`&` form bodies, targets with no query / trailing `?` / trailing `&`, LF vs CRLF line endings, present and absent `Cookie` headers, names needing percent-encoding, invalid header names, and a 64-name bucket. **All identical.**

## Bug the bench surfaced

`inject.cr` names `Location` in `apply`'s own signature but never required `./types` — so it only compiled when something else happened to pull types in first. Exactly the shape of the `ql.cr` / `Proto::Kind` fix in #267. A bench with narrow requires keeps proving to be a cheap detector for this.

## Test

Suite: **2353 examples, 0 failures**. Format clean, ameba clean on the touched files.