### PR TITLE
fix(browser): warn before launch when Firefox can't auto-trust the CA

### DIFF
--- a/docs/content/getting-started/quick-start.ko.md
+++ b/docs/content/getting-started/quick-start.ko.md
@@ -42,6 +42,8 @@ TUI 안에서:
 
 gori는 이미 CA를 신뢰하고 HTTP/HTTPS를 프록시로 경유하는 일회용 프로파일로 브라우저를 실행합니다. 그 브라우저에서 사이트를 방문하세요(`https://example.com`을 먼저, 그다음 테스트 중인 사이트를).
 
+> **Firefox 참고.** CA 자동 신뢰에는 `PATH`에 있는 `certutil`(NSS)이 필요합니다. 없으면 gori가 프록시는 설정하지만 Firefox가 CA를 신뢰하지 않아 HTTPS 사이트에서 보안 경고가 뜹니다. 먼저 설치하고(`brew install nss` macOS, `apt install libnss3-tools` Debian/Ubuntu, `dnf install nss-tools` Fedora) 브라우저를 다시 열거나, 같은 창에서 직접 신뢰 등록하세요: `about:preferences#privacy`를 열고 **인증서 보기**, **인증기관** 탭으로 가서 `gori ca`가 출력한 파일을 **가져오기** 하면 됩니다.
+
 ### Option B: 클라이언트를 직접 지정하기 {#option-b-point-any-client-yourself}
 
 CA 경로를 출력하고 그 파일을 시스템 또는 브라우저 신뢰 저장소에 **신뢰된 루트 CA**로 가져오세요:

