### PR TITLE
feat(cli): create and delete projects from `gori run project`

### DIFF
--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -69,6 +69,8 @@ gori run <subcommand> [options]
 | `issues` · `create` · `update` | 이슈 목록 / 내보내기, 또는 이슈 작성 |
 | `rewriter` · `add` · `rm` · `enable` · `disable` · `preview` | Match & Replace 규칙 관리 |
 | `project [list]` | 알려진 프로젝트 목록 |
+| `project create <name>` | 이름으로 프로젝트 생성 (같은 이름이면 다시 열기) |
+| `project delete <name>` | 프로젝트와 그 안에 캡처된 모든 것 삭제 (`--yes`로 확인) |
 | `project scope` | 스코프 규칙 목록 / 추가 / 삭제 / 활성화 / 비활성화 |
 | `project sandbox` | 하드 컨테인먼트 샌드박스 게이트 조회 / 설정 (`status`, `on`, `off`) |
 | `project env` | 프로젝트 env 변수 목록 / 설정 / 삭제 (`$KEY` 치환) |
@@ -362,12 +364,50 @@ gori run rewriter rm 3
 
 ### run project {#run-project}
 
-알려진 프로젝트 목록, 또는 프로젝트 스코프 설정(스코프 규칙, env 변수, 호스트 오버라이드) 관리:
+프로젝트 목록/생성/삭제, 또는 프로젝트 스코프 설정(스코프 규칙, env 변수, 호스트 오버라이드) 관리:
 
 ```bash
 gori run project --format json
 gori run project list
 ```
+
+#### project create {#project-create}
+
+트래픽을 캡처하지 않고 프로젝트를 만듭니다. `gori run capture --project=NAME`도 필요할 때 만들어 주지만, 이 명령은 요청을 보내지 않으므로 프록시를 띄우기 전에 스코프와 env를 미리 구성할 수 있습니다.
+
+```bash
+gori run project create "API test"
+gori run project create api-test --description="staging sweep"
+gori run project create api-test --format json
+```
+
+| Option / subcommand | Description |
+|---------------------|-------------|
+| `<name>` | 표시 이름. 공백이 들어가면 따옴표로 감쌉니다 |
+| `--description=TEXT` | 프로젝트 설정에 저장됩니다 |
+| `--format=FMT` | `text`(기본) 또는 `json` |
+
+이미 있는 이름은 오류가 아니라 그 프로젝트를 다시 여는 것으로 처리하며, `--format json`은 `"created": false`로 알려 줍니다. 다시 열 때 저장된 표시 이름은 마지막 create의 대소문자로 갱신되고, `--description`을 주면 기존 설명을 덮어씁니다.
+
+#### project delete {#project-delete}
+
+프로젝트 디렉터리와 그 안에 캡처된 모든 것(플로우, 이슈, 노트, 스코프, 규칙)을 삭제합니다. 되돌릴 수 없으므로 두 단계로 동작합니다. `--yes` 없이 실행하면 대상만 출력하고 0이 아닌 코드로 종료합니다.
+
+```bash
+gori run project delete api-test              # preview only, nothing is removed
+gori run project delete api-test --format json
+gori run project rm api-test --yes            # actually delete
+```
+
+| Option / subcommand | Description |
+|---------------------|-------------|
+| `<name>` | 짧은 id, id 접두사, 디렉터리 slug, 표시 이름 중 하나로 지정 |
+| `--yes` | 실제로 삭제. 없으면 아무것도 지우지 않습니다 |
+| `--format=FMT` | `text`(기본) 또는 `json` |
+
+미리보기는 플로우/이슈 개수, 디스크 사용량, 캡처가 살아 있는지를 함께 보여 줍니다. 다른 gori 인스턴스가 캡처 중인 프로젝트는 삭제를 거부하므로, 그 캡처를 먼저 중지해야 합니다.
+
+표시 이름은 유일하지 않습니다(같은 basename을 쓰는 두 워크스페이스는 이름을 공유합니다). 이름이 여러 프로젝트에 걸리면 삭제를 거부하고 각각의 slug를 보여 줍니다. 잘못 고르면 되돌릴 수 없기 때문입니다. slug와 짧은 id는 유일하므로 언제나 하나로 확정됩니다.
 
 #### project scope {#run-project-scope}
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -69,6 +69,8 @@ gori run <subcommand> [options]
 | `issues` · `create` · `update` | List / export issues, or write issues |
 | `rewriter` · `add` · `rm` · `enable` · `disable` · `preview` | Manage Match & Replace rules |
 | `project [list]` | List known projects |
