### PR TITLE
fix(tui): convert the remaining raw display_width column math

### DIFF
--- a/spec/tui/decoder_view_spec.cr
+++ b/spec/tui/decoder_view_spec.cr
@@ -173,3 +173,48 @@ describe Gori::Tui::ChainComplete do
     c.open?.should be_true
   end
 end
+
+describe "DecoderView OUTPUT h-scroll" do
+  # Decoding is precisely where raw control bytes surface — an unhex/base64 of a binary
+  # blob is the whole point of the tab. The OUTPUT rows draw through `screen.text`, which
+  # gives every control char a cell, but the h-scroll clamp measured them with
+  # display_width, where those chars are 0 columns. The clamp's ceiling therefore fell
+  # short of the real content and the tail of a decoded line could not be scrolled to.
+  it "scrolls a decoded line containing control bytes to its end" do
+    line = "STARTTOK#{"\t" * 100}ENDTOK"
+    Screen.display_width(line).should eq(14) # the raw measure: 60 tabs count for nothing
+    Screen.draw_width(line).should eq(114)   # what `text` paints: one cell per tab
+    input = line.to_slice.hexstring
+    result = Gori::Decoder.run(REG, input.to_slice, "unhex")
+    String.new(result.output.not_nil!).should eq(line) # the decode really produced the tabs
+
+    view = DecoderView.new
+    ta = TextArea.new(input)
+    rect = Rect.new(0, 0, 80, 30)
+    render = ->(b : MemoryBackend) do
+      view.render(Screen.new(b), rect, input: ta, chain: "unhex", chain_cx: 5, chain_pre: "",
+        result: result, pane: :output, focused: true, popup: ChainComplete.new,
+        prompt: nil, prompt_buf: "")
+    end
+
+    # Assert on the OUTPUT card ALONE: the PIPELINE card above it echoes the same decoded
+    # bytes as the unhex step's intermediate and does NOT scroll, so a whole-grid match
+    # would report the unscrolled copy (cf. the hscroll_output spec above, which keeps
+    # INPUT unrelated for the same reason).
+    out_card = ->(b : MemoryBackend) do
+      top = (0...30).index { |y| b.row(y).includes?("OUTPUT") }.not_nil!
+      (top...30).map { |y| b.row(y) }.join("\n")
+    end
+
+    at0 = MemoryBackend.new(80, 30)
+    render.call(at0)
+    out_card.call(at0).should contain("STARTTOK")
+    out_card.call(at0).should_not contain("ENDTOK") # tail off to the right
+
+    15.times { view.hscroll_output(4) }
+    scrolled = MemoryBackend.new(80, 30)
+    render.call(scrolled)
+    out_card.call(scrolled).should contain("ENDTOK")       # reachable
+    out_card.call(scrolled).should_not contain("STARTTOK") # head genuinely scrolled off
+  end
+end

--- a/spec/tui/foundation_spec.cr
+++ b/spec/tui/foundation_spec.cr
@@ -118,6 +118,32 @@ describe Gori::Tui::Screen do
     end
   end
 
