### PR TITLE
fix(discover): request splicing via crawled links, per-URL probe authorisation, fail-open scope, lost well-known findings (#390-#393)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -517,9 +517,9 @@ Three specifics worth recording:
 
 What this does **not** close, deliberately, because each is a separate decision: brute-force and
 calibration probes are still authorised by their *directory* rather than per URL, so a `string`
-or `regex` EXCLUDE that matches a child but not its parent does not stop them (closed by #391,
-below); and `Plan.resolve_policy` still hands an unconfigured scope an `OpenScope`, so Layer 2 is
-absent entirely on a project with Sandbox on and no rules.
+or `regex` EXCLUDE that matches a child but not its parent does not stop them; and
+`Plan.resolve_policy` still hands an unconfigured scope an `OpenScope`, so Layer 2 is absent
+entirely on a project with Sandbox on and no rules. Both are closed by the two entries below.
 
 ### 2026-07-26: a directory verdict does not authorise the URLs under it
 
@@ -562,6 +562,31 @@ The fix splits by layer rather than by call site, because the two layers have di
   mean a narrow anchored include silently disables brute-force under a directory that include
   itself admitted. Layer 2 is the layer that is identical everywhere, and it is the one that now
   bites every send.
+
+### 2026-07-26: a rule-less scope is not an absent one
+
+Refines: [§3](#s3). Issue #392.
+
+`Plan.resolve_policy` returned `OpenScope` for `scope.nil? || verdict.unscoped?`, and
+`unscoped?` is true exactly when `Scope#configured?` is false — that is, whenever the project's
+scope has no *rules*. `OpenScope#allowed?` is unconditionally true, so Layer 2 was absent for the
+entire run.
+
+Sandbox is enabled independently of rules (`Scope#enable_sandbox` takes none into account), and
+with no include rules `sandbox_blocks?` blocks everything, which [§3](#s3) states is deliberate.
+So on a project with Sandbox on and no rules the proxy blocked every request and every other
+automated sweep refused — `Outbound#sweep_block` skips only on a **nil** scope, never on a
+rule-less one — while `gori run discover` and the TUI Discover tab crawled and brute-forced
+completely unrestricted. Discover was the sole fail-**open** tool, in the one configuration §3
+singles out as fail-closed.
+
+The fix separates the two questions the old condition conflated. `scope.nil?` — genuinely no
+project — keeps `OpenScope`, because there is nothing to consult. A rule-less scope now gets
+`StoreScope` like any other. This changes containment not at all: `StoreScope#configured?`
+delegates to `Scope#configured?`, still false, so scope-aware containment keeps falling back to
+same-origin and `boundary?` is never consulted. The only difference is that `allowed?` starts
+consulting Sandbox and EXCLUDE, and on an ordinary rule-less project with Sandbox off both are
+false — so those runs are byte-for-byte unaffected.
 
 ---
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -517,9 +517,51 @@ Three specifics worth recording:
 
 What this does **not** close, deliberately, because each is a separate decision: brute-force and
 calibration probes are still authorised by their *directory* rather than per URL, so a `string`
-or `regex` EXCLUDE that matches a child but not its parent does not stop them; and
-`Plan.resolve_policy` still hands an unconfigured scope an `OpenScope`, so Layer 2 is absent
-entirely on a project with Sandbox on and no rules.
+or `regex` EXCLUDE that matches a child but not its parent does not stop them (closed by #391,
+below); and `Plan.resolve_policy` still hands an unconfigured scope an `OpenScope`, so Layer 2 is
+absent entirely on a project with Sandbox on and no rules.
+
+### 2026-07-26: a directory verdict does not authorise the URLs under it
+
+Refines: [§3](#s3). Issue #391, the remaining half of the #364 review.
+
+`enqueue_probes` was the only `@frontier <<` site with no gate: it built `Url.parse("#{bl.dir}#{cand}")`
+and pushed a Probe straight onto the frontier, and `process_calibrate` sent `"#{dir}#{bogus_name}"`
+`calibrate_probes + extensions.size` times the same way. With the defaults that is **~278 real
+requests per calibrated directory on one `allowed?` answer about the directory**.
+
+The reason a directory verdict cannot stand in for its children is that only some rule kinds are
+monotone under a path append. `host` rules and `string` INCLUDEs are; `string` and `regex`
+EXCLUDEs are not, and neither are the `regex` INCLUDEs Sandbox reads as its allowlist — any
+`$`-anchored or length-bounded pattern matches a directory and refuses everything beneath it. So
+an EXCLUDE on `logout` / `signout` / `shutdown`, the canonical "do not touch destructive
+endpoints" rule, was silently ignored by the brute-forcer even though `logout` ships on line 41
+of the built-in wordlist, alongside `admin`, `actuator/env`, `.git/config` and `.env`.
+
+The path confine was escapable by the same append: `Url.parse` collapses dot-segments, so a
+wordlist entry of `../admin` under an `/app/`-confined run re-parsed to `/admin`, and
+`@confine_path` lived only inside `bounded_url`, which probes never reached.
+
+The fix splits by layer rather than by call site, because the two layers have different contracts:
+
+- **Layer 2 moves to `send_with_retries`,** the single funnel all three send sites pass through.
+  Calibration probes are built by a *worker* at send time from a random bogus name, so no
+  enqueue-time gate can see them at all; this is the only line that can judge them. Brute-force
+  candidates are additionally gated in `enqueue_probes`, which keeps a refused one out of the
+  frontier and out of `per_dir_cap` instead of spending both on a send that will be refused.
+  A refusal returns a benign `Engine::SCOPE_REFUSED` Result in the shape `CappedBackend` already
+  uses for the request cap, and is **not** counted as an error: it is a decision the operator
+  asked for, not a failure of the run.
+- **The path confine moves to `enqueue_probes` only,** via the `confined?` predicate now shared
+  with `bounded_url`. It deliberately does *not* go on the send chokepoint: the origin-root
+  calibration and the two well-known paths waive the confine on purpose (previous entry), and
+  gating there would refuse them on every path-scoped run.
+- **Layer 1 (`containment` / `boundary?`) is deliberately NOT re-asked per probe.** It was
+  answered for the directory, which is what the crawl actually reached, and [§3](#s3) makes
+  Layer 1 the layer whose strictness legitimately varies per surface. Re-asking it would also
+  mean a narrow anchored include silently disables brute-force under a directory that include
+  itself admitted. Layer 2 is the layer that is identical everywhere, and it is the one that now
+  bites every send.
 
 ---
 

--- a/spec/discover/engine_spec.cr
+++ b/spec/discover/engine_spec.cr
@@ -496,4 +496,49 @@ describe Gori::Discover::Engine do
       findings.map(&.url).should_not contain("http://t/admin")
     end
   end
+
+  # Issue #393. `enqueue_seed_only_calibration` used to be skipped whenever the origin root WAS
+  # the seed's own brute-force directory, on the assumption that `enqueue_dir` had already
+  # queued a Calibrate for it. But `enqueue_dir` goes through `bounded_url`, which applies the
+  # path confine — and the confine refuses the origin root on a single-segment seed with no
+  # trailing slash. So no baseline ever arrived, and robots.txt/sitemap.xml were fetched for
+  # real and then parked forever.
+  describe "the origin calibration that grades robots.txt/sitemap.xml" do
+    # Every seed shape from the issue's table, including the three that already worked — the
+    # bug was one shape out of four, so pinning only the broken one would not show that the fix
+    # left the others alone.
+    {"http://t/api", "http://t/api/", "http://t/", "http://t/a/b"}.each do |seed|
+      it "records both well-known findings for a seed of #{seed}" do
+        cfg = D::Config.new(spider: true, bruteforce: true, calibrate_probes: 2, concurrency: 2,
+          retries: 0)
+        fetched = [] of String
+        findings, _ = run_discover(seed, [] of String, cfg) do |t|
+          fetched << t
+          case t
+          when "/robots.txt"  then make(200, "User-agent: *\nDisallow: /admin\n", "text/plain")
+          when "/sitemap.xml" then make(200, %(<?xml version="1.0"?><urlset><url><loc>http://t/x</loc></url></urlset>), "application/xml")
+          else                     notfound
+          end
+        end
+        # Both were always SENT; what the bug lost was the recording of their outcomes.
+        fetched.count("/robots.txt").should eq(1)
+        fetched.count("/sitemap.xml").should eq(1)
+        urls = findings.map(&.url)
+        urls.should contain("http://t/robots.txt")
+        urls.should contain("http://t/sitemap.xml")
+      end
+    end
+
+    it "still brute-forces the origin when it IS the seed's own directory" do
+      # The regression guard for dropping the `unless root_dir == bf_dir` short-circuit: a
+      # seed_only Calibrate never feeds enqueue_probes, so if it displaced the ordinary one
+      # instead of deduping against it, brute-force would go silently dead at the origin.
+      cfg = D::Config.new(spider: true, bruteforce: true, calibrate_probes: 2, concurrency: 1,
+        retries: 0, confidence_floor: 0.4)
+      findings, _ = run_discover("http://t/", ["admin"], cfg) do |t|
+        t == "/admin" ? html("ADMIN CONTROL PANEL") : notfound
+      end
+      findings.select(&.source.bruteforced?).map(&.url).should contain("http://t/admin")
+    end
+  end
 end

--- a/spec/discover/engine_spec.cr
+++ b/spec/discover/engine_spec.cr
@@ -368,4 +368,48 @@ describe Gori::Discover::Engine do
       findings.select { |f| f.source.robots? || f.source.sitemap? }.should be_empty
     end
   end
+
+  # Issue #390. `Extract::ATTR`'s `[^"]` matches CR and LF, `Url.resolve` strips only the ends,
+  # and `URI.parse` keeps an interior CR/LF verbatim in host, path AND query — so a crawled
+  # `<a href>` reached `Sender#build_get` intact and spliced a second, fully attacker-chosen
+  # request onto the connection. The byte-level proof lives in sender_spec; this pins the
+  # engine half: such a link is dropped before it is ever queued.
+  describe "a crawled link carrying a raw CRLF" do
+    it "is dropped silently and never reaches the backend" do
+      cfg = D::Config.new(spider: true, bruteforce: false, max_depth: 4, concurrency: 1, retries: 0)
+      poison = "/p\r\nX-Injected: 1\r\n\r\nGET http://evil.test/pwned HTTP/1.1\r\nHost: evil.test\r\n\r\n"
+      sent = [] of String
+      findings, _ = run_discover("http://t/", [] of String, cfg) do |t|
+        sent << t
+        case t
+        when "/"      then html(%(<a href="#{poison}">poison</a> <a href="/clean">ok</a>))
+        when "/clean" then html("an ordinary sibling link on the same page")
+        else               notfound
+        end
+      end
+      # The control: the page WAS crawled and its links WERE extracted, so "nothing poisoned
+      # went out" is a verdict about the guard and not about a crawl that never happened.
+      findings.map(&.url).should contain("http://t/clean")
+      sent.should contain("/clean")
+
+      sent.none?(&.includes?('\r')).should be_true
+      sent.none?(&.includes?('\n')).should be_true
+      sent.none?(&.includes?("evil.test")).should be_true
+      findings.map(&.url).none?(&.includes?("evil.test")).should be_true
+    end
+
+    it "is dropped when the CRLF sits in the QUERY rather than the path" do
+      # `URI.parse("http://t/a?q=1\r\nX: 1").query` keeps the CR/LF, and send_with_retries
+      # rebuilds the target as "#{path}?#{query}" — so a path-only check would miss this.
+      cfg = D::Config.new(spider: true, bruteforce: false, max_depth: 4, concurrency: 1, retries: 0)
+      sent = [] of String
+      run_discover("http://t/", [] of String, cfg) do |t|
+        sent << t
+        t == "/" ? html(%(<a href="/ok?q=1\r\nX-Injected: 1">q</a> <a href="/clean">ok</a>)) : notfound
+      end
+      sent.should contain("/clean")
+      sent.should_not contain("/ok?q=1")
+      sent.none? { |t| t.includes?('\r') || t.includes?('\n') }.should be_true
+    end
+  end
 end

--- a/spec/discover/engine_spec.cr
+++ b/spec/discover/engine_spec.cr
@@ -82,6 +82,27 @@ private class AllowExact < D::ScopePolicy
   end
 end
 
+# Allows a URL the first time it is asked and denies it afterwards — the shape a live scope
+# takes when the operator adds an EXCLUDE mid-run (the TUI shares the Scope object with the
+# engine's policy). Every Crawl/Fetch URL is asked once at enqueue and once at send.
+private class DenyAfterFirstAsk < D::ScopePolicy
+  def initialize
+    @asked = Set(String).new
+  end
+
+  def allowed?(url : String, host : String) : Bool
+    @asked.add?(url)
+  end
+
+  def boundary?(url : String, host : String) : Bool
+    true
+  end
+
+  def configured? : Bool
+    false
+  end
+end
+
 # The bogus soft-404 probes an origin-root calibration sends: one path segment directly under
 # "/", minus the two well-known paths seed_frontier queues by name. A path-scoped run's own
 # brute-force probes are deeper (/app/…), so they never land in here.
@@ -540,5 +561,91 @@ describe Gori::Discover::Engine do
       end
       findings.select(&.source.bruteforced?).map(&.url).should contain("http://t/admin")
     end
+  end
+
+  # Review findings on the four fixes above.
+  describe "the Layer-2 gate string" do
+    it "asks the scope in the port-less form every other consumer uses" do
+      # `Url.normalize` appends `:port` off the defaults, but gori's scope model has no port
+      # dimension: `Scope.request_url` is "scheme://host/target" and the proxy splits the port
+      # off before asking. So on :8080 discover asked about "http://t:8080/logout" while a rule
+      # was written against "http://t/logout", and a host-qualified string/regex EXCLUDE — the
+      # exact rule #391 is about — silently failed open.
+      cfg = D::Config.new(spider: false, bruteforce: true, calibrate_probes: 2, concurrency: 1,
+        retries: 0, confidence_floor: 0.4)
+      sent = [] of String
+      run_discover("http://t:8080/", ["logout", "admin"], cfg,
+        DenyExact.new(Set{"http://t/logout"})) do |t|
+        sent << t
+        notfound
+      end
+      sent.should_not contain("/logout")
+      sent.should contain("/admin") # control: the sibling probe on the same port still goes out
+    end
+
+    it "keeps the port on the crawled url and the finding" do
+      # Only the gate question drops the port — the resource's own identity keeps it.
+      cfg = D::Config.new(spider: true, bruteforce: false, concurrency: 1, retries: 0)
+      findings, _ = run_discover("http://t:8080/", [] of String, cfg) do |t|
+        t == "/" ? html(%(<a href="/kept">k</a>)) : html("an ordinary page body here")
+      end
+      findings.map(&.url).should contain("http://t:8080/kept")
+    end
+  end
+
+  describe "the error count" do
+    it "does not count the max-requests cap as an error on the crawl path" do
+      # handle_probe already excluded CAP_ERROR; handle_crawl excluded nothing. With
+      # max_requests set the orchestrator fills the @jobs buffer before any worker increments
+      # @capped.sent, so every over-dispatched crawl came back CAP_ERROR and was counted —
+      # `--max-requests 5` at default concurrency reported dozens of "errors" that were the
+      # cap working as designed.
+      # The frontier must hold more jobs than the cap at the moment of dispatch: `@jobs` is
+      # buffered to `concurrency`, so the orchestrator pushes all three seed tasks (the seed
+      # crawl + robots.txt + sitemap.xml) before any worker increments `@capped.sent`. The
+      # third then comes back CAP_ERROR.
+      cfg = D::Config.new(spider: true, bruteforce: false, max_requests: 2_i64,
+        concurrency: 8, retries: 0)
+      backend = RouteBackend.new(->(_t : String) { html("an ordinary page body here") })
+      engine = D::Engine.new("http://t/", [] of String, backend, cfg)
+      errors = 0_i64
+      sent = 0_i64
+      engine.run do |ev|
+        if ev.is_a?(D::DoneEvent)
+          errors = ev.progress.errors
+          sent = ev.progress.sent
+        end
+      end
+      sent.should eq(2)
+      errors.should eq(0)
+    end
+
+    it "does not count a Layer-2 refusal as an error on the crawl path" do
+      # Every Crawl/Fetch URL is asked twice — once at enqueue, once at send. In the TUI the
+      # Scope object is shared live, so an EXCLUDE added mid-run turns queued crawls into
+      # refusals at send; those are decisions the operator asked for, not failures.
+      cfg = D::Config.new(spider: true, bruteforce: false, concurrency: 1, retries: 0)
+      backend = RouteBackend.new(->(_t : String) { notfound })
+      engine = D::Engine.new("http://t/", [] of String, backend, cfg, DenyAfterFirstAsk.new)
+      errors = 0_i64
+      engine.run { |ev| errors = ev.progress.errors if ev.is_a?(D::DoneEvent) }
+      errors.should eq(0)
+    end
+  end
+
+  it "refuses a probe candidate carrying an interior CR from a hostile wordlist" do
+    # Wordlist.load strips only the ends of a line, so an interior lone CR survives into
+    # `bl.dir + cand`. The wire seam would catch it, but only after the candidate had been
+    # enqueued, retried and counted as an error — bounded_url refuses its equivalent, so the
+    # probe gate does too.
+    cfg = D::Config.new(spider: false, bruteforce: true, calibrate_probes: 1, concurrency: 1,
+      retries: 0)
+    sent = [] of String
+    run_discover("http://t/", ["ad\rmin", "clean"], cfg) do |t|
+      sent << t
+      notfound
+    end
+    sent.should contain("/clean")
+    sent.none?(&.includes?('\r')).should be_true
   end
 end

--- a/spec/discover/engine_spec.cr
+++ b/spec/discover/engine_spec.cr
@@ -62,6 +62,26 @@ private class DenyExact < D::ScopePolicy
   end
 end
 
+# A ScopePolicy that allows ONLY an exact URL set — the shape a `regex` include anchored with
+# `$` takes under Sandbox, and the one the issue-#391 table calls non-monotone: a directory can
+# be allowlisted while every child under it is not.
+private class AllowExact < D::ScopePolicy
+  def initialize(@allow : Set(String))
+  end
+
+  def allowed?(url : String, host : String) : Bool
+    @allow.includes?(url)
+  end
+
+  def boundary?(url : String, host : String) : Bool
+    true
+  end
+
+  def configured? : Bool
+    false
+  end
+end
+
 # The bogus soft-404 probes an origin-root calibration sends: one path segment directly under
 # "/", minus the two well-known paths seed_frontier queues by name. A path-scoped run's own
 # brute-force probes are deeper (/app/…), so they never land in here.
@@ -410,6 +430,70 @@ describe Gori::Discover::Engine do
       sent.should contain("/clean")
       sent.should_not contain("/ok?q=1")
       sent.none? { |t| t.includes?('\r') || t.includes?('\n') }.should be_true
+    end
+  end
+
+  # Issue #391 / DESIGN.md §7. Brute-force and calibration probes were authorised by their
+  # DIRECTORY: one `allowed?` answer about the dir stood in for ~278 real requests under it,
+  # and the path confine never applied to them at all.
+  describe "probes are authorised per URL, not by their directory" do
+    it "skips a wordlist entry an EXCLUDE denies while its directory is allowed" do
+      # The issue's repro. `logout` is line 41 of the built-in wordlist, and an exclude on it
+      # is the canonical "do not touch destructive endpoints" rule — silently ignored, because
+      # the only question ever asked was about "http://t/".
+      cfg = D::Config.new(spider: false, bruteforce: true, calibrate_probes: 2, concurrency: 1,
+        retries: 0, confidence_floor: 0.4)
+      sent = [] of String
+      findings, _ = run_discover("http://t/", ["logout", "admin"], cfg,
+        DenyExact.new(Set{"http://t/logout"})) do |t|
+        sent << t
+        t == "/logout" || t == "/admin" ? html("A REAL PAGE THAT WOULD BE REPORTED") : notfound
+      end
+      sent.should_not contain("/logout")
+      # The control: the sibling probe under the very same directory DID go out, so this is a
+      # verdict about the gate and not about a brute-forcer that never ran.
+      sent.should contain("/admin")
+      findings.map(&.url).should contain("http://t/admin")
+      findings.map(&.url).should_not contain("http://t/logout")
+    end
+
+    it "skips the calibration probes when the scope allows the directory but not its children" do
+      # process_calibrate builds "#{dir}#{bogus_name}" inside a WORKER at send time, so these
+      # are the sends no enqueue-time gate can ever see — only the send chokepoint can.
+      cfg = D::Config.new(spider: false, bruteforce: true, calibrate_probes: 3, concurrency: 1,
+        retries: 0)
+      gated = [] of String
+      backend = RouteBackend.new(->(t : String) { gated << t; notfound })
+      engine = D::Engine.new("http://t/", ["admin"], backend, cfg, AllowExact.new(Set{"http://t/"}))
+      errors = 0_i64
+      engine.run { |ev| errors = ev.progress.errors if ev.is_a?(D::DoneEvent) }
+      gated.should be_empty
+      # A refusal is a decision the operator asked for, not a failure — it must not inflate
+      # the error count every surface renders.
+      errors.should eq(0)
+
+      open = [] of String
+      run_discover("http://t/", ["admin"], cfg) do |t|
+        open << t
+        notfound
+      end
+      open.size.should eq(4) # control: 3 calibration probes + the one wordlist entry
+    end
+
+    it "keeps a traversal wordlist entry inside the seed's path confine" do
+      # `bl.dir + cand` is re-parsed by Url.parse, whose normalize_path collapses "..", so
+      # `../admin` under an /app/-confined run resolved to /admin. @confine_path lived only
+      # inside bounded_url, which probes never reached.
+      cfg = D::Config.new(spider: false, bruteforce: true, calibrate_probes: 2, concurrency: 1,
+        retries: 0, confidence_floor: 0.4)
+      sent = [] of String
+      findings, _ = run_discover("http://t/app/", ["../admin", "inner"], cfg) do |t|
+        sent << t
+        t == "/admin" || t == "/app/inner" ? html("A REAL PAGE THAT WOULD BE REPORTED") : notfound
+      end
+      sent.should_not contain("/admin")
+      sent.should contain("/app/inner") # control: an ordinary entry in the same list still probes
+      findings.map(&.url).should_not contain("http://t/admin")
     end
   end
 end

--- a/spec/discover/plan_spec.cr
+++ b/spec/discover/plan_spec.cr
@@ -181,14 +181,44 @@ describe Gori::Discover::Plan do
   describe "the crawl-time scope policy is derived from the Outbound" do
     seed = "https://acme.test/api"
 
-    it "bounds nothing when the project has no scope rules, on every surface" do
+    it "bounds nothing but still consults Layer 2 when the project has no scope rules" do
+      # Issue #392: a rule-LESS scope is not an ABSENT one. It used to get OpenScope, whose
+      # allowed? is unconditionally true, so Layer 2 was missing for the whole run.
       with_store do |store|
         scope = Gori::Scope.load(store)
         [Gori::Outbound.agent(scope, false), Gori::Outbound.cli(scope, false),
          Gori::Outbound.interactive(scope)].each do |ob|
-          D::Plan.build(D::PlanOptions.new(seed), ob).policy.class.should eq(D::OpenScope)
+          policy = D::Plan.build(D::PlanOptions.new(seed), ob).policy
+          policy.class.should eq(D::StoreScope)
+          # Containment is unchanged: configured? is still false, so scope-aware containment
+          # keeps falling back to same-origin and boundary? is never consulted.
+          policy.configured?.should be_false
+          # And with Sandbox off, an ordinary rule-less run is bounded exactly as before.
+          policy.allowed?(seed, "acme.test").should be_true
         end
       end
+    end
+
+    it "fails CLOSED for discover when Sandbox is on and the project has no rules" do
+      # Sandbox is enabled independently of rules, and §3 makes a scope with no include rules
+      # block everything on purpose. Every other sweep already refused here (`sweep_block`
+      # skips only on a NIL scope) and the proxy blocked every request, while discover crawled
+      # and brute-forced unrestricted — fail-open in the one configuration §3 calls fail-closed.
+      with_store do |store|
+        scope = Gori::Scope.load(store)
+        scope.enable_sandbox
+        [Gori::Outbound.agent(scope, false), Gori::Outbound.cli(scope, false),
+         Gori::Outbound.interactive(scope)].each do |ob|
+          D::Plan.build(D::PlanOptions.new(seed), ob).policy
+            .allowed?(seed, "acme.test").should be_false
+        end
+      end
+    end
+
+    it "keeps OpenScope when there is genuinely no project" do
+      # `scope.nil?` is a different question from "the scope has no rules", and only the
+      # former means there is nothing to consult.
+      D::Plan.build(D::PlanOptions.new(seed), ungated_outbound).policy.class.should eq(D::OpenScope)
     end
 
     it "applies the project scope when one is configured and Layer 1 was not waived by the operator" do

--- a/spec/discover/sender_spec.cr
+++ b/spec/discover/sender_spec.cr
@@ -1,0 +1,102 @@
+require "../spec_helper"
+
+private alias D = Gori::Discover
+
+# The bytes ONE `Discover::Sender#fetch` actually puts on a TCP connection.
+#
+# A spec that only inspected the URL string could not have caught #390: every layer between
+# the `<a href>` and the socket preserves a raw CR/LF happily (the extractor's `[^"]` matches
+# both, `Url.resolve` strips only the ends, `URI.parse` validates nothing), so the poisoning
+# is invisible until the request line is assembled. This reads the wire instead.
+#
+# Yields the listening port and returns the raw bytes the server received — or "" when the
+# sender never connected at all, told apart by a timeout rather than by blocking on `accept?`.
+private def wire_bytes(&) : String
+  server = TCPServer.new("127.0.0.1", 0)
+  seen = Channel(String).new(1)
+  spawn do
+    if conn = server.accept?
+      slice = Bytes.new(8192)
+      n = 0
+      begin
+        # One read, then stop: the sender is waiting on a response, so reading to EOF here
+        # would deadlock. A splice arrives in the SAME write as the request it rides on
+        # (`build_get` emits a single slice), so one read sees all of it.
+        conn.read_timeout = 500.milliseconds
+        n = conn.read(slice)
+      rescue IO::TimeoutError
+      end
+      seen.send(String.new(slice[0, n]))
+      begin
+        conn << "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nhi"
+        conn.flush
+      rescue
+      end
+      conn.close rescue nil
+    end
+  rescue
+  end
+
+  yield server.local_address.port
+  bytes =
+    select
+    when got = seen.receive
+      got
+    when timeout(2.seconds)
+      "" # never dialled
+    end
+  server.close rescue nil
+  bytes
+end
+
+# Request lines on the wire: "<METHOD> <target> HTTP/1.1". The whole point of #390 is that
+# there can be more than one, so this counts them rather than parsing the first.
+private def request_lines(wire : String) : Array(String)
+  wire.split("\r\n").select(&.matches?(/\A[A-Z]+ \S+ HTTP\/\d(?:\.\d)?\z/))
+end
+
+describe Gori::Discover::Sender do
+  # The control. Without it every assertion below would pass just as happily against a
+  # harness that never observes the socket at all.
+  it "puts exactly one request on the wire for an ordinary target" do
+    wire = wire_bytes do |port|
+      D::Sender.new(verify: false, timeout: 2.seconds).fetch("http", "127.0.0.1", port, "/a?b=1")
+    end
+    request_lines(wire).should eq(["GET /a?b=1 HTTP/1.1"])
+    wire.should match(/\AGET \/a\?b=1 HTTP\/1\.1\r\nHost: 127\.0\.0\.1:\d+\r\n/)
+  end
+
+  it "sends nothing at all when the target carries a raw CRLF (request splicing)" do
+    # The exact shape #390 captured off a real socket: the second request is complete and
+    # entirely attacker-chosen — method, absolute-form request line, and Host. With
+    # `Settings.upstream_proxy_addr` set, that absolute-form line is routed by the upstream
+    # proxy to a genuinely different host.
+    poisoned = "/a\r\nX-Injected: 1\r\n\r\nGET http://evil.test/pwned HTTP/1.1\r\nHost: evil.test\r\n\r\n"
+    result = nil.as(Gori::Repeater::Result?)
+    wire = wire_bytes do |port|
+      result = D::Sender.new(verify: false, timeout: 2.seconds).fetch("http", "127.0.0.1", port, poisoned)
+    end
+    # Named explicitly: with the guard removed, the splice is what survives on the wire — the
+    # ORIGINAL request line is destroyed ("GET /a" loses its version) and the attacker's is
+    # the one the server parses.
+    request_lines(wire).should_not contain("GET http://evil.test/pwned HTTP/1.1")
+    request_lines(wire).size.should eq(0)
+    wire.should eq("")
+    result.not_nil!.error.should eq(D::Sender::UNSAFE_URL)
+  end
+
+  it "sends nothing when the HOST carries a raw CRLF" do
+    # `URI.parse("http://ev\r\nil.test/a").host` is `"ev\r\nil.test"` verbatim, and the host is
+    # spliced into the `Host` header — so checking only the target would leave this open.
+    # Such a host does not resolve, so today the dial fails first; it becomes wire-reachable
+    # the moment a project hostname override supplies the IP (`Sender@overrides`). Asserting
+    # the refusal rather than the wire keeps the guard pinned either way.
+    result = nil.as(Gori::Repeater::Result?)
+    wire = wire_bytes do |port|
+      result = D::Sender.new(verify: false, timeout: 2.seconds)
+        .fetch("http", "127.0.0.1\r\nX-Injected: 1", port, "/a")
+    end
+    wire.should eq("")
+    result.not_nil!.error.should eq(D::Sender::UNSAFE_URL)
+  end
+end

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -1,5 +1,6 @@
 require "./types"
 require "./url"
+require "./headers"
 require "./fingerprint"
 require "./extract"
 require "./calibrate"
@@ -41,6 +42,15 @@ module Gori::Discover
 
   # Production backend over the Repeater engine (fresh connection per send). GET only.
   class Sender < Backend
+    # A send refused because the URL cannot be framed. `target` and `host` are spliced
+    # verbatim into the request line and the `Host` header by `build_get`, so a raw CR/LF in
+    # either splices a SECOND, fully attacker-chosen request (method, absolute-form request
+    # line, and Host) onto the same connection — and with `Settings.upstream_proxy_addr` set,
+    # an absolute-form line is routed by the upstream proxy to a genuinely different host.
+    # Returned as a benign error Result rather than raised: the caller's contract is one
+    # Result per fetch, and one poisoned link must not end the run.
+    UNSAFE_URL = "url contains a control character"
+
     @header_block : String
 
     def initialize(@verify : Bool, @timeout : Time::Span? = nil, @http2 : Bool = false,
@@ -53,6 +63,13 @@ module Gori::Discover
     end
 
     def fetch(scheme : String, host : String, port : Int32, target : String) : Repeater::Result
+      # The wire seam's own invariant, not a duplicate of the engine's gate: `Engine#bounded_url`
+      # drops a poisoned URL before it is ever queued, but this is the only line every send
+      # provably passes, so the guarantee "a Discover run never puts two request lines on one
+      # connection" is stated where it can actually be enforced (see UNSAFE_URL).
+      unless Headers.safe_value?(target) && Headers.safe_value?(host)
+        return Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, UNSAFE_URL)
+      end
       req = build_get(scheme, host, port, target)
       if @http2
         Repeater::H2Engine.send(req, scheme: scheme, host: host, port: port,
@@ -613,6 +630,17 @@ module Gori::Discover
     # hand it back rather than have the caller rebuild it. Still short-circuits on the path
     # confine before normalizing anything.
     private def bounded_url(p : Url::Parts) : String?
+      # A crawled `<a href>` is the one input here that no gate downstream can make safe: the
+      # extractor's `[^"]` matches CR and LF, `Url.resolve` only strips the ends, and
+      # `URI.parse` keeps an interior CR/LF verbatim — so the href reaches the request line
+      # intact (`Sender::UNSAFE_URL`). Same single rule the seed goes through in
+      # `Discover::Plan`, applied here because this is where a DERIVED url is judged.
+      #
+      # DROPPED SILENTLY, not recorded: a Finding asserts "this endpoint exists", and this URL
+      # is never requested, so there is no status, length, or content type to claim one with —
+      # and `Persist` would then write the poisoned string into the Sitemap as a real flow.
+      # It is refused for the same reason any out-of-bounds link is, and takes the same exit.
+      return nil unless Headers.safe_url?(p)
       if cp = @confine_path
         # Segment-boundary confinement: in-subtree iff the path IS the base or sits under
         # "base/". A bare starts_with?(base) would also admit sibling prefixes (/api-internal

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -157,6 +157,10 @@ module Gori::Discover
     # Setup error for a seed the Layer-2 gate refuses. A constant because it is the one
     # engine error a spec (and a surface) wants to recognize rather than merely display.
     SEED_BLOCKED = "seed blocked by scope (Sandbox or an exclude rule)"
+    # A send the per-URL Layer-2 gate refused, in the shape CappedBackend uses for the request
+    # cap: a benign Result, no network, and NOT counted as an error — a scope refusal is a
+    # decision the operator asked for, not a failure of the run.
+    SCOPE_REFUSED = "blocked by scope (Sandbox or an exclude rule)"
 
     enum State : UInt8
       Running
@@ -470,8 +474,8 @@ module Gori::Discover
     private def handle_probe(oc : Outcome) : Nil
       fetched = oc.fetched
       return unless fetched
-      if fetched.error
-        @errors += 1 unless fetched.error == CappedBackend::CAP_ERROR
+      if err = fetched.error
+        @errors += 1 unless err == CappedBackend::CAP_ERROR || err == SCOPE_REFUSED
         return
       end
       if oc.hit && oc.confidence >= @config.confidence_floor
@@ -613,6 +617,7 @@ module Gori::Discover
           break if cap > 0 && count >= cap
           p = Url.parse("#{bl.dir}#{cand}")
           next unless p
+          next unless probe_allowed?(p)
           key = Url.visit_key(p)
           next if @seen.includes?(key)
           @seen << key
@@ -641,12 +646,7 @@ module Gori::Discover
       # and `Persist` would then write the poisoned string into the Sitemap as a real flow.
       # It is refused for the same reason any out-of-bounds link is, and takes the same exit.
       return nil unless Headers.safe_url?(p)
-      if cp = @confine_path
-        # Segment-boundary confinement: in-subtree iff the path IS the base or sits under
-        # "base/". A bare starts_with?(base) would also admit sibling prefixes (/api-internal
-        # for an /api seed, /prefix-test-evil for /prefix-test) — the scope bypass this guards.
-        return nil unless p.path == cp || p.path.starts_with?("#{cp}/")
-      end
+      return nil unless confined?(p)
       url = Url.normalize(p)
       return nil unless @scope.allowed?(url, p.host) # excludes/sandbox — every mode
       ok = case @config.containment
@@ -655,6 +655,39 @@ module Gori::Discover
            in Containment::ScopeAware        then @scope.configured? ? @scope.boundary?(url, p.host) : same_origin?(p)
            end
       ok ? url : nil
+    end
+
+    # Segment-boundary confinement for a path-scoped run: in-subtree iff the path IS the base
+    # or sits under "base/". A bare starts_with?(base) would also admit sibling prefixes
+    # (/api-internal for an /api seed, /prefix-test-evil for /prefix-test) — the scope bypass
+    # this guards. Shared with `probe_allowed?`, which is the half `bounded_url` never saw.
+    private def confined?(p : Url::Parts) : Bool
+      return true unless cp = @confine_path
+      p.path == cp || p.path.starts_with?("#{cp}/")
+    end
+
+    # A brute-force candidate is `bl.dir` + a wordlist entry, and only the DIRECTORY was ever
+    # authorised — one `allowed?` answer standing in for ~278 real requests with the defaults.
+    # Two things do not survive that append:
+    #
+    #   * The path confine. `Url.parse` collapses dot-segments, so a wordlist entry like
+    #     `../admin` re-parses to a path OUTSIDE the seed's subtree; the confine lived only in
+    #     `bounded_url`, which probes never reached. Traversal entries are common in public
+    #     wordlists.
+    #   * Layer 2. Only `host` rules and `string` INCLUDEs are monotone under a path append —
+    #     `string`/`regex` EXCLUDEs and the `regex` INCLUDEs Sandbox reads as its allowlist are
+    #     not, so a child can be denied while its parent is allowed. An EXCLUDE on `logout` /
+    #     `signout` / `shutdown`, the canonical "do not touch destructive endpoints" rule, was
+    #     silently ignored by the brute-forcer even though `logout` ships in the built-in list.
+    #
+    # Containment / `boundary?` (Layer 1) is deliberately NOT re-asked here: it was answered
+    # for the directory, which is what the crawl actually reached, and Layer 1 is the layer
+    # DESIGN.md §3 says varies by surface. Layer 2 is the one that is identical everywhere.
+    # Gating at enqueue as well as at `send_with_retries` keeps a refused candidate out of the
+    # frontier and out of the per-directory cap entirely, rather than spending both on a send
+    # that will be refused.
+    private def probe_allowed?(p : Url::Parts) : Bool
+      confined?(p) && @scope.allowed?(Url.normalize(p), p.host)
     end
 
     private def same_origin?(p : Url::Parts) : Bool
@@ -749,6 +782,17 @@ module Gori::Discover
     private def send_with_retries(url : String) : Repeater::Result
       p = Url.parse(url)
       return Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, "unparseable url") unless p
+      # Layer 2, per URL, on the ONE line every send passes — the invariant §3 states for it
+      # ("identical on every surface, and applied even when Layer 1 was waived"). Calibration
+      # probes are `#{dir}#{bogus_name}` strings a worker builds at send time, so this is the
+      # only place they can be judged at all; brute-force probes are pre-gated in
+      # `enqueue_probes` and re-checked here, which is what makes a scope edit mid-run bite.
+      # Asked about the NORMALIZED url, so the gate and the crawl can never judge two
+      # different spellings of one target (the `dir + cand` concat is not normalized).
+      norm = Url.normalize(p)
+      unless @scope.allowed?(norm, p.host)
+        return Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, SCOPE_REFUSED)
+      end
       target = p.query ? "#{p.path}?#{p.query}" : p.path
       attempts = 0
       loop do

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -45,10 +45,11 @@ module Gori::Discover
     # A send refused because the URL cannot be framed. `target` and `host` are spliced
     # verbatim into the request line and the `Host` header by `build_get`, so a raw CR/LF in
     # either splices a SECOND, fully attacker-chosen request (method, absolute-form request
-    # line, and Host) onto the same connection — and with `Settings.upstream_proxy_addr` set,
-    # an absolute-form line is routed by the upstream proxy to a genuinely different host.
-    # Returned as a benign error Result rather than raised: the caller's contract is one
-    # Result per fetch, and one poisoned link must not end the run.
+    # line, and Host) onto the same connection. The victim is the ORIGIN gori dialled: an
+    # upstream proxy cannot be made to route the injected absolute-form line elsewhere,
+    # because `Upstream.dial` always CONNECT-tunnels (`proxy/upstream.cr`) rather than
+    # forwarding in absolute form. Returned as a benign error Result rather than raised: the
+    # caller's contract is one Result per fetch, and one poisoned link must not end the run.
     UNSAFE_URL = "url contains a control character"
 
     @header_block : String
@@ -441,8 +442,8 @@ module Gori::Discover
       @pages += 1 if task.kind == TaskKind::Crawl
       fetched = oc.fetched
       return unless fetched
-      if fetched.error
-        @errors += 1
+      if err = fetched.error
+        @errors += 1 unless benign_error?(err)
         return
       end
       if @seed_calibration_dir && (task.source.robots? || task.source.sitemap?)
@@ -450,6 +451,12 @@ module Gori::Discover
       else
         record_page(task, fetched)
       end
+      expand_links(oc, task, fetched)
+    end
+
+    # The link-expansion half of handle_crawl: the page's own links unless its content cluster
+    # has saturated, plus a followed redirect.
+    private def expand_links(oc : Outcome, task : Task, fetched : Calibrate::Fetched) : Nil
       count = @clusters.observe(fetched.simhash, @config.simhash_distance)
       if count > @config.cluster_saturation
         @cluster_suppressed += oc.links.size # a template/listing trap — stop expanding it
@@ -484,7 +491,7 @@ module Gori::Discover
       fetched = oc.fetched
       return unless fetched
       if err = fetched.error
-        @errors += 1 unless err == CappedBackend::CAP_ERROR || err == SCOPE_REFUSED
+        @errors += 1 unless benign_error?(err)
         return
       end
       if oc.hit && oc.confidence >= @config.confidence_floor
@@ -501,6 +508,18 @@ module Gori::Discover
 
     # Record a crawled/declared page as a finding (skip 404/5xx noise; 401/403 are kept —
     # they exist but gate access).
+    # A non-error "error": the engine's own budget or gate declining a send, not a failure
+    # reaching the target. Neither is a fault the operator can act on, and both are decisions
+    # they configured, so neither belongs in the error count every surface renders.
+    #
+    # `handle_probe` already excluded CAP_ERROR; `handle_crawl` excluded nothing, and with
+    # max_requests set the orchestrator fills the @jobs buffer before any worker increments
+    # @capped.sent — so `--max-requests 5` at the default concurrency reported dozens of
+    # "errors" that were the cap working exactly as designed.
+    private def benign_error?(err : String) : Bool
+      err == CappedBackend::CAP_ERROR || err == SCOPE_REFUSED
+    end
+
     private def record_page(task : Task, fetched : Calibrate::Fetched) : Nil
       s = fetched.status
       return unless s && (s < 400 || s == 401 || s == 403)
@@ -626,9 +645,11 @@ module Gori::Discover
           break if cap > 0 && count >= cap
           p = Url.parse("#{bl.dir}#{cand}")
           next unless p
-          next unless probe_allowed?(p)
+          # @seen first: it is a hash lookup, while probe_allowed? walks every scope rule
+          # under a mutex with PCRE2. Same verdict either way — this runs 275 words × dirs.
           key = Url.visit_key(p)
           next if @seen.includes?(key)
+          next unless probe_allowed?(p)
           @seen << key
           count += 1
           @frontier << Task.new(TaskKind::Probe, Url.normalize(p), task.depth,
@@ -657,11 +678,12 @@ module Gori::Discover
       return nil unless Headers.safe_url?(p)
       return nil unless confined?(p)
       url = Url.normalize(p)
-      return nil unless @scope.allowed?(url, p.host) # excludes/sandbox — every mode
+      gate = Url.gate_url(p)                          # port-less, matching every other Layer-2 consumer (see gate_url)
+      return nil unless @scope.allowed?(gate, p.host) # excludes/sandbox — every mode
       ok = case @config.containment
            in Containment::SameOrigin        then same_origin?(p)
            in Containment::HostAndSubdomains then same_or_subdomain?(p)
-           in Containment::ScopeAware        then @scope.configured? ? @scope.boundary?(url, p.host) : same_origin?(p)
+           in Containment::ScopeAware        then @scope.configured? ? @scope.boundary?(gate, p.host) : same_origin?(p)
            end
       ok ? url : nil
     end
@@ -695,8 +717,13 @@ module Gori::Discover
     # Gating at enqueue as well as at `send_with_retries` keeps a refused candidate out of the
     # frontier and out of the per-directory cap entirely, rather than spending both on a send
     # that will be refused.
+    #
+    # `safe_url?` is here for symmetry with `bounded_url`: a hostile wordlist can carry an
+    # interior lone CR (`Wordlist.load` strips only the ends of a line). The wire seam would
+    # catch it, but only after the candidate had been enqueued, retried `retries + 1` times
+    # and counted as an error — so refuse it at the same place every other derived URL is.
     private def probe_allowed?(p : Url::Parts) : Bool
-      confined?(p) && @scope.allowed?(Url.normalize(p), p.host)
+      Headers.safe_url?(p) && confined?(p) && @scope.allowed?(Url.gate_url(p), p.host)
     end
 
     private def same_origin?(p : Url::Parts) : Bool
@@ -795,11 +822,13 @@ module Gori::Discover
       # ("identical on every surface, and applied even when Layer 1 was waived"). Calibration
       # probes are `#{dir}#{bogus_name}` strings a worker builds at send time, so this is the
       # only place they can be judged at all; brute-force probes are pre-gated in
-      # `enqueue_probes` and re-checked here, which is what makes a scope edit mid-run bite.
-      # Asked about the NORMALIZED url, so the gate and the crawl can never judge two
-      # different spellings of one target (the `dir + cand` concat is not normalized).
-      norm = Url.normalize(p)
-      unless @scope.allowed?(norm, p.host)
+      # `enqueue_probes` and re-checked here so the two can never drift.
+      #
+      # `Url.gate_url`, not `Url.normalize`: the `dir + cand` concat is unnormalized, and the
+      # scope must be asked in the port-less form every other Layer-2 consumer uses — see
+      # `Url.gate_url`. NOTE the engine holds a snapshot policy, so this does NOT pick up a
+      # scope edit made mid-run except in the TUI, where the `Scope` object is shared live.
+      unless @scope.allowed?(Url.gate_url(p), p.host)
         return Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, SCOPE_REFUSED)
       end
       target = p.query ? "#{p.path}?#{p.query}" : p.path

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -376,9 +376,18 @@ module Gori::Discover
       # deserve the same soft-404 gate a brute-forced wordlist hit gets, not the "exists by
       # construction" trust record_page gives a crawled <a href>. Only wire this up when
       # bruteforce is on: that's the only mode with a calibration baseline to gate against.
-      # Reuse the dir bf_dir just calibrated above when it IS the seed's own dir; otherwise
-      # calibrate the origin separately — robots.txt/sitemap.xml always live there even on a
-      # path-scoped run confined elsewhere.
+      # The origin is calibrated separately — robots.txt/sitemap.xml always live there even on
+      # a path-scoped run confined elsewhere — and `enqueue_seed_only_calibration`'s own @dirs
+      # check reuses the bf_dir calibration when that dir IS the origin. Asking @dirs rather
+      # than comparing `root_dir == bf_dir` is the whole fix for #393: the old comparison
+      # assumed the `enqueue_dir` above had SUCCEEDED, but it goes through `bounded_url`, which
+      # applies the path confine — and the confine refuses the seed's own directory whenever
+      # the seed path is a single segment with no trailing slash. For `http://t/api`,
+      # @confine_path is "/api" while bf_dir is "http://t/", whose path is neither "/api" nor
+      # under "/api/". No Calibrate task was queued, yet @seed_calibration_dir was set, so
+      # robots.txt and sitemap.xml were fetched for real and then parked forever waiting on a
+      # baseline that never arrived: 2 real requests sent, 0 findings recorded, not even
+      # counted in calibrated_out.
       if @config.spider? && @config.bruteforce?
         root_dir = "#{Url.origin(@seed_parts)}/"
         # @seed_calibration_dir is set even when the Calibrate task below is refused, and that
@@ -388,7 +397,7 @@ module Gori::Discover
         # would send them to record_page, which is exactly the raw-status trust that reports a
         # wildcard-200 server's robots.txt as a finding. Fail safe, not fail loud.
         @seed_calibration_dir = root_dir
-        enqueue_seed_only_calibration(root_dir) unless root_dir == bf_dir
+        enqueue_seed_only_calibration(root_dir)
       end
     end
 

--- a/src/gori/discover/headers.cr
+++ b/src/gori/discover/headers.cr
@@ -1,3 +1,4 @@
+require "./url"
 require "../env"
 require "../proxy/codec/http1"
 
@@ -76,6 +77,16 @@ module Gori::Discover
     # seed (`Discover::Plan`), and post-expansion.
     def self.safe_value?(value : String) : Bool
       !value.includes?('\r') && !value.includes?('\n')
+    end
+
+    # The same rule for a URL bound for a request line. `URI.parse` keeps a raw CR/LF
+    # VERBATIM in a URL's host, path and query alike (it validates none of the three), and
+    # `Discover::Sender#build_get` splices all three into the request line and the `Host`
+    # header — so any one of them can splice a second, fully attacker-chosen request onto
+    # the connection. Checking only the path would leave the other two open.
+    def self.safe_url?(parts : Url::Parts) : Bool
+      q = parts.query
+      safe_value?(parts.host) && safe_value?(parts.path) && (q.nil? || safe_value?(q))
     end
 
     # The final ordered header list the Sender emits between `Host` and `Connection`:

--- a/src/gori/discover/plan.cr
+++ b/src/gori/discover/plan.cr
@@ -152,7 +152,7 @@ module Gori::Discover
     # re-derived per surface (`gori run discover` and MCP each carried a copy of this, the
     # MCP one labelled "mirror of the CLI's"; the TUI had a third, shorter one).
     #
-    # Unconfigured scope ⇒ OpenScope, nothing bounded. Otherwise StoreScope (sandbox/exclude
+    # No project at all ⇒ OpenScope, nothing bounded. Otherwise StoreScope (sandbox/exclude
     # + the include boundary) — UNLESS Layer 1 was waived by the OPERATOR (--allow-unscoped /
     # allow_unscoped:true) AND the seed is genuinely outside the include boundary, in which
     # case UnscopedStoreScope keeps the hard sandbox/exclude gate but drops the include
@@ -171,7 +171,20 @@ module Gori::Discover
       # `in_scope?` is "inside the include boundary" — the two questions this used to answer
       # by pulling the Scope out and re-running `configured?` / `matches_url?` by hand.
       verdict = outbound.check(seed, host)
-      return OpenScope.new if scope.nil? || verdict.unscoped?
+      # Only a genuinely absent project gets OpenScope. A project whose scope simply has no
+      # RULES does not: `verdict.unscoped?` is true exactly when `Scope#configured?` is false,
+      # and Sandbox is enabled independently of rules (`Scope#enable_sandbox`) — so discover
+      # used to crawl and brute-force completely unrestricted on the one configuration
+      # DESIGN.md §3 singles out as fail-CLOSED, while the proxy blocked every request and
+      # every other sweep (`Outbound#sweep_block`, which only skips on a nil scope) refused.
+      #
+      # Nothing about containment changes: `StoreScope#configured?` delegates to
+      # `Scope#configured?`, which is false here too, so scope-aware containment still falls
+      # back to same-origin and `boundary?` is never consulted. The only difference is that
+      # `allowed?` starts consulting Sandbox and EXCLUDE — both false on an ordinary
+      # rule-less project with Sandbox off, so those runs are unaffected.
+      return OpenScope.new if scope.nil?
+      return StoreScope.new(scope) if verdict.unscoped?
       if outbound.reason == Gori::Outbound::Reason::Operator && !verdict.in_scope?
         return UnscopedStoreScope.new(scope)
       end

--- a/src/gori/discover/url.cr
+++ b/src/gori/discover/url.cr
@@ -44,6 +44,26 @@ module Gori::Discover
       q ? "#{origin(p)}#{p.path}?#{q}" : "#{origin(p)}#{p.path}"
     end
 
+    # The string the SCOPE is asked about — deliberately NOT `normalize`.
+    #
+    # gori's scope model has no port dimension: `Scope.request_url` is
+    # `"#{scheme}://#{host}#{target}"` and the proxy splits host from port before asking
+    # (`client_conn.cr`), so every other Layer-2 consumer judges a port-LESS URL. `normalize`
+    # appends `:port` whenever it is not 80/443, so on a non-default port discover was asking
+    # about `http://acme.test:8080/logout` while a rule was written against
+    # `http://acme.test/logout` — and a host-qualified `string` or `regex` EXCLUDE therefore
+    # never matched. That is the exact rule the brute-forcer is supposed to obey, silently
+    # failing open on any `:8080`/`:8443` target.
+    #
+    # Kept as its own function rather than folded into `normalize` because the two answers
+    # must differ: the crawl, the findings and the Sitemap rows all need the port (it is part
+    # of the resource's identity), and only the gate question drops it.
+    def self.gate_url(p : Parts) : String
+      q = p.query
+      base = "#{p.scheme}://#{p.host}#{p.path}"
+      q ? "#{base}?#{q}" : base
+    end
+
     # EXACT identity — lowercase host, drop default port + fragment, sort query pairs, KEEP
     # values (?page=1 ≠ ?page=2). Populates `seen`.
     def self.visit_key(p : Parts) : String


### PR DESCRIPTION
Four pre-existing Discover bugs found while reviewing #364 (PR #389), fixed as one commit each. All four are independent of that fix.

Closes #390
Closes #391
Closes #392
Closes #393

## #390 — a crawled link could splice a second request onto the wire

A crawled `<a href>` carrying a raw CR/LF reached the request line intact and spliced a second, fully attacker-chosen request onto the same connection — method, absolute-form request line, and `Host`. It passed no scope gate, including under Sandbox.

One correction to the issue's write-up, caught in review: the victim is the **origin gori dialled**, not a different host. `Upstream.dial` always CONNECT-tunnels through a configured upstream proxy rather than forwarding in absolute form, so the injected absolute-form line cannot be routed elsewhere. The comment in the code says the corrected version.

Every layer between the href and the socket preserved the control bytes: `Extract::ATTR`'s `[^"]` matches CR and LF, `Url.resolve` strips only the ends, and `URI.parse` keeps an interior CR/LF verbatim — in a URL's **host, path and query alike**, which is why the new `Headers.safe_url?` checks all three rather than just the path.

`Discover::Plan` already guarded exactly this for the **seed** (`plan.cr:132`). The same rule now covers derived URLs, at two sites with distinct jobs:

- **`Engine#bounded_url`** — where every crawled/derived URL is judged.
- **`Sender#fetch`** — the wire seam's own invariant, and the only line every send provably passes.

**Decision: a link that fails the check is DROPPED SILENTLY, not recorded as a finding.** A `Finding` asserts "this endpoint exists", and this URL is never requested, so there is no status, length, or content type to claim one with — and `Discover::Persist` would then write the poisoned string into the Sitemap as a real flow row. It takes the same exit any out-of-bounds link takes, which is also how `enqueue_well_known` already treats a Layer-2 refusal.

The spec reads the **actual bytes a real `Discover::Sender` puts on a TCP socket**, because a spec that only checked the URL string could not have caught this.

## #391 — probes were authorised by their directory, not per URL

`enqueue_probes` was the only `@frontier <<` site with no gate, and `process_calibrate` sent `"#{dir}#{bogus_name}"` the same way — so with the defaults ~278 real requests went out per calibrated directory on **one** `allowed?` answer about the directory.

A directory verdict does not carry to its children: only `host` rules and `string` INCLUDEs are monotone under a path append. `string`/`regex` EXCLUDEs and the `regex` INCLUDEs Sandbox reads as its allowlist are not. So an EXCLUDE on `logout` — line 41 of the built-in wordlist, and the canonical "do not touch destructive endpoints" rule — was silently ignored by the brute-forcer.

The path confine was escapable the same way: `Url.parse` collapses dot-segments, so a wordlist entry of `../admin` under an `/app/`-confined run resolved to `/admin`.

Split by **layer** rather than by call site:

- **Layer 2 → `send_with_retries`**, the single funnel for all three send sites. Calibration probes are built inside a worker at send time from a random bogus name, so no enqueue-time gate can see them; this is the only line that can judge them. Brute-force candidates are gated at enqueue too, keeping a refused one out of the frontier and out of `per_dir_cap`. A refusal is `SCOPE_REFUSED`, shaped like `CappedBackend::CAP_ERROR` and likewise **not** counted as a run error.
- **The path confine → `enqueue_probes` only**, via a `confined?` predicate now shared with `bounded_url`. It deliberately does not go on the send chokepoint: the origin-root calibration and the two well-known paths waive the confine on purpose (#364), and gating there would refuse them on every path-scoped run.
- **Layer 1 (containment / `boundary?`) is deliberately not re-asked per probe** — it was answered for the directory, which is what the crawl actually reached, and DESIGN.md §3 makes Layer 1 the layer whose strictness varies by surface.

Recorded in DESIGN.md §7.

## #392 — a rule-less scope was treated as an absent one

`Plan.resolve_policy` returned `OpenScope` for `scope.nil? || verdict.unscoped?`, and `unscoped?` is true exactly when `Scope#configured?` is false — i.e. whenever the project's scope has no *rules*. `OpenScope#allowed?` is unconditionally true, so Layer 2 was absent for the whole run.

Checked against the other tools first, as the issue asked: `Outbound#sweep_block` skips only on a **nil** scope, never on a rule-less one, so Fuzz/Miner/Sequencer/Probe all already refused here, and the proxy blocked every request — while discover crawled and brute-forced unrestricted. Discover was the sole fail-**open** tool, in the one configuration §3 singles out as fail-closed. This change makes discover consistent with the rest rather than merely different.

`scope.nil?` (genuinely no project) still returns `OpenScope`. Containment is unchanged: `StoreScope#configured?` delegates to `Scope#configured?`, still false, so scope-aware containment keeps falling back to same-origin and `boundary?` is never consulted. The only difference is that `allowed?` starts consulting Sandbox and EXCLUDE, both false on an ordinary rule-less project with Sandbox off.

Recorded in DESIGN.md §7.

## #393 — a single-segment seed lost its robots.txt/sitemap.xml findings

`seed_frontier` skipped `enqueue_seed_only_calibration(root_dir)` whenever the origin root *was* the seed's own brute-force directory, assuming the `enqueue_dir(bf_dir)` above had already queued a Calibrate for it. But `enqueue_dir` goes through `bounded_url`, which applies the path confine — and the confine refuses the origin root whenever the seed path is a single segment with no trailing slash. For `http://t/api`, `@confine_path` is `/api` while `bf_dir` is `http://t/`, whose path is neither `/api` nor under `/api/`.

So no Calibrate was queued, yet `@seed_calibration_dir` was still set — which is what routes a robots/sitemap outcome to `resolve_seed_finding`. Both outcomes parked forever: **2 real requests sent, 0 findings recorded**, not even counted in `calibrated_out`.

Dropping the short-circuit lets `enqueue_seed_only_calibration`'s own `@dirs` check dedup, which already answers the real question ("was this directory queued?") rather than a proxy for it. Parking-without-a-baseline is unchanged; it is deliberate and #364 depends on it.

## Review findings, fixed in the last commit

I ran the review gate over the whole diff with three independent reviewers (security, correctness, adversarial + sibling sweep). Six findings survived verification against the code, and all six are fixed in `78fad5b`:

1. **The Layer-2 gate string was port-bearing, which undercut #391's headline case.** `Url.normalize` appends `:port` off the defaults, but gori's scope model has no port dimension — `Scope.request_url` is `scheme://host/target`, and the proxy splits the port off before asking. Proven with the real `Scope::Rule#matches?`: a host-qualified `string` *or* `regex` EXCLUDE returns `false` for `http://acme.test:8080/logout` and `true` for `http://acme.test/logout`. So the exact rule #391 exists to enforce still failed open on any non-default port. New `Url.gate_url` is the port-less form, kept separate from `normalize` because the crawl, the findings and the Sitemap rows all need the port; only the gate question drops it.
2. **`handle_crawl` counted benign errors.** `handle_probe` excluded `SCOPE_REFUSED` and `CAP_ERROR`; `handle_crawl` excluded neither, contradicting the invariant this branch writes into DESIGN.md verbatim. The `CAP_ERROR` half is pre-existing and measurable: `@jobs` is buffered to `concurrency`, so the orchestrator dispatches every seed task before a worker increments `@capped.sent`, and `--max-requests` reported the cap working as designed as run errors. Both now go through one `benign_error?` predicate.
3. **`probe_allowed?` omitted `Headers.safe_url?`**, unlike `bounded_url`. A hostile wordlist can carry an interior lone CR (`Wordlist.load` strips only line ends).
4. **A comment claimed the send gate "makes a scope edit mid-run bite".** False on CLI and MCP — the engine holds a snapshot policy and never reaches `Outbound#refresh`. Corrected in place; filed as #396.
5. **The `UNSAFE_URL` comment repeated the issue's upstream-proxy claim.** Corrected (see above).
6. **`enqueue_probes` gate order** — `@seen` is now checked before `probe_allowed?`. Identical verdict, and it stops a full rule walk under a mutex from running for already-seen candidates 275 words × directories deep.

One of my own specs was **vacuous** and I caught it on the control-run: the first `CAP_ERROR` test passed with the fix reverted, because the orchestrator stops dispatching once the cap is reached, so there was no over-dispatched crawl to mis-count. Rewritten around the real mechanism and confirmed to fail 3/3 without the fix.

## Deliberately not fixed here — filed instead

- **#394** — a raw SPACE (and TAB/C0/DEL) in a crawled href still reaches the request line. This is request-line *corruption*, not splicing, so it is outside #390's scope, and it is a real FP source (a 400 diverges from a 404 baseline, scoring `status_div` at +0.50). The correct fix is percent-encoding rather than rejection, which changes the bytes of every discover request and interacts with URL identity — a product decision, not a drive-by.
- **#395** — a file-shaped seed brute-forces nothing, and with `--no-spider` sends zero requests for no stated reason. Adjacent to #393, different half.
- **#396** — discover's Layer 2 never reloads the scope, so a mid-run rule change does not bite on CLI/MCP.
- **#397** — Fuzz's redirect follower splices a `Location` into the request line unvalidated (outside this branch's file boundary), plus a hardening note on the upstream CONNECT authority.

## Verification

Every fix was control-run: the guard was reverted and the new examples confirmed to fail, then restored.

- `just test` — 4293 examples, 0 failures
- `just check` — the two reported format diffs (`spec/proxy/tls/tunnel_spec.cr`, `src/gori/proxy/upstream.cr`) are pre-existing Crystal-version drift on files this branch does not touch
- ameba on touched files: no new findings (`spec/discover/engine_spec.cr` is one below its baseline)
- `crystal build --no-codegen src/main.cr` in an isolated cache dir
