### PR TITLE
fix(tui): clickable OAST callbacks, pane navigation, Rewriter preview

### DIFF
--- a/spec/rules_spec.cr
+++ b/spec/rules_spec.cr
@@ -131,10 +131,10 @@ describe Gori::Rules do
 
       req = "GET / HTTP/1.1\r\nHost: a\r\nUser-Agent: curl/8\r\nCookie: sid=1\r\n\r\n".to_slice
       out = String.new(rules.rewrite_request(req, ""))
-      out.should contain("X-Trace: on")       # added before the blank line
-      out.should contain("User-Agent: gori")  # value replaced, original name casing kept
-      out.should_not contain("Cookie:")        # removed
-      out.should contain("Host: a")            # untouched
+      out.should contain("X-Trace: on")      # added before the blank line
+      out.should contain("User-Agent: gori") # value replaced, original name casing kept
+      out.should_not contain("Cookie:")      # removed
+      out.should contain("Host: a")          # untouched
     end
   end
 
@@ -163,6 +163,31 @@ describe Gori::Rules do
       String.new(rules.rewrite_request(req, "api.example.com")).should contain("X-Env: prod")
       # a non-matching host is byte-identical (same slice returned)
       rules.rewrite_request(req, "other.test").should eq(req)
+    end
+  end
+
+  it "transforms a full HTTP message for the live preview (head + body seams)" do
+    with_store do |store|
+      rules = Gori::Rules.load(store)
+      rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head,
+        "Host: example.com", "Host: evil.test")
+      rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Body,
+        "hello", "hola")
+      sample = "GET / HTTP/1.1\r\nHost: example.com\r\n\r\nhello world"
+      out = rules.transform_message(sample, Gori::Store::RuleTarget::Request, "example.com")
+      out.should contain("Host: evil.test")
+      out.should contain("hola world")
+      out.should_not contain("hello world")
+      # disabled rules are skipped
+      id = rules.rules.find(&.part.body?).not_nil!.id
+      rules.toggle(id)
+      out2 = rules.transform_message(sample, Gori::Store::RuleTarget::Request, "example.com")
+      out2.should contain("hello world")
+      # response rules do not touch a request preview
+      rules.add(Gori::Store::RuleTarget::Response, Gori::Store::RulePart::Body, "hello", "nope")
+      out3 = rules.transform_message(sample, Gori::Store::RuleTarget::Request, "example.com")
+      out3.should contain("hello world")
+      out3.should_not contain("nope")
     end
   end
 end

--- a/src/gori/rules.cr
+++ b/src/gori/rules.cr
@@ -125,6 +125,32 @@ module Gori
       apply(entity, Store::RuleTarget::Response, Store::RulePart::Body, @resp_body_count, host)
     end
 
+    # Live preview for the Rewriter tab: apply every enabled rule for `target` over a
+    # full HTTP message (head + body split on the first blank line). Host-scoped rules
+    # use `host` (typically parsed from the sample's Host header). Empty host → only
+    # unscoped rules match. Order matches the proxy path (head rules then body rules).
+    def transform_message(text : String, target : Store::RuleTarget, host : String = "") : String
+      head, body, sep = split_message(text)
+      new_head = String.new(apply(head.to_slice, target, Store::RulePart::Head,
+        target.request? ? @req_head_count : @resp_head_count, host))
+      new_body = String.new(apply(body.to_slice, target, Store::RulePart::Body,
+        target.request? ? @req_body_count : @resp_body_count, host))
+      "#{new_head}#{sep}#{new_body}"
+    end
+
+    # Split an HTTP message into {head, body, separator}. Separator is "\r\n\r\n" or
+    # "\n\n" when a blank line exists; otherwise the whole text is the head and sep/body
+    # are empty (so header-only samples still rewrite).
+    private def split_message(text : String) : {String, String, String}
+      if idx = text.index("\r\n\r\n")
+        {text[0, idx], text[idx + 4..], "\r\n\r\n"}
+      elsif idx = text.index("\n\n")
+        {text[0, idx], text[idx + 2..], "\n\n"}
+      else
+        {text, "", ""}
+      end
+    end
+
     # Apply every enabled rule for {target, part} that also matches `host` over the bytes.
     # Returns the SAME bytes when nothing is configured or nothing is in scope (byte-
     # fidelity, P7). A no-op replace re-serializes to an equal slice (as it always has for

--- a/src/gori/tui/controllers/jwt_controller.cr
+++ b/src/gori/tui/controllers/jwt_controller.cr
@@ -80,9 +80,9 @@ module Gori::Tui
     def body_badge : Symbol
       s = cur
       editing = case s.pane
-                when :input            then s.input_mode == InputMode::Insert
+                when :input                     then s.input_mode == InputMode::Insert
                 when :header, :payload, :secret then true
-                else                        false
+                else                                 false
                 end
       editing ? :editor : :body
     end
