### PR TITLE
refactor(tui): type `@overlay` as `OverlayKind` and prep the overlay seam (#355 Phase 0)

### DIFF
--- a/spec/support/overlay_harness.cr
+++ b/spec/support/overlay_harness.cr
@@ -1,0 +1,168 @@
+require "../spec_helper"
+require "./memory_backend"
+
+# Drives ONE `Gori::Tui::Overlay` through the exact lifecycle the shell gives it —
+# open → keys / clicks / wheel / IME preedit → commit or cancel — with no terminal and
+# no Runner.
+#
+# The Runner needs a live tty, so it cannot be unit-tested; every migrated modal's spec
+# would otherwise re-derive the shell's generic dispatch by hand (and each slightly
+# differently). This is that dispatch, written once:
+#
+#   * `press` / `click` mirror `Runner#dispatch_overlay_key` / `#dispatch_overlay_click`
+#     LINE FOR LINE — :cancel closes, :commit runs `commit` and closes iff it returns
+#     true, anything else stays open.
+#   * `open?` mirrors whether the shell still holds the modal in `@active_overlay`.
+#   * `commits` counts runs of the injected `on_commit` closure — the open-site behaviour
+#     a migrated modal no longer carries itself.
+#
+# If those Runner methods ever change, change them HERE too: this harness is the
+# spec-side statement of that contract, and a modal spec that passes against a stale
+# harness proves nothing about the real shell.
+#
+# WHAT IT DOES NOT MODEL: the shell's pre-filter. `^C`/`^D` (quit-arm), `^B` (reveal) and
+# the space-menu / copy-as / send-to / `^F` prompts are all claimed in `Runner#handle_key`
+# BEFORE a migrated modal is dispatched to, so those keys never reach an overlay in the
+# real app. Driving them through this harness will "work" here and be dead in the TUI —
+# assert them against the Runner ladder instead.
+#
+# Note that `press`/`click` collapse `:cancel` and a truthy `:commit` to the same
+# `:closed`, because that is what the shell does. An example that cares WHICH one it was
+# must also assert `commits`, or call `overlay.handle_key` directly for the raw vocabulary.
+class OverlayHarness
+  # The body rect the shell hands an overlay. 80x24 is the size every existing overlay
+  # spec centres its card in, so box geometry matches what those specs already assert.
+  DEFAULT_AREA = Gori::Tui::Rect.new(0, 0, 80, 24)
+
+  getter overlay : Gori::Tui::Overlay
+  getter area : Gori::Tui::Rect
+  # Times the injected on_commit ran (a :commit outcome, whether or not it closed).
+  getter commits = 0
+  # The shell still holds this modal — false once a :cancel, or a :commit whose closure
+  # returned true, dropped it.
+  getter? open = true
+
+  # `commit` is what the injected closure reports back to the shell: true = "applied,
+  # close me", false = the validation-rejected path that keeps the form up. Override it
+  # mid-example with `on_commit`.
+  def initialize(@overlay : Gori::Tui::Overlay, *, area : Gori::Tui::Rect = DEFAULT_AREA,
+                 commit : Bool = true)
+    @area = area
+    @commit_result = commit
+    install_commit
+  end
+
+  # Replace the commit outcome (e.g. flip to a rejecting closure part-way through).
+  def commit_result=(ok : Bool)
+    @commit_result = ok
+    install_commit
+  end
+
+  # Inject a bespoke commit closure — still counted in `commits`. Use when the example
+  # needs to observe the overlay's state at commit time (the real open-sites all do).
+  def on_commit(&blk : -> Bool) : Nil
+    @overlay.on_commit = -> {
+      @commits += 1
+      blk.call
+    }
+  end
+
+  private def install_commit : Nil
+    ok = @commit_result
+    on_commit { ok }
+  end
+
+  # One key through the shell's dispatch. Returns :open or :closed — the shell-visible
+  # outcome, NOT the overlay's raw :stay/:commit/:cancel (assert that with
+  # `overlay.handle_key` directly when a spec cares about the vocabulary itself).
+  def press(k : Termisu::Input::Key, char : Char? = nil,
+            ctrl : Bool = false, alt : Bool = false, shift : Bool = false) : Symbol
+    live!
+    dispatch(@overlay.handle_key(event(k, char, ctrl, alt, shift)))
+  end
+
+  # Type a literal string one printable key at a time. Returns the state after the LAST
+  # character.
+  #
+  # CAVEAT: every char rides on Key::LowerA with the real char attached, which is what the
+  # existing overlay specs do and is correct for any field that reads `ev.char`. An overlay
+  # that branches on `ev.key` instead — vim-style j/k nav, a mnemonic matched off the key
+  # rather than the char — will NOT see the key you typed. Drive those with `press` and the
+  # real Input::Key.
+  def type(text : String) : Symbol
+    live!
+    out = :open
+    text.each_char { |c| out = press(Termisu::Input::Key::LowerA, c) }
+    out
+  end
+
+  # Absolute click within `area` (the shell passes raw body coordinates).
+  def click(mx : Int32, my : Int32) : Symbol
+    live!
+    dispatch(@overlay.handle_click(@area, mx, my))
+  end
+
+  # Click at an offset INSIDE the modal card — the readable way to hit a row, since each
+  # overlay puts its first row a different distance below its own box top.
+  def click_in_box(dx : Int32, dy : Int32) : Symbol
+    b = box
+    raise "overlay has no box to click in (overlay_box returned nil)" unless b
+    click(b.x + dx, b.y + dy)
+  end
+
+  # A scroll-wheel notch over the modal, already ±3-scaled like Runner#handle_wheel.
+  def wheel(step : Int32) : Nil
+    @overlay.handle_wheel(step)
+  end
+
+  def preedit(text : String) : Nil
+    @overlay.set_preedit(text)
+  end
+
+  def box : Gori::Tui::Rect?
+    @overlay.overlay_box(@area)
+  end
+
+  # Draw the card into a fresh MemoryBackend sized to `area` and return it, so an example
+  # can assert on what the user actually sees (`mb.contains?("…")`, `mb.row(y)`).
+  def render : MemoryBackend
+    mb = MemoryBackend.new(@area.x + @area.w, @area.y + @area.h)
+    @overlay.render(Gori::Tui::Screen.new(mb), @area)
+    mb
+  end
+
+  def rendered?(text : String) : Bool
+    render.contains?(text)
+  end
+
+  # The chrome the Runner's collapsed title/hint ladders now read off the overlay. Every
+  # migrated modal must supply all three, so assert it once per modal.
+  def assert_chrome(key : Gori::Tui::OverlayKind, title : String) : Nil
+    @overlay.key.should eq(key)
+    @overlay.title.should eq(title)
+    @overlay.hint.should_not be_empty
+  end
+
+  # The shell stops routing input the moment it drops the modal, so an example that keeps
+  # driving a closed overlay is asserting against something the user can no longer touch.
+  private def live! : Nil
+    raise "the overlay is already closed — the shell would have stopped routing input" unless @open
+  end
+
+  private def dispatch(outcome : Symbol) : Symbol
+    case outcome
+    when :cancel then @open = false
+    when :commit then @open = false if @overlay.commit
+    end
+    @open ? :open : :closed
+  end
+
+  private def event(k : Termisu::Input::Key, char : Char?,
+                    ctrl : Bool, alt : Bool, shift : Bool) : Termisu::Event::Key
+    mods = Termisu::Input::Modifier::None
+    mods |= Termisu::Input::Modifier::Ctrl if ctrl
+    mods |= Termisu::Input::Modifier::Alt if alt
+    mods |= Termisu::Input::Modifier::Shift if shift
+    Termisu::Event::Key.new(k, mods, char)
+  end
+end

--- a/spec/tui/overlay_dispatch_spec.cr
+++ b/spec/tui/overlay_dispatch_spec.cr
@@ -1,5 +1,6 @@
 require "../spec_helper"
 require "../support/memory_backend"
+require "../support/overlay_harness"
 
 include Gori::Tui
 
@@ -11,36 +12,38 @@ include Gori::Tui
 #   - commit runs the injected on_commit closure and honours its Bool (false keeps it open)
 #   - title / hint / key supply the chrome the collapsed ladders used to hard-code
 # If this contract holds, migrating the next overlay onto the seam is a local change.
+#
+# Everything below drives the modal through OverlayHarness (spec/support/overlay_harness.cr),
+# which replays Runner#dispatch_overlay_key / #dispatch_overlay_click exactly. A migration
+# batch should reach for the harness rather than re-deriving that dispatch by hand.
 
 private def skey(k : Termisu::Input::Key, char : Char? = nil) : Termisu::Event::Key
   Termisu::Event::Key.new(k, char: char)
 end
 
-# Mirrors Runner#dispatch_overlay_key exactly: returns :closed when the shell would drop
-# the overlay, :open when it stays. This is the seam the Runner drives.
-private def dispatch_key(ov : Overlay, ev : Termisu::Event::Key) : Symbol
-  case ov.handle_key(ev)
-  when :cancel then :closed
-  when :commit then ov.commit ? :closed : :open
-  else              :open
-  end
-end
+# The OverlayKind round-trip spec CANNOT catch a wrong spelling: to_sym and from_sym are
+# generated from the same constants with the same `underscore`, so they agree under any
+# rename. Only a literal list pins the wire names, and they are load-bearing twice over:
+# controllers compare `@host.overlay` against these symbols, and every symbol handed to
+# from_sym now RAISES if it is not a member (it used to be a silent no-op).
+EXPECTED_OVERLAY_SYMS = [
+  :none, :detail, :palette, :issue_new, :confirm, :browser, :choice, :tabs_more,
+  :comparer_pick, :repeater_subtab, :links, :issue_pick, :note_pick, :preferences,
+  :settings, :tabs, :hosts, :env, :hotkeys, :notifications, :probe_active,
+  :discover_config, :discover_headers, :fuzz_set, :fuzz_advanced, :oast_provider,
+  :probe_rule, :rewriter_rule, :ca_import, :import, :scope_rule, :sequence_config,
+  :mine_config,
+]
 
-# Mirrors Runner#dispatch_overlay_click.
-private def dispatch_click(ov : Overlay, area : Rect, mx : Int32, my : Int32) : Symbol
-  case ov.handle_click(area, mx, my)
-  when :cancel then :closed
-  when :commit then ov.commit ? :closed : :open
-  else              :open
-  end
-end
-
-# A minimal Overlay to pin the base-class defaults the Runner leans on.
-private class FakeOverlay < Overlay
+# A minimal Overlay to pin the base-class defaults the Runner leans on. Its `key` has to
+# name a real OverlayKind (that is the type), and Palette is the safe pick: the command
+# palette is explicitly OUT of the migration's scope, so no production Overlay will ever
+# claim it and collide with this double.
+private class StubOverlay < Overlay
   getter renders = 0
 
-  def key : Symbol
-    :fake
+  def key : OverlayKind
+    OverlayKind::Palette
   end
 
   def title : String
@@ -60,23 +63,80 @@ private class FakeOverlay < Overlay
   end
 end
 
+describe "OverlayKind — the state @overlay holds" do
+  it "round-trips every member through the Host facade's Symbol bridge" do
+    OverlayKind.values.each do |k|
+      OverlayKind.from_sym(k.to_sym).should eq(k)
+    end
+  end
+
+  it "spells every member exactly as the Host facade names it" do
+    OverlayKind.values.map(&.to_sym).should eq(EXPECTED_OVERLAY_SYMS)
+  end
+
+  it "resolves every symbol a live call-site hands to from_sym" do
+    # Reaching from_sym with a non-member is an ArgumentError out of handle_key, which the
+    # event loop does not rescue. These are the literals runner.cr and history_controller.cr
+    # actually pass: request_overlay(:detail/:none) and confirm(return_to:).
+    {:none, :detail, :settings, :tabs, :discover_config}.each do |sym|
+      OverlayKind.from_sym(sym).to_sym.should eq(sym)
+    end
+  end
+
+  it "raises on an unknown symbol instead of silently landing on None" do
+    expect_raises(ArgumentError, /unknown overlay kind/) { OverlayKind.from_sym(:probe_rules) }
+  end
+
+  it "leaves migrated modals out of the shell's input-capture list" do
+    # A migration DELETES its member from Runner::MODAL_OVERLAYS — the migrated modal
+    # answers modal_overlay? through active_overlay instead. Leaving a stale member behind
+    # would make the gate true with no overlay object to route to.
+    [OverlayKind::ScopeRule, OverlayKind::SequenceConfig, OverlayKind::MineConfig].each do |k|
+      Runner::MODAL_OVERLAYS.includes?(k).should be_false
+    end
+  end
+
+  it "still captures input for every UNMIGRATED modal" do
+    # The other half of the gate. MODAL_OVERLAYS is the one line all five Phase 1 batches
+    # edit, and an accidental deletion is invisible: the modal still renders, but the shell
+    # stops treating it as capturing, so clicks fall through to the tab body behind the card
+    # and the wheel scrolls that body. Pin the list until each batch removes its own member.
+    unmigrated = OverlayKind.values - [
+      OverlayKind::None, OverlayKind::Detail, # not modals: no card, never capture
+      OverlayKind::ScopeRule, OverlayKind::SequenceConfig, OverlayKind::MineConfig,
+    ]
+    unmigrated.size.should eq(28)
+    unmigrated.each do |k|
+      Runner::MODAL_OVERLAYS.includes?(k).should be_true, "#{k} lost its input-capture gate"
+    end
+  end
+end
+
 describe "Overlay seam — base contract" do
   it "defaults: no box, click dismisses, wheel/preedit are no-ops, commit closes" do
-    ov = FakeOverlay.new
-    area = Rect.new(0, 0, 80, 24)
+    h = OverlayHarness.new(StubOverlay.new)
 
-    ov.overlay_box(area).should be_nil
+    h.box.should be_nil
     # No box → a click can't be inside → the shell dismisses (prior close-on-click-away).
-    ov.handle_click(area, 10, 10).should eq(:cancel)
+    # Assert the RAW vocabulary, not just the harness's :closed: the harness maps both
+    # :cancel and a truthy :commit to :closed, so `eq(:closed)` alone would still pass if
+    # the default flipped to :commit — i.e. if clicking away silently APPLIED the modal.
+    h.overlay.handle_click(h.area, 10, 10).should eq(:cancel)
+    h.click(10, 10).should eq(:closed)
+    h.commits.should eq(0) # dismissing must never run the commit closure
     # No-op hooks must not raise (the Runner calls them unconditionally).
-    ov.handle_wheel(3)
-    ov.set_preedit("한")
-    # No on_commit supplied → commit is a no-op that closes.
-    ov.commit.should be_true
+    h.wheel(3)
+    h.preedit("한")
+  end
+
+  it "commits with no on_commit supplied (the base-class nil branch) " do
+    # The harness always injects a closure, so drive the bare overlay here: an open-site
+    # that supplies no closure must still get a commit that closes rather than raising.
+    StubOverlay.new.commit.should be_true
   end
 
   it "commit runs the injected closure and honours its Bool" do
-    ov = FakeOverlay.new
+    ov = StubOverlay.new
     calls = 0
     ov.on_commit = -> {
       calls += 1
@@ -92,74 +152,60 @@ end
 
 describe "Overlay seam — ScopeRuleOverlay (first migrated modal)" do
   it "exposes the chrome the collapsed ladders used to hard-code" do
-    ov = ScopeRuleOverlay.adding.as(Overlay)
-    ov.key.should eq(:scope_rule)
-    ov.title.should eq("SCOPE RULE")
-    ov.hint.should_not be_empty
+    OverlayHarness.new(ScopeRuleOverlay.adding).assert_chrome(OverlayKind::ScopeRule, "SCOPE RULE")
   end
 
   it "drives open → key → commit → apply(on_commit) → close through the generic dispatch" do
     committed = [] of {String, String, String}
     ov = ScopeRuleOverlay.new(kind: "include", match_type: "host")
-    ov.on_commit = -> {
+    h = OverlayHarness.new(ov)
+    h.on_commit do
       committed << {ov.kind, ov.match_type, ov.pattern}
       true
-    }
-    over = ov.as(Overlay)
+    end
 
     # ↓ ↓ to the pattern row, type a value, ↵ commits.
-    dispatch_key(over, skey(Termisu::Input::Key::Down)).should eq(:open)
-    dispatch_key(over, skey(Termisu::Input::Key::Down)).should eq(:open)
-    "acme.test".each_char { |c| dispatch_key(over, skey(Termisu::Input::Key::LowerA, c)) }
-    dispatch_key(over, skey(Termisu::Input::Key::Enter)).should eq(:closed)
+    h.press(Termisu::Input::Key::Down).should eq(:open)
+    h.press(Termisu::Input::Key::Down).should eq(:open)
+    h.type("acme.test").should eq(:open)
+    h.press(Termisu::Input::Key::Enter).should eq(:closed)
 
     committed.should eq([{"include", "host", "acme.test"}])
+    h.commits.should eq(1)
   end
 
   it "keeps the form open when on_commit reports failure (invalid pattern)" do
     ov = ScopeRuleOverlay.new(kind: "include", match_type: "host")
-    ov.on_commit = -> { false } # apply rejected it
-    over = ov.as(Overlay)
+    h = OverlayHarness.new(ov, commit: false) # apply rejected it
 
     ov.set_selected(3) # Save row
-    dispatch_key(over, skey(Termisu::Input::Key::Enter)).should eq(:open)
+    h.press(Termisu::Input::Key::Enter).should eq(:open)
+    h.commits.should eq(1) # it DID run — it just refused to close
   end
 
   it "esc cancels without committing" do
-    committed = 0
-    ov = ScopeRuleOverlay.adding
-    ov.on_commit = -> {
-      committed += 1
-      true
-    }
-    dispatch_key(ov.as(Overlay), skey(Termisu::Input::Key::Escape)).should eq(:closed)
-    committed.should eq(0)
+    h = OverlayHarness.new(ScopeRuleOverlay.adding)
+    h.press(Termisu::Input::Key::Escape).should eq(:closed)
+    h.commits.should eq(0)
   end
 
   it "click on the Save row commits; a click outside the card dismisses" do
-    committed = 0
-    ov = ScopeRuleOverlay.new(kind: "include", match_type: "host", pattern: "acme.test")
-    ov.on_commit = -> {
-      committed += 1
-      true
-    }
-    over = ov.as(Overlay)
-    area = Rect.new(0, 0, 80, 24)
-    box = ov.overlay_box(area).not_nil!
+    h = OverlayHarness.new(ScopeRuleOverlay.new(kind: "include", match_type: "host", pattern: "acme.test"))
 
     # Save is row index 3 (kind/type/pattern/save); its screen row is box.y + 2 + 3.
-    dispatch_click(over, area, box.x + 3, box.y + 5).should eq(:closed)
-    committed.should eq(1)
+    h.click_in_box(3, 5).should eq(:closed)
+    h.commits.should eq(1)
 
     # A click well outside the centered card is a dismiss (no commit).
-    ov2 = ScopeRuleOverlay.adding.as(Overlay)
-    dispatch_click(ov2, area, 0, 0).should eq(:closed)
+    away = OverlayHarness.new(ScopeRuleOverlay.adding)
+    away.click(0, 0).should eq(:closed)
+    away.commits.should eq(0)
   end
 
   it "wheel over the modal moves the selected field (delegates to move)" do
     ov = ScopeRuleOverlay.adding
     ov.on_save_row?.should be_false
-    ov.as(Overlay).handle_wheel(3) # 3 notches down: kind → type → pattern → save
+    OverlayHarness.new(ov).wheel(3) # 3 notches down: kind → type → pattern → save
     ov.on_save_row?.should be_true
   end
 end
@@ -186,12 +232,10 @@ end
 
 describe "Overlay seam — SequenceConfigOverlay (hard case: 2 open-sites, no flag)" do
   it "exposes chrome + a self-contained handle_key (formerly Runner#handle_sequence_config_key)" do
-    ov = SequenceConfigOverlay.new(seed).as(Overlay)
-    ov.key.should eq(:sequence_config)
-    ov.title.should eq("SEQUENCER")
-    ov.hint.should_not be_empty
+    ov = SequenceConfigOverlay.new(seed)
+    OverlayHarness.new(ov).assert_chrome(OverlayKind::SequenceConfig, "SEQUENCER")
     # esc cancels; ↓ moves; the Start row commits — all owned by the overlay now.
-    ov.handle_key(skey(Termisu::Input::Key::Escape)).should eq(:cancel)
+    ov.as(Overlay).handle_key(skey(Termisu::Input::Key::Escape)).should eq(:cancel)
   end
 
   it "routes the SAME :commit to different apply behaviour purely via the injected closure" do
@@ -199,23 +243,16 @@ describe "Overlay seam — SequenceConfigOverlay (hard case: 2 open-sites, no fl
     # deleted @sequence_reconfigure flag used to do.
     log = [] of String
 
-    new_ov = SequenceConfigOverlay.new(seed)
-    new_ov.on_commit = -> {
-      log << "start_session"
-      true
-    }
-    reconf_ov = SequenceConfigOverlay.new(seed)
-    reconf_ov.on_commit = -> {
-      log << "reconfigure_current"
-      true
-    }
+    new_h = OverlayHarness.new(SequenceConfigOverlay.new(seed))
+    new_h.on_commit { log << "start_session"; true }
+    reconf_h = OverlayHarness.new(SequenceConfigOverlay.new(seed))
+    reconf_h.on_commit { log << "reconfigure_current"; true }
 
     # Drive each to Start (row 5) and commit through the generic shell dispatch.
-    [new_ov, reconf_ov].each do |ov|
-      over = ov.as(Overlay)
-      4.times { dispatch_key(over, skey(Termisu::Input::Key::Down)) } # selector → … → Start
-      ov.on_start_row?.should be_true
-      dispatch_key(over, skey(Termisu::Input::Key::Enter)).should eq(:closed)
+    [new_h, reconf_h].each do |h|
+      4.times { h.press(Termisu::Input::Key::Down) } # selector → … → Start
+      h.overlay.as(SequenceConfigOverlay).on_start_row?.should be_true
+      h.press(Termisu::Input::Key::Enter).should eq(:closed)
     end
 
     log.should eq(["start_session", "reconfigure_current"])
@@ -224,39 +261,29 @@ describe "Overlay seam — SequenceConfigOverlay (hard case: 2 open-sites, no fl
   it "keeps the form open when the token location is unset (valid? gate in commit)" do
     ov = SequenceConfigOverlay.new(seed(loc: nil)) # nothing pre-filled → invalid
     ov.valid?.should be_false
-    # Real open-site gate: reject + keep open, mirroring Runner#commit_sequence.
-    ov.on_commit = -> { ov.valid? }
-    over = ov.as(Overlay)
-    ov.set_selected(5) # Start row
-    dispatch_key(over, skey(Termisu::Input::Key::Enter)).should eq(:open)
+    h = OverlayHarness.new(ov)
+    h.on_commit { ov.valid? } # real open-site gate: reject + keep open, mirroring Runner#commit_sequence
+    ov.set_selected(5)        # Start row
+    h.press(Termisu::Input::Key::Enter).should eq(:open)
   end
 
   it "click on Start commits; a click outside dismisses" do
-    committed = 0
-    ov = SequenceConfigOverlay.new(seed)
-    ov.on_commit = -> {
-      committed += 1
-      true
-    }
-    over = ov.as(Overlay)
-    area = Rect.new(0, 0, 80, 24)
-    box = ov.overlay_box(area).not_nil!
+    h = OverlayHarness.new(SequenceConfigOverlay.new(seed))
     # Start is row index 5; its screen row is box.y + 3 + 5.
-    dispatch_click(over, area, box.x + 3, box.y + 8).should eq(:closed)
-    committed.should eq(1)
+    h.click_in_box(3, 8).should eq(:closed)
+    h.commits.should eq(1)
 
-    dispatch_click(SequenceConfigOverlay.new(seed).as(Overlay), area, 0, 0).should eq(:closed)
+    OverlayHarness.new(SequenceConfigOverlay.new(seed)).click(0, 0).should eq(:closed)
   end
 
   it "routes IME preedit to the selector field (the seam's per-modal-IME promise)" do
     ov = SequenceConfigOverlay.new(seed(loc: nil)) # blank selector, opens on that row
     ov.editing_selector?.should be_true
+    h = OverlayHarness.new(ov)
     # ASCII preedit so the assertion isn't defeated by the width-2 continuation cell a CJK
     # glyph leaves between codepoints in MemoryBackend#row; routing is content-agnostic.
-    ov.as(Overlay).set_preedit("preedithere")
-    mb = MemoryBackend.new(80, 24)
-    ov.render(Screen.new(mb), Rect.new(0, 0, 80, 24))
-    mb.contains?("preedithere").should be_true
+    h.preedit("preedithere")
+    h.rendered?("preedithere").should be_true
   end
 end
 
@@ -276,59 +303,43 @@ end
 
 describe "Overlay seam — MineConfigOverlay (laggard: keys were shell-owned; click toggles rows)" do
   it "exposes chrome + a self-contained handle_key (formerly Runner#handle_mine_config_key)" do
-    ov = MineConfigOverlay.new(mseed).as(Overlay)
-    ov.key.should eq(:mine_config)
-    ov.title.should eq("MINE PARAMS")
-    ov.hint.should_not be_empty
-    ov.handle_key(skey(Termisu::Input::Key::Escape)).should eq(:cancel)
+    ov = MineConfigOverlay.new(mseed)
+    OverlayHarness.new(ov).assert_chrome(OverlayKind::MineConfig, "MINE PARAMS")
+    ov.as(Overlay).handle_key(skey(Termisu::Input::Key::Escape)).should eq(:cancel)
   end
 
   it "commits from the Start row through the generic dispatch" do
-    ran = 0
     ov = MineConfigOverlay.new(mseed)
-    ov.on_commit = -> {
-      ran += 1
-      true
-    }
-    over = ov.as(Overlay)
+    h = OverlayHarness.new(ov)
     # rows: [Query, Json, concurrency, notify, Start] → 4 downs to Start.
-    4.times { dispatch_key(over, skey(Termisu::Input::Key::Down)) }
+    4.times { h.press(Termisu::Input::Key::Down) }
     ov.on_start_row?.should be_true
-    dispatch_key(over, skey(Termisu::Input::Key::Enter)).should eq(:closed)
-    ran.should eq(1)
+    h.press(Termisu::Input::Key::Enter).should eq(:closed)
+    h.commits.should eq(1)
   end
 
   it "keeps the form open when the commit closure rejects (no location selected)" do
     ov = MineConfigOverlay.new(mseed)
-    ov.on_commit = -> { false } # e.g. any_checked? was false
-    ov.set_selected(4)          # Start row
-    dispatch_key(ov.as(Overlay), skey(Termisu::Input::Key::Enter)).should eq(:open)
+    h = OverlayHarness.new(ov, commit: false) # e.g. any_checked? was false
+    ov.set_selected(4)                        # Start row
+    h.press(Termisu::Input::Key::Enter).should eq(:open)
   end
 
   it "click on a location row TOGGLES its checkbox (behaviour preserved from click_mine_config)" do
     ov = MineConfigOverlay.new(mseed)
-    area = Rect.new(0, 0, 80, 24)
-    box = ov.overlay_box(area).not_nil!
+    h = OverlayHarness.new(ov)
     before = ov.build_config.locations.includes?(Gori::Miner::Location::Query)
     # Row 0 (Query) is at box.y + 3; a click there selects AND toggles it.
-    ov.as(Overlay).handle_click(area, box.x + 3, box.y + 3).should eq(:stay)
+    h.click_in_box(3, 3).should eq(:open)
     ov.build_config.locations.includes?(Gori::Miner::Location::Query).should_not eq(before)
   end
 
   it "click on Start commits; a click outside dismisses" do
-    ran = 0
-    ov = MineConfigOverlay.new(mseed)
-    ov.on_commit = -> {
-      ran += 1
-      true
-    }
-    over = ov.as(Overlay)
-    area = Rect.new(0, 0, 80, 24)
-    box = ov.overlay_box(area).not_nil!
+    h = OverlayHarness.new(MineConfigOverlay.new(mseed))
     # Start is row index 4; its screen row is box.y + 3 + 4.
-    dispatch_click(over, area, box.x + 3, box.y + 7).should eq(:closed)
-    ran.should eq(1)
+    h.click_in_box(3, 7).should eq(:closed)
+    h.commits.should eq(1)
 
-    dispatch_click(MineConfigOverlay.new(mseed).as(Overlay), area, 0, 0).should eq(:closed)
+    OverlayHarness.new(MineConfigOverlay.new(mseed)).click(0, 0).should eq(:closed)
   end
 end

--- a/src/gori/tui/mine_config_overlay.cr
+++ b/src/gori/tui/mine_config_overlay.cr
@@ -82,8 +82,8 @@ module Gori::Tui
     end
 
     # --- Overlay contract (see overlay.cr) ---
-    def key : Symbol
-      :mine_config
+    def key : OverlayKind
+      OverlayKind::MineConfig
     end
 
     def title : String

--- a/src/gori/tui/overlay.cr
+++ b/src/gori/tui/overlay.cr
@@ -3,6 +3,77 @@ require "./screen"
 require "./geometry"
 
 module Gori::Tui
+  # Every modal state the shell's `@overlay` can hold. This was a bare `Symbol` with 33
+  # values compared ~96 times across runner.cr, where one mistyped `:probe_rules` was a
+  # silent no-op — an overlay that never opened, never rendered and never captured a key,
+  # with no compiler help. As an enum the same typo is a compile error.
+  #
+  # Members keep the names the symbols had, so the mapping stays obvious: `ProbeRule` is the
+  # Probe custom-rule editor and `Tabs` the tab-bar customizer. `None` is "no modal"; `Detail`
+  # is the History drill-in, which is NOT a capturing modal (see Runner#modal_overlay?).
+  #
+  # `to_sym`/`from_sym` bridge the still-`Symbol` Host facade (TabController's
+  # `request_overlay` / `overlay` / `confirm(return_to:)`). Both are TOTAL: `to_sym` is an
+  # exhaustive `case … in`, so adding a member here fails to compile until it is mapped, and
+  # `from_sym` raises rather than silently landing on `None` — a bad symbol at that seam must
+  # be loud, since silence is the exact failure mode the enum exists to kill.
+  enum OverlayKind
+    None
+    Detail
+    Palette
+    IssueNew
+    Confirm
+    Browser
+    Choice
+    TabsMore
+    ComparerPick
+    RepeaterSubtab
+    Links
+    IssuePick
+    NotePick
+    Preferences
+    Settings
+    Tabs
+    Hosts
+    Env
+    Hotkeys
+    Notifications
+    ProbeActive
+    DiscoverConfig
+    DiscoverHeaders
+    FuzzSet
+    FuzzAdvanced
+    OastProvider
+    ProbeRule
+    RewriterRule
+    CaImport
+    Import
+    ScopeRule
+    SequenceConfig
+    MineConfig
+
+    def to_sym : Symbol
+      {% begin %}
+        case self
+        {% for c in @type.constants %}
+        in OverlayKind::{{ c }} then :{{ c.stringify.underscore.id }}
+        {% end %}
+        end
+      {% end %}
+    end
+
+    def self.from_sym(sym : Symbol) : OverlayKind
+      {% begin %}
+        case sym
+        {% for c in @type.constants %}
+        when :{{ c.stringify.underscore.id }} then OverlayKind::{{ c }}
+        {% end %}
+        else raise ArgumentError.new("unknown overlay kind: #{sym}")
+        end
+      {% end %}
+    end
+  end
+
   # A centered modal overlay the shell floats above the tab body. The Runner owns ONE
   # active overlay (`@active_overlay`) and dispatches to it polymorphically — the same
   # move TabController made for tab bodies, now extended to modals.
@@ -31,10 +102,10 @@ module Gori::Tui
     # it open — e.g. a validation error keeps the form up). Supplied at the open-site.
     property on_commit : Proc(Bool)?
 
-    # The `@overlay` state symbol this modal sets. Kept in sync by the Runner so
-    # `modal_overlay?` and any residual `@overlay ==` checks keep working while the other
-    # overlays migrate onto this base one at a time.
-    abstract def key : Symbol
+    # The `@overlay` state this modal sets. Kept in sync by the Runner so `modal_overlay?`
+    # and any residual `@overlay ==` checks keep working while the other overlays migrate
+    # onto this base one at a time.
+    abstract def key : OverlayKind
 
     # Shell chrome: the focus-badge title (top bar) and the bottom-row key hint. These
     # used to be `case @overlay` entries in the Runner; they now live with the overlay so

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -121,7 +121,9 @@ module Gori::Tui
       # Miner is hidden by default). Settings is loaded (cli.cr) before Runner.new.
       vis = Chrome.visible_tabs(Settings.tab_prefs).map(&.first)
       @active_tab = vis.includes?(:project) ? :project : vis.first
-      @overlay = :none # :none | :palette | :detail | :issue_new | :confirm | :browser | :choice | :tabs_more | :comparer_pick | :repeater_subtab | :links | :issue_pick | :note_pick | :settings | :tabs | :hosts | :env | :hotkeys | :notifications | :mine_config | :sequence_config | :probe_active | :fuzz_set | :fuzz_advanced | :scope_rule | :probe_rule | :rewriter_rule | :ca_import | :import
+      # Which modal (if any) is up. The value set is OverlayKind (see overlay.cr) — it was a
+      # bare Symbol until Phase 0 of #355, where a mistyped state was a silent no-op.
+      @overlay = OverlayKind::None
       # The "space" action menu (helix-style leader popup, bottom-right). Orthogonal
       # to @overlay so it floats over WHATEVER is underneath (the History list, an
       # open detail …) without disturbing that state; the scope is captured at open.
@@ -170,12 +172,12 @@ module Gori::Tui
       # seeded from the persisted default, propagated to History/Repeater each frame.
       @pretty = Settings.pretty_bodies_default
       # A destructive-action guard (delete project / close a sub-tab). When set,
-      # @overlay is :confirm; accepting runs @confirm_action. @confirm_return is the
-      # overlay to restore on close — :none for palette-launched confirms, or the parent
-      # overlay (e.g. :tabs) when the confirm is raised from inside another modal.
+      # @overlay is Confirm; accepting runs @confirm_action. @confirm_return is the
+      # overlay to restore on close — None for palette-launched confirms, or the parent
+      # overlay (e.g. Tabs) when the confirm is raised from inside another modal.
       @confirm = nil.as(ConfirmDialog?)
       @confirm_action = nil.as(Proc(Nil)?)
-      @confirm_return = :none
+      @confirm_return = OverlayKind::None
       # The "open browser" picker (palette → browser.open); @overlay is :browser
       # while it's up.
       @browser_picker = nil.as(BrowserPicker?)
@@ -935,25 +937,25 @@ module Gori::Tui
         return
       end
       case @overlay
-      when :palette          then @palette.set_preedit(text)
-      when :issue_new        then @issue_form.set_preedit(text)
-      when :comparer_pick    then @flow_picker.try(&.set_preedit(text))
-      when :repeater_subtab  then @subtab_picker.try(&.set_preedit(text))
-      when :issue_pick       then @issue_picker.try(&.set_preedit(text))
-      when :note_pick        then @note_picker.try(&.set_preedit(text))
-      when :preferences      then @preferences.set_preedit(text)
-      when :settings         then @settings_view.set_preedit(text)
-      when :hosts            then @hosts_overlay.set_preedit(text)
-      when :env              then @env_overlay.set_preedit(text)
-      when :discover_headers then @discover_headers_overlay.try(&.set_preedit(text))
-      when :fuzz_set         then @fuzz_set_overlay.try(&.set_preedit(text))
-      when :fuzz_advanced    then @fuzz_advanced_overlay.try(&.set_preedit(text))
-      when :oast_provider    then @oast_provider_overlay.try(&.set_preedit(text))
-      when :probe_rule       then @custom_rule_overlay.try(&.set_preedit(text))
-      when :rewriter_rule    then @rewriter_rule_overlay.try(&.set_preedit(text))
-      when :ca_import        then @ca_import_overlay.try(&.set_preedit(text))
-      when :import           then @import_overlay.try(&.set_preedit(text))
-      when :none             then apply_preedit_body(text)
+      when .palette?          then @palette.set_preedit(text)
+      when .issue_new?        then @issue_form.set_preedit(text)
+      when .comparer_pick?    then @flow_picker.try(&.set_preedit(text))
+      when .repeater_subtab?  then @subtab_picker.try(&.set_preedit(text))
+      when .issue_pick?       then @issue_picker.try(&.set_preedit(text))
+      when .note_pick?        then @note_picker.try(&.set_preedit(text))
+      when .preferences?      then @preferences.set_preedit(text)
+      when .settings?         then @settings_view.set_preedit(text)
+      when .hosts?            then @hosts_overlay.set_preedit(text)
+      when .env?              then @env_overlay.set_preedit(text)
+      when .discover_headers? then @discover_headers_overlay.try(&.set_preedit(text))
+      when .fuzz_set?         then @fuzz_set_overlay.try(&.set_preedit(text))
+      when .fuzz_advanced?    then @fuzz_advanced_overlay.try(&.set_preedit(text))
+      when .oast_provider?    then @oast_provider_overlay.try(&.set_preedit(text))
+      when .probe_rule?       then @custom_rule_overlay.try(&.set_preedit(text))
+      when .rewriter_rule?    then @rewriter_rule_overlay.try(&.set_preedit(text))
+      when .ca_import?        then @ca_import_overlay.try(&.set_preedit(text))
+      when .import?           then @import_overlay.try(&.set_preedit(text))
+      when .none?             then apply_preedit_body(text)
       end
     end
 
@@ -972,13 +974,13 @@ module Gori::Tui
       # In hotkey CAPTURE mode ^C/^D are capturable chords (reserved.cr rejects them inline
       # with "Ctrl-C/D quits gori" while staying in capture) — exclude them from the global
       # quit-arm so a stray ^D during a rebind can't silently arm an app quit.
-      capturing_hotkey = @overlay == :hotkeys && @hotkeys_overlay.capturing?
+      capturing_hotkey = @overlay.hotkeys? && @hotkeys_overlay.capturing?
       if (ev.ctrl_c? || (ev.ctrl? && ev.key.lower_d?)) && !capturing_hotkey
         if Settings.confirm_quit?
           # Opt-in (settings:general): a confirm modal replaces the double-press arm. Skip
           # re-opening if the quit confirm is already up (^D then just waits for y/n/esc).
           confirm("QUIT GORI", "Quit gori? (pending edits are committed first)",
-            confirm_label: "quit", danger: true) { quit! } unless @overlay == :confirm
+            confirm_label: "quit", danger: true) { quit! } unless @overlay.confirm?
         elsif @quit_armed
           quit!
         else
@@ -992,7 +994,7 @@ module Gori::Tui
       @toast = nil # clear last action's feedback; a new action may set it again
       # In hotkey CAPTURE mode the next key IS the new binding — intercept it before the
       # ^G/^F/^B guards (and everything else) so those chords can be recorded.
-      return handle_hotkeys_key(ev) if @overlay == :hotkeys && @hotkeys_overlay.capturing?
+      return handle_hotkeys_key(ev) if @overlay.hotkeys? && @hotkeys_overlay.capturing?
       return handle_space_menu_key(ev) if @space_menu_open # the space menu is modal while up
       return handle_copy_as_key(ev) if copy_as_shown?      # the copy-as picker is modal while up
       return handle_send_to_key(ev) if send_to_shown?      # the send-to picker is modal while up
@@ -1000,7 +1002,7 @@ module Gori::Tui
       # The ^F find prompt is modal while up — EXCEPT under its own replace confirm,
       # which must get the keys (the prompt stays open behind it so cancelling doesn't
       # cost you the query you just typed).
-      return handle_search_key(ev) if @search_open && @overlay != :confirm
+      return handle_search_key(ev) if @search_open && !@overlay.confirm?
       return handle_rename_key(ev) if @rename_open     # the sub-tab rename prompt is modal while up
       return handle_tag_edit_key(ev) if @tag_edit_open # the Repeater tag editor is modal while up
       # ^G "go to line" / ^F "find" — both open a bottom prompt for the focused
@@ -1020,83 +1022,83 @@ module Gori::Tui
         toggle_reveal
         return
       end
-      return handle_palette_key(ev) if @overlay == :palette
-      return handle_issue_new_key(ev) if @overlay == :issue_new
-      return handle_confirm_key(ev) if @overlay == :confirm
-      return handle_browser_key(ev) if @overlay == :browser
-      return handle_choice_key(ev) if @overlay == :choice
-      return handle_more_menu_key(ev) if @overlay == :tabs_more
-      return handle_flow_picker_key(ev) if @overlay == :comparer_pick
-      return handle_subtab_picker_key(ev) if @overlay == :repeater_subtab
-      return handle_links_key(ev) if @overlay == :links
-      return handle_issue_picker_key(ev) if @overlay == :issue_pick
-      return handle_note_picker_key(ev) if @overlay == :note_pick
-      return handle_preferences_key(ev) if @overlay == :preferences
+      return handle_palette_key(ev) if @overlay.palette?
+      return handle_issue_new_key(ev) if @overlay.issue_new?
+      return handle_confirm_key(ev) if @overlay.confirm?
+      return handle_browser_key(ev) if @overlay.browser?
+      return handle_choice_key(ev) if @overlay.choice?
+      return handle_more_menu_key(ev) if @overlay.tabs_more?
+      return handle_flow_picker_key(ev) if @overlay.comparer_pick?
+      return handle_subtab_picker_key(ev) if @overlay.repeater_subtab?
+      return handle_links_key(ev) if @overlay.links?
+      return handle_issue_picker_key(ev) if @overlay.issue_pick?
+      return handle_note_picker_key(ev) if @overlay.note_pick?
+      return handle_preferences_key(ev) if @overlay.preferences?
       if PREFS_SUB_EDITORS.includes?(@overlay)
         case @overlay
-        when :settings then handle_settings_key(ev)
-        when :tabs     then handle_tabs_key(ev)
-        when :hosts    then handle_hosts_key(ev)
-        when :env      then handle_env_key(ev)
-        when :hotkeys  then handle_hotkeys_key(ev)
+        when .settings? then handle_settings_key(ev)
+        when .tabs?     then handle_tabs_key(ev)
+        when .hosts?    then handle_hosts_key(ev)
+        when .env?      then handle_env_key(ev)
+        when .hotkeys?  then handle_hotkeys_key(ev)
         end
         settle_sub_editor # closing one opened from Preferences lands back in the modal
         return
       end
-      return handle_notifications_key(ev) if @overlay == :notifications
+      return handle_notifications_key(ev) if @overlay.notifications?
       # Migrated modals (Overlay base) dispatch generically — no per-modal handle_*_key.
       if ov = active_overlay
         dispatch_overlay_key(ov, ev)
         return
       end
-      return handle_probe_active_key(ev) if @overlay == :probe_active
-      return handle_discover_config_key(ev) if @overlay == :discover_config
-      return handle_discover_headers_key(ev) if @overlay == :discover_headers
-      return handle_fuzz_set_key(ev) if @overlay == :fuzz_set
-      return handle_fuzz_advanced_key(ev) if @overlay == :fuzz_advanced
-      return handle_oast_provider_key(ev) if @overlay == :oast_provider
-      return handle_custom_rule_key(ev) if @overlay == :probe_rule
-      return handle_rewriter_rule_key(ev) if @overlay == :rewriter_rule
-      return handle_ca_import_key(ev) if @overlay == :ca_import
-      return handle_import_key(ev) if @overlay == :import
+      return handle_probe_active_key(ev) if @overlay.probe_active?
+      return handle_discover_config_key(ev) if @overlay.discover_config?
+      return handle_discover_headers_key(ev) if @overlay.discover_headers?
+      return handle_fuzz_set_key(ev) if @overlay.fuzz_set?
+      return handle_fuzz_advanced_key(ev) if @overlay.fuzz_advanced?
+      return handle_oast_provider_key(ev) if @overlay.oast_provider?
+      return handle_custom_rule_key(ev) if @overlay.probe_rule?
+      return handle_rewriter_rule_key(ev) if @overlay.rewriter_rule?
+      return handle_ca_import_key(ev) if @overlay.ca_import?
+      return handle_import_key(ev) if @overlay.import?
       # Text-entry modes own Tab (complete) + Esc within themselves — let them run
       # before the global focus ring claims Tab.
-      if @active_tab == :history && @overlay == :none && @focus == :body && history_controller.view.querying?
+      if @active_tab == :history && @overlay.none? && @focus == :body && history_controller.view.querying?
         return if history_controller.handle_query_key(ev)
       end
-      if @active_tab == :target && target_controller.sitemap_active? && @overlay == :none && @focus == :body && sitemap_controller.view.querying?
+      if @active_tab == :target && target_controller.sitemap_active? && @overlay.none? && @focus == :body && sitemap_controller.view.querying?
         return if sitemap_controller.handle_query_key(ev)
       end
-      if @active_tab == :target && target_controller.sitemap_active? && @overlay == :none && @focus == :body && sitemap_controller.view.tagging?
+      if @active_tab == :target && target_controller.sitemap_active? && @overlay.none? && @focus == :body && sitemap_controller.view.tagging?
         return if sitemap_controller.handle_tag_key(ev)
       end
-      if @active_tab == :intercept && @overlay == :none && @focus == :body && intercept_controller.querying?
+      if @active_tab == :intercept && @overlay.none? && @focus == :body && intercept_controller.querying?
         return if intercept_controller.handle_query_key(ev)
       end
-      if @active_tab == :issues && @overlay == :none && @focus == :body && issues_controller.view.querying?
+      if @active_tab == :issues && @overlay.none? && @focus == :body && issues_controller.view.querying?
         return if issues_controller.handle_query_key(ev)
       end
-      if @active_tab == :probe && @overlay == :none && @focus == :body && probe_controller.view.querying?
+      if @active_tab == :probe && @overlay.none? && @focus == :body && probe_controller.view.querying?
         return if probe_controller.handle_query_key(ev)
       end
-      if @active_tab == :oast && @overlay == :none && @focus == :body && oast_controller.cb_filter_editing?
+      if @active_tab == :oast && @overlay.none? && @focus == :body && oast_controller.cb_filter_editing?
         return if oast_controller.handle_cb_filter_key(ev)
       end
       # Sub-tab filter (issue #121): the `/` bar captures keys until Enter/Esc. Opened
       # from the strip (not the body), so it's not gated on @focus. Generic across the
       # workbench tabs — only the active tab's controller can be in filter-edit mode.
-      if @overlay == :none && (ctl = @tabs[@active_tab]?) && ctl.subtab_filter_editing?
+      if @overlay.none? && (ctl = @tabs[@active_tab]?) && ctl.subtab_filter_editing?
         ctl.handle_subtab_filter_key(ev)
         return
       end
-      if @active_tab == :issues && @overlay == :none && @focus == :body && issues_controller.view.detail_open?
+      if @active_tab == :issues && @overlay.none? && @focus == :body && issues_controller.view.detail_open?
         return if issues_controller.handle_detail_key(ev)
       end
       # History detail drill-in: shift+arrows select, space opens the action menu.
-      if @active_tab == :history && @overlay == :detail && @focus == :body
+      if @active_tab == :history && @overlay.detail? && @focus == :body
         return if history_controller.handle_detail_key(ev)
         # PageUp/PageDown/Home/End page the open response/request body (the :detail
-        # overlay is outside the @overlay == :none body-nav path below, so route here).
+        # overlay is outside the @overlay.none? body-nav path below, so route here).
         if delta = page_nav_delta(ev.key)
           history_controller.scroll_detail(delta)
           return
@@ -1104,25 +1106,25 @@ module Gori::Tui
       end
       # The Decoder chain autocomplete owns Tab/↵/↑/↓/Esc while its popup is up —
       # before the focus ring claims Tab. Non-popup keys fall through (return false).
-      if @active_tab == :decoder && @overlay == :none && @focus == :body && decoder_controller.completing?
+      if @active_tab == :decoder && @overlay.none? && @focus == :body && decoder_controller.completing?
         return if decoder_controller.handle_complete_key(ev)
       end
       # The $ENV autocomplete popup in an editor (Repeater request, Fuzzer template) owns
       # Tab/↵/↑/↓/Esc while open — before the focus ring claims Tab, so Tab accepts the
       # suggestion. Non-popup keys fall through (return false) so editing + refilter flow on.
-      if @overlay == :none && @focus == :body && (ac = @tabs[@active_tab]?) && ac.editor_completing?
+      if @overlay.none? && @focus == :body && (ac = @tabs[@active_tab]?) && ac.editor_completing?
         return if ac.handle_editor_complete_key(ev)
       end
       # Editor-style Tab: while actively typing in a text editor, forward Tab inserts a tab
       # (or accepts a suggestion) instead of advancing the focus ring. Shift-Tab (back_tab)
       # is left to the focus ring below, so there's always a keyboard way out of the pane.
-      if @overlay == :none && @focus == :body && ev.key.tab? && (at = @tabs[@active_tab]?) && at.editor_captures_tab?
+      if @overlay.none? && @focus == :body && ev.key.tab? && (at = @tabs[@active_tab]?) && at.editor_captures_tab?
         return if at.handle_editor_tab(ev)
       end
       # Focusable sub-tab strip (Repeater/Notes): ←/→ switch sub-tabs, ↓/↵ drop into
       # the editor, ↑/esc pop to the tab bar. Claimed BEFORE the Tab ring + ^N so the
       # strip owns Tab and its own ^N. @focus is only ever :subtabs for Repeater/Notes.
-      return handle_subtabs_key(ev) if @overlay == :none && @focus == :subtabs
+      return handle_subtabs_key(ev) if @overlay.none? && @focus == :subtabs
 
       # Unified focus ring: Tab / Shift-Tab move focus across the tab bar and the
       # current tab's panes (tab-bar ▸ pane1 ▸ pane2 ▸ tab-bar). Claimed here so it
@@ -1130,7 +1132,7 @@ module Gori::Tui
       # termisu decodes Shift-Tab as the distinct BackTab key (not Tab+shift).
       # The scope add/edit row owns Tab while open (it stays inert) so a stray ↹ can't
       # strand a half-composed rule over the description editor.
-      if @overlay == :none && (ev.key.tab? || ev.key.back_tab?) &&
+      if @overlay.none? && (ev.key.tab? || ev.key.back_tab?) &&
          !(@active_tab == :project && @focus == :body && project_controller.scope_adding?)
         focus_advance(ev.key.back_tab? || ev.shift? ? -1 : 1)
         return
@@ -1138,27 +1140,27 @@ module Gori::Tui
 
       # Ctrl+, opens the unified Preferences modal from anywhere in-app (mirrors the
       # picker's Ctrl+,). Claimed before the keymap so the chord always reaches settings.
-      if @overlay == :none && ev.ctrl? && ev.key.comma?
+      if @overlay.none? && ev.ctrl? && ev.key.comma?
         open_preferences
         return
       end
 
       # ^N opens a new blank repeater whenever the Repeater tab is active — body OR
       # tab-bar focus — so the advertised empty-state shortcut is never a dead key.
-      if @active_tab == :repeater && @overlay == :none && ev.ctrl? && ev.key.lower_n?
+      if @active_tab == :repeater && @overlay.none? && ev.ctrl? && ev.key.lower_n?
         repeater_controller.repeater_new
         return
       end
 
       # ^N opens a new fuzz session from the Fuzzer tab (body OR tab-bar focus).
-      if @active_tab == :fuzzer && @overlay == :none && ev.ctrl? && ev.key.lower_n?
+      if @active_tab == :fuzzer && @overlay.none? && ev.ctrl? && ev.key.lower_n?
         fuzzer_controller.fuzz_new
         return
       end
 
       # ^N opens a new note from the Notes tab (body OR tab-bar focus), mirroring
       # Repeater's new-request shortcut so it's never a dead key.
-      if @active_tab == :notes && @overlay == :none && ev.ctrl? && ev.key.lower_n?
+      if @active_tab == :notes && @overlay.none? && ev.ctrl? && ev.key.lower_n?
         notes_controller.notes_new
         return
       end
@@ -1166,7 +1168,7 @@ module Gori::Tui
       # ^E opens the focused multi-line field in the external editor ($EDITOR /
       # settings:editor). A Body-scope verb would be shadowed by the per-tab handlers
       # below, so claim it inline here. Each target is gated to where it's editable.
-      if @overlay == :none && @focus == :body && ev.ctrl? && ev.key.lower_e?
+      if @overlay.none? && @focus == :body && ev.ctrl? && ev.key.lower_e?
         if @active_tab == :repeater && (v = repeater_controller.current_view) && v.focus == :request
           v.toggle_request_hex if v.request_hex?                                             # commit + drop the hex buffer (external editor is text)
           run_external_editor(v.edit_buffer_text, :request) { |t| v.replace_edit_buffer(t) } # active sub-pane (envelope/decoded)
@@ -1186,7 +1188,7 @@ module Gori::Tui
 
       # Migrated tabs: the controller claims body keys (true = handled). An unmigrated
       # tab is absent from @tabs and falls through to the verb keymap / space menu below.
-      if @overlay == :none && @focus == :body && (c = @tabs[@active_tab]?)
+      if @overlay.none? && @focus == :body && (c = @tabs[@active_tab]?)
         return if c.handle_body_key(ev)
         # PageUp/PageDown/Home/End: page/jump the focused list or read-only pane. These
         # keys never reach the verb keymap (Keybind.from_event doesn't encode them), so
@@ -1277,7 +1279,7 @@ module Gori::Tui
         close_tag_edit if @tag_edit_open
         return
       end
-      return unless renameable_subtabs? && @overlay == :none && !@space_menu_open && !copy_as_shown? && !@rename_open && !@tag_edit_open && subtabs_shown?
+      return unless renameable_subtabs? && @overlay.none? && !@space_menu_open && !copy_as_shown? && !@rename_open && !@tag_edit_open && subtabs_shown?
       sub_rect = BodyChrome.strip_rect(layout.body, strip: true, strip_divider: subtab_strip_divider?)
       return unless sub_rect && sub_rect.contains?(mx, my)
       if seg = Chrome.strip_segments(BodyChrome.tab_row(sub_rect), subtab_labels, current_subtab_index, current_subtab_start, current_subtab_hidden).find { |(_, r)| r.contains?(mx, my) }
@@ -1309,13 +1311,45 @@ module Gori::Tui
       click_body(layout.body, mx, my) if layout.body.contains?(mx, my)
     end
 
-    # The overlays that fully capture input (a centered card); :detail and :none do not.
+    # The overlays that fully capture input (a centered card); Detail and None do not.
+    # Migrated modals are absent: they answer through `active_overlay` instead (Overlay seam),
+    # so a migration DELETES its member here. One member per line on purpose — this is the
+    # input-capture gate every migration batch edits, and five parallel batches deleting from
+    # a single packed line would conflict on every merge.
+    MODAL_OVERLAYS = {
+      OverlayKind::Palette,
+      OverlayKind::IssueNew,
+      OverlayKind::Confirm,
+      OverlayKind::Browser,
+      OverlayKind::Choice,
+      OverlayKind::TabsMore,
+      OverlayKind::ComparerPick,
+      OverlayKind::RepeaterSubtab,
+      OverlayKind::Links,
+      OverlayKind::IssuePick,
+      OverlayKind::NotePick,
+      OverlayKind::Preferences,
+      OverlayKind::Settings,
+      OverlayKind::Tabs,
+      OverlayKind::Hosts,
+      OverlayKind::Env,
+      OverlayKind::Hotkeys,
+      OverlayKind::Notifications,
+      OverlayKind::ProbeActive,
+      OverlayKind::DiscoverConfig,
+      OverlayKind::DiscoverHeaders,
+      OverlayKind::FuzzSet,
+      OverlayKind::FuzzAdvanced,
+      OverlayKind::OastProvider,
+      OverlayKind::ProbeRule,
+      OverlayKind::RewriterRule,
+      OverlayKind::CaImport,
+      OverlayKind::Import,
+    }
+
     private def modal_overlay? : Bool
       return true if active_overlay # migrated modals capture input via the Overlay seam
-      case @overlay
-      when :palette, :issue_new, :confirm, :browser, :choice, :tabs_more, :comparer_pick, :repeater_subtab, :links, :issue_pick, :note_pick, :preferences, :settings, :tabs, :hosts, :env, :hotkeys, :notifications, :probe_active, :discover_config, :discover_headers, :fuzz_set, :fuzz_advanced, :oast_provider, :probe_rule, :rewriter_rule, :ca_import, :import then true
-      else                                                                                                                                                                                                                                                                                                                                                                false
-      end
+      MODAL_OVERLAYS.includes?(@overlay)
     end
 
     # Click the top tab bar: switch to the clicked tab and land focus on the bar
@@ -1405,34 +1439,34 @@ module Gori::Tui
         return
       end
       case @overlay
-      when :palette          then click_palette(area, mx, my)
-      when :browser          then click_browser(area, mx, my)
-      when :choice           then click_choice(area, mx, my)
-      when :tabs_more        then click_more_menu(layout, mx, my)
-      when :comparer_pick    then click_flow_picker(area, mx, my)
-      when :repeater_subtab  then click_subtab_picker(area, mx, my)
-      when :links            then click_links(area, mx, my)
-      when :issue_pick       then click_issue_picker(area, mx, my)
-      when :note_pick        then click_note_picker(area, mx, my)
-      when :confirm          then click_confirm(area, mx, my)
-      when :preferences      then apply_preferences_outcome(@preferences.click(area, mx, my))
-      when :settings         then (click_settings(area, mx, my); settle_sub_editor)
-      when :tabs             then (click_tabs(area, mx, my); settle_sub_editor)
-      when :hosts            then (click_hosts(area, mx, my); settle_sub_editor)
-      when :env              then (click_env(area, mx, my); settle_sub_editor)
-      when :hotkeys          then (click_hotkeys(area, mx, my); settle_sub_editor)
-      when :notifications    then click_notifications(area, mx, my)
-      when :probe_active     then click_probe_active(area, mx, my)
-      when :discover_config  then click_discover_config(area, mx, my)
-      when :discover_headers then click_discover_headers(area, mx, my)
-      when :fuzz_set         then click_fuzz_set(area, mx, my)
-      when :fuzz_advanced    then click_fuzz_advanced(area, mx, my)
-      when :oast_provider    then click_oast_provider(area, mx, my)
-      when :probe_rule       then click_custom_rule(area, mx, my)
-      when :rewriter_rule    then click_rewriter_rule(area, mx, my)
-      when :ca_import        then click_ca_import(area, mx, my)
-      when :import           then click_import(area, mx, my)
-        # :issue_new is a text form — keyboard-only in Phase 1 (cursor placement is Phase 2)
+      when .palette?          then click_palette(area, mx, my)
+      when .browser?          then click_browser(area, mx, my)
+      when .choice?           then click_choice(area, mx, my)
+      when .tabs_more?        then click_more_menu(layout, mx, my)
+      when .comparer_pick?    then click_flow_picker(area, mx, my)
+      when .repeater_subtab?  then click_subtab_picker(area, mx, my)
+      when .links?            then click_links(area, mx, my)
+      when .issue_pick?       then click_issue_picker(area, mx, my)
+      when .note_pick?        then click_note_picker(area, mx, my)
+      when .confirm?          then click_confirm(area, mx, my)
+      when .preferences?      then apply_preferences_outcome(@preferences.click(area, mx, my))
+      when .settings?         then (click_settings(area, mx, my); settle_sub_editor)
+      when .tabs?             then (click_tabs(area, mx, my); settle_sub_editor)
+      when .hosts?            then (click_hosts(area, mx, my); settle_sub_editor)
+      when .env?              then (click_env(area, mx, my); settle_sub_editor)
+      when .hotkeys?          then (click_hotkeys(area, mx, my); settle_sub_editor)
+      when .notifications?    then click_notifications(area, mx, my)
+      when .probe_active?     then click_probe_active(area, mx, my)
+      when .discover_config?  then click_discover_config(area, mx, my)
+      when .discover_headers? then click_discover_headers(area, mx, my)
+      when .fuzz_set?         then click_fuzz_set(area, mx, my)
+      when .fuzz_advanced?    then click_fuzz_advanced(area, mx, my)
+      when .oast_provider?    then click_oast_provider(area, mx, my)
+      when .probe_rule?       then click_custom_rule(area, mx, my)
+      when .rewriter_rule?    then click_rewriter_rule(area, mx, my)
+      when .ca_import?        then click_ca_import(area, mx, my)
+      when .import?           then click_import(area, mx, my)
+        # IssueNew is a text form — keyboard-only in Phase 1 (cursor placement is Phase 2)
       end
     end
 
@@ -1467,7 +1501,7 @@ module Gori::Tui
 
     private def click_notifications(area : Rect, mx : Int32, my : Int32) : Nil
       box = @notifications_overlay.overlay_box(area)
-      return (@overlay = :none) if box.nil? || dismiss_zone?(box, mx, my)
+      return (@overlay = OverlayKind::None) if box.nil? || dismiss_zone?(box, mx, my)
       if idx = @notifications_overlay.row_at(box, mx, my)
         @notifications_overlay.set_selected(idx)
         open_notification_goto
@@ -1595,7 +1629,7 @@ module Gori::Tui
     # esc); a row click selects it (toggle/reorder stay keyboard-driven).
     private def click_tabs(area : Rect, mx : Int32, my : Int32) : Nil
       box = @tabs_overlay.overlay_box(area)
-      return (@overlay = :none) if box.nil? || dismiss_zone?(box, mx, my)
+      return (@overlay = OverlayKind::None) if box.nil? || dismiss_zone?(box, mx, my)
       if idx = @tabs_overlay.row_at(box, mx, my)
         @tabs_overlay.set_selected(idx)
       end
@@ -1605,7 +1639,7 @@ module Gori::Tui
     # (add/edit/delete stay keyboard-driven).
     private def click_hosts(area : Rect, mx : Int32, my : Int32) : Nil
       box = @hosts_overlay.overlay_box(area)
-      return (@overlay = :none) if box.nil? || dismiss_zone?(box, mx, my)
+      return (@overlay = OverlayKind::None) if box.nil? || dismiss_zone?(box, mx, my)
       if idx = @hosts_overlay.row_at(box, mx, my)
         @hosts_overlay.set_selected(idx)
       end
@@ -1613,7 +1647,7 @@ module Gori::Tui
 
     private def click_env(area : Rect, mx : Int32, my : Int32) : Nil
       box = @env_overlay.overlay_box(area)
-      return (@overlay = :none) if box.nil? || dismiss_zone?(box, mx, my)
+      return (@overlay = OverlayKind::None) if box.nil? || dismiss_zone?(box, mx, my)
       if idx = @env_overlay.row_at(box, mx, my)
         @env_overlay.set_selected(idx)
       end
@@ -1623,7 +1657,7 @@ module Gori::Tui
     # row click selects that binding (rebind/unbind/reset stay keyboard-driven).
     private def click_hotkeys(area : Rect, mx : Int32, my : Int32) : Nil
       box = @hotkeys_overlay.overlay_box(area)
-      return (@overlay = :none) if box.nil? || dismiss_zone?(box, mx, my)
+      return (@overlay = OverlayKind::None) if box.nil? || dismiss_zone?(box, mx, my)
       if idx = @hotkeys_overlay.row_at(box, mx, my)
         @hotkeys_overlay.set_selected(idx)
       end
@@ -1642,7 +1676,7 @@ module Gori::Tui
         @resized = true
         @theme_restore = nil
       end
-      @overlay = :none
+      @overlay = OverlayKind::None
     end
 
     # Apply the persisted Mouse setting to the live terminal (both calls are
@@ -1674,31 +1708,31 @@ module Gori::Tui
         return
       end
       case @overlay
-      when :palette         then @palette.move(step)
-      when :browser         then @browser_picker.try(&.move(step))
-      when :choice          then @choice_picker.try(&.move(step))
-      when :tabs_more       then @more_menu.try(&.move(step))
-      when :comparer_pick   then @flow_picker.try(&.move(step))
-      when :repeater_subtab then @subtab_picker.try(&.move(step))
-      when :links           then @links_overlay.try(&.move(step))
-      when :issue_pick      then @issue_picker.try(&.move(step))
-      when :note_pick       then @note_picker.try(&.move(step))
-      when :preferences     then @preferences.wheel(step)
-      when :settings        then (@settings_view.move_field(step); preview_theme) # wheel scrolls the theme list too
-      when :tabs            then @tabs_overlay.select_move(step)
-      when :hosts           then @hosts_overlay.select_move(step)
-      when :env             then @env_overlay.select_move(step)
-      when :hotkeys         then @hotkeys_overlay.select_move(step)
-      when :notifications   then @notifications_overlay.select_move(step)
-      when :probe_active    then @probe_active_overlay.try(&.move(step))
-      when :discover_config then @discover_config_overlay.try(&.move(step))
-      when :fuzz_set        then @fuzz_set_overlay.try(&.move(step))
-      when :fuzz_advanced   then @fuzz_advanced_overlay.try(&.move(step))
-      when :oast_provider   then @oast_provider_overlay.try(&.move(step))
-      when :probe_rule      then @custom_rule_overlay.try(&.move(step))
-      when :rewriter_rule   then @rewriter_rule_overlay.try(&.move(step))
-      when :ca_import       then @ca_import_overlay.try(&.move(step))
-      when :import          then @import_overlay.try(&.move(step))
+      when .palette?         then @palette.move(step)
+      when .browser?         then @browser_picker.try(&.move(step))
+      when .choice?          then @choice_picker.try(&.move(step))
+      when .tabs_more?       then @more_menu.try(&.move(step))
+      when .comparer_pick?   then @flow_picker.try(&.move(step))
+      when .repeater_subtab? then @subtab_picker.try(&.move(step))
+      when .links?           then @links_overlay.try(&.move(step))
+      when .issue_pick?      then @issue_picker.try(&.move(step))
+      when .note_pick?       then @note_picker.try(&.move(step))
+      when .preferences?     then @preferences.wheel(step)
+      when .settings?        then (@settings_view.move_field(step); preview_theme) # wheel scrolls the theme list too
+      when .tabs?            then @tabs_overlay.select_move(step)
+      when .hosts?           then @hosts_overlay.select_move(step)
+      when .env?             then @env_overlay.select_move(step)
+      when .hotkeys?         then @hotkeys_overlay.select_move(step)
+      when .notifications?   then @notifications_overlay.select_move(step)
+      when .probe_active?    then @probe_active_overlay.try(&.move(step))
+      when .discover_config? then @discover_config_overlay.try(&.move(step))
+      when .fuzz_set?        then @fuzz_set_overlay.try(&.move(step))
+      when .fuzz_advanced?   then @fuzz_advanced_overlay.try(&.move(step))
+      when .oast_provider?   then @oast_provider_overlay.try(&.move(step))
+      when .probe_rule?      then @custom_rule_overlay.try(&.move(step))
+      when .rewriter_rule?   then @rewriter_rule_overlay.try(&.move(step))
+      when .ca_import?       then @ca_import_overlay.try(&.move(step))
+      when .import?          then @import_overlay.try(&.move(step))
       end
     end
 
@@ -1707,10 +1741,10 @@ module Gori::Tui
       key = ev.key
       c = ev.char
       if ev.ctrl? && key.lower_p?
-        @overlay = :none
+        @overlay = OverlayKind::None
         open_palette
       elsif key.escape?
-        @overlay = :none
+        @overlay = OverlayKind::None
       elsif key.up?
         @notifications_overlay.select_move(-1)
       elsif key.down?
@@ -1798,7 +1832,7 @@ module Gori::Tui
 
     private def close_active_overlay : Nil
       @active_overlay = nil
-      @overlay = :none
+      @overlay = OverlayKind::None
     end
 
     # The active migrated modal, but ONLY while @overlay still names it. @overlay is the
@@ -1806,7 +1840,7 @@ module Gori::Tui
     # (dismiss, tab jump, confirm return, …) without touching @active_overlay. Gating every
     # read here means such a reset makes the overlay inert (no render, no input capture) —
     # the pre-seam fail-safe — instead of a zombie that keeps drawing/capturing with
-    # @overlay == :none. Not reachable today (a live modal captures all input), but the
+    # @overlay.none?. Not reachable today (a live modal captures all input), but the
     # render/modal_overlay?/dispatch reads are authoritative, so this keeps the invariant
     # honest by construction rather than by convention.
     private def active_overlay : Overlay?
@@ -1841,7 +1875,7 @@ module Gori::Tui
     end
 
     private def close_ca_import : Nil
-      @overlay = :none
+      @overlay = OverlayKind::None
       @ca_import_overlay = nil
     end
 
@@ -1900,7 +1934,7 @@ module Gori::Tui
     end
 
     private def close_oast_provider : Nil
-      @overlay = :none
+      @overlay = OverlayKind::None
       @oast_provider_overlay = nil
     end
 
@@ -1920,7 +1954,7 @@ module Gori::Tui
     end
 
     private def close_custom_rule : Nil
-      @overlay = :none
+      @overlay = OverlayKind::None
       @custom_rule_overlay = nil
     end
 
@@ -1967,20 +2001,20 @@ module Gori::Tui
     end
 
     private def close_rewriter_rule : Nil
-      @overlay = :none
+      @overlay = OverlayKind::None
       @rewriter_rule_overlay = nil
       @rewriter_preview_sig = ""
     end
 
     private def apply_close_fuzz_set(ov : FuzzSetOverlay) : Nil
       fuzzer_controller.apply_fuzz_set(ov.edit_index, ov.build_spec)
-      @overlay = :none
+      @overlay = OverlayKind::None
       @fuzz_set_overlay = nil
     end
 
     private def apply_close_fuzz_advanced(ov : FuzzAdvancedOverlay) : Nil
       fuzzer_controller.apply_fuzz_advanced(ov.snapshot)
-      @overlay = :none
+      @overlay = OverlayKind::None
       @fuzz_advanced_overlay = nil
     end
 
@@ -1993,7 +2027,7 @@ module Gori::Tui
         # Drop a pending link-from-picker ref so a later standalone create doesn't
         # silently attach the stale workbench item.
         @link_pending_ref = nil
-        @overlay = :none
+        @overlay = OverlayKind::None
       when key.enter?     then create_issue_from_form
       when key.tab?       then @issue_form.severity_cycle(1)
       when key.back_tab?  then @issue_form.severity_cycle(-1)
@@ -2029,14 +2063,16 @@ module Gori::Tui
     # vs stay after create-and-link). `return_to` is the overlay restored on
     # close — leave it :none for a palette-launched confirm, or pass the parent
     # modal (e.g. :tabs) when raising the confirm from inside another overlay.
+    # It stays a Symbol because it is part of the Host facade (tab_controller.cr), which
+    # controllers still speak; from_sym is the total, loud-on-typo bridge to OverlayKind.
     def confirm(title : String, message : String, *, confirm_label : String = "delete",
                 cancel_label : String = "cancel",
                 danger : Bool = true, return_to : Symbol = :none, &action : -> Nil) : Nil
       @confirm = ConfirmDialog.new(title, message, confirm_label: confirm_label,
         cancel_label: cancel_label, danger: danger)
       @confirm_action = action
-      @confirm_return = return_to
-      @overlay = :confirm
+      @confirm_return = OverlayKind.from_sym(return_to)
+      @overlay = OverlayKind::Confirm
     end
 
     private def run_confirm : Nil
@@ -2049,7 +2085,7 @@ module Gori::Tui
       @overlay = @confirm_return
       @confirm = nil
       @confirm_action = nil
-      @confirm_return = :none
+      @confirm_return = OverlayKind::None
     end
 
     # "Open browser" overlay: ↑/↓ pick, ↵ launch the selected browser, esc cancel.
@@ -2064,7 +2100,7 @@ module Gori::Tui
     end
 
     private def close_browser_picker : Nil
-      @overlay = :none
+      @overlay = OverlayKind::None
       @browser_picker = nil
     end
 
@@ -2141,7 +2177,7 @@ module Gori::Tui
     end
 
     private def close_choice_picker : Nil
-      @overlay = :none
+      @overlay = OverlayKind::None
       @choice_picker = nil
     end
 
@@ -2169,7 +2205,7 @@ module Gori::Tui
       when :repeater
         repeater_controller.copy_as_menu
       when :history
-        @overlay == :detail ? history_controller.detail_copy_as_menu : {"COPY AS", [] of CopyMenu::Option}
+        @overlay.detail? ? history_controller.detail_copy_as_menu : {"COPY AS", [] of CopyMenu::Option}
       else
         {"COPY AS", [] of CopyMenu::Option}
       end
@@ -2365,7 +2401,7 @@ module Gori::Tui
 
     private def close_flow_picker : Nil
       owner = @link_add_owner
-      @overlay = :none
+      @overlay = OverlayKind::None
       @flow_picker = nil
       @link_add_owner = nil
       @link_add_ref_kind = nil
@@ -2447,7 +2483,7 @@ module Gori::Tui
         owner_kind, owner_id = owner
         open_links_overlay(owner_kind, owner_id)
       else
-        @overlay = :none
+        @overlay = OverlayKind::None
       end
     end
 
@@ -2492,7 +2528,7 @@ module Gori::Tui
     end
 
     private def close_links_overlay : Nil
-      @overlay = :none
+      @overlay = OverlayKind::None
       @links_overlay = nil
       @link_add_owner = nil
       @link_add_ref_kind = nil
@@ -2502,7 +2538,7 @@ module Gori::Tui
       lo = LinksOverlay.new(owner_kind, owner_id)
       lo.reload(@session.store)
       @links_overlay = lo
-      @overlay = :links
+      @overlay = OverlayKind::Links
     end
 
     private def open_selected_link(lo : LinksOverlay) : Nil
@@ -2533,7 +2569,7 @@ module Gori::Tui
       @link_add_ref_kind = Store::LinkRefKind::Flow
       rows = @session.store.recent_flows(500)
       @flow_picker = FlowPicker.new(rows, :link)
-      @overlay = :comparer_pick
+      @overlay = OverlayKind::ComparerPick
       lo.stop_add
     end
 
@@ -2543,7 +2579,7 @@ module Gori::Tui
       @link_add_owner = {lo.owner_kind, lo.owner_id}
       @link_add_ref_kind = Store::LinkRefKind::Repeater
       @subtab_picker = SubtabPicker.new("PICK REPEATER", rows, action: "link")
-      @overlay = :repeater_subtab
+      @overlay = OverlayKind::RepeaterSubtab
       lo.stop_add
     end
 
@@ -2553,7 +2589,7 @@ module Gori::Tui
       @link_add_owner = {lo.owner_kind, lo.owner_id}
       @link_add_ref_kind = Store::LinkRefKind::Fuzz
       @subtab_picker = SubtabPicker.new("PICK FUZZ", rows, action: "link")
-      @overlay = :repeater_subtab
+      @overlay = OverlayKind::RepeaterSubtab
       lo.stop_add
     end
 
@@ -2563,7 +2599,7 @@ module Gori::Tui
       @link_add_owner = {lo.owner_kind, lo.owner_id}
       @link_add_ref_kind = Store::LinkRefKind::Miner
       @subtab_picker = SubtabPicker.new("PICK MINER", rows, action: "link")
-      @overlay = :repeater_subtab
+      @overlay = OverlayKind::RepeaterSubtab
       lo.stop_add
     end
 
@@ -2628,12 +2664,12 @@ module Gori::Tui
       if ref && ref[0].flow?
         if row = @session.store.flow_row(ref[1])
           @issue_form = IssueForm.new("#{row.method} #{row.target}", row.host, ref[1])
-          @overlay = :issue_new
+          @overlay = OverlayKind::IssueNew
           return
         end
       end
       @issue_form = IssueForm.new
-      @overlay = :issue_new
+      @overlay = OverlayKind::IssueNew
     end
 
     private def click_issue_picker(area : Rect, mx : Int32, my : Int32) : Nil
@@ -2647,7 +2683,7 @@ module Gori::Tui
     end
 
     private def close_issue_picker : Nil
-      @overlay = :none
+      @overlay = OverlayKind::None
       @issue_picker = nil
       @link_pending_ref = nil
     end
@@ -2712,14 +2748,14 @@ module Gori::Tui
           navigate_to_created_note(id)
         end
       else
-        @overlay = :none
+        @overlay = OverlayKind::None
       end
     end
 
     private def navigate_to_created_issue(id : Int64) : Nil
       @active_tab = :issues
       @focus = :body
-      @overlay = :none
+      @overlay = OverlayKind::None
       if issues_controller.view.open_by_id(@session.store, id)
         @toast = "opened issue ##{id}"
       else
@@ -2731,7 +2767,7 @@ module Gori::Tui
     private def navigate_to_created_note(id : Int64) : Nil
       @active_tab = :notes
       @focus = :body
-      @overlay = :none
+      @overlay = OverlayKind::None
       if notes_controller.view.switch_note_by_id(id)
         notes_controller.refresh_link_preview
         @toast = "opened note"
@@ -2751,7 +2787,7 @@ module Gori::Tui
     end
 
     private def close_note_picker : Nil
-      @overlay = :none
+      @overlay = OverlayKind::None
       @note_picker = nil
       @link_pending_ref = nil
     end
@@ -2774,7 +2810,7 @@ module Gori::Tui
         if history_controller.view.open_detail_id(ref_id, @session.store)
           @active_tab = :history
           @focus = :body
-          @overlay = :detail
+          @overlay = OverlayKind::Detail
         else
           @toast = "flow no longer captured"
         end
@@ -2890,10 +2926,10 @@ module Gori::Tui
     private def handle_tabs_key(ev : Termisu::Event::Key) : Nil
       key = ev.key
       if ev.ctrl? && key.lower_p?
-        @overlay = :none
+        @overlay = OverlayKind::None
         open_palette
       elsif key.escape?
-        @overlay = :none # discard the working copy
+        @overlay = OverlayKind::None # discard the working copy
       elsif key.enter?
         save_tabs
       elsif key.up? && ev.shift?
@@ -2928,7 +2964,7 @@ module Gori::Tui
     private def save_tabs : Nil
       Settings.tab_prefs = @tabs_overlay.to_prefs
       ok = Settings.save
-      @overlay = :none
+      @overlay = OverlayKind::None
       @resized = true
       # Snap off a now-hidden active tab. Use the GENUINE visibility (no force:) for this
       # decision — effective_tabs force-includes the active tab, which would mask the hide.
@@ -2959,10 +2995,10 @@ module Gori::Tui
       key = ev.key
       c = ev.char || key.to_char
       if ev.ctrl? && key.lower_p?
-        @overlay = :none
+        @overlay = OverlayKind::None
         open_palette
       elsif key.escape?
-        @overlay = :none
+        @overlay = OverlayKind::None
       elsif key.up? || key.lower_k?
         @hosts_overlay.select_move(-1)
       elsif key.down? || key.lower_j?
@@ -3029,10 +3065,10 @@ module Gori::Tui
       key = ev.key
       c = ev.char || key.to_char
       if ev.ctrl? && key.lower_p?
-        @overlay = :none
+        @overlay = OverlayKind::None
         open_palette
       elsif key.escape?
-        @overlay = :none
+        @overlay = OverlayKind::None
       elsif key.up? || key.lower_k?
         @env_overlay.select_move(-1)
       elsif key.down? || key.lower_j?
@@ -3140,10 +3176,10 @@ module Gori::Tui
     private def handle_hotkeys_browse(ev : Termisu::Event::Key) : Nil
       key = ev.key
       if ev.ctrl? && key.lower_p?
-        @overlay = :none
+        @overlay = OverlayKind::None
         open_palette
       elsif key.escape?
-        @overlay = :none # discard the working copy
+        @overlay = OverlayKind::None # discard the working copy
       elsif key.enter?
         save_hotkeys
       elsif key.up?
@@ -3181,7 +3217,7 @@ module Gori::Tui
       @keymap = Hotkeys.build_keymap(@session.registry)
       # Help is built from the registry at open; reload so rebound labels stay honest.
       help_controller.reload_help(@session.registry)
-      @overlay = :none
+      @overlay = OverlayKind::None
       @toast = ok ? "hotkeys saved" : "hotkeys applied — could not save to #{Settings.path}"
     end
 
@@ -3359,7 +3395,7 @@ module Gori::Tui
           @toast = "issue created"
         end
       end
-      @overlay = :none
+      @overlay = OverlayKind::None
     end
 
     private def handle_palette_key(ev : Termisu::Event::Key) : Nil
@@ -3426,8 +3462,8 @@ module Gori::Tui
     # Which focused multi-line view ^G/^F jumps, or nil if the context has none. The
     # detail drill-in is shell state (@overlay); the rest is each controller's call.
     private def goto_target : Symbol?
-      return :detail if @overlay == :detail
-      return nil unless @overlay == :none && @focus == :body
+      return :detail if @overlay.detail?
+      return nil unless @overlay.none? && @focus == :body
       @tabs[@active_tab]?.try(&.goto_symbol)
     end
 
@@ -3646,9 +3682,9 @@ module Gori::Tui
 
     private def current_scope : Verb::Scope
       case @overlay
-      when :palette
+      when .palette?
         Verb::Scope::PaletteOpen
-      when :detail
+      when .detail?
         Verb::Scope::HistoryDetail
       else
         return Verb::Scope::Sidebar if @focus == :menu
@@ -3664,7 +3700,7 @@ module Gori::Tui
     # @overlay is always :none or :detail — every other overlay handles its own
     # keys earlier in handle_key and returns before space is ever checked.
     private def space_menu_context : {Verb::Scope, Symbol}
-      if @overlay == :detail
+      if @overlay.detail?
         {Verb::Scope::HistoryDetail, :common}
       else
         scope = @tabs[@active_tab]?.try(&.command_scope) || Verb::Scope::Body
@@ -3772,35 +3808,35 @@ module Gori::Tui
       Chrome.render_status(screen, layout.status, focus: focus_label, hints: format_status_message(@toast) || key_hints,
         activity: activity_chip, resource: @resource.label, time: clock_label)
       Chrome.render_statusline(screen, layout.statusline, @statusline.segments) unless layout.statusline.empty?
-      @palette.render(screen, layout.body) if @overlay == :palette
-      @issue_form.render(screen, layout.body) if @overlay == :issue_new
-      @confirm.try(&.render(screen, layout.body)) if @overlay == :confirm
-      @browser_picker.try(&.render(screen, layout.body)) if @overlay == :browser
-      @choice_picker.try(&.render(screen, layout.body)) if @overlay == :choice
-      @more_menu.try(&.render(screen, more_anchor_rect(layout), layout.body)) if @overlay == :tabs_more
-      @flow_picker.try(&.render(screen, layout.body)) if @overlay == :comparer_pick
-      @subtab_picker.try(&.render(screen, layout.body)) if @overlay == :repeater_subtab
-      @links_overlay.try(&.render(screen, layout.body)) if @overlay == :links
-      @issue_picker.try(&.render(screen, layout.body)) if @overlay == :issue_pick
-      @note_picker.try(&.render(screen, layout.body)) if @overlay == :note_pick
-      @preferences.render(screen, layout.body) if @overlay == :preferences
-      @settings_view.render(screen, layout.body) if @overlay == :settings
-      @tabs_overlay.render(screen, layout.body) if @overlay == :tabs
-      @hosts_overlay.render(screen, layout.body) if @overlay == :hosts
-      @env_overlay.render(screen, layout.body) if @overlay == :env
-      @hotkeys_overlay.render(screen, layout.body) if @overlay == :hotkeys
-      @notifications_overlay.render(screen, layout.body) if @overlay == :notifications
-      @probe_active_overlay.try(&.render(screen, layout.body)) if @overlay == :probe_active
-      @discover_config_overlay.try(&.render(screen, layout.body)) if @overlay == :discover_config
-      @discover_headers_overlay.try(&.render(screen, layout.body)) if @overlay == :discover_headers
-      @fuzz_set_overlay.try(&.render(screen, layout.body)) if @overlay == :fuzz_set
-      @fuzz_advanced_overlay.try(&.render(screen, layout.body)) if @overlay == :fuzz_advanced
+      @palette.render(screen, layout.body) if @overlay.palette?
+      @issue_form.render(screen, layout.body) if @overlay.issue_new?
+      @confirm.try(&.render(screen, layout.body)) if @overlay.confirm?
+      @browser_picker.try(&.render(screen, layout.body)) if @overlay.browser?
+      @choice_picker.try(&.render(screen, layout.body)) if @overlay.choice?
+      @more_menu.try(&.render(screen, more_anchor_rect(layout), layout.body)) if @overlay.tabs_more?
+      @flow_picker.try(&.render(screen, layout.body)) if @overlay.comparer_pick?
+      @subtab_picker.try(&.render(screen, layout.body)) if @overlay.repeater_subtab?
+      @links_overlay.try(&.render(screen, layout.body)) if @overlay.links?
+      @issue_picker.try(&.render(screen, layout.body)) if @overlay.issue_pick?
+      @note_picker.try(&.render(screen, layout.body)) if @overlay.note_pick?
+      @preferences.render(screen, layout.body) if @overlay.preferences?
+      @settings_view.render(screen, layout.body) if @overlay.settings?
+      @tabs_overlay.render(screen, layout.body) if @overlay.tabs?
+      @hosts_overlay.render(screen, layout.body) if @overlay.hosts?
+      @env_overlay.render(screen, layout.body) if @overlay.env?
+      @hotkeys_overlay.render(screen, layout.body) if @overlay.hotkeys?
+      @notifications_overlay.render(screen, layout.body) if @overlay.notifications?
+      @probe_active_overlay.try(&.render(screen, layout.body)) if @overlay.probe_active?
+      @discover_config_overlay.try(&.render(screen, layout.body)) if @overlay.discover_config?
+      @discover_headers_overlay.try(&.render(screen, layout.body)) if @overlay.discover_headers?
+      @fuzz_set_overlay.try(&.render(screen, layout.body)) if @overlay.fuzz_set?
+      @fuzz_advanced_overlay.try(&.render(screen, layout.body)) if @overlay.fuzz_advanced?
       active_overlay.try(&.render(screen, layout.body)) # migrated modals (Overlay seam; gated on @overlay)
-      @oast_provider_overlay.try(&.render(screen, layout.body)) if @overlay == :oast_provider
-      @custom_rule_overlay.try(&.render(screen, layout.body)) if @overlay == :probe_rule
-      @rewriter_rule_overlay.try(&.render(screen, layout.body)) if @overlay == :rewriter_rule
-      @ca_import_overlay.try(&.render(screen, layout.body)) if @overlay == :ca_import
-      @import_overlay.try(&.render(screen, layout.body)) if @overlay == :import
+      @oast_provider_overlay.try(&.render(screen, layout.body)) if @overlay.oast_provider?
+      @custom_rule_overlay.try(&.render(screen, layout.body)) if @overlay.probe_rule?
+      @rewriter_rule_overlay.try(&.render(screen, layout.body)) if @overlay.rewriter_rule?
+      @ca_import_overlay.try(&.render(screen, layout.body)) if @overlay.ca_import?
+      @import_overlay.try(&.render(screen, layout.body)) if @overlay.import?
       # The space menu + bottom prompts float over everything else (drawn last).
       render_prompts(screen, layout)
 
@@ -3908,33 +3944,33 @@ module Gori::Tui
         return ov.title
       end
       case @overlay
-      when :palette          then "PALETTE"
-      when :issue_new        then "ISSUE"
-      when :detail           then "DETAIL"
-      when :confirm          then "CONFIRM"
-      when :browser          then "BROWSER"
-      when :choice           then @choice_picker.try(&.title) || "CHOOSE"
-      when :comparer_pick    then "PICK FLOW"
-      when :repeater_subtab  then @subtab_picker.try(&.title) || "FIND SUB-TAB"
-      when :links            then @links_overlay.try(&.title) || "LINKS"
-      when :issue_pick       then "PICK ISSUE"
-      when :note_pick        then "PICK NOTE"
-      when :preferences      then "PREFERENCES"
-      when :settings         then "SETTINGS"
-      when :tabs             then "TAB BAR"
-      when :hosts            then "HOSTNAME OVERRIDES"
-      when :env              then "ENVIRONMENT"
-      when :hotkeys          then "HOTKEYS"
-      when :notifications    then "NOTIFICATIONS"
-      when :probe_active     then "ACTIVE SCAN"
-      when :discover_config  then "DISCOVER"
-      when :discover_headers then "CUSTOM HEADERS"
-      when :fuzz_set         then "PAYLOAD SET"
-      when :fuzz_advanced    then "ADVANCED"
-      when :rewriter_rule    then "REWRITER RULE"
-      when :oast_provider    then "OAST PROVIDER"
-      when :ca_import        then "IMPORT CA"
-      when :import           then "IMPORT #{@import_overlay.try(&.label) || "FILE"}"
+      when .palette?          then "PALETTE"
+      when .issue_new?        then "ISSUE"
+      when .detail?           then "DETAIL"
+      when .confirm?          then "CONFIRM"
+      when .browser?          then "BROWSER"
+      when .choice?           then @choice_picker.try(&.title) || "CHOOSE"
+      when .comparer_pick?    then "PICK FLOW"
+      when .repeater_subtab?  then @subtab_picker.try(&.title) || "FIND SUB-TAB"
+      when .links?            then @links_overlay.try(&.title) || "LINKS"
+      when .issue_pick?       then "PICK ISSUE"
+      when .note_pick?        then "PICK NOTE"
+      when .preferences?      then "PREFERENCES"
+      when .settings?         then "SETTINGS"
+      when .tabs?             then "TAB BAR"
+      when .hosts?            then "HOSTNAME OVERRIDES"
+      when .env?              then "ENVIRONMENT"
+      when .hotkeys?          then "HOTKEYS"
+      when .notifications?    then "NOTIFICATIONS"
+      when .probe_active?     then "ACTIVE SCAN"
+      when .discover_config?  then "DISCOVER"
+      when .discover_headers? then "CUSTOM HEADERS"
+      when .fuzz_set?         then "PAYLOAD SET"
+      when .fuzz_advanced?    then "ADVANCED"
+      when .rewriter_rule?    then "REWRITER RULE"
+      when .oast_provider?    then "OAST PROVIDER"
+      when .ca_import?        then "IMPORT CA"
+      when .import?           then "IMPORT #{@import_overlay.try(&.label) || "FILE"}"
       else
         case @focus
         when :menu    then "TABS"
@@ -3964,34 +4000,34 @@ module Gori::Tui
         return ov.hint
       end
       case @overlay
-      when :palette          then "↑/↓ select · ↵ run · ⌫ · esc close · type to filter"
-      when :issue_new        then "type title · ↵ create · esc cancel"
-      when :confirm          then "←/→ choose · y confirm · n/esc cancel · ↵ select"
-      when :browser          then "↑/↓ select · ↵ open · esc cancel"
-      when :choice           then "↑/↓ select · ↵ set · key picks · esc cancel"
-      when :tabs_more        then "↑/↓ select · ↵ open tab · ←/esc close"
-      when :comparer_pick    then "type to filter · ↑/↓ select · ↵ choose · esc cancel"
-      when :repeater_subtab  then "type to filter · ↑/↓ select · ↵ #{@subtab_picker.try(&.action) || "jump"} · esc cancel"
-      when :links            then @links_overlay.try(&.adding?) ? "f/r/z/m pick type · esc back" : "↑/↓ · ↵/o open · a add · d remove · esc close"
-      when :issue_pick       then "type to filter · ↑/↓ select · ↵ link · esc cancel"
-      when :note_pick        then "type to filter · ↑/↓ select · ↵ link · esc cancel"
-      when :preferences      then "←/→ group · ↑/↓ field · ↵ save/open · ^R reset · esc close"
-      when :settings         then "↑/↓ field · type to edit · ↵ save · ^R reset · esc close"
-      when :tabs             then "↑/↓ select · space show/hide · K/J reorder · r reset · ↵ save · esc cancel"
-      when :hosts            then @hosts_overlay.adding? ? "type \"IP host\" · ↵ save · esc cancel" : "↑/↓ select · a add · ↵/e edit · d delete · esc close"
-      when :env              then env_overlay_hints
-      when :hotkeys          then @hotkeys_overlay.capturing? ? "press a key to bind · esc cancel" : "↑/↓ select · e/␣ rebind · x unbind · r reset · ⇧R reset all · ←/→ profile · ↵ save · esc"
-      when :notifications    then "↑/↓ select · ↵ open · c clear · esc close"
-      when :probe_active     then "↑/↓ field · ←/→ adjust · ↵ run · esc cancel"
-      when :discover_config  then "↑/↓ field · ←/→ adjust · ␣ toggle · ↵ start/edit · esc cancel"
-      when :discover_headers then "one header per line · Host/Connection ignored · esc saves & closes"
-      when :fuzz_set         then "↑/↓/⇥ field · ←/→ type/caret · ↵ new value/next · esc applies & closes"
-      when :fuzz_advanced    then "↑/↓/⇥ field · ←/→ edit · ␣ toggle · ↵ next · esc applies & closes"
-      when :rewriter_rule    then "↑/↓ field · ←/→ options · type find/value · ↵ save · esc cancel"
-      when :oast_provider    then "↑/↓ field · ←/→ scope/type · type name/host/token · ↵ save · esc cancel"
-      when :ca_import        then "type to complete · ↹/↵ pick · ⇥/↑↓ field · ↵ submits · esc cancels"
-      when :import           then "type to complete · ↹ pick · ↑↓ browse · ↵ import · esc cancel"
-      when :detail           then history_controller.body_hint(:body)
+      when .palette?          then "↑/↓ select · ↵ run · ⌫ · esc close · type to filter"
+      when .issue_new?        then "type title · ↵ create · esc cancel"
+      when .confirm?          then "←/→ choose · y confirm · n/esc cancel · ↵ select"
+      when .browser?          then "↑/↓ select · ↵ open · esc cancel"
+      when .choice?           then "↑/↓ select · ↵ set · key picks · esc cancel"
+      when .tabs_more?        then "↑/↓ select · ↵ open tab · ←/esc close"
+      when .comparer_pick?    then "type to filter · ↑/↓ select · ↵ choose · esc cancel"
+      when .repeater_subtab?  then "type to filter · ↑/↓ select · ↵ #{@subtab_picker.try(&.action) || "jump"} · esc cancel"
+      when .links?            then @links_overlay.try(&.adding?) ? "f/r/z/m pick type · esc back" : "↑/↓ · ↵/o open · a add · d remove · esc close"
+      when .issue_pick?       then "type to filter · ↑/↓ select · ↵ link · esc cancel"
+      when .note_pick?        then "type to filter · ↑/↓ select · ↵ link · esc cancel"
+      when .preferences?      then "←/→ group · ↑/↓ field · ↵ save/open · ^R reset · esc close"
+      when .settings?         then "↑/↓ field · type to edit · ↵ save · ^R reset · esc close"
+      when .tabs?             then "↑/↓ select · space show/hide · K/J reorder · r reset · ↵ save · esc cancel"
+      when .hosts?            then @hosts_overlay.adding? ? "type \"IP host\" · ↵ save · esc cancel" : "↑/↓ select · a add · ↵/e edit · d delete · esc close"
+      when .env?              then env_overlay_hints
+      when .hotkeys?          then @hotkeys_overlay.capturing? ? "press a key to bind · esc cancel" : "↑/↓ select · e/␣ rebind · x unbind · r reset · ⇧R reset all · ←/→ profile · ↵ save · esc"
+      when .notifications?    then "↑/↓ select · ↵ open · c clear · esc close"
+      when .probe_active?     then "↑/↓ field · ←/→ adjust · ↵ run · esc cancel"
+      when .discover_config?  then "↑/↓ field · ←/→ adjust · ␣ toggle · ↵ start/edit · esc cancel"
+      when .discover_headers? then "one header per line · Host/Connection ignored · esc saves & closes"
+      when .fuzz_set?         then "↑/↓/⇥ field · ←/→ type/caret · ↵ new value/next · esc applies & closes"
+      when .fuzz_advanced?    then "↑/↓/⇥ field · ←/→ edit · ␣ toggle · ↵ next · esc applies & closes"
+      when .rewriter_rule?    then "↑/↓ field · ←/→ options · type find/value · ↵ save · esc cancel"
+      when .oast_provider?    then "↑/↓ field · ←/→ scope/type · type name/host/token · ↵ save · esc cancel"
+      when .ca_import?        then "type to complete · ↹/↵ pick · ⇥/↑↓ field · ↵ submits · esc cancels"
+      when .import?           then "type to complete · ↹ pick · ↑↓ browse · ↵ import · esc cancel"
+      when .detail?           then history_controller.body_hint(:body)
       else
         # Focus on the far-right ⋯ "more" affordance: ↵/↓ expands the hidden-tabs list.
         return "↵/↓ show hidden tabs · ← back · ^P cmds · q projects" if @focus == :menu && @menu_more
@@ -4028,7 +4064,7 @@ module Gori::Tui
       # out (see TrafficEmptyState.suppressed?). Every overlay but the ⋯ dropdown centres
       # itself in this same rect; tabs_more is anchored to its tab-bar chip and doesn't
       # cover the card, so it keeps it.
-      TrafficEmptyState.suppressed = @overlay != :none && @overlay != :tabs_more
+      TrafficEmptyState.suppressed = !@overlay.none? && !@overlay.tabs_more?
       # Every catalog tab has a controller that owns its body render; the `?` guard is
       # defensive (a blank body beats a crash if the active tab ever lacks one).
       @tabs[@active_tab]?.try(&.render_body(screen, rect, @focus))
@@ -4060,7 +4096,7 @@ module Gori::Tui
 
     def leave_project : Nil
       confirm("LEAVE PROJECT", "Close this project and return to the picker?",
-        confirm_label: "leave", danger: false, return_to: @overlay) do
+        confirm_label: "leave", danger: false, return_to: @overlay.to_sym) do
         commit_pending_edits
         @outcome = :back
       end
