### PR TITLE
Support global-scope OAST providers alongside project scope

### DIFF
--- a/spec/oast_provider_config_spec.cr
+++ b/spec/oast_provider_config_spec.cr
@@ -1,0 +1,97 @@
+require "./spec_helper"
+
+# Configured OAST providers: the global/project merge (Oast.provider_configs) mirrors
+# Probe.custom_rules — see probe_custom_rule_spec.cr for the analogous test.
+
+private def with_store(&)
+  path = File.tempname("gori-oast-config", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+describe Gori::Oast::ProviderConfig do
+  it "builds a scope-qualified key that can't collide across scopes" do
+    g = Gori::Oast::ProviderConfig.new("7", "g", "interactsh", "https://a", nil, true, "global")
+    p = Gori::Oast::ProviderConfig.new("7", "p", "interactsh", "https://a", nil, true, "project")
+    g.key.should eq("g_7")
+    p.key.should eq("p_7")
+    g.key.should_not eq(p.key)
+  end
+
+  it "exposes project_id only for project scope" do
+    Gori::Oast::ProviderConfig.new("123", "p", "boast", "https://a", nil, true, "project").project_id.should eq(123_i64)
+    Gori::Oast::ProviderConfig.new("abcd", "g", "boast", "https://a", nil, true, "global").project_id.should be_nil
+  end
+end
+
+describe "Gori::Settings global-provider CRUD" do
+  it "adds, updates, toggles, and deletes a global provider" do
+    # These mutators call `save` (real disk I/O), so — like settings_spec.cr's save-exercising
+    # examples — give this test its OWN GORI_HOME rather than writing through the shared
+    # GORI_TEST_HOME: resetting just the in-memory Gori::Settings.oast_providers in `ensure`
+    # would leave the shared settings.json (and @@loaded_raw) holding whatever the last `save`
+    # in this test wrote, if an assertion above failed before the final delete ran.
+    dir = File.tempname("gori-oast-provider-crud")
+    Dir.mkdir_p(dir)
+    prev = ENV["GORI_HOME"]?
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.oast_providers = [] of Gori::Settings::OastProvider
+      id = Gori::Settings.add_oast_provider("My Interactsh", "interactsh", "https://oast.pro", nil)
+      Gori::Settings.oast_providers.size.should eq(1)
+      Gori::Settings.oast_providers.first.enabled.should be_true
+
+      Gori::Settings.set_oast_provider_enabled(id, false)
+      Gori::Settings.oast_providers.first.enabled.should be_false
+
+      Gori::Settings.update_oast_provider(id, "Renamed", "interactsh", "https://oast.live", "tok")
+      updated = Gori::Settings.oast_providers.first
+      updated.name.should eq("Renamed")
+      updated.host.should eq("https://oast.live")
+      updated.token.should eq("tok")
+
+      Gori::Settings.delete_oast_provider(id)
+      Gori::Settings.oast_providers.should be_empty
+    ensure
+      prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(dir)
+      Gori::Settings.oast_providers = [] of Gori::Settings::OastProvider
+    end
+  end
+end
+
+describe "Gori::Oast.provider_configs merge" do
+  it "unions the global library with the project's own providers, tagged by scope" do
+    with_store do |store|
+      saved = Gori::Settings.oast_providers
+      begin
+        Gori::Settings.oast_providers = [
+          Gori::Settings::OastProvider.new("g1", "Global Interactsh", "interactsh", "https://oast.pro", nil, true),
+        ]
+        store.insert_oast_provider("Project BOAST", "BOAST", "https://odiss.eu:2096/events", "sekret", true, 0)
+
+        merged = Gori::Oast.provider_configs(store)
+        merged.size.should eq(2)
+
+        g = merged.find(&.global?).not_nil!
+        g.name.should eq("Global Interactsh")
+        g.id.should eq("g1")
+        g.project_id.should be_nil
+
+        p = merged.find { |c| !c.global? }.not_nil!
+        p.name.should eq("Project BOAST")
+        p.global?.should be_false
+        p.project_id.should_not be_nil
+      ensure
+        Gori::Settings.oast_providers = saved
+      end
+    end
+  end
+end

--- a/spec/tui/oast_provider_overlay_spec.cr
+++ b/spec/tui/oast_provider_overlay_spec.cr
@@ -11,13 +11,21 @@ private def stype(ov : OastProviderOverlay, s : String) : Nil
   s.each_char { |c| ov.handle_key(skey(Termisu::Input::Key::LowerA, c)) }
 end
 
+private def config(*, id = "42", name = "My Provider", kind = Gori::Oast::ProviderKind::Boast,
+                   host = "https://boast.example", token = "my-token", enabled = true,
+                   scope = "project") : Gori::Oast::ProviderConfig
+  Gori::Oast::ProviderConfig.new(id, name, kind.label, host, token, enabled, scope)
+end
+
 describe Gori::Tui::OastProviderOverlay do
-  it "defaults to Interactsh and cycles type with ←/→" do
+  it "defaults to Interactsh, project scope, and cycles type with ←/→" do
     ov = OastProviderOverlay.adding
     ov.kind.should eq(Gori::Oast::ProviderKind::Interactsh)
+    ov.scope.should eq("project")
     ov.editing?.should be_false
 
-    ov.handle_key(skey(Termisu::Input::Key::Down)).should eq(:stay)  # type row
+    ov.handle_key(skey(Termisu::Input::Key::Down)).should eq(:stay) # scope row
+    ov.handle_key(skey(Termisu::Input::Key::Down)).should eq(:stay) # type row
     ov.handle_key(skey(Termisu::Input::Key::Right)).should eq(:stay) # Interactsh -> CustomHttp
     ov.kind.should eq(Gori::Oast::ProviderKind::CustomHttp)
     ov.handle_key(skey(Termisu::Input::Key::Right)).should eq(:stay) # CustomHttp -> WebhookSite
@@ -26,14 +34,32 @@ describe Gori::Tui::OastProviderOverlay do
     ov.kind.should eq(Gori::Oast::ProviderKind::CustomHttp)
   end
 
-  it "seeds edit mode from an existing provider" do
-    ov = OastProviderOverlay.editing(42_i64, "My Provider", Gori::Oast::ProviderKind::Boast, "https://boast.example", "my-token")
+  it "cycles scope between project and global with ←/→" do
+    ov = OastProviderOverlay.adding
+    ov.scope.should eq("project")
+    ov.handle_key(skey(Termisu::Input::Key::Down)) # scope row
+    ov.handle_key(skey(Termisu::Input::Key::Right))
+    ov.scope.should eq("global")
+    ov.handle_key(skey(Termisu::Input::Key::Right)) # wraps back
+    ov.scope.should eq("project")
+  end
+
+  it "seeds edit mode from an existing (project-scope) provider config" do
+    ov = OastProviderOverlay.editing(config)
     ov.editing?.should be_true
-    ov.edit_id.should eq(42_i64)
+    ov.edit_id.should eq("42")
+    ov.edit_scope.should eq("project")
+    ov.scope.should eq("project")
     ov.provider_name.should eq("My Provider")
     ov.kind.should eq(Gori::Oast::ProviderKind::Boast)
     ov.host.should eq("https://boast.example")
     ov.token.should eq("my-token")
+  end
+
+  it "seeds edit mode from a global-scope provider config" do
+    ov = OastProviderOverlay.editing(config(scope: "global"))
+    ov.scope.should eq("global")
+    ov.edit_scope.should eq("global")
   end
 
   it "renders without crashing and maps a click to a row" do
@@ -43,7 +69,8 @@ describe Gori::Tui::OastProviderOverlay do
     ov.render(screen, area)
     box = ov.overlay_box(area).not_nil!
     ov.row_at(box, box.x + 3, box.y + 2).should eq(0) # name row
-    ov.row_at(box, box.x + 3, box.y + 3).should eq(1) # type row
-    ov.row_at(box, box.x + 3, box.y + 6).should eq(4) # save row
+    ov.row_at(box, box.x + 3, box.y + 3).should eq(1) # scope row
+    ov.row_at(box, box.x + 3, box.y + 4).should eq(2) # type row
+    ov.row_at(box, box.x + 3, box.y + 7).should eq(5) # save row
   end
 end

--- a/src/gori/oast/provider_config.cr
+++ b/src/gori/oast/provider_config.cr
@@ -1,0 +1,53 @@
+require "../store"
+require "../settings"
+
+module Gori::Oast
+  # A configured OAST provider, merged from both scopes: the GLOBAL library
+  # (Settings.oast_providers, reusable across every project) and this PROJECT's own
+  # (store.oast_providers). `Oast.provider_configs` merges both into the runtime list the
+  # Providers sub-tab renders and drives register/listen from. Mirrors Probe::CustomRule /
+  # Probe.custom_rules (the same global/project duality for Probe match rules).
+  #
+  # NOT required from oast.cr's umbrella: that engine is Store/TUI-free (driving `gori run
+  # oast` and the MCP oast_* tools, neither of which touches persisted providers), so this
+  # file — which pulls in Store + Settings — is required directly by its one consumer
+  # (the TUI OastController).
+  record ProviderConfig,
+    id : String,   # global: a random hex token; project: the DB row id as text — unique PER SCOPE
+    name : String,
+    kind : String, # ProviderKind label
+    host : String,
+    token : String?,
+    enabled : Bool,
+    scope : String do # "global" | "project"
+
+    # A scope-qualified key, unique across BOTH scopes (a project row id and a global hex id
+    # could otherwise collide) — keys listeners and disambiguates edit/toggle/delete routing.
+    def key : String
+      "#{scope[0]}_#{id}"
+    end
+
+    def global? : Bool
+      scope == "global"
+    end
+
+    # The project DB row id, when this entry is project-scoped (nil for global — a global
+    # provider has no row in this project's DB).
+    def project_id : Int64?
+      global? ? nil : id.to_i64
+    end
+  end
+
+  # Global first, then project — mirrors Probe.custom_rules; order only affects display,
+  # since selection/toggle/delete all key off `key`, not position.
+  def self.provider_configs(store : Store) : Array(ProviderConfig)
+    out = [] of ProviderConfig
+    Settings.oast_providers.each do |p|
+      out << ProviderConfig.new(p.id, p.name, p.kind, p.host, p.token, p.enabled, "global")
+    end
+    store.oast_providers.each do |p|
+      out << ProviderConfig.new(p.id.to_s, p.name, p.kind, p.host, p.token, p.enabled?, "project")
+    end
+    out
+  end
+end

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -3,6 +3,7 @@ require "./paths"
 require "./settings/network"
 require "./settings/env"
 require "./settings/scan_rules"
+require "./settings/oast_providers"
 require "./settings/display"
 require "./settings/tabs"
 require "./settings/keymap"
@@ -69,6 +70,7 @@ module Gori
       self.hostname_overrides = parse_hostname_overrides(root["hostname_overrides"]?)
       parse_env(root["env"]?)
       self.scan_rules = parse_scan_rules(root["scan_rules"]?)
+      self.oast_providers = parse_oast_providers(root["oast_providers"]?)
       parse_hotkeys(root["hotkeys"]?)
       if cv = root["decoder"]?
         self.decoder_sessions = parse_decoder_sessions(cv["sessions"]?)
@@ -176,6 +178,7 @@ module Gori
           serialize_hostname_overrides(j)
           serialize_env(j)
           serialize_scan_rules(j)
+          serialize_oast_providers(j)
           serialize_hotkeys(j)
           serialize_mine(j)
           serialize_probe(j)

--- a/src/gori/settings/oast_providers.cr
+++ b/src/gori/settings/oast_providers.cr
@@ -1,0 +1,86 @@
+require "json"
+
+# OAST PROVIDERS section (settings:oast providers → global scope): user-defined OAST
+# providers, reusable across every project. See settings.cr for the module-level overview
+# and the load/save/serialize orchestration.
+module Gori::Settings
+  # A GLOBAL OAST provider (settings.json "oast_providers"), reusable across every project.
+  # `kind` is the Oast::ProviderKind label. Project-scoped providers live in the project DB
+  # (Store::OastProviderRecord / oast_providers table). `id` is a random hex token assigned
+  # on creation. Mirrors ScanRule (the same global/project split for Probe custom rules).
+  record OastProvider,
+    id : String,
+    name : String,
+    kind : String,
+    host : String,
+    token : String?,
+    enabled : Bool
+  class_property oast_providers : Array(OastProvider) = [] of OastProvider
+
+  # Tolerant global-provider parse: a non-array (or absent) node keeps the current value;
+  # entries missing id/name/kind/host are dropped. Mirrors parse_scan_rules' robustness.
+  private def self.parse_oast_providers(node : JSON::Any?) : Array(OastProvider)
+    arr = node.try(&.as_a?)
+    return oast_providers unless arr
+    out = [] of OastProvider
+    arr.each do |e|
+      next unless o = e.as_h?
+      id = o["id"]?.try(&.as_s?)
+      name = o["name"]?.try(&.as_s?)
+      kind = o["kind"]?.try(&.as_s?)
+      host = o["host"]?.try(&.as_s?)
+      next if id.nil? || id.empty? || name.nil? || name.empty? || kind.nil? || kind.empty? || host.nil? || host.empty?
+      token = o["token"]?.try(&.as_s?)
+      enabled = o["enabled"]?.try(&.as_bool?)
+      out << OastProvider.new(id, name, kind, host, token, enabled.nil? ? true : enabled)
+    end
+    out
+  end
+
+  # --- global provider library CRUD (settings:oast providers → global scope) ---------------
+  # Each mutation rewrites the array and persists via save (atomic + 3-way merge). add returns
+  # the new provider's generated id so the caller can select it.
+  def self.add_oast_provider(name : String, kind : String, host : String, token : String?, enabled : Bool = true) : String
+    id = Random::Secure.hex(4)
+    self.oast_providers = oast_providers + [OastProvider.new(id, name, kind, host, token, enabled)]
+    save
+    id
+  end
+
+  def self.update_oast_provider(id : String, name : String, kind : String, host : String, token : String?) : Nil
+    self.oast_providers = oast_providers.map do |p|
+      p.id == id ? OastProvider.new(id, name, kind, host, token, p.enabled) : p
+    end
+    save
+  end
+
+  def self.set_oast_provider_enabled(id : String, enabled : Bool) : Nil
+    self.oast_providers = oast_providers.map { |p| p.id == id ? p.copy_with(enabled: enabled) : p }
+    save
+  end
+
+  def self.delete_oast_provider(id : String) : Nil
+    self.oast_providers = oast_providers.reject { |p| p.id == id }
+    save
+  end
+
+  # Omit when empty so an untouched install never writes "oast_providers": [].
+  private def self.serialize_oast_providers(j : JSON::Builder) : Nil
+    unless oast_providers.empty?
+      j.field "oast_providers" do
+        j.array do
+          oast_providers.each do |p|
+            j.object do
+              j.field "id", p.id
+              j.field "name", p.name
+              j.field "kind", p.kind
+              j.field "host", p.host
+              j.field "token", p.token if p.token
+              j.field "enabled", p.enabled
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/gori/tui/controllers/oast_controller.cr
+++ b/src/gori/tui/controllers/oast_controller.cr
@@ -6,7 +6,10 @@ require "../highlight"
 require "../clipboard"
 require "../text_field"
 require "../../store"
+require "../../settings"
 require "../../oast"
+require "../../oast/provider_config"
+require "../oast_provider_overlay"
 
 module Gori::Tui
   # The OAST tab: register out-of-band payload URLs and watch the DNS/HTTP/SMTP callbacks
@@ -22,15 +25,17 @@ module Gori::Tui
     POLL_INTERVAL = 5.seconds
 
     # A live listening session: the engine Session + its provider + poll fiber.
+    # `provider_key` is the scope-qualified Oast::ProviderConfig#key (stable across both
+    # scopes; a global provider has no project-DB row id to key off).
     class Listener
       getter session : Oast::Session
       getter provider : Oast::Provider
-      getter provider_id : Int64?
+      getter provider_key : String
       getter provider_label : String
       property poller : Oast::Poller?
       property job_id : Int32 = 0
 
-      def initialize(@session, @provider, @provider_id, @provider_label)
+      def initialize(@session, @provider, @provider_key, @provider_label)
       end
 
       def active? : Bool
@@ -44,15 +49,18 @@ module Gori::Tui
       raw_request : String, raw_response : String?
 
     # register() outcomes carried back to the main fiber (register is a network call run off
-    # the main fiber; persistence + poller start happen here on drain).
-    record RegOk, session : Oast::Session, provider : Oast::Provider, provider_id : Int64?,
-      provider_label : String, want_payload : Bool
-    record RegErr, message : String, provider_label : String, provider_id : Int64?
+    # the main fiber; persistence + poller start happen here on drain). `db_provider_id` is
+    # the project-DB row id to persist on the session (nil for a global-scope provider — it
+    # has no row in this project's DB; the session just won't re-resolve to a provider NAME
+    # after restart, falling back to the kind label like an already-deleted provider does).
+    record RegOk, session : Oast::Session, provider : Oast::Provider, provider_key : String,
+      db_provider_id : Int64?, provider_label : String, want_payload : Bool
+    record RegErr, message : String, provider_label : String, provider_key : String
     alias RegResult = RegOk | RegErr
 
     def initialize(host : Host)
       super(host)
-      @providers = [] of Store::OastProviderRecord
+      @providers = [] of Oast::ProviderConfig
       @listeners = [] of Listener
       @callbacks = [] of CbRow
       @seen = Hash(Int64, Set(String)).new       # session_id → seen provider_uids (dedup)
@@ -70,7 +78,7 @@ module Gori::Tui
       @last_payload = nil.as(String?)
       @oast_events = Channel(Oast::Event).new(256)
       @reg_events = Channel(RegResult).new(16)
-      @registering = Set(Int64).new # provider ids with a register round-trip in flight (dedup g/^R)
+      @registering = Set(String).new # provider keys with a register round-trip in flight (dedup g/^R)
       @max_cb_id = 0_i64            # highest callback row id folded in (watermark for reconcile)
       @cb_version = 0               # bumped on any @callbacks mutation → invalidates the view caches
       @ordered_cache = nil.as(Array(CbRow)?)
@@ -152,7 +160,7 @@ module Gori::Tui
     # Also reflects any peer-process deletions. Live/soft-sync updates go through reconcile.
     def reload : Nil
       store = @host.session.store
-      @providers = store.oast_providers
+      @providers = Oast.provider_configs(store)
       @callbacks.clear
       @seen.clear
       @session_label.clear
@@ -172,7 +180,7 @@ module Gori::Tui
     # must stay incremental; the full-table reload lives in reload (init + on_enter).
     def reconcile : Nil
       store = @host.session.store
-      @providers = store.oast_providers
+      @providers = Oast.provider_configs(store)
       store.oast_sessions.each do |s|
         @session_label[s.id] = provider_label_for(s)
         @seen[s.id] ||= Set(String).new
@@ -201,7 +209,7 @@ module Gori::Tui
     end
 
     private def provider_label_for(s : Store::OastSessionRecord) : String
-      if (pid = s.provider_id) && (p = @providers.find { |pr| pr.id == pid })
+      if (pid = s.provider_id) && (p = @providers.find { |pr| pr.project_id == pid })
         p.name
       else
         Oast::ProviderKind.parse?(s.kind).try(&.label) || s.kind
@@ -215,11 +223,11 @@ module Gori::Tui
     end
 
     # --- enabled providers (payload bar picks among these) ---
-    private def enabled_providers : Array(Store::OastProviderRecord)
-      @providers.select(&.enabled?)
+    private def enabled_providers : Array(Oast::ProviderConfig)
+      @providers.select(&.enabled)
     end
 
-    private def picked_provider : Store::OastProviderRecord?
+    private def picked_provider : Oast::ProviderConfig?
       ep = enabled_providers
       return nil if ep.empty? || @payload_pick == 0
       ep[(@payload_pick - 1).clamp(0, ep.size - 1)]?
@@ -237,7 +245,7 @@ module Gori::Tui
       end
       prov = picked_provider
       return @host.status("no enabled provider — add one in the Providers tab") unless prov
-      if listener = listener_for(prov.id)
+      if listener = listener_for(prov.key)
         url = listener.provider.generate_payload(listener.session)
         deliver_payload(url)
       else
@@ -260,7 +268,7 @@ module Gori::Tui
       end
       prov = picked_provider
       return @host.status("no enabled provider to listen with") unless prov
-      if listener_for(prov.id)
+      if listener_for(prov.key)
         @host.status("already listening with #{prov.name}")
       else
         start_listening(prov, want_payload: false)
@@ -273,40 +281,41 @@ module Gori::Tui
       end
       prov = picked_provider
       return @host.status("no provider selected") unless prov
-      listener = listener_for(prov.id)
+      listener = listener_for(prov.key)
       return @host.status("not listening with #{prov.name}") unless listener
       stop_listener(listener)
       @host.status("stopped listening with #{prov.name}")
     end
 
-    private def start_listening(prov : Store::OastProviderRecord, want_payload : Bool) : Nil
+    private def start_listening(prov : Oast::ProviderConfig, want_payload : Bool) : Nil
       # A register round-trip takes a few seconds and only appends the Listener on the
       # drain tick AFTER it returns, so listener_for is nil the whole time. Without an
       # in-flight guard a second g/^R spawns a duplicate register → two sessions, two
-      # Listeners and two poller fibers for one provider. Dedup on the provider id.
-      pid = prov.id
-      return @host.status("already registering with #{prov.name}…") if pid && @registering.includes?(pid)
+      # Listeners and two poller fibers for one provider. Dedup on the provider key.
+      key = prov.key
+      return @host.status("already registering with #{prov.name}…") if @registering.includes?(key)
       kind = Oast::ProviderKind.parse?(prov.kind)
       return @host.status("unknown provider type #{prov.kind}") unless kind
       provider = Oast::Provider.build(kind, prov.host, prov.token)
       http = Oast::HttpClient.new(verify_tls: !@host.session.config.insecure_upstream?)
       reg = @reg_events
       label = prov.name
-      @registering << pid if pid
+      db_id = prov.project_id
+      @registering << key
       spawn(name: "gori-oast-register") do
         begin
           session = provider.register(http)
-          reg.send(RegOk.new(session, provider, pid, label, want_payload))
+          reg.send(RegOk.new(session, provider, key, db_id, label, want_payload))
         rescue ex
-          reg.send(RegErr.new(ex.message || "register failed", label, pid))
+          reg.send(RegErr.new(ex.message || "register failed", label, key))
         end
       end
       @host.status("registering with #{label}…")
     end
 
-    private def listener_for(provider_id : Int64?) : Listener?
-      return nil unless provider_id
-      @listeners.find { |l| l.provider_id == provider_id && l.active? }
+    private def listener_for(provider_key : String?) : Listener?
+      return nil unless provider_key
+      @listeners.find { |l| l.provider_key == provider_key && l.active? }
     end
 
     private def stop_listener(listener : Listener) : Nil
@@ -345,17 +354,18 @@ module Gori::Tui
     # =========================================================================
 
     def open_add_provider : Nil
-      @host.open_oast_provider_editor(nil, "", "interactsh", "", "")
+      @host.open_oast_provider_editor(nil)
     end
 
     def open_edit_provider : Nil
       return @host.status("no provider selected") unless p = selected_provider
-      @host.open_oast_provider_editor(p.id, p.name, p.kind, p.host, p.token || "")
+      @host.open_oast_provider_editor(p)
     end
 
     def toggle_provider : Nil
       return unless p = selected_provider
-      @host.session.store.set_oast_provider_enabled(p.id, !p.enabled?)
+      on = !p.enabled
+      p.global? ? Settings.set_oast_provider_enabled(p.id, on) : @host.session.store.set_oast_provider_enabled(p.project_id.not_nil!, on)
       reload
     end
 
@@ -363,27 +373,59 @@ module Gori::Tui
       return unless p = selected_provider
       @host.confirm("DELETE PROVIDER", "Delete OAST provider \"#{p.name}\"?\nIts callback history is kept.",
         confirm_label: "delete", danger: true) do
-        if l = @listeners.find { |ls| ls.provider_id == p.id }
+        if l = @listeners.find { |ls| ls.provider_key == p.key }
           stop_listener(l)
         end
-        @host.session.store.delete_oast_provider(p.id)
+        p.global? ? Settings.delete_oast_provider(p.id) : @host.session.store.delete_oast_provider(p.project_id.not_nil!)
         reload
       end
     end
 
-    # Called back by the runner when the provider overlay commits.
-    def save_provider(edit_id : Int64?, name : String, kind : Oast::ProviderKind, host : String, token : String?) : Nil
+    # Called back by the runner when the provider overlay commits. Returns false (keep the
+    # form open) when invalid. A scope change on edit moves the provider between the global
+    # library and the project DB (mirrors ProbeController#apply_custom_rule) — its prior
+    # enabled state is carried over (not reset to on), and any listener still keyed to the
+    # OLD scope/id is stopped first (mirrors delete_provider), since the move mints a fresh
+    # key that nothing could ever reach it under again otherwise.
+    def save_provider(ov : OastProviderOverlay) : Bool
+      return false unless ov.valid?
       store = @host.session.store
-      if id = edit_id
-        store.update_oast_provider(id, name, kind.label, host, token, true)
+      if id = ov.edit_id
+        old = @providers.find { |p| p.scope == ov.edit_scope && p.id == id }
+        prev_enabled = old.try(&.enabled)
+        prev_enabled = true if prev_enabled.nil?
+        if ov.scope == ov.edit_scope
+          if ov.scope == "global"
+            Settings.update_oast_provider(id, ov.provider_name, ov.kind.label, ov.host, ov.token)
+          else
+            store.update_oast_provider(id.to_i64, ov.provider_name, ov.kind.label, ov.host, ov.token, prev_enabled)
+          end
+        else
+          if old && (l = @listeners.find { |ls| ls.provider_key == old.key })
+            stop_listener(l)
+          end
+          ov.edit_scope == "global" ? Settings.delete_oast_provider(id) : store.delete_oast_provider(id.to_i64)
+          insert_provider(store, ov, prev_enabled)
+        end
+        @host.status("updated provider #{ov.provider_name}")
       else
-        store.insert_oast_provider(name, kind.label, host, token, true, @providers.size)
+        insert_provider(store, ov, true)
+        @host.status("added provider #{ov.provider_name}")
       end
       reload
-      @host.status("saved provider #{name}")
+      true
     end
 
-    private def selected_provider : Store::OastProviderRecord?
+    private def insert_provider(store : Store, ov : OastProviderOverlay, enabled : Bool) : Nil
+      if ov.scope == "global"
+        Settings.add_oast_provider(ov.provider_name, ov.kind.label, ov.host, ov.token, enabled)
+      else
+        project_count = @providers.count { |p| !p.global? }
+        store.insert_oast_provider(ov.provider_name, ov.kind.label, ov.host, ov.token, enabled, project_count)
+      end
+    end
+
+    private def selected_provider : Oast::ProviderConfig?
       @providers[@prov_sel]?
     end
 
@@ -458,7 +500,7 @@ module Gori::Tui
         @listeners.any?(&.active?) ? "  ●listening" : ""
       else
         prov = ep[@payload_pick - 1]?
-        prov && listener_for(prov.id) ? "  ●listening" : ""
+        prov && listener_for(prov.key) ? "  ●listening" : ""
       end
       x = screen.text(x, rect.y, name, Theme.accent, Theme.panel)
       screen.text(x, rect.y, listening, Theme.green, Theme.panel) unless listening.empty?
@@ -546,8 +588,9 @@ module Gori::Tui
         return
       end
       screen.text(inner.x + 2, inner.y, "NAME", Theme.muted, Theme.bg)
-      screen.text(inner.x + 24, inner.y, "TYPE", Theme.muted, Theme.bg)
-      screen.text(inner.x + 38, inner.y, "HOST", Theme.muted, Theme.bg)
+      screen.text(inner.x + 19, inner.y, "SCOPE", Theme.muted, Theme.bg)
+      screen.text(inner.x + 27, inner.y, "TYPE", Theme.muted, Theme.bg)
+      screen.text(inner.x + 41, inner.y, "HOST", Theme.muted, Theme.bg)
       screen.text(inner.right - 8, inner.y, "ENABLED", Theme.muted, Theme.bg)
       rows = Rect.new(inner.x, inner.y + 1, inner.w, inner.h - 1)
       return if rows.h <= 0 # collapsed pane (tiny terminal): a negative slice count would raise
@@ -559,14 +602,15 @@ module Gori::Tui
         bg = sel ? (focused ? Theme.accent_bg : Theme.selection_dim) : Theme.bg
         screen.fill(Rect.new(rows.x, py, rows.w, 1), bg)
         screen.cell(rows.x, py, sel ? '▎' : ' ', Theme.accent, bg)
-        screen.text(rows.x + 2, py, p.name, sel ? Theme.text_bright : Theme.text, bg, width: 21)
+        screen.text(rows.x + 2, py, p.name, sel ? Theme.text_bright : Theme.text, bg, width: 16)
+        screen.text(rows.x + 19, py, p.global? ? "GLOBAL" : "PROJECT", p.global? ? Theme.yellow : Theme.muted, bg, width: 7)
         kind_label = Oast::ProviderKind.parse?(p.kind).try(&.label) || p.kind
-        screen.text(rows.x + 24, py, kind_label, Theme.accent, bg, width: 13)
-        hw = {rows.right - 10 - (rows.x + 38), 6}.max
-        screen.text(rows.x + 38, py, p.host, Theme.text, bg, width: hw)
-        listening = @listeners.any? { |l| l.provider_id == p.id && l.active? }
-        badge = p.enabled? ? (listening ? "● live" : "on") : "off"
-        screen.text(rows.right - 8, py, badge, p.enabled? ? Theme.green : Theme.muted, bg)
+        screen.text(rows.x + 27, py, kind_label, Theme.accent, bg, width: 13)
+        hw = {rows.right - 10 - (rows.x + 41), 6}.max
+        screen.text(rows.x + 41, py, p.host, Theme.text, bg, width: hw)
+        listening = @listeners.any? { |l| l.provider_key == p.key && l.active? }
+        badge = p.enabled ? (listening ? "● live" : "on") : "off"
+        screen.text(rows.right - 8, py, badge, p.enabled ? Theme.green : Theme.muted, bg)
       end
     end
 
@@ -929,18 +973,27 @@ module Gori::Tui
     end
 
     private def apply_registration(reg : RegResult) : Nil
-      if pid = reg.provider_id
-        @registering.delete(pid) # registration resolved (ok or err) — clear the in-flight guard
-      end
+      @registering.delete(reg.provider_key) # registration resolved (ok or err) — clear the in-flight guard
       case reg
       when RegErr
         @host.status("OAST register failed (#{reg.provider_label}): #{reg.message}")
       when RegOk
+        unless @providers.any? { |p| p.key == reg.provider_key }
+          # The provider was deleted or scope-migrated while register() was in flight — its
+          # key no longer resolves to anything in @providers, so a Listener built from it
+          # could never be found/stopped again. Deregister best-effort and drop the result
+          # instead of leaking an unreachable poller (mirrors stop_listener's deregister).
+          http = poll_http
+          provider = reg.provider
+          session = reg.session
+          spawn(name: "gori-oast-deregister") { provider.deregister(http, session) rescue nil }
+          return @host.status("OAST register for #{reg.provider_label} finished after its provider was removed — discarded")
+        end
         store = @host.session.store
-        id = store.insert_oast_session(reg.provider_id, reg.session.kind.label, reg.session.server_url,
+        id = store.insert_oast_session(reg.db_provider_id, reg.session.kind.label, reg.session.server_url,
           reg.session.correlation_id, reg.session.secret, reg.session.private_key_pem, reg.session.token)
         reg.session.id = id
-        listener = Listener.new(reg.session, reg.provider, reg.provider_id, reg.provider_label)
+        listener = Listener.new(reg.session, reg.provider, reg.provider_key, reg.provider_label)
         listener.job_id = @host.jobs.start(:oast, "OAST #{reg.provider_label}", goto: Jobs::Goto.new(:oast))
         poller = Oast::Poller.new(reg.provider, reg.session, poll_http, POLL_INTERVAL, @oast_events)
         listener.poller = poller

--- a/src/gori/tui/oast_provider_overlay.cr
+++ b/src/gori/tui/oast_provider_overlay.cr
@@ -3,18 +3,33 @@ require "./theme"
 require "./frame"
 require "./text_field"
 require "../oast"
+require "../oast/provider_config"
 
 module Gori::Tui
   # Popup form for adding or editing ONE OAST provider — same interaction model as
-  # ScopeRuleOverlay:
-  #   ↑/↓  field (name → type → host → token → Save)
-  #   ←/→  cycle the provider type when that row is selected
+  # CustomRuleOverlay (which has the same global/project scope row):
+  #   ↑/↓  field (name → scope → type → host → token → Save)
+  #   ←/→  cycle the scope / provider type when that row is selected
   #   type into name/host/token when focused; ↵ on Save (or a text row) commits
   #   esc cancels
+  # The runner validates + persists on :commit (global → settings.json, project → project DB).
   class OastProviderOverlay
-    KINDS = Gori::Oast::ProviderKind.values
+    ROW_NAME  = 0
+    ROW_SCOPE = 1
+    ROW_TYPE  = 2
+    ROW_HOST  = 3
+    ROW_TOKEN = 4
+    ROW_SAVE  = 5
+    ROW_COUNT = 6
 
-    getter edit_id : Int64?
+    SCOPES = %w[project global]
+    KINDS  = Gori::Oast::ProviderKind.values
+
+    getter edit_id : String?
+    getter edit_scope : String?
+
+    @scope_i : Int32
+    @kind_idx : Int32
 
     # Default (public-preset) host per provider type, so cycling the type in an ADD form
     # prefills a working endpoint (the "quick add" convenience without a separate picker).
@@ -24,28 +39,41 @@ module Gori::Tui
       h
     end
 
-    def initialize(*, name : String = "", kind : Gori::Oast::ProviderKind = Gori::Oast::ProviderKind::Interactsh,
-                   host : String = "", token : String = "", @edit_id : Int64? = nil)
+    def initialize(*, name : String = "", scope : String = "project",
+                   kind : Gori::Oast::ProviderKind = Gori::Oast::ProviderKind::Interactsh,
+                   host : String = "", token : String = "",
+                   @edit_id : String? = nil, @edit_scope : String? = nil)
       @name = TextField.new(name)
+      @scope_i = idx(SCOPES, scope)
       @kind_idx = KINDS.index(kind) || 0
       # Adding with no host → prefill the type's default preset host.
       host = DEFAULT_HOSTS[kind]? || "" if host.empty? && @edit_id.nil?
       @host = TextField.new(host)
       @token = TextField.new(token)
       @host_dirty = !@edit_id.nil? # editing keeps its host; adding auto-syncs to the type default
-      @sel = 0                     # 0 name · 1 type · 2 host · 3 token · 4 save
+      @sel = 0                      # ROW_NAME · ROW_SCOPE · ROW_TYPE · ROW_HOST · ROW_TOKEN · ROW_SAVE
     end
 
     def self.adding : OastProviderOverlay
       new
     end
 
-    def self.editing(id : Int64, name : String, kind : Gori::Oast::ProviderKind, host : String, token : String) : OastProviderOverlay
-      new(name: name, kind: kind, host: host, token: token, edit_id: id)
+    def self.editing(config : Gori::Oast::ProviderConfig) : OastProviderOverlay
+      kind = Gori::Oast::ProviderKind.parse?(config.kind) || Gori::Oast::ProviderKind::Interactsh
+      new(name: config.name, scope: config.scope, kind: kind, host: config.host, token: config.token || "",
+        edit_id: config.id, edit_scope: config.scope)
+    end
+
+    private def idx(list : Array(String), v : String) : Int32
+      list.index(v) || 0
     end
 
     def provider_name : String
       @name.value.strip
+    end
+
+    def scope : String
+      SCOPES[@scope_i]
     end
 
     def kind : Gori::Oast::ProviderKind
@@ -70,11 +98,11 @@ module Gori::Tui
     end
 
     private def row_count : Int32
-      5
+      ROW_COUNT
     end
 
     def on_save_row? : Bool
-      @sel == 4
+      @sel == ROW_SAVE
     end
 
     def move(d : Int32) : Nil
@@ -85,11 +113,19 @@ module Gori::Tui
       @sel = idx.clamp(0, row_count - 1)
     end
 
+    private def cycler_row?(row : Int32) : Bool
+      row == ROW_SCOPE || row == ROW_TYPE
+    end
+
     def adjust(d : Int32) : Nil
-      return unless @sel == 1
-      @kind_idx = (@kind_idx + d) % KINDS.size
-      # Keep the host synced to the type's preset until the user edits it themselves.
-      @host = TextField.new(DEFAULT_HOSTS[kind]? || "") unless @host_dirty
+      case @sel
+      when ROW_SCOPE
+        @scope_i = (@scope_i + d) % SCOPES.size
+      when ROW_TYPE
+        @kind_idx = (@kind_idx + d) % KINDS.size
+        # Keep the host synced to the type's preset until the user edits it themselves.
+        @host = TextField.new(DEFAULT_HOSTS[kind]? || "") unless @host_dirty
+      end
     end
 
     # :stay | :commit | :cancel
@@ -104,23 +140,20 @@ module Gori::Tui
         return :stay
       end
 
-      case @sel
-      when 1 # type cycler
-        if key.left?
-          adjust(-1)
-        elsif key.right?
-          adjust(1)
-        elsif key.enter? || key.space?
-          move(1)
+      if cycler_row?(@sel)
+        case
+        when key.left?              then adjust(-1)
+        when key.right?             then adjust(1)
+        when key.enter?, key.space? then move(1)
         end
         :stay
-      when 4 # save row
+      elsif @sel == ROW_SAVE
         (key.enter? || key.space?) ? :commit : :stay
       else # name / host / token text fields
         if key.enter?
           move(1) # ↵ advances to the next field; only the Save row commits
         else
-          @host_dirty = true if @sel == 2 # user edited host → stop auto-syncing to the type
+          @host_dirty = true if @sel == ROW_HOST # user edited host → stop auto-syncing to the type
           active_field.handle_edit_key(ev)
         end
         :stay
@@ -129,22 +162,22 @@ module Gori::Tui
 
     private def active_field : TextField
       case @sel
-      when 0 then @name
-      when 2 then @host
-      else        @token
+      when ROW_NAME then @name
+      when ROW_HOST then @host
+      else               @token
       end
     end
 
     def set_preedit(text : String) : Nil
       case @sel
-      when 0, 2, 3 then active_field.set_preedit(text)
+      when ROW_NAME, ROW_HOST, ROW_TOKEN then active_field.set_preedit(text)
       end
     end
 
     def overlay_box(area : Rect) : Rect?
       w = {area.w - 4, 56}.min
-      h = {area.h - 2, 12}.min # title + 5 rows + padding
-      return nil if w < 30 || h < 9
+      h = {area.h - 2, ROW_COUNT + 6}.min # title + rows + padding
+      return nil if w < 30 || h < 10
       Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
     end
 
@@ -164,7 +197,7 @@ module Gori::Tui
       end
       hint_y = box.bottom - 1
       if hint_y > first
-        screen.text(box.x + 2, hint_y, "↑/↓ field · ←/› type · ↵ save · esc cancel",
+        screen.text(box.x + 2, hint_y, "↑/↓ field · ←/› options · ↵ save · esc cancel",
           Theme.muted, Theme.panel, width: box.w - 4)
       end
     end
@@ -177,18 +210,25 @@ module Gori::Tui
       x = box.x + 3
       fg = sel ? Theme.text_bright : Theme.text
       case i
-      when 0 then draw_field(screen, box, py, "name:", @name, sel, bg, fg)
-      when 1
-        screen.text(x, py, "type:", Theme.muted, bg)
-        col = sel ? Theme.text_bright : Theme.accent
-        tx = screen.text(x + 6, py, kind.label, col, bg, Attribute::Bold)
-        screen.text(tx, py, "  ‹/›", Theme.muted, bg)
-      when 2 then draw_field(screen, box, py, "host:", @host, sel, bg, fg)
-      when 3 then draw_field(screen, box, py, "token:", @token, sel, bg, fg)
+      when ROW_NAME then draw_field(screen, box, py, "name:", @name, sel, bg, fg)
+      when ROW_SCOPE
+        draw_cycle(screen, x, py, bg, sel, "scope:", SCOPES, @scope_i)
+      when ROW_TYPE
+        draw_cycle(screen, x, py, bg, sel, "type:", KINDS.map(&.label), @kind_idx)
+      when ROW_HOST  then draw_field(screen, box, py, "host:", @host, sel, bg, fg)
+      when ROW_TOKEN then draw_field(screen, box, py, "token:", @token, sel, bg, fg)
       else
         label = valid? ? "[ Save provider ]" : "[ name + host required ]"
         screen.text(x, py, label, valid? ? Theme.accent : Theme.muted, bg, Attribute::Bold)
       end
+    end
+
+    private def draw_cycle(screen : Screen, x : Int32, py : Int32, bg : Color, row_sel : Bool,
+                           label : String, opts : Array(String), sel_i : Int32) : Nil
+      screen.text(x, py, label, Theme.muted, bg)
+      col = row_sel ? Theme.text_bright : Theme.accent
+      tx = screen.text(x + label.size + 1, py, opts[sel_i], col, bg, Attribute::Bold)
+      screen.text(tx, py, "  ‹/›", Theme.muted, bg)
     end
 
     private def draw_field(screen : Screen, box : Rect, py : Int32, label : String,

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1943,8 +1943,7 @@ module Gori::Tui
     end
 
     private def commit_oast_provider_overlay(ov : OastProviderOverlay) : Nil
-      return unless ov.valid?
-      oast_controller.save_provider(ov.edit_id, ov.provider_name, ov.kind, ov.host, ov.token)
+      return unless oast_controller.save_provider(ov)
       close_oast_provider
     end
 
@@ -4036,7 +4035,7 @@ module Gori::Tui
       when :fuzz_advanced    then "↑/↓/⇥ field · ←/→ edit · ␣ toggle · ↵ next · esc applies & closes"
       when :scope_rule       then "↑/↓ field · ←/→ kind·type · type pattern · ↵ save · esc cancel"
       when :rewriter_rule    then "↑/↓ field · ←/→ options · type find/value · ↵ save · esc cancel"
-      when :oast_provider    then "↑/↓ field · ←/→ type · type name/host/token · ↵ save · esc cancel"
+      when :oast_provider    then "↑/↓ field · ←/→ scope/type · type name/host/token · ↵ save · esc cancel"
       when :ca_import        then "type to complete · ↹/↵ pick · ⇥/↑↓ field · ↵ submits · esc cancels"
       when :import           then "type to complete · ↹ pick · ↑↓ browse · ↵ import · esc cancel"
       when :detail           then history_controller.body_hint(:body)
@@ -5124,15 +5123,9 @@ module Gori::Tui
       @overlay = :scope_rule
     end
 
-    # Host: open the OAST provider add/edit popup (nil edit_id = add a new provider).
-    def open_oast_provider_editor(edit_id : Int64?, name : String, kind : String, host : String, token : String) : Nil
-      k = Oast::ProviderKind.parse?(kind) || Oast::ProviderKind::Interactsh
-      @oast_provider_overlay =
-        if id = edit_id
-          OastProviderOverlay.editing(id, name, k, host, token)
-        else
-          OastProviderOverlay.adding
-        end
+    # Host: open the OAST provider add/edit popup (nil = add a new provider).
+    def open_oast_provider_editor(provider : Oast::ProviderConfig?) : Nil
+      @oast_provider_overlay = provider ? OastProviderOverlay.editing(provider) : OastProviderOverlay.adding
       @overlay = :oast_provider
     end
 

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -38,9 +38,9 @@ module Gori::Tui
     abstract def open_custom_rule_editor(rule : Probe::CustomRule?) : Nil
     # Open the Rewriter (Match & Replace) rule popup (nil = add; else edit the given rule).
     abstract def open_rewriter_rule_editor(rule : Store::MatchRule?) : Nil
-    # Open the OAST provider add/edit popup (nil edit_id = add; else edit that provider).
-    # `kind` is a ProviderKind label; seeds the form when editing (defaults for add).
-    abstract def open_oast_provider_editor(edit_id : Int64?, name : String, kind : String, host : String, token : String) : Nil
+    # Open the OAST provider add/edit popup (nil = add a new provider; else edit the given
+    # provider — global or project scope, per Oast::ProviderConfig#scope).
+    abstract def open_oast_provider_editor(provider : Oast::ProviderConfig?) : Nil
     # Destructive-action confirmation modal; `action` runs on confirm. `return_to` is the
     # overlay restored on cancel/accept (default :none) — pass the launching overlay (e.g.
     # :detail) when raising the confirm from inside another overlay so cancel returns there.


### PR DESCRIPTION
## Summary
- OAST providers were always bound to the current project. Add a Global scope, reusable across every project, mirroring the existing Global/Project split for Probe custom rules.
- Add a scope switch (project/global) to the OAST provider add/edit popup.
- `Oast::ProviderConfig` merges the global library (`Settings.oast_providers`, `~/.gori/settings.json`) with the project's own providers (`store.oast_providers`) into one runtime list the Providers sub-tab renders and registers/listens from.
- Editing an existing provider can move it between scopes; the migration stops any active listener on the old provider first and carries over its enabled state instead of resetting it to on.

## Test plan
- [x] `crystal build src/main.cr --no-codegen` — clean
- [x] `crystal spec` — 3286 examples, 0 failures
- [x] Added specs: `spec/oast_provider_config_spec.cr` (global CRUD + global/project merge), updated `spec/tui/oast_provider_overlay_spec.cr` for the new scope row