### PR TITLE
fix(proxy): reflect origin ALPN so h1-only origins load; harden upstream trust-store warning

### DIFF
--- a/spec/proxy/tls/tunnel_spec.cr
+++ b/spec/proxy/tls/tunnel_spec.cr
@@ -56,6 +56,31 @@ private def start_tls_origin(body : String, seen : Channel(String), advertise_h2
   port
 end
 
+# An HTTP/1.1-only origin (no h2 ALPN) that counts every accepted connection. Used to prove the
+# negative ALPN cache skips the probe on a repeat visit: visit 1 = probe + real = 2 accepts,
+# a cached visit 2 = real only = 1 accept.
+private def start_counting_h1_origin(body : String, accepts : Array(Int32)) : Int32
+  cert, key = CertBuilder.build_root("origin.test")
+  ctx = ContextFactory.server_context(cert, key, advertise_h2: false)
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    while raw = origin.accept?
+      accepts[0] += 1 # one-element box: a shared reference (Atomic is a struct and would copy)
+      begin
+        ssl = OpenSSL::SSL::Socket::Server.new(raw, ctx, sync_close: true)
+        head = Codec::Http1.read_head(ssl)
+        next unless head # a probe connection sends nothing
+        ssl << "HTTP/1.1 200 OK\r\nContent-Length: #{body.bytesize}\r\nConnection: close\r\n\r\n" << body
+        ssl.flush
+        ssl.close
+      rescue
+      end
+    end
+  end
+  port
+end
+
 # A minimal HTTP/2 origin: negotiates the h2 ALPN, reads the forwarded client preface + first
 # frame, then writes one recognizable frame back. It is a byte peer, not a real h2 stack — just
 # enough to exercise the relay's end-to-end pump. Holds the connection open until `ack` fires so
@@ -274,6 +299,47 @@ describe Gori::Proxy::Tls::Tunnel do
       req.host.should eq("localhost")
       req.port.should eq(origin_port)
       req.http_version.should eq("HTTP/1.1") # captured via the h1 path, not a dead h2 tunnel
+    ensure
+      FileUtils.rm_rf(dir) if Dir.exists?(dir)
+    end
+  end
+
+  it "caches an h1-only origin so a repeat visit skips the ALPN probe (fewer origin connections)" do
+    dir = File.tempname("gori-ca-h1cache")
+    done = Channel(Nil).new(4)
+    accepts = [0] # one-element box shared with the origin fiber
+    begin
+      origin_port = start_counting_h1_origin("OK", accepts)
+      ca = CertAuthority.load_or_create(dir)
+      sink = RecordingSink.new(done)
+      # One Tunnel instance across both visits — the negative cache lives on it.
+      proxy = Server.new("127.0.0.1", 0, sink, tls: Tunnel.new(ca, verify_upstream: false))
+      proxy.start
+      ca_cert = Cert.read_pem(File.join(dir, "root.crt.pem"))
+
+      2.times do
+        raw = TCPSocket.new("127.0.0.1", proxy.port)
+        raw << "CONNECT localhost:#{origin_port} HTTP/1.1\r\nHost: localhost:#{origin_port}\r\n\r\n"
+        raw.flush
+        Codec::Http1.read_head(raw).not_nil!
+
+        client_ctx = OpenSSL::SSL::Context::Client.new
+        client_ctx.alpn_protocol = "h2"
+        st = LibSSL.ssl_ctx_get_cert_store(client_ctx.to_unsafe)
+        LibCrypto.x509_store_add_cert(st, ca_cert.handle)
+
+        tls = OpenSSL::SSL::Socket::Client.new(raw, context: client_ctx, sync_close: true, hostname: "localhost")
+        tls.alpn_protocol.should_not eq("h2") # reflected h1 on both visits
+        tls << "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"
+        tls.flush
+        tls.gets_to_end
+        tls.close
+        done.receive # wait for the flow to complete before the next visit (deterministic count)
+      end
+
+      proxy.stop
+      # visit 1: probe + real = 2 accepts; cached visit 2: real only = 1. 4 would mean no caching.
+      accepts[0].should eq(3)
     ensure
       FileUtils.rm_rf(dir) if Dir.exists?(dir)
     end

--- a/spec/proxy/tls/tunnel_spec.cr
+++ b/spec/proxy/tls/tunnel_spec.cr
@@ -29,9 +29,11 @@ private class RecordingSink < FlowSink
 end
 
 # A self-signed TLS origin that echoes the request-line and replies with `body`.
-private def start_tls_origin(body : String, seen : Channel(String)) : Int32
+# `advertise_h2: false` makes it an HTTP/1.1-only origin (no h2 in ALPN) — used to exercise
+# gori's ALPN reflection, which must fall the client back to h1 for such origins.
+private def start_tls_origin(body : String, seen : Channel(String), advertise_h2 : Bool = true) : Int32
   cert, key = CertBuilder.build_root("origin.test")
-  ctx = ContextFactory.server_context(cert, key)
+  ctx = ContextFactory.server_context(cert, key, advertise_h2: advertise_h2)
   origin = TCPServer.new("127.0.0.1", 0)
   port = origin.local_address.port
   spawn do
@@ -39,10 +41,42 @@ private def start_tls_origin(body : String, seen : Channel(String)) : Int32
       begin
         ssl = OpenSSL::SSL::Socket::Server.new(raw, ctx, sync_close: true)
         head = Codec::Http1.read_head(ssl)
-        seen.send(head ? String.new(head).lines.first : "")
+        # Only a real request line reaches `seen`. ALPN reflection pre-dials a throwaway probe
+        # connection that sends nothing (read_head → nil); that artifact must not be mistaken
+        # for the forwarded request.
+        next unless head
+        seen.send(String.new(head).lines.first)
         ssl << "HTTP/1.1 200 OK\r\nContent-Length: #{body.bytesize}\r\nConnection: close\r\n\r\n" << body
         ssl.flush
         ssl.close
+      rescue
+      end
+    end
+  end
+  port
+end
+
+# A minimal HTTP/2 origin: negotiates the h2 ALPN, reads the forwarded client preface + first
+# frame, then writes one recognizable frame back. It is a byte peer, not a real h2 stack — just
+# enough to exercise the relay's end-to-end pump. Holds the connection open until `ack` fires so
+# the reply isn't lost to a close race. gori reuses the single pre-dialed (probe) socket for the
+# relay, so the origin sees exactly ONE connection.
+private def start_h2_origin(reply : Bytes, ack : Channel(Nil)) : Int32
+  cert, key = CertBuilder.build_root("origin.test")
+  ctx = ContextFactory.server_context(cert, key, advertise_h2: true)
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    if raw = origin.accept?
+      begin
+        ssl = OpenSSL::SSL::Socket::Server.new(raw, ctx, sync_close: true)
+        ssl.sync = true
+        Gori::Proxy::H2::Frame.read_preface(ssl) # gori forwarded the client's preface
+        Gori::Proxy::H2::Frame.read(ssl)          # + its first frame (SETTINGS)
+        ssl.write(reply)                           # a frame the client must receive via the relay
+        ssl.flush
+        ack.receive # keep the connection open until the client has read the reply
+        ssl.close rescue nil
       rescue
       end
     end
@@ -102,6 +136,52 @@ describe Gori::Proxy::Tls::Tunnel do
     end
   end
 
+  it "reflects an h2 origin: reuses the pre-dialed socket for the end-to-end h2 relay (#323)" do
+    # The common browser→h2-origin path. ALPN reflection pre-dials the origin offering h2, sees
+    # it negotiate h2, advertises h2 to the client, and hands that SAME pre-dialed socket to the
+    # relay (no re-dial). This drives a minimal frame round-trip to prove the reused socket pumps
+    # both directions — the h1/error tests never touch this handoff.
+    dir = File.tempname("gori-ca-h2h2")
+    done = Channel(Nil).new(4) # relay uses on_h2_* not on_response; buffered so teardown can't wedge
+    ack = Channel(Nil).new(1)
+    begin
+      reply = Gori::Proxy::H2::Frame::Header.new(0x6_u8, 0_u8, 0_u32, "GORIPING".to_slice).wire_bytes # PING
+      origin_port = start_h2_origin(reply, ack)
+      ca = CertAuthority.load_or_create(dir)
+      sink = RecordingSink.new(done)
+      proxy = Server.new("127.0.0.1", 0, sink, tls: Tunnel.new(ca, verify_upstream: false))
+      proxy.start
+
+      raw = TCPSocket.new("127.0.0.1", proxy.port)
+      raw << "CONNECT localhost:#{origin_port} HTTP/1.1\r\nHost: localhost:#{origin_port}\r\n\r\n"
+      raw.flush
+      Codec::Http1.read_head(raw).not_nil!
+
+      client_ctx = OpenSSL::SSL::Context::Client.new
+      client_ctx.alpn_protocol = "h2"
+      ca_cert = Cert.read_pem(File.join(dir, "root.crt.pem"))
+      st = LibSSL.ssl_ctx_get_cert_store(client_ctx.to_unsafe)
+      LibCrypto.x509_store_add_cert(st, ca_cert.handle)
+
+      tls = OpenSSL::SSL::Socket::Client.new(raw, context: client_ctx, sync_close: true, hostname: "localhost")
+      tls.sync = true
+      tls.alpn_protocol.should eq("h2") # origin speaks h2 → gori reflected h2 → the relay path
+
+      # Client preface + one frame, then read the origin's reply back through the reused upstream.
+      tls.write(Gori::Proxy::H2::Frame::PREFACE)
+      tls.write(Gori::Proxy::H2::Frame::Header.new(0x4_u8, 0_u8, 0_u32, Bytes.new(0)).wire_bytes) # SETTINGS
+      tls.flush
+
+      relayed = Gori::Proxy::H2::Frame.read(tls).not_nil!
+      String.new(relayed.payload).should eq("GORIPING") # origin's frame arrived via the relay
+      ack.send(nil)
+      tls.close rescue nil
+      proxy.stop
+    ensure
+      FileUtils.rm_rf(dir) if Dir.exists?(dir)
+    end
+  end
+
   it "downgrades an h2 client to HTTP/1.1 so live Match&Replace rules still apply" do
     dir = File.tempname("gori-ca-mr")
     dbpath = File.tempname("gori-mr", ".db")
@@ -150,8 +230,57 @@ describe Gori::Proxy::Tls::Tunnel do
     end
   end
 
-  it "records a visible error flow when the h2 upstream can't be reached (no silent drop, #323)" do
-    dir = File.tempname("gori-ca-h2err")
+  it "reflects an h1-only origin's ALPN: an h2 client falls back to h1 and the flow loads (#323)" do
+    dir = File.tempname("gori-ca-h1only")
+    seen = Channel(String).new(1)
+    done = Channel(Nil).new(1)
+    begin
+      # An HTTP/1.1-only origin (no h2 in its ALPN). Before ALPN reflection, gori advertised h2
+      # to the client, the client took h2, and the h2 tunnel died with no h1 fallback — a blank
+      # page + empty History (#323). Now gori pre-dials the origin, sees it won't speak h2, and
+      # reflects h1 to the client so the request loads over the h1 path.
+      origin_port = start_tls_origin("TOP SECRET", seen, advertise_h2: false)
+      ca = CertAuthority.load_or_create(dir)
+      sink = RecordingSink.new(done)
+      proxy = Server.new("127.0.0.1", 0, sink, tls: Tunnel.new(ca, verify_upstream: false))
+      proxy.start
+
+      raw = TCPSocket.new("127.0.0.1", proxy.port)
+      raw << "CONNECT localhost:#{origin_port} HTTP/1.1\r\nHost: localhost:#{origin_port}\r\n\r\n"
+      raw.flush
+      Codec::Http1.read_head(raw).not_nil!
+
+      client_ctx = OpenSSL::SSL::Context::Client.new
+      client_ctx.alpn_protocol = "h2" # client OFFERS h2 …
+      ca_cert = Cert.read_pem(File.join(dir, "root.crt.pem"))
+      st = LibSSL.ssl_ctx_get_cert_store(client_ctx.to_unsafe)
+      LibCrypto.x509_store_add_cert(st, ca_cert.handle)
+
+      tls = OpenSSL::SSL::Socket::Client.new(raw, context: client_ctx, sync_close: true, hostname: "localhost")
+      tls.alpn_protocol.should_not eq("h2") # … but gori reflected the origin's h1, not h2
+      tls << "GET /secret HTTP/1.1\r\nHost: localhost\r\n\r\n"
+      tls.flush
+      response = tls.gets_to_end
+      tls.close
+
+      done.receive
+      proxy.stop
+
+      response.should contain("200 OK")
+      response.should contain("TOP SECRET")           # loaded end-to-end over h1 (no blank page)
+      seen.receive.should eq("GET /secret HTTP/1.1")  # origin saw the forwarded request
+
+      req = sink.requests.first
+      req.host.should eq("localhost")
+      req.port.should eq(origin_port)
+      req.http_version.should eq("HTTP/1.1") # captured via the h1 path, not a dead h2 tunnel
+    ensure
+      FileUtils.rm_rf(dir) if Dir.exists?(dir)
+    end
+  end
+
+  it "reflects an unreachable origin as h1, surfacing the dial failure via the h1 path (#323)" do
+    dir = File.tempname("gori-ca-dead")
     done = Channel(Nil).new(1)
     begin
       ca = CertAuthority.load_or_create(dir)
@@ -159,7 +288,8 @@ describe Gori::Proxy::Tls::Tunnel do
       proxy = Server.new("127.0.0.1", 0, sink, tls: Tunnel.new(ca, verify_upstream: false))
       proxy.start
 
-      # A port with nothing listening → the upstream dial in intercept_h2 fails.
+      # A port with nothing listening → the ALPN-reflection pre-dial fails, so gori reflects h1
+      # and the client takes the h1 path, which records the dial failure (no silent drop).
       dead = TCPServer.new("127.0.0.1", 0)
       dead_port = dead.local_address.port
       dead.close
@@ -170,23 +300,17 @@ describe Gori::Proxy::Tls::Tunnel do
       Codec::Http1.read_head(raw).not_nil!
 
       client_ctx = OpenSSL::SSL::Context::Client.new
-      client_ctx.alpn_protocol = "h2" # client OFFERS h2 → gori (no rules) advertises + negotiates it
+      client_ctx.alpn_protocol = "h2" # client offers h2; the dead origin can't confirm it
       ca_cert = Cert.read_pem(File.join(dir, "root.crt.pem"))
       st = LibSSL.ssl_ctx_get_cert_store(client_ctx.to_unsafe)
       LibCrypto.x509_store_add_cert(st, ca_cert.handle)
 
       tls = OpenSSL::SSL::Socket::Client.new(raw, context: client_ctx, sync_close: true, hostname: "localhost")
-      tls.alpn_protocol.should eq("h2") # took the h2 relay path
-      # Send + flush the h2 client connection preface, exactly as a real h2 client does right
-      # after the handshake. This is REQUIRED, not cosmetic: under TLS 1.3 the server's
-      # SSL_accept only returns once it has read the client's Finished, which the client's SSL
-      # socket buffers until the first app-data flush. Without this the server handshake blocks
-      # forever, intercept_h2 (and its error recording) is never reached, and the spec hangs
-      # (reproduced on Linux/OpenSSL; masked on macOS/LibreSSL).
-      tls << "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+      tls.alpn_protocol.should_not eq("h2") # reflected h1: nothing upstream to relay h2 to
+      tls << "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"
       tls.flush
 
-      done.receive # an error response was recorded (previously: silent drop, empty History)
+      done.receive # the h1 path recorded the failure (previously: silent drop, empty History)
       tls.close rescue nil
       proxy.stop
 
@@ -194,7 +318,6 @@ describe Gori::Proxy::Tls::Tunnel do
       req.scheme.should eq("https")
       req.host.should eq("localhost")
       req.port.should eq(dead_port)
-      req.http_version.should eq("HTTP/2")
 
       resp = sink.responses.first
       resp.state.should eq(Gori::Store::FlowState::Error)

--- a/spec/proxy/upstream_spec.cr
+++ b/spec/proxy/upstream_spec.cr
@@ -287,6 +287,20 @@ describe Gori::Proxy::Upstream do
       end
     end
 
+    it "ignores a zero-byte file (present but shipping no certs → not a usable store)" do
+      f = File.tempname("gori-ca-empty", ".pem")
+      File.write(f, "")
+      begin
+        # A placeholder/zero-byte bundle at a standard path must not count as "trust available"
+        # — doing so would suppress the no-store warning while verify fails on an empty store.
+        file, dir = Gori::Proxy::Upstream.resolve_ca_source([f], [] of String)
+        file.should be_nil
+        dir.should be_nil
+      ensure
+        File.delete?(f)
+      end
+    end
+
     it "returns {nil, nil} when no candidate exists" do
       file, dir = Gori::Proxy::Upstream.resolve_ca_source(["/nonexistent/a.pem"], ["/nonexistent/dir"])
       file.should be_nil

--- a/src/gori/proxy/tls/tunnel.cr
+++ b/src/gori/proxy/tls/tunnel.cr
@@ -23,6 +23,11 @@ module Gori::Proxy::Tls
     # origin's TCP connect; a slower one simply reflects h1 (loads over h1, just not the relay).
     H2_PROBE_CONNECT_TIMEOUT = 5.seconds
 
+    # Cap on the negative ALPN cache (see @h1_only_origins) so a proxy left running against many
+    # distinct h1-only hosts can't grow it without bound. A pentest run touches at most dozens
+    # to hundreds of hosts, so the common origins are all cached long before this.
+    H1_ONLY_CACHE_MAX = 4096
+
     # Live-mutable so the TUI's settings:network toggle (Session#set_verify_upstream) can
     # flip upstream TLS verification without a restart; read per-CONNECT in `intercept`, so
     # the next tunnelled connection picks up the change.
@@ -38,6 +43,11 @@ module Gori::Proxy::Tls
                    @interceptor : Gori::Interceptor? = nil,
                    @host_overrides : Gori::HostOverrides? = nil,
                    @serve_landing : Bool = true)
