### PR TITLE
fix(cli,import): harden `gori run` — scope gate, import smuggling, byte-exact replay

### DIFF
--- a/spec/import/import_spec.cr
+++ b/spec/import/import_spec.cr
@@ -628,4 +628,96 @@ describe Gori::Import do
       File.delete?(oas)
     end
   end
+
+  # --- valid-JSON-but-wrong-shape files must be clean errors, not raw crashes -------------
+  # JSON::Any#[](String) raises a plain Exception on a non-Hash; cmd_import only rescues
+  # Gori::Error, so an unshaped-but-valid file used to dump a raw backtrace.
+  it "raises a clean Gori::Error (not a raw crash) for a valid-JSON but wrong-shape HAR" do
+    ["[]", %q({"log":"oops"}), "42"].each do |bad|
+      har = File.tempname("gori", ".har")
+      begin
+        File.write(har, bad)
+        with_store do |store|
+          expect_raises(Gori::Error) { Gori::Import.import_file(store, :har, har) }
+        end
+      ensure
+        File.delete?(har)
+      end
+    end
+  end
+
+  it "raises a clean Gori::Error (not a raw crash) for a valid-JSON but wrong-shape OpenAPI spec" do
+    oas = File.tempname("gori", ".json")
+    begin
+      File.write(oas, "[]")
+      with_store do |store|
+        expect_raises(Gori::Error) { Gori::Import.import_file(store, :oas, oas) }
+      end
+    ensure
+      File.delete?(oas)
+    end
+  end
+
+  # --- header/start-line CRLF injection (request smuggling on later replay) ---------------
+  it "skips a HAR entry whose header value smuggles a CRLF, leaving no fabricated request" do
+    # \r\n in a header value would forge a second HTTP message inside the stored head, which
+    # gori replays byte-exact. The bad entry is dropped (counted as skipped); the clean one
+    # imports, and the stored head carries no injected line.
+    inject = %q(bar\r\nX-Injected: evil\r\n\r\nGET /admin HTTP/1.1)
+    har = File.tempname("gori", ".har")
+    begin
+      File.write(har, <<-JSON)
+        {"log":{"entries":[
+          {"startedDateTime":"2026-06-01T12:00:00Z","request":{"method":"GET","url":"https://ok.test/a","httpVersion":"HTTP/1.1","headers":[{"name":"Accept","value":"*/*"}]}},
+          {"startedDateTime":"2026-06-01T12:00:00Z","request":{"method":"GET","url":"https://bad.test/b","httpVersion":"HTTP/1.1","headers":[{"name":"X-Foo","value":"#{inject}"}]}}
+        ]}}
+        JSON
+
+      with_store do |store|
+        result = Gori::Import.import_file(store, :har, har)
+        result.count.should eq(1)
+        result.skipped.should eq(1)
+        row = store.search(Gori::QL::EMPTY, 10).first
+        row.host.should eq("ok.test")
+        String.new(store.get_flow(row.id).not_nil!.request_head).should_not contain("X-Injected")
+      end
+    ensure
+      File.delete?(har)
+    end
+  end
+end
+
+describe Gori::Import::Builder do
+  it "rejects a header value containing CR/LF (request smuggling guard)" do
+    headers = Gori::Import::Builder::Headers.new
+    headers << {"X-Foo", "bar\r\nX-Injected: evil"}
+    expect_raises(Gori::Error, /control character/) do
+      Gori::Import::Builder.request_head("GET", "/", "HTTP/1.1", "h.test", headers, nil)
+    end
+  end
+
+  it "rejects a header NAME containing CR/LF" do
+    headers = Gori::Import::Builder::Headers.new
+    headers << {"X-Foo\r\nEvil", "bar"}
+    expect_raises(Gori::Error, /control character/) do
+      Gori::Import::Builder.response_head("HTTP/1.1", 200, "OK", headers, nil)
+    end
+  end
+
+  it "rejects a method / reason phrase containing CR/LF (start-line smuggling guard)" do
+    empty = Gori::Import::Builder::Headers.new
+    expect_raises(Gori::Error, /control character/) do
+      Gori::Import::Builder.request_head("GET\r\nHost: evil", "/", "HTTP/1.1", "h.test", empty, nil)
+    end
+    expect_raises(Gori::Error, /control character/) do
+      Gori::Import::Builder.response_head("HTTP/1.1", 200, "OK\r\nX-Injected: evil", empty, nil)
+    end
+  end
+
+  it "allows a horizontal tab in a header value (a legal field-value byte, not a boundary)" do
+    headers = Gori::Import::Builder::Headers.new
+    headers << {"X-Foo", "a\tb"}
+    head = String.new(Gori::Import::Builder.request_head("GET", "/", "HTTP/1.1", "h.test", headers, nil))
+    head.should contain("X-Foo: a\tb")
+  end
 end

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -135,7 +135,7 @@ module Gori
         {"history (ls)", "List / QL-query captured flows"},
         {"show <id>", "Print a flow's request/response (text, json, or raw bytes)"},
         {"repeater", "Re-send a captured flow; list/create/send (replay, incl. WebSocket) repeater sessions"},
-        {"compare <a> <b>", "Diff two flows' request or response, side-by-side"},
+        {"compare <a> <b>", "Diff two flows' request or response (unified diff)"},
         {"intercept", "Inspect/drive a live TUI's paused intercept queue (list, forward, drop, edit, …)"},
         {"fuzz [<id>]", "Fuzz/intrude a request: mark §…§ positions, sweep payloads"},
         {"mine [<id>]", "Discover hidden parameters (query/form/multipart/json/header/cookie)"},
@@ -235,6 +235,43 @@ module Gori
         end
       rescue
         nil
