### PR TITLE
test: cover verbs/ from zero and split the cli/run spec by subcommand (#358)

### DIFF
--- a/spec/cli/run/compare_spec.cr
+++ b/spec/cli/run/compare_spec.cr
@@ -1,0 +1,68 @@
+require "../../spec_helper"
+
+# `gori run compare` — the two flows' lines are built the same way the TUI Comparer does
+# it: REQUEST byte-faithful (no decoding — you are diffing what went on the wire) and
+# RESPONSE decoded (gzip/chunked), because a diff of two compressed blobs says nothing.
+
+private def flow_detail(request_head : String, request_body : Bytes? = nil,
+                        response_head : String? = nil, response_body : Bytes? = nil)
+  row = Gori::Store::FlowRow.new(
+    id: 7_i64, created_at: 0_i64, scheme: "https", method: "GET", host: "a.test", port: 443,
+    target: "/", status: 200, size: 0_i64, state: Gori::Store::FlowState::Complete)
+  Gori::Store::FlowDetail.new(row, "HTTP/1.1", request_head.to_slice, request_body,
+    response_head.try(&.to_slice), response_body)
+end
+
+# `compare_lines` / `emit_compare_result` are private CLI glue (compare_lines mirrors the
+# TUI Comparer's lines_for) — reopen the module for bare-call wrappers.
+module Gori::CLI::Run
+  def self.compare_lines_for_spec(d : Gori::Store::FlowDetail, pane : Symbol) : Array(String)
+    compare_lines(d, pane)
+  end
+end
+
+describe "gori run compare" do
+  it "builds request lines byte-faithful (no decoding) and response lines decoded" do
+    d = flow_detail("GET / HTTP/1.1\r\nHost: a.test\r\n\r\n",
+      response_head: "HTTP/1.1 200 OK\r\n\r\n", response_body: "hello".to_slice)
+    req_lines = Gori::CLI::Run.compare_lines_for_spec(d, :request)
+    req_lines.first.should eq("GET / HTTP/1.1")
+    resp_lines = Gori::CLI::Run.compare_lines_for_spec(d, :response)
+    resp_lines.should contain("hello")
+  end
+
+  it "leaves a chunked request body FRAMED — the request side never decodes" do
+    # Diffing two smuggling probes is the point of comparing requests: the chunk sizes and
+    # the framing ARE the payload. Decoding here would erase exactly what is being compared.
+    head = "POST /u HTTP/1.1\r\nHost: a.test\r\nTransfer-Encoding: chunked\r\n\r\n"
+    body = "5\r\nhello\r\n0\r\n\r\n".to_slice
+    lines = Gori::CLI::Run.compare_lines_for_spec(flow_detail(head, request_body: body), :request)
+    lines.should contain("5") # the chunk-size line survives verbatim
+    lines.should contain("hello")
+    lines.should contain("0")
+  end
+
+  it "dechunks the RESPONSE body, so the diff is over content and not framing" do
+    d = flow_detail("GET / HTTP/1.1\r\n\r\n",
+      response_head: "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n",
+      response_body: "5\r\nhello\r\n0\r\n\r\n".to_slice)
+    lines = Gori::CLI::Run.compare_lines_for_spec(d, :response)
+    lines.should contain("hello")
+    lines.should_not contain("5") # the chunk header is framing, decoded away
+  end
+
+  it "handles a flow with no response at all (a pending or errored capture)" do
+    # `compare <a> <b>` does not require either flow to have completed; a nil response
+    # pane must yield no lines rather than raising.
+    lines = Gori::CLI::Run.compare_lines_for_spec(flow_detail("GET / HTTP/1.1\r\n\r\n"), :response)
+    lines.should be_empty
+  end
+
+  it "counts changed lines through the shared differ" do
+    a = ["GET /a HTTP/1.1", "Host: x"]
+    b = ["GET /b HTTP/1.1", "Host: x"]
+    diff = Gori::Repeater::Diff.lines(a, b)
+    Gori::Repeater::Diff.change_count(diff).should be > 0
+    Gori::Repeater::Diff.change_count(Gori::Repeater::Diff.lines(a, a)).should eq(0)
+  end
+end

--- a/spec/cli/run/decoder_spec.cr
+++ b/spec/cli/run/decoder_spec.cr
@@ -1,0 +1,90 @@
+require "../../spec_helper"
+require "base64"
+require "json"
+
+# `gori run decoder` — the converter chain runner. Its `--format json` per-step document
+# is what makes a failing chain diagnosable, and it is the only place the CLI reports a
+# partial result: steps run left-to-right and stop at the first failure.
+
+# Private CLI glue — reopen the module for bare-call wrappers. (`parse_render_mode`'s
+# invalid branch aborts, so only the four valid spellings are exercised.)
+module Gori::CLI::Run
+  def self.decoder_json_for_spec(result : Gori::Decoder::ChainResult, mode : Gori::Decoder::RenderAs?) : String
+    decoder_json(result, mode)
+  end
+
+  def self.parse_render_mode_for_spec(v : String) : Gori::Decoder::RenderAs?
+    parse_render_mode(v)
+  end
+end
+
+private def run_chain(input : String, chain : String) : Gori::Decoder::ChainResult
+  Gori::Decoder.run(Gori::Decoder.shared_registry, input.to_slice, chain)
+end
+
+describe "gori run decoder --output" do
+  it "maps every documented spelling, case-insensitively, with auto meaning nil" do
+    Gori::CLI::Run.parse_render_mode_for_spec("auto").should be_nil # nil = let display() decide
+    Gori::CLI::Run.parse_render_mode_for_spec("text").should eq(Gori::Decoder::RenderAs::Text)
+    Gori::CLI::Run.parse_render_mode_for_spec("BASE64").should eq(Gori::Decoder::RenderAs::Base64)
+    Gori::CLI::Run.parse_render_mode_for_spec("Hex").should eq(Gori::Decoder::RenderAs::Hex)
+  end
+end
+
+describe "gori run decoder --format json" do
+  it "reports ok with one step object per converter, in chain order" do
+    json = JSON.parse(Gori::CLI::Run.decoder_json_for_spec(run_chain("SGVsbG8=", "base64-decode"), nil))
+    json["ok"].as_bool.should be_true
+    steps = json["steps"].as_a
+    steps.size.should eq(1)
+    steps[0]["token"].as_s.should eq("base64-decode")
+    steps[0]["name"].as_s.should_not be_empty
+    steps[0]["state"].as_s.should eq("ok")
+    steps[0]["output"].as_s.should eq("Hello")
+    json["output"].as_s.should eq("Hello")
+    json["failed_at"].raw.should be_nil
+  end
+
+  it "composes a chain left-to-right, keeping each intermediate output" do
+    result = run_chain("%53%47%56%73%62%47%38%3D", "url-decode > base64-decode")
+    json = JSON.parse(Gori::CLI::Run.decoder_json_for_spec(result, nil))
+    steps = json["steps"].as_a
+    steps.size.should eq(2)
+    steps[0]["output"].as_s.should eq("SGVsbG8=") # the url-decode result feeds step 2
+    steps[1]["output"].as_s.should eq("Hello")
+    json["output"].as_s.should eq("Hello")
+  end
+
+  it "reports an unknown converter as a 1-BASED failed_at, not a 0-based index" do
+    # `failed_at` is printed back to the user as "step #N"; emitting the raw 0-based index
+    # would point at the wrong converter in every chain longer than one.
+    result = run_chain("x", "url-decode > definitely-not-a-converter")
+    json = JSON.parse(Gori::CLI::Run.decoder_json_for_spec(result, nil))
+    json["ok"].as_bool.should be_false
+    json["failed_at"].as_i.should eq(2)
+    json["steps"].as_a[1]["state"].as_s.should eq("unknown")
+  end
+
+  it "honours an explicit --output mode on the FINAL value only" do
+    # Intermediate steps always render as-is (auto); forcing hex on them would bury the
+    # very thing the per-step view exists to show.
+    result = run_chain("hi", "sha256")
+    auto = JSON.parse(Gori::CLI::Run.decoder_json_for_spec(result, nil))
+    forced = JSON.parse(Gori::CLI::Run.decoder_json_for_spec(result, Gori::Decoder::RenderAs::Base64))
+    forced["render"].as_s.should eq("base64")
+    forced["output"].as_s.should_not eq(auto["output"].as_s)
+    # the step's own output keeps the auto rendering in BOTH documents
+    forced["steps"].as_a[0]["output"].as_s.should eq(auto["steps"].as_a[0]["output"].as_s)
+  end
+
+  it "renders binary output in a JSON-safe encoding, never raw bytes" do
+    # Decoder input is routinely attacker-controlled captured traffic; a base64 blob that
+    # decodes to arbitrary bytes must not put invalid UTF-8 into the JSON document.
+    binary = Base64.strict_encode(Bytes[0x00, 0xFF, 0xFE, 0x80])
+    json_str = Gori::CLI::Run.decoder_json_for_spec(run_chain(binary, "base64-decode"), nil)
+    json_str.valid_encoding?.should be_true
+    json = JSON.parse(json_str)
+    json["render"].as_s.should_not eq("text") # auto picked a byte-safe rendering
+    json["output"].as_s.valid_encoding?.should be_true
+  end
+end

--- a/spec/cli/run/history_spec.cr
+++ b/spec/cli/run/history_spec.cr
@@ -1,0 +1,233 @@
+require "../../spec_helper"
+require "base64"
+require "json"
+
+# `gori run history` / `gori run show` — the QL gate on the listing, the flow-row text and
+# JSON contract in CLI::Output, and the `show --format json` document. Split out of the
+# monolithic spec/cli_run_spec.cr so each subcommand mirrors src/gori/cli/run/.
+
+private def flow_row(*, target : String, host : String, status : Int32?, state : Gori::Store::FlowState)
+  Gori::Store::FlowRow.new(
+    id: 42_i64, created_at: 1_700_000_000_000_000_i64, scheme: "https", method: "GET",
+    host: host, port: 443, target: target, status: status, size: 1536_i64, state: state,
+    response_size: 1400_i64, duration_us: 3000_i64, content_type: "text/html")
+end
+
+private def flow_detail(scheme : String, host : String, port : Int32, request_head : String,
+                        http_version = "HTTP/1.1",
+                        response_head : String? = nil, response_body : String? = nil)
+  row = Gori::Store::FlowRow.new(
+    id: 7_i64, created_at: 0_i64, scheme: scheme, method: "GET", host: host, port: port,
+    target: "/", status: 200, size: 0_i64, state: Gori::Store::FlowState::Complete)
+  Gori::Store::FlowDetail.new(row, http_version, request_head.to_slice, nil,
+    response_head.try(&.to_slice), response_body.try(&.to_slice))
+end
+
+# `show_json` is `private` (CLI-command glue, not a public API) — reopen the module to
+# expose a thin bare-call wrapper for testing, same trick Crystal allows for whitebox
+# specs of private `self.` methods (a bare call from within the same type is permitted;
+# only an explicit-receiver call from outside is not).
+module Gori::CLI::Run
+  def self.show_json_for_spec(detail : Store::FlowDetail, req : Bool, resp : Bool,
+                              ws_msgs : Array(Store::WsMessage) = [] of Store::WsMessage) : String
+    show_json(detail, req, resp, ws_msgs)
+  end
+end
+
+describe "gori run history — the QL gate" do
+  # `gori run history -q` relies on this: a query that fails to compile to any
+  # clause collapses to the match-all EMPTY filter. The CLI special-cases that so
+  # a typo like `status:>=foo` errors instead of silently dumping every flow.
+  it "collapses an un-compilable query to EMPTY (so the CLI can reject it)" do
+    Gori::QL.parse("status:>=foo").should eq(Gori::QL::EMPTY)
+    Gori::QL.parse("-status:bar").should eq(Gori::QL::EMPTY)
+    Gori::QL.parse("login").should_not eq(Gori::QL::EMPTY)
+    Gori::QL.parse("status:>=500").should_not eq(Gori::QL::EMPTY)
+  end
+end
+
+describe "gori run history — CLI::Output rows" do
+  it "shows an absolute-form target as-is and prefixes an origin-form one with the host" do
+    abs = Gori::CLI::Output.flow_row_text(flow_row(target: "http://e.test/a", host: "e.test", status: 200, state: Gori::Store::FlowState::Complete))
+    abs.should contain("http://e.test/a")
+    abs.should_not contain("e.testhttp://") # no double host
+
+    rel = Gori::CLI::Output.flow_row_text(flow_row(target: "/a", host: "api.test", status: 200, state: Gori::Store::FlowState::Complete))
+    rel.should contain("api.test/a")
+  end
+
+  it "marks a pending flow with a dash status and a state tag" do
+    txt = Gori::CLI::Output.flow_row_text(flow_row(target: "/p", host: "h", status: nil, state: Gori::Store::FlowState::Pending))
+    txt.should contain("—")
+    txt.should contain("[Pending]")
+  end
+
+  it "neutralizes terminal escape sequences in an untrusted captured target" do
+    # A malicious client puts ANSI/OSC escapes in its request line; the text row must
+    # not inject them into the operator's terminal (they'd be replayed on every view).
+    evil = "/p\e[31m\r\n\e]0;pwned\a"
+    txt = Gori::CLI::Output.flow_row_text(flow_row(target: evil, host: "h", status: 200, state: Gori::Store::FlowState::Complete))
+    txt.should_not contain('\e') # no ESC
+    txt.should_not contain('\r') # no CR
+    txt.should_not contain('\a') # no BEL
+    txt.should contain("·")      # control bytes replaced with a visible marker
+  end
+
+  it "scrubs the METHOD and SCHEME columns too, not just the target" do
+    # All three come off the wire on the CLI's headless path; an escape in the method
+    # would land in the operator's terminal exactly like one in the target.
+    row = Gori::Store::FlowRow.new(
+      id: 1_i64, created_at: 0_i64, scheme: "ht\etp", method: "G\eET", host: "h", port: 80,
+      target: "/", status: 200, size: 0_i64, state: Gori::Store::FlowState::Complete)
+    txt = Gori::CLI::Output.flow_row_text(row)
+    txt.should_not contain('\e')
+    txt.should contain("G·ET")
+  end
+
+  it "term_safe leaves ordinary UTF-8 untouched but replaces control bytes" do
+    Gori::CLI::Output.term_safe("api.test/π/데이터").should eq("api.test/π/데이터")
+    Gori::CLI::Output.term_safe("a\tb\nc").should eq("a·b·c")
+  end
+
+  it "term_safe also scrubs invalid UTF-8 (not just control bytes) so JSON output stays valid" do
+    # A captured host/path is raw bytes off the wire (see Sitemap.template_class's comment)
+    # and can be invalid UTF-8 with NO control bytes at all — the old short-circuit
+    # (`return s unless s.each_char.any?(&.control?)`) let such a value straight through
+    # unchanged, since a replacement char isn't itself "control".
+    bad = String.new(Bytes[0x68, 0x69, 0xff, 0x68, 0x69]) # "hi\xFFhi"
+    bad.valid_encoding?.should be_false
+    out = Gori::CLI::Output.term_safe(bad)
+    out.valid_encoding?.should be_true
+    out.should eq("hi�hi")
+  end
+
+  it "term_safe_multiline keeps newlines and tabs while still killing ANSI/OSC" do
+    # This is the `show`/`repeater` TEXT view's scrubber: a captured head/body must keep
+    # its layout (a head flattened to one line is unreadable) while escapes still die.
+    src = "HTTP/1.1 200 OK\r\nX-A:\t1\n\e[31mred\e]0;title\a"
+    out = Gori::CLI::Output.term_safe_multiline(src)
+    out.should contain("\n") # line breaks survive
+    out.should contain("\t") # tabs survive
+    out.should_not contain('\e')
+    out.should_not contain('\a')
+    out.should contain('·') # the CR of the CRLF and the escapes are neutralized
+  end
+
+  it "emits a valid JSON object with the expected keys" do
+    json = JSON.parse(Gori::CLI::Output.flow_row_json(flow_row(target: "/a", host: "h", status: 200, state: Gori::Store::FlowState::Complete)))
+    json["id"].as_i.should eq(42)
+    json["method"].as_s.should eq("GET")
+    json["status"].as_i.should eq(200)
+    json["state"].as_s.should eq("complete") # lowercased to match the MCP serializer
+  end
+
+  # CLI::Output is the shape `gori run history --format json`, `gori run capture`'s
+  # JSON-Lines stream, and the MCP list_history tool all mirror. A field added to one
+  # serializer and not the other is a silent three-surface drift, and nothing else in the
+  # tree compares them. The ONE deliberate difference is the timestamp field name.
+  it "keeps the flow-row JSON keys in lockstep with the MCP serializer" do
+    row = flow_row(target: "/a", host: "h", status: 200, state: Gori::Store::FlowState::Complete)
+    cli = JSON.parse(Gori::CLI::Output.flow_row_json(row)).as_h.keys
+    mcp = JSON.parse(JSON.build { |j| Gori::MCP::Serialize.flow_row(j, row) }).as_h.keys
+
+    # Sorted: the point is a missing/extra FIELD, not the emission order.
+    (cli - ["time"]).sort!.should eq((mcp - ["created_at_iso"]).sort!)
+    cli.should contain("time")               # CLI names it `time`
+    mcp.should contain("created_at_iso")     # MCP names it `created_at_iso`
+    cli.should_not contain("created_at_iso") # …and neither carries both
+  end
+
+  it "humanises sizes and durations" do
+    Gori::CLI::Output.human_size(500_i64).should eq("500B")
+    Gori::CLI::Output.human_size(1536_i64).should eq("1.5kB")
+    Gori::CLI::Output.human_us(500_i64).should eq("500µs")
+    Gori::CLI::Output.human_us(1_500_i64).should eq("1.5ms")
+  end
+
+  it "scales human_size up to GB and TB (no '1024.0MB')" do
+    Gori::CLI::Output.human_size(1_073_741_824_i64).should eq("1.0GB")     # exactly 1 GiB
+    Gori::CLI::Output.human_size(5_368_709_120_i64).should eq("5.0GB")     # 5 GiB
+    Gori::CLI::Output.human_size(2_199_023_255_552_i64).should eq("2.0TB") # 2 TiB
+  end
+
+  it "rolls human_us over to seconds" do
+    Gori::CLI::Output.human_us(1_000_000_i64).should eq("1.0s")
+    # Both formatters share ONE rounding edge, and it is deliberate: the tier check runs
+    # before round1, so a value just under a boundary prints as the rounded boundary.
+    # Pinned here so it reads as a known edge rather than a formatter bug.
+    Gori::CLI::Output.human_us(999_999_i64).should eq("1000.0ms")
+    Gori::CLI::Output.human_size(1_048_575_i64).should eq("1024.0kB")
+  end
+end
+
+describe "gori run show --format json" do
+  it "nests the flow row under `flow` and carries the http version + error" do
+    detail = flow_detail("https", "x", 443, "GET / HTTP/1.1\r\nHost: x\r\n\r\n",
+      response_head: "HTTP/1.1 200 OK\r\n\r\n", response_body: "hi", http_version: "HTTP/2")
+    json = JSON.parse(Gori::CLI::Run.show_json_for_spec(detail, true, true))
+    json["flow"]["id"].as_i.should eq(7)
+    json["flow"]["state"].as_s.should eq("complete")
+    json["http_version"].as_s.should eq("HTTP/2")
+    json["error"].raw.should be_nil
+    json["request"]["head"].as_s.should contain("GET /")
+    json["response"]["head"].as_s.should contain("200 OK")
+  end
+
+  it "omits the side the --request-only / --response-only flags exclude" do
+    # --request-only must not leak a response-side token into the document; the flags are
+    # the only thing standing between a redacted export and the whole flow.
+    detail = flow_detail("https", "x", 443, "GET / HTTP/1.1\r\nHost: x\r\n\r\n",
+      response_head: "HTTP/1.1 200 OK\r\n\r\n", response_body: "secret")
+    req_only = JSON.parse(Gori::CLI::Run.show_json_for_spec(detail, true, false)).as_h
+    req_only.has_key?("request").should be_true
+    req_only.has_key?("response").should be_false
+
+    resp_only = JSON.parse(Gori::CLI::Run.show_json_for_spec(detail, false, true)).as_h
+    resp_only.has_key?("request").should be_false
+    resp_only.has_key?("response").should be_true
+  end
+
+  # Regression for the `sse_events.truncated` field: it used to be hardcoded `false`
+  # regardless of how many events were parsed, while the MCP `get_flow` serializer
+  # computed it from `events.size > SSE_EVENTS_MAX`. The two must agree.
+  it "reports sse_events.truncated as false at or under the cap" do
+    body = String.build { |io| 3.times { |i| io << "data: e#{i}\n\n" } }
+    head = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n"
+    detail = flow_detail("http", "x", 80, "GET / HTTP/1.1\r\nHost: x\r\n\r\n",
+      response_head: head, response_body: body)
+    sse = JSON.parse(Gori::CLI::Run.show_json_for_spec(detail, true, true))["sse_events"]
+    sse["count"].as_i.should eq(3)
+    sse["truncated"].as_bool.should be_false
+  end
+
+  it "reports sse_events.truncated once past SSE_EVENTS_MAX, matching the MCP serializer" do
+    n = Gori::MCP::Serialize::SSE_EVENTS_MAX + 1
+    body = String.build { |io| n.times { |i| io << "data: e#{i}\n\n" } }
+    head = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n"
+    detail = flow_detail("http", "x", 80, "GET / HTTP/1.1\r\nHost: x\r\n\r\n",
+      response_head: head, response_body: body)
+    sse = JSON.parse(Gori::CLI::Run.show_json_for_spec(detail, true, true))["sse_events"]
+    sse["count"].as_i.should eq(n)
+    sse["truncated"].as_bool.should be_true
+    # the CLI path stays unclipped (a script can read whole values) — unlike MCP, it
+    # does NOT drop events past the cap; `truncated` is a signal, not a clip.
+    sse["events"].as_a.size.should eq(n)
+  end
+
+  it "emits ws_messages with base64 for a binary frame and text for a text frame" do
+    detail = flow_detail("https", "ws.test", 443, "GET /ws HTTP/1.1\r\nHost: ws.test\r\n\r\n",
+      response_head: "HTTP/1.1 101 Switching Protocols\r\n\r\n")
+    msgs = [
+      Gori::Store::WsMessage.new(1_i64, 7_i64, nil, 0_i64, "out", 1, "hello".to_slice),
+      Gori::Store::WsMessage.new(2_i64, 7_i64, nil, 0_i64, "in", 2, Bytes[0x00, 0xFF]),
+    ]
+    ws = JSON.parse(Gori::CLI::Run.show_json_for_spec(detail, true, true, msgs))["ws_messages"]
+    ws["count"].as_i.should eq(2)
+    entries = ws["messages"].as_a
+    entries[0]["text"].as_s.should eq("hello")
+    entries[0]["direction"].as_s.should eq("out")
+    entries[1]["binary"].as_bool.should be_true
+    entries[1]["size"].as_i.should eq(2)
+    Base64.decode(entries[1]["base64"].as_s).should eq(Bytes[0x00, 0xFF])
+  end
+end

--- a/spec/cli/run/import_spec.cr
+++ b/spec/cli/run/import_spec.cr
@@ -1,0 +1,59 @@
+require "../../spec_helper"
+require "json"
+
+# `gori run import` — which source flag was given, and how the result is reported. The
+# abort paths (zero / two+ sources) call `exit`, so they can't be exercised in-process.
+
+# Private CLI glue — reopen the module for thin bare-call wrappers (same whitebox trick
+# the other CLI specs use).
+module Gori::CLI::Run
+  def self.import_source_for_spec(har : String?, oas : String?, urls : String?) : {Symbol, String}
+    import_source(har, oas, urls)
+  end
+
+  def self.import_result_json_for_spec(kind : Symbol, path : String, result : Import::Result) : String
+    import_result_json(kind, path, result)
+  end
+
+  def self.import_result_text_for_spec(kind : Symbol, path : String, result : Import::Result) : String
+    import_result_text(kind, path, result)
+  end
+end
+
+describe "gori run import" do
+  it "maps each source flag to its {kind, path}" do
+    Gori::CLI::Run.import_source_for_spec("a.har", nil, nil).should eq({:har, "a.har"})
+    Gori::CLI::Run.import_source_for_spec(nil, "api.yaml", nil).should eq({:oas, "api.yaml"})
+    Gori::CLI::Run.import_source_for_spec(nil, nil, "urls.txt").should eq({:urls, "urls.txt"})
+  end
+
+  it "carries kind, path, count and skipped in the JSON result" do
+    result = Gori::Import::Result.new(count: 12, skipped: 3)
+    json = JSON.parse(Gori::CLI::Run.import_result_json_for_spec(:har, "dump.har", result))
+    json["kind"].as_s.should eq("har")
+    json["path"].as_s.should eq("dump.har")
+    json["count"].as_i.should eq(12)
+    json["skipped"].as_i.should eq(3)
+  end
+
+  it "always reports `skipped` in JSON, even at zero" do
+    # A script comparing count vs skipped must not have to special-case a missing key —
+    # the text view drops the clause at zero, the machine contract does not.
+    json = JSON.parse(Gori::CLI::Run.import_result_json_for_spec(:oas, "a.yaml", Gori::Import::Result.new(count: 1)))
+    json["skipped"].as_i.should eq(0)
+  end
+
+  it "mirrors the TUI toast wording, with a skipped clause only when > 0" do
+    clean = Gori::CLI::Run.import_result_text_for_spec(:oas, "api.json", Gori::Import::Result.new(count: 1))
+    clean.should eq("imported 1 flow from OpenAPI · api.json")
+    skipped = Gori::CLI::Run.import_result_text_for_spec(:urls, "u.txt", Gori::Import::Result.new(count: 5, skipped: 2))
+    skipped.should eq("imported 5 flows from URLs · u.txt (2 entries skipped)")
+  end
+
+  it "singularises both counts independently" do
+    one = Gori::CLI::Run.import_result_text_for_spec(:har, "d.har", Gori::Import::Result.new(count: 1, skipped: 1))
+    one.should eq("imported 1 flow from HAR · d.har (1 entry skipped)")
+    many = Gori::CLI::Run.import_result_text_for_spec(:har, "d.har", Gori::Import::Result.new(count: 0, skipped: 4))
+    many.should eq("imported 0 flows from HAR · d.har (4 entries skipped)")
+  end
+end

--- a/spec/cli/run/issues_spec.cr
+++ b/spec/cli/run/issues_spec.cr
@@ -1,0 +1,171 @@
+require "../../spec_helper"
+require "json"
+
+# `gori run issues` — the text listing row, and the JSON / Markdown reports the
+# `--format` and `--export` flags write (Issues::Export, shared with the TUI's
+# issues.export-md / issues.export-json verbs).
+
+private def with_store(&)
+  path = File.tempname("gori-cliissues", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def issue(id : Int64, title : String, severity : Gori::Store::Severity,
+                  host : String?, flow_id : Int64?, notes = "",
+                  status = Gori::Store::Status::Open) : Gori::Store::Issue
+  Gori::Store::Issue.new(id, 0_i64, 0_i64, title, severity, host, flow_id, notes, status)
+end
+
+# `issues_text` is private CLI glue — reopen the module for a bare-call wrapper.
+module Gori::CLI::Run
+  def self.issues_text_for_spec(issues : Array(Gori::Store::Issue)) : String
+    issues_text(issues)
+  end
+end
+
+describe "gori run issues — the text listing" do
+  it "leads with the id, then the [severity/status] pair, title, host and flow" do
+    # Every triage subcommand addresses an issue BY ID, so the id has to be the first
+    # thing on the row — copy-pasteable straight into `issues update <id>`.
+    txt = Gori::CLI::Run.issues_text_for_spec([
+      issue(12_i64, "Reflected XSS", Gori::Store::Severity::High, "shop.test", 7_i64),
+    ])
+    txt.should eq("#12  [high/open]  Reflected XSS  (shop.test)  flow#7")
+  end
+
+  it "omits the host and flow clauses when the issue has neither" do
+    txt = Gori::CLI::Run.issues_text_for_spec([
+      issue(3_i64, "manual note", Gori::Store::Severity::Info, nil, nil),
+    ])
+    txt.should eq("#3  [info/open]  manual note")
+  end
+
+  it "flattens a multi-line title so one issue is always one row" do
+    # An issue title is free text (and can arrive from an MCP client); a raw newline would
+    # split one issue across two rows and desync the id column from the title.
+    txt = Gori::CLI::Run.issues_text_for_spec([
+      issue(4_i64, "line one\nline two", Gori::Store::Severity::Low, "h\nevil", nil),
+    ])
+    txt.lines.size.should eq(1)
+    txt.should_not contain('\n')
+  end
+
+  it "emits one row per issue with no trailing blank line" do
+    txt = Gori::CLI::Run.issues_text_for_spec([
+      issue(1_i64, "a", Gori::Store::Severity::Low, nil, nil),
+      issue(2_i64, "b", Gori::Store::Severity::Low, nil, nil),
+    ])
+    txt.lines.size.should eq(2)
+    txt.ends_with?('\n').should be_false
+    Gori::CLI::Run.issues_text_for_spec([] of Gori::Store::Issue).should eq("")
+  end
+end
+
+describe "gori run issues --format json" do
+  it "serialises issues with the documented fields" do
+    issues = [
+      issue(1_i64, "XSS", Gori::Store::Severity::High, "shop.test", 13_i64, "reflected",
+        Gori::Store::Status::Confirmed),
+      issue(2_i64, "note", Gori::Store::Severity::Info, nil, nil),
+    ]
+    parsed = JSON.parse(Gori::Issues::Export.json(issues)).as_a
+    parsed.size.should eq(2)
+    parsed[0]["title"].as_s.should eq("XSS")
+    parsed[0]["severity"].as_s.should eq("high")
+    parsed[0]["status"].as_s.should eq("confirmed")
+    parsed[0]["flow_id"].as_i.should eq(13)
+    parsed[0]["links"].as_a.should be_empty
+    parsed[1]["host"].raw.should be_nil
+    parsed[1]["flow_id"].raw.should be_nil
+  end
+
+  it "serialises entity links" do
+    with_store do |store|
+      fid = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "https", host: "api.test", port: 443, method: "GET",
+        target: "/x", http_version: "HTTP/1.1",
+        head: "GET /x HTTP/1.1\r\nHost: api.test\r\n\r\n".to_slice))
+      issue_id = store.insert_issue("linked", Gori::Store::Severity::Medium, "api.test", fid)
+      store.add_link(Gori::Store::LinkOwnerKind::Issue, issue_id,
+        Gori::Store::LinkRefKind::Repeater, 9_i64)
+      parsed = JSON.parse(Gori::Issues::Export.json(store.issues, store)).as_a
+      links = parsed[0]["links"].as_a
+      links.size.should eq(1) # primary flow link is deduped from the export list
+      links[0]["kind"].as_s.should eq("repeater")
+      links[0]["ref_id"].as_i.should eq(9)
+      links[0]["label"].as_s.should_not be_empty
+    end
+  end
+end
+
+describe "gori run issues --format markdown" do
+  it "renders a report with severity/status labels and notes" do
+    with_store do |store|
+      issues = [issue(1_i64, "Reflected XSS", Gori::Store::Severity::High, "shop.test", nil,
+        "encode on output")]
+      md = Gori::Issues::Export.markdown(issues, store, "demo")
+      md.should contain("# Issues — demo")
+      md.should contain("## [high] Reflected XSS")
+      md.should contain("**Severity:** high")
+      md.should contain("**Status:** open")
+      md.should contain("encode on output")
+    end
+  end
+
+  it "embeds linked-flow evidence" do
+    with_store do |store|
+      req = Gori::Store::CapturedRequest.new(
+        created_at: 0_i64, scheme: "https", host: "api.test", port: 443, method: "GET",
+        target: "/v1/debug", http_version: "HTTP/1.1",
+        head: "GET /v1/debug HTTP/1.1\r\nHost: api.test\r\n\r\n".to_slice)
+      fid = store.insert_flow(req)
+      store.flush
+      issues = [issue(1_i64, "leak", Gori::Store::Severity::Medium, "api.test", fid)]
+      md = Gori::Issues::Export.markdown(issues, store, "demo")
+      md.should contain("### Request")
+      md.should contain("GET /v1/debug HTTP/1.1")
+      md.should contain("(##{fid})")
+      # The header block's terminating CRLF CRLF is trimmed, so the last header
+      # line abuts the closing fence (no stack of blank lines inside the block).
+      md.should contain("Host: api.test\n```")
+      md.should_not contain("\r\n\r\n")
+    end
+  end
+
+  it "separates evidence headers from the body with exactly one blank line" do
+    with_store do |store|
+      req = Gori::Store::CapturedRequest.new(
+        created_at: 0_i64, scheme: "https", host: "api.test", port: 443, method: "POST",
+        target: "/login", http_version: "HTTP/1.1",
+        head: "POST /login HTTP/1.1\r\nHost: api.test\r\nContent-Length: 9\r\n\r\n".to_slice,
+        body: "user=root".to_slice)
+      fid = store.insert_flow(req)
+      store.flush
+      issues = [issue(1_i64, "creds in body", Gori::Store::Severity::High, "api.test", fid)]
+      md = Gori::Issues::Export.markdown(issues, store, "demo")
+      # one blank line between the last header and the body — not three
+      md.should contain("Content-Length: 9\n\nuser=root")
+      md.should_not contain("Content-Length: 9\n\n\nuser=root")
+    end
+  end
+
+  it "scrubs control bytes on the STDOUT path but keeps a file export verbatim" do
+    # The Markdown report embeds attacker-controlled evidence bodies; printed to a TTY a
+    # raw OSC could drive the terminal. `--export PATH` writes the bytes untouched — a
+    # saved file is not a live terminal, and stripping would corrupt captured evidence.
+    raw = "head\e]0;pwned\a\ntail\ttab"
+    scrubbed = Gori::Issues::Export.scrub_controls(raw)
+    scrubbed.should_not contain('\e')
+    scrubbed.should_not contain('\a')
+    scrubbed.should contain("\n") # structure preserved
+    scrubbed.should contain("\ttab")
+  end
+end

