### PR TITLE
fix(tui): measure draw columns per grapheme, not per codepoint

### DIFF
--- a/spec/tui/foundation_spec.cr
+++ b/spec/tui/foundation_spec.cr
@@ -56,6 +56,68 @@ describe Gori::Tui::Screen do
     Screen.column_width_upto("a\tb", 2).should eq(2)
   end
 
+  # The three measures, pinned side by side. They are NOT interchangeable, and picking the
+  # wrong one is exactly how the draw-alignment sites drifted: display_width under-counts a
+  # C0 control (Unicode width 0, but `cell` still paints a space there), column_width
+  # over-counts a multi-codepoint cluster (it floors every CODEPOINT to ≥1, right for the
+  # per-codepoint caret, wrong for a draw), and draw_width matches the cells actually
+  # painted because it floors per CLUSTER — the same walk `#text` / `Highlight.draw` do.
+  describe "display_width vs column_width vs draw_width" do
+    skin = "\u{1F44D}\u{1F3FD}"                                             # 👍🏽 thumbs-up + skin-tone modifier (2 cps)
+    zwj = "\u{1F468}\u{200D}\u{1F4BB}"                                      # 👨‍💻 man + ZWJ + laptop (3 cps)
+    family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}" # 👨‍👩‍👧‍👦 4 people + 3 ZWJ (7 cps)
+
+    # {label, string, display_width, column_width, draw_width}
+    cases = [
+      {"tab", "a\tb", 2, 3, 3},            # control: display under-counts; the tab owns a cell
+      {"ZWSP", "a\u{200B}b", 2, 3, 3},     # zero-width space: same, it still gets a cell
+      {"skin tone", skin, 2, 3, 2},        # 1 cluster, 1 glyph → 2 cols drawn, not 3
+      {"ZWJ", zwj, 2, 5, 2},               # column_width drifts 3
+      {"family", family, 2, 11, 2},        # column_width drifts 9 — the worst case
+      {"CJK", "한글", 4, 4, 4},              # wide but single-codepoint: all three agree
+      {"combining", "e\u{0301}", 1, 2, 1}, # é as e + U+0301: cluster is 1 col, not 2
+    ]
+
+    cases.each do |(label, str, dw, cw, gw)|
+      it "measures #{label} as display=#{dw} column=#{cw} draw=#{gw}" do
+        Screen.display_width(str).should eq(dw)
+        Screen.column_width(str).should eq(cw)
+        Screen.draw_width(str).should eq(gw)
+      end
+    end
+
+    it "draw_width equals the columns Screen#text actually advances" do
+      # The authoritative check: whatever `text` returns as its end-x IS the drawn width.
+      cases.each do |(label, str, _, _, gw)|
+        b = MemoryBackend.new(40, 1)
+        Screen.new(b).text(0, 0, str, Theme.text).should eq(gw) # (#{label})
+      end
+    end
+
+    it "draw_width_upto early-exits without walking the rest of the line" do
+      # Same contract as display_width_upto / column_width_upto: returns a value >= limit
+      # once reached, exact below it. The h-scroll clamps run per frame, so a minified
+      # multi-MB line must never be measured in full.
+      Screen.draw_width_upto(zwj + "abcdefgh", 100).should eq(10) # exact under the limit
+      Screen.draw_width_upto(zwj + "abcdefgh", 4).should be >= 4  # stopped early
+      Screen.draw_width_upto("", 5).should eq(0)
+      Screen.draw_width_upto("abc", 0).should eq(0)
+      # ASCII fast path stays exact and capped
+      Screen.draw_width_upto("abcdef", 3).should eq(3)
+      Screen.draw_width_upto("abcdef", 99).should eq(6)
+    end
+
+    it "draw_width keeps the ASCII fast path exact (1 char == 1 cluster per line)" do
+      # The fast path returns str.size. That is EXACT rather than approximate because the
+      # only multi-char ASCII grapheme cluster is CRLF, and no rendered line can hold one
+      # (every caller splits on '\n' first). Tabs and lone CRs still count as one cell.
+      Screen.draw_width("hello").should eq(5)
+      Screen.draw_width("a\tb").should eq(3)
+      Screen.draw_width("ab\rc").should eq(4)
+      Screen.draw_width("").should eq(0)
+    end
+  end
+
   it "text draws a tab as a one-column space (ASCII and mixed paths)" do
     # ASCII fast path
     b1 = MemoryBackend.new(10, 1)