+      end
+
+      # Project Scope for a CLI direct-dial command (fuzz/mine/sequence) — the missing gate
+      # that let those three fire at any host regardless of scope/Sandbox, unlike the TUI,
+      # MCP, and `gori run discover`/`repeater` which all enforce it. Loaded on the same
+      # trigger as cli_host_overrides (a project is in play). A SNAPSHOT: Scope.load reads
+      # every rule into memory, so the store can close and the read-only sandbox/exclude/
+      # include checks still work — ScopedBackend gets reload_every: nil (a short CLI run
+      # needs no mid-run reload). nil for --request/stdin with no project (nothing to gate
+      # against). A scope that fails to load must NOT silently fail OPEN (unlike overrides'
+      # rescue-to-nil): a raise here becomes a clean fail-CLOSED abort — never a raw
+      # backtrace, never a silently-unscoped run. (open_store already aborts on a bad DB.)
+      private def self.cli_scope(project_name : String?, db_path : String?, flow_id : Int64?) : Gori::Scope?
+        return nil unless flow_id || project_name || db_path
+        store = open_store(resolve_read_project(project_name, db_path))
+        begin
+          Gori::Scope.load(store)
+        rescue ex
+          store.close
+          abort "gori run: could not load project scope (refusing to send unscoped): #{ex.message}"
+        ensure
+          store.close
+        end
+      end
+
+      # Up-front include-scope gate for the CLI direct-dial tools (fuzz/mine/sequence),
+      # mirroring `guard_discover_scope`: when the project HAS a configured scope and the
+      # target is outside it, refuse unless --allow-unscoped. An unconfigured scope (or no
+      # project) does NOT block here — the same permissive default as `gori run discover`.
+      # This is only the soft include boundary; Sandbox mode + explicit exclude rules are
+      # still enforced per-request by Fuzz::ScopedBackend regardless of --allow-unscoped.
+      private def self.guard_active_scope(scope : Gori::Scope?, scheme : String, host : String,
+                                          target : String, allow_unscoped : Bool, cmd : String) : Nil
+        return if allow_unscoped
+        return unless (s = scope) && s.configured?
+        return if s.matches_url?(Gori::Scope.request_url(scheme, host, target), host)
+        abort "#{cmd}: #{host} is out of the project scope — add a scope include rule or pass --allow-unscoped"
       end
 
       # QL negation terms ("-field:value" / "-field~rx") begin with '-', so OptionParser

--- a/src/gori/cli/run/decoder.cr
+++ b/src/gori/cli/run/decoder.cr
@@ -51,13 +51,18 @@ module Gori
         else
           if final_bytes = result.output
             rendered, _ = Decoder.display(final_bytes, output_mode)
-            STDOUT.puts rendered
+            # Decoder input is routinely attacker-controlled captured traffic (base64/hex/
+            # gzip blobs); an auto/text render of a decoded ANSI/OSC escape would otherwise
+            # write raw control bytes to the live terminal. Neutralize them like every other
+            # captured-text view (run.cr#print_message_text). --format json and --output
+            # hex/base64 stay byte-exact for scripts.
+            STDOUT.puts CLI::Output.term_safe_multiline(rendered)
           end
-          unless result.ok?
-            report_convert_failure(result)
-            exit 1
-          end
+          report_convert_failure(result) unless result.ok?
         end
+        # A broken chain exits non-zero in BOTH formats — the json branch previously always
+        # exited 0, burying "ok":false (inconsistent with the text view + intercept acks).
+        exit 1 unless result.ok?
       end
 
       # STDERR line for the first non-Ok step, so a failing chain is diagnosable in

--- a/src/gori/cli/run/discover.cr
+++ b/src/gori/cli/run/discover.cr
@@ -73,7 +73,7 @@ module Gori
           rescue ex
             abort "gori run discover: wordlist error: #{ex.message}"
           end
-          policy : Discover::ScopePolicy = scope.configured? ? Discover::StoreScope.new(scope) : Discover::OpenScope.new
+          policy = discover_policy(scope, seed_url, allow_unscoped)
           sender = Discover::Sender.new(verify: !insecure, timeout: timeout, headers: config.headers,
             overrides: Gori::HostOverrides.load(store))
           engine = Discover::Engine.new(seed_url, words, sender, config, policy)
@@ -109,6 +109,22 @@ module Gori
         return unless p
         return if scope.matches_url?(seed_url, p.host)
         abort "gori run discover: #{seed_url} is out of the project scope — add a scope include rule or pass --allow-unscoped"
+      end
+
+      # The ScopePolicy the crawl engine enforces. Unconfigured scope ⇒ OpenScope (nothing
+      # bounded). Otherwise StoreScope (sandbox/exclude + the include boundary) — UNLESS
+      # --allow-unscoped was passed AND the seed is genuinely outside the include boundary,
+      # in which case UnscopedStoreScope keeps the hard sandbox/exclude gate but drops the
+      # include boundary so scope-aware containment can fall back to same-origin (the flag
+      # was a no-op on the policy before, gutting the crawl — see UnscopedStoreScope). When
+      # the seed IS in scope the flag is redundant, so normal StoreScope is kept unchanged.
+      private def self.discover_policy(scope : Scope, seed_url : String, allow_unscoped : Bool) : Discover::ScopePolicy
+        return Discover::OpenScope.new unless scope.configured?
+        if allow_unscoped
+          p = Discover::Url.parse(seed_url)
+          return Discover::UnscopedStoreScope.new(scope) if p.nil? || !scope.matches_url?(seed_url, p.host)
+        end
+        Discover::StoreScope.new(scope)
       end
 
       private def self.parse_extensions(v : String) : Array(String)

--- a/src/gori/cli/run/fuzz.cr
+++ b/src/gori/cli/run/fuzz.cr
@@ -29,6 +29,7 @@ module Gori
         auto_cal = false
         format = :text
         force = false
+        allow_unscoped = false
         fail_if_no_matches = false
         matcher = Fuzz::Matcher.new(keep_bodies: :none)
         positional = [] of String
@@ -77,6 +78,7 @@ module Gori
           p.on("--ac", "Auto-calibrate: sample the target's noise and drop matching responses") { auto_cal = true }
           p.on("--format=FMT", "Output: text (default) | json | jsonl") { |v| format = parse_format(v, [:text, :json, :jsonl]) }
           p.on("--force", "Run even when the request count is huge or unknown") { force = true }
+          p.on("--allow-unscoped", "Send even if the target is outside the project scope") { allow_unscoped = true }
           p.on("--fail-if-no-matches", "Exit 3 when no result matched") { fail_if_no_matches = true }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args { |rest, _| positional = rest }
