### PR TITLE
fix(tui): make the caret model per-grapheme, collapsing column_width away

### DIFF
--- a/spec/support/memory_backend.cr
+++ b/spec/support/memory_backend.cr
@@ -6,9 +6,15 @@ class MemoryBackend < Gori::Tui::Backend
   getter grid : Array(Array(Char))
   getter fg_grid : Array(Array(Gori::Tui::Color))
   getter bg_grid : Array(Array(Gori::Tui::Color))
+  # Full cell payload, kept alongside @grid because @grid is Array(Char) and so collapses a
+  # multi-codepoint grapheme cluster ("e" + U+0301, conjoining jamo, a ZWJ family) to its
+  # FIRST codepoint — invisible in `row`, which would let a caret that drops a combining
+  # mark pass unnoticed. Assert with `cluster_row` when the text has clusters.
+  getter cluster_grid : Array(Array(String))
 
   def initialize(@w : Int32, @h : Int32)
     @grid = Array.new(@h) { Array.new(@w, ' ') }
+    @cluster_grid = Array.new(@h) { Array.new(@w, " ") }
     @fg_grid = Array.new(@h) { Array.new(@w, Gori::Tui::Color.default) }
     @bg_grid = Array.new(@h) { Array.new(@w, Gori::Tui::Color.default) }
   end
@@ -17,6 +23,7 @@ class MemoryBackend < Gori::Tui::Backend
     return unless x >= 0 && y >= 0 && x < @w && y < @h
     ch = grapheme.is_a?(Char) ? grapheme : (grapheme.empty? ? ' ' : grapheme[0])
     @grid[y][x] = ch
+    @cluster_grid[y][x] = grapheme.is_a?(Char) ? grapheme.to_s : (grapheme.empty? ? " " : grapheme)
     @fg_grid[y][x] = fg
     @bg_grid[y][x] = bg
   end
@@ -27,6 +34,12 @@ class MemoryBackend < Gori::Tui::Backend
 
   def row(y : Int32) : String
     @grid[y].join
+  end
+
+  # As `row`, but each cell contributes its FULL grapheme cluster — so a combining mark or
+  # a ZWJ sequence the renderer placed survives into the assertion.
+  def cluster_row(y : Int32) : String
+    @cluster_grid[y].join
   end
 
   def fg_at(x : Int32, y : Int32) : Gori::Tui::Color

--- a/spec/support/memory_backend.cr
+++ b/spec/support/memory_backend.cr
@@ -52,9 +52,16 @@ class MemoryBackend < Gori::Tui::Backend
     end
   end
 
+  # Colors too, not just the glyph: termisu's clear_continuation_owner assigns a whole
+  # Cell.default, so an orphaned lead loses its fg/bg as well. Leaving them behind made
+  # every `bg_at(x, y) == Theme.accent` caret assertion in the suite VACUOUS — it passed
+  # on a caret that had just erased the wide glyph under it, which is exactly the bug the
+  # caret specs exist to catch.
   private def blank_cell(y : Int32, x : Int32) : Nil
     @grid[y][x] = ' '
     @cluster_grid[y][x] = " "
+    @fg_grid[y][x] = Gori::Tui::Color.default
+    @bg_grid[y][x] = Gori::Tui::Color.default
   end
 
   def size : {Int32, Int32}

--- a/spec/support/memory_backend.cr
+++ b/spec/support/memory_backend.cr
@@ -11,21 +11,50 @@ class MemoryBackend < Gori::Tui::Backend
   # FIRST codepoint — invisible in `row`, which would let a caret that drops a combining
   # mark pass unnoticed. Assert with `cluster_row` when the text has clusters.
   getter cluster_grid : Array(Array(String))
+  # Continuation ("right half") flags, mirroring TermisuBackend and termisu itself: a
+  # width-2 glyph written at x CLAIMS x+1, and a later write landing on a claimed cell
+  # orphans its lead at x-1, which the terminal then clears (clear_continuation_owner).
+  # Without modelling that, this harness silently absorbs the whole class of bug where a
+  # caret erases the very wide glyph it is highlighting — every assertion would pass while
+  # the real screen showed a blank.
+  getter cont_grid : Array(Array(Bool))
 
   def initialize(@w : Int32, @h : Int32)
     @grid = Array.new(@h) { Array.new(@w, ' ') }
     @cluster_grid = Array.new(@h) { Array.new(@w, " ") }
+    @cont_grid = Array.new(@h) { Array.new(@w, false) }
     @fg_grid = Array.new(@h) { Array.new(@w, Gori::Tui::Color.default) }
     @bg_grid = Array.new(@h) { Array.new(@w, Gori::Tui::Color.default) }
   end
 
   def put(x : Int32, y : Int32, grapheme : Char | String, fg : Gori::Tui::Color, bg : Gori::Tui::Color, attr : Gori::Tui::Attribute) : Nil
     return unless x >= 0 && y >= 0 && x < @w && y < @h
-    ch = grapheme.is_a?(Char) ? grapheme : (grapheme.empty? ? ' ' : grapheme[0])
-    @grid[y][x] = ch
-    @cluster_grid[y][x] = grapheme.is_a?(Char) ? grapheme.to_s : (grapheme.empty? ? " " : grapheme)
+    g = grapheme.is_a?(Char) ? grapheme.to_s : (grapheme.empty? ? " " : grapheme)
+    # Writing onto a continuation column orphans the wide glyph that owns it.
+    blank_cell(y, x - 1) if x > 0 && @cont_grid[y][x]
+    @cont_grid[y][x] = false
+    @grid[y][x] = g[0]
+    @cluster_grid[y][x] = g
     @fg_grid[y][x] = fg
     @bg_grid[y][x] = bg
+    claim_trailing(y, x, g)
+  end
+
+  # A width-2 glyph claims x+1 as its continuation; a narrow one drawn over a wide glyph's
+  # lead orphans the trailing cell that glyph had claimed, which the terminal clears.
+  private def claim_trailing(y : Int32, x : Int32, g : String) : Nil
+    return if x + 1 >= @w
+    if Gori::Tui::Screen.display_width(g) == 2
+      @cont_grid[y][x + 1] = true
+    elsif @cont_grid[y][x + 1]
+      @cont_grid[y][x + 1] = false
+      blank_cell(y, x + 1)
+    end
+  end
+
+  private def blank_cell(y : Int32, x : Int32) : Nil
+    @grid[y][x] = ' '
+    @cluster_grid[y][x] = " "
   end
 
   def size : {Int32, Int32}

--- a/spec/tui/foundation_spec.cr
+++ b/spec/tui/foundation_spec.cr
@@ -32,65 +32,141 @@ describe Gori::Tui::Rect do
 end
 
 describe Gori::Tui::Screen do
-  it "column_width counts a raw control char as 1 column (inverse of column_for)" do
+  it "draw_width counts a raw control char as 1 column (inverse of column_for)" do
     line = "ab\rc" # a lone CR (display width 0) between real chars
-    # display_width under-counts the control char (0); column_width matches the drawn
+    # display_width under-counts the control char (0); draw_width matches the drawn
     # cells + column_for, so the caret after it lands on the right column.
-    Screen.display_width(line).should eq(3)                                 # CR contributes 0
-    Screen.column_width(line).should eq(4)                                  # CR occupies a cell → counts as 1
-    Screen.column_for(line, Screen.column_width(line)).should eq(line.size) # round-trips
+    Screen.display_width(line).should eq(3)                                # CR contributes 0
+    Screen.draw_width(line).should eq(4)                                   # CR occupies a cell → counts as 1
+    Screen.column_for(line, Screen.draw_width(line)).should eq(line.size)  # round-trips
   end
 
-  it "column_width equals display_width for plain text and doubles wide glyphs" do
-    Screen.column_width("hello").should eq(5)
-    Screen.column_width("日本").should eq(4) # CJK: 2 columns each, same as display_width
+  it "draw_width equals display_width for plain text and doubles wide glyphs" do
+    Screen.draw_width("hello").should eq(5)
+    Screen.draw_width("日本").should eq(4) # CJK: 2 columns each, same as display_width
   end
 
   it "grapheme_cols floors a tab to 1 so draw advance matches the caret model" do
-    # display_width is pure Unicode (tab = 0); grapheme_cols / column_width keep the
+    # display_width is pure Unicode (tab = 0); grapheme_cols / draw_width keep the
     # space cell Screen#cell substitutes for C0 controls (issue #278).
     Screen.display_width("\t").should eq(0)
     Screen.grapheme_cols("\t").should eq(1)
-    Screen.column_width("a\tb").should eq(3)
-    Screen.column_width_upto("a\tb", 10).should eq(3)
-    Screen.column_width_upto("a\tb", 2).should eq(2)
+    Screen.draw_width("a\tb").should eq(3)
+    Screen.draw_width_upto("a\tb", 10).should eq(3)
+    Screen.draw_width_upto("a\tb", 2).should eq(2)
   end
 
-  # The three measures, pinned side by side. They are NOT interchangeable, and picking the
-  # wrong one is exactly how the draw-alignment sites drifted: display_width under-counts a
-  # C0 control (Unicode width 0, but `cell` still paints a space there), column_width
-  # over-counts a multi-codepoint cluster (it floors every CODEPOINT to ≥1, right for the
-  # per-codepoint caret, wrong for a draw), and draw_width matches the cells actually
-  # painted because it floors per CLUSTER — the same walk `#text` / `Highlight.draw` do.
-  describe "display_width vs column_width vs draw_width" do
+  # The two measures, pinned side by side. They are NOT interchangeable: display_width
+  # under-counts a C0 control (Unicode width 0, but `cell` still paints a space there),
+  # while draw_width matches the cells actually painted because it floors per CLUSTER —
+  # the same walk `#text` / `Highlight.draw` do.
+  #
+  # `column_width` used to sit between them, flooring every CODEPOINT to ≥1 to serve a
+  # per-codepoint caret. The `was` column below is what it returned. draw_width SUBSUMES
+  # it: identical wherever column_width mattered (control chars, zero-width chars — each
+  # its own cluster, still floored to ≥1) and different only where column_width was wrong
+  # against the screen, which is what painted a duplicate glyph past any cluster.
+  describe "display_width vs draw_width" do
     skin = "\u{1F44D}\u{1F3FD}"                                             # 👍🏽 thumbs-up + skin-tone modifier (2 cps)
     zwj = "\u{1F468}\u{200D}\u{1F4BB}"                                      # 👨‍💻 man + ZWJ + laptop (3 cps)
     family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}" # 👨‍👩‍👧‍👦 4 people + 3 ZWJ (7 cps)
+    nfd_han = "\u{1112}\u{1161}\u{11ab}"                                    # 한 as 3 conjoining jamo
 
-    # {label, string, display_width, column_width, draw_width}
+    # {label, string, display_width, draw_width, what column_width used to return}
     cases = [
-      {"tab", "a\tb", 2, 3, 3},            # control: display under-counts; the tab owns a cell
-      {"ZWSP", "a\u{200B}b", 2, 3, 3},     # zero-width space: same, it still gets a cell
-      {"skin tone", skin, 2, 3, 2},        # 1 cluster, 1 glyph → 2 cols drawn, not 3
-      {"ZWJ", zwj, 2, 5, 2},               # column_width drifts 3
-      {"family", family, 2, 11, 2},        # column_width drifts 9 — the worst case
-      {"CJK", "한글", 4, 4, 4},              # wide but single-codepoint: all three agree
-      {"combining", "e\u{0301}", 1, 2, 1}, # é as e + U+0301: cluster is 1 col, not 2
+      {"tab", "a\tb", 2, 3, 3},               # control: display under-counts; the tab owns a cell
+      {"ZWSP", "a\u{200B}b", 2, 3, 3},        # zero-width space: same, it still gets a cell
+      {"BOM", "a\u{FEFF}b", 3, 3, 3},         # zero-width no-break space: likewise its own cluster
+      {"skin tone", skin, 2, 2, 3},           # 1 cluster, 1 glyph → 2 cols drawn, not 3
+      {"ZWJ", zwj, 2, 2, 5},                  # column_width drifted 3
+      {"family", family, 2, 2, 11},           # column_width drifted 9 — the worst case
+      {"keycap", "1\u{FE0F}\u{20E3}", 2, 2, 3},
+      {"CJK", "한글", 4, 4, 4},                 # wide but single-codepoint: both agree
+      {"NFD Hangul", nfd_han, 2, 2, 4},       # 3 jamo (2 + 0 + 0 floored to 2+1+1), ONE cluster
+      {"combining", "e\u{0301}", 1, 1, 2},    # é as e + U+0301: cluster is 1 col, not 2
     ]
 
-    cases.each do |(label, str, dw, cw, gw)|
-      it "measures #{label} as display=#{dw} column=#{cw} draw=#{gw}" do
+    cases.each do |(label, str, dw, gw, was_cw)|
+      it "measures #{label} as display=#{dw} draw=#{gw} (column_width was #{was_cw})" do
         Screen.display_width(str).should eq(dw)
-        Screen.column_width(str).should eq(cw)
         Screen.draw_width(str).should eq(gw)
+        # The retired measure, recomputed inline: floor every CODEPOINT to ≥1. Pinned so
+        # the divergence this collapse removed stays visible rather than becoming folklore.
+        str.each_char.sum { |c| {Screen.display_width(c.to_s), 1}.max }.should eq(was_cw)
       end
     end
 
     it "draw_width equals the columns Screen#text actually advances" do
       # The authoritative check: whatever `text` returns as its end-x IS the drawn width.
-      cases.each do |(label, str, _, _, gw)|
+      cases.each do |(label, str, _, gw, _)|
         b = MemoryBackend.new(40, 1)
         Screen.new(b).text(0, 0, str, Theme.text).should eq(gw) # (#{label})
