### PR TITLE
test(tui): stop OverlayHarness from silently discarding a real commit closure (#355)

### DIFF
--- a/spec/support/overlay_harness.cr
+++ b/spec/support/overlay_harness.cr
@@ -32,6 +32,14 @@ require "./memory_backend"
 class OverlayHarness
   # The body rect the shell hands an overlay. 80x24 is the size every existing overlay
   # spec centres its card in, so box geometry matches what those specs already assert.
+  #
+  # CAVEAT: this is the whole SCREEN, not `layout.body`. On a real 80x24 terminal the shell
+  # passes Rect(2, 4, 76, 18) — 6 rows shorter and offset — so a card gets 22 usable rows
+  # here where production gives 16. Every migrated overlay's `overlay_box` bails out with
+  # `nil` below a floor (`w < 28 || h < 8`), and that nil path — where the base
+  # `handle_click` turns EVERY click into a dismiss — is therefore unreachable through this
+  # default. If your modal is tall, or you care about the small-terminal path, pass an
+  # explicit `area:` rather than trusting this.
   DEFAULT_AREA = Gori::Tui::Rect.new(0, 0, 80, 24)
 
   getter overlay : Gori::Tui::Overlay
@@ -45,31 +53,44 @@ class OverlayHarness
   # `commit` is what the injected closure reports back to the shell: true = "applied,
   # close me", false = the validation-rejected path that keeps the form up. Override it
   # mid-example with `on_commit`.
+  #
+  # An overlay that ALREADY carries a closure is wrapped, not replaced: the real open-sites
+  # (`open_scope_rule_editor` and friends) set `on_commit` before handing the modal over, so
+  # a migration spec that mirrors its open-site and then wraps it here must still be running
+  # the production closure. Silently swapping in `-> { true }` would leave the example
+  # asserting `commits == 1` while proving nothing about the code under test.
   def initialize(@overlay : Gori::Tui::Overlay, *, area : Gori::Tui::Rect = DEFAULT_AREA,
-                 commit : Bool = true)
+                 commit : Bool? = nil)
     @area = area
-    @commit_result = commit
-    install_commit
+    if existing = @overlay.on_commit
+      raise ArgumentError.new(
+        "the overlay already carries an on_commit closure; pass commit: to override it deliberately"
+      ) unless commit.nil?
+      count(&existing) # keep the production closure, just make its runs observable
+    else
+      result = commit.nil? ? true : commit
+      count { result }
+    end
   end
 
-  # Replace the commit outcome (e.g. flip to a rejecting closure part-way through).
+  # Replace the commit outcome wholesale (e.g. flip to a rejecting closure part-way
+  # through). Discards whatever closure is installed — that is the point.
   def commit_result=(ok : Bool)
-    @commit_result = ok
-    install_commit
+    count { ok }
   end
 
   # Inject a bespoke commit closure — still counted in `commits`. Use when the example
   # needs to observe the overlay's state at commit time (the real open-sites all do).
   def on_commit(&blk : -> Bool) : Nil
+    count(&blk)
+  end
+
+  # The one place a closure is installed, so `commits` counts every path uniformly.
+  private def count(&blk : -> Bool) : Nil
     @overlay.on_commit = -> {
       @commits += 1
       blk.call
     }
-  end
-
-  private def install_commit : Nil
-    ok = @commit_result
-    on_commit { ok }
   end
 
   # One key through the shell's dispatch. Returns :open or :closed — the shell-visible
@@ -111,11 +132,15 @@ class OverlayHarness
   end
 
   # A scroll-wheel notch over the modal, already ±3-scaled like Runner#handle_wheel.
+  # Guarded like press/click: once the shell has dropped the modal, `active_overlay`
+  # returns nil and neither Runner#wheel_overlay nor #apply_preedit reaches it again.
   def wheel(step : Int32) : Nil
+    live!
     @overlay.handle_wheel(step)
   end
 
   def preedit(text : String) : Nil
+    live!
     @overlay.set_preedit(text)
   end
 