@@ -4085,12 +4121,12 @@ module Gori::Tui
     end
 
     def open_palette : Nil
-      @overlay = :palette
+      @overlay = OverlayKind::Palette
       @palette.reset(self)
     end
 
     def close_overlay : Nil
-      @overlay = :none
+      @overlay = OverlayKind::None
     end
 
     # Emergency full repaint (palette-only). `@resized` routes the next flush through the
@@ -4107,8 +4143,13 @@ module Gori::Tui
     # Thin wrappers over the existing shell setters so a controller never writes
     # @overlay/@focus/@active_tab directly. `status` (above) already satisfies Host.
 
+    # The Host facade still speaks Symbol (tab_controller.cr), so these two are the ONE
+    # place a Symbol crosses into @overlay's OverlayKind. Both directions are total:
+    # from_sym raises on an unknown name rather than silently landing on None, and to_sym
+    # is an exhaustive case the compiler checks — so the enum's guarantee survives the
+    # bridge. Retyping the facade itself is a follow-up (it touches the controllers).
     def request_overlay(kind : Symbol) : Nil
-      @overlay = kind
+      @overlay = OverlayKind.from_sym(kind)
     end
 
     def request_focus(pane : Symbol) : Nil
@@ -4132,7 +4173,7 @@ module Gori::Tui
       flush_active_tab_edits # cross-tab "open this and land in it" jumps must persist the outgoing edit too
       @active_tab = tab
       @focus = :body
