### PR TITLE
feat(tui): startup update-available notice on the project picker

### DIFF
--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -50,6 +50,56 @@ describe Gori::Settings do
     end
   end
 
+  it "persists and reloads the update-check settings as JSON" do
+    dir = File.tempname("gori-settings-update")
+    Dir.mkdir_p(dir)
+    prev = ENV["GORI_HOME"]?
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.update_check_enabled = false
+      Gori::Settings.update_notified_version = "0.2.0"
+      Gori::Settings.update_latest_seen = "0.2.0"
+      Gori::Settings.update_checked_at = 1_700_000_000_i64
+      Gori::Settings.save.should be_true
+      File.read(Gori::Settings.path).should contain(%("update"))
+
+      Gori::Settings.update_check_enabled = true
+      Gori::Settings.update_notified_version = ""
+      Gori::Settings.update_latest_seen = ""
+      Gori::Settings.update_checked_at = 0_i64
+      Gori::Settings.load
+      Gori::Settings.update_check_enabled?.should be_false # a stored false survives the reload
+      Gori::Settings.update_notified_version.should eq("0.2.0")
+      Gori::Settings.update_latest_seen.should eq("0.2.0")
+      Gori::Settings.update_checked_at.should eq(1_700_000_000_i64)
+    ensure
+      prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(dir)
+      Gori::Settings.update_check_enabled = true
+      Gori::Settings.update_notified_version = ""
+      Gori::Settings.update_latest_seen = ""
+      Gori::Settings.update_checked_at = 0_i64
+    end
+  end
+
+  it "omits the update section from a default install" do
+    dir = File.tempname("gori-settings-update-default")
+    Dir.mkdir_p(dir)
+    prev = ENV["GORI_HOME"]?
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.update_check_enabled = true
+      Gori::Settings.update_notified_version = ""
+      Gori::Settings.update_latest_seen = ""
+      Gori::Settings.update_checked_at = 0_i64
+      Gori::Settings.save.should be_true
+      File.read(Gori::Settings.path).should_not contain(%("update"))
+    ensure
+      prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(dir)
+    end
+  end
+
   it "persists and reloads env settings as JSON" do
     dir = File.tempname("gori-settings-env")
     Dir.mkdir_p(dir)
@@ -719,7 +769,7 @@ describe Gori::Settings do
 
   describe ".bind_host_error" do
     it "accepts blank, IPv4/IPv6 literals, and plausible hostnames" do
-      Gori::Settings.bind_host_error("").should be_nil          # caller defaults blank
+      Gori::Settings.bind_host_error("").should be_nil # caller defaults blank
       Gori::Settings.bind_host_error("127.0.0.1").should be_nil
       Gori::Settings.bind_host_error("0.0.0.0").should be_nil
       Gori::Settings.bind_host_error("::").should be_nil

--- a/spec/tui/settings_view_spec.cr
+++ b/spec/tui/settings_view_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "../support/memory_backend"
 require "file_utils"
 
 include Gori::Tui
@@ -341,33 +342,47 @@ describe SettingsView do
     end
   end
 
-  it "saves and resets the GENERAL section (clipboard, confirm quit)" do
+  it "saves and resets the GENERAL section (clipboard, confirm quit, update check)" do
     dir = File.tempname("gori-settings-general-view")
     Dir.mkdir_p(dir)
     prev_home = ENV["GORI_HOME"]?
-    prev = {Gori::Settings.clipboard_osc52?, Gori::Settings.confirm_quit?}
+    prev = {Gori::Settings.clipboard_osc52?, Gori::Settings.confirm_quit?, Gori::Settings.update_check_enabled?}
     begin
       ENV["GORI_HOME"] = dir
       Gori::Settings.clipboard_osc52 = true
       Gori::Settings.confirm_quit = false
+      Gori::Settings.update_check_enabled = true
       v = SettingsView.new
       v.reload(:general)
       v.section.should eq(:general)
       v.toggle_or_move(1) # clipboard: on → off (bool)
       v.move_field(1)
       v.toggle_or_move(1) # confirm quit: off → on (bool)
+      v.move_field(1)
+      v.toggle_or_move(1) # update check: on → off (bool)
       v.save
       Gori::Settings.clipboard_osc52?.should be_false
       Gori::Settings.confirm_quit?.should be_true
