### PR TITLE
fix(proxy): close two self-loop guard gaps that wedge the proxy

### DIFF
--- a/spec/proxy/upstream_spec.cr
+++ b/spec/proxy/upstream_spec.cr
@@ -136,6 +136,52 @@ describe Gori::Proxy::Upstream do
     it "matches a concrete (non-wildcard) bind by literal host, local_host irrelevant" do
       Gori::Proxy::Upstream.addresses_self?("127.0.0.1", 8080, {"127.0.0.1", 8080}).should be_true
     end
+
+    # Gap 1: the OS routes a connect() to the all-zero address onto loopback, so a
+    # wildcard TARGET reaches us wherever a loopback target would.
+    it "treats a 0.0.0.0 target as self against a loopback bind" do
+      Gori::Proxy::Upstream.addresses_self?("0.0.0.0", 8080, {"127.0.0.1", 8080}).should be_true
+      Gori::Proxy::Upstream.addresses_self?("::", 8080, {"127.0.0.1", 8080}).should be_true
+      Gori::Proxy::Upstream.addresses_self?("0.0.0.0", 8080, {"0.0.0.0", 8080}).should be_true
+    end
+
+    # Gap 2: ::0 / 0:0:0:0:0:0:0:0 bind as full wildcards and Settings.bind_host_error
+    # accepts them, but the old literal test only knew "0.0.0.0"/"::" — so the self-page
+    # vanished under such a bind.
+    it "recognises loopback under the expanded all-zero IPv6 binds" do
+      {"::0", "0:0:0:0:0:0:0:0", "0000:0000:0000:0000:0000:0000:0000:0000"}.each do |bind|
+        Gori::Proxy::Upstream.addresses_self?("localhost", 8080, {bind, 8080}).should be_true
+        Gori::Proxy::Upstream.addresses_self?("::1", 8080, {bind, 8080}).should be_true
+        Gori::Proxy::Upstream.addresses_self?("127.0.0.1", 8080, {bind, 8080}).should be_true
+      end
+    end
+
+    it "classifies loopback by ADDRESS, not spelling (expanded v6 and v4-mapped)" do
+      Gori::Proxy::Upstream.addresses_self?("0:0:0:0:0:0:0:1", 8080, {"127.0.0.1", 8080}).should be_true
+      Gori::Proxy::Upstream.addresses_self?("::ffff:127.0.0.1", 8080, {"127.0.0.1", 8080}).should be_true
+      # Not a parseable IP literal, but it dials to 127.0.0.1 — the string fallback
+      # must survive the move to address-level classification.
+      Gori::Proxy::Upstream.addresses_self?("127.1", 8080, {"127.0.0.1", 8080}).should be_true
+    end
+
+    # The false-positive boundary. A match here serves the landing page (or, in
+    # loops_to_self?, 502s) instead of proxying, so these MUST stay false.
+    it "leaves a real external host on gori's own port alone" do
+      Gori::Proxy::Upstream.addresses_self?("example.com", 8080, {"::0", 8080}).should be_false
+      Gori::Proxy::Upstream.addresses_self?("93.184.216.34", 8080, {"0.0.0.0", 8080}).should be_false
+    end
+
+    it "does not let a concrete non-loopback bind swallow loopback or wildcard targets" do
+      # Measured: a listener on a concrete LAN address is NOT reachable by dialing
+      # 0.0.0.0, so neither of these is self and both must proxy normally.
+      Gori::Proxy::Upstream.addresses_self?("0.0.0.0", 8080, {"192.168.1.5", 8080}).should be_false
+      Gori::Proxy::Upstream.addresses_self?("127.0.0.1", 8080, {"192.168.1.5", 8080}).should be_false
+      Gori::Proxy::Upstream.addresses_self?("localhost", 8080, {"192.168.1.5", 8080}).should be_false
+    end
+
+    it "keeps the wildcard-target match scoped to the listener port" do
+      Gori::Proxy::Upstream.addresses_self?("0.0.0.0", 9999, {"127.0.0.1", 8080}).should be_false
+    end
   end
 
   describe ".loops_to_self?" do