+      # Origins that definitively negotiated HTTP/1.1 (not h2) on a prior probe — a repeat
+      # CONNECT skips the throwaway ALPN-reflection probe for these. See reflect_origin_h2.
+      # Bare Set, no mutex: single-threaded fibers, and the read/add don't yield (the yielding
+      # dial happens before the add), so a concurrent double-probe just re-adds idempotently.
+      @h1_only_origins = Set({String, Int32}).new
     end
 
     # TlsMitm seam: hand the connection loop the root CA (for the self-serve download
@@ -114,15 +124,26 @@ module Gori::Proxy::Tls
     # so advertising h2 for any of those stranded the client on a dead h2 tunnel (a blank page,
     # empty History). Nil falls the client back to the h1 ClientConn path, which loads normally
     # and records its own upstream errors. The cost: an h1-only origin, or a client that
-    # declines h2 (e.g. curl), spends one throwaway probe connection, closed here.
+    # declines h2 (e.g. curl), spends one throwaway probe connection, closed here — but a repeat
+    # visit to a KNOWN h1-only origin skips the probe entirely (see @h1_only_origins). This
+    # caching does NOT help the non-h2-client → h2-origin case (a curl to an h2 target still
+    # probes every connection: the probe negotiates h2, the client then takes h1, and the h2
+    # probe can't serve it) — a positive "this host is h2" cache WOULD, but a stale positive
+    # entry (origin since dropped to h1/down) would re-strand the client on a dead h2 tunnel,
+    # the exact #323 failure, so only the benign negative direction is cached.
     private def reflect_origin_h2(host : String, port : Int32) : OpenSSL::SSL::Socket::Client?
       return nil unless h2_candidate?(host)
