### PR TITLE
test: expand spec coverage across pure and harness-testable modules

### DIFF
--- a/spec/ascii_bytes_spec.cr
+++ b/spec/ascii_bytes_spec.cr
@@ -1,0 +1,165 @@
+require "./spec_helper"
+
+private def bytes(str : String) : Bytes
+  str.to_slice
+end
+
+private def contains?(hay : String, needle : String) : Bool
+  Gori::AsciiBytes.contains_ci?(hay.to_slice, needle.to_slice)
+end
+
+describe Gori::AsciiBytes do
+  describe ".contains_ci?" do
+    describe "empty and size boundaries" do
+      it "returns true for an empty needle regardless of hay" do
+        contains?("", "").should be_true
+        contains?("anything", "").should be_true
+        Gori::AsciiBytes.contains_ci?(Bytes[0xff, 0x00, 0x80], Bytes.empty).should be_true
+      end
+
+      it "returns false for a non-empty needle against an empty hay" do
+        contains?("", "x").should be_false
+        contains?("", "content-type").should be_false
+      end
+
+      it "returns false when hay is exactly one byte shorter than needle (off-by-one)" do
+        # hay.size == needle.size - 1 must take the `hay.size < n` early-out.
+        contains?("abcd", "abcde").should be_false
+        contains?("a", "ab").should be_false
+      end
+
+      it "matches when hay and needle are the same single byte" do
+        contains?("a", "a").should be_true
+        contains?("A", "a").should be_true # single byte, folded
+      end
+
+      it "matches when hay equals needle exactly (limit == 0)" do
+        contains?("content-type", "content-type").should be_true
+        contains?("CONTENT-TYPE", "content-type").should be_true
+      end
+    end
+
+    describe "ASCII case-folding" do
+      it "folds A-Z in hay to match a lowercase needle in any casing of hay" do
+        contains?("CONTENT-TYPE", "content-type").should be_true
+        contains?("Content-Type", "content-type").should be_true
+        contains?("CoNtEnT-TyPe", "content-type").should be_true
+      end
+
+      it "finds the needle as a substring of a larger hay" do
+        contains?("HTTP/1.1 200\r\nContent-Type: text/html", "content-type").should be_true
+        contains?("x-Content-Type-Options", "content-type").should be_true
+      end
+
+      it "matches a needle occurring at the very end of hay (i == limit)" do
+        # The trailing occurrence is only found because the scan runs through i == limit.
+        contains?("set-cookie: CONTENT-TYPE", "content-type").should be_true
+        contains?("zzzab", "ab").should be_true
+      end
+
+      it "does not match when a needle byte is absent even after folding" do
+        contains?("content-length", "content-type").should be_false
+        contains?("CONTENT", "content-type").should be_false # hay shorter overall handled, but also non-match
+      end
+    end
+
+    describe "fold boundary bytes (only A-Z 0x41-0x5a fold)" do
+      it "does not fold '@' (0x40, just below 'A')" do
+        # 0x40 | 0x20 == 0x60 ('`'); folding would wrongly match a '`' needle.
+        Gori::AsciiBytes.contains_ci?(Bytes[0x40_u8], Bytes[0x60_u8]).should be_false
+        Gori::AsciiBytes.contains_ci?(Bytes[0x40_u8], Bytes[0x40_u8]).should be_true
+      end
+
+      it "does not fold '[' (0x5b, just above 'Z')" do
+        # needle "{" (0x7b) differs from hay "[" (0x5b) by exactly 0x20 but 0x5b is
+        # outside A-Z, so it must NOT be folded and must NOT match.
+        Gori::AsciiBytes.contains_ci?(Bytes[0x5b_u8], Bytes[0x7b_u8]).should be_false
+        # identical non-folded byte still matches verbatim
+        Gori::AsciiBytes.contains_ci?(Bytes[0x5b_u8], Bytes[0x5b_u8]).should be_true
+      end
+
+      it "folds exactly the endpoints 'A' (0x41) and 'Z' (0x5a)" do
+        Gori::AsciiBytes.contains_ci?(Bytes[0x41_u8], Bytes[0x61_u8]).should be_true # A -> a
+        Gori::AsciiBytes.contains_ci?(Bytes[0x5a_u8], Bytes[0x7a_u8]).should be_true # Z -> z
+      end
+    end
+
+    describe "non-ASCII bytes compared verbatim" do
+      it "matches a CJK UTF-8 needle only against an identical byte sequence" do
+        contains?("헤더 안녕하세요", "안녕").should be_true
+        contains?("世界 hello", "世界").should be_true
+        # a different CJK sequence of the same length must not match
+        contains?("안녕", "세요").should be_false
+      end
+
+      it "matches an emoji needle byte-for-byte" do
+        contains?("status \u{1F600} ok", "\u{1F600}").should be_true
+        contains?("no emoji here", "\u{1F600}").should be_false
+      end
+
+      it "never case-folds bytes > 0x7f" do
+        # 0x61 ('a') and 0x41 ('A') fold; 0xC1 (== 0xA1 | 0x20) must not.
+        Gori::AsciiBytes.contains_ci?(Bytes[0xc1_u8], Bytes[0xa1_u8]).should be_false
+        Gori::AsciiBytes.contains_ci?(Bytes[0xc1_u8], Bytes[0xc1_u8]).should be_true
+      end
+
+      it "handles invalid/truncated UTF-8 bytes as raw bytes" do
+        hay = Bytes[0xff_u8, 0xfe_u8, 0x41_u8, 0x00_u8]
+        Gori::AsciiBytes.contains_ci?(hay, Bytes[0xff_u8, 0xfe_u8]).should be_true
+        Gori::AsciiBytes.contains_ci?(hay, Bytes[0x61_u8]).should be_true # 0x41 'A' folds to 'a'
+        Gori::AsciiBytes.contains_ci?(hay, Bytes[0x00_u8]).should be_true
+        Gori::AsciiBytes.contains_ci?(hay, Bytes[0xfd_u8]).should be_false
+      end
+    end
+
+    describe "lowercase-needle precondition (caller responsibility)" do
+      it "does not match when the needle carries an uppercase byte (documented precondition)" do
+        # Per the contract the needle MUST already be lowercase. Only hay is folded,
+        # so an uppercase needle byte cannot equal a folded (lowercase) hay byte.
+        # This asserts the documented precondition — a non-match, not a bug.
+        contains?("content-type", "content-TYPE").should be_false
+        contains?("content-type", "CONTENT-TYPE").should be_false
+        contains?("CONTENT-TYPE", "CONTENT-TYPE").should be_false
+      end
+
+      it "an uppercase needle byte still matches a verbatim uppercase hay byte" do
+        # 'T' (0x54) is in A-Z, so hay's 'T' folds to 't' (0x74) which != 'T' needle.
+        contains?("TYPE", "TYPE").should be_false
+      end
+    end
+
+    describe "overlapping / near-miss scanning" do
+      it "advances i past a partial match to find the true occurrence (hay 'aab', needle 'ab')" do
+        contains?("aab", "ab").should be_true
+      end
+
+      it "finds an occurrence that only appears after several false starts" do
+        contains?("aaaab", "aab").should be_true
+        contains?("abababc", "abc").should be_true
+      end
+
+      it "returns false when repeated prefixes never complete the needle" do
+        contains?("aaaa", "aab").should be_false
+        contains?("ababab", "abc").should be_false
+      end
+    end
+
+    describe "adversarial / performance" do
+      it "completes quickly on a large hay with a near-matching needle (no pathological blowup)" do
+        # 200k 'a's followed by 'b'; needle 'a'*64 + 'b' forces a full-length compare
+        # to restart at nearly every position — O(hay·needle) must still finish fast.
+        hay = ("a" * 200_000) + "b"
+        needle = ("a" * 64) + "b"
+        elapsed = Time.measure do
+          contains?(hay, needle).should be_true
+        end
+        elapsed.should be < 2.seconds
+      end
+
+      it "handles a large hay that never contains the needle" do
+        hay = "A" * 100_000
+        contains?(hay, "ab").should be_false
+      end
+    end
+  end
+end

--- a/spec/discover/extract_spec.cr
+++ b/spec/discover/extract_spec.cr
@@ -38,4 +38,90 @@ describe Gori::Discover::Extract do
     E.sitemap_body?(%(<html><body><a href="/loc">not a sitemap</a></body></html>).to_slice).should be_false
     E.sitemap_body?("User-agent: *\nDisallow: /admin\n".to_slice).should be_false
   end
