### PR TITLE
fix: dogfooding-surfaced bugs across proxy, cli, repeater, import, and scanners

### DIFF
--- a/spec/capture_lock_spec.cr
+++ b/spec/capture_lock_spec.cr
@@ -33,4 +33,46 @@ describe Gori::CaptureLock do
       FileUtils.rm_rf(parent) if Dir.exists?(parent)
     end
   end
+
+  it "keys the lock on the DB FILE so two --db files sharing a directory don't collide" do
+    dir = File.tempname("gori-lock-db")
+    Dir.mkdir_p(dir)
+    begin
+      pa = Gori::Project.new("a", File.join(dir, "a.db"))
+      pb = Gori::Project.new("b", File.join(dir, "b.db"))
+      # Distinct db files ⇒ distinct lock files (the bug: they shared <dir>/.capture.lock).
+      pa.capture_lock_path.should_not eq(pb.capture_lock_path)
+
+      la = Gori::CaptureLock.try_at(pa.capture_lock_path)
+      la.should_not be_nil
+      # A DIFFERENT database in the SAME directory must still acquire its own lock — no false
+      # serialization (previously this failed with "another instance holds this ... lock").
+      lb = Gori::CaptureLock.try_at(pb.capture_lock_path)
+      lb.should_not be_nil
+      # A second holder of the SAME database is still denied.
+      Gori::CaptureLock.try_at(pa.capture_lock_path).should be_nil
+
+      la.not_nil!.close
+      lb.not_nil!.close
+    ensure
+      FileUtils.rm_rf(dir) if Dir.exists?(dir)
+    end
+  end
+
+  it "keeps the canonical registry db on the legacy per-directory lock (dir-based held? still works)" do
+    dir = File.tempname("gori-lock-reg")
+    begin
+      proj = Gori::Project.new("reg", File.join(dir, Gori::Project::DB_FILE)) # gori.db
+      # The canonical db keeps <dir>/.capture.lock, so the registry's dir-based held? guards
+      # (delete/rename, project picker, mcp) keep detecting a live capturer — no regression.
+      proj.capture_lock_path.should eq(Gori::CaptureLock.path(dir))
+      lock = Gori::CaptureLock.try_at(proj.capture_lock_path)
+      lock.should_not be_nil
+      Gori::CaptureLock.held?(dir).should be_true # dir-based probe sees the db-keyed acquire
+      lock.not_nil!.close
+      Gori::CaptureLock.held?(dir).should be_false
+    ensure
+      FileUtils.rm_rf(dir) if Dir.exists?(dir)
+    end
+  end
 end

--- a/spec/cli_run_oast_stop_spec.cr
+++ b/spec/cli_run_oast_stop_spec.cr
@@ -1,0 +1,27 @@
+require "./spec_helper"
+
+# Test seam: oast_wait_or_stop is a private module method; expose a thin caller within
+# the same namespace (test binary only) so Fix #6's stop mechanism can be tested
+# without installing a real signal trap or delivering SIGINT to the spec runner.
+module Gori::CLI::Run
+  def self.spec_oast_wait_or_stop(stop : Channel(Nil), interval : Time::Span) : Bool
+    oast_wait_or_stop(stop, interval)
+  end
+end
+
+# Fix #6 — `gori run oast listen` ignored Ctrl-C: the poll loop trapped no signals and
+# only SIGTERM/SIGKILL stopped it. INT/TERM now send to a channel that oast_wait_or_stop
+# selects on, so a stop breaks the loop promptly instead of waiting out the interval.
+describe "Gori::CLI::Run.oast_wait_or_stop" do
+  it "returns true immediately when a stop is already signalled (interrupt the sleep)" do
+    stop = Channel(Nil).new(1)
+    stop.send(nil) # simulate the INT/TERM trap firing
+    # A long interval proves it doesn't wait it out: it must wake on the channel.
+    Gori::CLI::Run.spec_oast_wait_or_stop(stop, 30.seconds).should be_true
+  end
+
+  it "returns false on timeout when no stop arrives (keep polling)" do
+    stop = Channel(Nil).new(1)
+    Gori::CLI::Run.spec_oast_wait_or_stop(stop, 1.milliseconds).should be_false
+  end
+end

--- a/spec/cli_run_sequence_tokens_spec.cr
+++ b/spec/cli_run_sequence_tokens_spec.cr
@@ -1,0 +1,41 @@
+require "./spec_helper"
+
+# Test seam: read_token_list is a private module method; expose a thin caller within
+# the same namespace (this only exists in the test binary) so Fix #1 can be exercised
+# directly without going through the network/exit paths of the full subcommand.
+module Gori::CLI::Run
+  def self.spec_read_token_list(file : String) : Array(String)
+    read_token_list(file)
+  end
+end
+
+# Fix #1 — `gori run sequence --tokens=FILE` used to crash with
+# "ArgumentError: Regex match error: UTF-8 error" when the file held a non-UTF-8 byte,
+# because the `raw.split(/\r?\n/)` PCRE2 split rejects invalid UTF-8. The read now
+# scrubs to valid UTF-8 first so a stray byte doesn't abort the whole analysis.
+describe "Gori::CLI::Run.read_token_list" do
+  it "does not crash on a non-UTF-8 tokens file (scrubs the bad byte to U+FFFD)" do
+    path = File.tempname("gori-tokens")
+    # a \n b<0xff> \n c \n  — the 0xff used to make the regex split raise.
+    File.write(path, Bytes[0x61_u8, 0x0a_u8, 0x62_u8, 0xff_u8, 0x0a_u8, 0x63_u8, 0x0a_u8])
+    begin
+      tokens = Gori::CLI::Run.spec_read_token_list(path)
+      tokens.size.should eq(3)
+      tokens[0].should eq("a")
+      tokens[1].should eq("b\u{FFFD}") # invalid byte replaced with U+FFFD, token preserved
+      tokens[2].should eq("c")
+    ensure
+      File.delete(path) rescue nil
+    end
+  end
+
+  it "reads a normal UTF-8 tokens file unchanged (CRLF + blank lines handled)" do
+    path = File.tempname("gori-tokens")
+    File.write(path, "one\r\ntwo\n\n  three  \n")
+    begin
+      Gori::CLI::Run.spec_read_token_list(path).should eq(["one", "two", "three"])
+    ensure
+      File.delete(path) rescue nil
+    end
+  end
+end

--- a/spec/decoder_spec.cr
+++ b/spec/decoder_spec.cr
@@ -303,6 +303,33 @@ describe Gori::Decoder do
       out.should contain "UNSIGNED"
       out.should contain "signature: absent"
     end
+
+    it "still decodes header/payload/signature exactly as before for a plain 3-part token (no regression)" do
+      token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." \
+              "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0.abc"
+      out = conv("jwt-decode", token)
+      out.should_not contain "WARNING"
+      out.should_not contain "extra segment"
+    end
+
+    it "surfaces segments beyond the 3rd instead of silently dropping them (fix #22)" do
+      # a.b.c.d.e — a naive parts[0..2] read would decode this as if it were a plain
+      # 3-part JWT and silently drop "d" and "e", hiding smuggled/obfuscated trailing data.
+      out = conv("jwt-decode", "a.b.c.d.e")
+      out.should contain "WARNING"
+      out.should contain "5 dot-separated parts"
+      out.should contain "JWE-shaped"
+      out.should contain "[3] d"
+      out.should contain "[4] e"
+    end
+
+    it "flags a non-5-part extra-segment token generically, still showing the raw extras" do
+      out = conv("jwt-decode", "a.b.c.d")
+      out.should contain "WARNING"
+      out.should contain "4 dot-separated parts"
+      out.should contain "not a standard JWT"
+      out.should contain "[3] d"
+    end
   end
 
   describe ".run (chain executor)" do

--- a/spec/discover/engine_spec.cr
+++ b/spec/discover/engine_spec.cr
@@ -231,4 +231,23 @@ describe Gori::Discover::Engine do
     urls.should contain("http://t/app/inner")
     urls.should_not contain("http://t/outside")
   end
+
+  it "confines on path-SEGMENT boundaries, not a raw string prefix (no sibling-prefix bypass)" do
+    # Seed /api (no trailing slash). The old confine used p.path.starts_with?("/api"), so a
+    # SIBLING like /api-internal (which merely shares the string prefix) leaked into scope. The
+    # segment-boundary check keeps /api and /api/… in-subtree while excluding /api-internal/….
+    cfg = D::Config.new(spider: true, bruteforce: false, max_depth: 4, concurrency: 1, retries: 0)
+    findings, _ = run_discover("http://t/api", %w(), cfg) do |t|
+      case t
+      when "/api"                 then html(%(<a href="/api/inner">in</a> <a href="/api-internal/secret">sibling</a>))
+      when "/api/inner"           then html("inside the api subtree")
+      when "/api-internal/secret" then html("a sibling that only shares the string prefix")
+      else                             notfound
+      end
+    end
+    urls = findings.map(&.url)
+    urls.should contain("http://t/api")                     # the seed path itself (== base) stays in-subtree
+    urls.should contain("http://t/api/inner")               # a genuine child under base/
+    urls.should_not contain("http://t/api-internal/secret") # sibling prefix — must be excluded
+  end
 end

--- a/spec/filter_ast_spec.cr
+++ b/spec/filter_ast_spec.cr
@@ -219,4 +219,29 @@ describe Gori::FilterAst do
       end
     end
   end
+
+  # Regression for the recursive-descent depth guard (FilterAst::MAX_PARSE_DEPTH). Filter
+  # parsing is reached from History QL, Probe, Sitemap, Issues, the TUI filter bar and MCP;
+  # the parse_or→parse_and→parse_unary→parse_primary descent had no nesting cap, so a fuzzed
+  # or hostile `((((…))))` / `NOT NOT NOT …` thousands deep recursed one native stack frame
+  # per level and SIGSEGV'd the process. The guard must not change any normal parse.
+  describe "deep nesting (recursion depth guard)" do
+    it "does not overflow the stack on thousands of nested parentheses" do
+      q = "#{"(" * 8000}host:evil#{")" * 8000}"
+      # The crash was here (unbounded recursion). Past the cap the descent degrades like the
+      # existing empty-`()` handling and still recovers the real term rather than crashing.
+      Gori::FilterAst.terms(Gori::FilterAst.parse(q)).map(&.text).should contain("host:evil")
+    end
+
+    it "does not overflow the stack on a very long NOT chain" do
+      Gori::FilterAst.parse("#{"NOT " * 8000}host:x").should_not be_nil
+    end
+
+    it "parses normal shallow nesting exactly as before the guard" do
+      # A handful of levels is far under the cap, so these stay byte-for-byte unchanged.
+      parse("((a OR b) c) OR d").should eq("(or (and (or a b) c) d)")
+      parse("NOT (host:cdn OR host:static)").should eq("(not (or host:cdn host:static))")
+      parse("(host:a OR host:b) -method:GET").should eq("(and (or host:a host:b) -method:GET)")
+    end
+  end
 end

--- a/spec/fuzz_payload_wordlist_spec.cr
+++ b/spec/fuzz_payload_wordlist_spec.cr
@@ -1,0 +1,39 @@
+require "./spec_helper"
+require "file_utils"
+
+# Fix #24 — `gori run fuzz -w <path>` must surface a missing / unusable wordlist as a
+# clean Gori::Error (→ "gori run fuzz: wordlist …"), not a raw File::NotFoundError
+# backtrace leaking out of File.each_line / File.open.
+describe Gori::Fuzz::WordlistFile do
+  it "raises a clean Gori::Error for a missing wordlist path (not a raw File error)" do
+    wl = Gori::Fuzz::WordlistFile.new("/no/such/gori-wordlist-#{Random::Secure.hex(4)}.txt")
+    expect_raises(Gori::Error, /wordlist not found/) { wl.size }          # preflight open-check path
+    expect_raises(Gori::Error, /wordlist not found/) { wl.open_iterator } # run-time cursor path
+  end
+
+  it "rejects a directory given as a wordlist" do
+    dir = File.tempname("gori-wl-dir")
+    Dir.mkdir_p(dir)
+    begin
+      wl = Gori::Fuzz::WordlistFile.new(dir)
+      expect_raises(Gori::Error, /directory/) { wl.size }
+    ensure
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  it "counts and iterates a real wordlist unchanged" do
+    path = File.tempname("gori-wl")
+    File.write(path, "alpha\nbeta\ngamma\n")
+    begin
+      wl = Gori::Fuzz::WordlistFile.new(path)
+      wl.size.should eq(3_i64)
+      it = wl.open_iterator
+      values = [it.next_value, it.next_value, it.next_value, it.next_value]
+      values.should eq(["alpha", "beta", "gamma", nil])
+      it.close
+    ensure
+      File.delete(path) rescue nil
+    end
+  end
+end

--- a/spec/import/import_spec.cr
+++ b/spec/import/import_spec.cr
@@ -685,6 +685,82 @@ describe Gori::Import do
       File.delete?(har)
     end
   end
+
+  # --- content_type derivation (real header wins over HAR content.mimeType) ----------------
+  it "stores the real Content-Type response HEADER, not a disagreeing HAR content.mimeType" do
+    # A HAR whose mimeType lies (`text/html`) about a real `application/json` response must
+    # store the header's type as a live-captured flow would — else `run probe` fires HTML-only
+    # findings (missing_csp, missing_x_frame_options, …) on a pure JSON body (false positives).
+    har = File.tempname("gori", ".har")
+    begin
+      File.write(har, {log: {entries: [
+        {startedDateTime: "2026-06-01T12:00:00Z",
+         request:         {method: "GET", url: "https://api.test/data", httpVersion: "HTTP/1.1"},
+         response:        {status: 200, statusText: "OK", httpVersion: "HTTP/1.1",
+                    headers: [{name: "Content-Type", value: "application/json"}],
+                    content: {mimeType: "text/html", text: %({"ok":true})}}},
+      ]}}.to_json)
+      with_store do |store|
+        Gori::Import.import_file(store, :har, har).count.should eq(1)
+        store.search(Gori::QL::EMPTY, 1).first.content_type.should eq("application/json")
+      end
+    ensure
+      File.delete?(har)
+    end
+  end
+
+  it "falls back to HAR content.mimeType for content_type when there is no Content-Type header" do
+    har = File.tempname("gori", ".har")
+    begin
+      File.write(har, {log: {entries: [
+        {startedDateTime: "2026-06-01T12:00:00Z",
+         request:         {method: "GET", url: "https://api.test/x", httpVersion: "HTTP/1.1"},
+         response:        {status: 200, statusText: "OK", httpVersion: "HTTP/1.1",
+                    content: {mimeType: "application/json", text: "{}"}}},
+      ]}}.to_json)
+      with_store do |store|
+        Gori::Import.import_file(store, :har, har).count.should eq(1)
+        store.search(Gori::QL::EMPTY, 1).first.content_type.should eq("application/json")
+      end
+    ensure
+      File.delete?(har)
+    end
+  end
+
+  # --- host validation / IPv6 normalization ------------------------------------------------
+  it "skips a --urls line that is non-URL garbage with spaces (never stored as a host)" do
+    urls = File.tempname("gori", ".txt")
+    begin
+      File.write(urls, "not a url at all\nhttps://good.test/ok\n")
+      with_store do |store|
+        result = Gori::Import.import_file(store, :urls, urls)
+        result.count.should eq(1)   # only the real URL imported
+        result.skipped.should eq(1) # the space-laden garbage skipped, not stored
+        hosts = store.search(Gori::QL::EMPTY, 10).map(&.host)
+        hosts.should eq(["good.test"])
+        hosts.each { |h| h.should_not contain(' ') }
+      end
+    ensure
+      File.delete?(urls)
+    end
+  end
+
+  it "stores an imported IPv6 host bracket-free (matching the CONNECT path), port kept" do
+    urls = File.tempname("gori", ".txt")
+    begin
+      File.write(urls, "https://[::1]:9443/probe\n")
+      with_store do |store|
+        Gori::Import.import_file(store, :urls, urls).count.should eq(1)
+        row = store.search(Gori::QL::EMPTY, 1).first
+        row.host.should eq("::1") # not "[::1]"
+        row.port.should eq(9443)
+        # the Host header line stays RFC 7230 bracketed even though the stored host is bare
+        String.new(store.get_flow(row.id).not_nil!.request_head).should contain("Host: [::1]")
+      end
+    ensure
+      File.delete?(urls)
+    end
+  end
 end
 
 describe Gori::Import::Builder do
@@ -719,5 +795,18 @@ describe Gori::Import::Builder do
     headers << {"X-Foo", "a\tb"}
     head = String.new(Gori::Import::Builder.request_head("GET", "/", "HTTP/1.1", "h.test", headers, nil))
     head.should contain("X-Foo: a\tb")
+  end
+
+  it "rejects a host containing a space (non-URL garbage), consistent with bad-scheme skips" do
+    expect_raises(Gori::Error, /bad host/) do
+      Gori::Import::Builder.endpoint("not a url at all")
+    end
+  end
+
+  it "stores an IPv6 host bracket-free but re-brackets it in the Host header line" do
+    pair = Gori::Import::Builder.pending_request(0_i64, "https://[::1]:9443/probe")
+    pair.request.host.should eq("::1") # bare, matching the CONNECT path
+    pair.request.port.should eq(9443)
+    String.new(pair.request.head).should contain("Host: [::1]") # RFC 7230 §5.4 valid
   end
 end

--- a/spec/issues_export_spec.cr
+++ b/spec/issues_export_spec.cr
@@ -70,6 +70,29 @@ describe Gori::Issues::Export do
     end
   end
 
