### PR TITLE
fix(repeater): stop reconcile from resetting the Request caret in READ mode

### DIFF
--- a/spec/tui/repeater_view_spec.cr
+++ b/spec/tui/repeater_view_spec.cr
@@ -323,6 +323,34 @@ describe Gori::Tui::RepeaterView do
     view.request_text.includes?("Content-Length: 99").should be_false
   end
 
+  # Reconcile fires on every capture-driven data_version tick. The editor holds LF (set_text
+  # strips \r) but the store may hold wire CRLF (MCP create_repeater / import / a peer), so a
+  # naive request_text == row.request compare was LF-vs-CRLF false EVERY poll → apply_peer_request
+  # → set_text → request caret slammed to the top of the pane (only visible in READ mode; INS
+  # locks the tab out of reconcile). request_side_matches? must normalize CRLF so reconcile skips.
+  it "request_side_matches? treats a CRLF-stored request as equal to the LF editor buffer" do
+    view = RepeaterView.new
+    view.restore("https://h.test", "GET /a HTTP/1.1\nHost: h.test\n\n", false, false)
+    crlf_row = "GET /a HTTP/1.1\r\nHost: h.test\r\n\r\n"
+    view.request_side_matches?("https://h.test", crlf_row, false, false, nil).should be_true
+  end
+
+  # A soft reconcile sync that only touched a non-text field (here: the http2 flag) must not
+  # rewrite the editor — set_text zeroes the caret + scroll and clears undo. Guarded like
+  # FuzzerView#apply_peer_session / NotesView#soft_merge_from.
+  it "apply_peer_request keeps the request caret when only a non-text field changed" do
+    view = RepeaterView.new
+    view.restore("https://h.test", "GET /aaa HTTP/1.1\nHost: h.test\nX-A: 1\nX-B: 2\n\n", false, false)
+    view.pane_advance(1)      # :target → :request
+    view.goto_request_line(3) # caret at "X-A: 1", col 0
+    # Same request (as wire CRLF), only http2 flipped → text unchanged → set_text skipped.
+    view.apply_peer_request("https://h.test",
+      "GET /aaa HTTP/1.1\r\nHost: h.test\r\nX-A: 1\r\nX-B: 2\r\n\r\n", true, false)
+    view.edit_insert('Z')
+    view.request_text.includes?("ZX-A: 1").should be_true # caret preserved mid-buffer
+    view.request_text.includes?("ZGET").should be_false   # NOT reset to the top
+  end
+
   it "sends a lone § (no complete §…§ region) verbatim — byte-identical to today" do
     view = RepeaterView.new
     # a single § doesn't form a §…§ region, so there's nothing to render — sent as typed.

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -1024,9 +1024,15 @@ module Gori::Tui
     # True when the live view's request-side fields match a store row (reconcile skip).
     # Normalizes empty SNI: view.sni_override is nil when blank, but older/peer rows
     # may store "" — those must compare equal or every poll re-applies needlessly.
+    # Normalizes CRLF→LF on the request: the TextArea holds LF (set_text strips \r) but
+    # the store may hold wire CRLF (MCP create_repeater / import / a peer). Without this
+    # the compare is LF-vs-CRLF false EVERY poll, so reconcile re-applies apply_peer_request
+    # → set_text on every capture tick — which slams the request caret back to the top of
+    # the pane in READ mode (INS locks the tab out of reconcile, so it looked NOR-only).
+    # Mirrors FuzzerView#session_side_matches?.
     def request_side_matches?(target : String, request : String, http2 : Bool, auto_cl : Bool,
                               sni : String?) : Bool
-      @target == target && request_text == request &&
+      @target == target && request_text == normalize_lf(request) &&
         @http2 == http2 && @auto_content_length == auto_cl &&
         (sni_override || "") == (sni || "")
     end
@@ -1046,18 +1052,30 @@ module Gori::Tui
       if is_ws
         @ws_mode = true
         @ws_upgrade = request.to_slice
-        @editor.set_text(request)
-        msgs = ws_messages || [] of String
-        @decoded.set_text(msgs.join('\n'))
+        # Only rewrite the editor when the text ACTUALLY changed: set_text resets the caret
+        # + scroll and clears the undo stack, so a soft reconcile poll (apply_peer_request)
+        # that only touched a non-text field must not disturb the pane. Compare on a
+        # CRLF-normalized basis (the editor is LF; the store may be CRLF). Mirrors
+        # FuzzerView#apply_peer_session / NotesView#soft_merge_from.
+        @editor.set_text(request) if @editor.text != normalize_lf(request)
+        joined = (ws_messages || [] of String).join('\n')
+        @decoded.set_text(joined) if @decoded.text != normalize_lf(joined)
         @req_pane = :decoded
       else
         @ws_mode = false
-        @editor.set_text(request)
+        @editor.set_text(request) if @editor.text != normalize_lf(request)
       end
 
       @auto_content_length = auto_cl
       @loaded = true
       @dirty = false
+    end
+
+    # Wire CRLF → editor LF. The TextArea always stores LF (set_text strips \r), so a
+    # request/message that arrives CRLF (store, MCP, import, peer) must be normalized
+    # before comparing against editor text — else the compare is falsely unequal.
+    private def normalize_lf(s : String) : String
+      s.gsub("\r\n", "\n").gsub('\r', '\n')
     end
 
     # Re-seed the captured-original diff baseline for a ^R-from-History tab that was


### PR DESCRIPTION
## Problem

In the TUI **Repeater** tab, placing the cursor in the middle of the Request pane in **READ (NOR) mode** and waiting a moment forced the caret back to the very top. It happened repeatedly during traffic capture and was **NOR-only** (INS mode was fine).

## Root cause

The capture-driven `reconcile` poll (fires on every `data_version` bump) skips a tab when `request_side_matches?` returns true. That check compared `request_text == request`, but:

- The `TextArea` always stores **LF** (`set_text` strips `\r`).
- The store can hold **wire CRLF** — rows created via MCP `create_repeater`, import, or a peer.

So the compare was LF-vs-CRLF **false on every poll** → `apply_peer_request` → `set_text` → caret reset to `(0,0)`. INS mode was safe because `pane_insert?(:request)` locks the tab out of reconcile (`repeater_tab_locked?`); READ mode isn't locked.

Confirmed empirically: **every** stored repeater request in the sample DBs is CRLF (demo 4/4, brunch-test 1/1, LF-only 0).

## Fix (`src/gori/tui/repeater_view.cr`)

Two layers, both mirroring existing sibling-view patterns:

1. **Root cause** — `request_side_matches?` normalizes CRLF→LF on the request (mirrors `FuzzerView#session_side_matches?`). Reconcile now skips unchanged rows, which also stops the per-poll undo-stack clobber.
2. **Symptom guard** — `apply_request_fields` only calls `set_text` when the text actually changed (mirrors `FuzzerView#apply_peer_session` / `NotesView#soft_merge_from`), so a soft sync touching only a non-text field never disturbs the caret.

## Similar-bug survey

- **Fuzzer**, **Notes** — already guarded (no change needed).
- **Miner**, **Sequencer** — store bytes, no inline editor caret (not affected).
- `on_external_change` list views — reload with anchor-preserved selection (no editor caret).

Repeater was the only outlier.

## Verification

- 2 regression specs added; full repeater/fuzzer/notes/miner/text_area suite green (225 examples, 0 failures).
- **Negative control**: reverting the fix makes both new specs fail.
- **Real-data check**: ran the real `restore → reflect_content_length_in_editor → request_text` path against actual CRLF rows under the `auto_content_length=true` default — passes with the fix, fails without it.