### PR TITLE
TUI: show recent + favorited wordlist paths in the Fuzzer's Payload wordlist field

### DIFF
--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -696,6 +696,72 @@ describe Gori::Settings do
     end
   end
 
+  it "round-trips the Fuzzer wordlist recent + favorite paths" do
+    dir = File.tempname("gori-settings-fuzzer-wordlists")
+    Dir.mkdir_p(dir)
+    prev = ENV["GORI_HOME"]?
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.fuzz_recent_wordlists = [] of String
+      Gori::Settings.fuzz_favorite_wordlists = [] of String
+
+      Gori::Settings.record_recent_wordlist("/tmp/a.txt")
+      Gori::Settings.record_recent_wordlist("/tmp/b.txt")
+      # re-using an already-recent path moves it back to the front instead of duplicating it
+      Gori::Settings.record_recent_wordlist("/tmp/a.txt")
+      Gori::Settings.fuzz_recent_wordlists.should eq(["/tmp/a.txt", "/tmp/b.txt"])
+
+      # re-recording the path ALREADY at the front is a true no-op — no rebuild, no save.
+      # Proven by deleting the persisted file and confirming record doesn't recreate it
+      # (an mtime check could pass even with a broken guard if both saves land in the
+      # same clock tick, so absence/presence of the file is the deterministic signal).
+      File.delete?(Gori::Settings.path)
+      Gori::Settings.record_recent_wordlist("/tmp/a.txt")
+      Gori::Settings.fuzz_recent_wordlists.should eq(["/tmp/a.txt", "/tmp/b.txt"])
+      File.exists?(Gori::Settings.path).should be_false
+
+      Gori::Settings.toggle_favorite_wordlist("/tmp/b.txt").should be_true
+      Gori::Settings.favorite_wordlist?("/tmp/b.txt").should be_true
+
+      Gori::Settings.fuzz_recent_wordlists = [] of String
+      Gori::Settings.fuzz_favorite_wordlists = [] of String
+      Gori::Settings.load
+      Gori::Settings.fuzz_recent_wordlists.should eq(["/tmp/a.txt", "/tmp/b.txt"])
+      Gori::Settings.fuzz_favorite_wordlists.should eq(["/tmp/b.txt"])
+
+      # toggling again removes it
+      Gori::Settings.toggle_favorite_wordlist("/tmp/b.txt").should be_false
+      Gori::Settings.favorite_wordlist?("/tmp/b.txt").should be_false
+    ensure
+      prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(dir)
+      Gori::Settings.fuzz_recent_wordlists = [] of String
+      Gori::Settings.fuzz_favorite_wordlists = [] of String
+    end
+  end
+
+  it "caps the recent-wordlists MRU list and omits the fuzzer key when both lists are empty" do
+    dir = File.tempname("gori-settings-fuzzer-wordlists-cap")
+    Dir.mkdir_p(dir)
+    prev = ENV["GORI_HOME"]?
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.fuzz_recent_wordlists = [] of String
+      Gori::Settings.fuzz_favorite_wordlists = [] of String
+      Gori::Settings.save.should be_true
+      File.read(Gori::Settings.path).includes?("fuzzer").should be_false
+
+      15.times { |i| Gori::Settings.record_recent_wordlist("/tmp/wl#{i}.txt") }
+      Gori::Settings.fuzz_recent_wordlists.size.should eq(Gori::Settings::RECENT_WORDLISTS_CAP)
+      Gori::Settings.fuzz_recent_wordlists.first.should eq("/tmp/wl14.txt")
+    ensure
+      prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(dir)
+      Gori::Settings.fuzz_recent_wordlists = [] of String
+      Gori::Settings.fuzz_favorite_wordlists = [] of String
+    end
+  end
+
   describe "per-project network override layer" do
     it "effective_* falls back to the global when no override is set" do
       reset_net

--- a/spec/tui/fuzz_set_overlay_spec.cr
+++ b/spec/tui/fuzz_set_overlay_spec.cr
@@ -11,6 +11,10 @@ private def otype(ov : FuzzSetOverlay, s : String) : Nil
   s.each_char { |c| ov.handle_key(okey(Termisu::Input::Key::LowerA, c)) }
 end
 
