### PR TITLE
refactor(tui): extract a polymorphic Overlay seam; migrate scope_rule, sequence_config, mine_config

### DIFF
--- a/spec/tui/overlay_dispatch_spec.cr
+++ b/spec/tui/overlay_dispatch_spec.cr
@@ -1,0 +1,334 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# The polymorphic Overlay seam (src/gori/tui/overlay.cr) is what let the Runner collapse
+# a modal's ~13 scattered `case @overlay` ladder entries into one @active_overlay dispatch.
+# The Runner itself can't be unit-tested without a terminal, so these specs lock the
+# CONTRACT the Runner's generic dispatch relies on:
+#   - handle_key / handle_click return the :stay | :commit | :cancel vocabulary
+#   - commit runs the injected on_commit closure and honours its Bool (false keeps it open)
+#   - title / hint / key supply the chrome the collapsed ladders used to hard-code
+# If this contract holds, migrating the next overlay onto the seam is a local change.
+
+private def skey(k : Termisu::Input::Key, char : Char? = nil) : Termisu::Event::Key
+  Termisu::Event::Key.new(k, char: char)
+end
+
+# Mirrors Runner#dispatch_overlay_key exactly: returns :closed when the shell would drop
+# the overlay, :open when it stays. This is the seam the Runner drives.
+private def dispatch_key(ov : Overlay, ev : Termisu::Event::Key) : Symbol
+  case ov.handle_key(ev)
+  when :cancel then :closed
+  when :commit then ov.commit ? :closed : :open
+  else              :open
+  end
+end
+
+# Mirrors Runner#dispatch_overlay_click.
+private def dispatch_click(ov : Overlay, area : Rect, mx : Int32, my : Int32) : Symbol
+  case ov.handle_click(area, mx, my)
+  when :cancel then :closed
+  when :commit then ov.commit ? :closed : :open
+  else              :open
+  end
+end
+
+# A minimal Overlay to pin the base-class defaults the Runner leans on.
+private class FakeOverlay < Overlay
+  getter renders = 0
+
+  def key : Symbol
+    :fake
+  end
+
+  def title : String
+    "FAKE"
+  end
+
+  def hint : String
+    "fake hint"
+  end
+
+  def render(screen : Screen, area : Rect) : Nil
+    @renders += 1
+  end
+
+  def handle_key(ev : Termisu::Event::Key) : Symbol
+    :stay
+  end
+end
+
+describe "Overlay seam — base contract" do
+  it "defaults: no box, click dismisses, wheel/preedit are no-ops, commit closes" do
+    ov = FakeOverlay.new
+    area = Rect.new(0, 0, 80, 24)
+
+    ov.overlay_box(area).should be_nil
+    # No box → a click can't be inside → the shell dismisses (prior close-on-click-away).
+    ov.handle_click(area, 10, 10).should eq(:cancel)
+    # No-op hooks must not raise (the Runner calls them unconditionally).
+    ov.handle_wheel(3)
+    ov.set_preedit("한")
+    # No on_commit supplied → commit is a no-op that closes.
+    ov.commit.should be_true
+  end
+
+  it "commit runs the injected closure and honours its Bool" do
+    ov = FakeOverlay.new
+    calls = 0
+    ov.on_commit = -> {
+      calls += 1
+      false # e.g. validation failed → keep the form up
+    }
+    ov.commit.should be_false
+    calls.should eq(1)
+
+    ov.on_commit = -> { true }
+    ov.commit.should be_true
+  end
+end
+
+describe "Overlay seam — ScopeRuleOverlay (first migrated modal)" do
+  it "exposes the chrome the collapsed ladders used to hard-code" do
+    ov = ScopeRuleOverlay.adding.as(Overlay)
+    ov.key.should eq(:scope_rule)
+    ov.title.should eq("SCOPE RULE")
+    ov.hint.should_not be_empty
+  end
+
+  it "drives open → key → commit → apply(on_commit) → close through the generic dispatch" do
+    committed = [] of {String, String, String}
+    ov = ScopeRuleOverlay.new(kind: "include", match_type: "host")
+    ov.on_commit = -> {
+      committed << {ov.kind, ov.match_type, ov.pattern}
+      true
+    }
+    over = ov.as(Overlay)
+
+    # ↓ ↓ to the pattern row, type a value, ↵ commits.
+    dispatch_key(over, skey(Termisu::Input::Key::Down)).should eq(:open)
+    dispatch_key(over, skey(Termisu::Input::Key::Down)).should eq(:open)
+    "acme.test".each_char { |c| dispatch_key(over, skey(Termisu::Input::Key::LowerA, c)) }
+    dispatch_key(over, skey(Termisu::Input::Key::Enter)).should eq(:closed)
+
+    committed.should eq([{"include", "host", "acme.test"}])
+  end
+
+  it "keeps the form open when on_commit reports failure (invalid pattern)" do
+    ov = ScopeRuleOverlay.new(kind: "include", match_type: "host")
+    ov.on_commit = -> { false } # apply rejected it
+    over = ov.as(Overlay)
+
+    ov.set_selected(3) # Save row
+    dispatch_key(over, skey(Termisu::Input::Key::Enter)).should eq(:open)
+  end
+
+  it "esc cancels without committing" do
+    committed = 0
+    ov = ScopeRuleOverlay.adding
+    ov.on_commit = -> {
+      committed += 1
+      true
+    }
+    dispatch_key(ov.as(Overlay), skey(Termisu::Input::Key::Escape)).should eq(:closed)
+    committed.should eq(0)
+  end
+
+  it "click on the Save row commits; a click outside the card dismisses" do
+    committed = 0
+    ov = ScopeRuleOverlay.new(kind: "include", match_type: "host", pattern: "acme.test")
+    ov.on_commit = -> {
+      committed += 1
+      true
+    }
+    over = ov.as(Overlay)
+    area = Rect.new(0, 0, 80, 24)
+    box = ov.overlay_box(area).not_nil!
+
+    # Save is row index 3 (kind/type/pattern/save); its screen row is box.y + 2 + 3.
+    dispatch_click(over, area, box.x + 3, box.y + 5).should eq(:closed)
+    committed.should eq(1)
+
+    # A click well outside the centered card is a dismiss (no commit).
+    ov2 = ScopeRuleOverlay.adding.as(Overlay)
+    dispatch_click(ov2, area, 0, 0).should eq(:closed)
+  end
+
+  it "wheel over the modal moves the selected field (delegates to move)" do
+    ov = ScopeRuleOverlay.adding
+    ov.on_save_row?.should be_false
+    ov.as(Overlay).handle_wheel(3) # 3 notches down: kind → type → pattern → save
+    ov.on_save_row?.should be_true
+  end
+end
+
+# The HARD case the seam had to prove: a modal opened from TWO sites with different apply
+# semantics (new-session vs reconfigure-current), which previously needed a shell-side
+# @sequence_reconfigure flag. Under the seam that flag is gone — each open-site injects its
+# own on_commit closure and the overlay only ever reports :commit. These specs lock that
+# the closure injection carries the site-specific behaviour and the valid? gate.
+private def seed(loc : Gori::Sequencer::TokenLoc? = Gori::Sequencer::TokenLoc.new(Gori::Sequencer::ExtractKind::Cookie, "session")) : SequenceSeed
+  SequenceSeed.new(
+    target: "https://acme.test/",
+    request: "GET / HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice,
+    http2: false,
+    sni: nil,
+    flow_id: nil,
+    summary: "GET /",
+    mode: Gori::Sequencer::Mode::LiveReplay,
+    suggested_loc: loc,
+    candidate_cookies: ["session"],
+    candidate_headers: [] of String,
+  )
+end
+
+describe "Overlay seam — SequenceConfigOverlay (hard case: 2 open-sites, no flag)" do
+  it "exposes chrome + a self-contained handle_key (formerly Runner#handle_sequence_config_key)" do
+    ov = SequenceConfigOverlay.new(seed).as(Overlay)
+    ov.key.should eq(:sequence_config)
+    ov.title.should eq("SEQUENCER")
+    ov.hint.should_not be_empty
+    # esc cancels; ↓ moves; the Start row commits — all owned by the overlay now.
+    ov.handle_key(skey(Termisu::Input::Key::Escape)).should eq(:cancel)
+  end
+
+  it "routes the SAME :commit to different apply behaviour purely via the injected closure" do
+    # Two independent open-sites, distinguished only by their closure — the exact thing the
+    # deleted @sequence_reconfigure flag used to do.
+    log = [] of String
+
+    new_ov = SequenceConfigOverlay.new(seed)
+    new_ov.on_commit = -> {
+      log << "start_session"
+      true
+    }
+    reconf_ov = SequenceConfigOverlay.new(seed)
+    reconf_ov.on_commit = -> {
+      log << "reconfigure_current"
+      true
+    }
+
+    # Drive each to Start (row 5) and commit through the generic shell dispatch.
+    [new_ov, reconf_ov].each do |ov|
+      over = ov.as(Overlay)
+      4.times { dispatch_key(over, skey(Termisu::Input::Key::Down)) } # selector → … → Start
+      ov.on_start_row?.should be_true
+      dispatch_key(over, skey(Termisu::Input::Key::Enter)).should eq(:closed)
+    end
+
+    log.should eq(["start_session", "reconfigure_current"])
+  end
+
+  it "keeps the form open when the token location is unset (valid? gate in commit)" do
+    ov = SequenceConfigOverlay.new(seed(loc: nil)) # nothing pre-filled → invalid
+    ov.valid?.should be_false
+    # Real open-site gate: reject + keep open, mirroring Runner#commit_sequence.
+    ov.on_commit = -> { ov.valid? }
+    over = ov.as(Overlay)
+    ov.set_selected(5) # Start row
+    dispatch_key(over, skey(Termisu::Input::Key::Enter)).should eq(:open)
+  end
+
+  it "click on Start commits; a click outside dismisses" do
+    committed = 0
+    ov = SequenceConfigOverlay.new(seed)
+    ov.on_commit = -> {
+      committed += 1
+      true
+    }
+    over = ov.as(Overlay)
+    area = Rect.new(0, 0, 80, 24)
+    box = ov.overlay_box(area).not_nil!
+    # Start is row index 5; its screen row is box.y + 3 + 5.
+    dispatch_click(over, area, box.x + 3, box.y + 8).should eq(:closed)
+    committed.should eq(1)
+
+    dispatch_click(SequenceConfigOverlay.new(seed).as(Overlay), area, 0, 0).should eq(:closed)
+  end
+
+  it "routes IME preedit to the selector field (the seam's per-modal-IME promise)" do
+    ov = SequenceConfigOverlay.new(seed(loc: nil)) # blank selector, opens on that row
+    ov.editing_selector?.should be_true
+    # ASCII preedit so the assertion isn't defeated by the width-2 continuation cell a CJK
+    # glyph leaves between codepoints in MemoryBackend#row; routing is content-agnostic.
+    ov.as(Overlay).set_preedit("preedithere")
+    mb = MemoryBackend.new(80, 24)
+    ov.render(Screen.new(mb), Rect.new(0, 0, 80, 24))
+    mb.contains?("preedithere").should be_true
+  end
+end
+
+private def mseed(applicable = [Gori::Miner::Location::Query, Gori::Miner::Location::Json],
+                  default = [Gori::Miner::Location::Query]) : MineSeed
+  MineSeed.new(
+    target: "https://acme.test/",
+    request: "GET /?q=1 HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice,
+    http2: false,
+    sni: nil,
+    flow_id: nil,
+    summary: "GET /",
+    applicable: applicable,
+    default: default,
+  )
+end
+
+describe "Overlay seam — MineConfigOverlay (laggard: keys were shell-owned; click toggles rows)" do
+  it "exposes chrome + a self-contained handle_key (formerly Runner#handle_mine_config_key)" do
+    ov = MineConfigOverlay.new(mseed).as(Overlay)
+    ov.key.should eq(:mine_config)
+    ov.title.should eq("MINE PARAMS")
+    ov.hint.should_not be_empty
+    ov.handle_key(skey(Termisu::Input::Key::Escape)).should eq(:cancel)
+  end
+
+  it "commits from the Start row through the generic dispatch" do
+    ran = 0
+    ov = MineConfigOverlay.new(mseed)
+    ov.on_commit = -> {
+      ran += 1
+      true
+    }
+    over = ov.as(Overlay)
+    # rows: [Query, Json, concurrency, notify, Start] → 4 downs to Start.
+    4.times { dispatch_key(over, skey(Termisu::Input::Key::Down)) }
+    ov.on_start_row?.should be_true
+    dispatch_key(over, skey(Termisu::Input::Key::Enter)).should eq(:closed)
+    ran.should eq(1)
+  end
+
+  it "keeps the form open when the commit closure rejects (no location selected)" do
+    ov = MineConfigOverlay.new(mseed)
+    ov.on_commit = -> { false } # e.g. any_checked? was false
+    ov.set_selected(4)          # Start row
+    dispatch_key(ov.as(Overlay), skey(Termisu::Input::Key::Enter)).should eq(:open)
+  end
+
+  it "click on a location row TOGGLES its checkbox (behaviour preserved from click_mine_config)" do
+    ov = MineConfigOverlay.new(mseed)
+    area = Rect.new(0, 0, 80, 24)
+    box = ov.overlay_box(area).not_nil!
+    before = ov.build_config.locations.includes?(Gori::Miner::Location::Query)
+    # Row 0 (Query) is at box.y + 3; a click there selects AND toggles it.
+    ov.as(Overlay).handle_click(area, box.x + 3, box.y + 3).should eq(:stay)
+    ov.build_config.locations.includes?(Gori::Miner::Location::Query).should_not eq(before)
+  end
+
+  it "click on Start commits; a click outside dismisses" do
+    ran = 0
+    ov = MineConfigOverlay.new(mseed)
+    ov.on_commit = -> {
+      ran += 1
+      true
+    }
+    over = ov.as(Overlay)
+    area = Rect.new(0, 0, 80, 24)
+    box = ov.overlay_box(area).not_nil!
+    # Start is row index 4; its screen row is box.y + 3 + 4.
+    dispatch_click(over, area, box.x + 3, box.y + 7).should eq(:closed)
+    ran.should eq(1)
+
+    dispatch_click(MineConfigOverlay.new(mseed).as(Overlay), area, 0, 0).should eq(:closed)
+  end
+end