+      return nil if @h1_only_origins.includes?({host, port}) # known h1-only: skip the probe
       # Cap the connect wait so an unreachable origin doesn't burn the full timeout here before
       # the h1 fallback re-dials and waits again (never longer than the configured timeout).
       timeout = {Gori::Settings.connect_timeout, H2_PROBE_CONNECT_TIMEOUT}.min
       upstream = Proxy::Upstream.dial_tls(host, port, verify: @verify_upstream, alpn: "h2",
         connect_timeout: timeout, overrides: @host_overrides)
       return upstream if upstream && upstream.alpn_protocol == "h2"
+      # Remember a DEFINITIVE h1 negotiation (handshake completed, ALPN != h2) so repeat visits
+      # skip the probe. Never cache a nil dial — that's a transient reach/verify failure, not a
+      # statement about the origin's ALPN; caching it would wrongly pin a briefly-down origin.
+      @h1_only_origins << {host, port} if upstream && @h1_only_origins.size < H1_ONLY_CACHE_MAX
       upstream.try(&.close) rescue nil
       nil
     end

--- a/src/gori/proxy/tls/tunnel.cr
+++ b/src/gori/proxy/tls/tunnel.cr
@@ -6,9 +6,7 @@ require "../conn/client_conn"
 require "../upstream"
 require "../socket_tuning"
 require "../h2/relay"