-      @overlay = :none # clear any launching overlay (e.g. History :detail) so the destination
+      @overlay = OverlayKind::None # clear any launching overlay (e.g. History :detail) so the destination
       #                  tab's body keys/scope aren't deadened by a stale overlay gate
     end
 
@@ -4141,7 +4182,7 @@ module Gori::Tui
     end
 
     def overlay : Symbol
-      @overlay
+      @overlay.to_sym
     end
 
     def active_tab : Symbol
@@ -4173,7 +4214,7 @@ module Gori::Tui
     # Open the notification center (the app.notifications verb + the clickable top-bar
     # badge). Marks everything read, clearing the unread badge.
     def open_notifications : Nil
-      @overlay = :notifications
+      @overlay = OverlayKind::Notifications
       @notifications_overlay.reset
       @notifications.mark_all_read
     end
@@ -4181,7 +4222,7 @@ module Gori::Tui
     # Run the selected note's "jump to result" target, then close the center.
     private def open_notification_goto : Nil
       note = @notifications_overlay.selected_note
-      @overlay = :none
+      @overlay = OverlayKind::None
       run_goto(note.goto) if note
     end
 
@@ -4388,11 +4429,11 @@ module Gori::Tui
 
     private def open_import(kind : Symbol) : Nil
       @import_overlay = ImportOverlay.new(kind)
