### PR TITLE
docs: cover probe --unsafe/--aggressive, AGGRESSIVE mode, and `run project sandbox`

### DIFF
--- a/docs/content/guide/scanning.ko.md
+++ b/docs/content/guide/scanning.ko.md
@@ -13,7 +13,9 @@ gori에는 수동 테스트와 나란히 돌아가는 자동 분석 기능이 �
 
 **Probe**는 보안 이슈를 유형과 심각도로 묶습니다. 패시브 체크는 브라우징하는 동안 실행되며(추가 요청은 전혀 없이) **History** 플로우와 **Repeater** 전송 결과를 검사합니다.
 
-**액티브** 체크는 의도적으로 *light-touch*로 설계되었습니다. 이미 캡처한 트래픽에 대해 안전하고 저용량인 프로브 몇 개를 보낼 뿐입니다. 안전한 메서드(`GET` / `HEAD`)만 프로브하고, 고유한 표면마다 한 번씩만 테스트하며, 액티브 모드를 활성화하기 전에는 아무것도 나가지 않습니다. 흔적을 최소로 남기면서 빠른 직감을 확인하도록(파라미터가 반사되는지, origin이 허용되는지) 만들어졌습니다.
+**액티브** 체크는 의도적으로 *light-touch*로 설계되었습니다. 이미 캡처한 트래픽에 대해 안전하고 저용량인 프로브 몇 개를 보낼 뿐입니다. 기본적으로 안전한 메서드(`GET` / `HEAD`)만 프로브하고, 고유한 표면마다 한 번씩만 테스트하며, 액티브 모드를 활성화하기 전에는 아무것도 나가지 않습니다. 흔적을 최소로 남기면서 빠른 직감을 확인하도록(파라미터가 반사되는지, origin이 허용되는지) 만들어졌습니다.
+
+안전하지 않은 메서드(`POST` / `PUT` / `PATCH` / `DELETE`)를 다시 보내면 서버 상태가 변경될 수 있으므로 항상 명시적으로 켜야 합니다. 플로우별 *Run active scan* 팝업에서 **unsafe methods**를 체크해 한 번만 의도적으로 재전송하거나, Probe를 **AGGRESSIVE** 모드로 전환하면 안전하지 않은 메서드도 자동으로 프로브하고 룰별 상한을 높입니다(더 넓은 파라미터 집합, 더 넓은 forbidden-bypass 헤더 집합). 두 경우 모두 프로젝트 스코프 안에서만 동작하므로 스코프를 벗어난 호스트는 절대 건드리지 않습니다.
 
 <figure class="tui-shot">
   <img src="/images/tui/probe.svg" alt="심각도와 범주로 묶인 패시브 이슈를 나열하는 gori Probe 스캐너: 허용적 CORS, 누락된 CSP와 HSTS, 쿠키 플래그 문제, 캐시 가능한 응답, 각각 영향받는 호스트 표시">
@@ -37,6 +39,8 @@ gori에는 수동 테스트와 나란히 돌아가는 자동 분석 기능이 �
 ```bash
 gori run probe                       # passive issues
 gori run probe --active              # include active checks (sends probe requests)
+gori run probe --active --unsafe     # also re-send unsafe methods (may mutate server data)
+gori run probe --active --aggressive # wider caps + unsafe methods (authorized targets only)
 gori run probe --severity high       # only high-severity
 gori run probe --category cors       # a single category
 gori run probe -q 'host:example.com' # filter History with QL (Repeater still scanned)

--- a/docs/content/guide/scanning.md
+++ b/docs/content/guide/scanning.md
@@ -13,7 +13,9 @@ gori includes automated analysis that runs alongside your manual testing. **Prob
 
 **Probe** groups security issues by type and severity. Its passive checks run as you browse (with zero extra requests), inspecting **History** flows and **Repeater** send results.
 
-Its **active** checks are deliberately *light-touch*: a handful of safe, low-volume probes over traffic you've already captured. Only safe methods (`GET` / `HEAD`) are probed, each unique surface is tested once, and nothing goes out until you arm active mode. It's built to confirm a quick hunch (a parameter reflects, an origin is honored) while keeping your footprint quiet.
+Its **active** checks are deliberately *light-touch*: a handful of safe, low-volume probes over traffic you've already captured. By default only safe methods (`GET` / `HEAD`) are probed, each unique surface is tested once, and nothing goes out until you arm active mode. It's built to confirm a quick hunch (a parameter reflects, an origin is honored) while keeping your footprint quiet.
+
+Re-sending an unsafe method (`POST` / `PUT` / `PATCH` / `DELETE`) can mutate server state, so it is always opt-in. Tick **unsafe methods** in the per-flow *Run active scan* popup for a single deliberate re-send, or switch Probe to **AGGRESSIVE** mode, which also probes unsafe methods automatically and raises the per-rule caps (wider param sets, a wider forbidden-bypass header set). Both stay inside your project scope, so an out-of-scope host is never touched.
 
 <figure class="tui-shot">
   <img src="/images/tui/probe.svg" alt="gori Probe scanner listing passive issues grouped by severity and category: permissive CORS, missing CSP and HSTS, cookie flag issues, and cacheable responses, each with an affected host">
@@ -37,6 +39,8 @@ Run analysis headless. By default it reads what's already captured (History + Re
 ```bash
 gori run probe                       # passive issues
 gori run probe --active              # include active checks (sends probe requests)