+
+  # (1) MAX_SCAN boundary: only hrefs within the first MAX_SCAN bytes are scanned; a hostile
+  # page can't push work past the cap. Placed at the exact boundary so the guard is sharp.
+  it "extracts hrefs before the MAX_SCAN cap but not after it" do
+    before = %(<a href="/before">)
+    after = %(<a href="/after">)
+    pad = " " * (E::MAX_SCAN - before.bytesize) # before + pad == exactly MAX_SCAN bytes
+    body = (before + pad + after).to_slice
+    body.size.should be > E::MAX_SCAN # the /after token lives beyond the cap
+    links = E.from_html(body)
+    links.should contain("/before")
+    links.should_not contain("/after")
+  end
+
+  # (2)(3)(4) from_robots: the Sitemap: branch, the glob/comment trim (up to whitespace or '*'),
+  # and skipping of lines with no colon / an empty value. Whole-array assert (order preserved).
+  it "extracts robots Sitemap URLs, trims globs/comments, and skips junk lines" do
+    body = <<-ROBOTS.to_slice
+      Sitemap: http://h/sitemap.xml
+      Disallow: /admin/* # comment
+      NoColonLine here
+      Disallow:
+      Allow: /ok
+      ROBOTS
+    E.from_robots(body).should eq(["http://h/sitemap.xml", "/admin/", "/ok"])
+  end
+
+  it "trims a Disallow glob at the first '*' and a trailing comment at whitespace" do
+    E.from_robots("Disallow: /admin/* # comment\n".to_slice).should eq(["/admin/"])
+    E.from_robots("Disallow: /path # note\n".to_slice).should eq(["/path"])
+    E.from_robots("Sitemap: http://h/sitemap.xml\n".to_slice).should eq(["http://h/sitemap.xml"])
+  end
+
+  it "skips robots lines with no colon or an empty value" do
+    E.from_robots("this line has no colon\n".to_slice).should be_empty
+    E.from_robots("Disallow:\n".to_slice).should be_empty     # empty value
+    E.from_robots("Disallow:   \n".to_slice).should be_empty  # whitespace-only value
+    E.from_robots("User-agent: *\n".to_slice).should be_empty # not a disallow/allow/sitemap key
+  end
+
+  # (5) from_html: an empty attribute value adds nothing (v && !v.empty?); a bare unquoted value
+  # is captured via the third alternation group.
+  it "skips an empty href but captures a bare unquoted src" do
+    body = %(<a href="">empty</a> <script src=foo.js></script>).to_slice
+    E.from_html(body).should eq(["foo.js"])
+  end
+
+  it "captures bare unquoted href / action values (third regex group)" do
+    E.from_html(%(<a href=/plain.html>).to_slice).should eq(["/plain.html"])
+    E.from_html(%(<form action=submit.php>).to_slice).should eq(["submit.php"])
+  end
+
+  # (6) from_sitemap treats a <sitemapindex> child <loc> exactly like a <urlset> page <loc>.
+  it "extracts sitemapindex child locs like urlset page locs" do
+    index = %(<sitemapindex><sitemap><loc>http://h/child.xml</loc></sitemap></sitemapindex>).to_slice
+    urlset = %(<urlset><url><loc>http://h/page.xml</loc></url></urlset>).to_slice
+    E.from_sitemap(index).should eq(["http://h/child.xml"])
+    E.from_sitemap(urlset).should eq(["http://h/page.xml"])
+  end
+
+  # (7) sitemap_body? sniffs only the first SNIFF_MAX bytes, and scrubs invalid UTF-8 (no raise).
+  it "returns false when the sitemap root sits beyond SNIFF_MAX" do
+    junk = "x" * E::SNIFF_MAX # non-matching leading junk exactly filling the sniff window
+    body = (junk + %(<urlset><url><loc>http://h/p</loc></url></urlset>)).to_slice
+    E.sitemap_body?(body).should be_false
+    # sanity: with the root inside the window it is detected.
+    E.sitemap_body?((junk[0, 10] + "<urlset>").to_slice).should be_true
+  end
+
+  it "scrubs invalid UTF-8 bytes before the root instead of raising" do
+    io = IO::Memory.new
+    io.write(Bytes[0xff, 0xfe, 0x80, 0xc0]) # invalid UTF-8 lead bytes
+    io << %(<urlset><url><loc>http://h/p</loc></url></urlset>)
+    E.sitemap_body?(io.to_slice).should be_true
+  end
+
+  # (8) Adversarial regex regression guard (spec/fuzz_spec.cr style): a long unclosed
+  # <meta ... url= with a multi-KB attribute value must complete and RETURN (from_html does not
+  # rescue Regex::Error, so a hang → harness timeout and a raise → spec failure). NOT a known-vuln claim.
+  it "handles a long unclosed meta/attr body in bounded time (backtracking guard)" do
+    evil = ("<meta http-equiv=\"refresh\" content=\"" + ("url= " * 100_000)).to_slice
+    E.from_html(evil).should be_a(Array(String)) # returned, did not hang or raise
+    # a giant bare unquoted src value ([^\s"'>]+) is linear, not pathological
+    big = ("<img src=" + ("a" * 500_000)).to_slice
+    E.from_html(big).should eq(["a" * 500_000])
+  end
 end

--- a/spec/discover/types_spec.cr
+++ b/spec/discover/types_spec.cr
@@ -1,0 +1,132 @@
+require "../spec_helper"
+
+private alias C = Gori::Discover::Containment
+
+describe Gori::Discover::Containment do
+  describe ".parse?" do
+    it "decodes the strict / same-origin aliases to SameOrigin" do
+      C.parse?("same-origin").should eq(C::SameOrigin)
+      C.parse?("origin").should eq(C::SameOrigin)
+      C.parse?("strict").should eq(C::SameOrigin)
+    end
+
+    it "decodes the host+subdomains aliases to HostAndSubdomains" do
+      C.parse?("host").should eq(C::HostAndSubdomains)
+      C.parse?("subdomains").should eq(C::HostAndSubdomains)
+      C.parse?("host+subdomains").should eq(C::HostAndSubdomains)
+      C.parse?("host-and-subdomains").should eq(C::HostAndSubdomains)
+      C.parse?("host-subdomains").should eq(C::HostAndSubdomains)
+    end
+
+    it "decodes the scope aliases to ScopeAware" do
+      C.parse?("scope").should eq(C::ScopeAware)
+      C.parse?("scoped").should eq(C::ScopeAware)
+      C.parse?("scope-aware").should eq(C::ScopeAware)
+    end
+
+    it "round-trips every #label back to its own value" do
+      C.each do |value|
+        C.parse?(value.label).should eq(value)
+      end
+    end
+
+    it "is case-insensitive (SCOPE -> ScopeAware)" do
+      C.parse?("SCOPE").should eq(C::ScopeAware)
+      C.parse?("Origin").should eq(C::SameOrigin)
+      C.parse?("STRICT").should eq(C::SameOrigin)
+      C.parse?("ScOpE-AwArE").should eq(C::ScopeAware)
+      C.parse?("HOST+SUBDOMAINS").should eq(C::HostAndSubdomains)
+    end
+
+    it "strips surrounding whitespace and folds separator runs to a hyphen" do
+      # "  Host_And_Subdomains  " -> strip -> underscores collapsed to '-'.
+      C.parse?("  Host_And_Subdomains  ").should eq(C::HostAndSubdomains)
+    end
+
+    it "treats underscores and whitespace runs identically as a single hyphen" do
+      C.parse?("scope_aware").should eq(C::ScopeAware)
+      C.parse?("scope aware").should eq(C::ScopeAware)
+      C.parse?("same_origin").should eq(C::SameOrigin)
+      C.parse?("same origin").should eq(C::SameOrigin)
+      # Mixed multi-char runs of spaces + underscores collapse to ONE hyphen each.
+      C.parse?("host___and   subdomains").should eq(C::HostAndSubdomains)
+      C.parse?("host _ and _ subdomains").should eq(C::HostAndSubdomains)
+    end
+
+    it "normalizes tab and newline whitespace like spaces" do
+      C.parse?("\tstrict\n").should eq(C::SameOrigin)
+      C.parse?("\r\nscope\t").should eq(C::ScopeAware)
+      C.parse?("scope\taware").should eq(C::ScopeAware)
+    end
+
+    it "returns nil for the empty string" do
+      C.parse?("").should be_nil
+    end
+
+    it "returns nil for a whitespace-only token (strips to empty)" do
+      C.parse?("   ").should be_nil
+      C.parse?("\t\n ").should be_nil
+    end
+
+    it "returns nil for unrecognized garbage" do
+      C.parse?("garbage").should be_nil
+      C.parse?("sameorigin").should be_nil # missing separator, no fold applies
+      C.parse?("scopeaware").should be_nil
+    end
+
+    # Documented adversarial contract: a literal '+' with SURROUNDING spaces is
+    # NOT a separator the normalizer folds. The spaces collapse to hyphens but the
+    # '+' survives, yielding "host-+-subdomains", which matches no case -> nil.
+    # (Contrast "host+subdomains" with no spaces, which IS a literal alias.)
+    it "returns nil for 'host + subdomains' (spaced plus survives normalization)" do
+      C.parse?("host + subdomains").should be_nil
+      C.parse?("host  +  subdomains").should be_nil
+    end
+
+    it "does not fold a plus that is not adjacent to whitespace" do
+      # No whitespace/underscore anywhere -> '+' passes through untouched.
+      C.parse?("host+subdomains").should eq(C::HostAndSubdomains)
+      # But an internal alias built purely of hyphens must be exact.
+      C.parse?("host+and+subdomains").should be_nil
+    end
+
+    it "returns nil when separators sit at the edges (strip only removes whitespace, not underscores)" do
+      # Underscores are NOT stripped; they fold to leading/trailing hyphens,
+      # so "_strict_" -> "-strict-" which matches nothing.
+      C.parse?("_strict_").should be_nil
+      C.parse?("-scope-").should be_nil
+    end
+
+    it "returns nil for multibyte / CJK / emoji tokens" do
+      C.parse?("안녕").should be_nil
+      C.parse?("世界").should be_nil
+      C.parse?("🔥scope🔥").should be_nil
+      C.parse?("scｏpe").should be_nil # fullwidth latin, not ascii 'o'
+    end
+
+    it "returns nil for tokens with combining marks around a real alias" do
+      C.parse?("scopé").should be_nil # 'scope' + combining acute accent
+    end
+
+    it "does not misfire on partial or embedded aliases" do
+      C.parse?("strictly").should be_nil
+      C.parse?("prescope").should be_nil
+      C.parse?("host+subdomains+extra").should be_nil
+    end
+
+    it "handles a huge adversarial whitespace/underscore run without pathological slowdown" do
+      # Linear [\s_]+ fold — a megabyte of separators must collapse and return
+      # quickly (regression guard against catastrophic backtracking).
+      big = "scope" + (" _" * 500_000) + "aware"
+      elapsed = Time.measure do
+        # Collapses to "scope-aware" -> ScopeAware.
+        C.parse?(big).should eq(C::ScopeAware)
+      end
+      elapsed.should be < 2.seconds
+    end
+
+    it "returns nil (not a crash) for an all-separator adversarial blob" do
+      C.parse?("_ _ _ _ _".rjust(100_000, ' ')).should be_nil
+    end
+  end
+end

--- a/spec/discover/url_spec.cr
+++ b/spec/discover/url_spec.cr
@@ -40,4 +40,158 @@ describe Gori::Discover::Url do
     U.dir_of(U.parse("http://h/a/b/c").not_nil!).should eq("http://h/a/b/")
     U.dir_of(U.parse("http://h/").not_nil!).should eq("http://h/")
   end
+
+  describe ".fold_segment" do
+    it "folds a YYYY-MM-DD date to {date} (DATE_LEN 10)" do
+      U.fold_segment("2021-01-01").should eq("{date}")
+    end
+
+    it "folds a 12+ char hex run to {hex} but leaves an 11-char run literal (HEX_MIN floor)" do
+      U.fold_segment("a1b2c3d4e5f6").should eq("{hex}")      # exactly 12 bytes
+      U.fold_segment("a1b2c3d4e5f6ff").should eq("{hex}")    # longer still folds
+      U.fold_segment("abcdefabcde").should eq("abcdefabcde") # 11 bytes < HEX_MIN → literal
+    end
+
+    it "tests NUM before HEX so a 12-digit run folds to {n}, not {hex}" do
+      U.fold_segment("123456789012").should eq("{n}")
+      U.fold_segment("1").should eq("{n}")
+    end
+
+    it "leaves a non-ASCII segment as-is (ascii_only? guard) and downcases an ASCII one" do
+      U.fold_segment("사용자").should eq("사용자")
+      U.fold_segment("世界").should eq("世界")
+      U.fold_segment("café").should eq("café") # accented byte is non-ASCII → returned as-is
+      U.fold_segment("API").should eq("api")
+      U.fold_segment("Index.HTML").should eq("index.html")
+    end
+
+    it "folds an UPPERCASE uuid to {uuid} (case-insensitive)" do
+      U.fold_segment("550E8400-E29B-41D4-A716-446655440000").should eq("{uuid}")
+      U.fold_segment("550e8400-e29b-41d4-a716-446655440000").should eq("{uuid}")
+    end
+
+    it "leaves an empty-ish ordinary segment untouched and passes plain words through" do
+      U.fold_segment("users").should eq("users")
+      U.fold_segment("edit").should eq("edit")
+    end
+
+    it "handles a huge adversarial segment quickly (byte-scan gates before PCRE)" do
+      # Mirrors fuzz_spec: a large input must complete near-instantly. The all_digits?/
+      # ascii_only? byte scans decide the outcome without a catastrophic regex walk.
+      big_hex = "a1b2c3d4e5f6" * 20_000 # 240k bytes, all hex → {hex}
+      big_num = "1" * 200_000           # 200k digits → {n}
+      elapsed = Time.measure do
+        U.fold_segment(big_hex).should eq("{hex}")
+        U.fold_segment(big_num).should eq("{n}")
+        U.fold_segment("x" * 200_000).should eq("x" * 200_000) # long non-hex letters → literal
+      end
+      elapsed.should be < 2.seconds
+    end
+  end
+
+  describe ".parse" do
+    it "returns nil for a non-http(s) scheme" do
+      U.parse("ftp://h/x").should be_nil
+      U.parse("file:///x").should be_nil
+      U.parse("ws://h/x").should be_nil
+    end
+
+    it "returns nil for an empty / missing host" do
+      U.parse("http:///x").should be_nil
+      U.parse("not a url").should be_nil
+      U.parse("").should be_nil
+    end
+
+    it "fills the default port per scheme" do
+      U.parse("http://h/x").not_nil!.port.should eq(80)
+      U.parse("https://h/x").not_nil!.port.should eq(443)
+      U.parse("http://h:8080/x").not_nil!.port.should eq(8080)
+    end
+
+    it "omits the default port in normalize()/origin() but keeps an explicit one" do
+      U.origin(U.parse("http://h/x").not_nil!).should eq("http://h")
+      U.origin(U.parse("https://h/x").not_nil!).should eq("https://h")
+      U.normalize(U.parse("http://h:80/x").not_nil!).should eq("http://h/x")
+      U.origin(U.parse("http://h:8080/x").not_nil!).should eq("http://h:8080")
+      U.normalize(U.parse("http://h:8080/x").not_nil!).should eq("http://h:8080/x")
+    end
+
+    it "collapses dot-segments in the parsed path" do
+      U.parse("http://h/a/../b").not_nil!.path.should eq("/b")
+      U.parse("http://h/a/./b").not_nil!.path.should eq("/a/b")
+    end
+
+    it "defaults an empty path to /" do
+      U.parse("http://h").not_nil!.path.should eq("/")
+    end
+  end
+
+  describe ".resolve" do
+    it "re-appends the href's own query after path resolution" do
+      base = U.parse("http://h/a/b/page").not_nil!
+      U.resolve(base, "c?x=1").should eq("http://h/a/b/c?x=1")
+      U.resolve(base, "/root?y=2&z=3").should eq("http://h/root?y=2&z=3")
+    end
+
+    it "returns nil for non-http pseudo-schemes and empty href" do
+      base = U.parse("http://h/p").not_nil!
+      U.resolve(base, "data:text/html,<b>").should be_nil
+      U.resolve(base, "blob:http://h/uuid").should be_nil
+      U.resolve(base, "about:blank").should be_nil
+      U.resolve(base, "ws://h/x").should be_nil
+      U.resolve(base, "").should be_nil
+      U.resolve(base, "   ").should be_nil
+    end
+
+    # SUSPECTED BUG: resolve() checks the absolute-URL prefix case-sensitively
+    # (h.starts_with?("http://")), so an uppercase scheme falls through to the
+    # "some other scheme" branch and returns nil. HTML/URL schemes are
+    # case-insensitive (RFC 3986 §3.1) and the doc comment promises to "Handle
+    # absolute ... forms", so an uppercase absolute URL should resolve, not drop.
+    pending "resolves an uppercase absolute scheme (schemes are case-insensitive)" do
+      base = U.parse("http://h/p").not_nil!
+      # Intended: the absolute URL is returned (browsers treat HTTP:// as http://).
+      U.resolve(base, "HTTP://host/p").should eq("HTTP://host/p")
+    end
+  end
+
+  describe ".normalize_path" do
+    it "does not underflow past root when popping .. segments" do
+      U.normalize_path("/a/../../b").should eq("/b")
+      U.normalize_path("/../../../x").should eq("/x")
+    end
+
+    it "preserves a trailing slash" do
+      U.normalize_path("/a/b/").should eq("/a/b/")
+      U.normalize_path("/a/../b/").should eq("/b/")
+    end
+
+    it "drops a single-dot segment" do
+      U.normalize_path("/a/./b").should eq("/a/b")
+      U.normalize_path("/./").should eq("/")
+    end
+
+    it "reduces bare root to /" do
+      U.normalize_path("/").should eq("/")
+      U.normalize_path("//").should eq("/")
+    end
+  end
+
+  describe "canonical_query (via keys)" do
+    it "template_key folds the query to its deduped, sorted key set" do
+      # fold:true — values dropped, keys sorted + uniq'd
+      U.template_key(U.parse("http://h/s?b=2&a=1&a=9").not_nil!).should eq("http://h/s?a&b")
+      U.template_key(U.parse("http://h/s?z=1").not_nil!).should eq("http://h/s?z")
+    end
+
+    it "visit_key keeps values and sorts pairs" do
+      # fold:false — values kept, pairs sorted
+      U.visit_key(U.parse("http://h/s?b=2&a=1").not_nil!).should eq("http://h/s?a=1&b=2")
+    end
+
+    it "rejects empty pairs from a doubled ampersand" do
+      U.visit_key(U.parse("http://h/s?a=1&&b=2").not_nil!).should eq("http://h/s?a=1&b=2")
+      U.template_key(U.parse("http://h/s?a=1&&b=2").not_nil!).should eq("http://h/s?a&b")
+    end
+  end
 end

--- a/spec/form_data_spec.cr
+++ b/spec/form_data_spec.cr
@@ -1,0 +1,335 @@
+require "./spec_helper"
+
+# Builds an HTTP head Bytes from a request line + header pairs.
+private def head(line : String, *headers) : Bytes
+  String.build do |io|
+    io << line << "\r\n"
+    headers.each { |h| io << h << "\r\n" }
+    io << "\r\n"
+  end.to_slice
+end
+
+# Builds a multipart/form-data body (CRLF-delimited) from ready-made part blocks.
+# Each block is the text between two boundaries, e.g.
+#   "Content-Disposition: form-data; name=\"a\"\r\n\r\nval"
+private def multipart_body(boundary : String, *parts : String) : String
+  String.build do |io|
+    parts.each { |p| io << "--" << boundary << "\r\n" << p << "\r\n" }
+    io << "--" << boundary << "--\r\n"
+  end
+end
+
+private def urlencoded_head : Bytes
+  head("POST / HTTP/1.1", "Content-Type: application/x-www-form-urlencoded")
+end
+
+private def multipart_head(boundary : String) : Bytes
+  head("POST / HTTP/1.1", "Content-Type: multipart/form-data; boundary=#{boundary}")
+end
+
+# Fetch the (first) field with the given name from a from_flow result.
+private def field_named(fields : Array(Gori::FormData::Field)?, name : String) : Gori::FormData::Field?
+  fields.try(&.find { |f| f.name == name })
+end
+
+describe Gori::FormData do
+  describe ".from_flow — urlencoded body + query folding" do
+    it "decodes a urlencoded body into two :body fields" do
+      fields = Gori::FormData.from_flow("/", urlencoded_head, "a=1&b=2".to_slice)
+      fields.should_not be_nil
+      fields = fields.not_nil!
+      fields.size.should eq(2)
+      fields[0].should eq(Gori::FormData::Field.new("a", "1", :body))
+      fields[1].should eq(Gori::FormData::Field.new("b", "2", :body))
+    end
+
+    it "folds the target query string in as :query fields alongside the body" do
+      fields = Gori::FormData.from_flow("/login?next=%2Fhome&t=1", urlencoded_head, "a=1".to_slice)
+      fields.should_not be_nil
+      fields = fields.not_nil!
+      # query fields come first (source :query), then body fields (source :body)
+      field_named(fields, "next").should eq(Gori::FormData::Field.new("next", "/home", :query))
+      field_named(fields, "t").should eq(Gori::FormData::Field.new("t", "1", :query))
+      field_named(fields, "a").should eq(Gori::FormData::Field.new("a", "1", :body))
+    end
+
+    it "url-decodes percent-encoded multibyte (CJK) and emoji values" do
+      # %EC%95%88%EB%85%95 = 안녕 ; %F0%9F%98%80 = 😀
+      fields = Gori::FormData.from_flow("/", urlencoded_head,
+        "greet=%EC%95%88%EB%85%95&face=%F0%9F%98%80".to_slice)
+      field_named(fields, "greet").not_nil!.value.should eq("안녕")
+      field_named(fields, "face").not_nil!.value.should eq("😀")
+    end
+
+    it "decodes percent-encoded names as well as values" do
+      # %ED%95%9C = 한
+      fields = Gori::FormData.from_flow("/", urlencoded_head, "%ED%95%9C=x".to_slice)
+      field_named(fields, "한").not_nil!.value.should eq("x")
+    end
+
+    it "decodes a '+' as a space per www-form rules" do
+      Gori::FormData.from_flow("/", urlencoded_head, "q=a+b".to_slice)
+        .not_nil!.first.value.should eq("a b")
+    end
+  end
+
+  describe ".from_flow — urlencoded edges" do
+    it "treats a pair with no '=' as an empty value" do
+      fields = Gori::FormData.from_flow("/", urlencoded_head, "flag".to_slice)
+      fields.not_nil!.first.should eq(Gori::FormData::Field.new("flag", "", :body))
+    end
+
+    it "rejects the empty pairs produced by adjacent separators (a=1&&b=2)" do
+      fields = Gori::FormData.from_flow("/", urlencoded_head, "a=1&&b=2".to_slice)
+      fields.not_nil!.size.should eq(2)
+      fields.not_nil!.map(&.name).should eq(["a", "b"])
+    end
+
+    it "drops leading/trailing/duplicate separators entirely" do
+      fields = Gori::FormData.from_flow("/", urlencoded_head, "&&a=1&&&".to_slice)
+      fields.not_nil!.size.should eq(1)
+      fields.not_nil!.first.should eq(Gori::FormData::Field.new("a", "1", :body))
+    end
+
+    it "falls back to the raw token on a malformed percent-escape (no raise)" do
+      fields = Gori::FormData.from_flow("/", urlencoded_head, "x=%ZZ".to_slice)
+      fields.not_nil!.first.should eq(Gori::FormData::Field.new("x", "%ZZ", :body))
+    end
+
+    it "falls back to the raw name on a malformed escape in the key" do
+      fields = Gori::FormData.from_flow("/", urlencoded_head, "%GG=v".to_slice)
+      fields.not_nil!.first.should eq(Gori::FormData::Field.new("%GG", "v", :body))
+    end
+
+    it "keeps everything after the first '=' as the value (partition, not split)" do
+      fields = Gori::FormData.from_flow("/", urlencoded_head, "a=b=c".to_slice)
+      fields.not_nil!.first.should eq(Gori::FormData::Field.new("a", "b=c", :body))
+    end
+
+    it "handles a bare '=' as an empty name and empty value" do
+      fields = Gori::FormData.from_flow("/", urlencoded_head, "=".to_slice)
+      fields.not_nil!.first.should eq(Gori::FormData::Field.new("", "", :body))
+    end
+
+    it "distinguishes a=  (present-but-empty) from flag (no '=') — both value \"\"" do
+      fields = Gori::FormData.from_flow("/", urlencoded_head, "a=&flag".to_slice)
+      fields.not_nil!.map { |f| {f.name, f.value} }.should eq([{"a", ""}, {"flag", ""}])
+    end
+  end
+
+  describe ".from_flow — content-type detection" do
+    it "detects the header case-insensitively (lowercase 'content-type:')" do
+      fields = Gori::FormData.from_flow("/",
+        head("POST / HTTP/1.1", "content-type: application/x-www-form-urlencoded"),
+        "a=1".to_slice)
+      fields.not_nil!.first.should eq(Gori::FormData::Field.new("a", "1", :body))
+    end
+
+    it "detects the header case-insensitively (UPPERCASE 'CONTENT-TYPE:')" do
+      fields = Gori::FormData.from_flow("/",
+        head("POST / HTTP/1.1", "CONTENT-TYPE: application/x-www-form-urlencoded"),
+        "a=1".to_slice)
+      fields.not_nil!.first.should eq(Gori::FormData::Field.new("a", "1", :body))
+    end
+
+    it "handles a bare 'Content-Type:' header (13 chars, empty value) — body not folded" do
+      fields = Gori::FormData.from_flow("/x?q=1",
+        head("POST / HTTP/1.1", "Content-Type:"), "a=1".to_slice)
+      # empty CT matches neither urlencoded nor multipart → only the query field survives
+      fields.not_nil!.map(&.name).should eq(["q"])
+      field_named(fields, "q").not_nil!.source.should eq(:query)
+    end
+
+    it "yields only query fields when there is no Content-Type header at all" do
+      fields = Gori::FormData.from_flow("/search?q=hi&p=2",
+        head("POST / HTTP/1.1"), "a=1".to_slice)
+      fields.not_nil!.map(&.source).uniq!.should eq([:query])
+      fields.not_nil!.map(&.name).should eq(["q", "p"])
+    end
+
+    it "ignores a header line whose name only shares a prefix with content-type" do
+      # "Content-Type-Options" must NOT be read as the Content-Type value.
+      fields = Gori::FormData.from_flow("/?q=1",
+        head("POST / HTTP/1.1", "X-Content-Type-Options: nosniff"), "a=1".to_slice)
+      fields.not_nil!.map(&.name).should eq(["q"])
+    end
+  end
+
+  describe ".from_flow — multipart parts" do
+    it "inlines a text part as a :body field with no note" do
+      body = multipart_body("BND", %(Content-Disposition: form-data; name="title"\r\n\r\nHello))
+      fields = Gori::FormData.from_flow("/", multipart_head("BND"), body.to_slice)
+      field_named(fields, "title").should eq(Gori::FormData::Field.new("title", "Hello", :body))
+    end
+
+    it "summarises a file part as 'file: <name> (N bytes)' with an empty value" do
+      body = multipart_body("BND",
+        %(Content-Disposition: form-data; name="avatar"; filename="x.png"\r\nContent-Type: image/png\r\n\r\nABCDE))
+      f = field_named(Gori::FormData.from_flow("/", multipart_head("BND"), body.to_slice), "avatar").not_nil!
+      f.value.should eq("")
+      f.note.should eq("file: x.png (5 bytes)")
+      f.source.should eq(:body)
+    end
+
+    it "notes a binary (invalid-encoding) part as 'binary, N bytes'" do
+      io = IO::Memory.new
+      io << "--BND\r\nContent-Disposition: form-data; name=\"blob\"\r\n\r\n"
+      io.write(Bytes[0xff, 0xfe, 0x00])
+      io << "\r\n--BND--\r\n"
+      f = field_named(Gori::FormData.from_flow("/", multipart_head("BND"), io.to_slice), "blob").not_nil!
+      f.value.should eq("")
+      f.note.should eq("binary, 3 bytes")
+    end
+
+    it "notes an over-PART_MAX text part by size instead of inlining it" do
+      big = "x" * (64 * 1024 + 1) # PART_MAX + 1
+      body = multipart_body("BND", %(Content-Disposition: form-data; name="t"\r\n\r\n#{big}))
+      f = field_named(Gori::FormData.from_flow("/", multipart_head("BND"), body.to_slice), "t").not_nil!
+      f.value.should eq("") # not inlined
+      f.note.not_nil!.should contain("65537 bytes")
+    end
+
+    it "inlines a text part exactly at PART_MAX (boundary, off-by-one)" do
+      exact = "y" * (64 * 1024) # == PART_MAX
+      body = multipart_body("BND", %(Content-Disposition: form-data; name="t"\r\n\r\n#{exact}))
+      f = field_named(Gori::FormData.from_flow("/", multipart_head("BND"), body.to_slice), "t").not_nil!
+      f.value.should eq(exact)
+      f.note.should be_nil
+    end
+
+    it "names a part '(unnamed)' when its Content-Disposition has no name=" do
+      body = multipart_body("BND", %(Content-Disposition: form-data\r\n\r\nhi))
+      field_named(Gori::FormData.from_flow("/", multipart_head("BND"), body.to_slice), "(unnamed)")
+        .should eq(Gori::FormData::Field.new("(unnamed)", "hi", :body))
+    end
+
+    it "preserves a multibyte (CJK/emoji) filename in the file note" do
+      body = multipart_body("BND",
+        %(Content-Disposition: form-data; name="f"; filename="사진😀.png"\r\n\r\nZZ))
+      field_named(Gori::FormData.from_flow("/", multipart_head("BND"), body.to_slice), "f")
+        .not_nil!.note.should eq("file: 사진😀.png (2 bytes)")
+    end
+
+    # SUSPECTED BUG: a browser sends `filename=""` for a file input with NO file selected.
+    # part_field does `if filename = FILENAME_RE.match(cd).try(&.[1])`, and an empty String is
+    # truthy in Crystal, so the empty filename is treated as a real FILE part and emits the
+    # meaningless note "file:  (0 bytes)". The documented contract is that `note` carries a
+    # file/binary summary — an unselected file is neither. It should fall through to the
+    # inline-text branch (an empty :body field, note nil). Marked pending so the suite stays
+    # green without enshrining the buggy note.
+    pending "treats filename=\"\" (no file selected) as an empty field, not a file part" do
+      body = multipart_body("BND", %(Content-Disposition: form-data; name="f"; filename=""\r\n\r\n))
+      f = field_named(Gori::FormData.from_flow("/", multipart_head("BND"), body.to_slice), "f").not_nil!
+      f.note.should be_nil
+      f.value.should eq("")
+    end
+  end
+
+  describe ".from_flow — multipart limits & tolerance" do
+    it "stops collecting parts at MAX_PARTS (256)" do
+      parts = Array.new(300) { |i| %(Content-Disposition: form-data; name="p#{i}"\r\n\r\nv) }
+      # build the body manually (splat of a runtime array is not allowed)
+      raw = String.build do |io|
+        parts.each { |p| io << "--BND\r\n" << p << "\r\n" }
+        io << "--BND--\r\n"
+      end
+      fields = Gori::FormData.from_flow("/", multipart_head("BND"), raw.to_slice)
+      fields.not_nil!.size.should eq(256)
+    end
+
+    it "keeps whatever parsed before a malformed/truncated part (rescue, no raise)" do
+      raw = "--BND\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\nval\r\n" \
+            "--BND\r\nContent-Disposition: form-data; name=\"b\"\r\n\r\ntrunc"
+      fields = Gori::FormData.from_flow("/", multipart_head("BND"), raw.to_slice)
+      # the fully-formed first part must survive the tolerant parse
+      field_named(fields, "a").not_nil!.value.should eq("val")
+    end
+
+    it "yields no multipart fields when the boundary is absent" do
+      body = multipart_body("BND", %(Content-Disposition: form-data; name="a"\r\n\r\nv))
+      Gori::FormData.from_flow("/",
+        head("POST / HTTP/1.1", "Content-Type: multipart/form-data"), body.to_slice)
+        .should be_nil
+    end
+
+    it "yields no multipart fields when the boundary is empty" do
+      Gori::FormData.from_flow("/",
+        head("POST / HTTP/1.1", "Content-Type: multipart/form-data; boundary="),
+        "--\r\n".to_slice).should be_nil
+    end
+
+    it "still folds the query string when the multipart body is unparseable" do
+      Gori::FormData.from_flow("/u?ok=1",
+        head("POST / HTTP/1.1", "Content-Type: multipart/form-data"), "garbage".to_slice)
+        .not_nil!.map(&.name).should eq(["ok"])
+    end
+  end
+
+  describe ".from_flow — ceilings & nil" do
+    it "skips a body over MAX_BODY (8MiB+1) and returns query fields only" do
+      big = Bytes.new(8 * 1024 * 1024 + 1, 'a'.ord.to_u8) # MAX_BODY + 1
+      fields = Gori::FormData.from_flow("/q?keep=1", urlencoded_head, big)
+      fields.not_nil!.map(&.name).should eq(["keep"])
+      fields.not_nil!.first.source.should eq(:query)
+    end
+
+    it "still parses a body exactly at MAX_BODY (boundary, off-by-one)" do
+      # "a=" + 'x' repeated to hit exactly MAX_BODY bytes.
+      pad = "x" * (8 * 1024 * 1024 - 2)
+      fields = Gori::FormData.from_flow("/", urlencoded_head, "a=#{pad}".to_slice)
+      fields.not_nil!.first.name.should eq("a")
+      fields.not_nil!.first.value.bytesize.should eq(pad.bytesize)
+    end
+
+    it "returns nil when there is neither a query nor a parseable body" do
+      Gori::FormData.from_flow("/api",
+        head("POST /api HTTP/1.1", "Content-Type: application/json"),
+        %({"a":1}).to_slice).should be_nil
+    end
+
+    it "returns nil for an empty body and no query" do
+      Gori::FormData.from_flow("/", urlencoded_head, "".to_slice).should be_nil
+    end
+
+    it "returns nil when req_body is nil and there is no query" do
+      Gori::FormData.from_flow("/", urlencoded_head, nil).should be_nil
+    end
+
+    it "returns nil for a bare target with no '?'" do
+      Gori::FormData.from_flow("/plain", nil, nil).should be_nil
+    end
+
+    it "returns nil for a target with a '?' but an empty query" do
+      Gori::FormData.from_flow("/plain?", nil, nil).should be_nil
+    end
+
+    it "caps the total field list at MAX_FIELDS (500)" do
+      raw = (1..600).map { |i| "k#{i}=#{i}" }.join("&")
+      fields = Gori::FormData.from_flow("/", urlencoded_head, raw.to_slice)
+      fields.not_nil!.size.should eq(500)
+    end
+  end
+
+  describe ".from_flow — adversarial / robustness" do
+    it "completes quickly on a huge urlencoded body (no pathological blowup)" do
+      raw = (["a=1"] * 200_000).join("&")
+      elapsed = Time.measure do
+        Gori::FormData.from_flow("/", urlencoded_head, raw.to_slice)
+      end
+      elapsed.total_seconds.should be < 5.0
+    end
+
+    it "does not raise on invalid-UTF-8 bytes in a urlencoded body (String.new tolerant)" do
+      io = IO::Memory.new
+      io << "a="
+      io.write(Bytes[0xff, 0xfe])
+      # must not raise; the field is produced with whatever String.new yields
+      Gori::FormData.from_flow("/", urlencoded_head, io.to_slice).should_not be_nil
+    end
+
+    it "does not raise on a truncated percent-escape at the very end of a value" do
+      Gori::FormData.from_flow("/", urlencoded_head, "a=%E".to_slice)
+        .not_nil!.first.value.should eq("%E")
+    end
+  end
+end

--- a/spec/graphql_spec.cr
+++ b/spec/graphql_spec.cr
@@ -1,0 +1,262 @@
+require "./spec_helper"
+
+private alias GQL = Gori::Graphql
+
+# round-trip helper: display then parse back.
+private def round_trip(op : GQL::Op) : {String?, String, String?}
+  GQL.parse_display(GQL.display(op))
+end
+
+describe Gori::Graphql do
+  describe ".from_json" do
+    it "parses a real GraphQL POST body into an Op" do
+      GQL.from_json(%({"query":"{ me }"})).should eq(GQL::Op.new(nil, "{ me }", nil))
+    end
+
+    it "lifts operationName and pretty-prints an object variables field" do
+      op = GQL.from_json(%({"query":"query Q { me }","operationName":"Q","variables":{"a":1}}))
+      op.should eq(GQL::Op.new("Q", "query Q { me }", "{\n  \"a\": 1\n}"))
+    end
+
+    it "refuses to hijack a REST body whose query field has no selection set" do
+      GQL.from_json(%({"query":"shoes"})).should be_nil
+    end
+
+    it "returns nil when query is absent or not a string" do
+      GQL.from_json(%({"foo":1})).should be_nil
+      GQL.from_json(%({"query":123})).should be_nil
+    end
+
+    it "strips a leading UTF-8 BOM (and surrounding whitespace) before parsing" do
+      GQL.from_json("\u{FEFF}" + %({"query":"{ me }"})).should eq(GQL::Op.new(nil, "{ me }", nil))
+      GQL.from_json("  \n\t" + %({"query":"{ me }"}) + "  ").should eq(GQL::Op.new(nil, "{ me }", nil))
+    end
+
+    it "returns nil for malformed / non-object JSON" do
+      GQL.from_json("{not json").should be_nil
+      GQL.from_json("").should be_nil
+      GQL.from_json("[1,2,3]").should be_nil # top-level array, not an object
+      GQL.from_json("null").should be_nil
+    end
+
+    it "treats variables: null as absent (nil), not the string \"null\"" do
+      GQL.from_json(%({"query":"{ q }","variables":null})).should eq(GQL::Op.new(nil, "{ q }", nil))
+    end
+
+    it "de-escapes and strips the query document" do
+      # \n inside the JSON string becomes a real newline; surrounding space stripped.
+      op = GQL.from_json(%({"query":"  { a\\n  b }  "}))
+      op.should eq(GQL::Op.new(nil, "{ a\n  b }", nil))
+    end
+
+    it "handles multibyte / CJK / emoji inside the query" do
+      GQL.from_json(%({"query":"{ 사용자 世界 🎉 }"})).should eq(GQL::Op.new(nil, "{ 사용자 世界 🎉 }", nil))
+    end
+  end
+
+  describe ".from_query" do
+    it "decodes query/operationName/variables from a GET target" do
+      op = GQL.from_query("p?query=%7Bme%7D&operationName=Op&variables=%7B%22x%22%3A1%7D")
+      op.should eq(GQL::Op.new("Op", "{me}", "{\n  \"x\": 1\n}"))
+    end
+
+    it "requires an open-brace in the decoded query" do
+      GQL.from_query("p?query=shoes").should be_nil
+    end
+
+    it "returns nil when the target has no query string" do
+      GQL.from_query("shoes").should be_nil
+      GQL.from_query("/plain/path").should be_nil
+    end
+
+    it "returns nil when there is no query param at all" do
+      GQL.from_query("p?operationName=Op&variables=%7B%7D").should be_nil
+    end
+
+    it "falls back to the raw variables text when it is not valid JSON" do
+      op = GQL.from_query("p?query=%7Bme%7D&variables=notjson")
+      op.should eq(GQL::Op.new(nil, "{me}", "notjson"))
+    end
+
+    it "ignores a valueless (no '=') pair" do
+      op = GQL.from_query("p?query=%7Bme%7D&flag")
+      op.should eq(GQL::Op.new(nil, "{me}", nil))
+    end
+  end
+
+  describe ".display" do
+    it "emits only the sections that are present" do
+      GQL.display(GQL::Op.new(nil, "{ me }", nil)).should eq("{ me }")
+      GQL.display(GQL::Op.new("Foo", "{ me }", nil)).should eq("# operationName: Foo\n\n{ me }")
+      GQL.display(GQL::Op.new(nil, "{ me }", "{}")).should eq("{ me }\n\n# variables\n{}")
+      GQL.display(GQL::Op.new("Foo", "{ me }", "{}"))
+        .should eq("# operationName: Foo\n\n{ me }\n\n# variables\n{}")
+    end
+  end
+
+  describe ".parse_display" do
+    it "returns {nil, \"\", nil} for empty input" do
+      GQL.parse_display("").should eq({nil, "", nil})
+    end
+
+    it "keeps an in-query '# variables' comment in the query when it is not a real sentinel" do
+      # doc lines 78-86: a comment followed by more GraphQL (not JSON) must NOT truncate.
+      op, query, vars = GQL.parse_display("{ user { id } }\n# variables\n{ more }")
+      op.should be_nil
+      vars.should be_nil
+      query.should eq("{ user { id } }\n# variables\n{ more }")
+    end
+
+    it "detects a real trailing sentinel and lifts a leading operationName header off the query" do
+      op, query, vars = GQL.parse_display("# operationName: Foo\n\n{ user { id } }\n# variables\n{\"id\":1}")
+      op.should eq("Foo")
+      query.should eq("{ user { id } }")
+      query.includes?("operationName").should be_false
+      vars.should eq("{\"id\":1}")
+    end
+
+    it "accepts a JSON-array trailing block (tail_first == '[')" do
+      GQL.parse_display("{ q }\n# variables\n[1,2,3]").should eq({nil, "{ q }", "[1,2,3]"})
+    end
+
+    it "rejects a bare JSON scalar trailing block (tail_first is not '{'/'[')" do
+      # 42 is valid JSON but the tail_first gate only trusts '{'/'[' — stays in the query.
+      _, query, vars = GQL.parse_display("{ q }\n# variables\n42")
+      vars.should be_nil
+      query.should eq("{ q }\n# variables\n42")
+    end
+
+    it "rejects a '# variables' sentinel with an EMPTY trailing block" do
+      _, query, vars = GQL.parse_display("{ q }\n# variables\n")
+      vars.should be_nil
+      query.should eq("{ q }\n# variables")
+    end
+
+    it "treats an empty operationName value as no operation" do
+      GQL.parse_display("# operationName:").should eq({nil, "", nil})
+      GQL.parse_display("# operationName:   \n\n{ me }").should eq({nil, "{ me }", nil})
+    end
+
+    it "picks the LAST genuine sentinel when several exist" do
+      # only the final '# variables' whose trailing is JSON wins; earlier one stays in query.
+      _, query, vars = GQL.parse_display("{ a }\n# variables\nnot json\n# variables\n{\"z\":9}")
+      vars.should eq("{\"z\":9}")
+      query.should eq("{ a }\n# variables\nnot json")
+    end
+
+    it "stays fast and truncates nothing on hundreds of literal '# variables' comment lines" do
+      # ReDoS / O(n^2) guard: each sentinel is followed by non-bracket GraphQL, so the
+      # tail_first gate never invokes the JSON parse. Everything must remain in the query.
+      blocks = [] of String
+      2000.times { |i| blocks << "# variables"; blocks << "someField#{i} { id }" }
+      text = blocks.join('\n')
+      op, query, vars = GQL.parse_display(text)
+      op.should be_nil
+      vars.should be_nil
+      query.should eq(text)
+    end
+
+    it "handles multibyte / emoji in both the query and the variables block" do
+      _, query, vars = GQL.parse_display("{ 사용자 }\n# variables\n{\"이름\":\"世界🎉\"}")
+      query.should eq("{ 사용자 }")
+      vars.should eq("{\"이름\":\"世界🎉\"}")
+    end
+  end
+
+  describe "display / parse_display round-trip" do
+    it "recovers all three sections" do
+      op = GQL::Op.new("MyQuery", "{ user { id } }", %({"id": 1}))
+      round_trip(op).should eq({"MyQuery", "{ user { id } }", %({"id": 1})})
+    end
+
+    it "recovers an operation + query (no variables)" do
+      op = GQL::Op.new("Foo", "{ x }", nil)
+      round_trip(op).should eq({"Foo", "{ x }", nil})
+    end
+
+    it "recovers a query-only op" do
+      op = GQL::Op.new(nil, "{ me }", nil)
+      round_trip(op).should eq({nil, "{ me }", nil})
+    end
+  end
+
+  describe ".recompose" do
+    it "preserves an unmanaged extensions field and overlays edited query + variables (minified)" do
+      base = %({"query":"{ old }","variables":{"a":1},"extensions":{"pq":true}})
+      decoded = GQL.display(GQL::Op.new(nil, "{ new }", %({"b":2})))
+      out = GQL.recompose(base, decoded)
+      out.should eq(%({"query":"{ new }","variables":{"b":2},"extensions":{"pq":true}}))
+      out.includes?('\n').should be_false # minified
+    end
+
+    it "keeps the original variables when the decoded pane carries no variables block" do
+      base = %({"query":"{ old }","variables":{"a":1},"extensions":{"pq":true}})
+      decoded = GQL.display(GQL::Op.new("Op", "{ new }", nil))
+      out = GQL.recompose(base, decoded)
+      out.should eq(%({"operationName":"Op","query":"{ new }","variables":{"a":1},"extensions":{"pq":true}}))
+    end
+
+    it "works when the original body is not valid JSON (nothing to preserve)" do
+      out = GQL.recompose("garbage", GQL.display(GQL::Op.new(nil, "{ me }", nil)))
+      out.should eq(%({"query":"{ me }"}))
+    end
+  end
+
+  describe ".recompose_query" do
+    it "preserves unmanaged params and appends the edited query (no operationName pair when absent)" do
+      out = GQL.recompose_query("query=%7Bold%7D&apiKey=secret&operationName=Old", "{ new }")
+      out.should eq("apiKey=secret&query=%7B+new+%7D")
+      out.includes?("operationName").should be_false
+    end
+
+    it "minifies the variables and appends operationName when present" do
+      decoded = GQL.display(GQL::Op.new("Op", "{ new }", %({"x": 1})))
+      out = GQL.recompose_query("query=old&apiKey=x", decoded)
+      out.should eq("apiKey=x&query=%7B+new+%7D&operationName=Op&variables=%7B%22x%22%3A1%7D")
+    end
+  end
+
+  describe ".location" do
+    it "reports :body for a GraphQL JSON POST body" do
+      GQL.location(%({"query":"{ me }"}).to_slice).should eq(:body)
+    end
+
+    it "reports :query for a plain REST body" do
+      GQL.location(%({"query":"shoes"}).to_slice).should eq(:query)
+      GQL.location(%({"foo":1}).to_slice).should eq(:query)
+    end
+
+    it "reports :query for nil or empty bodies" do
+      GQL.location(nil).should eq(:query)
+      GQL.location(Bytes.new(0)).should eq(:query)
+    end
+
+    it "reports :query for an over-sized body without parsing it" do
+      big = Bytes.new(Gori::Graphql::MAX_BODY + 1, 0x7b_u8) # all '{'
+      GQL.location(big).should eq(:query)
+    end
+  end
+
+  describe ".from_flow" do
+    it "prefers a GraphQL JSON body over the GET binding" do
+      op = GQL.from_flow("p?query=%7Bfrom_get%7D", nil, %({"query":"{ from_body }"}).to_slice)
+      op.should eq(GQL::Op.new(nil, "{ from_body }", nil))
+    end
+
+    it "falls through to the GET query string when the body is non-GraphQL JSON" do
+      op = GQL.from_flow("p?query=%7Bme%7D", nil, %({"query":"shoes"}).to_slice)
+      op.should eq(GQL::Op.new(nil, "{me}", nil))
+    end
+
+    it "falls through to the GET binding for an empty / nil / oversized body" do
+      GQL.from_flow("p?query=%7Bme%7D", nil, nil).should eq(GQL::Op.new(nil, "{me}", nil))
+      GQL.from_flow("p?query=%7Bme%7D", nil, Bytes.new(0)).should eq(GQL::Op.new(nil, "{me}", nil))
+      big = Bytes.new(Gori::Graphql::MAX_BODY + 1, 0x7b_u8)
+      GQL.from_flow("p?query=%7Bme%7D", nil, big).should eq(GQL::Op.new(nil, "{me}", nil))
+    end
+
+    it "returns nil when neither the body nor the target is GraphQL" do
+      GQL.from_flow("/rest/path", nil, %({"foo":1}).to_slice).should be_nil
+    end
+  end
+end

--- a/spec/links_spec.cr
+++ b/spec/links_spec.cr
@@ -1,0 +1,315 @@
+require "./spec_helper"
+
+# In-memory Store on a tempfile (mirrors spec/store/entity_links_spec.cr).
+private def with_store(&)
+  path = File.tempname("gori-links", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+# Build an EntityLink directly — resolve only reads ref_kind + ref_id, so we can
+# skip the whole issues/notes owner machinery.
+private def link_for(kind : Gori::Store::LinkRefKind, ref_id : Int64) : Gori::Store::EntityLink
+  Gori::Store::EntityLink.new(1_i64, Gori::Store::LinkOwnerKind::Issue, 1_i64, kind, ref_id, 1_i64)
+end
+
+# Insert a flow and return its committed id.
+private def insert_flow_row(store, *, host : String, target : String, method : String = "GET",
+                            scheme : String = "http", port : Int32 = 80) : Int64
+  store.insert_flow(Gori::Store::CapturedRequest.new(
+    created_at: 1_i64, scheme: scheme, host: host, port: port, method: method,
+    target: target, http_version: "HTTP/1.1",
+    head: "#{method} #{target} HTTP/1.1\r\nHost: #{host}\r\n\r\n".to_slice, body: nil))
+end
+
+describe Gori::Links do
+  describe ".resolve (flow)" do
+    it "labels a gone flow as '(gone)' and marks it stale" do
+      with_store do |store|
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Flow, 777_i64))
+        r.tag.should eq("hist")
+        r.label.should eq("flow #777 (gone)")
+        r.url.should eq("flow #777")
+        r.stale?.should be_true
+      end
+    end
+
+    it "labels a present flow '<method> <location>' with url == row.url and not stale" do
+      with_store do |store|
+        fid = insert_flow_row(store, host: "a.test", target: "/x")
+        row = store.flow_row(fid).not_nil!
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Flow, fid))
+        r.tag.should eq("hist")
+        r.label.should eq("GET a.test/x")
+        r.url.should eq("http://a.test/x")
+        r.url.should eq(row.url)
+        r.stale?.should be_false
+      end
+    end
+
+    it "uses a target starting with 'http' verbatim as the location" do
+      with_store do |store|
+        fid = insert_flow_row(store, host: "a.test", target: "http://a.test:8080/abs")
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Flow, fid))
+        r.label.should eq("GET http://a.test:8080/abs")
+        # row.url returns absolute-form targets verbatim (no doubled authority).
+        r.url.should eq("http://a.test:8080/abs")
+        r.stale?.should be_false
+      end
+    end
+
+    it "prefixes host to a relative target (origin-form) for the location" do
+      with_store do |store|
+        fid = insert_flow_row(store, host: "shop.example", target: "/cart?id=1", method: "POST")
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Flow, fid))
+        r.label.should eq("POST shop.example/cart?id=1")
+      end
+    end
+
+    it "treats a schemeless 'http'-prefixed target as verbatim (best-effort location)" do
+      # flow_location checks starts_with?("http") loosely; a schemeless host that
+      # begins with "http" is passed through as-is. Documented as best-effort.
+      with_store do |store|
+        fid = insert_flow_row(store, host: "a.test", target: "httpbin.org/x")
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Flow, fid))
+        r.label.should eq("GET httpbin.org/x")
+      end
+    end
+
+    it "preserves a multibyte/CJK target intact in the location" do
+      with_store do |store|
+        fid = insert_flow_row(store, host: "검색.test", target: "/검색?q=안녕")
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Flow, fid))
+        r.label.should eq("GET 검색.test/검색?q=안녕")
+        r.stale?.should be_false
+      end
+    end
+  end
+
+  describe "Resolved#line" do
+    it "renders '[<tag>] <label>' exactly" do
+      with_store do |store|
+        fid = insert_flow_row(store, host: "a.test", target: "/x")
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Flow, fid))
+        r.line.should eq("[hist] GET a.test/x")
+      end
+    end
+
+    it "renders a gone flow line" do
+      with_store do |store|
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Flow, 5_i64))
+        r.line.should eq("[hist] flow #5 (gone)")
+      end
+    end
+  end
+
+  describe ".resolve (repeater)" do
+    it "marks a gone repeater stale with a '(gone)' label and tag 'repeater'" do
+      with_store do |store|
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Repeater, 42_i64))
+        r.tag.should eq("repeater")
+        r.label.should eq("repeater #42 (gone)")
+        r.url.should eq("repeater #42")
+        r.stale?.should be_true
+        r.line.should eq("[repeater] repeater #42 (gone)")
+      end
+    end
+
+    it "prefers the custom name for a present repeater" do
+      with_store do |store|
+        id = store.insert_repeater("https://t.test", "GET /a HTTP/1.1\r\n\r\n", false, false, nil, 0)
+        store.set_repeater_name(id, "my tab")
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Repeater, id))
+        r.label.should eq("my tab")
+        r.url.should eq("https://t.test")
+        r.stale?.should be_false
+      end
+    end
+
+    it "falls back to the request's first line when unnamed" do
+      with_store do |store|
+        id = store.insert_repeater("https://t.test", "GET /a HTTP/1.1\r\nHost: t.test\r\n\r\n", false, false, nil, 0)
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Repeater, id))
+        r.label.should eq("GET /a HTTP/1.1")
+        r.stale?.should be_false
+      end
+    end
+
+    it "falls back to 'repeater #N' when unnamed and the request is all-blank" do
+      with_store do |store|
+        id = store.insert_repeater("https://t.test", "\r\n   \r\n\r\n", false, false, nil, 0)
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Repeater, id))
+        r.label.should eq("repeater ##{id}")
+      end
+    end
+
+    it "falls back to 'repeater #N' when unnamed and the request is empty" do
+      with_store do |store|
+        id = store.insert_repeater("https://t.test", "", false, false, nil, 0)
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Repeater, id))
+        r.label.should eq("repeater ##{id}")
+      end
+    end
+  end
+
+  describe ".resolve (fuzz)" do
+    it "marks a gone fuzz session stale with a '(gone)' label and tag 'fuzz'" do
+      with_store do |store|
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Fuzz, 9_i64))
+        r.tag.should eq("fuzz")
+        r.label.should eq("fuzz #9 (gone)")
+        r.url.should eq("fuzz #9")
+        r.stale?.should be_true
+      end
+    end
+
+    it "prefers the name, else the template's first line for a present session" do
+      with_store do |store|
+        named = store.insert_fuzz_session("https://f.test", "GET /§x§ HTTP/1.1\r\n\r\n", false, nil, "{}", nil, 0, "attack A")
+        r1 = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Fuzz, named))
+        r1.label.should eq("attack A")
+        r1.url.should eq("https://f.test")
+        r1.stale?.should be_false
+
+        unnamed = store.insert_fuzz_session("https://f.test", "POST /login HTTP/1.1\r\nHost: f.test\r\n\r\n", false, nil, "{}", nil, 1)
+        r2 = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Fuzz, unnamed))
+        r2.label.should eq("POST /login HTTP/1.1")
+      end
+    end
+  end
+
+  describe ".resolve (miner)" do
+    it "marks a gone miner session stale with a '(gone)' label and tag 'miner'" do
+      with_store do |store|
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Miner, 3_i64))
+        r.tag.should eq("miner")
+        r.label.should eq("miner #3 (gone)")
+        r.url.should eq("miner #3")
+        r.stale?.should be_true
+      end
+    end
+
+    it "derives the label from the byte-exact request's first line when unnamed" do
+      with_store do |store|
+        req = "GET /params HTTP/1.1\r\nHost: m.test\r\n\r\n".to_slice
+        id = store.insert_miner_session("https://m.test", req, false, nil, "{}", nil, 0)
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Miner, id))
+        r.label.should eq("GET /params HTTP/1.1")
+        r.url.should eq("https://m.test")
+        r.stale?.should be_false
+      end
+    end
+
+    it "falls back to 'miner #N' when unnamed and the request bytes are empty" do
+      with_store do |store|
+        id = store.insert_miner_session("https://m.test", Bytes.new(0), false, nil, "{}", nil, 0)
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Miner, id))
+        r.label.should eq("miner ##{id}")
+      end
+    end
+  end
+
+  describe "first_line (via label fallback)" do
+    it "skips leading blank lines and returns the first non-blank line" do
+      with_store do |store|
+        id = store.insert_repeater("https://t.test", "\r\n\r\n   \r\nGET /deep HTTP/1.1\r\n\r\n", false, false, nil, 0)
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Repeater, id))
+        r.label.should eq("GET /deep HTTP/1.1")
+      end
+    end
+
+    it "strips a trailing CR from the returned line" do
+      with_store do |store|
+        # No trailing LF on the first line; rstrip('\r') must drop the CR.
+        id = store.insert_repeater("https://t.test", "GET /x HTTP/1.1\r", false, false, nil, 0)
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Repeater, id))
+        r.label.should eq("GET /x HTTP/1.1")
+      end
+    end
+
+    it "preserves a multibyte/CJK first line intact" do
+      with_store do |store|
+        id = store.insert_repeater("https://t.test", "GET /검색 HTTP/1.1\r\nHost: t.test\r\n\r\n", false, false, nil, 0)
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Repeater, id))
+        r.label.should eq("GET /검색 HTTP/1.1")
+      end
+    end
+
+    it "returns an all-emoji first line intact" do
+      with_store do |store|
+        id = store.insert_repeater("https://t.test", "GET /🔥/世界 HTTP/1.1\r\n\r\n", false, false, nil, 0)
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Repeater, id))
+        r.label.should eq("GET /🔥/世界 HTTP/1.1")
+      end
+    end
+
+    it "handles a huge run of blank lines quickly (linear robustness)" do
+      with_store do |store|
+        req = ("\r\n" * 100_000) + "GET /late HTTP/1.1\r\n"
+        id = store.insert_repeater("https://t.test", req, false, false, nil, 0)
+        elapsed = Time.measure do
+          r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Repeater, id))
+          r.label.should eq("GET /late HTTP/1.1")
+        end
+        elapsed.total_seconds.should be < 5.0
+      end
+    end
+
+    it "does not raise on a miner request with invalid UTF-8 bytes" do
+      with_store do |store|
+        # 0xFF is never valid UTF-8; String.new lossily replaces it. Must not crash.
+        req = Bytes[0x47, 0x45, 0x54, 0x20, 0xFF, 0x0D, 0x0A] # "GET \xFF\r\n"
+        id = store.insert_miner_session("https://m.test", req, false, nil, "{}", nil, 0)
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Miner, id))
+        r.stale?.should be_false
+        r.label.empty?.should be_false
+      end
+    end
+
+    it "returns the miner default when the request bytes are all blank lines" do
+      with_store do |store|
+        id = store.insert_miner_session("https://m.test", "\r\n\r\n".to_slice, false, nil, "{}", nil, 0)
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Miner, id))
+        r.label.should eq("miner ##{id}")
+      end
+    end
+  end
+
+  describe ".resolve_all" do
+    it "returns an empty array for an empty input" do
+      with_store do |store|
+        Gori::Links.resolve_all(store, [] of Gori::Store::EntityLink).should be_empty
+      end
+    end
+
+    it "preserves order and per-element stale flags over a mixed present/stale array" do
+      with_store do |store|
+        fid = insert_flow_row(store, host: "a.test", target: "/x")
+        rid = store.insert_repeater("https://t.test", "GET /a HTTP/1.1\r\n\r\n", false, false, nil, 0)
+
+        links = [
+          link_for(Gori::Store::LinkRefKind::Flow, fid),      # present
+          link_for(Gori::Store::LinkRefKind::Flow, 999_i64),  # gone
+          link_for(Gori::Store::LinkRefKind::Repeater, rid),  # present
+          link_for(Gori::Store::LinkRefKind::Miner, 888_i64), # gone
+        ]
+        resolved = Gori::Links.resolve_all(store, links)
+
+        resolved.size.should eq(4)
+        resolved.map(&.stale?).should eq([false, true, false, true])
+        resolved[0].label.should eq("GET a.test/x")
+        resolved[1].label.should eq("flow #999 (gone)")
+        resolved[2].label.should eq("GET /a HTTP/1.1")
+        resolved[3].label.should eq("miner #888 (gone)")
+        resolved.map(&.tag).should eq(["hist", "hist", "repeater", "miner"])
+      end
+    end
+  end
+end

--- a/spec/miner/baseline_spec.cr
+++ b/spec/miner/baseline_spec.cr
@@ -1,0 +1,320 @@
+require "../spec_helper"
+
+private alias M = Gori::Miner
+private alias F = Gori::Fuzz
+
+# Build a Baseline::Report directly (decide() is pure over a Report + Probe). Defaults are a
+# "clean" baseline; each spec overrides only the fields it exercises.
+private def mk_report(status : Int32? = 200, length_tol = 10_i64, words_tol = 5, lines_tol = 3,
+                      base_length = 100_i64, base_words = 50, base_lines = 20,
+                      stable = true,
+                      reflection_only = Hash(M::Location, Bool).new,
+                      reflects_all = Hash(M::Location, Bool).new,
+                      warning : String? = nil) : M::Baseline::Report
+  M::Baseline::Report.new(status, length_tol, words_tol, lines_tol,
+    base_length, base_words, base_lines, stable, reflection_only, reflects_all, warning)
+end
+
+# Build a Probe directly: metrics + the SET of reflected canaries (reflects? is a set lookup).
+private def mk_probe(status : Int32? = 200, length = 100_i64, words = 50, lines = 20,
+                     canaries : Set(String) = Set(String).new) : M::Probe
+  M::Probe.new(F::Metrics.new(status, length, words, lines, 1000_i64), canaries)
+end
+
+# A Fuzz::Backend whose send() returns each status in `codes` in turn (holding the last one
+# once exhausted). No error → probes always parse.
+private class SequenceBackend < F::Backend
+  getter origin : F::Origin
+
+  def initialize(@codes : Array(Int32))
+    @origin = F::Origin.new("http", "h", 80)
+    @i = 0
+  end
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    code = @codes[@i]? || @codes.last
+    @i += 1
+    body = "BASELINE BODY".to_slice
+    head = "HTTP/1.1 #{code} X\r\nContent-Length: #{body.size}\r\n\r\n".to_slice
+    resp = Gori::Proxy::Codec::Http1.parse_response_head(head)
+    Gori::Repeater::Result.new(head, body, resp, 1000_i64)
+  end
+end
+
+# A Fuzz::Backend whose every send() errors (connection refused) — the calibrator can never
+# obtain a single probe.
+private class DeadBackend < F::Backend
+  getter origin : F::Origin
+
+  def initialize
+    @origin = F::Origin.new("http", "h", 80)
+  end
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    Gori::Repeater::Result.new(Bytes.empty, nil, nil, 0_i64, "connection refused")
+  end
+end
+
+# An empty typed candidate list (name => canary pairs). A file-local helper so the tuple
+# element type never has to be spelled inline as a call argument.
+private def no_candidates : Array({String, String})
+  Array({String, String}).new
+end
+
+private def calibrate_cfg(stability_rounds = 2) : M::Config
+  c = M::Config.new
+  c.stability_rounds = stability_rounds
+  c
+end
+
+describe "Gori::Miner.decide" do
+  describe "metric precedence ladder (Status > Length > Words > Lines)" do
+    it "picks Status when status, length, words, and lines all diverge (strongest ONE)" do
+      report = mk_report(status: 200, base_length: 100_i64, base_words: 50, base_lines: 20)
+      probe = mk_probe(status: 500, length: 100_000_i64, words: 5_000, lines: 3_000)
+      d = M.decide(report, probe, no_candidates, M::Location::Query)
+      d.kind.should eq(M::DiffKind::Status)
+    end
+
+    it "picks Length (not Words) when status is equal but both length and words diverge" do
+      report = mk_report(status: 200, base_length: 100_i64, base_words: 50)
+      probe = mk_probe(status: 200, length: 100_000_i64, words: 5_000)
+      d = M.decide(report, probe, no_candidates, M::Location::Query)
+      d.kind.should eq(M::DiffKind::Length)
+    end
+
+    it "picks Words (skipping Length) when status equal + length within tol + words exceed tol" do
+      # length delta 0 (within tol), words delta 100 (> words_tol 5): the ladder falls
+      # through Length to Words.
+      report = mk_report(status: 200, base_length: 100_i64, length_tol: 10_i64,
+        base_words: 50, words_tol: 5)
+      probe = mk_probe(status: 200, length: 100_i64, words: 150)
+      d = M.decide(report, probe, no_candidates, M::Location::Query)
+      d.kind.should eq(M::DiffKind::Words)
+    end
+
+    it "picks Lines when only lines diverge (status/length/words all within tol)" do
+      report = mk_report(status: 200, base_length: 100_i64, length_tol: 10_i64,
+        base_words: 50, words_tol: 5, base_lines: 20, lines_tol: 3)
+      probe = mk_probe(status: 200, length: 100_i64, words: 50, lines: 200)
+      d = M.decide(report, probe, no_candidates, M::Location::Query)
+      d.kind.should eq(M::DiffKind::Lines)
+    end
+
+    it "picks Words over Lines when both exceed but length/status are within tol" do
+      report = mk_report(status: 200, base_length: 100_i64, length_tol: 10_i64,
+        base_words: 50, words_tol: 5, base_lines: 20, lines_tol: 3)
+      probe = mk_probe(status: 200, length: 100_i64, words: 500, lines: 500)
+      d = M.decide(report, probe, no_candidates, M::Location::Query)
+      d.kind.should eq(M::DiffKind::Words)
+    end
+
+    it "yields None when every metric is within tolerance" do
+      report = mk_report(status: 200, base_length: 100_i64, length_tol: 10_i64,
+        base_words: 50, words_tol: 5, base_lines: 20, lines_tol: 3)
+      probe = mk_probe(status: 200, length: 105_i64, words: 52, lines: 21)
+      d = M.decide(report, probe, no_candidates, M::Location::Query)
+      d.kind.should eq(M::DiffKind::None)
+    end
+  end
+
+  describe "length tolerance boundary (strict >, off-by-one)" do
+    it "does NOT flag a positive length delta EXACTLY equal to length_tol" do
+      report = mk_report(status: 200, base_length: 100_i64, length_tol: 10_i64)
+      probe = mk_probe(status: 200, length: 110_i64) # delta == 10 == tol
+      M.decide(report, probe, no_candidates, M::Location::Query)
+        .kind.should eq(M::DiffKind::None)
+    end
+
+    it "DOES flag a positive length delta of tol + 1" do
+      report = mk_report(status: 200, base_length: 100_i64, length_tol: 10_i64)
+      probe = mk_probe(status: 200, length: 111_i64) # delta == 11 == tol + 1
+      M.decide(report, probe, no_candidates, M::Location::Query)
+        .kind.should eq(M::DiffKind::Length)
+    end
+
+    it "does NOT flag a negative length delta EXACTLY equal to length_tol" do
+      report = mk_report(status: 200, base_length: 100_i64, length_tol: 10_i64)
+      probe = mk_probe(status: 200, length: 90_i64) # |delta| == 10 == tol
+      M.decide(report, probe, no_candidates, M::Location::Query)
+        .kind.should eq(M::DiffKind::None)
+    end
+
+    it "DOES flag a negative length delta of tol + 1" do
+      report = mk_report(status: 200, base_length: 100_i64, length_tol: 10_i64)
+      probe = mk_probe(status: 200, length: 89_i64) # |delta| == 11 == tol + 1
+      M.decide(report, probe, no_candidates, M::Location::Query)
+        .kind.should eq(M::DiffKind::Length)
+    end
+
+    it "treats a zero length_tol so any nonzero delta flags Length (delta 0 stays None)" do
+      report = mk_report(status: 200, base_length: 100_i64, length_tol: 0_i64)
+      M.decide(report, mk_probe(status: 200, length: 100_i64),
+        no_candidates, M::Location::Query).kind.should eq(M::DiffKind::None)
+      M.decide(report, mk_probe(status: 200, length: 101_i64),
+        no_candidates, M::Location::Query).kind.should eq(M::DiffKind::Length)
+    end
+  end
+
+  describe "status comparison" do
+    it "flags Status when the report baseline status is nil but the probe has one" do
+      report = mk_report(status: nil, base_length: 100_i64)
+      probe = mk_probe(status: 200, length: 100_i64)
+      M.decide(report, probe, no_candidates, M::Location::Query)
+        .kind.should eq(M::DiffKind::Status)
+    end
+
+    it "does NOT flag Status when both baseline and probe status are nil" do
+      report = mk_report(status: nil, base_length: 100_i64, length_tol: 10_i64)
+      probe = mk_probe(status: nil, length: 100_i64)
+      M.decide(report, probe, no_candidates, M::Location::Query)
+        .kind.should eq(M::DiffKind::None)
+    end
+  end
+
+  describe "reflection_only gate (suppresses ALL metric kinds)" do
+    it "returns None even with a huge length delta, while reflection still populates" do
+      loc = M::Location::Query
+      report = mk_report(status: 200, base_length: 100_i64, length_tol: 10_i64,
+        reflection_only: {loc => true})
+      probe = mk_probe(status: 500, length: 1_000_000_i64, canaries: Set{"gqdeadbeef"})
+      d = M.decide(report, probe, [{"secret", "gqdeadbeef"}], loc)
+      d.kind.should eq(M::DiffKind::None)
+      d.reflected.should eq({"gqdeadbeef" => "secret"})
+    end
+
+    it "still evaluates metrics for a DIFFERENT location not marked reflection-only" do
+      report = mk_report(status: 200, base_length: 100_i64, length_tol: 10_i64,
+        reflection_only: {M::Location::Form => true})
+      probe = mk_probe(status: 200, length: 1_000_i64)
+      # location Query is absent from the map → metrics evaluated normally.
+      M.decide(report, probe, no_candidates, M::Location::Query)
+        .kind.should eq(M::DiffKind::Length)
+    end
+
+    it "a reflection_only value of false does NOT suppress metrics" do
+      loc = M::Location::Query
+      report = mk_report(status: 200, base_length: 100_i64, length_tol: 10_i64,
+        reflection_only: {loc => false})
+      probe = mk_probe(status: 200, length: 1_000_i64)
+      M.decide(report, probe, no_candidates, loc).kind.should eq(M::DiffKind::Length)
+    end
+  end
+
+  describe "reflects_all gate (skips reflection detection entirely)" do
+    it "yields an empty reflected map even when the candidate canary IS present" do
+      loc = M::Location::Query
+      report = mk_report(status: 200, base_length: 100_i64, length_tol: 10_i64,
+        reflects_all: {loc => true})
+      probe = mk_probe(status: 200, length: 100_i64, canaries: Set{"gqcafebabe"})
+      d = M.decide(report, probe, [{"secret", "gqcafebabe"}], loc)
+      d.reflected.should be_empty
+    end
+
+    it "does NOT suppress the metric ladder — length still diffs on an echo endpoint" do
+      loc = M::Location::Query
+      report = mk_report(status: 200, base_length: 100_i64, length_tol: 10_i64,
+        reflects_all: {loc => true})
+      probe = mk_probe(status: 200, length: 1_000_i64, canaries: Set{"gqcafebabe"})
+      d = M.decide(report, probe, [{"secret", "gqcafebabe"}], loc)
+      d.reflected.should be_empty
+      d.kind.should eq(M::DiffKind::Length)
+    end
+
+    it "detects reflection normally when reflects_all is false for the location" do
+      loc = M::Location::Query
+      report = mk_report(status: 200, base_length: 100_i64, reflects_all: {loc => false})
+      probe = mk_probe(status: 200, length: 100_i64, canaries: Set{"gqcafebabe"})
+      d = M.decide(report, probe, [{"secret", "gqcafebabe"}], loc)
+      d.reflected.should eq({"gqcafebabe" => "secret"})
+    end
+  end
+
+  describe "candidate reflection mapping (canary => name)" do
+    it "maps ONLY the present canary and omits the absent candidate" do
+      probe = mk_probe(status: 200, length: 100_i64, canaries: Set{"gqaaaaaaaa"})
+      d = M.decide(mk_report, probe,
+        [{"present", "gqaaaaaaaa"}, {"absent", "gqbbbbbbbb"}], M::Location::Query)
+      d.reflected.should eq({"gqaaaaaaaa" => "present"})
+    end
+
+    it "maps every present candidate when several reflect" do
+      probe = mk_probe(status: 200, length: 100_i64,
+        canaries: Set{"gqaaaaaaaa", "gqbbbbbbbb"})
+      d = M.decide(mk_report, probe,
+        [{"one", "gqaaaaaaaa"}, {"two", "gqbbbbbbbb"}, {"three", "gqcccccccc"}],
+        M::Location::Query)
+      d.reflected.should eq({"gqaaaaaaaa" => "one", "gqbbbbbbbb" => "two"})
+    end
+
+    it "reports BOTH a reflection and a metric diff when neither gate is set (real finding)" do
+      # The everyday shape: a param echoes its canary AND shifts length, no suppression gate.
+      loc = M::Location::Query
+      report = mk_report(status: 200, base_length: 100_i64, length_tol: 10_i64)
+      probe = mk_probe(status: 200, length: 1_000_i64, canaries: Set{"gqaaaaaaaa"})
+      d = M.decide(report, probe, [{"secret", "gqaaaaaaaa"}], loc)
+      d.reflected.should eq({"gqaaaaaaaa" => "secret"})
+      d.kind.should eq(M::DiffKind::Length)
+    end
+
+    it "returns an empty reflected map for an empty candidate list" do
+      probe = mk_probe(status: 200, length: 100_i64, canaries: Set{"gqaaaaaaaa"})
+      M.decide(mk_report, probe, no_candidates, M::Location::Query)
+        .reflected.should be_empty
+    end
+
+    it "maps a candidate whose NAME is CJK/emoji (name is opaque; keyed by canary)" do
+      probe = mk_probe(status: 200, length: 100_i64, canaries: Set{"gqaaaaaaaa"})
+      d = M.decide(mk_report, probe, [{"안녕_世界_🚀", "gqaaaaaaaa"}], M::Location::Query)
+      d.reflected.should eq({"gqaaaaaaaa" => "안녕_世界_🚀"})
+    end
+
+    it "when the same canary is given twice, the LAST name wins in the map" do
+      probe = mk_probe(status: 200, length: 100_i64, canaries: Set{"gqaaaaaaaa"})
+      d = M.decide(mk_report, probe,
+        [{"first", "gqaaaaaaaa"}, {"second", "gqaaaaaaaa"}], M::Location::Query)
+      d.reflected.should eq({"gqaaaaaaaa" => "second"})
+    end
+  end
+
+  describe "adversarial / performance" do
+    it "handles a huge candidate list with no reflections in linear time" do
+      probe = mk_probe(status: 200, length: 100_i64, canaries: Set(String).new)
+      candidates = (0...200_000).map { |i| {"p#{i}", "gq#{i.to_s.rjust(8, '0')[0, 8]}"} }
+      elapsed = Time.measure do
+        d = M.decide(mk_report, probe, candidates, M::Location::Query)
+        d.reflected.should be_empty
+        d.kind.should eq(M::DiffKind::None)
+      end
+      elapsed.total_seconds.should be < 5.0
+    end
+  end
+end
+
+describe "Gori::Miner::Baseline#calibrate" do
+  it "returns an unreachable Report when every stability-round send errors" do
+    b = M::Baseline.new(DeadBackend.new, "GET / HTTP/1.1\r\nHost: h\r\n\r\n".to_slice,
+      calibrate_cfg(stability_rounds: 3))
+    report = b.calibrate(Array(M::Location).new)
+    report.status.should be_nil
+    report.stable.should be_false
+    report.warning.should eq("baseline unreachable")
+  end
+
+  it "warns 'baseline status varies (200/500)' when statuses differ across rounds" do
+    b = M::Baseline.new(SequenceBackend.new([200, 500]),
+      "GET / HTTP/1.1\r\nHost: h\r\n\r\n".to_slice, calibrate_cfg(stability_rounds: 2))
+    report = b.calibrate(Array(M::Location).new)
+    report.stable.should be_false
+    report.warning.not_nil!.should contain("baseline status varies (200/500)")
+  end
+
+  it "reports a stable baseline (no status warning) when every round is the same status" do
+    b = M::Baseline.new(SequenceBackend.new([200, 200, 200]),
+      "GET / HTTP/1.1\r\nHost: h\r\n\r\n".to_slice, calibrate_cfg(stability_rounds: 3))
+    report = b.calibrate(Array(M::Location).new)
+    report.stable.should be_true
+    report.status.should eq(200)
+    (report.warning.nil? || !report.warning.not_nil!.includes?("varies")).should be_true
+  end
+end

--- a/spec/miner/detect_spec.cr
+++ b/spec/miner/detect_spec.cr
@@ -1,0 +1,143 @@
+require "../spec_helper"
+
+private alias M = Gori::Miner
+
+private def req(s : String) : Bytes
+  s.to_slice
+end
+
+# Build a request whose body carries raw (possibly non-UTF-8) bytes: the request line +
+# headers + blank line are written as text, then the raw body bytes are appended verbatim.
+private def req_with_body(head : String, body : Bytes) : Bytes
+  io = IO::Memory.new
+  io << head
+  io.write(body)
+  io.to_slice
+end
+
+describe Gori::Miner::Detect do
+  describe "json by body shape (body_looks_json?) even with a non-JSON content-type" do
+    it "offers Json for a {\"a\":1} object body sent as text/plain" do
+      base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: text/plain\r\nContent-Length: 7\r\n\r\n{\"a\":1}"
+      appl = M::Detect.detect(req(base))
+      appl.applicable.should contain(M::Location::Json)
+      appl.default.should contain(M::Location::Json)
+    end
+
+    it "offers Json for an array-of-objects body sent as text/plain" do
+      base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: text/plain\r\nContent-Length: 9\r\n\r\n[{\"a\":1}]"
+      M::Detect.detect(req(base)).applicable.should contain(M::Location::Json)
+    end
+
+    it "offers Json for a multibyte object body (CJK keys/values) sent as text/plain" do
+      body = %({"\u{540D}":"\u{4E16}\u{754C}","안녕":true})
+      base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: text/plain\r\nContent-Length: #{body.bytesize}\r\n\r\n#{body}"
+      M::Detect.detect(req(base)).applicable.should contain(M::Location::Json)
+    end
+
+    it "does NOT offer Json for a plain-text non-JSON body under text/plain" do
+      base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhello"
+      M::Detect.detect(req(base)).applicable.should_not contain(M::Location::Json)
+    end
+  end
+
+  describe "body_looks_json? whitespace tolerance (lstrip)" do
+    it "tolerates leading spaces before the open brace under text/plain" do
+      base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: text/plain\r\nContent-Length: 10\r\n\r\n   {\"a\":1}"
+      M::Detect.detect(req(base)).applicable.should contain(M::Location::Json)
+    end
+
+    it "tolerates mixed leading whitespace (tab/newline/CR) before an array root" do
+      base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: text/plain\r\nContent-Length: 12\r\n\r\n\t\r\n [{\"a\":1}]"
+      M::Detect.detect(req(base)).applicable.should contain(M::Location::Json)
+    end
+
+    it "does not treat a body with non-whitespace leading junk as JSON" do
+      base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: text/plain\r\nContent-Length: 8\r\n\r\nx {\"a\":1}"
+      M::Detect.detect(req(base)).applicable.should_not contain(M::Location::Json)
+    end
+  end
+
+  describe "body_looks_json? invalid-UTF-8 scrub (first 64 bytes)" do
+    it "scrubs a body with leading invalid UTF-8 bytes without raising and offers no Json (text/plain)" do
+      # 0xff/0xfe are invalid UTF-8 lead bytes; scrub -> replacement char (not whitespace),
+      # so lstrip cannot expose the following brace and the shape sniff must be false.
+      head = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: text/plain\r\nContent-Length: 12\r\n\r\n"
+      body = IO::Memory.new
+      body.write(Bytes[0xff_u8, 0xfe_u8, 0xff_u8])
+      body << "{\"a\":1}"
+      bytes = req_with_body(head, body.to_slice)
+      appl = M::Detect.detect(bytes)
+      appl.applicable.should eq([M::Location::Query, M::Location::Headers, M::Location::Cookies])
+    end
+
+    it "does not raise when the first 64 bytes are entirely invalid UTF-8 (text/plain)" do
+      head = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: text/plain\r\nContent-Length: 80\r\n\r\n"
+      junk = Bytes.new(80) { 0xff_u8 }
+      bytes = req_with_body(head, junk)
+      appl = M::Detect.detect(bytes)
+      appl.applicable.should_not contain(M::Location::Json)
+    end
+  end
+
+  describe "has_body guard for empty bodies" do
+    it "does NOT offer Json for application/json with an empty body" do
+      base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n"
+      appl = M::Detect.detect(req(base))
+      appl.applicable.should eq([M::Location::Query, M::Location::Headers, M::Location::Cookies])
+      appl.applicable.should_not contain(M::Location::Json)
+      appl.default.should eq([M::Location::Query])
+    end
+
+    it "does NOT offer Form for x-www-form-urlencoded with an empty body" do
+      base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: 0\r\n\r\n"
+      appl = M::Detect.detect(req(base))
+      appl.applicable.should eq([M::Location::Query, M::Location::Headers, M::Location::Cookies])
+      appl.applicable.should_not contain(M::Location::Form)
+      appl.default.should eq([M::Location::Query])
+    end
+
+    it "does NOT offer Multipart for multipart/form-data with an empty body" do
+      base = "POST /u HTTP/1.1\r\nHost: h\r\nContent-Type: multipart/form-data; boundary=B\r\nContent-Length: 0\r\n\r\n"
+      M::Detect.detect(req(base)).applicable.should_not contain(M::Location::Multipart)
+    end
+  end
+
+  describe "multipart content-type case-insensitivity" do
+    it "offers Multipart for an upper-case MULTIPART/FORM-DATA content-type" do
+      body = "--B\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\n1\r\n--B--\r\n"
+      base = "POST /u HTTP/1.1\r\nHost: h\r\nContent-Type: MULTIPART/FORM-DATA; boundary=B\r\nContent-Length: #{body.bytesize}\r\n\r\n#{body}"
+      appl = M::Detect.detect(req(base))
+      appl.applicable.should contain(M::Location::Multipart)
+      appl.default.should_not contain(M::Location::Multipart)
+    end
+
+    it "offers Multipart for a mixed-case content-type with leading whitespace" do
+      body = "--xyz\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\n1\r\n--xyz--\r\n"
+      base = "POST /u HTTP/1.1\r\nHost: h\r\nContent-Type: Multipart/Form-Data; boundary=xyz\r\nContent-Length: #{body.bytesize}\r\n\r\n#{body}"
+      M::Detect.detect(req(base)).applicable.should contain(M::Location::Multipart)
+    end
+  end
+
+  describe "json shape sniffs but has no object node (json_object_node_count == 0)" do
+    it "does NOT offer Json for an array of scalars that looks like JSON under text/plain" do
+      # body_looks_json? is true (leading '['), but there is no injectable object node.
+      base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: text/plain\r\nContent-Length: 7\r\n\r\n[1,2,3]"
+      M::Detect.detect(req(base)).applicable.should_not contain(M::Location::Json)
+    end
+
+    it "does NOT offer Json for a bare-scalar-ish body that does not start with brace/bracket" do
+      base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: text/plain\r\nContent-Length: 3\r\n\r\n123"
+      M::Detect.detect(req(base)).applicable.should_not contain(M::Location::Json)
+    end
+  end
+
+  describe "location ordering and always-applicable locations" do
+    it "always appends Headers and Cookies (default OFF) after body locations" do
+      base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: 3\r\n\r\nx=1"
+      appl = M::Detect.detect(req(base))
+      appl.applicable.should eq([M::Location::Query, M::Location::Form, M::Location::Headers, M::Location::Cookies])
+      appl.default.should eq([M::Location::Query, M::Location::Form])
+    end
+  end
+end

--- a/spec/miner/fingerprint_spec.cr
+++ b/spec/miner/fingerprint_spec.cr
@@ -1,0 +1,213 @@
+require "../spec_helper"
+
+# Concatenate string / raw-byte parts into one Bytes slice (for building bodies that mix
+# ASCII text with adversarial / invalid-UTF-8 bytes).
+private def cat(*parts : String | Bytes) : Bytes
+  io = IO::Memory.new
+  parts.each do |p|
+    case p
+    in String then io.write(p.to_slice)
+    in Bytes  then io.write(p)
+    end
+  end
+  io.to_slice
+end
+
+# A clean response head with a status but NO canary-shaped token and NO content/transfer
+# encoding header (so ContentDecode short-circuits and the body is used verbatim).
+private def clean_head : Bytes
+  "HTTP/1.1 200 OK\r\n\r\n".to_slice
+end
+
+# Build a Repeater::Result exactly as engine_spec's ok() does, then probe it.
+private def probe_raw(head : Bytes, body : Bytes) : Gori::Miner::Probe
+  resp = Gori::Proxy::Codec::Http1.parse_response_head(head)
+  Gori::Miner::Fingerprint.probe(Gori::Repeater::Result.new(head, body, resp, 1000_i64))
+end
+
+private def probe_body(body : Bytes) : Gori::Miner::Probe
+  probe_raw(clean_head, body)
+end
+
+private def probe_str(body : String) : Gori::Miner::Probe
+  probe_body(body.to_slice)
+end
+
+describe Gori::Miner::Fingerprint do
+  describe "canary reflection (scan_canaries via probe)" do
+    it "finds a canary placed at the LAST valid body offset (i == last boundary)" do
+      # 3 bytes of padding then the 10-byte canary as the final bytes: 'g' sits at
+      # index size-10 == last, the highest offset the `i <= last` loop still checks.
+      p = probe_str("ZZZgqdeadbeef")
+      p.reflects?("gqdeadbeef").should be_true
+      p.canaries.should eq(Set{"gqdeadbeef"})
+    end
+
+    it "collects TWO adjacent canaries with no separator as distinct set entries" do
+      p = probe_str("gqaaaaaaaagqbbbbbbbb")
+      p.reflects?("gqaaaaaaaa").should be_true
+      p.reflects?("gqbbbbbbbb").should be_true
+      p.canaries.should eq(Set{"gqaaaaaaaa", "gqbbbbbbbb"})
+    end
+
+    it "returns an empty canary set for a body of exactly LEN-1 (9) bytes" do
+      # size 9 < Canary::LEN (10): scan_canaries early-returns before the loop.
+      p = probe_str("gqaaaaaaa") # gq + 7 hex = 9 bytes
+      p.canaries.should be_empty
+      p.reflects?("gqaaaaaaa").should be_false
+    end
+
+    it "finds a canary whose body is exactly LEN (10) bytes (last == 0)" do
+      p = probe_str("gq09af09af")
+      p.reflects?("gq09af09af").should be_true
+      p.canaries.size.should eq(1)
+    end
+
+    it "does NOT match an UPPERCASE hex tail (lower-hex only)" do
+      p = probe_str("gqAABBCCDD")
+      p.canaries.should be_empty
+      p.reflects?("gqAABBCCDD").should be_false
+    end
+
+    it "rejects a tail with a non-hex byte (gq + 7 hex + 'z')" do
+      p = probe_str("gq1234567z")
+      p.canaries.should be_empty
+      p.reflects?("gq1234567z").should be_false
+    end
+
+    it "accepts the full lower-hex alphabet 0-9 a-f in the tail" do
+      p = probe_str("gqabcdef01")
+      p.reflects?("gqabcdef01").should be_true
+    end
+
+    it "rejects tail bytes just outside each hex range (off-by-one boundaries)" do
+      # '/'=0x2f (below '0'), ':'=0x3a (above '9'), '`'=0x60 (below 'a'), 'g'=0x67 (above 'f')
+      probe_str("gq/0000000").canaries.should be_empty
+      probe_str("gq:0000000").canaries.should be_empty
+      probe_str("gq`0000000").canaries.should be_empty
+      probe_str("gqg0000000").canaries.should be_empty
+      # and the inclusive endpoints ARE accepted
+      probe_str("gq0000000f").reflects?("gq0000000f").should be_true
+      probe_str("gq9999999a").reflects?("gq9999999a").should be_true
+    end
+
+    it "requires the exact 'gq' prefix ('g' + non-'q' is not a canary)" do
+      p = probe_str("ghdeadbeef") # second byte 'h' (0x68) != 'q' (0x71)
+      p.canaries.should be_empty
+    end
+
+    it "reports a canary echoed ONLY in the response head (head scanned separately)" do
+      head = "HTTP/1.1 200 OK\r\nX-Reflected: gqcafebabe\r\n\r\n".to_slice
+      body = "clean baseline response, no token here".to_slice
+      p = probe_raw(head, body)
+      p.reflects?("gqcafebabe").should be_true
+      p.canaries.should eq(Set{"gqcafebabe"})
+    end
+
+    it "does NOT find a canary that straddles the body/head split (slices scanned independently)" do
+      # body ends with 'gqaaa' (partial); head begins with the remaining 'aaaaa'. Concatenated
+      # they spell 'gqaaaaaaaa', but each slice is scanned on its own so neither contains it.
+      body = "PADDINGgqaaa".to_slice # 'g' at index 7 > last (2) → never even inspected
+      head = "aaaaaHTTP/1.1 200 OK\r\n\r\n".to_slice
+      p = probe_raw(head, body)
+      p.reflects?("gqaaaaaaaa").should be_false
+      p.canaries.should be_empty
+    end
+
+    it "reports false for a canary-shaped needle that never appears" do
+      probe_str("nothing to see").reflects?("gq00000000").should be_false
+    end
+
+    it "finds a canary surrounded by invalid UTF-8 bytes (byte scan, not string scan)" do
+      body = cat(Bytes[0xff_u8, 0xfe_u8, 0x80_u8], "gqdeadbeef", Bytes[0x81_u8, 0xff_u8])
+      p = probe_body(body)
+      p.reflects?("gqdeadbeef").should be_true
+    end
+
+    it "does not treat overlapping 'gq' prefixes as a match when the tail starts with 'g'" do
+      # 'gqgqaaaaaa': at i=0 the tail's first byte is 'g' (0x67, not hex) → rejected.
+      probe_str("gqgqaaaaaa").canaries.should be_empty
+    end
+  end
+
+  describe "count_words (metrics.words via probe)" do
+    it "counts 0 words for an empty body" do
+      probe_body(Bytes.empty).metrics.words.should eq(0)
+    end
+
+    it "counts 0 words for whitespace-only bodies" do
+      probe_str(" \t\r\n ").metrics.words.should eq(0)
+    end
+
+    it "counts 1 word for a single token (with surrounding whitespace)" do
+      probe_str("  hello  ").metrics.words.should eq(1)
+    end
+
+    it "collapses a mixed run of space/tab/CR/LF between two tokens to a single boundary" do
+      probe_str("foo \t\r\n bar").metrics.words.should eq(2)
+    end
+
+    it "counts multibyte tokens by whitespace transition, not grapheme" do
+      probe_str("안녕 世界").metrics.words.should eq(2)
+      probe_str("안녕世界").metrics.words.should eq(1) # no whitespace → one contiguous run
+    end
+  end
+
+  describe "count_lines (metrics.lines via probe)" do
+    it "counts 0 lines for an empty body" do
+      probe_body(Bytes.empty).metrics.lines.should eq(0)
+    end
+
+    it "counts only LF (0x0a) — bare CR line endings yield 0 lines" do
+      probe_str("line1\rline2\rline3\r").metrics.lines.should eq(0)
+    end
+
+    it "counts a trailing LF" do
+      probe_str("only one line\n").metrics.lines.should eq(1)
+    end
+
+    it "counts each LF, including those inside CRLF sequences" do
+      probe_str("a\r\nb\r\nc").metrics.lines.should eq(2)
+      probe_str("a\nb\nc\n").metrics.lines.should eq(3)
+    end
+  end
+
+  describe "metrics scalars" do
+    it "carries status, decoded length, and duration through the probe" do
+      body = "hello world".to_slice
+      p = probe_body(body)
+      p.metrics.status.should eq(200)
+      p.metrics.length.should eq(body.size.to_i64)
+      p.metrics.duration_us.should eq(1000_i64)
+    end
+
+    it "treats a nil body as empty (0 length, no words/lines, no canaries)" do
+      resp = Gori::Proxy::Codec::Http1.parse_response_head(clean_head)
+      p = Gori::Miner::Fingerprint.probe(Gori::Repeater::Result.new(clean_head, nil, resp, 1000_i64))
+      p.metrics.length.should eq(0_i64)
+      p.metrics.words.should eq(0)
+      p.metrics.lines.should eq(0)
+      p.canaries.should be_empty
+    end
+  end
+
+  describe "adversarial / performance" do
+    it "scans a huge near-miss body in linear time without matching (backtracking-bait)" do
+      # 100k blocks of 'gqaaaaaaa!' = gq + 7 hex + '!': every block forces the full 8-byte
+      # tail loop and fails only on the last byte. A million bytes must complete promptly and
+      # find nothing (the scan is O(n), never quadratic).
+      body = ("gqaaaaaaa!" * 100_000).to_slice
+      elapsed = Time.measure do
+        p = probe_body(body)
+        p.canaries.should be_empty
+      end
+      elapsed.total_seconds.should be < 5.0
+    end
+
+    it "still finds a real canary buried in a large adversarial haystack" do
+      body = ("gqaaaaaaa!" * 50_000 + "gqfeedface" + "gqaaaaaaa!" * 50_000).to_slice
+      p = probe_body(body)
+      p.reflects?("gqfeedface").should be_true
+    end
+  end
+end

--- a/spec/oast/engine_spec.cr
+++ b/spec/oast/engine_spec.cr
@@ -9,35 +9,35 @@ private alias O = Gori::Oast
 #   key (bytes 0x00..0x1f) to PRIV_PEM's public key.
 # - MSG_B64: base64 of (IV ‖ AES-256-CFB ciphertext) of INTERACTION_JSON under that key.
 private PRIV_PEM = <<-PEM
------BEGIN PRIVATE KEY-----
-MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCYrErrK2qx8Pq5
-SZuN3rkUl9VL/X4I0O/aoq/ZvDYYKo2pf19V69B2MPkOz9LJBEQmk8sTy0Q5vehv
-69i8BApvlOC04QSTOfgjc7Cynx4kDUFXPkh24vePBK1fpkNuNoxQ8QsmLpGSSzfk
-DuDldtxoTPTjCu9G6Z0hVAVHlMh/uGH0twGyIv+i6R6ADFZDAgB1A6aaddRY4OOR
-Z/HLyvTIPVKGcWASlzN8Tsngp14RrZnNbwwp7OEvB8d6Idooi440R5wkx1FhuePs
-7aSXfAryxMKZuBHM3IkaHr7GGxV7Z/tWHNSYpjnfizvTuvwzh1fXdHAeQF695lTK
-MdAFnrp7AgMBAAECggEAA1UXZwL9v/zdPPgb91uQENaHyL+EZbyMtMGquXmQrwTF
-6x7UWKzeNy6iJvGc9fJiDL6QkRU/nzEh67rXBpgyuKQ/GQzg7vL/+IuZv80xNZjE
-QptlDJLXxnZhaOu+SBjGtNwarAl4SLB9nVeD5rycv7bnJQ1PriOQZzxNJgrHfBeg
-9t/FmSXHtBeRdAN/eLxDwS+zpev6y1Qa400objedxkN2ptx/M6fCDBP5ZcgMfPu8
-AhZcrBVcR7RB3BlON4Plz91HTHPflEqb92FcR475GNefGr4fQOeMOSW8JcYjeoHJ
-EP3nG+d7y5y8AbwH2k8ZbRbN7bw5HVHLMSU4fssOGQKBgQDVWhWxm/QBczOSP678
-aivxihzngQ4YeM1K2Rjx0JAFNNWj7eLE4Ee36j2aq5n6vuUmjC77WtR8fBASCloF
-ip+eWBawihT6bOMuJhTVnHdTmqGBOJWiotCUVFu4/H7i8KrMFDlJK1CQzpgifWeX
-cp7g+tpNP+3LhyfFs9GH0dVttQKBgQC3MRIzQo4MWOM+4ghGsawCPl3VLcxQZ8tt
-RcY6GuN9sWGCRLEMvnkS6q/gQOWcN9BrlP6ePajVzP2NHa7VGd/efw7tFYccKVqR
-cKHrMhWBjCv31htOASWqhTE/dqI8p85WcVj0J3sIS1s/XNsZ//Lmock6bE5kQczG
-YO3lR/UlbwKBgG+14oQDv2h+9HLQK4R45xdqlKXW2hWQMxXMxJXg+XfwaSiTZ1hk
-gsjWunjg/xfemkdrwTHVJksj/pojl20tX1RelUrMkh1ppC5GvEP40DYTUhtCEH9+
-tq3j2b7rXljfYN7IfBJGvsGDmv78IKCY4H22e1VVcuJNm1KWS9DM2u69AoGBAJvG
-pZRjRwlm2K6TZLhAw2URBZeOn0vMR2b/S0YDsWkj2if9I5UTrz8PxEjsxpNlvtyM
-0UtcYWKVMxK5p/7cRssbvmSKxt6Cp9o/LeEjMLh9qrHQJl3Zid8L7cnqpqDvjP1i
-22Ka4/s0oT4rRsFALZxC/SuqB6snbOtQZ1tuKh8PAoGBAIOcvhkavofj/oroiGcM
-ZPyZPo4tC4GLzcCzRznUox6qw7GpJhaRW1f4e5k2hmCJp/Sha4BPqblWoD3f84Ej
-AoYnPn6DAWVG5NOoazrfDDnYzWR0S6b9umD8W49e89Fgob56ZVgsJJy9euSuUZJ8
-WJsgaeppj/Vuf90EO0Z5M5v0
------END PRIVATE KEY-----
-PEM
+  -----BEGIN PRIVATE KEY-----
+  MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCYrErrK2qx8Pq5
+  SZuN3rkUl9VL/X4I0O/aoq/ZvDYYKo2pf19V69B2MPkOz9LJBEQmk8sTy0Q5vehv
+  69i8BApvlOC04QSTOfgjc7Cynx4kDUFXPkh24vePBK1fpkNuNoxQ8QsmLpGSSzfk
+  DuDldtxoTPTjCu9G6Z0hVAVHlMh/uGH0twGyIv+i6R6ADFZDAgB1A6aaddRY4OOR
+  Z/HLyvTIPVKGcWASlzN8Tsngp14RrZnNbwwp7OEvB8d6Idooi440R5wkx1FhuePs
+  7aSXfAryxMKZuBHM3IkaHr7GGxV7Z/tWHNSYpjnfizvTuvwzh1fXdHAeQF695lTK
+  MdAFnrp7AgMBAAECggEAA1UXZwL9v/zdPPgb91uQENaHyL+EZbyMtMGquXmQrwTF
+  6x7UWKzeNy6iJvGc9fJiDL6QkRU/nzEh67rXBpgyuKQ/GQzg7vL/+IuZv80xNZjE
+  QptlDJLXxnZhaOu+SBjGtNwarAl4SLB9nVeD5rycv7bnJQ1PriOQZzxNJgrHfBeg
+  9t/FmSXHtBeRdAN/eLxDwS+zpev6y1Qa400objedxkN2ptx/M6fCDBP5ZcgMfPu8
+  AhZcrBVcR7RB3BlON4Plz91HTHPflEqb92FcR475GNefGr4fQOeMOSW8JcYjeoHJ
+  EP3nG+d7y5y8AbwH2k8ZbRbN7bw5HVHLMSU4fssOGQKBgQDVWhWxm/QBczOSP678
+  aivxihzngQ4YeM1K2Rjx0JAFNNWj7eLE4Ee36j2aq5n6vuUmjC77WtR8fBASCloF
+  ip+eWBawihT6bOMuJhTVnHdTmqGBOJWiotCUVFu4/H7i8KrMFDlJK1CQzpgifWeX
+  cp7g+tpNP+3LhyfFs9GH0dVttQKBgQC3MRIzQo4MWOM+4ghGsawCPl3VLcxQZ8tt
+  RcY6GuN9sWGCRLEMvnkS6q/gQOWcN9BrlP6ePajVzP2NHa7VGd/efw7tFYccKVqR
+  cKHrMhWBjCv31htOASWqhTE/dqI8p85WcVj0J3sIS1s/XNsZ//Lmock6bE5kQczG
+  YO3lR/UlbwKBgG+14oQDv2h+9HLQK4R45xdqlKXW2hWQMxXMxJXg+XfwaSiTZ1hk
+  gsjWunjg/xfemkdrwTHVJksj/pojl20tX1RelUrMkh1ppC5GvEP40DYTUhtCEH9+
+  tq3j2b7rXljfYN7IfBJGvsGDmv78IKCY4H22e1VVcuJNm1KWS9DM2u69AoGBAJvG
+  pZRjRwlm2K6TZLhAw2URBZeOn0vMR2b/S0YDsWkj2if9I5UTrz8PxEjsxpNlvtyM
+  0UtcYWKVMxK5p/7cRssbvmSKxt6Cp9o/LeEjMLh9qrHQJl3Zid8L7cnqpqDvjP1i
+  22Ka4/s0oT4rRsFALZxC/SuqB6snbOtQZ1tuKh8PAoGBAIOcvhkavofj/oroiGcM
+  ZPyZPo4tC4GLzcCzRznUox6qw7GpJhaRW1f4e5k2hmCJp/Sha4BPqblWoD3f84Ej
+  AoYnPn6DAWVG5NOoazrfDDnYzWR0S6b9umD8W49e89Fgob56ZVgsJJy9euSuUZJ8
+  WJsgaeppj/Vuf90EO0Z5M5v0
+  -----END PRIVATE KEY-----
+  PEM
 
 private AESKEY_B64 = "i4CBi3bc+PYX6GqbkVqlF9NdghUyT9cJDPdJBDEfdxu2a2z1cLcrXCz0zISQplkWom1u622rnATmxmI7tH5x58T3m1mwW0+Fo8glhb4hZALcynWMacm6+nfDEKjVDP88pl9BzCezRkyrHl6FqGNvArssWb46YFGwhNCG4nFQWxPGEyBc5bI+0HlX3BibRv2K3YaJ6D267Ct5vgfYgo43yXOMqh09OUM3q7c5NGKtp+yCMd2hCL8A+wJxu/24ESbzIlx61S4isYDEGAGTpKq7zkubo2eg5nAc6slwblHQ4ghyeg1F4dUDAfb1NRVrnxJIG6kHrN0IQlIvepmeKjHaNA=="
 
@@ -83,7 +83,7 @@ describe Gori::Oast do
 
   describe O::Crypto do
     it "AES-256 round-trips through the decrypt helper (IV prefixed)" do
-      key = Bytes.new(32) { |i| i.to_u8 }
+      key = Bytes.new(32, &.to_u8)
       iv = Bytes.new(16) { |i| (0xa0 + i).to_u8 }
       plaintext = "the quick brown fox jumps over 13 lazy dogs"
       cipher = OpenSSL::Cipher.new("aes-256-cfb")
@@ -170,9 +170,156 @@ describe Gori::Oast do
   describe O::Presets do
     it "ships the public presets incl. 5 interactsh servers" do
       all = O::Presets.all
-      all.count { |p| p.kind.interactsh? }.should eq(5)
-      all.any? { |p| p.kind.boast? }.should be_true
-      all.any? { |p| p.kind.postbin? }.should be_true
+      all.count(&.kind.interactsh?).should eq(5)
+      all.any?(&.kind.boast?).should be_true
+      all.any?(&.kind.postbin?).should be_true
+    end
+  end
+
+  # --- APPENDED: pure boundary / error cases ----------------------------------
+
+  describe O::Crypto do
+    describe ".aes256_decrypt" do
+      it "raises Gori::Error when data is exactly 16 bytes (IV only, no ciphertext)" do
+        key = Bytes.new(32, &.to_u8)
+        expect_raises(Gori::Error) do
+          O::Crypto.aes256_decrypt(Bytes.new(16, &.to_u8), key, "aes-256-cfb")
+        end
+      end
+
+      it "does NOT raise at 17 bytes (16-byte IV + 1 ciphertext byte)" do
+        key = Bytes.new(32, &.to_u8)
+        out = O::Crypto.aes256_decrypt(Bytes.new(17, &.to_u8), key, "aes-256-cfb")
+        # CFB is a stream cipher: one ciphertext byte -> exactly one plaintext byte.
+        out.size.should eq(1)
+      end
+
+      it "round-trips aes-256-ctr (documented auto-detect fallback)" do
+        key = Bytes.new(32, &.to_u8)
+        iv = Bytes.new(16) { |i| (0x10 + i).to_u8 }
+        plaintext = "안녕 世界 — ctr fallback 🎯 payload"
+        cipher = OpenSSL::Cipher.new("aes-256-ctr")
+        cipher.encrypt
+        cipher.key = key
+        cipher.iv = iv
+        ct = IO::Memory.new
+        ct.write(cipher.update(plaintext))
+        ct.write(cipher.final)
+        msg = Bytes.new(16 + ct.bytesize)
+        iv.copy_to(msg)
+        ct.to_slice.copy_to(msg + 16)
+        String.new(O::Crypto.aes256_decrypt(msg, key, "aes-256-ctr")).should eq(plaintext)
+      end
+    end
+
+    describe ".random_id" do
+      it "returns the empty string for length 0" do
+        O::Crypto.random_id(0).should eq("")
+      end
+
+      it "returns a single DNS-safe char for length 1" do
+        id = O::Crypto.random_id(1)
+        id.size.should eq(1)
+        c = id[0]
+        (c.ascii_lowercase? || c.ascii_number?).should be_true
+      end
+
+      it "produces distinct ids across two length-20 calls" do
+        O::Crypto.random_id(20).should_not eq(O::Crypto.random_id(20))
+      end
+    end
+  end
+
+  describe O::RsaKeyPair do
+    describe ".from_private_pem" do
+      it "raises Gori::Error on non-PEM garbage" do
+        expect_raises(Gori::Error) { O::RsaKeyPair.from_private_pem("not a pem") }
+      end
+
+      it "raises Gori::Error on an empty string" do
+        expect_raises(Gori::Error) { O::RsaKeyPair.from_private_pem("") }
+      end
+    end
+
+    describe "#oaep_sha256_decrypt" do
+      it "raises Gori::Error on an undersized ciphertext (8 bytes)" do
+        kp = O::RsaKeyPair.from_private_pem(PRIV_PEM)
+        expect_raises(Gori::Error) { kp.oaep_sha256_decrypt(Bytes.new(8)) }
+      end
+
+      it "raises Gori::Error on a modulus-sized garbage buffer (OAEP unpad)" do
+        kp = O::RsaKeyPair.from_private_pem(PRIV_PEM)
+        garbage = Bytes.new(256) { |i| (i * 7 + 1).to_u8! }
+        expect_raises(Gori::Error) { kp.oaep_sha256_decrypt(garbage) }
+      end
+    end
+
+    describe ".generate_2048" do
+      it "mints two DISTINCT keypairs (different public SPKI PEMs)" do
+        a = O::RsaKeyPair.generate_2048
+        b = O::RsaKeyPair.generate_2048
+        a.public_spki_pem.should start_with("-----BEGIN PUBLIC KEY-----")
+        a.public_spki_pem.should_not eq(b.public_spki_pem)
+      end
+    end
+  end
+
+  describe O::Presets do
+    it "ships exactly 8 presets and no custom-http preset" do
+      all = O::Presets.all
+      all.size.should eq(8)
+      all.any?(&.kind.custom_http?).should be_false
+      # 5 interactsh + boast + webhook.site + postbin
+      all.count(&.kind.webhook_site?).should eq(1)
+    end
+
+    it "gives every preset a non-empty host and a nil token" do
+      O::Presets.all.each do |p|
+        p.host.empty?.should be_false
+        p.token.should be_nil
+      end
+    end
+
+    it "names each interactsh preset with the bare host while .host is the full url" do
+      interactsh = O::Presets.all.select(&.kind.interactsh?)
+      interactsh.size.should eq(5)
+      interactsh.each do |p|
+        p.host.should start_with("https://")
+        bare = URI.parse(p.host).host.not_nil!
+        p.name.should contain(bare)
+        p.name.should_not contain("https://")
+      end
+    end
+  end
+
+  describe O::ProviderKind do
+    it "renders #label for all five kinds" do
+      O::ProviderKind::Interactsh.label.should eq("interactsh")
+      O::ProviderKind::CustomHttp.label.should eq("custom-http")
+      O::ProviderKind::WebhookSite.label.should eq("webhook.site")
+      O::ProviderKind::Boast.label.should eq("BOAST")
+      O::ProviderKind::Postbin.label.should eq("postbin")
+    end
+
+    it "round-trips parse?(kind.label) == kind for every kind" do
+      O::ProviderKind.values.each do |kind|
+        O::ProviderKind.parse?(kind.label).should eq(kind)
+      end
+    end
+
+    it "parses tolerant tokens (case- and separator-insensitive)" do
+      O::ProviderKind.parse?("BOAST").should eq(O::ProviderKind::Boast)
+      O::ProviderKind.parse?("boast").should eq(O::ProviderKind::Boast)
+      O::ProviderKind.parse?("web_hook.site").should eq(O::ProviderKind::WebhookSite)
+      O::ProviderKind.parse?("webhook-site").should eq(O::ProviderKind::WebhookSite)
+    end
+
+    it "returns nil for the empty string" do
+      O::ProviderKind.parse?("").should be_nil
+    end
+
+    it "returns nil when a space separator is used (spaces are not normalized away)" do
+      O::ProviderKind.parse?("custom http").should be_nil
     end
   end
 end

--- a/spec/oast/present_spec.cr
+++ b/spec/oast/present_spec.cr
@@ -1,0 +1,234 @@
+require "../spec_helper"
+require "json"
+
+private alias O = Gori::Oast
+
+# The exact top-level key set the JSON contract promises (anti-drift for the CLI
+# `--format json` surface and the MCP oast_* tools — the two must never diverge).
+private INTERACTION_KEYS = %w[
+  unique_id protocol method source destination provider timestamp
+  raw_request raw_response
+]
+
+# Build an Interaction record with sensible HTTP defaults; individual fields are
+# overridable so each example can drive exactly the branch it cares about.
+private def build_interaction(
+  unique_id = "abc123",
+  protocol = "http",
+  method : String? = "GET",
+  source_ip : String? = "203.0.113.7",
+  full_id = "abc123.oast.example.com",
+  raw_request = "GET / HTTP/1.1\r\nHost: abc123.oast.example.com\r\n\r\n",
+  raw_response : String? = "HTTP/1.1 200 OK\r\n\r\n",
+  at = Time.utc(2026, 7, 21, 12, 30, 45),
+) : O::Interaction
+  O::Interaction.new(
+    unique_id: unique_id,
+    protocol: protocol,
+    method: method,
+    source_ip: source_ip,
+    full_id: full_id,
+    raw_request: raw_request,
+    raw_response: raw_response,
+    at: at,
+  )
+end
+
+describe Gori::Oast::Present do
+  describe ".interaction" do
+    it "returns a NamedTuple with EXACTLY the documented key set" do
+      nt = O::Present.interaction(build_interaction, "interactsh")
+      # NamedTuple#keys is a tuple of symbols; compare against the contract names.
+      nt.keys.map(&.to_s).to_a.sort.should eq(INTERACTION_KEYS.sort)
+      nt.keys.size.should eq(INTERACTION_KEYS.size)
+    end
+
+    it "maps each key to the documented Interaction accessor (renames included)" do
+      i = build_interaction(
+        unique_id: "uid-42",
+        protocol: "dns",
+        method: "POST",
+        source_ip: "198.51.100.9",
+        full_id: "sub.host.oast.example.com",
+        raw_request: "raw-req-bytes",
+        raw_response: "raw-resp-bytes",
+        at: Time.utc(2026, 1, 2, 3, 4, 5),
+      )
+      nt = O::Present.interaction(i, "webhook.site")
+
+      nt[:unique_id].should eq("uid-42")
+      nt[:protocol].should eq("dns")
+      nt[:method].should eq("POST")
+      # source <- i.source_ip (renamed)
+      nt[:source].should eq("198.51.100.9")
+      # destination <- i.full_id (renamed)
+      nt[:destination].should eq("sub.host.oast.example.com")
+      # provider comes from the argument, not the record
+      nt[:provider].should eq("webhook.site")
+      # timestamp <- i.at.to_rfc3339
+      nt[:timestamp].should eq(i.at.to_rfc3339)
+      nt[:raw_request].should eq("raw-req-bytes")
+      nt[:raw_response].should eq("raw-resp-bytes")
+    end
+
+    it "renders timestamp as the RFC3339 string of i.at (Zulu form for UTC)" do
+      i = build_interaction(at: Time.utc(2026, 7, 21, 12, 30, 45))
+      nt = O::Present.interaction(i, "boast")
+      nt[:timestamp].should eq("2026-07-21T12:30:45Z")
+      nt[:timestamp].should eq(i.at.to_rfc3339)
+    end
+
+    it "carries the provider argument through verbatim, independent of the record" do
+      i = build_interaction
+      O::Present.interaction(i, "custom-http")[:provider].should eq("custom-http")
+      O::Present.interaction(i, "postbin")[:provider].should eq("postbin")
+      # empty provider string is preserved, not defaulted
+      O::Present.interaction(i, "")[:provider].should eq("")
+    end
+  end
+
+  describe ".interaction JSON contract" do
+    it "serializes to a JSON object with exactly the documented keys" do
+      json = O::Present.interaction(build_interaction, "interactsh").to_json
+      keys = JSON.parse(json).as_h.keys
+      keys.sort.should eq(INTERACTION_KEYS.sort)
+      keys.size.should eq(INTERACTION_KEYS.size)
+    end
+
+    it "serializes a DNS interaction (method:nil) to \"method\":null" do
+      i = build_interaction(protocol: "dns", method: nil)
+      json = O::Present.interaction(i, "interactsh").to_json
+      parsed = JSON.parse(json).as_h
+      # The key is present but its value is JSON null.
+      parsed.has_key?("method").should be_true
+      parsed["method"].raw.should be_nil
+      # Explicit textual proof of the null literal in the emitted JSON.
+      json.should contain(%("method":null))
+    end
+
+    it "serializes raw_response:nil to \"raw_response\":null" do
+      i = build_interaction(raw_response: nil)
+      json = O::Present.interaction(i, "interactsh").to_json
+      parsed = JSON.parse(json).as_h
+      parsed.has_key?("raw_response").should be_true
+      parsed["raw_response"].raw.should be_nil
+      json.should contain(%("raw_response":null))
+    end
+
+    it "serializes source_ip:nil (no source) to \"source\":null" do
+      i = build_interaction(source_ip: nil)
+      json = O::Present.interaction(i, "interactsh").to_json
+      parsed = JSON.parse(json).as_h
+      parsed.has_key?("source").should be_true
+      parsed["source"].raw.should be_nil
+    end
+
+    it "emits non-null string values for a full HTTP interaction" do
+      i = build_interaction(protocol: "http", method: "GET", source_ip: "203.0.113.7")
+      parsed = JSON.parse(O::Present.interaction(i, "interactsh").to_json).as_h
+      parsed["method"].as_s.should eq("GET")
+      parsed["source"].as_s.should eq("203.0.113.7")
+      parsed["protocol"].as_s.should eq("http")
+    end
+
+    it "round-trips a multibyte/Unicode (emoji + CJK) raw_request through JSON" do
+      req = "GET /안녕世界🔥 HTTP/1.1\r\nHost: oast\r\nX-Combining: é\r\n\r\n"
+      i = build_interaction(raw_request: req)
+      json = O::Present.interaction(i, "interactsh").to_json
+      parsed = JSON.parse(json).as_h
+      parsed["raw_request"].as_s.should eq(req)
+    end
+
+    it "round-trips multibyte content in raw_response too" do
+      resp = "HTTP/1.1 200 OK\r\n\r\n<body>세계 🌍 café</body>"
+      i = build_interaction(raw_response: resp)
+      parsed = JSON.parse(O::Present.interaction(i, "boast").to_json).as_h
+      parsed["raw_response"].as_s.should eq(resp)
+    end
+
+    it "escapes and round-trips control bytes / quotes / backslashes / NUL in raw_request" do
+      req = "l1\r\nl2\tv=\"q\"\\slash\\ z\u0000 trail"
+      i = build_interaction(raw_request: req)
+      json = O::Present.interaction(i, "interactsh").to_json
+      # A raw newline byte must never be emitted literally into the JSON text.
+      json.should_not contain('\n')
+      # Round-trip proves the escaping is lossless.
+      JSON.parse(json).as_h["raw_request"].as_s.should eq(req)
+    end
+
+    it "round-trips an empty raw_request (empty string, not null)" do
+      i = build_interaction(raw_request: "")
+      parsed = JSON.parse(O::Present.interaction(i, "interactsh").to_json).as_h
+      parsed["raw_request"].raw.should_not be_nil
+      parsed["raw_request"].as_s.should eq("")
+    end
+
+    it "full round-trip preserves every field for a DNS interaction with nil method+response" do
+      i = build_interaction(
+        unique_id: "dns-uid",
+        protocol: "dns",
+        method: nil,
+        source_ip: "192.0.2.53",
+        full_id: "lookup.oast.example.com",
+        raw_request: "쿼리 A? lookup.oast.example.com",
+        raw_response: nil,
+        at: Time.utc(2026, 12, 31, 23, 59, 59),
+      )
+      parsed = JSON.parse(O::Present.interaction(i, "interactsh").to_json).as_h
+      parsed["unique_id"].as_s.should eq("dns-uid")
+      parsed["protocol"].as_s.should eq("dns")
+      parsed["method"].raw.should be_nil
+      parsed["source"].as_s.should eq("192.0.2.53")
+      parsed["destination"].as_s.should eq("lookup.oast.example.com")
+      parsed["provider"].as_s.should eq("interactsh")
+      parsed["timestamp"].as_s.should eq("2026-12-31T23:59:59Z")
+      parsed["raw_request"].as_s.should eq("쿼리 A? lookup.oast.example.com")
+      parsed["raw_response"].raw.should be_nil
+    end
+  end
+
+  describe ".payload" do
+    it "returns {payload_url:, session_id:, provider:} with the documented keys" do
+      nt = O::Present.payload("https://x.oast.example.com", 42_i64, "interactsh")
+      nt.keys.map(&.to_s).to_a.sort.should eq(%w[payload_url provider session_id].sort)
+      nt[:payload_url].should eq("https://x.oast.example.com")
+      nt[:session_id].should eq(42_i64)
+      nt[:provider].should eq("interactsh")
+    end
+
+    it "keeps the session_id an Int64 (compile-time type, not widened/stringified)" do
+      nt = O::Present.payload("u", 7_i64, "boast")
+      nt[:session_id].should be_a(Int64)
+      nt[:session_id].should eq(7_i64)
+    end
+
+    it "preserves a large Int64 session_id through JSON without precision loss" do
+      big = Int64::MAX
+      json = O::Present.payload("https://u", big, "webhook.site").to_json
+      parsed = JSON.parse(json).as_h
+      parsed["session_id"].as_i64.should eq(big)
+      parsed["payload_url"].as_s.should eq("https://u")
+      parsed["provider"].as_s.should eq("webhook.site")
+    end
+
+    it "preserves the ad-hoc/unpersisted session marker (session_id 0)" do
+      nt = O::Present.payload("https://u", 0_i64, "postbin")
+      nt[:session_id].should eq(0_i64)
+      JSON.parse(nt.to_json).as_h["session_id"].as_i64.should eq(0_i64)
+    end
+
+    it "round-trips a multibyte payload URL and the negative-boundary Int64" do
+      url = "https://안녕-🔥.oast.example.com/path?x=世界"
+      nt = O::Present.payload(url, Int64::MIN, "custom-http")
+      parsed = JSON.parse(nt.to_json).as_h
+      parsed["payload_url"].as_s.should eq(url)
+      parsed["session_id"].as_i64.should eq(Int64::MIN)
+    end
+
+    it "serializes to a JSON object with exactly the three documented keys" do
+      keys = JSON.parse(O::Present.payload("u", 1_i64, "interactsh").to_json).as_h.keys
+      keys.sort.should eq(%w[payload_url provider session_id].sort)
+      keys.size.should eq(3)
+    end
+  end
+end

--- a/spec/oast/session_spec.cr
+++ b/spec/oast/session_spec.cr
@@ -1,0 +1,113 @@
+require "../spec_helper"
+
+private alias O = Gori::Oast
+
+# Generate ONE interactsh-style private-key PEM for the whole file (RSA keygen is slow,
+# so we materialize it once and reuse). Self-contained: no dependency on engine_spec's
+# offline fixture PEM.
+private PEM = O::RsaKeyPair.generate_2048.private_pem
+
+private def interactsh_session(pem : String? = PEM) : O::Session
+  O::Session.new(1_i64, O::ProviderKind::Interactsh, "https://oast.pro",
+    "abc12300000000000000", "sec1234567890",
+    private_key_pem: pem, registered: true)
+end
+
+private def custom_session(url : String) : O::Session
+  O::Session.new(0_i64, O::ProviderKind::CustomHttp, url,
+    "corr", "sec")
+end
+
+describe O::Session do
+  describe "#rsa" do
+    it "lazily materializes an RsaKeyPair from private_key_pem" do
+      session = interactsh_session
+      kp = session.rsa
+      kp.should_not be_nil
+      kp.not_nil!.public_spki_pem.should start_with("-----BEGIN PUBLIC KEY-----")
+    end
+
+    it "MEMOIZES: two calls return the SAME object identity" do
+      session = interactsh_session
+      first = session.rsa
+      second = session.rsa
+      first.should_not be_nil
+      # identity, not just equality: the second call must reuse the cached instance
+      first.not_nil!.same?(second.not_nil!).should be_true
+    end
+
+    it "materialized keypair re-derives the SAME public key the PEM was exported from" do
+      # Contract: a resumed session (PEM only) keeps decrypting -> the reconstructed
+      # keypair must be the very key behind that PEM.
+      expected = O::RsaKeyPair.from_private_pem(PEM).public_spki_pem
+      session = interactsh_session
+      session.rsa.not_nil!.public_spki_pem.should eq(expected)
+    end
+
+    it "returns nil when private_key_pem is nil (non-interactsh session)" do
+      session = O::Session.new(0_i64, O::ProviderKind::WebhookSite,
+        "https://webhook.site", "token123", "")
+      session.rsa.should be_nil
+    end
+
+    it "returns nil repeatedly (no caching of a bogus non-nil) when PEM is nil" do
+      session = custom_session("https://my.oast.example/log")
+      session.rsa.should be_nil
+      session.rsa.should be_nil
+    end
+
+    it "prefers an rsa injected via the ctor over re-parsing the PEM" do
+      # When both an explicit rsa and a PEM are present, the pre-supplied instance wins
+      # and is returned by identity.
+      injected = O::RsaKeyPair.from_private_pem(PEM)
+      session = O::Session.new(1_i64, O::ProviderKind::Interactsh, "https://oast.pro",
+        "corr", "sec", private_key_pem: PEM, rsa: injected)
+      session.rsa.not_nil!.same?(injected).should be_true
+    end
+  end
+
+  describe "#host" do
+    it "returns the bare host for a scheme-qualified server_url" do
+      custom_session("https://oast.pro").host.should eq("oast.pro")
+    end
+
+    it "falls back to the raw server_url when URI.parse yields no host (no scheme)" do
+      # bare "oast.pro" -> URI.parse.host is nil -> the `|| @server_url` branch
+      custom_session("oast.pro").host.should eq("oast.pro")
+    end
+
+    it "strips the port, returning only the host for scheme://host:port" do
+      custom_session("https://oast.pro:8443").host.should eq("oast.pro")
+    end
+
+    it "strips scheme, port, and path, returning only the host" do
+      custom_session("http://my.oast.example:8080/log?x=1").host.should eq("my.oast.example")
+    end
+
+    it "returns the bare host for an http (non-https) url" do
+      custom_session("http://c1abc.interact.sh").host.should eq("c1abc.interact.sh")
+    end
+
+    it "handles a subdomained interactsh host" do
+      custom_session("https://cabc123.oast.pro").host.should eq("cabc123.oast.pro")
+    end
+
+    it "returns the raw string for the empty server_url (no host -> fallback)" do
+      custom_session("").host.should eq("")
+    end
+
+    it "returns the raw string for a bare host:port with no scheme (no host parsed)" do
+      # No scheme means URI.parse treats "oast.pro:8443" as scheme:path, host is nil,
+      # so the whole raw value comes back verbatim.
+      custom_session("oast.pro:8443").host.should eq("oast.pro:8443")
+    end
+
+    it "preserves a punycode/IDN host verbatim" do
+      custom_session("https://xn--r8jz45g.example").host.should eq("xn--r8jz45g.example")
+    end
+
+    it "returns the raw value for a bare multibyte host with no scheme" do
+      custom_session("안녕.example").host.should eq("안녕.example")
+    end
+  end
+end

--- a/spec/probe/passive/dom_xss_spec.cr
+++ b/spec/probe/passive/dom_xss_spec.cr
@@ -1,0 +1,390 @@
+require "../../spec_helper"
+
+# --- file-local harness (mirrors spec/probe_spec.cr's private with_store/capture_flow/analyze) ---
+
+private def with_store(&)
+  path = File.tempname("gori-domxss", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+# Insert a flow + response and return its full FlowDetail (what the analyzer feeds Passive).
+private def capture_flow(store, resp_head : String = "HTTP/1.1 200 OK\r\n\r\n", *,
+                         scheme = "https", host = "acme.test", target = "/", status = 200,
+                         content_type : String? = "text/html", body : String? = nil,
+                         method = "GET", req_headers = "", req_body : String? = nil) : Gori::Store::FlowDetail
+  head = String.build do |io|
+    io << method << " " << target << " HTTP/1.1\r\nHost: " << host << "\r\n" << req_headers << "\r\n"
+  end
+  req = Gori::Store::CapturedRequest.new(
+    created_at: 1_000_i64, scheme: scheme, host: host, port: scheme == "https" ? 443 : 80,
+    method: method, target: target, http_version: "HTTP/1.1",
+    head: head.to_slice, body: req_body.try(&.to_slice))
+  id = store.insert_flow(req)
+  store.update_response(Gori::Store::CapturedResponse.new(
+    flow_id: id, status: status, head: resp_head.to_slice, body: body.try(&.to_slice),
+    reason: "OK", content_type: content_type, duration_us: 1_i64))
+  store.get_flow(id).not_nil!
+end
+
+# Run passive analysis on one flow and return ONLY the dom_xss detections.
+private def dom(store, **kw) : Array(Gori::Probe::Detection)
+  Gori::Probe::Passive.analyze(capture_flow(store, **kw)).select { |d| d.code == "dom_xss" }
+end
+
+# HTML page carrying an inline <script> body.
+private def html_script(js : String) : String
+  "<!doctype html><html><body><script>#{js}</script></body></html>"
+end
+
+describe Gori::Probe::Passive::DomXss do
+  describe "#info" do
+    it "declares the dom_xss rule under the client category" do
+      info = Gori::Probe::Passive::DomXss.new.info
+      info.id.should eq("dom_xss")
+      info.category.should eq(Gori::Probe::Category::CLIENT)
+    end
+  end
+
+  # (1) source flows into an HTML sink in ONE statement.
+  describe "same-statement source → sink" do
+    it "flags location.hash flowing into innerHTML (inline HTML script)" do
+      with_store do |store|
+        dets = dom(store, body: html_script("el.innerHTML = location.hash"))
+        dets.size.should eq(1)
+        d = dets.first
+        d.code.should eq("dom_xss")
+        d.category.should eq(Gori::Probe::Category::CLIENT)
+        d.severity.should eq(Gori::Store::Severity::Medium)
+        d.evidence.should eq("location.hash → innerHTML")
+        d.title.should eq("Possible DOM-based XSS (innerHTML sink)")
+        d.host.should eq("acme.test")
+      end
+    end
+
+    # (2) application/javascript body: document.write(location.search).
+    it "flags document.write(location.search) in a JavaScript response body" do
+      with_store do |store|
+        dets = dom(store, content_type: "application/javascript",
+          body: "document.write(location.search)")
+        dets.size.should eq(1)
+        dets.first.evidence.should eq("location.search → document.write")
+        dets.first.severity.should eq(Gori::Store::Severity::Medium)
+      end
+    end
+
+    it "also accepts a text/ecmascript content-type as executable JS" do
+      with_store do |store|
+        dets = dom(store, content_type: "text/ecmascript",
+          body: "eval(location.hash)")
+        dets.size.should eq(1)
+        dets.first.evidence.should eq("location.hash → eval")
+      end
+    end
+
+    it "correlates a source that appears BEFORE the sink in the same statement" do
+      with_store do |store|
+        dets = dom(store, body: html_script("document.getElementById(location.hash).innerHTML = out"))
+        dets.size.should eq(1)
+        dets.first.evidence.should eq("location.hash → innerHTML")
+      end
+    end
+
+    it "treats outerHTML and the += form as the innerHTML sink" do
+      with_store do |store|
+        dom(store, body: html_script("el.outerHTML = location.hash"))
+          .map(&.evidence).should eq(["location.hash → innerHTML"])
+        dom(store, body: html_script("el.innerHTML += location.hash"))
+          .map(&.evidence).should eq(["location.hash → innerHTML"])
+      end
+    end
+  end
+
+  # (3) dedup: one detection per distinct source→sink SHAPE per host.
+  describe "per-host dedup by source→sink shape" do
+    it "collapses two identical innerHTML=location.hash into one detection" do
+      with_store do |store|
+        body = "<html><body>" \
+               "<script>a.innerHTML = location.hash</script>" \
+               "<script>b.innerHTML = location.hash</script>" \
+               "</body></html>"
+        dets = dom(store, body: body)
+        dets.size.should eq(1)
+        dets.first.evidence.should eq("location.hash → innerHTML")
+      end
+    end
+
+    it "keeps DISTINCT shapes as separate detections" do
+      with_store do |store|
+        body = "<html><body>" \
+               "<script>el.innerHTML = location.hash</script>" \
+               "<script>document.write(location.search)</script>" \
+               "</body></html>"
+        dets = dom(store, body: body)
+        dets.compact_map(&.evidence).sort!.should eq([
+          "location.hash → innerHTML",
+          "location.search → document.write",
+        ])
+      end
+    end
+  end
+
+  # (4) a bare sink with no source does NOT flag.
+  describe "bare sink (no source)" do
+    it "does not flag el.innerHTML = sanitize(x)" do
+      with_store do |store|
+        dom(store, body: html_script("el.innerHTML = sanitize(userInput)")).should be_empty
+      end
+    end
+
+    it "does not flag document.write of a static string" do
+      with_store do |store|
+        dom(store, content_type: "application/javascript",
+          body: "document.write(\"<b>static</b>\")").should be_empty
+      end
+    end
+
+    it "does not flag an innerHTML == comparison (negative lookahead on '=')" do
+      with_store do |store|
+        # `innerHTML ==` is a read/compare, not an assignment sink: the (?!=) guard rejects it.
+        dom(store, body: html_script("if (el.innerHTML == location.hash) { warn() }")).should be_empty
+      end
+    end
+  end
+
+  # (5) source/sink only inside a string or comment does NOT flag (client_code is stripped).
+  describe "string/comment noise is stripped" do
+    it "does not flag a source→sink that lives in a // line comment" do
+      with_store do |store|
+        dom(store, body: html_script("// el.innerHTML = location.hash")).should be_empty
+      end
+    end
+
+    it "does not flag a source→sink that lives in a /* block */ comment" do
+      with_store do |store|
+        dom(store, body: html_script("/* el.innerHTML = location.hash */")).should be_empty
+      end
+    end
+
+    it "does not flag a source→sink that lives entirely inside a string literal" do
+      with_store do |store|
+        dom(store, body: html_script("var doc = \"el.innerHTML = location.hash\"")).should be_empty
+      end
+    end
+  end
+
+  # (6) template-literal sink: interpolation keeps the source as code.
+  describe "template-literal sink" do
+    it "flags innerHTML = `${location.hash}` (interpolated source survives strip)" do
+      with_store do |store|
+        dets = dom(store, body: html_script("el.innerHTML = `<p>${location.hash}</p>`"))
+        dets.size.should eq(1)
+        dets.first.evidence.should eq("location.hash → innerHTML")
+      end
+    end
+
+    it "still flags an UNTERMINATED template literal without raising" do
+      with_store do |store|
+        # Truncated backtick string: the strip pass must not crash, and the interpolated
+        # source is still recovered as code.
+        dets = dom(store, content_type: "application/javascript",
+          body: "el.innerHTML = `x${location.hash}")
+        dets.map(&.evidence).should eq(["location.hash → innerHTML"])
+      end
+    end
+  end
+
+  # (7) every sink-kind evidence label resolves.
+  describe "sink-kind labels" do
+    cases = [
+      {"el.insertAdjacentHTML('beforeend', location.hash)", "location.hash → insertAdjacentHTML"},
+      {"document.writeln(location.search)", "location.search → document.write"},
+      {"eval(location.hash)", "location.hash → eval"},
+      {"new Function(location.hash)", "location.hash → Function"},
+      {"setTimeout(location.hash, 10)", "location.hash → setTimeout/setInterval"},
+      {"setInterval(location.hash, 10)", "location.hash → setTimeout/setInterval"},
+      {"el.dangerouslySetInnerHTML = location.hash", "location.hash → dangerouslySetInnerHTML"},
+      {"$('#out').html(location.hash)", "location.hash → jQuery.html()"},
+      {"frame.srcdoc = location.hash", "location.hash → iframe.srcdoc"},
+    ]
+
+    cases.each do |(code, evidence)|
+      it "labels #{evidence}" do
+        with_store do |store|
+          dets = dom(store, content_type: "application/javascript", body: code)
+          dets.size.should eq(1)
+          dets.first.evidence.should eq(evidence)
+          dets.first.severity.should eq(Gori::Store::Severity::Medium)
+        end
+      end
+    end
+  end
+
+  # A range of taint sources all resolve to their fixed labels.
+  describe "source labels" do
+    sources = {
+      "location.href"             => "location.href",
+      "location.pathname"         => "location.href",
+      "document.URL"              => "document.URL",
+      "document.referrer"         => "document.referrer",
+      "document.cookie"           => "document.cookie",
+      "window.name"               => "window.name",
+      "history.state"             => "history.state",
+      "event.data"                => "postMessage data",
+      "localStorage.getItem('k')" => "web storage",
+    }
+
+    sources.each do |expr, label|
+      it "labels #{expr} as #{label}" do
+        with_store do |store|
+          dets = dom(store, content_type: "application/javascript", body: "el.innerHTML = #{expr}")
+          dets.size.should eq(1)
+          dets.first.evidence.should eq("#{label} → innerHTML")
+        end
+      end
+    end
+  end
+
+  # (8) early gate: empty scripts / non-HTML-non-JS content-type → no detection.
+  describe "gating" do
+    it "does not flag when the content-type is text/plain" do
+      with_store do |store|
+        dom(store, content_type: "text/plain", body: "el.innerHTML = location.hash").should be_empty
+      end
+    end
+
+    it "does not flag when there is no content-type" do
+      with_store do |store|
+        dom(store, content_type: nil, body: "el.innerHTML = location.hash").should be_empty
+      end
+    end
+
+    it "does not flag an empty body" do
+      with_store do |store|
+        dom(store, body: nil).should be_empty
+        dom(store, body: "").should be_empty
+      end
+    end
+
+    it "does not flag an empty <script></script> block" do
+      with_store do |store|
+        dom(store, body: "<html><body><script></script></body></html>").should be_empty
+      end
+    end
+
+    it "skips an EXTERNAL <script src=...> even if it has decorative inline text" do
+      with_store do |store|
+        body = "<script src=\"/app.js\">el.innerHTML = location.hash</script>"
+        dom(store, body: body).should be_empty
+      end
+    end
+
+    it "skips a non-JS <script type> data/template island" do
+      with_store do |store|
+        body = "<script type=\"application/json\">{\"x\":\"el.innerHTML = location.hash\"}</script>"
+        dom(store, body: body).should be_empty
+      end
+    end
+  end
+
+  # Heuristic limits stated in the doc comment: same-statement only.
+  describe "documented heuristic limits" do
+    it "does NOT follow a source through an intermediate variable (separate statements)" do
+      with_store do |store|
+        # `;` ends the statement; the sink's statement holds only `x`, no taint source.
+        dom(store, body: html_script("var x = location.hash; el.innerHTML = x;")).should be_empty
+      end
+    end
+
+    it "does NOT correlate a source separated from the sink by a statement boundary" do
+      with_store do |store|
+        # Newline-separated statements: source is not in the sink's statement window.
+        dom(store, content_type: "application/javascript",
+          body: "var t = location.hash\nel.innerHTML = safe").should be_empty
+      end
+    end
+  end
+
+  # Window boundary: WINDOW = 250 chars each side (measured on the stripped code).
+  describe "statement window boundary" do
+    it "flags a source within the window on the same long statement" do
+      with_store do |store|
+        filler = "a" * 100
+        dom(store, content_type: "application/javascript",
+          body: "el.innerHTML = concat(#{filler} + location.hash)")
+          .map(&.evidence).should eq(["location.hash → innerHTML"])
+      end
+    end
+
+    it "does NOT flag a source pushed beyond the 250-char window" do
+      with_store do |store|
+        filler = "a" * 300 # > WINDOW; no ; { } newline and no source substring inside
+        dom(store, content_type: "application/javascript",
+          body: "el.innerHTML = concat(#{filler} + location.hash)").should be_empty
+      end
+    end
+  end
+
+  # Unicode / multibyte forces the Array(Char) strip path (offset-preserving).
+  describe "unicode / multibyte inputs" do
+    it "flags with CJK + emoji in a trailing comment (non-ASCII strip path)" do
+      with_store do |store|
+        dets = dom(store, body: html_script("el.innerHTML = location.hash; // 안녕 世界 🎉"))
+        dets.map(&.evidence).should eq(["location.hash → innerHTML"])
+      end
+    end
+
+    it "does NOT flag when the whole source→sink sits inside a CJK comment" do
+      with_store do |store|
+        dom(store, body: html_script("// 안녕 el.innerHTML = location.hash 世界")).should be_empty
+      end
+    end
+
+    it "flags across a multibyte block comment separating source and sink code" do
+      with_store do |store|
+        dets = dom(store, content_type: "application/javascript",
+          body: "el.innerHTML = /* 세계 コメント */ location.hash")
+        dets.map(&.evidence).should eq(["location.hash → innerHTML"])
+      end
+    end
+  end
+
+  # Adversarial / malformed input must be handled safely.
+  describe "adversarial input" do
+    it "scrubs invalid UTF-8 bytes and still flags the clean script" do
+      with_store do |store|
+        body = String.new(html_script("el.innerHTML = location.hash").to_slice + Bytes[0xff, 0xfe, 0x80])
+        dets = dom(store, body: body)
+        dets.map(&.evidence).should eq(["location.hash → innerHTML"])
+      end
+    end
+
+    it "completes quickly on a large repetitive body and dedups to one detection" do
+      with_store do |store|
+        huge = "el.innerHTML = location.hash;\n" * 5_000
+        dets = [] of Gori::Probe::Detection
+        elapsed = Time.measure { dets = dom(store, content_type: "application/javascript", body: huge) }
+        dets.size.should eq(1)
+        dets.first.evidence.should eq("location.hash → innerHTML")
+        elapsed.should be < 5.seconds
+      end
+    end
+
+    it "does not hang on a long backtracking-bait body with no source" do
+      with_store do |store|
+        bait = ".innerHTML=" + ("a" * 50_000)
+        elapsed = Time.measure do
+          dom(store, content_type: "application/javascript", body: bait).should be_empty
+        end
+        elapsed.should be < 5.seconds
+      end
+    end
+  end
+end

