### PR TITLE
feat(nix): package gori as a flake, plus install docs and a Nix update channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /docs/public/
 /lib/
 /bin/
+/result
+/result-*
 /.shards/
 *.dwarf
 /ca2/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ for HTTP body decode:
 
 - macOS: `brew install crystal brotli zstd sqlite`
 - Debian/Ubuntu: `apt install crystal libbrotli-dev libzstd-dev libsqlite3-dev`
+- Nix: `nix develop` sets all of it up, pinned to the compiler CI builds with
 
 Then:
 
@@ -31,6 +32,9 @@ work via stdlib) with `crystal build -Dwithout_native_codecs`.
   you touched; `just test-<area>` runs a single subdir while iterating.
 - Never build or benchmark with `-Dpreview_mt` — gori assumes the single-threaded fiber
   scheduler.
+- If you change `shard.lock`, regenerate the Nix dependency set in the same commit:
+  `crystal2nix` (in the dev shell) rewrites `shards.nix`. `just vu` keeps `flake.nix`'s
+  version in step with `shard.yml`.
 - Keep changes scoped and behavior-preserving unless the PR is explicitly a behavior
   change; note any intentional behavior change in the PR description.
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ brew tap hahwul/gori
 brew install gori
 ```
 
+### Nix
+
+The repo is a flake, so it runs without being installed:
+
+```bash
+nix run github:hahwul/gori
+nix profile install github:hahwul/gori   # or keep it
+```
+
 ### From source
 
 Requires [Crystal](https://crystal-lang.org/) `>= 1.20.2` and `pkg-config`.

--- a/docs/content/getting-started/_index.ko.md
+++ b/docs/content/getting-started/_index.ko.md
@@ -24,7 +24,7 @@ gori는 **HTTP/1.1, HTTP/2, WebSocket, gRPC, Server-Sent Events**를 이해하�
 
 ## 다음 단계 {#next-steps}
 
-- [설치](/ko/getting-started/installation/): Homebrew, AUR, Docker, 바이너리, 또는 소스에서 빌드
+- [설치](/ko/getting-started/installation/): Homebrew, AUR, Nix, Docker, 바이너리, 또는 소스에서 빌드
 - [빠른 시작](/ko/getting-started/quick-start/): 캡처, 단축키, 그리고 첫 Repeater
 - [AI 설정](/ko/getting-started/ai-setup/): AI 에이전트를 MCP로 프로젝트에 연결
 - [설정](/ko/getting-started/configuration/): 설정, 저장소, 그리고 CA

--- a/docs/content/getting-started/_index.md
+++ b/docs/content/getting-started/_index.md
@@ -24,7 +24,7 @@ It understands **HTTP/1.1, HTTP/2, WebSocket, gRPC, and Server-Sent Events**, an
 
 ## Next Steps
 
-- [Installation](/getting-started/installation/): Homebrew, the AUR, Docker, a binary, or from source
+- [Installation](/getting-started/installation/): Homebrew, the AUR, Nix, Docker, a binary, or from source
 - [Quick Start](/getting-started/quick-start/): capture, keys, and your first Repeater
 - [AI Setup](/getting-started/ai-setup/): connect an AI agent to the project over MCP
 - [Configuration](/getting-started/configuration/): settings, storage, and the CA

--- a/docs/content/getting-started/installation.ko.md
+++ b/docs/content/getting-started/installation.ko.md
@@ -68,7 +68,9 @@ NixOS / home-manager 설정에 입력(input)으로 고정할 수도 있습니다
 }
 ```
 
