### PR TITLE
fix(ui): render wildcard binds as a dialable address, not "0.0.0.0"

### DIFF
--- a/spec/bind_address_spec.cr
+++ b/spec/bind_address_spec.cr
@@ -1,0 +1,104 @@
+require "./spec_helper"
+
+# The two questions a bind address gets asked, which diverge the moment the bind is a
+# wildcard: what to SHOW (display) versus what to CONNECT to (dial_host). Every surface
+# that prints an address routes through here, so these examples are the single pin on
+# "gori never tells the user to type an address that cannot work".
+describe Gori::BindAddress do
+  describe ".display" do
+    it "renders a wildcard IPv4 bind as a dialable address plus the reachability note" do
+      # "0.0.0.0:8070" is what these surfaces used to print. Nothing can connect to it,
+      # so it is exactly the wrong thing to show next to "point your client here".
+      Gori::BindAddress.display("0.0.0.0", 8070).should eq("localhost:8070 (all interfaces)")
+    end
+
+    it "renders both IPv6 wildcard spellings the same way" do
+      Gori::BindAddress.display("::", 8070).should eq("localhost:8070 (all interfaces)")
+      Gori::BindAddress.display("::0", 8070).should eq("localhost:8070 (all interfaces)")
+    end
+
+    it "treats a blank bind as a wildcard (it is caller-defaulted to loopback)" do
+      Gori::BindAddress.display("", 8070).should eq("localhost:8070 (all interfaces)")
+    end
+
+    it "drops only the note when terse, never changing the address itself" do
+      # The invariant that lets the width-constrained chips share this helper: a user
+      # can never see two different addresses depending on which surface they look at.
+      terse = Gori::BindAddress.display("0.0.0.0", 8070, terse: true)
+      terse.should eq("localhost:8070")
+      Gori::BindAddress.display("0.0.0.0", 8070).should start_with(terse)
+    end
+
+    it "collapses the canonical loopback spellings to localhost" do
+      Gori::BindAddress.display("127.0.0.1", 8070).should eq("localhost:8070")
+      Gori::BindAddress.display("::1", 9000).should eq("localhost:9000")
+      Gori::BindAddress.display("localhost", 8070).should eq("localhost:8070")
+    end
+
+    it "leaves a concrete LAN IPv4 alone" do
+      Gori::BindAddress.display("192.168.1.5", 8070).should eq("192.168.1.5:8070")
+    end
+
+    it "brackets a concrete IPv6 literal so host:port stays unambiguous" do
+      # Bare interpolation produced "fe80::1:8080" — unparseable and not copy-pasteable.
+      Gori::BindAddress.display("fe80::1", 8080).should eq("[fe80::1]:8080")
+    end
+
+    it "does not double-bracket an already-bracketed literal" do
+      Gori::BindAddress.display("[fe80::1]", 8080).should eq("[fe80::1]:8080")
+    end
+
+    it "leaves a hostname alone" do
+      Gori::BindAddress.display("proxy.example.com", 3128).should eq("proxy.example.com:3128")
+    end
+
+    it "keeps a non-canonical loopback alias literal (localhost would not reach it)" do
+      Gori::BindAddress.display("127.0.0.2", 8070).should eq("127.0.0.2:8070")
+    end
+  end
+
+  describe ".dial_host" do
+    it "collapses a wildcard to loopback OF THE SAME FAMILY" do
+      # Family matters: a 0.0.0.0 listener is unreachable over ::1, and a :: listener is
+      # unreachable over 127.0.0.1 unless the kernel is dual-stack. "localhost" would
+      # leave that to the resolver's preference — the wrong-family hang we are avoiding.
+      Gori::BindAddress.dial_host("0.0.0.0").should eq("127.0.0.1")
+      Gori::BindAddress.dial_host("::").should eq("::1")
+      Gori::BindAddress.dial_host("::0").should eq("::1")
+      Gori::BindAddress.dial_host("").should eq("127.0.0.1")
+    end
+
+    it "returns a concrete bind unchanged" do
+      Gori::BindAddress.dial_host("192.168.1.5").should eq("192.168.1.5")
+      Gori::BindAddress.dial_host("127.0.0.1").should eq("127.0.0.1")
+      Gori::BindAddress.dial_host("proxy.example.com").should eq("proxy.example.com")
+    end
+
+    it "returns a BARE host, stripping brackets (Firefox's host-only pref must not see them)" do
+      Gori::BindAddress.dial_host("[fe80::1]").should eq("fe80::1")
+    end
+  end
+
+  describe ".authority" do
+    it "brackets IPv6 and leaves IPv4/hostnames bare" do
+      Gori::BindAddress.authority("::1", 8070).should eq("[::1]:8070")
+      Gori::BindAddress.authority("127.0.0.1", 8070).should eq("127.0.0.1:8070")
+      Gori::BindAddress.authority("example.com", 8070).should eq("example.com:8070")
+    end
+
+    it "does NOT resolve a wildcard — that is dial_host's job" do
+      Gori::BindAddress.authority("0.0.0.0", 8070).should eq("0.0.0.0:8070")
+    end
+  end
+
+  describe ".wildcard?" do
+    it "recognises every spelling bind_host_error accepts, and nothing else" do
+      {"0.0.0.0", "::", "::0", "0:0:0:0:0:0:0:0", "[::]", ""}.each do |h|
+        Gori::BindAddress.wildcard?(h).should be_true
+      end
+      {"127.0.0.1", "::1", "192.168.1.5", "localhost", "0.0.0.1"}.each do |h|
+        Gori::BindAddress.wildcard?(h).should be_false
+      end
+    end
+  end
+end

--- a/spec/browser_spec.cr
+++ b/spec/browser_spec.cr
@@ -47,6 +47,58 @@ describe Gori::Browser do
     end
   end
 
