### PR TITLE
fix(notes): stop the reconcile poll from resetting the Notes caret on a CRLF note

### DIFF
--- a/spec/tui/notes_view_spec.cr
+++ b/spec/tui/notes_view_spec.cr
@@ -114,6 +114,67 @@ describe Gori::Tui::NotesView do
     end
   end
 
+  # Regression: NoteEntry#text is whatever was written into the JSON KV, verbatim, and several
+  # writers store wire CRLF — MCP create_note/update_note pass the caller's string straight
+  # through, and `gori run notes create` takes its body from --text / positional args / STDIN
+  # (piping a CRLF file, or `gori run flow N --raw`, stores CRLF). The TextArea buffer is always
+  # LF (set_text strips \r), so the old `existing.area.text != e.text` compare was false on EVERY
+  # data_version poll (~1.3×/s while capturing) → set_text re-ran → caret + scroll zeroed and the
+  # undo stack cleared. Hit whenever Notes was open without body focus (notes_locked? only covers
+  # active_tab == :notes && focus == :body), and on every tab-away-and-back.
+  it "soft-merge keeps caret, scroll and undo when a CRLF-stored note matches the LF buffer" do
+    tmp_store do |store|
+      body = (1..8).map { |i| "line #{i}" }.join('\n')
+      view = NotesView.new
+      view.reload(store)
+      view.enter_insert!
+      type(view, body)
+      view.save(store) # the poll path is only reached on a clean buffer (reload bails when dirty)
+      id = view.current_note_id
+
+      # A peer (MCP update_note) rewrote the SAME content in wire CRLF form.
+      store.set_setting("notes.docs",
+        %({"cur":0,"next_id":#{id + 1},"notes":[{"id":#{id},"text":#{body.gsub('\n', "\r\n").to_json}}]}))
+
+      area = view.@notes[0].area
+      render_text(view, 40, 3) # a rendered viewport height is what scroll_view clamps against
+      area.scroll_view(2)
+      area.place_cursor(5, 3)
+      undo_depth = area.@undo_stack.size
+      undo_depth.should be > 0
+      cy, cx, scroll = area.cy, area.cx, area.scroll
+
+      view.reload(store) # the data_version poll
+
+      view.@notes[0].area.should be(area) # same TextArea object — never rebuilt
+      area.cy.should eq(cy)
+      area.cx.should eq(cx)
+      area.scroll.should eq(scroll)
+      area.@undo_stack.size.should eq(undo_depth) # set_text would have cleared it
+      view.current_text.should eq(body)
+    end
+  end
+
+  # The guard must not swallow a REAL peer edit: normalizing line endings only makes the compare
+  # ignore \r, not content. A CRLF peer body with different text still replaces the buffer (and
+  # lands as LF, since set_text strips \r).
+  it "soft-merge still applies a CRLF-stored peer edit whose content actually changed" do
+    tmp_store do |store|
+      view = NotesView.new
+      view.reload(store)
+      type(view, "alpha\nbravo")
+      view.save(store)
+      id = view.current_note_id
+
+      store.set_setting("notes.docs",
+        %({"cur":0,"next_id":#{id + 1},"notes":[{"id":#{id},"text":"alpha\\r\\nCHANGED"}]}))
+      view.reload(store)
+
+      view.current_text.should eq("alpha\nCHANGED")
+      view.dirty?.should be_false
+    end
+  end
+
   it "projects sub-tab filter rows (title + body) per note in chip order" do
     view = NotesView.new
     type(view, "Alpha title\nbody about idor")

--- a/spec/tui/text_area_spec.cr
+++ b/spec/tui/text_area_spec.cr
@@ -413,4 +413,20 @@ describe Gori::Tui::TextArea do
       (0...8).count { |y| off.grid[y][col] == '┃' }.should eq(0)
     end
   end
+
+  describe ".normalize_lf" do
+    # The contract is exactly "what set_text would store", since every reconcile guard uses it
+    # to decide whether set_text (caret/scroll/undo destroying) can be skipped.
+    it "returns the text set_text would store, for CRLF, bare LF and lone CR" do
+      {"a\r\nb\r\n\r\n", "a\nb\n\n", "plain", "", "a\rb", "tail\r"}.each do |s|
+        TextArea.normalize_lf(s).should eq(TextArea.new(s).text)
+      end
+    end
+
+    # A blanket \r→\n gsub would split "a\rb" into two lines and report a spurious mismatch;
+    # set_text keeps the lone \r on the line, so normalize_lf must too.
+    it "keeps a lone mid-line CR instead of splitting it into a new line" do
+      TextArea.normalize_lf("a\rb").should eq("a\rb")
+    end
+  end
 end

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -245,7 +245,11 @@ module Gori::Tui
       @tcx = @target.size
       @http2 = rec.http2?
       @sni = rec.sni || ""
-      @editor.set_text(rec.template) if @editor.text != rec.template
+      # Normalized compare for the same reason as session_side_matches? below: set_text zeroes
+      # the caret/scroll and clears undo, so it must only run on a REAL text change. No writer
+      # puts CRLF in fuzz_sessions.template today (only the fuzzer controller writes it, always
+      # from @editor.text, already LF) — kept consistent so it can't rot if one ever does.
+      @editor.set_text(rec.template) if @editor.text != TextArea.normalize_lf(rec.template)
       @name = rec.name
       apply_config_json(rec.config)
       @last_synced_config = rec.config
@@ -257,15 +261,11 @@ module Gori::Tui
     # Template compare normalizes CRLF→LF (TextArea stores LF; the store may hold wire CRLF).
     def session_side_matches?(rec : Store::FuzzSessionRecord) : Bool
       @target == rec.target &&
-        template_text == normalize_lf(rec.template) &&
+        template_text == TextArea.normalize_lf(rec.template) &&
         @http2 == rec.http2? &&
         (sni_override || "") == (rec.sni || "") &&
         (@name || "") == (rec.name || "") &&
         @last_synced_config == rec.config
-    end
-
-    private def normalize_lf(s : String) : String
-      s.gsub("\r\n", "\n").gsub('\r', '\n')
     end
 
     # Content-only clone for sub-tab Duplicate: template + target + config/sets.

--- a/src/gori/tui/notes_view.cr
+++ b/src/gori/tui/notes_view.cr
@@ -106,8 +106,16 @@ module Gori::Tui
       merged = [] of Note
       doc.notes.each do |e|
         if existing = by_id[e.id]?
-          if existing.area.text != e.text
-            # Peer (or our own saved) content changed — replace body; caret resets with set_text.
+          # Compare on a CRLF-normalized basis: the TextArea buffer is ALWAYS LF (set_text
+          # strips \r) while NoteEntry#text is whatever was written into the JSON KV verbatim,
+          # and several writers store wire CRLF — MCP create_note/update_note pass the caller's
+          # string straight through, and `gori run notes create` takes its body from --text /
+          # positional args / STDIN (piping a CRLF file, or `gori run flow N --raw`, stores
+          # CRLF). Without normalizing, a CRLF note compares unequal on EVERY poll, so set_text
+          # re-ran ~1.3×/s during capture and zeroed the caret + scroll and cleared undo.
+          if existing.area.text != TextArea.normalize_lf(e.text)
+            # Peer (or our own saved) content genuinely changed — replace body; caret resets
+            # with set_text, which is correct here: the text under it is no longer the same.
             existing.area.set_text(e.text)
           end
           # Same text → keep the TextArea object (caret/scroll/undo stack intact).

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -1032,7 +1032,7 @@ module Gori::Tui
     # Mirrors FuzzerView#session_side_matches?.
     def request_side_matches?(target : String, request : String, http2 : Bool, auto_cl : Bool,
                               sni : String?) : Bool
-      @target == target && request_text == normalize_lf(request) &&
+      @target == target && request_text == TextArea.normalize_lf(request) &&
         @http2 == http2 && @auto_content_length == auto_cl &&
         (sni_override || "") == (sni || "")
     end
@@ -1057,25 +1057,18 @@ module Gori::Tui
         # that only touched a non-text field must not disturb the pane. Compare on a
         # CRLF-normalized basis (the editor is LF; the store may be CRLF). Mirrors
         # FuzzerView#apply_peer_session / NotesView#soft_merge_from.
-        @editor.set_text(request) if @editor.text != normalize_lf(request)
+        @editor.set_text(request) if @editor.text != TextArea.normalize_lf(request)
         joined = (ws_messages || [] of String).join('\n')
-        @decoded.set_text(joined) if @decoded.text != normalize_lf(joined)
+        @decoded.set_text(joined) if @decoded.text != TextArea.normalize_lf(joined)
         @req_pane = :decoded
       else
         @ws_mode = false
-        @editor.set_text(request) if @editor.text != normalize_lf(request)
+        @editor.set_text(request) if @editor.text != TextArea.normalize_lf(request)
       end
 
       @auto_content_length = auto_cl
       @loaded = true
       @dirty = false
-    end
-
-    # Wire CRLF → editor LF. The TextArea always stores LF (set_text strips \r), so a
-    # request/message that arrives CRLF (store, MCP, import, peer) must be normalized
-    # before comparing against editor text — else the compare is falsely unequal.
-    private def normalize_lf(s : String) : String
-      s.gsub("\r\n", "\n").gsub('\r', '\n')
     end
 
     # Re-seed the captured-original diff baseline for a ^R-from-History tab that was

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -88,6 +88,30 @@ module Gori::Tui
     getter scroll : Int32
     getter? gutter : Bool
 
+    # The exact LF form `set_text` would store for `text` — the single source of truth for
+    # "does this incoming string already match what the buffer holds?".
+    #
+    # Every poll-driven reconcile path (RepeaterView#request_side_matches? /
+    # #apply_peer_request, FuzzerView#session_side_matches? / #apply_peer_session,
+    # NotesView#soft_merge_from) compares an incoming store string against `#text` BEFORE
+    # calling set_text, because set_text zeroes the caret + scroll and CLEARS THE UNDO STACK.
+    # The buffer is always LF (set_text below splits on \n and rstrips \r) while the store can
+    # hold wire CRLF — MCP create_repeater/create_note + update_note, `gori run notes create`
+    # piping a raw request or a CRLF file, import, or a peer session all write the body
+    # verbatim. So a raw `==` is falsely unequal on EVERY poll, the guard never fires, and the
+    # caret is slammed back to 0,0 (and undo wiped) on every data_version tick (~1.3×/s while
+    # capturing). Lives here, next to set_text, because set_text is what defines the answer:
+    # the two cannot drift.
+    #
+    # Mirrors set_text's split/rstrip rather than a blanket \r→\n gsub deliberately: a LONE \r
+    # mid-line is data set_text KEEPS on the line, whereas a gsub would split it into a second
+    # line and report a spurious mismatch — the very false-negative this exists to kill.
+    def self.normalize_lf(text : String) : String
+      return text unless text.includes?('\r') # the overwhelmingly common case — no allocation
+      text.split('\n').map(&.rstrip('\r')).join('\n')
+    end
+
+    # NOTE: `self.normalize_lf` above mirrors this line — keep them in step.
     def set_text(text : String) : Nil
       @lines = text.split('\n').map(&.rstrip('\r'))
       @lines = [""] if @lines.empty?


### PR DESCRIPTION
The same defect #277 fixed in RepeaterView, still live in `NotesView#soft_merge_from`.

```crystal
if existing.area.text != e.text
  existing.area.set_text(e.text)
end
```

`area.text` is always LF (`set_text` strips `\r`); `NoteEntry#text` is read verbatim out of the JSON KV and never normalized. For any note whose stored body carries CRLF the compare is false on **every** poll, so `set_text` re-runs — zeroing the caret, resetting scroll, and clearing the undo stack.

Confirmed CRLF writers, all storing the body verbatim:
- MCP `create_note` / `update_note` — the caller's string passes straight through.
- `gori run notes create` — body from `--text`, positional args, or STDIN. Piping a CRLF file, or `gori run flow N --raw | gori run notes create`, stores CRLF.

Poll path is `runner.cr` `apply_external_change`, firing on every `data_version` bump (~1.3×/s during capture). `reload` only bails on `@dirty`, and `soft_merge_from` sets `@dirty = false`, so it never latches. `notes_locked?` only covers `@active_tab == :notes && @focus == :body`, so the user hits it whenever Notes is open with focus on the sub-tab strip or the menu, and on every tab-away-and-back — the note is permanently scrolled back to the top and `^Z` does nothing.

## Approach
There were already **two** private copies of `normalize_lf` (`repeater_view.cr` from #277, `fuzzer_view.cr`). A third crossed the duplication threshold, so this hoists one class method to `TextArea.normalize_lf` and deletes both copies. It lives next to `set_text` because `set_text` is what *defines* the answer — the helper exists solely to predict what `set_text` would store, so co-locating them means the guard and the writer cannot drift.

That reframing exposed a latent bug in the inherited implementation. `gsub("\r\n","\n").gsub('\r','\n')` is **not** the inverse of `set_text`, which does `split('\n').map(&.rstrip('\r'))`:

```
"a\rb".split('\n').map(&.rstrip('\r')).join('\n')  => "a\rb"   # matches set_text
"a\rb".gsub("\r\n","\n").gsub('\r','\n')           => "a\nb"   # wrong
```

On a lone mid-line `\r` the gsub reports a spurious mismatch — the exact false-negative the helper exists to kill. The shared version mirrors `set_text` instead, plus a no-alloc fast path when there is no `\r`. Strictly a false-negative fix, never a false positive: `area.text == normalize_lf(s)` now literally means "`set_text(s)` would produce the current lines".

`FuzzerView#apply_peer_session` also compared unnormalized; converted for consistency. No production writer can put CRLF in `fuzz_sessions.template` today (only the fuzzer controller writes it, always from `@editor.text`), so that one is rot-proofing, not a live bug.

No sibling unguarded `set_text` in this file: the other write in `soft_merge_from` builds a fresh `Note` with no caret to destroy, and the remaining calls are user-driven, not poll-driven.

## Verification
Regression spec asserts caret (`cy`/`cx`), scroll, undo-stack size and TextArea object identity survive a poll on a CRLF-bodied note, plus a companion test that a genuinely-changed body still syncs — the obvious way to over-fix this is to break real syncing.

Control run with the fix reverted, proving the spec is not vacuous:

```
1) soft-merge keeps caret, scroll and undo when a CRLF-stored note matches the LF buffer
   Failure/Error: area.cy.should eq(cy)
     Expected: 5
          got: 0
```

`notes_view + text_area + repeater_view + fuzzer_view` → 168 examples, 0 failures. Full suite on the combined branch: 2424 examples, 0 failures.