--- a/src/gori/tui/mine_config_overlay.cr
+++ b/src/gori/tui/mine_config_overlay.cr
@@ -1,6 +1,7 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./overlay"
 require "../miner"
 require "../settings"
 
@@ -21,8 +22,9 @@ module Gori::Tui
   # The small config popup shown before a mine starts: adaptive location checkboxes,
   # concurrency + notification cyclers, and a Start row. No text field (so no IME
   # plumbing). Restores the last confirmed overlay choices from Settings when present.
-  # On Start the Runner reads build_config + seed and hands them to the MinerController.
-  class MineConfigOverlay
+  # On Start the injected commit closure reads build_config + seed and hands them to the
+  # MinerController. Migrated onto the polymorphic Overlay seam (see overlay.cr).
+  class MineConfigOverlay < Overlay
     CONC_CHOICES   = [5, 10, 20, 40]
     NOTIFY_CHOICES = Miner::NotifyMode.values
 
@@ -77,6 +79,53 @@ module Gori::Tui
 
     def on_start_row? : Bool
       @selected == start_row
+    end
+
+    # --- Overlay contract (see overlay.cr) ---
+    def key : Symbol
+      :mine_config
+    end
+
+    def title : String
+      "MINE PARAMS"
+    end
+
+    def hint : String
+      "↑/↓ field · ←/→ adjust · ␣ toggle · ↵ start · esc cancel"
+    end
+
+    # Own key handling (formerly Runner#handle_mine_config_key): ↑/↓ move, ←/→ adjust
+    # cyclers, ␣/↵ toggle a checkbox or commit on the Start row, esc cancels.
+    def handle_key(ev : Termisu::Event::Key) : Symbol
+      key = ev.key
+      return :cancel if key.escape?
+      if key.up?
+        move(-1)
+      elsif key.down?
+        move(1)
+      elsif key.left?
+        adjust(-1)
+      elsif key.right?
+        adjust(1)
+      elsif key.enter? || key.space?
+        return :commit if on_start_row?
+        toggle
+      end
+      :stay
+    end
+
+    # Click a row to select it; a click on Start commits; a click on any other row toggles
+    # it (checkbox flip / cycler advance); a click outside the card cancels. Mirrors the
+    # prior Runner#click_mine_config exactly.
+    def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      box = overlay_box(area)
+      return :cancel if box.nil? || !box.contains?(mx, my)
+      if idx = row_at(box, mx, my)
+        set_selected(idx)
+        return :commit if on_start_row?
+        toggle
+      end
+      :stay
     end
 
     def move(d : Int32) : Nil

