### PR TITLE
feat(tui): improve NOR/INS mode badge discoverability and click toggle

### DIFF
--- a/spec/tui/mouse_spec.cr
+++ b/spec/tui/mouse_spec.cr
@@ -260,6 +260,24 @@ describe "Frame.left_chip_hit / right_badge_hit" do
     Frame.right_badge_hit(15, y, y, right, 20, badges).should be_nil # PRETTY would start at 13 < 20
     Frame.right_badge_hit(28, y, y, right, 20, badges).should eq(:mark)
   end
+
+  it "hits the NOR/INS mode badge and chains left of right-aligned badges" do
+    y = 2
+    right = 40
+    # NOR label is " ↵:NOR " (7 cells) → [right-7, right).
+    Frame.mode_badge_hit(right - 2, y, y, right, 0, false).should be_true
+    Frame.mode_badge_hit(right - 7, y, y, right, 0, false).should be_true # inclusive start
+    Frame.mode_badge_hit(right, y, y, right, 0, false).should be_false    # exclusive end
+    Frame.mode_badge_hit(right - 8, y, y, right, 0, false).should be_false
+    # INS is " INS " (5 cells) → [right-5, right).
+    Frame.mode_badge_hit(right - 2, y, y, right, 0, true).should be_true
+    Frame.mode_badge_hit(right - 6, y, y, right, 0, true).should be_false
+    # Chained left of SEND+CL: edge after badges is where mode_badge draws.
+    badges = [{:send, "^R", "SEND"}, {:cl, "^L", "CL"}] of {Symbol, String, String}
+    edge = Frame.right_badge_edge(right, 0, badges)
+    Frame.mode_badge_hit(edge - 2, y, y, edge, 0, false).should be_true
+    Frame.mode_badge_hit(edge, y, y, edge, 0, false).should be_false
+  end
 end
 
 describe "RepeaterView#chrome_hit" do
@@ -280,7 +298,7 @@ describe "RepeaterView#chrome_hit" do
     view.chrome_hit(rect, resp.x + 12 + 9, resp.y).should eq(:hex) # past " d:diff " + gap
     view.chrome_hit(rect, resp.x + 12 + 9 + 9, resp.y).should eq(:pretty)
 
-    # REQUEST right-chain: rightmost is SEND, then CL, PRETTY
+    # REQUEST right-chain: rightmost is SEND, then CL, PRETTY, then NOR/INS
     send_label = " ^R:SEND "
     send_x = (req.right - 1) - send_label.size
     view.chrome_hit(rect, send_x + 1, req.y).should eq(:send)
@@ -290,6 +308,12 @@ describe "RepeaterView#chrome_hit" do
     pretty_label = " ^U:PRETTY "
     pretty_x = cl_x - pretty_label.size
     view.chrome_hit(rect, pretty_x + 1, req.y).should eq(:pretty_req)
+    mode_label = Frame.mode_badge_label(false) # " ↵:NOR "
+    mode_x = pretty_x - mode_label.size
+    view.chrome_hit(rect, mode_x + 1, req.y).should eq(:mode)
+
+    # TARGET NOR/INS on the top band
+    view.chrome_hit(rect, rect.right - 3, rect.y).should eq(:target_mode)
 
     # Body click (not on border chrome) → nil so caret path still runs
     view.chrome_hit(rect, resp.x + 2, resp.y + 2).should be_nil

--- a/spec/tui/repeater_view_spec.cr
+++ b/spec/tui/repeater_view_spec.cr
@@ -985,12 +985,13 @@ describe Gori::Tui::RepeaterView do
     view.enter_request_insert!
     backend = MemoryBackend.new(120, 24)
     view.render(Screen.new(backend), Rect.new(0, 0, 120, 24))
-    backend.contains?("i:INS").should be_true
+    backend.contains?("INS").should be_true
+    backend.contains?("i:INS").should be_false
     view.exit_request_insert!
     view.request_insert?.should be_false
     backend2 = MemoryBackend.new(120, 24)
     view.render(Screen.new(backend2), Rect.new(0, 0, 120, 24))
-    backend2.contains?("NOR").should be_true
+    backend2.contains?("↵:NOR").should be_true
   end
 
   it "resp_move + selection returns plain text for copy" do

