### PR TITLE
fix(install): survive GitHub API rate limits, and verify downloads

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -120,6 +120,30 @@ jobs:
           path: build
 
       - if: startsWith(github.ref, 'refs/tags/')
+        name: Create version-less alias assets
+        # Never let a convenience copy block the actual release: a failure here
+        # would otherwise skip the upload step below and ship a release with no
+        # assets at all for this platform. install.sh tries the versioned name
+        # first, so a missing alias costs nothing.
+        continue-on-error: true
+        # Copies of each asset under a name with no version in it, so
+        # https://github.com/hahwul/gori/releases/download/latest/<alias> resolves
+        # without first asking api.github.com for the tag — that API is capped at
+        # 60 req/h per IP unauthenticated, and a 403 there used to break install.sh
+        # outright. install.sh and `gori update` fall back to these.
+        #
+        # Deliberately copies, not renames: the Homebrew formula, the AUR
+        # PKGBUILD and the snapcraft recipe all pin the versioned filenames.
+        # Runs after upload-artifact so CI artifacts do not carry the duplicates.
+        run: |
+          if [ "${{ matrix.platform }}" = "linux" ]; then
+            cp "build/gori-${GITHUB_REF_SLUG}-linux-${ARCH}" "build/gori-linux-${ARCH}"
+          else
+            cp "build/gori-${GITHUB_REF_SLUG}-osx-${ARCH}.tar.gz" "build/gori-osx-${ARCH}.tar.gz"
+          fi
+          ls -la build
+
+      - if: startsWith(github.ref, 'refs/tags/')
         name: Upload to GitHub Releases
         uses: svenstaro/upload-release-action@v2
         with:
