### PR TITLE
feat(cli,mcp): close CLI/MCP parity gaps — Comparer, Intercept, WS repeater send, scope/env/host-override, import

### DIFF
--- a/spec/cli_run_spec.cr
+++ b/spec/cli_run_spec.cr
@@ -779,3 +779,90 @@ describe "gori run fuzz/mine/sequence — project host overrides (R2-1)" do
     end
   end
 end
+
+# `compare_lines` is private CLI glue (mirrors the TUI Comparer's lines_for) —
+# reopen the module for a bare-call wrapper, the same trick the other whitebox specs use.
+module Gori::CLI::Run
+  def self.compare_lines_for_spec(d : Gori::Store::FlowDetail, pane : Symbol) : Array(String)
+    compare_lines(d, pane)
+  end
+end
+
+describe "gori run compare" do
+  it "builds request lines byte-faithful (no decoding) and response lines decoded" do
+    d = flow_detail("https", "a.test", 443, "GET / HTTP/1.1\r\nHost: a.test\r\n\r\n",
+      response_head: "HTTP/1.1 200 OK\r\n\r\n", response_body: "hello")
+    req_lines = Gori::CLI::Run.compare_lines_for_spec(d, :request)
+    req_lines.first.should eq("GET / HTTP/1.1")
+    resp_lines = Gori::CLI::Run.compare_lines_for_spec(d, :response)
+    resp_lines.should contain("hello")
+  end
+end
+
+# `ws_out_messages` is private CLI glue (mirrors MCP send_websocket's default-messages
+# fallback) — reopen the module for a bare-call wrapper.
+module Gori::CLI::Run
+  def self.ws_out_messages_for_spec(store : Gori::Store, id : Int64, override : Array(String)) : Array(Gori::Repeater::WsEngine::OutMsg)
+    ws_out_messages(store, id, override)
+  end
+end
+
+describe "gori run repeater send (WebSocket)" do
+  it "uses --message overrides as text frames when given" do
+    with_store do |store|
+      msgs = Gori::CLI::Run.ws_out_messages_for_spec(store, 1_i64, ["ping", "pong"])
+      msgs.map(&.opcode).should eq([1, 1])
+      msgs.map { |m| String.new(m.payload) }.should eq(["ping", "pong"])
+    end
+  end
+
+  it "falls back to the repeater's stored OUT messages when no override is given" do
+    with_store do |store|
+      id = store.insert_repeater("ws://x.test", "GET /ws HTTP/1.1\r\n\r\n".to_slice, false, true, nil, 0)
+      store.update_repeater_ws_messages(id, ["hello"])
+      msgs = Gori::CLI::Run.ws_out_messages_for_spec(store, id, [] of String)
+      msgs.size.should eq(1)
+      String.new(msgs[0].payload).should eq("hello")
+    end
+  end
+end
+
+# `intercept_bridge_state` / `intercept_live?` are private CLI glue (mirror MCP's
+# identically-named helpers in src/gori/mcp/tools/intercept.cr) — reopen the module
+# for bare-call wrappers.
+module Gori::CLI::Run
+  def self.intercept_bridge_state_for_spec(store : Gori::Store) : Hash(String, JSON::Any)?
+    intercept_bridge_state(store)
+  end
+
+  def self.intercept_live_for_spec(bridge : Hash(String, JSON::Any)) : Bool
+    intercept_live?(bridge)
+  end
+end
+
+describe "gori run intercept (bridge state)" do
+  it "returns nil when no bridge has ever been published" do
+    with_store do |store|
+      Gori::CLI::Run.intercept_bridge_state_for_spec(store).should be_nil
+    end
+  end
+
+  it "parses a published bridge and reports live for a fresh heartbeat" do
+    with_store do |store|
+      now = Time.utc.to_unix_ms
+      store.set_intercept_bridge(%({"capturing":true,"enabled":true,"direction":"both","filter":"","session_token":"tok","heartbeat_ms":#{now}}))
+      bridge = Gori::CLI::Run.intercept_bridge_state_for_spec(store)
+      bridge.should_not be_nil
+      Gori::CLI::Run.intercept_live_for_spec(bridge.not_nil!).should be_true
+    end
+  end
+
+  it "treats a stale heartbeat as not live" do
+    with_store do |store|
+      stale = Time.utc.to_unix_ms - 60_000
+      store.set_intercept_bridge(%({"capturing":true,"session_token":"tok","heartbeat_ms":#{stale}}))
+      bridge = Gori::CLI::Run.intercept_bridge_state_for_spec(store).not_nil!
+      Gori::CLI::Run.intercept_live_for_spec(bridge).should be_false
+    end
+  end
+end

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -1465,6 +1465,257 @@ describe Gori::MCP::Server do
     end
   end
 
+  describe "compare_flows" do
+    it "diffs two flows' response bodies line by line" do
+      with_store do |store|
+        a = seed_flow(store, "a.test", "GET", "/x", 200, resp_body: "line1\nline2\nline3".to_slice)
+        b = seed_flow(store, "a.test", "GET", "/x", 200, resp_body: "line1\nCHANGED\nline3".to_slice)
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"compare_flows","arguments":{"flow_id_a":#{a},"flow_id_b":#{b}}}})
+        payload = tool_payload(drive(store, call)[0])
+        payload["pane"].as_s.should eq("response")
+        payload["identical"].as_bool.should be_false
+        payload["changed_lines"].as_i.should be > 0
+        kinds = payload["diff"].as_a.map(&.["kind"].as_s)
+        kinds.should contain("add")
+        kinds.should contain("del")
+      end
+    end
+
+    it "reports identical:true and zero changed_lines for identical flows" do
+      with_store do |store|
+        a = seed_flow(store, "a.test", "GET", "/x", 200, resp_body: "same".to_slice)
+        b = seed_flow(store, "a.test", "GET", "/x", 200, resp_body: "same".to_slice)
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"compare_flows","arguments":{"flow_id_a":#{a},"flow_id_b":#{b}}}})
+        payload = tool_payload(drive(store, call)[0])
+        payload["identical"].as_bool.should be_true
+        payload["changed_lines"].as_i.should eq(0)
+      end
+    end
+
+    it "diffs the request pane when pane:request" do
+      with_store do |store|
+        a = seed_flow(store, "a.test", "GET", "/x", 200)
+        b = seed_flow(store, "a.test", "POST", "/y", 200)
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"compare_flows","arguments":{"flow_id_a":#{a},"flow_id_b":#{b},"pane":"request"}}})
+        payload = tool_payload(drive(store, call)[0])
+        payload["pane"].as_s.should eq("request")
+        payload["identical"].as_bool.should be_false
+      end
+    end
+
+    it "redacts auth headers in the request-pane diff, reveals them with include_sensitive" do
+      with_store do |store|
+        a = store.insert_flow(Gori::Store::CapturedRequest.new(
+          created_at: 1_i64, scheme: "https", host: "a.test", port: 443,
+          method: "GET", target: "/x", http_version: "HTTP/1.1",
+          head: "GET /x HTTP/1.1\r\nHost: a.test\r\nAuthorization: Bearer topsecret\r\n\r\n".to_slice,
+          body: nil))
+        b = store.insert_flow(Gori::Store::CapturedRequest.new(
+          created_at: 2_i64, scheme: "https", host: "a.test", port: 443,
+          method: "GET", target: "/y", http_version: "HTTP/1.1",
+          head: "GET /y HTTP/1.1\r\nHost: a.test\r\nAuthorization: Bearer topsecret\r\n\r\n".to_slice,
+          body: nil))
+
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"compare_flows","arguments":{"flow_id_a":#{a},"flow_id_b":#{b},"pane":"request"}}})
+        payload = tool_payload(drive(store, call)[0])
+        texts = payload["diff"].as_a.map(&.["text"].as_s)
+        texts.any?(&.includes?("Authorization: [REDACTED]")).should be_true
+        texts.any?(&.includes?("topsecret")).should be_false
+
+        sensitive_call = %({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"compare_flows","arguments":{"flow_id_a":#{a},"flow_id_b":#{b},"pane":"request","include_sensitive":true}}})
+        sensitive_payload = tool_payload(drive(store, sensitive_call)[0])
+        sensitive_texts = sensitive_payload["diff"].as_a.map(&.["text"].as_s)
+        sensitive_texts.any?(&.includes?("Bearer topsecret")).should be_true
+      end
+    end
+
+    it "changes_only omits unchanged (same) lines from the diff" do
+      with_store do |store|
+        a = seed_flow(store, "a.test", "GET", "/x", 200, resp_body: "line1\nline2\nline3".to_slice)
+        b = seed_flow(store, "a.test", "GET", "/x", 200, resp_body: "line1\nCHANGED\nline3".to_slice)
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"compare_flows","arguments":{"flow_id_a":#{a},"flow_id_b":#{b},"changes_only":true}}})
+        payload = tool_payload(drive(store, call)[0])
+        payload["diff"].as_a.map(&.["kind"].as_s).should_not contain("same")
+      end
+    end
+
+    it "returns NOT_FOUND for a missing flow id" do
+      with_store do |store|
+        a = seed_flow(store, "a.test", "GET", "/x", 200)
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"compare_flows","arguments":{"flow_id_a":#{a},"flow_id_b":999999}}})
+        resp = drive(store, call)[0]["result"]
+        resp["isError"].as_bool.should be_true
+        resp["structuredContent"]["error_code"].as_s.should eq("NOT_FOUND")
+      end
+    end
+  end
+
+  describe "scope rule tools" do
+    it "adds, lists (with enabled), and deletes a scope rule" do
+      with_store do |store|
+        add = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"add_scope_rule","arguments":{"kind":"include","match_type":"host","pattern":"api.example.com"}}})
+        id = tool_payload(drive(store, add)[0])["id"].as_i64
+        id.should be > 0
+
+        listed = tool_payload(drive(store, %({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_scope"}}))[0])
+        listed["rules"].as_a.size.should eq(1)
+        listed["rules"][0]["pattern"].as_s.should eq("api.example.com")
+
+        del = %({"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"delete_scope_rule","arguments":{"id":#{id}}}})
+        tool_payload(drive(store, del)[0])["deleted"].as_bool.should be_true
+        store.scope_rules.should be_empty
+      end
+    end
+
+    it "rejects an invalid pattern (persists nothing)" do
+      with_store do |store|
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"add_scope_rule","arguments":{"match_type":"regex","pattern":"[invalid\(regex"}}})
+        resp = drive(store, call)[0]["result"]
+        resp["isError"].as_bool.should be_true
+        store.scope_rules.should be_empty
+      end
+    end
+
+    it "toggles the scope lens on/off and reflects it in list_scope" do
+      with_store do |store|
+        listed0 = tool_payload(drive(store, %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_scope"}}))[0])
+        listed0["enabled"].as_bool.should be_false
+
+        on = %({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"set_scope_enabled","arguments":{"enabled":true}}})
+        tool_payload(drive(store, on)[0])["enabled"].as_bool.should be_true
+
+        listed1 = tool_payload(drive(store, %({"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_scope"}}))[0])
+        listed1["enabled"].as_bool.should be_true
+      end
+    end
+
+    it "reports NOT_FOUND deleting an unknown scope rule id" do
+      with_store do |store|
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"delete_scope_rule","arguments":{"id":999}}})
+        resp = drive(store, call)[0]["result"]
+        resp["isError"].as_bool.should be_true
+        resp["structuredContent"]["error_code"].as_s.should eq("NOT_FOUND")
+      end
+    end
+  end
+
+  describe "env var tools" do
+    it "sets, lists (redacted by default), and deletes an env var" do
+      with_store do |store|
+        set = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"set_env_var","arguments":{"key":"TOKEN","value":"secret123"}}})
+        tool_payload(drive(store, set)[0])["set"].as_bool.should be_true
+
+        listed = tool_payload(drive(store, %({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_env"}}))[0]).as_a
+        listed.size.should eq(1)
+        listed[0]["key"].as_s.should eq("TOKEN")
+        listed[0]["value"].as_s.should eq("[REDACTED]")
+
+        sensitive = tool_payload(drive(store, %({"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_env","arguments":{"include_sensitive":true}}}))[0]).as_a
+        sensitive[0]["value"].as_s.should eq("secret123")
+
+        del = %({"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"delete_env_var","arguments":{"key":"TOKEN"}}})
+        tool_payload(drive(store, del)[0])["deleted"].as_bool.should be_true
+        Gori::Settings.project_env_vars.should be_empty
+      ensure
+        Gori::Settings.project_env_vars = [] of {String, String}
+      end
+    end
+
+    it "rejects an invalid key" do
+      with_store do |store|
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"set_env_var","arguments":{"key":"bad key!","value":"x"}}})
+        resp = drive(store, call)[0]["result"]
+        resp["isError"].as_bool.should be_true
+      ensure
+        Gori::Settings.project_env_vars = [] of {String, String}
+      end
+    end
+
+    it "reports NOT_FOUND deleting an unknown key" do
+      with_store do |store|
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"delete_env_var","arguments":{"key":"NOPE"}}})
+        resp = drive(store, call)[0]["result"]
+        resp["isError"].as_bool.should be_true
+        resp["structuredContent"]["error_code"].as_s.should eq("NOT_FOUND")
+      ensure
+        Gori::Settings.project_env_vars = [] of {String, String}
+      end
+    end
+  end
+
+  describe "host override tools" do
+    it "adds, lists, updates, and deletes a host override" do
+      with_store do |store|
+        add = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"add_host_override","arguments":{"host":"api.example.com","ip":"10.0.0.1"}}})
+        id = tool_payload(drive(store, add)[0])["id"].as_i64
+        id.should be > 0
+
+        listed = tool_payload(drive(store, %({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_host_overrides"}}))[0]).as_a
+        listed.size.should eq(1)
+        listed[0]["ip"].as_s.should eq("10.0.0.1")
+
+        upd = %({"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"update_host_override","arguments":{"id":#{id},"host":"api.example.com","ip":"10.0.0.2"}}})
+        tool_payload(drive(store, upd)[0])["ip"].as_s.should eq("10.0.0.2")
+
+        del = %({"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"delete_host_override","arguments":{"id":#{id}}}})
+        tool_payload(drive(store, del)[0])["deleted"].as_bool.should be_true
+        Gori::HostOverrides.load(store).entries.should be_empty
+      end
+    end
+
+    it "rejects an invalid ip literal" do
+      with_store do |store|
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"add_host_override","arguments":{"host":"api.example.com","ip":"not-an-ip"}}})
+        resp = drive(store, call)[0]["result"]
+        resp["isError"].as_bool.should be_true
+      end
+    end
+
+    it "reports NOT_FOUND updating an unknown id" do
+      with_store do |store|
+        upd = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"update_host_override","arguments":{"id":999,"host":"x.test","ip":"1.2.3.4"}}})
+        resp = drive(store, upd)[0]["result"]
+        resp["isError"].as_bool.should be_true
+        resp["structuredContent"]["error_code"].as_s.should eq("NOT_FOUND")
+      end
+    end
+  end
+
+  describe "import_flows" do
+    it "imports a URL list into History" do
+      with_store do |store|
+        path = File.tempname("gori-mcp-import", ".txt")
+        File.write(path, "https://a.test/\nhttps://b.test/x\n")
+        begin
+          call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"import_flows","arguments":{"kind":"urls","path":#{path.to_json}}}})
+          payload = tool_payload(drive(store, call)[0])
+          payload["count"].as_i.should eq(2)
+          store.count.should eq(2)
+        ensure
+          File.delete?(path)
+        end
+      end
+    end
+
+    it "returns a clean error for a missing file" do
+      with_store do |store|
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"import_flows","arguments":{"kind":"urls","path":"/no/such/file.txt"}}})
+        resp = drive(store, call)[0]["result"]
+        resp["isError"].as_bool.should be_true
+        resp["content"][0]["text"].as_s.should contain("not found")
+      end
+    end
+
+    it "rejects an invalid kind" do
+      with_store do |store|
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"import_flows","arguments":{"kind":"csv","path":"/tmp/x"}}})
+        resp = drive(store, call)[0]["result"]
+        resp["isError"].as_bool.should be_true
+        resp["structuredContent"]["field"].as_s.should eq("kind")
+      end
+    end
+  end
+
   describe "list_issues" do
     it "returns a paginated object (not a bare array)" do
       with_store do |store|

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -19,6 +19,7 @@ require "../repeater/h2_engine"
 require "../repeater/ws_engine"
 require "../repeater/flow_request"
 require "../repeater/diff"
+require "../repeater/message_lines"
 require "../fuzz"
 require "../decoder"
 require "../miner"
@@ -34,6 +35,8 @@ require "./output"
 require "./run/capture"
 require "./run/history"
 require "./run/repeater"
+require "./run/compare"
+require "./run/intercept"
 require "./run/fuzz_args"
 require "./run/fuzz"
 require "./run/mine"
@@ -107,6 +110,16 @@ module Gori
         when "decoder"  then cmd_decoder(rest)
         when "rewriter" then cmd_rewriter(rest)
         when "project"  then cmd_project(rest)
+        else                 dispatch_subcommand3(sub, rest)
+        end
+      end
+
+      # The third slice of the subcommand `case` (same complexity-bar reason as
+      # dispatch_subcommand2). `sub` is still non-nil here.
+      private def self.dispatch_subcommand3(sub : String?, rest : Array(String)) : Nil
+        case sub
+        when "compare"   then cmd_compare(rest)
+        when "intercept" then cmd_intercept(rest)
         else
           STDERR.puts "gori run: unknown subcommand '#{sub}'"
           print_help
@@ -121,7 +134,9 @@ module Gori
         {"capture", "Start the proxy and stream captured flows to STDOUT"},
         {"history (ls)", "List / QL-query captured flows"},
         {"show <id>", "Print a flow's request/response (text, json, or raw bytes)"},
-        {"repeater", "Re-send a captured flow; list/create/send (replay) repeater sessions"},
+        {"repeater", "Re-send a captured flow; list/create/send (replay, incl. WebSocket) repeater sessions"},
+        {"compare <a> <b>", "Diff two flows' request or response, side-by-side"},
+        {"intercept", "Inspect/drive a live TUI's paused intercept queue (list, forward, drop, edit, …)"},
         {"fuzz [<id>]", "Fuzz/intrude a request: mark §…§ positions, sweep payloads"},
         {"mine [<id>]", "Discover hidden parameters (query/form/multipart/json/header/cookie)"},
         {"sequence (seq)", "Analyze token randomness (collect via replay, or --tokens FILE)"},

--- a/src/gori/cli/run/compare.cr
+++ b/src/gori/cli/run/compare.cr
@@ -1,0 +1,101 @@
+# `gori run compare` — diff two flows' request or response (the CLI counterpart of
+# the TUI's Comparer tab). Reuses Repeater::MessageLines (decode/split) and
+# Repeater::Diff (LCS line diff) so the comparison matches the TUI exactly.
+module Gori
+  module CLI
+    module Run
+      private def self.cmd_compare(args : Array(String)) : Nil
+        db_path : String? = nil
+        project_name : String? = nil
+        pane = :response
+        changes_only = false
+        format = :text
+        positional = [] of String
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run compare <id-a> <id-b> [options]\n\n" \
+                     "Diff two flows' request or response (default: response)."
+          p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
+          p.on("--pane=PANE", "What to diff: request | response (default: response)") do |v|
+            pane = case v.strip.downcase
+                   when "request"  then :request
+                   when "response" then :response
+                   else                 abort "gori run compare: --pane must be request or response"
+                   end
+          end
+          p.on("--changes-only", "Only print added/removed lines (omit unchanged context)") { changes_only = true }
+          p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| positional = rest }
+          p.invalid_option { |f| abort "gori run compare: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run compare: missing value for #{f}" }
+        end
+        parser.parse(args)
+
+        abort "gori run compare: need two flow ids\n#{parser}" if positional.size < 2
+        abort "gori run compare: too many arguments (expected two flow ids, got: #{positional.join(" ")})" if positional.size > 2
+        id_a = positional[0].to_i64? || abort("gori run compare: invalid flow id '#{positional[0]}'")
+        id_b = positional[1].to_i64? || abort("gori run compare: invalid flow id '#{positional[1]}'")
+
+        project = resolve_read_project(project_name, db_path)
+        store = open_store(project)
+        detail_a, detail_b = begin
+          {store.get_flow(id_a), store.get_flow(id_b)}
+        ensure
+          store.close
+        end
+        abort "gori run compare: no flow ##{id_a}" unless detail_a
+        abort "gori run compare: no flow ##{id_b}" unless detail_b
+
+        lines_a = compare_lines(detail_a, pane)
+        lines_b = compare_lines(detail_b, pane)
+        truncated = lines_a.size > Repeater::Diff::MAX_LINES || lines_b.size > Repeater::Diff::MAX_LINES
+        full_diff = Repeater::Diff.lines(lines_a, lines_b)
+        change_count = Repeater::Diff.change_count(full_diff)
+        diff = changes_only ? full_diff.reject { |dl| dl.kind == Repeater::DiffKind::Same } : full_diff
+
+        emit_compare_result(id_a, id_b, pane, diff, change_count, truncated, format)
+      end
+
+      private def self.compare_lines(d : Store::FlowDetail, pane : Symbol) : Array(String)
+        if pane == :request
+          Repeater::MessageLines.of(d.request_head, d.request_body, decode: false)
+        else
+          Repeater::MessageLines.of(d.response_head, d.response_body, decode: true)
+        end
+      end
+
+      private def self.emit_compare_result(id_a : Int64, id_b : Int64, pane : Symbol,
+                                           diff : Array(Repeater::DiffLine), change_count : Int32,
+                                           truncated : Bool, format : Symbol) : Nil
+        if format == :json
+          puts(JSON.build do |j|
+            j.object do
+              j.field "flow_id_a", id_a
+              j.field "flow_id_b", id_b
+              j.field "pane", pane.to_s
+              j.field "changed_lines", change_count
+              j.field "truncated", truncated
+              j.field "diff" do
+                j.array do
+                  diff.each do |dl|
+                    j.object do
+                      j.field "kind", dl.kind.to_s.downcase
+                      j.field "text", dl.text
+                    end
+                  end
+                end
+              end
+            end
+          end)
+        else
+          STDERR.puts "— #{pane} diff: flow ##{id_a} vs ##{id_b} —"
+          print_diff(diff)
+          STDERR.puts "(truncated to #{Repeater::Diff::MAX_LINES} lines/side)" if truncated
+          STDERR.puts(change_count == 0 ? "no differences" : "#{change_count} line#{change_count == 1 ? "" : "s"} changed")
+        end
+      end
+    end
+  end
+end

--- a/src/gori/cli/run/intercept.cr
+++ b/src/gori/cli/run/intercept.cr
@@ -1,0 +1,438 @@
+# `gori run intercept` — inspect/drive the live intercept queue of a capturing TUI
+# instance. Interceptor is TUI-only (a headless `gori run capture` never holds
+# requests), so this is a script's window into a HUMAN's paused queue: read what's
+# held, then forward/drop/edit it, or flip catch/filter/direction. Mirrors `gori
+# mcp`'s intercept_* tools (src/gori/mcp/tools/intercept.cr) byte-for-byte — same
+# bridge blob (Store#intercept_bridge, published by Runner#publish_intercept_bridge),
+# same command-queue round-trip (Store#enqueue_intercept_command +
+# Store#command_status), same liveness/ack-poll constants — so a script gets the
+# same outcome whether it drives gori through the CLI or MCP.
+module Gori
+  module CLI
+    module Run
+      private def self.cmd_intercept(args : Array(String)) : Nil
+        sub = args.first?
+        case sub
+        when "-h", "--help" then print_intercept_help
+        when "get"          then cmd_intercept_get(args[1..])
+        when "forward"      then cmd_intercept_forward(args[1..])
+        when "drop"         then cmd_intercept_drop(args[1..])
+        when "list"         then cmd_intercept_list(args[1..])
+        when nil            then cmd_intercept_list(args)
+        else                     cmd_intercept2(sub, args)
+        end
+      end
+
+      # The second half of the subcommand `case` (split from cmd_intercept so each
+      # method stays under the cyclomatic-complexity bar). `sub` is non-nil here.
+      private def self.cmd_intercept2(sub : String?, args : Array(String)) : Nil
+        case sub
+        when "edit"      then cmd_intercept_edit(args[1..])
+        when "enable"    then cmd_intercept_toggle(true, args[1..])
+        when "disable"   then cmd_intercept_toggle(false, args[1..])
+        when "filter"    then cmd_intercept_set_filter(args[1..])
+        when "direction" then cmd_intercept_set_direction(args[1..])
+        else
+          if (s = sub) && s.starts_with?('-')
+            cmd_intercept_list(args)
+          else
+            STDERR.puts "gori run intercept: unknown subcommand '#{sub}'"
+            print_intercept_help
+            exit 1
+          end
+        end
+      end
+
+      private def self.print_intercept_help : Nil
+        puts <<-HELP
+        gori run intercept — inspect/drive the live intercept queue of a capturing TUI instance
+
+        Usage: gori run intercept [<subcommand>] [options]
+
+        Requires an open TUI on this project with intercept catch on — Interceptor is
+        TUI-only (a headless `gori run capture` never holds requests). Write subcommands
+        round-trip through the project database and bounded-poll for the TUI's ack.
+
+        Subcommands:
+          list                                 List held items + intercept state (default)
+          get <item-id>                        Full detail for one held item
+          forward <item-id>                    Forward a held item byte-exact
+          drop <item-id>                       Drop a held item (client gets a canned 502)
+          edit <item-id> (--raw=… | --raw-file=PATH)   Forward with edited bytes
+          enable                               Turn on live intercept catch
+          disable                              Turn off live intercept catch
+          filter <query>                       Set the conditional-intercept filter ("" clears)
+          direction <both|request|response>    Set which leg(s) intercept holds
+
+        Examples:
+          gori run intercept
+          gori run intercept get 3 --format json
+          gori run intercept forward 3
+          gori run intercept edit 3 --raw-file edited.txt
+          gori run intercept direction request
+
+        See 'gori run intercept <subcommand> --help' for more.
+        HELP
+      end
+
+      # --- bridge state (read side) -------------------------------------------
+
+      # Parse the bridge blob the capturing TUI publishes (nil when no capturing
+      # instance is live / has ever published). Mirrors MCP's intercept_bridge_state.
+      private def self.intercept_bridge_state(store : Store) : Hash(String, JSON::Any)?
+        raw = store.intercept_bridge
+        return nil unless raw
+        JSON.parse(raw).as_h?
+      rescue
+        nil
+      end
+
+      # A capturing instance is "live" only if its bridge says capturing AND the
+      # heartbeat is recent — otherwise a queued command would never be applied.
+      INTERCEPT_LIVE_MS   = 10_000_i64
+      INTERCEPT_ACK_POLLS =         30
+      INTERCEPT_ACK_SLEEP = 100.milliseconds
+
+      private def self.intercept_live?(bridge : Hash(String, JSON::Any)) : Bool
+        return false unless bridge["capturing"]?.try(&.as_bool?)
+        hb = bridge["heartbeat_ms"]?.try(&.as_i64?) || 0_i64
+        hb > 0 && (Time.utc.to_unix_ms - hb) < INTERCEPT_LIVE_MS
+      end
+
+      private def self.cmd_intercept_list(args : Array(String)) : Nil
+        db_path : String? = nil
+        project_name : String? = nil
+        format = :text
+        include_sensitive = false
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run intercept [list] [options]"
+          p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
+          p.on("--include-sensitive", "Show Authorization/Cookie/etc header values instead of [REDACTED]") { include_sensitive = true }
+          p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.invalid_option { |f| abort "gori run intercept: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run intercept: missing value for #{f}" }
+        end
+        parser.parse(args)
+
+        project = resolve_read_project(project_name, db_path)
+        store = open_store(project)
+        begin
+          bridge = intercept_bridge_state(store)
+          unless bridge
+            unavailable = "no capturing gori instance is publishing intercept state (open the project's TUI to intercept)"
+            if format == :json
+              puts(JSON.build { |j| j.object { j.field "available", false; j.field "reason", unavailable } })
+            else
+              STDERR.puts unavailable
+            end
+            return
+          end
+
+          token = bridge["session_token"]?.try(&.as_s?) || ""
+          now_ms = Time.utc.to_unix_ms
+          items = token.empty? ? [] of Store::HeldRow : store.intercept_held(token)
+          # Stamp viewed_ms so the capturing instance's auto-forward reaper sees this
+          # script is watching (mirrors MCP intercept_list).
+          store.touch_intercept_held(token, items.map(&.item_id), now_ms) unless items.empty?
+          emit_intercept_list(bridge, items, include_sensitive, now_ms, format)
+        ensure
+          store.close
+        end
+      end
+
+      private def self.emit_intercept_list(bridge : Hash(String, JSON::Any), items : Array(Store::HeldRow),
+                                           include_sensitive : Bool, now_ms : Int64, format : Symbol) : Nil
+        live = intercept_live?(bridge)
+        enabled = bridge["enabled"]?.try(&.as_bool?) || false
+        direction = bridge["direction"]?.try(&.as_s?) || "both"
+        filter = bridge["filter"]?.try(&.as_s?) || ""
+        if format == :json
+          puts(JSON.build do |j|
+            j.object do
+              j.field "available", true
+              j.field "capturing", live
+              j.field "enabled", enabled
+              j.field "direction", direction
+              j.field "filter", filter
+              j.field "heartbeat_age_seconds", (bridge["heartbeat_ms"]?.try(&.as_i64?).try { |hb| hb > 0 ? (now_ms - hb) // 1000 : nil })
+              j.field "pending_count", items.size
+              j.field("items") { j.array { items.each { |r| MCP::Serialize.intercept_item_row(j, r, include_sensitive, now_ms) } } }
+            end
+          end)
+        else
+          STDERR.puts "intercept: #{live ? "LIVE" : "not live (stale heartbeat)"} · catch #{enabled ? "ON" : "OFF"} · direction #{direction}"
+          STDERR.puts "filter: #{filter.empty? ? "(none)" : filter}"
+          if items.empty?
+            puts "No items currently held."
+          else
+            items.each do |r|
+              _, body = MCP::Serialize.head_and_body(r.raw)
+              # method/scheme/host/target are parsed off the wire (a held request's request
+              # line / Host header, or a held response) — CLI::Output.term_safe neutralizes
+              # any ANSI/OSC/CSI escapes before they hit the live terminal (see its doc
+              # comment; same discipline as flow_row_text/print_message_text).
+              method = CLI::Output.term_safe(r.method.ljust(6))
+              scheme = CLI::Output.term_safe(r.scheme)
+              host = CLI::Output.term_safe(r.host)
+              target = CLI::Output.term_safe(r.target)
+              puts "##{r.item_id}  [#{r.kind}]  #{method} #{scheme}://#{host}#{target}  (#{body.size}b body)"
+            end
+          end
+        end
+      end
+
+      private def self.cmd_intercept_get(args : Array(String)) : Nil
+        db_path : String? = nil
+        project_name : String? = nil
+        format = :text
+        include_sensitive = false
+        positional = [] of String
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run intercept get <item-id> [options]"
+          p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
+          p.on("--include-sensitive", "Also include the full raw message base64 (unredacted)") { include_sensitive = true }
+          p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| positional = rest }
+          p.invalid_option { |f| abort "gori run intercept get: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run intercept get: missing value for #{f}" }
+        end
+        parser.parse(args)
+        abort "gori run intercept get: missing <item-id>" if positional.empty?
+        abort "gori run intercept get: too many arguments (expected one <item-id>)" if positional.size > 1
+        item_id = positional[0].to_i64? || abort("gori run intercept get: invalid item id '#{positional[0]}'")
+
+        project = resolve_read_project(project_name, db_path)
+        store = open_store(project)
+        begin
+          bridge = intercept_bridge_state(store)
+          abort "gori run intercept get: no capturing gori instance is publishing intercept state" unless bridge
+          token = bridge["session_token"]?.try(&.as_s?) || ""
+          row = token.empty? ? nil : store.intercept_held(token).find { |r| r.item_id == item_id }
+          abort "gori run intercept get: held item #{item_id} is not currently held (already forwarded/dropped, or never held)" unless row
+          now_ms = Time.utc.to_unix_ms
+          store.touch_intercept_held(token, [row.item_id], now_ms)
+
+          if format == :json
+            puts(JSON.build { |j| MCP::Serialize.intercept_item_detail(j, row, include_sensitive, now_ms) })
+          else
+            head, body = MCP::Serialize.head_and_body(row.raw)
+            redacted = MCP::Serialize.redact_head(head, include_sensitive)
+            puts CLI::Output.term_safe_multiline(redacted).rstrip
+            unless body.empty?
+              puts ""
+              puts "[#{body.size} bytes of body — use --format json --include-sensitive for the raw bytes]"
+            end
+          end
+        ensure
+          store.close
+        end
+      end
+
+      # Enqueue one command against the project's live capturing instance, then
+      # bounded-poll its acknowledgement — mirrors MCP's enqueue_intercept/
+      # await_intercept_ack so a script gets a real outcome rather than assuming
+      # success on a write that may have been dropped or never drained.
+      private def self.enqueue_intercept(project_name : String?, db_path : String?, verb : String, *,
+                                         item_id : Int64? = nil, bytes : Bytes? = nil, arg : String? = nil) : {String, String?}
+        project = resolve_read_project(project_name, db_path)
+        store = open_store(project)
+        begin
+          bridge = intercept_bridge_state(store)
+          unless bridge && intercept_live?(bridge)
+            abort "gori run intercept: no live capturing gori instance is draining intercept commands (open the project's TUI with intercept on)"
+          end
+          token = bridge["session_token"]?.try(&.as_s?)
+          id = store.enqueue_intercept_command(token, verb, item_id: item_id, bytes: bytes, arg: arg)
+          abort "gori run intercept: could not enqueue intercept command (store write dropped); retry" if id == 0
+          await_intercept_ack(store, id)
+        ensure
+          store.close
+        end
+      end
+
+      private def self.await_intercept_ack(store : Store, id : Int64) : {String, String?}
+        INTERCEPT_ACK_POLLS.times do
+          if st = store.command_status(id)
+            return st unless st[0] == "pending"
+          end
+          sleep INTERCEPT_ACK_SLEEP
+        end
+        ms = (INTERCEPT_ACK_POLLS * INTERCEPT_ACK_SLEEP.total_milliseconds).to_i
+        abort "gori run intercept: command not confirmed within #{ms}ms — the capturing instance may be busy; retry"
+      end
+
+      private def self.emit_intercept_ack(status : String, detail : String?, format : Symbol) : Nil
+        ok = !status.in?("no_such_item", "stale", "error")
+        if format == :json
+          puts(JSON.build { |j| j.object { j.field "status", status; j.field "ok", ok; j.field "detail", detail } })
+        else
+          puts "#{status}#{detail ? ": #{detail}" : ""}"
+        end
+        exit 1 unless ok
+      end
+
+      private def self.cmd_intercept_forward(args : Array(String)) : Nil
+        item_id, project_name, db_path, format = parse_intercept_item_args(args, "forward")
+        status, detail = enqueue_intercept(project_name, db_path, "forward", item_id: item_id)
+        emit_intercept_ack(status, detail, format)
+      end
+
+      private def self.cmd_intercept_drop(args : Array(String)) : Nil
+        item_id, project_name, db_path, format = parse_intercept_item_args(args, "drop")
+        status, detail = enqueue_intercept(project_name, db_path, "drop", item_id: item_id)
+        emit_intercept_ack(status, detail, format)
+      end
+
+      # Shared option/positional parsing for the single-<item-id> write subcommands
+      # (forward/drop) so their bodies stay tiny and identical in shape.
+      private def self.parse_intercept_item_args(args : Array(String), verb : String) : {Int64, String?, String?, Symbol}
+        db_path : String? = nil
+        project_name : String? = nil
+        format = :text
+        positional = [] of String
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run intercept #{verb} <item-id> [options]"
+          p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
+          p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| positional = rest }
+          p.invalid_option { |f| abort "gori run intercept #{verb}: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run intercept #{verb}: missing value for #{f}" }
+        end
+        parser.parse(args)
+        abort "gori run intercept #{verb}: missing <item-id>" if positional.empty?
+        abort "gori run intercept #{verb}: too many arguments (expected one <item-id>)" if positional.size > 1
+        item_id = positional[0].to_i64? || abort("gori run intercept #{verb}: invalid item id '#{positional[0]}'")
+        {item_id, project_name, db_path, format}
+      end
+
+      private def self.cmd_intercept_edit(args : Array(String)) : Nil
+        db_path : String? = nil
+        project_name : String? = nil
+        format = :text
+        raw : String? = nil
+        raw_file : String? = nil
+        positional = [] of String
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run intercept edit <item-id> (--raw=RAW | --raw-file=PATH) [options]\n\n" \
+                     "Forward a held item with EDITED bytes: the full replacement wire message\n" \
+                     "(whichever leg — request or response — is held). Bytes are forwarded\n" \
+                     "VERBATIM (no $KEY expansion); Content-Length is resynced to the new body."
+          p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
+          p.on("--raw=RAW", "Verbatim replacement wire message") { |v| raw = v }
+          p.on("--raw-file=PATH", "Read the replacement wire message from FILE") { |v| raw_file = v }
+          p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| positional = rest }
+          p.invalid_option { |f| abort "gori run intercept edit: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run intercept edit: missing value for #{f}" }
+        end
+        parser.parse(args)
+        abort "gori run intercept edit: missing <item-id>" if positional.empty?
+        abort "gori run intercept edit: too many arguments (expected one <item-id>)" if positional.size > 1
+        item_id = positional[0].to_i64? || abort("gori run intercept edit: invalid item id '#{positional[0]}'")
+
+        content = if f = raw_file
+                    abort "gori run intercept edit: --raw-file '#{f}' is not readable" unless File.exists?(f) && !File.directory?(f)
+                    File.read(f)
+                  elsif r = raw
+                    r
+                  else
+                    abort "gori run intercept edit: --raw or --raw-file is required"
+                  end
+        abort "gori run intercept edit: replacement message must not be empty" if content.empty?
+
+        # Byte-level CRLF normalize, not `.gsub(/\r?\n/, "\r\n")` — content may be
+        # an arbitrary binary body read from --raw-file (invalid UTF-8), which a
+        # Regex subject cannot accept and would crash on.
+        wire = Env.normalize_crlf(content.to_slice)
+        bytes = Fuzz::ContentLength.sync(wire, add_when_missing: true)
+        status, detail = enqueue_intercept(project_name, db_path, "forward_edit", item_id: item_id, bytes: bytes)
+        emit_intercept_ack(status, detail, format)
+      end
+
+      private def self.cmd_intercept_toggle(enable : Bool, args : Array(String)) : Nil
+        db_path : String? = nil
+        project_name : String? = nil
+        format = :text
+        action = enable ? "enable" : "disable"
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run intercept #{action} [options]"
+          p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
+          p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.invalid_option { |f| abort "gori run intercept #{action}: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run intercept #{action}: missing value for #{f}" }
+        end
+        parser.parse(args)
+
+        status, detail = enqueue_intercept(project_name, db_path, "toggle", arg: enable ? "true" : "false")
+        emit_intercept_ack(status, detail, format)
+      end
+
+      private def self.cmd_intercept_set_filter(args : Array(String)) : Nil
+        db_path : String? = nil
+        project_name : String? = nil
+        format = :text
+        positional = [] of String
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run intercept filter <query> [options]\n\n" \
+                     "Set the conditional-intercept filter (a gori-QL-like query that narrows\n" \
+                     "which requests/responses are held). Pass an empty string to clear it."
+          p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
+          p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| positional = rest }
+          p.invalid_option { |f| abort "gori run intercept filter: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run intercept filter: missing value for #{f}" }
+        end
+        parser.parse(args)
+        abort "gori run intercept filter: missing <query> (pass \"\" to clear)" if positional.empty?
+        abort "gori run intercept filter: too many arguments (expected one <query>)" if positional.size > 1
+
+        status, detail = enqueue_intercept(project_name, db_path, "set_filter", arg: positional[0])
+        emit_intercept_ack(status, detail, format)
+      end
+
+      private def self.cmd_intercept_set_direction(args : Array(String)) : Nil
+        db_path : String? = nil
+        project_name : String? = nil
+        format = :text
+        positional = [] of String
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run intercept direction <both|request|response> [options]"
+          p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
+          p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| positional = rest }
+          p.invalid_option { |f| abort "gori run intercept direction: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run intercept direction: missing value for #{f}" }
+        end
+        parser.parse(args)
+        abort "gori run intercept direction: missing <both|request|response>" if positional.empty?
+        abort "gori run intercept direction: too many arguments (expected one)" if positional.size > 1
+        dir = positional[0].strip.downcase
+        abort "gori run intercept direction: invalid direction '#{positional[0]}' (expected both|request|response)" unless dir.in?("both", "request", "response")
+
+        status, detail = enqueue_intercept(project_name, db_path, "set_direction", arg: dir)
+        emit_intercept_ack(status, detail, format)
+      end
+    end
+  end
+end