+  # A browser is the one surface that doesn't just PRINT the bind — it dials it. Under a
+  # wildcard bind the raw "0.0.0.0" was written straight into the browser's proxy config,
+  # which opens a browser that proxies nothing and looks like gori is broken.
+  describe "proxy address resolution" do
+    wildcard = Gori::Browser::LaunchSpec.new(
+      proxy_host: "0.0.0.0", proxy_port: 8070,
+      ca_cert_path: "/tmp/root.crt.pem", spki_sha256: "PIN123=",
+      profile_root: "/tmp/gori-browser")
+    v6_wildcard = Gori::Browser::LaunchSpec.new(
+      proxy_host: "::", proxy_port: 8070,
+      ca_cert_path: "/tmp/root.crt.pem", spki_sha256: "PIN123=",
+      profile_root: "/tmp/gori-browser")
+    v6 = Gori::Browser::LaunchSpec.new(
+      proxy_host: "::1", proxy_port: 8070,
+      ca_cert_path: "/tmp/root.crt.pem", spki_sha256: "PIN123=",
+      profile_root: "/tmp/gori-browser")
+
+    it "points Chromium at loopback when the bind is a wildcard" do
+      Gori::Browser.chromium_args("/tmp/prof", wildcard)
+        .should contain("--proxy-server=http://127.0.0.1:8070")
+      # Same-family loopback: a :: listener isn't reliably reachable over 127.0.0.1.
+      Gori::Browser.chromium_args("/tmp/prof", v6_wildcard)
+        .should contain("--proxy-server=http://[::1]:8070")
+    end
+
+    it "brackets an IPv6 proxy host in the Chromium URL" do
+      # Bare interpolation yielded "http://::1:8070", which Chromium cannot parse.
+      Gori::Browser.chromium_args("/tmp/prof", v6)
+        .should contain("--proxy-server=http://[::1]:8070")
+    end
+
+    it "points Firefox at loopback when the bind is a wildcard" do
+      js = Gori::Browser.firefox_user_js(wildcard)
+      js.should contain(%(user_pref("network.proxy.http", "127.0.0.1");))
+      js.should contain(%(user_pref("network.proxy.ssl", "127.0.0.1");))
+      js.should_not contain("0.0.0.0")
+    end
+
+    it "writes a BARE IPv6 host to Firefox's prefs (the port is a separate pref)" do
+      js = Gori::Browser.firefox_user_js(v6)
+      js.should contain(%(user_pref("network.proxy.http", "::1");))
+      js.should contain(%(user_pref("network.proxy.http_port", 8070);))
+      js.should_not contain("[::1]")
+    end
+
+    it "exposes the resolved authority for the launch status line" do
+      wildcard.dial_authority.should eq("127.0.0.1:8070")
+      v6.dial_authority.should eq("[::1]:8070")
+      SPEC_LAUNCH.dial_authority.should eq("127.0.0.1:8070")
+    end
+  end
+
   describe ".detect" do
     it "only returns browsers of a known kind (env-dependent, may be empty)" do
       Gori::Browser.detect.each do |f|

--- a/spec/capture_status_spec.cr
+++ b/spec/capture_status_spec.cr
@@ -34,7 +34,17 @@ describe Gori::CaptureStatus do
   it "formats loopback hosts as localhost" do
     Gori::CaptureStatus.format_endpoint("127.0.0.1", 8070).should eq("localhost:8070")
     Gori::CaptureStatus.format_endpoint("::1", 9000).should eq("localhost:9000")
-    Gori::CaptureStatus.format_endpoint("0.0.0.0", 8070).should eq("0.0.0.0:8070")
+  end
+
+  it "shows a wildcard bind as the dialable address, not '0.0.0.0'" do
+    # The picker row used to read "● 0.0.0.0:8070" — an address no client can connect to.
+    # Terse (no "(all interfaces)" note): this rides inside a chip in a project row.
+    Gori::CaptureStatus.format_endpoint("0.0.0.0", 8070).should eq("localhost:8070")
+    Gori::CaptureStatus.format_endpoint("::", 8070).should eq("localhost:8070")
+  end
+
+  it "brackets an IPv6 bind so the chip stays copy-pasteable" do
+    Gori::CaptureStatus.format_endpoint("fe80::1", 8070).should eq("[fe80::1]:8070")
   end
 end
 

--- a/spec/proxy/self_page_spec.cr
+++ b/spec/proxy/self_page_spec.cr
@@ -93,10 +93,22 @@ describe Gori::Proxy::SelfPage do
       head.should contain("text/html")
       text = String.new(body)
       text.should contain("gori")
-      text.should contain("127.0.0.1:8070")
+      text.should contain("localhost:8070")
       text.should contain("9.9.9")
       text.should contain("/ca.der")
       text.should contain("/ca.pem")
+    end
+
+    it "brackets an IPv6 reached-address on the Listening line" do
+      # Since 5b956ee `listen[0]` is the CONCRETE address the device reached us on, which
+      # under a `::` bind is a bare IPv6 literal — "fe80::1:8070" is ambiguous and not
+      # copy-pasteable, which matters most here since this page exists to be read off a
+      # phone screen.
+      resp = Gori::Proxy::SelfPage.respond("/", pem: pem, der: der, spki: "SPKI==",
+        ca_path: "/home/u/.gori/ca/root.crt.pem", listen: {"fe80::1", 8070},
+        version: "9.9.9", head_only: false)
+      _, body = split_response(resp)
+      String.new(body).should contain("[fe80::1]:8070")
     end
 
     it "serves the PEM with an attachment disposition" do

--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -745,9 +745,9 @@ describe Gori::Tui::HistoryView do
       view.reload(store)
       backend = MemoryBackend.new(80, 14)
       view.render_list(Screen.new(backend), Rect.new(0, 0, 80, 14),
-        listen: "127.0.0.1:8070", capturing: true)
+        listen: {"127.0.0.1", 8070}, capturing: true)
       backend.contains?("waiting for traffic").should be_true
-      backend.contains?("127.0.0.1:8070").should be_true
+      backend.contains?("localhost:8070").should be_true
       backend.contains?("Open browser").should be_true
       backend.contains?("FLOW LOG").should be_true
     end

--- a/spec/tui/intercept_view_spec.cr
+++ b/spec/tui/intercept_view_spec.cr
@@ -57,7 +57,7 @@ describe Gori::Tui::InterceptView do
       view.reload(ic)
       backend = MemoryBackend.new(80, 14)
       view.render(Screen.new(backend), Rect.new(0, 0, 80, 14),
-        listen: "127.0.0.1:8070", capturing: true)
+        listen: {"127.0.0.1", 8070}, capturing: true)
       backend.contains?("no held messages").should be_true
       backend.contains?("INTERCEPT").should be_true
       backend.contains?("i:CATCH").should be_true

--- a/spec/tui/probe_live_refresh_spec.cr
+++ b/spec/tui/probe_live_refresh_spec.cr
@@ -47,7 +47,7 @@ describe "Probe live list refresh (generation poll)" do
       backend = MemoryBackend.new(100, 30)
       screen = Gori::Tui::Screen.new(backend)
       rect = Gori::Tui::Rect.new(0, 0, 100, 30)
