### PR TITLE
fix(discover): apply the Layer-2 scope gate to the seed and its two derived well-known paths (#364)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -462,6 +462,65 @@ known, and under decision in issue #357" — as settled by this entry: the gap i
 what would close it is the argument schema, not registry wiring. If CLI/MCP parity work resumes
 at the rate it ran before, revisit, but open the argument-schema issue first.
 
+### 2026-07-26: Discover's seed waives Layer 1, never Layer 2
+
+Refines: [P4](#p4). Issue #364, surfaced by the review of #354.
+
+`Discover::Engine#seed_frontier` put the seed, `<origin>/robots.txt`, `<origin>/sitemap.xml` and
+the origin-root soft-404 calibration straight onto the frontier with no `bounded_url` call.
+Every URL the crawl derived afterwards was gated normally, which is why it read as a deliberate
+seed exemption rather than a hole, but only the *path-confinement* half had ever been reasoned
+about (well-known paths live at the origin, so a run confined to `/app/` has to step outside its
+subtree to find them). The scope gate rode along with it by accident.
+
+The exposure was not uniform across the four, and the difference is what settles the decision. A
+Layer-1 `in_scope` verdict already implies a clean Layer 2, because `Scope#sandbox_blocks?` and
+`Outbound#evaluate` both route through `allowlisted_unlocked?` — so for the **seed** the gap only
+ever opened where Layer 1 was waived, which is the TUI and any `--allow-unscoped` run. The three
+**derived** requests were exposed on every surface, since they are anchored on `Url.origin` and a
+path-scoped include rule never covers them.
+
+The two-layer split in [§3](#s3) already answers this, and the answer is asymmetric on purpose:
+
+- **Layer 1 stays waived for all four.** The seed is what a human typed, which is the same
+  argument `Outbound.interactive` makes for the TUI, and every surface has already made that
+  decision before the engine runs (`Outbound.agent` refuses an out-of-scope seed, `.cli` refuses
+  one on a configured project, `.interactive` waives by name; the CLI and MCP enforce the verdict
+  right after `Plan.build`, before a single send). `robots.txt` and `sitemap.xml` inherit it:
+  they are derived from a seed the operator was already authorised to hit and live at that same
+  origin by construction. Re-asking the include question here would only re-ask what the surface
+  just answered, and on a path-scoped include rule it would break the calibration on every run
+  that has one.
+- **Layer 2 now applies to all four.** Sandbox's documented promise in [§3](#s3), that a request
+  to a host which is not allowlisted is blocked outright, carries no "unless the operator typed
+  it" clause, and `Outbound.interactive`'s own contract already says Layer 2 still hard-stops the
+  send. "The operator chose this target" was never an argument about Sandbox. Explicit EXCLUDE
+  rules come with it (`sweep_block` semantics, not `send_block`): discover is the most automated
+  sweep gori has, and its every other URL is judged by the same predicate.
+
+Three specifics worth recording:
+
+- **A blocked seed fails the run, loudly.** The verdict is taken in `Engine#initialize` and
+  `Engine#start` emits it as the run's sole terminal `ErrorEvent` (`Engine::SEED_BLOCKED`); it is
+  not a skipped enqueue. A blocked seed blocks everything derived from it, so the alternative is
+  a run that finishes with zero findings and no reason, which an operator reads as "there is
+  nothing there" rather than "gori sent nothing" ([P4](#p4)). A blocked `robots.txt`/`sitemap.xml`
+  is skipped silently instead: the crawl is still meaningful without it.
+- **A gated calibration still routes its two dependants.** `@seed_calibration_dir` is set whether
+  or not the Calibrate task survives the gate. Without it a robots/sitemap outcome falls back to
+  `record_page`, whose raw-status trust reports both as findings on a 200-everything server,
+  which is the exact false positive the calibration exists to prevent. With it and no baseline
+  they go uncounted: no baseline, no claim.
+- **The gate is the engine's injected `ScopePolicy`, not an `Outbound`.** `StoreScope#allowed?`
+  is already the negation of `sandbox_blocks? || excluded?`, which is `sweep_block`'s predicate,
+  and the engine stays Store-free, which is the whole reason that seam exists.
+
+What this does **not** close, deliberately, because each is a separate decision: brute-force and
+calibration probes are still authorised by their *directory* rather than per URL, so a `string`
+or `regex` EXCLUDE that matches a child but not its parent does not stop them; and
+`Plan.resolve_policy` still hands an unconfigured scope an `OpenScope`, so Layer 2 is absent
+entirely on a project with Sandbox on and no rules.
+
 ---
 
 *Keep this document honest against the code. When you change a subsystem it describes, update

--- a/spec/discover/engine_spec.cr
+++ b/spec/discover/engine_spec.cr
@@ -41,9 +41,39 @@ private def notfound : R
   make(404, "not found here")
 end
 
-private def run_discover(seed : String, words : Array(String), cfg : D::Config, &route : String -> R) : {Array(D::Finding), D::RunStats}
+# A ScopePolicy that denies an exact URL set — the shape `StoreScope#allowed?` takes for a
+# regex EXCLUDE rule, or for Sandbox with the host off the allowlist. `configured?` is false
+# so ScopeAware containment falls back to same-origin and only `allowed?` (Layer 2) is under
+# test here.
+private class DenyExact < D::ScopePolicy
+  def initialize(@deny : Set(String))
+  end
+
+  def allowed?(url : String, host : String) : Bool
+    !@deny.includes?(url)
+  end
+
+  def boundary?(url : String, host : String) : Bool
+    true
+  end
+
+  def configured? : Bool
+    false
+  end
+end
+
+# The bogus soft-404 probes an origin-root calibration sends: one path segment directly under
+# "/", minus the two well-known paths seed_frontier queues by name. A path-scoped run's own
+# brute-force probes are deeper (/app/…), so they never land in here.
+private def root_calibration_probes(targets : Array(String)) : Array(String)
+  targets.select { |t| t.matches?(%r{\A/[^/]+\z}) && t != "/robots.txt" && t != "/sitemap.xml" }
+end
+
+private def run_discover(seed : String, words : Array(String), cfg : D::Config,
+                         scope : D::ScopePolicy = D::OpenScope.new,
+                         &route : String -> R) : {Array(D::Finding), D::RunStats}
   backend = RouteBackend.new(route)
-  engine = D::Engine.new(seed, words, backend, cfg)
+  engine = D::Engine.new(seed, words, backend, cfg, scope)
   findings = [] of D::Finding
   stats = nil.as(D::RunStats?)
   engine.run do |ev|
@@ -249,5 +279,93 @@ describe Gori::Discover::Engine do
     urls.should contain("http://t/api")                     # the seed path itself (== base) stays in-subtree
     urls.should contain("http://t/api/inner")               # a genuine child under base/
     urls.should_not contain("http://t/api-internal/secret") # sibling prefix — must be excluded
+  end
+
+  # Issue #364 / DESIGN.md §7: the seed and its two derived well-known paths waive Layer 1,
+  # the containment mode and the path confine — but never Layer 2 (Sandbox + EXCLUDE).
+  describe "the Layer-2 gate on the seed trio" do
+    it "refuses the whole run, terminally and without a single send, when Layer 2 blocks the seed" do
+      sent = [] of String
+      backend = RouteBackend.new(->(t : String) { sent << t; notfound })
+      cfg = D::Config.new(spider: true, bruteforce: true, calibrate_probes: 2, concurrency: 1, retries: 0)
+      engine = D::Engine.new("http://t/", ["admin"], backend, cfg, DenyExact.new(Set{"http://t/"}))
+      kinds = [] of Symbol
+      messages = [] of String
+      engine.run do |ev|
+        if ev.is_a?(D::ErrorEvent)
+          kinds << :error
+          messages << ev.message
+        end
+        kinds << :done if ev.is_a?(D::DoneEvent)
+      end
+      # A silent 0-finding Done would read as "there is nothing there" rather than "gori sent
+      # nothing", which is the whole reason this is a setup error and not a skipped enqueue.
+      kinds.should eq([:error])
+      messages.first.should contain(D::Engine::SEED_BLOCKED)
+      sent.should be_empty
+    end
+
+    it "drops robots.txt/sitemap.xml when Layer 2 excludes them, and keeps the seed" do
+      cfg = D::Config.new(spider: true, bruteforce: false, concurrency: 1, retries: 0)
+      denied = Set{"http://t/robots.txt", "http://t/sitemap.xml"}
+      sent = [] of String
+      run_discover("http://t/", [] of String, cfg, DenyExact.new(denied)) do |t|
+        sent << t
+        t == "/" ? html("home, no links") : notfound
+      end
+      sent.should eq(["/"])
+    end
+
+    it "still fetches both when nothing denies them (the control for the case above)" do
+      cfg = D::Config.new(spider: true, bruteforce: false, concurrency: 1, retries: 0)
+      sent = [] of String
+      run_discover("http://t/", [] of String, cfg) do |t|
+        sent << t
+        t == "/" ? html("home, no links") : notfound
+      end
+      sent.sort.should eq(["/", "/robots.txt", "/sitemap.xml"])
+    end
+
+    it "gates the origin calibration a path-scoped run queues to grade those two paths" do
+      # The seed-only calibration is the LARGEST part of the trio's blast radius — one bogus
+      # probe per calibrate_probes, at the origin root, on a run confined to /app/. Denying
+      # the root dir alone leaves the seed and both well-known paths allowed, so what this
+      # asserts on is the calibration and nothing else.
+      cfg = D::Config.new(spider: true, bruteforce: true, calibrate_probes: 3, max_depth: 1,
+        concurrency: 1, retries: 0)
+      route = ->(t : String) { t == "/app/" ? html("app root, no links") : notfound }
+
+      gated = [] of String
+      run_discover("http://t/app/", ["admin"], cfg, DenyExact.new(Set{"http://t/"})) do |t|
+        gated << t
+        route.call(t)
+      end
+      root_calibration_probes(gated).should be_empty
+      gated.should contain("/robots.txt") # the deny was narrow: only the calibration is gone
+      gated.should contain("/sitemap.xml")
+
+      # Control run — without it, the assertion above would pass just as happily against an
+      # engine that never calibrates the origin at all.
+      open = [] of String
+      run_discover("http://t/app/", ["admin"], cfg) do |t|
+        open << t
+        route.call(t)
+      end
+      root_calibration_probes(open).size.should eq(3)
+    end
+
+    it "does not downgrade robots.txt/sitemap.xml to raw-status trust when that calibration is gated" do
+      # Gating the calibration must not also drop the routing that sends a robots/sitemap
+      # outcome through the soft-404 baseline: with no baseline they have to go UNCOUNTED
+      # ("no baseline, no claim"), not fall back to record_page — which on a 200-everything
+      # server reports both as findings, the exact false positive the calibration exists to
+      # stop. An earlier draft of this fix skipped the routing and did precisely that.
+      cfg = D::Config.new(spider: true, bruteforce: true, calibrate_probes: 3, max_depth: 1,
+        concurrency: 1, retries: 0)
+      findings, _ = run_discover("http://t/app/", ["admin"], cfg, DenyExact.new(Set{"http://t/"})) do |_t|
+        html("THE SAME SOFT-404 PAGE FOR EVERY SINGLE PATH ON THIS SERVER")
+      end
+      findings.select { |f| f.source.robots? || f.source.sitemap? }.should be_empty
+    end
   end
 end

--- a/spec/discover/plan_spec.cr
+++ b/spec/discover/plan_spec.cr
@@ -68,6 +68,19 @@ private def crawl_config : D::Config
     bruteforce: false, max_depth: 1, timeout: 3.seconds)
 end
 
+# The seed and its two derived well-known paths and NOTHING else: depth 0 so no link can add
+# a fourth request, and headroom on `max_requests` so a fourth would still be visible on the
+# wire rather than swallowed by CappedBackend. Used by the Layer-2 tests on the seed trio.
+private def seed_trio_config : D::Config
+  D::Config.new(concurrency: 1, retries: 0, max_requests: 10_i64, spider: true,
+    bruteforce: false, max_depth: 0, timeout: 3.seconds)
+end
+
+# The request targets an origin actually saw, in the order it saw them.
+private def targets_of(heads : Array(String)) : Array(String)
+  heads.compact_map { |h| h.lines.first?.try(&.split(' ')[1]?) }
+end
+
 # Run one plan against a throwaway origin. Yields the listener's port so the caller can
 # build a seed pointing at it; returns the findings plus every request head the origin saw.
 #
@@ -75,7 +88,7 @@ end
 # worth having: the getters and the engine are populated from the same locals, so asserting
 # `plan.seed` / `plan.policy` alone cannot tell a plan that hands the crawl the right values
 # from one that reports them and passes the engine something else.
-private def run_one(outbound = ungated_outbound, body = "hi",
+private def run_one(outbound = ungated_outbound, body = "hi", events : Array(D::Event)? = nil,
                     &build : Int32 -> D::PlanOptions) : {Array(D::Finding), Array(String)}
   server = TCPServer.new("127.0.0.1", 0)
   port = server.local_address.port
@@ -93,7 +106,10 @@ private def run_one(outbound = ungated_outbound, body = "hi",
   begin
     plan = D::Plan.build(build.call(port), outbound)
     findings = [] of D::Finding
-    plan.engine.run { |ev| findings << ev.finding if ev.is_a?(D::FindingEvent) }
+    plan.engine.run do |ev|
+      events << ev if events
+      findings << ev.finding if ev.is_a?(D::FindingEvent)
+    end
     {findings, seen}
   ensure
     server.close
@@ -237,9 +253,9 @@ describe Gori::Discover::Plan do
     # These two drive the engine instead, as an A/B on one crawled link: same plan, same
     # harness, only the scope rules differ.
     #
-    # The assertion is about the LINK, not the seed: the seed plus robots.txt/sitemap.xml
-    # bypass the engine's gate outright (issue #364, deliberately not fixed here), so they go
-    # out under both rule sets. Everything discovered after them is gated normally.
+    # The assertion is about the LINK, not the seed: the seed trio takes a DIFFERENT path
+    # through the gate (Layer 2 only — see the Layer-2 block below and DESIGN.md §7), so
+    # asserting on it here would conflate the two.
     linked = %(<html><a href="/deeper">d</a></html>)
 
     it "hands the derived policy to the engine, not just to the getter" do
@@ -265,6 +281,58 @@ describe Gori::Discover::Plan do
         end
         seen.any?(&.includes?("GET /deeper ")).should be_true
         findings.map(&.url).any?(&.includes?("/deeper")).should be_true
+      end
+    end
+  end
+
+  # Issue #364 / DESIGN.md §7. The seed and its two derived well-known paths waive Layer 1 —
+  # a human typed the target — but not Layer 2, whose promise ("blocks ALL out-of-scope
+  # traffic") is unconditional. These drive a REAL `Gori::Scope` end to end and assert on the
+  # bytes the origin received, because a policy double could only restate the decision.
+  describe "Layer 2 on the seed and its two derived well-known paths" do
+    it "sends nothing at all — and says why — when Sandbox blocks the seed's host" do
+      with_store do |store|
+        scope = Gori::Scope.load(store)
+        scope.add("include", "host", "elsewhere.test")
+        scope.enable_sandbox
+        events = [] of D::Event
+        # `Outbound.interactive` is the STRONGEST case for leaving the seed alone: the TUI's
+        # Layer 1 is waived precisely because the operator chose this target. Sandbox still
+        # has to stop it.
+        findings, seen = run_one(Gori::Outbound.interactive(scope), "hi", events) do |port|
+          D::PlanOptions.new("http://127.0.0.1:#{port}/", config: seed_trio_config, verify: false)
+        end
+        seen.should be_empty
+        findings.should be_empty
+        events.map(&.class).should eq([D::ErrorEvent])
+        events.first.as(D::ErrorEvent).message.should contain(D::Engine::SEED_BLOCKED)
+      end
+    end
+
+    it "sends all three once Sandbox allowlists the host" do
+      with_store do |store|
+        scope = Gori::Scope.load(store)
+        scope.add("include", "host", "127.0.0.1")
+        scope.enable_sandbox
+        _findings, seen = run_one(Gori::Outbound.interactive(scope)) do |port|
+          D::PlanOptions.new("http://127.0.0.1:#{port}/", config: seed_trio_config, verify: false)
+        end
+        targets_of(seen).sort.should eq(["/", "/robots.txt", "/sitemap.xml"])
+      end
+    end
+
+    it "drops the derived pair to an EXCLUDE rule while the seed still goes out" do
+      # Sandbox is OFF here: Layer 2 is Sandbox *plus* explicit excludes, and discover is the
+      # most automated sweep gori has, so an operator's carve-out has to hold on its seed
+      # requests exactly as it does on every URL the crawl derives afterwards.
+      with_store do |store|
+        scope = Gori::Scope.load(store)
+        scope.add("include", "host", "127.0.0.1")
+        scope.add("exclude", "regex", "/(robots\\.txt|sitemap\\.xml)\\z")
+        _findings, seen = run_one(Gori::Outbound.interactive(scope)) do |port|
+          D::PlanOptions.new("http://127.0.0.1:#{port}/", config: seed_trio_config, verify: false)
+        end
+        targets_of(seen).should eq(["/"])
       end
     end
   end

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -137,6 +137,9 @@ module Gori::Discover
     # them far past any real crawl. Once @seen hits this, consider_link stops tracking and
     # enqueuing new links: the run keeps draining what's in flight but adds nothing new.
     MAX_SEEN = 250_000
+    # Setup error for a seed the Layer-2 gate refuses. A constant because it is the one
+    # engine error a spec (and a surface) wants to recognize rather than merely display.
+    SEED_BLOCKED = "seed blocked by scope (Sandbox or an exclude rule)"
 
     enum State : UInt8
       Running
@@ -184,7 +187,23 @@ module Gori::Discover
     def initialize(seed_url : String, @words : Array(String), backend : Backend,
                    @config : Config, @scope : ScopePolicy = OpenScope.new)
       sp = Url.parse(seed_url)
-      @setup_error = sp ? nil : "invalid seed url: #{seed_url}"
+      @setup_error =
+        if sp.nil?
+          "invalid seed url: #{seed_url}"
+        else
+          # Layer 2 (Sandbox + explicit EXCLUDE) is the ONE gate the operator's own seed does
+          # not waive. Layer 1 is already waived FOR it, per surface (`Outbound.interactive`
+          # in the TUI, `--allow-unscoped` elsewhere) because a human typed the target — but
+          # "the operator chose this" was never an argument about Sandbox, whose documented
+          # promise is unconditional (DESIGN.md §3, and the §7 entry for #364).
+          #
+          # Refused up front as a TERMINAL error rather than by quietly enqueuing nothing: a
+          # blocked seed blocks everything derived from it, so the alternative is a run that
+          # finishes with zero findings and no reason, which reads as "there is nothing
+          # there" instead of "gori sent nothing" (P4).
+          seed_norm = Url.normalize(sp)
+          @scope.allowed?(seed_norm, sp.host) ? nil : "#{SEED_BLOCKED}: #{seed_norm}"
+        end
       @seed_parts = sp || Url::Parts.new("http", "invalid.invalid", 80, "/", nil)
       # A path-scoped run (seed path deeper than "/") confines discovery to that subtree.
       # Store the base with any single trailing slash stripped so bounded_url can test
@@ -322,11 +341,13 @@ module Gori::Discover
     private def seed_frontier : Nil
       @seen << Url.visit_key(@seed_parts)
       if @config.spider?
+        # The seed itself needs no gate here — `initialize` already refused the whole run if
+        # Layer 2 blocks it, so reaching this line means it passed.
         @crawl_enqueued += 1
         @frontier << Task.new(TaskKind::Crawl, Url.normalize(@seed_parts), 0, Source::Seed)
         root = Url.origin(@seed_parts)
-        @frontier << Task.new(TaskKind::Fetch, "#{root}/robots.txt", 0, Source::Robots)
-        @frontier << Task.new(TaskKind::Fetch, "#{root}/sitemap.xml", 0, Source::Sitemap)
+        enqueue_well_known("#{root}/robots.txt", Source::Robots)
+        enqueue_well_known("#{root}/sitemap.xml", Source::Sitemap)
       end
       bf_dir = Url.dir_of(@seed_parts)
       enqueue_dir(bf_dir, 0) if @config.bruteforce?
@@ -339,19 +360,40 @@ module Gori::Discover
       # path-scoped run confined elsewhere.
       if @config.spider? && @config.bruteforce?
         root_dir = "#{Url.origin(@seed_parts)}/"
+        # @seed_calibration_dir is set even when the Calibrate task below is refused, and that
+        # is deliberate: it is what routes a robots/sitemap outcome to resolve_seed_finding
+        # rather than record_page. With no baseline those outcomes park and are never counted
+        # ("no baseline, no claim", see resolve_seed_finding) — whereas dropping the routing
+        # would send them to record_page, which is exactly the raw-status trust that reports a
+        # wildcard-200 server's robots.txt as a finding. Fail safe, not fail loud.
         @seed_calibration_dir = root_dir
         enqueue_seed_only_calibration(root_dir) unless root_dir == bf_dir
       end
     end
 
+    # robots.txt / sitemap.xml are DERIVED, not typed: nothing but the run itself asked for
+    # them, and they are anchored on the origin, so on a path-confined run they sit outside
+    # the subtree by construction. They keep waiving Layer 1, containment and the path confine
+    # for the calibration reason above — but not Layer 2, same as the seed (DESIGN.md §7,
+    # #364). A blocked one is skipped silently rather than failing the run: unlike the seed,
+    # the crawl is still meaningful without it.
+    private def enqueue_well_known(url : String, source : Source) : Nil
+      # `url` is built from Url.origin(@seed_parts), so its host IS the seed's host.
+      return unless @scope.allowed?(url, @seed_parts.host)
+      @frontier << Task.new(TaskKind::Fetch, url, 0, source)
+    end
+
     # A Calibrate task queued ONLY to gate robots.txt/sitemap.xml (see seed_frontier) — unlike
     # enqueue_dir it never feeds enqueue_probes, so it can't brute-force the wordlist onto the
-    # origin on a run confined to a deeper subtree. Bypasses bounded_url/scope the same way the
-    # robots/sitemap Fetch tasks themselves already do (well-known paths are always checked at
-    # the origin, confine/scope notwithstanding).
+    # origin on a run confined to a deeper subtree. Bypasses the path confine and the
+    # containment mode the same way the robots/sitemap Fetch tasks do (well-known paths are
+    # always checked at the origin) — but not Layer 2: its bogus probes are real requests, and
+    # `calibrate_probes + extensions.size` of them made this the largest single part of the
+    # seed's formerly ungated blast radius (#364).
     private def enqueue_seed_only_calibration(dir : String) : Nil
       return if @dirs.includes?(dir)
       return unless Url.parse(dir)
+      return unless @scope.allowed?(dir, @seed_parts.host)
       @dirs << dir
       @frontier << Task.new(TaskKind::Calibrate, dir, 0, Source::Bruteforced, dir: dir, seed_only: true)
     end


### PR DESCRIPTION
Closes #364.

## The decision

The issue asked for a product decision before a patch, so here is the reasoning first.

**The seed is "interactive" for Layer 1, and stays ungated there.** That is not a new judgement
call — it is the one the codebase already made. `Outbound.interactive` exists precisely because
"the operator typed this target" answers the include question, and each discover surface has
already applied its own Layer-1 verdict before the engine runs (`Outbound.agent` refuses an
out-of-scope seed, `Outbound.cli` refuses one on a configured project, `.interactive` waives by
name). Re-asking the include question inside the engine would only re-ask what the surface just
answered.

**But Layer 2 was never part of that bargain, and all four requests now pass it.** Sandbox's
promise in DESIGN.md §3 — "a request to a host that is not allowlisted is blocked outright" —
carries no "unless the operator typed it" clause. `Outbound.interactive`'s own doc comment says
so explicitly: *"the operator typed the target, so there is no up-front gate — but Sandbox still
hard-stops every send."* That promise did not hold for these requests. "The operator chose this
target" was never an argument about Sandbox.

Explicit EXCLUDE rules come along with Sandbox (`sweep_block` semantics, not `send_block`),
because discover is the most automated sweep gori has and every *other* URL in the run is already
judged by that same predicate.

**robots.txt / sitemap.xml keep waiving Layer 1, containment and the path confine.** They are
derived from a seed the operator was already authorised to hit, they live at that origin by
construction, and the calibration reason for reaching outside a path-confined subtree
(`engine.cr` ~340) is sound and unchanged. Path-confinement and the scope gate really are
separate concerns — the fix keeps the former waived and closes the latter.

### Exposure was not uniform, and that is what settles it

A Layer-1 `in_scope` verdict already implies a clean Layer 2 (`Scope#sandbox_blocks?` and
`Outbound#evaluate` both route through `allowlisted_unlocked?`). So for the **seed** the gap only
ever opened where Layer 1 was waived: the TUI and any `--allow-unscoped` run. The three
**derived** requests were exposed on every surface, because they are anchored on `Url.origin` and
a path-scoped include rule never covers them.

### A fourth bypass, larger than the three in the issue

The issue scoped the blast radius at 3 requests. It is 3 + `calibrate_probes + extensions.size`:
`enqueue_seed_only_calibration` fires the origin-root soft-404 calibration, whose bogus probes are
real requests and which bypassed the gate the same way. That is now gated too, on its directory.

## What changed

- `Engine#initialize` refuses the run outright when Layer 2 blocks the seed — a terminal
  `ErrorEvent` (`Engine::SEED_BLOCKED`), no `DoneEvent`. Loud, not a skipped enqueue: a blocked
  seed blocks everything derived from it, so the alternative is a run that ends with zero findings
  and no reason, which reads as "there is nothing there" rather than "gori sent nothing" (P4).
- `enqueue_well_known` gates robots.txt / sitemap.xml. A blocked one is skipped silently — unlike
  the seed, the crawl is still meaningful without it.
- `enqueue_seed_only_calibration` gates the origin-root calibration on its directory.
- DESIGN.md §7 records the decision alongside the #354 entry.

`@seed_calibration_dir` is deliberately still set even when that calibration is refused. Dropping
it was my first draft and it was wrong: without it a robots/sitemap outcome falls back to
`record_page`, whose raw-status trust reports both as findings on a 200-everything server — the
exact false positive the calibration exists to prevent. `spec/discover/engine_spec.cr` pins that.

## Verification

- `just test` — 4273 examples, 0 failures, on the rebased tree.
- `crystal build --no-codegen src/main.cr` after the rebase (CI does not build the merge result).
- `crystal tool format --check` and `ameba` clean on the three touched files (0 new findings;
  the file's 8 pre-existing `%w()` style findings are untouched).
- Every new spec was **control-run against the unfixed engine** and fails there: 3 in
  `engine_spec.cr`, 2 in `plan_spec.cr`, plus the false-positive regression spec run against my
  own bad draft. The `plan_spec` pair drives a real `Gori::Scope` with Sandbox enabled through a
  real TCP listener and asserts on the request heads the origin actually received.

## Deliberately not closed here

Found while reviewing this diff, all **pre-existing on main** and each a separate decision. Filed
rather than folded in, to keep a security-gate change reviewable:

- Brute-force and calibration probes are authorised by their *directory*, not per URL, so a
  `string`/`regex` EXCLUDE matching a child but not its parent does not stop them (~278 requests
  per directory on one waiver).
- `Plan.resolve_policy` hands an unconfigured scope an `OpenScope`, so Layer 2 is absent entirely
  on a project with Sandbox on and no rules.
- A crawled `<a href>` carrying a raw CRLF splices a second, fully attacker-chosen request into
  the request line. `Plan.build` already guards exactly this for the seed via
  `Headers.safe_value?`; the guard was never applied to crawled links.
- A single-segment seed with no trailing slash (`http://t/api`) sets `@seed_calibration_dir`
  while the path confine refuses the matching Calibrate task, so robots/sitemap are fetched and
  their outcomes are never recorded.
