### PR TITLE
fix: Sequencer misses a shuffled sequential counter; Repeater crashes on a legacy TEXT-storage request row

### DIFF
--- a/spec/sequencer/stats_spec.cr
+++ b/spec/sequencer/stats_spec.cr
@@ -122,6 +122,44 @@ describe Gori::Sequencer::Stats do
     seq_detail(["1", "5", "3"]).should eq("non-monotonic")
   end
 
+  # ── detect_sequential: order-independent (concurrency-reordering) detection ─────
+
+  it "detects a shuffled-order sequential counter once the sample is large enough" do
+    # sequence_start allows concurrency up to 20 — same-cause responses routinely
+    # complete out of issuance order, so a real incrementing counter can be COLLECTED
+    # in shuffled order. Regression for a bug where this made "Sequential" report
+    # "non-monotonic"/PASS on a token set that was, in fact, a step-1 counter.
+    ordered = (100000..100199).map(&.to_s)
+    shuffled = ordered.shuffle(Random.new(42_u64))
+    report = S.analyze(shuffled)
+    report.sequential.should be_true
+    seq_detail(shuffled).should eq("constant step 1 (sorted — arrival order was shuffled)")
+  end
+
+  it "does not flag a shuffled sample of genuinely random numeric tokens as sequential" do
+    rng = Random.new(99_u64)
+    random_ints = Array.new(200) { rng.rand(1_000_000).to_s }
+    S.analyze(random_ints).sequential.should be_false
+  end
+
+  it "does not claim shuffling for a large sample that truly arrived in ascending order" do
+    # Regression: the sorted-order check must only run once the arrival-order (inc/dec)
+    # check has already failed, or it falsely claims "arrival order was shuffled" for a
+    # counter that was, in fact, observed directly in sequence (n=200 >= SMALL_SAMPLE).
+    ordered = (100000..100199).map(&.to_s)
+    seq_detail(ordered).should eq("constant step 1")
+  end
+
+  it "keeps the correct (negative) step and label for a large descending run, unshuffled" do
+    # Regression: sorting-first would flip a genuine descending run's reported sign
+    # (ascending "constant step 1" instead of "constant step -1") and falsely claim
+    # shuffling. The arrival-order check must win here since dec is true.
+    descending = (100000..100199).to_a.reverse.map(&.to_s)
+    report = S.analyze(descending)
+    report.sequential.should be_true
+    seq_detail(descending).should eq("constant step -1")
+  end
+
   # ── detect_sequential: 18-digit boundary guard against Int64 overflow ────────────
 
   it "keeps exactly-18-digit tokens on the numeric fast path" do

--- a/spec/store_repeaters_spec.cr
+++ b/spec/store_repeaters_spec.cr
@@ -4,7 +4,7 @@ private def with_store(&)
   path = File.tempname("gori-repeaters", ".db")
   store = Gori::Store.open(path)
   begin
-    yield store
+    yield store, path
   ensure
     store.close
     File.delete?(path)
@@ -118,6 +118,41 @@ describe "Gori::Store repeater tabs (v9)" do
       r = store.repeaters.find!(&.id.==(id))
       r.response_body.should be_nil
       r.response_error.should eq("connect failed: a.test:443")
+    end
+  end
+
+  it "reads a legacy row whose `request` was bound as a Crystal String (TEXT storage " \
+     "class), the way an out-of-date gori writer bound it before the V2 fix" do
+    with_store do |store, path|
+      # Bypass insert_repeater (always binds Bytes) to reproduce a row written by a
+      # mismatched-version writer still on the pre-V2 String bind — e.g. a long-lived
+      # `gori mcp`/TUI process running an out-of-date binary against an
+      # already-migrated project db. SQLite stores a String bind as TEXT storage class
+      # even in a column declared/affinity TEXT-or-BLOB; reading it back as Bytes used
+      # to raise an unhandled DB::ColumnTypeMismatchError. The body carries an embedded
+      # NUL byte — the exact historical failure mode the V2 migration's own comment
+      # describes (a single-arg `String.new(ptr)` read stops at the first 0x00) — so
+      # this also guards against a future regression to a String-based (not CAST'd)
+      # read silently truncating instead of raising.
+      raw = DB.open("sqlite3:#{path}")
+      begin
+        now = Time.utc.to_unix_ms.to_i64 * 1000
+        raw.exec(
+          "INSERT INTO repeaters (created_at, updated_at, target, request, http2, auto_content_length, position) " \
+          "VALUES (?,?,?,?,?,?,?)",
+          now, now, "https://legacy.test", "POST /legacy HTTP/1.1\r\nContent-Length: 3\r\n\r\nA\u0000B", 0, 1, 0)
+      ensure
+        raw.close
+      end
+
+      expected = "POST /legacy HTTP/1.1\r\nContent-Length: 3\r\n\r\nA\u0000B".to_slice
+      expected.includes?(0_u8).should be_true # sanity: the embedded NUL survives, not stripped by the literal itself
+      id = store.repeaters.first.id
+      store.repeaters.find!(&.id.==(id)).request.should eq(expected)
+      store.get_repeater(id).not_nil!.request.should eq(expected)
+      store.get_repeater_full(id).not_nil!.request.should eq(expected)
+      store.repeaters_meta.find!(&.id.==(id)).request.should eq(expected)
+      store.repeaters_mcp.find!(&.id.==(id)).request.should eq(expected)
     end
   end
 