+      Gori::Settings.update_check_enabled?.should be_false
 
       v.reset_to_defaults
       v.save
       Gori::Settings.clipboard_osc52?.should eq(Gori::Settings::DEFAULT_CLIPBOARD_OSC52)
       Gori::Settings.confirm_quit?.should eq(Gori::Settings::DEFAULT_CONFIRM_QUIT)
+      Gori::Settings.update_check_enabled?.should eq(Gori::Settings::DEFAULT_UPDATE_CHECK_ENABLED)
     ensure
       prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
-      Gori::Settings.clipboard_osc52, Gori::Settings.confirm_quit = prev
+      Gori::Settings.clipboard_osc52, Gori::Settings.confirm_quit = prev[0], prev[1]
+      Gori::Settings.update_check_enabled = prev[2]
       FileUtils.rm_rf(dir)
     end
+  end
+
+  it "renders the Update check toggle in the GENERAL section" do
+    backend = MemoryBackend.new(100, 30)
+    v = SettingsView.new
+    v.reload(:general)
+    v.render(Screen.new(backend), Rect.new(0, 0, 100, 30))
+    backend.contains?("Update check").should be_true
   end
 end

--- a/spec/update_spec.cr
+++ b/spec/update_spec.cr
@@ -114,6 +114,31 @@ describe Gori::Update do
     end
   end
 
+  describe ".notice_version" do
+    it "surfaces a strictly-newer release the user has not been notified about" do
+      Gori::Update.notice_version("0.1.1", "0.2.0", "").should eq("0.2.0")
+      Gori::Update.notice_version("0.1.1", "v0.2.0", "").should eq("0.2.0")
+    end
+
+    it "returns nil when up to date or on a newer local build" do
+      Gori::Update.notice_version("0.2.0", "0.2.0", "").should be_nil
+      Gori::Update.notice_version("0.3.0", "0.2.0", "").should be_nil
+    end
+
+    it "returns nil when the newer release was already notified (read-once)" do
+      Gori::Update.notice_version("0.1.1", "0.2.0", "0.2.0").should be_nil
+      Gori::Update.notice_version("0.1.1", "0.2.0", "v0.2.0").should be_nil
+    end
+
+    it "re-notifies when a release newer than the last-notified one appears" do
+      Gori::Update.notice_version("0.1.1", "0.3.0", "0.2.0").should eq("0.3.0")
+    end
+
+    it "returns nil for an empty latest (fetch failed / no cache)" do
+      Gori::Update.notice_version("0.1.1", "", "").should be_nil
+    end
+  end
+
   describe "lib destination safety" do
     it "forbids shared system library roots" do
       Gori::Update.forbidden_lib_destination?("/usr/local/lib").should be_true

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -10,6 +10,7 @@ require "./settings/decoder"
 require "./settings/miner"
 require "./settings/probe"
 require "./settings/discover"
+require "./settings/update"
 
 module Gori
   # Global, persisted user settings — the editable runtime CONFIG for one gori
@@ -83,6 +84,7 @@ module Gori
       parse_display(root["display"]?)
       parse_notifications(root["notifications"]?)
       parse_general(root["general"]?)
+      parse_update(root["update"]?)
       Env.bump_highlight_rev
     rescue
       # no file yet / unreadable / bad JSON — keep current values
@@ -167,6 +169,7 @@ module Gori
           serialize_display(j)
           serialize_notifications(j)
           serialize_general(j)
+          serialize_update(j)
           serialize_network(j)
           serialize_editor(j)
           serialize_tabs(j)