-require "../codec/message"
 require "../../host_overrides"
-require "../../flow_mapper"
 require "./cert_authority"
 
 module Gori::Proxy::Tls
@@ -18,6 +16,13 @@ module Gori::Proxy::Tls
   # loop with the upstream pinned to the CONNECT target over a TLS client
   # connection — so the same codec/capture path serves decrypted traffic.
   class Tunnel < Proxy::TlsMitm
+    # Connect timeout for the ALPN-reflection probe (see reflect_origin_h2). Capped well below
+    # the full connect timeout: the probe only CLASSIFIES the origin's ALPN, and an unreachable
+    # origin would otherwise burn the full timeout here AND again when the h1 fallback re-dials
+    # — doubling the wait a browser sees before its 502. 5s is generous for any reachable
+    # origin's TCP connect; a slower one simply reflects h1 (loads over h1, just not the relay).
+    H2_PROBE_CONNECT_TIMEOUT = 5.seconds
+
     # Live-mutable so the TUI's settings:network toggle (Session#set_verify_upstream) can
     # flip upstream TLS verification without a restart; read per-CONNECT in `intercept`, so
     # the next tunnelled connection picks up the change.
@@ -54,15 +59,12 @@ module Gori::Proxy::Tls
     end
 
     def intercept(host : String, port : Int32, client : IO, sink : Proxy::FlowSink) : Nil