-      @overlay = :import
+      @overlay = OverlayKind::Import
     end
 
     private def close_import : Nil
-      @overlay = :none
+      @overlay = OverlayKind::None
       @import_overlay = nil
     end
 
@@ -4505,7 +4546,7 @@ module Gori::Tui
       notes_controller.save_notes if @active_tab == :notes && @focus == :body && pane != :body
       @focus = pane
       @menu_more = false # any focus change lands on a real tab, not the ⋯ affordance
-      @overlay = :none
+      @overlay = OverlayKind::None
       view_focus_first if pane == :body
     end
 
@@ -4542,7 +4583,7 @@ module Gori::Tui
       @active_tab = tab
       @focus = focus
       @menu_more = false
-      @overlay = :none
+      @overlay = OverlayKind::None
       on_enter_tab
       view_focus_first
     end
@@ -4572,7 +4613,7 @@ module Gori::Tui
       idx = tabs.index { |(s, _)| s == @active_tab } || 0
       @active_tab = tabs[(idx + delta) % tabs.size][0]
       @menu_more = false
-      @overlay = :none
+      @overlay = OverlayKind::None
       on_enter_tab
       # Switching tabs on the bar (menu focus) just moves the highlight; switching
       # while in the body drops into the new tab's first pane.
@@ -4638,13 +4679,13 @@ module Gori::Tui
       @focus = :menu
       @menu_more = true
       @more_menu = MoreMenu.new(items)
