### PR TITLE
docs(verb): correct the P0/P1 claims in the verb system and record the decision

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -416,6 +416,52 @@ A surface still owns its own error wording: `Fuzz::PlanError` carries a machine-
 `reason`, and each surface renders the sentence naming its own flags (`--auto` / `auto:true` /
 `^A params`). Sharing the assembly must not flatten three different vocabularies into one.
 
+### 2026-07-26: the verb registry is a TUI concern, and `ExecContext` is a catalogue
+
+Refines: [P1](#p1). Issue #357.
+
+Two comments described a system that does not exist. `src/gori/verb.cr` promised that one
+`Verb::Definition` drives "a keybinding AND a command-palette entry (and later an MCP tool +
+CLI subcommand)", and `src/gori/verb/context.cr` called `ExecContext` "thin … deliberately
+(P0)". Neither the later nor the thin was true: `grep -rn 'Verb::Registry\|Verb::Definition'
+src/gori/cli src/gori/mcp` returns nothing, and the interface declares 266 abstract methods.
+Both read as descriptions of the present, which cost reviewers time. The comments are now
+corrected; the structure is deliberately unchanged.
+
+Measured on `main` at `57f1812`:
+
+- `ExecContext` requires **266** abstract methods: 42 in `verb/context.cr` and 224 more spread
+  across the twenty per-tool files in `verb/context/`, which exist only to hold declarations.
+- `Tui::Runner` (with its `runner/*.cr` mixins) defines **534** methods and implements all
+  266, none missing. It is the only production implementor; `spec/support/fake_context.cr` is
+  a recording double.
+- Only the 42 root ones are app chrome and cross-tool actions. The other 224 are tool intents
+  grouped by tool (repeater 28, issues 23, probe 22, history 17, fuzzer 17, jwt 13 …) —
+  surface-neutral in name.
+
+Collapsing `ExecContext` into direct `Runner` calls was considered and rejected. It would
+delete the 266 declarations and the indirection, not the 266 implementations, which the
+palette and keymap still have to invoke — a large mechanical edit for no behavioural gain. It
+would also destroy the two things the interface does buy: one enumerable catalogue of every
+action a verb can trigger, and a one-way dependency, since `verb/` names no `Tui::` in code
+([§2.1](#s2-1)). Keeping a 266-method abstraction is not a [P0](#p0) minimalism claim, and it
+should stop being written up as one.
+
+Wiring CLI and MCP into the registry was also rejected, for a reason worth recording because
+it is not obvious from the method names. Those 224 tool intents are surface-neutral in name
+and TUI-coupled in semantics: `repeater_send` means "send the ACTIVE sub-tab",
+`probe_rule_toggle` means "toggle the HIGHLIGHTED row". A CLI or MCP caller has no selection,
+only an id. Making them callable from another surface therefore requires an argument schema
+so an intent can name its target — the field `Verb::Definition` records as absent. That
+schema is the prerequisite, not a follow-up to the wiring, and it is a project of its own
+across ~224 intents.
+
+So P1's reach stays where [P1](#p1) already describes it: one execution path inside the TUI,
+parity elsewhere by calling the same engines. Read P1's closing sentence — "that gap is real,
+known, and under decision in issue #357" — as settled by this entry: the gap is deliberate, and
+what would close it is the argument schema, not registry wiring. If CLI/MCP parity work resumes
+at the rate it ran before, revisit, but open the argument-schema issue first.
+
 ---
 
 *Keep this document honest against the code. When you change a subsystem it describes, update

--- a/src/gori/mcp.cr
+++ b/src/gori/mcp.cr
@@ -8,10 +8,12 @@ require "./mcp/install"
 module Gori
   # The `gori mcp` server: exposes captured data + the repeater engines to an AI
   # client over the Model Context Protocol (JSON-RPC 2.0 on stdio). It talks
-  # straight to Store + Repeater rather than the TUI verb registry, because verbs
-  # drive a live ExecContext (UI state) and have nothing to offer a headless
-  # client. See `MCP::Server` (transport), `MCP::Tools` (the tool surface),
-  # `MCP::Serialize` (struct→JSON), and `MCP::RequestBuilder` (send_request bytes).
+  # straight to Store + Repeater rather than the TUI verb registry, because a verb
+  # names no target — it acts on whatever a live `ExecContext` has selected, which
+  # a headless client cannot express (DESIGN.md §7, 2026-07-26; issue #357). That
+  # separation is settled, not pending. See `MCP::Server` (transport), `MCP::Tools`
+  # (the tool surface), `MCP::Serialize` (struct→JSON), and `MCP::RequestBuilder`
+  # (send_request bytes).
   module MCP
   end
 end

--- a/src/gori/verb.cr
+++ b/src/gori/verb.cr
@@ -1,9 +1,17 @@
 require "./verb/context"
 
 module Gori
-  # The verb system — gori's "same surface" core (P1). A single Definition is the
-  # one source of truth that drives a keybinding AND a command-palette entry (and
-  # later an MCP tool + CLI subcommand). No per-surface code paths.
+  # The verb system — the TUI's one source of truth for an action (P1). A single
+  # Definition drives a keybinding, a command-palette entry AND a space-menu entry;
+  # all three run the same Definition#call, so the TUI has no per-surface dispatch.
+  #
+  # It stops at the TUI, deliberately. `gori run` and `gori mcp` declare their own
+  # commands and reach parity by calling the same engines (DESIGN.md §2.1), not by
+  # reading this registry. The blocker is not wiring: a verb names no target, it
+  # reads one from TUI selection state (`repeater_send` sends the ACTIVE sub-tab),
+  # and a caller with an id but no selection cannot express that — see the argument
+  # schema Definition does not have. Measured and decided in DESIGN.md §7
+  # (2026-07-26), issue #357.
   module Verb
     # Where a verb may fire. The active surface (focused tab / open overlay)
     # selects which scope's keymap is consulted; Global verbs fire everywhere.
@@ -95,8 +103,13 @@ module Gori
 
     # One action. `handler` runs the action and returns an optional status-line
     # message. `available?` gates visibility/firing for the current context (P4).
-    # Argument schemas (for palette prompts / MCP) are intentionally absent this
-    # milestone — no verb takes arguments yet, and the field is additive later.
+    #
+    # There is NO argument schema, and that absence is load-bearing: a verb reads
+    # its target from TUI selection state rather than naming it, which is exactly
+    # what keeps the registry TUI-only. Adding one is additive to this struct but
+    # is a project of its own — it means giving the 224 per-tool intents in
+    # verb/context/*.cr an explicit target — and it is the prerequisite for a
+    # surface-neutral registry, not a follow-up to one (DESIGN.md §7, 2026-07-26).
     struct Definition
       getter id : String
       getter title : String

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -21,11 +21,22 @@ require "./context/sitemap"
 
 module Gori
   module Verb
-    # The narrow facade a verb handler is given. Verbs express *intents* through
-    # it; they never touch raw TUI/proxy/store state directly (P5 — state changes
-    # are mediated). The TUI App provides the concrete implementation; tests use
-    # a recording double. Keeping this interface thin is deliberate (P0): it is
-    # the entire surface verbs can affect, so it doubles as the action catalogue.
+    # The facade a verb handler is given. Verbs express *intents* through it; they
+    # never touch raw TUI/proxy/store state directly (P5 — state changes are
+    # mediated). `Tui::Runner` is the one production implementation; specs use a
+    # recording double (`spec/support/fake_context.cr`).
+    #
+    # This interface is WIDE, not thin: 266 abstract methods (42 here — app chrome
+    # plus cross-tool actions — and 224 in context/*.cr, grouped by tool). With a
+    # single implementor there is no polymorphism being bought, so do not read the
+    # indirection as P0 minimalism. What it does buy, and why it is kept rather
+    # than collapsed into direct Runner calls: every action a verb can trigger is
+    # declared in ONE enumerable place, and `verb/` compiles without naming `Tui::`
+    # at all, keeping the dependency one-way (DESIGN.md §2.1).
+    #
+    # So a new method here is not free — it widens the catalogue and every double
+    # that implements it. Check whether an existing intent already covers the case.
+    # Measured and decided in DESIGN.md §7 (2026-07-26), issue #357.
     abstract class ExecContext
       # app lifecycle / messaging
       abstract def quit! : Nil         # exit gori entirely


### PR DESCRIPTION
Closes #357.

## What this is

Comments and docs only. No `.cr` code changed, no structure touched, no behaviour change.

Two comments described a system that does not exist:

- `src/gori/verb.cr:4-8` promised that one `Verb::Definition` drives "a keybinding AND a command-palette entry (and later an MCP tool + CLI subcommand)". The "later" never arrived and is not planned.
- `src/gori/verb/context.cr:26-30` called `ExecContext` "thin … deliberately (P0)" — for a 266-method interface.

Both read as descriptions of the present, which is what made them expensive: a reviewer takes them at face value.

## Measured on `main` at `57f1812` (re-verified in this branch, not copied from the issue)

| | |
|---|---|
| `ExecContext` abstract methods | **266** (42 in `verb/context.cr`, 224 in `verb/context/*.cr`) |
| lines of declarations | **478** |
| `Tui::Runner` (+ `runner/*.cr`) defines | **534**, implementing all 266, none missing |
| production implementors | **1** (`spec/support/fake_context.cr` is a recording double) |
| `Verb::Registry\|Definition\|Scope` in `src/gori/cli` + `src/gori/mcp` | **0 hits** |

One correction to the analysis comment on the issue: the declarations are **478** lines, not 986. 986 is `verb/context*.cr` (478) plus `spec/support/fake_context.cr` (1146)… which does not add up either; whatever produced it, 478 is what the tree has. Everything else in that comment reproduced exactly.

## The decision (Option 2, as settled on the issue)

**`ExecContext` is kept.** Collapsing it into direct `Runner` calls would delete the 266 declarations and the indirection, not the 266 implementations — the palette and keymap still have to invoke them. Large mechanical edit, zero behavioural gain, and it would destroy the two things the interface does buy: one enumerable catalogue of every action a verb can trigger, and a one-way dependency (`verb/` names no `Tui::` in code, per §2.1).

**CLI/MCP stay separate.** Not because the intents are TUI-shaped — 224 of the 266 are tool intents, surface-neutral in name — but because each is implicitly parameterised by TUI selection state. Verified at the call site, not inferred from the name: `repeater_send` reaches `repeater_controller.repeater_send`, whose first line is `return unless tab = current_repeater_tab`; `probe_rule_toggle` reaches `probe_controller.rules_toggle_selected`. A CLI or MCP caller has an id, not a selection. Making these callable elsewhere needs the argument schema `Verb::Definition` records as absent — that is the prerequisite, not a follow-up to registry wiring, and it is a project of its own across 224 intents.

## Changes

- `src/gori/verb.cr` — header now describes the TUI reality (keybinding + palette + space menu, all through `Definition#call`) and states plainly where it stops and why. The `Definition` comment now says the missing argument schema is load-bearing rather than "absent this milestone … additive later".
- `src/gori/verb/context.cr` — honest instead of flattering: wide, one implementor, no polymorphism being bought, and an explicit "do not read this as P0 minimalism", followed by what it actually buys.
- `src/gori/mcp.cr` — the only other comment in `src/` touching this question. It already pointed the right way; it now gives the precise reason (a verb names no target) and says the separation is settled, not pending.
- `DESIGN.md` §7 — new entry, `Refines: [P1](#p1). Issue #357.`, following the existing format, with the numbers and the rejected options.

Nothing else in `src/` or `docs/` asserts the three-surface promise (checked).

## Two notes for the reviewer

1. **Suggested retitle for #357:** "correct the P0/P1 claims in the verb system". It is no longer "decide ExecContext's fate" — the ExecContext-collapse option was measured and rejected for the reasons above.
2. **`DESIGN.md` §1 P1 is untouched, deliberately.** Its closing sentence still reads "that gap is real, known, and under decision in issue #357", which this PR settles. §7's own rule is to append rather than edit a principle's wording, so instead the new entry names that sentence and marks it settled. If you would rather P1 point straight at §7, that is a one-line follow-up — I did not want to edit a principle under a docs-only change.

## Verification

- `crystal build --no-codegen src/main.cr` — OK (this is also the proof that all 266 abstract methods are implemented; Crystal would reject the subclass otherwise)
- `just test` — **4265 examples, 0 failures, 0 errors**
- `crystal tool format --check` on the three touched `.cr` files — clean
- ameba on the touched files — 1 finding, pre-existing (`%w`-delimiters at `verb.cr:64`, untouched by this diff; it only moved line numbers)
- No specs added: there is no behaviour here to assert, and no spec reads `DESIGN.md`

`just check` does fail tree-wide, on `spec/proxy/tls/tunnel_spec.cr` and `src/gori/proxy/upstream.cr` — pre-existing Crystal 1.21.0 format drift in files this branch does not touch.