+      end
+    end
+
+    # THE invariant the collapse buys: draw_width and column_for are exact inverses at
+    # every cluster boundary, so the caret column and the click that maps back to it can
+    # no longer disagree. Two similar-but-different floored measures is what let #278
+    # (tabs) and #285 (emoji) trade off against each other; there is now only one.
+    it "column_for inverts draw_width at every cluster boundary" do
+      strings = [
+        "hello world",          # ASCII (the fast path on both sides)
+        "a\tb\tc",              # tabs — the #278 case
+        "ab\rc",                # raw control
+        "한글",                   # NFC CJK, wide, 1 cp per cluster
+        nfd_han + "글",           # NFD Hangul — jamo cluster next to a precomposed one
+        "cafe\u{0301} au lait", # NFD Latin, combining mark mid-word
+        "x#{skin}y",            # skin tone
+        "x#{zwj}y",             # ZWJ pair
+        "x#{family}y",          # 4-person ZWJ family — 9 columns of old drift
+        "1\u{FE0F}\u{20E3}!",   # keycap
+        "a\u{200B}b\u{FEFF}c",  # zero-width chars, each its own cluster
+        "a\t한#{skin}e\u{0301}#{family}z", # everything at once
+      ]
+      strings.each do |s|
+        # Walk the cluster boundaries: at each, the column is draw_width of the prefix and
+        # column_for must map that column back to exactly that character index.
+        i = 0
+        s.each_grapheme do |g|
+          col = Screen.draw_width(s[0, i])
+          Screen.column_for(s, col).should eq(i) # (#{s.inspect} @ #{i})
+          i += g.size
+        end
+        # …including the end of the string.
+        Screen.column_for(s, Screen.draw_width(s)).should eq(s.size) # (#{s.inspect} end)
+      end
+    end
+
+    it "column_for never returns an index inside a cluster" do
+      # Every column a click can produce must resolve to a cluster START, so a click can
+      # never drop the caret between the `e` and the combining acute of `é`.
+      s = "a\t한#{skin}e\u{0301}#{family}z"
+      starts = [] of Int32
+      i = 0
+      s.each_grapheme { |g| starts << i; i += g.size }
+      starts << s.size
+      (-3..Screen.draw_width(s) + 3).each do |col|
+        starts.should contain(Screen.column_for(s, col)) # (col #{col})
+      end
+    end
+
+    it "cluster_start / cluster_end snap to boundaries and are identity on them" do
+      s = "a#{skin}e\u{0301}z"
+      starts = [] of Int32
+      i = 0
+      s.each_grapheme { |g| starts << i; i += g.size }
+      starts << s.size
+      starts.each do |b|
+        Screen.cluster_start(s, b).should eq(b) # already a boundary → unchanged
+        Screen.cluster_end(s, b).should eq(b)
+      end
+      (0..s.size).each do |j|
+        st = Screen.cluster_start(s, j)
+        en = Screen.cluster_end(s, j)
+        starts.should contain(st)
+        starts.should contain(en)
+        st.should be <= j
+        en.should be >= j
       end
     end
 
@@ -134,14 +210,14 @@ describe Gori::Tui::Screen do
       # The caret is the single cell painted on the ACCENT background.
       col = (0...40).select { |x| b.bg_at(x, 1) == Theme.accent }
       col.size.should eq(1) # exactly one caret cell (cx=#{cx})
-      col[0].should eq(Screen.column_width(value[0, cx]))  # sits on its own glyph
+      col[0].should eq(Screen.draw_width(value[0, cx]))  # sits on its own glyph
       Screen.column_for(value, col[0]).should eq(cx)       # a click there returns the same cx
       Screen.display_width(value[0, cx]).should be <= cx   # (the old measure could only under-count)
     end
     # Concretely: past the ZWSP the two measures disagree by one, which is exactly the
     # column the caret used to be short by.
     Screen.display_width(value[0, 3]).should eq(2)
-    Screen.column_width(value[0, 3]).should eq(3)
+    Screen.draw_width(value[0, 3]).should eq(3)
   end
 
   it "text draws a tab as a one-column space (ASCII and mixed paths)" do

--- a/spec/tui/foundation_spec.cr
+++ b/spec/tui/foundation_spec.cr
@@ -150,6 +150,33 @@ describe Gori::Tui::Screen do
       end
     end
 
+    it "cannot be summed per CHARACTER — that re-creates the retired measure" do
+      # The trap eight duplicated selection-tint helpers fell into. draw_width of a SINGLE
+      # char is identical to the old per-codepoint measure (one char is always one
+      # cluster), so summing it char-by-char silently rebuilds column_width and drifts
+      # right by each cluster's inflation — while the caret and base draw in the same view
+      # measure per cluster. Drawing char-by-char is worse still: it shreds a cluster
+      # across cells. Any new copy of that helper must iterate CLUSTERS.
+      [{"cafe\u{0301}xyz", 7, 8}, {family, 2, 11}, {nfd_han, 2, 4}].each do |(s, whole, per_char)|
+        Screen.draw_width(s).should eq(whole)
+        s.each_char.sum { |c| Screen.draw_width(c.to_s) }.should eq(per_char)
+      end
+    end
+
+    it "treats the LF of a CRLF pair as cluster interior, not a boundary" do
+      # boundary?, the O(1) fast path in front of the grapheme walk, must not answer "yes"
+      # here. An `ascii_only?` short-circuit did: "a\r\nb" is all-ASCII, so index 2 (the
+      # \n, which UAX #29 GB3 binds to the \r) looked like a fresh cluster. That is the
+      # UNSAFE direction — a false "already a boundary" skips the snap and strands the
+      # caret mid-cluster. No caller can reach it today (every line producer splits on
+      # '\n' first) but the predicate must be right on its own terms.
+      s = "a\r\nb"
+      s.ascii_only?.should be_true # the trap: the short-circuit used to stop here
+      s.graphemes.size.should eq(3)
+      Screen.cluster_start(s, 2).should eq(1) # into the \r\n cluster, not 2
+      Screen.cluster_end(s, 2).should eq(3)
+    end
+
     it "cluster_start / cluster_end snap to boundaries and are identity on them" do
       s = "a#{skin}e\u{0301}z"
       starts = [] of Int32

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -532,7 +532,7 @@ describe "FuzzerView#template_click_to_cursor / #target_click_to_cursor" do
 
     view.focus_pane(:target)
     (0..target.size).each do |cx|
-      col = base + Screen.column_width(target[0, cx])
+      col = base + Screen.draw_width(target[0, cx])
       view.target_click_to_cursor(rect, col, rect.y + 1)
       b = MemoryBackend.new(100, 30)
       view.render(Screen.new(b), rect)