--- a/src/gori/cli/run/repeater.cr
+++ b/src/gori/cli/run/repeater.cr
@@ -201,15 +201,20 @@ module Gori
         insecure = false
         do_diff = false
         format = :text
+        ws_messages = [] of String
+        idle_ms : Int64? = nil
         positional = [] of String
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run repeater send <repeater-id> [options]\n\n" \
-                     "Replay a saved repeater SESSION (ids from `gori run repeater list`)."
+                     "Replay a saved repeater SESSION (ids from `gori run repeater list`).\n" \
+                     "A WebSocket-upgrade session performs a real RFC 6455 framed exchange."
           p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("-k", "--insecure-upstream", "Do not verify the upstream TLS certificate") { insecure = true }
           p.on("--diff", "Diff the new response against the session's last stored response") { do_diff = true }
+          p.on("--message=TEXT", "WebSocket: outbound text message (repeatable; replaces the session's stored messages)") { |v| ws_messages << v }
+          p.on("--idle-ms=N", "WebSocket: server-silence timeout after the first inbound frame (100-60000, default 3000)") { |v| idle_ms = parse_count(v, "--idle-ms").to_i64 }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args { |rest, _| positional = rest }
@@ -231,10 +236,9 @@ module Gori
         end
         abort "gori run repeater send: no repeater session ##{id}" unless rec
 