@@ -287,8 +287,8 @@ module Gori::Tui
       return handle_input_read(ev, c) unless s.input_mode == InputMode::Insert
       key = ev.key
       case
-      when ev.ctrl_z?    then s.input.undo; recompute_decode(s)
-      when key.enter?    then s.input.insert_newline; recompute_decode(s)
+      when ev.ctrl_z?     then s.input.undo; recompute_decode(s)
+      when key.enter?     then s.input.insert_newline; recompute_decode(s)
       when key.backspace? then s.input.backspace; recompute_decode(s)
       when key.up?
         s.input.at_top? ? cross_pane(s, -1) : s.input.move(-1, 0)
@@ -388,11 +388,14 @@ module Gori::Tui
       s = cur
       key = ev.key
       at_top = which == :decoded ? s.view.decoded_at_top? : s.view.output_at_top?
+      at_bottom = which == :decoded ? s.view.decoded_at_bottom? : s.view.output_at_bottom?
       case
       when key.up?, key.lower_k?
         at_top ? cross_pane(s, -1) : scroll_pane(s, which, -1)
       when key.down?, key.lower_j?
-        scroll_pane(s, which, 1)
+        # At bottom (or content fits): leave DECODED → ATTACKS. OUTPUT is last in ENCODE
+        # so cross_pane is a no-op past the end — same as ↑/↓ on a fully-visible card.
+        at_bottom ? cross_pane(s, 1) : scroll_pane(s, which, 1)
       when (c = ev.char || key.to_char) && !ev.ctrl? && !ev.alt? && !c.control?
         return false # y + Global breath → keymap
       end

--- a/src/gori/tui/controllers/oast_controller.cr
+++ b/src/gori/tui/controllers/oast_controller.cr
@@ -771,7 +771,89 @@ module Gori::Tui
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
       @host.focus_body
+      content = BodyChrome.content_rect(rect, strip: true)
+      if callbacks_sub?
+        click_callbacks(content, mx, my)
+      else
+        click_providers(content, mx, my)
+      end
       true
+    end
+
+    # Callbacks list: filter bar starts `/` edit; rows use History/Probe select-first
+    # (first click selects, second click on the selected row opens detail — same as ↵).
+    # Detail view itself is key-driven (like Probe).
+    private def click_callbacks(content : Rect, mx : Int32, my : Int32) : Nil
+      return if @cb_detail
+      return if content.h < 2
+      # payload bar (2 rows) — no row action; body is the filter + table card below
+      body = Rect.new(content.x, content.y + 2, content.w, content.h - 2)
+      return if body.h < 1
+      table = if body.h >= 2
+        if my == body.y
+          start_cb_filter unless @filter_editing
+          return
+        end
+        Rect.new(body.x, body.y + 1, body.w, body.h - 1)
+      else
+        body
+      end
+      return unless idx = callback_row_at(table, mx, my)
+      @filter_editing = false # a row click commits the filter, like History's list click
+      if idx == @cb_sel
+        @cb_detail = true
+        @cb_detail_scroll = 0
+      else
+        @cb_sel = idx
+        sync_scroll
+      end
+    end
+
+    # Hit-test a click against the CALLBACKS table card (mirrors render_callback_table).
+    private def callback_row_at(table : Rect, mx : Int32, my : Int32) : Int32?
+      return nil if table.empty? || !table.contains?(mx, my)
+      inner = table.inset(1, 1)
+      rows = Rect.new(inner.x, inner.y + 1, inner.w, {inner.h - 1, 0}.max)
+      return nil if rows.empty? || my < rows.y || my >= rows.bottom
+      return nil if mx < rows.x || mx >= rows.right
+      visible = rows.h
+      return nil if visible <= 0
+      ordered = ordered_callbacks
+      scroll = @cb_scroll
+      scroll = @cb_sel if @cb_sel < scroll
+      scroll = @cb_sel - visible + 1 if @cb_sel >= scroll + visible
+      scroll = scroll.clamp(0, {ordered.size - visible, 0}.max)
+      abs = scroll + (my - rows.y)
+      abs >= 0 && abs < ordered.size ? abs : nil
+    end
+
+    # Providers list: select-first; a second click on the selected row opens the editor (↵/e).
+    private def click_providers(content : Rect, mx : Int32, my : Int32) : Nil
+      return unless idx = provider_row_at(content, mx, my)
+      if idx == @prov_sel
+        open_edit_provider
+      else
+        @prov_sel = idx
+      end
+    end
+
+    # Hit-test a click against the PROVIDERS table card (mirrors render_providers).
+    private def provider_row_at(content : Rect, mx : Int32, my : Int32) : Int32?
+      return nil if content.empty? || !content.contains?(mx, my)
+      inner = content.inset(1, 1)
+      rows = Rect.new(inner.x, inner.y + 1, inner.w, {inner.h - 1, 0}.max)
+      return nil if rows.empty? || my < rows.y || my >= rows.bottom
+      return nil if mx < rows.x || mx >= rows.right
+      visible = rows.h
+      return nil if visible <= 0
+      scroll = @prov_scroll
+      if visible > 0
+        scroll = @prov_sel if @prov_sel < scroll
+        scroll = @prov_sel - visible + 1 if @prov_sel >= scroll + visible
+      end
+      scroll = scroll.clamp(0, {@providers.size - visible, 0}.max)
+      abs = scroll + (my - rows.y)
+      abs >= 0 && abs < @providers.size ? abs : nil
     end
 
     def handle_wheel(step : Int32) : Bool