@@ -548,13 +548,13 @@ describe "FuzzerView#template_click_to_cursor / #target_click_to_cursor" do
     # is the 'b' that sits AFTER the ZWSP, the first index the old measure got wrong.
     fresh = FuzzerView.new
     fresh.load_request(target, "GET / HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
-    fresh.target_click_to_cursor(rect, base + Screen.column_width(target[0, 12]), rect.y + 1)
+    fresh.target_click_to_cursor(rect, base + Screen.draw_width(target[0, 12]), rect.y + 1)
     fresh.target_insert('X')
     fresh.target.should eq("#{target[0, 12]}X#{target[12..]}")
 
     # Concretely: past the ZWSP the old measure was one column short of the drawn glyph.
     Screen.display_width(target).should eq(12)
-    Screen.column_width(target).should eq(13)
+    Screen.draw_width(target).should eq(13)
   end
 end
 

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -556,6 +556,39 @@ describe "FuzzerView#template_click_to_cursor / #target_click_to_cursor" do
     Screen.display_width(target).should eq(12)
     Screen.draw_width(target).should eq(13)
   end
+
+  # Same round trip over a MULTI-CODEPOINT cluster, where the retired per-codepoint
+  # measure drifted the other way — right, past the end of the drawn text. Only the
+  # cluster boundaries are checked: a mid-cluster index is not a caret position a click
+  # can produce, since column_for only ever returns cluster starts.
+  it "keeps the target caret and click agreeing across a decomposed cluster" do
+    target = "https://h/cafe\u{0301}b" # café as e + combining acute
+    view = FuzzerView.new
+    view.load_request(target, "GET / HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
+    rect = Rect.new(0, 0, 100, 30)
+    base = rect.x + 4
+
+    view.focus_pane(:target)
+    i = 0
+    bounds = [] of Int32
+    target.each_grapheme { |g| bounds << i; i += g.size }
+    bounds << target.size
+    bounds.each do |cx|
+      col = base + Screen.draw_width(target[0, cx])
+      view.target_click_to_cursor(rect, col, rect.y + 1)
+      b = MemoryBackend.new(100, 30)
+      view.render(Screen.new(b), rect)
+      caret = (base...(base + 24)).select do |x|
+        bg = b.bg_at(x, rect.y + 1)
+        bg == Theme.accent || bg == Theme.accent_bg
+      end
+      caret.should eq([col]) # (cx=#{cx})
+    end
+
+    # The per-codepoint measure over-counted by one for every combining mark.
+    Screen.draw_width(target).should eq(15)
+    target.each_char.sum { |c| Screen.draw_width(c.to_s) }.should eq(16)
+  end
 end
 
 describe "FuzzerView result-detail decode panes" do

--- a/spec/tui/text_area_spec.cr
+++ b/spec/tui/text_area_spec.cr
@@ -185,6 +185,115 @@ describe Gori::Tui::TextArea do
       ta.cx.should eq(2) # past the merged cluster, not between its two codepoints
     end
 
+    # A line JOIN re-clusters across the seam: `@cx = prev.size` / `@cx = cx` are assigned
+    # against a string concatenation just built, so if the joined-on line opens with a
+    # combining mark the seam is now cluster INTERIOR. Every other @cx mutation snapped;
+    # these two did not, and no existing spec crossed them (the join specs join ASCII lines,
+    # the cluster specs stay within one line).
+    describe "line joins re-cluster across the seam" do
+      # line 0 "cafe", line 1 U+0301 + "x" — the join fuses the acute onto the `e`.
+      split = "cafe\n\u{0301}x"
+
+      it "leaves the caret on a boundary after a backspace join" do
+        ta = TextArea.new(split)
+        ta.place_cursor(1, 0)
+        ta.backspace
+        ta.text.should eq("cafe\u{0301}x")
+        ta.cx.should eq(5) # past the fused `é`, NOT 4 (between the e and its acute)
+        line = ta.lines_snapshot[0]
+        # The defining invariant: caret column and click invert each other.
+        Screen.column_for(line, Screen.draw_width(line[0, ta.cx])).should eq(ta.cx)
+      end
+
+      it "leaves the caret on a boundary after a forward-delete join" do
+        ta = TextArea.new(split)
+        ta.place_cursor(0, 4)
+        ta.delete
+        ta.text.should eq("cafe\u{0301}x")
+        ta.cx.should eq(5)
+        line = ta.lines_snapshot[0]
+        Screen.column_for(line, Screen.draw_width(line[0, ta.cx])).should eq(ta.cx)
+      end
+
+      it "does not lose the following glyph when rendering after a join" do
+        ta = TextArea.new(split)
+        ta.place_cursor(1, 0)
+        ta.backspace
+        b = MemoryBackend.new(20, 2)
+        ta.render(Screen.new(b), Rect.new(0, 0, 20, 2), cursor: true, highlight: :request)
+        b.cluster_row(0).rstrip.should eq("cafe\u{0301}x") # was "café" with the x painted over
+      end
+
+      it "inserts after the fused cluster rather than splicing into it" do
+        ta = TextArea.new(split)
+        ta.place_cursor(1, 0)
+        ta.backspace
+        ta.insert('Z')
+        ta.text.should eq("cafe\u{0301}Zx") # was "cafeZ\u{0301}x" — Z between the e and its acute
+      end
+
+      it "does not strand the combining mark on the wrong base after a join" do
+        ta = TextArea.new(split)
+        ta.place_cursor(1, 0)
+        ta.backspace
+        ta.backspace  # removes the fused `é` as one cluster
+        ta.text.should eq("cafx") # was "caf\u{0301}x" — the acute stranded on the `f`
+      end
+    end
+
+    # The block caret used to paint its glyph and then a pad space at +1. For a WIDE glyph
+    # that pad landed on the continuation cell the glyph itself had just claimed, and a
+    # write there orphans the lead — which termisu (and TermisuBackend, mirroring it)
+    # clears. So the caret erased the very glyph it was highlighting. Invisible to the
+    # whole suite until MemoryBackend learned continuation cells.
+    describe "wide-glyph caret (CJK / Hangul)" do
+      it "does not erase the glyph it highlights" do
+        ta = TextArea.new("한글")
+        b = MemoryBackend.new(20, 2)
+        ta.render(Screen.new(b), Rect.new(0, 0, 20, 2), cursor: true, highlight: :request)
+        b.cluster_row(0).rstrip.should eq("한 글") # lead intact; " " is its continuation cell
+        b.cont_grid[0][1].should be_true          # the caret's glyph still owns column 1
+      end
+
+      it "keeps the accent background on the caret's own cell" do
+        ta = TextArea.new("한글")
+        b = MemoryBackend.new(20, 2)
+        ta.render(Screen.new(b), Rect.new(0, 0, 20, 2), cursor: true, highlight: :request)
+        b.bg_at(0, 0).should eq(Theme.accent)
+      end
+
+      it "does not spill its continuation cell outside the pane" do
+        # Caret on the wide glyph at the pane's LAST column: the continuation is claimed
+        # during the glyph's own write, so a `break` afterwards was too late. Draw a space.
+        ta = TextArea.new("ab한")
+        ta.move(0, 2) # caret on the 한, which sits at column 2 = the pane's last column
+        b = MemoryBackend.new(20, 2)
+        ta.render(Screen.new(b), Rect.new(0, 0, 3, 2), cursor: true, highlight: :request)
+        b.cont_grid[0][3].should be_false # column 3 is outside the 3-wide pane
+      end
+    end
+
+    it "leaves the caret on a boundary when stepping out of a concealed run" do
+      # snap_cx_out_of_conceal runs LAST (resting on a hidden byte corrupts the buffer,
+      # which beats a mispaint) and lands on `b + 1`, just past the closing `§`. The
+      # delimiters `¦` U+00A6 / `§` U+00A7 are NOT ASCII, but both are
+      # Grapheme_Cluster_Break=Other so they always start a cluster — `a` is safe. `b + 1`
+      # is not: a combining mark typed straight after the `§` binds to it, so the "legal
+      # rest" was cluster interior until that edge got rounded up.
+      text = "q=§data¦b64§\u{0301}x"
+      ta = TextArea.new(text)
+      ta.conceal_spans = [{7, 11}] # ¦b64, closing § at 11
+      ta.move(0, 7)                # the run's left edge
+      ta.cx.should eq(7)
+      ta.move(0, 1) # cross the run: past the §, and past the mark bound to it
+      line = ta.lines_snapshot[0]
+      starts = [] of Int32
+      i = 0
+      line.each_grapheme { |g| starts << i; i += g.size }
+      starts << line.size
+      starts.should contain(ta.cx) # was 12, interior of the "§ + acute" cluster
+    end
+
     it "lands a click on a cluster start, agreeing with where the caret paints" do
       rect = Rect.new(0, 0, 40, 3)
       ta = TextArea.new(cafe + "X")

--- a/spec/tui/text_area_spec.cr
+++ b/spec/tui/text_area_spec.cr
@@ -81,6 +81,121 @@ describe Gori::Tui::TextArea do
     end
   end
 
+  # Multi-codepoint grapheme clusters. The caret column was computed per CODEPOINT
+  # (Screen.column_width) while the glyphs were drawn per CLUSTER (Highlight.draw /
+  # Screen#text), so on any decomposed or combined text the caret landed N columns
+  # right of its glyph — N being the cluster's "inflation", codepoints minus clusters —
+  # and painted a DUPLICATE of value[@cx] there. Longstanding (reproduces at fe11895),
+  # not a regression from #278/#285/#289.
+  describe "multi-codepoint grapheme clusters (decomposed / ZWJ / skin tone)" do
+    nfc = "\u{d55c}\u{ae00}"          # 한글, 2 precomposed syllables
+    han = "\u{1112}\u{1161}\u{11ab}"  # 한, 3 conjoining jamo — ONE cluster, 2 columns
+    geul = "\u{1100}\u{1173}\u{11af}" # 글, likewise
+    nfd = han + geul                  # 한글, 6 codepoints / 2 clusters
+    cafe = "cafe\u{301}"              # café, e + combining acute (5 codepoints / 4 clusters)
+
+    it "keeps the caret on its own glyph for precomposed Hangul (the case that already worked)" do
+      # 1 codepoint per cluster, so per-codepoint and per-cluster columns agree.
+      render_req_tab(nfc + "X", nfc.size).row(0).rstrip.should eq("한 글 X")
+    end
+
+    it "does not paint a duplicate glyph past decomposed Hangul" do
+      # 6 jamo collapse to 2 drawn syllables: the old per-codepoint caret column was 8 while
+      # the draw advanced 4, so the caret stamped a second 'X' four cells right of the real
+      # one ("ᄒ ᄀ X   X"). Each syllable is one wide cluster → glyph + pad cell.
+      b = render_req_tab(nfd + "X", nfd.size)
+      b.row(0).rstrip.should eq("ᄒ ᄀ X")
+      # Built from the same codepoints, not an NFC literal: the two forms print identically
+      # but are different strings, so a literal here would fail while looking correct.
+      b.cluster_row(0).rstrip.should eq("#{han} #{geul} X") # wide cluster + its pad cell
+    end
+
+    it "does not paint a duplicate glyph past a combining acute" do
+      # Caret column was 5 against a 4-column draw → the caret's 'X' landed one cell right
+      # of the real one ("cafeXX"). cluster_row proves the acute is still on its base 'e'.
+      b = render_req_tab(cafe + "X", cafe.size)
+      b.row(0).rstrip.should eq("cafeX") # @grid is Array(Char): the acute can't show here
+      b.cluster_row(0).rstrip.should eq(cafe + "X") # every codepoint intact, none doubled
+    end
+
+    it "steps the caret over whole clusters, visiting only boundaries" do
+      # @cx stays a CHARACTER index, so the boundaries are 0,3,6 for two 3-jamo syllables —
+      # it just never RESTS between them. One → per syllable, no dead presses.
+      ta = TextArea.new(nfd)
+      ta.cx.should eq(0)
+      ta.move(0, 1)
+      ta.cx.should eq(han.size) # 3 — cleared the whole syllable, not one jamo
+      ta.move(0, 1)
+      ta.cx.should eq(nfd.size) # 6
+      ta.move(0, -1)
+      ta.cx.should eq(han.size)
+      ta.move(0, -1)
+      ta.cx.should eq(0)
+    end
+
+    it "renders no duplicate glyph at any caret position while stepping through" do
+      # The bug appeared only at certain caret columns, so walk them all.
+      text = "#{cafe}#{nfd}X"
+      ta = TextArea.new(text)
+      (0..text.size).each do |_|
+        b = MemoryBackend.new(40, 3)
+        ta.render(Screen.new(b), Rect.new(0, 0, 40, 3), cursor: true, highlight: :request)
+        # Strip the caret's own cell by comparing against the no-caret render: the drawn
+        # text must be identical either way — the caret may INVERT a cell, never add one.
+        plain = MemoryBackend.new(40, 3)
+        TextArea.new(text).render(Screen.new(plain), Rect.new(0, 0, 40, 3),
+          cursor: false, highlight: :request)
+        b.cluster_row(0).should eq(plain.cluster_row(0)) # (cx=#{ta.cx})
+        ta.move(0, 1)
+      end
+    end
+
+    it "backspaces a whole cluster rather than stranding a combining mark" do
+      ta = TextArea.new(cafe)
+      ta.move(0, 999) # end of line
+      ta.cx.should eq(cafe.size)
+      ta.backspace
+      ta.text.should eq("caf") # NOT "cafe" with the acute silently dropped
+      ta.cx.should eq(3)
+    end
+
+    it "backspaces a ZWJ family without leaving a dangling joiner" do
+      family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}"
+      ta = TextArea.new("a#{family}b")
+      ta.move(0, 999)
+      ta.backspace # the 'b'
+      ta.backspace # the whole family
+      ta.text.should eq("a")
+    end
+
+    it "forward-deletes a whole cluster too" do
+      ta = TextArea.new(nfd + "X")
+      ta.delete
+      ta.text.should eq(geul + "X") # the first syllable went as a unit
+      ta.delete
+      ta.text.should eq("X")
+    end
+
+    it "keeps the caret on a boundary after inserting in front of a combining mark" do
+      # Typing `e` before a lone U+0301 MERGES them into one cluster; the caret must end
+      # past the whole thing rather than inside it.
+      ta = TextArea.new("\u{0301}")
+      ta.insert('e')
+      ta.text.should eq("e\u{0301}")
+      ta.cx.should eq(2) # past the merged cluster, not between its two codepoints
+    end
+
+    it "lands a click on a cluster start, agreeing with where the caret paints" do
+      rect = Rect.new(0, 0, 40, 3)
+      ta = TextArea.new(cafe + "X")
+      # Column 3 is the `é` cluster (c,a,f each 1 column).
+      ta.click_to_cursor(rect, 3, 0)
+      ta.cx.should eq(3) # the cluster START — never 4, between the e and the acute
+      ta.click_to_cursor(rect, 4, 0)
+      ta.cx.should eq(cafe.size) # past the cluster, on the X
+    end
+  end
+
   describe "display concealment (@conceal_spans)" do
     # "q=§data¦base64-encode§ x": open § at 2, ¦ at 7, closing § at 21.
     text = "q=§data¦base64-encode§ x"

--- a/spec/tui/text_field_spec.cr
+++ b/spec/tui/text_field_spec.cr
@@ -75,7 +75,7 @@ describe Gori::Tui::TextField do
     # together, and the assertion below is on the caret EXISTING and being in-field.)
     value = "#{"a" * 6}#{"\u{200B}" * 5}b" # 12 chars: display_width 7, column_width 12
     Screen.display_width(value).should eq(7)
-    Screen.column_width(value).should eq(12)
+    Screen.draw_width(value).should eq(12)
     f = TextField.new(value) # TextField.new parks the caret at the end
     f.caret.should eq(12)
     backend = MemoryBackend.new(40, 3)

--- a/src/gori/tui/custom_rule_overlay.cr
+++ b/src/gori/tui/custom_rule_overlay.cr
@@ -263,7 +263,7 @@ module Gori::Tui
       screen.text(vx, py, shown, fg, bg, width: vw)
       if sel && pre.empty?
         cx = field.caret.clamp(0, val.size)
-        px = vx + Screen.column_width(val[0, cx])
+        px = vx + Screen.draw_width(val[0, cx])
         if px < box.right - 2
           ch = cx < val.size ? val[cx] : ' '
           screen.cell(px, py, ch, Theme.bg, Theme.accent_bg)

--- a/src/gori/tui/decoder_view.cr
+++ b/src/gori/tui/decoder_view.cr
@@ -310,13 +310,21 @@ module Gori::Tui
     private def paint_char_span_bg(screen : Screen, x : Int32, y : Int32, line : String,
                                    x0 : Int32, x1 : Int32, bg : Color) : Nil
       return if x0 >= x1
-      px = x
-      (0...x0).each { |i| px += Screen.draw_width(line[i].to_s) } if x0 > 0
-      (x0...x1).each do |i|
-        break if i >= line.size
-        w = Screen.draw_width(line[i].to_s)
-        screen.text(px, y, line[i].to_s, Theme.text, bg)
-        px += w
+      # Cluster-wise, matching the base draw and the caret. Summing draw_width over single
+      # CHARS is exactly the retired per-codepoint measure: it drifts right by each
+      # cluster's inflation (1 column for a skin tone, 9 for a ZWJ family), and drawing
+      # char-by-char also SHREDS a cluster across cells, stranding a bare combining mark in
+      # one of its own. Span edges snap outward so the tint covers whole glyphs.
+      a = Screen.cluster_start(line, {x0, line.size}.min)
+      b = Screen.cluster_end(line, {x1, line.size}.min)
+      px = x + Screen.draw_width(line[0, a])
+      i = a
+      while i < b
+        e = Screen.cluster_end(line, i + 1)
+        seg = line[i...e]
+        screen.text(px, y, seg, Theme.text, bg)
+        px += Screen.draw_width(seg)
+        i = e
       end
     end
 

--- a/src/gori/tui/decoder_view.cr
+++ b/src/gori/tui/decoder_view.cr
@@ -131,7 +131,7 @@ module Gori::Tui
       return unless cy >= scr && cy < scr + rect.h
       row = cy - scr
       line = lines[cy]
-      px = rect.x + Screen.column_width(line[0, cx])
+      px = rect.x + Screen.draw_width(line[0, cx])
       if px < rect.x + rect.w
         ch = cx < line.size ? line[cx] : ' '
         screen.cell(px, rect.y + row, ch, Theme.bg, Theme.accent_bg)
@@ -301,7 +301,7 @@ module Gori::Tui
       end
       return unless li == @out_read.cy
       cx = @out_read.cx.clamp(0, line.size)
-      px = x + Screen.column_width(line[0, cx])
+      px = x + Screen.draw_width(line[0, cx])
       ch = cx < line.size ? line[cx] : ' '
       screen.cell(px, y, ch, Theme.bg, Theme.accent_bg)
       screen.cursor(px, y)
@@ -311,10 +311,10 @@ module Gori::Tui
                                    x0 : Int32, x1 : Int32, bg : Color) : Nil
       return if x0 >= x1
       px = x
-      (0...x0).each { |i| px += Screen.column_width(line[i].to_s) } if x0 > 0
+      (0...x0).each { |i| px += Screen.draw_width(line[i].to_s) } if x0 > 0
       (x0...x1).each do |i|
         break if i >= line.size
-        w = Screen.column_width(line[i].to_s)
+        w = Screen.draw_width(line[i].to_s)
         screen.text(px, y, line[i].to_s, Theme.text, bg)
         px += w
       end

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -1518,7 +1518,7 @@ module Gori::Tui
         # paint_char_span_bg (the selection tint, just above) and inverts the
         # Screen.column_for in target_click_to_cursor. display_width put the caret a column
         # left of its glyph on a target holding a zero-width char.
-        cx = base + Screen.column_width(@target[0, @tcx])
+        cx = base + Screen.draw_width(@target[0, @tcx])
         if cx < rect.right - 1
           ch = @tcx < @target.size ? @target[@tcx] : ' '
           screen.cell(cx, rect.y + 1, ch, Theme.bg, ins ? Theme.accent : Theme.accent_bg)
@@ -1584,7 +1584,7 @@ module Gori::Tui
       row = cy - scr
       gw = @editor.gutter? ? Gutter.width(lines.size) : 0
       line = lines[cy]
-      px = rect.x + gw + Screen.column_width(line[0, cx])
+      px = rect.x + gw + Screen.draw_width(line[0, cx])
       if px < rect.x + rect.w
         ch = cx < line.size ? line[cx] : ' '
         screen.cell(px, rect.y + row, ch, Theme.bg, Theme.accent_bg)
@@ -1596,10 +1596,10 @@ module Gori::Tui
                                    x0 : Int32, x1 : Int32, bg : Color) : Nil
       return if x0 >= x1
       px = x
-      (0...x0).each { |i| px += Screen.column_width(line[i].to_s) } if x0 > 0
+      (0...x0).each { |i| px += Screen.draw_width(line[i].to_s) } if x0 > 0
       (x0...x1).each do |i|
         break if i >= line.size
-        w = Screen.column_width(line[i].to_s)
+        w = Screen.draw_width(line[i].to_s)
         screen.text(px, y, line[i].to_s, Theme.text, bg)
         px += w
       end
@@ -2023,7 +2023,7 @@ module Gori::Tui
       end
       return unless li == @detail_cursor.cy
       cx = @detail_cursor.cx.clamp(0, line.size)
-      px = x + Screen.column_width(line[0, cx])
+      px = x + Screen.draw_width(line[0, cx])
       ch = cx < line.size ? line[cx] : ' '
       screen.cell(px, y, ch, Theme.bg, Theme.accent_bg)
       screen.cursor(px, y)

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -1595,13 +1595,21 @@ module Gori::Tui
     private def paint_char_span_bg(screen : Screen, x : Int32, y : Int32, line : String,
                                    x0 : Int32, x1 : Int32, bg : Color) : Nil
       return if x0 >= x1
-      px = x
-      (0...x0).each { |i| px += Screen.draw_width(line[i].to_s) } if x0 > 0
-      (x0...x1).each do |i|
-        break if i >= line.size
-        w = Screen.draw_width(line[i].to_s)
-        screen.text(px, y, line[i].to_s, Theme.text, bg)
-        px += w
+      # Cluster-wise, matching the base draw and the caret. Summing draw_width over single
+      # CHARS is exactly the retired per-codepoint measure: it drifts right by each
+      # cluster's inflation (1 column for a skin tone, 9 for a ZWJ family), and drawing
+      # char-by-char also SHREDS a cluster across cells, stranding a bare combining mark in
+      # one of its own. Span edges snap outward so the tint covers whole glyphs.
+      a = Screen.cluster_start(line, {x0, line.size}.min)
+      b = Screen.cluster_end(line, {x1, line.size}.min)
+      px = x + Screen.draw_width(line[0, a])
+      i = a
+      while i < b
+        e = Screen.cluster_end(line, i + 1)
+        seg = line[i...e]
+        screen.text(px, y, seg, Theme.text, bg)
+        px += Screen.draw_width(seg)
+        i = e
       end
     end
 

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -1546,13 +1546,23 @@ module Gori::Tui
     private def paint_char_span_bg(screen : Screen, x : Int32, y : Int32, line : String,
                                    x0 : Int32, x1 : Int32, cw : Int32, bg : Color) : Nil
       return if x0 >= x1 || cw <= 0
