### PR TITLE
docs: nav install + GitHub links, unify flow-list image sizes

### DIFF
--- a/docs/i18n/en.toml
+++ b/docs/i18n/en.toml
@@ -4,6 +4,7 @@
 
 [nav]
 start = "Start"
+install = "Install"
 guide = "Guide"
 reference = "Reference"
 search = "Search"

--- a/docs/i18n/ko.toml
+++ b/docs/i18n/ko.toml
@@ -4,6 +4,7 @@
 
 [nav]
 start = "시작하기"
+install = "설치"
 guide = "가이드"
 reference = "레퍼런스"
 search = "검색"

--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -488,6 +488,7 @@ img {
   background: rgb(var(--ink-rgb) / 0.09);
 }
 
+.github-link,
 .theme-toggle {
   display: inline-flex;
   align-items: center;
@@ -500,15 +501,18 @@ img {
   background: rgb(var(--ink-rgb) / 0.055);
   color: var(--muted);
   cursor: pointer;
+  text-decoration: none;
   transition: transform var(--transition), border-color var(--transition), background var(--transition), color var(--transition);
 }
 
+.github-link:hover,
 .theme-toggle:hover {
   border-color: var(--line-strong);
   background: rgb(var(--ink-rgb) / 0.09);
   color: var(--accent-strong);
 }
 
+.github-link svg,
 .theme-toggle svg {
   width: 1.05rem;
   height: 1.05rem;
@@ -534,6 +538,7 @@ img {
    against its neighbours, so they answer a press with fill, not movement. */
 .search-trigger:active,
 .theme-toggle:active,
+.github-link:active,
 .button:active {
   transform: translateY(1px) scale(0.99);
 }
@@ -1030,6 +1035,13 @@ kbd {
   border-bottom: 1px solid var(--line);
 }
 
+/* Even rows mirror the layout (screenshot on the left). The columns are swapped
+   too so the screenshot keeps the wide 1.18fr track — otherwise `order` would
+   drop it into the narrow track and it would render smaller than its neighbours. */
+.flow-list > div:nth-child(even) {
+  grid-template-columns: minmax(0, 1.18fr) minmax(0, 0.82fr);
+}
+
 .flow-list > div:nth-child(even) .flow-shot {
   order: -1;
 }
@@ -1044,14 +1056,24 @@ kbd {
   max-width: 34ch;
 }
 
+/* Every shot is framed to the same 1206:520 box so the three steps read as one
+   uniform set. The Fuzzer capture is taller (34 rows vs 26), so it is cropped
+   from the top — the marked request and payload config stay in view, only the
+   empty results/hint strip at the bottom is trimmed. */
 .flow-shot {
   margin: 0;
+  aspect-ratio: 1206 / 520;
+  overflow: hidden;
+  border-radius: 8px;
+  box-shadow: 0 18px 44px rgb(0 0 0 / 0.42);
 }
 
 .flow-shot img {
+  display: block;
   width: 100%;
-  height: auto;
-  filter: drop-shadow(0 18px 44px rgb(0 0 0 / 0.42));
+  height: 100%;
+  object-fit: cover;
+  object-position: top;
 }
 
 /* --- Hand it to an agent (the MCP seam) ------------------------------- */
@@ -2556,7 +2578,8 @@ html.search-lock body {
     grid-template-columns: 1fr;
   }
 
-  .flow-list > div {
+  .flow-list > div,
+  .flow-list > div:nth-child(even) {
     grid-template-columns: 1fr;
     gap: 1.1rem;
   }

--- a/docs/templates/partials/nav.html
+++ b/docs/templates/partials/nav.html
@@ -5,6 +5,7 @@
   </a>
   <nav class="top-nav" aria-label="{{ "a11y.primary_nav" | t }}">
     <a href="{{ base_url }}{{ lang_prefix }}/getting-started/"{% if page.section == "getting-started" %} class="active" aria-current="true"{% endif %}>{{ "nav.start" | t }}</a>
+    <a href="{{ base_url }}{{ lang_prefix }}/getting-started/installation/">{{ "nav.install" | t }}</a>
     <a href="{{ base_url }}{{ lang_prefix }}/guide/"{% if page.section == "guide" %} class="active" aria-current="true"{% endif %}>{{ "nav.guide" | t }}</a>
     <a href="{{ base_url }}{{ lang_prefix }}/reference/"{% if page.section == "reference" %} class="active" aria-current="true"{% endif %}>{{ "nav.reference" | t }}</a>
   </nav>
@@ -33,6 +34,9 @@
       <span>{{ "nav.search" | t }}</span>
       <kbd>&#8984;K</kbd>
     </button>
+    <a class="github-link" href="https://github.com/hahwul/gori" target="_blank" rel="noopener noreferrer" aria-label="{{ "nav.github" | t }}" title="{{ "nav.github" | t }}">
+      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.37.5 0 5.87 0 12.5c0 5.3 3.44 9.8 8.21 11.39.6.11.82-.26.82-.58 0-.29-.01-1.05-.02-2.06-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.2.09 1.84 1.24 1.84 1.24 1.07 1.84 2.81 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.12-.3-.54-1.52.12-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.28-1.55 3.29-1.23 3.29-1.23.66 1.66.24 2.88.12 3.18.77.84 1.24 1.91 1.24 3.22 0 4.61-2.8 5.62-5.48 5.92.43.37.81 1.1.81 2.22 0 1.6-.01 2.9-.01 3.29 0 .32.22.7.83.58C20.57 22.29 24 17.79 24 12.5 24 5.87 18.63.5 12 .5z"/></svg>
+    </a>
     <button id="themeToggle" class="theme-toggle" type="button" aria-label="{{ "a11y.toggle_theme_aria" | t }}" title="{{ "a11y.toggle_theme_title" | t }}">
       <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>


### PR DESCRIPTION
## Summary
Docs site improvements for the landing page and top navigation.

- **Nav — Install link.** Add an `Install` item to the top nav pointing at `/getting-started/installation/` (new `nav.install` i18n key in `en`/`ko`).
- **Nav — GitHub link.** Add a GitHub icon link to the header-right cluster (`https://github.com/hahwul/gori`), reusing the existing `.theme-toggle` icon-button styling and the `nav.github` label.
- **Landing flow-list — uniform image sizes.** The Fuzzer capture is shot at 34 rows vs 26 for the others (`capture.sh:143`), so its SVG is taller (1206×664 vs 1206×520) and rendered larger. Two fixes:
  - Even rows now swap their grid columns so the screenshot keeps the wide `1.18fr` track (previously `order: -1` dropped it into the narrow track, so the Test shot rendered smaller in width).
  - `.flow-shot` now frames every shot to a uniform `1206:520` box with `object-fit: cover; object-position: top`, so all three render identically. Top-aligned crop keeps the marked request (§0) and payload config; only the empty results/hint strip at the bottom is trimmed.

## Verification
- `hwaro build` succeeds (42 pages, no template errors).
- Rendered locally: nav shows `Start · Install · Guide · Reference` + GitHub icon; install/github hrefs correct.
- All three flow images measure **613×264** (equal width **and** height) in both **dark and light** themes (the light `tui/light/fuzzer.svg` variant swaps in and matches too).
- Zigzag layout and mobile single-column reset preserved.

## Note
Matching sizes trims the Fuzzer screenshot's bottom ~22% (empty results table, `^R run` hint popup, status bar) — inherent to normalizing different aspect ratios; the meaningful content stays in view.