@@ -128,3 +152,53 @@ jobs:
           overwrite: true
           file_glob: true
           file: build/*
+
+  # One SHA256SUMS covering every platform, so integrity can be checked over a
+  # path that never touches api.github.com. It matters because the API is what
+  # normally hands `gori update` a per-asset digest: once the 60 req/h limit is
+  # spent and the client falls back to the release redirect, this file is the
+  # only checksum source left. Single aggregated file rather than one per asset
+  # to keep the release page readable.
+  checksums:
+    name: Publish SHA256SUMS
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v5
+
+      - name: Download built assets
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: build-*
+          merge-multiple: true
+
+      - name: Compute checksums
+        run: |
+          set -euo pipefail
+          : > SHA256SUMS
+          for path in artifacts/*; do
+            [ -f "$path" ] || continue
+            name="$(basename "$path")"
+            sum="$(sha256sum "$path" | cut -d' ' -f1)"
+            printf '%s  %s\n' "$sum" "$name" >> SHA256SUMS
+            # The version-less aliases are byte-identical copies, so the same
+            # hash is emitted under the alias name too — whichever filename a
+            # client downloaded, it finds a line it can verify against.
+            alias_name="${name/gori-${GITHUB_REF_SLUG}-/gori-}"
+            if [ "$alias_name" != "$name" ]; then
+              printf '%s  %s\n' "$sum" "$alias_name" >> SHA256SUMS
+            fi
+          done
+          test -s SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Upload SHA256SUMS
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}
+          overwrite: true
+          file: SHA256SUMS

--- a/docs/content/getting-started/installation.ko.md
+++ b/docs/content/getting-started/installation.ko.md
@@ -16,6 +16,41 @@ curl -fsSL https://gori.hahwul.com/install.sh | bash
 
 `/usr/local`에 쓸 수 있으면 그 아래에, 아니면 `~/.local`에 설치합니다. `GORI_INSTALL_PREFIX`로 재정의할 수 있습니다. 설치 후에는 `gori update`가 바이너리를 스스로 업데이트합니다(설치를 담당하는 채널이 Homebrew / Snap / AUR인 경우 그쪽으로 안내합니다).
 
+### GitHub rate limit에 걸린 경우 {#rate-limit}
+
+설치 스크립트는 최신 릴리스가 무엇인지 GitHub API에 묻는데, 이 API는 **비인증 요청을 IP당 시간당 60회**만 허용합니다. 공용 CI나 NAT 뒤에서는 `403`이 돌아올 수 있습니다. 설치 스크립트와 `gori update` 모두 rate limit이 없는 릴리스 리다이렉트로 자동 폴백하므로 그대로 동작하며, `resolved v0.1.4 via ... (no API call)` 같은 줄이 보입니다.
+
+인증 시 한도인 5000회/시간을 쓰려면 토큰을 먼저 export하세요. `curl` 앞에 붙이면 안 되고 반드시 export해야 합니다 — 스크립트는 파이프로 연결된 `bash`에서 실행되므로 `curl`에만 걸린 변수는 상속되지 않습니다:
+
+```bash
+export GITHUB_TOKEN=<personal access token>
+curl -fsSL https://gori.hahwul.com/install.sh | bash
+```
+
+`GORI_GITHUB_TOKEN`과 `GH_TOKEN`도 동일하게 동작하며, `gori update`도 같은 변수를 읽습니다. 공개 저장소 읽기 권한만 있으면 됩니다.
+
+### 직접 다운로드 (Dockerfile, CI) {#direct-download}
+
+모든 릴리스에는 버전이 없는 사본도 함께 올라갑니다. 버전 조회도 API 호출도 없이 고정된 URL로 최신 빌드를 받을 수 있습니다. v0.1.4 다음 릴리스부터 제공되며, 그 이전 릴리스에는 버전이 붙은 이름만 있습니다:
+
+```bash
+# Linux x86_64 / arm64 — 정적 바이너리
+curl -fsSL -o gori https://github.com/hahwul/gori/releases/latest/download/gori-linux-x86_64 && chmod +x gori
+
+# macOS arm64 / x86_64 — gori와 lib/이 담긴 tarball
+curl -fsSL -o gori.tar.gz https://github.com/hahwul/gori/releases/latest/download/gori-osx-arm64.tar.gz
+```
+
+버전이 붙은 이름(`gori-v0.1.4-linux-x86_64`)도 그대로 유지되니, 특정 빌드에 고정하려면 그쪽을 쓰세요.
+
+각 릴리스에는 두 이름 체계를 모두 담은 `SHA256SUMS`도 함께 올라갑니다. 설치 스크립트와 `gori update`는 이 파일로 자동 검증하며, 직접 받은 파일을 확인하려면:
+
+```bash
+curl -fsSL -O https://github.com/hahwul/gori/releases/latest/download/SHA256SUMS
+sha256sum -c --ignore-missing SHA256SUMS       # Linux
+shasum -a 256 -c --ignore-missing SHA256SUMS   # macOS
+```
+
 ## Homebrew {#homebrew}
 
 **macOS**(Apple Silicon 및 Intel)와 **Linux**(x86_64 및 arm64)에서 동작합니다:

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -16,6 +16,41 @@ curl -fsSL https://gori.hahwul.com/install.sh | bash
 
 Installs under `/usr/local` when writable, otherwise `~/.local`. Override with `GORI_INSTALL_PREFIX`. After install, `gori update` self-updates the binary (or guides you through Homebrew / Snap / AUR when those channels own the install).
 
+### If you hit a GitHub rate limit
+
+The installer asks the GitHub API which release is latest, and that API allows only **60 unauthenticated requests per hour per IP** — behind shared CI or NAT egress it can answer `403`. Both the installer and `gori update` fall back to the rate-limit-free release redirect automatically, so they keep working; you should see a line like `resolved v0.1.4 via ... (no API call)`.
+
+To use the authenticated 5000/hour limit instead, export a token first. Note that it has to be exported rather than prefixed onto `curl` — the script runs in the piped `bash`, which would not inherit a `curl`-scoped variable:
+
+```bash
+export GITHUB_TOKEN=<personal access token>
+curl -fsSL https://gori.hahwul.com/install.sh | bash
+```
+
+`GORI_GITHUB_TOKEN` and `GH_TOKEN` work too, and `gori update` reads the same variables. Only a public-repo read scope is needed.
+
+### Direct download (Dockerfiles, CI)
+
+Every release also carries a version-less copy of each asset, so you can pull the latest build from a stable URL with no version lookup and no API call. These land with the first release published after v0.1.4 — earlier releases only carry the versioned names:
+
+```bash
+# Linux x86_64 / arm64 — a static binary
+curl -fsSL -o gori https://github.com/hahwul/gori/releases/latest/download/gori-linux-x86_64 && chmod +x gori
+
+# macOS arm64 / x86_64 — a tarball holding gori plus its lib/
+curl -fsSL -o gori.tar.gz https://github.com/hahwul/gori/releases/latest/download/gori-osx-arm64.tar.gz
+```
+
+The versioned names (`gori-v0.1.4-linux-x86_64`) stay published alongside them — use those when you want to pin a build.
+
+Each release also publishes a `SHA256SUMS` listing every asset under both naming schemes. The installer and `gori update` check against it automatically; to verify a direct download yourself:
+
+```bash
+curl -fsSL -O https://github.com/hahwul/gori/releases/latest/download/SHA256SUMS
+sha256sum -c --ignore-missing SHA256SUMS       # Linux
+shasum -a 256 -c --ignore-missing SHA256SUMS   # macOS
+```
+
 ## Homebrew
 
 Works on **macOS** (Apple Silicon & Intel) and **Linux** (x86_64 & arm64):

--- a/docs/static/install.sh
+++ b/docs/static/install.sh
@@ -16,8 +16,15 @@ set -euo pipefail
 
 REPO="hahwul/gori"
 API_URL="https://api.github.com/repos/${REPO}/releases/latest"
+# Plain web endpoint (NOT the API): 302s to .../releases/tag/<tag>. No rate limit.
+LATEST_URL="https://github.com/${REPO}/releases/latest"
 # Download URL pattern: https://github.com/hahwul/gori/releases/download/<tag>/<asset>
 DOWNLOAD_BASE="https://github.com/${REPO}/releases/download"
+
+# Optional PAT. api.github.com allows 60 unauthenticated requests per hour per
+# IP; authenticated it is 5000. Shared CI/NAT egress IPs burn the anonymous
+# quota fast, which is what makes the unauthenticated tier unreliable.
+TOKEN="${GORI_GITHUB_TOKEN:-${GITHUB_TOKEN:-${GH_TOKEN:-}}}"
 
 log()  { printf 'gori-install: %s\n' "$*"; }
 die()  { printf 'gori-install: error: %s\n' "$*" >&2; exit 1; }
@@ -55,17 +62,56 @@ else
   PREFIX="${HOME}/.local"
 fi
 
-log "fetching latest release metadata from ${API_URL}"
-release_json="$(curl -fsSL \
-  -H "Accept: application/vnd.github+json" \
-  -H "User-Agent: gori-install.sh" \
-  "$API_URL")" || die "failed to fetch latest release (is the network up? are releases published?)"
+# Resolving the tag has three tiers, most informative first. The API is tried
+# before the redirect because only the API returns the asset list we validate
+# against; the redirect is the one that survives a spent rate limit.
+#
+#   1. authenticated API  — 5000 req/h, tag + asset list
+#   2. anonymous API      — same data, but only 60 req/h per IP
+#   3. release redirect   — github.com/<repo>/releases/latest 302s to the tag
+#                           URL. Not the API, so no quota; tag only.
 
-# Prefer python3 for JSON; fall back to a conservative sed/grep parse of tag_name.
+# Prints "<body>\n<http_code>". Never aborts the script: even a failed connection
+# yields a trailing status line (000), so the caller can tell "GitHub is down"
+# apart from "GitHub said no".
+#
+# stderr is deliberately NOT silenced. Without -f, curl stays quiet on an HTTP
+# error status (403 and friends reach us as $api_code), so the only thing this
+# lets through is a transport failure — DNS, TLS, proxy — which is exactly the
+# detail someone on a broken network needs and cannot get anywhere else.
+api_fetch() {
+  if [ -n "$TOKEN" ]; then
+    curl -sSL -w '\n%{http_code}' \
+      -H "Accept: application/vnd.github+json" \
+      -H "User-Agent: gori-install.sh" \
+      -H "Authorization: Bearer ${TOKEN}" \
+      "$1" || true
+  else
+    curl -sSL -w '\n%{http_code}' \
+      -H "Accept: application/vnd.github+json" \
+      -H "User-Agent: gori-install.sh" \
+      "$1" || true
+  fi
+}
+
+if [ -n "$TOKEN" ]; then
+  log "fetching latest release metadata from ${API_URL} (authenticated)"
+else
+  log "fetching latest release metadata from ${API_URL}"
+fi
+
+api_response="$(api_fetch "$API_URL")"
+api_code="$(printf '%s\n' "$api_response" | tail -n1)"
+release_json="$(printf '%s\n' "$api_response" | sed '$d')"
+
 tag=""
-asset_ok=""
-if command -v python3 >/dev/null 2>&1; then
-  parsed="$(printf '%s' "$release_json" | python3 -c '
+asset_names=""
+
+if [ "$api_code" = "200" ]; then
+  # Prefer python3 for JSON; fall back to a conservative sed/grep parse of tag_name.
+  parsed=""
+  if command -v python3 >/dev/null 2>&1; then
+    parsed="$(printf '%s' "$release_json" | python3 -c '
 import sys, json
 try:
     d = json.load(sys.stdin)
@@ -76,36 +122,91 @@ tag = d.get("tag_name") or ""
 names = [a.get("name","") for a in (d.get("assets") or [])]
 print(tag)
 print("\n".join(names))
-' )" || die "could not parse GitHub releases JSON"
-  tag="$(printf '%s\n' "$parsed" | head -1)"
-  asset_names="$(printf '%s\n' "$parsed" | tail -n +2)"
-elif command -v python >/dev/null 2>&1; then
-  parsed="$(printf '%s' "$release_json" | python -c '
+' 2>/dev/null || true)"
+  elif command -v python >/dev/null 2>&1; then
+    parsed="$(printf '%s' "$release_json" | python -c '
 import sys, json
 d = json.load(sys.stdin)
 tag = d.get("tag_name") or ""
 names = [a.get("name","") for a in (d.get("assets") or [])]
 print(tag)
 print("\n".join(names))
-' )" || die "could not parse GitHub releases JSON"
-  tag="$(printf '%s\n' "$parsed" | head -1)"
-  asset_names="$(printf '%s\n' "$parsed" | tail -n +2)"
+' 2>/dev/null || true)"
+  fi
+  if [ -n "$parsed" ]; then
+    tag="$(printf '%s\n' "$parsed" | head -1)"
+    asset_names="$(printf '%s\n' "$parsed" | tail -n +2)"
+  else
+    # No python, or python choked on the body — grep out just the tag.
+    tag="$(printf '%s' "$release_json" | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/' || true)"
+  fi
+  # A parsed-but-tagless response is a broken response; do not trust its asset
+  # list either, and let the redirect tier have a go.
+  if [ -z "$tag" ]; then
+    asset_names=""
+    log "could not parse tag_name from the API response — trying the release redirect"
+  fi
 else
-  tag="$(printf '%s' "$release_json" | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
-  asset_names=""
+  case "$api_code" in
+    401)
+      log "GitHub API rejected the token (HTTP 401 — check GITHUB_TOKEN/GH_TOKEN) — trying the release redirect" ;;
+    403|429)
+      log "GitHub API rate limit reached (HTTP ${api_code} — 60 requests/hour per IP unauthenticated) — trying the release redirect" ;;
+    000)
+      log "could not reach api.github.com — trying the release redirect" ;;
+    *)
+      log "GitHub API returned HTTP ${api_code} — trying the release redirect" ;;
+  esac
 fi
-[ -n "$tag" ] || die "could not parse tag_name from GitHub releases API response"
+
+if [ -z "$tag" ]; then
+  location="$(curl -sSI "$LATEST_URL" | tr -d '\r' | grep -i '^location:' | tail -n1 | sed 's/^[Ll][Oo][Cc][Aa][Tt][Ii][Oo][Nn]:[[:space:]]*//' || true)"
+  # Requiring the /releases/tag/ segment is what keeps this honest: a repo with
+  # no published release redirects to plain /releases, which must not read as a tag.
+  case "$location" in
+    */releases/tag/*)
+      tag="${location##*/releases/tag/}"
+      tag="${tag%%[?#]*}"   # drop any query string / fragment
+      tag="${tag%%/*}"      # drop any trailing path segment
+      ;;
+    *) tag="" ;;
+  esac
+  if [ -n "$tag" ]; then
+    log "resolved ${tag} via ${LATEST_URL} (no API call)"
+  fi
+fi
+
+if [ -z "$tag" ]; then
+  case "$api_code" in
+    403|429)
+      die "GitHub API rate limit reached (HTTP ${api_code}) and the release redirect failed too.
+  Retry in a few minutes, set GITHUB_TOKEN=<token> to raise the limit to 5000/hour,
+  or download manually from https://github.com/${REPO}/releases" ;;
+    *)
+      die "could not determine the latest release (API HTTP ${api_code}, redirect failed) — see https://github.com/${REPO}/releases" ;;
+  esac
+fi
 
 ver="${tag#v}"
