### PR TITLE
fix(settings): pretty-print settings.json for readable manual edits

### DIFF
--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -186,8 +186,8 @@ describe Gori::Settings do
       Gori::Settings.save.should be_true
       raw = File.read(Gori::Settings.path)
       raw.should contain(%("layout"))
-      raw.should contain(%("history_preview":true))
-      raw.should contain(%("history_list_order":"oldest"))
+      raw.should contain(%("history_preview": true))
+      raw.should contain(%("history_list_order": "oldest"))
 
       Gori::Settings.history_preview = false
       Gori::Settings.history_list_order = "newest"
@@ -257,8 +257,8 @@ describe Gori::Settings do
       Gori::Settings.save.should be_true
       raw = File.read(Gori::Settings.path)
       raw.should contain(%("display"))
-      raw.should contain(%("detail_pane":"response"))
-      raw.should contain(%("terminal_title":"off"))
+      raw.should contain(%("detail_pane": "response"))
+      raw.should contain(%("terminal_title": "off"))
 
       Gori::Settings.default_detail_pane = "request"
       Gori::Settings.history_time_format = "absolute"

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -180,7 +180,7 @@ module Gori
       disk_h = (JSON.parse(disk).as_h? rescue nil)
       return current unless cur_h && base_h && disk_h
       keys = (cur_h.keys + disk_h.keys).uniq!
-      JSON.build do |j|
+      JSON.build(indent: "  ") do |j|
         j.object do
           keys.each do |k|
             cur_v = cur_h[k]?
@@ -202,7 +202,7 @@ module Gori
     # reads by key), so this ordering is cosmetic/historical, kept only to make a
     # settings.json diff before/after this split a no-op.
     private def self.serialize : String
-      JSON.build do |j|
+      JSON.build(indent: "  ") do |j|
         j.object do
           serialize_appearance(j)
           serialize_layout(j)


### PR DESCRIPTION
## Summary
- `gori settings --edit` opened settings.json as a single minified line, which was awkward to hand-edit.
- Add `indent: "  "` to the two top-level `JSON.build` calls in `Settings.serialize` / `Settings.merge_with_disk` so the persisted file is pretty-printed (2-space indent). All section serializers share the same builder, so no other changes are needed.
- Updated two spec assertions that were matching the old minified `"key":value` substrings to the new `"key": value` spacing.

## Test plan
- [x] `crystal spec spec/settings_spec.cr` (42 examples, 0 failures)
- [x] `crystal spec spec/` (3436 examples, 0 failures)
- [x] Manually verified `gori settings` writes an indented `settings.json`