### PR TITLE
fix: 9 more confirmed bugs from a second dogfood pass

### DIFF
--- a/spec/env_spec.cr
+++ b/spec/env_spec.cr
@@ -28,6 +28,15 @@ describe Gori::Env do
     Gori::Env.parse_line("bad-key x").should be_nil
   end
 
+  it "parse_line picks the space form when whitespace precedes the first '=' (value contains '=')" do
+    # e.g. `gori run project env set APIKEY dGVzdA==` — the space form's value may
+    # itself contain '=' (base64 padding); the FIRST separator to appear (the
+    # space) decides the syntax, not whether '=' appears anywhere in the string.
+    Gori::Env.parse_line("APIKEY dGVzdA==").should eq({"APIKEY", "dGVzdA=="})
+    # '=' still wins when it comes first (unchanged KEY=value behavior).
+    Gori::Env.parse_line("TOKEN=a=b c=d").should eq({"TOKEN", "a=b c=d"})
+  end
+
   it "token_regions marks known vs unknown" do
     Gori::Settings.env_vars = [{"HOST", "h"}]
     Gori::Settings.project_env_vars = [] of {String, String}
@@ -49,6 +58,55 @@ describe Gori::Env do
     String.new(Gori::Env.expand_wire(lf)).should eq(crlf)
   ensure
     Gori::Settings.env_prefix = "$"
+  end
+
+  it "expand passes invalid UTF-8 bytes through unchanged when there is no $ prefix at all" do
+    Gori::Settings.env_prefix = "$"
+    Gori::Settings.env_vars = [] of {String, String}
+    Gori::Settings.project_env_vars = [] of {String, String}
+    # 0x80 is a lone continuation byte; 0xE2 0x28 is a truncated/invalid 3-byte
+    # lead — neither is valid UTF-8. Old `expand` rebuilt via `String#chars` and
+    # silently replaced both with U+FFFD, growing the byte count.
+    bad = Bytes[0x41, 0x80, 0x42, 0xE2, 0x28, 0x43]
+    text = String.new(bad)
+    Gori::Env.expand(text).to_slice.should eq(bad)
+  ensure
+    Gori::Settings.env_prefix = "$"
+  end
+
+  it "expand substitutes a known $KEY while leaving invalid UTF-8 bytes elsewhere untouched" do
+    Gori::Settings.env_prefix = "$"
+    Gori::Settings.env_vars = [{"TOKEN", "secret"}]
+    Gori::Settings.project_env_vars = [] of {String, String}
+    bad_body = Bytes[0x41, 0x80, 0x42, 0xE2, 0x28, 0x43]
+    raw = IO::Memory.new
+    raw << "Auth: $TOKEN\r\n"
+    raw.write(bad_body)
+    text = String.new(raw.to_slice)
+
+    result = Gori::Env.expand(text).to_slice
+    result[0, "Auth: secret\r\n".bytesize].should eq("Auth: secret\r\n".to_slice)
+    result[-bad_body.size, bad_body.size].should eq(bad_body)
+  ensure
+    Gori::Settings.env_vars = [] of {String, String}
+    Gori::Settings.env_prefix = "$"
+  end
+
+  it "expand_wire does not raise and still normalizes CRLF when the text has invalid UTF-8" do
+    Gori::Settings.env_prefix = "$"
+    Gori::Settings.env_vars = [] of {String, String}
+    Gori::Settings.project_env_vars = [] of {String, String}
+    bad = Bytes[0x47, 0x45, 0x54, 0x0A, 0x80, 0x0A] # "GET" LF <invalid> LF
+    text = String.new(bad)
+    Gori::Env.expand_wire(text).should eq(Bytes[0x47, 0x45, 0x54, 0x0D, 0x0A, 0x80, 0x0D, 0x0A])
+  ensure
+    Gori::Settings.env_prefix = "$"
+  end
+
+  it "mask_secrets passes invalid UTF-8 bytes through unchanged when nothing matches" do
+    vars = {"TOKEN" => "s3cr3tXY"}
+    bad = Bytes[0x41, 0x80, 0x42, 0xE2, 0x28, 0x43]
+    Gori::Env.mask_secrets(String.new(bad), vars, "$").to_slice.should eq(bad)
   end
 
   it "mask_secrets does not corrupt a token an earlier replacement inserted" do

--- a/spec/links_spec.cr
+++ b/spec/links_spec.cr
@@ -124,7 +124,7 @@ describe Gori::Links do
 
     it "prefers the custom name for a present repeater" do
       with_store do |store|
-        id = store.insert_repeater("https://t.test", "GET /a HTTP/1.1\r\n\r\n", false, false, nil, 0)
+        id = store.insert_repeater("https://t.test", "GET /a HTTP/1.1\r\n\r\n".to_slice, false, false, nil, 0)
         store.set_repeater_name(id, "my tab")
         r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Repeater, id))
         r.label.should eq("my tab")
@@ -135,7 +135,7 @@ describe Gori::Links do
 
     it "falls back to the request's first line when unnamed" do
       with_store do |store|
-        id = store.insert_repeater("https://t.test", "GET /a HTTP/1.1\r\nHost: t.test\r\n\r\n", false, false, nil, 0)
+        id = store.insert_repeater("https://t.test", "GET /a HTTP/1.1\r\nHost: t.test\r\n\r\n".to_slice, false, false, nil, 0)
         r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Repeater, id))
         r.label.should eq("GET /a HTTP/1.1")
         r.stale?.should be_false
@@ -144,7 +144,7 @@ describe Gori::Links do
 
     it "falls back to 'repeater #N' when unnamed and the request is all-blank" do
       with_store do |store|
-        id = store.insert_repeater("https://t.test", "\r\n   \r\n\r\n", false, false, nil, 0)
+        id = store.insert_repeater("https://t.test", "\r\n   \r\n\r\n".to_slice, false, false, nil, 0)
         r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Repeater, id))
         r.label.should eq("repeater ##{id}")
       end
@@ -152,7 +152,7 @@ describe Gori::Links do
 
     it "falls back to 'repeater #N' when unnamed and the request is empty" do
       with_store do |store|
-        id = store.insert_repeater("https://t.test", "", false, false, nil, 0)
+        id = store.insert_repeater("https://t.test", "".to_slice, false, false, nil, 0)
         r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Repeater, id))
         r.label.should eq("repeater ##{id}")
       end
@@ -219,7 +219,7 @@ describe Gori::Links do
   describe "first_line (via label fallback)" do
     it "skips leading blank lines and returns the first non-blank line" do
       with_store do |store|
-        id = store.insert_repeater("https://t.test", "\r\n\r\n   \r\nGET /deep HTTP/1.1\r\n\r\n", false, false, nil, 0)
+        id = store.insert_repeater("https://t.test", "\r\n\r\n   \r\nGET /deep HTTP/1.1\r\n\r\n".to_slice, false, false, nil, 0)
         r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Repeater, id))
         r.label.should eq("GET /deep HTTP/1.1")
       end
@@ -228,7 +228,7 @@ describe Gori::Links do
     it "strips a trailing CR from the returned line" do
       with_store do |store|
         # No trailing LF on the first line; rstrip('\r') must drop the CR.
-        id = store.insert_repeater("https://t.test", "GET /x HTTP/1.1\r", false, false, nil, 0)
+        id = store.insert_repeater("https://t.test", "GET /x HTTP/1.1\r".to_slice, false, false, nil, 0)
         r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Repeater, id))
         r.label.should eq("GET /x HTTP/1.1")
       end
@@ -236,7 +236,7 @@ describe Gori::Links do
 
     it "preserves a multibyte/CJK first line intact" do
       with_store do |store|
-        id = store.insert_repeater("https://t.test", "GET /검색 HTTP/1.1\r\nHost: t.test\r\n\r\n", false, false, nil, 0)
+        id = store.insert_repeater("https://t.test", "GET /검색 HTTP/1.1\r\nHost: t.test\r\n\r\n".to_slice, false, false, nil, 0)
         r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Repeater, id))
         r.label.should eq("GET /검색 HTTP/1.1")
       end
@@ -244,7 +244,7 @@ describe Gori::Links do
 
     it "returns an all-emoji first line intact" do
       with_store do |store|
-        id = store.insert_repeater("https://t.test", "GET /🔥/世界 HTTP/1.1\r\n\r\n", false, false, nil, 0)
+        id = store.insert_repeater("https://t.test", "GET /🔥/世界 HTTP/1.1\r\n\r\n".to_slice, false, false, nil, 0)
         r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Repeater, id))
         r.label.should eq("GET /🔥/世界 HTTP/1.1")
       end
@@ -253,7 +253,7 @@ describe Gori::Links do
     it "handles a huge run of blank lines quickly (linear robustness)" do
       with_store do |store|
         req = ("\r\n" * 100_000) + "GET /late HTTP/1.1\r\n"
-        id = store.insert_repeater("https://t.test", req, false, false, nil, 0)
+        id = store.insert_repeater("https://t.test", req.to_slice, false, false, nil, 0)
         elapsed = Time.measure do
           r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Repeater, id))
           r.label.should eq("GET /late HTTP/1.1")
@@ -292,7 +292,7 @@ describe Gori::Links do
     it "preserves order and per-element stale flags over a mixed present/stale array" do
       with_store do |store|
         fid = insert_flow_row(store, host: "a.test", target: "/x")
-        rid = store.insert_repeater("https://t.test", "GET /a HTTP/1.1\r\n\r\n", false, false, nil, 0)
+        rid = store.insert_repeater("https://t.test", "GET /a HTTP/1.1\r\n\r\n".to_slice, false, false, nil, 0)
 
         links = [
           link_for(Gori::Store::LinkRefKind::Flow, fid),      # present

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -890,13 +890,24 @@ describe Gori::MCP::Server do
 
     it "previews a rule's match count without creating it" do
       with_store do |store|
-        seed_flow(store, "auth.test", "GET", "/x", 200)          # request head has "auth.test"
+        seed_flow(store, "auth.test", "GET", "/x", 200) # request head has "auth.test"
         seed_flow(store, "other.test", "GET", "/y", 200)
         call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"preview_rule","arguments":{"pattern":"auth.test","target":"request","part":"head"}}})
         p = tool_payload(drive(store, call)[0])
         p["would_match"].as_i.should eq(1)
         p["scanned"].as_i.should eq(2)
         store.match_rules.should be_empty # preview creates nothing
+      end
+    end
+
+    it "rejects an uncompilable regex in preview_rule instead of a fake 0-match result" do
+      with_store do |store|
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"preview_rule","arguments":{"pattern":"[invalid\(regex","match":"regex"}}})
+        resp = drive(store, call)[0]["result"]
+        resp["isError"].as_bool.should be_true
+        resp["structuredContent"]["error_code"].as_s.should eq("INVALID_ARGUMENT")
+        resp["structuredContent"]["field"].as_s.should eq("pattern")
+        store.match_rules.should be_empty
       end
     end
 