--- a/src/gori/tui/controllers/rewriter_controller.cr
+++ b/src/gori/tui/controllers/rewriter_controller.cr
@@ -1,20 +1,27 @@
 require "../tab_controller"
 require "../rewriter_view"
+require "../text_area"
 require "../../store"
 require "../../rules"
 
 module Gori::Tui
   # The Rewriter tab: manage the project's Match & Replace rules (the shared Rules engine
-  # the proxy reads live). A single global list — no sub-tabs. The body is a navigable
-  # list; add/edit opens the RewriterRuleOverlay (a modal, wired in the runner like the
-  # Probe custom-rule editor). Rules do far more than the old palette overlay: literal or
-  # regex replace on head/body, add/set/remove header by name, and an optional host scope.
+  # the proxy reads live). A global list on top + a Caido-style live preview pair below
+  # (editable sample HTTP | transformed by enabled rules). Add/edit opens the
+  # RewriterRuleOverlay (modal, wired in the runner like the Probe custom-rule editor).
   class RewriterController < TabController
+    # Default sample so a new project can demo head/body/header rules without pasting.
+    DEFAULT_SAMPLE = "GET /index.html HTTP/1.1\r\nHost: example.com\r\nUser-Agent: gori\r\nCookie: session=REPLACE_ME\r\n\r\nhello world\r\n"
+
     def initialize(host : Host)
       super(host)
       @view = RewriterView.new
       @sel = 0
       @scroll = 0
+      @focus = :list # :list | :preview_in | :preview_out
+      @preview_input = TextArea.new(DEFAULT_SAMPLE)
+      @out_scroll = 0
+      @last_body = Rect.new(0, 0, 0, 0) # last content rect — click/wheel geometry
     end
 
     def tab : Symbol
@@ -26,7 +33,7 @@ module Gori::Tui
     end
 
     def body_badge : Symbol
-      :body
+      @focus == :preview_in ? :editor : :body
     end
 
     private def rules_engine : Rules
@@ -54,24 +61,19 @@ module Gori::Tui
     # --- render ---
     def render_body(screen : Screen, rect : Rect, focus : Symbol) : Nil
       body_focused = focus == :body
-      shell = BodyChrome.shell_focused(focus, multi_pane: false)
+      shell = BodyChrome.shell_focused(focus, multi_pane: true)
       BodyChrome.framed(screen, rect, shell) do |inner|
+        @last_body = inner
         list = rule_list
         @sel = @sel.clamp(0, {list.size - 1, 0}.max)
         ensure_visible(inner, list.size)
-        @view.render(screen, inner, list, @sel, @scroll, rules_engine.enabled_count, body_focused, rules_engine.active?)
+        @view.render(screen, inner, list, @sel, @scroll, rules_engine.enabled_count,
+          @focus, body_focused, rules_engine.active?, @preview_input, preview_output, @out_scroll)
       end
     end
 
-    # Rows visible in the list area (inner minus header, minus the live note row).
-    private def list_height(inner : Rect) : Int32
-      h = inner.h - RewriterView::HEADER_H
-      h -= 1 if rules_engine.active?
-      {h, 0}.max
-    end
-
     private def ensure_visible(inner : Rect, count : Int32) : Nil
-      lh = list_height(inner)
+      lh = @view.list_row_capacity(inner, rules_engine.active?)
       return if lh <= 0
       if @sel < @scroll
         @scroll = @sel
@@ -81,18 +83,53 @@ module Gori::Tui
       @scroll = @scroll.clamp(0, {count - lh, 0}.max)
     end
 
+    # Enabled rules applied to the sample (request side; host from Host: header).
+    private def preview_output : String
+      text = @preview_input.text
+      host = host_from_sample(text)
+      rules_engine.transform_message(text, Store::RuleTarget::Request, host)
+    end
+
+    private def host_from_sample(text : String) : String
+      text.each_line do |ln|
+        # Allow both "Host:" and "host:" (HTTP/2-style lowercasing in samples).
+        if ln.size >= 5 && ln[0, 5].downcase == "host:"
+          return ln[5..].strip
+        end
+      end
+      ""
+    end
+
     # --- keys ---
     def handle_body_key(ev : Termisu::Event::Key) : Bool
