### PR TITLE
perf(discover): stop re-parsing the page URL per link and gate the segment folder

### DIFF
--- a/bench/discover_url_bench.cr
+++ b/bench/discover_url_bench.cr
@@ -1,0 +1,66 @@
+# Discover::Url — the per-link and per-probe string work in the crawl loop.
+#
+# `consider_link` runs resolve + parse + visit_key + template_key for EVERY href on EVERY
+# crawled page (max_pages defaults in the thousands, each page carrying tens of links), and
+# `template_key` folds every path segment of every one of them.
+#
+# Build: crystal build bench/discover_url_bench.cr -o bin/discover_url_bench --release
+# Run:   bin/discover_url_bench
+require "benchmark"
+
+module Gori
+  class Error < Exception; end
+end
+
+require "../src/gori/discover/url"
+
+include Gori::Discover
+
+BASE = Url.parse("https://app.example.com/shop/catalog/index.html?ref=nav") ||
+       raise "bench base url failed to parse"
+
+# A realistic mix of hrefs off one page: relative, root-absolute, dotted, absolute, and the
+# non-HTTP schemes the resolver has to reject.
+HREFS = [
+  "product/1234",
+  "../cart",
+  "./checkout?step=2",
+  "/account/orders",
+  "/static/css/app.min.css",
+  "https://cdn.example.com/img/logo.png",
+  "//fonts.example.com/f.woff2",
+  "mailto:sales@example.com",
+  "javascript:void(0)",
+  "#section",
+  "help/faq#top",
+  "/user/550e8400-e29b-41d4-a716-446655440000/profile",
+]
+
+# Segment shapes template_key folds. Most real segments are plain words that should never
+# reach a regex at all.
+SEGMENTS = [
+  "api", "v1", "users", "catalog", "index.html", "static", "css",
+  "550e8400-e29b-41d4-a716-446655440000",
+  "2026-07-19",
+  "12345",
+  "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+]
+
+PATHS = [
+  "https://app.example.com/api/v1/users/12345/orders",
+  "https://app.example.com/shop/catalog/index.html?ref=nav&sort=price",
+  "https://app.example.com/user/550e8400-e29b-41d4-a716-446655440000/profile",
+  "https://app.example.com/blog/2026-07-19/a-post-title",
+]
+PARSED = PATHS.compact_map { |u| Url.parse(u) }
+
+puts "Discover::Url per-link work:"
+puts "  #{HREFS.size} hrefs resolved per page-batch, #{SEGMENTS.size} segments folded, #{PARSED.size} urls keyed"
+
+Benchmark.ips do |x|
+  x.report("resolve x#{HREFS.size} hrefs  ") { HREFS.each { |h| Url.resolve(BASE, h) } }
+  x.report("fold_segment x#{SEGMENTS.size}    ") { SEGMENTS.each { |s| Url.fold_segment(s) } }
+  x.report("template_key x#{PARSED.size}     ") { PARSED.each { |p| Url.template_key(p) } }
+  x.report("visit_key x#{PARSED.size}        ") { PARSED.each { |p| Url.visit_key(p) } }
+  x.report("parse x#{PATHS.size}            ") { PATHS.each { |u| Url.parse(u) } }
+end

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -326,10 +326,17 @@ module Gori::Discover
       if count > @config.cluster_saturation
         @cluster_suppressed += oc.links.size # a template/listing trap — stop expanding it
       else
-        oc.links.each { |lnk| consider_link(task, lnk) }
+        # Parse the page's own URL ONCE for the whole link set: it is loop-invariant, and
+        # consider_link used to re-run URI.parse (plus the host downcase and the scheme/path
+        # substrings) for every href on the page.
+        if base = Url.parse(task.url)
+          oc.links.each { |lnk| consider_link(task, base, lnk) }
+        end
       end
       if @config.follow_redirects? && (loc = fetched.redirect_to)
-        consider_link(task, RawLink.new(loc, Source::Redirect))
+        if base = Url.parse(task.url)
+          consider_link(task, base, RawLink.new(loc, Source::Redirect))
+        end
       end
     end
 
@@ -394,9 +401,7 @@ module Gori::Discover
 
     # Resolve a discovered link against its page, dedup, template-fold, bound-check, then
     # enqueue a crawl (spider) and derive a directory (brute).
-    private def consider_link(task : Task, link : RawLink) : Nil
-      base = Url.parse(task.url)
-      return unless base
+    private def consider_link(task : Task, base : Url::Parts, link : RawLink) : Nil
       abs = Url.resolve(base, link.href)
       return unless abs
       p = Url.parse(abs)
@@ -413,11 +418,12 @@ module Gori::Discover
         @template_suppressed += 1
         return
       end
-      return unless within_bounds?(p)
+      # One normalize for both the bound check and the enqueued Task (it was built twice).
+      return unless norm = bounded_url(p)
       @seen << key
       if @config.spider? && task.depth < @config.max_depth && @crawl_enqueued < @config.max_pages
         @crawl_enqueued += 1
-        @frontier << Task.new(TaskKind::Crawl, Url.normalize(p), task.depth + 1, link.source)
+        @frontier << Task.new(TaskKind::Crawl, norm, task.depth + 1, link.source)
       end
       enqueue_dir(Url.dir_of(p), task.depth) if @config.bruteforce?
     end
@@ -435,7 +441,7 @@ module Gori::Discover
       return if depth > @config.max_depth
       return if @dirs.includes?(dir)
       dp = Url.parse(dir)
-      return unless dp && within_bounds?(dp)
+      return unless dp && bounded_url(dp)
       @dirs << dir
       @frontier << Task.new(TaskKind::Calibrate, dir, depth, Source::Bruteforced, dir: dir)
     end
@@ -463,17 +469,22 @@ module Gori::Discover
     end
 
     # Containment (origin/subdomain/scope-aware) + the injected scope policy + path confine.
-    private def within_bounds?(p : Url::Parts) : Bool
+    # Returns the normalized URL when `p` is in bounds, else nil. It has to build that string to
+    # ask the scope anyway, and consider_link needs the same one for the Task it enqueues — so
+    # hand it back rather than have the caller rebuild it. Still short-circuits on the path
+    # confine before normalizing anything.
+    private def bounded_url(p : Url::Parts) : String?
       if cp = @confine_path
-        return false unless p.path.starts_with?(cp)
+        return nil unless p.path.starts_with?(cp)
       end
       url = Url.normalize(p)
-      return false unless @scope.allowed?(url, p.host) # excludes/sandbox — every mode
-      case @config.containment
-      in Containment::SameOrigin        then same_origin?(p)
-      in Containment::HostAndSubdomains then same_or_subdomain?(p)
-      in Containment::ScopeAware        then @scope.configured? ? @scope.boundary?(url, p.host) : same_origin?(p)
-      end
+      return nil unless @scope.allowed?(url, p.host) # excludes/sandbox — every mode
+      ok = case @config.containment
+           in Containment::SameOrigin        then same_origin?(p)
+           in Containment::HostAndSubdomains then same_or_subdomain?(p)
+           in Containment::ScopeAware        then @scope.configured? ? @scope.boundary?(url, p.host) : same_origin?(p)
+           end
+      ok ? url : nil
     end
 
     private def same_origin?(p : Url::Parts) : Bool

--- a/src/gori/discover/url.cr
+++ b/src/gori/discover/url.cr
@@ -61,15 +61,43 @@ module Gori::Discover
       q.empty? ? base : "#{base}?#{q}"
     end
 
+    UUID_LEN = 36
+    DATE_LEN = 10
+    HEX_MIN  = 12
+
+    # NOTE the literal branch returns the DOWNCASED segment — callers rely on template_key being
+    # case-folded, so this is not display text.
+    #
+    # Gated the way Sitemap.template_class already gates the same three patterns: an ordinary
+    # segment ("api", "users", "index.html") is the overwhelming majority and now reaches no
+    # regex at all. All four patterns are ASCII-only, so a non-ASCII segment can never match and
+    # is rejected before PCRE2 sees it. Sizes are exact for UUID/DATE and a floor for HEX.
+    #
+    # ORDER IS LOAD-BEARING: HEX also matches a long run of digits, so NUM must be tested first
+    # or every long numeric id would fold to {hex}.
     def self.fold_segment(seg : String) : String
-      d = seg.downcase
-      case
-      when UUID.matches?(d) then "{uuid}"
-      when DATE.matches?(d) then "{date}"
-      when NUM.matches?(d)  then "{n}"
-      when HEX.matches?(d)  then "{hex}"
-      else                       d
-      end
+      d = ascii_downcase(seg)
+      return d unless d.ascii_only?
+      sz = d.bytesize
+      return "{uuid}" if sz == UUID_LEN && UUID.matches?(d)
+      return "{date}" if sz == DATE_LEN && DATE.matches?(d)
+      return "{n}" if all_digits?(d)
+      return "{hex}" if sz >= HEX_MIN && HEX.matches?(d)
+      d
+    end
+
+    # `seg` itself when it holds no ASCII uppercase (the common case — String#downcase builds a
+    # fresh String even when nothing changes), else a downcased copy.
+    private def self.ascii_downcase(seg : String) : String
+      seg.each_byte { |b| return seg.downcase if 0x41_u8 <= b <= 0x5a_u8 }
+      seg
+    end
+
+    # Allocation- and PCRE-free stand-in for NUM (`\A\d+\z`).
+    private def self.all_digits?(s : String) : Bool
+      return false if s.empty?
+      s.each_byte { |b| return false unless 0x30_u8 <= b <= 0x39_u8 }
+      true
     end
 
     private def self.canonical_query(query : String?, *, fold : Bool) : String
@@ -123,15 +151,17 @@ module Gori::Discover
         h = h[0, qi]
       end
 
+      # normalize_path ONCE. The relative branch used to normalize and then be normalized again
+      # by the unconditional call that followed — running the whole split/Array-of-segments/join
+      # chain twice for an identical result, on the commonest href shape there is.
       abs_path =
         if h.starts_with?('/')
-          h
+          normalize_path(h)
         elsif lower.matches?(/\A[a-z][a-z0-9+.-]*:/)
           return nil # some other scheme (ftp:, ws:, …)
         else
           normalize_path(dir_path(base.path) + h)
         end
-      abs_path = normalize_path(abs_path)
       url = "#{origin(base)}#{abs_path}"
       hq ? "#{url}?#{hq}" : url
     end


### PR DESCRIPTION
Last item from the #263 backlog. Benched first, as with #271 and #272.

## Why it matters

The crawl loop runs `resolve` + `parse` + `visit_key` + `template_key` for **every href on every crawled page** (`max_pages` defaults in the thousands, each page carrying tens of links), and `template_key` folds every path segment of every one of them.

## Changes

- **`Url.fold_segment` gated** the way `Sitemap.template_class` already gates the same three patterns. An ordinary segment (`api`, `users`, `index.html`) now reaches no regex at all: exact size gates for UUID/DATE, a floor for HEX, an `ascii_only?` guard (all four patterns are ASCII-only, so a non-ASCII segment could never match), and a byte loop replacing `NUM`. The unconditional `seg.downcase` is skipped when the segment holds no ASCII uppercase — `String#downcase` builds a fresh String either way.
  **Order is unchanged and still load-bearing:** `HEX` also matches a long run of digits, so `NUM` stays ahead of it.
- **`Url.resolve` normalized the path twice** for a relative href — the branch computed `normalize_path(dir_path + h)` and the line after normalized the result again, running the whole split/Array-of-segments/join chain for an identical answer. (The differential below confirms `normalize_path` is idempotent rather than assuming it.)
- **`consider_link` re-ran `Url.parse(task.url)` for every link** even though it is loop-invariant. `handle_crawl` parses once and passes the `Parts` down.
- **`within_bounds?` → `bounded_url`**, returning the normalized URL instead of a Bool. It had to build that string to ask the scope anyway, and `consider_link` then built the same string a second time for the Task it enqueues. Still short-circuits on the path confine before normalizing anything, so the confined case gains no extra work.

## Measured

`bench/discover_url_bench.cr` (new):

| | before | after | |
|---|---|---|---|
| `fold_segment` ×11 | 1.02 µs / 416 B | 266 ns / **0 B** | **3.8×, zero alloc** |
| `template_key` ×4 | 2.69 µs / 2.87 kB | 1.85 µs / 2.42 kB | 1.45× |
| `resolve` ×12 | 3.98 µs / 6.07 kB | 3.07 µs / 4.51 kB | 1.30×, −26% alloc |
| `visit_key`, `parse` | — | unchanged | not touched |

The engine-level hoists (parse-once, normalize-once) aren't in the table — the orchestrator needs a Store and a network backend to bench honestly — but the `parse` row shows what each avoided call costs, and they are removals of provably redundant work.

## Byte-exactness

Differential over **150 cases**, all identical:

- **124 resolve combinations** (4 bases × 31 hrefs): relative, dotted, `../` overflowing the root, root-absolute, protocol-relative, absolute, non-HTTP schemes (`mailto:`/`javascript:`/`ftp:`/`x:y`), empty and blank, query-only, encoded `%2e%2e`, embedded spaces, unicode paths.
- **22 `fold_segment` shapes**: uppercase UUID, shape-only non-dates (`1234-56-78`), hex at and just below the 12-char floor, CJK, accented, `v1.2.3`.
- `template_key` / `visit_key` / `normalize` / `dir_of` over 4 URLs.

## Test

Suite: **2353 examples, 0 failures**. Format and ameba clean on the touched files (`engine.cr` has two spots of pre-existing formatter drift, present at HEAD and untouched here).