### PR TITLE
fix(cli,form_data): support device streams in CLI file checks and unquoted multipart params

### DIFF
--- a/spec/form_data_spec.cr
+++ b/spec/form_data_spec.cr
@@ -331,5 +331,18 @@ describe Gori::FormData do
       Gori::FormData.from_flow("/", urlencoded_head, "a=%E".to_slice)
         .not_nil!.first.value.should eq("%E")
     end
+
+    it "extracts unquoted and single-quoted name and filename parameters in multipart forms" do
+      boundary = "----Boundary123"
+      body = multipart_body(boundary,
+        "Content-Disposition: form-data; name=unquoted_name; filename=unquoted.txt\r\n\r\ncontent",
+        "Content-Disposition: form-data; name='single_quoted'; filename='single.txt'\r\n\r\ncontent")
+      fields = Gori::FormData.from_flow("/", multipart_head(boundary), body.to_slice).not_nil!
+      fields.size.should eq(2)
+      fields[0].name.should eq("unquoted_name")
+      fields[0].note.not_nil!.should contain("file: unquoted.txt")
+      fields[1].name.should eq("single_quoted")
+      fields[1].note.not_nil!.should contain("file: single.txt")
+    end
   end
 end

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -166,7 +166,7 @@ module Gori
       # select by slug/id, not display name alone (parity with MCP --project).
       private def self.resolve_read_project(project_name : String?, db_path : String?) : Project
         if path = db_path
-          abort "gori run: --db is not a readable file: #{path}" unless File.file?(path)
+          abort "gori run: --db is not a readable file: #{path}" unless File.exists?(path) && !File.directory?(path)
           return Project.new(File.basename(File.dirname(path)), path)
         end
         registry = ProjectRegistry.new(Paths.projects_dir)

--- a/src/gori/cli/run/fuzz.cr
+++ b/src/gori/cli/run/fuzz.cr
@@ -116,7 +116,7 @@ module Gori
       private def self.fuzz_source(flow_id : Int64?, request_file : String?,
                                    project_name : String?, db_path : String?) : {String, String?, Bool}
         if file = request_file
-          abort "gori run fuzz: not a readable file: #{file}" unless File.file?(file)
+          abort "gori run fuzz: not a readable file: #{file}" unless File.exists?(file) && !File.directory?(file)
           {File.read(file), nil, false}
         elsif id = flow_id
           store = open_store(resolve_read_project(project_name, db_path))

--- a/src/gori/cli/run/mine.cr
+++ b/src/gori/cli/run/mine.cr
@@ -93,7 +93,7 @@ module Gori
       private def self.mine_source(flow_id : Int64?, request_file : String?,
                                    project_name : String?, db_path : String?) : {Bytes, String?, Bool}
         if file = request_file
-          abort "gori run mine: not a readable file: #{file}" unless File.file?(file)
+          abort "gori run mine: not a readable file: #{file}" unless File.exists?(file) && !File.directory?(file)
           {Env.expand_wire(File.read(file)), nil, false}
         elsif id = flow_id
           store = open_store(resolve_read_project(project_name, db_path))

--- a/src/gori/cli/run/repeater.cr
+++ b/src/gori/cli/run/repeater.cr
@@ -106,7 +106,7 @@ module Gori
 
         req_content = ""
         if file = request_file
-          abort "gori run repeater create: request-file '#{file}' is not readable" unless File.file?(file)
+          abort "gori run repeater create: request-file '#{file}' is not readable" unless File.exists?(file) && !File.directory?(file)
           req_content = File.read(file)
         elsif raw = request_raw
           req_content = raw

--- a/src/gori/cli/run/sequence.cr
+++ b/src/gori/cli/run/sequence.cr
@@ -96,7 +96,7 @@ module Gori
       end
 
       private def self.read_token_list(file : String) : Array(String)
-        raw = file == "-" ? STDIN.gets_to_end : (File.file?(file) ? File.read(file) : abort("gori run sequence: not a readable file: #{file}"))
+        raw = file == "-" ? STDIN.gets_to_end : (File.exists?(file) && !File.directory?(file) ? File.read(file) : abort("gori run sequence: not a readable file: #{file}"))
         raw.split(/\r?\n/).map(&.strip).reject(&.empty?)
       end
 
@@ -117,7 +117,7 @@ module Gori
       private def self.mine_source_for(cmd : String, flow_id : Int64?, request_file : String?,
                                        project_name : String?, db_path : String?) : {Bytes, String?, Bool}
         if file = request_file
-          abort "gori run #{cmd}: not a readable file: #{file}" unless File.file?(file)
+          abort "gori run #{cmd}: not a readable file: #{file}" unless File.exists?(file) && !File.directory?(file)
           {Env.expand_wire(File.read(file)), nil, false}
         elsif id = flow_id
           store = open_store(resolve_read_project(project_name, db_path))

--- a/src/gori/form_data.cr
+++ b/src/gori/form_data.cr
@@ -55,8 +55,14 @@ module Gori
       end
     end
 
-    NAME_RE     = /name="([^"]*)"/
-    FILENAME_RE = /filename="([^"]*)"/
+    NAME_RE     = /name=(?:"([^"]*)"|'([^']*)'|([^;\s]+))/i
+    FILENAME_RE = /filename=(?:"([^"]*)"|'([^']*)'|([^;\s]+))/i
+
+    private def extract_param(cd : String, re : Regex) : String?
+      if m = re.match(cd)
+        m[1]? || m[2]? || m[3]?
+      end
+    end
 
     private def multipart(body : Bytes, ct : String) : Array(Field)
       fields = [] of Field
@@ -77,8 +83,8 @@ module Gori
 
     private def part_field(headers : HTTP::Headers, content : String) : Field
       cd = headers["Content-Disposition"]? || ""
-      name = NAME_RE.match(cd).try(&.[1]) || "(unnamed)"
-      if (filename = FILENAME_RE.match(cd).try(&.[1])) && !filename.empty?
+      name = extract_param(cd, NAME_RE) || "(unnamed)"
+      if (filename = extract_param(cd, FILENAME_RE)) && !filename.empty?
         Field.new(name, "", :body, "file: #{filename} (#{content.bytesize} bytes)")
       elsif content.valid_encoding? && content.bytesize <= PART_MAX
         Field.new(name, content, :body)


### PR DESCRIPTION
### Summary

1. **CLI device streams & FIFOs support (`gori run sequence --tokens /dev/stdin`, etc.)**:
   Replaced strict regular-file check `File.file?(path)` with `File.exists?(path) && !File.directory?(path)` across CLI file readers (`run.cr`, `fuzz.cr`, `mine.cr`, `repeater.cr`, `sequence.cr`). Non-regular readable paths like `/dev/stdin`, named FIFOs, and process substitution paths (`<(...)`) are now supported.

2. **Multipart parameter parsing (`FormData`)**:
   Updated `NAME_RE` and `FILENAME_RE` in `src/gori/form_data.cr` to extract unquoted and single-quoted `name` and `filename` parameters per RFC 7578 / RFC 2183. Added spec coverage.