### PR TITLE
refactor(tui): migrate the Preferences family onto the Overlay seam (#355)

### DIFF
--- a/spec/tui/overlay_c5_spec.cr
+++ b/spec/tui/overlay_c5_spec.cr
@@ -1,0 +1,788 @@
+require "../spec_helper"
+require "../support/memory_backend"
+require "../support/overlay_harness"
+
+include Gori::Tui
+
+# Batch C5 of the Overlay migration (#355): the Preferences family — the unified modal and
+# the theme / tab-bar / hostnames / env / hotkeys editors it opens.
+#
+# Everything here rides OverlayHarness, which replays Runner#dispatch_overlay_key /
+# #dispatch_overlay_click, so these lock the routing runner.cr no longer spells out:
+# a handle_*_key method and six `case @overlay` arms per modal were deleted, and the
+# behaviour they encoded now has to live in the overlay or in an injected closure.
+#
+# The three things worth being careful about, and why each gets examples below:
+#   * the ADD/PREFIX sub-modes of the hostnames + env editors folded into their parent
+#     overlay, so esc there must cancel the SUB-MODE and leave the modal up;
+#   * the hotkey rebinder's capture mode, which the shell routes to ahead of its own
+#     ^C/^D quit-arm — the overlay answers for that through `raw_key_capture?`;
+#   * the nested lifecycle, which was a shell-wide `@prefs_return` flag and is now
+#     `Overlay#on_close`, running on a cancel AND on a commit that closed.
+#
+# CAVEAT on driving keys: these overlays branch on `ev.key` for navigation (`key.lower_k?`)
+# and on `ev.char` for mnemonics, exactly as the deleted Runner handlers did. So a mnemonic
+# is pressed as `press(Key::LowerA, 'a')` and vim-nav as `press(Key::LowerK)` — `type` would
+# send every char on Key::LowerA and silently miss the nav branch.
+
+private ESC   = Termisu::Input::Key::Escape
+private ENTER = Termisu::Input::Key::Enter
+private SPACE = Termisu::Input::Key::Space
+private LEFT  = Termisu::Input::Key::Left
+private RIGHT = Termisu::Input::Key::Right
+private DOWN  = Termisu::Input::Key::Down
+private UP    = Termisu::Input::Key::Up
+private TAB   = Termisu::Input::Key::Tab
+private BKSP  = Termisu::Input::Key::Backspace
+private ALPHA = Termisu::Input::Key::LowerA
+
+# Press a printable mnemonic the way the terminal delivers it: the real char attached, so
+# `ev.char` sees it. The key itself is irrelevant to every mnemonic branch in this family.
+private def mnemonic(h : OverlayHarness, c : Char) : Symbol
+  h.press(ALPHA, c)
+end
+
+# ^P — the one chord every modal in this family claims, to leave for the command palette.
+private def ctrl_p(h : OverlayHarness) : Symbol
+  h.press(Termisu::Input::Key::LowerP, ctrl: true)
+end
+
+# ---------------------------------------------------------------------------------------
+# TAB BAR
+# ---------------------------------------------------------------------------------------
+
+# Hide every tab but one, so the next space hits the "last visible" refusal. Each toggle
+# succeeds until only one is left standing, whose toggle is refused — which also parks the
+# selection on that row.
+private def leave_one_visible(o : TabsOverlay) : Nil
+  o.to_prefs.each_with_index do |(_, vis), i|
+    next unless vis
+    o.set_selected(i)
+    o.toggle_selected
+  end
+end
+
+describe "C5 · TabsOverlay on the Overlay seam" do
+  it "supplies the chrome the collapsed title/hint ladders read off it" do
+    OverlayHarness.new(TabsOverlay.new).assert_chrome(OverlayKind::Tabs, "TAB BAR")
+  end
+
+  it "applies the working copy on ↵ and discards it on esc" do
+    ov = TabsOverlay.new
+    ov.on_commit = -> { true } # mirrors the open-site's save_tabs
+    h = OverlayHarness.new(ov)
+    h.press(ENTER).should eq(:closed)
+    h.commits.should eq(1)
+
+    esc = OverlayHarness.new(TabsOverlay.new)
+    esc.press(ESC).should eq(:closed)
+    esc.commits.should eq(0) # esc must never persist the working copy
+  end
+
+  it "reorders with K/J and only moves the selection with k/j" do
+    ov = TabsOverlay.new
+    before = ov.to_prefs
+    h = OverlayHarness.new(ov)
+    mnemonic(h, 'j') # selection down only
+    ov.to_prefs.should eq(before)
+    mnemonic(h, 'J') # now reorder the row the selection landed on
+    ov.to_prefs[1].should eq(before[2])
+    ov.to_prefs[2].should eq(before[1])
+  end
+
+  it "refuses to hide the last visible tab and reports the refusal as a toast" do
+    ov = TabsOverlay.new
+    toasts = [] of String
+    ov.on_toast = ->(m : String) { toasts << m; nil }
+    leave_one_visible(ov)
+    h = OverlayHarness.new(ov)
+    h.press(SPACE, ' ').should eq(:open)
+    toasts.should eq(["keep at least one tab visible"])
+    ov.to_prefs.count { |(_, vis)| vis }.should eq(1) # the hide really was refused
+  end
+
+  it "keeps the modal up while r raises the shell's reset confirm" do
+    # The confirm outlives the keystroke, so `r` must NOT close the editor — the reset
+    # lands later, from the confirm's action, on this same instance.
+    ov = TabsOverlay.new
+    resets = 0
+    ov.on_reset = -> { resets += 1; nil }
+    h = OverlayHarness.new(ov)
+    mnemonic(h, 'r').should eq(:open)
+    resets.should eq(1)
+    h.commits.should eq(0)
+  end
+
+  it "selects the clicked row, so a reorder after it moves that row and not row 0" do
+    ov = TabsOverlay.new
+    before = ov.to_prefs
+    h = OverlayHarness.new(ov)
+    h.click_in_box(5, 4).should eq(:open) # list starts at box.y+2 → third row (index 2)
+    mnemonic(h, 'J')
+    after = ov.to_prefs
+    after[2].should eq(before[3])
+    after[3].should eq(before[2])
+    after[0].should eq(before[0]) # row 0 untouched — the click really moved the selection
+  end
+
+  it "dismisses on a click away without applying anything" do
+    h = OverlayHarness.new(TabsOverlay.new)
+    h.overlay.handle_click(h.area, 0, 0).should eq(:cancel) # raw vocabulary, not just :closed
+    h.click(0, 0).should eq(:closed)
+    h.commits.should eq(0)
+  end
+
+  it "scrolls the selection with the wheel" do
+    ov = TabsOverlay.new
+    before = ov.to_prefs
+    h = OverlayHarness.new(ov)
+    h.wheel(3) # one notch, already ±3-scaled like Runner#handle_wheel
+    mnemonic(h, 'J')
+    ov.to_prefs[3].should eq(before[4]) # selection had moved to index 3
+    ov.to_prefs[4].should eq(before[3])
+  end
+
+  it "runs on_close after a commit AND after a cancel — the pop-back into Preferences" do
+    # This is what replaced @prefs_return + settle_sub_editor. Both exits have to reach it:
+    # saving the tab bar from inside the Preferences modal must land back there too, not
+    # only escaping out of it.
+    {ENTER, ESC}.each do |k|
+      ov = TabsOverlay.new
+      backs = 0
+      ov.on_close = -> { backs += 1; nil }
+      ov.on_commit = -> { true }
+      h = OverlayHarness.new(ov)
+      h.press(k).should eq(:closed)
+      backs.should eq(1), "on_close did not run for #{k}"
+    end
+  end
+
+  it "leaves the shell's ^C/^D quit-arm alone" do
+    TabsOverlay.new.raw_key_capture?.should be_false
+  end
+end
+
+# ---------------------------------------------------------------------------------------
+# HOSTNAME OVERRIDES
+# ---------------------------------------------------------------------------------------
+
+private def with_hosts(entries : Array({String, String}), &)
+  prev = Gori::Settings.hostname_overrides
+  Gori::Settings.hostname_overrides = entries
+  yield
+ensure
+  Gori::Settings.hostname_overrides = prev.not_nil!
+end
+
+# The editor wired the way its open-site wires it, minus the disk write: `on_save` reports
+# a successful persist so the toasts take their "saved" branch.
+private def hosts_editor(saves : Array(Int32)? = nil, toasts : Array(String)? = nil,
+                         persisted : Bool = true) : HostsOverlay
+  ov = HostsOverlay.new
+  ov.on_save = -> { saves.try(&.<<(1)); persisted }
+  ov.on_toast = ->(m : String) { toasts.try(&.<<(m)); nil }
+  ov
+end
+
+describe "C5 · HostsOverlay on the Overlay seam" do
+  it "supplies chrome, and swaps the hint when the add row opens" do
+    with_hosts([] of {String, String}) do
+      ov = hosts_editor
+      h = OverlayHarness.new(ov)
+      h.assert_chrome(OverlayKind::Hosts, "HOSTNAME OVERRIDES")
+      ov.hint.should contain("a add")
+      mnemonic(h, 'a')
+      ov.hint.should contain(%("IP host")) # the add row owns the bottom row while it is up
+    end
+  end
+
+  it "commits a valid entry from the add row and persists it" do
+    with_hosts([] of {String, String}) do
+      saves = [] of Int32
+      toasts = [] of String
+      ov = hosts_editor(saves, toasts)
+      h = OverlayHarness.new(ov)
+      mnemonic(h, 'a')
+      h.type("10.0.0.1 staging.acme.test")
+      h.press(ENTER).should eq(:open) # ↵ commits the ROW, never the modal
+      ov.to_overrides.should eq([{"staging.acme.test", "10.0.0.1"}])
+      saves.size.should eq(1)
+      toasts.last.should eq("host override saved — 1 total")
+    end
+  end
+
+  it "reports a failed disk write without pretending the entry was saved" do
+    with_hosts([] of {String, String}) do
+      toasts = [] of String
+      ov = hosts_editor(nil, toasts, persisted: false)
+      h = OverlayHarness.new(ov)
+      mnemonic(h, 'a')
+      h.type("10.0.0.1 staging.acme.test")
+      h.press(ENTER)
+      ov.to_overrides.size.should eq(1) # applied in memory…
+      toasts.last.should contain("could not save")
+      toasts.last.should_not contain("host override saved")
+    end
+  end
+
+  it "rejects a malformed entry with a toast and adds nothing" do
+    with_hosts([] of {String, String}) do
+      saves = [] of Int32
+      toasts = [] of String
+      ov = hosts_editor(saves, toasts)
+      h = OverlayHarness.new(ov)
+      mnemonic(h, 'a')
+      h.type("not-an-ip")
+      h.press(ENTER)
+      ov.to_overrides.should be_empty
+      saves.should be_empty # nothing to persist
+      toasts.last.should contain("need")
+    end
+  end
+
+  it "esc in the add row cancels the ROW, not the modal" do
+    # The sub-mode folded into this overlay; the shell no longer has a handle_hosts_add_key
+    # to route to, so the overlay itself has to swallow that esc.
+    with_hosts([] of {String, String}) do
+      ov = hosts_editor
+      h = OverlayHarness.new(ov)
+      mnemonic(h, 'a')
+      ov.adding?.should be_true
+      h.press(ESC).should eq(:open)
+      ov.adding?.should be_false
+      h.press(ESC).should eq(:closed) # a second esc, now in the list, closes it
+    end
+  end
+
+  it "backspace on an empty add input cancels the row, but not while it has text" do
+    with_hosts([] of {String, String}) do
+      ov = hosts_editor
+      h = OverlayHarness.new(ov)
+      mnemonic(h, 'a')
+      h.type("1")
+      h.press(BKSP)
+      ov.adding?.should be_true # deleted the char, kept the row
+      h.press(BKSP)
+      ov.adding?.should be_false # nothing left to delete → the row backs out
+    end
+  end
+
+  it "types the IP/host separator on Tab instead of jumping focus" do
+    with_hosts([] of {String, String}) do
+      saves = [] of Int32
+      ov = hosts_editor(saves)
+      h = OverlayHarness.new(ov)
+      mnemonic(h, 'a')
+      h.type("10.0.0.1")
+      h.press(TAB)
+      h.type("acme.test")
+      h.press(ENTER)
+      ov.to_overrides.should eq([{"acme.test", "10.0.0.1"}]) # Tab landed as the space
+    end
+  end
+
+  it "edits the selected row in place rather than appending a duplicate" do
+    with_hosts([{"acme.test", "10.0.0.1"}]) do
+      ov = hosts_editor
+      h = OverlayHarness.new(ov)
+      h.press(ENTER) # ↵ on a list row opens the edit form seeded with that row
+      ov.adding?.should be_true
+      9.times { h.press(BKSP) } # trim exactly "acme.test" off "10.0.0.1 acme.test"
+      h.type("beta.test")
+      h.press(ENTER)
+      ov.to_overrides.should eq([{"beta.test", "10.0.0.1"}]) # replaced, not appended
+    end
+  end
+
+  it "deletes the selected row and persists" do
+    with_hosts([{"acme.test", "10.0.0.1"}, {"beta.test", "10.0.0.2"}]) do
+      saves = [] of Int32
+      toasts = [] of String
+      ov = hosts_editor(saves, toasts)
+      h = OverlayHarness.new(ov)
+      mnemonic(h, 'd')
+      ov.to_overrides.should eq([{"beta.test", "10.0.0.2"}])
+      saves.size.should eq(1)
+      toasts.last.should eq("removed host override: acme.test")
+    end
+  end
+
+  it "navigates with k/j (the key, not the char) and the wheel" do
+    with_hosts([{"a.test", "10.0.0.1"}, {"b.test", "10.0.0.2"}, {"c.test", "10.0.0.3"}]) do
+      ov = hosts_editor
+      h = OverlayHarness.new(ov)
+      h.press(Termisu::Input::Key::LowerJ)
+      h.press(Termisu::Input::Key::LowerJ)
+      mnemonic(h, 'd')
+      ov.to_overrides.map(&.[0]).should eq(["a.test", "b.test"]) # deleted the third
+
+      ov2 = hosts_editor
+      h2 = OverlayHarness.new(ov2)
+      h2.wheel(3) # clamps to the last row on a 3-entry list
+      mnemonic(h2, 'd')
+      ov2.to_overrides.map(&.[0]).should eq(["a.test", "b.test"])
+    end
+  end
+
+  it "dismisses on a click away and selects the clicked row" do
+    with_hosts([{"a.test", "10.0.0.1"}, {"b.test", "10.0.0.2"}]) do
+      ov = hosts_editor
+      h = OverlayHarness.new(ov)
+      h.click_in_box(5, 3).should eq(:open) # list starts at box.y+2 → second row
+      mnemonic(h, 'd')
+      ov.to_overrides.map(&.[0]).should eq(["a.test"]) # the click moved the selection
+
+      away = OverlayHarness.new(hosts_editor)
+      away.overlay.handle_click(away.area, 0, 0).should eq(:cancel)
+      away.click(0, 0).should eq(:closed)
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------------------
+# ENVIRONMENT
+# ---------------------------------------------------------------------------------------
+
+private def with_env(prefix : String, vars : Array({String, String}), &)
+  prev_prefix = Gori::Settings.env_prefix
+  prev_vars = Gori::Settings.env_vars
+  Gori::Settings.env_prefix = prefix
+  Gori::Settings.env_vars = vars
+  yield
+ensure
+  Gori::Settings.env_prefix = prev_prefix.not_nil!
+  Gori::Settings.env_vars = prev_vars.not_nil!
+end
+
+private def env_editor(saves : Array(Int32)? = nil, toasts : Array(String)? = nil) : EnvOverlay
+  ov = EnvOverlay.new
+  ov.on_save = -> { saves.try(&.<<(1)); true }
+  ov.on_toast = ->(m : String) { toasts.try(&.<<(m)); nil }
+  ov
+end
+
+describe "C5 · the form overlays must not shadow the Overlay contract" do
+  it "keeps `commit` meaning the shell's commit, not the add-row field parser" do
+    # Crystal has no `override` keyword, so a form method named `commit` SILENTLY replaces
+    # `Overlay#commit`, which the shell calls to run the injected closure and decide whether
+    # to close. Both editors used to name their "parse the IP host / KEY VALUE row" method
+    # exactly that; it was inert only because neither returns a :commit outcome today, and it
+    # would have broken the moment one did — the shell would run the parser and read its
+    # truthy Symbol (`:empty`!) as "close me", never running on_commit.
+    #
+    # Driven through an `Overlay`-typed reference, which is how the shell holds it, so the
+    # example fails the same way the shell would.
+    with_hosts([] of {String, String}) do
+      with_env("$", [] of {String, String}) do
+        {HostsOverlay.new.as(Overlay), EnvOverlay.new.as(Overlay)}.each do |ov|
+          ran = 0
+          ov.on_commit = -> { ran += 1; true }
+          ov.commit.should be_true # Bool, not a Symbol
+          ran.should eq(1), "#{ov.class} shadowed Overlay#commit with its own method"
+        end
+      end
+    end
+  end
+end
+
+describe "C5 · EnvOverlay on the Overlay seam" do
+  it "supplies chrome, and its hint tracks BOTH sub-modes" do
+    # This replaced env_overlay_hints, the one hint the Runner computed in a method rather
+    # than a `case` arm — three states, all of which have to survive the move.
+    with_env("$", [] of {String, String}) do
+      ov = env_editor
+      h = OverlayHarness.new(ov)
+      h.assert_chrome(OverlayKind::Env, "ENVIRONMENT")
+      ov.hint.should contain("p prefix")
+      mnemonic(h, 'a')
+      ov.hint.should contain(%("KEY VALUE"))
+      h.press(ESC)
+      mnemonic(h, 'p')
+      ov.hint.should contain("type prefix")
+    end
+  end
+
+  it "commits a KEY VALUE pair from the add row and persists it" do
+    with_env("$", [] of {String, String}) do
+      saves = [] of Int32
+      toasts = [] of String
+      ov = env_editor(saves, toasts)
+      h = OverlayHarness.new(ov)
+      mnemonic(h, 'a')
+      h.type("HOST api.example.com")
+      h.press(ENTER).should eq(:open)
+      ov.to_config[1].should eq([{"HOST", "api.example.com"}])
+      saves.size.should eq(1)
+      toasts.last.should eq("env var saved — 1 total")
+    end
+  end
+
+  it "rejects a malformed pair and refuses a duplicate KEY" do
+    with_env("$", [{"HOST", "api.example.com"}]) do
+      toasts = [] of String
+      ov = env_editor(nil, toasts)
+      h = OverlayHarness.new(ov)
+      mnemonic(h, 'a')
+      h.type("1BAD value")
+      h.press(ENTER).should eq(:open) # the row stays up, holding the rejected text
+      toasts.last.should contain("KEY is")
+      ov.to_config[1].should eq([{"HOST", "api.example.com"}])
+
+      h.press(ESC) # back out of the add row, then start a clean one
+      mnemonic(h, 'a')
+      h.type("HOST other")
+      h.press(ENTER)
+      toasts.last.should eq("env var: KEY already defined")
+      ov.to_config[1].should eq([{"HOST", "api.example.com"}]) # unchanged
+    end
+  end
+
+  it "edits the prefix sigil in its own sub-mode, which esc backs out of" do
+    with_env("$", [] of {String, String}) do
+      saves = [] of Int32
+      toasts = [] of String
+      ov = env_editor(saves, toasts)
+      h = OverlayHarness.new(ov)
+      mnemonic(h, 'p')
+      ov.prefix_editing?.should be_true
+      h.press(ESC).should eq(:open) # cancels the SUB-MODE, not the modal
+      ov.prefix_editing?.should be_false
+      ov.to_config[0].should eq("$")
+
+      mnemonic(h, 'p')
+      h.press(BKSP) # clear the seeded "$"
+      h.type("%")
+      h.press(ENTER).should eq(:open)
+      ov.to_config[0].should eq("%")
+      saves.size.should eq(1)
+      toasts.last.should eq(%(env prefix saved — "%"))
+    end
+  end
+
+  it "rejects an empty prefix instead of persisting a blank sigil" do
+    with_env("$", [] of {String, String}) do
+      saves = [] of Int32
+      toasts = [] of String
+      ov = env_editor(saves, toasts)
+      h = OverlayHarness.new(ov)
+      mnemonic(h, 'p')
+      h.press(BKSP)
+      h.press(ENTER)
+      toasts.last.should eq("env prefix: empty")
+      saves.should be_empty
+      ov.to_config[0].should eq("$")
+    end
+  end
+
+  it "deletes the selected var and persists" do
+    with_env("$", [{"HOST", "a"}, {"TOKEN", "b"}]) do
+      saves = [] of Int32
+      toasts = [] of String
+      ov = env_editor(saves, toasts)
+      h = OverlayHarness.new(ov)
+      h.press(DOWN)
+      mnemonic(h, 'd')
+      ov.to_config[1].should eq([{"HOST", "a"}])
+      saves.size.should eq(1)
+      toasts.last.should eq("removed env: TOKEN")
+    end
+  end
+
+  it "esc closes from the list, and a click away dismisses" do
+    with_env("$", [] of {String, String}) do
+      h = OverlayHarness.new(env_editor)
+      h.press(ESC).should eq(:closed)
+
+      away = OverlayHarness.new(env_editor)
+      away.overlay.handle_click(away.area, 0, 0).should eq(:cancel)
+      away.click(0, 0).should eq(:closed)
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------------------
+# HOTKEYS — the capture-mode carve-out
+# ---------------------------------------------------------------------------------------
+
+private def fresh_hotkeys : HotkeysOverlay
+  Gori::Settings.keymap_os = "auto"
+  Gori::Settings.keymap_overrides = {} of String => Array(String)
+  HotkeysOverlay.new(Gori::Verbs.registry)
+end
+
+private def reset_keymap : Nil
+  Gori::Settings.keymap_os = "auto"
+  Gori::Settings.keymap_overrides = {} of String => Array(String)
+end
+
+describe "C5 · HotkeysOverlay on the Overlay seam" do
+  it "supplies chrome, and its hint switches to the capture prompt" do
+    ov = fresh_hotkeys
+    OverlayHarness.new(ov).assert_chrome(OverlayKind::Hotkeys, "HOTKEYS")
+    ov.hint.should contain("rebind")
+    ov.begin_capture
+    ov.hint.should eq("press a key to bind · esc cancel")
+  ensure
+    reset_keymap
+  end
+
+  it "claims every key ahead of the shell's pre-filter ONLY while capturing" do
+    # runner.cr:975 — the global ^C/^D quit-arm is skipped, and the key handed straight to
+    # the modal, exactly when this is true. If it answered true in browse mode the app
+    # could no longer be quit from the hotkeys editor; if it answered false in capture,
+    # binding ^C/^D would arm a quit instead of being rejected inline by reserved.cr.
+    ov = fresh_hotkeys
+    ov.raw_key_capture?.should be_false
+    ov.begin_capture
+    ov.raw_key_capture?.should be_true
+    ov.cancel_capture
+    ov.raw_key_capture?.should be_false
+  ensure
+    reset_keymap
+  end
+
+  it "records the next key as a binding and returns to browse" do
+    ov = fresh_hotkeys
+    h = OverlayHarness.new(ov)
+    mnemonic(h, 'e') # e/␣ enter capture on the selected row
+    ov.capturing?.should be_true
+    h.press(Termisu::Input::Key::LowerY, 'y', alt: true).should eq(:open)
+    ov.capturing?.should be_false
+    working, _ = ov.to_working
+    working.values.first.should eq(Gori::Verb::Chord.new("y", alt: true))
+  ensure
+    reset_keymap
+  end
+
+  it "esc in capture backs out to browse and binds nothing" do
+    ov = fresh_hotkeys
+    h = OverlayHarness.new(ov)
+    mnemonic(h, ' ')
+    ov.capturing?.should be_true
+    h.press(ESC).should eq(:open) # NOT a modal dismiss — capture owns that esc
+    ov.capturing?.should be_false
+    ov.to_working[0].should be_empty
+    h.press(ESC).should eq(:closed) # …and now the browse esc does close it
+  ensure
+    reset_keymap
+  end
+
+  it "stays in capture on a reserved chord instead of applying it" do
+    ov = fresh_hotkeys
+    h = OverlayHarness.new(ov)
+    mnemonic(h, 'e')
+    h.press(Termisu::Input::Key::LowerC, 'c', ctrl: true).should eq(:open)
+    ov.capturing?.should be_true # reserved.cr rejected it inline
+    ov.to_working[0].should be_empty
+    h.rendered?("quits gori").should be_true # and said why, in the card's footer
+  ensure
+    reset_keymap
+  end
+
+  it "applies the working copy on ↵ and discards it on esc" do
+    ov = fresh_hotkeys
+    ov.on_commit = -> { true } # mirrors save_hotkeys at the open-site
+    h = OverlayHarness.new(ov)
+    h.press(ENTER).should eq(:closed)
+    h.commits.should eq(1)
+
+    esc = OverlayHarness.new(fresh_hotkeys)
+    esc.press(ESC).should eq(:closed)
+    esc.commits.should eq(0)
+  ensure
+    reset_keymap
+  end
+
+  it "cycles the OS profile with ←/→ and dismisses on a click away" do
+    ov = fresh_hotkeys
+    h = OverlayHarness.new(ov)
+    h.press(RIGHT).should eq(:open)
+    ov.to_working[1].should_not eq("auto")
+    h.press(LEFT)
+    ov.to_working[1].should eq("auto")
+
+    away = OverlayHarness.new(fresh_hotkeys)
+    away.overlay.handle_click(away.area, 0, 0).should eq(:cancel)
+    away.click(0, 0).should eq(:closed)
+  ensure
+    reset_keymap
+  end
+end
+
+# ---------------------------------------------------------------------------------------
+# SETTINGS CARD (the theme swatch list)
+# ---------------------------------------------------------------------------------------
+
+private def with_theme(name : String, &)
+  prev = Gori::Settings.theme
+  Gori::Settings.theme = name
+  yield
+ensure
+  Gori::Settings.theme = prev.not_nil!
+  Theme.apply(prev.not_nil!)
+end
+
+describe "C5 · SettingsOverlay on the Overlay seam" do
+  it "supplies the chrome the collapsed ladders read off it" do
+    with_theme("gori") do
+      OverlayHarness.new(SettingsOverlay.new(:theme)).assert_chrome(OverlayKind::Settings, "SETTINGS")
+    end
+  end
+
+  it "live-previews the theme the selection lands on, by key and by wheel" do
+    with_theme("gori") do
+      ov = SettingsOverlay.new(:theme)
+      previews = [] of String?
+      ov.on_preview = -> { previews << ov.theme_value; nil }
+      h = OverlayHarness.new(ov)
+      h.press(DOWN)
+      h.wheel(1)
+      previews.size.should eq(2)
+      previews.compact.size.should eq(2)          # :theme always names a theme
+      previews.uniq.size.should eq(previews.size) # each step landed on a DIFFERENT theme
+    end
+  end
+
+  it "saves the focused section on ↵ and hands the toast to the shell, staying open" do
+    with_theme("gori") do
+      ov = SettingsOverlay.new(:theme)
+      saved = [] of {Symbol, String}
+      ov.on_save = ->(sec : Symbol, msg : String) { saved << {sec, msg}; nil }
+      h = OverlayHarness.new(ov)
+      h.press(DOWN)
+      h.press(ENTER).should eq(:open) # ↵ saves the section; it does NOT close the card
+      saved.size.should eq(1)
+      saved.first[0].should eq(:theme)
+      Gori::Settings.theme.should_not eq("gori") # the moved-to theme really persisted
+    end
+  end
+
+  it "keeps the card up while ^R raises the shell's reset confirm" do
+    with_theme("gori") do
+      ov = SettingsOverlay.new(:theme)
+      resets = 0
+      ov.on_reset = -> { resets += 1; nil }
+      h = OverlayHarness.new(ov)
+      h.press(Termisu::Input::Key::LowerR, ctrl: true).should eq(:open)
+      resets.should eq(1)
+    end
+  end
+
+  it "cancels on esc and on a click away, so the shell can revert the preview" do
+    with_theme("gori") do
+      h = OverlayHarness.new(SettingsOverlay.new(:theme))
+      h.press(ESC).should eq(:closed)
+      h.closes.should eq(1) # on_close is where revert_theme_preview hangs
+
+      away = OverlayHarness.new(SettingsOverlay.new(:theme))
+      away.overlay.handle_click(away.area, 0, 0).should eq(:cancel)
+      away.click(0, 0).should eq(:closed)
+    end
+  end
+
+  it "opens an action row's own editor instead of saving the section" do
+    # Network's "Hostname overrides" row. The card only ever shows :theme in-app, but the
+    # opener path is the field engine's, not the theme section's — and the same branch
+    # serves the mouse (click) and the keyboard (↵).
+    with_theme("gori") do
+      ov = SettingsOverlay.new(:network)
+      opened = [] of Symbol
+      ov.on_open_editor = ->(sec : Symbol) { opened << sec; nil }
+      saved = 0
+      ov.on_save = ->(_s : Symbol, _m : String) { saved += 1; nil }
+      h = OverlayHarness.new(ov)
+      8.times { h.press(DOWN) } # walk to the last NETWORK field, the Hostnames opener
+      h.press(ENTER).should eq(:open)
+      opened.should eq([:hosts])
+      saved.should eq(0) # an opener row must not persist the section
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------------------
+# PREFERENCES — the parent of the nested lifecycle
+# ---------------------------------------------------------------------------------------
+
+describe "C5 · PreferencesOverlay on the Overlay seam" do
+  it "supplies the chrome the collapsed ladders read off it" do
+    OverlayHarness.new(PreferencesOverlay.new).assert_chrome(OverlayKind::Preferences, "PREFERENCES")
+  end
+
+  it "closes on esc when clean, and only after the warning when edits are pending" do
+    # The view owns this guard; what the overlay adds is the mapping — a warning is :stay,
+    # a real close is :cancel. Collapsing both to :cancel would drop typed input silently.
+    h = OverlayHarness.new(PreferencesOverlay.new)
+    h.press(ESC).should eq(:closed)
+
+    dirty = PreferencesOverlay.new(:general)
+    d = OverlayHarness.new(dirty)
+    d.press(SPACE, ' ') # flip a toggle in the focused section
+    d.press(ESC).should eq(:open)
+    d.press(ESC).should eq(:closed)
+  end
+
+  it "stays up when an opener row hands off to its dedicated editor" do
+    # :open must NOT be :commit or :cancel. The shell's closure opens the editor, which
+    # replaces @active_overlay itself — a :cancel here would then close the EDITOR the
+    # closure just opened, one keystroke after it appeared.
+    ov = PreferencesOverlay.new(:theme)
+    opened = [] of Symbol
+    ov.on_open_editor = ->(sec : Symbol) { opened << sec; nil }
+    h = OverlayHarness.new(ov)
+    h.press(ENTER).should eq(:open)
+    opened.should eq([:theme])
+    h.commits.should eq(0)
+    h.closes.should eq(0) # nothing closed → no pop-back fired
+  end
+
+  it "reports a save to the shell without closing the modal" do
+    prev = Gori::Settings.clipboard_osc52?
+    begin
+      ov = PreferencesOverlay.new(:general)
+      saved = [] of Symbol
+      ov.on_saved = ->(sec : Symbol, _m : String) { saved << sec; nil }
+      h = OverlayHarness.new(ov)
+      h.press(SPACE, ' ') # flip the focused toggle so the save has something to persist
+      h.press(ENTER).should eq(:open)
+      saved.should eq([:general])
+      Gori::Settings.clipboard_osc52?.should eq(!prev)
+    ensure
+      Gori::Settings.clipboard_osc52 = prev
+    end
+  end
+
+  it "hands ^P to the shell and lets IT leave the stack" do
+    # The palette jump can't be a :cancel: Runner#jump_to_palette drops the whole stack
+    # WITHOUT running on_close, precisely so a nested editor's pop-back doesn't re-open on
+    # top of the palette. Returning :cancel here would run this modal's on_close instead.
+    ov = PreferencesOverlay.new
+    jumps = 0
+    ov.on_palette = -> { jumps += 1; nil }
+    h = OverlayHarness.new(ov)
+    ctrl_p(h).should eq(:open)
+    jumps.should eq(1)
+    h.closes.should eq(0)
+  end
+
+  it "dismisses on a click away, through the same unsaved-edits guard as esc" do
+    h = OverlayHarness.new(PreferencesOverlay.new)
+    h.overlay.handle_click(h.area, 0, 0).should eq(:cancel)
+    h.click(0, 0).should eq(:closed)
+
+    dirty = PreferencesOverlay.new(:general)
+    d = OverlayHarness.new(dirty)
+    d.press(SPACE, ' ')
+    d.click(0, 0).should eq(:open) # a stray click must not discard what was typed
+    d.click(0, 0).should eq(:closed)
+  end
+
+  it "moves the field focus with the wheel" do
+    # Asserted through the rendered card because the focused row is private state; the
+    # highlight is the only thing the user can actually see move.
+    h = OverlayHarness.new(PreferencesOverlay.new(:general))
+    before = (0...24).map { |y| h.render.row(y) }
+    h.wheel(3)
+    after = (0...24).map { |y| h.render.row(y) }
+    after.should_not eq(before)
+  end
+end

--- a/spec/tui/overlay_dispatch_spec.cr
+++ b/spec/tui/overlay_dispatch_spec.cr
@@ -67,6 +67,13 @@ private MIGRATED_KINDS = [
   OverlayKind::Links,
   OverlayKind::IssuePick,
   OverlayKind::NotePick,
+  # C5 — the Preferences family
+  OverlayKind::Preferences,
+  OverlayKind::Settings,
+  OverlayKind::Tabs,
+  OverlayKind::Hosts,
+  OverlayKind::Env,
+  OverlayKind::Hotkeys,
 ]
 
 # Never in MODAL_OVERLAYS by design, migrated or not. `None` is "no modal at all" and

--- a/src/gori/tui/env_overlay.cr
+++ b/src/gori/tui/env_overlay.cr
@@ -2,6 +2,7 @@ require "./screen"
 require "./theme"
 require "./frame"
 require "./highlight"
+require "./overlay"
 require "../settings"
 require "../env"
 
@@ -9,7 +10,14 @@ module Gori::Tui
   # Global environment-variable editor (settings:env). Edits a working copy of the
   # prefix sigil + {key, value} pairs; the Runner persists to Settings on every
   # mutation. Entry form: "KEY VALUE" or "KEY=value".
-  class EnvOverlay
+  class EnvOverlay < Overlay
+    # Injected at the open-site (Runner#open_settings). Like the Hostnames editor this one
+    # persists on every mutation rather than on ↵, so esc just closes and the base
+    # `on_commit` is never reached; `on_save` reports whether the write landed.
+    property on_palette : Proc(Nil)?
+    property on_save : Proc(Bool)?
+    property on_toast : Proc(String, Nil)?
+
     def initialize
       @items = [] of {String, String}
       @prefix = Settings.env_prefix
@@ -41,6 +49,142 @@ module Gori::Tui
 
     def prefix_editing? : Bool
       @prefix_editing
+    end
+
+    # --- Overlay contract (see overlay.cr) ---
+    def key : OverlayKind
+      OverlayKind::Env
+    end
+
+    def title : String
+      "ENVIRONMENT"
+    end
+
+    def hint : String
+      return "type prefix · ↵ save · esc cancel" if @prefix_editing
+      return %(type "KEY VALUE" · ↵ save · esc cancel) if @adding
+      "↑/↓ select · a add · ↵/e edit · d delete · p prefix · esc close"
+    end
+
+    # a add · ↵/e edit · d delete · p edit the prefix sigil · esc close. ^P jumps back to
+    # the palette. The prefix and add/edit rows are sub-modes of this same overlay — each
+    # owns every key while open — not separate shell states.
+    def handle_key(ev : Termisu::Event::Key) : Symbol
+      return handle_prefix_key(ev) if @prefix_editing
+      return handle_add_key(ev) if @adding
+      key = ev.key
+      if ev.ctrl? && key.lower_p?
+        on_palette.try(&.call)
+      elsif key.escape?
+        return :cancel
+      elsif key.up? || key.lower_k?
+        select_move(-1)
+      elsif key.down? || key.lower_j?
+        select_move(1)
+      elsif key.enter?
+        edit_start
+      else
+        handle_list_char(ev.char || key.to_char)
+      end
+      :stay
+    end
+
+    private def handle_list_char(c : Char?) : Nil
+      case c
+      when 'e' then edit_start
+      when 'a' then add_start
+      when 'p' then prefix_edit_start
+      when 'd' then delete_and_persist
+      end
+    end
+
+    private def handle_prefix_key(ev : Termisu::Event::Key) : Symbol
+      key = ev.key
+      c = ev.char || key.to_char
+      if key.escape?
+        cancel_prefix_edit
+      elsif key.enter?
+        commit_prefix_and_persist
+      elsif key.left?
+        move_cursor(-1)
+      elsif key.right?
+        move_cursor(1)
+      elsif key.backspace?
+        cancel_prefix_edit unless backspace
+      elsif c && !ev.ctrl? && !ev.alt?
+        input(c)
+        set_preedit("")
+      end
+      :stay
+    end
+
+    private def handle_add_key(ev : Termisu::Event::Key) : Symbol
+      key = ev.key
+      c = ev.char || key.to_char
+      if key.escape?
+        cancel_add
+      elsif key.enter?
+        commit_and_persist
+      elsif key.left?
+        move_cursor(-1)
+      elsif key.right?
+        move_cursor(1)
+      elsif key.backspace?
+        cancel_add unless backspace
+      elsif key.tab?
+        input(' ') # Tab types the KEY/VALUE separator, not a focus jump
+        set_preedit("")
+      elsif c && !ev.ctrl? && !ev.alt?
+        input(c)
+        set_preedit("")
+      end
+      :stay
+    end
+
+    private def commit_prefix_and_persist : Nil
+      case commit_prefix
+      when :empty then toast("env prefix: empty")
+      when :ok
+        toast(persist ? "env prefix saved — #{@prefix.inspect}" : "prefix applied — could not save to #{Settings.path}")
+      end
+    end
+
+    private def commit_and_persist : Nil
+      case commit_entry
+      when :empty   then toast("env var: empty")
+      when :invalid then toast(%(env var: need "KEY VALUE" or "KEY=value" — KEY is [A-Za-z_][A-Za-z0-9_]*))
+      when :dup     then toast("env var: KEY already defined")
+      when :ok
+        toast(persist ? "env var saved — #{@items.size} total" : "env var applied — could not save to #{Settings.path}")
+      end
+    end
+
+    private def delete_and_persist : Nil
+      return unless key_name = delete_selected
+      toast(persist ? "removed env: #{key_name}" : "removed #{key_name} — could not save to #{Settings.path}")
+    end
+
+    private def persist : Bool
+      (s = on_save) ? s.call : true
+    end
+
+    private def toast(msg : String) : Nil
+      on_toast.try(&.call(msg))
+    end
+
+    # A click outside dismisses (esc); a row click selects it (add/edit/delete stay
+    # keyboard-driven).
+    def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      box = overlay_box(area)
+      return :cancel if box.nil? || !box.contains?(mx, my)
+      if idx = row_at(box, mx, my)
+        set_selected(idx)
+      end
+      :stay
+    end
+
+    def move(step : Int32) : Nil
+      select_move(step)
     end
 
     def select_move(d : Int32) : Nil
@@ -124,7 +268,13 @@ module Gori::Tui
       :ok
     end
 
-    def commit : Symbol
+    # NOT `commit`: that name belongs to `Overlay`, whose `commit : Bool` runs the injected
+    # on_commit closure and tells the shell whether to close. Crystal has no `override`
+    # keyword, so naming this one `commit` silently replaced the base contract — inert only
+    # because this editor never returns a :commit outcome (it persists per mutation), and a
+    # landmine the moment one is added: the shell would run this field parser instead of the
+    # closure and read its truthy Symbol as "close me". (`commit_prefix` does not collide.)
+    def commit_entry : Symbol
       text = @input.strip
       return :empty if text.empty?
       parsed = Env.parse_line(text)

--- a/src/gori/tui/hosts_overlay.cr
+++ b/src/gori/tui/hosts_overlay.cr
@@ -1,6 +1,7 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./overlay"
 require "../settings"
 require "../host_overrides"
 
@@ -16,7 +17,15 @@ module Gori::Tui
   # HOST OVERRIDES pane.
   #
   #   10.0.0.1     → staging.acme.test   ▎ selected
-  class HostsOverlay
+  class HostsOverlay < Overlay
+    # Injected at the open-site (Runner#open_settings). `on_save` persists the working copy
+    # and reports whether the write landed, so the toast can tell "saved" from
+    # "applied but not written". There is no ↵-to-commit here — every mutation persists
+    # immediately, so esc just closes and the base `on_commit` is never reached.
+    property on_palette : Proc(Nil)?
+    property on_save : Proc(Bool)?
+    property on_toast : Proc(String, Nil)?
+
     def initialize
       @items = [] of {String, String} # {host, ip}
       @selected = 0
@@ -43,6 +52,113 @@ module Gori::Tui
 
     def adding? : Bool
       @adding
+    end
+
+    # --- Overlay contract (see overlay.cr) ---
+    def key : OverlayKind
+      OverlayKind::Hosts
+    end
+
+    def title : String
+      "HOSTNAME OVERRIDES"
+    end
+
+    def hint : String
+      return %(type "IP host" · ↵ save · esc cancel) if @adding
+      "↑/↓ select · a add · ↵/e edit · d delete · esc close"
+    end
+
+    # a add · ↵/e edit · d delete · esc close. ^P jumps back to the palette. The add/edit
+    # row is a sub-mode of this same overlay (it owns every key while open), not a
+    # separate shell state.
+    def handle_key(ev : Termisu::Event::Key) : Symbol
+      return handle_add_key(ev) if @adding
+      key = ev.key
+      if ev.ctrl? && key.lower_p?
+        on_palette.try(&.call)
+      elsif key.escape?
+        return :cancel
+      elsif key.up? || key.lower_k?
+        select_move(-1)
+      elsif key.down? || key.lower_j?
+        select_move(1)
+      elsif key.enter?
+        edit_start
+      else
+        handle_list_char(ev.char || key.to_char)
+      end
+      :stay
+    end
+
+    private def handle_list_char(c : Char?) : Nil
+      case c
+      when 'e' then edit_start
+      when 'a' then add_start
+      when 'd' then delete_and_persist
+      end
+    end
+
+    # The inline add/edit row: type "IP host", ↵ commits, ⌫ on an empty input cancels,
+    # esc cancels. Never closes the overlay — it drops back to the list.
+    private def handle_add_key(ev : Termisu::Event::Key) : Symbol
+      key = ev.key
+      c = ev.char || key.to_char
+      if key.escape?
+        cancel_add
+      elsif key.enter?
+        commit_and_persist
+      elsif key.left?
+        move_cursor(-1)
+      elsif key.right?
+        move_cursor(1)
+      elsif key.backspace?
+        cancel_add unless backspace
+      elsif key.tab?
+        input(' ') # Tab types the IP/host separator, not a focus jump
+        set_preedit("")
+      elsif c && !ev.ctrl? && !ev.alt?
+        input(c)
+        set_preedit("")
+      end
+      :stay
+    end
+
+    private def delete_and_persist : Nil
+      return unless host = delete_selected
+      toast(persist ? "removed host override: #{host}" : "removed #{host} — could not save to #{Settings.path}")
+    end
+
+    private def commit_and_persist : Nil
+      case commit_entry
+      when :empty   then toast("host override: empty")
+      when :invalid then toast(%(host override: need "IP host" — a valid IP + a hostname))
+      when :dup     then toast("host override: host already mapped")
+      when :ok
+        toast(persist ? "host override saved — #{@items.size} total" : "host override applied — could not save to #{Settings.path}")
+      end
+    end
+
+    private def persist : Bool
+      (s = on_save) ? s.call : true
+    end
+
+    private def toast(msg : String) : Nil
+      on_toast.try(&.call(msg))
+    end
+
+    # A click outside dismisses (esc); a row click selects it (add/edit/delete stay
+    # keyboard-driven).
+    def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      box = overlay_box(area)
+      return :cancel if box.nil? || !box.contains?(mx, my)
+      if idx = row_at(box, mx, my)
+        set_selected(idx)
+      end
+      :stay
+    end
+
+    def move(step : Int32) : Nil
+      select_move(step)
     end
 
     def select_move(d : Int32) : Nil
@@ -103,7 +219,14 @@ module Gori::Tui
     # Commit the add/edit row ("IP host", /etc/hosts order). Returns :ok|:empty|:invalid|
     # :dup. On :ok the working copy is mutated (the Runner then persists). Dedupes on the
     # host (excluding the row being edited).
-    def commit : Symbol
+    #
+    # NOT `commit`: that name belongs to `Overlay`, whose `commit : Bool` runs the injected
+    # on_commit closure and tells the shell whether to close. Crystal has no `override`
+    # keyword, so naming this one `commit` silently replaced the base contract — inert only
+    # because this editor never returns a :commit outcome (it persists per mutation), and a
+    # landmine the moment one is added: the shell would run this field parser instead of the
+    # closure and read its truthy Symbol as "close me".
+    def commit_entry : Symbol
       text = @input.strip
       return :empty if text.empty?
       parsed = HostOverrides.parse_line(text)

--- a/src/gori/tui/hotkeys_overlay.cr
+++ b/src/gori/tui/hotkeys_overlay.cr
@@ -2,6 +2,7 @@ require "./screen"
 require "./theme"
 require "./frame"
 require "./keybind"
+require "./overlay"
 require "../verb"
 require "../hotkeys"
 require "../settings"
@@ -14,9 +15,13 @@ module Gori::Tui
   # checks block a bad capture inline. An OS default profile (auto/macOS/Linux/Windows) is
   # cycled with ←/→. Reads every effective chord through Gori::Hotkeys so the view never
   # drifts from the live keymap.
-  class HotkeysOverlay
+  class HotkeysOverlay < Overlay
     # A rendered line: a scope :header or a rebindable verb :binding.
     record Row, kind : Symbol, verb_id : String, scope : Verb::Scope, title : String
+
+    # Injected at the open-site (Runner#open_settings): ^P leaves the modal stack for the
+    # command palette. ↵ persists + rebuilds the live keymap via the base `on_commit`.
+    property on_palette : Proc(Nil)?
 
     SCOPE_LABEL = {
       Verb::Scope::Global        => "GLOBAL",
@@ -85,6 +90,94 @@ module Gori::Tui
 
     def to_working : {Hash(String, Verb::Chord?), String}
       {@overrides, @profile}
+    end
+
+    # --- Overlay contract (see overlay.cr) ---
+    def key : OverlayKind
+      OverlayKind::Hotkeys
+    end
+
+    def title : String
+      "HOTKEYS"
+    end
+
+    def hint : String
+      return "press a key to bind · esc cancel" if capturing?
+      "↑/↓ select · e/␣ rebind · x unbind · r reset · ⇧R reset all · ←/→ profile · ↵ save · esc"
+    end
+
+    # In :capture the shell must route EVERY key here before its own pre-filter, so a
+    # chord like ^C/^D can be recorded as a binding instead of arming the global quit
+    # (reserved.cr then rejects it inline with "Ctrl-C/D quits gori" while staying in
+    # capture). That precedence is the whole reason capture mode needs a shell carve-out.
+    def raw_key_capture? : Bool
+      capturing?
+    end
+
+    def handle_key(ev : Termisu::Event::Key) : Symbol
+      capturing? ? handle_capture_key(ev) : handle_browse_key(ev)
+    end
+
+    # :capture — the next key IS the new binding.
+    private def handle_capture_key(ev : Termisu::Event::Key) : Symbol
+      if ev.key.escape?
+        cancel_capture
+      elsif chord = Keybind.from_event(ev)
+        apply_capture(chord) # reserved/conflict → inline error, stays in capture
+      end
+      # an unmappable key (non-ASCII / a bare modifier) is ignored — capture stays open
+      :stay
+    end
+
+    # :browse — navigate/edit the list. ↵ saves+applies, esc discards the working copy.
+    private def handle_browse_key(ev : Termisu::Event::Key) : Symbol
+      key = ev.key
+      if ev.ctrl? && key.lower_p?
+        on_palette.try(&.call)
+      elsif key.escape?
+        return :cancel # discard the working copy
+      elsif key.enter?
+        return :commit
+      elsif key.up?
+        select_move(-1)
+      elsif key.down?
+        select_move(1)
+      elsif key.left?
+        cycle_profile(-1)
+      elsif key.right?
+        cycle_profile(1)
+      elsif key.backspace?
+        unbind_selected
+      elsif c = ev.char
+        handle_char(c)
+      end
+      :stay
+    end
+
+    private def handle_char(c : Char) : Nil
+      case c
+      when 'e', ' ' then begin_capture
+      when 'x'      then unbind_selected
+      when 'r'      then reset_selected
+      when 'R'      then reset_all
+      when 'k'      then select_move(-1)
+      when 'j'      then select_move(1)
+      end
+    end
+
+    # A click outside dismisses (discards the working copy, like esc); a row click selects
+    # that binding (rebind/unbind/reset stay keyboard-driven).
+    def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      box = overlay_box(area)
+      return :cancel if box.nil? || !box.contains?(mx, my)
+      if idx = row_at(box, mx, my)
+        set_selected(idx)
+      end
+      :stay
+    end
+
+    def move(step : Int32) : Nil
+      select_move(step)
     end
 
     private def selected_id : String

--- a/src/gori/tui/overlay.cr
+++ b/src/gori/tui/overlay.cr
@@ -183,6 +183,14 @@ module Gori::Tui
     def set_preedit(text : String) : Nil
     end
 
+    # True while the overlay is recording a RAW chord (the hotkey rebinder's capture
+    # mode). The shell then hands it every key BEFORE its own pre-filter, so ^C/^D reach
+    # the overlay as bindable chords instead of arming the global quit. Default false —
+    # no other modal wants the shell's chords, and the pre-filter must keep claiming them.
+    def raw_key_capture? : Bool
+      false
+    end
+
     # Run the injected commit closure. Returns true when the shell should close the
     # overlay (default true when no closure was supplied).
     def commit : Bool

--- a/src/gori/tui/preferences_view.cr
+++ b/src/gori/tui/preferences_view.cr
@@ -2,6 +2,7 @@ require "./settings_catalog"
 require "./settings_view"
 require "./frame"
 require "./chrome"
+require "./overlay"
 
 module Gori::Tui
   # The unified Preferences modal — ONE grouped settings surface reachable everywhere:
@@ -311,7 +312,8 @@ module Gori::Tui
 
     # The centred modal card. Height fits the tallest group's content (so switching groups
     # doesn't resize the card), capped to the terminal; content scrolls when it overflows.
-    private def overlay_box(area : Rect) : Rect
+    # Public because PreferencesOverlay exposes it as the shell's click-away hit-test.
+    def overlay_box(area : Rect) : Rect
       tallest = SettingsCatalog::GROUPS.max_of { |g| height_of(g[0]) }
       w = {area.w - 4, 82}.min
       # Fit the tallest group's content but never exceed the area — on a short terminal h
@@ -539,6 +541,85 @@ module Gori::Tui
         row += 1 # spacer
       end
       nil
+    end
+  end
+
+  # The unified Preferences modal on the Overlay seam (@overlay is :preferences).
+  # PreferencesView stays a plain view because the project picker drives it too, with its
+  # own `@mode` state machine and no Overlay seam — so the modal is this thin Overlay
+  # around it, translating the view's Outcome into the shell's :stay | :commit | :cancel.
+  #
+  # Only :close ends the modal. A save or an opener row is a side effect that leaves it
+  # up: the modal stacks several sections (↵ saves the focused one) and a dedicated editor
+  # opened from an opener row returns INTO it — see Overlay#on_close, which the open-site
+  # wires for exactly that.
+  class PreferencesOverlay < Overlay
+    property on_palette : Proc(Nil)?
+    property on_saved : Proc(Symbol, String, Nil)?
+    property on_open_editor : Proc(Symbol, Nil)?
+
+    getter view : PreferencesView
+
+    # `section` positions the modal on one section (the "Settings: …" palette entries);
+    # nil lands on the group strip (Ctrl+, / the ⚙ top-bar chip).
+    def initialize(section : Symbol? = nil)
+      @view = PreferencesView.new
+      section ? @view.open(section) : @view.open_default
+    end
+
+    # Re-pull ONE section after a dedicated editor changed what a form row summarizes —
+    # the Hostnames editor moves Network's "N entries" row. Called on the way back in.
+    def refresh(section : Symbol) : Nil
+      @view.refresh(section)
+    end
+
+    # --- Overlay contract (see overlay.cr) ---
+    def key : OverlayKind
+      OverlayKind::Preferences
+    end
+
+    def title : String
+      "PREFERENCES"
+    end
+
+    def hint : String
+      "←/→ group · ↑/↓ field · ↵ save/open · ^R reset · esc close"
+    end
+
+    def render(screen : Screen, area : Rect) : Nil
+      @view.render(screen, area)
+    end
+
+    def overlay_box(area : Rect) : Rect?
+      @view.overlay_box(area)
+    end
+
+    def set_preedit(text : String) : Nil
+      @view.set_preedit(text)
+    end
+
+    def move(step : Int32) : Nil
+      @view.wheel(step)
+    end
+
+    def handle_key(ev : Termisu::Event::Key) : Symbol
+      apply(@view.handle_key(ev))
+    end
+
+    # The view hit-tests itself: a click outside the card runs the same unsaved-edits
+    # guard as esc, so a stray click can't silently drop what was typed.
+    def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      apply(@view.click(area, mx, my))
+    end
+
+    private def apply(outcome : PreferencesView::Outcome) : Symbol
+      case outcome.kind
+      when :close   then return :cancel
+      when :palette then on_palette.try(&.call)
+      when :saved   then on_saved.try(&.call(outcome.section.not_nil!, outcome.message || ""))
+      when :open    then on_open_editor.try(&.call(outcome.section.not_nil!))
+      end
+      :stay
     end
   end
 end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -182,18 +182,6 @@ module Gori::Tui
       # The "send selection to X" destination picker (space → S); same orthogonal-to-
       # @overlay lifetime as @copy_picker. Non-nil ⇔ shown (see send_to_shown?).
       @send_picker = nil.as(SendPicker?)
-      # The settings editor (palette → settings:network); @overlay is :settings.
-      @settings_view = SettingsView.new
-      @preferences = PreferencesView.new # the unified grouped settings modal (Ctrl+, / ⚙ / palette)
-      @prefs_return = false              # a dedicated editor was opened FROM the modal → return to it on close
-      # The tab-bar customizer (palette → settings:tabs); @overlay is :tabs. Distinct
-      # from @tabs (the controller registry built below).
-      @tabs_overlay = TabsOverlay.new
-      # The global hostname-overrides editor (settings → "Hostname overrides"); @overlay is :hosts.
-      @hosts_overlay = HostsOverlay.new
-      @env_overlay = EnvOverlay.new
-      # The hotkey rebinder (palette → settings:hotkeys); @overlay is :hotkeys.
-      @hotkeys_overlay = HotkeysOverlay.new(@session.registry)
       # Shared background-job + notification layer (Miner is the first consumer). The
       # registries are mutated only on the main fiber (controller drains); the spinner
       # frame advances while a job is active so the bottom-bar chip animates.
@@ -893,12 +881,8 @@ module Gori::Tui
         return
       end
       case @overlay
-      when .palette?     then @palette.set_preedit(text)
-      when .preferences? then @preferences.set_preedit(text)
-      when .settings?    then @settings_view.set_preedit(text)
-      when .hosts?       then @hosts_overlay.set_preedit(text)
-      when .env?         then @env_overlay.set_preedit(text)
-      when .none?        then apply_preedit_body(text)
+      when .palette? then @palette.set_preedit(text)
+      when .none?    then apply_preedit_body(text)
       end
     end
 
@@ -916,9 +900,10 @@ module Gori::Tui
       # it works uniformly across tabs, editors and overlays.
       # In hotkey CAPTURE mode ^C/^D are capturable chords (reserved.cr rejects them inline
       # with "Ctrl-C/D quits gori" while staying in capture) — exclude them from the global
-      # quit-arm so a stray ^D during a rebind can't silently arm an app quit.
-      capturing_hotkey = @overlay.hotkeys? && @hotkeys_overlay.capturing?
-      if (ev.ctrl_c? || (ev.ctrl? && ev.key.lower_d?)) && !capturing_hotkey
+      # quit-arm so a stray ^D during a rebind can't silently arm an app quit. The modal
+      # answers for itself (Overlay#raw_key_capture?); no other overlay claims these.
+      raw_capture = active_overlay.try(&.raw_key_capture?) || false
+      if (ev.ctrl_c? || (ev.ctrl? && ev.key.lower_d?)) && !raw_capture
         if Settings.confirm_quit?
           # Opt-in (settings:general): a confirm modal replaces the double-press arm. Skip
           # re-opening if the quit confirm is already up (^D then just waits for y/n/esc).
@@ -937,7 +922,10 @@ module Gori::Tui
       @toast = nil # clear last action's feedback; a new action may set it again
       # In hotkey CAPTURE mode the next key IS the new binding — intercept it before the
       # ^G/^F/^B guards (and everything else) so those chords can be recorded.
-      return handle_hotkeys_key(ev) if @overlay.hotkeys? && @hotkeys_overlay.capturing?
+      if raw_capture && (ov = active_overlay)
+        dispatch_overlay_key(ov, ev)
+        return
+      end
       return handle_space_menu_key(ev) if @space_menu_open # the space menu is modal while up
       return handle_copy_as_key(ev) if copy_as_shown?      # the copy-as picker is modal while up
       return handle_send_to_key(ev) if send_to_shown?      # the send-to picker is modal while up
@@ -967,18 +955,6 @@ module Gori::Tui
       end
       return handle_palette_key(ev) if @overlay.palette?
       return handle_more_menu_key(ev) if @overlay.tabs_more?
-      return handle_preferences_key(ev) if @overlay.preferences?
-      if PREFS_SUB_EDITORS.includes?(@overlay)
-        case @overlay
-        when .settings? then handle_settings_key(ev)
-        when .tabs?     then handle_tabs_key(ev)
-        when .hosts?    then handle_hosts_key(ev)
-        when .env?      then handle_env_key(ev)
-        when .hotkeys?  then handle_hotkeys_key(ev)
-        end
-        settle_sub_editor # closing one opened from Preferences lands back in the modal
-        return
-      end
       # Migrated modals (Overlay base) dispatch generically — no per-modal handle_*_key.
       if ov = active_overlay
         dispatch_overlay_key(ov, ev)
@@ -1242,12 +1218,6 @@ module Gori::Tui
     MODAL_OVERLAYS = {
       OverlayKind::Palette,
       OverlayKind::TabsMore,
-      OverlayKind::Preferences,
-      OverlayKind::Settings,
-      OverlayKind::Tabs,
-      OverlayKind::Hosts,
-      OverlayKind::Env,
-      OverlayKind::Hotkeys,
     }
 
     private def modal_overlay? : Bool
@@ -1342,14 +1312,8 @@ module Gori::Tui
         return
       end
       case @overlay
-      when .palette?     then click_palette(area, mx, my)
-      when .tabs_more?   then click_more_menu(layout, mx, my)
-      when .preferences? then apply_preferences_outcome(@preferences.click(area, mx, my))
-      when .settings?    then (click_settings(area, mx, my); settle_sub_editor)
-      when .tabs?        then (click_tabs(area, mx, my); settle_sub_editor)
-      when .hosts?       then (click_hosts(area, mx, my); settle_sub_editor)
-      when .env?         then (click_env(area, mx, my); settle_sub_editor)
-      when .hotkeys?     then (click_hotkeys(area, mx, my); settle_sub_editor)
+      when .palette?   then click_palette(area, mx, my)
+      when .tabs_more? then click_more_menu(layout, mx, my)
       end
     end
 
@@ -1393,71 +1357,10 @@ module Gori::Tui
       end
     end
 
-    private def click_settings(area : Rect, mx : Int32, my : Int32) : Nil
-      box = @settings_view.overlay_box(area)
-      return cancel_settings if dismiss_zone?(box, mx, my)
-      if idx = @settings_view.field_at(box, mx, my)
-        @settings_view.set_field(idx)
-        if opener = @settings_view.focused_opener
-          open_settings(opener) # an action row → open its sub-editor on click (mouse parity with ↵)
-        else
-          preview_theme # clicking a theme row live-previews it (no-op outside :theme)
-        end
-      end
-    end
-
-    # Tab-bar customizer: a click outside dismisses (discards the working copy, like
-    # esc); a row click selects it (toggle/reorder stay keyboard-driven).
-    private def click_tabs(area : Rect, mx : Int32, my : Int32) : Nil
-      box = @tabs_overlay.overlay_box(area)
-      return (@overlay = OverlayKind::None) if box.nil? || dismiss_zone?(box, mx, my)
-      if idx = @tabs_overlay.row_at(box, mx, my)
-        @tabs_overlay.set_selected(idx)
-      end
-    end
-
-    # Hostname-overrides editor: a click outside dismisses (esc); a row click selects it
-    # (add/edit/delete stay keyboard-driven).
-    private def click_hosts(area : Rect, mx : Int32, my : Int32) : Nil
-      box = @hosts_overlay.overlay_box(area)
-      return (@overlay = OverlayKind::None) if box.nil? || dismiss_zone?(box, mx, my)
-      if idx = @hosts_overlay.row_at(box, mx, my)
-        @hosts_overlay.set_selected(idx)
-      end
-    end
-
-    private def click_env(area : Rect, mx : Int32, my : Int32) : Nil
-      box = @env_overlay.overlay_box(area)
-      return (@overlay = OverlayKind::None) if box.nil? || dismiss_zone?(box, mx, my)
-      if idx = @env_overlay.row_at(box, mx, my)
-        @env_overlay.set_selected(idx)
-      end
-    end
-
-    # Hotkey editor: a click outside dismisses (discards the working copy, like esc); a
-    # row click selects that binding (rebind/unbind/reset stay keyboard-driven).
-    private def click_hotkeys(area : Rect, mx : Int32, my : Int32) : Nil
-      box = @hotkeys_overlay.overlay_box(area)
-      return (@overlay = OverlayKind::None) if box.nil? || dismiss_zone?(box, mx, my)
-      if idx = @hotkeys_overlay.row_at(box, mx, my)
-        @hotkeys_overlay.set_selected(idx)
-      end
-    end
-
     # True when a click should dismiss a modal: anywhere outside its box (click-away
     # is the universal close affordance — every modal also still closes on esc).
     private def dismiss_zone?(box : Rect, mx : Int32, my : Int32) : Bool
       !box.contains?(mx, my)
-    end
-
-    # Cancel the settings modal: revert any live theme preview (mirrors the esc path).
-    private def cancel_settings : Nil
-      if restore = @theme_restore
-        Theme.apply(restore)
-        @resized = true
-        @theme_restore = nil
-      end
-      @overlay = OverlayKind::None
     end
 
     # Apply the persisted Mouse setting to the live terminal (both calls are
@@ -1491,14 +1394,8 @@ module Gori::Tui
         return
       end
       case @overlay
-      when .palette?     then @palette.move(step)
-      when .tabs_more?   then @more_menu.try(&.move(step))
-      when .preferences? then @preferences.wheel(step)
-      when .settings?    then (@settings_view.move_field(step); preview_theme) # wheel scrolls the theme list too
-      when .tabs?        then @tabs_overlay.select_move(step)
-      when .hosts?       then @hosts_overlay.select_move(step)
-      when .env?         then @env_overlay.select_move(step)
-      when .hotkeys?     then @hotkeys_overlay.select_move(step)
+      when .palette?   then @palette.move(step)
+      when .tabs_more? then @more_menu.try(&.move(step))
       end
     end
 
@@ -2148,110 +2045,14 @@ module Gori::Tui
       end
     end
 
-    # Settings editor (palette → settings:network): ↑/↓ pick a field, type to edit,
-    # ↵ save (persist + apply), esc close, ^P jump to the palette.
-    private def handle_settings_key(ev : Termisu::Event::Key) : Nil
-      key = ev.key
-      c = ev.char || key.to_char
-      if ev.ctrl? && key.lower_p?
-        cancel_settings # revert any live theme preview before jumping (mirrors esc); sets @overlay=:none
-        open_palette
-      elsif key.escape?
-        cancel_settings # revert any live theme preview, close
-      elsif key.enter?
-        if opener = @settings_view.focused_opener
-          # An action row (e.g. "Hostname overrides") — open its sub-editor instead of
-          # saving the section. The sub-editor persists on its own.
-          open_settings(opener)
-          return
-        end
-        # :network rebinds the live proxy; :theme swaps the palette + repaints; the
-        # rest just persist (the value is read live or only matters next session). The
-        # side effects live in apply_settings_saved so the Settings tab applies a save
-        # the same way — one seam, no drift.
-        msg = @settings_view.save
-        @toast = apply_settings_saved(@settings_view.section, msg)
-      elsif key.up?
-        @settings_view.move_field(-1)
-        preview_theme # ↑/↓ moves the theme-list selection in the :theme section
-      elsif key.down?
-        @settings_view.move_field(1)
-        preview_theme
-      elsif key.left?
-        @settings_view.toggle_or_move(-1)
-        preview_theme
-      elsif key.right?
-        @settings_view.toggle_or_move(1)
-        preview_theme
-      elsif key.backspace?
-        @settings_view.backspace
-      elsif key.delete?
-        @settings_view.delete
-      elsif ev.ctrl? && key.lower_r?
-        # ^R (not a bare letter — those are typed into the focused field) reverts the
-        # section to its factory defaults, gated behind a confirm like the tab-bar reset.
-        section = @settings_view.section
-        confirm("RESET SETTINGS",
-          "Reset the #{section.to_s.upcase} settings to their\n" \
-          "default values? Unsaved edits here are replaced.",
-          confirm_label: "reset", danger: true, return_to: :settings) do
-          @settings_view.reset_to_defaults
-          preview_theme # :theme live-previews the restored default theme
-          @toast = "#{section} settings reset to defaults — ↵ to save"
-        end
-      elsif c && !ev.ctrl? && !ev.alt?
-        @settings_view.insert(c)
-        @settings_view.set_preedit("")
-        preview_theme # space cycles the theme in the :theme section — preview it too
-      end
-    end
-
-    # The tab-bar customizer (settings:tabs). Working copy: ↵ saves+applies, esc discards.
-    # ↑/↓ (and k/j) move the selection; K/J reorder the selected tab; space toggles
-    # show/hide (refused for the last visible tab); r reverts to the factory default
-    # order/visibility. ^P jumps back to the palette.
-    private def handle_tabs_key(ev : Termisu::Event::Key) : Nil
-      key = ev.key
-      if ev.ctrl? && key.lower_p?
-        @overlay = OverlayKind::None
-        open_palette
-      elsif key.escape?
-        @overlay = OverlayKind::None # discard the working copy
-      elsif key.enter?
-        save_tabs
-      elsif key.up? && ev.shift?
-        @tabs_overlay.move_selected(-1)
-      elsif key.down? && ev.shift?
-        @tabs_overlay.move_selected(1)
-      elsif key.up?
-        @tabs_overlay.select_move(-1)
-      elsif key.down?
-        @tabs_overlay.select_move(1)
-      elsif (c = ev.char) && c == ' '
-        @toast = "keep at least one tab visible" unless @tabs_overlay.toggle_selected
-      elsif (c = ev.char) && (c == 'K' || c == 'k')
-        c == 'K' ? @tabs_overlay.move_selected(-1) : @tabs_overlay.select_move(-1)
-      elsif (c = ev.char) && (c == 'J' || c == 'j')
-        c == 'J' ? @tabs_overlay.move_selected(1) : @tabs_overlay.select_move(1)
-      elsif (c = ev.char) && (c == 'r' || c == 'R')
-        confirm("RESET TAB BAR",
-          "Reset the tab bar to its default order and\n" \
-          "visibility? Your current arrangement is replaced.",
-          confirm_label: "reset", danger: true, return_to: :tabs) do
-          @tabs_overlay.reset_to_defaults
-          @toast = "tabs reset to defaults — ↵ to save"
-        end
-      end
-    end
-
     # Commit the tab-bar working copy: persist once, force a full repaint (the tab set/
     # order changed behind the centered overlay), and if the active tab was just hidden
     # snap to the first visible one — committing the outgoing tab's edits first (a hidden
     # Project desc / Repeater request must not be silently dropped), mirroring focus_tab.
-    private def save_tabs : Nil
-      Settings.tab_prefs = @tabs_overlay.to_prefs
+    # Always true: the shell closes the editor on ↵ whether or not the disk write landed.
+    private def save_tabs(ov : TabsOverlay) : Bool
+      Settings.tab_prefs = ov.to_prefs
       ok = Settings.save
-      @overlay = OverlayKind::None
       @resized = true
       # Snap off a now-hidden active tab. Use the GENUINE visibility (no force:) for this
       # decision — effective_tabs force-includes the active tab, which would mask the hide.
@@ -2269,167 +2070,20 @@ module Gori::Tui
       # The layout is applied to the live session regardless (like theme/network); only the
       # disk write can fail, so say so honestly rather than implying nothing happened.
       @toast = ok ? "tabs saved" : "tabs applied — could not save to #{Settings.path}"
+      true
     end
 
-    # The global hostname-overrides editor (settings → "Hostname overrides"). Persisted on
-    # every mutation (the live proxy reads Settings.host_override_ip on the next flow), so
-    # esc just closes. a add · ↵/e edit · d delete · esc close. ^P jumps back to the palette.
-    private def handle_hosts_key(ev : Termisu::Event::Key) : Nil
-      if @hosts_overlay.adding?
-        handle_hosts_add_key(ev)
-        return
-      end
-      key = ev.key
-      c = ev.char || key.to_char
-      if ev.ctrl? && key.lower_p?
-        @overlay = OverlayKind::None
-        open_palette
-      elsif key.escape?
-        @overlay = OverlayKind::None
-      elsif key.up? || key.lower_k?
-        @hosts_overlay.select_move(-1)
-      elsif key.down? || key.lower_j?
-        @hosts_overlay.select_move(1)
-      elsif key.enter? || c == 'e'
-        @hosts_overlay.edit_start
-      elsif c == 'a'
-        @hosts_overlay.add_start
-      elsif c == 'd'
-        if host = @hosts_overlay.delete_selected
-          ok = save_hosts
-          @toast = ok ? "removed host override: #{host}" : "removed #{host} — could not save to #{Settings.path}"
-        end
-      end
-    end
-
-    # The inline add/edit row: type "IP host", ↵ commits, ⌫ on an empty input cancels,
-    # esc cancels.
-    private def handle_hosts_add_key(ev : Termisu::Event::Key) : Nil
-      key = ev.key
-      c = ev.char || key.to_char
-      if key.escape?
-        @hosts_overlay.cancel_add
-      elsif key.enter?
-        case @hosts_overlay.commit
-        when :empty   then @toast = "host override: empty"
-        when :invalid then @toast = %(host override: need "IP host" — a valid IP + a hostname)
-        when :dup     then @toast = "host override: host already mapped"
-        when :ok
-          ok = save_hosts
-          @toast = ok ? "host override saved — #{@hosts_overlay.to_overrides.size} total" : "host override applied — could not save to #{Settings.path}"
-        end
-      elsif key.left?
-        @hosts_overlay.move_cursor(-1)
-      elsif key.right?
-        @hosts_overlay.move_cursor(1)
-      elsif key.backspace?
-        @hosts_overlay.cancel_add unless @hosts_overlay.backspace
-      elsif key.tab?
-        @hosts_overlay.input(' ') # Tab types the IP/host separator, not a focus jump
-        @hosts_overlay.set_preedit("")
-      elsif c && !ev.ctrl? && !ev.alt?
-        @hosts_overlay.input(c)
-        @hosts_overlay.set_preedit("")
-      end
-    end
-
-    # Returns Settings.save's success so callers can branch the toast (saved vs
-    # applied-but-not-persisted), like save_tabs/save_hotkeys.
-    private def save_hosts : Bool
-      Settings.hostname_overrides = @hosts_overlay.to_overrides.dup
+    # Persist the hostname-overrides working copy. Returns Settings.save's success so the
+    # editor can branch its toast (saved vs applied-but-not-persisted), like save_env.
+    # Called on EVERY mutation — the live proxy reads Settings.host_override_ip on the next
+    # flow — which is why that editor has no ↵-to-commit and esc just closes.
+    private def save_hosts(ov : HostsOverlay) : Bool
+      Settings.hostname_overrides = ov.to_overrides.dup
       Settings.save
     end
 
-    private def handle_env_key(ev : Termisu::Event::Key) : Nil
-      if @env_overlay.prefix_editing?
-        handle_env_prefix_key(ev)
-        return
-      end
-      if @env_overlay.adding?
-        handle_env_add_key(ev)
-        return
-      end
-      key = ev.key
-      c = ev.char || key.to_char
-      if ev.ctrl? && key.lower_p?
-        @overlay = OverlayKind::None
-        open_palette
-      elsif key.escape?
-        @overlay = OverlayKind::None
-      elsif key.up? || key.lower_k?
-        @env_overlay.select_move(-1)
-      elsif key.down? || key.lower_j?
-        @env_overlay.select_move(1)
-      elsif key.enter? || c == 'e'
-        @env_overlay.edit_start
-      elsif c == 'a'
-        @env_overlay.add_start
-      elsif c == 'p'
-        @env_overlay.prefix_edit_start
-      elsif c == 'd'
-        if key_name = @env_overlay.delete_selected
-          ok = save_env
-          @toast = ok ? "removed env: #{key_name}" : "removed #{key_name} — could not save to #{Settings.path}"
-        end
-      end
-    end
-
-    private def handle_env_prefix_key(ev : Termisu::Event::Key) : Nil
-      key = ev.key
-      c = ev.char || key.to_char
-      if key.escape?
-        @env_overlay.cancel_prefix_edit
-      elsif key.enter?
-        case @env_overlay.commit_prefix
-        when :empty then @toast = "env prefix: empty"
-        when :ok
-          ok = save_env
-          @toast = ok ? "env prefix saved — #{@env_overlay.to_config[0].inspect}" : "prefix applied — could not save to #{Settings.path}"
-        end
-      elsif key.left?
-        @env_overlay.move_cursor(-1)
-      elsif key.right?
-        @env_overlay.move_cursor(1)
-      elsif key.backspace?
-        @env_overlay.cancel_prefix_edit unless @env_overlay.backspace
-      elsif c && !ev.ctrl? && !ev.alt?
-        @env_overlay.input(c)
-        @env_overlay.set_preedit("")
-      end
-    end
-
-    private def handle_env_add_key(ev : Termisu::Event::Key) : Nil
-      key = ev.key
-      c = ev.char || key.to_char
-      if key.escape?
-        @env_overlay.cancel_add
-      elsif key.enter?
-        case @env_overlay.commit
-        when :empty   then @toast = "env var: empty"
-        when :invalid then @toast = %(env var: need "KEY VALUE" or "KEY=value" — KEY is [A-Za-z_][A-Za-z0-9_]*)
-        when :dup     then @toast = "env var: KEY already defined"
-        when :ok
-          ok = save_env
-          n = @env_overlay.to_config[1].size
-          @toast = ok ? "env var saved — #{n} total" : "env var applied — could not save to #{Settings.path}"
-        end
-      elsif key.left?
-        @env_overlay.move_cursor(-1)
-      elsif key.right?
-        @env_overlay.move_cursor(1)
-      elsif key.backspace?
-        @env_overlay.cancel_add unless @env_overlay.backspace
-      elsif key.tab?
-        @env_overlay.input(' ') # Tab types the KEY/VALUE separator, not a focus jump
-        @env_overlay.set_preedit("")
-      elsif c && !ev.ctrl? && !ev.alt?
-        @env_overlay.input(c)
-        @env_overlay.set_preedit("")
-      end
-    end
-
-    private def save_env : Bool
-      prefix, vars = @env_overlay.to_config
+    private def save_env(ov : EnvOverlay) : Bool
+      prefix, vars = ov.to_config
       Settings.env_prefix = prefix
       Settings.env_vars = vars.dup
       ok = Settings.save
@@ -2437,75 +2091,17 @@ module Gori::Tui
       ok
     end
 
-    private def env_overlay_hints : String
-      return "type prefix · ↵ save · esc cancel" if @env_overlay.prefix_editing?
-      return "type \"KEY VALUE\" · ↵ save · esc cancel" if @env_overlay.adding?
-      "↑/↓ select · a add · ↵/e edit · d delete · p prefix · esc close"
-    end
-
-    # The hotkey rebinder (settings:hotkeys). Working copy: ↵ saves+applies, esc discards.
-    # Two sub-modes — :browse navigates/edits the list, :capture records the next key as
-    # the new binding (entered via e/space on a row; the capture early-return in handle_key
-    # routes keys here so ^G/^F/^B can be bound).
-    private def handle_hotkeys_key(ev : Termisu::Event::Key) : Nil
-      @hotkeys_overlay.capturing? ? handle_hotkeys_capture(ev) : handle_hotkeys_browse(ev)
-    end
-
-    private def handle_hotkeys_capture(ev : Termisu::Event::Key) : Nil
-      if ev.key.escape?
-        @hotkeys_overlay.cancel_capture
-      elsif chord = Keybind.from_event(ev)
-        @hotkeys_overlay.apply_capture(chord) # reserved/conflict → inline error, stays in capture
-      end
-      # an unmappable key (non-ASCII / a bare modifier) is ignored — capture stays open
-    end
-
-    private def handle_hotkeys_browse(ev : Termisu::Event::Key) : Nil
-      key = ev.key
-      if ev.ctrl? && key.lower_p?
-        @overlay = OverlayKind::None
-        open_palette
-      elsif key.escape?
-        @overlay = OverlayKind::None # discard the working copy
-      elsif key.enter?
-        save_hotkeys
-      elsif key.up?
-        @hotkeys_overlay.select_move(-1)
-      elsif key.down?
-        @hotkeys_overlay.select_move(1)
-      elsif key.left?
-        @hotkeys_overlay.cycle_profile(-1)
-      elsif key.right?
-        @hotkeys_overlay.cycle_profile(1)
-      elsif key.backspace?
-        @hotkeys_overlay.unbind_selected
-      elsif c = ev.char
-        handle_hotkeys_char(c)
-      end
-    end
-
-    private def handle_hotkeys_char(c : Char) : Nil
-      case c
-      when 'e', ' ' then @hotkeys_overlay.begin_capture
-      when 'x'      then @hotkeys_overlay.unbind_selected
-      when 'r'      then @hotkeys_overlay.reset_selected
-      when 'R'      then @hotkeys_overlay.reset_all
-      when 'k'      then @hotkeys_overlay.select_move(-1)
-      when 'j'      then @hotkeys_overlay.select_move(1)
-      end
-    end
-
     # Commit the hotkey working copy: persist the overrides + profile, rebuild the live
     # keymap so dispatch reflects them immediately, close.
-    private def save_hotkeys : Nil
-      working, profile = @hotkeys_overlay.to_working
+    private def save_hotkeys(ov : HotkeysOverlay) : Bool
+      working, profile = ov.to_working
       Hotkeys.apply(working, profile)
       ok = Settings.save
       @keymap = Hotkeys.build_keymap(@session.registry)
       # Help is built from the registry at open; reload so rebound labels stay honest.
       help_controller.reload_help(@session.registry)
-      @overlay = OverlayKind::None
       @toast = ok ? "hotkeys saved" : "hotkeys applied — could not save to #{Settings.path}"
+      true
     end
 
     # A navigable sub-tab strip is showing — gates entry into :subtabs (and the strip
@@ -3089,12 +2685,6 @@ module Gori::Tui
       Chrome.render_statusline(screen, layout.statusline, @statusline.segments) unless layout.statusline.empty?
       @palette.render(screen, layout.body) if @overlay.palette?
       @more_menu.try(&.render(screen, more_anchor_rect(layout), layout.body)) if @overlay.tabs_more?
-      @preferences.render(screen, layout.body) if @overlay.preferences?
-      @settings_view.render(screen, layout.body) if @overlay.settings?
-      @tabs_overlay.render(screen, layout.body) if @overlay.tabs?
-      @hosts_overlay.render(screen, layout.body) if @overlay.hosts?
-      @env_overlay.render(screen, layout.body) if @overlay.env?
-      @hotkeys_overlay.render(screen, layout.body) if @overlay.hotkeys?
       active_overlay.try(&.render(screen, layout.body)) # migrated modals (Overlay seam; gated on @overlay)
       # The space menu + bottom prompts float over everything else (drawn last).
       render_prompts(screen, layout)
@@ -3206,14 +2796,8 @@ module Gori::Tui
         return ov.title
       end
       case @overlay
-      when .palette?     then "PALETTE"
-      when .detail?      then "DETAIL"
-      when .preferences? then "PREFERENCES"
-      when .settings?    then "SETTINGS"
-      when .tabs?        then "TAB BAR"
-      when .hosts?       then "HOSTNAME OVERRIDES"
-      when .env?         then "ENVIRONMENT"
-      when .hotkeys?     then "HOTKEYS"
+      when .palette? then "PALETTE"
+      when .detail?  then "DETAIL"
       else
         case @focus
         when :menu    then "TABS"
@@ -3244,15 +2828,9 @@ module Gori::Tui
         return ov.hint
       end
       case @overlay
-      when .palette?     then "↑/↓ select · ↵ run · ⌫ · esc close · type to filter"
-      when .tabs_more?   then "↑/↓ select · ↵ open tab · ←/esc close"
-      when .preferences? then "←/→ group · ↑/↓ field · ↵ save/open · ^R reset · esc close"
-      when .settings?    then "↑/↓ field · type to edit · ↵ save · ^R reset · esc close"
-      when .tabs?        then "↑/↓ select · space show/hide · K/J reorder · r reset · ↵ save · esc cancel"
-      when .hosts?       then @hosts_overlay.adding? ? "type \"IP host\" · ↵ save · esc cancel" : "↑/↓ select · a add · ↵/e edit · d delete · esc close"
-      when .env?         then env_overlay_hints
-      when .hotkeys?     then @hotkeys_overlay.capturing? ? "press a key to bind · esc cancel" : "↑/↓ select · e/␣ rebind · x unbind · r reset · ⇧R reset all · ←/→ profile · ↵ save · esc"
-      when .detail?      then history_controller.body_hint(:body)
+      when .palette?   then "↑/↓ select · ↵ run · ⌫ · esc close · type to filter"
+      when .tabs_more? then "↑/↓ select · ↵ open tab · ←/esc close"
+      when .detail?    then history_controller.body_hint(:body)
       else
         # Focus on the far-right ⋯ "more" affordance: ↵/↓ expands the hidden-tabs list.
         return "↵/↓ show hidden tabs · ← back · ^P cmds · q projects" if @focus == :menu && @menu_more
@@ -4626,27 +4204,25 @@ module Gori::Tui
       open_import(:oas)
     end
 
+    # Palette / verb entry (`settings.*`): nothing to return to, so an editor opened here
+    # closes to the tab body.
     def open_settings(section : Symbol) : Nil
+      open_settings_section(section, nil)
+    end
+
+    # `back` is the Preferences modal an opener row was activated from. The editor pops
+    # back INTO it on close (Overlay#on_close) — otherwise ↵-ing into Theme and pressing
+    # esc drops you out of settings entirely, while the project picker (which does return
+    # to the modal) would behave differently.
+    private def open_settings_section(section : Symbol, back : PreferencesOverlay?) : Nil
       case section
       when :network, :editor, :layout, :statusline, :display, :notifications, :general
-        open_preferences(section) # the unified grouped modal, positioned at this section
-      when :theme
-        @settings_view.reload(:theme) # theme keeps its dedicated swatch-list card
-        @resized = true               # an edited/removed active theme just changed → full repaint
-        @overlay = OverlayKind::Settings
-        @theme_restore = Settings.theme # baseline for live-preview revert
-      when :tabs
-        @tabs_overlay.reset # rebuild the working copy from persisted config
-        @overlay = OverlayKind::Tabs
-      when :hosts
-        @hosts_overlay.reset # rebuild the working copy from persisted overrides
-        @overlay = OverlayKind::Hosts
-      when :env
-        @env_overlay.reset
-        @overlay = OverlayKind::Env
-      when :hotkeys
-        @hotkeys_overlay.reset # rebuild the working copy from persisted overrides
-        @overlay = OverlayKind::Hotkeys
+        open_preferences(section)                       # the unified grouped modal, positioned at this section
+      when :theme   then open_overlay(theme_card(back)) # theme keeps its dedicated swatch-list card
+      when :tabs    then open_overlay(tabs_editor(back))
+      when :hosts   then open_overlay(hosts_editor(back))
+      when :env     then open_overlay(env_editor(back))
+      when :hotkeys then open_overlay(hotkeys_editor(back))
       else
         @toast = "#{section} settings — coming soon (TODO)"
       end
@@ -4654,53 +4230,113 @@ module Gori::Tui
 
     # Open the unified Preferences modal — at a specific section (the "Settings: …" palette
     # entries) or, with no section, at the group strip (Ctrl+, / the ⚙ top-bar chip). The
-    # project picker shares the SAME PreferencesView; only in-app can reach the dedicated
-    # editors from opener rows, so the picker builds its view with allow_openers: false.
+    # project picker shares the SAME PreferencesView (wrapped here as an Overlay); only
+    # in-app can reach the dedicated editors from opener rows, so the picker builds its
+    # view with a restricted allowed_openers set.
     def open_preferences(section : Symbol? = nil) : Nil
-      section ? @preferences.open(section) : @preferences.open_default
-      @prefs_return = false # a fresh open — not a hop out to a sub-editor and back
-      @overlay = OverlayKind::Preferences
+      ov = PreferencesOverlay.new(section)
+      ov.on_palette = -> { jump_to_palette }
+      # Live-apply the saved section through the shared seam, so a save takes effect
+      # identically from the modal and the dedicated settings card — one seam, no drift.
+      ov.on_saved = ->(sec : Symbol, msg : String) { @toast = apply_settings_saved(sec, msg); nil }
+      ov.on_open_editor = ->(sec : Symbol) { open_settings_section(sec, ov) }
+      open_overlay(ov)
     end
 
-    private def handle_preferences_key(ev : Termisu::Event::Key) : Nil
-      apply_preferences_outcome(@preferences.handle_key(ev))
+    # Land back in the Preferences modal a dedicated editor was opened from. Re-pulls the
+    # Network section first: the Hostnames editor moves its "N entries" row.
+    private def resume_preferences(back : PreferencesOverlay?) : Nil
+      return unless back
+      back.refresh(:network)
+      open_overlay(back)
     end
 
-    # Act on what the modal asked for: close, jump to the palette, live-apply a save (via
-    # the shared apply_settings_saved seam), or open a dedicated editor
-    # (theme/tabs/hosts/env/hotkeys) — flagged so that editor returns INTO the modal.
-    private def apply_preferences_outcome(outcome : PreferencesView::Outcome) : Nil
-      case outcome.kind
-      when :close   then @overlay = OverlayKind::None
-      when :palette then (@overlay = OverlayKind::None; open_palette)
-      when :saved   then @toast = apply_settings_saved(outcome.section.not_nil!, outcome.message || "")
-      when :open
-        @prefs_return = true
-        open_settings(outcome.section.not_nil!)
+    # ^P from inside a modal. Leaves the whole stack WITHOUT running on_close — a nested
+    # editor's pop-back into Preferences would otherwise re-open on top of the palette.
+    private def jump_to_palette : Nil
+      leave_overlay
+      open_palette
+    end
+
+    # The dedicated theme card. Only in-app reaches it: open_settings routes every other
+    # section into the Preferences modal, so this is the THEME swatch list in practice.
+    private def theme_card(back : PreferencesOverlay?) : SettingsOverlay
+      ov = SettingsOverlay.new(:theme)
+      @resized = true                 # an edited/removed active theme just changed → full repaint
+      @theme_restore = Settings.theme # baseline for live-preview revert
+      # esc / click-away drop the live preview, exactly as ^P does before it jumps.
+      ov.on_close = -> { revert_theme_preview; resume_preferences(back) }
+      ov.on_palette = -> { revert_theme_preview; jump_to_palette }
+      ov.on_preview = -> { apply_theme_preview(ov.theme_value) }
+      ov.on_save = ->(sec : Symbol, msg : String) { @toast = apply_settings_saved(sec, msg); nil }
+      ov.on_open_editor = ->(sec : Symbol) { open_settings_section(sec, back) }
+      ov.on_reset = -> { confirm_section_reset(ov) }
+      ov
+    end
+
+    private def tabs_editor(back : PreferencesOverlay?) : TabsOverlay
+      ov = TabsOverlay.new
+      ov.on_close = -> { resume_preferences(back) }
+      ov.on_palette = -> { jump_to_palette }
+      ov.on_toast = ->(msg : String) { @toast = msg; nil }
+      ov.on_reset = -> { confirm_tabs_reset(ov) }
+      ov.on_commit = -> { save_tabs(ov) }
+      ov
+    end
+
+    private def hosts_editor(back : PreferencesOverlay?) : HostsOverlay
+      ov = HostsOverlay.new
+      ov.on_close = -> { resume_preferences(back) }
+      ov.on_palette = -> { jump_to_palette }
+      ov.on_toast = ->(msg : String) { @toast = msg; nil }
+      ov.on_save = -> { save_hosts(ov) }
+      ov
+    end
+
+    private def env_editor(back : PreferencesOverlay?) : EnvOverlay
+      ov = EnvOverlay.new
+      ov.on_close = -> { resume_preferences(back) }
+      ov.on_palette = -> { jump_to_palette }
+      ov.on_toast = ->(msg : String) { @toast = msg; nil }
+      ov.on_save = -> { save_env(ov) }
+      ov
+    end
+
+    private def hotkeys_editor(back : PreferencesOverlay?) : HotkeysOverlay
+      ov = HotkeysOverlay.new(@session.registry)
+      ov.on_close = -> { resume_preferences(back) }
+      ov.on_palette = -> { jump_to_palette }
+      ov.on_commit = -> { save_hotkeys(ov) }
+      ov
+    end
+
+    # ^R in the settings card: revert the section to its factory defaults, gated behind a
+    # confirm like the tab-bar reset. `return_to:` is what brings the card back: `confirm`
+    # captures the live overlay BEFORE `open_overlay` replaces it, and `restore_overlay`
+    # re-opens that captured object when the named kind is the one it holds. (It used to
+    # work because raising a confirm only moved @overlay and left @active_overlay alone —
+    # no longer true since ConfirmDialog moved onto the seam itself, so the capture is now
+    # the only thing holding this card.)
+    private def confirm_section_reset(ov : SettingsOverlay) : Nil
+      section = ov.section
+      confirm("RESET SETTINGS",
+        "Reset the #{section.to_s.upcase} settings to their\n" \
+        "default values? Unsaved edits here are replaced.",
+        confirm_label: "reset", danger: true, return_to: :settings) do
+        ov.reset_to_defaults
+        apply_theme_preview(ov.theme_value) # :theme live-previews the restored default theme
+        @toast = "#{section} settings reset to defaults — ↵ to save"
       end
     end
 
-    # The dedicated editors reachable from a Preferences opener row. Each closes by setting
-    # @overlay = OverlayKind::None from a handful of places, so rather than patch every close site the
-    # dispatch chokepoints below redirect that :none back INTO the modal it was opened from
-    # — otherwise ↵-ing into Theme and pressing esc drops you out of settings entirely,
-    # while the project picker (which does return to the modal) behaves differently.
-    PREFS_SUB_EDITORS = {
-      OverlayKind::Settings,
-      OverlayKind::Tabs,
-      OverlayKind::Hosts,
-      OverlayKind::Env,
-      OverlayKind::Hotkeys,
-    }
-
-    private def settle_sub_editor : Nil
-      return unless @prefs_return
-      # Still editing, chained into another editor, or raising a confirm the editor set a
-      # `return_to:` for (^R reset / tab-bar reset) — the flag has to survive all three.
-      return if PREFS_SUB_EDITORS.includes?(@overlay) || @overlay.confirm?
-      @overlay = OverlayKind::Preferences if @overlay.none? # a ^P jump to the palette still wins
-      @preferences.refresh(:network)                        # the Hostnames editor moves Network's "N entries" row
-      @prefs_return = false
+    private def confirm_tabs_reset(ov : TabsOverlay) : Nil
+      confirm("RESET TAB BAR",
+        "Reset the tab bar to its default order and\n" \
+        "visibility? Your current arrangement is replaced.",
+        confirm_label: "reset", danger: true, return_to: :tabs) do
+        ov.reset_to_defaults
+        @toast = "tabs reset to defaults — ↵ to save"
+      end
     end
 
     # Live-apply a just-saved settings section and return the toast to show. The ONE seam
@@ -4748,13 +4384,21 @@ module Gori::Tui
       save_msg
     end
 
-    # Live-apply the theme being cycled in settings so it's visible before committing;
-    # cancelling (esc) reverts to @theme_restore. No-op outside the theme section.
-    private def preview_theme : Nil
-      if name = @settings_view.theme_value
-        Theme.apply(name)
-        @resized = true
-      end
+    # Live-apply the theme being cycled in the settings card so it's visible before
+    # committing. nil (any section but :theme) is a no-op.
+    private def apply_theme_preview(name : String?) : Nil
+      return unless name
+      Theme.apply(name)
+      @resized = true
+    end
+
+    # Drop a live theme preview, restoring what was active when the card opened — the esc
+    # / click-away / ^P path. A saved theme clears @theme_restore, so this reverts nothing.
+    private def revert_theme_preview : Nil
+      return unless restore = @theme_restore
+      Theme.apply(restore)
+      @resized = true
+      @theme_restore = nil
     end
 
     # Hand the focused field's text to the external editor; on a clean change write

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -1,6 +1,7 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./overlay"
 require "../settings"
 
 module Gori::Tui
@@ -737,6 +738,163 @@ module Gori::Tui
       hint = @section == :theme ? "↑/↓ select · ↵ apply · ^R reset · esc close" : "↑/↓ field · ↵ save · ^R reset · esc close"
       hx = {box.right - hint.size - 2, box.x + 1}.max # never start left of the box interior
       screen.text(hx, hint_y, hint, Theme.muted, Theme.panel, width: {box.right - hx - 1, 0}.max)
+    end
+  end
+
+  # The dedicated per-section settings CARD on the Overlay seam (@overlay is :settings).
+  # SettingsView itself stays a plain form engine because three surfaces share it — this
+  # card, the Preferences modal's inline sections (render_fields_into) and the project
+  # picker's theme card — and only one of them is a Runner modal. So the modal is this
+  # thin Overlay around it rather than the engine itself.
+  #
+  # In-app only the THEME section reaches the card: open_settings routes every other
+  # section into the Preferences modal. It still drives any section, so the opener-row and
+  # save paths below are the engine's, not theme-specific.
+  #
+  # Runner coupling is injected at the open-site: a saved section is live-applied by the
+  # shell (apply_settings_saved), ^R raises the reset confirm, ↑/↓/←/→ live-preview the
+  # theme being cycled, an opener row hands off to its own editor, and ^P leaves for the
+  # command palette.
+  class SettingsOverlay < Overlay
+    property on_palette : Proc(Nil)?
+    property on_preview : Proc(Nil)?
+    property on_reset : Proc(Nil)?
+    property on_save : Proc(Symbol, String, Nil)?
+    property on_open_editor : Proc(Symbol, Nil)?
+
+    getter view : SettingsView
+
+    def initialize(section : Symbol = :theme)
+      @view = SettingsView.new
+      @view.reload(section)
+    end
+
+    def section : Symbol
+      @view.section
+    end
+
+    # The theme being previewed (nil outside :theme) — the shell's live-preview closure
+    # reads it rather than the overlay applying a theme itself.
+    def theme_value : String?
+      @view.theme_value
+    end
+
+    # Run by the ^R confirm's action, which the shell owns (the confirm outlives one key).
+    def reset_to_defaults : Nil
+      @view.reset_to_defaults
+    end
+
+    # --- Overlay contract (see overlay.cr) ---
+    def key : OverlayKind
+      OverlayKind::Settings
+    end
+
+    def title : String
+      "SETTINGS"
+    end
+
+    def hint : String
+      "↑/↓ field · type to edit · ↵ save · ^R reset · esc close"
+    end
+
+    def render(screen : Screen, area : Rect) : Nil
+      @view.render(screen, area)
+    end
+
+    # SettingsView returns an EMPTY rect where render declines to draw, so a click there
+    # falls through to !contains? and closes instead of focusing a field on an undrawn card.
+    def overlay_box(area : Rect) : Rect?
+      @view.overlay_box(area)
+    end
+
+    def set_preedit(text : String) : Nil
+      @view.set_preedit(text)
+    end
+
+    # ↑/↓ and the wheel share this — in :theme the section's single field IS the list, so
+    # this scrolls the theme selection and previews it.
+    def move(step : Int32) : Nil
+      @view.move_field(step)
+      preview
+    end
+
+    # ↑/↓ pick a field, type to edit, ↵ save (persist + apply), esc close, ^P palette.
+    def handle_key(ev : Termisu::Event::Key) : Symbol
+      key = ev.key
+      if ev.ctrl? && key.lower_p?
+        on_palette.try(&.call)
+      elsif ev.ctrl? && key.lower_r?
+        # ^R (not a bare letter — those are typed into the focused field) reverts the
+        # section to its factory defaults, gated behind a confirm like the tab-bar reset.
+        on_reset.try(&.call)
+      elsif key.escape?
+        return :cancel
+      elsif key.enter?
+        activate
+      else
+        handle_field_key(ev)
+      end
+      :stay
+    end
+
+    # ↑/↓ move between fields (in :theme the section IS the list, so they scroll it) and
+    # ←/→ flip a toggle, cycle a choice or move the caret — each live-previewing whatever
+    # theme it lands on. ⌫/Del and any printable edit the focused field.
+    private def handle_field_key(ev : Termisu::Event::Key) : Nil
+      key = ev.key
+      c = ev.char || key.to_char
+      if key.up?
+        move(-1)
+      elsif key.down?
+        move(1)
+      elsif key.left?
+        @view.toggle_or_move(-1)
+        preview
+      elsif key.right?
+        @view.toggle_or_move(1)
+        preview
+      elsif key.backspace?
+        @view.backspace
+      elsif key.delete?
+        @view.delete
+      elsif c && !ev.ctrl? && !ev.alt?
+        @view.insert(c)
+        @view.set_preedit("")
+        preview # space cycles the theme in the :theme section — preview it too
+      end
+    end
+
+    # A click outside dismisses; a row click focuses that field, opens an action row's
+    # sub-editor (mouse parity with ↵), or live-previews a clicked theme.
+    def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      box = @view.overlay_box(area)
+      return :cancel unless box.contains?(mx, my)
+      if idx = @view.field_at(box, mx, my)
+        @view.set_field(idx)
+        if opener = @view.focused_opener
+          on_open_editor.try(&.call(opener))
+        else
+          preview # clicking a theme row live-previews it (no-op outside :theme)
+        end
+      end
+      :stay
+    end
+
+    # ↵: an action row (e.g. "Hostname overrides") opens its sub-editor instead of saving
+    # the section — the sub-editor persists on its own. Any other row saves, and the shell
+    # live-applies the section through apply_settings_saved so the Preferences modal and
+    # this card can't drift.
+    private def activate : Nil
+      if opener = @view.focused_opener
+        on_open_editor.try(&.call(opener))
+        return
+      end
+      msg = @view.save
+      on_save.try(&.call(@view.section, msg))
+    end
+
+    private def preview : Nil
+      on_preview.try(&.call)
     end
   end
 end

--- a/src/gori/tui/tabs_overlay.cr
+++ b/src/gori/tui/tabs_overlay.cr
@@ -2,6 +2,7 @@ require "./screen"
 require "./theme"
 require "./frame"
 require "./chrome"
+require "./overlay"
 require "../settings"
 
 module Gori::Tui
@@ -13,11 +14,81 @@ module Gori::Tui
   #
   #   ✓ Project      ▎ selected, shown
   #   · Miner           hidden
-  class TabsOverlay
+  class TabsOverlay < Overlay
+    # Injected at the open-site (Runner#open_settings): ^P leaves the modal stack for the
+    # command palette, `r` raises the reset confirm, and a refused hide reports through the
+    # shell's toast. ↵ persists via the base `on_commit`; esc discards by closing.
+    property on_palette : Proc(Nil)?
+    property on_reset : Proc(Nil)?
+    property on_toast : Proc(String, Nil)?
+
     def initialize
       @items = [] of {Symbol, String, Bool}
       @selected = 0
       reset
+    end
+
+    # --- Overlay contract (see overlay.cr) ---
+    def key : OverlayKind
+      OverlayKind::Tabs
+    end
+
+    def title : String
+      "TAB BAR"
+    end
+
+    def hint : String
+      "↑/↓ select · space show/hide · K/J reorder · r reset · ↵ save · esc cancel"
+    end
+
+    # ↑/↓ move the selection and ⇧↑/⇧↓ reorder the selected tab; ↵ saves+applies, esc
+    # discards; ^P jumps back to the palette.
+    def handle_key(ev : Termisu::Event::Key) : Symbol
+      key = ev.key
+      if ev.ctrl? && key.lower_p?
+        on_palette.try(&.call)
+      elsif key.escape?
+        return :cancel # discard the working copy
+      elsif key.enter?
+        return :commit
+      elsif key.up?
+        ev.shift? ? move_selected(-1) : select_move(-1)
+      elsif key.down?
+        ev.shift? ? move_selected(1) : select_move(1)
+      elsif c = ev.char
+        handle_char(c)
+      end
+      :stay
+    end
+
+    # k/j mirror ↑/↓ and K/J mirror ⇧↑/⇧↓; space toggles show/hide (refused for the last
+    # visible tab, which the shell toasts); r reverts to the factory default order and
+    # visibility, behind the injected confirm.
+    private def handle_char(c : Char) : Nil
+      case c
+      when ' '      then on_toast.try(&.call("keep at least one tab visible")) unless toggle_selected
+      when 'k'      then select_move(-1)
+      when 'K'      then move_selected(-1)
+      when 'j'      then select_move(1)
+      when 'J'      then move_selected(1)
+      when 'r', 'R' then on_reset.try(&.call)
+      end
+    end
+
+    # A click outside dismisses (discards the working copy, like esc); a row click selects
+    # it (toggle/reorder stay keyboard-driven).
+    def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      box = overlay_box(area)
+      return :cancel if box.nil? || !box.contains?(mx, my)
+      if idx = row_at(box, mx, my)
+        set_selected(idx)
+      end
+      :stay
+    end
+
+    # ↑/↓ and the scroll wheel share the selection move (Overlay#handle_wheel calls this).
+    def move(step : Int32) : Nil
+      select_move(step)
     end
 
     # Rebuild the working copy from persisted config (called when the overlay opens),


### PR DESCRIPTION
Batch **C5** of #355 — the unified Preferences modal and the five dedicated editors it opens: the theme card, the tab-bar customizer, the global hostname overrides, the environment variables, and the hotkey rebinder. Each was a `handle_*_key` method plus an arm in all seven `case @overlay` ladders (preedit, key, click, wheel, render, title, hint). Each is now an `Overlay`, with its Runner coupling injected as closures at the open-site.

Builds on #372 (the `on_close` seam), which was split out of this batch and merged first.

| | before | after |
|---|---|---|
| `runner.cr` lines | 5,585 | **5,062** |
| `handle_*_key` in `runner.cr` | 31 | **25** |
| `runner.cr` references to these six `OverlayKind`s | 60 | **0** |

## The nested lifecycle

This batch owned `@prefs_return` + `settle_sub_editor` — a shell-wide flag plus a call at each dispatch chokepoint, whose only job was landing a sub-editor back in the Preferences modal it was opened from. Both are gone. Each editor's open-site supplies its own `on_close`, so the relationship is per-overlay and composes rather than being one bit for the whole shell.

`^P` goes through `jump_to_palette` (`leave_overlay` + `open_palette`), which deliberately skips `on_close` so the pop-back cannot re-open Preferences on top of the palette — the case the old flag handled with `@overlay.none?` inside `settle_sub_editor`.

The two resets that raise a confirm from *inside* an editor (settings ^R, tab-bar `r`) still use `return_to:`. Raising a confirm only moves `@overlay`, so `@active_overlay` keeps holding the editor and the existing liveness gate brings it back when the confirm closes.

## The capture-mode carve-out

The global ^C/^D quit-arm must be skipped while the hotkey rebinder is recording a chord, so those chords can be **bound** (reserved.cr rejects them inline with "Ctrl-C/D quits gori" while staying in capture) instead of arming a quit. That check read `@overlay.hotkeys? && @hotkeys_overlay.capturing?`; with the ivar gone it asks the modal through `Overlay#raw_key_capture?`, default false. Precedence, `@quit_armed` and `@toast` handling are unchanged.

## Shape

The four Runner-only editors subclass `Overlay` directly. `SettingsView` and `PreferencesView` do **not**: three surfaces share them — the Preferences modal's inline sections (`render_fields_into`), the project picker, and these cards — and only one is a Runner modal. So the modal is a thin `SettingsOverlay` / `PreferencesOverlay` around the unchanged form engine, which also leaves `project_picker.cr` untouched.

The add/edit sub-modes of the hostnames and env editors (and env's prefix editor) fold into their parent overlay, so esc there cancels the **sub-mode** and leaves the modal up, exactly as the three separate Runner handlers did. `env_overlay_hints` becomes `EnvOverlay#hint`.

## Verification

`just test` → **4,010 examples, 0 failures**. `spec/tui/overlay_c5_spec.cr` adds 48 examples driving all six through `OverlayHarness`.

Also smoke-tested against the real TUI, because the specs reach the shell only through doubles:

- palette → Settings → PREFERENCES → Appearance → ↵ on the Theme opener → the `SETTINGS · THEME` card; ↓ live-previews; **esc lands back in PREFERENCES** with the preview reverted and nothing persisted
- PREFERENCES → Editor & Keys → ↵ on Hotkeys → `e` → **^C is rejected inline with "Ctrl-C quits gori", stays in capture, and gori does not quit**
- esc unwinds one level at a time: capture → HOTKEYS → PREFERENCES → TABS
- palette → `Settings: Tabs` → `r` → CONFIRM → esc **lands back in TAB BAR**

Two spec bugs of my own were caught by running them rather than by reading: an off-by-three backspace count, and a sequence that overshot the add row, cancelled it, and then had `e` land in the *list* as edit-start — where the entry legitimately is not a duplicate.

`ameba` on the touched files: 52 findings vs **61** on the same files at `main` — no new categories, no new instances.

Closes #355