### PR TITLE
feat(probe): manual unsafe-method opt-in + AGGRESSIVE mode (#342)

### DIFF
--- a/spec/mcp_probe_spec.cr
+++ b/spec/mcp_probe_spec.cr
@@ -88,6 +88,19 @@ describe "MCP probe_scan tool" do
     end
   end
 
+  it "accepts unsafe/aggressive params, inert (not echoed) under a passive scan" do
+    with_store do |store|
+      seed_secret_flow(store)
+      tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+      # active defaults false → the two knobs parse but do nothing and are not echoed.
+      res = call_json(tools, "probe_scan", %({"unsafe":true,"aggressive":true}))
+      res["active"].as_bool.should be_false
+      res.as_h.has_key?("active_unsafe_methods").should be_false
+      res.as_h.has_key?("active_aggressive").should be_false
+      res["issue_count"].as_i.should be > 0 # passive scan still runs normally
+    end
+  end
+
   it "refuses an active scan with an excludes-only scope (no include rule would send anything)" do
     with_store do |store|
       seed_secret_flow(store)

--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -314,6 +314,41 @@ describe Gori::Probe::Active do
     end
   end
 
+  # The equivalence invariant must hold PER-opts: threading allow_unsafe/aggressive into plan and
+  # dedup_key together keeps them from drifting, and the widened method gate / raised caps make the
+  # previously-nil POST + over-cap flows non-nil (so both paths must agree on the SAME non-nil key).
+  it "dedup_key equals plan.dedup_key under allow_unsafe / aggressive opts (both rules)" do
+    with_store do |store|
+      cors_resp = "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: https://app.example\r\n\r\n"
+      plain_resp = "HTTP/1.1 200 OK\r\n\r\n"
+      many = (0..50).map { |i| "p#{i}=v" }.join("&") # 51 params: > MAX_PARAMS, < MAX_PARAMS_AGGRESSIVE
+      unsafe = Gori::Probe::Active::Options.new(allow_unsafe: true)
+      aggr = Gori::Probe::Active::Options.new(allow_unsafe: true, aggressive: true)
+
+      reflected = Gori::Probe::Active::ReflectedParam.new
+      cors = Gori::Probe::Active::CorsReflection.new
+
+      post = capture_flow(store, plain_resp, host: "t.example", target: "/a?x=1&y=2", method: "POST")
+      put = capture_flow(store, cors_resp, host: "t.example", target: "/cors", method: "PUT")
+      wide = capture_flow(store, plain_resp, host: "t.example", target: "/many?#{many}", method: "POST")
+
+      # allow_unsafe widens the method gate: a POST/PUT is now planned, and both paths agree.
+      reflected.plan(post, unsafe).should_not be_nil
+      reflected.dedup_key(post, unsafe).should eq(reflected.plan(post, unsafe).try(&.dedup_key))
+      cors.plan(put, unsafe).should_not be_nil
+      cors.dedup_key(put, unsafe).should eq(cors.plan(put, unsafe).try(&.dedup_key))
+
+      # A 51-param POST: nil under allow_unsafe alone (over MAX_PARAMS), non-nil under aggressive.
+      reflected.plan(wide, unsafe).should be_nil
+      reflected.plan(wide, aggr).should_not be_nil
+      reflected.dedup_key(wide, aggr).should eq(reflected.plan(wide, aggr).try(&.dedup_key))
+
+      # Default opts leave the POST unprobed (automatic-pipeline behaviour unchanged).
+      reflected.plan(post).should be_nil
+      cors.plan(put).should be_nil
+    end
+  end
+
   it "normalizes an absolute-form target to origin-form, preserving a query on a PATHLESS URI" do
     # The authority ends at the first '/', '?' or '#': a pathless absolute-URI carrying a query
     # must keep it (was collapsed to "/", silently dropping the reflectable surface), and a '/'
@@ -364,6 +399,35 @@ describe Gori::Probe::Analyzer do
       b = Gori::Probe::Analyzer.new(store, scope, feed2, Gori::Probe::Mode::Passive, true)
       b.start
       b.set_mode(Gori::Probe::Mode::Active)
+      sleep 50.milliseconds
+      b.stop
+    end
+  end
+
+  # AGGRESSIVE drives the SAME automatic pipeline as ACTIVE (probes_actively?), but with widened
+  # Options (unsafe methods + raised caps). It stays scope-gated. No network assert — the queue may
+  # drop and sends to acme.test won't resolve; this verifies the pipeline re-arms and persists the
+  # mode without raising over an in-scope unsafe-method (POST) flow.
+  it "AGGRESSIVE mode re-arms the pipeline + persists over an in-scope POST flow" do
+    with_store do |store|
+      capture_flow(store, "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n",
+        target: "/submit?q=hi", method: "POST", body: "<p>hi</p>")
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "acme.test")
+
+      # start already in AGGRESSIVE (persisted project) — backfill path over the POST
+      feed = Channel(Gori::Store::FlowEvent).new(8)
+      a = Gori::Probe::Analyzer.new(store, scope, feed, Gori::Probe::Mode::Aggressive, true)
+      a.start
+      sleep 50.milliseconds
+      a.stop
+
+      # ACTIVE → AGGRESSIVE transition mid-session re-arms and persists the new mode.
+      feed2 = Channel(Gori::Store::FlowEvent).new(8)
+      b = Gori::Probe::Analyzer.new(store, scope, feed2, Gori::Probe::Mode::Active, true)
+      b.start
+      b.set_mode(Gori::Probe::Mode::Aggressive)
+      store.probe_mode.should eq(Gori::Probe::Mode::Aggressive)
       sleep 50.milliseconds
       b.stop
     end
@@ -539,8 +603,25 @@ describe Gori::Probe::Mode do
   it "round-trips its label and cycles" do
     Gori::Probe::Mode.from_setting("off").should eq(Gori::Probe::Mode::Off)
     Gori::Probe::Mode.from_setting(nil).should eq(Gori::Probe::Mode::Passive)
+    Gori::Probe::Mode.from_setting("aggressive").should eq(Gori::Probe::Mode::Aggressive)
     Gori::Probe::Mode::Off.cycle.should eq(Gori::Probe::Mode::Passive)
-    Gori::Probe::Mode::Active.cycle.should eq(Gori::Probe::Mode::Off)
+    # OFF → PASSIVE → ACTIVE → AGGRESSIVE → OFF
+    Gori::Probe::Mode::Active.cycle.should eq(Gori::Probe::Mode::Aggressive)
+    Gori::Probe::Mode::Aggressive.cycle.should eq(Gori::Probe::Mode::Off)
+  end
+
+  it "persists and reloads Aggressive" do
+    with_store do |store|
+      store.set_probe_mode(Gori::Probe::Mode::Aggressive)
+      store.probe_mode.should eq(Gori::Probe::Mode::Aggressive)
+    end
+  end
+
+  it "probes_actively? covers Active and Aggressive only" do
+    Gori::Probe::Mode::Off.probes_actively?.should be_false
+    Gori::Probe::Mode::Passive.probes_actively?.should be_false
+    Gori::Probe::Mode::Active.probes_actively?.should be_true
+    Gori::Probe::Mode::Aggressive.probes_actively?.should be_true
   end
 end
 
@@ -1412,10 +1493,29 @@ describe "Gori::Probe::Active::ForbiddenBypass" do
       probe.plan(forbidden).should_not be_nil
       unauth = capture_flow(store, "HTTP/1.1 401 Unauthorized\r\n\r\n", target: "/admin", status: 401, content_type: nil)
       probe.plan(unauth).should_not be_nil
-      # A POST is never probed (no auto state mutation) even when denied.
+      # A POST is never probed (no auto state mutation) even when denied…
       post = capture_flow(store, "HTTP/1.1 403 Forbidden\r\n\r\n", target: "/admin", status: 403,
         method: "POST", content_type: nil)
       probe.plan(post).should be_nil
+      # …unless the caller opts into unsafe methods (manual per-flow scan / AGGRESSIVE mode).
+      unsafe = Gori::Probe::Active::Options.new(allow_unsafe: true)
+      probe.plan(post, unsafe).should_not be_nil
+      probe.dedup_key(post, unsafe).should eq(probe.plan(post, unsafe).try(&.dedup_key))
+    end
+  end
+
+  it "uses the wider bypass-header set under aggressive opts (still one request)" do
+    with_store do |store|
+      forbidden = capture_flow(store, "HTTP/1.1 403 Forbidden\r\n\r\n", target: "/admin", status: 403, content_type: nil)
+      base = String.new(probe.plan(forbidden).not_nil!.request)
+      aggr = String.new(probe.plan(forbidden, Gori::Probe::Active::Options.new(aggressive: true)).not_nil!.request)
+      # The extra headers appear only in the aggressive probe; the base set is present in both.
+      Gori::Probe::Active::ForbiddenBypass::BYPASS_HEADERS_EXTRA.each do |name|
+        base.should_not contain("\r\n#{name}: ")
+        aggr.scan("\r\n#{name}: 127.0.0.1").size.should eq(1), "expected exactly one #{name} (aggressive)"
+      end
+      # Still a single request (a wider header set, not more probes).
+      probe.plan(forbidden, Gori::Probe::Active::Options.new(aggressive: true)).not_nil!.followups.should be_empty
     end
   end
 
@@ -1586,14 +1686,31 @@ describe "Gori::Probe::Active::NginxAliasTraversal" do
       end
     end
   end
+
+  it "widens to non-GET body methods under allow_unsafe, but never HEAD" do
+    with_store do |store|
+      unsafe = Gori::Probe::Active::Options.new(allow_unsafe: true)
+      post = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", scheme: "http", host: "t.example",
+        target: "/static/main.css", method: "POST", status: 200, content_type: "text/css")
+      probe.plan(post).should be_nil             # GET-only by default
+      probe.plan(post, unsafe).should_not be_nil # body-differential still works on a POST
+      probe.dedup_key(post, unsafe).should eq(probe.plan(post, unsafe).try(&.dedup_key))
+      # HEAD has no body to diff — excluded even with allow_unsafe.
+      head = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", scheme: "http", host: "t.example",
+        target: "/static/main.css", method: "HEAD", status: 200, content_type: "text/css")
+      probe.plan(head, unsafe).should be_nil
+    end
+  end
 end
 
 describe "Gori::Probe::Active (safety + coverage)" do
