### PR TITLE
fix(tui): keep tab/control chars as one editor cell (#278)

### DIFF
--- a/spec/tui/foundation_spec.cr
+++ b/spec/tui/foundation_spec.cr
@@ -46,6 +46,27 @@ describe Gori::Tui::Screen do
     Screen.column_width("日本").should eq(4) # CJK: 2 columns each, same as display_width
   end
 
+  it "grapheme_cols floors a tab to 1 so draw advance matches the caret model" do
+    # display_width is pure Unicode (tab = 0); grapheme_cols / column_width keep the
+    # space cell Screen#cell substitutes for C0 controls (issue #278).
+    Screen.display_width("\t").should eq(0)
+    Screen.grapheme_cols("\t").should eq(1)
+    Screen.column_width("a\tb").should eq(3)
+    Screen.column_width_upto("a\tb", 10).should eq(3)
+    Screen.column_width_upto("a\tb", 2).should eq(2)
+  end
+
+  it "text draws a tab as a one-column space (ASCII and mixed paths)" do
+    # ASCII fast path
+    b1 = MemoryBackend.new(10, 1)
+    Screen.new(b1).text(0, 0, "a\tb", Theme.text)
+    b1.row(0).rstrip.should eq("a b")
+    # Non-ASCII path (any multibyte glyph forces grapheme walk) still keeps the tab cell
+    b2 = MemoryBackend.new(10, 1)
+    Screen.new(b2).text(0, 0, "a\t가", Theme.text)
+    b2.row(0).rstrip.should eq("a 가")
+  end
+
   it "fit truncates a too-wide string with an ellipsis and returns a fitting one whole" do
     screen = Screen.new(MemoryBackend.new(10, 1))
     screen.fit("hello", 10).should eq("hello")   # fits → unchanged

--- a/spec/tui/highlight_spec.cr
+++ b/spec/tui/highlight_spec.cr
@@ -364,6 +364,30 @@ describe Gori::Tui::Highlight do
       Highlight.draw(Screen.new(b), 0, 0, [Highlight::Span.new("hi", Theme.text)], width: 0)
       b.row(0).strip.should eq("")
     end
+
+    it "keeps a tab as one space cell so it matches Screen#text (issue #278)" do
+      # A span with an embedded tab is NOT printable_ascii?, so draw takes the grapheme
+      # path. That path must floor width-0 controls to 1 and substitute a space — same
+      # as Screen#text's Char path — or the styled editor collapses "x,\ty" to "x,y"
+      # while the caret still steps across the missing cell.
+      {"x,\ty", "a\tb", "{\"a\":1,\t\"b\":2}"}.each do |str|
+        plain = MemoryBackend.new(24, 1)
+        px = Screen.new(plain).text(0, 0, str, Theme.text)
+        hl = MemoryBackend.new(24, 1)
+        hx = Highlight.draw(Screen.new(hl), 0, 0, [Highlight::Span.new(str, Theme.text)], width: 24)
+        hl.row(0).should eq(plain.row(0)) # same glyphs (str=#{str.inspect})
+        hx.should eq(px)                  # same advance
+        # Explicit layout: tab → space, neighbours unmoved
+        expected = str.gsub('\t', ' ')
+        hl.row(0).rstrip.should eq(expected)
+      end
+    end
+
+    it "line_width counts a tab as one column" do
+      line = [Highlight::Span.new("a\tb", Theme.text)]
+      Highlight.line_width(line).should eq(3)
+      Highlight.line_width_upto(line, 10).should eq(3)
+    end
   end
 
   # The body tokenizers were rewritten from `raw.chars` + `.join` to a byte-scan. These

--- a/spec/tui/text_area_spec.cr
+++ b/spec/tui/text_area_spec.cr
@@ -30,7 +30,57 @@ private def render_concealed(text : String, conceal : Array({Int32, Int32}), cx 
   backend
 end
 
+# Issue #278 helpers: request-highlighted TextArea (Repeater-style) at a given caret col.
+private def render_req_tab(text : String, cx : Int32, cursor : Bool = true) : MemoryBackend
+  ta = Gori::Tui::TextArea.new(text)
+  ta.move(0, cx)
+  b = MemoryBackend.new(40, 3)
+  ta.render(Gori::Tui::Screen.new(b), Gori::Tui::Rect.new(0, 0, 40, 3),
+    cursor: cursor, highlight: :request)
+  b
+end
+
 describe Gori::Tui::TextArea do
+  # Issue #278: syntax-highlighted editors (Repeater request) used to collapse `\t` to
+  # zero columns in Highlight.draw while the caret advanced by column_width (≥1), so
+  # parking the caret on a tab overwrote the next glyph ("pushed characters together").
+  describe "tab / zero-width control cells (issue #278)" do
+    it "draws an embedded tab as a space without collapsing neighbours" do
+      b = render_req_tab("x,\ty", 0, cursor: false)
+      b.row(0).rstrip.should eq("x, y")
+    end
+
+    it "keeps the next glyph visible when the caret sits on the tab" do
+      # Before the fix: Highlight collapsed the tab, caret painted a space at col 2 → "x,"
+      # (the 'y' was overwritten). After: "x, y" with the space under the caret.
+      b = render_req_tab("x,\ty", 2, cursor: true) # cx on '\t'
+      b.row(0).rstrip.should eq("x, y")
+      b.row(0)[2].should eq(' ') # tab cell
+      b.row(0)[3].should eq('y') # neighbour intact
+    end
+
+    it "does not double-paint the next glyph when the caret is just past the tab" do
+      # Before: caret at cx=3 used column_width prefix=3 on a 2-col collapsed draw → "x,yy"
+      b = render_req_tab("x,\ty", 3, cursor: true) # cx on 'y'
+      b.row(0).rstrip.should eq("x, y")
+      b.row(0)[0, 4].should eq("x, y")
+    end
+
+    it "handles a JSON body with a tab after a comma (the issue screenshot case)" do
+      body = "{\"a\":1,\t\"b\":2}"
+      tab_i = body.index('\t').not_nil!
+      # No caret: tab is a space cell, not deleted
+      render_req_tab(body, 0, cursor: false).row(0).rstrip.should eq("{\"a\":1, \"b\":2}")
+      # Caret on the tab: does not swallow the following quote
+      on_tab = render_req_tab(body, tab_i, cursor: true)
+      on_tab.row(0).rstrip.should eq("{\"a\":1, \"b\":2}")
+      on_tab.row(0)[tab_i + 1].should eq('"')
+      # Caret after the tab: no doubled quote
+      after = render_req_tab(body, tab_i + 1, cursor: true)
+      after.row(0).rstrip.should eq("{\"a\":1, \"b\":2}")
+    end
+  end
+
   describe "display concealment (@conceal_spans)" do
     # "q=§data¦base64-encode§ x": open § at 2, ¦ at 7, closing § at 21.
     text = "q=§data¦base64-encode§ x"

--- a/src/gori/tui/highlight.cr
+++ b/src/gori/tui/highlight.cr
@@ -414,8 +414,13 @@ module Gori::Tui
       if limit == 1
         if line.any? && !line[0].text.empty?
           first = line[0].text.each_grapheme.first.to_s
-          screen.cell(x, y, first, line[0].fg, bg, line[0].attr)
-          return x + Screen.display_width(first)
+          # Char path so a leading C0 control becomes the space cell (not rejected).
+          if first.size == 1
+            screen.cell(x, y, first[0], line[0].fg, bg, line[0].attr)
+          else
+            screen.cell(x, y, first, line[0].fg, bg, line[0].attr)
+          end
+          return x + Screen.grapheme_cols(first)
         end
         return x
       end
@@ -426,6 +431,8 @@ module Gori::Tui
       # glyphs, so its width is its char count: skip the grapheme walk (and its per-glyph
       # `g.to_s` String) entirely, mirroring Screen#text's ASCII fast path. Mixed lines
       # stay correct — width accumulates across spans regardless of which branch each takes.
+      # Non-printable spans use `grapheme_cols` (≥1) so an embedded tab still counts as a
+      # cell — same floor as Screen#text / the editor caret (issue #278).
       overflow = false
       acc = 0
       line.each do |span|
@@ -438,7 +445,7 @@ module Gori::Tui
           acc += t.size
         else
           t.each_grapheme do |g|
-            acc += Termisu::UnicodeWidth.grapheme_width(g.to_s)
+            acc += Screen.grapheme_cols(g.to_s)
             if acc > limit
               overflow = true
               break
@@ -468,7 +475,8 @@ module Gori::Tui
           end
         else
           t.each_grapheme do |g|
-            gw = Termisu::UnicodeWidth.grapheme_width(g.to_s)
+            gs = g.to_s
+            gw = Screen.grapheme_cols(gs)
             # The FIRST grapheme that doesn't fit terminates ALL rendering — a single
             # continuous walk, so a later span can't resume into the leftover room and draw
             # a narrower glyph in place of the skipped wide one (Screen#fit glyph parity).
@@ -476,7 +484,14 @@ module Gori::Tui
               done = true
               break
             end
-            screen.cell(x + visual_col, y, g.to_s, span.fg, bg, span.attr)
+            # Single codepoint → Char path (C0 control → space via ASCII_CELL). Multi-
+            # codepoint clusters stay on the String path. Floor-to-1 above means a tab
+            # advances one column instead of collapsing the rest of the line leftward.
+            if gs.size == 1
+              screen.cell(x + visual_col, y, gs[0], span.fg, bg, span.attr)
+            else
+              screen.cell(x + visual_col, y, gs, span.fg, bg, span.attr)
+            end
             visual_col += gw
           end
         end
@@ -505,7 +520,10 @@ module Gori::Tui
           out << span
           next
         end
-        sw = Screen.display_width(span.text)
+        # column_width / grapheme_cols (not raw display_width): a control char still
+        # occupies a drawn cell after Highlight.draw's ≥1 floor, so h-scroll cuts must
+        # count it the same way or the styled slice drifts left of the caret.
+        sw = Screen.column_width(span.text)
         if acc + sw <= start_col # whole span is left of the cut
           acc += sw
           next
@@ -513,7 +531,7 @@ module Gori::Tui
         kept = String.build do |io|
           span.text.each_char do |ch|
             if cutting
-              w = Screen.display_width(ch.to_s)
+              w = Screen.grapheme_cols(ch.to_s)
               if acc + w <= start_col
                 acc += w
                 next
@@ -542,7 +560,7 @@ module Gori::Tui
       String.build do |io|
         s.each_char do |ch|
           if cutting
-            w = Screen.display_width(ch.to_s)
+            w = Screen.grapheme_cols(ch.to_s)
             if acc + w <= start_col
               acc += w
               next
@@ -589,21 +607,22 @@ module Gori::Tui
       out
     end
 
-    # Total display width of a styled line (sum of its spans) — used to clamp a
-    # horizontal scroll offset against the widest currently-visible row.
+    # Total column span of a styled line (sum of its spans, ≥1 per char) — used to
+    # clamp a horizontal scroll offset against the widest currently-visible row. Uses
+    # column_width so embedded tabs/controls match Highlight.draw's cell advance.
     def self.line_width(line : Line) : Int32
-      line.sum { |span| Screen.display_width(span.text) }
+      line.sum { |span| Screen.column_width(span.text) }
     end
 
     # As `line_width`, but stops summing once the running width reaches `limit` — and
     # caps WITHIN a span too (a huge minified body is one plain span > MAX_HL_LINE), so
     # the per-frame h-scroll clamp never fully measures a multi-MB line. See
-    # Screen.display_width_upto. Exact for lines narrower than limit.
+    # Screen.column_width_upto. Exact for lines narrower than limit.
     def self.line_width_upto(line : Line, limit : Int32) : Int32
       w = 0
       line.each do |span|
         break if w >= limit
-        w += Screen.display_width_upto(span.text, limit - w)
+        w += Screen.column_width_upto(span.text, limit - w)
       end
       w
     end

--- a/src/gori/tui/screen.cr
+++ b/src/gori/tui/screen.cr
@@ -234,6 +234,21 @@ module Gori::Tui
       w
     end
 
+    # As `column_width`, but stops once the running width reaches `limit`. Used by the
+    # editor h-scroll clamp so a multi-MB line with embedded tabs isn't fully walked
+    # every frame, while still counting each control char as one cell.
+    def self.column_width_upto(str : String, limit : Int32) : Int32
+      return 0 if str.empty? || limit <= 0
+      # ASCII: every char is exactly 1 column under column_width (controls floored).
+      return {str.size, limit}.min if str.ascii_only?
+      w = 0
+      str.each_char do |ch|
+        w += grapheme_cols(ch.to_s)
+        return w if w >= limit
+      end
+      w
+    end
+
     # The codepoint index in `str` whose display cell the column `target` lands on,
     # clamped to [0, str.size]. Inverts a left-to-right display-width advance (the
     # same one `display_width` / `text` use), so click-to-cursor maps a click x to
@@ -243,7 +258,7 @@ module Gori::Tui
       return 0 if target <= 0
       acc = 0
       str.each_char_with_index do |ch, j|
-        w = {display_width(ch.to_s), 1}.max
+        w = grapheme_cols(ch.to_s)
         return j if target < acc + w
         acc += w
       end
@@ -263,8 +278,17 @@ module Gori::Tui
       # (wide glyphs via display_width, combining marks floored to 1).
       return str.size if str.ascii_only?
       w = 0
-      str.each_char { |ch| w += {display_width(ch.to_s), 1}.max }
+      str.each_char { |ch| w += grapheme_cols(ch.to_s) }
       w
+    end
+
+    # Columns one grapheme occupies when drawn by `#text` / `Highlight.draw` and when the
+    # editor caret / click-to-cursor advance over it. Unicode width floored to ≥1 so a C0
+    # control (`\t`, `\r`, …) keeps the space cell that Char-path `cell` substitutes —
+    # matching `column_width` and preventing the styled draw path from collapsing a tab
+    # to zero columns while the caret still steps across it (issue #278).
+    def self.grapheme_cols(g : String) : Int32
+      {display_width(g), 1}.max
     end
 
     def cell(x : Int32, y : Int32, grapheme : Char | String, fg : Color, bg : Color = Theme.bg,
@@ -317,12 +341,21 @@ module Gori::Tui
         return x + i
       end
       # Non-ASCII (CJK/emoji/combining): grapheme-aware truncation + draw.
+      # `grapheme_cols` floors width-0 controls to 1 so a mixed line with an embedded
+      # tab advances the same way the ASCII fast path does (1 cell, space glyph).
       s = fit(str, limit)
       cur_x = x
       s.each_grapheme do |g|
-        gw = Termisu::UnicodeWidth.grapheme_width(g.to_s)
+        gs = g.to_s
+        gw = Screen.grapheme_cols(gs)
         break if cur_x + gw > @width
-        cell(cur_x, y, g.to_s, fg, bg, attr)
+        # Single-codepoint → Char path (C0 → space via ASCII_CELL); multi-codepoint
+        # clusters (emoji ZWJ, …) stay on the String path.
+        if gs.size == 1
+          cell(cur_x, y, gs[0], fg, bg, attr)
+        else
+          cell(cur_x, y, gs, fg, bg, attr)
+        end
         cur_x += gw
       end
       cur_x
@@ -358,14 +391,15 @@ module Gori::Tui
       overflow = false
       head = String.build do |io|
         str.each_grapheme do |g|
-          gw = Termisu::UnicodeWidth.grapheme_width(g.to_s)
+          gs = g.to_s
+          gw = Screen.grapheme_cols(gs) # ≥1 so a control byte keeps its cell under truncation too
           total += gw
           if total > w
             overflow = true
             break
           end
           if cur + gw <= w - 1
-            io << g.to_s
+            io << gs
             cur += gw
           end
         end

--- a/src/gori/tui/search_hi.cr
+++ b/src/gori/tui/search_hi.cr
@@ -22,11 +22,13 @@ module Gori::Tui
       # src[0, i] per match (was O(line²) on token-dense lines during a search).
       acc = 0
       while (i = dt.index(q, pos))
-        acc += Screen.display_width(src[pos, i - pos])
+        # column_width (not display_width): match the base draw / caret so a match after
+        # a tab or other zero-width control still lands on the right cell.
+        acc += Screen.column_width(src[pos, i - pos])
         col = x + acc
         seg = src[i, q.size]
         screen.text(col, y, seg, Theme.bg, Theme.yellow, width: {max_x - col, 0}.max) if col < max_x
-        acc += Screen.display_width(seg)
+        acc += Screen.column_width(seg)
         pos = i + q.size
       end
     end

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -542,7 +542,7 @@ module Gori::Tui
             r = @cx
             cr.each { |(a, b)| r = b if r >= a && r < b } if cr && !cr.empty?
             ch = @preedit.empty? ? (r < line.size ? line[r] : ' ') : @preedit[0]
-            cgw = [Screen.display_width(ch.to_s), 1].max
+            cgw = Screen.grapheme_cols(ch.to_s)
             (0...cgw).each do |off|
               break if cxs + off >= cx0 + cw # a wide-glyph caret at the last column must not spill its 2nd cell onto the pane border
               cch = (off == 0 ? ch : ' ')
@@ -604,13 +604,14 @@ module Gori::Tui
     end
 
     # Overlay the bg_regions intersecting THIS line. `off0` is the line's start offset
-    # in the full LF-joined buffer. Column math mirrors SearchHi.mark (same
-    # Screen.display_width as the base draw, so an ambiguous-width glyph can't drift the
-    # tint off the cells). Multi-line regions clamp to [0, line.size): first line tints
-    # col→EOL, fully-covered lines 0→size, last line BOL→col; the '\n' offset has no cell.
-    # Region columns are computed against the FULL (unscrolled) line, then shifted left by
-    # @xscroll and clipped to the visible window — a no-op when @xscroll == 0 (the common
-    # case, since only the Fuzzer template sets bg_regions and it doesn't enable follow_x).
+    # in the full LF-joined buffer. Column math mirrors the base draw + caret
+    # (Screen.column_width / grapheme_cols ≥1 per char, so a tab in a marker band can't
+    # drift the tint left of the cells). Multi-line regions clamp to [0, line.size): first
+    # line tints col→EOL, fully-covered lines 0→size, last line BOL→col; the '\n' offset
+    # has no cell. Region columns are computed against the FULL (unscrolled) line, then
+    # shifted left by @xscroll and clipped to the visible window — a no-op when
+    # @xscroll == 0 (the common case, since only the Fuzzer template sets bg_regions and
+    # it doesn't enable follow_x).
     private def paint_bg_regions(screen : Screen, cx0 : Int32, y : Int32, off0 : Int32,
                                  line : String, cw : Int32, cr : Array({Int32, Int32})? = nil) : Nil
       return if @bg_regions.empty? || @reveal # opt-in; reveal rewrites the glyphs
@@ -621,8 +622,8 @@ module Gori::Tui
         la = (a - off0).clamp(0, line.size)
         lb = (b - off0).clamp(0, line.size)
         next if la >= lb
-        start_col = Screen.display_width(line[0, la]) - @xscroll
-        end_col = Screen.display_width(line[0, lb]) - @xscroll
+        start_col = Screen.column_width(line[0, la]) - @xscroll
+        end_col = Screen.column_width(line[0, lb]) - @xscroll
         draw_from = {start_col, 0}.max
         draw_to = {end_col, cw}.min
         next if draw_from >= draw_to
@@ -652,7 +653,7 @@ module Gori::Tui
             i = hit[1] # skip the hidden run in one hop
             next
           end
-          w = Screen.display_width(line[i].to_s)
+          w = Screen.grapheme_cols(line[i].to_s)
           sx = cx0 + col - @xscroll
           if sx >= cx0 && sx < cx0 + cw
             accent = cr.any? { |(_, rb)| rb == i } # char immediately after a concealed run = closing §
@@ -706,18 +707,18 @@ module Gori::Tui
       w + Screen.column_width(line[pos...cx])
     end
 
-    # As `concealed_col` but in display_width columns (no ≥1 floor) — used by the band
-    # over-paint so its glyph columns line up with Highlight.draw's advance.
+    # As `concealed_col` — column_width / grapheme_cols semantics matching Highlight.draw's
+    # ≥1 floor, used by the band over-paint so tint columns line up with drawn cells.
     private def concealed_display_prefix(line : String, ranges : Array({Int32, Int32}), cx : Int32) : Int32
       w = 0
       pos = 0
       ranges.each do |(a, b)|
         break if a >= cx
-        w += Screen.display_width(line[pos...a]) if a > pos
+        w += Screen.column_width(line[pos...a]) if a > pos
         return w if b >= cx
         pos = b
       end
-      w + Screen.display_width(line[pos...cx])
+      w + Screen.column_width(line[pos...cx])
     end
 
     # Inverse of `concealed_col` for click-to-cursor: the raw char index whose concealed
@@ -734,7 +735,7 @@ module Gori::Tui
           i = hit[1]
           next
         end
-        w = {Screen.display_width(line[i].to_s), 1}.max
+        w = Screen.grapheme_cols(line[i].to_s)
         return i if target < col + w
         col += w
         i += 1


### PR DESCRIPTION
## Summary

- Fixes [#278](https://github.com/hahwul/gori/issues/278): in the Repeater request editor (and other syntax-highlighted TextAreas), an embedded TAB was drawn as Unicode width 0 while the caret advanced with `column_width` (≥1). Parking the caret on the tab overwrote the next glyph (“characters pushed together”).
- Introduce `Screen.grapheme_cols` / `column_width_upto` and use the ≥1 cell floor in `Highlight.draw`, `Screen#text` (non-ASCII path), h-scroll slice, search highlight, and marker band paint so draw and caret stay aligned.
- Control chars still render as a space cell (same as Char-path `cell` / ASCII_CELL); they are not expanded to tab-stops.

## Root cause

| Path | TAB width before |
|------|------------------|
| `Highlight.draw` grapheme path | 0 (`grapheme_width`) |
| Caret / `column_width` | 1 |
| `screen.text` ASCII path | 1 (space) |

Repeater request always uses `highlight: :request`, so it hit the collapsing path.

## Test plan

- [x] `crystal spec spec/tui/foundation_spec.cr spec/tui/highlight_spec.cr spec/tui/text_area_spec.cr`
- [x] `crystal spec spec/tui/repeater_view_spec.cr spec/tui/history_view_spec.cr`
- [ ] Manual: open Repeater, paste a body with a TAB after a comma (e.g. `{"a":1,<TAB>"b":2}`), move the caret onto and past the tab — neighbours should not collapse or double.
- [ ] Manual: toggle Reveal (`→` for tab) and confirm layout still lines up with the caret.
- [ ] Manual: CJK/emoji lines still render and move correctly (wide glyphs unchanged).