@@ -106,7 +108,15 @@ module Gori
         sender = Fuzz::Sender.new(Fuzz::Origin.new(scheme, host, port),
           http2: force_h2 || src_h2, verify: !insecure, sni: sni, timeout: timeout,
           overrides: cli_host_overrides(project_name, db_path, flow_id))
-        engine = Fuzz::Engine.new(generator, matcher, sender, config)
+        # Gate outbound traffic through the project scope, like the TUI/MCP fuzzer and
+        # `gori run discover`/`repeater` (a snapshot Scope, so no store stays open): the
+        # up-front check refuses an out-of-scope host unless --allow-unscoped, and
+        # ScopedBackend enforces Sandbox mode + explicit exclude rules on every send
+        # regardless of that flag. No scope (or --request/stdin with no project) → no gate.
+        scope = cli_scope(project_name, db_path, flow_id)
+        guard_active_scope(scope, scheme, host, request_target(text.to_slice), allow_unscoped, "gori run fuzz")
+        backend = scope ? Fuzz::ScopedBackend.new(sender, scope) : sender
+        engine = Fuzz::Engine.new(generator, matcher, backend, config)
         engine.calibrate_baseline if auto_cal
 
         run_fuzz_stream(engine, mode, scheme, host, port, format, force, fail_if_no_matches)

--- a/src/gori/cli/run/issues.cr
+++ b/src/gori/cli/run/issues.cr
@@ -149,16 +149,25 @@ module Gori
         project = resolve_read_project(project_name, db_path)
         store = open_store(project)
         begin
-          abort "gori run issues update: no issue with id #{id}" unless store.get_issue(id)
+          unless store.get_issue(id)
+            store.close
+            abort "gori run issues update: no issue with id #{id}"
+          end
 
           if title.nil? && severity.nil? && notes.nil? && status.nil?
+            store.close
             abort "gori run issues update: no fields to update (provide at least one of --title/--severity/--notes/--status)"
           end
 
           masked_title = title.try { |t| Env.mask_secrets(t) }
           masked_notes = notes.try { |n| Env.mask_secrets(n) }
 
-          store.update_issue(id, title: masked_title, severity: severity, notes: masked_notes, status: status)
+          # update_issue returns false when the write didn't commit (store busy/locked):
+          # don't report success then.
+          unless store.update_issue(id, title: masked_title, severity: severity, notes: masked_notes, status: status)
+            store.close
+            abort "gori run issues update: project is busy (write did not commit) — try again"
+          end
           puts "Issue ##{id} updated successfully."
         ensure
           store.close

--- a/src/gori/cli/run/jwt.cr
+++ b/src/gori/cli/run/jwt.cr
@@ -53,7 +53,10 @@ module Gori
         if format == :json
           puts Jwt.decode_json(token)
         else
-          puts Decoder::Codecs.jwt_decode(token.to_slice)
+          # A JWT is routinely lifted from live (attacker-controlled) traffic; the decode
+          # view prints the signature segment raw, so neutralize ANSI/OSC/control bytes
+          # before the terminal sees them (--format json stays escaped/byte-exact).
+          puts CLI::Output.term_safe_multiline(Decoder::Codecs.jwt_decode(token.to_slice))
         end
       rescue ex : Gori::Error
         abort "gori run jwt: #{ex.message}"
@@ -79,7 +82,9 @@ module Gori
         if format == :json
           puts Jwt.attacks_json(attacks)
         else
-          attacks.each { |a| puts CLI::Output.jwt_attack_text(a) }
+          # Attack tokens splice the token's raw (unvalidated) payload segment, which can
+          # carry control bytes from a captured token — neutralize before the terminal.
+          attacks.each { |a| puts CLI::Output.term_safe_multiline(CLI::Output.jwt_attack_text(a)) }
         end
       end
     end

--- a/src/gori/cli/run/mine.cr
+++ b/src/gori/cli/run/mine.cr
@@ -21,6 +21,7 @@ module Gori
         retries = 1
         max_requests : Int64? = nil
         format = :text
+        allow_unscoped = false
         positional = [] of String
 
         parser = OptionParser.new do |p|
@@ -42,6 +43,7 @@ module Gori
           p.on("--timeout=SEC", "Per-request connect + idle timeout (seconds)") { |v| timeout = parse_count(v, "--timeout").seconds }
           p.on("--retries=N", "Retries on a network error") { |v| retries = parse_nonneg(v, "--retries") }
           p.on("--max-requests=N", "Hard cap on total requests sent") { |v| max_requests = parse_count(v, "--max-requests").to_i64 }