--- a/src/gori/tui/controllers/decoder_controller.cr
+++ b/src/gori/tui/controllers/decoder_controller.cr
@@ -316,8 +316,15 @@ module Gori::Tui
       if regions.input.contains?(mx, my)
         s.pane = :input
         @popup.close
-        s.input.click_to_cursor(regions.input.inset(1, 1), mx, my)
-        s.input_read.sync_from(s.input) unless s.input_mode == InputMode::Insert
+        # NOR/INS border chip toggles insert (same as ↵ / esc); don't move caret.
+        if Frame.mode_badge_hit(mx, my, regions.input.y, regions.input.right - 1,
+             regions.input.x + 6, s.input_mode == InputMode::Insert)
+          s.input_mode = s.input_mode == InputMode::Insert ? InputMode::Read : InputMode::Insert
+          s.input_read.sync_from(s.input) if s.input_mode == InputMode::Read
+        else
+          s.input.click_to_cursor(regions.input.inset(1, 1), mx, my)
+          s.input_read.sync_from(s.input) unless s.input_mode == InputMode::Insert
+        end
       elsif regions.chain.contains?(mx, my)
         s.pane = :chain
         field = regions.chain.inset(1, 1)

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -521,13 +521,32 @@ module Gori::Tui
         end
         return true
       end
-      # The TEMPLATE border's ^R:RUN badge — the primary action, clickable like a button
-      # (mirrors the Repeater's ^R:SEND). Consumes the click (no caret move / focus race).
-      if v.template_chrome_hit(body, mx, my) == :run
+      # TEMPLATE border chrome (^R:RUN / PRETTY / NOR·INS) and TARGET NOR/INS.
+      if chip = v.template_chrome_hit(body, mx, my)
         save_current
         @host.focus_body
         v.focus_pane(:template)
-        fuzz_run
+        case chip
+        when :run    then fuzz_run
+        when :pretty then fuzz_pretty_template
+        when :mode
+          if v.template_insert?
+            v.exit_template_insert!
+          else
+            v.enter_template_insert!
+          end
+        end
+        return true
+      end
+      if v.target_chrome_hit(body, mx, my) == :mode
+        save_current
+        @host.focus_body
+        v.focus_pane(:target)
+        if v.target_insert?
+          v.exit_target_insert!
+        else
+          v.enter_target_insert!
+        end
         return true
       end
       return true unless pane = v.pane_at(body, mx, my)

--- a/src/gori/tui/controllers/issues_controller.cr
+++ b/src/gori/tui/controllers/issues_controller.cr
@@ -75,6 +75,17 @@ module Gori::Tui
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
       inner = rect.inset(1, 1)
       if @issues.detail_open?
+        card = @issues.notes_card_rect(inner)
+        # NOR/INS chip on the NOTES card border toggles insert (same as ↵ / esc).
+        if !card.empty? && Frame.mode_badge_hit(mx, my, card.y, card.right - 1, card.x + 7,
+             @issues.notes_insert_mode?)
+          if @issues.notes_insert_mode?
+            @issues.exit_notes_insert!
+          else
+            @issues.enter_notes_insert!
+          end
+          return true
+        end
         notes_rect = @issues.notes_body_rect(inner)
         if !notes_rect.empty? && mx >= notes_rect.x && mx < notes_rect.right &&
            my >= notes_rect.y && my < notes_rect.bottom

--- a/src/gori/tui/controllers/jwt_controller.cr
+++ b/src/gori/tui/controllers/jwt_controller.cr
@@ -468,8 +468,15 @@ module Gori::Tui
         input_c, dec_c, atk_c = s.view.decode_layout(body)
         if input_c.contains?(mx, my)
           enter_pane(s, :input)
-          s.input.click_to_cursor(input_c.inset(1, 1), mx, my)
-          s.input_read.sync_from(s.input) unless s.input_mode == InputMode::Insert
+          # NOR/INS border chip toggles insert (same as ↵ / esc); don't move caret.
+          if Frame.mode_badge_hit(mx, my, input_c.y, input_c.right - 1, input_c.x + 8,
+               s.input_mode == InputMode::Insert)
+            s.input_mode = s.input_mode == InputMode::Insert ? InputMode::Read : InputMode::Insert
+            s.input_read.sync_from(s.input) if s.input_mode == InputMode::Read
+          else
+            s.input.click_to_cursor(input_c.inset(1, 1), mx, my)
+            s.input_read.sync_from(s.input) unless s.input_mode == InputMode::Insert
+          end
         elsif dec_c.contains?(mx, my)
           enter_pane(s, :decoded)
         elsif atk_c.contains?(mx, my)

