### PR TITLE
fix(fuzz,miner,decoder,mcp): scope-gate Fuzzer/Miner, wire Fuzzer into Probe, fix Decoder rendering

### DIFF
--- a/src/gori/fuzz/engine.cr
+++ b/src/gori/fuzz/engine.cr
@@ -1,6 +1,7 @@
 require "uri"
 require "../repeater/engine"
 require "../repeater/h2_engine"
+require "../scope"
 
 module Gori::Fuzz
   # The origin a run targets (also the boundary for redirect following).
@@ -59,6 +60,45 @@ module Gori::Fuzz
       return Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, CAP_ERROR) if cap_reached?
       @sent += 1
       @inner.send(bytes)
+    end
+  end
+
+  # Refuses to send when the target falls outside the project's Scope (a sandbox
+  # block or an explicit exclude rule) — the same per-request gate Discover applies
+  # via `bounded_url` (discover/adapters.cr). Fuzz and Miner otherwise dial a
+  # Backend directly with no Scope awareness, so Sandbox mode's "blocks ALL
+  # out-of-scope traffic" promise didn't hold for either tool. Wrap OUTERMOST
+  # (around CappedBackend) so a blocked attempt never reaches the network — the
+  # request budget is still spent on it, same as CappedBackend already does for
+  # retries/redirects, rather than adding a second accounting path.
+  class ScopedBackend < Backend
+    SCOPE_ERROR = "blocked by scope"
+
+    getter blocked : Int64 = 0_i64
+
+    def initialize(@inner : Backend, @scope : Gori::Scope)
+    end
+
+    def origin : Origin
+      @inner.origin
+    end
+
+    def send(bytes : Bytes) : Repeater::Result
+      o = origin
+      url = "#{o.scheme}://#{o.host}#{request_target(bytes)}"
+      if @scope.sandbox_blocks?(url, o.host) || @scope.excluded?(url, o.host)
+        @blocked += 1
+        return Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, SCOPE_ERROR)
+      end
+      @inner.send(bytes)
+    end
+
+    # The request-target (path) from the first line of a raw request, mirroring
+    # mcp/tools/send.cr#request_target — builds the scheme://host/target URL the
+    # scope string/regex rules match against.
+    private def request_target(bytes : Bytes) : String
+      line = String.new(bytes).each_line.first? || ""
+      line.split(' ')[1]? || "/"
     end
   end
 

--- a/src/gori/fuzz/template.cr
+++ b/src/gori/fuzz/template.cr
@@ -166,7 +166,7 @@ module Gori::Fuzz
       # parse contract (segments.size == positions.size + 1) the sum is exact, and off-contract
       # it can only OVER-estimate (fewer segments written) — never under, so never a truncation.
       io = IO::Memory.new(@segments.sum(&.bytesize) + payloads.sum(&.bytesize))
-      io << @segments[0]
+      io << @segments[0]?
       payloads.each_with_index do |p, k|
         io << p
         io << @segments[k + 1]?

--- a/src/gori/mcp/tools/fuzz.cr
+++ b/src/gori/mcp/tools/fuzz.cr
@@ -237,7 +237,10 @@ module Gori
         generator = Fuzz::Generator.new(template, gen_sets, config, registry: Decoder.shared_registry)
         sender = Fuzz::Sender.new(origin, http2: use_h2,
           verify: @verify_upstream && !(bool(h, "insecure") || false), timeout: fuzz_timeout(h))
-        engine = Fuzz::Engine.new(generator, matcher, sender, config)
+        # Defense-in-depth alongside the job-start scope_check above: that check only
+        # covers the origin once, not a path a template mutates per-request.
+        backend = Fuzz::ScopedBackend.new(sender, Scope.load(store))
+        engine = Fuzz::Engine.new(generator, matcher, backend, config)
         {engine, origin, engine.total, use_h2}
       rescue ex : File::Error
         raise FuzzArgError.new("wordlist error: #{ex.message}")

--- a/src/gori/mcp/tools/mine.cr
+++ b/src/gori/mcp/tools/mine.cr
@@ -3,6 +3,7 @@ require "../../env"
 require "../../fuzz"
 require "../../miner"
 require "../../repeater/flow_request"
+require "../../scope"
 
 module Gori
   module MCP
@@ -150,6 +151,9 @@ module Gori
         origin = fuzz_origin(h, default_target)
         sender = Fuzz::Sender.new(origin, http2: use_h2,
           verify: @verify_upstream && !(bool(h, "insecure") || false), timeout: fuzz_timeout(h))