+private def ctrl_d : Termisu::Event::Key
+  Termisu::Event::Key.new(Termisu::Input::Key::LowerD, Termisu::Input::Modifier::Ctrl)
+end
+
 describe Gori::Tui::FuzzSetOverlay do
   it "List: multi-line values build a comma-joined spec (newline = a new value)" do
     ov = FuzzSetOverlay.for_list
@@ -96,5 +100,38 @@ describe Gori::Tui::FuzzSetOverlay do
     ov.render(Screen.new(backend), Rect.new(0, 0, 120, 30))
     backend.contains?("PAYLOAD SET").should be_true
     backend.contains?("List").should be_true
+  end
+
+  it "^D on the wordlist Path field toggles the typed path in/out of favorites" do
+    dir = File.tempname("gori-fuzz-set-overlay-favorite")
+    Dir.mkdir_p(dir)
+    prev = ENV["GORI_HOME"]?
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.fuzz_favorite_wordlists = [] of String
+
+      ov = FuzzSetOverlay.for_list
+      2.times { ov.handle_key(okey(Termisu::Input::Key::Right)) } # List → Wordlist
+      ov.handle_key(okey(Termisu::Input::Key::Down))              # Type row → the Path field
+      otype(ov, "/tmp/words.txt")
+
+      Gori::Settings.favorite_wordlist?("/tmp/words.txt").should be_false
+      ov.handle_key(ctrl_d).should eq(:stay) # doesn't apply/close the overlay
+      Gori::Settings.favorite_wordlist?("/tmp/words.txt").should be_true
+      # the star indicator renders alongside the Path field once favorited
+      backend = MemoryBackend.new(120, 30)
+      ov.render(Screen.new(backend), Rect.new(0, 0, 120, 30))
+      backend.contains?("★").should be_true
+
+      ov.handle_key(ctrl_d) # toggle back off
+      Gori::Settings.favorite_wordlist?("/tmp/words.txt").should be_false
+
+      # the path itself is untouched — ^D only manages favorites
+      ov.build_spec.not_nil!.value.should eq("/tmp/words.txt")
+    ensure
+      prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(dir)
+      Gori::Settings.fuzz_favorite_wordlists = [] of String
+    end
   end
 end

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -492,6 +492,117 @@ describe Gori::Tui::PathComplete do
       FileUtils.rm_rf(root)
     end
   end