--- a/spec/probe/passive/prototype_pollution_spec.cr
+++ b/spec/probe/passive/prototype_pollution_spec.cr
@@ -1,0 +1,423 @@
+require "../../spec_helper"
+
+# --- file-local harness (mirrors spec/probe_spec.cr) -----------------------------------
+private def with_store(&)
+  path = File.tempname("gori-protopoll", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+# Insert a flow + response and return its full FlowDetail (what the analyzer feeds Passive).
+private def capture_flow(store, resp_head : String, *, scheme = "https", host = "acme.test",
+                         target = "/", status = 200, content_type : String? = "text/html",
+                         body : String? = nil, method = "GET", req_headers = "",
+                         req_body : String? = nil) : Gori::Store::FlowDetail
+  head = String.build do |io|
+    io << method << " " << target << " HTTP/1.1\r\nHost: " << host << "\r\n" << req_headers << "\r\n"
+  end
+  req = Gori::Store::CapturedRequest.new(
+    created_at: 1_000_i64, scheme: scheme, host: host, port: scheme == "https" ? 443 : 80,
+    method: method, target: target, http_version: "HTTP/1.1",
+    head: head.to_slice, body: req_body.try(&.to_slice))
+  id = store.insert_flow(req)
+  store.update_response(Gori::Store::CapturedResponse.new(
+    flow_id: id, status: status, head: resp_head.to_slice, body: body.try(&.to_slice),
+    reason: "OK", content_type: content_type, duration_us: 1_i64))
+  store.get_flow(id).not_nil!
+end
+
+# Run passive analysis on one flow and return the detections (ungrouped).
+private def analyze(store, **kw) : Array(Gori::Probe::Detection)
+  Gori::Probe::Passive.analyze(capture_flow(store, **kw))
+end
+
+private def codes_of(dets : Array(Gori::Probe::Detection)) : Array(String)
+  dets.map(&.code)
+end
+
+# Build a FlowDetail directly (no store) so a request head / body can carry RAW,
+# possibly non-UTF-8 bytes — the byte-safety path the store round-trip would obscure.
+# Only `request_head` (and optionally `request_body`) carry the adversarial bytes; the
+# row target stays clean ASCII (req.target is parsed from the head, not the row).
+private def raw_detail(req_head : Bytes, *, req_body : Bytes? = nil,
+                       content_type : String? = nil) : Gori::Store::FlowDetail
+  row = Gori::Store::FlowRow.new(1_i64, 0_i64, "https", "GET", "acme.test", 443, "/", 200,
+    0_i64, Gori::Store::FlowState::Complete, nil, nil, content_type)
+  Gori::Store::FlowDetail.new(row, "HTTP/1.1", req_head, req_body, nil, nil)
+end
+
+# A JS response body wrapped so the whole body is treated as one client script.
+private def js_dets(store, code : String) : Array(Gori::Probe::Detection)
+  analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n",
+    content_type: "application/javascript", body: code)
+end
+
+private def proto_sink_count(dets : Array(Gori::Probe::Detection)) : Int32
+  dets.count(&.code.==("prototype_pollution"))
+end
+
+describe Gori::Probe::Passive::PrototypePollution do
+  # ---------------------------------------------------------------------------------------
+  # CLIENT SINK path (scans Context#client_scripts_nocomment): one Low per SINK_PATTERNS label
+  # ---------------------------------------------------------------------------------------
+  describe "client-script sinks" do
+    it "flags obj.__proto__ = ... as a Low '__proto__ assignment'" do
+      with_store do |store|
+        dets = js_dets(store, "obj.__proto__ = payload;")
+        proto_sink_count(dets).should eq(1)
+        hit = dets.find(&.code.==("prototype_pollution")).not_nil!
+        hit.severity.should eq(Gori::Store::Severity::Low)
+        hit.evidence.should eq("__proto__ assignment")
+        hit.category.should eq("client")
+      end
+    end
+
+    it %(flags x["__proto__"] = ... as a Low '__proto__ key assignment') do
+      with_store do |store|
+        dets = js_dets(store, %(x["__proto__"] = payload;))
+        proto_sink_count(dets).should eq(1)
+        dets.find(&.code.==("prototype_pollution")).not_nil!.evidence
+          .should eq("__proto__ key assignment")
+      end
+    end
+
+    it "matches single- and back-quoted __proto__ key forms too" do
+      with_store do |store|
+        js_dets(store, %(x['__proto__'] = v;)).find(&.code.==("prototype_pollution"))
+          .not_nil!.evidence.should eq("__proto__ key assignment")
+        js_dets(store, %(x[`__proto__`] = v;)).find(&.code.==("prototype_pollution"))
+          .not_nil!.evidence.should eq("__proto__ key assignment")
+      end
+    end
+
+    it "flags constructor.prototype[k] as a Low 'constructor.prototype[] write'" do
+      with_store do |store|
+        dets = js_dets(store, "foo.constructor.prototype[k] = 1;")
+        proto_sink_count(dets).should eq(1)
+        dets.find(&.code.==("prototype_pollution")).not_nil!.evidence
+          .should eq("constructor.prototype[] write")
+      end
+    end
+
+    it "flags Object.prototype[k] as a Low 'Object.prototype[] write'" do
+      with_store do |store|
+        dets = js_dets(store, "Object.prototype[key] = value;")
+        proto_sink_count(dets).should eq(1)
+        dets.find(&.code.==("prototype_pollution")).not_nil!.evidence
+          .should eq("Object.prototype[] write")
+      end
+    end
+
+    it "flags $.extend(true, a, b) as a Low '$.extend(true) deep merge'" do
+      with_store do |store|
+        dets = js_dets(store, "$.extend(true, target, source);")
+        proto_sink_count(dets).should eq(1)
+        dets.find(&.code.==("prototype_pollution")).not_nil!.evidence
+          .should eq("$.extend(true) deep merge")
+      end
+    end
+
+    it "does NOT flag a shallow $.extend(a, b) (no leading true)" do
+      with_store do |store|
+        proto_sink_count(js_dets(store, "$.extend(target, source);")).should eq(0)
+      end
+    end
+
+    it "flags lodash _.merge(a, b) as a Low 'lodash deep merge/set'" do
+      with_store do |store|
+        dets = js_dets(store, "_.merge(dst, src);")
+        proto_sink_count(dets).should eq(1)
+        dets.find(&.code.==("prototype_pollution")).not_nil!.evidence
+          .should eq("lodash deep merge/set")
+      end
+    end
+
+    it "matches the other lodash pollution-prone APIs (mergeWith/defaultsDeep/set/setWith)" do
+      with_store do |store|
+        %w[mergeWith defaultsDeep set setWith].each do |fn|
+          js_dets(store, "_.#{fn}(a, b);").find(&.code.==("prototype_pollution"))
+            .not_nil!.evidence.should eq("lodash deep merge/set")
+        end
+      end
+    end
+
+    it "emits ONE detection per label when every shape appears in one script" do
+      with_store do |store|
+        body = <<-JS
+          obj.__proto__ = a;
+          x["__proto__"] = b;
+          foo.constructor.prototype[k] = 1;
+          Object.prototype[k] = 2;
+          $.extend(true, t, s);
+          _.merge(d, e);
+          JS
+        dets = js_dets(store, body)
+        proto_sink_count(dets).should eq(6)
+        labels = dets.select(&.code.==("prototype_pollution")).map(&.evidence)
+        labels.should contain("__proto__ assignment")
+        labels.should contain("__proto__ key assignment")
+        labels.should contain("constructor.prototype[] write")
+        labels.should contain("Object.prototype[] write")
+        labels.should contain("$.extend(true) deep merge")
+        labels.should contain("lodash deep merge/set")
+        labels.uniq.size.should eq(6) # no duplicate label (dedup on the seen-set)
+      end
+    end
+
+    it "de-dups a label seen across multiple inline scripts (HTML with two <script>s)" do
+      with_store do |store|
+        html = "<html><script>obj.__proto__ = a;</script>" \
+               "<script>other.__proto__ = b;</script></html>"
+        dets = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n",
+          content_type: "text/html", body: html)
+        proto_sink_count(dets).should eq(1) # same label collapses to one
+      end
+    end
+
+    it "keeps the string-key form visible (it is NOT stripped like a comment)" do
+      with_store do |store|
+        # strip_comments blanks comments but KEEPS string-literal contents, so a "__proto__"
+        # written as a bracket-string key still matches.
+        proto_sink_count(js_dets(store, %(payload["__proto__"] = 1;))).should eq(1)
+      end
+    end
+
+    it "matches a sink on a non-ASCII (CJK) receiver identifier" do
+      with_store do |store|
+        proto_sink_count(js_dets(store, "안녕.__proto__ = 世界;")).should eq(1)
+      end
+    end
+
+    # -- comment / negative-lookahead false-positive guards --------------------------------
+    it "does NOT flag a __proto__ assignment that lives inside a // line comment" do
+      with_store do |store|
+        proto_sink_count(js_dets(store, "// obj.__proto__ = evil;\nvar ok = 1;")).should eq(0)
+      end
+    end
+
+    it "does NOT flag a __proto__ assignment inside a /* block */ comment" do
+      with_store do |store|
+        proto_sink_count(js_dets(store, "/* Object.prototype[x] = 1; $.extend(true,a,b) */")).should eq(0)
+      end
+    end
+
+    it "does NOT match a comparison (negative lookahead on '='): obj.__proto__ == poison" do
+      with_store do |store|
+        # The `==` is exactly what `=(?!=)` rejects — a comparison is not an assignment.
+        proto_sink_count(js_dets(store, "if (obj.__proto__ == poison) alert(1);")).should eq(0)
+      end
+    end
+
+    it "does NOT match the literal 'x == obj.__proto__' read (no '=' follows __proto__)" do
+      with_store do |store|
+        proto_sink_count(js_dets(store, "var y = x == obj.__proto__;")).should eq(0)
+      end
+    end
+
+    it "does NOT match a strict-equality bracket read x[\"__proto__\"] === y" do
+      with_store do |store|
+        code = %(if (x["__proto__"] === y) { z(); })
+        proto_sink_count(js_dets(store, code)).should eq(0)
+      end
+    end
+
+    it "produces no sink detection for an empty or sink-free script" do
+      with_store do |store|
+        proto_sink_count(js_dets(store, "")).should eq(0)
+        proto_sink_count(js_dets(store, "const a = 1; function f(){ return a + 2; }")).should eq(0)
+      end
+    end
+
+    it "does not run the client path for a non-document (no HTML/JS content-type)" do
+      with_store do |store|
+        # content_type nil → client_scripts empty → sink path never engages.
+        dets = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n",
+          content_type: nil, body: "obj.__proto__ = evil;")
+        proto_sink_count(dets).should eq(0)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------------------
+  # REQUEST path (pure string work): prototype_pollution_param, Low
+  # ---------------------------------------------------------------------------------------
+  describe "request parameter surface" do
+    it "flags a __proto__ key in the request TARGET (Low)" do
+      with_store do |store|
+        dets = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n",
+          target: "/api?__proto__[x]=1", content_type: nil)
+        hit = dets.find(&.code.==("prototype_pollution_param")).not_nil!
+        hit.severity.should eq(Gori::Store::Severity::Low)
+        hit.evidence.should eq("__proto__/constructor.prototype in request")
+        hit.category.should eq("client")
+      end
+    end
+
+    it "flags a constructor[prototype] target: requires BOTH substrings present" do
+      with_store do |store|
+        both = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n",
+          target: "/api?constructor[prototype][x]=1", content_type: nil)
+        codes_of(both).should contain("prototype_pollution_param")
+
+        # Both substrings anywhere in the target qualify (independent includes?, not adjacency).
+        split = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n",
+          target: "/api?constructor=1&role=prototype", content_type: nil)
+        codes_of(split).should contain("prototype_pollution_param")
+      end
+    end
+
+    it "does NOT flag a target carrying only ONE of constructor / prototype" do
+      with_store do |store|
+        only_c = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n",
+          target: "/api?constructor[x]=1", content_type: nil)
+        codes_of(only_c).should_not contain("prototype_pollution_param")
+        only_p = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n",
+          target: "/api?prototype[x]=1", content_type: nil)
+        codes_of(only_p).should_not contain("prototype_pollution_param")
+      end
+    end
+
+    it "does NOT flag a benign target with no prototype key" do
+      with_store do |store|
+        dets = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n",
+          target: "/api?user=alice&page=2", content_type: nil)
+        codes_of(dets).should_not contain("prototype_pollution_param")
+      end
+    end
+
+    it "flags a __proto__ key in a urlencoded request BODY (REQ_BODY_PROTO)" do
+      with_store do |store|
+        dets = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", method: "POST",
+          target: "/submit", content_type: nil,
+          req_headers: "Content-Type: application/x-www-form-urlencoded\r\n",
+          req_body: "a[__proto__][b]=1&x=2")
+        codes_of(dets).should contain("prototype_pollution_param")
+      end
+    end
+
+    it "flags a __proto__ key in a JSON request BODY" do
+      with_store do |store|
+        dets = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", method: "POST",
+          target: "/submit", content_type: nil,
+          req_headers: "Content-Type: application/json\r\n",
+          req_body: %({"__proto__":{"polluted":true}}))
+        codes_of(dets).should contain("prototype_pollution_param")
+      end
+    end
+
+    it "flags URL-encoded constructor%5Bprototype%5D in the body (case-insensitive, %5B/[ alt)" do
+      with_store do |store|
+        upper = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", method: "POST",
+          target: "/submit", content_type: nil,
+          req_body: "constructor%5Bprototype%5D%5Bx%5D=1")
+        codes_of(upper).should contain("prototype_pollution_param")
+
+        # lowercase %5b + mixed case constructor/prototype — the /i flag covers it.
+        lower = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", method: "POST",
+          target: "/submit", content_type: nil,
+          req_body: "CONSTRUCTOR%5bPROTOTYPE%5d=1")
+        codes_of(lower).should contain("prototype_pollution_param")
+
+        # the open-bracket alternation also matches a raw '[' form in the body.
+        bracket = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", method: "POST",
+          target: "/submit", content_type: nil,
+          req_body: "constructor[prototype][x]=1")
+        codes_of(bracket).should contain("prototype_pollution_param")
+      end
+    end
+
+    it "honours the bounded proximity cap between constructor%5B and prototype (12 chars)" do
+      with_store do |store|
+        # `constructor(?:\[|%5B).{0,12}prototype` — exactly 12 filler chars still matches...
+        gap12 = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", method: "POST",
+          target: "/submit", content_type: nil,
+          req_body: "constructor%5B" + ("a" * 12) + "prototype=1")
+        codes_of(gap12).should contain("prototype_pollution_param")
+        # ...but a 13-char gap exceeds the cap and does not match this alternation.
+        gap13 = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", method: "POST",
+          target: "/submit", content_type: nil,
+          req_body: "constructor%5B" + ("a" * 13) + "prototype=1")
+        codes_of(gap13).should_not contain("prototype_pollution_param")
+      end
+    end
+
+    it "does NOT flag a benign request body without a prototype key" do
+      with_store do |store|
+        dets = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", method: "POST",
+          target: "/submit", content_type: nil,
+          req_body: %({"name":"alice","role":"admin"}))
+        codes_of(dets).should_not contain("prototype_pollution_param")
+      end
+    end
+
+    it "emits at most one request-parameter detection even when target AND body both carry it" do
+      with_store do |store|
+        dets = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", method: "POST",
+          target: "/api?__proto__[x]=1", content_type: nil,
+          req_body: %({"__proto__":{}}))
+        dets.count(&.code.==("prototype_pollution_param")).should eq(1)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------------------
+  # BYTE-SAFETY (item 8): non-UTF-8 target uses includes? (no PCRE); body is scrubbed then regex
+  # ---------------------------------------------------------------------------------------
+  describe "byte-safety on adversarial input" do
+    it "scans a non-UTF-8 request TARGET with includes? without raising (and still detects)" do
+      with_store do |_|
+        head = IO::Memory.new
+        head << "GET /api?"
+        head.write(Bytes[0xff, 0xfe, 0x80]) # invalid UTF-8, kept away from the token
+        head << "&__proto__[x]=1 HTTP/1.1\r\nHost: h\r\n\r\n"
+        dets = Gori::Probe::Passive.analyze(raw_detail(head.to_slice))
+        codes_of(dets).should contain("prototype_pollution_param")
+      end
+    end
+
+    it "does not raise or flag on a non-UTF-8 target that carries no prototype key" do
+      with_store do |_|
+        head = IO::Memory.new
+        head << "GET /api?q="
+        head.write(Bytes[0xc0, 0xc1, 0xff]) # invalid UTF-8, no proto substring
+        head << " HTTP/1.1\r\nHost: h\r\n\r\n"
+        dets = Gori::Probe::Passive.analyze(raw_detail(head.to_slice))
+        codes_of(dets).should_not contain("prototype_pollution_param")
+      end
+    end
+
+    it "regex-scans a request BODY holding invalid UTF-8 safely (scrubbed first, then matched)" do
+      with_store do |_|
+        req_head = "POST /submit HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+        # invalid bytes precede the token but stay separated so the scrub cannot break adjacency.
+        body = IO::Memory.new
+        body << "junk="
+        body.write(Bytes[0xff, 0xfe])
+        body << "&a[__proto__][b]=1"
+        dets = Gori::Probe::Passive.analyze(raw_detail(req_head, req_body: body.to_slice))
+        codes_of(dets).should contain("prototype_pollution_param")
+      end
+    end
+
+    it "completes quickly on a large adversarial 'constructor' body with no bracket (no ReDoS)" do
+      with_store do |store|
+        # `constructor(?:\[|%5B)…` never engages without a following bracket; the other
+        # alternations are anchor-free but linear. A big repeat must finish fast and not match.
+        blob = "constructor" * 20_000
+        elapsed = Time.measure do
+          dets = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", method: "POST",
+            target: "/submit", content_type: nil, req_body: blob)
+          codes_of(dets).should_not contain("prototype_pollution_param")
+        end
+        elapsed.total_seconds.should be < 2.0
+      end
+    end
+  end
+end