+# Every release also ships a version-less copy of each asset, so a name derived
+# from a tag we could not validate against an asset list still has a fallback.
 if [ "$os_key" = "linux" ]; then
   asset="gori-v${ver}-linux-${arch_key}"
+  alias_asset="gori-linux-${arch_key}"
 else
   asset="gori-v${ver}-osx-${arch_key}.tar.gz"
+  alias_asset="gori-osx-${arch_key}.tar.gz"
 fi
 
 if [ -n "$asset_names" ]; then
-  printf '%s\n' "$asset_names" | grep -Fxq "$asset" || \
-    die "release ${tag} has no asset '${asset}' (see https://github.com/${REPO}/releases) — assets may not be published yet"
+  if ! printf '%s\n' "$asset_names" | grep -Fxq "$asset"; then
+    if printf '%s\n' "$asset_names" | grep -Fxq "$alias_asset"; then
+      log "release ${tag} has no '${asset}' — using version-less alias '${alias_asset}'"
+      asset="$alias_asset"
+    else
+      die "release ${tag} has no asset '${asset}' (see https://github.com/${REPO}/releases) — assets may not be published yet"
+    fi
+  fi
 fi
 
 url="${DOWNLOAD_BASE}/${tag}/${asset}"
@@ -118,10 +219,62 @@ tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/gori-install.XXXXXX")"
 cleanup() { rm -rf "$tmpdir"; }
 trap cleanup EXIT
 