-      view.render(screen, rect, focused: true, listen: "127.0.0.1:8080", capturing: true)
+      view.render(screen, rect, focused: true, listen: {"127.0.0.1", 8080}, capturing: true)
       backend.contains?("Reflected parameter").should be_true
       backend.contains?("xss.test").should be_true
     ensure

--- a/spec/tui/sitemap_view_spec.cr
+++ b/spec/tui/sitemap_view_spec.cr
@@ -71,9 +71,9 @@ describe Gori::Tui::SitemapView do
       view.reload(store)
       backend = MemoryBackend.new(70, 14)
       view.render(Screen.new(backend), Rect.new(0, 0, 70, 14),
-        listen: "127.0.0.1:8070", capturing: true)
+        listen: {"127.0.0.1", 8070}, capturing: true)
       backend.contains?("no traffic captured").should be_true
-      backend.contains?("127.0.0.1:8070").should be_true
+      backend.contains?("localhost:8070").should be_true
       backend.contains?("Open browser").should be_true
       backend.contains?("SITE MAP").should be_true
       backend.contains?("HOST / PATH").should be_true

--- a/spec/tui/traffic_empty_state_spec.cr
+++ b/spec/tui/traffic_empty_state_spec.cr
@@ -8,10 +8,10 @@ describe Gori::Tui::TrafficEmptyState do
     backend = MemoryBackend.new(60, 12)
     rect = Rect.new(0, 0, 60, 12)
     TrafficEmptyState.render(Screen.new(backend), rect,
-      variant: :history, listen: "127.0.0.1:8070", capturing: true)
+      variant: :history, listen: {"127.0.0.1", 8070}, capturing: true)
     backend.contains?("waiting for traffic").should be_true
     backend.contains?("FLOW LOG").should be_true
-    backend.contains?("127.0.0.1:8070").should be_true
+    backend.contains?("localhost:8070").should be_true
     backend.contains?("Open browser").should be_true
     backend.contains?("──►").should be_true
     backend.contains?("SITE MAP").should be_false
@@ -21,10 +21,14 @@ describe Gori::Tui::TrafficEmptyState do
     backend = MemoryBackend.new(60, 12)
     rect = Rect.new(0, 0, 60, 12)
     TrafficEmptyState.render(Screen.new(backend), rect,
-      variant: :sitemap, listen: "0.0.0.0:9090", capturing: true)
+      variant: :sitemap, listen: {"0.0.0.0", 9090}, capturing: true)
     backend.contains?("no traffic captured").should be_true
     backend.contains?("SITE MAP").should be_true
-    backend.contains?("0.0.0.0:9090").should be_true
+    # A wildcard bind must NOT be shown as "0.0.0.0:9090" here — this card is the
+    # onboarding surface and that address is the one the user is told to type. The full
+    # card has room for the note that LAN devices can reach the listener too.
+    backend.contains?("0.0.0.0").should be_false
+    backend.contains?("localhost:9090 (all interfaces)").should be_true
     backend.contains?("hosts group traffic").should be_true
     backend.contains?("paths nest").should be_true
     backend.contains?("FLOW LOG").should be_false
@@ -34,7 +38,7 @@ describe Gori::Tui::TrafficEmptyState do
     backend = MemoryBackend.new(60, 12)
     rect = Rect.new(0, 0, 60, 12)
     TrafficEmptyState.render(Screen.new(backend), rect,
-      variant: :history, listen: "127.0.0.1:8070", capturing: false)
+      variant: :history, listen: {"127.0.0.1", 8070}, capturing: false)
     backend.contains?("capture is OFF").should be_true
     backend.contains?("press c").should be_true
   end
@@ -43,7 +47,7 @@ describe Gori::Tui::TrafficEmptyState do
     backend = MemoryBackend.new(34, 6)
     rect = Rect.new(0, 0, 34, 6)
     TrafficEmptyState.render(Screen.new(backend), rect,
-      variant: :history, listen: "10.0.0.5:3128", capturing: true)
+      variant: :history, listen: {"10.0.0.5", 3128}, capturing: true)
     backend.contains?("waiting for traffic").should be_true
     backend.contains?("10.0.0.5:3128").should be_true
     backend.contains?("──►").should be_true
@@ -54,17 +58,30 @@ describe Gori::Tui::TrafficEmptyState do
     backend = MemoryBackend.new(34, 6)
     rect = Rect.new(0, 0, 34, 6)
     TrafficEmptyState.render(Screen.new(backend), rect,
-      variant: :sitemap, listen: "10.0.0.5:3128", capturing: true)
+      variant: :sitemap, listen: {"10.0.0.5", 3128}, capturing: true)
     backend.contains?("no traffic captured").should be_true
     backend.contains?("◆ proxy").should be_true
     backend.contains?("host tr").should be_true # truncated on narrow panes
+  end
+
+  it "drops only the wildcard note on a narrow pane, never the address" do
+    # The compact fallbacks inline the address into a longer hint line, so they take the
+    # terse render. The ADDRESS still matches the full card's — a resize must not look
+    # like the proxy moved, and must never fall back to the undialable "0.0.0.0".
+    backend = MemoryBackend.new(34, 6)
+    rect = Rect.new(0, 0, 34, 6)
+    TrafficEmptyState.render(Screen.new(backend), rect,
+      variant: :history, listen: {"0.0.0.0", 9090}, capturing: true)
+    backend.contains?("localhost:9090").should be_true
+    backend.contains?("0.0.0.0").should be_false
+    backend.contains?("all interfaces").should be_false
   end
 
   it "renders the intercept hold-queue card" do
     backend = MemoryBackend.new(60, 12)
     rect = Rect.new(0, 0, 60, 12)
     TrafficEmptyState.render(Screen.new(backend), rect,
-      variant: :intercept, listen: "127.0.0.1:8070", capturing: true, catch_on: false)
+      variant: :intercept, listen: {"127.0.0.1", 8070}, capturing: true, catch_on: false)
     backend.contains?("no held messages").should be_true
     backend.contains?("INTERCEPT").should be_true
     backend.contains?("press i").should be_true