--- a/spec/cli/run/jwt_spec.cr
+++ b/spec/cli/run/jwt_spec.cr
@@ -1,0 +1,65 @@
+require "../../spec_helper"
+require "json"
+
+# `gori run jwt` builds its JSON from the shared engine emitters (jwt/present.cr) so the
+# CLI and the MCP jwt_* tools stay byte-identical; the text formatter is CLI-only.
+
+# `jwt_token_input` is private CLI glue — reopen the module for a bare-call wrapper.
+# (Its STDIN branch is not reachable in-process, and the >1-argument branch aborts.)
+module Gori::CLI::Run
+  def self.jwt_token_input_for_spec(positional : Array(String)) : String
+    jwt_token_input(positional)
+  end
+end
+
+describe "gori run jwt" do
+  jwt = Gori::Jwt.encode(%({"typ":"JWT"}), %({"sub":"1"}), "HS256", "k")
+
+  it "takes the token from the positional argument, trimmed" do
+    # A token pasted from a terminal or piped through a shell routinely arrives with
+    # surrounding whitespace/newline; an untrimmed one fails to decode with no clue why.
+    Gori::CLI::Run.jwt_token_input_for_spec(["  #{jwt}\n"]).should eq(jwt)
+  end
+
+  it "decode_json carries nested header/payload objects + the signed flag" do
+    j = JSON.parse(Gori::Jwt.decode_json(jwt))
+    j["alg"].as_s.should eq("HS256")
+    j["header"]["typ"].as_s.should eq("JWT")
+    j["payload"]["sub"].as_s.should eq("1")
+    j["signed"].as_bool.should be_true
+  end
+
+  it "attacks_json is an array of {name, category, note, token}" do
+    arr = JSON.parse(Gori::Jwt.attacks_json(Gori::Jwt.attacks(jwt))).as_a
+    arr.should_not be_empty
+    arr.first["name"].as_s.should_not be_empty
+    arr.first["token"].as_s.should contain(".")
+    arr.map(&.["category"].as_s).should contain("weak-secret")
+  end
+
+  it "gives every generated attack a name, a category, a note and a token" do
+    # These four fields are the whole machine contract of `--attacks --format json`; a
+    # payload missing one is unusable to a script driving the attacks downstream.
+    JSON.parse(Gori::Jwt.attacks_json(Gori::Jwt.attacks(jwt))).as_a.each do |a|
+      a["name"].as_s.should_not be_empty
+      a["category"].as_s.should_not be_empty
+      a["note"].as_s.should_not be_empty
+      a["token"].as_s.should_not be_empty
+    end
+  end
+
+  it "jwt_attack_text prints the category, name, note, and token" do
+    a = Gori::Jwt.attacks(jwt).find { |x| x.name == "alg=none" }.not_nil!
+    text = Gori::CLI::Output.jwt_attack_text(a)
+    text.should contain("[none]")
+    text.should contain("alg=none")
+    text.should contain(a.token)
+  end
+
+  it "keeps the attack text on two lines, token last (so a shell can cut it)" do
+    a = Gori::Jwt.attacks(jwt).first
+    lines = Gori::CLI::Output.jwt_attack_text(a).lines
+    lines.size.should eq(2)
+    lines[1].strip.should eq(a.token)
+  end
+end