+      case @focus
+      when :preview_in  then handle_preview_in_key(ev)
+      when :preview_out then handle_preview_out_key(ev)
+      else                   handle_list_key(ev)
+      end
+    end
+
+    private def handle_list_key(ev : Termisu::Event::Key) : Bool
       key = ev.key
       c = ev.char || key.to_char
       case
       when key.space? && !ev.ctrl? && !ev.alt? then @host.open_space_menu
       when key.up?, c == 'k'                   then move_up
-      when key.down?, c == 'j'                 then move_sel(1)
+      when key.down?, c == 'j'                 then list_down
       when key.escape?                         then @host.request_focus(:menu)
       else                                          return handle_action_key(ev, c)
       end
       true
+    end
+
+    # ↓ past the last rule (or empty list) enters the preview input when shown.
+    private def list_down : Nil
+      n = rule_list.size
+      if n == 0 || @sel >= n - 1
+        enter_preview_in if preview_available?
+      else
+        move_sel(1)
+      end
     end
 
     # ↑/k at the top of the list releases focus back to the tab bar (like the Intercept
@@ -105,7 +142,6 @@ module Gori::Tui
       end
     end
 
-    # The rule-action keys, split out to keep handle_body_key's branching low.
     private def handle_action_key(ev : Termisu::Event::Key, c : Char?) : Bool
       key = ev.key
       case
@@ -120,23 +156,113 @@ module Gori::Tui
       true
     end
 
+    private def handle_preview_in_key(ev : Termisu::Event::Key) : Bool
+      key = ev.key
+      ed = @preview_input
+      case
+      when key.escape?
+        @focus = :list
+      when key.up?
+        ed.at_top? ? (@focus = :list) : ed.move(-1, 0)
+      when key.down?
+        ed.at_bottom? ? (@focus = :preview_out) : ed.move(1, 0)
+      when key.left?
+        ed.at_start? ? (@focus = :list) : ed.move(0, -1)
+      when key.right?
+        ed.move(0, 1)
+      when key.enter?
+        ed.insert_newline
+      when key.backspace?
+        ed.backspace
+      when key.delete?
+        ed.delete
+      when key.home?
+        ed.home
+      when key.end?
+        ed.end_of_line
+      when ev.ctrl_z?
+        ed.undo
+      else
+        if (c = ev.char || key.to_char) && !ev.ctrl? && !ev.alt? && !c.control?
+          ed.insert(c)
+          ed.set_preedit("")
+        elsif key.space? && !ev.ctrl? && !ev.alt?
+          @host.open_space_menu
+        else
+          return false
+        end
+      end
+      true
+    end
+
+    private def handle_preview_out_key(ev : Termisu::Event::Key) : Bool
+      key = ev.key
+      case
+      when key.escape?, key.left? then @focus = :preview_in
+      when key.up?, key.lower_k?
+        if @out_scroll <= 0
+          @focus = :preview_in
+        else
+          @out_scroll = {@out_scroll - 1, 0}.max
+        end
+      when key.down?, key.lower_j?
+        @out_scroll += 1
+      when key.space? && !ev.ctrl? && !ev.alt?
+        @host.open_space_menu
+      else
+        return false
+      end
+      true
+    end
+
     private def move_sel(d : Int32) : Nil
       n = rule_list.size
       return if n == 0
       @sel = (@sel + d).clamp(0, n - 1)
     end
 
+    private def preview_available? : Bool
+      return false if @last_body.empty?
+      @view.preview_shown?(@last_body)
+    end
+
+    private def enter_preview_in : Nil
+      return unless preview_available?
+      @focus = :preview_in
+    end
+
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
       @host.focus_body
       inner = BodyChrome.frame_inner(rect)
-      if idx = @view.row_at(inner, mx, my, @scroll, rule_list.size, rules_engine.active?)
-        @sel = idx
+      @last_body = inner
+      case @view.pane_at(inner, mx, my)
+      when :list
+        @focus = :list
+        if idx = @view.row_at(inner, mx, my, @scroll, rule_list.size, rules_engine.active?)
+          @sel = idx
+        end
+      when :preview_in
+        @focus = :preview_in
+        body = @view.preview_input_body(inner)
+        @preview_input.click_to_cursor(body, mx, my) unless body.empty?
+      when :preview_out
+        @focus = :preview_out
       end
       true
     end
 
     def handle_wheel(step : Int32) : Bool
-      move_sel(step)
+      case @focus
+      when :preview_in  then @preview_input.scroll_view(step)
+      when :preview_out then @out_scroll = {@out_scroll + step, 0}.max
+      else                   move_sel(step)
+      end
+      true
+    end
+
+    def set_preedit(text : String) : Bool
+      return false unless @focus == :preview_in
+      @preview_input.set_preedit(text)
       true
     end
 