@@ -104,7 +121,7 @@ describe Gori::Tui::TrafficEmptyState do
     backend = MemoryBackend.new(60, 12)
     rect = Rect.new(0, 0, 60, 12)
     TrafficEmptyState.render(Screen.new(backend), rect,
-      variant: :probe, listen: "127.0.0.1:8070", capturing: true, scan_on: true)
+      variant: :probe, listen: {"127.0.0.1", 8070}, capturing: true, scan_on: true)
     backend.contains?("no issues yet").should be_true
     backend.contains?("PROBE").should be_true
     backend.contains?("scan").should be_true
@@ -145,7 +162,7 @@ describe Gori::Tui::TrafficEmptyState do
     backend = MemoryBackend.new(38, 3)
     rect = Rect.new(0, 0, 38, 3)
     TrafficEmptyState.render(Screen.new(backend), rect,
-      variant: :sitemap, listen: "127.0.0.1:8070", capturing: false)
+      variant: :sitemap, listen: {"127.0.0.1", 8070}, capturing: false)
     backend.contains?("no traffic captured").should be_true
     backend.contains?("◆ proxy").should be_true
     backend.contains?("^P Open br").should be_true # truncated on narrow panes

--- a/src/gori/app.cr
+++ b/src/gori/app.cr
@@ -1,4 +1,5 @@
 require "log"
+require "./bind_address"
 require "./config"
 require "./paths"
 require "./settings"
@@ -177,9 +178,13 @@ module Gori
     private def print_banner(session : Session) : Nil
       proxy = session.proxy
       upstream = @config.insecure_upstream? ? "insecure-upstream" : "verify-upstream"
-      STDERR.puts "gori #{VERSION} listening on #{proxy.host}:#{proxy.port} (#{upstream})"
+      # The bind is what we CALL the listener; `addr` is what the user can actually type
+      # into a client. Under a wildcard bind those differ — telling someone to point their
+      # proxy at "0.0.0.0:8070" hands them a string no client can connect to.
+      addr = BindAddress.display(proxy.host, proxy.port)
+      STDERR.puts "gori #{VERSION} listening on #{addr} (#{upstream})"
       STDERR.puts "  root CA: #{@ca.ca_cert_path}"
-      STDERR.puts "  trust the CA above, then point your client's HTTP+HTTPS proxy at #{proxy.host}:#{proxy.port}"
+      STDERR.puts "  trust the CA above, then point your client's HTTP+HTTPS proxy at #{addr}"
       STDERR.puts "  db: #{session.project.db_path}"
       STDERR.puts "  press Ctrl-C to stop"
     end

--- a/src/gori/bind_address.cr
+++ b/src/gori/bind_address.cr
@@ -1,0 +1,95 @@
+module Gori
+  # One place that answers the two DIFFERENT questions a proxy bind address gets asked.
+  # They read like the same question and stop being one the moment the bind is a wildcard:
+  #
+  #   display(host, port) — what to SHOW a human ("localhost:8070 (all interfaces)")
+  #   dial_host(host)     — what a client on this machine must actually CONNECT to
+  #
+  # A wildcard bind ("0.0.0.0" / "::") means "answer on every interface". It is a fine
+  # thing to bind and a useless thing to dial: nothing connects TO 0.0.0.0. So printing
+  # "point your client's proxy at 0.0.0.0:8070" hands the user a string that cannot work,
+  # and feeding it to a browser's --proxy-server launches a browser that proxies nothing
+  # (the bug this module exists to kill). Both surfaces resolve a wildcard to loopback.
+  #
+  # Deliberately a leaf with NO requires: `capture_status` (a json-only sidecar read by
+  # the project picker) and `proxy/conn/self_page` (deep inside the proxy) both need it,
+  # and neither may grow a dependency on the other's subtree.
+  module BindAddress
+    # Appended to a wildcard bind's display. "localhost" alone is typeable but hides that
+    # LAN devices can reach this listener too — and that reachability is the entire reason
+    # anyone binds a wildcard (installing the CA on a phone, see 5b956ee).
+    WILDCARD_NOTE = "all interfaces"
+
+    # Every spelling of "bind to every interface" that Settings.bind_host_error accepts,
+    # plus blank — blank is caller-defaulted to loopback (SetupWizard#effective_ip) and
+    # is just as undialable as 0.0.0.0 until it is.
+    def self.wildcard?(host : String) : Bool
+      case normalize(host)
+      when "", "0.0.0.0", "::", "::0", "0:0:0:0:0:0:0:0" then true
+      else                                                    false
+      end
+    end
+
+    # The concrete host a client ON THIS MACHINE should dial to reach a listener bound to
+    # `host`. Only a wildcard moves, and it collapses to loopback OF THE SAME FAMILY:
+    # 127.0.0.1 for an IPv4 wildcard, ::1 for an IPv6 one. Deliberately NOT "localhost" —
+    # that name resolves to whichever family the resolver prefers, and a 0.0.0.0 listener
+    # is unreachable over ::1 (a :: listener likewise over 127.0.0.1 unless the kernel is
+    # dual-stack), so "localhost" reintroduces the classic wrong-family connect failure
+    # at exactly the point we are trying to remove one.
+    #
+    # A concrete bind is already dialable and comes back unchanged, with brackets stripped
+    # so callers needing a BARE host get one (Firefox's network.proxy.http pref takes the
+    # port separately and must not see brackets); `authority` re-adds them.
+    def self.dial_host(host : String) : String
+      h = strip_brackets(host.strip)
+      return h unless wildcard?(h)
+      h.includes?(':') ? "::1" : "127.0.0.1"
+    end
+
+    # "host:port", bracketing an IPv6 literal. Call sites used to build this by hand with
+    # bare interpolation, which renders a perfectly legal `::1` bind (bind_host_error
+    # accepts it) as the unparseable "::1:8070".
+    def self.authority(host : String, port : Int32) : String
+      h = strip_brackets(host.strip)
+      h.includes?(':') ? "[#{h}]:#{port}" : "#{h}:#{port}"
+    end
+
+    # The bind as a human should read it: a loopback spelling collapses to "localhost"
+    # (what the user would actually type), an IPv6 literal is bracketed, and a wildcard
+    # renders as the loopback address they CAN type plus a note that it is not only that.
+    #
+    # `terse` drops the note for width-constrained readouts (the top-bar listen chip, the
+    # project-picker row). The ADDRESS is byte-identical either way — only the
+    # parenthetical is budgeted — so no two surfaces can ever show the user a different
+    # address to type, which is the whole point of routing every site through here.
+    def self.display(host : String, port : Int32, *, terse : Bool = false) : String
+      if wildcard?(host)
+        base = "localhost:#{port}"
+        terse ? base : "#{base} (#{WILDCARD_NOTE})"
+      elsif localhost_alias?(host)
+        "localhost:#{port}"
+      else
+        authority(host, port)
+      end
+    end
+
+    # Only the CANONICAL loopback spellings become "localhost". A non-canonical 127.x
+    # (127.0.0.2, a second loopback alias someone bound on purpose) stays literal: dialing
+    # "localhost" would not reach it, so collapsing it would print an address that lies.
+    private def self.localhost_alias?(host : String) : Bool
+      case normalize(host)
+      when "localhost", "127.0.0.1", "::1", "0:0:0:0:0:0:0:1" then true
+      else                                                         false
+      end
+    end
+
+    private def self.normalize(host : String) : String
+      strip_brackets(host.strip).downcase
+    end
+
+    private def self.strip_brackets(h : String) : String
+      h.starts_with?('[') && h.ends_with?(']') ? h[1...-1] : h
+    end
+  end
+end

