### PR TITLE
feat(cli): accept -V as a version flag alias

### DIFF
--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -24,7 +24,7 @@ module Gori
   module CLI
     def self.run(argv : Array(String) = ARGV) : Nil
       # Global version (works before/after any subcommand or alone)
-      if argv.any? { |a| a == "-v" || a == "--version" }
+      if argv.any? { |a| a == "-v" || a == "-V" || a == "--version" }
         puts "gori #{VERSION}"
         return
       end
@@ -105,6 +105,7 @@ module Gori
         p.on("--insecure-upstream", "Do not verify upstream TLS certificates") { insecure = true }
         p.on("-h", "--help", "Show this help") { puts p; exit 0 }
         p.on("-v", "--version", "Show version") { puts "gori #{VERSION}"; exit 0 }
+        p.on("-V", "Show version") { puts "gori #{VERSION}"; exit 0 }
         p.invalid_option { |flag| abort "unknown option: #{flag}\n#{p}" }
         p.missing_option { |flag| abort "missing value for #{flag}" }
       end


### PR DESCRIPTION
## Summary

Add `-V` (uppercase) as an alias for the version flag. Many CLI users expect uppercase `-V` to print the version, so this accepts it alongside the existing `-v` / `--version`.

- Top-level global check (`gori -V`, works before/after any subcommand)
- `tui` subcommand parser (`gori tui -V`), also surfaced in `gori tui --help`

## Test

Built via `crystal build src/main.cr` and verified:

| Command | Output |
|---|---|
| `gori -V` / `gori -v` / `gori --version` | `gori 0.1.2` |
| `gori tui -V` / `tui -v` / `tui --version` | `gori 0.1.2` |