--- a/spec/tui/highlight_spec.cr
+++ b/spec/tui/highlight_spec.cr
@@ -390,6 +390,102 @@ describe Gori::Tui::Highlight do
     end
   end
 
+  # Grapheme-cluster alignment. `column_width` floors every CODEPOINT to ≥1, so a ZWJ /
+  # skin-tone cluster measured that way is 3-9 columns wider than the single glyph `draw`
+  # paints. Measuring the h-scroll clamp and the slice per CLUSTER (Screen.draw_width) is
+  # what keeps them lined up with the cells — and stops the slicer cutting a cluster in half.
+  describe "grapheme clusters (draw alignment)" do
+    zwj = "\u{1F468}\u{200D}\u{1F4BB}"                                      # 👨‍💻 (3 cps, 2 cols)
+    family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}" # 👨‍👩‍👧‍👦 (7 cps, 2 cols)
+
+    it "line_width measures a cluster as its DRAWN columns, not its codepoint count" do
+      # Under column_width these were 5 and 11, letting the h-scroll clamp run the view
+      # 3 (resp. 9) columns past the end of the content.
+      Highlight.line_width([Highlight::Span.new(zwj, Theme.text)]).should eq(2)
+      Highlight.line_width([Highlight::Span.new(family, Theme.text)]).should eq(2)
+      line = [Highlight::Span.new(zwj, Theme.text), Highlight::Span.new("abc", Theme.text)]
+      Highlight.line_width(line).should eq(5)
+      Highlight.line_width_upto(line, 99).should eq(5)
+      Highlight.line_width_upto(line, 3).should be >= 3 # early exit still honoured
+    end
+
+    it "line_width agrees with what draw actually advances" do
+      line = [Highlight::Span.new(zwj, Theme.text), Highlight::Span.new("abc", Theme.text)]
+      b = MemoryBackend.new(40, 1)
+      Highlight.draw(Screen.new(b), 0, 0, line, width: 40).should eq(Highlight.line_width(line))
+    end
+
+    it "slice_left never emits a partial cluster (no bare ZWJ / orphan modifier)" do
+      # The bug: a per-codepoint cut could stop between 👨 and 💻 and emit the ZWJ (or the
+      # tail half) as its own "glyph". A cluster must be all-or-nothing — kept whole, or
+      # replaced by spaces when the cut straddles it.
+      # An INTACT cluster of course still contains its ZWJ, so the assertion is on the
+      # RESIDUE: delete every whole cluster from the output and nothing cluster-internal
+      # (ZWJ, skin-tone modifier, either half of the pair) may be left behind.
+      {zwj, family, "\u{1F44D}\u{1F3FD}"}.each do |emoji|
+        line = [Highlight::Span.new(emoji + "abcdef", Theme.text)]
+        (0..8).each do |col|
+          sliced = Highlight.slice_left(line, col).map(&.text).join
+          # Only the padding spaces and "abcdef" may remain — any leaked ZWJ, skin-tone
+          # modifier or half-cluster would be non-ASCII and trip this. (col=#{col})
+          sliced.gsub(emoji, "").ascii_only?.should be_true
+          # And the cluster is either wholly present or wholly gone — never split.
+          sliced.count(emoji[0]).should eq(sliced.includes?(emoji) ? 1 : 0)
+        end
+      end
+    end
+
+    it "slice_left_text never emits a partial cluster either" do
+      (0..8).each do |col|
+        sliced = Highlight.slice_left_text(family + "abcdef", col)
+        sliced.gsub(family, "").ascii_only?.should be_true
+      end
+    end
+
+    it "slice_left cuts in DRAWN columns so the remainder lines up with the cells" do
+      # zwj is 2 drawn columns, so cutting 2 leaves exactly "abc" — under the old
+      # per-codepoint math this needed a cut of 5 and any smaller cut leaked cluster parts.
+      Highlight.slice_left([Highlight::Span.new(zwj + "abc", Theme.text)], 2)
+        .map(&.text).join.should eq("abc")
+      Highlight.slice_left_text(zwj + "abc", 2).should eq("abc")
+      # Cutting INTO the cluster replaces it with blanks (it cannot be half-drawn).
+      Highlight.slice_left_text(zwj + "abc", 1).should eq(" abc")
+      # Identity below the cut, and tabs still count as their one cell.
+      Highlight.slice_left_text(zwj + "abc", 0).should eq(zwj + "abc")
+      Highlight.slice_left_text("a\tbc", 2).should eq("bc")
+    end
+  end
+
+  # The search overlay repaints cells the base draw already painted, using screen.text
+  # (grapheme-walked). Its column must therefore be grapheme-summed too, or the yellow
+  # band lands right of the match and covers unrelated glyphs.
+  describe "SearchHi column alignment" do
+    it "highlights the match columns after a ZWJ emoji, not 3 columns right of them" do
+      zwj = "\u{1F468}\u{200D}\u{1F4BB}"
+      text = zwj + "needle"
+      b = MemoryBackend.new(40, 1)
+      screen = Screen.new(b)
+      screen.text(0, 0, text, Theme.text)
+      SearchHi.mark(screen, 0, 0, text, "needle", 40)
+      # The emoji occupies cols 0-1, so "needle" is drawn at cols 2..7 and that is exactly
+      # where the yellow band must sit. Under column_width it started at col 5.
+      (2...8).each { |x| b.bg_at(x, 0).should eq(Theme.yellow) }
+      b.bg_at(1, 0).should_not eq(Theme.yellow) # emoji untouched
+      b.bg_at(8, 0).should_not eq(Theme.yellow) # nothing past the match
+      b.row(0)[2, 6].should eq("needle")
+    end
+
+    it "still lands correctly after a tab (issue #278 case, ASCII path)" do
+      text = "a\tneedle"
+      b = MemoryBackend.new(40, 1)
+      screen = Screen.new(b)
+      screen.text(0, 0, text, Theme.text)
+      SearchHi.mark(screen, 0, 0, text, "needle", 40)
+      (2...8).each { |x| b.bg_at(x, 0).should eq(Theme.yellow) }
+      b.bg_at(1, 0).should_not eq(Theme.yellow)
+    end
+  end
+
   # The body tokenizers were rewritten from `raw.chars` + `.join` to a byte-scan. These
   # reference impls are the ORIGINAL char-based tokenizers, kept here to fuzz-verify the byte
   # version is span-for-span identical (text + colour) across ASCII + multibyte inputs.

