### PR TITLE
fix(proxy): reject bare-CR header obfuscation and ambiguous response framing

### DIFF
--- a/spec/proxy/codec/body_spec.cr
+++ b/spec/proxy/codec/body_spec.cr
@@ -245,6 +245,79 @@ describe Gori::Proxy::Codec::Body do
       expect_raises(Gori::Error) { Body.request_framing(req) }
     end
 
+    it "rejects a bare CR used to hide a header from the CRLF-only framing scan" do
+      # The mirror of the bare-LF case: index_crlf/parse_headers only break on the 2-byte
+      # CRLF, so a lone CR leaves the smuggled TE inside the previous field-value — while a
+      # recipient that ends a line on a lone CR reads it. CL says 0, the hidden TE says
+      # chunked: a CL.TE desync.
+      Http1.obfuscated_header?(
+        "GET / HTTP/1.1\r\nHost: h\r\nFoo: bar\rTransfer-Encoding: chunked\r\n\r\n".to_slice).should be_true
+      req = Http1.parse_request_head(
+        "POST / HTTP/1.1\r\nHost: h\r\nContent-Length: 0\r\nFoo: bar\rTransfer-Encoding: chunked\r\n\r\n".to_slice)
+      expect_raises(Gori::Error) { Body.request_framing(req) }
+    end
+
+    it "treats a trailing bare CR as obfuscated (a real head always ends CRLFCRLF)" do
+      Http1.obfuscated_header?("GET / HTTP/1.1\r\nHost: h\r".to_slice).should be_true
+    end
+
+    it "rejects a response whose framing header a bare LF/CR hides from the strict parse" do
+      # gori would frame by Content-Length: 0 and read the next response off a reused
+      # upstream, while an LF-lenient browser reads the hidden chunked body — so the bytes
+      # gori calls "the next response" are the bytes the browser renders as this one.
+      ["\n", "\r"].each do |sep| # %w[] would not process the escapes
+        head = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nX-Foo: bar#{sep}Transfer-Encoding: chunked\r\n\r\n"
+        resp = Http1.parse_response_head(head.to_slice)
+        Http1.framing_ambiguous?(resp.raw_head, resp.headers).should be_true
+        expect_raises(Gori::Error) { Body.response_framing(resp, "GET") }
+      end
+    end
+
+    it "rejects an obs-folded response Content-Length (strict sees empty, a client sees the value)" do
+      resp = Http1.parse_response_head("HTTP/1.1 200 OK\r\nContent-Length:\r\n 5\r\n\r\n".to_slice)
+      expect_raises(Gori::Error) { Body.response_framing(resp, "GET") }
+    end
+
+    it "rejects a response with whitespace before the Transfer-Encoding colon" do
+      # `Transfer-Encoding : chunked` misses the exact-match TE lookup, so gori frames by
+      # CL while a whitespace-tolerant client reads chunked.
+      resp = Http1.parse_response_head(
+        "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nTransfer-Encoding : chunked\r\n\r\n".to_slice)
+      expect_raises(Gori::Error) { Body.response_framing(resp, "GET") }
+    end
+
+    it "checks response framing ambiguity even on bodyless statuses and HEAD" do
+      # The bodyless short-circuits (HEAD/CONNECT, 1xx/204/304) must not route around the
+      # ambiguity check — the client, not gori, decides what it reads next.
+      head = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nX-Foo: bar\nTransfer-Encoding: chunked\r\n\r\n"
+      resp = Http1.parse_response_head(head.to_slice)
+      expect_raises(Gori::Error) { Body.response_framing(resp, "GET") }
+      ok = Http1.parse_response_head("HTTP/1.1 200 OK\r\nContent-Length: 42\r\n\r\n".to_slice)
+      Body.response_framing(ok, "HEAD").should eq({BodyFraming::None, 0_i64})
+    end
+
+    it "lets a sloppy-but-unambiguous response through (obfuscation off the framing headers)" do
+      # An origin that bare-LFs or obs-folds a header which CANNOT move the body boundary is
+      # sloppy, not dangerous — and embedded/legacy targets like this are exactly what a
+      # pentester points gori at, so these must still load rather than 502. Both parses agree
+      # on Content-Length, so there is nothing to desync.
+      bare_lf = Http1.parse_response_head(
+        "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nX-Foo: a\nX-Bar: b\r\n\r\n".to_slice)
+      Http1.framing_ambiguous?(bare_lf.raw_head, bare_lf.headers).should be_false
+      Body.response_framing(bare_lf, "GET").should eq({BodyFraming::Length, 5_i64})
+
+      folded = Http1.parse_response_head(
+        "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nX-Foo: bar\r\n continued\r\n\r\n".to_slice)
+      Body.response_framing(folded, "GET").should eq({BodyFraming::Length, 5_i64})
+    end
+
+    it "leaves an ordinary clean response untouched by the ambiguity check" do
+      resp = Http1.parse_response_head(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nTransfer-Encoding: chunked\r\n\r\n".to_slice)
+      Http1.framing_ambiguous?(resp.raw_head, resp.headers).should be_false
+      Body.response_framing(resp, "GET").should eq({BodyFraming::Chunked, 0_i64})
+    end
+
     it "leaves a response with a non-chunked Transfer-Encoding as close-delimited (not rejected)" do
       # Responses may legitimately be close-delimited under a non-chunked TE — only the
       # request path (which must know the body boundary to keep-alive) rejects.

--- a/src/gori/proxy/codec/body.cr
+++ b/src/gori/proxy/codec/body.cr
@@ -156,7 +156,7 @@ module Gori::Proxy::Codec
       # obs-folded is invisible to the exact-match framing lookups below, yet a lenient
       # backend still honours it — a CL/TE request-smuggling primitive. Reject up front,
       # like CL+TE, rather than framing on a header we can't see (RFC 7230 §3.2.4).
-      raise Gori::Error.new("obfuscated request header (whitespace before colon, obs-fold, or bare LF)") if Http1.obfuscated_header?(req.raw_head)
+      raise Gori::Error.new("obfuscated request header (whitespace before colon, obs-fold, or a bare CR/LF)") if Http1.obfuscated_header?(req.raw_head)
       # Skip the get_all Array allocation when Transfer-Encoding is absent (the common case);
       # an empty list means neither chunked? nor te_present? — fall straight to Content-Length.
       te = req.headers.has?("Transfer-Encoding") ? req.headers.get_all("Transfer-Encoding") : EMPTY_TE
@@ -181,6 +181,19 @@ module Gori::Proxy::Codec
 
     # RFC 7230 §3.3.3 framing for a response body, given the request method.
     def self.response_framing(resp : RawResponse, request_method : String) : {BodyFraming, Int64}
+      # A response head whose FRAMING headers a lenient recipient would read differently
+      # than this parse did is a response-desync primitive, the mirror of the request-side
+      # smuggling request_framing rejects above. gori frames (and so stops reading) by what
+      # IT sees, then forwards the head byte-exact (P7) — so the browser behind gori, which
+      # RFC 7230 §3.5 lets accept a bare LF and which unfolds obs-fold, can frame by a
+      # Content-Length/Transfer-Encoding gori never saw. The bytes gori then reads as the
+      # NEXT response on a reused upstream are the bytes that client is still consuming as
+      # this body: a malicious origin picks what the user's browser renders as the following
+      # response. Checked BEFORE the bodyless short-circuits below so no status/method
+      # combination can route around it. Narrower than the request side's blanket
+      # obfuscated_header? on purpose — see Http1.framing_ambiguous?. RFC 7230 §3.2.4
+      # explicitly sanctions refusing a message here rather than guessing.
+      raise Gori::Error.new("ambiguous framing headers (a lenient recipient would frame this response differently)") if Http1.framing_ambiguous?(resp.raw_head, resp.headers)
       # Allocation-free case-insensitive match (per response); `.upcase` allocated a String.
       if request_method.compare("HEAD", case_insensitive: true) == 0 ||
          request_method.compare("CONNECT", case_insensitive: true) == 0

--- a/src/gori/proxy/codec/http1.cr
+++ b/src/gori/proxy/codec/http1.cr
@@ -204,12 +204,18 @@ module Gori::Proxy::Codec::Http1
   # (RFC 7230 §3.5) still reads it — a hidden Transfer-Encoding/Content-Length. read_head
   # only ever returns a head ending in CRLFCRLF, so a well-formed head has every LF
   # CR-preceded; reject any that doesn't.
+  #
+  # A bare CR (0x0d NOT immediately followed by 0x0a) is the mirror image and is rejected
+  # for the same reason: index_crlf/parse_headers only ever break a line on the 2-byte
+  # CRLF, so a lone CR is just another byte inside the current field-value and everything
+  # after it — up to the next real CRLF — is swallowed into that value. A recipient that
+  # treats a lone CR as end-of-line (they exist; CR is not a legal field-vchar, so parsers
+  # differ on what to do with one) reads the smuggled `Transfer-Encoding: chunked` sitting
+  # after it. CR is never valid inside a field-value (RFC 7230 §3.2.6 field-vchar is
+  # VCHAR/obs-text), so this can't false-positive on conformant traffic. A CR as the very
+  # last byte counts as bare: a genuine head always ends CRLFCRLF, never a dangling CR.
   def self.obfuscated_header?(raw : Bytes) : Bool
-    i = 0
-    while i < raw.size
-      return true if raw.unsafe_fetch(i) == 0x0a_u8 && (i == 0 || raw.unsafe_fetch(i - 1) != 0x0d_u8)
-      i += 1
-    end
+    return true if bare_cr_or_lf?(raw)
     start_crlf = index_crlf(raw, 0)
     return false if start_crlf.nil?
     pos = start_crlf + 2 # first byte after the start-line's CRLF
@@ -219,19 +225,134 @@ module Gori::Proxy::Codec::Http1
       break if line_end == pos # empty line → end of headers
       first = raw.unsafe_fetch(pos)
       return true if first == 0x20_u8 || first == 0x09_u8 # obs-fold continuation line
-      # Whitespace between field-name and colon: the byte just before the first ':' is SP/HTAB.
-      i = pos
-      while i < line_end && raw.unsafe_fetch(i) != 0x3a_u8 # ':'
-        i += 1
-      end
-      if i < line_end && i > pos
-        prev = raw.unsafe_fetch(i - 1)
-        return true if prev == 0x20_u8 || prev == 0x09_u8
-      end
+      return true if space_before_colon?(raw, pos, line_end)
       break if crlf.nil?
       pos = crlf + 2
     end
     false
+  end
+
+  # Whitespace between field-name and colon on the header line spanning [pos, line_end):
+  # the byte just before the first ':' is SP/HTAB (`Transfer-Encoding : chunked`), which the
+  # exact-match framing lookups cannot see but a lenient backend still reads.
+  private def self.space_before_colon?(raw : Bytes, pos : Int32, line_end : Int32) : Bool
+    i = pos
+    while i < line_end && raw.unsafe_fetch(i) != 0x3a_u8 # ':'
+      i += 1
+    end
+    return false unless i < line_end && i > pos
+    prev = raw.unsafe_fetch(i - 1)
+    prev == 0x20_u8 || prev == 0x09_u8
+  end
+
+  # Any LF not immediately preceded by CR, or CR not immediately followed by LF — either
+  # one lets a recipient that ends a line on it see a header this CRLF-only codec cannot
+  # (see obfuscated_header?, whose contract this implements).
+  private def self.bare_cr_or_lf?(raw : Bytes) : Bool
+    i = 0
+    while i < raw.size
+      b = raw.unsafe_fetch(i)
+      if b == 0x0a_u8
+        return true if i == 0 || raw.unsafe_fetch(i - 1) != 0x0d_u8
+      elsif b == 0x0d_u8
+        return true if i + 1 >= raw.size || raw.unsafe_fetch(i + 1) != 0x0a_u8
+      end
+      i += 1
+    end
+    false
+  end
+
+  # The only header names body framing ever reads (see Body.request_framing /
+  # Body.response_framing). Obfuscation that cannot change one of these cannot move the
+  # body boundary, so it cannot desync anyone. Lowercase, for the stripped-name compare.
+  FRAMING_NAMES = {"content-length", "transfer-encoding"}
+
+  # True when a LENIENT recipient would read DIFFERENT body-framing headers out of `raw`
+  # than gori's strict CRLF-only parse did (`headers`, i.e. what parse_headers produced).
+  #
+  # This is the RESPONSE-side counterpart to obfuscated_header?, and it is deliberately
+  # narrower. request_framing rejects on ANY obfuscation because a request's peer is the
+  # operator's own browser, which never emits one — so a blunt rule costs nothing. A
+  # RESPONSE's peer is the whole internet, and the sloppy-but-harmless origins that emit a
+  # bare LF or an obs-fold on some unrelated header (embedded devices, legacy CGI) are
+  # exactly the systems a pentester points gori at. Refusing those outright would break the
+  # target's pages and read as "gori is broken". So: reject only when the ambiguity actually
+  # lands on Content-Length / Transfer-Encoding, and let everything else through byte-exact.
+  #
+  # obfuscated_header? is the cheap gate — a clean CRLF head can hide nothing, so the common
+  # path is one byte scan and no allocation at all; only a head that already looks odd pays
+  # for the two views.
+  def self.framing_ambiguous?(raw : Bytes, headers : HeaderList) : Bool
+    return false unless obfuscated_header?(raw)
+    strict_framing_view(headers) != lenient_framing_view(raw)
+  end
+
+  # The framing headers as gori's STRICT parse sees them, "name:value" in wire order.
+  # parse_headers keeps the field-name UNSTRIPPED, so `Transfer-Encoding : chunked` arrives
+  # here named "transfer-encoding " and correctly fails to match FRAMING_NAMES — that
+  # blindness is precisely what this view is measuring.
+  private def self.strict_framing_view(headers : HeaderList) : Array(String)
+    view = [] of String
+    headers.each do |h|
+      name = h.name.downcase
+      view << "#{name}:#{h.value}" if FRAMING_NAMES.includes?(name)
+    end
+    view
+  end
+
+  # The framing headers as a LENIENT recipient would see them, in the same "name:value"
+  # shape so the two views compare directly: a line ends at CR, LF *or* CRLF (not only
+  # CRLF); a line starting with SP/HTAB is an obs-fold continuation appended to the
+  # previous field-value; and the field-name is stripped before it is matched.
+  private def self.lenient_framing_view(raw : Bytes) : Array(String)
+    view = [] of String
+    pos = lenient_next_line(raw, lenient_line_end(raw, 0)) # skip the start-line
+    folds_into = -1                                        # index in `view` an obs-fold continuation would extend, or -1
+    while pos < raw.size
+      stop = lenient_line_end(raw, pos)
+      break if stop == pos # empty line → end of headers
+      line = raw[pos, stop - pos]
+      first = line.unsafe_fetch(0)
+      if first == 0x20_u8 || first == 0x09_u8 # obs-fold: continues the previous field-value
+        view[folds_into] = "#{view[folds_into]} #{String.new(line).strip}" if folds_into >= 0
+      elsif (kv = lenient_header(line)) && FRAMING_NAMES.includes?(kv[0])
+        view << "#{kv[0]}:#{kv[1]}"
+        folds_into = view.size - 1
+      else
+        folds_into = -1
+      end
+      pos = lenient_next_line(raw, stop)
+    end
+    view
+  end
+
+  # Index of the first CR or LF at/after `pos` (i.e. where a lenient recipient ends the
+  # line), or raw.size when the line runs to the end of the buffer.
+  private def self.lenient_line_end(raw : Bytes, pos : Int32) : Int32
+    i = pos
+    while i < raw.size
+      b = raw.unsafe_fetch(i)
+      break if b == 0x0d_u8 || b == 0x0a_u8
+      i += 1
+    end
+    i
+  end
+
+  # Start of the next line, stepping over the terminator at `stop`. CRLF counts as ONE
+  # terminator; a lone CR and a lone LF each end a line on their own.
+  private def self.lenient_next_line(raw : Bytes, stop : Int32) : Int32
+    return stop if stop >= raw.size
+    crlf = raw.unsafe_fetch(stop) == 0x0d_u8 && stop + 1 < raw.size && raw.unsafe_fetch(stop + 1) == 0x0a_u8
+    stop + (crlf ? 2 : 1)
+  end
+
+  # {stripped+downcased field-name, stripped field-value} of one header line, or nil when
+  # the line carries no colon (a lenient recipient has no header to read out of it either).
+  private def self.lenient_header(line : Bytes) : {String, String}?
+    colon = line.index(0x3a_u8) # ':'
+    return nil unless colon
+    {String.new(line[0, colon]).strip.downcase,
+     String.new(line[colon + 1, line.size - colon - 1]).strip}
   end
 
   private def self.parse_headers(raw : Bytes, start_crlf : Int32?) : HeaderList


### PR DESCRIPTION
Two request-smuggling / response-desync gaps found while dogfooding the proxy against raw-socket origins.

## The bugs

**1. `Http1.obfuscated_header?` flagged a bare LF but not its mirror, a bare CR.**

`index_crlf`/`parse_headers` only ever break a line on the 2-byte CRLF, so a lone CR (0x0d not followed by 0x0a) is just another byte inside the current field-value and everything after it is swallowed into that value:

```
POST /echo-post HTTP/1.1
Host: h
Content-Length: 0
X-Foo: bar\rTransfer-Encoding: chunked
```

gori framed this as `Content-Length: 0` while a recipient that ends a line on a lone CR reads the hidden `Transfer-Encoding: chunked`. The byte-identical **bare-LF** version was already correctly rejected — only the CR mirror was missing. CR is not a legal `field-vchar` (RFC 7230 §3.2.6), so rejecting it cannot false-positive on conformant traffic.

**2. `Body.response_framing` had no obfuscation guard at all** — neither CR nor LF, while `request_framing` has had one. gori frames by what *it* sees, then forwards the head byte-exact (P7), so an origin can hide a `Content-Length`/`Transfer-Encoding` from gori that the browser behind it still reads. The bytes gori then treats as the *next* response on a reused upstream are the bytes that client is still consuming as this one — a malicious origin gets to pick what the operator's browser renders next.

## The fix is deliberately asymmetric

The response side does **not** reuse the request side's blanket "any obfuscation → reject" rule, and that's the main thing to review.

A request's peer is the operator's own browser, which never obfuscates — a blunt rule costs nothing there. A response's peer is the whole internet, and the sloppy-but-harmless origins that bare-LF or obs-fold some *unrelated* header (embedded devices, legacy CGI) are exactly the systems gori gets pointed at. Blanket rejection would break those targets' pages and read as "gori is broken".

So the response side gets a narrower `Http1.framing_ambiguous?(raw, headers)`: it compares the framing-relevant headers (`Content-Length` / `Transfer-Encoding`) as gori's **strict** CRLF parse saw them against what a **lenient** recipient would read (CR, LF *or* CRLF ends a line; obs-fold continues the previous value; field-name stripped before matching), and rejects **only when those two views differ**. Anything else is forwarded byte-exact.

`obfuscated_header?` is reused as the cheap gate, so a clean CRLF head costs one byte scan and zero allocation on the hot path; only an already-odd head pays for building the two views. The check sits *before* the bodyless short-circuits (HEAD/CONNECT, 1xx/204/304) so no status/method combination routes around it — the client, not gori, decides what it reads next off that connection.

Existing error paths needed no change: `response_framing_or_close` records a visible error flow and closes, the held-response path falls back to close-delimited, and the Repeater keeps the head + flags incomplete — which is what a smuggling probe *wants* to see rather than have hidden.

## Verification

- **Control-ran the fix**, since a green suite proves nothing here: neutered each behavior in place while keeping the new API (a plain `git stash` revert only yields a compile error, which proves the API is new but says nothing about behavior). Exactly the 6 rejection specs fail; the 2 no-false-positive specs hold in both directions.
- Re-ran the original raw-socket PoCs against a freshly built binary: the malicious response no longer reaches the client (curl exit 52) and lands in History as `response framing rejected: ambiguous framing headers …`; the bare-CR request is rejected while the byte-identical CR-free request still returns 200.
- **Real-traffic regression pass** (the main false-positive risk, since this now runs on every response): example.com, google, github, cloudflare, wikipedia, news.ycombinator.com, bbc.com/news over h2 + keep-alive — zero rejections.
- Suite **3453 / 0 failures**. ameba clean on the touched files, which also clears a **pre-existing** 18/12 cyclomatic warning on `obfuscated_header?` (extracting `bare_cr_or_lf?` / `space_before_colon?` brought it under the ceiling).

## Behavior change

A response whose framing headers are genuinely ambiguous is now refused instead of relayed. That is intentional and is the point of the PR; RFC 7230 §3.2.4 explicitly sanctions refusing here rather than guessing.
