### PR TITLE
fix: 11 more confirmed bugs from a third dogfood pass

### DIFF
--- a/spec/cli_run_spec.cr
+++ b/spec/cli_run_spec.cr
@@ -257,6 +257,18 @@ describe Gori::CLI::Output do
     Gori::CLI::Output.term_safe("a\tb\nc").should eq("a·b·c")
   end
 
+  it "term_safe also scrubs invalid UTF-8 (not just control bytes) so JSON output stays valid" do
+    # A captured host/path is raw bytes off the wire (see Sitemap.template_class's comment)
+    # and can be invalid UTF-8 with NO control bytes at all — the old short-circuit
+    # (`return s unless s.each_char.any?(&.control?)`) let such a value straight through
+    # unchanged, since a replacement char isn't itself "control".
+    bad = String.new(Bytes[0x68, 0x69, 0xff, 0x68, 0x69]) # "hi\xFFhi"
+    bad.valid_encoding?.should be_false
+    out = Gori::CLI::Output.term_safe(bad)
+    out.valid_encoding?.should be_true
+    out.should eq("hi�hi")
+  end
+
   it "emits a valid JSON object with the expected keys" do
     json = JSON.parse(Gori::CLI::Output.flow_row_json(flow_row(target: "/a", host: "h", status: 200, state: Gori::Store::FlowState::Complete)))
     json["id"].as_i.should eq(42)
@@ -463,6 +475,31 @@ describe Gori::CLI::Output do
       "GET  h/users/a1b2c3d4-5566-7788-99aa-bbccddeeff00\n")
   end
 
