### PR TITLE
docs: refine the top nav and flatten the landing CTA

### DIFF
--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -536,17 +536,26 @@ kbd {
   transition: transform var(--transition), border-color var(--transition), background var(--transition), color var(--transition);
 }
 
+/* Flat gold, no leaf gradient: the brushed metal look stays on the artwork
+   and the mark, while the CTA reads as a plain, confident surface. */
 .button-primary {
-  border: 1px solid var(--accent-strong);
-  background: var(--grad-gold-leaf);
+  border: 1px solid transparent;
+  background: var(--accent);
   color: var(--accent-ink);
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.28), var(--shadow-soft);
 }
 
 .button-primary:hover {
-  border-color: var(--accent-strong);
-  color: var(--accent-ink);
-  filter: brightness(1.06);
+  background: var(--accent-strong);
+}
+
+/* On paper the mid gold leaves the cream label short of AA, so the flat fill
+   deepens and hover lightens instead. */
+:root[data-theme="light"] .button-primary {
+  background: var(--accent-strong);
+}
+
+:root[data-theme="light"] .button-primary:hover {
+  background: var(--accent);
 }
 
 .button-secondary {

--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -241,7 +241,7 @@ img {
   display: inline-flex;
   align-items: center;
   gap: 0.6rem;
-  margin-right: 2rem;
+  margin-right: 1.4rem;
   color: var(--heading);
   font-weight: 760;
   line-height: 1;
@@ -286,236 +286,116 @@ img {
   background-clip: text;
 }
 
+/* Section links sit as quiet pills: a soft ink wash on hover, and the active
+   section carries the gold thread as a tinted pill instead of an underline. */
 .top-nav {
   display: flex;
   align-items: center;
-  gap: 1.25rem;
+  gap: 0.2rem;
   min-width: 0;
 }
 
 .top-nav a {
-  position: relative;
+  padding: 0.38rem 0.8rem;
+  border-radius: var(--radius-pill);
   color: var(--muted);
-  font-size: 0.9rem;
+  font-size: 0.88rem;
   text-decoration: none;
   white-space: nowrap;
+  transition: color var(--transition), background var(--transition);
 }
 
 .top-nav a:hover {
   color: var(--heading);
+  background: rgb(var(--ink-rgb) / 0.06);
 }
 
 .top-nav a.active {
   color: var(--accent-strong);
+  background: rgb(var(--accent-rgb) / 0.12);
+  font-weight: 500;
 }
 
-.top-nav a.active::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: -0.55rem;
-  height: 2px;
-  border-radius: 2px;
-  background: var(--accent);
-}
-
+/* The right cluster keeps one drawn control (the segmented language pill) and
+   quiet borderless icons for search, GitHub, and the theme. One level of
+   chrome per level of importance, instead of four outlined blobs competing at
+   equal weight. */
 .header-right {
   display: flex;
   align-items: center;
-  gap: 0.7rem;
+  gap: 0.45rem;
   margin-left: auto;
 }
 
-/* Language switcher — a compact dropdown that names the current language
-   (in its own script) and scales to more locales without crowding the header. */
-.lang-switcher {
-  position: relative;
-}
-
-.lang-trigger {
+/* Language switcher — a segmented pill of locale codes. Every language is one
+   click away and the control stays narrower than the old named dropdown. */
+.lang-switch {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
-  min-height: 2.3rem;
-  padding: 0.35rem 0.58rem;
+  gap: 0.1rem;
+  padding: 0.2rem;
   border: 1px solid var(--line);
   border-radius: var(--radius-pill);
-  background: rgb(var(--ink-rgb) / 0.055);
-  color: var(--text);
-  font: inherit;
-  font-size: 0.84rem;
-  line-height: 1;
-  cursor: pointer;
-  list-style: none;
-  user-select: none;
-  transition: transform var(--transition), border-color var(--transition),
-    background var(--transition), color var(--transition);
+  background: rgb(var(--ink-rgb) / 0.045);
 }
 
-.lang-trigger::-webkit-details-marker {
-  display: none;
-}
-
-.lang-trigger:hover {
-  border-color: var(--line-strong);
-  background: rgb(var(--ink-rgb) / 0.09);
-}
-
-.lang-switcher[open] > .lang-trigger {
-  border-color: var(--line-strong);
-  color: var(--heading);
-}
-
-.lang-trigger:active {
-  transform: translateY(1px) scale(0.99);
-}
-
-.lang-globe {
-  width: 1rem;
-  height: 1rem;
-  flex: none;
-  color: var(--muted);
-}
-
-.lang-trigger:hover .lang-globe,
-.lang-switcher[open] .lang-globe {
-  color: var(--accent-strong);
-}
-
-.lang-trigger-label {
-  font-weight: 500;
-  white-space: nowrap;
-}
-
-.lang-caret {
-  width: 0.82rem;
-  height: 0.82rem;
-  flex: none;
-  color: var(--muted);
-  transition: transform var(--transition);
-}
-
-.lang-switcher[open] .lang-caret {
-  transform: rotate(180deg);
-}
-
-.lang-menu {
-  position: absolute;
-  top: calc(100% + 0.5rem);
-  right: 0;
-  min-width: 11rem;
-  margin: 0;
-  padding: 0.3rem;
-  list-style: none;
-  border: 1px solid var(--line-strong);
-  border-radius: var(--radius-sm);
-  background: var(--bg-panel);
-  box-shadow: var(--shadow-soft), 0 0 0 1px rgb(var(--accent-rgb) / 0.06);
-  z-index: 120;
-  animation: langMenuIn 0.14s ease;
-}
-
-@keyframes langMenuIn {
-  from {
-    opacity: 0;
-    transform: translateY(-4px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.lang-menu a {
-  display: flex;
+.lang-switch a {
+  display: inline-flex;
   align-items: center;
-  gap: 0.6rem;
-  padding: 0.5rem 0.55rem;
-  border-radius: 7px;
-  color: var(--text);
-  font-size: 0.86rem;
-  text-decoration: none;
-  white-space: nowrap;
-}
-
-.lang-menu a:hover {
-  background: rgb(var(--ink-rgb) / 0.06);
-  color: var(--heading);
-}
-
-.lang-menu-name {
-  flex: 1 1 auto;
-}
-
-.lang-menu-code {
-  font-size: 0.72rem;
-  letter-spacing: 0.04em;
+  justify-content: center;
+  min-width: 2.1rem;
+  padding: 0.26rem 0.5rem;
+  border-radius: var(--radius-pill);
   color: var(--muted);
-}
-
-.lang-menu a.is-current {
-  color: var(--accent-strong);
-  background: rgb(var(--accent-rgb) / 0.1);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
   font-weight: 600;
+  letter-spacing: 0.07em;
+  line-height: 1;
+  text-decoration: none;
+  transition: color var(--transition), background var(--transition);
 }
 
-.lang-check {
-  width: 0.95rem;
-  height: 0.95rem;
-  flex: none;
+.lang-switch a:hover {
+  color: var(--heading);
+  background: rgb(var(--ink-rgb) / 0.07);
+}
+
+.lang-switch a.is-current {
   color: var(--accent-strong);
+  background: rgb(var(--accent-rgb) / 0.16);
 }
 
-.search-trigger {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.55rem;
-  min-height: 2.3rem;
-  padding: 0.35rem 0.45rem 0.35rem 0.8rem;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-pill);
-  background: rgb(var(--ink-rgb) / 0.055);
-  color: var(--text);
-  font: inherit;
-  font-size: 0.86rem;
-  cursor: pointer;
-  transition: transform var(--transition), border-color var(--transition), background var(--transition);
-}
-
-.search-trigger:hover {
-  border-color: var(--line-strong);
-  background: rgb(var(--ink-rgb) / 0.09);
-}
-
+.search-trigger,
 .github-link,
 .theme-toggle {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.3rem;
-  height: 2.3rem;
+  width: 2.25rem;
+  height: 2.25rem;
   padding: 0;
-  border: 1px solid var(--line);
+  border: 0;
   border-radius: var(--radius-pill);
-  background: rgb(var(--ink-rgb) / 0.055);
+  background: transparent;
   color: var(--muted);
   cursor: pointer;
   text-decoration: none;
-  transition: transform var(--transition), border-color var(--transition), background var(--transition), color var(--transition);
+  transition: transform var(--transition), background var(--transition), color var(--transition);
 }
 
+.search-trigger:hover,
 .github-link:hover,
 .theme-toggle:hover {
-  border-color: var(--line-strong);
-  background: rgb(var(--ink-rgb) / 0.09);
+  background: rgb(var(--ink-rgb) / 0.08);
   color: var(--accent-strong);
 }
 
+.search-trigger svg,
 .github-link svg,
 .theme-toggle svg {
-  width: 1.05rem;
-  height: 1.05rem;
+  width: 1.1rem;
+  height: 1.1rem;
 }
 
 .theme-toggle .icon-sun {
@@ -2659,7 +2539,10 @@ html.search-lock body {
 
 @media (max-width: 1100px) {
   .home-hero {
-    grid-template-columns: 1fr;
+    /* minmax(0, 1fr), not bare 1fr: 1fr's auto minimum inherits the install
+       one-liner's nowrap width and shoves the whole column past narrow
+       viewports. A zero minimum lets the widget shrink and scroll inside. */
+    grid-template-columns: minmax(0, 1fr);
     padding-top: 3rem;
   }
 
@@ -2832,8 +2715,8 @@ html.search-lock body {
     margin-right: 0.75rem;
   }
 
-  .search-trigger span {
-    display: none;
+  .header-right {
+    gap: 0.3rem;
   }
 
   .home-hero h1,

--- a/docs/templates/footer.html
+++ b/docs/templates/footer.html
@@ -47,17 +47,13 @@
     syncTuiShots();
   })();
 
-  /* Language dropdown: close on outside click or Escape (it closes on its own
-     when a language is chosen, since that navigates away). */
+  /* The search tooltip ships as ⌘K; outside Apple platforms say Ctrl K
+     instead (search.js already answers to both modifiers). */
   (function () {
-    var ls = document.getElementById("langSwitcher");
-    if (!ls) return;
-    document.addEventListener("click", function (e) {
-      if (ls.open && !ls.contains(e.target)) ls.removeAttribute("open");
-    });
-    document.addEventListener("keydown", function (e) {
-      if (e.key === "Escape" && ls.open) ls.removeAttribute("open");
-    });
+    var st = document.querySelector(".search-trigger");
+    if (st && !/Mac|iPhone|iPad|iPod/.test(navigator.platform || "")) {
+      st.title = st.title.replace("⌘K", "Ctrl K");
+    }
   })();
 
   /* Hero install picker: swap the one-liner for the chosen channel, copy it

--- a/docs/templates/partials/nav.html
+++ b/docs/templates/partials/nav.html
@@ -10,30 +10,17 @@
     <a href="{{ base_url }}{{ lang_prefix }}/reference/"{% if page.section == "reference" %} class="active" aria-current="true"{% endif %}>{{ "nav.reference" | t }}</a>
   </nav>
   <div class="header-right">
+    <button class="search-trigger" onclick="openSearch()" aria-label="{{ "a11y.search_docs" | t }}" title="{{ "a11y.search_docs" | t }} (&#8984;K)">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.6-3.6"/></svg>
+    </button>
     {% if page.translations | length > 0 %}
     {% set lang_names = {"en": "English", "ko": "한국어"} %}
-    <details class="lang-switcher" id="langSwitcher">
-      <summary class="lang-trigger" aria-label="{{ "a11y.language" | t }}" title="{{ "a11y.language" | t }}">
-        <svg class="lang-globe" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M3 12h18"/><path d="M12 3a14.5 14.5 0 0 1 0 18 14.5 14.5 0 0 1 0-18z"/></svg>
-        <span class="lang-trigger-label">{{ lang_names[page_language] | default(page_language, true) }}</span>
-        <svg class="lang-caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
-      </summary>
-      <ul class="lang-menu" role="menu">
-        {% for t in page.translations %}
-        <li role="none">
-          <a role="menuitem" href="{{ base_url }}{{ t.url }}" hreflang="{{ t.code }}" lang="{{ t.code }}"{% if t.is_current %} class="is-current" aria-current="true"{% endif %}>
-            <span class="lang-menu-name">{{ lang_names[t.code] | default(t.code, true) }}</span>
-            {% if t.is_current %}<svg class="lang-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m5 12 5 5 9-11"/></svg>{% else %}<span class="lang-menu-code">{{ t.code | upper }}</span>{% endif %}
-          </a>
-        </li>
-        {% endfor %}
-      </ul>
-    </details>
+    <nav class="lang-switch" aria-label="{{ "a11y.language" | t }}">
+      {% for t in page.translations %}
+      <a href="{{ base_url }}{{ t.url }}" hreflang="{{ t.code }}" lang="{{ t.code }}" aria-label="{{ lang_names[t.code] | default(t.code, true) }}" title="{{ lang_names[t.code] | default(t.code, true) }}"{% if t.is_current %} class="is-current" aria-current="true"{% endif %}>{{ t.code | upper }}</a>
+      {% endfor %}
+    </nav>
     {% endif %}
-    <button class="search-trigger" onclick="openSearch()" title="{{ "a11y.search_docs" | t }}">
-      <span>{{ "nav.search" | t }}</span>
-      <kbd>&#8984;K</kbd>
-    </button>
     <a class="github-link" href="https://github.com/hahwul/gori" target="_blank" rel="noopener noreferrer" aria-label="{{ "nav.github" | t }}" title="{{ "nav.github" | t }}">
       <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.37.5 0 5.87 0 12.5c0 5.3 3.44 9.8 8.21 11.39.6.11.82-.26.82-.58 0-.29-.01-1.05-.02-2.06-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.2.09 1.84 1.24 1.84 1.24 1.07 1.84 2.81 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.12-.3-.54-1.52.12-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.28-1.55 3.29-1.23 3.29-1.23.66 1.66.24 2.88.12 3.18.77.84 1.24 1.91 1.24 3.22 0 4.61-2.8 5.62-5.48 5.92.43.37.81 1.1.81 2.22 0 1.6-.01 2.9-.01 3.29 0 .32.22.7.83.58C20.57 22.29 24 17.79 24 12.5 24 5.87 18.63.5 12 .5z"/></svg>
     </a>


### PR DESCRIPTION
## Summary

Reworks the docs header toward a quieter control hierarchy (referencing hwaro and OWASP Noir), and calms the landing CTA.

- **Language switch**: the details dropdown becomes a segmented EN | KO pill in mono type; one click per locale, and the outside-click JS in the footer goes away.
- **Search / GitHub / theme**: uniform borderless 2.25rem icon buttons sharing one rule group. The Cmd+K hint moves into the search button tooltip (Ctrl K off Apple platforms).
- **Section links**: pill hover, and the active section carries a gold tinted pill instead of the underline bar.
- **Landing CTA**: Get started drops the gold-leaf gradient, gloss, and shadow for a flat accent fill; the light theme deepens it so the label clears WCAG AA.
- **Mobile fix**: the home hero grid used a bare `1fr` track whose auto minimum inherited the install one-liner's nowrap width, pushing the column past narrow viewports on the live site. Now `minmax(0, 1fr)`.

## Verification

Built with `hwaro build` and screenshotted via headless Chrome: dark and light themes, home and guide pages, desktop and a true 390px viewport (iframe-wrapped to dodge Chrome's minimum window width).