### PR TITLE
ci: add the merge_group trigger so CI can build the merge result (refs #382)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ on:
       - shard.lock
       - docker/Dockerfile
       - "**/*.cr"
+  # Builds the PROSPECTIVE MERGE RESULT, not the PR branch. Without this, two PRs that
+  # each pass CI alone and touch different hunks of one file can merge cleanly and leave
+  # `main` broken — which is exactly what #371 + #372 did (#382): one changed a method's
+  # arity, the other added a call site against the old signature. Inert until a merge
+  # queue is enabled for `main` in the repository settings; harmless before then.
+  merge_group:
   push:
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
Prep only — **no behaviour change today.**

`ci.yml` builds each PR branch in isolation and `main` after a merge has landed. Nothing builds the *prospective merge result*, which is how #371 and #372 — each CI-green, touching different hunks of `runner.cr`, merging without conflict — left `main` unable to compile until #376.

`merge_group:` is inert until a merge queue is enabled for `main` in repository settings. That is your call, not mine: #382 lays out the trade-off against the two cheaper alternatives (require branches up to date, or rely on authors running `crystal build --no-codegen` after rebasing). This just means turning it on later is a settings toggle instead of a code change.

I have deliberately **not** touched branch protection — `main` currently has none at all, and adding the first gate to a repo that mostly self-merges is a judgement about acceptable friction that belongs to you.

Refs #382