--- a/src/gori/settings/update.cr
+++ b/src/gori/settings/update.cr
@@ -1,0 +1,55 @@
+require "json"
+
+# Startup update-check settings — the state behind the ProjectPicker's one-line
+# "update available" notice. See settings.cr for the load/save orchestration.
+#
+# The picker does a best-effort background probe of the latest GitHub release and,
+# when it's newer than the running binary, shows a brief hint above the key row —
+# once per new release (the read-once marker). This is the ONLY automatic outbound
+# call gori makes; `gori update` stays the explicit install path.
+module Gori::Settings
+  # check_enabled: opt-out for egress-sensitive users (default on — the maintainer
+  #   asked for the notice). Gating it off skips the probe entirely.
+  # notified_version: the latest version we've already surfaced — the read-once marker.
+  # latest_seen / checked_at: a once-a-day cache (unix seconds) so we don't re-probe
+  #   GitHub on every launch; only refreshed on a successful live fetch.
+  DEFAULT_UPDATE_CHECK_ENABLED = true
+
+  class_property? update_check_enabled : Bool = DEFAULT_UPDATE_CHECK_ENABLED
+  class_property update_notified_version : String = ""
+  class_property update_latest_seen : String = ""
+  class_property update_checked_at : Int64 = 0_i64
+
+  # Tolerant update section: absent/non-object keeps current.
+  private def self.parse_update(node : JSON::Any?) : Nil
+    return unless o = node.try(&.as_h?)
+    self.update_check_enabled = load_bool_h(o, "check_enabled", update_check_enabled?)
+    if v = o["notified_version"]?.try(&.as_s?)
+      self.update_notified_version = v
+    end
+    if v = o["latest_seen"]?.try(&.as_s?)
+      self.update_latest_seen = v
+    end
+    if v = o["checked_at"]?.try(&.as_i64?)
+      self.update_checked_at = v
+    end
+  end
+
+  # Omit the section entirely on a quiet/default install (merge-safe; mirrors
+  # serialize_display/serialize_layout).
+  private def self.serialize_update(j : JSON::Builder) : Nil
+    unless update_check_enabled? == DEFAULT_UPDATE_CHECK_ENABLED &&
+           update_notified_version.empty? &&
+           update_latest_seen.empty? &&
+           update_checked_at == 0_i64
+      j.field "update" do
+        j.object do
+          j.field "check_enabled", update_check_enabled?
+          j.field "notified_version", update_notified_version
+          j.field "latest_seen", update_latest_seen
+          j.field "checked_at", update_checked_at
+        end
+      end
+    end
+  end
+end

--- a/src/gori/tui/project_picker.cr
+++ b/src/gori/tui/project_picker.cr
@@ -3,6 +3,7 @@ require "../capture_lock"
 require "../capture_status"
 require "../project"
 require "../project_registry"
+require "../update"
 require "../fuzzy"
 require "./geometry"
 require "./screen"
@@ -91,10 +92,27 @@ module Gori::Tui
       @running_cache = {} of String => RunningProbe
       @art_frame = 0  # entrance-animation clock for the brand art; advances each frame until ART_ANIM_DONE
       @star_frame = 0 # starfield twinkle clock; unlike @art_frame it never freezes (wraps via &+)
+      # Startup update check (see start_update_check / reconcile_update_check / the
+      # notice in render_list). The background fiber only writes @remote_latest +
+      # @remote_ready; every Settings mutation stays on the main fiber.
+      @update_started = false          # guard: kick the check off exactly once
+      @update_reconciled = false       # guard: fold the result in exactly once
+      @remote_latest = nil.as(String?) # fetched (or cached) latest version, normalized
+      @remote_ready = false            # set last by the producer so the reader sees a consistent pair
+      @fetched_live = false            # true when @remote_latest came from a live fetch (→ refresh the cache)
+      @update_notice = nil.as(String?) # the one-line notice text, once a fresh update is available
+      @update_notice_version = ""      # the version the notice is for (persisted as the read-once marker)
+      @notice_persisted = false        # guard: write the read-once marker after the notice's first real paint
     end
 
+    # Once-a-day cache window: skip the network probe when the last successful check
+    # is this recent (still surfaces a not-yet-notified update from the cached value).
+    UPDATE_CHECK_TTL = 24 * 60 * 60
+
     def run : Project?
+      start_update_check
       loop do
+        reconcile_update_check
         render
         # Drive the entrance animation off the idle poll cadence (~50 ms/frame):
         # the loop re-renders whenever poll_event times out, so bumping the clock
@@ -137,6 +155,56 @@ module Gori::Tui
             @preedit = ev.text
           end
         end