+  describe ".scrub_controls" do
+    it "strips terminal escape sequences (ESC/BEL/OSC/CSI, C0/C1) but preserves newlines and tabs" do
+      # An OSC "set window title" (ESC ] 0 ; … BEL) printed raw to a TTY would drive the terminal.
+      # scrub_controls removes the control BYTES (defanging the sequence) while keeping the note's
+      # own newlines/tabs so a multi-line value stays intact.
+      esc = 27.chr                             # ESC 0x1B
+      bel = 7.chr                              # BEL 0x07 (OSC terminator)
+      raw = "a#{esc}]0;INJECTED#{bel}b\r\n\tc" # ESC-introduced OSC + BEL, a bare CR, then \n\t
+      out = Gori::Issues::Export.scrub_controls(raw)
+      out.includes?(esc).should be_false  # ESC gone
+      out.includes?(bel).should be_false  # BEL gone
+      out.includes?('\r').should be_false # lone CR gone (cursor-overwrite defanged)
+      out.should contain("INJECTED")      # the payload TEXT remains, only the control bytes go
+      out.should contain("\n\tc")         # newline + tab preserved (multi-line structure intact)
+    end
+
+    it "leaves ordinary text untouched and does not raise on invalid UTF-8" do
+      Gori::Issues::Export.scrub_controls("plain\nmulti-line\ttext").should eq("plain\nmulti-line\ttext")
+      out = Gori::Issues::Export.scrub_controls(String.new(Bytes[0x61, 0x80, 0x62])) # invalid byte
+      out.valid_encoding?.should be_true
+    end
+  end
+
   describe ".markdown" do
     it "keeps an attacker-controlled body (``` + headings) inside its code fence" do
       with_store do |store|
@@ -203,6 +226,22 @@ describe Gori::Issues::Export do
         md = Gori::Issues::Export.markdown(store.issues, store, "proj")
         md.valid_encoding?.should be_true
         md.should contain("l1�\nl2") # newline preserved, invalid byte scrubbed to U+FFFD
+      end
+    end
+    it "neutralizes terminal escape sequences in an issue's notes field (markdown printed to a TTY)" do
+      # notes routes through scrub_controls: an OSC "set window title" (ESC ] 0 ; … BEL) embedded
+      # in a notes field would otherwise reach the terminal when `gori run issues --format markdown`
+      # prints the report to STDOUT. The payload TEXT survives (defanged); the ESC/BEL bytes go.
+      with_store do |store|
+        id = store.insert_issue("clean title", Gori::Store::Severity::Low, "clean.host", nil)
+        store.update_issue(id, notes: "before#{27.chr}]0;pwn#{7.chr}after")
+
+        md = Gori::Issues::Export.markdown(store.issues, store, "proj")
+        md.includes?(27.chr).should be_false # ESC stripped
+        md.includes?(7.chr).should be_false  # BEL stripped
+        md.should contain("before")
+        md.should contain("pwn") # payload text remains, defanged
+        md.should contain("after")
       end
     end
   end

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -1669,6 +1669,26 @@ describe Gori::MCP::Server do
         resp["structuredContent"]["error_code"].as_s.should eq("NOT_FOUND")
       end
     end
+
+    it "toggles the sandbox gate on/off, flags block-all, and reflects it in list_scope" do
+      with_store do |store|
+        listed0 = tool_payload(drive(store, %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_scope"}}))[0])
+        listed0["sandbox"].as_bool.should be_false
+
+        on = %({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"set_sandbox","arguments":{"enabled":true}}})
+        payload = tool_payload(drive(store, on)[0])
+        payload["sandbox"].as_bool.should be_true
+        payload["blocks_all"].as_bool.should be_true # no include rules yet ⇒ blocks everything
+        store.setting(Gori::Scope::SETTING_SANDBOX).should eq("1")
+
+        listed1 = tool_payload(drive(store, %({"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_scope"}}))[0])
+        listed1["sandbox"].as_bool.should be_true
+
+        off = %({"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"set_sandbox","arguments":{"enabled":false}}})
+        tool_payload(drive(store, off)[0])["sandbox"].as_bool.should be_false
+        store.setting(Gori::Scope::SETTING_SANDBOX).should eq("0")
+      end
+    end
   end
 
   describe "env var tools" do

--- a/spec/miner/engine_spec.cr
+++ b/spec/miner/engine_spec.cr
@@ -187,4 +187,22 @@ describe Gori::Miner::Engine do
     mine(backend, names, c)
     backend.sent.should be <= 12 # was ~cap + 2*concurrency
   end
+
+  it "does not count max-requests cap refusals as errors (fix #19)" do
+    # Regression: process_bucket used to count EVERY raw.error as @errors, including
+    # CappedBackend's post-cap refusal — buckets already dispatched into the buffered
+    # worker channel before the cap check fired. Under concurrency, that inflated
+    # "errors" with pure cap-refusals rather than real network failures.
+    backend = HiddenParamBackend.new(F::Origin.new("http", "h", 80), reflect: ["secret"])
+    c = cfg
+    c.concurrency = 8
+    c.max_requests = 5_i64 # far below what baseline + mining 80 names would need
+    names = (1..80).map { |i| "p#{i}" } + ["secret"]
+    base = "GET /api HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+    engine = M::Engine.new(base, http2: false, names: names, backend: backend, config: c)
+    done_progress = nil.as(M::Progress?)
+    engine.run { |ev| done_progress = ev.progress if ev.is_a?(M::DoneEvent) }
+    done_progress.should_not be_nil
+    done_progress.not_nil!.errors.should eq(0)
+  end
 end

--- a/spec/notes_spec.cr
+++ b/spec/notes_spec.cr
@@ -1,0 +1,28 @@
+require "./spec_helper"
+require "../src/gori/notes"
+
+describe Gori::Notes do
+  describe "Doc#texts" do
+    it "strips terminal control sequences from note bodies but preserves newlines/tabs and leaves stored text raw" do
+      # `gori run notes` (and --all) print doc.texts straight to STDOUT. A note body carrying an
+      # OSC "set window title" (ESC ] 0 ; … BEL) would drive the terminal — texts is the CLI
+      # listing accessor, so it neutralizes the control bytes while keeping the note's own line
+      # breaks/tabs. The STORED NoteEntry text must stay raw (persistence + TUI editing see it).
+      esc = 27.chr # ESC 0x1B
+      bel = 7.chr  # BEL 0x07
+      raw = "line1#{esc}]0;INJECTED#{bel}\nline2\twith tab"
+      entries = [Gori::Notes::NoteEntry.new(1_i64, raw)]
+      doc = Gori::Notes::Doc.new(0, entries, 2_i64)
+
+      out = doc.texts.first
+      out.includes?(esc).should be_false # ESC stripped
+      out.includes?(bel).should be_false # BEL stripped
+      out.should contain("line1")
+      out.should contain("INJECTED")   # payload text remains (defanged)
+      out.should contain("\nline2")    # newline preserved (multi-line notes stay intact)
+      out.should contain("\twith tab") # tab preserved
+
+      doc.notes.first.text.should eq(raw) # stored entry untouched — round-trips raw for persistence
+    end
+  end
+end

--- a/spec/project_registry_nonascii_spec.cr
+++ b/spec/project_registry_nonascii_spec.cr
@@ -1,0 +1,51 @@
+require "./spec_helper"
+require "file_utils"
+
+# Fix #5 — an all-non-ASCII project name (e.g. "日本語") used to slugify to "" and be
+# rejected as "invalid project name", making such projects unusable via --project.
+# ProjectRegistry#slugify now derives a stable, filesystem-safe fallback slug for them
+# WITHOUT changing any existing ASCII project's directory name.
+private def with_nonascii_root(&)
+  root = File.tempname("gori-registry-nonascii")
+  begin
+    yield root
+  ensure
+    FileUtils.rm_rf(root) if Dir.exists?(root)
+  end
+end
+
+describe Gori::ProjectRegistry do
+  it "creates a usable project for an all-non-ASCII display name (stable hashed slug)" do
+    with_nonascii_root do |root|
+      reg = Gori::ProjectRegistry.new(root)
+      p = reg.create("日本語")
+      p.name.should eq("日本語") # verbatim display name preserved
+      slug = File.basename(p.dir)
+      slug.should start_with("project-") # ASCII-safe fallback slug
+      slug.matches?(/\Aproject-[0-9a-f]+\z/).should be_true
+      Dir.exists?(p.dir).should be_true
+      # Deterministic: reopening the same name resolves to the SAME directory.
+      reg.create("日本語").dir.should eq(p.dir)
+      # Materialize the DB so list/find sees the project (as the sibling specs do),
+      # then confirm it's addressable by its verbatim display name via #find.
+      Gori::Store.open(p.db_path).close
+      reg.find("日本語").try(&.dir).should eq(p.dir)
+    end
+  end
+
+  it "leaves an ASCII name's slug unchanged by the non-ASCII fallback" do
+    with_nonascii_root do |root|
+      reg = Gori::ProjectRegistry.new(root)
+      reg.create("ACME Red Team!").db_path.should eq(File.join(root, "acme-red-team", "gori.db"))
+    end
+  end
+
+  it "still rejects a blank / ASCII-punctuation-only name (no '.'/'..' traversal)" do
+    with_nonascii_root do |root|
+      reg = Gori::ProjectRegistry.new(root)
+      expect_raises(Gori::Error, /invalid project name/) { reg.create("   ") }
+      expect_raises(Gori::Error, /invalid project name/) { reg.create("..") }
+      expect_raises(Gori::Error, /invalid project name/) { reg.create("---") }
+    end
+  end
+end

--- a/spec/proxy/request_line_capture_spec.cr
+++ b/spec/proxy/request_line_capture_spec.cr
@@ -1,0 +1,132 @@
+require "../spec_helper"
+require "socket"
+
+# Fix #12: an active request-rewrite rule must NOT rewrite the CAPTURED request-line form.
+#
+# A forward-proxy client sends an ABSOLUTE-form request line (`GET http://host/p HTTP/1.1`).
+# resolve_forward normalizes that to ORIGIN-form (`GET /p`) for the outbound wire request, but
+# the RECORDED request must preserve the client's original absolute-form line (byte-fidelity),
+# applying only the rule's intended change on top of it — so an unrelated rule (e.g. add_header)
+# leaves the request line untouched, while a rule targeting the request line still shows its
+# change. The wire request legitimately stays origin-form.
+
+private class CaptureSink < Gori::Proxy::FlowSink
+  getter requests = [] of Gori::Store::CapturedRequest
+  getter responses = [] of Gori::Store::CapturedResponse
+
+  def initialize(@done : Channel(Nil))
+    @next_id = 0_i64
+  end
+
+  def on_request(req : Gori::Store::CapturedRequest) : Int64
+    @requests << req
+    @next_id += 1
+  end
+
+  def on_response(resp : Gori::Store::CapturedResponse) : Nil
+    @responses << resp
+    @done.send(nil)
+  end
+
+  def on_ws_message(flow_id : Int64, direction : String, opcode : Int32, payload : Bytes) : Nil
+  end
+end
+
+# Adds an unrelated header; leaves the request LINE untouched.
+private class HeaderAddRewriter < Gori::Proxy::HeadRewriter
+  def rewrite_request(head : Bytes, host : String) : Bytes
+    String.new(head).sub("\r\n", "\r\nX-Injected: 1\r\n").to_slice
+  end
+
+  def rewrite_response(head : Bytes, host : String) : Bytes
+    head
+  end
+end
+
+# Rewrites the request path (which appears in BOTH the absolute-form and the origin-form line).
+private class PathRewriter < Gori::Proxy::HeadRewriter
+  def rewrite_request(head : Bytes, host : String) : Bytes
+    String.new(head).gsub("/hello", "/hi").to_slice
+  end
+
+  def rewrite_response(head : Bytes, host : String) : Bytes
+    head
+  end
+end
+
+# Minimal origin: records the request-line it saw, replies Connection: close.
+private def start_capture_origin(seen : Channel(String)) : Int32
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    while conn = origin.accept?
+      head = Gori::Proxy::Codec::Http1.read_head(conn)
+      seen.send(head ? String.new(head).lines.first : "")
+      conn << "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nhi"
+      conn.flush
+      conn.close
+    end
+  rescue
+  end
+  port
+end
+
+describe "Gori::Proxy request-line capture fidelity (Fix #12)" do
+  it "preserves the client's absolute-form request line in the capture when a rule adds an unrelated header" do
+    seen = Channel(String).new(1)
+    done = Channel(Nil).new(1)
+    origin_port = start_capture_origin(seen)
+
+    sink = CaptureSink.new(done)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink, rewriter: HeaderAddRewriter.new)
+    proxy.start
+
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    client.read_timeout = 5.seconds
+    client << "GET http://127.0.0.1:#{origin_port}/hello HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\n\r\n"
+    client.flush
+    client.gets_to_end
+    client.close
+
+    done.receive
+    proxy.stop
+
+    # Wire: normalized to origin-form (unchanged behavior); the rule's header IS sent upstream.
+    seen.receive.should eq("GET /hello HTTP/1.1")
+
+    # Capture: the ORIGINAL absolute-form request line is preserved (byte-fidelity), with the
+    # rule's added header on top — NOT the origin-form line resolve_forward put on the wire.
+    req = sink.requests.first
+    req.target.should eq("http://127.0.0.1:#{origin_port}/hello")
+    head = String.new(req.head)
+    head.should start_with("GET http://127.0.0.1:#{origin_port}/hello HTTP/1.1\r\n")
+    head.should contain("X-Injected: 1")
+  end
+
+  it "shows a request-line-targeting rule's change while keeping the absolute-form" do
+    seen = Channel(String).new(1)
+    done = Channel(Nil).new(1)
+    origin_port = start_capture_origin(seen)
+
+    sink = CaptureSink.new(done)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink, rewriter: PathRewriter.new)
+    proxy.start
+
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    client.read_timeout = 5.seconds
+    client << "GET http://127.0.0.1:#{origin_port}/hello HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\n\r\n"
+    client.flush
+    client.gets_to_end
+    client.close
+
+    done.receive
+    proxy.stop
+
+    seen.receive.should eq("GET /hi HTTP/1.1") # wire: origin-form, path rewritten
+
+    # Capture: absolute-form preserved AND the intended path change shown.
+    req = sink.requests.first
+    req.target.should eq("http://127.0.0.1:#{origin_port}/hi")
+    String.new(req.head).should start_with("GET http://127.0.0.1:#{origin_port}/hi HTTP/1.1\r\n")
+  end
+end

--- a/spec/proxy/streaming_client_abort_spec.cr
+++ b/spec/proxy/streaming_client_abort_spec.cr
@@ -1,0 +1,141 @@
+require "../spec_helper"
+require "socket"
+
+# Fix #7: a client-aborted close-delimited/SSE response with an IDLE upstream must not leak.
+#
+# For a close-delimited/SSE response both legs' timeouts are relaxed, so the upstream->client
+# copy can block on an idle-origin read indefinitely — and would only notice the CLIENT already
+# went away on its NEXT write, which an idle origin never triggers. That pinned the flow Pending
+# forever and leaked the fiber + both sockets. A concurrent client-abort watcher now tears the
+# idle upstream down on client disconnect so the flow is finalized Aborted — while a still-
+# connected (write-side-open) idle stream keeps flowing untouched.
+
+private class StateSink < Gori::Proxy::FlowSink
+  getter responses = [] of Gori::Store::CapturedResponse
+
+  def initialize(@done : Channel(Nil))
+    @n = 0_i64
+  end
+
+  def on_request(req : Gori::Store::CapturedRequest) : Int64
+    @n += 1
+  end
+
+  def on_response(resp : Gori::Store::CapturedResponse) : Nil
+    @responses << resp
+    @done.send(nil)
+  end
+
+  def on_ws_message(flow_id : Int64, direction : String, opcode : Int32, payload : Bytes) : Nil
+  end
+end
+
+# Reads from `io` until `marker` is seen (or EOF/timeout), returning what was read so far.
+private def read_client_until(io : IO, marker : String) : String
+  buf = IO::Memory.new
+  chunk = Bytes.new(1024)
+  loop do
+    n = io.read(chunk)
+    break if n == 0
+    buf.write(chunk[0, n])
+    break if buf.to_s.includes?(marker)
+  end
+  buf.to_s
+rescue
+  buf.to_s
+end
+
+# Waits up to `within` for a signal on `done`, returning false on timeout instead of hanging the
+# suite — so a regressed (leaking) fix fails cleanly rather than blocking forever.
+private def received_within?(done : Channel(Nil), within : Time::Span) : Bool
+  outcome = Channel(Bool).new(1)
+  spawn { done.receive; outcome.send(true) rescue nil }
+  spawn { sleep within; outcome.send(false) rescue nil }
+  outcome.receive
+end
+
+# A close-delimited SSE origin: sends the event-stream head + a burst, then HOLDS the connection
+# open (no more data, no close) until `release` fires; then optionally sends `more` and closes.
+private def start_idle_sse_origin(release : Channel(Nil), more : String? = nil) : {Int32, TCPServer}
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    if conn = origin.accept?
+      Gori::Proxy::Codec::Http1.read_head(conn)
+      conn << "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n"
+      conn << "data: hello\n\n"
+      conn.flush
+      release.receive # stay idle (connection open) until the test lets go
+      if m = more
+        conn << m
+        conn.flush
+      end
+      conn.close rescue nil
+    end
+  rescue
+  end
+  {port, origin}
+end
+
+describe "Gori::Proxy close-delimited/SSE client-abort teardown (Fix #7)" do
+  it "finalizes the flow Aborted (not Pending) when the client aborts an idle SSE stream" do
+    release = Channel(Nil).new(1)
+    origin_port, origin = start_idle_sse_origin(release)
+
+    done = Channel(Nil).new(1)
+    sink = StateSink.new(done)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink)
+    proxy.start
+
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    client.read_timeout = 5.seconds
+    client << "GET /stream HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\n\r\n"
+    client.flush
+    # Read the burst — guarantees the proxy is in the relaxed streaming phase (watcher spawned).
+    read_client_until(client, "hello").should contain("hello")
+    client.close # abort while the origin stays idle-open
+
+    # With the fix, the client-abort watcher tears the idle upstream down and the flow is
+    # finalized promptly. Without it, on_response never fires (the flow leaks Pending forever).
+    received_within?(done, 3.seconds).should be_true
+
+    release.send(nil) rescue nil
+    proxy.stop
+    origin.close rescue nil
+
+    sink.responses.first.state.should eq(Gori::Store::FlowState::Aborted)
+  end
+
+  it "keeps a still-connected idle SSE stream flowing (does not tear down on idle)" do
+    release = Channel(Nil).new(1)
+    origin_port, origin = start_idle_sse_origin(release, more: "data: bye\n\n")
+
+    done = Channel(Nil).new(1)
+    sink = StateSink.new(done)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink)
+    proxy.start
+
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    client.read_timeout = 5.seconds
+    client << "GET /stream HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\n\r\n"
+    client.flush
+    read_client_until(client, "hello").should contain("hello")
+
+    # The client stays connected while the origin is idle: the stream must NOT be finalized. The
+    # watcher only fires on a client DISCONNECT (a closed write side gives read EOF); a live-but-
+    # idle client keeps its write side open, so the watcher's read just blocks and the stream lives.
+    sleep 0.3.seconds
+    sink.responses.should be_empty
+
+    # Let the origin send the final event and close → the stream completes cleanly.
+    release.send(nil)
+    client.gets_to_end.should contain("bye")
+    client.close
+
+    received_within?(done, 3.seconds).should be_true
+    proxy.stop
+    origin.close rescue nil
+
+    sink.responses.first.state.should eq(Gori::Store::FlowState::Complete)
+  end
+end