@@ -151,6 +197,47 @@ describe Gori::Proxy::Upstream do
     it "leaves a real external host on the same port alone" do
       Gori::Proxy::Upstream.loops_to_self?(
         "example.com", 8080, nil, {"0.0.0.0", 8080}, local_host: "192.168.1.5").should be_false
+    end
+
+    # Gap 1, the wedge case: one such request cost 2048 connections (the MAX_CONNECTIONS
+    # cap) in 3 seconds against the shipping 127.0.0.1 default bind, after which accept()
+    # stalls and the proxy is unusable.
+    it "refuses a forward to a 0.0.0.0 target that would land back on a loopback bind" do
+      Gori::Proxy::Upstream.loops_to_self?("0.0.0.0", 8080, nil, {"127.0.0.1", 8080}).should be_true
+      Gori::Proxy::Upstream.loops_to_self?("::", 8080, nil, {"127.0.0.1", 8080}).should be_true
+      Gori::Proxy::Upstream.loops_to_self?("0.0.0.0", 8080, nil, {"0.0.0.0", 8080}).should be_true
+    end
+
+    # Gap 2: under an expanded all-zero bind the refusal disappeared entirely, so an
+    # absolute-form GET http://localhost:<port>/ wedged the proxy the same way.
+    it "still refuses a loopback self-loop under the expanded all-zero IPv6 binds" do
+      {"::0", "0:0:0:0:0:0:0:0"}.each do |bind|
+        Gori::Proxy::Upstream.loops_to_self?("localhost", 8080, nil, {bind, 8080}).should be_true
+        Gori::Proxy::Upstream.loops_to_self?("127.0.0.1", 8080, nil, {bind, 8080}).should be_true
+        Gori::Proxy::Upstream.loops_to_self?("0.0.0.0", 8080, nil, {bind, 8080}).should be_true
+      end
+    end
+
+    it "refuses a hostname override that resolves onto the wildcard address" do
+      Gori::Settings.hostname_overrides = [{"api.example.com", "0.0.0.0"}]
+      begin
+        Gori::Proxy::Upstream.loops_to_self?(
+          "api.example.com", 8080, nil, {"127.0.0.1", 8080}).should be_true
+      ensure
+        Gori::Settings.hostname_overrides = [] of {String, String}
+      end
+    end
+
+    # The false-positive boundary: refusing here is a 502 on traffic that would have
+    # proxied fine, which is worse than the loop it guards against.
+    it "does not refuse anything a concrete non-loopback bind cannot possibly serve" do
+      Gori::Proxy::Upstream.loops_to_self?("0.0.0.0", 8080, nil, {"192.168.1.5", 8080}).should be_false
+      Gori::Proxy::Upstream.loops_to_self?("localhost", 8080, nil, {"192.168.1.5", 8080}).should be_false
+      Gori::Proxy::Upstream.loops_to_self?("example.com", 8080, nil, {"::0", 8080}).should be_false
+    end
+
+    it "keeps the wildcard-target refusal scoped to the listener port" do
+      Gori::Proxy::Upstream.loops_to_self?("0.0.0.0", 9999, nil, {"127.0.0.1", 8080}).should be_false
     end
   end
 end

--- a/src/gori/proxy/upstream.cr
+++ b/src/gori/proxy/upstream.cr
@@ -41,8 +41,9 @@ module Gori::Proxy
     # to gori's own listener `self_addr` — an unbounded self-proxy loop (gori dials
     # itself, its accept loop treats that as a new client, re-resolves the same
     # target, dials itself again…). Triggered when a hostname override — or a request
-    # Host — points at the proxy's own bind. Only a matching port on a loopback/self
-    # address counts, so proxying a real external host on the same port is unaffected.
+    # Host — points at the proxy's own bind. Only a matching port on a loopback/wildcard/
+    # self address counts (see reaches_self?), so proxying a real external host on the
+    # same port is unaffected.
     #
     # `local_host` is the concrete address the client actually reached us on
     # (the accepted socket's local address). Under a wildcard bind (0.0.0.0 / ::)
@@ -57,7 +58,7 @@ module Gori::Proxy
       bind = normalize_host(self_addr[0])
       return true if target == bind
       return true if local_host && target == normalize_host(local_host)