+      end
+    end
+
+    # --- update check --------------------------------------------------------
+
+    # Kick the startup update probe off exactly once (from `run`, not `initialize`,
+    # so a picker built in a spec never phones home). A fresh cache is used inline
+    # (no network); otherwise a background fiber fetches the latest release version
+    # and hands it back via @remote_latest/@remote_ready — no Settings I/O here.
+    private def start_update_check : Nil
+      return if @update_started
+      @update_started = true
+      return unless Settings.update_check_enabled?
+
+      now = Time.utc.to_unix
+      cached = Settings.update_latest_seen
+      if !cached.empty? && (now - Settings.update_checked_at) < UPDATE_CHECK_TTL
+        @remote_latest = cached
+        @remote_ready = true
+        return
+      end
+
+      spawn(name: "gori-update-check") do
+        latest = Update.latest_version # nil on any failure (offline, rate-limited, …)
+        @remote_latest = latest
+        @fetched_live = true
+        @remote_ready = true # set last so the reader never sees a half-written pair
+      end
+    end
+
+    # Fold a ready result in once, on the main fiber: refresh the day cache after a
+    # live fetch, then decide whether a fresh, not-yet-notified update should show.
+    # The marker itself is persisted only when the notice actually paints (render_list).
+    private def reconcile_update_check : Nil
+      return unless @remote_ready
+      return if @update_reconciled
+      @update_reconciled = true
+
+      latest = @remote_latest
+      return unless latest # failed fetch → nothing to show, cache untouched (retry next launch)
+
+      if @fetched_live
+        Settings.update_latest_seen = latest
+        Settings.update_checked_at = Time.utc.to_unix
+        Settings.save
+      end
+
+      if nv = Update.notice_version(Gori::VERSION, latest, Settings.update_notified_version)
+        @update_notice_version = nv
+        @update_notice = "update available: v#{Update.normalize_version(Gori::VERSION)} → v#{nv} · run: gori update"
       end
     end
 
@@ -1037,9 +1105,21 @@ module Gori::Tui
         end
       end
 
-      # Transient result of the last compaction, one row above the hint.
+      # Row above the hint (h-3): a transient compaction result when present, else
+      # the once-per-release "update available" notice. The compaction flash is a
+      # direct response to a keypress, so it takes the row; the notice returns when
+      # the flash clears on the next keystroke.
       if flash = @flash
         centered(screen, h - 3, flash, @flash_ok ? Theme.green : Theme.red, w)
+      elsif notice = @update_notice
+        centered(screen, h - 3, notice, Theme.yellow, w)
+        # Mark this release "read" only once it has actually reached the screen, so a
+        # fetch that lands as the user opens a project doesn't burn the one showing.
+        unless @notice_persisted
+          @notice_persisted = true
+          Settings.update_notified_version = @update_notice_version
+          Settings.save
+        end
       end
 
       if tokens = list_hint_tokens

--- a/src/gori/tui/settings_catalog.cr
+++ b/src/gori/tui/settings_catalog.cr
@@ -41,7 +41,7 @@ module Gori::Tui
     SECTIONS = [
       # General
       Section.new(:general, "settings.general", "General",
-        "Clipboard (OSC 52) integration and confirm-before-quit", :general, :form),
+        "Clipboard (OSC 52) integration, confirm-before-quit, and the startup update check", :general, :form),
       Section.new(:notifications, "settings.notifications", "Notifications",
         "Terminal bell + toast on background results, and how many notifications are kept", :general, :form),
       Section.new(:statusline, "settings.statusline", "Statusline",

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -76,8 +76,8 @@ module Gori::Tui
         "how often to re-run the command — seconds (min 1)"),
     ]
     # Display: message-body + chrome prefs (three choice fields, two bools, a text cap).
-    DISPLAY_PANE_CHOICES  = ["request", "response"]
-    DISPLAY_TIME_CHOICES  = ["absolute", "relative"]
+    DISPLAY_PANE_CHOICES = ["request", "response"]
+    DISPLAY_TIME_CHOICES = ["absolute", "relative"]
     # Kept short: all three render inline on one row inside the settings box.
     DISPLAY_TITLE_CHOICES = ["project + tab", "tab", "off"]
     DISPLAY_FIELDS        = [
@@ -110,13 +110,16 @@ module Gori::Tui
       Field.new("Retention (count)",
         "how many notifications the ring buffer keeps — count (min 1)"),
     ]
