### PR TITLE
refactor(tui): migrate the rule, provider and import modals onto the Overlay seam (#355)

### DIFF
--- a/spec/tui/ca_import_overlay_spec.cr
+++ b/spec/tui/ca_import_overlay_spec.cr
@@ -1,0 +1,118 @@
+require "../spec_helper"
+require "../support/memory_backend"
+require "../support/overlay_harness"
+
+include Gori::Tui
+
+private def ckey(k : Termisu::Input::Key, char : Char? = nil) : Termisu::Event::Key
+  Termisu::Event::Key.new(k, char: char)
+end
+
+# The "Import CA certificate" popup (palette → ca.import). It is a DUMB two-path form:
+# the destructive half — validating the pair, dropping the card, and running the danger
+# confirm before CertAuthority#import! — is the injected on_commit closure at the
+# open-site (Runner#import_ca). These specs pin that split, because the failure mode of
+# getting it wrong is a root CA replaced without a confirm.
+describe Gori::Tui::CAImportOverlay do
+  it "exposes the chrome the collapsed Runner ladders used to hard-code" do
+    OverlayHarness.new(CAImportOverlay.new).assert_chrome(OverlayKind::CaImport, "IMPORT CA")
+  end
+
+  it "walks cert → key with ⇥/↓ and commits only from the LAST row" do
+    ov = CAImportOverlay.new
+    h = OverlayHarness.new(ov)
+    h.on_commit { true }
+
+    # A path under a directory that cannot exist, so the completion dropdown never opens
+    # and ↵ means "next row" rather than "accept a suggestion" (it owns both).
+    h.type("/gori-spec-no-such-dir/ca.pem").should eq(:open)
+    # ↵ on the certificate row advances instead of submitting — a half-filled form must
+    # not reach the confirm.
+    h.press(Termisu::Input::Key::Enter).should eq(:open)
+    h.commits.should eq(0)
+    h.type("/gori-spec-no-such-dir/ca.key").should eq(:open)
+    h.press(Termisu::Input::Key::Enter).should eq(:closed)
+
+    h.commits.should eq(1)
+    ov.cert_path.should eq("/gori-spec-no-such-dir/ca.pem")
+    ov.key_path.should eq("/gori-spec-no-such-dir/ca.key")
+  end
+
+  it "keeps the form up when the commit closure rejects it (a missing path)" do
+    # Runner#submit_ca_import toasts "both … are required" and returns false; the card
+    # must stay so the user can fill the row in, not vanish with the typed path.
+    ov = CAImportOverlay.new
+    h = OverlayHarness.new(ov, commit: false)
+    h.press(Termisu::Input::Key::Down) # → key row
+    h.press(Termisu::Input::Key::Enter).should eq(:open)
+    h.commits.should eq(1) # it ran — it just refused to close
+  end
+
+  it "esc cancels and a click-away dismisses — neither ever commits" do
+    h = OverlayHarness.new(CAImportOverlay.new)
+    h.press(Termisu::Input::Key::Escape).should eq(:closed)
+    h.commits.should eq(0)
+
+    away = OverlayHarness.new(CAImportOverlay.new)
+    # Assert the RAW outcome too: the harness folds :cancel and a truthy :commit into
+    # :closed, so eq(:closed) alone would still pass if clicking away started a CA swap.
+    away.overlay.handle_click(away.area, 0, 0).should eq(:cancel)
+    away.click(0, 0).should eq(:closed)
+    away.commits.should eq(0)
+  end
+
+  it "click selects the field row under the pointer (rows start at box.y + 3)" do
+    ov = CAImportOverlay.new
+    h = OverlayHarness.new(ov)
+    h.click_in_box(3, 4).should eq(:open) # the Private key row
+    h.type("/gori-spec-no-such-dir/ca.key")
+    ov.key_path.should eq("/gori-spec-no-such-dir/ca.key")
+    ov.cert_path.should be_empty
+  end
+
+  it "scrolls the field cursor with the wheel" do
+    ov = CAImportOverlay.new
+    OverlayHarness.new(ov).wheel(3) # clamps at the last row
+    ov.as(Overlay).handle_key(ckey(Termisu::Input::Key::Enter)).should eq(:commit)
+  end
+
+  it "routes IME preedit to the focused row" do
+    h = OverlayHarness.new(CAImportOverlay.new)
+    h.preedit("preedithere")
+    h.rendered?("preedithere").should be_true
+  end
+
+  it "dismisses — never submits — when the window is too small to draw the card" do
+    # The harness's DEFAULT_AREA is the whole screen, so this path is unreachable through
+    # it; production hands `layout.body`, which is 6 rows shorter. With no box, every click
+    # is a dismiss (the pre-migration `close_ca_import if box.nil?`), and the card degrades
+    # to a one-line "needs a larger window" notice rather than a phantom form.
+    tiny = Gori::Tui::Rect.new(2, 4, 30, 6)
+    h = OverlayHarness.new(CAImportOverlay.new, area: tiny)
+    h.box.should be_nil
+    h.overlay.handle_click(tiny, 10, 5).should eq(:cancel) # raw: not a CA swap
+    h.click(10, 5).should eq(:closed)
+    h.commits.should eq(0)
+    h.render.contains?("CA import needs a larger").should be_true # the rest is clipped by the 30-col area
+  end
+
+  it "keeps Tab path completion inside the overlay, caret at the end" do
+    # Tab is the completion key here, NOT a field-advance the shell could claim: the
+    # dropdown owns it while open. Driven end-to-end so the whole accept path stays covered.
+    dir = File.join(Dir.tempdir, "gori-ca-import-spec-#{Process.pid}")
+    Dir.mkdir_p(dir)
+    File.write(File.join(dir, "root.pem"), "-----BEGIN CERTIFICATE-----")
+    begin
+      ov = CAImportOverlay.new
+      h = OverlayHarness.new(ov)
+      h.type("#{dir}/")                 # opens the dropdown on root.pem
+      h.press(Termisu::Input::Key::Tab) # accept the completion
+      ov.cert_path.should eq(File.join(dir, "root.pem"))
+      h.type("X") # …and the caret is at the END
+      ov.cert_path.should eq(File.join(dir, "root.pemX"))
+      h.commits.should eq(0) # completing is not committing
+    ensure
+      FileUtils.rm_rf(dir)
+    end
+  end
+end

--- a/spec/tui/custom_rule_overlay_spec.cr
+++ b/spec/tui/custom_rule_overlay_spec.cr
@@ -1,0 +1,92 @@
+require "../spec_helper"
+require "../support/memory_backend"
+require "../support/overlay_harness"
+
+include Gori::Tui
+
+private def rdown(h : OverlayHarness, n : Int32) : Nil
+  n.times { h.press(Termisu::Input::Key::Down) }
+end
+
+# The Probe custom-rule form (Probe → Rules → a/e). A dumb form: the persist — global →
+# settings.json, project → project DB, plus the move between them when the scope row
+# changes on an edit — is ProbeController#apply_custom_rule, injected as on_commit at the
+# open-site (Runner#open_custom_rule_editor).
+describe Gori::Tui::CustomRuleOverlay do
+  it "exposes the chrome the Runner ladders never had for it" do
+    # BEHAVIOUR CHANGE, deliberate: pre-migration this modal had NO entry in either the
+    # focus-badge or the key-hint ladder, so an open custom-rule card showed the tab
+    # bar's/body's stale label and hints. Under the seam `title`/`hint` are abstract, so
+    # the gap is closed by construction.
+    OverlayHarness.new(CustomRuleOverlay.adding).assert_chrome(OverlayKind::ProbeRule, "CUSTOM RULE")
+  end
+
+  it "drives fields → Save → on_commit → close through the generic dispatch" do
+    ov = CustomRuleOverlay.adding
+    h = OverlayHarness.new(ov)
+    saved = [] of {String, String, String, String}
+    h.on_commit do
+      # rule_title, NOT title: `title` is the Overlay chrome label. ProbeController reads
+      # exactly these accessors, so a collision here would persist the badge text as the
+      # rule's name — silently, on every save.
+      saved << {ov.rule_title, ov.description, ov.scope, ov.pattern}
+      true
+    end
+
+    h.type("leaky header")
+    rdown(h, 1)
+    h.type("finds a debug header")
+    rdown(h, 1)                         # → scope (project)
+    h.press(Termisu::Input::Key::Right) # project → global
+    rdown(h, 5)                         # scope → side → region → match → severity → pattern
+    h.type("X-Debug")
+    h.press(Termisu::Input::Key::Enter).should eq(:closed) # ↵ on the pattern row commits
+
+    saved.should eq([{"leaky header", "finds a debug header", "global", "X-Debug"}])
+  end
+
+  it "keeps the form open when the controller rejects it (invalid rule)" do
+    ov = CustomRuleOverlay.adding
+    ov.valid?.should be_false # nothing filled in
+    h = OverlayHarness.new(ov, commit: false)
+    ov.set_selected(8) # Save row
+    h.press(Termisu::Input::Key::Enter).should eq(:open)
+    h.commits.should eq(1) # apply_custom_rule DID run — it just returned false
+  end
+
+  it "esc cancels and a click-away dismisses — neither persists anything" do
+    h = OverlayHarness.new(CustomRuleOverlay.adding)
+    h.press(Termisu::Input::Key::Escape).should eq(:closed)
+    h.commits.should eq(0)
+
+    away = OverlayHarness.new(CustomRuleOverlay.adding)
+    away.overlay.handle_click(away.area, 0, 0).should eq(:cancel) # raw: not a silent save
+    away.click(0, 0).should eq(:closed)
+    away.commits.should eq(0)
+  end
+
+  it "click selects a row, and a click on Save commits" do
+    ov = CustomRuleOverlay.editing(
+      Gori::Probe::CustomRule.new(id: "7", title: "leaky", description: "desc",
+        side: "response", region: "body", kind: "string", pattern: "X-Debug",
+        severity: Gori::Store::Severity::Info, scope: "project", enabled: true))
+    h = OverlayHarness.new(ov)
+    # Rows start at box.y + 2; Save is index 8.
+    h.click_in_box(3, 3).should eq(:open) # the desc row
+    ov.on_save_row?.should be_false
+    h.click_in_box(3, 10).should eq(:closed)
+    h.commits.should eq(1)
+  end
+
+  it "moves the selected field with the wheel" do
+    ov = CustomRuleOverlay.adding
+    OverlayHarness.new(ov).wheel(3 * 3) # 9 notches down clamps onto Save
+    ov.on_save_row?.should be_true
+  end
+
+  it "routes IME preedit to the focused text row" do
+    h = OverlayHarness.new(CustomRuleOverlay.adding)
+    h.preedit("preedithere")
+    h.rendered?("preedithere").should be_true
+  end
+end

--- a/spec/tui/import_overlay_spec.cr
+++ b/spec/tui/import_overlay_spec.cr
@@ -1,5 +1,6 @@
 require "../spec_helper"
 require "../support/memory_backend"
+require "../support/overlay_harness"
 
 include Gori::Tui
 
@@ -44,7 +45,7 @@ describe Gori::Tui::ImportOverlay do
     ov = ImportOverlay.new(:har)
     type(ov, "/tmp/x.har")
     ov.path.should eq("/tmp/x.har")
-    ov.handle_key(key(Termisu::Input::Key::Enter)).should eq(:submit)
+    ov.handle_key(key(Termisu::Input::Key::Enter)).should eq(:commit)
   end
 
   it "cancels on esc" do
@@ -80,10 +81,56 @@ describe Gori::Tui::ImportOverlay do
     end
   end
 
-  it "consumes clicks inside the card but reports those outside (click-away dismisses)" do
+  it "consumes clicks inside the card but dismisses on a click-away" do
+    # Inherited from Overlay's default handle_click — there is one field and it always
+    # holds focus, so a click inside has nothing to select but must not read as a dismiss.
     ov = ImportOverlay.new(:har)
-    box = ov.overlay_box(Rect.new(0, 0, 100, 30)).not_nil!
-    ov.handle_click(box, box.x + 2, box.y + 3).should be_true
-    ov.handle_click(box, box.x - 1, box.y).should be_false
+    area = Rect.new(0, 0, 100, 30)
+    box = ov.overlay_box(area).not_nil!
+    ov.handle_click(area, box.x + 2, box.y + 3).should eq(:stay)
+    ov.handle_click(area, box.x - 1, box.y).should eq(:cancel)
+  end
+end
+
+# The seam the migration bought: the Runner no longer owns a handle_import_key, a
+# click_import, an @import_overlay ivar or the "IMPORT #{label}" title interpolation —
+# it opens this overlay with an on_commit closure and dispatches generically.
+describe "Gori::Tui::ImportOverlay — Overlay seam" do
+  it "names itself in the focus badge by SOURCE FORMAT, not just \"IMPORT\"" do
+    # This was a Runner-side `"IMPORT #{@import_overlay.try(&.label) || "FILE"}"`; the
+    # per-kind title has to survive the move, or every import reads the same in the badge.
+    {:har => "IMPORT HAR", :urls => "IMPORT URLs", :oas => "IMPORT OpenAPI"}.each do |kind, want|
+      OverlayHarness.new(ImportOverlay.new(kind)).assert_chrome(OverlayKind::Import, want)
+    end
+  end
+
+  it "drives type → ↵ → on_commit → close through the generic shell dispatch" do
+    ov = ImportOverlay.new(:har)
+    h = OverlayHarness.new(ov)
+    imported = [] of {Symbol, String}
+    h.on_commit do
+      imported << {ov.kind, ov.path} # the open-site reads kind/path off the form
+      true
+    end
+
+    h.type("/tmp/x.har").should eq(:open)
+    h.press(Termisu::Input::Key::Enter).should eq(:closed)
+    imported.should eq([{:har, "/tmp/x.har"}])
+  end
+
+  it "esc cancels without importing, and a click-away is a dismiss (never an import)" do
+    h = OverlayHarness.new(ImportOverlay.new(:har))
+    h.press(Termisu::Input::Key::Escape).should eq(:closed)
+    h.commits.should eq(0)
+
+    away = OverlayHarness.new(ImportOverlay.new(:har))
+    away.click(0, 0).should eq(:closed)
+    away.commits.should eq(0)
+  end
+
+  it "routes IME preedit to the path field" do
+    h = OverlayHarness.new(ImportOverlay.new(:har))
+    h.preedit("preedithere")
+    h.rendered?("preedithere").should be_true
   end
 end

--- a/spec/tui/oast_provider_overlay_spec.cr
+++ b/spec/tui/oast_provider_overlay_spec.cr
@@ -1,5 +1,6 @@
 require "../spec_helper"
 require "../support/memory_backend"
+require "../support/overlay_harness"
 
 include Gori::Tui
 
@@ -72,5 +73,79 @@ describe Gori::Tui::OastProviderOverlay do
     ov.row_at(box, box.x + 3, box.y + 3).should eq(1) # scope row
     ov.row_at(box, box.x + 3, box.y + 4).should eq(2) # type row
     ov.row_at(box, box.x + 3, box.y + 7).should eq(5) # save row
+  end
+end
+
+# Post-migration surface: the Runner no longer owns handle_oast_provider_key /
+# click_oast_provider / commit_oast_provider_overlay / @oast_provider_overlay — it opens
+# this overlay with OastController#save_provider injected as on_commit and dispatches
+# generically (see spec/tui/overlay_dispatch_spec.cr for the shared contract).
+describe "Gori::Tui::OastProviderOverlay — Overlay seam" do
+  it "exposes the chrome the collapsed Runner ladders used to hard-code" do
+    OverlayHarness.new(OastProviderOverlay.adding).assert_chrome(OverlayKind::OastProvider, "OAST PROVIDER")
+  end
+
+  it "carries the global-vs-project scope field through to the commit closure" do
+    # The scope row decides settings.json vs the project DB — the one field whose loss
+    # would silently write a provider to the wrong place.
+    ov = OastProviderOverlay.adding
+    h = OverlayHarness.new(ov)
+    saved = [] of {String, String, String}
+    h.on_commit do
+      saved << {ov.provider_name, ov.scope, ov.host}
+      true
+    end
+
+    h.type("my-oast")
+    h.press(Termisu::Input::Key::Down)  # → scope
+    h.press(Termisu::Input::Key::Right) # project → global
+    3.times { h.press(Termisu::Input::Key::Down) }
+    ov.on_save_row?.should be_false # host → token → Save
+    h.press(Termisu::Input::Key::Down)
+    ov.on_save_row?.should be_true
+    h.press(Termisu::Input::Key::Enter).should eq(:closed)
+
+    saved.should eq([{"my-oast", "global", "https://oast.pro"}])
+  end
+
+  it "keeps the form open when the controller rejects it (name/host required)" do
+    ov = OastProviderOverlay.adding
+    ov.valid?.should be_false # no name yet
+    h = OverlayHarness.new(ov, commit: false)
+    ov.set_selected(5) # Save row
+    h.press(Termisu::Input::Key::Enter).should eq(:open)
+    h.commits.should eq(1) # save_provider DID run — it just returned false
+  end
+
+  it "esc cancels and a click-away dismisses — neither persists anything" do
+    h = OverlayHarness.new(OastProviderOverlay.adding)
+    h.press(Termisu::Input::Key::Escape).should eq(:closed)
+    h.commits.should eq(0)
+
+    away = OverlayHarness.new(OastProviderOverlay.adding)
+    away.overlay.handle_click(away.area, 0, 0).should eq(:cancel) # raw: not a silent save
+    away.click(0, 0).should eq(:closed)
+    away.commits.should eq(0)
+  end
+
+  it "click selects a row, and a click on Save commits" do
+    ov = OastProviderOverlay.editing(config)
+    h = OverlayHarness.new(ov)
+    # Rows start at box.y + 2; Save is index 5.
+    h.click_in_box(3, 3).should eq(:open) # scope row
+    h.click_in_box(3, 7).should eq(:closed)
+    h.commits.should eq(1)
+  end
+
+  it "moves the selected field with the wheel" do
+    ov = OastProviderOverlay.adding
+    OverlayHarness.new(ov).wheel(2 * 3) # 6 notches down clamps onto Save
+    ov.on_save_row?.should be_true
+  end
+
+  it "routes IME preedit to the focused text row" do
+    h = OverlayHarness.new(OastProviderOverlay.adding)
+    h.preedit("preedithere")
+    h.rendered?("preedithere").should be_true
   end
 end

--- a/spec/tui/overlay_dispatch_spec.cr
+++ b/spec/tui/overlay_dispatch_spec.cr
@@ -35,6 +35,27 @@ private EXPECTED_OVERLAY_SYMS = {
   :mine_config,
 }
 
+# The migration ledger — THE one line a Phase 1 batch edits in this file. Each batch
+# appends its own members, one per line, when its modals move onto the Overlay seam; two
+# batches appending different lines merge cleanly, where a shared count could not. Both
+# examples below read this, so the ledger lives in exactly one place.
+private MIGRATED_KINDS = [
+  OverlayKind::ScopeRule,
+  OverlayKind::SequenceConfig,
+  OverlayKind::MineConfig,
+  # C2 — rule / provider / import forms
+  OverlayKind::OastProvider,
+  OverlayKind::ProbeRule,
+  OverlayKind::RewriterRule,
+  OverlayKind::CaImport,
+  OverlayKind::Import,
+]
+
+# Never in MODAL_OVERLAYS by design, migrated or not: neither draws a capturing card.
+# `None` is "no modal at all" and `Detail` is the History drill-in, which the Runner keeps
+# in the tab body rather than a centered card (see Runner#modal_overlay?).
+private NON_MODAL_KINDS = [OverlayKind::None, OverlayKind::Detail]
+
 # A minimal Overlay to pin the base-class defaults the Runner leans on. Its `key` has to
 # name a real OverlayKind (that is the type), and Palette is the safe pick: the command
 # palette is explicitly OUT of the migration's scope, so no production Overlay will ever
@@ -91,24 +112,26 @@ describe "OverlayKind — the state @overlay holds" do
     # A migration DELETES its member from Runner::MODAL_OVERLAYS — the migrated modal
     # answers modal_overlay? through active_overlay instead. Leaving a stale member behind
     # would make the gate true with no overlay object to route to.
-    [OverlayKind::ScopeRule, OverlayKind::SequenceConfig, OverlayKind::MineConfig].each do |k|
-      Runner::MODAL_OVERLAYS.includes?(k).should be_false
+    MIGRATED_KINDS.each do |k|
+      Runner::MODAL_OVERLAYS.includes?(k).should be_false, "#{k} migrated but kept the legacy gate"
     end
   end
 
   it "still captures input for every UNMIGRATED modal" do
-    # The other half of the gate. MODAL_OVERLAYS is the one line all five Phase 1 batches
-    # edit, and an accidental deletion is invisible: the modal still renders, but the shell
-    # stops treating it as capturing, so clicks fall through to the tab body behind the card
-    # and the wheel scrolls that body. Pin the list until each batch removes its own member.
-    unmigrated = OverlayKind.values - [
-      OverlayKind::None, OverlayKind::Detail, # not modals: no card, never capture
-      OverlayKind::ScopeRule, OverlayKind::SequenceConfig, OverlayKind::MineConfig,
-    ]
-    unmigrated.size.should eq(28)
-    unmigrated.each do |k|
-      Runner::MODAL_OVERLAYS.includes?(k).should be_true, "#{k} lost its input-capture gate"
-    end
+    # The other half of the gate, and the reason it is SET EQUALITY rather than a count.
+    #
+    # An accidental deletion from MODAL_OVERLAYS is invisible at runtime: the modal still
+    # renders, but the shell stops treating it as capturing, so clicks fall through to the
+    # tab body behind the card and the wheel scrolls that body. An accidental ADDITION is
+    # equally invisible, and a count could never catch it — only complementarity can.
+    #
+    # Both sides are derived, so this needs no edit when an OverlayKind member is added:
+    # the single per-batch edit is appending to MIGRATED_KINDS above. It used to be a
+    # hard-coded total, which put five parallel batches on one line each wanting a
+    # different integer — and resolving that conflict by keeping your own literal asserts
+    # a total that is wrong for the combined state.
+    unmigrated = OverlayKind.values - NON_MODAL_KINDS - MIGRATED_KINDS
+    unmigrated.to_set.should eq(Runner::MODAL_OVERLAYS.to_set)
   end
 end
 

--- a/spec/tui/rewriter_rule_overlay_spec.cr
+++ b/spec/tui/rewriter_rule_overlay_spec.cr
@@ -1,5 +1,6 @@
 require "../spec_helper"
 require "../support/memory_backend"
+require "../support/overlay_harness"
 
 include Gori::Tui
 
@@ -95,5 +96,107 @@ describe Gori::Tui::RewriterRuleOverlay do
     ov.render(screen, area)
     box = ov.overlay_box(area).not_nil!
     ov.row_at(box, box.x + 3, box.y + 2).should eq(0) # name row
+  end
+end
+
+# Post-migration surface. This form carries TWO injected couplings, not one: on_commit
+# (RewriterController#apply_rewriter_rule) and on_preview (a scan of recent flows). The
+# form owns only WHEN to ask for a preview — that gate used to be @rewriter_preview_sig
+# on the Runner, and it is what keeps typing from rescanning traffic on every keystroke.
+describe "Gori::Tui::RewriterRuleOverlay — Overlay seam" do
+  it "exposes the chrome the collapsed Runner ladders used to hard-code" do
+    OverlayHarness.new(RewriterRuleOverlay.adding).assert_chrome(OverlayKind::RewriterRule, "REWRITER RULE")
+  end
+
+  it "drives fields → ↵ on value → on_commit → close through the generic dispatch" do
+    ov = RewriterRuleOverlay.adding
+    h = OverlayHarness.new(ov)
+    saved = [] of {String, String, String}
+    h.on_commit do
+      saved << {ov.name, ov.pattern, ov.replacement}
+      true
+    end
+
+    h.type("strip-csp")
+    6.times { h.press(Termisu::Input::Key::Down) } # name → … → find
+    h.type("secret")
+    h.press(Termisu::Input::Key::Down) # → value
+    h.type("REDACTED")
+    h.press(Termisu::Input::Key::Enter).should eq(:closed)
+
+    saved.should eq([{"strip-csp", "secret", "REDACTED"}])
+  end
+
+  it "keeps the form open when the controller rejects it (empty pattern)" do
+    ov = RewriterRuleOverlay.adding
+    ov.valid?.should be_false
+    h = OverlayHarness.new(ov, commit: false)
+    ov.set_selected(8) # Save row
+    h.press(Termisu::Input::Key::Enter).should eq(:open)
+    h.commits.should eq(1) # apply_rewriter_rule DID run — it just returned false
+  end
+
+  it "esc cancels and a click-away dismisses — neither persists anything" do
+    h = OverlayHarness.new(RewriterRuleOverlay.adding)
+    h.press(Termisu::Input::Key::Escape).should eq(:closed)
+    h.commits.should eq(0)
+
+    away = OverlayHarness.new(RewriterRuleOverlay.adding)
+    away.overlay.handle_click(away.area, 0, 0).should eq(:cancel) # raw: not a silent save
+    away.click(0, 0).should eq(:closed)
+    away.commits.should eq(0)
+  end
+
+  it "click selects a row, and a click on Save commits" do
+    ov = RewriterRuleOverlay.adding
+    h = OverlayHarness.new(ov)
+    # Rows start at box.y + 2; Save is index 8.
+    h.click_in_box(3, 4).should eq(:open) # the op row
+    h.click_in_box(3, 10).should eq(:closed)
+    h.commits.should eq(1)
+  end
+
+  it "asks the injected preview source ONCE per match-relevant change, never for pure nav" do
+    ov = RewriterRuleOverlay.adding
+    asked = [] of Gori::Store::MatchRule
+    ov.on_preview = ->(candidate : Gori::Store::MatchRule) {
+      asked << candidate
+      "affects 2 of 7 recent flows"
+    }
+    h = OverlayHarness.new(ov)
+
+    # An empty pattern must never scan (it would match everything); the slot says so.
+    h.press(Termisu::Input::Key::Down)
+    ov.preview.should eq("enter a pattern to preview")
+    asked.should be_empty
+
+    5.times { h.press(Termisu::Input::Key::Down) } # → find
+    h.type("secret")
+    asked.size.should eq(6) # one scan per character that changed the pattern
+    asked.last.pattern.should eq("secret")
+    ov.preview.should eq("affects 2 of 7 recent flows")
+
+    # Moving the selection changes no match-relevant field → no rescan, so typing stays
+    # responsive no matter how much traffic is in the project.
+    before = asked.size
+    3.times { h.press(Termisu::Input::Key::Up) }
+    h.click_in_box(3, 4)
+    h.wheel(3)
+    asked.size.should eq(before)
+  end
+
+  it "labels the preview slot for a header op (\"header name\", not \"pattern\")" do
+    ov = RewriterRuleOverlay.adding
+    h = OverlayHarness.new(ov)
+    2.times { h.press(Termisu::Input::Key::Down) } # → op
+    h.press(Termisu::Input::Key::Right)            # replace → add_header
+    ov.header_op?.should be_true
+    ov.preview.should eq("enter a header name to preview")
+  end
+
+  it "routes IME preedit to the focused text row" do
+    h = OverlayHarness.new(RewriterRuleOverlay.adding)
+    h.preedit("preedithere")
+    h.rendered?("preedithere").should be_true
   end
 end

--- a/src/gori/tui/ca_import_overlay.cr
+++ b/src/gori/tui/ca_import_overlay.cr
@@ -3,6 +3,7 @@ require "./theme"
 require "./frame"
 require "./text_field"
 require "./path_complete"
+require "./overlay"
 
 module Gori::Tui
   # Full-area popup collecting an externally-created root CA's certificate + private
@@ -10,11 +11,12 @@ module Gori::Tui
   # fields with an inline PathComplete dropdown, modeled on FuzzSetOverlay's
   # field+dropdown pattern but far simpler (no payload grammar).
   #
-  # Surfaces used by the Runner: handle_key returns :submit when the user commits
-  # (↵ on the Key row), :cancel on esc, :stay otherwise. On :submit the Runner reads
-  # cert_path / key_path and runs the destructive-CA confirm before calling
-  # CertAuthority#import!. set_preedit routes composing (IME) text to the focused row.
-  class CAImportOverlay
+  # On the polymorphic Overlay seam (see overlay.cr): the Runner dispatches key/click/
+  # wheel/preedit/render/title/hint here generically, and the destructive half — read
+  # cert_path / key_path, then run the same danger confirm as regenerate before calling
+  # CertAuthority#import! — is injected as `on_commit` at the open-site (Runner#import_ca).
+  # This form never touches the CA itself.
+  class CAImportOverlay < Overlay
     ROWS = [:cert, :key]
 
     def initialize
@@ -42,8 +44,21 @@ module Gori::Tui
       @sel == ROWS.size - 1
     end
 
+    # --- Overlay contract (see overlay.cr) -----------------------------------
+    def key : OverlayKind
+      OverlayKind::CaImport
+    end
+
+    def title : String
+      "IMPORT CA"
+    end
+
+    def hint : String
+      "type to complete · ↹/↵ pick · ⇥/↑↓ field · ↵ submits · esc cancels"
+    end
+
     # --- input ---------------------------------------------------------------
-    # :submit when the user commits (↵ on the last row), :cancel on esc, else :stay.
+    # :commit when the user submits (↵ on the last row), :cancel on esc, else :stay.
     def handle_key(ev : Termisu::Event::Key) : Symbol
       key = ev.key
 
@@ -64,7 +79,7 @@ module Gori::Tui
       elsif key.back_tab? || key.up?
         move_row(-1); return :stay
       elsif key.enter?
-        return :submit if on_last_row?
+        return :commit if on_last_row?
         move_row(1); return :stay
       end
 
@@ -144,15 +159,17 @@ module Gori::Tui
     end
 
     # --- mouse ---------------------------------------------------------------
-    # Focus the field row under a click. Returns true when the click was inside the box.
-    def handle_click(box : Rect, mx : Int32, my : Int32) : Bool
-      return false unless box.contains?(mx, my)
+    # Focus the field row under a click. A click outside the card cancels — never a
+    # submit, since the CA swap behind it is destructive.
+    def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      box = overlay_box(area)
+      return :cancel if box.nil? || !box.contains?(mx, my)
       i = my - (box.y + 3)
       if 0 <= i < ROWS.size
         @sel = i
         @path_complete.close
       end
-      true
+      :stay
     end
   end
 end

--- a/src/gori/tui/controllers/probe_controller.cr
+++ b/src/gori/tui/controllers/probe_controller.cr
@@ -426,9 +426,9 @@ module Gori::Tui
       if id = ov.edit_id
         if ov.scope == ov.edit_scope
           if ov.scope == "global"
-            Settings.update_scan_rule(id, ov.title, ov.description, ov.side, ov.region, ov.kind, ov.pattern, ov.severity.label)
+            Settings.update_scan_rule(id, ov.rule_title, ov.description, ov.side, ov.region, ov.kind, ov.pattern, ov.severity.label)
           else
-            store.update_probe_custom_rule(id.to_i64, ov.title, ov.description, ov.side, ov.region, ov.kind, ov.pattern, ov.severity)
+            store.update_probe_custom_rule(id.to_i64, ov.rule_title, ov.description, ov.side, ov.region, ov.kind, ov.pattern, ov.severity)
           end
         else
           ov.edit_scope == "global" ? Settings.delete_scan_rule(id) : store.delete_probe_custom_rule(id.to_i64)
@@ -445,9 +445,9 @@ module Gori::Tui
 
     private def insert_custom_rule(ov : CustomRuleOverlay, store : Store) : Nil
       if ov.scope == "global"
-        Settings.add_scan_rule(ov.title, ov.description, ov.side, ov.region, ov.kind, ov.pattern, ov.severity.label)
+        Settings.add_scan_rule(ov.rule_title, ov.description, ov.side, ov.region, ov.kind, ov.pattern, ov.severity.label)
       else
-        store.insert_probe_custom_rule(ov.title, ov.description, ov.side, ov.region, ov.kind, ov.pattern, ov.severity)
+        store.insert_probe_custom_rule(ov.rule_title, ov.description, ov.side, ov.region, ov.kind, ov.pattern, ov.severity)
       end
     end
 

--- a/src/gori/tui/custom_rule_overlay.cr
+++ b/src/gori/tui/custom_rule_overlay.cr
@@ -2,6 +2,7 @@ require "./screen"
 require "./theme"
 require "./frame"
 require "./text_field"
+require "./overlay"
 require "../store"
 require "../store/safe_regexp"
 require "../probe/custom_rule"
@@ -13,8 +14,14 @@ module Gori::Tui
   #   ←/→        cycle the selected option row (scope/side/region/match/severity)
   #   type       edit the focused text row (title / description / pattern)
   #   ↵          advance a text row (↵ on pattern or Save commits) · esc cancels
-  # The runner validates + persists on :commit (global → settings.json, project → project DB).
-  class CustomRuleOverlay
+  #
+  # On the polymorphic Overlay seam (see overlay.cr): the persist — global →
+  # settings.json, project → project DB, and the scope-change move between them — is
+  # injected as `on_commit` at the open-site (Runner#open_custom_rule_editor), which
+  # routes it to ProbeController#apply_custom_rule. An invalid form (missing title/
+  # description, or a regex that won't compile) makes that closure return false, which
+  # keeps the card up.
+  class CustomRuleOverlay < Overlay
     ROW_TITLE   = 0
     ROW_DESC    = 1
     ROW_SCOPE   = 2
@@ -73,7 +80,10 @@ module Gori::Tui
       list.index(v) || 0
     end
 
-    def title : String
+    # NOT `title`: that name belongs to the Overlay contract (the focus-badge label). The
+    # two are unrelated strings and collapsing them would silently persist every rule
+    # under the badge text.
+    def rule_title : String
       @fields[:title].value.strip
     end
 
@@ -116,8 +126,33 @@ module Gori::Tui
     # Every required field is present and, for a regex rule, the pattern compiles (the shared
     # validator the CLI/MCP write paths use too).
     def valid? : Bool
-      return false if title.empty? || description.empty?
+      return false if rule_title.empty? || description.empty?
       Probe::CustomRule.valid_pattern?(pattern, kind)
+    end
+
+    # --- Overlay contract (see overlay.cr) ---
+    def key : OverlayKind
+      OverlayKind::ProbeRule
+    end
+
+    def title : String
+      "CUSTOM RULE"
+    end
+
+    def hint : String
+      "↑/↓ field · ←/→ options · type title/pattern · ↵ save · esc cancel"
+    end
+
+    # Click a field row to select it; a click on Save commits; a click outside the card
+    # cancels. Mirrors the ↑/↓ + ↵ keyboard model.
+    def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      box = overlay_box(area)
+      return :cancel if box.nil? || !box.contains?(mx, my)
+      if idx = row_at(box, mx, my)
+        set_selected(idx)
+        return :commit if on_save_row?
+      end
+      :stay
     end
 
     def move(d : Int32) : Nil

--- a/src/gori/tui/import_overlay.cr
+++ b/src/gori/tui/import_overlay.cr
@@ -3,6 +3,7 @@ require "./theme"
 require "./frame"
 require "./text_field"
 require "./path_complete"
+require "./overlay"
 
 module Gori::Tui
   # Centered popup collecting the source path for palette → "Import: HAR / URLs /
@@ -15,9 +16,16 @@ module Gori::Tui
   # the row (`rect.y - 9`) because there was nothing below it. Centered, the path gets a
   # full card width and the dropdown hangs under the field where it belongs.
   #
-  # Surfaces used by the Runner: `handle_key` returns :submit on ↵, :cancel on esc,
-  # :stay otherwise. On :submit the Runner reads `path` and runs the import.
-  class ImportOverlay
+  # On the polymorphic Overlay seam (see overlay.cr): the Runner dispatches key/click/
+  # wheel/preedit/render/title/hint here generically, and the import itself is injected
+  # as `on_commit` at the open-site (Runner#open_import), which reads `path`/`kind`.
+  #
+  # It defines no handle_click: the base default (click inside → stay, outside → dismiss)
+  # already IS this form's behaviour, since the one field is always focused and there is
+  # nothing else to select. Picking a dropdown row by mouse would mean inverting
+  # PathComplete's private scroll window; it is keyboard-only in the CA import popup too,
+  # so this stays consistent rather than special-casing one call site of a shared widget.
+  class ImportOverlay < Overlay
     getter kind : Symbol
 
     def initialize(@kind : Symbol)
@@ -49,8 +57,23 @@ module Gori::Tui
       end
     end
 
+    # --- Overlay contract (see overlay.cr) -----------------------------------
+    def key : OverlayKind
+      OverlayKind::Import
+    end
+
+    # The focus badge names the SOURCE FORMAT, not just "IMPORT" — the same `label` the
+    # card title and the result toast read, so the three can't disagree.
+    def title : String
+      "IMPORT #{label}"
+    end
+
+    def hint : String
+      "type to complete · ↹ pick · ↑↓ browse · ↵ import · esc cancel"
+    end
+
     # --- input ---------------------------------------------------------------
-    # :submit when the user commits, :cancel on esc, else :stay.
+    # :commit when the user submits, :cancel on esc, else :stay.
     def handle_key(ev : Termisu::Event::Key) : Symbol
       key = ev.key
 
@@ -90,11 +113,11 @@ module Gori::Tui
           @path_complete.refresh(insert)
         else
           @path_complete.close
-          return :submit if key.enter?
+          return :commit if key.enter?
         end
         return :stay
       end
-      key.enter? ? :submit : :stay
+      key.enter? ? :commit : :stay
     end
 
     def set_preedit(text : String) : Nil
@@ -160,17 +183,6 @@ module Gori::Tui
 
     private def value_x(box : Rect) : Int32
       box.x + 2 + LABEL_W
-    end
-
-    # --- mouse ---------------------------------------------------------------
-    # A click inside the card is inert but CONSUMED — there's one field and it already
-    # holds focus, so there's nothing to select; returning true just stops the Runner
-    # reading it as a click-away dismiss. (Picking a dropdown row by mouse would mean
-    # inverting PathComplete's private scroll window; it's keyboard-only there for the
-    # CA import popup too, so this stays consistent rather than special-casing one call
-    # site of a shared widget.)
-    def handle_click(box : Rect, mx : Int32, my : Int32) : Bool
-      box.contains?(mx, my)
     end
   end
 end

--- a/src/gori/tui/oast_provider_overlay.cr
+++ b/src/gori/tui/oast_provider_overlay.cr
@@ -2,6 +2,7 @@ require "./screen"
 require "./theme"
 require "./frame"
 require "./text_field"
+require "./overlay"
 require "../oast"
 require "../oast/provider_config"
 
@@ -12,8 +13,13 @@ module Gori::Tui
   #   ←/→  cycle the scope / provider type when that row is selected
   #   type into name/host/token when focused; ↵ on Save (or a text row) commits
   #   esc cancels
-  # The runner validates + persists on :commit (global → settings.json, project → project DB).
-  class OastProviderOverlay
+  #
+  # On the polymorphic Overlay seam (see overlay.cr): the persist — global →
+  # settings.json, project → project DB, and the scope-change move between them — is
+  # injected as `on_commit` at the open-site (Runner#open_oast_provider_editor), which
+  # routes it to OastController#save_provider. An invalid form (missing name/host) makes
+  # that closure return false, which keeps the card up.
+  class OastProviderOverlay < Overlay
     ROW_NAME  = 0
     ROW_SCOPE = 1
     ROW_TYPE  = 2
@@ -95,6 +101,31 @@ module Gori::Tui
 
     def valid? : Bool
       !provider_name.empty? && !host.empty?
+    end
+
+    # --- Overlay contract (see overlay.cr) ---
+    def key : OverlayKind
+      OverlayKind::OastProvider
+    end
+
+    def title : String
+      "OAST PROVIDER"
+    end
+
+    def hint : String
+      "↑/↓ field · ←/→ scope/type · type name/host/token · ↵ save · esc cancel"
+    end
+
+    # Click a field row to select it; a click on Save commits; a click outside the card
+    # cancels. Mirrors the ↑/↓ + ↵ keyboard model.
+    def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      box = overlay_box(area)
+      return :cancel if box.nil? || !box.contains?(mx, my)
+      if idx = row_at(box, mx, my)
+        set_selected(idx)
+        return :commit if on_save_row?
+      end
+      :stay
     end
 
     private def row_count : Int32

--- a/src/gori/tui/rewriter_rule_overlay.cr
+++ b/src/gori/tui/rewriter_rule_overlay.cr
@@ -2,6 +2,7 @@ require "./screen"
 require "./theme"
 require "./frame"
 require "./text_field"
+require "./overlay"
 require "../store"
 require "../store/safe_regexp"
 
@@ -12,9 +13,13 @@ module Gori::Tui
   #   ←/→         cycle the selected option row (target / op / match / part)
   #   type        edit the focused text row (name / host / find / value)
   #   ↵           advance a text row (↵ on value or Save commits) · esc cancels
-  # The runner refreshes a live match PREVIEW after each key and persists on :commit
-  # through the shared Rules engine (which the proxy reads live).
-  class RewriterRuleOverlay
+  #
+  # On the polymorphic Overlay seam (see overlay.cr). BOTH domain couplings are injected
+  # at the open-site (Runner#open_rewriter_rule_editor): `on_commit` persists through the
+  # shared Rules engine (which the proxy reads live), and `on_preview` scans recent flows
+  # for the live match PREVIEW. The form owns only WHEN to ask for that preview — see
+  # refresh_preview.
+  class RewriterRuleOverlay < Overlay
     ROW_NAME   = 0
     ROW_TARGET = 1
     ROW_OP     = 2
@@ -34,12 +39,18 @@ module Gori::Tui
 
     getter edit_id : Int64?
 
+    # Renders the "affects N of M recent flows" line under the form. Injected at the
+    # open-site because it READS TRAFFIC — the form itself stays store-free.
+    property on_preview : Proc(Store::MatchRule, String)?
+
     @target_i : Int32
     @op_i : Int32
     @match_i : Int32
     @part_i : Int32
     @sel : Int32
     @preview : String = ""
+    # Last previewed field set; gates the rescan to real changes (see refresh_preview).
+    @preview_sig : String = ""
 
     def initialize(*, name : String = "", target : String = "request", op : String = "replace",
                    match : String = "literal", part : String = "head", host : String = "",
@@ -127,13 +138,30 @@ module Gori::Tui
       false
     end
 
-    def set_preview(text : String) : Nil
-      @preview = text
+    # The preview line as last computed — "" until the first key that changes a
+    # match-relevant field (opening an edit form does NOT scan).
+    getter preview
+
+    # The fields a match preview depends on — only rescan when this changes.
+    private def preview_signature : String
+      "#{@target_i}|#{@op_i}|#{@match_i}|#{@part_i}|#{host}|#{pattern}|#{replacement}"
     end
 
-    # The fields a match preview depends on — the runner only rescans when this changes.
-    def preview_signature : String
-      "#{@target_i}|#{@op_i}|#{@match_i}|#{@part_i}|#{host}|#{pattern}|#{replacement}"
+    # Recompute the preview when the candidate rule's match-relevant fields changed.
+    # Selection moves and caret keys therefore cost nothing, which is what keeps typing
+    # responsive: the injected scan is the expensive part. An empty pattern never scans —
+    # it would match everything — and says so in the preview slot instead.
+    private def refresh_preview : Nil
+      sig = preview_signature
+      return if sig == @preview_sig
+      @preview_sig = sig
+      if pattern.empty?
+        @preview = "enter a #{header_op? ? "header name" : "pattern"} to preview"
+        return
+      end
+      if src = @on_preview
+        @preview = src.call(candidate_rule)
+      end
     end
 
     # The rule as currently edited (id 0 when adding) — used for the live preview.
@@ -173,8 +201,41 @@ module Gori::Tui
       end
     end
 
-    # :stay | :commit | :cancel
+    # --- Overlay contract (see overlay.cr) ---
+    def key : OverlayKind
+      OverlayKind::RewriterRule
+    end
+
+    def title : String
+      "REWRITER RULE"
+    end
+
+    def hint : String
+      "↑/↓ field · ←/→ options · type find/value · ↵ save · esc cancel"
+    end
+
+    # :stay | :commit | :cancel. A key that leaves the form open also refreshes the match
+    # preview (only the :stay path — there is nothing to preview once it closes).
     def handle_key(ev : Termisu::Event::Key) : Symbol
+      out = edit_key(ev)
+      refresh_preview if out == :stay
+      out
+    end
+
+    # Click a field row to select it; a click on Save commits; a click outside the card
+    # cancels. Mirrors the ↑/↓ + ↵ keyboard model. No preview refresh: selecting a row
+    # can't change a match-relevant field.
+    def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      box = overlay_box(area)
+      return :cancel if box.nil? || !box.contains?(mx, my)
+      if idx = row_at(box, mx, my)
+        set_selected(idx)
+        return :commit if on_save_row?
+      end
+      :stay
+    end
+
+    private def edit_key(ev : Termisu::Event::Key) : Symbol
       key = ev.key
       return :cancel if key.escape?
       if key.up? || key.back_tab?

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -161,10 +161,6 @@ module Gori::Tui
       @tag_buffer = ""
       @tag_preedit = ""
       @tag_view = nil.as(RepeaterView?)
-      # The import path popup (palette → import:har/urls/oas) — a CENTERED modal
-      # (@overlay is :import), not a bottom prompt: a path is long and the status row
-      # couldn't host it or its completion dropdown legibly. See ImportOverlay.
-      @import_overlay = nil.as(ImportOverlay?)
       # Whitespace reveal (·→␍␊) toggle for the req/res views — global view pref,
       # propagated to the focused view in render_body. Handy for smuggling tests.
       @reveal = false
@@ -263,16 +259,6 @@ module Gori::Tui
       # ladders. nil = no such modal up. (SCOPE add/edit was the first migrated — the
       # former @scope_rule_overlay ivar now lives here.)
       @active_overlay = nil.as(Overlay?)
-      @custom_rule_overlay = nil.as(CustomRuleOverlay?)
-      # Rewriter (Match & Replace) add/edit popup (a/e on the rule list). Built fresh each
-      # open; @rewriter_preview_sig gates the live match-preview rescan to real changes.
-      @rewriter_rule_overlay = nil.as(RewriterRuleOverlay?)
-      @rewriter_preview_sig = ""
-      # OAST provider add/edit popup (a/e on the Providers sub-tab). Built fresh each open.
-      @oast_provider_overlay = nil.as(OastProviderOverlay?)
-      # The "Import CA certificate" popup (palette → ca.import): collects the cert +
-      # key PEM paths, then hands off to the destructive-CA confirm. @overlay is :ca_import.
-      @ca_import_overlay = nil.as(CAImportOverlay?)
       @theme_restore = nil.as(String?) # theme to revert to if the theme settings are cancelled (live preview)
       @focus = :menu                   # default focus on the tab bar (TABS) on project entry; :body for content
       @menu_more = false               # tab-bar focus is on the far-right ⋯ "more" affordance (only meaningful when @focus == :menu)
@@ -950,11 +936,6 @@ module Gori::Tui
       when .discover_headers? then @discover_headers_overlay.try(&.set_preedit(text))
       when .fuzz_set?         then @fuzz_set_overlay.try(&.set_preedit(text))
       when .fuzz_advanced?    then @fuzz_advanced_overlay.try(&.set_preedit(text))
-      when .oast_provider?    then @oast_provider_overlay.try(&.set_preedit(text))
-      when .probe_rule?       then @custom_rule_overlay.try(&.set_preedit(text))
-      when .rewriter_rule?    then @rewriter_rule_overlay.try(&.set_preedit(text))
-      when .ca_import?        then @ca_import_overlay.try(&.set_preedit(text))
-      when .import?           then @import_overlay.try(&.set_preedit(text))
       when .none?             then apply_preedit_body(text)
       end
     end
@@ -1056,11 +1037,6 @@ module Gori::Tui
       return handle_discover_headers_key(ev) if @overlay.discover_headers?
       return handle_fuzz_set_key(ev) if @overlay.fuzz_set?
       return handle_fuzz_advanced_key(ev) if @overlay.fuzz_advanced?
-      return handle_oast_provider_key(ev) if @overlay.oast_provider?
-      return handle_custom_rule_key(ev) if @overlay.probe_rule?
-      return handle_rewriter_rule_key(ev) if @overlay.rewriter_rule?
-      return handle_ca_import_key(ev) if @overlay.ca_import?
-      return handle_import_key(ev) if @overlay.import?
       # Text-entry modes own Tab (complete) + Esc within themselves — let them run
       # before the global focus ring claims Tab.
       if @active_tab == :history && @overlay.none? && @focus == :body && history_controller.view.querying?
@@ -1340,11 +1316,6 @@ module Gori::Tui
       OverlayKind::DiscoverHeaders,
       OverlayKind::FuzzSet,
       OverlayKind::FuzzAdvanced,
-      OverlayKind::OastProvider,
-      OverlayKind::ProbeRule,
-      OverlayKind::RewriterRule,
-      OverlayKind::CaImport,
-      OverlayKind::Import,
     }
 
     private def modal_overlay? : Bool
@@ -1461,11 +1432,6 @@ module Gori::Tui
       when .discover_headers? then click_discover_headers(area, mx, my)
       when .fuzz_set?         then click_fuzz_set(area, mx, my)
       when .fuzz_advanced?    then click_fuzz_advanced(area, mx, my)
-      when .oast_provider?    then click_oast_provider(area, mx, my)
-      when .probe_rule?       then click_custom_rule(area, mx, my)
-      when .rewriter_rule?    then click_rewriter_rule(area, mx, my)
-      when .ca_import?        then click_ca_import(area, mx, my)
-      when .import?           then click_import(area, mx, my)
         # IssueNew is a text form — keyboard-only in Phase 1 (cursor placement is Phase 2)
       end
     end
@@ -1556,20 +1522,6 @@ module Gori::Tui
       ov.handle_click(box, mx, my)
     end
 
-    private def click_ca_import(area : Rect, mx : Int32, my : Int32) : Nil
-      ov = @ca_import_overlay || return
-      box = ov.overlay_box(area)
-      return close_ca_import if box.nil? || dismiss_zone?(box, mx, my) # click-away = cancel (destructive: never auto-submit)
-      ov.handle_click(box, mx, my)
-    end
-
-    private def click_import(area : Rect, mx : Int32, my : Int32) : Nil
-      ov = @import_overlay || return
-      box = ov.overlay_box(area)
-      return close_import if box.nil? || dismiss_zone?(box, mx, my) # click-away = cancel
-      ov.handle_click(box, mx, my)
-    end
-
     private def click_palette(area : Rect, mx : Int32, my : Int32) : Nil
       box = @palette.overlay_box(area)
       return close_overlay if box.empty? || dismiss_zone?(box, mx, my)
@@ -1578,16 +1530,6 @@ module Gori::Tui
       if verb = @palette.selected_verb
         close_overlay
         @toast = verb.call(self) || @toast
-      end
-    end
-
-    private def click_rewriter_rule(area : Rect, mx : Int32, my : Int32) : Nil
-      ov = @rewriter_rule_overlay || return
-      box = ov.overlay_box(area)
-      return close_rewriter_rule if box.nil? || dismiss_zone?(box, mx, my) # click-away = cancel
-      if idx = ov.row_at(box, mx, my)
-        ov.set_selected(idx)
-        commit_rewriter_rule_overlay(ov) if ov.on_save_row?
       end
     end
 
@@ -1728,11 +1670,6 @@ module Gori::Tui
       when .discover_config? then @discover_config_overlay.try(&.move(step))
       when .fuzz_set?        then @fuzz_set_overlay.try(&.move(step))
       when .fuzz_advanced?   then @fuzz_advanced_overlay.try(&.move(step))
-      when .oast_provider?   then @oast_provider_overlay.try(&.move(step))
-      when .probe_rule?      then @custom_rule_overlay.try(&.move(step))
-      when .rewriter_rule?   then @rewriter_rule_overlay.try(&.move(step))
-      when .ca_import?       then @ca_import_overlay.try(&.move(step))
-      when .import?          then @import_overlay.try(&.move(step))
       end
     end
 
@@ -1864,33 +1801,26 @@ module Gori::Tui
       end
     end
 
-    # CA import popup: collect cert + key paths, then hand off to the destructive
-    # confirm on :submit. esc cancels without touching the CA.
-    private def handle_ca_import_key(ev : Termisu::Event::Key) : Nil
-      ov = @ca_import_overlay || return
-      case ov.handle_key(ev)
-      when :cancel then close_ca_import
-      when :submit then submit_ca_import(ov)
-      end
-    end
-
-    private def close_ca_import : Nil
-      @overlay = OverlayKind::None
-      @ca_import_overlay = nil
-    end
-
     # Validate the two paths are filled, close the overlay, then run the same danger
     # confirm as regenerate before adopting the imported CA. import! does the heavy
     # validation (pair match, CA flag) and leaves the current CA untouched on failure.
-    private def submit_ca_import(ov : CAImportOverlay) : Nil
+    #
+    # The CAImportOverlay commit closure (Runner#import_ca), and the ONE closure in this
+    # batch that closes itself. The rule the others follow — return true and let the shell
+    # close you (see submit_import) — does not work here: the shell's post-commit close
+    # unconditionally resets @overlay, which would wipe the confirm this opens one line
+    # after opening it. So it closes first and returns false, meaning "already handled,
+    # keep your hands off @overlay". The missing-path branch returns false for the ordinary
+    # reason: keep the form up so it can be corrected.
+    private def submit_ca_import(ov : CAImportOverlay) : Bool
       cert = ov.cert_path
       key = ov.key_path
       if cert.empty? || key.empty?
         @toast = "CA import: both certificate and key paths are required"
-        return
+        return false
       end
       path = @session.ca.ca_cert_path
-      close_ca_import
+      close_active_overlay
       confirm("IMPORT CA",
         "Replace the current root CA with the imported one?\n\n" \
         "The old CA becomes untrusted — re-trust the imported\n" \
@@ -1906,104 +1836,7 @@ module Gori::Tui
           @toast = "CA import failed: #{ex.message}"
         end
       end
-    end
-
-    # OAST provider add/edit popup: same interaction as the scope-rule form. Commit persists
-    # via the controller; an invalid form (missing name/host) keeps the popup open.
-    private def handle_oast_provider_key(ev : Termisu::Event::Key) : Nil
-      ov = @oast_provider_overlay || return
-      case ov.handle_key(ev)
-      when :cancel then close_oast_provider
-      when :commit then commit_oast_provider_overlay(ov)
-      end
-    end
-
-    private def click_oast_provider(area : Rect, mx : Int32, my : Int32) : Nil
-      ov = @oast_provider_overlay || return
-      box = ov.overlay_box(area)
-      return close_oast_provider if box.nil? || dismiss_zone?(box, mx, my) # click-away = cancel
-      if idx = ov.row_at(box, mx, my)
-        ov.set_selected(idx)
-        commit_oast_provider_overlay(ov) if ov.on_save_row?
-      end
-    end
-
-    private def commit_oast_provider_overlay(ov : OastProviderOverlay) : Nil
-      return unless oast_controller.save_provider(ov)
-      close_oast_provider
-    end
-
-    private def close_oast_provider : Nil
-      @overlay = OverlayKind::None
-      @oast_provider_overlay = nil
-    end
-
-    # Probe custom-rule popup: same interaction as the scope-rule form. Commit persists via the
-    # controller (returns false → keep the form open, e.g. an incomplete/invalid pattern).
-    private def handle_custom_rule_key(ev : Termisu::Event::Key) : Nil
-      ov = @custom_rule_overlay || return
-      case ov.handle_key(ev)
-      when :cancel then close_custom_rule
-      when :commit then commit_custom_rule_overlay(ov)
-      end
-    end
-
-    private def commit_custom_rule_overlay(ov : CustomRuleOverlay) : Nil
-      return unless probe_controller.apply_custom_rule(ov)
-      close_custom_rule
-    end
-
-    private def close_custom_rule : Nil
-      @overlay = OverlayKind::None
-      @custom_rule_overlay = nil
-    end
-
-    private def click_custom_rule(area : Rect, mx : Int32, my : Int32) : Nil
-      ov = @custom_rule_overlay || return
-      box = ov.overlay_box(area)
-      return close_custom_rule if box.nil? || dismiss_zone?(box, mx, my) # click-away = cancel
-      if idx = ov.row_at(box, mx, my)
-        ov.set_selected(idx)
-        commit_custom_rule_overlay(ov) if ov.on_save_row?
-      end
-    end
-
-    # Rewriter (Match & Replace) add/edit popup: same interaction as the custom-rule form,
-    # plus a live match PREVIEW refreshed after each key (only rescanning when the
-    # match-relevant fields actually changed). Commit persists via the controller.
-    private def handle_rewriter_rule_key(ev : Termisu::Event::Key) : Nil
-      ov = @rewriter_rule_overlay || return
-      case ov.handle_key(ev)
-      when :cancel then close_rewriter_rule
-      when :commit then commit_rewriter_rule_overlay(ov)
-      else              refresh_rewriter_preview(ov)
-      end
-    end
-
-    # Recompute the "N of M recent flows" preview when the candidate rule's match-relevant
-    # fields changed. Bounded so a keystroke stays responsive; nothing is written.
-    private def refresh_rewriter_preview(ov : RewriterRuleOverlay) : Nil
-      sig = ov.preview_signature
-      return if sig == @rewriter_preview_sig
-      @rewriter_preview_sig = sig
-      if ov.pattern.empty?
-        ov.set_preview("enter a #{ov.header_op? ? "header name" : "pattern"} to preview")
-        return
-      end
-      pv = @session.rules.preview(ov.candidate_rule, 200)
-      more = pv.total > pv.scanned ? " (of #{pv.total})" : ""
-      ov.set_preview("affects #{pv.matched} of #{pv.scanned} recent flows#{more}")
-    end
-
-    private def commit_rewriter_rule_overlay(ov : RewriterRuleOverlay) : Nil
-      return unless rewriter_controller.apply_rewriter_rule(ov)
-      close_rewriter_rule
-    end
-
-    private def close_rewriter_rule : Nil
-      @overlay = OverlayKind::None
-      @rewriter_rule_overlay = nil
-      @rewriter_preview_sig = ""
+      false
     end
 
     private def apply_close_fuzz_set(ov : FuzzSetOverlay) : Nil
@@ -3832,11 +3665,6 @@ module Gori::Tui
       @fuzz_set_overlay.try(&.render(screen, layout.body)) if @overlay.fuzz_set?
       @fuzz_advanced_overlay.try(&.render(screen, layout.body)) if @overlay.fuzz_advanced?
       active_overlay.try(&.render(screen, layout.body)) # migrated modals (Overlay seam; gated on @overlay)
-      @oast_provider_overlay.try(&.render(screen, layout.body)) if @overlay.oast_provider?
-      @custom_rule_overlay.try(&.render(screen, layout.body)) if @overlay.probe_rule?
-      @rewriter_rule_overlay.try(&.render(screen, layout.body)) if @overlay.rewriter_rule?
-      @ca_import_overlay.try(&.render(screen, layout.body)) if @overlay.ca_import?
-      @import_overlay.try(&.render(screen, layout.body)) if @overlay.import?
       # The space menu + bottom prompts float over everything else (drawn last).
       render_prompts(screen, layout)
 
@@ -3967,10 +3795,6 @@ module Gori::Tui
       when .discover_headers? then "CUSTOM HEADERS"
       when .fuzz_set?         then "PAYLOAD SET"
       when .fuzz_advanced?    then "ADVANCED"
-      when .rewriter_rule?    then "REWRITER RULE"
-      when .oast_provider?    then "OAST PROVIDER"
-      when .ca_import?        then "IMPORT CA"
-      when .import?           then "IMPORT #{@import_overlay.try(&.label) || "FILE"}"
       else
         case @focus
         when :menu    then "TABS"
@@ -4023,10 +3847,6 @@ module Gori::Tui
       when .discover_headers? then "one header per line · Host/Connection ignored · esc saves & closes"
       when .fuzz_set?         then "↑/↓/⇥ field · ←/→ type/caret · ↵ new value/next · esc applies & closes"
       when .fuzz_advanced?    then "↑/↓/⇥ field · ←/→ edit · ␣ toggle · ↵ next · esc applies & closes"
-      when .rewriter_rule?    then "↑/↓ field · ←/→ options · type find/value · ↵ save · esc cancel"
-      when .oast_provider?    then "↑/↓ field · ←/→ scope/type · type name/host/token · ↵ save · esc cancel"
-      when .ca_import?        then "type to complete · ↹/↵ pick · ⇥/↑↓ field · ↵ submits · esc cancels"
-      when .import?           then "type to complete · ↹ pick · ↑↓ browse · ↵ import · esc cancel"
       when .detail?           then history_controller.body_hint(:body)
       else
         # Focus on the far-right ⋯ "more" affordance: ↵/↓ expands the hidden-tabs list.
@@ -4428,35 +4248,22 @@ module Gori::Tui
     # --- Import path popup (palette → import:har/urls/oas) -------------------
 
     private def open_import(kind : Symbol) : Nil
-      @import_overlay = ImportOverlay.new(kind)
-      @overlay = OverlayKind::Import
+      ov = ImportOverlay.new(kind)
+      ov.on_commit = -> { submit_import(ov) }
+      open_overlay(ov)
     end
 
-    private def close_import : Nil
-      @overlay = OverlayKind::None
-      @import_overlay = nil
-    end
-
-    private def handle_import_key(ev : Termisu::Event::Key) : Nil
-      ov = @import_overlay || return
-      case ov.handle_key(ev)
-      when :cancel then close_import
-      when :submit then submit_import(ov)
-      end
-    end
-
-    # Read the path off the popup, close it, THEN import — so the card is gone before a
-    # slow parse blocks the loop, and the resulting toast isn't drawn behind the modal.
-    private def submit_import(ov : ImportOverlay) : Nil
-      path = ov.path
-      label = ov.label
-      kind = ov.kind
-      close_import
-      if path.empty?
+    # The ImportOverlay commit closure. Returns true so the SHELL closes the card — no
+    # frame is drawn between this returning and that close, so the card is still gone
+    # before the parse's toast is painted, which the pre-seam early close was for. An
+    # empty path is a no-op cancel, not a correctable error, so it closes too.
+    private def submit_import(ov : ImportOverlay) : Bool
+      if ov.path.empty?
         @toast = "import cancelled — path is empty"
-        return
+      else
+        apply_import(ov.kind, ov.label, ov.path)
       end
-      apply_import(kind, label, path)
+      true
     end
 
     private def apply_import(kind : Symbol, label : String, path : String) : Nil
@@ -5119,23 +4926,38 @@ module Gori::Tui
       open_overlay(ov)
     end
 
-    # Host: open the OAST provider add/edit popup (nil = add a new provider).
+    # Host: open the OAST provider add/edit popup (nil = add a new provider). Saving is
+    # the controller's (global → settings.json, project → project DB); false keeps the
+    # form up on an invalid entry.
     def open_oast_provider_editor(provider : Oast::ProviderConfig?) : Nil
-      @oast_provider_overlay = provider ? OastProviderOverlay.editing(provider) : OastProviderOverlay.adding
-      @overlay = OverlayKind::OastProvider
+      ov = provider ? OastProviderOverlay.editing(provider) : OastProviderOverlay.adding
+      ov.on_commit = -> { oast_controller.save_provider(ov) }
+      open_overlay(ov)
     end
 
     # Host: open the Probe custom-rule popup (nil rule = add; else edit the given rule).
     def open_custom_rule_editor(rule : Probe::CustomRule?) : Nil
-      @custom_rule_overlay = rule ? CustomRuleOverlay.editing(rule) : CustomRuleOverlay.adding
-      @overlay = OverlayKind::ProbeRule
+      ov = rule ? CustomRuleOverlay.editing(rule) : CustomRuleOverlay.adding
+      ov.on_commit = -> { probe_controller.apply_custom_rule(ov) }
+      open_overlay(ov)
     end
 
     # Host: open the Rewriter (Match & Replace) rule popup (nil rule = add; else edit).
+    # The form asks for its live match preview through on_preview (it decides WHEN — only
+    # when a match-relevant field actually changed).
     def open_rewriter_rule_editor(rule : Store::MatchRule?) : Nil
-      @rewriter_rule_overlay = rule ? RewriterRuleOverlay.editing(rule) : RewriterRuleOverlay.adding
-      @rewriter_preview_sig = ""
-      @overlay = OverlayKind::RewriterRule
+      ov = rule ? RewriterRuleOverlay.editing(rule) : RewriterRuleOverlay.adding
+      ov.on_preview = ->rewriter_preview_text(Store::MatchRule)
+      ov.on_commit = -> { rewriter_controller.apply_rewriter_rule(ov) }
+      open_overlay(ov)
+    end
+
+    # The "N of M recent flows" line under the Rewriter form. Bounded so a keystroke stays
+    # responsive; nothing is written.
+    private def rewriter_preview_text(candidate : Store::MatchRule) : String
+      pv = @session.rules.preview(candidate, 200)
+      more = pv.total > pv.scanned ? " (of #{pv.total})" : ""
+      "affects #{pv.matched} of #{pv.scanned} recent flows#{more}"
     end
 
     # Notes must not be reloaded out from under in-progress typing. Focus alone is
@@ -5196,8 +5018,9 @@ module Gori::Tui
     # cert + key PEM paths. The destructive swap happens later, on submit, behind
     # the same confirm as regenerate (see submit_ca_import).
     def import_ca : Nil
-      @ca_import_overlay = CAImportOverlay.new
-      @overlay = OverlayKind::CaImport
+      ov = CAImportOverlay.new
+      ov.on_commit = -> { submit_ca_import(ov) }
+      open_overlay(ov)
     end
 
     # --- browser (open a pre-trusted system browser) ---


### PR DESCRIPTION
Phase 1 **batch C2** of #355. Migrates `ca_import`, `import`, `oast_provider`, `custom_rule` (probe_rule) and `rewriter_rule` onto the polymorphic `Overlay` seam.

`runner.cr` loses 227 lines: five modals' arms in all seven dispatch ladders (preedit / key / capture-gate / click / wheel / title / hint), 19 private handler methods, and six ivars (`@import_overlay`, `@ca_import_overlay`, `@custom_rule_overlay`, `@rewriter_rule_overlay`, `@oast_provider_overlay`, `@rewriter_preview_sig`). Domain coupling moves to an `on_commit` closure at each open-site, mirroring `ScopeRuleOverlay`.

## Two pre-existing bugs that fall out of the move

**1. `probe_rule` had no chrome at all.** It was missing from *both* the `focus_label` and `key_hints` ladders on `main` (the other four modals were in both). With the custom-rule form open, the badge showed the tab body's label and the bottom row advertised `^N new` / `^W close` while a modal owned the keyboard. `title`/`hint` are abstract on `Overlay`, so migrating closes the gap by construction. **This is the one place the diff is not byte-for-byte behaviour-preserving** — deliberately. The other four modals' title/hint strings are byte-identical to their deleted ladder arms.

**2. `Overlay#title` silently collides with `CustomRuleOverlay#title`** — the rule's own user-entered title, which `ProbeController` reads to persist the rule. Crystal has no `override`, so this is silent in *both* directions: left alone the badge shows the rule name; "fixed" naively, every saved rule is named `"CUSTOM RULE"`. The form's accessor is now `rule_title` (following the precedent `OastProviderOverlay#provider_name` already set); 4 call sites in `probe_controller.cr` updated. Caught by a spec, then proved end-to-end in the running TUI.

## The CA-import ordering trap

`submit_ca_import` is the **one** commit closure that closes itself and returns `false`. The shell's post-commit `close_active_overlay` unconditionally resets `@overlay`, which would wipe the destructive-CA confirm this opens one line after opening it — the trap recorded on #355 as directly blocking C2. Every other closure returns `true` and lets the shell close it; the asymmetry is commented at both sites. Verified in the running TUI: the confirm actually appears.

## Rewriter preview

The "only rescan when a match-relevant field changed" gate is preserved, but split by dependency: the **gate** (form state) moves into the overlay, while the **scan** (a traffic read) is injected as `on_preview` at the open-site. `Runner#refresh_rewriter_preview` and `@rewriter_preview_sig` are gone. Without the gate, every keystroke would re-run a 200-flow scan.

## Shared spec file

`MODAL_OVERLAYS`'s assertion becomes derived set-complementarity instead of `unmigrated.size.should eq(28)`. That literal was one line five parallel batches each wanted a different integer on, and a conflict resolved by keeping your own value asserts a total that is wrong for the combined state. It also could never catch an accidental **extra** member. The per-batch edit is now appending to one `MIGRATED_KINDS` list. Both failure directions proved by mutation.

## Verification

Specs alone can't reach the Runner (it needs a tty), so every modal was also driven in a real TUI under tmux:

| modal | verified in the running app |
|---|---|
| ca_import | badge/hint; empty-path keeps the form up + toasts; filled → the destructive confirm appears |
| import | badge reads `IMPORT HAR` (per-kind, not generic); a real HAR imported; card closed; toast |
| custom_rule | badge `CUSTOM RULE` (new); rule persisted as `leaky header`, **not** `CUSTOM RULE` |
| rewriter_rule | badge/hint; live preview both states; rule saved and live in the preview output |
| oast_provider | badge/hint; saved with **global** scope preserved |

- `crystal spec spec/tui` → **1162 examples, 0 failures**
- `crystal spec` → 3948 examples, 8 failures, **all pre-existing/environmental** (a `gori` holding :8070); reproduced identically at `origin/main` with no patch applied
- Re-verified in a clean isolated worktree (`origin/main` + this diff only)
- **Six mutations, six failures** — no spec passes vacuously: `rule_title` collision reintroduced, preview gate removed, ca_import committing from any row, import title losing its per-kind label, and an extra/missing `MODAL_OVERLAYS` member
- ameba: baseline unchanged (one finding *removed*, none added); format clean on every touched file

## Deliberately not done here

- Extracting a `RowFormOverlay` base for the 6 now-identical row-form `handle_click` bodies — touches `overlay.cr` + `scope_rule_overlay.cr`, both outside this batch while four agents are in flight. Phase 2.
- Renaming the contract method `title` → `badge_title`, which would remove the collision class for good (`IssueNew` is the next landmine). Phase 2.
- One stale orphan comment at `runner.cr:1759` — sits adjacent to C1's deletion range, not worth the conflict.

Composes with C5's `on_close` base change: this branch does not touch `overlay.cr`, and my overlays set no `on_close`, so `close_active_overlay` behaves identically under it.

Part of #355 — batch C2 of 5. Deliberately NOT "Closes #355": C1, C3, C4 and C5 are still in flight, and an auto-close here would drop the tracking issue four batches early.