--- a/src/gori/browser.cr
+++ b/src/gori/browser.cr
@@ -1,3 +1,5 @@
+require "./bind_address"
+
 module Gori
   # Detect installed browsers and launch one pre-configured to trust gori's CA
   # and route through gori's proxy — the "open browser" feature Burp/Caido ship.
@@ -18,12 +20,29 @@ module Gori
     record Found, id : String, name : String, kind : Kind, path : String
 
     # Everything launch() needs, resolved by the caller from the live session.
+    # `proxy_host` is the RAW bind, exactly as the session holds it — the resolution to
+    # something a browser can dial happens here (see `dial_host`) so every launch path
+    # gets it, rather than in each caller.
     record LaunchSpec,
       proxy_host : String,
       proxy_port : Int32,
       ca_cert_path : String,
       spki_sha256 : String,
-      profile_root : String
+      profile_root : String do
+      # The proxy host to actually WRITE INTO the browser's config. Under a wildcard bind
+      # the raw value is "0.0.0.0", and a browser pointed at http://0.0.0.0:port proxies
+      # nothing — it opens, captures no traffic, and looks like gori is broken. Bare, so
+      # Firefox's host-only pref gets no brackets.
+      def dial_host : String
+        BindAddress.dial_host(proxy_host)
+      end
+
+      # "host:port" for the places that need one string, with an IPv6 literal bracketed —
+      # a `::1` bind interpolated bare yields the unparseable "::1:8070".
+      def dial_authority : String
+        BindAddress.authority(dial_host, proxy_port)
+      end
+    end
 
     # A candidate browser + where to look for it: absolute app binaries on macOS
     # (checked with File.exists?), bare command names on Linux (looked up on PATH).
@@ -78,7 +97,7 @@ module Gori
       case found.kind
       in Kind::Chromium
         spawn_detached(found.path, chromium_args(profile, spec))
-        "opened #{found.name} — CA trusted, proxy → #{spec.proxy_host}:#{spec.proxy_port}"
+        "opened #{found.name} — CA trusted, proxy → #{spec.dial_authority}"
       in Kind::Firefox
         note = setup_firefox_profile(profile, spec)
         spawn_detached(found.path, firefox_args(profile))
