### PR TITLE
fix(proxy): surface h2 tunnel upstream failures instead of dropping silently

### DIFF
--- a/spec/proxy/tls/tunnel_spec.cr
+++ b/spec/proxy/tls/tunnel_spec.cr
@@ -149,4 +149,50 @@ describe Gori::Proxy::Tls::Tunnel do
       File.delete?("#{dbpath}-shm")
     end
   end
+
+  it "records a visible error flow when the h2 upstream can't be reached (no silent drop, #323)" do
+    dir = File.tempname("gori-ca-h2err")
+    done = Channel(Nil).new(1)
+    begin
+      ca = CertAuthority.load_or_create(dir)
+      sink = RecordingSink.new(done)
+      proxy = Server.new("127.0.0.1", 0, sink, tls: Tunnel.new(ca, verify_upstream: false))
+      proxy.start
+
+      # A port with nothing listening → the upstream dial in intercept_h2 fails.
+      dead = TCPServer.new("127.0.0.1", 0)
+      dead_port = dead.local_address.port
+      dead.close
+
+      raw = TCPSocket.new("127.0.0.1", proxy.port)
+      raw << "CONNECT localhost:#{dead_port} HTTP/1.1\r\nHost: localhost:#{dead_port}\r\n\r\n"
+      raw.flush
+      Codec::Http1.read_head(raw).not_nil!
+
+      client_ctx = OpenSSL::SSL::Context::Client.new
+      client_ctx.alpn_protocol = "h2" # client OFFERS h2 → gori (no rules) advertises + negotiates it
+      ca_cert = Cert.read_pem(File.join(dir, "root.crt.pem"))
+      st = LibSSL.ssl_ctx_get_cert_store(client_ctx.to_unsafe)
+      LibCrypto.x509_store_add_cert(st, ca_cert.handle)
+
+      tls = OpenSSL::SSL::Socket::Client.new(raw, context: client_ctx, sync_close: true, hostname: "localhost")
+      tls.alpn_protocol.should eq("h2") # took the h2 relay path
+      tls.close rescue nil
+
+      done.receive # an error response was recorded (previously: silent drop, empty History)
+      proxy.stop
+
+      req = sink.requests.first
+      req.scheme.should eq("https")
+      req.host.should eq("localhost")
+      req.port.should eq(dead_port)
+      req.http_version.should eq("HTTP/2")
+
+      resp = sink.responses.first
+      resp.state.should eq(Gori::Store::FlowState::Error)
+      resp.error.not_nil!.should contain("localhost:#{dead_port}")
+    ensure
+      FileUtils.rm_rf(dir) if Dir.exists?(dir)
+    end
+  end
 end

--- a/src/gori/proxy/tls/tunnel.cr
+++ b/src/gori/proxy/tls/tunnel.cr
@@ -6,7 +6,9 @@ require "../conn/client_conn"
 require "../upstream"
 require "../socket_tuning"
 require "../h2/relay"
+require "../codec/message"
 require "../../host_overrides"
+require "../../flow_mapper"
 require "./cert_authority"
 
 module Gori::Proxy::Tls
@@ -95,21 +97,52 @@ module Gori::Proxy::Tls
       client_tls.try(&.close) rescue nil
     end
 
-    # End-to-end h2: dial the origin offering h2. If the origin won't speak h2,
-    # v1 does not translate h2↔h1 — the connection is dropped (the human sees no
-    # flow rather than a corrupted one, P7).
+    # End-to-end h2: dial the origin offering h2. A tunnel we can't build is
+    # recorded as a visible error flow (see record_h2_error) rather than dropped
+    # silently — most browsers negotiate h2 by default, so a silent drop here left
+    # the user with a blank page and an empty History and no hint of the cause (#323).
     private def intercept_h2(host : String, port : Int32, client_tls : IO, sink : Proxy::FlowSink) : Nil
       upstream = Proxy::Upstream.dial_tls(host, port, verify: @verify_upstream, alpn: "h2", overrides: @host_overrides)
-      if upstream && upstream.alpn_protocol == "h2"
-        upstream.sync = true
-        # Long-lived end-to-end h2 relay: relax both legs so an idle h2 connection isn't reaped
-        # (keepalive on both underlying sockets reaps a dead peer). Resolves through the TLS wrap.
-        Proxy::SocketTuning.relax(client_tls)
-        Proxy::SocketTuning.relax(upstream)
-        Proxy::H2::Relay.run(client_tls, upstream, host, port, sink)
+      if upstream.nil?
+        # Couldn't reach or TLS-verify the origin — no h2 tunnel to build. The most common
+        # cause behind #323: upstream-cert verification failing when the (statically-linked)
+        # binary can't resolve a system trust store. The h1 path already surfaces this via
+        # ClientConn#record_error; bring h2 to parity instead of dropping the connection.
+        record_h2_error(host, port, sink, "upstream connect/TLS-verify failed: #{host}:#{port}")
+        return
       end