-      @overlay = :tabs_more
+      @overlay = OverlayKind::TabsMore
     end
 
     # Dismiss the dropdown back to the ⋯ affordance (esc / ← / click-outside). Focus
     # stays on the bar with @menu_more set, so ←/→ keep navigating from there.
     private def close_more_menu : Nil
-      @overlay = :none
+      @overlay = OverlayKind::None
       @more_menu = nil
     end
 
@@ -4730,7 +4771,7 @@ module Gori::Tui
 
     def link_flow_id : Int64?
       return unless @active_tab == :history
-      if @overlay == :detail
+      if @overlay.detail?
         history_controller.view.detail_flow_id
       else
         history_controller.view.selected_id
@@ -4742,7 +4783,7 @@ module Gori::Tui
     # while the detail overlay stays on its flow, so detail.* verbs (repeater/issue/fuzz/mine/
     # comparer/copy/scope) must read the detail, not the cursor — or they act on the wrong flow.
     def history_target_flow_id : Int64?
-      @overlay == :detail ? history_controller.view.detail_flow_id : history_controller.selected_flow_id
+      @overlay.detail? ? history_controller.view.detail_flow_id : history_controller.selected_flow_id
     end
 
     def link_repeater_id : Int64?
@@ -4768,7 +4809,7 @@ module Gori::Tui
       end
       @link_pending_ref = ref
       @issue_picker = IssuePicker.new(@session.store.issues)