--- a/docs/content/getting-started/quick-start.md
+++ b/docs/content/getting-started/quick-start.md
@@ -42,6 +42,8 @@ Inside the TUI:
 
 gori launches it with a throwaway profile that already trusts the CA and routes HTTP/HTTPS through the proxy. In that browser, visit a site (try `https://example.com`, then a site you're testing).
 
+> **Firefox note.** Auto-trusting the CA needs `certutil` (NSS) on `PATH`. Without it, gori still sets the proxy but Firefox won't trust the CA, so HTTPS sites show a security warning. Either install it first (`brew install nss` on macOS, `apt install libnss3-tools` on Debian/Ubuntu, `dnf install nss-tools` on Fedora) and reopen the browser, or trust the CA by hand in that same window: open `about:preferences#privacy`, click **View Certificates**, go to **Authorities**, then **Import** the file `gori ca` prints.
+
 ### Option B: Point any client yourself
 
 Print the CA path and import that file into your system or browser trust store as a **trusted root CA**:

--- a/spec/browser_spec.cr
+++ b/spec/browser_spec.cr
@@ -99,6 +99,12 @@ describe Gori::Browser do
     end
   end
 
+  describe ".certutil_available?" do
+    it "matches whether certutil resolves on PATH (env-dependent)" do
+      Gori::Browser.certutil_available?.should eq(!Process.find_executable("certutil").nil?)
+    end
+  end
+
   describe ".detect" do
     it "only returns browsers of a known kind (env-dependent, may be empty)" do
       Gori::Browser.detect.each do |f|

--- a/spec/tui/browser_picker_spec.cr
+++ b/spec/tui/browser_picker_spec.cr
@@ -32,4 +32,21 @@ describe Gori::Tui::BrowserPicker do
     backend.contains?("Google Chrome").should be_true
     backend.contains?("Firefox").should be_true
   end
+
+  # Firefox trusts the CA via a `certutil` NSS import (see Browser.setup_firefox_profile);
+  # without it the profile only gets proxy prefs and HTTPS shows cert errors. Warn on the
+  # row BEFORE launch — the post-launch toast is easy to miss once focus jumps to the
+  # freshly opened browser window (see issue #311).
+  it "warns on the Firefox row when certutil is unavailable" do
+    backend = MemoryBackend.new(80, 14)
+    BrowserPicker.new(BROWSERS, false).render(Screen.new(backend), Rect.new(0, 0, 80, 14))
+    backend.contains?("firefox ⚠").should be_true
+  end
+
+  it "doesn't warn when certutil is available" do
+    backend = MemoryBackend.new(80, 14)
+    BrowserPicker.new(BROWSERS, true).render(Screen.new(backend), Rect.new(0, 0, 80, 14))
+    backend.contains?("firefox ⚠").should be_false
+    backend.contains?("firefox").should be_true
+  end
 end

--- a/src/gori/browser.cr
+++ b/src/gori/browser.cr
@@ -153,6 +153,13 @@ module Gori
       end
     end
 
+    # Whether Firefox's CA auto-import path is available on this system — exposed
+    # so the picker can warn BEFORE launch rather than only via the post-launch
+    # toast (which is easy to miss once focus jumps to the new browser window).
+    def self.certutil_available? : Bool
+      !Process.find_executable("certutil").nil?
+    end
+
     # Writes proxy prefs and, when certutil exists, imports the CA into the
     # profile's NSS db (sql: creates cert9.db). Returns a status note.
     private def self.setup_firefox_profile(profile : String, spec : LaunchSpec) : String
@@ -161,8 +168,10 @@ module Gori
         import_firefox_ca(certutil, profile, spec.ca_cert_path) ? "CA imported, proxy set" : "proxy set (CA import failed)"
       else
         # No certutil → the CA can't be injected into Firefox's NSS store, so HTTPS sites
-        # will show SEC_ERROR/cert warnings. Say so, not just "install certutil".
-        "proxy set — HTTPS will show cert errors; install certutil (nss) to auto-trust the CA"
+        # will show SEC_ERROR/cert warnings. Say so, not just "install certutil" — the
+        # picker already warned before launch (see BrowserPicker), so repeat the concrete
+        # fallback here too since that's the toast the user is actually looking at now.
+        "proxy set — HTTPS will show cert errors; install certutil (nss), or in this Firefox window: about:preferences#privacy → View Certificates → Authorities → Import"
       end
     end
 

--- a/src/gori/tui/browser_picker.cr
+++ b/src/gori/tui/browser_picker.cr
@@ -11,7 +11,9 @@ module Gori::Tui
   class BrowserPicker
     getter selected : Int32
 
-    def initialize(@browsers : Array(Browser::Found))
+    # `certutil_available` is resolved once by the caller (Runner) rather than probed
+    # here on every render — detection belongs to the Runner, per this class's doc.
+    def initialize(@browsers : Array(Browser::Found), @certutil_available : Bool = true)
       @selected = 0
       @scroll = 0
     end
@@ -86,7 +88,12 @@ module Gori::Tui
         screen.cell(box.x + 1, ry, active ? '▎' : ' ', Theme.accent, bg)
         screen.text(box.x + 3, ry, b.name, active ? Theme.text_bright : Theme.text, bg, width: w - 16)
         kind = b.kind.to_s.downcase
-        screen.text(box.right - kind.size - 2, ry, kind, Theme.muted, bg)
+        if b.kind.firefox? && !@certutil_available
+          kind = "#{kind} ⚠"
+          screen.text(box.right - Screen.display_width(kind) - 2, ry, kind, Theme.yellow, bg)
+        else
+          screen.text(box.right - kind.size - 2, ry, kind, Theme.muted, bg)
+        end
       end
     end
   end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -5213,7 +5213,7 @@ module Gori::Tui
         @toast = "no supported browser found (Chrome/Chromium/Brave/Edge/Vivaldi/Firefox)"
         return
       end
-      @browser_picker = BrowserPicker.new(found)
+      @browser_picker = BrowserPicker.new(found, Browser.certutil_available?)
       @overlay = :browser
     end
 


### PR DESCRIPTION
## Summary
Firefox needs `certutil` (NSS) on `PATH` to import gori's CA into its profile's NSS store. Without it, "Open browser" silently launched a proxy-only, untrusted Firefox and the only clue was a toast that's easy to miss once focus jumps to the new browser window — exactly what #311 reports (screenshot shows Firefox's native "Warning: Security Risk" on an HTTPS site while the proxy itself is working fine).

- `Browser.certutil_available?` lets the picker show a `firefox ⚠` badge **before** launch, not just via the post-launch toast.
- The post-launch toast (when certutil is missing) now also names the certutil-free fallback: Firefox's own Settings → Certificates → Authorities → Import.
- `quick-start.md` / `.ko.md` gained a Firefox note with per-OS install commands (`brew install nss`, `apt install libnss3-tools`, `dnf install nss-tools`) and the manual import fallback.

Investigated and dropped: auto-navigating the launched Firefox straight to gori's own CA-download landing page (`self_page.cr`, already built for direct hits). Doesn't work — once Firefox is proxy-configured it sends absolute-form requests, which trip the self-loop 502 guard rather than the landing page. The tempting workaround (excluding gori's host from Firefox's `no_proxies_on`) would silently stop proxying any `localhost:PORT` dev server tested through gori, regressing the deliberate loopback-proxying fix from #279/#284/#287. Not worth the risk for this fix.

Fixes #311

## Test plan
- [x] `crystal spec` — 3314 examples, 0 failures
- [x] `crystal tool format --check` on touched files
- [x] ameba on touched files — no new findings (pre-existing `set_selected` naming warning only)
- [x] Added specs: `Browser.certutil_available?`, and picker render tests asserting the `firefox ⚠` badge appears/doesn't appear