### PR TITLE
docs: simplify header nav zones and restore mobile section access

### DIFF
--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -349,18 +349,20 @@ img {
   -webkit-text-fill-color: transparent;
 }
 
-/* Section links sit as quiet pills: a soft ink wash on hover, and the active
-   section carries the gold thread as a tinted pill instead of an underline. */
+/* Header zones: brand | primary sections | tools.
+   Primary links are quiet pills; the right cluster is utilities only
+   (search, language, GitHub, theme). Install is not header chrome —
+   it lives under Start and on the home hero one-liner. */
+
 .top-nav {
   display: flex;
   align-items: center;
-  gap: 0.2rem;
+  gap: 0.15rem;
   min-width: 0;
 }
 
-.top-nav a,
-.install-link {
-  padding: 0.38rem 0.8rem;
+.top-nav a {
+  padding: 0.38rem 0.78rem;
   border-radius: var(--radius-pill);
   color: var(--muted);
   font-size: 0.88rem;
@@ -369,27 +371,96 @@ img {
   transition: color var(--transition), background var(--transition);
 }
 
-.top-nav a:hover,
-.install-link:hover {
+.top-nav a:hover {
   color: var(--heading);
   background: rgb(var(--ink-rgb) / 0.06);
 }
 
-.top-nav a.active,
-.install-link.active {
+.top-nav a.active {
   color: var(--accent-strong);
   background: rgb(var(--accent-rgb) / 0.12);
   font-weight: 500;
 }
 
-/* The right cluster keeps one drawn control (the segmented language pill) and
-   quiet borderless icons for search, GitHub, and the theme. One level of
-   chrome per level of importance, instead of four outlined blobs competing at
-   equal weight. */
+/* Mobile section picker: hidden on desktop; replaces .top-nav when it collapses. */
+.nav-compact {
+  display: none;
+  position: relative;
+  margin-right: 0.15rem;
+}
+
+.nav-compact-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  list-style: none;
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition);
+}
+
+.nav-compact-trigger::-webkit-details-marker {
+  display: none;
+}
+
+.nav-compact-trigger:hover,
+.nav-compact[open] > .nav-compact-trigger {
+  background: rgb(var(--ink-rgb) / 0.08);
+  color: var(--accent-strong);
+}
+
+.nav-compact-trigger svg {
+  width: 1.15rem;
+  height: 1.15rem;
+}
+
+.nav-compact-panel {
+  position: absolute;
+  top: calc(100% + 0.45rem);
+  left: 0;
+  z-index: 120;
+  display: flex;
+  flex-direction: column;
+  min-width: 10.5rem;
+  padding: 0.35rem;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: var(--modal-bg);
+  box-shadow: var(--shadow-soft);
+}
+
+.nav-compact-panel a {
+  display: block;
+  padding: 0.5rem 0.75rem;
+  border-radius: calc(var(--radius-sm) - 2px);
+  color: var(--heading);
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background var(--transition), color var(--transition);
+}
+
+.nav-compact-panel a:hover {
+  background: rgb(var(--ink-rgb) / 0.06);
+  color: var(--heading);
+}
+
+.nav-compact-panel a.active {
+  background: rgb(var(--accent-rgb) / 0.12);
+  color: var(--accent-strong);
+}
+
+/* Tools cluster: one drawn control (language pill) + quiet icon hits.
+   Search first (docs muscle memory), then locale, source, theme. */
 .header-right {
   display: flex;
   align-items: center;
-  gap: 0.45rem;
+  gap: 0.3rem;
   margin-left: auto;
 }
 
@@ -434,8 +505,8 @@ img {
 
 .search-trigger,
 .github-link,
-.x-link,
-.theme-toggle {
+.theme-toggle,
+.nav-compact-trigger {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -453,7 +524,6 @@ img {
 
 .search-trigger:hover,
 .github-link:hover,
-.x-link:hover,
 .theme-toggle:hover {
   background: rgb(var(--ink-rgb) / 0.08);
   color: var(--accent-strong);
@@ -461,7 +531,6 @@ img {
 
 .search-trigger svg,
 .github-link svg,
-.x-link svg,
 .theme-toggle svg {
   width: 1.1rem;
   height: 1.1rem;
@@ -488,7 +557,6 @@ img {
 .search-trigger:active,
 .theme-toggle:active,
 .github-link:active,
-.x-link:active,
 .button:active {
   transform: translateY(1px) scale(0.99);
 }
@@ -3031,8 +3099,22 @@ html.search-lock body {
     padding: 0 1rem;
   }
 
+  /* Wordmark drops first; the mark alone is enough next to the tools. */
+  .logo-word {
+    display: none;
+  }
+
+  .logo {
+    margin-right: 0.55rem;
+  }
+
+  /* Primary section links stay available via the compact menu. */
   .top-nav {
     display: none;
+  }
+
+  .nav-compact {
+    display: block;
   }
 
   .home-main {
@@ -3179,11 +3261,24 @@ html.search-lock body {
 
 @media (max-width: 520px) {
   .logo {
-    margin-right: 0.75rem;
+    margin-right: 0.4rem;
   }
 
   .header-right {
-    gap: 0.3rem;
+    gap: 0.15rem;
+  }
+
+  .lang-switch a {
+    min-width: 1.85rem;
+    padding: 0.26rem 0.38rem;
+  }
+
+  .search-trigger,
+  .github-link,
+  .theme-toggle,
+  .nav-compact-trigger {
+    width: 2.1rem;
+    height: 2.1rem;
   }
 
   .home-hero h1,

--- a/docs/templates/partials/nav.html
+++ b/docs/templates/partials/nav.html
@@ -3,13 +3,31 @@
     <span class="logo-mark" aria-hidden="true" style="--logo-src: url('{{ base_url }}/images/gori.png')" title="{{ "logo.hint" | t }}"></span>
     <span class="logo-word" aria-hidden="true">𝓰𝓸𝓻𝓲</span>
   </a>
+
+  {# Primary IA: three doc sections only. Installation lives under Start
+     (sidebar + hero one-liner); it is not a peer of Guide/Reference. #}
   <nav class="top-nav" aria-label="{{ "a11y.primary_nav" | t }}">
-    <a href="{{ base_url }}{{ lang_prefix }}/getting-started/"{% if page and page.section == "getting-started" and page.slug != "installation" %} class="active" aria-current="true"{% endif %}>{{ "nav.start" | t }}</a>
+    <a href="{{ base_url }}{{ lang_prefix }}/getting-started/"{% if page and page.section == "getting-started" %} class="active" aria-current="true"{% endif %}>{{ "nav.start" | t }}</a>
     <a href="{{ base_url }}{{ lang_prefix }}/guide/"{% if page and page.section == "guide" %} class="active" aria-current="true"{% endif %}>{{ "nav.guide" | t }}</a>
     <a href="{{ base_url }}{{ lang_prefix }}/reference/"{% if page and page.section == "reference" %} class="active" aria-current="true"{% endif %}>{{ "nav.reference" | t }}</a>
   </nav>
+
+  {# Compact section picker for viewports that collapse .top-nav. #}
+  <details class="nav-compact">
+    <summary class="nav-compact-trigger" aria-label="{{ "a11y.primary_nav" | t }}">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16"/></svg>
+    </summary>
+    <div class="nav-compact-panel" role="navigation" aria-label="{{ "a11y.primary_nav" | t }}">
+      <a href="{{ base_url }}{{ lang_prefix }}/getting-started/"{% if page and page.section == "getting-started" %} class="active" aria-current="true"{% endif %}>{{ "nav.start" | t }}</a>
+      <a href="{{ base_url }}{{ lang_prefix }}/guide/"{% if page and page.section == "guide" %} class="active" aria-current="true"{% endif %}>{{ "nav.guide" | t }}</a>
+      <a href="{{ base_url }}{{ lang_prefix }}/reference/"{% if page and page.section == "reference" %} class="active" aria-current="true"{% endif %}>{{ "nav.reference" | t }}</a>
+      <a href="{{ base_url }}{{ lang_prefix }}/getting-started/installation/"{% if page and page.slug == "installation" %} class="active" aria-current="true"{% endif %}>{{ "nav.install" | t }}</a>
+    </div>
+  </details>
+
+  {# Tools only: search, locale, source, theme. No social, no install CTA —
+     those fight the quiet header chrome and the gilded wordmark. #}
   <div class="header-right">
-    <a class="install-link{% if page and page.slug == "installation" %} active{% endif %}" href="{{ base_url }}{{ lang_prefix }}/getting-started/installation/">{{ "nav.install" | t }}</a>
     <button class="search-trigger" onclick="openSearch()" aria-label="{{ "a11y.search_docs" | t }}" title="{{ "a11y.search_docs" | t }} (&#8984;K)">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.6-3.6"/></svg>
     </button>
@@ -24,10 +42,6 @@
     <a class="github-link" href="https://github.com/hahwul/gori" target="_blank" rel="noopener noreferrer" aria-label="{{ "nav.github" | t }}" title="{{ "nav.github" | t }}">
       <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.37.5 0 5.87 0 12.5c0 5.3 3.44 9.8 8.21 11.39.6.11.82-.26.82-.58 0-.29-.01-1.05-.02-2.06-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.2.09 1.84 1.24 1.84 1.24 1.07 1.84 2.81 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.12-.3-.54-1.52.12-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.28-1.55 3.29-1.23 3.29-1.23.66 1.66.24 2.88.12 3.18.77.84 1.24 1.91 1.24 3.22 0 4.61-2.8 5.62-5.48 5.92.43.37.81 1.1.81 2.22 0 1.6-.01 2.9-.01 3.29 0 .32.22.7.83.58C20.57 22.29 24 17.79 24 12.5 24 5.87 18.63.5 12 .5z"/></svg>
     </a>
-    <a class="x-link" href="https://x.com/hahwul" target="_blank" rel="noopener noreferrer" aria-label="{{ "nav.x" | t }}" title="{{ "nav.x" | t }}">
-      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
-    </a>
-
     <button id="themeToggle" class="theme-toggle" type="button" aria-label="{{ "a11y.toggle_theme_aria" | t }}" title="{{ "a11y.toggle_theme_title" | t }}">
       <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>


### PR DESCRIPTION
## Summary
- Split the docs header into clear zones: **Start / Guide / Reference** as primary IA, and **Search · Lang · GitHub · Theme** as tools only.
- Remove the header Install CTA and X link so they no longer compete with the gilded wordmark or the quiet chrome hierarchy (Install stays under Start and on the home hero one-liner).
- Fix Start active state to cover installation pages, and add a compact section menu on narrow viewports where the primary links collapse.

## Test plan
- [ ] Desktop: Start / Guide / Reference highlight correctly, including on Installation
- [ ] Desktop right cluster: Search, language switch, GitHub, theme only
- [ ] ≤860px: hamburger opens Start / Guide / Reference / Install
- [ ] Home hero install one-liner and Start sidebar Installation still work
- [ ] Light and dark theme still look balanced in the header