### PR TITLE
fix(mcp,proxy,tui): tool-stability hardening + Repeater ^N Host auto-sync

### DIFF
--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -1082,6 +1082,43 @@ describe Gori::MCP::Server do
         payload["project_slug"].as_s.should eq("demo")
       end
     end
+
+    it "redacts sensitive headers in the nested tui_repeater snapshot unless include_sensitive" do
+      with_store do |store|
+        req = "GET / HTTP/1.1\r\nHost: ex.test\r\nAuthorization: Bearer s3cr3t\r\nCookie: sid=abc\r\n\r\n"
+        ui = JSON.build do |j|
+          j.object do
+            j.field "active_tab", "repeater"
+            j.field "repeater" do
+              j.object do
+                j.field "count", 1
+                j.field "active" do
+                  j.object do
+                    j.field "http2", false
+                    j.field "request", req # NESTED under "active" — the real TUI shape
+                  end
+                end
+              end
+            end
+          end
+        end
+        store.set_setting(Gori::Store::UI_STATE_KEY, ui)
+
+        # Default (include_sensitive:false): the nested request's credential values must be redacted.
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_repeater_context","arguments":{"include_content":true}}})
+        redacted = tool_payload(drive(store, call, project_name: "demo", project_slug: "demo")[0])
+        text = redacted["tui_repeater"]["active"]["request"].as_s
+        text.should_not contain("s3cr3t")
+        text.should_not contain("sid=abc")
+        text.should contain("[REDACTED]")
+        redacted["sensitive_headers_redacted"].as_bool.should be_true
+
+        # include_sensitive:true passes the raw request through (matches the sessions[] policy).
+        call2 = %({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_repeater_context","arguments":{"include_content":true,"include_sensitive":true}}})
+        raw = tool_payload(drive(store, call2, project_name: "demo", project_slug: "demo")[0])
+        raw["tui_repeater"]["active"]["request"].as_s.should contain("s3cr3t")
+      end
+    end
   end
 
   describe "get_current_context" do
@@ -1389,19 +1426,54 @@ describe Gori::MCP::Server do
     end
 
     # A `raw` template's request line is taken VERBATIM (request_target in send.cr),
-    # so it can be ABSOLUTE-FORM (`GET http://host/path HTTP/1.1`) — same wire shape a
-    # plain-HTTP forward-proxy request arrives in. The scope check must not double it
-    # into `http://hosthttp://host/path` (which would break this anchored regex include
-    # and wrongly report the in-scope target as unscoped/out-of-scope).
+    # so it can be ABSOLUTE-FORM (`GET http://host/path HTTP/1.1`). The scope check
+    # anchors on the DIAL host (built.host) reduced to origin-form, so an absolute-form
+    # line whose host matches `url` still resolves in-scope (no URL doubling, host keyed
+    # without port to match Scope.request_url's origin-form convention).
     it "reports in_scope for a raw request whose line is already ABSOLUTE-FORM" do
       with_store do |store|
         port = start_mcp_http_origin("ok")
-        store.add_scope_rule("include", "regex", "^http://127\\.0\\.0\\.1:#{port}/$")
+        store.add_scope_rule("include", "regex", "^http://127\\.0\\.0\\.1/")
         raw = "GET http://127.0.0.1:#{port}/ HTTP/1.1\\r\\nHost: 127.0.0.1:#{port}\\r\\n\\r\\n"
         call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"send_request","arguments":{"url":"http://127.0.0.1:#{port}/","raw":"#{raw}"}}})
         p = tool_payload(drive(store, call, verify_upstream: false)[0])
         p["scope_decision"].as_s.should eq("in_scope")
         p["scope_rule_id"].as_i64.should be > 0
+      end
+    end
+
+    # Host-header attack / cache-poisoning / SSRF-via-absolute-form: the caller DELIBERATELY
+    # spoofs the request-line host to a DIFFERENT (here out-of-scope) host while dialing the
+    # in-scope `url`. gori must ALLOW this and scope on the host it actually dials, so the
+    # test proceeds against the in-scope origin and the spoofed line rides along verbatim.
+    it "allows a deliberately spoofed request-line host, scoping on the dialed host" do
+      with_store do |store|
+        port = start_mcp_http_origin("ok")
+        store.add_scope_rule("include", "regex", "^http://127\\.0\\.0\\.1/")
+        raw = "GET http://evil.example/ HTTP/1.1\\r\\nHost: evil.example\\r\\n\\r\\n"
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"send_request","arguments":{"url":"http://127.0.0.1:#{port}/","raw":"#{raw}"}}})
+        p = tool_payload(drive(store, call, verify_upstream: false)[0])
+        p["scope_decision"].as_s.should eq("in_scope") # scoped on the dialed 127.0.0.1, not the spoofed line
+      end
+    end
+
+    # The converse (the bypass this closes): dialing an OUT-of-scope host while the
+    # absolute-form line names the in-scope host must NOT report in_scope — the scope
+    # decision follows the dialed host, so this is blocked without allow_unscoped.
+    it "scopes a raw absolute-form send on the dialed host, not the request-line host (no bypass)" do
+      with_store do |store|
+        port = start_mcp_http_origin("ok")
+        store.add_scope_rule("include", "string", "127.0.0.1")
+        # Absolute-form line names the in-scope 127.0.0.1, but `url` dials the out-of-scope
+        # 10.99.99.99. The gate follows the DIALED host → blocked (no allow_unscoped), and
+        # nothing is sent (so the unroutable IP is never actually dialed).
+        raw = "GET http://127.0.0.1:#{port}/ HTTP/1.1\\r\\nHost: 127.0.0.1:#{port}\\r\\n\\r\\n"
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"send_request","arguments":{"url":"http://10.99.99.99:#{port}/","raw":"#{raw}"}}})
+        resp = drive(store, call, verify_upstream: false)[0]
+        resp["result"]["isError"].as_bool.should be_true
+        sc = resp["result"]["structuredContent"]
+        sc["error_code"].as_s.should eq("SCOPE_BLOCKED")
+        sc["details"]["scope_decision"].as_s.should eq("out_of_scope")
       end
     end
   end
@@ -1947,19 +2019,6 @@ describe Gori::MCP::Serialize do
     text.should contain("A")
   end
 
-  it "flags a repeater result as incomplete when the origin cut the body short" do
-    head = "HTTP/1.1 200 OK\r\n\r\n".to_slice
-    r = Gori::Repeater::Result.new(head, "hi".to_slice, nil, 1000_i64, incomplete: true)
-    out = JSON.parse(Gori::MCP::Serialize.repeater_result_json(r))
-    out["incomplete"].as_bool.should be_true
-  end
-
-  it "omits the incomplete field for a complete repeater result" do
-    head = "HTTP/1.1 200 OK\r\n\r\n".to_slice
-    r = Gori::Repeater::Result.new(head, "hi".to_slice, nil, 1000_i64)
-    out = JSON.parse(Gori::MCP::Serialize.repeater_result_json(r))
-    out["incomplete"]?.should be_nil
-  end
 end
 
 describe Gori::MCP::RequestBuilder do

--- a/spec/proxy/codec/body_spec.cr
+++ b/spec/proxy/codec/body_spec.cr
@@ -98,6 +98,29 @@ describe "Gori::Proxy::Codec::Body.read_complete" do
     complete.should be_true
   end
 
+  # C1: the capture-only read (Repeater/Fuzz/Miner) bounds the body at max_bytes so a
+  # streaming or oversized origin can't OOM/hang the single-threaded caller.
+  it "caps a close-delimited body at max_bytes and reports it INCOMPLETE (not a false EOF)" do
+    src = IO::Memory.new("x" * 100)
+    bytes, complete = Body.read_complete(src, BodyFraming::CloseDelimited, 0_i64, max_bytes: 10_i64)
+    bytes.not_nil!.size.should eq(10)
+    complete.should be_false # the cap surfaces as an IO::Sized EOF — must NOT read as the real end
+  end
+
+  it "caps a Content-Length body at max_bytes and reports INCOMPLETE" do
+    src = IO::Memory.new("y" * 100)
+    bytes, complete = Body.read_complete(src, BodyFraming::Length, 100_i64, max_bytes: 10_i64)
+    bytes.not_nil!.size.should eq(10)
+    complete.should be_false
+  end
+
+  it "does not cap when max_bytes is unset (proxy forward path stays byte-exact/uncapped)" do
+    src = IO::Memory.new("z" * 100)
+    bytes, complete = Body.read_complete(src, BodyFraming::CloseDelimited, 0_i64)
+    bytes.not_nil!.size.should eq(100)
+    complete.should be_true
+  end
+
   it "reports complete with a nil body for None framing" do
     bytes, complete = Body.read_complete(IO::Memory.new(""), BodyFraming::None, 0_i64)
     bytes.should be_nil

--- a/spec/tui/repeater_view_spec.cr
+++ b/spec/tui/repeater_view_spec.cr
@@ -87,6 +87,83 @@ describe Gori::Tui::RepeaterView do
     backend.contains?("— not sent — press ^R to resend —").should be_true
   end
 