--- a/src/gori/tui/controllers/notes_controller.cr
+++ b/src/gori/tui/controllers/notes_controller.cr
@@ -153,6 +153,15 @@ module Gori::Tui
       @host.focus_body
       body = body_rect_below_filter(rect)
       body = carve_links_row(body)[1] unless @notes.link_preview.empty?
+      # NOR/INS chip on the editor top border toggles insert (same as ↵ / esc).
+      if Frame.mode_badge_hit(mx, my, body.y, body.right - 1, body.x + 1, @notes.insert_mode?)
+        if @notes.insert_mode?
+          @notes.exit_insert!
+        else
+          @notes.enter_insert!
+        end
+        return true
+      end
       @notes.click_to_cursor(body, mx, my)
       true
     end

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -126,6 +126,18 @@ module Gori::Tui
         end
       when :desc
         @project_view.focus_pane(:desc)
+        # NOR/INS chip on the DESCRIPTION card border toggles insert (same as ↵ / esc).
+        if desc = @project_view.desc_card_rect(rect)
+          if Frame.mode_badge_hit(mx, my, desc.y, desc.right - 1, desc.x + 14,
+               @project_view.desc_insert_mode?)
+            if @project_view.desc_insert_mode?
+              @project_view.exit_desc_insert!
+            else
+              @project_view.enter_desc_insert!
+            end
+            return true
+          end
+        end
         @project_view.desc_click_to_cursor(rect, mx, my)
       when :settings
         @project_view.focus_pane(:settings)

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -555,6 +555,20 @@ module Gori::Tui
       when :send
         view.focus_pane(:request)
         repeater_send
+      when :mode
+        view.focus_pane(:request)
+        if view.request_insert?
+          view.exit_request_insert!
+        else
+          view.enter_request_insert!
+        end
+      when :target_mode
+        view.focus_pane(:target)
+        if view.target_insert?
+          view.exit_target_insert!
+        else
+          view.enter_target_insert!
+        end
       end
     end
 

--- a/src/gori/tui/decoder_view.cr
+++ b/src/gori/tui/decoder_view.cr
@@ -108,7 +108,7 @@ module Gori::Tui
                              mode : InputMode, read : TextReadState?, reading : Bool) : Nil
       Frame.card(screen, card, "INPUT", bg: Theme.bg, border: Frame.pane_border(active || reading))
       if active || reading
-        render_mode_badge(screen, card.right - 1, card.y, card.x + 6, mode == InputMode::Insert)
+        Frame.mode_badge(screen, card.right - 1, card.y, card.x + 6, mode == InputMode::Insert)
       end
       body = card.inset(1, 1)
       input.render(screen, body, cursor: active, gauge: true, gauge_focused: active)
@@ -136,15 +136,6 @@ module Gori::Tui
         ch = cx < line.size ? line[cx] : ' '
         screen.cell(px, rect.y + row, ch, Theme.bg, Theme.accent_bg)
         screen.cursor(px, rect.y + row)
-      end
-    end
-
-    private def render_mode_badge(screen : Screen, right_edge : Int32, y : Int32, min_x : Int32, insert : Bool) : Nil
-      if insert
-        Frame.toggle_badge(screen, right_edge, y, min_x, "i", "INS", true)
-      else
-        x = right_edge - " NOR ".size
-        screen.text(x, y, " NOR ", Theme.muted, Theme.bg) if x >= min_x
       end
     end
 

--- a/src/gori/tui/frame.cr
+++ b/src/gori/tui/frame.cr
@@ -140,6 +140,53 @@ module Gori::Tui
       x
     end
 