--- a/src/gori/sequencer/stats.cr
+++ b/src/gori/sequencer/stats.cr
@@ -415,16 +415,46 @@ module Gori::Sequencer
         inc = (1...vals.size).all? { |i| vals[i] > vals[i - 1] }
         dec = (1...vals.size).all? { |i| vals[i] < vals[i - 1] }
         if inc || dec
-          deltas = (1...vals.size).map { |i| vals[i] - vals[i - 1] }
-          return {true, deltas.uniq.size == 1 ? "constant step #{deltas.first}" : (inc ? "monotonic up" : "monotonic down")}
+          step = constant_step(vals)
+          return {true, step ? "constant step #{step}" : (inc ? "monotonic up" : "monotonic down")}
+        end
+        # Reached only when arrival order is NEITHER ascending nor descending — so
+        # "shuffled" below is an earned claim, not a guess. Collection order isn't
+        # issuance order once concurrency > 1 (sequence_start allows up to 20 in
+        # flight): two in-flight replays can complete swapped, so a textbook
+        # incrementing counter can arrive shuffled and the inc/dec check above misses
+        # it. Check the SORTED values for an even step — order-independent, so
+        # concurrent collection can't hide it. Gated behind SMALL_SAMPLE because a tiny
+        # sample "sorts evenly" by pure coincidence often enough to be noise (e.g.
+        # [1, 5, 3] sorts to a constant step of 2 despite being a genuinely
+        # non-monotonic 3-token run — see the up-then-down spec); at real sample sizes
+        # that coincidence is negligible.
+        if n >= SMALL_SAMPLE && (step = constant_step(vals.sort))
+          return {true, "constant step #{step} (sorted — arrival order was shuffled)"}
         end
         return {false, "non-monotonic"}
       end
-      # General path — correlation of arrival order with a leading-byte magnitude.
+      # General path — correlation of arrival order with a leading-byte magnitude. Shares
+      # the same order-dependency the numeric fast path had above (arrival order can be
+      # shuffled by concurrency), but isn't fixed here — a coordinate-only fix couldn't
+      # reuse the sort-then-diff trick since this path also weighs HOW closely order
+      # tracks magnitude, not just whether the values are evenly spaced.
       xs = Array(Float64).new(n, &.to_f)
       ys = tokens.map { |t| leading_value(t) }
       r = pearson(xs, ys)
       {r.abs > 0.9, "corr=#{fmt(r)}"}
+    end
+
+    # The constant gap between every consecutive pair in `values`, or nil if the gaps
+    # vary (or all values are identical). Short-circuits on the first mismatching pair
+    # rather than building a full delta array + `.uniq` just to read its size. Shared by
+    # detect_sequential's arrival-order and sorted-order checks so both express "is this
+    # an even arithmetic progression" the same way.
+    private def self.constant_step(values : Array(Int64)) : Int64?
+      return nil if values.size < 2
+      step = values[1] - values[0]
+      return nil if step == 0
+      (2...values.size).all? { |i| values[i] - values[i - 1] == step } ? step : nil
     end
 
     private def self.leading_value(t : String) : Float64

--- a/src/gori/store/repeater_sessions.cr
+++ b/src/gori/store/repeater_sessions.cr
@@ -9,13 +9,30 @@ module Gori
     # / reconcile must soft-sync and skip unchanged rows, not assume "own writes are
     # invisible". Callers that full-restore on every poll self-clobber.
 
+    # `repeaters.request` is declared TEXT (schema.cr) but every CURRENT insert/update
+    # binds it as `Bytes`, which SQLite stores as BLOB regardless of the column's
+    # declared affinity — see the V2 migration's `CAST(request AS BLOB)` comment for the
+    # history (an older gori bound it as a Crystal `String`, producing TEXT-storage-class
+    # rows that silently truncated at an embedded NUL on read). That migration fixed data
+    # existing at upgrade time, but it can't protect a row written LATER by a mismatched
+    # writer — e.g. a `gori mcp`/TUI process still running an out-of-date binary against
+    # an already-migrated project db, which is exactly how gori is meant to be run
+    # long-lived alongside a dev rebuild. Every read below casts defensively so a
+    # TEXT-storage-class value coerces to Bytes instead of `rs.read(Bytes)` raising an
+    # unhandled DB::ColumnTypeMismatchError — which, left unhandled, doesn't just fail
+    # that one row: `repeaters`/`repeaters_meta`/`repeaters_mcp` read ALL rows in a single
+    # query, so one bad row crashed the entire CLI/TUI/MCP process and blocked every
+    # Repeater operation for the project. CAST is a documented no-op on an
+    # already-BLOB-storage value, so this never changes behavior for the common case.
+    REQUEST_COL = "CAST(request AS BLOB) AS request"
+
     # Full repeater rows INCLUDING the persisted response BLOBs. Used once at project
     # open to seed each tab's last response (V11). NOT for the recurring reconcile
     # poll — use `repeaters_meta` there to avoid re-materializing every tab's
     # (potentially multi-MB) response on each cross-session commit.
     def repeaters : Array(RepeaterRecord)
       list = [] of RepeaterRecord