-      @overlay = :issue_pick
+      @overlay = OverlayKind::IssuePick
     end
 
     def link_to_note : Nil
@@ -4777,7 +4818,7 @@ module Gori::Tui
       notes_controller.save_notes
       @link_pending_ref = ref
       @note_picker = NotePicker.new(note_picker_rows)
-      @overlay = :note_pick
+      @overlay = OverlayKind::NotePick
     end
 
     # Trim an issue title for a one-line toast (avoid a wall of text on wide titles).
@@ -4815,7 +4856,7 @@ module Gori::Tui
         return
       end
       @probe_active_overlay = ProbeActiveOverlay.new(detail, est_safe, est_unsafe, repeater_id)
-      @overlay = :probe_active
+      @overlay = OverlayKind::ProbeActive
     end
 
     # Confirm the popup: run the probes in the BACKGROUND (mode-independent), persist the chosen
@@ -4840,7 +4881,7 @@ module Gori::Tui
     end
 
     private def close_probe_active : Nil
-      @overlay = :none
+      @overlay = OverlayKind::None
       @probe_active_overlay = nil
     end
 
@@ -4915,7 +4956,7 @@ module Gori::Tui
       rows = @tabs[@active_tab]?.try(&.subtab_search_rows) || [] of SubtabPicker::Row
       return @toast = "no other sub-tab to search" if rows.size < 2
       @subtab_picker = SubtabPicker.new("FIND SUB-TAB", rows)