-      # Start at the span's on-screen column: display width up to x0, shifted by xscroll.
-      px = x + Screen.draw_width(line[0, {x0, line.size}.min]) - @detail_xscroll
-      (x0...x1).each do |i|
-        break if i >= line.size
-        w = Screen.draw_width(line[i].to_s)
-        screen.text(px, y, line[i].to_s, Theme.text, bg) if px >= x && px + w <= x + cw
+      # Start at the span's on-screen column: drawn width up to x0, shifted by xscroll.
+      # Cluster-wise, matching the base draw and the caret. Summing draw_width over single
+      # CHARS is exactly the retired per-codepoint measure: it drifts right by each
+      # cluster's inflation (1 column for a skin tone, 9 for a ZWJ family), and drawing
+      # char-by-char also SHREDS a cluster across cells, stranding a bare combining mark in
+      # one of its own. Span edges snap outward so the tint covers whole glyphs.
+      a = Screen.cluster_start(line, {x0, line.size}.min)
+      b = Screen.cluster_end(line, {x1, line.size}.min)
+      px = x + Screen.draw_width(line[0, a]) - @detail_xscroll
+      i = a
+      while i < b
+        e = Screen.cluster_end(line, i + 1)
+        seg = line[i...e]
+        w = Screen.draw_width(seg)
+        screen.text(px, y, seg, Theme.text, bg) if px >= x && px + w <= x + cw
         px += w
+        i = e
       end
     end
 

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -872,18 +872,19 @@ module Gori::Tui
 
     # Horizontal companion to ensure_detail_visible: slide @detail_xscroll so the caret
     # column stays inside the visible content width [xscroll, xscroll + cw). Mirrors
-    # TextArea#ensure_visible_x; uses Screen.column_width (the caret painter's measure).
+    # TextArea#ensure_visible_x; uses Screen.draw_width (the caret painter's measure, and
+    # the one Highlight.slice_left consumes @detail_xscroll in — they used to disagree).
     private def ensure_detail_visible_x(cw : Int32) : Nil
       return if cw <= 0
       size, line_at = detail_line_source
       return if size <= 0 || @detail_read.cy >= size
       line = line_at.call(@detail_read.cy)
-      if Screen.column_width(line) <= cw
+      if Screen.draw_width(line) <= cw
         @detail_xscroll = 0
         return
       end
       cx = @detail_read.cx.clamp(0, line.size)
-      curx = Screen.column_width(line[0, cx])
+      curx = Screen.draw_width(line[0, cx])
       @detail_xscroll = curx if curx < @detail_xscroll
       @detail_xscroll = curx - cw + 1 if curx >= @detail_xscroll + cw
       @detail_xscroll = 0 if @detail_xscroll < 0
@@ -1535,7 +1536,7 @@ module Gori::Tui
       end
       return unless li == @detail_read.cy
       cx = @detail_read.cx.clamp(0, line.size)
-      px = x + Screen.column_width(line[0, cx]) - @detail_xscroll
+      px = x + Screen.draw_width(line[0, cx]) - @detail_xscroll
       return if px < x || px >= x + cw # caret scrolled outside the visible content
       ch = cx < line.size ? line[cx] : ' '
       screen.cell(px, y, ch, Theme.bg, Theme.accent_bg)
@@ -1546,10 +1547,10 @@ module Gori::Tui
                                    x0 : Int32, x1 : Int32, cw : Int32, bg : Color) : Nil
       return if x0 >= x1 || cw <= 0
       # Start at the span's on-screen column: display width up to x0, shifted by xscroll.
-      px = x + Screen.column_width(line[0, {x0, line.size}.min]) - @detail_xscroll
+      px = x + Screen.draw_width(line[0, {x0, line.size}.min]) - @detail_xscroll
       (x0...x1).each do |i|
         break if i >= line.size
-        w = Screen.column_width(line[i].to_s)
+        w = Screen.draw_width(line[i].to_s)
         screen.text(px, y, line[i].to_s, Theme.text, bg) if px >= x && px + w <= x + cw
         px += w
       end

--- a/src/gori/tui/issues_view.cr
+++ b/src/gori/tui/issues_view.cr
@@ -711,7 +711,7 @@ module Gori::Tui
       return unless cy >= scr && cy < scr + rect.h
       row = cy - scr
       line = lines[cy]
-      px = rect.x + Screen.column_width(line[0, cx])
+      px = rect.x + Screen.draw_width(line[0, cx])
       if px < rect.x + rect.w
         ch = cx < line.size ? line[cx] : ' '
         screen.cell(px, rect.y + row, ch, Theme.bg, Theme.accent_bg)
@@ -723,10 +723,10 @@ module Gori::Tui
                                    x0 : Int32, x1 : Int32, bg : Color) : Nil
       return if x0 >= x1
       px = x
-      (0...x0).each { |i| px += Screen.column_width(line[i].to_s) } if x0 > 0
+      (0...x0).each { |i| px += Screen.draw_width(line[i].to_s) } if x0 > 0
       (x0...x1).each do |i|
         break if i >= line.size
-        w = Screen.column_width(line[i].to_s)
+        w = Screen.draw_width(line[i].to_s)
         screen.text(px, y, line[i].to_s, Theme.text, bg)
         px += w
       end

--- a/src/gori/tui/issues_view.cr
+++ b/src/gori/tui/issues_view.cr
@@ -722,13 +722,21 @@ module Gori::Tui
     private def paint_char_span_bg(screen : Screen, x : Int32, y : Int32, line : String,
                                    x0 : Int32, x1 : Int32, bg : Color) : Nil
       return if x0 >= x1
-      px = x
-      (0...x0).each { |i| px += Screen.draw_width(line[i].to_s) } if x0 > 0
-      (x0...x1).each do |i|
-        break if i >= line.size
-        w = Screen.draw_width(line[i].to_s)
-        screen.text(px, y, line[i].to_s, Theme.text, bg)
-        px += w
+      # Cluster-wise, matching the base draw and the caret. Summing draw_width over single
+      # CHARS is exactly the retired per-codepoint measure: it drifts right by each
+      # cluster's inflation (1 column for a skin tone, 9 for a ZWJ family), and drawing
+      # char-by-char also SHREDS a cluster across cells, stranding a bare combining mark in
+      # one of its own. Span edges snap outward so the tint covers whole glyphs.
+      a = Screen.cluster_start(line, {x0, line.size}.min)
+      b = Screen.cluster_end(line, {x1, line.size}.min)
+      px = x + Screen.draw_width(line[0, a])
+      i = a
+      while i < b
+        e = Screen.cluster_end(line, i + 1)
+        seg = line[i...e]
+        screen.text(px, y, seg, Theme.text, bg)
+        px += Screen.draw_width(seg)
+        i = e
       end
     end
 

--- a/src/gori/tui/jwt_view.cr
+++ b/src/gori/tui/jwt_view.cr
@@ -199,7 +199,7 @@ module Gori::Tui
       cy, cx = read.cursor.cy, read.cursor.cx
       return unless cy >= scr && cy < scr + rect.h
       line = lines[cy]
-      px = rect.x + Screen.column_width(line[0, cx.clamp(0, line.size)])
+      px = rect.x + Screen.draw_width(line[0, cx.clamp(0, line.size)])
       return if px >= rect.x + rect.w
       ch = cx < line.size ? line[cx] : ' '
       screen.cell(px, rect.y + (cy - scr), ch, Theme.bg, Theme.accent_bg)
@@ -209,11 +209,11 @@ module Gori::Tui
     private def paint_span_bg(screen : Screen, x : Int32, y : Int32, line : String, x0 : Int32, x1 : Int32) : Nil
       return if x0 >= x1
       px = x
-      (0...x0).each { |i| px += Screen.column_width(line[i].to_s) if i < line.size }
+      (0...x0).each { |i| px += Screen.draw_width(line[i].to_s) if i < line.size }
       (x0...x1).each do |i|
         break if i >= line.size
         screen.text(px, y, line[i].to_s, Theme.text, Theme.accent_bg)
-        px += Screen.column_width(line[i].to_s)
+        px += Screen.draw_width(line[i].to_s)
       end
     end
 

--- a/src/gori/tui/jwt_view.cr
+++ b/src/gori/tui/jwt_view.cr
@@ -208,12 +208,21 @@ module Gori::Tui
 
     private def paint_span_bg(screen : Screen, x : Int32, y : Int32, line : String, x0 : Int32, x1 : Int32) : Nil
       return if x0 >= x1
-      px = x
-      (0...x0).each { |i| px += Screen.draw_width(line[i].to_s) if i < line.size }
-      (x0...x1).each do |i|
-        break if i >= line.size
-        screen.text(px, y, line[i].to_s, Theme.text, Theme.accent_bg)
-        px += Screen.draw_width(line[i].to_s)
+      # Cluster-wise, matching the base draw and the caret. Summing draw_width over single
+      # CHARS is exactly the retired per-codepoint measure: it drifts right by each
+      # cluster's inflation (1 column for a skin tone, 9 for a ZWJ family), and drawing
+      # char-by-char also SHREDS a cluster across cells, stranding a bare combining mark in
+      # one of its own. Span edges snap outward so the tint covers whole glyphs.
+      a = Screen.cluster_start(line, {x0, line.size}.min)
+      b = Screen.cluster_end(line, {x1, line.size}.min)
+      px = x + Screen.draw_width(line[0, a])
+      i = a
+      while i < b
+        e = Screen.cluster_end(line, i + 1)
+        seg = line[i...e]
+        screen.text(px, y, seg, Theme.text, Theme.accent_bg)
+        px += Screen.draw_width(seg)
+        i = e
       end
     end
 

--- a/src/gori/tui/notes_view.cr
+++ b/src/gori/tui/notes_view.cr
@@ -411,7 +411,7 @@ module Gori::Tui
       row = cy - scr
       gw = ed.gutter? ? Gutter.width(lines.size) : 0
       line = lines[cy]
-      px = rect.x + gw + Screen.column_width(line[0, cx])
+      px = rect.x + gw + Screen.draw_width(line[0, cx])
       if px < rect.x + rect.w
         ch = cx < line.size ? line[cx] : ' '
         screen.cell(px, rect.y + row, ch, Theme.bg, Theme.accent_bg)
@@ -423,10 +423,10 @@ module Gori::Tui
                                    x0 : Int32, x1 : Int32, bg : Color) : Nil
       return if x0 >= x1
       px = x
-      (0...x0).each { |i| px += Screen.column_width(line[i].to_s) } if x0 > 0
+      (0...x0).each { |i| px += Screen.draw_width(line[i].to_s) } if x0 > 0
       (x0...x1).each do |i|
         break if i >= line.size
-        w = Screen.column_width(line[i].to_s)
+        w = Screen.draw_width(line[i].to_s)
         screen.text(px, y, line[i].to_s, Theme.text, bg)
         px += w
       end

--- a/src/gori/tui/notes_view.cr
+++ b/src/gori/tui/notes_view.cr
@@ -422,13 +422,21 @@ module Gori::Tui
     private def paint_char_span_bg(screen : Screen, x : Int32, y : Int32, line : String,
                                    x0 : Int32, x1 : Int32, bg : Color) : Nil
       return if x0 >= x1
-      px = x
-      (0...x0).each { |i| px += Screen.draw_width(line[i].to_s) } if x0 > 0
-      (x0...x1).each do |i|
-        break if i >= line.size
-        w = Screen.draw_width(line[i].to_s)
-        screen.text(px, y, line[i].to_s, Theme.text, bg)
-        px += w
+      # Cluster-wise, matching the base draw and the caret. Summing draw_width over single
+      # CHARS is exactly the retired per-codepoint measure: it drifts right by each
+      # cluster's inflation (1 column for a skin tone, 9 for a ZWJ family), and drawing
+      # char-by-char also SHREDS a cluster across cells, stranding a bare combining mark in
+      # one of its own. Span edges snap outward so the tint covers whole glyphs.
+      a = Screen.cluster_start(line, {x0, line.size}.min)
+      b = Screen.cluster_end(line, {x1, line.size}.min)
+      px = x + Screen.draw_width(line[0, a])
+      i = a
+      while i < b
+        e = Screen.cluster_end(line, i + 1)
+        seg = line[i...e]
+        screen.text(px, y, seg, Theme.text, bg)
+        px += Screen.draw_width(seg)
+        i = e
       end
     end
 

--- a/src/gori/tui/oast_provider_overlay.cr
+++ b/src/gori/tui/oast_provider_overlay.cr
@@ -203,7 +203,7 @@ module Gori::Tui
       screen.text(vx, py, shown, fg, bg, width: vw)
       if sel && pre.empty?
         cx = field.caret.clamp(0, val.size)
-        px = vx + Screen.column_width(val[0, cx])
+        px = vx + Screen.draw_width(val[0, cx])
         if px < box.right - 2
           ch = cx < val.size ? val[cx] : ' '
           screen.cell(px, py, ch, Theme.bg, Theme.accent_bg)

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -1312,13 +1312,21 @@ module Gori::Tui
     private def paint_char_span_bg(screen : Screen, x : Int32, y : Int32, line : String,
                                    x0 : Int32, x1 : Int32, bg : Color) : Nil
       return if x0 >= x1
-      px = x
-      (0...x0).each { |i| px += Screen.draw_width(line[i].to_s) } if x0 > 0
-      (x0...x1).each do |i|
-        break if i >= line.size
-        w = Screen.draw_width(line[i].to_s)
-        screen.text(px, y, line[i].to_s, Theme.text, bg)
-        px += w
+      # Cluster-wise, matching the base draw and the caret. Summing draw_width over single
+      # CHARS is exactly the retired per-codepoint measure: it drifts right by each
+      # cluster's inflation (1 column for a skin tone, 9 for a ZWJ family), and drawing
+      # char-by-char also SHREDS a cluster across cells, stranding a bare combining mark in
+      # one of its own. Span edges snap outward so the tint covers whole glyphs.
+      a = Screen.cluster_start(line, {x0, line.size}.min)
+      b = Screen.cluster_end(line, {x1, line.size}.min)
+      px = x + Screen.draw_width(line[0, a])
+      i = a
+      while i < b
+        e = Screen.cluster_end(line, i + 1)
+        seg = line[i...e]
+        screen.text(px, y, seg, Theme.text, bg)
+        px += Screen.draw_width(seg)
+        i = e
       end
     end
 

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -1301,7 +1301,7 @@ module Gori::Tui
       return unless cy >= scr && cy < scr + rect.h
       row = cy - scr
       line = lines[cy]