@@ -204,7 +330,14 @@ module Gori::Tui
     end
 
     def body_hint(focus : Symbol) : String
-      "↑/↓ select · a add · ↵/e edit · x on/off · d delete · ⇧J/⇧K reorder · space cmds · esc tabs"
+      case @focus
+      when :preview_in
+        "type sample HTTP · ↑ list · ↓/→ output · esc list"
+      when :preview_out
+        "↑/↓ scroll · ← input · esc input"
+      else
+        "↑/↓ select · ↓ preview · a add · ↵/e edit · x on/off · d delete · ⇧J/⇧K reorder · space cmds · esc tabs"
+      end
     end
   end
 end

--- a/src/gori/tui/controllers/sequencer_controller.cr
+++ b/src/gori/tui/controllers/sequencer_controller.cr
@@ -80,8 +80,8 @@ module Gori::Tui
       v = current_view
       return "↹/esc tabs · send a request here (space → Send to Sequencer) or a selection" unless v
       case v.focus
-      when :samples  then "↑/↓ select · ↵ detail · ^X stop · c config · space cmds · ↹ pane · esc tabs"
-      when :analysis then "↑/↓ scroll · ^R run · c config · ↹ pane · esc tabs"
+      when :samples  then "↑/↓ select · → analysis · ↵ detail · ^X stop · c config · space cmds · ↹ pane · esc tabs"
+      when :analysis then "↑/↓ scroll · ← samples · ^R run · c config · ↹ pane · esc tabs"
       when :detail   then "↑/↓ scroll · esc back"
       else                "^R run · c config · space cmds · ↹ pane · esc tabs"
       end
@@ -190,17 +190,33 @@ module Gori::Tui
     private def handle_samples(ev : Termisu::Event::Key, v : SequencerView) : Nil
       key = ev.key
       case
-      when key.enter?              then v.open_detail
-      when key.down?, key.lower_j? then v.samples_move(1)
-      when key.up?, key.lower_k?   then v.samples_at_top? ? v.focus_pane(:config) : v.samples_move(-1)
+      when key.enter? then v.open_detail
+      when key.right?
+        v.focus_pane(:analysis) # side-by-side: cross to Analysis; stacked: still the next pane
+      when key.down?, key.lower_j?
+        # Stacked layout: ↓ past the last sample drops into Analysis below.
+        if !v.side_by_side? && v.samples_at_bottom?
+          v.focus_pane(:analysis)
+        else
+          v.samples_move(1)
+        end
+      when key.up?, key.lower_k? then v.samples_at_top? ? v.focus_pane(:config) : v.samples_move(-1)
       end
     end
 
     private def handle_analysis(ev : Termisu::Event::Key, v : SequencerView) : Nil
       key = ev.key
-      if key.up? || key.lower_k?
-        v.analysis_scroll(-1)
-      elsif key.down? || key.lower_j?
+      case
+      when key.left?
+        v.focus_pane(:samples)
+      when key.up?, key.lower_k?
+        if v.analysis_at_top?
+          # Side-by-side: up leaves to Config; stacked: Analysis sits under Samples.
+          v.focus_pane(v.side_by_side? ? :config : :samples)
+        else
+          v.analysis_scroll(-1)
+        end
+      when key.down?, key.lower_j?
         v.analysis_scroll(1)
       end
     end

--- a/src/gori/tui/jwt_view.cr
+++ b/src/gori/tui/jwt_view.cr
@@ -24,8 +24,10 @@ module Gori::Tui
 
     @dec_scroll : Int32 = 0
     @dec_h : Int32 = 0
+    @dec_lines : Int32 = 0
     @out_scroll : Int32 = 0
     @out_h : Int32 = 0
+    @out_lines : Int32 = 0
     @atk_sel : Int32 = 0
     @atk_scroll : Int32 = 0
     @atk_h : Int32 = 0
@@ -71,6 +73,7 @@ module Gori::Tui
       render_input(screen, input_c, input, focused && pane == :input, input_mode, input_read) unless input_c.empty?
       unless dec_c.empty?
         lines = decoded_lines(decoded)
+        @dec_lines = lines.size
         @dec_h, @dec_scroll = draw_text_card(screen, dec_c, "DECODED", lines, @dec_scroll, focused && pane == :decoded)
       end
       render_attacks(screen, atk_c, attacks, focused && pane == :attacks) unless atk_c.empty?
@@ -88,6 +91,7 @@ module Gori::Tui
       render_secret(screen, sec_c, secret, secret_cx, secret_pre, alg, focused && pane == :secret) unless sec_c.empty?
       unless out_c.empty?
         out_lines = output_ok ? output.split('\n') : ["✗ #{output}"]
+        @out_lines = out_lines.size
         title = "OUTPUT#{output_ok ? "" : "  ✗ invalid JSON"}"
         @out_h, @out_scroll = draw_text_card(screen, out_c, title, out_lines, @out_scroll,
           focused && pane == :output, fg: output_ok ? Theme.text : Theme.red)