+| `project create <name>` | Create (or reopen) a project by name |
+| `project delete <name>` | Delete a project and everything captured in it (`--yes` to confirm) |
 | `project scope` | List / add / delete / enable / disable scope rules |
 | `project sandbox` | Get / set the hard-containment sandbox gate (`status`, `on`, `off`) |
 | `project env` | List / set / delete project env vars (`$KEY` substitution) |
@@ -362,12 +364,50 @@ Body rules re-sync `Content-Length` and de-chunk as needed, and an enabled rule 
 
 ### run project
 
-List known projects, or manage project-scoped config (scope rules, env vars, host overrides):
+List, create, or delete projects, or manage project-scoped config (scope rules, env vars, host overrides):
 
 ```bash
 gori run project --format json
 gori run project list
 ```
+
+#### project create
+
+Create a project without capturing into it first. `gori run capture --project=NAME` also creates on demand; this is the traffic-free way to do it, so scripts can set up scope and env before the proxy starts.
+
+```bash
+gori run project create "API test"
+gori run project create api-test --description="staging sweep"
+gori run project create api-test --format json
+```
+
+| Option / subcommand | Description |
+|---------------------|-------------|
+| `<name>` | Display name. Quote it if it contains spaces |
+| `--description=TEXT` | Stored in the project's settings |
+| `--format=FMT` | `text` (default) or `json` |
+
+A name that already exists reopens that project instead of failing; `--format json` reports it as `"created": false`. The reopen rewrites the stored display name (so its casing follows the last create) and replaces the description when `--description` is given.
+
+#### project delete
+
+Delete a project directory and everything captured in it (flows, issues, notes, scope, rules). Irreversible, so it takes two steps: without `--yes` it only prints the target and exits non-zero.
+
+```bash
+gori run project delete api-test              # preview only, nothing is removed
+gori run project delete api-test --format json
+gori run project rm api-test --yes            # actually delete
+```
+
+| Option / subcommand | Description |
+|---------------------|-------------|
+| `<name>` | Matches a short id, id prefix, directory slug, or display name |
+| `--yes` | Perform the delete. Without it the command removes nothing |
+| `--format=FMT` | `text` (default) or `json` |
+
+The preview reports flow and issue counts, on-disk size, and whether a capture is live. Deleting a project another gori instance is capturing into is refused: stop that capture first.
+
+Display names are not unique (two workspaces with the same basename share one). When a name matches more than one project, delete refuses and lists their slugs, since the wrong guess is unrecoverable. Slugs and short ids are unique, so either always resolves.
 
 #### project scope
 

--- a/spec/cli_run_spec.cr
+++ b/spec/cli_run_spec.cr
@@ -866,3 +866,146 @@ describe "gori run intercept (bridge state)" do
     end
   end
 end