+
+  it "a blank field lists favorites (under a header) before recents, excluding recents already favorited" do
+    Gori::Settings.fuzz_favorite_wordlists = ["/wl/fav.txt"]
+    Gori::Settings.fuzz_recent_wordlists = ["/wl/fav.txt", "/wl/recent.txt"]
+    begin
+      pc = PathComplete.new(wordlist_history: true)
+      pc.refresh("")
+      pc.open?.should be_true
+      pc.entries.map(&.label).should eq(["★ Favorites", "/wl/fav.txt", "🕒 Recent", "/wl/recent.txt"])
+      # the cursor lands on the first SELECTABLE row, not the header
+      pc.selected.should eq(1)
+    ensure
+      Gori::Settings.fuzz_favorite_wordlists = [] of String
+      Gori::Settings.fuzz_recent_wordlists = [] of String
+    end
+  end
+
+  it "an instance NOT opted into wordlist_history ignores recent/favorite state entirely (Import/CA-import overlays)" do
+    home = File.tempname("gori_home_pc_no_history")
+    wl = File.join(home, "wordlists")
+    Dir.mkdir_p(wl)
+    File.write(File.join(wl, "rockyou.txt"), "")
+    old = ENV["GORI_HOME"]?
+    ENV["GORI_HOME"] = home
+    Gori::Settings.fuzz_favorite_wordlists = ["/wl/fav.txt"]
+    Gori::Settings.fuzz_recent_wordlists = ["/wl/recent.txt"]
+    begin
+      pc = PathComplete.new # the default — every non-Fuzzer caller (Import, CA Import)
+      pc.refresh("")
+      pc.open?.should be_true # still opens the plain cwd + ~/.gori/wordlists listing
+      pc.entries.map(&.label).should_not contain("★ Favorites")
+      pc.entries.map(&.label).should_not contain("🕒 Recent")
+      pc.entries.none? { |e| e.label == "/wl/fav.txt" || e.label == "/wl/recent.txt" }.should be_true
+    ensure
+      old ? (ENV["GORI_HOME"] = old) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(home)
+      Gori::Settings.fuzz_favorite_wordlists = [] of String
+      Gori::Settings.fuzz_recent_wordlists = [] of String
+    end
+  end
+
+  it "falls back to the cwd + ~/.gori/wordlists listing when blank with no recent/favorite history yet" do
+    home = File.tempname("gori_home_pc_fallback")
+    wl = File.join(home, "wordlists")
+    Dir.mkdir_p(wl)
+    File.write(File.join(wl, "rockyou.txt"), "")
+    cwd = File.tempname("gori_pc_fallback_cwd")
+    Dir.mkdir_p(cwd)
+    old_home = ENV["GORI_HOME"]?
+    old_cwd = Dir.current
+    ENV["GORI_HOME"] = home
+    # An empty, dedicated cwd — the merged cwd + ~/.gori/wordlists list is capped
+    # (PathComplete::CAP), so asserting against the REAL repo root (which the
+    # process's actual cwd would otherwise be) is one runaway top-level file away
+    # from evicting rockyou.txt out of the cap and flaking this assertion.
+    Dir.cd(cwd)
+    Gori::Settings.fuzz_recent_wordlists = [] of String
+    Gori::Settings.fuzz_favorite_wordlists = [] of String
+    begin
+      pc = PathComplete.new(wordlist_history: true)
+      pc.refresh("")
+      pc.open?.should be_true
+      pc.entries.map(&.label).should_not contain("★ Favorites")
+      pc.entries.map(&.label).should_not contain("🕒 Recent")
+      pc.entries.any?(&.label.starts_with?("rockyou.txt")).should be_true
+    ensure
+      Dir.cd(old_cwd)
+      old_home ? (ENV["GORI_HOME"] = old_home) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(home)
+      FileUtils.rm_rf(cwd)
+    end
+  end
+
+  it "move() steps over header rows in both directions and stops (no-op) at either edge" do
+    Gori::Settings.fuzz_favorite_wordlists = ["/wl/fav.txt"]
+    Gori::Settings.fuzz_recent_wordlists = ["/wl/recent.txt"]
+    begin
+      pc = PathComplete.new(wordlist_history: true)
+      pc.refresh("") # entries: [Header, fav.txt, Header, recent.txt] · selected = 1
+      pc.selected.should eq(1)
+
+      pc.move(-1) # nothing selectable above the Favorites header — no-op
+      pc.selected.should eq(1)
+
+      pc.move(1) # fav.txt → skips the "Recent" header → lands on recent.txt
+      pc.selected.should eq(3)
+
+      pc.move(1) # already on the last row — no-op
+      pc.selected.should eq(3)
+
+      pc.move(-1) # recent.txt → skips the header → back to fav.txt
+      pc.selected.should eq(1)
+    ensure
+      Gori::Settings.fuzz_favorite_wordlists = [] of String
+      Gori::Settings.fuzz_recent_wordlists = [] of String
+    end
+  end
+
+  it "typing even one character drops the recent/favorite view for the usual fuzzy directory search" do
+    Gori::Settings.fuzz_favorite_wordlists = ["/wl/fav.txt"]
+    Gori::Settings.fuzz_recent_wordlists = ["/wl/recent.txt"]
+    begin
+      pc = PathComplete.new(wordlist_history: true)
+      pc.refresh("x")
+      pc.entries.map(&.label).should_not contain("★ Favorites")
+      pc.entries.map(&.label).should_not contain("🕒 Recent")
+    ensure
+      Gori::Settings.fuzz_favorite_wordlists = [] of String
+      Gori::Settings.fuzz_recent_wordlists = [] of String
+    end
+  end
 end
 
 describe "FuzzerView#template_click_to_cursor / #target_click_to_cursor" do

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -11,6 +11,7 @@ require "./settings/miner"
 require "./settings/probe"
 require "./settings/discover"
 require "./settings/update"