+    # READ/INS mode chip on an editor pane's top border (Repeater REQUEST, Decoder INPUT,
+    # Notes, …). NOR advertises ↵ (and i) as the way into insert; INS is a plain lit label
+    # (esc exits — already in the status strip). Clickable via `mode_badge_hit`. Returns
+    # the badge's left x for chaining, or `right_edge` when it doesn't fit.
+    def self.mode_badge(screen : Screen, right_edge : Int32, y : Int32, min_x : Int32,
+                        insert : Bool) : Int32
+      text = mode_badge_label(insert)
+      x = right_edge - text.size
+      return right_edge if x < min_x
+      if insert
+        screen.text(x, y, text, Theme.text_bright, Theme.accent_bg)
+      else
+        screen.text(x, y, text, Theme.muted, Theme.bg)
+      end
+      x
+    end
+
+    # Label drawn by `mode_badge` / measured by `mode_badge_hit`. Keep geometry in one place.
+    def self.mode_badge_label(insert : Bool) : String
+      insert ? " INS " : " ↵:NOR "
+    end
+
+    # Hit-test for a single `mode_badge` at the same geometry as draw. Miss → false.
+    def self.mode_badge_hit(mx : Int32, my : Int32, y : Int32, right_edge : Int32,
+                            min_x : Int32, insert : Bool) : Bool
+      return false if my != y
+      text = mode_badge_label(insert)
+      x = right_edge - text.size
+      return false if x < min_x
+      mx >= x && mx < x + text.size
+    end
+
+    # Left edge after a right-chained `toggle_badge`/`action_badge` run — the right_edge
+    # to pass the next (leftward) badge, including `mode_badge`. Same skip-past-min_x rule
+    # as draw/hit. Pure geometry for chrome hit-tests that need to chain mode after others.
+    def self.right_badge_edge(right_edge : Int32, min_x : Int32,
+                              badges : Array({Symbol, String, String})) : Int32
+      edge = right_edge
+      badges.each do |(_, chord, name)|
+        text = " #{chord}:#{name} "
+        x = edge - text.size
+        break if x < min_x
+        edge = x
+      end
+      edge
+    end
+
     # The one PRIMARY-action badge on a pane's top border — the button that actually fires
     # the request: Repeater's ` ^R:SEND `, Fuzzer's ` ^R:RUN `. Geometry + text are identical
     # to `toggle_badge` (same " chord:NAME " string), so a click still hit-tests through

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -1485,20 +1485,11 @@ module Gori::Tui
       insert ? Theme.accent : Theme.focus_gold
     end
 
-    private def render_mode_badge(screen : Screen, right_edge : Int32, y : Int32, min_x : Int32, insert : Bool) : Nil
-      if insert
-        Frame.toggle_badge(screen, right_edge, y, min_x, "i", "INS", true)
-      else
-        x = right_edge - " NOR ".size
-        screen.text(x, y, " NOR ", Theme.muted, Theme.bg) if x >= min_x
-      end
-    end
-
     private def render_target(screen : Screen, rect : Rect, focused : Bool) : Nil
       return if rect.h < 2
       ins = focused && target_insert?
       Frame.card(screen, rect, "TARGET", bg: Theme.bg, border: pane_border(focused, insert: ins))
-      render_mode_badge(screen, rect.right - 1, rect.y, rect.x + 8, ins)
+      Frame.mode_badge(screen, rect.right - 1, rect.y, rect.x + 8, ins)
       unless @sni.strip.empty?
         badge = " SNI "
         bx = {rect.right - badge.size - 1, rect.x + 9}.max
@@ -1542,7 +1533,7 @@ module Gori::Tui
       # estimate stays there as a passive summary (render_run_summary).
       run_x = Frame.action_badge(screen, rect.right - 1, rect.y, min_x, "^R", "RUN", !running?)
       pretty_x = Frame.toggle_badge(screen, run_x, rect.y, min_x, "^U", "PRETTY", false)
-      render_mode_badge(screen, pretty_x, rect.y, min_x, ins)
+      Frame.mode_badge(screen, pretty_x, rect.y, min_x, ins)
       screen.text({pretty_x - badge.size, min_x}.max, rect.y, badge,
         pc > 0 ? Theme.text_bright : Theme.muted, pc > 0 ? Theme.accent_bg : Theme.bg)
       # Marker i ↔ position i ↔ generator.set_for(i). The value gets the position hue; a
@@ -2257,10 +2248,8 @@ module Gori::Tui
       ] of {Symbol, String, String})
     end
 
-    # Hit-test the TEMPLATE border's ^R:RUN badge (rightmost, drawn by render_template).
-    # Returns :run when the click lands on it, else nil (caller falls through to caret/focus).
-    # Geometry mirrors render → render_top's left-column top border; the CHAIN split hangs
-    # below, so the border row is unaffected by whether the strip is shown.
+    # Hit-test the TEMPLATE border chrome (^R:RUN, ^U:PRETTY, NOR/INS). Geometry mirrors
+    # render_template. Miss → nil (caller falls through to caret/focus).
     def template_chrome_hit(rect : Rect, mx : Int32, my : Int32) : Symbol?
       return nil unless @loaded
       target_h = {rect.h, 3}.min
