### PR TITLE
fix(proxy): serve CA cert page to LAN clients under a 0.0.0.0 bind

### DIFF
--- a/spec/proxy/upstream_spec.cr
+++ b/spec/proxy/upstream_spec.cr
@@ -94,4 +94,63 @@ describe Gori::Proxy::Upstream do
       Gori::Proxy::Upstream.split_host_port("::1", 443).should eq({"::1", 443})
     end
   end
+
+  # The self-page / self-loop detection. The interesting case is a WILDCARD bind
+  # (0.0.0.0 / ::): the proxy answers on every interface, so a request whose Host
+  # names the LAN/interface IP the client connected through is the proxy itself —
+  # but "0.0.0.0" alone can't see that. `local_host` (the accepted socket's local
+  # address) supplies the concrete IP that makes the match work.
+  describe ".addresses_self?" do
+    it "recognises the LAN IP a device reached a 0.0.0.0 listener on (via local_host)" do
+      Gori::Proxy::Upstream.addresses_self?(
+        "192.168.1.5", 8080, {"0.0.0.0", 8080}, local_host: "192.168.1.5").should be_true
+    end
+
+    it "does NOT recognise that LAN IP without local_host (pins the pre-fix behaviour)" do
+      # This is the bug: a mobile device hitting http://<LAN-IP>:port/ against a
+      # 0.0.0.0 bind was neither served the self-page nor refused — it looped.
+      Gori::Proxy::Upstream.addresses_self?(
+        "192.168.1.5", 8080, {"0.0.0.0", 8080}).should be_false
+    end
+
+    it "still treats loopback as self under a wildcard bind (regression guard)" do
+      Gori::Proxy::Upstream.addresses_self?("127.0.0.1", 8080, {"0.0.0.0", 8080}).should be_true
+      Gori::Proxy::Upstream.addresses_self?("localhost", 8080, {"0.0.0.0", 8080}).should be_true
+    end
+
+    it "matches an IPv6 interface address under a :: bind, stripping Host brackets" do
+      Gori::Proxy::Upstream.addresses_self?(
+        "[fe80::1]", 8080, {"::", 8080}, local_host: "fe80::1").should be_true
+    end
+
+    it "is scoped to the listener port" do
+      Gori::Proxy::Upstream.addresses_self?(
+        "192.168.1.5", 9999, {"0.0.0.0", 8080}, local_host: "192.168.1.5").should be_false
+    end
+
+    it "does not match an unrelated host even when local_host is known" do
+      Gori::Proxy::Upstream.addresses_self?(
+        "example.com", 8080, {"0.0.0.0", 8080}, local_host: "192.168.1.5").should be_false
+    end
+
+    it "matches a concrete (non-wildcard) bind by literal host, local_host irrelevant" do
+      Gori::Proxy::Upstream.addresses_self?("127.0.0.1", 8080, {"127.0.0.1", 8080}).should be_true
+    end
+  end
+
+  describe ".loops_to_self?" do
+    it "refuses a forward to the LAN IP of a 0.0.0.0 listener (via local_host)" do
+      Gori::Proxy::Upstream.loops_to_self?(
+        "192.168.1.5", 8080, nil, {"0.0.0.0", 8080}, local_host: "192.168.1.5").should be_true
+    end
+
+    it "still catches a loopback self-loop under a wildcard bind" do
+      Gori::Proxy::Upstream.loops_to_self?("127.0.0.1", 8080, nil, {"0.0.0.0", 8080}).should be_true
+    end
+
+    it "leaves a real external host on the same port alone" do
+      Gori::Proxy::Upstream.loops_to_self?(
+        "example.com", 8080, nil, {"0.0.0.0", 8080}, local_host: "192.168.1.5").should be_false
+    end
+  end
 end

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -36,7 +36,8 @@ module Gori::Proxy
                    @tls_upstream : Bool = false, @verify_upstream : Bool = true,
                    @rewriter : HeadRewriter? = nil, @interceptor : Gori::Interceptor? = nil,
                    @host_overrides : Gori::HostOverrides? = nil,
-                   @self_addr : {String, Int32}? = nil)
+                   @self_addr : {String, Int32}? = nil,
+                   @local_host : String? = nil)
       # Per-connection upstream reuse (see `acquire_upstream`). One live origin
       # connection kept across this client's keep-alive requests.
       @upstream = nil.as(IO?)