+require "./settings/fuzzer"
 
 module Gori
   # Global, persisted user settings — the editable runtime CONFIG for one gori
@@ -75,6 +76,7 @@ module Gori
         self.decoder_chains = parse_decoder_chains(cv["chains"]?)
       end
       parse_mine_prefs(root["mine"]?)
+      parse_fuzzer_prefs(root["fuzzer"]?)
       if pr = root["probe"]?.try(&.as_h?)
         pr["active_notify"]?.try(&.as_s?).try { |s| self.probe_active_notify = s }
       end
@@ -178,6 +180,7 @@ module Gori
           serialize_scan_rules(j)
           serialize_hotkeys(j)
           serialize_mine(j)
+          serialize_fuzzer(j)
           serialize_probe(j)
           serialize_discover(j)
           serialize_decoder(j)

--- a/src/gori/settings/fuzzer.cr
+++ b/src/gori/settings/fuzzer.cr
@@ -1,0 +1,70 @@
+require "json"
+
+# FUZZER section: recently-used + favorited wordlist file paths for the Payload
+# overlay's wordlist Path field (global scratch/prefs, not project data). See
+# settings.cr for the module-level overview and the load/save/serialize orchestration.
+module Gori::Settings
+  # MRU cap: PathComplete's dropdown only ever shows ~8 rows at a time, so a
+  # double-page's worth is plenty without letting the list grow unbounded.
+  RECENT_WORDLISTS_CAP = 10
+
+  class_property fuzz_recent_wordlists : Array(String) = [] of String
+  class_property fuzz_favorite_wordlists : Array(String) = [] of String
+
+  # Move `path` to the front (deduped), capped. Called once a wordlist payload set
+  # is actually applied to the Fuzzer session, not on every keystroke — but that's
+  # still once per esc/↵ on an UNCHANGED existing set, so skip the array rebuild +
+  # disk save entirely when `path` is already the most-recent entry (a no-op).
+  def self.record_recent_wordlist(path : String) : Nil
+    p = path.strip
+    return if p.empty? || fuzz_recent_wordlists.first? == p
+    self.fuzz_recent_wordlists = ([p] + fuzz_recent_wordlists.reject { |e| e == p }).first(RECENT_WORDLISTS_CAP)
+    save
+  end
+
+  # Add/remove `path` from favorites. Returns the NEW favorite state so the caller
+  # (the Path field's ★ indicator) can reflect it without a second lookup.
+  def self.toggle_favorite_wordlist(path : String) : Bool
+    p = path.strip
+    return false if p.empty?
+    now_favorite = !fuzz_favorite_wordlists.includes?(p)
+    self.fuzz_favorite_wordlists = now_favorite ? [p] + fuzz_favorite_wordlists : fuzz_favorite_wordlists.reject { |e| e == p }
+    save
+    now_favorite
+  end
+
+  def self.favorite_wordlist?(path : String) : Bool
+    fuzz_favorite_wordlists.includes?(path.strip)
+  end
+
+  private def self.parse_fuzzer_prefs(node : JSON::Any?) : Nil
+    obj = node.try(&.as_h?)
+    return unless obj
+    if recent = obj["recent_wordlists"]?.try(&.as_a?)
+      self.fuzz_recent_wordlists = recent.compact_map(&.as_s?).map(&.strip).reject(&.empty?).first(RECENT_WORDLISTS_CAP)
+    end
+    if favs = obj["favorite_wordlists"]?.try(&.as_a?)
+      self.fuzz_favorite_wordlists = favs.compact_map(&.as_s?).map(&.strip).reject(&.empty?)
+    end
+  end
+
+  # Omit the whole block when there's nothing worth persisting, so an install that
+  # never touches the wordlist field never grows a "fuzzer" section.
+  private def self.serialize_fuzzer(j : JSON::Builder) : Nil
+    return if fuzz_recent_wordlists.empty? && fuzz_favorite_wordlists.empty?
+    j.field "fuzzer" do
+      j.object do
+        unless fuzz_recent_wordlists.empty?
+          j.field "recent_wordlists" do
+            j.array { fuzz_recent_wordlists.each { |p| j.string p } }
+          end
+        end
+        unless fuzz_favorite_wordlists.empty?
+          j.field "favorite_wordlists" do
+            j.array { fuzz_favorite_wordlists.each { |p| j.string p } }
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -278,6 +278,7 @@ module Gori::Tui
     def apply_fuzz_set(edit_index : Int32?, spec : SetSpec?) : Nil
       return unless v = current_view
       v.apply_set(edit_index, spec)