@@ -2273,9 +2262,21 @@ module Gori::Tui
       return nil if left.w < 2 || my != left.y
       label = @http2 ? "TEMPLATE (h2)" : "TEMPLATE"
       min_x = left.x + label.size + 4
-      Frame.right_badge_hit(mx, my, left.y, left.right - 1, min_x, [
-        {:run, "^R", "RUN"},
-      ] of {Symbol, String, String})
+      right_edge = left.right - 1
+      badges = [{:run, "^R", "RUN"}, {:pretty, "^U", "PRETTY"}] of {Symbol, String, String}
+      if hit = Frame.right_badge_hit(mx, my, left.y, right_edge, min_x, badges)
+        return hit
+      end
+      mode_edge = Frame.right_badge_edge(right_edge, min_x, badges)
+      Frame.mode_badge_hit(mx, my, left.y, mode_edge, min_x, template_insert? || @chain_focused) ? :mode : nil
+    end
+
+    # Hit-test the TARGET border NOR/INS chip. Geometry matches render_target.
+    def target_chrome_hit(rect : Rect, mx : Int32, my : Int32) : Symbol?
+      return nil unless @loaded
+      target_h = {rect.h, 3}.min
+      return nil if target_h < 2 || my != rect.y
+      Frame.mode_badge_hit(mx, my, rect.y, rect.right - 1, rect.x + 8, target_insert?) ? :mode : nil
     end
 
     def pane_at(rect : Rect, mx : Int32, my : Int32) : Symbol?

--- a/src/gori/tui/issues_view.cr
+++ b/src/gori/tui/issues_view.cr
@@ -662,9 +662,10 @@ module Gori::Tui
       ins = focused && notes_insert_mode?
       Frame.card(screen, card, "NOTES", bg: Theme.bg, border: Frame.pane_border(notes_active || ins))
       if notes_active || ins
-        render_notes_mode_badge(screen, card.right - 1, card.y, card.x + 7, ins)
+        Frame.mode_badge(screen, card.right - 1, card.y, card.x + 7, ins)
       elsif !notes_insert_mode?
-        edit_hint = " i/↵ "
+        # Unfocused NOTES still hints how to enter insert (same ↵ cue as the mode badge).
+        edit_hint = " ↵ "
         bx = card.right - edit_hint.size - 1
         screen.text(bx, card.y, edit_hint, Theme.muted, Theme.bg) if bx >= card.x + 7
       end
@@ -685,15 +686,6 @@ module Gori::Tui
     # Interior of the NOTES card (where TextArea draws) — matches Frame.card inset.
     def notes_body_rect(rect : Rect) : Rect
       notes_card_rect(rect).inset(1, 1)
-    end
-
-    private def render_notes_mode_badge(screen : Screen, right_edge : Int32, y : Int32, min_x : Int32, insert : Bool) : Nil
-      if insert
-        Frame.toggle_badge(screen, right_edge, y, min_x, "i", "INS", true)
-      else
-        bx = right_edge - " NOR ".size
-        screen.text(bx, y, " NOR ", Theme.muted, Theme.bg) if bx >= min_x
-      end
     end
 
     private def paint_notes_read_chrome(screen : Screen, rect : Rect, active : Bool) : Nil

--- a/src/gori/tui/jwt_view.cr
+++ b/src/gori/tui/jwt_view.cr
@@ -101,7 +101,7 @@ module Gori::Tui
       insert = active && mode == InputMode::Insert
       Frame.card(screen, card, "INPUT", bg: Theme.bg, border: Frame.pane_border(active))
       if active
-        Frame.toggle_badge(screen, card.right - 1, card.y, card.x + 8, "i", insert ? "INS" : "NOR", insert)
+        Frame.mode_badge(screen, card.right - 1, card.y, card.x + 8, insert)
       end
       body = card.inset(1, 1)
       input.render(screen, body, cursor: insert, gauge: true, gauge_focused: active)

--- a/src/gori/tui/notes_view.cr
+++ b/src/gori/tui/notes_view.cr
@@ -371,21 +371,12 @@ module Gori::Tui
       TrafficEmptyState.render(screen, area, variant: :notes) if current_blank?
       ins = focused && insert_mode?
       if focused