+
+# `gori run project create/delete` glue is private CLI code — reopen the module for
+# bare-call wrappers (the same whitebox trick as the others above).
+module Gori::CLI::Run
+  def self.project_object_counts_for_spec(project : Gori::Project) : {Int64?, Int32?}
+    project_object_counts(project)
+  end
+
+  def self.ambiguous_project_name_for_spec(registry : Gori::ProjectRegistry, name : String) : Bool
+    ambiguous_name?(registry, name)
+  end
+end
+
+private def with_project_root(&)
+  root = File.tempname("gori-projroot")
+  begin
+    yield Gori::ProjectRegistry.new(root)
+  ensure
+    FileUtils.rm_rf(root)
+  end
+end
+
+private def seed_project_flow(store) : Int64
+  store.insert_flow(Gori::Store::CapturedRequest.new(
+    created_at: 1_i64, scheme: "https", host: "ex.test", port: 443,
+    method: "GET", target: "/", http_version: "HTTP/1.1",
+    head: "GET / HTTP/1.1\r\nHost: ex.test\r\n\r\n".to_slice, body: nil))
+end
+
+# One handle, closed exactly once — Store#close is NOT idempotent (a 2nd @done.receive
+# blocks forever), so each open gets its own short block instead of a close-then-flag.
+private def with_project_store(project : Gori::Project, &)
+  store = Gori::Store.open(project.db_path)
+  begin
+    yield store
+  ensure
+    store.close
+  end
+end
+
+describe "gori run project create" do
+  it "reports created-vs-reopened from the registry, not from a name lookup" do
+    with_project_root do |registry|
+      project, created = registry.create_or_reopen("spec proj")
+      created.should be_true
+      # A name that is a PREFIX of the first project's short id: #find would resolve it to
+      # that project and call this brand-new one a reopen.
+      id = registry.id_of(project).not_nil!
+      other, other_created = registry.create_or_reopen(id[0, 4])
+      other_created.should be_true
+      other.dir.should_not eq(project.dir)
+
+      registry.create_or_reopen("spec proj")[1].should be_false # same name → reopen
+    end
+  end
+
+  it "materializes the DB so a description-less project is immediately listed" do
+    with_project_root do |registry|
+      # #list skips a directory with no DB; a lazily-created one would stay invisible to
+      # `project list` / --project until something captured into it.
+      project = registry.create("spec proj")
+      File.exists?(project.db_path).should be_true
+      registry.list.map(&.name).should eq(["spec proj"])
+    end
+  end
+
+  it "leaves an existing DB untouched when create reopens the project" do
+    with_project_root do |registry|
+      project = registry.create("spec proj")
+      with_project_store(project) { |store| seed_project_flow(store) }
+      registry.create("spec proj") # reopen path: must not recreate the DB
+      with_project_store(project, &.count.should(eq(1)))
+    end
+  end
+end
+
+describe "gori run project delete (preview)" do
+  it "counts the flows and issues that deleting would destroy" do
+    with_project_root do |registry|
+      project = registry.create("spec proj")
+      with_project_store(project) do |store|
+        2.times { seed_project_flow(store) }
+        store.insert_issue("finding", Gori::Store::Severity::Low, "ex.test", nil)
+      end
+      Gori::CLI::Run.project_object_counts_for_spec(project).should eq({2_i64, 1})
+      # The whole directory is what rm_rf takes, so the preview sizes it (DB + WAL/SHM +
+      # sidecars), never just the DB file.
+      project.disk_size.should be > project.db_size
+    end
+  end
+
+  it "reports nil counts for a project whose DB was deleted under it" do
+    with_project_root do |registry|
+      project = registry.create("empty proj")
+      File.delete(project.db_path)
+      Gori::CLI::Run.project_object_counts_for_spec(project).should eq({nil, nil})
+      project.disk_size.should be > 0 # the .name/.id sidecars still go with the directory
+    end
+  end
+
+  it "sizes a directory whose path contains glob metacharacters" do
+    root = File.tempname("gori-proj[root]") # `[...]` is a glob character class
+    begin
+      project = Gori::ProjectRegistry.new(root).create("globby")
+      project.disk_size.should be > 0
+    ensure
+      FileUtils.rm_rf(root)
+    end
+  end
+end
+
+describe "gori run project delete (resolution)" do
+  it "refuses a display name shared by two projects, and accepts either slug" do
+    root = File.tempname("gori-projroot")
+    begin
+      registry = Gori::ProjectRegistry.new(root)
+      # What create_for_workspace produces for two checkouts with the same basename:
+      # distinct slugs (my-api, my-api-2), one shared display name.
+      registry.create("My API")
+      twin = File.join(root, "my-api-2")
+      Dir.mkdir_p(twin)
+      File.write(File.join(twin, Gori::ProjectRegistry::NAME_FILE), "My API")
+      Gori::Store.open(File.join(twin, Gori::Project::DB_FILE)).close
+
+      registry.list.count { |p| p.name == "My API" }.should eq(2)
+      Gori::CLI::Run.ambiguous_project_name_for_spec(registry, "My API").should be_true
+      Gori::CLI::Run.ambiguous_project_name_for_spec(registry, "my api").should be_true # find is case-insensitive
+      # Slugs are unique, and #find resolves them before the display-name pass.
+      Gori::CLI::Run.ambiguous_project_name_for_spec(registry, "my-api").should be_false
+      Gori::CLI::Run.ambiguous_project_name_for_spec(registry, "my-api-2").should be_false
+    ensure
+      FileUtils.rm_rf(root)
+    end
+  end
+
+  it "does not call a uniquely-named project ambiguous" do
+    with_project_root do |registry|
+      registry.create("alpha")
+      registry.create("beta")
+      Gori::CLI::Run.ambiguous_project_name_for_spec(registry, "alpha").should be_false
+    end
+  end
+end

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -151,7 +151,10 @@ module Gori
         {"decoder <chain>", "Encode/decode/hash via the Decoder engine (base64, hex, url, gzip …)"},
         {"rewriter", "Manage Match & Replace rules (list, add, rm, enable/disable, preview)"},
         {"project [list]", "List known projects"},