--- a/spec/probe_query_spec.cr
+++ b/spec/probe_query_spec.cr
@@ -1,0 +1,423 @@
+require "./spec_helper"
+
+# Build a Probe issue directly. The sibling probe_spec make_issue only emits Low/Open/headers,
+# so this file-local helper takes severity/status/category/title/host explicitly.
+private def make_issue(code : String,
+                       severity : Gori::Store::Severity = Gori::Store::Severity::Low,
+                       status : Gori::Store::Status = Gori::Store::Status::Open,
+                       category : String = "headers",
+                       title : String = "Issue title",
+                       host : String = "acme.test") : Gori::Store::ProbeIssue
+  Gori::Store::ProbeIssue.new(1_i64, code, category, host, title, severity, status, 1_i64,
+    [] of String, nil, nil, 1_i64, 1_i64)
+end
+
+# Parse a query and match it against one issue. Named `hits?` (not `matches?`) so it
+# never shadows the method under test.
+private def hits?(query : String, issue : Gori::Store::ProbeIssue) : Bool
+  Gori::Probe::Filter.parse(query).matches?(issue)
+end
+
+# One issue per severity rung, so ordinal comparisons can be checked at every boundary.
+private def info_issue : Gori::Store::ProbeIssue
+  make_issue("c_info", Gori::Store::Severity::Info)
+end
+
+private def low_issue : Gori::Store::ProbeIssue
+  make_issue("c_low", Gori::Store::Severity::Low)
+end
+
+private def med_issue : Gori::Store::ProbeIssue
+  make_issue("c_med", Gori::Store::Severity::Medium)
+end
+
+private def high_issue : Gori::Store::ProbeIssue
+  make_issue("c_high", Gori::Store::Severity::High)
+end
+
+private def crit_issue : Gori::Store::ProbeIssue
+  make_issue("c_crit", Gori::Store::Severity::Critical)
+end
+
+describe Gori::Probe::Filter do
+  describe "#match_severity (ordinal comparison over Info..Critical)" do
+    it "sev:>=high matches High and Critical only (boundary at High)" do
+      hits?("sev:>=high", info_issue).should be_false
+      hits?("sev:>=high", low_issue).should be_false
+      hits?("sev:>=high", med_issue).should be_false # boundary: Medium excluded
+      hits?("sev:>=high", high_issue).should be_true
+      hits?("sev:>=high", crit_issue).should be_true
+    end
+
+    it "sev:>medium is strict — excludes Medium itself, matches High and Critical" do
+      hits?("sev:>medium", low_issue).should be_false
+      hits?("sev:>medium", med_issue).should be_false # boundary: strict > excludes equal
+      hits?("sev:>medium", high_issue).should be_true
+      hits?("sev:>medium", crit_issue).should be_true
+    end
+
+    it "sev:<=low matches Info and Low, excludes Medium (boundary at Low)" do
+      hits?("sev:<=low", info_issue).should be_true
+      hits?("sev:<=low", low_issue).should be_true
+      hits?("sev:<=low", med_issue).should be_false # boundary: Medium excluded
+      hits?("sev:<=low", high_issue).should be_false
+    end
+
+    it "sev:<medium is strict — matches Info and Low, excludes Medium" do
+      hits?("sev:<medium", info_issue).should be_true
+      hits?("sev:<medium", low_issue).should be_true
+      hits?("sev:<medium", med_issue).should be_false # boundary: strict < excludes equal
+      hits?("sev:<medium", high_issue).should be_false
+    end
+
+    it "sev:=high matches exactly High" do
+      hits?("sev:=high", med_issue).should be_false
+      hits?("sev:=high", high_issue).should be_true
+      hits?("sev:=high", crit_issue).should be_false
+    end
+
+    it "bare sev:high behaves identically to sev:=high" do
+      hits?("sev:high", low_issue).should be_false
+      hits?("sev:high", high_issue).should be_true
+      hits?("sev:high", crit_issue).should be_false
+    end
+
+    it "abbreviation med == medium (rung 2)" do
+      hits?("sev:med", med_issue).should be_true
+      hits?("sev:=med", med_issue).should be_true
+      hits?("sev:>=med", low_issue).should be_false
+      hits?("sev:>=med", med_issue).should be_true
+      hits?("sev:>=med", high_issue).should be_true
+    end
+
+    it "abbreviation crit == critical (top rung 4, boundary)" do
+      hits?("sev:crit", crit_issue).should be_true
+      hits?("sev:crit", high_issue).should be_false
+      hits?("sev:>=crit", crit_issue).should be_true # top rung is the ceiling
+      hits?("sev:>=crit", high_issue).should be_false
+      hits?("sev:>crit", crit_issue).should be_false # nothing above Critical
+    end
+
+    it "the severity value is matched case-insensitively (sev:HIGH, sev:MED)" do
+      hits?("sev:HIGH", high_issue).should be_true
+      hits?("sev:>=MED", high_issue).should be_true
+      hits?("sev:>=MED", low_issue).should be_false
+    end
+
+    it "a truncated op (sev:>= , sev:>) leaves an empty value → matches all (never blanks the list)" do
+      # split_op strips the operator; the residual empty value hits match_term's empty guard.
+      hits?("sev:>=", info_issue).should be_true
+      hits?("sev:>=", crit_issue).should be_true
+      hits?("sev:>", low_issue).should be_true
+      hits?("sev:", high_issue).should be_true
+    end
+  end
+
+  describe "#match_severity unknown severity" do
+    it "sev:bogus matches NOTHING (unknown rung → false, not match-all)" do
+      # severity_value returns nil → match_severity is false for every issue.
+      hits?("sev:bogus", info_issue).should be_false
+      hits?("sev:bogus", low_issue).should be_false
+      hits?("sev:bogus", med_issue).should be_false
+      hits?("sev:bogus", high_issue).should be_false
+      hits?("sev:bogus", crit_issue).should be_false
+    end
+
+    it "sev:>=bogus (an operator on an unknown rung) also matches nothing" do
+      hits?("sev:>=bogus", crit_issue).should be_false
+    end
+  end
+
+  describe "#match_status" do
+    it "open matches only Open" do
+      hits?("status:open", make_issue("c", status: Gori::Store::Status::Open)).should be_true
+      hits?("status:open", make_issue("c", status: Gori::Store::Status::Confirmed)).should be_false
+      hits?("status:open", make_issue("c", status: Gori::Store::Status::Resolved)).should be_false
+    end
+
+    it "confirmed and its abbreviation conf both match Confirmed" do
+      confirmed = make_issue("c", status: Gori::Store::Status::Confirmed)
+      hits?("status:confirmed", confirmed).should be_true
+      hits?("status:conf", confirmed).should be_true
+      hits?("status:confirmed", make_issue("c", status: Gori::Store::Status::Open)).should be_false
+    end
+
+    it "false-positive and fp both match FalsePositive" do
+      fp = make_issue("c", status: Gori::Store::Status::FalsePositive)
+      hits?("status:false-positive", fp).should be_true
+      hits?("status:fp", fp).should be_true
+      hits?("status:fp", make_issue("c", status: Gori::Store::Status::Resolved)).should be_false
+    end
+
+    it "resolved and done both match Resolved" do
+      resolved = make_issue("c", status: Gori::Store::Status::Resolved)
+      hits?("status:resolved", resolved).should be_true
+      hits?("status:done", resolved).should be_true
+      hits?("status:done", make_issue("c", status: Gori::Store::Status::Open)).should be_false
+    end
+
+    it "closed matches every non-open status and never Open" do
+      hits?("status:closed", make_issue("c", status: Gori::Store::Status::Open)).should be_false
+      hits?("status:closed", make_issue("c", status: Gori::Store::Status::Confirmed)).should be_true
+      hits?("status:closed", make_issue("c", status: Gori::Store::Status::FalsePositive)).should be_true
+      hits?("status:closed", make_issue("c", status: Gori::Store::Status::Resolved)).should be_true
+    end
+
+    it "an unknown status token (status:zzz) matches nothing" do
+      hits?("status:zzz", make_issue("c", status: Gori::Store::Status::Open)).should be_false
+      hits?("status:zzz", make_issue("c", status: Gori::Store::Status::Resolved)).should be_false
+    end
+
+    it "the st: alias resolves the same field, matched case-insensitively" do
+      hits?("st:OPEN", make_issue("c", status: Gori::Store::Status::Open)).should be_true
+      hits?("st:CLOSED", make_issue("c", status: Gori::Store::Status::Resolved)).should be_true
+    end
+  end
+
+  describe "#match_term category / code (substring, case-insensitive)" do
+    it "category matches on substring (category:head hits 'headers', category:tech does not)" do
+      headers = make_issue("c", category: "headers")
+      hits?("category:head", headers).should be_true
+      hits?("category:headers", headers).should be_true
+      hits?("category:tech", headers).should be_false
+    end
+
+    it "the cat: alias behaves like category:" do
+      hits?("cat:head", make_issue("c", category: "headers")).should be_true
+    end
+
+    it "code matches on substring (code:csp hits 'missing_csp')" do
+      csp = make_issue("missing_csp")
+      hits?("code:missing_csp", csp).should be_true
+      hits?("code:csp", csp).should be_true
+      hits?("code:hsts", csp).should be_false
+    end
+
+    it "code is matched case-insensitively (code:CSP vs code missing_csp)" do
+      hits?("code:CSP", make_issue("missing_csp")).should be_true
+      hits?("code:MISSING", make_issue("missing_csp")).should be_true
+    end
+
+    it "category is matched case-insensitively (category:TECH vs category tech-stack)" do
+      hits?("category:TECH", make_issue("c", category: "tech-stack")).should be_true
+    end
+
+    it "host matches on substring, case-insensitively" do
+      hits?("host:acme", make_issue("c", host: "api.acme.test")).should be_true
+      hits?("host:ACME", make_issue("c", host: "api.acme.test")).should be_true
+      hits?("host:other", make_issue("c", host: "api.acme.test")).should be_false
+    end
+  end
+
+  describe "#free_text (DIVERGENCE from Issues: also searches code)" do
+    it "a bare token matching ONLY the code still hits (Issues would search title+host only)" do
+      # NOTE: Issues::Filter free-texts title+host only; Probe adds code. We assert Probe's
+      # behavior directly (no Issues::Filter instantiation) — the code-only hit is the proof.
+      code_only = make_issue("missing_hsts", title: "no match here", host: "example.com")
+      hits?("hsts", code_only).should be_true
+    end
+
+    it "a bare token matches title or host as well" do
+      hits?("title", make_issue("c", title: "Issue title", host: "h.test")).should be_true
+      hits?("acme", make_issue("c", title: "t", host: "acme.test")).should be_true
+    end
+
+    it "a bare token present in none of title/host/code does not hit" do
+      hits?("absent", make_issue("missing_csp", title: "t", host: "acme.test")).should be_false
+    end
+
+    it "free text is case-insensitive across all three fields" do
+      hits?("HSTS", make_issue("missing_hsts", title: "t", host: "h.test")).should be_true
+      hits?("TITLE", make_issue("c", title: "Nice Title", host: "h.test")).should be_true
+    end
+  end
+
+  describe "negation of a non-empty term (-field:value)" do
+    it "-code:csp keeps issues whose code lacks 'csp'" do
+      hits?("-code:csp", make_issue("missing_csp")).should be_false
+      hits?("-code:csp", make_issue("missing_hsts")).should be_true
+    end
+
+    it "-severity:high drops High and keeps everything else" do
+      hits?("-severity:high", high_issue).should be_false
+      hits?("-severity:high", low_issue).should be_true
+      hits?("-severity:high", crit_issue).should be_true
+    end
+
+    it "-status:open drops Open and keeps the rest" do
+      hits?("-status:open", make_issue("c", status: Gori::Store::Status::Open)).should be_false
+      hits?("-status:open", make_issue("c", status: Gori::Store::Status::Resolved)).should be_true
+    end
+
+    it "a negated bare token excludes matches over title/host/code" do
+      hits?("-hsts", make_issue("missing_hsts")).should be_false
+      hits?("-hsts", make_issue("missing_csp")).should be_true
+    end
+  end
+
+  describe "empty-value DIVERGENCE (-host: matches ALL, unlike Issues)" do
+    it "a bare incomplete term (host:) matches everything" do
+      # match_term: `return true if t.text.empty?` fires before any field logic.
+      hits?("host:", make_issue("c", host: "acme.test")).should be_true
+      hits?("code:", make_issue("missing_csp")).should be_true
+      hits?("category:", make_issue("c", category: "headers")).should be_true
+    end
+
+    it "a NEGATED incomplete term (-host:) STILL matches everything (Probe's deliberate divergence)" do
+      # Probe returns true on empty BEFORE the negate flip, so a half-typed negation can't
+      # blank the whole list. Issues::Filter returns `!t.negate` here → would match nothing.
+      hits?("-host:", make_issue("c", host: "acme.test")).should be_true
+      hits?("-code:", make_issue("missing_csp")).should be_true
+      hits?("-status:", make_issue("c", status: Gori::Store::Status::Open)).should be_true
+      hits?("-severity:", high_issue).should be_true
+    end
+  end
+
+  describe "implicit AND (whitespace intersects terms)" do
+    it "'category:headers sev:>=medium' requires both" do
+      q = "category:headers sev:>=medium"
+      hits?(q, make_issue("c", severity: Gori::Store::Severity::High, category: "headers")).should be_true
+      # right category, too-low severity → excluded
+      hits?(q, make_issue("c", severity: Gori::Store::Severity::Low, category: "headers")).should be_false
+      # high enough, wrong category → excluded
+      hits?(q, make_issue("c", severity: Gori::Store::Severity::High, category: "tech")).should be_false
+    end
+
+    it "a field term ANDs with a free-text token" do
+      q = "status:open csp"
+      hits?(q, make_issue("missing_csp", status: Gori::Store::Status::Open)).should be_true
+      hits?(q, make_issue("missing_csp", status: Gori::Store::Status::Resolved)).should be_false
+      hits?(q, make_issue("missing_hsts", status: Gori::Store::Status::Open)).should be_false
+    end
+  end
+
+  describe "OR / parentheses / NOT (FilterAst boolean grammar)" do
+    it "'code:csp OR code:hsts' matches either code (exercises the .or? arm)" do
+      q = "code:csp OR code:hsts"
+      hits?(q, make_issue("missing_csp")).should be_true
+      hits?(q, make_issue("missing_hsts")).should be_true
+      hits?(q, make_issue("missing_x_frame_options")).should be_false
+    end
+
+    it "'(host:a OR host:b) -category:tech' groups the OR then ANDs a negated category" do
+      q = "(host:a OR host:b) -category:tech"
+      # host contains 'a', category has no 'tech' → matches
+      hits?(q, make_issue("c", category: "headers", host: "a.test")).should be_true
+      # host contains 'b', but category has 'tech' → excluded by the negation
+      hits?(q, make_issue("c", category: "tech-stack", host: "b.test")).should be_false
+      # host matches neither 'a' nor 'b' → OR branch fails
+      hits?(q, make_issue("c", category: "headers", host: "c.test")).should be_false
+    end
+
+    it "an explicit uppercase AND behaves like whitespace" do
+      q = "status:open AND sev:>=high"
+      hits?(q, make_issue("c", severity: Gori::Store::Severity::High, status: Gori::Store::Status::Open)).should be_true
+      hits?(q, make_issue("c", severity: Gori::Store::Severity::Low, status: Gori::Store::Status::Open)).should be_false
+    end
+
+    it "NOT over a group excludes the whole group" do
+      q = "NOT (code:csp OR code:hsts)"
+      hits?(q, make_issue("missing_csp")).should be_false
+      hits?(q, make_issue("missing_hsts")).should be_false
+      hits?(q, make_issue("cookie_no_secure")).should be_true
+    end
+
+    it "lowercase 'or' is free text, not the operator" do
+      # Keywords are UPPERCASE-only; 'or' here is a bare token searched in title+host+code.
+      hits?("or", make_issue("c", title: "vendor report", host: "h.test")).should be_true
+      hits?("or", make_issue("c", title: "clean", host: "h.test")).should be_false
+    end
+  end
+
+  describe "#apply / #empty? / #has_status_term?" do
+    it "apply selects the matching subset, preserving order" do
+      issues = [info_issue, low_issue, med_issue, high_issue, crit_issue]
+      filter = Gori::Probe::Filter.parse("sev:>=high")
+      filter.apply(issues).map(&.code).should eq(["c_high", "c_crit"])
+    end
+
+    it "an empty query is empty? and matches every issue (apply returns the input)" do
+      filter = Gori::Probe::Filter.parse("")
+      filter.empty?.should be_true
+      filter.matches?(high_issue).should be_true
+      issues = [low_issue, high_issue]
+      filter.apply(issues).should eq(issues)
+    end
+
+    it "a whitespace-only query is also empty?" do
+      Gori::Probe::Filter.parse("   ").empty?.should be_true
+    end
+
+    it "has_status_term? is true only when a status/st term appears (even inside OR/negation)" do
+      Gori::Probe::Filter.parse("status:open").has_status_term?.should be_true
+      Gori::Probe::Filter.parse("-st:resolved").has_status_term?.should be_true
+      Gori::Probe::Filter.parse("code:csp OR status:done").has_status_term?.should be_true
+      Gori::Probe::Filter.parse("code:csp sev:>=high").has_status_term?.should be_false
+      Gori::Probe::Filter.parse("").has_status_term?.should be_false
+    end
+  end
+
+  describe "unicode / multibyte inputs" do
+    it "matches CJK host/category/title substrings, case-folded where applicable" do
+      issue = make_issue("missing_csp", title: "世界 title", category: "헤더", host: "안녕.example")
+      hits?("host:안녕", issue).should be_true
+      hits?("category:헤더", issue).should be_true
+      hits?("世界", issue).should be_true # free text over title
+      hits?("host:없음", issue).should be_false
+    end
+
+    it "matches an emoji token appearing in the title via free text" do
+      issue = make_issue("c", title: "leak 🔑 found", host: "h.test")
+      hits?("🔑", issue).should be_true
+      hits?("🔒", issue).should be_false
+    end
+
+    it "matches an accented (multibyte) host substring" do
+      issue = make_issue("c", host: "café.test")
+      hits?("host:café", issue).should be_true
+      hits?("host:zzz", issue).should be_false
+    end
+  end
+
+  describe "adversarial / boundary inputs (all substring — no regex, no backtracking)" do
+    it "a deeply nested / very long boolean query parses and matches quickly" do
+      # 2000-way OR chain plus 200 nested parens: the forgiving parser must not blow up.
+      chain = Array.new(2000) { |i| "code:c#{i}" }.join(" OR ")
+      query = ("(" * 200) + chain + " OR code:target" + (")" * 200)
+      elapsed = Time.measure do
+        Gori::Probe::Filter.parse(query).matches?(make_issue("target")).should be_true
+      end
+      elapsed.should be < 2.seconds
+    end
+
+    it "a pathological run of negations and empty terms stays match-all and fast" do
+      query = (["-code:"] * 500).join(" ")
+      elapsed = Time.measure do
+        Gori::Probe::Filter.parse(query).matches?(make_issue("missing_csp")).should be_true
+      end
+      elapsed.should be < 1.second
+    end
+
+    it "an unclosed group closes at end-of-input rather than blanking (forgiving parse)" do
+      hits?("(code:csp OR code:hsts", make_issue("missing_csp")).should be_true
+      hits?("(code:csp OR code:hsts", make_issue("cookie_no_secure")).should be_false
+    end
+
+    it "a lone dangling operator is ignored" do
+      Gori::Probe::Filter.parse("AND").empty?.should be_true
+      hits?("code:csp OR", make_issue("missing_csp")).should be_true
+    end
+
+    it "a quoted phrase keeps its spaces as one token" do
+      issue = make_issue("c", title: "two words here", host: "h.test")
+      hits?(%("two words"), issue).should be_true
+      hits?(%("two zzz"), issue).should be_false
+    end
+
+    it "a single-element severity boundary (Info is rung 0, the floor)" do
+      hits?("sev:<=info", info_issue).should be_true
+      hits?("sev:<info", info_issue).should be_false # nothing below Info
+      hits?("sev:>=info", crit_issue).should be_true # floor comparison holds for the top rung
+    end
+  end
+end