--- a/spec/cli/run/links_spec.cr
+++ b/spec/cli/run/links_spec.cr
@@ -1,0 +1,115 @@
+require "../../spec_helper"
+
+# `gori run links` — the evidence pointers an Issue or Note carries. Both ENDS are
+# validated before a link is filed: without that, `links add` would write an orphan row
+# pointing at nothing and still report success, and `links list` on a typo'd id would
+# print "no links on issue #99999" — which reads as "this issue has no evidence" rather
+# than "there is no such issue".
+
+private def with_store(&)
+  path = File.tempname("gori-clilinks", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def seed_flow(store : Gori::Store) : Int64
+  store.insert_flow(Gori::Store::CapturedRequest.new(
+    created_at: 1_i64, scheme: "https", host: "api.test", port: 443, method: "GET",
+    target: "/x", http_version: "HTTP/1.1",
+    head: "GET /x HTTP/1.1\r\nHost: api.test\r\n\r\n".to_slice))
+end
+
+# Private CLI glue — reopen the module for bare-call wrappers. (The `abort` branches of
+# resolve_link_ends / parse_link_id call `exit`, so only their success paths run here.)
+module Gori::CLI::Run
+  def self.link_owner_exists_for_spec(store : Gori::Store, kind : Gori::Store::LinkOwnerKind, id : Int64) : Bool
+    link_owner_exists?(store, kind, id)
+  end
+
+  def self.link_ref_exists_for_spec(store : Gori::Store, kind : Gori::Store::LinkRefKind, id : Int64) : Bool
+    link_ref_exists?(store, kind, id)
+  end
+
+  def self.resolve_link_ends_for_spec(verb : String, owner_id : Int64?, ref_s : String?,
+                                      ref_id : Int64?) : {Int64, Gori::Store::LinkRefKind, Int64}
+    resolve_link_ends(verb, owner_id, ref_s, ref_id)
+  end
+
+  def self.parse_link_id_for_spec(v : String, flag : String) : Int64
+    parse_link_id(v, flag)
+  end
+end
+
+describe "gori run links — flag parsing" do
+  it "parses --owner / --ref spellings and rejects anything else" do
+    Gori::Store::LinkOwnerKind.parse("issue").should eq(Gori::Store::LinkOwnerKind::Issue)
+    Gori::Store::LinkOwnerKind.parse("note").should eq(Gori::Store::LinkOwnerKind::Note)
+    Gori::Store::LinkOwnerKind.parse("flow").should be_nil # a flow is a REF, never an owner
+
+    Gori::Store::LinkRefKind.parse("flow").should eq(Gori::Store::LinkRefKind::Flow)
+    Gori::Store::LinkRefKind.parse("repeater").should eq(Gori::Store::LinkRefKind::Repeater)
+    Gori::Store::LinkRefKind.parse("fuzz").should eq(Gori::Store::LinkRefKind::Fuzz)
+    Gori::Store::LinkRefKind.parse("miner").should eq(Gori::Store::LinkRefKind::Miner)
+    Gori::Store::LinkRefKind.parse("issue").should be_nil # an issue is an OWNER, never a ref
+  end
+
+  it "returns the {owner id, ref kind, ref id} triple when all three are given" do
+    Gori::CLI::Run.resolve_link_ends_for_spec("add", 4_i64, "repeater", 9_i64)
+      .should eq({4_i64, Gori::Store::LinkRefKind::Repeater, 9_i64})
+  end
+
+  it "parses a plain integer id, including a large one" do
+    Gori::CLI::Run.parse_link_id_for_spec("42", "--id").should eq(42_i64)
+    Gori::CLI::Run.parse_link_id_for_spec("9007199254740993", "--ref-id").should eq(9_007_199_254_740_993_i64)
+  end
+end
+
+describe "gori run links — end validation" do
+  it "recognises an existing issue and rejects a missing one" do
+    with_store do |store|
+      id = store.insert_issue("finding", Gori::Store::Severity::Low, "api.test", nil)
+      Gori::CLI::Run.link_owner_exists_for_spec(store, Gori::Store::LinkOwnerKind::Issue, id).should be_true
+      Gori::CLI::Run.link_owner_exists_for_spec(store, Gori::Store::LinkOwnerKind::Issue, 99_999_i64).should be_false
+    end
+  end
+
+  it "resolves a NOTE owner through the notes document, not a table row" do
+    # Notes live as a JSON document under a settings key, so the note branch cannot use the
+    # same "is there a row?" query the issue branch does.
+    with_store do |store|
+      store.set_setting("notes.docs",
+        Gori::Notes.serialize(0, [Gori::Notes::NoteEntry.new(7_i64, "a")], 8_i64))
+      nid = Gori::Notes.load(store).notes.first.id
+      nid.should eq(7_i64)
+      Gori::CLI::Run.link_owner_exists_for_spec(store, Gori::Store::LinkOwnerKind::Note, nid).should be_true
+      Gori::CLI::Run.link_owner_exists_for_spec(store, Gori::Store::LinkOwnerKind::Note, nid + 1000).should be_false
+    end
+  end
+
+  it "checks each ref kind against its own table" do
+    with_store do |store|
+      fid = seed_flow(store)
+      rid = store.insert_repeater("https://api.test", "GET / HTTP/1.1\r\n\r\n".to_slice, false, true, nil, 0)
+
+      Gori::CLI::Run.link_ref_exists_for_spec(store, Gori::Store::LinkRefKind::Flow, fid).should be_true
+      Gori::CLI::Run.link_ref_exists_for_spec(store, Gori::Store::LinkRefKind::Repeater, rid).should be_true
+      # A flow id is NOT a repeater id: the kinds must not fall through to a shared lookup.
+      Gori::CLI::Run.link_ref_exists_for_spec(store, Gori::Store::LinkRefKind::Fuzz, fid).should be_false
+      Gori::CLI::Run.link_ref_exists_for_spec(store, Gori::Store::LinkRefKind::Miner, rid).should be_false
+      Gori::CLI::Run.link_ref_exists_for_spec(store, Gori::Store::LinkRefKind::Flow, 99_999_i64).should be_false
+    end
+  end
+end
+
+# The listing itself resolves through Gori::Links.resolve_all, whose ordering, per-element
+# `stale?` flags and exact labels are already pinned strictly in spec/links_spec.cr — not
+# duplicated here. What is CLI-specific is the validation above: `links list` refuses an
+# unknown owner instead of printing "no links on issue #99999", which would read as "this
+# issue has no evidence" rather than "there is no such issue".

--- a/spec/cli/run/notes_spec.cr
+++ b/spec/cli/run/notes_spec.cr
@@ -1,0 +1,90 @@
+require "../../spec_helper"
+require "json"
+
+# `gori run notes` — the listing row, the single-note object, and the whole-set array.
+# The JSON shapes here are the documented contract scripts read; the MCP list_notes /
+# get_note tools mirror the same fields.
+
+describe "gori run notes — listing rows" do
+  it "formats a row: 1-based index, title, '*' for the active note" do
+    row = Gori::CLI::Output.note_row_text(1, "scope\nmore", current: true)
+    row.should contain("* 2")                                                           # 0-based 1 → shown as #2
+    row.should contain("scope")                                                         # title = first non-blank line
+    row.should contain("(2 lines, ")                                                    # plural
+    Gori::CLI::Output.note_row_text(0, "x", current: false).should contain(" 1")        # no '*'
+    Gori::CLI::Output.note_row_text(0, "x", current: false).should contain("(1 line, ") # singular
+  end
+
+  it "falls back to 'note N' for a blank note" do
+    Gori::CLI::Output.note_row_text(2, "   \n\t", current: false).should contain("note 3")
+    Gori::CLI::Output.note_label(2, "   \n\t").should eq("note 3")
+    Gori::CLI::Output.note_label(0, "Title\nbody").should eq("Title")
+  end
+
+  it "counts BYTES, not characters, in the row size" do
+    # The size is a storage figure; a multi-byte note reported in characters would
+    # under-report by 2-3× on any non-ASCII corpus.
+    text = "데이터" # 3 chars, 9 bytes
+    Gori::CLI::Output.note_row_text(0, text, current: false).should contain("9B")
+  end
+end
+
+describe "gori run notes show --format json" do
+  it "emits the documented fields, with the body only when asked" do
+    entry = Gori::Notes::NoteEntry.new(42_i64, "Title\nbody")
+    full = JSON.parse(Gori::CLI::Output.note_object_json(0, entry, current: true, with_text: true))
+    full["id"].as_i64.should eq(42_i64)
+    full["index"].as_i.should eq(1)
+    full["title"].as_s.should eq("Title")
+    full["lines"].as_i.should eq(2)
+    full["bytes"].as_i.should eq("Title\nbody".bytesize)
+    full["current"].as_bool.should be_true
+    full["text"].as_s.should eq("Title\nbody")
+
+    summary = JSON.parse(Gori::CLI::Output.note_object_json(0, entry, current: false, with_text: false))
+    summary["text"]?.should be_nil # summary omits the body
+    summary["title"].as_s.should eq("Title")
+  end
+
+  it "emits a null title for a blank note rather than the positional fallback" do
+    # The listing's "note 3" is a DISPLAY fallback; JSON must report the absence so a
+    # script can tell "untitled" from a note literally titled "note 3".
+    entry = Gori::Notes::NoteEntry.new(1_i64, "   \n\t")
+    JSON.parse(Gori::CLI::Output.note_object_json(2, entry, current: false, with_text: false))["title"].raw.should be_nil
+  end
+end
+
+describe "gori run notes --format json (whole set)" do
+  it "emits an array marking the active note" do
+    doc = Gori::Notes::Doc.new(1, [
+      Gori::Notes::NoteEntry.new(1_i64, "one"),
+      Gori::Notes::NoteEntry.new(2_i64, "two"),
+    ], 3_i64)
+    arr = JSON.parse(Gori::CLI::Output.notes_array_json(doc, with_text: false)).as_a
+    arr.size.should eq(2)
+    arr[0]["id"].as_i64.should eq(1_i64)
+    arr[0]["index"].as_i.should eq(1)
+    arr[0]["current"].as_bool.should be_false
+    arr[1]["current"].as_bool.should be_true # cur == 1
+    arr[0]["text"]?.should be_nil            # summary array
+
+    with_text = JSON.parse(Gori::CLI::Output.notes_array_json(doc, with_text: true)).as_a
+    with_text[1]["text"].as_s.should eq("two")
+  end
+
+  it "emits a valid empty array for a project with no notes" do
+    # A script parsing `gori run notes --format json` must always get valid JSON, even in
+    # the empty state (the text view prints its note to STDERR instead).
+    empty = Gori::Notes::Doc.new(0, [] of Gori::Notes::NoteEntry, 1_i64)
+    Gori::CLI::Output.notes_array_json(empty, with_text: false).should eq("[]")
+  end
+
+  it "carries a note body VERBATIM into JSON, escapes and all" do
+    # JSON output is the byte-exact path for scripts (unlike the text view, which scrubs
+    # control bytes before the terminal sees them) — the escaping must be JSON's, not ours.
+    entry = Gori::Notes::NoteEntry.new(1_i64, "a\e[31m\tb")
+    doc = Gori::Notes::Doc.new(0, [entry], 2_i64)
+    parsed = JSON.parse(Gori::CLI::Output.notes_array_json(doc, with_text: true)).as_a
+    parsed[0]["text"].as_s.should eq("a\e[31m\tb")
+  end
+end

--- a/spec/cli/run/project_spec.cr
+++ b/spec/cli/run/project_spec.cr
@@ -1,0 +1,158 @@
+require "../../spec_helper"
+require "file_utils"
+
+# `gori run project create / delete` — project resolution and the delete preview. These
+# operate on the on-disk registry, so they are the CLI surface where a wrong answer
+# destroys data: the delete preview is the only thing standing between `rm -rf` and a
+# project the operator did not mean to name.
+
+# Private CLI glue — reopen the module for bare-call wrappers.
+module Gori::CLI::Run
+  def self.project_object_counts_for_spec(project : Gori::Project) : {Int64?, Int32?}
+    project_object_counts(project)
+  end
+
+  def self.ambiguous_project_name_for_spec(registry : Gori::ProjectRegistry, name : String) : Bool
+    ambiguous_name?(registry, name)
+  end
+end
+
+private def with_project_root(&)
+  root = File.tempname("gori-projroot")
+  begin
+    yield Gori::ProjectRegistry.new(root)
+  ensure
+    FileUtils.rm_rf(root)
+  end
+end
+
+private def seed_project_flow(store) : Int64
+  store.insert_flow(Gori::Store::CapturedRequest.new(
+    created_at: 1_i64, scheme: "https", host: "ex.test", port: 443,
+    method: "GET", target: "/", http_version: "HTTP/1.1",
+    head: "GET / HTTP/1.1\r\nHost: ex.test\r\n\r\n".to_slice, body: nil))
+end
+
+# One handle, closed exactly once — Store#close is NOT idempotent (a 2nd @done.receive
+# blocks forever), so each open gets its own short block instead of a close-then-flag.
+private def with_project_store(project : Gori::Project, &)
+  store = Gori::Store.open(project.db_path)
+  begin
+    yield store
+  ensure
+    store.close
+  end
+end
+
+describe "gori run project create" do
+  it "reports created-vs-reopened from the registry, not from a name lookup" do
+    with_project_root do |registry|
+      project, created = registry.create_or_reopen("spec proj")
+      created.should be_true
+      # A name that is a PREFIX of the first project's short id: #find would resolve it to
+      # that project and call this brand-new one a reopen.
+      id = registry.id_of(project).not_nil!
+      other, other_created = registry.create_or_reopen(id[0, 4])
+      other_created.should be_true
+      other.dir.should_not eq(project.dir)
+
+      registry.create_or_reopen("spec proj")[1].should be_false # same name → reopen
+    end
+  end
+
+  it "materializes the DB so a description-less project is immediately listed" do
+    with_project_root do |registry|
+      # #list skips a directory with no DB; a lazily-created one would stay invisible to
+      # `project list` / --project until something captured into it.
+      project = registry.create("spec proj")
+      File.exists?(project.db_path).should be_true
+      registry.list.map(&.name).should eq(["spec proj"])
+    end
+  end
+
+  it "leaves an existing DB untouched when create reopens the project" do
+    with_project_root do |registry|
+      project = registry.create("spec proj")
+      with_project_store(project) { |store| seed_project_flow(store) }
+      registry.create("spec proj") # reopen path: must not recreate the DB
+      with_project_store(project, &.count.should(eq(1)))
+    end
+  end
+end
+
+describe "gori run project delete (preview)" do
+  it "counts the flows and issues that deleting would destroy" do
+    with_project_root do |registry|
+      project = registry.create("spec proj")
+      with_project_store(project) do |store|
+        2.times { seed_project_flow(store) }
+        store.insert_issue("finding", Gori::Store::Severity::Low, "ex.test", nil)
+      end
+      Gori::CLI::Run.project_object_counts_for_spec(project).should eq({2_i64, 1})
+      # The whole directory is what rm_rf takes, so the preview sizes it (DB + WAL/SHM +
+      # sidecars), never just the DB file.
+      project.disk_size.should be > project.db_size
+    end
+  end
+
+  it "reports nil counts for a project whose DB was deleted under it" do
+    with_project_root do |registry|
+      project = registry.create("empty proj")
+      File.delete(project.db_path)
+      Gori::CLI::Run.project_object_counts_for_spec(project).should eq({nil, nil})
+      project.disk_size.should be > 0 # the .name/.id sidecars still go with the directory
+    end
+  end
+
+  it "sizes a directory whose path contains glob metacharacters" do
+    root = File.tempname("gori-proj[root]") # `[...]` is a glob character class
+    begin
+      project = Gori::ProjectRegistry.new(root).create("globby")
+      project.disk_size.should be > 0
+    ensure
+      FileUtils.rm_rf(root)
+    end
+  end
+end
+
+describe "gori run project delete (resolution)" do
+  it "refuses a display name shared by two projects, and accepts either slug" do
+    root = File.tempname("gori-projroot")
+    begin
+      registry = Gori::ProjectRegistry.new(root)
+      # What create_for_workspace produces for two checkouts with the same basename:
+      # distinct slugs (my-api, my-api-2), one shared display name.
+      registry.create("My API")
+      twin = File.join(root, "my-api-2")
+      Dir.mkdir_p(twin)
+      File.write(File.join(twin, Gori::ProjectRegistry::NAME_FILE), "My API")
+      Gori::Store.open(File.join(twin, Gori::Project::DB_FILE)).close
+
+      registry.list.count { |p| p.name == "My API" }.should eq(2)
+      Gori::CLI::Run.ambiguous_project_name_for_spec(registry, "My API").should be_true
+      Gori::CLI::Run.ambiguous_project_name_for_spec(registry, "my api").should be_true # find is case-insensitive
+      # Slugs are unique, and #find resolves them before the display-name pass.
+      Gori::CLI::Run.ambiguous_project_name_for_spec(registry, "my-api").should be_false
+      Gori::CLI::Run.ambiguous_project_name_for_spec(registry, "my-api-2").should be_false
+    ensure
+      FileUtils.rm_rf(root)
+    end
+  end
+
+  it "does not call a uniquely-named project ambiguous" do
+    with_project_root do |registry|
+      registry.create("alpha")
+      registry.create("beta")
+      Gori::CLI::Run.ambiguous_project_name_for_spec(registry, "alpha").should be_false
+    end
+  end
+
+  it "does not call an unknown name ambiguous (that is a separate, clearer error)" do
+    # `ambiguous_name?` gates the "refuse to guess" abort; answering true for a name that
+    # matches nothing would report a collision where the real problem is a typo.
+    with_project_root do |registry|
+      registry.create("alpha")
+      Gori::CLI::Run.ambiguous_project_name_for_spec(registry, "no-such-project").should be_false
+    end
+  end
+end

--- a/spec/cli/run/replay_reconstruct_spec.cr
+++ b/spec/cli/run/replay_reconstruct_spec.cr
@@ -1,0 +1,182 @@
+require "../../spec_helper"
+
+# P7 — "never reject malformed input on replay, only on the live MITM path."
+#
+# Gori::Repeater::FlowRequest is the reconstruct step every headless replay goes through
+# (`gori run repeater send --flow`, the MCP send_request(flow_id:) tool, the TUI's
+# load-into-Repeater). It is deliberately NOT a parser: it rewrites an absolute-form
+# request line to origin-form and otherwise hands the captured bytes back untouched.
+#
+# That is the whole point for a security tool — the malformed request IS the test case. A
+# smuggling probe, a fuzzed target, a bare-CR terminator, a NUL in a header: if any of
+# these were normalized or refused on the way out, the operator could no longer replay the
+# exact bytes that produced the original behaviour. Nothing asserted that invariant until
+# now; these examples pin it byte-for-byte.
+#
+# The WELL-FORMED side of the same function — the absolute→origin rewrite on ordinary
+# requests, the http2 flag, the target derivation, and the Content-Length/chunked re-frame
+# applied when a capture was TRUNCATED — is covered by `describe Gori::Repeater::FlowRequest`
+# in spec/cli_run_spec.cr. This file only adds the hostile inputs.
+
+# Every example reconstructs the same way `gori run repeater send --flow` does: a complete
+# http/1.1 flow whose only interesting part is the captured request bytes.
+private def rebuilt(head : String, body : Bytes? = nil) : Bytes
+  row = Gori::Store::FlowRow.new(
+    id: 1_i64, created_at: 0_i64, scheme: "http", method: "GET", host: "h", port: 80,
+    target: "/", status: 200, size: 0_i64, state: Gori::Store::FlowState::Complete)
+  detail = Gori::Store::FlowDetail.new(row, "HTTP/1.1", head.to_slice, body, nil, nil)
+  Gori::Repeater::FlowRequest.build(detail).bytes
+end
+
+describe "replay reconstruct (P7) — malformed input is never rejected" do
+  it "replays a head with NO line terminator at all, verbatim" do
+    head = "GET / HTTP/1.1" # no CRLF, no LF, no blank line
+    String.new(rebuilt(head)).should eq(head)
+  end
+
+  it "replays an EMPTY request head without raising" do
+    rebuilt("").size.should eq(0)
+  end
+
+  it "replays a two-token (HTTP/0.9-style) request line verbatim" do
+    # rewrite_request_line only touches a well-formed 3-token line; anything else is the
+    # operator's bytes and goes out as captured.
+    head = "GET /only-two-tokens\r\nHost: h\r\n\r\n"
+    String.new(rebuilt(head)).should eq(head)
+  end
+
+  it "replays a request line with a RAW SPACE in the target verbatim" do
+    # 4 tokens — a classic fuzz/smuggling shape. Splitting or re-encoding it would destroy
+    # exactly what the operator is testing.
+    head = "GET /a b HTTP/1.1\r\nHost: h\r\n\r\n"
+    String.new(rebuilt(head)).should eq(head)
+    # …and the same in absolute-form: still 4 tokens, so still no rewrite.
+    abs = "GET http://h/a b HTTP/1.1\r\nHost: h\r\n\r\n"
+    String.new(rebuilt(abs)).should eq(abs)
+  end
+
+  it "replays a head that is not HTTP at all, byte-for-byte" do
+    head = String.new(Bytes[0x00, 0x01, 0xFF, 0x0A, 0x7F, 0x00])
+    rebuilt(head).to_a.should eq(head.to_slice.to_a)
+  end
+
+  it "preserves NUL and 8-bit bytes inside a header value" do
+    head = String.new(Bytes[0x47, 0x45, 0x54, 0x20, 0x2F, 0x20, 0x48, 0x54, 0x54, 0x50, 0x2F,
+      0x31, 0x2E, 0x31, 0x0D, 0x0A]) + # "GET / HTTP/1.1\r\n"
+           "X-Raw: " + String.new(Bytes[0x00, 0xFF, 0x80]) + "\r\n\r\n"
+    rebuilt(head).to_a.should eq(head.to_slice.to_a)
+  end
+
+  it "preserves a BARE CR inside the head (the CR-smuggling probe)" do
+    # A lone \r that never becomes \r\n is the payload of a request-smuggling test; a
+    # line-normalizing rebuild would silently defuse it.
+    head = "GET / HTTP/1.1\r\nX-A: 1\rX-B: 2\r\n\r\n"
+    String.new(rebuilt(head)).should eq(head)
+    rebuilt(head).count(0x0D_u8).should eq(head.to_slice.count(0x0D_u8))
+  end
+
+  it "preserves BOTH framing headers of a CL.TE probe when the body was not truncated" do
+    # RFC 7230 forbids TE+CL; keeping both is the entire test. (The single-Content-Length
+    # collapse fires ONLY on the truncated-capture path, which cannot replay faithfully
+    # anyway — that branch is covered in spec/cli_run_spec.cr, not here.)
+    head = "POST /u HTTP/1.1\r\nHost: h\r\nContent-Length: 6\r\nTransfer-Encoding: chunked\r\n\r\n"
+    body = "0\r\n\r\n".to_slice
+    String.new(rebuilt(head, body)).should eq(head + "0\r\n\r\n")
+  end
+
+  it "preserves a duplicate Host header and header-name casing" do
+    head = "GET / HTTP/1.1\r\nhOsT: a\r\nHost: b\r\n\r\n"
+    String.new(rebuilt(head)).should eq(head)
+  end
+
+  it "preserves the %%% group separator a pipelined send splits on" do
+    head = "GET /a HTTP/1.1\r\nHost: h\r\n\r\n%%%\r\nGET /b HTTP/1.1\r\nHost: h\r\n\r\n"
+    String.new(rebuilt(head)).should eq(head)
+  end
+end
+
+describe "replay reconstruct (P7) — the ONE rewrite it does make" do
+  it "keeps a percent-encoded path and query byte-identical through the rewrite" do
+    # `/a%2Fb` and `%2e%2e` are traversal/normalization probes: decoding them on the way
+    # out would replay a DIFFERENT request than the one that was captured.
+    head = "GET http://h/a%2Fb/%2e%2e/x?q=%ff&x=1 HTTP/1.1\r\nHost: h\r\n\r\n"
+    String.new(rebuilt(head)).should eq("GET /a%2Fb/%2e%2e/x?q=%ff&x=1 HTTP/1.1\r\nHost: h\r\n\r\n")
+  end
+
+  it "supplies '/' for an absolute-form URL with no path" do
+    String.new(rebuilt("GET http://h HTTP/1.1\r\nHost: h\r\n\r\n"))
+      .should eq("GET / HTTP/1.1\r\nHost: h\r\n\r\n")
+  end
+
+  it "keeps an empty query marker ('?') that a normalizing rebuild would drop" do
+    String.new(rebuilt("GET http://h/a? HTTP/1.1\r\nHost: h\r\n\r\n"))
+      .should eq("GET /a? HTTP/1.1\r\nHost: h\r\n\r\n")
+  end
+
+  it "rewrites only the FIRST line, never an absolute URL appearing later in the head" do
+    head = "GET http://h/p HTTP/1.1\r\nReferer: http://h/other\r\n\r\n"
+    String.new(rebuilt(head)).should eq("GET /p HTTP/1.1\r\nReferer: http://h/other\r\n\r\n")
+  end
+
+  it "leaves a non-http scheme in the request line alone" do
+    # Only http:// and https:// are absolute-form request lines; anything else is data.
+    head = "GET ftp://h/p HTTP/1.1\r\nHost: h\r\n\r\n"
+    String.new(rebuilt(head)).should eq(head)
+  end
+end
+
+describe "replay reconstruct (P7) — target parsing never raises" do
+  it "falls back to a neutral triple instead of raising on a hostile target" do
+    # A --target can come straight off a captured (attacker-controlled) authority. A raise
+    # here would abort the replay rather than let the operator send the bytes.
+    Gori::Repeater::FlowRequest.parse_target("http://h:abc").should eq({"http", "", 0}) # URI::Error
+    # Everything else degrades to the scheme default rather than exploding.
+    ["://///", "", "   ", "ht tp://x"].each do |t|
+      Gori::Repeater::FlowRequest.parse_target(t).should eq({"http", "", 80})
+    end
+  end
+
+  it "round-trips an IPv6 literal through build_target / parse_target" do
+    # An unbracketed IPv6 host splits wrong on the ':' — both directions must agree, or a
+    # replay dials the wrong address.
+    target = Gori::Repeater::FlowRequest.build_target("https", "::1", 8443)
+    target.should eq("https://[::1]:8443")
+    Gori::Repeater::FlowRequest.parse_target(target).should eq({"https", "::1", 8443})
+
+    default_port = Gori::Repeater::FlowRequest.build_target("https", "::1", 443)
+    default_port.should eq("https://[::1]")
+    Gori::Repeater::FlowRequest.parse_target(default_port).should eq({"https", "::1", 443})
+  end
+
+  it "maps the WebSocket schemes onto the right default ports" do
+    Gori::Repeater::FlowRequest.build_target("wss", "h", 443).should eq("wss://h")
+    Gori::Repeater::FlowRequest.build_target("ws", "h", 80).should eq("ws://h")
+    Gori::Repeater::FlowRequest.build_target("ws", "h", 8080).should eq("ws://h:8080")
+  end
+end
+
+describe "replay reconstruct (P7) — Content-Length re-sync" do
+  it "rewrites an EXISTING Content-Length to the body it actually ships" do
+    # Used after $KEY expansion changes the body; an unsynced CL makes the origin over-
+    # or under-read.
+    bytes = "POST /u HTTP/1.1\r\nHost: h\r\nContent-Length: 99\r\n\r\nhello".to_slice
+    String.new(Gori::Repeater::FlowRequest.resync_content_length(bytes))
+      .should eq("POST /u HTTP/1.1\r\nHost: h\r\nContent-Length: 5\r\n\r\nhello")
+  end
+
+  it "never ADDS a Content-Length to a request that has none" do
+    # A bodyless GET must stay clean, and a chunked request must keep its framing.
+    get = "GET / HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+    String.new(Gori::Repeater::FlowRequest.resync_content_length(get)).should eq(String.new(get))
+
+    chunked = "POST /u HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n".to_slice
+    String.new(Gori::Repeater::FlowRequest.resync_content_length(chunked)).should eq(String.new(chunked))
+  end
+
+  it "leaves a head with no CRLFCRLF separator completely untouched" do
+    # LF-only or truncated heads have no recognizable body boundary; guessing one would
+    # corrupt bytes the operator captured deliberately.
+    lf_only = "POST /u HTTP/1.1\nContent-Length: 99\n\nhello".to_slice
+    String.new(Gori::Repeater::FlowRequest.resync_content_length(lf_only)).should eq(String.new(lf_only))
+  end
+end

--- a/spec/cli/run/sitemap_spec.cr
+++ b/spec/cli/run/sitemap_spec.cr
@@ -1,0 +1,218 @@
+require "../../spec_helper"
+require "json"
+
+# `gori run sitemap` — the three output formats (text tree / json / paths) and the tag
+# key normalization the `sitemap tag` subcommand writes with.
+
+# `sitemap_tag_path` is private CLI glue; reopen the module for a bare-call wrapper (the
+# same whitebox trick the other CLI specs use).
+module Gori::CLI::Run
+  def self.sitemap_tag_path_for_spec(target : String) : String
+    sitemap_tag_path(target)
+  end
+end
+
+describe "gori run sitemap — text tree" do
+  it "renders an indented tree with counts, methods, and a path tag" do
+    hosts = Gori::Sitemap.build([
+      {"acme.test", "GET", "/"},
+      {"acme.test", "POST", "/api/orders"},
+      {"acme.test", "GET", "/api/users"},
+    ])
+    Gori::Sitemap.stamp_tags!(hosts, { {"acme.test", "/api"} => "payment flow" })
+    hosts.each { |h| h.endpoints = Gori::Sitemap.endpoint_count(h) }
+    txt = Gori::CLI::Output.sitemap_text(hosts)
+    txt.should contain("acme.test  (3 paths)")
+    txt.should contain("├─ ") # tree guide
+    txt.should contain("orders  [POST]")
+    txt.should contain("api  # payment flow") # tag on the folder node, no methods
+  end
+
+  it "collapses a folded numeric group with a value count" do
+    hosts = Gori::Sitemap.build((1001..1012).map { |i| {"h", "GET", "/p/#{i}"} })
+    hosts.each { |h| Gori::Sitemap.group_sequences!(h) }
+    hosts.each { |h| h.endpoints = Gori::Sitemap.endpoint_count(h) }
+    txt = Gori::CLI::Output.sitemap_text(hosts)
+    txt.should contain("[1001, 1002, 1003 … +9]  (12 values)")
+    txt.should_not contain("1010") # a folded child is hidden in the collapsed text tree
+  end
+
+  it "shows one representative subtree under an id fold" do
+    # A numeric fold collapses whole; an ID fold must not, or /users/<uuid>/orders and
+    # /settings — real route structure, not noise — vanish from the default report.
+    hosts = Gori::Sitemap.build([
+      {"h", "GET", "/users/3f2a8b1c-1234-5678-9abc-def012345678/orders"},
+      {"h", "GET", "/users/3f2a8b1c-1234-5678-9abc-def012345678/settings"},
+      {"h", "GET", "/users/a1b2c3d4-5566-7788-99aa-bbccddeeff00/orders"},
+    ])
+    hosts.each { |h| Gori::Sitemap.fold_templates!(h) }
+    hosts.each { |h| h.endpoints = Gori::Sitemap.endpoint_count(h) }
+    txt = Gori::CLI::Output.sitemap_text(hosts)
+    # No verbs on the fold: /users/<uuid> itself was never requested here, only its
+    # children were — so the fold correctly stands for a folder, not an endpoint.
+    txt.should contain("{uuid}  (2 values)\n")
+    txt.should contain("orders")   # route shape below the id survives
+    txt.should contain("settings") # ...from ONE representative child
+    txt.should_not contain("3f2a8b1c")
+  end
+
+  it "shows the verbs a fold stands in for when the ids are themselves endpoints" do
+    hosts = Gori::Sitemap.build([
+      {"h", "GET", "/users/3f2a8b1c-1234-5678-9abc-def012345678"},
+      {"h", "PATCH", "/users/3f2a8b1c-1234-5678-9abc-def012345678"},
+      {"h", "GET", "/users/a1b2c3d4-5566-7788-99aa-bbccddeeff00"},
+    ])
+    hosts.each { |h| Gori::Sitemap.fold_templates!(h) }
+    hosts.each { |h| h.endpoints = Gori::Sitemap.endpoint_count(h) }
+    txt = Gori::CLI::Output.sitemap_text(hosts)
+    txt.should contain("{uuid}  (2 values)  [GET PATCH]")
+    txt.should contain("h  (2 paths)") # the fold did not inflate the endpoint count
+  end
+end
+
+describe "gori run sitemap --format paths" do
+  it "lists every endpoint flat (numeric folding irrelevant)" do
+    hosts = Gori::Sitemap.build([
+      {"acme.test", "GET", "/api/users"},
+      {"acme.test", "POST", "/api/users"},
+    ])
+    Gori::CLI::Output.sitemap_paths(hosts).should eq("GET,POST  acme.test/api/users\n")
+  end
+
+  it "still lists every FOLDED endpoint flat" do
+    hosts = Gori::Sitemap.build([
+      {"h", "GET", "/users/3f2a8b1c-1234-5678-9abc-def012345678"},
+      {"h", "GET", "/users/a1b2c3d4-5566-7788-99aa-bbccddeeff00"},
+    ])
+    hosts.each { |h| Gori::Sitemap.fold_templates!(h) }
+    Gori::CLI::Output.sitemap_paths(hosts).should eq(
+      "GET  h/users/3f2a8b1c-1234-5678-9abc-def012345678\n" \
+      "GET  h/users/a1b2c3d4-5566-7788-99aa-bbccddeeff00\n")
+  end
+end
+
+describe "gori run sitemap --format json" do
+  it "emits host/endpoint/children fields and an empty array when blank" do
+    hosts = Gori::Sitemap.build([{"acme.test", "GET", "/api/users"}])
+    Gori::Sitemap.stamp_tags!(hosts, { {"acme.test", "/api"} => "memo" })
+    hosts.each { |h| h.endpoints = Gori::Sitemap.endpoint_count(h) }
+    json = JSON.parse(Gori::CLI::Output.sitemap_json(hosts)).as_a
+    json.size.should eq(1)
+    json[0]["host"].as_s.should eq("acme.test")
+    json[0]["endpoints"].as_i.should eq(1)
+    api = json[0]["children"].as_a.find! { |c| c["label"].as_s == "api" }
+    api["tag"].as_s.should eq("memo")
+    users = api["children"].as_a.find! { |c| c["label"].as_s == "users" }
+    users["path"].as_s.should eq("/api/users")
+    users["methods"].as_a.map(&.as_s).should eq(["GET"])
+
+    Gori::CLI::Output.sitemap_json([] of Gori::Sitemap::Node).should eq("[]")
+  end
+
+  it "marks an id fold with a template class, omits its path, and keeps children" do
+    hosts = Gori::Sitemap.build([
+      {"h", "GET", "/users/3f2a8b1c-1234-5678-9abc-def012345678"},
+      {"h", "GET", "/users/a1b2c3d4-5566-7788-99aa-bbccddeeff00"},
+    ])
+    hosts.each { |h| Gori::Sitemap.fold_templates!(h) }
+    json = JSON.parse(Gori::CLI::Output.sitemap_json(hosts)).as_a
+    users = json[0]["children"].as_a.find! { |c| c["label"].as_s == "users" }
+    fold = users["children"].as_a.find! { |c| c["label"].as_s == "{uuid}" }
+    fold["grouped"].as_bool.should be_true
+    fold["template"].as_s.should eq("{uuid}")
+    fold["path"]?.should be_nil                         # synthetic: a fold has no path
+    fold["methods"].as_a.map(&.as_s).should eq(["GET"]) # union of its children's verbs
+    kids = fold["children"].as_a
+    kids.size.should eq(2)
+    kids.map(&.["path"].as_s).sort!.should eq([
+      "/users/3f2a8b1c-1234-5678-9abc-def012345678",
+      "/users/a1b2c3d4-5566-7788-99aa-bbccddeeff00",
+    ])
+  end
+
+  # sitemap_json is emitted by hand rather than through JSON::Builder precisely because the
+  # builder hard-caps nesting at 100, and each path segment costs ~2 levels (object +
+  # children array) — a deep captured path used to tear the whole report down with
+  # `JSON::Error: Nesting of 100 is too deep`. A security tool must not silently truncate
+  # its endpoint tree, so the ceiling is gone; nothing tested that until now.
+  it "emits a path deeper than JSON::Builder's 100-level nesting cap" do
+    depth = 80 # ≈160 JSON levels — well past the builder's limit
+    deep = "/" + (1..depth).map { |i| "s#{i}" }.join('/')
+    hosts = Gori::Sitemap.build([{"deep.test", "GET", deep}])
+    hosts.each { |h| h.endpoints = Gori::Sitemap.endpoint_count(h) }
+
+    parsed = JSON.parse(Gori::CLI::Output.sitemap_json(hosts)).as_a
+    node = parsed[0]
+    depth.times do |i|
+      node = node["children"].as_a.find! { |c| c["label"].as_s == "s#{i + 1}" }
+    end
+    node["path"].as_s.should eq(deep) # the leaf survived the whole descent
+    Gori::CLI::Output.sitemap_paths(hosts).should contain(deep)
+  end
+
+  it "emits valid UTF-8 in every format when a captured host/path is invalid UTF-8" do
+    # Sitemap.template_class's own comment documents that a captured target is raw bytes off
+    # the wire and can be invalid UTF-8 (a legacy-encoded or fuzzed path). Repro: no control
+    # chars, just a raw 0xFF byte in the host and in a path segment.
+    bad_host = String.new(Bytes[0x62, 0x61, 0x64, 0xff, 0x68, 0x6f, 0x73, 0x74]) # "bad\xFFhost"
+    bad_seg = String.new(Bytes[0x70, 0x61, 0x74, 0x68, 0xff, 0x73, 0x65, 0x67])  # "path\xFFseg"
+    hosts = Gori::Sitemap.build([{bad_host, "GET", "/#{bad_seg}"}])
+    hosts.each { |h| h.endpoints = Gori::Sitemap.endpoint_count(h) }
+
+    text = Gori::CLI::Output.sitemap_text(hosts)
+    text.valid_encoding?.should be_true
+    text.should contain("bad�host")
+    text.should contain("path�seg")
+
+    json_str = Gori::CLI::Output.sitemap_json(hosts)
+    json_str.valid_encoding?.should be_true
+    parsed = JSON.parse(json_str).as_a
+    parsed[0]["host"].as_s.valid_encoding?.should be_true
+    parsed[0]["children"].as_a[0]["label"].as_s.valid_encoding?.should be_true
+
+    paths = Gori::CLI::Output.sitemap_paths(hosts)
+    paths.valid_encoding?.should be_true
+    paths.should contain("bad�host")
+  end
+
+  it "does not leak a host tag onto a fold" do
+    # Host rows are taggable with path "" — the same value a synthetic fold carries.
+    hosts = Gori::Sitemap.build([
+      {"h", "GET", "/u/3f2a8b1c-1234-5678-9abc-def012345678"},
+      {"h", "GET", "/u/a1b2c3d4-5566-7788-99aa-bbccddeeff00"},
+    ])
+    hosts.each { |h| Gori::Sitemap.fold_templates!(h) }
+    Gori::Sitemap.stamp_tags!(hosts, { {"h", ""} => "whole host" })
+    u = hosts.first.children.find! { |c| c.label == "u" }
+    u.children.find! { |c| c.label == "{uuid}" }.tag.should be_nil
+  end
+end
+
+describe "gori run sitemap tag — the key a tag is filed under" do
+  # Every assertion here pins a LITERAL rather than re-deriving the expected value from
+  # Sitemap.normalize_path: comparing the function against itself would move both sides
+  # together, and a regression in normalize_path — the exact thing that would orphan every
+  # stored tag — would keep the spec green.
+
+  # The key KEEPS the query string, because "/login?a=1" is a distinct tree node from
+  # "/login". Stripping it would file the tag under a key no node ever has, and the tag
+  # would silently never appear in the tree.
+  it "keeps the query string, so a query-bearing endpoint keys on its own node" do
+    Gori::CLI::Run.sitemap_tag_path_for_spec("/login?a=1").should eq("/login?a=1")
+    Gori::CLI::Run.sitemap_tag_path_for_spec("/api/users").should eq("/api/users")
+    Gori::CLI::Run.sitemap_tag_path_for_spec("  /api/users  ").should eq("/api/users")
+  end
+
+  it "adds the leading slash a hand-typed --path omits, and maps empty to /" do
+    Gori::CLI::Run.sitemap_tag_path_for_spec("api/users").should eq("/api/users")
+    Gori::CLI::Run.sitemap_tag_path_for_spec("").should eq("/")
+    Gori::CLI::Run.sitemap_tag_path_for_spec("   ").should eq("/")
+  end
+
+  it "reduces an absolute-form target to its origin-form path" do
+    # A tag typed as a full URL still has to land on the node the tree built, and
+    # Sitemap.build normalizes before stamping — so the key is "/a", not the whole URL.
+    Gori::CLI::Run.sitemap_tag_path_for_spec("http://h/a").should eq("/a")
+    Gori::CLI::Run.sitemap_tag_path_for_spec("https://h/a?b=1").should eq("/a?b=1")
+  end
+end

--- a/spec/cli_run_spec.cr
+++ b/spec/cli_run_spec.cr
@@ -1,6 +1,29 @@
 require "./spec_helper"
 require "json"
 
+# What is LEFT of the old monolithic `gori run` spec.
+#
+# MOVED to spec/cli/run/<subcommand>_spec.cr, mirroring src/gori/cli/run/:
+#   history · sitemap · notes · issues · links · decoder · jwt · compare · project · import
+#   plus spec/cli/run/replay_reconstruct_spec.cr — the P7 "never reject malformed input on
+#   replay" invariant over Repeater::FlowRequest's HOSTILE inputs.
+#
+# STILL HERE, and why:
+#   • describe Gori::Repeater::FlowRequest — the WELL-FORMED reconstruct cases (absolute→
+#     origin rewrite, http2 flag, truncated-capture Content-Length/chunked re-frame).
+#   • describe Gori::CLI::Output — the probe group JSON/text rows. `gori run probe` is an
+#     active-sender subcommand, so its spec waits with the rest of them.
+#   • describe Gori::Notes — the notes ENGINE (parse/serialize/load/title/line_count), not
+#     the `gori run notes` output; spec/cli/run/notes_spec.cr covers the CLI formatting.
+#   • The active-sender subcommands: repeater send (h1/WS), fuzz/mine/sequence host
+#     overrides, intercept bridge state, probe categories. Their semantics are being
+#     changed under separate issues, so specs written against today's behaviour would be
+#     rewritten anyway — split them out with that work.
+#
+# Two more `gori run` specs predate the split and still sit at the top level:
+# spec/cli_run_oast_stop_spec.cr and spec/cli_run_sequence_tokens_spec.cr (oast / sequence,
+# also active-sender). Fold them into spec/cli/run/ when those subcommands are covered.
+
 # Builds a minimal FlowDetail without touching the DB (the structs have public
 # initializers) — enough to exercise the pure reconstruction/formatting code.
 private def flow_detail(scheme : String, host : String, port : Int32, request_head : String,
@@ -13,13 +36,6 @@ private def flow_detail(scheme : String, host : String, port : Int32, request_he
   Gori::Store::FlowDetail.new(row, http_version, request_head.to_slice, request_body,
     response_head.try(&.to_slice), response_body.try(&.to_slice),
     request_body_truncated: request_body_truncated)
-end
-
-private def flow_row(*, target : String, host : String, status : Int32?, state : Gori::Store::FlowState)
-  Gori::Store::FlowRow.new(
-    id: 42_i64, created_at: 1_700_000_000_000_000_i64, scheme: "https", method: "GET",
-    host: host, port: 443, target: target, status: status, size: 1536_i64, state: state,
-    response_size: 1400_i64, duration_us: 3000_i64, content_type: "text/html")
 end
 
 private def with_store(&)
@@ -123,173 +139,7 @@ describe Gori::Repeater::FlowRequest do
   end
 end
 
-describe Gori::Issues::Export do
-  it "serialises issues to JSON with the documented fields" do
-    issues = [
-      Gori::Store::Issue.new(1_i64, 10_i64, 20_i64, "XSS", Gori::Store::Severity::High,
-        "shop.test", 13_i64, "reflected", Gori::Store::Status::Confirmed),
-      Gori::Store::Issue.new(2_i64, 11_i64, 11_i64, "note", Gori::Store::Severity::Info,
-        nil, nil, "", Gori::Store::Status::Open),
-    ]
-    parsed = JSON.parse(Gori::Issues::Export.json(issues)).as_a
-    parsed.size.should eq(2)
-    parsed[0]["title"].as_s.should eq("XSS")
-    parsed[0]["severity"].as_s.should eq("high")
-    parsed[0]["status"].as_s.should eq("confirmed")
-    parsed[0]["flow_id"].as_i.should eq(13)
-    parsed[0]["links"].as_a.should be_empty
-    parsed[1]["host"].raw.should be_nil
-    parsed[1]["flow_id"].raw.should be_nil
-  end
-
-  it "serialises entity links in issues JSON export" do
-    with_store do |store|
-      fid = store.insert_flow(Gori::Store::CapturedRequest.new(
-        created_at: 1_i64, scheme: "https", host: "api.test", port: 443, method: "GET",
-        target: "/x", http_version: "HTTP/1.1",
-        head: "GET /x HTTP/1.1\r\nHost: api.test\r\n\r\n".to_slice))
-      issue_id = store.insert_issue("linked", Gori::Store::Severity::Medium, "api.test", fid)
-      store.add_link(Gori::Store::LinkOwnerKind::Issue, issue_id,
-        Gori::Store::LinkRefKind::Repeater, 9_i64)
-      parsed = JSON.parse(Gori::Issues::Export.json(store.issues, store)).as_a
-      links = parsed[0]["links"].as_a
-      links.size.should eq(1) # primary flow link is deduped from the export list
-      links[0]["kind"].as_s.should eq("repeater")
-      links[0]["ref_id"].as_i.should eq(9)
-      links[0]["label"].as_s.should_not be_empty
-    end
-  end
-
-  it "renders a Markdown report with severity/status labels and notes" do
-    with_store do |store|
-      issues = [Gori::Store::Issue.new(1_i64, 0_i64, 0_i64, "Reflected XSS",
-        Gori::Store::Severity::High, "shop.test", nil, "encode on output", Gori::Store::Status::Open)]
-      md = Gori::Issues::Export.markdown(issues, store, "demo")
-      md.should contain("# Issues — demo")
-      md.should contain("## [high] Reflected XSS")
-      md.should contain("**Severity:** high")
-      md.should contain("**Status:** open")
-      md.should contain("encode on output")
-    end
-  end
-
-  it "embeds linked-flow evidence in the Markdown report" do
-    with_store do |store|
-      req = Gori::Store::CapturedRequest.new(
-        created_at: 0_i64, scheme: "https", host: "api.test", port: 443, method: "GET",
-        target: "/v1/debug", http_version: "HTTP/1.1",
-        head: "GET /v1/debug HTTP/1.1\r\nHost: api.test\r\n\r\n".to_slice)
-      fid = store.insert_flow(req)
-      store.flush
-      issues = [Gori::Store::Issue.new(1_i64, 0_i64, 0_i64, "leak",
-        Gori::Store::Severity::Medium, "api.test", fid, "", Gori::Store::Status::Open)]
-      md = Gori::Issues::Export.markdown(issues, store, "demo")
-      md.should contain("### Request")
-      md.should contain("GET /v1/debug HTTP/1.1")
-      md.should contain("(##{fid})")
-      # The header block's terminating CRLF CRLF is trimmed, so the last header
-      # line abuts the closing fence (no stack of blank lines inside the block).
-      md.should contain("Host: api.test\n```")
-      md.should_not contain("\r\n\r\n")
-    end
-  end
-
-  it "separates evidence headers from the body with exactly one blank line" do
-    with_store do |store|
-      req = Gori::Store::CapturedRequest.new(
-        created_at: 0_i64, scheme: "https", host: "api.test", port: 443, method: "POST",
-        target: "/login", http_version: "HTTP/1.1",
-        head: "POST /login HTTP/1.1\r\nHost: api.test\r\nContent-Length: 9\r\n\r\n".to_slice,
-        body: "user=root".to_slice)
-      fid = store.insert_flow(req)
-      store.flush
-      issues = [Gori::Store::Issue.new(1_i64, 0_i64, 0_i64, "creds in body",
-        Gori::Store::Severity::High, "api.test", fid, "", Gori::Store::Status::Open)]
-      md = Gori::Issues::Export.markdown(issues, store, "demo")
-      # one blank line between the last header and the body — not three
-      md.should contain("Content-Length: 9\n\nuser=root")
-      md.should_not contain("Content-Length: 9\n\n\nuser=root")
-    end
-  end
-end
-
-describe Gori::QL do
-  # `gori run history -q` relies on this: a query that fails to compile to any
-  # clause collapses to the match-all EMPTY filter. The CLI special-cases that so
-  # a typo like `status:>=foo` errors instead of silently dumping every flow.
-  it "collapses an un-compilable query to EMPTY (so the CLI can reject it)" do
-    Gori::QL.parse("status:>=foo").should eq(Gori::QL::EMPTY)
-    Gori::QL.parse("-status:bar").should eq(Gori::QL::EMPTY)
-    Gori::QL.parse("login").should_not eq(Gori::QL::EMPTY)
-    Gori::QL.parse("status:>=500").should_not eq(Gori::QL::EMPTY)
-  end
-end
-
 describe Gori::CLI::Output do
-  it "shows an absolute-form target as-is and prefixes an origin-form one with the host" do
-    abs = Gori::CLI::Output.flow_row_text(flow_row(target: "http://e.test/a", host: "e.test", status: 200, state: Gori::Store::FlowState::Complete))
-    abs.should contain("http://e.test/a")
-    abs.should_not contain("e.testhttp://") # no double host
-
-    rel = Gori::CLI::Output.flow_row_text(flow_row(target: "/a", host: "api.test", status: 200, state: Gori::Store::FlowState::Complete))
-    rel.should contain("api.test/a")
-  end
-
-  it "marks a pending flow with a dash status and a state tag" do
-    txt = Gori::CLI::Output.flow_row_text(flow_row(target: "/p", host: "h", status: nil, state: Gori::Store::FlowState::Pending))
-    txt.should contain("—")
-    txt.should contain("[Pending]")
-  end
-
-  it "neutralizes terminal escape sequences in an untrusted captured target" do
-    # A malicious client puts ANSI/OSC escapes in its request line; the text row must
-    # not inject them into the operator's terminal (they'd be replayed on every view).
-    evil = "/p\e[31m\r\n\e]0;pwned\a"
-    txt = Gori::CLI::Output.flow_row_text(flow_row(target: evil, host: "h", status: 200, state: Gori::Store::FlowState::Complete))
-    txt.should_not contain('\e') # no ESC
-    txt.should_not contain('\r') # no CR
-    txt.should_not contain('\a') # no BEL
-    txt.should contain("·")      # control bytes replaced with a visible marker
-  end
-
-  it "term_safe leaves ordinary UTF-8 untouched but replaces control bytes" do
-    Gori::CLI::Output.term_safe("api.test/π/데이터").should eq("api.test/π/데이터")
-    Gori::CLI::Output.term_safe("a\tb\nc").should eq("a·b·c")
-  end
-
-  it "term_safe also scrubs invalid UTF-8 (not just control bytes) so JSON output stays valid" do
-    # A captured host/path is raw bytes off the wire (see Sitemap.template_class's comment)
-    # and can be invalid UTF-8 with NO control bytes at all — the old short-circuit
-    # (`return s unless s.each_char.any?(&.control?)`) let such a value straight through
-    # unchanged, since a replacement char isn't itself "control".
-    bad = String.new(Bytes[0x68, 0x69, 0xff, 0x68, 0x69]) # "hi\xFFhi"
-    bad.valid_encoding?.should be_false
-    out = Gori::CLI::Output.term_safe(bad)
-    out.valid_encoding?.should be_true
-    out.should eq("hi�hi")
-  end
-
-  it "emits a valid JSON object with the expected keys" do
-    json = JSON.parse(Gori::CLI::Output.flow_row_json(flow_row(target: "/a", host: "h", status: 200, state: Gori::Store::FlowState::Complete)))
-    json["id"].as_i.should eq(42)
-    json["method"].as_s.should eq("GET")
-    json["status"].as_i.should eq(200)
-    json["state"].as_s.should eq("complete") # lowercased to match the MCP serializer
-  end
-
-  it "humanises sizes and durations" do
-    Gori::CLI::Output.human_size(500_i64).should eq("500B")
-    Gori::CLI::Output.human_size(1536_i64).should eq("1.5kB")
-    Gori::CLI::Output.human_us(500_i64).should eq("500µs")
-    Gori::CLI::Output.human_us(1_500_i64).should eq("1.5ms")
-  end
-
-  it "scales human_size up to GB and TB (no '1024.0MB')" do
-    Gori::CLI::Output.human_size(1_073_741_824_i64).should eq("1.0GB")     # exactly 1 GiB
-    Gori::CLI::Output.human_size(5_368_709_120_i64).should eq("5.0GB")     # 5 GiB
-    Gori::CLI::Output.human_size(2_199_023_255_552_i64).should eq("2.0TB") # 2 TiB
-  end
-
   it "serialises a probe group to JSON with the documented fields (incl. remediation)" do
     g = Gori::Probe::Group.new("secret_in_url", "infoleak", "api.test", "Secret in URL",
       Gori::Store::Severity::High, 3, ["https://api.test/a", "https://api.test/b"], "token", 7_i64)
@@ -315,201 +165,6 @@ describe Gori::CLI::Output do
     txt.should contain("×4")
     txt.should contain("https://api.test/a")
     txt.should contain("(+2 more)") # 3 affected − 1 shown
-  end
-
-  it "formats a note listing row: 1-based index, title, '*' for the active note" do
-    row = Gori::CLI::Output.note_row_text(1, "scope\nmore", current: true)
-    row.should contain("* 2")                                                           # 0-based 1 → shown as #2
-    row.should contain("scope")                                                         # title = first non-blank line
-    row.should contain("(2 lines, ")                                                    # plural
-    Gori::CLI::Output.note_row_text(0, "x", current: false).should contain(" 1")        # no '*'
-    Gori::CLI::Output.note_row_text(0, "x", current: false).should contain("(1 line, ") # singular
-  end
-
-  it "falls back to 'note N' in a row for a blank note" do
-    Gori::CLI::Output.note_row_text(2, "   \n\t", current: false).should contain("note 3")
-  end
-
-  it "emits a single-note JSON object with the documented fields (text only when asked)" do
-    entry = Gori::Notes::NoteEntry.new(42_i64, "Title\nbody")
-    full = JSON.parse(Gori::CLI::Output.note_object_json(0, entry, current: true, with_text: true))
-    full["id"].as_i64.should eq(42_i64)
-    full["index"].as_i.should eq(1)
-    full["title"].as_s.should eq("Title")
-    full["lines"].as_i.should eq(2)
-    full["bytes"].as_i.should eq("Title\nbody".bytesize)
-    full["current"].as_bool.should be_true
-    full["text"].as_s.should eq("Title\nbody")
-
-    summary = JSON.parse(Gori::CLI::Output.note_object_json(0, entry, current: false, with_text: false))
-    summary["text"]?.should be_nil # summary omits the body
-    summary["title"].as_s.should eq("Title")
-  end
-
-  it "emits the whole note set as a JSON array, marking the active note" do
-    doc = Gori::Notes::Doc.new(1, [
-      Gori::Notes::NoteEntry.new(1_i64, "one"),
-      Gori::Notes::NoteEntry.new(2_i64, "two"),
-    ], 3_i64)
-    arr = JSON.parse(Gori::CLI::Output.notes_array_json(doc, with_text: false)).as_a
-    arr.size.should eq(2)
-    arr[0]["id"].as_i64.should eq(1_i64)
-    arr[0]["index"].as_i.should eq(1)
-    arr[0]["current"].as_bool.should be_false
-    arr[1]["current"].as_bool.should be_true # cur == 1
-    arr[0]["text"]?.should be_nil            # summary array
-
-    with_text = JSON.parse(Gori::CLI::Output.notes_array_json(doc, with_text: true)).as_a
-    with_text[1]["text"].as_s.should eq("two")
-  end
-  it "renders the sitemap as an indented tree with counts, methods, and a path tag" do
-    hosts = Gori::Sitemap.build([
-      {"acme.test", "GET", "/"},
-      {"acme.test", "POST", "/api/orders"},
-      {"acme.test", "GET", "/api/users"},
-    ])
-    Gori::Sitemap.stamp_tags!(hosts, { {"acme.test", "/api"} => "payment flow" })
-    hosts.each { |h| h.endpoints = Gori::Sitemap.endpoint_count(h) }
-    txt = Gori::CLI::Output.sitemap_text(hosts)
-    txt.should contain("acme.test  (3 paths)")
-    txt.should contain("├─ ") # tree guide
-    txt.should contain("orders  [POST]")
-    txt.should contain("api  # payment flow") # tag on the folder node, no methods
-  end
-
-  it "collapses a folded numeric group in the text tree with a value count" do
-    hosts = Gori::Sitemap.build((1001..1012).map { |i| {"h", "GET", "/p/#{i}"} })
-    hosts.each { |h| Gori::Sitemap.group_sequences!(h) }
-    hosts.each { |h| h.endpoints = Gori::Sitemap.endpoint_count(h) }
-    txt = Gori::CLI::Output.sitemap_text(hosts)
-    txt.should contain("[1001, 1002, 1003 … +9]  (12 values)")
-    txt.should_not contain("1010") # a folded child is hidden in the collapsed text tree
-  end
-
-  it "shows one representative subtree under an id fold in the text tree" do
-    # A numeric fold collapses whole; an ID fold must not, or /users/<uuid>/orders and
-    # /settings — real route structure, not noise — vanish from the default report.
-    hosts = Gori::Sitemap.build([
-      {"h", "GET", "/users/3f2a8b1c-1234-5678-9abc-def012345678/orders"},
-      {"h", "GET", "/users/3f2a8b1c-1234-5678-9abc-def012345678/settings"},
-      {"h", "GET", "/users/a1b2c3d4-5566-7788-99aa-bbccddeeff00/orders"},
-    ])
-    hosts.each { |h| Gori::Sitemap.fold_templates!(h) }
-    hosts.each { |h| h.endpoints = Gori::Sitemap.endpoint_count(h) }
-    txt = Gori::CLI::Output.sitemap_text(hosts)
-    # No verbs on the fold: /users/<uuid> itself was never requested here, only its
-    # children were — so the fold correctly stands for a folder, not an endpoint.
-    txt.should contain("{uuid}  (2 values)\n")
-    txt.should contain("orders")   # route shape below the id survives
-    txt.should contain("settings") # ...from ONE representative child
-    txt.should_not contain("3f2a8b1c")
-  end
-
-  it "shows the verbs a fold stands in for when the ids are themselves endpoints" do
-    hosts = Gori::Sitemap.build([
-      {"h", "GET", "/users/3f2a8b1c-1234-5678-9abc-def012345678"},
-      {"h", "PATCH", "/users/3f2a8b1c-1234-5678-9abc-def012345678"},
-      {"h", "GET", "/users/a1b2c3d4-5566-7788-99aa-bbccddeeff00"},
-    ])
-    hosts.each { |h| Gori::Sitemap.fold_templates!(h) }
-    hosts.each { |h| h.endpoints = Gori::Sitemap.endpoint_count(h) }
-    txt = Gori::CLI::Output.sitemap_text(hosts)
-    txt.should contain("{uuid}  (2 values)  [GET PATCH]")
-    txt.should contain("h  (2 paths)") # the fold did not inflate the endpoint count
-  end
-
-  it "lists every endpoint flat in the paths format (numeric folding irrelevant)" do
-    hosts = Gori::Sitemap.build([
-      {"acme.test", "GET", "/api/users"},
-      {"acme.test", "POST", "/api/users"},
-    ])
-    Gori::CLI::Output.sitemap_paths(hosts).should eq("GET,POST  acme.test/api/users\n")
-  end
-
-  it "emits the sitemap as JSON with host/endpoint/children fields and an empty array when blank" do
-    hosts = Gori::Sitemap.build([{"acme.test", "GET", "/api/users"}])
-    Gori::Sitemap.stamp_tags!(hosts, { {"acme.test", "/api"} => "memo" })
-    hosts.each { |h| h.endpoints = Gori::Sitemap.endpoint_count(h) }
-    json = JSON.parse(Gori::CLI::Output.sitemap_json(hosts)).as_a
-    json.size.should eq(1)
-    json[0]["host"].as_s.should eq("acme.test")
-    json[0]["endpoints"].as_i.should eq(1)
-    api = json[0]["children"].as_a.find! { |c| c["label"].as_s == "api" }
-    api["tag"].as_s.should eq("memo")
-    users = api["children"].as_a.find! { |c| c["label"].as_s == "users" }
-    users["path"].as_s.should eq("/api/users")
-    users["methods"].as_a.map(&.as_s).should eq(["GET"])
-
-    Gori::CLI::Output.sitemap_json([] of Gori::Sitemap::Node).should eq("[]")
-  end
-
-  it "marks an id fold in JSON with a template class, omits its path, and keeps children" do
-    hosts = Gori::Sitemap.build([
-      {"h", "GET", "/users/3f2a8b1c-1234-5678-9abc-def012345678"},
-      {"h", "GET", "/users/a1b2c3d4-5566-7788-99aa-bbccddeeff00"},
-    ])
-    hosts.each { |h| Gori::Sitemap.fold_templates!(h) }
-    json = JSON.parse(Gori::CLI::Output.sitemap_json(hosts)).as_a
-    users = json[0]["children"].as_a.find! { |c| c["label"].as_s == "users" }
-    fold = users["children"].as_a.find! { |c| c["label"].as_s == "{uuid}" }
-    fold["grouped"].as_bool.should be_true
-    fold["template"].as_s.should eq("{uuid}")
-    fold["path"]?.should be_nil                         # synthetic: a fold has no path
-    fold["methods"].as_a.map(&.as_s).should eq(["GET"]) # union of its children's verbs
-    kids = fold["children"].as_a
-    kids.size.should eq(2)
-    kids.map(&.["path"].as_s).sort!.should eq([
-      "/users/3f2a8b1c-1234-5678-9abc-def012345678",
-      "/users/a1b2c3d4-5566-7788-99aa-bbccddeeff00",
-    ])
-  end
-
-  it "still lists every folded endpoint flat in the paths format" do
-    hosts = Gori::Sitemap.build([
-      {"h", "GET", "/users/3f2a8b1c-1234-5678-9abc-def012345678"},
-      {"h", "GET", "/users/a1b2c3d4-5566-7788-99aa-bbccddeeff00"},
-    ])
-    hosts.each { |h| Gori::Sitemap.fold_templates!(h) }
-    Gori::CLI::Output.sitemap_paths(hosts).should eq(
-      "GET  h/users/3f2a8b1c-1234-5678-9abc-def012345678\n" \
-      "GET  h/users/a1b2c3d4-5566-7788-99aa-bbccddeeff00\n")
-  end
-
-  it "emits valid UTF-8 in every sitemap format (text/json/paths) when a captured host/path is invalid UTF-8" do
-    # Sitemap.template_class's own comment documents that a captured target is raw bytes off
-    # the wire and can be invalid UTF-8 (a legacy-encoded or fuzzed path). Repro: no control
-    # chars, just a raw 0xFF byte in the host and in a path segment.
-    bad_host = String.new(Bytes[0x62, 0x61, 0x64, 0xff, 0x68, 0x6f, 0x73, 0x74]) # "bad\xFFhost"
-    bad_seg = String.new(Bytes[0x70, 0x61, 0x74, 0x68, 0xff, 0x73, 0x65, 0x67])  # "path\xFFseg"
-    hosts = Gori::Sitemap.build([{bad_host, "GET", "/#{bad_seg}"}])
-    hosts.each { |h| h.endpoints = Gori::Sitemap.endpoint_count(h) }
-
-    text = Gori::CLI::Output.sitemap_text(hosts)
-    text.valid_encoding?.should be_true
-    text.should contain("bad�host")
-    text.should contain("path�seg")
-
-    json_str = Gori::CLI::Output.sitemap_json(hosts)
-    json_str.valid_encoding?.should be_true
-    parsed = JSON.parse(json_str).as_a
-    parsed[0]["host"].as_s.valid_encoding?.should be_true
-    parsed[0]["children"].as_a[0]["label"].as_s.valid_encoding?.should be_true
-
-    paths = Gori::CLI::Output.sitemap_paths(hosts)
-    paths.valid_encoding?.should be_true
-    paths.should contain("bad�host")
-  end
-
-  it "does not leak a host tag onto a fold" do
-    # Host rows are taggable with path "" — the same value a synthetic fold carries.
-    hosts = Gori::Sitemap.build([
-      {"h", "GET", "/u/3f2a8b1c-1234-5678-9abc-def012345678"},
-      {"h", "GET", "/u/a1b2c3d4-5566-7788-99aa-bbccddeeff00"},
-    ])
-    hosts.each { |h| Gori::Sitemap.fold_templates!(h) }
-    Gori::Sitemap.stamp_tags!(hosts, { {"h", ""} => "whole host" })
-    u = hosts.first.children.find! { |c| c.label == "u" }
-    u.children.find! { |c| c.label == "{uuid}" }.tag.should be_nil
   end
 end
 
@@ -593,79 +248,6 @@ describe Gori::Notes do
   end
 end
 
-# `gori run jwt` builds its JSON output from the shared engine emitters (jwt/present.cr)
-# and its text from CLI::Output — the same pure functions tested here.
-describe "gori run jwt output" do
-  jwt = Gori::Jwt.encode(%({"typ":"JWT"}), %({"sub":"1"}), "HS256", "k")
-
-  it "decode_json carries nested header/payload objects + the signed flag" do
-    j = JSON.parse(Gori::Jwt.decode_json(jwt))
-    j["alg"].as_s.should eq("HS256")
-    j["header"]["typ"].as_s.should eq("JWT")
-    j["payload"]["sub"].as_s.should eq("1")
-    j["signed"].as_bool.should be_true
-  end
-
-  it "attacks_json is an array of {name, category, note, token}" do
-    arr = JSON.parse(Gori::Jwt.attacks_json(Gori::Jwt.attacks(jwt))).as_a
-    arr.should_not be_empty
-    arr.first["name"].as_s.should_not be_empty
-    arr.first["token"].as_s.should contain(".")
-    arr.map { |a| a["category"].as_s }.uniq.should contain("weak-secret")
-  end
-
-  it "jwt_attack_text prints the category, name, note, and token" do
-    a = Gori::Jwt.attacks(jwt).find { |x| x.name == "alg=none" }.not_nil!
-    text = Gori::CLI::Output.jwt_attack_text(a)
-    text.should contain("[none]")
-    text.should contain("alg=none")
-    text.should contain(a.token)
-  end
-end
-
-# `show_json` is `private` (CLI-command glue, not a public API) — reopen the module to
-# expose a thin bare-call wrapper for testing, same trick Crystal allows for whitebox
-# specs of private `self.` methods (a bare call from within the same type is permitted;
-# only an explicit-receiver call from outside is not).
-module Gori::CLI::Run
-  def self.show_json_for_spec(detail : Store::FlowDetail, req : Bool, resp : Bool,
-                              ws_msgs : Array(Store::WsMessage) = [] of Store::WsMessage) : String
-    show_json(detail, req, resp, ws_msgs)
-  end
-end
-
-# Regression for the `sse_events.truncated` field: `gori run show --format json` used to
-# hardcode it to `false` regardless of how many events were parsed, while the MCP
-# `get_flow` serializer (mcp/serialize.cr) computed it correctly from `events.size >
-# SSE_EVENTS_MAX`. The two must agree — CLI now reuses the exact same constant.
-describe "gori run show --format json sse_events.truncated" do
-  it "is false when the event count is at or under the cap" do
-    body = String.build { |io| 3.times { |i| io << "data: e#{i}\n\n" } }
-    head = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n"
-    detail = flow_detail("http", "x", 80, "GET / HTTP/1.1\r\nHost: x\r\n\r\n",
-      response_head: head, response_body: body)
-    json = JSON.parse(Gori::CLI::Run.show_json_for_spec(detail, true, true))
-    sse = json["sse_events"]
-    sse["count"].as_i.should eq(3)
-    sse["truncated"].as_bool.should be_false
-  end
-
-  it "is true once the event count exceeds SSE_EVENTS_MAX, matching the MCP serializer" do
-    n = Gori::MCP::Serialize::SSE_EVENTS_MAX + 1
-    body = String.build { |io| n.times { |i| io << "data: e#{i}\n\n" } }
-    head = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n"
-    detail = flow_detail("http", "x", 80, "GET / HTTP/1.1\r\nHost: x\r\n\r\n",
-      response_head: head, response_body: body)
-    json = JSON.parse(Gori::CLI::Run.show_json_for_spec(detail, true, true))
-    sse = json["sse_events"]
-    sse["count"].as_i.should eq(n)
-    sse["truncated"].as_bool.should be_true
-    # the CLI path stays unclipped (a script can read whole values) — unlike MCP, it
-    # does NOT drop events past the cap; `truncated` is a signal, not a clip.
-    sse["events"].as_a.size.should eq(n)
-  end
-end
-
 describe "gori run probe --active" do
   it "includes Category::ACTIVE in PROBE_CATEGORIES" do
     Gori::CLI::Run::PROBE_CATEGORIES.should contain(Gori::Probe::Category::ACTIVE)
@@ -711,47 +293,6 @@ describe "gori run repeater send (session replay resolution)" do
   end
 end
 
-# `import_source` / `import_result_*` are private CLI glue; reopen the module to expose
-# thin bare-call wrappers (same whitebox trick as the other *_for_spec wrappers above).
-# The abort paths (zero / two+ sources) call `exit`, so they can't be exercised in-process.
-module Gori::CLI::Run
-  def self.import_source_for_spec(har : String?, oas : String?, urls : String?) : {Symbol, String}
-    import_source(har, oas, urls)
-  end
-
-  def self.import_result_json_for_spec(kind : Symbol, path : String, result : Import::Result) : String
-    import_result_json(kind, path, result)
-  end
-
-  def self.import_result_text_for_spec(kind : Symbol, path : String, result : Import::Result) : String
-    import_result_text(kind, path, result)
-  end
-end
-
-describe "gori run import" do
-  it "import_source maps each source flag to its {kind, path}" do
-    Gori::CLI::Run.import_source_for_spec("a.har", nil, nil).should eq({:har, "a.har"})
-    Gori::CLI::Run.import_source_for_spec(nil, "api.yaml", nil).should eq({:oas, "api.yaml"})
-    Gori::CLI::Run.import_source_for_spec(nil, nil, "urls.txt").should eq({:urls, "urls.txt"})
-  end
-
-  it "import_result_json carries kind, path, count, and skipped" do
-    result = Gori::Import::Result.new(count: 12, skipped: 3)
-    json = JSON.parse(Gori::CLI::Run.import_result_json_for_spec(:har, "dump.har", result))
-    json["kind"].as_s.should eq("har")
-    json["path"].as_s.should eq("dump.har")
-    json["count"].as_i.should eq(12)
-    json["skipped"].as_i.should eq(3)
-  end
-
-  it "import_result_text mirrors the TUI toast wording, with a skipped clause only when > 0" do
-    clean = Gori::CLI::Run.import_result_text_for_spec(:oas, "api.json", Gori::Import::Result.new(count: 1))
-    clean.should eq("imported 1 flow from OpenAPI · api.json")
-    skipped = Gori::CLI::Run.import_result_text_for_spec(:urls, "u.txt", Gori::Import::Result.new(count: 5, skipped: 2))
-    skipped.should eq("imported 5 flows from URLs · u.txt (2 entries skipped)")
-  end
-end
-
 # cli_host_overrides is private CLI glue (R2-1 parity for the fuzz/mine/sequence senders);
 # reopen the module for a bare-call wrapper (same whitebox trick as the others above).
 module Gori::CLI::Run
@@ -777,25 +318,6 @@ describe "gori run fuzz/mine/sequence — project host overrides (R2-1)" do
       store.close unless closed
       File.delete?(path); File.delete?("#{path}-wal"); File.delete?("#{path}-shm")
     end
-  end
-end
-
-# `compare_lines` is private CLI glue (mirrors the TUI Comparer's lines_for) —
-# reopen the module for a bare-call wrapper, the same trick the other whitebox specs use.
-module Gori::CLI::Run
-  def self.compare_lines_for_spec(d : Gori::Store::FlowDetail, pane : Symbol) : Array(String)
-    compare_lines(d, pane)
-  end
-end
-
-describe "gori run compare" do
-  it "builds request lines byte-faithful (no decoding) and response lines decoded" do
-    d = flow_detail("https", "a.test", 443, "GET / HTTP/1.1\r\nHost: a.test\r\n\r\n",
-      response_head: "HTTP/1.1 200 OK\r\n\r\n", response_body: "hello")
-    req_lines = Gori::CLI::Run.compare_lines_for_spec(d, :request)
-    req_lines.first.should eq("GET / HTTP/1.1")
-    resp_lines = Gori::CLI::Run.compare_lines_for_spec(d, :response)
-    resp_lines.should contain("hello")
   end
 end
 
@@ -863,149 +385,6 @@ describe "gori run intercept (bridge state)" do
       store.set_intercept_bridge(%({"capturing":true,"session_token":"tok","heartbeat_ms":#{stale}}))
       bridge = Gori::CLI::Run.intercept_bridge_state_for_spec(store).not_nil!
       Gori::CLI::Run.intercept_live_for_spec(bridge).should be_false
-    end
-  end
-end
-
-# `gori run project create/delete` glue is private CLI code — reopen the module for
-# bare-call wrappers (the same whitebox trick as the others above).
-module Gori::CLI::Run
-  def self.project_object_counts_for_spec(project : Gori::Project) : {Int64?, Int32?}
-    project_object_counts(project)
-  end
-
-  def self.ambiguous_project_name_for_spec(registry : Gori::ProjectRegistry, name : String) : Bool
-    ambiguous_name?(registry, name)
-  end
-end
-
-private def with_project_root(&)
-  root = File.tempname("gori-projroot")
-  begin
-    yield Gori::ProjectRegistry.new(root)
-  ensure
-    FileUtils.rm_rf(root)
-  end
-end
-
-private def seed_project_flow(store) : Int64
-  store.insert_flow(Gori::Store::CapturedRequest.new(
-    created_at: 1_i64, scheme: "https", host: "ex.test", port: 443,
-    method: "GET", target: "/", http_version: "HTTP/1.1",
-    head: "GET / HTTP/1.1\r\nHost: ex.test\r\n\r\n".to_slice, body: nil))
-end
-
-# One handle, closed exactly once — Store#close is NOT idempotent (a 2nd @done.receive
-# blocks forever), so each open gets its own short block instead of a close-then-flag.
-private def with_project_store(project : Gori::Project, &)
-  store = Gori::Store.open(project.db_path)
-  begin
-    yield store
-  ensure
-    store.close
-  end
-end
-
-describe "gori run project create" do
-  it "reports created-vs-reopened from the registry, not from a name lookup" do
-    with_project_root do |registry|
-      project, created = registry.create_or_reopen("spec proj")
-      created.should be_true
-      # A name that is a PREFIX of the first project's short id: #find would resolve it to
-      # that project and call this brand-new one a reopen.
-      id = registry.id_of(project).not_nil!
-      other, other_created = registry.create_or_reopen(id[0, 4])
-      other_created.should be_true
-      other.dir.should_not eq(project.dir)
-
-      registry.create_or_reopen("spec proj")[1].should be_false # same name → reopen
-    end
-  end
-
-  it "materializes the DB so a description-less project is immediately listed" do
-    with_project_root do |registry|
-      # #list skips a directory with no DB; a lazily-created one would stay invisible to
-      # `project list` / --project until something captured into it.
-      project = registry.create("spec proj")
-      File.exists?(project.db_path).should be_true
-      registry.list.map(&.name).should eq(["spec proj"])
-    end
-  end
-
-  it "leaves an existing DB untouched when create reopens the project" do
-    with_project_root do |registry|
-      project = registry.create("spec proj")
-      with_project_store(project) { |store| seed_project_flow(store) }
-      registry.create("spec proj") # reopen path: must not recreate the DB
-      with_project_store(project, &.count.should(eq(1)))
-    end
-  end
-end
-
-describe "gori run project delete (preview)" do
-  it "counts the flows and issues that deleting would destroy" do
-    with_project_root do |registry|
-      project = registry.create("spec proj")
-      with_project_store(project) do |store|
-        2.times { seed_project_flow(store) }
-        store.insert_issue("finding", Gori::Store::Severity::Low, "ex.test", nil)
-      end
-      Gori::CLI::Run.project_object_counts_for_spec(project).should eq({2_i64, 1})
-      # The whole directory is what rm_rf takes, so the preview sizes it (DB + WAL/SHM +
-      # sidecars), never just the DB file.
-      project.disk_size.should be > project.db_size
-    end
-  end
-
-  it "reports nil counts for a project whose DB was deleted under it" do
-    with_project_root do |registry|
-      project = registry.create("empty proj")
-      File.delete(project.db_path)
-      Gori::CLI::Run.project_object_counts_for_spec(project).should eq({nil, nil})
-      project.disk_size.should be > 0 # the .name/.id sidecars still go with the directory
-    end
-  end
-
-  it "sizes a directory whose path contains glob metacharacters" do
-    root = File.tempname("gori-proj[root]") # `[...]` is a glob character class
-    begin
-      project = Gori::ProjectRegistry.new(root).create("globby")
-      project.disk_size.should be > 0
-    ensure
-      FileUtils.rm_rf(root)
-    end
-  end
-end
-
-describe "gori run project delete (resolution)" do
-  it "refuses a display name shared by two projects, and accepts either slug" do
-    root = File.tempname("gori-projroot")
-    begin
-      registry = Gori::ProjectRegistry.new(root)
-      # What create_for_workspace produces for two checkouts with the same basename:
-      # distinct slugs (my-api, my-api-2), one shared display name.
-      registry.create("My API")
-      twin = File.join(root, "my-api-2")
-      Dir.mkdir_p(twin)
-      File.write(File.join(twin, Gori::ProjectRegistry::NAME_FILE), "My API")
-      Gori::Store.open(File.join(twin, Gori::Project::DB_FILE)).close
-
-      registry.list.count { |p| p.name == "My API" }.should eq(2)
-      Gori::CLI::Run.ambiguous_project_name_for_spec(registry, "My API").should be_true
-      Gori::CLI::Run.ambiguous_project_name_for_spec(registry, "my api").should be_true # find is case-insensitive
-      # Slugs are unique, and #find resolves them before the display-name pass.
-      Gori::CLI::Run.ambiguous_project_name_for_spec(registry, "my-api").should be_false
-      Gori::CLI::Run.ambiguous_project_name_for_spec(registry, "my-api-2").should be_false
-    ensure
-      FileUtils.rm_rf(root)
-    end
-  end
-
-  it "does not call a uniquely-named project ambiguous" do
-    with_project_root do |registry|
-      registry.create("alpha")
-      registry.create("beta")
-      Gori::CLI::Run.ambiguous_project_name_for_spec(registry, "alpha").should be_false
     end
   end
 end

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -1,83 +1,190 @@
 require "../../src/gori"
 
-# A no-op ExecContext for exercising registry/palette logic in specs.
+# A RECORDING ExecContext for exercising registry/palette logic and the verb bodies
+# themselves. Every command method (the Nil-returning "do something" half of the
+# interface) appends a Call instead of doing work, so a spec can assert exactly which
+# intent a verb dispatched — and in what order, which matters for the verbs that chain
+# two calls (detail.repeater closes the detail BEFORE opening the Repeater). The query
+# half (selected_flow_id, *_read_mode?, *_count …) stays settable state, since verbs
+# read it through `available?` gates rather than driving it.
 class FakeExecContext < Gori::Verb::ExecContext
+  # One recorded dispatch: the ExecContext method plus its stringified arguments
+  # (Symbol/Int32 both render usefully, and a String comparison keeps assertions terse).
+  record Call, name : Symbol, args : Array(String)
+
+  getter calls = [] of Call
+
   property selected : Int64? = nil
   property current_tab : Symbol = :history # settable so tab-gated verbs (Decoder, …) can be exercised
 
-  def quit! : Nil; end
+  # The recorded method names in dispatch order — the usual assertion target.
+  def call_names : Array(Symbol)
+    @calls.map(&.name)
+  end
 
-  def leave_project : Nil; end
+  # Arguments of the one recorded call named `name`, or nil when it never fired. RAISES
+  # when the intent fired more than once: returning the first match would let a handler
+  # that dispatched the same intent twice with different arguments (focus_pane(:menu)
+  # then focus_pane(:subtabs)) hide behind the one the spec happened to expect.
+  def args_for(name : Symbol) : Array(String)?
+    found = @calls.select { |c| c.name == name }
+    if found.size > 1
+      raise "#{name} was dispatched #{found.size} times (#{found.map(&.args).inspect}); assert on #calls instead"
+    end
+    found.first?.try(&.args)
+  end
 
-  def status(message : String) : Nil; end
+  private def rec(name : Symbol) : Nil
+    @calls << Call.new(name, [] of String)
+  end
 
-  def open_palette : Nil; end
+  private def rec(name : Symbol, *args) : Nil
+    @calls << Call.new(name, args.map(&.to_s).to_a)
+  end
 
-  def open_notifications : Nil; end
+  def quit! : Nil
+    rec(:quit!)
+  end
 
-  def close_overlay : Nil; end
+  def leave_project : Nil
+    rec(:leave_project)
+  end
 
-  def refresh_screen : Nil; end
+  def status(message : String) : Nil
+    rec(:status, message)
+  end
 
-  def focus_pane(pane : Symbol) : Nil; end
+  def open_palette : Nil
+    rec(:open_palette)
+  end
 
-  def enter_content : Nil; end
+  def open_notifications : Nil
+    rec(:open_notifications)
+  end
 
-  def focus_tab(tab : Symbol) : Nil; end
+  def close_overlay : Nil
+    rec(:close_overlay)
+  end
 
-  def focus_visible_tab(n : Int32) : Nil; end
+  def refresh_screen : Nil
+    rec(:refresh_screen)
+  end
 
-  def cycle_tab(delta : Int32) : Nil; end
+  def focus_pane(pane : Symbol) : Nil
+    rec(:focus_pane, pane)
+  end
 
-  def menu_left : Nil; end
+  def enter_content : Nil
+    rec(:enter_content)
+  end
 
-  def menu_right : Nil; end
+  def focus_tab(tab : Symbol) : Nil
+    rec(:focus_tab, tab)
+  end
 
-  def move_selection(delta : Int32) : Nil; end
+  def focus_visible_tab(n : Int32) : Nil
+    rec(:focus_visible_tab, n)
+  end
 
-  def open_detail : Nil; end
+  def cycle_tab(delta : Int32) : Nil
+    rec(:cycle_tab, delta)
+  end
 
-  def close_detail : Nil; end
+  def menu_left : Nil
+    rec(:menu_left)
+  end
 
-  def toggle_follow : Nil; end
+  def menu_right : Nil
+    rec(:menu_right)
+  end
+
+  def move_selection(delta : Int32) : Nil
+    rec(:move_selection, delta)
+  end
+
+  def open_detail : Nil
+    rec(:open_detail)
+  end
+
+  def close_detail : Nil
+    rec(:close_detail)
+  end
+
+  def toggle_follow : Nil
+    rec(:toggle_follow)
+  end
 
   def selected_flow_id : Int64?
     @selected
   end
 
-  def copy_selection : Nil; end
+  def copy_selection : Nil
+    rec(:copy_selection)
+  end
 
-  def history_query : Nil; end
+  def history_query : Nil
+    rec(:history_query)
+  end
 
-  def history_delete : Nil; end
+  def history_delete : Nil
+    rec(:history_delete)
+  end
 
-  def history_clear : Nil; end
+  def history_clear : Nil
+    rec(:history_clear)
+  end
 
-  def scroll_detail(delta : Int32) : Nil; end
+  def scroll_detail(delta : Int32) : Nil
+    rec(:scroll_detail, delta)
+  end
 
-  def detail_copy_selection : Nil; end
+  def detail_copy_selection : Nil
+    rec(:detail_copy_selection)
+  end
 
-  def hscroll_detail(delta : Int32) : Nil; end
+  def hscroll_detail(delta : Int32) : Nil
+    rec(:hscroll_detail, delta)
+  end
 
-  def toggle_detail_pane : Nil; end
+  def toggle_detail_pane : Nil
+    rec(:toggle_detail_pane)
+  end
 
-  def move_detail_pane(dir : Int32) : Nil; end
+  def move_detail_pane(dir : Int32) : Nil
+    rec(:move_detail_pane, dir)
+  end
 
-  def toggle_detail_hex : Nil; end
+  def toggle_detail_hex : Nil
+    rec(:toggle_detail_hex)
+  end
 
-  def toggle_reveal : Nil; end
+  def toggle_reveal : Nil
+    rec(:toggle_reveal)
+  end
 
-  def toggle_pretty : Nil; end
+  def toggle_pretty : Nil
+    rec(:toggle_pretty)
+  end
 
-  def repeater_selected : Nil; end
+  def repeater_selected : Nil
+    rec(:repeater_selected)
+  end
 
-  def repeater_new : Nil; end
+  def repeater_new : Nil
+    rec(:repeater_new)
+  end
 
-  def repeater_send : Nil; end
+  def repeater_send : Nil
+    rec(:repeater_send)
+  end
 
-  def repeater_send_group : Nil; end
+  def repeater_send_group : Nil
+    rec(:repeater_send_group)
+  end
 
-  def repeater_find_subtab : Nil; end
+  def repeater_find_subtab : Nil
+    rec(:repeater_find_subtab)
+  end
 
   property repeater_tab_count : Int32 = 0
 
@@ -85,9 +192,13 @@ class FakeExecContext < Gori::Verb::ExecContext
     @repeater_tab_count
   end
 
-  def subtab_search_open : Nil; end
+  def subtab_search_open : Nil
+    rec(:subtab_search_open)
+  end
 
-  def subtab_filter_open : Nil; end
+  def subtab_filter_open : Nil
+    rec(:subtab_filter_open)
+  end
 
   property subtab_search_tab_count : Int32 = 0
 
@@ -95,51 +206,97 @@ class FakeExecContext < Gori::Verb::ExecContext
     @subtab_search_tab_count
   end
 
-  def repeater_rename_subtab : Nil; end
+  def repeater_rename_subtab : Nil
+    rec(:repeater_rename_subtab)
+  end
 
-  def repeater_tag_subtab : Nil; end
+  def repeater_tag_subtab : Nil
+    rec(:repeater_tag_subtab)
+  end
 
-  def repeater_filter_subtabs : Nil; end
+  def repeater_filter_subtabs : Nil
+    rec(:repeater_filter_subtabs)
+  end
 
-  def repeater_close_subtab : Nil; end
+  def repeater_close_subtab : Nil
+    rec(:repeater_close_subtab)
+  end
 
-  def repeater_duplicate_subtab : Nil; end
+  def repeater_duplicate_subtab : Nil
+    rec(:repeater_duplicate_subtab)
+  end
 
-  def repeater_toggle_hex : Nil; end
+  def repeater_toggle_hex : Nil
+    rec(:repeater_toggle_hex)
+  end
 
-  def repeater_toggle_decoded : Nil; end
+  def repeater_toggle_decoded : Nil
+    rec(:repeater_toggle_decoded)
+  end
 
-  def repeater_toggle_sni : Nil; end
+  def repeater_toggle_sni : Nil
+    rec(:repeater_toggle_sni)
+  end
 
-  def repeater_toggle_auto_content_length : Nil; end
+  def repeater_toggle_auto_content_length : Nil
+    rec(:repeater_toggle_auto_content_length)
+  end
 
-  def repeater_toggle_http2 : Nil; end
+  def repeater_toggle_http2 : Nil
+    rec(:repeater_toggle_http2)
+  end
 
-  def repeater_toggle_resp_diff : Nil; end
+  def repeater_toggle_resp_diff : Nil
+    rec(:repeater_toggle_resp_diff)
+  end
 
-  def repeater_toggle_resp_hex : Nil; end
+  def repeater_toggle_resp_hex : Nil
+    rec(:repeater_toggle_resp_hex)
+  end
 
-  def repeater_pretty_request : Nil; end
+  def repeater_pretty_request : Nil
+    rec(:repeater_pretty_request)
+  end
 
-  def repeater_minimize : Nil; end
+  def repeater_minimize : Nil
+    rec(:repeater_minimize)
+  end
 
-  def fuzz_pretty_template : Nil; end
+  def fuzz_pretty_template : Nil
+    rec(:fuzz_pretty_template)
+  end
 
-  def fuzz_toggle_http2 : Nil; end
+  def fuzz_toggle_http2 : Nil
+    rec(:fuzz_toggle_http2)
+  end
 
-  def repeater_auto_mark : Nil; end
+  def repeater_auto_mark : Nil
+    rec(:repeater_auto_mark)
+  end
 
-  def repeater_mark_word : Nil; end
+  def repeater_mark_word : Nil
+    rec(:repeater_mark_word)
+  end
 
-  def repeater_insert_marker : Nil; end
+  def repeater_insert_marker : Nil
+    rec(:repeater_insert_marker)
+  end
 
-  def repeater_clear_marks : Nil; end
+  def repeater_clear_marks : Nil
+    rec(:repeater_clear_marks)
+  end
 
-  def repeater_attach_chain : Nil; end
+  def repeater_attach_chain : Nil
+    rec(:repeater_attach_chain)
+  end
 
-  def repeater_copy : Nil; end
+  def repeater_copy : Nil
+    rec(:repeater_copy)
+  end
 
-  def repeater_copy_all : Nil; end
+  def repeater_copy_all : Nil
+    rec(:repeater_copy_all)
+  end
 
   property repeater_read_mode : Bool = false # settable so grouped-menu specs can exercise the read-mode verbs
 
@@ -147,59 +304,108 @@ class FakeExecContext < Gori::Verb::ExecContext
     @repeater_read_mode
   end
 
-  def fuzz_selected : Nil; end
-
-  def fuzz_from_repeater : Nil; end
-
-  def fuzz_run : Nil; end
-
-  def fuzz_stop : Nil; end
-
-  def fuzz_new : Nil; end
-
-  def fuzz_automark : Nil; end
-
-  def fuzz_attach_chain : Nil; end
-
-  def fuzz_list_paste : Nil; end
-
-  def fuzz_clear_marks : Nil; end
-
-  def fuzzer_rename_subtab : Nil; end
-
-  def fuzzer_close_subtab : Nil; end
-
-  def fuzzer_duplicate_subtab : Nil; end
-
-  def fuzzer_copy : Nil; end
-
-  def fuzzer_copy_all : Nil; end
-
-  def fuzzer_read_mode? : Bool
-    false
+  def fuzz_selected : Nil
+    rec(:fuzz_selected)
   end
 
-  def mine_selected : Nil; end
+  def fuzz_from_repeater : Nil
+    rec(:fuzz_from_repeater)
+  end
 
-  def mine_from_repeater : Nil; end
+  def fuzz_run : Nil
+    rec(:fuzz_run)
+  end
 
-  def mine_run : Nil; end
+  def fuzz_stop : Nil
+    rec(:fuzz_stop)
+  end
 
-  def mine_stop : Nil; end
+  def fuzz_new : Nil
+    rec(:fuzz_new)
+  end
 
-  def sequence_selected : Nil; end
+  def fuzz_automark : Nil
+    rec(:fuzz_automark)
+  end
 
-  def sequence_from_repeater : Nil; end
+  def fuzz_attach_chain : Nil
+    rec(:fuzz_attach_chain)
+  end
 
-  def sequence_from_sitemap : Nil; end
+  def fuzz_list_paste : Nil
+    rec(:fuzz_list_paste)
+  end
 
-  def sequence_run : Nil; end
+  def fuzz_clear_marks : Nil
+    rec(:fuzz_clear_marks)
+  end
 
-  def sequence_stop : Nil; end
+  def fuzzer_rename_subtab : Nil
+    rec(:fuzzer_rename_subtab)
+  end
 
-  def sequence_configure : Nil; end
+  def fuzzer_close_subtab : Nil
+    rec(:fuzzer_close_subtab)
+  end
 
-  def miner_duplicate_subtab : Nil; end
+  def fuzzer_duplicate_subtab : Nil
+    rec(:fuzzer_duplicate_subtab)
+  end
+
+  def fuzzer_copy : Nil
+    rec(:fuzzer_copy)
+  end
+
+  def fuzzer_copy_all : Nil
+    rec(:fuzzer_copy_all)
+  end
+
+  # Settable so the read-mode-gated Fuzzer verbs can be exercised.
+  property? fuzzer_read_mode : Bool = false
+
+  def mine_selected : Nil
+    rec(:mine_selected)
+  end
+
+  def mine_from_repeater : Nil
+    rec(:mine_from_repeater)
+  end
+
+  def mine_run : Nil
+    rec(:mine_run)
+  end
+
+  def mine_stop : Nil
+    rec(:mine_stop)
+  end
+
+  def sequence_selected : Nil
+    rec(:sequence_selected)
+  end
+
+  def sequence_from_repeater : Nil
+    rec(:sequence_from_repeater)
+  end
+
+  def sequence_from_sitemap : Nil
+    rec(:sequence_from_sitemap)
+  end
+
+  def sequence_run : Nil
+    rec(:sequence_run)
+  end
+
+  def sequence_stop : Nil
+    rec(:sequence_stop)
+  end
+
+  def sequence_configure : Nil
+    rec(:sequence_configure)
+  end
+
+  def miner_duplicate_subtab : Nil
+    rec(:miner_duplicate_subtab)
+  end
 
   property? miner_has_issue = false
 
@@ -207,75 +413,138 @@ class FakeExecContext < Gori::Verb::ExecContext
     @miner_has_issue
   end
 
-  def mine_repeater_selected : Nil; end
-
-  def sitemap_move(delta : Int32) : Nil; end
-
-  def sitemap_toggle : Nil; end
-
-  def sitemap_expand : Nil; end
-
-  def sitemap_collapse : Nil; end
-
-  def sitemap_query : Nil; end
-
-  def sitemap_tag : Nil; end
-
-  def sitemap_toggle_grouping : Nil; end
-
-  def sitemap_discover : Nil; end
-
-  def sitemap_repeater : Nil; end
-
-  def history_discover : Nil; end
-
-  def discover_run : Nil; end
-
-  def discover_stop : Nil; end
-
-  def discover_toggle_pause : Nil; end
-
-  def goto_discover : Nil; end
-
-  def oast_listen : Nil; end
-
-  def oast_stop : Nil; end
-
-  def oast_generate : Nil; end
-
-  def oast_copy : Nil; end
-
-  def oast_filter : Nil; end
-
-  def oast_add_provider : Nil; end
-
-  def oast_edit_provider : Nil; end
-
-  def oast_toggle_provider : Nil; end
-
-  def oast_delete_provider : Nil; end
-
-  def oast_payload_available? : Bool
-    false
+  def mine_repeater_selected : Nil
+    rec(:mine_repeater_selected)
   end
 
-  def oast_insert_payload : Nil; end
+  def sitemap_move(delta : Int32) : Nil
+    rec(:sitemap_move, delta)
+  end
 
-  def oast_copy_payload : Nil; end
+  def sitemap_toggle : Nil
+    rec(:sitemap_toggle)
+  end
 
-  def scope_open : Nil; end
+  def sitemap_expand : Nil
+    rec(:sitemap_expand)
+  end
 
-  def scope_add_host : Nil; end
+  def sitemap_collapse : Nil
+    rec(:sitemap_collapse)
+  end
 
-  def scope_toggle_lens : Nil; end
+  def sitemap_query : Nil
+    rec(:sitemap_query)
+  end
+
+  def sitemap_tag : Nil
+    rec(:sitemap_tag)
+  end
+
+  def sitemap_toggle_grouping : Nil
+    rec(:sitemap_toggle_grouping)
+  end
+
+  def sitemap_discover : Nil
+    rec(:sitemap_discover)
+  end
+
+  def sitemap_repeater : Nil
+    rec(:sitemap_repeater)
+  end
+
+  def history_discover : Nil
+    rec(:history_discover)
+  end
+
+  def discover_run : Nil
+    rec(:discover_run)
+  end
+
+  def discover_stop : Nil
+    rec(:discover_stop)
+  end
+
+  def discover_toggle_pause : Nil
+    rec(:discover_toggle_pause)
+  end
+
+  def goto_discover : Nil
+    rec(:goto_discover)
+  end
+
+  def oast_listen : Nil
+    rec(:oast_listen)
+  end
+
+  def oast_stop : Nil
+    rec(:oast_stop)
+  end
+
+  def oast_generate : Nil
+    rec(:oast_generate)
+  end
+
+  def oast_copy : Nil
+    rec(:oast_copy)
+  end
+
+  def oast_filter : Nil
+    rec(:oast_filter)
+  end
+
+  def oast_add_provider : Nil
+    rec(:oast_add_provider)
+  end
+
+  def oast_edit_provider : Nil
+    rec(:oast_edit_provider)
+  end
+
+  def oast_toggle_provider : Nil
+    rec(:oast_toggle_provider)
+  end
+
+  def oast_delete_provider : Nil
+    rec(:oast_delete_provider)
+  end
+
+  # Settable so the listener-gated OAST insert verbs can be exercised.
+  property? oast_payload_available : Bool = false
+
+  def oast_insert_payload : Nil
+    rec(:oast_insert_payload)
+  end
+
+  def oast_copy_payload : Nil
+    rec(:oast_copy_payload)
+  end
+
+  def scope_open : Nil
+    rec(:scope_open)
+  end
+
+  def scope_add_host : Nil
+    rec(:scope_add_host)
+  end
+
+  def scope_toggle_lens : Nil
+    rec(:scope_toggle_lens)
+  end
 
   property scope_has_rule : Bool = false
 
-  def scope_add_rule : Nil; end
+  def scope_add_rule : Nil
+    rec(:scope_add_rule)
+  end
 
-  def scope_edit_rule : Nil; end
+  def scope_edit_rule : Nil
+    rec(:scope_edit_rule)
+  end
 
-  def scope_delete_rule : Nil; end
+  def scope_delete_rule : Nil
+    rec(:scope_delete_rule)
+  end
 
   def scope_rule_selected? : Bool
     @scope_has_rule
@@ -283,13 +552,21 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   property probe_has_custom_rule : Bool = false
 
-  def probe_rule_toggle : Nil; end
+  def probe_rule_toggle : Nil
+    rec(:probe_rule_toggle)
+  end
 
-  def probe_rule_add : Nil; end
+  def probe_rule_add : Nil
+    rec(:probe_rule_add)
+  end
 
-  def probe_rule_edit : Nil; end
+  def probe_rule_edit : Nil
+    rec(:probe_rule_edit)
+  end
 
-  def probe_rule_delete : Nil; end
+  def probe_rule_delete : Nil
+    rec(:probe_rule_delete)
+  end
 
   def probe_custom_rule_selected? : Bool
     @probe_has_custom_rule
@@ -297,11 +574,17 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   property hostov_has_entry : Bool = false
 
-  def hostov_add_entry : Nil; end
+  def hostov_add_entry : Nil
+    rec(:hostov_add_entry)
+  end
 
-  def hostov_edit_entry : Nil; end
+  def hostov_edit_entry : Nil
+    rec(:hostov_edit_entry)
+  end
 
-  def hostov_delete_entry : Nil; end
+  def hostov_delete_entry : Nil
+    rec(:hostov_delete_entry)
+  end
 
   def hostov_entry_selected? : Bool
     @hostov_has_entry
@@ -309,143 +592,275 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   property env_has_var : Bool = false
 
-  def env_add_var : Nil; end
+  def env_add_var : Nil
+    rec(:env_add_var)
+  end
 
-  def env_edit_var : Nil; end
+  def env_edit_var : Nil
+    rec(:env_edit_var)
+  end
 
-  def env_delete_var : Nil; end
+  def env_delete_var : Nil
+    rec(:env_delete_var)
+  end
 
-  def env_edit_prefix : Nil; end
+  def env_edit_prefix : Nil
+    rec(:env_edit_prefix)
+  end
 
   def env_var_selected? : Bool
     @env_has_var
   end
 
-  def issue_create : Nil; end
-
-  def issues_new : Nil; end
-
-  def issues_query : Nil; end
-
-  def issues_move(delta : Int32) : Nil; end
-
-  def issues_open : Nil; end
-
-  def issue_close : Nil; end
-
-  def issues_delete : Nil; end
-
-  def issue_severity(delta : Int32) : Nil; end
-
-  def issue_status(delta : Int32) : Nil; end
-
-  def issue_set_severity : Nil; end
-
-  def issue_set_status : Nil; end
-
-  def issue_edit_notes : Nil; end
-
-  def issue_hscroll(delta : Int32) : Nil; end
-
-  def issue_edit_title : Nil; end
-
-  def issue_open_flow : Nil; end
-
-  def issue_repeater_flow : Nil; end
-
-  def issues_export(format : Symbol) : Nil; end
-
-  def probe_move(delta : Int32) : Nil; end
-
-  def probe_open : Nil; end
-
-  def probe_close : Nil; end
-
-  def probe_query : Nil; end
-
-  def probe_set_mode : Nil; end
-
-  def probe_clear : Nil; end
-
-  def probe_delete : Nil; end
-
-  def probe_dismiss : Nil; end
-
-  def probe_toggle_closed : Nil; end
-
-  def probe_dismiss_code : Nil; end
-
-  def probe_dismiss_host : Nil; end
-
-  def probe_open_flow : Nil; end
-
-  def probe_repeater_flow : Nil; end
-
-  def probe_promote : Nil; end
-
-  def probe_active_selected : Nil; end
-
-  def probe_active_rescan : Nil; end
-
-  def probe_active_from_repeater : Nil; end
-
-  def toggle_capture : Nil; end
-
-  def intercept_toggle : Nil; end
-
-  def intercept_forward : Nil; end
-
-  def intercept_drop : Nil; end
-
-  def intercept_forward_all : Nil; end
-
-  def intercept_query : Nil; end
-
-  def intercept_cycle_direction : Nil; end
-
-  def selected_intercept_id : Int64?
-    nil
+  def issue_create : Nil
+    rec(:issue_create)
   end
 
-  def export_ca : Nil; end
+  def issues_new : Nil
+    rec(:issues_new)
+  end
 
-  def regenerate_ca : Nil; end
+  def issues_query : Nil
+    rec(:issues_query)
+  end
 
-  def import_ca : Nil; end
+  def issues_move(delta : Int32) : Nil
+    rec(:issues_move, delta)
+  end
 
-  def open_browser_picker : Nil; end
+  def issues_open : Nil
+    rec(:issues_open)
+  end
 
-  def comparer_pick(slot : Symbol) : Nil; end
+  def issue_close : Nil
+    rec(:issue_close)
+  end
 
-  def comparer_swap : Nil; end
+  def issues_delete : Nil
+    rec(:issues_delete)
+  end
 
-  def comparer_toggle_pane : Nil; end
+  def issue_severity(delta : Int32) : Nil
+    rec(:issue_severity, delta)
+  end
 
-  def comparer_add_selected : Nil; end
+  def issue_status(delta : Int32) : Nil
+    rec(:issue_status, delta)
+  end
 
-  def comparer_new : Nil; end
+  def issue_set_severity : Nil
+    rec(:issue_set_severity)
+  end
 
-  def comparer_close_subtab : Nil; end
+  def issue_set_status : Nil
+    rec(:issue_set_status)
+  end
 
-  def comparer_rename_subtab : Nil; end
+  def issue_edit_notes : Nil
+    rec(:issue_edit_notes)
+  end
 
-  def comparer_duplicate_subtab : Nil; end
+  def issue_hscroll(delta : Int32) : Nil
+    rec(:issue_hscroll, delta)
+  end
 
-  def decoder_new : Nil; end
+  def issue_edit_title : Nil
+    rec(:issue_edit_title)
+  end
 
-  def decoder_close : Nil; end
+  def issue_open_flow : Nil
+    rec(:issue_open_flow)
+  end
 
-  def decoder_rename_subtab : Nil; end
+  def issue_repeater_flow : Nil
+    rec(:issue_repeater_flow)
+  end
 
-  def decoder_duplicate_subtab : Nil; end
+  def issues_export(format : Symbol) : Nil
+    rec(:issues_export, format)
+  end
 
-  def decoder_clear : Nil; end
+  def probe_move(delta : Int32) : Nil
+    rec(:probe_move, delta)
+  end
 
-  def decoder_copy : Nil; end
+  def probe_open : Nil
+    rec(:probe_open)
+  end
 
-  def decoder_copy_selection : Nil; end
+  def probe_close : Nil
+    rec(:probe_close)
+  end
 
-  def decoder_copy_all : Nil; end
+  def probe_query : Nil
+    rec(:probe_query)
+  end
+
+  def probe_set_mode : Nil
+    rec(:probe_set_mode)
+  end
+
+  def probe_clear : Nil
+    rec(:probe_clear)
+  end
+
+  def probe_delete : Nil
+    rec(:probe_delete)
+  end
+
+  def probe_dismiss : Nil
+    rec(:probe_dismiss)
+  end
+
+  def probe_toggle_closed : Nil
+    rec(:probe_toggle_closed)
+  end
+
+  def probe_dismiss_code : Nil
+    rec(:probe_dismiss_code)
+  end
+
+  def probe_dismiss_host : Nil
+    rec(:probe_dismiss_host)
+  end
+
+  def probe_open_flow : Nil
+    rec(:probe_open_flow)
+  end
+
+  def probe_repeater_flow : Nil
+    rec(:probe_repeater_flow)
+  end
+
+  def probe_promote : Nil
+    rec(:probe_promote)
+  end
+
+  def probe_active_selected : Nil
+    rec(:probe_active_selected)
+  end
+
+  def probe_active_rescan : Nil
+    rec(:probe_active_rescan)
+  end
+
+  def probe_active_from_repeater : Nil
+    rec(:probe_active_from_repeater)
+  end
+
+  def toggle_capture : Nil
+    rec(:toggle_capture)
+  end
+
+  def intercept_toggle : Nil
+    rec(:intercept_toggle)
+  end
+
+  def intercept_forward : Nil
+    rec(:intercept_forward)
+  end
+
+  def intercept_drop : Nil
+    rec(:intercept_drop)
+  end
+
+  def intercept_forward_all : Nil
+    rec(:intercept_forward_all)
+  end
+
+  def intercept_query : Nil
+    rec(:intercept_query)
+  end
+
+  def intercept_cycle_direction : Nil
+    rec(:intercept_cycle_direction)
+  end
+
+  property intercept_selected : Int64? = nil # settable so the held-message-gated verbs can be exercised
+
+  def selected_intercept_id : Int64?
+    @intercept_selected
+  end
+
+  def export_ca : Nil
+    rec(:export_ca)
+  end
+
+  def regenerate_ca : Nil
+    rec(:regenerate_ca)
+  end
+
+  def import_ca : Nil
+    rec(:import_ca)
+  end
+
+  def open_browser_picker : Nil
+    rec(:open_browser_picker)
+  end
+
+  def comparer_pick(slot : Symbol) : Nil
+    rec(:comparer_pick, slot)
+  end
+
+  def comparer_swap : Nil
+    rec(:comparer_swap)
+  end
+
+  def comparer_toggle_pane : Nil
+    rec(:comparer_toggle_pane)
+  end
+
+  def comparer_add_selected : Nil
+    rec(:comparer_add_selected)
+  end
+
+  def comparer_new : Nil
+    rec(:comparer_new)
+  end
+
+  def comparer_close_subtab : Nil
+    rec(:comparer_close_subtab)
+  end
+
+  def comparer_rename_subtab : Nil
+    rec(:comparer_rename_subtab)
+  end
+
+  def comparer_duplicate_subtab : Nil
+    rec(:comparer_duplicate_subtab)
+  end
+
+  def decoder_new : Nil
+    rec(:decoder_new)
+  end
+
+  def decoder_close : Nil
+    rec(:decoder_close)
+  end
+
+  def decoder_rename_subtab : Nil
+    rec(:decoder_rename_subtab)
+  end
+
+  def decoder_duplicate_subtab : Nil
+    rec(:decoder_duplicate_subtab)
+  end
+
+  def decoder_clear : Nil
+    rec(:decoder_clear)
+  end
+
+  def decoder_copy : Nil
+    rec(:decoder_copy)
+  end
+
+  def decoder_copy_selection : Nil
+    rec(:decoder_copy_selection)
+  end
+
+  def decoder_copy_all : Nil
+    rec(:decoder_copy_all)
+  end
 
   property decoder_read_mode : Bool = false # settable so grouped-menu specs can exercise COMMON's Copy
 
@@ -453,35 +868,65 @@ class FakeExecContext < Gori::Verb::ExecContext
     @decoder_read_mode
   end
 
-  def decoder_cycle_mode : Nil; end
+  def decoder_cycle_mode : Nil
+    rec(:decoder_cycle_mode)
+  end
 
-  def decoder_save : Nil; end
+  def decoder_save : Nil
+    rec(:decoder_save)
+  end
 
-  def decoder_load : Nil; end
+  def decoder_load : Nil
+    rec(:decoder_load)
+  end
 
-  def jwt_new : Nil; end
+  def jwt_new : Nil
+    rec(:jwt_new)
+  end
 
-  def jwt_close : Nil; end
+  def jwt_close : Nil
+    rec(:jwt_close)
+  end
 
-  def jwt_rename_subtab : Nil; end
+  def jwt_rename_subtab : Nil
+    rec(:jwt_rename_subtab)
+  end
 
-  def jwt_duplicate_subtab : Nil; end
+  def jwt_duplicate_subtab : Nil
+    rec(:jwt_duplicate_subtab)
+  end
 
-  def jwt_clear : Nil; end
+  def jwt_clear : Nil
+    rec(:jwt_clear)
+  end
 
-  def jwt_toggle_mode : Nil; end
+  def jwt_toggle_mode : Nil
+    rec(:jwt_toggle_mode)
+  end
 
-  def jwt_cycle_alg : Nil; end
+  def jwt_cycle_alg : Nil
+    rec(:jwt_cycle_alg)
+  end
 
-  def jwt_load_decoded : Nil; end
+  def jwt_load_decoded : Nil
+    rec(:jwt_load_decoded)
+  end
 
-  def jwt_copy : Nil; end
+  def jwt_copy : Nil
+    rec(:jwt_copy)
+  end
 
-  def jwt_copy_all : Nil; end
+  def jwt_copy_all : Nil
+    rec(:jwt_copy_all)
+  end
 
-  def jwt_copy_token : Nil; end
+  def jwt_copy_token : Nil
+    rec(:jwt_copy_token)
+  end
 
-  def jwt_copy_attack : Nil; end
+  def jwt_copy_attack : Nil
+    rec(:jwt_copy_attack)
+  end
 
   property jwt_read_mode : Bool = false # settable so grouped-menu specs can exercise COMMON's Copy
 
@@ -491,55 +936,91 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   property rewriter_rule_selected : Bool = false # settable so the has-rule gate can be exercised
 
-  def rewriter_add : Nil; end
+  def rewriter_add : Nil
+    rec(:rewriter_add)
+  end
 
-  def rewriter_edit : Nil; end
+  def rewriter_edit : Nil
+    rec(:rewriter_edit)
+  end
 
-  def rewriter_toggle : Nil; end
+  def rewriter_toggle : Nil
+    rec(:rewriter_toggle)
+  end
 
-  def rewriter_delete : Nil; end
+  def rewriter_delete : Nil
+    rec(:rewriter_delete)
+  end
 
-  def rewriter_move(dir : Int32) : Nil; end
+  def rewriter_move(dir : Int32) : Nil
+    rec(:rewriter_move, dir)
+  end
 
-  def rewriter_duplicate : Nil; end
+  def rewriter_duplicate : Nil
+    rec(:rewriter_duplicate)
+  end
 
-  def rewriter_reload : Nil; end
+  def rewriter_reload : Nil
+    rec(:rewriter_reload)
+  end
 
   def rewriter_rule_selected? : Bool
     @rewriter_rule_selected
   end
 
-  def notes_new : Nil; end
-
-  def notes_close : Nil; end
-
-  def notes_duplicate_subtab : Nil; end
-
-  def notes_copy : Nil; end
-
-  def notes_copy_all : Nil; end
-
-  def notes_read_mode? : Bool
-    true
+  def notes_new : Nil
+    rec(:notes_new)
   end
 
-  def notes_clear : Nil; end
-
-  def notes_edit : Nil; end
-
-  def notes_goto : Nil; end
-
-  def notes_find : Nil; end
-
-  def notes_links : Nil; end
-
-  def project_desc_read_mode? : Bool
-    false
+  def notes_close : Nil
+    rec(:notes_close)
   end
 
-  def project_copy : Nil; end
+  def notes_duplicate_subtab : Nil
+    rec(:notes_duplicate_subtab)
+  end
 
-  def project_copy_all : Nil; end
+  def notes_copy : Nil
+    rec(:notes_copy)
+  end
+
+  def notes_copy_all : Nil
+    rec(:notes_copy_all)
+  end
+
+  # Settable; defaults ON — the Notes body opens in read mode.
+  property? notes_read_mode : Bool = true
+
+  def notes_clear : Nil
+    rec(:notes_clear)
+  end
+
+  def notes_edit : Nil
+    rec(:notes_edit)
+  end
+
+  def notes_goto : Nil
+    rec(:notes_goto)
+  end
+
+  def notes_find : Nil
+    rec(:notes_find)
+  end
+
+  def notes_links : Nil
+    rec(:notes_links)
+  end
+
+  # Settable so project.copy / project.select-line can be exercised.
+  property? project_desc_read_mode : Bool = false
+
+  def project_copy : Nil
+    rec(:project_copy)
+  end
+
+  def project_copy_all : Nil
+    rec(:project_copy_all)
+  end
 
   property selection_active : Bool = false # settable so selection-gated verbs (send-to, clear-selection) can be exercised
 
@@ -547,18 +1028,27 @@ class FakeExecContext < Gori::Verb::ExecContext
     selection_active
   end
 
-  def read_select_line : Nil; end
+  def read_select_line : Nil
+    rec(:read_select_line)
+  end
 
-  def read_clear_selection : Nil; end
+  def read_clear_selection : Nil
+    rec(:read_clear_selection)
+  end
 
-  def read_copy : Nil; end
+  def read_copy : Nil
+    rec(:read_copy)
+  end
 
-  def copy_as_open : Nil; end
+  def copy_as_open : Nil
+    rec(:copy_as_open)
+  end
 
   getter send_to_opened : Bool = false
 
   def send_to_open : Nil
     @send_to_opened = true
+    rec(:send_to_open)
   end
 
   property detail_navigable : Bool = false # settable so grouped-menu specs can exercise detail.select-line
@@ -571,47 +1061,86 @@ class FakeExecContext < Gori::Verb::ExecContext
     nil
   end
 
-  def issue_links : Nil; end
-
-  def issue_open_link : Nil; end
-
-  def issue_link_move(delta : Int32) : Nil; end
-
-  def issues_notes_read_mode? : Bool
-    false
+  def issue_links : Nil
+    rec(:issue_links)
   end
 
-  def issues_copy : Nil; end
+  def issue_open_link : Nil
+    rec(:issue_open_link)
+  end
 
-  def issues_copy_all : Nil; end
+  def issue_link_move(delta : Int32) : Nil
+    rec(:issue_link_move, delta)
+  end
 
-  def link_to_issue : Nil; end
+  # Settable so the issue-notes read verbs can be exercised.
+  property? issues_notes_read_mode : Bool = false
 
-  def link_to_note : Nil; end
+  def issues_copy : Nil
+    rec(:issues_copy)
+  end
+
+  def issues_copy_all : Nil
+    rec(:issues_copy_all)
+  end
+
+  def link_to_issue : Nil
+    rec(:link_to_issue)
+  end
+
+  def link_to_note : Nil
+    rec(:link_to_note)
+  end
+
+  # The four linkable-entity ids, settable so both sides of the link.* gates can be
+  # exercised (a verb is offered only once the entity has a persisted row to point at).
+  property link_flow : Int64? = nil
+  property link_repeater : Int64? = nil
+  property link_fuzz : Int64? = nil
+  property link_miner : Int64? = nil
 
   def link_flow_id : Int64?
-    nil
+    @link_flow
   end
 
   def link_repeater_id : Int64?
-    nil
+    @link_repeater
   end
 
   def link_fuzz_id : Int64?
-    nil
+    @link_fuzz
   end
 
   def link_miner_id : Int64?
-    nil
+    @link_miner
   end
 
-  def open_settings(section : Symbol) : Nil; end
+  def open_settings(section : Symbol) : Nil
+    rec(:open_settings, section)
+  end
 
-  def open_preferences : Nil; end
+  def open_preferences : Nil
+    rec(:open_preferences)
+  end
 
-  def import_har : Nil; end
+  def import_har : Nil
+    rec(:import_har)
+  end
 
-  def import_urls : Nil; end
+  def import_urls : Nil
+    rec(:import_urls)
+  end
 
-  def import_oas : Nil; end
+  def import_oas : Nil
+    rec(:import_oas)
+  end
+end
+
+# Fire one verb on a fresh recording context and return the intents it dispatched, IN
+# ORDER — the shape every spec/verbs/*_spec.cr asserts on. Lives here rather than being
+# re-declared per file so a change to it (say, also asserting arguments) is one edit.
+def verb_intents(registry : Gori::Verb::Registry, id : String,
+                 ctx = FakeExecContext.new) : Array(Symbol)
+  registry[id].call(ctx)
+  ctx.call_names
 end

--- a/spec/verbs/comparer_spec.cr
+++ b/spec/verbs/comparer_spec.cr
@@ -1,0 +1,57 @@
+require "../spec_helper"
+require "../support/fake_context"
+
+# src/gori/verbs/comparer.cr — the Comparer tab (A/B flow diff, multi-pair sub-tabs).
+private def in_comparer(sessions : Int32 = 0) : FakeExecContext
+  ctx = FakeExecContext.new
+  ctx.current_tab = :comparer
+  ctx.subtab_search_tab_count = sessions
+  ctx
+end
+
+describe "Gori::Verbs.register_comparer" do
+  r = Gori::Verbs.registry
+
+  it "passes the slot symbol through to comparer_pick, one verb per slot" do
+    # One handler taking :a/:b — a copy-paste slip here silently makes 'b' overwrite A.
+    {"comparer.pick-a" => {"a", "a"}, "comparer.pick-b" => {"b", "b"}}.each do |id, (key, slot)|
+      ctx = in_comparer
+      r[id].chords.should eq([Gori::Verb::Chord.new(key)])
+      r[id].call(ctx)
+      ctx.call_names.should eq([:comparer_pick])
+      ctx.args_for(:comparer_pick).should eq([slot])
+    end
+  end
+
+  it "gates every Comparer verb on the Comparer tab" do
+    elsewhere = FakeExecContext.new
+    {"comparer.swap"             => :comparer_swap,
+     "comparer.toggle-pane"      => :comparer_toggle_pane,
+     "comparer.new"              => :comparer_new,
+     "comparer.rename-subtab"    => :comparer_rename_subtab,
+     "comparer.close-subtab"     => :comparer_close_subtab,
+     "comparer.duplicate-subtab" => :comparer_duplicate_subtab,
+    }.each do |id, intent|
+      r[id].available?(elsewhere).should be_false
+      r[id].available?(in_comparer).should be_true
+      verb_intents(r, id).should eq([intent])
+    end
+  end
+
+  it "keeps New in :common and the chip actions on :subtab" do
+    r["comparer.new"].section.should eq(:common)
+    %w[comparer.rename-subtab comparer.close-subtab comparer.duplicate-subtab].each do |id|
+      r[id].section.should eq(:subtab)
+    end
+  end
+
+  it "shows the sub-tab search/filter only with two or more comparisons open" do
+    %w[comparer.find-subtab comparer.filter-subtabs].each do |id|
+      r[id].section.should eq(:tab)
+      r[id].available?(in_comparer(sessions: 1)).should be_false
+      r[id].available?(in_comparer(sessions: 2)).should be_true
+    end
+    verb_intents(r, "comparer.find-subtab").should eq([:subtab_search_open])
+    verb_intents(r, "comparer.filter-subtabs").should eq([:subtab_filter_open])
+  end
+end

--- a/spec/verbs/core_spec.cr
+++ b/spec/verbs/core_spec.cr
@@ -1,0 +1,220 @@
+require "../spec_helper"
+require "../support/fake_context"
+
+# src/gori/verbs/core.cr — the app-wide verbs (quit/palette/capture/CA/settings/scope/
+# intercept/tab nav). Two things are asserted per verb: the INTENT it dispatches on the
+# recording ExecContext, and its `available?` gate (P4), which had no test at all.
+describe "Gori::Verbs.register_core" do
+  r = Gori::Verbs.registry
+
+  describe "app lifecycle" do
+    it "keeps 'q' → projects on the tab bar only, with the palette entry Global" do
+      # The Global entry deliberately carries NO chord: as a Global chord, `q` dumped the
+      # user to the picker from mid-browse in Sitemap/Issues (a one-key dead-end).
+      r["app.back"].scope.should eq(Gori::Verb::Scope::Global)
+      r["app.back"].chords.should be_empty
+      r["app.back"].hidden?.should be_false
+
+      key = r["app.back-key"]
+      key.scope.should eq(Gori::Verb::Scope::Sidebar)
+      key.chords.should eq([Gori::Verb::Chord.new("q")])
+      key.hidden?.should be_true # same action, so only one of the two lists in the palette
+
+      verb_intents(r, "app.back").should eq([:leave_project])
+      verb_intents(r, "app.back-key").should eq([:leave_project])
+    end
+
+    it "leaves Quit palette-only — the keyboard path is a deliberate double ^D/^C" do
+      r["app.quit"].chords.should be_empty
+      r["app.quit"].category.should eq(Gori::Verb::Category::System)
+      verb_intents(r, "app.quit").should eq([:quit!])
+    end
+
+    it "binds the palette to ctrl-p and the notification centre to no chord" do
+      r["app.palette"].chords.should eq([Gori::Verb::Chord.new("p", ctrl: true)])
+      verb_intents(r, "app.palette").should eq([:open_palette])
+      r["app.notifications"].chords.should be_empty
+      verb_intents(r, "app.notifications").should eq([:open_notifications])
+    end
+
+    it "routes capture / reveal-whitespace / refresh to their own intents" do
+      verb_intents(r, "capture.toggle").should eq([:toggle_capture])
+      verb_intents(r, "view.reveal-ws").should eq([:toggle_reveal])
+      verb_intents(r, "view.refresh").should eq([:refresh_screen])
+    end
+
+    it "keeps the destructive CA verbs palette-only (no chord to fat-finger)" do
+      %w[ca.export ca.regenerate ca.import browser.open].each { |id| r[id].chords.should be_empty }
+      verb_intents(r, "ca.export").should eq([:export_ca])
+      verb_intents(r, "ca.regenerate").should eq([:regenerate_ca])
+      verb_intents(r, "ca.import").should eq([:import_ca])
+      verb_intents(r, "browser.open").should eq([:open_browser_picker])
+    end
+  end
+
+  describe "settings" do
+    # Palette entries and the Settings tab's groups both read Tui::SettingsCatalog; a
+    # section registered without a verb (or a verb passing the wrong sym) silently makes
+    # that section unreachable from Ctrl-P.
+    it "registers one Settings verb per catalog section, passing that section's sym" do
+      Gori::Tui::SettingsCatalog.all.each do |s|
+        verb = r[s.id]
+        verb.category.should eq(Gori::Verb::Category::Settings)
+        verb.scope.should eq(Gori::Verb::Scope::Global)
+        ctx = FakeExecContext.new
+        verb.call(ctx)
+        ctx.call_names.should eq([:open_settings])
+        ctx.args_for(:open_settings).should eq([s.sym.to_s])
+      end
+    end
+
+    it "opens the unified Preferences modal from settings.open" do
+      verb_intents(r, "settings.open").should eq([:open_preferences])
+    end
+  end
+
+  describe "scope" do
+    it "toggles the lens from anywhere with bare 's' and jumps to the editor via the palette" do
+      r["scope.toggle-lens"].chords.should eq([Gori::Verb::Chord.new("s")])
+      verb_intents(r, "scope.toggle-lens").should eq([:scope_toggle_lens])
+      r["scope.edit"].chords.should be_empty
+      verb_intents(r, "scope.edit").should eq([:scope_open])
+    end
+
+    it "gates scope.add-host on the History tab AND a selected flow" do
+      verb = r["scope.add-host"]
+      ctx = FakeExecContext.new # :history, nothing selected
+      verb.available?(ctx).should be_false
+      ctx.selected = 7_i64
+      verb.available?(ctx).should be_true
+      ctx.current_tab = :repeater
+      verb.available?(ctx).should be_false
+      verb_intents(r, "scope.add-host").should eq([:scope_add_host])
+    end
+
+    it "gates the Body scope toggle on the History tab, selection or not" do
+      verb = r["scope.toggle"]
+      ctx = FakeExecContext.new
+      verb.available?(ctx).should be_true # no selection needed — it filters the whole list
+      ctx.current_tab = :sitemap
+      verb.available?(ctx).should be_false
+    end
+
+    it "gates the Project pane's edit/delete on a selected rule, but not add" do
+      ctx = FakeExecContext.new
+      r["scope.add-rule"].available?(ctx).should be_true
+      r["scope.edit-rule"].available?(ctx).should be_false
+      r["scope.delete-rule"].available?(ctx).should be_false
+      ctx.scope_has_rule = true
+      r["scope.edit-rule"].available?(ctx).should be_true
+      r["scope.delete-rule"].available?(ctx).should be_true
+
+      verb_intents(r, "scope.add-rule").should eq([:scope_add_rule])
+      verb_intents(r, "scope.edit-rule").should eq([:scope_edit_rule])
+      verb_intents(r, "scope.delete-rule").should eq([:scope_delete_rule])
+      verb_intents(r, "scope.lens-toggle").should eq([:scope_toggle_lens])
+    end
+  end
+
+  describe "project description copy" do
+    # The chord was dropped deliberately: plain 'y' collided with history.copy in the same
+    # (Body, :common) space-menu view AND as a raw Chord in the same scope. Re-adding one
+    # would make validate_menu_keys! / the keymap conflict guard fail at boot.
+    it "carries the 'Y' menu key with no chord, gated on the description read pane" do
+      verb = r["project.copy"]
+      verb.chords.should be_empty
+      verb.menu_key.should eq('Y')
+      ctx = FakeExecContext.new
+      verb.available?(ctx).should be_false # the description pane is not in read mode
+      ctx.project_desc_read_mode = true
+      verb.available?(ctx).should be_true
+      verb_intents(r, "project.copy").should eq([:read_copy])
+    end
+  end
+
+  describe "intercept" do
+    it "binds the Global toggle to bare 'i'" do
+      r["intercept.toggle"].chords.should eq([Gori::Verb::Chord.new("i")])
+      verb_intents(r, "intercept.toggle").should eq([:intercept_toggle])
+    end
+
+    it "gates forward / drop / forward-all on a held message being selected" do
+      ctx = FakeExecContext.new # nothing held
+      %w[intercept.forward intercept.drop intercept.forward-all].each do |id|
+        r[id].available?(ctx).should be_false
+        r[id].scope.should eq(Gori::Verb::Scope::Intercept)
+      end
+      ctx.intercept_selected = 3_i64
+      %w[intercept.forward intercept.drop intercept.forward-all].each do |id|
+        r[id].available?(ctx).should be_true
+      end
+      verb_intents(r, "intercept.forward").should eq([:intercept_forward])
+      verb_intents(r, "intercept.drop").should eq([:intercept_drop])
+      verb_intents(r, "intercept.forward-all").should eq([:intercept_forward_all])
+    end
+
+    it "leaves the catch controls ungated (they configure the queue, not a row)" do
+      ctx = FakeExecContext.new
+      r["intercept.direction"].available?(ctx).should be_true
+      r["intercept.filter"].available?(ctx).should be_true
+      verb_intents(r, "intercept.direction").should eq([:intercept_cycle_direction])
+      verb_intents(r, "intercept.filter").should eq([:intercept_query])
+    end
+  end
+
+  describe "navigation" do
+    it "cycles tabs with the bracket chords" do
+      ctx = FakeExecContext.new
+      r["nav.next-tab"].call(ctx)
+      ctx.args_for(:cycle_tab).should eq(["1"])
+      ctx = FakeExecContext.new
+      r["nav.prev-tab"].call(ctx)
+      ctx.args_for(:cycle_tab).should eq(["-1"])
+    end
+
+    it "binds digits 1..9 to the Nth VISIBLE tab, hidden from the palette" do
+      (1..9).each do |n|
+        verb = r["nav.pos#{n}"]
+        verb.hidden?.should be_true
+        verb.chords.should eq([Gori::Verb::Chord.new(n.to_s)])
+        ctx = FakeExecContext.new
+        verb.call(ctx)
+        ctx.args_for(:focus_visible_tab).should eq([n.to_s])
+      end
+    end
+
+    it "keeps a named 'Go to' verb for every catalog tab, including the hidden ones" do
+      # focus_tab force-shows a tab hidden in settings:tabs, so these are the only way to
+      # reach Miner/Sequencer by command when the user has hidden them.
+      %w[project target history intercept repeater fuzzer miner oast sequencer
+        decoder jwt comparer probe issues notes rewriter help].each do |tab|
+        ctx = FakeExecContext.new
+        verb = r["tab.#{tab}"]
+        verb.category.should eq(Gori::Verb::Category::Navigation)
+        verb.call(ctx)
+        ctx.call_names.should eq([:focus_tab])
+        ctx.args_for(:focus_tab).should eq([tab])
+      end
+      r["tab.help"].chords.should eq([Gori::Verb::Chord.new("?")])
+      verb_intents(r, "tab.discover").should eq([:goto_discover]) # a Target sub-tab, not a tab
+    end
+
+    it "walks the focus ring: sidebar ↔ body, and closes the palette overlay" do
+      verb_intents(r, "sidebar.prev").should eq([:menu_left])
+      verb_intents(r, "sidebar.next").should eq([:menu_right])
+      verb_intents(r, "sidebar.enter").should eq([:enter_content])
+      verb_intents(r, "palette.close").should eq([:close_overlay])
+
+      ctx = FakeExecContext.new
+      r["body.to-menu"].call(ctx)
+      ctx.args_for(:focus_pane).should eq(["menu"])
+    end
+
+    it "opens the Rewriter tab from the familiar 'Match & Replace' palette name" do
+      r["rules.edit"].title.should eq("Match & Replace")
+      ctx = FakeExecContext.new
+      r["rules.edit"].call(ctx)
+      ctx.args_for(:focus_tab).should eq(["rewriter"])
+    end
+  end
+end

--- a/spec/verbs/decoder_spec.cr
+++ b/spec/verbs/decoder_spec.cr
@@ -1,0 +1,74 @@
+require "../spec_helper"
+require "../support/fake_context"
+
+# src/gori/verbs/decoder.cr — the Decoder tab. Its body captures every printable key as
+# literal text, so these verbs are reachable only from the space menu and the palette;
+# the section each one carries decides which pane's menu lists it.
+private def in_decoder(read : Bool = false, sessions : Int32 = 0) : FakeExecContext
+  ctx = FakeExecContext.new
+  ctx.current_tab = :decoder
+  ctx.decoder_read_mode = read
+  ctx.subtab_search_tab_count = sessions
+  ctx
+end
+
+describe "Gori::Verbs.register_decoder" do
+  r = Gori::Verbs.registry
+
+  it "gates every Decoder verb on the Decoder tab" do
+    elsewhere = FakeExecContext.new # :history
+    %w[decoder.new decoder.close decoder.rename-subtab decoder.duplicate-subtab
+      decoder.clear decoder.mode decoder.save decoder.load].each do |id|
+      r[id].scope.should eq(Gori::Verb::Scope::Decoder)
+      r[id].available?(elsewhere).should be_false
+      r[id].available?(in_decoder).should be_true
+    end
+  end
+
+  it "keeps New/Close in :common so session management works from inside the body panes" do
+    # Tagged :tab/:subtab they were invisible from INPUT/CHAIN/OUTPUT, since the space menu
+    # renders COMMON ∪ the focused pane's section only.
+    r["decoder.new"].section.should eq(:common)
+    r["decoder.close"].section.should eq(:common)
+    verb_intents(r, "decoder.new").should eq([:decoder_new])
+    verb_intents(r, "decoder.close").should eq([:decoder_close])
+  end
+
+  it "routes the pane actions to their own intents, in their own sections" do
+    r["decoder.clear"].section.should eq(:input)
+    r["decoder.mode"].section.should eq(:output)
+    r["decoder.rename-subtab"].section.should eq(:subtab)
+    r["decoder.duplicate-subtab"].section.should eq(:subtab)
+    {"decoder.clear"            => :decoder_clear,
+     "decoder.mode"             => :decoder_cycle_mode,
+     "decoder.rename-subtab"    => :decoder_rename_subtab,
+     "decoder.duplicate-subtab" => :decoder_duplicate_subtab,
+    }.each { |id, intent| verb_intents(r, id).should eq([intent]) }
+  end
+
+  it "puts save/load in :tab so the tab-bar menu has a group of its own" do
+    # This is what seeds has_section?(Decoder, :tab); without it the tab-bar space menu
+    # falls back to whichever body pane happened to be focused last.
+    r["decoder.save"].section.should eq(:tab)
+    r["decoder.load"].section.should eq(:tab)
+    verb_intents(r, "decoder.save").should eq([:decoder_save])
+    verb_intents(r, "decoder.load").should eq([:decoder_load])
+  end
+
+  it "gates Copy on a read-mode pane and routes it through the shared read_copy" do
+    r["decoder.copy"].available?(in_decoder).should be_false
+    r["decoder.copy"].available?(in_decoder(read: true)).should be_true
+    r["decoder.copy"].chords.should eq([Gori::Verb::Chord.new("y")])
+    verb_intents(r, "decoder.copy").should eq([:read_copy])
+  end
+
+  it "shows the sub-tab search/filter only with two or more conversions open" do
+    %w[decoder.find-subtab decoder.filter-subtabs].each do |id|
+      r[id].available?(in_decoder(sessions: 1)).should be_false
+      r[id].available?(in_decoder(sessions: 2)).should be_true
+      r[id].section.should eq(:tab)
+    end
+    verb_intents(r, "decoder.find-subtab").should eq([:subtab_search_open])
+    verb_intents(r, "decoder.filter-subtabs").should eq([:subtab_filter_open])
+  end
+end

--- a/spec/verbs/discover_spec.cr
+++ b/spec/verbs/discover_spec.cr
@@ -1,0 +1,33 @@
+require "../spec_helper"
+require "../support/fake_context"
+
+# src/gori/verbs/discover.cr — the Discover sub-tab (under Target) run controls.
+describe "Gori::Verbs.register_discover" do
+  r = Gori::Verbs.registry
+
+  it "controls the current run from the Discover scope" do
+    {"discover.run"   => :discover_run,
+     "discover.stop"  => :discover_stop,
+     "discover.pause" => :discover_toggle_pause,
+    }.each do |id, intent|
+      r[id].scope.should eq(Gori::Verb::Scope::Discover)
+      verb_intents(r, id).should eq([intent])
+    end
+  end
+
+  it "keeps pause off ctrl-p, which belongs to the command palette" do
+    # Plain `p` is handled by the controller body; the verb exists for the space menu.
+    r["discover.pause"].chords.should be_empty
+    r["discover.pause"].menu_key.should eq('p')
+    r["app.palette"].chords.should eq([Gori::Verb::Chord.new("p", ctrl: true)])
+    r["discover.run"].chords.should eq([Gori::Verb::Chord.new("r", ctrl: true)])
+    r["discover.stop"].chords.should eq([Gori::Verb::Chord.new("x", ctrl: true)])
+  end
+
+  it "escapes back to the Sitemap/Discover strip, not the tab bar" do
+    ctx = FakeExecContext.new
+    r["discover.to-menu"].call(ctx)
+    ctx.args_for(:focus_pane).should eq(["subtabs"])
+    r["discover.to-menu"].hidden?.should be_true
+  end
+end

--- a/spec/verbs/env_spec.cr
+++ b/spec/verbs/env_spec.cr
@@ -1,0 +1,46 @@
+require "../spec_helper"
+require "../support/fake_context"
+
+# src/gori/verbs/env.cr — the Project tab's ENVIRONMENT pane. Its own scope, so a/e/d
+# act on the env-var list and never on the SCOPE rules or HOST OVERRIDES stacked above it.
+describe "Gori::Verbs.register_env" do
+  r = Gori::Verbs.registry
+
+  it "keeps a/e/d in the Env scope, distinct from the panes above it" do
+    {"env.add-var" => "a", "env.edit-var" => "e", "env.delete-var" => "d"}.each do |id, key|
+      r[id].scope.should eq(Gori::Verb::Scope::Env)
+      r[id].chords.should eq([Gori::Verb::Chord.new(key)])
+      # The same letters in the sibling panes belong to DIFFERENT verbs in DIFFERENT
+      # scopes; sharing a scope would make one set silently shadow the other.
+      r[id].scope.should_not eq(Gori::Verb::Scope::Project)
+      r[id].scope.should_not eq(Gori::Verb::Scope::HostOverrides)
+    end
+  end
+
+  it "gates edit and delete on a selected var, leaving add always available" do
+    ctx = FakeExecContext.new
+    r["env.add-var"].available?(ctx).should be_true
+    r["env.edit-var"].available?(ctx).should be_false
+    r["env.delete-var"].available?(ctx).should be_false
+    ctx.env_has_var = true
+    r["env.edit-var"].available?(ctx).should be_true
+    r["env.delete-var"].available?(ctx).should be_true
+  end
+
+  it "leaves the GLOBAL prefix setting menu-only, out of the way of everyday edits" do
+    # The prefix sigil applies app-wide, not per project — a direct chord next to add/edit
+    # would read as another per-project field.
+    verb = r["env.edit-prefix"]
+    verb.chords.should be_empty
+    verb.menu_key.should eq('p')
+    verb.available?(FakeExecContext.new).should be_true
+  end
+
+  it "routes each action to its own intent" do
+    {"env.add-var"     => :env_add_var,
+     "env.edit-var"    => :env_edit_var,
+     "env.delete-var"  => :env_delete_var,
+     "env.edit-prefix" => :env_edit_prefix,
+    }.each { |id, intent| verb_intents(r, id).should eq([intent]) }
+  end
+end

--- a/spec/verbs/history_spec.cr
+++ b/spec/verbs/history_spec.cr
@@ -1,0 +1,299 @@
+require "../spec_helper"
+require "../support/fake_context"
+
+# src/gori/verbs/history.cr — the History list + detail, the Repeater workbench, and
+# (registered in the same file) the Fuzzer and Miner verbs. Each example pins the INTENT
+# a verb dispatches on the recording ExecContext and the `available?` gate around it.
+# A context sitting on `tab` with a flow selected — what most of these verbs gate on.
+private def on(tab : Symbol, selected : Int64? = nil) : FakeExecContext
+  ctx = FakeExecContext.new
+  ctx.current_tab = tab
+  ctx.selected = selected
+  ctx
+end
+
+describe "Gori::Verbs.register_history" do
+  r = Gori::Verbs.registry
+
+  describe "History list (Body)" do
+    it "moves the selection with a signed delta" do
+      ctx = FakeExecContext.new
+      r["body.down"].call(ctx)
+      ctx.args_for(:move_selection).should eq(["1"])
+      ctx = FakeExecContext.new
+      r["body.up"].call(ctx)
+      ctx.args_for(:move_selection).should eq(["-1"])
+    end
+
+    # The two gates are NOT interchangeable: a list-wide action (filter/follow/clear)
+    # only needs the tab, a flow action needs a selected row too. Widening the flow gate
+    # to in_history would let 'y'/^R/'X' fire against nothing.
+    it "gates flow actions on a selected flow and list actions on the tab alone" do
+      empty = on(:history)
+      picked = on(:history, 7_i64)
+      elsewhere = on(:repeater, 7_i64)
+
+      {"body.open"        => :open_detail,
+       "history.copy"     => :copy_selection,
+       "history.repeater" => :repeater_selected,
+       "history.discover" => :history_discover,
+       "history.compare"  => :comparer_add_selected,
+       "history.delete"   => :history_delete,
+      }.each do |id, intent|
+        r[id].available?(empty).should be_false
+        r[id].available?(picked).should be_true
+        r[id].available?(elsewhere).should be_false
+        verb_intents(r, id).should eq([intent])
+      end
+
+      {"history.query"         => :history_query,
+       "history.toggle-follow" => :toggle_follow,
+       "history.clear"         => :history_clear,
+      }.each do |id, intent|
+        r[id].available?(empty).should be_true
+        r[id].available?(elsewhere).should be_false
+        verb_intents(r, id).should eq([intent])
+      end
+    end
+
+    it "keeps the destructive list verbs menu-only, on capitals that don't shadow a chord" do
+      # 'x' is select-line and 'c' is compare in the same Body COMMON view, so delete/clear
+      # take 'X'/'C'. A lowercase mnemonic here would silently shadow one of those.
+      r["history.delete"].chords.should be_empty
+      r["history.delete"].menu_key.should eq('X')
+      r["history.clear"].chords.should be_empty
+      r["history.clear"].menu_key.should eq('C')
+      r["history.probe-active"].menu_key.should eq('A')
+      verb_intents(r, "history.probe-active").should eq([:probe_active_selected])
+    end
+  end
+
+  describe "History detail" do
+    # These mirror the list's space menu so muscle memory carries into the drill-in — and
+    # each one that navigates AWAY closes the detail FIRST, so the overlay doesn't float
+    # over the destination tab. Order is the whole point of the assertion.
+    it "closes the detail before jumping to another tab" do
+      verb_intents(r, "detail.repeater").should eq([:close_detail, :repeater_selected])
+      verb_intents(r, "detail.issue").should eq([:close_detail, :issue_create])
+      verb_intents(r, "detail.fuzz").should eq([:close_detail, :fuzz_selected])
+      verb_intents(r, "detail.mine").should eq([:close_detail, :mine_selected])
+      verb_intents(r, "detail.sequence").should eq([:close_detail, :sequence_selected])
+      verb_intents(r, "detail.probe-active").should eq([:close_detail, :probe_active_selected])
+    end
+
+    it "keeps the in-place actions from closing the detail" do
+      verb_intents(r, "detail.compare").should eq([:comparer_add_selected])
+      verb_intents(r, "detail.copy").should eq([:detail_copy_selection])
+      verb_intents(r, "detail.copy-flow").should eq([:copy_selection])
+      verb_intents(r, "detail.copy-as").should eq([:copy_as_open])
+      verb_intents(r, "detail.add-host").should eq([:scope_add_host])
+      verb_intents(r, "detail.delete").should eq([:history_delete])
+    end
+
+    it "walks the panes and the caret with signed deltas" do
+      ctx = FakeExecContext.new
+      r["detail.next-pane"].call(ctx)
+      ctx.args_for(:move_detail_pane).should eq(["1"])
+      ctx = FakeExecContext.new
+      r["detail.prev-pane"].call(ctx)
+      ctx.args_for(:move_detail_pane).should eq(["-1"])
+      ctx = FakeExecContext.new
+      r["detail.down"].call(ctx)
+      ctx.args_for(:scroll_detail).should eq(["1"])
+      ctx = FakeExecContext.new
+      r["detail.up"].call(ctx)
+      ctx.args_for(:scroll_detail).should eq(["-1"])
+      verb_intents(r, "detail.toggle-pane").should eq([:toggle_detail_pane])
+      verb_intents(r, "detail.close").should eq([:close_detail])
+    end
+
+    it "leaves the view toggles visible so they front the detail's space menu" do
+      # The palette is Global-only, so un-hiding them cannot leak them there.
+      %w[detail.toggle-hex detail.toggle-ws detail.toggle-pretty].each do |id|
+        r[id].hidden?.should be_false
+        r[id].scope.should eq(Gori::Verb::Scope::HistoryDetail)
+      end
+      r["detail.toggle-hex"].menu_key.should eq('e') # ^X has no menu key; plain 'x' is select-line
+      verb_intents(r, "detail.toggle-hex").should eq([:toggle_detail_hex])
+      verb_intents(r, "detail.toggle-ws").should eq([:toggle_reveal])
+      verb_intents(r, "detail.toggle-pretty").should eq([:toggle_pretty])
+    end
+  end
+
+  describe "Repeater workbench" do
+    it "gates every Repeater verb on the Repeater tab" do
+      ctx = on(:history)
+      %w[repeater.send repeater.new repeater.minimize repeater.insert-marker
+        repeater.auto-mark repeater.toggle-hex repeater.toggle-http2
+        repeater.send-group repeater.toggle-diff].each do |id|
+        r[id].available?(ctx).should be_false
+        r[id].available?(on(:repeater)).should be_true
+      end
+    end
+
+    it "routes send / new / minimize / group-send to their own intents" do
+      verb_intents(r, "repeater.send").should eq([:repeater_send])
+      verb_intents(r, "repeater.new").should eq([:repeater_new])
+      verb_intents(r, "repeater.minimize").should eq([:repeater_minimize])
+      verb_intents(r, "repeater.send-group").should eq([:repeater_send_group])
+    end
+
+    it "routes Copy through read_copy (the single smart copy), gated on a read pane" do
+      verb = r["repeater.copy"]
+      verb.available?(on(:repeater)).should be_false # not in read mode
+      ctx = on(:repeater)
+      ctx.repeater_read_mode = true
+      verb.available?(ctx).should be_true
+      verb_intents(r, "repeater.copy").should eq([:read_copy])
+      r["repeater.copy-as"].menu_key.should eq('Y') # pairs with copy's 'y'
+      verb_intents(r, "repeater.copy-as").should eq([:copy_as_open])
+    end
+
+    it "shows the sub-tab jump only once there are two sessions to pick between" do
+      one = on(:repeater)
+      one.repeater_tab_count = 1
+      two = on(:repeater)
+      two.repeater_tab_count = 2
+      %w[repeater.find-subtab repeater.filter-subtabs].each do |id|
+        r[id].available?(one).should be_false
+        r[id].available?(two).should be_true
+        r[id].section.should eq(:tab) # seeds has_section?(Repeater, :tab) for the tab-bar menu
+      end
+      # Duplicate needs only ONE session — it clones what is open.
+      r["repeater.duplicate-subtab"].available?(one).should be_true
+      r["repeater.duplicate-subtab"].available?(on(:repeater)).should be_false # zero sessions
+    end
+
+    it "keeps the marker actions on the :request section and the diff toggles on :response" do
+      {"repeater.insert-marker" => :repeater_insert_marker,
+       "repeater.mark-word"     => :repeater_mark_word,
+       "repeater.auto-mark"     => :repeater_auto_mark,
+       "repeater.clear-marks"   => :repeater_clear_marks,
+       "repeater.attach-chain"  => :repeater_attach_chain,
+       "repeater.toggle-hex"    => :repeater_toggle_hex,
+       "repeater.toggle-http2"  => :repeater_toggle_http2,
+      }.each do |id, intent|
+        r[id].section.should eq(:request)
+        verb_intents(r, id).should eq([intent])
+      end
+
+      {"repeater.toggle-diff"     => :repeater_toggle_resp_diff,
+       "repeater.toggle-resp-hex" => :repeater_toggle_resp_hex,
+       "repeater.toggle-pretty"   => :toggle_pretty,
+      }.each do |id, intent|
+        r[id].section.should eq(:response)
+        verb_intents(r, id).should eq([intent])
+      end
+
+      r["repeater.toggle-sni"].section.should eq(:target)
+      verb_intents(r, "repeater.toggle-sni").should eq([:repeater_toggle_sni])
+    end
+
+    it "gates Link to issue/note on the session having been persisted" do
+      # link_repeater_id is nil until the session has a row — linking before that would
+      # attach evidence to an id that does not exist.
+      ctx = on(:repeater)
+      r["link.repeater.to-issue"].available?(ctx).should be_false
+      r["link.repeater.to-note"].available?(ctx).should be_false
+      ctx.link_repeater = 4_i64
+      r["link.repeater.to-issue"].available?(ctx).should be_true
+      r["link.repeater.to-note"].available?(ctx).should be_true
+      verb_intents(r, "link.repeater.to-issue").should eq([:link_to_issue])
+      verb_intents(r, "link.repeater.to-note").should eq([:link_to_note])
+    end
+  end
+
+  describe "Fuzzer (register_fuzz)" do
+    it "sends to the Fuzzer from History (selected flow) and from Repeater (template)" do
+      r["history.fuzz"].available?(on(:history)).should be_false
+      r["history.fuzz"].available?(on(:history, 3_i64)).should be_true
+      verb_intents(r, "history.fuzz").should eq([:fuzz_selected])
+
+      r["repeater.fuzz"].available?(on(:history, 3_i64)).should be_false
+      r["repeater.fuzz"].available?(on(:repeater)).should be_true
+      verb_intents(r, "repeater.fuzz").should eq([:fuzz_from_repeater])
+    end
+
+    it "gates the Fuzzer-scope actions on the Fuzzer tab" do
+      ctx = on(:fuzzer)
+      {"fuzz.run"             => :fuzz_run,
+       "fuzz.stop"            => :fuzz_stop,
+       "fuzz.new"             => :fuzz_new,
+       "fuzz.automark"        => :fuzz_automark,
+       "fuzz.attach-chain"    => :fuzz_attach_chain,
+       "fuzz.list-paste"      => :fuzz_list_paste,
+       "fuzz.pretty-template" => :fuzz_pretty_template,
+       "fuzz.toggle-http2"    => :fuzz_toggle_http2,
+       "fuzz.clear-marks"     => :fuzz_clear_marks,
+      }.each do |id, intent|
+        r[id].available?(ctx).should be_true
+        r[id].available?(on(:repeater)).should be_false
+        verb_intents(r, id).should eq([intent])
+      end
+    end
+
+    it "shares one sub-tab search/filter counter across the workbench tabs" do
+      ctx = on(:fuzzer)
+      ctx.subtab_search_tab_count = 2
+      r["fuzz.find-subtab"].available?(ctx).should be_true
+      r["fuzz.filter-subtabs"].available?(ctx).should be_true
+      verb_intents(r, "fuzz.find-subtab").should eq([:subtab_search_open])
+      verb_intents(r, "fuzz.filter-subtabs").should eq([:subtab_filter_open])
+    end
+
+    it "gates the Fuzzer Copy on read mode, like the Repeater one" do
+      ctx = on(:fuzzer)
+      r["fuzzer.copy"].available?(ctx).should be_false
+      ctx.fuzzer_read_mode = true
+      r["fuzzer.copy"].available?(ctx).should be_true
+      verb_intents(r, "fuzzer.copy").should eq([:read_copy])
+    end
+
+    it "gates Link to issue/note on the FUZZ session id, not the repeater one" do
+      # link.fuzzer.* and link.repeater.* are near-identical registrations; each must read
+      # its OWN id, or the Fuzzer entries are offered against a session that isn't there.
+      ctx = on(:fuzzer)
+      ctx.link_repeater = 4_i64 # a live repeater session must not unlock the Fuzzer verbs
+      r["link.fuzzer.to-issue"].available?(ctx).should be_false
+      r["link.fuzzer.to-note"].available?(ctx).should be_false
+      ctx.link_fuzz = 8_i64
+      r["link.fuzzer.to-issue"].available?(ctx).should be_true
+      r["link.fuzzer.to-note"].available?(ctx).should be_true
+      ctx.current_tab = :repeater
+      r["link.fuzzer.to-issue"].available?(ctx).should be_false # linkable fuzz, wrong tab
+      verb_intents(r, "link.fuzzer.to-issue").should eq([:link_to_issue])
+      verb_intents(r, "link.fuzzer.to-note").should eq([:link_to_note])
+    end
+  end
+
+  describe "Miner (register_miner)" do
+    it "sends to the Miner from History, the detail, and Repeater" do
+      r["history.mine"].available?(on(:history)).should be_false
+      r["history.mine"].available?(on(:history, 1_i64)).should be_true
+      verb_intents(r, "history.mine").should eq([:mine_selected])
+      verb_intents(r, "repeater.mine").should eq([:mine_from_repeater])
+    end
+
+    it "gates 'Send to Repeater' on a selected finding, not just the Miner tab" do
+      ctx = on(:miner)
+      r["mine.repeater"].available?(ctx).should be_false
+      ctx.miner_has_issue = true
+      r["mine.repeater"].available?(ctx).should be_true
+      verb_intents(r, "mine.repeater").should eq([:mine_repeater_selected])
+    end
+
+    it "routes run / stop / duplicate on the Miner tab" do
+      ctx = on(:miner)
+      r["mine.run"].available?(ctx).should be_true
+      r["mine.stop"].available?(ctx).should be_true
+      verb_intents(r, "mine.run").should eq([:mine_run])
+      verb_intents(r, "mine.stop").should eq([:mine_stop])
+      verb_intents(r, "mine.duplicate-subtab").should eq([:miner_duplicate_subtab])
+    end
+
+    it "runs the active Probe checks against the current Repeater request" do
+      r["repeater.probe-active"].available?(on(:repeater)).should be_true
+      verb_intents(r, "repeater.probe-active").should eq([:probe_active_from_repeater])
+    end
+  end
+end

--- a/spec/verbs/host_overrides_spec.cr
+++ b/spec/verbs/host_overrides_spec.cr
@@ -1,0 +1,37 @@
+require "../spec_helper"
+require "../support/fake_context"
+
+# src/gori/verbs/host_overrides.cr — the Project tab's HOST OVERRIDES pane. Its own scope,
+# so a/e/d act on the override list and never on the SCOPE rules right above it.
+describe "Gori::Verbs.register_host_overrides" do
+  r = Gori::Verbs.registry
+
+  it "keeps a/e/d in the HostOverrides scope, distinct from the scope-rule list" do
+    {"hostoverride.add-entry"    => "a",
+     "hostoverride.edit-entry"   => "e",
+     "hostoverride.delete-entry" => "d",
+    }.each do |id, key|
+      r[id].scope.should eq(Gori::Verb::Scope::HostOverrides)
+      r[id].chords.should eq([Gori::Verb::Chord.new(key)])
+      # The Project scope binds the same letters to scope.add-rule/edit-rule/delete-rule.
+      r[id].scope.should_not eq(Gori::Verb::Scope::Project)
+    end
+  end
+
+  it "gates edit and delete on a selected entry, leaving add always available" do
+    ctx = FakeExecContext.new
+    r["hostoverride.add-entry"].available?(ctx).should be_true
+    r["hostoverride.edit-entry"].available?(ctx).should be_false
+    r["hostoverride.delete-entry"].available?(ctx).should be_false
+    ctx.hostov_has_entry = true
+    r["hostoverride.edit-entry"].available?(ctx).should be_true
+    r["hostoverride.delete-entry"].available?(ctx).should be_true
+  end
+
+  it "routes each action to its own intent" do
+    {"hostoverride.add-entry"    => :hostov_add_entry,
+     "hostoverride.edit-entry"   => :hostov_edit_entry,
+     "hostoverride.delete-entry" => :hostov_delete_entry,
+    }.each { |id, intent| verb_intents(r, id).should eq([intent]) }
+  end
+end

--- a/spec/verbs/import_spec.cr
+++ b/spec/verbs/import_spec.cr
@@ -1,0 +1,29 @@
+require "../spec_helper"
+require "../support/fake_context"
+
+# src/gori/verbs/import.cr — the three palette-only import entries. Each maps to ONE
+# ExecContext method; the CLI mirror of the same three sources is covered in
+# spec/cli/run/import_spec.cr.
+describe "Gori::Verbs.register_import" do
+  r = Gori::Verbs.registry
+
+  it "registers one Global, chordless verb per import source" do
+    {"import.har" => :import_har, "import.urls" => :import_urls, "import.oas" => :import_oas}
+      .each do |id, intent|
+        verb = r[id]
+        verb.scope.should eq(Gori::Verb::Scope::Global)
+        verb.category.should eq(Gori::Verb::Category::Action)
+        verb.chords.should be_empty # palette-only — importing is deliberate, never a keypress
+        verb.available?(FakeExecContext.new).should be_true
+        verb_intents(r, id).should eq([intent])
+      end
+  end
+
+  it "keeps the three sources on separate handlers (no shared 'import' dispatcher)" do
+    # A single handler taking a kind would be one closure-capture slip away from importing
+    # a HAR as a URL list; three ids → three intents is the invariant.
+    ctx = FakeExecContext.new
+    %w[import.har import.urls import.oas].each { |id| r[id].call(ctx) }
+    ctx.call_names.should eq([:import_har, :import_urls, :import_oas])
+  end
+end

--- a/spec/verbs/issues_spec.cr
+++ b/spec/verbs/issues_spec.cr
@@ -1,0 +1,143 @@
+require "../spec_helper"
+require "../support/fake_context"
+
+# src/gori/verbs/issues.cr — the Issues list, the issue detail, and the two export verbs.
+describe "Gori::Verbs.register_issues" do
+  r = Gori::Verbs.registry
+
+  describe "creating from a flow" do
+    it "gates issue.create on the History tab AND a selected flow" do
+      verb = r["issue.create"]
+      ctx = FakeExecContext.new
+      verb.available?(ctx).should be_false
+      ctx.selected = 5_i64
+      verb.available?(ctx).should be_true
+      ctx.current_tab = :issues
+      verb.available?(ctx).should be_false
+      verb.chords.should eq([Gori::Verb::Chord.new("f", shift: true)])
+      verb_intents(r, "issue.create").should eq([:issue_create])
+    end
+  end
+
+  describe "the issues list" do
+    it "moves the selection with a signed delta" do
+      ctx = FakeExecContext.new
+      r["issues.down"].call(ctx)
+      ctx.args_for(:issues_move).should eq(["1"])
+      ctx = FakeExecContext.new
+      r["issues.up"].call(ctx)
+      ctx.args_for(:issues_move).should eq(["-1"])
+    end
+
+    it "keeps open/new/delete visible so they front the list's space menu" do
+      # The palette is Global-only, so a non-hidden Issues-scope verb cannot leak there.
+      %w[issues.open issues.new issues.delete issues.export-key].each do |id|
+        r[id].hidden?.should be_false
+        r[id].scope.should eq(Gori::Verb::Scope::Issues)
+      end
+      # open's primary chord is enter/l — 'l' would front the menu unintuitively, so it
+      # carries an explicit 'o'.
+      r["issues.open"].menu_key.should eq('o')
+      verb_intents(r, "issues.open").should eq([:issues_open])
+      verb_intents(r, "issues.new").should eq([:issues_new])
+      verb_intents(r, "issues.delete").should eq([:issues_delete])
+      verb_intents(r, "issues.filter").should eq([:issues_query])
+    end
+
+    it "returns focus to the tab menu on escape only (← was a tab-bar overshoot)" do
+      verb = r["issues.leave"]
+      verb.chords.should eq([Gori::Verb::Chord.new("escape")])
+      ctx = FakeExecContext.new
+      verb.call(ctx)
+      ctx.args_for(:focus_pane).should eq(["menu"])
+    end
+  end
+
+  describe "the issue detail" do
+    it "cycles severity and status with signed deltas on the bracket/brace chords" do
+      {"issue.severity-up"   => {:issue_severity, "1", "]"},
+       "issue.severity-down" => {:issue_severity, "-1", "["},
+       "issue.status-up"     => {:issue_status, "1", "}"},
+       "issue.status-down"   => {:issue_status, "-1", "{"},
+      }.each do |id, (intent, delta, key)|
+        verb = r[id]
+        verb.hidden?.should be_true # power shortcut; the pickers are the discoverable path
+        verb.chords.should eq([Gori::Verb::Chord.new(key)])
+        ctx = FakeExecContext.new
+        verb.call(ctx)
+        ctx.args_for(intent).should eq([delta])
+      end
+    end
+
+    it "puts the severity/status PICKERS on the space menu with no chord" do
+      # Chordless on purpose: arrows must never change triage state by accident.
+      r["issue.set-severity"].chords.should be_empty
+      r["issue.set-severity"].menu_key.should eq('s')
+      r["issue.set-status"].chords.should be_empty
+      r["issue.set-status"].menu_key.should eq('c')
+      verb_intents(r, "issue.set-severity").should eq([:issue_set_severity])
+      verb_intents(r, "issue.set-status").should eq([:issue_set_status])
+    end
+
+    it "gates Copy on the notes pane being in read mode" do
+      ctx = FakeExecContext.new
+      r["issue.copy"].available?(ctx).should be_false
+      ctx.issues_notes_read_mode = true
+      r["issue.copy"].available?(ctx).should be_true
+      verb_intents(r, "issue.copy").should eq([:read_copy])
+    end
+
+    it "scrolls a long notes line with SHIFT+←/→, leaving plain ← to close" do
+      # issue.close owns plain ←/h; the h-scroll chords carry shift, so they don't collide.
+      r["issue.hscroll-right"].chords.should eq([Gori::Verb::Chord.new("right", shift: true)])
+      r["issue.hscroll-left"].chords.should eq([Gori::Verb::Chord.new("left", shift: true)])
+      r["issue.close"].chords.should contain(Gori::Verb::Chord.new("left"))
+      ctx = FakeExecContext.new
+      r["issue.hscroll-right"].call(ctx)
+      ctx.args_for(:issue_hscroll).should eq(["1"])
+      ctx = FakeExecContext.new
+      r["issue.hscroll-left"].call(ctx)
+      ctx.args_for(:issue_hscroll).should eq(["-1"])
+    end
+
+    it "routes the detail actions to their own intents" do
+      {"issue.close"         => :issue_close,
+       "issue.edit-notes"    => :issue_edit_notes,
+       "issue.edit-title"    => :issue_edit_title,
+       "issue.open-flow"     => :issue_open_flow,
+       "issue.repeater-flow" => :issue_repeater_flow,
+       "issue.delete"        => :issues_delete,
+       "issue.links"         => :issue_links,
+       "issue.open-link"     => :issue_open_link,
+      }.each { |id, intent| verb_intents(r, id).should eq([intent]) }
+
+      ctx = FakeExecContext.new
+      r["issue.link-down"].call(ctx)
+      ctx.args_for(:issue_link_move).should eq(["1"])
+      ctx = FakeExecContext.new
+      r["issue.link-up"].call(ctx)
+      ctx.args_for(:issue_link_move).should eq(["-1"])
+    end
+  end
+
+  describe "export" do
+    it "passes the right format symbol per export verb" do
+      {"issues.export-md" => "markdown", "issues.export-json" => "json"}.each do |id, format|
+        r[id].scope.should eq(Gori::Verb::Scope::Global) # palette-reachable from anywhere
+        ctx = FakeExecContext.new
+        r[id].call(ctx)
+        ctx.call_names.should eq([:issues_export])
+        ctx.args_for(:issues_export).should eq([format])
+      end
+    end
+
+    it "defaults the Issues-scope 'x' chord to the human-readable Markdown report" do
+      # Issues-scoped so 'x' doesn't collide with the hex toggles in other scopes.
+      verb = r["issues.export-key"]
+      verb.chords.should eq([Gori::Verb::Chord.new("x")])
+      ctx = FakeExecContext.new
+      verb.call(ctx)
+      ctx.args_for(:issues_export).should eq(["markdown"])
+    end
+  end
+end

--- a/spec/verbs/jwt_spec.cr
+++ b/spec/verbs/jwt_spec.cr
@@ -1,0 +1,61 @@
+require "../spec_helper"
+require "../support/fake_context"
+
+# src/gori/verbs/jwt.cr — the JWT workbench tab.
+private def in_jwt(read : Bool = false, sessions : Int32 = 0) : FakeExecContext
+  ctx = FakeExecContext.new
+  ctx.current_tab = :jwt
+  ctx.jwt_read_mode = read
+  ctx.subtab_search_tab_count = sessions
+  ctx
+end
+
+describe "Gori::Verbs.register_jwt" do
+  r = Gori::Verbs.registry
+
+  it "keeps session management and the lens toggles in :common (reachable from every pane)" do
+    {"jwt.new"          => :jwt_new,
+     "jwt.close"        => :jwt_close,
+     "jwt.toggle-mode"  => :jwt_toggle_mode,
+     "jwt.cycle-alg"    => :jwt_cycle_alg,
+     "jwt.load-decoded" => :jwt_load_decoded,
+     "jwt.clear"        => :jwt_clear,
+    }.each do |id, intent|
+      r[id].section.should eq(:common)
+      r[id].available?(FakeExecContext.new).should be_false # gated on the JWT tab
+      r[id].available?(in_jwt).should be_true
+      verb_intents(r, id).should eq([intent])
+    end
+  end
+
+  it "gates the smart Copy on a read-mode pane, but not the pane-specific copies" do
+    r["jwt.copy"].available?(in_jwt).should be_false
+    r["jwt.copy"].available?(in_jwt(read: true)).should be_true
+    r["jwt.copy"].chords.should eq([Gori::Verb::Chord.new("y")])
+    verb_intents(r, "jwt.copy").should eq([:jwt_copy])
+
+    # copy-token / copy-attack copy a computed value, not a text selection, so they only
+    # need the tab — and they live in the section of the pane that value comes from.
+    r["jwt.copy-token"].section.should eq(:output)
+    r["jwt.copy-attack"].section.should eq(:attacks)
+    r["jwt.copy-token"].available?(in_jwt).should be_true
+    r["jwt.copy-attack"].available?(in_jwt).should be_true
+    verb_intents(r, "jwt.copy-token").should eq([:jwt_copy_token])
+    verb_intents(r, "jwt.copy-attack").should eq([:jwt_copy_attack])
+  end
+
+  it "puts rename/duplicate on :subtab and search/filter on :tab" do
+    r["jwt.rename-subtab"].section.should eq(:subtab)
+    r["jwt.duplicate-subtab"].section.should eq(:subtab)
+    verb_intents(r, "jwt.rename-subtab").should eq([:jwt_rename_subtab])
+    verb_intents(r, "jwt.duplicate-subtab").should eq([:jwt_duplicate_subtab])
+
+    %w[jwt.find-subtab jwt.filter-subtabs].each do |id|
+      r[id].section.should eq(:tab)
+      r[id].available?(in_jwt(sessions: 1)).should be_false
+      r[id].available?(in_jwt(sessions: 2)).should be_true
+    end
+    verb_intents(r, "jwt.find-subtab").should eq([:subtab_search_open])
+    verb_intents(r, "jwt.filter-subtabs").should eq([:subtab_filter_open])
+  end
+end

--- a/spec/verbs/links_spec.cr
+++ b/spec/verbs/links_spec.cr
@@ -1,0 +1,48 @@
+require "../spec_helper"
+require "../support/fake_context"
+
+# src/gori/verbs/links.cr — "Link to issue / note" from History, the History detail, and
+# the Miner. (Repeater's and the Fuzzer's own pair is registered in verbs/history.cr so
+# their COMMON menu order lands after Fuzz/Mine — asserted in spec/verbs/history_spec.cr.)
+describe "Gori::Verbs.register_links" do
+  r = Gori::Verbs.registry
+
+  it "registers the issue/note pair in each linkable scope, on the same menu keys" do
+    {"link.history.to-issue"        => Gori::Verb::Scope::Body,
+     "link.history-detail.to-issue" => Gori::Verb::Scope::HistoryDetail,
+     "link.miner.to-issue"          => Gori::Verb::Scope::Miner,
+    }.each do |id, scope|
+      r[id].scope.should eq(scope)
+      r[id].menu_key.should eq('k')
+      verb_intents(r, id).should eq([:link_to_issue])
+    end
+
+    {"link.history.to-note"        => Gori::Verb::Scope::Body,
+     "link.history-detail.to-note" => Gori::Verb::Scope::HistoryDetail,
+     "link.miner.to-note"          => Gori::Verb::Scope::Miner,
+    }.each do |id, scope|
+      r[id].scope.should eq(scope)
+      r[id].menu_key.should eq('u')
+      verb_intents(r, id).should eq([:link_to_note])
+    end
+  end
+
+  it "gates on the LINK id, not the selection — a flow with no row cannot be linked" do
+    # link_flow_id is nil on the fake, so being on the History tab is not enough. Attaching
+    # evidence to an id that does not exist would file an orphan row.
+    ctx = FakeExecContext.new
+    ctx.current_tab = :history
+    ctx.selected = 9_i64
+    r["link.history.to-issue"].available?(ctx).should be_false
+    r["link.history.to-note"].available?(ctx).should be_false
+    ctx.link_flow = 9_i64
+    r["link.history.to-issue"].available?(ctx).should be_true
+    r["link.history.to-note"].available?(ctx).should be_true
+
+    ctx.current_tab = :miner
+    r["link.history.to-issue"].available?(ctx).should be_false # linkable flow, wrong tab
+    r["link.miner.to-issue"].available?(ctx).should be_false   # right tab, no miner session
+    ctx.link_miner = 2_i64
+    r["link.miner.to-issue"].available?(ctx).should be_true
+  end
+end

--- a/spec/verbs/notes_spec.cr
+++ b/spec/verbs/notes_spec.cr
@@ -1,0 +1,52 @@
+require "../spec_helper"
+require "../support/fake_context"
+
+# src/gori/verbs/notes.cr — the Notes tab's space-menu / palette actions.
+private def in_notes(sessions : Int32 = 0) : FakeExecContext
+  ctx = FakeExecContext.new
+  ctx.current_tab = :notes
+  ctx.subtab_search_tab_count = sessions
+  ctx
+end
+
+describe "Gori::Verbs.register_notes" do
+  r = Gori::Verbs.registry
+
+  it "gates every Notes verb on the Notes tab" do
+    elsewhere = FakeExecContext.new # :history
+    {"notes.new"   => :notes_new,
+     "notes.close" => :notes_close,
+     "notes.clear" => :notes_clear,
+     "notes.edit"  => :notes_edit,
+     "notes.goto"  => :notes_goto,
+     "notes.find"  => :notes_find,
+     "notes.links" => :notes_links,
+     "notes.copy"  => :read_copy,
+    }.each do |id, intent|
+      r[id].scope.should eq(Gori::Verb::Scope::Notes)
+      r[id].available?(elsewhere).should be_false
+      r[id].available?(in_notes).should be_true
+      verb_intents(r, id).should eq([intent])
+    end
+  end
+
+  it "keeps every mnemonic distinct within the scope" do
+    # The space menu is a first-match find, so a duplicate key would silently make the
+    # later verb unreachable. Registry#validate_menu_keys! guards this at boot; assert the
+    # Notes scope explicitly since its body swallows every printable key.
+    keys = r.select { |v| v.scope.notes? && !v.hidden? }.compact_map(&.menu_key)
+    keys.should eq(keys.uniq)
+  end
+
+  it "shows the sub-tab search/filter only with two or more notes open" do
+    %w[notes.find-subtab notes.filter-subtabs].each do |id|
+      r[id].section.should eq(:tab)
+      r[id].available?(in_notes(sessions: 1)).should be_false
+      r[id].available?(in_notes(sessions: 2)).should be_true
+    end
+    verb_intents(r, "notes.find-subtab").should eq([:subtab_search_open])
+    verb_intents(r, "notes.filter-subtabs").should eq([:subtab_filter_open])
+    r["notes.duplicate-subtab"].section.should eq(:subtab)
+    verb_intents(r, "notes.duplicate-subtab").should eq([:notes_duplicate_subtab])
+  end
+end

--- a/spec/verbs/oast_spec.cr
+++ b/spec/verbs/oast_spec.cr
@@ -1,0 +1,61 @@
+require "../spec_helper"
+require "../support/fake_context"
+
+# src/gori/verbs/oast.cr — the OAST tab's two sub-tabs (Callbacks / Providers) and the
+# cross-tab "insert a fresh payload" actions.
+describe "Gori::Verbs.register_oast" do
+  r = Gori::Verbs.registry
+
+  it "splits Callbacks and Providers into distinct scopes" do
+    # a/e/t/d on the Providers list must never reach the Callbacks list (and vice versa);
+    # the scope split is what keeps them apart, not an available? predicate.
+    %w[oast.listen oast.stop oast.generate oast.copy oast.filter].each do |id|
+      r[id].scope.should eq(Gori::Verb::Scope::OastCallbacks)
+    end
+    %w[oast.add-provider oast.edit-provider oast.toggle-provider oast.delete-provider].each do |id|
+      r[id].scope.should eq(Gori::Verb::Scope::OastProviders)
+    end
+  end
+
+  it "routes each sub-tab action to its own intent" do
+    {"oast.listen"          => :oast_listen,
+     "oast.stop"            => :oast_stop,
+     "oast.generate"        => :oast_generate,
+     "oast.copy"            => :oast_copy,
+     "oast.filter"          => :oast_filter,
+     "oast.add-provider"    => :oast_add_provider,
+     "oast.edit-provider"   => :oast_edit_provider,
+     "oast.toggle-provider" => :oast_toggle_provider,
+     "oast.delete-provider" => :oast_delete_provider,
+    }.each { |id, intent| verb_intents(r, id).should eq([intent]) }
+  end
+
+  it "escapes back to the tab menu from either sub-tab" do
+    %w[oast.callbacks-to-menu oast.providers-to-menu].each do |id|
+      ctx = FakeExecContext.new
+      r[id].call(ctx)
+      ctx.args_for(:focus_pane).should eq(["menu"])
+      r[id].hidden?.should be_true
+    end
+  end
+
+  it "gates the cross-tab payload verbs on BOTH the host tab and an active listener" do
+    # Without a listener there is no payload to insert, so the verb would be a dead entry
+    # that toasts; without the tab check, Repeater's insert would show up in the Fuzzer.
+    {"repeater.oast-insert" => {:repeater, :oast_insert_payload},
+     "fuzzer.oast-insert"   => {:fuzzer, :oast_insert_payload},
+     "history.oast-copy"    => {:history, :oast_copy_payload},
+    }.each do |id, (tab, intent)|
+      ctx = FakeExecContext.new
+      ctx.current_tab = tab
+      ctx.oast_payload_available = false
+      r[id].available?(ctx).should be_false # right tab, no listener
+      ctx.oast_payload_available = true
+      r[id].available?(ctx).should be_true
+      ctx.current_tab = :issues
+      r[id].available?(ctx).should be_false # listener, wrong tab
+      r[id].menu_key.should eq('O')
+      verb_intents(r, id).should eq([intent])
+    end
+  end
+end

--- a/spec/verbs/probe_spec.cr
+++ b/spec/verbs/probe_spec.cr
@@ -1,0 +1,114 @@
+require "../spec_helper"
+require "../support/fake_context"
+
+# src/gori/verbs/probe.cr — the Probe scan-issue list, the issue detail, and the Rules
+# sub-tab. Triage keys are one-press and destructive-adjacent, so the exact chord each
+# action claims is part of the contract.
+describe "Gori::Verbs.register_probe" do
+  r = Gori::Verbs.registry
+
+  describe "the issue list" do
+    it "moves the selection with a signed delta" do
+      ctx = FakeExecContext.new
+      r["probe.down"].call(ctx)
+      ctx.args_for(:probe_move).should eq(["1"])
+      ctx = FakeExecContext.new
+      r["probe.up"].call(ctx)
+      ctx.args_for(:probe_move).should eq(["-1"])
+    end
+
+    it "claims one distinct chord per triage action" do
+      # A collision here is invisible at runtime (the keymap takes one, the other is dead),
+      # so the mapping is asserted key-by-key.
+      {"probe.filter"            => "/",
+       "probe.mode"              => "m",
+       "probe.dismiss-selected"  => "c",
+       "probe.toggle-closed"     => "a",
+       "probe.open-evidence"     => "o",
+       "probe.repeater-evidence" => "r",
+       "probe.promote-selected"  => "p",
+       "probe.delete-selected"   => "d",
+       "probe.clear"             => "x",
+      }.each do |id, key|
+        r[id].scope.should eq(Gori::Verb::Scope::Probe)
+        r[id].chords.should eq([Gori::Verb::Chord.new(key)])
+      end
+      r["probe.open"].chords.first.should eq(Gori::Verb::Chord.new("enter"))
+      r["probe.open"].menu_key.should eq('v') # 'o' is reserved for open-evidence
+      r["probe.scope-toggle"].chords.should eq([Gori::Verb::Chord.new("s", shift: true)])
+    end
+
+    it "routes each list action to its own intent" do
+      {"probe.open"              => :probe_open,
+       "probe.filter"            => :probe_query,
+       "probe.mode"              => :probe_set_mode,
+       "probe.dismiss-selected"  => :probe_dismiss,
+       "probe.toggle-closed"     => :probe_toggle_closed,
+       "probe.scope-toggle"      => :scope_toggle_lens,
+       "probe.dismiss-code"      => :probe_dismiss_code,
+       "probe.dismiss-host"      => :probe_dismiss_host,
+       "probe.open-evidence"     => :probe_open_flow,
+       "probe.repeater-evidence" => :probe_repeater_flow,
+       "probe.active-rescan"     => :probe_active_rescan,
+       "probe.promote-selected"  => :probe_promote,
+       "probe.delete-selected"   => :probe_delete,
+       "probe.clear"             => :probe_clear,
+      }.each { |id, intent| verb_intents(r, id).should eq([intent]) }
+    end
+
+    it "keeps the BULK dismissals menu-only, so no stray key mutes a whole host" do
+      %w[probe.dismiss-code probe.dismiss-host probe.active-rescan].each do |id|
+        r[id].chords.should be_empty
+      end
+      r["probe.dismiss-code"].menu_key.should eq('g')
+      r["probe.dismiss-host"].menu_key.should eq('h')
+      r["probe.active-rescan"].menu_key.should eq('A') # lowercase 'a' is toggle-closed
+    end
+
+    it "returns focus to the tab menu on escape" do
+      ctx = FakeExecContext.new
+      r["probe.leave"].call(ctx)
+      ctx.args_for(:focus_pane).should eq(["menu"])
+      r["probe.leave"].hidden?.should be_true
+    end
+  end
+
+  describe "the issue detail" do
+    it "mirrors the list's actions on the same keys, in the ProbeDetail scope" do
+      {"probe.open-flow"     => {:probe_open_flow, "o"},
+       "probe.repeater-flow" => {:probe_repeater_flow, "r"},
+       "probe.promote"       => {:probe_promote, "p"},
+       "probe.dismiss"       => {:probe_dismiss, "c"},
+       "probe.delete"        => {:probe_delete, "d"},
+      }.each do |id, (intent, key)|
+        r[id].scope.should eq(Gori::Verb::Scope::ProbeDetail)
+        r[id].chords.should eq([Gori::Verb::Chord.new(key)])
+        verb_intents(r, id).should eq([intent])
+      end
+      verb_intents(r, "probe.close").should eq([:probe_close])
+    end
+  end
+
+  describe "the Rules sub-tab" do
+    it "leaves toggle and add ungated — every rule can be enabled or disabled" do
+      ctx = FakeExecContext.new
+      r["probe-rules.toggle"].available?(ctx).should be_true
+      r["probe-rules.add"].available?(ctx).should be_true
+      r["probe-rules.toggle"].menu_key.should eq('t') # enter/x are its chords
+      verb_intents(r, "probe-rules.toggle").should eq([:probe_rule_toggle])
+      verb_intents(r, "probe-rules.add").should eq([:probe_rule_add])
+    end
+
+    it "gates edit and delete on a CUSTOM rule being selected" do
+      # Built-ins can only be toggled; offering Edit/Delete on one would be a dead action.
+      ctx = FakeExecContext.new
+      r["probe-rules.edit"].available?(ctx).should be_false
+      r["probe-rules.delete"].available?(ctx).should be_false
+      ctx.probe_has_custom_rule = true
+      r["probe-rules.edit"].available?(ctx).should be_true
+      r["probe-rules.delete"].available?(ctx).should be_true
+      verb_intents(r, "probe-rules.edit").should eq([:probe_rule_edit])
+      verb_intents(r, "probe-rules.delete").should eq([:probe_rule_delete])
+    end
+  end
+end

--- a/spec/verbs/read_edit_spec.cr
+++ b/spec/verbs/read_edit_spec.cr
@@ -1,0 +1,117 @@
+require "../spec_helper"
+require "../support/fake_context"
+
+# src/gori/verbs/read_edit.cr — the READ-mode select-line / clear-selection / send-to
+# triple, registered once per scope. Two invariants carry the whole file:
+#   1. select-line is gated on THAT tab's read mode, so 'x' never fires as an action
+#      while the same pane is in edit mode (where 'x' is literal text).
+#   2. send-to must live in :common on every multi-section tab. It is menu-only (no
+#      keybinding fallback), and the space menu shows COMMON ∪ ONE section — tagging it
+#      to a section would hide it while another pane has focus, leaving no way to invoke it.
+describe "Gori::Verbs.register_read_edit" do
+  r = Gori::Verbs.registry
+
+  # {verb prefix, scope, the section select-line/clear-selection are tagged into}
+  per_scope = [
+    {"notes", Gori::Verb::Scope::Notes, :common},
+    {"repeater", Gori::Verb::Scope::Repeater, :response},
+    {"decoder", Gori::Verb::Scope::Decoder, :input},
+    {"fuzzer", Gori::Verb::Scope::Fuzzer, :template},
+    {"jwt", Gori::Verb::Scope::Jwt, :input},
+    {"issue", Gori::Verb::Scope::IssuesDetail, :common},
+    {"project", Gori::Verb::Scope::Body, :common},
+    {"detail", Gori::Verb::Scope::HistoryDetail, :common},
+  ]
+
+  it "registers the triple in every read-mode scope, on the same keys" do
+    per_scope.each do |(prefix, scope, section)|
+      select_line = r["#{prefix}.select-line"]
+      select_line.scope.should eq(scope)
+      select_line.chords.should eq([Gori::Verb::Chord.new("x")])
+      select_line.menu_key.should eq('x')
+      select_line.section.should eq(section)
+
+      clear = r["#{prefix}.clear-selection"]
+      clear.scope.should eq(scope)
+      clear.chords.should be_empty # menu-only; 'v' is the mnemonic, not a chord
+      clear.menu_key.should eq('v')
+      clear.section.should eq(section)
+
+      send_to = r["#{prefix}.send-to"]
+      send_to.scope.should eq(scope)
+      send_to.menu_key.should eq('S') # capital dodges lowercase 's' elsewhere in the scope
+      send_to.section.should eq(:common)
+    end
+  end
+
+  it "dispatches select-line / clear-selection / send-to to the shared read intents" do
+    per_scope.each do |(prefix, _, _)|
+      verb_intents(r, "#{prefix}.select-line").should eq([:read_select_line])
+      verb_intents(r, "#{prefix}.clear-selection").should eq([:read_clear_selection])
+      verb_intents(r, "#{prefix}.send-to").should eq([:send_to_open])
+    end
+  end
+
+  it "gates clear-selection and send-to on an ACTIVE selection, in every scope" do
+    idle = FakeExecContext.new
+    selecting = FakeExecContext.new
+    selecting.selection_active = true
+
+    per_scope.each do |(prefix, _, _)|
+      r["#{prefix}.clear-selection"].available?(idle).should be_false
+      r["#{prefix}.clear-selection"].available?(selecting).should be_true
+      r["#{prefix}.send-to"].available?(idle).should be_false
+      r["#{prefix}.send-to"].available?(selecting).should be_true
+    end
+  end
+
+  it "gates select-line on the tab AND that tab's read mode" do
+    # Notes' fake read mode is always true, so the tab alone decides there; the other
+    # workbench tabs need both. A gate that dropped the read-mode half would make 'x'
+    # select a line while the user is typing an 'x' into the same pane.
+    notes = FakeExecContext.new
+    notes.current_tab = :notes
+    r["notes.select-line"].available?(notes).should be_true
+    notes.current_tab = :decoder
+    r["notes.select-line"].available?(notes).should be_false
+
+    {"repeater" => :repeater, "decoder" => :decoder, "jwt" => :jwt, "fuzzer" => :fuzzer}.each do |prefix, tab|
+      ctx = FakeExecContext.new
+      ctx.current_tab = tab
+      r["#{prefix}.select-line"].available?(ctx).should be_false # right tab, edit mode
+      case prefix
+      when "repeater" then ctx.repeater_read_mode = true
+      when "decoder"  then ctx.decoder_read_mode = true
+      when "jwt"      then ctx.jwt_read_mode = true
+      when "fuzzer"   then ctx.fuzzer_read_mode = true
+      end
+      r["#{prefix}.select-line"].available?(ctx).should be_true
+      ctx.current_tab = :issues
+      r["#{prefix}.select-line"].available?(ctx).should be_false # read mode, wrong tab
+    end
+  end
+
+  it "gates the issue detail's select-line on the notes pane being in read mode" do
+    ctx = FakeExecContext.new
+    r["issue.select-line"].available?(ctx).should be_false
+    ctx.issues_notes_read_mode = true
+    r["issue.select-line"].available?(ctx).should be_true
+  end
+
+  it "gates the History detail's select-line on the pane being navigable" do
+    ctx = FakeExecContext.new
+    r["detail.select-line"].available?(ctx).should be_false
+    ctx.detail_navigable = true
+    r["detail.select-line"].available?(ctx).should be_true
+  end
+
+  it "gates the Project description's select-line on its read pane, not on a tab symbol" do
+    # Project shares Verb::Scope::Body with the History list, so the gate is the pane's own
+    # read-mode flag — current_tab would not distinguish them.
+    ctx = FakeExecContext.new
+    ctx.current_tab = :history
+    r["project.select-line"].available?(ctx).should be_false
+    ctx.project_desc_read_mode = true
+    r["project.select-line"].available?(ctx).should be_true # still :history — the pane decides
+  end
+end

--- a/spec/verbs/registry_sweep_spec.cr
+++ b/spec/verbs/registry_sweep_spec.cr
@@ -1,0 +1,39 @@
+require "../spec_helper"
+require "../support/fake_context"
+
+# Whole-registry invariants over EVERY verb file under src/gori/verbs/, not just one.
+# Kept out of the per-file specs on purpose: a failure here names the offending verb id,
+# and filing it under any single register_* group would send the reader to the wrong file.
+describe "Gori::Verbs.registry (every verb)" do
+  r = Gori::Verbs.registry
+
+  it "registers a non-trivial number of verbs" do
+    # Guards the two sweeps below: if the registry ever came back empty (or nearly so),
+    # `select`/`each` over it would assert nothing and both would pass vacuously.
+    r.size.should be > 100
+  end
+
+  # A verb whose handler dispatches nothing is a dead palette/menu entry: it renders, it
+  # fires, and nothing happens. Nothing in the type system catches that.
+  it "dispatches at least one ExecContext intent per verb" do
+    dead = r.select { |v| verb_intents(r, v.id).empty? }.map(&.id)
+    dead.should be_empty
+  end
+
+  # available? runs on every keypress and on every palette / space-menu render, over a
+  # context whose panes may be empty — a raise there takes the whole TUI down.
+  it "answers available? on a bare context without raising, for every verb" do
+    ctx = FakeExecContext.new
+    answered = r.count { |v| !v.available?(ctx).nil? }
+    answered.should eq(r.size)
+  end
+
+  it "gives every verb a non-empty id, title and description" do
+    # All three are user-visible in the palette; a blank one ships as an unlabelled row.
+    r.each do |v|
+      v.id.should_not be_empty
+      v.title.should_not be_empty
+      v.description.should_not be_empty
+    end
+  end
+end

--- a/spec/verbs/rewriter_spec.cr
+++ b/spec/verbs/rewriter_spec.cr
@@ -1,0 +1,57 @@
+require "../spec_helper"
+require "../support/fake_context"
+
+# src/gori/verbs/rewriter.cr — the Rewriter (Match & Replace) tab's rule list.
+private def in_rewriter(rule : Bool = false) : FakeExecContext
+  ctx = FakeExecContext.new
+  ctx.current_tab = :rewriter
+  ctx.rewriter_rule_selected = rule
+  ctx
+end
+
+describe "Gori::Verbs.register_rewriter" do
+  r = Gori::Verbs.registry
+
+  it "gates every rule action on a SELECTED rule, but leaves add and reload open" do
+    empty = in_rewriter
+    picked = in_rewriter(rule: true)
+
+    %w[rewriter.edit rewriter.toggle rewriter.delete rewriter.move-up
+      rewriter.move-down rewriter.duplicate].each do |id|
+      r[id].available?(empty).should be_false
+      r[id].available?(picked).should be_true
+    end
+    r["rewriter.add"].available?(empty).should be_true
+    r["rewriter.reload"].available?(empty).should be_true
+  end
+
+  it "still requires the Rewriter tab even with a rule selected" do
+    # rewriter_rule_selected? is pane state that survives a tab switch, so the tab half of
+    # the gate is what stops these firing from another tab's Body.
+    ctx = FakeExecContext.new
+    ctx.current_tab = :history
+    ctx.rewriter_rule_selected = true
+    r["rewriter.edit"].available?(ctx).should be_false
+    r["rewriter.add"].available?(ctx).should be_false
+  end
+
+  it "moves a rule in apply order with a signed delta" do
+    # Apply order IS the semantics of a rule set; up/down must not share a sign.
+    ctx = in_rewriter(rule: true)
+    r["rewriter.move-up"].call(ctx)
+    ctx.args_for(:rewriter_move).should eq(["-1"])
+    ctx = in_rewriter(rule: true)
+    r["rewriter.move-down"].call(ctx)
+    ctx.args_for(:rewriter_move).should eq(["1"])
+  end
+
+  it "routes the remaining actions to their own intents" do
+    {"rewriter.add"       => :rewriter_add,
+     "rewriter.edit"      => :rewriter_edit,
+     "rewriter.toggle"    => :rewriter_toggle,
+     "rewriter.delete"    => :rewriter_delete,
+     "rewriter.duplicate" => :rewriter_duplicate,
+     "rewriter.reload"    => :rewriter_reload,
+    }.each { |id, intent| verb_intents(r, id).should eq([intent]) }
+  end
+end

--- a/spec/verbs/sequencer_spec.cr
+++ b/spec/verbs/sequencer_spec.cr
@@ -1,0 +1,64 @@
+require "../spec_helper"
+require "../support/fake_context"
+
+# src/gori/verbs/sequencer.cr — "Send to Sequencer" from four surfaces, plus the
+# Sequencer tab's own run/stop/configure.
+describe "Gori::Verbs.register_sequencer" do
+  r = Gori::Verbs.registry
+
+  it "sends from History only with a flow selected, and from the detail unconditionally" do
+    ctx = FakeExecContext.new # :history, nothing selected
+    r["history.sequence"].available?(ctx).should be_false
+    ctx.selected = 4_i64
+    r["history.sequence"].available?(ctx).should be_true
+    verb_intents(r, "history.sequence").should eq([:sequence_selected])
+    # The detail can only be open over a flow, so it needs no gate — but it must close
+    # first so the overlay doesn't float over the Sequencer tab.
+    verb_intents(r, "detail.sequence").should eq([:close_detail, :sequence_selected])
+  end
+
+  it "sends from Repeater and from the Sitemap through their own intents" do
+    repeater = FakeExecContext.new
+    repeater.current_tab = :repeater
+    r["repeater.sequence"].available?(repeater).should be_true
+    r["repeater.sequence"].available?(FakeExecContext.new).should be_false
+    verb_intents(r, "repeater.sequence").should eq([:sequence_from_repeater])
+
+    # Scope::Sitemap already means the Target/Sitemap sub-tab has focus; a current_tab
+    # predicate would test the retired :sitemap top-level symbol and never fire.
+    r["sitemap.sequence"].scope.should eq(Gori::Verb::Scope::Sitemap)
+    r["sitemap.sequence"].available?(FakeExecContext.new).should be_true
+    verb_intents(r, "sitemap.sequence").should eq([:sequence_from_sitemap])
+  end
+
+  it "shares the 'q' menu key across all four send-to-Sequencer surfaces" do
+    %w[history.sequence detail.sequence repeater.sequence sitemap.sequence].each do |id|
+      r[id].menu_key.should eq('q')
+    end
+  end
+
+  it "gates run / stop / configure on the Sequencer tab" do
+    ctx = FakeExecContext.new
+    ctx.current_tab = :sequencer
+    {"sequence.run"       => :sequence_run,
+     "sequence.stop"      => :sequence_stop,
+     "sequence.configure" => :sequence_configure,
+    }.each do |id, intent|
+      r[id].available?(ctx).should be_true
+      r[id].available?(FakeExecContext.new).should be_false
+      verb_intents(r, id).should eq([intent])
+    end
+  end
+
+  it "shows the sub-tab search/filter only with two or more sessions open" do
+    ctx = FakeExecContext.new
+    ctx.current_tab = :sequencer
+    %w[sequence.find-subtab sequence.filter-subtabs].each do |id|
+      r[id].available?(ctx).should be_false
+      r[id].section.should eq(:tab)
+    end
+    ctx.subtab_search_tab_count = 2
+    r["sequence.find-subtab"].available?(ctx).should be_true
+    r["sequence.filter-subtabs"].available?(ctx).should be_true
+  end
+end

--- a/spec/verbs/sitemap_spec.cr
+++ b/spec/verbs/sitemap_spec.cr
@@ -1,0 +1,56 @@
+require "../spec_helper"
+require "../support/fake_context"
+
+# src/gori/verbs/sitemap.cr — the Sitemap sub-tab (under Target).
+describe "Gori::Verbs.register_sitemap" do
+  r = Gori::Verbs.registry
+
+  it "navigates the tree, leaving `space` free for the action menu" do
+    ctx = FakeExecContext.new
+    r["sitemap.down"].call(ctx)
+    ctx.args_for(:sitemap_move).should eq(["1"])
+    ctx = FakeExecContext.new
+    r["sitemap.up"].call(ctx)
+    ctx.args_for(:sitemap_move).should eq(["-1"])
+
+    verb_intents(r, "sitemap.toggle").should eq([:sitemap_toggle])
+    verb_intents(r, "sitemap.expand").should eq([:sitemap_expand])
+    verb_intents(r, "sitemap.collapse").should eq([:sitemap_collapse])
+    # `enter` toggles; a redundant `space` expand binding would shadow the helix leader.
+    sitemap_verbs = r.select(&.scope.sitemap?)
+    sitemap_verbs.should_not be_empty # else the sweep below asserts nothing
+    sitemap_verbs.each { |v| v.chords.should_not contain(Gori::Verb::Chord.new("space")) }
+  end
+
+  it "routes the tree actions to their own intents" do
+    {"sitemap.query"           => :sitemap_query,
+     "sitemap.tag"             => :sitemap_tag,
+     "sitemap.toggle-grouping" => :sitemap_toggle_grouping,
+     "sitemap.scope-toggle"    => :scope_toggle_lens,
+     "sitemap.discover"        => :sitemap_discover,
+     "sitemap.repeater"        => :sitemap_repeater,
+    }.each { |id, intent| verb_intents(r, id).should eq([intent]) }
+  end
+
+  it "gives the scope toggle an explicit 's' menu key (its only chord is ⇧S)" do
+    verb = r["sitemap.scope-toggle"]
+    verb.chords.should eq([Gori::Verb::Chord.new("s", shift: true)])
+    verb.menu_key.should eq('s') # a shifted chord yields no menu key on its own
+  end
+
+  it "escapes back to the Sitemap/Discover strip, not the tab bar" do
+    ctx = FakeExecContext.new
+    r["sitemap.to-menu"].call(ctx)
+    ctx.args_for(:focus_pane).should eq(["subtabs"])
+  end
+
+  it "leaves every Sitemap verb ungated — the scope alone means the sub-tab has focus" do
+    # command_scope returns Sitemap only when that sub-tab is focused, so a current_tab
+    # predicate here would check the retired :sitemap top-level symbol and never fire.
+    ctx = FakeExecContext.new
+    ctx.current_tab = :target
+    sitemap_verbs = r.select(&.scope.sitemap?)
+    sitemap_verbs.should_not be_empty # else the sweep below asserts nothing
+    sitemap_verbs.each(&.available?(ctx).should(be_true))
+  end
+end


### PR DESCRIPTION
Closes #358 (wave-1 slice).

`src/gori/verbs/` was 1,920 lines of behaviour with **no dedicated spec file** — `spec/verb/` covers the registry/keymap/chord machinery, not the verb bodies. `gori run` was characterised by a single 1,011-line `spec/cli_run_spec.cr` against ~7.9k lines spread over 24 subcommand files.

**Test-only: `src/` is untouched.**

## `verbs/` — 0 → 19 files, 120 examples

`spec/support/fake_context.cr` becomes a **recording** double: its 239 command methods append a `Call(name, args)` instead of no-op'ing. The query half (`*_read_mode?`, `oast_payload_available?`, `link_*_id`, `selected_intercept_id`) is now settable, so **both sides** of every gate can be exercised rather than just the false one.

Each verb asserts two things: the intent it dispatches, and its `available?` gate (P4), which had no test at all. Dispatch **order** is part of the contract where two calls chain — `detail.repeater` closes the detail *before* opening the Repeater, so the overlay doesn't float over the destination tab.

`spec/verbs/registry_sweep_spec.cr` adds whole-registry invariants:
- every verb dispatches at least one intent (a dead palette entry renders, fires, and does nothing — no other symptom)
- every verb answers `available?` on a bare context without raising (it runs on every keypress and every menu render)
- every verb carries a non-empty id/title/description

## `cli/run` — split by subcommand, 45 moved + 68 new

`spec/cli_run_spec.cr` (1,011 → 383 lines) splits into `spec/cli/run/*.cr` mirroring `src/gori/cli/run/`: `history · sitemap · notes · issues · links · decoder · jwt · compare · project · import`. Verified by diffing example titles that nothing was dropped in the move (21 renames, 0 losses).

New coverage worth calling out:

- **CLI ↔ MCP flow-row JSON key parity.** `CLI::Output` is the contract MCP `list_history` and `gori run capture`'s JSON-Lines stream both mirror. Nothing compared them, so a field added to one serializer and not the other was a silent three-surface drift.
- **P7 "never reject malformed input on replay"** (`spec/cli/run/replay_reconstruct_spec.cr`, 20 examples). A head with no terminator, an empty head, a raw space in the request line, bare-CR smuggling, CL+TE together, NUL/8-bit header bytes, the `%%%` group separator — all replay byte-for-byte. A stated design invariant with no test asserting it until now.
- **sitemap JSON survives a path deeper than `JSON::Builder`'s 100-level nesting cap** (80 segments ≈ 160 levels) — the documented reason the emitter is hand-rolled, never asserted.
- **`sitemap tag` keys KEEP the query string**, pinned as a literal rather than re-derived from `normalize_path`, so a regression there can't move both sides of the assertion.

## Verification

- `crystal spec`: **3,869 examples, 0 failures**
- ameba: **0 findings** in `spec/verbs` and `spec/cli`. `spec/support/fake_context.cr` still has exactly its 11 pre-existing `Naming/QueryBoolMethods` findings — none added.
- `crystal tool format --check` flags `spec/proxy/tls/tunnel_spec.cr` and `src/gori/proxy/upstream.cr`; both do so on a clean tree too (Crystal version drift), unrelated to this branch.

## `/code-review` gate

Ran it on the working diff; it returned 15 findings and **14 are fixed in this branch**, including two real ones it verified with a compiled probe:

- `sitemap_tag_path("http://h/a")` — my test was titled *"leaves an absolute-form target alone"* and asserted `eq(normalize_path("http://h/a"))`, i.e. the function against itself. `normalize_path` actually returns `"/a"`, so the title and comment were **backwards** and the assertion could never fail. Now pins `"/a"`.
- the query-preservation test had the same tautology; now pins `"/login?a=1"` literally.

Also fixed: the untested `link.fuzzer.*` gate (its `link_fuzz` property had zero readers — inverting the predicate would have kept the suite green), the assertion-free `available?` sweep, two vacuous `if`-guarded sweeps in `spec/verbs/sitemap_spec.cr`, `args_for` masking a repeated intent, the `dispatched` helper copy-pasted into 18 files (hoisted to `spec/support/`), weaker-duplicate `resolve_all` coverage in `links_spec` (deleted — `spec/links_spec.cr` pins it far more strictly), and a materially wrong header comment on the trimmed `cli_run_spec.cr`.

**Two findings deliberately not acted on**, both because they need files outside this issue's lane:
1. Consolidating the new `FakeExecContext` with the pre-existing `private class FakeContext` in `spec/verb/registry_spec.cr` — a real duplication over the same ~250-method interface, but that file is outside the stated boundary. Worth a follow-up.
2. Dropping `send_to_opened` in favour of the `calls` log — its only reader is `spec/tui/space_menu_spec.cr`, and `tui/` specs are explicitly out of scope while #355 reshapes that code.

## Scope

Per #358's parallelism note, the active-sender subcommands (`repeater send`, `fuzz`/`mine`/`sequence`, `intercept`, `probe`, `oast`, `discover`) stay in `spec/cli_run_spec.cr` until #354/#356 settle their semantics. The file's header now states exactly what remains and why, and names the two `gori run` specs still at the top level (`cli_run_oast_stop_spec.cr`, `cli_run_sequence_tokens_spec.cr`) so the new convention doesn't read as "those are untested".