-      px = rect.x + Screen.column_width(line[0, cx])
+      px = rect.x + Screen.draw_width(line[0, cx])
       if px < rect.x + rect.w
         ch = cx < line.size ? line[cx] : ' '
         screen.cell(px, rect.y + row, ch, Theme.bg, Theme.accent_bg)
@@ -1313,10 +1313,10 @@ module Gori::Tui
                                    x0 : Int32, x1 : Int32, bg : Color) : Nil
       return if x0 >= x1
       px = x
-      (0...x0).each { |i| px += Screen.column_width(line[i].to_s) } if x0 > 0
+      (0...x0).each { |i| px += Screen.draw_width(line[i].to_s) } if x0 > 0
       (x0...x1).each do |i|
         break if i >= line.size
-        w = Screen.column_width(line[i].to_s)
+        w = Screen.draw_width(line[i].to_s)
         screen.text(px, y, line[i].to_s, Theme.text, bg)
         px += w
       end

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -2427,7 +2427,7 @@ module Gori::Tui
         # covered one span, the caret sat a column left of its glyph, and a click landed a
         # character off. A URL carrying U+200B is ordinary traffic for this tool (it is a
         # stock filter-bypass payload), so this is reachable, not theoretical.
-        cursor_x = base + Screen.column_width(value[0, cx])
+        cursor_x = base + Screen.draw_width(value[0, cx])
         if cursor_x < rect.right - 1
           ch = cx < value.size ? value[cx] : ' '
           screen.cell(cursor_x, row, ch, Theme.bg, insert ? Theme.accent : Theme.accent_bg)
@@ -2530,7 +2530,7 @@ module Gori::Tui
       row = cy - scr
       gw = ed.gutter? ? Gutter.width(lines.size) : 0
       line = lines[cy]
-      px = rect.x + gw + Screen.column_width(line[0, cx])
+      px = rect.x + gw + Screen.draw_width(line[0, cx])
       if px < rect.x + rect.w
         ch = cx < line.size ? line[cx] : ' '
         screen.cell(px, rect.y + row, ch, Theme.bg, Theme.accent_bg)
@@ -2542,10 +2542,10 @@ module Gori::Tui
                                    x0 : Int32, x1 : Int32, bg : Color) : Nil
       return if x0 >= x1
       px = x
-      (0...x0).each { |i| px += Screen.column_width(line[i].to_s) } if x0 > 0
+      (0...x0).each { |i| px += Screen.draw_width(line[i].to_s) } if x0 > 0
       (x0...x1).each do |i|
         break if i >= line.size
-        w = Screen.column_width(line[i].to_s)
+        w = Screen.draw_width(line[i].to_s)
         screen.text(px, y, line[i].to_s, Theme.text, bg)
         px += w
       end
@@ -2893,7 +2893,7 @@ module Gori::Tui
       end
       return unless li == @resp_cursor.cy
       cx = @resp_cursor.cx.clamp(0, line.size)
-      px = x + Screen.column_width(line[0, cx])
+      px = x + Screen.draw_width(line[0, cx])
       ch = cx < line.size ? line[cx] : ' '
       screen.cell(px, y, ch, Theme.bg, Theme.accent_bg)
       screen.cursor(px, y)

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -2541,13 +2541,21 @@ module Gori::Tui
     private def paint_char_span_bg(screen : Screen, x : Int32, y : Int32, line : String,
                                    x0 : Int32, x1 : Int32, bg : Color) : Nil
       return if x0 >= x1
-      px = x
-      (0...x0).each { |i| px += Screen.draw_width(line[i].to_s) } if x0 > 0
-      (x0...x1).each do |i|
-        break if i >= line.size
-        w = Screen.draw_width(line[i].to_s)
-        screen.text(px, y, line[i].to_s, Theme.text, bg)
-        px += w
+      # Cluster-wise, matching the base draw and the caret. Summing draw_width over single
+      # CHARS is exactly the retired per-codepoint measure: it drifts right by each
+      # cluster's inflation (1 column for a skin tone, 9 for a ZWJ family), and drawing
+      # char-by-char also SHREDS a cluster across cells, stranding a bare combining mark in
+      # one of its own. Span edges snap outward so the tint covers whole glyphs.
+      a = Screen.cluster_start(line, {x0, line.size}.min)
+      b = Screen.cluster_end(line, {x1, line.size}.min)
+      px = x + Screen.draw_width(line[0, a])
+      i = a
+      while i < b
+        e = Screen.cluster_end(line, i + 1)
+        seg = line[i...e]
+        screen.text(px, y, seg, Theme.text, bg)
+        px += Screen.draw_width(seg)
+        i = e
       end
     end
 

--- a/src/gori/tui/rewriter_rule_overlay.cr
+++ b/src/gori/tui/rewriter_rule_overlay.cr
@@ -302,7 +302,7 @@ module Gori::Tui
       screen.text(vx, py, shown, fg, bg, width: vw)
       if sel && pre.empty?
         cx = field.caret.clamp(0, val.size)
-        px = vx + Screen.column_width(val[0, cx])
+        px = vx + Screen.draw_width(val[0, cx])
         if px < box.right - 2
           ch = cx < val.size ? val[cx] : ' '
           screen.cell(px, py, ch, Theme.bg, Theme.accent_bg)

--- a/src/gori/tui/scope_rule_overlay.cr
+++ b/src/gori/tui/scope_rule_overlay.cr
@@ -186,7 +186,7 @@ module Gori::Tui
         if sel
           # block caret
           cx = @pattern.caret.clamp(0, val.size)
-          px = vx + Screen.column_width(val[0, cx])
+          px = vx + Screen.draw_width(val[0, cx])
           if px < box.right - 2
             ch = cx < val.size ? val[cx] : ' '
             screen.cell(px, py, ch, Theme.bg, Theme.accent_bg)

--- a/src/gori/tui/screen.cr
+++ b/src/gori/tui/screen.cr
@@ -282,13 +282,18 @@ module Gori::Tui
     # Cheap sufficient test for "index `i` already starts a cluster", so the snap helpers
     # can skip their O(prefix) grapheme walk on the overwhelmingly common case — every
     # keystroke in a line that merely CONTAINS a glyph would otherwise re-walk the prefix.
-    # An ASCII char always starts a cluster: Extend / ZWJ / Prepend / Regional-Indicator
-    # are all non-ASCII, so nothing can bind an ASCII char to what precedes it. The lone
-    # exception is the `\n` of a CRLF pair, which cannot occur here — every caller splits
-    # on '\n' first (TextArea#set_text also rstrips the '\r'), so no line holds one.
-    # Conservative by design: false means "walk to be sure", never a wrong answer.
+    # An ASCII char normally starts a cluster: Extend / ZWJ / Prepend / Regional-Indicator
+    # are all non-ASCII, so nothing can bind one to what precedes it.
+    #
+    # The lone exception is the `\n` of a CRLF pair (UAX #29 GB3), and it is tested
+    # explicitly rather than assumed away. No line reaching here can hold one — every
+    # caller splits on '\n' first — but an `ascii_only?` short-circuit would answer TRUE
+    # for it, which is the UNSAFE direction: a wrong "already a boundary" skips the snap
+    # and strands the caret mid-cluster, while a wrong "not a boundary" only costs a walk
+    # that returns the same index. Conservative for real, not by assertion.
     private def self.boundary?(str : String, i : Int32) : Bool
-      str.ascii_only? || str[i].ascii?
+      c = str[i]
+      c.ascii? && !(c == '\n' && i > 0 && str[i - 1] == '\r')
     end
 
     # Snap a character index to the END (exclusive) of the grapheme cluster holding it —
@@ -544,13 +549,27 @@ module Gori::Tui
       # cluster, which is the duplicate-glyph bug the collapse to draw_width fixes.
       #
       # `cx` here is NOT guaranteed to sit on a cluster boundary: the single-line cursors
-      # (TextField#@caret, ReadCursor#@cx, the views' own @tcx/@scx) still step per
-      # codepoint, unlike TextArea#@cx which now snaps. Landing mid-cluster costs at most a
-      # dead keypress — draw_width returns the same column for every index inside a cluster
-      # — and can no longer misplace the caret onto a neighbouring glyph.
+      # (TextField#@caret, ReadCursor#@cx, the views' own @tcx/@scx/@qcx, the decoder's
+      # chain_cx) still step per codepoint, unlike TextArea#@cx which now snaps. The
+      # residual on those, stated honestly: for "caféx", cx 4 and cx 5 both resolve
+      # to column 4, so one → is a dead keypress — but at cx 4 `caret_glyph` returns the
+      # bare combining mark and paints it at column 4, i.e. ON the cell where the `x`
+      # lives. So it is a misplaced glyph, not merely a dead press. It is still strictly
+      # better than before the collapse, where the caret ran off the end of the drawn text
+      # and stamped a DUPLICATE character past it; and it is unreachable by click, since
+      # column_for only ever returns cluster starts.
+      #
+      # Relatedly, TextField#backspace still deletes one codepoint ("café" → "cafe"),
+      # inconsistent with TextArea's whole-cluster delete. Converting these cursors is
+      # three more edit-path audits and is deliberately out of scope here.
       caret_x = x + Screen.draw_width(prefix) + Screen.draw_width(preedit)
       caret_ch = preedit.empty? ? Screen.caret_glyph(value, cx) : ' '
       if caret_x < right
+        # A wide caret glyph CLAIMS caret_x + 1 as a continuation cell during its own
+        # write, so one landing on the field's last column would cross the right edge onto
+        # whatever borders it. Draw a space there instead — same guard, and same reason, as
+        # the TextArea block caret.
+        caret_ch = ' ' if Screen.grapheme_cols(caret_ch.to_s) == 2 && caret_x + 1 >= right
         cell(caret_x, y, caret_ch, Theme.bg, Theme.accent)
         cursor(caret_x, y)
       end

--- a/src/gori/tui/screen.cr
+++ b/src/gori/tui/screen.cr
@@ -234,79 +234,125 @@ module Gori::Tui
       w
     end
 
-    # As `column_width`, but stops once the running width reaches `limit`. Used by the
-    # editor h-scroll clamp so a multi-MB line with embedded tabs isn't fully walked
-    # every frame, while still counting each control char as one cell.
-    def self.column_width_upto(str : String, limit : Int32) : Int32
-      return 0 if str.empty? || limit <= 0
-      # ASCII: every char is exactly 1 column under column_width (controls floored).
-      return {str.size, limit}.min if str.ascii_only?
-      w = 0
-      str.each_char do |ch|
-        w += grapheme_cols(ch.to_s)
-        return w if w >= limit
-      end
-      w
-    end
-
-    # The codepoint index in `str` whose display cell the column `target` lands on,
-    # clamped to [0, str.size]. Inverts a left-to-right display-width advance (the
-    # same one `display_width` / `text` use), so click-to-cursor maps a click x to
-    # the right index even past CJK/emoji (width-2) cells. Each codepoint counts as
-    # at least one clickable cell to match the editor's codepoint cursor model.
+    # The CHARACTER index in `str` whose drawn cell the column `target` lands on, clamped
+    # to [0, str.size] and always at a grapheme-CLUSTER START. The exact inverse of
+    # `draw_width`: both walk clusters and floor each to ≥1, so `draw_width(str[0, i])`
+    # and `column_for` round-trip at every boundary. Caret and click therefore agree BY
+    # CONSTRUCTION rather than by two hand-matched measures happening to coincide — which
+    # is the whole point of the collapse (see draw_width).
+    #
+    # Still a CHARACTER index, not a cluster ordinal: every caller slices with it
+    # (`chain[0, chain_cx]`, `line[cx]`, `@target[0, @tcx]`) and Crystal's `String#[]` is
+    # char-indexed. The collapse only narrows the REACHABLE set to cluster starts, so a
+    # click can no longer drop a caret between the `e` and the combining acute of `é`.
     def self.column_for(str : String, target : Int32) : Int32
       return 0 if target <= 0
+      # ASCII fast path: 1 char == 1 cluster == 1 column (see draw_width), so the column IS
+      # the index. Keeps every click off the grapheme walk + its per-glyph `to_s` String.
+      return {target, str.size}.min if str.ascii_only?
       acc = 0
-      str.each_char_with_index do |ch, j|
-        w = grapheme_cols(ch.to_s)
-        return j if target < acc + w
+      i = 0
+      str.each_grapheme do |g|
+        w = grapheme_cols(g.to_s)
+        return i if target < acc + w
         acc += w
+        i += g.size # Grapheme#size is the cluster's CHARACTER count — allocates nothing
       end
       str.size
     end
 
-    # Column span of `str` where EVERY char counts at least 1 column — the exact
-    # inverse of `column_for`. `display_width` alone reports 0 for a raw control char
-    # (e.g. a lone \r), but each such char still occupies a drawn cell and click-to-
-    # cursor / Reveal count it as ≥1, so cursor placement must too or it lands one
-    # column short and overwrites a glyph.
-    def self.column_width(str : String) : Int32
-      # ASCII fast path: every ASCII char counts as exactly 1 column here — a printable is
-      # width 1, and a control char (width 0) is floored to 1 by the max below — so the span
-      # is just the char count. Skips the per-char `display_width(ch.to_s)` grapheme walk +
-      # String on the common case (all-ASCII fields). Non-ASCII keeps the exact per-char loop
-      # (wide glyphs via display_width, combining marks floored to 1).
-      return str.size if str.ascii_only?
-      w = 0
-      str.each_char { |ch| w += grapheme_cols(ch.to_s) }
-      w
+    # Snap a character index to the START of the grapheme cluster holding it (the caret's
+    # "round down"); an index already on a boundary is returned unchanged. Paired with
+    # `cluster_end` this is how TextArea keeps `@cx` — which stays a CHARACTER index — off
+    # the interior of a cluster, so `draw_width(line[0, @cx])` is single-valued and
+    # `column_for` inverts it. Without the snap `draw_width` is not strictly monotone in
+    # `@cx` (all 7 char indices inside a 4-person ZWJ family share one column).
+    def self.cluster_start(str : String, i : Int32) : Int32
+      return 0 if i <= 0
+      return i if i >= str.size || boundary?(str, i)
+      pos = 0
+      str.each_grapheme do |g|
+        nxt = pos + g.size
+        return pos if i < nxt
+        pos = nxt
+      end
+      str.size
+    end
+
+    # Cheap sufficient test for "index `i` already starts a cluster", so the snap helpers
+    # can skip their O(prefix) grapheme walk on the overwhelmingly common case — every
+    # keystroke in a line that merely CONTAINS a glyph would otherwise re-walk the prefix.
+    # An ASCII char always starts a cluster: Extend / ZWJ / Prepend / Regional-Indicator
+    # are all non-ASCII, so nothing can bind an ASCII char to what precedes it. The lone
+    # exception is the `\n` of a CRLF pair, which cannot occur here — every caller splits
+    # on '\n' first (TextArea#set_text also rstrips the '\r'), so no line holds one.
+    # Conservative by design: false means "walk to be sure", never a wrong answer.
+    private def self.boundary?(str : String, i : Int32) : Bool
+      str.ascii_only? || str[i].ascii?
+    end
+
+    # Snap a character index to the END (exclusive) of the grapheme cluster holding it —
+    # the caret's "round up", used when travel is rightwards so a → never parks inside a
+    # cluster. See `cluster_start`.
+    def self.cluster_end(str : String, i : Int32) : Int32
+      return 0 if i <= 0
+      return {i, str.size}.min if i >= str.size || boundary?(str, i)
+      pos = 0
+      str.each_grapheme do |g|
+        return i if i == pos # already on a boundary
+        nxt = pos + g.size
+        return nxt if i < nxt # interior → the cluster's far edge
+        pos = nxt
+      end
+      str.size
+    end
+
+    # The glyph a block caret at character index `i` must invert. Returns a plain `Char`
+    # when the cluster there is a single codepoint — so `cell` keeps its interned ASCII /
+    # glyph-cache path and the caret allocates nothing on the common case — and the full
+    # cluster String only when it is not. Parking on `é` (e + U+0301) or a ZWJ family has
+    # to invert the WHOLE glyph; `str[i]` alone inverted its first codepoint, showing a
+    # bare `e` or a lone 👨 under the caret. A space past the end (nothing to invert).
+    def self.caret_glyph(str : String, i : Int32) : Char | String
+      return ' ' if i < 0 || i >= str.size
+      e = cluster_end(str, i + 1)
+      e == i + 1 ? str[i] : str[i, e - i]
     end
 
     # Columns one grapheme occupies when drawn by `#text` / `Highlight.draw` and when the
     # editor caret / click-to-cursor advance over it. Unicode width floored to ≥1 so a C0
