### PR TITLE
fix: 10 confirmed bugs from a build-and-dogfood pass

### DIFF
--- a/docs/tools/tui-capture/capture.sh
+++ b/docs/tools/tui-capture/capture.sh
@@ -117,9 +117,10 @@ PY
 }
 
 # run_scene <name> <rows> <title> <tmux-keys...> — the full TUI over the seeded DB.
+# `--db` opens it directly (no project-picker preamble needed).
 run_scene() {
   local name="$1" rows="$2" title="$3"; shift 3
-  _shoot "$name" "$rows" "$title" "tui --port $PORT --db '$DB'" 1 "$@"
+  _shoot "$name" "$rows" "$title" "tui --port $PORT --db '$DB'" 0 "$@"
 }
 
 # run_tour <name> <rows> <title> <tmux-keys...> — `gori tutorial` (no picker).

--- a/spec/discover/engine_spec.cr
+++ b/spec/discover/engine_spec.cr
@@ -176,18 +176,45 @@ describe Gori::Discover::Engine do
     cfg = D::Config.new(spider: true, bruteforce: false, max_depth: 5, concurrency: 1, retries: 0)
     findings, _ = run_discover("http://t/", %w(), cfg) do |t|
       case t
-      when "/"           then html("home, no links")
-      when "/robots.txt" then make(200, "User-agent: *\nSitemap: http://t/custom/sm.xml\n", "text/plain")
+      when "/"            then html("home, no links")
+      when "/robots.txt"  then make(200, "User-agent: *\nSitemap: http://t/custom/sm.xml\n", "text/plain")
       when "/sitemap.xml" then notfound # the well-known path is absent; only robots knows the real one
       when "/custom/sm.xml"
         make(200, %(<?xml version="1.0"?><urlset><url><loc>http://t/only-in-sitemap</loc></url></urlset>), "application/xml")
       when "/only-in-sitemap" then html("the page only the sitemap knew about")
-      else                    notfound
+      else                         notfound
       end
     end
     # Under source-label parsing the custom sitemap was parsed as robots (no <loc>s) and this
     # URL was lost; content-aware parsing recovers it.
     findings.map(&.url).should contain("http://t/only-in-sitemap")
+  end
+
+  it "calibrates robots.txt/sitemap.xml against the origin's soft-404 baseline (no FP on a wildcard-200 server)" do
+    cfg = D::Config.new(spider: true, bruteforce: true, calibrate_probes: 3, concurrency: 2, retries: 0)
+    findings, stats = run_discover("http://t/", ["admin", "secret"], cfg) do |_t|
+      html("THE SAME SOFT-404 PAGE FOR EVERY SINGLE PATH ON THIS SERVER")
+    end
+    # robots.txt/sitemap.xml are guessed well-known paths, exactly like a brute-forced wordlist
+    # entry — a server that 200s everything must not get to report them as "findings".
+    findings.select { |f| f.source.robots? || f.source.sitemap? }.should be_empty
+    findings.select(&.source.bruteforced?).should be_empty
+    stats.calibrated_out.should be > 0
+  end
+
+  it "still records a genuine robots.txt/sitemap.xml on a server with a real 404 baseline" do
+    cfg = D::Config.new(spider: true, bruteforce: true, calibrate_probes: 2, concurrency: 2, retries: 0)
+    findings, _ = run_discover("http://t/", %w(), cfg) do |t|
+      case t
+      when "/robots.txt"  then make(200, "User-agent: *\nDisallow: /admin\n", "text/plain")
+      when "/sitemap.xml" then make(200, %(<?xml version="1.0"?><urlset><url><loc>http://t/x</loc></url></urlset>), "application/xml")
+      when "/"            then html("home")
+      else                     notfound
+      end
+    end
+    urls = findings.map(&.url)
+    urls.should contain("http://t/robots.txt")
+    urls.should contain("http://t/sitemap.xml")
   end
 
   it "confines a path-scoped run to the seed subtree" do

--- a/spec/issues_export_spec.cr
+++ b/spec/issues_export_spec.cr
@@ -1,5 +1,12 @@
 require "./spec_helper"
+require "compress/gzip"
 require "../src/gori/issues_export"
+
+private def gzip(data : String) : Bytes
+  io = IO::Memory.new
+  Compress::Gzip::Writer.open(io) { |w| w.print(data) }
+  io.to_slice
+end
 
 private def with_store(&)
   path = File.tempname("gori-fexport", ".db")
@@ -118,6 +125,45 @@ describe Gori::Issues::Export do
         md = Gori::Issues::Export.markdown(store.issues, store, "proj")
         md.should_not contain("binary body omitted")
         md.should contain("body truncated")
+      end
+    end
+
+    it "decodes a gzip Content-Encoding body instead of dropping it as binary" do
+      with_store do |store|
+        id = store.insert_flow(Gori::Store::CapturedRequest.new(
+          created_at: 1_i64, scheme: "http", host: "h.test", port: 80,
+          method: "GET", target: "/", http_version: "HTTP/1.1",
+          head: "GET / HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice, body: nil))
+        store.update_response(Gori::Store::CapturedResponse.new(
+          flow_id: id, status: 200,
+          head: "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\n\r\n".to_slice,
+          body: gzip("gzip-body-marker-XYZ123"), reason: "OK", content_type: "application/json", duration_us: 1_i64))
+        store.insert_issue("gzip evidence", Gori::Store::Severity::Low, "h.test", id)
+
+        md = Gori::Issues::Export.markdown(store.issues, store, "proj")
+        md.should contain("gzip-body-marker-XYZ123")
+        md.should_not contain("binary body omitted")
+      end
+    end
+
+    it "de-chunks a Transfer-Encoding: chunked body instead of embedding wire framing" do
+      with_store do |store|
+        id = store.insert_flow(Gori::Store::CapturedRequest.new(
+          created_at: 1_i64, scheme: "http", host: "h.test", port: 80,
+          method: "GET", target: "/", http_version: "HTTP/1.1",
+          head: "GET / HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice, body: nil))
+        # "5\r\nhello\r\n0\r\n\r\n" — a single 5-byte chunk, then the terminator.
+        chunked = "5\r\nhello\r\n0\r\n\r\n".to_slice
+        store.update_response(Gori::Store::CapturedResponse.new(
+          flow_id: id, status: 200,
+          head: "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n".to_slice,
+          body: chunked, reason: "OK", content_type: "text/plain", duration_us: 1_i64))
+        store.insert_issue("chunked evidence", Gori::Store::Severity::Low, "h.test", id)
+
+        md = Gori::Issues::Export.markdown(store.issues, store, "proj")
+        md.should contain("\nhello\n") # the decoded body, on its own line inside the fence
+        md.should_not contain("5\r\nhello")
+        md.should_not contain("0\r\n\r\n")
       end
     end
 

--- a/spec/miner/inject_spec.cr
+++ b/spec/miner/inject_spec.cr
@@ -49,6 +49,23 @@ describe Gori::Miner::Inject do
     t.should contain("Content-Length: 7")
   end
 
+  # Regression for a CLI-only bug: `--locations=form` forced onto a request with no existing
+  # urlencoded-form body used to splice a bare body on with no Content-Length AND no
+  # Content-Type header at all — a framing-broken request the tool reported as "0 errors".
+  # inject_form must be a no-op (like inject_multipart/inject_json already are) when Form
+  # isn't applicable, matching Detect's own applicability test.
+  it "does not inject into a bodyless request (no framing-broken body)" do
+    base = "GET /a HTTP/1.1\r\nHost: h\r\n\r\n"
+    res = M::Inject.apply(req(base), M::Location::Form, [{"p", "v"}], add_cl_when_missing: false)
+    text(res).should eq(base)
+  end
+
+  it "does not inject form params into a body whose Content-Type isn't urlencoded" do
+    base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\nContent-Length: 7\r\n\r\n{\"a\":1}"
+    res = M::Inject.apply(req(base), M::Location::Form, [{"p", "v"}], add_cl_when_missing: false)
+    text(res).should eq(base)
+  end
+
   it "merges keys into a JSON object body" do
     base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\nContent-Length: 7\r\n\r\n{\"a\":1}"
     res = M::Inject.apply(req(base), M::Location::Json, [{"p", "v"}])

--- a/spec/proxy/codec/http1_spec.cr
+++ b/spec/proxy/codec/http1_spec.cr
@@ -45,6 +45,42 @@ describe Gori::Proxy::Codec::Http1 do
       req.malformed?.should be_true
       req.raw_head.should eq(raw) # truth preserved regardless
     end
+
+    it "flags the RFC 7540 h2 client preface as malformed despite its well-formed 3-token shape" do
+      # "PRI * HTTP/2.0" splits into exactly 3 tokens like a normal request-line, so the
+      # generic `parts.size != 3` rule alone would accept it. This is the exact literal an
+      # h2/gRPC client sends first — forced onto this HTTP/1.1 parser by the deliberate
+      # ALPN downgrade while Intercept/Sandbox/Match&Replace is active (Tunnel#intercept) —
+      # and must be recognized so the caller can reject the connection instead of treating
+      # it as a real "PRI *" request.
+      raw = bytes("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
+      req = Http1.parse_request_head(raw)
+
+      req.method.should eq("PRI")
+      req.target.should eq("*")
+      req.version.should eq("HTTP/2.0")
+      req.malformed?.should be_true
+      Http1.h2_preface?(req).should be_true
+    end
+
+    it "does not flag an ordinary request as the h2 preface" do
+      raw = bytes("GET / HTTP/2.0\r\nHost: a\r\n\r\n")
+      req = Http1.parse_request_head(raw)
+
+      req.malformed?.should be_false
+      Http1.h2_preface?(req).should be_false
+    end
+  end
+
+  describe ".parse_request_line" do
+    it "mirrors parse_request_head's malformed verdict for the h2 preface" do
+      raw = bytes("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
+      method, target, malformed = Http1.parse_request_line(raw)
+
+      method.should eq("PRI")
+      target.should eq("*")
+      malformed.should be_true
+    end
   end
 
   describe ".parse_response_head" do

--- a/spec/proxy/server_spec.cr
+++ b/spec/proxy/server_spec.cr
@@ -904,6 +904,45 @@ describe Gori::Proxy::Server do
     got.receive.should eq("3:SMU")
   end
 
+  it "rejects a garbage h2 client preface instead of queueing it in Intercept forever" do
+    # RFC 7540 §3.4's client preface start-line ("PRI * HTTP/2.0") happens to be a
+    # well-formed-SHAPE HTTP/1.1 request-line. When ALPN doesn't negotiate h2 (the
+    # deliberate Tunnel#intercept downgrade while catch mode is on), the h2/gRPC client's
+    # preface bytes land on this HTTP/1.1 path and — without the fix — would sail into the
+    # Intercept hold queue as a confusing fake "PRI *" request with no way out. It must
+    # instead be rejected cleanly: recorded as an error flow, connection closed, never held.
+    done = Channel(Nil).new(1)
+    store_path = File.tempname("gori-icp-h2", ".db")
+    store = Gori::Store.open(store_path)
+    interceptor = Gori::Interceptor.new(Gori::Scope.load(store))
+    interceptor.toggle # enable catch mode
+
+    sink = RecordingSink.new(done)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink, interceptor: interceptor)
+    proxy.start
+
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    client << "PRI * HTTP/2.0\r\n\r\n"
+    client.flush
+
+    done.receive # record_error's on_response fires — the connection was rejected, not held
+    # The proxy must not have written an HTTP/1.1 response back (a real h2/gRPC client can't
+    # parse one) — it just closes. Confirms the client sees a clean EOF, not a hang.
+    client.gets_to_end.should eq("")
+    client.close
+
+    interceptor.pending.should be_empty # never reached the hold queue
+    proxy.stop
+    store.close
+    File.delete?(store_path)
+    File.delete?("#{store_path}-wal")
+    File.delete?("#{store_path}-shm")
+
+    sink.requests.last.method.should eq("PRI")
+    sink.responses.last.state.error?.should be_true
+    sink.responses.last.error.try(&.includes?("h2/gRPC")).should be_true
+  end
+
   it "sandbox blocks an out-of-scope request before it reaches upstream (403 + recorded abort)" do
     done = Channel(Nil).new(1)
     store_path = File.tempname("gori-sbx", ".db")

--- a/spec/proxy/ws_spec.cr
+++ b/spec/proxy/ws_spec.cr
@@ -279,6 +279,52 @@ describe Gori::Proxy::WS do
       sink.messages.should contain({"in", 1, "abc"})
       sink.messages.any? { |(_, _, s)| s.includes?("too large to capture") }.should be_true
     end
+
+    it "waits for the peer's replying CLOSE frame instead of tearing the tunnel down the instant one side forwards one (RFC 6455 closing handshake)" do
+      cs_r, cs_w = IO.pipe # client → server
+      ts_r, ts_w = IO.pipe # relay → server
+      ss_r, ss_w = IO.pipe # server → client
+      tc_r, tc_w = IO.pipe # relay → client
+      # sync_close: true so `run`'s internal `client.close`/`upstream.close` propagate to the
+      # real underlying pipe fds (as they do for the real sockets `run` is normally handed) —
+      # without it, the OLD code's early close only flips IO::Stapled's own closed flag and
+      # this spec hangs (tc_r never sees EOF) instead of failing fast.
+      client = IO::Stapled.new(cs_r, tc_w, sync_close: true)
+      upstream = IO::Stapled.new(ss_r, ts_w, sync_close: true)
+
+      client_close = Gori::Proxy::WS.encode(Gori::Proxy::WS::OP_CLOSE, "bye".to_slice, mask: true)
+      server_close = Gori::Proxy::WS.encode(Gori::Proxy::WS::OP_CLOSE, "bye".to_slice, mask: false)
+
+      # The client sends its CLOSE and has nothing more to say — like a real client, it
+      # doesn't hold the connection open waiting on its own reply.
+      cs_w.write(client_close)
+      cs_w.close
+
+      # Stands in for the real peer: reads the forwarded CLOSE, then deliberately waits a
+      # beat (standing in for the real network round trip a genuine reply needs) before
+      # replying. Without the fix, `run` tears down BOTH sockets the instant the
+      # client→upstream pump forwards the CLOSE and returns — a near-instant local op, long
+      # before this reply is sent — dropping it exactly like the real bug (client saw "EOF
+      # while reading 2, got 0" instead of the peer's closing-handshake reply).
+      spawn do
+        got = Bytes.new(client_close.size)
+        ts_r.read_fully(got)
+        sleep 0.05.seconds
+        ss_w.write(server_close)
+        ss_w.close
+      rescue
+        # broken pipe: the old bug already closed our write end before we got here
+      end
+
+      sink = WsSink.new
+      Gori::Proxy::WS::Relay.run(client, upstream, 13_i64, sink)
+
+      # read_fully raises on short read/EOF — the old, buggy behavior (reply dropped, tc_r
+      # closes with 0 bytes available).
+      forwarded_reply = Bytes.new(server_close.size)
+      tc_r.read_fully(forwarded_reply)
+      forwarded_reply.should eq(server_close)
+    end
   end
 end
 

--- a/spec/rules_spec.cr
+++ b/spec/rules_spec.cr
@@ -166,6 +166,36 @@ describe Gori::Rules do
     end
   end
 
+  it "reload picks up an external edit on the SAME live instance (TUI 'r' key / headless capture's periodic reload)" do
+    with_store do |store|
+      # `live` stands in for the Rules object a Session hands to the proxy pipeline —
+      # held for a while, never re-`load`ed. `editor` stands in for a separate `gori run
+      # rewriter add` process (or the TUI's own editor) writing to the SAME store.
+      live = Gori::Rules.load(store)
+      live.active?.should be_false
+
+      editor = Gori::Rules.load(store)
+      editor.add(Gori::Store::RuleTarget::Response, Gori::Store::RulePart::Head, "Server: nginx", "Server: gori")
+
+      resp = "HTTP/1.1 200 OK\r\nServer: nginx\r\n\r\n".to_slice
+      # the external add is invisible to `live` until it reloads
+      live.active?.should be_false
+      live.rewrite_response(resp, "").should eq(resp)
+
+      live.reload
+      live.active?.should be_true
+      String.new(live.rewrite_response(resp, "")).should contain("Server: gori")
+
+      # disabling externally is picked up the same way
+      id = live.rules.first.id
+      editor.toggle(id)
+      live.active?.should be_true # still stale
+      live.reload
+      live.active?.should be_false
+      live.rewrite_response(resp, "").should eq(resp)
+    end
+  end
+
   it "transforms a full HTTP message for the live preview (head + body seams)" do
     with_store do |store|
       rules = Gori::Rules.load(store)

--- a/spec/sequencer/engine_spec.cr
+++ b/spec/sequencer/engine_spec.cr
@@ -4,15 +4,21 @@ private alias Q = Gori::Sequencer
 private alias F = Gori::Fuzz
 
 # A backend that issues an incrementing session cookie each send (a sequential-token
-# server) so a collection over it is both extractable and detectably weak.
+# server) so a collection over it is both extractable and detectably weak. `latency`
+# simulates real network round-trip time with a `sleep` — a fiber yield point that lets
+# the dispatcher fiber race ahead of completions, exactly like a real socket read would.
+# A near-instantaneous fake backend (the old default here) never yields between dispatch
+# and completion often enough to expose that race, which is why this spec didn't catch
+# the live-collection overshoot bug (see engine.cr's dispatch loop comment).
 private class CounterCookieBackend < F::Backend
   getter origin : F::Origin
   getter sent : Int32 = 0
 
-  def initialize(@origin : F::Origin, @start : Int32 = 1000)
+  def initialize(@origin : F::Origin, @start : Int32 = 1000, @latency : Time::Span = 2.milliseconds)
   end
 
   def send(bytes : Bytes) : Gori::Repeater::Result
+    sleep @latency
     n = @start + @sent
     @sent += 1
     head = "HTTP/1.1 200 OK\r\nSet-Cookie: SID=#{n}; Path=/\r\nContent-Length: 2\r\n\r\n"
@@ -28,19 +34,34 @@ private def drain(engine : Q::Engine) : Array(Q::Sample)
 end
 
 describe Gori::Sequencer::Engine do
-  it "collects the goal count of tokens in live-replay mode" do
+  it "collects exactly the goal count of tokens in live-replay mode, no overshoot" do
     backend = CounterCookieBackend.new(F::Origin.new("http", "h", 80))
     config = Q::Config.new(mode: Q::Mode::LiveReplay,
       token_loc: Q::TokenLoc.cookie("SID"), goal: 25, concurrency: 1, retries: 0)
     req = "GET /login HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
     samples = drain(Q::Engine.new(req, http2: false, backend: backend, config: config))
 
-    # The goal is counted by successful extractions; the pipeline may overshoot by up
-    # to `concurrency` (the dispatcher races one job ahead of the collected counter).
-    samples.size.should be >= 25
-    samples.size.should be <= 25 + config.concurrency
+    # The dispatch loop stops handing out jobs once enough are already IN FLIGHT to
+    # reach the goal (not only once they've fully round-tripped), so — with a backend
+    # that never misses extraction — the count lands EXACTLY on the goal. This backend
+    # has non-zero `latency` (a real `sleep`, i.e. a fiber yield point) specifically so
+    # this spec exercises the same dispatcher/worker race that only manifested against
+    # real network latency; a near-instant fake backend does not reliably yield between
+    # dispatch and completion and would let a regression here slip back in unnoticed.
+    samples.size.should eq(25)
     samples.all? { |s| s.token }.should be_true
     Q::Stats.analyze(samples.compact_map(&.token)).sequential.should be_true
+  end
+
+  it "collects exactly the goal count at concurrency > 1, no overshoot" do
+    backend = CounterCookieBackend.new(F::Origin.new("http", "h", 80))
+    config = Q::Config.new(mode: Q::Mode::LiveReplay,
+      token_loc: Q::TokenLoc.cookie("SID"), goal: 40, concurrency: 5, retries: 0)
+    req = "GET /login HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+    samples = drain(Q::Engine.new(req, http2: false, backend: backend, config: config))
+
+    samples.size.should eq(40)
+    samples.all? { |s| s.token }.should be_true
   end
 
   it "terminates via the max-sends cap when the descriptor never matches" do
@@ -51,7 +72,7 @@ describe Gori::Sequencer::Engine do
     samples = drain(Q::Engine.new(req, http2: false, backend: backend, config: config))
 
     samples.none?(&.token).should be_true
-    backend.sent.should be <= config.max_sends # goal never met → stops at the cap (goal*2)
+    backend.sent.should eq(config.max_sends) # goal never met → stops exactly at the cap (goal*2)
   end
 
   it "emits pasted tokens in manual mode without touching the network" do
@@ -71,6 +92,6 @@ describe Gori::Sequencer::Engine do
     Q::Engine.new(req, http2: false, backend: backend, config: config).run do |ev|
       done = ev if ev.is_a?(Q::DoneEvent)
     end
-    done.not_nil!.collected.should be >= 10 # ≥ goal (may overshoot by ≤ concurrency)
+    done.not_nil!.collected.should eq(10) # lands exactly on the goal, no overshoot
   end
 end

--- a/src/gori/app.cr
+++ b/src/gori/app.cr
@@ -36,6 +36,14 @@ module Gori
     getter ca : Proxy::Tls::CertAuthority
     getter registry : Verb::Registry
 
+    # How often headless `gori run capture` re-reads Rewriter rules from the store, so
+    # `gori run rewriter add/rm/enable/disable` against the SAME running project take
+    # effect without a restart (docs/content/guide/proxy.md promises "no restart"). The
+    # TUI gets this on demand via the `r` key (Rewriter::rewriter_reload); headless has no
+    # keyboard to press, so it polls instead. A couple of seconds keeps external edits
+    # feeling live without hammering the store — matching the OAST poller's interval scale.
+    REWRITER_RELOAD_INTERVAL = 2.seconds
+
     def initialize(@config : Config)
       Paths.ensure_dirs
       @ca = Proxy::Tls::CertAuthority.load_or_create(@config.ca_dir)
@@ -45,7 +53,12 @@ module Gori
 
     # Interactive TUI: pick a project, run its shell, return to the picker on
     # `q`, exit on quit. Logs go to a file (never STDOUT — that's the screen).
-    def run_tui : Nil
+    #
+    # `open_db_path`, when given (CLI `--db=PATH`), opens that database directly —
+    # skipping the picker — before ever showing it; `q` from that session still
+    # falls through to the normal picker below, so navigating elsewhere afterward
+    # still works.
+    def run_tui(open_db_path : String? = nil) : Nil
       setup_logging(File.open(File.join(Paths.home_dir, "gori.log"), "a"))
       Tui::Theme.load_custom           # register user themes from <GORI_HOME>/themes/*.json
       Tui::Theme.apply(Settings.theme) # honour the persisted theme from the first frame (picker included)
@@ -66,6 +79,9 @@ module Gori
         # the terminal if it raises. The wizard persists settings.json (even on skip),
         # so it never auto-launches again.
         Tui::SetupWizard.new(term).run unless File.exists?(Settings.path)
+        if open_db_path
+          return if open_and_run(project_for_db_path(open_db_path), term) == :quit
+        end
         loop do
           project = Tui::ProjectPicker.new(term, projects).run
           break unless project # nil => quit gori
@@ -74,6 +90,18 @@ module Gori
       ensure
         term.close # restore the terminal even on error
       end
+    end
+
+    # Wraps an explicit `--db` path as a one-off Project, bypassing the registry
+    # entirely. Never ephemeral — Project#cleanup deletes ephemeral projects' dirs
+    # on close, which must never happen to a file the user pointed us at directly.
+    # Named after the containing directory for the conventional `gori.db` filename
+    # (mirrors how registry projects are named after their dir), else after the
+    # file's own basename.
+    private def project_for_db_path(db_path : String) : Project
+      base = File.basename(db_path)
+      name = base == Project::DB_FILE ? File.basename(File.dirname(db_path)) : File.basename(db_path, File.extname(db_path))
+      Project.new(name.presence || db_path, db_path)
     end
 
     # Non-interactive capture into `project`. Binds the proxy (fatal on failure, as
@@ -98,6 +126,7 @@ module Gori
       end
       print_banner(session)
       spawn { capture_printer(session, format, max) }
+      reload_stop = spawn_rewriter_reload_loop(session)
       install_signal_traps
       if span = every
         # Wall-clock terminator: nudge the same shutdown channel the signal traps use.
@@ -107,6 +136,10 @@ module Gori
         end
       end
       @shutdown.receive
+      # Unbuffered: this rendezvous only completes once the reload fiber is parked back
+      # at `select` (never mid-reload), so by the time it returns the fiber is guaranteed
+      # to make no further store calls — safe to close the store right after.
+      reload_stop.send(nil) rescue nil
       session.close
     end
 
@@ -173,6 +206,33 @@ module Gori
       # so there's nothing left to stream — wind the session down gracefully
       # instead of letting the unhandled error take down the whole process.
       @shutdown.send(nil) rescue nil
+    end
+
+    # Periodically re-reads Rewriter rules from the store for the lifetime of a headless
+    # capture session — same effect as the TUI's manual `r` key
+    # (Rules#reload / rewriter_controller#rewriter_reload), just on a timer instead of a
+    # keypress. Returns an unbuffered stop channel: sending to it blocks until the loop is
+    # parked back at `select` (i.e. not mid-reload), so the caller can safely close the
+    # session right after — no fiber left querying a closed store handle.
+    private def spawn_rewriter_reload_loop(session : Session) : Channel(Nil)
+      stop = Channel(Nil).new
+      spawn(name: "gori-capture-rewriter-reload") do
+        loop do
+          select
+          when stop.receive
+            break
+          when timeout(REWRITER_RELOAD_INTERVAL)
+            begin
+              session.rules.reload
+            rescue ex
+              # A transient store hiccup must not kill the reload loop for the rest of
+              # the capture session — log and try again next tick.
+              Log.error(exception: ex) { "rewriter rule reload failed" }
+            end
+          end
+        end
+      end
+      stop
     end
 
     private def print_banner(session : Session) : Nil

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -89,6 +89,7 @@ module Gori
       listen = Settings.bind_host
       port = Settings.bind_port
       db_path = Paths.default_db
+      db_explicit = false
       ca_dir = Paths.default_ca_dir
       insecure = false
 
@@ -100,7 +101,7 @@ module Gori
           abort "gori: invalid --port '#{v}' (expected 0-65535)" unless parsed && 0 <= parsed <= 65535
           port = parsed
         end
-        p.on("--db=PATH", "SQLite database path") { |v| db_path = v }
+        p.on("--db=PATH", "SQLite database path (opens it directly, skipping the project picker)") { |v| db_path = v; db_explicit = true }
         p.on("--ca-dir=PATH", "Directory for the root CA") { |v| ca_dir = v }
         p.on("--insecure-upstream", "Do not verify upstream TLS certificates") { insecure = true }
         p.on("-h", "--help", "Show this help") { puts p; exit 0 }
@@ -121,7 +122,7 @@ module Gori
       # reflects the active state; toggling it there re-syncs the live proxy + persists.
       Settings.verify_upstream = false if insecure
       config = Config.new(listen, port, db_path, ca_dir, !Settings.verify_upstream?)
-      App.new(config).run_tui
+      App.new(config).run_tui(open_db_path: db_explicit ? db_path : nil)
     end
 
     # `gori settings` prints the path to the persisted settings file (settings.json

--- a/src/gori/cli/run/discover.cr
+++ b/src/gori/cli/run/discover.cr
@@ -137,6 +137,7 @@ module Gori
         pending = [] of {Store::CapturedRequest, Store::CapturedResponse?}
         base_ts = Time.utc.to_unix * 1_000_000
         had_error = false
+        interrupted = install_discover_interrupt_trap(engine)
         engine.run do |ev|
           case ev
           when Discover::FindingEvent
@@ -154,10 +155,44 @@ module Gori
           end
         end
         # Flush after the loop (not in the Done branch): an error terminates with an ErrorEvent
-        # and no DoneEvent, but findings discovered before it should still reach the Sitemap.
+        # and no DoneEvent, but findings discovered before it should still reach the Sitemap. A
+        # SIGINT/SIGTERM lands here too (see the trap above) since Engine#stop makes the run end
+        # like any other — so this one flush covers the normal, error, AND interrupted paths.
         flush_discover(store, pending) unless no_store
+        report_discover_interrupt(findings, no_store) if interrupted.call
         puts CLI::Output.discover_array_json(findings) if format == :json
         exit 1 if had_error
+      end
+
+      private def self.report_discover_interrupt(findings : Array(Discover::Finding), no_store : Bool) : Nil
+        verb = no_store ? "collected" : "saved"
+        plural = findings.size == 1 ? "" : "s"
+        STDERR.puts "interrupted — #{findings.size} finding#{plural} #{verb}"
+      end
+
+      # A raw SIGINT/SIGTERM used to just kill the process here: `pending` (and everything
+      # printed to the terminal since the last 200-item flush) was garbage-collected with it,
+      # and the DB never saw a row. The trap itself does the minimal/safe thing only — a
+      # buffered channel send, matching Gori::App#install_signal_traps — and hands the actual
+      # stop off to a fiber. Engine#stop makes the orchestrator drain in-flight work and close
+      # @events exactly like a normal finish, so the caller's `engine.run` returns on its own
+      # and the SAME flush every other exit path already uses covers "interrupted mid-run" too,
+      # instead of needing a separate DB write in the trap or the watcher fiber. The returned
+      # proc reads the `interrupted` local the watcher fiber sets — same shared-closure trick,
+      # just returned instead of read further down the SAME method, to keep run_discover_stream
+      # itself simple enough for the complexity linter.
+      private def self.install_discover_interrupt_trap(engine : Discover::Engine) : -> Bool
+        interrupted = false
+        shutdown = Channel(Nil).new(1)
+        Signal::INT.trap { shutdown.send(nil) rescue nil }
+        Signal::TERM.trap { shutdown.send(nil) rescue nil }
+        spawn(name: "discover-interrupt") do
+          shutdown.receive
+          interrupted = true
+          STDERR.puts "\ninterrupted — stopping and flushing findings…"
+          engine.stop
+        end
+        -> { interrupted }
       end
 
       private def self.flush_discover(store : Store,

--- a/src/gori/cli/run/mine.cr
+++ b/src/gori/cli/run/mine.cr
@@ -58,8 +58,14 @@ module Gori
         http2 = force_h2 || src_h2
 
         config = Miner::Config.new
-        config.locations = locations.empty? ? Miner::Detect.detect(bytes).default : locations
+        detected = Miner::Detect.detect(bytes)
+        config.locations = locations.empty? ? detected.default : locations
         abort "gori run mine: no applicable locations for this request" if config.locations.empty?
+        unless locations.empty?
+          (config.locations - detected.applicable).each do |loc|
+            STDERR.puts "gori run mine: #{loc.label}: not applicable to this request (no matching existing body), skipping"
+          end
+        end
         config.concurrency = concurrency
         config.rps = rate
         config.throttle_ms = throttle

--- a/src/gori/cli/run/oast.cr
+++ b/src/gori/cli/run/oast.cr
@@ -48,7 +48,7 @@ module Gori
           p.on("--interval=SEC", "Poll interval seconds (default 5)") { |v| interval = parse_count(v, "--interval") }
           p.on("--once", "Poll once and exit (no loop)") { once = true }
           p.on("--json", "Emit each callback as a JSON line (same shape as MCP)") { json = true }
-          p.on("-h", "--help") { puts p; exit 0 }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
         end
         parser.parse(args)
 

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -104,7 +104,11 @@ module Gori::Discover
     depth : Int32,
     source : Source,
     dir : String? = nil,
-    baseline : Calibrate::DirBaseline? = nil
+    baseline : Calibrate::DirBaseline? = nil,
+    # A Calibrate task queued ONLY to gate robots.txt/sitemap.xml against a soft-404
+    # baseline (see enqueue_seed_only_calibration) — never feeds enqueue_probes, so it
+    # can't expand the brute-force wordlist onto a directory outside the run's own scope.
+    seed_only : Bool = false
 
   private record RawLink, href : String, source : Source
 
@@ -122,8 +126,8 @@ module Gori::Discover
   # with zero locks; N worker fibers only do network I/O + CPU (decode/extract/fingerprint)
   # and feed Outcomes back over a channel. Mirrors the Fuzz/Miner lifecycle shape.
   class Engine
-    EVENT_BUFFER    =  256
-    MAX_CONCURRENCY =  500
+    EVENT_BUFFER    = 256
+    MAX_CONCURRENCY = 500
     MAX_BODY        = 2 * 1024 * 1024 # decoded body cap (matches Extract::MAX_SCAN)
 
     enum State : UInt8
@@ -165,6 +169,9 @@ module Gori::Discover
     @conf_hist : Array(Int32)
     @last_dispatch : Time::Instant
     @phase : Phase
+    @seed_calibration_dir : String?
+    @seed_baseline : Calibrate::DirBaseline?
+    @pending_seed_fetches : Array({Task, Calibrate::Fetched})
 
     def initialize(seed_url : String, @words : Array(String), backend : Backend,
                    @config : Config, @scope : ScopePolicy = OpenScope.new)
@@ -201,6 +208,9 @@ module Gori::Discover
       @conf_hist = [0, 0, 0, 0]
       @last_dispatch = Time.instant
       @phase = Phase::Seeding
+      @seed_calibration_dir = nil
+      @seed_baseline = nil
+      @pending_seed_fetches = [] of {Task, Calibrate::Fetched}
     end
 
     def start : Nil
@@ -301,13 +311,38 @@ module Gori::Discover
         @frontier << Task.new(TaskKind::Fetch, "#{root}/robots.txt", 0, Source::Robots)
         @frontier << Task.new(TaskKind::Fetch, "#{root}/sitemap.xml", 0, Source::Sitemap)
       end
-      enqueue_dir(Url.dir_of(@seed_parts), 0) if @config.bruteforce?
+      bf_dir = Url.dir_of(@seed_parts)
+      enqueue_dir(bf_dir, 0) if @config.bruteforce?
+      # robots.txt/sitemap.xml are GUESSED well-known paths, not organically-linked ones — they
+      # deserve the same soft-404 gate a brute-forced wordlist hit gets, not the "exists by
+      # construction" trust record_page gives a crawled <a href>. Only wire this up when
+      # bruteforce is on: that's the only mode with a calibration baseline to gate against.
+      # Reuse the dir bf_dir just calibrated above when it IS the seed's own dir; otherwise
+      # calibrate the origin separately — robots.txt/sitemap.xml always live there even on a
+      # path-scoped run confined elsewhere.
+      if @config.spider? && @config.bruteforce?
+        root_dir = "#{Url.origin(@seed_parts)}/"
+        @seed_calibration_dir = root_dir
+        enqueue_seed_only_calibration(root_dir) unless root_dir == bf_dir
+      end
+    end
+
+    # A Calibrate task queued ONLY to gate robots.txt/sitemap.xml (see seed_frontier) — unlike
+    # enqueue_dir it never feeds enqueue_probes, so it can't brute-force the wordlist onto the
+    # origin on a run confined to a deeper subtree. Bypasses bounded_url/scope the same way the
+    # robots/sitemap Fetch tasks themselves already do (well-known paths are always checked at
+    # the origin, confine/scope notwithstanding).
+    private def enqueue_seed_only_calibration(dir : String) : Nil
+      return if @dirs.includes?(dir)
+      return unless Url.parse(dir)
+      @dirs << dir
+      @frontier << Task.new(TaskKind::Calibrate, dir, 0, Source::Bruteforced, dir: dir, seed_only: true)
     end
 
     private def handle(oc : Outcome) : Nil
       case oc.task.kind
-      in TaskKind::Calibrate         then handle_calibrate(oc)
-      in TaskKind::Probe             then handle_probe(oc)
+      in TaskKind::Calibrate              then handle_calibrate(oc)
+      in TaskKind::Probe                  then handle_probe(oc)
       in TaskKind::Crawl, TaskKind::Fetch then handle_crawl(oc)
       end
     end
@@ -321,7 +356,11 @@ module Gori::Discover
         @errors += 1
         return
       end
-      record_page(task, fetched)
+      if @seed_calibration_dir && (task.source.robots? || task.source.sitemap?)
+        resolve_seed_finding(task, fetched)
+      else
+        record_page(task, fetched)
+      end
       count = @clusters.observe(fetched.simhash, @config.simhash_distance)
       if count > @config.cluster_saturation
         @cluster_suppressed += oc.links.size # a template/listing trap — stop expanding it
@@ -345,7 +384,11 @@ module Gori::Discover
       return unless bl
       @uncalibratable += 1 if bl.kind.uncalibratable?
       @events.send(BaselineEvent.new(bl.dir, bl.kind.label, nil))
-      enqueue_probes(oc.task, bl)
+      if bl.dir == @seed_calibration_dir
+        @seed_baseline = bl
+        flush_pending_seed_fetches
+      end
+      enqueue_probes(oc.task, bl) unless oc.task.seed_only
     end
 
     private def handle_probe(oc : Outcome) : Nil
@@ -384,6 +427,39 @@ module Gori::Discover
         0.95
       else
         0.85
+      end
+    end
+
+    # robots.txt/sitemap.xml are well-known GUESSES, not links a real page pointed at — gate
+    # them through the same soft-404 baseline a brute-forced wordlist hit needs to clear,
+    # instead of record_page's raw-status trust (a wildcard-200 server would otherwise report
+    # both as "findings" even though it 200s literally everything). The baseline may not be
+    # ready yet — its Calibrate task races this Fetch task — so an early arrival buffers here
+    # until handle_calibrate delivers @seed_baseline; if the run stops before that ever
+    # happens, the buffered entry is simply never counted (fail safe: no baseline, no claim).
+    private def resolve_seed_finding(task : Task, fetched : Calibrate::Fetched) : Nil
+      if bl = @seed_baseline
+        record_seed_hit(task, fetched, bl)
+      else
+        @pending_seed_fetches << {task, fetched}
+      end
+    end
+
+    private def flush_pending_seed_fetches : Nil
+      return if @pending_seed_fetches.empty?
+      return unless bl = @seed_baseline
+      @pending_seed_fetches.each { |task, fetched| record_seed_hit(task, fetched, bl) }
+      @pending_seed_fetches.clear
+    end
+
+    # Same hit/confidence gate handle_probe applies to a brute-forced wordlist entry.
+    private def record_seed_hit(task : Task, fetched : Calibrate::Fetched, bl : Calibrate::DirBaseline) : Nil
+      hit, conf = Calibrate.hit?(bl, fetched)
+      if hit && conf >= @config.confidence_floor
+        record_finding(Finding.new(task.url, "GET", fetched.status, fetched.length, fetched.content_type,
+          task.source, task.depth, conf, nil))
+      else
+        @calibrated_out += 1
       end
     end
 

--- a/src/gori/issues_export.cr
+++ b/src/gori/issues_export.cr
@@ -1,6 +1,7 @@
 require "json"
 require "./store"
 require "./links"
+require "./proxy/codec/content_decode"
 
 module Gori
   module Issues
@@ -121,16 +122,23 @@ module Gori
           c << String.new(hslice).scrub.rstrip
           c << "\n\n[… headers truncated, #{head.size} bytes total …]" if head.size > cap
           if body && !body.empty?
+            # De-chunk + inflate Content-Encoding for display, mirroring `gori run show` and the
+            # TUI detail view — otherwise a chunked body embeds its wire-format chunk framing
+            # verbatim, and a gzip/br/deflate body (the common case for real HTTPS traffic) fails
+            # the valid-UTF-8 check below and gets dropped as "binary", silently discarding the
+            # evidence a shared report exists to preserve.
+            decoded, _ = Proxy::Codec::ContentDecode.decode(head, body)
+            display_body = decoded || body
             # Decide text-vs-binary on the readable PREFIX (≤ cap), not the whole body: a body
             # that is valid text up to the cap but has a stray byte deeper still shows its
             # readable prefix. But back the cut off to a UTF-8 codepoint boundary first, so a
             # multi-byte char split at exactly `cap` isn't misread as binary.
-            slice = body.size > cap ? trim_to_codepoint_boundary(body[0, cap]) : body
+            slice = display_body.size > cap ? trim_to_codepoint_boundary(display_body[0, cap]) : display_body
             if String.new(slice).valid_encoding?
               c << "\n\n" << String.new(slice)
-              c << "\n\n[… body truncated, #{body.size} bytes total …]" if body.size > cap
+              c << "\n\n[… body truncated, #{display_body.size} bytes total …]" if display_body.size > cap
             else
-              c << "\n\n[binary body omitted, #{body.size} bytes]"
+              c << "\n\n[binary body omitted, #{display_body.size} bytes]"
             end
           end
         end

--- a/src/gori/miner/inject.cr
+++ b/src/gori/miner/inject.cr
@@ -118,8 +118,17 @@ module Gori::Miner
 
     # ── form (application/x-www-form-urlencoded) ─────────────────────────────────────
 
+    # Applicable only when there's an existing urlencoded-form body to append params to —
+    # the same test Detect uses to decide whether Form is offered at all (see detect.cr).
+    # A bodyless (or non-form) request has no Content-Type to splice params under and no
+    # body shape to preserve, so injecting here would fabricate a framing-broken request:
+    # a body with no Content-Length and no Content-Type header at all. Bail out unmodified
+    # instead, same as inject_multipart/inject_json do when their location doesn't apply.
     private def self.inject_form(request : Bytes, params : Array({String, String})) : Bytes
       head, body, eol = split(request)
+      return request if body.empty?
+      ct = (header_value(request, "content-type") || "").downcase
+      return request unless ct.includes?("x-www-form-urlencoded")
       extra = encode_pairs(params)
       # The body is spliced through as bytes. It used to be copied into a String, then again by
       # the interpolation that joined it to `extra`, then a third time into the IO — and the

--- a/src/gori/proxy/codec/http1.cr
+++ b/src/gori/proxy/codec/http1.cr
@@ -92,11 +92,23 @@ module Gori::Proxy::Codec::Http1
     s[n - 4] == 0x0d_u8 && s[n - 3] == 0x0a_u8 && s[n - 2] == 0x0d_u8 && s[n - 1] == 0x0a_u8
   end
 
+  # The RFC 7540 §3.4 HTTP/2 client connection preface's request-line. When ALPN doesn't
+  # negotiate h2 — e.g. Gori::Interceptor/Tunnel#intercept's deliberate h2→h1 ALPN downgrade
+  # while Intercept/Sandbox/Match&Replace is active — an h2/gRPC client's preface bytes land on
+  # this HTTP/1.1 parser instead of a real HTTP/2 stack. Its request-line happens to be
+  # well-formed HTTP/1.1 SHAPE (exactly 3 space-separated tokens), so without this check it
+  # parses cleanly as an ordinary (if odd-looking) request — method "PRI", target "*" — and
+  # sails straight through: forwarded to an origin, or (Intercept catch mode) HELD forever with
+  # nothing indicating it's actually an h2 client, not an HTTP/1.1 one. This exact literal is
+  # what every RFC 7540-conformant client sends first, unambiguously — treat it as malformed so
+  # callers can reject the connection cleanly instead of accepting a fake request.
+  H2_PREFACE_LINE = "PRI * HTTP/2.0"
+
   def self.parse_request_head(raw : Bytes) : RawRequest
     first_crlf = index_crlf(raw, 0)
     start = String.new(raw[0, first_crlf || raw.size])
     parts = start.split(' ')
-    malformed = parts.size != 3
+    malformed = parts.size != 3 || start == H2_PREFACE_LINE
     RawRequest.new(
       raw_head: raw,
       method: parts[0]? || "",
@@ -107,16 +119,24 @@ module Gori::Proxy::Codec::Http1
     )
   end
 
+  # True when `req`'s start-line is EXACTLY the HTTP/2 client preface (H2_PREFACE_LINE) — the
+  # well-known, unambiguous signal that this connection is an h2/gRPC client, not HTTP/1.1, so a
+  # caller (ClientConn) can reject it outright instead of treating it as a real request.
+  def self.h2_preface?(req : RawRequest) : Bool
+    req.method == "PRI" && req.target == "*" && req.version == "HTTP/2.0"
+  end
+
   # The request start-line's {method, target, malformed} WITHOUT parsing/allocating the header
   # block. Mirrors parse_request_head's start-line parse EXACTLY (same index_crlf + String.new
-  # over the first line + split(' ') + `parts.size != 3` malformed rule), so a caller that only
-  # needs method+target (the active-probe dedup_key gate) keys byte-identically to a full parse.
-  # The dedup_key ⇔ plan equivalence spec guards against any drift from parse_request_head.
+  # over the first line + split(' ') + `parts.size != 3 || start == H2_PREFACE_LINE` malformed
+  # rule), so a caller that only needs method+target (the active-probe dedup_key gate) keys
+  # byte-identically to a full parse. The dedup_key ⇔ plan equivalence spec guards against any
+  # drift from parse_request_head.
   def self.parse_request_line(raw : Bytes) : {String, String, Bool}
     first_crlf = index_crlf(raw, 0)
     start = String.new(raw[0, first_crlf || raw.size])
     parts = start.split(' ')
-    {parts[0]? || "", parts[1]? || "", parts.size != 3}
+    {parts[0]? || "", parts[1]? || "", parts.size != 3 || start == H2_PREFACE_LINE}
   end
 
   def self.parse_response_head(raw : Bytes) : RawResponse

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -117,6 +117,21 @@ module Gori::Proxy
 
       started = Time.instant
       created_at = now_us
+
+      # A garbage h2/gRPC client preface forced onto this HTTP/1.1 path by the (intentional)
+      # ALPN downgrade — see Tunnel#intercept — must NOT be treated as a real request: left
+      # alone it parses as an ordinary-looking "PRI * HTTP/2.0" request and either gets
+      # forwarded to an origin that can't make sense of it, or (Intercept catch mode) sits in
+      # the hold queue forever as a confusing fake entry with no indication it was an h2
+      # client. Reject the connection cleanly instead. No 502 is written back: a real h2/gRPC
+      # client isn't expecting (or able to parse) an HTTP/1.1 response here, and the existing
+      # "framing rejected" precedent below also just records + closes.
+      if Codec::Http1.h2_preface?(req)
+        record_error(req, @scheme, @fixed_host || req.host? || "", @fixed_port, created_at,
+          "rejected h2/gRPC client preface on the HTTP/1.1 path (ALPN downgrade, see Tunnel#intercept)")
+        return false
+      end
+
       # A client-supplied absolute-form target with a bad/oversized port makes URI.parse
       # raise; keep the malformed attempt visible in History instead of letting it unwind
       # to run's blanket rescue (which would silently drop the flow and kill the connection).

--- a/src/gori/proxy/ws/relay.cr
+++ b/src/gori/proxy/ws/relay.cr
@@ -17,17 +17,47 @@ module Gori::Proxy::WS
     # otherwise-idle long-lived connection.
     RESET_THRESHOLD = 256 * 1024
 
+    # Bounded wait for the peer's REPLYING close frame once we've relayed one direction's
+    # CLOSE (RFC 6455 §7.1.1 closing handshake), before tearing the tunnel down. This is a
+    # local channel wait (not a network read — the WS tunnel's socket timeouts are relaxed,
+    # see SocketTuning.relax in ClientConn), so it's kept well under the proxy's 30 s
+    # baseline IO timeout (SocketTuning::CLIENT_IO_TIMEOUT / Upstream::IO_TIMEOUT): a real
+    # peer replies near-instantly, and a dead one shouldn't pin the tunnel for 30 s.
+    CLOSE_TIMEOUT = 5.seconds
+
     def self.run(client : IO, upstream : IO, flow_id : Int64, sink : FlowSink) : Nil
-      done = Channel(Nil).new(2)
-      spawn { pump(client, upstream, "out", flow_id, sink); done.send(nil) }
-      spawn { pump(upstream, client, "in", flow_id, sink); done.send(nil) }
-      # When EITHER direction ends (EOF / close / reset), close both sockets so the
-      # other pump's blocked read unblocks (raises → rescued → sends done). Without
-      # this a half-open peer pins the surviving pump fiber + socket forever.
-      done.receive
+      done = Channel(Bool).new(2) # each pump's payload: did it end by relaying a CLOSE frame?
+      spawn { done.send(pump(client, upstream, "out", flow_id, sink)) }
+      spawn { done.send(pump(upstream, client, "in", flow_id, sink)) }
+
+      # The first direction to end tells us how to tear down:
+      #   - abnormal end (EOF / reset / truncated frame): the peer is gone — close both
+      #     sockets NOW so the other pump's blocked read unblocks (raises → rescued → sends
+      #     done). Without this a half-open peer pins the surviving pump fiber + socket
+      #     forever.
+      #   - clean end (it just forwarded a CLOSE frame): that's only HALF the RFC 6455
+      #     closing handshake — the peer's REPLYING close frame is very likely still in
+      #     flight on the OTHER direction. Closing immediately here is exactly the race that
+      #     used to drop it (the local "forward, then break" is near-instant; the peer's
+      #     reply needs a real round trip). Give the other pump a bounded window
+      #     (CLOSE_TIMEOUT) to relay that reply before tearing down.
+      first_clean = done.receive
+      second_pending = true
+      if first_clean
+        select
+        when done.receive
+          second_pending = false # other side finished within the window (reply relayed, or its own end)
+        when timeout(CLOSE_TIMEOUT)
+          # peer never replied — give up waiting; the pump below is reaped after closing.
+        end
+      end
       client.close rescue nil
       upstream.close rescue nil
-      done.receive
+      # Every path above consumes exactly one of the two `done` sends before this point
+      # except the "still waiting" case, so reap the outstanding one now (closing the
+      # sockets just unblocked its pending read) — `run` must never return with a pump
+      # fiber still alive.
+      done.receive if second_pending
     end
 
     # Chunk size for streaming an oversized frame's payload (see stream_payload).
@@ -37,10 +67,17 @@ module Gori::Proxy::WS
     # the reassembled message on FIN. A frame larger than MAX_FRAME is streamed
     # through (byte-exact, P7) rather than aborting the whole tunnel; its payload is
     # too large to buffer, so capture records a marker for that frame instead.
-    private def self.pump(src : IO, dst : IO, direction : String, flow_id : Int64, sink : FlowSink) : Nil
+    #
+    # Returns whether this direction ended by successfully relaying a CLOSE frame (the
+    # "clean" end of the RFC 6455 closing handshake) — as opposed to an abnormal end (EOF,
+    # reset, or a truncated frame, all `false`) — so `run` can tell the two cases apart and
+    # give the peer's replying CLOSE a bounded window instead of tearing the tunnel down
+    # the instant either direction stops.
+    private def self.pump(src : IO, dst : IO, direction : String, flow_id : Int64, sink : FlowSink) : Bool
       assembling = IO::Memory.new
       message_opcode = OP_TEXT
       scratch = Bytes.new(STREAM_CHUNK)
+      clean_close = false
       loop do
         h = WS.read_header(src) || break
         message_opcode = h.opcode if h.data? && h.opcode != OP_CONT
@@ -54,7 +91,10 @@ module Gori::Proxy::WS
             assembling = assembling.size > RESET_THRESHOLD ? IO::Memory.new : assembling.tap(&.clear)
           end
           break unless forward_oversized_frame(src, dst, h, direction, flow_id, sink, message_opcode, scratch)
-          break if h.close? # an oversized CLOSE still terminates the tunnel, like a normal one
+          if h.close? # an oversized CLOSE still terminates the tunnel, like a normal one
+            clean_close = true
+            break
+          end
           next
         end
 
@@ -62,10 +102,14 @@ module Gori::Proxy::WS
         dst.write(frame.raw)
         dst.flush
         assembling = capture_frame(frame, assembling, direction, flow_id, sink, message_opcode)
-        break if frame.close?
+        if frame.close?
+          clean_close = true
+          break
+        end
       end
+      clean_close
     rescue
-      # peer closed / reset: this direction ends
+      false # peer closed / reset: this direction ends
     end
 
     # Appends a data frame's payload to the reassembly buffer (up to the cap; the

--- a/src/gori/sequencer/engine.cr
+++ b/src/gori/sequencer/engine.cr
@@ -141,7 +141,21 @@ module Gori::Sequencer
             break if @state.stopped?
             park_if_paused
             break if @state.stopped?
-            break if @collected >= @config.goal
+            # Stop handing out jobs once enough are already IN FLIGHT to reach the
+            # goal, not only once they've fully round-tripped. `@dispatched - @sent`
+            # is the outstanding (dispatched-but-not-yet-completed) count — @sent
+            # increments in process_one right after the send returns, success or
+            # not — so this sum is an optimistic projection of the final collected
+            # count if every outstanding job extracts a token. It only grows via a
+            # dispatch here (+1) and only shrinks via an extraction MISS in
+            # process_one (-1), so it steps by exactly ±1 and lands on @config.goal
+            # exactly (no overshoot) whenever the goal is reachable, while still
+            # letting the loop keep dispatching past a run of misses (bounded by
+            # max_sends below) — unlike the old `@collected >= @config.goal` check,
+            # which only reacted after a full round-trip and let the channel's
+            # buffer slot plus one already-in-flight worker job race the goal by up
+            # to 2 extra live requests.
+            break if @collected + (@dispatched - @sent) >= @config.goal
             break if @dispatched >= @config.max_sends
             break if @backend.cap_reached?
             pace(interval)


### PR DESCRIPTION
## Summary

Built gori, dogfooded it end-to-end (CLI + TUI, across History/Sitemap/Repeater/Intercept/Comparer/Issues), then fanned out across Fuzzer/Sequencer, Discover/Rewriter, WebSocket/gRPC/SSE, and Miner/OAST. Every bug below was reproduced against real traffic (or a hand-rolled protocol client where a public target wasn't reliable enough), root-caused in source, and fixed with a verified before/after — several with a control run confirming the added spec fails on the pre-fix code.

- `fix(tui,capture)`: `gori tui --db=PATH` was a dead flag (parsed, never read) — now opens that db directly, skipping the picker. Headless `gori run capture` also never picked up live Rewriter rule edits despite the docs promising "no restart" — now hot-reloads every 2s.
- `fix(cli)`: `gori run oast listen --help` crashed with an unhandled exception (wrong `OptionParser#on` overload).
- `fix(issues)`: `gori run issues --format markdown` embedded raw chunked/compressed bytes as evidence instead of decoding them — a gzip-compressed response's evidence was silently replaced with `[binary body omitted]`.
- `fix(discover)`: Ctrl-C during `gori run discover` lost every finding not yet flushed (no signal trap on the headless path). Separately, `/robots.txt` and `/sitemap.xml` skipped the soft-404 SimHash calibration that correctly filters brute-forced wordlist hits, causing false positives against a "returns 200 for everything" server.
- `fix(sequencer)`: live token collection consistently overshot `--count` by up to 2 requests — a dispatch/goal-check race that sends unrequested extra live requests to the target (real risk for stateful session tokens).
- `fix(miner)`: `--locations=form` against a bodyless request sent framing-broken HTTP requests (no `Content-Length`/`Content-Type`) instead of no-op'ing like `inject_multipart`/`inject_json` already do.
- `fix(proxy)`: WebSocket close-handshake teardown raced ahead of the peer's replying CLOSE frame, dropping it every time (RFC 6455 violation). Separately, a malformed h2/gRPC client preface forced onto the HTTP/1.1 intercept path parsed as a normal request and sat in the Intercept queue forever with no indication it was ever h2 — root-causing the known "gRPC-intercept BREAKS" symptom.

## Test plan

- [x] `crystal spec` — 3242 examples, 0 failures, 0 errors (2 pre-existing pending, unrelated)
- [x] `shards build` / `crystal build src/main.cr -o bin/gori` — clean
- [x] `crystal tool format --check` on every touched file — clean
- [x] `ameba` on every touched file — no new findings beyond the pre-existing baseline
- [x] Each fix reproduced end-to-end against real traffic (or a hand-rolled client) before the fix, and re-verified fixed after — see individual commit messages for repro shape