### PR TITLE
docs: improve homepage title in docs

### DIFF
--- a/docs/content/index.ko.md
+++ b/docs/content/index.ko.md
@@ -1,5 +1,5 @@
 +++
-title = "gori"
+title = "Gori - Hack from the terminal"
 description = "고리 안에 머무르세요. 터미널을 위한 빠르고 키보드 중심의 HTTP 인터셉트 프록시이자 웹 해킹 툴킷."
 +++
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,5 +1,5 @@
 +++
-title = "gori"
+title = "Gori - Hack from the terminal"
 description = "Sit in the loop. A fast, keyboard-driven HTTP intercepting proxy and web-hacking toolkit for the terminal."
 +++
 

--- a/docs/templates/header.html
+++ b/docs/templates/header.html
@@ -15,7 +15,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="{{ page.description | default(site.description, true) | e }}">
-  <title>{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}</title>
+  <title>{% if page.section == "" %}{{ page.title | e }}{% else %}{% if page.title is present %}{{ page.title | e }} - {% endif %}{{ site.title | e }}{% endif %}</title>
   <link rel="icon" type="image/png" href="/icons/favicon-96x96.png" sizes="96x96" />
   <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
   <link rel="shortcut icon" href="/icons/favicon.ico" />


### PR DESCRIPTION
This PR fixes the homepage title in the documentation to be 'Gori - Hack from the terminal' instead of 'gori - gori'.