+gori run probe --active --unsafe     # also re-send unsafe methods (may mutate server data)
+gori run probe --active --aggressive # wider caps + unsafe methods (authorized targets only)
 gori run probe --severity high       # only high-severity
 gori run probe --category cors       # a single category
 gori run probe -q 'host:example.com' # filter History with QL (Repeater still scanned)

--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -70,6 +70,7 @@ gori run <subcommand> [options]
 | `rewriter` · `add` · `rm` · `enable` · `disable` · `preview` | Match & Replace 규칙 관리 |
 | `project [list]` | 알려진 프로젝트 목록 |
 | `project scope` | 스코프 규칙 목록 / 추가 / 삭제 / 활성화 / 비활성화 |
+| `project sandbox` | 하드 컨테인먼트 샌드박스 게이트 조회 / 설정 (`status`, `on`, `off`) |
 | `project env` | 프로젝트 env 변수 목록 / 설정 / 삭제 (`$KEY` 치환) |
 
 읽기 서브커맨드에 공통인 플래그: `--project=NAME`, `--db=PATH`, `--format=FMT` (보통 `text` 또는 `json`).
@@ -202,6 +203,8 @@ gori run probe -a
 ```
 
 `--severity`는 `info`\|`low`\|`medium`\|`high`\|`critical` 중 하나입니다. `--category`는 `headers`\|`cookies`\|`tech`\|`infoleak`\|`cors`\|`client`\|`active`입니다. 기본적으로 패시브 검사를 수행하며, `-a`/`--active` 옵션을 사용하여 액티브 프로브 검사를 포함할 수 있습니다. `-q`/`--query`로 QL 필터를 겁니다.
+
+`--active`와 함께: `--unsafe`는 안전하지 않은 메서드(`POST`/`PUT`/`PATCH`/`DELETE`)도 프로브하며, 이 재전송은 서버 데이터를 변경할 수 있습니다. `--aggressive`는 룰별 상한을 높이고 forbidden-bypass 헤더 집합을 넓힙니다(그리고 `--unsafe`를 함의합니다). 둘 다 `--allow-unscoped`를 함께 주지 않는 한 스코프 게이트를 따릅니다. 인가된 대상에만 사용하세요.
 
 ### run discover {#run-discover}
 
@@ -386,6 +389,25 @@ gori run project scope disable
 | `add` | `--kind=include\|exclude`, `--type=host\|string\|regex`, `--pattern=…` |
 | `delete <rule-id>` | id로 규칙 제거 |
 | `enable` / `disable` | 스코프 필터링 적용 여부 토글 |
+
+#### project sandbox {#run-project-sandbox}
+
+**하드 컨테인먼트** 샌드박스 게이트를 조회하거나 설정합니다. TUI Project NETWORK 토글의 헤드리스 등가물입니다. 켜면 캡처 프록시가 스코프가 허용하는 요청만 전달하고 나머지는 모두 차단합니다. 표시 렌즈일 뿐인 `project scope enable`과는 다릅니다.
+
+```bash
+gori run project sandbox                 # show the current state (status is the default)
+gori run project sandbox status --format json
+gori run project sandbox on              # start blocking out-of-scope traffic
+gori run project sandbox off             # stop blocking
+```
+
+| Option / subcommand | Description |
+|---------------------|-------------|
+| (default) / `status` | 게이트 상태 표시; `--format`은 `text` 또는 `json` |
+| `on` / `enable` | 스코프가 허용하지 않는 모든 요청 차단 |
+| `off` / `disable` | 차단 중지 |
+
+> include 규칙이 없으면 샌드박스를 켤 때 규칙을 추가하기 전까지 **모든** 캡처 트래픽이 차단됩니다(`gori run project scope add …`). 이 명령은 경고 후 진행하므로 CI에서 컨테인먼트를 부트스트랩할 수 있습니다.
 
 #### project env {#run-project-env}
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -70,6 +70,7 @@ gori run <subcommand> [options]
 | `rewriter` · `add` · `rm` · `enable` · `disable` · `preview` | Manage Match & Replace rules |
 | `project [list]` | List known projects |
 | `project scope` | List / add / delete / enable / disable scope rules |
+| `project sandbox` | Get / set the hard-containment sandbox gate (`status`, `on`, `off`) |
 | `project env` | List / set / delete project env vars (`$KEY` substitution) |
 
 Common flags across read subcommands: `--project=NAME`, `--db=PATH`, `--format=FMT` (usually `text` or `json`).
@@ -202,6 +203,8 @@ gori run probe -a
 ```
 
 `--severity` is `info`\|`low`\|`medium`\|`high`\|`critical`; `--category` is `headers`\|`cookies`\|`tech`\|`infoleak`\|`cors`\|`client`\|`active`; `-a`/`--active` includes light-touch active checks; `-q`/`--query` filters with QL.
