### PR TITLE
fix: dogfooding-surfaced bugs — Repeater bypassed Sandbox, RST left flows stuck Pending

### DIFF
--- a/src/gori/cli/run/repeater.cr
+++ b/src/gori/cli/run/repeater.cr
@@ -174,6 +174,32 @@ module Gori
         end
       end
 
+      # Sandbox gate for `gori run repeater`'s direct sends — mirrors
+      # repeater_controller.cr#sandbox_block_reason (TUI) and `Fuzz::ScopedBackend`
+      # (Fuzzer/Miner): Sandbox mode's "blocks ALL out-of-scope traffic" promise didn't
+      # hold for the CLI repeater path either, since it dials Repeater::Engine/H2Engine/
+      # WsEngine directly. Returns the block reason, or nil when the send may proceed.
+      private def self.sandbox_block_reason(scope : Gori::Scope, scheme : String, host : String, target : String) : String?
+        return nil unless scope.sandbox?
+        return nil unless scope.sandbox_blocks?(Gori::Scope.request_url(scheme, host, target), host)
+        "blocked by sandbox (out of scope)"
+      end
+
+      # `abort`s with a uniform message when the Sandbox gate refuses `target` — a one-line
+      # call at each send site so the branch lives here, not in the (already-complex)
+      # command handlers.
+      private def self.abort_if_sandboxed!(scope : Gori::Scope, scheme : String, host : String, target : String, prefix : String) : Nil
+        return unless reason = sandbox_block_reason(scope, scheme, host, target)
+        abort "#{prefix}: #{reason}"
+      end
+
+      # The request-target (path) from a raw request's first line — mirrors
+      # fuzz/engine.cr#request_target / mcp/tools/send.cr#request_target.
+      private def self.request_target(bytes : Bytes) : String
+        line = String.new(bytes).each_line.first? || ""
+        line.split(' ')[1]? || "/"
+      end
+
       # Resolved send parameters for a saved Repeater SESSION replay — the session
       # counterpart of FlowRequest::Built (which starts from a captured flow).
       record RepeaterSend, bytes : Bytes, scheme : String, host : String,
@@ -229,21 +255,26 @@ module Gori
         # get_repeater_full loads the response BLOBs too (needed for --diff), so the
         # store can close before the send — same lifetime pattern as the flow path.
         store = open_store(resolve_read_project(project_name, db_path))
-        rec, host_overrides = begin
-          {store.get_repeater_full(id), Gori::HostOverrides.load(store)}
+        rec, host_overrides, scope = begin
+          {store.get_repeater_full(id), Gori::HostOverrides.load(store), Gori::Scope.load(store)}
         ensure
           store.close
         end
         abort "gori run repeater send: no repeater session ##{id}" unless rec
 
         if Repeater::WsEngine.upgrade_request?(String.new(rec.request))
-          cmd_repeater_send_ws(id, rec, project_name, db_path, insecure, idle_ms, ws_messages, host_overrides, format)
+          cmd_repeater_send_ws(id, rec, project_name, db_path, insecure, idle_ms, ws_messages, host_overrides, scope, format)
           return
         end
 
         send = build_repeater_send(rec)
         abort "gori run repeater send: could not determine a target host for session ##{id}" if send.host.empty?
         abort "gori run repeater send: unsupported target scheme #{send.scheme.inspect} (use http:// or https://)" unless send.scheme.in?("http", "https")
+
+        # Same Sandbox gate `Fuzz::ScopedBackend` applies to Fuzz/Miner and the TUI Repeater
+        # applies (repeater_controller.cr#sandbox_block_reason) — `gori run repeater send`
+        # dials Repeater::Engine/H2Engine directly too, so it needs the same gate.
+        abort_if_sandboxed!(scope, send.scheme, send.host, request_target(send.bytes), "gori run repeater send")
 
         verify = !insecure
         result = send.http2 ? Repeater::H2Engine.send(send.bytes, scheme: send.scheme, host: send.host, port: send.port, verify_upstream: verify, sni: send.sni, overrides: host_overrides) : Repeater::Engine.send(send.bytes, scheme: send.scheme, host: send.host, port: send.port, verify_upstream: verify, sni: send.sni, overrides: host_overrides)
@@ -265,10 +296,12 @@ module Gori
       private def self.cmd_repeater_send_ws(id : Int64, rec : Store::RepeaterRecord, project_name : String?,
                                             db_path : String?, insecure : Bool, idle_ms : Int64?,
                                             message_override : Array(String), host_overrides : Gori::HostOverrides,
-                                            format : Symbol) : Nil
+                                            scope : Gori::Scope, format : Symbol) : Nil
         target = Env.expand(rec.target)
         scheme, host, port = Repeater::FlowRequest.parse_target(target)
         abort "gori run repeater send: could not determine a target host for session ##{id}" if host.empty?
+
+        abort_if_sandboxed!(scope, scheme, host, request_target(Env.expand_wire(String.new(rec.request)).to_slice), "gori run repeater send")
 
         # host_overrides was already loaded by the caller (cmd_repeater_send) from the
         # same store open that fetched `rec` — reuse it instead of a second table scan.