@@ -134,7 +135,7 @@ module Gori::Proxy
       # proxy-configured browser) that targets self is a genuine loop and still 502s.
       # Not recorded as a flow — it's a local UI hit, not proxied traffic.
       if (sa = @self_addr) && (tls = @tls) && tls.serve_landing? &&
-         origin_form?(req) && get_or_head?(req) && Upstream.addresses_self?(host, port, sa)
+         origin_form?(req) && get_or_head?(req) && Upstream.addresses_self?(host, port, sa, @local_host)
         serve_self_page(req, tls, sa)
         return false
       end
@@ -142,7 +143,7 @@ module Gori::Proxy
       # Refuse to forward a request whose (override-resolved) target is gori's own
       # listener — otherwise gori dials itself, accepts that as a new client, and
       # loops forever. Record it as a visible error instead.
-      if (sa = @self_addr) && Upstream.loops_to_self?(host, port, @host_overrides, sa)
+      if (sa = @self_addr) && Upstream.loops_to_self?(host, port, @host_overrides, sa, @local_host)
         record_error(req, scheme, host, port, created_at, "refusing to proxy to self (loop): #{host}:#{port}")
         write_gateway_error
         return false
@@ -772,7 +773,7 @@ module Gori::Proxy
 
       # A CONNECT whose (override-resolved) authority is gori's own listener would
       # loop the proxy into itself — refuse before answering 200 / starting MITM.
-      if (sa = @self_addr) && Upstream.loops_to_self?(host, port, @host_overrides, sa)
+      if (sa = @self_addr) && Upstream.loops_to_self?(host, port, @host_overrides, sa, @local_host)
         write_gateway_error
         return false
       end
@@ -1062,9 +1063,12 @@ module Gori::Proxy
     # just drops the connection like every other canned response here.
     private def serve_self_page(req : Codec::RawRequest, tls : TlsMitm, self_addr : {String, Int32}) : Nil
       head_only = req.method.compare("HEAD", case_insensitive: true) == 0
+      # Show the concrete address the device actually reached us on rather than a
+      # wildcard "0.0.0.0" — under a wildcard bind that's the friendlier, truthful value.
+      listen = (lh = @local_host) ? {lh, self_addr[1]} : self_addr
       resp = SelfPage.respond(req.target,
         pem: tls.ca_cert_pem, der: tls.ca_cert_der, spki: tls.ca_spki_sha256,
-        ca_path: tls.ca_cert_path, listen: self_addr, version: Gori::VERSION, head_only: head_only)
+        ca_path: tls.ca_cert_path, listen: listen, version: Gori::VERSION, head_only: head_only)
       @io.write(resp)
       @io.flush
     rescue

--- a/src/gori/proxy/server.cr
+++ b/src/gori/proxy/server.cr
@@ -134,8 +134,15 @@ module Gori::Proxy
         # and relaxes both on entering a WS/SSE/CONNECT/h2 tunnel.
         SocketTuning.enable_keepalive(client)
         SocketTuning.arm(client, SocketTuning::CLIENT_IO_TIMEOUT)
+        # The concrete address this client reached us on. Under a wildcard bind
+        # (0.0.0.0 / ::) it's the LAN/interface IP the device connected through —
+        # the signal that lets addresses_self?/loops_to_self? recognise a Host that
+        # names that IP as the proxy itself (self-page + loop refusal). Best-effort:
+        # a peer that RST'd between accept and here makes local_address raise, which
+        # the rescue below turns into a clean close.
+        local_host = (client.local_address.address rescue nil)
         ClientConn.new(client, "http", @sink, @tls, rewriter: @rewriter, interceptor: @interceptor,
-          host_overrides: @host_overrides, self_addr: {@host, @port}).run
+          host_overrides: @host_overrides, self_addr: {@host, @port}, local_host: local_host).run
       rescue
         # Setup (setsockopt) can raise if the peer RST'd between accept and here;
         # ClientConn never took ownership, so close the accepted fd ourselves or

--- a/src/gori/proxy/upstream.cr
+++ b/src/gori/proxy/upstream.cr
@@ -43,12 +43,20 @@ module Gori::Proxy
     # target, dials itself again…). Triggered when a hostname override — or a request
     # Host — points at the proxy's own bind. Only a matching port on a loopback/self
     # address counts, so proxying a real external host on the same port is unaffected.