--- a/spec/proxy/upstream_spec.cr
+++ b/spec/proxy/upstream_spec.cr
@@ -95,6 +95,16 @@ describe Gori::Proxy::Upstream do
     it "treats an unbracketed IPv6 literal as a bare host" do
       Gori::Proxy::Upstream.split_host_port("::1", 443).should eq({"::1", 443})
     end
+
+    it "does not swallow the port for a malformed multi-colon authority (regression #13)" do
+      # Was: host="127.0.0.1:19110:bogus", port=80 — a non-v6 multi-colon authority was
+      # treated as a whole IPv6 host and the real port was silently dropped.
+      host, _ = Gori::Proxy::Upstream.split_host_port("127.0.0.1:19110:bogus", 80)
+      host.should_not eq("127.0.0.1:19110:bogus") # the whole authority is NOT the host
+      # host:port semantics win — split on the LAST colon.
+      Gori::Proxy::Upstream.split_host_port("127.0.0.1:19110:bogus", 80).should eq({"127.0.0.1:19110", 80})
+      Gori::Proxy::Upstream.split_host_port("127.0.0.1:80", 443).should eq({"127.0.0.1", 80})
+    end
   end
 
   # The self-page / self-loop detection. The interesting case is a WILDCARD bind

--- a/spec/repeater/repeater_bugfixes_spec.cr
+++ b/spec/repeater/repeater_bugfixes_spec.cr
@@ -1,0 +1,160 @@
+require "../spec_helper"
+require "socket"
+require "digest/sha1"
+require "base64"
+
+# Bug-fix regression specs for three verified repeater bugs:
+#   #8  — a malformed / non-HTTP upstream response was returned as {ok:true,status:0}
+#   #15 — `repeater <id> -H "Content-Length: N"` silently discarded the override
+#   #17 — a WebSocket repeater silently dropped binary outbound frames
+private alias WS = Gori::Proxy::WS
+private alias WsEngine = Gori::Repeater::WsEngine
+
+# An origin that reads the request head, then replies with `reply` verbatim (used to feed a
+# non-HTTP / unparseable status line back to the repeater engine).
+private def start_reply_origin(reply : String) : Int32
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    while conn = origin.accept?
+      Gori::Proxy::Codec::Http1.read_head(conn)
+      conn << reply
+      conn.flush
+      conn.close
+    end
+  end
+  port
+end
+
+private BFX_UPGRADE = ("GET /ws HTTP/1.1\r\nHost: 127.0.0.1\r\n" \
+                       "Upgrade: websocket\r\nConnection: Upgrade\r\n" \
+                       "Sec-WebSocket-Key: dGhlIHNhbXBsZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n").to_slice
+
+# A WS origin that completes the upgrade, records the opcode of the FIRST inbound data frame
+# into `seen`, then sends Close so the engine's drain ends immediately.
+private def start_ws_opcode_origin(seen : Channel(Int32)) : Int32
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    next unless conn = origin.accept?
+    conn.read_timeout = 5.seconds
+    head = Gori::Proxy::Codec::Http1.read_head(conn).not_nil!
+    key = String.new(head).each_line
+      .find(&.downcase.starts_with?("sec-websocket-key:"))
+      .try { |l| l.split(':', 2)[1].strip } || ""
+    accept = Base64.strict_encode(Digest::SHA1.digest(key + WsEngine::GUID))
+    conn << "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n" \
+            "Connection: Upgrade\r\nSec-WebSocket-Accept: #{accept}\r\n\r\n"
+    conn.flush
+    frame = WS.read_frame(conn)
+    if frame && frame.data?
+      seen.send(frame.opcode.to_i)
+    else
+      seen.send(-1)
+    end
+    conn.write(WS.encode(WS::OP_CLOSE, Bytes[0x03, 0xE8], mask: false)) # 1000 Normal
+    conn.flush
+    conn.close
+  rescue
+    seen.send(-1) rescue nil
+  end
+  port
+end
+
+# Fix #8 — a status line the codec flags `malformed?` must surface as a failure, not a
+# false success, but keep the raw head so the workbench still shows what came back.
+describe "Gori::Repeater::Engine (malformed response — fix #8)" do
+  it "reports a non-HTTP / unparseable response as a failure (not {ok:true,status:0})" do
+    port = start_reply_origin("NOT_HTTP garbage\r\n\r\n")
+    result = Gori::Repeater::Engine.send("GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n".to_slice,
+      scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
+
+    result.ok?.should be_false
+    result.error.not_nil!.should contain("malformed")
+    result.response.not_nil!.status.should eq(0)
+    String.new(result.head).should contain("NOT_HTTP") # raw bytes preserved for the workbench
+    result.body.should be_nil                          # no body read against unframeable garbage
+  end
+
+  it "still reports a well-formed response exactly as before" do
+    port = start_reply_origin("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+    result = Gori::Repeater::Engine.send("GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n".to_slice,
+      scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
+
+    result.ok?.should be_true
+    result.response.not_nil!.status.should eq(200)
+    String.new(result.body.not_nil!).should eq("ok")
+  end
+
+  it "send_pipeline retires the connection after a malformed response (surfaces desync)" do
+    origin = TCPServer.new("127.0.0.1", 0)
+    port = origin.local_address.port
+    spawn do
+      if conn = origin.accept?
+        Gori::Proxy::Codec::Http1.read_head(conn)
+        conn << "GARBAGE-NON-HTTP\r\n\r\n" # first response has no valid status line
+        conn.flush
+        conn.close
+      end
+    rescue
+    end
+
+    reqs = ["GET /a HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n".to_slice,
+            "GET /b HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n".to_slice]
+    results = Gori::Repeater::Engine.send_pipeline(reqs,
+      scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
+
+    results.size.should eq(2)
+    results[0].ok?.should be_false
+    results[0].error.not_nil!.should contain("malformed")
+    results[1].ok?.should be_false # connection retired — the next request can't be misframed
+  end
+end
+
+# Fix #15 — the single-flow request builder honors an explicit `-H "Content-Length: N"`
+# verbatim (CL-mismatch / smuggling testing) yet auto-syncs when none is given.
+describe "Gori::CLI::Run.build_single_flow_request (explicit Content-Length — fix #15)" do
+  it "honors an explicit -H Content-Length verbatim (no resync to body length)" do
+    head = "POST /x HTTP/1.1\r\nHost: h\r\nContent-Length: 5\r\n\r\n".to_slice
+    out = String.new(Gori::CLI::Run.build_single_flow_request_for_spec(
+      head, "hello".to_slice, ["Content-Length: 999"], nil, nil))
+
+    out.should contain("Content-Length: 999") # the deliberately-wrong CL survives
+    out.should_not contain("Content-Length: 5")
+    out.should contain("\r\n\r\nhello") # body kept byte-exact (CL now mismatches, on purpose)
+  end
+
+  it "auto-syncs Content-Length to the actual body when no explicit CL override is given" do
+    head = "POST /x HTTP/1.1\r\nHost: h\r\nContent-Length: 999\r\n\r\n".to_slice
+    out = String.new(Gori::CLI::Run.build_single_flow_request_for_spec(
+      head, "hello".to_slice, [] of String, nil, nil))
+
+    out.should contain("Content-Length: 5") # resynced to the real 5-byte body
+    out.should_not contain("Content-Length: 999")
+  end
+end
+
+# Fix #17 — the WS send path transmits an outbound binary message as a real binary frame.
+describe "Gori::Repeater::WsEngine (binary outbound frame — fix #17)" do
+  it "transmits an outbound binary message as a WS BINARY frame (not text)" do
+    seen = Channel(Int32).new(1)
+    port = start_ws_opcode_origin(seen)
+
+    payload = Bytes[0x00, 0x01, 0xFF, 0xFE] # non-text bytes
+    result = WsEngine.send(BFX_UPGRADE, [WsEngine::OutMsg.new(2, payload)],
+      scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
+
+    seen.receive.should eq(WS::OP_BIN.to_i) # origin saw a BINARY frame, not text
+    result.ok?.should be_true
+    result.messages.any? { |m| m.direction == "out" && m.opcode == 2 }.should be_true
+  end
+end
+
+# Whitebox shim: `build_single_flow_request` is private CLI glue — reopen the module for a
+# bare-call wrapper, the same trick the other `*_for_spec` specs use.
+module Gori::CLI::Run
+  def self.build_single_flow_request_for_spec(head : Bytes, body : Bytes, headers : Array(String),
+                                              body_override : String?, target_override : String?) : Bytes
+    build_single_flow_request(head, body, headers, body_override, target_override)
+  end
+end

--- a/spec/scope_spec.cr
+++ b/spec/scope_spec.cr
@@ -168,6 +168,14 @@ describe Gori::Scope do
       err.should contain("127.0.0.1") # bare-host suggestion (port stripped)
       err.should_not contain("9091")
 
+      # A bracketed IPv6 + port is rejected too, and the suggestion points at the BARE
+      # stored form ("::1"), NOT the bracketed one — following the old bracketed advice
+      # produced a rule that could never match the bare host the tunnel path stores.
+      err6 = Gori::Scope.validation_error("host", "[::1]:9091").not_nil!
+      err6.should contain("::1")
+      err6.should_not contain("[::1]") # bare form recommended, not bracketed
+      err6.should_not contain("9091")
+
       scope.add("include", "host", "127.0.0.1:9091").should be_false
       store.scope_rules.should be_empty
 
@@ -186,6 +194,24 @@ describe Gori::Scope do
       Gori::Scope.valid?("host", "*.acme.test:8080").should be_false # host glob + port
       Gori::Scope.valid?("string", "acme.test:8080").should be_true  # port fine in string/regex
       Gori::Scope.valid?("regex", ":8080$").should be_true
+    end
+  end
+
+  it "normalizes IPv6 brackets so [::1] and ::1 match a host rule interchangeably" do
+    # The CONNECT/tunnel path (the dominant HTTPS-MITM case) stores the flow host bare,
+    # so a bracketed rule (the form the old suggestion recommended) must still match it —
+    # and a bare rule must match a bracketed flow host.
+    with_store do |store|
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "[::1]").should be_true # bracketed rule
+      scope.host_in_scope?("::1").should be_true           # matches the bare stored host
+      scope.host_in_scope?("::2").should be_false          # negative control (still precise)
+    end
+
+    with_store do |store|
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "::1").should be_true # bare rule
+      scope.host_in_scope?("[::1]").should be_true       # matches a bracketed flow host
     end
   end
 

--- a/spec/sequencer/stats_spec.cr
+++ b/spec/sequencer/stats_spec.cr
@@ -179,6 +179,16 @@ describe Gori::Sequencer::Stats do
     report.sequential.should be_false          # identical leading bytes → r = 0
   end
 
+  it "never reports a NaN correlation for a constant leading-byte series (fix #16)" do
+    # Regression: pearson's den = Math.sqrt((m*sx2-sx*sx)*(m*sy2-sy*sy)) can see
+    # floating-point cancellation drive the y-variance factor slightly NEGATIVE for a
+    # constant/near-constant series, making the radicand negative and Math.sqrt return
+    # NaN — which used to leak into the detail text as "corr=NaN" even though ys here is
+    # exactly constant (identical leading 8 bytes) and the correlation should read 0.
+    big = ["9999999999999999999", "9999999999999999998", "9999999999999999997"]
+    seq_detail(big).should_not contain("NaN")
+  end
+
   # ── detect_sequential: general (leading-byte correlation) path ───────────────────
 
   it "flags non-numeric tokens whose leading byte increases monotonically as sequential" do

--- a/spec/sitemap_depth_spec.cr
+++ b/spec/sitemap_depth_spec.cr
@@ -1,0 +1,105 @@
+require "./spec_helper"
+require "json"
+
+# Iteratively descend first-children to the deepest leaf, and count the chain length,
+# WITHOUT recursion — so the assertions themselves can't overflow on the very deep trees
+# these specs build.
+private def deepest_leaf(host : Gori::Sitemap::Node) : Gori::Sitemap::Node
+  node = host
+  until node.children.empty?
+    node = node.children.first
+  end
+  node
+end
+
+# Regression coverage for the iterative (non-recursive) rewrite of Sitemap.fold_templates!
+# and Sitemap.group_sequences!. A single very deep captured/imported path builds a
+# proportionally deep tree, and the old one-frame-per-level recursion SIGSEGV'd (stack
+# overflow). The transforms are shared by the Sitemap TUI tab and `gori run sitemap`.
+describe Gori::Sitemap do
+  describe "deep trees (no unbounded recursion)" do
+    it "folds a path thousands of segments deep without overflowing the stack" do
+      depth = 20_000
+      target = String.build do |io|
+        depth.times { |i| io << "/seg" << i }
+      end
+      hosts = Gori::Sitemap.build([{"deep.test", "GET", target}])
+
+      # The bug: either of these recursed once per tree level and crashed the process.
+      hosts.each { |h| Gori::Sitemap.fold_templates!(h) }
+      hosts.each { |h| Gori::Sitemap.group_sequences!(h) }
+
+      # Distinct, non-id, non-numeric segments → nothing folds; the literal chain survives.
+      leaf = deepest_leaf(hosts.first)
+      leaf.label.should eq("seg#{depth - 1}")
+      leaf.methods.should eq(["GET"])
+    end
+
+    it "still folds id classes and numeric runs correctly after the rewrite" do
+      entries = [] of {String, String, String}
+      (1..12).each { |i| entries << {"h", "GET", "/api/items/#{i}"} } # 12 numeric siblings → numeric fold
+      ["3f2a8b1c-1234-5678-9abc-def012345678",
+       "a1b2c3d4-5566-7788-99aa-bbccddeeff00"].each do |u|
+        entries << {"h", "GET", "/api/users/#{u}"} # 2 uuid siblings → {uuid} fold
+      end
+      hosts = Gori::Sitemap.build(entries)
+      hosts.each { |h| Gori::Sitemap.fold_templates!(h) }
+      hosts.each { |h| Gori::Sitemap.group_sequences!(h) }
+
+      api = hosts.first.children.find! { |c| c.label == "api" }
+      items = api.children.find! { |c| c.label == "items" }
+      numeric = items.children.find! { |c| c.grouped }
+      numeric.label.starts_with?("[1, 2, 3").should be_true
+      numeric.children.size.should eq(12)
+      users = api.children.find! { |c| c.label == "users" }
+      uuid = users.children.find! { |c| c.label == "{uuid}" }
+      uuid.grouped.should be_true
+      uuid.children.size.should eq(2)
+    end
+
+    it "keeps both passes idempotent (a second call folds nothing new)" do
+      hosts = Gori::Sitemap.build([
+        {"h", "GET", "/u/3f2a8b1c-1234-5678-9abc-def012345678"},
+        {"h", "GET", "/u/a1b2c3d4-5566-7788-99aa-bbccddeeff00"},
+      ])
+      hosts.each { |h| Gori::Sitemap.fold_templates!(h) }
+      hosts.each { |h| Gori::Sitemap.group_sequences!(h) }
+      u = hosts.first.children.find! { |c| c.label == "u" }
+      first = u.children.map(&.label)
+      hosts.each { |h| Gori::Sitemap.fold_templates!(h) } # re-run: must be a no-op
+      hosts.each { |h| Gori::Sitemap.group_sequences!(h) }
+      u.children.map(&.label).should eq(first)
+    end
+  end
+end
+
+# Regression for `gori run sitemap --format json`: the tree nests ~2 JSON levels per path
+# segment and Crystal's JSON::Builder hard-caps nesting at 100, so a path ~45-50 segments
+# deep crashed with `JSON::Error: Nesting of 100 is too deep`. Output.sitemap_json now
+# hand-emits the tree (no builder, no artificial ceiling) — a security tool must keep the
+# whole endpoint tree rather than truncate it.
+describe Gori::CLI::Output do
+  describe ".sitemap_json (deep tree)" do
+    it "serializes a path well past the builder's 100-level nesting cap without crashing" do
+      depth = 120 # ~240 JSON nesting levels: over the old 100 builder cap, under the parser's
+      target = String.build do |io|
+        depth.times { |i| io << "/s" << i }
+      end
+      hosts = Gori::Sitemap.build([{"deep.test", "GET", target}])
+      hosts.each { |h| h.endpoints = Gori::Sitemap.endpoint_count(h) }
+
+      str = Gori::CLI::Output.sitemap_json(hosts)
+      str.valid_encoding?.should be_true
+
+      # Round-trips as valid JSON and preserves the full chain down to the leaf.
+      parsed = JSON.parse(str).as_a
+      parsed[0]["host"].as_s.should eq("deep.test")
+      node = parsed[0]
+      depth.times do |i|
+        node = node["children"].as_a.find! { |c| c["label"].as_s == "s#{i}" }
+      end
+      node["path"].as_s.should eq(target)
+      node["methods"].as_a.map(&.as_s).should eq(["GET"])
+    end
+  end
+end

--- a/src/gori/capture_lock.cr
+++ b/src/gori/capture_lock.cr
@@ -1,12 +1,17 @@
 module Gori
-  # Per-PROJECT advisory capture lock. The FIRST live instance to enter a project
-  # holds `<project.dir>/.capture.lock` (BSD flock) for the session's lifetime; a
-  # SECOND instance of the SAME project fails to acquire it and opens VIEW-ONLY
-  # (no second listener — it live-refreshes off the shared DB via the data_version
-  # poll). A different project has a different dir, hence its own lock, so it still
-  # captures on its own port. The lock is auto-released when the File is closed OR
-  # when the owning process dies (flock is per open-file-description, freed by the
-  # kernel on close / exit).
+  # Advisory capture lock keyed on the DB FILE. The FIRST live instance to open a
+  # database holds a lock file (BSD flock) for the session's lifetime; a SECOND
+  # instance of the SAME database fails to acquire it and opens VIEW-ONLY (no second
+  # listener — it live-refreshes off the shared DB via the data_version poll). A
+  # DIFFERENT database — even one sharing the same directory, e.g. two `--db` files —
+  # has its OWN lock file, so it still captures on its own port. Callers hand in the
+  # lock-file path via `try_at`/`held_at?` (see Project#capture_lock_path, which keys
+  # it on the db file: `<db_path>.capture.lock`). The legacy `try`/`held?`/`path`
+  # take a DIRECTORY and lock `<dir>/.capture.lock`; the canonical registry db keeps
+  # that per-directory path so the registry's dir-based `held?` guards (delete/rename)
+  # still detect a live capturer with no regression. The lock is auto-released when
+  # the File is closed OR when the owning process dies (flock is per open-file-
+  # description, freed by the kernel on close / exit).
   #
   # Caveats: flock is advisory and a no-op on many network filesystems (NFS), so on
   # such a mount the lock gives no protection — the proxy's own port-probe fallback
@@ -16,15 +21,21 @@ module Gori
   class CaptureLock
     LOCK_FILE = ".capture.lock"
 
+    # The legacy per-DIRECTORY lock path (`<dir>/.capture.lock`).
     def self.path(dir : String) : String
       File.join(dir, LOCK_FILE)
     end
 
-    # Non-blocking probe: true when another LIVE instance already holds the lock.
-    # Opens and immediately releases the lock when free. Non-contention failures
-    # from `try` (EACCES, unwritable dir, …) propagate to the caller.
+    # Non-blocking probe on the DIRECTORY lock: true when another LIVE instance holds it.
     def self.held?(dir : String) : Bool
-      lock = try(dir)
+      held_at?(path(dir))
+    end
+
+    # Non-blocking probe on an explicit LOCK FILE PATH: true when another LIVE instance
+    # already holds it. Opens and immediately releases when free. Non-contention failures
+    # from `try_at` (EACCES, unwritable dir, …) propagate to the caller.
+    def self.held_at?(lock_path : String) : Bool
+      lock = try_at(lock_path)
       if lock
         lock.close
         false
@@ -33,15 +44,20 @@ module Gori
       end
     end
 
-    # Try to acquire the project's capture lock WITHOUT blocking. Returns a held
-    # CaptureLock (the caller MUST keep it alive for the session and `close` it on
-    # session end) when this instance is the capturer, or nil when another LIVE
-    # instance already holds it. A non-contention failure (can't create the dir,
-    # open EACCES, …) is RE-RAISED so it is never mistaken for "someone else holds
-    # it".
+    # Try to acquire the DIRECTORY lock (`<dir>/.capture.lock`) WITHOUT blocking.
     def self.try(dir : String) : CaptureLock?
+      try_at(path(dir))
+    end
+
+    # Try to acquire the lock at an explicit LOCK FILE PATH WITHOUT blocking. Returns a held
+    # CaptureLock (the caller MUST keep it alive for the session and `close` it on session
+    # end) when this instance is the capturer, or nil when another LIVE instance already holds
+    # it. A non-contention failure (can't create the dir, open EACCES, …) is RE-RAISED so it
+    # is never mistaken for "someone else holds it".
+    def self.try_at(lock_path : String) : CaptureLock?
+      dir = File.dirname(lock_path)
       Dir.mkdir_p(dir) unless Dir.exists?(dir) # a headless Project has no registry mkdir
-      file = File.open(path(dir), "w")
+      file = File.open(lock_path, "w")
       begin
         file.flock_exclusive(blocking: false) # => Nil on success; RAISES IO::Error if held
         new(file)

--- a/src/gori/cli/output.cr
+++ b/src/gori/cli/output.cr
@@ -382,55 +382,85 @@ module Gori
       # (which collapses a numeric fold and shows one representative under an ID fold),
       # JSON always keeps every child nested — the complete tree, with `grouped` as the
       # hint so a consumer can collapse it itself.
+      #
+      # Emitted by hand to an IO rather than through JSON::Builder: the tree nests one
+      # object + one "children" array per path segment (~2 JSON levels each), and
+      # JSON::Builder hard-caps nesting at 100, so a captured path ~45 segments deep tore
+      # the whole report down with `JSON::Error: Nesting of 100 is too deep`. A security
+      # tool must not silently truncate the endpoint tree, so we drop the artificial
+      # ceiling instead — String#to_json still does every value's escaping, so the bytes
+      # are identical to what the builder produced for shallow trees.
       def self.sitemap_json(hosts : Array(Sitemap::Node)) : String
-        JSON.build do |j|
-          j.array { hosts.each { |h| sitemap_host_json(j, h) } }
+        String.build do |io|
+          io << '['
+          hosts.each_with_index do |h, i|
+            io << ',' if i > 0
+            sitemap_host_json(io, h)
+          end
+          io << ']'
         end
       end
 
-      private def self.sitemap_host_json(j : JSON::Builder, host : Sitemap::Node) : Nil
-        j.object do
-          # host.label/tag are captured/user data and can be invalid UTF-8 (see
-          # Sitemap.template_class) — term_safe scrubs that (and strips control bytes),
-          # so this stays valid UTF-8 JSON like the text/paths formats already are.
-          j.field "host", term_safe(host.label)
-          j.field "endpoints", host.endpoints
-          if t = host.tag
-            j.field "tag", term_safe(t)
-          end
-          sitemap_children_json(j, host)
+      private def self.sitemap_host_json(io : IO, host : Sitemap::Node) : Nil
+        io << '{'
+        # host.label/tag are captured/user data and can be invalid UTF-8 (see
+        # Sitemap.template_class) — term_safe scrubs that (and strips control bytes),
+        # so this stays valid UTF-8 JSON like the text/paths formats already are.
+        io << %("host":)
+        term_safe(host.label).to_json(io)
+        io << %(,"endpoints":)
+        host.endpoints.to_json(io)
+        if t = host.tag
+          io << %(,"tag":)
+          term_safe(t).to_json(io)
         end
+        sitemap_children_json(io, host)
+        io << '}'
       end
 
-      private def self.sitemap_node_json(j : JSON::Builder, node : Sitemap::Node) : Nil
-        j.object do
-          j.field "label", term_safe(node.label)
-          # A fold is synthetic — its `path` is always "" and carries no meaning, so it is
-          # omitted rather than emitted as an empty string. `template` names the id class
-          # so a consumer can tell an id fold from a numeric run without parsing labels.
-          if node.grouped
-            j.field "grouped", true
-            j.field "template", node.label if node.template? # one of TEMPLATE_LABELS: always plain ASCII
-          else
-            j.field "path", term_safe(node.path)
+      private def self.sitemap_node_json(io : IO, node : Sitemap::Node) : Nil
+        io << '{'
+        io << %("label":)
+        term_safe(node.label).to_json(io)
+        # A fold is synthetic — its `path` is always "" and carries no meaning, so it is
+        # omitted rather than emitted as an empty string. `template` names the id class
+        # so a consumer can tell an id fold from a numeric run without parsing labels.
+        if node.grouped
+          io << %(,"grouped":true)
+          if node.template? # one of TEMPLATE_LABELS: always plain ASCII
+            io << %(,"template":)
+            node.label.to_json(io)
           end
-          # On a fold these are the union of its children's verbs, not its own.
-          verbs = node.grouped ? node.fold_methods : node.methods
-          unless verbs.empty?
-            j.field("methods") { j.array { verbs.each { |m| j.string(term_safe(m)) } } }
-          end
-          if t = node.tag
-            j.field "tag", term_safe(t)
-          end
-          sitemap_children_json(j, node)
+        else
+          io << %(,"path":)
+          term_safe(node.path).to_json(io)
         end
+        # On a fold these are the union of its children's verbs, not its own.
+        verbs = node.grouped ? node.fold_methods : node.methods
+        unless verbs.empty?
+          io << %(,"methods":[)
+          verbs.each_with_index do |m, i|
+            io << ',' if i > 0
+            term_safe(m).to_json(io)
+          end
+          io << ']'
+        end
+        if t = node.tag
+          io << %(,"tag":)
+          term_safe(t).to_json(io)
+        end
+        sitemap_children_json(io, node)
+        io << '}'
       end
 
-      private def self.sitemap_children_json(j : JSON::Builder, node : Sitemap::Node) : Nil
+      private def self.sitemap_children_json(io : IO, node : Sitemap::Node) : Nil
         return if node.children.empty?
-        j.field "children" do
-          j.array { node.children.each { |c| sitemap_node_json(j, c) } }
+        io << %(,"children":[)
+        node.children.each_with_index do |c, i|
+          io << ',' if i > 0
+          sitemap_node_json(io, c)
         end
+        io << ']'
       end
 
       def self.human_size(bytes : Int64) : String

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -208,7 +208,20 @@ module Gori
           abort "gori run capture: --db parent directory does not exist: #{parent}" unless Dir.exists?(parent)
           return Project.new(File.basename(parent), path)
         end
-        ProjectRegistry.new(Paths.projects_dir).create(project_name || "default")
+        # create() rejects a name that slugifies to nothing (blank / punctuation-only)
+        # with a Gori::Error, and Dir.mkdir_p raises a File::Error for an unusable slug
+        # (e.g. longer than the filesystem's name limit). Surface both as a clean
+        # `gori run capture:` message, like every other resolve_* path, instead of a raw
+        # backtrace. (Non-ASCII names like "日本語" now get a hashed fallback slug in
+        # ProjectRegistry#slugify, so they no longer land here.)
+        name = project_name || "default"
+        begin
+          ProjectRegistry.new(Paths.projects_dir).create(name)
+        rescue ex : Gori::Error
+          abort "gori run capture: #{ex.message} (#{name.inspect})"
+        rescue ex : File::Error
+          abort "gori run capture: could not create project #{name.inspect}: #{ex.message}"
+        end
       end
 
       # Opening a non-SQLite file (or a path we can't read) raises deep in the driver;

--- a/src/gori/cli/run/issues.cr
+++ b/src/gori/cli/run/issues.cr
@@ -62,7 +62,13 @@ module Gori
           end
           STDERR.puts "exported #{count} issue#{count == 1 ? "" : "s"} → #{path}"
         else
-          puts content
+          # Neutralize terminal escape sequences before writing to STDOUT/a TTY: the markdown
+          # report embeds attacker-controlled evidence bodies (proxied traffic) and free-text
+          # notes that can carry raw ESC/OSC/BEL — a bare `puts` would let them drive the
+          # terminal (window-title spoof, OSC 52 clipboard write). Newlines/tabs are preserved,
+          # so structure is intact. File export (above) keeps the bytes verbatim — a saved file
+          # is not a live terminal, and stripping would corrupt captured evidence.
+          puts Issues::Export.scrub_controls(content)
         end
       end
 

--- a/src/gori/cli/run/notes.cr
+++ b/src/gori/cli/run/notes.cr
@@ -158,7 +158,7 @@ module Gori
         if format == :json
           puts CLI::Output.note_object_json(idx, entry, current: doc.cur == idx, with_text: true)
         else
-          STDOUT.puts text
+          STDOUT.puts Issues::Export.scrub_controls(text)
         end
       end
 

--- a/src/gori/cli/run/oast.cr
+++ b/src/gori/cli/run/oast.cr
@@ -98,6 +98,17 @@ module Gori
         puts payload
         STDERR.puts "waiting for callbacks (Ctrl-C to stop)…" unless once
         seen = Set(String).new
+        # Ctrl-C used to do nothing here: the poll loop trapped no signals, so despite the
+        # "Ctrl-C to stop" hint only SIGTERM/SIGKILL ended the listener. Trap INT+TERM into
+        # a buffered channel (matching gori run discover / App#install_signal_traps) and let
+        # oast_wait_or_stop wake on it, so the interval sleep is interrupted promptly rather
+        # than only at the next tick. (--once polls exactly once and returns, so it keeps the
+        # default Ctrl-C = immediate-exit behavior and installs no trap.)
+        stop = Channel(Nil).new(1)
+        unless once
+          Signal::INT.trap { stop.send(nil) rescue nil }
+          Signal::TERM.trap { stop.send(nil) rescue nil }
+        end
         loop do
           interactions = begin
             prov.poll(http, session)
@@ -116,9 +127,22 @@ module Gori
             STDOUT.flush
           end
           break if once
-          sleep interval.seconds
+          break if oast_wait_or_stop(stop, interval.seconds)
         end
         prov.deregister(http, session) if once
+      end
+
+      # Block up to `interval`, returning true the instant a stop arrives (Ctrl-C via the
+      # INT/TERM trap sends to `stop`) so the poll loop breaks promptly, or false on timeout
+      # to poll again. Split out both to keep oast_listen readable and to be unit-testable
+      # without delivering a real signal.
+      private def self.oast_wait_or_stop(stop : Channel(Nil), interval : Time::Span) : Bool
+        select
+        when stop.receive
+          true
+        when timeout(interval)
+          false
+        end
       end
     end
   end

--- a/src/gori/cli/run/probe.cr
+++ b/src/gori/cli/run/probe.cr
@@ -53,7 +53,7 @@ module Gori
           # A query that compiles to NOTHING (e.g. `status:>=foo`) becomes the match-all EMPTY
           # filter — here that would scan every flow, the opposite of what was asked. Refuse it.
           if !q.strip.empty? && parsed == QL::EMPTY
-            abort "gori run probe: query #{q.inspect} did not match any field (check syntax, e.g. status:>=500 host:example.com method:POST)"
+            abort "gori run probe: query #{truncate_query(q).inspect} did not match any field (check syntax, e.g. status:>=500 host:example.com method:POST)"
           end
           filter = parsed
         end
@@ -70,7 +70,7 @@ module Gori
           ids = begin
             Probe::Scan.flow_ids(store, filter)
           rescue ex
-            abort "gori run probe: query #{query.inspect} failed: #{ex.message}"
+            abort "gori run probe: query #{truncate_query(query).inspect} failed: #{ex.message}"
           end
           meter = STDERR.tty?
           dets, rn = Probe::Scan.scan_all(store, ids, active: active, scope: scope,
@@ -120,6 +120,15 @@ module Gori
           end
           nil
         end
+      end
+
+      # A malformed QL query can be arbitrarily large (a raw regex term, say) — don't dump
+      # the whole thing into an error message. Keep enough to identify the query, not replay it.
+      QUERY_ECHO_LIMIT = 200
+
+      private def self.truncate_query(q : String?) : String?
+        return q unless q && q.size > QUERY_ECHO_LIMIT
+        "#{q[0, QUERY_ECHO_LIMIT]}…"
       end
 
       private def self.parse_severity(v : String) : Store::Severity

--- a/src/gori/cli/run/project.cr
+++ b/src/gori/cli/run/project.cr
@@ -14,6 +14,8 @@ module Gori
           cmd_project_list(args[1..])
         when "scope"
           cmd_project_scope(args[1..])
+        when "sandbox"
+          cmd_project_sandbox(args[1..])
         when "env"
           cmd_project_env(args[1..])
         when "host-override", "host-overrides"
@@ -39,12 +41,14 @@ module Gori
         Subcommands:
           list               List known projects (default when no subcommand)
           scope              Manage scope rules (list, add, delete, enable/disable)
+          sandbox            Get/set the hard-containment sandbox gate (status, on, off)
           env                Manage project env vars ($KEY substitution)
           host-override      Manage host overrides (list, add, update, delete)
 
         Examples:
           gori run project --format json
           gori run project scope add --kind=include --type=host --pattern=api.example.com
+          gori run project sandbox on
           gori run project env set TOKEN=secret
           gori run project host-override add --host=api.example.com --ip=10.0.0.1
 
@@ -280,6 +284,113 @@ module Gori
             abort "gori run project scope #{enable ? "enable" : "disable"}: project is busy (write did not commit) — try again"
           end
           puts enable ? "Scope filtering enabled." : "Scope filtering disabled."
+        ensure
+          store.close
+        end
+      end
+
+      # `gori run project sandbox` — get/set the HARD-CONTAINMENT sandbox gate (Scope's
+      # blocking policy, distinct from the ⇧S display lens). Until now this could only be
+      # toggled from the interactive TUI (Project NETWORK pane); this is the headless
+      # bootstrap so a CI / authorized-testing run can enable containment without the UI.
+      private def self.cmd_project_sandbox(args : Array(String)) : Nil
+        sub = args.first?
+        case sub
+        when "on", "enable"
+          cmd_sandbox_set(true, args[1..])
+        when "off", "disable"
+          cmd_sandbox_set(false, args[1..])
+        when "status"
+          cmd_sandbox_status(args[1..])
+        when nil
+          cmd_sandbox_status(args)
+        else
+          if (s = sub) && s.starts_with?('-')
+            cmd_sandbox_status(args)
+          else
+            STDERR.puts "gori run project sandbox: unknown subcommand '#{sub}'"
+            STDERR.puts "Usage: gori run project sandbox [status options] | on|enable | off|disable"
+            exit 1
+          end
+        end
+      end
+
+      private def self.cmd_sandbox_status(args : Array(String)) : Nil
+        db_path : String? = nil
+        project_name : String? = nil
+        format = :text
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run project sandbox [options]\n\n" \
+                     "Show the hard-containment sandbox gate: when ON, the capture proxy forwards\n" \
+                     "ONLY requests the scope allows and BLOCKS everything else (see\n" \
+                     "'gori run project scope'). Or set it:\n" \
+                     "  gori run project sandbox on|enable\n" \
+                     "  gori run project sandbox off|disable"
+          p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
+          p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.invalid_option { |f| abort "gori run project sandbox: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run project sandbox: missing value for #{f}" }
+        end
+        parser.parse(args)
+
+        project = resolve_read_project(project_name, db_path)
+        store = open_store(project)
+        begin
+          scope = Scope.load(store)
+          if format == :json
+            puts(JSON.build do |j|
+              j.object do
+                j.field "sandbox", scope.sandbox?
+              end
+            end)
+          else
+            puts "Sandbox: #{scope.sandbox? ? "ENABLED" : "DISABLED"}"
+          end
+        ensure
+          store.close
+        end
+      end
+
+      private def self.cmd_sandbox_set(enable : Bool, args : Array(String)) : Nil
+        db_path : String? = nil
+        project_name : String? = nil
+        action = enable ? "on" : "off"
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run project sandbox #{action} [options]"
+          p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.invalid_option { |f| abort "gori run project sandbox #{action}: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run project sandbox #{action}: missing value for #{f}" }
+        end
+        parser.parse(args)
+
+        project = resolve_read_project(project_name, db_path)
+        store = open_store(project)
+        begin
+          scope = Scope.load(store)
+          # Enabling with NO include rule turns the proxy into a black hole (every captured
+          # request blocked). The TUI danger-confirms this; a headless run can't prompt, so
+          # it warns and proceeds (the whole point is to bootstrap containment for CI).
+          if enable && scope.include_count == 0
+            STDERR.puts "gori run project sandbox on: warning — the scope has no include rules, " \
+                        "so the sandbox will BLOCK ALL captured traffic until you add one " \
+                        "(gori run project scope add ...)"
+          end
+          # Scope's sandbox setters persist through the SAME settings-table write the TUI uses
+          # (set_sandbox_unlocked → Store#set_setting) but return Nil, so confirm the flag
+          # committed by reading it back — a busy/locked store must not report success
+          # (mirrors scope enable/disable's committed check).
+          enable ? scope.enable_sandbox : scope.disable_sandbox
+          unless store.setting(Scope::SETTING_SANDBOX) == (enable ? "1" : "0")
+            store.close
+            abort "gori run project sandbox #{action}: project is busy (write did not commit) — try again"
+          end
+          puts enable ? "Sandbox enabled." : "Sandbox disabled."
         ensure
           store.close
         end

--- a/src/gori/cli/run/repeater.cr
+++ b/src/gori/cli/run/repeater.cr
@@ -143,7 +143,15 @@ module Gori
 
             if detail.row.status == 101
               is_ws = true
-              ws_messages = store.ws_messages(fid).select { |m| m.direction == "out" && m.text? }.map { |m| String.new(m.payload).scrub }
+              out_frames = store.ws_messages(fid).select { |m| m.direction == "out" }
+              ws_messages = out_frames.select(&.text?).map { |m| String.new(m.payload).scrub }
+              # A repeater SESSION persists outbound messages as editable text lines
+              # (update_repeater_ws_messages stores Array(String) as opcode 1), so a binary
+              # outbound frame can't round-trip through the session store and would vanish from
+              # every later `repeater send` replay — warn instead of dropping it silently.
+              if (dropped = out_frames.size - ws_messages.size) > 0
+                STDERR.puts "gori run repeater create: #{dropped} binary outbound WebSocket frame#{dropped == 1 ? "" : "s"} dropped — the repeater session store keeps text messages only, so #{dropped == 1 ? "it is" : "they are"} not replayable"
+              end
             end
           end
 
@@ -430,6 +438,131 @@ module Gori
         end
       end
 
+      # Build the final single-flow replay request wire from the captured head + body and the CLI
+      # overrides (-H headers, -b body, --target Host sync). PURE: no store, no network, no exit —
+      # the testable core of cmd_repeater_single's request mutation.
+      #
+      # Edits the head as RAW LINES so the request line and every header stay byte-exact except
+      # where a flag overrides them. The old path rebuilt the request line from split
+      # method/target/version tokens, which corrupted any line with a raw space in the target
+      # (fuzzer/smuggling captures split into >3 tokens: the version was dropped and the path
+      # truncated); it also re-emitted only parse_headers' output, silently dropping any colon-less
+      # header line. Both are exactly the payloads this tool exists to replay faithfully, so we
+      # never reconstruct them from parsed tokens.
+      #
+      # An explicit `-H "Content-Length: N"` is honored VERBATIM: a deliberately-wrong CL is the
+      # whole point of CL-mismatch / request-smuggling testing, so neither the auto-resync nor the
+      # post-expansion resync overwrites it (parity with `repeater create --no-auto-cl` + `send`,
+      # the only other path that could do this before).
+      private def self.build_single_flow_request(head_bytes : Bytes, body_bytes : Bytes,
+                                                 headers : Array(String), body_override : String?,
+                                                 target_override : String?) : Bytes
+        head_str = String.new(head_bytes)
+        first_crlf = head_str.index("\r\n") || head_str.size
+        request_line = head_str[0, first_crlf]
+        # Header lines between the request line and the terminating blank line, each verbatim.
+        raw_lines = head_str[first_crlf..].split("\r\n").reject(&.empty?)
+
+        # -H overrides: lower-name → value, plus the flag-cased name in flag order for appends.
+        custom_headers = {} of String => String
+        custom_order = [] of {String, String}
+        headers.each do |h_str|
+          next unless h_str.includes?(':')
+          name, _, val = h_str.partition(':')
+          next if name.strip.empty?
+          lname = name.strip.downcase
+          custom_order << {lname, name.strip} unless custom_headers.has_key?(lname)
+          custom_headers[lname] = val.strip
+        end
+
+        # The header NAME of a raw line (bytes before the first colon), or "" for a
+        # colon-less line — those are kept verbatim, never treated as a header to edit.
+        line_name = ->(line : String) do
+          c = line.index(':')
+          c && c > 0 ? line[0, c] : ""
+        end
+
+        # Replace the FIRST occurrence of an overridden header (DROP later duplicates so an
+        # h2 request's repeated cookie:/set-cookie: lines aren't left half-overridden), and
+        # keep every other line — including colon-less ones — byte-exact.
+        applied = Set(String).new
+        new_lines = [] of String
+        raw_lines.each do |line|
+          name = line_name.call(line)
+          lname = name.strip.downcase
+          if !lname.empty? && custom_headers.has_key?(lname)
+            next if applied.includes?(lname)
+            applied << lname
+            new_lines << "#{name}: #{custom_headers[lname]}"
+          else
+            new_lines << line
+          end
+        end
+        custom_order.each do |(lname, orig)|
+          next if applied.includes?(lname)
+          new_lines << "#{orig}: #{custom_headers[lname]}"
+        end
+
+        final_body = if b_over = body_override
+                       b_over.to_slice
+                     else
+                       body_bytes
+                     end
+
+        has_te = new_lines.any? { |l| line_name.call(l).compare("Transfer-Encoding", case_insensitive: true) == 0 }
+        # RFC 7230 §3.3.3 forbids sending Transfer-Encoding and Content-Length together.
+        # When the original request was chunked (TE present, no override), keep its wire
+        # framing byte-exact and don't inject a Content-Length. When the body is replaced
+        # via -b, drop Transfer-Encoding and self-frame the new bytes with Content-Length.
+        if has_te && body_override
+          new_lines.reject! { |l| line_name.call(l).compare("Transfer-Encoding", case_insensitive: true) == 0 }
+          has_te = false
+        end
+        # An explicit `-H "Content-Length: N"` is an intentional CL, so it is honored VERBATIM.
+        # When present, skip BOTH the auto-resync below and the post-expansion resync so neither
+        # overwrites the user's value — the header the override loop already wrote into new_lines
+        # stands.
+        explicit_cl = custom_headers.has_key?("content-length")
+        has_cl = new_lines.any? { |l| line_name.call(l).compare("Content-Length", case_insensitive: true) == 0 }
+        if !explicit_cl && !has_te && (body_override || has_cl || final_body.size > 0)
+          cl_idx = new_lines.index { |l| line_name.call(l).compare("Content-Length", case_insensitive: true) == 0 }
+          if cl_idx
+            new_lines[cl_idx] = "#{line_name.call(new_lines[cl_idx])}: #{final_body.size}"
+          else
+            new_lines << "Content-Length: #{final_body.size}"
+          end
+        end
+
+        # Sync Host from --target, UNLESS the user set an explicit `-H "Host: …"` — a
+        # host-header-confusion / vhost test deliberately pairs --target (where to connect)
+        # with a different claimed Host, so that override must win.
+        if (override = target_override) && !custom_headers.has_key?("host")
+          scheme_part, host_part, port_part = Repeater::FlowRequest.parse_target(override)
+          default_port = scheme_part == "https" ? 443 : 80
+          host_hdr_val = port_part == default_port ? host_part : "#{host_part}:#{port_part}"
+          host_idx = new_lines.index { |l| line_name.call(l).compare("Host", case_insensitive: true) == 0 }
+          if host_idx
+            new_lines[host_idx] = "#{line_name.call(new_lines[host_idx])}: #{host_hdr_val}"
+          else
+            new_lines << "Host: #{host_hdr_val}"
+          end
+        end
+
+        new_head_str = String.build do |io|
+          io << request_line << "\r\n"
+          new_lines.each { |l| io << l << "\r\n" }
+          io << "\r\n"
+        end
+
+        final_request_bytes = new_head_str.to_slice + final_body
+
+        # Re-sync Content-Length after expansion — a `$KEY` in the body changes its length, and
+        # `build` framed CL over the pre-expansion bytes — UNLESS the user pinned an explicit
+        # `-H "Content-Length: N"` (honor the deliberately-wrong value for CL-mismatch testing).
+        expanded_wire = Env.expand_wire(String.new(final_request_bytes))
+        explicit_cl ? expanded_wire : Repeater::FlowRequest.resync_content_length(expanded_wire)
+      end
+
       private def self.cmd_repeater_single(args : Array(String)) : Nil
         db_path : String? = nil
         project_name : String? = nil
@@ -457,7 +590,7 @@ module Gori
           p.on("--sni=HOST", "TLS SNI override") { |v| sni_override = v }
           p.on("-k", "--insecure-upstream", "Do not verify the upstream TLS certificate") { insecure = true }
           p.on("--diff", "Diff the new response against the captured one") { do_diff = true }
-          p.on("-HHEADER", "--header=HEADER", "Custom header to overwrite/add (repeatable)") { |v| headers << v }
+          p.on("-HHEADER", "--header=HEADER", "Custom header to overwrite/add (repeatable). An explicit Content-Length is honored verbatim (no auto-resync) for CL-mismatch testing") { |v| headers << v }
           p.on("-bBODY", "--body=BODY", "Request body override") { |v| body_override = v }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
@@ -524,111 +657,8 @@ module Gori
         head_bytes = raw_bytes[0, crlf_crlf_idx + 4]
         body_bytes = raw_bytes[crlf_crlf_idx + 4..]
 
-        # Edit the head as RAW LINES so the request line and every header stay byte-exact
-        # except where a flag overrides them. The old path rebuilt the request line from
-        # split method/target/version tokens, which corrupted any line with a raw space in
-        # the target (fuzzer/smuggling captures split into >3 tokens: the version was dropped
-        # and the path truncated); it also re-emitted only parse_headers' output, silently
-        # dropping any colon-less header line. Both are exactly the payloads this tool exists
-        # to replay faithfully, so we never reconstruct them from parsed tokens.
-        head_str = String.new(head_bytes)
-        first_crlf = head_str.index("\r\n") || head_str.size
-        request_line = head_str[0, first_crlf]
-        # Header lines between the request line and the terminating blank line, each verbatim.
-        raw_lines = head_str[first_crlf..].split("\r\n").reject(&.empty?)
-
-        # -H overrides: lower-name → value, plus the flag-cased name in flag order for appends.
-        custom_headers = {} of String => String
-        custom_order = [] of {String, String}
-        headers.each do |h_str|
-          next unless h_str.includes?(':')
-          name, _, val = h_str.partition(':')
-          next if name.strip.empty?
-          lname = name.strip.downcase
-          custom_order << {lname, name.strip} unless custom_headers.has_key?(lname)
-          custom_headers[lname] = val.strip
-        end
-
-        # The header NAME of a raw line (bytes before the first colon), or "" for a
-        # colon-less line — those are kept verbatim, never treated as a header to edit.
-        line_name = ->(line : String) do
-          c = line.index(':')
-          c && c > 0 ? line[0, c] : ""
-        end
-
-        # Replace the FIRST occurrence of an overridden header (DROP later duplicates so an
-        # h2 request's repeated cookie:/set-cookie: lines aren't left half-overridden), and
-        # keep every other line — including colon-less ones — byte-exact.
-        applied = Set(String).new
-        new_lines = [] of String
-        raw_lines.each do |line|
-          name = line_name.call(line)
-          lname = name.strip.downcase
-          if !lname.empty? && custom_headers.has_key?(lname)
-            next if applied.includes?(lname)
-            applied << lname
-            new_lines << "#{name}: #{custom_headers[lname]}"
-          else
-            new_lines << line
-          end
-        end
-        custom_order.each do |(lname, orig)|
-          next if applied.includes?(lname)
-          new_lines << "#{orig}: #{custom_headers[lname]}"
-        end
-
-        final_body = if b_over = body_override
-                       b_over.to_slice
-                     else
-                       body_bytes
-                     end
-
-        has_te = new_lines.any? { |l| line_name.call(l).compare("Transfer-Encoding", case_insensitive: true) == 0 }
-        # RFC 7230 §3.3.3 forbids sending Transfer-Encoding and Content-Length together.
-        # When the original request was chunked (TE present, no override), keep its wire
-        # framing byte-exact and don't inject a Content-Length. When the body is replaced
-        # via -b, drop Transfer-Encoding and self-frame the new bytes with Content-Length.
-        if has_te && body_override
-          new_lines.reject! { |l| line_name.call(l).compare("Transfer-Encoding", case_insensitive: true) == 0 }
-          has_te = false
-        end
-        has_cl = new_lines.any? { |l| line_name.call(l).compare("Content-Length", case_insensitive: true) == 0 }
-        if !has_te && (body_override || has_cl || final_body.size > 0)
-          cl_idx = new_lines.index { |l| line_name.call(l).compare("Content-Length", case_insensitive: true) == 0 }
-          if cl_idx
-            new_lines[cl_idx] = "#{line_name.call(new_lines[cl_idx])}: #{final_body.size}"
-          else
-            new_lines << "Content-Length: #{final_body.size}"
-          end
-        end
-
-        # Sync Host from --target, UNLESS the user set an explicit `-H "Host: …"` — a
-        # host-header-confusion / vhost test deliberately pairs --target (where to connect)
-        # with a different claimed Host, so that override must win.
-        if (override = target_override) && !custom_headers.has_key?("host")
-          scheme_part, host_part, port_part = Repeater::FlowRequest.parse_target(override)
-          default_port = scheme_part == "https" ? 443 : 80
-          host_hdr_val = port_part == default_port ? host_part : "#{host_part}:#{port_part}"
-          host_idx = new_lines.index { |l| line_name.call(l).compare("Host", case_insensitive: true) == 0 }
-          if host_idx
-            new_lines[host_idx] = "#{line_name.call(new_lines[host_idx])}: #{host_hdr_val}"
-          else
-            new_lines << "Host: #{host_hdr_val}"
-          end
-        end
-
-        new_head_str = String.build do |io|
-          io << request_line << "\r\n"
-          new_lines.each { |l| io << l << "\r\n" }
-          io << "\r\n"
-        end
-
-        final_request_bytes = new_head_str.to_slice + final_body
-
+        bytes = build_single_flow_request(head_bytes, body_bytes, headers, body_override, target_override)
         override = target_override # copy the closured flag into a plain local so || narrows
-        # Re-sync Content-Length after expansion — a `$KEY` in the body changes its length,
-        # and `build` framed CL over the pre-expansion bytes.
-        bytes = Repeater::FlowRequest.resync_content_length(Env.expand_wire(String.new(final_request_bytes)))
         target = Env.expand(override || built.target)
         scheme, host, port = Repeater::FlowRequest.parse_target(target)
         abort "gori run repeater: could not determine a target host" if host.empty?

--- a/src/gori/cli/run/sequence.cr
+++ b/src/gori/cli/run/sequence.cr
@@ -105,7 +105,11 @@ module Gori
 
       private def self.read_token_list(file : String) : Array(String)
         raw = file == "-" ? STDIN.gets_to_end : (File.exists?(file) && !File.directory?(file) ? File.read(file) : abort("gori run sequence: not a readable file: #{file}"))
-        raw.split(/\r?\n/).map(&.strip).reject(&.empty?)
+        # Token lists are usually text, but a stray non-UTF-8 byte (0xff/0xfe) makes the
+        # PCRE2 regex split raise "Regex match error: UTF-8 error" and kill the run. Scrub
+        # to valid UTF-8 first (bad bytes → U+FFFD) so a lone junk byte doesn't abort the
+        # whole analysis; a normal UTF-8 file is unchanged.
+        raw.scrub.split(/\r?\n/).map(&.strip).reject(&.empty?)
       end
 
       private def self.build_token_loc(kind : Sequencer::ExtractKind, selector : String, cmd : String) : Sequencer::TokenLoc

--- a/src/gori/decoder/codecs.cr
+++ b/src/gori/decoder/codecs.cr
@@ -400,6 +400,16 @@ module Gori::Decoder
         if (alg = jwt_alg(parts[0])) && alg.downcase == "none"
           io << "\n\n// WARNING: alg=none — this token is UNSIGNED and can be forged by anyone; never trust it as authentication."
         end
+        # >3 segments isn't a plain JWT (JWS) — most commonly a 5-part JWE (header,
+        # encrypted key, IV, ciphertext, tag), but could just as well be smuggled/obfuscated
+        # data riding after a valid-looking JWS prefix. Either way, silently decoding only
+        # parts[0..2] would hide it. Surface the extra segments rather than dropping them.
+        if parts.size > 3
+          extra = parts[3..]
+          shape = parts.size == 5 ? "JWE-shaped (5 parts: header.key.iv.ciphertext.tag) — not JOSE/JWS-decodable" : "not a standard JWT"
+          io << "\n\n// WARNING: #{parts.size} dot-separated parts (#{shape}); #{extra.size} extra segment(s) beyond header.payload.signature, shown raw:\n"
+          extra.each_with_index(3) { |seg, i| io << "//   [#{i}] #{seg}\n" }
+        end
       end
     end
 

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -187,7 +187,11 @@ module Gori::Discover
       @setup_error = sp ? nil : "invalid seed url: #{seed_url}"
       @seed_parts = sp || Url::Parts.new("http", "invalid.invalid", 80, "/", nil)
       # A path-scoped run (seed path deeper than "/") confines discovery to that subtree.
-      @confine_path = @seed_parts.path == "/" ? nil : @seed_parts.path
+      # Store the base with any single trailing slash stripped so bounded_url can test
+      # containment on PATH-SEGMENT boundaries. The old raw-string-prefix check let a sibling
+      # like /api-internal leak into an /api-scoped run (they share the "/api" prefix); a
+      # trailing-slash target already excluded it, proving the leak was prefix- not segment-based.
+      @confine_path = @seed_parts.path == "/" ? nil : @seed_parts.path.rchop('/')
       @capped = CappedBackend.new(backend, @config.max_requests)
       conc = @config.concurrency.clamp(1, MAX_CONCURRENCY)
       @concurrency = conc
@@ -568,7 +572,10 @@ module Gori::Discover
     # confine before normalizing anything.
     private def bounded_url(p : Url::Parts) : String?
       if cp = @confine_path
-        return nil unless p.path.starts_with?(cp)
+        # Segment-boundary confinement: in-subtree iff the path IS the base or sits under
+        # "base/". A bare starts_with?(base) would also admit sibling prefixes (/api-internal
+        # for an /api seed, /prefix-test-evil for /prefix-test) — the scope bypass this guards.
+        return nil unless p.path == cp || p.path.starts_with?("#{cp}/")
       end
       url = Url.normalize(p)
       return nil unless @scope.allowed?(url, p.host) # excludes/sandbox — every mode

--- a/src/gori/filter_ast.cr
+++ b/src/gori/filter_ast.cr
@@ -209,17 +209,30 @@ module Gori
     def self.parse(query : String) : Node?
       lexemes = lex(query)
       return nil if lexemes.empty?
-      pos = 0
-      node, _ = parse_or(lexemes, pos)
+      node, _ = parse_or(lexemes, 0, 0)
       node
     end
 
-    private def self.parse_or(lx : Array(Lexeme), pos : Int32) : {Node?, Int32}
-      node, pos = parse_and(lx, pos)
+    # Deepest paren/NOT nesting the recursive descent will follow before it stops
+    # recursing. No real query nests more than a handful of levels; a fuzzed or hostile one
+    # (`((((…))))` / `NOT NOT NOT …` thousands deep) used to recurse one native stack frame
+    # per level and SIGSEGV the process — and every filter surface (History QL, Probe,
+    # Sitemap, Issues, the TUI filter bar, MCP) parses through here, so it was the widest
+    # crash. Past the cap the descent degrades FORGIVINGLY: an over-deep group parses as if
+    # empty, exactly like the existing `()` handling, so `parse_and` flattens the excess
+    # parens and still picks up any real term underneath rather than crashing or blanking.
+    MAX_PARSE_DEPTH = 256
+
+    # `depth` counts only the recursion that actually deepens the tree — a `(` group or a
+    # `NOT` — since the parse_or→parse_and→parse_unary→parse_primary cycle stays at one
+    # level. Bounding it bounds the native stack.
+    private def self.parse_or(lx : Array(Lexeme), pos : Int32, depth : Int32) : {Node?, Int32}
+      return {nil, pos} if depth > MAX_PARSE_DEPTH
+      node, pos = parse_and(lx, pos, depth)
       children = node ? [node] : [] of Node
       while pos < lx.size && lx[pos].tok.or?
         pos += 1
-        rhs, pos = parse_and(lx, pos)
+        rhs, pos = parse_and(lx, pos, depth)
         children << rhs if rhs
       end
       return {nil, pos} if children.empty?
@@ -228,7 +241,7 @@ module Gori
 
     # AND binds tighter than OR. The operator is optional: adjacent terms combine with
     # AND, which is what whitespace has always meant here.
-    private def self.parse_and(lx : Array(Lexeme), pos : Int32) : {Node?, Int32}
+    private def self.parse_and(lx : Array(Lexeme), pos : Int32, depth : Int32) : {Node?, Int32}
       children = [] of Node
       loop do
         while pos < lx.size && lx[pos].tok.and? # explicit AND, or a stray one
@@ -236,7 +249,7 @@ module Gori
         end
         break if pos >= lx.size || lx[pos].tok.or? || lx[pos].tok.r_paren?
         before = pos
-        node, pos = parse_unary(lx, pos)
+        node, pos = parse_unary(lx, pos, depth)
         if node
           children << node
         elsif pos == before
@@ -255,21 +268,22 @@ module Gori
       {children.size == 1 ? children.first : AndNode.new(children), pos}
     end
 
-    private def self.parse_unary(lx : Array(Lexeme), pos : Int32) : {Node?, Int32}
+    private def self.parse_unary(lx : Array(Lexeme), pos : Int32, depth : Int32) : {Node?, Int32}
+      return {nil, pos} if depth > MAX_PARSE_DEPTH
       if pos < lx.size && lx[pos].tok.not?
-        node, pos = parse_unary(lx, pos + 1)
+        node, pos = parse_unary(lx, pos + 1, depth + 1)
         return {nil, pos} unless node
         # A lone term flips its own flag; only a group needs a wrapper.
         return {node.is_a?(TermNode) ? TermNode.new(node.term.negated) : NotNode.new(node), pos}
       end
-      parse_primary(lx, pos)
+      parse_primary(lx, pos, depth)
     end
 
-    private def self.parse_primary(lx : Array(Lexeme), pos : Int32) : {Node?, Int32}
+    private def self.parse_primary(lx : Array(Lexeme), pos : Int32, depth : Int32) : {Node?, Int32}
       return {nil, pos} if pos >= lx.size
       lexeme = lx[pos]
       if lexeme.tok.l_paren?
-        node, pos = parse_or(lx, pos + 1)
+        node, pos = parse_or(lx, pos + 1, depth + 1)
         pos += 1 if pos < lx.size && lx[pos].tok.r_paren? # tolerate the unclosed group
         return {node, pos}
       end

--- a/src/gori/fuzz/payload.cr
+++ b/src/gori/fuzz/payload.cr
@@ -74,6 +74,7 @@ module Gori::Fuzz
 
     def size : Int64?
       unless @counted
+        ensure_readable
         n = 0_i64
         File.each_line(@path) { n += 1 }
         @count = n
@@ -83,7 +84,18 @@ module Gori::Fuzz
     end
 
     def open_iterator : SetIterator
+      ensure_readable
       LineIterator.new(@path)
+    end
+
+    # Turn a missing / directory / unreadable wordlist path into a clean Gori::Error
+    # (surfaced by the caller as "gori run fuzz: wordlist …") instead of leaking a raw
+    # `File::NotFoundError: Error opening file with mode 'r'` backtrace out of the
+    # File.each_line / File.open below.
+    private def ensure_readable : Nil
+      raise Gori::Error.new("wordlist not found: #{@path}") unless File.exists?(@path)
+      raise Gori::Error.new("wordlist is a directory, not a file: #{@path}") if File.directory?(@path)
+      raise Gori::Error.new("wordlist not readable: #{@path}") unless File::Info.readable?(@path)
     end
 
     private class LineIterator < SetIterator

--- a/src/gori/import/builder.cr
+++ b/src/gori/import/builder.cr
@@ -37,6 +37,15 @@ module Gori
       # caller's existing skip-a-bad-entry rescue handles it identically to those checks.
       CONTROL_CHAR = /[\x00-\x1f\x7f]/
 
+      # URI.parse copies a reg-name authority into `host` VERBATIM without validating it — a
+      # `--urls`/HAR line like `not a url at all` becomes a stored "host" of literal spaces
+      # instead of being skipped the way `ftp://…` and empty URLs already are. A real host
+      # (reg-name, IPv4/IPv6 literal, punycode) never contains a space or other C0/DEL byte —
+      # userinfo, port and the `://` sit outside `uri.host` — so reject one in `endpoint`, at
+      # the same raise-to-skip point the scheme/shape checks use. Space (0x20) is what
+      # CONTROL_CHAR misses, so this widens the range to include it.
+      HOST_INVALID = /[\x00-\x20\x7f]/
+
       def self.normalize_url(url : String) : String
         u = url.strip
         raise Gori::Error.new("invalid URL (control character): #{url.inspect}") if u.matches?(CONTROL_CHAR)
@@ -49,6 +58,11 @@ module Gori
         uri = URI.parse(normalize_url(url))
         scheme = uri.scheme.not_nil!
         host = uri.host.presence || raise Gori::Error.new("URL missing host: #{url}")
+        raise Gori::Error.new("invalid URL (bad host): #{url.inspect}") if host.matches?(HOST_INVALID)
+        # URI.parse keeps the brackets on an IPv6 literal (`[::1]`); the CONNECT/tunnel path
+        # stores the bare inner address (`::1`). Strip the brackets so an imported IPv6 target
+        # matches that canonical bracket-free form and Scope host rules see ONE target, not two.
+        host = host[1..-2] if host.starts_with?('[') && host.ends_with?(']')
         port = uri.port || (scheme == "https" ? 443 : 80)
         path = uri.path.presence || "/"
         target = uri.query ? "#{path}?#{uri.query}" : path
@@ -93,7 +107,10 @@ module Gori
         reject_header_injection!(headers)
         String.build do |b|
           b << method.upcase << ' ' << target << ' ' << http_version << "\r\n"
-          b << "Host: " << host << "\r\n"
+          # `host` is stored bracket-free (matching the CONNECT path); an IPv6 literal must be
+          # re-bracketed in the Host header line to stay RFC 7230 §5.4 valid (`Host: [::1]`).
+          # A reg-name/IPv4 host never contains `:` (userinfo/port live outside `uri.host`).
+          b << "Host: " << (host.includes?(':') ? "[#{host}]" : host) << "\r\n"
           # One pass, allocation-free case-insensitive compares. Skip BOTH the Host line and any
           # incoming Content-Length: the stored head must agree with the body we actually build
           # and store, but a HAR postData.params entry (no `text`) rebuilds a fresh urlencoded

--- a/src/gori/import/har.cr
+++ b/src/gori/import/har.cr
@@ -63,8 +63,15 @@ module Gori
         status = resp["status"]?.try(&.as_i).try(&.to_i32) || 0
         reason = resp["statusText"]?.to_s.presence || status_reason(status)
         resp_headers = headers_list(resp["headers"]?)
-        resp_body, content_type = response_body(resp)
-        content_type ||= resp_headers.find { |(k, _)| k.compare("content-type", case_insensitive: true) == 0 }.try(&.[1])
+        resp_body, mime_type = response_body(resp)
+        # Prefer the ACTUAL Content-Type response HEADER over HAR content.mimeType, matching how
+        # a live-captured flow derives content_type from the real header. A HAR whose mimeType
+        # disagrees with the header (e.g. mimeType `text/html` but a real `application/json`
+        # header) must not store the mimeType, or `run probe` fires HTML-only findings
+        # (missing_csp, missing_x_frame_options, …) on a pure JSON body. mimeType stays a
+        # fallback for entries that carry no Content-Type header.
+        header_ct = resp_headers.find { |(k, _)| k.compare("content-type", case_insensitive: true) == 0 }.try(&.[1])
+        content_type = header_ct.presence || mime_type
 
         Builder.complete_flow(
           created_at, url, method, req_headers, req_body, http_version,

--- a/src/gori/issues_export.cr
+++ b/src/gori/issues_export.cr
@@ -36,10 +36,11 @@ module Gori
               end
             end
             append_related_links(io, f, store)
-            # notes is multi-line by design (free text) — scrub_only fixes invalid UTF-8
-            # (the same captured-data class title/host carry) without collapsing its newlines,
-            # unlike one_line above, which would flatten it into a single unreadable line.
-            io << "\n" << scrub_only(f.notes) << "\n" unless f.notes.strip.empty?
+            # notes is multi-line by design (free text) — scrub_controls fixes invalid UTF-8
+            # AND strips terminal escape sequences (ESC/BEL/OSC/CSI) so a notes value carrying
+            # an OSC "set window title" can't drive a TTY when the report is printed/`cat`d,
+            # yet keeps its newlines (unlike one_line, which would flatten title/host to a line).
+            io << "\n" << scrub_controls(f.notes) << "\n" unless f.notes.strip.empty?
             if flow
               append_evidence(io, "Request", flow.request_head, flow.request_body)
               append_evidence(io, "Response", flow.response_head, flow.response_body)
@@ -86,6 +87,19 @@ module Gori
       # later PCRE gsub over it.
       def self.scrub_only(s : String) : String
         s.scrub
+      end
+
+      # Terminal-safety sibling of `one_line`: neutralize the control characters a TTY would
+      # interpret as escape sequences — ESC (0x1B), BEL (0x07), the CSI/OSC introducers, and
+      # every other C0/C1 control — while PRESERVING newlines and tabs so a multi-line value
+      # (an issue's free-text `notes`, a note body) keeps its structure. Stripping the control
+      # BYTES defangs OSC/CSI sequences without modelling the full grammar: an OSC "set window
+      # title" or OSC 52 clipboard-write can no longer reach the terminal. Use this for text
+      # printed to STDOUT/a TTY — unlike one_line it does NOT collapse to a single line, and
+      # unlike scrub_only it does NOT leave ESC/BEL intact. (scrub first: a captured value can
+      # be invalid UTF-8, which would make the following per-char walk operate on U+FFFD safely.)
+      def self.scrub_controls(s : String) : String
+        scrub_only(s).gsub { |ch| ch.control? && ch != '\n' && ch != '\t' ? "" : ch }
       end
 
       # Collapse control characters (CR/LF/tab/…) to a single space so a value with

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -94,7 +94,7 @@ module Gori
         "create_note", "update_note", "delete_note",
         "create_repeater", "update_repeater", "delete_repeater",
         "oast_start", "oast_stop",
-        "add_scope_rule", "delete_scope_rule", "set_scope_enabled",
+        "add_scope_rule", "delete_scope_rule", "set_scope_enabled", "set_sandbox",
         "set_env_var", "delete_env_var",
         "add_host_override", "update_host_override", "delete_host_override",
         "import_flows",
@@ -530,7 +530,7 @@ module Gori
             s.field "limit", intprop("max issue groups to return (default 200, max 2000)")
           end
 
-          tool j, "list_scope", "List the project's scope include/exclude rules, plus whether the scope lens/gate is enabled." { }
+          tool j, "list_scope", "List the project's scope include/exclude rules, plus whether the scope lens/gate and the hard-containment sandbox are enabled." { }
 
           tool j, "list_env",
             "List the project's env vars (used for $KEY substitution in outbound requests — see " \
@@ -748,6 +748,15 @@ module Gori
             tool j, "set_scope_enabled",
               "Turn the scope lens/gate on or off (the rules themselves are untouched)." do |s|
               s.field "enabled", boolprop("true = filter to in-scope; false = show/allow everything"), required: true
+            end
+
+            tool j, "set_sandbox",
+              "Turn the HARD-CONTAINMENT sandbox gate on or off — the headless equivalent of the " \
+              "TUI Project NETWORK pane toggle. When ON, the capture proxy forwards ONLY requests " \
+              "the scope allows and BLOCKS everything else; with NO include rule it blocks ALL " \
+              "captured traffic (reported as blocks_all). Distinct from set_scope_enabled, which is " \
+              "only the display lens. See list_scope for the current state." do |s|
+              s.field "enabled", boolprop("true = block every request the scope does not allow; false = stop blocking"), required: true
             end
 
             tool j, "set_env_var",
@@ -1312,6 +1321,7 @@ module Gori
         when "add_scope_rule"          then gated { add_scope_rule(h) }
         when "delete_scope_rule"       then gated { delete_scope_rule(h) }
         when "set_scope_enabled"       then gated { set_scope_enabled(h) }
+        when "set_sandbox"             then gated { set_sandbox(h) }
         when "set_env_var"             then gated { set_env_var(h) }
         when "delete_env_var"          then gated { delete_env_var(h) }
         when "add_host_override"       then gated { add_host_override(h) }

--- a/src/gori/mcp/tools/context.cr
+++ b/src/gori/mcp/tools/context.cr
@@ -8,9 +8,11 @@ module Gori
   module MCP
     class Tools
       private def list_scope : Result
+        scope = Scope.load(store)
         Result.new(JSON.build do |j|
           j.object do
-            j.field "enabled", Scope.load(store).enabled?
+            j.field "enabled", scope.enabled?
+            j.field "sandbox", scope.sandbox?
             j.field "rules" do
               j.array do
                 store.scope_rules.each do |(id, kind, match_type, pattern)|

--- a/src/gori/mcp/tools/scope.cr
+++ b/src/gori/mcp/tools/scope.cr
@@ -53,6 +53,30 @@ module Gori
         return busy("scope enable/disable NOT persisted (store busy or unwritable); the gate is unchanged") unless committed
         Result.new(JSON.build { |j| j.object { j.field "enabled", enabled } })
       end
+
+      # Turn the HARD-CONTAINMENT sandbox gate on or off (the headless equivalent of the
+      # TUI Project NETWORK pane toggle, and `gori run project sandbox on|off`). Distinct
+      # from set_scope_enabled (the display lens): the sandbox BLOCKS every request the
+      # scope does not allow — with no include rule it blocks ALL captured traffic
+      # (reported as blocks_all).
+      private def set_sandbox(h) : Result
+        enabled = bool(h, "enabled")
+        return err("missing required 'enabled' (true or false)", "INVALID_ARGUMENT", field: "enabled") if enabled.nil?
+        scope = Scope.load(store)
+        # Scope's sandbox setters persist through the SAME settings write the TUI uses but
+        # return Nil, so confirm the flag committed by reading it back — a busy/locked store
+        # must not report success (mirrors set_scope_enabled's committed check).
+        enabled ? scope.enable_sandbox : scope.disable_sandbox
+        unless store.setting(Scope::SETTING_SANDBOX) == (enabled ? "1" : "0")
+          return busy("sandbox enable/disable NOT persisted (store busy or unwritable); the gate is unchanged")
+        end
+        Result.new(JSON.build do |j|
+          j.object do
+            j.field "sandbox", enabled
+            j.field "blocks_all", enabled && scope.include_count == 0
+          end
+        end)
+      end
     end
   end
 end

--- a/src/gori/miner/engine.cr
+++ b/src/gori/miner/engine.cr
@@ -181,7 +181,8 @@ module Gori::Miner
       pairs = task.names.map { |n| {n, Canary.fresh} }
       raw = send_with_retries(Inject.apply(@base, task.location, pairs, @config.add_content_length_when_missing?))
       if raw.error
-        @errors += 1
+        # A max-requests cap refusal isn't a network error — don't let it inflate @errors.
+        @errors += 1 unless raw.error == Fuzz::CappedBackend::CAP_ERROR
         mark_done(task.names.size) # keep the bar monotonic; this bucket is inconclusive
         return [] of Task
       end

--- a/src/gori/notes.cr
+++ b/src/gori/notes.cr
@@ -1,5 +1,6 @@
 require "json"
 require "./store"
+require "./issues_export" # Issues::Export.scrub_controls — the shared terminal-safety helper
 
 module Gori
   # Shared reader/writer for the Notes tab's persisted documents. The TUI
@@ -28,9 +29,14 @@ module Gori
         notes.size
       end
 
-      # Note bodies in tab order (CLI listing).
+      # Note bodies in tab order, sanitized for terminal display — this is the CLI listing
+      # accessor (`gori run notes` prints these straight to STDOUT). Control characters a TTY
+      # would treat as escape sequences (ESC/BEL/OSC/CSI, other C0/C1) are stripped while
+      # newlines/tabs are preserved, so a note body carrying an OSC "set window title" /
+      # clipboard-write can't drive the terminal. The stored NoteEntry text is left untouched,
+      # so persistence and TUI editing still see the raw bytes.
       def texts : Array(String)
-        notes.map(&.text)
+        notes.map { |n| Issues::Export.scrub_controls(n.text) }
       end
 
       def note_id(idx : Int32) : Int64?

--- a/src/gori/project.cr
+++ b/src/gori/project.cr
@@ -1,4 +1,5 @@
 require "file_utils"
+require "./capture_lock"
 
 module Gori
   # A workspace: a named SQLite DB, so each project's history/sitemap/etc. are
@@ -16,6 +17,16 @@ module Gori
 
     def dir : String
       File.dirname(@db_path)
+    end
+
+    # Path of this project's advisory capture lock — keyed on the DB FILE, not the parent
+    # directory, so two independent `--db` databases that happen to share a directory don't
+    # falsely serialize (each is its own database with its own capture session). The canonical
+    # registry db (DB_FILE) keeps the legacy per-directory lock path (`<dir>/.capture.lock`),
+    # so the registry's directory-based CaptureLock.held? guards (delete/rename) still detect a
+    # live capturer with no regression.
+    def capture_lock_path : String
+      File.basename(@db_path) == DB_FILE ? CaptureLock.path(dir) : "#{@db_path}.capture.lock"
     end
 
     # Best-effort last-activity time (DB file mtime), for the picker.

--- a/src/gori/project_registry.cr
+++ b/src/gori/project_registry.cr
@@ -1,4 +1,5 @@
 require "file_utils"
+require "digest/sha256"
 require "./project"
 require "./store"
 require "./capture_lock"
@@ -281,7 +282,18 @@ module Gori
     # ("." / ".." / "...") collapses to "" and is rejected by create() — otherwise
     # File.join(@root, slug) would resolve to @root or its parent (traversal).
     private def slugify(name : String) : String
-      name.downcase.gsub(/[^a-z0-9._-]+/, "-").strip("-.")
+      slug = name.downcase.gsub(/[^a-z0-9._-]+/, "-").strip("-.")
+      return slug unless slug.empty?
+      # An all-non-ASCII display name (e.g. "日本語") has no [a-z0-9] to slugify and would
+      # otherwise collapse to "" and be rejected as "invalid project name" — leaving such
+      # projects completely unusable via --project. When the name carries real (non-ASCII)
+      # content, derive a stable, filesystem-safe fallback slug from its hash so it round-
+      # trips (same name → same dir). Only reached when the ASCII slug is empty, so no
+      # existing (non-empty-slug) project's directory name ever changes. A purely-ASCII-
+      # punctuation name (".", "..", "---", blank) still yields "" and stays rejected — a
+      # dot-run must never become a path (traversal).
+      return slug unless name.each_char.any? { |c| c.ord > 127 }
+      "project-#{Digest::SHA256.hexdigest(name)[0, 10]}"
     end
   end
 end

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -60,6 +60,25 @@ module Gori::Proxy
       @copy_buf ||= Bytes.new(Codec::Body::BUFSIZE)
     end
 
+    # One-shot teardown claim shared between a relaxed-stream copy and its client-abort watcher
+    # (see stream_response_body). Deliberately a REFERENCE type: both fibers must see the SAME
+    # flag, but the watcher is started with `spawn watch_client_abort(upstream, latch)` (the call
+    # form, to avoid loop-var capture), which COPIES its arguments — a captured `Atomic` STRUCT
+    # would be duplicated per fiber and the two would never agree (the ConnCounter hazard called
+    # out in concurrency_reuse_spec). Whoever calls `claim?` first owns teardown: the watcher
+    # closes upstream only if it wins, the copy raises (→ Aborted) only if it lost.
+    private class TeardownLatch
+      def initialize
+        @claimed = Atomic(Int32).new(0)
+      end
+
+      # True to the FIRST caller only; false to every caller after. Non-blocking, so on the
+      # single proxy thread a claim never interleaves with the other fiber's.
+      def claim? : Bool
+        @claimed.compare_and_set(0, 1)[1]
+      end
+    end
+
     def run : Nil
       loop do
         # Re-arm the client read/write timeout at the START of every keep-alive request, so a
@@ -172,13 +191,25 @@ module Gori::Proxy
       # a rule actually changes something do we capture the modified bytes (the
       # user's chosen semantics); otherwise the original client bytes are kept
       # byte-exact (P7). Body framing always uses the original request.
+      #
+      # `sent_head`/`sent_req` is the ORIGIN-FORM head/projection put on the wire —
+      # resolve_forward already normalized an absolute-form forward-proxy target
+      # (`GET http://h/p`) to origin-form (`GET /p`). What we RECORD must instead
+      # preserve the CLIENT's original request-line form, so `record_req` re-applies
+      # the same rewrite on top of `req.raw_head` (the client's original bytes): an
+      # unrelated rule (e.g. add_header) then leaves the original absolute-form request
+      # line byte-intact in History, while a rule that DOES target the request line still
+      # shows its intended change. The wire request stays origin-form (unchanged).
       sent_req = req
       sent_head = forward_head
+      record_req = req
       if rw = @rewriter
         rewritten = rw.rewrite_request(forward_head, host)
         if rewritten != forward_head
           sent_head = rewritten
           sent_req = Codec::Http1.parse_request_head(rewritten)
+          record_head = rw.rewrite_request(req.raw_head, host)
+          record_req = Codec::Http1.parse_request_head(record_head) unless record_head == req.raw_head
         end
       end
 
@@ -250,7 +281,7 @@ module Gori::Proxy
         return false
       end
       req_body = req_framing.none? ? nil : req_capture.to_slice
-      flow_id = @sink.on_request(FlowMapper.request(sent_req,
+      flow_id = @sink.on_request(FlowMapper.request(record_req,
         scheme: scheme, host: host, port: port, created_at: created_at, body: req_body,
         body_truncated: req_capture.truncated?, body_size: req_capture.total))
       unless req_complete # client cut the request body short — don't reuse the connection
@@ -448,14 +479,15 @@ module Gori::Proxy
           scheme, resp, sent_resp_head, resp_framing, resp_len, ttfb, started)
       end
 
-      relax_for_streaming_response(resp, resp_framing, upstream)
+      relaxed = relax_for_streaming_response(resp, resp_framing, upstream)
 
       # Non-hold path: stream the response body byte-for-byte (P6) and record the
       # flow. `completed` is true only when the whole body was delivered cleanly; a
       # client abort or upstream truncation is recorded Aborted (see the helper).
+      # `relaxed` streams also run a concurrent client-abort watcher (see the helper).
       resp_capture = Codec::CaptureBuffer.new(Settings.capture_max, capture_hint(resp_framing, resp_len))
       completed = stream_nonhold_response(upstream, sent_resp, sent_resp_head,
-        resp_framing, resp_len, resp_capture, flow_id, ttfb, started)
+        resp_framing, resp_len, resp_capture, flow_id, ttfb, started, relaxed: relaxed)
 
       if completed && resp.status == 101
         # A 101 Switching Protocols turns the connection into a bidirectional tunnel of the
@@ -486,6 +518,17 @@ module Gori::Proxy
       # end-of-response instead of waiting for the missing bytes while we read its
       # next keep-alive request.
       unless completed
+        release_upstream
+        return false
+      end
+      # A relaxed (close-delimited/SSE) stream ran a concurrent client-abort watcher that
+      # may still be parked on @io.read (see stream_response_body). Do NOT keep this client
+      # connection alive: closing it (return false) is what lets `run`'s ensure unblock and
+      # end that watcher, and it keeps a lingering @io read from colliding with a next reused
+      # request. Close-delimited already never keep-alives; forcing the same for chunked/Length
+      # SSE is the safe price of watching them (closing after a complete response is always
+      # valid), and the upstream isn't parked for reuse since this connection is ending.
+      if relaxed
         release_upstream
         return false
       end
@@ -568,11 +611,12 @@ module Gori::Proxy
     private def stream_nonhold_response(upstream : IO, sent_resp : Codec::RawResponse,
                                         sent_resp_head : Bytes, resp_framing : Codec::BodyFraming,
                                         resp_len : Int64, resp_capture : Codec::CaptureBuffer,
-                                        flow_id : Int64, ttfb : Int64, started : Time::Instant) : Bool
+                                        flow_id : Int64, ttfb : Int64, started : Time::Instant,
+                                        relaxed : Bool = false) : Bool
       begin
         @io.write(sent_resp_head)
         @io.flush
-        resp_complete = Codec::Body.stream(upstream, @io, resp_framing, resp_len, resp_capture, copy_buf)
+        resp_complete = stream_response_body(upstream, resp_framing, resp_len, resp_capture, relaxed)
       rescue
         record_streamed_response(sent_resp, resp_framing, resp_capture, flow_id, ttfb, started,
           state: Store::FlowState::Aborted, error: "connection closed mid-response")
@@ -582,6 +626,54 @@ module Gori::Proxy
         state: resp_complete ? Store::FlowState::Complete : Store::FlowState::Aborted,
         error: resp_complete ? nil : "upstream closed before response body complete")
       resp_complete
+    end
+
+    # Copies the response body upstream→@io. For a normal (timed) response this is just
+    # `Codec::Body.stream`. For a RELAXED (close-delimited/SSE) stream both legs' timeouts
+    # were cleared, so the copy can block on an idle-origin read indefinitely — and would
+    # only notice the CLIENT already went away on its NEXT write to @io, which an idle origin
+    # never triggers. That leaks this fiber + both sockets for every aborted SSE/long-poll
+    # flow (and pins the flow Pending forever). So run a concurrent watcher on the client leg:
+    # on a client FIN/reset it closes `upstream`, unblocking the copy's read; the copy then
+    # raises and the caller records the flow Aborted (mirroring the failed-client-write abort).
+    #
+    # A one-shot `teardown` latch makes the copy and the watcher race to OWN the close, so a
+    # normal completion isn't mistaken for an abort and neither double-closes. A legitimately-
+    # idle-but-connected client keeps its write half open, so the watcher's @io.read simply
+    # BLOCKS (no EOF) and the stream flows indefinitely — only a client that closed its side
+    # trips teardown. A relaxed stream never keep-alives (handle_response closes it after), so a
+    # watcher still parked on @io.read is safely ended when `run`'s ensure closes @io, with no
+    # risk of colliding with a next reused request on this connection.
+    private def stream_response_body(upstream : IO, resp_framing : Codec::BodyFraming,
+                                     resp_len : Int64, resp_capture : Codec::CaptureBuffer,
+                                     relaxed : Bool) : Bool
+      return Codec::Body.stream(upstream, @io, resp_framing, resp_len, resp_capture, copy_buf) unless relaxed
+      latch = TeardownLatch.new
+      spawn watch_client_abort(upstream, latch)
+      begin
+        Codec::Body.stream(upstream, @io, resp_framing, resp_len, resp_capture, copy_buf)
+      ensure
+        # Claim teardown so a still-parked watcher can't close `upstream` after we hand it back.
+        # Losing the claim means the watcher already fired (client gone, upstream closed under the
+        # copy) — surface that as an abort so the caller records Aborted, not a clean/half read.
+        # (claim? is non-blocking, so it can't interleave with the watcher's on the single thread.)
+        raise IO::Error.new("client disconnected mid-stream") unless latch.claim?
+      end
+    end
+
+    # The client-leg watcher for a relaxed streaming response (see stream_response_body). Blocks
+    # reading @io: a 0-byte read (clean FIN) or any read error (reset) means the client closed
+    # its side, so — if it wins the one-shot `latch` — it closes `upstream` to unblock the copy
+    # loop. Bytes arriving from the client mid-stream are unusual for SSE/close-delimited (no
+    # keep-alive follows) and are NOT proof the client left, so it just keeps watching.
+    private def watch_client_abort(upstream : IO, latch : TeardownLatch) : Nil
+      buf = Bytes.new(1)
+      while @io.read(buf) > 0
+      end
+    rescue
+      # client reset / read error → treat as gone (fall through to teardown)
+    ensure
+      upstream.close rescue nil if latch.claim?
     end
 
     private def record_streamed_response(sent_resp : Codec::RawResponse, resp_framing : Codec::BodyFraming,
@@ -758,10 +850,13 @@ module Gori::Proxy
     # relax BOTH legs' read/write timeouts so a legitimately-idle stream isn't torn down mid-flight
     # (keepalive reaps a genuinely dead peer). A normal Length/chunked response keeps the baseline
     # timeout, and the `run`/`acquire_and_send` re-arm restores it for any later keep-alive request.
-    private def relax_for_streaming_response(resp : Codec::RawResponse, resp_framing : Codec::BodyFraming, upstream : IO) : Nil
-      return unless resp_framing.close_delimited? || sse?(resp)
+    # Returns whether it relaxed — the caller then streams with a concurrent client-abort watcher
+    # (an un-timed upstream read can't otherwise notice a gone client) and won't keep-alive after.
+    private def relax_for_streaming_response(resp : Codec::RawResponse, resp_framing : Codec::BodyFraming, upstream : IO) : Bool
+      return false unless resp_framing.close_delimited? || sse?(resp)
       SocketTuning.relax(@io)
       SocketTuning.relax(upstream)
+      true
     end
 
     # Cleartext HTTP/2 (h2c) tunnelled inside a CONNECT: the target is the

--- a/src/gori/proxy/upstream.cr
+++ b/src/gori/proxy/upstream.cr
@@ -413,10 +413,21 @@ module Gori::Proxy
       {nil, TlsDialError::Tls}
     end
 
+    # A bare (unbracketed) IPv6 literal. The charset guard scrubs and rejects anything
+    # outside the v6 alphabet before valid_v6? (mirrors cert_builder's ipv6?), so an
+    # invalid-UTF-8 / otherwise odd authority can't raise on this parse path.
+    private def self.valid_ipv6?(host : String) : Bool
+      return false unless (host.scrub =~ /\A[0-9A-Fa-f:.]+\z/) != nil
+      Socket::IPAddress.valid_v6?(host)
+    end
+
     # Splits an "host:port" / "host" authority. Falls back to default_port.
     # Handles bracketed IPv6 ("[::1]" / "[::1]:8080") by returning the bare inner
-    # address; an unbracketed IPv6 literal ("::1") is treated as a bare host (a
-    # port can't be disambiguated from the address colons without brackets).
+    # address; an unbracketed authority is a whole IPv6 host ONLY when it is a valid
+    # v6 literal ("::1") — a port can't be disambiguated from the address colons
+    # without brackets. A multi-colon authority that is NOT a valid v6 literal
+    # ("127.0.0.1:19110:bogus") is split on the LAST colon so host:port semantics win
+    # and a real port isn't silently swallowed into the host.
     def self.split_host_port(authority : String, default_port : Int32) : {String, Int32}
       if authority.starts_with?('[')
         if close = authority.index(']')
@@ -426,10 +437,10 @@ module Gori::Proxy
           return {host, port}
         end
       end
+      return {authority, default_port} if valid_ipv6?(authority) # unbracketed IPv6 literal
       idx = authority.rindex(':')
       return {authority, default_port} unless idx
       host = authority[0...idx]
-      return {authority, default_port} if host.includes?(':') # unbracketed IPv6
       port = authority[(idx + 1)..].to_i? || default_port
       {host, port}
     end

--- a/src/gori/repeater/engine.cr
+++ b/src/gori/repeater/engine.cr
@@ -133,6 +133,18 @@ module Gori
           return error("upstream closed after interim 1xx from #{host}:#{port}", started) unless head
           resp = Proxy::Codec::Http1.parse_response_head(head)
         end
+        # A reply whose status-line can't be parsed (no HTTP-version, or a non-numeric status —
+        # garbage/non-HTTP, or an h2 stack answering this h1 request) is flagged `malformed?` by
+        # parse_response_head but was otherwise returned as {ok:true,status:0} — a false success,
+        # and precisely the desync/smuggling anomaly send_pipeline exists to surface. Report it as
+        # a failure with a descriptive error, but keep the raw head + parsed projection so the
+        # workbench still shows the bytes that came back. No body is read: with no valid framing
+        # anything after the head is unstructured, and (in a group) `error` already retires the
+        # socket so the next request won't be misframed against these leftovers.
+        if resp.malformed?
+          return Result.new(head, nil, resp, elapsed(started),
+            error: "malformed/non-HTTP response from #{host}:#{port} (status line unparseable)")
+        end
         begin
           framing, len = Proxy::Codec::Body.response_framing(resp, request_method(request))
           # Cap the capture read at CAPTURE_READ_MAX (parity with the h2 engine's MAX_BODY):

--- a/src/gori/scope.cr
+++ b/src/gori/scope.cr
@@ -36,6 +36,7 @@ module Gori
       getter pattern : String
       @regex : Regex?
       @pattern_down : String
+      @pattern_host : String
 
       def initialize(@id : Int64, @kind : String, @match_type : String, @pattern : String)
         # The pattern is immutable (a Rule is rebuilt, never edited in place), so its
@@ -43,6 +44,10 @@ module Gori
         # of a Scope-filtered reload and per host of a Sitemap reload — is computed ONCE
         # here rather than re-allocated on each `matches?` call (mirrors @regex).
         @pattern_down = @pattern.downcase
+        # The bare, bracket-free host form ("[::1]" → "::1"), likewise precomputed. Host
+        # matching compares against this so an IPv6 rule matches whether the flow host was
+        # captured bracketed (some URL paths) or bare (the CONNECT/tunnel path).
+        @pattern_host = Scope.bare_host(@pattern_down)
         # Compile the regex once. An invalid pattern degrades to nil → never-match,
         # rather than unwinding through SQLite's C REGEXP callback or a proxy fiber.
         # Persisted patterns are validated on add/update; this is defense-in-depth.
@@ -90,7 +95,7 @@ module Gori
       end
 
       private def host_match?(host : String) : Bool
-        h = host.downcase
+        h = Scope.bare_host(host.downcase) # normalize "[::1]" → "::1" (see @pattern_host)
         if @pattern.includes?('*')
           # File.match? raises on a malformed glob; treat as non-matching so it can't
           # unwind onto the proxy hot path (mirrors SQLite GLOB's tolerance → keeps
@@ -101,7 +106,7 @@ module Gori
             false
           end
         else
-          h == @pattern_down || h.ends_with?(".#{@pattern_down}")
+          h == @pattern_host || h.ends_with?(".#{@pattern_host}")
         end
       end
     end
@@ -427,14 +432,25 @@ module Gori
       pattern[(i + 1)..].each_char.all?(&.ascii_number?)
     end
 
-    # The pattern with its :PORT stripped, for the rejection message (only called when a
-    # port is present). "[::1]:9091" → "[::1]"; "127.0.0.1:9091" → "127.0.0.1".
+    # A host / host-pattern reduced to the bare, bracket-free form the CONNECT/tunnel
+    # path stores ("[::1]" → "::1"). IPv6 flow hosts arrive bracketed via some URL-parsing
+    # paths but bare via the dominant HTTPS-MITM CONNECT path; peeling surrounding brackets
+    # on BOTH the rule pattern and the flow host lets "[::1]" and "::1" match interchangeably
+    # (Rule#host_match? / host_cond) and keeps the suggested form the one actually stored.
+    def self.bare_host(host : String) : String
+      (host.starts_with?('[') && host.ends_with?(']')) ? host[1...-1] : host
+    end
+
+    # The pattern with its :PORT stripped AND surrounding brackets peeled, for the
+    # rejection message (only called when a port is present). "[::1]:9091" → "::1";
+    # "127.0.0.1:9091" → "127.0.0.1". The bare form is the one host matching stores/compares,
+    # so following the suggestion yields a rule that actually matches.
     private def self.host_without_port(pattern : String) : String
       if pattern.starts_with?('[') && (close = pattern.index(']'))
-        return pattern[0..close]
+        return bare_host(pattern[0..close])
       end
       i = pattern.rindex(':')
-      i ? pattern[0...i] : pattern
+      bare_host(i ? pattern[0...i] : pattern)
     end
 
     # Regex compiles? (the historical `valid?` body, now a helper of validation_error.)
@@ -498,6 +514,9 @@ module Gori
     end
 
     private def host_cond(pattern : String) : {String, Array(DB::Any)}
+      # Peel brackets so a "[::1]" rule compares against the bare "::1" the host column
+      # stores — matches Rule#host_match?'s @pattern_host normalization (keeps SQL parity).
+      pattern = Scope.bare_host(pattern)
       if pattern.includes?('*')
         {"lower(host) GLOB ?", [pattern.downcase] of DB::Any}
       else

--- a/src/gori/sequencer/stats.cr
+++ b/src/gori/sequencer/stats.cr
@@ -473,7 +473,14 @@ module Gori::Sequencer
         sx2 += xs[i] * xs[i]
         sy2 += ys[i] * ys[i]
       end
-      den = Math.sqrt((m * sx2 - sx * sx) * (m * sy2 - sy * sy))
+      # Each factor is a variance (scaled by m) and mathematically can't be negative, but
+      # floating-point cancellation can land it just below 0 for a constant/near-constant
+      # series — clamp before the product so sqrt never sees a negative radicand and
+      # returns NaN. A clamped-to-0 factor means (near-)zero variance, so den == 0 below
+      # still catches it and correlation falls back to the intended 0.0.
+      vx = {0.0, m * sx2 - sx * sx}.max
+      vy = {0.0, m * sy2 - sy * sy}.max
+      den = Math.sqrt(vx * vy)
       den == 0 ? 0.0 : (m * sxy - sx * sy) / den
     end
 

--- a/src/gori/session.cr
+++ b/src/gori/session.cr
@@ -84,7 +84,7 @@ module Gori
         # all read the store / dial upstream directly and don't need the listener.
         bind_error =
           begin
-            lock = CaptureLock.try(project.dir)
+            lock = CaptureLock.try_at(project.capture_lock_path)
             if lock
               begin
                 proxy.start(fallback: bind_fallback)
@@ -97,7 +97,7 @@ module Gori
                 ex.message || "could not bind #{config.listen}:#{config.port}"
               end
             else
-              "another gori instance already holds this directory's capture lock"
+              "another gori instance already holds this database's capture lock"
             end
           rescue ex
             # CaptureLock.try itself failed (can't create/open the lock file) — not a
@@ -185,10 +185,10 @@ module Gori
           @proxy.stop
           false
         else
-          @capture_lock ||= CaptureLock.try(@project.dir) # reuse if held, else try to take over
-          return false unless @capture_lock               # still held by another instance
-          @probe.start                                    # we now hold the lock → run the scanner (idempotent if already running)
-          @proxy.start(fallback: true)                    # cover a DIFFERENT project's port on resume
+          @capture_lock ||= CaptureLock.try_at(@project.capture_lock_path) # reuse if held, else try to take over
+          return false unless @capture_lock                                # still held by another instance
+          @probe.start                                                     # we now hold the lock → run the scanner (idempotent if already running)
+          @proxy.start(fallback: true)                                     # cover a DIFFERENT project's port on resume
           true
         end
       sync_capture_status!

--- a/src/gori/sitemap.cr
+++ b/src/gori/sitemap.cr
@@ -199,6 +199,31 @@ module Gori
       node.children.each { |c| stamp_node_tags(c, host, tags) }
     end
 
+    # Visit every node in `root`'s subtree exactly once, each node AFTER its whole subtree
+    # (post-order), WITHOUT native recursion. The tree transforms below used to recurse one
+    # stack frame per tree level, which a single very deep captured/imported path (tens of
+    # thousands of segments) overflowed — SIGSEGV — on both the TUI Sitemap poll and
+    # `gori run sitemap`; an explicit work-list has no such ceiling. Collect nodes
+    # parent-before-child, then yield them in REVERSE — every node precedes its ancestors,
+    # so it is handed to the block only after its whole subtree, matching the old
+    # `children.each { recurse }; <body>` order. A transform may therefore reshape a node's
+    # OWN children when yielded (wrap them in a fold): its descendants are already done, and
+    # the new fold node is not in the collected list, so it is never re-visited.
+    private def self.post_order(root : Node, & : Node ->) : Nil
+      order = [root]
+      i = 0
+      while i < order.size
+        order[i].children.each { |c| order << c }
+        i += 1
+      end
+      # Index iteration (not `reverse_each`) keeps `yield` out of a block, which the compiler bars.
+      i = order.size - 1
+      while i >= 0
+        yield order[i]
+        i -= 1
+      end
+    end
+
     # Fold a node's opaque-id children into one collapsed node per class
     # (`{uuid}`/`{hex}`/`{date}`); siblings that aren't ids stay put. Same synthetic-
     # wrapper shape as `group_sequences!` — the real children keep their literal `path`,
@@ -207,9 +232,17 @@ module Gori
     # Runs BEFORE group_sequences!. Numerics are deliberately not classified here, so
     # the two passes partition the work instead of competing for the same children.
     def self.fold_templates!(node : Node) : Nil
-      node.children.each { |c| fold_templates!(c) }
-      # Descend THROUGH a fold — its children are real and may hide further ids — but
-      # never re-fold a fold's OWN children. This is what makes the pass idempotent.
+      # Iterative post-order (see post_order): the old
+      # `node.children.each { |c| fold_templates!(c) }` recursed one frame per tree level and
+      # overflowed the native stack on a pathologically deep path. Each node is still folded
+      # only after its subtree, so it sees a fully-folded child set exactly as before.
+      post_order(node) { |n| fold_templates_node!(n) }
+    end
+
+    # Fold ONE node's opaque-id children (see fold_templates!). Descend THROUGH a fold — its
+    # children are real and may hide further ids — but never re-fold a fold's OWN children,
+    # which is what makes the pass idempotent.
+    private def self.fold_templates_node!(node : Node) : Nil
       return if node.grouped
       buckets = {} of String => Array(Node)
       node.children.each do |c|
@@ -296,14 +329,21 @@ module Gori
     end
 
     # Fold a node's pure-numeric children into one collapsed `[1, 2, 3 … +N]` group
-    # when they exceed the threshold; non-numeric siblings stay put. Recurses first
-    # so nested sequences fold too. Sorting by (length, lexicographic) is numeric
-    # order without parsing (handles arbitrarily long ids, no overflow).
+    # when they exceed the threshold; non-numeric siblings stay put. Visits deepest-first
+    # (post_order) so nested sequences fold too. Sorting by (length, lexicographic) is
+    # numeric order without parsing (handles arbitrarily long ids, no overflow).
     def self.group_sequences!(node : Node) : Nil
-      node.children.each { |c| group_sequences!(c) }
-      # Same idempotency guard as fold_templates! — recurse through a fold, never re-fold
-      # its own children (without this, a {hex} fold of long numerics grows a nested
-      # [1000… +N] inside it, and a second call nests one more level).
+      # Iterative post-order (see post_order): the old
+      # `node.children.each { |c| group_sequences!(c) }` recursion SIGSEGV'd on a very deep
+      # tree. Same shared work-list, same per-node transform below.
+      post_order(node) { |n| group_sequences_node!(n) }
+    end
+
+    # Group ONE node's pure-numeric children (see group_sequences!). Same idempotency guard
+    # as fold_templates! — descend through a fold, never re-fold its own children (without
+    # this, a {hex} fold of long numerics grows a nested [1000… +N] inside it, and a second
+    # call nests one more level).
+    private def self.group_sequences_node!(node : Node) : Nil
       return if node.grouped
       # Count first, materialise second. The overwhelming majority of nodes have no numeric
       # children at all, and `select` used to allocate the result Array for every one of them

--- a/src/gori/store/compact.cr
+++ b/src/gori/store/compact.cr
@@ -105,7 +105,11 @@ class Gori::Store
   def self.compact(path : String, plan : CompactPlan) : CompactResult?
     return nil unless File.exists?(path)
     dir = File.dirname(path)
-    lock = CaptureLock.try(dir)
+    # Probe the SAME capture lock a live session would hold: keyed on the DB file for an
+    # arbitrary `--db` database, or the legacy per-directory lock for the canonical registry
+    # db — so compaction of a `--db` file being captured into is still correctly refused.
+    lock_path = File.basename(path) == Project::DB_FILE ? CaptureLock.path(dir) : "#{path}.capture.lock"
+    lock = CaptureLock.try_at(lock_path)
     return nil unless lock # another live instance is capturing into this project
     begin
       before = File.info(path).size

--- a/src/gori/tui/controllers/miner_controller.cr
+++ b/src/gori/tui/controllers/miner_controller.cr
@@ -105,7 +105,8 @@ module Gori::Tui
             v.render(screen, body, body_focused)
           else
             screen.text(body.x + 1, body.y,
-              "no mining sessions — from History/Repeater press space → \"Mine parameters\"", Theme.muted)
+              "no mining sessions — from History/Repeater press space → \"Mine parameters\"", Theme.muted,
+              width: body.w - 2)
           end
         end
       end

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -1058,10 +1058,16 @@ module Gori::Tui
       if detail.row.status == 101
         # WebSocket: seed the editor with recorded client→server TEXT messages. The
         # tab is session-only (db_id nil) — WS transcripts aren't persisted/synced.
-        out_msgs = @host.session.store.ws_messages(id).select { |m| m.direction == "out" && m.text? }.map { |m| String.new(m.payload).scrub }
+        all_out = @host.session.store.ws_messages(id).select { |m| m.direction == "out" }
+        out_msgs = all_out.select(&.text?).map { |m| String.new(m.payload).scrub }
         view.load_ws(detail, out_msgs)
         @repeaters << RepeaterTab.new(view, id, nil)
-        @host.status("ws repeater: #{view.summary} — edit messages (one per line) · ^R send · esc back")
+        # The WS message editor is text-only (one message per line), so binary outbound frames
+        # can't be represented/edited and are omitted from the seed — say so in the status line
+        # rather than letting them vanish from the replay without a trace.
+        dropped = all_out.size - out_msgs.size
+        omitted = dropped > 0 ? " — #{dropped} binary frame#{dropped == 1 ? "" : "s"} omitted (text editor can't replay them)" : ""
+        @host.status("ws repeater: #{view.summary} — edit messages (one per line)#{omitted} · ^R send · esc back")
       elsif grpc_flow?(detail)
         # gRPC: head editable as text; a unary call's message payload is hex-editable (^X)
         # and reframed on send. Session-only (db_id nil) — the binary body can't round-trip

--- a/src/gori/tui/controllers/sequencer_controller.cr
+++ b/src/gori/tui/controllers/sequencer_controller.cr
@@ -99,7 +99,8 @@ module Gori::Tui
             v.render(screen, body, body_focused)
           else
             screen.text(body.x + 1, body.y,
-              "no sequencer sessions — from History/Repeater press space → \"Send to Sequencer\", or select a token and use \"Send selection to\"", Theme.muted)
+              "no sequencer sessions — from History/Repeater press space → \"Send to Sequencer\", or select a token and use \"Send selection to\"", Theme.muted,
+              width: body.w - 2)
           end
         end
       end


### PR DESCRIPTION
A dogfooding pass (6 exploratory agents driving every `gori run` subcommand + the TUI against local targets) surfaced **25 bugs**; this PR fixes all of them plus one capability gap. Each fix was reproduced, then re-verified after the change (crashes/leaks driven live from their original repro commands; the rest covered by new specs).

### Crashes / hangs
- **sitemap `--format json`** no longer hits `JSON::Builder`'s 100-level nesting cap (hand-emitted JSON); deep-path tree transforms (`fold_templates!`/`group_sequences!`) are now iterative — no more `SIGSEGV` on deep paths.
- **QL parser** gained a recursion-depth guard — deeply nested parens no longer stack-overflow every `history`/`probe`/`sitemap`/`issues` query (shared grammar).
- **`sequence --tokens`** scrubs non-UTF-8 input instead of crashing on the regex split.
- **`capture --project`** aborts cleanly on degenerate names; all-non-ASCII names are now usable via a deterministic slug fallback.
- **`oast listen`** installs INT/TERM traps so Ctrl-C actually stops it.
- **`fuzz -w`** gives a clean "wordlist not found" error instead of a raw `File` exception.

### Proxy correctness / fidelity
- **`split_host_port`** treats only a valid IPv6 literal as a bare host, so `host:port:extra` no longer swallows the port (h1 Host / CONNECT / h2 `:authority`).
- **scope** normalizes IPv6 brackets so `[::1]` and `::1` match interchangeably.
- **client_conn** tears down a client-aborted idle SSE/close-delimited stream (watcher fiber) so the upstream socket/fiber don't leak and the flow is recorded `Aborted` instead of stuck `Pending`.
- **client_conn** preserves the client's original request-line form in captured history when an unrelated rewrite rule fires.

### Repeater
- Surface malformed / non-HTTP responses as `ok:false` (the desync/smuggling signal) instead of silently reporting success.
- Honor an explicit `-H "Content-Length: N"` on single-flow replay.
- Warn instead of silently dropping binary outbound WebSocket frames.

### Import
- Prefer the real `Content-Type` response header over HAR `content.mimeType` (fixes Probe false positives).
- Reject non-URL garbage hosts (embedded spaces); store IPv6 hosts bracket-free.

### Scanners / misc
- **discover** confines path-subtree crawls on segment boundaries (no `/api` → `/api-internal` leak).
- **notes/issues** strip terminal control sequences (ESC/OSC/BEL) from stdout, preserving newlines/tabs.
- **capture lock** keyed on the db file, not its parent directory.
- **sequencer** clamps the Pearson radicand so a constant series can't report `NaN`.
- **miner** no longer counts `--max-requests` cap refusals as errors.
- **decoder** warns on JWT tokens with extra (JWE-shaped) segments instead of silently dropping them.
- **tui** clamps Sequencer/Miner empty-state text to the pane border.
- **probe** truncates the echoed QL query in error messages.

### New capability
- **`feat(scope)`** headless Sandbox toggle via `gori run project sandbox status|on|off` and an MCP `set_sandbox` tool, so hard-containment can be bootstrapped without the TUI.

### Testing
- `shards build` clean (no warnings); `crystal spec` green — **3504 examples, 0 failures**.
- 9 new spec files + 11 updated; each fix carries a regression test (except two cosmetic TUI/CLI-abort cases with no lightweight test harness).

### Known residuals (documented, not silently skipped)
- WS binary replay now *warns* rather than silently dropping, but full binary replay needs a capture-time persistence (schema) change.
- The primary sitemap crash sites are iterative; a few sibling traversals remain recursive but survive the verified depths (folding collapses uniform paths first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)