### PR TITLE
refactor(proxy): use Outbound::SANDBOX_ERROR in client_conn

### DIFF
--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -6,6 +6,7 @@ require "../sink"
 require "../head_rewriter"
 require "../../interceptor"
 require "../../host_overrides"
+require "../../outbound"
 require "../prefix_io"
 require "../socket_tuning"
 require "../h2/relay"
@@ -1143,7 +1144,7 @@ module Gori::Proxy
     private def record_blocked_request(req, scheme, host, port, created_at) : Nil
       flow_id = @sink.on_request(FlowMapper.request(req,
         scheme: scheme, host: host, port: port, created_at: created_at, body: nil))
-      @sink.on_response(FlowMapper.aborted_response(flow_id, "blocked by sandbox (out of scope)"))
+      @sink.on_response(FlowMapper.aborted_response(flow_id, Gori::Outbound::SANDBOX_ERROR))
     end
 
     # Tell the client the sandbox refused this request — a distinct 403 + marker header so a


### PR DESCRIPTION
Closes #365.

## What

`src/gori/proxy/conn/client_conn.cr` hard-coded the sandbox refusal string that `Gori::Outbound::SANDBOX_ERROR` (`src/gori/outbound.cr:38`) already owns. The strings were byte-identical, so there is no user-visible change — this removes the drift hazard between the two paths that show the same message for the same reason (live capture vs. active tooling).

## Change

```diff
+require "../../outbound"
...
-      @sink.on_response(FlowMapper.aborted_response(flow_id, "blocked by sandbox (out of scope)"))
+      @sink.on_response(FlowMapper.aborted_response(flow_id, Gori::Outbound::SANDBOX_ERROR))
```

Two lines: one require, one literal swap.

## Other occurrences

Grepped `"blocked by sandbox (out of scope)"` tree-wide. Three hits: the constant definition (`outbound.cr:38`), the one fixed here (`client_conn.cr:1146`), and `spec/proxy/server_spec.cr:1007`. The spec assertion is intentionally left as a literal — it's an independent anchor for the user-visible string; referencing the constant it verifies would make it pass vacuously on a typo.

## DESIGN.md §2.1 layering contract

The required grep returns exactly one hit (a comment in `probe/group.cr`) both before and after the change. `outbound.cr` and its transitive requires (`scope.cr`, `store.cr`) have zero `Tui::`/`CLI::`/`MCP::` references, so pulling `outbound` into the proxy layer does not breach the contract.

Before:
```
$ grep -rnE '\b(Tui|CLI|MCP)::' \
  src/gori/{store,proxy,probe,fuzz,miner,discover,sequencer,oast}/ \
  src/gori/{store,probe,fuzz,miner,discover,sequencer,oast}.cr
src/gori/probe/group.cr:112:    # shared by `gori run probe --format json` (CLI::Output.probe_group_fields delegates here)
```

After: identical — same single hit.

## Verification

- `crystal build --no-codegen src/main.cr` → clean
- `crystal spec spec/proxy/server_spec.cr` → 30 examples, 0 failures
- `crystal spec` (full suite) → 4265 examples, 0 failures
- ameba on the changed file: same 2 pre-existing findings as `HEAD` (both on `handle_response`, untouched), zero new