-        # A WS upgrade can't be replayed by a one-shot HTTP send (it would stop at the
-        # 101 handshake), matching MCP's repeater-branch guard.
         if Repeater::WsEngine.upgrade_request?(String.new(rec.request))
-          abort "gori run repeater send: repeater session ##{id} is a WebSocket upgrade — replay it from the TUI Repeater tab or via the MCP `send_websocket` tool for a framed exchange."
+          cmd_repeater_send_ws(id, rec, project_name, db_path, insecure, idle_ms, ws_messages, host_overrides, format)
+          return
         end
 
         send = build_repeater_send(rec)
@@ -252,6 +256,101 @@ module Gori
           end
         emit_repeater_result(result, new_body, diff, format)
         exit 1 unless result.ok?
+      end
+
+      # Execute a WebSocket repeater SESSION: a fresh RFC 6455 handshake, the
+      # session's outbound messages (or `--message` overrides), and the inbound
+      # transcript. Mirrors MCP send_websocket (src/gori/mcp/tools/send.cr) so a
+      # script gets the same exchange whether it drives gori via CLI or MCP.
+      private def self.cmd_repeater_send_ws(id : Int64, rec : Store::RepeaterRecord, project_name : String?,
+                                            db_path : String?, insecure : Bool, idle_ms : Int64?,
+                                            message_override : Array(String), host_overrides : Gori::HostOverrides,
+                                            format : Symbol) : Nil
+        target = Env.expand(rec.target)
+        scheme, host, port = Repeater::FlowRequest.parse_target(target)
+        abort "gori run repeater send: could not determine a target host for session ##{id}" if host.empty?
+
+        # host_overrides was already loaded by the caller (cmd_repeater_send) from the
+        # same store open that fetched `rec` — reuse it instead of a second table scan.
+        store = open_store(resolve_read_project(project_name, db_path))
+        out_messages = begin
+          ws_out_messages(store, id, message_override)
+        ensure
+          store.close
+        end
+
+        idle = (idle_ms || 3000_i64).clamp(100_i64, 60_000_i64).milliseconds
+        verify = !insecure
+        request = Env.expand_wire(String.new(rec.request))
+        sni = rec.sni.try { |v| Env.expand(v) }
+        result = Repeater::WsEngine.send(request, out_messages, scheme: scheme, host: host, port: port,
+          verify_upstream: verify, sni: sni, idle: idle, overrides: host_overrides)
+
+        store2 = open_store(resolve_read_project(project_name, db_path))
+        begin
+          store2.update_repeater_response(id, result.handshake_head, Bytes.empty, result.error, result.duration_us)
+        ensure
+          store2.close
+        end
+
+        emit_ws_result(id, result, format)
+        exit 1 unless result.ok?
+      end
+
+      # The session's outbound messages: `--message` overrides when given (each
+      # sent as a text frame), else the WS messages stored on the repeater (the
+      # ones with direction "out"), env-expanded like MCP send_websocket.
+      private def self.ws_out_messages(store : Store, id : Int64, override : Array(String)) : Array(Repeater::WsEngine::OutMsg)
+        return override.map { |t| Repeater::WsEngine::OutMsg.new(1, Env.expand(t).to_slice) } unless override.empty?
+        store.ws_messages_for_repeater(id).compact_map do |m|
+          next nil unless m.direction == "out"
+          payload = m.text? ? Env.expand(String.new(m.payload).scrub).to_slice : m.payload
+          Repeater::WsEngine::OutMsg.new(m.opcode, payload)
+        end
+      end
+
+      private def self.emit_ws_result(id : Int64, result : Repeater::WsEngine::Result, format : Symbol) : Nil
+        if format == :json
+          puts(JSON.build do |j|
+            j.object do
+              j.field "repeater_id", id
+              j.field "upgraded", result.upgraded?
+              j.field "duration_us", result.duration_us
+              j.field "close_code", result.close_code
+              j.field "error", result.error
+              j.field "note", result.note
+              j.field "messages" do
+                j.array do
+                  result.messages.each do |m|
+                    j.object do
+                      j.field "direction", m.direction
+                      j.field "opcode", m.opcode
+                      if m.opcode == 1
+                        j.field "text", scrub(m.payload)
+                      else
+                        j.field "binary", true
+                        j.field "size", m.payload.size
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end)
+        elsif result.ok?
+          STDERR.puts "→ WebSocket upgraded=#{result.upgraded?} in #{CLI::Output.human_us(result.duration_us)}#{result.close_code ? " (close #{result.close_code})" : ""}"
+          STDERR.puts "note: #{result.note}" if result.note
+          result.messages.each do |m|
+            arrow = m.direction == "out" ? "→" : "←"
+            if m.opcode == 1
+              puts "#{arrow} #{scrub(m.payload)}"
+            else
+              puts "#{arrow} [binary frame, #{m.payload.size} bytes]"
+            end
+          end
+        else
+          STDERR.puts "repeater failed: #{result.error}"
+        end
       end
 
       # Render a replay Result (text or json, optional diff), shared by the flow-id
@@ -342,7 +441,7 @@ module Gori
         # (status 101 + a WebSocket upgrade request) and refuse with an actionable pointer,
         # rather than the plain h1/h2 engines that don't do the RFC 6455 framed exchange.
         if detail.row.status == 101 && Repeater::WsEngine.upgrade_request?(String.new(detail.request_head))
-          abort "gori run repeater: flow ##{id} is a WebSocket session — `gori run repeater` only re-sends the HTTP upgrade and captures the 101 handshake, not the framed messages. Repeater it from the TUI Repeater tab, or create a repeater from it and use the MCP `send_websocket` tool for a real framed exchange."
+          abort "gori run repeater: flow ##{id} is a WebSocket session — `gori run repeater` only re-sends the HTTP upgrade and captures the 101 handshake, not the framed messages. Create a repeater from it (`gori run repeater create --flow=#{id}`) and replay it with `gori run repeater send <id>` for a real framed exchange."
         end
 
         # The captured request body was capped at CAPTURE_MAX; FlowRequest.build re-syncs the

--- a/src/gori/env.cr
+++ b/src/gori/env.cr
@@ -137,8 +137,10 @@ module Gori
     # Byte-level equivalent of `gsub(/\r?\n/, "\r\n")`: inserts `\r` before any
     # `\n` not already preceded by one, leaving everything else untouched. Used
     # instead of a `Regex` because `bytes` (the expanded request text) may carry
-    # invalid UTF-8, which `Regex` cannot accept as a subject.
-    private def self.normalize_crlf(bytes : Bytes) : Bytes
+    # invalid UTF-8, which `Regex` cannot accept as a subject. Public: also reused
+    # by `gori run intercept edit --raw-file` (a locally-read file may be an
+    # arbitrary binary body, same invalid-UTF-8 hazard).
+    def self.normalize_crlf(bytes : Bytes) : Bytes
       buf = IO::Memory.new(bytes.size)
       prev : UInt8 = 0
       bytes.each do |b|

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -24,11 +24,15 @@ require "../notes"
 require "../probe"
 require "./serialize"
 require "./request_builder"
+require "./tools/compare"
 require "./tools/context"
 require "./tools/decode"
 require "./tools/discover"
+require "./tools/env"
 require "./tools/flows"
 require "./tools/fuzz"
+require "./tools/host_overrides"
+require "./tools/import"
 require "./tools/intercept"
 require "./tools/issues"
 require "./tools/jobs"
@@ -39,6 +43,7 @@ require "./tools/projects"
 require "./tools/ql"
 require "./tools/repeater"
 require "./tools/rules"
+require "./tools/scope"
 require "./tools/send"
 require "./tools/sequence"
 require "./tools/sitemap"
@@ -89,6 +94,10 @@ module Gori
         "create_note", "update_note", "delete_note",
         "create_repeater", "update_repeater", "delete_repeater",
         "oast_start", "oast_stop",
+        "add_scope_rule", "delete_scope_rule", "set_scope_enabled",
+        "set_env_var", "delete_env_var",
+        "add_host_override", "update_host_override", "delete_host_override",
+        "import_flows",
       }
 
       # R2-3 — active/outbound tools that expand or mask `$KEY` env tokens at call