--- a/src/gori/tui/highlight.cr
+++ b/src/gori/tui/highlight.cr
@@ -520,28 +520,31 @@ module Gori::Tui
           out << span
           next
         end
-        # column_width / grapheme_cols (not raw display_width): a control char still
-        # occupies a drawn cell after Highlight.draw's ≥1 floor, so h-scroll cuts must
-        # count it the same way or the styled slice drifts left of the caret.
-        sw = Screen.column_width(span.text)
+        # draw_width / a GRAPHEME walk, matching `draw`'s advance. Two reasons this cannot
+        # be the per-codepoint column_width: it over-counts a cluster (so the cut lands
+        # left of where the glyphs really are), and worse, cutting per codepoint can slice
+        # a ZWJ sequence in half and emit a bare ZWJ or a dangling skin-tone modifier as
+        # its own "glyph". Walking clusters keeps a cluster atomic: it is either kept
+        # whole or replaced by spaces, never split.
+        sw = Screen.draw_width(span.text)
         if acc + sw <= start_col # whole span is left of the cut
           acc += sw
           next
         end
         kept = String.build do |io|
-          span.text.each_char do |ch|
+          span.text.each_grapheme do |g|
             if cutting
-              w = Screen.grapheme_cols(ch.to_s)
+              w = Screen.grapheme_cols(g.to_s)
               if acc + w <= start_col
                 acc += w
                 next
               end
-              io << " " * (acc + w - start_col) if acc < start_col # straddling glyph → visible cells as spaces
-              io << ch if acc >= start_col                         # clean boundary keeps the glyph
+              io << " " * (acc + w - start_col) if acc < start_col # straddling cluster → visible cells as spaces
+              io << g if acc >= start_col                          # clean boundary keeps the cluster whole
               acc += w
               cutting = false
             else