@@ -1194,7 +1205,7 @@ describe Gori::MCP::Server do
         resp["result"]["isError"].as_bool.should be_true
         payload = tool_payload(resp)
         payload["error"].as_s.downcase.should contain("fail")
-        payload["error_kind"].as_s.should eq("connect")     # classified network error
+        payload["error_kind"].as_s.should eq("connect")       # classified network error
         payload["error_code"].as_s.should eq("NETWORK_ERROR") # structured-error contract (criterion #4)
         payload["retryable"].as_bool.should be_true
         store.get_flow(payload["recorded_flow_id"].as_i64).not_nil!.row.state.error?.should be_true

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -537,8 +537,8 @@ describe Gori::MCP::Server do
 
     it "links a repeater on create and on a link-only update" do
       with_store do |store|
-        repeater_a = store.insert_repeater("https://ex.test", "GET /a HTTP/1.1\r\n\r\n", false, true, nil, 0)
-        repeater_b = store.insert_repeater("https://ex.test", "GET /b HTTP/1.1\r\n\r\n", false, true, nil, 1)
+        repeater_a = store.insert_repeater("https://ex.test", "GET /a HTTP/1.1\r\n\r\n".to_slice, false, true, nil, 0)
+        repeater_b = store.insert_repeater("https://ex.test", "GET /b HTTP/1.1\r\n\r\n".to_slice, false, true, nil, 1)
         create = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"create_issue","arguments":{"title":"linked","repeater_id":#{repeater_a}}}})
         issue_id = tool_payload(drive(store, create)[0])["id"].as_i64
         links = store.list_links(Gori::Store::LinkOwnerKind::Issue, issue_id)
@@ -975,7 +975,7 @@ describe Gori::MCP::Server do
   describe "get_repeater_context" do
     it "lists persisted repeater sessions with last response status" do
       with_store do |store|
-        store.insert_repeater("https://ex.test", "GET /x HTTP/1.1\nHost: ex.test\n\n", false, true, nil, 0)
+        store.insert_repeater("https://ex.test", "GET /x HTTP/1.1\nHost: ex.test\n\n".to_slice, false, true, nil, 0)
         id = store.repeaters_meta.last.id
         store.update_repeater_response(id, "HTTP/1.1 400 Bad\r\n\r\n".to_slice, "nope".to_slice, nil, 99_i64)
         call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_repeater_context","arguments":{}}})
@@ -999,7 +999,7 @@ describe Gori::MCP::Server do
     it "base64-encodes a binary WebSocket frame (keeps the JSON-RPC stream valid UTF-8)" do
       with_store do |store|
         store.insert_repeater("wss://ex.test/ws",
-          "GET /ws HTTP/1.1\r\nHost: ex.test\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n", false, true, nil, 0)
+          "GET /ws HTTP/1.1\r\nHost: ex.test\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n".to_slice, false, true, nil, 0)
         id = store.repeaters_meta.last.id
         store.insert_ws_message(0_i64, "out", 1, "ping".to_slice, repeater_id: id)        # text frame
         store.insert_ws_message(0_i64, "in", 2, Bytes[0x00, 0xff, 0x80], repeater_id: id) # binary (invalid UTF-8)
