### PR TITLE
fix(proxy): distinguish upstream TLS-verify failures from connect failures

### DIFF
--- a/spec/proxy/upstream_spec.cr
+++ b/spec/proxy/upstream_spec.cr
@@ -350,4 +350,55 @@ describe Gori::Proxy::Upstream do
       end
     end
   end
+
+  # The #323 diagnostic split: the proxy capture path records WHY an HTTPS upstream dial
+  # failed, so a verify rejection (fix: --insecure-upstream) is never mislabelled as an
+  # unreachable origin. dial_tls delegates to dial_tls_result, so this covers both.
+  describe ".dial_tls_result" do
+    it "classifies an unreachable origin as a Connect failure" do
+      srv = TCPServer.new("127.0.0.1", 0)
+      port = srv.local_address.port
+      srv.close # free the port so the connect is refused, not accepted
+      sock, err = Gori::Proxy::Upstream.dial_tls_result("127.0.0.1", port, verify: false)
+      sock.should be_nil
+      err.should eq(Gori::Proxy::Upstream::TlsDialError::Connect)
+    end
+
+    it "classifies an untrusted-cert origin as a Tls failure under verify, and succeeds with verify off" do
+      # A leaf for "localhost" signed by a CA the client does NOT trust: the origin is REACHED
+      # (so not a Connect failure) but the chain doesn't verify — exactly the #323 shape.
+      ca_cert, ca_key = Gori::Proxy::Tls::CertBuilder.build_root("gori-spec Untrusted CA")
+      leaf_cert, leaf_key = Gori::Proxy::Tls::CertBuilder.build_leaf("localhost", ca_cert, ca_key)
+      origin_ctx = Gori::Proxy::Tls::ContextFactory.server_context(leaf_cert, leaf_key, ca_cert: ca_cert)
+
+      origin = TCPServer.new("127.0.0.1", 0)
+      port = origin.local_address.port
+      spawn do
+        2.times do
+          next unless raw = origin.accept?
+          begin
+            OpenSSL::SSL::Socket::Server.new(raw, origin_ctx, sync_close: true).close
+          rescue
+            raw.close rescue nil
+          end
+        end
+      end
+
+      begin
+        # verify ON: chain to an untrusted root → a TLS (verify) failure, NOT Connect.
+        # Dial 127.0.0.1 explicitly (no localhost→::1 resolution race), verify the "localhost" cert via SNI.
+        sock, err = Gori::Proxy::Upstream.dial_tls_result("127.0.0.1", port, verify: true, sni: "localhost")
+        sock.should be_nil
+        err.should eq(Gori::Proxy::Upstream::TlsDialError::Tls)
+
+        # verify OFF: the same origin dials fine — a live socket, no error.
+        sock2, err2 = Gori::Proxy::Upstream.dial_tls_result("127.0.0.1", port, verify: false, sni: "localhost")
+        sock2.should_not be_nil
+        err2.should be_nil
+        sock2.try(&.close) rescue nil
+      ensure
+        origin.close rescue nil
+      end
+    end
+  end
 end

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -47,6 +47,10 @@ module Gori::Proxy
       # this connection (see `copy_buf`), so a keep-alive stream stops churning a large-object
       # allocation per body. Lazily allocated on the first body copy.
       @copy_buf = nil.as(Bytes?)
+      # Why the most recent upstream dial failed, set by `open_upstream` and read only when a
+      # dial returned nil — lets a failed HTTPS flow distinguish unreachable from a TLS/verify
+      # rejection (the #323 case, whose fix is --insecure-upstream). See `upstream_error_message`.
+      @last_tls_dial_error = nil.as(Upstream::TlsDialError?)
     end
 
     # The connection-lifetime scratch buffer for body forwarding, allocated on first use.
@@ -241,7 +245,7 @@ module Gori::Proxy
       end
       unless upstream && sent
         release_upstream
