### PR TITLE
fix(tui): main does not compile — close_active_overlay arity after #371 + #372

### DIFF
--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -3861,7 +3861,7 @@ module Gori::Tui
       }
       # Close BEFORE raising the palette: the reverse order would drop @active_overlay on
       # top of the modal we just opened.
-      ov.on_palette = -> { close_active_overlay; open_palette }
+      ov.on_palette = -> { leave_overlay; open_palette }
       open_overlay(ov)
       @notifications.mark_all_read
     end


### PR DESCRIPTION
`origin/main` (`b377a0f`) does not compile. #371 and #372 were each CI-green on their own branch and broke the tree when combined.

```
In src/gori/tui/runner.cr:3864:28
 3864 | ov.on_palette = -> { close_active_overlay; open_palette }
Error: wrong number of arguments for 'Gori::Tui::Runner#close_active_overlay' (given 0, expected 1)
```

#372 split the teardown into `close_active_overlay(ov)` (drops the modal **and** runs its `on_close`) and `leave_overlay` (drops it **without**). #371 added the call site above against the old zero-arg signature.

**The fix is `leave_overlay`, not `close_active_overlay(ov)`.** #372's comment names this call site as the reason `leave_overlay` exists — the ^P jump to the palette, "where a nested modal's pop-back would otherwise re-open on top of the destination". Passing `ov` would compile and then re-open the notification centre over the palette.

Verified locally: `crystal build --no-codegen` clean; `overlay_dispatch_spec` + `overlay_nesting_spec` 42 examples, 0 failures.

Blocking C3, C4, C5 (#355) and plan-sequencer, plan-repeater (#356) — #375 and #377 are both red for this reason and not for anything in their own diffs.

Refs #355