@@ -98,7 +117,7 @@ module Gori
     def self.chromium_args(profile : String, spec : LaunchSpec) : Array(String)
       [
         "--user-data-dir=#{profile}",
-        "--proxy-server=http://#{spec.proxy_host}:#{spec.proxy_port}",
+        "--proxy-server=http://#{spec.dial_authority}",
         "--proxy-bypass-list=<-loopback>",
         "--ignore-certificate-errors-spki-list=#{spec.spki_sha256}",
         "--test-type",
@@ -118,12 +137,15 @@ module Gori
 
     # The proxy prefs Firefox reads from its profile's user.js (it ignores Chrome
     # flags). share_proxy_settings routes https through the same host:port.
+    # These prefs take a BARE host (the port is its own pref), so they get `dial_host`
+    # rather than `dial_authority` — brackets here would be parsed as part of the name.
     def self.firefox_user_js(spec : LaunchSpec) : String
+      host = spec.dial_host
       String.build do |s|
         s << %(user_pref("network.proxy.type", 1);\n)
-        s << %(user_pref("network.proxy.http", "#{spec.proxy_host}");\n)
+        s << %(user_pref("network.proxy.http", "#{host}");\n)
         s << %(user_pref("network.proxy.http_port", #{spec.proxy_port});\n)
-        s << %(user_pref("network.proxy.ssl", "#{spec.proxy_host}");\n)
+        s << %(user_pref("network.proxy.ssl", "#{host}");\n)
         s << %(user_pref("network.proxy.ssl_port", #{spec.proxy_port});\n)
         s << %(user_pref("network.proxy.share_proxy_settings", true);\n)
         s << %(user_pref("network.proxy.no_proxies_on", "");\n)

--- a/src/gori/capture_status.cr
+++ b/src/gori/capture_status.cr
@@ -1,4 +1,5 @@
 require "json"
+require "./bind_address"
 
 module Gori
   # Per-project capture sidecar written by the session that holds the capture lock.
@@ -53,13 +54,11 @@ module Gori
       File.delete?(path(dir))
     end
 
-    # Human-friendly bind label for the picker (127.0.0.1 → localhost).
+    # Human-friendly bind label for the picker. Terse: this rides inside a project row's
+    # chip, so it takes the address without BindAddress's "(all interfaces)" note — the
+    # address itself is identical to every other surface's.
     def self.format_endpoint(host : String, port : Int32) : String
-      display_host = case host
-                     when "127.0.0.1", "::1" then "localhost"
-                     else                         host
-                     end
-      "#{display_host}:#{port}"
+      BindAddress.display(host, port, terse: true)
     end
   end
 end

--- a/src/gori/proxy/conn/self_page.cr
+++ b/src/gori/proxy/conn/self_page.cr
@@ -1,4 +1,5 @@
 require "html"
+require "../../bind_address"
 
 module Gori::Proxy
   # The self-serve landing page ClientConn returns when a browser hits the proxy
@@ -119,7 +120,12 @@ module Gori::Proxy
 
     private def self.index_html(*, ca_available : Bool, spki : String?, ca_path : String?,
                                 listen : {String, Int32}, version : String) : String
-      listen_s = HTML.escape("#{listen[0]}:#{listen[1]}")
+      # `listen[0]` is normally the CONCRETE address this device reached us on (ClientConn
+      # threads the accepted socket's local address in), which under a `::` bind is a bare
+      # IPv6 literal — "fe80::1:8080" is ambiguous and not copy-pasteable. BindAddress
+      # brackets it, and covers the fallback where local_host was unavailable and this is
+      # still the raw wildcard.
+      listen_s = HTML.escape(Gori::BindAddress.display(listen[0], listen[1]))
       ver = HTML.escape(version)
       path = HTML.escape(ca_path || "unknown")
       fp = spki ? HTML.escape(spki) : nil

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -54,7 +54,7 @@ module Gori::Tui
         @history.refresh_preview(@host.session.store) if @history.preview_enabled?
         BodyChrome.framed(screen, rect, body_focused) do |inner|
           @history.render_list(screen, inner, focused: body_focused,
-            listen: "#{proxy.host}:#{proxy.port}", capturing: @host.session.capturing?)
+            listen: {proxy.host, proxy.port}, capturing: @host.session.capturing?)
         end
       end
     end

--- a/src/gori/tui/controllers/intercept_controller.cr
+++ b/src/gori/tui/controllers/intercept_controller.cr
@@ -60,7 +60,7 @@ module Gori::Tui
       shell = BodyChrome.shell_focused(focus, multi_pane: !@intercept.empty?)
       BodyChrome.framed(screen, rect, shell) do |inner|
         @intercept.render(screen, inner, focused: body_focused,
-          listen: "#{proxy.host}:#{proxy.port}", capturing: @host.session.capturing?)
+          listen: {proxy.host, proxy.port}, capturing: @host.session.capturing?)
       end
     end
 

--- a/src/gori/tui/controllers/probe_controller.cr
+++ b/src/gori/tui/controllers/probe_controller.cr
@@ -116,7 +116,7 @@ module Gori::Tui
         else
           proxy = @host.session.proxy
           @probe.render(screen, content, focused: focused,
-            listen: "#{proxy.host}:#{proxy.port}", capturing: @host.session.capturing?)
+            listen: {proxy.host, proxy.port}, capturing: @host.session.capturing?)
         end
       end
     end

--- a/src/gori/tui/controllers/sitemap_controller.cr
+++ b/src/gori/tui/controllers/sitemap_controller.cr
@@ -48,7 +48,7 @@ module Gori::Tui
       focused = focus == :body
       proxy = @host.session.proxy
       @sitemap.render(screen, content, focused: focused,
-        listen: "#{proxy.host}:#{proxy.port}", capturing: @host.session.capturing?)
+        listen: {proxy.host, proxy.port}, capturing: @host.session.capturing?)
     end
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool

--- a/src/gori/tui/controllers/statusline_controller.cr
+++ b/src/gori/tui/controllers/statusline_controller.cr
@@ -1,5 +1,6 @@
 require "json"
 require "../ansi"
+require "../../bind_address"
 require "../../settings"
 
 module Gori::Tui
@@ -217,7 +218,12 @@ module Gori::Tui
             j.object do
               j.field "host", host
               j.field "port", port
-              j.field "addr", "#{host}:#{port}"
+              # `authority`, NOT `display`: this is a machine contract a user's script
+              # parses, so it keeps the RAW bind semantics (no wildcard→loopback collapse,
+              # which would hide a fact the script may want) and only gains the IPv6
+              # bracketing an authority string requires — bare interpolation rendered a
+              # `::1` bind as the unparseable "::1:8070".
+              j.field "addr", BindAddress.authority(host, port)
             end
           end
           j.field "upstream", Settings.effective_upstream_proxy

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -1087,7 +1087,7 @@ module Gori::Tui
     # --- rendering -----------------------------------------------------------
 
     def render_list(screen : Screen, rect : Rect, focused : Bool = true, *,
-                    listen : String? = nil, capturing : Bool = true) : Nil
+                    listen : {String, Int32}? = nil, capturing : Bool = true) : Nil
       return if rect.empty?
       list_rect, preview_rect = list_split(rect)
       render_list_body(screen, list_rect, focused, listen: listen, capturing: capturing)
@@ -1095,7 +1095,7 @@ module Gori::Tui
     end
 
     private def render_list_body(screen : Screen, rect : Rect, focused : Bool, *,
-                                 listen : String? = nil, capturing : Bool = true) : Nil
+                                 listen : {String, Int32}? = nil, capturing : Bool = true) : Nil
       return if rect.empty?
       render_ql_bar(screen, rect)
       hdr_y = rect.y + 1
@@ -1165,9 +1165,8 @@ module Gori::Tui
           elsif filtering? # in-scope subset is empty (Scope lens, no QL query)
             {"no flows in scope", "⇧S clears the scope lens"}
           else
-            addr = listen || "#{Settings.effective_bind_host}:#{Settings.effective_bind_port}"
             list_rect = Rect.new(time_x, list_top, rect.right - time_x, list_h)
-            TrafficEmptyState.render(screen, list_rect, variant: :history, listen: addr, capturing: capturing)
+            TrafficEmptyState.render(screen, list_rect, variant: :history, listen: listen, capturing: capturing)
             return
           end
         screen.text(time_x, list_top, msg, Theme.muted)

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -465,7 +465,7 @@ module Gori::Tui
     # --- rendering -----------------------------------------------------------
 
     def render(screen : Screen, rect : Rect, focused : Bool = true, *,
-               listen : String? = nil, capturing : Bool = true) : Nil
+               listen : {String, Int32}? = nil, capturing : Bool = true) : Nil
       return if rect.empty?
       render_filter_bar(screen, Rect.new(rect.x, rect.y, rect.w, FILTER_BAR_H), focused)
       render_suggestions(screen, rect, rect.y + FILTER_BAR_H) if @querying
@@ -473,8 +473,7 @@ module Gori::Tui
       return if body.empty?
 
       if @items.empty?
-        addr = listen || "#{Settings.effective_bind_host}:#{Settings.effective_bind_port}"
-        TrafficEmptyState.render(screen, body, variant: :intercept, listen: addr,
+        TrafficEmptyState.render(screen, body, variant: :intercept, listen: listen,
           capturing: capturing, catch_on: @enabled)
         return
       end

--- a/src/gori/tui/probe_view.cr
+++ b/src/gori/tui/probe_view.cr
@@ -360,7 +360,7 @@ module Gori::Tui
     # --- rendering ------------------------------------------------------------
 
     def render(screen : Screen, rect : Rect, focused : Bool = true, *,
-               listen : String? = nil, capturing : Bool = true) : Nil
+               listen : {String, Int32}? = nil, capturing : Bool = true) : Nil
       return if rect.empty?
       if @detail
         render_detail(screen, rect, focused)