-다른 채널과 달리 이 채널은 **소스에서 빌드**하므로, 첫 설치에는 컴파일에 몇 분이 걸립니다. Brotli와 Zstd 디코딩이 포함되며 호스트에 따로 준비할 것은 없습니다. Linux와 macOS의 x86_64 및 arm64에서 동작합니다.
+다른 채널과 달리 이 채널은 **소스에서 빌드**합니다. nixpkgs의 Crystal이 gori가 요구하는 버전보다 한 단계 낮아, 플레이크가 컴파일러를 직접 고정하며 첫 빌드는 그것까지 함께 컴파일합니다. 몇 분이 걸리고 이후로는 캐시됩니다. Brotli와 Zstd 디코딩이 포함되며 호스트에 따로 준비할 것은 없습니다.
+
+Linux(x86_64 및 arm64)와 Apple Silicon macOS를 지원합니다. nixpkgs가 Intel macOS 지원을 중단했으므로, 그쪽에서는 [Homebrew](#homebrew)나 [사전 빌드 바이너리](#pre-built-binary)를 사용하세요.
 
 `nix develop`을 실행하면 Crystal, shards, `just`와 링크되는 라이브러리가 갖춰진 셸로 들어갑니다. [gori 자체를 개발](https://github.com/hahwul/gori/blob/main/CONTRIBUTING.md)하는 데 필요한 것이 모두 들어 있습니다.
 

--- a/docs/content/getting-started/installation.ko.md
+++ b/docs/content/getting-started/installation.ko.md
@@ -1,6 +1,6 @@
 +++
 title = "설치"
-description = "curl, Homebrew, AUR, Docker, 사전 빌드 바이너리, 또는 소스에서 gori를 설치합니다."
+description = "curl, Homebrew, AUR, Nix, Docker, 사전 빌드 바이너리, 또는 소스에서 gori를 설치합니다."
 weight = 10
 +++
 
@@ -42,6 +42,35 @@ yay -S gori
 # or
 paru -S gori
 ```
+
+## Nix {#nix}
+
+이 저장소는 [플레이크(flake)](https://wiki.nixos.org/wiki/Flakes)이므로, 설치하지 않고 바로 실행할 수 있습니다:
+
+```bash
+nix run github:hahwul/gori
+```
+
+프로필에 설치하려면:
+
+```bash
+nix profile install github:hahwul/gori
+```
+
+NixOS / home-manager 설정에 입력(input)으로 고정할 수도 있습니다:
+
+```nix
+{
+  inputs.gori.url = "github:hahwul/gori";
+
+  # 이후 패키지 목록에서:
+  #   inputs.gori.packages.${pkgs.system}.default
+}
+```
+
+다른 채널과 달리 이 채널은 **소스에서 빌드**하므로, 첫 설치에는 컴파일에 몇 분이 걸립니다. Brotli와 Zstd 디코딩이 포함되며 호스트에 따로 준비할 것은 없습니다. Linux와 macOS의 x86_64 및 arm64에서 동작합니다.
+
+`nix develop`을 실행하면 Crystal, shards, `just`와 링크되는 라이브러리가 갖춰진 셸로 들어갑니다. [gori 자체를 개발](https://github.com/hahwul/gori/blob/main/CONTRIBUTING.md)하는 데 필요한 것이 모두 들어 있습니다.
 
 ## Docker {#docker}
 

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -68,7 +68,9 @@ Or pin it as an input to a NixOS / home-manager configuration:
 }
 ```
 
-Unlike the other channels this one **builds from source**, so the first install spends a few minutes compiling. Brotli and Zstd decoding are included; nothing else is needed on the host. Works on Linux and macOS, x86_64 and arm64.
+Unlike the other channels this one **builds from source**. nixpkgs is still a Crystal release behind what gori needs, so the flake pins its own compiler and a cold build compiles that too: several minutes, cached from then on. Brotli and Zstd decoding are included, and nothing else is needed on the host.
+
+Covers Linux (x86_64 and arm64) and Apple Silicon macOS. nixpkgs has dropped Intel macOS, so on those machines use [Homebrew](#homebrew) or a [pre-built binary](#pre-built-binary).
 
 `nix develop` gives you a shell with Crystal, shards, `just` and the linked libraries, which is all you need to [hack on gori itself](https://github.com/hahwul/gori/blob/main/CONTRIBUTING.md).
 

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -1,6 +1,6 @@
 +++
 title = "Installation"
-description = "Install gori via curl, Homebrew, the AUR, Docker, a pre-built binary, or from source."
+description = "Install gori via curl, Homebrew, the AUR, Nix, Docker, a pre-built binary, or from source."
 weight = 10
 +++
 
@@ -42,6 +42,35 @@ yay -S gori
 # or
 paru -S gori
 ```
+
+## Nix
+
+The repository is a [flake](https://wiki.nixos.org/wiki/Flakes), so you can run gori without installing it at all:
+
+```bash
+nix run github:hahwul/gori
+```
+
+Install it into your profile instead:
+
+```bash
+nix profile install github:hahwul/gori
+```
+
+Or pin it as an input to a NixOS / home-manager configuration:
+
+```nix
+{
+  inputs.gori.url = "github:hahwul/gori";
+
+  # then, in your package list:
+  #   inputs.gori.packages.${pkgs.system}.default
+}
+```
+
+Unlike the other channels this one **builds from source**, so the first install spends a few minutes compiling. Brotli and Zstd decoding are included; nothing else is needed on the host. Works on Linux and macOS, x86_64 and arm64.
+
+`nix develop` gives you a shell with Crystal, shards, `just` and the linked libraries, which is all you need to [hack on gori itself](https://github.com/hahwul/gori/blob/main/CONTRIBUTING.md).
 
 ## Docker
 

--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -19,7 +19,7 @@ gori [command] [options]
 | `settings` | `settings.json` 표시 또는 편집 |
 | `wizard` | 대화형 최초 실행 설정 |
 | `tutorial` | 가이드형 TUI 투어 (탐색, 팔레트, 스페이스 메뉴, 편집 모드) |
-| `update` | 채널 인식 자체 업데이트 (바이너리 / Homebrew / Snap / AUR) |
+| `update` | 채널 인식 자체 업데이트 (바이너리 / Homebrew / Snap / AUR / Nix) |
 
 전역 플래그: `-v` / `--version`, `-h` / `--help`.
 
@@ -535,6 +535,7 @@ gori update --exec   # Homebrew/Snap: run the package-manager command
 | pacman / AUR | `yay` / `paru` / `pacman` 안내 출력 |
 | deb (dpkg) | `apt` 업그레이드 안내 출력 |
 | rpm | `dnf` / `yum` / `zypper` 안내 출력 |
+| Nix (`/nix/store`) | `nix profile upgrade` / 플레이크 업데이트 안내 출력; 스토어가 읽기 전용이므로 아무것도 내려받지 않음 |
 
 `/usr/bin` 또는 `/bin` 아래 경로는 패키지 소유권(`pacman -Qo`, `dpkg-query -S`, `rpm -qf`)으로 분류됩니다. 관리자가 파일을 소유하면 gori는 절대 덮어쓰지 않습니다. 프로브가 소유자를 찾지 못하면 바이너리 채널이 자체 업데이트합니다. 패키지 도구가 전혀 없으면 `/etc/os-release`(`ID` / `ID_LIKE`)로 Arch 계열 / Debian 계열 / RHEL 계열 안내를 폴백으로 고릅니다.
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -19,7 +19,7 @@ gori [command] [options]
 | `settings` | Show or edit `settings.json` |
 | `wizard` | Interactive first-run setup |
 | `tutorial` | Guided TUI tour (navigation, palette, space menu, edit mode) |
-| `update` | Channel-aware self-update (binary / Homebrew / Snap / AUR) |
+| `update` | Channel-aware self-update (binary / Homebrew / Snap / AUR / Nix) |
 
 Global flags: `-v` / `--version`, `-h` / `--help`.
 
@@ -535,6 +535,7 @@ Detects how this `gori` binary was installed and updates accordingly:
 | pacman / AUR | Prints `yay` / `paru` / `pacman` guidance |
 | deb (dpkg) | Prints `apt` upgrade guidance |
 | rpm | Prints `dnf` / `yum` / `zypper` guidance |
+| Nix (`/nix/store`) | Prints `nix profile upgrade` / flake-update guidance; the store is read-only, so nothing is downloaded |
 
 Paths under `/usr/bin` or `/bin` are classified by package ownership (`pacman -Qo`, `dpkg-query -S`, `rpm -qf`). If a manager owns the file, gori never overwrites it. If probes find no owner, the binary channel self-updates. When no package tools are available, `/etc/os-release` (`ID` / `ID_LIKE`) picks Arch-like / Debian-like / RHEL-like guidance as a fallback.
 

--- a/docs/templates/page.html
+++ b/docs/templates/page.html
@@ -22,6 +22,7 @@
           <button type="button" class="install-tab" aria-pressed="true" data-cmd="curl -fsSL https://gori.hahwul.com/install.sh | bash">curl</button>
           <button type="button" class="install-tab" aria-pressed="false" data-cmd="brew install hahwul/gori/gori">brew</button>
           <button type="button" class="install-tab" aria-pressed="false" data-cmd="yay -S gori">AUR</button>
+          <button type="button" class="install-tab" aria-pressed="false" data-cmd="nix profile install github:hahwul/gori">nix</button>
           <button type="button" class="install-tab" aria-pressed="false" data-cmd="docker run --rm -it -v gori:/data -p 8070:8070 ghcr.io/hahwul/gori --listen 0.0.0.0">docker</button>
         </div>
         <div class="install-line">

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1784783405,
+        "narHash": "sha256-4IHyyLgLBdKefkljdKod4IMn023pQiDXAWJA187cmdY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7525d999cd850b9a488817abc89c75dc733acf17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -94,7 +94,15 @@
             homepage = "https://gori.hahwul.com";
             downloadPage = "https://github.com/hahwul/gori/releases";
             license = lib.licenses.asl20;
-            maintainers = [ "hahwul" ];
+            # An attrset, not a bare string: nixpkgs types this as `listOf attrs`
+            # (check-meta.nix), and anything reading meta.maintainers expects the
+            # maintainer shape. No lib.maintainers.hahwul exists to reference yet.
+            maintainers = [{
+              name = "hahwul";
+              email = "hahwul@gmail.com";
+              github = "hahwul";
+              githubId = 13212227;
+            }];
             mainProgram = "gori";
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,11 @@
   };
 
   outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+    # Not eachDefaultSystem: that set includes x86_64-darwin, which nixpkgs 26.11
+    # dropped outright, so every output would fail to even evaluate there (and take
+    # `nix flake show` down with it). Intel macOS installs via Homebrew or the
+    # release tarball instead.
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ] (system:
       let
         pkgs = import nixpkgs { inherit system; };
         inherit (pkgs) lib;
@@ -41,10 +45,13 @@
         #   brotli -> src/gori/proxy/codec/brotli.cr  @[Link(pkg_config: "libbrotlidec")]
         #   zstd   -> src/gori/proxy/codec/zstd.cr    @[Link(pkg_config: "libzstd")]
         #   sqlite -> the sqlite3 shard               @[Link("sqlite3")]
+        #   gmp    -> src/gori/decoder/codecs.cr      `require "big"`
         #
+        # gmp is easy to miss: nixpkgs' crystal lists it under nativeCheckInputs only,
+        # so the stdlib emits `-lgmp` with no `-L` to match and the link dies.
         # brotli/zstd resolve through pkg-config, so they need their `dev` outputs —
         # which is exactly what listing them in buildInputs arranges.
-        nativeLibs = with pkgs; [ brotli zstd sqlite ];
+        nativeLibs = with pkgs; [ brotli zstd sqlite gmp ];
 
         # `lib/` and `bin/` are shards' working dirs: buildCrystalPackage populates
         # `lib/` itself from shards.nix, so a checkout that already ran `shards

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,118 @@
+{
+  description = "gori: a fast, keyboard-driven HTTP/HTTPS intercepting proxy and web-hacking workbench for the terminal";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        inherit (pkgs) lib;
+
+        # nixpkgs still ships Crystal 1.19.1, which is below shard.yml's
+        # `crystal: '>= 1.20.2'` and does not compile gori: src/gori/proxy/
+        # socket_tuning.cr reopens OpenSSL::SSL::Socket to reach `#bio`, which only
+        # exists from 1.20 on. So pin the version gori's CI builds with instead.
+        # Delete this override (and use pkgs.crystal) once nixpkgs is >= 1.20.2.
+        crystalVersion = "1.21.0";
+        crystal = pkgs.crystal_1_19.overrideAttrs (old: {
+          version = crystalVersion;
+          src = pkgs.fetchFromGitHub {
+            owner = "crystal-lang";
+            repo = "crystal";
+            rev = crystalVersion;
+            hash = "sha256-QnFj6JIWdfkTLKvqT3R9LwdImwunkLz+YTDVmPtKSzk=";
+          };
+          makeFlags = [ "CRYSTAL_CONFIG_VERSION=${crystalVersion}" "progress=1" ];
+          # 1.21 stopped shipping a pre-generated man/crystal.1 — it is rendered from
+          # doc/man/*.adoc by a make target nixpkgs' buildFlags do not run, so the
+          # stock installPhase dies on it. Dropping that one line beats pulling
+          # asciidoctor into the compiler build for a page nothing here reads.
+          installPhase = builtins.replaceStrings
+            [ "installManPage man/crystal.1" ] [ "" ] old.installPhase;
+        });
+
+        # Libraries gori links on top of what the `crystal` wrapper already puts on
+        # CRYSTAL_LIBRARY_PATH (openssl, libyaml, zlib, pcre2, boehm-gc, libevent):
+        #
+        #   brotli -> src/gori/proxy/codec/brotli.cr  @[Link(pkg_config: "libbrotlidec")]
+        #   zstd   -> src/gori/proxy/codec/zstd.cr    @[Link(pkg_config: "libzstd")]
+        #   sqlite -> the sqlite3 shard               @[Link("sqlite3")]
+        #
+        # brotli/zstd resolve through pkg-config, so they need their `dev` outputs —
+        # which is exactly what listing them in buildInputs arranges.
+        nativeLibs = with pkgs; [ brotli zstd sqlite ];
+
+        # `lib/` and `bin/` are shards' working dirs: buildCrystalPackage populates
+        # `lib/` itself from shards.nix, so a checkout that already ran `shards
+        # install` must not leak its copy into the sandbox. `docs/` is the website
+        # and is never compiled — dropping it keeps doc edits from busting the
+        # build's input hash.
+        src = lib.cleanSourceWith {
+          name = "gori-source";
+          src = lib.cleanSource ./.;
+          filter = path: type:
+            let base = baseNameOf (toString path);
+            in !(type == "directory" && (base == "lib" || base == "bin" || base == "docs"));
+        };
+
+        gori = crystal.buildCrystalPackage {
+          pname = "gori";
+          version = "0.1.3";
+
+          inherit src;
+
+          # `crystal` (not `shards`) as the builder: `lib/` is already materialised
+          # from shards.nix during configurePhase, so going through shards would only
+          # add a dependency resolution step that the sandbox has no network for.
+          format = "crystal";
+          shardsFile = ./shards.nix;
+
+          crystalBinaries.gori.src = "src/main.cr";
+          # Deliberately NO `-Dpreview_mt`: Store, Fuzz::Engine, Miner::Engine and
+          # Store::SafeRegexp rely on the single-threaded fiber scheduler for their
+          # unguarded ivars. See the comments in those files before changing this.
+          crystalBinaries.gori.options = [ "--release" "--no-debug" "--progress" ];
+
+          buildInputs = nativeLibs;
+
+          # The suite binds real ports and spawns proxies; leave it to CI.
+          doCheck = false;
+
+          meta = {
+            description = "A fast, keyboard-driven HTTP/HTTPS intercepting proxy and web-hacking workbench for the terminal";
+            homepage = "https://gori.hahwul.com";
+            downloadPage = "https://github.com/hahwul/gori/releases";
+            license = lib.licenses.asl20;
+            maintainers = [ "hahwul" ];
+            mainProgram = "gori";
+          };
+        };
+      in
+      {
+        packages.default = gori;
+        packages.gori = gori;
+
+        apps.default = flake-utils.lib.mkApp { drv = gori; };
+
+        checks.default = gori;
+
+        devShells.default = pkgs.mkShell {
+          # crystal + the linked libraries, straight from the package definition.
+          inputsFrom = [ gori ];
+          # `shards` is absent from a format = "crystal" build; the dev loop needs it,
+          # plus `just` for the task runner and `crystal2nix` to regenerate shards.nix
+          # whenever shard.lock moves.
+          nativeBuildInputs = with pkgs; [ shards crystal2nix just git ];
+
+          shellHook = ''
+            echo "gori dev shell (crystal $(crystal version | head -n1 | cut -d' ' -f2))"
+            echo "  just build   # bin/gori (debug)   just test   # crystal spec"
+            echo "  after editing shard.lock: crystal2nix && git add shards.nix"
+          '';
+        };
+      });
+}

--- a/justfile
+++ b/justfile
@@ -20,6 +20,16 @@ dev: build
 build:
     shards build
 
+# Build through the flake — the exact path `nix profile install` takes.
+[group('build')]
+nix-build:
+    nix build .#gori
+
+# Regenerate shards.nix from shard.lock (run it alongside any dependency change).
+[group('build')]
+nix-shards:
+    nix run nixpkgs#crystal2nix
+
 # Run all tests.
 [group('development')]
 test:

--- a/scripts/version_check.cr
+++ b/scripts/version_check.cr
@@ -8,6 +8,7 @@ FILES = {
   "src/gori.cr"                                     => /VERSION = "([^"]+)"/,
   "snap/snapcraft.yaml"                             => /^version:\s*(\S+)/m,
   "aur/PKGBUILD"                                    => /^pkgver=(\S+)/m,
+  "flake.nix"                                       => /version = "([^"]+)";/,
   "spec/gori_spec.cr"                               => /VERSION\.should eq\("([^"]+)"\)/,
   "docs/content/getting-started/installation.md"    => /You should see `gori ([^`]+)`\./,
   "docs/content/getting-started/installation.ko.md" => /`gori ([^`]+)`이 표시되어야 합니다\./,

--- a/scripts/version_update.cr
+++ b/scripts/version_update.cr
@@ -4,12 +4,17 @@
 # scripts/version_check.cr.
 #
 # Usage: crystal run scripts/version_update.cr  (just vu)
+#
+# flake.nix holds two versions; the pattern below hits gori's and not the pinned
+# compiler's, because that one is spelled `crystalVersion` (capital V) and the
+# attribute referencing it, `version = crystalVersion;`, has no string literal.
 
 FILES = {
   "shard.yml"                                       => {/^version:\s*\S+/m, ->(v : String) { "version: #{v}" }},
   "src/gori.cr"                                     => {/VERSION = "[^"]+"/, ->(v : String) { %(VERSION = "#{v}") }},
   "snap/snapcraft.yaml"                             => {/^version:\s*\S+/m, ->(v : String) { "version: #{v}" }},
   "aur/PKGBUILD"                                    => {/^pkgver=\S+/m, ->(v : String) { "pkgver=#{v}" }},
+  "flake.nix"                                       => {/version = "[^"]+";/, ->(v : String) { %(version = "#{v}";) }},
   "spec/gori_spec.cr"                               => {/VERSION\.should eq\("[^"]+"\)/, ->(v : String) { %(VERSION.should eq("#{v}")) }},
   "docs/content/getting-started/installation.md"    => {/You should see `gori [^`]+`\./, ->(v : String) { "You should see `gori #{v}`." }},
   "docs/content/getting-started/installation.ko.md" => {/`gori [^`]+`이 표시되어야 합니다\./, ->(v : String) { "`gori #{v}`이 표시되어야 합니다." }},

--- a/shards.nix
+++ b/shards.nix
@@ -1,0 +1,22 @@
+{
+  "ameba" = {
+    url = "https://github.com/crystal-ameba/ameba.git";
+    rev = "fcbd5703c50b47a5f280a11ab1c3416f5f3a9ea9";
+    sha256 = "0lcpbvjbhzq4njby80xqkz0cbw1iappjs1j36vfymxjjwvdf4ag8";
+  };
+  "db" = {
+    url = "https://github.com/crystal-lang/crystal-db.git";
+    rev = "v0.14.0";
+    sha256 = "1s67fs5abzgg2yyjsm2la967mk881i91h8jdnal072fb9qh9wr58";
+  };
+  "sqlite3" = {
+    url = "https://github.com/crystal-lang/crystal-sqlite3.git";
+    rev = "v0.23.0";
+    sha256 = "1adfdw19r5b1dhzs3x410z5s1cgan4ypgmhph3fqsa65svvw83af";
+  };
+  "termisu" = {
+    url = "https://github.com/hahwul/termisu.git";
+    rev = "825b6f37fd550807120499334b50a3a5367b248f";
+    sha256 = "0m52wqb1lf015za4ck7xdwm89ravfxk581nz2spgk72d03gxbmws";
+  };
+}

--- a/spec/update_spec.cr
+++ b/spec/update_spec.cr
@@ -21,6 +21,16 @@ describe Gori::Update do
       Gori::Update.detect_channel("/snap/bin/gori").should eq(Gori::Update::Channel::Snap)
     end
 
+    it "detects Nix store paths" do
+      Gori::Update.detect_channel("/nix/store/0fhkwk15n3ya0llfr0754awcldpz4x54-gori-0.1.3/bin/gori")
+        .should eq(Gori::Update::Channel::Nix)
+      # `~/.nix-profile/bin/gori` is a symlink; the caller realpaths it into the store
+      # before this runs, so only the resolved form has to match.
+      Gori::Update.detect_channel("/nix/store/abc-gori-0.1.3/bin/gori")
+        .should eq(Gori::Update::Channel::Nix)
+      Gori::Update.detect_channel("/home/u/nix/store/gori").should eq(Gori::Update::Channel::Binary)
+    end
+
     it "classifies /usr/bin by package ownership, not path alone" do
       Gori::Update.detect_channel("/usr/bin/gori",
         owner: Gori::Update::OwnerResult::Pacman).should eq(Gori::Update::Channel::Pacman)
@@ -325,6 +335,13 @@ describe Gori::Update do
       rpm[:message].should match(/dnf|yum|zypper/i)
     end
 
+    it "returns nix guidance without a single auto-run command" do
+      action = Gori::Update.package_action(Gori::Update::Channel::Nix)
+      action[:command].should be_nil
+      action[:message].should contain("nix profile upgrade gori")
+      action[:message].should match(/read-only/i)
+    end
+
     it "describes standalone binary self-update" do
       action = Gori::Update.package_action(Gori::Update::Channel::Binary)
       action[:command].should be_nil
@@ -364,6 +381,16 @@ describe Gori::Update do
       out = io.to_s
       out.should contain("install channel: pacman")
       out.should contain("yay -Syu gori")
+    end
+
+    it "prints nix guidance instead of downloading into the read-only store" do
+      io = IO::Memory.new
+      Gori::Update.run(io, io,
+        exe_path: "/nix/store/0fhkwk15n3ya0llfr0754awcldpz4x54-gori-0.1.3/bin/gori")
+      out = io.to_s
+      out.should contain("install channel: nix")
+      out.should contain("nix profile upgrade gori")
+      out.should_not contain("Running:")
     end
 
     it "prints apt guidance for dpkg-owned /usr/bin" do

--- a/src/gori/update.cr
+++ b/src/gori/update.cr
@@ -44,6 +44,7 @@ module Gori
       Pacman
       Deb
       Rpm
+      Nix
       Binary
     end
 
@@ -70,6 +71,10 @@ module Gori
 
     # Classify an install from the executable path plus optional ownership/OS hints.
     #
+    # The Nix store is checked first: it is the one root that is *immutable*, so a
+    # self-update there cannot even be attempted (and `~/.nix-profile/bin/gori` is a
+    # symlink chain the caller's `File.realpath` has already resolved into it).
+    #
     # For FHS system bins (`/usr/bin`, `/bin`):
     # - owned by pacman/dpkg/rpm → that package channel (never overwrite)
     # - probed and **not** owned → Binary (manual copy; self-update allowed)
@@ -77,6 +82,7 @@ module Gori
     def self.detect_channel(exe_path : String, *,
                             owner : OwnerResult = OwnerResult::Unknown,
                             os_family : OsFamily = OsFamily::Unknown) : Channel
+      return Channel::Nix if nix_path?(exe_path)
       return Channel::Snap if snap_path?(exe_path)
       return Channel::Homebrew if homebrew_path?(exe_path)
 
@@ -123,6 +129,14 @@ module Gori
 
     def self.snap_path?(path : String) : Bool
       path.starts_with?("/snap/") || path.includes?("/snap/gori/")
+    end
+
+    # Covers every Nix entry point — `nix profile`, `nix run`, NixOS/home-manager —
+    # because all of them ultimately resolve to a store path. Kept to the default
+    # store location (a relocated NIX_STORE_DIR would degrade to Binary, which the
+    # read-only store then rejects with a plain permission error).
+    def self.nix_path?(path : String) : Bool
+      path.starts_with?("/nix/store/")
     end
 
     # Paths where distro packages typically install the CLI (not /usr/local).
@@ -251,6 +265,13 @@ module Gori
           message: "RPM package install detected. Upgrade with your package manager (do not overwrite /usr/bin):\n  sudo dnf upgrade gori\n  # or: sudo yum upgrade gori\n  # or: sudo zypper update gori",
           command: nil,
         }
+      when .nix?
+        # No `command:` — which one is right depends on how it was installed, and the
+        # store is read-only either way, so guessing would be worse than listing them.
+        {
+          message: "Nix install detected (the store is read-only). Upgrade the way you installed it:\n  nix profile upgrade gori\n  # declarative (NixOS / home-manager): nix flake update gori, then rebuild\n  # one-off run of the latest: nix run github:hahwul/gori",
+          command: nil,
+        }
       else
         {
           message: "Standalone binary install — downloading the latest GitHub release asset.",
@@ -260,7 +281,7 @@ module Gori
     end
 
     def self.package_managed?(channel : Channel) : Bool
-      channel.homebrew? || channel.snap? || channel.pacman? || channel.deb? || channel.rpm?
+      channel.homebrew? || channel.snap? || channel.pacman? || channel.deb? || channel.rpm? || channel.nix?
     end
 
     # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #292.

## What

Makes gori installable with Nix, and teaches `gori update` about it.

- **`flake.nix`** — `packages.default` / `packages.gori`, `apps.default` (so `nix run github:hahwul/gori` works), `checks.default`, and a `devShells.default` carrying crystal, shards, crystal2nix and just.
- **`shards.nix`** — generated by `crystal2nix` from `shard.lock`; regenerate it in the same commit as any dependency change (`just nix-shards`).
- **`gori update`** — a binary under `/nix/store` cannot self-update, so it now detects the Nix channel and prints `nix profile upgrade` / flake-update guidance instead of downloading a release asset into a read-only path.
- **Docs** — a Nix section in the installation guide (EN + KO, matching `#nix` anchors), a `nix` tab in the landing install picker, the `gori update` channel tables in the CLI reference, README and CONTRIBUTING.
- **Plumbing** — `flake.nix` joins the version-checked file set (`just vc` / `just vu`), `just nix-build` / `just nix-shards`, and `/result` in `.gitignore`.

## Four things the packaging had to work around

All four are commented in `flake.nix` rather than left as folklore. Each one was found by actually running `nix build`, not by reading:

1. **nixpkgs still ships Crystal 1.19.1**, below `shard.yml`'s `crystal: '>= 1.20.2'`, and it genuinely does not compile gori — `src/gori/proxy/socket_tuning.cr` reopens `OpenSSL::SSL::Socket` to reach `#bio`, which only exists from 1.20 on (and the `rescue nil` there cannot catch a *compile* error). The flake pins **1.21.0**, the version CI builds with, by overriding `crystal_1_19`. The override is written to be deleted once nixpkgs catches up.
2. **Crystal 1.21 no longer ships a pre-generated `man/crystal.1`** (it is rendered from `doc/man/*.adoc` by a make target nixpkgs' `buildFlags` do not run), so the stock `installPhase` died on it. Dropping that one line beats pulling asciidoctor into the compiler build for a page nothing here reads.
3. **`ld: library not found for -lgmp`.** nixpkgs' crystal lists gmp under `nativeCheckInputs` only, so the wrapper's `CRYSTAL_LIBRARY_PATH` omits it while `require "big"` still emits a bare `-lgmp`. gmp was the only gap; openssl, yaml, zlib, pcre2, gc, libevent and iconv all arrive through the wrapper.
4. **x86_64-darwin cannot be supported.** nixpkgs 26.11 dropped the platform, so under `eachDefaultSystem` every output failed to evaluate there and took `nix flake show` down with it. The flake now declares the three systems that actually build.

The package builds through `crystal`, not `shards` (`format = "crystal"`): `buildCrystalPackage` already materialises `lib/` from `shards.nix` during `configurePhase`, and the sandbox has no network for dependency resolution. Deliberately **no `-Dpreview_mt`**, matching every other gori build.

## Verification

Ran, not assumed:

- **`nix build .#gori` on aarch64-darwin: green.** With the flake-built binary: `--version` / `--help`, root-CA generation, and an end-to-end proxy run (`gori run capture` → `curl -x` → flow captured to SQLite → read back via `gori run history`). Brotli- and Zstd-encoded responses both decode to plaintext through `gori run show`, which exercises the pkg-config linkage this flake sets up.
- `nix flake show` clean; `packages.{x86_64-linux,aarch64-linux,aarch64-darwin}.default` all evaluate.
- Full spec suite: **3439 examples, 0 failures**.
- `crystal tool format --check` and ameba clean on the touched files (no new findings against baseline).
- `just vc` passes with `flake.nix` in the tracked set.
- Docs site builds; both language variants render a `#nix` anchor and resolve the new cross-links; the landing picker keeps all five tabs on one row.

Only aarch64-darwin was built end-to-end — the Linux systems are evaluated but not compiled here.

## Not included

No CI job for the flake. Until nixpkgs ships Crystal >= 1.20.2, a cold flake build compiles the compiler from source (~5-7 min, on top of gori's own ~1 min), which is too slow to put on every push.