--- a/spec/tui/overlay_dispatch_spec.cr
+++ b/spec/tui/overlay_dispatch_spec.cr
@@ -26,14 +26,14 @@ end
 # rename. Only a literal list pins the wire names, and they are load-bearing twice over:
 # controllers compare `@host.overlay` against these symbols, and every symbol handed to
 # from_sym now RAISES if it is not a member (it used to be a silent no-op).
-EXPECTED_OVERLAY_SYMS = [
+private EXPECTED_OVERLAY_SYMS = {
   :none, :detail, :palette, :issue_new, :confirm, :browser, :choice, :tabs_more,
   :comparer_pick, :repeater_subtab, :links, :issue_pick, :note_pick, :preferences,
   :settings, :tabs, :hosts, :env, :hotkeys, :notifications, :probe_active,
   :discover_config, :discover_headers, :fuzz_set, :fuzz_advanced, :oast_provider,
   :probe_rule, :rewriter_rule, :ca_import, :import, :scope_rule, :sequence_config,
   :mine_config,
-]
+}
 
 # A minimal Overlay to pin the base-class defaults the Runner leans on. Its `key` has to
 # name a real OverlayKind (that is the type), and Palette is the safe pick: the command
@@ -71,7 +71,7 @@ describe "OverlayKind — the state @overlay holds" do
   end
 
   it "spells every member exactly as the Host facade names it" do
-    OverlayKind.values.map(&.to_sym).should eq(EXPECTED_OVERLAY_SYMS)
+    OverlayKind.values.map(&.to_sym).should eq(EXPECTED_OVERLAY_SYMS.to_a)
   end
 
   it "resolves every symbol a live call-site hands to from_sym" do
@@ -117,6 +117,11 @@ describe "Overlay seam — base contract" do
     h = OverlayHarness.new(StubOverlay.new)
 
     h.box.should be_nil
+    # The no-op hooks must not raise — the Runner calls them on whatever modal is up,
+    # without asking whether the base class overrode them. Exercised BEFORE the click
+    # below, because once the shell drops a modal it stops routing to it entirely.
+    h.wheel(3)
+    h.preedit("한")
     # No box → a click can't be inside → the shell dismisses (prior close-on-click-away).
     # Assert the RAW vocabulary, not just the harness's :closed: the harness maps both
     # :cancel and a truthy :commit to :closed, so `eq(:closed)` alone would still pass if
@@ -124,9 +129,43 @@ describe "Overlay seam — base contract" do
     h.overlay.handle_click(h.area, 10, 10).should eq(:cancel)
     h.click(10, 10).should eq(:closed)
     h.commits.should eq(0) # dismissing must never run the commit closure
-    # No-op hooks must not raise (the Runner calls them unconditionally).
-    h.wheel(3)
-    h.preedit("한")
+  end
+
+  it "stops routing input once the shell has dropped the modal" do
+    # The harness's own invariant, and the reason wheel/preedit are guarded too: after a
+    # dismiss, Runner#active_overlay returns nil, so neither #wheel_overlay nor
+    # #apply_preedit reaches the overlay. An example that kept driving one would be
+    # asserting against something the user can no longer touch.
+    h = OverlayHarness.new(StubOverlay.new)
+    h.click(10, 10).should eq(:closed)
+    expect_raises(Exception, /already closed/) { h.press(Termisu::Input::Key::Escape) }
+    expect_raises(Exception, /already closed/) { h.wheel(3) }
+    expect_raises(Exception, /already closed/) { h.preedit("x") }
+  end
+
+  it "keeps a closure the overlay already carried instead of swapping in its own" do
+    # A migration spec mirrors its open-site (which sets on_commit) and THEN wraps the
+    # overlay in the harness. If the harness replaced that closure with `-> { true }`, the
+    # example would assert `commits == 1` and pass while never running the production
+    # apply — the exact vacuous-green this harness exists to prevent.
+    ov = StubOverlay.new
+    applied = 0
+    ov.on_commit = -> {
+      applied += 1
+      true
+    }
+    h = OverlayHarness.new(ov)
+    h.overlay.commit.should be_true
+    applied.should eq(1) # the REAL closure ran
+    h.commits.should eq(1)
+  end
+
+  it "refuses to silently override a pre-set closure with a commit: result" do
+    ov = StubOverlay.new
+    ov.on_commit = -> { true }
+    expect_raises(ArgumentError, /already carries an on_commit/) do
+      OverlayHarness.new(ov, commit: false)
+    end
   end
 
   it "commits with no on_commit supplied (the base-class nil branch) " do