+        {"project create", "Create (or reopen) a project by name"},
+        {"project delete", "Delete a project and everything captured in it"},
         {"project scope", "Manage scope rules (list, add, delete, enable/disable)"},
+        {"project sandbox", "Get/set the hard-containment sandbox gate (status, on, off)"},
         {"project env", "Manage project env vars ($KEY substitution)"},
         {"project host-override", "Manage host overrides (list, add, update, delete)"},
       ]

--- a/src/gori/cli/run/project.cr
+++ b/src/gori/cli/run/project.cr
@@ -1,4 +1,4 @@
-# `gori run project` — list known projects, or manage project-scoped config:
+# `gori run project` — list/create/delete projects, or manage project-scoped config:
 # scope rules, env vars ($KEY substitution), and host overrides.
 module Gori
   module CLI
@@ -12,6 +12,10 @@ module Gori
           print_project_help
         when "list"
           cmd_project_list(args[1..])
+        when "create"
+          cmd_project_create(args[1..])
+        when "delete", "rm"
+          cmd_project_delete(args[1..])
         when "scope"
           cmd_project_scope(args[1..])
         when "sandbox"
@@ -34,12 +38,14 @@ module Gori
 
       private def self.print_project_help : Nil
         puts <<-HELP
-        gori run project — list projects, or manage project-scoped config
+        gori run project — list/create/delete projects, or manage project-scoped config
 
         Usage: gori run project [<subcommand>] [options]
 
         Subcommands:
           list               List known projects (default when no subcommand)
+          create <name>      Create (or reopen) a project by name
+          delete|rm <name>   Delete a project and everything captured in it
           scope              Manage scope rules (list, add, delete, enable/disable)
           sandbox            Get/set the hard-containment sandbox gate (status, on, off)
           env                Manage project env vars ($KEY substitution)
@@ -47,6 +53,8 @@ module Gori
 
         Examples:
           gori run project --format json
+          gori run project create "API test" --description="staging sweep"
+          gori run project delete api-test --yes
           gori run project scope add --kind=include --type=host --pattern=api.example.com
           gori run project sandbox on
           gori run project env set TOKEN=secret
@@ -94,6 +102,212 @@ module Gori
             puts "#{pr.name.ljust(24)}  #{id.ljust(8)}  #{ts}  #{CLI::Output.human_size(pr.db_size)}"
           end
         end