-              io << ch
+              io << g # past the cut: append the cluster directly (no `to_s` allocation)
             end
           end
         end
@@ -558,19 +561,19 @@ module Gori::Tui
       acc = 0
       cutting = true
       String.build do |io|
-        s.each_char do |ch|
+        s.each_grapheme do |g| # cluster-wise, same reason as slice_left: never split a ZWJ sequence
           if cutting
-            w = Screen.grapheme_cols(ch.to_s)
+            w = Screen.grapheme_cols(g.to_s)
             if acc + w <= start_col
               acc += w
               next
             end
-            io << " " * (acc + w - start_col) if acc < start_col # straddling glyph → visible cells as spaces
-            io << ch if acc >= start_col                         # clean boundary keeps the glyph
+            io << " " * (acc + w - start_col) if acc < start_col # straddling cluster → visible cells as spaces
+            io << g if acc >= start_col                          # clean boundary keeps the cluster whole
             acc += w
             cutting = false
           else
-            io << ch
+            io << g
           end
         end
       end
@@ -607,22 +610,24 @@ module Gori::Tui
       out
     end
 
-    # Total column span of a styled line (sum of its spans, ≥1 per char) — used to
-    # clamp a horizontal scroll offset against the widest currently-visible row. Uses
-    # column_width so embedded tabs/controls match Highlight.draw's cell advance.
+    # Total drawn column span of a styled line (sum of its spans) — used to clamp a
+    # horizontal scroll offset against the widest currently-visible row. Uses draw_width,
+    # which is what `draw` below actually advances by: ≥1 per cluster so an embedded tab
+    # keeps its cell, but ONE cluster per glyph so a ZWJ emoji doesn't inflate the line by
+    # its codepoint count and let the view scroll past the end of the content.
     def self.line_width(line : Line) : Int32
-      line.sum { |span| Screen.column_width(span.text) }
+      line.sum { |span| Screen.draw_width(span.text) }
     end
 
     # As `line_width`, but stops summing once the running width reaches `limit` — and
     # caps WITHIN a span too (a huge minified body is one plain span > MAX_HL_LINE), so
     # the per-frame h-scroll clamp never fully measures a multi-MB line. See
-    # Screen.column_width_upto. Exact for lines narrower than limit.
+    # Screen.draw_width_upto. Exact for lines narrower than limit.
     def self.line_width_upto(line : Line, limit : Int32) : Int32
       w = 0
       line.each do |span|
         break if w >= limit
-        w += Screen.column_width_upto(span.text, limit - w)
+        w += Screen.draw_width_upto(span.text, limit - w)
       end
       w
     end

--- a/src/gori/tui/screen.cr
+++ b/src/gori/tui/screen.cr
@@ -291,6 +291,50 @@ module Gori::Tui
       {display_width(g), 1}.max
     end
 