-      @overlay = :repeater_subtab
+      @overlay = OverlayKind::RepeaterSubtab
     end
 
     def subtab_search_count : Int32
@@ -5002,7 +5043,7 @@ module Gori::Tui
         return
       end
       @discover_config_overlay = DiscoverConfigOverlay.new(seed)
-      @overlay = :discover_config
+      @overlay = OverlayKind::DiscoverConfig
     end
 
     # Confirm the popup: launch the BACKGROUND run and switch to the Discover sub-tab so
@@ -5021,14 +5062,14 @@ module Gori::Tui
     end
 
     private def close_discover_config : Nil
-      @overlay = :none
+      @overlay = OverlayKind::None
       @discover_config_overlay = nil
     end
 
     # --- Discover custom-headers editor (opened from the config popup's headers row) ---
     private def open_discover_headers(ov : DiscoverConfigOverlay) : Nil
       @discover_headers_overlay = DiscoverHeadersOverlay.new(ov.headers)
-      @overlay = :discover_headers
+      @overlay = OverlayKind::DiscoverHeaders
     end
 
     # esc / click-away: parse the edited lines back onto the config popup and reopen it.
@@ -5037,7 +5078,7 @@ module Gori::Tui
         ov.set_headers(hov.headers)
       end
       @discover_headers_overlay = nil
-      @overlay = :discover_config
+      @overlay = OverlayKind::DiscoverConfig
     end
 
     private def handle_discover_headers_key(ev : Termisu::Event::Key) : Nil
@@ -5055,13 +5096,13 @@ module Gori::Tui
         else
           FuzzSetOverlay.for_list
         end
-      @overlay = :fuzz_set
+      @overlay = OverlayKind::FuzzSet
     end
 
     def open_fuzz_advanced_editor : Nil
       return unless v = fuzzer_controller.current_view
       @fuzz_advanced_overlay = FuzzAdvancedOverlay.new(v.advanced_snapshot)
-      @overlay = :fuzz_advanced
+      @overlay = OverlayKind::FuzzAdvanced
     end
 
     # Host: open the Project SCOPE rule popup (nil edit_id = add a new rule). The apply is
@@ -5081,20 +5122,20 @@ module Gori::Tui
     # Host: open the OAST provider add/edit popup (nil = add a new provider).
     def open_oast_provider_editor(provider : Oast::ProviderConfig?) : Nil
       @oast_provider_overlay = provider ? OastProviderOverlay.editing(provider) : OastProviderOverlay.adding
-      @overlay = :oast_provider
+      @overlay = OverlayKind::OastProvider
     end
 
     # Host: open the Probe custom-rule popup (nil rule = add; else edit the given rule).
     def open_custom_rule_editor(rule : Probe::CustomRule?) : Nil
       @custom_rule_overlay = rule ? CustomRuleOverlay.editing(rule) : CustomRuleOverlay.adding
