### PR TITLE
fix(fuzz): validate a redirect Location before splicing it into the request line (#397)

### DIFF
--- a/spec/fuzz/redirect_wire_spec.cr
+++ b/spec/fuzz/redirect_wire_spec.cr
@@ -1,0 +1,192 @@
+require "../spec_helper"
+
+private alias F = Gori::Fuzz
+
+# The bytes the fuzzer's redirect follower actually puts on a socket (#397).
+#
+# A spec that asserted on the resolved path STRING would prove nothing here — that was #390's
+# lesson. Every layer between the `Location` header and the request line preserves a raw SP or
+# TAB happily (the response codec strips only the OWS around a field-value, and `URI.parse`
+# validates neither `path` nor `query`), so the forged request line stays invisible until it is
+# assembled. These examples read it back off a real TCP connection instead, and COUNT request
+# lines rather than parsing the first one.
+
+# A recording origin. Answers each connection with the next canned response (repeating the last
+# once they run out, with `{PORT}` substituted so a response can name the listener itself) and
+# returns the raw bytes of every connection it accepted, in order.
+private def wire_of(responses : Array(String), &) : Array(String)
+  server = TCPServer.new("127.0.0.1", 0)
+  port = server.local_address.port
+  seen = [] of String
+  spawn do
+    hop = 0
+    while conn = server.accept?
+      slice = Bytes.new(16384)
+      n = 0
+      begin
+        # One read, then answer: the sender is blocked waiting on a response, so reading to
+        # EOF here would deadlock. A splice rides in the SAME write as the request it hangs
+        # off (the follower emits a single slice), so one read sees all of it.
+        conn.read_timeout = 500.milliseconds
+        n = conn.read(slice)
+      rescue IO::Error
+      end
+      # Recorded BEFORE the response is written, so every connection the engine has finished
+      # with is already in `seen` by the time `run` returns.
+      seen << String.new(slice[0, n])
+      begin
+        # `last?`, not `last`: an empty `responses` would otherwise raise IndexError here, which
+        # is neither of the rescued IO errors — the recording fiber would die and every
+        # assertion below would read an empty wire as "nothing was sent".
+        conn << (responses[hop]? || responses.last? || OK_RESPONSE).gsub("{PORT}", port)
+        conn.flush
+      rescue IO::Error
+      end
+      hop += 1
+      conn.close rescue nil
+    end
+  rescue IO::Error
+  end
+
+  yield port
+  server.close rescue nil
+  seen
+end
+
+# Every request line across every connection of the run. The whole point of this class of bug is
+# that there can be more of them than the engine believes it sent, so this counts.
+#
+# Two details are load-bearing, and getting either wrong makes this silently blind to the very
+# bug it exists to catch. Lines are split on a bare LF as well as CRLF, because that is how a
+# poisoned Location reaches the wire (see the bare-LF example below) and because an LF-lenient
+# origin breaks lines on either (RFC 7230 §3.5). And the target is matched with `.+`, not `\S+`:
+# a forged line has FOUR or more tokens (`GET /a b HTTP/1.1 HTTP/1.1`), so `\S+` would refuse to
+# match it and quietly drop it from the count.
+private def request_lines(wire : Array(String)) : Array(String)
+  wire.flat_map(&.split(/\r\n|\n/)).select(&.matches?(/\A[A-Z]+ .+ HTTP\/\d(?:\.\d)?\z/))
+end
+
+private def redirect_to(location : String) : String
+  "HTTP/1.1 302 Found\r\nLocation: #{location}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+end
+
+private OK_RESPONSE = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"
+
+# Drives one single-payload run against `port` with redirect following on, and hands the results
+# back so an example can also assert what the operator is shown.
+private def run_fuzz(port : Int32) : Array(F::Result)
+  tmpl = F::Template.parse("GET /start?q=§a§ HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+  set = F::PayloadSet.new(F::InlineList.new(["one"]))
+  cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: 1, follow_redirects: true,
+    max_redirects: 3, timeout: 2.seconds)
+  gen = F::Generator.new(tmpl, [set], cfg)
+  backend = F::Sender.new(F::Origin.new("http", "127.0.0.1", port), ungated_outbound,
+    http2: false, verify: false)
+  results = [] of F::Result
+  F::Engine.new(gen, F::Matcher.new, backend, cfg).run do |ev|
+    results << ev.result if ev.is_a?(F::ResultEvent)
+  end
+  results
+end
+
+describe "Fuzz::Engine redirect following" do
+  # The control. Without it every assertion below would pass just as happily against a harness
+  # that never observes the socket, or against an engine that stopped following redirects at all.
+  it "follows a clean same-origin Location, one request per hop" do
+    wire = wire_of([redirect_to("/next?ok=1"), OK_RESPONSE]) { |port| run_fuzz(port) }
+
+    request_lines(wire).should eq([
+      "GET /start?q=one HTTP/1.1",
+      "GET /next?ok=1 HTTP/1.1",
+    ])
+    wire[1].should match(/\AGET \/next\?ok=1 HTTP\/1\.1\r\nHost: 127\.0\.0\.1:\d+\r\nConnection: close\r\n\r\n\z/)
+  end
+
+  it "does not follow a Location carrying a raw space (request-line forgery)" do
+    # The exact shape #397 recorded: `Location: /a b HTTP/1.1` survives the response codec
+    # verbatim, and interpolating it produced `GET /a b HTTP/1.1 HTTP/1.1` — which a lenient
+    # origin reads as target `/a`, version `b`. gori would then record and report a hit on a
+    # resource it never actually asked for.
+    wire = wire_of([redirect_to("/a b HTTP/1.1"), OK_RESPONSE]) { |port| run_fuzz(port) }
+
+    request_lines(wire).should eq(["GET /start?q=one HTTP/1.1"])
+    wire.size.should eq(1) # the second hop is never dialled at all
+    wire.join.should_not contain("/a b")
+  end
+
+  it "does not follow a Location carrying a raw tab" do
+    wire = wire_of([redirect_to("/a\tb"), OK_RESPONSE]) { |port| run_fuzz(port) }
+
+    request_lines(wire).should eq(["GET /start?q=one HTTP/1.1"])
+    wire.size.should eq(1)
+    wire.join.should_not contain("/a\tb")
+  end
+
+  it "applies the same rule to an absolute-form same-origin Location" do
+    # `URI.parse("http://127.0.0.1:PORT/a b").path` is `"/a b"` just as verbatim, and that
+    # branch of resolve_redirect_path reaches the request line through the same assembler — so
+    # a guard wired only into the relative branch would leave this half open.
+    wire = wire_of([redirect_to("http://127.0.0.1:{PORT}/a b"), OK_RESPONSE]) { |port| run_fuzz(port) }
+
+    request_lines(wire).should eq(["GET /start?q=one HTTP/1.1"])
+    wire.size.should eq(1)
+    wire.join.should_not contain("/a b")
+  end
+
+  it "still follows an absolute-form same-origin Location that is clean" do
+    # The control for the example above: the absolute-form branch is refused for the byte, not
+    # because absolute-form stopped working.
+    wire = wire_of([redirect_to("http://127.0.0.1:{PORT}/next"), OK_RESPONSE]) { |port| run_fuzz(port) }
+
+    request_lines(wire).should eq([
+      "GET /start?q=one HTTP/1.1",
+      "GET /next HTTP/1.1",
+    ])
+  end
+
+  it "reports the refused 3xx rather than dropping or erroring the row" do
+    results = [] of F::Result
+    wire = wire_of([redirect_to("/a b"), OK_RESPONSE]) { |port| results = run_fuzz(port) }
+
+    request_lines(wire).size.should eq(1)
+    # Refusing to follow leaves the operator with the redirect the origin actually sent, exactly
+    # like the existing cross-origin behaviour — not a dropped row and not a fabricated error.
+    results.size.should eq(1)
+    results[0].status.should eq(302)
+    results[0].error.should be_nil
+  end
+
+  # The splicing half of the class, and the reason this is more than a correctness bug.
+  #
+  # #397 recorded that CR/LF "is not reachable here — the response head is split on line
+  # terminators before Location is read". That is not so, and it is worth pinning as a test
+  # rather than a comment. `index_crlf`/`parse_headers` break header lines on the TWO-BYTE CRLF
+  # only, and a field-value is stripped at its ends, so a BARE LF or bare CR sits in the parsed
+  # `Location` verbatim. `obfuscated_header?` would catch it, but the RESPONSE path deliberately
+  # gates on the narrower `framing_ambiguous?` instead, so that a legacy origin does not 502.
+  #
+  # That narrowness is what leaves this reachable. A poisoned `Location` IS refused before the
+  # follower when its smuggled lines change how the response frames — a blank line, or a
+  # `Content-Length:` line, makes the strict and lenient views disagree and `Repeater::Engine`
+  # errors. Neither is needed to forge a request: the payload below carries only an ordinary
+  # request line, both views agree, the read succeeds, and pre-fix those bytes went on the wire.
+  it "does not follow a Location carrying a bare LF (request splicing)" do
+    poisoned = "/a\nGET http://evil.test/pwned HTTP/1.1\nHost: evil.test"
+    wire = wire_of([redirect_to(poisoned), OK_RESPONSE]) { |port| run_fuzz(port) }
+
+    request_lines(wire).should eq(["GET /start?q=one HTTP/1.1"])
+    wire.size.should eq(1)
+    wire.join.should_not contain("evil.test")
+  end
+
+  it "does not follow a Location carrying a bare CR" do
+    # The mirror image, reachable for the same reason: a lone CR never terminates a header line
+    # for `index_crlf` either, so it too survives into the value.
+    poisoned = "/a\rGET http://evil.test/pwned HTTP/1.1\rHost: evil.test"
+    wire = wire_of([redirect_to(poisoned), OK_RESPONSE]) { |port| run_fuzz(port) }
+
+    request_lines(wire).should eq(["GET /start?q=one HTTP/1.1"])
+    wire.size.should eq(1)
+    wire.join.should_not contain("evil.test")
+  end
+end

--- a/spec/proxy/codec/http1_spec.cr
+++ b/spec/proxy/codec/http1_spec.cr
@@ -127,4 +127,43 @@ describe Gori::Proxy::Codec::Http1 do
       Http1.read_head(IO::Memory.new("")).should be_nil
     end
   end
+
+  # The rule for text gori SYNTHESIZES into a request line. Its callers are the ones that build
+  # a request out of something a remote chose: `Fuzz::Engine`'s redirect follower (#397) and
+  # `MCP::RequestBuilder`'s method / target / host / header-name checks.
+  describe ".request_token_safe?" do
+    it "accepts an ordinary request target, including the punctuation a URL needs" do
+      Http1.request_token_safe?("/a/b?x=1&y=2#f").should be_true
+      Http1.request_token_safe?("*").should be_true
+      Http1.request_token_safe?("http://host:8080/p%20q").should be_true
+      Http1.request_token_safe?("GET").should be_true
+    end
+
+    it "rejects every octet that can break a request line into more tokens" do
+      # SP and TAB forge the line (`GET /a b HTTP/1.1` reads as target `/a`, version `b`);
+      # CR and LF splice a second request onto the connection; NUL and DEL are the remaining
+      # members of the same class and are never legal here either.
+      {" ", "\t", "\r", "\n", "\0", "\u007F"}.each do |c|
+        Http1.request_token_safe?("/a#{c}b").should be_false
+        Http1.request_token_safe?("/a#{c}").should be_false
+        Http1.request_token_safe?("#{c}/a").should be_false
+      end
+    end
+
+    it "accepts an empty string" do
+      # Emptiness is the caller's business (MCP raises its own "must not be empty" first);
+      # this predicate answers only "does it contain a line-breaking octet".
+      Http1.request_token_safe?("").should be_true
+    end
+
+    it "does not reject a non-ASCII target for being non-ASCII" do
+      # Every octet of a multi-byte UTF-8 sequence is >= 0x80, so none of them can trip the
+      # <= 0x20 test. Deliberately NOT claimed here: that a byte-wise scan and a char-wise one
+      # differ. They do not — 0x00-0x20 and 0x7F can never appear as UTF-8 continuation octets,
+      # so the two agree on every input, valid or invalid. The byte-wise form is preferred for
+      # being decode-free, not for a behaviour difference, and no example can pin that choice.
+      Http1.request_token_safe?("/검색?q=값").should be_true
+      Http1.request_token_safe?("/검색 ?q=값").should be_false
+    end
+  end
 end

--- a/src/gori/fuzz/engine.cr
+++ b/src/gori/fuzz/engine.cr
@@ -1,6 +1,7 @@
 require "uri"
 require "../repeater/engine"
 require "../repeater/h2_engine"
+require "../proxy/codec/http1"
 require "../outbound"
 require "../scope"
 
@@ -342,7 +343,25 @@ module Gori::Fuzz
     private def redirect_request(loc : String) : Bytes?
       o = @backend.origin
       path = resolve_redirect_path(loc, o)
-      return nil unless path
+      # The `Location` is chosen by whatever host answered, and the next line splices it
+      # straight into a request line — so it gets the same rule as any other remote-chosen
+      # request-line token (#397). Checked HERE rather than inside resolve_redirect_path
+      # because this is the method that assembles the bytes, and both of that method's
+      # branches (relative, and absolute-form same-origin — `URI.parse` keeps a raw space in
+      # `path` and `query` just as verbatim) reach the wire through it.
+      #
+      # Both halves of the rule are live here, not just the SP/TAB one. A bare LF or CR in a
+      # field-value survives `parse_headers` (which breaks lines on the two-byte CRLF only),
+      # and the response path gates on `framing_ambiguous?` rather than the stricter
+      # `obfuscated_header?` — so a `Location` carrying a smuggled request line that does not
+      # disturb framing reaches this method and used to put a whole second, attacker-chosen
+      # request on the connection. spec/fuzz/redirect_wire_spec.cr pins that off a real socket.
+      #
+      # An unsafe Location is not followed at all rather than percent-encoded: gori cannot
+      # know whether the origin meant a literal space or a broken link, and refusing leaves
+      # the run reporting the 3xx it actually got. That matches the existing treatment of a
+      # cross-origin Location — the chain stops, the 3xx is the result.
+      return nil unless path && Proxy::Codec::Http1.request_token_safe?(path)
       default = o.scheme == "https" ? 443 : 80
       host = o.port == default ? o.host : "#{o.host}:#{o.port}"
       "GET #{path} HTTP/1.1\r\nHost: #{host}\r\nConnection: close\r\n\r\n".to_slice

--- a/src/gori/mcp/request_builder.cr
+++ b/src/gori/mcp/request_builder.cr
@@ -1,6 +1,7 @@
 require "json"
 require "uri"
 require "../env"
+require "../proxy/codec/http1"
 
 module Gori
   module MCP
@@ -140,13 +141,14 @@ module Gori
         reject_token_breakers(method, "method #{method.inspect}")
       end
 
-      # Reject any whitespace or control octet (<= 0x20, incl. SP/TAB, or DEL) in
-      # `s`. Used for the method, header names, the request target, and the host —
-      # all single tokens where even a bare SP forges the request line
-      # (`GET /a b HTTP/1.1`: a lenient origin then reads target `/a`, version `b`).
+      # Raise unless `s` is safe as one request-line token. Used for the method, header
+      # names, the request target, and the host. The rule itself is
+      # `Codec::Http1.request_token_safe?` — this is only the MCP-shaped error around it, so
+      # that this surface and the engines that build a request line out of remote-chosen text
+      # (`Fuzz::Engine`'s redirect follower) cannot drift apart.
       private def self.reject_token_breakers(s : String, what : String) : Nil
-        s.each_char do |c|
-          raise Gori::Error.new("illegal whitespace/control character in #{what}") if c <= ' ' || c == '\u007F'
+        unless Proxy::Codec::Http1.request_token_safe?(s)
+          raise Gori::Error.new("illegal whitespace/control character in #{what}")
         end
       end
 

--- a/src/gori/proxy/codec/http1.cr
+++ b/src/gori/proxy/codec/http1.cr
@@ -170,6 +170,35 @@ module Gori::Proxy::Codec::Http1
     resp.raw_head
   end
 
+  # Whether `s` may be written onto a request line as ONE space-delimited token — the
+  # method, the request target, or an authority. False for any octet at or below SP
+  # (0x20, which covers SP, HTAB, CR, LF and NUL) and for DEL (0x7F).
+  #
+  # A request line is `METHOD SP target SP version`, so a single SP inside any of the three
+  # forges it: `GET /a b HTTP/1.1` reads to a lenient origin as target `/a` and version `b`,
+  # and gori then records a request it did not send. CR or LF is the worse half of the same
+  # class — it terminates the line and splices a second, fully attacker-chosen request onto
+  # the connection.
+  #
+  # This is the one home for that rule. gori has now hit the same shape in three subsystems
+  # (#390 a crawled `<a href>` in Discover, #394 a raw space in the same, #397 a redirect
+  # `Location` in the fuzzer), each time because the rule was written next to one caller and
+  # the next subsystem did not know it existed. It lives with the HTTP/1 framing predicates
+  # because that is what it is, and because every engine and every surface already depends on
+  # this codec — `Fuzz::Engine`'s redirect follower and the MCP request builder's
+  # `reject_token_breakers` both call it, and `Discover::Headers.safe_url?` (CR/LF only today)
+  # is the third caller once #394 settles whether Discover encodes or refuses.
+  #
+  # It does NOT apply to bytes an operator handed gori to replay: those go out verbatim,
+  # malformed or not (P7). It applies where gori SYNTHESIZES a request line out of text that
+  # a remote chose.
+  def self.request_token_safe?(s : String) : Bool
+    # Bytes, not chars: the multi-byte UTF-8 continuation octets are all >= 0x80, so this is
+    # identical to the char-wise test on valid input and correct on invalid input too.
+    s.each_byte { |b| return false if b <= 0x20_u8 || b == 0x7f_u8 }
+    true
+  end
+
   # Index of the CRLF at or after `from`, or nil if none. Scans the raw bytes so
   # the parser never materializes the whole head as a String (P7: raw is truth).
   private def self.index_crlf(raw : Bytes, from : Int32) : Int32?


### PR DESCRIPTION
Closes #397.

## The bug

`Fuzz::Engine#redirect_request` interpolated a 3xx `Location` **verbatim** into a raw request line:

```crystal
"GET #{path} HTTP/1.1\r\nHost: #{host}\r\nConnection: close\r\n\r\n"
```

The Location is chosen by whatever host answered, so an attacker who controls a redirect target controlled gori's request line.

## #397 under-rated it: the CR/LF half IS reachable

The issue says *"CR/LF is not reachable here — the response head is split on line terminators before `Location` is read"*, and scoped this to request-line corruption. That is wrong, and the specs now pin why:

- `index_crlf` / `parse_headers` break header lines on the **two-byte CRLF only**, and a field-value is stripped at its ends — so a **bare LF or bare CR survives into the parsed `Location`**.
- `obfuscated_header?` would catch it, but the *response* path deliberately gates on the narrower `framing_ambiguous?` so legacy origins don't 502.
- That narrowness is what leaves it reachable. A poisoned Location **is** refused earlier when its smuggled lines change framing (a blank line, or a `Content-Length:` line — both verified rejected). Neither is needed to forge a request.

Measured off a real socket with the guard removed:

```
Location: /a\nGET http://evil.test/pwned HTTP/1.1\nHost: evil.test
  ->  request lines on the wire:
      ["GET /start?q=one HTTP/1.1", "GET http://evil.test/pwned HTTP/1.1"]
```

A complete, attacker-chosen absolute-form request, off an ordinary 302. That is the #390 vector in the fuzzer. (Still gated behind `follow_redirects`, which defaults to false.)

## One root cause, one home — not a fourth copy

Third instance of the same shape (#390 crawled `<a href>`, #394 a space in the same, #397 this), each time because the rule sat next to one caller. So it now has a single home:

`Codec::Http1.request_token_safe?(s)` — rejects any octet `<= 0x20` (SP, TAB, CR, LF, NUL) or DEL.

**Why `proxy/codec/http1.cr`:** DESIGN.md §2.1 names *"the codecs"* as the shared layer every engine depends on, and the file already hosts sibling predicates that exist purely so callers can refuse (`obfuscated_header?`, `framing_ambiguous?`, `bare_cr_or_lf?`). It is reachable from core and surfaces alike without inverting any dependency. `Discover::Headers` was the alternative, but fuzz→discover is engine-to-engine coupling, broadening it is #394's product decision, and a sibling agent is editing that file right now.

`MCP::RequestBuilder.reject_token_breakers` now **delegates** rather than keeping its own copy. `Discover::Headers.safe_url?` (CR/LF-only today) becomes the third caller once #394 settles encode-vs-refuse.

### §2.1 layering check, before and after

Required by the issue. Both runs of the DESIGN.md §2.1 grep return **exactly one hit — the same pre-existing comment**:

```
$ grep -rnE '\b(Tui|CLI|MCP)::' \
    src/gori/{store,proxy,probe,fuzz,miner,discover,sequencer,oast}/ \
    src/gori/{store,probe,fuzz,miner,discover,sequencer,oast}.cr

# origin/main:
src/gori/probe/group.cr:112:  # shared by `gori run probe --format json` (CLI::Output... delegates here)

# this branch:
src/gori/probe/group.cr:112:  # shared by `gori run probe --format json` (CLI::Output... delegates here)
```

The new doc comment deliberately says "the MCP request builder" in prose rather than `MCP::RequestBuilder`, so it does not add a second hit and DESIGN.md's "exactly one hit" claim stays true without editing that shared file.

## Refuse, not encode

An unsafe Location is not followed at all. gori cannot know whether the origin meant a literal space or a broken link, and percent-encoding would invent a URL the origin never named while gori records it as sent. Refusing keeps the recorded request identical to the bytes on the wire, and matches the existing cross-origin treatment: the chain stops, the 3xx is the result.

## Specs read the socket, not the string

`spec/fuzz/redirect_wire_spec.cr` (new) drives the production `Fuzz::Sender` against a recording `TCPServer` and counts request lines across every connection. #390's lesson was that asserting on the resolved path string proves nothing.

**Control-run** (guard reverted → restored): **6 of 8 fail**, the two clean-redirect controls pass.

| example | fails without guard |
|---|---|
| clean relative Location (control) | no — passes both ways |
| clean absolute-form Location (control) | no — passes both ways |
| raw space | yes |
| raw tab | yes |
| absolute-form + space | yes |
| refused 3xx still reported (302, no error) | yes |
| bare LF (splice) | yes |
| bare CR (splice) | yes |

Two harness bugs found by review and fixed before merge — worth naming since both would have made the file look green while blind:
- `request_lines` matched the target with `\S+` and split only on CRLF. A forged line has **4+ tokens**, and a spliced one is **LF-delimited**, so it could not see either. Now `.+` and split on `/\r\n|\n/`.
- The bare-LF example originally used a payload with a blank line, which `framing_ambiguous?` rejects one layer earlier — it passed without the guard. Replaced with a payload that actually reaches the follower.

## Sibling sweep — other engines that follow redirects

Asked for by the issue. **Discover is the only other engine that follows a redirect** (`discover/engine.cr:471`); miner, sequencer and repeater have no redirect follower at all, and `probe/active/open_redirect.cr` reads a `Location` only for analysis (`Active.url_authority`), never back onto a request line.

Three same-shape gaps found outside this branch's boundary, **not fixed here**:

1. **`discover/engine.cr:87`** — SP/TAB in a crawled href still reaches `"GET #{target} HTTP/1.1"`; `Headers.safe_url?` is CR/LF-only. This is **#394**, already owned.
2. **`proxy/upstream.cr:195`** — #397 noted it *"could not demonstrate a live reachable path"* to the unguarded `CONNECT #{authority}` line. There is one, via Discover: `http://ac me.acme.test/x` passes `safe_url?` and `same_or_subdomain?`, reaching `CONNECT ac me.acme.test:80` when an upstream proxy is configured. Worth adding to #394.
3. **`import/builder.cr:109`** — `CONTROL_CHAR = /[\x00-\x1f\x7f]/` misses SP (0x20) for the request target, so `/a b` is stored and replayed byte-exact by Repeater. `HOST_INVALID` already covers space, but only for the host.

## Verification

- `just test` → **4310 examples, 0 failures**
- `crystal tool format --check` on the 5 touched files → clean (two *untouched* files, `spec/proxy/tls/tunnel_spec.cr` and `src/gori/proxy/upstream.cr`, fail the tree-wide check on `main` too — pre-existing Crystal version drift)
- ameba on the 5 touched files → **4 findings, byte-identical to `origin/main`** (line-shifted only); zero new