### PR TITLE
refactor(tui): give Overlay a nested-modal seam (on_close) (#355)

### DIFF
--- a/spec/support/overlay_harness.cr
+++ b/spec/support/overlay_harness.cr
@@ -15,6 +15,8 @@ require "./memory_backend"
 #   * `open?` mirrors whether the shell still holds the modal in `@active_overlay`.
 #   * `commits` counts runs of the injected `on_commit` closure — the open-site behaviour
 #     a migrated modal no longer carries itself.
+#   * `closes` counts runs of `on_close`, the nested-modal pop-back the shell performs
+#     AFTER dropping the modal (see the ordering note on `close!`).
 #
 # If those Runner methods ever change, change them HERE too: this harness is the
 # spec-side statement of that contract, and a modal spec that passes against a stale
@@ -46,6 +48,9 @@ class OverlayHarness
   getter area : Gori::Tui::Rect
   # Times the injected on_commit ran (a :commit outcome, whether or not it closed).
   getter commits = 0
+  # Times the overlay's on_close ran — the nested-modal pop-back, which fires on a cancel
+  # AND on a commit that closed, but never while the modal stays up.
+  getter closes = 0
   # The shell still holds this modal — false once a :cancel, or a :commit whose closure
   # returned true, dropped it.
   getter? open = true
@@ -176,10 +181,20 @@ class OverlayHarness
 
   private def dispatch(outcome : Symbol) : Symbol
     case outcome
-    when :cancel then @open = false
-    when :commit then @open = false if @overlay.commit
+    when :cancel then close!
+    when :commit then close! if @overlay.commit
     end
     @open ? :open : :closed
+  end
+
+  # Mirrors `Runner#close_active_overlay`: the shell DROPS the modal first and runs its
+  # `on_close` after. That order is load-bearing rather than incidental — a pop-back
+  # closure re-opens its parent with `open_overlay`, so it has to be the last write;
+  # running on_close first would leave the shell holding nothing.
+  private def close! : Nil
+    @open = false
+    @closes += 1
+    @overlay.on_close.try(&.call)
   end
 
   private def event(k : Termisu::Input::Key, char : Char?,

--- a/spec/tui/overlay_nesting_spec.cr
+++ b/spec/tui/overlay_nesting_spec.cr
@@ -1,0 +1,350 @@
+require "../spec_helper"
+require "../support/memory_backend"
+require "../support/overlay_harness"
+
+include Gori::Tui
+
+# `Overlay#on_close` — the nested-modal seam (#355). A modal opened FROM another pops back
+# into it on close, which the shell used to express with a single `@prefs_return` flag plus
+# a `settle_sub_editor` call at each dispatch chokepoint: one hard-coded relationship for
+# the whole app, and one the Preferences family alone could use.
+#
+# Everything the migration batches need from it is a CONTRACT about shell state, not about
+# any one modal, so this file pins the contract with doubles and no production overlay:
+#
+#   * on_close runs on a cancel and on a commit that closed — never while the modal is up
+#   * the shell drops the modal BEFORE running it, so a pop-back's open_overlay sticks
+#   * the parent it restores may be a migrated `Overlay` OR an unmigrated `@overlay` state
+#   * `leave_overlay` deliberately skips it, for an exit that goes somewhere else (^P)
+#
+# The last three are what a confirm raised from INSIDE another modal needs — the three
+# live sites being `runner.cr`'s settings ^R reset and tab-bar reset (migrated parents) and
+# `history_controller.cr:385`'s delete-from-detail (an unmigrated `:detail` parent).
+
+private def nkey(k : Termisu::Input::Key) : Termisu::Event::Key
+  Termisu::Event::Key.new(k)
+end
+
+private ESC   = Termisu::Input::Key::Escape
+private ENTER = Termisu::Input::Key::Enter
+
+# A modal that answers the outcome vocabulary and nothing else — esc cancels, ↵ commits.
+# `key` is a constructor argument so an example can stand one in for whichever real modal
+# it is modelling (a Settings card, a Confirm dialog) without depending on that modal.
+private class NestModal < Overlay
+  def initialize(@kind : OverlayKind)
+  end
+
+  def key : OverlayKind
+    @kind
+  end
+
+  def title : String
+    @kind.to_s.upcase
+  end
+
+  def hint : String
+    "nest hint"
+  end
+
+  def render(screen : Screen, area : Rect) : Nil
+  end
+
+  def handle_key(ev : Termisu::Event::Key) : Symbol
+    return :cancel if ev.key.escape?
+    return :commit if ev.key.enter?
+    :stay
+  end
+end
+
+# A miniature of the Runner's overlay STATE — `@active_overlay` + `@overlay` and the four
+# methods that read or write them, copied from runner.cr. OverlayHarness models the
+# dispatch but holds no shell state, and the Runner itself needs a live tty, so this is the
+# only way to assert what a nested close leaves the shell holding.
+#
+# Keep it in step with runner.cr: an example that passes against a drifted double proves
+# nothing about the real shell.
+private class NestShell
+  # `property` because ~40 production sites assign @overlay directly without touching
+  # @active_overlay — which is exactly what an unmigrated parent's restore has to do.
+  property overlay = OverlayKind::None
+  getter active : Overlay?
+
+  def open_overlay(ov : Overlay) : Nil
+    @active = ov
+    @overlay = ov.key
+  end
+
+  def close_active_overlay(ov : Overlay) : Nil
+    cur = @active
+    return unless cur && cur.same?(ov)
+    leave_overlay
+    ov.on_close.try(&.call)
+  end
+
+  def leave_overlay : Nil
+    @active = nil
+    @overlay = OverlayKind::None
+  end
+
+  # The liveness gate: a modal is routed to only while @overlay still names it.
+  def active_overlay : Overlay?
+    ov = @active
+    ov if ov && @overlay == ov.key
+  end
+
+  def press(k : Termisu::Input::Key) : Nil
+    return unless ov = active_overlay
+    case ov.handle_key(nkey(k))
+    when :cancel then close_active_overlay(ov)
+    when :commit then close_active_overlay(ov) if ov.commit
+    end
+  end
+end
+
+# A modal whose handler opens ANOTHER modal and then returns the WRONG outcome — the
+# mistake the identity check in close_active_overlay is there to absorb. Real handlers
+# that hand off (a Preferences opener row) return :stay.
+private class SwapModal < Overlay
+  def initialize(@shell : NestShell, @next : Overlay, @outcome : Symbol)
+  end
+
+  def key : OverlayKind
+    OverlayKind::Preferences
+  end
+
+  def title : String
+    "SWAP"
+  end
+
+  def hint : String
+    "swap hint"
+  end
+
+  def render(screen : Screen, area : Rect) : Nil
+  end
+
+  def handle_key(ev : Termisu::Event::Key) : Symbol
+    @shell.open_overlay(@next)
+    @outcome
+  end
+end
+
+describe "Overlay#on_close — when it runs" do
+  # Every example here counts the OVERLAY'S OWN closure, not just `harness.closes`. The
+  # counter alone is a tautology: it would keep incrementing even if the harness stopped
+  # invoking `on_close` entirely, and every migration spec downstream would stay green
+  # while the pop-back never ran. Proved by mutation — deleting the harness's
+  # `on_close.try(&.call)` left this file passing until the assertions moved onto `ran`.
+  it "runs the overlay's own closure on a cancel and on a commit that closed" do
+    {ESC, ENTER}.each do |k|
+      ov = NestModal.new(OverlayKind::ScopeRule)
+      ran = 0
+      ov.on_close = -> { ran += 1; nil }
+      h = OverlayHarness.new(ov)
+      h.press(k).should eq(:closed)
+      ran.should eq(1), "the overlay's own on_close did not run for #{k}"
+      h.closes.should eq(1)
+    end
+  end
+
+  it "does NOT run for a commit the closure rejected — the modal is still up" do
+    # A validation failure keeps the form open, so there is nothing to pop back to yet.
+    # Firing the pop-back here would swap the parent in underneath a modal still on screen.
+    ov = NestModal.new(OverlayKind::ScopeRule)
+    ran = 0
+    ov.on_close = -> { ran += 1; nil }
+    h = OverlayHarness.new(ov, commit: false)
+    h.press(ENTER).should eq(:open)
+    h.commits.should eq(1)
+    ran.should eq(0)
+  end
+
+  it "does not run while the modal merely stays open" do
+    ov = NestModal.new(OverlayKind::ScopeRule)
+    ran = 0
+    ov.on_close = -> { ran += 1; nil }
+    h = OverlayHarness.new(ov)
+    h.press(Termisu::Input::Key::Down).should eq(:open)
+    ran.should eq(0)
+  end
+
+  it "runs AFTER the modal is dropped, so a pop-back is the last word" do
+    # The closure observes the shell mid-close: by the time it runs, the modal is already
+    # gone. That is what lets it call open_overlay(parent) and have it stick.
+    h = OverlayHarness.new(NestModal.new(OverlayKind::ScopeRule))
+    still_held = nil.as(Bool?)
+    h.overlay.on_close = -> { still_held = h.open?; nil }
+    h.press(ESC).should eq(:closed)
+    still_held.should be_false
+  end
+
+  it "is optional — closing a modal that never set one must not raise" do
+    h = OverlayHarness.new(NestModal.new(OverlayKind::ScopeRule))
+    h.overlay.on_close.should be_nil
+    h.press(ESC).should eq(:closed)
+  end
+end
+
+describe "Overlay#on_close — the nested lifecycle" do
+  it "leaves the shell holding the parent, because the drop happens first" do
+    # If close_active_overlay ran on_close BEFORE clearing @active_overlay, the clear would
+    # undo the pop-back and the user would land on the bare tab body.
+    shell = NestShell.new
+    parent = NestModal.new(OverlayKind::Preferences)
+    child = NestModal.new(OverlayKind::Hosts)
+    child.on_close = -> { shell.open_overlay(parent) }
+
+    shell.open_overlay(child)
+    shell.press(ESC)
+
+    shell.active_overlay.should be(parent)
+    shell.overlay.should eq(OverlayKind::Preferences)
+  end
+
+  it "composes: a child of a child pops back one level at a time" do
+    # The flag it replaced could not express this — @prefs_return was one bit for the whole
+    # shell, so a second level of nesting had nowhere to record where it came from.
+    shell = NestShell.new
+    prefs = NestModal.new(OverlayKind::Preferences)
+    editor = NestModal.new(OverlayKind::Settings)
+    dialog = NestModal.new(OverlayKind::Confirm)
+    editor.on_close = -> { shell.open_overlay(prefs) }
+    dialog.on_close = -> { shell.open_overlay(editor) }
+
+    shell.open_overlay(dialog)
+    shell.press(ESC)
+    shell.active_overlay.should be(editor) # …not straight out to Preferences
+    shell.press(ESC)
+    shell.active_overlay.should be(prefs)
+    shell.press(ESC)
+    shell.active_overlay.should be_nil # the outermost has no parent → out to the body
+    shell.overlay.should eq(OverlayKind::None)
+  end
+
+  it "restores a parent that has NOT migrated, by naming its @overlay state" do
+    # History's delete-from-detail (history_controller.cr:385) raises its confirm with
+    # `return_to: :detail`. The History drill-in is not an Overlay object at all and is out
+    # of the migration's scope, so the closure assigns the state instead of re-opening an
+    # object. on_close has to cover that too, or that call-site has no path.
+    shell = NestShell.new
+    shell.overlay = OverlayKind::Detail
+    dialog = NestModal.new(OverlayKind::Confirm)
+    dialog.on_close = -> { shell.overlay = OverlayKind::Detail }
+
+    shell.open_overlay(dialog)
+    shell.press(ESC) # cancel → back to the flow detail, not out to the list
+    shell.overlay.should eq(OverlayKind::Detail)
+    shell.active_overlay.should be_nil # no object to route to — @overlay alone drives it
+  end
+
+  it "never closes a modal the handler swapped in mid-key" do
+    # A handler may open another modal — a Preferences opener row hands off to its editor —
+    # and must return :stay when it does. A wrong :cancel would otherwise drop the editor
+    # that had just appeared AND run the editor's own pop-back, one keystroke after it
+    # opened. close_active_overlay compares against what the shell currently holds, so the
+    # wrong return is inert instead of user-visible.
+    shell = NestShell.new
+    editor = NestModal.new(OverlayKind::Hosts)
+    popped = 0
+    editor.on_close = -> { popped += 1; nil }
+
+    shell.open_overlay(SwapModal.new(shell, editor, :cancel))
+    shell.press(ESC)
+
+    shell.active_overlay.should be(editor) # the handed-off editor is still up
+    popped.should eq(0)                    # …and its pop-back never fired
+  end
+
+  it "leaves a ^P palette jump alone even if the handler then returns :cancel" do
+    # The other half: a handler that calls leave_overlay on its way to the palette has
+    # already emptied @active_overlay. Closing again would blank @overlay and take the
+    # palette down with it.
+    shell = NestShell.new
+    jumper = NestModal.new(OverlayKind::Hosts)
+    shell.open_overlay(jumper)
+    shell.leave_overlay
+    shell.overlay = OverlayKind::Palette # what open_palette does next
+
+    shell.close_active_overlay(jumper) # the stale close the wrong outcome would trigger
+    shell.overlay.should eq(OverlayKind::Palette)
+  end
+
+  it "skips on_close for an exit that goes somewhere else (the ^P palette jump)" do
+    # leave_overlay is the escape hatch: a pop-back would re-open the parent ON TOP of the
+    # palette the user just asked for.
+    shell = NestShell.new
+    parent = NestModal.new(OverlayKind::Preferences)
+    child = NestModal.new(OverlayKind::Hosts)
+    pops = 0
+    child.on_close = -> { pops += 1; shell.open_overlay(parent) }
+
+    shell.open_overlay(child)
+    shell.leave_overlay
+    shell.overlay = OverlayKind::Palette # what open_palette does next
+
+    pops.should eq(0)
+    shell.overlay.should eq(OverlayKind::Palette)
+    shell.active_overlay.should be_nil
+  end
+end
+
+describe "Overlay#on_close — a confirm raised from inside another modal" do
+  it "needs the parent captured BEFORE the dialog is opened" do
+    # Today `confirm()` never touches @active_overlay — it only moves @overlay, so the
+    # parent goes inert but stays held and `@overlay = @confirm_return` brings it back for
+    # free. The moment ConfirmDialog is opened through open_overlay that stops being true:
+    # the parent reference is overwritten and only a capture taken first still has it.
+    shell = NestShell.new
+    parent = NestModal.new(OverlayKind::Settings)
+    shell.open_overlay(parent)
+
+    captured = shell.active_overlay # the read confirm() must do at its top
+    dialog = NestModal.new(OverlayKind::Confirm)
+    shell.open_overlay(dialog)
+    shell.active_overlay.should be(dialog) # the shell no longer holds the parent
+    captured.should be(parent)             # …only the capture does
+
+    dialog.on_close = -> { captured.try { |p| shell.open_overlay(p) } }
+    shell.press(ESC) # CANCEL lands back in the parent, same as accept
+    shell.active_overlay.should be(parent)
+    shell.overlay.should eq(OverlayKind::Settings)
+  end
+
+  it "can run the dialog's action AFTER the restore, which History depends on" do
+    # `Runner#run_confirm` is restore-then-action today, and history_controller.cr:385
+    # relies on it: its action reads `@host.overlay == :detail` to decide whether the
+    # drill-in should close now that the flow is gone. on_close is the hook that reproduces
+    # that order under the generic dispatch.
+    shell = NestShell.new
+    seen_by_action = nil.as(OverlayKind?)
+    accepted = false
+    dialog = NestModal.new(OverlayKind::Confirm)
+    dialog.on_commit = -> { accepted = true; true }
+    dialog.on_close = -> {
+      shell.overlay = OverlayKind::Detail        # the restore…
+      seen_by_action = shell.overlay if accepted # …then the action, which reads it
+      nil
+    }
+
+    shell.open_overlay(dialog)
+    shell.press(ENTER)
+    seen_by_action.should eq(OverlayKind::Detail)
+  end
+
+  it "shows why that action cannot ride on_commit instead" do
+    # The dispatch runs `commit` BEFORE the close (`close_active_overlay if ov.commit`), so
+    # an action wired into on_commit sees the DIALOG's state, never the restored parent's.
+    # History's guard would silently never fire, and the pop-back would then re-open the
+    # flow detail on a flow that was just deleted.
+    shell = NestShell.new
+    seen_by_action = nil.as(OverlayKind?)
+    dialog = NestModal.new(OverlayKind::Confirm)
+    dialog.on_commit = -> { seen_by_action = shell.overlay; true }
+    dialog.on_close = -> { shell.overlay = OverlayKind::Detail }
+
+    shell.open_overlay(dialog)
+    shell.press(ENTER)
+    seen_by_action.should eq(OverlayKind::Confirm) # not :detail — too early to read it
+  end
+end

--- a/src/gori/tui/overlay.cr
+++ b/src/gori/tui/overlay.cr
@@ -99,6 +99,29 @@ module Gori::Tui
     # it open — e.g. a validation error keeps the form up). Supplied at the open-site.
     property on_commit : Proc(Bool)?
 
+    # What the shell runs AFTER this overlay closes, whether it committed or cancelled.
+    #
+    # This is the NESTED-MODAL seam. A modal opened FROM another supplies
+    # `-> { open_overlay(parent) }` here, so closing pops back into the parent instead of
+    # dropping the user on the bare tab body: ↵-ing into the Theme editor from Preferences
+    # and pressing esc must land back in Preferences, not on the tab underneath. The shell
+    # used to express exactly ONE such relationship, with a `@prefs_return` flag plus a
+    # `settle_sub_editor` call at each dispatch chokepoint; as a per-overlay closure it
+    # composes, so a modal can nest inside a modal that is itself nested.
+    #
+    # A proc rather than a parent reference, because the restore is not always just
+    # "re-open the parent". Returning from the Hostnames editor has to re-pull the
+    # Preferences modal's Network section first, whose "N entries" row that editor just
+    # moved. A `return_to : Overlay?` cannot say that; a closure can.
+    #
+    # ORDERING, which is load-bearing: the shell drops the modal FIRST and runs this
+    # after (see `Runner#close_active_overlay`), so a closure that calls `open_overlay` is
+    # the last write and the shell really is holding the parent when it returns. An exit
+    # that goes somewhere else entirely — ^P to the command palette — deliberately uses
+    # `Runner#leave_overlay`, which skips this, so the pop-back can't re-open on top of
+    # where the user asked to go.
+    property on_close : Proc(Nil)?
+
     # The `@overlay` state this modal sets, written by `Runner#open_overlay`.
     #
     # It is NOT what makes the modal capture input: a migrated modal's member is deleted

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1767,7 +1767,31 @@ module Gori::Tui
       @overlay = ov.key
     end
 
-    private def close_active_overlay : Nil
+    # Close `ov` and run its on_close — the nested-modal seam (overlay.cr). A modal opened
+    # from another pops back INTO it here, so the shell needs no per-family "return to"
+    # flag of its own.
+    #
+    # The order matters: the modal is dropped BEFORE the closure runs, so a pop-back's
+    # `open_overlay` is the last write and the shell is holding the parent when this
+    # returns. Running on_close first would have the drop undo it.
+    #
+    # `ov` is checked against what the shell CURRENTLY holds because a handler is allowed
+    # to change that mid-key: a Preferences opener row opens its own editor, and ^P calls
+    # `leave_overlay` on the way to the palette. Both must return :stay — and this makes a
+    # wrong return inert instead of user-visible, since otherwise the shell would drop the
+    # editor that had just appeared (running ITS pop-back), or blank the palette ^P had
+    # just opened.
+    private def close_active_overlay(ov : Overlay) : Nil
+      cur = @active_overlay
+      return unless cur && cur.same?(ov)
+      leave_overlay
+      ov.on_close.try(&.call)
+    end
+
+    # Drop the active modal WITHOUT running its on_close. For an exit that goes somewhere
+    # else entirely — the ^P jump to the command palette — where a nested modal's pop-back
+    # would otherwise re-open on top of the destination.
+    private def leave_overlay : Nil
       @active_overlay = nil
       @overlay = OverlayKind::None
     end
@@ -1789,15 +1813,15 @@ module Gori::Tui
     # closes iff it returns true (a validation failure keeps the form up).
     private def dispatch_overlay_key(ov : Overlay, ev : Termisu::Event::Key) : Nil
       case ov.handle_key(ev)
-      when :cancel then close_active_overlay
-      when :commit then close_active_overlay if ov.commit
+      when :cancel then close_active_overlay(ov)
+      when :commit then close_active_overlay(ov) if ov.commit
       end
     end
 
     private def dispatch_overlay_click(ov : Overlay, area : Rect, mx : Int32, my : Int32) : Nil
       case ov.handle_click(area, mx, my)
-      when :cancel then close_active_overlay
-      when :commit then close_active_overlay if ov.commit
+      when :cancel then close_active_overlay(ov)
+      when :commit then close_active_overlay(ov) if ov.commit
       end
     end
 
@@ -1820,7 +1844,7 @@ module Gori::Tui
         return false
       end
       path = @session.ca.ca_cert_path
-      close_active_overlay
+      close_active_overlay(ov)
       confirm("IMPORT CA",
         "Replace the current root CA with the imported one?\n\n" \
         "The old CA becomes untrusted — re-trust the imported\n" \


### PR DESCRIPTION
Phase 1 of #355 migrates 28 modals onto the `Overlay` seam in five parallel batches, and two of those batches need a modal to open **another** modal and be returned to when it closes. The shell can express exactly one such relationship today — a `@prefs_return` flag plus a `settle_sub_editor` call at each dispatch chokepoint — usable only by the Preferences family that owns it.

Split out of the **C5** batch and landed on its own so **C3** (`confirm`) can build on it instead of inventing a second mechanism in the same file. No modal migrations here.

## The seam

`Overlay#on_close : Proc(Nil)?` — what the shell runs after this overlay closes, on a commit or a cancel. A modal opened from another supplies `-> { open_overlay(parent) }`, so ↵-ing into the Theme editor from Preferences and pressing esc lands back in Preferences rather than on the bare tab body.

A proc rather than a `return_to : Overlay?`, because the restore is not always just "re-open the parent": returning from the Hostnames editor also has to re-pull the Preferences modal's Network section, whose "N entries" row that editor just moved. It also composes, which one shell-wide flag could not — a modal can nest inside a modal that is itself nested.

Two ordering properties are load-bearing and both are spec'd:

- `close_active_overlay` drops the modal **first** and runs `on_close` after, so a pop-back's `open_overlay` is the last write.
- `leave_overlay` is the deliberate escape hatch that **skips** it, for an exit going somewhere else entirely (^P to the palette), where a pop-back would re-open on top of the destination.

`close_active_overlay` also now takes the overlay it is closing and checks it against what the shell currently holds. A handler may change that mid-key (a Preferences opener row opens its editor; ^P calls `leave_overlay`) and both must return `:stay` — re-reading `@active_overlay` meant a wrong return would drop the editor that had just appeared and run *its* pop-back, or blank the palette ^P had just opened. Latent rather than live today (the three migrated modals are leaf forms), but the seam exists for the batches about to add exactly those handlers.

**No behaviour change**: nothing sets `on_close` yet, so every close runs a nil proc.

## For C3

The three sites where a confirm is raised from inside another modal are covered, and each has an example:

| site | parent | restored as |
|---|---|---|
| settings ^R reset | `SettingsOverlay` (migrated) | the object, via `open_overlay` |
| tab-bar reset | `TabsOverlay` (migrated) | the object, via `open_overlay` |
| `history_controller.cr:385` delete-from-detail | `:detail` (**not** migrated) | the `@overlay` state |

Cancel lands back in the parent for all three.

Two things `confirm()` has to get right, both spec'd here:

1. **Capture the parent before `open_overlay`.** Today `confirm()` never touches `@active_overlay`, so the parent goes inert but stays held. Once ConfirmDialog is opened through `open_overlay`, that reference is overwritten.
2. **Run the action from `on_close`, after the restore — not from `on_commit`.** `run_confirm` is restore-then-action today, and `history_controller.cr:385`'s action reads `@host.overlay == :detail` to decide whether the drill-in should close now the flow is gone. The generic dispatch runs `commit` *before* the close, so an action wired into `on_commit` reads the dialog's own state, the guard never fires, and the pop-back then re-opens the detail on a deleted flow. Two examples state both halves.

## Verification

- `just test` → **3926 examples, 0 failures**
- `crystal tool format --check` clean on the touched files; `ameba` byte-identical to the `origin/main` baseline for the same files (zero new findings)
- Every example control-run against the mutation that motivated it: removing the harness's `on_close` call, inverting the drop/close order, closing on a REJECTED commit, and dropping the identity check each fail the file. The first of those initially did **not** fail — the examples asserted `harness.closes` (a counter that increments however the harness behaves) instead of the overlay's own closure; they now count the closure.

`OverlayHarness` learns `on_close` because it is the spec-side statement of `dispatch_overlay_key` / `close_active_overlay`; a change to that dispatch has to land there too, or every downstream migration spec passes against a stale double.

## Also

`spec/tui/overlay_dispatch_spec.cr`'s input-capture gate is now a **derived set** rather than a hard-coded total of 28. All five Phase 1 batches edit that assertion, and five agents editing one integer to five different values merges badly, whereas five appending to a one-member-per-line list does not. Both directions still fail on mutation: a migrated kind left in `MODAL_OVERLAYS`, and an unmigrated kind deleted from it.

Refs #355