### PR TITLE
fix(nix): sync flake.nix to 0.1.4 so `just vc` passes on main

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,7 @@
 
         gori = crystal.buildCrystalPackage {
           pname = "gori";
-          version = "0.1.3";
+          version = "0.1.4";
 
           inherit src;
 


### PR DESCRIPTION
Follow-up to #338. `just vc` currently **fails on main**:

```
shard.yml:                                          0.1.4
src/gori.cr:                                        0.1.4
snap/snapcraft.yaml:                                0.1.4
aur/PKGBUILD:                                       0.1.4
flake.nix:                                          0.1.3
spec/gori_spec.cr:                                  0.1.4
...
✗ version mismatch: 0.1.4, 0.1.3
```

## Why

v0.1.4 was cut while #338 was open. At that point `just vu` did not know about `flake.nix` — #338 is the very change that added it to the tracked file set — so the release bumped the other seven files while the open branch kept carrying `0.1.3`. Merging #338 on top then landed a stale version.

A one-off consequence of the ordering, not a gap in the version tooling: from here on `just vu` rewrites `flake.nix` alongside everything else, so the next bump stays in step on its own.

## Verification

- `just vc` green: `✓ versions match (0.1.4)`
- `nix eval .#packages.aarch64-darwin.default.name` → `gori-0.1.4`