@@ -453,6 +462,20 @@ module Gori
             s.field "raw", boolprop("page stored response bytes without content decoding (default false)")
           end
 
+          tool j, "compare_flows",
+            "Line-diff two flows' request or response — the MCP equivalent of the TUI's Comparer " \
+            "tab. Response bodies are decoded (de-chunked/decompressed) before diffing; request " \
+            "bodies are compared byte-faithful. Returns {changed_lines, identical, truncated, " \
+            "diff:[{kind: same|add|del, text}]} (add = only in flow B, del = only in flow A). " \
+            "Authorization/Cookie/Set-Cookie/API-key header values are [REDACTED] in the diff " \
+            "text unless include_sensitive=true. Pure read: no network, nothing written." do |s|
+            s.field "flow_id_a", intprop("first flow id (the 'original' side)"), required: true
+            s.field "flow_id_b", intprop("second flow id (the 'new' side)"), required: true
+            s.field "pane", strprop("request | response (default response)")
+            s.field "changes_only", boolprop("omit unchanged (same) lines from the diff (default false)")
+            s.field "include_sensitive", boolprop("return Authorization/Cookie/Set-Cookie/API-key header values instead of [REDACTED] (default false)")
+          end
+
           tool j, "list_sitemap",
             "Distinct endpoints discovered in capture, keyed by TRANSPORT " \
             "(scheme, host, port, http_version, method, target) so the same path over " \