@@ -273,7 +312,9 @@ describe "Overlay seam — SequenceConfigOverlay (hard case: 2 open-sites, no fl
     h.click_in_box(3, 8).should eq(:closed)
     h.commits.should eq(1)
 
-    OverlayHarness.new(SequenceConfigOverlay.new(seed)).click(0, 0).should eq(:closed)
+    away = OverlayHarness.new(SequenceConfigOverlay.new(seed))
+    away.click(0, 0).should eq(:closed)
+    away.commits.should eq(0) # :closed alone would also match a commit — clicking away must not START the run
   end
 
   it "routes IME preedit to the selector field (the seam's per-modal-IME promise)" do
@@ -340,6 +381,8 @@ describe "Overlay seam — MineConfigOverlay (laggard: keys were shell-owned; cl
     h.click_in_box(3, 7).should eq(:closed)
     h.commits.should eq(1)
 
-    OverlayHarness.new(MineConfigOverlay.new(mseed)).click(0, 0).should eq(:closed)
+    away = OverlayHarness.new(MineConfigOverlay.new(mseed))
+    away.click(0, 0).should eq(:closed)
+    away.commits.should eq(0) # ditto: a dismiss must not kick off the miner
   end
 end

--- a/src/gori/tui/overlay.cr
+++ b/src/gori/tui/overlay.cr
@@ -62,15 +62,12 @@ module Gori::Tui
       {% end %}
     end
 
+    # `Enum.parse?` already matches on the underscored member name and already answers nil
+    # on an unknown one, so this is just its raising wrapper — no second hand-rolled name
+    # table to drift out of step with the member list. Only `to_sym` needs a macro, because
+    # Symbol literals cannot be built at runtime.
     def self.from_sym(sym : Symbol) : OverlayKind
-      {% begin %}
-        case sym
-        {% for c in @type.constants %}
-        when :{{ c.stringify.underscore.id }} then OverlayKind::{{ c }}
-        {% end %}
-        else raise ArgumentError.new("unknown overlay kind: #{sym}")
-        end
-      {% end %}
+      parse?(sym.to_s) || raise ArgumentError.new("unknown overlay kind: #{sym}")
     end
   end
 
@@ -102,9 +99,14 @@ module Gori::Tui
     # it open — e.g. a validation error keeps the form up). Supplied at the open-site.
     property on_commit : Proc(Bool)?
 
-    # The `@overlay` state this modal sets. Kept in sync by the Runner so `modal_overlay?`
-    # and any residual `@overlay ==` checks keep working while the other overlays migrate
-    # onto this base one at a time.
+    # The `@overlay` state this modal sets, written by `Runner#open_overlay`.
+    #
+    # It is NOT what makes the modal capture input: a migrated modal's member is deleted
+    # from `Runner::MODAL_OVERLAYS`, and `modal_overlay?` answers for it through
+    # `active_overlay` instead. `key`'s real job is the liveness token in that method's
+    # `@overlay == ov.key` gate — ~40 sites reset `@overlay` directly without clearing
+    # `@active_overlay`, and comparing against `key` is what makes such a reset render the
+    # overlay inert rather than leaving a zombie that keeps drawing and capturing.
     abstract def key : OverlayKind
 
     # Shell chrome: the focus-badge title (top bar) and the bottom-row key hint. These


### PR DESCRIPTION
Follow-up to #368. A `/code-review` pass came back after that PR merged; these are the findings on the **new** code, each proved by mutation (break the code, watch the suite stay green) and each control-run after the fix.

Landing before C1–C5 start, because `OverlayHarness` is the scaffolding all five batches build on.