+      end
+
+      # `gori run project create` — make a project without capturing into it first.
+      # `gori run capture --project=NAME` already creates on demand, but that is the only
+      # headless way to get one today: every other run subcommand aborts on an unknown
+      # --project. This is the explicit, traffic-free door (CLI parity with MCP
+      # create_project). Reopening by name is not an error — it mirrors both.
+      private def self.cmd_project_create(args : Array(String)) : Nil
+        description = ""
+        format = :text
+        positional = [] of String
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run project create <name> [options]\n\n" \
+                     "Create a project, or reopen the existing one with that name."
+          p.on("--description=TEXT", "Description stored in the project's settings") { |v| description = v }
+          p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| positional = rest }
+          p.invalid_option { |f| abort "gori run project create: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run project create: missing value for #{f}" }
+        end
+        parser.parse(args)
+
+        abort "gori run project create: missing <name>" if positional.empty?
+        abort "gori run project create: too many arguments (quote a name that contains spaces)" if positional.size > 1
+        name = positional[0]
+
+        registry = ProjectRegistry.new(Paths.projects_dir)
+        project, created = create_project_entry(registry, name, description)
+
+        if format == :json
+          puts(JSON.build do |j|
+            j.object do
+              j.field "name", project.name
+              j.field "id", registry.id_of(project)
+              j.field "slug", registry.slug_of(project)
+              j.field "db_path", project.db_path
+              j.field "created", created # false = reopened an existing same-name project
+            end
+          end)
+        elsif created
+          puts "Project #{project.name.inspect} created (#{project.db_path})."
+        else
+          puts "Project #{project.name.inspect} already exists — reopened (#{project.db_path})."
+        end
+      end
+
+      # create_or_reopen rejects a name that slugifies to nothing (blank / punctuation-only)
+      # with a Gori::Error, and it both makes the directory and opens the DB — so a full,
+      # read-only or otherwise unusable projects root surfaces as File::Error/IO::Error or a
+      # driver error. Every one of them becomes a clean `gori run project create:` message
+      # (the TUI picker's safe_create rescues the same four).
+      private def self.create_project_entry(registry : ProjectRegistry, name : String,
+                                            description : String) : {Project, Bool}
+        registry.create_or_reopen(name, description)
+      rescue ex : Gori::Error
+        abort "gori run project create: #{ex.message} (#{name.inspect})"
+      rescue ex : File::Error | IO::Error
+        abort "gori run project create: could not create project #{name.inspect}: #{ex.message}"
+      rescue ex : DB::Error | SQLite3::Exception
+        abort "gori run project create: could not initialize the database for #{name.inspect}: #{ex.message}"
+      end
+
+      # `gori run project delete` — remove a project directory and everything in it. Until
+      # now this lived only in the TUI picker (confirm modal) and MCP delete_project
+      # (dry-run + token). Irreversible, so the headless form keeps the same two steps:
+      # without --yes it prints what would go and exits non-zero.
+      private def self.cmd_project_delete(args : Array(String)) : Nil
+        yes = false
+        format = :text
+        positional = [] of String
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run project delete|rm <name> [options]\n\n" \
+                     "Permanently removes the project directory: captured flows, issues,\n" \
+                     "notes, scope, everything. Without --yes it only previews the target.\n" \
+                     "<name> matches a short id, id prefix, directory slug, or display name."
+          p.on("--yes", "Actually delete (without it, nothing is removed)") { yes = true }
+          p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| positional = rest }
+          p.invalid_option { |f| abort "gori run project delete: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run project delete: missing value for #{f}" }
+        end
+        parser.parse(args)
+
+        abort "gori run project delete: missing <name>" if positional.empty?
+        abort "gori run project delete: too many arguments (expected one <name>)" if positional.size > 1
+        name = positional[0]
+
+        registry = ProjectRegistry.new(Paths.projects_dir)
+        project = registry.find(name) || abort_unknown_project(registry, name)
+        abort_ambiguous_project(registry, name) if ambiguous_name?(registry, name)
+        print_delete_preview(registry, project, format) unless yes # NoReturn
+
+        # Read the sidecars while they still exist — rm_rf takes them with the directory.
+        id = registry.id_of(project)
+        slug = registry.slug_of(project)
+        begin
+          registry.delete(project) # refuses while another live instance holds the capture lock
+        rescue ex : Gori::Error
+          abort "gori run project delete: #{ex.message}"
+        rescue ex : File::Error | IO::Error
+          abort "gori run project delete: could not remove #{project.dir}: #{ex.message}"
+        end
+
+        if format == :json
+          puts(JSON.build do |j|
+            j.object do
+              j.field "deleted", true
+              j.field "name", project.name
+              j.field "id", id
+              j.field "slug", slug
+              j.field "dir", project.dir
+              j.field "db_path", project.db_path
+            end
+          end)
+        else
+          puts "Project #{project.name.inspect} deleted (#{project.dir})."
+        end
+      end
+
+      private def self.abort_unknown_project(registry : ProjectRegistry, name : String) : NoReturn
+        projects = registry.list
+        have = projects.empty? ? "" : " (have: #{projects.map(&.name).join(", ")})"
+        abort "gori run project delete: no project matching '#{name}'#{have}"
+      end
+
+      # Display names are deliberately NOT unique (two workspaces sharing a basename get the
+      # same name, e.g. slugs `api` and `api-2`), and #find resolves a name to the
+      # most-recently-active match. Good enough for a read; not for an rm_rf. Refuse and make
+      # the caller name the slug or short id — which, being unique, resolve before the name
+      # pass in #find, so an exact one of those is never called ambiguous.
+      private def self.ambiguous_name?(registry : ProjectRegistry, name : String) : Bool
+        q = name.strip.downcase
+        projects = registry.list
+        return false if projects.any? { |p| registry.slug_of(p).downcase == q || registry.id_of(p).try(&.downcase) == q }
+        projects.count { |p| p.name.downcase == q } > 1
+      end
+
+      private def self.abort_ambiguous_project(registry : ProjectRegistry, name : String) : NoReturn
+        q = name.strip.downcase
+        candidates = registry.list.select { |p| p.name.downcase == q }
+        listed = candidates.map { |p| "#{registry.slug_of(p)} (id #{registry.id_of(p) || "—"})" }.join(", ")
+        abort "gori run project delete: '#{name}' matches #{candidates.size} projects — " \
+              "delete by slug or short id instead: #{listed}"
+      end
+
+      # What --yes would destroy. Exits NON-ZERO: this path removed nothing, and a script
+      # that forgot --yes must not read a 0 as "it's gone".
+      private def self.print_delete_preview(registry : ProjectRegistry, project : Project, format : Symbol) : NoReturn
+        flows, issues = project_object_counts(project)
+        locked = capture_running?(project)
+        if format == :json
+          puts(JSON.build do |j|
+            j.object do
+              j.field "dry_run", true
+              j.field "deleted", false
+              j.field "name", project.name
+              j.field "id", registry.id_of(project)
+              j.field "slug", registry.slug_of(project)
+              j.field "dir", project.dir
+              j.field "db_path", project.db_path
+              j.field "flows", flows
+              j.field "issues", issues
+              j.field "db_size", project.db_size
+              j.field "disk_size", project.disk_size
+              j.field "capture_lock_held", locked
+            end
+          end)
+        else
+          puts "Project:  #{project.name}  (id #{registry.id_of(project) || "—"}, slug #{registry.slug_of(project)})"
+          puts "Dir:      #{project.dir}"
+          puts "Flows:    #{flows || "—"}"
+          puts "Issues:   #{issues || "—"}"
+          puts "On disk:  #{CLI::Output.human_size(project.disk_size)}"
+          puts "Capture:  #{locked ? "RUNNING in another gori instance" : "not running"}"
+        end
+        abort "gori run project delete: nothing deleted — re-run with --yes to remove #{project.dir}"
+      end
+
+      # Is another live instance capturing into this project? CaptureLock.held? probes by
+      # ACQUIRING the lock (it creates the lock file and re-raises anything that is not
+      # contention), so a project directory this user can read but not write would blow up a
+      # command that promised to only look. Unknown reads as "not running" here; the delete
+      # itself re-probes through ProjectRegistry#delete, which is where being wrong matters.
+      private def self.capture_running?(project : Project) : Bool
+        CaptureLock.held?(project.dir)
+      rescue
+        false
+      end
+
+      # Flow + issue counts for the delete preview, from a short-lived handle of its own.
+      # Best-effort: a locked or corrupt DB reports nil rather than failing the preview
+      # (mirrors MCP delete_project's dry run).
+      private def self.project_object_counts(project : Project) : {Int64?, Int32?}
+        return {nil, nil} unless File.exists?(project.db_path)
+        store = Store.open(project.db_path)
+        begin
+          {store.count, store.count_issues}
+        ensure
+          store.close
+        end
+      rescue
+        {nil, nil}
       end
 
       private def self.cmd_project_scope(args : Array(String)) : Nil