+      Settings.record_recent_wordlist(spec.value) if spec && spec.kind == :file
       save_current
     end
 

--- a/src/gori/tui/fuzz_set_overlay.cr
+++ b/src/gori/tui/fuzz_set_overlay.cr
@@ -4,6 +4,7 @@ require "./frame"
 require "./text_area"
 require "./text_field"
 require "./path_complete"
+require "../settings"
 
 module Gori::Tui
   # One payload set: a source kind + a value string in the compact grammar the Fuzz
@@ -43,7 +44,7 @@ module Gori::Tui
       }
       @values = TextArea.new
       @values.follow_x = true # long list values scroll horizontally to keep the caret visible
-      @path_complete = PathComplete.new
+      @path_complete = PathComplete.new(wordlist_history: true)
     end
 
     # Open pre-seeded to List (the ^L / "Add a List payload set" verb).
@@ -196,6 +197,10 @@ module Gori::Tui
     private def handle_field(ev : Termisu::Event::Key, f : Symbol) : Symbol
       key = ev.key
       tf = @fields[f]? || return :stay
+      # ^D (browser-bookmark convention): toggle the CURRENTLY TYPED path in/out of
+      # favorites — checked before the TextField sees the keystroke so it never
+      # inserts a literal "d".
+      return toggle_favorite_path if f == :path && ev.ctrl_d?
       case
       when key.up?    then move_row(-1)
       when key.down?  then move_row(1)
@@ -204,6 +209,11 @@ module Gori::Tui
         tf.handle_edit_key(ev)
         refresh_path(f) # keep the wordlist dropdown in lockstep with the field
       end
+      :stay
+    end
+
+    private def toggle_favorite_path : Symbol
+      Gori::Settings.toggle_favorite_wordlist(@fields[:path].value)
       :stay
     end
 
@@ -364,7 +374,11 @@ module Gori::Tui
         bg = foc ? Theme.accent_bg : Theme.bg
         screen.fill(Rect.new(box.x + 1, y, box.w - 2, 1), bg) if foc
         screen.text(box.x + 2, y, field_label(f), foc ? Theme.text_bright : Theme.muted, bg)
-        @fields[f].render(screen, vx, y, vw, foc, foc ? Theme.text_bright : Theme.text, bg)
+        # overlay_box already refused to render below w=34 (see `render`), so vw - 2
+        # never underflows here.
+        favorited = f == :path && Gori::Settings.favorite_wordlist?(@fields[f].value)
+        screen.text(box.right - 3, y, "★", Theme.accent, bg) if favorited
+        @fields[f].render(screen, vx, y, favorited ? vw - 2 : vw, foc, foc ? Theme.text_bright : Theme.text, bg)
       end
     end
 
@@ -385,7 +399,7 @@ module Gori::Tui
       hint =
         case @ptype
         when :list     then "one value per line · ↵ new value · ⇥ field · esc applies"
-        when :wordlist then "type to filter · ↹/↵ complete · ⇥ field · esc applies"
+        when :wordlist then "filter · ↹/↵ complete · ^D favorite · ⇥ field · esc applies"
         else                "⇥/↑↓ field · ↵ next · esc applies & closes"
         end
       screen.text(box.x + 2, box.bottom - 2, hint, Theme.muted, Theme.bg, width: box.w - 4)