+      unless upstream.alpn_protocol == "h2"
+        # Origin won't speak h2; v1 does not translate h2↔h1 (a translated flow would be
+        # corrupted, P7). Record WHY rather than dropping silently — an Error flow is an
+        # honest projection, not a corrupted one.
+        record_h2_error(host, port, sink, "origin did not negotiate HTTP/2 (h2↔h1 not supported): #{host}:#{port}")
+        return
+      end
+      upstream.sync = true
+      # Long-lived end-to-end h2 relay: relax both legs so an idle h2 connection isn't reaped
+      # (keepalive on both underlying sockets reaps a dead peer). Resolves through the TLS wrap.
+      Proxy::SocketTuning.relax(client_tls)
+      Proxy::SocketTuning.relax(upstream)
+      Proxy::H2::Relay.run(client_tls, upstream, host, port, sink)
     ensure
       upstream.try(&.close) rescue nil
+    end
+
+    # Record a VISIBLE error flow for an h2 tunnel we could not establish, mirroring the
+    # h1 path's ClientConn#record_error. `head` is a synthesized marker: the real h2 request
+    # frames were never relayed or decoded (the failure is before the relay), so there is no
+    # wire request to capture — the raw-frame log stays the truth for real h2 flows (P7).
+    # Best-effort: a store error here must not take down the tunnel teardown.
+    private def record_h2_error(host : String, port : Int32, sink : Proxy::FlowSink, message : String) : Nil
+      created_at = (Time.utc - Time::UNIX_EPOCH).total_microseconds.to_i64
+      head = "GET / HTTP/2\r\nHost: #{host}\r\n\r\n".to_slice
+      req = Proxy::Codec::RawRequest.new(head, "GET", "/", "HTTP/2",
+        Proxy::Codec::HeaderList.new([Proxy::Codec::Header.new("Host", host)]))
+      flow_id = sink.on_request(FlowMapper.request(req,
+        scheme: "https", host: host, port: port, created_at: created_at, alpn: "h2"))
+      sink.on_response(FlowMapper.error_response(flow_id, message))
+    rescue
+      # never let error-recording take down the tunnel teardown path
     end
   end
 end


### PR DESCRIPTION
## Scope (read first)

This is the **visibility half** of #323 — it does **not** make HTTPS load for the reporter. The underlying cause (upstream trust-store resolution on statically-linked musl builds — see analysis below) is still open; this PR only makes the failure **visible in History** instead of vanishing. Hence `Refs`, not `Fixes`.

## Problem

Firefox (and most browsers) negotiate **HTTP/2 by default**, so an HTTPS `CONNECT` takes the h2 relay path (`Tunnel#intercept_h2`). When the upstream dial failed — unreachable origin, or **upstream-cert verification failing** — `intercept_h2` had:

```crystal
if upstream && upstream.alpn_protocol == "h2"
  ... H2::Relay.run(...)
end
# no else — upstream nil ⇒ falls through, nothing recorded, no log
```

No `else`, plus the outer bare `rescue`, meant the connection was dropped **silently**: the browser gets a blank page and gori's History shows **nothing** — exactly the "the proxy doesn't receive any information at all" in #323. The h1 path already records this as a visible error flow (`upstream connect/write failed: host:port` via `ClientConn#record_error`); only h2 swallowed it.

## Change

`intercept_h2` now records a visible **Error** flow (mirroring the h1 path) when the tunnel can't be built:
- upstream unreachable / TLS-verify failed → `upstream connect/TLS-verify failed: host:port`
- origin didn't negotiate h2 → `origin did not negotiate HTTP/2 (h2↔h1 not supported): host:port`

The client still resets (we can't MITM without a usable upstream) — but the operator now sees the cause.

## ⚠️ Decision point for review

The `origin did not negotiate h2` branch changes behavior the original code called **intentional** (old comment: "the human sees no flow rather than a corrupted one, P7"). My reasoning: an *Error* flow is an honest projection, not a corrupted one. **Consequence:** this now emits an error flow for **every h1-only HTTPS origin** an h2 browser visits through gori, not just the dial-failure case. Flagging so it's a choice, not a review surprise — happy to drop that branch and keep it to the `upstream.nil?` case only if you prefer.

## Verified

- `crystal spec spec/proxy/` → 248 examples, 0 failures (incl. a new tunnel spec asserting a dead h2 upstream records an Error flow).
- End-to-end repro with a broken trust store (`SSL_CERT_FILE=/nonexistent`), h2 client via the proxy:
  - **before:** History empty
  - **after:** `https example.com … state:error` → `upstream connect/TLS-verify failed: example.com:443`

## Root cause of #323 (context, not fixed here)

`Upstream.client_context` builds `OpenSSL::SSL::Context::Client.new`, which loads OpenSSL's default verify paths. The Linux release binaries are statically linked (musl), so the compiled-in CA path can miss the distro's actual CA store ⇒ all upstream HTTPS verification fails (HTTP is unaffected — no upstream TLS). mitmproxy bundles its own CA store (certifi), which is why it works with the same Firefox + CA. A follow-up should resolve the trust store properly (system-path autodetection and/or a bundled fallback); user workaround today: `--insecure-upstream` or `SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt`.

Refs #323