+  it "emits valid UTF-8 in every sitemap format (text/json/paths) when a captured host/path is invalid UTF-8" do
+    # Sitemap.template_class's own comment documents that a captured target is raw bytes off
+    # the wire and can be invalid UTF-8 (a legacy-encoded or fuzzed path). Repro: no control
+    # chars, just a raw 0xFF byte in the host and in a path segment.
+    bad_host = String.new(Bytes[0x62, 0x61, 0x64, 0xff, 0x68, 0x6f, 0x73, 0x74]) # "bad\xFFhost"
+    bad_seg = String.new(Bytes[0x70, 0x61, 0x74, 0x68, 0xff, 0x73, 0x65, 0x67])  # "path\xFFseg"
+    hosts = Gori::Sitemap.build([{bad_host, "GET", "/#{bad_seg}"}])
+    hosts.each { |h| h.endpoints = Gori::Sitemap.endpoint_count(h) }
+
+    text = Gori::CLI::Output.sitemap_text(hosts)
+    text.valid_encoding?.should be_true
+    text.should contain("bad�host")
+    text.should contain("path�seg")
+
+    json_str = Gori::CLI::Output.sitemap_json(hosts)
+    json_str.valid_encoding?.should be_true
+    parsed = JSON.parse(json_str).as_a
+    parsed[0]["host"].as_s.valid_encoding?.should be_true
+    parsed[0]["children"].as_a[0]["label"].as_s.valid_encoding?.should be_true
+
+    paths = Gori::CLI::Output.sitemap_paths(hosts)
+    paths.valid_encoding?.should be_true
+    paths.should contain("bad�host")
+  end
+
   it "does not leak a host tag onto a fold" do
     # Host rows are taggable with path "" — the same value a synthetic fold carries.
     hosts = Gori::Sitemap.build([
@@ -583,5 +620,48 @@ describe "gori run jwt output" do
     text.should contain("[none]")
     text.should contain("alg=none")
     text.should contain(a.token)
+  end
+end
+
+# `show_json` is `private` (CLI-command glue, not a public API) — reopen the module to
+# expose a thin bare-call wrapper for testing, same trick Crystal allows for whitebox
+# specs of private `self.` methods (a bare call from within the same type is permitted;
+# only an explicit-receiver call from outside is not).
+module Gori::CLI::Run
+  def self.show_json_for_spec(detail : Store::FlowDetail, req : Bool, resp : Bool,
+                              ws_msgs : Array(Store::WsMessage) = [] of Store::WsMessage) : String
+    show_json(detail, req, resp, ws_msgs)
+  end
+end
+
+# Regression for the `sse_events.truncated` field: `gori run show --format json` used to
+# hardcode it to `false` regardless of how many events were parsed, while the MCP
+# `get_flow` serializer (mcp/serialize.cr) computed it correctly from `events.size >
+# SSE_EVENTS_MAX`. The two must agree — CLI now reuses the exact same constant.
+describe "gori run show --format json sse_events.truncated" do
+  it "is false when the event count is at or under the cap" do
+    body = String.build { |io| 3.times { |i| io << "data: e#{i}\n\n" } }
+    head = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n"
+    detail = flow_detail("http", "x", 80, "GET / HTTP/1.1\r\nHost: x\r\n\r\n",
+      response_head: head, response_body: body)
+    json = JSON.parse(Gori::CLI::Run.show_json_for_spec(detail, true, true))
+    sse = json["sse_events"]
+    sse["count"].as_i.should eq(3)
+    sse["truncated"].as_bool.should be_false
+  end
+
+  it "is true once the event count exceeds SSE_EVENTS_MAX, matching the MCP serializer" do
+    n = Gori::MCP::Serialize::SSE_EVENTS_MAX + 1
+    body = String.build { |io| n.times { |i| io << "data: e#{i}\n\n" } }
+    head = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n"
+    detail = flow_detail("http", "x", 80, "GET / HTTP/1.1\r\nHost: x\r\n\r\n",
+      response_head: head, response_body: body)
+    json = JSON.parse(Gori::CLI::Run.show_json_for_spec(detail, true, true))
+    sse = json["sse_events"]
+    sse["count"].as_i.should eq(n)
+    sse["truncated"].as_bool.should be_true
+    # the CLI path stays unclipped (a script can read whole values) — unlike MCP, it
+    # does NOT drop events past the cap; `truncated` is a signal, not a clip.
+    sse["events"].as_a.size.should eq(n)
   end
 end

--- a/spec/env_spec.cr
+++ b/spec/env_spec.cr
@@ -103,6 +103,70 @@ describe Gori::Env do
     Gori::Settings.env_prefix = "$"
   end
 
+  # Regression: normalize_crlf used to run over the WHOLE buffer (head + body), so a bare
+  # 0x0A byte inside a binary/compressed BODY — not a line ending — got a spurious 0x0D
+  # inserted in front of it. Silent corruption: Content-Length gets resynced to the
+  # already-corrupted body afterward, so nothing downstream notices the mismatch. Only the
+  # HEAD (through the blank-line separator) may be CRLF-normalized; the body must round-trip
+  # byte-exact regardless of what bytes it contains.
+  it "expand_wire leaves a bare LF byte in the BODY untouched (head-only CRLF normalization)" do
+    Gori::Settings.env_prefix = "$"
+    Gori::Settings.env_vars = [] of {String, String}
+    Gori::Settings.project_env_vars = [] of {String, String}
+    # LF-joined head (editor storage form) + a body with a bare LF, a lone CR, and an
+    # already-CRLF pair — none of these body bytes are line endings and must survive as-is.
+    text = "POST / HTTP/1.1\nHost: x\nContent-Length: 6\n\n" + String.new(Bytes[0x41, 0x0A, 0x42, 0x0D, 0x0A, 0x43])
+    result = Gori::Env.expand_wire(text)
+    expected_head = "POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 6\r\n\r\n".to_slice
+    expected_body = Bytes[0x41, 0x0A, 0x42, 0x0D, 0x0A, 0x43] # unchanged: A LF B CR LF C
+    result[0, expected_head.size].should eq(expected_head)
+    result[expected_head.size, expected_body.size].should eq(expected_body)
+    result.size.should eq(expected_head.size + expected_body.size)
+  ensure
+    Gori::Settings.env_prefix = "$"
+  end
+
+  it "expand_wire normalizes an already-CRLF head and leaves a bare-LF body untouched" do
+    Gori::Settings.env_prefix = "$"
+    Gori::Settings.env_vars = [] of {String, String}
+    Gori::Settings.project_env_vars = [] of {String, String}
+    # Already-CRLF head (e.g. captured flow bytes) — must not double to \r\r\n — followed
+    # by a bare-LF body that must stay untouched.
+    text = "POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 3\r\n\r\n" + String.new(Bytes[0x41, 0x0A, 0x42])
+    result = Gori::Env.expand_wire(text)
+    expected_head = "POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 3\r\n\r\n".to_slice
+    expected_body = Bytes[0x41, 0x0A, 0x42]
+    result[0, expected_head.size].should eq(expected_head)
+    result[expected_head.size, expected_body.size].should eq(expected_body)
+    result.size.should eq(expected_head.size + expected_body.size)
+  ensure
+    Gori::Settings.env_prefix = "$"
+  end
+
+  it "expand_wire substitutes a $KEY in the head while a bare-LF body stays untouched" do
+    Gori::Settings.env_prefix = "$"
+    Gori::Settings.env_vars = [{"TOKEN", "secret"}]
+    Gori::Settings.project_env_vars = [] of {String, String}
+    text = "POST / HTTP/1.1\nHost: x\nAuth: $TOKEN\nContent-Length: 3\n\n" + String.new(Bytes[0x41, 0x0A, 0x42])
+    result = Gori::Env.expand_wire(text)
+    expected_head = "POST / HTTP/1.1\r\nHost: x\r\nAuth: secret\r\nContent-Length: 3\r\n\r\n".to_slice
+    expected_body = Bytes[0x41, 0x0A, 0x42]
+    result[0, expected_head.size].should eq(expected_head)
+    result[expected_head.size, expected_body.size].should eq(expected_body)
+  ensure
+    Gori::Settings.env_vars = [] of {String, String}
+    Gori::Settings.env_prefix = "$"
+  end
+
+  it "expand_wire normalizes the whole buffer when there is no blank-line separator (all-head, no body)" do
+    Gori::Settings.env_prefix = "$"
+    Gori::Settings.env_vars = [] of {String, String}
+    Gori::Settings.project_env_vars = [] of {String, String}
+    Gori::Env.expand_wire("GET / HTTP/1.1\nHost: x").should eq("GET / HTTP/1.1\r\nHost: x".to_slice)
+  ensure
+    Gori::Settings.env_prefix = "$"
+  end
+
   it "mask_secrets passes invalid UTF-8 bytes through unchanged when nothing matches" do
     vars = {"TOKEN" => "s3cr3tXY"}
     bad = Bytes[0x41, 0x80, 0x42, 0xE2, 0x28, 0x43]

--- a/spec/fuzz_spec.cr
+++ b/spec/fuzz_spec.cr
@@ -445,6 +445,61 @@ describe F::Matcher do
     e.extract = /(a+)+$/
     e.build(job, ok_result(200, evil)).extracted.should be_nil
   end
+
+  it "auto-calibration (multi-sample) suppresses EVERY sampled baseline shape, not just one, " \
+     "and never suppresses a status-flip anomaly (the original single-snapshot bug: only " \
+     "whichever ONE shape the lone baseline call happened to catch got dropped)" do
+    m = F::Matcher.new(auto_calibrate: true)
+    job = F::Job.new(0_i64, ["x"], nil, "".to_slice)
+    # As if Engine#calibrate_baseline sampled a target that rotates between two distinct
+    # 200-status shapes ("a"*100 and "a"*250 have no whitespace → 1 word, 0 lines each).
+    m.baseline = [
+      F::BaselineSample.new(F::Metrics.new(200, 100_i64, 1, 0, 0_i64), 6),
+      F::BaselineSample.new(F::Metrics.new(200, 250_i64, 1, 0, 0_i64), 11),
+    ]
+    m.build(job, ok_result(200, "a" * 100)).matched?.should be_false # shape 1 — calibrated out
+    m.build(job, ok_result(200, "a" * 250)).matched?.should be_false # shape 2 — ALSO calibrated out
+    m.build(job, ok_result(200, "a" * 400)).matched?.should be_true  # neither sampled shape — reported
+    # Same size/words as a sampled shape, but status flips — never calibrated out.
+    m.build(job, ok_result(500, "a" * 100)).matched?.should be_true
+  end
+
+  it "Matcher.reflects_length? detects response length tracking payload length across the " \
+     "staggered calibration samples, and does not false-positive on merely-noisy (rotating, " \
+     "non-tracking) samples" do
+    reflecting = [
+      F::BaselineSample.new(F::Metrics.new(200, 120_i64, 5, 1, 0_i64), 6),
+      F::BaselineSample.new(F::Metrics.new(200, 125_i64, 5, 1, 0_i64), 11),
+      F::BaselineSample.new(F::Metrics.new(200, 130_i64, 5, 1, 0_i64), 16),
+    ]
+    F::Matcher.reflects_length?(reflecting).should be_true
+
+    rotating = [
+      F::BaselineSample.new(F::Metrics.new(200, 100_i64, 20, 1, 0_i64), 6),
+      F::BaselineSample.new(F::Metrics.new(200, 250_i64, 45, 1, 0_i64), 11),
+      F::BaselineSample.new(F::Metrics.new(200, 150_i64, 30, 1, 0_i64), 16),
+    ]
+    F::Matcher.reflects_length?(rotating).should be_false
+  end
+
+  it "auto-calibration falls back to word/line counts when response length reflects payload " \
+     "length (a target that echoes the fuzzed value back — the harder, continuously-varying " \
+     "proven-broken scenario, where no finite exact-length baseline SET could ever suffice)" do
+    m = F::Matcher.new(auto_calibrate: true)
+    m.baseline = [
+      F::BaselineSample.new(F::Metrics.new(200, 108_i64, 1, 0, 0_i64), 6),
+      F::BaselineSample.new(F::Metrics.new(200, 118_i64, 1, 0, 0_i64), 16),
+    ]
+    m.reflects_length?.should be_true
+    job = F::Job.new(0_i64, ["x"], nil, "".to_slice)
+    # A payload length NEVER sampled (30) whose reflected body is a new exact byte length —
+    # an exact-length-against-a-set match would never fire here; the word/line fallback still
+    # recognizes the same (1 word, 0 lines) noise shape.
+    m.build(job, ok_result(200, "R:" + "a" * 30)).matched?.should be_false
+    # A genuine anomaly (extra words/lines) still flags despite sharing the baseline's status.
+    m.build(job, ok_result(200, "totally different shape\nwith another line")).matched?.should be_true
+    m.build(job, ok_result(500, "R:" + "a" * 30)).matched?.should be_true
+  end
 end
 
 describe F::Engine do
@@ -462,6 +517,38 @@ describe F::Engine do
     backend.sent.should eq(4)
     done.as(F::DoneEvent).progress.matched.should eq(4)
     done.as(F::DoneEvent).stopped.should be_false
+  end
+
+  it "auto-calibration end-to-end: calibrate_baseline's synthetic sends capture EVERY shape " \
+     "of a rotating-noise target, so the whole sweep is suppressed except a seeded status " \
+     "anomaly planted mid-sweep (reproduces the reported bug: a single-snapshot baseline let " \
+     "75/100 rotating-noise responses through; multi-sample calibration must let through only " \
+     "the genuine anomaly)" do
+    shapes = [100, 150, 200, 250] # 4 fixed "normal" body shapes, keyed off a global counter
+    n = 0
+    backend = FakeBackend.new(F::Origin.new("http", "h", 80)) do |bytes|
+      if String.new(bytes).includes?("ANOMALY")
+        ok_result(500, "Z" * 4000) # the genuine, never-to-be-suppressed anomaly
+      else
+        n += 1
+        ok_result(200, "x" * shapes[n % shapes.size])
+      end
+    end
+    payloads = (1..16).map { |i| "noise#{i}" }
+    payloads.insert(8, "ANOMALY") # planted mid-sweep (17 payloads total)
+    set = F::PayloadSet.new(F::InlineList.new(payloads))
+    cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: 1, auto_calibrate: true)
+    gen = F::Generator.new(base, [set], cfg)
+    matcher = F::Matcher.new(auto_calibrate: true)
+    engine = F::Engine.new(gen, matcher, backend, cfg)
+    engine.calibrate_baseline # CALIBRATION_SAMPLES (6) synthetic sends — ≥ the rotation's
+    # period of 4, so every shape gets captured regardless of which phase calibration starts on.
+    results, _ = drain(engine)
+
+    results.size.should eq(17)
+    matched = results.select(&.matched?)
+    matched.size.should eq(1) # only the anomaly — 0 false positives among the 16 noise rows
+    matched.first.status.should eq(500)
   end
 
   it "retries on a network error up to the configured count" do

--- a/spec/import/import_spec.cr
+++ b/spec/import/import_spec.cr
@@ -416,4 +416,86 @@ describe Gori::Import do
       File.delete?(urls)
     end
   end
+
+  it "skips a HAR entry whose URL carries a CRLF injection instead of importing a fabricated request" do
+    har = File.tempname("gori", ".har")
+    begin
+      # The malicious entry's URL smuggles a second fake request via literal CRLFs. Left
+      # unchecked this used to land straight in the stored request line/History row.
+      File.write(har, {log: {entries: [
+        {request: {method: "GET", url: "https://a.test/1"}, response: {status: 200, content: {text: "ok"}}},
+        {request:  {method: "GET", url: "https://evil.test/path\r\nX-Injected: pwn\r\n\r\nGET /second HTTP/1.1"},
+         response: {status: 200, content: {text: "ok"}}},
+        {request: {method: "GET", url: "https://a.test/2"}, response: {status: 200, content: {text: "ok"}}},
+      ]}}.to_json)
+      with_store do |store|
+        result = Gori::Import.import_file(store, :har, har)
+        result.count.should eq(2)   # the two clean entries imported
+        result.skipped.should eq(1) # the CRLF-injected entry skipped, not fabricated
+        store.count.should eq(2)
+        rows = store.search(Gori::QL::EMPTY, 10)
+        rows.each { |r| r.target.should_not match(/[\r\n]/) }
+        rows.map(&.host).sort.should eq(["a.test", "a.test"])
+      end
+    ensure
+      File.delete?(har)
+    end
+  end
+
+  it "skips a URL-list line with a raw control character in the path" do
+    urls = File.tempname("gori", ".txt")
+    begin
+      File.write(urls, "https://a.test/1\nhttp://a.test/\x01\x02control\nhttps://a.test/2\n")
+      with_store do |store|
+        result = Gori::Import.import_file(store, :urls, urls)
+        result.count.should eq(2)   # the two clean lines imported
+        result.skipped.should eq(1) # the control-char line skipped
+        store.count.should eq(2)
+      end
+    ensure
+      File.delete?(urls)
+    end
+  end
+
+  it "raises a clean Gori::Error for a HAR file that is not valid JSON" do
+    har = File.tempname("gori", ".har")
+    begin
+      File.write(har, "not json at all {{{")
+      with_store do |store|
+        expect_raises(Gori::Error, /not valid JSON/) do
+          Gori::Import.import_file(store, :har, har)
+        end
+      end
+    ensure
+      File.delete?(har)
+    end
+  end
+
+  it "raises a clean Gori::Error for an OpenAPI .yaml file that is not valid YAML" do
+    oas = File.tempname("gori", ".yaml")
+    begin
+      File.write(oas, "paths: [unclosed")
+      with_store do |store|
+        expect_raises(Gori::Error, /not valid YAML/) do
+          Gori::Import.import_file(store, :oas, oas)
+        end
+      end
+    ensure
+      File.delete?(oas)
+    end
+  end
+
+  it "raises a clean Gori::Error for a .json-named OpenAPI file with YAML-only (non-JSON) syntax" do
+    oas = File.tempname("gori", ".json")
+    begin
+      File.write(oas, "paths:\n  /x:\n    get: {}\n")
+      with_store do |store|
+        expect_raises(Gori::Error, /not valid JSON/) do
+          Gori::Import.import_file(store, :oas, oas)
+        end
+      end
+    ensure
+      File.delete?(oas)
+    end
+  end
 end

--- a/spec/issues_export_spec.cr
+++ b/spec/issues_export_spec.cr
@@ -1,5 +1,6 @@
 require "./spec_helper"
 require "compress/gzip"
+require "json"
 require "../src/gori/issues_export"
 
 private def gzip(data : String) : Bytes
@@ -55,6 +56,17 @@ describe Gori::Issues::Export do
       out = Gori::Issues::Export.one_line(String.new(Bytes[0x61, 0x80, 0x62]))
       out.should_not be_empty
       out.valid_encoding?.should be_true
+    end
+  end
+
+  describe ".scrub_only" do
+    it "fixes invalid UTF-8 but leaves newlines/control characters untouched" do
+      # notes is multi-line by design — the encoding-safety half of one_line, without its
+      # newline-collapsing half, since collapsing would mangle a legitimate multi-line note.
+      scrubbed = Gori::Issues::Export.scrub_only(String.new(Bytes[0x6c, 0x31, 0xff, 0x0a, 0x6c, 0x32])) # "l1\xFF\nl2"
+      scrubbed.valid_encoding?.should be_true
+      scrubbed.should eq("l1�\nl2")
+      scrubbed.lines.size.should eq(2) # the newline survived
     end
   end
 
@@ -177,6 +189,51 @@ describe Gori::Issues::Export do
         md.lines.count { |l| l.strip == "```" }.should eq(0)
         md.lines.any? { |l| l.starts_with?("## INJECTED") }.should be_false
         md.should contain("- **Host:** evil.test ``` ## INJECTED VIA HOST")
+      end
+    end
+
+    it "does not raise on a multi-line notes field with an invalid UTF-8 byte, and keeps its newlines" do
+      # Bug: title/host were routed through one_line (which scrubs), but the notes line
+      # (`io << f.notes` directly) was not — the ONE field markdown's own .scrub convention
+      # missed. notes is multi-line by design, so it needs scrub_only, not one_line.
+      with_store do |store|
+        id = store.insert_issue("clean title", Gori::Store::Severity::Low, "clean.host", nil)
+        store.update_issue(id, notes: String.new(Bytes[0x6c, 0x31, 0xff, 0x0a, 0x6c, 0x32])) # "l1\xFF\nl2"
+
+        md = Gori::Issues::Export.markdown(store.issues, store, "proj")
+        md.valid_encoding?.should be_true
+        md.should contain("l1�\nl2") # newline preserved, invalid byte scrubbed to U+FFFD
+      end
+    end
+  end
+
+  describe ".json" do
+    it "does not raise and stays valid UTF-8 when title/host/notes carry a raw invalid byte" do
+      # Unlike .markdown's one_line() convention, .json wrote these fields straight into
+      # JSON::Builder, which performs NO UTF-8 validation — an invalid byte (e.g. a captured
+      # h2 :authority) passed straight through to `gori run issues --format json`.
+      with_store do |store|
+        id = store.insert_issue(String.new(Bytes[0x62, 0x61, 0x64, 0xff, 0x74]), # "bad\xFFt"
+          Gori::Store::Severity::High, String.new(Bytes[0x68, 0xff, 0x6f]),      # "h\xFFo"
+          nil        )
+        store.update_issue(id, notes: String.new(Bytes[0x6e, 0x31, 0xff, 0x0a, 0x6e, 0x32])) # "n1\xFF\nn2"
+
+        json_out = Gori::Issues::Export.json(store.issues, store)
+        json_out.valid_encoding?.should be_true
+        parsed = JSON.parse(json_out) # would raise on malformed JSON; also proves it's parseable
+        issue = parsed.as_a.first
+        issue["title"].as_s.valid_encoding?.should be_true
+        issue["host"].as_s.valid_encoding?.should be_true
+        issue["notes"].as_s.valid_encoding?.should be_true
+        issue["notes"].as_s.lines.size.should eq(2) # notes keeps its newline (scrub_only, not one_line)
+      end
+    end
+
+    it "emits null for a nil host, not the string 'null'" do
+      with_store do |store|
+        store.insert_issue("t", Gori::Store::Severity::Info, nil, nil)
+        parsed = JSON.parse(Gori::Issues::Export.json(store.issues, store))
+        parsed.as_a.first["host"].raw.should be_nil
       end
     end
   end

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -1421,6 +1421,54 @@ describe Gori::MCP::Server do
         payload["total"].as_i.should eq(2)
       end
     end
+
+    it "keeps the JSON-RPC response line valid UTF-8 when title/host/notes carry a raw invalid byte" do
+      # Same captured-data-can-be-invalid-UTF-8 gap as Issues::Export.json (Serialize.issue
+      # wrote these fields unscrubbed) — but here an unscrubbed byte breaks the WIRE response
+      # line itself, a genuine JSON-RPC protocol violation a real client could choke on.
+      # JSON.parse in Crystal does NOT validate embedded string bytes (confirmed separately),
+      # so the meaningful assertion is `valid_encoding?` on the raw response, not just that
+      # parsing succeeds.
+      with_store do |store|
+        id = store.insert_issue(String.new(Bytes[0x62, 0x61, 0x64, 0xff, 0x74]), # "bad\xFFt"
+          Gori::Store::Severity::High, String.new(Bytes[0x68, 0xff, 0x6f]),      # "h\xFFo"
+          nil        )
+        store.update_issue(id, notes: String.new(Bytes[0x6e, 0x31, 0xff, 0x0a, 0x6e, 0x32])) # "n1\xFF\nn2"
+        store.flush
+
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_issues","arguments":{}}})
+        resp = drive(store, call)[0]
+        # the literal wire value a real client reads: content[0].text (the nested JSON text)
+        resp["result"]["content"][0]["text"].as_s.valid_encoding?.should be_true
+
+        issue = tool_payload(resp)["issues"].as_a.first
+        issue["title"].as_s.valid_encoding?.should be_true
+        issue["host"].as_s.valid_encoding?.should be_true
+        issue["notes"].as_s.valid_encoding?.should be_true
+        issue["notes"].as_s.lines.size.should eq(2) # notes keeps its newline
+      end
+    end
+  end
+
+  describe "get_issue" do
+    it "keeps the JSON-RPC response line valid UTF-8 when title/host/notes carry a raw invalid byte" do
+      with_store do |store|
+        id = store.insert_issue(String.new(Bytes[0x62, 0x61, 0x64, 0xff, 0x74]),
+          Gori::Store::Severity::High, String.new(Bytes[0x68, 0xff, 0x6f]), nil)
+        store.update_issue(id, notes: String.new(Bytes[0x6e, 0x31, 0xff, 0x0a, 0x6e, 0x32]))
+        store.flush
+
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_issue","arguments":{"id":#{id}}}})
+        resp = drive(store, call)[0]
+        # the literal wire value a real client reads: content[0].text (the nested JSON text)
+        resp["result"]["content"][0]["text"].as_s.valid_encoding?.should be_true
+
+        issue = tool_payload(resp)
+        issue["title"].as_s.valid_encoding?.should be_true
+        issue["host"].as_s.valid_encoding?.should be_true
+        issue["notes"].as_s.valid_encoding?.should be_true
+      end
+    end
   end
 
   describe "error channels" do

--- a/spec/scope_spec.cr
+++ b/spec/scope_spec.cr
@@ -264,6 +264,64 @@ describe Gori::Scope do
     end
   end
 
+  it "reload picks up an external scope edit on the SAME live instance (Sitemap's data_version " \
+     "poll / headless capture's periodic reload)" do
+    with_store do |store|
+      # `live` stands in for the Scope object a Session hands to the Sitemap/Interceptor/
+      # Sandbox gate — held for a while, never re-`load`ed. `editor` stands in for a
+      # separate `gori run project scope add/rm` process (or another instance's TUI)
+      # writing to the SAME store.
+      live = Gori::Scope.load(store)
+      live.host_in_scope?("acme.test").should be_false # no rules yet → nothing to mark
+
+      editor = Gori::Scope.load(store)
+      editor.add("include", "host", "acme.test")
+
+      # the external add is invisible to `live` until it reloads
+      live.host_in_scope?("acme.test").should be_false
+      live.configured?.should be_false
+
+      live.reload
+      live.configured?.should be_true
+      live.host_in_scope?("acme.test").should be_true
+
+      # removing externally is picked up the same way
+      id = live.rules.first.id
+      editor.remove(id)
+      live.host_in_scope?("acme.test").should be_true # still stale
+      live.reload
+      live.host_in_scope?("acme.test").should be_false
+      live.configured?.should be_false
+    end
+  end
+
+  it "reload picks up an external enabled/sandbox flag flip alongside rule edits" do
+    with_store do |store|
+      live = Gori::Scope.load(store)
+      live.enabled?.should be_false
+      live.sandbox?.should be_false
+
+      editor = Gori::Scope.load(store)
+      editor.add("include", "host", "acme.test")
+      editor.enable
+      editor.enable_sandbox
+
+      live.enabled?.should be_false # stale
+      live.sandbox?.should be_false
+      live.reload
+      live.enabled?.should be_true
+      live.sandbox?.should be_true
+      live.active?.should be_true
+
+      editor.disable_sandbox
+      editor.disable
+      live.sandbox?.should be_true # still stale
+      live.reload
+      live.enabled?.should be_false
+      live.sandbox?.should be_false
+    end
+  end
+
   it "migrates pre-V13 bare host patterns to include/host rows" do
     with_store do |store|
       store.add_scope_rule("include", "host", "legacy.test")
@@ -350,11 +408,11 @@ describe Gori::Scope do
         scope = Gori::Scope.load(store)
         scope.add("include", "host", "acme.test")
         scope.enable_sandbox
-        scope.sandbox_blocks_host?("acme.test").should be_false      # included
-        scope.sandbox_blocks_host?("api.acme.test").should be_false  # subdomain of an include
-        scope.sandbox_blocks_host?("evil.test").should be_true       # no include covers it
+        scope.sandbox_blocks_host?("acme.test").should be_false     # included
+        scope.sandbox_blocks_host?("api.acme.test").should be_false # subdomain of an include
+        scope.sandbox_blocks_host?("evil.test").should be_true      # no include covers it
         scope.add("exclude", "host", "cdn.acme.test")
-        scope.sandbox_blocks_host?("cdn.acme.test").should be_true   # host-level exclude
+        scope.sandbox_blocks_host?("cdn.acme.test").should be_true # host-level exclude
       end
     end
 

--- a/src/gori/app.cr
+++ b/src/gori/app.cr
@@ -36,13 +36,17 @@ module Gori
     getter ca : Proxy::Tls::CertAuthority
     getter registry : Verb::Registry
 
-    # How often headless `gori run capture` re-reads Rewriter rules from the store, so
-    # `gori run rewriter add/rm/enable/disable` against the SAME running project take
-    # effect without a restart (docs/content/guide/proxy.md promises "no restart"). The
-    # TUI gets this on demand via the `r` key (Rewriter::rewriter_reload); headless has no
-    # keyboard to press, so it polls instead. A couple of seconds keeps external edits
-    # feeling live without hammering the store — matching the OAST poller's interval scale.
-    REWRITER_RELOAD_INTERVAL = 2.seconds
+    # How often headless `gori run capture` re-reads Rewriter rules AND Scope from the
+    # store, so `gori run rewriter add/rm/enable/disable` / `gori run project scope
+    # add/rm` against the SAME running project take effect without a restart
+    # (docs/content/guide/proxy.md promises "no restart" for Rewriter; Scope has the
+    # same expectation — its Sandbox gate is enforced off this SAME live object). The TUI
+    # gets Rewriter on demand via the `r` key (Rewriter::rewriter_reload) and Scope via its
+    # own store data_version poll (Runner#apply_external_change); headless has neither a
+    # keyboard nor that poll, so it re-reads both on a timer instead. A couple of seconds
+    # keeps external edits feeling live without hammering the store — matching the OAST
+    # poller's interval scale.
+    RELOAD_POLL_INTERVAL = 2.seconds
 
     def initialize(@config : Config)
       Paths.ensure_dirs
@@ -59,7 +63,8 @@ module Gori
     # falls through to the normal picker below, so navigating elsewhere afterward
     # still works.
     def run_tui(open_db_path : String? = nil) : Nil
-      setup_logging(File.open(File.join(Paths.home_dir, "gori.log"), "a"))
+      log_io = File.open(File.join(Paths.home_dir, "gori.log"), "a")
+      setup_logging(log_io)
       Tui::Theme.load_custom           # register user themes from <GORI_HOME>/themes/*.json
       Tui::Theme.apply(Settings.theme) # honour the persisted theme from the first frame (picker included)
       projects = ProjectRegistry.new(Paths.projects_dir)
@@ -67,6 +72,15 @@ module Gori
       # first-run wizard auto-launched below, so a no-tty run (CI/detached) gets a clean
       # message instead of a raw backtrace.
       term = Tui.open_terminal("run it directly, not under CI or a detached/background job, or use 'gori run capture' for non-interactive capture")
+      # Termisu.new (just above) unconditionally runs its OWN `Log.setup("*", ...)`, aimed at
+      # TERMISU_LOG_FILE (default /tmp/termisu.log, a shared, unbounded, non-project-scoped
+      # file). Crystal's `Log.setup` always fully reconfigures the root logger (clears prior
+      # bindings first), so whichever call runs LAST wins process-wide — Termisu's call would
+      # otherwise silently swallow every subsequent `Log.*` call gori itself makes, including
+      # the "failed to open session" error this TUI depends on landing in gori.log. Re-assert
+      # gori's binding now that Termisu has had its say, so it's the one left standing
+      # regardless of what Termisu does internally (same io — no new fd, no duplicate lines).
+      setup_logging(log_io)
 
       begin
         # enable_* run INSIDE the begin so `ensure term.close` restores the tty if either
@@ -126,7 +140,7 @@ module Gori
       end
       print_banner(session)
       spawn { capture_printer(session, format, max) }
-      reload_stop = spawn_rewriter_reload_loop(session)
+      reload_stop = spawn_reload_loop(session)
       install_signal_traps
       if span = every
         # Wall-clock terminator: nudge the same shutdown channel the signal traps use.
@@ -208,26 +222,35 @@ module Gori
       @shutdown.send(nil) rescue nil
     end
 
-    # Periodically re-reads Rewriter rules from the store for the lifetime of a headless
-    # capture session — same effect as the TUI's manual `r` key
-    # (Rules#reload / rewriter_controller#rewriter_reload), just on a timer instead of a
-    # keypress. Returns an unbuffered stop channel: sending to it blocks until the loop is
-    # parked back at `select` (i.e. not mid-reload), so the caller can safely close the
-    # session right after — no fiber left querying a closed store handle.
-    private def spawn_rewriter_reload_loop(session : Session) : Channel(Nil)
+    # Periodically re-reads Rewriter rules AND Scope from the store for the lifetime of a
+    # headless capture session. Rewriter mirrors the TUI's manual `r` key (Rules#reload /
+    # rewriter_controller#rewriter_reload); Scope mirrors the TUI's own data_version poll
+    # (Runner#apply_external_change → Scope#reload) — headless has neither a keypress nor
+    # that poll, so both ride the SAME timer/fiber here instead. One fiber, one stop
+    # channel, both reloads per tick — no need to duplicate the fiber-management
+    # boilerplate per object. Returns an unbuffered stop channel: sending to it blocks
+    # until the loop is parked back at `select` (i.e. not mid-reload), so the caller can
+    # safely close the session right after — no fiber left querying a closed store handle.
+    private def spawn_reload_loop(session : Session) : Channel(Nil)
       stop = Channel(Nil).new
-      spawn(name: "gori-capture-rewriter-reload") do
+      spawn(name: "gori-capture-reload") do
         loop do
           select
           when stop.receive
             break
-          when timeout(REWRITER_RELOAD_INTERVAL)
+          when timeout(RELOAD_POLL_INTERVAL)
+            # Each reload is guarded independently so a transient store hiccup on one
+            # (or a bad regex/glob resurfacing as an exception) can't skip the other —
+            # log and try both again next tick.
             begin
               session.rules.reload
             rescue ex
-              # A transient store hiccup must not kill the reload loop for the rest of
-              # the capture session — log and try again next tick.
               Log.error(exception: ex) { "rewriter rule reload failed" }
+            end
+            begin
+              session.scope.reload
+            rescue ex
+              Log.error(exception: ex) { "scope rule reload failed" }
             end
           end
         end

--- a/src/gori/cli/output.cr
+++ b/src/gori/cli/output.cr
@@ -46,7 +46,15 @@ module Gori
       # sequences in its request line (method / host / target), which `puts` would
       # otherwise inject verbatim into the operator's terminal (and re-inject on every
       # later view). Replace every control char (incl. ESC, CR/LF, tab, C1) with '·'.
+      #
+      # Also scrubs invalid UTF-8 first: a captured host/path is raw bytes off the wire
+      # (see Sitemap.template_class's comment) and can be invalid UTF-8 without containing
+      # a single control byte, which JSON::Builder does NOT validate — the sitemap JSON/text/
+      # paths exports all route through this, so an unscrubbed value here reaches STDOUT as
+      # invalid UTF-8. `.scrub` is a no-op (returns self, no allocation) on the common
+      # valid-UTF-8 case, so this stays free when there's nothing to fix.
       def self.term_safe(s : String) : String
+        s = s.scrub
         return s unless s.each_char.any?(&.control?)
         String.build { |io| s.each_char { |c| io << (c.control? ? '·' : c) } }
       end
@@ -56,6 +64,7 @@ module Gori
       # for captured text written to a live terminal (the `show`/`repeater` text views).
       # `--format raw` stays the exact-bytes path for scripts/redirection.
       def self.term_safe_multiline(s : String) : String
+        s = s.scrub
         return s unless s.each_char.any? { |c| c.control? && c != '\n' && c != '\t' }
         String.build { |io| s.each_char { |c| io << ((c.control? && c != '\n' && c != '\t') ? '·' : c) } }
       end
@@ -394,10 +403,13 @@ module Gori
 
       private def self.sitemap_host_json(j : JSON::Builder, host : Sitemap::Node) : Nil
         j.object do
-          j.field "host", host.label
+          # host.label/tag are captured/user data and can be invalid UTF-8 (see
+          # Sitemap.template_class) — term_safe scrubs that (and strips control bytes),
+          # so this stays valid UTF-8 JSON like the text/paths formats already are.
+          j.field "host", term_safe(host.label)
           j.field "endpoints", host.endpoints
           if t = host.tag
-            j.field "tag", t
+            j.field "tag", term_safe(t)
           end
           sitemap_children_json(j, host)
         end
@@ -405,23 +417,23 @@ module Gori
 
       private def self.sitemap_node_json(j : JSON::Builder, node : Sitemap::Node) : Nil
         j.object do
-          j.field "label", node.label
+          j.field "label", term_safe(node.label)
           # A fold is synthetic — its `path` is always "" and carries no meaning, so it is
           # omitted rather than emitted as an empty string. `template` names the id class
           # so a consumer can tell an id fold from a numeric run without parsing labels.
           if node.grouped
             j.field "grouped", true
-            j.field "template", node.label if node.template?
+            j.field "template", node.label if node.template? # one of TEMPLATE_LABELS: always plain ASCII
           else
-            j.field "path", node.path
+            j.field "path", term_safe(node.path)
           end
           # On a fold these are the union of its children's verbs, not its own.
           verbs = node.grouped ? node.fold_methods : node.methods
           unless verbs.empty?
-            j.field("methods") { j.array { verbs.each { |m| j.string(m) } } }
+            j.field("methods") { j.array { verbs.each { |m| j.string(term_safe(m)) } } }
           end
           if t = node.tag
-            j.field "tag", t
+            j.field "tag", term_safe(t)
           end
           sitemap_children_json(j, node)
         end

--- a/src/gori/cli/run/fuzz.cr
+++ b/src/gori/cli/run/fuzz.cr
@@ -74,7 +74,7 @@ module Gori
           p.on("--mr=REGEX", "Match response-body regex") { |v| matcher.match_regex = parse_regex(v) }
           p.on("--fr=REGEX", "Filter out response-body regex") { |v| matcher.filter_regex = parse_regex(v) }
           p.on("--extract=REGEX", "Grep-extract a value from each response (capture group 1)") { |v| matcher.extract = parse_regex(v) }
-          p.on("--ac", "Auto-calibrate: drop responses identical to the baseline") { auto_cal = true }
+          p.on("--ac", "Auto-calibrate: sample the target's noise and drop matching responses") { auto_cal = true }
           p.on("--format=FMT", "Output: text (default) | json | jsonl") { |v| format = parse_format(v, [:text, :json, :jsonl]) }
           p.on("--force", "Run even when the request count is huge or unknown") { force = true }
           p.on("--fail-if-no-matches", "Exit 3 when no result matched") { fail_if_no_matches = true }

--- a/src/gori/cli/run/history.cr
+++ b/src/gori/cli/run/history.cr
@@ -297,7 +297,11 @@ module Gori
                 j.field "sse_events" do
                   j.object do
                     j.field "count", events.size
-                    j.field "truncated", false
+                    # Same cap/expression as the MCP serializer (mcp/serialize.cr
+                    # `emit_sse_events`) — was hardcoded `false` here, so a caller
+                    # reading only `sse_events` (the point of --format json) had no
+                    # signal the array was clipped.
+                    j.field "truncated", events.size > MCP::Serialize::SSE_EVENTS_MAX
                     j.field "events" do
                       j.array do
                         events.each do |e|

--- a/src/gori/env.cr
+++ b/src/gori/env.cr
@@ -40,9 +40,29 @@ module Gori
     # `Regex` (gsub) *requires* valid UTF-8 and raises `ArgumentError` on a subject
     # string that isn't — which a captured flow's binary body routinely isn't. See
     # `expand` below for why the text reaching this point may carry invalid UTF-8.
+    #
+    # CRLF normalization is HEAD-ONLY: a raw `0x0A` inside the BODY is just a byte
+    # (binary/compressed data, or a bare LF a client legitimately sent) — not a line
+    # ending — and must never be rewritten to `0x0D 0x0A`. Only HTTP header lines
+    # require CRLF termination on the wire; the editors that feed this (Repeater,
+    # Miner) store the whole head+body blob as one LF-joined buffer, so naively
+    # normalizing the entire buffer corrupted every bare-LF byte in the body
+    # (silently, since Content-Length gets resynced to the corrupted body
+    # afterward). `head_body_boundary` locates the blank-line separator first;
+    # only the head (through and including that separator) is normalized, and the
+    # body is copied through byte-for-byte untouched.
     def self.expand_wire(text : String, vars : Hash(String, String) = effective_vars,
                          prefix : String = Settings.env_prefix) : Bytes
-      normalize_crlf(expand(text, vars, prefix).to_slice)
+      bytes = expand(text, vars, prefix).to_slice
+      boundary = head_body_boundary(bytes)
+      head = normalize_crlf(bytes[0...boundary])
+      return head if boundary >= bytes.size
+
+      body = bytes[boundary..]
+      buf = IO::Memory.new(head.size + body.size)
+      buf.write(head)
+      buf.write(body)
+      buf.to_slice
     end
 
     # Substitute registered `prefix+KEY` tokens; unknown keys stay literal.
@@ -89,6 +109,29 @@ module Gori
         end
       end
       String.new(buf.to_slice)
+    end
+
+    # Finds the head/body boundary in wire-form text: the byte offset where the
+    # body starts, right after the first blank line. Checks for both a bare
+    # `\n\n` (how the Repeater/Miner editors store the blob internally) and,
+    # defensively, an already-CRLF `\r\n\r\n` (e.g. captured flow bytes loaded
+    # verbatim). Returns `bytes.size` when no blank line is found — an all-head
+    # buffer (no body), which `expand_wire` then normalizes in full, matching the
+    # pre-existing behavior for header-only text.
+    private def self.head_body_boundary(bytes : Bytes) : Int32
+      n = bytes.size
+      i = 0
+      while i < n
+        if bytes[i] == 0x0A_u8 && i + 1 < n && bytes[i + 1] == 0x0A_u8
+          return i + 2
+        end
+        if bytes[i] == 0x0D_u8 && i + 3 < n &&
+           bytes[i + 1] == 0x0A_u8 && bytes[i + 2] == 0x0D_u8 && bytes[i + 3] == 0x0A_u8
+          return i + 4
+        end
+        i += 1
+      end
+      n
     end
 
     # Byte-level equivalent of `gsub(/\r?\n/, "\r\n")`: inserts `\r` before any

--- a/src/gori/fuzz/engine.cr
+++ b/src/gori/fuzz/engine.cr
@@ -75,6 +75,11 @@ module Gori::Fuzz
   class Engine
     EVENT_BUFFER    =  256
     MAX_CONCURRENCY = 1000 # hard ceiling on worker fibers / channel capacity
+    # Synthetic baseline requests sent before the sweep when auto-calibration is on (see
+    # calibrate_baseline). A single exact-match snapshot can't tell a target's ordinary
+    # per-request variability apart from a genuine anomaly; a handful of staggered,
+    # randomly-payloaded samples can, at the cost of this many extra sends up front.
+    CALIBRATION_SAMPLES = 6
 
     enum State : UInt8
       Running
@@ -135,11 +140,26 @@ module Gori::Fuzz
       @total
     end
 
-    # Seed the baseline metrics from the unmodified request (all-defaults), for
-    # anomaly diffing / auto-calibration. Optional; call before `start`.
+    # Seed the matcher's calibration set from CALIBRATION_SAMPLES synthetic,
+    # randomly-payloaded requests (see Generator#calibration_requests and
+    # Matcher.reflects_length?) — replaces the old single-snapshot baseline, which a
+    # target with ANY legitimate per-request variability (a nonce, rotating content, a
+    # reflected parameter) trivially defeated. Optional; call before `start`. Every
+    # send routes through @backend like any other, so calibration sends still count
+    # against a configured max_requests cap; under a tight cap, sample count is
+    # trimmed so at least one send is left for the sweep itself. A failed/empty
+    # calibration is non-fatal — auto_calibrate then simply suppresses nothing.
     def calibrate_baseline : Nil
-      raw = @backend.send(@generator.baseline_request)
-      @matcher.baseline = @matcher.metrics(raw) if raw.error.nil?
+      wanted = CALIBRATION_SAMPLES
+      if (cap = @config.max_requests) && cap > 0 && cap - 1 < wanted
+        wanted = Math.max(cap - 1, 1_i64).to_i32
+      end
+      samples = [] of BaselineSample
+      @generator.calibration_requests(wanted).each do |bytes, payload_len|
+        raw = @backend.send(bytes)
+        samples << BaselineSample.new(@matcher.metrics(raw), payload_len) if raw.error.nil?
+      end
+      @matcher.baseline = samples
     rescue
       # a failed baseline is non-fatal — just skip calibration
     end

--- a/src/gori/fuzz/generator.cr
+++ b/src/gori/fuzz/generator.cr
@@ -6,6 +6,14 @@ module Gori::Fuzz
   #   Pitchfork / ClusterBomb → one set per position (set[i] → position i).
   # (the frontend builds that mapping; out-of-range positions fall back to set 0.)
   class Generator
+    # calibration_requests: injected-payload length of the FIRST sample, and the
+    # per-sample increment — chosen small enough to stay a plausible query/body value,
+    # but distinct enough (multiples of CALIBRATION_STEP) that Matcher.reflects_length?'s
+    # byte-level correlation check isn't fooled by incidental ±1-byte noise.
+    CALIBRATION_BASE_LEN = 6
+    CALIBRATION_STEP     = 5
+    CALIBRATION_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"
+
     @has_chains : Bool
 
     # `registry` (when given) applies each marked position's inline Decoder chain to
@@ -48,10 +56,30 @@ module Gori::Fuzz
     end
 
     # The unmodified base request (all positions = their defaults), CL-synced — used
-    # to seed the matcher baseline for anomaly diffing / auto-calibration.
+    # to seed the matcher baseline for anomaly diffing.
     def baseline_request : Bytes
       raw = @template.render(chained(@template.default_payloads))
       @config.update_content_length? ? ContentLength.sync(raw, @config.add_content_length_when_missing?) : raw
+    end
+
+    # `n` synthetic requests for auto-calibration (Engine#calibrate_baseline): each
+    # substitutes EVERY marked position with a random, nonce-like value — never a real
+    # attack payload — so the target's ordinary per-request variability (a timestamp, a
+    # session nonce, a rotating banner, a reflected parameter) can be sampled as "noise"
+    # up front rather than compared against a single lucky/unlucky snapshot. Injected
+    # payload BYTE LENGTH is staggered across samples (see CALIBRATION_BASE_LEN/_STEP)
+    # so Matcher.reflects_length? can tell "this target echoes the payload" (length
+    # grows with payload length) apart from ordinary noise. Returns {request bytes,
+    # total injected payload length across all positions} per sample.
+    def calibration_requests(n : Int32) : Array({Bytes, Int32})
+      count = @template.position_count
+      (0...n).map do |i|
+        plen = CALIBRATION_BASE_LEN + i * CALIBRATION_STEP
+        payloads = Array.new(count) { random_nonce(plen) }
+        raw = @template.render(chained(payloads))
+        bytes = @config.update_content_length? ? ContentLength.sync(raw, @config.add_content_length_when_missing?) : raw
+        {bytes, plen * count}
+      end
     end
 
     # ── modes ────────────────────────────────────────────────────────────────────
@@ -136,6 +164,13 @@ module Gori::Fuzz
       raw = @template.render(chained(payloads))
       bytes = @config.update_content_length? ? ContentLength.sync(raw, @config.add_content_length_when_missing?) : raw
       Job.new(idx, payloads, pos, bytes) # keep the ORIGINAL payloads for reporting; only the wire bytes are transformed
+    end
+
+    # A random alphanumeric string with no whitespace — safe to drop into a query/body
+    # position without corrupting framing, and (deliberately) never a real payload, so a
+    # calibration send can't coincide with anything meaningful on the target.
+    private def random_nonce(len : Int32) : String
+      String.build(len) { |sb| len.times { sb << CALIBRATION_ALPHABET[Random.rand(CALIBRATION_ALPHABET.size)] } }
     end
 
     # Apply each position's inline Decoder chain to its payload (identity when no

--- a/src/gori/fuzz/matcher.cr
+++ b/src/gori/fuzz/matcher.cr
@@ -12,6 +12,13 @@ module Gori::Fuzz
     lines : Int32,
     duration_us : Int64
 
+  # One auto-calibration sample: the metrics of a synthetic (nonce-payloaded) baseline
+  # response, tagged with how much payload text was injected across every marked
+  # position for THAT sample. `payload_len` is what lets Matcher.reflects_length?
+  # tell "this target's response length legitimately tracks payload length" (reflection)
+  # apart from "this target's response length is just noisy" (needs a wider sample set).
+  record BaselineSample, metrics : Metrics, payload_len : Int32
+
   # Decides whether a response is "interesting" and extracts a value from it.
   # ffuf/Burp semantics: a result is MATCHED when every active matcher dimension
   # passes AND no filter dimension passes. Each dimension is a comma-list spec
@@ -70,12 +77,65 @@ module Gori::Fuzz
     end
 
     property extract : Regex?
-    property baseline : Metrics?
+    # The active calibration set (see Engine#calibrate_baseline). Empty = "no
+    # calibration collected" (auto-calibration off, or the calibration sends all
+    # failed) — calibrated_out? treats that identically to auto_calibrate being off.
+    getter baseline : Array(BaselineSample)
+    # Cached alongside `baseline` (recomputed only when the set changes, never on the
+    # per-response hot path) — see Matcher.reflects_length? for what it detects.
+    getter? reflects_length : Bool = false
     property? auto_calibrate : Bool
     property keep_bodies : Symbol # :none | :matched | :all
 
     def initialize(@keep_bodies : Symbol = :matched, @auto_calibrate : Bool = false)
-      @baseline = nil
+      @baseline = [] of BaselineSample
+    end
+
+    def baseline=(samples : Array(BaselineSample)) : Nil
+      @baseline = samples
+      @reflects_length = Matcher.reflects_length?(samples)
+    end
+
+    # A generous per-pair slack (bytes) for the length-tracks-payload check below — covers
+    # HTML-entity re-encoding of a few nonce characters, off-by-one wrapper text, etc.
+    # without being wide enough to misclassify genuinely-noisy (non-reflecting) targets.
+    LENGTH_TOLERANCE = 4_i64
+
+    # Detects a target that reflects the substituted payload back into its response body:
+    # the calibration samples deliberately inject STAGGERED payload lengths (see
+    # Generator#calibration_requests), so if response byte length grows in lockstep with
+    # payload length across every pair of samples, comparing raw length can never repeat —
+    # every distinct real attack payload has its own length, so no finite baseline set
+    # would ever exact-match it (the second proven-broken scenario: 100/100 false
+    # positives with a single-sample baseline). `baseline_matches?` then substitutes
+    # word/line counts for length.
+    #
+    # Conservative by design: EVERY pair with a different payload length must show the
+    # tracking relationship, or this returns false and length stays in the (safe, if
+    # sometimes less effective) exact-match comparison — a target that just happens to be
+    # noisy must never be misread as "reflecting".
+    #
+    # What this does NOT catch: partial reflection (the target truncates, HTML-escapes, or
+    # otherwise transforms the payload before embedding it, so growth isn't ~1:1) reads as
+    # "not reflecting" and falls through to stricter exact-length matching — under-
+    # suppressing rather than over-suppressing, the safe failure direction for a security
+    # tool. A target whose word/line count ALSO happens to shift with an opaque nonce
+    # (e.g. it reflects the payload on its own line, adding a line each time) likewise
+    # isn't calibrated out — again a missed suppression, never a missed finding.
+    def self.reflects_length?(samples : Array(BaselineSample)) : Bool
+      pairs = 0
+      tracked = 0
+      samples.each_with_index do |a, i|
+        samples.each_with_index do |b, j|
+          next unless j > i
+          dp = (b.payload_len - a.payload_len).to_i64
+          next if dp == 0
+          dl = b.metrics.length - a.metrics.length
+          pairs += 1
+          tracked += 1 if (dl - dp).abs <= LENGTH_TOLERANCE
+        end
+      end
+      pairs > 0 && tracked == pairs
     end
 
     # Build the metrics for a raw send WITHOUT deciding match (used to seed the
@@ -110,16 +170,36 @@ module Gori::Fuzz
     private def decide(raw : Repeater::Result, status : Int32?, length : Int64,
                        words : Int32, lines : Int32, text : String) : Bool
       return false unless raw.error.nil?
-      return false if calibrated_out?(status, length, words)
+      return false if calibrated_out?(status, length, words, lines)
       matchers_pass?(raw, status, length, words, lines, text) &&
         !filtered?(status, length, words, lines, text)
     end
 
-    private def calibrated_out?(status : Int32?, length : Int64, words : Int32) : Bool
+    # A response is "noise" when it matches ANY collected baseline sample — not just a
+    # single exact snapshot. That's what lets a target that legitimately rotates between
+    # a handful of response shapes (a rotating banner, an A/B variant, …) get every
+    # sampled shape recognized as noise, instead of only whichever one shape a single
+    # lucky/unlucky baseline call happened to catch (the original bug: with one sample,
+    # 3 of 4 rotating shapes were reported as false-positive hits).
+    private def calibrated_out?(status : Int32?, length : Int64, words : Int32, lines : Int32) : Bool
       return false unless @auto_calibrate
-      b = @baseline
-      return false unless b
-      status == b.status && length == b.length && words == b.words
+      samples = @baseline
+      return false if samples.empty?
+      samples.any? { |b| baseline_matches?(b.metrics, status, length, words, lines) }
+    end
+
+    # Status is always compared exactly — a genuine anomaly that flips status (e.g. a
+    # seeded 500) must never calibrate out, regardless of body-size heuristics. When
+    # `reflects_length?` is set (see Matcher.reflects_length?), raw byte length is
+    # dropped from the comparison since it legitimately varies with EVERY distinct
+    # payload (no finite sample set would ever exact-match it); word/line counts are
+    # used instead, since an opaque alphanumeric nonce substitution — unlike its byte
+    # length — rarely changes how many whitespace-delimited words or lines a page has.
+    private def baseline_matches?(b : Metrics, status : Int32?, length : Int64,
+                                  words : Int32, lines : Int32) : Bool
+      return false unless status == b.status
+      return words == b.words && lines == b.lines if reflects_length?
+      length == b.length && words == b.words
     end
 
     # Every active matcher dimension must pass.

--- a/src/gori/import/builder.cr
+++ b/src/gori/import/builder.cr
@@ -27,8 +27,19 @@ module Gori
       LEADING_SCHEME = /\A[a-z][a-z0-9+.-]*:\/\//i
       HTTP_SCHEME    = /\Ahttps?:\/\//i
 
+      # A raw CR/LF (or other C0 control / DEL) in a URL is never legitimate — a
+      # PERCENT-ENCODED `%0d%0a` stays encoded text through URI.parse (harmless), but a
+      # LITERAL control byte does not: URI.parse copies it verbatim into host/path with
+      # no rejection, so left unchecked it flows straight into request_head/response_head
+      # and forges a second, fabricated HTTP message inside one stored request/status line
+      # (e.g. `GET /path\r\nX-Injected: pwn\r\n\r\nGET /second HTTP/1.1 HTTP/1.0\r\n...`).
+      # Reject the entry here, at the same point the scheme/shape checks below do, so every
+      # caller's existing skip-a-bad-entry rescue handles it identically to those checks.
+      CONTROL_CHAR = /[\x00-\x1f\x7f]/
+
       def self.normalize_url(url : String) : String
         u = url.strip
+        raise Gori::Error.new("invalid URL (control character): #{url.inspect}") if u.matches?(CONTROL_CHAR)
         return u if u.starts_with?(HTTP_SCHEME)
         raise Gori::Error.new("invalid URL (missing scheme): #{url}") if u.matches?(LEADING_SCHEME)
         "https://#{u}"

--- a/src/gori/import/har.cr
+++ b/src/gori/import/har.cr
@@ -9,7 +9,11 @@ module Gori
     module Har
       def self.parse_file(path : String) : ParseResult
         raw = File.read(path)
-        doc = JSON.parse(raw)
+        doc = begin
+          JSON.parse(raw)
+        rescue ex : JSON::ParseException
+          raise Gori::Error.new("HAR file is not valid JSON: #{ex.message}")
+        end
         log = doc["log"]?
         raise Gori::Error.new("HAR file missing log object") unless log
         entries = log["entries"]?.try(&.as_a?)

--- a/src/gori/import/oas.cr
+++ b/src/gori/import/oas.cr
@@ -10,10 +10,20 @@ module Gori
       def self.parse_file(path : String) : ParseResult
         raw = File.read(path)
         json_raw = case File.extname(path).downcase
-                   when ".yaml", ".yml" then YAML.parse(raw).to_json
-                   else                      raw
+                   when ".yaml", ".yml"
+                     begin
+                       YAML.parse(raw).to_json
+                     rescue ex : YAML::ParseException
+                       raise Gori::Error.new("OpenAPI spec is not valid YAML: #{ex.message}")
+                     end
+                   else
+                     raw
                    end
-        spec = JSON.parse(json_raw)
+        spec = begin
+          JSON.parse(json_raw)
+        rescue ex : JSON::ParseException
+          raise Gori::Error.new("OpenAPI spec is not valid JSON: #{ex.message}")
+        end
         paths = spec["paths"]?
         raise Gori::Error.new("OpenAPI spec missing paths") unless paths
         # A `paths` that isn't an object (null / string / array) is a malformed spec, not

--- a/src/gori/issues_export.cr
+++ b/src/gori/issues_export.cr
@@ -36,7 +36,10 @@ module Gori
               end
             end
             append_related_links(io, f, store)
-            io << "\n" << f.notes << "\n" unless f.notes.strip.empty?
+            # notes is multi-line by design (free text) — scrub_only fixes invalid UTF-8
+            # (the same captured-data class title/host carry) without collapsing its newlines,
+            # unlike one_line above, which would flatten it into a single unreadable line.
+            io << "\n" << scrub_only(f.notes) << "\n" unless f.notes.strip.empty?
             if flow
               append_evidence(io, "Request", flow.request_head, flow.request_body)
               append_evidence(io, "Response", flow.response_head, flow.response_body)
@@ -51,14 +54,20 @@ module Gori
             issues.each do |f|
               j.object do
                 j.field "id", f.id
-                j.field "title", f.title
+                # title/host: normalise with one_line (scrub + collapse control chars) — they're
+                # semantically single-line fields, so a raw newline is worth collapsing even though
+                # JSON itself would tolerate it verbatim (an MCP tool response IS this same JSON
+                # shape, and a client rendering "title" inline shouldn't see it split mid-string).
+                j.field "title", one_line(f.title)
                 j.field "severity", f.severity.label
                 j.field "status", f.status.label
-                j.field "host", f.host
+                j.field "host", f.host.try { |h| one_line(h) }
                 j.field "flow_id", f.flow_id
                 j.field "created_at", f.created_at
                 j.field "updated_at", f.updated_at
-                j.field "notes", f.notes
+                # notes is multi-line BY DESIGN (free-text) — only the encoding-safety half of
+                # one_line applies; collapsing its newlines would mangle a legitimate multi-line note.
+                j.field "notes", scrub_only(f.notes)
                 j.field "links" do
                   j.array { append_links_json(j, f, store) }
                 end
@@ -68,6 +77,17 @@ module Gori
         end
       end
 
+      # Fix invalid-UTF-8 bytes only, leaving control characters (incl. newlines) intact —
+      # the encoding-safety half of `one_line`, split out for a field that is multi-line BY
+      # DESIGN (e.g. an issue's free-text `notes`) and must not have its line breaks collapsed,
+      # but still needs the same guarantee `one_line` exists for: a captured value can carry a
+      # raw invalid byte (e.g. an h2 :path pseudo-header), and unscrubbed output either breaks
+      # the exporter's encoding contract (JSON/Markdown must stay valid UTF-8) or crashes a
+      # later PCRE gsub over it.
+      def self.scrub_only(s : String) : String
+        s.scrub
+      end
+
       # Collapse control characters (CR/LF/tab/…) to a single space so a value with
       # embedded newlines can't break the single-line structure it sits in — a
       # Markdown heading here, a one-row line in the text export. Shared with
@@ -75,7 +95,7 @@ module Gori
       def self.one_line(s : String) : String
         # scrub: captured values (target/host/method/title, e.g. an h2 :path with a raw byte) can
         # be invalid UTF-8, which would make the PCRE gsub raise and crash the markdown/text export.
-        s.scrub.gsub(/[[:cntrl:]]+/, " ").strip
+        scrub_only(s).gsub(/[[:cntrl:]]+/, " ").strip
       end
 
       private def self.append_related_links(io : String::Builder, f : Store::Issue, store : Store) : Nil

--- a/src/gori/mcp/serialize.cr
+++ b/src/gori/mcp/serialize.cr
@@ -339,12 +339,17 @@ module Gori
           j.field "created_at_iso", unix_micros_iso(f.created_at)
           j.field "updated_at", f.updated_at
           j.field "updated_at_iso", unix_micros_iso(f.updated_at)
-          j.field "title", f.title
+          # title/host/notes: same captured-data-can-be-invalid-UTF-8 gap `Issues::Export.json`
+          # has (this IS that same JSON shape, just wrapped in a JSON-RPC tool response) — an
+          # unscrubbed raw byte here breaks the whole response line's UTF-8 validity, a real
+          # protocol violation an MCP client could choke on, not merely a display glitch.
+          j.field "title", Issues::Export.one_line(f.title)
           j.field "severity", f.severity.label
           j.field "status", f.status.label
-          j.field "host", f.host
+          j.field "host", f.host.try { |h| Issues::Export.one_line(h) }
           j.field "flow_id", f.flow_id
-          j.field "notes", f.notes
+          # notes is multi-line by design — scrub only, don't collapse (mirrors Export.json).
+          j.field "notes", Issues::Export.scrub_only(f.notes)
           j.field "links" do
             j.array { Issues::Export.append_links_json(j, f, store) if store }
           end

--- a/src/gori/scope.cr
+++ b/src/gori/scope.cr
@@ -360,6 +360,22 @@ module Gori
       @mutex.synchronize { set_enabled_unlocked(false) }
     end
 
+    # Re-read rules + the enabled/sandbox flags from the store after an EXTERNAL change —
+    # another process (`gori run project scope add/rm`) or another instance's TUI writing
+    # to the SAME db. Mirrors Rules#reload: every other piece of code already holds a
+    # reference to THIS object (Sitemap, Interceptor, Probe, the Sandbox gate…), so
+    # refreshing it in place is enough — no additional wiring needed. Pulled by the TUI's
+    # data_version poll (Runner#apply_external_change) and headless capture's periodic
+    # reload fiber (App#spawn_reload_loop), the same two call sites Rules#reload already
+    # has.
+    def reload : Nil
+      @mutex.synchronize do
+        reload_rules_unlocked
+        @enabled = @store.setting(SETTING_ENABLED) == "1"
+        @sandbox = @store.setting(SETTING_SANDBOX) == "1"
+      end
+    end
+
     # A regex pattern must compile — the SQLite REGEXP callback and the proxy hot path
     # both call `Regex.new` and would otherwise raise. host/string patterns always valid.
     def self.valid?(match_type : String, pattern : String) : Bool

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -856,6 +856,12 @@ module Gori::Tui
     # store-backed views. Active-tab reloads use id/path soft-anchors; Repeater/Notes
     # soft-merge and skip dirty buffers so session UI is not clobbered.
     private def apply_external_change : Nil
+      # Scope has no dirty-edit-buffer concept to protect (add/remove/toggle write straight
+      # through to the store), so it's always safe to refresh in place here — unlike a
+      # controller with an open, unsaved editor. This is what keeps the Sitemap's in-scope
+      # markers (and Sandbox enforcement, which reads the SAME live object) from going stale
+      # after an external `gori run project scope add/rm` against this project's db.
+      @session.scope.reload
       # Reload a store-backed view only when it's the ACTIVE tab (others reload on
       # tab entry via on_enter_tab) — avoids re-querying History's page ~1.3×/sec
       # while the user is elsewhere. Own-session captures also arrive via flow_events.
@@ -5393,8 +5399,8 @@ module Gori::Tui
       when :network, :editor, :layout, :statusline, :display, :notifications, :general
         open_preferences(section) # the unified grouped modal, positioned at this section
       when :theme
-        @settings_view.reload(:theme)   # theme keeps its dedicated swatch-list card
-        @resized = true                 # an edited/removed active theme just changed → full repaint
+        @settings_view.reload(:theme) # theme keeps its dedicated swatch-list card
+        @resized = true               # an edited/removed active theme just changed → full repaint
         @overlay = :settings
         @theme_restore = Settings.theme # baseline for live-preview revert
       when :tabs


### PR DESCRIPTION
## Summary

Third round of build-and-dogfood, fanning out into Import (HAR/URL-list/OpenAPI — never tested before), project management/retention/capture-lock, Sitemap/Issues, a deeper SSE/gRPC pass, and Fuzzer internals/Content-Length consistency. This round also caught gaps in fixes from the previous two rounds (a residual UTF-8 case the markdown-export fix missed, and a body-corruption bug adjacent to but distinct from the earlier Env fix) — a useful signal that the dogfooding is finding real depth, not just surface-level issues.

- `fix(import)`: a URL containing CRLF (or other control characters) sailed through `URI.parse` unrejected — a HAR entry with `\r\nX-Injected: pwn\r\n\r\nGET /second HTTP/1.1` embedded in its URL became a real, corrupted row in History instead of being skipped per Import's own stated contract. Also wrapped two raw stdlib exceptions (`JSON::ParseException`, `YAML::ParseException`) that broke the file's otherwise-consistent "malformed input → clean `Gori::Error`" convention.
- `fix`: invalid UTF-8 in a captured value (host/target/h2 pseudo-header) leaked through four export paths that the existing `Issues::Export.markdown` fix didn't cover — `Export.json`, MCP's `get_issue`/`list_issues`, `markdown`'s own `notes` field (missed by the original fix), and Sitemap's CLI export (text/json/paths).
- `fix(fuzz)`: auto-calibration (`--ac`) compared against a single exact-match baseline snapshot, so it was trivially defeated by any legitimate response variability — verified false-positive rates of 75/99 and 99/99 against two realistic target shapes (rotating content, payload-reflecting pages). Now uses multiple randomized-nonce baseline samples plus a word/line-count fallback when response length tracks payload length; both scenarios verified down to 0/99 false positives with the seeded real anomaly still correctly flagged throughout.
- `fix`: Termisu's constructor calls `Log.setup` internally, which — since Crystal's `Log.setup` fully clears prior configuration — silently redirected all of gori's own logging into a shared, unbounded `/tmp/termisu.log` instead of the documented `$GORI_HOME/gori.log`, making session-open failures undiagnosable. Also: `Scope` had no reload path anywhere (TUI included, unlike `Rules` which already got one) — an externally-added scope rule never reached an open TUI's Sitemap markers, and more seriously, never reached **Sandbox enforcement** either, verified with real headless-capture traffic staying blocked/allowed against a stale rule set until restart.
- `fix`: `Env.normalize_crlf` (used by Repeater/Miner's wire-form expansion) inserted a CR before every LF byte in the *entire* buffer, head and body alike — corrupting any binary/compressed body containing a bare LF byte, silently, since Content-Length was resynced to match the already-corrupted body. Fuzzer (a different code path) was already correct and served as the reference. Also fixed `sse_events.truncated` being hardcoded `false` in `gori run show --format json` while the MCP serializer computed it correctly.

## Test plan

- [x] `crystal spec` — 3280 examples, 0 failures, 0 errors (2 pre-existing pending, unrelated)
- [x] `shards build` / `crystal build src/main.cr -o bin/gori` — clean
- [x] `crystal tool format --check` on every touched file — clean
- [x] `ameba` on every touched file — compared against a `main`-checkout baseline worktree: identical finding count (64), zero new issues
- [x] Each fix reproduced end-to-end before the fix and re-verified after — see individual commit messages for repro shape; several with explicit before/after false-positive-rate or byte-level evidence