-    # General: clipboard + quit-confirm toggles.
+    # General: clipboard + quit-confirm + update-check toggles.
     GENERAL_FIELDS = [
       Field.new("Clipboard (OSC 52)",
         "copy to the system clipboard via the OSC 52 terminal escape — off makes copies no-op — ←/→/space toggles",
         bool: true),
       Field.new("Confirm before quit",
         "require a confirm modal to quit (instead of double-press ^D) — ←/→/space toggles",
+        bool: true),
+      Field.new("Update check",
+        "on startup, check GitHub for a newer release and show a one-line notice on the project picker — off = no outbound check; ←/→/space toggles",
         bool: true),
     ]
     SECTIONS = {
@@ -164,7 +167,7 @@ module Gori::Tui
                 when :statusline    then [Settings.statusline_enabled? ? "on" : "off", Settings.statusline_command, Settings.statusline_interval.to_s]
                 when :display       then display_values
                 when :notifications then [Settings.notify_bell? ? "on" : "off", Settings.notify_toast? ? "on" : "off", Settings.notify_retention.to_s]
-                when :general       then [Settings.clipboard_osc52? ? "on" : "off", Settings.confirm_quit? ? "on" : "off"]
+                when :general       then [Settings.clipboard_osc52? ? "on" : "off", Settings.confirm_quit? ? "on" : "off", Settings.update_check_enabled? ? "on" : "off"]
                 else                     [Settings.bind_host, Settings.bind_port.to_s, Settings.upstream_proxy, Settings.verify_upstream? ? "on" : "off", Settings.serve_landing? ? "on" : "off", Settings.connect_timeout_secs.to_s, Settings.io_timeout_secs.to_s, Settings.capture_max_mib.to_s, hostnames_summary]
                 end
       @focused = 0
@@ -219,6 +222,7 @@ module Gori::Tui
                 when :general then [
                   Settings::DEFAULT_CLIPBOARD_OSC52 ? "on" : "off",
                   Settings::DEFAULT_CONFIRM_QUIT ? "on" : "off",
+                  Settings::DEFAULT_UPDATE_CHECK_ENABLED ? "on" : "off",
                 ]
                 else [Settings::DEFAULT_BIND_HOST, Settings::DEFAULT_BIND_PORT.to_s, Settings::DEFAULT_UPSTREAM_PROXY, Settings::DEFAULT_VERIFY_UPSTREAM ? "on" : "off", Settings::DEFAULT_SERVE_LANDING ? "on" : "off", Settings::DEFAULT_CONNECT_TIMEOUT_SECS.to_s, Settings::DEFAULT_IO_TIMEOUT_SECS.to_s, Settings::DEFAULT_CAPTURE_MAX_MIB.to_s, hostnames_summary]
                 end
@@ -467,7 +471,8 @@ module Gori::Tui
       if @section == :general
         Settings.clipboard_osc52 = @values[0] == "on"
         Settings.confirm_quit = @values[1] == "on"
-        @values = [Settings.clipboard_osc52? ? "on" : "off", Settings.confirm_quit? ? "on" : "off"]
+        Settings.update_check_enabled = @values[2] == "on"
+        @values = [Settings.clipboard_osc52? ? "on" : "off", Settings.confirm_quit? ? "on" : "off", Settings.update_check_enabled? ? "on" : "off"]
         return persist
       end
       if err = Settings.bind_host_error(@values[0])

--- a/src/gori/update.cr
+++ b/src/gori/update.cr
@@ -17,6 +17,10 @@ module Gori
     USER_AGENT    = "gori/#{VERSION} (+#{REPOSITORY_URL})"
     MAX_REDIRECTS = 10
     HTTP_TIMEOUT  = 60.seconds
+    # Short timeout for the TUI startup update check (background, best-effort) so a
+    # slow/hung GitHub never keeps a fiber alive for a full minute. The explicit
+    # `gori update` flow keeps HTTP_TIMEOUT.
+    UPDATE_CHECK_TIMEOUT = 8.seconds
     # Download progress meter
     PROGRESS_BAR_WIDTH    = 24
     PROGRESS_CHUNK        = 64 * 1024
@@ -299,6 +303,19 @@ module Gori
       0
     end
 
+    # The version the ProjectPicker should surface as "update available", or nil
+    # when nothing fresh should be shown. Pure (unit-tested): `latest` is offered
+    # only when it is strictly newer than `local` AND we have not already notified
+    # about it (read-once — `notified` is the last version we surfaced). Returns the
+    # normalized version so the caller can persist it as the new read-once marker.
+    def self.notice_version(local : String, latest : String, notified : String) : String?
+      return nil if latest.empty?
+      return nil unless version_cmp(local, latest) < 0
+      norm = normalize_version(latest)
+      return nil if norm == normalize_version(notified)
+      norm
+    end
+
     # Release asset basename for platform (matches PR #114 / hwaro parity).
     # Linux: plain binary `gori-v{ver}-linux-{x86_64|arm64}`
     # macOS: tarball `gori-v{ver}-osx-{arm64|x86_64}.tar.gz` (contains gori + lib/)
@@ -577,11 +594,22 @@ module Gori
       File.realpath(path)
     end
 
-    private def self.http_client(host : String, port : Int32, tls : Bool) : HTTP::Client
+    private def self.http_client(host : String, port : Int32, tls : Bool,
+                                 timeout : Time::Span = HTTP_TIMEOUT) : HTTP::Client
       client = HTTP::Client.new(host, port, tls)
-      client.connect_timeout = HTTP_TIMEOUT
-      client.read_timeout = HTTP_TIMEOUT
+      client.connect_timeout = timeout
+      client.read_timeout = timeout
       client
+    end
+
+    # Best-effort latest published release version (normalized, no leading `v`), or
+    # nil on ANY failure (offline, rate-limited, malformed). Used by the TUI startup
+    # update check — never raises into the caller, uses UPDATE_CHECK_TIMEOUT.
+    def self.latest_version(api_url : String? = nil,
+                            timeout : Time::Span = UPDATE_CHECK_TIMEOUT) : String?
+      parse_release(fetch_latest_release_json(api_url, timeout: timeout)).version
+    rescue
+      nil
     end
 
     # Resolves the releases API URL: explicit arg → env override → GitHub default.
@@ -589,7 +617,8 @@ module Gori
       api_url || ENV[UPDATE_API_ENV]? || API_LATEST
     end
 
-    def self.fetch_latest_release_json(api_url : String? = nil) : String
+    def self.fetch_latest_release_json(api_url : String? = nil, *,
+                                       timeout : Time::Span = HTTP_TIMEOUT) : String
       url = resolve_api_url(api_url)
       uri = URI.parse(url)
       headers = HTTP::Headers{
@@ -599,7 +628,7 @@ module Gori
       host = uri.host || raise Error.new("invalid API URL: #{url}")
       port = uri.port || (uri.scheme == "https" ? 443 : 80)
       tls = uri.scheme == "https"
-      client = http_client(host, port, tls)
+      client = http_client(host, port, tls, timeout)
       begin
         response = client.get(uri.request_target, headers: headers)
         case response.status_code


### PR DESCRIPTION
## What

On `gori tui` startup, the **project picker** now shows a brief one-line notice above the key-hint row when a newer release is available:

```
update available: v0.1.1 → v0.2.0 · run: gori update
↑/↓ select   ↵ open   type to search   ctrl-n new
```

It appears **once per release** (a persisted read-once marker), not on every launch.

## How

- **`Update.notice_version(local, latest, notified)`** — pure, unit-tested decision: surface `latest` only when it's strictly newer *and* not already notified.
- **`Update.latest_version`** — best-effort GitHub fetch, `nil` on any failure, short 8s timeout (the explicit `gori update` path keeps its full timeout).
- **New `update` settings section** — `check_enabled` (default **on**; a hand-editable + UI opt-out for egress-sensitive users), `notified_version` (read-once marker), and a once-a-day `latest_seen`/`checked_at` cache so we don't probe GitHub on every launch. Section is omitted from `settings.json` at defaults.
- **`ProjectPicker`** — spawns the probe in `run()` (not `initialize`, so specs never phone home); a fresh cache is used inline, otherwise a background fiber fetches. All `Settings` mutation stays on the main fiber; the marker persists only once the notice **actually paints** (so a fetch that lands as the user opens a project doesn't burn the one showing). The compaction flash still wins the row when present.
- **Discoverable toggle** — "Update check" in `settings:general`, visible in both the picker's Ctrl+, and the in-app Ctrl+,.

## Verification

- Full suite: **2466 examples, 0 failures**.
- Added specs: `notice_version` cases, update-section round-trip + omit-at-default, and the General-section toggle (save/reset + renders the label).
- Live PTY smoke run against `scripts/mock_update_server.cr` (`--tag v99.0.0`): notice rendered above the hint on first launch, hidden on second (read-once).

## Notes

- This is the only automatic outbound call gori makes; `gori update` remains the explicit install path. The opt-out gates it entirely.
- The notice string is ~53 cols (clips on very narrow terminals, consistent with the existing wider hints).