+        # Defense-in-depth alongside the job-start scope_check above: that check only
+        # covers the origin once, not a path mining mutates per-request.
+        backend = Fuzz::ScopedBackend.new(sender, Scope.load(store))
         config = Miner::Config.new
         config.locations = mine_locations(h, bytes)
         raise FuzzArgError.new("no applicable locations for this request") if config.locations.empty?
@@ -165,7 +169,7 @@ module Gori
           config.locations.each { |loc| config.bucket_size[loc] = bucket }
         end
         names = Miner::Wordlist.load(config.user_wordlist)
-        engine = Miner::Engine.new(bytes, use_h2, names, sender, config)
+        engine = Miner::Engine.new(bytes, use_h2, names, backend, config)
         {engine, origin, engine.total_names}
       rescue ex : File::Error
         raise FuzzArgError.new("wordlist error: #{ex.message}")

--- a/src/gori/mcp/tools/ql.cr
+++ b/src/gori/mcp/tools/ql.cr
@@ -13,11 +13,25 @@ module Gori
         return QL::EMPTY if query.nil? || query.strip.empty?
         filter = QL.parse(query)
         return ql_error(query) if QL.reject_empty?(query, filter)
+        bad = QL.invalid_regex_terms(query)
+        return ql_invalid_regex_error(query, bad) unless bad.empty?
         if bool(h, "strict") || false
           analysis = QL.analyze(query)
           return ql_strict_error(analysis) unless analysis.clean?
         end
         filter
+      end
+
+      # A `~` term with an uncompilable regex degrades to a never-match clause —
+      # narrows the result to zero rather than dropping the term (which would
+      # broaden, like a bad numeric term does). Unlike that broaden case, this is
+      # ALWAYS an error, not gated behind strict: a silently-empty result set
+      # looks identical to "no matching flows" to an automated caller.
+      private def ql_invalid_regex_error(query : String, bad : Array(String)) : Result
+        err("invalid query #{query.inspect}: regex term(s) failed to compile and would " \
+            "silently match nothing: #{bad.join(", ")} (call ql_reference; fix the pattern or drop the term)",
+          "QUERY_SYNTAX", field: "query",
+          details: JSON.parse({"invalid_regex_terms" => bad}.to_json))
       end
 
       private def ql_strict_error(a : QL::TermAnalysis) : Result

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -5,6 +5,7 @@ require "../clipboard"
 require "../../store"
 require "../../fuzz"
 require "../../hotkeys"
+require "../../probe"
 
 module Gori::Tui
   # One open Fuzzer session (a sub-tab under the Fuzzer tab). `flow_id` is the source
@@ -771,7 +772,9 @@ module Gori::Tui
           ev.progress.sent.clamp(0_i64, Int32::MAX.to_i64).to_i32,
           ev.progress.total.try(&.clamp(0_i64, Int32::MAX.to_i64).to_i32),
           "#{ev.progress.matched} hit")
-      when Fuzz::ResultEvent then v.append_result(ev.result)
+      when Fuzz::ResultEvent
+        v.append_result(ev.result)
+        probe_scan_fuzz_result(ev.result, v)
       when Fuzz::DoneEvent
         v.finish_run
         finish_job(v, ev)
@@ -786,6 +789,24 @@ module Gori::Tui
         log_event(v, :error, "Fuzzer: #{ev.message} on #{v.summary}")
         @host.status("fuzz error: #{ev.message}")
       end
+    end
+
+    # Passive-scan a fuzz result into Probe (mode-gated by the analyzer) — mirrors
+    # RepeaterController#probe_scan_repeater so URLs only ever visited through the
+    # Fuzzer still surface header/tech findings. Only fires when this result's
+    # head/body/request were retained (the run's keep_bodies policy — :all, or
+    # :matched plus this one matched); a :none run has nothing to scan, same limit
+    # the Repeater path doesn't face.
+    private def probe_scan_fuzz_result(result : Fuzz::Result, v : FuzzerView) : Nil
+      return unless head = result.head
+      return if head.empty?
+      rec = Store::RepeaterRecord.new(
+        0_i64, v.target_origin, result.request || Bytes.empty, v.http2?, false,
+        nil, 0, head, result.body, nil, result.duration_us, nil, nil)
+      return unless detail = Probe.detail_from_repeater(rec)
+      @host.session.probe.scan_detail(detail)
+    rescue
+      # Probe must never break the Fuzzer UX
     end
 
     private def finish_job(v : FuzzerView, ev : Fuzz::DoneEvent) : Nil