+          p.on("--allow-unscoped", "Send even if the target is outside the project scope") { allow_unscoped = true }
           p.on("--format=FMT", "Output: text (default) | json | jsonl") { |v| format = parse_format(v, [:text, :json, :jsonl]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args { |rest, _| positional = rest }
@@ -85,7 +87,12 @@ module Gori
         sender = Fuzz::Sender.new(Fuzz::Origin.new(scheme, host, port),
           http2: http2, verify: !insecure, sni: sni, timeout: timeout,
           overrides: cli_host_overrides(project_name, db_path, flow_id))
-        engine = Miner::Engine.new(bytes, http2, names, sender, config)
+        # Scope gate — see cmd_fuzz / cli_scope: refuse an out-of-scope host unless
+        # --allow-unscoped, and enforce Sandbox + exclude rules on every send.
+        scope = cli_scope(project_name, db_path, flow_id)
+        guard_active_scope(scope, scheme, host, request_target(bytes), allow_unscoped, "gori run mine")
+        backend = scope ? Fuzz::ScopedBackend.new(sender, scope) : sender
+        engine = Miner::Engine.new(bytes, http2, names, backend, config)
         run_mine_stream(engine, scheme, host, port, config, format)
       end
 

--- a/src/gori/cli/run/notes.cr
+++ b/src/gori/cli/run/notes.cr
@@ -81,11 +81,21 @@ module Gori
 
         store = open_store(resolve_read_project(project_name, db_path))
         begin
-          doc = Notes.load(store)
-          new_id = doc.next_id
-          new_notes = doc.notes + [Notes::NoteEntry.new(new_id, body)]
-          store.set_setting(Notes::DOCS_KEY, Notes.serialize(new_notes.size - 1, new_notes, new_id + 1))
-          puts "Note ##{new_notes.size} created."
+          # Merge the append into the freshly-read doc instead of a blind load→overwrite,
+          # so a concurrent writer's notes (a TUI editing the same project) aren't reverted.
+          # Same reconcile the TUI save path uses (Notes.merge): `mine` is only the new note,
+          # so every persisted note is kept and just the delta is added.
+          persisted = Notes.load(store)
+          new_id = persisted.next_id
+          merged = Notes.merge(persisted, [Notes::NoteEntry.new(new_id, body)], Set(Int64).new,
+            persisted.size, persisted.next_id + 1)
+          # set_setting returns false when the write didn't commit (store busy/locked):
+          # don't claim success then — same guard as issues/rewriter/project mutations.
+          unless store.set_setting(Notes::DOCS_KEY, Notes.serialize(merged.cur, merged.notes, merged.next_id))
+            store.close
+            abort "gori run notes create: project is busy (write did not commit) — try again"
+          end
+          puts "Note ##{merged.size} created."
         ensure
           store.close
         end
@@ -114,12 +124,20 @@ module Gori
 
         store = open_store(resolve_read_project(project_name, db_path))
         begin
-          doc = Notes.load(store)
-          abort "gori run notes delete: no note ##{n} (this project has #{doc.size} note#{doc.size == 1 ? "" : "s"})" unless n <= doc.size
-          new_notes = doc.notes.dup
-          new_notes.delete_at(n - 1)
-          new_cur = doc.cur.clamp(0, {new_notes.size - 1, 0}.max)
-          store.set_setting(Notes::DOCS_KEY, Notes.serialize(new_cur, new_notes, doc.next_id))
+          persisted = Notes.load(store)
+          unless n <= persisted.size
+            store.close
+            abort "gori run notes delete: no note ##{n} (this project has #{persisted.size} note#{persisted.size == 1 ? "" : "s"})"
+          end
+          # Delete by the note's STABLE id (not its list position) and merge, so a concurrent
+          # writer's other notes aren't clobbered by a blind overwrite. See Notes.merge.
+          target_id = persisted.notes[n - 1].id
+          merged = Notes.merge(persisted, [] of Notes::NoteEntry, Set{target_id},
+            persisted.cur, persisted.next_id)
+          unless store.set_setting(Notes::DOCS_KEY, Notes.serialize(merged.cur, merged.notes, merged.next_id))
+            store.close
+            abort "gori run notes delete: project is busy (write did not commit) — try again"
+          end
           puts "Note ##{n} deleted."
         ensure
           store.close

--- a/src/gori/cli/run/oast.cr
+++ b/src/gori/cli/run/oast.cr
@@ -6,7 +6,7 @@ module Gori
       # `gori run oast` — headless out-of-band listener (interactsh & friends). Store-free
       # and ad-hoc: register a payload, print it, then stream decrypted callbacks.
       private def self.cmd_oast(args : Array(String)) : Nil
-        filtered = args.reject { |a| a.starts_with?("--project") || a.starts_with?("--db") }
+        filtered = strip_project_flags(args)
         case sub = filtered.first?
         when "presets"           then oast_presets
         when "listen"            then oast_listen(filtered[1..])
@@ -16,6 +16,28 @@ module Gori
           oast_help
           exit 1
         end
+      end
+
+      # oast is a store-free ad-hoc listener, so --project/--db are accepted-and-ignored for
+      # CLI consistency (the top-level help says most subcommands take them). Strip BOTH the
+      # attached `--project=X` and the space-separated `--project X` forms — the old
+      # reject-token-only left a stray value that then parsed as the subcommand ("unknown
+      # subcommand 'myproj'").
+      private def self.strip_project_flags(args : Array(String)) : Array(String)
+        out = [] of String
+        i = 0
+        while i < args.size
+          a = args[i]
+          if a == "--project" || a == "--db"
+            i += 2 # skip the flag AND its value
+          elsif a.starts_with?("--project=") || a.starts_with?("--db=")
+            i += 1 # attached form is a single token
+          else
+            out << a
+            i += 1
+          end
+        end
+        out
       end
 
       private def self.oast_help : Nil

--- a/src/gori/cli/run/project.cr
+++ b/src/gori/cli/run/project.cr
@@ -272,13 +272,14 @@ module Gori
         store = open_store(project)
         begin
           scope = Scope.load(store)
-          if enable
-            scope.enable
-            puts "Scope filtering enabled."
-          else
-            scope.disable
-            puts "Scope filtering disabled."
+          # enable/disable return false when the write didn't commit (store busy/locked/
+          # closing, e.g. a live capture holds the writer): don't claim success then.
+          ok = enable ? scope.enable : scope.disable
+          unless ok
+            store.close
+            abort "gori run project scope #{enable ? "enable" : "disable"}: project is busy (write did not commit) — try again"
           end
+          puts enable ? "Scope filtering enabled." : "Scope filtering disabled."
         ensure
           store.close
         end
@@ -384,7 +385,10 @@ module Gori
           else
             vars << {key, val}
           end
-          Env.save_project(store, vars)
+          unless Env.save_project(store, vars)
+            store.close
+            abort "gori run project env set: project is busy (write did not commit) — try again"
+          end
           puts "Env var #{key} set."
         ensure
           store.close
@@ -422,7 +426,10 @@ module Gori
             store.close
             abort "gori run project env delete: no env var named '#{key}'"
           end
-          Env.save_project(store, vars)
+          unless Env.save_project(store, vars)
+            store.close
+            abort "gori run project env delete: project is busy (write did not commit) — try again"
+          end
           puts "Env var #{key} deleted."
         ensure
           store.close
@@ -530,6 +537,10 @@ module Gori
         pair =
           if (h_flag = host) && (i_flag = ip)
             {h_flag, i_flag}
+          elsif host || ip
+            # A lone --host/--ip is ambiguous next to positional args, which would otherwise
+            # silently win and drop the flag — require the pair to be fully one form or the other.
+            abort "gori run project host-override add: give BOTH --host and --ip, or the positional IP HOST form (not a mix)"
           else
             abort "gori run project host-override add: need --host and --ip, or positional IP HOST" if positional.empty?
             parsed = HostOverrides.parse_line(positional.join(' '))
@@ -632,7 +643,10 @@ module Gori
             store.close
             abort "gori run project host-override delete: no override with id #{id}"
           end
-          ov.remove(id)
+          unless ov.remove(id)
+            store.close
+            abort "gori run project host-override delete: project is busy (write did not commit) — try again"
+          end
           puts "Host override ##{id} deleted."
         ensure
           store.close

--- a/src/gori/cli/run/repeater.cr
+++ b/src/gori/cli/run/repeater.cr
@@ -128,7 +128,10 @@ module Gori
             detail = store.get_flow(fid)
             abort "gori run repeater create: no flow ##{fid} to clone" unless detail
             built = Repeater::FlowRequest.build(detail)
-            req_content = String.new(built.bytes)
+            # Only seed the request from the flow when the user didn't hand one in: --flow
+            # doubles as provenance (the flow_id column) for a custom --request-raw/-file,
+            # so an explicit request must NOT be silently overwritten by the flow's bytes.
+            req_content = String.new(built.bytes) if request_file.nil? && request_raw.nil?
             if tgt_str.empty?
               bt = built.target
               tgt_str = bt ? bt : ""
@@ -218,6 +221,20 @@ module Gori
         RepeaterSend.new(bytes, scheme, host, port, rec.http2?, rec.sni.try { |v| Env.expand(v) })
       end
 
+      # Persist a repeater SESSION's last response (V11) so it survives a reopen and a later
+      # `repeater list` / `--diff` see it — parity with the TUI (repeater_controller.cr
+      # #drain_results). Reopens the store because `send` closed it before the (slow) dial.
+      # Callers gate on `result.ok?`: a failed resend must not wipe a good stored response.
+      private def self.persist_repeater_response(id : Int64, head : Bytes, body : Bytes?, error : String?,
+                                                 duration_us : Int64, project_name : String?, db_path : String?) : Nil
+        store = open_store(resolve_read_project(project_name, db_path))
+        begin
+          store.update_repeater_response(id, head, body, error, duration_us)
+        ensure
+          store.close
+        end
+      end
+
       # `gori run repeater send <repeater-id>` — replay a saved repeater SESSION (as
       # opposed to a bare id, which replays a History FLOW). Honors the session's
       # target / http2 / sni / auto_content_length toggle.
@@ -286,6 +303,7 @@ module Gori
             Repeater::Diff.lines(orig, message_lines(result.head, new_body))
           end
         emit_repeater_result(result, new_body, diff, format)
+        persist_repeater_response(id, result.head, result.body, result.error, result.duration_us, project_name, db_path) if result.ok?
         exit 1 unless result.ok?
       end
 
@@ -319,11 +337,15 @@ module Gori
         result = Repeater::WsEngine.send(request, out_messages, scheme: scheme, host: host, port: port,
           verify_upstream: verify, sni: sni, idle: idle, overrides: host_overrides)
 
-        store2 = open_store(resolve_read_project(project_name, db_path))
-        begin
-          store2.update_repeater_response(id, result.handshake_head, Bytes.empty, result.error, result.duration_us)
-        ensure
-          store2.close
+        # Persist ONLY on success — parity with the TUI (repeater_controller#drain_results):
+        # a later failed resend must not wipe a good stored handshake/response.
+        if result.ok?
+          store2 = open_store(resolve_read_project(project_name, db_path))
+          begin
+            store2.update_repeater_response(id, result.handshake_head, Bytes.empty, result.error, result.duration_us)
+          ensure
+            store2.close
+          end
         end
 
         emit_ws_result(id, result, format)
@@ -502,44 +524,57 @@ module Gori
         head_bytes = raw_bytes[0, crlf_crlf_idx + 4]
         body_bytes = raw_bytes[crlf_crlf_idx + 4..]
 
-        raw_req = Proxy::Codec::Http1.parse_request_head(head_bytes)
+        # Edit the head as RAW LINES so the request line and every header stay byte-exact
+        # except where a flag overrides them. The old path rebuilt the request line from
+        # split method/target/version tokens, which corrupted any line with a raw space in
+        # the target (fuzzer/smuggling captures split into >3 tokens: the version was dropped
+        # and the path truncated); it also re-emitted only parse_headers' output, silently
+        # dropping any colon-less header line. Both are exactly the payloads this tool exists
+        # to replay faithfully, so we never reconstruct them from parsed tokens.
+        head_str = String.new(head_bytes)
+        first_crlf = head_str.index("\r\n") || head_str.size
+        request_line = head_str[0, first_crlf]
+        # Header lines between the request line and the terminating blank line, each verbatim.
+        raw_lines = head_str[first_crlf..].split("\r\n").reject(&.empty?)
 
+        # -H overrides: lower-name → value, plus the flag-cased name in flag order for appends.
         custom_headers = {} of String => String
+        custom_order = [] of {String, String}
         headers.each do |h_str|
           next unless h_str.includes?(':')
           name, _, val = h_str.partition(':')
           next if name.strip.empty?
-          custom_headers[name.strip.downcase] = val.strip
+          lname = name.strip.downcase
+          custom_order << {lname, name.strip} unless custom_headers.has_key?(lname)
+          custom_headers[lname] = val.strip
         end
 
-        new_headers = [] of Proxy::Codec::Header
-        applied = Set(String).new # custom names whose FIRST occurrence was already replaced
-        raw_req.headers.each do |hdr|
-          lower_name = hdr.name.downcase
-          if custom_headers.has_key?(lower_name)
-            # Replace the first matching line; DROP later duplicates (a captured h2 request
-            # can carry several `cookie:`/`set-cookie:` lines) so the override isn't left
-            # half-applied with a stale second occurrence.
-            next if applied.includes?(lower_name)
-            new_headers << Proxy::Codec::Header.new(hdr.name, custom_headers[lower_name])
-            applied << lower_name
+        # The header NAME of a raw line (bytes before the first colon), or "" for a
+        # colon-less line — those are kept verbatim, never treated as a header to edit.
+        line_name = ->(line : String) do
+          c = line.index(':')
+          c && c > 0 ? line[0, c] : ""
+        end
+
+        # Replace the FIRST occurrence of an overridden header (DROP later duplicates so an
+        # h2 request's repeated cookie:/set-cookie: lines aren't left half-overridden), and
+        # keep every other line — including colon-less ones — byte-exact.
+        applied = Set(String).new
+        new_lines = [] of String
+        raw_lines.each do |line|
+          name = line_name.call(line)
+          lname = name.strip.downcase
+          if !lname.empty? && custom_headers.has_key?(lname)
+            next if applied.includes?(lname)
+            applied << lname
+            new_lines << "#{name}: #{custom_headers[lname]}"
           else
-            new_headers << hdr
+            new_lines << line
           end
         end
-
-        custom_headers.each do |lower_name, val|
-          next if applied.includes?(lower_name) # already replaced an existing line
-          orig_name = ""
-          headers.each do |h_str|
-            name, _, _ = h_str.partition(':')
-            if name.strip.downcase == lower_name
-              orig_name = name.strip
-              break
-            end
-          end
-          orig_name = lower_name if orig_name.empty?
-          new_headers << Proxy::Codec::Header.new(orig_name, val)
+        custom_order.each do |(lname, orig)|
+          next if applied.includes?(lname)
+          new_lines << "#{orig}: #{custom_headers[lname]}"
         end
 
         final_body = if b_over = body_override
@@ -548,22 +583,22 @@ module Gori
                        body_bytes
                      end
 
-        has_cl = new_headers.any? { |h| h.name.compare("Content-Length", case_insensitive: true) == 0 }
-        has_te = new_headers.any? { |h| h.name.compare("Transfer-Encoding", case_insensitive: true) == 0 }
+        has_te = new_lines.any? { |l| line_name.call(l).compare("Transfer-Encoding", case_insensitive: true) == 0 }
         # RFC 7230 §3.3.3 forbids sending Transfer-Encoding and Content-Length together.
         # When the original request was chunked (TE present, no override), keep its wire
         # framing byte-exact and don't inject a Content-Length. When the body is replaced
         # via -b, drop Transfer-Encoding and self-frame the new bytes with Content-Length.
         if has_te && body_override
-          new_headers.reject! { |h| h.name.compare("Transfer-Encoding", case_insensitive: true) == 0 }
+          new_lines.reject! { |l| line_name.call(l).compare("Transfer-Encoding", case_insensitive: true) == 0 }
           has_te = false
         end
+        has_cl = new_lines.any? { |l| line_name.call(l).compare("Content-Length", case_insensitive: true) == 0 }
         if !has_te && (body_override || has_cl || final_body.size > 0)
-          cl_idx = new_headers.index { |h| h.name.compare("Content-Length", case_insensitive: true) == 0 }
+          cl_idx = new_lines.index { |l| line_name.call(l).compare("Content-Length", case_insensitive: true) == 0 }
           if cl_idx
-            new_headers[cl_idx] = Proxy::Codec::Header.new(new_headers[cl_idx].name, final_body.size.to_s)
+            new_lines[cl_idx] = "#{line_name.call(new_lines[cl_idx])}: #{final_body.size}"
           else
-            new_headers << Proxy::Codec::Header.new("Content-Length", final_body.size.to_s)
+            new_lines << "Content-Length: #{final_body.size}"
           end
         end
 
@@ -574,19 +609,17 @@ module Gori
           scheme_part, host_part, port_part = Repeater::FlowRequest.parse_target(override)
           default_port = scheme_part == "https" ? 443 : 80
           host_hdr_val = port_part == default_port ? host_part : "#{host_part}:#{port_part}"
-          host_idx = new_headers.index { |h| h.name.compare("Host", case_insensitive: true) == 0 }
+          host_idx = new_lines.index { |l| line_name.call(l).compare("Host", case_insensitive: true) == 0 }
           if host_idx
-            new_headers[host_idx] = Proxy::Codec::Header.new(new_headers[host_idx].name, host_hdr_val)
+            new_lines[host_idx] = "#{line_name.call(new_lines[host_idx])}: #{host_hdr_val}"
           else
-            new_headers << Proxy::Codec::Header.new("Host", host_hdr_val)
+            new_lines << "Host: #{host_hdr_val}"
           end
         end
 
         new_head_str = String.build do |io|
-          io << raw_req.method << " " << raw_req.target << " " << raw_req.version << "\r\n"
-          new_headers.each do |hdr|
-            io << hdr.name << ": " << hdr.value << "\r\n"
-          end
+          io << request_line << "\r\n"
+          new_lines.each { |l| io << l << "\r\n" }
           io << "\r\n"
         end
 

--- a/src/gori/cli/run/rewriter.cr
+++ b/src/gori/cli/run/rewriter.cr
@@ -188,7 +188,10 @@ module Gori
             store.close
             abort "gori run rewriter rm: no rule with id #{id}"
           end
-          store.delete_rule(id)
+          unless store.delete_rule(id)
+            store.close
+            abort "gori run rewriter rm: project is busy (write did not commit) — try again"
+          end
           puts "Rule ##{id} deleted."
         ensure
           store.close
@@ -220,7 +223,10 @@ module Gori
             store.close
             abort "gori run rewriter #{action}: no rule with id #{id}"
           end
-          store.set_rule_enabled(id, enable)
+          unless store.set_rule_enabled(id, enable)
+            store.close
+            abort "gori run rewriter #{action}: project is busy (write did not commit) — try again"
+          end
           puts "Rule ##{id} #{enable ? "enabled" : "disabled"}."
         ensure
           store.close

--- a/src/gori/cli/run/sequence.cr
+++ b/src/gori/cli/run/sequence.cr
@@ -25,6 +25,7 @@ module Gori
         retries = 1
         max_requests : Int64? = nil
         format = :text
+        allow_unscoped = false
         positional = [] of String
 
         set_loc = ->(k : Sequencer::ExtractKind, v : String) {
@@ -56,6 +57,7 @@ module Gori
           p.on("--timeout=SEC", "Per-request connect + idle timeout (seconds)") { |v| timeout = parse_count(v, "--timeout").seconds }
           p.on("--retries=N", "Retries on a network error") { |v| retries = parse_nonneg(v, "--retries") }
           p.on("--max-requests=N", "Hard cap on total requests sent") { |v| max_requests = parse_count(v, "--max-requests").to_i64 }
+          p.on("--allow-unscoped", "Send even if the target is outside the project scope") { allow_unscoped = true }
           p.on("--format=FMT", "Output: text (default) | json | jsonl") { |v| format = parse_format(v, [:text, :json, :jsonl]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args { |rest, _| positional = rest }
@@ -91,7 +93,13 @@ module Gori
         sender = Fuzz::Sender.new(Fuzz::Origin.new(scheme, host, port),
           http2: http2, verify: !insecure, sni: sni, timeout: timeout,
           overrides: cli_host_overrides(project_name, db_path, flow_id))
-        engine = Sequencer::Engine.new(bytes, http2, sender, config)
+        # Scope gate — see cmd_fuzz / cli_scope: refuse an out-of-scope host unless
+        # --allow-unscoped, and enforce Sandbox + exclude rules on every send. (The
+        # --tokens path returned above without touching the network, so it needs none.)
+        scope = cli_scope(project_name, db_path, flow_id)
+        guard_active_scope(scope, scheme, host, request_target(bytes), allow_unscoped, "gori run sequence")
+        backend = scope ? Fuzz::ScopedBackend.new(sender, scope) : sender
+        engine = Sequencer::Engine.new(bytes, http2, backend, config)
         run_sequence_stream(engine, scheme, host, port, token_loc, count, format)
       end
 

--- a/src/gori/discover/adapters.cr
+++ b/src/gori/discover/adapters.cr
@@ -26,6 +26,19 @@ module Gori::Discover
     end
   end
 
+  # StoreScope for a run that passed --allow-unscoped on an OUT-OF-SCOPE seed: the hard
+  # sandbox/exclude gate (allowed?) still applies, but configured? reports false so
+  # scope-aware containment falls back to same-origin (bounding the crawl to the seed the
+  # operator explicitly named). Without this, StoreScope#boundary? blocked every hop the
+  # seed's own include rules don't match — so --allow-unscoped fetched only the seed +
+  # robots/sitemap, brute-force never started, and the spider was stuck at depth 0, silently
+  # contradicting the flag. (The include boundary is exactly what --allow-unscoped waives.)
+  class UnscopedStoreScope < StoreScope
+    def configured? : Bool
+      false
+    end
+  end
+
   # Persist a discovered endpoint as a normal flow row so it surfaces in the Sitemap (which
   # groups by host/method/target). No response body is stored — the Sitemap needs only
   # method/target/status; re-send via Repeater for the live body. A finding with no status

--- a/src/gori/import/builder.cr
+++ b/src/gori/import/builder.cr
@@ -60,9 +60,37 @@ module Gori
       # silently collapse duplicates to the last value.
       alias Headers = Array({String, String})
 
+      # A raw CR/LF (or NUL) inside a header NAME or VALUE forges a message boundary once
+      # the head is serialized here and later replayed byte-exact (Repeater): a HAR/OAS
+      # value of `"a\r\nX-Injected: evil\r\n\r\nGET /admin HTTP/1.1"` would smuggle a whole
+      # second request into the stored head. This is the header analogue of the URL
+      # smuggling normalize_url guards against — reject the entry at the SAME point (a raise
+      # here is caught by every import parser's per-entry rescue, dropping the bad entry
+      # exactly like a bad URL). Narrower than CONTROL_CHAR on purpose: a header VALUE may
+      # legally contain a horizontal tab (RFC 7230 §3.2 field-value), so only CR/LF/NUL —
+      # the bytes that can actually forge a boundary or truncate — are rejected.
+      HEADER_INJECT = /[\r\n\x00]/
+
+      # Reject any header whose name/value could forge a message boundary (see HEADER_INJECT).
+      def self.reject_header_injection!(headers : Headers) : Nil
+        headers.each do |k, v|
+          raise Gori::Error.new("invalid header (control character): #{k.inspect}") if k.matches?(HEADER_INJECT) || v.matches?(HEADER_INJECT)
+        end
+      end
+
+      # A start-line scalar (method / statusText reason / HTTP version) that reaches the
+      # request/status line: same boundary-forging risk as a header, so reject the same
+      # CR/LF/NUL bytes. (`target`/`host` come from normalize_url and are already clean.)
+      def self.reject_inject!(field : String, label : String) : Nil
+        raise Gori::Error.new("invalid #{label} (control character): #{field.inspect}") if field.matches?(HEADER_INJECT)
+      end
+
       def self.request_head(method : String, target : String, http_version : String,
                             host : String, headers : Headers,
                             body : Bytes?) : Bytes
+        reject_inject!(method, "method")
+        reject_inject!(http_version, "HTTP version")
+        reject_header_injection!(headers)
         String.build do |b|
           b << method.upcase << ' ' << target << ' ' << http_version << "\r\n"
           b << "Host: " << host << "\r\n"
@@ -84,6 +112,9 @@ module Gori
 
       def self.response_head(http_version : String, status : Int32, reason : String,
                              headers : Headers, body : Bytes?) : Bytes
+        reject_inject!(http_version, "HTTP version")
+        reject_inject!(reason, "reason phrase")
+        reject_header_injection!(headers)
         String.build do |b|
           b << http_version << ' ' << status << ' ' << reason << "\r\n"
           has_cl = false

--- a/src/gori/import/har.cr
+++ b/src/gori/import/har.cr
@@ -14,7 +14,11 @@ module Gori
         rescue ex : JSON::ParseException
           raise Gori::Error.new("HAR file is not valid JSON: #{ex.message}")
         end
-        log = doc["log"]?
+        # A valid-JSON-but-wrong-shape file (a top-level array, a scalar, a `log` that
+        # isn't an object) must yield a clean Gori::Error, not the raw Exception that
+        # JSON::Any#[](String) throws on a non-Hash — cmd_import only rescues Gori::Error.
+        doc_h = doc.as_h? || raise Gori::Error.new("HAR file is not a JSON object")
+        log = doc_h["log"]?.try(&.as_h?)
         raise Gori::Error.new("HAR file missing log object") unless log
         entries = log["entries"]?.try(&.as_a?)
         raise Gori::Error.new("HAR file has no entries") unless entries

--- a/src/gori/import/oas.cr
+++ b/src/gori/import/oas.cr
@@ -25,6 +25,11 @@ module Gori
         rescue ex : JSON::ParseException
           raise Gori::Error.new("OpenAPI spec is not valid JSON: #{ex.message}")
         end
+        # A valid-JSON-but-wrong-shape spec (top-level array/scalar) must yield a clean
+        # Gori::Error, not the raw Exception JSON::Any#[](String) throws on a non-Hash —
+        # cmd_import only rescues Gori::Error. Guarding here also makes the later
+        # spec["servers"]/["security"]/["components"] accesses safe (spec is a Hash).
+        raise Gori::Error.new("OpenAPI spec is not a JSON object") unless spec.as_h?
         paths = spec["paths"]?
         raise Gori::Error.new("OpenAPI spec missing paths") unless paths
         # A `paths` that isn't an object (null / string / array) is a malformed spec, not

--- a/src/gori/mcp/tools/discover.cr
+++ b/src/gori/mcp/tools/discover.cr
@@ -68,13 +68,23 @@ module Gori
           headers: Discover::Headers.parse_lines(header_lines))
         words = Discover::Wordlist.load(str(h, "wordlist").presence)
         scope = Scope.load(store)
-        policy : Discover::ScopePolicy = scope.configured? ? Discover::StoreScope.new(scope) : Discover::OpenScope.new
+        policy = discover_policy(scope, seed, parts.host, bool(h, "allow_unscoped") || false)
         sender = Discover::Sender.new(verify: @verify_upstream && !(bool(h, "insecure") || false), timeout: discover_timeout(h),
           headers: config.headers, overrides: HostOverrides.load(store))
         engine = Discover::Engine.new(seed, words, sender, config, policy)
         {engine, seed, parts.host}
       rescue ex : File::Error
         raise FuzzArgError.new("wordlist error: #{ex.message}")
+      end
+
+      # Mirror of the CLI's discover_policy (cli/run/discover.cr): with allow_unscoped on an
+      # out-of-scope seed, keep sandbox/exclude but drop the include boundary so scope-aware
+      # containment falls back to same-origin instead of blocking every hop (which otherwise
+      # gutted the crawl to just the seed + robots/sitemap — see UnscopedStoreScope).
+      private def discover_policy(scope : Scope, seed : String, host : String, allow_unscoped : Bool) : Discover::ScopePolicy
+        return Discover::OpenScope.new unless scope.configured?
+        return Discover::UnscopedStoreScope.new(scope) if allow_unscoped && !scope.matches_url?(seed, host)
+        Discover::StoreScope.new(scope)
       end
 
       private def discover_timeout(h) : Time::Span?


### PR DESCRIPTION
## Summary

A subcommand-wide review of `gori run` surfaced **15 findings**; this PR fixes **all 15**, verified with the full suite (3443/0) plus per-fix end-to-end tests against a local listener/HTTP server. 7 new import specs cover the security fixes.

### Security
- **import (HAR/OpenAPI)** — reject `CR`/`LF`/`NUL` in header names/values and start-line scalars (method / statusText / version). A crafted entry could otherwise smuggle a whole second HTTP request into the stored head, which gori replays byte-exact. Header analogue of the existing `normalize_url` guard; narrower than `CONTROL_CHAR` so a legal horizontal tab in a value still passes.
- **fuzz / mine / sequence** — these three dialed any host with **zero** scope/sandbox enforcement (unlike discover, repeater, and every MCP tool). Added `--allow-unscoped` + an up-front include-scope gate + `Fuzz::ScopedBackend` (enforces Sandbox mode & exclude rules per request regardless of the flag). Mirrors the CLI `discover` philosophy (unscoped ⇒ allowed; a configured-but-unmatched scope blocks).
- **decoder / jwt** — text output now neutralizes ANSI/OSC/control bytes (decoded values are routinely attacker-controlled captured traffic). `--format json` and `--output hex/base64` stay byte-exact.

### Correctness
- **repeater `<flow-id>`** — edits the head as raw lines, so a request line with a raw space in the target (fuzzer/smuggling captures) and colon-less header lines replay **byte-exact** instead of being corrupted by a naive 3-token rebuild.
- **repeater send** — persists the h1/h2 result (parity with the TUI); WS persists **only on success** so a failed resend can't wipe a good stored response.
- **discover `--allow-unscoped`** — now actually relaxes the crawl boundary (new `UnscopedStoreScope`, keeps sandbox/exclude, falls back to same-origin) instead of silently gutting the crawl to just the seed. Fixed in CLI **and** MCP.
- **import** — clean error, not a raw backtrace, on a valid-JSON-but-wrong-shape HAR/OpenAPI file.
- **repeater create `--flow`** — keeps an explicit `--request-raw/-file` instead of overwriting it with the flow's bytes.
- **notes create/delete** — merge against a fresh reload (delete by stable id) so a concurrent editor isn't clobbered.
- **CLI mutations** (scope / env / host-override / rewriter / issues / notes) — abort `"project is busy"` when the write doesn't commit instead of falsely reporting success.
- **host-override add** — errors on a lone `--host`/`--ip` mixed with positional args instead of silently dropping the flag.
- **decoder `--format json`** — exits non-zero on a broken chain.
- **oast `--project NAME`** (space form) — routes correctly instead of `unknown subcommand`.
- **compare help** — describes the actual unified-diff output.

## Test plan
- `crystal spec` → **3443 examples, 0 failures**.
- 7 new specs in `spec/import/import_spec.cr` (header/start-line CRLF injection rejected; wrong-shape HAR/OAS → clean error; tab preserved).
- e2e verified against a local server: scope gate blocks/allows correctly for fuzz/mine/sequence; a raw-space request line and a colon-less header replay verbatim; `repeater send` persists `last_duration_us`; discover `--allow-unscoped` spiders past an out-of-scope seed.
- `crystal tool format --check` and ameba clean on all touched files (no new findings).