@@ -493,7 +516,19 @@ module Gori
             s.field "limit", intprop("max issue groups to return (default 200, max 2000)")
           end
 
-          tool j, "list_scope", "List the project's scope include/exclude rules." { }
+          tool j, "list_scope", "List the project's scope include/exclude rules, plus whether the scope lens/gate is enabled." { }
+
+          tool j, "list_env",
+            "List the project's env vars (used for $KEY substitution in outbound requests — see " \
+            "send_request/send_websocket). Values are [REDACTED] by default (a project env var is " \
+            "exactly the kind of place a credential/token lives); pass include_sensitive:true to see them." do |s|
+            s.field "include_sensitive", boolprop("return actual values instead of [REDACTED] (default false)")
+          end
+
+          tool j, "list_host_overrides",
+            "List the project's host overrides (/etc/hosts-style: dial a specific IP for a hostname; " \
+            "SNI/Host header unchanged). Project overrides win over the global Settings ones on a " \
+            "collision." { }
 
           tool j, "project_info",
             "Project totals: flow count, issue count, captured bytes, earliest capture time, " \
@@ -682,6 +717,60 @@ module Gori
               "Set which leg(s) intercept holds: both | request | response. Applied by the " \
               "capturing instance." do |s|
               s.field "direction", strprop("both | request | response"), required: true