-      loopback?(target) && (loopback?(bind) || wildcard?(bind))
+      reaches_self?(target, bind)
     end
 
     # True when the request LITERALLY targets gori's own listener `self_addr` — the
@@ -75,7 +76,28 @@ module Gori::Proxy
       bind = normalize_host(self_addr[0])
       return true if target == bind
       return true if local_host && target == normalize_host(local_host)
-      loopback?(target) && (loopback?(bind) || wildcard?(bind))
+      reaches_self?(target, bind)
+    end
+
+    # The shared "would dialing `target` land back on our own listener?" test, reached
+    # only after the port gate and the literal bind/local_host matches above.
+    #
+    # A LOOPBACK target reaches us when we are bound to loopback or to a wildcard. An
+    # UNSPECIFIED target (0.0.0.0 / ::) is loopback-EQUIVALENT and must ride the SAME
+    # gate: the OS routes a connect() to the all-zero address onto loopback, so dialing
+    # 0.0.0.0:<our port> lands on our own listener exactly as 127.0.0.1:<our port> does.
+    # Without this, one `GET http://0.0.0.0:<port>/` against the default 127.0.0.1 bind
+    # made gori dial itself, accept that as a fresh client, re-resolve the same target
+    # and dial itself again — 2048 connections (the MAX_CONNECTIONS cap) in 3 seconds,
+    # after which accept() stalls and the proxy is wedged.
+    #
+    # The `(loopback?(bind) || wildcard?(bind))` half is NOT redundant for the wildcard
+    # target, it is the false-positive guard: a listener on a concrete LAN address is
+    # genuinely NOT reachable by dialing 0.0.0.0 (measured — the connect is refused), so
+    # matching a wildcard target unconditionally would 502 legitimate traffic for anyone
+    # proxying a real host on gori's port, which is a worse failure than the loop.
+    private def self.reaches_self?(target : String, bind : String) : Bool
+      (loopback?(target) || unspecified?(target)) && (loopback?(bind) || wildcard?(bind))
     end
 
     private def self.normalize_host(h : String) : String
@@ -83,12 +105,45 @@ module Gori::Proxy
       h.downcase
     end
 
-    private def self.loopback?(h : String) : Bool
-      h == "localhost" || h == "::1" || h == "0:0:0:0:0:0:0:1" || h.starts_with?("127.")
+    # `h` parsed as an IP literal, or nil when it is a hostname ("localhost",
+    # "a.example.com") — those never parse, and we deliberately do NOT resolve them (a
+    # DNS lookup on this path would be a blocking side effect on every request). Parsing
+    # is what makes the classifiers below spelling-proof: Socket::IPAddress canonicalises
+    # ::0, 0:0:0:0:0:0:0:0 and 0000:…:0000 to one address, so they test the ADDRESS rather
+    # than a hand-kept list of strings that a new spelling silently escapes. The parse cost
+    # is irrelevant: both callers sit behind `port == self_addr[1]`, so this only runs for
+    # a request already aimed at gori's own listener port.
+    private def self.parse_ip(h : String) : Socket::IPAddress?
+      Socket::IPAddress.new(h, 0)
+    rescue Socket::Error
+      nil
     end
 
+    # Address-level classification, with the original string tests kept as a FALLBACK
+    # rather than replaced by it: several spellings that genuinely reach a 127.0.0.1
+    # listener are rejected by inet_pton ("127.1" dials fine but is not a parseable
+    # literal), so dropping the prefix test would regress the exact case it guards.
+    # Parsing additionally buys the v4-mapped forms (::ffff:127.0.0.1) for free.
+    private def self.loopback?(h : String) : Bool
+      if ip = parse_ip(h)
+        return ip.loopback?
+      end
+      h == "localhost" || h.starts_with?("127.")
+    end
+
+    # The all-zero address in ANY spelling (0.0.0.0, ::, ::0, 0:0:0:0:0:0:0:0, 0000:…).
+    # Settings.bind_host_error accepts every one of these and they all bind as a full
+    # wildcard, but a literal-string test only knew "0.0.0.0"/"::" — so under a `::0`
+    # bind the loopback/wildcard conjunct collapsed to false for every loopback target
+    # and BOTH the self-page (CA download) and the self-loop refusal disappeared.
+    private def self.unspecified?(h : String) : Bool
+      !!parse_ip(h).try(&.unspecified?)
+    end
+
+    # A BIND that answers on every interface: the all-zero address, plus the empty string
+    # (an unset bind is caller-defaulted, and reading it as a wildcard is the safe side).
     private def self.wildcard?(h : String) : Bool