+  # Screen#input_line is the shared single-line field renderer (~30 call sites: Scope,
+  # Rules, Palette, the History query bar, every TextField overlay). Its caret and its
+  # click inverse have to be exact inverses of each other, or the block caret paints over
+  # the neighbouring glyph and a click lands off by the same amount. They drifted: the
+  # caret was measured with display_width (a zero-width char = 0 columns) while every
+  # field's click-to-cursor goes through Screen.column_for, which floors each CODEPOINT to
+  # ≥1. `parse_printable` accepts U+200B / U+FEFF / a combining mark unfiltered, and a URL
+  # carrying a zero-width char is a stock filter-bypass payload — reachable input here.
+  it "input_line puts the caret exactly where column_for maps that column back" do
+    value = "ab\u{200B}cd" # ZWSP at index 2: display_width 0, column_width 1, drawn 1 cell
+    (0..value.size).each do |cx|
+      b = MemoryBackend.new(40, 3)
+      Screen.new(b).input_line(0, 1, value, cx, "", Theme.text)
+      # The caret is the single cell painted on the ACCENT background.
+      col = (0...40).select { |x| b.bg_at(x, 1) == Theme.accent }
+      col.size.should eq(1) # exactly one caret cell (cx=#{cx})
+      col[0].should eq(Screen.column_width(value[0, cx]))  # sits on its own glyph
+      Screen.column_for(value, col[0]).should eq(cx)       # a click there returns the same cx
+      Screen.display_width(value[0, cx]).should be <= cx   # (the old measure could only under-count)
+    end
+    # Concretely: past the ZWSP the two measures disagree by one, which is exactly the
+    # column the caret used to be short by.
+    Screen.display_width(value[0, 3]).should eq(2)
+    Screen.column_width(value[0, 3]).should eq(3)
+  end
+
   it "text draws a tab as a one-column space (ASCII and mixed paths)" do
     # ASCII fast path
     b1 = MemoryBackend.new(10, 1)

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -515,6 +515,47 @@ describe "FuzzerView#template_click_to_cursor / #target_click_to_cursor" do
     view.target_insert('X')
     view.target.should eq("httXps://h")
   end