+            end
+
+            tool j, "add_scope_rule",
+              "Add a scope include/exclude rule (the Target/Sitemap ⇧S lens, and the intercept " \
+              "gate). Deduped on the kind/match_type/pattern triple." do |s|
+              s.field "kind", strprop("include | exclude (default include)")
+              s.field "match_type", strprop("host | string | regex (default host)")
+              s.field "pattern", strprop("host: exact/subdomain/'*' glob; string: substring of scheme://host/target; regex: over the same (case-sensitive; use (?i) to opt out)"), required: true
+            end
+
+            tool j, "delete_scope_rule", "Delete a scope rule by id (see list_scope)." do |s|
+              s.field "id", intprop("scope rule id"), required: true
+            end
+
+            tool j, "set_scope_enabled",
+              "Turn the scope lens/gate on or off (the rules themselves are untouched)." do |s|
+              s.field "enabled", boolprop("true = filter to in-scope; false = show/allow everything"), required: true
+            end
+
+            tool j, "set_env_var",
+              "Set (create or update) a project env var used for $KEY substitution in outbound " \
+              "requests (send_request, send_websocket, repeater sends)." do |s|
+              s.field "key", strprop("variable name ([A-Za-z_][A-Za-z0-9_]*)"), required: true
+              s.field "value", strprop("variable value (default empty)")
+            end
+
+            tool j, "delete_env_var", "Delete a project env var by key (see list_env)." do |s|
+              s.field "key", strprop("variable name"), required: true
+            end
+
+            tool j, "add_host_override",
+              "Add a host override (dial a specific IP for a hostname; SNI/Host header unchanged) — " \
+              "used by send_request/send_websocket/repeater and the live proxy." do |s|
+              s.field "host", strprop("hostname to override (case-insensitive)"), required: true
+              s.field "ip", strprop("IPv4/IPv6 literal to dial"), required: true
+            end
+
+            tool j, "update_host_override", "Update an existing host override by id." do |s|
+              s.field "id", intprop("host override id (see list_host_overrides)"), required: true
+              s.field "host", strprop("new hostname"), required: true
+              s.field "ip", strprop("new IPv4/IPv6 literal"), required: true
+            end
+
+            tool j, "delete_host_override", "Delete a host override by id." do |s|
+              s.field "id", intprop("host override id (see list_host_overrides)"), required: true
+            end
+
+            tool j, "import_flows",
+              "Bulk-import flows into the project's History from a HAR export, a URL list, or an " \
+              "OpenAPI/Swagger spec — the MCP equivalent of `gori run import`. `path` is read from " \
+              "the MCP SERVER's local filesystem (this process runs locally, same trust boundary as " \
+              "send_request)." do |s|
+              s.field "kind", strprop("har | urls | oas"), required: true
+              s.field "path", strprop("filesystem path to the HAR/URL-list/OpenAPI file"), required: true
             end
 
             tool j, "create_rule",