-    # control (`\t`, `\r`, …) keeps the space cell that Char-path `cell` substitutes —
-    # matching `column_width` and preventing the styled draw path from collapsing a tab
-    # to zero columns while the caret still steps across it (issue #278).
+    # control (`\t`, `\r`, …) keeps the space cell that Char-path `cell` substitutes,
+    # preventing the styled draw path from collapsing a tab to zero columns while the
+    # caret still steps across it (issue #278).
     def self.grapheme_cols(g : String) : Int32
       {display_width(g), 1}.max
     end
 
     # Columns `str` occupies when DRAWN: `grapheme_cols` summed over grapheme CLUSTERS,
-    # which is exactly how `#text` and `Highlight.draw` advance. This is a THIRD measure,
-    # equal to neither sibling, and the only one that matches the cells on screen:
+    # which is exactly how `#text` and `Highlight.draw` advance. THE column measure — the
+    # caret, click-to-cursor, h-scroll clamps and tint bands all use this one, and
+    # `column_for` inverts it.
     #
-    #   "a\tb"     display_width 2   column_width 3    draw_width 3   (tab: a drawn cell)
-    #   "👍🏽"       display_width 2   column_width 3    draw_width 2   (skin tone: 2 cps)
-    #   "👨‍👩‍👧‍👦"    display_width 2   column_width 11   draw_width 2   (3 ZWJ: 9 cols of drift)
+    # There used to be a second floored measure, `column_width`, which walked CODEPOINTS
+    # instead of clusters to serve a per-codepoint caret. The two agreed on ASCII, tabs and
+    # precomposed CJK and diverged only on a multi-codepoint cluster, where `column_width`
+    # over-counted every codepoint past the first:
     #
-    # `display_width` UNDER-counts: a C0 control is Unicode width 0, but `cell` still
-    # substitutes a space for it, so it owns a cell. `column_width` OVER-counts: it floors
-    # every CODEPOINT to ≥1, which is right for the per-codepoint caret model it exists to
-    # serve (TextArea's char-index `@cx`, `column_for`) but wrong for a draw, where a
-    # multi-codepoint cluster — skin-tone modifier, ZWJ sequence, combining mark — is ONE
-    # glyph drawn into ONE cell run. Rule of thumb: measure with `draw_width` when the
-    # result is compared against drawn cells (search overlay, h-scroll clamp, slice), with
-    # `column_width` when it is compared against the caret.
+    #   "a\tb"     display_width 2   (was column_width 3)    draw_width 3
+    #   "👍🏽"       display_width 2   (was column_width 3)    draw_width 2   (skin tone)
+    #   "👨‍👩‍👧‍👦"    display_width 2   (was column_width 11)   draw_width 2   (3 ZWJ)
+    #   "한글" NFD  display_width 4   (was column_width 8)    draw_width 4   (6 jamo)
+    #
+    # Keeping both is what made #278 (tabs) and #285 (emoji) trade off against each other,
+    # and it painted a DUPLICATE glyph past any decomposed text: the caret advanced 8
+    # columns over NFD "한글" while the draw advanced 4, so `value[@cx]` was stamped four
+    # cells right of where the glyph ended. `draw_width` SUBSUMES the old measure — every
+    # property `column_width` existed for survives, because `grapheme_cols` still floors to
+    # ≥1 and a control char, a tab and a zero-width `U+200B`/`U+FEFF` are each their own
+    # cluster — so the caret model moved onto clusters (see `column_for`, `cluster_start`)
+    # and the codepoint measure is gone. `display_width` remains, and remains DIFFERENT: it
+    # is raw Unicode width, scoring a C0 control 0 even though `cell` substitutes a space
+    # and so gives it a real cell. Use it only for text with no control chars.
     def self.draw_width(str : String) : Int32
       # ASCII fast path, and it is EXACT rather than an approximation: the only multi-char
       # ASCII grapheme cluster is CRLF, which cannot appear inside a rendered line because
@@ -321,7 +367,7 @@ module Gori::Tui
 
     # As `draw_width`, but stops once the running width reaches `limit` (returning a value
     # ≥ limit without walking the rest). Same early-exit contract, and the same reason, as
-    # `display_width_upto` / `column_width_upto`: the h-scroll clamps run EVERY frame and
+    # `display_width_upto`: the h-scroll clamps run EVERY frame and
     # only need to know whether a line reaches the view's right edge, so a minified
     # multi-MB single line must never be measured in full. Exact for lines under `limit`.
     def self.draw_width_upto(str : String, limit : Int32) : Int32
@@ -487,19 +533,23 @@ module Gori::Tui
       styled_run(px, y, suffix, cx, colors, fg, bg, right) unless suffix.empty?
       # Block caret sits just after prefix+preedit, over the suffix's first cell
       # (or a space). The terminal's own IME UI anchors at the hardware cursor.
-      # column_width, NOT display_width and NOT draw_width. `cx` is a CHARACTER index into
-      # `value` (see the clamp above and `value[cx]` below), and this caret's inverse is
-      # Screen.column_for — the per-codepoint, floored-to-≥1 mapping used by every click
-      # handler that drives a field (read_cursor, repeater/fuzzer target, decoder chain).
-      # column_width is that function's exact inverse, so caret and click agree by
-      # construction; display_width scored a zero-width char (U+200B, U+FEFF, a combining
+      # draw_width, NOT display_width. `cx` is a CHARACTER index into `value` (see the
+      # clamp above), and this caret's inverse is Screen.column_for, which every click
+      # handler driving a field runs (read_cursor, repeater/fuzzer target, decoder chain).
+      # draw_width is that function's exact inverse, so caret and click agree by
+      # construction. display_width scored a zero-width char (U+200B, U+FEFF, a combining
       # mark — all of which parse_printable accepts unfiltered) as 0 columns, leaving the
-      # block caret one column left of its glyph, painting over the neighbour, and landing
-      # a click one character off. draw_width would match the DRAW but not `column_for`,
-      # re-breaking the click; reconciling those two is the caret-model change documented
-      # at TextArea#ensure_visible_x and deliberately not attempted here.
-      caret_x = x + Screen.column_width(prefix) + Screen.column_width(preedit)
-      caret_ch = preedit.empty? ? (cx < value.size ? value[cx] : ' ') : ' '
+      # block caret one column left of its glyph and painting over the neighbour; the
+      # per-codepoint column_width that replaced it then over-counted the other way on any
+      # cluster, which is the duplicate-glyph bug the collapse to draw_width fixes.
+      #
+      # `cx` here is NOT guaranteed to sit on a cluster boundary: the single-line cursors
+      # (TextField#@caret, ReadCursor#@cx, the views' own @tcx/@scx) still step per
+      # codepoint, unlike TextArea#@cx which now snaps. Landing mid-cluster costs at most a
+      # dead keypress — draw_width returns the same column for every index inside a cluster
+      # — and can no longer misplace the caret onto a neighbouring glyph.
+      caret_x = x + Screen.draw_width(prefix) + Screen.draw_width(preedit)
+      caret_ch = preedit.empty? ? Screen.caret_glyph(value, cx) : ' '
       if caret_x < right
         cell(caret_x, y, caret_ch, Theme.bg, Theme.accent)
         cursor(caret_x, y)

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -255,6 +255,14 @@ module Gori::Tui
         @lines[@cy - 1] = prev + @lines[@cy]
         @lines.delete_at(@cy)
         @cy -= 1
+        # The JOIN re-clusters across the seam: if the next line opened with a combining
+        # mark it has just fused onto `prev`'s last glyph, so `prev.size` — the seam — is
+        # now cluster INTERIOR. Snap forward, past the fused glyph, which is where the seam
+        # visually is ("café|x", not "caf|éx"). Without this the caret paints over the
+        # following glyph, an insert splices INTO the cluster ("cafe" + "́x" then
+        # typing Z gave "cafeŹx"), and the next backspace strands the mark on the wrong
+        # base ("caf́x") — the exact outcome the whole-cluster delete above exists to avoid.
+        snap_cx_to_cluster(1)
       end
       @styled = nil
       @edits += 1
@@ -290,6 +298,12 @@ module Gori::Tui
         return # end of buffer — nothing to delete, don't dirty
       end
       @cx = cx
+      # The line-join branch re-clusters across the seam exactly as backspace's does (see
+      # the note there), so the caret has to be re-snapped. Forward rather than back:
+      # snapping back would leave the caret before a glyph the join FUSED, so the next
+      # Delete would take the pre-existing base char with it ("cafe" → "cafx"). A no-op on
+      # the common in-line branch, where `cx` was already a boundary.
+      snap_cx_to_cluster(1)
       @styled = nil
       @edits += 1
       refresh_env_complete
@@ -368,7 +382,7 @@ module Gori::Tui
       # the hidden runs so a click never lands the caret on an unseen ¦chain char.
       # No cluster snap needed: BOTH inverses already return a cluster start by construction
       # (Screen.column_for walks clusters; concealed_col_to_raw does too, and its conceal
-      # edges are ASCII `¦`/`§`, each its own cluster).
+      # edges `¦`/`§` always begin a cluster — see snap_cx_out_of_conceal).
       @cx = (cr && !cr.empty?) ? concealed_col_to_raw(line, cr, target) : Screen.column_for(line, target)
       snap_cx_out_of_conceal(0) # a click on the closing-§ column resolves to it; nudge to a legal rest
       env_complete_close
@@ -605,12 +619,23 @@ module Gori::Tui
             # The whole CLUSTER at `r`, not `line[r]`: parking on `é` (e + U+0301) or a ZWJ
             # family has to invert the glyph the user sees, not its leading codepoint.
             ch = @preedit.empty? ? Screen.caret_glyph(line, r) : Screen.caret_glyph(@preedit, 0)
-            cgw = Screen.grapheme_cols(ch.to_s)
-            (0...cgw).each do |off|
-              break if cxs + off >= cx0 + cw # a wide-glyph caret at the last column must not spill its 2nd cell onto the pane border
-              cch = (off == 0 ? ch : ' ')
-              screen.cell(cxs + off, rect.y + i, cch, Theme.bg, Theme.accent)
-            end
+            # ONE write, never two. A width-2 glyph already claims its trailing column as a
+            # continuation cell carrying this same fg/bg/attr — termisu materialises that
+            # cell from its lead — so the accent spans both columns without a second write.
+            # The second write was not merely redundant but destructive: it landed ON the
+            # continuation, and a write there orphans the lead, which the backend blanks
+            # (mirroring termisu's clear_continuation_owner). The caret therefore ERASED
+            # the very glyph it was highlighting — the long-standing "caret blanks a
+            # Hangul/CJK glyph" bug. MemoryBackend models continuation cells now, so this
+            # is covered rather than invisible to every spec in the suite.
+            #
+            # A wide glyph whose continuation would land outside the pane is drawn as a
+            # space instead. The claim happens during the glyph's OWN write, so the `break`
+            # this loop used to do on its second iteration was already too late to keep the
+            # caret off the pane border.
+            wide = Screen.grapheme_cols(ch.to_s) == 2
+            cch = (wide && cxs + 1 >= cx0 + cw) ? ' ' : ch
+            screen.cell(cxs, rect.y + i, cch, Theme.bg, Theme.accent)
           end
         end
       end
@@ -800,8 +825,9 @@ module Gori::Tui
         end
         # Step by CLUSTER, matching `concealed_col`'s draw_width and the cells actually
         # drawn, so this stays that function's exact inverse and a click lands where the
-        # caret paints. A conceal run always opens on a `¦` and closes before a `§` — both
-        # ASCII, both their own cluster — so no cluster straddles a run boundary.
+        # caret paints. A conceal run opens on a `¦` and closes before a `§`: neither is
+        # ASCII, but both are Grapheme_Cluster_Break=Other and so always BEGIN a cluster,
+        # which is what guarantees no cluster straddles a run boundary.
         e = Screen.cluster_end(line, i + 1)
         w = Screen.draw_width(line[i...e])
         return i if target < col + w
@@ -838,11 +864,23 @@ module Gori::Tui
     # left edge, on visible bytes) and `b + 1` (past the closing glyph) are legal rests —
     # and they sit at the same column / the next column, so crossing the whole run is one
     # keypress in each direction (no dead press). `dir` is the travel sign.