+  it "mirrors the target host into the Host header on the first edit of a blank tab" do
+    view = RepeaterView.new
+    view.load_blank
+    view.request_text.should contain("Host: example.com") # the placeholder Host
+
+    # Simulate replacing the target and leaving insert mode (the ^N → edit-target flow).
+    view.enter_target_insert!
+    view.target.size.times { view.target_backspace }
+    "https://real.test".each_char { |c| view.target_insert(c) }
+    view.exit_target_insert!
+
+    view.target.should eq("https://real.test")
+    view.request_text.should contain("Host: real.test")
+    view.request_text.should_not contain("Host: example.com")
+  end
+
+  it "keeps a non-default port in the mirrored Host header" do
+    view = RepeaterView.new
+    view.load_blank
+    view.enter_target_insert!
+    view.target.size.times { view.target_backspace }
+    "https://real.test:8443".each_char { |c| view.target_insert(c) }
+    view.exit_target_insert!
+    view.request_text.should contain("Host: real.test:8443")
+  end
+
+  it "syncs the Host only ONCE — a later target edit never re-clobbers it" do
+    view = RepeaterView.new
+    view.load_blank
+    view.enter_target_insert!
+    view.target.size.times { view.target_backspace }
+    "https://real.test".each_char { |c| view.target_insert(c) }
+    view.exit_target_insert! # first edit → Host synced to real.test
+
+    # A second target change must NOT re-sync (so a hand-set Host survives).
+    view.enter_target_insert!
+    view.target.size.times { view.target_backspace }
+    "https://other.test".each_char { |c| view.target_insert(c) }
+    view.exit_target_insert!
+
+    view.target.should eq("https://other.test")
+    view.request_text.should contain("Host: real.test") # NOT re-synced to other.test
+  end
+
+  # ^R sends WITHOUT leaving target-insert (a modified chord defers past exit_target_insert!),
+  # so repeater_send calls sync_host_to_target_once at send prep. Mimic that: type the target
+  # but never exit insert, then run the send-time hook.
+  it "mirrors the Host at send time even if the target edit never left insert mode" do
+    view = RepeaterView.new
+    view.load_blank
+    view.enter_target_insert!
+    view.target.size.times { view.target_backspace }
+    "https://real.test".each_char { |c| view.target_insert(c) }
+    view.sync_host_to_target_once # what repeater_send does beside commit_chain_pane (no exit_target_insert!)
+    view.request_text.should contain("Host: real.test")
+    view.request_text.should_not contain("Host: example.com")
+  end
+
+  # The clobber guard: leaving the target for the body must SPEND the one-shot, so a Host the
+  # user then sets by hand (a deliberate Host≠target mismatch — Host-header attack) is never
+  # overwritten by the send-time hook. This is why the primary trigger is focus-leave.
+  it "never clobbers a hand-set Host once focus has left the target" do
+    view = RepeaterView.new
+    view.load_blank
+    view.enter_target_insert!
+    view.target.size.times { view.target_backspace }
+    "https://real.test".each_char { |c| view.target_insert(c) }
+    view.focus_pane(:request) # leaving the target flushes the link AND spends the one-shot
+    view.request_text.should contain("Host: real.test")
+
+    # User deliberately sets a mismatched Host in the body, then sends.
+    view.replace_edit_buffer("GET / HTTP/1.1\nHost: evil.test\nUser-Agent: gori\n\n")
+    view.sync_host_to_target_once # send-time hook — one-shot already spent, must be a no-op
+    view.request_text.should contain("Host: evil.test")
+    view.request_text.should_not contain("Host: real.test")
+  end
+
   # The response body is styled one visible line at a time and memoized (per-line) so an
   # unrelated re-render (a keystroke in the request editor) doesn't re-tokenize the pane.
   # The memo must be dropped in lockstep with the response view — a new send, or a pretty

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -130,6 +130,13 @@ module Gori::Discover
     EVENT_BUFFER    = 256
     MAX_CONCURRENCY = 500
     MAX_BODY        = 2 * 1024 * 1024 # decoded body cap (matches Extract::MAX_SCAN)
+    # Ceiling on the dedup/template bookkeeping (@seen + @templates). The network send
+    # count is capped by @config.max_requests and crawl pages by max_pages, but @seen and
+    # @templates grow once per CONSIDERED link — bounded by pages×links, not the request
+    # cap — so a pathological target (a huge page of distinct-template links) could bloat
+    # them far past any real crawl. Once @seen hits this, consider_link stops tracking and
+    # enqueuing new links: the run keeps draining what's in flight but adds nothing new.
+    MAX_SEEN = 250_000
 
     enum State : UInt8
       Running
@@ -289,6 +296,11 @@ module Gori::Discover
     rescue ex
       # ErrorEvent is terminal (no trailing DoneEvent) so consumers don't mask the error
       # with a success Done — see the setup-error path above.
+      # Close @jobs too (the happy path does this at line ~285): otherwise the worker
+      # fibers stay parked on @jobs.receive? forever — a fiber + socket leak. Closing it
+      # makes each worker's receive? return nil, so they run their `ensure @finished.send`
+      # and exit (their one in-flight outcome fits in @discovered's conc*2 buffer).
+      @jobs.close rescue nil
       @events.send(ErrorEvent.new(ex.message || "discover error")) rescue nil
       @events.close rescue nil
     end
@@ -479,11 +491,15 @@ module Gori::Discover
     # Resolve a discovered link against its page, dedup, template-fold, bound-check, then
     # enqueue a crawl (spider) and derive a directory (brute).
     private def consider_link(task : Task, base : Url::Parts, link : RawLink) : Nil
+      # Bound the dedup/template bookkeeping: past MAX_SEEN, stop tracking + enqueuing new
+      # links so @seen/@templates can't bloat on a pathological target (see MAX_SEEN). A URL
+      # already in @seen is still cheap to skip below, so honour that first.
       abs = Url.resolve(base, link.href)
       return unless abs
       p = Url.parse(abs)
       return unless p
       key = Url.visit_key(p)
+      return if @seen.size >= MAX_SEEN && !@seen.includes?(key)
       if @seen.includes?(key)
         @dedup_suppressed += 1
         return

--- a/src/gori/env.cr
+++ b/src/gori/env.cr
@@ -288,14 +288,20 @@ module Gori
       bump_highlight_rev
     end
 
-    def self.save_project(store : Store, vars : Array({String, String})) : Nil
-      if vars.empty?
-        store.delete_setting(PROJECT_VARS_KEY)
-      else
-        store.set_setting(PROJECT_VARS_KEY, serialize_vars(vars))
-      end
+    # Returns whether the persisted write committed (false = store busy/locked). The
+    # in-memory Settings.project_env_vars is updated regardless (the TUI relies on the
+    # immediate update; an MCP caller that got false reloads from the store on its next
+    # active tool, so a rolled-back change doesn't stick).
+    def self.save_project(store : Store, vars : Array({String, String})) : Bool
+      committed =
+        if vars.empty?
+          store.delete_setting(PROJECT_VARS_KEY)
+        else
+          store.set_setting(PROJECT_VARS_KEY, serialize_vars(vars))
+        end
       Settings.project_env_vars = vars.dup
       bump_highlight_rev
+      committed
     end
 
     def self.valid_key?(key : String) : Bool

--- a/src/gori/host_overrides.cr
+++ b/src/gori/host_overrides.cr
@@ -73,16 +73,18 @@ module Gori
       return false unless HostOverrides.valid?(host, ip)
       @mutex.synchronize do
         return false if @entries.any? { |e| e.id != id && e.host == host }
-        @store.update_host_override(id, host, ip)
+        committed = @store.update_host_override(id, host, ip)
         reload_entries_unlocked
+        committed # false also when the store write rolled back (busy/locked), not just on dup
       end
-      true
     end
 
-    def remove(id : Int64) : Nil
+    # Returns whether the delete committed (false = store busy/locked/closing).
+    def remove(id : Int64) : Bool
       @mutex.synchronize do
-        @store.remove_host_override(id)
+        committed = @store.remove_host_override(id)
         reload_entries_unlocked
+        committed
       end
     end
 

--- a/src/gori/mcp/serialize.cr
+++ b/src/gori/mcp/serialize.cr
@@ -356,32 +356,6 @@ module Gori
         end
       end
 
-      # --- repeater / send_request response -------------------------------------
-      def self.repeater_result_json(r : Repeater::Result) : String
-        JSON.build do |j|
-          j.object do
-            if resp = r.response
-              j.field "status", resp.status
-              j.field "reason", resp.reason
-              j.field "http_version", resp.version
-              j.field "headers" do
-                j.array do
-                  resp.headers.each do |h|
-                    j.object { j.field "name", h.name; j.field "value", h.value }
-                  end
-                end
-              end
-            end
-            j.field "duration_us", r.duration_us
-            # The origin cut the body short (premature EOF on a Content-Length /
-            # chunked response). Surfaced top-level so it survives even an empty
-            # body, and kept distinct from a `body.truncated` display cap.
-            j.field "incomplete", true if r.incomplete?
-            emit_body(j, "body", r.head, r.body, false)
-          end
-        end
-      end
-
       # Heads are short and ASCII-ish; render as (lossy-on-display) text. nil head
       # (e.g. a Pending flow's response) becomes JSON null. `scrub` guards a
       # malformed/binary head from emitting invalid UTF-8 that would corrupt the

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -155,6 +155,20 @@ module Gori
 
       MCP_REPEATER_REQUEST_MAX = 16 * 1024
 
+      # Ceiling on concurrently-live OAST listening sessions (each holds an Oast::Http
+      # socket until oast_stop). Bounds the leak from an agent that starts sessions and
+      # never stops them; well above any realistic out-of-band test.
+      MAX_OAST_SESSIONS = 32
+
+      # Ceiling on how many finished jobs each of the four async-job maps
+      # (@jobs/@mine_jobs/@sequence_jobs/@discover_jobs) retains. The server is
+      # long-lived (it outlives a single call), and a completed job holds its whole
+      # buffered result set (up to FUZZ_MAX_STORED etc.) for the process lifetime, so
+      # a long session issuing many *_start calls would grow memory without bound.
+      # A new *_start evicts the OLDEST terminal jobs down to this cap; :running jobs
+      # are never evicted (their fibers still reference them and a poller may return).
+      MAX_JOBS_RETAINED = 100
+
       # Default inlined-body cap for body_mode:preview (full uses Serialize::MAX_TEXT).
       BODY_PREVIEW_BYTES = 2048
 