--- a/src/gori/tui/overlay.cr
+++ b/src/gori/tui/overlay.cr
@@ -1,0 +1,88 @@
+require "termisu"
+require "./screen"
+require "./geometry"
+
+module Gori::Tui
+  # A centered modal overlay the shell floats above the tab body. The Runner owns ONE
+  # active overlay (`@active_overlay`) and dispatches to it polymorphically — the same
+  # move TabController made for tab bodies, now extended to modals.
+  #
+  # Before this seam, every modal scattered ~13 `case @overlay` entries through the
+  # Runner (key / click / wheel / preedit / render / title / hint routing + open/close/
+  # commit glue). That central fan-out was the merge-conflict surface: touching any one
+  # modal meant editing a dozen shared methods 5,000 lines apart. An `Overlay` collapses
+  # all of that into the hooks below, so ADDING or editing a modal touches only its own
+  # file plus one open-site — never the Runner's central dispatch. Two overlays never
+  # share an edit surface in runner.cr. That is the parallel-work win.
+  #
+  # Concrete overlays stay dumb form objects (their own field/caret state). Behaviour
+  # that couples to a domain controller is injected as the `on_commit` closure at the
+  # open-site — mirroring ConfirmDialog's action proc. A modal opened from two sites with
+  # different apply semantics (e.g. Sequencer new-vs-reconfigure) therefore needs no
+  # shell-side flag: each site supplies its own closure.
+  #
+  # Outcome vocabulary (returned by handle_key / handle_click), the contract the Runner's
+  # generic dispatch switches on:
+  #   :stay   → stay open, redraw
+  #   :commit → run `commit`; the shell closes the overlay iff `commit` returns true
+  #   :cancel → close without committing
+  abstract class Overlay
+    # Runs on a :commit outcome; returns true when the overlay should close (false keeps
+    # it open — e.g. a validation error keeps the form up). Supplied at the open-site.
+    property on_commit : Proc(Bool)?
+
+    # The `@overlay` state symbol this modal sets. Kept in sync by the Runner so
+    # `modal_overlay?` and any residual `@overlay ==` checks keep working while the other
+    # overlays migrate onto this base one at a time.
+    abstract def key : Symbol
+
+    # Shell chrome: the focus-badge title (top bar) and the bottom-row key hint. These
+    # used to be `case @overlay` entries in the Runner; they now live with the overlay so
+    # the ladders don't grow per modal.
+    abstract def title : String
+    abstract def hint : String
+
+    # Draw the modal card within `area` (the body rect).
+    abstract def render(screen : Screen, area : Rect) : Nil
+
+    # Handle one key. Return an outcome from the vocabulary above.
+    abstract def handle_key(ev : Termisu::Event::Key) : Symbol
+
+    # Handle a left-click at (mx, my) within `area`. Same outcome vocabulary. The default
+    # implements the shared "click-away (outside the modal box) cancels, anything inside
+    # stays" behaviour; overlays with clickable rows override to also commit on a hit.
+    def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      box = overlay_box(area)
+      (box.nil? || !box.contains?(mx, my)) ? :cancel : :stay
+    end
+
+    # The modal's box within `area` — the click-away hit-test. `nil` means the card has
+    # no room to draw; the default handle_click then treats any click as a dismiss (the
+    # prior shell behaviour: `close if box.nil? || click-outside`). Overlays that center a
+    # card override this (most already do, for render).
+    def overlay_box(area : Rect) : Rect?
+      nil
+    end
+
+    # Move the selected field by a signed step (↑/↓ and the scroll wheel share this).
+    # Default no-op; form overlays override it. Button-only modals leave it inert.
+    def move(step : Int32) : Nil
+    end
+
+    # A scroll-wheel notch over the modal (already ±3-scaled). Defaults to a field move, so
+    # form overlays get wheel scrolling for free by overriding `move`.
+    def handle_wheel(step : Int32) : Nil
+      move(step)
+    end
+
+    # Live IME composition text for the focused field. Default: no-op.
+    def set_preedit(text : String) : Nil
+    end
+
+    # Run the injected commit closure. Returns true when the shell should close the
+    # overlay (default true when no closure was supplied).
+    def commit : Bool
+      (c = on_commit) ? c.call : true
+    end
+  end
+end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -65,6 +65,7 @@ require "./fuzz_advanced_overlay"
 require "./discover_config_overlay"
 require "./discover_headers_overlay"
 require "./probe_active_overlay"