-      @db.query("SELECT id, target, request, http2, auto_content_length, flow_id, position, response_head, response_body, response_error, response_duration_us, name, sni, tags FROM repeaters ORDER BY position, id") do |rs|
+      @db.query("SELECT id, target, #{REQUEST_COL}, http2, auto_content_length, flow_id, position, response_head, response_body, response_error, response_duration_us, name, sni, tags FROM repeaters ORDER BY position, id") do |rs|
         rs.each do
           list << RepeaterRecord.new(
             rs.read(Int64), rs.read(String), rs.read(Bytes),
@@ -32,7 +49,7 @@ module Gori
     # response (responses are personal per session). Response fields stay nil.
     def get_repeater(id : Int64) : RepeaterRecord?
       @db.query(
-        "SELECT id, target, request, http2, auto_content_length, flow_id, position, sni, name FROM repeaters WHERE id = ?",
+        "SELECT id, target, #{REQUEST_COL}, http2, auto_content_length, flow_id, position, sni, name FROM repeaters WHERE id = ?",
         id) do |rs|
         return RepeaterRecord.new(
           rs.read(Int64), rs.read(String), rs.read(Bytes),
@@ -47,7 +64,7 @@ module Gori
     # repeater response BLOBs just to retrieve one continuation chunk.
     def get_repeater_full(id : Int64) : RepeaterRecord?
       @db.query(
-        "SELECT id, target, request, http2, auto_content_length, flow_id, position, " \
+        "SELECT id, target, #{REQUEST_COL}, http2, auto_content_length, flow_id, position, " \
         "response_head, response_body, response_error, response_duration_us, name, sni, tags " \
         "FROM repeaters WHERE id = ?", id) do |rs|
         if rs.move_next
@@ -63,7 +80,7 @@ module Gori
 
     def repeaters_meta : Array(RepeaterRecord)
       list = [] of RepeaterRecord
-      @db.query("SELECT id, target, request, http2, auto_content_length, flow_id, position, sni FROM repeaters ORDER BY position, id") do |rs|
+      @db.query("SELECT id, target, #{REQUEST_COL}, http2, auto_content_length, flow_id, position, sni FROM repeaters ORDER BY position, id") do |rs|
         rs.each do
           list << RepeaterRecord.new(
             rs.read(Int64), rs.read(String), rs.read(Bytes),
@@ -79,7 +96,7 @@ module Gori
     def repeaters_mcp : Array(RepeaterRecord)
       list = [] of RepeaterRecord
       @db.query(
-        "SELECT id, target, request, http2, auto_content_length, flow_id, position, sni, " \
+        "SELECT id, target, #{REQUEST_COL}, http2, auto_content_length, flow_id, position, sni, " \
         "name, response_head, response_error, response_duration_us FROM repeaters ORDER BY position, id") do |rs|
         rs.each do
           list << RepeaterRecord.new(


### PR DESCRIPTION
## Summary
- `Sequencer::Stats#detect_sequential` only checked literal collection order for an incrementing/decrementing counter. Once `sequence_start` collects with concurrency > 1 (allowed up to 20), responses can complete out of issuance order, so a genuinely sequential token silently reported `"non-monotonic"` (PASS) instead of the CRITICAL finding it should be. Fixed by checking arrival order first (unchanged for the common case) and only falling back to a sorted, order-independent constant-step check when that fails — so "arrival order was shuffled" is only ever claimed when it demonstrably was, and a descending run keeps its correct (negative) step instead of losing its sign. A shared `constant_step` helper replaces duplicated `deltas.uniq.size` logic with a short-circuiting scan.
- `Store#repeaters`/`get_repeater`/`get_repeater_full`/`repeaters_meta`/`repeaters_mcp` raised an unhandled `DB::ColumnTypeMismatchError` — crashing the whole CLI/TUI/MCP process and blocking every Repeater operation for the project — when `repeaters.request` held a TEXT-storage-class value instead of the BLOB current writers produce. This happens whenever a mismatched-version writer (e.g. a stale `gori mcp` binary still on the pre-V2 String bind, running long-lived against an already-migrated project db) writes a new row. Every read of that column now goes through `CAST(request AS BLOB)`, a documented no-op on the common already-BLOB case.

## Test plan
- [x] `crystal spec` — 3285 examples, 0 failures, 0 errors, 2 pre-existing pending
- [x] New regression coverage: shuffled-order sequential detection, non-shuffled ascending/descending stay correctly labeled, a legacy TEXT-storage `request` row (including an embedded NUL — the historical V2 failure mode) reads cleanly through all 5 Store methods
- [x] Live-verified against a rebuilt binary: reproduced both original crashes/false-negatives, confirmed both are gone post-fix