@@ -1197,6 +1211,11 @@ module Gori
         return Result.new("unknown provider '#{provider}'", is_error: true) unless kind
         host = str(h, "server") || Oast::Presets.all.find { |p| p.kind == kind }.try(&.host)
         return Result.new("'server' is required for #{kind.label}", is_error: true) unless host
+        # Bound the number of live sessions: each holds an Oast::Http (socket) for the
+        # process life until oast_stop, so an agent that never stops them would leak.
+        if @oast_mcp.size >= MAX_OAST_SESSIONS
+          return Result.new("too many active OAST sessions (#{@oast_mcp.size}/#{MAX_OAST_SESSIONS}); call oast_stop on one before starting another", is_error: true)
+        end
         prov = Oast::Provider.build(kind, host, str(h, "token"))
         http = Oast::HttpClient.new(@verify_upstream)
         session = prov.register(http)
@@ -1394,9 +1413,26 @@ module Gori
         {head, body}
       end
 
+      # Evict the OLDEST terminal (non-:running) jobs from `jobs` so it never grows past
+      # MAX_JOBS_RETAINED across a long session. Insertion order (Hash preserves it) is
+      # age order, so the first removable entries are the oldest. :running jobs are kept
+      # (a fiber still writes them and a poller may still read them) even past the cap.
+      # Called by each *_start just before it inserts the new job.
+      private def evict_finished_jobs(jobs : Hash(String, T)) : Nil forall T
+        return if jobs.size < MAX_JOBS_RETAINED
+        overflow = jobs.size - MAX_JOBS_RETAINED + 1 # +1 to make room for the incoming job
+        # Collect victims first, then delete — mutating a Hash mid-iteration is unsafe.
+        victims = [] of String
+        jobs.each do |key, job|
+          break if victims.size >= overflow
+          victims << key if job.status != :running
+        end
+        victims.each { |k| jobs.delete(k) }
+      end
+
       # A background job's fiber must never exit with the job still :running — that
       # hangs every poller and permanently trips jobs_running?. Land it terminal.
-      private def finalize_job(job : FuzzJob | MineJob | SequenceJob) : Nil
+      private def finalize_job(job : FuzzJob | MineJob | SequenceJob | DiscoverJob) : Nil
         if job.status == :running
           job.status = :error
           job.error_msg ||= "job ended without a terminal event"

--- a/src/gori/mcp/tools/compare.cr
+++ b/src/gori/mcp/tools/compare.cr
@@ -35,6 +35,12 @@ module Gori
         full_diff = Repeater::Diff.lines(lines_a, lines_b)
         change_count = Repeater::Diff.change_count(full_diff)
         diff = changes_only ? full_diff.reject { |dl| dl.kind == Repeater::DiffKind::Same } : full_diff
+        # Bound the emitted diff by BYTES, not just MAX_LINES (a line count). A decoded
+        # response body can be one enormous line (minified JS/JSON, a base64 data URI up
+        # to the 32 MiB decode ceiling), so a 1500-line diff could still be tens of MiB in
+        # a single JSON-RPC response. Cap each line's text and the total; flag `truncated`.
+        capped, byte_truncated = cap_diff_bytes(diff)
+        truncated ||= byte_truncated
 
         Result.new(JSON.build do |j|
           j.object do
@@ -46,16 +52,50 @@ module Gori
             j.field "truncated", truncated
             j.field "diff" do
               j.array do
-                diff.each do |dl|
+                capped.each do |(kind, text)|
                   j.object do
-                    j.field "kind", dl.kind.to_s.downcase
-                    j.field "text", dl.text
+                    j.field "kind", kind
+                    j.field "text", text
                   end
                 end
               end
             end
           end
         end)
+      end
+
+      # Total byte budget for a compare_flows diff's emitted `text` (across all lines),
+      # and the per-line ceiling. Generous enough for real request/response diffs while
+      # keeping one call off the multi-MB JSON-RPC cliff every other read tool avoids.
+      COMPARE_MAX_DIFF_BYTES = 256 * 1024
+      COMPARE_MAX_LINE_BYTES = Serialize::MAX_TEXT # 64 KiB — a single huge line still shows a prefix
+
+      # Trim the diff to the byte budget: cap each line's text (byte-safe, then scrub so a
+      # cut through a multi-byte UTF-8 sequence can't emit invalid UTF-8 onto the stdio
+      # stream), stop once the total budget is spent. Returns the kept {kind, text} pairs
+      # and whether anything was trimmed.
+      private def cap_diff_bytes(diff : Array(Repeater::DiffLine)) : {Array({String, String}), Bool}
+        budget = COMPARE_MAX_DIFF_BYTES
+        kept = [] of {String, String}
+        trimmed = false
+        diff.each do |dl|
+          if budget <= 0
+            trimmed = true
+            break
+          end
+          text = dl.text
+          if text.bytesize > COMPARE_MAX_LINE_BYTES
+            text = text.byte_slice(0, COMPARE_MAX_LINE_BYTES).scrub
+            trimmed = true
+          end
+          if text.bytesize > budget
+            text = text.byte_slice(0, budget).scrub
+            trimmed = true
+          end
+          budget -= text.bytesize
+          kept << {dl.kind.to_s.downcase, text}
+        end
+        {kept, trimmed}
       end
 
       private def compare_lines(d : Store::FlowDetail, pane : Symbol, include_sensitive : Bool) : Array(String)

--- a/src/gori/mcp/tools/context.cr
+++ b/src/gori/mcp/tools/context.cr
@@ -175,7 +175,7 @@ module Gori
                 end
               end
               if include_content && (repeater = ui["repeater"]?)
-                j.field "tui_repeater", repeater
+                emit_tui_repeater(j, repeater, include_sensitive)
               elsif ui["repeater"]?
                 j.field "tui_repeater_available", true
               end
@@ -283,6 +283,40 @@ module Gori
           # invalid UTF-8 through the store, and JSON::Builder emits it verbatim — which
           # corrupts the stdio JSON-RPC stream (must be well-formed UTF-8).
           j.field field, text.scrub
+        end
+      end
+
+      # The live-TUI repeater snapshot (ui["repeater"]) is the raw editor state the human is
+      # working on; its `request` / `upgrade_request` fields are full HTTP request text whose
+      # headers carry Authorization/Cookie. The blob is persisted (and read back) VERBATIM, so
+      # — unlike the sessions[] path (emit_repeater_session, which redact_head's its request +
+      # response head) — it would bypass redaction if emitted as-is. Rebuild the object here,
+      # running redact_head over those two text fields; every other field (summary, status,
+      # ws payloads-as-body, timings) passes through unchanged. With include_sensitive the blob
+      # is emitted verbatim, matching the sessions policy and the sensitive_headers_redacted flag.
+      private def emit_tui_repeater(j : JSON::Builder, repeater : JSON::Any, include_sensitive : Bool) : Nil
+        if include_sensitive
+          j.field "tui_repeater", repeater
+          return
+        end
+        j.field("tui_repeater") { redact_tui_repeater(j, repeater, nil) }
+      end
+
+      # Re-emit the repeater snapshot with redaction. The raw-HTTP-text fields
+      # (`request` / `upgrade_request`) are NESTED under "active" (repeater_controller
+      # builds count/active_subtab/active{write_mcp_fields}), so walk recursively and run
+      # redact_head over any string reached under one of those keys, at any depth — a
+      # top-level-only pass would miss the nested request and leak its headers. Everything
+      # else passes through verbatim.
+      private def redact_tui_repeater(j : JSON::Builder, value : JSON::Any, key : String?) : Nil
+        if (key == "request" || key == "upgrade_request") && (s = value.as_s?)
+          j.string Serialize.redact_head(s, false)
+        elsif obj = value.as_h?
+          j.object { obj.each { |k, v| j.field(k) { redact_tui_repeater(j, v, k) } } }
+        elsif arr = value.as_a?
+          j.array { arr.each { |v| redact_tui_repeater(j, v, nil) } }
+        else
+          value.to_json(j)
         end
       end
 

--- a/src/gori/mcp/tools/discover.cr
+++ b/src/gori/mcp/tools/discover.cr
@@ -21,6 +21,7 @@ module Gori
           clamp(int(h, "concurrency"), 20, DISCOVER_MAX_CONCURRENCY),
           int(h, "max_requests"), Time.utc.to_unix_ms)
         djob = DiscoverJob.new(id, engine, audit)
+        evict_finished_jobs(@discover_jobs)
         @discover_jobs[id] = djob
         Log.info { "discover_start #{id} #{seed_url} scope=#{sc.decision}" }
         spawn(name: "mcp-discover-#{id}") { run_discover_job(djob, engine) }
@@ -81,24 +82,45 @@ module Gori
         ms && ms > 0 ? ms.milliseconds : nil
       end
 
+      # Background drain, mirroring run_fuzz_job/mine/sequence: a per-event rescue keeps the
+      # drain alive on a callback failure (so the engine's worker fibers, parked on
+      # @events.send, still finish and exit instead of leaking), and the ensure GUARANTEES a
+      # terminal state — a fiber that dies here must never leave the job wedged at :running,
+      # which would hang a polling client forever and keep jobs_running? true (blocking
+      # switch_project/delete_project). The discover engine already emits a terminal event on
+      # every path, but this net matches the other three jobs so a future change can't regress.
       private def run_discover_job(djob : DiscoverJob, engine : Discover::Engine) : Nil
         base_ts = Time.utc.to_unix * 1_000_000