+require "./overlay"
 require "./scope_rule_overlay"
 require "./custom_rule_overlay"
 require "./oast_provider_overlay"
@@ -240,15 +241,12 @@ module Gori::Tui
       # Samples nothing while disabled; see ResourceMeter for the idle-repaint discipline.
       @resource = ResourceMeter.new
       @spinner_frame = 0
-      # The Miner config popup (History/Repeater → space → "Mine parameters"); @overlay is
-      # :mine_config while it's up. Built fresh each time it opens (holds the seed request).
-      @mine_config_overlay = nil.as(MineConfigOverlay?)
+      # The Miner config popup (History/Repeater → space → "Mine parameters") rides the
+      # Overlay seam (@active_overlay); built fresh each open with an injected commit.
       # The Sequencer config popup (History/Repeater/Sitemap → "Send to Sequencer", or `c`
-      # to reconfigure the current session); @overlay is :sequence_config while up.
-      # @sequence_reconfigure distinguishes a reconfigure of the CURRENT session (apply +
-      # re-run) from a new-session flow handoff (create + run).
-      @sequence_config_overlay = nil.as(SequenceConfigOverlay?)
-      @sequence_reconfigure = false
+      # to reconfigure the current session) rides the Overlay seam (@active_overlay). The
+      # new-vs-reconfigure distinction that used to need a @sequence_reconfigure flag now
+      # lives in each open-site's injected commit closure.
       @discover_config_overlay = nil.as(DiscoverConfigOverlay?)
       @discover_headers_overlay = nil.as(DiscoverHeadersOverlay?)
       # :probe_active while the "Run active scan" popup is up (holds the seed flow + estimate).
@@ -258,8 +256,11 @@ module Gori::Tui
       # built fresh from the current fuzz session each time they open.
       @fuzz_set_overlay = nil.as(FuzzSetOverlay?)
       @fuzz_advanced_overlay = nil.as(FuzzAdvancedOverlay?)
-      # Project SCOPE add/edit popup (a/e on the rule list). Built fresh each open.
-      @scope_rule_overlay = nil.as(ScopeRuleOverlay?)
+      # The one active polymorphic modal (see overlay.cr). Overlays migrated onto the
+      # Overlay base flow through here instead of a per-modal typed ivar + `case @overlay`
+      # ladders. nil = no such modal up. (SCOPE add/edit was the first migrated — the
+      # former @scope_rule_overlay ivar now lives here.)
+      @active_overlay = nil.as(Overlay?)
       @custom_rule_overlay = nil.as(CustomRuleOverlay?)
       # Rewriter (Match & Replace) add/edit popup (a/e on the rule list). Built fresh each
       # open; @rewriter_preview_sig gates the live match-preview rescan to real changes.
@@ -929,6 +930,10 @@ module Gori::Tui
       # priority mirrors handle_key: overlays first, then text-entry sub-modes,
       # then the focused tab body — so EVERY text field gets the same live
       # composition preview, not just the Notes/Project/Repeater editors.
+      if ov = active_overlay # a migrated modal routes its own IME text
+        ov.set_preedit(text)
+        return
+      end
       case @overlay
       when :palette          then @palette.set_preedit(text)
       when :issue_new        then @issue_form.set_preedit(text)
@@ -943,7 +948,6 @@ module Gori::Tui
       when :discover_headers then @discover_headers_overlay.try(&.set_preedit(text))
       when :fuzz_set         then @fuzz_set_overlay.try(&.set_preedit(text))
       when :fuzz_advanced    then @fuzz_advanced_overlay.try(&.set_preedit(text))
-      when :scope_rule       then @scope_rule_overlay.try(&.set_preedit(text))
       when :oast_provider    then @oast_provider_overlay.try(&.set_preedit(text))
       when :probe_rule       then @custom_rule_overlay.try(&.set_preedit(text))
       when :rewriter_rule    then @rewriter_rule_overlay.try(&.set_preedit(text))
@@ -1040,14 +1044,16 @@ module Gori::Tui
         return
       end
       return handle_notifications_key(ev) if @overlay == :notifications
-      return handle_mine_config_key(ev) if @overlay == :mine_config
+      # Migrated modals (Overlay base) dispatch generically — no per-modal handle_*_key.
+      if ov = active_overlay
+        dispatch_overlay_key(ov, ev)
+        return
+      end
       return handle_probe_active_key(ev) if @overlay == :probe_active
-      return handle_sequence_config_key(ev) if @overlay == :sequence_config
       return handle_discover_config_key(ev) if @overlay == :discover_config
       return handle_discover_headers_key(ev) if @overlay == :discover_headers
       return handle_fuzz_set_key(ev) if @overlay == :fuzz_set
       return handle_fuzz_advanced_key(ev) if @overlay == :fuzz_advanced
-      return handle_scope_rule_key(ev) if @overlay == :scope_rule
       return handle_oast_provider_key(ev) if @overlay == :oast_provider
       return handle_custom_rule_key(ev) if @overlay == :probe_rule
       return handle_rewriter_rule_key(ev) if @overlay == :rewriter_rule
@@ -1305,9 +1311,10 @@ module Gori::Tui
 
     # The overlays that fully capture input (a centered card); :detail and :none do not.
     private def modal_overlay? : Bool
+      return true if active_overlay # migrated modals capture input via the Overlay seam
       case @overlay
-      when :palette, :issue_new, :confirm, :browser, :choice, :tabs_more, :comparer_pick, :repeater_subtab, :links, :issue_pick, :note_pick, :preferences, :settings, :tabs, :hosts, :env, :hotkeys, :notifications, :mine_config, :sequence_config, :probe_active, :discover_config, :discover_headers, :fuzz_set, :fuzz_advanced, :scope_rule, :oast_provider, :probe_rule, :rewriter_rule, :ca_import, :import then true
-      else                                                                                                                                                                                                                                                                                                                                                                                                             false
+      when :palette, :issue_new, :confirm, :browser, :choice, :tabs_more, :comparer_pick, :repeater_subtab, :links, :issue_pick, :note_pick, :preferences, :settings, :tabs, :hosts, :env, :hotkeys, :notifications, :probe_active, :discover_config, :discover_headers, :fuzz_set, :fuzz_advanced, :oast_provider, :probe_rule, :rewriter_rule, :ca_import, :import then true
+      else                                                                                                                                                                                                                                                                                                                                                                false
       end
     end
 
@@ -1393,6 +1400,10 @@ module Gori::Tui
     # box (or on the [x]); list overlays run/select on a row click.
     private def handle_overlay_click(layout : Layout, mx : Int32, my : Int32) : Nil
       area = layout.body