+    #
+    # `local_host` is the concrete address the client actually reached us on
+    # (the accepted socket's local address). Under a wildcard bind (0.0.0.0 / ::)
+    # the proxy answers on EVERY interface, so a Host that matches the LAN/interface
+    # IP the client connected through is just as much "self" as loopback is —
+    # `self_addr[0]` alone ("0.0.0.0") can't see that. Nothing else can be bound on
+    # that IP:port, so matching it never refuses legitimate traffic.
     def self.loops_to_self?(host : String, port : Int32, overrides : Gori::HostOverrides?,
-                            self_addr : {String, Int32}) : Bool
+                            self_addr : {String, Int32}, local_host : String? = nil) : Bool
       return false unless port == self_addr[1]
       target = normalize_host(connect_target(host, overrides))
       bind = normalize_host(self_addr[0])
       return true if target == bind
+      return true if local_host && target == normalize_host(local_host)
       loopback?(target) && (loopback?(bind) || wildcard?(bind))
     end
 
@@ -57,12 +65,16 @@ module Gori::Proxy
     # Same loopback/wildcard/port-scoped test as loops_to_self? but WITHOUT the hostname-
     # override step, so an override that happens to point a real domain at the bind still
     # falls through to the 502 self-loop refusal (the user meant that mapped host, not the
-    # welcome page) rather than getting the landing page.
-    def self.addresses_self?(host : String, port : Int32, self_addr : {String, Int32}) : Bool
+    # welcome page) rather than getting the landing page. `local_host` — see loops_to_self?:
+    # the concrete IP the client reached us on, which is what makes the landing page work
+    # for a device hitting `http://<LAN-IP>:port/` against a 0.0.0.0 listener.
+    def self.addresses_self?(host : String, port : Int32, self_addr : {String, Int32},
+                             local_host : String? = nil) : Bool
       return false unless port == self_addr[1]
       target = normalize_host(host)
       bind = normalize_host(self_addr[0])
       return true if target == bind
+      return true if local_host && target == normalize_host(local_host)
       loopback?(target) && (loopback?(bind) || wildcard?(bind))
     end
 


### PR DESCRIPTION
## Problem

With the proxy bound to `0.0.0.0` (the setup you'd use to let phones/tablets reach it over the LAN), mobile devices connect to `http://<LAN-IP>:port/` but **can't download the CA certificate** — the self-serve landing page never appears.

## Root cause

`Upstream.addresses_self?` / `loops_to_self?` were only given the **bind string** (`{"0.0.0.0", port}`). A device reaches the listener on the machine's LAN IP (e.g. `192.168.1.5`), which is neither loopback, nor `0.0.0.0`, nor a literal match — so:

- `addresses_self?` → `false` → the CA-download self-page is **not** served
- `loops_to_self?` → `false` → gori forwards `GET /` to `<LAN-IP>:port` = **itself** → self-loop

Under a wildcard bind the proxy answers on *every* interface, so a `Host` naming the interface IP the client connected through is just as much "self" as loopback — but the bind string alone can't see that.

## Fix

Thread the accepted socket's local address (`client.local_address.address` — the concrete IP the client actually reached us on) into both helpers as an **additive** match clause.

- Strict addition — loopback-under-wildcard and concrete binds behave exactly as before (regression-guarded by tests).
- No false-positive risk: nothing else can be bound on that `IP:port`, so matching it never refuses legitimate traffic. It also *fixes* loop detection for a proxy-configured client targeting the wildcard listener's LAN IP (previously slipped through and looped; now cleanly refused).
- Landing page's "Listening on" line now shows the concrete reached address instead of `0.0.0.0`.

## Tests

- 10 new unit tests for `addresses_self?` / `loops_to_self?` covering: LAN-IP-under-wildcard (the bug), the pre-fix behaviour pinned as `false` without `local_host`, loopback-under-wildcard regression guard, IPv6 `::`, port scoping, and no-false-positive on an unrelated host.
- `spec/proxy/` → **223 examples, 0 failures**. Full type-check + `crystal tool format --check` pass.

## Follow-up (out of scope)

This fixes the **direct-hit** flow (device with no proxy configured types the IP), which is the documented/designed mobile cert path. If a device configures the proxy *first* and then browses to the cert URL, the request is absolute-form and now gets a clean `502` (instead of looping) but still no cert — serving the cert in that flow would need a magic-host route (mitmproxy `mitm.it`-style). Tracked as a separate feature.