-        record_error(req, scheme, host, port, created_at, "upstream connect/write failed: #{host}:#{port}")
+        record_error(req, scheme, host, port, created_at, upstream_error_message(host, port, upstream))
         write_gateway_error
         return false
       end
@@ -301,7 +305,7 @@ module Gori::Proxy
       upstream, reused, sent = acquire_and_send(host, port, retryable) { |up| write_request(up, sent_head, edited_body) }
       unless upstream && sent
         release_upstream
-        record_error(sent_req, scheme, host, port, created_at, "upstream connect/write failed: #{host}:#{port}")
+        record_error(sent_req, scheme, host, port, created_at, upstream_error_message(host, port, upstream))
         write_gateway_error
         return false
       end
@@ -334,7 +338,7 @@ module Gori::Proxy
       upstream, reused, sent = acquire_and_send(host, port, false) { |up| write_request(up, sent_head, fwd_body) }
       unless upstream && sent
         release_upstream
-        record_error(sent_req, scheme, host, port, created_at, "upstream connect/write failed: #{host}:#{port}")
+        record_error(sent_req, scheme, host, port, created_at, upstream_error_message(host, port, upstream))
         write_gateway_error
         return false
       end
@@ -862,9 +866,31 @@ module Gori::Proxy
     # origin-form for the upstream; the captured truth keeps the original bytes.
     private def open_upstream(host : String, port : Int32) : IO?
       if @tls_upstream
-        Upstream.dial_tls(host, port, verify: @verify_upstream, overrides: @host_overrides)
+        sock, err = Upstream.dial_tls_result(host, port, verify: @verify_upstream, overrides: @host_overrides)
+        @last_tls_dial_error = err
+        sock
       else
+        @last_tls_dial_error = nil # plaintext forward-proxy dial: no TLS leg to classify
         Upstream.dial(host, port, overrides: @host_overrides)
+      end
+    end
+
+    # The error text for a failed upstream acquire/send. A nil `upstream` is a DIAL failure,
+    # split into unreachable (connect) vs. a TLS/verify rejection — the #323 case, whose fix is
+    # --insecure-upstream, so the recorded flow points there instead of at reachability. A
+    # non-nil `upstream` means the socket was live but the mid-request write failed.
+    private def upstream_error_message(host : String, port : Int32, upstream : IO?) : String
+      return "upstream write failed: #{host}:#{port}" unless upstream.nil?
+      case @last_tls_dial_error
+      when Upstream::TlsDialError::Tls
+        if @verify_upstream
+          "upstream TLS verification failed: #{host}:#{port} — origin certificate not trusted; " \
+          "retry with --insecure-upstream or set SSL_CERT_FILE"
+        else
+          "upstream TLS handshake failed: #{host}:#{port}"
+        end
+      else
+        "upstream connect failed: #{host}:#{port}"
       end
     end
 

--- a/src/gori/proxy/upstream.cr
+++ b/src/gori/proxy/upstream.cr
@@ -369,6 +369,16 @@ module Gori::Proxy
       end
     end
 
+    # Why a TLS upstream dial failed. The proxy capture path records this so a failed HTTPS
+    # flow says WHAT broke instead of a blanket "connect/write failed": a Connect failure is a
+    # reachability problem, whereas a Tls failure under verify-on is almost always an untrusted
+    # / self-signed / expired origin cert (the #323 shape) whose fix is --insecure-upstream
+    # (or SSL_CERT_FILE) — guidance a "connect failed" message actively hides.
+    enum TlsDialError
+      Connect # TCP connect (or the upstream proxy's CONNECT tunnel) to the origin failed
+      Tls     # origin reached, but the TLS handshake / certificate verification failed
+    end
+
     # `sni` overrides the name presented in the TLS ClientHello (and, under verify,
     # the name the cert is checked against) WITHOUT changing the dialed host:port —
     # the repeater workbench uses it for domain-fronting / vhost-confusion / IP-direct