-      h.empty? || h == "0.0.0.0" || h == "::"
+      h.empty? || unspecified?(h)
     end
 
     private def self.direct_dial(host : String, port : Int32,


### PR DESCRIPTION
Found while sweeping the codebase for issues similar to the ones fixed today (#277, #279, #281).

Both gaps make gori dial itself in an unbounded loop: it accepts its own connection as a fresh client, re-resolves the same target, and dials itself again. Measured on a real `Proxy::Server`: **2048 connections (the `MAX_CONNECTIONS` cap) in 3 seconds**, after which `accept()` stalls and the proxy is wedged.

### Gap 1 — wildcard tested on the bind, never on the target
`loops_to_self?` / `addresses_self?` ended in `loopback?(target) && (loopback?(bind) || wildcard?(bind))`. The OS routes a connect to the all-zero address onto loopback, so a target of `0.0.0.0:<gori port>` reaches our own listener exactly as `127.0.0.1` does — but nothing classified it. This fires on the **shipping default bind** `127.0.0.1`, and is reachable without contrivance: a hostname override pointing at `0.0.0.0`, or SSRF-fuzzing a param with `0.0.0.0:<port>` (gori's own use case).

### Gap 2 — `wildcard?` missed the all-zero IPv6 spellings
`Settings.bind_host_error` accepts `::0` and `0:0:0:0:0:0:0:0` (both `valid_v6?`) and both bind as full wildcards, but the literal test only knew `"0.0.0.0"` / `"::"`. Under such a bind the conjunct collapsed to false for every loopback target, so **both** the self-page (CA download) and the loop refusal vanished. The `local_host` thread from #279 does not rescue it — it matches a literal `::1`, but `localhost`, which is what users type, still missed.

Note the asymmetry that shows this was an oversight: `loopback?` already handled the expanded `0:0:0:0:0:0:0:1`; `wildcard?` had no expanded counterpart.

## Approach
Classification is now address-level (`Socket::IPAddress` canonicalises every all-zero spelling) with the **original string tests kept as a fallback, not replaced**. That matters: `127.1` genuinely reaches a `127.0.0.1` listener but `inet_pton` rejects it, so a parse-only classifier would have regressed the exact case `starts_with?("127.")` guards. Parsing additionally picks up `::ffff:127.0.0.1` for free.

The `(loopback?(bind) || wildcard?(bind))` half is deliberately **kept** for the new wildcard-target case — it is the false-positive guard. Measured: a listener bound to a concrete LAN IP is genuinely *not* reachable by dialling `0.0.0.0` (connect refused), so matching a wildcard target unconditionally would 502 legitimate traffic for anyone proxying a real host on gori's port — a worse failure than the loop. The port gate is untouched.

## Verification
End-to-end against a real `Proxy::Server`, counting flows. Control run with the fix stashed:

```
bind=127.0.0.1  target=0.0.0.0    flows=2048  <read failed: IO::TimeoutError>
bind=127.0.0.1  target=127.0.0.1  flows=1     HTTP/1.1 502 Bad Gateway
bind=::0        target=localhost  flows=2048  <read failed: IO::TimeoutError>
bind=::0        target=0.0.0.0    flows=2048  <read failed: IO::TimeoutError>
bind=::         target=localhost  flows=1     HTTP/1.1 502 Bad Gateway
```

With the fix all five are `flows=1` / clean 502.

Specs cover both predicates for wildcard targets, both `::0` spellings, and explicit **negative** cases pinning the false-positive boundary (real external host on gori's port still proxies; a concrete non-loopback bind swallows nothing).

`spec/proxy/` 234 examples, 0 failures. Full suite on the combined branch: 2424 examples, 0 failures.

Two residual latent gaps deliberately not chased, as neither falls out of the classifier: `0` / `2130706433` (libc resolution quirks, not address spellings) and `::ffff:0.0.0.0`.