--- a/src/gori/mcp/tools/projects.cr
+++ b/src/gori/mcp/tools/projects.cr
@@ -61,11 +61,11 @@ module Gori
         return err("missing required 'name'", "INVALID_ARGUMENT", field: "name") if name.nil? || name.strip.empty?
         description = str(h, "description") || ""
         reg = registry
-        existed = !reg.find(name).nil?
-        proj = reg.create(name, description)
-        # Materialize the DB (create+migrate) so the project is immediately visible
-        # to list_projects/switch_project even when no description was supplied.
-        Store.open(proj.db_path).close unless File.exists?(proj.db_path)
+        # The registry reports created-vs-reopened (and materializes the DB, so the project
+        # is immediately visible to list_projects/switch_project). Asking #find beforehand
+        # instead would call a brand-new project a reopen whenever its name happens to be a
+        # prefix of another project's short id.
+        proj, created = reg.create_or_reopen(name, description)
 
         # First-run UX: when the server has no project yet, bind immediately so the
         # agent can use traffic tools without a separate switch_project call.
@@ -82,7 +82,7 @@ module Gori
             j.field "id", reg.id_of(proj)
             j.field "slug", reg.slug_of(proj)
             j.field "db_path", proj.db_path
-            j.field "created", !existed # false = reopened an existing same-name project
+            j.field "created", created # false = reopened an existing same-name project
             j.field "switched", auto_bound
           end
         end)