-curl -fsSL -o "${tmpdir}/${asset}" "$url" || die "download failed — asset may not exist yet for ${tag} (see https://github.com/${REPO}/releases)"
+# -S omitted on this first attempt only: a 404 here is handled (we retry the
+# alias below), so curl's own error line would read as a failure when it is not.
+if ! curl -fsL -o "${tmpdir}/${asset}" "$url"; then
+  # Reached without an asset list to check against (redirect tier), so the
+  # versioned filename was a guess. Retry the version-less alias under the SAME
+  # tag — not /releases/latest/download/, which could hand us a different
+  # release if one is published mid-install.
+  if [ "$asset" != "$alias_asset" ]; then
+    log "no ${asset} in ${tag} — retrying version-less alias ${alias_asset}"
+    asset="$alias_asset"
+    url="${DOWNLOAD_BASE}/${tag}/${asset}"
+    log "downloading ${url}"
+    curl -fsSL -o "${tmpdir}/${asset}" "$url" || \
+      die "download failed — neither the versioned nor the alias asset exists for ${tag} (see https://github.com/${REPO}/releases)"
+  else
+    die "download failed — asset may not exist yet for ${tag} (see https://github.com/${REPO}/releases)"
+  fi
+fi
 
 if [ ! -s "${tmpdir}/${asset}" ]; then
   die "downloaded asset is empty: ${asset}"
+fi
+
+# Integrity check against the release's SHA256SUMS, fetched over the same
+# download path — so it still works on the redirect tier, where no API digest is
+# available. Best-effort by design: releases published before SHA256SUMS existed
+# carry none, and refusing to install those would be a regression. A checksum
+# that IS present and does NOT match is always fatal.
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | cut -d' ' -f1
+  else
+    return 1
+  fi
+}
+
+if sums="$(curl -fsL "${DOWNLOAD_BASE}/${tag}/SHA256SUMS")"; then
+  # SHA256SUMS lists both the versioned and the version-less name for each
+  # asset, so this matches whichever one we ended up downloading.
+  expected="$(printf '%s\n' "$sums" | awk -v want="$asset" \
+    '{ n = $2; sub(/^\*/, "", n); if (n == want) { print $1; exit } }' || true)"
+  if [ -z "$expected" ]; then
+    log "SHA256SUMS has no entry for ${asset} — skipping checksum verification"
+  elif actual="$(sha256_of "${tmpdir}/${asset}")"; then
+    if [ "$actual" = "$expected" ]; then
+      log "sha256 verified"
+    else
+      die "checksum mismatch for ${asset}: expected ${expected}, got ${actual} (download corrupted or tampered in transit)"
+    fi
+  else
+    log "no sha256sum/shasum on this system — skipping checksum verification"
+  fi
+else
+  log "no SHA256SUMS published for ${tag} — skipping checksum verification"
 fi
 
 bin_dir="${PREFIX}/bin"

--- a/spec/support/mock_release_server.cr
+++ b/spec/support/mock_release_server.cr
@@ -11,8 +11,14 @@ class MockReleaseServer
   getter body : Bytes
   getter asset_names : Array(String)
 
+  # Headers of the most recent request to the release-API path, so specs can
+  # assert what we do and do not send (e.g. that a PAT never leaves for a
+  # non-github.com host).
+  getter last_api_headers : HTTP::Headers?
+
   @server : HTTP::Server
   @closed = false
+  @last_api_headers : HTTP::Headers? = nil
 
   # `reported_size`: override the release JSON's `size` field independent of the
   # real asset body (defaults to the true body size). Lets specs simulate the
@@ -30,7 +36,9 @@ class MockReleaseServer
                  reported_size : Int64? = nil,
                  truncate_at : Int32? = nil,
                  provide_digest : Bool = false,
-                 digest_override : String? = nil)
+                 digest_override : String? = nil,
+                 api_status : Int32 = 200)
+    @api_status = api_status
     @tag = tag
     @body = body.is_a?(Bytes) ? body : body.to_slice
     ver = tag.lchop('v').lchop('V')
@@ -96,7 +104,14 @@ class MockReleaseServer
     path = req.path
     case
     when path == "/repos/hahwul/gori/releases/latest"
+      @last_api_headers = req.headers.dup
       context.response.content_type = "application/json"
+      if @api_status != 200
+        # Shaped like the real thing so error-message specs match reality.
+        context.response.status = HTTP::Status.new(@api_status)
+        context.response.print %({"message":"API rate limit exceeded for 203.0.113.7."})
+        return
+      end
       context.response.print release_json
     when path.starts_with?("/download/")
       name = path.lchop("/download/")

--- a/spec/update_spec.cr
+++ b/spec/update_spec.cr
@@ -2,6 +2,19 @@ require "./spec_helper"
 require "file_utils"
 require "./support/mock_release_server"
 
+# Sets env vars for the block and restores them exactly afterwards — a nil value
+# means "unset", both going in and coming back out, so a var that did not exist
+# before does not linger as an empty string for later examples.
+private def with_env(vars : Hash(String, String?), &)
+  saved = vars.keys.to_h { |key| {key, ENV[key]?} }
+  begin
+    vars.each { |key, value| value ? (ENV[key] = value) : ENV.delete(key) }
+    yield
+  ensure
+    saved.each { |key, value| value ? (ENV[key] = value) : ENV.delete(key) }
+  end
+end
+
 describe Gori::Update do
   describe ".detect_channel" do
     it "detects Homebrew Cellar paths" do
@@ -804,6 +817,159 @@ describe Gori::Update do
         end
       ensure
         FileUtils.rm_rf(root) if File.exists?(root)