@@ -834,7 +855,7 @@ module Gori::Tui
       # would otherwise apply the stale event to the NEW run's job (premature/wrong
       # "done", orphaned bottom-bar spinner). Draining now settles the old job first.
       drain_events
-      engine, err = v.build_engine(!@host.session.config.insecure_upstream?)
+      engine, err = v.build_engine(!@host.session.config.insecure_upstream?, @host.session.scope)
       unless engine
         @host.status(err || "cannot run")
         return

--- a/src/gori/tui/controllers/miner_controller.cr
+++ b/src/gori/tui/controllers/miner_controller.cr
@@ -393,7 +393,7 @@ module Gori::Tui
     end
 
     private def start_run(view : MinerView) : Nil
-      engine, err = view.build_engine(!@host.session.config.insecure_upstream?)
+      engine, err = view.build_engine(!@host.session.config.insecure_upstream?, @host.session.scope)
       unless engine
         @host.status(err || "cannot mine")
         return

--- a/src/gori/tui/decoder_view.cr
+++ b/src/gori/tui/decoder_view.cr
@@ -354,7 +354,7 @@ module Gori::Tui
     def output_text(result : Decoder::ChainResult) : String
       if bytes = result.output
         text, _ = Decoder.display(bytes, @prefer)
-        text
+        sanitize_display(text)
       elsif fa = result.failed_at
         s = result.steps[fa]
         "✗ #{s.name}: #{s.error}"
@@ -371,7 +371,15 @@ module Gori::Tui
     # A single-line, control-char-sanitized preview of one step's bytes.
     private def preview(bytes : Bytes) : String
       s, _ = Decoder.display(bytes)
-      String.build { |io| s.each_char { |ch| io << (ch.control? ? '·' : ch) } }
+      sanitize_display(s)
+    end
+
+    # Swap terminal-unsafe control chars for a visible placeholder. Without this,
+    # a control byte (e.g. from a base64/hex decode of binary) reaches `screen.cell`,
+    # which maps ASCII control bytes to a blank space — the byte is drawn but
+    # invisible, reading as truncated even though it isn't.
+    private def sanitize_display(text : String) : String
+      String.build { |io| text.each_char { |ch| io << (ch.control? ? '·' : ch) } }
     end
 
     private def render_prompt(screen : Screen, rect : Rect, prompt : Symbol, buf : String) : Nil

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -922,8 +922,10 @@ module Gori::Tui
     end
 
     # --- engine assembly -----------------------------------------------------
-    # Build an engine ready to run, or {nil, error}.
-    def build_engine(verify : Bool) : {Fuzz::Engine?, String?}
+    # Build an engine ready to run, or {nil, error}. `scope` gates every send
+    # against Sandbox/exclude rules (ScopedBackend) — the same protection
+    # Discover already applies per-request.
+    def build_engine(verify : Bool, scope : Gori::Scope) : {Fuzz::Engine?, String?}
       commit_buffers
       if err = regex_error
         return {nil, err} # don't silently run match-everything on a bad pattern
@@ -939,10 +941,18 @@ module Gori::Tui
       generator = Fuzz::Generator.new(template, gen_sets, @config, registry: Decoder.shared_registry)
       sender = Fuzz::Sender.new(Fuzz::Origin.new(scheme, host, port),
         http2: @http2, verify: verify, sni: sni_override, timeout: @config.timeout)
+      backend = Fuzz::ScopedBackend.new(sender, scope)
       @matcher.auto_calibrate = @config.auto_calibrate?
-      {Fuzz::Engine.new(generator, @matcher, sender, @config), nil}
+      {Fuzz::Engine.new(generator, @matcher, backend, @config), nil}
     rescue ex
       {nil, "config error: #{ex.message}"}
+    end
+
+    # Whether the run targets HTTP/2 — for Probe's synthetic RepeaterRecord (see
+    # FuzzerController#probe_scan_fuzz_result), which needs to know the protocol
+    # the same way RepeaterView#http2? already exposes it.
+    def http2? : Bool
+      @http2
     end
 
     def target_origin : String