-        render_mode_badge(screen, rect.right - 1, rect.y, rect.x + 1, ins)
+        Frame.mode_badge(screen, rect.right - 1, rect.y, rect.x + 1, ins)
       end
       ed = current.area
       ed.render(screen, area, cursor: ins,
         highlight: Settings.editor_markdown ? :markdown : nil)
       paint_read_chrome(screen, area, ed, focused && !insert_mode?) if !insert_mode?
-    end
-
-    private def render_mode_badge(screen : Screen, right_edge : Int32, y : Int32, min_x : Int32, insert : Bool) : Nil
-      if insert
-        Frame.toggle_badge(screen, right_edge, y, min_x, "i", "INS", true)
-      else
-        x = right_edge - " NOR ".size
-        screen.text(x, y, " NOR ", Theme.muted, Theme.bg) if x >= min_x
-      end
     end
 
     private def paint_read_chrome(screen : Screen, rect : Rect, ed : TextArea, focused : Bool) : Nil

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -375,6 +375,11 @@ module Gori::Tui
       @ov_sel = idx.clamp(0, n - 1)
     end
 
+    # DESCRIPTION card outer rect (for border chrome hit-tests). Nil when layout is empty.
+    def desc_card_rect(rect : Rect) : Rect?
+      body_panes(rect).try &.[3]
+    end
+
     # Mouse: place the description-editor cursor at a click. `rect` is the body rect
     # render() receives; re-derive the DESCRIPTION card + its 1-cell inset via body_panes
     # (the same geometry render uses), then map into the @desc_area editor.
@@ -1259,7 +1264,7 @@ module Gori::Tui
       border = desc_pane_border(focused, ins)
       Frame.card(screen, rect, "DESCRIPTION", bg: Theme.bg, border: border)
       if focused
