### PR TITLE
refactor(tui): migrate the scan/fuzz config modals onto the Overlay seam (#355)

### DIFF
--- a/spec/tui/discover_config_overlay_spec.cr
+++ b/spec/tui/discover_config_overlay_spec.cr
@@ -1,5 +1,6 @@
 require "../spec_helper"
 require "../support/memory_backend"
+require "../support/overlay_harness"
 
 include Gori::Tui
 
@@ -36,5 +37,111 @@ describe Gori::Tui::DiscoverConfigOverlay do
     box = ov.overlay_box(area).not_nil!
     ov.row_at(box, box.x + 3, box.y + 3 + DiscoverConfigOverlay::ROW_HEADERS)
       .should eq(DiscoverConfigOverlay::ROW_HEADERS)
+  end
+
+  # --- Overlay seam (see overlay.cr): the routing the Runner's generic dispatch replaced.
+  # OverlayHarness replays Runner#dispatch_overlay_key / #dispatch_overlay_click.
+  it "exposes the chrome the collapsed ladders used to hard-code" do
+    OverlayHarness.new(DiscoverConfigOverlay.new(dseed)).assert_chrome(OverlayKind::DiscoverConfig, "DISCOVER")
+  end
+
+  it "↵ on Start commits; esc cancels without starting a run" do
+    ov = DiscoverConfigOverlay.new(dseed)
+    h = OverlayHarness.new(ov)
+    ov.set_selected(DiscoverConfigOverlay::ROW_START)
+    h.press(Termisu::Input::Key::Enter).should eq(:closed)
+    h.commits.should eq(1)
+
+    esc = OverlayHarness.new(DiscoverConfigOverlay.new(dseed))
+    esc.press(Termisu::Input::Key::Escape).should eq(:closed)
+    esc.commits.should eq(0)
+  end
+
+  it "keeps the popup up when the closure refuses (neither spider nor bruteforce)" do
+    ov = DiscoverConfigOverlay.new(dseed)
+    h = OverlayHarness.new(ov, commit: false)
+    ov.set_selected(DiscoverConfigOverlay::ROW_START)
+    h.press(Termisu::Input::Key::Enter).should eq(:open)
+    h.commits.should eq(1) # it DID run — it just refused to close
+  end
+
+  it "↵ on the headers row raises the sub-editor instead of committing or closing" do
+    ov = DiscoverConfigOverlay.new(dseed)
+    opened = 0
+    ov.on_edit_headers = -> { opened += 1; nil }
+    h = OverlayHarness.new(ov)
+    ov.set_selected(DiscoverConfigOverlay::ROW_HEADERS)
+    h.press(Termisu::Input::Key::Enter).should eq(:open)
+    opened.should eq(1)
+    h.commits.should eq(0)
+  end
+
+  it "␣ on a checkbox row toggles it and stays open" do
+    ov = DiscoverConfigOverlay.new(dseed)
+    h = OverlayHarness.new(ov)
+    ov.set_selected(DiscoverConfigOverlay::ROW_SPIDER)
+    before = ov.build_config.spider?
+    h.press(Termisu::Input::Key::Space).should eq(:open)
+    ov.build_config.spider?.should eq(!before)
+    h.commits.should eq(0)
+  end
+
+  it "←/→ cycles the row under the cursor" do
+    ov = DiscoverConfigOverlay.new(dseed)
+    h = OverlayHarness.new(ov)
+    ov.set_selected(DiscoverConfigOverlay::ROW_DEPTH)
+    depth = ov.build_config.max_depth
+    h.press(Termisu::Input::Key::Right).should eq(:open)
+    ov.build_config.max_depth.should_not eq(depth)
+  end
+
+  it "a click routes rows exactly like ↵; a click outside dismisses" do
+    ov = DiscoverConfigOverlay.new(dseed)
+    opened = 0
+    ov.on_edit_headers = -> { opened += 1; nil }
+    h = OverlayHarness.new(ov)
+    # Rows start at box.y + 3 (see render).
+    h.click_in_box(3, 3 + DiscoverConfigOverlay::ROW_HEADERS).should eq(:open)
+    opened.should eq(1)
+    h.click_in_box(3, 3 + DiscoverConfigOverlay::ROW_START).should eq(:closed)
+    h.commits.should eq(1)
+
+    away = OverlayHarness.new(DiscoverConfigOverlay.new(dseed))
+    away.click(0, 0).should eq(:closed)
+    away.commits.should eq(0)
+  end
+
+  it "the wheel moves the selected row (base handle_wheel delegates to move)" do
+    ov = DiscoverConfigOverlay.new(dseed)
+    OverlayHarness.new(ov).wheel(DiscoverConfigOverlay::ROW_START)
+    ov.on_start_row?.should be_true
+  end
+
+  it "dismisses (never starts a run on) a click when the window is too small" do
+    # The overlay_box → nil path. OverlayHarness::DEFAULT_AREA is the whole screen, so this
+    # path is unreachable through the default — pass an area that actually forces it. A
+    # discovery run fires real traffic, so an unrenderable card MUST cancel, matching the
+    # pre-seam `return close_discover_config if box.nil?`.
+    tiny = Gori::Tui::Rect.new(0, 0, 29, 6)
+    ov = DiscoverConfigOverlay.new(dseed)
+    ov.overlay_box(tiny).should be_nil
+    ov.handle_click(tiny, 5, 3).should eq(:cancel)
+    h = OverlayHarness.new(ov, area: tiny)
+    h.click(5, 3).should eq(:closed)
+    h.commits.should eq(0)
+    h.rendered?("config needs").should be_true
+  end
+
+  it "still hit-tests its rows in the rect the shell actually passes (layout.body)" do
+    # Production hands an overlay `layout.body` — 6 rows shorter and offset from the screen,
+    # which for this 9-row card is where it starts getting clipped.
+    body = Gori::Tui::Rect.new(2, 4, 76, 18)
+    ov = DiscoverConfigOverlay.new(dseed)
+    h = OverlayHarness.new(ov, area: body)
+    box = h.box.not_nil!
+    ov.row_at(box, box.x + 3, box.y + 3 + DiscoverConfigOverlay::ROW_START)
+      .should eq(DiscoverConfigOverlay::ROW_START)
+    h.click_in_box(3, 3 + DiscoverConfigOverlay::ROW_START).should eq(:closed)
+    h.commits.should eq(1)
   end
 end

--- a/spec/tui/discover_headers_overlay_spec.cr
+++ b/spec/tui/discover_headers_overlay_spec.cr
@@ -1,5 +1,6 @@
 require "../spec_helper"
 require "../support/memory_backend"
+require "../support/overlay_harness"
 
 include Gori::Tui
 
@@ -20,5 +21,111 @@ describe Gori::Tui::DiscoverHeadersOverlay do
     ov.headers.should be_empty
     screen = Screen.new(MemoryBackend.new(80, 24))
     ov.render(screen, Rect.new(0, 0, 80, 24))
+  end
+
+  # --- Overlay seam (see overlay.cr): the routing the Runner's generic dispatch replaced.
+  # OverlayHarness replays Runner#dispatch_overlay_key / #dispatch_overlay_click.
+  it "exposes the chrome the collapsed ladders used to hard-code" do
+    OverlayHarness.new(DiscoverHeadersOverlay.new([] of {String, String}))
+      .assert_chrome(OverlayKind::DiscoverHeaders, "CUSTOM HEADERS")
+  end
+
+  it "esc SAVES what was typed — there is no cancel path out of this sub-editor" do
+    ov = DiscoverHeadersOverlay.new([] of {String, String})
+    saved = [] of Array({String, String})
+    h = OverlayHarness.new(ov)
+    h.on_commit do
+      saved << ov.headers
+      true
+    end
+    h.type("X-Env: staging").should eq(:open)
+    h.press(Termisu::Input::Key::Escape).should eq(:closed)
+    saved.should eq([[{"X-Env", "staging"}]])
+  end
+
+  it "a click OUTSIDE the card saves too (esc semantics), a click inside just edits" do
+    away = OverlayHarness.new(DiscoverHeadersOverlay.new([{"A", "b"}]))
+    away.click(0, 0).should eq(:closed)
+    away.commits.should eq(1) # NOT a dismissal: the base class's click-away cancel is overridden
+
+    inside = OverlayHarness.new(DiscoverHeadersOverlay.new([{"A", "b"}]))
+    inside.click_in_box(3, 1).should eq(:open)
+    inside.commits.should eq(0)
+  end
+
+  it "↵ inserts a header line rather than committing" do
+    ov = DiscoverHeadersOverlay.new([] of {String, String})
+    h = OverlayHarness.new(ov)
+    h.type("A: 1")
+    h.press(Termisu::Input::Key::Enter).should eq(:open)
+    h.type("B: 2")
+    ov.headers.should eq([{"A", "1"}, {"B", "2"}])
+  end
+
+  it "routes IME preedit into the editor" do
+    # Seeded, because an EMPTY buffer renders the placeholder line instead of the editor.
+    ov = DiscoverHeadersOverlay.new([{"A", "b"}])
+    h = OverlayHarness.new(ov)
+    h.rendered?("한").should be_false
+    h.preedit("한") # composing text draws but has not committed to the buffer yet
+    h.rendered?("한").should be_true
+    ov.headers.should eq([{"A", "b"}])
+  end
+
+  it "the wheel does nothing (it never had a move entry in the shell's ladder)" do
+    # Asserting on `headers` alone cannot fail: it re-parses the buffer, so it is caret- and
+    # scroll-independent and holds no matter what a `move` override did. Compare the whole
+    # drawn frame instead — glyphs AND background — so adding a `move` that scrolls the
+    # editor or shifts the caret shows up here.
+    ov = DiscoverHeadersOverlay.new([{"A", "b"}, {"C", "d"}])
+    h = OverlayHarness.new(ov)
+    before = h.render
+    rows = (0...24).map { |y| before.row(y) }
+    bgs = (0...24).map { |y| (0...80).map { |x| before.bg_at(x, y) } }
+
+    h.wheel(3)
+
+    after = h.render
+    (0...24).each do |y|
+      after.row(y).should eq(rows[y])
+      (0...80).each { |x| after.bg_at(x, y).should eq(bgs[y][x]) }
+    end
+    ov.headers.should eq([{"A", "b"}, {"C", "d"}])
+  end
+
+  it "SAVES a click when the window is too small to draw the card" do
+    # The overlay_box → nil path. OverlayHarness::DEFAULT_AREA is the whole screen, so this
+    # path is unreachable through the default — pass an area that actually forces it. This
+    # editor diverges from the base class on purpose: the pre-seam shell ran
+    # `commit_discover_headers if box.nil?`, so an unrenderable card must SAVE, and the
+    # inherited :cancel would silently drop headers the user had already typed.
+    tiny = Gori::Tui::Rect.new(0, 0, 29, 6)
+    ov = DiscoverHeadersOverlay.new([{"A", "b"}])
+    ov.overlay_box(tiny).should be_nil
+    ov.handle_click(tiny, 5, 3).should eq(:commit)
+    h = OverlayHarness.new(ov, area: tiny)
+    h.click(5, 3).should eq(:closed)
+    h.commits.should eq(1)
+    h.rendered?("headers editor").should be_true
+  end
+
+  it "hit-tests against the rect the shell passes, not the whole screen" do
+    # Production hands `layout.body` — 6 rows shorter and offset — so the card is 14 rows
+    # here against 16 under OverlayHarness::DEFAULT_AREA, and its top edge sits lower. A
+    # point inside that band is INSIDE the card on the default area and OUTSIDE it here, so
+    # the same click must save-and-close rather than keep editing. Driving keys through a
+    # smaller area proves nothing: handle_key never sees `area`.
+    body = Gori::Tui::Rect.new(2, 4, 76, 18)
+    screen_h = OverlayHarness.new(DiscoverHeadersOverlay.new([{"A", "b"}]))
+    body_h = OverlayHarness.new(DiscoverHeadersOverlay.new([{"A", "b"}]), area: body)
+    screen_box = screen_h.box.not_nil!
+    body_box = body_h.box.not_nil!
+    body_box.y.should be > screen_box.y
+
+    probe_y = screen_box.y # inside the screen-area card, above the body-area card
+    screen_h.click(20, probe_y).should eq(:open)
+    screen_h.commits.should eq(0)
+    body_h.click(20, probe_y).should eq(:closed)
+    body_h.commits.should eq(1)
   end
 end

--- a/spec/tui/fuzz_advanced_overlay_spec.cr
+++ b/spec/tui/fuzz_advanced_overlay_spec.cr
@@ -1,5 +1,6 @@
 require "../spec_helper"
 require "../support/memory_backend"
+require "../support/overlay_harness"
 
 include Gori::Tui
 
@@ -30,9 +31,9 @@ describe Gori::Tui::FuzzAdvancedOverlay do
     ov.snapshot.follow.should be_true
   end
 
-  it "esc returns :apply so the Runner writes the snapshot back" do
+  it "esc returns :commit so the open-site's closure writes the snapshot back" do
     ov = FuzzAdvancedOverlay.new(blank_snapshot)
-    ov.handle_key(akey(Termisu::Input::Key::Escape)).should eq(:apply)
+    ov.handle_key(akey(Termisu::Input::Key::Escape)).should eq(:commit)
   end
 
   it "renders every field on its own labeled row" do
@@ -43,5 +44,115 @@ describe Gori::Tui::FuzzAdvancedOverlay do
     backend.contains?("Concurrency").should be_true
     backend.contains?("Match status").should be_true
     backend.contains?("Filter regex").should be_true
+  end
+
+  # --- Overlay seam (see overlay.cr): the routing the Runner's generic dispatch replaced.
+  # OverlayHarness replays Runner#dispatch_overlay_key / #dispatch_overlay_click.
+  it "exposes the chrome the collapsed ladders used to hard-code" do
+    OverlayHarness.new(FuzzAdvancedOverlay.new(blank_snapshot)).assert_chrome(OverlayKind::FuzzAdvanced, "ADVANCED")
+  end
+
+  it "esc applies the edited snapshot through the injected closure" do
+    ov = FuzzAdvancedOverlay.new(blank_snapshot)
+    applied = [] of String
+    h = OverlayHarness.new(ov)
+    h.on_commit do
+      applied << ov.snapshot.conc
+      true
+    end
+    2.times { h.press(Termisu::Input::Key::Backspace) } # clear "20"
+    h.type("50").should eq(:open)
+    h.press(Termisu::Input::Key::Escape).should eq(:closed)
+    applied.should eq(["50"])
+  end
+
+  it "↵ advances a row and, on the LAST row, does nothing at all" do
+    # Pins the PRE-EXISTING behaviour the migration preserved: handle_key discards the
+    # case's value, so handle_text's commit-on-the-last-row never reaches the shell. Only
+    # esc and a click-away apply. See the note on FuzzAdvancedOverlay#handle_key.
+    ov = FuzzAdvancedOverlay.new(blank_snapshot)
+    h = OverlayHarness.new(ov)
+    h.press(Termisu::Input::Key::Enter).should eq(:open) # row 0 → row 1
+    h.commits.should eq(0)
+    (FuzzAdvancedOverlay::ROWS.size - 1).times { h.press(Termisu::Input::Key::Down) }
+    h.press(Termisu::Input::Key::Enter).should eq(:open)
+    h.commits.should eq(0)
+    # …and the last row stays FOCUSED rather than stepping out of ROWS' range: what gets
+    # typed next still lands in Filter regex.
+    h.type("x").should eq(:open)
+    ov.snapshot.f_regex.should eq("x")
+  end
+
+  it "a click outside the card APPLIES rather than dismissing" do
+    # This modal has no cancel: apply_close_fuzz_advanced was the shell's click-away path too.
+    away = OverlayHarness.new(FuzzAdvancedOverlay.new(blank_snapshot))
+    away.click(0, 0).should eq(:closed)
+    away.commits.should eq(1)
+  end
+
+  it "a click inside focuses the row under the pointer and stays open" do
+    ov = FuzzAdvancedOverlay.new(blank_snapshot)
+    h = OverlayHarness.new(ov)
+    h.click_in_box(2, 5).should eq(:open) # rows start at box.y + 1 → row index 4 (Follow redirects)
+    h.commits.should eq(0)
+    h.press(Termisu::Input::Key::Space)
+    ov.snapshot.follow.should be_true
+  end
+
+  it "the wheel moves the selected row (base handle_wheel delegates to move)" do
+    ov = FuzzAdvancedOverlay.new(blank_snapshot)
+    h = OverlayHarness.new(ov)
+    h.wheel(5) # → Calibrate (row 5)
+    h.press(Termisu::Input::Key::Space)
+    ov.snapshot.calibrate.should be_true
+    ov.snapshot.follow.should be_false
+  end
+
+  it "routes IME preedit into the focused text row" do
+    h = OverlayHarness.new(FuzzAdvancedOverlay.new(blank_snapshot))
+    h.preedit("한")
+    h.rendered?("한").should be_true
+  end
+
+  it "APPLIES a click when the window is too small to draw the card" do
+    # The overlay_box → nil path. OverlayHarness::DEFAULT_AREA is the whole screen, so this
+    # path is unreachable through the default — pass an area that actually forces it. This
+    # editor diverges from the base class on purpose: the pre-seam shell ran
+    # `apply_close_fuzz_advanced(ov) if box.nil?`, so an unrenderable card must APPLY, and
+    # the inherited :cancel would silently drop knobs the user had already edited.
+    tiny = Gori::Tui::Rect.new(0, 0, 29, 6)
+    ov = FuzzAdvancedOverlay.new(blank_snapshot)
+    ov.overlay_box(tiny).should be_nil
+    ov.handle_click(tiny, 5, 3).should eq(:commit)
+    h = OverlayHarness.new(ov, area: tiny)
+    h.click(5, 3).should eq(:closed)
+    h.commits.should eq(1)
+    h.rendered?("advanced editor").should be_true
+  end
+
+  it "offsets a click by the scroll position once the list has scrolled" do
+    # Production hands an overlay `layout.body` — 6 rows shorter and offset from the screen —
+    # so this 18-row card renders clipped to 14 and the row list must scroll to reach the
+    # bottom fields. That scroll is what makes handle_click's `@scroll + i` load-bearing:
+    # @scroll only ever advances inside `render`, so a click example that never renders
+    # leaves it at 0, where `@scroll + i` and plain `i` are indistinguishable.
+    body = Gori::Tui::Rect.new(2, 4, 76, 18)
+    ov = FuzzAdvancedOverlay.new(blank_snapshot)
+    h = OverlayHarness.new(ov, area: body)
+    h.box.should_not be_nil
+    h.rendered?("Filter regex").should be_false # off-screen until the list scrolls
+    (FuzzAdvancedOverlay::ROWS.size - 1).times { h.press(Termisu::Input::Key::Down) }
+    h.rendered?("Filter regex").should be_true # this render is what advances @scroll
+    h.type("x")
+
+    # The first VISIBLE row is now ROWS[3] (Retries), not ROWS[0] (Concurrency).
+    h.click_in_box(2, 1).should eq(:open)
+    h.type("9")
+    ov.snapshot.retries.should eq("09") # lands in Concurrency if the click ignores @scroll
+    ov.snapshot.conc.should eq("20")    # …and Concurrency stays untouched
+    ov.snapshot.f_regex.should eq("x")
+
+    h.press(Termisu::Input::Key::Escape).should eq(:closed)
+    h.commits.should eq(1)
   end
 end

--- a/spec/tui/fuzz_set_overlay_spec.cr
+++ b/spec/tui/fuzz_set_overlay_spec.cr
@@ -1,5 +1,6 @@
 require "../spec_helper"
 require "../support/memory_backend"
+require "../support/overlay_harness"
 
 include Gori::Tui
 
@@ -51,9 +52,9 @@ describe Gori::Tui::FuzzSetOverlay do
     ov.build_spec.not_nil!.value.should eq("a,b,c")
   end
 
-  it "esc returns :apply; a blank List yields nil so @sets stays unchanged" do
+  it "esc returns :commit; a blank List yields nil so @sets stays unchanged" do
     ov = FuzzSetOverlay.for_list
-    ov.handle_key(okey(Termisu::Input::Key::Escape)).should eq(:apply)
+    ov.handle_key(okey(Termisu::Input::Key::Escape)).should eq(:commit)
     ov.build_spec.should be_nil
   end
 
@@ -133,5 +134,114 @@ describe Gori::Tui::FuzzSetOverlay do
       FileUtils.rm_rf(dir)
       Gori::Settings.fuzz_favorite_wordlists = [] of String
     end
+  end
+
+  # --- Overlay seam (see overlay.cr): the routing the Runner's generic dispatch replaced.
+  # OverlayHarness replays Runner#dispatch_overlay_key / #dispatch_overlay_click.
+  it "exposes the chrome the collapsed ladders used to hard-code" do
+    OverlayHarness.new(FuzzSetOverlay.for_list).assert_chrome(OverlayKind::FuzzSet, "PAYLOAD SET")
+  end
+
+  it "esc applies the edited set through the injected closure" do
+    ov = FuzzSetOverlay.for_list
+    applied = [] of SetSpec?
+    h = OverlayHarness.new(ov)
+    h.on_commit do
+      applied << ov.build_spec
+      true
+    end
+    h.press(Termisu::Input::Key::Down) # Type row → the values editor
+    h.type("a").should eq(:open)
+    h.press(Termisu::Input::Key::Enter) # ↵ opens a new value line, it does NOT apply
+    h.commits.should eq(0)
+    h.type("b").should eq(:open)
+    h.press(Termisu::Input::Key::Escape).should eq(:closed)
+    applied.map(&.try(&.value)).should eq(["a,b"])
+  end
+
+  it "↵ on the last FIELD row applies (Numbers: From/To/Step)" do
+    ov = FuzzSetOverlay.for_list
+    h = OverlayHarness.new(ov)
+    h.press(Termisu::Input::Key::Right)            # Type: List → Numbers
+    3.times { h.press(Termisu::Input::Key::Down) } # Type → From → To → Step (the last row)
+    h.press(Termisu::Input::Key::Enter).should eq(:closed)
+    h.commits.should eq(1)
+    ov.build_spec.not_nil!.value.should eq("1-100:1")
+  end
+
+  it "a click outside the card APPLIES rather than dismissing" do
+    # This modal has no cancel: apply_close_fuzz_set was the shell's click-away path too.
+    away = OverlayHarness.new(FuzzSetOverlay.for_list)
+    away.click(0, 0).should eq(:closed)
+    away.commits.should eq(1)
+  end
+
+  it "a click on the Type row focuses it and stays open" do
+    ov = FuzzSetOverlay.for_list
+    h = OverlayHarness.new(ov)
+    h.press(Termisu::Input::Key::Down) # move off the Type row into the values editor
+    h.click_in_box(2, 1).should eq(:open)
+    h.commits.should eq(0)
+    # Proof the Type row really took focus back: → cycles the payload type there, whereas
+    # in the values editor the same key only moves the caret.
+    h.press(Termisu::Input::Key::Right)
+    ov.build_spec.not_nil!.kind.should eq(:numbers)
+  end
+
+  it "the wheel moves the selected row (base handle_wheel delegates to move)" do
+    h = OverlayHarness.new(FuzzSetOverlay.for_list)
+    h.press(Termisu::Input::Key::Right) # Type: List → Numbers (rows: type/from/to/step)
+    h.wheel(3)                          # → Step, the last row
+    # ↵ applies only from the last row — on the Type row it would just advance.
+    h.press(Termisu::Input::Key::Enter).should eq(:closed)
+    h.commits.should eq(1)
+  end
+
+  it "APPLIES a click when the window is too small to draw the card" do
+    # The overlay_box → nil path. OverlayHarness::DEFAULT_AREA is the whole screen, so this
+    # path is unreachable through the default — pass an area that actually forces it. This
+    # editor diverges from the base class on purpose: the pre-seam shell ran
+    # `apply_close_fuzz_set(ov) if box.nil?`, so an unrenderable card must APPLY, and the
+    # inherited :cancel would silently drop the payload set the user had already typed.
+    tiny = Gori::Tui::Rect.new(0, 0, 29, 6)
+    ov = FuzzSetOverlay.editing(Gori::Tui::SetSpec.new(:list, "a,b"), 0)
+    ov.overlay_box(tiny).should be_nil
+    ov.handle_click(tiny, 5, 3).should eq(:commit)
+    h = OverlayHarness.new(ov, area: tiny)
+    h.click(5, 3).should eq(:closed)
+    h.commits.should eq(1)
+    h.rendered?("payload set editor").should be_true
+  end
+
+  it "hit-tests rows against the rect the shell passes (layout.body)" do
+    # Production hands an overlay `layout.body` — 6 rows shorter and offset from the screen,
+    # so this 20-row card renders clipped to 14 and sits lower. Only CLICKS can tell the two
+    # areas apart: handle_key never sees `area`, so driving keys through a smaller rect would
+    # be a byte-for-byte copy of the DEFAULT_AREA examples above.
+    body = Gori::Tui::Rect.new(2, 4, 76, 18)
+    ov = FuzzSetOverlay.for_list
+    h = OverlayHarness.new(ov, area: body)
+    box = h.box.not_nil!
+    box.h.should eq(14) # clipped from the 20 rows DEFAULT_AREA would allow
+
+    h.press(Termisu::Input::Key::Down) # Type row → the values editor
+    h.type("admin")
+    # The Type row sits at box.y + 1 of the SMALLER box; clicking it must take focus back.
+    h.click(box.x + 2, box.y + 1).should eq(:open)
+    h.press(Termisu::Input::Key::Right) # → cycles the type, which only the Type row does
+    ov.build_spec.not_nil!.kind.should eq(:numbers)
+
+    h.press(Termisu::Input::Key::Escape).should eq(:closed)
+    h.commits.should eq(1)
+  end
+
+  it "routes IME preedit into the focused editor" do
+    ov = FuzzSetOverlay.for_list
+    h = OverlayHarness.new(ov)
+    h.press(Termisu::Input::Key::Down) # into the values editor
+    h.type("x")                        # non-empty, so the editor renders instead of the placeholder
+    h.preedit("한")
+    h.rendered?("한").should be_true
+    ov.build_spec.not_nil!.value.should eq("x") # composing text is not in the buffer yet
   end
 end

--- a/spec/tui/notifications_overlay_spec.cr
+++ b/spec/tui/notifications_overlay_spec.cr
@@ -1,0 +1,128 @@
+require "../spec_helper"
+require "../support/memory_backend"
+require "../support/overlay_harness"
+
+include Gori::Tui
+
+private def store(*messages : String) : Notifications
+  s = Notifications.new
+  messages.each_with_index { |m, i| s.push(:info, m, Jobs::Goto.new(:history, i.to_i64)) }
+  s
+end
+
+# The notification center is the one LIST modal in this batch: no form, no commit
+# closure of its own state — ↵ hands the selected note to the shell's jump, and `c`
+# empties the store it was handed. Driven through OverlayHarness, which replays the
+# Runner's generic dispatch (see spec/support/overlay_harness.cr).
+describe Gori::Tui::NotificationsOverlay do
+  it "exposes the chrome the collapsed ladders used to hard-code" do
+    OverlayHarness.new(NotificationsOverlay.new(store("a"))).assert_chrome(OverlayKind::Notifications, "NOTIFICATIONS")
+  end
+
+  it "↵ commits the SELECTED note, not just the first" do
+    # Notes render newest-first, so pushing a,b,c lists them c,b,a — ↓ once lands on b.
+    ov = NotificationsOverlay.new(store("a", "b", "c"))
+    jumped = [] of String
+    h = OverlayHarness.new(ov)
+    h.on_commit do
+      jumped << ov.selected_note.not_nil!.message
+      true
+    end
+
+    h.press(Termisu::Input::Key::Down).should eq(:open)
+    h.press(Termisu::Input::Key::Enter).should eq(:closed)
+    jumped.should eq(["b"])
+  end
+
+  it "esc closes without running the jump" do
+    h = OverlayHarness.new(NotificationsOverlay.new(store("a")))
+    h.press(Termisu::Input::Key::Escape).should eq(:closed)
+    h.commits.should eq(0)
+  end
+
+  it "c empties the shared store in place and stays open" do
+    s = store("a", "b")
+    h = OverlayHarness.new(NotificationsOverlay.new(s))
+    h.press(Termisu::Input::Key::LowerC, 'c').should eq(:open)
+    s.all.should be_empty
+    h.commits.should eq(0)
+  end
+
+  it "^P runs the injected palette hop instead of committing or cancelling" do
+    ov = NotificationsOverlay.new(store("a"))
+    hops = 0
+    ov.on_palette = -> { hops += 1; nil }
+    h = OverlayHarness.new(ov)
+    # :stay, because the closure itself closes this modal and raises the palette — the
+    # shell must not run a second dismissal on top of what the closure just opened.
+    h.press(Termisu::Input::Key::LowerP, ctrl: true).should eq(:open)
+    hops.should eq(1)
+    h.commits.should eq(0)
+  end
+
+  it "a click on a row selects AND opens it; inside-but-not-a-row stays; outside dismisses" do
+    ov = NotificationsOverlay.new(store("a", "b", "c"))
+    picked = [] of String
+    h = OverlayHarness.new(ov)
+    h.on_commit do
+      picked << ov.selected_note.not_nil!.message
+      true
+    end
+    # Rows start at box.y + 2; the third row is the oldest note ("a").
+    h.click_in_box(3, 4).should eq(:closed)
+    picked.should eq(["a"])
+
+    # The card's title row holds no note — a click there must not commit or close.
+    inside = OverlayHarness.new(NotificationsOverlay.new(store("a")))
+    inside.click_in_box(3, 0).should eq(:open)
+    inside.commits.should eq(0)
+
+    away = OverlayHarness.new(NotificationsOverlay.new(store("a")))
+    away.click(0, 0).should eq(:closed)
+    away.commits.should eq(0)
+  end
+
+  it "the wheel moves the selection (base handle_wheel delegates to move)" do
+    ov = NotificationsOverlay.new(store("a", "b", "c"))
+    OverlayHarness.new(ov).wheel(2)
+    ov.selected_note.not_nil!.message.should eq("a") # newest-first: c, b, a
+  end
+
+  it "dismisses (never opens) a click when the window is too small to draw the card" do
+    # The overlay_box → nil path. OverlayHarness::DEFAULT_AREA is the whole screen, so this
+    # path is unreachable through the default — pass an area that actually forces it. The
+    # pre-seam shell closed the center here (`return @overlay = None if box.nil?`), so the
+    # override must report :cancel, NOT the :commit that would fire a jump with no card.
+    tiny = Gori::Tui::Rect.new(0, 0, 29, 6)
+    ov = NotificationsOverlay.new(store("a"))
+    ov.overlay_box(tiny).should be_nil
+    ov.handle_click(tiny, 5, 3).should eq(:cancel)
+    h = OverlayHarness.new(ov, area: tiny)
+    h.click(5, 3).should eq(:closed)
+    h.commits.should eq(0)
+    h.rendered?("notifications need").should be_true
+  end
+
+  it "still hit-tests rows in the rect the shell actually passes (layout.body)" do
+    # Production hands an overlay `layout.body` — 6 rows shorter and offset from the screen.
+    body = Gori::Tui::Rect.new(2, 4, 76, 18)
+    ov = NotificationsOverlay.new(store("a", "b", "c"))
+    picked = [] of String
+    h = OverlayHarness.new(ov, area: body)
+    h.on_commit do
+      picked << ov.selected_note.not_nil!.message
+      true
+    end
+    # Row 2, NOT row 0: the overlay opens on row 0, so clicking it would assert an end state
+    # identical to the no-op path and would still pass with set_selected deleted.
+    h.click_in_box(3, 4).should eq(:closed)
+    picked.should eq(["a"]) # newest-first (c, b, a), so row 2 is the oldest note
+  end
+
+  it "clamps the selection on an empty store instead of raising" do
+    h = OverlayHarness.new(NotificationsOverlay.new(Notifications.new))
+    h.press(Termisu::Input::Key::Down).should eq(:open)
+    h.overlay.as(NotificationsOverlay).selected_note.should be_nil
+    h.rendered?("(no notifications yet)").should be_true
+  end
+end

--- a/spec/tui/overlay_dispatch_spec.cr
+++ b/spec/tui/overlay_dispatch_spec.cr
@@ -49,6 +49,13 @@ private MIGRATED_KINDS = [
   OverlayKind::RewriterRule,
   OverlayKind::CaImport,
   OverlayKind::Import,
+  # C1 — scan/fuzz config forms
+  OverlayKind::Notifications,
+  OverlayKind::ProbeActive,
+  OverlayKind::DiscoverConfig,
+  OverlayKind::DiscoverHeaders,
+  OverlayKind::FuzzSet,
+  OverlayKind::FuzzAdvanced,
 ]
 
 # Never in MODAL_OVERLAYS by design, migrated or not: neither draws a capturing card.

--- a/spec/tui/probe_active_overlay_spec.cr
+++ b/spec/tui/probe_active_overlay_spec.cr
@@ -1,5 +1,6 @@
 require "../spec_helper"
 require "../support/memory_backend"
+require "../support/overlay_harness"
 
 include Gori::Tui
 
@@ -83,6 +84,123 @@ describe Gori::Tui::ProbeActiveOverlay do
       # notify + unsafe + run are all hit-testable (row_at maps their y bands to 0/1/2).
       rows = (box.y...box.bottom).compact_map { |y| ov.row_at(box, box.x + 3, y) }.uniq!.sort!
       rows.should eq([0, 1, 2])
+    end
+  end
+
+  # --- Overlay seam (see overlay.cr): the routing the Runner's generic dispatch replaced.
+  # OverlayHarness replays Runner#dispatch_overlay_key / #dispatch_overlay_click.
+  it "exposes the chrome the collapsed ladders used to hard-code" do
+    tmp_store do |store|
+      ov = ProbeActiveOverlay.new(flow(store, "GET", "/s?q=1"), [est("x")], [est("x")])
+      OverlayHarness.new(ov).assert_chrome(OverlayKind::ProbeActive, "ACTIVE SCAN")
+    end
+  end
+
+  it "↵ on Run commits; esc cancels without running the scan" do
+    tmp_store do |store|
+      same = [est("reflected_param")]
+      ov = ProbeActiveOverlay.new(flow(store, "GET", "/s?q=1"), same, same)
+      h = OverlayHarness.new(ov)
+      ov.on_run_row?.should be_true # opens on Run
+      h.press(Termisu::Input::Key::Enter).should eq(:closed)
+      h.commits.should eq(1)
+
+      esc = OverlayHarness.new(ProbeActiveOverlay.new(flow(store, "GET", "/s?q=1"), same, same))
+      esc.press(Termisu::Input::Key::Escape).should eq(:closed)
+      esc.commits.should eq(0)
+    end
+  end
+
+  it "keeps the popup up when the closure refuses (nothing to send)" do
+    tmp_store do |store|
+      # A POST with the unsafe opt-in still off: start_probe_active toasts and reports false.
+      ov = ProbeActiveOverlay.new(flow(store, "POST", "/submit?q=1"),
+        [] of Gori::Probe::Analyzer::ActiveEstimate, [est("reflected_param")])
+      h = OverlayHarness.new(ov, commit: false)
+      h.press(Termisu::Input::Key::Enter).should eq(:open)
+      h.commits.should eq(1) # it DID run — it just refused to close
+    end
+  end
+
+  it "␣ on a non-Run row toggles instead of committing" do
+    tmp_store do |store|
+      ov = ProbeActiveOverlay.new(flow(store, "POST", "/submit?q=1"),
+        [] of Gori::Probe::Analyzer::ActiveEstimate, [est("reflected_param")])
+      h = OverlayHarness.new(ov)
+      h.press(Termisu::Input::Key::Up).should eq(:open) # Run → unsafe opt-in
+      h.press(Termisu::Input::Key::Space).should eq(:open)
+      ov.allow_unsafe?.should be_true
+      h.commits.should eq(0)
+    end
+  end
+
+  it "a click on Run commits, a click on another row toggles, a click outside dismisses" do
+    tmp_store do |store|
+      ov = ProbeActiveOverlay.new(flow(store, "POST", "/submit?q=1"),
+        [] of Gori::Probe::Analyzer::ActiveEstimate, [est("reflected_param")])
+      h = OverlayHarness.new(ov)
+      box = h.box.not_nil!
+      first = (box.y...box.bottom).find { |y| ov.row_at(box, box.x + 3, y) == 0 }.not_nil!
+
+      # Row 1 is the unsafe opt-in: clicking it selects + flips, and stays open.
+      h.click(box.x + 3, first + 1).should eq(:open)
+      ov.allow_unsafe?.should be_true
+      h.commits.should eq(0)
+
+      # Row 2 is Run.
+      h.click(box.x + 3, first + 2).should eq(:closed)
+      h.commits.should eq(1)
+
+      away = OverlayHarness.new(ProbeActiveOverlay.new(flow(store, "GET", "/s?q=1"), [est("x")], [est("x")]))
+      away.click(0, 0).should eq(:closed)
+      away.commits.should eq(0)
+    end
+  end
+
+  it "the wheel moves the selected row (base handle_wheel delegates to move)" do
+    tmp_store do |store|
+      ov = ProbeActiveOverlay.new(flow(store, "GET", "/s?q=1"), [est("x")], [est("x")])
+      ov.on_run_row?.should be_true
+      OverlayHarness.new(ov).wheel(-1) # up one notch: Run → notify
+      ov.on_run_row?.should be_false
+    end
+  end
+
+  it "dismisses (never runs the scan on) a click when the window is too small" do
+    # The overlay_box → nil path. OverlayHarness::DEFAULT_AREA is the whole screen, so this
+    # path is unreachable through the default — pass an area that actually forces it. This
+    # popup sends real requests on commit, so an unrenderable card MUST cancel, matching the
+    # pre-seam `return close_probe_active if box.nil?`.
+    tmp_store do |store|
+      tiny = Gori::Tui::Rect.new(0, 0, 29, 6)
+      ov = ProbeActiveOverlay.new(flow(store, "GET", "/s?q=1"), [est("x")], [est("x")])
+      ov.overlay_box(tiny).should be_nil
+      ov.handle_click(tiny, 5, 3).should eq(:cancel)
+      h = OverlayHarness.new(ov, area: tiny)
+      h.click(5, 3).should eq(:closed)
+      h.commits.should eq(0)
+      h.rendered?("window too small").should be_true
+    end
+  end
+
+  it "runs the scan from a click in the rect the shell passes (layout.body)" do
+    # Production hands an overlay `layout.body` — 6 rows shorter and offset from the screen.
+    # Asserting row_at over that box would just restate the 80x24 example above, since the
+    # card fits either way; drive a real click so the smaller rect is actually load-bearing.
+    tmp_store do |store|
+      body = Gori::Tui::Rect.new(2, 4, 76, 18)
+      ov = ProbeActiveOverlay.new(flow(store, "POST", "/submit?q=1"),
+        [] of Gori::Probe::Analyzer::ActiveEstimate, [est("reflected_param")])
+      h = OverlayHarness.new(ov, area: body)
+      box = h.box.not_nil!
+      box.y.should be > 4 # centred inside the body rect, not the screen
+      first = (box.y...box.bottom).find { |y| ov.row_at(box, box.x + 3, y) == 0 }.not_nil!
+
+      # Row 1 is the unsafe opt-in, row 2 is Run — both must hit-test against THIS box.
+      h.click(box.x + 3, first + 1).should eq(:open)
+      ov.allow_unsafe?.should be_true
+      h.click(box.x + 3, first + 2).should eq(:closed)
+      h.commits.should eq(1)
     end
   end
 end

--- a/src/gori/tui/discover_config_overlay.cr
+++ b/src/gori/tui/discover_config_overlay.cr
@@ -1,6 +1,7 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./overlay"
 require "../discover"
 require "../settings"
 
@@ -15,8 +16,9 @@ module Gori::Tui
 
   # The config popup shown before a discovery run: a start-target chooser, spider/bruteforce
   # checkboxes, a max-depth cycler, a containment cycler, a concurrency cycler, and a Start row.
-  # No text field (so no IME plumbing). Mirrors MineConfigOverlay's shape.
-  class DiscoverConfigOverlay
+  # No text field (so no IME plumbing). Mirrors MineConfigOverlay's shape, and like it
+  # rides the polymorphic Overlay seam (see overlay.cr).
+  class DiscoverConfigOverlay < Overlay
     DEPTHS       = [1, 2, 3, 4, 5, 6, 8]
     CONCS        = [10, 20, 40, 80]
     CONTAINMENTS = [Discover::Containment::ScopeAware, Discover::Containment::SameOrigin, Discover::Containment::HostAndSubdomains]
@@ -37,6 +39,11 @@ module Gori::Tui
     # Custom request headers ({name, value}) prefilled from a History flow and/or
     # edited in the headers overlay. NOT persisted to prefs — they can carry secrets.
     getter headers : Array({String, String}) = [] of {String, String}
+
+    # ↵ on the headers row raises the CUSTOM HEADERS sub-editor. Injected because opening
+    # a second modal (and landing back here on its close) is the shell's job — see
+    # Runner#open_discover_headers.
+    property on_edit_headers : Proc(Nil)?
 
     def initialize(@seed : DiscoverSeed)
       @target_idx = 0
@@ -87,6 +94,56 @@ module Gori::Tui
 
     def on_start_row? : Bool
       @selected == ROW_START
+    end
+
+    # --- Overlay contract (see overlay.cr) ---
+    def key : OverlayKind
+      OverlayKind::DiscoverConfig
+    end
+
+    def title : String
+      "DISCOVER"
+    end
+
+    def hint : String
+      "↑/↓ field · ←/→ adjust · ␣ toggle · ↵ start/edit · esc cancel"
+    end
+
+    # Formerly Runner#handle_discover_config_key: ↑/↓ move, ←/→ adjust the cyclers, ␣/↵
+    # commits on Start, opens the headers sub-editor on the headers row, else toggles.
+    def handle_key(ev : Termisu::Event::Key) : Symbol
+      k = ev.key
+      return :cancel if k.escape?
+      if k.up?
+        move(-1)
+      elsif k.down?
+        move(1)
+      elsif k.left?
+        adjust(-1)
+      elsif k.right?
+        adjust(1)
+      elsif k.enter? || k.space?
+        return :commit if on_start_row?
+        activate_row
+      end
+      :stay
+    end
+
+    # Click a row to select it, then act on it exactly as ↵ would; outside the card cancels.
+    # Mirrors the prior Runner#click_discover_config.
+    def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      box = overlay_box(area)
+      return :cancel if box.nil? || !box.contains?(mx, my)
+      if idx = row_at(box, mx, my)
+        set_selected(idx)
+        return :commit if on_start_row?
+        activate_row
+      end
+      :stay
+    end
+
+    private def activate_row : Nil
+      on_headers_row? ? @on_edit_headers.try(&.call) : toggle
     end
 
     def move(d : Int32) : Nil

--- a/src/gori/tui/discover_headers_overlay.cr
+++ b/src/gori/tui/discover_headers_overlay.cr
@@ -1,6 +1,7 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./overlay"
 require "./text_area"
 require "../discover"
 
@@ -10,7 +11,11 @@ module Gori::Tui
   # esc saves (parsing the lines, dropping malformed ones) and returns to the popup.
   # Host/Connection are always emitted by the engine, so entering them here is a
   # no-op (dropped on parse).
-  class DiscoverHeadersOverlay
+  #
+  # A SUB-EDITOR on the Overlay seam (see overlay.cr): it has no cancel path at all, so
+  # both esc and click-away commit, and the injected closure writes the parsed headers
+  # back onto the Discover popup and re-opens it.
+  class DiscoverHeadersOverlay < Overlay
     def initialize(headers : Array({String, String}))
       text = headers.map { |name, value| "#{name}: #{value}" }.join("\n")
       @editor = TextArea.new(text)
@@ -19,6 +24,26 @@ module Gori::Tui
     # Current headers parsed from the editor buffer (invalid/forced lines dropped).
     def headers : Array({String, String})
       Discover::Headers.parse_lines(@editor.text.split('\n'))
+    end
+
+    # --- Overlay contract (see overlay.cr) ---
+    def key : OverlayKind
+      OverlayKind::DiscoverHeaders
+    end
+
+    def title : String
+      "CUSTOM HEADERS"
+    end
+
+    def hint : String
+      "one header per line · Host/Connection ignored · esc saves & closes"
+    end
+
+    # There is nothing to cancel INTO — the user is still inside the Discover popup — so a
+    # click outside the card saves exactly like esc, which is what the shell did before.
+    def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      box = overlay_box(area)
+      (box.nil? || !box.contains?(mx, my)) ? :commit : :stay
     end
 
     # esc = save & close (:commit); every other key edits the buffer (:stay).

--- a/src/gori/tui/fuzz_advanced_overlay.cr
+++ b/src/gori/tui/fuzz_advanced_overlay.cr
@@ -1,6 +1,7 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./overlay"
 require "./text_field"
 
 module Gori::Tui
@@ -18,8 +19,10 @@ module Gori::Tui
   # / filter knob gets its OWN labeled row (no more horizontal fields walked by ↑/↓,
   # no more ←/→-cycle-vs-caret overload): ↑/↓/⇥ move rows, ←/→ moves the caret on a
   # text row or flips a toggle row, esc applies + closes. Modeled on the same row
-  # idiom as MineConfigOverlay/FuzzSetOverlay.
-  class FuzzAdvancedOverlay
+  # idiom as MineConfigOverlay/FuzzSetOverlay, and like them it rides the polymorphic
+  # Overlay seam (see overlay.cr) — where "apply" IS :commit, so there is no cancel:
+  # esc and click-away both write the snapshot back through the injected closure.
+  class FuzzAdvancedOverlay < Overlay
     # {field key, label, kind(:text|:toggle)} in display order.
     ROWS = [
       {:conc, "Concurrency", :text},
@@ -64,10 +67,29 @@ module Gori::Tui
       ROWS[@sel]
     end
 
+    # --- Overlay contract (see overlay.cr) ---
+    def key : OverlayKind
+      OverlayKind::FuzzAdvanced
+    end
+
+    def title : String
+      "ADVANCED"
+    end
+
+    def hint : String
+      "↑/↓/⇥ field · ←/→ edit · ␣ toggle · ↵ next · esc applies & closes"
+    end
+
     # --- input --------------------------------------------------------------
+    # PRE-EXISTING (kept as-is by the Overlay migration, which is behaviour-preserving):
+    # the `case` value is discarded, so handle_text's commit-on-the-last-row never reaches
+    # the shell — ↵ there is a no-op, not an apply. Only esc and a click-away apply. The
+    # rendered hint already says "esc applies" and does not promise ↵, so this is a lost
+    # convenience rather than a broken advertised key; fixing it is a behaviour change and
+    # belongs in its own patch.
     def handle_key(ev : Termisu::Event::Key) : Symbol
       key = ev.key
-      return :apply if key.escape?
+      return :commit if key.escape?
       case
       when key.tab?, key.down?    then @sel = (@sel + 1).clamp(0, ROWS.size - 1)
       when key.back_tab?, key.up? then @sel = (@sel - 1).clamp(0, ROWS.size - 1)
@@ -86,7 +108,10 @@ module Gori::Tui
 
     private def handle_text(ev : Termisu::Event::Key) : Symbol
       if ev.key.enter?
-        return :apply if @sel == ROWS.size - 1
+        # handle_key drops this :commit (see the note there), but the early return is still
+        # load-bearing: without it @sel would step past the last row and `current` would
+        # index ROWS out of range.
+        return :commit if @sel == ROWS.size - 1
         @sel += 1
       else
         @fields[current[0]].handle_edit_key(ev)
@@ -166,12 +191,15 @@ module Gori::Tui
       end
     end
 
-    def handle_click(box : Rect, mx : Int32, my : Int32) : Bool
-      return false unless box.contains?(mx, my)
+    # Focus the row under a click; a click outside the card APPLIES (esc semantics), the
+    # same dismissal the shell used to run through apply_close_fuzz_advanced.
+    def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      box = overlay_box(area)
+      return :commit if box.nil? || !box.contains?(mx, my)
       i = my - (box.y + 1)
       ri = @scroll + i
       @sel = ri if 0 <= i && 0 <= ri < ROWS.size
-      true
+      :stay
     end
   end
 end

--- a/src/gori/tui/fuzz_set_overlay.cr
+++ b/src/gori/tui/fuzz_set_overlay.cr
@@ -1,6 +1,7 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./overlay"
 require "./text_area"
 require "./text_field"
 require "./path_complete"
@@ -21,10 +22,11 @@ module Gori::Tui
   # with text fields, so it also carries IME (set_preedit) plumbing and, for the
   # wordlist Path field, an inline PathComplete dropdown.
   #
-  # Surfaces used by the Runner: handle_key returns :apply when the user commits
-  # (esc, or ↵ on the last field) so the Runner writes build_spec back into @sets;
-  # :stay otherwise. overlay_box centers the box; set_preedit routes composing text.
-  class FuzzSetOverlay
+  # Rides the polymorphic Overlay seam (see overlay.cr). handle_key returns :commit when
+  # the user applies (esc, ↵ on the last field, or a click-away) and the injected closure
+  # writes build_spec back into @sets; :stay otherwise. There is no cancel: every exit
+  # applies, which is what the shell's apply_close_fuzz_set did on all three paths.
+  class FuzzSetOverlay < Overlay
     PTYPES = [:list, :numbers, :wordlist, :null, :brute]
 
     getter edit_index : Int32?
@@ -118,8 +120,22 @@ module Gori::Tui
       @sel == rows.size - 1
     end
 
+    # --- Overlay contract (see overlay.cr) ---
+    def key : OverlayKind
+      OverlayKind::FuzzSet
+    end
+
+    def title : String
+      "PAYLOAD SET"
+    end
+
+    def hint : String
+      "↑/↓/⇥ field · ←/→ type/caret · ↵ new value/next · esc applies & closes"
+    end
+
     # --- input ---------------------------------------------------------------
-    # Returns :apply when the user commits (Runner writes build_spec back), else :stay.
+    # Returns :commit when the user applies (the injected closure writes build_spec
+    # back), else :stay.
     def handle_key(ev : Termisu::Event::Key) : Symbol
       key = ev.key
       f = focused
@@ -135,7 +151,7 @@ module Gori::Tui
         end
       end
 
-      return :apply if key.escape?
+      return :commit if key.escape?
       if key.tab?
         move_row(1); return :stay
       elsif key.back_tab?
@@ -204,7 +220,7 @@ module Gori::Tui
       case
       when key.up?    then move_row(-1)
       when key.down?  then move_row(1)
-      when key.enter? then return :apply if on_last_row?; move_row(1)
+      when key.enter? then return :commit if on_last_row?; move_row(1)
       else
         tf.handle_edit_key(ev)
         refresh_path(f) # keep the wordlist dropdown in lockstep with the field
@@ -329,10 +345,12 @@ module Gori::Tui
         screen.text(area.x + 1, area.y, "payload set editor needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
         return
       end
-      title = @edit_index ? "PAYLOAD SET · edit" : "PAYLOAD SET · new"
+      # Not `title` — that is now the Overlay chrome method, and a local of the same name
+      # shadowing it inside render is the collision C2 hit (Crystal has no `override`).
+      card_title = @edit_index ? "PAYLOAD SET · edit" : "PAYLOAD SET · new"
       # bg: Theme.bg (not the card default panel) so the embedded List TextArea, which
       # always paints on Theme.bg, doesn't two-tone against the card interior.
-      Frame.card(screen, box, title, bg: Theme.bg, border: Theme.border_focus)
+      Frame.card(screen, box, card_title, bg: Theme.bg, border: Theme.border_focus)
       render_meta(screen, box)
       render_type_row(screen, box)
       Frame.tee_divider(screen, box, box.y + 2, Theme.bg)
@@ -413,9 +431,11 @@ module Gori::Tui
 
     # --- mouse ---------------------------------------------------------------
     # Focus the row under a click; place the List caret when the click lands in the
-    # editor. Returns true when the click was inside the box (consumed).
-    def handle_click(box : Rect, mx : Int32, my : Int32) : Bool
-      return false unless box.contains?(mx, my)
+    # editor. A click outside the card APPLIES (esc semantics) — the same dismissal the
+    # shell used to run through apply_close_fuzz_set.
+    def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      box = overlay_box(area)
+      return :commit if box.nil? || !box.contains?(mx, my)
       if my == box.y + 1
         @sel = 0
         sync_path_complete
@@ -427,7 +447,7 @@ module Gori::Tui
         @sel = (i + 1).clamp(1, rows.size - 1) if 0 <= i < field_rows.size
         sync_path_complete
       end
-      true
+      :stay
     end
 
     def move(d : Int32) : Nil

--- a/src/gori/tui/notifications_overlay.cr
+++ b/src/gori/tui/notifications_overlay.cr
@@ -1,18 +1,28 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./overlay"
 require "./notifications"
 
 module Gori::Tui
   # The notification center: a centered overlay listing recent notifications (newest
-  # first). Pure state (@selected) + render; the Runner owns open/close and runs a
-  # note's `goto`. Reads the live store, so a note pushed by a drain while the center
-  # is open appears at once. Chosen over a persistent "Activity" tab — lighter, and it
-  # reuses the existing modal-overlay machinery.
+  # first). Pure state (@selected) + render; the injected closures run a note's `goto`
+  # and the palette hop. Reads the live store, so a note pushed by a drain while the
+  # center is open appears at once. Chosen over a persistent "Activity" tab — lighter,
+  # and it reuses the existing modal-overlay machinery.
   #
   #   ▎ ✓ Miner: 3 params found on GET /api/x          3s
   #     ⚠ Repeater: upstream timeout                      5m
-  class NotificationsOverlay
+  #
+  # Migrated onto the polymorphic Overlay seam (see overlay.cr). `c` clears the store
+  # this overlay was handed, so it stays a plain key case; the two actions that belong
+  # to the SHELL (jump to a note's result, hop to the palette) are injected closures.
+  class NotificationsOverlay < Overlay
+    # ^P leaves the center for the command palette. Injected because raising another
+    # modal is the shell's job — and it must close this one FIRST, or the shell's own
+    # close would land on top of the palette. See Runner#open_notifications.
+    property on_palette : Proc(Nil)?
+
     def initialize(@store : Notifications)
       @selected = 0
     end
@@ -25,7 +35,54 @@ module Gori::Tui
       @store.all
     end
 
-    def select_move(d : Int32) : Nil
+    # --- Overlay contract (see overlay.cr) ---
+    def key : OverlayKind
+      OverlayKind::Notifications
+    end
+
+    def title : String
+      "NOTIFICATIONS"
+    end
+
+    def hint : String
+      "↑/↓ select · ↵ open · c clear · esc close"
+    end
+
+    # Formerly Runner#handle_notifications_key. ↵ commits (the open-site's closure jumps
+    # to the selected note's result); `c` empties the store in place and stays open.
+    def handle_key(ev : Termisu::Event::Key) : Symbol
+      k = ev.key
+      c = ev.char
+      if ev.ctrl? && k.lower_p?
+        @on_palette.try(&.call)
+      elsif k.escape?
+        return :cancel
+      elsif k.up?
+        move(-1)
+      elsif k.down?
+        move(1)
+      elsif k.enter?
+        return :commit
+      elsif c == 'c'
+        @store.clear
+        reset
+      end
+      :stay
+    end
+
+    # A click on a row selects it and opens it (same as ↵); a click elsewhere inside the
+    # card does nothing; a click outside dismisses. Mirrors Runner#click_notifications.
+    def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      box = overlay_box(area)
+      return :cancel if box.nil? || !box.contains?(mx, my)
+      if idx = row_at(box, mx, my)
+        set_selected(idx)
+        return :commit
+      end
+      :stay
+    end
+
+    def move(d : Int32) : Nil
       @selected = (@selected + d).clamp(0, {notes.size - 1, 0}.max)
     end
 

--- a/src/gori/tui/probe_active_overlay.cr
+++ b/src/gori/tui/probe_active_overlay.cr
@@ -1,6 +1,7 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./overlay"
 require "../probe/analyzer"
 require "../miner/types"
 require "../store"
@@ -12,9 +13,10 @@ module Gori::Tui
   # mode cycler (‹/›, mirroring the Mine popup), an OPTIONAL "unsafe methods" opt-in cycler (shown
   # only when unsafe-method probing would add checks the safe scan can't run — i.e. the flow is a
   # POST/PUT/PATCH/DELETE, or a rule that only runs on non-GET bodies would apply), and a Run row.
-  # The Runner reads notify_mode + allow_unsafe? + detail/repeater_id on Run and persists the notify
-  # choice. Pure state + render.
-  class ProbeActiveOverlay
+  # The injected commit closure reads notify_mode + allow_unsafe? + detail/repeater_id on Run and
+  # persists the notify choice. Pure state + render; migrated onto the polymorphic Overlay seam
+  # (see overlay.cr).
+  class ProbeActiveOverlay < Overlay
     NOTIFY_CHOICES = Miner::NotifyMode.values
 
     getter detail : Store::FlowDetail
@@ -91,6 +93,53 @@ module Gori::Tui
 
     def on_run_row? : Bool
       @selected == run_row
+    end
+
+    # --- Overlay contract (see overlay.cr) ---
+    def key : OverlayKind
+      OverlayKind::ProbeActive
+    end
+
+    def title : String
+      "ACTIVE SCAN"
+    end
+
+    def hint : String
+      "↑/↓ field · ←/→ adjust · ↵ run · esc cancel"
+    end
+
+    # Formerly Runner#handle_probe_active_key: ↑/↓ move, ←/→ adjust the cyclers, ␣/↵ toggles a
+    # row or commits on Run (the open-site's closure fires the scan and reports whether the
+    # options actually send anything — a no-op selection keeps the popup up).
+    def handle_key(ev : Termisu::Event::Key) : Symbol
+      k = ev.key
+      return :cancel if k.escape?
+      if k.up?
+        move(-1)
+      elsif k.down?
+        move(1)
+      elsif k.left?
+        adjust(-1)
+      elsif k.right?
+        adjust(1)
+      elsif k.enter? || k.space?
+        return :commit if on_run_row?
+        toggle
+      end
+      :stay
+    end
+
+    # Click a row to select it; Run commits, any other row toggles; outside the card cancels.
+    # Mirrors the prior Runner#click_probe_active exactly.
+    def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      box = overlay_box(area)
+      return :cancel if box.nil? || !box.contains?(mx, my)
+      if idx = row_at(box, mx, my)
+        set_selected(idx)
+        return :commit if on_run_row?
+        toggle
+      end
+      :stay
     end
 
     def move(d : Int32) : Nil

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -219,7 +219,6 @@ module Gori::Tui
       # frame advances while a job is active so the bottom-bar chip animates.
       @jobs = Jobs.new
       @notifications = Notifications.new
-      @notifications_overlay = NotificationsOverlay.new(@notifications)
       # #123: high-water-mark of intercept_commands drained + applied to the live interceptor
       # (agent forward/drop/edit/toggle). Seeded to the current max at run start so a fresh
       # session never replays a prior command; advances monotonically as commands are consumed.
@@ -245,15 +244,6 @@ module Gori::Tui
       # to reconfigure the current session) rides the Overlay seam (@active_overlay). The
       # new-vs-reconfigure distinction that used to need a @sequence_reconfigure flag now
       # lives in each open-site's injected commit closure.
-      @discover_config_overlay = nil.as(DiscoverConfigOverlay?)
-      @discover_headers_overlay = nil.as(DiscoverHeadersOverlay?)
-      # :probe_active while the "Run active scan" popup is up (holds the seed flow + estimate).
-      @probe_active_overlay = nil.as(ProbeActiveOverlay?)
-      # The Fuzzer config overlays (CONFIG pane → ↵ on a set / Add / Advanced): a payload-set
-      # editor and the advanced-settings form. @overlay is :fuzz_set / :fuzz_advanced while up;
-      # built fresh from the current fuzz session each time they open.
-      @fuzz_set_overlay = nil.as(FuzzSetOverlay?)
-      @fuzz_advanced_overlay = nil.as(FuzzAdvancedOverlay?)
       # The one active polymorphic modal (see overlay.cr). Overlays migrated onto the
       # Overlay base flow through here instead of a per-modal typed ivar + `case @overlay`
       # ladders. nil = no such modal up. (SCOPE add/edit was the first migrated — the
@@ -923,20 +913,17 @@ module Gori::Tui
         return
       end
       case @overlay
-      when .palette?          then @palette.set_preedit(text)
-      when .issue_new?        then @issue_form.set_preedit(text)
-      when .comparer_pick?    then @flow_picker.try(&.set_preedit(text))
-      when .repeater_subtab?  then @subtab_picker.try(&.set_preedit(text))
-      when .issue_pick?       then @issue_picker.try(&.set_preedit(text))
-      when .note_pick?        then @note_picker.try(&.set_preedit(text))
-      when .preferences?      then @preferences.set_preedit(text)
-      when .settings?         then @settings_view.set_preedit(text)
-      when .hosts?            then @hosts_overlay.set_preedit(text)
-      when .env?              then @env_overlay.set_preedit(text)
-      when .discover_headers? then @discover_headers_overlay.try(&.set_preedit(text))
-      when .fuzz_set?         then @fuzz_set_overlay.try(&.set_preedit(text))
-      when .fuzz_advanced?    then @fuzz_advanced_overlay.try(&.set_preedit(text))
-      when .none?             then apply_preedit_body(text)
+      when .palette?         then @palette.set_preedit(text)
+      when .issue_new?       then @issue_form.set_preedit(text)
+      when .comparer_pick?   then @flow_picker.try(&.set_preedit(text))
+      when .repeater_subtab? then @subtab_picker.try(&.set_preedit(text))
+      when .issue_pick?      then @issue_picker.try(&.set_preedit(text))
+      when .note_pick?       then @note_picker.try(&.set_preedit(text))
+      when .preferences?     then @preferences.set_preedit(text)
+      when .settings?        then @settings_view.set_preedit(text)
+      when .hosts?           then @hosts_overlay.set_preedit(text)
+      when .env?             then @env_overlay.set_preedit(text)
+      when .none?            then apply_preedit_body(text)
       end
     end
 
@@ -1026,17 +1013,11 @@ module Gori::Tui
         settle_sub_editor # closing one opened from Preferences lands back in the modal
         return
       end
-      return handle_notifications_key(ev) if @overlay.notifications?
       # Migrated modals (Overlay base) dispatch generically — no per-modal handle_*_key.
       if ov = active_overlay
         dispatch_overlay_key(ov, ev)
         return
       end
-      return handle_probe_active_key(ev) if @overlay.probe_active?
-      return handle_discover_config_key(ev) if @overlay.discover_config?
-      return handle_discover_headers_key(ev) if @overlay.discover_headers?
-      return handle_fuzz_set_key(ev) if @overlay.fuzz_set?
-      return handle_fuzz_advanced_key(ev) if @overlay.fuzz_advanced?
       # Text-entry modes own Tab (complete) + Esc within themselves — let them run
       # before the global focus ring claims Tab.
       if @active_tab == :history && @overlay.none? && @focus == :body && history_controller.view.querying?
@@ -1310,12 +1291,6 @@ module Gori::Tui
       OverlayKind::Hosts,
       OverlayKind::Env,
       OverlayKind::Hotkeys,
-      OverlayKind::Notifications,
-      OverlayKind::ProbeActive,
-      OverlayKind::DiscoverConfig,
-      OverlayKind::DiscoverHeaders,
-      OverlayKind::FuzzSet,
-      OverlayKind::FuzzAdvanced,
     }
 
     private def modal_overlay? : Bool
@@ -1410,28 +1385,22 @@ module Gori::Tui
         return
       end
       case @overlay
-      when .palette?          then click_palette(area, mx, my)
-      when .browser?          then click_browser(area, mx, my)
-      when .choice?           then click_choice(area, mx, my)
-      when .tabs_more?        then click_more_menu(layout, mx, my)
-      when .comparer_pick?    then click_flow_picker(area, mx, my)
-      when .repeater_subtab?  then click_subtab_picker(area, mx, my)
-      when .links?            then click_links(area, mx, my)
-      when .issue_pick?       then click_issue_picker(area, mx, my)
-      when .note_pick?        then click_note_picker(area, mx, my)
-      when .confirm?          then click_confirm(area, mx, my)
-      when .preferences?      then apply_preferences_outcome(@preferences.click(area, mx, my))
-      when .settings?         then (click_settings(area, mx, my); settle_sub_editor)
-      when .tabs?             then (click_tabs(area, mx, my); settle_sub_editor)
-      when .hosts?            then (click_hosts(area, mx, my); settle_sub_editor)
-      when .env?              then (click_env(area, mx, my); settle_sub_editor)
-      when .hotkeys?          then (click_hotkeys(area, mx, my); settle_sub_editor)
-      when .notifications?    then click_notifications(area, mx, my)
-      when .probe_active?     then click_probe_active(area, mx, my)
-      when .discover_config?  then click_discover_config(area, mx, my)
-      when .discover_headers? then click_discover_headers(area, mx, my)
-      when .fuzz_set?         then click_fuzz_set(area, mx, my)
-      when .fuzz_advanced?    then click_fuzz_advanced(area, mx, my)
+      when .palette?         then click_palette(area, mx, my)
+      when .browser?         then click_browser(area, mx, my)
+      when .choice?          then click_choice(area, mx, my)
+      when .tabs_more?       then click_more_menu(layout, mx, my)
+      when .comparer_pick?   then click_flow_picker(area, mx, my)
+      when .repeater_subtab? then click_subtab_picker(area, mx, my)
+      when .links?           then click_links(area, mx, my)
+      when .issue_pick?      then click_issue_picker(area, mx, my)
+      when .note_pick?       then click_note_picker(area, mx, my)
+      when .confirm?         then click_confirm(area, mx, my)
+      when .preferences?     then apply_preferences_outcome(@preferences.click(area, mx, my))
+      when .settings?        then (click_settings(area, mx, my); settle_sub_editor)
+      when .tabs?            then (click_tabs(area, mx, my); settle_sub_editor)
+      when .hosts?           then (click_hosts(area, mx, my); settle_sub_editor)
+      when .env?             then (click_env(area, mx, my); settle_sub_editor)
+      when .hotkeys?         then (click_hotkeys(area, mx, my); settle_sub_editor)
         # IssueNew is a text form — keyboard-only in Phase 1 (cursor placement is Phase 2)
       end
     end
@@ -1463,63 +1432,6 @@ module Gori::Tui
       when :settings then open_preferences
       end
       true
-    end
-
-    private def click_notifications(area : Rect, mx : Int32, my : Int32) : Nil
-      box = @notifications_overlay.overlay_box(area)
-      return (@overlay = OverlayKind::None) if box.nil? || dismiss_zone?(box, mx, my)
-      if idx = @notifications_overlay.row_at(box, mx, my)
-        @notifications_overlay.set_selected(idx)
-        open_notification_goto
-      end
-    end
-
-    private def click_probe_active(area : Rect, mx : Int32, my : Int32) : Nil
-      ov = @probe_active_overlay
-      return unless ov
-      box = ov.overlay_box(area)
-      return close_probe_active if box.nil? || dismiss_zone?(box, mx, my)
-      if idx = ov.row_at(box, mx, my)
-        ov.set_selected(idx)
-        ov.on_run_row? ? start_probe_active(ov) : ov.toggle
-      end
-    end
-
-    private def click_discover_config(area : Rect, mx : Int32, my : Int32) : Nil
-      ov = @discover_config_overlay
-      return unless ov
-      box = ov.overlay_box(area)
-      return close_discover_config if box.nil? || dismiss_zone?(box, mx, my)
-      if idx = ov.row_at(box, mx, my)
-        ov.set_selected(idx)
-        if ov.on_start_row?
-          start_discover(ov)
-        elsif ov.on_headers_row?
-          open_discover_headers(ov)
-        else
-          ov.toggle
-        end
-      end
-    end
-
-    private def click_discover_headers(area : Rect, mx : Int32, my : Int32) : Nil
-      ov = @discover_headers_overlay || return
-      box = ov.overlay_box(area)
-      commit_discover_headers if box.nil? || dismiss_zone?(box, mx, my) # click-away saves (esc semantics)
-    end
-
-    private def click_fuzz_set(area : Rect, mx : Int32, my : Int32) : Nil
-      ov = @fuzz_set_overlay || return
-      box = ov.overlay_box(area)
-      return apply_close_fuzz_set(ov) if box.nil? || dismiss_zone?(box, mx, my) # click-away applies (esc semantics)
-      ov.handle_click(box, mx, my)
-    end
-
-    private def click_fuzz_advanced(area : Rect, mx : Int32, my : Int32) : Nil
-      ov = @fuzz_advanced_overlay || return
-      box = ov.overlay_box(area)
-      return apply_close_fuzz_advanced(ov) if box.nil? || dismiss_zone?(box, mx, my)
-      ov.handle_click(box, mx, my)
     end
 
     private def click_palette(area : Rect, mx : Int32, my : Int32) : Nil
@@ -1665,95 +1577,7 @@ module Gori::Tui
       when .hosts?           then @hosts_overlay.select_move(step)
       when .env?             then @env_overlay.select_move(step)
       when .hotkeys?         then @hotkeys_overlay.select_move(step)
-      when .notifications?   then @notifications_overlay.select_move(step)
-      when .probe_active?    then @probe_active_overlay.try(&.move(step))
-      when .discover_config? then @discover_config_overlay.try(&.move(step))
-      when .fuzz_set?        then @fuzz_set_overlay.try(&.move(step))
-      when .fuzz_advanced?   then @fuzz_advanced_overlay.try(&.move(step))
       end
-    end
-
-    # Notification center: ↑/↓ select · ↵ jump to the result · c clear · ^P palette · esc.
-    private def handle_notifications_key(ev : Termisu::Event::Key) : Nil
-      key = ev.key
-      c = ev.char
-      if ev.ctrl? && key.lower_p?
-        @overlay = OverlayKind::None
-        open_palette
-      elsif key.escape?
-        @overlay = OverlayKind::None
-      elsif key.up?
-        @notifications_overlay.select_move(-1)
-      elsif key.down?
-        @notifications_overlay.select_move(1)
-      elsif key.enter?
-        open_notification_goto
-      elsif c == 'c'
-        @notifications.clear
-        @notifications_overlay.reset
-      end
-    end
-
-    # Miner config popup: ↑/↓ field · ←/→ adjust · ␣ toggle · ↵ start · esc cancel.
-    # Run-active-scan popup: ↑/↓ field · ←/→ notify · ↵ run · esc cancel.
-    private def handle_probe_active_key(ev : Termisu::Event::Key) : Nil
-      ov = @probe_active_overlay
-      return unless ov
-      key = ev.key
-      if key.escape?
-        close_probe_active
-      elsif key.up?
-        ov.move(-1)
-      elsif key.down?
-        ov.move(1)
-      elsif key.left?
-        ov.adjust(-1)
-      elsif key.right?
-        ov.adjust(1)
-      elsif key.enter? || key.space?
-        ov.on_run_row? ? start_probe_active(ov) : ov.toggle
-      end
-    end
-
-    # Sequencer config popup: ↑/↓ field · type to edit the selector · ←/→ cycle · ↵ start.
-    # The selector row is a text field, so printable/caret keys route there first; every
-    # other row uses the ←/→ cycler nav.
-    private def handle_discover_config_key(ev : Termisu::Event::Key) : Nil
-      ov = @discover_config_overlay
-      return unless ov
-      key = ev.key
-      if key.escape?
-        close_discover_config
-      elsif key.up?
-        ov.move(-1)
-      elsif key.down?
-        ov.move(1)
-      elsif key.left?
-        ov.adjust(-1)
-      elsif key.right?
-        ov.adjust(1)
-      elsif key.enter? || key.space?
-        if ov.on_start_row?
-          start_discover(ov)
-        elsif ov.on_headers_row?
-          open_discover_headers(ov)
-        else
-          ov.toggle
-        end
-      end
-    end
-
-    # Fuzzer payload-set / advanced overlays. Each owns ALL its keys (incl. Tab + its
-    # own wordlist autocomplete) while open; :apply (esc / ↵ on the last field / a
-    # click-away) writes the edit back into the fuzz session and closes.
-    private def handle_fuzz_set_key(ev : Termisu::Event::Key) : Nil
-      ov = @fuzz_set_overlay || return
-      apply_close_fuzz_set(ov) if ov.handle_key(ev) == :apply
-    end
-
-    private def handle_fuzz_advanced_key(ev : Termisu::Event::Key) : Nil
-      ov = @fuzz_advanced_overlay || return
-      apply_close_fuzz_advanced(ov) if ov.handle_key(ev) == :apply
     end
 
     # Project SCOPE rule popup: ↑/↓ field · ←/→ kind/type · type pattern · ↵ save · esc cancel.
@@ -1837,18 +1661,6 @@ module Gori::Tui
         end
       end
       false
-    end
-
-    private def apply_close_fuzz_set(ov : FuzzSetOverlay) : Nil
-      fuzzer_controller.apply_fuzz_set(ov.edit_index, ov.build_spec)
-      @overlay = OverlayKind::None
-      @fuzz_set_overlay = nil
-    end
-
-    private def apply_close_fuzz_advanced(ov : FuzzAdvancedOverlay) : Nil
-      fuzzer_controller.apply_fuzz_advanced(ov.snapshot)
-      @overlay = OverlayKind::None
-      @fuzz_advanced_overlay = nil
     end
 
     # New-issue form: type a title; ↵ create, esc cancel.
@@ -3658,12 +3470,6 @@ module Gori::Tui
       @hosts_overlay.render(screen, layout.body) if @overlay.hosts?
       @env_overlay.render(screen, layout.body) if @overlay.env?
       @hotkeys_overlay.render(screen, layout.body) if @overlay.hotkeys?
-      @notifications_overlay.render(screen, layout.body) if @overlay.notifications?
-      @probe_active_overlay.try(&.render(screen, layout.body)) if @overlay.probe_active?
-      @discover_config_overlay.try(&.render(screen, layout.body)) if @overlay.discover_config?
-      @discover_headers_overlay.try(&.render(screen, layout.body)) if @overlay.discover_headers?
-      @fuzz_set_overlay.try(&.render(screen, layout.body)) if @overlay.fuzz_set?
-      @fuzz_advanced_overlay.try(&.render(screen, layout.body)) if @overlay.fuzz_advanced?
       active_overlay.try(&.render(screen, layout.body)) # migrated modals (Overlay seam; gated on @overlay)
       # The space menu + bottom prompts float over everything else (drawn last).
       render_prompts(screen, layout)
@@ -3772,29 +3578,23 @@ module Gori::Tui
         return ov.title
       end
       case @overlay
-      when .palette?          then "PALETTE"
-      when .issue_new?        then "ISSUE"
-      when .detail?           then "DETAIL"
-      when .confirm?          then "CONFIRM"
-      when .browser?          then "BROWSER"
-      when .choice?           then @choice_picker.try(&.title) || "CHOOSE"
-      when .comparer_pick?    then "PICK FLOW"
-      when .repeater_subtab?  then @subtab_picker.try(&.title) || "FIND SUB-TAB"
-      when .links?            then @links_overlay.try(&.title) || "LINKS"
-      when .issue_pick?       then "PICK ISSUE"
-      when .note_pick?        then "PICK NOTE"
-      when .preferences?      then "PREFERENCES"
-      when .settings?         then "SETTINGS"
-      when .tabs?             then "TAB BAR"
-      when .hosts?            then "HOSTNAME OVERRIDES"
-      when .env?              then "ENVIRONMENT"
-      when .hotkeys?          then "HOTKEYS"
-      when .notifications?    then "NOTIFICATIONS"
-      when .probe_active?     then "ACTIVE SCAN"
-      when .discover_config?  then "DISCOVER"
-      when .discover_headers? then "CUSTOM HEADERS"
-      when .fuzz_set?         then "PAYLOAD SET"
-      when .fuzz_advanced?    then "ADVANCED"
+      when .palette?         then "PALETTE"
+      when .issue_new?       then "ISSUE"
+      when .detail?          then "DETAIL"
+      when .confirm?         then "CONFIRM"
+      when .browser?         then "BROWSER"
+      when .choice?          then @choice_picker.try(&.title) || "CHOOSE"
+      when .comparer_pick?   then "PICK FLOW"
+      when .repeater_subtab? then @subtab_picker.try(&.title) || "FIND SUB-TAB"
+      when .links?           then @links_overlay.try(&.title) || "LINKS"
+      when .issue_pick?      then "PICK ISSUE"
+      when .note_pick?       then "PICK NOTE"
+      when .preferences?     then "PREFERENCES"
+      when .settings?        then "SETTINGS"
+      when .tabs?            then "TAB BAR"
+      when .hosts?           then "HOSTNAME OVERRIDES"
+      when .env?             then "ENVIRONMENT"
+      when .hotkeys?         then "HOTKEYS"
       else
         case @focus
         when :menu    then "TABS"
@@ -3824,30 +3624,24 @@ module Gori::Tui
         return ov.hint
       end
       case @overlay
-      when .palette?          then "↑/↓ select · ↵ run · ⌫ · esc close · type to filter"
-      when .issue_new?        then "type title · ↵ create · esc cancel"
-      when .confirm?          then "←/→ choose · y confirm · n/esc cancel · ↵ select"
-      when .browser?          then "↑/↓ select · ↵ open · esc cancel"
-      when .choice?           then "↑/↓ select · ↵ set · key picks · esc cancel"
-      when .tabs_more?        then "↑/↓ select · ↵ open tab · ←/esc close"
-      when .comparer_pick?    then "type to filter · ↑/↓ select · ↵ choose · esc cancel"
-      when .repeater_subtab?  then "type to filter · ↑/↓ select · ↵ #{@subtab_picker.try(&.action) || "jump"} · esc cancel"
-      when .links?            then @links_overlay.try(&.adding?) ? "f/r/z/m pick type · esc back" : "↑/↓ · ↵/o open · a add · d remove · esc close"
-      when .issue_pick?       then "type to filter · ↑/↓ select · ↵ link · esc cancel"
-      when .note_pick?        then "type to filter · ↑/↓ select · ↵ link · esc cancel"
-      when .preferences?      then "←/→ group · ↑/↓ field · ↵ save/open · ^R reset · esc close"
-      when .settings?         then "↑/↓ field · type to edit · ↵ save · ^R reset · esc close"
-      when .tabs?             then "↑/↓ select · space show/hide · K/J reorder · r reset · ↵ save · esc cancel"
-      when .hosts?            then @hosts_overlay.adding? ? "type \"IP host\" · ↵ save · esc cancel" : "↑/↓ select · a add · ↵/e edit · d delete · esc close"
-      when .env?              then env_overlay_hints
-      when .hotkeys?          then @hotkeys_overlay.capturing? ? "press a key to bind · esc cancel" : "↑/↓ select · e/␣ rebind · x unbind · r reset · ⇧R reset all · ←/→ profile · ↵ save · esc"
-      when .notifications?    then "↑/↓ select · ↵ open · c clear · esc close"
-      when .probe_active?     then "↑/↓ field · ←/→ adjust · ↵ run · esc cancel"
-      when .discover_config?  then "↑/↓ field · ←/→ adjust · ␣ toggle · ↵ start/edit · esc cancel"
-      when .discover_headers? then "one header per line · Host/Connection ignored · esc saves & closes"
-      when .fuzz_set?         then "↑/↓/⇥ field · ←/→ type/caret · ↵ new value/next · esc applies & closes"
-      when .fuzz_advanced?    then "↑/↓/⇥ field · ←/→ edit · ␣ toggle · ↵ next · esc applies & closes"
-      when .detail?           then history_controller.body_hint(:body)
+      when .palette?         then "↑/↓ select · ↵ run · ⌫ · esc close · type to filter"
+      when .issue_new?       then "type title · ↵ create · esc cancel"
+      when .confirm?         then "←/→ choose · y confirm · n/esc cancel · ↵ select"
+      when .browser?         then "↑/↓ select · ↵ open · esc cancel"
+      when .choice?          then "↑/↓ select · ↵ set · key picks · esc cancel"
+      when .tabs_more?       then "↑/↓ select · ↵ open tab · ←/esc close"
+      when .comparer_pick?   then "type to filter · ↑/↓ select · ↵ choose · esc cancel"
+      when .repeater_subtab? then "type to filter · ↑/↓ select · ↵ #{@subtab_picker.try(&.action) || "jump"} · esc cancel"
+      when .links?           then @links_overlay.try(&.adding?) ? "f/r/z/m pick type · esc back" : "↑/↓ · ↵/o open · a add · d remove · esc close"
+      when .issue_pick?      then "type to filter · ↑/↓ select · ↵ link · esc cancel"
+      when .note_pick?       then "type to filter · ↑/↓ select · ↵ link · esc cancel"
+      when .preferences?     then "←/→ group · ↑/↓ field · ↵ save/open · ^R reset · esc close"
+      when .settings?        then "↑/↓ field · type to edit · ↵ save · ^R reset · esc close"
+      when .tabs?            then "↑/↓ select · space show/hide · K/J reorder · r reset · ↵ save · esc cancel"
+      when .hosts?           then @hosts_overlay.adding? ? "type \"IP host\" · ↵ save · esc cancel" : "↑/↓ select · a add · ↵/e edit · d delete · esc close"
+      when .env?             then env_overlay_hints
+      when .hotkeys?         then @hotkeys_overlay.capturing? ? "press a key to bind · esc cancel" : "↑/↓ select · e/␣ rebind · x unbind · r reset · ⇧R reset all · ←/→ profile · ↵ save · esc"
+      when .detail?          then history_controller.body_hint(:body)
       else
         # Focus on the far-right ⋯ "more" affordance: ↵/↓ expands the hidden-tabs list.
         return "↵/↓ show hidden tabs · ← back · ^P cmds · q projects" if @focus == :menu && @menu_more
@@ -4034,16 +3828,18 @@ module Gori::Tui
     # Open the notification center (the app.notifications verb + the clickable top-bar
     # badge). Marks everything read, clearing the unread badge.
     def open_notifications : Nil
-      @overlay = OverlayKind::Notifications
-      @notifications_overlay.reset
+      ov = NotificationsOverlay.new(@notifications)
+      # The jump itself lands on the target tab, and focus_tab already clears @overlay —
+      # so the shell's close-on-commit is a no-op after it, not a second dismissal.
+      ov.on_commit = -> {
+        run_goto(ov.selected_note.try(&.goto))
+        true
+      }
+      # Close BEFORE raising the palette: the reverse order would drop @active_overlay on
+      # top of the modal we just opened.
+      ov.on_palette = -> { close_active_overlay; open_palette }
+      open_overlay(ov)
       @notifications.mark_all_read
-    end
-
-    # Run the selected note's "jump to result" target, then close the center.
-    private def open_notification_goto : Nil
-      note = @notifications_overlay.selected_note
-      @overlay = OverlayKind::None
-      run_goto(note.goto) if note
     end
 
     private def run_goto(g : Jobs::Goto?) : Nil
@@ -4662,20 +4458,22 @@ module Gori::Tui
         @toast = "no active checks apply (needs a request with reflectable params, or a CORS response)"
         return
       end
-      @probe_active_overlay = ProbeActiveOverlay.new(detail, est_safe, est_unsafe, repeater_id)
-      @overlay = OverlayKind::ProbeActive
+      ov = ProbeActiveOverlay.new(detail, est_safe, est_unsafe, repeater_id)
+      ov.on_commit = -> { start_probe_active(ov) }
+      open_overlay(ov)
     end
 
     # Confirm the popup: run the probes in the BACKGROUND (mode-independent), persist the chosen
     # notify mode as the next default, and toast the request count. Findings land in the Probe tab
     # via the usual probe_generation poll + event drain. The unsafe-methods opt-in threads through
     # to run_active_now so a deliberately-selected POST/PUT/… flow is actually re-sent.
-    private def start_probe_active(ov : ProbeActiveOverlay) : Nil
+    # Returns whether the popup should close (the Overlay seam's commit contract).
+    private def start_probe_active(ov : ProbeActiveOverlay) : Bool
       # Selected options send nothing (e.g. a POST with the unsafe opt-in still off) — hint, don't
       # fire a no-op scan or close the popup.
       if ov.estimate_empty?
         @toast = "nothing to send — enable unsafe methods to probe this #{ov.detail.row.method}"
-        return
+        return false
       end
       notify = ov.notify_mode
       Settings.save_probe_active_notify(notify.token)
@@ -4684,12 +4482,7 @@ module Gori::Tui
         allow_unsafe: ov.allow_unsafe?, notify: notify)
       unsafe_note = ov.allow_unsafe? ? " (incl. unsafe methods)" : ""
       @toast = "active scan → #{host}: #{ov.total_label} sent#{unsafe_note} (see the Probe tab)"
-      close_probe_active
-    end
-
-    private def close_probe_active : Nil
-      @overlay = OverlayKind::None
-      @probe_active_overlay = nil
+      true
     end
 
     # Host-facade alias so a TabController (the Project settings pane's lens row + click) flips
@@ -4738,7 +4531,9 @@ module Gori::Tui
     private def offer_flow_headers(id : Int64, request_head : Bytes) : Nil
       hdrs = Discover::Headers.from_flow(request_head)
       return if hdrs.empty?
-      ov = @discover_config_overlay
+      # The popup open_discover_config just raised — the confirm below leaves @active_overlay
+      # alone and `return_to:` restores @overlay, so it is live again when the closure runs.
+      ov = active_overlay.as?(DiscoverConfigOverlay)
       names = hdrs.first(3).map { |n, _| n }.join(", ")
       names += ", …" if hdrs.size > 3
       confirm("Use this flow's headers?",
@@ -4849,67 +4644,67 @@ module Gori::Tui
         @toast = "cannot discover from here"
         return
       end
-      @discover_config_overlay = DiscoverConfigOverlay.new(seed)
-      @overlay = OverlayKind::DiscoverConfig
+      ov = DiscoverConfigOverlay.new(seed)
+      ov.on_commit = -> { start_discover(ov) }
+      ov.on_edit_headers = -> { open_discover_headers(ov) }
+      open_overlay(ov)
     end
 
     # Confirm the popup: launch the BACKGROUND run and switch to the Discover sub-tab so
     # its live results are visible (we're already under the Target tab if launched here).
-    private def start_discover(ov : DiscoverConfigOverlay) : Nil
+    # Returns whether the popup should close (the Overlay seam's commit contract).
+    private def start_discover(ov : DiscoverConfigOverlay) : Bool
       unless ov.valid?
         @toast = "enable spider or bruteforce"
-        return
+        return false
       end
       ov.save_prefs
       discover_controller.start_session(ov.selected_target, ov.build_config)
-      close_discover_config
       switch_tab(:target)
       target_controller.select_discover
       @focus = :body
-    end
-
-    private def close_discover_config : Nil
-      @overlay = OverlayKind::None
-      @discover_config_overlay = nil
+      true
     end
 
     # --- Discover custom-headers editor (opened from the config popup's headers row) ---
-    private def open_discover_headers(ov : DiscoverConfigOverlay) : Nil
-      @discover_headers_overlay = DiscoverHeadersOverlay.new(ov.headers)
-      @overlay = OverlayKind::DiscoverHeaders
-    end
-
-    # esc / click-away: parse the edited lines back onto the config popup and reopen it.
-    private def commit_discover_headers : Nil
-      if (hov = @discover_headers_overlay) && (ov = @discover_config_overlay)
-        ov.set_headers(hov.headers)
-      end
-      @discover_headers_overlay = nil
-      @overlay = OverlayKind::DiscoverConfig
-    end
-
-    private def handle_discover_headers_key(ev : Termisu::Event::Key) : Nil
-      ov = @discover_headers_overlay || return
-      commit_discover_headers if ov.handle_key(ev) == :commit
+    # A sub-editor: esc / click-away parses the edited lines back onto the config popup and
+    # RETURNS to it. The closure restores the parent itself and reports false so the shell's
+    # close-on-commit doesn't immediately drop the popup we just put back.
+    private def open_discover_headers(cfg : DiscoverConfigOverlay) : Nil
+      hov = DiscoverHeadersOverlay.new(cfg.headers)
+      hov.on_commit = -> {
+        cfg.set_headers(hov.headers)
+        open_overlay(cfg)
+        false
+      }
+      open_overlay(hov)
     end
 
     # Host: open the Fuzzer payload-set editor (nil = add, else edit that index) and
     # the advanced-settings editor, each built from the current fuzz session.
     def open_fuzz_set_editor(edit_index : Int32?) : Nil
       return unless v = fuzzer_controller.current_view
-      @fuzz_set_overlay =
+      ov =
         if (i = edit_index) && (spec = v.set_specs[i]?)
           FuzzSetOverlay.editing(spec, i)
         else
           FuzzSetOverlay.for_list
         end
-      @overlay = OverlayKind::FuzzSet
+      ov.on_commit = -> {
+        fuzzer_controller.apply_fuzz_set(ov.edit_index, ov.build_spec)
+        true
+      }
+      open_overlay(ov)
     end
 
     def open_fuzz_advanced_editor : Nil
       return unless v = fuzzer_controller.current_view
-      @fuzz_advanced_overlay = FuzzAdvancedOverlay.new(v.advanced_snapshot)
-      @overlay = OverlayKind::FuzzAdvanced
+      ov = FuzzAdvancedOverlay.new(v.advanced_snapshot)
+      ov.on_commit = -> {
+        fuzzer_controller.apply_fuzz_advanced(ov.snapshot)
+        true
+      }
+      open_overlay(ov)
     end
 
     # Host: open the Project SCOPE rule popup (nil edit_id = add a new rule). The apply is


### PR DESCRIPTION
Phase 1 batch **C1** of the overlay-seam migration: the six scan/fuzz config modals move
off the Runner's hand-ordered `case @overlay` ladders onto the polymorphic `Overlay` base.

`notifications`, `probe_active`, `discover_config`, `discover_headers`, `fuzz_set`,
`fuzz_advanced` — each is now an `Overlay` subclass supplying `key`/`title`/`hint`/`render`/
`handle_key` (plus `handle_click`/`move`/`set_preedit` where it had them), and each is deleted
from all seven ladders: IME preedit, key, `MODAL_OVERLAYS`, click, wheel/move, render,
focus-badge title, bottom-row hint. Six `@*_overlay` ivars are gone; the shell holds them in
`@active_overlay`.

`runner.cr` 5,570 → 5,368 lines; `handle_*_key` 39 → 33.

### Domain coupling is injected at the open-site

Every action that belongs to the shell rather than the form is a closure set where the modal
opens, mirroring `ConfirmDialog`:

| Modal | Injected as | Notes |
|---|---|---|
| notifications | `on_commit` (jump to note), `on_palette` (^P hop) | `c` clears the store the overlay already holds, so it stays a plain key case |
| probe_active | `on_commit` → `start_probe_active` | now returns `Bool`; `false` when the selected options would send nothing, so the popup stays up |
| discover_config | `on_commit` → `start_discover`, `on_edit_headers` | `start_discover` returns `Bool`; `false` on the invalid (no spider/bruteforce) path |
| discover_headers | `on_commit` → write back + re-open the parent | see below |
| fuzz_set / fuzz_advanced | `on_commit` → `apply_fuzz_*` | no cancel path: esc, ↵-on-last-field and click-away all apply |

### The `discover_config → discover_headers` nesting

This is trap #1 from the review comment on #355: `close_active_overlay` runs *after* `ov.commit`
and unconditionally clears `@overlay`, so a commit closure that opens another modal gets
clobbered. The headers sub-editor takes the documented workaround — its closure re-opens the
parent itself and returns `false`, so the shell's close-on-commit leaves the restored popup in
place:

```crystal
hov.on_commit = -> {
  cfg.set_headers(hov.headers)
  open_overlay(cfg)
  false
}
```

C5's `property on_close : Proc(Nil)?` is the tree's agreed nesting mechanism and lands after this
batch; folding this call-site onto it is a clean follow-up. This PR does not touch `overlay.cr`.

`^P` out of the notification center has the same ordering hazard in reverse, so its closure
closes first and raises the palette second.

### Click-away semantics are preserved per modal, including the box-nil path

The old ladder was not uniform and the base class's default is `:cancel`, so three of the six
override it. Each was checked against its old `click_*` helper and is now pinned by a spec that
forces the `overlay_box → nil` path with an explicit small `area:` (unreachable through
`OverlayHarness::DEFAULT_AREA`, which is the whole screen):

| Modal | click-away / window-too-small |
|---|---|
| notifications, probe_active, discover_config | dismiss (`:cancel`) |
| discover_headers, fuzz_set, fuzz_advanced | apply (`:commit`) |

### Pre-existing bug found, deliberately NOT fixed

`FuzzAdvancedOverlay#handle_key` discards its `case` value and always returns `:stay`, so
`handle_text`'s commit-on-the-last-row has never reached the shell — ↵ on *Filter regex* is a
no-op, not an apply. The early `return` is still load-bearing as a bounds guard (`@sel` would
otherwise index past `ROWS`). Fixing it is a behaviour change, so this PR documents it at both
sites and pins the *current* behaviour in a spec; it belongs in its own patch. The rendered hint
only promises "esc applies", so nothing advertised is broken.

### `/code-review` findings, all fixed

A correctness pass found no behavioural divergence (it independently re-derived the
`start_discover` ordering analysis and the `offer_flow_headers` capture argument). A test-quality
pass found four specs of mine that passed **vacuously**; each fix was control-run against the
exact mutation that used to survive:

| Spec | Mutation that used to pass | Now |
|---|---|---|
| `fuzz_advanced` click | `ri = @scroll + i` → `ri = i` | fails — `@scroll` only advances inside `render`, so the click example now renders, scrolls, and clicks the scrolled row |
| `notifications` layout.body click | delete `set_selected(idx)` | fails — the example clicked row 0, which is already the default selection |
| `discover_headers` "wheel does nothing" | add a `move` override that scrolls the editor | fails — `headers` re-parses the buffer so it is caret-independent; now compares the whole drawn frame, glyphs and background |
| `discover_headers` / `fuzz_set` / `probe_active` layout.body | hit-test against a hard-coded screen rect | fails — those examples only drove keys, which never see `area`; they now click |

Also replaced the shared gate spec's `unmigrated.size.should eq(28)` literal with derived set
equality (`unmigrated.to_set.should eq(MODAL_OVERLAYS.to_set)`), per the coordination note on
#355. The literal was a same-line conflict for all five batches whose correct value depends on
two independent moving parts; set equality needs no number, leaves each batch appending only to
`migrated`, and is strictly stronger — control-run against an accidental EXTRA member in
`MODAL_OVERLAYS`, which the old count-plus-`includes?` pair could not see.

### Verification

- `just test` → 3966 examples, 0 failures
- `just check` → clean on every touched file; the two `crystal tool format --check` failures
  (`src/gori/proxy/upstream.cr`, `spec/proxy/tls/tunnel_spec.cr`) are pre-existing Crystal-version
  drift, untouched by this branch. ameba per-file counts are identical to `origin/main`
  (`runner.cr` 42 → 42, each overlay unchanged) — no new findings.
- Live TUI smoke test (tmux, isolated `GORI_HOME`): all six modals opened, showed the right focus
  badge and hint, and committed/cancelled correctly — including the `offer_flow_headers` confirm
  round-trip (`return_to: :discover_config` restoring through the `active_overlay` gate), the
  headers sub-editor returning into the Discover popup, `^P` out of the notification center, a
  real active scan firing and toasting, and a fuzz payload set + advanced toggle persisting.

### Note for the other batches

`crystal tool format` re-aligned the `then` column in four ladders (preedit, click, title, hint)
because the widest `when` arm in each (`.discover_headers?`) was deleted. That makes this diff
touch ~90 ladder lines belonging to other batches' modals. It is forced by the formatter, not a
tidy-up. On conflict: resolve on content (keep both sides' deletions), then re-run
`crystal tool format src/gori/tui/runner.cr`.

The shared `spec/tui/overlay_dispatch_spec.cr` edit is held to the two gate examples, which are a
genuine global invariant every batch must update; they are now merged into one derived example so
the only per-batch edit is appending to `migrated`. All new examples live in the per-modal spec
files, which no sibling batch touches.

Closes #355 for batch C1.