@@ -247,8 +251,20 @@ module Gori::Tui
       @dec_scroll <= 0
     end
 
+    # True when the DECODED card has no more lines below the viewport (or content fits).
+    # A short decode uses this so ↓ leaves to ATTACKS instead of a no-op scroll.
+    def decoded_at_bottom? : Bool
+      return true if @dec_h <= 0
+      @dec_scroll >= {@dec_lines - @dec_h, 0}.max
+    end
+
     def output_at_top? : Bool
       @out_scroll <= 0
+    end
+
+    def output_at_bottom? : Bool
+      return true if @out_h <= 0
+      @out_scroll >= {@out_lines - @out_h, 0}.max
     end
 
     def attacks_at_top? : Bool

--- a/src/gori/tui/rewriter_view.cr
+++ b/src/gori/tui/rewriter_view.cr
@@ -1,43 +1,97 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./text_area"
 require "../store"
 
 module Gori::Tui
-  # The Rewriter tab body: a scrollable list of Match & Replace rules in apply order.
-  # Stateless — the controller owns selection/scroll and passes them in. One row per rule:
-  #   ▎ ✓  REQ  sub/H  [name]  @host  pattern → value
-  # The op tag encodes op + part + match kind (sub/re = literal/regex replace on H/B head/
-  # body; +hdr / ~hdr / -hdr = add / set / remove header).
+  # The Rewriter tab body: a scrollable Match & Replace rule list on top, and a
+  # Caido-style live preview pair underneath (editable sample HTTP | transformed).
+  # Stateless for the list (controller owns selection/scroll); layout helpers keep
+  # render and click hit-tests on the same geometry.
   class RewriterView
