### PR TITLE
refactor(discover): one Plan builder for TUI/CLI/MCP run assembly (#356) + TUI host overrides (#367)

### DIFF
--- a/spec/discover/plan_spec.cr
+++ b/spec/discover/plan_spec.cr
@@ -1,0 +1,403 @@
+require "../spec_helper"
+require "socket"
+
+private alias D = Gori::Discover
+
+private def with_store(&)
+  path = File.tempname("gori-discover-plan", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def with_wordlist(names : Array(String), &)
+  path = File.tempname("gori-discover-words", ".txt")
+  File.write(path, names.join('\n'))
+  begin
+    yield path
+  ensure
+    File.delete?(path)
+  end
+end
+
+# What the builder DERIVES, flattened so two plans compare with a single `should eq`. The
+# Config knobs are deliberately absent: all three arms are handed the same Config instance,
+# so reading `max_depth`/`containment`/… back off it would compare that object with itself
+# and could never fail. Only these four are computed by `Plan.build`. `policy` is the CLASS
+# NAME rather than the object — UnscopedStoreScope is a StoreScope subclass, so comparing
+# instances would let the include-boundary waiver slip through unnoticed.
+private record Shape,
+  seed : String,
+  host : String,
+  word_count : Int32,
+  policy : String
+
+private def shape_of(options : D::PlanOptions) : Shape
+  plan = D::Plan.build(options, ungated_outbound)
+  Shape.new(seed: plan.seed, host: plan.host, word_count: plan.word_count,
+    policy: plan.policy.class.name)
+end
+
+# The one run every surface is asked to assemble, expressed as the Config each of them
+# builds. Identical by construction — what differs between the arms is the SEED STRING and
+# nothing else, which is the whole remaining surface-specific job after the refactor.
+private def run_config(wordlist : String) : D::Config
+  D::Config.new(concurrency: 5, max_requests: 100_i64, spider: true, bruteforce: true,
+    max_depth: 2, user_wordlist: wordlist, extensions: ["php"],
+    containment: D::Containment::SameOrigin)
+end
+
+# A one-request run against a local listener: spider only, depth 0, `max_requests: 1` so the
+# derived robots.txt / sitemap.xml probes are refused by CappedBackend without touching the
+# network. Exactly one GET reaches the origin, so the head it records is unambiguous.
+private def one_shot_config(headers : Array({String, String}) = [] of {String, String}) : D::Config
+  D::Config.new(concurrency: 1, retries: 0, max_requests: 1_i64, spider: true,
+    bruteforce: false, max_depth: 0, timeout: 3.seconds, headers: headers)
+end
+
+# Room for the seed plus its two derived well-known probes plus ONE crawled link, so a
+# depth-1 hop is observable. Used by the policy A/B, which asserts on that hop.
+private def crawl_config : D::Config
+  D::Config.new(concurrency: 1, retries: 0, max_requests: 6_i64, spider: true,
+    bruteforce: false, max_depth: 1, timeout: 3.seconds)
+end
+
+# Run one plan against a throwaway origin. Yields the listener's port so the caller can
+# build a seed pointing at it; returns the findings plus every request head the origin saw.
+#
+# Driving the ENGINE (rather than reading `Plan`'s getters back) is what makes these tests
+# worth having: the getters and the engine are populated from the same locals, so asserting
+# `plan.seed` / `plan.policy` alone cannot tell a plan that hands the crawl the right values
+# from one that reports them and passes the engine something else.
+private def run_one(outbound = ungated_outbound, body = "hi",
+                    &build : Int32 -> D::PlanOptions) : {Array(D::Finding), Array(String)}
+  server = TCPServer.new("127.0.0.1", 0)
+  port = server.local_address.port
+  seen = [] of String
+  spawn(name: "discover-plan-spec-origin") do
+    while conn = server.accept?
+      head = Gori::Proxy::Codec::Http1.read_head(conn)
+      seen << (head ? String.new(head) : "")
+      conn << "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: #{body.bytesize}\r\n" \
+              "Connection: close\r\n\r\n#{body}"
+      conn.flush
+      conn.close
+    end
+  end
+  begin
+    plan = D::Plan.build(build.call(port), outbound)
+    findings = [] of D::Finding
+    plan.engine.run { |ev| findings << ev.finding if ev.is_a?(D::FindingEvent) }
+    {findings, seen}
+  ensure
+    server.close
+  end
+end
+
+describe Gori::Discover::Plan do
+  describe "cross-surface equivalence" do
+    it "assembles the same run from each surface's seed spelling" do
+      Gori::Settings.env_vars = [{"SEED", "https://acme.test"}]
+      with_wordlist(["zz-plan-spec-a", "zz-plan-spec-b"]) do |wl|
+        config = run_config(wl)
+        # `gori run discover --target acme.test/api` — a bare host, no scheme.
+        cli = shape_of(D::PlanOptions.new("acme.test/api", config: config))
+        # MCP `{"url": "$SEED/api"}` — an env token the agent never resolved itself.
+        mcp = shape_of(D::PlanOptions.new("$SEED/api", config: config))
+        # The TUI, seeded from a Sitemap row that already carries a full URL.
+        tui = shape_of(D::PlanOptions.new("https://acme.test/api", config: config))
+
+        cli.should eq(mcp)
+        cli.should eq(tui)
+        # Pinned literally, so the three arms agree on a stated answer and not just on
+        # each other: scheme defaulted, env token expanded, both applied exactly once.
+        cli.seed.should eq("https://acme.test/api")
+        cli.host.should eq("acme.test")
+      end
+    ensure
+      Gori::Settings.env_vars = [] of {String, String}
+    end
+
+    it "normalizes the seed the scope gate matches on" do
+      # Every surface gates with `outbound.check(plan.seed, plan.host)`, so the spelling of
+      # this string decides whether a `string`/`regex` rule matches. Left un-normalized, an
+      # exclude anchored on `^https://prod\.acme\.test` missed `PROD.acme.test` and
+      # `prod.acme.test:443`, and an include anchored on `^https://acme\.test/` missed a seed
+      # given as a bare host. Both were live before this builder existed.
+      shape_of(D::PlanOptions.new("https://PROD.Acme.Test:443/api")).seed.should eq("https://prod.acme.test/api")
+      shape_of(D::PlanOptions.new("acme.test")).seed.should eq("https://acme.test/")
+      shape_of(D::PlanOptions.new("http://acme.test:8080/a?b=1")).seed.should eq("http://acme.test:8080/a?b=1")
+    end
+
+    it "blocks an out-of-scope seed whose spelling differs from the rule's" do
+      # The above, proven through the real gate rather than through string equality.
+      with_store do |store|
+        scope = Gori::Scope.load(store)
+        scope.add("include", "host", "acme.test")
+        scope.add("exclude", "regex", "^https://prod\\.acme\\.test")
+        ob = Gori::Outbound.agent(scope, false)
+        plan = D::Plan.build(D::PlanOptions.new("https://PROD.acme.test:443/"), ob)
+        ob.check(plan.seed, plan.host).blocked?.should be_true
+      end
+    end
+
+    it "reads the user wordlist from config.user_wordlist on every surface" do
+      # `--wordlist` and MCP's `wordlist` arg used to bypass the Config and be handed to
+      # Wordlist.load separately, leaving config.user_wordlist nil on two surfaces out of
+      # three. One field now, so the count moves for all of them or none.
+      with_wordlist(["zz-plan-spec-a", "zz-plan-spec-b"]) do |wl|
+        with_list = shape_of(D::PlanOptions.new("https://acme.test/", config: run_config(wl)))
+        without = shape_of(D::PlanOptions.new("https://acme.test/",
+          config: D::Config.new(concurrency: 5, max_requests: 100_i64, spider: true,
+            bruteforce: true, max_depth: 2, extensions: ["php"],
+            containment: D::Containment::SameOrigin)))
+        with_list.word_count.should eq(without.word_count + 2)
+      end
+    end
+  end
+
+  describe "the crawl-time scope policy is derived from the Outbound" do
+    seed = "https://acme.test/api"
+
+    it "bounds nothing when the project has no scope rules, on every surface" do
+      with_store do |store|
+        scope = Gori::Scope.load(store)
+        [Gori::Outbound.agent(scope, false), Gori::Outbound.cli(scope, false),
+         Gori::Outbound.interactive(scope)].each do |ob|
+          D::Plan.build(D::PlanOptions.new(seed), ob).policy.class.should eq(D::OpenScope)
+        end
+      end
+    end
+
+    it "applies the project scope when one is configured and Layer 1 was not waived by the operator" do
+      with_store do |store|
+        scope = Gori::Scope.load(store)
+        scope.add("include", "host", "acme.test")
+        [Gori::Outbound.agent(scope, false), Gori::Outbound.cli(scope, false),
+         Gori::Outbound.interactive(scope)].each do |ob|
+          D::Plan.build(D::PlanOptions.new(seed), ob).policy.class.should eq(D::StoreScope)
+        end
+      end
+    end
+
+    it "keeps the include boundary under an operator waiver when the seed IS in scope" do
+      with_store do |store|
+        scope = Gori::Scope.load(store)
+        scope.add("include", "host", "acme.test")
+        # --allow-unscoped / allow_unscoped:true is redundant here, so it must not widen
+        # the crawl: the seed the operator named is inside the boundary already.
+        [Gori::Outbound.cli(scope, true), Gori::Outbound.agent(scope, true)].each do |ob|
+          D::Plan.build(D::PlanOptions.new(seed), ob).policy.class.should eq(D::StoreScope)
+        end
+      end
+    end
+
+    it "drops the include boundary only for an OPERATOR waiver on an out-of-scope seed" do
+      with_store do |store|
+        scope = Gori::Scope.load(store)
+        scope.add("include", "host", "other.test")
+        [Gori::Outbound.cli(scope, true), Gori::Outbound.agent(scope, true)].each do |ob|
+          policy = D::Plan.build(D::PlanOptions.new(seed), ob).policy
+          policy.class.should eq(D::UnscopedStoreScope)
+          # The behavioural difference, not just the class: scope-aware containment falls
+          # back to same-origin instead of blocking every hop off the seed.
+          policy.configured?.should be_false
+          # The hard gate survives the waiver.
+          policy.allowed?(seed, "acme.test").should be_true
+        end
+
+        # The TUI is ALSO Layer-1 waived — for Reason::Interactive — and that must NOT
+        # widen the crawl: "a human typed this target" is not a request to drop the
+        # include boundary the same human configured.
+        tui = D::Plan.build(D::PlanOptions.new(seed), Gori::Outbound.interactive(scope)).policy
+        tui.class.should eq(D::StoreScope)
+        tui.configured?.should be_true
+        tui.boundary?(seed, "acme.test").should be_false
+      end
+    end
+
+    it "still bounds a sandbox-blocked host under an operator waiver" do
+      with_store do |store|
+        scope = Gori::Scope.load(store)
+        scope.add("include", "host", "other.test")
+        scope.enable_sandbox
+        policy = D::Plan.build(D::PlanOptions.new(seed), Gori::Outbound.cli(scope, true)).policy
+        policy.allowed?(seed, "acme.test").should be_false
+      end
+    end
+
+    # The getters above and the Engine are populated from the same locals, so all five stay
+    # green if `Plan.build` reports the right policy and hands the CRAWL an ungated one.
+    # These two drive the engine instead, as an A/B on one crawled link: same plan, same
+    # harness, only the scope rules differ.
+    #
+    # The assertion is about the LINK, not the seed: the seed plus robots.txt/sitemap.xml
+    # bypass the engine's gate outright (issue #364, deliberately not fixed here), so they go
+    # out under both rule sets. Everything discovered after them is gated normally.
+    linked = %(<html><a href="/deeper">d</a></html>)
+
+    it "hands the derived policy to the engine, not just to the getter" do
+      with_store do |store|
+        scope = Gori::Scope.load(store)
+        scope.add("include", "host", "elsewhere.test")
+        scope.enable_sandbox
+        findings, seen = run_one(Gori::Outbound.interactive(scope), linked) do |port|
+          D::PlanOptions.new("http://127.0.0.1:#{port}/", config: crawl_config, verify: false)
+        end
+        seen.any?(&.includes?("/deeper")).should be_false
+        findings.map(&.url).any?(&.includes?("/deeper")).should be_false
+      end
+    end
+
+    it "crawls that same link once the scope allowlists the host" do
+      with_store do |store|
+        scope = Gori::Scope.load(store)
+        scope.add("include", "host", "127.0.0.1")
+        scope.enable_sandbox
+        findings, seen = run_one(Gori::Outbound.interactive(scope), linked) do |port|
+          D::PlanOptions.new("http://127.0.0.1:#{port}/", config: crawl_config, verify: false)
+        end
+        seen.any?(&.includes?("GET /deeper ")).should be_true
+        findings.map(&.url).any?(&.includes?("/deeper")).should be_true
+      end
+    end
+  end
+
+  describe "the wire" do
+    it "expands $VAR in custom headers without touching the caller's Config" do
+      Gori::Settings.env_vars = [{"TOKEN", "s3cr3t"}]
+      config = one_shot_config(D::Headers.parse_lines(["X-Auth: $TOKEN"]))
+      findings, seen = run_one do |port|
+        D::PlanOptions.new("http://127.0.0.1:#{port}/probe", config: config, verify: false)
+      end
+      findings.size.should eq(1)
+      seen.size.should eq(1)
+      seen[0].should contain("GET /probe HTTP/1.1\r\n")
+      seen[0].should contain("X-Auth: s3cr3t\r\n")
+      # The TUI's headers overlay binds this very instance; expanding in place would
+      # rewrite what it shows and expand a SECOND time on the next ^R.
+      config.headers.should eq([{"X-Auth", "$TOKEN"}])
+    ensure
+      Gori::Settings.env_vars = [] of {String, String}
+    end
+
+    it "drops a header whose expanded value carries CRLF" do
+      # `Headers.parse_lines` refuses a hand-typed CRLF, but it only ever saw `$TOKEN`.
+      # Without a second guard after expansion, an env var's value would splice extra
+      # headers into every probe the crawl sends.
+      Gori::Settings.env_vars = [{"TOKEN", "a\r\nX-Injected: 1"}]
+      config = one_shot_config(D::Headers.parse_lines(["X-Auth: $TOKEN"]))
+      _findings, seen = run_one do |port|
+        D::PlanOptions.new("http://127.0.0.1:#{port}/probe", config: config, verify: false)
+      end
+      seen.size.should eq(1)
+      seen[0].should_not contain("X-Injected")
+      seen[0].should_not contain("X-Auth")
+    ensure
+      Gori::Settings.env_vars = [] of {String, String}
+    end
+
+    # Issue #367: every CLI/MCP tool passed `overrides:` to its sender and no TUI tool did,
+    # so a project host override silently did not apply to a TUI-launched crawl. The
+    # argument's absence was invisible to the old specs, so this pair asserts the DIALLED
+    # host, not the plumbing: `.invalid` is reserved (RFC 2606) and never resolves, so the
+    # run can only reach the local listener through the override.
+    it "dials the override IP while keeping the original name in the Host header" do
+      with_store do |store|
+        overrides = Gori::HostOverrides.load(store)
+        overrides.add("nonexistent.invalid", "127.0.0.1").should be_true
+        findings, seen = run_one do |port|
+          D::PlanOptions.new("http://nonexistent.invalid:#{port}/probe",
+            config: one_shot_config, verify: false, overrides: overrides)
+        end
+        findings.size.should eq(1)
+        seen.size.should eq(1)
+        seen[0].should contain("GET /probe HTTP/1.1\r\n")
+        seen[0].should contain("Host: nonexistent.invalid:") # name preserved, only the IP changed
+      end
+    end
+
+    it "hands the RESOLVED seed to the engine, not just to the getter" do
+      # `plan.seed` alone cannot prove this: a build that resolves the seed for the getter and
+      # passes `options.target` to `Engine.new` reports the same string either way. Here the
+      # raw target is an unexpanded env token, so the crawl reaches the listener only if the
+      # engine received the resolved form.
+      Gori::Settings.env_vars = [{"SEEDORIGIN", "http://127.0.0.1"}]
+      findings, seen = run_one do |port|
+        D::PlanOptions.new("$SEEDORIGIN:#{port}/probe?a=1", config: one_shot_config, verify: false)
+      end
+      findings.size.should eq(1)
+      seen.size.should eq(1)
+      seen[0].should contain("GET /probe?a=1 HTTP/1.1\r\n")
+    ensure
+      Gori::Settings.env_vars = [] of {String, String}
+    end
+
+    it "cannot reach the same target with no overrides (so the override is what connects)" do
+      findings, seen = run_one do |port|
+        D::PlanOptions.new("http://nonexistent.invalid:#{port}/probe",
+          config: one_shot_config, verify: false)
+      end
+      findings.should be_empty
+      seen.should be_empty
+    end
+  end
+
+  describe "refusals" do
+    it "reports NoTechnique before anything else, so a surface names the flags first" do
+      both_off = D::Config.new(spider: false, bruteforce: false)
+      ex = expect_raises(D::PlanError) { D::Plan.build(D::PlanOptions.new("", config: both_off), ungated_outbound) }
+      ex.reason.should eq(D::PlanError::Reason::NoTechnique)
+    end
+
+    it "reports NoTarget for a blank seed, and for one an env var emptied" do
+      ex = expect_raises(D::PlanError) { D::Plan.build(D::PlanOptions.new("   "), ungated_outbound) }
+      ex.reason.should eq(D::PlanError::Reason::NoTarget)
+      # The second case pins the ORDER: expansion has to happen before the blank test, or a
+      # var set to "" reaches the parser and reports BadTarget("https://") instead.
+      Gori::Settings.env_vars = [{"NOTHING", ""}]
+      ex = expect_raises(D::PlanError) { D::Plan.build(D::PlanOptions.new("$NOTHING"), ungated_outbound) }
+      ex.reason.should eq(D::PlanError::Reason::NoTarget)
+    ensure
+      Gori::Settings.env_vars = [] of {String, String}
+    end
+
+    it "reports BadTarget with the expanded string a surface quotes back" do
+      ex = expect_raises(D::PlanError) { D::Plan.build(D::PlanOptions.new("http://"), ungated_outbound) }
+      ex.reason.should eq(D::PlanError::Reason::BadTarget)
+      ex.detail.should eq("http://")
+      # Quoting the raw `$BROKEN` back would leave the operator hunting for a URL that is not
+      # what the run actually tried.
+      Gori::Settings.env_vars = [{"BROKEN", "http://"}]
+      ex = expect_raises(D::PlanError) { D::Plan.build(D::PlanOptions.new("$BROKEN"), ungated_outbound) }
+      ex.detail.should eq("http://")
+    ensure
+      Gori::Settings.env_vars = [] of {String, String}
+    end
+
+    it "refuses a seed whose expanded value carries CRLF" do
+      # `URI.parse` keeps a raw CR/LF in the path and the seed is spliced into a request line,
+      # so this would otherwise inject a second request on every surface.
+      Gori::Settings.env_vars = [{"EVIL", "http://acme.test/x\r\nX-Injected: 1"}]
+      ex = expect_raises(D::PlanError) { D::Plan.build(D::PlanOptions.new("$EVIL"), ungated_outbound) }
+      ex.reason.should eq(D::PlanError::Reason::BadTarget)
+    ensure
+      Gori::Settings.env_vars = [] of {String, String}
+    end
+
+    it "reports Wordlist for an unreadable path instead of raising File::Error at a surface" do
+      config = D::Config.new(user_wordlist: File.join(Dir.tempdir, "gori-nope-#{Process.pid}.txt"))
+      ex = expect_raises(D::PlanError) do
+        D::Plan.build(D::PlanOptions.new("https://acme.test/", config: config), ungated_outbound)
+      end
+      ex.reason.should eq(D::PlanError::Reason::Wordlist)
+      ex.detail.should_not be_nil
+    end
+  end
+end

--- a/src/gori/cli/run/discover.cr
+++ b/src/gori/cli/run/discover.cr
@@ -1,4 +1,6 @@
 # `gori run discover` — spider + directory brute-force a target; findings feed the Sitemap.
+require "../../discover/plan"
+
 module Gori
   module CLI
     module Run
@@ -54,33 +56,63 @@ module Gori
         end
         parser.parse(args)
 
-        abort "gori run discover: --no-spider and --no-bruteforce can't both be set" unless spider || bruteforce
-        seed_url = resolve_discover_seed(target_override)
+        # The two checks that read ONLY the flags, made before the project is resolved. The
+        # builder makes them too and is the authority — but `--db PATH` is create-or-reopened
+        # below, and `abort` exits without unwinding, so letting a malformed invocation reach
+        # that point would leave a freshly-migrated database (plus its -wal/-shm) behind and
+        # would report "no projects yet" instead of naming the flag that was wrong. The
+        # sentences come from the ONE mapping so they cannot drift from the builder's.
+        abort "gori run discover: #{discover_reason_error(Discover::PlanError::Reason::NoTechnique)}" unless spider || bruteforce
+        abort "gori run discover: #{discover_reason_error(Discover::PlanError::Reason::NoTarget)}" if target_override.to_s.strip.empty?
+
+        config = Discover::Config.new(
+          concurrency: concurrency, rps: rate, throttle_ms: throttle, timeout: timeout,
+          retries: retries, max_requests: max_requests, spider: spider, bruteforce: bruteforce,
+          max_depth: max_depth, user_wordlist: wordlist, extensions: extensions,
+          containment: containment, headers: Discover::Headers.parse_lines(headers))
 
         project = resolve_discover_project(project_name, db_path)
         store = open_store(project)
         begin
-          scope = Scope.load(store)
-          guard_discover_scope(seed_url, scope, allow_unscoped)
-
-          config = Discover::Config.new(
-            concurrency: concurrency, rps: rate, throttle_ms: throttle, timeout: timeout,
-            retries: retries, max_requests: max_requests, spider: spider, bruteforce: bruteforce,
-            max_depth: max_depth, extensions: extensions, containment: containment,
-            headers: Discover::Headers.parse_lines(headers))
-          words = begin
-            Discover::Wordlist.load(wordlist)
-          rescue ex
-            abort "gori run discover: wordlist error: #{ex.message}"
+          # The store stays open for the whole run (findings are written through it), so the
+          # Outbound does NOT take ownership of it — the ensure below is what closes it.
+          outbound = Gori::Outbound.cli(Scope.load(store), allow_unscoped)
+          # `.to_s` rather than `|| ""`: an OptionParser-closured var never narrows out of String?.
+          options = Discover::PlanOptions.new(target_override.to_s, config: config,
+            verify: !insecure, overrides: Gori::HostOverrides.load(store))
+          plan = begin
+            Discover::Plan.build(options, outbound)
+          rescue ex : Discover::PlanError
+            abort "gori run discover: #{discover_plan_error(ex)}"
           end
-          policy = discover_policy(scope, seed_url, allow_unscoped)
-          sender = Discover::Sender.new(verify: !insecure, timeout: timeout, headers: config.headers,
-            overrides: Gori::HostOverrides.load(store))
-          engine = Discover::Engine.new(seed_url, words, sender, config, policy)
-          discover_preflight(seed_url, config, words.size, force)
-          run_discover_stream(engine, store, format, no_store)
+          guard_discover_scope(plan, outbound)
+          discover_preflight(plan, force)
+          run_discover_stream(plan.engine, store, format, no_store)
         ensure
           store.close
+        end
+      end
+
+      # `gori run discover`'s wording for a plan the options can't produce. The builder
+      # reports the machine-readable `reason`; the sentence (and the flags it names) is ours.
+      private def self.discover_plan_error(ex : Discover::PlanError) : String
+        case ex.reason
+        in Discover::PlanError::Reason::BadTarget
+          "invalid --target #{ex.detail.inspect} (use http:// or https://)"
+        in Discover::PlanError::Reason::Wordlist
+          "wordlist error: #{ex.detail}"
+        in Discover::PlanError::Reason::NoTarget, Discover::PlanError::Reason::NoTechnique
+          discover_reason_error(ex.reason)
+        end
+      end
+
+      # The reasons whose sentence needs no `detail`, so the flag pre-checks above can share
+      # the exact wording the builder's own failure would produce.
+      private def self.discover_reason_error(reason : Discover::PlanError::Reason) : String
+        case reason
+        when Discover::PlanError::Reason::NoTarget    then "--target URL is required"
+        when Discover::PlanError::Reason::NoTechnique then "--no-spider and --no-bruteforce can't both be set"
+        else                                               "invalid discover options"
         end
       end
 
@@ -96,35 +128,15 @@ module Gori
         resolve_read_project(project_name, nil)
       end
 
-      private def self.resolve_discover_seed(target : String?) : String
-        raw = Env.expand(target || abort("gori run discover: --target URL is required"))
-        seed = raw.matches?(/\Ahttps?:\/\//i) ? raw : "https://#{raw}"
-        abort "gori run discover: invalid --target #{raw.inspect} (use http:// or https://)" unless Discover::Url.parse(seed)
-        seed
-      end
-
-      private def self.guard_discover_scope(seed_url : String, scope : Scope, allow_unscoped : Bool) : Nil
-        return if allow_unscoped || !scope.configured?
-        p = Discover::Url.parse(seed_url)
-        return unless p
-        return if scope.matches_url?(seed_url, p.host)
-        abort "gori run discover: #{seed_url} is out of the project scope — add a scope include rule or pass --allow-unscoped"
-      end
-
-      # The ScopePolicy the crawl engine enforces. Unconfigured scope ⇒ OpenScope (nothing
-      # bounded). Otherwise StoreScope (sandbox/exclude + the include boundary) — UNLESS
-      # --allow-unscoped was passed AND the seed is genuinely outside the include boundary,
-      # in which case UnscopedStoreScope keeps the hard sandbox/exclude gate but drops the
-      # include boundary so scope-aware containment can fall back to same-origin (the flag
-      # was a no-op on the policy before, gutting the crawl — see UnscopedStoreScope). When
-      # the seed IS in scope the flag is redundant, so normal StoreScope is kept unchanged.
-      private def self.discover_policy(scope : Scope, seed_url : String, allow_unscoped : Bool) : Discover::ScopePolicy
-        return Discover::OpenScope.new unless scope.configured?
-        if allow_unscoped
-          p = Discover::Url.parse(seed_url)
-          return Discover::UnscopedStoreScope.new(scope) if p.nil? || !scope.matches_url?(seed_url, p.host)
-        end
-        Discover::StoreScope.new(scope)
+      # Layer-1 scope gate, matched on the SEED URL (path included) rather than on its bare
+      # origin: a project scoped to `https://acme.test/api/` should be crawlable from
+      # `https://acme.test/api/v1`, which an origin-only check would refuse. The policy
+      # itself is the Outbound's (`Outbound.cli`: an unconfigured project stays permissive,
+      # a configured one refuses an out-of-scope seed unless --allow-unscoped); only the
+      # sentence is ours.
+      private def self.guard_discover_scope(plan : Discover::Plan, outbound : Gori::Outbound) : Nil
+        return unless outbound.check(plan.seed, plan.host).blocked?
+        abort "gori run discover: #{plan.seed} is out of the project scope — add a scope include rule or pass --allow-unscoped"
       end
 
       private def self.parse_extensions(v : String) : Array(String)
@@ -138,11 +150,12 @@ module Gori
         Discover::Containment.parse?(v) || abort("gori run discover: invalid --containment '#{v}' (same-origin|scope-aware|host+subdomains)")
       end
 
-      private def self.discover_preflight(seed_url : String, config : Discover::Config, words : Int32, force : Bool) : Nil
+      private def self.discover_preflight(plan : Discover::Plan, force : Bool) : Nil
+        config = plan.config
         techniques = [] of String
         techniques << "spider(d#{config.max_depth})" if config.spider?
-        techniques << "brute(#{words}w)" if config.bruteforce?
-        STDERR.puts "discovering #{seed_url} · #{techniques.join("+")} · #{config.containment.label}"
+        techniques << "brute(#{plan.word_count}w)" if config.bruteforce?
+        STDERR.puts "discovering #{plan.seed} · #{techniques.join("+")} · #{config.containment.label}"
         if config.max_requests.nil? && config.spider? && config.max_depth >= 8 && !force
           abort "gori run discover: a depth-#{config.max_depth} crawl with no --max-requests could send a lot; pass --max-requests / a lower --max-depth, or --force"
         end

--- a/src/gori/discover/headers.cr
+++ b/src/gori/discover/headers.cr
@@ -1,3 +1,4 @@
+require "../env"
 require "../proxy/codec/http1"
 
 module Gori::Discover
@@ -37,7 +38,7 @@ module Gori::Discover
         name = name.strip
         value = value.strip
         next if name.empty? || !valid_name?(name)
-        next if value.includes?('\r') || value.includes?('\n')
+        next unless safe_value?(value)
         out << {name, value}
       end
       out
@@ -50,10 +51,31 @@ module Gori::Discover
       out = [] of {String, String}
       req.headers.each do |h|
         next if DROP.includes?(h.name.downcase)
-        next if h.value.includes?('\r') || h.value.includes?('\n')
+        next unless safe_value?(h.value)
         out << {h.name, h.value}
       end
       out
+    end
+
+    # Header values with `$VAR` resolved, applied by `Discover::Plan` at send time (the
+    # editor / CLI flag / MCP map all keep the raw `$TOKEN` so the operator still sees what
+    # they typed). Expansion happens AFTER parsing, so `safe_value?` has to run again here:
+    # `parse_lines` only ever judged the literal `$TOKEN`, and an env var whose VALUE carries
+    # a newline would otherwise splice extra headers into every probe the crawl sends.
+    def self.expand(pairs : Array({String, String})) : Array({String, String})
+      pairs.compact_map do |(name, value)|
+        # Stripped AFTER substituting, matching what `parse_lines` did back when MCP expanded
+        # before parsing: a var whose value has surrounding spaces must not widen the OWS.
+        expanded = Env.expand(value).strip
+        safe_value?(expanded) ? {name, expanded} : nil
+      end
+    end
+
+    # The one injection rule: a value may not carry CR or LF. Applied wherever untrusted text
+    # reaches a request line or header — hand-typed lines, a reused flow's headers, a crawl
+    # seed (`Discover::Plan`), and post-expansion.
+    def self.safe_value?(value : String) : Bool
+      !value.includes?('\r') && !value.includes?('\n')
     end
 
     # The final ordered header list the Sender emits between `Host` and `Connection`:

--- a/src/gori/discover/plan.cr
+++ b/src/gori/discover/plan.cr
@@ -1,0 +1,190 @@
+require "./adapters"
+require "./engine"
+require "./types"
+require "./url"
+require "./wordlist"
+require "../env"
+require "../host_overrides"
+require "../outbound"
+
+module Gori::Discover
+  # Why one option set cannot become a runnable discover plan.
+  #
+  # The builder never writes the user-facing sentence: every surface phrases these in its
+  # own idiom (`gori run discover: --target URL is required` vs the TUI's `start from
+  # Sitemap/History (space → "Discover here")`), and those strings are part of each
+  # surface's contract. So `reason` is the machine-readable fact and the `message` here is
+  # only a fallback for a caller that has nothing better to say.
+  class PlanError < Exception
+    enum Reason
+      # No seed target at all (missing, blank, or an Env var that expanded to nothing).
+      NoTarget
+      # A seed was given but no http(s) host could be parsed out of it (`detail` = the
+      # Env-expanded string that failed, for surfaces that quote it back).
+      BadTarget
+      # Both techniques disabled — a run with neither spider nor brute-force sends nothing.
+      NoTechnique
+      # The user wordlist could not be read (`detail` = the underlying error message).
+      Wordlist
+    end
+
+    getter reason : Reason
+    getter detail : String?
+
+    def initialize(@reason : Reason, message : String, @detail : String? = nil)
+      super(message)
+    end
+  end
+
+  # A normalized, surface-independent description of ONE discover run.
+  #
+  # Each surface's remaining job is to parse ITS OWN input format into this — `OptionParser`
+  # for `gori run discover`, the JSON args hash for MCP, the config overlay's state for the
+  # TUI tab — and nothing else. Everything downstream of it (seed normalization, wordlist
+  # load, scope policy, sender, engine, and the `Env.expand` / host-override wiring that used
+  # to drift between the three copies) belongs to `Plan.build`.
+  #
+  # `config` is the live mutable object the caller owns — the TUI's discover config overlay
+  # edits its `Config` in place while a run row is selected, so the plan must read that
+  # instance, not a copy of it. The builder never writes to it (see the header expansion in
+  # `Plan.build`): a re-run of the same row must see exactly what the operator configured.
+  struct PlanOptions
+    # Raw seed, BEFORE `Env.expand` and before the scheme default — the builder owns both
+    # so they happen exactly once, on every surface (see `Plan.build`).
+    property target : String
+    # Every knob of the run: pacing, budget, techniques, depth, containment, extensions,
+    # custom headers, AND the user wordlist path (`config.user_wordlist`). One field, one
+    # source — the TUI's overlay already stored the path there while `gori run --wordlist`
+    # and MCP's `wordlist` arg used to pass it separately and leave the Config's copy nil.
+    property config : Config
+    # Verify upstream TLS certificates.
+    property? verify : Bool
+    # The project's hostname overrides, or nil when the surface has no project to load them
+    # from. Only a surface can reach a Store, so this is passed in rather than loaded — and
+    # the TUI passes its LIVE `Session#host_overrides` so a mid-session edit is honoured
+    # (issue #367).
+    property overrides : Gori::HostOverrides?
+
+    def initialize(@target : String,
+                   *,
+                   @config : Config = Config.new,
+                   @verify : Bool = true,
+                   @overrides : Gori::HostOverrides? = nil)
+    end
+  end
+
+  # A ready-to-run discover job: THE only place a `Discover::Engine` is constructed.
+  #
+  # The sequence *expand → scheme default → parse → wordlist → scope policy → sender →
+  # engine* used to exist three times over (TUI `build_engine`, `gori run discover`, MCP
+  # `build_discover_job`), and the copies had drifted: the TUI applied neither `Env.expand`
+  # nor the project's host overrides and rejected a bare host outright, while MCP expanded
+  # custom header values and `gori run discover` did not. One builder makes those answers the
+  # same by construction.
+  #
+  # `outbound` is an ARGUMENT, never built here: Layer-1 strictness differs per surface on
+  # purpose (`Outbound.agent` / `.cli` / `.interactive`, DESIGN.md §7), and constructing one
+  # in here would silently collapse that distinction into whichever policy was hard-coded.
+  # Discover is also the one tool whose *engine* carries a scope of its own (`ScopePolicy`,
+  # which keeps the engine Store-free), and that policy is DERIVED from this same Outbound —
+  # see `resolve_policy`.
+  struct Plan
+    getter engine : Engine
+    # The seed the engine will actually crawl: Env-expanded, `https://` filled in when the
+    # operator gave a bare host, then `Url.normalize`d. This — not the origin — is the string
+    # the Layer-1 scope check matches on, since it is the first URL the run requests, and it
+    # is normalized so the gate and the crawl can never judge two different spellings.
+    getter seed : String
+    # The seed's host, for the Layer-1 verdict and the audit line.
+    getter host : String
+    # The crawl-time scope gate handed to the engine. Exposed rather than left buried inside
+    # the Engine because it is a DERIVED scope decision (see `resolve_policy`) and not a run
+    # knob the caller passed in — so it stays assertable, and folding it into `Config` would
+    # hide the one part of the plan the operator did not choose directly.
+    getter policy : ScopePolicy
+    getter config : Config
+    # Brute-force candidate count (built-in list + the user wordlist), for the CLI preflight.
+    getter word_count : Int32
+
+    def initialize(@engine : Engine, @seed : String, @host : String,
+                   @policy : ScopePolicy, @config : Config, @word_count : Int32)
+    end
+
+    def self.build(options : PlanOptions, outbound : Gori::Outbound) : Plan
+      config = options.config
+      unless config.spider? || config.bruteforce?
+        raise PlanError.new(PlanError::Reason::NoTechnique, "neither spider nor brute-force is enabled")
+      end
+      raw = resolve_seed(options.target)
+      parts = Url.parse(raw) ||
+              raise PlanError.new(PlanError::Reason::BadTarget, "could not parse a host from #{raw.inspect}", raw)
+      # CANONICAL form, and the reason this is not just `raw`: every scope rule and the crawl
+      # itself must judge one spelling of the seed. `Url.normalize` lowercases the host, drops
+      # a default port, and fills in the path — without it a `string`/`regex` rule saw whatever
+      # the operator typed, so an exclude like `^https://prod\.acme\.test` missed
+      # `https://PROD.acme.test/` and `prod.acme.test:443`, while an include anchored on
+      # `^https://acme\.test/` missed a seed given as bare `acme.test` (no trailing slash).
+      # Both directions were live at HEAD; gating on the normalized string closes them.
+      seed = Url.normalize(parts)
+      # The seed is spliced straight into a request line (`Sender#build_get`), and `URI.parse`
+      # keeps a raw CR/LF in the path — so an env var whose VALUE carries one would inject a
+      # second request. Same single rule the header values go through.
+      unless Headers.safe_value?(seed)
+        raise PlanError.new(PlanError::Reason::BadTarget, "seed contains a control character", raw)
+      end
+      words = load_words(config.user_wordlist)
+      policy = resolve_policy(outbound, seed, parts.host)
+      sender = Sender.new(verify: options.verify?, timeout: config.timeout,
+        headers: Headers.expand(config.headers), overrides: options.overrides)
+      new(engine: Engine.new(seed, words, sender, config, policy), seed: seed, host: parts.host,
+        policy: policy, config: config, word_count: words.size)
+    end
+
+    # ONE `Env.expand` over the seed, then the scheme default: `acme.test/admin` means
+    # `https://acme.test/admin` on every surface (the TUI used to reject it as invalid).
+    private def self.resolve_seed(raw : String) : String
+      target = Env.expand(raw.strip)
+      raise PlanError.new(PlanError::Reason::NoTarget, "no seed target") if target.empty?
+      target.matches?(/\Ahttps?:\/\//i) ? target : "https://#{target}"
+    end
+
+    # The crawl-time scope gate, derived from the Outbound the surface handed in rather than
+    # re-derived per surface (`gori run discover` and MCP each carried a copy of this, the
+    # MCP one labelled "mirror of the CLI's"; the TUI had a third, shorter one).
+    #
+    # Unconfigured scope ⇒ OpenScope, nothing bounded. Otherwise StoreScope (sandbox/exclude
+    # + the include boundary) — UNLESS Layer 1 was waived by the OPERATOR (--allow-unscoped /
+    # allow_unscoped:true) AND the seed is genuinely outside the include boundary, in which
+    # case UnscopedStoreScope keeps the hard sandbox/exclude gate but drops the include
+    # boundary so scope-aware containment can fall back to same-origin. Without that the flag
+    # was a no-op on the policy and gutted the crawl to the seed alone (see UnscopedStoreScope).
+    #
+    # The waiver test is on `Reason::Operator` specifically, NOT on `gate.waived?`: the TUI's
+    # Outbound is also waived, for `Reason::Interactive`, and "the human typed this target"
+    # is not a request to drop the include boundary the same human configured. (That test
+    # would read better as an `Outbound#operator_waived?` predicate — `src/gori/outbound.cr`
+    # already names `gated?` for the same reason — but that file belongs to another issue.)
+    private def self.resolve_policy(outbound : Gori::Outbound, seed : String, host : String) : ScopePolicy
+      scope = outbound.scope
+      # The scope's OWN reading of the seed, not a second copy of it: `Verdict#decision` is
+      # gate-independent (`Outbound#evaluate`), so `unscoped?` is "no configured scope" and
+      # `in_scope?` is "inside the include boundary" — the two questions this used to answer
+      # by pulling the Scope out and re-running `configured?` / `matches_url?` by hand.
+      verdict = outbound.check(seed, host)
+      return OpenScope.new if scope.nil? || verdict.unscoped?
+      if outbound.reason == Gori::Outbound::Reason::Operator && !verdict.in_scope?
+        return UnscopedStoreScope.new(scope)
+      end
+      StoreScope.new(scope)
+    end
+
+    # A missing/unreadable/binary wordlist is a user mistake, not a crash: every surface
+    # already caught it (each with its own rescue, one of them blanket), so the catch-all
+    # lives here once. Nothing in `Wordlist.load` raises PlanError, so this cannot swallow one.
+    private def self.load_words(path : String?) : Array(String)
+      Wordlist.load(path)
+    rescue ex
+      raise PlanError.new(PlanError::Reason::Wordlist, "wordlist error: #{ex.message}", ex.message)
+    end
+  end
+end

--- a/src/gori/mcp/tools/discover.cr
+++ b/src/gori/mcp/tools/discover.cr
@@ -1,8 +1,7 @@
 require "json"
 require "../../discover"
 require "../../discover/adapters"
-require "../../env"
-require "../../scope"
+require "../../discover/plan"
 
 module Gori
   module MCP
@@ -10,53 +9,56 @@ module Gori
       # --- discover (spider + directory brute-force) --------------------------
 
       private def discover_start(h) : Result
-        engine, seed_url, host = build_discover_job(h)
-        p = Discover::Url.parse(seed_url)
-        chk_url = p ? "#{Discover::Url.origin(p)}/" : seed_url
-        sc = outbound(bool(h, "allow_unscoped") || false).check(chk_url, host)
+        # ONE Outbound for the whole call: the builder derives the crawl-time ScopePolicy
+        # from it (see Discover::Plan.resolve_policy) and the Layer-1 check below reads the
+        # same decision, so `allow_unscoped` cannot be honoured by one and not the other.
+        ob = outbound(bool(h, "allow_unscoped") || false)
+        plan = build_discover_plan(h, ob)
+        # Matched on the SEED URL (path included), not its bare origin: a project scoped to
+        # `https://acme.test/api/` should be crawlable from `https://acme.test/api/v1`.
+        sc = ob.check(plan.seed, plan.host)
         return scope_blocked(sc) if sc.blocked?
         @job_seq += 1
         id = "ds_#{@job_seq}"
-        audit = JobAudit.new(seed_url, int(h, "rate").try(&.to_f64),
-          clamp(int(h, "concurrency"), 20, DISCOVER_MAX_CONCURRENCY),
-          int(h, "max_requests"), Time.utc.to_unix_ms)
+        # Read back off the plan, not re-derived from the args: the concurrency clamp used to
+        # be written out twice, and `max_requests` was recorded RAW while the engine ran with
+        # `min(requested, DISCOVER_MAX_REQUESTS)` — an audit line that disagreed with the run.
+        audit = JobAudit.new(plan.seed, plan.config.rps, plan.config.concurrency,
+          plan.config.max_requests, Time.utc.to_unix_ms)
+        engine = plan.engine
         djob = DiscoverJob.new(id, engine, audit)
         evict_finished_jobs(@discover_jobs)
         @discover_jobs[id] = djob
-        Log.info { "discover_start #{id} #{seed_url} scope=#{sc.decision}" }
+        Log.info { "discover_start #{id} #{plan.seed} scope=#{sc.decision}" }
         spawn(name: "mcp-discover-#{id}") { run_discover_job(djob, engine) }
         Result.new(JSON.build { |j| j.object { j.field "job_id", id; j.field "status", "running"; emit_scope(j, sc) } })
       rescue ex : FuzzArgError
         Result.new(ex.message || "invalid discover arguments", is_error: true)
       end
 
-      # Build a ready-to-run discover engine + seed URL + host from the tool args.
-      private def build_discover_job(h) : {Discover::Engine, String, String}
-        raw = str(h, "url").presence || raise FuzzArgError.new("provide a 'url' seed target")
-        seed = Env.expand(raw)
-        seed = "https://#{seed}" unless seed.matches?(/\Ahttps?:\/\//i)
-        parts = Discover::Url.parse(seed) || raise FuzzArgError.new("could not parse a host from '#{raw}'")
+      # Parse the tool args into Discover::PlanOptions and hand them to the ONE builder every
+      # surface shares. Everything here is arg decoding (clamps, enum tokens, MCP's own
+      # ceilings); seed normalization, wordlist load, scope policy and sender wiring are the
+      # builder's. Raises FuzzArgError (clean message) on any malformed input.
+      private def build_discover_plan(h, ob : Outbound) : Discover::Plan
+        options = Discover::PlanOptions.new(str(h, "url") || "", config: discover_config(h),
+          verify: @verify_upstream && !(bool(h, "insecure") || false),
+          overrides: HostOverrides.load(store))
+        Discover::Plan.build(options, ob)
+      rescue ex : Discover::PlanError
+        raise FuzzArgError.new(discover_plan_error(ex))
+      end
 
+      # Every run knob the args carry, with MCP's own ceilings applied (an agent must not be
+      # able to ask for an unbounded crawl). `user_wordlist` lives on the Config like every
+      # other knob — the builder reads it from there on all three surfaces.
+      private def discover_config(h) : Discover::Config
         spider = bool(h, "spider")
         bruteforce = bool(h, "bruteforce")
         spider = true if spider.nil?
         bruteforce = true if bruteforce.nil?
-        raise FuzzArgError.new("at least one of spider/bruteforce must stay enabled") unless spider || bruteforce
-
-        containment = Discover::Containment::ScopeAware
-        if c = str(h, "containment").presence
-          containment = Discover::Containment.parse?(c) || raise FuzzArgError.new("invalid containment '#{c}' (same-origin|scope-aware|host+subdomains)")
-        end
-        extensions = (str(h, "extensions") || "").split(',').compact_map do |t|
-          tok = t.strip.lchop('.')
-          tok.empty? ? nil : tok
-        end
-        header_lines = [] of String
-        if hm = h["headers"]?.try(&.as_h?)
-          hm.each { |k, v| header_lines << "#{k}: #{Env.expand(v.as_s? || v.to_s)}" }
-        end
         cap = int(h, "max_requests")
-        config = Discover::Config.new(
+        Discover::Config.new(
           concurrency: clamp(int(h, "concurrency"), 20, DISCOVER_MAX_CONCURRENCY),
           rps: int(h, "rate").try(&.to_f64),
           timeout: discover_timeout(h),
@@ -64,27 +66,48 @@ module Gori
           max_requests: cap ? {cap, DISCOVER_MAX_REQUESTS}.min : DISCOVER_MAX_REQUESTS,
           spider: spider, bruteforce: bruteforce,
           max_depth: clamp(int(h, "max_depth"), 4, DISCOVER_MAX_DEPTH),
-          extensions: extensions, containment: containment,
-          headers: Discover::Headers.parse_lines(header_lines))
-        words = Discover::Wordlist.load(str(h, "wordlist").presence)
-        scope = Scope.load(store)
-        policy = discover_policy(scope, seed, parts.host, bool(h, "allow_unscoped") || false)
-        sender = Discover::Sender.new(verify: @verify_upstream && !(bool(h, "insecure") || false), timeout: discover_timeout(h),
-          headers: config.headers, overrides: HostOverrides.load(store))
-        engine = Discover::Engine.new(seed, words, sender, config, policy)
-        {engine, seed, parts.host}
-      rescue ex : File::Error
-        raise FuzzArgError.new("wordlist error: #{ex.message}")
+          user_wordlist: str(h, "wordlist").presence,
+          extensions: discover_extensions(h), containment: discover_containment(h),
+          headers: Discover::Headers.parse_lines(discover_header_lines(h)))
       end
 
-      # Mirror of the CLI's discover_policy (cli/run/discover.cr): with allow_unscoped on an
-      # out-of-scope seed, keep sandbox/exclude but drop the include boundary so scope-aware
-      # containment falls back to same-origin instead of blocking every hop (which otherwise
-      # gutted the crawl to just the seed + robots/sitemap — see UnscopedStoreScope).
-      private def discover_policy(scope : Scope, seed : String, host : String, allow_unscoped : Bool) : Discover::ScopePolicy
-        return Discover::OpenScope.new unless scope.configured?
-        return Discover::UnscopedStoreScope.new(scope) if allow_unscoped && !scope.matches_url?(seed, host)
-        Discover::StoreScope.new(scope)
+      private def discover_containment(h) : Discover::Containment
+        c = str(h, "containment").presence
+        return Discover::Containment::ScopeAware unless c
+        Discover::Containment.parse?(c) ||
+          raise FuzzArgError.new("invalid containment '#{c}' (same-origin|scope-aware|host+subdomains)")
+      end
+
+      private def discover_extensions(h) : Array(String)
+        (str(h, "extensions") || "").split(',').compact_map do |t|
+          tok = t.strip.lchop('.')
+          tok.empty? ? nil : tok
+        end
+      end
+
+      # `{"headers": {"X-A": "1"}}` as raw `Name: Value` lines. `$VAR` in a value is left
+      # alone here — the builder expands it (and re-applies the CRLF guard afterwards).
+      private def discover_header_lines(h) : Array(String)
+        lines = [] of String
+        if hm = h["headers"]?.try(&.as_h?)
+          hm.each { |k, v| lines << "#{k}: #{v.as_s? || v.to_s}" }
+        end
+        lines
+      end
+
+      # MCP's wording for a plan the args can't produce — the builder reports the
+      # machine-readable `reason`, the sentence (and the arg names it points at) is ours.
+      private def discover_plan_error(ex : Discover::PlanError) : String
+        case ex.reason
+        in Discover::PlanError::Reason::NoTarget
+          "provide a 'url' seed target"
+        in Discover::PlanError::Reason::BadTarget
+          "could not parse a host from '#{ex.detail}'"
+        in Discover::PlanError::Reason::NoTechnique
+          "at least one of spider/bruteforce must stay enabled"
+        in Discover::PlanError::Reason::Wordlist
+          "wordlist error: #{ex.detail}"
+        end
       end
 
       private def discover_timeout(h) : Time::Span?

--- a/src/gori/tui/controllers/discover_controller.cr
+++ b/src/gori/tui/controllers/discover_controller.cr
@@ -2,6 +2,8 @@ require "../tab_controller"
 require "../discover_view"
 require "../../discover"
 require "../../discover/adapters"
+require "../../discover/plan"
+require "../../outbound"
 require "../../store"
 
 module Gori::Tui
@@ -181,16 +183,41 @@ module Gori::Tui
       @host.status("discovering #{run.target} in the background — watch the bottom bar / notifications")
     end
 
+    # View state → Discover::PlanOptions → the ONE builder every surface shares. The run's
+    # `config` is passed by REFERENCE on purpose: the discover config overlay edits that same
+    # instance while the row is selected, so a ^R re-run must read it, not a snapshot.
+    #
+    # `Outbound.interactive` is the TUI's Layer-1 policy (no up-front gate — the operator
+    # chose this target from the Sitemap/History; Sandbox and EXCLUDE still bound the crawl
+    # through the ScopePolicy the builder derives from it). The session's LIVE HostOverrides
+    # instance is handed over rather than a fresh `HostOverrides.load`, so an override the
+    # operator adds in the Project tab mid-session applies to the next run (issue #367) — the
+    # Fuzzer/Miner/Sequencer/Repeater tabs used to drop this argument entirely and silently
+    # dial the real DNS answer while `gori run discover` pinned it.
     private def build_engine(run : DiscoverRun) : {Discover::Engine?, String?}
-      return {nil, "invalid target — use scheme://host[:port][/path]"} unless Discover::Url.parse(run.target)
-      words = Discover::Wordlist.load(run.config.user_wordlist)
-      scope = @host.session.scope
-      policy : Discover::ScopePolicy = scope.configured? ? Discover::StoreScope.new(scope) : Discover::OpenScope.new
-      sender = Discover::Sender.new(verify: !@host.session.config.insecure_upstream?, timeout: run.config.timeout,
-        headers: run.config.headers)
-      {Discover::Engine.new(run.target, words, sender, run.config, policy), nil}
+      session = @host.session
+      options = Discover::PlanOptions.new(run.target, config: run.config,
+        verify: !session.config.insecure_upstream?, overrides: session.host_overrides)
+      {Discover::Plan.build(options, Gori::Outbound.interactive(session.scope)).engine, nil}
+    rescue ex : Discover::PlanError
+      {nil, discover_plan_error(ex)}
     rescue ex
       {nil, "config error: #{ex.message}"}
+    end
+
+    # The Discover tab's wording for a plan the run can't produce. The builder reports the
+    # machine-readable `reason`; naming the tab's own hotkeys and panes is ours.
+    private def discover_plan_error(ex : Discover::PlanError) : String
+      case ex.reason
+      in Discover::PlanError::Reason::NoTarget
+        "no target — start from Sitemap/History (space → \"Discover here\")"
+      in Discover::PlanError::Reason::BadTarget
+        "invalid target — use scheme://host[:port][/path]"
+      in Discover::PlanError::Reason::NoTechnique
+        "enable spider or brute-force in the run config first"
+      in Discover::PlanError::Reason::Wordlist
+        "wordlist error: #{ex.detail}"
+      end
     end
 
     # --- async drain (run-loop tick) ---


### PR DESCRIPTION
The discover slice of #356, plus the discover slice of #367.

`Discover::PlanOptions` + `Discover::Plan.build(options, outbound) : Plan` follow the
convention `Fuzz::Plan` set in 7dc9908. Each surface is now only an option parser
(`OptionParser` → CLI, args hash → MCP, view state → TUI), and `Discover::Engine.new`
has exactly one call site.

## What I unified, and why

**The scope policy now comes from the `Outbound`.** Discover is the one tool whose engine
carries a scope of its own (`ScopePolicy`, which keeps the engine Store-free), and there
were three copies of the derivation — the CLI's, MCP's (whose comment literally read
"Mirror of the CLI's `discover_policy`"), and a third, shorter one in the TUI.
`Plan.resolve_policy` derives it from the Outbound the surface hands in, which is what
makes `outbound` load-bearing for this tool rather than an unused parameter.

The task brief asked to keep the policy "a first-class `PlanOptions` field". I put it on
`Plan` instead of `PlanOptions`, because a pre-built `ScopePolicy` in the options would
have preserved exactly the three-way drift the issue exists to remove. It is still
first-class and still not folded into `Config`.

The waiver test is `Reason::Operator`, **not** `gate.waived?`: the TUI's Outbound is also
waived, for `Reason::Interactive`, and "a human typed this target" is not a request to
drop the include boundary the same human configured. `gate.waived?` there would have
handed the TUI `UnscopedStoreScope`. A mutation test confirms the spec catches it.

**The gate matches on a normalized seed.** Both surfaces gated on an un-normalized
string, and it was wrong in both directions:

| scope rule | seed | before | after |
|---|---|---|---|
| exclude regex `^https://prod\.acme\.test` | `https://PROD.acme.test/` | allowed | blocked |
| exclude string `prod.acme.test/` | `https://prod.acme.test:443/` | allowed | blocked |
| include regex `^https://acme\.test/` | `acme.test` | blocked | allowed |

`plan.seed` is `Url.normalize`d, so the gate and the crawl can never judge two spellings.
MCP additionally gated on the bare origin (`"#{Url.origin(p)}/"`), which refused a seed
inside a path-scoped project — `https://acme.test/api/v1` under an `…/api/` include. Both
surfaces now check the seed URL itself, which is the first URL the run actually requests.

**`Env.expand` runs once, on the seed and on header values.** The TUI applied neither and
rejected a bare host outright; the CLI never expanded `-H` values. Because expansion now
happens *after* parsing, `Headers.parse_lines`' CR/LF guard no longer covers it, so the
rule moved into `Headers.safe_value?` (it was written out three times) and is re-applied
in `Headers.expand`. The **seed** goes through it too: `URI.parse` keeps a raw CR/LF in
the path and `Sender#build_get` splices the target straight into the request line, so an
env var whose value carried one would have injected a second request.

**`config.user_wordlist` is the single home for the wordlist path.** `--wordlist` and
MCP's `wordlist` arg used to be passed to `Wordlist.load` separately, leaving the Config's
own copy nil on two surfaces out of three.

**MCP's `JobAudit` reads back off the plan.** `max_requests` was recorded raw while the
engine ran with `min(requested, DISCOVER_MAX_REQUESTS)` — an audit line that disagreed
with its own run. The concurrency clamp was also written out twice.

## #367 — TUI host overrides

`tui/controllers/discover_controller.cr` passed no `overrides:`, so a project host override
was silently ignored by a TUI-launched crawl while `gori run discover` pinned it. It now
passes the session's **live** `Session#host_overrides` (per #367's note) rather than a
second `HostOverrides.load(store)` copy, so an override added in the Project tab
mid-session applies to the next run.

The spec asserts the **dialled** host, not the plumbing: `.invalid` is reserved (RFC 2606)
and never resolves, so the crawl can only reach the local listener through the override,
and the paired negative test proves the same setup fails without it. Removing the
`overrides:` argument turns the suite red.

Closes #356 for discover. Closes #367 for discover.

## Notes for the other three Plan-builder agents

- `Outbound#reason == Reason::Operator` wants to be a named `Outbound#operator_waived?`
  predicate — `outbound.cr` already names `gated?` for exactly this reason — but that file
  belongs to #354. Left as a comment at the call site.
- `Fuzz::PlanOptions#overrides` defaults to `nil`, which is what let #367 happen. Making it
  a required named argument on all five builders would turn a future omission into a
  compile error. That is a shared-convention change, so I did not do it unilaterally.

## #364 (out of scope, deliberately not fixed)

`Engine#seed_frontier` still pushes the seed + `robots.txt` + `sitemap.xml` past the
Layer-2 gate. This refactor does not change that, and one spec documents it: the
policy A/B had to assert on a **crawled link**, because the seed goes out under both rule
sets. If #364 is settled as "gate them", the change is now local to
`engine.cr#seed_frontier` — the policy it needs is already the one `Plan` hands the engine,
so no surface has to be touched.

## Verification

- `just test` — 3969 examples, 0 failures (rebased on d5a11d3)
- `just check` — the two files it rewrites (`proxy/upstream.cr`, `proxy/tls/tunnel_spec.cr`)
  are pre-existing Crystal-version drift, untouched by this branch; my six files are clean
  under `crystal tool format --check` and ameba
- Smoke-tested all three surfaces against a local site: CLI (crawl, every error path, the
  scope refusal, `--allow-unscoped` reaching `UnscopedStoreScope`), MCP over stdio
  (happy path, `SCOPE_BLOCKED`, both error wordings), and the builder-level TUI path
- Every user-facing error string is byte-identical to the pre-refactor one
- `/code-review` ran with security, correctness and test-quality passes; 21 mutations were
  applied to the builder to check the spec actually fails on each