@@ -419,9 +452,9 @@ module Gori
         store = open_store(resolve_read_project(project_name, db_path))
         # HostOverrides.load snapshots rows into memory (connect_ip never re-touches the
         # store), so it's safe to load here and use after the store closes.
-        detail, session_collision, host_overrides = begin
+        detail, session_collision, host_overrides, scope = begin
           d = store.get_flow(id)
-          {d, d ? !store.get_repeater(id).nil? : false, Gori::HostOverrides.load(store)}
+          {d, d ? !store.get_repeater(id).nil? : false, Gori::HostOverrides.load(store), Gori::Scope.load(store)}
         ensure
           store.close
         end
@@ -567,6 +600,7 @@ module Gori
         scheme, host, port = Repeater::FlowRequest.parse_target(target)
         abort "gori run repeater: could not determine a target host" if host.empty?
         abort "gori run repeater: unsupported target scheme #{scheme.inspect} (use http:// or https://)" unless scheme.in?("http", "https")
+        abort_if_sandboxed!(scope, scheme, host, request_target(bytes), "gori run repeater")
         use_h2 = force_h2 || built.http2
         verify = !insecure
         sni_val = sni_override.presence || built.sni

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -528,7 +528,7 @@ module Gori::Proxy
           @io.write(resp_head) # forward byte-exact (P6/P7); no rewrite on interim
           @io.flush
         end
-        resp_head = Codec::Http1.read_head(upstream)
+        resp_head = safe_read_head(upstream)
         if resp_head.nil?
           @sink.on_response(FlowMapper.error_response(flow_id, "upstream closed after interim 1xx response"))
           release_upstream
@@ -639,16 +639,28 @@ module Gori::Proxy
     # connection after a retry, so callers must rebind their local.
     private def read_response_head(upstream : IO, host : String, port : Int32,
                                    reused : Bool, sent_head : Bytes, can_retry : Bool) : {Bytes?, IO}
-      resp_head = Codec::Http1.read_head(upstream)
+      resp_head = safe_read_head(upstream)
       if resp_head.nil? && reused && can_retry
         release_upstream
         fresh, _ = acquire_upstream(host, port)
         if fresh
           upstream = fresh
-          resp_head = Codec::Http1.read_head(fresh) if write_request(fresh, sent_head, nil)
+          resp_head = safe_read_head(fresh) if write_request(fresh, sent_head, nil)
         end
       end
       {resp_head, upstream}
+    end
+
+    # `Codec::Http1.read_head` returns nil on a graceful EOF, but a RESET upstream
+    # (RST, not FIN — e.g. a dead/killed backend) raises instead. Left uncaught, that
+    # unwinds past the already-recorded Pending flow to `run`'s blanket rescue, which
+    # closes the connection without ever marking the flow — it sits in History as
+    # "waiting for response…" forever. Treat a reset the same as a graceful EOF (nil)
+    # so the caller's existing "no response from upstream" handling covers it too.
+    private def safe_read_head(io : IO) : Bytes?
+      Codec::Http1.read_head(io)
+    rescue
+      nil
     end
 
     # Apply response-head Match&Replace; returns the (possibly rewritten) head +

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -1202,6 +1202,11 @@ module Gori::Tui
       http2 = view.http2?
       sni = view.sni_override # custom TLS SNI host (nil → present the dialed host)
       results = @repeater_results