@@ -1259,7 +1259,7 @@ describe Gori::MCP::Server do
       with_store do |store|
         port = start_mcp_http_origin("repeater-ok")
         rid = store.insert_repeater(target: "http://127.0.0.1:#{port}",
-          request: "GET /rep HTTP/1.1\r\nHost: 127.0.0.1:#{port}\r\n\r\n",
+          request: "GET /rep HTTP/1.1\r\nHost: 127.0.0.1:#{port}\r\n\r\n".to_slice,
           http2: false, auto_cl: true, flow_id: nil, position: 0, sni: nil)
         call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"send_request","arguments":{"repeater_id":#{rid},"allow_unscoped":true}}})
         p = tool_payload(drive(store, call, verify_upstream: false)[0])
@@ -1272,7 +1272,7 @@ describe Gori::MCP::Server do
     it "rejects send_request on a WebSocket repeater and points to send_websocket" do
       with_store do |store|
         rid = store.insert_repeater(target: "http://127.0.0.1:9",
-          request: "GET /ws HTTP/1.1\r\nHost: 127.0.0.1:9\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: x\r\nSec-WebSocket-Version: 13\r\n\r\n",
+          request: "GET /ws HTTP/1.1\r\nHost: 127.0.0.1:9\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: x\r\nSec-WebSocket-Version: 13\r\n\r\n".to_slice,
           http2: false, auto_cl: true, flow_id: nil, position: 0, sni: nil)
         call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"send_request","arguments":{"repeater_id":#{rid},"allow_unscoped":true}}})
         resp = drive(store, call)[0]["result"]
@@ -1342,7 +1342,7 @@ describe Gori::MCP::Server do
       with_store do |store|
         port = start_mcp_ws_origin
         request = "GET /ws HTTP/1.1\r\nHost: 127.0.0.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n"
-        repeater_id = store.insert_repeater("ws://127.0.0.1:#{port}", request, false, true, nil, 0)
+        repeater_id = store.insert_repeater("ws://127.0.0.1:#{port}", request.to_slice, false, true, nil, 0)
         call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"send_websocket","arguments":{"repeater_id":#{repeater_id},"messages":["ping"],"idle_ms":100,"allow_unscoped":true}}})
         resp = drive(store, call, verify_upstream: false)[0]
         resp["result"]["isError"].as_bool.should be_false
@@ -1358,7 +1358,7 @@ describe Gori::MCP::Server do
 
     it "rejects a non-WebSocket repeater before making a connection" do
       with_store do |store|
-        repeater_id = store.insert_repeater("http://127.0.0.1:1", "GET / HTTP/1.1\r\nHost: x\r\n\r\n", false, true, nil, 0)
+        repeater_id = store.insert_repeater("http://127.0.0.1:1", "GET / HTTP/1.1\r\nHost: x\r\n\r\n".to_slice, false, true, nil, 0)
         call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"send_websocket","arguments":{"repeater_id":#{repeater_id},"allow_unscoped":true}}})
         resp = drive(store, call)[0]
         resp["result"]["isError"].as_bool.should be_true
@@ -1368,7 +1368,7 @@ describe Gori::MCP::Server do
 
     it "uses the WebSocket engine and returns a clean connection error" do
       with_store do |store|
-        repeater_id = store.insert_repeater("ws://127.0.0.1:1", "GET /ws HTTP/1.1\r\nHost: 127.0.0.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n", false, true, nil, 0)
+        repeater_id = store.insert_repeater("ws://127.0.0.1:1", "GET /ws HTTP/1.1\r\nHost: 127.0.0.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n".to_slice, false, true, nil, 0)
         call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"send_websocket","arguments":{"repeater_id":#{repeater_id},"messages":["ping"],"idle_ms":100,"allow_unscoped":true}}})
         resp = drive(store, call, verify_upstream: false)[0]
         resp["result"]["isError"].as_bool.should be_true
@@ -1384,7 +1384,7 @@ describe Gori::MCP::Server do
         store.add_scope_rule("include", "host", "example.com") # blocks 127.0.0.1
         issue_id = store.insert_issue("ev", Gori::Store::Severity::Low, nil, nil)
         rid = store.insert_repeater("ws://127.0.0.1:1",
-          "GET /ws HTTP/1.1\r\nHost: 127.0.0.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n",
+          "GET /ws HTTP/1.1\r\nHost: 127.0.0.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n".to_slice,
           false, true, nil, 0)
         call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"send_websocket","arguments":{"repeater_id":#{rid},"issue_id":#{issue_id}}}})
         resp = drive(store, call)[0]["result"]
@@ -1536,7 +1536,7 @@ describe Gori::MCP::Server do
     it "redacts auth headers in get_repeater_context content" do
       with_store do |store|
         rid = store.insert_repeater(target: "https://h.test",
-          request: "GET / HTTP/1.1\r\nHost: h.test\r\nAuthorization: Bearer topsecret\r\n\r\n",
+          request: "GET / HTTP/1.1\r\nHost: h.test\r\nAuthorization: Bearer topsecret\r\n\r\n".to_slice,
           http2: false, auto_cl: true, flow_id: nil, position: 0, sni: nil)
         call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_repeater_context","arguments":{"id":#{rid},"include_content":true}}})
         p = tool_payload(drive(store, call)[0])

--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -1780,7 +1780,7 @@ describe Gori::Probe, "WebSocket + Repeater sources" do
     with_store do |store|
       req = "GET /api HTTP/1.1\r\nHost: repeater.test\r\n\r\n"
       resp = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nServer: nginx/1.25\r\n\r\n"
-      id = store.insert_repeater("https://repeater.test", req, false, true, nil, 0)
+      id = store.insert_repeater("https://repeater.test", req.to_slice, false, true, nil, 0)
       store.update_repeater_response(id, resp.to_slice, "<html/>".to_slice, nil, 12_i64)
       rec = store.get_repeater(id).not_nil!
       # get_repeater may not load response blobs — use full repeaters list
@@ -1810,7 +1810,7 @@ describe Gori::Probe, "WebSocket + Repeater sources" do
             "Origin: https://evil.example\n"
       resp = "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: https://evil.example\r\n" \
              "Access-Control-Allow-Credentials: true\r\n\r\n"
-      id = store.insert_repeater("http://acme.test", req, false, false, nil, 0)
+      id = store.insert_repeater("http://acme.test", req.to_slice, false, false, nil, 0)
       store.update_repeater_response(id, resp.to_slice, "{}".to_slice, nil, 5_i64)
       rec = store.repeaters.find!(&.id.== id)
       detail = Gori::Probe.detail_from_repeater(rec).not_nil!
@@ -1823,7 +1823,7 @@ describe Gori::Probe, "WebSocket + Repeater sources" do
 
   it "skips Repeater tabs with no response head" do
     with_store do |store|
-      id = store.insert_repeater("https://empty.test", "GET / HTTP/1.1\r\nHost: empty.test\r\n\r\n",
+      id = store.insert_repeater("https://empty.test", "GET / HTTP/1.1\r\nHost: empty.test\r\n\r\n".to_slice,
         false, true, nil, 0)
       rec = store.repeaters_meta.find!(&.id.== id)
       Gori::Probe.detail_from_repeater(rec).should be_nil

--- a/spec/store/store_spec.cr
+++ b/spec/store/store_spec.cr
@@ -282,7 +282,7 @@ describe Gori::Store do
     Gori::Store::Schema.migrate!(db)
     store = Gori::Store.new(db, nil, retention_flows: 5, prune_interval: 10)
     begin
-      rid = store.insert_repeater("wss://acme.test/ws", "GET /ws HTTP/1.1\r\n\r\n", false, false, nil, 0)
+      rid = store.insert_repeater("wss://acme.test/ws", "GET /ws HTTP/1.1\r\n\r\n".to_slice, false, false, nil, 0)
       store.update_repeater_ws_messages(rid, ["client frame 1", "client frame 2"])
       # Churn flows well past retention so prune fires (cutoff = max_id - 5 > 0). The bug:
       # DELETE ... WHERE flow_id <= cutoff also matched the repeater rows (flow_id = 0), wiping them.
@@ -317,7 +317,7 @@ describe Gori::Store do
 
   it "update_repeater_ws_messages stores an empty frame text without aborting the batch" do
     with_store do |store|
-      rid = store.insert_repeater("wss://acme.test/ws", "GET /ws HTTP/1.1\r\n\r\n", false, false, nil, 0)
+      rid = store.insert_repeater("wss://acme.test/ws", "GET /ws HTTP/1.1\r\n\r\n".to_slice, false, false, nil, 0)
       store.update_repeater_ws_messages(rid, ["", "frame"])
       store.flush
       store.ws_messages_for_repeater(rid).size.should eq(2)
@@ -351,6 +351,50 @@ describe Gori::Store do
     ensure
       db1.close
       db2.close
+      File.delete?(path)
+      File.delete?("#{path}-wal")
+      File.delete?("#{path}-shm")
+    end
+  end
+
+  it "V2 migration recovers a pre-existing repeaters.request value that the OLD read path truncated at an embedded NUL" do
+    # Recreates exactly what a pre-fix (V1-only) gori install left on disk: the V1
+    # CREATE TABLE only (no V2 UPDATE), with a `request` row inserted the OLD way — a bound
+    # Crystal String. sqlite3_bind_text takes an explicit byte count (not NUL-terminated),
+    # so the write already stored the full bytes; the bug was purely in the OLD read path
+    # (sqlite3_column_text + a NUL-terminated String.new), which the untyped Bytes read
+    # below does NOT use — this proves the migration recovers what was already on disk for
+    # any existing user, not just what a fresh insert produces going forward.
+    path = File.tempname("gori-repeater-migrate", ".db")
+    db = DB.open("sqlite3:#{path}?journal_mode=wal&busy_timeout=5000")
+    begin
+      Gori::Store::Schema::V1.each { |sql| db.exec(sql) }
+      db.exec("PRAGMA user_version = 1")
+
+      with_nul = "GET /x HTTP/1.1\r\nHost: h\r\n\r\n".to_slice + Bytes[0_u8] + "BINARYTAIL".to_slice
+      normal = "GET /y HTTP/1.1\r\n\r\n"
+      ts = 1_i64
+      db.exec("INSERT INTO repeaters (created_at, updated_at, target, request, http2, auto_content_length, position) VALUES (?,?,?,?,?,?,?)",
+        ts, ts, "https://a.test", String.new(with_nul), 0, 1, 0)
+      db.exec("INSERT INTO repeaters (created_at, updated_at, target, request, http2, auto_content_length, position) VALUES (?,?,?,?,?,?,?)",
+        ts, ts, "https://b.test", normal, 0, 1, 1)
+
+      # Pre-migration: the OLD read shape (untyped `read` dispatches TEXT-storage-class
+      # values through sqlite3_column_text) truncates at the embedded NUL, exactly
+      # reproducing the original bug.
+      db.query_one("SELECT request FROM repeaters WHERE target = 'https://a.test'", as: String)
+        .should eq("GET /x HTTP/1.1\r\nHost: h\r\n\r\n")
+
+      Gori::Store::Schema.migrate!(db)
+      db.scalar("PRAGMA user_version").as(Int64).should eq(2_i64)
+
+      recovered = db.query_one("SELECT request FROM repeaters WHERE target = 'https://a.test'", as: Bytes)
+      recovered.should eq(with_nul) # full byte-for-byte recovery, embedded NUL and all
+
+      unaffected = db.query_one("SELECT request FROM repeaters WHERE target = 'https://b.test'", as: Bytes)
+      String.new(unaffected).should eq(normal) # a normal (no-NUL) row is untouched
+    ensure
+      db.close
       File.delete?(path)
       File.delete?("#{path}-wal")
       File.delete?("#{path}-shm")

--- a/spec/store_repeaters_spec.cr
+++ b/spec/store_repeaters_spec.cr
@@ -17,7 +17,7 @@ describe "Gori::Store repeater tabs (v9)" do
   it "round-trips insert → load" do
     with_store do |store|
       store.repeaters.should be_empty
-      id = store.insert_repeater("https://a.test", "GET / HTTP/1.1\r\n\r\n", false, true, 7_i64, 0)
+      id = store.insert_repeater("https://a.test", "GET / HTTP/1.1\r\n\r\n".to_slice, false, true, 7_i64, 0)
       id.should be > 0
 
       rows = store.repeaters
@@ -25,7 +25,7 @@ describe "Gori::Store repeater tabs (v9)" do
       r = rows.first
       r.id.should eq(id)
       r.target.should eq("https://a.test")
-      r.request.should eq("GET / HTTP/1.1\r\n\r\n")
+      r.request.should eq("GET / HTTP/1.1\r\n\r\n".to_slice)
       r.http2?.should be_false
       r.auto_content_length?.should be_true
       r.flow_id.should eq(7_i64)
@@ -35,7 +35,7 @@ describe "Gori::Store repeater tabs (v9)" do
 
   it "round-trips the http2 + auto_content_length flags and a NULL flow_id" do
     with_store do |store|
-      id = store.insert_repeater("http://h2.test", "POST / HTTP/2\r\n\r\n", true, false, nil, 0)
+      id = store.insert_repeater("http://h2.test", "POST / HTTP/2\r\n\r\n".to_slice, true, false, nil, 0)
       r = store.repeaters.find!(&.id.==(id))
       r.http2?.should be_true
       r.auto_content_length?.should be_false
@@ -45,11 +45,11 @@ describe "Gori::Store repeater tabs (v9)" do
 
   it "updates a tab in place" do
     with_store do |store|
-      id = store.insert_repeater("https://a.test", "GET / HTTP/1.1\r\n\r\n", false, true, nil, 0)
-      store.update_repeater(id, "https://b.test", "PUT /x HTTP/1.1\r\n\r\n", true, false)
+      id = store.insert_repeater("https://a.test", "GET / HTTP/1.1\r\n\r\n".to_slice, false, true, nil, 0)
+      store.update_repeater(id, "https://b.test", "PUT /x HTTP/1.1\r\n\r\n".to_slice, true, false)
       r = store.repeaters.find!(&.id.==(id))
       r.target.should eq("https://b.test")
-      r.request.should eq("PUT /x HTTP/1.1\r\n\r\n")
+      r.request.should eq("PUT /x HTTP/1.1\r\n\r\n".to_slice)
       r.http2?.should be_true
       r.auto_content_length?.should be_false
     end
@@ -57,7 +57,7 @@ describe "Gori::Store repeater tabs (v9)" do
 
   it "deletes a tab" do
     with_store do |store|
-      id = store.insert_repeater("https://a.test", "GET / HTTP/1.1\r\n\r\n", false, true, nil, 0)
+      id = store.insert_repeater("https://a.test", "GET / HTTP/1.1\r\n\r\n".to_slice, false, true, nil, 0)
       store.delete_repeater(id)
       store.repeaters.should be_empty
     end
@@ -65,16 +65,16 @@ describe "Gori::Store repeater tabs (v9)" do
 
   it "orders by position then id (id breaks a position tie)" do
     with_store do |store|
-      a = store.insert_repeater("https://a.test", "a", false, true, nil, 2)
-      b = store.insert_repeater("https://b.test", "b", false, true, nil, 0)
-      c = store.insert_repeater("https://c.test", "c", false, true, nil, 0) # tie with b → id breaks it
+      a = store.insert_repeater("https://a.test", "a".to_slice, false, true, nil, 2)
+      b = store.insert_repeater("https://b.test", "b".to_slice, false, true, nil, 0)
+      c = store.insert_repeater("https://c.test", "c".to_slice, false, true, nil, 0) # tie with b → id breaks it
       store.repeaters.map(&.id).should eq([b, c, a])
     end
   end
 
   it "starts a fresh tab with no persisted response (V11 columns NULL)" do
     with_store do |store|
-      id = store.insert_repeater("https://a.test", "GET / HTTP/1.1\r\n\r\n", false, true, nil, 0)
+      id = store.insert_repeater("https://a.test", "GET / HTTP/1.1\r\n\r\n".to_slice, false, true, nil, 0)
       r = store.repeaters.find!(&.id.==(id))
       r.response_head.should be_nil
       r.response_body.should be_nil
@@ -85,7 +85,7 @@ describe "Gori::Store repeater tabs (v9)" do
 
   it "round-trips a persisted last response (head + body + duration)" do
     with_store do |store|
-      id = store.insert_repeater("https://a.test", "GET / HTTP/1.1\r\n\r\n", false, true, nil, 0)
+      id = store.insert_repeater("https://a.test", "GET / HTTP/1.1\r\n\r\n".to_slice, false, true, nil, 0)
       head = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n".to_slice
       body = "PONG".to_slice
       store.update_repeater_response(id, head, body, nil, 4200_i64)
@@ -95,13 +95,13 @@ describe "Gori::Store repeater tabs (v9)" do
       r.response_error.should be_nil
       r.response_duration_us.should eq(4200_i64)
       # the request side is untouched by a response write
-      r.request.should eq("GET / HTTP/1.1\r\n\r\n")
+      r.request.should eq("GET / HTTP/1.1\r\n\r\n".to_slice)
     end
   end
 
   it "repeaters_meta omits the response BLOBs (lighter reconcile poll)" do
     with_store do |store|
-      id = store.insert_repeater("https://a.test", "GET / HTTP/1.1\r\n\r\n", false, true, nil, 0)
+      id = store.insert_repeater("https://a.test", "GET / HTTP/1.1\r\n\r\n".to_slice, false, true, nil, 0)
       store.update_repeater_response(id, "HTTP/1.1 200 OK\r\n\r\n".to_slice, "body".to_slice, nil, 1_i64)
       meta = store.repeaters_meta.find!(&.id.==(id))
       meta.response_head.should be_nil # not loaded by the metadata query
@@ -113,7 +113,7 @@ describe "Gori::Store repeater tabs (v9)" do
 
   it "persists an errored send (empty head, nil body, error text)" do
     with_store do |store|
-      id = store.insert_repeater("https://a.test", "GET / HTTP/1.1\r\n\r\n", false, true, nil, 0)
+      id = store.insert_repeater("https://a.test", "GET / HTTP/1.1\r\n\r\n".to_slice, false, true, nil, 0)
       store.update_repeater_response(id, Bytes.empty, nil, "connect failed: a.test:443", 0_i64)
       r = store.repeaters.find!(&.id.==(id))
       r.response_body.should be_nil
@@ -123,14 +123,14 @@ describe "Gori::Store repeater tabs (v9)" do
 
   it "round-trips the V31 tags column (default nil, set + clear)" do
     with_store do |store|
-      id = store.insert_repeater("https://a.test", "GET / HTTP/1.1\r\n\r\n", false, true, nil, 0)
+      id = store.insert_repeater("https://a.test", "GET / HTTP/1.1\r\n\r\n".to_slice, false, true, nil, 0)
       store.repeaters.find!(&.id.==(id)).tags.should be_nil # untagged by default
 
       store.set_repeater_tags(id, "idor auth")
       store.repeaters.find!(&.id.==(id)).tags.should eq("idor auth")
 
       # tagging does not rewrite the request (its own narrow UPDATE, like the name)
-      store.repeaters.find!(&.id.==(id)).request.should eq("GET / HTTP/1.1\r\n\r\n")
+      store.repeaters.find!(&.id.==(id)).request.should eq("GET / HTTP/1.1\r\n\r\n".to_slice)
 
       store.set_repeater_tags(id, nil) # blank clears the column back to NULL
       store.repeaters.find!(&.id.==(id)).tags.should be_nil

--- a/spec/support/mock_release_server.cr
+++ b/spec/support/mock_release_server.cr
@@ -13,11 +13,21 @@ class MockReleaseServer
   @server : HTTP::Server
   @closed = false
 
+  # `reported_size`: override the release JSON's `size` field independent of the
+  # real asset body (defaults to the true body size). Lets specs simulate the
+  # unauthenticated/wrong-JSON-size scenario (Bug A) without touching the real
+  # HTTP Content-Length, which is always derived from the actual body.
+  #
+  # `truncate_at`: when set, the download handler writes only this many bytes
+  # of `body` (Content-Length still advertises the full size), sets
+  # `Connection: close`, and hangs up — simulating a server killed mid-transfer.
   def initialize(*,
                  tag : String = "v99.0.0",
                  body : String | Bytes = "mock-gori-binary\n",
                  asset_names : Array(String)? = nil,
-                 throttle_bps : Int32 = 0)
+                 throttle_bps : Int32 = 0,
+                 reported_size : Int64? = nil,
+                 truncate_at : Int32? = nil)
     @tag = tag
     @body = body.is_a?(Bytes) ? body : body.to_slice
     ver = tag.lchop('v').lchop('V')
@@ -28,6 +38,8 @@ class MockReleaseServer
       "gori-v#{ver}-osx-x86_64.tar.gz",
     ]
     @throttle_bps = throttle_bps
+    @reported_size = reported_size || @body.size.to_i64
+    @truncate_at = truncate_at
 
     # Bind first so we know the ephemeral port before building asset URLs.
     @server = HTTP::Server.new do |context|
@@ -54,7 +66,7 @@ class MockReleaseServer
       {
         "name"                 => name,
         "browser_download_url" => download_url(name),
-        "size"                 => @body.size,
+        "size"                 => @reported_size,
       }
     end
     {
@@ -86,7 +98,14 @@ class MockReleaseServer
       end
       context.response.content_type = "application/octet-stream"
       context.response.content_length = @body.size
-      if @throttle_bps > 0
+      if trunc = @truncate_at
+        # Promise the full Content-Length but only ever send `trunc` bytes, then
+        # force the socket closed — simulates a server/process killed mid-transfer.
+        context.response.headers["Connection"] = "close"
+        context.response.write(@body[0, Math.min(trunc, @body.size)])
+        context.response.flush
+        context.response.close
+      elsif @throttle_bps > 0
         write_throttled(context.response, @body, @throttle_bps)
       else
         context.response.write(@body)

--- a/spec/tui/repeater_view_spec.cr
+++ b/spec/tui/repeater_view_spec.cr
@@ -861,7 +861,7 @@ describe Gori::Tui::RepeaterView do
 
   it "persists a repeater tab's custom name (set / clear)" do
     repeater_tmp_store do |store|
-      id = store.insert_repeater("http://h/x", "GET /x HTTP/1.1", false, true, nil, 0)
+      id = store.insert_repeater("http://h/x", "GET /x HTTP/1.1".to_slice, false, true, nil, 0)
       store.set_repeater_name(id, "my-tab")
       store.repeaters.first.name.should eq("my-tab")
       store.set_repeater_name(id, nil) # blank clears the custom name
@@ -943,10 +943,10 @@ describe Gori::Tui::RepeaterView do
 
   it "persists a repeater tab's SNI override (set / clear)" do
     repeater_tmp_store do |store|
-      id = store.insert_repeater("https://h/x", "GET /x HTTP/1.1", false, true, nil, 0, "evil.com")
+      id = store.insert_repeater("https://h/x", "GET /x HTTP/1.1".to_slice, false, true, nil, 0, "evil.com")
       store.repeaters.first.sni.should eq("evil.com")
-      store.repeaters_meta.first.sni.should eq("evil.com")                          # syncs via the fast reconcile poll too
-      store.update_repeater(id, "https://h/x", "GET /x HTTP/1.1", false, true, nil) # clear
+      store.repeaters_meta.first.sni.should eq("evil.com")                                     # syncs via the fast reconcile poll too
+      store.update_repeater(id, "https://h/x", "GET /x HTTP/1.1".to_slice, false, true, nil) # clear
       store.repeaters.first.sni.should be_nil
     end
   end
@@ -1069,7 +1069,7 @@ describe Gori::Tui::RepeaterView do
     begin
       view = RepeaterView.new
       view.load_blank
-      rid = store.insert_repeater(view.target, view.request_text, view.http2?, view.auto_content_length?,
+      rid = store.insert_repeater(view.target, view.request_text.to_slice, view.http2?, view.auto_content_length?,
         nil, 0, view.sni_override)
       view.clear_dirty
       ok = Gori::Repeater::Result.new("HTTP/1.1 200 OK\r\n\r\n".to_slice, "KEEPME".to_slice, nil, 500_i64)
@@ -1080,14 +1080,15 @@ describe Gori::Tui::RepeaterView do
 
       row = store.repeaters_meta.find { |r| r.id == rid }.not_nil!
       # Own row still matches → reconcile would skip. Force a peer-like request edit.
-      store.update_repeater(rid, "https://peer.test", "GET /from-peer HTTP/1.1\nHost: peer.test\n\n",
+      store.update_repeater(rid, "https://peer.test", "GET /from-peer HTTP/1.1\nHost: peer.test\n\n".to_slice,
         false, true, nil)
       store.flush
       row = store.repeaters_meta.find { |r| r.id == rid }.not_nil!
-      view.request_side_matches?(row.target, row.request, row.http2?,
+      row_request_text = String.new(row.request)
+      view.request_side_matches?(row.target, row_request_text, row.http2?,
         row.auto_content_length?, row.sni).should be_false
 
-      view.apply_peer_request(row.target, row.request, row.http2?, row.auto_content_length?,
+      view.apply_peer_request(row.target, row_request_text, row.http2?, row.auto_content_length?,
         sni: row.sni || "")
       view.focus.should eq(:response)
       view.target.should eq("https://peer.test")

--- a/spec/tui/repeater_view_spec.cr
+++ b/spec/tui/repeater_view_spec.cr
@@ -321,6 +321,58 @@ describe Gori::Tui::RepeaterView do
     end
   end
 
+  # Regression for the "Repeater silently corrupts binary/non-UTF-8 request bodies on
+  # every default-path send" bug: a History-loaded flow whose body has genuinely
+  # invalid UTF-8 (a lone continuation byte, a truncated multi-byte lead — NOT just an
+  # embedded NUL, which is valid single-byte UTF-8) used to come out of `request_bytes`
+  # with those bytes rewritten to U+FFFD by `Env.expand`'s old `String#chars` rebuild,
+  # even though the request has no `$KEY` token anywhere — silently changing the
+  # Content-Length and garbling the body on a plain ^R send.
+  it "resends an invalid-UTF-8 body byte-exact via the default (no $KEY) send path" do
+    repeater_tmp_store do |store|
+      body = Bytes[0x41, 0x80, 0x42, 0xE2, 0x28, 0x43] # 6 bytes; 0x80 and 0xE2,0x28 are invalid UTF-8
+      id = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "http", host: "h.test", port: 80,
+        method: "POST", target: "/x", http_version: "HTTP/1.1",
+        head: "POST /x HTTP/1.1\r\nHost: h.test\r\nContent-Length: 6\r\n\r\n".to_slice,
+        body: body))
+      detail = store.get_flow(id).not_nil!
+
+      view = RepeaterView.new
+      view.load(detail)
+
+      sent = view.request_bytes
+      String.new(sent).includes?("Content-Length: 6").should be_true # size did NOT balloon (was corrupted to a larger CL)
+      sent[-body.size, body.size].should eq(body)                    # body bytes preserved exactly
+    end
+  end
+
+  # Same corruption class, but with a `$KEY` token present elsewhere in the request:
+  # substitution must still work for the token while invalid-UTF-8 bytes in the body
+  # (unrelated to the token) pass through unchanged.
+  it "substitutes a known $KEY while leaving an invalid-UTF-8 body untouched" do
+    Gori::Settings.env_vars = [{"TOKEN", "secret"}]
+    Gori::Settings.project_env_vars = [] of {String, String}
+    repeater_tmp_store do |store|
+      body = Bytes[0x41, 0x80, 0x42, 0xE2, 0x28, 0x43]
+      id = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "http", host: "h.test", port: 80,
+        method: "POST", target: "/x", http_version: "HTTP/1.1",
+        head: "POST /x HTTP/1.1\r\nHost: h.test\r\nAuthorization: $TOKEN\r\nContent-Length: 6\r\n\r\n".to_slice,
+        body: body))
+      detail = store.get_flow(id).not_nil!
+
+      view = RepeaterView.new
+      view.load(detail)
+
+      sent = view.request_bytes
+      String.new(sent).includes?("Authorization: secret").should be_true # $TOKEN substituted
+      sent[-body.size, body.size].should eq(body)                        # body bytes still preserved exactly
+    end
+  ensure
+    Gori::Settings.env_vars = [] of {String, String}
+  end
+
   it "reflects auto Content-Length in the visible REQUEST editor (^L on)" do
     view = RepeaterView.new
     view.restore("https://h.test",

--- a/spec/update_spec.cr
+++ b/spec/update_spec.cr
@@ -533,6 +533,68 @@ describe Gori::Update do
         rel.assets.size.should be > 0
       end
     end
+
+    it "rejects a truncated download even when the release JSON reports size: 0 (Bug A)" do
+      # Mirrors the confirmed exploit: the release JSON's `size` field is
+      # unauthenticated and wrong (0), but the real HTTP Content-Length header
+      # promises the full asset — and the server only ever delivers half of it
+      # before hanging up (simulating a killed-mid-transfer process). The fix
+      # must catch this from the real Content-Length, not the JSON size.
+      payload = "x" * 40_000
+      with_mock_release_server(tag: "v99.0.0", body: payload, reported_size: 0_i64, truncate_at: 20_000) do |server|
+        name = server.asset_names.find { |n| n.includes?("linux-x86_64") }.not_nil!
+        dest = File.tempname("gori-dl-")
+        begin
+          expect_raises(Gori::Error, /truncated/) do
+            Gori::Update.download_to(server.download_url(name), dest, expected_size: 0_i64)
+          end
+        ensure
+          File.delete?(dest)
+        end
+      end
+    end
+
+    it "update_binary refuses to install a truncated download and leaves the target untouched (Bug A)" do
+      payload = "y" * 40_000
+      root = File.tempname("gori-trunc-")
+      Dir.mkdir_p(root)
+      begin
+        want = Gori::Update.asset_name("99.0.0", Gori::Update.current_os, Gori::Update.current_arch)
+        with_mock_release_server(tag: "v99.0.0", body: payload, asset_names: [want],
+          reported_size: 0_i64, truncate_at: 20_000) do |srv|
+          target_dir = File.join(root, "opt", "gori")
+          Dir.mkdir_p(target_dir)
+          target = File.join(target_dir, "gori")
+          original = "#!/bin/sh\necho old\n"
+          File.write(target, original)
+          File.chmod(target, 0o755)
+
+          io = IO::Memory.new
+          expect_raises(Gori::Error, /truncated/) do
+            Gori::Update.update_binary(target, io, release_json: srv.release_json)
+          end
+
+          File.read(target).should eq(original)
+        end
+      ensure
+        FileUtils.rm_rf(root) if File.exists?(root)
+      end
+    end
+  end
+
+  describe ".parse_release non-JSON handling (Bug B)" do
+    it "raises a clean Gori::Error instead of an unhandled JSON::ParseException" do
+      expect_raises(Gori::Error, /could not parse release information/) do
+        Gori::Update.parse_release("<html><body>captive portal</body></html>")
+      end
+    end
+
+    it "update_binary surfaces the same clean error for a non-JSON release response" do
+      io = IO::Memory.new
+      expect_raises(Gori::Error, /could not parse release information/) do
+        Gori::Update.update_binary("/tmp/does-not-matter", io, release_json: "not json at all")
+      end
+    end
   end
 
   describe ".install_from_download (plain binary)" do

--- a/src/gori/cli/run/repeater.cr
+++ b/src/gori/cli/run/repeater.cr
@@ -147,7 +147,7 @@ module Gori
 
           id = store.insert_repeater(
             target: Env.mask_secrets(tgt_str),
-            request: Env.mask_secrets(req_content),
+            request: Env.mask_secrets(req_content).to_slice,
             http2: http2,
             auto_cl: auto_cl,
             flow_id: flow_id,

--- a/src/gori/env.cr
+++ b/src/gori/env.cr
@@ -32,45 +32,78 @@ module Gori
     end
 
     # Expand env tokens in wire-form HTTP text (LF or CRLF) and return CRLF bytes.
-    # Uses `gsub(/\r?\n/, "\r\n")` — NOT `split('\n').join("\r\n")` — so already-CRLF
-    # input (captured flow bytes) isn't doubled into `\r\r\n`, which would destroy the
-    # head/body separator and break framing on every CLI/MCP repeater+mine send path.
+    # Normalizes newlines with a byte-level scan (`normalize_crlf`) — NOT
+    # `gsub(/\r?\n/, "\r\n")` and NOT `split('\n').join("\r\n")` — for two reasons:
+    # the gsub-vs-split/join distinction avoids doubling already-CRLF input
+    # (captured flow bytes) into `\r\r\n`, which would destroy the head/body
+    # separator and break framing on every CLI/MCP repeater+mine send path; and a
+    # `Regex` (gsub) *requires* valid UTF-8 and raises `ArgumentError` on a subject
+    # string that isn't — which a captured flow's binary body routinely isn't. See
+    # `expand` below for why the text reaching this point may carry invalid UTF-8.
     def self.expand_wire(text : String, vars : Hash(String, String) = effective_vars,
                          prefix : String = Settings.env_prefix) : Bytes
-      expand(text, vars, prefix).gsub(/\r?\n/, "\r\n").to_slice
+      normalize_crlf(expand(text, vars, prefix).to_slice)
     end
 
     # Substitute registered `prefix+KEY` tokens; unknown keys stay literal.
+    #
+    # Operates on raw bytes, not `String#chars`. `prefix` and KEY names are always
+    # ASCII (`KEY_HEAD`/`KEY_TAIL`), so a token can be found/replaced by scanning
+    # bytes alone — never decoding to codepoints. That matters because the text
+    # here can be a captured flow's body loaded verbatim into the Repeater editor,
+    # which may contain byte sequences that are not valid UTF-8 (a raw binary
+    # body). `String#chars` (the previous implementation) decodes lossily: any
+    # invalid sequence is silently replaced by U+FFFD, corrupting the wire bytes
+    # on every send — even when the text has no `$KEY` token at all. Scanning
+    # bytes instead means every span that isn't part of a matched token — valid
+    # UTF-8 or not — is copied through byte-for-byte, unchanged.
     def self.expand(text : String, vars : Hash(String, String) = effective_vars,
                     prefix : String = Settings.env_prefix) : String
       return text if prefix.empty?
-      out = IO::Memory.new
-      chars = text.chars
-      n = chars.size
-      plen = prefix.size
-      prefix_chars = prefix.chars
+      return text unless text.byte_index(prefix) # fast, lossless no-op when the prefix never occurs
+
+      bytes = text.to_slice
+      prefix_bytes = prefix.to_slice
+      n = bytes.size
+      plen = prefix_bytes.size
+      buf = IO::Memory.new(n)
       i = 0
       while i < n
-        if i + plen <= n && prefix_chars.each_with_index.all? { |c, j| chars[i + j] == c }
-          if parsed = read_key(chars, i + plen, n)
+        if i + plen <= n && prefix_bytes.each_with_index.all? { |b, j| bytes[i + j] == b }
+          if parsed = read_key_bytes(bytes, i + plen, n)
             key, consumed = parsed
             if val = vars[key]?
-              out << val
+              buf << val
               i += plen + consumed
             else
-              out << prefix
+              buf << prefix
               i += plen
             end
           else
-            out << prefix
+            buf << prefix
             i += plen
           end
         else
-          out << chars[i]
+          buf.write_byte(bytes[i])
           i += 1
         end
       end
-      out.to_s
+      String.new(buf.to_slice)
+    end
+
+    # Byte-level equivalent of `gsub(/\r?\n/, "\r\n")`: inserts `\r` before any
+    # `\n` not already preceded by one, leaving everything else untouched. Used
+    # instead of a `Regex` because `bytes` (the expanded request text) may carry
+    # invalid UTF-8, which `Regex` cannot accept as a subject.
+    private def self.normalize_crlf(bytes : Bytes) : Bytes
+      buf = IO::Memory.new(bytes.size)
+      prev : UInt8 = 0
+      bytes.each do |b|
+        buf.write_byte(0x0D_u8) if b == 0x0A_u8 && prev != 0x0D_u8
+        buf.write_byte(b)
+        prev = b
+      end
+      buf.to_slice
     end
 
     # Scans the text for occurrences of any registered env var value and replaces
@@ -81,6 +114,15 @@ module Gori
     # can re-match a token an earlier replacement inserted — e.g. value "OKEN"
     # matching inside a just-inserted "$TOKEN" — silently corrupting the mask. The
     # pass never re-scans replaced spans, so inserted tokens stay intact.
+    #
+    # Byte-level, same reasoning as `expand`: callers pass raw request/response
+    # text (e.g. MCP `send`/`repeater` tools mask a captured flow's raw bytes for
+    # display), which may not be valid UTF-8. Scanning `text.chars` would silently
+    # replace any invalid byte sequence with U+FFFD even where no secret value
+    # matches nearby — corrupting the displayed/logged text on every call, not
+    # just the masked spans. Byte-level value matching is also strictly more
+    # precise than char matching: it finds a value's literal bytes regardless of
+    # whether the surrounding haystack happens to be well-formed UTF-8.
     def self.mask_secrets(text : String, vars : Hash(String, String) = effective_vars,
                           prefix : String = Settings.env_prefix) : String
       return text if prefix.empty? || vars.empty?
@@ -88,28 +130,28 @@ module Gori
       # Filter out empty values and short/common values that might lead to false positives (e.g., single characters)
       candidates = vars.to_a
         .reject { |(k, v)| v.strip.empty? || v.size < 4 }
-        .sort_by! { |(k, v)| -v.size }
-        .map { |(k, v)| {k, v.chars} }
+        .sort_by! { |(k, v)| -v.bytesize }
+        .map { |(k, v)| {k, v.to_slice} }
 
       return text if candidates.empty?
 
-      chars = text.chars
-      n = chars.size
-      String.build do |io|
-        i = 0
-        while i < n
-          hit = candidates.find do |(_, vchars)|
-            i + vchars.size <= n && vchars.each_with_index.all? { |c, j| chars[i + j] == c }
-          end
-          if hit
-            io << prefix << hit[0]
-            i += hit[1].size
-          else
-            io << chars[i]
-            i += 1
-          end
+      bytes = text.to_slice
+      n = bytes.size
+      buf = IO::Memory.new(n)
+      i = 0
+      while i < n
+        hit = candidates.find do |(_, vbytes)|
+          i + vbytes.size <= n && vbytes.each_with_index.all? { |b, j| bytes[i + j] == b }
+        end
+        if hit
+          buf << prefix << hit[0]
+          i += hit[1].size
+        else
+          buf.write_byte(bytes[i])
+          i += 1
         end
       end
+      String.new(buf.to_slice)
     end
 
     # Char offsets [start, end) of each env-shaped token in `text` (end exclusive).
@@ -142,11 +184,18 @@ module Gori
     end
 
     # Parse "KEY VALUE" or "KEY=value" (value may contain spaces when using the
-    # space form). Returns nil when KEY is invalid.
+    # space form). Which syntax was used is decided by whichever separator — `=`
+    # or whitespace — appears FIRST in the string, not by whether `=` appears
+    # anywhere at all: a space-form value that itself contains `=` (e.g. a
+    # base64-padded API key, `APIKEY dGVzdA==`) must still split on the leading
+    # whitespace, not on the `=` buried inside the value. Returns nil when KEY is
+    # invalid.
     def self.parse_line(text : String) : {String, String}?
       raw = text.strip
       return nil if raw.empty?
-      if eq = raw.index('=')
+      eq = raw.index('=')
+      ws = raw.index(/\s/)
+      if eq && (ws.nil? || eq < ws)
         key = raw[0...eq].strip
         val = raw[eq + 1..]
         return nil unless valid_key?(key)
@@ -217,6 +266,20 @@ module Gori
         j += 1
       end
       {chars[start...j].join, j - start}
+    end
+
+    # Byte-level counterpart to `read_key`, used by `expand`. KEY_HEAD/KEY_TAIL
+    # are pure-ASCII patterns, so matching a single byte at a time via `UInt8#chr`
+    # (never decoding a multi-byte sequence) is exact — and safe on invalid UTF-8,
+    # since a byte that's part of an invalid sequence simply won't match `[A-Za-z0-9_]`
+    # and gets left alone by the caller.
+    private def self.read_key_bytes(bytes : Bytes, start : Int32, n : Int32) : {String, Int32}?
+      return nil if start >= n || !KEY_HEAD.matches?(bytes[start].chr.to_s)
+      j = start + 1
+      while j < n && KEY_TAIL.matches?(bytes[j].chr.to_s)
+        j += 1
+      end
+      {String.new(bytes[start...j]), j - start}
     end
   end
 end

--- a/src/gori/links.cr
+++ b/src/gori/links.cr
@@ -49,7 +49,7 @@ module Gori
 
     private def self.resolve_repeater(store : Store, link : Store::EntityLink) : Resolved
       if rec = store.get_repeater(link.ref_id)
-        label = rec.name || first_line(rec.request) || "repeater ##{rec.id}"
+        label = rec.name || first_line(String.new(rec.request).scrub) || "repeater ##{rec.id}"
         Resolved.new(link, link.ref_kind.tag, label, rec.target)
       else
         Resolved.new(link, link.ref_kind.tag, "repeater ##{link.ref_id} (gone)", "repeater ##{link.ref_id}", stale: true)

--- a/src/gori/mcp/tools/context.cr
+++ b/src/gori/mcp/tools/context.cr
@@ -136,7 +136,7 @@ module Gori
                                  # meets any such repeater. Scrub is lossless for a filter match.
                                  r.target.scrub.matches?(rx) ||
                                    r.name.try(&.scrub.matches?(rx)) ||
-                                   r.request.scrub.matches?(rx)
+                                   String.new(r.request).scrub.matches?(rx)
                                end
                              else
                                all_repeaters
@@ -215,9 +215,10 @@ module Gori
           j.field "flow_id", r.flow_id if r.flow_id
           j.field "name", r.name if r.name
           j.field "sni", r.sni if r.sni
-          emit_capped_text(j, "request", Serialize.redact_head(r.request, include_sensitive)) if include_content
+          r_request_text = String.new(r.request).scrub
+          emit_capped_text(j, "request", Serialize.redact_head(r_request_text, include_sensitive)) if include_content
 
-          if Repeater::WsEngine.upgrade_request?(r.request)
+          if Repeater::WsEngine.upgrade_request?(r_request_text)
             ws_msgs = store.ws_messages_for_repeater(r.id)
             j.field "ws_mode", true
             j.field "ws_message_count", ws_msgs.size

--- a/src/gori/mcp/tools/repeater.cr
+++ b/src/gori/mcp/tools/repeater.cr
@@ -83,7 +83,7 @@ module Gori
 
         id = store.insert_repeater(
           target: masked_target,
-          request: masked_request,
+          request: masked_request.to_slice,
           http2: http2,
           auto_cl: auto_cl,
           flow_id: flow_id,
@@ -147,7 +147,7 @@ module Gori
         return not_found("no repeater with id #{id}") unless existing
 
         target = str(h, "target") || existing.target
-        request = str(h, "request") || existing.request
+        request = str(h, "request") || String.new(existing.request)
         # An explicitly-passed empty string is truthy in Crystal, so guard it here to
         # mirror create_repeater's invariant — a blank target/request can't be sent.
         return Result.new("target must not be empty", is_error: true) if target.empty?
@@ -175,7 +175,7 @@ module Gori
         store.update_repeater(
           id: id,
           target: masked_target,
-          request: masked_request,
+          request: masked_request.to_slice,
           http2: http2,
           auto_cl: auto_cl,
           sni: masked_sni

--- a/src/gori/mcp/tools/rules.cr
+++ b/src/gori/mcp/tools/rules.cr
@@ -131,6 +131,13 @@ module Gori
         return ok if ok.is_a?(Result)
         op, match_kind = ok
         part = Store::RulePart::Head if op.header?
+        # Reject an uncompilable regex up front, same as create/update_rule — otherwise
+        # Rules#apply_rule's own rescue (a deliberate passthrough so a bad LIVE rule
+        # can't corrupt traffic) silently reports a fake "0 matches" instead of the
+        # compile error preview_rule exists to catch before create_rule.
+        unless valid_rule_regex?(op, match_kind, pattern)
+          return err("invalid regex pattern (failed to compile)", "INVALID_ARGUMENT", field: "pattern")
+        end
         replacement = str(h, "replacement") || ""
         host = str(h, "host") || ""
         candidate = Store::MatchRule.new(0_i64, true, target, part, pattern, replacement, op, match_kind, "", host)

--- a/src/gori/mcp/tools/send.cr
+++ b/src/gori/mcp/tools/send.cr
@@ -137,7 +137,7 @@ module Gori
         masked_req = Env.mask_secrets(String.new(built.bytes))
         repeater_id = store.insert_repeater(
           target: masked_target,
-          request: masked_req,
+          request: masked_req.to_slice,
           http2: http2,
           auto_cl: true,
           flow_id: flow_id,
@@ -270,7 +270,8 @@ module Gori
         return Result.new(id_error(h, "repeater_id"), is_error: true) unless repeater_id
         repeater = store.get_repeater(repeater_id)
         return not_found("no repeater with id #{repeater_id}") unless repeater
-        unless Repeater::WsEngine.upgrade_request?(repeater.request)
+        repeater_request_text = String.new(repeater.request)
+        unless Repeater::WsEngine.upgrade_request?(repeater_request_text)
           return Result.new("repeater #{repeater_id} is not a WebSocket upgrade request", is_error: true)
         end
 
@@ -314,7 +315,7 @@ module Gori
             Store::LinkRefKind::Repeater, repeater_id)
         end
         verify = @verify_upstream && !(bool(h, "insecure") || false)
-        request = Env.expand_wire(repeater.request)
+        request = Env.expand_wire(repeater_request_text)
         sni = repeater.sni.try { |value| Env.expand(value) }
         result = Repeater::WsEngine.send(request, out_messages,
           scheme: scheme, host: host, port: port, verify_upstream: verify, sni: sni, idle: idle)
@@ -381,10 +382,11 @@ module Gori
           raise Gori::Error.new(id_error(h, "repeater_id")) unless id
           rec = store.get_repeater(id)
           raise Gori::Error.new("no repeater with id #{id}") unless rec
-          if Repeater::WsEngine.upgrade_request?(rec.request)
+          rec_request_text = String.new(rec.request)
+          if Repeater::WsEngine.upgrade_request?(rec_request_text)
             raise Gori::Error.new("repeater #{id} is a WebSocket upgrade — use send_websocket")
           end
-          expanded = Env.expand_wire(rec.request)
+          expanded = Env.expand_wire(rec_request_text)
           # Respect the repeater's auto-Content-Length setting (the TUI Repeater does):
           # only recompute CL when it's on, so a deliberately hand-set CL is preserved.
           bytes = rec.auto_content_length? ? Repeater::FlowRequest.resync_content_length(expanded) : expanded
@@ -463,7 +465,7 @@ module Gori
         return unless store.probe_mode.scanning?
         return if head.empty?
         rec = Store::RepeaterRecord.new(
-          repeater_id, target, request, http2, true, flow_id, 0,
+          repeater_id, target, request.to_slice, http2, true, flow_id, 0,
           head, body, nil, duration_us, nil, nil)
         return unless detail = Probe.detail_from_repeater(rec)
         Probe::Passive.analyze(detail).each do |d|

--- a/src/gori/probe/from_repeater.cr
+++ b/src/gori/probe/from_repeater.cr
@@ -18,7 +18,7 @@ module Gori
       # request head+body without scrubbing), which would make the PCRE gsub below raise. This
       # builds a synthetic FlowDetail for PASSIVE ANALYSIS only (never re-sent), so scrub is
       # lossless here. Cf. secret_in_url.cr / issues_export.one_line.
-      req_text = record.request.scrub
+      req_text = String.new(record.request).scrub
       # Take whichever blank-line boundary occurs FIRST — the editor uses bare-LF, so a
       # literal "\r\n\r\n" inside the body must not win over the true earlier "\n\n" head
       # boundary (the naive `crlf || lf` fallback would snap to the body's sequence).

--- a/src/gori/store/models.cr
+++ b/src/gori/store/models.cr
@@ -417,7 +417,7 @@ module Gori
     struct RepeaterRecord
       getter id : Int64
       getter target : String
-      getter request : String
+      getter request : Bytes
       getter? http2 : Bool
       getter? auto_content_length : Bool
       getter flow_id : Int64?

--- a/src/gori/store/repeater_sessions.cr
+++ b/src/gori/store/repeater_sessions.cr
@@ -18,7 +18,7 @@ module Gori
       @db.query("SELECT id, target, request, http2, auto_content_length, flow_id, position, response_head, response_body, response_error, response_duration_us, name, sni, tags FROM repeaters ORDER BY position, id") do |rs|
         rs.each do
           list << RepeaterRecord.new(
-            rs.read(Int64), rs.read(String), rs.read(String),
+            rs.read(Int64), rs.read(String), rs.read(Bytes),
             rs.read(Int32) != 0, rs.read(Int32) != 0, rs.read(Int64?), rs.read(Int32),
             rs.read(Bytes?), rs.read(Bytes?), rs.read(String?), rs.read(Int64?), rs.read(String?), rs.read(String?),
             tags: rs.read(String?))
@@ -35,7 +35,7 @@ module Gori
         "SELECT id, target, request, http2, auto_content_length, flow_id, position, sni, name FROM repeaters WHERE id = ?",
         id) do |rs|
         return RepeaterRecord.new(
-          rs.read(Int64), rs.read(String), rs.read(String),
+          rs.read(Int64), rs.read(String), rs.read(Bytes),
           rs.read(Int32) != 0, rs.read(Int32) != 0, rs.read(Int64?), rs.read(Int32),
           sni: rs.read(String?), name: rs.read(String?)) if rs.move_next
       end
@@ -52,7 +52,7 @@ module Gori
         "FROM repeaters WHERE id = ?", id) do |rs|
         if rs.move_next
           return RepeaterRecord.new(
-            rs.read(Int64), rs.read(String), rs.read(String),
+            rs.read(Int64), rs.read(String), rs.read(Bytes),
             rs.read(Int32) != 0, rs.read(Int32) != 0, rs.read(Int64?), rs.read(Int32),
             rs.read(Bytes?), rs.read(Bytes?), rs.read(String?), rs.read(Int64?), rs.read(String?), rs.read(String?),
             tags: rs.read(String?))
@@ -66,7 +66,7 @@ module Gori
       @db.query("SELECT id, target, request, http2, auto_content_length, flow_id, position, sni FROM repeaters ORDER BY position, id") do |rs|
         rs.each do
           list << RepeaterRecord.new(
-            rs.read(Int64), rs.read(String), rs.read(String),
+            rs.read(Int64), rs.read(String), rs.read(Bytes),
             rs.read(Int32) != 0, rs.read(Int32) != 0, rs.read(Int64?), rs.read(Int32),
             sni: rs.read(String?))
         end
@@ -83,7 +83,7 @@ module Gori
         "name, response_head, response_error, response_duration_us FROM repeaters ORDER BY position, id") do |rs|
         rs.each do
           list << RepeaterRecord.new(
-            rs.read(Int64), rs.read(String), rs.read(String),
+            rs.read(Int64), rs.read(String), rs.read(Bytes),
             rs.read(Int32) != 0, rs.read(Int32) != 0, rs.read(Int64?), rs.read(Int32),
             sni: rs.read(String?), name: rs.read(String?),
             response_head: rs.read(Bytes?), response_error: rs.read(String?), response_duration_us: rs.read(Int64?))
@@ -94,7 +94,7 @@ module Gori
 
     # Returns the new row id (or 0 if the store is closing — the caller normalizes
     # 0 → nil so a later update never targets a bogus row).
-    def insert_repeater(target : String, request : String, http2 : Bool,
+    def insert_repeater(target : String, request : Bytes, http2 : Bool,
                         auto_cl : Bool, flow_id : Int64?, position : Int32, sni : String? = nil) : Int64
       ts = now_us
       exec_task ->(c : DB::Connection) {
@@ -104,7 +104,7 @@ module Gori
       }
     end
 
-    def update_repeater(id : Int64, target : String, request : String, http2 : Bool, auto_cl : Bool,
+    def update_repeater(id : Int64, target : String, request : Bytes, http2 : Bool, auto_cl : Bool,
                         sni : String? = nil) : Nil
       exec_task ->(c : DB::Connection) {
         c.exec("UPDATE repeaters SET target = ?, request = ?, http2 = ?, auto_content_length = ?, sni = ?, updated_at = ? WHERE id = ?",

--- a/src/gori/store/schema.cr
+++ b/src/gori/store/schema.cr
@@ -7,7 +7,7 @@ module Gori
     # baseline schema; every later change to a released schema arrives as a NEW
     # entry appended to MIGRATIONS (never an edit to an existing one).
     module Schema
-      VERSION = 1
+      VERSION = MIGRATIONS.size
 
       V1 = [
         # ── Capture ──────────────────────────────────────────────────────────────
@@ -537,7 +537,27 @@ module Gori
         "CREATE INDEX idx_oast_callbacks_session ON oast_callbacks (session_id, id)",
       ]
 
-      MIGRATIONS = [V1]
+      # V2: `repeaters.request` was always written as a bound Crystal String — SQLite
+      # stores the exact bytes (sqlite3_bind_text takes an explicit byte count, not a
+      # NUL-terminated length), so no data was ever lost on write. But the crystal-sqlite3
+      # driver reads a TEXT-storage-class column via sqlite3_column_text + a single-arg
+      # `String.new(ptr)`, which stops at the first embedded NUL — so any repeater request
+      # containing a raw 0x00 byte (a binary body, or a hex-edited byte) silently truncated
+      # on every read after the one write, corrupting/emptying the request in Repeater.
+      #
+      # `CAST(x AS BLOB)` reinterprets a TEXT value's existing bytes as-is (no reparse, no
+      # NUL truncation — verified against the actual crystal-sqlite3 driver: a 31-byte value
+      # with two embedded NULs round-trips byte-for-byte after this UPDATE, vs. truncating to
+      # 5 bytes before it). This is a data-only migration — no column type change, since
+      # SQLite's TEXT affinity never coerces a BLOB-storage-class value back to TEXT, so the
+      # fix holds permanently once `insert_repeater`/`update_repeater` bind `Bytes` instead
+      # of `String` (see Store#insert_repeater). Recovers EXISTING users' truncation-prone
+      # rows losslessly; a no-op for rows that never contained a NUL.
+      V2 = [
+        "UPDATE repeaters SET request = CAST(request AS BLOB)",
+      ]
+
+      MIGRATIONS = [V1, V2]
 
       def self.migrate!(db : DB::Database) : Nil
         db.using_connection do |conn|

--- a/src/gori/tui/controllers/decoder_controller.cr
+++ b/src/gori/tui/controllers/decoder_controller.cr
@@ -52,7 +52,7 @@ module Gori::Tui
       @registry = Decoder.default_registry
       @popup = ChainComplete.new
       @popup_engaged = false # false = passive full-list menu (Tab still navigates panes)
-      @prompt = nil # :save_as | :load inline mini-prompt (else nil)
+      @prompt = nil          # :save_as | :load inline mini-prompt (else nil)
       @prompt_buf = ""
       @chain_pre = "" # IME preedit for the focused CHAIN field
       @dirty = false  # session set changed since the last persist
@@ -655,6 +655,19 @@ module Gori::Tui
           s.pane = :output # down from CHAIN drops into the OUTPUT pane
           @popup.close
         end
+      when key.enter?
+        recompute # the pipeline is already live; just re-derive
+      else
+        edit_chain_caret(ev, s, c) # ←/→/Home/End/Delete/Backspace + literal insert
+      end
+    end
+
+    # The within-line caret keys + literal insert/delete for the CHAIN field (split
+    # out of edit_chain so its up/down pane-transition + popup logic stays under the
+    # complexity budget — mirrors edit_input_caret's split from edit_input).
+    private def edit_chain_caret(ev : Termisu::Event::Key, s, c : Char?) : Nil
+      key = ev.key
+      case
       when key.backspace?
         if s.chain_cx > 0
           s.chain = s.chain[0, s.chain_cx - 1] + s.chain[s.chain_cx..]
@@ -669,8 +682,19 @@ module Gori::Tui
       when key.right?
         s.chain_cx = {s.chain_cx + 1, s.chain.size}.min
         refilter_popup
-      when key.enter?
-        recompute # the pipeline is already live; just re-derive
+      when key.home?
+        s.chain_cx = 0
+        refilter_popup
+      when key.end?
+        s.chain_cx = s.chain.size
+        refilter_popup
+      when key.delete?
+        if s.chain_cx < s.chain.size
+          s.chain = s.chain[0, s.chain_cx] + s.chain[(s.chain_cx + 1)..]
+          @chain_pre = ""
+          touch
+          refilter_popup
+        end
       else
         if c && !ev.ctrl? && !ev.alt?
           s.chain = s.chain[0, s.chain_cx] + c.to_s + s.chain[s.chain_cx..]

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -40,12 +40,13 @@ module Gori::Tui
       @host.session.store.repeaters.each do |r|
         view = RepeaterView.new
         ws_msgs = nil.as(Array(String)?)
-        if Repeater::WsEngine.upgrade_request?(r.request)
+        request_text = String.new(r.request)
+        if Repeater::WsEngine.upgrade_request?(request_text)
           ws_msgs = @host.session.store.ws_messages_for_repeater(r.id).compact_map do |m|
             m.direction == "out" ? String.new(m.payload) : nil
           end
         end
-        view.restore(r.target, r.request, r.http2?, r.auto_content_length?,
+        view.restore(r.target, request_text, r.http2?, r.auto_content_length?,
           r.response_head, r.response_body, r.response_error, r.response_duration_us,
           sni: r.sni || "", ws_messages: ws_msgs)
         view.name = r.name                       # custom sub-tab label survives reopen
@@ -875,7 +876,7 @@ module Gori::Tui
     private def persist_repeater_tab(tab : RepeaterTab) : Nil
       return unless (id = tab.db_id) && tab.view.dirty?
       v = tab.view
-      @host.session.store.update_repeater(id, v.target, v.request_text, v.http2?, v.auto_content_length?, v.sni_override)
+      @host.session.store.update_repeater(id, v.target, v.request_text.to_slice, v.http2?, v.auto_content_length?, v.sni_override)
       v.clear_dirty
     end
 
@@ -889,7 +890,7 @@ module Gori::Tui
       return unless resp = view.last_http_response
       head, body = resp
       rec = Store::RepeaterRecord.new(
-        tab.db_id || 0_i64, view.target, view.request_text, view.http2?, view.auto_content_length?,
+        tab.db_id || 0_i64, view.target, view.request_text.to_slice, view.http2?, view.auto_content_length?,
         tab.flow_id, 0, head, body, nil, 0_i64, view.name, view.sni_override)
       Probe.detail_from_repeater(rec)
     rescue
@@ -901,7 +902,7 @@ module Gori::Tui
                                     duration_us : Int64, flow_id : Int64?, view : RepeaterView) : Nil
       return if head.empty?
       rec = Store::RepeaterRecord.new(
-        repeater_id, view.target, view.request_text, view.http2?, view.auto_content_length?,
+        repeater_id, view.target, view.request_text.to_slice, view.http2?, view.auto_content_length?,
         flow_id, 0, head, body, nil, duration_us, view.name, view.sni_override)
       return unless detail = Probe.detail_from_repeater(rec)
       @host.session.probe.scan_detail(detail, repeater_id: repeater_id)
@@ -917,7 +918,7 @@ module Gori::Tui
       upgrade = view.ws_upgrade_bytes
       req_text = upgrade.empty? ? view.request_text : String.new(upgrade).scrub
       rec = Store::RepeaterRecord.new(
-        repeater_id, view.target, req_text, false, false,
+        repeater_id, view.target, req_text.to_slice, false, false,
         flow_id, 0, head, Bytes.empty, nil, result.duration_us, view.name, view.sni_override)
       return unless detail = Probe.detail_from_repeater(rec)
       # Synthetic WsMessage rows (id unused by the rule; opcode 1 = text).
@@ -990,18 +991,19 @@ module Gori::Tui
         v = tab.view
         # Only re-apply when the PERSISTED request side actually changed (data_version
         # also bumps on capture/response writes, so most polls touch an identical row).
-        next if v.request_side_matches?(row.target, row.request, row.http2?,
+        next if v.request_side_matches?(row.target, String.new(row.request), row.http2?,
                   row.auto_content_length?, row.sni)
         # Soft sync: request/target/flags only. Full restore() would reset focus to
         # :target and clear @result (no response BLOBs on this path) — that is the
         # "send then response vanishes / focus jumps to Target" bug.
         ws_msgs = nil.as(Array(String)?)
-        if Repeater::WsEngine.upgrade_request?(row.request)
+        row_request_text = String.new(row.request)
+        if Repeater::WsEngine.upgrade_request?(row_request_text)
           ws_msgs = @host.session.store.ws_messages_for_repeater(row.id).compact_map do |m|
             m.direction == "out" ? String.new(m.payload) : nil
           end
         end
-        v.apply_peer_request(row.target, row.request, row.http2?, row.auto_content_length?,
+        v.apply_peer_request(row.target, row_request_text, row.http2?, row.auto_content_length?,
           sni: row.sni || "", ws_messages: ws_msgs)
         seed_repeater_original(v, row.flow_id) # baseline may need re-seed if it was empty
       end
@@ -1011,12 +1013,13 @@ module Gori::Tui
         next if local_ids.includes?(row.id)
         view = RepeaterView.new
         ws_msgs = nil.as(Array(String)?)
-        if Repeater::WsEngine.upgrade_request?(row.request)
+        row_request_text = String.new(row.request)
+        if Repeater::WsEngine.upgrade_request?(row_request_text)
           ws_msgs = @host.session.store.ws_messages_for_repeater(row.id).compact_map do |m|
             m.direction == "out" ? String.new(m.payload) : nil
           end
         end
-        view.restore(row.target, row.request, row.http2?, row.auto_content_length?,
+        view.restore(row.target, row_request_text, row.http2?, row.auto_content_length?,
           sni: row.sni || "", ws_messages: ws_msgs)
         seed_repeater_original(view, row.flow_id)
         @repeaters << RepeaterTab.new(view, row.flow_id, row.id)
@@ -1144,7 +1147,7 @@ module Gori::Tui
     # Insert a freshly-opened repeater tab into the store so it has a stable row id (the
     # reconcile key). A closing store returns 0 → nil, leaving the tab unsaved.
     private def persist_new_repeater(view : RepeaterView, flow_id : Int64?) : Int64?
-      id = @host.session.store.insert_repeater(view.target, view.request_text, view.http2?,
+      id = @host.session.store.insert_repeater(view.target, view.request_text.to_slice, view.http2?,
         view.auto_content_length?, flow_id, @repeaters.size, view.sni_override)
       id == 0 ? nil : id
     end
@@ -1376,12 +1379,12 @@ module Gori::Tui
         # Persist the RAW handshake text (request_text = the editor's `$KEY` tokens, LF),
         # NOT ws_upgrade_bytes (env-expanded + CRLF): baking the expanded form in would
         # write secrets to the DB and defeat the reconcile guard (which compares LF text).
-        @host.session.store.update_repeater(id, v.target, v.request_text, v.http2?, v.auto_content_length?,
+        @host.session.store.update_repeater(id, v.target, v.request_text.to_slice, v.http2?, v.auto_content_length?,
           v.sni_override)
         # Raw message lines too — the store masks secrets; env tokens re-expand on send.
         @host.session.store.update_repeater_ws_messages(id, v.ws_out_texts_raw)
       else
-        @host.session.store.update_repeater(id, v.target, v.request_text, v.http2?, v.auto_content_length?,
+        @host.session.store.update_repeater(id, v.target, v.request_text.to_slice, v.http2?, v.auto_content_length?,
           v.sni_override)
       end
       v.clear_dirty

--- a/src/gori/tui/setup_wizard.cr
+++ b/src/gori/tui/setup_wizard.cr
@@ -536,17 +536,18 @@ module Gori::Tui
       y = box.y + 2
       screen.text(ix, y, "You're all set!", Theme.text_bright, Theme.panel, width: {box.w - 6, 1}.max)
       y += 2
-      recap(screen, box, ix, y, "Proxy (global)", "#{effective_ip}:#{@port.strip}"); y += 1
-      recap(screen, box, ix, y, "Theme", @theme_name); y += 2
+      recap_labels = ["Proxy (global)", "Theme"]
+      vx = ix + recap_labels.max_of(&.size) + 2 # +2 = min visible gap before the value column
+      recap(screen, box, ix, vx, y, "Proxy (global)", "#{effective_ip}:#{@port.strip}"); y += 1
+      recap(screen, box, ix, vx, y, "Theme", @theme_name); y += 2
       screen.text(ix, y, "New to gori? Take a quick tour of the TUI:", Theme.muted, Theme.panel, width: {box.w - 6, 1}.max)
       y += 1
       render_offer_row(screen, box, y, "Take the guided tour", @offer == :tour); y += 1
       render_offer_row(screen, box, y, "Skip — finish setup", @offer == :skip)
     end
 
-    private def recap(screen : Screen, box : Rect, ix : Int32, y : Int32, key : String, value : String) : Nil
+    private def recap(screen : Screen, box : Rect, ix : Int32, vx : Int32, y : Int32, key : String, value : String) : Nil
       screen.text(ix, y, key, Theme.muted, Theme.panel)
-      vx = ix + 14
       screen.text(vx, y, value, Theme.text_bright, Theme.panel, width: {box.right - vx - 1, 1}.max)
     end
 

--- a/src/gori/tui/tutorial.cr
+++ b/src/gori/tui/tutorial.cr
@@ -41,8 +41,8 @@ module Gori::Tui
     CONTENT_ROWS = 15
     MIN_CARD_H   = 12 # below this the card can't hold a legible mock → "too small"
     CARD_W       = 78
-    HEADER_ROWS  = 2  # brand + progress rail
-    FOOTER_ROWS  = 2  # hint + Prev/Next buttons
+    HEADER_ROWS  =  2 # brand + progress rail
+    FOOTER_ROWS  =  2 # hint + Prev/Next buttons
 
     # Fake palette rows used by the palette lesson + practice overlay.
     PALETTE_ROWS = [
@@ -253,7 +253,14 @@ module Gori::Tui
         @tried_nav = true if @step.navigate?
         return
       end
-      @running = false
+      # Esc only fully exits the tour on the two steps whose footer hint actually
+      # documents it ("esc leave" — Welcome / Done). On every other step esc isn't
+      # (yet) the lesson's move: either the live mock has nothing to pop (not yet
+      # live, or already back at the tab bar), or the passive lesson never claimed
+      # esc at all — silently ending the WHOLE tour there would be a trap, so treat
+      # it as a safe no-op instead (n/b and the Prev/Next buttons remain the only
+      # way to move; progression is never blocked by this).
+      @running = false if @step.welcome? || @step.done?
     end
 
     private def live_shell? : Bool
@@ -457,9 +464,9 @@ module Gori::Tui
         if (row = rows[@pal_sel]?)
           # Mirror a couple of real "Go to …" actions so the palette feels alive.
           case row[1]
-          when "Go to Repeater"  then @p_tab = 1; mark_switch
-          when "Go to History" then @p_tab = 0; mark_switch
-          when "Open Help"     then @p_tab = 4; mark_switch
+          when "Go to Repeater" then @p_tab = 1; mark_switch
+          when "Go to History"  then @p_tab = 0; mark_switch
+          when "Open Help"      then @p_tab = 4; mark_switch
           end
         end
       end
@@ -798,8 +805,8 @@ module Gori::Tui
 
     private def next_btn_label : String
       case @step
-      when Step::Welcome              then " Start "
-      when Step::Done                 then " Finish "
+      when Step::Welcome then " Start "
+      when Step::Done    then " Finish "
       when Step::Practice
         practice_done? ? " Next " : " Skip "
       else " Next "

--- a/src/gori/update.cr
+++ b/src/gori/update.cr
@@ -423,7 +423,11 @@ module Gori
     end
 
     def self.parse_release(json_body : String) : Release
-      data = JSON.parse(json_body)
+      data = begin
+        JSON.parse(json_body)
+      rescue ex : JSON::ParseException
+        raise Error.new("could not parse release information (server did not return valid JSON): #{ex.message}")
+      end
       tag = data["tag_name"]?.try(&.as_s?)
       raise Error.new("release JSON missing tag_name") unless tag
 
@@ -685,6 +689,17 @@ module Gori
             progress_io: progress_io,
             on_progress: on_progress,
             force_progress: force_progress)
+          # Verify against the ACTUAL HTTP Content-Length header, not just whatever
+          # size the (unauthenticated) release JSON claims. A truncated/interrupted
+          # transfer must never be silently accepted just because the JSON's `size`
+          # field is 0 or wrong — this is the one completeness signal the server
+          # can't lie about without also lying to every other HTTP client.
+          if cl > 0 && result != cl
+            File.delete?(dest)
+            raise Error.new(
+              "download truncated for #{url}: expected #{cl} bytes (Content-Length) but received #{result}"
+            )
+          end
         end
         if next_url = redirect_url
           return download_to(next_url, dest, redirects_left - 1,


### PR DESCRIPTION
## Summary

Second round of build-and-dogfood, this time fanning out into the MCP server, Settings/Notes/host-overrides/env, TLS/CA + update, JWT/Convert/Decoder/Hex in the TUI, and Tutorial/Wizard/general polish — plus a manual Scope/Sandbox pass (came back clean, no bug there). Every bug below was reproduced against real traffic or a hand-built repro, root-caused in source, and fixed with verified before/after evidence — several with a control run confirming the added spec fails on the pre-fix code.

- `fix(repeater)` **(critical)**: `repeaters.request` was written as a bound Crystal `String`, and the crystal-sqlite3 driver reads a TEXT-storage-class column via a NUL-terminated `String.new(ptr)` — any request body containing a raw `0x00` byte (a binary body, or a hex-edited byte) silently truncated on every read after the one write. Storage is now `Bytes` end-to-end (mirroring how `response_head`/`response_body` already work), **plus a V2 migration** (`UPDATE repeaters SET request = CAST(request AS BLOB)`) that losslessly recovers already-affected rows for existing users — the bug was read-only, so nothing was ever actually lost on disk, just unreadable through the old path. Verified against the real driver: a 31-byte value with two embedded NULs read back truncated to 5 bytes before the migration, all 31 bytes after. Verified live end-to-end through the TUI: a 5-byte NUL-containing body sent through Repeater to a local echo server arrived byte-exact.
- `fix(env)`: `Env.expand`/`expand_wire`/`mask_secrets` rebuilt text via `String#chars`, silently replacing invalid UTF-8 with U+FFFD even when there was nothing to substitute — corrupting any non-UTF-8 Repeater body on a plain send. Now byte-level (prefix/keys/secrets are pure ASCII, so no decode is needed). Also fixed `gori run project env set KEY value` failing on any value containing `=` (e.g. base64 padding) — the space-vs-`=`-form detection picked the wrong syntax whenever `=` appeared anywhere instead of checking which separator comes first.
- `fix(update)`: a truncated/corrupted download could overwrite the live `gori` binary — the only integrity check trusted the release JSON's unauthenticated `size` field, which a truncated-transfer repro (server reports `size: 0`, connection cut mid-stream) sailed straight past into the atomic install. Now verified against the real HTTP `Content-Length` instead. Also fixed a raw, unhandled crash when the release API returns non-JSON.
- `fix`: `gori tutorial`'s Esc silently exited the whole guided tour on steps that never say it will (including the Practice step's own "esc back" instruction); MCP `preview_rule` accepted an uncompilable regex that `create_rule`/`update_rule` correctly reject; the setup wizard's Review screen ran a label into its value with no space; the Decoder CHAIN field ignored Home/End/Delete unlike its sibling JWT field.

## Test plan

- [x] `crystal spec` — 3255 examples, 0 failures, 0 errors (2 pre-existing pending, unrelated)
- [x] `shards build` / `crystal build src/main.cr -o bin/gori` — clean
- [x] `crystal tool format --check` on every touched file — clean
- [x] `ameba` on every touched file — compared against a `main`-checkout baseline worktree: identical finding count, zero new issues
- [x] Each fix reproduced end-to-end before the fix and re-verified after — see individual commit messages for repro shape
- [x] The Repeater NUL-truncation fix additionally verified with a real migration-recovery test against a hand-built pre-fix (V1-only) database, and live through the actual TUI against a local echo server