+    #
+    # Runs LAST, after snap_cx_to_cluster, because resting on a hidden byte corrupts the
+    # buffer while resting mid-cluster only mispaints — so this one gets the final word.
+    # Both landing sites stay cluster-legal, but not for the reason one might guess: the
+    # delimiters are `¦` U+00A6 and `§` U+00A7, which are NOT ASCII. What matters is that
+    # both are Grapheme_Cluster_Break=Other, so each always BEGINS a cluster no matter what
+    # precedes it — hence `a` (the `¦`) is provably a boundary and needs no snap. `b + 1`
+    # is not: it is the index AFTER the closing `§`, and a combining mark typed right there
+    # binds to that `§`, making b + 1 cluster interior. So round it up. Forward is the only
+    # safe direction — it can only increase, staying clear of the `(a, b]` no-rest zone,
+    # whereas rounding down would land on `b` itself, the one index this exists to avoid.
     private def snap_cx_out_of_conceal(dir : Int32) : Nil
       return if @conceal_spans.empty?
-      line_conceal(line_start_offset(@cy), @lines[@cy].size).each do |(a, b)|
+      line = @lines[@cy]
+      line_conceal(line_start_offset(@cy), line.size).each do |(a, b)|
         next unless @cx > a && @cx <= b
-        right = {b + 1, @lines[@cy].size}.min
+        right = {Screen.cluster_end(line, b + 1), line.size}.min
         @cx = if dir > 0
                 right
               elsif dir < 0

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -165,7 +165,10 @@ module Gori::Tui
       line = @lines[@cy]
       cx = @cx.clamp(0, line.size)
       @lines[@cy] = "#{line[0, cx]}#{ch}#{line[cx..]}"
+      # Forward-snap: the typed char can MERGE with what follows (typing `e` in front of a
+      # lone U+0301 makes one `é` cluster), which would leave the caret inside it.
       @cx = cx + 1
+      snap_cx_to_cluster(1)
       @styled = nil
       @edits += 1
       refresh_env_complete
@@ -181,6 +184,7 @@ module Gori::Tui
       cx = @cx.clamp(0, line.size)
       @lines[@cy] = "#{line[0, cx]}#{str}#{line[cx..]}"
       @cx = cx + str.size
+      snap_cx_to_cluster(1) # the paste's last char can merge with the text it landed before
       @styled = nil
       @edits += 1
       refresh_env_complete
@@ -195,6 +199,7 @@ module Gori::Tui
       cx = @cx.clamp(0, line.size)
       @lines[@cy] = "#{line[0, cx]}#{ch}#{ch}#{line[cx..]}"
       @cx = cx + 2
+      snap_cx_to_cluster(1) # `§`/`¦` are their own clusters, but the char after may combine
       @styled = nil
       @edits += 1
       refresh_env_complete
@@ -233,8 +238,16 @@ module Gori::Tui
         push_undo
         line = @lines[@cy]
         cx = @cx.clamp(0, line.size)
-        @lines[@cy] = "#{line[0, cx - 1]}#{line[cx..]}"
-        @cx = cx - 1
+        # Delete the whole grapheme CLUSTER before the caret, not one codepoint. Backspacing
+        # `café` gives `caf`, never `cafe` with the acute silently dropped; backspacing a ZWJ
+        # family removes the family rather than leaving `👨‍👩‍👧‍` with a trailing joiner that the
+        # terminal renders as a broken sequence. The cluster is the user-perceived character,
+        # so this is what one press should undo — and it keeps @cx on a boundary for free.
+        # (Composing a cluster codepoint-by-codepoint is the IME's job, via preedit; once it
+        # has COMMITTED a glyph, taking it apart is not something a backspace should do.)
+        st = Screen.cluster_start(line, cx - 1)
+        @lines[@cy] = "#{line[0, st]}#{line[cx..]}"
+        @cx = st
       elsif @cy > 0
         push_undo
         prev = @lines[@cy - 1]
@@ -267,7 +280,8 @@ module Gori::Tui
       cx = @cx.clamp(0, line.size)
       if cx < line.size
         push_undo
-        @lines[@cy] = "#{line[0, cx]}#{line[cx + 1..]}"
+        # Whole-cluster forward delete, mirroring backspace — see the note there.
+        @lines[@cy] = "#{line[0, cx]}#{line[Screen.cluster_end(line, cx + 1)..]}"
       elsif @cy < @lines.size - 1
         push_undo
         @lines[@cy] = line + @lines[@cy + 1]
@@ -285,6 +299,7 @@ module Gori::Tui
       if dr != 0
         @cy = (@cy + dr).clamp(0, @lines.size - 1)
         @cx = @cx.clamp(0, @lines[@cy].size)
+        snap_cx_to_cluster(0) # the column carried across rows can land mid-cluster
       end
       if dc != 0
         @cx += dc
@@ -303,6 +318,11 @@ module Gori::Tui
             @cx = @lines[@cy].size
           end
         end
+        # `@cx += dc` steps CODEPOINTS; the caret column and the draw step CLUSTERS. Snap
+        # in the direction of travel so → clears a whole cluster and ← lands on its start,
+        # rather than resting between the `e` and the combining acute of `é` (where the
+        # caret would be column-ambiguous and a delete would strand the mark).
+        snap_cx_to_cluster(dc)
       end
       snap_cx_out_of_conceal(dc) unless @conceal_spans.empty? # never rest on a hidden ¦chain char
       refresh_env_complete
@@ -329,7 +349,8 @@ module Gori::Tui
 
     # Place the cursor at the click (mx,my), inverting render's layout: the visible
     # row maps to @scroll + offset; the display-x (after the optional gutter) maps to
-    # a codepoint index via Screen.column_for. `rect` is the SAME rect render gets.
+    # a character index (at a cluster start) via Screen.column_for. `rect` is the SAME
+    # rect render gets.
     # Coords are 0-based; a click below the text lands on the last line, left of the
     # text on column 0. render's ensure_visible reconciles @scroll next frame.
     def click_to_cursor(rect : Rect, mx : Int32, my : Int32) : Nil
@@ -345,6 +366,9 @@ module Gori::Tui
       cr = @conceal_spans.empty? ? nil : line_conceal(line_start_offset(@cy), line.size)
       # On a concealed line the click column is in concealed space; map it back through
       # the hidden runs so a click never lands the caret on an unseen ¦chain char.
+      # No cluster snap needed: BOTH inverses already return a cluster start by construction
+      # (Screen.column_for walks clusters; concealed_col_to_raw does too, and its conceal
+      # edges are ASCII `¦`/`§`, each its own cluster).
       @cx = (cr && !cr.empty?) ? concealed_col_to_raw(line, cr, target) : Screen.column_for(line, target)
       snap_cx_out_of_conceal(0) # a click on the closing-§ column resolves to it; nudge to a legal rest
       env_complete_close
@@ -361,6 +385,7 @@ module Gori::Tui
       @scroll = (@scroll + step).clamp(0, max)
       @cy = @cy.clamp(@scroll, {@scroll + @last_h - 1, @lines.size - 1}.min)
       @cx = @cx.clamp(0, @lines[@cy].size)
+      snap_cx_to_cluster(0) # the row changed under the caret; its column may re-cluster
       env_complete_close
     end
 
@@ -382,6 +407,7 @@ module Gori::Tui
     def place_cursor(cy : Int32, cx : Int32) : Nil
       @cy = cy.clamp(0, @lines.size - 1)
       @cx = cx.clamp(0, @lines[@cy].size)
+      snap_cx_to_cluster(0) # caller-supplied index — unconstrained, may land mid-cluster
       env_complete_close
     end
 
@@ -396,7 +422,10 @@ module Gori::Tui
       return if @lines[idx] == content
       push_undo
       @lines[idx] = content
-      @cx = @cx.clamp(0, content.size) if @cy == idx
+      if @cy == idx
+        @cx = @cx.clamp(0, content.size)
+        snap_cx_to_cluster(0) # the replacement line re-clusters under the old index
+      end
       @styled = nil
       @edits += 1
     end
@@ -421,6 +450,7 @@ module Gori::Tui
       end
       @cy = cy
       @cx = off.clamp(0, @lines[cy].size)
+      snap_cx_to_cluster(0) # a flat buffer offset carries no cluster guarantee
       env_complete_close
     end
 
@@ -522,11 +552,16 @@ module Gori::Tui
             px = cx0
             if !prefix.empty?
               screen.text(px, rect.y + i, prefix, Theme.text, width: cw)
-              px += Screen.column_width(prefix) # ≥1/char, matching the drawn cells + caret math
+              px += Screen.draw_width(prefix) # ≥1/cluster, matching the drawn cells + caret math
             end
             if !@preedit.empty?
               screen.text(px, rect.y + i, @preedit, Theme.text, attr: Attribute::Underline, width: cw - (px - cx0))
-              px += Screen.display_width(@preedit)
+              # draw_width, not display_width (#289): `screen.text` just drew the preedit by
+              # CLUSTER with a ≥1 floor, so the advance has to be measured the same way or
+              # the suffix is laid down on top of the composing text. The two differ when a
+              # preedit carries a control or zero-width codepoint — see ensure_visible_x for
+              # what the IME actually sends.
+              px += Screen.draw_width(@preedit)
             end
             if !suffix.empty?
               screen.text(px, rect.y + i, suffix, Theme.text, width: cw - (px - cx0))
@@ -550,11 +585,13 @@ module Gori::Tui
         # is drawn (cursor=false in NORMAL) — the value peek anchors to it in read mode too.
         # The block-cursor GLYPH itself still paints only when `cursor` (insert mode).
         next unless li == @cy
-        # column_width (not display_width): a raw control char in the prefix occupies a
-        # cell and click-to-cursor counts it, so the caret must too — else it sits one
-        # column left of the real position and paints over a glyph.
-        prefix_w = (cr && !cr.empty?) ? concealed_col(line, cr, @cx) : Screen.column_width(line[0, @cx])
-        preedit_w = Screen.display_width(@preedit)
+        # draw_width (not display_width): a raw control char in the prefix occupies a cell
+        # and click-to-cursor counts it, so the caret must too — else it sits one column
+        # left of the real position and paints over a glyph. Per CLUSTER, matching the draw
+        # exactly: `@cx` rests only on cluster boundaries (snap_cx_to_cluster), so this is
+        # single-valued and Screen.column_for inverts it.
+        prefix_w = (cr && !cr.empty?) ? concealed_col(line, cr, @cx) : Screen.draw_width(line[0, @cx])
+        preedit_w = Screen.draw_width(@preedit)
         cxs = cx0 + prefix_w + preedit_w - @xscroll
         if cxs >= cx0 && cxs < cx0 + cw
           caret_cell = {cxs, rect.y + i}
@@ -565,7 +602,9 @@ module Gori::Tui
             # any concealed run to the glyph the user actually sees (the closing §).
             r = @cx
             cr.each { |(a, b)| r = b if r >= a && r < b } if cr && !cr.empty?
-            ch = @preedit.empty? ? (r < line.size ? line[r] : ' ') : @preedit[0]
+            # The whole CLUSTER at `r`, not `line[r]`: parking on `é` (e + U+0301) or a ZWJ
+            # family has to invert the glyph the user sees, not its leading codepoint.
+            ch = @preedit.empty? ? Screen.caret_glyph(line, r) : Screen.caret_glyph(@preedit, 0)
             cgw = Screen.grapheme_cols(ch.to_s)
             (0...cgw).each do |off|
               break if cxs + off >= cx0 + cw # a wide-glyph caret at the last column must not spill its 2nd cell onto the pane border
@@ -629,7 +668,7 @@ module Gori::Tui
 
     # Overlay the bg_regions intersecting THIS line. `off0` is the line's start offset
     # in the full LF-joined buffer. Column math mirrors the base draw + caret
-    # (Screen.column_width / grapheme_cols ≥1 per char, so a tab in a marker band can't
+    # (Screen.draw_width / grapheme_cols ≥1 per cluster, so a tab in a marker band can't
     # drift the tint left of the cells). Multi-line regions clamp to [0, line.size): first
     # line tints col→EOL, fully-covered lines 0→size, last line BOL→col; the '\n' offset
     # has no cell. Region columns are computed against the FULL (unscrolled) line, then
@@ -646,8 +685,8 @@ module Gori::Tui
         la = (a - off0).clamp(0, line.size)
         lb = (b - off0).clamp(0, line.size)
         next if la >= lb
-        start_col = Screen.column_width(line[0, la]) - @xscroll
-        end_col = Screen.column_width(line[0, lb]) - @xscroll
+        start_col = Screen.draw_width(line[0, la]) - @xscroll
+        end_col = Screen.draw_width(line[0, lb]) - @xscroll
         draw_from = {start_col, 0}.max
         draw_to = {end_col, cw}.min
         next if draw_from >= draw_to
@@ -715,7 +754,7 @@ module Gori::Tui
       off
     end
 
-    # Display column (column_width semantics, matching the caret) of raw caret index `cx`
+    # Display column (draw_width semantics, matching the caret) of raw caret index `cx`
     # on a concealed line: the width of the surviving chars in [0, cx). A cx inside a
     # concealed run collapses to that run's start column (both edges share the cell).
     private def concealed_col(line : String, ranges : Array({Int32, Int32}), cx : Int32) : Int32
@@ -724,25 +763,25 @@ module Gori::Tui
       pos = 0
       ranges.each do |(a, b)|
         break if a >= cx
-        w += Screen.column_width(line[pos...a]) if a > pos
+        w += Screen.draw_width(line[pos...a]) if a > pos
         return w if b >= cx # cx lands inside/at this run → column at the run's start
         pos = b
       end
-      w + Screen.column_width(line[pos...cx])
+      w + Screen.draw_width(line[pos...cx])
     end
 
-    # As `concealed_col` — column_width / grapheme_cols semantics matching Highlight.draw's
+    # As `concealed_col` — draw_width / grapheme_cols semantics matching Highlight.draw's
     # ≥1 floor, used by the band over-paint so tint columns line up with drawn cells.
     private def concealed_display_prefix(line : String, ranges : Array({Int32, Int32}), cx : Int32) : Int32
       w = 0
       pos = 0
       ranges.each do |(a, b)|
         break if a >= cx
-        w += Screen.column_width(line[pos...a]) if a > pos
+        w += Screen.draw_width(line[pos...a]) if a > pos
         return w if b >= cx
         pos = b
       end
-      w + Screen.column_width(line[pos...cx])
+      w + Screen.draw_width(line[pos...cx])
     end
 
     # Inverse of `concealed_col` for click-to-cursor: the raw char index whose concealed
@@ -759,12 +798,37 @@ module Gori::Tui
           i = hit[1]
           next
         end
-        w = Screen.grapheme_cols(line[i].to_s)
+        # Step by CLUSTER, matching `concealed_col`'s draw_width and the cells actually
+        # drawn, so this stays that function's exact inverse and a click lands where the
+        # caret paints. A conceal run always opens on a `¦` and closes before a `§` — both
+        # ASCII, both their own cluster — so no cluster straddles a run boundary.
+        e = Screen.cluster_end(line, i + 1)
+        w = Screen.draw_width(line[i...e])
         return i if target < col + w
         col += w