+      end
+    end
+  end
+
+  # --- rate-limit fallback ---------------------------------------------------
+  # api.github.com allows 60 unauthenticated requests/hour per IP; past that it
+  # answers 403 and `gori update` used to simply fail. These cover the two ways
+  # out: a token, and naming the release from the web redirect instead.
+
+  describe ".tag_from_release_location" do
+    it "extracts the tag from a release redirect" do
+      Gori::Update.tag_from_release_location(
+        "https://github.com/hahwul/gori/releases/tag/v0.1.4").should eq("v0.1.4")
+    end
+
+    it "ignores query strings, fragments and trailing segments" do
+      Gori::Update.tag_from_release_location(
+        "https://github.com/hahwul/gori/releases/tag/v1.2.3?a=1").should eq("v1.2.3")
+      Gori::Update.tag_from_release_location(
+        "  https://github.com/hahwul/gori/releases/tag/v1.2.3#notes  ").should eq("v1.2.3")
+    end
+
+    it "returns nil when the redirect is not a release page" do
+      # A repo with no published release redirects to plain /releases. Reading a
+      # tag out of that would send the installer after an asset that cannot exist.
+      Gori::Update.tag_from_release_location("https://github.com/hahwul/gori/releases").should be_nil
+      Gori::Update.tag_from_release_location("https://github.com/hahwul/gori/releases/tag/").should be_nil
+      Gori::Update.tag_from_release_location("https://github.com/login").should be_nil
+      Gori::Update.tag_from_release_location(nil).should be_nil
+    end
+  end
+
+  describe ".github_token" do
+    it "takes the first non-empty of GORI_GITHUB_TOKEN, GITHUB_TOKEN, GH_TOKEN" do
+      with_env({"GORI_GITHUB_TOKEN" => "a", "GITHUB_TOKEN" => "b", "GH_TOKEN" => "c"}) do
+        Gori::Update.github_token.should eq("a")
+      end
+      with_env({"GORI_GITHUB_TOKEN" => nil, "GITHUB_TOKEN" => "b", "GH_TOKEN" => "c"}) do
+        Gori::Update.github_token.should eq("b")
+      end
+      with_env({"GORI_GITHUB_TOKEN" => nil, "GITHUB_TOKEN" => nil, "GH_TOKEN" => "c"}) do
+        Gori::Update.github_token.should eq("c")
+      end
+    end
+
+    it "treats a blank value as absent" do
+      with_env({"GORI_GITHUB_TOKEN" => "   ", "GITHUB_TOKEN" => nil, "GH_TOKEN" => nil}) do
+        Gori::Update.github_token.should be_nil
+      end
+    end
+  end
+
+  describe ".default_api?" do
+    it "is false for an explicit URL or the env override" do
+      Gori::Update.default_api?("http://127.0.0.1:1/x").should be_false
+      with_env({"GORI_UPDATE_API_URL" => "http://127.0.0.1:1/x"}) do
+        Gori::Update.default_api?.should be_false
+      end
+    end
+
+    it "is true for the stock GitHub endpoint" do
+      with_env({"GORI_UPDATE_API_URL" => nil}) do
+        Gori::Update.default_api?.should be_true
+      end
+    end
+  end
+
+  describe ".synthesize_release_json" do
+    it "builds a release the normal parser and asset picker consume" do
+      json = Gori::Update.synthesize_release_json("v9.9.9", "linux", "x86_64")
+      release = Gori::Update.parse_release(json)
+      release.tag_name.should eq("v9.9.9")
+      asset = Gori::Update.select_asset(release, "linux", "x86_64").not_nil!
+      asset.name.should eq("gori-v9.9.9-linux-x86_64")
+      asset.browser_download_url.should eq(
+        "https://github.com/hahwul/gori/releases/download/v9.9.9/gori-v9.9.9-linux-x86_64")
+    end
+
+    it "advertises no digest when SHA256SUMS gave none, rather than faking one" do
+      release = Gori::Update.parse_release(
+        Gori::Update.synthesize_release_json("v9.9.9", "osx", "arm64"))
+      release.assets.first.digest.should be_nil
+      Gori::Update.parse_sha256_digest(release.assets.first.digest).should be_nil
+    end
+
+    it "carries a SHA256SUMS digest through so verify_sha256! actually runs" do
+      hex = "e" * 64
+      release = Gori::Update.parse_release(
+        Gori::Update.synthesize_release_json("v9.9.9", "linux", "x86_64", digest: hex))
+      Gori::Update.parse_sha256_digest(release.assets.first.digest).should eq(hex)
+    end
+  end
+
+  describe ".parse_checksums" do
+    it "parses sha256sum-style lines" do
+      text = "#{"a" * 64}  gori-v9.9.9-linux-x86_64\n#{"b" * 64}  gori-linux-x86_64\n"
+      sums = Gori::Update.parse_checksums(text)
+      sums["gori-v9.9.9-linux-x86_64"].should eq("a" * 64)
+      sums["gori-linux-x86_64"].should eq("b" * 64)
+    end
+
+    it "accepts the binary-mode marker and uppercase hex" do
+      sums = Gori::Update.parse_checksums("#{"A" * 64} *gori-osx-arm64.tar.gz\n")
+      sums["gori-osx-arm64.tar.gz"].should eq("a" * 64)
+    end
+
+    it "skips malformed lines instead of discarding the whole file" do
+      text = String.build do |s|
+        s << "not-a-hash  gori-bad\n"
+        s << "\n"
+        s << "#{"c" * 64}  gori-ok\n"
+        s << "#{"d" * 63}  gori-tooshort\n"
+        s << "#{"e" * 64}\n" # hash with no name
+      end
+      sums = Gori::Update.parse_checksums(text)
+      sums.keys.should eq(["gori-ok"])
+    end
+  end
+
+  describe ".fetch_latest_release_json_with_fallback" do
+    it "reports HTTP 403 as a rate limit and names the token workaround" do
+      with_mock_release_server(api_status: 403) do |server|
+        ex = expect_raises(Gori::Error, /rate limit/i) do
+          Gori::Update.fetch_latest_release_json(server.api_url)
+        end
+        ex.message.not_nil!.should contain("GITHUB_TOKEN")
+      end
+    end
+
+    it "passes an API success straight through, with no fallback flag" do
+      with_mock_release_server do |server|
+        json, via_redirect = Gori::Update.fetch_latest_release_json_with_fallback(server.api_url)
+        via_redirect.should be_false
+        Gori::Update.parse_release(json).tag_name.should eq("v99.0.0")
+      end
+    end
+
+    it "does not fall back to github.com when an explicit API URL was given" do
+      # Mock servers and GORI_UPDATE_API_URL must stay hermetic: a 403 from the
+      # injected endpoint has to surface, not silently retarget the real repo.
+      with_mock_release_server(api_status: 403) do |server|
+        expect_raises(Gori::Error, /rate limit/i) do
+          Gori::Update.fetch_latest_release_json_with_fallback(server.api_url)
+        end
+      end
+    end
+
+    it "never sends a token to a host other than api.github.com" do
+      with_env({"GORI_GITHUB_TOKEN" => "secret-pat"}) do
+        with_mock_release_server do |server|
+          Gori::Update.fetch_latest_release_json(server.api_url)
+          server.last_api_headers.not_nil!["Authorization"]?.should be_nil
+        end
       end
     end
   end

