### PR TITLE
fix(tui): pass hostname overrides from the Fuzzer controller (closes #367)

### DIFF
--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -855,7 +855,8 @@ module Gori::Tui
       # would otherwise apply the stale event to the NEW run's job (premature/wrong
       # "done", orphaned bottom-bar spinner). Draining now settles the old job first.
       drain_events
-      engine, err = v.build_engine(!@host.session.config.insecure_upstream?, @host.session.scope)
+      engine, err = v.build_engine(!@host.session.config.insecure_upstream?,
+        @host.session.scope, @host.session.host_overrides)
       unless engine
         @host.status(err || "cannot run")
         return


### PR DESCRIPTION
Last open site of #367. The CLI and MCP fuzz paths always passed `overrides`; Discover, Miner, Repeater and Sequencer were closed by #373/#374/#375/#377 as part of their Plan migrations. Fuzz was missed because #366 landed **first**, before #367 existed — it added the `overrides` parameter with a nil default and left wiring the caller as a follow-up, and the follower briefs that folded #367 in never came back for fuzz.

So the tool the gap was originally found on was the one still carrying it.

```crystal
# before — overrides takes its nil default, the Fuzzer dials real DNS
engine, err = v.build_engine(!@host.session.config.insecure_upstream?, @host.session.scope)

# after — matching miner_controller.cr:403
engine, err = v.build_engine(!@host.session.config.insecure_upstream?,
  @host.session.scope, @host.session.host_overrides)
```

Passes the session's live `HostOverrides` rather than a fresh `load(store)`, per #367 — the proxy reads that instance and the TUI edits it under a Mutex, so a second copy would not see later edits.

**Failure mode closed:** pin `api.prod.example.com` to a staging IP in the Project tab, fuzz that host from the TUI, and the payloads land on production — while the same run through `gori run fuzz` is pinned correctly.

Verified: `crystal build --no-codegen` clean; `crystal spec spec/fuzz spec/fuzz_spec.cr` 72 examples, 0 failures.

**Deliberately no spec here.** The existing specs pass with the argument absent, which is how this survived four reviews, and no sibling tool has such a spec either — adding one only for fuzz would imply the others are covered. A follow-up should assert all five call sites forward it.

Closes #367