-        engine.run do |ev|
-          case ev
-          when Discover::FindingEvent then store_discover_finding(djob, ev.finding, base_ts)
-          when Discover::ProgressEvent
-            p = ev.progress
-            djob.sent = p.sent; djob.found = p.found; djob.errors = p.errors; djob.queued = p.queued
-          when Discover::DoneEvent
-            djob.sent = ev.progress.sent; djob.found = ev.progress.found; djob.errors = ev.progress.errors
-            djob.stats = ev.stats
-            djob.status = ev.stopped ? :stopped : :done
-            djob.ended_at_ms = Time.utc.to_unix_ms
-          when Discover::ErrorEvent
-            djob.status = :error
-            djob.error_msg = ev.message
-          end
+        engine.run { |ev| drain_discover_event(djob, ev, base_ts) }
+      rescue ex
+        Log.error(exception: ex) { "discover job #{djob.id} crashed" }
+        djob.error_msg ||= ex.message || "internal discover job error"
+      ensure
+        finalize_job(djob)
+      end
+
+      # Apply one discover event to the job, contained: a callback failure records the error
+      # and marks the job but never unwinds out of engine.run.
+      private def drain_discover_event(djob : DiscoverJob, ev : Discover::Event, base_ts : Int64) : Nil
+        case ev
+        when Discover::FindingEvent then store_discover_finding(djob, ev.finding, base_ts)
+        when Discover::ProgressEvent
+          p = ev.progress
+          djob.sent = p.sent; djob.found = p.found; djob.errors = p.errors; djob.queued = p.queued
+        when Discover::DoneEvent
+          djob.sent = ev.progress.sent; djob.found = ev.progress.found; djob.errors = ev.progress.errors
+          djob.stats = ev.stats
+          djob.status = ev.stopped ? :stopped : :done
+          djob.ended_at_ms = Time.utc.to_unix_ms
+        when Discover::ErrorEvent
+          djob.status = :error
+          djob.error_msg = ev.message
+          djob.ended_at_ms ||= Time.utc.to_unix_ms # parity with fuzz/mine/sequence — a terminal error stamps end time
         end
+      rescue ex
+        Log.error(exception: ex) { "discover job #{djob.id} drain error" }
+        djob.status = :error if djob.status == :running
+        djob.error_msg ||= ex.message || "internal discover drain error"
       end
 
       # Buffer the finding for discover_results AND write it into the project so list_sitemap /

--- a/src/gori/mcp/tools/env.cr
+++ b/src/gori/mcp/tools/env.cr
@@ -35,7 +35,7 @@ module Gori
         else
           vars << {key, value}
         end
-        Env.save_project(store, vars)
+        return busy("env var NOT saved (store busy or unwritable); the previous value is unchanged") unless Env.save_project(store, vars)
         Result.new(JSON.build { |j| j.object { j.field "key", key; j.field "set", true } })
       end
 
@@ -46,7 +46,7 @@ module Gori
         before = vars.size
         vars.reject! { |(k, _)| k == key }
         return not_found("no env var named '#{key}'") if vars.size == before
-        Env.save_project(store, vars)
+        return busy("env var NOT deleted (store busy or unwritable); it is unchanged") unless Env.save_project(store, vars)
         Result.new(JSON.build { |j| j.object { j.field "key", key; j.field "deleted", true } })
       end
     end

--- a/src/gori/mcp/tools/flows.cr
+++ b/src/gori/mcp/tools/flows.cr
@@ -68,6 +68,10 @@ module Gori
         decoded, decode_note = options.raw ? {nil, nil} : Proxy::Codec::ContentDecode.decode(head, stored)
         bytes = decoded || stored
         total = bytes.size.to_i64
+        # The decoded view is capped at ContentDecode::MAX_OUT (decompression-bomb ceiling).
+        # At the cap, `complete:true` at the end would falsely imply the whole body — flag it
+        # so a caller knows more decoded data may exist and can page the wire bytes with raw:true.
+        decode_capped = !decoded.nil? && decoded.size >= Proxy::Codec::ContentDecode::MAX_OUT
         # An offset past the end used to silently clamp to the body end (0 bytes,
         # complete:true) — indistinguishable from a legitimate final read. Surface
         # both the requested and the effective offset plus a warning so the caller
@@ -92,6 +96,10 @@ module Gori
             j.field "total_bytes", total
             j.field "representation", decoded ? "decoded" : "raw"
             j.field "decode_note", decode_note if decode_note
+            if decode_capped
+              j.field "decode_capped", true
+              j.field "decode_cap_warning", "decoded view capped at #{Proxy::Codec::ContentDecode::MAX_OUT} bytes (decompression-bomb ceiling); more decoded data may exist beyond this — page the raw wire bytes with raw:true"
+            end
             j.field "complete", next_offset >= total
             j.field "next_offset", next_offset < total ? next_offset : nil
             if text.valid_encoding?

--- a/src/gori/mcp/tools/fuzz.cr
+++ b/src/gori/mcp/tools/fuzz.cr
@@ -29,6 +29,7 @@ module Gori
           int(h, "rate").try(&.to_f64), clamp(int(h, "concurrency"), 20, FUZZ_MAX_CONCURRENCY),
           int(h, "max_requests"), Time.utc.to_unix_ms)
         fjob = FuzzJob.new(id, total, engine, fuzz_record_policy(h), origin, http2, audit)
+        evict_finished_jobs(@jobs)
         @jobs[id] = fjob
         warn = budget_warning(total, int(h, "max_requests"))
         # Audit on STDERR — never STDOUT (reserved for JSON-RPC).

--- a/src/gori/mcp/tools/host_overrides.cr
+++ b/src/gori/mcp/tools/host_overrides.cr
@@ -59,7 +59,7 @@ module Gori
         return err(id_error(h, "id"), "INVALID_ARGUMENT", field: "id") unless id
         ov = HostOverrides.load(store)
         return not_found("no host override with id #{id}") unless ov.entries.any? { |e| e.id == id }
-        ov.remove(id)
+        return busy("host override NOT deleted (store busy or unwritable); it is unchanged") unless ov.remove(id)
         Result.new(JSON.build { |j| j.object { j.field "id", id; j.field "deleted", true } })
       end
     end

--- a/src/gori/mcp/tools/import.cr
+++ b/src/gori/mcp/tools/import.cr
@@ -22,6 +22,11 @@ module Gori
         path = str(h, "path").try(&.strip)
         return err("missing required 'path'", "INVALID_ARGUMENT", field: "path") if path.nil? || path.empty?
         result = Import.import_file(store, kind, path)