@@ -376,7 +376,7 @@ module Gori::Tui
     end
 
     private def render_list(screen : Screen, rect : Rect, focused : Bool, *,
-                            listen : String? = nil, capturing : Bool = true) : Nil
+                            listen : {String, Int32}? = nil, capturing : Bool = true) : Nil
       render_mode_band(screen, rect)
       render_filter_bar(screen, rect, rect.y + 1)
       screen.text(rect.x + 1, rect.y + 2, "SEV", Theme.muted)
@@ -480,7 +480,7 @@ module Gori::Tui
     end
 
     private def render_empty(screen : Screen, rect : Rect, top : Int32, *,
-                             listen : String? = nil, capturing : Bool = true) : Nil
+                             listen : {String, Int32}? = nil, capturing : Bool = true) : Nil
       # Branch on a real `/` query FIRST (querying-aware hint): a blank-query empty set
       # is caused by the triage lens or the scope lens, where "esc clears the filter"
       # would mislead. Mirrors HistoryView/SitemapView's ordering.
@@ -493,8 +493,7 @@ module Gori::Tui
       elsif scope_active?
         screen.text(rect.x + 1, top, "no issues in scope · ⇧S clears the scope lens", Theme.muted)
       else
-        addr = listen || "#{Settings.effective_bind_host}:#{Settings.effective_bind_port}"
-        TrafficEmptyState.render(screen, list_rect, variant: :probe, listen: addr,
+        TrafficEmptyState.render(screen, list_rect, variant: :probe, listen: listen,
           capturing: capturing, scan_on: !@mode.off?,
           title: @mode.off? ? "scanning is OFF" : "no issues yet")
       end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1,4 +1,5 @@
 require "termisu"
+require "../bind_address"
 require "../verb"
 require "../store"
 require "../session"
@@ -1434,7 +1435,7 @@ module Gori::Tui
     private def click_top_bar(rect : Rect, mx : Int32, my : Int32) : Bool
       tag = Chrome.top_bar_chip_at(rect, mx, my, scope: scope_label, probe: probe_label,
         rules: rules_label, intercept: intercept_label, sandbox: sandbox_label,
-        listen: "#{@session.proxy.host}:#{@session.proxy.port}",
+        listen: listen_chip_label,
         unread: @notifications.unread, capturing: @session.capturing?,
         write_failures: @session.store.write_failures)
       return false unless tag
@@ -3794,7 +3795,7 @@ module Gori::Tui
 
       layout = Layout.compute(w, h, statusline_active?)
       Chrome.render_top_bar(screen, layout.topbar, project: @session.project.name,
-        listen: "#{@session.proxy.host}:#{@session.proxy.port}",
+        listen: listen_chip_label,
         scope: scope_label, probe: probe_label, rules: rules_label, intercept: intercept_label,
         sandbox: sandbox_label,
         unread: @notifications.unread, capturing: @session.capturing?,
@@ -3887,6 +3888,15 @@ module Gori::Tui
 
     private def scope_label : String
       @scope.active? ? "scope:#{@scope.size}" : "scope:off"
+    end
+
+    # The address on the top-bar listen chip. TERSE: the bar is a dense right-aligned chip
+    # row that already floors the project name to fit, so the "(all interfaces)" note a
+    # wildcard bind gets elsewhere has no budget here. The address itself is the same
+    # BindAddress render every other surface shows, so a wildcard still reads as a
+    # dialable "localhost:8070" rather than the unusable "0.0.0.0:8070".
+    private def listen_chip_label : String
+      BindAddress.display(@session.proxy.host, @session.proxy.port, terse: true)
     end
 
     # The probe chip, always present like scope: passive scanning is on by default, so an
@@ -5331,14 +5341,17 @@ module Gori::Tui
       begin
         proxy.rebind(eff_host, eff_port)
         @session.sync_capture_status!
+        # These toasts tell the user where to REPOINT a client, so they carry the full
+        # BindAddress render — a wildcard bind must not tell them to type "0.0.0.0:8070".
+        addr = BindAddress.display(proxy.host, proxy.port)
         if @session.capturing?
-          "settings saved — now listening on #{proxy.host}:#{proxy.port} (repoint your client)"
+          "settings saved — now listening on #{addr} (repoint your client)"
         else
           # capture is off: rebind only records the new address; the user starts it.
-          "settings saved — bind set to #{proxy.host}:#{proxy.port}; press c to start capture"
+          "settings saved — bind set to #{addr}; press c to start capture"
         end
       rescue ex
-        "settings saved, but rebind failed: #{ex.message} (kept #{proxy.host}:#{proxy.port})"
+        "settings saved, but rebind failed: #{ex.message} (kept #{BindAddress.display(proxy.host, proxy.port)})"
       end
     end
 

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -571,7 +571,7 @@ module Gori::Tui
     end
 
     def render(screen : Screen, rect : Rect, focused : Bool = true, *,
-               listen : String? = nil, capturing : Bool = true) : Nil
+               listen : {String, Int32}? = nil, capturing : Bool = true) : Nil
       return if rect.empty?
       render_ql_bar(screen, rect)
       hdr_y = rect.y + 1
@@ -596,8 +596,7 @@ module Gori::Tui
           elsif filtering? # in-scope subset is empty (Scope lens, no QL query)
             {"no endpoints in scope", nil}
           else
-            addr = listen || "#{Settings.effective_bind_host}:#{Settings.effective_bind_port}"
-            TrafficEmptyState.render(screen, tree, variant: :sitemap, listen: addr, capturing: capturing)
+            TrafficEmptyState.render(screen, tree, variant: :sitemap, listen: listen, capturing: capturing)
             return
           end
         screen.text(tree.x + 1, tree.y, msg, Theme.muted)

--- a/src/gori/tui/traffic_empty_state.cr
+++ b/src/gori/tui/traffic_empty_state.cr
@@ -1,6 +1,7 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "../bind_address"
 require "../settings"
 
 module Gori::Tui
@@ -24,9 +25,13 @@ module Gori::Tui
     # a "how to start" hint, and a dialog means the user already has.
     class_property? suppressed : Bool = false
 
+    # `listen` is the live bind as (host, port), NOT a pre-joined string: the card renders
+    # the address at full width but the medium/minimal fallbacks inline it into a longer
+    # hint, so this has to pick the verbose or terse form per branch — which needs the
+    # parts. Nil falls back to the configured bind.
     def render(screen : Screen, rect : Rect, *,
                variant : Symbol,
-               listen : String? = nil,
+               listen : {String, Int32}? = nil,
                capturing : Bool = true,
                catch_on : Bool = false,
                running : Bool = false,
@@ -35,15 +40,23 @@ module Gori::Tui
       return if suppressed?
       return if rect.empty?
 
-      addr = listen || "#{Settings.effective_bind_host}:#{Settings.effective_bind_port}"
+      host, port = listen || {Settings.effective_bind_host, Settings.effective_bind_port}
       headline = title || default_title(variant, running: running, scan_on: scan_on)
       min_h = variant == :fuzzer_results ? 5 : FULL_MIN_H
 
+      # This card is the onboarding surface — the address on it is the one the user is
+      # meant to TYPE into a client, so a wildcard bind must not render as "0.0.0.0:8070".
+      # Only the FULL card has room for the "(all interfaces)" note; the narrower fallbacks
+      # inline the address into a longer hint line and take the terse form. Same address
+      # either way, so a resize can never appear to move the proxy.
       if rect.h >= min_h && rect.w >= FULL_MIN_W
+        addr = BindAddress.display(host, port)
         render_full(screen, rect, variant, headline, addr, capturing, catch_on, running, scan_on)
       elsif rect.h >= MED_MIN_H && rect.w >= MED_MIN_W
+        addr = BindAddress.display(host, port, terse: true)
         render_medium(screen, rect, variant, headline, addr, capturing, catch_on, running, scan_on)
       else
+        addr = BindAddress.display(host, port, terse: true)
         render_minimal(screen, rect, variant, headline, addr, capturing, catch_on, running, scan_on)
       end
     end


### PR DESCRIPTION
#279 solved the wildcard-bind problem for the CA landing page by threading the accepted socket's concrete local address. Every *other* surface that shows the user an address still printed the raw wildcard — and one of them actually dialled it.

## Functional bugs
- **`browser.cr`** — under a wildcard bind, "open browser" launched Chromium with `--proxy-server=http://0.0.0.0:8070` (and the equivalent Firefox prefs), so the browser proxied nothing and the user saw a session that captured no traffic. **Independently**, the URL was built with bare `#{host}:#{port}` with no IPv6 bracketing, so a perfectly legal bind of `::1` (accepted by `Settings.bind_host_error`) produced the unparseable `http://::1:8070`.
- **`self_page.cr`** — since #279 `listen[0]` can be the concrete reached address, which under a `::` bind is a bare IPv6 literal, rendering `Listening on fe80::1:8080`. Now bracketed.

## Presentational
`app.cr` banner, the `traffic_empty_state` onboarding card (History/Sitemap/Intercept/Probe), the `runner.cr` top-bar chip and settings-saved toasts, and `capture_status.cr` (which already special-cased `127.0.0.1`/`::1` → `localhost` but passed `0.0.0.0` straight through, so the project picker showed `● 0.0.0.0:8070`). All of these tell the user *the address to type into their client's proxy setting*, and `0.0.0.0` cannot be typed anywhere.

## Approach
One leaf module, `Gori::BindAddress`, with zero requires:

```crystal
BindAddress.display(host, port, *, terse : Bool = false) : String  # what to SHOW
BindAddress.dial_host(host) : String                               # what to CONNECT to
BindAddress.authority(host, port) : String                         # "host:port", bracketed
BindAddress.wildcard?(host) : Bool
```

A leaf was the only clean dependency edge: the two hardest consumers are `capture_status.cr` (a light sidecar the project picker reads) and `proxy/conn/self_page.cr`, and neither may grow a dependency on the other's subtree. `CaptureStatus.format_endpoint` survives as a thin delegator so the picker call sites are untouched.

**Rendering decision: `localhost:8070 (all interfaces)`**, with `terse: true` giving `localhost:8070`. Rejected the concrete LAN IP (a syscall on a per-frame render path, can pick the wrong NIC, changes under the user when the network does) and rejected keeping `0.0.0.0` (untypeable). `localhost` alone would hide LAN reachability, which is the whole point of a wildcard bind — the mobile CA install that motivated #279 — hence the parenthetical. The terse form drops **only the parenthetical, never the address**, so the chip, the picker row and the full card can never show two different addresses; that invariant is pinned by a spec.

`dial_host` deliberately does *not* return `"localhost"`: it collapses to loopback **of the same family** (`0.0.0.0`→`127.0.0.1`, `::`/`::0`→`::1`), because a `0.0.0.0` listener is unreachable over `::1` and `localhost` would hand the family choice to the resolver, reintroducing a wrong-family connect failure at the exact point we are removing one.

## Beyond the obvious sites
The empty-state card fed 8 more hand-built `"#{host}:#{port}"` sites across `history`/`sitemap`/`intercept`/`probe` views and their controllers. `listen` changed from `String?` to `{String, Int32}?` through that chain — the pre-joined string was premature formatting, and choosing between the full card (room for the parenthetical) and the compact fallbacks (no room) needs the parts.

One judgment call: `statusline_controller.cr`'s JSON `addr` field also concatenated bare. It is a documented machine contract (`docs/content/reference/config.md`), so it gets `authority` only — IPv6 bracketing, no wildcard collapse — rather than `display`, which would hide a fact a user's script may want.

## Verification
```
16 spec files → 339 examples, 0 failures
```
New `spec/bind_address_spec.cr` covers `0.0.0.0`, `::`, `::0`, `0:0:0:0:0:0:0:0`, blank, already-bracketed input, loopback v4/v6, a concrete LAN IPv4, a concrete IPv6, a hostname, and the terse-is-a-prefix invariant. `spec/browser_spec.cr` covers wildcard→dialable for both families, IPv6 bracketing in the Chromium URL, and bare host in the Firefox prefs.

Four existing specs updated because they pinned the old behavior (`format_endpoint("0.0.0.0", 8070) == "0.0.0.0:8070"`, the self-page Listening line, and `listen:` as a string).

Full suite on the combined branch: 2424 examples, 0 failures.