### PR TITLE
fix(tui): use leave_overlay for the notification center's palette hop (#355)

### DIFF
--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -3861,7 +3861,10 @@ module Gori::Tui
       }
       # Close BEFORE raising the palette: the reverse order would drop @active_overlay on
       # top of the modal we just opened.
-      ov.on_palette = -> { close_active_overlay; open_palette }
+      # leave_overlay, not close_active_overlay: this exit goes somewhere else entirely, so
+      # the modal is dropped WITHOUT running on_close (a pop-back would land on top of the
+      # palette). Order matters either way — closing after open_palette would drop it.
+      ov.on_palette = -> { leave_overlay; open_palette }
       open_overlay(ov)
       @notifications.mark_all_read
     end


### PR DESCRIPTION
**main is red.** Build fix for a C1×C5 semantic merge conflict.

```
In src/gori/tui/runner.cr:3864:28
 3864 | ov.on_palette = -> { close_active_overlay; open_palette }
Error: wrong number of arguments for 'Gori::Tui::Runner#close_active_overlay' (given 0, expected 1)
```

#371 (C1) introduced the `on_palette` closure and was rebased onto `d5a11d3` (C2). #372 (C5) then retyped `close_active_overlay` to take the overlay it is closing. Both merged textually clean and both were green on their own base — only the combination fails to compile, so no branch CI could have caught it. It surfaced on main's post-merge run within minutes.

`leave_overlay` is the correct call, not a one-arg close. C5 added `leave_overlay` for precisely this exit — its own comment says *"For an exit that goes somewhere else entirely — the ^P jump to the command palette — where a nested modal's pop-back would otherwise re-open on top of the destination."* The notification center is abandoned rather than popped back, so its `on_close` must not run.

Verified on `origin/main` + this commit: `crystal build --no-codegen src/main.cr` compiles, `just test` → 4058 examples, 0 failures. Re-smoked the hop in the TUI after CI.