-      @overlay = :probe_rule
+      @overlay = OverlayKind::ProbeRule
     end
 
     # Host: open the Rewriter (Match & Replace) rule popup (nil rule = add; else edit).
     def open_rewriter_rule_editor(rule : Store::MatchRule?) : Nil
       @rewriter_rule_overlay = rule ? RewriterRuleOverlay.editing(rule) : RewriterRuleOverlay.adding
       @rewriter_preview_sig = ""
-      @overlay = :rewriter_rule
+      @overlay = OverlayKind::RewriterRule
     end
 
     # Notes must not be reloaded out from under in-progress typing. Focus alone is
@@ -5156,7 +5197,7 @@ module Gori::Tui
     # the same confirm as regenerate (see submit_ca_import).
     def import_ca : Nil
       @ca_import_overlay = CAImportOverlay.new
-      @overlay = :ca_import
+      @overlay = OverlayKind::CaImport
     end
 
     # --- browser (open a pre-trusted system browser) ---
@@ -5169,7 +5210,7 @@ module Gori::Tui
         return
       end
       @browser_picker = BrowserPicker.new(found, Browser.certutil_available?)
-      @overlay = :browser
+      @overlay = OverlayKind::Browser
     end
 
     # --- comparer (diff two arbitrary flows) ---
@@ -5200,7 +5241,7 @@ module Gori::Tui
       when :issues   then issues_controller.issues_notes_selection_active?
       when :project  then project_controller.project_desc_selection_active?
       when :history
-        @overlay == :detail && history_controller.detail_selection_active?
+        @overlay.detail? && history_controller.detail_selection_active?
       else
         false
       end
@@ -5220,7 +5261,7 @@ module Gori::Tui
       when :issues   then issues_controller.issues_notes_selection_text
       when :project  then project_controller.project_desc_selection_text
       when :history
-        @overlay == :detail ? history_controller.detail_selection_text : ""
+        @overlay.detail? ? history_controller.detail_selection_text : ""
       else
         ""
       end
@@ -5236,7 +5277,7 @@ module Gori::Tui
       when :issues   then issues_controller.issues_notes_select_line
       when :project  then project_controller.project_desc_select_line
       when :history
-        history_controller.detail_select_line if @overlay == :detail
+        history_controller.detail_select_line if @overlay.detail?
       end
     end
 
@@ -5250,7 +5291,7 @@ module Gori::Tui
       when :issues   then issues_controller.issues_notes_clear_selection
       when :project  then project_controller.project_desc_clear_selection
       when :history
-        history_controller.detail_clear_selection if @overlay == :detail
+        history_controller.detail_clear_selection if @overlay.detail?
       end
     end
 
@@ -5270,12 +5311,12 @@ module Gori::Tui
       when :history
         # No whole-rendered-pane delegator exists for the detail text pane — both
         # branches fall back to the selection-or-current-line copy.
-        detail_copy_selection if @overlay == :detail
+        detail_copy_selection if @overlay.detail?
       end
     end
 
     def detail_navigable? : Bool
-      @active_tab == :history && @overlay == :detail && history_controller.view.detail_navigable?
+      @active_tab == :history && @overlay.detail? && history_controller.view.detail_navigable?
     end
 
     # --- settings (config control) ---
@@ -5349,20 +5390,20 @@ module Gori::Tui
       when :theme
         @settings_view.reload(:theme) # theme keeps its dedicated swatch-list card
         @resized = true               # an edited/removed active theme just changed → full repaint
-        @overlay = :settings
+        @overlay = OverlayKind::Settings
         @theme_restore = Settings.theme # baseline for live-preview revert
       when :tabs
         @tabs_overlay.reset # rebuild the working copy from persisted config
-        @overlay = :tabs
+        @overlay = OverlayKind::Tabs
       when :hosts
         @hosts_overlay.reset # rebuild the working copy from persisted overrides
-        @overlay = :hosts
+        @overlay = OverlayKind::Hosts
       when :env
         @env_overlay.reset
-        @overlay = :env
+        @overlay = OverlayKind::Env
       when :hotkeys
         @hotkeys_overlay.reset # rebuild the working copy from persisted overrides
-        @overlay = :hotkeys
+        @overlay = OverlayKind::Hotkeys
       else
         @toast = "#{section} settings — coming soon (TODO)"
       end
@@ -5375,7 +5416,7 @@ module Gori::Tui
     def open_preferences(section : Symbol? = nil) : Nil
       section ? @preferences.open(section) : @preferences.open_default
       @prefs_return = false # a fresh open — not a hop out to a sub-editor and back
-      @overlay = :preferences
+      @overlay = OverlayKind::Preferences
     end
 
     private def handle_preferences_key(ev : Termisu::Event::Key) : Nil
@@ -5387,8 +5428,8 @@ module Gori::Tui
     # (theme/tabs/hosts/env/hotkeys) — flagged so that editor returns INTO the modal.
     private def apply_preferences_outcome(outcome : PreferencesView::Outcome) : Nil
       case outcome.kind
-      when :close   then @overlay = :none
-      when :palette then (@overlay = :none; open_palette)
+      when :close   then @overlay = OverlayKind::None
+      when :palette then (@overlay = OverlayKind::None; open_palette)
       when :saved   then @toast = apply_settings_saved(outcome.section.not_nil!, outcome.message || "")
       when :open
         @prefs_return = true
@@ -5397,19 +5438,25 @@ module Gori::Tui
     end
 
     # The dedicated editors reachable from a Preferences opener row. Each closes by setting
-    # @overlay = :none from a handful of places, so rather than patch every close site the
+    # @overlay = OverlayKind::None from a handful of places, so rather than patch every close site the
     # dispatch chokepoints below redirect that :none back INTO the modal it was opened from
     # — otherwise ↵-ing into Theme and pressing esc drops you out of settings entirely,
     # while the project picker (which does return to the modal) behaves differently.
-    PREFS_SUB_EDITORS = {:settings, :tabs, :hosts, :env, :hotkeys}
+    PREFS_SUB_EDITORS = {
+      OverlayKind::Settings,
+      OverlayKind::Tabs,
+      OverlayKind::Hosts,
+      OverlayKind::Env,
+      OverlayKind::Hotkeys,
+    }
 
     private def settle_sub_editor : Nil
       return unless @prefs_return
       # Still editing, chained into another editor, or raising a confirm the editor set a
       # `return_to:` for (^R reset / tab-bar reset) — the flag has to survive all three.
-      return if PREFS_SUB_EDITORS.includes?(@overlay) || @overlay == :confirm
-      @overlay = :preferences if @overlay == :none # a ^P jump to the palette still wins
-      @preferences.refresh(:network)               # the Hostnames editor moves Network's "N entries" row
+      return if PREFS_SUB_EDITORS.includes?(@overlay) || @overlay.confirm?
+      @overlay = OverlayKind::Preferences if @overlay.none? # a ^P jump to the palette still wins
+      @preferences.refresh(:network)                        # the Hostnames editor moves Network's "N entries" row
       @prefs_return = false
     end
 

--- a/src/gori/tui/runner/comparer.cr
+++ b/src/gori/tui/runner/comparer.cr
@@ -5,7 +5,7 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
   # flows; the picker filters them in memory.
   def comparer_pick(slot : Symbol) : Nil
     @flow_picker = FlowPicker.new(@session.store.recent_flows(2000), slot)
-    @overlay = :comparer_pick
+    @overlay = OverlayKind::ComparerPick
   end
 
   def comparer_swap : Nil

--- a/src/gori/tui/runner/issues.cr
+++ b/src/gori/tui/runner/issues.cr
@@ -6,13 +6,13 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     return unless id
     if row = @session.store.flow_row(id)
       @issue_form = IssueForm.new("#{row.method} #{row.target}", row.host, id)
-      @overlay = :issue_new
+      @overlay = OverlayKind::IssueNew
     end
   end
 
   def issues_new : Nil
     @issue_form = IssueForm.new
-    @overlay = :issue_new
+    @overlay = OverlayKind::IssueNew
   end
 
   def issues_query : Nil
@@ -48,13 +48,13 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
   def issue_set_severity : Nil
     return unless f = issues_controller.view.detail_issue
     @choice_picker = ChoicePicker.for_severity(f.severity.value)
-    @overlay = :choice
+    @overlay = OverlayKind::Choice
   end
 
   def issue_set_status : Nil
     return unless f = issues_controller.view.detail_issue
     @choice_picker = ChoicePicker.for_status(f.status.value)
-    @overlay = :choice
+    @overlay = OverlayKind::Choice
   end
 
   def issue_edit_notes : Nil
@@ -83,7 +83,7 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
   def issue_edit_title : Nil
     return unless f = issues_controller.view.detail_issue
     @issue_form = IssueForm.new(f.title, f.host, f.flow_id, f.severity, edit_id: f.id, heading: "EDIT ISSUE")
-    @overlay = :issue_new
+    @overlay = OverlayKind::IssueNew
   end
 
   # Jump from an issue to its linked flow's request/response in History. CROSS-TAB
@@ -94,7 +94,7 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     if history_controller.view.open_detail_id(fid, @session.store)
       @active_tab = :history
       @focus = :body
-      @overlay = :detail
+      @overlay = OverlayKind::Detail
     else
       @toast = "evidence no longer captured (pruned)"
     end

--- a/src/gori/tui/runner/probe.cr
+++ b/src/gori/tui/runner/probe.cr
@@ -28,7 +28,7 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
   # Open the MODE picker (a shell overlay); apply_choice applies it to the analyzer.
   def probe_set_mode : Nil
     @choice_picker = ChoicePicker.for_probe_mode(@session.probe.mode.value)
-    @overlay = :choice
+    @overlay = OverlayKind::Choice
   end
 
   def probe_dismiss : Nil
@@ -55,7 +55,7 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
       if history_controller.view.open_detail_id(fid, @session.store)
         @active_tab = :history
         @focus = :body
-        @overlay = :detail
+        @overlay = OverlayKind::Detail
       else
         @toast = "evidence no longer captured (pruned)"
       end

--- a/src/gori/tui/scope_rule_overlay.cr
+++ b/src/gori/tui/scope_rule_overlay.cr
@@ -52,8 +52,8 @@ module Gori::Tui
     end
 
     # --- Overlay contract (see overlay.cr) ---
-    def key : Symbol
-      :scope_rule
+    def key : OverlayKind
+      OverlayKind::ScopeRule
     end
 
     def title : String

--- a/src/gori/tui/sequence_config_overlay.cr
+++ b/src/gori/tui/sequence_config_overlay.cr
@@ -85,8 +85,8 @@ module Gori::Tui
     end
 
     # --- Overlay contract (see overlay.cr) ---
-    def key : Symbol
-      :sequence_config
+    def key : OverlayKind
+      OverlayKind::SequenceConfig
     end
 
     def title : String


### PR DESCRIPTION
Phase 0 of #355. **Prep only — no modal was migrated.**

## Scope

This is deliberately the boring, serial, whole-file change that has to land before the five Phase 1 batches can run in parallel. To be explicit about what this PR does **not** do:

- No modal was migrated onto the `Overlay` base — still 3 of 31 (`scope_rule`, `sequence_config`, `mine_config`).
- No `handle_*_key` method was deleted.
- The modal count is unchanged, and no `*_overlay.cr` was touched beyond retyping `key` on the three already-migrated ones.

## What changed

**1. `@overlay` is now the `OverlayKind` enum, not a bare `Symbol`.**

It held 33 states compared ~96 times across `runner.cr`. A mistyped `:probe_rules` was a silent no-op — an overlay that never opened, never rendered and never captured a key, with no compiler help. As an enum the same typo is a compile error. Bare `@overlay == :sym` comparisons went **235 → 0**.

The `Host` facade (`tab_controller.cr`) still speaks `Symbol`, so `to_sym`/`from_sym` bridge it. Both are total on purpose: `to_sym` is an exhaustive `case … in` (adding a member fails to compile until it is mapped) and `from_sym` **raises** rather than silently landing on `None` — silence at that seam is the exact failure mode the enum exists to kill. Retyping the facade itself touches the controllers and is left as a follow-up.

**2. `modal_overlay?`'s packed `when` list became the `MODAL_OVERLAYS` constant**, one member per line. That list is the input-capture gate every Phase 1 batch edits (a migration deletes its own member); five parallel batches deleting from a single packed line would conflict on every merge.

**3. `spec/support/overlay_harness.cr`** replays `Runner#dispatch_overlay_key` / `#dispatch_overlay_click` line for line, so each batch inherits the scaffolding instead of re-deriving the shell's dispatch by hand (and each slightly differently).

## Note on the issue's Phase 0 checklist

The first checkbox — *"add a generic `active_overlay` fallback to the title and hint ladders"* — was **already satisfied on main**; both fallbacks landed in #331 (`focus_label` and `key_hints` each open with `if ov = active_overlay`). The table in #355 was stale on those two rows. Nothing to do, verified rather than re-implemented.

## Verification

The `runner.cr` diff is a **pure mechanical rename**, and I checked that mechanically rather than by reading: reversing the conversion (`OverlayKind::Foo` → `:foo`, `@overlay.foo?` → `@overlay == :foo`, `!@overlay.foo?` → `@overlay != :foo`) and diffing against `origin/main` leaves a residue of only the new constant, the two facade bridges, and comments. In particular `MODAL_OVERLAYS` is the same 28 members in the same order as the old packed `when`, and `PREFS_SUB_EDITORS` is the same 5.

Both load-bearing carve-outs are preserved: the `@search_open && !@overlay.confirm?` search carve-out, and the hotkeys capture-mode check ahead of the global `^C`/`^D` quit-arm.

Every symbol that reaches `from_sym` at a live call site (`:none`, `:detail`, `:settings`, `:tabs`, `:discover_config`) resolves, so the new raise is not reachable today.

- `just build` clean, `just test` **3910 examples, 0 failures**
- `crystal tool format --check` clean on the changed files
- ameba on the touched files identical to baseline (43 before, 43 after — all pre-existing)

## Review findings fixed in this PR

An adversarial review proved three spec weaknesses **by mutation** (break the code, watch the suite stay green). All three are now caught — I control-ran each fix against the same mutation:

1. The `from_sym` round-trip spec could not fail: `to_sym` and `from_sym` are generated from the same constants with the same `underscore`, so they agree under *any* rename. Renaming `Settings` → `SettingsEditor` left all 1121 `spec/tui` examples green while `from_sym(:settings)` raised. Now the wire names are pinned against a literal list.
2. The base-contract click-away assertion went through the harness, which collapses `:cancel` and a truthy `:commit` to the same `:closed` — so flipping `Overlay#handle_click`'s default to `:commit` (click-away silently *applies* the modal) stayed green. Now the raw `:cancel` vocabulary and `commits == 0` are both asserted.
3. `MODAL_OVERLAYS` had absence coverage for the migrated modals but no presence coverage, so dropping a still-unmigrated member compiled and stayed green while silently disabling that modal's input-capture gate. Given five batches are about to edit exactly that line, it now asserts all 28 unmigrated kinds are present.

## Follow-ups (deliberately out of scope)

- Retype the `Host` facade (`request_overlay` / `overlay` / `confirm(return_to:)`) from `Symbol` to `OverlayKind` and delete the bridges — touches the controllers.
- `OverlayHarness` does not model the shell's pre-filter (`^C`/`^D`, `^B`, the space menu and bottom prompts are claimed before a modal is dispatched to); documented in the harness header so a future batch does not assert something that is dead in the app.

Unblocks batches C1–C5.

Refs #355