### PR TITLE
fix(ql,discover,mcp,cli): fix QL url: and size units, Discover scheme, MCP job dispatch & oast flags

### DIFF
--- a/spec/discover/url_spec.cr
+++ b/spec/discover/url_spec.cr
@@ -148,9 +148,8 @@ describe Gori::Discover::Url do
     # "some other scheme" branch and returns nil. HTML/URL schemes are
     # case-insensitive (RFC 3986 §3.1) and the doc comment promises to "Handle
     # absolute ... forms", so an uppercase absolute URL should resolve, not drop.
-    pending "resolves an uppercase absolute scheme (schemes are case-insensitive)" do
+    it "resolves an uppercase absolute scheme (schemes are case-insensitive)" do
       base = U.parse("http://h/p").not_nil!
-      # Intended: the absolute URL is returned (browsers treat HTTP:// as http://).
       U.resolve(base, "HTTP://host/p").should eq("HTTP://host/p")
     end
   end

--- a/spec/ql_spec.cr
+++ b/spec/ql_spec.cr
@@ -26,6 +26,17 @@ private def capture(store, host, method, target, status = nil)
 end
 
 describe Gori::QL do
+  it "compiles url: field filters" do
+    f = Gori::QL.parse("url:shop.demo.test")
+    f.sql.should contain("LIKE ? ESCAPE '\\'")
+    f.args.should eq(["%shop.demo.test%"])
+  end
+
+  it "compiles size: filters with byte unit suffixes (k, M, G)" do
+    Gori::QL.parse("size:>10k").args.should eq([10240_i64])
+    Gori::QL.parse("size:>=1M").args.should eq([1048576_i64])
+  end
+
   it "compiles AND-ed terms with parameterised values" do
     f = Gori::QL.parse("host:acme status:>=500")
     f.sql.should eq("(lower(host) LIKE ? ESCAPE '\\' AND status >= ?)")

--- a/src/gori/cli/run/oast.cr
+++ b/src/gori/cli/run/oast.cr
@@ -6,9 +6,10 @@ module Gori
       # `gori run oast` — headless out-of-band listener (interactsh & friends). Store-free
       # and ad-hoc: register a payload, print it, then stream decrypted callbacks.
       private def self.cmd_oast(args : Array(String)) : Nil
-        case sub = args.first?
+        filtered = args.reject { |a| a.starts_with?("--project") || a.starts_with?("--db") }
+        case sub = filtered.first?
         when "presets"           then oast_presets
-        when "listen"            then oast_listen(args[1..])
+        when "listen"            then oast_listen(filtered[1..])
         when nil, "-h", "--help" then oast_help
         else
           STDERR.puts "gori run oast: unknown subcommand '#{sub}'"

--- a/src/gori/discover/url.cr
+++ b/src/gori/discover/url.cr
@@ -138,7 +138,7 @@ module Gori::Discover
                     lower.starts_with?("javascript:") || lower.starts_with?("data:") ||
                     lower.starts_with?("about:") || lower.starts_with?("blob:")
 
-      if h.starts_with?("http://") || h.starts_with?("https://")
+      if lower.starts_with?("http://") || lower.starts_with?("https://")
         return h
       elsif h.starts_with?("//")
         return "#{base.scheme}:#{h}"

--- a/src/gori/mcp/tools/jobs.cr
+++ b/src/gori/mcp/tools/jobs.cr
@@ -8,7 +8,7 @@ module Gori
       private def list_jobs : Result
         Result.new(JSON.build do |j|
           j.object do
-            j.field "count", @jobs.size + @mine_jobs.size + @discover_jobs.size
+            j.field "count", @jobs.size + @mine_jobs.size + @discover_jobs.size + @sequence_jobs.size
             j.field("jobs") do
               j.array do
                 @jobs.each_value do |f|
@@ -43,15 +43,25 @@ module Gori
                     j.field "target", d.audit.target
                   end
                 end
+                @sequence_jobs.each_value do |s|
+                  j.object do
+                    j.field "job_id", s.id
+                    j.field "kind", "sequence"
+                    j.field "status", s.status.to_s
+                    j.field "goal", s.goal
+                    j.field "collected", s.collected
+                    j.field "target", s.audit.target
+                  end
+                end
               end
             end
           end
         end)
       end
 
-      # Unified status for a fuzz OR mine job (dispatch by the id prefix), so a
-      # caller polling many jobs needs one tool. Delegates to the per-engine
-      # status serializers, which already carry counts/audit/incomplete_reason.
+      # Unified status for a fuzz, mine, discover, or sequence job (dispatch by the id prefix),
+      # so a caller polling many jobs needs one tool. Delegates to the per-engine status
+      # serializers, which already carry counts/audit/incomplete_reason.
       private def get_job(h) : Result
         id = str(h, "job_id")
         return err("missing required 'job_id'", "INVALID_ARGUMENT", field: "job_id") if id.nil? || id.empty?
@@ -59,18 +69,22 @@ module Gori
           fuzz_status(h)
         elsif @mine_jobs.has_key?(id)
           mine_status(h)
+        elsif @discover_jobs.has_key?(id)
+          discover_status(h)
+        elsif @sequence_jobs.has_key?(id)
+          sequence_status(h)
         else
           not_found("no job #{id}")
         end
       end
 