+      if ov = active_overlay # migrated modals hit-test + dismiss themselves
+        dispatch_overlay_click(ov, area, mx, my)
+        return
+      end
       case @overlay
       when :palette          then click_palette(area, mx, my)
       when :browser          then click_browser(area, mx, my)
@@ -1411,14 +1422,11 @@ module Gori::Tui
       when :env              then (click_env(area, mx, my); settle_sub_editor)
       when :hotkeys          then (click_hotkeys(area, mx, my); settle_sub_editor)
       when :notifications    then click_notifications(area, mx, my)
-      when :mine_config      then click_mine_config(area, mx, my)
       when :probe_active     then click_probe_active(area, mx, my)
-      when :sequence_config  then click_sequence_config(area, mx, my)
       when :discover_config  then click_discover_config(area, mx, my)
       when :discover_headers then click_discover_headers(area, mx, my)
       when :fuzz_set         then click_fuzz_set(area, mx, my)
       when :fuzz_advanced    then click_fuzz_advanced(area, mx, my)
-      when :scope_rule       then click_scope_rule(area, mx, my)
       when :oast_provider    then click_oast_provider(area, mx, my)
       when :probe_rule       then click_custom_rule(area, mx, my)
       when :rewriter_rule    then click_rewriter_rule(area, mx, my)
@@ -1466,17 +1474,6 @@ module Gori::Tui
       end
     end
 
-    private def click_mine_config(area : Rect, mx : Int32, my : Int32) : Nil
-      ov = @mine_config_overlay
-      return unless ov
-      box = ov.overlay_box(area)
-      return close_mine_config if box.nil? || dismiss_zone?(box, mx, my)
-      if idx = ov.row_at(box, mx, my)
-        ov.set_selected(idx)
-        ov.on_start_row? ? start_mining(ov) : ov.toggle
-      end
-    end
-
     private def click_probe_active(area : Rect, mx : Int32, my : Int32) : Nil
       ov = @probe_active_overlay
       return unless ov
@@ -1485,17 +1482,6 @@ module Gori::Tui
       if idx = ov.row_at(box, mx, my)
         ov.set_selected(idx)
         ov.on_run_row? ? start_probe_active(ov) : ov.toggle
-      end
-    end
-
-    private def click_sequence_config(area : Rect, mx : Int32, my : Int32) : Nil
-      ov = @sequence_config_overlay
-      return unless ov
-      box = ov.overlay_box(area)
-      return close_sequence_config if box.nil? || dismiss_zone?(box, mx, my)
-      if idx = ov.row_at(box, mx, my)
-        ov.set_selected(idx)
-        start_sequencing(ov) if ov.on_start_row?
       end
     end
 
@@ -1548,16 +1534,6 @@ module Gori::Tui
       box = ov.overlay_box(area)
       return close_import if box.nil? || dismiss_zone?(box, mx, my) # click-away = cancel
       ov.handle_click(box, mx, my)
-    end
-
-    private def click_scope_rule(area : Rect, mx : Int32, my : Int32) : Nil
-      ov = @scope_rule_overlay || return
-      box = ov.overlay_box(area)
-      return close_scope_rule if box.nil? || dismiss_zone?(box, mx, my) # click-away = cancel
-      if idx = ov.row_at(box, mx, my)
-        ov.set_selected(idx)
-        commit_scope_rule_overlay(ov) if ov.on_save_row?
-      end
     end
 
     private def click_palette(area : Rect, mx : Int32, my : Int32) : Nil
@@ -1693,6 +1669,10 @@ module Gori::Tui
 
     # Wheel inside a centered modal scrolls its list (no movement for the button modals).
     private def wheel_overlay(step : Int32) : Nil
+      if ov = active_overlay # migrated modals scroll themselves
+        ov.handle_wheel(step)
+        return
+      end
       case @overlay
       when :palette         then @palette.move(step)
       when :browser         then @browser_picker.try(&.move(step))
@@ -1710,13 +1690,10 @@ module Gori::Tui
       when :env             then @env_overlay.select_move(step)
       when :hotkeys         then @hotkeys_overlay.select_move(step)
       when :notifications   then @notifications_overlay.select_move(step)
-      when :mine_config     then @mine_config_overlay.try(&.move(step))
       when :probe_active    then @probe_active_overlay.try(&.move(step))
-      when :sequence_config then @sequence_config_overlay.try(&.move(step))
       when :discover_config then @discover_config_overlay.try(&.move(step))
       when :fuzz_set        then @fuzz_set_overlay.try(&.move(step))
       when :fuzz_advanced   then @fuzz_advanced_overlay.try(&.move(step))
-      when :scope_rule      then @scope_rule_overlay.try(&.move(step))
       when :oast_provider   then @oast_provider_overlay.try(&.move(step))
       when :probe_rule      then @custom_rule_overlay.try(&.move(step))
       when :rewriter_rule   then @rewriter_rule_overlay.try(&.move(step))
@@ -1747,25 +1724,6 @@ module Gori::Tui
     end
 
     # Miner config popup: ↑/↓ field · ←/→ adjust · ␣ toggle · ↵ start · esc cancel.
-    private def handle_mine_config_key(ev : Termisu::Event::Key) : Nil
-      ov = @mine_config_overlay
-      return unless ov
-      key = ev.key
-      if key.escape?
-        close_mine_config
-      elsif key.up?
-        ov.move(-1)
-      elsif key.down?
-        ov.move(1)
-      elsif key.left?
-        ov.adjust(-1)
-      elsif key.right?
-        ov.adjust(1)
-      elsif key.enter? || key.space?
-        ov.on_start_row? ? start_mining(ov) : ov.toggle
-      end
-    end
-
     # Run-active-scan popup: ↑/↓ field · ←/→ notify · ↵ run · esc cancel.
     private def handle_probe_active_key(ev : Termisu::Event::Key) : Nil
       ov = @probe_active_overlay
@@ -1789,38 +1747,6 @@ module Gori::Tui
     # Sequencer config popup: ↑/↓ field · type to edit the selector · ←/→ cycle · ↵ start.
     # The selector row is a text field, so printable/caret keys route there first; every
     # other row uses the ←/→ cycler nav.
-    private def handle_sequence_config_key(ev : Termisu::Event::Key) : Nil
-      ov = @sequence_config_overlay
-      return unless ov
-      key = ev.key
-      if key.escape?
-        close_sequence_config
-        return
-      end
-      if key.up?
-        ov.move(-1)
-        return
-      end
-      if key.down?
-        ov.move(1)
-        return
-      end
-      if key.enter?
-        ov.on_start_row? ? start_sequencing(ov) : ov.toggle_or_advance
-        return
-      end
-      # On the selector row, let the text field consume printable/caret/backspace keys
-      # (incl. ←/→ as caret motion) before the cycler nav sees them.
-      return if ov.editing_selector? && ov.handle_text_key(ev)
-      if key.left?
-        ov.adjust(-1)
-      elsif key.right?
-        ov.adjust(1)
-      elsif key.space?
-        ov.toggle_or_advance
-      end
-    end
-
     private def handle_discover_config_key(ev : Termisu::Event::Key) : Nil
       ov = @discover_config_overlay
       return unless ov