@@ -171,7 +171,7 @@ module Gori
             j.field "flows", flows
             j.field "issues", issues
             j.field "db_size", proj.db_size
-            j.field "disk_size", dir_size(proj.dir)
+            j.field "disk_size", proj.disk_size
             j.field "capture_lock_held", CaptureLock.held?(proj.dir)
             j.field "confirmation_token", token
             j.field "token_expires_in_seconds", DELETE_TOKEN_TTL
@@ -219,17 +219,6 @@ module Gori
         end
       rescue
         {nil, nil}
-      end
-
-      private def dir_size(dir : String) : Int64
-        return 0_i64 unless Dir.exists?(dir)
-        total = 0_i64
-        Dir.glob(File.join(dir, "**", "*")).each do |f|
-          total += File.info(f).size if File.file?(f)
-        rescue
-          # skip anything that vanished / is unreadable mid-walk
-        end
-        total
       end
     end
   end

--- a/src/gori/project.cr
+++ b/src/gori/project.cr
@@ -39,6 +39,43 @@ module Gori
       File.exists?(@db_path) ? File.info(@db_path).size : 0_i64
     end
 
+    # Total bytes of every file under the project directory (DB + WAL/SHM + the dotfile
+    # sidecars), for the "this is what you are deleting" previews. Walks with Dir.children
+    # rather than Dir.glob: a glob pattern is built from the projects ROOT, so a home
+    # directory holding `[`, `*` or `?` would silently match nothing and report 0 bytes for
+    # a multi-GB capture — the one number an operator reads before confirming an
+    # irreversible delete. Best-effort otherwise: anything that vanishes or is unreadable
+    # mid-walk is skipped rather than raising.
+    #
+    # Meaningful only for a REGISTRY project, whose `dir` is its own workspace. A Project
+    # built from an explicit `--db PATH` borrows an arbitrary parent directory, and walking
+    # that is neither cheap nor meaningful.
+    def disk_size : Int64
+      d = dir
+      return 0_i64 unless Dir.exists?(d)
+      total = 0_i64
+      pending = [d]
+      while current = pending.pop?
+        children = begin
+          Dir.children(current)
+        rescue
+          next # a directory that vanished or became unlistable mid-walk
+        end
+        children.each do |child|
+          path = File.join(current, child)
+          info = File.info(path, follow_symlinks: false)
+          if info.directory?
+            pending << path
+          else
+            total += info.size
+          end
+        rescue
+          # skip anything that vanished / is unreadable mid-walk
+        end
+      end
+      total
+    end
+
     # Best-effort project creation time (project dir mtime from mkdir in registry;
     # falls back to earliest flow activity inside the Project tab view).
     def created : Time?

--- a/src/gori/project_registry.cr
+++ b/src/gori/project_registry.cr
@@ -125,25 +125,40 @@ module Gori
     # `description` is optional and persisted immediately into the project's
     # settings (so it is available on first open in the Project tab).
     def create(name : String, description : String = "") : Project