--- a/spec/repeater/diff_spec.cr
+++ b/spec/repeater/diff_spec.cr
@@ -1,0 +1,276 @@
+require "../spec_helper"
+
+private alias D = Gori::Repeater::Diff
+private alias DK = Gori::Repeater::DiffKind
+private alias DLine = Gori::Repeater::DiffLine
+
+# Rebuild the original `a` from a diff: the lines that were present in `a` are
+# exactly the Same and Del rows, in order.
+private def rebuild_a(diff : Array(DLine)) : Array(String)
+  diff.select { |d| d.kind == DK::Same || d.kind == DK::Del }.map(&.text)
+end
+
+# Rebuild the new `b` from a diff: the lines present in `b` are the Same and Add
+# rows, in order.
+private def rebuild_b(diff : Array(DLine)) : Array(String)
+  diff.select { |d| d.kind == DK::Same || d.kind == DK::Add }.map(&.text)
+end
+
+private def kinds(diff : Array(DLine)) : Array(DK)
+  diff.map(&.kind)
+end
+
+describe Gori::Repeater::Diff do
+  describe "identical / disjoint extremes" do
+    it "marks a fully-identical pair as all Same with change_count 0" do
+      a = ["alpha", "beta", "gamma"]
+      diff = D.lines(a, a)
+      diff.size.should eq(3)
+      kinds(diff).all? { |k| k == DK::Same }.should be_true
+      D.change_count(diff).should eq(0)
+      rebuild_a(diff).should eq(a)
+      rebuild_b(diff).should eq(a)
+    end
+
+    it "reports change_count == a.size + b.size for a fully-disjoint pair" do
+      a = ["a1", "a2", "a3"]
+      b = ["b1", "b2"]
+      diff = D.lines(a, b)
+      D.change_count(diff).should eq(a.size + b.size)
+      # No Same rows at all when nothing is shared.
+      diff.any? { |d| d.kind == DK::Same }.should be_false
+      rebuild_a(diff).should eq(a)
+      rebuild_b(diff).should eq(b)
+    end
+
+    it "returns an empty diff for two empty inputs" do
+      D.lines([] of String, [] of String).should be_empty
+    end
+  end
+
+  describe "one empty side (emit_middle mm==0 / nn==0)" do
+    it "emits pure Add rows when the original side is empty" do
+      diff = D.lines([] of String, ["a", "b"])
+      kinds(diff).should eq([DK::Add, DK::Add])
+      diff.map(&.text).should eq(["a", "b"])
+      D.change_count(diff).should eq(2)
+      rebuild_a(diff).should eq([] of String)
+      rebuild_b(diff).should eq(["a", "b"])
+    end
+
+    it "emits pure Del rows when the new side is empty" do
+      diff = D.lines(["a", "b"], [] of String)
+      kinds(diff).should eq([DK::Del, DK::Del])
+      diff.map(&.text).should eq(["a", "b"])
+      D.change_count(diff).should eq(2)
+      rebuild_a(diff).should eq(["a", "b"])
+      rebuild_b(diff).should eq([] of String)
+    end
+
+    it "treats a single-element vs empty as one Add / one Del" do
+      D.lines([] of String, ["only"]).map(&.kind).should eq([DK::Add])
+      D.lines(["only"], [] of String).map(&.kind).should eq([DK::Del])
+    end
+  end
+
+  describe "documented tie-break: Del before Add on an LCS-length tie" do
+    it "emits Del then Add for a single replaced line" do
+      diff = D.lines(["X"], ["Y"])
+      kinds(diff).should eq([DK::Del, DK::Add])
+      diff.map(&.text).should eq(["X", "Y"])
+      rebuild_a(diff).should eq(["X"])
+      rebuild_b(diff).should eq(["Y"])
+    end
+
+    it "keeps Del ahead of Add across a changed middle with common prefix/suffix" do
+      diff = D.lines(["ctx", "old", "tail"], ["ctx", "new", "tail"])
+      kinds(diff).should eq([DK::Same, DK::Del, DK::Add, DK::Same])
+      diff.map(&.text).should eq(["ctx", "old", "new", "tail"])
+    end
+
+    it "orders every Del before the Adds when several lines are replaced" do
+      a = ["p", "o1", "o2", "s"]
+      b = ["p", "n1", "n2", "s"]
+      diff = D.lines(a, b)
+      # first non-Same row after the peeled prefix must be a Del
+      middle = diff.reject { |d| d.kind == DK::Same }
+      middle.first.kind.should eq(DK::Del)
+      rebuild_a(diff).should eq(a)
+      rebuild_b(diff).should eq(b)
+    end
+  end
+
+  describe "insertions and deletions preserve reconstruction" do
+    it "reconstructs both sides for a pure insertion" do
+      a = ["a", "b"]
+      b = ["a", "x", "y", "b"]
+      diff = D.lines(a, b)
+      rebuild_a(diff).should eq(a)
+      rebuild_b(diff).should eq(b)
+      D.change_count(diff).should eq(2)
+    end
+
+    it "reconstructs both sides for a pure deletion" do
+      a = ["a", "x", "y", "b"]
+      b = ["a", "b"]
+      diff = D.lines(a, b)
+      rebuild_a(diff).should eq(a)
+      rebuild_b(diff).should eq(b)
+      D.change_count(diff).should eq(2)
+    end
+  end
+
+  describe "empty-string lines mixed with content" do
+    it "keeps blank prefix/suffix Same and diffs only the changed middle" do
+      a = ["", "content", ""]
+      b = ["", "changed", ""]
+      diff = D.lines(a, b)
+      kinds(diff).should eq([DK::Same, DK::Del, DK::Add, DK::Same])
+      rebuild_a(diff).should eq(a)
+      rebuild_b(diff).should eq(b)
+    end
+
+    it "distinguishes blank lines added/removed from surrounding content" do
+      a = ["head", "body"]
+      b = ["head", "", "body", ""]
+      diff = D.lines(a, b)
+      rebuild_a(diff).should eq(a)
+      rebuild_b(diff).should eq(b)
+      # two blank lines are additions
+      D.change_count(diff).should eq(2)
+    end
+
+    it "handles an all-blank vs mixed-blank pair" do
+      a = ["", "", ""]
+      b = ["", "x", ""]
+      diff = D.lines(a, b)
+      rebuild_a(diff).should eq(a)
+      rebuild_b(diff).should eq(b)
+    end
+  end
+
+  describe "multibyte / duplicate-heavy stress" do
+    it "diffs CJK and emoji lines and reconstructs both sides" do
+      a = ["안녕", "世界", "🎉", "shared"]
+      b = ["안녕", "세계", "🎉", "shared"]
+      diff = D.lines(a, b)
+      # only the second line changed (世界 -> 세계)
+      D.change_count(diff).should eq(2)
+      kinds(diff).should eq([DK::Same, DK::Del, DK::Add, DK::Same, DK::Same])
+      rebuild_a(diff).should eq(a)
+      rebuild_b(diff).should eq(b)
+    end
+
+    it "handles a line repeated many times with an interior change" do
+      dup = "😀 반복되는 줄"
+      a = Array.new(20) { dup }
+      b = Array.new(20) { dup }
+      b[10] = "🚀 changed"
+      diff = D.lines(a, b)
+      # exactly one Del + one Add for the single altered occurrence
+      D.change_count(diff).should eq(2)
+      diff.count { |d| d.kind == DK::Del }.should eq(1)
+      diff.count { |d| d.kind == DK::Add }.should eq(1)
+      rebuild_a(diff).should eq(a)
+      rebuild_b(diff).should eq(b)
+    end
+
+    it "reconstructs when many duplicate lines are inserted" do
+      a = ["x"]
+      b = Array.new(50) { "x" }
+      diff = D.lines(a, b)
+      rebuild_a(diff).should eq(a)
+      rebuild_b(diff).should eq(b)
+      # 49 duplicate lines added
+      D.change_count(diff).should eq(49)
+    end
+
+    it "treats combining-mark variants as distinct lines" do
+      # precomposed e-acute (U+00E9) vs decomposed e + combining acute (U+0301)
+      a = ["caf\u{00E9}"]
+      b = ["cafe\u{0301}"]
+      # sanity: these are genuinely different byte sequences
+      a.first.should_not eq(b.first)
+      diff = D.lines(a, b)
+      # not byte-identical, so it is a change
+      D.change_count(diff).should eq(2)
+      rebuild_a(diff).should eq(a)
+      rebuild_b(diff).should eq(b)
+    end
+  end
+
+  describe "MAX_LINES = 1500 truncation" do
+    it "exposes the documented cap constant" do
+      Gori::Repeater::Diff::MAX_LINES.should eq(1500)
+    end
+
+    it "considers only the first 1500 lines of each side" do
+      a = Array.new(1600) { |i| "L#{i}" }
+      b = a
+      diff = D.lines(a, b)
+      # identical within the cap => all Same, one row per considered line
+      diff.size.should eq(1500)
+      kinds(diff).all? { |k| k == DK::Same }.should be_true
+      D.change_count(diff).should eq(0)
+      # lines at index 1500 and beyond never appear
+      diff.any? { |d| d.text == "L1500" }.should be_false
+      diff.any? { |d| d.text == "L1599" }.should be_false
+      diff.last.text.should eq("L1499")
+    end
+
+    it "keeps all lines when each side has exactly 1500 (boundary)" do
+      a = Array.new(1500) { |i| "n#{i}" }
+      diff = D.lines(a, a)
+      diff.size.should eq(1500)
+      diff.last.text.should eq("n1499")
+      D.change_count(diff).should eq(0)
+    end
+
+    it "drops the 1501st line (off-by-one over the cap)" do
+      a = Array.new(1501) { |i| "n#{i}" }
+      diff = D.lines(a, a)
+      diff.size.should eq(1500)
+      diff.last.text.should eq("n1499")
+      diff.any? { |d| d.text == "n1500" }.should be_false
+    end
+
+    it "diffs only within the cap when the sole difference is past line 1500" do
+      a = Array.new(1600) { |i| "c#{i}" }
+      b = a.dup
+      b[1550] = "MUTATED" # beyond the cap -> invisible to the diff
+      diff = D.lines(a, b)
+      diff.size.should eq(1500)
+      D.change_count(diff).should eq(0)
+      diff.any? { |d| d.text == "MUTATED" }.should be_false
+    end
+
+    it "completes quickly on large near-identical adversarial inputs" do
+      # Two 1500-line bodies differing only in the middle: peeling keeps the
+      # O(n*m) table tiny, so this must finish well under the timeout.
+      a = Array.new(1500) { |i| "line-#{i}" }
+      b = a.dup
+      b[750] = "line-750-CHANGED"
+      elapsed = Time.measure do
+        diff = D.lines(a, b)
+        D.change_count(diff).should eq(2)
+      end
+      elapsed.should be < 2.seconds
+    end
+  end
+
+  describe "change_count" do
+    it "counts only non-Same rows" do
+      diff = [
+        DLine.new(DK::Same, "s"),
+        DLine.new(DK::Add, "a"),
+        DLine.new(DK::Del, "d"),
+        DLine.new(DK::Same, "s2"),
+      ]
+      D.change_count(diff).should eq(2)
+    end
+
+    it "is 0 for an empty diff" do
+      D.change_count([] of DLine).should eq(0)
+    end
+  end
+end