+    # Columns `str` occupies when DRAWN: `grapheme_cols` summed over grapheme CLUSTERS,
+    # which is exactly how `#text` and `Highlight.draw` advance. This is a THIRD measure,
+    # equal to neither sibling, and the only one that matches the cells on screen:
+    #
+    #   "a\tb"     display_width 2   column_width 3    draw_width 3   (tab: a drawn cell)
+    #   "👍🏽"       display_width 2   column_width 3    draw_width 2   (skin tone: 2 cps)
+    #   "👨‍👩‍👧‍👦"    display_width 2   column_width 11   draw_width 2   (3 ZWJ: 9 cols of drift)
+    #
+    # `display_width` UNDER-counts: a C0 control is Unicode width 0, but `cell` still
+    # substitutes a space for it, so it owns a cell. `column_width` OVER-counts: it floors
+    # every CODEPOINT to ≥1, which is right for the per-codepoint caret model it exists to
+    # serve (TextArea's char-index `@cx`, `column_for`) but wrong for a draw, where a
+    # multi-codepoint cluster — skin-tone modifier, ZWJ sequence, combining mark — is ONE
+    # glyph drawn into ONE cell run. Rule of thumb: measure with `draw_width` when the
+    # result is compared against drawn cells (search overlay, h-scroll clamp, slice), with
+    # `column_width` when it is compared against the caret.
+    def self.draw_width(str : String) : Int32
+      # ASCII fast path, and it is EXACT rather than an approximation: the only multi-char
+      # ASCII grapheme cluster is CRLF, which cannot appear inside a rendered line because
+      # every caller splits on '\n' first (TextArea#text= also rstrips the '\r'). So each
+      # ASCII char is its own cluster and the cluster sum IS the char count. Keeps the hot
+      # path off the grapheme walk + its per-glyph `g.to_s` String, as the siblings do.
+      return str.size if str.ascii_only?
+      w = 0
+      str.each_grapheme { |g| w += grapheme_cols(g.to_s) }
+      w
+    end
+
+    # As `draw_width`, but stops once the running width reaches `limit` (returning a value
+    # ≥ limit without walking the rest). Same early-exit contract, and the same reason, as
+    # `display_width_upto` / `column_width_upto`: the h-scroll clamps run EVERY frame and
+    # only need to know whether a line reaches the view's right edge, so a minified
+    # multi-MB single line must never be measured in full. Exact for lines under `limit`.
+    def self.draw_width_upto(str : String, limit : Int32) : Int32
+      return 0 if str.empty? || limit <= 0
+      return {str.size, limit}.min if str.ascii_only? # see draw_width: 1 char == 1 cluster
+      w = 0
+      str.each_grapheme do |g|
+        w += grapheme_cols(g.to_s)
+        return w if w >= limit
+      end
+      w
+    end
+
     def cell(x : Int32, y : Int32, grapheme : Char | String, fg : Color, bg : Color = Theme.bg,
              attr : Attribute = Attribute::None) : Nil
       return unless x >= 0 && y >= 0 && x < @width && y < @height

--- a/src/gori/tui/search_hi.cr
+++ b/src/gori/tui/search_hi.cr
@@ -22,13 +22,17 @@ module Gori::Tui
       # src[0, i] per match (was O(line²) on token-dense lines during a search).
       acc = 0
       while (i = dt.index(q, pos))
-        # column_width (not display_width): match the base draw / caret so a match after
-        # a tab or other zero-width control still lands on the right cell.
-        acc += Screen.column_width(src[pos, i - pos])
+        # draw_width, not display_width (under-counts a tab) and not column_width
+        # (over-counts a multi-codepoint cluster). The overlay is positioned against cells
+        # the BASE DRAW already painted, and it repaints them with `screen.text`, which
+        # advances per grapheme — so the column must be summed per grapheme too. Under
+        # column_width a match after a ZWJ emoji landed 3-9 columns right of itself and
+        # painted yellow over unrelated glyphs.
+        acc += Screen.draw_width(src[pos, i - pos])
         col = x + acc
         seg = src[i, q.size]
         screen.text(col, y, seg, Theme.bg, Theme.yellow, width: {max_x - col, 0}.max) if col < max_x
-        acc += Screen.column_width(seg)
+        acc += Screen.draw_width(seg)
         pos = i + q.size
       end
     end

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -801,6 +801,18 @@ module Gori::Tui
       # column_width (not display_width) to match the actual draw: a raw control char
       # occupies one drawn cell, so measuring it as width 0 here would let the caret render
       # outside the window (cursor detaches / no scroll-into-view).
+      #
+      # KNOWN LIMITATION (grapheme clusters). These columns are per-CODEPOINT because the
+      # caret is: @cx is a char index and `move` steps it raw, so the caret genuinely can
+      # park inside a ZWJ/skin-tone cluster. But Highlight.slice_left consumes @xscroll in
+      # per-CLUSTER (drawn) columns. On a line holding a multi-codepoint cluster the two
+      # disagree by the cluster's "inflation" (codepoint columns minus drawn columns: 1 for
+      # a skin tone, 3 for a ZWJ pair, 9 for a 4-person family), so the view can over-scroll
+      # by up to that many columns and show trailing blanks. It can only blank the row
+      # entirely when the pane is narrower than 1 + inflation (< 10 cols for the worst
+      # case), which no real pane is. Not fixable here: making this per-cluster would
+      # desync it from `cxs`/`prefix_w` below, which are per-codepoint to track the caret —
+      # reconciling the two IS the caret-model change, so it belongs in its own PR.
       full = concealed ? concealed_col(line, cr.not_nil!, line.size) : Screen.column_width(line)
       if full + pw <= cw
         @xscroll = 0