-        render_desc_mode_badge(screen, rect.right - 1, rect.y, rect.x + 14, ins)
+        Frame.mode_badge(screen, rect.right - 1, rect.y, rect.x + 14, ins)
       end
       inner = rect.inset(1, 1)
       @desc_area.render(screen, inner, cursor: ins,
@@ -1270,15 +1275,6 @@ module Gori::Tui
     private def desc_pane_border(focused : Bool, insert : Bool) : Color
       return Frame.pane_border(false) unless focused
       insert ? Theme.accent : Frame.pane_border(true)
-    end
-
-    private def render_desc_mode_badge(screen : Screen, right_edge : Int32, y : Int32, min_x : Int32, insert : Bool) : Nil
-      if insert
-        Frame.toggle_badge(screen, right_edge, y, min_x, "i", "INS", true)
-      else
-        bx = right_edge - " NOR ".size
-        screen.text(bx, y, " NOR ", Theme.muted, Theme.bg) if bx >= min_x
-      end
     end
 
     private def paint_desc_read_chrome(screen : Screen, rect : Rect, active : Bool) : Nil

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -1570,6 +1570,12 @@ module Gori::Tui
     def chrome_hit(rect : Rect, mx : Int32, my : Int32) : Symbol?
       return nil unless @loaded && rect.contains?(mx, my)
       target_h = {rect.h, target_card_h}.min
+      # TARGET NOR/INS chip (top band) — click toggles insert like ↵/esc.
+      if my == rect.y && target_h >= 2
+        if Frame.mode_badge_hit(mx, my, rect.y, rect.right - 1, rect.x + 8, target_insert?)
+          return :target_mode
+        end
+      end
       content = Rect.new(rect.x, rect.y + target_h, rect.w, {rect.h - target_h, 0}.max)
       return nil if content.h <= 0
       half = {(content.w - 1) // 2, 1}.max
@@ -1590,7 +1596,8 @@ module Gori::Tui
       end
 
       # REQUEST badges: ^R:SEND is always rightmost (primary action). Then CL/PRETTY (or
-      # HEX) when drawn. Decode / CHAIN splits keep chrome on the top card.
+      # HEX) when drawn; NOR/INS mode chip chains left of those. Decode / CHAIN splits
+      # keep chrome on the top card. WS/gRPC skip the mode chip (no render_mode_badge).
       req_card = (@decode_kind || @ws_mode) ? decode_split(left)[0] : left
       if req_card.w >= 2 && my == req_card.y
         label = render_request_label
@@ -1613,6 +1620,13 @@ module Gori::Tui
         end
         if hit = Frame.right_badge_hit(mx, my, req_card.y, right_edge, min_x, badges)
           return hit
+        end
+        # Mode chip only drawn for plain HTTP request (not WS / gRPC / hex-edit).
+        unless @ws_mode || @grpc_mode || @req_hex_edit
+          mode_edge = Frame.right_badge_edge(right_edge, min_x, badges)
+          if Frame.mode_badge_hit(mx, my, req_card.y, mode_edge, min_x, request_insert?)
+            return :mode
+          end
         end
       end
       nil
@@ -2379,20 +2393,11 @@ module Gori::Tui
       insert ? Theme.accent : Theme.focus_gold
     end
 
-    private def render_mode_badge(screen : Screen, right_edge : Int32, y : Int32, min_x : Int32, insert : Bool) : Nil
-      if insert
-        Frame.toggle_badge(screen, right_edge, y, min_x, "i", "INS", true)
-      else
-        x = right_edge - " NOR ".size
-        screen.text(x, y, " NOR ", Theme.muted, Theme.bg) if x >= min_x
-      end
-    end
-
     private def render_target(screen : Screen, rect : Rect, focused : Bool) : Nil
       return if rect.h < 2
       ins = focused && target_insert?
       Frame.card(screen, rect, "TARGET", bg: Theme.bg, border: pane_border(focused, insert: ins))
-      render_mode_badge(screen, rect.right - 1, rect.y, rect.x + 8, ins)
+      Frame.mode_badge(screen, rect.right - 1, rect.y, rect.x + 8, ins)
       # An at-a-glance SNI marker on the top border (right of the title) whenever an
       # override is set, so a custom SNI is visible even before the row is reached.
       unless @sni.strip.empty?
@@ -2504,7 +2509,7 @@ module Gori::Tui
       end
       cl_x = Frame.toggle_badge(screen, send_edge, rect.y, min_x, "^L", "CL", @auto_content_length)
       mode_x = Frame.toggle_badge(screen, cl_x, rect.y, min_x, "^U", "PRETTY", false)
-      render_mode_badge(screen, mode_x, rect.y, min_x, ins)
+      Frame.mode_badge(screen, mode_x, rect.y, min_x, ins)
       update_request_marker_tint
       inner = rect.inset(1, 1)
       @editor.render(screen, inner, cursor: ins, highlight: :request, peek: focused, gauge: true, gauge_focused: focused)

--- a/src/gori/tui/tutorial.cr
+++ b/src/gori/tui/tutorial.cr
@@ -1182,13 +1182,7 @@ module Gori::Tui
       return if rect.w < 8 || rect.h < 3
       Frame.card(screen, rect, "REQUEST", border: Frame.pane_border(focused))
       badge_min = rect.x + 10
-      if insert
-        Frame.toggle_badge(screen, rect.right - 1, rect.y, badge_min, "i", "INS", true)
-      else
-        lbl = " NOR "
-        bx = rect.right - 1 - lbl.size
-        screen.text(bx, rect.y, lbl, Theme.muted, Theme.bg) if bx >= badge_min
-      end
+      Frame.mode_badge(screen, rect.right - 1, rect.y, badge_min, insert)
 
       ix = rect.x + 2
       iw = {rect.w - 4, 1}.max


### PR DESCRIPTION
## Summary
- NOR badge now shows `↵:NOR` so enter-to-insert is discoverable; INS is a plain lit `INS` label (no redundant `i:` chord).
- Centralize the chip in `Frame.mode_badge` / `mode_badge_hit` / `right_badge_edge` and drop the per-view `render_mode_badge` copies.
- Clicking the NOR/INS chip toggles READ↔INS across Repeater, Fuzzer, Decoder, JWT, Notes, Issues notes, and Project description.

## Test plan
- [x] `crystal spec spec/tui/mouse_spec.cr spec/tui/repeater_view_spec.cr`
- [x] `crystal spec spec/tui/fuzzer_view_spec.cr spec/tui/decoder_view_spec.cr spec/tui/notes_view_spec.cr spec/tui/project_view_spec.cr spec/tui/issues_view_spec.cr`
- [x] `crystal build src/main.cr`
- [ ] Manually: focus Repeater REQUEST → confirm `↵:NOR` → click badge → lit `INS` → click again → NOR; same for TARGET and Fuzzer TEMPLATE