--- a/src/gori/tui/miner_view.cr
+++ b/src/gori/tui/miner_view.cr
@@ -281,7 +281,9 @@ module Gori::Tui
     end
 
     # --- engine ---
-    def build_engine(verify : Bool) : {Miner::Engine?, String?}
+    # `scope` gates every send against Sandbox/exclude rules (ScopedBackend) — the
+    # same protection Discover already applies per-request.
+    def build_engine(verify : Bool, scope : Gori::Scope) : {Miner::Engine?, String?}
       scheme, host, port = Repeater::FlowRequest.parse_target(@target)
       return {nil, "invalid target — use scheme://host[:port]/path"} if host.empty?
       return {nil, "no locations selected"} if @config.locations.empty?
@@ -289,7 +291,8 @@ module Gori::Tui
       return {nil, "wordlist is empty"} if names.empty?
       sender = Fuzz::Sender.new(Fuzz::Origin.new(scheme, host, port),
         http2: @http2, verify: verify, sni: sni_override, timeout: @config.timeout)
-      {Miner::Engine.new(@request, @http2, names, sender, @config), nil}
+      backend = Fuzz::ScopedBackend.new(sender, scope)
+      {Miner::Engine.new(@request, @http2, names, backend, @config), nil}
     rescue ex
       {nil, "config error: #{ex.message}"}
     end


### PR DESCRIPTION
## Summary
Fixes five bugs found by dogfooding the TUI live (build fresh, drive via tmux, cross-check with source reads):

- **Fuzzer/Miner bypassed the Scope sandbox/exclude gate.** Sandbox mode's own confirm dialog says "blocks ALL out-of-scope traffic," but `Fuzz::Engine`/`Miner::Engine` dialed targets directly with no `Scope` reference at all — unlike Discover, which already gates every request. Adds `Fuzz::ScopedBackend` (mirrors the existing `CappedBackend` decorator) and wires it into the TUI Fuzzer/Miner views+controllers and the MCP `fuzz`/`mine` tools (as defense-in-depth alongside the existing job-start `scope_check`, which only covers the origin once, not a path a template mutates per-request).
- **Fuzzer traffic never reached Probe.** Repeater sends are explicitly passive-scanned (`probe_scan_repeater`); Fuzzer had no equivalent, so findings (missing security headers, tech fingerprints) on URLs only ever visited through the Fuzzer were silently dropped. Adds `probe_scan_fuzz_result`, modeled 1:1 on the Repeater path.
- **Decoder's OUTPUT pane hid non-printable bytes.** A correctly-decoded value containing control bytes (e.g. from a base64/hex decode of binary) rendered as if truncated — the bytes were drawn, just as invisible blank cells, while the PIPELINE preview line for the same bytes correctly showed a `·` placeholder. Now both use the same sanitization.
- **MCP `ql_filter_or_error` silently returned empty results for an invalid regex.** A `~` term that fails to compile degrades to a never-match SQL clause; the default (non-`strict`) path returned this with no warning — indistinguishable from "no matching flows" to an automated caller. Now a hard, typed `QUERY_SYNTAX` error, unconditionally (symmetric with how an empty-compile query already errors).
- **`Fuzz::Template#render` had one unguarded `@segments[0]`** next to an already-guarded `@segments[k+1]?` on the next line — latent, not live (guarded by the parse invariant), but closes the asymmetry.

Two related items were investigated and explicitly **not** included: Miner→Probe wiring (bigger lift — `Miner::Finding` carries no raw bytes at all, needs an engine-level change) and the root-cause "focus-scoped keys silently no-op → fall through as global hotkeys" issue (architectural, needs its own dedicated investigation).

## Test plan
- [x] `crystal build src/main.cr -o bin/gori` — clean
- [x] `ameba` on all touched files — no new findings (all flagged lines pre-existing)
- [x] Targeted specs (decoder, fuzz, miner, ql, mcp_fuzz, probe) — 343+99 examples, 0 failures
- [x] Full `crystal spec` — 3318 examples, 0 failures, 0 errors
- [x] Live via tmux: Decoder shows `ABC·······` instead of `ABC` for a base64-decode with embedded control bytes
- [x] Live via tmux: Sandbox ON + scope=example.com only → Fuzzer run against httpbin.org returns `ERR` (blocked by scope) while a parallel curl to example.com and the listener itself remain unaffected
- [x] Live via tmux: Fuzzer run against example.com surfaces a new URL in Probe's "Missing Content-Security-Policy" finding's affected-URL list