-  it "does not probe mutating methods (POST), only safe ones (GET)" do
+  it "does not probe mutating methods (POST) by default, but opts-in widens it" do
     with_store do |store|
       post = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/comment", method: "POST",
         req_headers: "Content-Type: application/x-www-form-urlencoded\r\n", req_body: "text=hi", content_type: nil)
-      Gori::Probe::Active.plan(post).should be_nil
+      Gori::Probe::Active.plan(post).should be_nil # automatic pipeline (default opts) never mutates
+      # The manual opt-in / AGGRESSIVE mode probes the reflectable form params on the POST.
+      Gori::Probe::Active.plan(post, Gori::Probe::Active::Options.new(allow_unsafe: true)).should_not be_nil
       get = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=hi", content_type: nil)
       Gori::Probe::Active.plan(get).should_not be_nil
     end
@@ -2235,12 +2352,16 @@ describe "Gori::Probe::Active (manual run estimate)" do
     with_store do |store|
       a = Gori::Probe::Analyzer.new(store, Gori::Scope.load(store),
         Channel(Gori::Store::FlowEvent).new(1), Gori::Probe::Mode::Passive, true)
-      # POST is never probed (no safe method).
+      # POST is never probed under the default (safe-only) estimate…
       post = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/x?q=1", method: "POST")
       a.active_estimate(post).should be_empty
-      # GET with no params + no ACAO has nothing to test.
+      # …but the allow_unsafe estimate (the run popup's opt-in) surfaces the reflectable-param check.
+      unsafe_est = a.active_estimate(post, Gori::Probe::Active::Options.new(allow_unsafe: true))
+      unsafe_est.map(&.info.id).should contain("reflected_param")
+      # GET with no params + no ACAO has nothing to test, opt-in or not.
       bare = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/nothing")
       a.active_estimate(bare).should be_empty
+      a.active_estimate(bare, Gori::Probe::Active::Options.new(allow_unsafe: true)).should be_empty
     end
   end
 
@@ -2256,6 +2377,9 @@ describe "Gori::Probe::Active (manual run estimate)" do
         # Every notify mode; sends to acme.test won't resolve, so the error is swallowed and the
         # Always completion is suppressed (errored run — verified by not raising).
         Gori::Miner::NotifyMode.values.each { |n| a.run_active_now(detail, notify: n) }
+        # The unsafe-method opt-in path must also run without raising (a POST manual scan).
+        post = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/x?q=1", method: "POST")
+        a.run_active_now(post, allow_unsafe: true)
         sleep 50.milliseconds
         a.stop
       end