@@ -1158,11 +1247,14 @@ module Gori
         when "intercept_get"           then intercept_get(h)
         when "get_flow"                then get_flow(h)
         when "get_response_body_chunk" then get_response_body_chunk(h)
+        when "compare_flows"           then compare_flows(h)
         when "list_sitemap"            then list_sitemap(h)
         when "list_issues"             then list_issues(h)
         when "get_issue"               then get_issue(h)
         when "probe_scan"              then probe_scan(h)
         when "list_scope"              then list_scope
+        when "list_env"                then list_env(h)
+        when "list_host_overrides"     then list_host_overrides
         when "project_info"            then project_info
         when "get_current_context"     then get_current_context
         when "get_repeater_context"    then get_repeater_context(h)
@@ -1198,6 +1290,15 @@ module Gori
         when "intercept_toggle"        then gated { intercept_toggle(h) }
         when "intercept_set_filter"    then gated { intercept_set_filter(h) }
         when "intercept_set_direction" then gated { intercept_set_direction(h) }
+        when "add_scope_rule"          then gated { add_scope_rule(h) }
+        when "delete_scope_rule"       then gated { delete_scope_rule(h) }
+        when "set_scope_enabled"       then gated { set_scope_enabled(h) }
+        when "set_env_var"             then gated { set_env_var(h) }
+        when "delete_env_var"          then gated { delete_env_var(h) }
+        when "add_host_override"       then gated { add_host_override(h) }
+        when "update_host_override"    then gated { update_host_override(h) }
+        when "delete_host_override"    then gated { delete_host_override(h) }
+        when "import_flows"            then gated { import_flows(h) }
         when "create_repeater"         then gated { create_repeater(h) }
         when "update_repeater"         then gated { update_repeater(h) }
         when "delete_repeater"         then gated { delete_repeater(h) }

--- a/src/gori/mcp/tools/compare.cr
+++ b/src/gori/mcp/tools/compare.cr
@@ -1,0 +1,79 @@
+require "json"
+require "../../store"
+require "../../repeater/message_lines"
+require "../../repeater/diff"
+require "../serialize"
+
+module Gori
+  module MCP
+    class Tools
+      # Diff two flows' request or response — the MCP counterpart of the TUI's
+      # Comparer tab (src/gori/tui/comparer_view.cr). Reuses Repeater::MessageLines
+      # (decode/split) and Repeater::Diff (LCS line diff), same engine and MAX_LINES
+      # cap, so the comparison matches what a human sees in the Comparer tab.
+      private def compare_flows(h) : Result
+        id_a = int(h, "flow_id_a")
+        return err(id_error(h, "flow_id_a"), "INVALID_ARGUMENT", field: "flow_id_a") unless id_a
+        id_b = int(h, "flow_id_b")
+        return err(id_error(h, "flow_id_b"), "INVALID_ARGUMENT", field: "flow_id_b") unless id_b
+        detail_a = store.get_flow(id_a)
+        return not_found("no flow with id #{id_a}") unless detail_a
+        detail_b = store.get_flow(id_b)
+        return not_found("no flow with id #{id_b}") unless detail_b
+
+        pane_s = str(h, "pane").try(&.strip.downcase)
+        if pane_s && !pane_s.in?("request", "response")
+          return err("invalid 'pane' (expected request|response)", "INVALID_ARGUMENT", field: "pane")
+        end
+        pane = pane_s == "request" ? :request : :response
+        changes_only = bool_arg(h, "changes_only", false)
+        include_sensitive = bool_arg(h, "include_sensitive", false)
+
+        lines_a = compare_lines(detail_a, pane, include_sensitive)
+        lines_b = compare_lines(detail_b, pane, include_sensitive)
+        truncated = lines_a.size > Repeater::Diff::MAX_LINES || lines_b.size > Repeater::Diff::MAX_LINES
+        full_diff = Repeater::Diff.lines(lines_a, lines_b)
+        change_count = Repeater::Diff.change_count(full_diff)
+        diff = changes_only ? full_diff.reject { |dl| dl.kind == Repeater::DiffKind::Same } : full_diff
+
+        Result.new(JSON.build do |j|
+          j.object do
+            j.field "flow_id_a", id_a
+            j.field "flow_id_b", id_b
+            j.field "pane", pane.to_s
+            j.field "changed_lines", change_count
+            j.field "identical", change_count == 0
+            j.field "truncated", truncated
+            j.field "diff" do
+              j.array do
+                diff.each do |dl|
+                  j.object do
+                    j.field "kind", dl.kind.to_s.downcase
+                    j.field "text", dl.text
+                  end
+                end
+              end
+            end
+          end
+        end)
+      end
+
+      private def compare_lines(d : Store::FlowDetail, pane : Symbol, include_sensitive : Bool) : Array(String)
+        if pane == :request
+          Repeater::MessageLines.of(redacted_head(d.request_head, include_sensitive), d.request_body, decode: false)
+        else
+          Repeater::MessageLines.of(redacted_head(d.response_head, include_sensitive), d.response_body, decode: true)
+        end
+      end
+
+      # Authorization/Cookie/Set-Cookie/API-key header VALUES are [REDACTED] unless
+      # include_sensitive:true — same default as get_flow/intercept_get/
+      # get_repeater_context. Applied before diffing so a redacted value can't leak
+      # through the `text` field of a diff line.
+      private def redacted_head(head : Bytes?, include_sensitive : Bool) : Bytes?
+        return head unless head
+        Serialize.redact_head(String.new(head).scrub, include_sensitive).to_slice
+      end
+    end
+  end
+end