-      # Don't advertise h2 — forcing the client to HTTP/1.1, the ClientConn path —
-      # when the sandbox is on, OR intercept is on for this host, OR Match&Replace rules
-      # are live. h2's HPACK-encoded heads never reach the HeadRewriter/interceptor seams
-      # (nor ClientConn's sandbox block), so the fast h2 relay would silently skip all of
-      # them. Sandbox forces h1 for EVERY MITM'd host so the per-request block always runs;
-      # out-of-scope, sandbox-off, intercept-off, rule-less hosts keep the fast h2 relay.
-      advertise_h2 = !(@interceptor.try(&.sandbox_enabled?) ||
-                       @interceptor.try(&.intercepts_host?(host)) || @rewriter.try(&.active?))
-      server_ctx = @ca.context_for(host, advertise_h2: advertise_h2)
+      # ALPN reflection (#323): advertise h2 to the client only when the ORIGIN speaks it. A
+      # non-nil result is a live upstream already confirmed h2 (reflect_origin_h2 dials it and
+      # keeps it for reuse); nil means fall the client back to the h1 path. See that helper.
+      upstream = reflect_origin_h2(host, port)
+
+      server_ctx = @ca.context_for(host, advertise_h2: !upstream.nil?)
       # sync_close: true is REQUIRED, not cosmetic. The h2/ws relays tear down by
       # closing the socket the *other* pump fiber is mid-read on, to unblock it.
       # With sync_close: false, OpenSSL::SSL::Socket#close does a *bidirectional*