+
+With `--active`: `--unsafe` also probes unsafe methods (`POST`/`PUT`/`PATCH`/`DELETE`), whose re-sends may mutate server data; `--aggressive` raises the per-rule caps and widens the forbidden-bypass header set (and implies `--unsafe`). Both stay scope-gated unless you also pass `--allow-unscoped`. Use them only against authorized targets.
 
 ### run discover
 
@@ -386,6 +389,25 @@ gori run project scope disable
 | `add` | `--kind=include\|exclude`, `--type=host\|string\|regex`, `--pattern=…` |
 | `delete <rule-id>` | Remove a rule by id |
 | `enable` / `disable` | Toggle whether scope filtering is applied |
+
+#### project sandbox
+
+Get or set the **hard-containment** sandbox gate, the headless equivalent of the TUI Project NETWORK toggle. When on, the capture proxy forwards only requests the scope allows and blocks everything else. This is distinct from `project scope enable`, which is only the display lens.
+
+```bash
+gori run project sandbox                 # show the current state (status is the default)
+gori run project sandbox status --format json
+gori run project sandbox on              # start blocking out-of-scope traffic
+gori run project sandbox off             # stop blocking
+```
+
+| Option / subcommand | Description |
+|---------------------|-------------|
+| (default) / `status` | Show the gate state; `--format` is `text` or `json` |
+| `on` / `enable` | Block every request the scope does not allow |
+| `off` / `disable` | Stop blocking |
+
+> With no include rule, turning the sandbox on blocks **all** captured traffic until you add one (`gori run project scope add …`). The command warns and proceeds, so it can bootstrap containment for CI.
 
 #### project env
 


### PR DESCRIPTION
## Problem

Reviewing today's merged work (#342/#346 probe unsafe opt-in + AGGRESSIVE mode, #344 `gori run project sandbox`) surfaced a documentation gap, not a code defect: three shipped features had no docs, and one existing sentence had gone stale.

- `guide/scanning.md` stated **"Only safe methods (`GET`/`HEAD`) are probed"** — no longer true once AGGRESSIVE mode and the per-flow unsafe opt-in exist.
- `reference/cli.md` documented neither the `--unsafe`/`--aggressive` probe flags nor the new `gori run project sandbox` subcommand. (`gori.proxy` from #347 was already documented.)

## Fix

- **scanning.md / .ko.md** — "by default only safe methods", plus a paragraph on the two opt-in paths (per-flow *Run active scan* popup, or AGGRESSIVE mode), both of which stay inside project scope. Added `--unsafe`/`--aggressive` example lines.
- **cli.md / .ko.md** — `run probe` now documents `--unsafe`/`--aggressive` and their scope gate; a new `project sandbox` subsection (status/on/off + the no-include-rule block-all warning); and a `project sandbox` row in the run-subcommand overview table.

## Notes

Docs-only, `+54/-2` across 4 files. EN + KO parity, no em-dashes (de-AI tone), anchors match each file's sibling convention, code-fence balance verified.

Verification during review: build clean, 800+ relevant specs green, `gori run project sandbox` exercised end-to-end (status/on/off/json + warning). No code changes.