### PR TITLE
fix(mcp): start unbound outside Git so install-and-use works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- MCP: start **unbound** outside a Git workspace instead of aborting before the handshake, so `gori mcp --install-*` always connects; agents bind via `list_projects` / `create_project` (auto-binds when unbound) / `switch_project`. Traffic tools return `NO_PROJECT` until bound. Add `--no-project` to force unbound inside a workspace. Unbound never silently opens the active TUI/MRU project (still requires `--use-active-project`).
+
 ## v0.1.1
 
 - Fix wide-character/emoji rendering and caret placement in the TUI editors with a per-grapheme width model (#281, #285, #289, #291)

--- a/docs/content/getting-started/ai-setup.ko.md
+++ b/docs/content/getting-started/ai-setup.ko.md
@@ -36,16 +36,26 @@ gori mcp --install-grok          # Grok
 
 **체크포인트.** 클라이언트가 gori의 도구들(`list_history`, `send_request`, `project_info` 등)을 나열합니다. 나타나지 않으면 클라이언트를 재시작했는지, 그리고 `gori`가 클라이언트가 사용하는 `PATH`에 있는지 확인하세요.
 
-## 2. 올바른 프로젝트 고정하기 {#2-pin-the-right-project}
+## 2. 프로젝트 바인딩 (또는 에이전트가 고르게) {#2-pin-the-right-project}
 
-각 gori 프로젝트는 별도의 데이터베이스이므로, 에이전트가 올바른 것을 제공해야 합니다. 선택자가 없으면 gori는 가장 가까운 Git 워크스페이스를 격리된 프로젝트에 path-bind 합니다. Git 워크스페이스 밖에서 시작하면 무관한 프로젝트를 제공하는 대신 오류를 내며 멈춥니다. 클라이언트가 고정된 디렉터리에서 MCP 서버를 시작한다면, 설치할 때 프로젝트를 고정하세요.
+각 gori 프로젝트는 별도의 데이터베이스입니다. 설치 후 `gori mcp`는 항상 연결됩니다.
+
+| 클라이언트가 MCP를 띄우는 방식 | 동작 |
+|-------------------------------|------|
+| Git 리포지토리 안 | 그 워크스페이스를 자체 gori 프로젝트에 path-bind |
+| Git 밖 (Desktop / 전역 에이전트에서 흔함) | **unbound**로 시작 — 핸드셰이크 성공; 에이전트가 트래픽 도구 전에 `list_projects` / `create_project` / `switch_project` 호출 |
+| `--project` / `--db`로 설치 | 첫 도구 호출부터 그 프로젝트 제공 |
+
+에이전트가 먼저 `project_info`를 호출하게 하세요. `bound`가 false이면 프로젝트를 나열·생성(unbound일 때 create는 자동 바인딩)하거나 switch 한 뒤, bound일 때 이름·DB 경로·선택 출처를 확인한 다음 데이터를 건드리게 합니다.
+
+설치 시점에 고정 engagement를 박아 두려면:
 
 ```bash
 gori mcp --project my-engagement --install-codex     # 이름 붙은 프로젝트의 데이터베이스
 gori mcp --db /path/to/project.db --install-claude-code   # 특정 데이터베이스 파일
 ```
 
-그런 다음 에이전트가 먼저 `project_info`를 호출하게 하세요. 선택된 프로젝트, 데이터베이스 경로, 워크스페이스 루트, 그리고 선택이 이루어진 방식을 보고하므로, 에이전트가 무언가를 건드리기 전에 올바른 데이터를 보고 있는지 확인합니다. 전체 선택 규칙은 [프로젝트 선택](/ko/guide/mcp/#choosing-a-project)에 있습니다.
+전체 선택 규칙은 [프로젝트 선택](/ko/guide/mcp/#choosing-a-project)에 있습니다.
 
 ## 3. 읽기 전용으로 안전하게 넘기기 {#3-hand-off-safely-with-read-only}
 

--- a/docs/content/getting-started/ai-setup.md
+++ b/docs/content/getting-started/ai-setup.md
@@ -36,16 +36,26 @@ Wiring it up by hand instead? The server is just the `gori mcp` command over std
 
 **Checkpoint.** Your client lists gori's tools (`list_history`, `send_request`, `project_info`, and the rest). If they do not appear, confirm the client was restarted and that `gori` is on the `PATH` the client uses.
 
-## 2. Pin the right project
+## 2. Bind a project (or let the agent pick one)
 
-Each gori project is its own database, so the agent has to serve the right one. With no selector, gori path-binds the nearest Git workspace to its own project; started outside a Git workspace it fails closed rather than serving an unrelated project. If your client launches MCP servers from a fixed directory, pin the project when you install:
+Each gori project is its own database. After install, `gori mcp` always connects:
+
+| How the client starts MCP | What happens |
+|---------------------------|--------------|
+| Inside a Git repository | Path-binds that workspace to its own gori project |
+| Outside a Git repository (common for Desktop / global agents) | Starts **unbound** — handshake succeeds; the agent calls `list_projects` / `create_project` / `switch_project` before traffic tools |
+| Installed with `--project` / `--db` | Serves that project from the first tool call |
+
+Have the agent call `project_info` first. When `bound` is false, it should list or create a project (create auto-binds when unbound), then switch if needed. When bound, confirm the name, database path, and selection source before mutating data.
+
+To pin a fixed engagement at install time:
 
 ```bash
 gori mcp --project my-engagement --install-codex     # a named project's database
 gori mcp --db /path/to/project.db --install-claude-code   # a specific database file
 ```
 
-Then have the agent call `project_info` first. It reports the selected project, the database path, the workspace root, and how the selection was made, so the agent confirms it is looking at the right data before touching anything. The full selection rules live in [Choosing a Project](/guide/mcp/#choosing-a-project).
+The full selection rules live in [Choosing a Project](/guide/mcp/#choosing-a-project).
 
 ## 3. Hand off safely with read-only
 

--- a/docs/content/guide/mcp.ko.md
+++ b/docs/content/guide/mcp.ko.md
@@ -38,11 +38,14 @@ cd /path/to/my-repository && gori mcp # path-binds this Git workspace to its own
 gori mcp --project my-engagement   # serve a named project's database
 gori mcp --db /path/to/project.db  # serve a specific database file
 gori mcp --use-active-project      # explicitly serve the active TUI/MRU project
+gori mcp --no-project              # force unbound even inside a Git workspace
 ```
 
-명시적 선택자가 없으면, gori는 가장 가까운 Git 루트를 찾아 그 정규 경로를 격리된 프로젝트에 바인딩합니다. 이 바인딩은 디렉터리 이름이 같은 두 리포지토리가 하나의 데이터베이스를 공유하는 것을 막습니다. 프로세스가 Git 워크스페이스 밖에 있으면, gori는 무관한 활성 프로젝트를 슬그머니 제공하지 않고 오류를 내며 멈춥니다. `--project`, `--db`, `GORI_MCP_PROJECT`, `GORI_MCP_DB`, 또는 명시적 옵트인인 `--use-active-project`를 전달하세요.
+명시적 선택자가 없으면, gori는 가장 가까운 Git 루트를 찾아 그 정규 경로를 격리된 프로젝트에 바인딩합니다. 이 바인딩은 디렉터리 이름이 같은 두 리포지토리가 하나의 데이터베이스를 공유하는 것을 막습니다.
 
-데이터를 사용하기 전에 `project_info`를 호출하세요. 선택된 프로젝트, 데이터베이스 경로, 워크스페이스 루트, 선택 출처를 보고합니다.
+**Git 워크스페이스 밖**에서 뜨면(AI 클라이언트가 홈·앱 디렉터리에서 MCP를 띄우는 흔한 경우) 서버는 **unbound**로 시작합니다. MCP 핸드셰이크와 도구 목록은 바로 성공하지만, 트래픽 도구(`list_history`, `send_request` 등)는 에이전트가 `list_projects`, `create_project`(unbound일 때 자동 바인딩), 또는 `switch_project`를 호출하기 전까지 `NO_PROJECT`를 반환합니다. unbound는 활성 TUI/MRU 프로젝트를 슬그머니 열지 않습니다 — 그건 명시적 `--use-active-project` 옵트인(또는 `--project` / `--db` / `GORI_MCP_PROJECT` / `GORI_MCP_DB`)이 필요합니다.
+
+데이터를 사용하기 전에 `project_info`를 호출하세요. `bound`, 선택된 프로젝트, 데이터베이스 경로, 워크스페이스 루트, 선택 출처를 보고합니다.
 
 ## 읽기 전용 모드 {#read-only-mode}
 
@@ -72,7 +75,7 @@ gori mcp --install-grok
 
 Codex와 Grok은 JSON이 아니라 `[mcp_servers.gori]` 테이블이 있는 TOML을 사용합니다. 설치 후 클라이언트를 재시작하거나 세션을 다시 열어 MCP 서버를 다시 로드하세요.
 
-클라이언트가 리포지토리 디렉터리 밖에서 MCP를 시작한다면, 설치를 프로젝트에 고정하세요. 예: `gori mcp --project my-engagement --install-codex`.
+클라이언트가 리포지토리 디렉터리 밖에서 MCP를 시작해도 서버는 unbound로 연결되며, 에이전트가 도구로 프로젝트를 고르거나 만들 수 있습니다. 설치 시점에 고정 engagement를 박아 두려면 선택자를 넘기세요. 예: `gori mcp --project my-engagement --install-codex`.
 
 ## 도구 {#tools}
 

--- a/docs/content/guide/mcp.md
+++ b/docs/content/guide/mcp.md
@@ -38,11 +38,14 @@ cd /path/to/my-repository && gori mcp # path-binds this Git workspace to its own
 gori mcp --project my-engagement   # serve a named project's database
 gori mcp --db /path/to/project.db  # serve a specific database file
 gori mcp --use-active-project      # explicitly serve the active TUI/MRU project
+gori mcp --no-project              # force unbound even inside a Git workspace
 ```
 
-With no explicit selector, gori discovers the nearest Git root and binds its canonical path to an isolated project. The binding prevents two repositories with the same directory name from sharing a database. If the process is outside a Git workspace, gori fails closed instead of silently serving an unrelated active project; pass `--project`, `--db`, `GORI_MCP_PROJECT`, `GORI_MCP_DB`, or the explicit `--use-active-project` opt-in.
+With no explicit selector, gori discovers the nearest Git root and binds its canonical path to an isolated project. The binding prevents two repositories with the same directory name from sharing a database.
 
-Call `project_info` before using data. It reports the selected project, database path, workspace root, and selection source.
+**Outside a Git workspace** (the common case when an AI client spawns MCP from a home or app directory), the server starts **unbound**: the MCP handshake and tool list succeed immediately, but traffic tools (`list_history`, `send_request`, …) return `NO_PROJECT` until the agent calls `list_projects`, `create_project` (auto-binds when unbound), or `switch_project`. Unbound mode never silently opens the active TUI or MRU project — that requires the explicit `--use-active-project` opt-in (or `--project` / `--db` / `GORI_MCP_PROJECT` / `GORI_MCP_DB`).
+
+Call `project_info` before using data. It reports `bound`, the selected project, database path, workspace root, and selection source.
 
 ## Read-Only Mode
 
@@ -72,7 +75,7 @@ gori mcp --install-grok
 
 Codex and Grok use TOML with an `[mcp_servers.gori]` table (not JSON). Restart the client (or re-open the session) after installing so it reloads MCP servers.
 
-If a client starts MCP outside your repository directory, pin the installation to a project, for example `gori mcp --project my-engagement --install-codex`.
+If a client starts MCP outside your repository directory, the server starts unbound and the agent can pick or create a project over tools. To pin a fixed engagement at install time instead, pass a selector, for example `gori mcp --project my-engagement --install-codex`.
 
 ## Tools
 

--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -433,8 +433,9 @@ MCP stdio 서버입니다. 도구 세부사항은 [MCP 가이드](/ko/guide/mcp/
 | `--db=PATH` | 이 데이터베이스를 제공 (`--project`보다 우선) |
 | `--project=NAME` | 이름이 지정된 프로젝트의 데이터베이스 제공 |
 | `--use-active-project` | Git 워크스페이스 선택을 무시하고 활성 TUI/MRU 프로젝트를 명시적으로 제공 |
+| `--no-project` | Git 워크스페이스 안에서도 unbound로 시작 (에이전트가 list/create/switch로 선택) |
 | `--insecure-upstream` | `send_request`: 업스트림 TLS 검증 생략 |
-| `--read-only` | 액션 도구 비활성화 (`send_request`, 이슈 생성/수정, fuzz/mine) |
+| `--read-only` | 액션 도구 비활성화 (`send_request`, 이슈 생성/수정, fuzz/mine); `switch_project`(및 unbound 시 `create_project`)는 유지 |
 | `--install-claude` | Claude Desktop `mcpServers` 설정 기록 |
 | `--install-claude-code` | Claude Code `~/.claude.json` `mcpServers` 항목 기록 |
 | `--install-codex` | OpenAI Codex `~/.codex/config.toml` `[mcp_servers.gori]` 기록 |

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -433,8 +433,9 @@ MCP stdio server. See the [MCP guide](/guide/mcp/) for tool details.
 | `--db=PATH` | Serve this database (overrides `--project`) |
 | `--project=NAME` | Serve a named project's database |
 | `--use-active-project` | Ignore Git-workspace selection and explicitly serve the active TUI/MRU project |
+| `--no-project` | Start unbound even inside a Git workspace (agent picks via list/create/switch) |
 | `--insecure-upstream` | `send_request`: skip upstream TLS verification |
-| `--read-only` | Disable action tools (`send_request`, create/update issues, fuzz/mine) |
+| `--read-only` | Disable action tools (`send_request`, create/update issues, fuzz/mine); `switch_project` (and `create_project` when unbound) stay available |
 | `--install-claude` | Write Claude Desktop `mcpServers` config |
 | `--install-claude-code` | Write Claude Code `~/.claude.json` `mcpServers` entry |
 | `--install-codex` | Write OpenAI Codex `~/.codex/config.toml` `[mcp_servers.gori]` |

--- a/spec/mcp_project_resolver_spec.cr
+++ b/spec/mcp_project_resolver_spec.cr
@@ -55,7 +55,7 @@ describe Gori::MCP::ProjectResolver do
       before_open = Gori::MCP::ProjectResolver.resolve(nil, nil, cwd: workspace,
         env_db: nil, env_project: nil)
       before_open.db_path.should eq(first.db_path)
-      store = Gori::Store.open(first.db_path)
+      store = Gori::Store.open(first.db_path.not_nil!)
       store.close
 
       second = Gori::MCP::ProjectResolver.resolve(nil, nil, cwd: workspace,
@@ -90,7 +90,7 @@ describe Gori::MCP::ProjectResolver do
 
       first = Gori::MCP::ProjectResolver.resolve(nil, nil, cwd: first_root,
         env_db: nil, env_project: nil)
-      store = Gori::Store.open(first.db_path)
+      store = Gori::Store.open(first.db_path.not_nil!)
       store.close
       second = Gori::MCP::ProjectResolver.resolve(nil, nil, cwd: second_root,
         env_db: nil, env_project: nil)
@@ -131,14 +131,43 @@ describe Gori::MCP::ProjectResolver do
     end
   end
 
-  it "fails closed outside a workspace instead of leaking the MRU project" do
+  it "starts unbound outside a workspace instead of leaking the MRU project" do
     with_isolated_gori_home do |base|
+      Gori::Paths.ensure_dirs
+      registry = Gori::ProjectRegistry.new(Gori::Paths.projects_dir)
+      mru = registry.create("mru engagement")
+      store = Gori::Store.open(mru.db_path)
+      store.close
+      Gori::Paths.write_active_project(mru.db_path)
+
       plain_dir = File.join(base, "not-a-repository")
       Dir.mkdir_p(plain_dir)
-      expect_raises(Gori::MCP::ProjectResolver::Error, /cannot infer a project/) do
-        Gori::MCP::ProjectResolver.resolve(nil, nil, cwd: plain_dir,
-          env_db: nil, env_project: nil)
-      end
+      selected = Gori::MCP::ProjectResolver.resolve(nil, nil, cwd: plain_dir,
+        env_db: nil, env_project: nil)
+      selected.bound?.should be_false
+      selected.db_path.should be_nil
+      selected.source.should eq("unbound")
+      selected.db_path.should_not eq(mru.db_path)
+    end
+  end
+
+  it "still serves the active TUI project when --use-active-project is opted in" do
+    with_isolated_gori_home do |base|
+      Gori::Paths.ensure_dirs
+      registry = Gori::ProjectRegistry.new(Gori::Paths.projects_dir)
+      active = registry.create("active engagement")
+      store = Gori::Store.open(active.db_path)
+      store.close
+      Gori::Paths.write_active_project(active.db_path)
+      plain_dir = File.join(base, "not-a-repository")
+      Dir.mkdir_p(plain_dir)
+
+      selected = Gori::MCP::ProjectResolver.resolve(nil, nil, cwd: plain_dir,
+        workspace_project: false, allow_active_fallback: true,
+        env_db: nil, env_project: nil)
+      selected.bound?.should be_true
+      selected.db_path.should eq(active.db_path)
+      selected.source.should eq("active-tui")
     end
   end
 end

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -1086,6 +1086,7 @@ describe Gori::MCP::Server do
         info = tool_payload(response)
         info["flows"].as_i.should eq(0)
         info["read_only"].as_bool.should be_false
+        info["bound"].as_bool.should be_true
         # Modern MCP clients get parsed data directly; content[0].text remains
         # for backward compatibility.
         response["result"]["structuredContent"]["project"].as_s.should eq("demo")
@@ -1738,9 +1739,10 @@ describe "Gori::MCP::Tools project lifecycle" do
     store = Gori::Store.open(cur_db)
     tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false, db_path: cur_db)
     begin
-      # create two projects
+      # create two projects (already bound → create does NOT auto-switch)
       doomed = JSON.parse(tools.call("create_project", JSON.parse(%({"name":"Doomed","description":"scratch"}))).text)
       doomed["created"].as_bool.should be_true
+      doomed["switched"]?.try(&.as_bool?).should be_false
       doomed_slug = doomed["slug"].as_s
       alt = JSON.parse(tools.call("create_project", JSON.parse(%({"name":"Alt"}))).text)["slug"].as_s
 
@@ -1783,5 +1785,100 @@ describe "Gori::MCP::Tools project lifecycle" do
       prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
       FileUtils.rm_rf(root)
     end
+  end
+end
+
+describe "Gori::MCP::Tools unbound mode" do
+  it "connects without a store, refuses traffic tools, and binds on create" do
+    root = File.tempname("gori-unbound")
+    Dir.mkdir_p(root)
+    prev = ENV["GORI_HOME"]?
+    ENV["GORI_HOME"] = root
+    tools = Gori::MCP::Tools.new(nil, allow_actions: true, verify_upstream: false,
+      selection_source: "unbound")
+    begin
+      info = JSON.parse(tools.call("project_info", JSON.parse("{}")).text)
+      info["bound"].as_bool.should be_false
+      info["selection_source"].as_s.should eq("unbound")
+      info["note"]?.try(&.as_s?).should_not be_nil
+
+      hist = tools.call("list_history", JSON.parse("{}"))
+      hist.is_error.should be_true
+      hist.error_code.should eq("NO_PROJECT")
+
+      # pure tools work unbound
+      dec = tools.call("decode", JSON.parse(%({"input":"aGVsbG8=","spec":"base64-decode"})))
+      dec.is_error.should be_false
+
+      # create auto-binds when unbound
+      created = JSON.parse(tools.call("create_project", JSON.parse(%({"name":"First"}))).text)
+      created["created"].as_bool.should be_true
+      created["switched"].as_bool.should be_true
+
+      info2 = JSON.parse(tools.call("project_info", JSON.parse("{}")).text)
+      info2["bound"].as_bool.should be_true
+      info2["project"].as_s.should eq("First")
+
+      hist2 = tools.call("list_history", JSON.parse("{}"))
+      hist2.is_error.should be_false
+    ensure
+      prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(root)
+    end
+  end
+
+  it "allows switch_project and create_project under read-only when unbound" do
+    root = File.tempname("gori-unbound-ro")
+    Dir.mkdir_p(root)
+    prev = ENV["GORI_HOME"]?
+    ENV["GORI_HOME"] = root
+    # Seed a project via registry so switch has a target without using create.
+    reg = Gori::ProjectRegistry.new(Gori::Paths.projects_dir)
+    seeded = reg.create("Seeded")
+    Gori::Store.open(seeded.db_path).close
+
+    tools = Gori::MCP::Tools.new(nil, allow_actions: false, verify_upstream: false,
+      selection_source: "unbound")
+    begin
+      send = tools.call("send_request", JSON.parse(%({"url":"http://example.test/"})))
+      send.is_error.should be_true
+      # unbound gate fires first for traffic tools that need a project
+      send.error_code.should eq("NO_PROJECT")
+
+      sw = JSON.parse(tools.call("switch_project", JSON.parse(%({"project":"Seeded"}))).text)
+      sw["switched"].as_bool.should be_true
+
+      # after bind, send is still disabled by read-only
+      send2 = tools.call("send_request", JSON.parse(%({"url":"http://example.test/"})))
+      send2.is_error.should be_true
+      send2.error_code.should eq("TOOL_DISABLED")
+
+      # create under read-only is refused once bound
+      cr = tools.call("create_project", JSON.parse(%({"name":"Nope"})))
+      cr.is_error.should be_true
+      cr.error_code.should eq("TOOL_DISABLED")
+    ensure
+      prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(root)
+    end
+  end
+
+  it "handshakes an unbound Server over stdio" do
+    input = IO::Memory.new(%({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"t","version":"0"}}}
+{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
+))
+    output = IO::Memory.new
+    Gori::MCP::Server.new(nil, allow_actions: true, verify_upstream: false,
+      selection_source: "unbound", input: input, output: output).run
+    lines = output.to_s.each_line.reject(&.strip.empty?).map { |l| JSON.parse(l) }.to_a
+    lines.size.should eq(2)
+    init = lines[0]["result"]
+    init["serverInfo"]["name"].as_s.should eq("gori")
+    init["instructions"].as_s.should match(/No project is bound/i)
+    names = lines[1]["result"]["tools"].as_a.map { |t| t["name"].as_s }
+    names.should contain("list_projects")
+    names.should contain("create_project")
+    names.should contain("switch_project")
+    names.should contain("list_history")
   end
 end

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -423,17 +423,20 @@ module Gori
       insecure_upstream = false
       read_only = false
       use_active_project = false
+      no_project = false
       install_target = nil.as(String?)
 
       parser = OptionParser.new do |p|
         p.banner = "Usage: gori mcp [options]\n\n" \
                    "Start an MCP (Model Context Protocol) server over stdio. An AI client\n" \
                    "spawns this and talks JSON-RPC on stdin/stdout. With no --db/--project,\n" \
-                   "a Git workspace is path-bound to its own project. Outside a workspace,\n" \
-                   "choose --project/--db or explicitly pass --use-active-project."
+                   "a Git workspace is path-bound to its own project. Outside a workspace\n" \
+                   "the server starts unbound so the agent can list/create/switch projects.\n" \
+                   "Pass --use-active-project to serve the active TUI/MRU project instead."
         p.on("--db=PATH", "Serve this SQLite db (overrides --project)") { |v| db_path = v }
         p.on("--project=NAME", "Serve a named project's db") { |v| project = v }
         p.on("--use-active-project", "Ignore the current Git workspace and serve the active TUI/MRU project") { use_active_project = true }
+        p.on("--no-project", "Start unbound even inside a Git workspace (agent picks via list/create/switch)") { no_project = true }
         p.on("--insecure-upstream", "send_request: skip upstream TLS verification") { insecure_upstream = true }
         p.on("--read-only", "Disable action tools (send_request, create/update_issue)") { read_only = true }
         p.on("--install-agy", "Install gori as an MCP server in Antigravity (~/.gemini/antigravity-cli/mcp_config.json)") { install_target = "agy" }
@@ -450,6 +453,9 @@ module Gori
       if use_active_project && (db_path.try(&.presence) || project.try(&.presence))
         abort "gori mcp: --use-active-project cannot be combined with --db/--project"
       end
+      if no_project && (db_path.try(&.presence) || project.try(&.presence) || use_active_project)
+        abort "gori mcp: --no-project cannot be combined with --db/--project/--use-active-project"
+      end
 
       if target = install_target
         install_mcp_config(target, db_path, project, read_only, insecure_upstream, use_active_project)
@@ -460,12 +466,27 @@ module Gori
       Log.setup(:info, Log::IOBackend.new(STDERR))
       Settings.load # send_request's repeater engines read the upstream-proxy setting from here
 
-      selection = resolve_mcp_project(db_path, project, workspace_project: !use_active_project,
-        allow_active_fallback: use_active_project)
-      resolved = selection.db_path
+      selection = if no_project
+                    MCP::ProjectResolver::Selection.new(nil, nil, nil, "unbound")
+                  else
+                    resolve_mcp_project(db_path, project,
+                      workspace_project: !use_active_project,
+                      allow_active_fallback: use_active_project)
+                  end
       project_name = selection.project_name
       project_slug = selection.project_slug
       project_id = selection.project_id
+
+      unless selection.bound?
+        Log.info { "mcp: unbound (no project); use list_projects / create_project / switch_project (actions=#{!read_only})" }
+        server = MCP::Server.new(nil, allow_actions: !read_only, verify_upstream: !insecure_upstream,
+          project_name: nil, project_slug: nil, db_path: nil,
+          selection_source: selection.source, workspace_root: nil, project_id: nil)
+        server.run
+        return
+      end
+
+      resolved = selection.db_path.not_nil!
       Log.info { "mcp: serving #{resolved}#{" (#{project_name})" if project_name}#{" [#{project_slug}]" if project_slug} source=#{selection.source} (actions=#{!read_only})" }
       if selection.auto_created
         Log.warn { "mcp: created an isolated project for workspace #{selection.workspace_root}; use --project/--db to override" }

--- a/src/gori/mcp/project_resolver.cr
+++ b/src/gori/mcp/project_resolver.cr
@@ -5,19 +5,24 @@ module Gori
   module MCP
     # Resolves the database an MCP process serves. Explicit CLI/env selectors win;
     # otherwise a process started inside a Git workspace gets a path-bound gori
-    # project. Non-workspace launches fail closed unless the active-TUI fallback
-    # was explicitly requested.
+    # project. Non-workspace launches start *unbound* (no store) so the agent can
+    # list/create/switch projects over MCP — unless the active-TUI fallback was
+    # explicitly requested via --use-active-project.
     # This fail-safe prevents an agent in repository A from silently reading or
     # writing repository B's most-recently-used capture database.
     module ProjectResolver
       record Selection,
-        db_path : String,
+        db_path : String?,
         project_name : String?,
         project_slug : String?,
         source : String,
         workspace_root : String? = nil,
         auto_created : Bool = false,
-        project_id : String? = nil
+        project_id : String? = nil do
+        def bound? : Bool
+          !db_path.nil?
+        end
+      end
 
       class Error < Exception
       end
@@ -57,8 +62,9 @@ module Gori
 
         return active_fallback(registry) if allow_active_fallback
 
-        raise Error.new("cannot infer a project outside a Git workspace; pass --project/--db, " \
-                        "set GORI_MCP_PROJECT/GORI_MCP_DB, or explicitly opt into --use-active-project")
+        # Unbound: MCP handshake succeeds; traffic tools refuse until switch/create.
+        # Never silently adopt the active TUI / MRU project without an explicit opt-in.
+        Selection.new(nil, nil, nil, "unbound")
       end
 
       # Nearest Git worktree root. `.git` may be a directory or a worktree file.

--- a/src/gori/mcp/server.cr
+++ b/src/gori/mcp/server.cr
@@ -27,7 +27,7 @@ module Gori
 
       EMPTY_ARGS = JSON::Any.new({} of String => JSON::Any)
 
-      def initialize(@store : Store, *, allow_actions : Bool, verify_upstream : Bool,
+      def initialize(@store : Store? = nil, *, allow_actions : Bool, verify_upstream : Bool,
                      @project_name : String? = nil, @project_slug : String? = nil,
                      @db_path : String? = nil, @selection_source : String? = nil,
                      @workspace_root : String? = nil, @project_id : String? = nil,
@@ -130,7 +130,12 @@ module Gori
       # exposes — in particular whether the (otherwise simply absent) action tools are
       # disabled by read-only mode, rather than discovering it only on a rejected call.
       private def instructions_text : String
-        selected = if @project_name || @project_slug
+        selected = if @store.nil?
+                     " No project is bound yet. Call list_projects to see available projects, " \
+                     "create_project to make one (auto-binds when unbound), or switch_project " \
+                     "before using traffic tools (list_history, send_request, …). Pure tools " \
+                     "(decode, jwt_*, ql_reference) work immediately."
+                   elsif @project_name || @project_slug
                      " This server is pinned to project #{@project_name || @project_slug}#{" [#{@project_slug}]" if @project_slug}" \
                      " via #{@selection_source || "an explicit database"}#{" for workspace #{@workspace_root}" if @workspace_root}."
                    else
@@ -151,7 +156,8 @@ module Gori
           "allow_unscoped:true. Projects can be managed via list/create/switch/delete_project."
         else
           "#{base} Read-only mode: action tools (send_request, send_websocket, fuzz_*, mine_*, " \
-          "create/update_issue, create/delete_rule) are disabled — restart without --read-only to enable them."
+          "create/update_issue, create/delete_rule) are disabled — restart without --read-only to enable them. " \
+          "switch_project (and create_project when unbound) remain available so you can still pick a project to inspect."
         end
       end
 

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -139,11 +139,15 @@ module Gori
       # the JSON-RPC channel, so truncate the display string and flag it.
       DECODER_MAX_OUTPUT = 256 * 1024
 
-      def initialize(@store : Store, @allow_actions : Bool, @verify_upstream : Bool,
+      # Tools may start *unbound* (`store` nil): project lifecycle + pure-compute tools
+      # work immediately; traffic/action tools return NO_PROJECT until switch/create binds a DB.
+      def initialize(@store : Store?, @allow_actions : Bool, @verify_upstream : Bool,
                      @project_name : String? = nil, @project_slug : String? = nil,
                      @db_path : String? = nil, @selection_source : String? = nil,
                      @workspace_root : String? = nil, @project_id : String? = nil)
-        Env.load_project(@store)
+        if s = @store
+          Env.load_project(s)
+        end
         @jobs = {} of String => FuzzJob
         @mine_jobs = {} of String => MineJob
         @sequence_jobs = {} of String => SequenceJob
@@ -153,10 +157,36 @@ module Gori
         # switch_project reopens @store; @owns_store tracks whether WE opened the
         # current one (and must close it on the next switch). The initial store is
         # owned by the caller (the `gori mcp` command), so it starts false.
+        # When started unbound, every store Tools opens is owned by Tools.
         @owns_store = false
         # Short-lived confirmation tokens issued by delete_project(dry_run) →
         # {db_path, issued_at_ms}. A real delete must present a matching, unexpired one.
         @delete_tokens = {} of String => {String, Int64}
+      end
+
+      # Bound-only helpers call this after the unbound gate; raises only on internal misuse.
+      private def store : Store
+        s = @store
+        raise "internal: tool invoked without a bound project" unless s
+        s
+      end
+
+      private def unbound? : Bool
+        @store.nil?
+      end
+
+      # Tools that work with no project store open.
+      UNBOUND_SAFE = Set{
+        "list_projects", "create_project", "switch_project", "delete_project",
+        "project_info",
+        "decode", "jwt_decode", "jwt_encode", "jwt_attacks",
+        "sequence_analyze", "ql_reference", "ql_explain",
+        "oast_presets", "oast_start", "oast_poll", "oast_payload", "oast_stop",
+      }
+
+      private def no_project : Result
+        err("no project bound; call list_projects, create_project, or switch_project first",
+          "NO_PROJECT")
       end
 
       # Ceiling (seconds) a delete_project dry-run confirmation token stays valid.
@@ -424,8 +454,9 @@ module Gori
 
           tool j, "project_info",
             "Project totals: flow count, issue count, captured bytes, earliest capture time, " \
-            "plus which project/db is being served and how it was selected. Always verify this " \
-            "before reading or mutating security-test data." { }
+            "plus which project/db is being served and how it was selected. When unbound " \
+            "(bound:false), call list_projects / create_project / switch_project first. " \
+            "Always verify this before reading or mutating security-test data." { }
 
           tool j, "get_current_context",
             "What the user is currently viewing in the gori TUI: active tab, focused pane, the " \
@@ -510,7 +541,29 @@ module Gori
           tool j, "list_projects",
             "List gori projects on this host (name, slug, db_path, db_size, last_modified, " \
             "workspace binding) and which one this server is currently serving (current:true). " \
-            "Use switch_project to change the active project." { }
+            "Use switch_project to change the active project. When the server started unbound " \
+            "(no project), call list_projects then create_project or switch_project before " \
+            "traffic tools." { }
+
+          # Project selection is always listed so install-and-use works (and under --read-only
+          # an agent can still pick a project to inspect). create_project is callable when
+          # unbound even under --read-only; once bound it requires allow_actions.
+          if @allow_actions || unbound?
+            tool j, "create_project",
+              "Create a new gori project (or reopen an existing one with the same name). " \
+              "When the server is unbound, create auto-binds to the new project; when already " \
+              "bound, call switch_project to make it active." do |s|
+              s.field "name", strprop("project display name (slugified for its directory)"), required: true
+              s.field "description", strprop("optional description stored in the project settings")
+            end
+          end
+
+          tool j, "switch_project",
+            "Point this server at a different project for all subsequent tools. Always available " \
+            "(including --read-only and when the server started unbound). Refused while a " \
+            "fuzz/mine job is running. Verify with project_info afterwards." do |s|
+            s.field "project", strprop("target project display name or directory slug"), required: true
+          end
 
           tool j, "oast_presets",
             "List built-in public OAST providers (interactsh servers, BOAST, webhook.site, postbin)." { }
@@ -638,19 +691,6 @@ module Gori
 
             tool j, "delete_rule", "Delete a Match & Replace rule by id." do |s|
               s.field "id", intprop("rule id from list_rules"), required: true
-            end
-
-            tool j, "create_project",
-              "Create a new gori project (or reopen an existing one with the same name). " \
-              "Does NOT switch to it — call switch_project to make it active." do |s|
-              s.field "name", strprop("project display name (slugified for its directory)"), required: true
-              s.field "description", strprop("optional description stored in the project settings")
-            end
-
-            tool j, "switch_project",
-              "Point this server at a different project for all subsequent tools. Refused " \
-              "while a fuzz/mine job is running. Verify with project_info afterwards." do |s|
-              s.field "project", strprop("target project display name or directory slug"), required: true
             end
 
             tool j, "delete_project",
@@ -964,6 +1004,9 @@ module Gori
       # an is_error Result so one bad call never tears down the server loop.
       def call(name : String, args : JSON::Any) : Result
         h = args.as_h? || EMPTY_HASH
+        if unbound? && !UNBOUND_SAFE.includes?(name)
+          return no_project
+        end
         result = read_tool(name, h) || action_tool(name, h) ||
                  err("unknown tool: #{name}", "UNKNOWN_TOOL")
         result = classify(result)
@@ -981,9 +1024,10 @@ module Gori
       # Best-effort: feed logging never breaks the tool call it describes.
       private def log_agent_action(name : String, result : Result) : Nil
         return if result.error_code == "TOOL_DISABLED"
+        return unless s = @store
         level = result.is_error ? "warn" : "info"
         outcome = result.is_error ? "failed (#{result.error_code || "error"})" : "ok"
-        @store.insert_event("agent", "agent_action", level, "#{name} #{outcome}", payload: name)
+        s.insert_event("agent", "agent_action", level, "#{name} #{outcome}", payload: name)
       rescue ex
         Log.warn(exception: ex) { "event feed: failed to log agent action #{name}" }
       end
@@ -1087,8 +1131,9 @@ module Gori
         end
       end
 
-      # Action + write tools, each gated behind allow_actions. nil when `name`
-      # isn't one of them.
+      # Action + write tools. Project selection (switch always; create when unbound
+      # or when actions allowed) is not fully blocked by --read-only so install-and-use
+      # works on a fresh machine. nil when `name` isn't one of them.
       private def action_tool(name : String, h) : Result?
         case name
         when "send_request"            then gated { send_request(h) }
@@ -1133,10 +1178,17 @@ module Gori
         when "preview_rule"            then gated { preview_rule(h) }
         when "set_rule_enabled"        then gated { set_rule_enabled(h) }
         when "delete_rule"             then gated { delete_rule(h) }
-        when "create_project"          then gated { create_project(h) }
-        when "switch_project"          then gated { switch_project(h) }
+        # switch is always available (selecting a DB is not a data mutation).
+        when "switch_project"          then switch_project(h)
+        # create when unbound even under --read-only; once bound, actions-gated.
+        when "create_project"          then create_project_entry(h)
         when "delete_project"          then gated { delete_project(h) }
         end
+      end
+
+      private def create_project_entry(h) : Result
+        return create_project(h) if unbound? || @allow_actions
+        err("tool disabled (gori mcp --read-only)", "TOOL_DISABLED")
       end
 
       # Resolve body_mode (none|preview|full) + max_body_bytes into an inlined-body

--- a/src/gori/mcp/tools/context.cr
+++ b/src/gori/mcp/tools/context.cr
@@ -10,7 +10,7 @@ module Gori
       private def list_scope : Result
         Result.new(JSON.build do |j|
           j.array do
-            @store.scope_rules.each do |(id, kind, match_type, pattern)|
+            store.scope_rules.each do |(id, kind, match_type, pattern)|
               j.object do
                 j.field "id", id
                 j.field "kind", kind
@@ -25,6 +25,7 @@ module Gori
       private def project_info : Result
         Result.new(JSON.build do |j|
           j.object do
+            j.field "bound", !unbound?
             j.field "project", @project_name
             j.field "project_slug", @project_slug
             j.field "project_id", @project_id
@@ -33,12 +34,16 @@ module Gori
             j.field "workspace_root", @workspace_root
             j.field "workspace_bound", !@workspace_root.nil?
             j.field "read_only", !@allow_actions
-            j.field "flows", @store.count
-            j.field "issues", @store.count_issues
-            j.field "total_bytes", @store.total_size
-            j.field "earliest_created_at", @store.earliest_created_at
-            if ea = @store.earliest_created_at
-              j.field "earliest_created_at_iso", Serialize.unix_micros_iso(ea)
+            if s = @store
+              j.field "flows", s.count
+              j.field "issues", s.count_issues
+              j.field "total_bytes", s.total_size
+              j.field "earliest_created_at", s.earliest_created_at
+              if ea = s.earliest_created_at
+                j.field "earliest_created_at_iso", Serialize.unix_micros_iso(ea)
+              end
+            else
+              j.field "note", "No project bound. Call list_projects, create_project, or switch_project before traffic tools."
             end
           end
         end)
@@ -50,7 +55,7 @@ module Gori
       # age_seconds (there is no live-TUI heartbeat), not a name comparison that would skew on
       # display-name-vs-slug.
       private def get_current_context : Result
-        raw = @store.setting(Store::UI_STATE_KEY)
+        raw = store.setting(Store::UI_STATE_KEY)
         parsed = raw.try do |r|
           begin
             obj = JSON.parse(r)
@@ -117,7 +122,7 @@ module Gori
         query_str = str(h, "query").try(&.strip)
         query_rx = query_str.try { |q| q.empty? ? nil : Regex.new(Regex.escape(q), Regex::Options::IGNORE_CASE) }
 
-        all_repeaters = @store.repeaters_mcp
+        all_repeaters = store.repeaters_mcp
         if repeater_id && !all_repeaters.any? { |r| r.id == repeater_id }
           return not_found("no repeater with id #{repeater_id}")
         end
@@ -193,7 +198,7 @@ module Gori
 
       private def emit_repeater_sessions(j : JSON::Builder, include_content : Bool = false,
                                          include_sensitive : Bool = false) : Nil
-        @store.repeaters_mcp.each do |r|
+        store.repeaters_mcp.each do |r|
           emit_repeater_session(j, r, include_content, include_sensitive)
         end
       end
@@ -213,7 +218,7 @@ module Gori
           emit_capped_text(j, "request", Serialize.redact_head(r.request, include_sensitive)) if include_content
 
           if Repeater::WsEngine.upgrade_request?(r.request)
-            ws_msgs = @store.ws_messages_for_repeater(r.id)
+            ws_msgs = store.ws_messages_for_repeater(r.id)
             j.field "ws_mode", true
             j.field "ws_message_count", ws_msgs.size
             j.field "ws_messages" do
@@ -276,7 +281,7 @@ module Gori
       end
 
       private def parse_ui_state : JSON::Any?
-        @store.setting(Store::UI_STATE_KEY).try do |r|
+        store.setting(Store::UI_STATE_KEY).try do |r|
           begin
             obj = JSON.parse(r)
             obj if obj.as_h?

--- a/src/gori/mcp/tools/discover.cr
+++ b/src/gori/mcp/tools/discover.cr
@@ -66,7 +66,7 @@ module Gori
           extensions: extensions, containment: containment,
           headers: Discover::Headers.parse_lines(header_lines))
         words = Discover::Wordlist.load(str(h, "wordlist").presence)
-        scope = Scope.load(@store)
+        scope = Scope.load(store)
         policy : Discover::ScopePolicy = scope.configured? ? Discover::StoreScope.new(scope) : Discover::OpenScope.new
         sender = Discover::Sender.new(verify: @verify_upstream && !(bool(h, "insecure") || false), timeout: discover_timeout(h),
           headers: config.headers)
@@ -110,7 +110,7 @@ module Gori
           djob.truncated = true
         end
         pair = Discover::Persist.flow_pair(f, base_ts + djob.results.size)
-        @store.insert_import_batch([{pair.request, pair.response}])
+        store.insert_import_batch([{pair.request, pair.response}])
       rescue
       end
 

--- a/src/gori/mcp/tools/flows.cr
+++ b/src/gori/mcp/tools/flows.cr
@@ -19,7 +19,7 @@ module Gori
         query = str(h, "query")
         filter = ql_filter_or_error(h, query)
         return filter if filter.is_a?(Result)
-        rows = (query && !query.strip.empty?) ? @store.search(filter, limit, before_id, since_id) : @store.recent_flows(limit, before_id, since_id)
+        rows = (query && !query.strip.empty?) ? store.search(filter, limit, before_id, since_id) : store.recent_flows(limit, before_id, since_id)
         Result.new(JSON.build { |j| j.array { rows.each { |r| Serialize.flow_row(j, r) } } })
       end
 
@@ -32,7 +32,7 @@ module Gori
         limit = clamp(int(h, "limit"), 100, 500)
         source = str(h, "source")
         kind = str(h, "kind")
-        scanned = @store.events_after(since, limit)
+        scanned = store.events_after(since, limit)
         next_cursor = scanned.empty? ? since : scanned.last.id
         rows = scanned
         rows = rows.select { |r| r.source == source } if source && !source.empty?
@@ -48,11 +48,11 @@ module Gori
       private def get_flow(h) : Result
         id = int(h, "id")
         return Result.new(id_error(h, "id"), is_error: true) unless id
-        detail = @store.get_flow(id)
+        detail = store.get_flow(id)
         return not_found("no flow with id #{id}") unless detail
         # A WebSocket flow (101) carries a separate message log; fetch it so get_flow
         # surfaces the frames (parity with `gori run show`). Non-WS flows skip the query.
-        ws_msgs = detail.row.status == 101 ? @store.ws_messages(id) : [] of Store::WsMessage
+        ws_msgs = detail.row.status == 101 ? store.ws_messages(id) : [] of Store::WsMessage
         include_sensitive = bool(h, "include_sensitive") || false
         cap, omit = body_return_opts(h)
         Result.new(Serialize.flow_detail_json(detail, ws_msgs, include_sensitive, cap, omit))
@@ -120,11 +120,11 @@ module Gori
 
       private def load_response_body(flow_id : Int64?, repeater_id : Int64?) : {Bytes?, Bytes?} | Result
         if id = flow_id
-          detail = @store.get_flow(id)
+          detail = store.get_flow(id)
           return not_found("no flow with id #{id}") unless detail
           {detail.response_head, detail.response_body}
         elsif id = repeater_id
-          repeater = @store.get_repeater_full(id)
+          repeater = store.get_repeater_full(id)
           return not_found("no repeater with id #{id}") unless repeater
           {repeater.response_head, repeater.response_body}
         else

--- a/src/gori/mcp/tools/fuzz.cr
+++ b/src/gori/mcp/tools/fuzz.cr
@@ -101,7 +101,7 @@ module Gori
       private def record_fuzz_flow(request : Bytes, origin : Fuzz::Origin, http2 : Bool, r : Fuzz::Result) : Int64?
         head, body = split_wire_request(request)
         parsed = Proxy::Codec::Http1.parse_request_head(head)
-        fid = @store.insert_flow(Store::CapturedRequest.new(
+        fid = store.insert_flow(Store::CapturedRequest.new(
           created_at: Time.utc.to_unix_ms * 1000_i64,
           scheme: origin.scheme, host: origin.host, port: origin.port,
           method: parsed.method, target: parsed.target,
@@ -110,12 +110,12 @@ module Gori
         return nil if fid <= 0
         rhead = r.head
         if rhead && !rhead.empty? && (resp = (Proxy::Codec::Http1.parse_response_head(rhead) rescue nil))
-          @store.update_response(FlowMapper.response(resp, flow_id: fid, body: r.body,
+          store.update_response(FlowMapper.response(resp, flow_id: fid, body: r.body,
             duration_us: r.duration_us,
             state: r.error ? Store::FlowState::Error : Store::FlowState::Complete,
             error: r.error, body_size: r.body.try(&.size.to_i64)))
         else
-          @store.update_response(FlowMapper.error_response(fid, r.error || "no response recorded"))
+          store.update_response(FlowMapper.error_response(fid, r.error || "no response recorded"))
         end
         fid
       rescue ex
@@ -259,7 +259,7 @@ module Gori
           return {t, nil, false} unless t.strip.empty?
         end
         if id = int(h, "flow_id")
-          detail = @store.get_flow(id)
+          detail = store.get_flow(id)
           raise FuzzArgError.new("no flow with id #{id}") unless detail
           built = Repeater::FlowRequest.build(detail)
           return {String.new(built.bytes).scrub, built.target, built.http2}

--- a/src/gori/mcp/tools/intercept.cr
+++ b/src/gori/mcp/tools/intercept.cr
@@ -11,7 +11,7 @@ module Gori
       # Parse the bridge blob the capturing TUI publishes (nil when no capturing instance is
       # live / has ever published). See Runner#publish_intercept_bridge.
       private def intercept_bridge_state : Hash(String, JSON::Any)?
-        raw = @store.intercept_bridge
+        raw = store.intercept_bridge
         return nil unless raw
         JSON.parse(raw).as_h?
       rescue
@@ -32,10 +32,10 @@ module Gori
         token = bridge["session_token"]?.try(&.as_s?) || ""
         hb = bridge["heartbeat_ms"]?.try(&.as_i64?) || 0_i64
         now_ms = Time.utc.to_unix_ms
-        items = token.empty? ? [] of Store::HeldRow : @store.intercept_held(token)
+        items = token.empty? ? [] of Store::HeldRow : store.intercept_held(token)
         # Stamp viewed_ms so the capturing instance's auto-forward reaper sees the agent is
         # watching (only meaningful when we can actually act; skip in read-only mode).
-        @store.touch_intercept_held(token, items.map(&.item_id), now_ms) if @allow_actions && !items.empty?
+        store.touch_intercept_held(token, items.map(&.item_id), now_ms) if @allow_actions && !items.empty?
         Result.new(JSON.build do |j|
           j.object do
             j.field "available", true
@@ -61,9 +61,9 @@ module Gori
         bridge = intercept_bridge_state
         return not_found("no capturing gori instance is publishing intercept state") unless bridge
         token = bridge["session_token"]?.try(&.as_s?) || ""
-        row = token.empty? ? nil : @store.intercept_held(token).find { |r| r.item_id == item_id }
+        row = token.empty? ? nil : store.intercept_held(token).find { |r| r.item_id == item_id }
         return not_found("held item #{item_id} is not currently held (already forwarded/dropped, or never held)") unless row
-        @store.touch_intercept_held(token, [row.item_id], Time.utc.to_unix_ms) if @allow_actions
+        store.touch_intercept_held(token, [row.item_id], Time.utc.to_unix_ms) if @allow_actions
         Result.new(JSON.build { |j| Serialize.intercept_item_detail(j, row, include_sensitive, Time.utc.to_unix_ms) })
       end
 
@@ -138,14 +138,14 @@ module Gori
           return busy("no live capturing gori instance is draining intercept commands (open the project's TUI with intercept on)")
         end
         token = bridge["session_token"]?.try(&.as_s?)
-        id = @store.enqueue_intercept_command(token, verb, item_id: item_id, bytes: bytes, arg: arg)
+        id = store.enqueue_intercept_command(token, verb, item_id: item_id, bytes: bytes, arg: arg)
         return busy("could not enqueue intercept command (store write dropped); retry") if id == 0
         await_intercept_ack(id)
       end
 
       private def await_intercept_ack(id : Int64) : Result
         INTERCEPT_ACK_POLLS.times do
-          if st = @store.command_status(id)
+          if st = store.command_status(id)
             return intercept_ack_result(st[0], st[1]) unless st[0] == "pending"
           end
           sleep INTERCEPT_ACK_SLEEP

--- a/src/gori/mcp/tools/issues.cr
+++ b/src/gori/mcp/tools/issues.cr
@@ -11,11 +11,11 @@ module Gori
         req_lim = int(h, "limit")
         offset = clamp_nonneg(req_off)
         limit = clamp(req_lim, 100, 500)
-        all = @store.issues
+        all = store.issues
         page = all[offset, limit]? || [] of Store::Issue
         Result.new(JSON.build do |j|
           j.object do
-            j.field("issues") { j.array { page.each { |f| Serialize.issue(j, f, @store) } } }
+            j.field("issues") { j.array { page.each { |f| Serialize.issue(j, f, store) } } }
             j.field "returned", page.size
             j.field "offset", offset
             j.field "limit", limit
@@ -29,9 +29,9 @@ module Gori
       private def get_issue(h) : Result
         id = int(h, "id")
         return Result.new(id_error(h, "id"), is_error: true) unless id
-        f = @store.get_issue(id)
+        f = store.get_issue(id)
         return not_found("no issue with id #{id}") unless f
-        Result.new(JSON.build { |j| Serialize.issue(j, f, @store) })
+        Result.new(JSON.build { |j| Serialize.issue(j, f, store) })
       end
 
       private def create_issue(h) : Result
@@ -55,18 +55,18 @@ module Gori
         return Result.new("invalid 'flow_id' (expected an integer)", is_error: true) if flow_id.nil? && present?(h, "flow_id")
         repeater_id = int(h, "repeater_id")
         return Result.new(id_error(h, "repeater_id"), is_error: true) if repeater_id.nil? && present?(h, "repeater_id")
-        if repeater_id && !@store.get_repeater(repeater_id)
+        if repeater_id && !store.get_repeater(repeater_id)
           return not_found("no repeater with id #{repeater_id}")
         end
 
         host = str(h, "host").try { |hst| Env.mask_secrets(hst) }
-        id = @store.insert_issue(masked_title, severity, host, flow_id)
+        id = store.insert_issue(masked_title, severity, host, flow_id)
         # insert_issue returns 0 (never raises) when the write batch fails — e.g.
         # the cross-process SQLite lock couldn't be acquired (a TUI capturing into
         # the same project) or the disk is full. Don't report a phantom success.
         return busy("failed to persist issue (store busy or unwritable)") if id == 0
         if repeater_id
-          @store.add_link(Store::LinkOwnerKind::Issue, id,
+          store.add_link(Store::LinkOwnerKind::Issue, id,
             Store::LinkRefKind::Repeater, repeater_id)
         end
         Result.new(JSON.build do |j|
@@ -80,7 +80,7 @@ module Gori
       private def update_issue(h) : Result
         id = int(h, "id")
         return Result.new(id_error(h, "id"), is_error: true) unless id
-        return not_found("no issue with id #{id}") unless @store.get_issue(id)
+        return not_found("no issue with id #{id}") unless store.get_issue(id)
         # A blank severity/status means "leave unchanged"; only a present,
         # non-blank, unrecognised value is an error.
         sev_s = str(h, "severity")
@@ -99,7 +99,7 @@ module Gori
         status = status_from(stat_s)
         repeater_id = int(h, "repeater_id")
         return Result.new(id_error(h, "repeater_id"), is_error: true) if repeater_id.nil? && present?(h, "repeater_id")
-        if repeater_id && !@store.get_repeater(repeater_id)
+        if repeater_id && !store.get_repeater(repeater_id)
           return not_found("no repeater with id #{repeater_id}")
         end
 
@@ -111,10 +111,10 @@ module Gori
         end
 
         unless title.nil? && severity.nil? && notes.nil? && status.nil?
-          @store.update_issue(id, title: title, severity: severity, notes: notes, status: status)
+          store.update_issue(id, title: title, severity: severity, notes: notes, status: status)
         end
         if repeater_id
-          @store.add_link(Store::LinkOwnerKind::Issue, id,
+          store.add_link(Store::LinkOwnerKind::Issue, id,
             Store::LinkRefKind::Repeater, repeater_id)
         end
         Result.new(JSON.build do |j|

--- a/src/gori/mcp/tools/mine.cr
+++ b/src/gori/mcp/tools/mine.cr
@@ -176,7 +176,7 @@ module Gori
           return {Env.expand_wire(t), nil, false} unless t.strip.empty?
         end
         if id = int(h, "flow_id")
-          detail = @store.get_flow(id)
+          detail = store.get_flow(id)
           raise FuzzArgError.new("no flow with id #{id}") unless detail
           built = Repeater::FlowRequest.build(detail)
           return {Env.expand_wire(String.new(built.bytes)), Env.expand(built.target), built.http2}

--- a/src/gori/mcp/tools/notes.cr
+++ b/src/gori/mcp/tools/notes.cr
@@ -5,7 +5,7 @@ module Gori
   module MCP
     class Tools
       private def list_notes : Result
-        doc = Notes.load(@store)
+        doc = Notes.load(store)
         Result.new(JSON.build do |j|
           j.object do
             j.field "cur", doc.cur
@@ -28,7 +28,7 @@ module Gori
       private def get_note(h) : Result
         id = int(h, "id")
         return Result.new(id_error(h, "id"), is_error: true) unless id
-        doc = Notes.load(@store)
+        doc = Notes.load(store)
         entry = doc.notes.find { |n| n.id == id }
         return not_found("no note with id #{id}") unless entry
         idx = doc.notes.index(entry).not_nil!
@@ -44,7 +44,7 @@ module Gori
 
       private def create_note(h) : Result
         text = str(h, "text") || ""
-        doc = Notes.load(@store)
+        doc = Notes.load(store)
         new_id = doc.next_id
         new_entry = Notes::NoteEntry.new(new_id, text)
         new_notes = doc.notes + [new_entry]
@@ -52,7 +52,7 @@ module Gori
         new_next_id = new_id + 1
 
         serialized = Notes.serialize(new_cur, new_notes, new_next_id)
-        @store.set_setting(Notes::DOCS_KEY, serialized)
+        store.set_setting(Notes::DOCS_KEY, serialized)
 
         Result.new(JSON.build do |j|
           j.object do
@@ -68,7 +68,7 @@ module Gori
         text = str(h, "text")
         return Result.new("missing 'text' parameter", is_error: true) unless text
 
-        doc = Notes.load(@store)
+        doc = Notes.load(store)
         entry_idx = doc.notes.index { |n| n.id == id }
         return not_found("no note with id #{id}") unless entry_idx
 
@@ -77,7 +77,7 @@ module Gori
         new_notes[entry_idx] = updated_entry
 
         serialized = Notes.serialize(doc.cur, new_notes, doc.next_id)
-        @store.set_setting(Notes::DOCS_KEY, serialized)
+        store.set_setting(Notes::DOCS_KEY, serialized)
 
         Result.new(JSON.build do |j|
           j.object do
@@ -91,7 +91,7 @@ module Gori
         id = int(h, "id")
         return Result.new(id_error(h, "id"), is_error: true) unless id
 
-        doc = Notes.load(@store)
+        doc = Notes.load(store)
         entry_idx = doc.notes.index { |n| n.id == id }
         return not_found("no note with id #{id}") unless entry_idx
 
@@ -100,7 +100,7 @@ module Gori
         new_cur = doc.cur.clamp(0, {new_notes.size - 1, 0}.max)
 
         serialized = Notes.serialize(new_cur, new_notes, doc.next_id)
-        @store.set_setting(Notes::DOCS_KEY, serialized)
+        store.set_setting(Notes::DOCS_KEY, serialized)
 
         Result.new(JSON.build do |j|
           j.object do

--- a/src/gori/mcp/tools/projects.cr
+++ b/src/gori/mcp/tools/projects.cr
@@ -26,9 +26,11 @@ module Gori
       private def list_projects : Result
         reg = registry
         projects = reg.list
+        current = @db_path
         Result.new(JSON.build do |j|
           j.object do
-            j.field "current_db_path", @db_path
+            j.field "bound", !unbound?
+            j.field "current_db_path", current
             j.field "projects_root", Paths.projects_dir
             j.field("projects") do
               j.array do
@@ -39,7 +41,7 @@ module Gori
                     j.field "slug", reg.slug_of(p)
                     j.field "db_path", p.db_path
                     j.field "db_size", p.db_size
-                    j.field "current", p.db_path == @db_path
+                    j.field "current", !current.nil? && p.db_path == current
                     j.field "workspace", reg.workspace_of(p)
                     if lm = p.last_modified
                       j.field "last_modified", lm.to_unix
@@ -63,6 +65,16 @@ module Gori
         # Materialize the DB (create+migrate) so the project is immediately visible
         # to list_projects/switch_project even when no description was supplied.
         Store.open(proj.db_path).close unless File.exists?(proj.db_path)
+
+        # First-run UX: when the server has no project yet, bind immediately so the
+        # agent can use traffic tools without a separate switch_project call.
+        auto_bound = false
+        if unbound?
+          bind = bind_project(proj, reg, source: "create_project")
+          return bind if bind.is_error
+          auto_bound = true
+        end
+
         Result.new(JSON.build do |j|
           j.object do
             j.field "name", proj.name
@@ -70,6 +82,7 @@ module Gori
             j.field "slug", reg.slug_of(proj)
             j.field "db_path", proj.db_path
             j.field "created", !existed # false = reopened an existing same-name project
+            j.field "switched", auto_bound
           end
         end)
       rescue ex : Gori::Error
@@ -84,12 +97,21 @@ module Gori
         return not_found("no such project: #{name} (match short id, id prefix, dir slug, or display name)") unless proj
         return busy("cannot switch project while a fuzz/mine job is running; stop it first") if jobs_running?
 
+        bind_project(proj, reg, source: "switch_project")
+      end
+
+      # Open *proj* as the server's store and update selection metadata.
+      # Closes a Tools-owned previous store; never closes a CLI-owned initial store
+      # unless Tools already took ownership via a prior switch.
+      private def bind_project(proj : Project, reg : ProjectRegistry, *, source : String) : Result
         new_store = begin
           Store.open(proj.db_path)
         rescue ex
           return err("could not open project database: #{ex.message}", "INTERNAL")
         end
-        @store.close if @owns_store # never close the caller-owned initial store
+        if @owns_store
+          @store.try(&.close)
+        end
         @store = new_store
         @owns_store = true
         @project_name = proj.name
@@ -97,8 +119,8 @@ module Gori
         @project_id = reg.id_of(proj)
         @db_path = proj.db_path
         @workspace_root = reg.workspace_of(proj)
-        @selection_source = "switch_project"
-        Env.load_project(@store)
+        @selection_source = source
+        Env.load_project(new_store)
         Result.new(JSON.build do |j|
           j.object do
             j.field "switched", true
@@ -106,8 +128,9 @@ module Gori
             j.field "project_slug", @project_slug
             j.field "project_id", @project_id
             j.field "db_path", @db_path
-            j.field "flows", @store.count
-            j.field "issues", @store.count_issues
+            j.field "flows", new_store.count
+            j.field "issues", new_store.count_issues
+            j.field "selection_source", source
           end
         end)
       end

--- a/src/gori/mcp/tools/repeater.cr
+++ b/src/gori/mcp/tools/repeater.cr
@@ -15,7 +15,7 @@ module Gori
         request = str(h, "request")
 
         if issue_id
-          issue = @store.get_issue(issue_id)
+          issue = store.get_issue(issue_id)
           return not_found("no issue with id #{issue_id}") unless issue
           if fid = issue.flow_id
             flow_id = fid
@@ -31,7 +31,7 @@ module Gori
         ws_messages_override = nil.as(Array(String)?)
 
         if flow_id
-          flow = @store.get_flow(flow_id)
+          flow = store.get_flow(flow_id)
           return not_found("no flow with id #{flow_id}") unless flow
 
           if target.nil? || target.empty?
@@ -55,7 +55,7 @@ module Gori
           end
 
           if flow.row.status == 101 && !present?(h, "ws_out_messages")
-            ws_messages_override = @store.ws_messages(flow_id).select { |m| m.direction == "out" && m.text? }.map { |m| String.new(m.payload).scrub }
+            ws_messages_override = store.ws_messages(flow_id).select { |m| m.direction == "out" && m.text? }.map { |m| String.new(m.payload).scrub }
           end
         end
 
@@ -67,7 +67,7 @@ module Gori
         position = int(h, "position")
         if position.nil?
           return Result.new(id_error(h, "position"), is_error: true) if present?(h, "position") # present but non-integer
-          position = @store.repeaters_meta.size.to_i64
+          position = store.repeaters_meta.size.to_i64
         elsif position < Int32::MIN || position > Int32::MAX
           return Result.new("'position' out of range", is_error: true)
         end
@@ -81,7 +81,7 @@ module Gori
         # WebSocket mode check
         is_ws = Repeater::WsEngine.upgrade_request?(masked_request)
 
-        id = @store.insert_repeater(
+        id = store.insert_repeater(
           target: masked_target,
           request: masked_request,
           http2: http2,
@@ -94,12 +94,12 @@ module Gori
         return busy("failed to persist repeater (store busy or unwritable)") if id == 0
 
         if issue_id
-          @store.add_link(Store::LinkOwnerKind::Issue, issue_id,
+          store.add_link(Store::LinkOwnerKind::Issue, issue_id,
             Store::LinkRefKind::Repeater, id)
         end
 
         if name && !name.empty?
-          @store.set_repeater_name(id, name)
+          store.set_repeater_name(id, name)
         end
 
         # WebSocket messages handling
@@ -116,7 +116,7 @@ module Gori
           end
 
           unless messages.empty?
-            @store.update_repeater_ws_messages(id, messages)
+            store.update_repeater_ws_messages(id, messages)
           end
         end
 
@@ -143,7 +143,7 @@ module Gori
         id = int(h, "id")
         return Result.new("missing or invalid required 'id'", is_error: true) unless id
 
-        existing = @store.get_repeater(id)
+        existing = store.get_repeater(id)
         return not_found("no repeater with id #{id}") unless existing
 
         target = str(h, "target") || existing.target
@@ -172,7 +172,7 @@ module Gori
         masked_sni = sni.try { |s| Env.mask_secrets(s) }
         name = present?(h, "name") ? str(h, "name").try { |n| Env.mask_secrets(n) } : existing.name
 
-        @store.update_repeater(
+        store.update_repeater(
           id: id,
           target: masked_target,
           request: masked_request,
@@ -182,7 +182,7 @@ module Gori
         )
 
         if present?(h, "name")
-          @store.set_repeater_name(id, name)
+          store.set_repeater_name(id, name)
         end
 
         # WebSocket messages handling
@@ -194,7 +194,7 @@ module Gori
             messages = str_val.split('\n').compact_map { |l| l.strip.empty? ? nil : l }
           end
 
-          @store.update_repeater_ws_messages(id, messages)
+          store.update_repeater_ws_messages(id, messages)
         end
 
         # Derive summary
@@ -219,10 +219,10 @@ module Gori
         id = int(h, "id")
         return Result.new("missing or invalid required 'id'", is_error: true) unless id
 
-        existing = @store.get_repeater(id)
+        existing = store.get_repeater(id)
         return not_found("no repeater with id #{id}") unless existing
 
-        @store.delete_repeater(id)
+        store.delete_repeater(id)
         Result.new(JSON.build { |j| j.object { j.field "success", true } })
       end
     end

--- a/src/gori/mcp/tools/rules.cr
+++ b/src/gori/mcp/tools/rules.cr
@@ -5,7 +5,7 @@ module Gori
   module MCP
     class Tools
       private def list_rules : Result
-        rules = @store.match_rules
+        rules = store.match_rules
         Result.new(JSON.build do |j|
           j.object do
             j.field "count", rules.size
@@ -63,7 +63,7 @@ module Gori
         # Atomic disabled creation: insert already-disabled so there is no window
         # where a just-created rule is live before a follow-up disable call.
         enabled = bool_arg(h, "enabled", true)
-        id = @store.insert_rule(target, part, pattern, replacement, op, match_kind, name, host, enabled)
+        id = store.insert_rule(target, part, pattern, replacement, op, match_kind, name, host, enabled)
         return busy("failed to persist rule (store busy or unwritable)") if id == 0
         Result.new(JSON.build do |j|
           j.object do
@@ -82,7 +82,7 @@ module Gori
       private def update_rule(h) : Result
         id = int(h, "id")
         return err(id_error(h, "id"), "INVALID_ARGUMENT", field: "id") unless id
-        existing = @store.match_rules.find { |r| r.id == id }
+        existing = store.match_rules.find { |r| r.id == id }
         return not_found("no rule with id #{id}") unless existing
         tp = rule_target_part(h, existing.target, existing.part)
         return tp if tp.is_a?(Result)
@@ -99,10 +99,10 @@ module Gori
         replacement = present?(h, "replacement") ? (str(h, "replacement") || "") : existing.replacement
         name = present?(h, "name") ? (str(h, "name") || "") : existing.name
         host = present?(h, "host") ? (str(h, "host") || "") : existing.host
-        @store.update_rule(id, target, part, pattern, replacement, op, match_kind, name, host)
+        store.update_rule(id, target, part, pattern, replacement, op, match_kind, name, host)
         if present?(h, "enabled")
           en = bool_arg(h, "enabled", existing.enabled?)
-          @store.set_rule_enabled(id, en)
+          store.set_rule_enabled(id, en)
         end
         Result.new(JSON.build do |j|
           j.object do
@@ -135,7 +135,7 @@ module Gori
         host = str(h, "host") || ""
         candidate = Store::MatchRule.new(0_i64, true, target, part, pattern, replacement, op, match_kind, "", host)
         # Reuse the engine's preview over a throwaway Rules bound only to the store.
-        pv = Gori::Rules.new(@store, [] of Store::MatchRule).preview(candidate)
+        pv = Gori::Rules.new(store, [] of Store::MatchRule).preview(candidate)
         Result.new(JSON.build do |j|
           j.object do
             j.field "target", target.label
@@ -204,7 +204,7 @@ module Gori
         enabled = bool(h, "enabled")
         return Result.new("missing required 'enabled' (true|false)", is_error: true) if enabled.nil?
         return not_found("no rule with id #{id}") unless rule_exists?(id)
-        @store.set_rule_enabled(id, enabled)
+        store.set_rule_enabled(id, enabled)
         Result.new(JSON.build { |j| j.object { j.field "id", id; j.field "enabled", enabled } })
       end
 
@@ -212,7 +212,7 @@ module Gori
         id = int(h, "id")
         return Result.new(id_error(h, "id"), is_error: true) unless id
         return not_found("no rule with id #{id}") unless rule_exists?(id)
-        @store.delete_rule(id)
+        store.delete_rule(id)
         Result.new(JSON.build { |j| j.object { j.field "id", id; j.field "deleted", true } })
       end
 
@@ -220,7 +220,7 @@ module Gori
       # single-row rule fetch), but the rule set is tiny and enable/disable/delete
       # are low-frequency actions.
       private def rule_exists?(id : Int64) : Bool
-        @store.match_rules.any? { |r| r.id == id }
+        store.match_rules.any? { |r| r.id == id }
       end
     end
   end

--- a/src/gori/mcp/tools/send.cr
+++ b/src/gori/mcp/tools/send.cr
@@ -84,7 +84,7 @@ module Gori
         return err(id_error(h, "issue_id"), "INVALID_ARGUMENT", field: "issue_id") if issue_id.nil? && present?(h, "issue_id")
         if issue_id
           return err("issue_id requires save_as_repeater=true", "INVALID_ARGUMENT", field: "issue_id") unless save
-          return not_found("no issue with id #{issue_id}") unless @store.get_issue(issue_id)
+          return not_found("no issue with id #{issue_id}") unless store.get_issue(issue_id)
         end
         issue_id
       end
@@ -135,26 +135,26 @@ module Gori
         flow_id = int(h, "flow_id") || recorded_flow_id
         masked_target = Env.mask_secrets(target_url)
         masked_req = Env.mask_secrets(String.new(built.bytes))
-        repeater_id = @store.insert_repeater(
+        repeater_id = store.insert_repeater(
           target: masked_target,
           request: masked_req,
           http2: http2,
           auto_cl: true,
           flow_id: flow_id,
-          position: @store.repeaters_meta.size.to_i32,
+          position: store.repeaters_meta.size.to_i32,
           sni: nil
         )
         return nil unless repeater_id > 0
 
-        @store.add_link(Store::LinkOwnerKind::Issue, issue_id,
+        store.add_link(Store::LinkOwnerKind::Issue, issue_id,
           Store::LinkRefKind::Repeater, repeater_id) if issue_id
         if (name = str(h, "name")) && !name.empty?
-          @store.set_repeater_name(repeater_id, Env.mask_secrets(name))
+          store.set_repeater_name(repeater_id, Env.mask_secrets(name))
         end
 
         # Persist whatever was received even when framing failed after the
         # response head. This keeps partial evidence and enables paged reads.
-        @store.update_repeater_response(repeater_id, result.head, result.body,
+        store.update_repeater_response(repeater_id, result.head, result.body,
           result.error, result.duration_us)
         if result.response
           probe_scan_saved_repeater(repeater_id, masked_target, masked_req, http2, flow_id,
@@ -178,7 +178,7 @@ module Gori
           body: body,
           body_size: body.try(&.size.to_i64),
         )
-        id = @store.insert_flow(captured)
+        id = store.insert_flow(captured)
         if id <= 0
           raise Gori::Error.new("could not record outbound request in History; pass record_history=false only if an unaudited send is intentional")
         end
@@ -190,7 +190,7 @@ module Gori
           error = result.error
           error ||= "upstream response body was incomplete" if result.incomplete?
           state = error ? Store::FlowState::Error : Store::FlowState::Complete
-          @store.update_response(FlowMapper.response(response,
+          store.update_response(FlowMapper.response(response,
             flow_id: flow_id,
             body: result.body,
             duration_us: result.duration_us,
@@ -198,7 +198,7 @@ module Gori
             error: error,
             body_size: result.body.try(&.size.to_i64)))
         else
-          @store.update_response(FlowMapper.error_response(flow_id,
+          store.update_response(FlowMapper.error_response(flow_id,
             result.error || "request failed before a response was received", result.duration_us))
         end
       rescue ex
@@ -268,7 +268,7 @@ module Gori
       private def send_websocket(h) : Result
         repeater_id = int(h, "repeater_id")
         return Result.new(id_error(h, "repeater_id"), is_error: true) unless repeater_id
-        repeater = @store.get_repeater(repeater_id)
+        repeater = store.get_repeater(repeater_id)
         return not_found("no repeater with id #{repeater_id}") unless repeater
         unless Repeater::WsEngine.upgrade_request?(repeater.request)
           return Result.new("repeater #{repeater_id} is not a WebSocket upgrade request", is_error: true)
@@ -278,7 +278,7 @@ module Gori
         return Result.new(id_error(h, "issue_id"), is_error: true) if issue_id.nil? && present?(h, "issue_id")
         # Validate the issue now, but DON'T create the link yet — it must not persist
         # if the scope gate below refuses the send. The link is created after the gate.
-        return not_found("no issue with id #{issue_id}") if issue_id && !@store.get_issue(issue_id)
+        return not_found("no issue with id #{issue_id}") if issue_id && !store.get_issue(issue_id)
 
         idle_ms = int(h, "idle_ms")
         return Result.new(id_error(h, "idle_ms"), is_error: true) if idle_ms.nil? && present?(h, "idle_ms")
@@ -295,7 +295,7 @@ module Gori
                          end
                          parsed
                        else
-                         @store.ws_messages_for_repeater(repeater_id).compact_map do |m|
+                         store.ws_messages_for_repeater(repeater_id).compact_map do |m|
                            next unless m.direction == "out"
                            payload = m.text? ? Env.expand(String.new(m.payload).scrub).to_slice : m.payload
                            Repeater::WsEngine::OutMsg.new(m.opcode, payload)
@@ -310,7 +310,7 @@ module Gori
         return scope_blocked(sc) if sc.blocked
         # Scope passed — now it's safe to persist the issue link.
         if issue_id
-          @store.add_link(Store::LinkOwnerKind::Issue, issue_id,
+          store.add_link(Store::LinkOwnerKind::Issue, issue_id,
             Store::LinkRefKind::Repeater, repeater_id)
         end
         verify = @verify_upstream && !(bool(h, "insecure") || false)
@@ -319,7 +319,7 @@ module Gori
         result = Repeater::WsEngine.send(request, out_messages,
           scheme: scheme, host: host, port: port, verify_upstream: verify, sni: sni, idle: idle)
 
-        @store.update_repeater_response(repeater_id, result.handshake_head, Bytes.empty,
+        store.update_repeater_response(repeater_id, result.handshake_head, Bytes.empty,
           result.error, result.duration_us)
         Log.info { "send_websocket #{scheme}://#{host}:#{port} repeater_id=#{repeater_id} -> #{result.ok? ? "ok" : result.error}" }
 
@@ -379,7 +379,7 @@ module Gori
         if present?(h, "repeater_id")
           id = int(h, "repeater_id")
           raise Gori::Error.new(id_error(h, "repeater_id")) unless id
-          rec = @store.get_repeater(id)
+          rec = store.get_repeater(id)
           raise Gori::Error.new("no repeater with id #{id}") unless rec
           if Repeater::WsEngine.upgrade_request?(rec.request)
             raise Gori::Error.new("repeater #{id} is a WebSocket upgrade — use send_websocket")
@@ -398,7 +398,7 @@ module Gori
         if present?(h, "flow_id")
           id = int(h, "flow_id")
           raise Gori::Error.new(id_error(h, "flow_id")) unless id
-          detail = @store.get_flow(id)
+          detail = store.get_flow(id)
           raise Gori::Error.new("no flow with id #{id}") unless detail
           flow = Repeater::FlowRequest.build(detail)
           # Re-sync Content-Length after expansion (a body `$KEY` changes its length).
@@ -429,7 +429,7 @@ module Gori
       #     guardrail at all), so an active request needs an explicit opt-in.
       # in_scope requests always proceed and carry the matched rule id.
       private def scope_check(url : String, host : String, allow_unscoped : Bool) : ScopeCheck
-        scope = Scope.load(@store)
+        scope = Scope.load(store)
         return ScopeCheck.new("unscoped", host, nil, !allow_unscoped) unless scope.configured?
         if scope.matches_url?(url, host)
           rid = scope.rules.find { |r| r.include? && r.matches?(url, host) }.try(&.id)
@@ -460,14 +460,14 @@ module Gori
       private def probe_scan_saved_repeater(repeater_id : Int64, target : String, request : String,
                                             http2 : Bool, flow_id : Int64?, head : Bytes, body : Bytes?,
                                             duration_us : Int64) : Nil
-        return unless @store.probe_mode.scanning?
+        return unless store.probe_mode.scanning?
         return if head.empty?
         rec = Store::RepeaterRecord.new(
           repeater_id, target, request, http2, true, flow_id, 0,
           head, body, nil, duration_us, nil, nil)
         return unless detail = Probe.detail_from_repeater(rec)
         Probe::Passive.analyze(detail).each do |d|
-          @store.upsert_probe_issue(Probe.with_source(d, flow_id: flow_id, repeater_id: repeater_id))
+          store.upsert_probe_issue(Probe.with_source(d, flow_id: flow_id, repeater_id: repeater_id))
         end
       rescue
         # Probe must never break send_request

--- a/src/gori/mcp/tools/sitemap.cr
+++ b/src/gori/mcp/tools/sitemap.cr
@@ -11,7 +11,7 @@ module Gori
         filter = ql_filter_or_error(h, query)
         return filter if filter.is_a?(Result)
         return collapsed_sitemap(filter, limit) if bool(h, "collapse_transport") || false
-        entries = @store.sitemap_entries_detailed(filter, limit)
+        entries = store.sitemap_entries_detailed(filter, limit)
         Result.new(JSON.build do |j|
           j.array do
             entries.each do |e|
@@ -39,7 +39,7 @@ module Gori
       # The legacy collapsed sitemap (distinct host/method/target only), for
       # collapse_transport:true.
       private def collapsed_sitemap(filter : QL::Filter, limit : Int32) : Result
-        entries = @store.sitemap_entries(filter, limit)
+        entries = store.sitemap_entries(filter, limit)
         Result.new(JSON.build do |j|
           j.array do
             entries.each do |(host, method, target)|

--- a/src/gori/paths.cr
+++ b/src/gori/paths.cr
@@ -36,9 +36,10 @@ module Gori
     end
 
     # A tiny global marker holding the DB PATH of the project the interactive TUI last
-    # opened. Headless integrations use this only after an explicit opt-in (for MCP,
-    # `--use-active-project`); a source workspace must never silently inherit another
-    # repository's active project. Path (not name) avoids display-name/slug ambiguity.
+    # opened. Headless MCP uses this only after an explicit opt-in (`--use-active-project`);
+    # otherwise MCP outside a Git workspace starts unbound so the agent can list/create/
+    # switch. A source workspace must never silently inherit another repository's active
+    # project. Path (not name) avoids display-name/slug ambiguity.
     def self.active_project_file : String
       File.join(home_dir, "active_project")
     end


### PR DESCRIPTION
## Summary

- Outside a Git workspace (the common case when AI clients spawn MCP from home/app dirs), `gori mcp` now starts **unbound** instead of aborting before `initialize`.
- Agents bind via `list_projects` / `create_project` (auto-binds when unbound) / `switch_project`; traffic tools return `NO_PROJECT` until bound.
- Unbound never silently opens the active TUI/MRU project (`--use-active-project` remains an explicit opt-in).
- Add `--no-project` to force unbound even inside a Git workspace.
- Docs (en/ko) and CHANGELOG updated for the install-and-use flow.

## Why

`gori mcp --install-*` writes plain `args = ["mcp"]`. Clients often start the server outside a repo, so project inference failed and the connection died with EOF — contradicting “install and use.”

## Test plan

- [x] `crystal spec spec/mcp_project_resolver_spec.cr spec/mcp_spec.cr spec/mcp_install_spec.cr` (155 examples)
- [x] Smoke: non-git cwd `gori mcp` accepts `initialize`; `project_info` reports `bound:false`
- [x] Unbound → `create_project` auto-binds → `list_history` works
- [x] Read-only unbound: `switch_project` works; `send_request` stays `TOOL_DISABLED` after bind
- [x] Git workspace path-bind and `--use-active-project` unchanged