--- a/src/gori/mcp/tools/context.cr
+++ b/src/gori/mcp/tools/context.cr
@@ -9,13 +9,18 @@ module Gori
     class Tools
       private def list_scope : Result
         Result.new(JSON.build do |j|
-          j.array do
-            store.scope_rules.each do |(id, kind, match_type, pattern)|
-              j.object do
-                j.field "id", id
-                j.field "kind", kind
-                j.field "match_type", match_type
-                j.field "pattern", pattern
+          j.object do
+            j.field "enabled", Scope.load(store).enabled?
+            j.field "rules" do
+              j.array do
+                store.scope_rules.each do |(id, kind, match_type, pattern)|
+                  j.object do
+                    j.field "id", id
+                    j.field "kind", kind
+                    j.field "match_type", match_type
+                    j.field "pattern", pattern
+                  end
+                end
               end
             end
           end

--- a/src/gori/mcp/tools/env.cr
+++ b/src/gori/mcp/tools/env.cr
@@ -1,0 +1,54 @@
+require "json"
+require "../../store"
+require "../../env"
+
+module Gori
+  module MCP
+    class Tools
+      # Values are REDACTED by default (mirrors the sensitive-header policy elsewhere
+      # in this file) — a project env var is exactly the kind of place a
+      # credential/token lives (see `gori run project env`'s own `TOKEN=secret`
+      # example), and this response can flow through a hosted LLM. Pass
+      # include_sensitive:true to see the actual values.
+      private def list_env(h) : Result
+        include_sensitive = bool_arg(h, "include_sensitive", false)
+        Result.new(JSON.build do |j|
+          j.array do
+            Settings.project_env_vars.each do |(key, val)|
+              j.object do
+                j.field "key", key
+                j.field "value", include_sensitive ? val : "[REDACTED]"
+              end
+            end
+          end
+        end)
+      end
+
+      private def set_env_var(h) : Result
+        key = str(h, "key").try(&.strip)
+        return err("missing required 'key'", "INVALID_ARGUMENT", field: "key") if key.nil? || key.empty?
+        return err("invalid 'key' (use [A-Za-z_][A-Za-z0-9_]*)", "INVALID_ARGUMENT", field: "key") unless Env.valid_key?(key)
+        value = str(h, "value") || ""
+        vars = Settings.project_env_vars.dup
+        if idx = vars.index { |(k, _)| k == key }
+          vars[idx] = {key, value}
+        else
+          vars << {key, value}
+        end
+        Env.save_project(store, vars)
+        Result.new(JSON.build { |j| j.object { j.field "key", key; j.field "set", true } })
+      end
+
+      private def delete_env_var(h) : Result
+        key = str(h, "key").try(&.strip)
+        return err("missing required 'key'", "INVALID_ARGUMENT", field: "key") if key.nil? || key.empty?
+        vars = Settings.project_env_vars.dup
+        before = vars.size
+        vars.reject! { |(k, _)| k == key }
+        return not_found("no env var named '#{key}'") if vars.size == before
+        Env.save_project(store, vars)
+        Result.new(JSON.build { |j| j.object { j.field "key", key; j.field "deleted", true } })
+      end
+    end
+  end
+end

--- a/src/gori/mcp/tools/host_overrides.cr
+++ b/src/gori/mcp/tools/host_overrides.cr
@@ -1,0 +1,67 @@
+require "json"
+require "../../store"
+require "../../host_overrides"
+
+module Gori
+  module MCP
+    class Tools
+      private def list_host_overrides : Result
+        Result.new(JSON.build do |j|
+          j.array do
+            HostOverrides.load(store).entries.each do |e|
+              j.object do
+                j.field "id", e.id
+                j.field "host", e.host
+                j.field "ip", e.ip
+              end
+            end
+          end
+        end)
+      end
+
+      private def add_host_override(h) : Result
+        host = str(h, "host").try(&.strip)
+        return err("missing required 'host'", "INVALID_ARGUMENT", field: "host") if host.nil? || host.empty?
+        ip = str(h, "ip").try(&.strip)
+        return err("missing required 'ip'", "INVALID_ARGUMENT", field: "ip") if ip.nil? || ip.empty?
+        return err("invalid host/ip (host hostname-shaped, ip an IPv4/IPv6 literal)", "INVALID_ARGUMENT") unless HostOverrides.valid?(host, ip)
+        ov = HostOverrides.load(store)
+        unless ov.add(host, ip)
+          return busy("failed to add host override (duplicate host, empty, or invalid)")
+        end
+        entry = ov.entries.find { |e| e.host == host.strip.downcase }
+        Result.new(JSON.build do |j|
+          j.object do
+            j.field "id", entry.try(&.id)
+            j.field "host", host.strip.downcase
+            j.field "ip", ip
+          end
+        end)
+      end
+
+      private def update_host_override(h) : Result
+        id = int(h, "id")
+        return err(id_error(h, "id"), "INVALID_ARGUMENT", field: "id") unless id
+        ov = HostOverrides.load(store)
+        return not_found("no host override with id #{id}") unless ov.entries.any? { |e| e.id == id }
+        host = str(h, "host").try(&.strip)
+        ip = str(h, "ip").try(&.strip)
+        return err("'host' and 'ip' are both required", "INVALID_ARGUMENT") if host.nil? || host.empty? || ip.nil? || ip.empty?
+        return err("invalid host/ip (host hostname-shaped, ip an IPv4/IPv6 literal)", "INVALID_ARGUMENT") unless HostOverrides.valid?(host, ip)
+        unless ov.update(id, host, ip)
+          return busy("failed to update host override (duplicate host, empty, or invalid)")
+        end
+        Result.new(JSON.build { |j| j.object { j.field "id", id; j.field "host", host.strip.downcase; j.field "ip", ip } })
+      end
+
+      private def delete_host_override(h) : Result
+        id = int(h, "id")
+        return err(id_error(h, "id"), "INVALID_ARGUMENT", field: "id") unless id
+        ov = HostOverrides.load(store)
+        return not_found("no host override with id #{id}") unless ov.entries.any? { |e| e.id == id }
+        ov.remove(id)
+        Result.new(JSON.build { |j| j.object { j.field "id", id; j.field "deleted", true } })
+      end
+    end
+  end
+end

--- a/src/gori/mcp/tools/import.cr
+++ b/src/gori/mcp/tools/import.cr
@@ -1,0 +1,38 @@
+require "json"
+require "../../store"
+require "../../import"
+
+module Gori
+  module MCP
+    class Tools
+      # Bulk-import flows into the project's History from a HAR export, a URL list,
+      # or an OpenAPI/Swagger spec — the MCP counterpart of `gori run import`. `path`
+      # is resolved on the MCP SERVER's filesystem (same trust boundary as
+      # send_request/repeater — this process runs locally alongside the agent).
+      private def import_flows(h) : Result
+        kind_s = str(h, "kind").try(&.strip.downcase)
+        unless kind_s.in?("har", "urls", "oas")
+          return err("invalid 'kind' (expected har|urls|oas)", "INVALID_ARGUMENT", field: "kind")
+        end
+        kind = case kind_s
+               when "har"  then :har
+               when "urls" then :urls
+               else             :oas
+               end
+        path = str(h, "path").try(&.strip)
+        return err("missing required 'path'", "INVALID_ARGUMENT", field: "path") if path.nil? || path.empty?
+        result = Import.import_file(store, kind, path)
+        Result.new(JSON.build do |j|
+          j.object do
+            j.field "kind", kind_s
+            j.field "path", path
+            j.field "count", result.count
+            j.field "skipped", result.skipped
+          end
+        end)
+      rescue ex : Gori::Error
+        err(ex.message || "import failed", "INVALID_ARGUMENT")
+      end
+    end
+  end
+end

--- a/src/gori/mcp/tools/scope.cr
+++ b/src/gori/mcp/tools/scope.cr
@@ -1,0 +1,54 @@
+require "json"
+require "../../store"
+require "../../scope"
+
+module Gori
+  module MCP
+    class Tools
+      # Add a scope rule (validates + dedupes, like `gori run project scope add`).
+      private def add_scope_rule(h) : Result
+        kind = str(h, "kind").try(&.strip.downcase) || "include"
+        return err("invalid 'kind' (expected include|exclude)", "INVALID_ARGUMENT", field: "kind") unless kind.in?(Scope::KINDS)
+        match_type = str(h, "match_type").try(&.strip.downcase) || "host"
+        return err("invalid 'match_type' (expected host|string|regex)", "INVALID_ARGUMENT", field: "match_type") unless match_type.in?(Scope::TYPES)
+        pattern = str(h, "pattern").try(&.strip)
+        return err("missing required 'pattern'", "INVALID_ARGUMENT", field: "pattern") if pattern.nil? || pattern.empty?
+        if e = Scope.validation_error(match_type, pattern)
+          return err(e, "INVALID_ARGUMENT", field: "pattern")
+        end
+        scope = Scope.load(store)
+        unless scope.add(kind, match_type, pattern)
+          return busy("failed to add scope rule (duplicate, empty, or invalid)")
+        end
+        # Scope#add reloads @rules from the store before returning, so this lookup
+        # already sees the freshly assigned id.
+        rule = scope.rules.find { |r| r.kind == kind && r.match_type == match_type && r.pattern == pattern }
+        Result.new(JSON.build do |j|
+          j.object do
+            j.field "id", rule.try(&.id)
+            j.field "kind", kind
+            j.field "match_type", match_type
+            j.field "pattern", pattern
+          end
+        end)
+      end
+
+      private def delete_scope_rule(h) : Result
+        id = int(h, "id")
+        return err(id_error(h, "id"), "INVALID_ARGUMENT", field: "id") unless id
+        scope = Scope.load(store)
+        return not_found("no scope rule with id #{id}") unless scope.rules.any? { |r| r.id == id }
+        scope.remove(id)
+        Result.new(JSON.build { |j| j.object { j.field "id", id; j.field "deleted", true } })
+      end
+
+      private def set_scope_enabled(h) : Result
+        enabled = bool(h, "enabled")
+        return err("missing required 'enabled' (true or false)", "INVALID_ARGUMENT", field: "enabled") if enabled.nil?
+        scope = Scope.load(store)
+        enabled ? scope.enable : scope.disable
+        Result.new(JSON.build { |j| j.object { j.field "enabled", enabled } })
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

An audit of `gori run` vs `gori mcp` against the TUI feature set found several one-sided gaps. This closes them so a script gets the same capability whether it drives gori through the CLI or MCP.

- **Comparer was missing from BOTH** — `gori run compare <a> <b> [--pane=request|response] [--changes-only]` and MCP `compare_flows` line-diff two flows' request/response, reusing the same `Repeater::MessageLines`/`Repeater::Diff` engine as the TUI Comparer tab.
- **`gori run intercept`** (list/get/forward/drop/edit/enable/disable/filter/direction) brings MCP's live-intercept round-trip to the CLI, mirroring `mcp/tools/intercept.cr`'s bridge/command-queue mechanism byte-for-byte.
- **`gori run repeater send`** now performs a real RFC 6455 WebSocket framed exchange (`--message`/`--idle-ms`) instead of aborting and pointing at MCP `send_websocket`.
- **MCP gained**: scope-rule mutation (`add_scope_rule`/`delete_scope_rule`/`set_scope_enabled`), env var management (`list_env`/`set_env_var`/`delete_env_var`, values redacted by default), host override management (`list_host_overrides`/`add_host_override`/`update_host_override`/`delete_host_override`), and `import_flows` (HAR/URL-list/OpenAPI) — CLI already had all of these via `gori run project scope/env/host-override` and `gori run import`.

The intentional gap (MCP has no `start_capture`/`stop_capture` — it's read+replay only, assumes a capture session is already running) was left alone.

## Fixes from code review

- `gori run intercept edit --raw-file` crashed on a binary body (invalid UTF-8) because the CRLF-normalize step used a UTF-8-only `Regex`; switched to the byte-level normalizer `Env.expand_wire` already uses internally (made public, reused instead of duplicated).
- `compare_flows` didn't redact `Authorization`/`Cookie`/`Set-Cookie`/API-key header values like every other MCP read tool (`get_flow`, `intercept_get`, `get_repeater_context`); added `include_sensitive` (default false, redacted).
- `gori run intercept` printed captured method/host/target/head straight to the terminal without the ANSI/OSC escape neutralization (`CLI::Output.term_safe`/`term_safe_multiline`) every other captured-data CLI view uses.
- `cmd_repeater_send_ws` reloaded `HostOverrides` a second time instead of reusing the value the caller already loaded from the same store open.

## Test plan

- [x] `crystal build src/main.cr` — clean
- [x] `crystal spec` — 3399 examples, 0 failures (was 3374; +25 new specs across `spec/mcp_spec.cr` and `spec/cli_run_spec.cr`)
- [x] `crystal tool format --check` — clean on all touched/new files
- [x] `lib/ameba/bin/ameba.cr` — no new finding categories vs. pre-existing baseline (verified via `git stash` diff on every touched file)
- [x] Live-smoke-tested the built binary: `gori run compare`, `gori run intercept` (list/get/help), `gori run repeater send --help`, and reproduced + confirmed the fix for the `intercept edit --raw-file` binary-body crash