-    # Height reserved above the list (the count header) and below (the h2-downgrade note).
-    HEADER_H = 1
+    # Minimum heights before the preview pair is shown (narrow terminals keep the list only).
+    LIST_MIN_H    = 4
+    PREVIEW_MIN_H = 6
+
+    # Split the body into {list, preview_in, preview_out}. Empty preview rects when
+    # the body is too short to host both a usable list and a preview pair.
+    def layout(rect : Rect) : {Rect, Rect, Rect}
+      empty = Rect.new(rect.x, rect.y, 0, 0)
+      return {rect, empty, empty} if rect.w < 20 || rect.h < LIST_MIN_H + PREVIEW_MIN_H
+      list_h = {rect.h * 45 // 100, LIST_MIN_H}.max
+      list_h = {list_h, rect.h - PREVIEW_MIN_H}.min
+      preview_h = rect.h - list_h
+      list = Rect.new(rect.x, rect.y, rect.w, list_h)
+      prev = Rect.new(rect.x, rect.y + list_h, rect.w, preview_h)
+      mid = {prev.w // 2, 10}.max
+      mid = prev.w - 10 if mid > prev.w - 10 && prev.w >= 20
+      in_r = Rect.new(prev.x, prev.y, mid, prev.h)
+      out_r = Rect.new(prev.x + mid, prev.y, {prev.w - mid, 0}.max, prev.h)
+      {list, in_r, out_r}
+    end
+
+    def preview_shown?(rect : Rect) : Bool
+      _, pin, _ = layout(rect)
+      pin.w > 0 && pin.h > 0
+    end
+
+    # Which pane contains (mx,my): :list | :preview_in | :preview_out | nil.
+    def pane_at(rect : Rect, mx : Int32, my : Int32) : Symbol?
+      list, pin, pout = layout(rect)
+      return :list if list.contains?(mx, my)
+      return :preview_in if pin.w > 0 && pin.contains?(mx, my)
+      return :preview_out if pout.w > 0 && pout.contains?(mx, my)
+      nil
+    end
 
     def render(screen : Screen, rect : Rect, rules : Array(Store::MatchRule), sel : Int32,
-               scroll : Int32, enabled_count : Int32, focused : Bool, live : Bool) : Nil
+               scroll : Int32, enabled_count : Int32, focus : Symbol, body_focused : Bool,
+               live : Bool, preview_input : TextArea, preview_output : String,
+               out_scroll : Int32) : Nil
       return if rect.w < 6 || rect.h < 2
-      meta = "#{enabled_count}/#{rules.size} enabled"
-      screen.text(rect.x + 1, rect.y, "MATCH & REPLACE", Theme.accent, Theme.bg)
-      screen.text({rect.right - meta.size - 1, rect.x + 17}.max, rect.y, meta, Theme.muted, Theme.bg)
+      list_r, pin_r, pout_r = layout(rect)
+      render_list(screen, list_r, rules, sel, scroll, enabled_count,
+        body_focused && focus == :list, live)
+      unless pin_r.empty?
+        render_preview_input(screen, pin_r, preview_input, body_focused && focus == :preview_in)
+        render_preview_output(screen, pout_r, preview_output, out_scroll,
+          body_focused && focus == :preview_out)
+      end
+    end
 
-      list_top = rect.y + HEADER_H
-      list_h = rect.bottom - list_top
+    private def render_list(screen : Screen, rect : Rect, rules : Array(Store::MatchRule),
+                            sel : Int32, scroll : Int32, enabled_count : Int32,
+                            focused : Bool, live : Bool) : Nil
+      return if rect.w < 6 || rect.h < 2
+      Frame.card(screen, rect, "MATCH & REPLACE", bg: Theme.bg, border: Frame.pane_border(focused))
+      meta = "#{enabled_count}/#{rules.size} enabled"
+      # Count rides the top border (right of the title), not a list row.
+      if rect.w > meta.size + 20
+        screen.text({rect.right - meta.size - 2, rect.x + 18}.max, rect.y, meta, Theme.muted, Theme.bg)
+      end
+      inner = rect.inset(1, 1)
+      return if inner.empty?
+
+      # Rows fill the card interior. Optional live note on the last row.
+      list_top = inner.y
+      list_h = inner.h
       if live && list_h > 1
-        note = "note: an enabled rule forces HTTP/1.1 on matching hosts (h2 heads bypass the rewrite seam)"
-        screen.text(rect.x + 1, rect.bottom - 1, note, Theme.muted, Theme.bg, width: rect.w - 2)
+        note = "h2 hosts with a live rule fall back to HTTP/1.1"
+        screen.text(inner.x, inner.bottom - 1, note, Theme.muted, Theme.bg, width: inner.w)
         list_h -= 1
       end
 
       if rules.empty?
-        screen.text(rect.x + 2, list_top, "no rules — press a to add  ·  add/remove headers, regex replace, host scope",
-          Theme.muted, Theme.bg, width: rect.w - 3)
+        screen.text(inner.x, list_top, "no rules — press a to add",
+          Theme.muted, Theme.bg, width: inner.w)
         return
       end
 
       (0...list_h).each do |i|
         idx = scroll + i
         break if idx >= rules.size
-        render_row(screen, rect, rules[idx], list_top + i, idx == sel, focused)
+        render_row(screen, inner, rules[idx], list_top + i, idx == sel, focused)
       end
     end
 
@@ -71,6 +125,30 @@ module Gori::Tui
       screen.text(x, py, desc, fg, bg, width: {rect.right - x, 1}.max) if x < rect.right
     end
 
+    private def render_preview_input(screen : Screen, rect : Rect, ed : TextArea, focused : Bool) : Nil
+      return if rect.w < 4 || rect.h < 2
+      Frame.card(screen, rect, "PREVIEW INPUT", bg: Theme.bg, border: Frame.pane_border(focused))
+      body = rect.inset(1, 1)
+      return if body.empty?
+      ed.render(screen, body, cursor: focused, highlight: :request, gauge: true, gauge_focused: focused)
+    end
+
+    private def render_preview_output(screen : Screen, rect : Rect, text : String,
+                                      scroll : Int32, focused : Bool) : Nil
+      return if rect.w < 4 || rect.h < 2
+      Frame.card(screen, rect, "PREVIEW OUTPUT", bg: Theme.bg, border: Frame.pane_border(focused))
+      body = rect.inset(1, 1)
+      return if body.empty?
+      lines = text.empty? ? ["(empty)"] : text.split('\n')
+      top = scroll.clamp(0, {lines.size - body.h, 0}.max)
+      (0...body.h).each do |i|
+        line = lines[top + i]?
+        break unless line
+        screen.text(body.x, body.y + i, line, Theme.text, Theme.bg, width: body.w)
+      end
+      Frame.scroll_gauge(screen, body, lines.size, top, focused)
+    end
+
     private def op_tag(rule : Store::MatchRule) : String
       case rule.op
       when .replace?
@@ -91,15 +169,38 @@ module Gori::Tui
       end
     end
 
-    # The rule index under (mx,my), mirroring the render loop (header row on top, then rows).
+    # Visible row count inside the list card (for scroll clamping).
+    def list_row_capacity(rect : Rect, live : Bool) : Int32
+      list_r, _, _ = layout(rect)
+      inner = list_r.inset(1, 1)
+      h = inner.h
+      h -= 1 if live && h > 1
+      {h, 0}.max
+    end
+
+    # The rule index under (mx,my) in the list card.
     def row_at(rect : Rect, mx : Int32, my : Int32, scroll : Int32, count : Int32, live : Bool) : Int32?
-      return nil unless rect.contains?(mx, my)
-      list_top = rect.y + HEADER_H
-      list_h = rect.bottom - list_top - (live ? 1 : 0)
-      i = my - list_top
+      list_r, _, _ = layout(rect)
+      return nil unless list_r.contains?(mx, my)
+      inner = list_r.inset(1, 1)
+      return nil if inner.empty?
+      list_h = inner.h
+      list_h -= 1 if live && list_h > 1
+      i = my - inner.y
       return nil if i < 0 || i >= list_h
       idx = scroll + i
       idx < count ? idx : nil
+    end
+
+    # Clickable content rect for the PREVIEW INPUT editor (inside the card border).
+    def preview_input_body(rect : Rect) : Rect
+      _, pin, _ = layout(rect)
+      pin.empty? ? pin : pin.inset(1, 1)
+    end
+
+    def preview_output_body(rect : Rect) : Rect
+      _, _, pout = layout(rect)
+      pout.empty? ? pout : pout.inset(1, 1)
     end
   end
 end

--- a/src/gori/tui/sequencer_view.cr
+++ b/src/gori/tui/sequencer_view.cr
@@ -50,6 +50,9 @@ module Gori::Tui
       @sel = 0
       @scroll = 0
       @analysis_scroll = 0
+      @analysis_line_count = 0
+      @analysis_h = 0
+      @side_by_side = true # last render layout (Samples | Analysis vs stacked)
       @detail_scroll = 0
       @job_id = 0
     end
@@ -199,6 +202,20 @@ module Gori::Tui
       @sel == 0
     end
 
+    def samples_at_bottom? : Bool
+      return true if @samples.empty?
+      @sel >= @samples.size - 1
+    end
+
+    def analysis_at_top? : Bool
+      @analysis_scroll <= 0
+    end
+
+    # Last render put Samples and Analysis side-by-side (wide) vs stacked (narrow).
+    def side_by_side? : Bool
+      @side_by_side
+    end
+
     def pane_advance(dir : Int32) : Bool
       idx = PANE_ORDER.index(@focus) || 0
       nidx = idx + dir
@@ -214,7 +231,8 @@ module Gori::Tui
     end
 
     def analysis_scroll(d : Int32) : Nil
-      @analysis_scroll = {@analysis_scroll + d, 0}.max
+      max = {@analysis_line_count - @analysis_h, 0}.max
+      @analysis_scroll = (@analysis_scroll + d).clamp(0, max)
     end
 
     def open_detail : Nil
@@ -363,7 +381,8 @@ module Gori::Tui
       lower = Rect.new(rect.x, rect.y + cfg_h, rect.w, {rect.h - cfg_h, 2}.max)
       render_config(screen, cfg_rect, focused && @focus == :config)
 
-      if lower.w >= 84
+      @side_by_side = lower.w >= 84
+      if @side_by_side
         sw = {lower.w * 42 // 100, 30}.max
         s_rect = Rect.new(lower.x, lower.y, sw, lower.h)
         a_rect = Rect.new(lower.x + sw, lower.y, lower.w - sw, lower.h)
@@ -483,13 +502,17 @@ module Gori::Tui
     private def render_analysis(screen : Screen, rect : Rect, focused : Bool) : Nil
       Frame.card(screen, rect, "ANALYSIS", border: focused ? Theme.focus_gold : Theme.border, bg: Theme.bg)
       inner = rect.inset(1, 1)
+      @analysis_h = {inner.h, 0}.max
       return if inner.h <= 0 || inner.w <= 2
       rep = report
       if rep.usable_count == 0
+        @analysis_line_count = 1
+        @analysis_scroll = 0
         screen.text(inner.x + 1, inner.y, @running ? "collecting…" : "no tokens yet", Theme.muted, Theme.bg)
         return
       end
       lines = analysis_lines(rep, inner.w)
+      @analysis_line_count = lines.size
       max_scroll = {lines.size - inner.h, 0}.max
       @analysis_scroll = @analysis_scroll.clamp(0, max_scroll)
       inner.h.times do |i|


### PR DESCRIPTION
## Summary
- **OAST Callbacks**: rows are clickable (select-first, second click opens detail), matching History/Probe; Providers get the same pattern (second click edits).
- **Sequencer**: arrow keys move between Samples ↔ Analysis (and leave Analysis at scroll top); stacked layout gets ↓/↑ spatial exits.
- **JWT Decode**: ↓ at bottom of Decoded moves focus to Attacks (same as Input → Decoded).
- **Rewriter**: Caido-style bottom preview — left editable HTTP sample, right live transform via new `Rules#transform_message`.

## Test plan
- [ ] OAST → Callbacks: click a row to select; click again to open detail; filter bar click starts `/`
- [ ] Sequencer: from Samples press `→` to Analysis; `←` back; Analysis `↑` at top leaves pane
- [ ] JWT Decode: from Decoded press `↓` (short token) to reach Attacks; `↑` returns
- [ ] Rewriter: bottom preview shows; edit sample / toggle a rule and Output updates
- [ ] `crystal spec spec/rules_spec.cr` (transform_message coverage)