+
+  # The TARGET caret was measured with display_width while BOTH of its counterparts —
+  # paint_char_span_bg (the selection tint, in the same render) and Screen.column_for (the
+  # click inverse, in target_click_to_cursor) — floor each codepoint to ≥1. On a target
+  # holding a zero-width char the three disagreed: the caret sat a column left of its
+  # glyph and a click came back one character off. A URL carrying U+200B is not exotic
+  # here; it is a stock filter-bypass payload, i.e. exactly what gets pasted into a fuzz
+  # target. Pin the round trip: caret column → click at that column → the same index.
+  it "keeps the target caret and click-to-cursor agreeing across a zero-width char" do
+    target = "https://h/a\u{200B}b" # ZWSP: display_width 0, column_width 1, one drawn cell
+    view = FuzzerView.new
+    view.load_request(target, "GET / HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
+    rect = Rect.new(0, 0, 100, 30)
+    base = rect.x + 4 # render_target draws the value here (the "›" marker sits at rect.x+2)
+
+    view.focus_pane(:target)
+    (0..target.size).each do |cx|
+      col = base + Screen.column_width(target[0, cx])
+      view.target_click_to_cursor(rect, col, rect.y + 1)
+      b = MemoryBackend.new(100, 30)
+      view.render(Screen.new(b), rect)
+      # The caret is the single cell painted on an accent background in the field.
+      caret = (base...(base + 24)).select do |x|
+        bg = b.bg_at(x, rect.y + 1)
+        bg == Theme.accent || bg == Theme.accent_bg
+      end
+      caret.should eq([col]) # click column → caret column, with nothing left over
+    end
+
+    # …and the click lands on the right CHARACTER, not merely the right column: index 12
+    # is the 'b' that sits AFTER the ZWSP, the first index the old measure got wrong.
+    fresh = FuzzerView.new
+    fresh.load_request(target, "GET / HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
+    fresh.target_click_to_cursor(rect, base + Screen.column_width(target[0, 12]), rect.y + 1)
+    fresh.target_insert('X')
+    fresh.target.should eq("#{target[0, 12]}X#{target[12..]}")
+
+    # Concretely: past the ZWSP the old measure was one column short of the drawn glyph.
+    Screen.display_width(target).should eq(12)
+    Screen.column_width(target).should eq(13)
+  end
 end
 
 describe "FuzzerView result-detail decode panes" do

--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -466,6 +466,46 @@ describe Gori::Tui::HistoryView do
     end
   end
 
+  # Same clamp bug as RepeaterView#render_reveal, but here it also FOUGHT the caret:
+  # ensure_detail_visible_x slides @detail_xscroll using column_width (a tab counts 1),
+  # then this clamp immediately clawed it back with display_width (a tab counts 0). The
+  # caret-follow and the clamp were pulling in opposite directions every frame, so on a
+  # tab-indented body the caret could never scroll into view at the end of a line.
+  it "scrolls a tab-filled response line to its end in reveal mode" do
+    tmp_store do |store|
+      line = "STARTTOK#{"\t" * 100}ENDTOK"
+      Screen.display_width(line).should eq(14) # the raw measure the clamp used to trust
+      Screen.draw_width(line).should eq(114)   # what reveal actually paints (tab → '→')
+      id = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "http", host: "h.test", port: 80,
+        method: "GET", target: "/t", http_version: "HTTP/1.1",
+        head: "GET /t HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice, body: nil))
+      store.update_response(Gori::Store::CapturedResponse.new(
+        flow_id: id, status: 200,
+        head: "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n#{line}".to_slice,
+        body: line.to_slice, content_type: "text/plain"))
+
+      view = HistoryView.new
+      view.reload(store)
+      view.open_detail(store).should be_true
+      view.toggle_pane # request → response
+      view.reveal = true
+
+      rect = Rect.new(0, 0, 80, 16)
+      at0 = MemoryBackend.new(80, 16)
+      view.render_detail(Screen.new(at0), rect)
+      at0.contains?("STARTTOK").should be_true
+      at0.contains?("ENDTOK").should be_false # tail off to the right
+      at0.contains?("→").should be_true       # reveal is drawing tab markers
+
+      20.times { view.hscroll_detail(4) }
+      scrolled = MemoryBackend.new(80, 16)
+      view.render_detail(Screen.new(scrolled), rect)
+      scrolled.contains?("ENDTOK").should be_true    # reachable now
+      scrolled.contains?("STARTTOK").should be_false # head genuinely scrolled off
+    end
+  end
+
   it "refresh_detail picks up a Pending flow's response but skips a stable Complete one" do
     tmp_store do |store|
       pid = store.insert_flow(Gori::Store::CapturedRequest.new(

--- a/spec/tui/repeater_view_spec.cr
+++ b/spec/tui/repeater_view_spec.cr
@@ -143,6 +143,37 @@ describe Gori::Tui::RepeaterView do
     back.contains?("ALPHATOKEN").should be_true # cached Line uncorrupted by the intervening slice
   end
 
+  # Reveal mode is the surface built to inspect whitespace, and it was the one surface a
+  # tabbed line could not be scrolled across. Reveal.styled gives every control char a
+  # 1-column marker (tab → '→'), so the row DRAWS one cell per tab, but the h-scroll clamp
+  # measured the raw string with display_width, where a tab is 0 columns. On a tab-heavy
+  # line the clamp's ceiling collapsed to 0 and @xscroll was pinned there every frame, so
+  # the tail of the line was permanently unreachable no matter how far right you scrolled.
+  it "scrolls a tab-filled line all the way to its end in reveal mode" do
+    view = RepeaterView.new
+    view.load_blank
+    view.focus_pane(:response)
+    hdr = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n"
+    line = "STARTTOK#{"\t" * 60}ENDTOK"
+    # The two measures disagree by the tab count — that gap IS the unreachable tail.
+    Screen.display_width(line).should eq(14)
+    Screen.draw_width(line).should eq(74)
+    view.apply(Gori::Repeater::Result.new(hdr.to_slice, line.to_slice, nil, 1000_i64))
+    view.reveal = true
+
+    at0 = MemoryBackend.new(120, 20)
+    view.render(Screen.new(at0), Rect.new(0, 0, 120, 20))
+    at0.contains?("STARTTOK").should be_true # left edge
+    at0.contains?("ENDTOK").should be_false  # tail is off to the right
+    at0.contains?("→").should be_true        # reveal really is drawing tab markers
+
+    30.times { view.hscroll(4) } # slide right, well past the line's drawn width
+    scrolled = MemoryBackend.new(120, 20)
+    view.render(Screen.new(scrolled), Rect.new(0, 0, 120, 20))
+    scrolled.contains?("ENDTOK").should be_true    # the tail is reachable
+    scrolled.contains?("STARTTOK").should be_false # …and the head has genuinely scrolled off
+  end
+
   it "duplicate_from copies request content, flags, and last response (no source flow)" do
     src = RepeaterView.new
     src.load_blank

--- a/spec/tui/text_field_spec.cr
+++ b/spec/tui/text_field_spec.cr
@@ -61,6 +61,31 @@ describe Gori::Tui::TextField do
     backend.contains?("/tmp/x").should be_true
   end
 
+  it "still scrolls to keep the caret visible when the value holds zero-width chars" do
+    # window_start decides when to scroll, so it has to measure in the SAME units
+    # Screen#input_line places the caret in. It measured with display_width, which scores
+    # a zero-width char 0 while input_line's caret (column_width) and the drawn cell both
+    # count it as 1. The window therefore under-counted, concluded the value still fit,
+    # and left start at 0 — putting the caret at column == width, one past the right edge,
+    # where input_line's `caret_x < right` guard drops it entirely. The field then had NO
+    # visible caret and no hardware cursor, so IME composition had nowhere to anchor.
+    # (This pins window_start specifically: it only fails once input_line itself measures
+    # with column_width. With BOTH on display_width the two under-counts cancelled and the
+    # caret was merely in the wrong column rather than missing — so the pair must move
+    # together, and the assertion below is on the caret EXISTING and being in-field.)
+    value = "#{"a" * 6}#{"\u{200B}" * 5}b" # 12 chars: display_width 7, column_width 12
+    Screen.display_width(value).should eq(7)
+    Screen.column_width(value).should eq(12)
+    f = TextField.new(value) # TextField.new parks the caret at the end
+    f.caret.should eq(12)
+    backend = MemoryBackend.new(40, 3)
+    f.render(Screen.new(backend), 0, 1, 12, true, Theme.text, Theme.bg)
+    # The caret cell is the one on the ACCENT background; it must exist and be in-field.
+    caret = (0...40).select { |x| backend.bg_at(x, 1) == Theme.accent }
+    caret.size.should eq(1)
+    caret[0].should be < 12 # inside the 12-column field, not off its right edge
+  end
+
   it "seeds the caret at the end on construction" do
     TextField.new("hello").caret.should eq(5)
     TextField.new.caret.should eq(0)

--- a/src/gori/tui/decoder_view.cr
+++ b/src/gori/tui/decoder_view.cr
@@ -218,7 +218,12 @@ module Gori::Tui
       gw = {Gutter.width(lines.size), rect.w}.min
       cw = {rect.w - gw, 0}.max
       rows = (0...rect.h).compact_map { |i| lines[@out_scroll + i]? }
-      @out_xscroll = @out_xscroll.clamp(0, {(rows.max_of? { |l| Screen.display_width_upto(l, @out_xscroll + cw + 1) } || 0) - cw, 0}.max)
+      # draw_width, not display_width: the rows go out through `screen.text` below, which
+      # advances ≥1 per grapheme. Decoder output is exactly where raw control bytes surface
+      # (a base64/hex decode of binary), and the raw measure scores every one of them 0 —
+      # so the clamp pinned @out_xscroll short and the tail of a decoded line was
+      # unreachable. _upto preserves the per-frame early exit on a huge single-line decode.
+      @out_xscroll = @out_xscroll.clamp(0, {(rows.max_of? { |l| Screen.draw_width_upto(l, @out_xscroll + cw + 1) } || 0) - cw, 0}.max)
       ensure_out_visible(rect.h) if focused
       rows.each_with_index do |line, i|
         li = @out_scroll + i

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -1514,7 +1514,11 @@ module Gori::Tui
       end
       Highlight.draw(screen, base, rect.y + 1, Highlight.env_line(@target, Theme.text_bright), width: tw)
       if focused
-        cx = base + Screen.display_width(@target[0, @tcx])
+        # column_width — same three-way agreement as RepeaterView#render_target: it matches
+        # paint_char_span_bg (the selection tint, just above) and inverts the
+        # Screen.column_for in target_click_to_cursor. display_width put the caret a column
+        # left of its glyph on a target holding a zero-width char.
+        cx = base + Screen.column_width(@target[0, @tcx])
         if cx < rect.right - 1
           ch = @tcx < @target.size ? @target[@tcx] : ' '
           screen.cell(cx, rect.y + 1, ch, Theme.bg, ins ? Theme.accent : Theme.accent_bg)
@@ -1987,7 +1991,12 @@ module Gori::Tui
       gw = {Gutter.width(lines.size), inner.w}.min
       cw = {inner.w - gw, 0}.max
       rows = (0...inner.h).compact_map { |i| lines[@detail_scroll + i]? }
-      @detail_xscroll = @detail_xscroll.clamp(0, {(rows.max_of? { |l| Screen.display_width_upto(l, @detail_xscroll + cw + 1) } || 0) - cw, 0}.max)
+      # draw_width, not display_width: these rows are drawn per grapheme (Highlight.draw on
+      # the styled overlay, `screen.text` on the plain fallback), so a control char in a
+      # fuzz response holds a cell the raw measure scores 0 and the clamp stopped short of
+      # the content. _upto keeps the early exit — this runs every frame over response lines
+      # that are attacker-shaped and can be arbitrarily long.
+      @detail_xscroll = @detail_xscroll.clamp(0, {(rows.max_of? { |l| Screen.draw_width_upto(l, @detail_xscroll + cw + 1) } || 0) - cw, 0}.max)
       # Selection spans for the WHOLE buffer, built once per frame. This used to sit inside
       # paint_detail_line_chrome, i.e. rebuilt and thrown away once per drawn row — O(rows ×
       # selection length) tuple appends, plus a fresh Array per row even with nothing selected.

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -1501,7 +1501,12 @@ module Gori::Tui
       gw = Settings.show_gutter ? {Gutter.width(total), body.w}.min : 0
       cw = {body.w - gw, 0}.max
       @detail_last_cw = cw # remember for horizontal caret-follow (ensure_detail_visible_x)
-      widest = (0...body.h).compact_map { |i| lines[@detail_scroll + i]? }.max_of? { |l| Screen.display_width_upto(l, @detail_xscroll + cw + 1) } || 0
+      # draw_width, not display_width — as RepeaterView#render_reveal. Reveal.styled gives
+      # every control char a 1-column marker, so a tab is a drawn cell the raw measure calls
+      # 0. Here it also FOUGHT the caret: ensure_detail_visible_x sets @detail_xscroll with
+      # column_width (tab ≥1), then this clamp immediately clawed it back with the smaller
+      # raw measure, so on a tabbed line the caret could never scroll into view at all.
+      widest = (0...body.h).compact_map { |i| lines[@detail_scroll + i]? }.max_of? { |l| Screen.draw_width_upto(l, @detail_xscroll + cw + 1) } || 0
       @detail_xscroll = @detail_xscroll.clamp(0, {widest - cw, 0}.max)
       ensure_detail_visible(body.h) if detail_navigable? && focused
       (0...body.h).each do |i|

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -2420,7 +2420,14 @@ module Gori::Tui
       end
       Highlight.draw(screen, base, row, Highlight.env_line(value, Theme.text_bright), width: w)
       if active
-        cursor_x = base + Screen.display_width(value[0, cx])
+        # column_width — the measure paint_char_span_bg (the selection tint, a few lines up)
+        # already uses on this same value in this same render, and the exact inverse of the
+        # Screen.column_for that target_click_to_cursor uses to turn a click back into `cx`.
+        # display_width scored a zero-width char as 0, so the three disagreed: the tint
+        # covered one span, the caret sat a column left of its glyph, and a click landed a
+        # character off. A URL carrying U+200B is ordinary traffic for this tool (it is a
+        # stock filter-bypass payload), so this is reachable, not theoretical.
+        cursor_x = base + Screen.column_width(value[0, cx])
         if cursor_x < rect.right - 1
           ch = cx < value.size ? value[cx] : ' '
           screen.cell(cursor_x, row, ch, Theme.bg, insert ? Theme.accent : Theme.accent_bg)
@@ -2644,7 +2651,12 @@ module Gori::Tui
       end
       gw = Settings.show_gutter ? {Gutter.width(lines.size), body.w}.min : 0
       cw = {body.w - gw, 0}.max
-      widest = (0...body.h).compact_map { |i| lines[@scroll + i]? }.max_of? { |(t, _)| Screen.display_width(t) } || 0
+      # draw_width, not display_width: the rows are drawn with `screen.text` (below), which
+      # advances ≥1 per grapheme, so a control byte inside a WS text frame owns a cell the
+      # raw measure scores 0 — the clamp then stopped short of the real content. Switching
+      # to the _upto variant also gives this site the early exit its siblings have: it runs
+      # every frame, and one WS frame can carry a multi-MB single-line payload.
+      widest = (0...body.h).compact_map { |i| lines[@scroll + i]? }.max_of? { |(t, _)| Screen.draw_width_upto(t, @xscroll + cw + 1) } || 0
       @xscroll = @xscroll.clamp(0, {widest - cw, 0}.max)
       @resp_last_h = body.h
       sel_spans = resp_sel_spans_if(focused)
@@ -2797,7 +2809,13 @@ module Gori::Tui
       @resp_last_h = rect.h
       gw = Settings.show_gutter ? {Gutter.width(total), rect.w}.min : 0
       cw = {rect.w - gw, 0}.max
-      widest = (0...rect.h).compact_map { |i| lines[@scroll + i]? }.max_of? { |l| Screen.display_width_upto(l, @xscroll + cw + 1) } || 0
+      # draw_width, not display_width: the rows below are drawn through Reveal.styled, which
+      # maps EVERY control char to a 1-column marker (tab → '→', CR → '␍'). display_width
+      # calls a tab 0 columns, so the clamp under-counted by one per tab and pinned @xscroll
+      # short of the content — on a tab-indented body it pinned it at 0 outright, leaving the
+      # tail of the line permanently unreachable on the very surface built to inspect tabs.
+      # _upto keeps the early exit: this runs every frame and a minified line can be MBs.
+      widest = (0...rect.h).compact_map { |i| lines[@scroll + i]? }.max_of? { |l| Screen.draw_width_upto(l, @xscroll + cw + 1) } || 0
       @xscroll = @xscroll.clamp(0, {widest - cw, 0}.max)
       sel_spans = resp_sel_spans_if(focused)
       (0...rect.h).each do |i|
@@ -2903,7 +2921,11 @@ module Gori::Tui
                         end
         {di, "#{prefix} #{d.text}", color, d.text}
       end
-      @xscroll = @xscroll.clamp(0, {(rows.max_of? { |(_, full, _, _)| Screen.display_width(full) } || 0) - cw, 0}.max)
+      # draw_width, not display_width — `full` (the "+ "/"- " prefix plus the diff line) is
+      # drawn by `screen.text` below, so a control char in either side of the diff holds a
+      # cell the raw measure scores 0 and the clamp cut the line short. _upto for the early
+      # exit, as everywhere else this clamp shape appears: it runs every frame.
+      @xscroll = @xscroll.clamp(0, {(rows.max_of? { |(_, full, _, _)| Screen.draw_width_upto(full, @xscroll + cw + 1) } || 0) - cw, 0}.max)
       @resp_last_h = rect.h
       sel_spans = resp_sel_spans_if(focused)
       rows.each_with_index do |(di, full, color, text), i|

--- a/src/gori/tui/screen.cr
+++ b/src/gori/tui/screen.cr
@@ -487,7 +487,18 @@ module Gori::Tui
       styled_run(px, y, suffix, cx, colors, fg, bg, right) unless suffix.empty?
       # Block caret sits just after prefix+preedit, over the suffix's first cell
       # (or a space). The terminal's own IME UI anchors at the hardware cursor.
-      caret_x = x + Screen.display_width(prefix) + Screen.display_width(preedit)
+      # column_width, NOT display_width and NOT draw_width. `cx` is a CHARACTER index into
+      # `value` (see the clamp above and `value[cx]` below), and this caret's inverse is
+      # Screen.column_for — the per-codepoint, floored-to-≥1 mapping used by every click
+      # handler that drives a field (read_cursor, repeater/fuzzer target, decoder chain).
+      # column_width is that function's exact inverse, so caret and click agree by
+      # construction; display_width scored a zero-width char (U+200B, U+FEFF, a combining
+      # mark — all of which parse_printable accepts unfiltered) as 0 columns, leaving the
+      # block caret one column left of its glyph, painting over the neighbour, and landing
+      # a click one character off. draw_width would match the DRAW but not `column_for`,
+      # re-breaking the click; reconciling those two is the caret-model change documented
+      # at TextArea#ensure_visible_x and deliberately not attempted here.
+      caret_x = x + Screen.column_width(prefix) + Screen.column_width(preedit)
       caret_ch = preedit.empty? ? (cx < value.size ? value[cx] : ' ') : ' '
       if caret_x < right
         cell(caret_x, y, caret_ch, Theme.bg, Theme.accent)

--- a/src/gori/tui/text_field.cr
+++ b/src/gori/tui/text_field.cr
@@ -130,15 +130,21 @@ module Gori::Tui
 
     # First visible character index: 0 until the caret (plus any preedit, plus the caret
     # cell itself) would overflow `width`, then far enough right to keep it on screen.
-    # Walks by DISPLAY width so a CJK path scrolls by columns, not by characters.
+    # Walks by COLUMN width so a CJK path scrolls by columns, not by characters — and,
+    # specifically, the same measure Screen#input_line places the caret with. This window
+    # exists to keep the caret on screen, so it has to agree with the caret: under
+    # display_width a zero-width char cost 0 here but ≥1 there, so the window under-counted,
+    # decided the value still fit, and let the caret run off the right edge. Per-CODEPOINT
+    # is also what the loop below is: it steps `start` back one CHARACTER at a time, which
+    # is the unit @caret and @value[start..] are indexed in.
     private def window_start(width : Int32) : Int32
       c = @caret.clamp(0, @value.size)
-      used = Screen.display_width(@value[0, c]) + Screen.display_width(@preedit) + 1
+      used = Screen.column_width(@value[0, c]) + Screen.column_width(@preedit) + 1
       return 0 if used <= width
-      used = Screen.display_width(@preedit) + 1 # the caret cell always stays visible
+      used = Screen.column_width(@preedit) + 1 # the caret cell always stays visible
       start = c
       while start > 0
-        w = Screen.display_width(@value[start - 1].to_s)
+        w = Screen.column_width(@value[start - 1].to_s)
         break if used + w > width
         used += w
         start -= 1


### PR DESCRIPTION
Completes the sweep #281 and #285 started. Those converted the styled-`Line` paths; this converts the remaining raw-`String` ones the audit found still on `display_width`.

Uses the rule #285 documented: **`draw_width` when the result is compared against drawn cells, `column_width` when it is compared against the caret.**

## Part 1 — six h-scroll clamps → `draw_width_upto`
All six draw through `screen.text` / `Highlight.draw`, which floor a control char to one cell, but clamped with raw `display_width`, which scores it 0. The clamp under-counts and the tail of the line becomes unreachable.

**The reveal-mode symptom reproduced cleanly** on unmodified source. Response line `STARTTOK` + 60 tabs + `ENDTOK`:

```
AT 0:          STARTTOK=true  ENDTOK=false
AFTER SCROLL:  STARTTOK=true  ENDTOK=false   <- 120 columns requested, nothing moved
display_width=14  draw_width=74
```

The clamp's ceiling was `14 - cw`, i.e. 0, so `@xscroll` was pinned at 0 every frame. After the fix: `STARTTOK=false ENDTOK=true`. Reveal is the strongest case because `Reveal.styled` gives every control char a 1-column marker (`→` for tab), so drawn width is exactly 1/char — and reveal is the tab-inspection surface.

In `history_view` the two measures were actively fighting: `ensure_detail_visible_x` sets `@detail_xscroll` with `column_width`, then the clamp immediately clawed it back with the smaller raw measure, so the caret could never scroll into view at the end of a tabbed line.

Sites: `repeater_view.cr` (reveal, WS transcript, diff), `history_view.cr` (reveal), `decoder_view.cr` (output), `fuzzer_view.cr` (detail). The WS transcript and diff sites had no `_upto` variant at all and measured lines in **full** every frame; they now get the early exit their siblings already had, so the multi-MB-line property is improved rather than just preserved.

## Part 2 — four caret sites → `column_width` (deliberately not `draw_width`)
`Screen#input_line` drew by accumulating `text()` returns (floored) but independently recomputed `caret_x` with raw `display_width`; `text_field.cr#window_start` sized the h-scroll window with the raw measure while `input_line` placed the caret with the floored one; the repeater/fuzzer TARGET-SNI rows contradicted themselves in the same render, with the selection tint on `column_width` and the caret on `display_width`.

These land on `column_width`, **not** `draw_width`: `@cx` / `@tcx` / `@caret` are character indices and the click inverse is `Screen.column_for`, which is per-codepoint and floored. `column_width` is that function's exact inverse, so caret and click agree by construction. `draw_width` would match the draw and re-break the click — that tension is the caret-model change documented at `TextArea#ensure_visible_x` and is deliberately not attempted here.

Trigger is not Tab (the focus ring steals it) but U+200B / U+FEFF / an NFD combining mark, which `parse_printable` accepts unfiltered — a realistic filter-bypass payload to find in a URL in a tool like this.

## Left alone, flagged
`text_area.cr:529,557` still use `display_width(@preedit)`. Unlike `input_line`, the draw path and caret path there use the **same** measure, so there is no relative drift and no symptom. Line 529's `px +=` is a draw advance compared against cells `screen.text` painted, so by the documented rule it is arguably `draw_width` — a real finding, but converting it means stepping into the caret-model rewrite, so it gets its own look rather than a drive-by change here.

## Verification
Every new spec was confirmed to **fail** against unfixed source before passing:

```
223 examples, 5 failures     <- control, src stashed
  foundation_spec:129     input_line caret vs column_for
  repeater_view_spec:152  reveal h-scroll to end
  history_view_spec:474   reveal h-scroll to end
  decoder_view_spec:183   decoded control bytes h-scroll
  fuzzer_view_spec:526    Expected: [16] got: [15]   <- caret one column short
```

`text_field_spec` needed an isolated control: it passes with both fixes reverted because two `display_width` under-counts cancel out. Stashing only `text_field.cr` gives `caret.size Expected: 1 got: 0` — the caret dropped entirely. That dependency is documented in the spec so it doesn't read as a test that never fails.

`spec/tui/` 888 examples, 0 failures — #285 and #281 intact. Full suite merged onto main: 2430 examples, 0 failures.