--- a/spec/saml_spec.cr
+++ b/spec/saml_spec.cr
@@ -1,0 +1,318 @@
+require "./spec_helper"
+require "base64"
+require "compress/deflate"
+require "uri"
+
+# Raw DEFLATE (RFC 1951) a string, mirroring Saml#raw_deflate, so we can build
+# HTTP-Redirect binding fixtures the way the wire carries them.
+private def deflate(s : String) : Bytes
+  io = IO::Memory.new
+  Compress::Deflate::Writer.open(io, &.write(s.to_slice))
+  io.to_slice
+end
+
+# base64(xml) — the HTTP-POST binding wire value (already url-decoded form).
+private def post_value(xml : String) : String
+  Base64.strict_encode(xml.to_slice)
+end
+
+# base64(deflate(xml)) — the HTTP-Redirect binding wire value (url-decoded form).
+private def redirect_value(xml : String) : String
+  Base64.strict_encode(deflate(xml))
+end
+
+# A representative assertion body used across the binding cases.
+private SAMPLE_XML = "<samlp:AuthnRequest ID=\"a\">안녕 世界</samlp:AuthnRequest>"
+
+describe Gori::Saml do
+  describe ".decode_value (binding auto-detect)" do
+    it "reads a base64(literal XML) payload as the HTTP-POST binding" do
+      dec = Gori::Saml.decode_value(post_value(SAMPLE_XML))
+      dec.should eq({SAMPLE_XML, :post})
+    end
+
+    it "reads a base64(raw-DEFLATE(xml)) payload as the HTTP-Redirect binding" do
+      dec = Gori::Saml.decode_value(redirect_value(SAMPLE_XML))
+      dec.should eq({SAMPLE_XML, :redirect})
+    end
+
+    it "returns nil for base64 of a non-XML string" do
+      Gori::Saml.decode_value(post_value("hello")).should be_nil
+    end
+
+    it "returns nil for a non-base64 value" do
+      Gori::Saml.decode_value("!!!").should be_nil
+    end
+
+    it "returns nil for an empty value" do
+      Gori::Saml.decode_value("").should be_nil
+    end
+
+    it "returns nil when base64 decodes to empty bytes" do
+      # A padding-only value decodes to zero bytes -> not a document.
+      Gori::Saml.decode_value("====").should be_nil
+    end
+
+    it "strips embedded whitespace before decoding (no url-decode)" do
+      raw = post_value("<x/>")
+      spaced = "#{raw[0, 2]} \t\r\n#{raw[2..]}"
+      Gori::Saml.decode_value(spaced).should eq({"<x/>", :post})
+    end
+
+    it "detects the shortest valid XML document" do
+      Gori::Saml.decode_value(post_value("<")).should eq({"<", :post})
+    end
+  end
+
+  describe ".decode_value MAX_XML ceiling" do
+    it "surfaces a decoded POST document sized exactly MAX_XML" do
+      xml = "<" + "a" * (Gori::Saml::MAX_XML - 1)
+      xml.bytesize.should eq(Gori::Saml::MAX_XML)
+      dec = Gori::Saml.decode_value(post_value(xml))
+      dec.should_not be_nil
+      dec.not_nil![1].should eq(:post)
+      dec.not_nil![0].bytesize.should eq(Gori::Saml::MAX_XML)
+    end
+
+    it "rejects a decoded POST document one byte over MAX_XML" do
+      xml = "<" + "a" * Gori::Saml::MAX_XML
+      xml.bytesize.should eq(Gori::Saml::MAX_XML + 1)
+      Gori::Saml.decode_value(post_value(xml)).should be_nil
+    end
+  end
+
+  describe ".decode_value looks_like_xml? detection" do
+    it "treats leading spaces/tabs/CR/LF before '<' as XML" do
+      Gori::Saml.decode_value(post_value(" \t\r\n<x/>")).should eq({" \t\r\n<x/>", :post})
+    end
+
+    it "treats a UTF-8 BOM followed by '<' as XML (BOM retained in the decoded bytes)" do
+      bom = String.new(Bytes[0xEF_u8, 0xBB_u8, 0xBF_u8]) + "<x/>"
+      dec = Gori::Saml.decode_value(post_value(bom))
+      dec.should_not be_nil
+      dec.not_nil![1].should eq(:post)
+      dec.not_nil![0].should eq(bom)
+    end
+
+    it "rejects bytes whose first non-whitespace byte is not '<'" do
+      Gori::Saml.decode_value(post_value("   plain text")).should be_nil
+      Gori::Saml.decode_value(post_value("{\"json\":1}")).should be_nil
+    end
+  end
+
+  describe ".encode_value" do
+    it "base64+URL-encodes without DEFLATE for HTTP-POST" do
+      # "<x/>" -> base64 "PHgvPg==" -> URL-encode -> "PHgvPg%3D%3D"
+      Gori::Saml.encode_value("<x/>", :post).should eq("PHgvPg%3D%3D")
+    end
+
+    it "DEFLATEs then base64+URL-encodes for HTTP-Redirect" do
+      expected = URI.encode_www_form(Base64.strict_encode(deflate(SAMPLE_XML)))
+      Gori::Saml.encode_value(SAMPLE_XML, :redirect).should eq(expected)
+    end
+
+    it "round-trips through url-decode + decode_value for HTTP-Redirect" do
+      wire = Gori::Saml.encode_value(SAMPLE_XML, :redirect)
+      value = URI.decode_www_form(wire, plus_to_space: false)
+      Gori::Saml.decode_value(value).should eq({SAMPLE_XML, :redirect})
+    end
+
+    it "round-trips through url-decode + decode_value for HTTP-POST" do
+      wire = Gori::Saml.encode_value(SAMPLE_XML, :post)
+      value = URI.decode_www_form(wire, plus_to_space: false)
+      Gori::Saml.decode_value(value).should eq({SAMPLE_XML, :post})
+    end
+  end
+
+  describe ".replace_param" do
+    it "replaces only the first matching pair, leaving siblings byte-for-byte" do
+      out = Gori::Saml.replace_param(
+        "SAMLResponse=OLD&RelayState=/app%2Fx&SigAlg=rsa-sha256",
+        "SAMLResponse", "NEW")
+      out.should eq("SAMLResponse=NEW&RelayState=/app%2Fx&SigAlg=rsa-sha256")
+    end
+
+    it "replaces only the first of duplicate keys" do
+      Gori::Saml.replace_param("a=1&a=2", "a", "NEW").should eq("a=NEW&a=2")
+    end
+
+    it "appends the pair when the param is absent" do
+      Gori::Saml.replace_param("RelayState=x", "SAMLResponse", "V")
+        .should eq("RelayState=x&SAMLResponse=V")
+    end
+
+    it "produces 'param=value' from an empty original" do
+      Gori::Saml.replace_param("", "SAMLResponse", "V").should eq("SAMLResponse=V")
+    end
+
+    it "does not match a bare key with no '=', appending instead" do
+      # "SAMLResponse" (no '=') partitions with an empty separator, so it is not
+      # a match; the pair is appended and the bare key survives untouched.
+      Gori::Saml.replace_param("SAMLResponse&x=1", "SAMLResponse", "V")
+        .should eq("SAMLResponse&x=1&SAMLResponse=V")
+    end
+
+    it "matches a param whose value is empty" do
+      Gori::Saml.replace_param("SAMLResponse=&x=1", "SAMLResponse", "V")
+        .should eq("SAMLResponse=V&x=1")
+    end
+  end
+
+  describe ".from_flow / .from_request precedence" do
+    it "prefers a request-body SAMLResponse over the URL query" do
+      body = "SAMLResponse=#{post_value("<body/>")}"
+      target = "https://sp/acs?SAMLRequest=#{post_value("<query/>")}"
+      doc = Gori::Saml.from_flow(target, nil, body.to_slice, nil, nil)
+      doc.should_not be_nil
+      doc.not_nil!.param.should eq("SAMLResponse")
+      doc.not_nil!.location.should eq(:body)
+      doc.not_nil!.xml.should eq("<body/>")
+    end
+
+    it "falls back to the URL query (HTTP-Redirect) when the body has no SAML param" do
+      redir = URI.encode_www_form(redirect_value("<query/>"))
+      target = "https://idp/sso?SAMLRequest=#{redir}&RelayState=rs"
+      doc = Gori::Saml.from_flow(target, nil, "unrelated=1".to_slice, nil, nil)
+      doc.should_not be_nil
+      doc.not_nil!.param.should eq("SAMLRequest")
+      doc.not_nil!.location.should eq(:query)
+      doc.not_nil!.binding.should eq(:redirect)
+    end
+
+    it "url-decodes RelayState onto the Doc" do
+      body = "SAMLResponse=#{post_value("<x/>")}&RelayState=%2Fapp%2Fhome"
+      doc = Gori::Saml.from_flow("t", nil, body.to_slice, nil, nil)
+      doc.not_nil!.relay_state.should eq("/app/home")
+    end
+
+    it "leaves relay_state nil when no RelayState pair is present" do
+      body = "SAMLResponse=#{post_value("<x/>")}"
+      Gori::Saml.from_flow("t", nil, body.to_slice, nil, nil).not_nil!.relay_state.should be_nil
+    end
+
+    it "keeps a literal '+' in the base64 value (plus_to_space: false)" do
+      # base64 of "<a>ûÿ</a>" contains a literal '+', a valid base64 char
+      # that must NOT be folded to a space before decode.
+      xml = "<a>ûÿ</a>"
+      value = Base64.strict_encode(xml.to_slice)
+      value.includes?("+").should be_true
+      body = "SAMLResponse=#{value}"
+      doc = Gori::Saml.from_flow("t", nil, body.to_slice, nil, nil)
+      doc.should_not be_nil
+      doc.not_nil!.xml.should eq(xml)
+    end
+
+    it "returns nil for a flow carrying no SAML message" do
+      Gori::Saml.from_flow("https://x/y?q=1", nil, "a=b".to_slice, nil, nil).should be_nil
+      Gori::Saml.from_flow("https://x/y", nil, nil, nil, nil).should be_nil
+    end
+  end
+
+  describe ".from_response_html" do
+    it "extracts a SAMLResponse from a hidden input with name-before-value (AFTER)" do
+      b64 = post_value("<resp/>")
+      html = "<html><body><form action=\"/acs\" method=\"post\">" \
+             "<input type=\"hidden\" name=\"SAMLResponse\" value=\"#{b64}\"/>" \
+             "</form></body></html>"
+      doc = Gori::Saml.from_flow("t", nil, nil, nil, html.to_slice)
+      doc.should_not be_nil
+      doc.not_nil!.param.should eq("SAMLResponse")
+      doc.not_nil!.location.should eq(:response)
+      doc.not_nil!.xml.should eq("<resp/>")
+    end
+
+    it "extracts a SAMLResponse from value-before-name attribute order (BEFORE)" do
+      b64 = post_value("<resp/>")
+      html = "<input value='#{b64}' type='hidden' name='SAMLResponse'/>"
+      doc = Gori::Saml.from_flow("t", nil, nil, nil, html.to_slice)
+      doc.should_not be_nil
+      doc.not_nil!.location.should eq(:response)
+      doc.not_nil!.xml.should eq("<resp/>")
+    end
+
+    it "unescapes '&amp;'/'&#43;' inside the attribute value before decoding" do
+      # An HTML-escaped '+' (as &#43;) inside the value must be restored so the
+      # base64 alphabet survives the attribute encoding.
+      xml = "<a>ûÿ</a>"
+      b64 = Base64.strict_encode(xml.to_slice)
+      b64.includes?("+").should be_true
+      escaped = b64.gsub("+", "&#43;")
+      html = "<input name=\"SAMLResponse\" value=\"#{escaped}\">"
+      doc = Gori::Saml.from_flow("t", nil, nil, nil, html.to_slice)
+      doc.should_not be_nil
+      doc.not_nil!.xml.should eq(xml)
+    end
+
+    it "scrubs a hostile invalid-UTF-8 response body containing 'SAMLResponse' and does not raise" do
+      # Invalid bytes around the literal must be scrubbed (String.new doesn't validate,
+      # Regex#match raises on invalid bytes) — the decoder must survive and return nil.
+      hostile = Bytes[0x3C_u8, 0xFF_u8, 0xFE_u8] +
+                "SAMLResponse".to_slice +
+                Bytes[0xC0_u8, 0x80_u8, 0xFF_u8]
+      # If the scrub were missing this would raise and fail the example.
+      Gori::Saml.from_flow("t", nil, nil, nil, hostile).should be_nil
+    end
+
+    it "returns nil for a response body without the SAMLResponse marker" do
+      Gori::Saml.from_flow("t", nil, nil, nil, "<html>nothing here</html>".to_slice).should be_nil
+    end
+
+    it "returns nil for a response body larger than MAX_XML" do
+      big = Bytes.new(Gori::Saml::MAX_XML + 1, 0x20_u8)
+      Gori::Saml.from_flow("t", nil, nil, nil, big).should be_nil
+    end
+  end
+
+  describe ".summary" do
+    it "labels the HTTP-POST binding and a request-body location" do
+      body = "SAMLResponse=#{post_value("<x/>")}"
+      doc = Gori::Saml.from_flow("t", nil, body.to_slice, nil, nil).not_nil!
+      Gori::Saml.summary(doc).should eq("SAMLResponse · HTTP-POST binding · request body")
+    end
+
+    it "labels the HTTP-Redirect binding and a URL-query location, appending RelayState" do
+      redir = URI.encode_www_form(redirect_value("<q/>"))
+      target = "https://idp/sso?SAMLRequest=#{redir}&RelayState=state1"
+      doc = Gori::Saml.from_flow(target, nil, nil, nil, nil).not_nil!
+      Gori::Saml.summary(doc)
+        .should eq("SAMLRequest · HTTP-Redirect binding · URL query · RelayState: state1")
+    end
+
+    it "labels a response-form location" do
+      html = "<input name=\"SAMLResponse\" value=\"#{post_value("<r/>")}\">"
+      doc = Gori::Saml.from_flow("t", nil, nil, nil, html.to_slice).not_nil!
+      Gori::Saml.summary(doc).should eq("SAMLResponse · HTTP-POST binding · response form")
+    end
+
+    it "appends RelayState only when it is present" do
+      body = "SAMLResponse=#{post_value("<x/>")}"
+      no_rs = Gori::Saml.from_flow("t", nil, body.to_slice, nil, nil).not_nil!
+      Gori::Saml.summary(no_rs).includes?("RelayState").should be_false
+
+      with_rs = Gori::Saml.from_flow("t", nil, "#{body}&RelayState=r".to_slice, nil, nil).not_nil!
+      Gori::Saml.summary(with_rs).should end_with("· RelayState: r")
+    end
+  end
+
+  describe ".decode_value raw_inflate tolerance" do
+    it "keeps the partial head of a truncated DEFLATE stream" do
+      xml = "<root><child>hello world, some text worth compressing here</child></root>"
+      full = deflate(xml)
+      truncated = full[0, full.size // 2]
+      dec = Gori::Saml.decode_value(Base64.strict_encode(truncated))
+      dec.should_not be_nil
+      dec.not_nil![1].should eq(:redirect)
+      dec.not_nil![0].starts_with?("<root>").should be_true
+    end
+
+    it "completes quickly on a large adversarial deflate bomb (bounded output)" do
+      # 8 MiB of NULs compresses to a tiny stream that inflates past MAX_XML; the
+      # bounded reader must stop, not run away. Does not look like XML -> nil.
+      bomb = deflate(String.new(Bytes.new(8 * 1024 * 1024, 0_u8)))
+      elapsed = Time.measure do
+        Gori::Saml.decode_value(Base64.strict_encode(bomb)).should be_nil
+      end
+      elapsed.should be < 5.seconds
+    end
+  end
+end

--- a/spec/sequencer/present_spec.cr
+++ b/spec/sequencer/present_spec.cr
@@ -1,0 +1,234 @@
+require "../spec_helper"
+require "json"
+
+private alias S = Gori::Sequencer::Stats
+private alias P = Gori::Sequencer::Present
+private alias TR = Gori::Sequencer::Stats::TestRow
+
+# Deterministic hex tokens of `len` nibbles from a seeded PRNG (reproducible specs).
+private def random_hex(count : Int32, len : Int32, seed : UInt64 = 4321_u64) : Array(String)
+  rng = Random.new(seed)
+  Array(String).new(count) { String.build { |io| len.times { io << "0123456789abcdef"[rng.rand(16)] } } }
+end
+
+# Present is documented as pure over a Stats::Report, so a synthetic report lets us drive
+# exact field values / verdict labels / the empty-detail branch that analyze can't reach
+# (every TestRow analyze emits carries a non-empty detail).
+private def build_report(
+  sample_count = 10, usable_count = 10,
+  min_len = 32, max_len = 32, variable_length = false,
+  charset_size = 16, charset_label = "lower-hex",
+  bits_per_char = 4.0, effective_entropy = 128.0,
+  uniqueness = 1.0, duplicate_count = 0, sequential = false,
+  rating = S::Rating::Secure,
+  tests = [] of TR,
+) : S::Report
+  S::Report.new(
+    sample_count: sample_count, usable_count: usable_count,
+    min_len: min_len, max_len: max_len, variable_length: variable_length,
+    charset_size: charset_size, charset_label: charset_label,
+    bits_per_char: bits_per_char, shannon_total: 0.0,
+    effective_entropy: effective_entropy, length_entropy: 0.0,
+    uniqueness: uniqueness, duplicate_count: duplicate_count,
+    sequential: sequential, rating: rating, tests: tests,
+    char_counts: [] of {UInt8, Int32}, len_hist: [] of Int32,
+    len_min: min_len, len_max: max_len,
+    per_pos_entropy: [] of Float64, bit_bias: [] of Float64)
+end
+
+# The exact top-level field set the JSON contract promises (anti-drift for CLI + MCP).
+private JSON_FIELDS = %w[
+  rating rationale sample_count usable_count
+  effective_entropy_bits shannon_bits_per_char
+  charset_size charset min_len max_len variable_length
+  uniqueness duplicate_count sequential tests
+]
+
+describe Gori::Sequencer::Present do
+  describe ".report_json" do
+    it "emits exactly the documented top-level field set" do
+      rep = S.analyze(random_hex(60, 32))
+      keys = JSON.parse(P.report_json(rep)).as_h.keys
+      # Membership + no extras is the contract (order is not part of the JSON contract).
+      keys.sort.should eq(JSON_FIELDS.sort)
+      keys.size.should eq(JSON_FIELDS.size)
+    end
+
+    it "preserves the source field order (informational, stable-across-drift)" do
+      rep = S.analyze(random_hex(60, 32))
+      JSON.parse(P.report_json(rep)).as_h.keys.should eq(JSON_FIELDS)
+    end
+
+    it "maps each top-level field to the matching Report accessor" do
+      rep = S.analyze(random_hex(60, 32))
+      j = JSON.parse(P.report_json(rep)).as_h
+      j["rating"].as_s.should eq(rep.rating.label)
+      j["rationale"].as_s.should eq(rep.rationale)
+      j["sample_count"].as_i.should eq(rep.sample_count)
+      j["usable_count"].as_i.should eq(rep.usable_count)
+      j["effective_entropy_bits"].as_f.should eq(rep.effective_entropy)
+      j["shannon_bits_per_char"].as_f.should eq(rep.bits_per_char)
+      j["charset_size"].as_i.should eq(rep.charset_size)
+      j["charset"].as_s.should eq(rep.charset_label)
+      j["min_len"].as_i.should eq(rep.min_len)
+      j["max_len"].as_i.should eq(rep.max_len)
+      j["variable_length"].as_bool.should eq(rep.variable_length)
+      j["uniqueness"].as_f.should eq(rep.uniqueness)
+      j["duplicate_count"].as_i.should eq(rep.duplicate_count)
+      j["sequential"].as_bool.should eq(rep.sequential)
+    end
+
+    it "renders 'tests' as an array of {name,value,detail,verdict}" do
+      rep = S.analyze(random_hex(60, 32))
+      tests = JSON.parse(P.report_json(rep))["tests"].as_a
+      tests.size.should eq(rep.tests.size)
+      tests.each do |t|
+        t.as_h.keys.should eq(%w[name value detail verdict])
+      end
+    end
+
+    it "emits verdict as the STRING label (not the enum ordinal) — incl. a FAIL row" do
+      # A monotonically-increasing counter deterministically fails the Sequential test.
+      rep = S.analyze((100_000..100_199).map(&.to_s))
+      rep.tests.any?(&.verdict.fail?).should be_true # sanity: corpus really has a FAIL row
+
+      tests = JSON.parse(P.report_json(rep))["tests"].as_a
+      seq = tests.find { |t| t["name"].as_s == "Sequential" }.not_nil!
+      # .as_s raising if this were a JSON number is itself the proof it is the label string.
+      seq["verdict"].as_s.should eq("FAIL")
+
+      labels = tests.map(&.["verdict"].as_s)
+      labels.should contain("FAIL")
+      labels.each { |l| %w[PASS WARN FAIL INFO].should contain(l) }
+    end
+
+    it "round-trips every Verdict to its label via a synthetic report" do
+      tests = [
+        TR.new("A", "1", "d", S::Verdict::Pass),
+        TR.new("B", "2", "d", S::Verdict::Warn),
+        TR.new("C", "3", "d", S::Verdict::Fail),
+        TR.new("D", "4", "d", S::Verdict::Info),
+      ]
+      verdicts = JSON.parse(P.report_json(build_report(tests: tests)))["tests"].as_a.map(&.["verdict"].as_s)
+      verdicts.should eq(%w[PASS WARN FAIL INFO])
+    end
+
+    it "produces the documented empty-report shape for no usable tokens" do
+      rep = S.analyze(["", ""])
+      j = JSON.parse(P.report_json(rep)).as_h
+      j["rating"].as_s.should eq("CRITICAL")
+      j["sample_count"].as_i.should eq(2)
+      j["usable_count"].as_i.should eq(0)
+      j["rationale"].as_s.should eq("no usable tokens")
+
+      tests = j["tests"].as_a
+      tests.size.should eq(1)
+      tests[0]["name"].as_s.should eq("Samples")
+      tests[0]["value"].as_s.should eq("0")
+      tests[0]["detail"].as_s.should eq("no usable tokens")
+      tests[0]["verdict"].as_s.should eq("INFO")
+    end
+
+    it "stays valid parseable JSON for adversarial control-byte / invalid-UTF-8 tokens" do
+      # Bytes outside 0x20..0x7e force classify → "binary"; construct them so a seed tweak
+      # can't silently flip the charset.
+      rng = Random.new(11_u64)
+      tokens = Array(String).new(40) do
+        String.new(Bytes.new(16) { rng.rand(256).to_u8 })
+      end
+      tokens << String.new(Bytes[0x00_u8, 0x01_u8, 0xff_u8, 0x80_u8, 0x1f_u8, 0x7f_u8, 0xfe_u8, 0x0a_u8])
+
+      rep = S.analyze(tokens)
+      rep.charset_label.should eq("binary")
+
+      json = P.report_json(rep)
+      parsed = JSON.parse(json) # must not raise
+      parsed["charset"].as_s.should eq("binary")
+      # The raw (possibly non-UTF-8) token bytes never leak into the JSON — only ASCII stats.
+      parsed["tests"].as_a.empty?.should be_false
+    end
+
+    it "stays valid JSON for CJK / emoji multibyte tokens" do
+      tokens = ["안녕하세요", "世界世界", "🔥🔥🔥", "héllo", "안녕世界🔥"] * 8
+      rep = S.analyze(tokens)
+      parsed = JSON.parse(P.report_json(rep))
+      parsed.as_h.keys.sort!.should eq(JSON_FIELDS.sort)
+    end
+
+    it "stays valid JSON for a single-token corpus" do
+      rep = S.analyze(["only-one"])
+      j = JSON.parse(P.report_json(rep)).as_h
+      j["sample_count"].as_i.should eq(1)
+      j["usable_count"].as_i.should eq(1)
+      j.keys.sort!.should eq(JSON_FIELDS.sort)
+    end
+  end
+
+  describe ".report_text" do
+    it "uses the fixed labels for a fixed-length corpus" do
+      rep = S.analyze(random_hex(60, 32))
+      text = P.report_text(rep)
+      text.should contain("rating:    ")
+      text.should contain("samples:   60 usable / 60 total")
+      text.should contain("entropy:   ")
+      text.should contain("charset:   16 (lower-hex)")
+      text.should contain("length:    32 (fixed)")
+      text.should contain("unique:    0 duplicate(s)")
+      text.should contain("\ntests:\n")
+    end
+
+    it "renders variable length as 'MIN-MAX (variable)'" do
+      rep = S.analyze(["abcd", "abcde", "abcdef"])
+      text = P.report_text(rep)
+      text.should contain("length:    4-6 (variable)")
+    end
+
+    it "renders fixed length as 'MIN (fixed)'" do
+      rep = S.analyze(["abcd", "abcd", "abcd"])
+      text = P.report_text(rep)
+      text.should contain("length:    4 (fixed)")
+    end
+
+    it "formats the empty-report tests row as verdict.ljust(5) name.ljust(14) value (detail)" do
+      rep = S.analyze(["", ""])
+      text = P.report_text(rep)
+      text.should contain("rating:    CRITICAL  (no usable tokens)")
+      text.should contain("samples:   0 usable / 2 total")
+      text.should contain("charset:   0 (—)")
+      text.should contain("length:    0 (fixed)")
+      # 2 spaces, "INFO"+1 pad, +1 sep, "Samples"+7 pad, +1 sep, value, 2 spaces + (detail).
+      text.should contain("  INFO  Samples        0  (no usable tokens)")
+    end
+
+    it "omits the parenthetical when a test row detail is empty (synthetic)" do
+      rep = build_report(tests: [TR.new("NoDetail", "val", "", S::Verdict::Pass)])
+      line = P.report_text(rep).lines.find(&.includes?("NoDetail")).not_nil!
+      line.should eq("  PASS  NoDetail       val")
+      line.should_not contain("(")
+    end
+
+    it "includes the parenthetical when a test row detail is non-empty (synthetic)" do
+      rep = build_report(tests: [TR.new("WithDetail", "val", "some detail", S::Verdict::Warn)])
+      line = P.report_text(rep).lines.find(&.includes?("WithDetail")).not_nil!
+      line.should eq("  WARN  WithDetail     val  (some detail)")
+    end
+
+    it "does not raise on an all-identical corpus with zero entropy / bits (round of zero)" do
+      rep = S.analyze(Array.new(30, "aaaaaaaa"))
+      rep.effective_entropy.should eq(0.0)
+      rep.bits_per_char.should eq(0.0)
+      text = P.report_text(rep)
+      text.should contain("entropy:   0.0 bits effective · 0.0 bits/char")
+      text.should contain("unique:    29 duplicate(s)")
+    end
+
+    it "does not raise for adversarial control-byte tokens" do
+      rng = Random.new(99_u64)
+      tokens = Array(String).new(30) { String.new(Bytes.new(12) { rng.rand(256).to_u8 }) }
+      tokens << String.new(Bytes[0x00_u8, 0xff_u8, 0x01_u8, 0x7f_u8])
+      text = P.report_text(S.analyze(tokens))
+      text.should contain("rating:    ")
+      text.should contain("charset:   ")
+    end
+  end
+end

--- a/spec/sequencer/stats_spec.cr
+++ b/spec/sequencer/stats_spec.cr
@@ -8,6 +8,12 @@ private def random_hex(count : Int32, len : Int32, seed : UInt64 = 1234_u64) : A
   Array(String).new(count) { String.build { |io| len.times { io << "0123456789abcdef"[rng.rand(16)] } } }
 end
 
+# The `detail` string of the Sequential test row for a given token set — the human-readable
+# classification ("constant step N", "monotonic up/down", "non-monotonic", "corr=…", "n/a").
+private def seq_detail(tokens : Array(String)) : String
+  S.analyze(tokens).tests.find { |t| t.name == "Sequential" }.not_nil!.detail
+end
+
 describe Gori::Sequencer::Stats do
   it "rates a large high-entropy hex corpus as strong with no duplicates" do
     report = S.analyze(random_hex(300, 32))
@@ -66,5 +72,259 @@ describe Gori::Sequencer::Stats do
     report.variable_length.should be_true
     report.min_len.should eq(4)
     report.max_len.should eq(6)
+  end
+
+  # ── classify: byte-set → charset label ──────────────────────────────────────────
+
+  it "labels each ASCII byte-set family via the classify precedence chain" do
+    # digits + uppercase A–F only → upper-hex (lower-hex requires a..f, so 'A' skips it)
+    S.analyze(Array.new(5, "A1B2C3")).charset_label.should eq("upper-hex")
+    # both cases of hex present → neither lower- nor upper-hex, but still hex
+    S.analyze(Array.new(5, "aF3bC9")).charset_label.should eq("hex")
+    # base64url-only markers ('-' / '_') plus alnum → base64url (a '-' is not hex)
+    S.analyze(Array.new(5, "gZ-_09")).charset_label.should eq("base64url")
+    # base64-only markers ('+' / '/') → base64 (a '+' is not allowed in base64url)
+    S.analyze(Array.new(5, "ab+/CD09")).charset_label.should eq("base64")
+    # printable ASCII with punctuation outside the base64 set → ascii
+    S.analyze(Array.new(5, "hi! .#")).charset_label.should eq("ascii")
+  end
+
+  it "classifies any multibyte / control / invalid-UTF-8 token as binary (byte-based)" do
+    S.analyze(Array.new(5, "안녕세계")).charset_label.should eq("binary")
+    S.analyze(Array.new(5, "😀🎉")).charset_label.should eq("binary")
+    S.analyze(Array.new(5, "a\u0001b")).charset_label.should eq("binary") # 0x01 control byte
+    S.analyze(Array.new(5, String.new(Bytes[0xff_u8, 0xfe_u8, 0x80_u8]))).charset_label.should eq("binary")
+  end
+
+  # ── detect_sequential: numeric fast path ────────────────────────────────────────
+
+  it "labels a constant-step numeric counter with its step" do
+    report = S.analyze(["100", "102", "104"])
+    report.sequential.should be_true
+    seq_detail(["100", "102", "104"]).should eq("constant step 2")
+  end
+
+  it "labels a variable-step decreasing run 'monotonic down'" do
+    report = S.analyze(["100", "98", "95"])
+    report.sequential.should be_true
+    seq_detail(["100", "98", "95"]).should eq("monotonic down")
+  end
+
+  it "labels a variable-step increasing run 'monotonic up'" do
+    report = S.analyze(["1", "3", "6"])
+    report.sequential.should be_true
+    seq_detail(["1", "3", "6"]).should eq("monotonic up")
+  end
+
+  it "reports 'non-monotonic' and not-sequential for an up-then-down numeric run" do
+    report = S.analyze(["1", "5", "3"])
+    report.sequential.should be_false
+    seq_detail(["1", "5", "3"]).should eq("non-monotonic")
+  end
+
+  # ── detect_sequential: 18-digit boundary guard against Int64 overflow ────────────
+
+  it "keeps exactly-18-digit tokens on the numeric fast path" do
+    eighteen = ["100000000000000000", "100000000000000001", "100000000000000002"]
+    eighteen.each(&.size.should(eq(18)))
+    report = S.analyze(eighteen)
+    report.sequential.should be_true
+    seq_detail(eighteen).should eq("constant step 1")
+  end
+
+  it "sends 19-digit numeric tokens down the general path without an Int64 overflow raise" do
+    # Each value exceeds Int64::MAX (9_223_372_036_854_775_807); a to_i64 attempt would raise.
+    big = ["9999999999999999999", "9999999999999999998", "9999999999999999997"]
+    big.each(&.size.should(eq(19)))
+    report = S.analyze(big)                    # must not raise
+    seq_detail(big).should start_with("corr=") # general (correlation) path, not "constant step"
+    report.sequential.should be_false          # identical leading bytes → r = 0
+  end
+
+  # ── detect_sequential: general (leading-byte correlation) path ───────────────────
+
+  it "flags non-numeric tokens whose leading byte increases monotonically as sequential" do
+    inc = ('a'..'j').map { |c| "#{c}zzzzzzzz" } # first byte a<b<…<j, tail constant
+    report = S.analyze(inc)
+    report.sequential.should be_true
+    seq_detail(inc).should start_with("corr=")
+  end
+
+  it "does not flag non-numeric tokens with a randomized leading byte" do
+    rng = Random.new(2024_u64)
+    letters = "ghijklmnopqrstuvwxyz"
+    shuffled = Array(String).new(30) { "#{letters[rng.rand(letters.size)]}zzzzzzzz" }
+    S.analyze(shuffled).sequential.should be_false
+  end
+
+  it "returns 'n/a' sequential detail for fewer than three tokens" do
+    S.analyze(["abcd", "efgh"]).sequential.should be_false
+    seq_detail(["abcd", "efgh"]).should eq("n/a")
+    seq_detail(["solo"]).should eq("n/a")
+  end
+
+  # ── gate_bits: power-of-two alphabet gating ──────────────────────────────────────
+
+  it "downgrades failing bit tests to INFO for a non-power-of-2 alphabet and spares the rating" do
+    rng = Random.new(42_u64)
+    dec = Array(String).new(60) { String.build { |io| 20.times { io << "0123456789"[rng.rand(10)] } } }
+    report = S.analyze(dec)
+    report.charset_size.should eq(10) # decimal, non-power-of-2
+
+    gated = ["Monobit", "Poker", "Runs", "Long run", "Bit bias"]
+    # A would-be FAIL is downgraded — no gated bit test may carry a FAIL verdict.
+    report.tests.select { |t| gated.includes?(t.name) }.none?(&.verdict.fail?).should be_true
+    # …and at least one carries the not-applicable note as INFO.
+    downgraded = report.tests.select { |t| gated.includes?(t.name) && t.verdict.info? }
+    downgraded.any? { |t| t.detail.includes?("n/a for non-power-of-2 alphabet") }.should be_true
+    # A gated INFO never counts as a fail, so it cannot pull the rating down to Critical.
+    report.rating.should_not eq(S::Rating::Critical)
+  end
+
+  it "keeps bit tests active for a power-of-2 (hex) alphabet — no gating note" do
+    report = S.analyze(random_hex(60, 32))
+    report.charset_size.should eq(16)
+    report.tests.none? { |t| t.detail.includes?("n/a for non-power-of-2 alphabet") }.should be_true
+  end
+
+  # ── Report#rationale ─────────────────────────────────────────────────────────────
+
+  it "renders singular vs plural duplicate-token rationale" do
+    base = random_hex(60, 32)
+
+    one = base.dup
+    one << base[0]
+    r1 = S.analyze(one)
+    r1.duplicate_count.should eq(1)
+    r1.rationale.should contain("1 duplicate token ")
+    r1.rationale.includes?("duplicate tokens").should be_false
+
+    two = base.dup
+    two << base[0]
+    two << base[1]
+    r2 = S.analyze(two)
+    r2.duplicate_count.should eq(2)
+    r2.rationale.should contain("2 duplicate tokens")
+  end
+
+  it "renders sequential-pattern rationale for a counter" do
+    report = S.analyze((100000..100050).map(&.to_s))
+    report.sequential.should be_true
+    report.rationale.should contain("sequential pattern")
+  end
+
+  it "renders 'all tests passed' rationale for a clean high-entropy corpus" do
+    report = S.analyze(random_hex(300, 32))
+    report.duplicate_count.should eq(0)
+    report.sequential.should be_false
+    report.tests.count(&.verdict.fail?).should eq(0)
+    report.rationale.should contain("all tests passed")
+  end
+
+  it "renders plural 'N tests failed' rationale when several tests fail without dup/seq" do
+    pref = random_hex(60, 60, 99_u64).map { |s| "abcd" + s[4..] } # constant prefix, random tail
+    report = S.analyze(pref)
+    report.duplicate_count.should eq(0)
+    report.sequential.should be_false
+    fails = report.tests.count(&.verdict.fail?)
+    fails.should be > 1
+    report.rationale.should contain("#{fails} tests failed")
+  end
+
+  it "renders 'no usable tokens' rationale for an empty report" do
+    S.analyze([] of String).rationale.should eq("no usable tokens")
+    S.analyze(["", "", ""]).rationale.should eq("no usable tokens")
+  end
+
+  # ── rate: tier / FAIL demotion and small-sample clamp ────────────────────────────
+
+  it "demotes a Secure-tier corpus one step per FAIL (and renders singular 'test failed')" do
+    # Skewed decimal: Secure-tier entropy, non-power-of-2 → the bit tests gate to INFO,
+    # leaving chi-square as the lone active failure. Secure(3) − 1 fail = Moderate.
+    rng = Random.new(7_u64)
+    dec = Array(String).new(60) do
+      String.build { |io| 30.times { io << (rng.rand < 0.25 ? '0' : "0123456789"[rng.rand(10)]) } }
+    end
+    report = S.analyze(dec)
+    report.charset_size.should eq(10)
+    report.effective_entropy.should be >= 88.0 # tier == Secure
+    report.sequential.should be_false
+    report.duplicate_count.should eq(0)
+    report.tests.count(&.verdict.fail?).should eq(1)
+    report.tests.find { |t| t.name == "Chi-square" }.not_nil!.verdict.should eq(S::Verdict::Fail)
+    report.rating.should eq(S::Rating::Moderate)
+    report.rationale.should contain("1 test failed")
+    report.rationale.includes?("tests failed").should be_false
+  end
+
+  it "clamps to <= Moderate below the small-sample threshold — n==20 vs n==19 boundary" do
+    at_threshold = S.analyze(random_hex(20, 32)) # n == SMALL_SAMPLE (20): not small
+    at_threshold.effective_entropy.should be >= 88.0
+    at_threshold.tests.count(&.verdict.fail?).should eq(0)
+    at_threshold.rating.should eq(S::Rating::Secure) # clamp does not apply
+
+    below = S.analyze(random_hex(19, 32)) # n == 19: small
+    below.effective_entropy.should be >= 88.0
+    below.tests.count(&.verdict.fail?).should eq(0)
+    below.rating.should eq(S::Rating::Moderate) # Secure tier clamped down
+  end
+
+  # ── single-distinct-byte corpus (charset_size 1) ─────────────────────────────────
+
+  it "fails chi-square with 'no byte variation' for a single-distinct-byte corpus" do
+    report = S.analyze(Array.new(50, "aaaaaaaaaaaaaaaa"))
+    report.charset_size.should eq(1)
+    chi = report.tests.find { |t| t.name == "Chi-square" }.not_nil!
+    chi.value.should eq("1 value")
+    chi.detail.should eq("no byte variation")
+    chi.verdict.should eq(S::Verdict::Fail)
+  end
+
+  it "analyzes a single-distinct-byte, variable-length corpus without raising" do
+    report = S.analyze((1..40).map { |n| "a" * n }) # charset 1, bps 0, distinct lengths
+    report.charset_size.should eq(1)
+    report.usable_count.should eq(40)
+    report.bits_per_char.should eq(0.0)
+  end
+
+  # ── length histogram binning ─────────────────────────────────────────────────────
+
+  it "clamps the length histogram to 24 bins for a wide length span" do
+    rng = Random.new(9_u64)
+    spanning = (1..40).map do |len|
+      String.build { |io| len.times { io << "0123456789abcdef"[rng.rand(16)] } }
+    end
+    report = S.analyze(spanning)
+    report.len_min.should eq(1)
+    report.len_max.should eq(40)
+    report.len_hist.size.should eq(24) # (40 - 1 + 1) clamped to 24
+    report.len_hist.sum.should eq(40)  # every token bucketed exactly once
+  end
+
+  it "collapses a fixed-length corpus into a single histogram bin" do
+    report = S.analyze(random_hex(50, 16))
+    report.len_min.should eq(16)
+    report.len_max.should eq(16)
+    report.len_hist.size.should eq(1) # span 0 → bins clamped to 1
+    report.len_hist[0].should eq(50)
+  end
+
+  # ── sample vs usable accounting + adversarial robustness ─────────────────────────
+
+  it "separates sample_count from usable_count when empty tokens are present" do
+    report = S.analyze(["", "abcd", "", "efgh", "ijkl"])
+    report.sample_count.should eq(5)
+    report.usable_count.should eq(3)
+  end
+
+  it "handles a large single-byte corpus and invalid-UTF-8 bytes without raising" do
+    large = S.analyze(Array.new(5000, "x" * 40)) # bps 0 → no symbol-bit allocation
+    large.charset_size.should eq(1)
+    large.usable_count.should eq(5000)
+
+    bad = Array(String).new(30) { |i| String.new(Bytes[0xff_u8, (i % 250 + 1).to_u8, 0x00_u8, 0x80_u8]) }
+    report = S.analyze(bad)
+    report.charset_label.should eq("binary")
+    report.usable_count.should eq(30)
   end
 end

--- a/spec/sequencer/types_spec.cr
+++ b/spec/sequencer/types_spec.cr
@@ -1,0 +1,273 @@
+require "../spec_helper"
+
+private alias Q = Gori::Sequencer
+
+# A configurable Config so max_sends clamp math can be exercised without repeating
+# the long positional/keyword initializer at every call site.
+private def config(goal : Int32 = 500, max_requests : Int64? = nil) : Q::Config
+  Q::Config.new(goal: goal, max_requests: max_requests)
+end
+
+describe Gori::Sequencer::Mode do
+  describe ".parse?" do
+    it "maps the LiveReplay aliases" do
+      Q::Mode.parse?("live").should eq(Q::Mode::LiveReplay)
+      Q::Mode.parse?("replay").should eq(Q::Mode::LiveReplay)
+      Q::Mode.parse?("live-replay").should eq(Q::Mode::LiveReplay)
+      Q::Mode.parse?("l").should eq(Q::Mode::LiveReplay)
+    end
+
+    it "maps the Manual aliases" do
+      Q::Mode.parse?("manual").should eq(Q::Mode::Manual)
+      Q::Mode.parse?("paste").should eq(Q::Mode::Manual)
+      Q::Mode.parse?("m").should eq(Q::Mode::Manual)
+    end
+
+    it "is case-insensitive and whitespace-insensitive" do
+      Q::Mode.parse?(" LIVE ").should eq(Q::Mode::LiveReplay)
+      Q::Mode.parse?("Manual").should eq(Q::Mode::Manual)
+      Q::Mode.parse?("\tLive-Replay\n").should eq(Q::Mode::LiveReplay)
+      Q::Mode.parse?("PASTE").should eq(Q::Mode::Manual)
+    end
+
+    it "returns nil for unknown, empty, and multibyte tokens" do
+      Q::Mode.parse?("nope").should be_nil
+      Q::Mode.parse?("").should be_nil
+      Q::Mode.parse?("   ").should be_nil
+      Q::Mode.parse?("안녕").should be_nil
+      Q::Mode.parse?("世界🌍").should be_nil
+      # a prefix of a valid alias must not match (whole-token only)
+      Q::Mode.parse?("liv").should be_nil
+      Q::Mode.parse?("live replay").should be_nil # space, not hyphen
+    end
+  end
+
+  describe "#label" do
+    it "renders a human label per value" do
+      Q::Mode::LiveReplay.label.should eq("live replay")
+      Q::Mode::Manual.label.should eq("manual")
+    end
+  end
+end
+
+describe Gori::Sequencer::ExtractKind do
+  describe ".parse?" do
+    it "maps every alias including single-letter forms" do
+      Q::ExtractKind.parse?("cookie").should eq(Q::ExtractKind::Cookie)
+      Q::ExtractKind.parse?("c").should eq(Q::ExtractKind::Cookie)
+      Q::ExtractKind.parse?("header").should eq(Q::ExtractKind::Header)
+      Q::ExtractKind.parse?("h").should eq(Q::ExtractKind::Header)
+      Q::ExtractKind.parse?("regex").should eq(Q::ExtractKind::Regex)
+      Q::ExtractKind.parse?("re").should eq(Q::ExtractKind::Regex)
+      Q::ExtractKind.parse?("r").should eq(Q::ExtractKind::Regex)
+      Q::ExtractKind.parse?("position").should eq(Q::ExtractKind::Position)
+      Q::ExtractKind.parse?("pos").should eq(Q::ExtractKind::Position)
+      Q::ExtractKind.parse?("p").should eq(Q::ExtractKind::Position)
+      Q::ExtractKind.parse?("jsonpath").should eq(Q::ExtractKind::JsonPath)
+      Q::ExtractKind.parse?("json").should eq(Q::ExtractKind::JsonPath)
+      Q::ExtractKind.parse?("j").should eq(Q::ExtractKind::JsonPath)
+    end
+
+    it "disambiguates 'r' to Regex (not Position's 'r')" do
+      Q::ExtractKind.parse?("r").should eq(Q::ExtractKind::Regex)
+    end
+
+    it "is case-insensitive and whitespace-insensitive" do
+      Q::ExtractKind.parse?(" COOKIE ").should eq(Q::ExtractKind::Cookie)
+      Q::ExtractKind.parse?("JsonPath").should eq(Q::ExtractKind::JsonPath)
+      Q::ExtractKind.parse?("\tPOS\n").should eq(Q::ExtractKind::Position)
+    end
+
+    it "returns nil for unknown, empty, and multibyte tokens" do
+      Q::ExtractKind.parse?("nope").should be_nil
+      Q::ExtractKind.parse?("").should be_nil
+      Q::ExtractKind.parse?("   ").should be_nil
+      Q::ExtractKind.parse?("cook").should be_nil
+      Q::ExtractKind.parse?("안녕").should be_nil
+      Q::ExtractKind.parse?("🍪").should be_nil
+    end
+  end
+
+  describe "#label" do
+    it "renders a human label per value" do
+      Q::ExtractKind::Cookie.label.should eq("cookie")
+      Q::ExtractKind::Header.label.should eq("header")
+      Q::ExtractKind::Regex.label.should eq("regex")
+      Q::ExtractKind::Position.label.should eq("position")
+      Q::ExtractKind::JsonPath.label.should eq("jsonpath")
+    end
+  end
+end
+
+describe Gori::Sequencer::TokenLoc do
+  describe "#label" do
+    it "quotes the cookie selector via inspect" do
+      Q::TokenLoc.new(Q::ExtractKind::Cookie, "SESSIONID").label.should eq(%(cookie "SESSIONID"))
+      # the .cookie factory produces the same value
+      Q::TokenLoc.cookie("SESSIONID").label.should eq(%(cookie "SESSIONID"))
+      # empty selector still renders quoted
+      Q::TokenLoc.new(Q::ExtractKind::Cookie).label.should eq(%(cookie ""))
+    end
+
+    it "renders the header selector bare" do
+      Q::TokenLoc.new(Q::ExtractKind::Header, "X-Csrf-Token").label.should eq("header X-Csrf-Token")
+    end
+
+    it "wraps the regex source in slashes" do
+      Q::TokenLoc.new(Q::ExtractKind::Regex, %("token":"(\\w+)")).label
+        .should eq(%(regex /"token":"(\\w+)"/))
+    end
+
+    it "renders a half-open byte range for Position" do
+      Q::TokenLoc.new(Q::ExtractKind::Position, "", 4, 20).label.should eq("body[4...20]")
+      # default zero range
+      Q::TokenLoc.new(Q::ExtractKind::Position).label.should eq("body[0...0]")
+    end
+
+    it "renders the jsonpath selector bare" do
+      Q::TokenLoc.new(Q::ExtractKind::JsonPath, "data.token").label.should eq("jsonpath data.token")
+    end
+
+    it "handles a multibyte selector without mangling" do
+      Q::TokenLoc.new(Q::ExtractKind::Header, "X-안녕").label.should eq("header X-안녕")
+      Q::TokenLoc.new(Q::ExtractKind::Cookie, "세션🍪").label.should eq(%(cookie "세션🍪"))
+    end
+  end
+
+  it "has value equality across identical records" do
+    Q::TokenLoc.new(Q::ExtractKind::Cookie, "a", 1, 2)
+      .should eq(Q::TokenLoc.new(Q::ExtractKind::Cookie, "a", 1, 2))
+    Q::TokenLoc.cookie("a").should eq(Q::TokenLoc.new(Q::ExtractKind::Cookie, "a"))
+  end
+end
+
+describe Gori::Sequencer::NotifyMode do
+  describe ".parse?" do
+    it "maps the WhenDone aliases" do
+      Q::NotifyMode.parse?("when-done").should eq(Q::NotifyMode::WhenDone)
+      Q::NotifyMode.parse?("whendone").should eq(Q::NotifyMode::WhenDone)
+      Q::NotifyMode.parse?("done").should eq(Q::NotifyMode::WhenDone)
+    end
+
+    it "maps the Off aliases" do
+      Q::NotifyMode.parse?("off").should eq(Q::NotifyMode::Off)
+      Q::NotifyMode.parse?("none").should eq(Q::NotifyMode::Off)
+      Q::NotifyMode.parse?("no").should eq(Q::NotifyMode::Off)
+    end
+
+    it "maps the Always aliases" do
+      Q::NotifyMode.parse?("always").should eq(Q::NotifyMode::Always)
+      Q::NotifyMode.parse?("on").should eq(Q::NotifyMode::Always)
+      Q::NotifyMode.parse?("all").should eq(Q::NotifyMode::Always)
+    end
+
+    it "normalizes internal spaces and underscores to hyphens" do
+      Q::NotifyMode.parse?("when done").should eq(Q::NotifyMode::WhenDone)
+      Q::NotifyMode.parse?("when_done").should eq(Q::NotifyMode::WhenDone)
+      Q::NotifyMode.parse?("when   done").should eq(Q::NotifyMode::WhenDone)
+      Q::NotifyMode.parse?("when__done").should eq(Q::NotifyMode::WhenDone)
+      Q::NotifyMode.parse?("when \t_ done").should eq(Q::NotifyMode::WhenDone)
+    end
+
+    it "is case-insensitive and trims surrounding whitespace" do
+      Q::NotifyMode.parse?("  WHEN-DONE  ").should eq(Q::NotifyMode::WhenDone)
+      Q::NotifyMode.parse?("Always").should eq(Q::NotifyMode::Always)
+      Q::NotifyMode.parse?("OFF").should eq(Q::NotifyMode::Off)
+    end
+
+    it "returns nil for unknown, empty, and multibyte tokens" do
+      Q::NotifyMode.parse?("nope").should be_nil
+      Q::NotifyMode.parse?("").should be_nil
+      Q::NotifyMode.parse?("   ").should be_nil
+      Q::NotifyMode.parse?("안녕").should be_nil
+      Q::NotifyMode.parse?("🔔").should be_nil
+    end
+
+    it "round-trips every value through its token" do
+      Q::NotifyMode.values.each do |m|
+        Q::NotifyMode.parse?(m.token).should eq(m)
+      end
+    end
+  end
+
+  describe "#token and #label" do
+    it "renders the machine token per value" do
+      Q::NotifyMode::WhenDone.token.should eq("when-done")
+      Q::NotifyMode::Off.token.should eq("off")
+      Q::NotifyMode::Always.token.should eq("always")
+    end
+
+    it "renders the human label per value" do
+      Q::NotifyMode::WhenDone.label.should eq("when done")
+      Q::NotifyMode::Off.label.should eq("off")
+      Q::NotifyMode::Always.label.should eq("always")
+    end
+  end
+
+  describe "#posts_notification?" do
+    it "Off never posts, even on error" do
+      Q::NotifyMode::Off.posts_notification?(0).should be_false
+      Q::NotifyMode::Off.posts_notification?(100).should be_false
+      Q::NotifyMode::Off.posts_notification?(0, error: true).should be_false
+      Q::NotifyMode::Off.posts_notification?(100, error: true).should be_false
+    end
+
+    it "WhenDone posts only when something was collected or an error occurred" do
+      Q::NotifyMode::WhenDone.posts_notification?(0).should be_false
+      Q::NotifyMode::WhenDone.posts_notification?(1).should be_true
+      Q::NotifyMode::WhenDone.posts_notification?(0, error: true).should be_true
+      Q::NotifyMode::WhenDone.posts_notification?(500).should be_true
+    end
+
+    it "Always posts even at zero collected" do
+      Q::NotifyMode::Always.posts_notification?(0).should be_true
+      Q::NotifyMode::Always.posts_notification?(0, error: false).should be_true
+      Q::NotifyMode::Always.posts_notification?(9999).should be_true
+    end
+  end
+end
+
+describe Gori::Sequencer::Config do
+  it "exposes GOAL_CEILING as 50_000" do
+    Q::Config::GOAL_CEILING.should eq(50_000)
+  end
+
+  it "defaults to LiveReplay, goal 500, and WhenDone notify" do
+    c = Q::Config.new
+    c.mode.should eq(Q::Mode::LiveReplay)
+    c.goal.should eq(500)
+    c.notify.should eq(Q::NotifyMode::WhenDone)
+    c.token_loc.kind.should eq(Q::ExtractKind::Cookie)
+  end
+
+  describe "#max_sends" do
+    it "defaults to twice the goal when no explicit cap" do
+      config(goal: 500).max_sends.should eq(1000_i64)
+      config(goal: 1).max_sends.should eq(2_i64)
+    end
+
+    it "clamps twice-the-goal to the GOAL_CEILING" do
+      # 30000*2 = 60000 -> clamped down to 50_000
+      config(goal: 30_000).max_sends.should eq(50_000_i64)
+      # exactly at the ceiling boundary: 25000*2 = 50000
+      config(goal: 25_000).max_sends.should eq(50_000_i64)
+      # just under: 24999*2 = 49998
+      config(goal: 24_999).max_sends.should eq(49_998_i64)
+      # goal exactly at the ceiling: clamp min==max is valid, stays at 50_000
+      config(goal: 50_000).max_sends.should eq(50_000_i64)
+    end
+
+    it "honors an explicit positive max_requests exactly" do
+      config(goal: 500, max_requests: 42_i64).max_sends.should eq(42_i64)
+      # an explicit cap may exceed the goal-derived ceiling
+      config(goal: 500, max_requests: 1_000_000_i64).max_sends.should eq(1_000_000_i64)
+      # or be far below the goal
+      config(goal: 500, max_requests: 3_i64).max_sends.should eq(3_i64)
+    end
+
+    it "falls back to twice-the-goal for a non-positive max_requests" do
+      config(goal: 500, max_requests: 0_i64).max_sends.should eq(1000_i64)
+      config(goal: 500, max_requests: -5_i64).max_sends.should eq(1000_i64)
+    end
+  end
+end

--- a/spec/tui/geometry_spec.cr
+++ b/spec/tui/geometry_spec.cr
@@ -1,0 +1,187 @@
+require "../spec_helper"
+
+describe Gori::Tui::Rect do
+  describe "#initialize / getters" do
+    it "exposes the four fields verbatim, including negatives" do
+      r = Gori::Tui::Rect.new(-3, -4, 7, 9)
+      r.x.should eq(-3)
+      r.y.should eq(-4)
+      r.w.should eq(7)
+      r.h.should eq(9)
+    end
+
+    it "gives structs value equality across identical fields" do
+      Gori::Tui::Rect.new(1, 2, 3, 4).should eq(Gori::Tui::Rect.new(1, 2, 3, 4))
+      Gori::Tui::Rect.new(1, 2, 3, 4).should_not eq(Gori::Tui::Rect.new(1, 2, 3, 5))
+    end
+  end
+
+  describe "#right" do
+    it "is x + w (exclusive edge)" do
+      Gori::Tui::Rect.new(2, 3, 5, 4).right.should eq(7)
+    end
+
+    it "collapses to x when width is zero" do
+      Gori::Tui::Rect.new(10, 0, 0, 5).right.should eq(10)
+    end
+
+    it "can fall left of x when width is negative" do
+      Gori::Tui::Rect.new(10, 0, -3, 5).right.should eq(7)
+    end
+
+    it "handles a rect anchored at the origin" do
+      Gori::Tui::Rect.new(0, 0, 1, 1).right.should eq(1)
+    end
+  end
+
+  describe "#bottom" do
+    it "is y + h (exclusive edge)" do
+      Gori::Tui::Rect.new(2, 3, 5, 4).bottom.should eq(7)
+    end
+
+    it "collapses to y when height is zero" do
+      Gori::Tui::Rect.new(0, 10, 5, 0).bottom.should eq(10)
+    end
+
+    it "can fall above y when height is negative" do
+      Gori::Tui::Rect.new(0, 10, 5, -4).bottom.should eq(6)
+    end
+  end
+
+  describe "#empty?" do
+    it "is true when width is zero" do
+      Gori::Tui::Rect.new(0, 0, 0, 5).empty?.should be_true
+    end
+
+    it "is true when height is zero" do
+      Gori::Tui::Rect.new(0, 0, 5, 0).empty?.should be_true
+    end
+
+    it "is true when both dimensions are zero" do
+      Gori::Tui::Rect.new(0, 0, 0, 0).empty?.should be_true
+    end
+
+    it "is true when width is negative" do
+      Gori::Tui::Rect.new(0, 0, -1, 5).empty?.should be_true
+    end
+
+    it "is true when height is negative" do
+      Gori::Tui::Rect.new(0, 0, 5, -1).empty?.should be_true
+    end
+
+    it "is false for a 1x1 rect" do
+      Gori::Tui::Rect.new(0, 0, 1, 1).empty?.should be_false
+    end
+
+    it "is false for a normal positive rect regardless of origin" do
+      Gori::Tui::Rect.new(-5, -5, 3, 3).empty?.should be_false
+    end
+  end
+
+  describe "#contains?" do
+    # Rect spans x in [2,7) and y in [3,7).
+    it "includes the top-left corner (inclusive origin)" do
+      Gori::Tui::Rect.new(2, 3, 5, 4).contains?(2, 3).should be_true
+    end
+
+    it "includes an interior point" do
+      Gori::Tui::Rect.new(2, 3, 5, 4).contains?(4, 5).should be_true
+    end
+
+    it "excludes the right edge (exclusive, off-by-one)" do
+      Gori::Tui::Rect.new(2, 3, 5, 4).contains?(7, 3).should be_false
+    end
+
+    it "excludes the bottom edge (exclusive, off-by-one)" do
+      Gori::Tui::Rect.new(2, 3, 5, 4).contains?(2, 7).should be_false
+    end
+
+    it "includes the last cell just inside the exclusive edges" do
+      Gori::Tui::Rect.new(2, 3, 5, 4).contains?(6, 6).should be_true
+    end
+
+    it "excludes points left of x and above y" do
+      r = Gori::Tui::Rect.new(2, 3, 5, 4)
+      r.contains?(1, 5).should be_false
+      r.contains?(4, 2).should be_false
+    end
+
+    it "excludes the bottom-right exclusive corner" do
+      Gori::Tui::Rect.new(2, 3, 5, 4).contains?(7, 7).should be_false
+    end
+
+    it "contains nothing when the rect is empty (zero width)" do
+      r = Gori::Tui::Rect.new(2, 3, 0, 4)
+      r.contains?(2, 3).should be_false
+      r.contains?(2, 5).should be_false
+    end
+
+    it "contains nothing when the rect is empty (zero height)" do
+      r = Gori::Tui::Rect.new(2, 3, 5, 0)
+      r.contains?(4, 3).should be_false
+    end
+
+    it "hit-tests correctly around a negative origin" do
+      r = Gori::Tui::Rect.new(-4, -3, 3, 2)
+      r.contains?(-4, -3).should be_true  # inclusive top-left
+      r.contains?(-2, -2).should be_true  # last interior cell
+      r.contains?(-1, -3).should be_false # right edge exclusive (x+w == -1)
+      r.contains?(-4, -1).should be_false # bottom edge exclusive (y+h == -1)
+      r.contains?(-5, -3).should be_false # left of x
+    end
+  end
+
+  describe "#inset" do
+    it "shrinks inward by dx/dy on each side" do
+      Gori::Tui::Rect.new(0, 0, 10, 10).inset(2, 1).should eq(Gori::Tui::Rect.new(2, 1, 6, 8))
+    end
+
+    it "returns a distinct value-equal Rect (immutability)" do
+      base = Gori::Tui::Rect.new(0, 0, 10, 10)
+      inset = base.inset(2, 1)
+      base.should eq(Gori::Tui::Rect.new(0, 0, 10, 10)) # original untouched
+      inset.w.should eq(6)
+      inset.h.should eq(8)
+    end
+
+    it "supports asymmetric dx/dy" do
+      Gori::Tui::Rect.new(5, 5, 20, 12).inset(3, 0).should eq(Gori::Tui::Rect.new(8, 5, 14, 12))
+    end
+
+    it "clamps width and height at zero rather than going negative" do
+      r = Gori::Tui::Rect.new(0, 0, 3, 3).inset(5, 5)
+      r.x.should eq(5)
+      r.y.should eq(5)
+      r.w.should eq(0)
+      r.h.should eq(0)
+    end
+
+    it "clamps only the dimension that overshoots" do
+      # dx=5 overshoots w=3 -> 0; dy=1 keeps h=3-2 -> 1
+      Gori::Tui::Rect.new(0, 0, 3, 3).inset(5, 1).should eq(Gori::Tui::Rect.new(5, 1, 0, 1))
+    end
+
+    it "produces an empty rect once clamped" do
+      Gori::Tui::Rect.new(0, 0, 3, 3).inset(5, 5).empty?.should be_true
+    end
+
+    it "grows the rect when dx/dy are negative (max-with-0 contract)" do
+      # w - 2*dx with dx=-1 -> w + 2; origin shifts by dx.
+      Gori::Tui::Rect.new(0, 0, 10, 10).inset(-1, -1).should eq(Gori::Tui::Rect.new(-1, -1, 12, 12))
+    end
+
+    it "is a no-op for zero inset" do
+      Gori::Tui::Rect.new(4, 5, 6, 7).inset(0, 0).should eq(Gori::Tui::Rect.new(4, 5, 6, 7))
+    end
+
+    it "lands exactly on zero width at the clamp boundary" do
+      # w=4, dx=2 -> 4-4 == 0 (exactly clamped, not below)
+      Gori::Tui::Rect.new(0, 0, 4, 4).inset(2, 2).should eq(Gori::Tui::Rect.new(2, 2, 0, 0))
+    end
+
+    it "leaves a 1-cell sliver just before the clamp boundary" do
+      # w=5, dx=2 -> 5-4 == 1
+      Gori::Tui::Rect.new(0, 0, 5, 5).inset(2, 2).should eq(Gori::Tui::Rect.new(2, 2, 1, 1))
+    end
+  end
+end

--- a/spec/tui/keybind_spec.cr
+++ b/spec/tui/keybind_spec.cr
@@ -1,0 +1,272 @@
+require "../spec_helper"
+
+# Builds a Termisu key event. Positional order matches the struct constructor
+# (key, modifiers, char) so tests can construct any raw event the parser might
+# hand Keybind.from_event.
+private def key_event(k : Termisu::Input::Key,
+                      mods : Termisu::Input::Modifier = Termisu::Input::Modifier::None,
+                      char : Char? = nil) : Termisu::Event::Key
+  Termisu::Event::Key.new(k, mods, char)
+end
+
+# Runs the unit under test.
+private def chord(k : Termisu::Input::Key,
+                  mods : Termisu::Input::Modifier = Termisu::Input::Modifier::None,
+                  char : Char? = nil) : Gori::Verb::Chord?
+  Gori::Tui::Keybind.from_event(key_event(k, mods, char))
+end
+
+private alias Key = Termisu::Input::Key
+private alias Mod = Termisu::Input::Modifier
+private alias Chord = Gori::Verb::Chord
+
+describe Gori::Tui::Keybind do
+  describe ".from_event named special keys" do
+    it "maps Enter to \"enter\"" do
+      chord(Key::Enter).should eq(Chord.new("enter"))
+    end
+
+    it "maps Escape to \"escape\"" do
+      chord(Key::Escape).should eq(Chord.new("escape"))
+    end
+
+    it "maps Tab to \"tab\"" do
+      chord(Key::Tab).should eq(Chord.new("tab"))
+    end
+
+    it "maps Up to \"up\"" do
+      chord(Key::Up).should eq(Chord.new("up"))
+    end
+
+    it "maps Down to \"down\"" do
+      chord(Key::Down).should eq(Chord.new("down"))
+    end
+
+    it "maps Left to \"left\"" do
+      chord(Key::Left).should eq(Chord.new("left"))
+    end
+
+    it "maps Right to \"right\"" do
+      chord(Key::Right).should eq(Chord.new("right"))
+    end
+
+    it "maps Backspace to \"backspace\"" do
+      chord(Key::Backspace).should eq(Chord.new("backspace"))
+    end
+
+    it "maps Space to \"space\" (not the literal space char)" do
+      # Space is caught by the named-key ladder before the char branch, so the
+      # chord key is the multi-char name, never " ".
+      chord(Key::Space).should eq(Chord.new("space"))
+    end
+
+    it "gives a bare named key no modifiers" do
+      c = chord(Key::Enter).not_nil!
+      c.ctrl.should be_false
+      c.alt.should be_false
+      c.shift.should be_false
+    end
+  end
+
+  describe ".from_event uppercase normalisation" do
+    it "normalises a typed uppercase letter with NO shift modifier to shift+lowercase" do
+      # Terminals deliver a shifted letter as the char itself with no shift bit;
+      # the contract is to synthesise shift + lowercase so \"shift-f\" binds.
+      chord(Key::UpperF).should eq(Chord.new("f", shift: true))
+    end
+
+    it "normalises every letter of the alphabet the same way" do
+      ('A'..'Z').each do |ch|
+        k = Key.from_char(ch)
+        chord(k).should eq(Chord.new(ch.downcase.to_s, shift: true))
+      end
+    end
+
+    it "keeps shift true when uppercase AND the shift modifier are both present" do
+      chord(Key::UpperF, Mod::Shift).should eq(Chord.new("f", shift: true))
+    end
+
+    it "honours an explicitly attached uppercase @char over the key's own char" do
+      # @char takes precedence over key.to_char; an uppercase override still
+      # triggers the shift synthesis even though the key is a lowercase letter.
+      chord(Key::LowerA, char: 'A').should eq(Chord.new("a", shift: true))
+    end
+  end
+
+  describe ".from_event lowercase letters" do
+    it "maps a plain lowercase letter to shift:false" do
+      chord(Key::LowerF).should eq(Chord.new("f", shift: false))
+    end
+
+    it "carries the shift modifier through even when the char stays lowercase" do
+      # Some terminals send lowercase char + a real shift bit; shift ||= false
+      # leaves the already-true modifier intact.
+      chord(Key::LowerA, Mod::Shift).should eq(Chord.new("a", shift: true))
+    end
+
+    it "maps the whole lowercase alphabet with no synthesised shift" do
+      ('a'..'z').each do |ch|
+        chord(Key.from_char(ch)).should eq(Chord.new(ch.to_s, shift: false))
+      end
+    end
+  end
+
+  describe ".from_event non-ASCII printable chars" do
+    it "returns nil for a CJK char (Hangul)" do
+      chord(Key::Unknown, char: '안').should be_nil
+    end
+
+    it "returns nil for a CJK char (Han)" do
+      chord(Key::Unknown, char: '世').should be_nil
+    end
+
+    it "returns nil for an emoji" do
+      chord(Key::Unknown, char: '🔥').should be_nil
+    end
+
+    it "returns nil for a combining mark" do
+      chord(Key::Unknown, char: '́').should be_nil
+    end
+
+    it "returns nil for an accented Latin-1 char just past the ASCII boundary" do
+      # 'ÿ' is U+00FF — first codepoint above the 0x7F ASCII ceiling.
+      chord(Key::Unknown, char: 'ÿ').should be_nil
+    end
+
+    it "accepts the char exactly at the ASCII ceiling (0x7E '~')" do
+      chord(Key::Unknown, char: '~').should eq(Chord.new("~", shift: false))
+    end
+  end
+
+  describe ".from_event digits and punctuation" do
+    it "passes a digit through unchanged" do
+      chord(Key::Num1).should eq(Chord.new("1"))
+    end
+
+    it "maps every digit key to its own char" do
+      ('0'..'9').each do |ch|
+        chord(Key.from_char(ch)).should eq(Chord.new(ch.to_s, shift: false))
+      end
+    end
+
+    it "passes an unshifted punctuation key through" do
+      chord(Key::LeftBracket).should eq(Chord.new("["))
+    end
+
+    it "passes the literal minus key through (so \"ctrl--\" can round-trip)" do
+      chord(Key::Minus).should eq(Chord.new("-"))
+    end
+
+    it "does NOT synthesise shift for a shifted-symbol key (only ascii_uppercase? triggers it)" do
+      # '!' is not ascii_uppercase?, so shift stays whatever the modifier said —
+      # here None. The contract keys shift off letter case, not symbol shiftiness.
+      chord(Key::Exclaim).should eq(Chord.new("!", shift: false))
+    end
+
+    it "carries a real shift modifier on a symbol key without touching the key name" do
+      chord(Key::Exclaim, Mod::Shift).should eq(Chord.new("!", shift: true))
+    end
+  end
+
+  describe ".from_event modifier propagation" do
+    it "propagates ctrl into a named-key chord (ctrl+Enter)" do
+      chord(Key::Enter, Mod::Ctrl).should eq(Chord.new("enter", ctrl: true))
+    end
+
+    it "propagates alt into a letter chord (alt+a)" do
+      chord(Key::LowerA, Mod::Alt).should eq(Chord.new("a", alt: true))
+    end
+
+    it "propagates ctrl into a letter chord (ctrl+a)" do
+      chord(Key::LowerA, Mod::Ctrl).should eq(Chord.new("a", ctrl: true))
+    end
+
+    it "propagates alt into a named-key chord (alt+Left)" do
+      chord(Key::Left, Mod::Alt).should eq(Chord.new("left", alt: true))
+    end
+
+    it "combines ctrl+alt on a letter" do
+      chord(Key::LowerA, Mod::Ctrl | Mod::Alt).should eq(Chord.new("a", ctrl: true, alt: true))
+    end
+
+    it "combines ctrl+shift on an uppercase letter (shift already true, ctrl added)" do
+      chord(Key::UpperF, Mod::Ctrl).should eq(Chord.new("f", ctrl: true, shift: true))
+    end
+
+    it "carries all three modifiers on a named key" do
+      chord(Key::Tab, Mod::Ctrl | Mod::Alt | Mod::Shift)
+        .should eq(Chord.new("tab", ctrl: true, alt: true, shift: true))
+    end
+
+    it "ignores the meta modifier (Keybind reads only ctrl/alt/shift)" do
+      # Meta has no field on Chord; a meta-only Enter is still a bare \"enter\".
+      chord(Key::Enter, Mod::Meta).should eq(Chord.new("enter"))
+    end
+  end
+
+  describe ".from_event shift on named keys" do
+    it "carries shift on shift+Tab (Tab key + shift bit)" do
+      chord(Key::Tab, Mod::Shift).should eq(Chord.new("tab", shift: true))
+    end
+
+    it "carries shift on shift+Enter" do
+      chord(Key::Enter, Mod::Shift).should eq(Chord.new("enter", shift: true))
+    end
+  end
+
+  describe ".from_event unrecognised keys" do
+    it "returns nil for a function key (F1) — no name, no printable char" do
+      chord(Key::F1).should be_nil
+    end
+
+    it "returns nil for a high function key (F24)" do
+      chord(Key::F24).should be_nil
+    end
+
+    it "returns nil for BackTab (its own key, not Tab; no printable char)" do
+      # Shift+Tab arrives as a distinct BackTab key on some terminals. It is not
+      # Key::Tab, so key.tab? is false, and BackTab has no to_char — final else.
+      chord(Key::BackTab).should be_nil
+    end
+
+    it "returns nil for Home / navigation keys with no char and no name" do
+      chord(Key::Home).should be_nil
+      chord(Key::PageUp).should be_nil
+      chord(Key::Delete).should be_nil
+    end
+
+    it "returns nil for an Unknown key with no attached char" do
+      chord(Key::Unknown).should be_nil
+    end
+
+    it "returns nil for CapsLock and other protocol-only keys" do
+      chord(Key::CapsLock).should be_nil
+      chord(Key::PrintScreen).should be_nil
+    end
+  end
+
+  describe ".from_event completeness" do
+    it "resolves every declared NAMED_KEY of a Chord to a non-nil chord with that name" do
+      # The named-key ladder must emit exactly the names Chord advertises as legal.
+      name_to_key = {
+        "enter"     => Key::Enter,
+        "escape"    => Key::Escape,
+        "tab"       => Key::Tab,
+        "up"        => Key::Up,
+        "down"      => Key::Down,
+        "left"      => Key::Left,
+        "right"     => Key::Right,
+        "backspace" => Key::Backspace,
+        "space"     => Key::Space,
+      }
+      Chord::NAMED_KEYS.each do |name|
+        k = name_to_key[name]? || fail("no key mapping for NAMED_KEY #{name}")
+        chord(k).should eq(Chord.new(name))
+      end
+    end
+
+    it "returns a value-equal Chord (record equality) rather than an identity" do
+      chord(Key::LowerG).should eq(Chord.new("g", ctrl: false, alt: false, shift: false))
+    end
+  end
+end

--- a/spec/tui/layout_spec.cr
+++ b/spec/tui/layout_spec.cr
@@ -1,0 +1,217 @@
+require "../spec_helper"
+
+# The layout is pure integer geometry, so no backend/harness is needed. We assert
+# the documented contract from src/gori/tui/layout.cr: chrome rows (topbar/rule/menu)
+# at y0+0/+1/+2, body at y0+3, status pinned near the bottom, an empty statusline
+# Rect unless the feature is on, and the clamped dims that must never go negative.
+
+private HPAD = Gori::Tui::Layout::H_PADDING # 2
+private VPAD = Gori::Tui::Layout::V_PADDING # 1
+
+describe Gori::Tui::Layout do
+  describe ".usable?" do
+    it "requires at least 40 columns AND 8 rows (>= on both dims)" do
+      # exact thresholds from source: width >= 40 && height >= 8
+      Gori::Tui::Layout.usable?(40, 8).should be_true
+    end
+
+    it "rejects one column short of the width threshold" do
+      Gori::Tui::Layout.usable?(39, 8).should be_false
+    end
+
+    it "rejects one row short of the height threshold" do
+      Gori::Tui::Layout.usable?(40, 7).should be_false
+    end
+
+    it "accepts values comfortably above both thresholds" do
+      Gori::Tui::Layout.usable?(41, 9).should be_true
+      Gori::Tui::Layout.usable?(80, 24).should be_true
+      Gori::Tui::Layout.usable?(Int32::MAX, Int32::MAX).should be_true
+    end
+
+    it "rejects a terminal that is wide enough but far too short" do
+      Gori::Tui::Layout.usable?(200, 1).should be_false
+    end
+
+    it "rejects a terminal that is tall enough but far too narrow" do
+      Gori::Tui::Layout.usable?(1, 200).should be_false
+    end
+
+    it "rejects zero and negative sizes" do
+      Gori::Tui::Layout.usable?(0, 0).should be_false
+      Gori::Tui::Layout.usable?(-40, -8).should be_false
+    end
+  end
+
+  describe ".compute (default, statusline off)" do
+    it "places chrome, body and status at the documented rows with reserved==4" do
+      l = Gori::Tui::Layout.compute(80, 24)
+      x = HPAD              # 2
+      y0 = VPAD             # 1
+      inner_w = 80 - 2*HPAD # 76
+      inner_h = 24 - 2*VPAD # 22
+
+      # topbar/rule/menu are single-row inset bars stacked at y0, y0+1, y0+2.
+      l.topbar.should eq(Gori::Tui::Rect.new(x, y0 + 0, inner_w, 1))
+      l.rule.should eq(Gori::Tui::Rect.new(x, y0 + 1, inner_w, 1))
+      l.menu.should eq(Gori::Tui::Rect.new(x, y0 + 2, inner_w, 1))
+
+      # body starts at row 3 and reserves 4 rows (topbar+rule+menu+status).
+      l.body.should eq(Gori::Tui::Rect.new(x, y0 + 3, inner_w, inner_h - 4))
+      l.body.h.should eq(18)
+
+      # status sits on the last inner row (statusline off => -1).
+      l.status.should eq(Gori::Tui::Rect.new(x, y0 + inner_h - 1, inner_w, 1))
+
+      # statusline is the empty Rect built at (x, y0, 0, 0) when the feature is off.
+      l.statusline.should eq(Gori::Tui::Rect.new(x, y0, 0, 0))
+      (l.statusline.w == 0 && l.statusline.h == 0).should be_true
+      l.statusline.empty?.should be_true
+    end
+
+    it "field-wiring regression: menu.y is y0+2 and rule.y is y0+1 (never swapped)" do
+      # initialize(@topbar,@menu,@rule,...) takes params in a different order than the
+      # local vars, so a swap at the call site would flip these two. Guard against it.
+      l = Gori::Tui::Layout.compute(80, 24)
+      l.rule.y.should eq(VPAD + 1) # 2
+      l.menu.y.should eq(VPAD + 2) # 3
+      l.topbar.y.should eq(VPAD)   # 1
+      l.rule.y.should be < l.menu.y
+    end
+
+    it "insets every chrome/body rect by H_PADDING on x and shares inner_w width" do
+      l = Gori::Tui::Layout.compute(80, 24)
+      inner_w = 80 - 2*HPAD
+      {l.topbar, l.rule, l.menu, l.body, l.status}.each do |r|
+        r.x.should eq(HPAD)
+        r.w.should eq(inner_w)
+      end
+    end
+
+    it "explicitly reserves 4 rows: inner_h - body.h == 4 for a tall terminal" do
+      l = Gori::Tui::Layout.compute(80, 100)
+      inner_h = 100 - 2*VPAD
+      (inner_h - l.body.h).should eq(4)
+    end
+  end
+
+  describe ".compute (statusline on)" do
+    it "reserves 5 rows, shifts status up one and gives the statusline the last row" do
+      x = HPAD
+      y0 = VPAD
+      inner_w = 80 - 2*HPAD
+      inner_h = 24 - 2*VPAD
+
+      on = Gori::Tui::Layout.compute(80, 24, true)
+
+      # chrome is unchanged relative to the default layout.
+      on.topbar.should eq(Gori::Tui::Rect.new(x, y0 + 0, inner_w, 1))
+      on.rule.should eq(Gori::Tui::Rect.new(x, y0 + 1, inner_w, 1))
+      on.menu.should eq(Gori::Tui::Rect.new(x, y0 + 2, inner_w, 1))
+
+      # status moves to inner_h-2; statusline occupies inner_h-1 with full inner_w.
+      on.status.should eq(Gori::Tui::Rect.new(x, y0 + inner_h - 2, inner_w, 1))
+      on.statusline.should eq(Gori::Tui::Rect.new(x, y0 + inner_h - 1, inner_w, 1))
+      on.statusline.w.should eq(inner_w)
+      on.statusline.empty?.should be_false
+
+      # reserved == 5 => body one row shorter than the default layout.
+      on.body.should eq(Gori::Tui::Rect.new(x, y0 + 3, inner_w, inner_h - 5))
+      (inner_h - on.body.h).should eq(5)
+    end
+
+    it "makes body exactly one row shorter than the statusline-off layout" do
+      off = Gori::Tui::Layout.compute(80, 24, false)
+      on = Gori::Tui::Layout.compute(80, 24, true)
+      (off.body.h - on.body.h).should eq(1)
+      # and the statusline row exactly occupies where off.status used to be free below.
+      on.statusline.y.should eq(off.status.y)
+    end
+  end
+
+  describe ".compute (clamping and tiny terminals)" do
+    it "clamps inner_w/inner_h and body.h to 0 on a 0x0 terminal (never negative)" do
+      l = Gori::Tui::Layout.compute(0, 0)
+      # inner_w = max(0 - 4, 0) = 0; inner_h = max(0 - 2, 0) = 0.
+      l.topbar.w.should eq(0)
+      l.body.w.should eq(0)
+      l.body.h.should eq(0)
+      # widths/heights that are clamped must never be negative.
+      {l.topbar, l.rule, l.menu, l.body, l.status, l.statusline}.each do |r|
+        r.w.should be >= 0
+        r.h.should be >= 0
+      end
+    end
+
+    it "clamps inner_w to 0 when width is below twice the horizontal padding" do
+      # width 3 < 2*HPAD(=4) => inner_w = max(3-4,0) = 0.
+      l = Gori::Tui::Layout.compute(3, 40)
+      l.topbar.w.should eq(0)
+      l.body.w.should eq(0)
+    end
+
+    it "clamps body.h to 0 (default, reserved=4) when inner_h < reserved" do
+      # height 5 => inner_h = 3 < 4 => body.h = max(3-4,0) = 0.
+      l = Gori::Tui::Layout.compute(80, 5)
+      l.body.h.should eq(0)
+    end
+
+    it "clamps body.h to 0 (statusline, reserved=5) when inner_h < reserved" do
+      # NOTE: the checklist's "height=9 statusline -> body.h==0" is off: at height 9
+      # inner_h=7, body.h=max(7-5,0)=2. The clamp only bites once inner_h<5, i.e.
+      # height<7. Assert the real source contract with height=6 (inner_h=4).
+      l = Gori::Tui::Layout.compute(80, 6, true)
+      l.body.h.should eq(0)
+    end
+
+    it "verifies the checklist's height=9 statusline case actually yields body.h==2" do
+      # Documents the corrected arithmetic so a future reader is not misled.
+      l = Gori::Tui::Layout.compute(80, 9, true)
+      l.body.h.should eq(2)
+    end
+
+    it "keeps clamped dims non-negative even when statusline is on at 0x0" do
+      l = Gori::Tui::Layout.compute(0, 0, true)
+      l.body.w.should eq(0)
+      l.body.h.should eq(0)
+      l.statusline.w.should eq(0)
+      # inner_h==0 pushes status.y negative (y0+0-2 = -1). The doc only promises the
+      # dims are clamped, not the coords, and usable? gates rendering at 40x8, so this
+      # is out-of-contract territory: assert the actual value rather than a "no
+      # negative coords" rule the source never claims.
+      l.status.y.should eq(VPAD + 0 - 2) # -1
+    end
+  end
+
+  describe ".compute (boundaries and extreme sizes)" do
+    it "produces a 1-row body at the smallest usable height (8) with statusline off" do
+      # inner_h = 8 - 2 = 6; body.h = 6 - 4 = 2.
+      l = Gori::Tui::Layout.compute(40, 8)
+      l.body.h.should eq(2)
+      l.status.y.should eq(VPAD + (8 - 2*VPAD) - 1) # last inner row
+    end
+
+    it "handles Int32::MAX dimensions without overflowing (overflow-clamp analogue)" do
+      # inner_w = max(MAX-4,0) = MAX-4; inner_h = MAX-2; y0+inner_h = MAX-1 (no wrap).
+      l = Gori::Tui::Layout.compute(Int32::MAX, Int32::MAX)
+      l.topbar.w.should eq(Int32::MAX - 2*HPAD)
+      l.topbar.y.should eq(VPAD)
+      l.body.h.should eq(Int32::MAX - 2*VPAD - 4)
+      l.status.y.should eq(VPAD + (Int32::MAX - 2*VPAD) - 1)
+      l.body.h.should be > 0
+    end
+
+    it "handles Int32::MAX dimensions with the statusline on" do
+      l = Gori::Tui::Layout.compute(Int32::MAX, Int32::MAX, true)
+      l.body.h.should eq(Int32::MAX - 2*VPAD - 5)
+      l.statusline.w.should eq(Int32::MAX - 2*HPAD)
+      l.statusline.y.should eq(VPAD + (Int32::MAX - 2*VPAD) - 1)
+      l.status.y.should eq(VPAD + (Int32::MAX - 2*VPAD) - 2)
+    end
+
+    it "exposes the padding constants used to inset the chrome" do
+      Gori::Tui::Layout::H_PADDING.should eq(2)
+      Gori::Tui::Layout::V_PADDING.should eq(1)
+    end
+  end
+end

--- a/spec/tui/search_hi_spec.cr
+++ b/spec/tui/search_hi_spec.cr
@@ -1,0 +1,216 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# Draw `text` as the base line at (x, y) exactly as a view would before the
+# search overlay runs, then apply the overlay — mirrors the real call order so
+# the yellow band lands on cells the base draw actually painted.
+private def base_and_mark(text : String, query : String, max_x : Int32, x = 0, w = 40) : MemoryBackend
+  backend = MemoryBackend.new(w, 1)
+  screen = Screen.new(backend)
+  screen.text(x, 0, text, Theme.text)
+  SearchHi.mark(screen, x, 0, text, query, max_x)
+  backend
+end
+
+# Overlay-only: no base draw, so untouched cells keep Color.default. Lets a
+# "nothing was painted" assertion distinguish a highlighted cell from a bare one.
+private def mark_only(text : String, query : String, max_x : Int32, x = 0, w = 40) : MemoryBackend
+  backend = MemoryBackend.new(w, 1)
+  SearchHi.mark(Screen.new(backend), x, 0, text, query, max_x)
+  backend
+end
+
+# The columns [from, to) whose background is the search-match yellow.
+private def yellow_cols(b : MemoryBackend, w = 40) : Array(Int32)
+  (0...w).select { |x| b.bg_at(x, 0) == Theme.yellow }
+end
+
+describe Gori::Tui::SearchHi do
+  describe "early return (empty query or empty text)" do
+    it "paints nothing when the query is empty (bg stays default across the row)" do
+      b = mark_only("a FOObar", "", 40)
+      (0...40).each { |x| b.bg_at(x, 0).should eq(Gori::Tui::Color.default) }
+    end
+
+    it "paints nothing when the text is empty (bg stays default across the row)" do
+      b = mark_only("", "foo", 40)
+      (0...40).each { |x| b.bg_at(x, 0).should eq(Gori::Tui::Color.default) }
+    end
+
+    it "paints nothing when BOTH are empty" do
+      b = mark_only("", "", 40)
+      yellow_cols(b).should be_empty
+    end
+  end
+
+  describe "a single case-insensitive match" do
+    it "paints exactly q.size cells at the right column (\"foo\" in \"a FOObar\")" do
+      b = base_and_mark("a FOObar", "foo", 40)
+      # "FOO" sits at char/col 2..4; the overlay lowercases the query but positions
+      # against the ORIGINAL cells, so cols 2,3,4 get the yellow band.
+      yellow_cols(b).should eq([2, 3, 4])
+      b.bg_at(1, 0).should_not eq(Theme.yellow) # the space before is untouched
+      b.bg_at(5, 0).should_not eq(Theme.yellow) # "bar" after is untouched
+    end
+
+    it "matches regardless of the query's own case (\"FOO\" query, \"foo\" text)" do
+      b = base_and_mark("x foobar", "FOO", 40)
+      yellow_cols(b).should eq([2, 3, 4])
+    end
+
+    it "honours the content-x offset x (band = x + column)" do
+      b = base_and_mark("a FOObar", "foo", 40, x: 5)
+      yellow_cols(b).should eq([7, 8, 9])
+    end
+
+    it "paints nothing when the query does not occur" do
+      b = base_and_mark("a FOObar", "zzz", 40)
+      yellow_cols(b).should be_empty
+    end
+
+    it "paints nothing when the query is longer than the text" do
+      b = base_and_mark("hi", "hiya", 40)
+      yellow_cols(b).should be_empty
+    end
+  end
+
+  describe "multiple occurrences (guards the O(line) accumulator)" do
+    it "highlights every occurrence with column-correct offsets (\"ab\" in \"ab ab ab\")" do
+      b = base_and_mark("ab ab ab", "ab", 40)
+      yellow_cols(b).should eq([0, 1, 3, 4, 6, 7])
+      # the single-space gaps stay unpainted
+      b.bg_at(2, 0).should_not eq(Theme.yellow)
+      b.bg_at(5, 0).should_not eq(Theme.yellow)
+    end
+
+    it "keeps offsets correct when gaps between matches vary in width" do
+      # "a" then a 5-space gap then "a" — the accumulator must measure only the gap
+      # since the previous match, not re-walk from column 0.
+      b = base_and_mark("a     a", "a", 40)
+      yellow_cols(b).should eq([0, 6])
+    end
+  end
+
+  describe "column correctness after a wide (CJK / width-2) prefix" do
+    it "lands at x + draw_width(prefix), not the character count (\"世界\" prefix)" do
+      # "世界" is two width-2 glyphs ⇒ 4 drawn columns, so "foo" is drawn at cols 4,5,6.
+      # A char-count column would have put the band at col 2, over the CJK glyphs.
+      b = base_and_mark("世界foo", "foo", 40)
+      yellow_cols(b).should eq([4, 5, 6])
+      b.bg_at(0, 0).should_not eq(Theme.yellow) # 世
+      b.bg_at(2, 0).should_not eq(Theme.yellow) # 界
+      # confirm the base draw really placed the CJK glyphs at cols 0 and 2 (col 1 is
+      # the wide-glyph continuation), so the col-4 band is genuinely past the prefix.
+      b.cluster_grid[0][0].should eq("世")
+      b.cluster_grid[0][2].should eq("界")
+    end
+
+    it "lands correctly after a ZWJ emoji cluster (the #285 off-by-N bug)" do
+      zwj = "\u{1F468}\u{200D}\u{1F4BB}" # 👨‍💻 : 3 codepoints, 2 drawn columns
+      b = base_and_mark(zwj + "needle", "needle", 40)
+      # The cluster occupies cols 0-1, so "needle" is at cols 2..7 — under column_width
+      # (per-codepoint) the band drifted to col 5, painting over unrelated glyphs.
+      yellow_cols(b).should eq([2, 3, 4, 5, 6, 7])
+      b.bg_at(1, 0).should_not eq(Theme.yellow) # the emoji stays uncoloured
+      b.bg_at(8, 0).should_not eq(Theme.yellow) # nothing past the match
+    end
+
+    it "lands correctly after a tab (issue #278, ASCII grapheme path)" do
+      # A tab is one drawn column, so "needle" begins at col 2.
+      b = base_and_mark("a\tneedle", "needle", 40)
+      yellow_cols(b).should eq([2, 3, 4, 5, 6, 7])
+    end
+  end
+
+  describe "U+0130 length-change fallback (dt.size != text.size)" do
+    it "does not crash and keeps the column right when downcase expands a glyph" do
+      # 'İ' (U+0130) lowercases to "i" + U+0307 (2 codepoints), so the downcased copy
+      # is longer than the source; the code falls back to slicing the downcased string.
+      text = "İ foo"
+      (text.downcase.size != text.size).should be_true # branch is actually live
+      b = base_and_mark(text, "foo", 40)
+      # 'İ' draws in one column, space in one, so "foo" is at cols 2,3,4 regardless.
+      yellow_cols(b).should eq([2, 3, 4])
+    end
+  end
+
+  describe "clipping at max_x (exclusive)" do
+    it "does not paint a match whose start column is at or past max_x" do
+      # "foo" would start at col 2; max_x == 2 makes col < max_x false.
+      b = base_and_mark("xxfoo", "foo", 2)
+      yellow_cols(b).should be_empty
+    end
+
+    it "paints only max(max_x - col, 0) cells for a match straddling max_x" do
+      # "cdef" starts at col 2; max_x == 4 ⇒ a 2-cell band (cols 2,3). Screen#text
+      # renders "c…" there, but the yellow BAND width is what the clamp guarantees.
+      b = base_and_mark("abcdef", "cdef", 4)
+      yellow_cols(b).should eq([2, 3])
+      b.bg_at(4, 0).should_not eq(Theme.yellow)
+      b.bg_at(5, 0).should_not eq(Theme.yellow)
+    end
+
+    it "paints the whole match when max_x sits exactly at its end (boundary)" do
+      # "cdef" occupies cols 2..5; max_x == 6 is exclusive but one past the last cell.
+      b = base_and_mark("abcdef", "cdef", 6)
+      yellow_cols(b).should eq([2, 3, 4, 5])
+    end
+  end
+
+  describe "match at position 0 and back-to-back matches" do
+    it "highlights a match that starts at column 0" do
+      b = base_and_mark("foobar", "foo", 40)
+      yellow_cols(b).should eq([0, 1, 2])
+    end
+
+    it "advances past adjacent matches without double-paint or an infinite loop (\"aa\" in \"aaaa\")" do
+      # Non-overlapping matches at 0 and 2 cover all four cells exactly once; pos jumps
+      # by q.size each time so the loop terminates.
+      b = base_and_mark("aaaa", "aa", 40)
+      yellow_cols(b).should eq([0, 1, 2, 3])
+    end
+
+    it "handles a single-character query filling the whole run" do
+      b = base_and_mark("aaaa", "a", 40)
+      yellow_cols(b).should eq([0, 1, 2, 3])
+    end
+  end
+
+  describe "adversarial scale (String#index, no regex → no ReDoS)" do
+    it "walks a token-dense line with thousands of matches without hanging" do
+      # "abab…ab" — every 2 columns is a fresh match. Painting is clipped by a tiny
+      # max_x, but the match loop still scans the whole string; it must terminate and
+      # stay correct. (A generous bound: this size runs in tens of ms.)
+      text = "ab" * 2_000
+      backend = MemoryBackend.new(10, 1)
+      t0 = Time.instant
+      SearchHi.mark(Screen.new(backend), 0, 0, text, "ab", 8)
+      # Generous ceiling: normal runs are tens of ms; only a quadratic/hang regression
+      # (which would take many seconds) trips it, so a slow CI box can't flake this.
+      ((Time.instant - t0).total_milliseconds).should be < 5_000.0
+      # Only the first 8 columns are inside max_x, so exactly cols 0..7 are painted.
+      yellow_cols(backend, 10).should eq([0, 1, 2, 3, 4, 5, 6, 7])
+    end
+
+    it "returns quickly when a long line contains no match (one index scan)" do
+      text = "a" * 200_000
+      backend = MemoryBackend.new(10, 1)
+      t0 = Time.instant
+      SearchHi.mark(Screen.new(backend), 0, 0, text, "zzz", 10)
+      ((Time.instant - t0).total_milliseconds).should be < 5_000.0
+      yellow_cols(backend, 10).should be_empty
+    end
+
+    # SUSPECTED BUG (reported as a finding, not an executable test — a big-O claim can only
+    # be shown by timing, which is too flaky to assert in CI): the accumulator comment
+    # (search_hi.cr:20-23) documents the mark loop as "O(line) total instead of ... O(line²)
+    # on token-dense lines". But the loop's `dt.index(q, pos)` takes a CHARACTER offset, and
+    # String#index converts it to a byte offset by walking `pos` characters each call — so on
+    # a token-dense line the total is still O(line²) (measured: matches 1k→2k→4k→8k gave
+    # 0.8→4→14→39 ms, quadrupling per doubling). The draw_width re-walk was removed but an
+    # index re-walk remains, so the documented O(line) contract does not hold. Functionally
+    # correct (highlighting stays column-correct — covered by the cases above); perf only.
+  end
+end

--- a/spec/tui/url_spec.cr
+++ b/spec/tui/url_spec.cr
@@ -1,0 +1,158 @@
+require "../spec_helper"
+
+describe Gori::Tui::Url do
+  describe ".origin_path" do
+    it "projects an absolute-form URL to origin-form, keeping query and fragment" do
+      Gori::Tui::Url.origin_path("http://example.com/a/b?q=1#f").should eq("/a/b?q=1#f")
+    end
+
+    it "returns '/' for an absolute-form URL with no path" do
+      Gori::Tui::Url.origin_path("http://example.com").should eq("/")
+    end
+
+    it "strips the port from the authority" do
+      Gori::Tui::Url.origin_path("https://host:8443/x").should eq("/x")
+    end
+
+    it "passes a non-URL target through unchanged (e.g. a status reason phrase)" do
+      Gori::Tui::Url.origin_path("405 Method Not Allowed").should eq("405 Method Not Allowed")
+    end
+
+    it "leaves a bare origin-form target untouched" do
+      Gori::Tui::Url.origin_path("/foo/bar").should eq("/foo/bar")
+    end
+
+    it "treats a single-slash near-miss scheme as a non-URL (identity)" do
+      Gori::Tui::Url.origin_path("http:/example").should eq("http:/example")
+    end
+
+    it "treats an unknown scheme prefix as a non-URL (identity)" do
+      Gori::Tui::Url.origin_path("httpx://h/p").should eq("httpx://h/p")
+    end
+
+    it "slices on char boundaries with a multibyte host and path (no corruption)" do
+      Gori::Tui::Url.origin_path("http://éxample.com/한").should eq("/한")
+    end
+
+    it "returns the empty string unchanged" do
+      Gori::Tui::Url.origin_path("").should eq("")
+    end
+
+    # --- glue-bug regression: output must never re-embed the authority ---
+
+    it "never glues the host onto the projected path" do
+      out = Gori::Tui::Url.origin_path("http://example.com/x")
+      out.should eq("/x")
+      out.should_not contain("example.com")
+      out.should_not contain("http")
+    end
+
+    it "does not carry the host when there is no path" do
+      out = Gori::Tui::Url.origin_path("http://example.com")
+      out.should_not contain("example.com")
+      out.starts_with?("/").should be_true
+    end
+
+    # --- scheme boundary / prefix cases ---
+
+    it "handles the https scheme the same as http" do
+      Gori::Tui::Url.origin_path("https://example.com/secure").should eq("/secure")
+    end
+
+    it "is case-sensitive on the scheme (uppercase passes through)" do
+      Gori::Tui::Url.origin_path("HTTP://example.com/x").should eq("HTTP://example.com/x")
+    end
+
+    it "passes through a scheme-relative URL (no scheme prefix)" do
+      Gori::Tui::Url.origin_path("//example.com/x").should eq("//example.com/x")
+    end
+
+    it "passes through a mailto: (non-http) URL unchanged" do
+      Gori::Tui::Url.origin_path("mailto:user@example.com").should eq("mailto:user@example.com")
+    end
+
+    # --- boundary: minimal / truncated absolute forms ---
+
+    it "returns '/' for a bare scheme+authority separator (http://)" do
+      Gori::Tui::Url.origin_path("http://").should eq("/")
+    end
+
+    it "returns '/' for a bare https:// separator" do
+      Gori::Tui::Url.origin_path("https://").should eq("/")
+    end
+
+    it "returns '/' for scheme+host with no trailing slash" do
+      Gori::Tui::Url.origin_path("http://h").should eq("/")
+    end
+
+    it "preserves a lone trailing slash as the whole path" do
+      Gori::Tui::Url.origin_path("http://example.com/").should eq("/")
+    end
+
+    it "handles an empty authority (triple slash)" do
+      Gori::Tui::Url.origin_path("http:///path").should eq("/path")
+    end
+
+    # --- path content preservation ---
+
+    it "keeps every slash of a deep path" do
+      Gori::Tui::Url.origin_path("http://h/a/b/c/d/e").should eq("/a/b/c/d/e")
+    end
+
+    it "keeps reserved and encoded characters verbatim in the path" do
+      Gori::Tui::Url.origin_path("http://h/p%20a?x=%2F&y=a+b#frag/ment")
+        .should eq("/p%20a?x=%2F&y=a+b#frag/ment")
+    end
+
+    it "keeps a userinfo-bearing authority out of the projection" do
+      out = Gori::Tui::Url.origin_path("http://user:pass@host:80/p")
+      out.should eq("/p")
+      out.should_not contain("pass")
+    end
+
+    # --- query/fragment on an empty path ---
+    # NOTE: the source keys off the first '/' after the authority. A URL whose only
+    # component after the authority is a query or fragment (no '/') has no such slash,
+    # so it collapses to "/". This is the actual, safe behavior for the display helper;
+    # such wire targets are rare (origin-form always carries a path). Asserting actual.
+
+    it "collapses an absolute URL whose only tail is a query to '/'" do
+      Gori::Tui::Url.origin_path("http://example.com?q=1").should eq("/")
+    end
+
+    it "collapses an absolute URL whose only tail is a fragment to '/'" do
+      Gori::Tui::Url.origin_path("http://example.com#f").should eq("/")
+    end
+
+    # --- multibyte / adversarial ---
+
+    it "handles a CJK-only path segment" do
+      Gori::Tui::Url.origin_path("http://호스트/안녕/世界").should eq("/안녕/世界")
+    end
+
+    it "handles an emoji (surrogate/astral) path" do
+      Gori::Tui::Url.origin_path("http://h/🚀/x").should eq("/🚀/x")
+    end
+
+    it "handles a combining-mark host without corrupting the following path" do
+      # "e" + U+0301 combining acute accent in the host
+      Gori::Tui::Url.origin_path("http://éhost.com/p").should eq("/p")
+    end
+
+    it "completes quickly on a very long path (no pathological scanning)" do
+      long = "http://h/" + ("a/" * 200_000)
+      elapsed = Time.measure { Gori::Tui::Url.origin_path(long) }
+      elapsed.should be < 1.second
+      out = Gori::Tui::Url.origin_path(long)
+      out.starts_with?("/a/").should be_true
+      out.size.should eq(long.size - 8) # dropped "http://h"
+    end
+
+    it "completes quickly on a long multibyte path" do
+      long = "http://héllo/" + ("한/" * 100_000)
+      out = Gori::Tui::Url.origin_path(long)
+      out.starts_with?("/한/").should be_true
+      out.should_not contain("héllo")
+    end
+  end
+end


### PR DESCRIPTION
## What

Expands the spec suite by **22 new files + 4 extended (~757 new examples)**, targeting previously-untested pure-logic modules and passive probe rules. Tests assert the **documented contract** (not incidental output) and lean on diverse edge inputs: empty, multibyte/Unicode (CJK/emoji/combining), malformed/adversarial (truncated, invalid UTF-8, ReDoS bait, overflow), and boundaries (0/1/max/off-by-one).

Coverage added, by area:

| Area | Specs |
|------|-------|
| Parsers | `graphql`, `saml`, `form_data` |
| Sequencer (randomness grader) | `stats` (+26), `present`, `types` |
| Miner | `fingerprint`, `baseline`, `detect` |
| OAST | `engine` (crypto `<=16`/CTR, rsa error paths, presets roster), `present`, `session` |
| Passive probe rules | `dom_xss`, `prototype_pollution` |
| Query language | `probe_query` (pins the 2 documented divergences from `Issues::Filter`) |
| Helpers | `links`, `repeater/diff`, `discover/{url,extract,types}`, `ascii_bytes`, `tui/{keybind,url,geometry,layout,search_hi}` |

## 🐞 Source bugs surfaced (documented, NOT enshrined — suite stays green)

1. **`src/gori/form_data.cr`** — a browser's empty `filename=""` (file input, nothing selected) is mis-classified as a file part (empty match is truthy) → junk `file:  (0 bytes)` note. Parked `pending` in `spec/form_data_spec.cr`.
2. **`src/gori/discover/url.cr` `resolve`** — the absolute-scheme prefix check is case-sensitive, so `HTTP://host/p` is dropped (`nil`) despite RFC 3986 case-insensitive schemes → lost crawl links. Parked `pending` in `spec/discover/url_spec.cr`.
3. **`src/gori/tui/search_hi.cr`** — the mark loop is O(line²) on token-dense lines (`String#index(q, pos)` re-walks `pos` chars) despite the O(line) doc comment. Functionally correct; recorded as a comment finding.

## Notes

- Branched off latest `main` (`48fdf56`); confirmed none of the 26 target source files changed on main.
- Full suite: **3229 examples, 0 failures, 0 errors, 2 pending**. `crystal tool format --check` + ameba clean on all touched files.
- `ameba --fix` incidentally tidied a few pre-existing lint lines in `spec/oast/engine_spec.cr`, including a **whitespace-only reindent of the PEM fixture heredoc** (`<<-PEM` strips the indent, so the value is unchanged — the RSA-OAEP fixture-decrypt test passes).
- Deferred (need a new sequenced-HTTP fake): OAST provider tests (boast/webhook.site/postbin, interactsh CTR fallback).