--- a/src/gori/update.cr
+++ b/src/gori/update.cr
@@ -18,6 +18,14 @@ module Gori
     USER_AGENT    = "gori/#{VERSION} (+#{REPOSITORY_URL})"
     MAX_REDIRECTS = 10
     HTTP_TIMEOUT  = 60.seconds
+    # api.github.com caps unauthenticated callers at 60 requests/hour per IP and
+    # answers 403 once that is spent — a shared NAT/CI egress IP burns it fast.
+    # This endpoint is the plain web one, not the API, so it carries no such cap:
+    # it 302s to .../releases/tag/<tag>, which is enough to name the release.
+    RELEASES_LATEST_URL = "#{RELEASES_URL}/latest"
+    DOWNLOAD_BASE       = "#{RELEASES_URL}/download"
+    # A PAT lifts the API cap to 5000/hour. Checked in order, first non-empty wins.
+    TOKEN_ENVS = %w[GORI_GITHUB_TOKEN GITHUB_TOKEN GH_TOKEN]
     # Short timeout for the TUI startup update check (background, best-effort) so a
     # slow/hung GitHub never keeps a fiber alive for a full minute. The explicit
     # `gori update` flow keeps HTTP_TIMEOUT.
@@ -638,6 +646,23 @@ module Gori
       HEX_SHA256.matches?(hex) ? hex : nil
     end
 
+    # Parses a `sha256sum`-style SHA256SUMS body into {asset name => hex}. Lines
+    # are "<64 hex><spaces><name>", the name optionally prefixed with `*` for
+    # binary mode. Anything that does not match that shape is skipped rather than
+    # raising — a malformed line must not cost us the checksums we can read.
+    def self.parse_checksums(text : String) : Hash(String, String)
+      sums = {} of String => String
+      text.each_line do |line|
+        parts = line.strip.split(/\s+/, 2)
+        next unless parts.size == 2
+        hex = parts[0].downcase
+        next unless HEX_SHA256.matches?(hex)
+        name = parts[1].strip.lchop('*')
+        sums[name] = hex unless name.empty?
+      end
+      sums
+    end
+
     # Streamed SHA256 of a file as lowercase hex (constant memory).
     def self.file_sha256(path : String) : String
       digest = Digest::SHA256.new
@@ -690,12 +715,144 @@ module Gori
                             timeout : Time::Span = UPDATE_CHECK_TIMEOUT) : String?
       parse_release(fetch_latest_release_json(api_url, timeout: timeout)).version
     rescue
-      nil
+      # Rate-limited or offline. This check only needs a version number, and the
+      # redirect endpoint still supplies one, so the notice survives a spent quota.
+      return nil unless default_api?(api_url)
+      resolve_tag_via_redirect(timeout).try { |tag| normalize_version(tag) }
     end
 
     # Resolves the releases API URL: explicit arg → env override → GitHub default.
     def self.resolve_api_url(api_url : String? = nil) : String
       api_url || ENV[UPDATE_API_ENV]? || API_LATEST