@@ -1860,11 +1786,47 @@ module Gori::Tui
     end
 
     # Project SCOPE rule popup: ↑/↓ field · ←/→ kind/type · type pattern · ↵ save · esc cancel.
-    private def handle_scope_rule_key(ev : Termisu::Event::Key) : Nil
-      ov = @scope_rule_overlay || return
+    # --- Overlay seam (see overlay.cr) — generic dispatch for the ONE @active_overlay,
+    # shared by every migrated modal so key/click routing never grows per modal. ---
+
+    # Open a migrated modal: it becomes @active_overlay and syncs @overlay to its key
+    # (so modal_overlay? + residual `@overlay ==` checks keep working during migration).
+    private def open_overlay(ov : Overlay) : Nil
+      @active_overlay = ov
+      @overlay = ov.key
+    end
+
+    private def close_active_overlay : Nil
+      @active_overlay = nil
+      @overlay = :none
+    end
+
+    # The active migrated modal, but ONLY while @overlay still names it. @overlay is the
+    # single source of truth for "what modal is up": ~40 sites reset it to :none directly
+    # (dismiss, tab jump, confirm return, …) without touching @active_overlay. Gating every
+    # read here means such a reset makes the overlay inert (no render, no input capture) —
+    # the pre-seam fail-safe — instead of a zombie that keeps drawing/capturing with
+    # @overlay == :none. Not reachable today (a live modal captures all input), but the
+    # render/modal_overlay?/dispatch reads are authoritative, so this keeps the invariant
+    # honest by construction rather than by convention.
+    private def active_overlay : Overlay?
+      ov = @active_overlay
+      ov if ov && @overlay == ov.key
+    end
+
+    # :stay stays open; :cancel closes; :commit runs the injected commit closure and
+    # closes iff it returns true (a validation failure keeps the form up).
+    private def dispatch_overlay_key(ov : Overlay, ev : Termisu::Event::Key) : Nil
       case ov.handle_key(ev)
-      when :cancel then close_scope_rule
-      when :commit then commit_scope_rule_overlay(ov)
+      when :cancel then close_active_overlay
+      when :commit then close_active_overlay if ov.commit
+      end
+    end
+
+    private def dispatch_overlay_click(ov : Overlay, area : Rect, mx : Int32, my : Int32) : Nil
+      case ov.handle_click(area, mx, my)
+      when :cancel then close_active_overlay
+      when :commit then close_active_overlay if ov.commit
       end
     end
 
@@ -1910,16 +1872,6 @@ module Gori::Tui
           @toast = "CA import failed: #{ex.message}"
         end
       end
-    end
-
-    private def commit_scope_rule_overlay(ov : ScopeRuleOverlay) : Nil
-      return unless project_controller.apply_scope_rule(ov.edit_id, ov.kind, ov.match_type, ov.pattern)
-      close_scope_rule
-    end
-
-    private def close_scope_rule : Nil
-      @overlay = :none
-      @scope_rule_overlay = nil
     end
 
     # OAST provider add/edit popup: same interaction as the scope-rule form. Commit persists
@@ -3835,14 +3787,12 @@ module Gori::Tui
       @env_overlay.render(screen, layout.body) if @overlay == :env
       @hotkeys_overlay.render(screen, layout.body) if @overlay == :hotkeys
       @notifications_overlay.render(screen, layout.body) if @overlay == :notifications
-      @mine_config_overlay.try(&.render(screen, layout.body)) if @overlay == :mine_config
       @probe_active_overlay.try(&.render(screen, layout.body)) if @overlay == :probe_active
-      @sequence_config_overlay.try(&.render(screen, layout.body)) if @overlay == :sequence_config
       @discover_config_overlay.try(&.render(screen, layout.body)) if @overlay == :discover_config
       @discover_headers_overlay.try(&.render(screen, layout.body)) if @overlay == :discover_headers
       @fuzz_set_overlay.try(&.render(screen, layout.body)) if @overlay == :fuzz_set
       @fuzz_advanced_overlay.try(&.render(screen, layout.body)) if @overlay == :fuzz_advanced
-      @scope_rule_overlay.try(&.render(screen, layout.body)) if @overlay == :scope_rule
+      active_overlay.try(&.render(screen, layout.body)) # migrated modals (Overlay seam; gated on @overlay)
       @oast_provider_overlay.try(&.render(screen, layout.body)) if @overlay == :oast_provider
       @custom_rule_overlay.try(&.render(screen, layout.body)) if @overlay == :probe_rule
       @rewriter_rule_overlay.try(&.render(screen, layout.body)) if @overlay == :rewriter_rule
@@ -3951,6 +3901,9 @@ module Gori::Tui
       return "SPACE" if @space_menu_open                              # orthogonal to @overlay — floats over it
       return @copy_picker.try(&.title) || "COPY AS" if copy_as_shown? # ditto
       return "SEND TO" if send_to_shown?                              # ditto
+      if ov = active_overlay                                          # migrated modals name themselves (Overlay seam)
+        return ov.title
+      end
       case @overlay
       when :palette          then "PALETTE"
       when :issue_new        then "ISSUE"
@@ -3970,14 +3923,11 @@ module Gori::Tui
       when :env              then "ENVIRONMENT"
       when :hotkeys          then "HOTKEYS"
       when :notifications    then "NOTIFICATIONS"
-      when :mine_config      then "MINE PARAMS"
       when :probe_active     then "ACTIVE SCAN"
-      when :sequence_config  then "SEQUENCER"
       when :discover_config  then "DISCOVER"
       when :discover_headers then "CUSTOM HEADERS"
       when :fuzz_set         then "PAYLOAD SET"
       when :fuzz_advanced    then "ADVANCED"
-      when :scope_rule       then "SCOPE RULE"
       when :rewriter_rule    then "REWRITER RULE"
       when :oast_provider    then "OAST PROVIDER"
       when :ca_import        then "IMPORT CA"
@@ -4007,6 +3957,9 @@ module Gori::Tui
       return "press a key · ↑/↓ select · ↵ run · esc close" if @space_menu_open
       return "↑/↓ select · ↵ copy · key picks · esc cancel" if copy_as_shown?
       return "↑/↓ select · ↵ send · key picks · esc cancel" if send_to_shown?
+      if ov = active_overlay # migrated modals carry their own hint (Overlay seam)
+        return ov.hint
+      end
       case @overlay
       when :palette          then "↑/↓ select · ↵ run · ⌫ · esc close · type to filter"
       when :issue_new        then "type title · ↵ create · esc cancel"
@@ -4026,14 +3979,11 @@ module Gori::Tui
       when :env              then env_overlay_hints
       when :hotkeys          then @hotkeys_overlay.capturing? ? "press a key to bind · esc cancel" : "↑/↓ select · e/␣ rebind · x unbind · r reset · ⇧R reset all · ←/→ profile · ↵ save · esc"
       when :notifications    then "↑/↓ select · ↵ open · c clear · esc close"