+      create_or_reopen(name, description)[0]
+    end
+
+    # #create, plus WHICH of the two it did: `true` = a new project, `false` = reopened one
+    # that already existed under that name. Only the registry can answer that honestly — it
+    # is the one that resolves the slug — so every caller that reports "created" (CLI, MCP)
+    # reads it from here instead of guessing beforehand with #find, which also matches a
+    # short-id prefix and would call a brand-new project a reopen.
+    def create_or_reopen(name : String, description : String = "") : {Project, Bool}
       display = name.strip
       slug = slugify(display)
       raise Gori::Error.new("invalid project name") if slug.empty?
       slug = unique_slug(slug, display) # don't merge into a DIFFERENT project that slugifies alike
       dir = File.join(@root, slug)
+      db_path = File.join(dir, Project::DB_FILE)
+      # A DB at the resolved path is the same thing #list calls an existing project.
+      reopened = File.exists?(db_path)
       Paths.ensure_dir(dir) # 0700 — the project dir holds a DB of captured secrets
       # Persist the verbatim display name so a later `list` shows "My Project", not
       # the lossy slug "my-project".
       File.write(File.join(dir, NAME_FILE), display) rescue nil
       write_id_if_absent(dir) # a fresh project gets a stable short id; a reopen keeps its own
-      proj = Project.new(display, File.join(dir, Project::DB_FILE))
-      desc = description.strip
-      unless desc.empty?
-        # First open creates the DB + runs migrations (including settings table).
-        s = Store.open(proj.db_path)
-        s.set_setting("description", desc)
+      proj = Project.new(display, db_path)
+      # Open once even with no description: this creates the DB + runs migrations, and #list
+      # SKIPS a directory without one. Leaving it lazy made a freshly created project
+      # invisible to `gori run project list` / --project until something captured into it.
+      s = Store.open(proj.db_path)
+      begin
+        desc = description.strip
+        s.set_setting("description", desc) unless desc.empty?
+      ensure
         s.close
       end
-      proj
+      {proj, !reopened}
     end
 
     # Resolve or create the project for a source workspace. Exact path binding


### PR DESCRIPTION
`gori run project` could list projects but never make or remove one, so a headless run had to start a capture just to get a project. Project lifecycle lived only in the TUI picker and MCP.

## Added

- **`gori run project create <name>`** — `--description`, `--format=text|json`. An existing name reopens instead of failing (`"created": false`).
- **`gori run project delete|rm <name>`** — preview by default (flows, issues, on-disk size, whether a capture is live), `--yes` to actually remove. The preview exits **non-zero**: a script that forgot `--yes` must not read a 0 as "it's gone". Mirrors MCP `delete_project`'s dry-run/confirm shape.

## Fixed along the way

- `ProjectRegistry#create_or_reopen` now reports created-vs-reopened and always materializes the DB. `#list` skips a directory without one, so a lazily created project stayed invisible to `project list` / `--project`. Both CLI and MCP were guessing "did this exist?" from `#find`, which also matches a short-id prefix and so reported a brand-new project as a reopen — MCP `create_project` returned `"created": false` for it.
- Delete refuses a display name shared by two projects (display names are deliberately not unique; slugs and ids are) and lists their slugs, rather than `rm -rf`ing the most-recently-active one.
- `Project#disk_size` replaces MCP's private `dir_size` and walks with `Dir.children` instead of `Dir.glob`: a projects root containing `[`, `*` or `?` matched nothing and reported 0 bytes, which is the number an operator confirms an irreversible delete on. It now also counts the dotfile sidecars.
- The capture-lock probe in the preview no longer propagates a non-contention error (`CaptureLock.held?` acquires to probe, so an unwritable project dir crashed a command that promised to only look).
- `gori run -h` was missing `project sandbox`.

## Verification

- 3635 examples, 0 failures. New specs cover the created/reopen flag (including the id-prefix trap), materialization, delete-preview counts, `disk_size` over a glob-metacharacter path, and the ambiguous-name guard.
- Manually verified against an isolated `GORI_HOME`: create/reopen/JSON, preview exit codes, delete by slug and by id prefix, ambiguity refusal, and refusal while a live `gori run capture` holds the lock.
- ameba: no new findings on touched files. `crystal tool format` clean. Docs (EN + KO) rebuilt with `hwaro build`; new KO anchors match the EN-generated ids.

## Not changed

`project_object_counts` still duplicates MCP's `count_project_objects`; sharing it would put `Store.open` on the `Project` struct, which is a pure path type today.