### PR TITLE
refactor(tui): migrate the seven picker modals onto the Overlay seam (#355)

### DIFF
--- a/spec/tui/copy_picker_spec.cr
+++ b/spec/tui/copy_picker_spec.cr
@@ -1,5 +1,6 @@
 require "../spec_helper"
 require "../support/memory_backend"
+require "../support/overlay_harness"
 
 include Gori::Tui
 
@@ -44,5 +45,89 @@ describe Gori::Tui::CopyPicker do
     backend.contains?("COPY REQUEST AS").should be_true
     backend.contains?("URL").should be_true
     backend.contains?("cURL").should be_true
+  end
+end
+
+# --- Overlay seam (issue #355, batch C4) ------------------------------------------
+#
+# CopyPicker is PROMPT-TIER: an Overlay like any migrated modal, but the Runner keeps it
+# in its own slot rather than @active_overlay so it floats over @overlay (the History
+# detail drill-in) instead of replacing it. What it dispatches, though, is the same
+# :stay/:commit/:cancel contract, so it is driven through OverlayHarness here.
+describe "CopyPicker — Overlay contract" do
+  it "names and hints itself exactly as the Runner's deleted ladder arms did" do
+    OverlayHarness.new(sample_picker).assert_chrome(OverlayKind::CopyAs, "COPY REQUEST AS")
+    sample_picker.hint.should eq("↑/↓ select · ↵ copy · key picks · esc cancel")
+  end
+
+  it "copies on ↵ and hands the picked row to the injected closure" do
+    ov = sample_picker
+    h = OverlayHarness.new(ov)
+    picked = [] of String
+    h.on_commit { picked << (ov.selected_option.try(&.label) || "none"); true }
+
+    h.press(Termisu::Input::Key::Down).should eq(:open)
+    h.press(Termisu::Input::Key::Enter).should eq(:closed)
+    picked.size.should eq(1)
+    picked.first.should eq(ov.selected_option.not_nil!.label)
+  end
+
+  it "a row mnemonic selects AND copies in one keystroke" do
+    ov = sample_picker
+    h = OverlayHarness.new(ov)
+    idx = ov.index_for('u').not_nil!
+    h.press(Termisu::Input::Key::LowerU, 'u').should eq(:closed)
+    ov.selected.should eq(idx)
+    h.commits.should eq(1)
+  end
+
+  it "keeps its j/k vim fallback for keys that are NOT mnemonics" do
+    # Deliberately asymmetric with SendPicker, whose 'j' IS a mnemonic (JWT). A shared
+    # picker base is exactly where that difference would get quietly unified away.
+    ov = sample_picker
+    ov.index_for('j').should be_nil
+    h = OverlayHarness.new(ov)
+    h.press(Termisu::Input::Key::LowerJ, 'j').should eq(:open)
+    ov.selected.should eq(1)
+    h.press(Termisu::Input::Key::LowerK, 'k').should eq(:open)
+    ov.selected.should eq(0)
+    h.commits.should eq(0)
+  end
+
+  it "ignores a mnemonic pressed with a modifier (^B is reveal, not 'copy body')" do
+    h = OverlayHarness.new(sample_picker)
+    h.press(Termisu::Input::Key::LowerU, 'u', ctrl: true).should eq(:open)
+    h.commits.should eq(0)
+  end
+
+  it "esc cancels without copying" do
+    h = OverlayHarness.new(sample_picker)
+    h.press(Termisu::Input::Key::Escape).should eq(:closed)
+    h.commits.should eq(0)
+  end
+
+  it "a click on a row copies it; a click outside the card dismisses" do
+    ov = sample_picker
+    h = OverlayHarness.new(ov)
+    h.click_in_box(3, 1).should eq(:closed) # rows start at box.y + 1
+    ov.selected.should eq(0)
+    h.commits.should eq(1)
+
+    away = OverlayHarness.new(sample_picker)
+    away.overlay.handle_click(away.area, 0, 0).should eq(:cancel)
+    away.commits.should eq(0)
+  end
+
+  it "swallows a click inside the card but off the list (never leaks to the pane below)" do
+    h = OverlayHarness.new(sample_picker)
+    box = h.box.not_nil!
+    h.overlay.handle_click(h.area, box.x, box.y).should eq(:stay) # the border
+    h.commits.should eq(0)
+  end
+
+  it "scrolls with the wheel (Runner#handle_wheel delegates to move)" do
+    ov = sample_picker
+    OverlayHarness.new(ov).wheel(1)
+    ov.selected.should eq(1)
   end
 end

--- a/spec/tui/flow_picker_spec.cr
+++ b/spec/tui/flow_picker_spec.cr
@@ -1,0 +1,154 @@
+require "../spec_helper"
+require "../support/memory_backend"
+require "../support/overlay_harness"
+
+include Gori::Tui
+
+private def flow_row(id : Int64, method : String, host : String, target : String) : Gori::Store::FlowRow
+  Gori::Store::FlowRow.new(id, 1_i64, "https", method, host, 443, target,
+    200, 100_i64, Gori::Store::FlowState::Complete, 50_i64, 1_i64, "text/plain")
+end
+
+private def sample_picker(target : Symbol = :a) : FlowPicker
+  FlowPicker.new([
+    flow_row(1_i64, "GET", "app.test", "/login"),
+    flow_row(2_i64, "POST", "api.test", "/search"),
+    flow_row(3_i64, "GET", "cdn.test", "/asset.js"),
+  ], target)
+end
+
+describe Gori::Tui::FlowPicker do
+  it "starts on the newest row with the whole snapshot visible" do
+    p = sample_picker
+    p.entry_count.should eq(3)
+    p.selected.should eq(0)
+    p.selected_row.try(&.id).should eq(1_i64)
+  end
+
+  it "filters on method, host and path, case-insensitively" do
+    p = sample_picker
+    OverlayHarness.new(p).type("POST")
+    p.entry_count.should eq(1)
+    p.selected_row.try(&.host).should eq("api.test")
+  end
+
+  it "requires EVERY whitespace-separated term to match, not the raw string" do
+    p = sample_picker
+    OverlayHarness.new(p).type("get cdn")
+    p.entry_count.should eq(1)
+    p.selected_row.try(&.id).should eq(3_i64)
+  end
+
+  it "⌫ widens the match set again and is a no-op on an empty query" do
+    p = sample_picker
+    h = OverlayHarness.new(p)
+    h.type("api")
+    p.entry_count.should eq(1)
+    h.press(Termisu::Input::Key::Backspace)
+    p.entry_count.should eq(2) # "ap" → app.test and api.test, not cdn.test
+    2.times { h.press(Termisu::Input::Key::Backspace) }
+    p.entry_count.should eq(3)
+    h.press(Termisu::Input::Key::Backspace).should eq(:open)
+    p.entry_count.should eq(3)
+  end
+
+  it "clamps movement at both ends of the filtered list" do
+    p = sample_picker
+    p.move(-5)
+    p.selected.should eq(0)
+    p.move(99)
+    p.selected.should eq(2)
+  end
+
+  it "renders the card heading with its target slot, and the rows" do
+    h = OverlayHarness.new(sample_picker(:b))
+    h.rendered?("PICK FLOW B").should be_true
+    h.rendered?("app.test/login").should be_true
+    h.rendered?("POST").should be_true
+  end
+
+  it "says so rather than drawing nothing when there is no flow to pick" do
+    OverlayHarness.new(FlowPicker.new([] of Gori::Store::FlowRow, :a))
+      .rendered?("no flows captured yet").should be_true
+    h = OverlayHarness.new(sample_picker)
+    h.type("zzzz")
+    h.rendered?("no flows match").should be_true
+  end
+end
+
+# --- Overlay seam (issue #355, batch C4) ------------------------------------------
+describe "FlowPicker — Overlay contract" do
+  it "carries the chrome the Runner's ladder arms used to hard-code" do
+    # focus_label said the literal "PICK FLOW" even though the CARD heading names the slot
+    # ("PICK FLOW A" / "PICK FLOW LINK"). Keep the badge slot-agnostic.
+    OverlayHarness.new(sample_picker).assert_chrome(OverlayKind::ComparerPick, "PICK FLOW")
+    sample_picker(:link).title.should eq("PICK FLOW")
+    sample_picker.hint.should eq("type to filter · ↑/↓ select · ↵ choose · esc cancel")
+  end
+
+  it "routes the SAME :commit to different behaviour purely via the injected closure" do
+    # One picker serves the Comparer (load the flow into slot A/B) and the entity-link flow
+    # (attach it to an issue/note). Before the seam that fork was `if fp.target == :link`
+    # INSIDE the shared commit; now the open-site supplies it and the picker stays dumb.
+    log = [] of String
+
+    slot = OverlayHarness.new(sample_picker(:a))
+    slot.on_commit { log << "set_slot"; true }
+    slot.press(Termisu::Input::Key::Enter).should eq(:closed)
+
+    link = OverlayHarness.new(sample_picker(:link))
+    link.on_commit { log << "add_link"; true }
+    link.press(Termisu::Input::Key::Enter).should eq(:closed)
+
+    log.should eq(["set_slot", "add_link"])
+  end
+
+  it "↵ commits the highlighted row; esc cancels without committing" do
+    ov = sample_picker
+    h = OverlayHarness.new(ov)
+    chosen = [] of Int64
+    h.on_commit { chosen << ov.selected_row.not_nil!.id; true }
+    h.press(Termisu::Input::Key::Down)
+    h.press(Termisu::Input::Key::Enter).should eq(:closed)
+    chosen.should eq([2_i64])
+
+    esc = OverlayHarness.new(sample_picker)
+    esc.press(Termisu::Input::Key::Escape).should eq(:closed)
+    esc.commits.should eq(0)
+  end
+
+  it "keeps the card up when the commit closure reports failure" do
+    h = OverlayHarness.new(sample_picker, commit: false)
+    h.press(Termisu::Input::Key::Enter).should eq(:open)
+    h.commits.should eq(1) # it DID run — it just refused to close
+  end
+
+  it "routes IME preedit into the filter bar" do
+    h = OverlayHarness.new(sample_picker)
+    h.preedit("preedithere")
+    h.rendered?("preedithere").should be_true
+  end
+
+  it "shows the idle hint until something is typed, then the live filter" do
+    h = OverlayHarness.new(sample_picker)
+    h.rendered?("type to filter").should be_true
+    h.rendered?("filter:").should be_false
+    h.type("ap")
+    h.rendered?("filter:").should be_true
+  end
+
+  it "clicking a row commits it; clicking outside dismisses; the wheel scrolls" do
+    ov = sample_picker
+    h = OverlayHarness.new(ov)
+    h.click_in_box(3, 4).should eq(:closed) # list starts at box.y + 3 → second row
+    ov.selected.should eq(1)
+    h.commits.should eq(1)
+
+    away = OverlayHarness.new(sample_picker)
+    away.overlay.handle_click(away.area, 0, 0).should eq(:cancel)
+
+    scrolled = sample_picker
+    OverlayHarness.new(scrolled).wheel(2)
+    scrolled.selected.should eq(2)
+  end
+end

--- a/spec/tui/issue_picker_spec.cr
+++ b/spec/tui/issue_picker_spec.cr
@@ -1,5 +1,6 @@
 require "../spec_helper"
 require "../support/memory_backend"
+require "../support/overlay_harness"
 
 include Gori::Tui
 
@@ -73,5 +74,74 @@ describe Gori::Tui::IssuePicker do
     backend.contains?("+ New issue…").should be_true
     backend.contains?("Reflected XSS").should be_true
     backend.contains?("SQL injection").should be_true
+  end
+end
+
+# --- Overlay seam (issue #355, batch C4) ------------------------------------------
+describe "IssuePicker — Overlay contract" do
+  it "carries the chrome the Runner's ladder arms used to hard-code" do
+    OverlayHarness.new(sample_picker).assert_chrome(OverlayKind::IssuePick, "PICK ISSUE")
+    # The bottom row says "link"; the card's own hint row also names the create action.
+    sample_picker.hint.should eq("type to filter · ↑/↓ select · ↵ link · esc cancel")
+    OverlayHarness.new(sample_picker).rendered?("↵ link / create").should be_true
+  end
+
+  it "keeps the pinned create row out of the filtered count (the off-by-one)" do
+    ov = sample_picker
+    OverlayHarness.new(ov).type("sql")
+    ov.entry_count.should eq(2) # "+ New issue…" plus the one match
+    ov.selected.should eq(1)
+    ov.selected_create?.should be_false
+    ov.selected_issue.try(&.id).should eq(2_i64)
+    ov.move(-1)
+    ov.selected_create?.should be_true
+    ov.selected_issue.should be_nil
+  end
+
+  it "lands on the create row when nothing matches" do
+    ov = sample_picker
+    OverlayHarness.new(ov).type("zzzz")
+    ov.entry_count.should eq(1)
+    ov.selected_create?.should be_true
+  end
+
+  it "↵ on an existing issue commits it to the injected closure" do
+    ov = sample_picker
+    h = OverlayHarness.new(ov)
+    linked = [] of Int64
+    h.on_commit { linked << ov.selected_issue.not_nil!.id; true }
+    h.press(Termisu::Input::Key::Enter).should eq(:closed)
+    linked.should eq([1_i64])
+  end
+
+  it "↵ on the create row is still a plain :commit — the closure decides what create means" do
+    # Runner#link_picked_issue answers that :commit by opening the NEW ISSUE form and
+    # reporting FALSE, because close_active_overlay would otherwise wipe the @overlay that
+    # form just claimed. Mirrored here: the overlay must not special-case the create row.
+    ov = IssuePicker.new([] of Gori::Store::Issue)
+    ov.selected_create?.should be_true
+    h = OverlayHarness.new(ov)
+    creates = 0
+    h.on_commit do
+      creates += 1 if ov.selected_create?
+      false # "I put my own modal up — do not close me"
+    end
+    h.press(Termisu::Input::Key::Enter).should eq(:open)
+    creates.should eq(1)
+  end
+
+  it "esc cancels; a row click commits; a click away dismisses" do
+    esc = OverlayHarness.new(sample_picker)
+    esc.press(Termisu::Input::Key::Escape).should eq(:closed)
+    esc.commits.should eq(0)
+
+    ov = sample_picker
+    click = OverlayHarness.new(ov)
+    click.click_in_box(3, 4).should eq(:closed) # list starts at box.y + 3 → second row
+    ov.selected.should eq(1)
+    click.commits.should eq(1)
+
+    away = OverlayHarness.new(sample_picker)
+    away.overlay.handle_click(away.area, 0, 0).should eq(:cancel)
   end
 end

--- a/spec/tui/links_overlay_spec.cr
+++ b/spec/tui/links_overlay_spec.cr
@@ -1,0 +1,257 @@
+require "../spec_helper"
+require "../support/memory_backend"
+require "../support/overlay_harness"
+
+include Gori::Tui
+
+# LinksOverlay is the one C4 modal that is not a plain list: adding a link is a two-step
+# flow that used to span the shell as three Runner ivars (@link_add_owner /
+# @link_add_ref_kind plus the picker) and a pair of close methods that rebuilt this
+# overlay from scratch on every sub-picker exit. The seam has ONE @active_overlay, so the
+# sub-picker is held here instead and this overlay forwards to it. These specs pin both
+# halves: the browse-mode keys, and the child lifecycle.
+
+private def flow_row(id : Int64) : Gori::Store::FlowRow
+  Gori::Store::FlowRow.new(id, 1_i64, "https", "GET", "app.test", 443, "/p#{id}",
+    200, 100_i64, Gori::Store::FlowState::Complete, 50_i64, 1_i64, "text/plain")
+end
+
+private def child_picker : FlowPicker
+  FlowPicker.new([flow_row(1_i64), flow_row(2_i64)], :link)
+end
+
+private def links_for(store, owner_id : Int64) : LinksOverlay
+  lo = LinksOverlay.new(Gori::Store::LinkOwnerKind::Issue, owner_id)
+  lo.reload(store)
+  lo
+end
+
+private def with_store(&)
+  path = File.tempname("gori-links", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+describe Gori::Tui::LinksOverlay do
+  it "names itself after its owner and carries both mode hints" do
+    lo = LinksOverlay.new(Gori::Store::LinkOwnerKind::Issue, 7_i64)
+    OverlayHarness.new(lo).assert_chrome(OverlayKind::Links, "LINKS — ISSUE #7")
+    LinksOverlay.new(Gori::Store::LinkOwnerKind::Note, 3_i64).title.should eq("LINKS — NOTE #3")
+    lo.hint.should eq("↑/↓ · ↵/o open · a add · d remove · esc close")
+  end
+
+  it "swaps the hint when `a` arms adding (was a ternary in the Runner's ladder)" do
+    lo = LinksOverlay.new(Gori::Store::LinkOwnerKind::Issue, 1_i64)
+    h = OverlayHarness.new(lo)
+    h.press(Termisu::Input::Key::LowerA, 'a').should eq(:open)
+    lo.adding?.should be_true
+    lo.hint.should eq("f/r/z/m pick type · esc back")
+    h.rendered?("choose type to add…").should be_true
+  end
+
+  it "esc backs out of adding, driven with the char a real terminal sends" do
+    # REGRESSION GUARD, and a warning about the harness. gori enables the Kitty keyboard
+    # protocol unconditionally (app.cr), under which Escape arrives as `CSI 27 u` and the
+    # parser attaches `char: '\e'`. The pre-seam shell read `ev.char || key.to_char` and
+    # backed out of adding on that branch — which reads like dead code, because termisu's
+    # `Key#to_char` has NO mapping for Escape, and `OverlayHarness#press(Key::Escape)`
+    # defaults `char: nil`. Driving it the harness's default way builds the legacy event
+    # shape the app never receives, passes, and hides a modal the keyboard cannot leave.
+    lo = LinksOverlay.new(Gori::Store::LinkOwnerKind::Issue, 1_i64)
+    h = OverlayHarness.new(lo)
+    h.press(Termisu::Input::Key::LowerA, 'a')
+    lo.adding?.should be_true
+    h.press(Termisu::Input::Key::Escape, '\e').should eq(:open)
+    lo.adding?.should be_false
+    lo.pending_add.should be_nil
+    # …and a second esc, now in browse, closes the card.
+    h.press(Termisu::Input::Key::Escape, '\e').should eq(:closed)
+  end
+
+  it "backs out on a legacy bare ESC too (char nil), not just the Kitty shape" do
+    lo = LinksOverlay.new(Gori::Store::LinkOwnerKind::Issue, 1_i64)
+    h = OverlayHarness.new(lo)
+    h.press(Termisu::Input::Key::LowerA, 'a')
+    h.press(Termisu::Input::Key::Escape).should eq(:open)
+    lo.adding?.should be_false
+  end
+
+  it "swallows any other key while adding rather than half-leaving the flow" do
+    lo = LinksOverlay.new(Gori::Store::LinkOwnerKind::Issue, 1_i64)
+    h = OverlayHarness.new(lo)
+    h.press(Termisu::Input::Key::LowerA, 'a')
+    h.press(Termisu::Input::Key::LowerX, 'x').should eq(:open)
+    lo.adding?.should be_true
+    lo.pending_add.should be_nil
+  end
+
+  it "spells out each source key on the CARD, where there is room for it" do
+    # The card hint and the shell's bottom-row hint are deliberately different strings:
+    # only the card has the width to say which key means which source. Collapsing them
+    # onto the terse bottom-row pair silently drops the only z=fuzz / m=miner legend.
+    lo = LinksOverlay.new(Gori::Store::LinkOwnerKind::Issue, 1_i64)
+    h = OverlayHarness.new(lo)
+    h.rendered?("↑/↓ select · ↵/o open · a add · d remove · esc close").should be_true
+    lo.hint.should eq("↑/↓ · ↵/o open · a add · d remove · esc close")
+
+    h.press(Termisu::Input::Key::LowerA, 'a')
+    h.rendered?("add: f flow · r repeater · z fuzz · m miner · esc back").should be_true
+    lo.hint.should eq("f/r/z/m pick type · esc back")
+  end
+
+  it "browse: k/j navigate like ↑/↓, d removes and stays, esc cancels" do
+    with_store do |store|
+      id = store.insert_issue("target", Gori::Store::Severity::High, "app.test", nil)
+      3.times { |i| store.add_link(Gori::Store::LinkOwnerKind::Issue, id, Gori::Store::LinkRefKind::Repeater, (i + 1).to_i64) }
+      lo = links_for(store, id)
+      lo.count.should eq(3)
+
+      removes = 0
+      lo.on_remove = -> { removes += 1; nil }
+      h = OverlayHarness.new(lo)
+      h.press(Termisu::Input::Key::LowerJ).should eq(:open)
+      lo.selected.should eq(1)
+      h.press(Termisu::Input::Key::LowerK).should eq(:open)
+      lo.selected.should eq(0)
+
+      h.press(Termisu::Input::Key::LowerD, 'd').should eq(:open) # removing is repeatable
+      removes.should eq(1)
+      h.commits.should eq(0) # remove is NOT the commit action
+
+      esc = OverlayHarness.new(lo)
+      esc.press(Termisu::Input::Key::Escape).should eq(:closed)
+      esc.commits.should eq(0)
+    end
+  end
+
+  it "↵ and `o` are the same open action" do
+    with_store do |store|
+      id = store.insert_issue("target", Gori::Store::Severity::High, "app.test", nil)
+      store.add_link(Gori::Store::LinkOwnerKind::Issue, id, Gori::Store::LinkRefKind::Repeater, 7_i64)
+      lo = links_for(store, id)
+
+      enter = OverlayHarness.new(lo)
+      enter.press(Termisu::Input::Key::Enter).should eq(:closed)
+      enter.commits.should eq(1)
+
+      o = OverlayHarness.new(lo)
+      o.press(Termisu::Input::Key::LowerO, 'o').should eq(:closed)
+      o.commits.should eq(1)
+    end
+  end
+
+  it "a ↵ with nothing to open keeps the card up (the old open_selected_link guard)" do
+    # Runner#open_link_target reports false in exactly this case — and also after a real
+    # open, because it closes itself first so navigate_link_ref's own @overlay survives.
+    lo = LinksOverlay.new(Gori::Store::LinkOwnerKind::Issue, 1_i64)
+    lo.selected_link.should be_nil
+    h = OverlayHarness.new(lo, commit: false)
+    h.press(Termisu::Input::Key::Enter).should eq(:open)
+    h.rendered?("no links yet — press a to add").should be_true
+  end
+
+  it "row clicks open, clicks away dismiss, clicks off the list are swallowed" do
+    with_store do |store|
+      id = store.insert_issue("target", Gori::Store::Severity::High, "app.test", nil)
+      store.add_link(Gori::Store::LinkOwnerKind::Issue, id, Gori::Store::LinkRefKind::Repeater, 7_i64)
+      lo = links_for(store, id)
+
+      h = OverlayHarness.new(lo)
+      h.click_in_box(3, 3).should eq(:closed) # list starts at box.y + 3
+      h.commits.should eq(1)
+
+      away = OverlayHarness.new(links_for(store, id))
+      away.overlay.handle_click(away.area, 0, 0).should eq(:cancel)
+
+      inside = OverlayHarness.new(links_for(store, id))
+      box = inside.box.not_nil!
+      inside.overlay.handle_click(inside.area, box.x, box.y).should eq(:stay)
+      inside.commits.should eq(0)
+    end
+  end
+
+  it "can be rebuilt on a chosen row, for the add path that never left the list" do
+    # Runner#open_link_add_picker uses this when a source has nothing to link ("no fuzz
+    # sessions to link"): the user never left the card, so it is rebuilt on the row they
+    # were on instead of snapping to the top. The ordinary pop-back after a sub-picker
+    # does start at the top, which is what the pre-seam rebuild did.
+    with_store do |store|
+      id = store.insert_issue("t", Gori::Store::Severity::High, "app.test", nil)
+      3.times { |i| store.add_link(Gori::Store::LinkOwnerKind::Issue, id, Gori::Store::LinkRefKind::Repeater, (i + 1).to_i64) }
+      lo = links_for(store, id)
+      lo.selected.should eq(0)
+      lo.set_selected(2)
+      lo.selected.should eq(2)
+      # Out of range is clamped, not an index error — the list may have shrunk meanwhile.
+      lo.set_selected(99)
+      lo.selected.should eq(2)
+    end
+  end
+end
+
+describe "LinksOverlay — the add hand-off (Overlay#on_close nested-modal seam)" do
+  it "arms pending_add and reports :cancel so the shell can swap in the sub-picker" do
+    # The shell holds exactly ONE modal, so this card has to go before the sub-picker
+    # arrives. :cancel drops it; on_close (injected by Runner#open_links_overlay) then
+    # reads pending_add and opens the picker in its place.
+    lo = LinksOverlay.new(Gori::Store::LinkOwnerKind::Note, 4_i64)
+    lo.pending_add.should be_nil
+    h = OverlayHarness.new(lo)
+    h.press(Termisu::Input::Key::LowerA, 'a').should eq(:open)
+    h.press(Termisu::Input::Key::LowerR, 'r').should eq(:closed)
+    lo.pending_add.should eq('r')
+    h.commits.should eq(0) # arming an add is NOT the card's commit action
+  end
+
+  it "accepts each of the four source keys and only those" do
+    "frzm".each_char do |k|
+      lo = LinksOverlay.new(Gori::Store::LinkOwnerKind::Issue, 1_i64)
+      h = OverlayHarness.new(lo)
+      h.press(Termisu::Input::Key::LowerA, 'a')
+      h.press(Termisu::Input::Key::LowerF, k).should eq(:closed)
+      lo.pending_add.should eq(k)
+    end
+
+    other = LinksOverlay.new(Gori::Store::LinkOwnerKind::Issue, 1_i64)
+    oh = OverlayHarness.new(other)
+    oh.press(Termisu::Input::Key::LowerA, 'a')
+    oh.press(Termisu::Input::Key::LowerX, 'x').should eq(:open) # not a source
+    other.pending_add.should be_nil
+    other.adding?.should be_true
+  end
+
+  it "leaves pending_add nil on every exit that is NOT an add" do
+    # on_close is shared between the add hand-off and the ↵/o navigation, so a stale
+    # pending_add would re-open a picker after the user simply closed the card.
+    esc = LinksOverlay.new(Gori::Store::LinkOwnerKind::Issue, 1_i64)
+    OverlayHarness.new(esc).press(Termisu::Input::Key::Escape).should eq(:closed)
+    esc.pending_add.should be_nil
+
+    with_store do |store|
+      id = store.insert_issue("t", Gori::Store::Severity::High, "app.test", nil)
+      store.add_link(Gori::Store::LinkOwnerKind::Issue, id, Gori::Store::LinkRefKind::Repeater, 7_i64)
+      open_lo = links_for(store, id)
+      OverlayHarness.new(open_lo).press(Termisu::Input::Key::Enter).should eq(:closed)
+      open_lo.pending_add.should be_nil
+    end
+  end
+
+  it "an armed add survives as the ONLY armed exit (on_close picks one branch)" do
+    # Mirrors Runner#open_links_overlay's on_close: `if pending_add … elsif opening …`.
+    lo = LinksOverlay.new(Gori::Store::LinkOwnerKind::Issue, 1_i64)
+    h = OverlayHarness.new(lo)
+    opened = [] of String
+    h.on_commit { opened << "navigate"; true }
+    h.press(Termisu::Input::Key::LowerA, 'a')
+    h.press(Termisu::Input::Key::LowerZ, 'z').should eq(:closed)
+    lo.pending_add.should eq('z')
+    opened.should be_empty # the add path must not also trigger the open path
+  end
+end

--- a/spec/tui/note_picker_spec.cr
+++ b/spec/tui/note_picker_spec.cr
@@ -1,5 +1,6 @@
 require "../spec_helper"
 require "../support/memory_backend"
+require "../support/overlay_harness"
 
 include Gori::Tui
 
@@ -58,5 +59,64 @@ describe Gori::Tui::NotePicker do
     backend.contains?("+ New note…").should be_true
     backend.contains?("1:XSS notes").should be_true
     backend.contains?("2:Auth flow").should be_true
+  end
+end
+
+# --- Overlay seam (issue #355, batch C4) ------------------------------------------
+describe "NotePicker — Overlay contract" do
+  it "carries the chrome the Runner's ladder arms used to hard-code" do
+    OverlayHarness.new(sample_picker).assert_chrome(OverlayKind::NotePick, "PICK NOTE")
+    sample_picker.hint.should eq("type to filter · ↑/↓ select · ↵ link · esc cancel")
+    OverlayHarness.new(sample_picker).rendered?("↵ link / create").should be_true
+  end
+
+  it "keeps the pinned create row out of the filtered count (the off-by-one)" do
+    ov = sample_picker
+    OverlayHarness.new(ov).type("auth")
+    ov.entry_count.should eq(2) # "+ New note…" plus the one match
+    ov.selected.should eq(1)
+    ov.selected_row.try(&.id).should eq(11_i64)
+    ov.move(-1)
+    ov.selected_create?.should be_true
+    ov.selected_row.should be_nil
+  end
+
+  it "↵ on an existing note commits it to the injected closure" do
+    ov = sample_picker
+    h = OverlayHarness.new(ov)
+    linked = [] of Int64
+    h.on_commit { linked << ov.selected_row.not_nil!.id; true }
+    h.press(Termisu::Input::Key::Enter).should eq(:closed)
+    linked.should eq([10_i64])
+  end
+
+  it "↵ on the create row is a plain :commit that the closure may decline to close" do
+    # Runner#link_picked_note creates the note, links it, and hands off to the open-vs-stay
+    # CONFIRM modal — so it reports false, or close_active_overlay would wipe that confirm.
+    ov = NotePicker.new([] of NotePicker::Row)
+    ov.selected_create?.should be_true
+    h = OverlayHarness.new(ov)
+    creates = 0
+    h.on_commit do
+      creates += 1 if ov.selected_create?
+      false
+    end
+    h.press(Termisu::Input::Key::Enter).should eq(:open)
+    creates.should eq(1)
+  end
+
+  it "esc cancels; a row click commits; a click away dismisses" do
+    esc = OverlayHarness.new(sample_picker)
+    esc.press(Termisu::Input::Key::Escape).should eq(:closed)
+    esc.commits.should eq(0)
+
+    ov = sample_picker
+    click = OverlayHarness.new(ov)
+    click.click_in_box(3, 4).should eq(:closed) # list starts at box.y + 3 → second row
+    ov.selected.should eq(1)
+    click.commits.should eq(1)
+
+    away = OverlayHarness.new(sample_picker)
+    away.overlay.handle_click(away.area, 0, 0).should eq(:cancel)
   end
 end

--- a/spec/tui/overlay_dispatch_spec.cr
+++ b/spec/tui/overlay_dispatch_spec.cr
@@ -32,7 +32,7 @@ private EXPECTED_OVERLAY_SYMS = {
   :settings, :tabs, :hosts, :env, :hotkeys, :notifications, :probe_active,
   :discover_config, :discover_headers, :fuzz_set, :fuzz_advanced, :oast_provider,
   :probe_rule, :rewriter_rule, :ca_import, :import, :scope_rule, :sequence_config,
-  :mine_config,
+  :mine_config, :copy_as, :send_to,
 }
 
 # The migration ledger — THE one line a Phase 1 batch edits in this file. Each batch
@@ -61,12 +61,26 @@ private MIGRATED_KINDS = [
   OverlayKind::Confirm,
   OverlayKind::Browser,
   OverlayKind::Choice,
+  # C4 — pickers
+  OverlayKind::ComparerPick,
+  OverlayKind::RepeaterSubtab,
+  OverlayKind::Links,
+  OverlayKind::IssuePick,
+  OverlayKind::NotePick,
 ]
 
-# Never in MODAL_OVERLAYS by design, migrated or not: neither draws a capturing card.
-# `None` is "no modal at all" and `Detail` is the History drill-in, which the Runner keeps
-# in the tab body rather than a centered card (see Runner#modal_overlay?).
-private NON_MODAL_KINDS = [OverlayKind::None, OverlayKind::Detail]
+# Never in MODAL_OVERLAYS by design, migrated or not. `None` is "no modal at all" and
+# `Detail` is the History drill-in, which the Runner keeps in the tab body rather than a
+# centered card (see Runner#modal_overlay?). `CopyAs`/`SendTo` (C4) DO draw a card, but the
+# Runner holds those two in their own slots so they float OVER `@overlay` instead of
+# replacing it — listing either would make `modal_overlay?` true while `@overlay` still
+# says `:detail`, routing clicks into a modal that is not the one on screen.
+private NON_MODAL_KINDS = [
+  OverlayKind::None,
+  OverlayKind::Detail,
+  OverlayKind::CopyAs,
+  OverlayKind::SendTo,
+]
 
 # A minimal Overlay to pin the base-class defaults the Runner leans on. Its `key` has to
 # name a real OverlayKind (that is the type), and Palette is the safe pick: the command

--- a/spec/tui/picker_overlay_spec.cr
+++ b/spec/tui/picker_overlay_spec.cr
@@ -1,0 +1,151 @@
+require "../spec_helper"
+require "../support/memory_backend"
+require "../support/overlay_harness"
+
+include Gori::Tui
+
+# PickerOverlay / FilterPickerOverlay are the base the seven C4 selection-list modals
+# share (issue #355). Each of them used to repeat the same dispatch by hand in runner.cr;
+# unifying seven copies is exactly where a "harmless" tidy silently changes behaviour, so
+# what is pinned here is the base's own contract, once, for every subclass at the same
+# time. The per-modal files own the behaviour that actually differs.
+
+# What the shell really hands an overlay on an 80x24 terminal: layout.body, which is
+# 6 rows shorter and offset from OverlayHarness::DEFAULT_AREA (the whole screen).
+private PROD_BODY = Gori::Tui::Rect.new(2, 4, 76, 18)
+
+# Small enough that EVERY C4 card bails out of overlay_box with nil. The filter pickers
+# floor at w<30/h<8 and the prompt-tier ones at w<18/h<5, so this clears the lower bound.
+private NO_ROOM = Gori::Tui::Rect.new(0, 0, 20, 4)
+
+private def flow_rows : Array(Gori::Store::FlowRow)
+  (1..3).map do |i|
+    Gori::Store::FlowRow.new(i.to_i64, 1_i64, "https", "GET", "h#{i}.test", 443, "/p#{i}",
+      200, 100_i64, Gori::Store::FlowState::Complete, 50_i64, 1_i64, "text/plain")
+  end
+end
+
+private def every_picker : Array(PickerOverlay)
+  [
+    FlowPicker.new(flow_rows, :a),
+    SubtabPicker.new("FIND SUB-TAB", [SubtabPicker::Row.new(0, "a", "b")]),
+    IssuePicker.new([Gori::Store::Issue.new(1_i64, 0_i64, 0_i64, "t", Gori::Store::Severity::High, "h.test", nil, "")]),
+    NotePicker.new([NotePicker::Row.new(1_i64, "n", "d")]),
+    LinksOverlay.new(Gori::Store::LinkOwnerKind::Issue, 1_i64),
+    CopyPicker.new("COPY AS", [CopyMenu::Option.new("URL", 'u', "https://a.test/")]),
+    SendPicker.new("Send selection to", "abc", SendMenu.destinations),
+  ] of PickerOverlay
+end
+
+describe Gori::Tui::PickerOverlay do
+  it "clamps the cursor at both ends for every picker" do
+    every_picker.each do |ov|
+      ov.move(-99)
+      ov.selected.should eq(0), "#{ov.class} underflowed"
+      ov.move(99)
+      ov.selected.should eq({ov.entry_count - 1, 0}.max), "#{ov.class} overflowed"
+    end
+  end
+
+  it "leaves the cursor alone on an empty list rather than going negative" do
+    # entry_count 0 has no valid index; the pre-migration guards were `return if empty?`.
+    [FlowPicker.new([] of Gori::Store::FlowRow, :a),
+     SubtabPicker.new("FIND SUB-TAB", [] of SubtabPicker::Row),
+     LinksOverlay.new(Gori::Store::LinkOwnerKind::Issue, 1_i64),
+     CopyPicker.new("COPY AS", [] of CopyMenu::Option),
+     SendPicker.new("Send selection to", "x", [] of SendMenu::Destination)].each do |ov|
+      ov.entry_count.should eq(0), "#{ov.class} is not actually empty"
+      ov.move(1)
+      ov.selected.should eq(0)
+      ov.set_selected(5)
+      ov.selected.should eq(0)
+    end
+  end
+
+  it "the wheel scrolls the list — the base routes handle_wheel to move" do
+    ov = FlowPicker.new(flow_rows, :a)
+    OverlayHarness.new(ov).wheel(2)
+    ov.selected.should eq(2)
+  end
+
+  it "still centres a card in layout.body, not just in the harness's full screen" do
+    # DEFAULT_AREA is the whole 80x24 screen; production gives 76x18 at (2,4). A card that
+    # only fits in the former would be a nil box — an unclickable modal — in the real app.
+    every_picker.each do |ov|
+      box = ov.overlay_box(PROD_BODY)
+      box.should_not be_nil, "#{ov.class} has no box at the production body size"
+      b = box.not_nil!
+      PROD_BODY.contains?(b.x, b.y).should be_true, "#{ov.class} starts outside the body"
+      (b.right <= PROD_BODY.right).should be_true, "#{ov.class} overflows the body width"
+      (b.bottom <= PROD_BODY.bottom).should be_true, "#{ov.class} overflows the body height"
+    end
+  end
+
+  it "turns EVERY click into a dismiss once the terminal is too small to draw the card" do
+    # Every pre-migration handler opened with `box.nil? || dismiss_zone? → close`. The base
+    # has to keep that: with no card on screen there is nothing to hit, and swallowing the
+    # click would strand the user in an invisible modal.
+    every_picker.each do |ov|
+      ov.overlay_box(NO_ROOM).should be_nil, "#{ov.class} still claims a box at 20x4"
+      ov.handle_click(NO_ROOM, 5, 3).should eq(:cancel), "#{ov.class} swallowed a click with no card"
+    end
+  end
+  it "answers a click on an EMPTY picker instead of raising out of the event loop" do
+    # CopyPicker/SendPicker size their card from the widest row, via a max_of that throws
+    # on an empty list — and the base calls overlay_box on EVERY click. Both open-sites
+    # refuse to open an empty picker today, so this is unreachable; it is guarded because
+    # the base now makes "a click outside dismisses" a promise for all seven, and an
+    # Enumerable::EmptyError out of handle_click would take the event loop with it.
+    area = Gori::Tui::Rect.new(0, 0, 80, 24)
+    [CopyPicker.new("COPY AS", [] of CopyMenu::Option),
+     SendPicker.new("Send selection to", "x", [] of SendMenu::Destination)].each do |ov|
+      ov.overlay_box(area).should be_nil, "#{ov.class} sized a card from zero rows"
+      ov.handle_click(area, 5, 5).should eq(:cancel)
+    end
+
+    # The filter pickers keep a fixed-size card, so an empty one still has a box: a click
+    # inside is swallowed, a click outside dismisses. Neither may raise.
+    [FlowPicker.new([] of Gori::Store::FlowRow, :a),
+     SubtabPicker.new("FIND SUB-TAB", [] of SubtabPicker::Row)].each do |ov|
+      box = ov.overlay_box(area).not_nil!
+      ov.handle_click(area, box.x + 3, box.y + 4).should eq(:stay)
+      ov.handle_click(area, 0, 0).should eq(:cancel)
+    end
+  end
+end
+
+describe Gori::Tui::FilterPickerOverlay do
+  it "reports :stay for a filter keystroke and :commit/:cancel only for ↵/esc" do
+    # The raw vocabulary, not the harness's collapsed :open/:closed — a filter key that
+    # leaked :commit would apply the modal on every character typed.
+    ov = FlowPicker.new(flow_rows, :a)
+    ov.handle_key(Termisu::Event::Key.new(Termisu::Input::Key::LowerA, char: 'h')).should eq(:stay)
+    ov.handle_key(Termisu::Event::Key.new(Termisu::Input::Key::Down)).should eq(:stay)
+    ov.handle_key(Termisu::Event::Key.new(Termisu::Input::Key::Backspace)).should eq(:stay)
+    ov.handle_key(Termisu::Event::Key.new(Termisu::Input::Key::Enter)).should eq(:commit)
+    ov.handle_key(Termisu::Event::Key.new(Termisu::Input::Key::Escape)).should eq(:cancel)
+  end
+
+  it "drops control characters from the filter instead of typing them in" do
+    # handle_key's `else` arm forwards whatever ev.char it is given, so the control guard
+    # has to live in query_char — otherwise a stray tab or escape byte lands in the query
+    # and silently filters every row away with no visible cause.
+    ov = FlowPicker.new(flow_rows, :a)
+    ov.query_char('\t')
+    ov.query_char('\e')
+    ov.entry_count.should eq(3)
+    OverlayHarness.new(ov).rendered?("filter:").should be_false # the query is still empty
+
+    ov.query_char('h') # ...but a printable one does go in
+    OverlayHarness.new(ov).rendered?("filter:").should be_true
+  end
+
+  it "a committed character ends an in-progress IME composition" do
+    # Otherwise the preedit underline lingers next to text that already committed.
+    h = OverlayHarness.new(FlowPicker.new(flow_rows, :a))
+    h.preedit("preedithere")
+    h.rendered?("preedithere").should be_true
+    h.type("h")
+    h.rendered?("preedithere").should be_false
+  end
+end

--- a/spec/tui/send_picker_spec.cr
+++ b/spec/tui/send_picker_spec.cr
@@ -1,5 +1,6 @@
 require "../spec_helper"
 require "../support/memory_backend"
+require "../support/overlay_harness"
 
 include Gori::Tui
 
@@ -53,5 +54,66 @@ describe Gori::Tui::SendMenu do
     dests = SendMenu.destinations
     dests.any? { |d| d.tab == :decoder }.should be_true
     dests.map(&.key).uniq.size.should eq(dests.size) # mnemonics are unique
+  end
+end
+
+# --- Overlay seam (issue #355, batch C4) ------------------------------------------
+#
+# Prompt-tier, exactly like CopyPicker: an Overlay the Runner keeps in its own slot so it
+# floats over @overlay rather than replacing it.
+describe "SendPicker — Overlay contract" do
+  it "names itself SEND TO, not by the card's own sentence heading" do
+    # focus_label showed the literal "SEND TO"; the card says "Send selection to · 8 B".
+    # A region badge is a name, not a sentence — keep them distinct.
+    OverlayHarness.new(sample_picker).assert_chrome(OverlayKind::SendTo, "SEND TO")
+    sample_picker.hint.should eq("↑/↓ select · ↵ send · key picks · esc cancel")
+    OverlayHarness.new(sample_picker).rendered?("Send selection to").should be_true
+  end
+
+  it "sends on ↵ and hands the picked destination to the injected closure" do
+    ov = sample_picker
+    h = OverlayHarness.new(ov)
+    sent = [] of Symbol
+    h.on_commit { sent << ov.selected_destination.not_nil!.tab; true }
+    h.press(Termisu::Input::Key::Down).should eq(:open)
+    h.press(Termisu::Input::Key::Enter).should eq(:closed)
+    sent.should eq([:sequencer])
+  end
+
+  it "has NO j/k fallback — 'j' is the JWT mnemonic and must send" do
+    # The real destination list includes JWT at 'j'. A j/k nav fallback (which CopyPicker
+    # does keep) would shadow that mnemonic and be asymmetric: k moves up, j sends.
+    dests = SendMenu.destinations
+    ov = SendPicker.new("Send selection to", "abc", dests)
+    ov.index_for('j').should_not be_nil
+    h = OverlayHarness.new(ov)
+    h.press(Termisu::Input::Key::LowerJ, 'j').should eq(:closed)
+    ov.selected_destination.try(&.tab).should eq(:jwt)
+    h.commits.should eq(1)
+  end
+
+  it "swallows a non-mnemonic key rather than navigating" do
+    ov = sample_picker
+    ov.index_for('k').should be_nil
+    h = OverlayHarness.new(ov)
+    h.press(Termisu::Input::Key::LowerK, 'k').should eq(:open)
+    ov.selected.should eq(0)
+    h.commits.should eq(0)
+  end
+
+  it "esc cancels without sending; a click on a row sends; a click away dismisses" do
+    esc = OverlayHarness.new(sample_picker)
+    esc.press(Termisu::Input::Key::Escape).should eq(:closed)
+    esc.commits.should eq(0)
+
+    ov = sample_picker
+    click = OverlayHarness.new(ov)
+    click.click_in_box(3, 2).should eq(:closed) # rows start at box.y + 1 → second row
+    ov.selected.should eq(1)
+    click.commits.should eq(1)
+
+    away = OverlayHarness.new(sample_picker)
+    away.overlay.handle_click(away.area, 0, 0).should eq(:cancel)
+    away.commits.should eq(0)
   end
 end

--- a/spec/tui/subtab_picker_spec.cr
+++ b/spec/tui/subtab_picker_spec.cr
@@ -1,5 +1,6 @@
 require "../spec_helper"
 require "../support/memory_backend"
+require "../support/overlay_harness"
 
 include Gori::Tui
 
@@ -64,5 +65,85 @@ describe Gori::Tui::SubtabPicker do
     backend.contains?("FIND SUB-TAB").should be_true
     backend.contains?("login").should be_true
     backend.contains?("checkout").should be_true
+  end
+end
+
+# --- Overlay seam (issue #355, batch C4) ------------------------------------------
+describe "SubtabPicker — Overlay contract" do
+  it "carries the chrome, with a ↵ verb that varies by open-site" do
+    # The Runner interpolated `@subtab_picker.action` into its hint arm; the overlay owns
+    # that now, and the card's own hint row must read the same string as the bottom row.
+    search = sample_picker
+    OverlayHarness.new(search).assert_chrome(OverlayKind::RepeaterSubtab, "FIND SUB-TAB")
+    search.hint.should eq("type to filter · ↑/↓ select · ↵ jump · esc cancel")
+    OverlayHarness.new(search).rendered?("↵ jump").should be_true
+
+    link = SubtabPicker.new("PICK REPEATER", [SubtabPicker::Row.new(0, "a", "b")], action: "link")
+    link.title.should eq("PICK REPEATER")
+    link.hint.should eq("type to filter · ↑/↓ select · ↵ link · esc cancel")
+    OverlayHarness.new(link).rendered?("↵ link").should be_true
+  end
+
+  it "hands back the ABSOLUTE sub-tab index, not the filtered position" do
+    # jump_subtab and db_id_at both index the real strip, so returning the filtered offset
+    # would jump to — or link — the wrong session the moment a filter is typed.
+    ov = sample_picker
+    OverlayHarness.new(ov).type("checkout")
+    ov.entry_count.should eq(1)
+    ov.selected.should eq(0)
+    ov.selected_index.should eq(2)
+  end
+
+  it "resets the cursor to the top of each new match set" do
+    ov = sample_picker
+    h = OverlayHarness.new(ov)
+    h.press(Termisu::Input::Key::Down)
+    ov.selected.should eq(1)
+    h.type("e") # login/search api/checkout all still match
+    ov.entry_count.should eq(3)
+    ov.selected.should eq(0)
+  end
+
+  it "↵ commits the highlighted row; esc cancels without committing" do
+    ov = sample_picker
+    h = OverlayHarness.new(ov)
+    jumped = [] of Int32
+    h.on_commit { jumped << ov.selected_index.not_nil!; true }
+    h.press(Termisu::Input::Key::Down)
+    h.press(Termisu::Input::Key::Enter).should eq(:closed)
+    jumped.should eq([1])
+
+    esc = OverlayHarness.new(sample_picker)
+    esc.press(Termisu::Input::Key::Escape).should eq(:closed)
+    esc.commits.should eq(0)
+  end
+
+  it "⌫ widens the filter again and is a no-op on an empty query" do
+    ov = sample_picker
+    h = OverlayHarness.new(ov)
+    h.type("checkout")
+    ov.entry_count.should eq(1)
+    8.times { h.press(Termisu::Input::Key::Backspace) }
+    ov.entry_count.should eq(3)
+    h.press(Termisu::Input::Key::Backspace).should eq(:open) # already empty
+    ov.entry_count.should eq(3)
+  end
+
+  it "routes IME preedit into the filter bar" do
+    h = OverlayHarness.new(sample_picker)
+    h.preedit("preedithere")
+    h.rendered?("preedithere").should be_true
+    h.rendered?("filter:").should be_true
+  end
+
+  it "clicking a row commits it; clicking outside dismisses" do
+    ov = sample_picker
+    h = OverlayHarness.new(ov)
+    h.click_in_box(3, 3).should eq(:closed) # the list starts at box.y + 3
+    ov.selected.should eq(0)
+    h.commits.should eq(1)
+
+    away = OverlayHarness.new(sample_picker)
+    away.overlay.handle_click(away.area, 0, 0).should eq(:cancel)
   end
 end

--- a/src/gori/tui/copy_picker.cr
+++ b/src/gori/tui/copy_picker.cr
@@ -3,39 +3,41 @@ require "./theme"
 require "./frame"
 require "./fmt"
 require "./copy_menu"
+require "./picker_overlay"
 
 module Gori::Tui
   # A small centered picker for the "copy as X" action (space → Y): pick which slice
   # of the focused HTTP message to copy — url / headers / body / cookies / curl / raw.
-  # Structurally a twin of ChoicePicker (pure state + rendering; the Runner owns
-  # open/close and performs the clipboard write), but each row carries the payload
-  # `text` outright and shows its byte size rather than a "current" marker — there's
-  # no persisted value here, just a one-shot copy. Rows are fronted by a mnemonic key.
-  class CopyPicker
-    getter selected : Int32
+  # Structurally a twin of ChoicePicker, but each row carries the payload `text`
+  # outright and shows its byte size rather than a "current" marker — there's no
+  # persisted value here, just a one-shot copy. Rows are fronted by a mnemonic key.
+  #
+  # PROMPT-TIER on the Overlay seam: the clipboard write is the injected `on_commit`
+  # (Runner#copy_as_open) like any migrated modal, but the Runner keeps this in its own
+  # slot rather than @active_overlay, because the picker must float over the History
+  # detail drill-in without collapsing it and must claim keys before the ^G/^F guards.
+  class CopyPicker < PickerOverlay
+    # DELIBERATELY doubles as `Overlay#title`, the shell's focus badge — the pre-seam
+    # `focus_label` read this very field (`@copy_picker.try(&.title)`), so the badge and
+    # the card heading have always been one string. Crystal has no `override` keyword, so
+    # a field silently satisfying an abstract method is easy to do BY ACCIDENT and wrong
+    # most of the time (see SendPicker, whose heading is a sentence, not a region name).
+    # Here it is intended; the spec pins both.
     getter title : String
 
     def initialize(@title : String, @options : Array(CopyMenu::Option))
-      @selected = 0
-      @scroll = 0
     end
 
     def empty? : Bool
       @options.empty?
     end
 
-    def move(delta : Int32) : Nil
-      return if @options.empty?
-      @selected = (@selected + delta).clamp(0, @options.size - 1)
+    def entry_count : Int32
+      @options.size
     end
 
     def selected_option : CopyMenu::Option?
       @options[@selected]?
-    end
-
-    def set_selected(idx : Int32) : Nil
-      return if @options.empty?
-      @selected = idx.clamp(0, @options.size - 1)
     end
 
     # The row whose mnemonic matches `c` (case-insensitive), or nil for a miss.
@@ -44,10 +46,49 @@ module Gori::Tui
       @options.index { |o| o.key.downcase == lc }
     end
 
+    # --- Overlay contract (see overlay.cr) ---
+    def key : OverlayKind
+      OverlayKind::CopyAs
+    end
+
+    def hint : String
+      "↑/↓ select · ↵ copy · key picks · esc cancel"
+    end
+
+    # ↑/↓ move, ↵ or a row mnemonic copies, esc cancels — j/k fall back to vim-style nav
+    # only when they aren't themselves a mnemonic, so the reflex keystroke moves the
+    # highlight instead of being ignored (mirrors ChoicePicker so the two feel identical).
+    def handle_key(ev : Termisu::Event::Key) : Symbol
+      key = ev.key
+      case
+      when key.escape? then return :cancel
+      when key.up?     then move(-1)
+      when key.down?   then move(1)
+      when key.enter?  then return :commit
+      else
+        if (c = ev.char) && !ev.ctrl? && !ev.alt?
+          if idx = index_for(c)
+            set_selected(idx)
+            return :commit
+          elsif c == 'j'
+            move(1)
+          elsif c == 'k'
+            move(-1)
+          end
+        end
+      end
+      :stay
+    end
+
     # Centered card geometry over `area` — inverse of render's offset math. nil when
     # render would draw nothing (mirrors the w/h guard). Width leaves room for the
     # right-aligned size hint.
     def overlay_box(area : Rect) : Rect?
+      # content_w is a max_of over the rows, which raises on an empty list. Unreachable
+      # today (both open-sites refuse to open an empty picker), but PickerOverlay#handle_click
+      # calls this for EVERY click, so a nil here is the difference between the base's
+      # "a click outside dismisses" promise and an exception out of the event loop.
+      return nil if @options.empty?
       w = {area.w - 4, content_w + 10}.min
       h = {@options.size + 2, area.h - 2}.min
       return nil if w < 18 || area.h < 5
@@ -66,13 +107,6 @@ module Gori::Tui
       return nil if mx <= box.x || mx >= box.right - 1
       ci = @scroll + i
       ci < @options.size ? ci : nil
-    end
-
-    private def ensure_visible(rows : Int32) : Nil
-      return if rows <= 0
-      @scroll = @selected if @selected < @scroll
-      @scroll = @selected - rows + 1 if @selected >= @scroll + rows
-      @scroll = @scroll.clamp(0, {@options.size - rows, 0}.max)
     end
 
     def render(screen : Screen, area : Rect) : Nil

--- a/src/gori/tui/flow_picker.cr
+++ b/src/gori/tui/flow_picker.cr
@@ -3,65 +3,56 @@ require "./theme"
 require "./frame"
 require "./url"
 require "./flow_status"
+require "./picker_overlay"
 require "../store"
 
 module Gori::Tui
   # The Comparer's flow picker overlay (a/b → choose a flow for slot A/B). Lists a
   # snapshot of recent flows with a type-to-filter bar (in-memory substring match —
-  # no per-keystroke SQL) and returns the highlighted row. Pure state + rendering;
-  # the Runner owns the @overlay lifecycle (open/key/click/wheel/render), mirroring
-  # BrowserPicker. `target` is the slot the chosen flow fills.
-  class FlowPicker
+  # no per-keystroke SQL) and returns the highlighted row.
+  #
+  # A dumb form object on the Overlay seam: what happens to the pick is the injected
+  # `on_commit`, so the SAME picker serves the Comparer (load the flow into slot A/B,
+  # Runner#comparer_pick) and the entity-link flow (attach the flow to an issue/note,
+  # opened as a child of LinksOverlay) with no mode flag here. `target` survives only
+  # as the card's heading.
+  class FlowPicker < FilterPickerOverlay
+    IDLE_HINT = "type to filter · ↑/↓ select · ↵ choose · esc cancel"
+
     getter target : Symbol
-    getter selected : Int32
     @indexed : Array({Store::FlowRow, String}) # each row paired with its precomputed filter haystack
 
     def initialize(@rows : Array(Store::FlowRow), @target : Symbol)
-      @query = ""
-      @preedit = "" # live IME composition (e.g. Hangul jamo) shown under the filter caret
       # Precompute each row's filter haystack ONCE (not per keystroke) so typing into
       # a 2000-row snapshot doesn't rebuild 2000 strings on every character.
       @indexed = @rows.map { |row| {row, haystack(row)} }
       @filtered = @rows
-      @selected = 0
-      @scroll = 0
-    end
-
-    def set_preedit(text : String) : Nil
-      @preedit = text
     end
 
     def selected_row : Store::FlowRow?
       @filtered[@selected]?
     end
 
-    def move(delta : Int32) : Nil
-      return if @filtered.empty?
-      @selected = (@selected + delta).clamp(0, @filtered.size - 1)
+    def entry_count : Int32
+      @filtered.size
     end
 
-    def set_selected(idx : Int32) : Nil
-      return if @filtered.empty?
-      @selected = idx.clamp(0, @filtered.size - 1)
+    # --- Overlay contract (see overlay.cr) ---
+    def key : OverlayKind
+      OverlayKind::ComparerPick
     end
 
-    def query_char(ch : Char) : Nil
-      return if ch.control?
-      @preedit = "" # a committed char ends any in-progress composition
-      @query += ch
-      refilter
+    def title : String
+      "PICK FLOW"
     end
 
-    def backspace : Nil
-      return if @query.empty?
-      @preedit = ""
-      @query = @query[0, @query.size - 1]
-      refilter
+    def hint : String
+      IDLE_HINT
     end
 
     # Recompute the visible rows from the precomputed haystacks: every whitespace-
     # separated term must appear (case-insensitive). Resets the cursor to the top.
-    private def refilter : Nil
+    protected def refilter : Nil
       terms = @query.downcase.split
       @filtered = terms.empty? ? @rows : @indexed.select { |(_, hay)| terms.all? { |t| hay.includes?(t) } }.map(&.first)
       @selected = 0
@@ -85,9 +76,8 @@ module Gori::Tui
 
     # Row index under (mx, my), mirroring render's list loop; nil outside the list.
     def row_at(box : Rect, mx : Int32, my : Int32) : Int32?
-      list_top = box.y + 3
-      list_h = box.bottom - 1 - list_top
-      i = my - list_top
+      list_h = list_height(box)
+      i = my - (box.y + LIST_OFFSET)
       return nil if i < 0 || i >= list_h
       return nil if mx < box.x + 1 || mx >= box.right - 1
       ri = @scroll + i
@@ -102,20 +92,8 @@ module Gori::Tui
       end
       Frame.card(screen, box, "PICK FLOW #{@target.to_s.upcase}", border: Theme.border_focus)
 
-      if @query.empty? && @preedit.empty?
-        screen.text(box.x + 2, box.y + 1, "type to filter · ↑/↓ select · ↵ choose · esc cancel",
-          Theme.muted, Theme.panel, width: box.w - 4)
-      else
-        # Live filter input — input_line shows committed text + IME preedit (underline)
-        # + a caret, and syncs the terminal cursor so Hangul/CJK composition shows.
-        px = screen.text(box.x + 2, box.y + 1, "filter: ", Theme.muted, Theme.panel)
-        screen.input_line(px, box.y + 1, @query, @query.size, @preedit, Theme.text_bright,
-          Theme.panel, width: {box.right - 1 - px, 1}.max)
-      end
-      Frame.tee_divider(screen, box, box.y + 2)
-
-      list_top = box.y + 3
-      list_h = box.bottom - 1 - list_top
+      list_top = render_filter(screen, box, IDLE_HINT)
+      list_h = list_height(box)
       ensure_visible(list_h)
 
       if @filtered.empty?
@@ -146,14 +124,6 @@ module Gori::Tui
       screen.text(host_x, ry, "#{row.host}#{Url.origin_path(row.target)}", fg, bg, width: host_w)
       status, scolor = FlowStatus.cell(row)
       screen.text(status_x, ry, status, scolor, bg, width: 4)
-    end
-
-    # Keep the selection on-screen (selection-follow scroll), like the History list.
-    private def ensure_visible(list_h : Int32) : Nil
-      return if list_h <= 0
-      @scroll = @selected if @selected < @scroll
-      @scroll = @selected - list_h + 1 if @selected >= @scroll + list_h
-      @scroll = @scroll.clamp(0, {@filtered.size - list_h, 0}.max)
     end
   end
 end

--- a/src/gori/tui/issue_picker.cr
+++ b/src/gori/tui/issue_picker.cr
@@ -1,30 +1,29 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./picker_overlay"
 require "../store"
 
 module Gori::Tui
   # Pick an issue to attach the current workbench ref to. Mirrors FlowPicker's
-  # in-memory filter; the Runner owns the overlay lifecycle. A pinned
-  # "+ New issue…" row (always first) opens create-and-link via the issue form.
-  class IssuePicker
+  # in-memory filter. A pinned "+ New issue…" row (always first) hands off to the
+  # NEW ISSUE form for create-and-link.
+  #
+  # A dumb form object on the Overlay seam: which ref gets attached, and what the
+  # create row does, are both the injected `on_commit` (Runner#link_to_issue).
+  class IssuePicker < FilterPickerOverlay
     CREATE_LABEL = "+ New issue…"
+    IDLE_HINT    = "type to filter · ↑/↓ select · ↵ link · esc cancel"
+    # The card's own hint row names the create row too; the shell's bottom row does not.
+    CARD_HINT = "type to filter · ↑/↓ select · ↵ link / create · esc cancel"
 
-    getter selected : Int32
     @indexed : Array({Store::Issue, String})
 
     def initialize(@rows : Array(Store::Issue))
-      @query = ""
-      @preedit = ""
       @indexed = @rows.map { |f| {f, haystack(f)} }
       @filtered = @rows
       # Prefer the first existing issue when present (create is always index 0).
       @selected = @rows.empty? ? 0 : 1
-      @scroll = 0
-    end
-
-    def set_preedit(text : String) : Nil
-      @preedit = text
     end
 
     # Total navigable rows: create action + filtered issues.
@@ -41,33 +40,20 @@ module Gori::Tui
       @filtered[@selected - 1]?
     end
 
-    def move(delta : Int32) : Nil
-      n = entry_count
-      return if n == 0
-      @selected = (@selected + delta).clamp(0, n - 1)
+    # --- Overlay contract (see overlay.cr) ---
+    def key : OverlayKind
+      OverlayKind::IssuePick
     end
 
-    def set_selected(idx : Int32) : Nil
-      n = entry_count
-      return if n == 0
-      @selected = idx.clamp(0, n - 1)
+    def title : String
+      "PICK ISSUE"
     end
 
-    def query_char(ch : Char) : Nil
-      return if ch.control?
-      @preedit = ""
-      @query += ch
-      refilter
+    def hint : String
+      IDLE_HINT
     end
 
-    def backspace : Nil
-      return if @query.empty?
-      @preedit = ""
-      @query = @query[0, @query.size - 1]
-      refilter
-    end
-
-    private def refilter : Nil
+    protected def refilter : Nil
       terms = @query.downcase.split
       @filtered = terms.empty? ? @rows : @indexed.select { |(_, hay)| terms.all? { |t| hay.includes?(t) } }.map(&.first)
       # Keep create at 0; land on first match when any, else the create row.
@@ -89,9 +75,8 @@ module Gori::Tui
     end
 
     def row_at(box : Rect, mx : Int32, my : Int32) : Int32?
-      list_top = box.y + 3
-      list_h = box.bottom - 1 - list_top
-      i = my - list_top
+      list_h = list_height(box)
+      i = my - (box.y + LIST_OFFSET)
       return nil if i < 0 || i >= list_h
       return nil if mx < box.x + 1 || mx >= box.right - 1
       ri = @scroll + i
@@ -101,18 +86,9 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       return unless box
-      Frame.card(screen, box, "PICK ISSUE", border: Theme.border_focus)
-      if @query.empty? && @preedit.empty?
-        screen.text(box.x + 2, box.y + 1, "type to filter · ↑/↓ select · ↵ link / create · esc cancel",
-          Theme.muted, Theme.panel, width: box.w - 4)
-      else
-        px = screen.text(box.x + 2, box.y + 1, "filter: ", Theme.muted, Theme.panel)
-        screen.input_line(px, box.y + 1, @query, @query.size, @preedit, Theme.text_bright,
-          Theme.panel, width: {box.right - 1 - px, 1}.max)
-      end
-      Frame.tee_divider(screen, box, box.y + 2)
-      list_top = box.y + 3
-      list_h = box.bottom - 1 - list_top
+      Frame.card(screen, box, title, border: Theme.border_focus)
+      list_top = render_filter(screen, box, CARD_HINT)
+      list_h = list_height(box)
       ensure_visible(list_h)
       (0...list_h).each do |i|
         ri = @scroll + i
@@ -140,13 +116,6 @@ module Gori::Tui
       screen.cell(box.x + 1, ry, active ? '▎' : ' ', Theme.accent, bg)
       label = "##{f.id} [#{f.severity.label}] #{f.title}"
       screen.text(box.x + 3, ry, label, fg, bg, width: box.w - 5)
-    end
-
-    private def ensure_visible(list_h : Int32) : Nil
-      return if list_h <= 0
-      @scroll = @selected if @selected < @scroll
-      @scroll = @selected - list_h + 1 if @selected >= @scroll + list_h
-      @scroll = @scroll.clamp(0, {entry_count - list_h, 0}.max)
     end
   end
 end

--- a/src/gori/tui/links_overlay.cr
+++ b/src/gori/tui/links_overlay.cr
@@ -1,23 +1,53 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./picker_overlay"
 require "../store"
 require "../links"
 
 module Gori::Tui
-  # Manage entity_links for a Issue or Note: list, select, add (via Runner sub-pickers),
-  # open, and remove. Pure state + rendering; the Runner owns @overlay lifecycle.
-  class LinksOverlay
+  # Manage entity_links for an Issue or Note: list, select, open, remove, and add.
+  #
+  # Adding is a two-step flow (`a` arms it, then f/r/z/m picks a source) that opens a
+  # SECOND modal — the flow or sub-tab picker. Pre-seam that round-trip lived in the
+  # Runner as three ivars (@link_add_owner / @link_add_ref_kind plus the picker itself)
+  # and a pair of close methods that rebuilt this overlay from scratch on every exit.
+  # It now rides the base's nested-modal seam: a source key reports :cancel with
+  # `pending_add` set, and the injected `on_close` puts the sub-picker up in this card's
+  # place — the sub-picker's own `on_close` pops back to a fresh LINKS card, whichever
+  # way it exits. The owner is already ours (`owner_kind`/`owner_id`), so none of that
+  # pending-link state survives in Runner.
+  #
+  # Domain edges are injected at the open-site (Runner#open_links_overlay): `on_commit`
+  # opens the selected link, `on_remove` deletes it, `on_close` drives the add hand-off.
+  class LinksOverlay < PickerOverlay
+    # The card's own hint row and the shell's bottom row say DIFFERENT things on purpose:
+    # the card has the width to spell out what each source key means, the status bar does
+    # not. Collapsing them onto the terse pair loses the only place that tells the user
+    # z is fuzz and m is miner.
+    CARD_ADD_HINT    = "add: f flow · r repeater · z fuzz · m miner · esc back"
+    CARD_BROWSE_HINT = "↑/↓ select · ↵/o open · a add · d remove · esc close"
+    ADD_HINT         = "f/r/z/m pick type · esc back"
+    BROWSE_HINT      = "↑/↓ · ↵/o open · a add · d remove · esc close"
+    # The link sources, as the keys the adding-mode hint advertises.
+    ADD_KEYS = "frzm"
+
     getter owner_kind : Store::LinkOwnerKind
     getter owner_id : Int64
-    getter selected : Int32
     getter? adding : Bool
+    # The source key chosen while adding, read by `on_close` once the shell has dropped
+    # this card. nil for every other exit, which is what keeps `on_close` inert when the
+    # user merely opened a link or pressed esc.
+    getter pending_add : Char?
+
+    # Deletes the highlighted link and reloads. Stays open — removing is a repeatable
+    # edit, not a dismissal.
+    property on_remove : Proc(Nil)?
 
     def initialize(@owner_kind : Store::LinkOwnerKind, @owner_id : Int64)
       @resolved = [] of Links::Resolved
-      @selected = 0
-      @scroll = 0
       @adding = false
+      @pending_add = nil
     end
 
     def reload(store : Store) : Nil
@@ -39,22 +69,16 @@ module Gori::Tui
       @resolved.size
     end
 
+    def entry_count : Int32
+      @resolved.size
+    end
+
     def selected_link : Links::Resolved?
       @resolved[@selected]?
     end
 
     def selected_entity_link : Store::EntityLink?
       @resolved[@selected]?.try(&.link)
-    end
-
-    def move(delta : Int32) : Nil
-      return if @resolved.empty?
-      @selected = (@selected + delta).clamp(0, @resolved.size - 1)
-    end
-
-    def set_selected(idx : Int32) : Nil
-      return if @resolved.empty?
-      @selected = idx.clamp(0, @resolved.size - 1)
     end
 
     def start_add : Nil
@@ -65,9 +89,36 @@ module Gori::Tui
       @adding = false
     end
 
+    # --- Overlay contract (see overlay.cr) ---
+    def key : OverlayKind
+      OverlayKind::Links
+    end
+
     def title : String
       owner = @owner_kind.issue? ? "ISSUE ##{@owner_id}" : "NOTE ##{@owner_id}"
       "LINKS — #{owner}"
+    end
+
+    def hint : String
+      adding? ? ADD_HINT : BROWSE_HINT
+    end
+
+    # Browse: ↑/↓ (or k/j) select · ↵/o open · a arms add · d removes · esc closes.
+    # Adding: f/r/z/m choose the source, which hands off through on_close.
+    def handle_key(ev : Termisu::Event::Key) : Symbol
+      key = ev.key
+      ch = ev.char || key.to_char
+      return handle_add_key(key, ch) if adding?
+      case
+      when key.escape?             then return :cancel
+      when key.up?, key.lower_k?   then move(-1)
+      when key.down?, key.lower_j? then move(1)
+      when key.enter?              then return :commit
+      when ch == 'o'               then return :commit
+      when ch == 'd'               then on_remove.try(&.call)
+      when ch == 'a'               then start_add
+      end
+      :stay
     end
 
     def overlay_box(area : Rect) : Rect?
@@ -97,12 +148,8 @@ module Gori::Tui
       end
       Frame.card(screen, box, title, border: Theme.border_focus)
 
-      hint = if @adding
-               "add: f flow · r repeater · z fuzz · m miner · esc back"
-             else
-               "↑/↓ select · ↵/o open · a add · d remove · esc close"
-             end
-      screen.text(box.x + 2, box.y + 1, hint, Theme.muted, Theme.panel, width: box.w - 4)
+      card_hint = adding? ? CARD_ADD_HINT : CARD_BROWSE_HINT
+      screen.text(box.x + 2, box.y + 1, card_hint, Theme.muted, Theme.panel, width: box.w - 4)
       Frame.tee_divider(screen, box, box.y + 2)
 
       list_top = box.y + 3
@@ -125,6 +172,26 @@ module Gori::Tui
       end
     end
 
+    # A source key arms the hand-off and drops this card, so `on_close` can put the
+    # sub-picker up in its place (the shell holds exactly one modal). esc backs out to
+    # browse; anything else is swallowed so a stray key can't leave the flow half-armed.
+    #
+    # The esc branch is load-bearing and easy to lose: the pre-seam shell reached it
+    # through `case (ev.char || key.to_char) … else stop_add if key.escape?`, which reads
+    # like dead code because termisu's `Key#to_char` has no mapping for Escape. It is not
+    # dead — gori enables the Kitty keyboard protocol unconditionally (app.cr), and under
+    # it Escape arrives as `CSI 27 u`, which the parser turns into `char: '\e'`. So `c`
+    # was non-nil and `stop_add` ran. Adding mode has no other keyboard exit, so dropping
+    # this traps the user in the card whenever the mouse is off.
+    private def handle_add_key(key : Termisu::Input::Key, ch : Char?) : Symbol
+      if ch && ADD_KEYS.includes?(ch)
+        @pending_add = ch
+        return :cancel
+      end
+      stop_add if key.escape?
+      :stay
+    end
+
     private def draw_row(screen : Screen, box : Rect, ry : Int32, res : Links::Resolved, active : Bool) : Nil
       bg = active ? Theme.accent_bg : Theme.panel
       fg = res.stale? ? Theme.muted : (active ? Theme.text_bright : Theme.text)
@@ -132,13 +199,6 @@ module Gori::Tui
       screen.cell(box.x + 1, ry, active ? '▎' : ' ', Theme.accent, bg)
       line = res.line
       screen.text(box.x + 3, ry, line, fg, bg, width: box.w - 5)
-    end
-
-    private def ensure_visible(list_h : Int32) : Nil
-      return if list_h <= 0
-      @scroll = @selected if @selected < @scroll
-      @scroll = @selected - list_h + 1 if @selected >= @scroll + list_h
-      @scroll = @scroll.clamp(0, {@resolved.size - list_h, 0}.max)
     end
   end
 end

--- a/src/gori/tui/note_picker.cr
+++ b/src/gori/tui/note_picker.cr
@@ -1,31 +1,30 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./picker_overlay"
 require "../notes"
 
 module Gori::Tui
   # Pick a note sub-tab to attach the current workbench ref to. A pinned
   # "+ New note…" row (always first) creates a blank note and links it.
-  class NotePicker
+  #
+  # A dumb form object on the Overlay seam: which ref gets attached, and the
+  # create-and-link path, are both the injected `on_commit` (Runner#link_to_note).
+  class NotePicker < FilterPickerOverlay
     CREATE_LABEL = "+ New note…"
+    IDLE_HINT    = "type to filter · ↑/↓ select · ↵ link · esc cancel"
+    # The card's own hint row names the create row too; the shell's bottom row does not.
+    CARD_HINT = "type to filter · ↑/↓ select · ↵ link / create · esc cancel"
 
     record Row, id : Int64, label : String, detail : String
 
-    getter selected : Int32
     @indexed : Array({Row, String})
 
     def initialize(@rows : Array(Row))
-      @query = ""
-      @preedit = ""
       @indexed = @rows.map { |row| {row, "#{row.label} #{row.detail}".downcase} }
       @filtered = @rows
       # Prefer the first existing note when present (create is always index 0).
       @selected = @rows.empty? ? 0 : 1
-      @scroll = 0
-    end
-
-    def set_preedit(text : String) : Nil
-      @preedit = text
     end
 
     # Total navigable rows: create action + filtered notes.
@@ -42,33 +41,20 @@ module Gori::Tui
       @filtered[@selected - 1]?
     end
 
-    def move(delta : Int32) : Nil
-      n = entry_count
-      return if n == 0
-      @selected = (@selected + delta).clamp(0, n - 1)
+    # --- Overlay contract (see overlay.cr) ---
+    def key : OverlayKind
+      OverlayKind::NotePick
     end
 
-    def set_selected(idx : Int32) : Nil
-      n = entry_count
-      return if n == 0
-      @selected = idx.clamp(0, n - 1)
+    def title : String
+      "PICK NOTE"
     end
 
-    def query_char(ch : Char) : Nil
-      return if ch.control?
-      @preedit = ""
-      @query += ch
-      refilter
+    def hint : String
+      IDLE_HINT
     end
 
-    def backspace : Nil
-      return if @query.empty?
-      @preedit = ""
-      @query = @query[0, @query.size - 1]
-      refilter
-    end
-
-    private def refilter : Nil
+    protected def refilter : Nil
       terms = @query.downcase.split
       @filtered = terms.empty? ? @rows : @indexed.select { |(_, hay)| terms.all? { |t| hay.includes?(t) } }.map(&.first)
       @selected = @filtered.empty? ? 0 : 1
@@ -85,9 +71,8 @@ module Gori::Tui
     end
 
     def row_at(box : Rect, mx : Int32, my : Int32) : Int32?
-      list_top = box.y + 3
-      list_h = box.bottom - 1 - list_top
-      i = my - list_top
+      list_h = list_height(box)
+      i = my - (box.y + LIST_OFFSET)
       return nil if i < 0 || i >= list_h
       return nil if mx < box.x + 1 || mx >= box.right - 1
       ri = @scroll + i
@@ -97,18 +82,9 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       return unless box
-      Frame.card(screen, box, "PICK NOTE", border: Theme.border_focus)
-      if @query.empty? && @preedit.empty?
-        screen.text(box.x + 2, box.y + 1, "type to filter · ↑/↓ select · ↵ link / create · esc cancel",
-          Theme.muted, Theme.panel, width: box.w - 4)
-      else
-        px = screen.text(box.x + 2, box.y + 1, "filter: ", Theme.muted, Theme.panel)
-        screen.input_line(px, box.y + 1, @query, @query.size, @preedit, Theme.text_bright,
-          Theme.panel, width: {box.right - 1 - px, 1}.max)
-      end
-      Frame.tee_divider(screen, box, box.y + 2)
-      list_top = box.y + 3
-      list_h = box.bottom - 1 - list_top
+      Frame.card(screen, box, title, border: Theme.border_focus)
+      list_top = render_filter(screen, box, CARD_HINT)
+      list_h = list_height(box)
       ensure_visible(list_h)
       (0...list_h).each do |i|
         ri = @scroll + i
@@ -135,13 +111,6 @@ module Gori::Tui
       screen.fill(Rect.new(box.x + 1, ry, box.w - 2, 1), bg)
       screen.cell(box.x + 1, ry, active ? '▎' : ' ', Theme.accent, bg)
       screen.text(box.x + 3, ry, row.label, fg, bg, width: box.w - 5)
-    end
-
-    private def ensure_visible(list_h : Int32) : Nil
-      return if list_h <= 0
-      @scroll = @selected if @selected < @scroll
-      @scroll = @selected - list_h + 1 if @selected >= @scroll + list_h
-      @scroll = @scroll.clamp(0, {entry_count - list_h, 0}.max)
     end
   end
 end

--- a/src/gori/tui/overlay.cr
+++ b/src/gori/tui/overlay.cr
@@ -51,6 +51,14 @@ module Gori::Tui
     ScopeRule
     SequenceConfig
     MineConfig
+    # Prompt-tier pickers. These two name a modal that `@overlay` NEVER holds: copy-as
+    # and send-to float over whatever is underneath (a tab body OR the History detail
+    # drill-in) without disturbing it, and are claimed before the ^G/^F/^B guards, so the
+    # Runner keeps them in their own slots (see Runner#copy_as_shown?). They are members
+    # anyway because `Overlay#key` is how a modal names itself, and a picker on the seam
+    # must answer it honestly rather than borrow `None`.
+    CopyAs
+    SendTo
 
     def to_sym : Symbol
       {% begin %}

--- a/src/gori/tui/picker_overlay.cr
+++ b/src/gori/tui/picker_overlay.cr
@@ -1,0 +1,131 @@
+require "./screen"
+require "./theme"
+require "./frame"
+require "./overlay"
+
+module Gori::Tui
+  # Shared base for the seven selection-list modals — copy-as, send-to, the Comparer
+  # flow picker, the sub-tab search, and the issue/note/links pickers.
+  #
+  # Each of them used to repeat the SAME dispatch by hand in runner.cr (esc cancels,
+  # ↑/↓ move, ↵ picks, a row click selects-and-picks, a click outside dismisses, the
+  # wheel scrolls), once per picker, thousands of lines apart. On the Overlay seam that
+  # contract belongs to the type, so it lives here once: subclasses own their rows and
+  # their card, this owns the cursor, the scroll window and the shell-facing outcome.
+  abstract class PickerOverlay < Overlay
+    getter selected : Int32 = 0
+    @scroll = 0
+
+    # Navigable rows, INCLUDING any pinned action row (IssuePicker/NotePicker keep
+    # "+ New …" at index 0, so their count is one more than the filtered list).
+    abstract def entry_count : Int32
+
+    # Row index under (mx, my) inside the card, or nil off the list.
+    abstract def row_at(box : Rect, mx : Int32, my : Int32) : Int32?
+
+    def move(step : Int32) : Nil
+      n = entry_count
+      return if n == 0
+      @selected = (@selected + step).clamp(0, n - 1)
+    end
+
+    def set_selected(idx : Int32) : Nil
+      n = entry_count
+      return if n == 0
+      @selected = idx.clamp(0, n - 1)
+    end
+
+    # A click on a row picks it (same as ↵); a click outside the card dismisses; a click
+    # inside but off the list is swallowed so it can't leak to the pane underneath.
+    def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      box = overlay_box(area)
+      return :cancel if box.nil? || !box.contains?(mx, my)
+      if idx = row_at(box, mx, my)
+        set_selected(idx)
+        return :commit
+      end
+      :stay
+    end
+
+    # Selection-follow scroll, like the History list: keep the cursor on-screen.
+    private def ensure_visible(list_h : Int32) : Nil
+      return if list_h <= 0
+      @scroll = @selected if @selected < @scroll
+      @scroll = @selected - list_h + 1 if @selected >= @scroll + list_h
+      @scroll = @scroll.clamp(0, {entry_count - list_h, 0}.max)
+    end
+  end
+
+  # The type-to-filter half of the family (flow / sub-tab / issue / note): a filter bar
+  # above a `tee_divider`, an in-memory substring match over precomputed haystacks, and
+  # live IME composition on the query. Every printable key that isn't a nav key filters.
+  abstract class FilterPickerOverlay < PickerOverlay
+    # The row the list starts on, measured from the card's top — the filter bar takes
+    # row +1 and the divider row +2.
+    LIST_OFFSET = 3
+
+    @query = ""
+    @preedit = "" # live IME composition (e.g. Hangul jamo) shown under the filter caret
+
+    def set_preedit(text : String) : Nil
+      @preedit = text
+    end
+
+    def query_char(ch : Char) : Nil
+      return if ch.control?
+      @preedit = "" # a committed char ends any in-progress composition
+      @query += ch
+      refilter
+    end
+
+    def backspace : Nil
+      return if @query.empty?
+      @preedit = ""
+      @query = @query[0, @query.size - 1]
+      refilter
+    end
+
+    # esc cancels · ↑/↓ move · ↵ picks · ⌫ edits the filter · anything else printable
+    # goes into the filter (query_char drops control chars itself).
+    def handle_key(ev : Termisu::Event::Key) : Symbol
+      key = ev.key
+      case
+      when key.escape?    then return :cancel
+      when key.up?        then move(-1)
+      when key.down?      then move(1)
+      when key.enter?     then return :commit
+      when key.backspace? then backspace
+      else
+        if c = ev.char
+          query_char(c)
+        end
+      end
+      :stay
+    end
+
+    # Draw the filter bar + divider and return the list's first row. `idle_hint` shows
+    # while nothing has been typed, so the card explains itself before it filters.
+    private def render_filter(screen : Screen, box : Rect, idle_hint : String) : Int32
+      if @query.empty? && @preedit.empty?
+        screen.text(box.x + 2, box.y + 1, idle_hint, Theme.muted, Theme.panel, width: box.w - 4)
+      else
+        # input_line shows committed text + IME preedit (underline) + a caret, and syncs
+        # the terminal cursor so Hangul/CJK composition renders where the user is typing.
+        px = screen.text(box.x + 2, box.y + 1, "filter: ", Theme.muted, Theme.panel)
+        screen.input_line(px, box.y + 1, @query, @query.size, @preedit, Theme.text_bright,
+          Theme.panel, width: {box.right - 1 - px, 1}.max)
+      end
+      Frame.tee_divider(screen, box, box.y + 2)
+      box.y + LIST_OFFSET
+    end
+
+    # Rows visible in the list area of `box`.
+    private def list_height(box : Rect) : Int32
+      box.bottom - 1 - (box.y + LIST_OFFSET)
+    end
+
+    # Recompute the visible rows for the current query and reset the cursor. Subclasses
+    # own their row type, so each filters its own.
+    protected abstract def refilter : Nil
+  end
+end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -174,22 +174,14 @@ module Gori::Tui
       # The "copy as X" format picker (Repeater/History detail → space Y). ORTHOGONAL to
       # @overlay (like @space_menu_open) so it floats over whatever's underneath — the
       # Repeater body (@overlay :none) OR the History detail drill-in (@overlay :detail) —
-      # without disturbing that state. Non-nil ⇔ shown (see copy_as_shown?).
+      # without disturbing that state. Non-nil ⇔ shown (see copy_as_shown?). Both these
+      # pickers are Overlays and dispatch through the same :stay/:commit/:cancel
+      # vocabulary, but they keep their own slots instead of @active_overlay: they must
+      # float over @overlay rather than replace it, and claim keys before the ^G/^F guards.
       @copy_picker = nil.as(CopyPicker?)
       # The "send selection to X" destination picker (space → S); same orthogonal-to-
       # @overlay lifetime as @copy_picker. Non-nil ⇔ shown (see send_to_shown?).
       @send_picker = nil.as(SendPicker?)
-      # The Comparer flow picker (a/b → choose flow A/B); @overlay is :comparer_pick.
-      @flow_picker = nil.as(FlowPicker?)
-      # The Repeater sub-tab search picker (space → s); @overlay is :repeater_subtab.
-      @subtab_picker = nil.as(SubtabPicker?)
-      # Entity links overlay (Issues/Notes → space l) and pickers for add/link-to.
-      @links_overlay = nil.as(LinksOverlay?)
-      @issue_picker = nil.as(IssuePicker?)
-      @note_picker = nil.as(NotePicker?)
-      @link_pending_ref = nil.as({Store::LinkRefKind, Int64}?)
-      @link_add_owner = nil.as({Store::LinkOwnerKind, Int64}?)
-      @link_add_ref_kind = nil.as(Store::LinkRefKind?)
       # The settings editor (palette → settings:network); @overlay is :settings.
       @settings_view = SettingsView.new
       @preferences = PreferencesView.new # the unified grouped settings modal (Ctrl+, / ⚙ / palette)
@@ -901,16 +893,12 @@ module Gori::Tui
         return
       end
       case @overlay
-      when .palette?         then @palette.set_preedit(text)
-      when .comparer_pick?   then @flow_picker.try(&.set_preedit(text))
-      when .repeater_subtab? then @subtab_picker.try(&.set_preedit(text))
-      when .issue_pick?      then @issue_picker.try(&.set_preedit(text))
-      when .note_pick?       then @note_picker.try(&.set_preedit(text))
-      when .preferences?     then @preferences.set_preedit(text)
-      when .settings?        then @settings_view.set_preedit(text)
-      when .hosts?           then @hosts_overlay.set_preedit(text)
-      when .env?             then @env_overlay.set_preedit(text)
-      when .none?            then apply_preedit_body(text)
+      when .palette?     then @palette.set_preedit(text)
+      when .preferences? then @preferences.set_preedit(text)
+      when .settings?    then @settings_view.set_preedit(text)
+      when .hosts?       then @hosts_overlay.set_preedit(text)
+      when .env?         then @env_overlay.set_preedit(text)
+      when .none?        then apply_preedit_body(text)
       end
     end
 
@@ -979,11 +967,6 @@ module Gori::Tui
       end
       return handle_palette_key(ev) if @overlay.palette?
       return handle_more_menu_key(ev) if @overlay.tabs_more?
-      return handle_flow_picker_key(ev) if @overlay.comparer_pick?
-      return handle_subtab_picker_key(ev) if @overlay.repeater_subtab?
-      return handle_links_key(ev) if @overlay.links?
-      return handle_issue_picker_key(ev) if @overlay.issue_pick?
-      return handle_note_picker_key(ev) if @overlay.note_pick?
       return handle_preferences_key(ev) if @overlay.preferences?
       if PREFS_SUB_EDITORS.includes?(@overlay)
         case @overlay
@@ -1259,11 +1242,6 @@ module Gori::Tui
     MODAL_OVERLAYS = {
       OverlayKind::Palette,
       OverlayKind::TabsMore,
-      OverlayKind::ComparerPick,
-      OverlayKind::RepeaterSubtab,
-      OverlayKind::Links,
-      OverlayKind::IssuePick,
-      OverlayKind::NotePick,
       OverlayKind::Preferences,
       OverlayKind::Settings,
       OverlayKind::Tabs,
@@ -1364,19 +1342,14 @@ module Gori::Tui
         return
       end
       case @overlay
-      when .palette?         then click_palette(area, mx, my)
-      when .tabs_more?       then click_more_menu(layout, mx, my)
-      when .comparer_pick?   then click_flow_picker(area, mx, my)
-      when .repeater_subtab? then click_subtab_picker(area, mx, my)
-      when .links?           then click_links(area, mx, my)
-      when .issue_pick?      then click_issue_picker(area, mx, my)
-      when .note_pick?       then click_note_picker(area, mx, my)
-      when .preferences?     then apply_preferences_outcome(@preferences.click(area, mx, my))
-      when .settings?        then (click_settings(area, mx, my); settle_sub_editor)
-      when .tabs?            then (click_tabs(area, mx, my); settle_sub_editor)
-      when .hosts?           then (click_hosts(area, mx, my); settle_sub_editor)
-      when .env?             then (click_env(area, mx, my); settle_sub_editor)
-      when .hotkeys?         then (click_hotkeys(area, mx, my); settle_sub_editor)
+      when .palette?     then click_palette(area, mx, my)
+      when .tabs_more?   then click_more_menu(layout, mx, my)
+      when .preferences? then apply_preferences_outcome(@preferences.click(area, mx, my))
+      when .settings?    then (click_settings(area, mx, my); settle_sub_editor)
+      when .tabs?        then (click_tabs(area, mx, my); settle_sub_editor)
+      when .hosts?       then (click_hosts(area, mx, my); settle_sub_editor)
+      when .env?         then (click_env(area, mx, my); settle_sub_editor)
+      when .hotkeys?     then (click_hotkeys(area, mx, my); settle_sub_editor)
       end
     end
 
@@ -1500,8 +1473,10 @@ module Gori::Tui
     private def handle_wheel(layout : Layout, mx : Int32, my : Int32, dir : Int32) : Nil
       step = dir * 3
       return @space_menu.move(step) if @space_menu_open
-      return @copy_picker.try(&.move(step)) if copy_as_shown?
-      return @send_picker.try(&.move(step)) if send_to_shown?
+      # Through handle_wheel, not move, so these two honour the same Overlay hook the
+      # five @active_overlay modals get (the base routes it to move by default).
+      return @copy_picker.try(&.handle_wheel(step)) if copy_as_shown?
+      return @send_picker.try(&.handle_wheel(step)) if send_to_shown?
       return wheel_overlay(step) if modal_overlay?
       return unless layout.body.contains?(mx, my)
       # Pass the pointer + body rect so a multi-pane tab (Project) scrolls the pane
@@ -1516,19 +1491,14 @@ module Gori::Tui
         return
       end
       case @overlay
-      when .palette?         then @palette.move(step)
-      when .tabs_more?       then @more_menu.try(&.move(step))
-      when .comparer_pick?   then @flow_picker.try(&.move(step))
-      when .repeater_subtab? then @subtab_picker.try(&.move(step))
-      when .links?           then @links_overlay.try(&.move(step))
-      when .issue_pick?      then @issue_picker.try(&.move(step))
-      when .note_pick?       then @note_picker.try(&.move(step))
-      when .preferences?     then @preferences.wheel(step)
-      when .settings?        then (@settings_view.move_field(step); preview_theme) # wheel scrolls the theme list too
-      when .tabs?            then @tabs_overlay.select_move(step)
-      when .hosts?           then @hosts_overlay.select_move(step)
-      when .env?             then @env_overlay.select_move(step)
-      when .hotkeys?         then @hotkeys_overlay.select_move(step)
+      when .palette?     then @palette.move(step)
+      when .tabs_more?   then @more_menu.try(&.move(step))
+      when .preferences? then @preferences.wheel(step)
+      when .settings?    then (@settings_view.move_field(step); preview_theme) # wheel scrolls the theme list too
+      when .tabs?        then @tabs_overlay.select_move(step)
+      when .hosts?       then @hosts_overlay.select_move(step)
+      when .env?         then @env_overlay.select_move(step)
+      when .hotkeys?     then @hotkeys_overlay.select_move(step)
       end
     end
 
@@ -1743,6 +1713,13 @@ module Gori::Tui
       !@copy_picker.nil?
     end
 
+    # Whichever prompt-tier picker is up (at most one — both open from the space menu,
+    # which closes on the verb). The chrome ladders read it the way they read
+    # active_overlay, so these two name and hint themselves like any migrated modal.
+    private def prompt_picker : Overlay?
+      @copy_picker || @send_picker
+    end
+
     # "Copy as X" (space → Y): open a centered picker of the focused HTTP message's
     # copy formats (url/headers/body/cookies/curl/raw), built from the active tab's
     # current focus. Falls back to the plain smart-copy when the context has no format
@@ -1753,7 +1730,20 @@ module Gori::Tui
         # No format variants here — degrade to the existing "Copy" behaviour.
         return read_copy
       end
-      @copy_picker = CopyPicker.new(title, options)
+      cp = CopyPicker.new(title, options)
+      # Place the picked format on the clipboard, reporting the label + bytes and
+      # flagging a clip when the 64KB cap truncated the payload. Always closes: a
+      # copy is one-shot, so there is no validation path that keeps the card up.
+      cp.on_commit = -> {
+        if opt = cp.selected_option
+          written = Clipboard.copy(opt.text)
+          msg = "copied #{opt.label.downcase} (#{written}b)"
+          msg += " — clipped from #{opt.text.bytesize}b (64KB cap)" if written < opt.text.bytesize
+          @toast = msg
+        end
+        true
+      }
+      @copy_picker = cp
     end
 
     # The focus-aware option set for the active context (empty ⇒ no copy-as variants).
@@ -1768,64 +1758,31 @@ module Gori::Tui
       end
     end
 
-    # Copy-as picker input: ↑/↓ move, ↵ or a row mnemonic copies, esc cancels (mirrors
-    # the choice picker so the two feel identical).
+    # The prompt-tier twin of dispatch_overlay_key: same :stay/:commit/:cancel contract,
+    # but closing drops only the picker's own slot — @overlay is left exactly as it was,
+    # so the Repeater body or History detail drill-in underneath is undisturbed and the
+    # user returns precisely where they invoked it.
     private def handle_copy_as_key(ev : Termisu::Event::Key) : Nil
-      key = ev.key
-      p = @copy_picker
-      return close_copy_picker unless p
-      case
-      when key.escape? then close_copy_picker
-      when key.up?     then p.move(-1)
-      when key.down?   then p.move(1)
-      when key.enter?  then apply_copy_as
-      else
-        if (c = ev.char) && !ev.ctrl? && !ev.alt?
-          if idx = p.index_for(c)
-            p.set_selected(idx)
-            apply_copy_as
-          elsif c == 'j'
-            p.move(1)
-          elsif c == 'k'
-            p.move(-1)
-          end
-        end
+      cp = @copy_picker
+      return close_copy_picker unless cp
+      case cp.handle_key(ev)
+      when :cancel then close_copy_picker
+      when :commit then close_copy_picker if cp.commit
       end
     end
 
     # Always consumes the click (returns true) so it never leaks to the pane below —
     # a click on a row copies, a click outside dismisses.
     private def click_copy_as(area : Rect, mx : Int32, my : Int32) : Bool
-      p = @copy_picker
-      box = p.try(&.overlay_box(area))
-      if p.nil? || box.nil? || dismiss_zone?(box, mx, my)
-        close_copy_picker
-        return true
-      end
-      if idx = p.row_at(box, mx, my)
-        p.set_selected(idx)
-        apply_copy_as
+      cp = @copy_picker
+      return (close_copy_picker; true) unless cp
+      case cp.handle_click(area, mx, my)
+      when :cancel then close_copy_picker
+      when :commit then close_copy_picker if cp.commit
       end
       true
     end
 
-    # Place the picked format on the clipboard, then close. Reports the label + bytes,
-    # and flags a clip when the 64KB cap truncated the payload.
-    private def apply_copy_as : Nil
-      p = @copy_picker
-      return close_copy_picker unless p
-      if opt = p.selected_option
-        written = Clipboard.copy(opt.text)
-        msg = "copied #{opt.label.downcase} (#{written}b)"
-        msg += " — clipped from #{opt.text.bytesize}b (64KB cap)" if written < opt.text.bytesize
-        @toast = msg
-      end
-      close_copy_picker
-    end
-
-    # Orthogonal to @overlay — closing just drops the picker; whatever was underneath
-    # (Repeater body or the History detail drill-in) is untouched, so the user returns
-    # exactly where they invoked it.
     private def close_copy_picker : Nil
       @copy_picker = nil
     end
@@ -1846,262 +1803,153 @@ module Gori::Tui
         @toast = "nothing selected to send"
         return
       end
-      @send_picker = SendPicker.new("Send selection to", payload, SendMenu.destinations)
+      sp = SendPicker.new("Send selection to", payload, SendMenu.destinations)
+      # Route the captured selection to the chosen destination. Each destination
+      # controller owns the seeding (a new pre-filled session + goto_tab), so adding a
+      # target is a `when` branch here plus a SendMenu.destinations entry.
+      sp.on_commit = -> {
+        if dest = sp.selected_destination
+          case dest.tab
+          when :decoder   then decoder_controller.decoder_from_text(sp.payload)
+          when :jwt       then jwt_controller.jwt_from_text(sp.payload)
+          when :sequencer then sequencer_controller.sequence_from_text(sp.payload)
+          end
+        end
+        true
+      }
+      @send_picker = sp
     end
 
-    # Send-to picker input: ↑/↓ move, ↵ or a row mnemonic sends, esc cancels (mirrors
-    # the copy-as picker so the two feel identical).
+    # Prompt-tier dispatch, same as the copy-as picker above.
     private def handle_send_to_key(ev : Termisu::Event::Key) : Nil
-      key = ev.key
-      p = @send_picker
-      return close_send_picker unless p
-      case
-      when key.escape? then close_send_picker
-      when key.up?     then p.move(-1)
-      when key.down?   then p.move(1)
-      when key.enter?  then apply_send_to
-      else
-        # Mnemonic → immediate send. No j/k vim fallback: destination mnemonics now
-        # include 'j' (JWT), so a j/k nav fallback both shadowed that mnemonic and was
-        # asymmetric (k moved up, j sent). Arrows handle navigation.
-        if (c = ev.char) && !ev.ctrl? && !ev.alt? && (idx = p.index_for(c))
-          p.set_selected(idx)
-          apply_send_to
-        end
+      sp = @send_picker
+      return close_send_picker unless sp
+      case sp.handle_key(ev)
+      when :cancel then close_send_picker
+      when :commit then close_send_picker if sp.commit
       end
     end
 
     # Always consumes the click (returns true) so it never leaks to the pane below —
     # a click on a row sends, a click outside dismisses.
     private def click_send_to(area : Rect, mx : Int32, my : Int32) : Bool
-      p = @send_picker
-      box = p.try(&.overlay_box(area))
-      if p.nil? || box.nil? || dismiss_zone?(box, mx, my)
-        close_send_picker
-        return true
-      end
-      if idx = p.row_at(box, mx, my)
-        p.set_selected(idx)
-        apply_send_to
+      sp = @send_picker
+      return (close_send_picker; true) unless sp
+      case sp.handle_click(area, mx, my)
+      when :cancel then close_send_picker
+      when :commit then close_send_picker if sp.commit
       end
       true
     end
 
-    # Route the captured selection to the chosen destination, then close. Each
-    # destination controller owns the seeding (a new pre-filled session + goto_tab), so
-    # adding a target is a `when` branch here plus a SendMenu.destinations entry.
-    private def apply_send_to : Nil
-      p = @send_picker
-      return close_send_picker unless p
-      if dest = p.selected_destination
-        payload = p.payload
-        case dest.tab
-        when :decoder   then decoder_controller.decoder_from_text(payload)
-        when :jwt       then jwt_controller.jwt_from_text(payload)
-        when :sequencer then sequencer_controller.sequence_from_text(payload)
-        end
-      end
-      close_send_picker
-    end
-
-    # Orthogonal to @overlay — closing just drops the picker; whatever was underneath
-    # is untouched, so the user returns exactly where they invoked it.
     private def close_send_picker : Nil
       @send_picker = nil
     end
 
-    # Comparer flow picker (a/b → choose flow A/B): type to filter, ↑/↓ select,
-    # ↵ choose (load into the slot), esc cancel.
-    private def handle_flow_picker_key(ev : Termisu::Event::Key) : Nil
-      fp = @flow_picker
-      return close_flow_picker if fp.nil?
-      key = ev.key
-      case
-      when key.escape?    then close_flow_picker
-      when key.up?        then fp.move(-1)
-      when key.down?      then fp.move(1)
-      when key.enter?     then commit_flow_picker
-      when key.backspace? then fp.backspace
-      else
-        fp.query_char(ev.char.not_nil!) if ev.char
-      end
-    end
-
-    # Load the highlighted flow into the picker's target slot and close.
-    private def commit_flow_picker : Nil
-      fp = @flow_picker
-      return close_flow_picker if fp.nil?
-      if row = fp.selected_row
-        if fp.target == :link
-          commit_link_add(Store::LinkRefKind::Flow, row.id)
-          @flow_picker = nil
-          return
-        elsif detail = @session.store.get_flow(row.id)
-          comparer_controller.view.set_slot(fp.target, detail)
-          @toast = "comparer: set #{fp.target.to_s.upcase} — #{row.method} #{row.host}"
-        else
-          @toast = "flow no longer available"
-        end
-      end
-      close_flow_picker
-    end
-
-    private def click_flow_picker(area : Rect, mx : Int32, my : Int32) : Nil
-      fp = @flow_picker
-      box = fp.try(&.overlay_box(area))
-      return close_flow_picker if fp.nil? || box.nil? || dismiss_zone?(box, mx, my)
-      if idx = fp.row_at(box, mx, my)
-        fp.set_selected(idx)
-        commit_flow_picker
-      end
-    end
-
-    private def close_flow_picker : Nil
-      owner = @link_add_owner
-      @overlay = OverlayKind::None
-      @flow_picker = nil
-      @link_add_owner = nil
-      @link_add_ref_kind = nil
-      if owner
-        owner_kind, owner_id = owner
-        open_links_overlay(owner_kind, owner_id)
-      end
-    end
-
-    # Repeater sub-tab search (space → s): type to filter the open sessions, ↑/↓
-    # select, ↵ jump to the highlighted one, esc cancel.
-    private def handle_subtab_picker_key(ev : Termisu::Event::Key) : Nil
-      sp = @subtab_picker
-      return close_subtab_picker if sp.nil?
-      key = ev.key
-      case
-      when key.escape?    then close_subtab_picker
-      when key.up?        then sp.move(-1)
-      when key.down?      then sp.move(1)
-      when key.enter?     then commit_subtab_picker
-      when key.backspace? then sp.backspace
-      else
-        sp.query_char(ev.char.not_nil!) if ev.char
-      end
-    end
-
-    # Jump to the highlighted sub-tab and close. The picker hands back the absolute
-    # index; jump_subtab clamps + saves the outgoing tab, so a stale index (the
-    # cross-session reconcile reordered behind the modal) is a safe no-op.
-    private def commit_subtab_picker : Nil
-      sp = @subtab_picker
-      return close_subtab_picker if sp.nil?
-      if @link_add_owner
-        if idx = sp.selected_index
-          ref_kind = @link_add_ref_kind
-          ref_id = if rk = ref_kind
-                     case rk
-                     when .repeater? then repeater_controller.db_id_at(idx)
-                     when .fuzz?     then fuzzer_controller.db_id_at(idx)
-                     when .miner?    then miner_controller.db_id_at(idx)
-                     else                 nil
-                     end
-                   end
-          if rid = ref_id
-            commit_link_add(ref_kind.not_nil!, rid)
-          else
-            @toast = "session not persisted"
-            close_subtab_picker
-          end
-        else
-          close_subtab_picker
-        end
-        @subtab_picker = nil
-        return
-      end
-      if idx = sp.selected_index
-        @tabs[@active_tab]?.try(&.jump_subtab(idx)) # active tab owns the strip (Repeater/Fuzzer/Notes/Decoder)
-        @focus = :body                              # land on the chosen session's content
-      end
-      close_subtab_picker
-    end
-
-    private def click_subtab_picker(area : Rect, mx : Int32, my : Int32) : Nil
-      sp = @subtab_picker
-      box = sp.try(&.overlay_box(area))
-      return close_subtab_picker if sp.nil? || box.nil? || dismiss_zone?(box, mx, my)
-      if idx = sp.row_at(box, mx, my)
-        sp.set_selected(idx)
-        commit_subtab_picker
-      end
-    end
-
-    private def close_subtab_picker : Nil
-      owner = @link_add_owner
-      @subtab_picker = nil
-      @link_add_ref_kind = nil
-      @link_add_owner = nil
-      if owner
-        owner_kind, owner_id = owner
-        open_links_overlay(owner_kind, owner_id)
-      else
-        @overlay = OverlayKind::None
-      end
-    end
-
     # --- entity links overlay ------------------------------------------------
 
-    private def handle_links_key(ev : Termisu::Event::Key) : Nil
-      lo = @links_overlay
-      return close_links_overlay unless lo
-      key = ev.key
-      c = ev.char || key.to_char
-      if lo.adding?
-        case c
-        when 'f' then open_link_add_flow_picker(lo)
-        when 'r' then open_link_add_repeater_picker(lo)
-        when 'z' then open_link_add_fuzz_picker(lo)
-        when 'm' then open_link_add_miner_picker(lo)
-        when nil
-        else
-          lo.stop_add if key.escape?
-        end
-        return
-      end
-      case
-      when key.escape?             then close_links_overlay
-      when key.up?, key.lower_k?   then lo.move(-1)
-      when key.down?, key.lower_j? then lo.move(1)
-      when key.enter?              then open_selected_link(lo)
-      when c == 'o'                then open_selected_link(lo)
-      when c == 'd'                then remove_selected_link(lo)
-      when c == 'a'                then lo.start_add
-      end
-    end
-
-    private def click_links(area : Rect, mx : Int32, my : Int32) : Nil
-      lo = @links_overlay
-      box = lo.try(&.overlay_box(area))
-      return close_links_overlay if lo.nil? || box.nil? || dismiss_zone?(box, mx, my)
-      if idx = lo.row_at(box, mx, my)
-        lo.set_selected(idx)
-        open_selected_link(lo)
-      end
-    end
-
-    private def close_links_overlay : Nil
-      @overlay = OverlayKind::None
-      @links_overlay = nil
-      @link_add_owner = nil
-      @link_add_ref_kind = nil
-    end
-
-    def open_links_overlay(owner_kind : Store::LinkOwnerKind, owner_id : Int64) : Nil
+    # Opened from an Issue/Note (space → l). Every domain edge is injected: opening a
+    # link, removing one, and the add hand-off. The add round-trip rides the base's
+    # nested-modal seam (Overlay#on_close) rather than any shell-side flag, so the three
+    # @link_add_* ivars this used to need are gone.
+    # `cursor` restores the selection when the card is rebuilt for a reason the user did
+    # not ask for (a source with nothing to link); the ordinary pop-back after a
+    # sub-picker leaves it at the top, which is what the pre-seam rebuild did.
+    def open_links_overlay(owner_kind : Store::LinkOwnerKind, owner_id : Int64,
+                           cursor : Int32? = nil) : Nil
       lo = LinksOverlay.new(owner_kind, owner_id)
       lo.reload(@session.store)
-      @links_overlay = lo
-      @overlay = OverlayKind::Links
+      lo.set_selected(cursor) if cursor
+      opening = nil.as(Store::EntityLink?)
+      # ↵/o: record what to open and let the shell drop the card. The navigation itself
+      # must run AFTER that drop — navigate_link_ref sets its own @overlay for a flow (the
+      # History DETAIL drill-in), which close_active_overlay would otherwise wipe. A ↵
+      # with nothing selected reports false and leaves the card up, as it always did.
+      lo.on_commit = -> {
+        if res = lo.selected_link
+          opening = res.link
+          true
+        else
+          false
+        end
+      }
+      lo.on_remove = -> { remove_selected_link(lo) }
+      # Runs after the shell has dropped this card (see Overlay#on_close). At most one of
+      # the two is armed: a source key sets pending_add, ↵/o sets `opening`, esc neither.
+      lo.on_close = -> {
+        if kind = lo.pending_add
+          open_link_add_picker(lo, kind)
+        elsif link = opening
+          navigate_link_ref(link.ref_kind, link.ref_id)
+        end
+      }
+      open_overlay(lo)
     end
 
-    private def open_selected_link(lo : LinksOverlay) : Nil
-      return unless res = lo.selected_link
-      close_links_overlay
-      navigate_link_ref(res.link.ref_kind, res.link.ref_id)
+    # Put the chosen add sub-picker up in the links card's place. Whichever way it exits —
+    # a pick, esc, or click-away — its own on_close pops back to a FRESH links card, which
+    # is what the pre-seam close_flow_picker/close_subtab_picker pair did by rebuilding the
+    # overlay. "Nothing to pick" (already toasted) pops straight back.
+    private def open_link_add_picker(lo : LinksOverlay, kind : Char) : Nil
+      owner_kind, owner_id = lo.owner_kind, lo.owner_id
+      picker = build_link_add_picker(lo, kind)
+      unless picker
+        # Nothing to link (already toasted). The user never left the list, so put them
+        # back on the row they were on rather than snapping to the top.
+        open_links_overlay(owner_kind, owner_id, cursor: lo.selected)
+        return
+      end
+      picker.on_close = -> { open_links_overlay(owner_kind, owner_id) }
+      open_overlay(picker)
+    end
+
+    # The add sub-picker for a source key, with its commit wired to attach the pick to
+    # THIS overlay's owner — that closure is what used to be @link_add_owner /
+    # @link_add_ref_kind on the Runner. nil means the source had nothing to offer.
+    private def build_link_add_picker(lo : LinksOverlay, kind : Char) : PickerOverlay?
+      case kind
+      when 'f' then link_add_flow_picker(lo)
+      when 'r' then link_add_subtab_picker(lo, "PICK REPEATER", repeater_controller.subtab_search_rows,
+        Store::LinkRefKind::Repeater, "no repeater sessions to link") { |i| repeater_controller.db_id_at(i) }
+      when 'z' then link_add_subtab_picker(lo, "PICK FUZZ", fuzz_subtab_rows,
+        Store::LinkRefKind::Fuzz, "no fuzz sessions to link") { |i| fuzzer_controller.db_id_at(i) }
+      when 'm' then link_add_subtab_picker(lo, "PICK MINER", miner_subtab_rows,
+        Store::LinkRefKind::Miner, "no miner sessions to link") { |i| miner_controller.db_id_at(i) }
+      end
+    end
+
+    private def link_add_flow_picker(lo : LinksOverlay) : PickerOverlay
+      fp = FlowPicker.new(@session.store.recent_flows(500), :link)
+      fp.on_commit = -> {
+        if row = fp.selected_row
+          commit_link_to_owner(lo.owner_kind, lo.owner_id, Store::LinkRefKind::Flow, row.id)
+        end
+        true
+      }
+      fp
+    end
+
+    # One builder for the three session pickers (repeater / fuzz / miner): they differ
+    # only by heading, row source, link kind and how a sub-tab index resolves to a DB id.
+    private def link_add_subtab_picker(lo : LinksOverlay, title : String, rows : Array(SubtabPicker::Row),
+                                       ref_kind : Store::LinkRefKind, empty_toast : String,
+                                       &db_id : Int32 -> Int64?) : PickerOverlay?
+      if rows.empty?
+        @toast = empty_toast
+        return nil
+      end
+      sp = SubtabPicker.new(title, rows, action: "link")
+      sp.on_commit = -> {
+        if idx = sp.selected_index
+          if rid = db_id.call(idx)
+            commit_link_to_owner(lo.owner_kind, lo.owner_id, ref_kind, rid)
+          else
+            @toast = "session not persisted"
+          end
+        end
+        true
+      }
+      sp
     end
 
     private def remove_selected_link(lo : LinksOverlay) : Nil
@@ -2121,45 +1969,6 @@ module Gori::Tui
       end
     end
 
-    private def open_link_add_flow_picker(lo : LinksOverlay) : Nil
-      @link_add_owner = {lo.owner_kind, lo.owner_id}
-      @link_add_ref_kind = Store::LinkRefKind::Flow
-      rows = @session.store.recent_flows(500)
-      @flow_picker = FlowPicker.new(rows, :link)
-      @overlay = OverlayKind::ComparerPick
-      lo.stop_add
-    end
-
-    private def open_link_add_repeater_picker(lo : LinksOverlay) : Nil
-      rows = repeater_controller.subtab_search_rows
-      return (@toast = "no repeater sessions to link"; lo.stop_add) if rows.empty?
-      @link_add_owner = {lo.owner_kind, lo.owner_id}
-      @link_add_ref_kind = Store::LinkRefKind::Repeater
-      @subtab_picker = SubtabPicker.new("PICK REPEATER", rows, action: "link")
-      @overlay = OverlayKind::RepeaterSubtab
-      lo.stop_add
-    end
-
-    private def open_link_add_fuzz_picker(lo : LinksOverlay) : Nil
-      rows = fuzz_subtab_rows
-      return (@toast = "no fuzz sessions to link"; lo.stop_add) if rows.empty?
-      @link_add_owner = {lo.owner_kind, lo.owner_id}
-      @link_add_ref_kind = Store::LinkRefKind::Fuzz
-      @subtab_picker = SubtabPicker.new("PICK FUZZ", rows, action: "link")
-      @overlay = OverlayKind::RepeaterSubtab
-      lo.stop_add
-    end
-
-    private def open_link_add_miner_picker(lo : LinksOverlay) : Nil
-      rows = miner_subtab_rows
-      return (@toast = "no miner sessions to link"; lo.stop_add) if rows.empty?
-      @link_add_owner = {lo.owner_kind, lo.owner_id}
-      @link_add_ref_kind = Store::LinkRefKind::Miner
-      @subtab_picker = SubtabPicker.new("PICK MINER", rows, action: "link")
-      @overlay = OverlayKind::RepeaterSubtab
-      lo.stop_add
-    end
-
     private def fuzz_subtab_rows : Array(SubtabPicker::Row)
       fuzzer_controller.subtab_labels.map_with_index do |label, i|
         detail = @session.store.fuzz_sessions[i]?.try(&.target) || ""
@@ -2174,55 +1983,26 @@ module Gori::Tui
       end
     end
 
-    private def commit_link_add(ref_kind : Store::LinkRefKind, ref_id : Int64) : Nil
-      return unless owner = @link_add_owner
-      owner_kind, owner_id = owner
-      commit_link_to_owner(owner_kind, owner_id, ref_kind, ref_id)
-      open_links_overlay(owner_kind, owner_id)
-      @link_add_owner = nil
-      @link_add_ref_kind = nil
+    # ↵ on the issue picker: "+ New issue…" hands off to the NEW ISSUE form, any other
+    # row takes the link. The create row arms on_close rather than opening the form here,
+    # because the form claims @overlay and the shell's close would tear it straight back
+    # down; on_close runs after the drop, so the form is the last write (see Overlay).
+    private def link_picked_issue(ip : IssuePicker, ref : {Store::LinkRefKind, Int64}) : Bool
+      if ip.selected_create?
+        ip.on_close = -> { open_issue_form_for_link(ref) }
+        return true
+      end
+      if f = ip.selected_issue
+        commit_link_to_owner(Store::LinkOwnerKind::Issue, f.id, ref[0], ref[1])
+      end
+      true
     end
 
-    private def handle_issue_picker_key(ev : Termisu::Event::Key) : Nil
-      fp = @issue_picker
-      return close_issue_picker if fp.nil?
-      key = ev.key
-      case
-      when key.escape?    then close_issue_picker
-      when key.up?        then fp.move(-1)
-      when key.down?      then fp.move(1)
-      when key.enter?     then commit_issue_picker
-      when key.backspace? then fp.backspace
-      else
-        fp.query_char(ev.char.not_nil!) if ev.char
-      end
-    end
-
-    private def commit_issue_picker : Nil
-      fp = @issue_picker
-      return close_issue_picker if fp.nil?
-      if fp.selected_create?
-        open_issue_form_for_link
-        return
-      end
-      if f = fp.selected_issue
-        if ref = @link_pending_ref
-          commit_link_to_owner(Store::LinkOwnerKind::Issue, f.id, ref[0], ref[1])
-        end
-      end
-      close_issue_picker
-    end
-
-    # Transition from the issue picker into NEW ISSUE form while keeping the
-    # pending workbench ref so form ↵ creates + links without leaving the tab.
-    # Ownership of the ref MOVES into the form: dropping the form (esc, click-away) now
-    # drops the pending link with it, so a cancelled create-and-link can no longer leave a
-    # stale ref for a later standalone create to silently attach.
-    private def open_issue_form_for_link : Nil
-      ref = @link_pending_ref
-      @link_pending_ref = nil
-      @issue_picker = nil
-      if ref && ref[0].flow?
+    # Transition from the issue picker into the NEW ISSUE form. Ownership of the ref moves
+    # INTO the form (C3's `link_ref:`), so dropping the form — esc, click-away — drops the
+    # pending link with it; nothing is parked on the Runner.
+    private def open_issue_form_for_link(ref : {Store::LinkRefKind, Int64}) : Nil
+      if ref[0].flow?
         if row = @session.store.flow_row(ref[1])
           open_issue_form(IssueForm.new("#{row.method} #{row.target}", row.host, ref[1], link_ref: ref))
           return
@@ -2231,61 +2011,25 @@ module Gori::Tui
       open_issue_form(IssueForm.new(link_ref: ref))
     end
 
-    private def click_issue_picker(area : Rect, mx : Int32, my : Int32) : Nil
-      fp = @issue_picker
-      box = fp.try(&.overlay_box(area))
-      return close_issue_picker if fp.nil? || box.nil? || dismiss_zone?(box, mx, my)
-      if idx = fp.row_at(box, mx, my)
-        fp.set_selected(idx)
-        commit_issue_picker
-      end
-    end
-
-    private def close_issue_picker : Nil
-      @overlay = OverlayKind::None
-      @issue_picker = nil
-      @link_pending_ref = nil
-    end
-
-    private def handle_note_picker_key(ev : Termisu::Event::Key) : Nil
-      np = @note_picker
-      return close_note_picker if np.nil?
-      key = ev.key
-      case
-      when key.escape?    then close_note_picker
-      when key.up?        then np.move(-1)
-      when key.down?      then np.move(1)
-      when key.enter?     then commit_note_picker
-      when key.backspace? then np.backspace
-      else
-        np.query_char(ev.char.not_nil!) if ev.char
-      end
-    end
-
-    private def commit_note_picker : Nil
-      np = @note_picker
-      return close_note_picker if np.nil?
+    # ↵ on the note picker: "+ New note…" creates a blank note and links to it, any
+    # other row links to the note picked. Same on_close hand-off as the issue picker —
+    # create_note_and_link ends on the open-vs-stay confirm, which claims @overlay.
+    private def link_picked_note(np : NotePicker, ref : {Store::LinkRefKind, Int64}) : Bool
       if np.selected_create?
-        create_note_and_link
-        return
+        np.on_close = -> { create_note_and_link(ref) }
+        return true
       end
       if row = np.selected_row
-        if ref = @link_pending_ref
-          commit_link_to_owner(Store::LinkOwnerKind::Note, row.id, ref[0], ref[1])
-        end
+        commit_link_to_owner(Store::LinkOwnerKind::Note, row.id, ref[0], ref[1])
       end
-      close_note_picker
+      true
     end
 
-    # Blank note + link the pending workbench ref, then ask open vs stay.
-    private def create_note_and_link : Nil
-      ref = @link_pending_ref
-      return close_note_picker if ref.nil?
+    # Blank note + link the workbench ref, then ask open vs stay.
+    private def create_note_and_link(ref : {Store::LinkRefKind, Int64}) : Nil
       note_id = notes_controller.create_blank_note_id
       commit_link_to_owner(Store::LinkOwnerKind::Note, note_id, ref[0], ref[1])
       @toast = "note created and linked"
-      @note_picker = nil
-      @link_pending_ref = nil
       offer_open_created(:note, note_id)
     end
 
@@ -2333,22 +2077,6 @@ module Gori::Tui
       else
         @toast = "note created"
       end
-    end
-
-    private def click_note_picker(area : Rect, mx : Int32, my : Int32) : Nil
-      np = @note_picker
-      box = np.try(&.overlay_box(area))
-      return close_note_picker if np.nil? || box.nil? || dismiss_zone?(box, mx, my)
-      if idx = np.row_at(box, mx, my)
-        np.set_selected(idx)
-        commit_note_picker
-      end
-    end
-
-    private def close_note_picker : Nil
-      @overlay = OverlayKind::None
-      @note_picker = nil
-      @link_pending_ref = nil
     end
 
     private def commit_link_to_owner(owner_kind : Store::LinkOwnerKind, owner_id : Int64,
@@ -3361,11 +3089,6 @@ module Gori::Tui
       Chrome.render_statusline(screen, layout.statusline, @statusline.segments) unless layout.statusline.empty?
       @palette.render(screen, layout.body) if @overlay.palette?
       @more_menu.try(&.render(screen, more_anchor_rect(layout), layout.body)) if @overlay.tabs_more?
-      @flow_picker.try(&.render(screen, layout.body)) if @overlay.comparer_pick?
-      @subtab_picker.try(&.render(screen, layout.body)) if @overlay.repeater_subtab?
-      @links_overlay.try(&.render(screen, layout.body)) if @overlay.links?
-      @issue_picker.try(&.render(screen, layout.body)) if @overlay.issue_pick?
-      @note_picker.try(&.render(screen, layout.body)) if @overlay.note_pick?
       @preferences.render(screen, layout.body) if @overlay.preferences?
       @settings_view.render(screen, layout.body) if @overlay.settings?
       @tabs_overlay.render(screen, layout.body) if @overlay.tabs?
@@ -3473,26 +3196,24 @@ module Gori::Tui
     # always knows which region the keys drive: an open overlay wins, else the
     # tab bar (TABS) vs the content pane (BODY).
     private def focus_label : String
-      return "SPACE" if @space_menu_open                              # orthogonal to @overlay — floats over it
-      return @copy_picker.try(&.title) || "COPY AS" if copy_as_shown? # ditto
-      return "SEND TO" if send_to_shown?                              # ditto
-      if ov = active_overlay                                          # migrated modals name themselves (Overlay seam)
+      return "SPACE" if @space_menu_open # orthogonal to @overlay — floats over it
+      # The prompt-tier pickers self-name exactly like a migrated modal; they just live
+      # in their own slots rather than @active_overlay (see copy_as_shown?).
+      if pt = prompt_picker
+        return pt.title
+      end
+      if ov = active_overlay # migrated modals name themselves (Overlay seam)
         return ov.title
       end
       case @overlay
-      when .palette?         then "PALETTE"
-      when .detail?          then "DETAIL"
-      when .comparer_pick?   then "PICK FLOW"
-      when .repeater_subtab? then @subtab_picker.try(&.title) || "FIND SUB-TAB"
-      when .links?           then @links_overlay.try(&.title) || "LINKS"
-      when .issue_pick?      then "PICK ISSUE"
-      when .note_pick?       then "PICK NOTE"
-      when .preferences?     then "PREFERENCES"
-      when .settings?        then "SETTINGS"
-      when .tabs?            then "TAB BAR"
-      when .hosts?           then "HOSTNAME OVERRIDES"
-      when .env?             then "ENVIRONMENT"
-      when .hotkeys?         then "HOTKEYS"
+      when .palette?     then "PALETTE"
+      when .detail?      then "DETAIL"
+      when .preferences? then "PREFERENCES"
+      when .settings?    then "SETTINGS"
+      when .tabs?        then "TAB BAR"
+      when .hosts?       then "HOSTNAME OVERRIDES"
+      when .env?         then "ENVIRONMENT"
+      when .hotkeys?     then "HOTKEYS"
       else
         case @focus
         when :menu    then "TABS"
@@ -3516,26 +3237,22 @@ module Gori::Tui
     # under their fingers do right now).
     private def key_hints : String
       return "press a key · ↑/↓ select · ↵ run · esc close" if @space_menu_open
-      return "↑/↓ select · ↵ copy · key picks · esc cancel" if copy_as_shown?
-      return "↑/↓ select · ↵ send · key picks · esc cancel" if send_to_shown?
+      if pt = prompt_picker # prompt-tier Overlays carry their own hint too
+        return pt.hint
+      end
       if ov = active_overlay # migrated modals carry their own hint (Overlay seam)
         return ov.hint
       end
       case @overlay
-      when .palette?         then "↑/↓ select · ↵ run · ⌫ · esc close · type to filter"
-      when .tabs_more?       then "↑/↓ select · ↵ open tab · ←/esc close"
-      when .comparer_pick?   then "type to filter · ↑/↓ select · ↵ choose · esc cancel"
-      when .repeater_subtab? then "type to filter · ↑/↓ select · ↵ #{@subtab_picker.try(&.action) || "jump"} · esc cancel"
-      when .links?           then @links_overlay.try(&.adding?) ? "f/r/z/m pick type · esc back" : "↑/↓ · ↵/o open · a add · d remove · esc close"
-      when .issue_pick?      then "type to filter · ↑/↓ select · ↵ link · esc cancel"
-      when .note_pick?       then "type to filter · ↑/↓ select · ↵ link · esc cancel"
-      when .preferences?     then "←/→ group · ↑/↓ field · ↵ save/open · ^R reset · esc close"
-      when .settings?        then "↑/↓ field · type to edit · ↵ save · ^R reset · esc close"
-      when .tabs?            then "↑/↓ select · space show/hide · K/J reorder · r reset · ↵ save · esc cancel"
-      when .hosts?           then @hosts_overlay.adding? ? "type \"IP host\" · ↵ save · esc cancel" : "↑/↓ select · a add · ↵/e edit · d delete · esc close"
-      when .env?             then env_overlay_hints
-      when .hotkeys?         then @hotkeys_overlay.capturing? ? "press a key to bind · esc cancel" : "↑/↓ select · e/␣ rebind · x unbind · r reset · ⇧R reset all · ←/→ profile · ↵ save · esc"
-      when .detail?          then history_controller.body_hint(:body)
+      when .palette?     then "↑/↓ select · ↵ run · ⌫ · esc close · type to filter"
+      when .tabs_more?   then "↑/↓ select · ↵ open tab · ←/esc close"
+      when .preferences? then "←/→ group · ↑/↓ field · ↵ save/open · ^R reset · esc close"
+      when .settings?    then "↑/↓ field · type to edit · ↵ save · ^R reset · esc close"
+      when .tabs?        then "↑/↓ select · space show/hide · K/J reorder · r reset · ↵ save · esc cancel"
+      when .hosts?       then @hosts_overlay.adding? ? "type \"IP host\" · ↵ save · esc cancel" : "↑/↓ select · a add · ↵/e edit · d delete · esc close"
+      when .env?         then env_overlay_hints
+      when .hotkeys?     then @hotkeys_overlay.capturing? ? "press a key to bind · esc cancel" : "↑/↓ select · e/␣ rebind · x unbind · r reset · ⇧R reset all · ←/→ profile · ↵ save · esc"
+      when .detail?      then history_controller.body_hint(:body)
       else
         # Focus on the far-right ⋯ "more" affordance: ↵/↓ expands the hidden-tabs list.
         return "↵/↓ show hidden tabs · ← back · ^P cmds · q projects" if @focus == :menu && @menu_more
@@ -4307,18 +4024,18 @@ module Gori::Tui
         @toast = "linked to issue ##{f.id}: #{link_title_snip(f.title)}" if commit_link_to_owner(Store::LinkOwnerKind::Issue, f.id, ref[0], ref[1])
         return
       end
-      @link_pending_ref = ref
-      @issue_picker = IssuePicker.new(@session.store.issues)
-      @overlay = OverlayKind::IssuePick
+      ip = IssuePicker.new(@session.store.issues)
+      ip.on_commit = -> { link_picked_issue(ip, ref) }
+      open_overlay(ip)
     end
 
     def link_to_note : Nil
       ref = current_link_ref
       return (@toast = "nothing to link") unless ref
       notes_controller.save_notes
-      @link_pending_ref = ref
-      @note_picker = NotePicker.new(note_picker_rows)
-      @overlay = OverlayKind::NotePick
+      np = NotePicker.new(note_picker_rows)
+      np.on_commit = -> { link_picked_note(np, ref) }
+      open_overlay(np)
     end
 
     # Trim an issue title for a one-line toast (avoid a wall of text on wide titles).
@@ -4448,14 +4165,24 @@ module Gori::Tui
     end
 
     # Generic sub-tab search — opens the fuzzy picker over the ACTIVE tab's sub-tabs
-    # (Repeater/Fuzzer/Notes/Decoder). commit_subtab_picker jumps on the active controller,
-    # so one path serves every strip. Gives Fuzzer/Notes/Decoder a search-and-jump that
-    # doesn't rely on Ctrl+digit (undeliverable on many terminals).
+    # (Repeater/Fuzzer/Notes/Decoder). The commit jumps on the active controller, so one
+    # path serves every strip. Gives Fuzzer/Notes/Decoder a search-and-jump that doesn't
+    # rely on Ctrl+digit (undeliverable on many terminals).
     def subtab_search_open : Nil
       rows = @tabs[@active_tab]?.try(&.subtab_search_rows) || [] of SubtabPicker::Row
       return @toast = "no other sub-tab to search" if rows.size < 2
-      @subtab_picker = SubtabPicker.new("FIND SUB-TAB", rows)
-      @overlay = OverlayKind::RepeaterSubtab
+      sp = SubtabPicker.new("FIND SUB-TAB", rows)
+      # The picker hands back the ABSOLUTE index; jump_subtab clamps + saves the outgoing
+      # tab, so a stale index (the cross-session reconcile reordered behind the modal) is
+      # a safe no-op.
+      sp.on_commit = -> {
+        if idx = sp.selected_index
+          @tabs[@active_tab]?.try(&.jump_subtab(idx)) # active tab owns the strip (Repeater/Fuzzer/Notes/Decoder)
+          @focus = :body                              # land on the chosen session's content
+        end
+        true
+      }
+      open_overlay(sp)
     end
 
     def subtab_search_count : Int32

--- a/src/gori/tui/runner/comparer.cr
+++ b/src/gori/tui/runner/comparer.cr
@@ -2,10 +2,25 @@
 # tui/runner.cr for the event loop, Host facade, overlays, and rendering).
 class Gori::Tui::Runner < Gori::Verb::ExecContext
   # Open the flow picker to choose the flow for slot :a / :b. Snapshots recent
-  # flows; the picker filters them in memory.
+  # flows; the picker filters them in memory. Loading the pick into the slot is the
+  # injected commit, so the same picker also serves the entity-link flow (see
+  # Runner#build_link_add_picker) with no mode flag in the picker itself.
   def comparer_pick(slot : Symbol) : Nil
-    @flow_picker = FlowPicker.new(@session.store.recent_flows(2000), slot)
-    @overlay = OverlayKind::ComparerPick
+    fp = FlowPicker.new(@session.store.recent_flows(2000), slot)
+    fp.on_commit = -> { comparer_load_slot(fp, slot) }
+    open_overlay(fp)
+  end
+
+  private def comparer_load_slot(fp : FlowPicker, slot : Symbol) : Bool
+    if row = fp.selected_row
+      if detail = @session.store.get_flow(row.id)
+        comparer_controller.view.set_slot(slot, detail)
+        @toast = "comparer: set #{slot.to_s.upcase} — #{row.method} #{row.host}"
+      else
+        @toast = "flow no longer available"
+      end
+    end
+    true
   end
 
   def comparer_swap : Nil

--- a/src/gori/tui/send_menu.cr
+++ b/src/gori/tui/send_menu.cr
@@ -1,12 +1,12 @@
 module Gori::Tui
   # The catalog of destinations the "Send selection to…" picker (space → S) offers:
   # string-handling tools that accept a raw selected string as their input. The
-  # SendPicker overlay renders these rows; the Runner routes the chosen one's `tab`
-  # to that controller's seeding method (apply_send_to). No TUI/state deps, so the
+  # SendPicker overlay renders these rows; the picker's injected commit routes the
+  # chosen one's `tab` to that controller's seeding method. No TUI/state deps, so the
   # list stays a single trivially-extensible source of truth.
   #
-  # Adding a target later (e.g. a Sequencer or Encryption tab) is one line here plus
-  # a `when :<tab>` branch in Runner#apply_send_to — no other wiring.
+  # Adding a target later (e.g. an Encryption tab) is one line here plus a `when :<tab>`
+  # branch in the commit closure at Runner#send_to_open — no other wiring.
   module SendMenu
     # One offered destination: the row `label`, its mnemonic `key` (unique within the
     # list — the picker dispatches on it), the `tab` symbol the Runner routes to, and

--- a/src/gori/tui/send_picker.cr
+++ b/src/gori/tui/send_picker.cr
@@ -3,40 +3,34 @@ require "./theme"
 require "./frame"
 require "./fmt"
 require "./send_menu"
+require "./picker_overlay"
 
 module Gori::Tui
   # A small centered picker for the "send selection to X" action (space → S): pick a
   # string-handling destination for the current text selection. Structurally a twin
-  # of CopyPicker (pure state + rendering; the Runner owns open/close and performs
-  # the send), but every row shares ONE `@payload` (the selection) and differs only
-  # by destination — so rows show the target's `hint` (not a per-row byte size), and
-  # the card title carries the payload size once. Rows are fronted by a mnemonic key.
-  class SendPicker
-    getter selected : Int32
-    getter title : String
+  # of CopyPicker, but every row shares ONE `@payload` (the selection) and differs
+  # only by destination — so rows show the target's `hint` (not a per-row byte size),
+  # and the card title carries the payload size once. Rows are fronted by a mnemonic key.
+  #
+  # PROMPT-TIER on the Overlay seam, exactly like CopyPicker: the send is the injected
+  # `on_commit` (Runner#send_to_open), but the Runner keeps it out of @active_overlay so
+  # it floats over @overlay instead of replacing it.
+  class SendPicker < PickerOverlay
     getter payload : String
 
-    def initialize(@title : String, @payload : String, @destinations : Array(SendMenu::Destination))
-      @selected = 0
-      @scroll = 0
+    def initialize(@card_label : String, @payload : String, @destinations : Array(SendMenu::Destination))
     end
 
     def empty? : Bool
       @destinations.empty?
     end
 
-    def move(delta : Int32) : Nil
-      return if @destinations.empty?
-      @selected = (@selected + delta).clamp(0, @destinations.size - 1)
+    def entry_count : Int32
+      @destinations.size
     end
 
     def selected_destination : SendMenu::Destination?
       @destinations[@selected]?
-    end
-
-    def set_selected(idx : Int32) : Nil
-      return if @destinations.empty?
-      @selected = idx.clamp(0, @destinations.size - 1)
     end
 
     # The row whose mnemonic matches `c` (case-insensitive), or nil for a miss.
@@ -45,10 +39,49 @@ module Gori::Tui
       @destinations.index { |d| d.key.downcase == lc }
     end
 
+    # --- Overlay contract (see overlay.cr) ---
+    def key : OverlayKind
+      OverlayKind::SendTo
+    end
+
+    # The focus badge. Deliberately NOT the card's own label ("Send selection to · 128 B"),
+    # which is a sentence, not a region name.
+    def title : String
+      "SEND TO"
+    end
+
+    def hint : String
+      "↑/↓ select · ↵ send · key picks · esc cancel"
+    end
+
+    # ↑/↓ move, ↵ or a row mnemonic sends, esc cancels. No j/k vim fallback: destination
+    # mnemonics now include 'j' (JWT), so a j/k nav fallback both shadowed that mnemonic
+    # and was asymmetric (k moved up, j sent). Arrows handle navigation.
+    def handle_key(ev : Termisu::Event::Key) : Symbol
+      key = ev.key
+      case
+      when key.escape? then return :cancel
+      when key.up?     then move(-1)
+      when key.down?   then move(1)
+      when key.enter?  then return :commit
+      else
+        if (c = ev.char) && !ev.ctrl? && !ev.alt? && (idx = index_for(c))
+          set_selected(idx)
+          return :commit
+        end
+      end
+      :stay
+    end
+
     # Centered card geometry over `area` — inverse of render's offset math. nil when
     # render would draw nothing (mirrors the w/h guard). Width fits the widest of the
     # rows (label + hint) and the sized title.
     def overlay_box(area : Rect) : Rect?
+      # content_w is a max_of over the rows, which raises on an empty list. Unreachable
+      # today (both open-sites refuse to open an empty picker), but PickerOverlay#handle_click
+      # calls this for EVERY click, so a nil here is the difference between the base's
+      # "a click outside dismisses" promise and an exception out of the event loop.
+      return nil if @destinations.empty?
       w = {area.w - 4, content_w + 10}.min
       h = {@destinations.size + 2, area.h - 2}.min
       return nil if w < 18 || area.h < 5
@@ -67,13 +100,6 @@ module Gori::Tui
       return nil if mx <= box.x || mx >= box.right - 1
       ci = @scroll + i
       ci < @destinations.size ? ci : nil
-    end
-
-    private def ensure_visible(rows : Int32) : Nil
-      return if rows <= 0
-      @scroll = @selected if @selected < @scroll
-      @scroll = @selected - rows + 1 if @selected >= @scroll + rows
-      @scroll = @scroll.clamp(0, {@destinations.size - rows, 0}.max)
     end
 
     def render(screen : Screen, area : Rect) : Nil
@@ -100,9 +126,10 @@ module Gori::Tui
       end
     end
 
-    # The title with the shared payload's size appended once (e.g. "Send selection to · 128 B").
+    # The card's own heading, with the shared payload's size appended once
+    # (e.g. "Send selection to · 128 B").
     private def card_title : String
-      "#{@title} · #{Fmt.size(@payload.bytesize.to_i64)}"
+      "#{@card_label} · #{Fmt.size(@payload.bytesize.to_i64)}"
     end
 
     # Widest row (label + hint) and the sized title, driving the card width.

--- a/src/gori/tui/subtab_picker.cr
+++ b/src/gori/tui/subtab_picker.cr
@@ -1,36 +1,36 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./picker_overlay"
 
 module Gori::Tui
   # A type-to-filter picker over a tab's sub-tabs — search the open sessions by
   # their chip label / request line, ↑/↓ select, ↵ jump to the chosen one. The
   # structural twin of FlowPicker (in-memory substring filter, IME preedit,
   # selection-follow scroll, mouse hit-test) but lists sub-tabs instead of flows.
-  # Pure state + rendering; the Runner owns the @overlay lifecycle and applies the
-  # pick. Generic over any sub-tab strip (only Repeater wires it today).
-  class SubtabPicker
+  # Generic over any sub-tab strip (only Repeater wires it today).
+  #
+  # A dumb form object on the Overlay seam: the pick's effect is the injected
+  # `on_commit`, so one picker serves both sub-tab search (jump to the session,
+  # Runner#subtab_search_open) and the entity-link flow (attach the repeater/fuzz/miner
+  # session to an issue or note, opened as a child of LinksOverlay).
+  class SubtabPicker < FilterPickerOverlay
     # `index` is the sub-tab's absolute position — the value handed back on commit;
     # `label` is the chip text, `detail` the dim searchable request line.
     record Row, index : Int32, label : String, detail : String
 
+    # Doubles as `Overlay#title` on purpose: the pre-seam `focus_label` read this field
+    # (`@subtab_picker.try(&.title)`), so "FIND SUB-TAB" / "PICK REPEATER" is both the card
+    # heading and the focus badge. Intended here — but a field quietly satisfying an
+    # abstract method is a real hazard in Crystal (no `override`), so it is spelled out.
     getter title : String
-    getter action : String # verb shown in the ↵ hint ("jump" for search, "link" when picking a link target)
-    getter selected : Int32
+    getter action : String          # verb shown in the ↵ hint ("jump" for search, "link" when picking a link target)
     @indexed : Array({Row, String}) # each row paired with its precomputed filter haystack
 
     def initialize(@title : String, @rows : Array(Row), @action : String = "jump")
-      @query = ""
-      @preedit = "" # live IME composition (e.g. Hangul jamo) shown under the filter caret
       # Precompute each row's filter haystack ONCE (not per keystroke).
       @indexed = @rows.map { |row| {row, "#{row.label} #{row.detail}".downcase} }
       @filtered = @rows
-      @selected = 0
-      @scroll = 0
-    end
-
-    def set_preedit(text : String) : Nil
-      @preedit = text
     end
 
     # The absolute sub-tab index of the highlighted row (nil when nothing matches).
@@ -38,33 +38,28 @@ module Gori::Tui
       @filtered[@selected]?.try(&.index)
     end
 
-    def move(delta : Int32) : Nil
-      return if @filtered.empty?
-      @selected = (@selected + delta).clamp(0, @filtered.size - 1)
+    def entry_count : Int32
+      @filtered.size
     end
 
-    def set_selected(idx : Int32) : Nil
-      return if @filtered.empty?
-      @selected = idx.clamp(0, @filtered.size - 1)
+    # --- Overlay contract (see overlay.cr) ---
+    def key : OverlayKind
+      OverlayKind::RepeaterSubtab
     end
 
-    def query_char(ch : Char) : Nil
-      return if ch.control?
-      @preedit = "" # a committed char ends any in-progress composition
-      @query += ch
-      refilter
+    def hint : String
+      idle_hint
     end
 
-    def backspace : Nil
-      return if @query.empty?
-      @preedit = ""
-      @query = @query[0, @query.size - 1]
-      refilter
+    # The ↵ verb varies with the open-site ("jump" vs "link"), so the card's own hint row
+    # and the shell's bottom row read the same string.
+    private def idle_hint : String
+      "type to filter · ↑/↓ select · ↵ #{@action} · esc cancel"
     end
 
     # Recompute the visible rows from the precomputed haystacks: every whitespace-
     # separated term must appear (case-insensitive). Resets the cursor to the top.
-    private def refilter : Nil
+    protected def refilter : Nil
       terms = @query.downcase.split
       @filtered = terms.empty? ? @rows : @indexed.select { |(_, hay)| terms.all? { |t| hay.includes?(t) } }.map(&.first)
       @selected = 0
@@ -84,9 +79,8 @@ module Gori::Tui
 
     # Row index under (mx, my), mirroring render's list loop; nil outside the list.
     def row_at(box : Rect, mx : Int32, my : Int32) : Int32?
-      list_top = box.y + 3
-      list_h = box.bottom - 1 - list_top
-      i = my - list_top
+      list_h = list_height(box)
+      i = my - (box.y + LIST_OFFSET)
       return nil if i < 0 || i >= list_h
       return nil if mx < box.x + 1 || mx >= box.right - 1
       ri = @scroll + i
@@ -101,18 +95,8 @@ module Gori::Tui
       end
       Frame.card(screen, box, @title, border: Theme.border_focus)
 
-      if @query.empty? && @preedit.empty?
-        screen.text(box.x + 2, box.y + 1, "type to filter · ↑/↓ select · ↵ #{@action} · esc cancel",
-          Theme.muted, Theme.panel, width: box.w - 4)
-      else
-        px = screen.text(box.x + 2, box.y + 1, "filter: ", Theme.muted, Theme.panel)
-        screen.input_line(px, box.y + 1, @query, @query.size, @preedit, Theme.text_bright,
-          Theme.panel, width: {box.right - 1 - px, 1}.max)
-      end
-      Frame.tee_divider(screen, box, box.y + 2)
-
-      list_top = box.y + 3
-      list_h = box.bottom - 1 - list_top
+      list_top = render_filter(screen, box, idle_hint)
+      list_h = list_height(box)
       ensure_visible(list_h)
 
       if @filtered.empty?
@@ -143,14 +127,6 @@ module Gori::Tui
       screen.text(num_x, ry, "#{row.index + 1}", Theme.accent, bg, width: 3)
       screen.text(label_x, ry, row.label, fg, bg, Attribute::Bold, width: label_w)
       screen.text(detail_x, ry, row.detail, Theme.muted, bg, width: detail_w)
-    end
-
-    # Keep the selection on-screen (selection-follow scroll), like the History list.
-    private def ensure_visible(list_h : Int32) : Nil
-      return if list_h <= 0
-      @scroll = @selected if @selected < @scroll
-      @scroll = @selected - list_h + 1 if @selected >= @scroll + list_h
-      @scroll = @scroll.clamp(0, {@filtered.size - list_h, 0}.max)
     end
   end
 end

--- a/src/gori/verbs/sequencer.cr
+++ b/src/gori/verbs/sequencer.cr
@@ -6,7 +6,8 @@ module Gori
     # History detail, Repeater, and Sitemap) opens a small config popup, then the token
     # collection runs in the BACKGROUND. run/stop/configure act on the focused Sequencer
     # session. The "Send selection to → Sequencer" destination is wired separately
-    # (send_menu.cr + apply_send_to), so it isn't a verb here.
+    # (send_menu.cr + the SendPicker commit closure in Runner#send_to_open), so it isn't a
+    # verb here.
     def self.register_sequencer(r : Verb::Registry) : Nil
       history_selected = ->(ctx : Verb::ExecContext) { ctx.current_tab == :history && !ctx.selected_flow_id.nil? }
       in_sequencer = ->(ctx : Verb::ExecContext) { ctx.current_tab == :sequencer }


### PR DESCRIPTION
Batch **C4** of #355 — the seven selection-list modals.

`copy_as`, `send_to`, the Comparer flow picker, the sub-tab search, the entity-links card and the issue/note pickers each carried their own hand-written dispatch in `runner.cr`: the same seven-line `case` (esc cancels, ↑/↓ move, ↵ picks, a row click selects-and-picks, a click outside dismisses), repeated once per picker thousands of lines apart, plus an entry in each of the eight shared ladders.

They are now `Overlay`s, and the repeated part lives once in a new `PickerOverlay` / `FilterPickerOverlay` base.

## What went

- **40 ladder entries** across preedit / key / `MODAL_OVERLAYS` / click / wheel / render / title / hint.
- **Five `@*_picker` ivars** and the three-ivar pending-link state (`@link_pending_ref`, `@link_add_owner`, `@link_add_ref_kind`). The commit closures and C3's `IssueForm#link_ref` do that job between them now, so `@link_pending_ref` is gone entirely rather than merely reduced.
- `runner.cr` is down to 4,813 lines; `handle_*_key` down to 19.

## Two deliberate non-uniformities

**copy-as / send-to stay in their own Runner slots**, not `@active_overlay`. They must float *over* `@overlay` — a copy-as raised from the History detail drill-in has to leave that drill-in standing — and they are claimed before the `^G`/`^F`/`^B` guards. They are `Overlay`s and dispatch through the same `:stay`/`:commit`/`:cancel` vocabulary; only the slot differs. Their `OverlayKind` members exist so `key` can answer honestly, and they sit in the spec's `NON_MODAL_KINDS`, never in `MODAL_OVERLAYS`.

**The links add flow rides @hahwul's `Overlay#on_close` seam** (#372) rather than a private mechanism: a source key reports `:cancel` with `pending_add` set, `on_close` swaps in the sub-picker, and the sub-picker's own `on_close` pops back to a fresh links card whichever way it exits — which is exactly what the pre-seam `close_flow_picker`/`close_subtab_picker` pair did by rebuilding the overlay. (I had hand-rolled a composite first; converged on `on_close` once #372 landed.)

## Behaviour preserved, including where it is odd

Pinned by spec: FlowPicker's badge stays `PICK FLOW` while its card heading keeps the slot suffix, and CopyPicker keeps a j/k nav fallback that SendPicker must **not** have, because `j` is the JWT mnemonic there.

## Found by review, not by the refactor

- **`Overlay#title` is easy to satisfy by accident** — Crystal has no `override`. SendPicker's card heading is a sentence (`Send selection to · 128 B`), not a region name, so it keeps that as `card_label` and the badge reads `SEND TO` as before. CopyPicker and SubtabPicker genuinely do mean one string by both; that is now said out loud where the field is declared.
- **An empty CopyPicker/SendPicker raised `Enumerable::EmptyError` out of `handle_click`**, since both size their card with `max_of` over the rows. Unreachable today, but the base now promises "a click outside dismisses" for all seven, so it is guarded.

`/code-review` also caught a **regression I had introduced and then wrongly pinned**: I removed the `esc` exit from the links card's adding mode, on the reasoning that termisu maps no char to Escape so the old branch was dead. It was not dead — gori enables the Kitty keyboard protocol unconditionally, under which Escape arrives as `CSI 27 u` with `char: '\e'`. My spec "confirming" the old behaviour used `OverlayHarness#press(Key::Escape)`, whose `char:` defaults to `nil` — the legacy event shape the app never receives. Adding mode had ended up with no keyboard exit at all. Fixed, and the guard now drives both event shapes; reverting the fix fails it.

## Pre-existing, reported not changed

Left alone because this is a behaviour-preserving refactor:

1. A row click while the links card is in *adding* mode navigates away instead of being swallowed — the pre-seam `click_links` had no `adding?` check either.
2. `IssuePicker`/`NotePicker` render nothing at all when the card does not fit, where the other five print `… needs a larger window · esc to close`.
3. The "pinned" create row scrolls off with the list.
4. `FilterPickerOverlay` has no ctrl/alt guard, so a fallen-through `^G` puts `g` in the filter — faithful to the four deleted handlers, and the base is now the one place to fix it.

## Verification

- `just test` → **4216 examples, 0 failures** on this base.
- `crystal build --no-codegen src/main.cr` against the merge result — the check that #371+#372 needed.
- Real-TUI smoke via tmux: links add (commit, cancel, nothing-to-link), `esc` out of adding, open-link → History DETAIL survives the close, copy-as over DETAIL leaving the drill-in intact, note-create → CONFIRM, and issue-create → NEW ISSUE form → created-and-linked across C3's `link_ref` seam.

Closes #355 for batch C4.