-        i += 1
+        i = e
       end
       n
+    end
+
+    # Pull @cx onto a grapheme-CLUSTER boundary. `@cx` stays a CHARACTER index — conceal
+    # ranges, bg_regions, marker spans and the search / find-replace offsets are all char-
+    # or byte-indexed and come from string operations rather than caret motion, so
+    # renumbering it would break every one of them — but it may only ever REST on a
+    # boundary. That is what makes `Screen.draw_width(line[0, @cx])` single-valued (it
+    # returns the same column for all 7 char indices inside a ZWJ family) and therefore
+    # exactly invertible by `Screen.column_for`, so caret and click agree by construction.
+    #
+    # `dir` is the travel sign: > 0 rounds up to the cluster's far edge (→ crosses the
+    # whole glyph), < 0 rounds down to its start, 0 rounds down (vertical move, click,
+    # clamp after an external edit). Called at EVERY @cx mutation point, not just `move` —
+    # an insert can merge the caret's char into the preceding cluster, and a caller-
+    # supplied index (place_cursor / place_at_offset / undo) is unconstrained.
+    # Both helpers no-op cheaply when @cx is already on a boundary (Screen.boundary?), so
+    # ordinary typing never pays for the grapheme walk.
+    private def snap_cx_to_cluster(dir : Int32) : Nil
+      line = @lines[@cy]
+      @cx = dir > 0 ? Screen.cluster_end(line, @cx) : Screen.cluster_start(line, @cx)
     end
 
     # Pull @cx out of the "no-rest zone" `(a, b]` of a concealed run so the caret can't
@@ -817,33 +881,40 @@ module Gori::Tui
       return unless @follow_x
       return if cw <= 0
       line = @lines[@cy]
-      pw = Screen.display_width(@preedit)
+      # draw_width, not display_width (#289): the preedit is drawn by `screen.text` /
+      # Highlight.draw, both per-cluster with a ≥1 floor, so the window has to be sized the
+      # same way. What the IME actually puts here is whatever the terminal forwards in the
+      # kitty keyboard protocol's text codepoints — termisu passes it through verbatim
+      # (input/parser.cr emits Event::Preedit with the raw text, no normalisation), so gori
+      # cannot assume a form. A Hangul IME composing 한 may send the precomposed syllable
+      # U+D55C, a compatibility jamo U+314E, or conjoining jamo U+1112 U+1161 U+11AB; the
+      # first two are one cluster and one codepoint, the third is one cluster of THREE. Only
+      # a cluster measure is right for all of them, which is the collapse this file now
+      # relies on everywhere else.
+      pw = Screen.draw_width(@preedit)
       # On a concealed line, measure in CONCEALED columns — the hidden ¦chain doesn't take
       # cells, so the caret window must be sized/positioned against what's actually drawn.
       cr = @conceal_spans.empty? ? nil : line_conceal(line_start_offset(@cy), line.size)
       concealed = cr && !cr.empty?
-      # column_width (not display_width) to match the actual draw: a raw control char
+      # draw_width (not display_width) to match the actual draw: a raw control char
       # occupies one drawn cell, so measuring it as width 0 here would let the caret render
       # outside the window (cursor detaches / no scroll-into-view).
       #
-      # KNOWN LIMITATION (grapheme clusters). These columns are per-CODEPOINT because the
-      # caret is: @cx is a char index and `move` steps it raw, so the caret genuinely can
-      # park inside a ZWJ/skin-tone cluster. But Highlight.slice_left consumes @xscroll in
-      # per-CLUSTER (drawn) columns. On a line holding a multi-codepoint cluster the two
-      # disagree by the cluster's "inflation" (codepoint columns minus drawn columns: 1 for
-      # a skin tone, 3 for a ZWJ pair, 9 for a 4-person family), so the view can over-scroll
-      # by up to that many columns and show trailing blanks. It can only blank the row
-      # entirely when the pane is narrower than 1 + inflation (< 10 cols for the worst
-      # case), which no real pane is. Not fixable here: making this per-cluster would
-      # desync it from `cxs`/`prefix_w` below, which are per-codepoint to track the caret —
-      # reconciling the two IS the caret-model change, so it belongs in its own PR.
-      full = concealed ? concealed_col(line, cr.not_nil!, line.size) : Screen.column_width(line)
+      # These columns used to be per-CODEPOINT, because the caret was: @cx is a char index
+      # and `move` stepped it raw, so the caret could park inside a ZWJ/skin-tone cluster
+      # while Highlight.slice_left consumed @xscroll in per-CLUSTER (drawn) columns. The two
+      # disagreed by the cluster's "inflation" (1 column for a skin tone, 9 for a 4-person
+      # family) and the view over-scrolled by that much. @cx now snaps to cluster boundaries
+      # (snap_cx_to_cluster) and every measure here, in `cxs`/`prefix_w`, and in
+      # Highlight.slice_left is draw_width, so the window, the slice and the caret finally
+      # agree — that reconciliation was the caret-model change this comment used to defer.
+      full = concealed ? concealed_col(line, cr.not_nil!, line.size) : Screen.draw_width(line)
       if full + pw <= cw
         @xscroll = 0
         return
       end
       cx = @cx.clamp(0, line.size)
-      curx = (concealed ? concealed_col(line, cr.not_nil!, cx) : Screen.column_width(line[0, cx])) + pw
+      curx = (concealed ? concealed_col(line, cr.not_nil!, cx) : Screen.draw_width(line[0, cx])) + pw
       @xscroll = curx if curx < @xscroll                # caret left of the window → snap left
       @xscroll = curx - cw + 1 if curx >= @xscroll + cw # caret past the right edge → snap right
       @xscroll = 0 if @xscroll < 0
@@ -903,6 +974,7 @@ module Gori::Tui
       @lines = [""] if @lines.empty?
       @cy = state.cy.clamp(0, @lines.size - 1)
       @cx = state.cx.clamp(0, @lines[@cy].size)
+      snap_cx_to_cluster(0) # the snapshot's line may differ from the one we clamp against
       @styled = nil
       @edits += 1
       refresh_env_complete
@@ -958,6 +1030,7 @@ module Gori::Tui
       newline, ncx = ec.accept(line, @cx.clamp(0, line.size))
       @lines[@cy] = newline
       @cx = ncx.clamp(0, newline.size)
+      snap_cx_to_cluster(1) # the expansion's tail can merge with the text it was spliced into
       ec.close
       @styled = nil
       @edits += 1

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -619,9 +619,12 @@ module Gori::Tui
             # The whole CLUSTER at `r`, not `line[r]`: parking on `é` (e + U+0301) or a ZWJ
             # family has to invert the glyph the user sees, not its leading codepoint.
             ch = @preedit.empty? ? Screen.caret_glyph(line, r) : Screen.caret_glyph(@preedit, 0)
-            # ONE write, never two. A width-2 glyph already claims its trailing column as a
-            # continuation cell carrying this same fg/bg/attr — termisu materialises that
-            # cell from its lead — so the accent spans both columns without a second write.
+            # ONE write, never two. The accent still spans both columns of a width-2 glyph,
+            # though NOT because the continuation carries the lead's colors — it doesn't;
+            # Cell.continuation is a default-colored singleton. It works because termisu's
+            # render_row_batch SKIPS continuation cells without breaking the SGR batch and
+            # advances by the lead's width, so the lead's accent is still in effect across
+            # the pair (verified against the real backend for both CJK and a ZWJ family).
             # The second write was not merely redundant but destructive: it landed ON the
             # continuation, and a write there orphans the lead, which the backend blanks
             # (mirroring termisu's clear_continuation_owner). The caret therefore ERASED

--- a/src/gori/tui/text_field.cr
+++ b/src/gori/tui/text_field.cr
@@ -139,12 +139,12 @@ module Gori::Tui
     # is the unit @caret and @value[start..] are indexed in.
     private def window_start(width : Int32) : Int32
       c = @caret.clamp(0, @value.size)
-      used = Screen.column_width(@value[0, c]) + Screen.column_width(@preedit) + 1
+      used = Screen.draw_width(@value[0, c]) + Screen.draw_width(@preedit) + 1
       return 0 if used <= width
-      used = Screen.column_width(@preedit) + 1 # the caret cell always stays visible
+      used = Screen.draw_width(@preedit) + 1 # the caret cell always stays visible
       start = c
       while start > 0
-        w = Screen.column_width(@value[start - 1].to_s)
+        w = Screen.draw_width(@value[start - 1].to_s)
         break if used + w > width
         used += w
         start -= 1


### PR DESCRIPTION
Closes the root cause behind #281, #285 and #289 rather than patching another instance of it.

## The bug
`TextArea#@cx` was a CHARACTER index while `Screen#text` / `Highlight.draw` advance per grapheme CLUSTER. With the caret parked on the trailing `X`:

```
NFC 한글 + X   caret_col=4   row="한 글 X"      <- correct
NFD 한글 + X   caret_col=8   row="ᄒ ᄀ X   X"   <- duplicate glyph, jamo lost
NFD café + X   caret_col=5   row="cafeXX"      <- X painted twice
```

The caret painted `value[cx]` at a per-codepoint column while the glyphs were drawn per-cluster, so it landed past the real glyph and painted a DUPLICATE there. Longstanding — byte-identical output at `fe11895`, before any of today's width work.

Trigger is any multi-codepoint cluster: combining marks (NFD), skin-tone and ZWJ emoji, keycaps. For a proxy whose users deliberately craft Unicode normalization payloads, mangling exactly that input in the editor is a real problem.

## The fix: three measures collapse to two
`column_width` (floored per CODEPOINT) is **deleted**; everything is on `draw_width` (floored per CLUSTER). Verified across 15 cases that they agree on ASCII, tab, CR, NUL, ZWSP, BOM and NFC CJK — every property `column_width` existed for survives, because `grapheme_cols` still floors to ≥1 and a tab is its own cluster — and diverge only where `column_width` was wrong against the screen (NFD Hangul 8 vs 4, ZWJ family 11 vs 2). `column_width_upto` had zero call sites.

Having two similar-but-different floored measures is precisely why #281 fixed tabs and broke emoji. Removing the ambiguity kills the bug class.

`@cx` stays a **character** index — conceal ranges, `bg_regions`, marker spans and find/replace offsets are char-indexed and come from string operations, not caret motion — but is now SNAPPED to cluster starts. `Screen.column_for` became `draw_width`'s exact inverse (walks clusters, accumulates `g.size`, returns a char index at a cluster start), so caret and click agree by construction rather than by two hand-matched measures happening to coincide.

**Delete semantics**: whole cluster, both directions. `café` → `caf`, never `cafe` with a dangling acute. The cluster is the user-perceived character; taking a committed glyph apart is the IME's job via preedit, not backspace's.

## Also fixed here: the caret erased the glyph under it
The caret loop wrote the glyph then a space at `off=1`. `TermisuBackend#put` blanks the lead at `idx-1` when a write lands on a continuation cell, so the caret ERASED the wide glyph it was highlighting — the repo's long-standing "caret blanks a Hangul/CJK glyph" bug. Now one write. The accent still spans both columns because termisu's `render_row_batch` skips continuation cells without breaking the SGR batch.

Same site: `break if cxs + off >= cx0 + cw` never worked, because the continuation is claimed during the glyph's *own* write. A wide glyph whose continuation would fall outside the pane is now drawn as a space. `Screen#input_line` had the identical spill.

## Two rounds of adversarial review
The first pass found three blocking defects that the 2446 passing examples did not:

- **Line joins landed `@cx` mid-cluster.** `@cx = prev.size` is assigned against a string concatenation just re-clustered, so joining onto a line opening with a combining mark put the seam inside a cluster. Downstream: the render lost a glyph, `insert('Z')` gave `"cafeŹx"`, and a second backspace gave `"caf́x"` — stranding the acute on the `f`, exactly what the new delete semantics claim to prevent. Both joins now snap **forward**, past the fused glyph; snapping back would leave the caret before a glyph the join fused, so the next Delete would take the pre-existing base char. Existing specs missed this because they only ever joined ASCII lines and only ever deleted clusters within a line — no spec crossed the two.
- **The harness was blind.** `MemoryBackend` had no continuation-cell model, so no caret spec could observe the erase. It now models them.
- **The conversion of eight per-view loops was textual.** `draw_width(line[i].to_s)` for a single char *is* the old `column_width`, so summing it over chars silently rebuilt the per-codepoint measure while the caret and base draw in the same view had moved to per-cluster (drift 1 on `"caféxyz"`, 9 on a ZWJ family) — and they drew per codepoint, shredding clusters across cells. All eight now iterate clusters.

The second pass could not falsify the fixes but found the harness fix incomplete: `blank_cell` reset the glyph but not fg/bg, leaving every `bg_at == Theme.accent` caret assertion vacuous — passing on a caret that had just erased its glyph. Fixed in the last commit; control run with the old two-write caret restored now fails `text_area_spec:258` where it previously passed.

Also corrected during review: `§`/`¦` are U+00A7/U+00A6, **not ASCII** — contradicting three comments and the first reviewer's safety assumption. The conceal invariant survives because both are `Grapheme_Cluster_Break=Other` so each always begins a cluster, but the `b + 1` edge genuinely needed rounding up (a combining mark typed after the closing `§` binds to it).

## Verification
- Full suite **2458 examples, 0 failures**; `crystal build --no-codegen` clean; ameba zero delta (701 vs 701).
- #281/#285/#289 specs re-run individually by name — all green.
- 24,000 randomized edit sequences across backspace/delete/insert/move/newline/home/end/undo over clustered text: 0 boundary violations. 1,000 randomized sequences: 0 `draw_width`/`column_for` round-trip failures. 400 randomized conceal navigations: 0 rests in the no-rest zone.

## Known residuals, documented not fixed
`TextField#@caret`, `ReadCursor#@cx` and the views' `@tcx`/`@scx`/`@qcx`/`chain_cx` still step per codepoint — three more cursor models, each needing its own edit-path audit. Post-collapse the cost is bounded (all measures now return one column per cluster), but it is not zero: at a mid-cluster index the caret can paint a bare combining mark, and `TextField#backspace` still deletes one codepoint, now inconsistent with TextArea. `MemoryBackend` still diverges from `TermisuBackend` on `accepted_width` rejections (zero-width marks, C0/C1, a wide glyph at the screen's last column), so a spill assertion at the *screen* edge would still mislead. All noted in comments at the relevant sites.