## The one that matters

**`OverlayHarness.new` overwrote `on_commit` unconditionally.** The real open-sites (`open_scope_rule_editor` and friends) set that closure *before* handing the modal over, so a migration spec written the natural way:

```crystal
ov = FooOverlay.new(seed)
ov.on_commit = -> { foo_controller.apply(ov) }   # mirror the open-site
h = OverlayHarness.new(ov)                        # ...silently thrown away
h.press(Enter).should eq(:closed)
h.commits.should eq(1)                            # passes, proving nothing
```

...had its production apply replaced by `-> { true }` with no warning, then asserted `commits == 1` and passed. That is exactly the vacuous-green this harness exists to prevent, and it would have bitten all five batches.

It now **wraps** an existing closure (keeping it, just making its runs observable) and **raises** if you also pass `commit:`, rather than dropping one on the floor.

## Also fixed

- **`wheel`/`preedit` are guarded by `live!`** like `press`/`click`. Once the shell drops a modal, `Runner#active_overlay` returns nil and neither `wheel_overlay` nor `apply_preedit` reaches it. The base-contract example was driving both on an already-closed overlay under a comment claiming *"the Runner calls them unconditionally"* — it doesn't. Adding the guard made that example fail immediately, which is how I confirmed the finding.
- **Clicking away from SEQUENCER / MINE PARAMS now asserts `commits == 0`.** The harness collapses `:cancel` and a truthy `:commit` into the same `:closed`, so those two examples passed even when a dismiss *started the run*. Verified: flipping both overlays' click-away to `:commit` now fails both examples; before, the suite stayed green.
- **`from_sym` drops its 9-line macro for `Enum.parse?`**, which already matches the underscored member name and already answers nil on an unknown one (verified: `parse?("scope_rule")` → `ScopeRule`, `parse?("ca_import")` → `CaImport`, `parse?("probe_rules")` → nil). One less hand-rolled name table to drift out of step with the member list. Raising behaviour is unchanged.
- **`EXPECTED_OVERLAY_SYMS` is now `private` and a Tuple.** It was a non-private mutable global `Array` in a suite that compiles as one binary — any spec could have mutated the wire-name pin in place, disarming the only check that catches a renamed enum member.
- **`Overlay#key`'s doc described a mechanism this migration inverted.** It said `key` is kept in sync "so `modal_overlay?` keeps working", but for a migrated modal `modal_overlay?` no longer consults `key` at all — its member is deleted from `MODAL_OVERLAYS`. `key`'s real contract is the liveness token in `@overlay == ov.key`. Phase 1 authors read this file first.
- `DEFAULT_AREA`'s divergence from `layout.body` is now documented rather than changed — see below.

## Verification

- `just build` clean, `just test` **3913 examples, 0 failures**
- `crystal tool format` clean on the three changed files
- Mutation-tested both new guards: reverting the harness fix fails 2 examples; flipping SequenceConfig/MineConfig click-away to `:commit` fails 2 more.

## Deliberately NOT changed

`DEFAULT_AREA` is `Rect(0,0,80,24)` — the whole screen — where the shell actually passes `layout.body`, `Rect(2,4,76,18)` on an 80x24 terminal. So cards get 22 usable rows in spec vs 16 in production, and the `overlay_box → nil` path (small terminal, where the base `handle_click` turns every click into a dismiss) is unreachable through the default. Correcting it would re-baseline geometry assertions across every existing overlay spec, which is not something to do in the window where five batches are about to branch. **Documented in the harness header with a pointer to pass an explicit `area:`**; worth a follow-up once C1–C5 have landed.

## Pre-existing issues found, filed separately

The review also surfaced real bugs that predate #368 and are out of scope here — they are reported on #355 for the batch authors, notably that `probe_rule` has no branch in the `focus_label`/`key_hints` ladders (confirmed present on main before #368), and that `dispatch_overlay_key` calls `close_active_overlay` *after* `ov.commit`, which clobbers any modal the commit closure opened (a live trap for C2's `ca_import`).

Refs #355