### PR DESCRIPTION
Follow-up to #281, which landed earlier today. That fix was right about tabs and, as a side effect, wrong about emoji.

## There are three measures, not two
#281 framed this as raw-vs-floored and moved several sites from `display_width` to `column_width`. But `column_width` walks `each_char`, flooring **each codepoint**, while the renderer (`Screen#text`, `Highlight.draw`) walks `each_grapheme` and advances per **cluster**. The two agree only when every grapheme is one codepoint — true for tabs, false for emoji. Measured in-repo:

```
a\tb                      display=2  column=3   DRAWN=3   ok
a<ZWSP>b                  display=2  column=3   DRAWN=3   ok
👍🏽  (1f44d,1f3fd)         display=2  column=3   DRAWN=2   MISMATCH
👨‍💻  (1f468,200d,1f4bb)    display=2  column=5   DRAWN=2   MISMATCH
👨‍👩‍👧‍👦 (4 people, 3 ZWJ)     display=2  column=11  DRAWN=2   MISMATCH  <- 9 columns
한글                       display=4  column=4   DRAWN=4   ok
```

So the sites where `display_width` had been **correct** now drift on emoji:

- `search_hi.cr` — the yellow search highlight lands 3 (or 9) columns right of its match, painting over unrelated glyphs.
- `highlight.cr` `line_width` / `line_width_upto` — the h-scroll clamp lets the view scroll past the content.
- `highlight.cr` `slice_left` / `slice_left_text` — these walk `each_char`, so beyond miscounting they **split a ZWJ cluster and emit a bare ZWJ**. Confirmed reachable by ordinary → keypresses; control run on unpatched code rendered `" ‍💻 ab…"` (orphan ZWJ), then `" 💻 ab…"` (half a cluster). Patched: clean.

## Approach
New `Screen.draw_width` / `draw_width_upto`: `grapheme_cols` summed over **clusters**, which is exactly what the renderer advances by. `slice_left*` now walk graphemes so a cluster is atomic.

`Screen.column_width`, `col_to_index` and the TextArea caret model are deliberately **untouched** — `@cx` is a char index, so the per-codepoint measure is correct there, and changing it would undo #281. Rule of thumb, documented at the helper: `draw_width` when the result is compared against drawn cells, `column_width` when it is compared against the caret.

The ASCII fast path is exact rather than approximate: the only multi-char ASCII cluster is CRLF, which cannot appear in a rendered line because every caller splits on `\n` first.

## Known follow-up, not fixed here
`ensure_visible_x` derives `@xscroll` per codepoint while `slice_left` now consumes it per cluster. `TextArea#move` does a raw `@cx += dc` with no grapheme snapping, so a caret **can** park inside a cluster and the mismatch is genuinely reachable — the view over-scrolls by the cluster's inflation (1 column for skin tone, 3 for ZWJ, 9 for a family), showing trailing blanks. It can only blank the row entirely when the pane is under ~10 columns, which no real pane is.

Not fixed because every option is worse or out of scope: making `ensure_visible_x` per-cluster detaches the caret from `cxs`/`prefix_w`; making those per-cluster is the caret-model rewrite; clamping `@xscroll` alone leaves the caret pointing at a cell that no longer holds its glyph. Documented in a comment at `ensure_visible_x` (comment only, no behavior change).

The deeper root cause this exposes, independent of `@xscroll` and unchanged here: at `@xscroll == 0`, `prefix_w` is per-codepoint, so on a line starting with a ZWJ emoji the caret for `'a'` renders 3 columns off (9 for a family). That belongs in a caret-model follow-up.

## Verification
#281's own examples still pass — this edits a fix that landed hours ago:

```
-e "issue #278"        → 6 examples, 0 failures
foundation -e "tab"    → 9 examples, 0 failures
foundation + highlight + text_area → 133 examples, 0 failures
spec/tui/              → 877 examples, 0 failures
```

Specs pin the three-way table above plus behavioural cases: a match after a ZWJ emoji highlights the right columns, and `slice_left` never emits a partial cluster. Full suite on the combined branch: 2424 examples, 0 failures.