--- a/src/gori/tui/path_complete.cr
+++ b/src/gori/tui/path_complete.cr
@@ -2,6 +2,7 @@ require "./screen"
 require "./theme"
 require "../fuzzy"
 require "../paths"
+require "../settings"
 
 module Gori::Tui
   # Inline filesystem path completion for the wordlist payload field. Mirrors the
@@ -13,7 +14,9 @@ module Gori::Tui
   class PathComplete
     CAP = 60
 
-    record Entry, label : String, insert : String, dir : Bool
+    # `header` rows (section labels "★ Favorites" / "🕒 Recent") are unselectable —
+    # `move` steps over them and `refresh`/`accept` never land the cursor on one.
+    record Entry, label : String, insert : String, dir : Bool, header : Bool = false
 
     getter? open : Bool = false
     getter entries : Array(Entry) = [] of Entry
@@ -21,16 +24,33 @@ module Gori::Tui
     @scroll = 0
     @cache = {} of String => Array(String) # dir → sorted children
 
-    def refresh(value : String) : Nil
-      @entries = candidates(value)
-      @selected = 0
-      @scroll = 0
-      @open = !@entries.empty?
+    # PathComplete is shared by every path-picking field in the TUI (the Fuzzer
+    # wordlist Path, the Import overlay's source path, the CA Import cert/key
+    # paths, …). The recent/favorite view is Fuzzer-wordlist-specific data
+    # (Gori::Settings.fuzz_recent_wordlists/fuzz_favorite_wordlists), so it must
+    # opt in per instance — defaulting it on would leak wordlist history into
+    # every other overlay's blank-field dropdown.
+    def initialize(@wordlist_history : Bool = false)
     end
 
+    def refresh(value : String) : Nil
+      @entries = candidates(value)
+      @selected = @entries.index { |e| !e.header } || 0
+      @scroll = 0
+      @open = @entries.any? { |e| !e.header }
+    end
+
+    # Steps by `d`, skipping header rows; a no-op if there's no selectable row
+    # further in that direction (mirrors the plain clamp's edge no-op).
     def move(d : Int32) : Nil
       return if @entries.empty?
-      @selected = (@selected + d).clamp(0, @entries.size - 1)
+      i = @selected
+      loop do
+        i += d
+        return if i < 0 || i >= @entries.size
+        break unless @entries[i].header
+      end
+      @selected = i
     end
 
     def close : Nil
@@ -41,10 +61,21 @@ module Gori::Tui
     # popup open + refreshes on a dir, closes on a file). nil when nothing selectable.
     def accept : {String, Bool}?
       e = @entries[@selected]? || return nil
+      return nil if e.header
       {e.insert, e.dir}
     end
 
+    # Blank Path field → the user's own recent/favorited wordlist picks (no cwd
+    # noise); typing anything at all falls through to the usual fuzzy directory
+    # search below. Favorites first, then recents (a path already favorited isn't
+    # repeated under Recent). A user with no history yet (or a fresh install)
+    # still gets the original cwd + ~/.gori/wordlists listing — recent/favorite
+    # is additive, not a replacement for that discovery path.
     private def candidates(value : String) : Array(Entry)
+      if value.empty? && @wordlist_history
+        rf = recent_and_favorite_entries
+        return rf unless rf.empty?
+      end
       if slash = value.rindex('/')
         prefix = value[0..slash] # kept verbatim, incl. trailing '/'
         partial = value[(slash + 1)..]
@@ -67,6 +98,30 @@ module Gori::Tui
         end
         merge_cap(merged)
       end