-      when :mine_config      then "↑/↓ field · ←/→ adjust · ␣ toggle · ↵ start · esc cancel"
       when :probe_active     then "↑/↓ field · ←/→ notify · ↵ run · esc cancel"
-      when :sequence_config  then "↑/↓ field · type to edit selector · ←/→ cycle · ↵ start · esc cancel"
       when :discover_config  then "↑/↓ field · ←/→ adjust · ␣ toggle · ↵ start/edit · esc cancel"
       when :discover_headers then "one header per line · Host/Connection ignored · esc saves & closes"
       when :fuzz_set         then "↑/↓/⇥ field · ←/→ type/caret · ↵ new value/next · esc applies & closes"
       when :fuzz_advanced    then "↑/↓/⇥ field · ←/→ edit · ␣ toggle · ↵ next · esc applies & closes"
-      when :scope_rule       then "↑/↓ field · ←/→ kind·type · type pattern · ↵ save · esc cancel"
       when :rewriter_rule    then "↑/↓ field · ←/→ options · type find/value · ↵ save · esc cancel"
       when :oast_provider    then "↑/↓ field · ←/→ scope/type · type name/host/token · ↵ save · esc cancel"
       when :ca_import        then "type to complete · ↹/↵ pick · ⇥/↑↓ field · ↵ submits · esc cancels"
@@ -4980,36 +4930,33 @@ module Gori::Tui
         @toast = "no mineable locations for this request"
         return
       end
-      @mine_config_overlay = MineConfigOverlay.new(seed)
-      @overlay = :mine_config
-    end
-
-    # Confirm the config popup: kick off the BACKGROUND mine and stay where we are.
-    private def start_mining(ov : MineConfigOverlay) : Nil
-      unless ov.any_checked?
-        @toast = "select at least one location to mine"
-        return
-      end
-      ov.save_prefs
-      miner_controller.start_session(ov.seed, ov.build_config)
-      close_mine_config
-    end
-
-    private def close_mine_config : Nil
-      @overlay = :none
-      @mine_config_overlay = nil
+      ov = MineConfigOverlay.new(seed)
+      # Start commits: require ≥1 location (keep the form up otherwise), then kick off the
+      # BACKGROUND mine and stay where we are.
+      ov.on_commit = -> {
+        if ov.any_checked?
+          ov.save_prefs
+          miner_controller.start_session(ov.seed, ov.build_config)
+          true
+        else
+          @toast = "select at least one location to mine"
+          false
+        end
+      }
+      open_overlay(ov)
     end
 
     # --- Sequencer ExecContext / cross-tab mediators ---
 
     # Reconfigure the CURRENT session's token descriptor/goal (Sequencer `c` / verb). Opens
-    # the same overlay with the reconfigure flag so Start applies to the open session.
+    # the same overlay; Start applies to the OPEN session — that "apply to current" is the
+    # injected commit, so no shell flag distinguishes it from a new-session open.
     def reconfigure_sequence : Nil
       seed = sequencer_controller.build_seed_from_current
       return (@toast = "manual sessions have no token descriptor to configure") unless seed
-      @sequence_reconfigure = true
-      @sequence_config_overlay = SequenceConfigOverlay.new(seed)
-      @overlay = :sequence_config
+      ov = SequenceConfigOverlay.new(seed)
+      ov.on_commit = -> { commit_sequence(ov) { sequencer_controller.reconfigure_current(ov.build_config) } }
+      open_overlay(ov)
     end
 
     private def open_sequence_config(seed : SequenceSeed?) : Nil
@@ -5017,30 +4964,21 @@ module Gori::Tui
         @toast = "cannot sequence this request"
         return
       end
-      @sequence_reconfigure = false
-      @sequence_config_overlay = SequenceConfigOverlay.new(seed)
-      @overlay = :sequence_config
+      ov = SequenceConfigOverlay.new(seed)
+      ov.on_commit = -> { commit_sequence(ov) { sequencer_controller.start_session(ov.seed, ov.build_config) } }
+      open_overlay(ov)
     end
 
-    # Confirm the config popup: start collecting (new session) or apply + re-collect
-    # (reconfigure), staying where we are.
-    private def start_sequencing(ov : SequenceConfigOverlay) : Nil
+    # Shared Start gate for both Sequencer open-sites: reject an unset token location
+    # (keep the form up), else run the site-specific apply and close. Returns whether to
+    # close, matching the Overlay#commit contract.
+    private def commit_sequence(ov : SequenceConfigOverlay, & : -> Nil) : Bool
       unless ov.valid?
         @toast = "set a token location first"
-        return
+        return false
       end
-      if @sequence_reconfigure
-        sequencer_controller.reconfigure_current(ov.build_config)
-      else
-        sequencer_controller.start_session(ov.seed, ov.build_config)
-      end
-      close_sequence_config
-    end
-
-    private def close_sequence_config : Nil
-      @overlay = :none
-      @sequence_config_overlay = nil
-      @sequence_reconfigure = false
+      yield
+      true
     end
 
     # --- Discover config popup (Sitemap/History → "Discover here") ---
@@ -5112,15 +5050,18 @@ module Gori::Tui
       @overlay = :fuzz_advanced
     end
 
-    # Host: open the Project SCOPE rule popup (nil edit_id = add a new rule).
+    # Host: open the Project SCOPE rule popup (nil edit_id = add a new rule). The apply is
+    # injected as the overlay's commit closure (Overlay seam): it persists via the Project
+    # controller and returns whether to close (false = invalid pattern → keep the form up).
     def open_scope_rule_editor(edit_id : Int64?, kind : String, match_type : String, pattern : String) : Nil
-      @scope_rule_overlay =
+      ov =
         if id = edit_id
           ScopeRuleOverlay.editing(id, kind, match_type, pattern)
         else
           ScopeRuleOverlay.new(kind: kind, match_type: match_type, pattern: pattern)
         end
-      @overlay = :scope_rule
+      ov.on_commit = -> { project_controller.apply_scope_rule(ov.edit_id, ov.kind, ov.match_type, ov.pattern) }
+      open_overlay(ov)
     end
 
     # Host: open the OAST provider add/edit popup (nil = add a new provider).

--- a/src/gori/tui/scope_rule_overlay.cr
+++ b/src/gori/tui/scope_rule_overlay.cr
@@ -2,6 +2,7 @@ require "./screen"
 require "./theme"
 require "./frame"
 require "./text_field"
+require "./overlay"
 require "../scope"
 
 module Gori::Tui
@@ -11,7 +12,11 @@ module Gori::Tui
   #   ←/→  cycle kind or type when that row is selected
   #   type into Pattern when focused; ↵ on Save (or last field) commits
   #   esc cancels