-      # Stop a fuzz OR mine job. With wait:true, blocks (yielding to the runner
+      # Stop a fuzz, mine, discover, or sequence job. With wait:true, blocks (yielding to the runner
       # fiber via sleep) until the job reaches a terminal state or wait_timeout_ms
       # elapses, so a caller can stop-and-confirm in one call instead of polling.
       private def stop_job(h) : Result
         id = str(h, "job_id")
         return err("missing required 'job_id'", "INVALID_ARGUMENT", field: "job_id") if id.nil? || id.empty?
-        job = @jobs[id]? || @mine_jobs[id]?
+        job = @jobs[id]? || @mine_jobs[id]? || @discover_jobs[id]? || @sequence_jobs[id]?
         return not_found("no job #{id}") unless job
         job.stop
         wait = bool(h, "wait") || false
@@ -102,15 +116,15 @@ module Gori
         end)
       end
 
-      private def job_running?(job : FuzzJob | MineJob) : Bool
+      private def job_running?(job : FuzzJob | MineJob | DiscoverJob | SequenceJob) : Bool
         job.status == :running
       end
 
-      private def job_status_and_end(job : FuzzJob | MineJob) : {String, Int64?}
+      private def job_status_and_end(job : FuzzJob | MineJob | DiscoverJob | SequenceJob) : {String, Int64?}
         {job.status.to_s, job.ended_at_ms}
       end
 
-      private def job_stop_requested(job : FuzzJob | MineJob) : Int64?
+      private def job_stop_requested(job : FuzzJob | MineJob | DiscoverJob | SequenceJob) : Int64?
         job.stop_requested_at_ms
       end
     end

--- a/src/gori/mcp/tools/projects.cr
+++ b/src/gori/mcp/tools/projects.cr
@@ -20,7 +20,8 @@ module Gori
       private def jobs_running? : Bool
         @jobs.each_value.any? { |j| j.status == :running } ||
           @mine_jobs.each_value.any? { |j| j.status == :running } ||
-          @discover_jobs.each_value.any? { |j| j.status == :running }
+          @discover_jobs.each_value.any? { |j| j.status == :running } ||
+          @sequence_jobs.each_value.any? { |j| j.status == :running }
       end
 
       private def list_projects : Result

--- a/src/gori/ql.cr
+++ b/src/gori/ql.cr
@@ -199,6 +199,7 @@ module Gori
       return nil if value.empty?
       case field
       when "host"                        then {"lower(host) LIKE ? ESCAPE '\\'", [like(value)] of DB::Any}
+      when "url"                         then {"#{URL_EXPR} LIKE ? ESCAPE '\\'", [like(value)] of DB::Any}
       when "path"                        then {"lower(target) LIKE ? ESCAPE '\\'", [like(value)] of DB::Any}
       when "method"                      then {"upper(method) = ?", [value.upcase] of DB::Any}
       when "scheme"                      then {"scheme = ?", [value.downcase] of DB::Any}
@@ -313,9 +314,34 @@ module Gori
     # dropped, like a bad status:).
     private def self.numeric_cond(column : String, value : String) : {String, Array(DB::Any)}?
       op, rest = split_op(value)
-      n = rest.to_i64?
-      return nil unless n
-      {"#{column} #{op} ?", [n] of DB::Any}
+      scale = 1.0
+      lower_rest = rest.downcase
+      if lower_rest.ends_with?("kb")
+        rest = rest[0...-2]
+        scale = 1024.0
+      elsif lower_rest.ends_with?('k')
+        rest = rest[0...-1]
+        scale = 1024.0
+      elsif lower_rest.ends_with?("mb")
+        rest = rest[0...-2]
+        scale = 1024.0 * 1024.0
+      elsif lower_rest.ends_with?('m')
+        rest = rest[0...-1]
+        scale = 1024.0 * 1024.0
+      elsif lower_rest.ends_with?("gb")
+        rest = rest[0...-2]
+        scale = 1024.0 * 1024.0 * 1024.0
+      elsif lower_rest.ends_with?('g')
+        rest = rest[0...-1]
+        scale = 1024.0 * 1024.0 * 1024.0
+      elsif lower_rest.ends_with?('b')
+        rest = rest[0...-1]
+      end
+      n = rest.to_f?
+      return nil unless n && n.finite?
+      bytes = (n * scale).round
+      return nil unless bytes.abs < 9.0e18
+      {"#{column} #{op} ?", [bytes.to_i64] of DB::Any}
     end
 
     # dur: is milliseconds (how latency reads), compared against the microsecond


### PR DESCRIPTION
## Summary
This PR resolves 6 confirmed bugs and edge cases discovered during a comprehensive 20-round audit of gori:

- **BUG-01 (QL)**: Fix missing `when "url"` condition in `QL.field_cond` so `url:pattern` searches correctly.
- **BUG-02 (Discover)**: Fix case-sensitive `starts_with?("http://")` in `Discover::Url.resolve` so `HTTP://` / `Https://` links are not dropped.
- **BUG-03 (CLI)**: Filter out common CLI flags (`--project`, `--db`) before sub-parsing in `gori run oast`.
- **BUG-04 (QL)**: Add byte unit suffix (`k`, `M`, `G`, `KB`, `MB`, `GB`) support to `size:`, `reqsize:`, `respsize:` numeric filters.
- **BUG-05 (MCP)**: Add `DiscoverJob` and `SequenceJob` dispatch handlers to MCP `list_jobs`, `get_job`, and `stop_job`.
- **BUG-06 (MCP)**: Add `@sequence_jobs` running check to `jobs_running?` in `projects.cr` to prevent DB switching/deletion while sequence jobs run.

## Verification
- All 3,316 spec tests pass (`0 failures, 0 errors, 0 pending`).
- Binary compiled successfully with `shards build`.