@@ -2298,6 +2422,28 @@ describe "Gori::Probe::Active::BackslashPowered" do
       probe.plan(capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=1", method: "POST")).should be_nil
       probe.plan(capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=1", method: "HEAD")).should be_nil
       probe.plan(capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s")).should be_nil
+    end
+  end
+
+  it "plans a POST query param under allow_unsafe, but never HEAD (no body to diff)" do
+    with_store do |store|
+      unsafe = Gori::Probe::Active::Options.new(allow_unsafe: true)
+      post = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=1", method: "POST")
+      probe.plan(post, unsafe).not_nil!.params.map(&.name).should eq(["q"])
+      probe.dedup_key(post, unsafe).should eq(probe.plan(post, unsafe).try(&.dedup_key))
+      probe.plan(capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=1", method: "HEAD"), unsafe).should be_nil
+      # A paramless request still has nothing to inject even under the opt-in.
+      probe.plan(capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s", method: "POST"), unsafe).should be_nil
+    end
+  end
+
+  it "raises the param cap under aggressive opts" do
+    with_store do |store|
+      wide = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?" + (0...6).map { |i| "p#{i}=v" }.join("&"))
+      # Default: capped at MAX_PROBE_PARAMS (3).
+      probe.plan(wide).not_nil!.params.size.should eq(Gori::Probe::Active::BackslashPowered::MAX_PROBE_PARAMS)
+      # Aggressive: all 6 params probed (< MAX_PROBE_PARAMS_AGGRESSIVE).
+      probe.plan(wide, Gori::Probe::Active::Options.new(aggressive: true)).not_nil!.params.size.should eq(6)
     end
   end
 

--- a/spec/tui/probe_active_overlay_spec.cr
+++ b/spec/tui/probe_active_overlay_spec.cr
@@ -1,0 +1,88 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+private def tmp_store(&)
+  path = File.tempname("gori-pao", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def flow(store, method, target) : Gori::Store::FlowDetail
+  id = store.insert_flow(Gori::Store::CapturedRequest.new(
+    created_at: 1_i64, scheme: "http", host: "h.test", port: 80,
+    method: method, target: target, http_version: "HTTP/1.1",
+    head: "#{method} #{target} HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice, body: nil))
+  store.update_response(Gori::Store::CapturedResponse.new(
+    flow_id: id, status: 200, head: "HTTP/1.1 200 OK\r\n\r\n".to_slice, content_type: "text/html"))
+  store.get_flow(id).not_nil!
+end
+
+private def est(id : String) : Gori::Probe::Analyzer::ActiveEstimate
+  info = Gori::Probe::RuleInfo.new(id, id, "desc", Gori::Probe::Category::ACTIVE)
+  Gori::Probe::Analyzer::ActiveEstimate.new(info, 1..1)
+end
+
+describe Gori::Tui::ProbeActiveOverlay do
+  it "hides the unsafe row when safe and unsafe estimates match (GET flow)" do
+    tmp_store do |store|
+      d = flow(store, "GET", "/s?q=1")
+      same = [est("reflected_param")]
+      ov = ProbeActiveOverlay.new(d, same, same)
+      # rows: [0]=notify, [1]=run — no unsafe opt-in offered.
+      ov.on_run_row?.should be_true # starts on Run
+      ov.allow_unsafe?.should be_false
+      ov.estimate_empty?.should be_false
+      ov.move(-1) # notify row
+      ov.on_run_row?.should be_false
+      ov.move(-1) # clamped — there is no unsafe row to land on
+      ov.on_run_row?.should be_false
+    end
+  end
+
+  it "offers an off-by-default unsafe opt-in for an unsafe-method flow (POST)" do
+    tmp_store do |store|
+      d = flow(store, "POST", "/submit?q=1")
+      safe = [] of Gori::Probe::Analyzer::ActiveEstimate # nothing runs safe-only on a POST
+      unsafe = [est("reflected_param")]                  # the opt-in surfaces the reflected-param check
+      ov = ProbeActiveOverlay.new(d, safe, unsafe)
+
+      # Default: opt-in OFF, so the safe (empty) estimate is selected → nothing to send.
+      ov.allow_unsafe?.should be_false
+      ov.estimate_empty?.should be_true
+
+      # rows: [0]=notify, [1]=unsafe, [2]=run. Move onto the unsafe row and flip it on.
+      ov.move(-1) # from Run(2) → unsafe(1)
+      ov.toggle
+      ov.allow_unsafe?.should be_true
+      ov.estimate_empty?.should be_false # the widened estimate now has a check to send
+      ov.total_label.should eq("1 request")
+
+      # ‹/› also toggles it back off.
+      ov.adjust(-1)
+      ov.allow_unsafe?.should be_false
+    end
+  end
+
+  it "renders without crashing and hit-tests all three rows for a POST flow" do
+    tmp_store do |store|
+      d = flow(store, "POST", "/submit?q=1")
+      ov = ProbeActiveOverlay.new(d, [] of Gori::Probe::Analyzer::ActiveEstimate, [est("reflected_param")])
+      screen = Screen.new(MemoryBackend.new(80, 24))
+      area = Rect.new(0, 0, 80, 24)
+      ov.render(screen, area)
+      box = ov.overlay_box(area).not_nil!
+      # notify + unsafe + run are all hit-testable (row_at maps their y bands to 0/1/2).
+      rows = (box.y...box.bottom).compact_map { |y| ov.row_at(box, box.x + 3, y) }.uniq!.sort!
+      rows.should eq([0, 1, 2])
+    end
+  end
+end

--- a/src/gori/cli/run/probe.cr
+++ b/src/gori/cli/run/probe.cr
@@ -14,6 +14,8 @@ module Gori
         format = :text
         active = false
         allow_unscoped = false
+        unsafe = false
+        aggressive = false
         positional = [] of String
 
         parser = OptionParser.new do |p|
@@ -30,6 +32,8 @@ module Gori
           p.on("--category=CAT", "Only show issues in CAT (#{PROBE_CATEGORIES.join("|")})") { |v| category = parse_probe_category(v) }
           p.on("-a", "--active", "Include light-touch active checks (sends probe requests)") { active = true }
           p.on("--allow-unscoped", "With --active, probe flows even when outside the project scope (default: only scope-included hosts)") { allow_unscoped = true }
+          p.on("--unsafe", "With --active, ALSO probe unsafe methods (POST/PUT/PATCH/DELETE) — re-sends may mutate server data") { unsafe = true }
+          p.on("--aggressive", "With --active, raise per-rule caps + wider bypass sets (implies --unsafe)") { aggressive = true }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args { |rest, _| positional = rest }
@@ -73,8 +77,10 @@ module Gori
             abort "gori run probe: query #{truncate_query(query).inspect} failed: #{ex.message}"
           end
           meter = STDERR.tty?
+          # --aggressive implies --unsafe (it also raises caps + widens bypass sets).
+          opts = Probe::Active::Options.new(allow_unsafe: unsafe || aggressive, aggressive: aggressive)
           dets, rn = Probe::Scan.scan_all(store, ids, active: active, scope: scope,
-            allow_unscoped: allow_unscoped, progress: probe_progress_meter(meter))
+            allow_unscoped: allow_unscoped, opts: opts, progress: probe_progress_meter(meter))
           STDERR.print "\r\e[K" if meter # clear the in-place meter before the summary line
           {Probe.group(dets), ids.size, rn}
         ensure

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -527,6 +527,8 @@ module Gori
             s.field "severity", strprop("only return issues at/above this level (info|low|medium|high|critical)")
             s.field "category", strprop("only return issues in this category (#{Probe::SCAN_CATEGORIES.join("|")})")
             s.field "allow_unscoped", boolprop("with active:true, run even when a target host is outside — or without — a configured scope (default false)")
+            s.field "unsafe", boolprop("with active:true, ALSO probe unsafe methods (POST/PUT/PATCH/DELETE) — re-sends may mutate server data (default false)")
+            s.field "aggressive", boolprop("with active:true, raise per-rule caps + use wider bypass sets (implies unsafe) — authorized targets only (default false)")
             s.field "limit", intprop("max issue groups to return (default 200, max 2000)")
           end
 

--- a/src/gori/mcp/tools/probe.cr
+++ b/src/gori/mcp/tools/probe.cr
@@ -27,21 +27,25 @@ module Gori
 
         active = bool(h, "active") || false
         allow_unscoped = bool(h, "allow_unscoped") || false
+        # --aggressive implies unsafe (it also raises caps + widens bypass sets).
+        aggressive = bool(h, "aggressive") || false
+        unsafe = (bool(h, "unsafe") || false) || aggressive
         gate = probe_active_gate(active, allow_unscoped)
         return gate if gate.is_a?(Result)
         scope, scope_configured = gate
 
+        opts = Probe::Active::Options.new(allow_unsafe: unsafe, aggressive: aggressive)
         ids = Probe::Scan.flow_ids(store, filter)
         # Cap only the ACTIVE sends (network volume); the request-free PASSIVE scan always
         # covers every flow. (An earlier version truncated `ids`, which silently dropped
         # passive coverage of the newest flows under active:true.)
         capped = active && ids.size > PROBE_ACTIVE_MAX_FLOWS
         dets, repeater_n = Probe::Scan.scan_all(store, ids, active: active, verify_upstream: @verify_upstream,
-          scope: scope, allow_unscoped: allow_unscoped, active_limit: active ? PROBE_ACTIVE_MAX_FLOWS : nil)
+          scope: scope, allow_unscoped: allow_unscoped, opts: opts, active_limit: active ? PROBE_ACTIVE_MAX_FLOWS : nil)
 
         groups = probe_filter_groups(Probe.group(dets), severity_from(str(h, "severity")), category.as(String?))
         Result.new(probe_scan_json(groups, ids.size, repeater_n, active, allow_unscoped,
-          scope_configured, capped, clamp(int(h, "limit"), 200, 2000)))
+          scope_configured, capped, unsafe, aggressive, clamp(int(h, "limit"), 200, 2000)))
       end
 
       # The QL filter (History only; blank/absent → nil = scan all), or a QUERY_SYNTAX Result.
@@ -86,7 +90,7 @@ module Gori
 
       private def probe_scan_json(groups : Array(Probe::Group), flows_scanned : Int32, repeater_n : Int32,
                                   active : Bool, allow_unscoped : Bool, scope_configured : Bool,
-                                  capped : Bool, limit : Int32) : String
+                                  capped : Bool, unsafe : Bool, aggressive : Bool, limit : Int32) : String
         JSON.build do |j|
           j.object do
             j.field "flows_scanned", flows_scanned
@@ -96,6 +100,8 @@ module Gori
               j.field "scope_configured", scope_configured
               j.field "active_scope_gated", !allow_unscoped # per-flow include-filter applied unless bypassed
               j.field "active_flows_capped", true if capped
+              j.field "active_unsafe_methods", true if unsafe # POST/PUT/PATCH/DELETE re-sent
+              j.field "active_aggressive", true if aggressive # raised caps + wider bypass sets
             end
             j.field "issue_count", groups.size
             j.field("issues") { j.array { groups.first(limit).each { |g| Probe.group_json(j, g) } } }

--- a/src/gori/probe/active.cr
+++ b/src/gori/probe/active.cr
@@ -21,12 +21,12 @@ module Gori
 
       # Convenience facade over the primary (reflected-param) rule. The analyzer drives the
       # whole RULES list; these keep a stable single-rule entry point for callers/tests.
-      def self.dedup_key(detail : Store::FlowDetail) : String?
-        PRIMARY.dedup_key(detail)
+      def self.dedup_key(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : String?
+        PRIMARY.dedup_key(detail, opts)
       end
 
-      def self.plan(detail : Store::FlowDetail) : Plan?
-        PRIMARY.plan(detail)
+      def self.plan(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : Plan?
+        PRIMARY.plan(detail, opts)
       end
 
       def self.detections(plan : Plan, result : Repeater::Result, detail : Store::FlowDetail) : Array(Detection)
@@ -44,9 +44,10 @@ module Gori
       # explicit exclude rule HARD-blocks the probe at the socket seam (PR #322's protection for
       # Fuzz/Miner) even when the caller bypassed its own include gate (--allow-unscoped).
       # `backend` overrides the default Fuzz::Sender so specs can drive the rules without a socket.
+      # `opts` widens the method gate / raises caps (manual unsafe opt-in, AGGRESSIVE mode).
       def self.analyze(detail : Store::FlowDetail, verify_upstream : Bool = true,
                        timeout : Time::Span = 10.seconds, scope : Scope? = nil,
-                       backend : Fuzz::Backend? = nil) : Array(Detection)
+                       backend : Fuzz::Backend? = nil, opts : Options = Options::DEFAULT) : Array(Detection)
         out = [] of Detection
         row = detail.row
         origin = Fuzz::Origin.new(row.scheme, row.host, row.port)
@@ -55,7 +56,7 @@ module Gori
         sender = scope ? Fuzz::ScopedBackend.new(base, scope) : base
 
         RULES.each do |rule|
-          plan = rule.plan(detail)
+          plan = rule.plan(detail, opts)
           next unless plan
           result = sender.send(plan.request)
           next unless result.ok?

--- a/src/gori/probe/active/backslash_powered.cr
+++ b/src/gori/probe/active/backslash_powered.cr
@@ -28,13 +28,17 @@ module Gori
       #
       # This is the active scanner's first DIFFERENTIAL (multi-probe) rule: `plan` builds a baseline
       # plus a `\`/`\\` pair per param into `Plan.followups`, the analyzer sends them all, and
-      # `detections_all` compares the responses. Gated to GET (the differential compares BODIES, so
-      # HEAD is out, and POST/PUT/… are never auto-probed — they mutate state) and capped at
-      # MAX_PROBE_PARAMS params so a wide query can't blow up the request count.
+      # `detections_all` compares the responses. The differential compares BODIES, so HEAD is always
+      # out; by default GET only (POST/PUT/… are never auto-probed — they mutate state), but an
+      # explicit opt-in (Options#allow_unsafe: the manual per-flow scan or AGGRESSIVE mode) widens
+      # it to any body-bearing method. Capped at MAX_PROBE_PARAMS params (raised under AGGRESSIVE)
+      # so a wide query can't blow up the request count.
       class BackslashPowered < Rule
         # Probe at most this many params per flow (in query order). Bounds the request count and
         # keeps the automatic scan light-touch; a wider query is still covered for its first params.
-        MAX_PROBE_PARAMS = 3
+        # AGGRESSIVE (opts.aggressive) raises the cap for deeper coverage on an authorized target.
+        MAX_PROBE_PARAMS            =  3
+        MAX_PROBE_PARAMS_AGGRESSIVE = 10
 
         # Appended (URL-encoded, so it decodes to a real backslash server-side) to a param's value.
         SINGLE = "%5C"    # one backslash  →  value\
@@ -57,15 +61,15 @@ module Gori
         # Dedup key WITHOUT rebuilding probes — derived from the same `injectables` gate `plan` uses,
         # so it is byte-identical to `plan(detail).dedup_key` and nil in exactly the same cases
         # (verified by the equivalence spec).
-        def dedup_key(detail : Store::FlowDetail) : String?
-          g = injectables(detail)
+        def dedup_key(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : String?
+          g = injectables(detail, opts)
           return nil unless g
           method_up, path, pairs, probe = g
           build_dedup_key(detail, method_up, path, probe.map { |i| decode_name(pair_name(pairs[i])) })
         end
 
-        def plan(detail : Store::FlowDetail) : Plan?
-          g = injectables(detail)
+        def plan(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : Plan?
+          g = injectables(detail, opts)
           return nil unless g
           method_up, path, pairs, probe = g
           body = detail.request_body
@@ -124,15 +128,18 @@ module Gori
         # Shared gate for plan + dedup_key so the two can't drift (equivalence-spec invariant).
         # Returns {METHOD, path, all query pairs verbatim, indices of the first ≤MAX_PROBE_PARAMS
         # pairs that are real k=v params} for a GET carrying ≥1 such param, else nil.
-        private def injectables(detail : Store::FlowDetail) : {String, String, Array(String), Array(Int32)}?
+        private def injectables(detail : Store::FlowDetail, opts : Options) : {String, String, Array(String), Array(Int32)}?
           method, target, malformed = Proxy::Codec::Http1.parse_request_line(detail.request_head)
           return nil if malformed
           method_up = method.upcase
-          # GET only: the differential compares response bodies (HEAD has none) and the active scan
-          # never auto-re-sends a state-changing method (SAFE_METHODS is GET/HEAD; we keep GET).
-          return nil unless method_up == "GET"
+          # Body-differential gate: the comparison reads response BODIES (HEAD has none), so HEAD is
+          # always out. By default GET only — the automatic scan never auto-re-sends a state-changing
+          # method — but opts.allow_unsafe (manual per-flow scan / AGGRESSIVE mode) widens to
+          # POST/PUT/PATCH/DELETE, whose query params can still be interpreted server-side.
+          return nil unless diff_method_allowed?(method_up, opts)
           path, query = split_target(Active.origin_form(target))
           return nil if query.empty?
+          cap = opts.aggressive ? MAX_PROBE_PARAMS_AGGRESSIVE : MAX_PROBE_PARAMS
           pairs = query.split('&')
           probe = [] of Int32
           pairs.each_with_index do |pair, i|
@@ -141,7 +148,7 @@ module Gori
             next unless eq
             next if pair[0...eq].empty?
             probe << i
-            break if probe.size >= MAX_PROBE_PARAMS
+            break if probe.size >= cap
           end
           return nil if probe.empty?
           {method_up, path, pairs, probe}

--- a/src/gori/probe/active/cors_reflection.cr
+++ b/src/gori/probe/active/cors_reflection.cr
@@ -29,12 +29,12 @@ module Gori
 
         # The dedup key WITHOUT rebuilding the probe request — same gates as `plan` (safe method,
         # response already did CORS), same key. nil exactly when `plan` returns nil.
-        def dedup_key(detail : Store::FlowDetail) : String?
+        def dedup_key(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : String?
           # Request headers are never needed here (the key is method + target only), so parse
           # just the start-line. The RESPONSE head parse below IS required and stays.
           method, target, malformed = Proxy::Codec::Http1.parse_request_line(detail.request_head)
           return nil if malformed
-          return nil unless SAFE_METHODS.includes?(method.upcase)
+          return nil unless method_allowed?(method.upcase, opts)
           rhead = detail.response_head
           return nil unless rhead
           resp = Proxy::Codec::Http1.parse_response_head(rhead)
@@ -42,10 +42,10 @@ module Gori
           key_string(detail, method.upcase, target)
         end
 
-        def plan(detail : Store::FlowDetail) : Plan?
+        def plan(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : Plan?
           req = Proxy::Codec::Http1.parse_request_head(detail.request_head)
           return nil if req.malformed?
-          return nil unless SAFE_METHODS.includes?(req.method.upcase)
+          return nil unless method_allowed?(req.method.upcase, opts)
           # Only probe endpoints that demonstrably do CORS (response already carried an ACAO).
           rhead = detail.response_head
           return nil unless rhead

--- a/src/gori/probe/active/forbidden_bypass.cr
+++ b/src/gori/probe/active/forbidden_bypass.cr
@@ -52,27 +52,48 @@ module Gori
           X-Custom-IP-Authorization
         ]
 
-        # Downcased names, for dropping any the browser already sent (so we insert exactly one of
-        # each and the forged value can't be diluted by a second header line).
-        BYPASS_HEADER_SET = BYPASS_HEADERS.map(&.downcase).to_set
+        # Additional client-IP / host-claim headers used ONLY in AGGRESSIVE mode (opts.aggressive):
+        # a wider set trades noise for coverage on an authorized target. Still sent in the SAME
+        # single request (1 req/flow) — a wider set, not more requests. Every entry sensibly carries
+        # BYPASS_VALUE (127.0.0.1) as a bare IP/host claim, so this rule's one flat value stays
+        # valid — path-rewrite headers (X-Original-URL, …) belong to a different probe, not here.
+        BYPASS_HEADERS_EXTRA = %w[
+          X-Forwarded-Host
+          X-Host
+          X-Forwarded-Server
+          CF-Connecting-IP
+          Fastly-Client-IP
+          X-Azure-ClientIP
+          X-Azure-SocketIP
+          X-Appengine-User-Ip
+        ]
 
-        # The dedup key WITHOUT rebuilding the probe — same gates as `plan` (safe method, response
-        # was 401/403), same key. nil exactly when `plan` returns nil. Both gates read
+        # The aggressive superset (base + extra), in a stable order for deterministic probes.
+        BYPASS_HEADERS_AGGRESSIVE = BYPASS_HEADERS + BYPASS_HEADERS_EXTRA
+
+        # Downcased names, for dropping any the browser already sent (so we insert exactly one of
+        # each and the forged value can't be diluted by a second header line). One set per header
+        # list; the rebuild drops EXACTLY the set it is about to insert (never a header it won't).
+        BYPASS_HEADER_SET            = BYPASS_HEADERS.map(&.downcase).to_set
+        BYPASS_HEADER_SET_AGGRESSIVE = BYPASS_HEADERS_AGGRESSIVE.map(&.downcase).to_set
+
+        # The dedup key WITHOUT rebuilding the probe — same gates as `plan` (eligible method,
+        # response was 401/403), same key. nil exactly when `plan` returns nil. Both gates read
         # detail.row.status (not a header re-parse), so the two paths cannot drift.
-        def dedup_key(detail : Store::FlowDetail) : String?
+        def dedup_key(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : String?
           method, target, malformed = Proxy::Codec::Http1.parse_request_line(detail.request_head)
           return nil if malformed
-          return nil unless SAFE_METHODS.includes?(method.upcase)
+          return nil unless method_allowed?(method.upcase, opts)
           return nil unless denied_status?(detail.row.status)
           key_string(detail, method.upcase, target)
         end
 
-        def plan(detail : Store::FlowDetail) : Plan?
+        def plan(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : Plan?
           req = Proxy::Codec::Http1.parse_request_head(detail.request_head)
           return nil if req.malformed?
-          return nil unless SAFE_METHODS.includes?(req.method.upcase)
+          return nil unless method_allowed?(req.method.upcase, opts)
           return nil unless denied_status?(detail.row.status)
-          request = rebuild_with_bypass_headers(detail.request_head, detail.request_body)
+          request = rebuild_with_bypass_headers(detail.request_head, detail.request_body, opts.aggressive)
           Plan.new(request, [] of Param, key_string(detail, req.method.upcase, req.target))
         end
 
@@ -126,8 +147,10 @@ module Gori
         # Rebuild the request with the full IP-spoofing header set inserted right after the request
         # line: first drop any of those headers the browser already sent (so exactly one authoritative
         # copy of each remains), then insert ours. The body is untouched — none of the inserted names
-        # is Content-Length — so no resync is needed.
-        private def rebuild_with_bypass_headers(head : Bytes, body : Bytes?) : Bytes
+        # is Content-Length — so no resync is needed. `aggressive` selects the wider header set.
+        private def rebuild_with_bypass_headers(head : Bytes, body : Bytes?, aggressive : Bool) : Bytes
+          headers = aggressive ? BYPASS_HEADERS_AGGRESSIVE : BYPASS_HEADERS
+          drop_set = aggressive ? BYPASS_HEADER_SET_AGGRESSIVE : BYPASS_HEADER_SET
           combined = if body && !body.empty?
                        io = IO::Memory.new(head.size + body.size)
                        io.write(head)
@@ -140,7 +163,7 @@ module Gori
           lines = String.new(hbytes).split(eol)
           kept = [] of String
           lines.each_with_index do |l, i|
-            next if i > 0 && bypass_header?(l) # request line (i == 0) is normalized below
+            next if i > 0 && bypass_header?(l, drop_set) # request line (i == 0) is normalized below
             kept << l
           end
           # Normalize an absolute-form (forward-proxy) request line to origin-form: like the other
@@ -150,7 +173,7 @@ module Gori
           unless kept.empty?
             rl = kept[0].split(' ')
             kept[0] = "#{rl[0]} #{Active.origin_form(rl[1])} #{rl[2]}" if rl.size == 3
-            BYPASS_HEADERS.each_with_index { |name, i| kept.insert(1 + i, "#{name}: #{BYPASS_VALUE}") }
+            headers.each_with_index { |name, i| kept.insert(1 + i, "#{name}: #{BYPASS_VALUE}") }
           end
           io = IO::Memory.new
           io << kept.join(eol) << eol << eol
@@ -158,8 +181,8 @@ module Gori
           io.to_slice
         end
 
-        private def bypass_header?(line : String) : Bool
-          (c = line.index(':')) ? BYPASS_HEADER_SET.includes?(line[0...c].strip.downcase) : false
+        private def bypass_header?(line : String, drop_set : Set(String)) : Bool
+          (c = line.index(':')) ? drop_set.includes?(line[0...c].strip.downcase) : false
         end
       end
     end

--- a/src/gori/probe/active/nginx_alias_traversal.cr
+++ b/src/gori/probe/active/nginx_alias_traversal.cr
@@ -25,8 +25,10 @@ module Gori
       # the confirmation, so a normal 404/redirect/different-page can't produce a false positive.
       #
       # Gated hard to stay quiet and low-FP:
-      #   * GET only — the confirmation compares response BODIES, and HEAD returns none. (A safe,
-      #     idempotent re-read of a resource the browser already fetched — never a mutation.)
+      #   * GET by default — the confirmation compares response BODIES, and HEAD returns none (a
+      #     safe, idempotent re-read of a resource the browser already fetched). An explicit opt-in
+      #     (Options#allow_unsafe: manual per-flow scan / AGGRESSIVE) widens to other body-bearing
+      #     methods; HEAD stays out regardless.
       #   * 2xx captured status — there must be a real served resource to re-fetch.
       #   * Non-HTML content type — a SPA / framework catch-all returns the SAME index.html for
       #     ANY path, so an HTML baseline could byte-match the traversal path WITHOUT any alias
@@ -43,13 +45,13 @@ module Gori
 
         # The dedup key WITHOUT rebuilding the probe — same gates as `plan`, same key (nil in
         # exactly the same cases). Both funnel through `gate`, so the two paths cannot drift.
-        def dedup_key(detail : Store::FlowDetail) : String?
-          g = gate(detail) || return nil
+        def dedup_key(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : String?
+          g = gate(detail, opts) || return nil
           key_string(detail, g[0], g[1])
         end
 
-        def plan(detail : Store::FlowDetail) : Plan?
-          g = gate(detail) || return nil
+        def plan(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : Plan?
+          g = gate(detail, opts) || return nil
           method_up, path_key = g
           # Rebuild from the ORIGIN-FORM target (query kept, so we re-fetch the exact resource);
           # `traversal_target` re-derives the same leading segment `gate` validated.
@@ -86,11 +88,14 @@ module Gori
         # The shared gate both `plan` and `dedup_key` funnel through, returning
         # {method_upcase, path-without-query} or nil. Cheap: only the start line + FlowRow fields
         # (status / content_type), no header re-parse.
-        private def gate(detail : Store::FlowDetail) : {String, String}?
+        private def gate(detail : Store::FlowDetail, opts : Options) : {String, String}?
           method, target, malformed = Proxy::Codec::Http1.parse_request_line(detail.request_head)
           return nil if malformed
           method_up = method.upcase
-          return nil unless method_up == "GET" # need a body to byte-compare; HEAD has none
+          # Body-differential: need a body to byte-compare, so HEAD is always out. By default GET
+          # only; opts.allow_unsafe (manual per-flow scan / AGGRESSIVE) widens to any body-bearing
+          # method — a static asset gated behind POST/etc. can still leak via the alias boundary.
+          return nil unless diff_method_allowed?(method_up, opts)
           status = detail.row.status
           return nil unless status && (200..299).includes?(status)
           ct = detail.row.content_type

--- a/src/gori/probe/active/reflected_param.cr
+++ b/src/gori/probe/active/reflected_param.cr
@@ -27,15 +27,15 @@ module Gori
         # the key is byte-identical to `plan(detail).dedup_key`. Returns nil in exactly the cases
         # `plan` does (malformed / unsafe method / no params / too many). Verified against `plan`
         # by the equivalence spec.
-        def dedup_key(detail : Store::FlowDetail) : String?
-          # Start-line-only fast path: the key needs only method + target, so a non-safe method
+        def dedup_key(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : String?
+          # Start-line-only fast path: the key needs only method + target, so a non-eligible method
           # or malformed head is rejected WITHOUT allocating the whole header block. The dominant
           # bodyless GET/HEAD never parses headers; only a request that actually carries a body
           # falls through to a full parse (for Content-Type). Byte-identical to plan's key.
           method, target, malformed = Proxy::Codec::Http1.parse_request_line(detail.request_head)
           return nil if malformed
           method_up = method.upcase
-          return nil unless SAFE_METHODS.includes?(method_up)
+          return nil unless method_allowed?(method_up, opts)
           path, query = split_target(Active.origin_form(target))
           names = [] of {String, String} # {name, location}, matching Param.{name, location}
           each_param_name(query) { |raw| names << {decode_name(raw), "query"} }
@@ -51,15 +51,15 @@ module Gori
               each_json_string_key(body) { |k| names << {k, "json"} }
             end
           end
-          return nil if names.empty? || names.size > MAX_PARAMS
+          return nil if names.empty? || names.size > opts.max_params
           build_dedup_key(detail, method_up, path, names)
         end
 
         # Build a probe from a captured flow, or nil if there is nothing reflectable.
-        def plan(detail : Store::FlowDetail) : Plan?
+        def plan(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : Plan?
           req = Proxy::Codec::Http1.parse_request_head(detail.request_head)
           return nil if req.malformed?
-          return nil unless SAFE_METHODS.includes?(req.method.upcase)
+          return nil unless method_allowed?(req.method.upcase, opts)
           # A plaintext forward-proxy flow is captured ABSOLUTE-form ("GET http://h/p"); the
           # probe is sent DIRECT to the origin (Fuzz::Sender → Repeater::Engine, no rewrite),
           # so normalize to origin-form here the way the regular repeater path (FlowRequest)
@@ -87,7 +87,7 @@ module Gori
             end
           end
 
-          return nil if params.empty? || params.size > MAX_PARAMS
+          return nil if params.empty? || params.size > opts.max_params
           request = rebuild(detail.request_head, path, new_query, new_body)
           # Same key builder `dedup_key` uses, fed the built params — so the pre-build dedup key
           # and this one can't drift.

--- a/src/gori/probe/active/types.cr
+++ b/src/gori/probe/active/types.cr
@@ -9,14 +9,35 @@ module Gori
     # body decoder, and the Fuzz sender — no Store/TUI. One rule per file under `active/`;
     # register new ones in `Active::RULES` (active.cr).
     module Active
-      BODY_CAP   = 64 * 1024
-      MAX_PARAMS = 50 # don't probe pathological param sets (request-size / canary budget)
+      BODY_CAP = 64 * 1024
 
-      # Only methods WITHOUT side effects are probed. The active scan runs automatically over
-      # captured traffic, so re-sending a POST/PUT/PATCH/DELETE with canary values would cause
-      # real server-side mutations (duplicate records, messages, deletions). Reflected-XSS via
-      # query parameters — the common case — is fully covered by GET/HEAD.
+      # Per-flow param budget. The default keeps the automatic scan light (request-size / canary
+      # budget); AGGRESSIVE (opts.aggressive) probes wider param sets on an authorized target.
+      MAX_PARAMS            =  50 # don't probe pathological param sets
+      MAX_PARAMS_AGGRESSIVE = 150 # AGGRESSIVE mode: cover wide queries/forms too
+
+      # Methods WITHOUT side effects — probed by default. The active scan normally runs
+      # automatically over captured traffic, so re-sending a POST/PUT/PATCH/DELETE with canary
+      # values would cause real server-side mutations (duplicate records, messages, deletions).
+      # Reflected-XSS via query parameters — the common case — is fully covered by GET/HEAD.
+      # Unsafe methods are probed ONLY when the caller opts in (Options#allow_unsafe): the manual
+      # per-flow "Run active scan" or AGGRESSIVE mode over in-scope traffic.
       SAFE_METHODS = Set{"GET", "HEAD"}
+
+      # Per-scan knobs threaded into every rule's `plan`/`dedup_key`, so a rule stays a pure
+      # function of (flow, opts). The DEFAULT (both false) reproduces the historic safe-method,
+      # base-cap behaviour, so any 1-arg caller is unchanged.
+      #   allow_unsafe — widen the method gate beyond SAFE_METHODS (re-sends POST/PUT/PATCH/DELETE).
+      #   aggressive   — raise per-rule caps (MAX_PARAMS_AGGRESSIVE, MAX_PROBE_PARAMS_AGGRESSIVE)
+      #                  and use the wider bypass-header set.
+      record Options, allow_unsafe : Bool = false, aggressive : Bool = false do
+        DEFAULT = new
+
+        # The param budget for this scan (aggressive raises it).
+        def max_params : Int32
+          aggressive ? MAX_PARAMS_AGGRESSIVE : MAX_PARAMS
+        end
+      end
 
       record Param, location : String, name : String, canary : String
 
@@ -55,9 +76,23 @@ module Gori
         # BEFORE calling `plan`, so a repeat surface (the common case in steady browsing) skips
         # the expensive canary generation + request rebuild that `plan` does. MUST stay identical
         # to the key `plan` produces or the seen-set would re-probe / skip (see the equivalence spec).
-        abstract def dedup_key(detail : Store::FlowDetail) : String?
-        abstract def plan(detail : Store::FlowDetail) : Plan?
+        abstract def dedup_key(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : String?
+        abstract def plan(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : Plan?
         abstract def detections(plan : Plan, result : Repeater::Result, detail : Store::FlowDetail) : Array(Detection)
+
+        # Whether METHOD (already upcased) is eligible for a rule gated to SAFE_METHODS. Unsafe
+        # methods pass only under an explicit opt-in (manual per-flow scan / AGGRESSIVE mode).
+        protected def method_allowed?(method_upcase : String, opts : Options) : Bool
+          opts.allow_unsafe || SAFE_METHODS.includes?(method_upcase)
+        end
+
+        # Whether METHOD (already upcased) is eligible for a BODY-DIFFERENTIAL rule (compares
+        # response bodies, so HEAD is always out). By default GET only; opts.allow_unsafe widens
+        # to any body-bearing method (POST/PUT/PATCH/DELETE) but never HEAD.
+        protected def diff_method_allowed?(method_upcase : String, opts : Options) : Bool
+          return false if method_upcase == "HEAD"
+          opts.allow_unsafe || method_upcase == "GET"
+        end
 
         # Interpret ALL of a plan's probe responses at once: the primary (`plan.request`) first,
         # then one per `plan.followups` entry, in the SAME order they were built. The analyzer calls

--- a/src/gori/probe/analyzer.cr
+++ b/src/gori/probe/analyzer.cr
@@ -117,7 +117,10 @@ module Gori
         prev = @mode
         @mode = m
         @store.set_probe_mode(m)
-        arm_active_backfill if m.active? && !prev.active?
+        # Re-arm when entering an actively-probing mode from one that wasn't (OFF/PASSIVE), OR when
+        # switching between ACTIVE and AGGRESSIVE — the wider AGGRESSIVE opts (unsafe methods,
+        # raised caps) produce new dedup keys, so recent in-scope traffic should be re-swept.
+        arm_active_backfill if m.probes_actively? && (!prev.probes_actively? || prev != m)
       end
 
       def start : Nil
@@ -128,9 +131,9 @@ module Gori
         spawn(name: "gori-probe") { passive_loop }
         spawn(name: "gori-probe-active") { active_loop }
         spawn(name: "gori-probe-catchup") { catch_up_loop }
-        # Project already set to Active (persisted) — probe recent in-scope History now,
-        # not only traffic that arrives after this open.
-        arm_active_backfill if @mode.active?
+        # Project already in an actively-probing mode (persisted) — probe recent in-scope History
+        # now, not only traffic that arrives after this open.
+        arm_active_backfill if @mode.probes_actively?
       end
 
       # Winds the analyzer down BEFORE the store/channels close: stop accepting active work,
@@ -165,10 +168,11 @@ module Gori
       # active rule that applies to `detail` (dedup_key non-nil ⇔ plan non-nil, per the equivalence
       # spec), with the requests it sends. Cheap — dedup_key never builds canaries and nothing is
       # sent — so it's safe on the render path. Matches exactly what run_active_now will fire.
-      def active_estimate(detail : Store::FlowDetail) : Array(ActiveEstimate)
+      def active_estimate(detail : Store::FlowDetail,
+                          opts : Active::Options = Active::Options::DEFAULT) : Array(ActiveEstimate)
         Active::RULES.compact_map do |rule|
           next if @disabled.includes?(rule.info.id)
-          next unless rule.dedup_key(detail)
+          next unless rule.dedup_key(detail, opts)
           ActiveEstimate.new(rule.info, rule.requests_per_flow)
         end
       end
@@ -181,17 +185,21 @@ module Gori
       # usual upsert (probe_generation poll) + IssueEvent notification path. `repeater_id` stamps
       # detections for evidence linking back to a Repeater tab. `notify` (the run popup's choice)
       # gates the tray: Off is silent, WhenFound posts per finding, Always also posts a completion
-      # note when the scan came back clean.
+      # note when the scan came back clean. `allow_unsafe` (the run popup's off-by-default opt-in)
+      # widens the rule gate to unsafe methods (POST/PUT/PATCH/DELETE) for this deliberate, single-
+      # flow re-send — the automatic pipeline only sets it in AGGRESSIVE mode (via active_opts).
       def run_active_now(detail : Store::FlowDetail, *, repeater_id : Int64? = nil,
+                         allow_unsafe : Bool = false,
                          notify : Miner::NotifyMode = Miner::NotifyMode::WhenFound) : Nil
         return if @stopped
+        opts = Active::Options.new(allow_unsafe: allow_unsafe)
         spawn(name: "gori-probe-active-manual") do
           found = 0
           errored = false
           Active::RULES.each do |rule|
             break if @stopped
             next if @disabled.includes?(rule.info.id)
-            plan = rule.plan(detail)
+            plan = rule.plan(detail, opts)
             next unless plan
             if wrote = execute_active(rule, plan, detail, repeater_id: repeater_id, notify: notify)
               found += wrote
@@ -345,30 +353,38 @@ module Gori
 
       private def maybe_enqueue_active(detail : Store::FlowDetail) : Nil
         return if @stopped
-        return unless @mode.active?
+        return unless @mode.probes_actively?
         row = detail.row
         url = row.url
         # Active probes only on hosts/paths covered by Project scope INCLUDE rules
         # (matches_url? — lens-independent; requires ≥1 include so excludes-only never
         # means "probe everything"). in_scope_url? is wrong here: it is permissive when
-        # the ⇧S display lens is off.
+        # the ⇧S display lens is off. AGGRESSIVE never widens this — same scope gate.
         return unless @scope.matches_url?(url, row.host)
-        Active::RULES.each { |rule| enqueue_probe(rule, detail) unless @disabled.includes?(rule.info.id) }
+        opts = active_opts
+        Active::RULES.each { |rule| enqueue_probe(rule, detail, opts) unless @disabled.includes?(rule.info.id) }
       rescue Channel::ClosedError
+      end
+
+      # The Active::Options the AUTOMATIC pipeline runs with, derived from the live mode. ACTIVE
+      # keeps the historic safe-method, base-cap defaults; AGGRESSIVE widens to unsafe methods and
+      # raises caps / bypass sets (still scope-gated by maybe_enqueue_active).
+      private def active_opts : Active::Options
+        @mode.aggressive? ? Active::Options.new(allow_unsafe: true, aggressive: true) : Active::Options::DEFAULT
       end
 
       # Fire-and-forget: walk recent History and enqueue active probes for in-scope surfaces.
       # Dedup via @active_seen keeps this cheap when called more than once.
       private def arm_active_backfill : Nil
         return if @stopped
-        return unless @mode.active?
+        return unless @mode.probes_actively?
         return unless @running # queue consumer must be up (start) or about to be (set_mode mid-session)
         spawn(name: "gori-probe-active-backfill") { active_backfill }
       end
 
       private def active_backfill : Nil
         @store.recent_flows(ACTIVE_BACKFILL).each do |row|
-          break if @stopped || !@mode.active?
+          break if @stopped || !@mode.probes_actively?
           next unless row.state.complete?
           detail = @store.get_flow(row.id)
           next unless detail
@@ -378,13 +394,13 @@ module Gori
       rescue Channel::ClosedError
       end
 
-      private def enqueue_probe(rule : Active::Rule, detail : Store::FlowDetail) : Nil
+      private def enqueue_probe(rule : Active::Rule, detail : Store::FlowDetail, opts : Active::Options) : Nil
         # Cheap dedup key FIRST: a repeat surface (the norm in steady browsing) is rejected here
         # WITHOUT the full plan build (canary generation, JSON re-serialize, request rebuild).
-        key = rule.dedup_key(detail)
+        key = rule.dedup_key(detail, opts)
         return unless key
         return if @active_seen.includes?(key)
-        plan = rule.plan(detail)
+        plan = rule.plan(detail, opts)
         return unless plan
         select
         when @active_jobs.send(ActiveTask.new(rule, plan, detail))
@@ -415,8 +431,8 @@ module Gori
         # — so the consumer MUST re-check the live mode, or buffered canary/CORS probes keep hitting
         # the target after Active was turned off. RELEASE the dedup key when dropping for this
         # reason: it was recorded at enqueue, and keeping it would suppress the surface forever if
-        # Active is re-enabled (arm_active_backfill would skip it as already-seen).
-        unless @mode.active?
+        # active probing is re-enabled (arm_active_backfill would skip it as already-seen).
+        unless @mode.probes_actively?
           @active_seen.delete(task.plan.dedup_key)
           return
         end

--- a/src/gori/probe/mode.cr
+++ b/src/gori/probe/mode.cr
@@ -14,13 +14,19 @@ module Gori
     # Per-project scanning mode. Off = no analysis at all; Passive = zero-request checks on
     # observed traffic (the safe default); Active = Passive plus a set of light-touch probes
     # (reflected params today) over hosts/paths covered by Project scope rules only — the ⇧S
-    # display lens need not be on; one probe per unique target. Keep active DELIBERATELY quiet:
-    # any new check must stay safe-method + low-volume (a handful of confirming probes), never a
-    # Burp-style flood of attack payloads.
+    # display lens need not be on; one probe per unique target. Keep Active DELIBERATELY quiet:
+    # safe-method only, low-volume (a handful of confirming probes), one probe per unique target.
+    #
+    # Aggressive = Active's sanctioned louder tier for AUTHORIZED targets: raised per-rule caps
+    # (wider param sets), a wider bypass-header set, and — unlike Active — it also probes
+    # UNSAFE methods (POST/PUT/PATCH/DELETE), so an in-scope endpoint can be state-mutated by the
+    # automatic pipeline. It is still Project-scope-gated (never widens scope) and still "more of
+    # the same probes with relaxed caps", NOT an unbounded flood of attack payloads.
     enum Mode
       Off
       Passive
       Active
+      Aggressive
 
       def label : String
         to_s.downcase
@@ -30,28 +36,36 @@ module Gori
         to_s.upcase
       end
 
-      # Any analysis at all (Passive OR Active). `passive?`/`active?`/`off?` are the
-      # auto-generated exact-member predicates.
+      # Any analysis at all (Passive OR Active OR Aggressive). `passive?`/`active?`/`aggressive?`/
+      # `off?` are the auto-generated exact-member predicates.
       def scanning? : Bool
         !off?
+      end
+
+      # Whether this mode drives the AUTOMATIC active-probe pipeline (enqueue + backfill). Active
+      # and Aggressive both do; the difference is the Options they run with, not whether they run.
+      def probes_actively? : Bool
+        active? || aggressive?
       end
 
       # Parse a stored label back to a Mode; unknown/nil → Passive (the safe, zero-request
       # default so a fresh project scans passively out of the box).
       def self.from_setting(value : String?) : Mode
         case value
-        when "off"    then Off
-        when "active" then Active
-        else               Passive
+        when "off"        then Off
+        when "active"     then Active
+        when "aggressive" then Aggressive
+        else                   Passive
         end
       end
 
-      # Next mode in the OFF → Passive → Active → OFF cycle (the `m` key affordance).
+      # Next mode in the OFF → Passive → Active → Aggressive → OFF cycle (the `m` key affordance).
       def cycle : Mode
         case self
-        in Off     then Passive
-        in Passive then Active
-        in Active  then Off
+        in Off        then Passive
+        in Passive    then Active
+        in Active     then Aggressive
+        in Aggressive then Off
         end
       end
     end

--- a/src/gori/probe/scan.cr
+++ b/src/gori/probe/scan.cr
@@ -34,18 +34,20 @@ module Gori
       # limiting the request-free PASSIVE scan — nil means no active cap (the CLI).
       def scan_all(store : Store, ids : Array(Int64), *, active : Bool,
                    verify_upstream : Bool = true, scope : Scope? = nil, allow_unscoped : Bool = false,
-                   active_limit : Int32? = nil, progress : Proc(Int32, Int32, Nil)? = nil) : {Array(Detection), Int32}
+                   active_limit : Int32? = nil, opts : Active::Options = Active::Options::DEFAULT,
+                   progress : Proc(Int32, Int32, Nil)? = nil) : {Array(Detection), Int32}
         detections = scan_flows(store, ids, active: active, verify_upstream: verify_upstream,
-          scope: scope, allow_unscoped: allow_unscoped, active_limit: active_limit, progress: progress)
+          scope: scope, allow_unscoped: allow_unscoped, active_limit: active_limit, opts: opts, progress: progress)
         repeater_dets, repeater_n = scan_repeaters(store, active: active, verify_upstream: verify_upstream,
-          scope: scope, allow_unscoped: allow_unscoped)
+          scope: scope, allow_unscoped: allow_unscoped, opts: opts)
         detections.concat(repeater_dets)
         {detections, repeater_n}
       end
 
       def scan_flows(store : Store, ids : Array(Int64), *, active : Bool,
                      verify_upstream : Bool = true, scope : Scope? = nil, allow_unscoped : Bool = false,
-                     active_limit : Int32? = nil, progress : Proc(Int32, Int32, Nil)? = nil) : Array(Detection)
+                     active_limit : Int32? = nil, opts : Active::Options = Active::Options::DEFAULT,
+                     progress : Proc(Int32, Int32, Nil)? = nil) : Array(Detection)
         detections = [] of Detection
         active_sent = 0
         ids.each_with_index do |id, i|
@@ -54,7 +56,7 @@ module Gori
             ws = detail.row.status == 101 ? store.ws_messages(id, 200) : [] of Store::WsMessage
             detections.concat(Passive.analyze(detail, ws)) # passive is request-free — NEVER capped
             if active && active_target?(detail, scope, allow_unscoped) && !(active_limit && active_sent >= active_limit)
-              detections.concat(Active.analyze(detail, verify_upstream, scope: scope))
+              detections.concat(Active.analyze(detail, verify_upstream, scope: scope, opts: opts))
               active_sent += 1
             end
           end
@@ -65,7 +67,8 @@ module Gori
 
       # Scan Repeater tabs. Stamps sample_repeater_id.
       def scan_repeaters(store : Store, *, active : Bool, verify_upstream : Bool = true,
-                         scope : Scope? = nil, allow_unscoped : Bool = false) : {Array(Detection), Int32}
+                         scope : Scope? = nil, allow_unscoped : Bool = false,
+                         opts : Active::Options = Active::Options::DEFAULT) : {Array(Detection), Int32}
         detections = [] of Detection
         n = 0
         store.repeaters.each do |rec|
@@ -76,7 +79,7 @@ module Gori
             detections << Probe.with_source(d, flow_id: rec.flow_id, repeater_id: rec.id)
           end
           if active && active_target?(detail, scope, allow_unscoped)
-            Active.analyze(detail, verify_upstream, scope: scope).each do |d|
+            Active.analyze(detail, verify_upstream, scope: scope, opts: opts).each do |d|
               detections << Probe.with_source(d, flow_id: rec.flow_id, repeater_id: rec.id)
             end
           end

--- a/src/gori/tui/choice_picker.cr
+++ b/src/gori/tui/choice_picker.cr
@@ -44,12 +44,13 @@ module Gori::Tui
     end
 
     # Probe scan MODE picker (kind :probe_mode — the Runner applies it to the analyzer).
-    # Values match Probe::Mode (Off=0, Passive=1, Active=2).
+    # Values match Probe::Mode (Off=0, Passive=1, Active=2, Aggressive=3).
     def self.for_probe_mode(current : Int32) : ChoicePicker
       new("SET PROBE MODE", [
         Choice.new("OFF — no scanning", 'o', Theme.muted, 0),
         Choice.new("PASSIVE — observe only", 'p', Theme.accent, 1),
         Choice.new("ACTIVE — passive + light-touch probes (in-scope)", 'a', Theme.orange, 2),
+        Choice.new("AGGRESSIVE — deeper probing incl. unsafe methods (authorized, in-scope)", 'g', Theme.red, 3),
       ], current, :probe_mode)
     end
 

--- a/src/gori/tui/probe_active_overlay.cr
+++ b/src/gori/tui/probe_active_overlay.cr
@@ -8,9 +8,12 @@ require "../settings"
 
 module Gori::Tui
   # The small popup shown before a manual "Run active scan" fires. A read-only header (the target
-  # request, the per-rule request estimate, and the total), then two interactive rows: a
-  # notification-mode cycler (‹/›, mirroring the Mine popup) and a Run row. The Runner reads
-  # notify_mode + detail/repeater_id on Run and persists the notify choice. Pure state + render.
+  # request, the per-rule request estimate, and the total), then interactive rows: a notification-
+  # mode cycler (‹/›, mirroring the Mine popup), an OPTIONAL "unsafe methods" opt-in cycler (shown
+  # only when unsafe-method probing would add checks the safe scan can't run — i.e. the flow is a
+  # POST/PUT/PATCH/DELETE, or a rule that only runs on non-GET bodies would apply), and a Run row.
+  # The Runner reads notify_mode + allow_unsafe? + detail/repeater_id on Run and persists the notify
+  # choice. Pure state + render.
   class ProbeActiveOverlay
     NOTIFY_CHOICES = Miner::NotifyMode.values
 
@@ -19,16 +22,26 @@ module Gori::Tui
 
     @selected : Int32
     @notify_idx : Int32
+    @allow_unsafe : Bool
+    @show_unsafe_row : Bool
     @info : Array(String)
 
+    # `est_safe` is what runs with the safe-method gate (default); `est_unsafe` is what runs once
+    # unsafe methods are allowed (always a superset). When they differ, the unsafe opt-in row is
+    # offered; otherwise it's hidden (the common GET/HEAD case is unchanged).
     def initialize(@detail : Store::FlowDetail,
-                   @estimate : Array(Probe::Analyzer::ActiveEstimate),
+                   @est_safe : Array(Probe::Analyzer::ActiveEstimate),
+                   @est_unsafe : Array(Probe::Analyzer::ActiveEstimate),
                    @repeater_id : Int64? = nil)
       @notify_idx = NOTIFY_CHOICES.index(Miner::NotifyMode::WhenFound) || 0
       if mode = Miner::NotifyMode.parse?(Settings.probe_active_notify)
         @notify_idx = NOTIFY_CHOICES.index(mode) || @notify_idx
       end
-      @selected = run_row # start on Run so a reflexive ↵ fires with the saved default
+      @allow_unsafe = false
+      # est_unsafe is a superset of est_safe (allow_unsafe only widens the method gate), so a size
+      # difference means unsafe probing would add checks — only then is the opt-in meaningful.
+      @show_unsafe_row = @est_unsafe.size != @est_safe.size
+      @selected = run_row # start on Run so a reflexive ↵ fires with the saved defaults
       @info = build_info
     end
 
@@ -36,10 +49,26 @@ module Gori::Tui
       NOTIFY_CHOICES[@notify_idx]
     end
 
+    def allow_unsafe? : Bool
+      @allow_unsafe
+    end
+
+    # The estimate for the current opt-in state (safe by default, widened when unsafe is toggled on).
+    private def estimate : Array(Probe::Analyzer::ActiveEstimate)
+      @allow_unsafe ? @est_unsafe : @est_safe
+    end
+
+    # True when the currently-selected options would send nothing (e.g. a POST with the unsafe
+    # opt-in still off) — the Runner uses this to hint instead of firing a no-op scan.
+    def estimate_empty? : Bool
+      estimate.empty?
+    end
+
     # The "N request(s)" summary the Runner reuses in its post-run toast.
     def total_label : String
-      min = @estimate.sum { |e| e.requests.begin }
-      max = @estimate.sum { |e| e.requests.end }
+      est = estimate
+      min = est.sum(&.requests.begin)
+      max = est.sum(&.requests.end)
       min == max ? "#{min} request#{min == 1 ? "" : "s"}" : "#{min}–#{max} requests"
     end
 
@@ -47,12 +76,17 @@ module Gori::Tui
       0
     end
 
+    # -1 when hidden; the row indices below shift by whether the unsafe row is shown.
+    private def unsafe_row : Int32
+      @show_unsafe_row ? 1 : -1
+    end
+
     private def run_row : Int32
-      1
+      @show_unsafe_row ? 2 : 1
     end
 
     private def row_count : Int32
-      2
+      @show_unsafe_row ? 3 : 2
     end
 
     def on_run_row? : Bool
@@ -68,12 +102,26 @@ module Gori::Tui
     end
 
     def adjust(d : Int32) : Nil
-      @notify_idx = (@notify_idx + d) % NOTIFY_CHOICES.size if @selected == notify_row
+      if @selected == notify_row
+        @notify_idx = (@notify_idx + d) % NOTIFY_CHOICES.size
+      elsif @show_unsafe_row && @selected == unsafe_row
+        toggle_unsafe
+      end
     end
 
-    # ␣/↵ on the notify row cycles it; the Run row is handled by the Runner.
+    # ␣/↵ on the notify row cycles it; on the unsafe row flips the opt-in; the Run row is handled
+    # by the Runner.
     def toggle : Nil
-      adjust(1) if @selected == notify_row
+      if @selected == notify_row
+        adjust(1)
+      elsif @show_unsafe_row && @selected == unsafe_row
+        toggle_unsafe
+      end
+    end
+
+    private def toggle_unsafe : Nil
+      @allow_unsafe = !@allow_unsafe
+      @info = build_info # the estimate list + total change with the opt-in
     end
 
     private def build_info : Array(String)
@@ -82,9 +130,19 @@ module Gori::Tui
       url = "#{url[0, 51]}…" if url.size > 52
       lines << "#{@detail.row.method} #{url}"
       lines << ""
-      @estimate.each { |e| lines << "  #{e.info.name} — #{req_label(e.requests)}" }
+      est = estimate
+      if est.empty?
+        lines << "  no active checks apply"
+        # A state-changing flow with the opt-in still off: point at the toggle rather than dead-end.
+        if @show_unsafe_row && !@allow_unsafe
+          lines << "  (enable unsafe methods below to probe this #{@detail.row.method})"
+        end
+      else
+        est.each { |e| lines << "  #{e.info.name} — #{req_label(e.requests)}" }
+      end
       lines << ""
-      lines << "#{total_label} → #{@detail.row.host}"
+      lines << "⚠ re-sends #{@detail.row.method} — may mutate server data" if @allow_unsafe
+      lines << (est.empty? ? "0 requests → #{@detail.row.host}" : "#{total_label} → #{@detail.row.host}")
       lines
     end
 
@@ -94,7 +152,7 @@ module Gori::Tui
 
     def overlay_box(area : Rect) : Rect?
       longest = @info.max_of { |l| Screen.display_width(l) }
-      w = {area.w - 4, {longest + 6, 54}.max.clamp(30, 60)}.min
+      w = {area.w - 4, {longest + 6, 54}.max.clamp(30, 64)}.min
       h = {area.h - 2, @info.size + row_count + 4}.min # title + info + gap + rows + border
       return nil if w < 30 || h < 6
       Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
@@ -115,7 +173,13 @@ module Gori::Tui
       @info.each_with_index do |line, i|
         py = box.y + 1 + i
         break if py >= box.bottom - 2
-        fg = i == 0 ? Theme.text_bright : Theme.text
+        fg = if i == 0
+               Theme.text_bright
+             elsif line.starts_with?("⚠")
+               Theme.red
+             else
+               Theme.text
+             end
         screen.text(box.x + 2, py, line, fg, Theme.panel, width: box.w - 4)
       end
       row_count.times { |i| draw_row(screen, box, i) }
@@ -132,6 +196,11 @@ module Gori::Tui
       if i == notify_row
         screen.text(x, py, "notification:", Theme.muted, bg)
         screen.text(x + 14, py, "#{notify_mode.label}  ‹/›", sel ? Theme.text_bright : Theme.text, bg)
+      elsif @show_unsafe_row && i == unsafe_row
+        screen.text(x, py, "unsafe methods:", Theme.muted, bg)
+        state = @allow_unsafe ? "ON" : "off"
+        col = @allow_unsafe ? Theme.red : (sel ? Theme.text_bright : Theme.text)
+        screen.text(x + 16, py, "#{state}  ‹/›", col, bg)
       else
         screen.text(x, py, "[ Run active scan ]", Theme.accent, bg, Attribute::Bold)
       end

--- a/src/gori/tui/probe_view.cr
+++ b/src/gori/tui/probe_view.cr
@@ -645,9 +645,10 @@ module Gori::Tui
 
     private def mode_color(m : Probe::Mode) : Color
       case m
-      in Probe::Mode::Off     then Theme.muted
-      in Probe::Mode::Passive then Theme.accent
-      in Probe::Mode::Active  then Theme.orange
+      in Probe::Mode::Off        then Theme.muted
+      in Probe::Mode::Passive    then Theme.accent
+      in Probe::Mode::Active     then Theme.orange
+      in Probe::Mode::Aggressive then Theme.red
       end
     end
 

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -2118,7 +2118,10 @@ module Gori::Tui
         @session.probe.set_mode(Probe::Mode.new(p.selected_value))
         probe_controller.view.reload(@session.store)
         mode = @session.probe.mode
-        @toast = if mode.active?
+        @toast = case mode
+                 when .aggressive?
+                   "Probe mode: AGGRESSIVE — deeper in-scope probing, incl. unsafe methods (authorized targets only)"
+                 when .active?
                    "Probe mode: ACTIVE — light-touch probes over recent in-scope traffic"
                  else
                    "Probe mode: #{mode.title}"
@@ -3979,7 +3982,7 @@ module Gori::Tui
       when :env              then env_overlay_hints
       when :hotkeys          then @hotkeys_overlay.capturing? ? "press a key to bind · esc cancel" : "↑/↓ select · e/␣ rebind · x unbind · r reset · ⇧R reset all · ←/→ profile · ↵ save · esc"
       when :notifications    then "↑/↓ select · ↵ open · c clear · esc close"
-      when :probe_active     then "↑/↓ field · ←/→ notify · ↵ run · esc cancel"
+      when :probe_active     then "↑/↓ field · ←/→ adjust · ↵ run · esc cancel"
       when :discover_config  then "↑/↓ field · ←/→ adjust · ␣ toggle · ↵ start/edit · esc cancel"
       when :discover_headers then "one header per line · Host/Connection ignored · esc saves & closes"
       when :fuzz_set         then "↑/↓/⇥ field · ←/→ type/caret · ↵ new value/next · esc applies & closes"
@@ -4801,27 +4804,38 @@ module Gori::Tui
     # request count before anything is sent.
 
     # Estimate the active-scan request count for `detail`, then open the "Run active scan" popup
-    # (per-rule breakdown + total + a notification-mode cycler). Running is deferred to
-    # start_probe_active so the operator can pick the notify mode first.
+    # (per-rule breakdown + total + a notification-mode cycler + an off-by-default unsafe-methods
+    # opt-in). Running is deferred to start_probe_active so the operator can pick the options first.
     private def open_probe_active_overlay(detail : Store::FlowDetail, repeater_id : Int64? = nil) : Nil
-      est = @session.probe.active_estimate(detail)
-      if est.empty?
-        @toast = "no active checks apply (needs a GET/HEAD with reflectable params, or a CORS response)"
+      est_safe = @session.probe.active_estimate(detail)
+      est_unsafe = @session.probe.active_estimate(detail, Probe::Active::Options.new(allow_unsafe: true))
+      # Nothing applies even with unsafe methods allowed — no popup to show.
+      if est_unsafe.empty?
+        @toast = "no active checks apply (needs a request with reflectable params, or a CORS response)"
         return
       end
-      @probe_active_overlay = ProbeActiveOverlay.new(detail, est, repeater_id)
+      @probe_active_overlay = ProbeActiveOverlay.new(detail, est_safe, est_unsafe, repeater_id)
       @overlay = :probe_active
     end
 
     # Confirm the popup: run the probes in the BACKGROUND (mode-independent), persist the chosen
     # notify mode as the next default, and toast the request count. Findings land in the Probe tab
-    # via the usual probe_generation poll + event drain.
+    # via the usual probe_generation poll + event drain. The unsafe-methods opt-in threads through
+    # to run_active_now so a deliberately-selected POST/PUT/… flow is actually re-sent.
     private def start_probe_active(ov : ProbeActiveOverlay) : Nil
+      # Selected options send nothing (e.g. a POST with the unsafe opt-in still off) — hint, don't
+      # fire a no-op scan or close the popup.
+      if ov.estimate_empty?
+        @toast = "nothing to send — enable unsafe methods to probe this #{ov.detail.row.method}"
+        return
+      end
       notify = ov.notify_mode
       Settings.save_probe_active_notify(notify.token)
       host = ov.detail.row.host
-      @session.probe.run_active_now(ov.detail, repeater_id: ov.repeater_id, notify: notify)
-      @toast = "active scan → #{host}: #{ov.total_label} sent (see the Probe tab)"
+      @session.probe.run_active_now(ov.detail, repeater_id: ov.repeater_id,
+        allow_unsafe: ov.allow_unsafe?, notify: notify)
+      unsafe_note = ov.allow_unsafe? ? " (incl. unsafe methods)" : ""
+      @toast = "active scan → #{host}: #{ov.total_label} sent#{unsafe_note} (see the Probe tab)"
       close_probe_active
     end
 


### PR DESCRIPTION
Closes #342.

Two opt-in knobs for deeper Probe active scanning, both scope-gated.

## Design
One pure record threads it all: `Active::Options(allow_unsafe, aggressive)` is passed into every active rule's `plan`/`dedup_key`. The default (`Options::DEFAULT`, both `false`) reproduces the historic safe-method, base-cap behavior byte-for-byte, so the automatic **ACTIVE** pipeline is unchanged. The hardcoded `SAFE_METHODS` gate becomes two opts-aware helpers on the `Rule` base:
- `method_allowed?` — SAFE_METHODS rules (`reflected_param`, `cors_reflection`, `forbidden_bypass`) widen to any method under `allow_unsafe`.
- `diff_method_allowed?` — body-differential rules (`backslash_powered`, `nginx_alias_traversal`) always exclude HEAD (no body to diff), GET-only by default, POST/PUT/… under `allow_unsafe`.

The `dedup_key == plan.dedup_key` equivalence invariant now holds **per-opts**.

## Part 1 — manual unsafe-method opt-in
- `run_active_now(..., allow_unsafe:)` widens the gate for a deliberate single-flow re-send.
- TUI "Run active scan" popup gains an **off-by-default** "unsafe methods" toggle (shown only when it would add checks, i.e. the flow is POST/PUT/PATCH/DELETE), with a "may mutate server data" warning.
- CLI `gori run probe --active --unsafe` (and `--aggressive`); MCP `probe_scan {unsafe, aggressive}`.

## Part 2 — AGGRESSIVE mode
- New `Mode::Aggressive` (cycle `Off→Passive→Active→Aggressive→Off`, `from_setting("aggressive")`, red chip). New `probes_actively?` replaces the bare `active?` checks in the analyzer's enqueue/backfill/consumer paths.
- Raised caps (`MAX_PARAMS 50→150`, `MAX_PROBE_PARAMS 3→10`) + a wider client-IP/host bypass-header set in `forbidden_bypass` (still **1 req/flow**), selected by `opts.aggressive`.

### ⚠️ Deliberate divergence from the issue
The issue's Part 2 says "explicitly NOT automatic unsafe-method mutation." Per the issue author's direction during planning, **AGGRESSIVE's automatic pipeline also probes unsafe methods** (`analyzer#active_opts`). It stays hard-gated by Project scope INCLUDE rules — only in-scope traffic is ever auto-mutated. This is intentional; see the code comments.

## Tests
- `spec/probe_spec.cr`: per-opts equivalence, per-rule method gates, aggressive caps, `Mode` cycle/persist/`probes_actively?`, analyzer AGGRESSIVE re-arm.
- `spec/mcp_probe_spec.cr`: new `unsafe`/`aggressive` params.
- New `spec/tui/probe_active_overlay_spec.cr`: unsafe-toggle row logic.
- Full suite: **3530 examples, 0 failures**. Touched files pass `crystal tool format --check`; no new ameba findings.