+      if reason = sandbox_block_reason(scheme, host, request_target(bytes))
+        results.send({view, Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, reason)})
+        @host.status("repeater: #{reason}")
+        return
+      end
       view.inflight = true
       @host.status("sending → #{host}:#{port}#{sni ? " (SNI #{sni})" : ""}…")
       # Off the UI fiber: a round-trip can block up to 30s. The fiber touches only these
@@ -1262,10 +1267,12 @@ module Gori::Tui
         raw = Env.expand_wire(t)
         auto_cl ? Repeater::FlowRequest.resync_content_length(raw) : raw
       end
-      backend = Fuzz::CappedBackend.new(
-        Fuzz::Sender.new(Fuzz::Origin.new(scheme, host, port), view.http2?,
-          !@host.session.config.insecure_upstream?, view.sni_override, timeout: 10.seconds),
-        MINIMIZE_SEND_CAP)
+      backend = Fuzz::ScopedBackend.new(
+        Fuzz::CappedBackend.new(
+          Fuzz::Sender.new(Fuzz::Origin.new(scheme, host, port), view.http2?,
+            !@host.session.config.insecure_upstream?, view.sni_override, timeout: 10.seconds),
+          MINIMIZE_SEND_CAP),
+        @host.session.scope)
       job = @host.jobs.start(:minimize, view.summary, goto: Jobs::Goto.new(:repeater, tab.db_id))
       @minimize_job = {view, job, text} # `text` is the snapshot the run minimizes; see apply_minimize_report
       events = @minimize_events
@@ -1290,9 +1297,14 @@ module Gori::Tui
     private def ws_repeater_send(view : RepeaterView, scheme : String, host : String, port : Int32) : Nil
       verify = !@host.session.config.insecure_upstream?
       upgrade = view.ws_upgrade_bytes
+      results = @ws_results
+      if reason = sandbox_block_reason(scheme, host, request_target(upgrade))
+        results.send({view, Repeater::WsEngine::Result.new(Bytes.new(0), [] of Repeater::WsEngine::Message, 0_i64, reason)})
+        @host.status("ws repeater: #{reason}")
+        return
+      end
       messages = view.ws_out_messages
       sni = view.sni_override
-      results = @ws_results
       view.inflight = true
       @host.status("ws sending → #{host}:#{port} (#{messages.size} msg#{messages.size == 1 ? "" : "s"})…")
       spawn(name: "gori-ws-repeater") do
@@ -1337,6 +1349,14 @@ module Gori::Tui
       labels = reqs.map(&.[0])
       bytes = reqs.map(&.[1])
       results = @group_results
+      # Block the WHOLE pipeline if ANY request in it targets out of scope — these all ride
+      # one connection, so partially sending would still reach the blocked path's origin.
+      if reason = bytes.compact_map { |b| sandbox_block_reason(scheme, host, request_target(b)) }.first?
+        labeled = labels.map { |l| {l, Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, reason)} }
+        results.send({view, labeled})
+        @host.status("send group: #{reason}")
+        return
+      end
       view.inflight = true
       @host.status("send group → #{host}:#{port} · #{bytes.size} request#{bytes.size == 1 ? "" : "s"} on one connection…")
       spawn(name: "gori-repeater-group") do
@@ -1367,6 +1387,29 @@ module Gori::Tui
     private def current_repeater_tab : RepeaterTab?
       return nil if @current_repeater_idx < 0 || @current_repeater_idx >= @repeaters.size
       @repeaters[@current_repeater_idx]
+    end
+
+    # Sandbox gate for Repeater's direct sends (^R, send-group, WS, minimize) — unlike ordinary
+    # proxied traffic, these dial Repeater::Engine/H2Engine/WsEngine straight from the TUI,
+    # bypassing ClientConn's per-request gate entirely. Without this, Sandbox mode's "blocks ALL
+    # out-of-scope traffic" promise (project_view.cr) didn't hold for Repeater — the same gap
+    # `Fuzz::ScopedBackend` was added to close for Fuzzer/Miner (fuzz/engine.cr). Mirrors
+    # `Interceptor#sandbox_blocks?` (client_conn.cr): Sandbox alone blocks a single deliberate
+    # send — EXCLUDE doesn't (that's only layered on top for Fuzz/Miner's bigger blast radius).
+    # Returns the block reason, or nil when the send may proceed.
+    private def sandbox_block_reason(scheme : String, host : String, target : String) : String?
+      scope = @host.session.scope
+      return nil unless scope.sandbox?
+      return nil unless scope.sandbox_blocks?(Scope.request_url(scheme, host, target), host)
+      "blocked by sandbox (out of scope)"
+    end
+
+    # The request-target (path) from a raw request's first line — mirrors
+    # fuzz/engine.cr#request_target / mcp/tools/send.cr#request_target (the scope URL
+    # `scheme://host/target` these callers build to match Scope rules against).
+    private def request_target(bytes : Bytes) : String
+      line = String.new(bytes).each_line.first? || ""
+      line.split(' ')[1]? || "/"
     end
 
     # Persist the current repeater tab's edits (cheap no-op when clean). Sprinkled on


### PR DESCRIPTION
## Summary
- Repeater (TUI `^R`/send-group/WS/Minimize, and `gori run repeater`) dialed the network directly with no Scope awareness, so Sandbox mode's "blocks ALL out-of-scope traffic" promise didn't hold for it — the same gap #322 closed for Fuzzer/Miner, extended here to Repeater's 6 direct-send call sites (TUI + CLI). MCP's `send_request`/`send_websocket` already had their own stricter gate and needed no change.
- An upstream RST (not a graceful FIN) while reading the response head raised past the already-recorded Pending flow to `ClientConn#run`'s blanket rescue, leaving the flow stuck in History as "waiting for response…" forever instead of surfacing an error. Both `read_response_head` and the interim-1xx read now go through a `safe_read_head` that treats a reset the same as a graceful EOF.

Both found by dogfooding the TUI live.

## Test plan
- [x] Full `crystal spec` suite green (3399 examples, 0 failures)
- [x] `ameba`/`crystal tool format` clean on touched files (0 new findings vs baseline)
- [x] Live tmux TUI verification: RST'd flow shows `ERR` / "upstream error: no response from upstream" instead of hanging forever
- [x] Live tmux TUI verification: with Sandbox on, an out-of-scope Repeater `^R` send is refused (0ms, no network call); an in-scope send still works
- [x] Live CLI verification: `gori run repeater <flow-id>` and `gori run repeater send <session-id>` both honor the same Sandbox gate