+    end
+
+    # True only when we are talking to the real GitHub API rather than a mock
+    # server injected by a spec or GORI_UPDATE_API_URL. The redirect fallback
+    # targets github.com specifically, so it must not fire for those.
+    def self.default_api?(api_url : String? = nil) : Bool
+      resolve_api_url(api_url) == API_LATEST
+    end
+
+    # First non-empty value among TOKEN_ENVS, or nil.
+    def self.github_token : String?
+      TOKEN_ENVS.each do |name|
+        value = ENV[name]?.try(&.strip)
+        return value if value && !value.empty?
+      end
+      nil
+    end
+
+    # Tag out of a /releases/latest redirect Location, or nil when the target is
+    # not a release page. A repo with no published release redirects to plain
+    # /releases, so requiring the /releases/tag/ segment is what stops this path
+    # from inventing a tag out of an unrelated redirect.
+    def self.tag_from_release_location(location : String?) : String?
+      return nil unless location
+      loc = location.strip
+      return nil unless loc.includes?("/releases/tag/")
+      tag = loc.rpartition("/releases/tag/")[2]
+      # Drop anything GitHub might append after the tag.
+      tag = tag.partition('?')[0].partition('#')[0].partition('/')[0]
+      tag.empty? ? nil : tag
+    end
+
+    # Names the latest release from the web redirect instead of the API: no
+    # quota, but the tag is all we learn (no asset list, no size, no digest).
+    # Returns nil on any failure — callers treat that as "fallback unavailable".
+    def self.resolve_tag_via_redirect(timeout : Time::Span = HTTP_TIMEOUT) : String?
+      uri = URI.parse(RELEASES_LATEST_URL)
+      host = uri.host
+      return nil unless host
+      port = uri.port || (uri.scheme == "https" ? 443 : 80)
+      client = http_client(host, port, uri.scheme == "https", timeout)
+      begin
+        response = client.head(uri.request_target,
+          headers: HTTP::Headers{"User-Agent" => USER_AGENT})
+        return nil unless {301, 302, 303, 307, 308}.includes?(response.status_code)
+        tag_from_release_location(response.headers["Location"]?)
+      ensure
+        client.close
+      end
+    rescue
+      nil
+    end
+
+    # Stand-in for the API payload, built from a tag alone, so the redirect path
+    # can reuse parse_release/resolve_asset_from_json unchanged. The asset name is
+    # derived exactly as release-binary.yml builds it. `digest` comes from the
+    # release's SHA256SUMS when it has one; without it verify_sha256! no-ops, so
+    # the caller warns that the checksum check was skipped (see update_binary).
+    def self.synthesize_release_json(tag : String, os : String = current_os,
+                                     arch : String = current_arch,
+                                     digest : String? = nil) : String
+      name = asset_name(tag, os, arch)
+      JSON.build do |json|
+        json.object do
+          json.field "tag_name", tag
+          json.field "assets" do
+            json.array do
+              json.object do
+                json.field "name", name
+                json.field "browser_download_url", "#{DOWNLOAD_BASE}/#{tag}/#{name}"
+                json.field "digest", "sha256:#{digest}" if digest
+              end
+            end
+          end
+        end
+      end
+    end
+
+    # sha256 for `name` out of the release's SHA256SUMS, or nil when the release
+    # publishes none / the fetch fails. Only needed on the redirect fallback: the
+    # API hands us a per-asset digest directly, but it is the API that is
+    # unavailable there, and SHA256SUMS travels the same no-quota download path.
+    def self.fetch_asset_digest(tag : String, name : String) : String?
+      body : String? = nil
+      with_tempdir("gori-sums-") do |dir|
+        dest = File.join(dir, "SHA256SUMS")
+        download_to("#{DOWNLOAD_BASE}/#{tag}/SHA256SUMS", dest)
+        body = File.read(dest)
+      end
+      body.try { |text| parse_checksums(text)[name]? }
+    rescue
+      nil
+    end
+
+    # fetch_latest_release_json, but when GitHub refuses (rate limit, outage) it
+    # names the release through the redirect endpoint instead. Returns the JSON
+    # and whether it came from that fallback, so the caller can say so.
+    #
+    # Falls back on any fetch error rather than only 403: resolve_tag_via_redirect
+    # validates its own answer, so a genuine "no releases" still surfaces the
+    # original error instead of being papered over.
+    def self.fetch_latest_release_json_with_fallback(api_url : String? = nil, *,
+                                                     timeout : Time::Span = HTTP_TIMEOUT) : {String, Bool}
+      {fetch_latest_release_json(api_url, timeout: timeout), false}
+    rescue ex
+      raise ex unless default_api?(api_url)
+      tag = resolve_tag_via_redirect(timeout)
+      raise ex unless tag
+      digest = fetch_asset_digest(tag, asset_name(tag, current_os, current_arch))
+      {synthesize_release_json(tag, digest: digest), true}
+    end
+
+    # Maps a non-200 releases-API status onto the error we surface. Split out of
+    # fetch_latest_release_json so the status ladder does not dominate it.
+    private def self.api_error(status : Int32, body : String) : Error
+      case status
+      when 404
+        Error.new("no GitHub releases found for #{GITHUB_REPO} — see #{RELEASES_URL}")
+      when 401
+        Error.new("GitHub API rejected the token (HTTP 401) — check #{TOKEN_ENVS.join('/')}")
+      when 403, 429
+        Error.new(
+          "GitHub API rate limit reached (HTTP #{status}; unauthenticated callers get " \
+          "60 requests/hour per IP) — retry shortly, or set GITHUB_TOKEN to raise it to 5000/hour"
+        )
+      else
+        snippet = body.lines.first?.try { |l| l.size > 200 ? l[0, 200] : l } || ""
+        Error.new("GitHub releases API returned HTTP #{status}#{snippet.empty? ? "" : ": #{snippet}"}")
+      end
     end
 
     def self.fetch_latest_release_json(api_url : String? = nil, *,
@@ -707,22 +864,18 @@ module Gori
         "User-Agent" => USER_AGENT,
       }
       host = uri.host || raise Error.new("invalid API URL: #{url}")
+      # Gated on the host, not on resolve_api_url: a token must never travel to a
+      # mock server or any other endpoint someone points GORI_UPDATE_API_URL at.
+      if host == "api.github.com" && (token = github_token)
+        headers["Authorization"] = "Bearer #{token}"
+      end
       port = uri.port || (uri.scheme == "https" ? 443 : 80)
       tls = uri.scheme == "https"
       client = http_client(host, port, tls, timeout)
       begin
         response = client.get(uri.request_target, headers: headers)
-        case response.status_code
-        when 200
-          response.body
-        when 404
-          raise Error.new("no GitHub releases found for #{GITHUB_REPO} — see #{RELEASES_URL}")
-        when 403
-          raise Error.new("GitHub API forbidden (rate limit or auth) — see #{RELEASES_URL}")
-        else
-          snippet = response.body.lines.first?.try { |l| l.size > 200 ? l[0, 200] : l } || ""
-          raise Error.new("GitHub releases API returned HTTP #{response.status_code}#{snippet.empty? ? "" : ": #{snippet}"}")
-        end
+        raise api_error(response.status_code, response.body) unless response.status_code == 200
+        response.body
       ensure
         client.close
       end
@@ -913,11 +1066,29 @@ module Gori
       end
     end
 
+    # Post-download integrity gate: non-empty, matches the size the release
+    # advertised, and matches its sha256 when the API supplied a digest. The
+    # digest is absent on the redirect fallback, where verify_sha256! no-ops.
+    private def self.verify_download!(dest : String, asset : Asset, got : Int64, io : IO) : Nil
+      raise Error.new("downloaded asset is empty: #{asset.name}") unless got > 0
+      if asset.size > 0 && got != asset.size
+        raise Error.new("downloaded size mismatch for #{asset.name}: expected #{asset.size} bytes, got #{got}")
+      end
+      if expected_sha = parse_sha256_digest(asset.digest)
+        io.puts "Verifying sha256 checksum"
+        verify_sha256!(dest, expected_sha, asset.name)
+      end
+    end
+
     def self.update_binary(target_path : String, io : IO = STDOUT, _err : IO = STDERR, *,
                            release_json : String? = nil,
                            api_url : String? = nil,
                            force_progress : Bool = false) : Nil
-      json = release_json || fetch_latest_release_json(api_url)
+      json, via_redirect = if provided = release_json
+                             {provided, false}
+                           else
+                             fetch_latest_release_json_with_fallback(api_url)
+                           end
       release = parse_release(json)
       ver = release.version
       local = normalize_version(VERSION)
@@ -942,6 +1113,14 @@ module Gori
         )
       end
 
+      if via_redirect
+        io.puts "Note: the GitHub release API was unavailable (rate limit or outage);"
+        io.puts "      resolved #{release.tag_name} from #{RELEASES_LATEST_URL} instead."
+        unless parse_sha256_digest(asset.digest)
+          io.puts "      #{release.tag_name} publishes no SHA256SUMS, so sha256 verification is skipped."
+        end
+      end
+
       io.puts "Updating #{VERSION} → #{release.tag_name}"
       size_note = asset.size > 0 ? " (#{format_size(asset.size)})" : ""
       io.puts "Downloading #{asset.name}#{size_note}"
@@ -953,14 +1132,7 @@ module Gori
           expected_size: asset.size,
           progress_io: io,
           force_progress: force_progress)