+    end
+
+    private def recent_and_favorite_entries : Array(Entry)
+      favs = Gori::Settings.fuzz_favorite_wordlists
+      recents = Gori::Settings.fuzz_recent_wordlists.reject { |p| favs.includes?(p) }
+      entries = [] of Entry
+      unless favs.empty?
+        entries << Entry.new("★ Favorites", "", false, header: true)
+        favs.first(CAP).each { |p| entries << history_entry(p) }
+      end
+      unless recents.empty?
+        entries << Entry.new("🕒 Recent", "", false, header: true)
+        recents.first(CAP).each { |p| entries << history_entry(p) }
+      end
+      entries
+    end
+
+    # A history (recent/favorite) pick's dir-ness must be checked against the
+    # filesystem — unlike the fuzzy-search entries below, these paths didn't just
+    # come from listing a directory, so accept()'s close-vs-keep-drilling
+    # semantics would silently pick the wrong one otherwise.
+    private def history_entry(p : String) : Entry
+      dir = File.directory?(p)
+      Entry.new(p, "#{p}#{dir ? "/" : ""}", dir)
     end
 
     private def merge_cap(scored : Array({Entry, Int32})) : Array(Entry)
@@ -113,6 +168,11 @@ module Gori::Tui
       @scroll = @scroll.clamp(0, {@entries.size - h, 0}.max)
       (0...h).each do |i|
         e = @entries[@scroll + i]? || break
+        if e.header
+          screen.fill(Rect.new(x, y + i, w, 1), Theme.elevated)
+          screen.text(x + 1, y + i, e.label, Theme.muted, Theme.elevated, width: {w - 1, 1}.max)
+          next
+        end
         active = (@scroll + i) == @selected
         bg = active ? Theme.accent_bg : Theme.elevated
         screen.fill(Rect.new(x, y + i, w, 1), bg)


### PR DESCRIPTION
## Summary
- Blank Path field in the Fuzzer's Payload Set overlay (Wordlist type) now shows the user's own recently-used and favorited wordlist paths (`★ Favorites` / `🕒 Recent`), instead of only the plain cwd + `~/.gori/wordlists` listing.
- `^D` on the Path field toggles the currently-typed path in/out of favorites (browser-bookmark convention); a `★` indicator shows next to the field when the current value is favorited.
- Recent paths are recorded automatically (MRU, capped at 10) whenever a wordlist payload set is applied.
- Falls back to the original cwd + `~/.gori/wordlists` listing when there's no recent/favorite history yet, so a fresh install isn't left with an empty dropdown.
- Persisted globally in `~/.gori/settings.json` under a new `fuzzer` section, following the same pattern as the existing `decoder`/`mine` sections.

## Code review fixes
This went through an internal review pass before opening the PR. One real bug was caught and fixed pre-merge:

- **Shared-widget data leak (fixed):** `PathComplete` is a generic path-completion dropdown also used by the Import overlay and the CA Import overlay (certificate/private-key PEM paths). The initial implementation read the Fuzzer-only recent/favorite wordlist state unconditionally from `candidates()`, which would have surfaced Fuzzer wordlist paths as selectable completions in unrelated fields (e.g. a CA cert/key path). Fixed by gating the behavior behind a `wordlist_history` opt-in flag on `PathComplete.new`, defaulting to `false`; only the Fuzzer's instance passes `true`. A regression test locks in that non-opted-in instances (Import, CA Import) never see this data.
- Recent/favorite entries built from history now check `File.directory?` instead of hardcoding `dir: false`, so a favorited directory path still drills in instead of incorrectly closing the dropdown.
- `record_recent_wordlist` now no-ops (skips the array rebuild + settings.json save) when the path is already the most-recent entry, instead of writing to disk on every re-application of an unchanged wordlist set.
- Removed dead/unreachable code (a redundant early-return guard, an unreachable width clamp) surfaced during review.
- Shortened the Wordlist type's hint-bar text, which had grown past the overlay's max render width and would have silently truncated the "esc applies" hint.

## Test plan
- [x] `crystal spec` — full suite green (3288 examples, 0 failures)
- [x] `crystal build --no-codegen` — clean
- [x] `ameba` lint — no new findings introduced
- [ ] Not manually exercised in a live terminal; dropdown/★-indicator rendering is covered via `MemoryBackend`-based render assertions only, not a real TUI session.