+        # import_file RAISES when the parse yields zero flows, so it only returns here with
+        # ≥1 flow to insert. A count of 0 therefore means the batch write was rolled back
+        # (store busy/locked) — NOT an empty import — so surface it as retryable rather than
+        # reporting a silent "imported 0".
+        return busy("import parsed flows but persisted none (store busy or unwritable); retry") if result.count == 0
         Result.new(JSON.build do |j|
           j.object do
             j.field "kind", kind_s

--- a/src/gori/mcp/tools/issues.cr
+++ b/src/gori/mcp/tools/issues.cr
@@ -111,7 +111,7 @@ module Gori
         end
 
         unless title.nil? && severity.nil? && notes.nil? && status.nil?
-          store.update_issue(id, title: title, severity: severity, notes: notes, status: status)
+          return busy("issue NOT updated (store busy or unwritable); it is unchanged") unless store.update_issue(id, title: title, severity: severity, notes: notes, status: status)
         end
         if repeater_id
           store.add_link(Store::LinkOwnerKind::Issue, id,

--- a/src/gori/mcp/tools/mine.cr
+++ b/src/gori/mcp/tools/mine.cr
@@ -20,6 +20,7 @@ module Gori
           int(h, "rate").try(&.to_f64), clamp(int(h, "concurrency"), 10, MINE_MAX_CONCURRENCY),
           int(h, "max_requests"), Time.utc.to_unix_ms)
         mjob = MineJob.new(id, total, engine, audit)
+        evict_finished_jobs(@mine_jobs)
         @mine_jobs[id] = mjob
         Log.info { "mine_start #{id} #{origin.scheme}://#{origin.host}:#{origin.port} scope=#{sc.decision} names=#{total}" }
         spawn(name: "mcp-mine-#{id}") { run_mine_job(mjob, engine) }

--- a/src/gori/mcp/tools/notes.cr
+++ b/src/gori/mcp/tools/notes.cr
@@ -52,7 +52,7 @@ module Gori
         new_next_id = new_id + 1
 
         serialized = Notes.serialize(new_cur, new_notes, new_next_id)
-        store.set_setting(Notes::DOCS_KEY, serialized)
+        return busy("note NOT saved (store busy or unwritable); nothing was persisted") unless store.set_setting(Notes::DOCS_KEY, serialized)
 
         Result.new(JSON.build do |j|
           j.object do
@@ -77,7 +77,7 @@ module Gori
         new_notes[entry_idx] = updated_entry
 
         serialized = Notes.serialize(doc.cur, new_notes, doc.next_id)
-        store.set_setting(Notes::DOCS_KEY, serialized)
+        return busy("note NOT updated (store busy or unwritable); it is unchanged") unless store.set_setting(Notes::DOCS_KEY, serialized)
 
         Result.new(JSON.build do |j|
           j.object do
@@ -100,7 +100,7 @@ module Gori
         new_cur = doc.cur.clamp(0, {new_notes.size - 1, 0}.max)
 
         serialized = Notes.serialize(new_cur, new_notes, doc.next_id)
-        store.set_setting(Notes::DOCS_KEY, serialized)
+        return busy("note NOT deleted (store busy or unwritable); it is unchanged") unless store.set_setting(Notes::DOCS_KEY, serialized)
 
         Result.new(JSON.build do |j|
           j.object do

--- a/src/gori/mcp/tools/projects.cr
+++ b/src/gori/mcp/tools/projects.cr
@@ -154,8 +154,12 @@ module Gori
 
       private def delete_project_dry_run(reg : ProjectRegistry, proj : Project) : Result
         flows, issues = count_project_objects(proj)
+        now = Time.utc.to_unix_ms
+        # Sweep expired tokens so an issued-but-never-confirmed dry-run doesn't linger for
+        # the whole process life (they're only removed lazily on a confirmed delete today).
+        @delete_tokens.reject! { |_, (_, issued)| now - issued > DELETE_TOKEN_TTL * 1000 }
         token = "del_#{Random::Secure.hex(8)}"
-        @delete_tokens[token] = {proj.db_path, Time.utc.to_unix_ms}
+        @delete_tokens[token] = {proj.db_path, now}
         Result.new(JSON.build do |j|
           j.object do
             j.field "dry_run", true

--- a/src/gori/mcp/tools/repeater.cr
+++ b/src/gori/mcp/tools/repeater.cr
@@ -172,14 +172,16 @@ module Gori
         masked_sni = sni.try { |s| Env.mask_secrets(s) }
         name = present?(h, "name") ? str(h, "name").try { |n| Env.mask_secrets(n) } : existing.name
 
-        store.update_repeater(
-          id: id,
-          target: masked_target,
-          request: masked_request.to_slice,
-          http2: http2,
-          auto_cl: auto_cl,
-          sni: masked_sni
-        )
+        unless store.update_repeater(
+                 id: id,
+                 target: masked_target,
+                 request: masked_request.to_slice,
+                 http2: http2,
+                 auto_cl: auto_cl,
+                 sni: masked_sni
+               )
+          return busy("repeater NOT updated (store busy or unwritable); it is unchanged")
+        end
 
         if present?(h, "name")
           store.set_repeater_name(id, name)
@@ -222,7 +224,7 @@ module Gori
         existing = store.get_repeater(id)
         return not_found("no repeater with id #{id}") unless existing
 
-        store.delete_repeater(id)
+        return busy("repeater NOT deleted (store busy or unwritable); it is unchanged") unless store.delete_repeater(id)
         Result.new(JSON.build { |j| j.object { j.field "success", true } })
       end
     end

--- a/src/gori/mcp/tools/rules.cr
+++ b/src/gori/mcp/tools/rules.cr
@@ -99,10 +99,10 @@ module Gori
         replacement = present?(h, "replacement") ? (str(h, "replacement") || "") : existing.replacement
         name = present?(h, "name") ? (str(h, "name") || "") : existing.name
         host = present?(h, "host") ? (str(h, "host") || "") : existing.host
-        store.update_rule(id, target, part, pattern, replacement, op, match_kind, name, host)
+        return busy("rule not updated (store busy or unwritable); the rule is unchanged") unless store.update_rule(id, target, part, pattern, replacement, op, match_kind, name, host)
         if present?(h, "enabled")
           en = bool_arg(h, "enabled", existing.enabled?)
-          store.set_rule_enabled(id, en)
+          return busy("rule fields were updated but the enable/disable did not persist (store busy or unwritable); retry") unless store.set_rule_enabled(id, en)
         end
         Result.new(JSON.build do |j|
           j.object do
@@ -211,7 +211,7 @@ module Gori
         enabled = bool(h, "enabled")
         return Result.new("missing required 'enabled' (true|false)", is_error: true) if enabled.nil?
         return not_found("no rule with id #{id}") unless rule_exists?(id)
-        store.set_rule_enabled(id, enabled)
+        return busy("enable/disable NOT applied (store busy or unwritable); the rule is unchanged and may still be rewriting live traffic") unless store.set_rule_enabled(id, enabled)
         Result.new(JSON.build { |j| j.object { j.field "id", id; j.field "enabled", enabled } })
       end
 
@@ -219,7 +219,7 @@ module Gori
         id = int(h, "id")
         return Result.new(id_error(h, "id"), is_error: true) unless id
         return not_found("no rule with id #{id}") unless rule_exists?(id)
-        store.delete_rule(id)
+        return busy("rule NOT deleted (store busy or unwritable); it is unchanged and may still be rewriting live traffic") unless store.delete_rule(id)
         Result.new(JSON.build { |j| j.object { j.field "id", id; j.field "deleted", true } })
       end
 

--- a/src/gori/mcp/tools/scope.cr
+++ b/src/gori/mcp/tools/scope.cr
@@ -38,7 +38,10 @@ module Gori
         return err(id_error(h, "id"), "INVALID_ARGUMENT", field: "id") unless id
         scope = Scope.load(store)
         return not_found("no scope rule with id #{id}") unless scope.rules.any? { |r| r.id == id }
-        scope.remove(id)
+        # Write straight to the store (this Scope is a throwaway load, so scope.remove's
+        # in-place reload buys nothing here) and confirm it committed — a busy/locked
+        # rollback must not report the rule deleted while it still gates active requests.
+        return busy("scope rule NOT deleted (store busy or unwritable); it is unchanged and still gates traffic") unless store.remove_scope_rule(id)
         Result.new(JSON.build { |j| j.object { j.field "id", id; j.field "deleted", true } })
       end
 
@@ -46,7 +49,8 @@ module Gori
         enabled = bool(h, "enabled")
         return err("missing required 'enabled' (true or false)", "INVALID_ARGUMENT", field: "enabled") if enabled.nil?
         scope = Scope.load(store)
-        enabled ? scope.enable : scope.disable
+        committed = enabled ? scope.enable : scope.disable
+        return busy("scope enable/disable NOT persisted (store busy or unwritable); the gate is unchanged") unless committed
         Result.new(JSON.build { |j| j.object { j.field "enabled", enabled } })
       end
     end

--- a/src/gori/mcp/tools/send.cr
+++ b/src/gori/mcp/tools/send.cr
@@ -32,12 +32,13 @@ module Gori
         built, applied_rules = maybe_apply_request_rules(h, built)
         # Scope gate BEFORE any outbound byte / History write: an out-of-scope
         # target is refused (nothing sent, nothing recorded) unless allow_unscoped.
-        # request_target reads the target VERBATIM off the first line of `built.bytes` —
-        # ABSOLUTE-FORM when the caller hand-wrote a `raw` template with a full-URL
-        # request line, same as any plain-HTTP forward-proxy request — so this goes
-        # through Scope.request_url rather than a naive concat (see its doc comment).
-        sc = scope_check(Scope.request_url(built.scheme, built.host, request_target(built.bytes)),
-          built.host, bool(h, "allow_unscoped") || false)
+        # The scope URL is anchored on the DIAL target (built.host — what Engine.send
+        # actually connects to), see request_scope_url. Deliberately spoofing the
+        # request-line/Host to a DIFFERENT host (Host-header attacks, cache poisoning,
+        # SSRF via absolute-form) is a legitimate test and is NOT blocked — we still send
+        # the bytes verbatim; we just scope on the host we dial, so a send can't reach an
+        # out-of-scope host while the gate matched the (spoofed) request-line host instead.
+        sc = scope_check(request_scope_url(built), built.host, bool(h, "allow_unscoped") || false)
         return scope_blocked(sc) if sc.blocked
         recorded_flow_id = record_history ? record_outbound_request(built, http2) : nil
         verify = @verify_upstream && !(bool(h, "insecure") || false)
@@ -486,6 +487,25 @@ module Gori
       private def request_target(bytes : Bytes) : String
         line = String.new(bytes).each_line.first? || ""
         line.split(' ')[1]? || "/"
+      end
+
+      # The URL the scope gate evaluates, ALWAYS anchored on the DIAL target (built.scheme/
+      # host — what Engine.send connects to), never the request LINE's host. A raw request
+      # may carry an absolute-form request line (`GET http://other/p HTTP/1.1`) whose host is
+      # deliberately DIFFERENT from `url` — a Host-header / cache-poisoning / SSRF test, which
+      # gori must allow. Scoping on that spoofed host would either block a legitimate test or
+      # (the bug this fixes) let a send reach an out-of-scope host while an include rule matched
+      # the spoofed host and logged scope=in_scope. So reduce an absolute-form target to its
+      # path+query and rebuild against built.host. Port is omitted to match Scope.request_url's
+      # origin-form convention (the scope lens keys on host, not port).
+      private def request_scope_url(built : RequestBuilder::Built) : String
+        target = request_target(built.bytes)
+        if Store::FlowRow.absolute_form?(target)
+          uri = URI.parse(target) rescue nil
+          path = uri.try(&.path).presence || "/"
+          target = (q = uri.try(&.query)) ? "#{path}?#{q}" : path
+        end
+        Scope.request_url(built.scheme, built.host, target)
       end
 
       # Passive-scan a just-saved Repeater send into probe_issues when mode is Passive/Active.

--- a/src/gori/mcp/tools/sequence.cr
+++ b/src/gori/mcp/tools/sequence.cr
@@ -32,6 +32,7 @@ module Gori
           int(h, "rate").try(&.to_f64), clamp(int(h, "concurrency"), 1, SEQUENCE_MAX_CONCURRENCY),
           int(h, "max_requests"), Time.utc.to_unix_ms)
         sjob = SequenceJob.new(id, goal, engine, audit)
+        evict_finished_jobs(@sequence_jobs)
         @sequence_jobs[id] = sjob
         Log.info { "sequence_start #{id} #{origin.scheme}://#{origin.host}:#{origin.port} scope=#{sc.decision} goal=#{goal} loc=#{loc.label}" }
         spawn(name: "mcp-seq-#{id}") { run_sequence_job(sjob, engine) }

--- a/src/gori/proxy/codec/body.cr
+++ b/src/gori/proxy/codec/body.cr
@@ -139,6 +139,17 @@ module Gori::Proxy::Codec
     # capture). Tune as needed.
     CAPTURE_MAX = 2 * 1024 * 1024 # 2 MiB
 
+    # Ceiling on the body bytes a CAPTURE-ONLY read (Repeater/Fuzz/Miner send) will
+    # pull off the wire. Mirrors the h2 engine's MAX_BODY (8 MiB): the h1 capture
+    # buffers into a plain IO::Memory and the copy loops read until framing-end, so
+    # WITHOUT this bound an oversized origin OOMs, and a chunked / close-delimited
+    # stream that keeps trickling data inside the idle timeout (SSE, a heartbeat feed)
+    # never returns — hanging the single-threaded caller. A body that hits the cap is
+    # reported incomplete (same signal as a premature EOF), so the connection is not
+    # reused. The live proxy forward path does NOT use this — it passes no cap to
+    # read_complete (Int64::MAX) and streams byte-exact (P6/P7).
+    CAPTURE_READ_MAX = 8 * 1024 * 1024 # 8 MiB (h1 capture read ceiling; parity with H2Engine::MAX_BODY)
+
     # RFC 7230 §3.3.3 framing for a request body.
     def self.request_framing(req : RawRequest) : {BodyFraming, Int64}
       # A header written as `Transfer-Encoding : chunked` (whitespace before colon) or
@@ -222,20 +233,27 @@ module Gori::Proxy::Codec
 
     # Reads a message body (by framing) into a single buffer — used by the Repeater
     # engine to capture a response without forwarding it anywhere.
-    def self.read(src : IO, framing : BodyFraming, length : Int64) : Bytes?
-      read_complete(src, framing, length)[0]
+    def self.read(src : IO, framing : BodyFraming, length : Int64, max_bytes : Int64 = Int64::MAX) : Bytes?
+      read_complete(src, framing, length, max_bytes)[0]
     end
 
     # As `read`, but also returns whether the body completed (false = a
     # Content-Length/chunked body the origin cut short). Lets the Repeater engine
     # flag a half-delivered response instead of presenting it as whole.
-    def self.read_complete(src : IO, framing : BodyFraming, length : Int64) : {Bytes?, Bool}
+    def self.read_complete(src : IO, framing : BodyFraming, length : Int64, max_bytes : Int64 = Int64::MAX) : {Bytes?, Bool}
       return {nil, true} if framing.none?
       # Presize the capture for a KNOWN Content-Length so it doesn't climb IO::Memory's
       # 64→128→…→N doubling-realloc chain (each step copies everything captured so far);
       # bounded by PRESIZE_CAP so a lying Content-Length can't force a huge up-front alloc.
       # Chunked / close-delimited length is unknown → default growth (as before).
       capture = presized_capture(framing, length)
+      # Bound the body READ, not just the capture buffer: the copy loops read until the
+      # framing ends, so a plain IO::Memory would grow with every byte an oversized or
+      # endlessly-streaming origin sends. IO::Sized returns EOF once max_bytes are read,
+      # which makes copy_n/copy_until_eof/copy_chunked stop and report the body incomplete
+      # (false). Only capture-only callers pass a finite cap; the proxy forward path leaves
+      # max_bytes at Int64::MAX so forwarding stays byte-exact and uncapped (P6/P7).
+      src = IO::Sized.new(src, read_size: max_bytes) unless max_bytes == Int64::MAX
       # Right-size the scratch read buffer too: a small Length body drops a 64 KiB
       # large-object scratch to a body-sized small-object alloc (copy_n/copy_until_eof
       # re-key their read size off the buffer's own size, so a sub-BUFSIZE buffer stays
@@ -243,6 +261,15 @@ module Gori::Proxy::Codec
       # sink rather than a second IO::Memory so a large response isn't held in memory
       # TWICE (the old `IO::Memory.new` tee doubled peak RAM on every read_complete).
       complete = stream(src, capture, framing, length, DiscardIO.new, read_buffer(framing, length))
+      # CloseDelimited framing treats EOF as the natural end and returns complete=true, but
+      # our IO::Sized cap surfaces AS an EOF — so a close-delimited body (SSE / no
+      # Content-Length) that hit the ceiling would be mislabeled complete. When the wrapper
+      # is exhausted on such a body, force incomplete (Length/Chunked already report the
+      # short read through copy_n/copy_chunked). Guarded on close_delimited? so an exactly-
+      # max_bytes Length body isn't falsely flagged.
+      if framing.close_delimited? && (limited = src).is_a?(IO::Sized) && limited.read_remaining == 0
+        complete = false
+      end
       # `capture` is a fresh local, never stored in a field/closure and unreachable after
       # return, so the returned view is its SOLE owner (the slice's pointer keeps the backing
       # buffer alive) — no defensive `.dup` of the whole body (mirrors CaptureBuffer#to_slice).

--- a/src/gori/repeater/engine.cr
+++ b/src/gori/repeater/engine.cr
@@ -1,6 +1,7 @@
 require "../proxy/upstream"
 require "../proxy/codec/http1"
 require "../proxy/codec/body"
+require "../proxy/socket_tuning"
 
 module Gori
   module Repeater
@@ -11,11 +12,13 @@ module Gori
       getter response : Proxy::Codec::RawResponse?
       getter duration_us : Int64
       getter error : String?
-      # The origin closed before delivering the full body it framed: a
-      # Content-Length cut short, or a chunked body without its terminating
-      # 0-chunk. The captured `body` is what actually arrived — distinct from a
-      # *display* truncation (gori capping what it shows). A consumer must not
-      # treat a half-delivered response as the whole thing.
+      # The captured `body` is not the whole response the origin framed, for one of
+      # two reasons: the origin closed early (a Content-Length cut short, or a chunked
+      # body without its terminating 0-chunk), OR the body exceeded Body::CAPTURE_READ_MAX
+      # and the read stopped at the ceiling (an oversized or endlessly-streaming origin).
+      # Either way the socket has undelivered/unread bytes, so it must not be reused, and
+      # a consumer must not treat a half-delivered response as the whole thing. Distinct
+      # from a *display* truncation (gori capping what it shows).
       getter? incomplete : Bool
 
       def initialize(@head, @body, @response, @duration_us, @error = nil, @incomplete = false)
@@ -86,7 +89,11 @@ module Gori
             end
             r = exchange(upstream, request, host, port, Time.instant)
             results << r
-            dead = true if r.error # a failed exchange leaves the socket state unusable for the rest
+            # A failed OR incomplete exchange leaves the socket unusable for the rest: an
+            # error is self-evident; an incomplete body (origin cut it short, or we hit the
+            # CAPTURE_READ_MAX ceiling) leaves unread bytes on the wire, so reusing the
+            # connection would misframe the next request (response desync).
+            dead = true if r.error || r.incomplete?
           end
         ensure
           upstream.close rescue nil
@@ -102,7 +109,7 @@ module Gori
                                 started : Time::Instant) : Result
         upstream.write(request)
         upstream.flush
-        head = Proxy::Codec::Http1.read_head(upstream)
+        head = read_response_head(upstream)
         return error("no response from #{host}:#{port}", started) unless head
 
         resp = Proxy::Codec::Http1.parse_response_head(head)
@@ -122,13 +129,16 @@ module Gori
           # repeater/fuzz worker fiber indefinitely (there is no whole-request deadline).
           interim_seen += 1
           return error("too many interim 1xx responses from #{host}:#{port}", started) if interim_seen > MAX_INTERIM
-          head = Proxy::Codec::Http1.read_head(upstream)
+          head = read_response_head(upstream)
           return error("upstream closed after interim 1xx from #{host}:#{port}", started) unless head
           resp = Proxy::Codec::Http1.parse_response_head(head)
         end
         begin
           framing, len = Proxy::Codec::Body.response_framing(resp, request_method(request))
-          body, complete = Proxy::Codec::Body.read_complete(upstream, framing, len)
+          # Cap the capture read at CAPTURE_READ_MAX (parity with the h2 engine's MAX_BODY):
+          # without it a streaming origin (SSE/heartbeat) or a multi-GB body hangs or OOMs
+          # this single-threaded send. A capped body comes back complete:false → incomplete.
+          body, complete = Proxy::Codec::Body.read_complete(upstream, framing, len, Proxy::Codec::Body::CAPTURE_READ_MAX)
           Result.new(head, body, resp, elapsed(started), incomplete: !complete)
         rescue ex
           # The head was already read + parsed. A framing rejection (CL+TE — precisely the
@@ -139,6 +149,19 @@ module Gori
         end
       rescue ex
         error(ex.message || "repeater error", started)
+      end
+
+      # Read a response head with a TOTAL head-assembly deadline (parity with the proxy's
+      # client read, client_conn.cr:111). The per-operation io_timeout only bounds the gap
+      # BETWEEN reads, so a slowloris origin dripping the head one byte at a time (each byte
+      # inside io_timeout) would pin this read — and, since the MCP server is single-threaded,
+      # freeze every other tool. HEAD_DEADLINE caps the whole head. underlying_socket returns
+      # nil for an IO with no settable socket, in which case read_head simply skips the
+      # deadline (unchanged behaviour), so this is safe on every transport.
+      private def self.read_response_head(upstream : IO) : Bytes?
+        Proxy::Codec::Http1.read_head(upstream,
+          deadline: Proxy::SocketTuning::HEAD_DEADLINE,
+          timeout_sock: Proxy::SocketTuning.underlying_socket(upstream))
       end
 
       private def self.error(message : String, started : Time::Instant) : Result

--- a/src/gori/scope.cr
+++ b/src/gori/scope.cr
@@ -352,11 +352,13 @@ module Gori
       @mutex.synchronize { set_enabled_unlocked(!@enabled) }
     end
 
-    def enable : Nil
+    # Returns whether the persisted enabled flag committed (false = store busy/locked).
+    def enable : Bool
       @mutex.synchronize { set_enabled_unlocked(true) }
     end
 
-    def disable : Nil
+    # Returns whether the persisted enabled flag committed (false = store busy/locked).
+    def disable : Bool
       @mutex.synchronize { set_enabled_unlocked(false) }
     end
 
@@ -450,7 +452,7 @@ module Gori
       @rules = Scope.load_rules(@store)
     end
 
-    private def set_enabled_unlocked(value : Bool) : Nil
+    private def set_enabled_unlocked(value : Bool) : Bool
       @enabled = value
       @store.set_setting(SETTING_ENABLED, value ? "1" : "0")
     end

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -104,6 +104,20 @@ module Gori
       end
     end
 
+    # Like ExecTask, but its reply is a COMMITTED bool rather than a rowid. exec_task
+    # signals failure only via last_insert_rowid()==0, which is meaningful for INSERTs
+    # but NOT for UPDATE/DELETE (a committed UPDATE can also yield 0), so a rolled-back
+    # UPDATE/DELETE was indistinguishable from a successful one — a busy/locked mutation
+    # reported success. This variant carries an unambiguous commit/rollback signal so a
+    # caller (e.g. an MCP mutation tool) can surface PROJECT_BUSY on a dropped write.
+    struct ExecTaskChecked < WriteOp
+      getter run : DB::Connection -> Nil
+      getter reply : Channel(Bool)
+
+      def initialize(@run, @reply)
+      end
+    end
+
     # Marks every Pending flow Error (e.g. proxy shutdown before a response landed).
     struct AbandonPending < WriteOp
       getter message : String
@@ -382,6 +396,12 @@ module Gori
                   op.run.call(c)
                   rowid = c.scalar("SELECT last_insert_rowid()").as(Int64)
                   deferred << -> { task_reply.send(rowid) }
+                when ExecTaskChecked
+                  checked_reply = op.reply
+                  op.run.call(c)
+                  # Deferred until the batch commits (below), so `true` truthfully means
+                  # persisted; a rollback routes through fail_reply → `false`.
+                  deferred << -> { checked_reply.send(true) }
                 when AbandonPending
                   ab_reply = op.reply
                   ids = abandon_all_pending(c, op.message)
@@ -471,6 +491,7 @@ module Gori
       when UpdateResp        then op.reply.send(nil)
       when InsertWs          then op.reply.send(nil)
       when ExecTask          then op.reply.send(0_i64)
+      when ExecTaskChecked   then op.reply.send(false)
       when AbandonPending    then op.reply.send(0_i32)
       end
     rescue
@@ -708,6 +729,19 @@ module Gori
       reply.receive
     rescue Channel::ClosedError
       0_i64 # store closing — caller (settings/issues/flush) degrades, doesn't raise
+    end
+
+    # Runs a write closure and returns whether its batch COMMITTED (true) or was
+    # rolled back / the store is closing (false). Use for UPDATE/DELETE mutations where
+    # a caller must know the write actually persisted (last_insert_rowid can't tell a
+    # committed non-INSERT from a rollback). A false is transient (cross-process SQLite
+    # busy/lock) → the caller surfaces PROJECT_BUSY (retryable).
+    private def exec_task_ok(run : DB::Connection -> Nil) : Bool
+      reply = Channel(Bool).new(1) # buffered: the writer must never block sending a reply
+      @writes.send(ExecTaskChecked.new(run, reply))
+      reply.receive
+    rescue Channel::ClosedError
+      false # store closing — treat as a failed write
     end
 
     private def read_issue(rs : DB::ResultSet) : Issue

--- a/src/gori/store/host_overrides.cr
+++ b/src/gori/store/host_overrides.cr
@@ -22,14 +22,16 @@ module Gori
       }
     end
 
-    def update_host_override(id : Int64, host : String, ip : String) : Nil
-      exec_task ->(c : DB::Connection) {
+    # Returns whether the write committed (false = store busy/locked/closing).
+    def update_host_override(id : Int64, host : String, ip : String) : Bool
+      exec_task_ok ->(c : DB::Connection) {
         c.exec("UPDATE host_overrides SET host = ?, ip = ? WHERE id = ?", host, ip, id); nil
       }
     end
 
-    def remove_host_override(id : Int64) : Nil
-      exec_task ->(c : DB::Connection) { c.exec("DELETE FROM host_overrides WHERE id = ?", id); nil }
+    # Returns whether the write committed (false = store busy/locked/closing).
+    def remove_host_override(id : Int64) : Bool
+      exec_task_ok ->(c : DB::Connection) { c.exec("DELETE FROM host_overrides WHERE id = ?", id); nil }
     end
   end
 end

--- a/src/gori/store/issues.cr
+++ b/src/gori/store/issues.cr
@@ -24,8 +24,10 @@ module Gori
       issue_id
     end
 
+    # Returns whether the write committed (false = store busy/locked/closing). An empty
+    # update (no fields supplied) is a no-op → true (nothing to persist, nothing failed).
     def update_issue(id : Int64, *, title : String? = nil, severity : Severity? = nil,
-                     notes : String? = nil, status : Status? = nil) : Nil
+                     notes : String? = nil, status : Status? = nil) : Bool
       sets = [] of String
       args = [] of DB::Any
       if t = title
@@ -40,15 +42,16 @@ module Gori
       if st = status
         sets << "status = ?"; args << st.value
       end
-      return if sets.empty?
+      return true if sets.empty?
       sets << "updated_at = ?"; args << now_us
       args << id
       sql = "UPDATE issues SET #{sets.join(", ")} WHERE id = ?"
-      exec_task ->(c : DB::Connection) { c.exec(sql, args: args); nil }
+      exec_task_ok ->(c : DB::Connection) { c.exec(sql, args: args); nil }
     end
 
-    def delete_issue(id : Int64) : Nil
-      exec_task ->(c : DB::Connection) {
+    # Returns whether the write committed (false = store busy/locked/closing).
+    def delete_issue(id : Int64) : Bool
+      exec_task_ok ->(c : DB::Connection) {
         c.exec("DELETE FROM entity_links WHERE owner_kind = 'issue' AND owner_id = ?", id)
         c.exec("DELETE FROM issues WHERE id = ?", id)
         nil

--- a/src/gori/store/match_rules.cr
+++ b/src/gori/store/match_rules.cr
@@ -34,16 +34,19 @@ module Gori
       }
     end
 
-    def set_rule_enabled(id : Int64, enabled : Bool) : Nil
-      exec_task ->(c : DB::Connection) { c.exec("UPDATE match_rules SET enabled = ? WHERE id = ?", enabled ? 1 : 0, id); nil }
+    # Returns whether the write committed (false = store busy/locked/closing → the
+    # caller must not report the toggle as applied; the rule stays in its prior state).
+    def set_rule_enabled(id : Int64, enabled : Bool) : Bool
+      exec_task_ok ->(c : DB::Connection) { c.exec("UPDATE match_rules SET enabled = ? WHERE id = ?", enabled ? 1 : 0, id); nil }
     end
 
     # Update a rule's fields in place (enabled/position unchanged). No-op when the id
     # doesn't exist.
+    # Returns whether the write committed (false = store busy/locked/closing).
     def update_rule(id : Int64, target : RuleTarget, part : RulePart, pattern : String, replacement : String,
                     op : RuleOp = RuleOp::Replace, match_kind : MatchKind = MatchKind::Literal,
-                    name : String = "", host : String = "") : Nil
-      exec_task ->(c : DB::Connection) {
+                    name : String = "", host : String = "") : Bool
+      exec_task_ok ->(c : DB::Connection) {
         c.exec("UPDATE match_rules SET target = ?, part = ?, pattern = ?, replacement = ?, op = ?, match_kind = ?, name = ?, host = ? WHERE id = ?",
           target.label, part.label, pattern, replacement, op.label, match_kind.label, name, host, id)
         nil
@@ -68,8 +71,9 @@ module Gori
       }
     end
 
-    def delete_rule(id : Int64) : Nil
-      exec_task ->(c : DB::Connection) { c.exec("DELETE FROM match_rules WHERE id = ?", id); nil }
+    # Returns whether the write committed (false = store busy/locked/closing).
+    def delete_rule(id : Int64) : Bool
+      exec_task_ok ->(c : DB::Connection) { c.exec("DELETE FROM match_rules WHERE id = ?", id); nil }
     end
   end
 end

--- a/src/gori/store/repeater_sessions.cr
+++ b/src/gori/store/repeater_sessions.cr
@@ -121,9 +121,10 @@ module Gori
       }
     end
 
+    # Returns whether the write committed (false = store busy/locked/closing).
     def update_repeater(id : Int64, target : String, request : Bytes, http2 : Bool, auto_cl : Bool,
-                        sni : String? = nil) : Nil
-      exec_task ->(c : DB::Connection) {
+                        sni : String? = nil) : Bool
+      exec_task_ok ->(c : DB::Connection) {
         c.exec("UPDATE repeaters SET target = ?, request = ?, http2 = ?, auto_content_length = ?, sni = ?, updated_at = ? WHERE id = ?",
           target, request, http2 ? 1 : 0, auto_cl ? 1 : 0, sni, now_us, id)
         nil
@@ -162,8 +163,9 @@ module Gori
       }
     end
 
-    def delete_repeater(id : Int64) : Nil
-      exec_task ->(c : DB::Connection) {
+    # Returns whether the write committed (false = store busy/locked/closing).
+    def delete_repeater(id : Int64) : Bool
+      exec_task_ok ->(c : DB::Connection) {
         c.exec("DELETE FROM ws_messages WHERE repeater_id = ?", id)
         c.exec("DELETE FROM repeaters WHERE id = ?", id)
         nil

--- a/src/gori/store/scope_rules.cr
+++ b/src/gori/store/scope_rules.cr
@@ -18,14 +18,16 @@ module Gori
       }
     end
 
-    def update_scope_rule(id : Int64, kind : String, match_type : String, pattern : String) : Nil
-      exec_task ->(c : DB::Connection) {
+    # Returns whether the write committed (false = store busy/locked/closing).
+    def update_scope_rule(id : Int64, kind : String, match_type : String, pattern : String) : Bool
+      exec_task_ok ->(c : DB::Connection) {
         c.exec("UPDATE scope_rules SET kind = ?, match_type = ?, pattern = ? WHERE id = ?", kind, match_type, pattern, id); nil
       }
     end
 
-    def remove_scope_rule(id : Int64) : Nil
-      exec_task ->(c : DB::Connection) { c.exec("DELETE FROM scope_rules WHERE id = ?", id); nil }
+    # Returns whether the write committed (false = store busy/locked/closing).
+    def remove_scope_rule(id : Int64) : Bool
+      exec_task_ok ->(c : DB::Connection) { c.exec("DELETE FROM scope_rules WHERE id = ?", id); nil }
     end
   end
 end

--- a/src/gori/store/settings_kv.cr
+++ b/src/gori/store/settings_kv.cr
@@ -11,8 +11,11 @@ module Gori
       @db.query_one?("SELECT value FROM settings WHERE key = ?", key, as: String)
     end
 
-    def set_setting(key : String, value : String) : Nil
-      exec_task ->(c : DB::Connection) {
+    # Returns whether the write committed (false = store busy/locked/closing). Most callers
+    # (high-frequency UI-state writes) ignore it; a caller that must confirm the value
+    # persisted (an MCP mutation tool) checks it and surfaces PROJECT_BUSY on false.
+    def set_setting(key : String, value : String) : Bool
+      exec_task_ok ->(c : DB::Connection) {
         c.exec("INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = ?", key, value, value)
         nil
       }
@@ -20,8 +23,9 @@ module Gori
 
     # Drop a per-project setting so `setting(key)` reads nil again (the Project settings pane
     # clears a network override this way — reverting the field to inherit the global value).
-    def delete_setting(key : String) : Nil
-      exec_task ->(c : DB::Connection) {
+    # Returns whether the write committed (false = store busy/locked/closing).
+    def delete_setting(key : String) : Bool
+      exec_task_ok ->(c : DB::Connection) {
         c.exec("DELETE FROM settings WHERE key = ?", key)
         nil
       }

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -1182,7 +1182,8 @@ module Gori::Tui
 
     def repeater_send : Nil
       return unless (tab = current_repeater_tab) && (view = tab.view).loaded?
-      view.commit_chain_pane # flush an in-progress CHAIN-pane edit so ^R can't send stale bytes (matches the SEND-chip click)
+      view.commit_chain_pane           # flush an in-progress CHAIN-pane edit so ^R can't send stale bytes (matches the SEND-chip click)
+      view.sync_host_to_target_once    # ^R defers past exit_target_insert!, so mirror a fresh ^N tab's target into Host here too (one-shot)
       if view.inflight?      # one outstanding round-trip per view — don't pile up fibers on ^R mashing
         @host.status("repeater already in flight…")
         return

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -42,6 +42,11 @@ module Gori::Tui
     getter target : String # the raw target URL (persistence + cross-session sync)
     # unsaved local edits — gates persistence + protects the tab from sync clobber
     @dirty : Bool = false
+    # One-shot, armed only by load_blank (a fresh ^N tab). The first time the user edits the
+    # target away from the placeholder, the Host header is mirrored to the new host so they
+    # don't have to edit both; cleared after that first sync (and never armed for tabs loaded
+    # from a captured flow / saved repeater), so a hand-set Host is never clobbered.
+    @link_host_to_target : Bool = false
 
     def dirty? : Bool
       @dirty || (@ws_mode && @decoded_dirty)
@@ -321,6 +326,7 @@ module Gori::Tui
 
     def exit_target_insert! : Nil
       @target_mode = InputMode::Read
+      sync_host_to_target_once
     end
 
     def resp_navigable? : Bool
@@ -1092,6 +1098,7 @@ module Gori::Tui
       @flow = nil
       @http2 = false
       @target = BLANK_TARGET
+      @link_host_to_target = true # first target edit mirrors into the Host header (see the field)
       @tcx = @target.size
       @sni = ""
       @scx = 0
@@ -1481,6 +1488,43 @@ module Gori::Tui
       @editor.replace_line(raw_cl_idx, new_line)
     end
 
+    # See @link_host_to_target: on the FIRST target edit of a fresh ^N tab, mirror the new
+    # host into the Host header (a ^N tab starts on https://example.com / Host: example.com,
+    # so without this the user edits both). One-shot — cleared after the first sync, and it
+    # only fires once the target actually moved off the placeholder.
+    # Public so the send path can flush it too: ^R sends WITHOUT going through
+    # exit_target_insert! (a modified chord defers straight to the keymap), so a
+    # type-target-then-^R flow would otherwise send the stale Host. Calling this at send
+    # prep (repeater_send, beside commit_chain_pane) closes that. No-op unless armed.
+    def sync_host_to_target_once : Nil
+      return unless @link_host_to_target
+      return if @target == BLANK_TARGET # not edited off the placeholder yet — keep waiting
+      _, host, _ = parse_target
+      return if host.empty? # edited to something with no parseable host — stay armed for a real one
+      @link_host_to_target = false
+      reflect_target_host_in_editor
+    end
+
+    # Rewrite the request's `Host:` line to the target's authority (host, or host:port for a
+    # non-default port). Plain text tabs only — WS/gRPC/hex request buffers frame their host
+    # elsewhere. Models reflect_content_length_in_editor (locate the header by content, then
+    # replace_line). @dirty is already set by the target edit that triggered this.
+    private def reflect_target_host_in_editor : Nil
+      return if @req_hex_edit || @ws_mode || @grpc_mode
+      scheme, host, port = parse_target
+      return if host.empty?
+      default_port = (scheme == "https" || scheme == "wss") ? 443 : 80
+      authority = port == default_port ? host : "#{host}:#{port}"
+      env_sep = @editor.text.index("\n\n")
+      return unless env_sep
+      head_lines = @editor.text[0, env_sep].split('\n')
+      host_idx = head_lines.index { |l| l.lstrip.downcase.starts_with?("host:") }
+      return unless host_idx
+      new_line = "Host: #{authority}"
+      return if head_lines[host_idx] == new_line
+      @editor.replace_line(host_idx, new_line)
+    end
+
     # {scheme, host, port} parsed from the target field.
     # Delegate to the engine's parser so the TUI field and `gori run`/the repeater engine never
     # disagree on host/port (they used to be byte-for-byte duplicate implementations).
@@ -1528,6 +1572,13 @@ module Gori::Tui
     # editing SNI and returning would silently route URL keystrokes into @sni.
     private def set_focus(pane : Symbol) : Nil
       commit_chain_pane if @chain_focused # any focus change saves a pending chain edit
+      # Leaving the target for another pane flushes the ^N host-link here — BEFORE the user
+      # can reach the request body to hand-edit the Host. That ordering is what keeps the
+      # one-shot from ever clobbering a deliberately-mismatched Host (Host-header attacks):
+      # the flag is spent on the way out of the target, so a later body Host edit stands.
+      # Covers every target→elsewhere path (keyboard pane_advance, mouse focus_pane, chips);
+      # exit_target_insert! (Esc) and repeater_send (^R straight from target) are the other two.
+      sync_host_to_target_once if @focus == :target && pane != :target
       @focus = pane
       @target_field = :url
     end


### PR DESCRIPTION
## Summary

A focused MCP **tool-stability** review, its fixes, and one small Repeater UX feature that came up alongside it. Two commits: the stability hardening, and the feature.

## Stability fixes (`fix(mcp,proxy)`)

Each finding has a regression spec.

- **CRITICAL — unbounded h1 capture read (OOM / whole-loop hang).** The h2 engine caps a captured response at `MAX_BODY` (8 MiB); the h1 path buffered into an unbounded `IO::Memory` with no whole-body deadline, so a streaming or oversized in-scope origin (SSE, a heartbeat feed, a multi-GB body) could OOM the process or hang the single-threaded MCP server — freezing every tool. `Body.read_complete` now takes a `max_bytes` cap (`IO::Sized`); the repeater engine passes `CAPTURE_READ_MAX` (8 MiB, parity with h2). Proxy forwarding is uncapped/byte-exact.
- **HIGH — `get_repeater_context` credential leak.** With `include_content` + default `include_sensitive:false`, the live-TUI `tui_repeater` snapshot was emitted verbatim while claiming `sensitive_headers_redacted:true`. Its `request`/`upgrade_request` fields are now redacted recursively (they nest under `active`), matching the `sessions[]` path.
- **HIGH — rolled-back store writes reported success.** `exec_task` signalled failure only via `last_insert_rowid()==0`, meaningless for UPDATE/DELETE — a busy/locked rollback (e.g. `set_rule_enabled` on a live rule) returned success while the write was dropped. New `exec_task_ok` (committed bool) threaded through rules/issues/notes/env/scope/host-overrides/repeater/import; tools now return `PROJECT_BUSY` (retryable).
- **MEDIUM** — scope gate anchors on the **dialed** host (not the raw request-line host), closing a bypass while still allowing deliberate Host/target mismatches (Host-header attacks); `compare_flows` diff byte-capped; async job maps evict finished jobs.
- **LOW** — repeater head slowloris deadline; discover job finalize/rescue net + bounded `@seen`/`@templates` + engine closes `@jobs` on its rescue path; `get_response_body_chunk` decode-cap flag; dead redaction-landmine serializer removed; OAST sessions / delete tokens bounded/swept.

## Feature (`feat(tui)`)

Repeater `^N` blank tab now mirrors the target host into the `Host` header on the **first** target edit (one-shot). Primary trigger is focus-leave, so a Host you set by hand afterward (a deliberate mismatch) is never clobbered.

## Testing

`crystal build` clean; `crystal spec` green (**3436 examples, 0 failures, 0 errors**). New specs cover the h1 cap + incomplete labelling, the nested redaction, the scope dial-host anchoring (incl. spoof-allowed and bypass-blocked), and the Repeater Host-sync (first-edit, port, one-shot, send-time, and the no-clobber guard).