@@ -77,11 +79,16 @@ module Gori::Proxy::Tls
       client_tls = OpenSSL::SSL::Socket::Server.new(client, server_ctx, sync_close: true, accept: true)
       client_tls.sync = true
 
-      # ALPN routing: if the client negotiated h2 with us, run the h2 relay
-      # (end-to-end h2, raw-frame capture); otherwise the normal h1 path.
-      if client_tls.alpn_protocol == "h2"
-        intercept_h2(host, port, client_tls, sink)
+      # ALPN routing: if the client negotiated h2 with us, run the h2 relay (end-to-end h2,
+      # raw-frame capture) over the upstream we already confirmed speaks h2; otherwise the
+      # normal h1 path. A non-nil `upstream` is guaranteed whenever the client could have picked
+      # h2 (we only advertised h2 in that case).
+      if client_tls.alpn_protocol == "h2" && (up = upstream)
+        upstream = nil # ownership transfers to relay_h2 (its ensure closes it)
+        relay_h2(host, port, client_tls, up, sink)
       else
+        upstream.try(&.close) rescue nil # client took h1: an h2 probe socket can't serve it
+        upstream = nil
         Proxy::ClientConn.new(
           client_tls, "https", sink,
           fixed_host: host, fixed_port: port,
@@ -94,30 +101,48 @@ module Gori::Proxy::Tls
       # Client refused our cert (CA not trusted) or handshake failed: there's
       # nothing decrypted to capture. The outer connection is torn down.
     ensure
+      upstream.try(&.close) rescue nil # a probe orphaned by a failed client handshake
       client_tls.try(&.close) rescue nil
     end
 
-    # End-to-end h2: dial the origin offering h2. A tunnel we can't build is
-    # recorded as a visible error flow (see record_h2_error) rather than dropped
-    # silently — most browsers negotiate h2 by default, so a silent drop here left
-    # the user with a blank page and an empty History and no hint of the cause (#323).
-    private def intercept_h2(host : String, port : Int32, client_tls : IO, sink : Proxy::FlowSink) : Nil
-      upstream = Proxy::Upstream.dial_tls(host, port, verify: @verify_upstream, alpn: "h2", overrides: @host_overrides)
-      if upstream.nil?
-        # Couldn't reach or TLS-verify the origin — no h2 tunnel to build. The most common
-        # cause behind #323: upstream-cert verification failing when the (statically-linked)
-        # binary can't resolve a system trust store. The h1 path already surfaces this via
-        # ClientConn#record_error; bring h2 to parity instead of dropping the connection.
-        record_h2_error(host, port, sink, "upstream connect/TLS-verify failed: #{host}:#{port}")
-        return
-      end
-      unless upstream.alpn_protocol == "h2"
-        # Origin won't speak h2; v1 does not translate h2↔h1 (a translated flow would be
-        # corrupted, P7). Record WHY rather than dropping silently — an Error flow is an
-        # honest projection, not a corrupted one.
-        record_h2_error(host, port, sink, "origin did not negotiate HTTP/2 (h2↔h1 not supported): #{host}:#{port}")
-        return
-      end
+    # ALPN reflection probe (#323). When this host is an h2 candidate, pre-dial the origin
+    # offering h2 BEFORE the client handshake and return the socket ONLY if the origin
+    # negotiated h2 — the caller then advertises h2 to the client and hands this same socket to
+    # the relay (reused, not re-dialed), so the common browser→h2-origin path adds no extra
+    # origin connection: the dial just moves ahead of the client handshake. Returns nil for a
+    # non-candidate, an h1-only origin, or an unreachable origin — v1 has no h2↔h1 translation,
+    # so advertising h2 for any of those stranded the client on a dead h2 tunnel (a blank page,
+    # empty History). Nil falls the client back to the h1 ClientConn path, which loads normally
+    # and records its own upstream errors. The cost: an h1-only origin, or a client that
+    # declines h2 (e.g. curl), spends one throwaway probe connection, closed here.
+    private def reflect_origin_h2(host : String, port : Int32) : OpenSSL::SSL::Socket::Client?
+      return nil unless h2_candidate?(host)
+      # Cap the connect wait so an unreachable origin doesn't burn the full timeout here before
+      # the h1 fallback re-dials and waits again (never longer than the configured timeout).
+      timeout = {Gori::Settings.connect_timeout, H2_PROBE_CONNECT_TIMEOUT}.min
+      upstream = Proxy::Upstream.dial_tls(host, port, verify: @verify_upstream, alpn: "h2",
+        connect_timeout: timeout, overrides: @host_overrides)
+      return upstream if upstream && upstream.alpn_protocol == "h2"
+      upstream.try(&.close) rescue nil
+      nil
+    end
+
+    # Whether this host may take the fast h2 relay at all. FALSE — forcing HTTP/1.1, the
+    # ClientConn path — when the sandbox is on, OR intercept is on for this host, OR
+    # Match&Replace rules are live: h2's HPACK-encoded heads never reach the
+    # HeadRewriter/interceptor seams (nor ClientConn's sandbox block), so the relay would
+    # silently skip all of them. Out-of-scope, sandbox-off, intercept-off, rule-less hosts are
+    # candidates (subject to the origin actually speaking h2 — see reflect_origin_h2).
+    private def h2_candidate?(host : String) : Bool
+      !(@interceptor.try(&.sandbox_enabled?) ||
+        @interceptor.try(&.intercepts_host?(host)) || @rewriter.try(&.active?))
+    end
+
+    # End-to-end h2 relay over an upstream ALREADY dialed (and confirmed h2) by `intercept`.
+    # Reusing that socket is what keeps the common browser→h2-origin path at a single origin
+    # connection. Owns `upstream` — closes it on teardown.
+    private def relay_h2(host : String, port : Int32, client_tls : IO,
+                         upstream : OpenSSL::SSL::Socket::Client, sink : Proxy::FlowSink) : Nil
       upstream.sync = true
       # Long-lived end-to-end h2 relay: relax both legs so an idle h2 connection isn't reaped
       # (keepalive on both underlying sockets reaps a dead peer). Resolves through the TLS wrap.
@@ -125,24 +150,7 @@ module Gori::Proxy::Tls
       Proxy::SocketTuning.relax(upstream)
       Proxy::H2::Relay.run(client_tls, upstream, host, port, sink)
     ensure
-      upstream.try(&.close) rescue nil
-    end
-
-    # Record a VISIBLE error flow for an h2 tunnel we could not establish, mirroring the
-    # h1 path's ClientConn#record_error. `head` is a synthesized marker: the real h2 request
-    # frames were never relayed or decoded (the failure is before the relay), so there is no
-    # wire request to capture — the raw-frame log stays the truth for real h2 flows (P7).
-    # Best-effort: a store error here must not take down the tunnel teardown.
-    private def record_h2_error(host : String, port : Int32, sink : Proxy::FlowSink, message : String) : Nil
-      created_at = (Time.utc - Time::UNIX_EPOCH).total_microseconds.to_i64
-      head = "GET / HTTP/2\r\nHost: #{host}\r\n\r\n".to_slice
-      req = Proxy::Codec::RawRequest.new(head, "GET", "/", "HTTP/2",
-        Proxy::Codec::HeaderList.new([Proxy::Codec::Header.new("Host", host)]))
-      flow_id = sink.on_request(FlowMapper.request(req,
-        scheme: "https", host: host, port: port, created_at: created_at, alpn: "h2"))
-      sink.on_response(FlowMapper.error_response(flow_id, message))
-    rescue
-      # never let error-recording take down the tunnel teardown path
+      upstream.close rescue nil
     end
   end
 end

--- a/src/gori/proxy/upstream.cr
+++ b/src/gori/proxy/upstream.cr
@@ -4,6 +4,16 @@ require "../settings"
 require "../host_overrides"
 require "./socket_tuning"
 
+# OpenSSL's own compiled-in default trust locations — the paths SSL_CTX_set_default_verify_paths
+# consults. Not bound by the stdlib, so declared here to let the no-store warning reflect the
+# store OpenSSL ACTUALLY uses rather than a guessed path list. Reopening the stdlib's LibCrypto
+# inherits its @[Link], so no extra linker directive is needed; both symbols are stable,
+# long-standing C API present in OpenSSL and LibreSSL alike.
+lib LibCrypto
+  fun x509_get_default_cert_file = X509_get_default_cert_file : Char*
+  fun x509_get_default_cert_dir = X509_get_default_cert_dir : Char*
+end
+
 module Gori::Proxy
   # Dials origin servers and parses authorities. A dialed upstream is reused across a
   # single client connection's keep-alive requests (see ClientConn#acquire_upstream) and
@@ -255,13 +265,32 @@ module Gori::Proxy
     # both load an empty store (verify still fails) AND suppress the startup warning in exactly
     # the no-store case it exists for. Pure (no ENV, no side effects) so it is unit-testable.
     def self.resolve_ca_source(files = SYSTEM_CA_FILES, dirs = SYSTEM_CA_DIRS) : {String?, String?}
-      if f = files.find { |p| File.file?(p) }
+      if f = files.find { |p| ca_file_usable?(p) }
         {f, nil}
-      elsif d = dirs.find { |p| Dir.exists?(p) && !Dir.empty?(p) }
+      elsif d = dirs.find { |p| ca_dir_usable?(p) }
         {nil, d}
       else
         {nil, nil}
       end
+    end
+
+    # A readable, NON-EMPTY regular file. Non-empty because a zero-byte placeholder bundle at
+    # a standard path would otherwise count as "trust available", suppressing the no-store
+    # warning while verification silently fails against an empty store. rescue-guarded: a
+    # permission error (or a TOCTOU with the Dir.exists? guard) on a probed path must not
+    # propagate out of the startup warning check — print_banner has no rescue around it, and
+    # apply_system_trust already swallows the same failures on the load side.
+    private def self.ca_file_usable?(path : String) : Bool
+      File.file?(path) && File.size(path) > 0
+    rescue
+      false
+    end
+
+    # A present, non-empty directory. Same rescue rationale as ca_file_usable?.
+    private def self.ca_dir_usable?(path : String) : Bool
+      Dir.exists?(path) && !Dir.empty?(path)
+    rescue
+      false
     end
 
     # SSL_CERT_FILE / SSL_CERT_DIR are already honoured by SSL_CTX_set_default_verify_paths
@@ -294,8 +323,28 @@ module Gori::Proxy
     # on this together with verify being on.
     def self.system_trust_available? : Bool
       return true if env_ca_override?
+      return true if openssl_default_store_populated?
       file, dir = resolve_ca_source
       !(file.nil? && dir.nil?)
+    end
+
+    # Is OpenSSL's OWN default trust store (the OPENSSLDIR paths compiled into the linked
+    # libcrypto) actually populated? A statically-linked musl build's compiled-in path resolves
+    # to nothing — the #323 case the warning exists for — but a normal dynamic build (e.g. a
+    # Homebrew macOS openssl@3) has a populated default that the hardcoded SYSTEM_CA_* list
+    # would MISS, producing a spurious warning even though verification works. Consulting the
+    # real default paths keeps the warning accurate on both. Fully guarded — a getter returning
+    # null / an unreadable path must never propagate out of the startup check.
+    private def self.openssl_default_store_populated? : Bool
+      file = default_cert_path(LibCrypto.x509_get_default_cert_file)
+      dir = default_cert_path(LibCrypto.x509_get_default_cert_dir)
+      !!((file && ca_file_usable?(file)) || (dir && ca_dir_usable?(dir)))
+    rescue
+      false
+    end
+
+    private def self.default_cert_path(ptr : LibCrypto::Char*) : String?
+      ptr.null? ? nil : String.new(ptr).presence
     end
 
     # A one-line operator hint when NO trust store can be resolved (a statically-linked


### PR DESCRIPTION
Follow-up to the recent certificate-handling work (#332, #333). A review of that
work surfaced one behavioral flaw and three trust-store-warning gaps; this fixes
them and adds an ALPN cache.

## What & why

**Reflect origin ALPN (fabb2ac) — the behavioral flaw.**
When gori advertised h2 to the client but the origin only spoke HTTP/1.1, v1 had
no h2↔h1 translation, so the client was stranded on a dead h2 tunnel — a blank
page and empty History (#323). #332 made that failure *visible*; it didn't fix
it. `intercept` now pre-dials the origin offering h2 **before** the client
handshake and advertises h2 to the client only when the origin actually
negotiated it. The pre-dialed socket is **reused** by the relay when the client
also takes h2, so the common browser→h2-origin path adds no extra origin
connection — the dial just moves ahead of the client handshake. An h1-only or
unreachable origin reflects h1 and falls through to the h1 `ClientConn` path,
which loads normally and records its own upstream errors, so the now-superseded
`record_h2_error` phantom-flow path is removed. The classification probe uses a
capped connect timeout so an unreachable origin doesn't burn the full timeout
twice.

**Harden the trust-store warning (37b24a7).** Three fixes to the #333 no-store
warning: consult OpenSSL's own default trust paths (`X509_get_default_cert_file/dir`)
so a populated OPENSSLDIR that isn't in the hardcoded probe list (e.g. Homebrew
macOS) no longer warns spuriously; require a probed CA file to be non-empty so a
zero-byte placeholder doesn't suppress the warning while verify silently fails;
and rescue-guard the file/dir probes so a permission/TOCTOU error can't crash
startup via `print_banner`.

**Cache h1-only origins (71ac475).** Remember origins that definitively
negotiated h1 so a repeat CONNECT skips the throwaway ALPN probe. Negative-only
by design — a stale negative entry is benign, whereas a stale positive entry
would re-strand the client on a dead h2 tunnel (the #323 failure).

## Testing
- `crystal spec spec/proxy/` — 257 examples, 0 failures (adds: h2→h2 relay
  socket-reuse round-trip, h1-only origin loads via h1, unreachable origin
  records an h1 error, h1-only ALPN cache skips the probe on repeat, zero-byte
  CA file).
- Full `crystal build --no-codegen` type-check + ameba clean on changed files.
- Manual smoke: `curl --http2` through gori to a real h2 origin → 200 over h2,
  flow captured, verify-upstream on with no spurious warning.

Refs #323