-  class ScopeRuleOverlay
+  #
+  # First modal migrated onto the polymorphic Overlay seam (see overlay.cr): the Runner
+  # dispatches key/click/wheel/preedit/render/title/hint to it generically, and the SCOPE
+  # apply is injected as `on_commit` at the open-site (Runner#open_scope_rule_editor).
+  class ScopeRuleOverlay < Overlay
     getter edit_id : Int64?
 
     def initialize(*, kind : String = "include", match_type : String = "host",
@@ -44,6 +49,31 @@ module Gori::Tui
 
     def editing? : Bool
       !@edit_id.nil?
+    end
+
+    # --- Overlay contract (see overlay.cr) ---
+    def key : Symbol
+      :scope_rule
+    end
+
+    def title : String
+      "SCOPE RULE"
+    end
+
+    def hint : String
+      "↑/↓ field · ←/→ kind·type · type pattern · ↵ save · esc cancel"
+    end
+
+    # Click a field row to select it; a click on Save commits; a click outside the card
+    # cancels. Mirrors the ↑/↓ + ↵ keyboard model.
+    def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      box = overlay_box(area)
+      return :cancel if box.nil? || !box.contains?(mx, my)
+      if idx = row_at(box, mx, my)
+        set_selected(idx)
+        return :commit if on_save_row?
+      end
+      :stay
     end
 
     private def row_count : Int32

--- a/src/gori/tui/sequence_config_overlay.cr
+++ b/src/gori/tui/sequence_config_overlay.cr
@@ -2,6 +2,7 @@ require "./screen"
 require "./theme"
 require "./frame"
 require "./text_field"
+require "./overlay"
 require "../sequencer"
 
 module Gori::Tui
@@ -24,8 +25,15 @@ module Gori::Tui
   # The config popup shown before a live collection: a token-descriptor kind cycler + an
   # editable selector field, then goal / concurrency / notification cyclers and a Start
   # row. The selector is the one text field (a mistyped cookie name is the #1 failure
-  # mode); everything else cycles with ←/→. On Start the Runner reads build_config + seed.
-  class SequenceConfigOverlay
+  # mode); everything else cycles with ←/→. On Start the commit closure reads build_config
+  # + seed.
+  #
+  # Migrated onto the polymorphic Overlay seam (see overlay.cr). It opens from TWO sites
+  # with different apply semantics — a NEW session (open_sequence_config) and a
+  # RECONFIGURE of the current one (reconfigure_sequence). Each site injects its own
+  # `on_commit` closure, so the old `@sequence_reconfigure` shell flag is gone: the
+  # overlay only reports :commit and the closure decides what "Start" means.
+  class SequenceConfigOverlay < Overlay
     KINDS          = Sequencer::ExtractKind.values
     GOAL_CHOICES   = [100, 250, 500, 1000, 2000, 5000]
     CONC_CHOICES   = [1, 2, 5, 10]
@@ -74,6 +82,66 @@ module Gori::Tui
 
     def handle_text_key(ev : Termisu::Event::Key) : Bool
       @selector.handle_edit_key(ev)
+    end
+
+    # --- Overlay contract (see overlay.cr) ---
+    def key : Symbol
+      :sequence_config
+    end
+
+    def title : String
+      "SEQUENCER"
+    end
+
+    def hint : String
+      "↑/↓ field · type to edit selector · ←/→ cycle · ↵ start · esc cancel"
+    end
+
+    # Own key handling (formerly Runner#handle_sequence_config_key). ↑/↓ move fields; the
+    # selector row eats printable/caret/backspace (incl. ←/→ as caret motion) before the
+    # cyclers see them; ↵ on Start commits, elsewhere advances the cycler; esc cancels.
+    def handle_key(ev : Termisu::Event::Key) : Symbol
+      key = ev.key
+      return :cancel if key.escape?
+      if key.up?
+        move(-1)
+        return :stay
+      end
+      if key.down?
+        move(1)
+        return :stay
+      end
+      if key.enter?
+        return :commit if on_start_row?
+        toggle_or_advance
+        return :stay
+      end
+      return :stay if editing_selector? && handle_text_key(ev)
+      if key.left?
+        adjust(-1)
+      elsif key.right?
+        adjust(1)
+      elsif key.space?
+        toggle_or_advance
+      end
+      :stay
+    end
+
+    # Click a row to select it; a click on Start commits; a click outside the card cancels.
+    def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      box = overlay_box(area)
+      return :cancel if box.nil? || !box.contains?(mx, my)
+      if idx = row_at(box, mx, my)
+        set_selected(idx)
+        return :commit if on_start_row?
+      end
+      :stay
+    end
+
+    # Live IME composition for the selector text field (only meaningful on that row) — a
+    # mistyped cookie/header name is the #1 failure mode, so show composition as it builds.
+    def set_preedit(text : String) : Nil
+      @selector.set_preedit(text) if editing_selector?
     end
 
     def adjust(d : Int32) : Nil


### PR DESCRIPTION
## Why

`Runner` (`src/gori/tui/runner.cr`) is a ~5.5k-line god object. Every modal used to scatter **~13 `case @overlay` arms** across the central key / click / wheel / preedit / render / title / hint routing — **128 ladder arms in total**. Editing one modal meant touching a dozen shared methods thousands of lines apart, so every TUI feature collided in `runner.cr`. That fan-out was the real merge-conflict surface and the reason the file is hard to read.

## What

Introduce **`Overlay`** (`src/gori/tui/overlay.cr`), an abstract base that extends the codebase's existing `TabController` polymorphism from tab *bodies* to *modals*. The Runner now drives **one `@active_overlay`** polymorphically; each central ladder gets a single generic guard, and a migrated modal deletes all of its scattered arms. Domain-coupled behaviour is injected as an `on_commit` closure at the open-site (mirrors `ConfirmDialog`'s action proc), so a modal opened from two sites needs no shell flag.

Three overlays migrated as the **proven template** (easy → hard):

| overlay | why it was chosen |
|---|---|
| `scope_rule` | clean case — already self-handled keys, had a spec → isolates the new seam |
| `sequence_config` | **hard case** — two open-sites (new vs reconfigure); the `@sequence_reconfigure` shell flag **dissolves** into per-site `on_commit` closures; shell-owned `handle_sequence_config_key` moves into the overlay |
| `mine_config` | laggard whose keys the shell drove; its click **toggles** rows (behaviour preserved exactly) |

`@overlay` stays the single source of truth via a gated `active_overlay` accessor (from code review), so a stray reset elsewhere can't strand a zombie modal that keeps drawing/capturing.

## Result

- `runner.cr` **−72 LOC** net (after the one-time seam machinery is amortized) and shrinks further per migration; three typed overlay ivars + one flag collapse into one `@active_overlay`.
- Per-overlay central-ladder arms: **13 → 0**. The remaining ~11 overlays are now **independent, parallelizable** migrations (one file + one open-site each).

## Tests

- **17 new seam-contract specs** (`spec/tui/overlay_dispatch_spec.cr`) locking the polymorphic contract the Runner depends on (the Runner isn't unit-testable without a terminal), incl. the hard-case multi-open-site closure routing and click-toggle behaviour preservation.
- Full suite: **3417 examples, 0 failures**. `crystal tool format --check` clean. (CI runs `crystal spec`.)