@@ -377,19 +387,30 @@ module Gori::Proxy
                       connect_timeout : Time::Span = Settings.connect_timeout,
                       io_timeout : Time::Span = Settings.io_timeout,
                       *, overrides : Gori::HostOverrides? = nil) : OpenSSL::SSL::Socket::Client?
+      dial_tls_result(host, port, verify, alpn, sni, connect_timeout, io_timeout, overrides: overrides)[0]
+    end
+
+    # Like `dial_tls` but also reports WHY the dial failed (see TlsDialError) as the second
+    # tuple element — nil on success. The proxy capture path uses this to record an accurate,
+    # actionable upstream error; other callers use `dial_tls` and only need the socket.
+    def self.dial_tls_result(host : String, port : Int32, verify : Bool, alpn : String? = nil, sni : String? = nil,
+                             connect_timeout : Time::Span = Settings.connect_timeout,
+                             io_timeout : Time::Span = Settings.io_timeout,
+                             *, overrides : Gori::HostOverrides? = nil) : {OpenSSL::SSL::Socket::Client?, TlsDialError?}
       tcp = dial(host, port, connect_timeout, io_timeout, overrides: overrides)
-      return nil unless tcp
+      return {nil, TlsDialError::Connect} unless tcp
       ssl = OpenSSL::SSL::Socket::Client.new(tcp, context: client_context(verify, alpn), sync_close: true, hostname: sni || host)
       ssl.sync = true
-      ssl
+      {ssl, nil}
     rescue
       # A handshake failure inside Socket::Client.new (cert mismatch under verify,
       # expired/self-signed cert, plaintext-on-443, peer reset mid-handshake) does
       # NOT close the underlying socket — sync_close only transfers ownership once
       # the SSL object is constructed. Close `tcp` ourselves or the fd leaks (one
-      # per failed origin → fd exhaustion).
+      # per failed origin → fd exhaustion). `tcp` is non-nil here: `dial` never raises
+      # (it returns nil), so the only raising step runs after the nil-guard above.
       tcp.try(&.close) rescue nil
-      nil
+      {nil, TlsDialError::Tls}
     end
 
     # Splits an "host:port" / "host" authority. Falls back to default_port.


### PR DESCRIPTION
## What

`Upstream.dial_tls` returned `nil` for *both* a TCP connect failure and a TLS/certificate-verification rejection, so the proxy capture path recorded a single blanket `"upstream connect/write failed"` for every cause. With upstream verification on by default, a self-signed / internal-CA origin (a routine pentest target) surfaced as a misleading `"connect failed"` — pointing at reachability instead of at the actual fix, `--insecure-upstream`.

## Change

- Add `Upstream::TlsDialError` (`Connect` / `Tls`) + `dial_tls_result`, which reports *why* the dial failed. `dial_tls` delegates to it, so repeater / fuzz / probe callers are unchanged (same signature, same socket-or-nil).
- `ClientConn` stashes the last dial failure and records a classified message:

  | Situation | Message |
  |---|---|
  | TLS verify failure (verify on) | `upstream TLS verification failed: h:p — origin certificate not trusted; retry with --insecure-upstream or set SSL_CERT_FILE` |
  | unreachable origin | `upstream connect failed: h:p` |
  | handshake failure, verify already off | `upstream TLS handshake failed: h:p` |
  | live socket, mid-send write failure | `upstream write failed: h:p` |

- The `--insecure-upstream` hint is added **only while verification is on** (it isn't the fix once verify is already off). The stashed reason is read only when the dial returned `nil`, so a reused/​write-fail path (live socket) never reads a stale value.

## Tests

- New specs cover the `Connect` vs `Tls` classification: an unreachable port, and an untrusted-cert origin that classifies as `Tls` under verify-on yet dials clean with verify off.
- `crystal spec spec/proxy/` → 262 examples, 0 failures.
- `crystal build` clean; ameba complexity warnings on the file are the pre-existing baseline (unchanged by this diff).