-        raise Error.new("downloaded asset is empty: #{asset.name}") unless got > 0
-        if asset.size > 0 && got != asset.size
-          raise Error.new("downloaded size mismatch for #{asset.name}: expected #{asset.size} bytes, got #{got}")
-        end
-        if expected_sha = parse_sha256_digest(asset.digest)
-          io.puts "Verifying sha256 checksum"
-          verify_sha256!(dest, expected_sha, asset.name)
-        end
+        verify_download!(dest, asset, got, io)
         io.puts "Downloaded #{format_size(got)} in #{format_duration(started.elapsed)}"
         install_from_download(dest, target_path, asset_is_archive?(asset.name))
       end


### PR DESCRIPTION
## Problem

```
$ curl -fsSL https://gori.hahwul.com/install.sh | bash
gori-install: fetching latest release metadata from https://api.github.com/repos/hahwul/gori/releases/latest
curl: (56) The requested URL returned error: 403
gori-install: error: failed to fetch latest release (is the network up? are releases published?)
```

`api.github.com` allows **60 unauthenticated requests per hour per IP**, and answers `403` once that is spent — shared CI or NAT egress burns it fast. The installer had no fallback, and the error text blamed missing releases, which sends people looking in the wrong place. Releases were fine the whole time.

## Fix

**Three tiers resolve the tag**, most informative first. The API goes first because it is the only tier that returns an asset list to validate against; the redirect is the one that survives a spent quota.

| tier | source | limit | gives |
|---|---|---|---|
| 1 | API + `Authorization` | 5000/h | tag + asset list |
| 2 | API, anonymous | 60/h per IP | tag + asset list |
| 3 | `github.com/<repo>/releases/latest` 302 | none — not the API | tag only |

Tokens come from `GORI_GITHUB_TOKEN` / `GITHUB_TOKEN` / `GH_TOKEN`. The HTTP status is captured so 401 / 403 / 429 / 000 each report their real cause.

`gori update` gets the same treatment, with two gates:
- the redirect fallback only fires for the **default API URL**, so `GORI_UPDATE_API_URL` mock servers stay hermetic
- the token is attached only when the host is **`api.github.com`**, so it never travels to an injected endpoint (covered by a spec)

**Version-less alias assets** (`gori-linux-x86_64`, `gori-osx-arm64.tar.gz`) ship alongside the versioned ones as *copies, not renames* — the Homebrew formula, AUR PKGBUILD and snapcraft recipe all pin the versioned names. Their real value is a stable no-lookup URL for Dockerfiles and CI, now documented. The alias step is `continue-on-error`: a convenience copy must never fail the job and skip the upload step below it, which would ship a release with no assets at all.

**`SHA256SUMS`.** Falling back off the API costs the per-asset digest it advertises, so each release now publishes one aggregated checksums file covering both naming schemes (aggregated rather than per-asset to keep the release page readable). `install.sh` verifies against it — it did **no** checksum check at all before — and the update fallback uses it to populate the digest so `verify_sha256!` still runs.

## Verification

Measured against live GitHub while the quota was genuinely exhausted, and against a local fixture server for the checksum paths.

| scenario | result |
|---|---|
| install.sh, API 403 | falls back, `resolved v0.1.4 via ... (no API call)`, installs |
| install.sh, normal API 200 | output **byte-identical** to before |
| install.sh, bad token → 401 | falls back, installs |
| install.sh, alias retry / both missing | retries alias; clear error when neither exists |
| install.sh, checksum matches | `sha256 verified` |
| **install.sh, checksum mismatch** | **exit 1, nothing installed** |
| install.sh, no SHA256SUMS (today's v0.1.4) | skips with a log line, installs |
| broken network | `curl: (7) …` transport error still surfaces |
| `gori update`, quota 0 | `Already up to date (v0.1.4)` — API 403 but the release still resolved |

`crystal spec`: **3473 examples, 0 failures** (update_spec 68 → 85). Build passes. `crystal tool format --check` clean; ameba introduces no new findings (the 7 that remain are all present on `main`).

## Notes

- Verification is **best-effort by design**: releases predating `SHA256SUMS` have none, and refusing to install those would be a regression. A checksum that *is* present and does *not* match is always fatal.
- The alias URLs and `SHA256SUMS` only exist from the **next** release onward; the docs say so explicitly.
- `fetch_asset_digest`'s HTTP fetch is exercised only on its absent/404 path, since no release ships `SHA256SUMS` yet — the parsing, JSON injection and verification around it are spec-covered. Worth eyeballing that `gori update` prints `Verifying sha256 checksum` after the first release that carries the file.
- Checksums give integrity, not authenticity — an attacker who owns the release can publish a matching one. Same limit already noted in `update.cr`; real authenticity needs signing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)