### PR TITLE
fix(tui): restore a modal displaced by a :none confirm instead of dropping it (#384)

### DIFF
--- a/spec/tui/overlay_nesting_spec.cr
+++ b/spec/tui/overlay_nesting_spec.cr
@@ -70,6 +70,10 @@ private class NestShell
   property overlay = OverlayKind::None
   getter active : Overlay?
 
+  # Mirrors Runner::MODAL_OVERLAYS — the states restore_overlay is allowed to name without
+  # an object behind them. Keep in step (it is deliberately tiny; migrated modals are absent).
+  MODAL_OVERLAYS = {OverlayKind::Palette, OverlayKind::TabsMore}
+
   def open_overlay(ov : Overlay) : Nil
     @active = ov
     @overlay = ov.key
@@ -91,6 +95,32 @@ private class NestShell
   def active_overlay : Overlay?
     ov = @active
     ov if ov && @overlay == ov.key
+  end
+
+  # Mirror of Runner#restore_overlay (runner.cr). Keep in step — a spec that passes against
+  # a drifted copy proves nothing about the real shell. The `|| kind.none?` clause is the
+  # #384 fix: a :none confirm displacing a modal restores it, rather than dropping it.
+  def restore_overlay(kind : OverlayKind, parent : Overlay?) : Nil
+    return open_overlay(parent) if parent && (parent.key == kind || kind.none?)
+    restorable = kind.none? || kind.detail? || MODAL_OVERLAYS.includes?(kind)
+    @overlay = restorable ? kind : OverlayKind::None
+  end
+
+  # Mirror of Runner#confirm's overlay-state wiring (runner.cr): capture the displaced
+  # parent BEFORE open_overlay overwrites it, then wire the dialog to restore-first-act-
+  # second on close. Uses the real ConfirmDialog so `y`/`n`/esc route exactly as they do
+  # in the shell. `return_to` mirrors the production Symbol seam.
+  def confirm(*, return_to : Symbol = :none, &action : -> Nil) : Nil
+    ov = ConfirmDialog.new("CONFIRM", "quit?")
+    back = OverlayKind.from_sym(return_to)
+    parent = active_overlay
+    accepted = false
+    ov.on_commit = -> { accepted = true; true }
+    ov.on_close = -> {
+      restore_overlay(back, parent)
+      action.call if accepted
+    }
+    open_overlay(ov)
   end
 
   def press(k : Termisu::Input::Key) : Nil
@@ -346,5 +376,92 @@ describe "Overlay#on_close — a confirm raised from inside another modal" do
     shell.open_overlay(dialog)
     shell.press(ENTER)
     seen_by_action.should eq(OverlayKind::Confirm) # not :detail — too early to read it
+  end
+end
+
+# #384 — a confirm raised OVER another modal with the default `return_to: :none`. Its one
+# reachable trigger is the opt-in quit confirm (settings:general "Confirm before quit"),
+# which fires from `Runner#handle_key` while ANY modal is up. These drive the real
+# `NestShell#confirm` + `#restore_overlay` (mirrors of runner.cr) through the real
+# ConfirmDialog, so `n`/`y`/esc route exactly as the shell does.
+private YES = Termisu::Input::Key::LowerY
+private NO  = Termisu::Input::Key::LowerN
+
+describe "Runner#restore_overlay — a :none confirm displacing a modal (#384)" do
+  it "restores the displaced modal on decline, and does NOT run its on_close" do
+    # The bug: declining the quit confirm dropped the modal AND left its on_close unrun, so
+    # a theme preview stuck applied, an unsaved edit vanished, or a nested pop-back was lost.
+    # The modal was only DISPLACED, never asked to close, so its teardown must not fire — it
+    # comes back exactly as it was.
+    shell = NestShell.new
+    editor = NestModal.new(OverlayKind::Settings) # e.g. the Theme card, mid live-preview
+    popped_back = 0
+    editor.on_close = -> { popped_back += 1; nil } # its teardown (revert preview / pop to Prefs)
+    shell.open_overlay(editor)
+
+    shell.confirm(return_to: :none) { } # ^C/^D with confirm-before-quit on
+    shell.active_overlay.should be_a(ConfirmDialog)
+    shell.press(NO) # "no, don't quit"
+
+    shell.active_overlay.should be(editor)         # the card is back…
+    shell.overlay.should eq(OverlayKind::Settings) # …object AND state, so it renders + captures
+    popped_back.should eq(0)                       # …and its teardown never ran
+  end
+
+  it "on accept, restores the modal FIRST and then runs the quit action" do
+    # Accepting still runs restore-then-action (the ordering history_controller relies on).
+    # The quit action fires last; the restore before it is harmless (the app is leaving).
+    shell = NestShell.new
+    editor = NestModal.new(OverlayKind::Hosts)
+    shell.open_overlay(editor)
+
+    quit_ran = false
+    seen_by_action = nil.as(Overlay?)
+    shell.confirm(return_to: :none) { quit_ran = true; seen_by_action = shell.active_overlay }
+    shell.press(YES) # "yes, quit"
+
+    quit_ran.should be_true
+    seen_by_action.should be(editor) # the restore ran before the action, not after
+  end
+
+  it "still restores when return_to NAMES the parent (the existing path, unregressed)" do
+    # RESET SETTINGS / RESET TAB BAR raise their confirm with return_to: :settings / :tabs
+    # from inside the card. This worked before #384 and must keep working: same object-restore.
+    shell = NestShell.new
+    card = NestModal.new(OverlayKind::Settings)
+    reset_ran = 0
+    card.on_close = -> { reset_ran += 1; nil }
+    shell.open_overlay(card)
+
+    shell.confirm(return_to: :settings) { }
+    shell.press(NO)
+
+    shell.active_overlay.should be(card)
+    shell.overlay.should eq(OverlayKind::Settings)
+    reset_ran.should eq(0) # the card was displaced, not closed
+  end
+
+  it "lands on the bare body when a :none confirm displaced nothing" do
+    # A palette-launched confirm (no modal up) still means "nowhere to go back to": decline
+    # leaves the user on the tab body. The fix must not conjure a parent that was never there.
+    shell = NestShell.new
+    shell.confirm(return_to: :none) { }
+    shell.press(NO)
+
+    shell.active_overlay.should be_nil
+    shell.overlay.should eq(OverlayKind::None)
+  end
+
+  it "never restores a MIGRATED kind by STATE alone — the phantom hazard" do
+    # restore_overlay may only name a state for None / Detail / an unmigrated MODAL_OVERLAYS
+    # member. A migrated kind restored by @overlay alone (no object) renders nothing, takes
+    # no keys, and — being absent from MODAL_OVERLAYS — lets clicks fall through to the body
+    # behind a card that was never drawn. With no object to restore it, fall to the bare body.
+    shell = NestShell.new
+    shell.restore_overlay(OverlayKind::Settings, nil) # a migrated kind, no object
+    shell.overlay.should eq(OverlayKind::None)        # …not a phantom Settings
+
+    shell.restore_overlay(OverlayKind::Palette, nil) # an unmigrated MODAL_OVERLAYS member
+    shell.overlay.should eq(OverlayKind::Palette)    # …that one IS routed by state
   end
 end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1522,9 +1522,12 @@ module Gori::Tui
     # Open the confirmation modal; `action` runs only if the user accepts.
     # Defaults to a red "danger" confirm button (destructive deletes). Pass
     # `danger: false` and custom labels for non-destructive choices (e.g. open
-    # vs stay after create-and-link). `return_to` is the overlay restored on
-    # close — leave it :none for a palette-launched confirm, or pass the parent
-    # modal (e.g. :tabs) when raising the confirm from inside another overlay.
+    # vs stay after create-and-link). `return_to` is what `restore_overlay` puts
+    # back on close — pass the parent modal (e.g. :tabs) when raising the confirm
+    # from inside another overlay, or leave it :none. :none means "I did not ask
+    # to change where you were": with nothing up it lands on the bare body, but
+    # over a modal (the quit confirm, which hits any modal) it restores that modal
+    # rather than dropping it — see restore_overlay (#384).
     # It stays a Symbol because it is part of the Host facade (tab_controller.cr), which
     # controllers still speak; from_sym is the total, loud-on-typo bridge to OverlayKind.
     def confirm(title : String, message : String, *, confirm_label : String = "delete",
@@ -1555,18 +1558,31 @@ module Gori::Tui
       open_overlay(ov)
     end
 
-    # Put back the modal a confirm was raised from. A parent that has migrated onto the
-    # Overlay seam has to be re-opened as an OBJECT — setting @overlay alone would name a
-    # modal with nothing behind it, which neither renders nor takes keys.
+    # Put back the modal a confirm was raised OVER. The confirm DISPLACED it (open_overlay
+    # overwrote @active_overlay); it was never asked to close, so its on_close must NOT run.
+    # Running it would treat the interruption as a cancel and fire that modal's teardown — it
+    # would revert a live theme preview, or drop a sub-editor's unsaved edits with no warning
+    # (#384). So a displaced parent is re-opened as the captured OBJECT, which restores BOTH
+    # @active_overlay and @overlay; it comes back exactly as it was, edits and all.
+    #
+    # That happens when `return_to:` NAMES the parent (a confirm raised from inside the modal
+    # — RESET SETTINGS over the Settings card) OR when `return_to:` is :none. :none means "I
+    # did not ask to change where you were": the opt-in quit confirm and every palette-
+    # launched confirm use it, and the right answer over a modal is to leave the user where
+    # they were, not to tear it down. Before #384 only the named case restored, so a :none
+    # confirm over any modal dropped it, on_close and all — the reachable trigger being the
+    # quit confirm (^C/^D with settings:general "Confirm before quit" on), which hits every
+    # modal in the app.
     private def restore_overlay(kind : OverlayKind, parent : Overlay?) : Nil
-      return open_overlay(parent) if parent && parent.key == kind
-      # No object to restore. Setting @overlay alone is right for a parent the shell still
-      # routes BY STATE — an unmigrated modal, or the non-modal None/Detail. For a MIGRATED
-      # kind it would be a phantom: nothing renders or takes keys, and since a migrated kind
-      # is deleted from MODAL_OVERLAYS, modal_overlay? answers false too, so clicks fall
-      # through to the tab body behind a card that was never drawn. No `return_to:` names a
-      # migrated modal today, but that changes the moment Settings / Tabs / DiscoverConfig
-      # migrate — so land on the bare body, which the user can at least act from.
+      return open_overlay(parent) if parent && (parent.key == kind || kind.none?)
+      # No object to restore — either nothing was displaced (a :none confirm over the bare
+      # body or the History Detail drill-in), or `return_to:` names a state the shell routes
+      # BY STATE. Setting @overlay alone is right for None / Detail / an unmigrated
+      # MODAL_OVERLAYS member. A MIGRATED kind here would be a phantom: nothing renders or
+      # takes keys, and being deleted from MODAL_OVERLAYS modal_overlay? answers false too, so
+      # clicks fall through to the tab body behind a card that was never drawn — so land on
+      # the bare body instead. (Unreachable today: a migrated parent is always captured as
+      # `parent` and restored above.)
       restorable = kind.none? || kind.detail? || MODAL_OVERLAYS.includes?(kind)
       @overlay = restorable ? kind : OverlayKind::None
     end


### PR DESCRIPTION
## Summary

A confirm raised **over** another modal with the default `return_to: :none` discarded that modal without running its `on_close`. `restore_overlay` only re-opened the parent when `return_to:` named its kind (`parent.key == kind`); a `:none` confirm fell through the first branch and dropped the parent — teardown and all.

The one reachable trigger is the opt-in **quit confirm** (settings → General → *Confirm before quit*), which fires from `Runner#handle_key` while **any** modal is up. Declining it produced the three symptoms in #384:

- a live theme preview stuck applied (its revert `on_close` never ran),
- a nested sub-editor gone, its pop-back to Preferences lost,
- an unsaved Preferences edit silently discarded, bypassing `close_or_warn`.

## The design decision: restore, not drop

The issue laid out two options for a modal a confirm displaces: (a) preserve and restore it, or (b) close it properly by running its `on_close` at displacement time. **This PR picks (a).**

A displaced modal was *never asked to close*. The confirm interrupted the user (a global ^C/^D), it did not cancel the modal. Running the modal's `on_close` would treat that interruption as a cancel and fire teardown that is wrong for "no, don't quit": it would revert a live theme preview the user was still working on, and — worst of the three — discard a sub-editor's unsaved edits with no warning. Restoring brings the modal back exactly as it was, edits and all, which is what "no, don't quit" means. This also matches the issue author's own recommendation.

Restore is done by re-opening the **captured parent object**, which sets both `@active_overlay` and `@overlay`, so it cannot produce the phantom-overlay state the old comment warns about (a migrated kind restored by `@overlay` alone renders nothing and captures no keys). The state-restore fallback keeps its phantom guard for the parent-less case.

## The change

```crystal
-      return open_overlay(parent) if parent && parent.key == kind
+      return open_overlay(parent) if parent && (parent.key == kind || kind.none?)
```

`:none` now means "I did not ask to change where you were": over a modal it restores that modal; with nothing up it still lands on the bare body. The named-parent path (RESET SETTINGS / RESET TAB BAR raising a confirm with `return_to: :settings` / `:tabs` from inside the card) is unchanged. I audited every `confirm(` call-site: the only `:none`-over-a-migrated-modal path is the global quit confirm (checked *before* modal dispatch, so no controller confirm ever fires over a modal); every other `:none` confirm either has no modal up or drops its own modal first (e.g. `submit_ca_import`). The `restore_overlay` and `confirm` comments were rewritten to describe this accurately.

## Tests

`spec/tui/overlay_nesting_spec.cr`'s `NestShell` double gains faithful mirrors of `Runner#confirm` + `#restore_overlay` (the Runner needs a live tty and can't be unit-tested, so the file already mirrors its overlay-state machine; this keeps that discipline), driving the **real** `ConfirmDialog` so `y`/`n`/esc route exactly as the shell does. New examples:

- **quit-confirm decline** (`:none` over a migrated modal): restores the modal, and its `on_close` never runs — the #384 fix.
- **quit-confirm accept**: restores the modal *first*, then runs the quit action (the restore-then-act order History relies on).
- **named-parent** (`return_to: :settings`): still restores the object — regression guard for RESET SETTINGS/TAB BAR.
- **bare body**: a `:none` confirm that displaced nothing lands on `None`.
- **phantom guard**: a migrated kind with no object restores to `None`, not a phantom; an unmigrated `MODAL_OVERLAYS` member still restores by state.

**Control-run:** reverting `|| kind.none?` in the mirror turns the two `:none`-over-modal examples red while the three regression guards stay green — the intended split. Full suite: `crystal spec` → 4270 examples, 0 failures. Rebased onto current `main` and re-verified `crystal build --no-codegen src/main.cr` (the merge result) builds.

Closes #384