### PR TITLE
fix(discover): raw-space request-line corruption, a file-shaped seed that probes nothing, and a snapshot scope gate (#394-#396)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -640,6 +640,38 @@ repairable half never reaches it, having been encoded upstream — and it means 
 state the invariant it is there to state: a Discover run never puts a malformed or doubled
 request line on a connection.
 
+### 2026-07-26: a path-confined run brute-forces its own subtree, and an empty frontier is an error
+
+Refines: [P4](#p4). Issue #395, adjacent to #393.
+
+`seed_frontier` took the brute-force base from `Url.dir_of(seed)` — everything up to the last
+`/` — while `@confine_path` was derived from the seed's full path. For a **file-shaped seed**
+(a path with no trailing slash) the two disagreed: on `http://t/api`, `dir_of` is the origin
+root `http://t/`, whose path is neither `/api` nor under `/api/`, so `enqueue_dir` went through
+`bounded_url`, the confine refused it, and the seed's own subtree was never probed. With
+`spider: false, bruteforce: true` — `gori run discover --target https://acme.test/api
+--no-spider`, an ordinary invocation — that was the entire run: `sent=0 findings=[]`, a clean
+`DoneEvent`, no reason given.
+
+The issue offered two fixes, and the answer is a third that the confine's own documented meaning
+already implies. Widening `@confine_path` from `/api` to `/` would spray the built-in wordlist —
+`admin`, `logout`, `.git/config`, `.env` — at the origin root of a run the operator explicitly
+scoped to `/api`, which is what the confine exists to prevent. Reporting "brute-force has
+nothing to do" answers a question nobody asked: a seed path deeper than `/` means *the subtree
+rooted here* (`confined?`), so **the brute-force base is that subtree's root as a directory**,
+not the seed's containing directory. `/api` and `/api/` therefore both calibrate `http://t/api/`,
+`/a/b` calibrates `http://t/a/b/`, and a seed at `/` is unchanged (no confine, so `dir_of`).
+Every row of the issue's matrix that already worked keeps its exact behaviour; the derivation
+never reaches outside what the operator typed.
+
+Separately, and as the general backstop: **an empty frontier after seeding is now a terminal
+`ErrorEvent`** (`Engine::NOTHING_TO_SEND`), not a `DoneEvent` with zero findings. This is the
+same [P4](#p4) argument `Engine::SEED_BLOCKED` records — an operator reads "0 found" as "there
+is nothing there" rather than "gori sent nothing" — applied to every present and future reason
+the frontier can come up empty, rather than to the one shape this issue found. After the fix
+above the remaining reason is a Layer-2 or containment refusal of the brute-force root on a
+`--no-spider` run, which is a decision worth naming out loud.
+
 ---
 
 *Keep this document honest against the code. When you change a subsystem it describes, update

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -588,6 +588,58 @@ same-origin and `boundary?` is never consulted. The only difference is that `all
 consulting Sandbox and EXCLUDE, and on an ordinary rule-less project with Sandbox off both are
 false — so those runs are byte-for-byte unaffected.
 
+### 2026-07-26: a request line refuses what frames it and encodes what merely breaks it
+
+Refines: [P7](#p7). Issue #394, the remaining half of the #390 review.
+
+`Headers.safe_url?` rejected CR and LF only, but `Sender#build_get` writes
+`GET #{target} HTTP/1.1\r\n` and **space is that line's field separator**. `Extract::ATTR`'s
+`"([^"]*)"` captures a space, `Url.resolve` strips only the ends, and `URI.parse` keeps it
+verbatim in `path` and `query` — so an ordinary `<a href="/my file.pdf">`, which is common in
+handwritten HTML, put `GET /my file.pdf HTTP/1.1` on a real socket. No attacker required. A
+lenient origin reads target `/my` and version `file.pdf`, so gori requests a resource it did
+not record; a strict one 400s, and that 400 diverges from the soft-404 baseline, which
+`Calibrate.hit?` scores at +0.50 — a false-POSITIVE source in the brute-forcer, not a cosmetic
+defect. The malformed line then persisted into the stored flow head via `Discover::Persist`
+(`Import::Builder::CONTROL_CHAR` is `[\x00-\x1f\x7f]`, which does not cover 0x20), so a
+byte-exact Repeater re-send reproduced it.
+
+The rule is now stated once, over the whole octet class rather than the two members each
+incident happened to name: **`Url.request_line_safe?` — no octet `<= 0x20` or `0x7F` reaches a
+request line raw.** That is the rule `src/gori/mcp/request_builder.cr`'s `reject_token_breakers`
+already applies to the method, the target and the host.
+
+The *remedy* splits, and the split is by what the octet does to the wire rather than by which
+issue found it:
+
+- **CR and LF frame.** They do not corrupt one request line, they end it and begin a second
+  message (#390). No author writes one into an href. They are **refused** — dropped at every
+  enqueue by `Headers.safe_url?`, refused at the wire by `Sender#fetch` — which keeps #390's
+  disposition intact. Encoding them instead would convert a splice attempt into a real request
+  for a URL nobody authored, and put `%0D%0A` rows in the operator's Sitemap.
+- **SP, TAB, DEL and the remaining C0 separate fields.** They break one line and cannot start a
+  second. A space in an href is a real resource a browser fetches, so refusing it would silently
+  shrink a crawl's coverage — the failure mode this project treats as worse than an error
+  ([P4](#p4)). They are **percent-encoded**, which is lossless and is what every browser does.
+
+Encoded at **parse** (`Url.parse`), not in `build_get`, because a URL must have exactly one
+spelling: `visit_key`, `template_key`, the Layer-2 gate question, the `Finding`, and the Sitemap
+row `Persist` writes all come off the same `Parts`. Encoding only at the wire would leave the
+raw octet in all five, so the scope would judge a different URL than the one sent — the exact
+two-spellings bug `Url.gate_url` and the seed's `Url.normalize` were introduced to kill. It also
+makes discover ask the gate the already-encoded form every other Layer-2 consumer sees, since
+those targets arrive off the wire from a real client. The encoding is idempotent (`%` is not in
+the class), which `#{bl.dir}#{cand}` and every re-crawled link rely on.
+
+The **host** is refused rather than repaired, by `Url.parse` returning nil: percent-encoding is
+defined for a path, not for a reg-name, and `Import::Builder::HOST_INVALID` already records that
+a real host never carries one of these octets.
+
+`Sender#fetch` now refuses the whole class rather than CR/LF. That costs no coverage — the
+repairable half never reaches it, having been encoded upstream — and it means the wire seam can
+state the invariant it is there to state: a Discover run never puts a malformed or doubled
+request line on a connection.
+
 ---
 
 *Keep this document honest against the code. When you change a subsystem it describes, update

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -604,13 +604,12 @@ defect. The malformed line then persisted into the stored flow head via `Discove
 (`Import::Builder::CONTROL_CHAR` is `[\x00-\x1f\x7f]`, which does not cover 0x20), so a
 byte-exact Repeater re-send reproduced it.
 
-The rule is now stated once, over the whole octet class rather than the two members each
-incident happened to name: **`Url.request_line_safe?` — no octet `<= 0x20` or `0x7F` reaches a
-request line raw.** That is the rule `src/gori/mcp/request_builder.cr`'s `reject_token_breakers`
-already applies to the method, the target and the host.
+The rule is not restated here. It is `Proxy::Codec::Http1.request_token_safe?` — no octet
+`<= 0x20` or `0x7F` reaches a request line raw — which the #397 fix made the one home for
+exactly this class, after gori hit it in three subsystems in a week. Discover adds only the
+part that is its own: a **repair** for the half of the class that has one.
 
-The *remedy* splits, and the split is by what the octet does to the wire rather than by which
-issue found it:
+The remedy splits by what the octet does to the wire, not by which issue found it:
 
 - **CR and LF frame.** They do not corrupt one request line, they end it and begin a second
   message (#390). No author writes one into an href. They are **refused** — dropped at every
@@ -621,6 +620,14 @@ issue found it:
   second. A space in an href is a real resource a browser fetches, so refusing it would silently
   shrink a crawl's coverage — the failure mode this project treats as worse than an error
   ([P4](#p4)). They are **percent-encoded**, which is lossless and is what every browser does.
+
+This is deliberately the opposite call from #397, which **refuses** an unsafe redirect
+`Location` on the same octet class, and the difference is provenance rather than inconsistency.
+A page's own `<a href>` is text that page authored and that a browser would encode before
+fetching, so encoding reproduces what the link meant. A redirect `Location` is named by whatever
+host answered; encoding it would invent a URL the origin never named while gori recorded it as
+sent. Same class, same one predicate, different answer because the input is a different kind of
+thing.
 
 Encoded at **parse** (`Url.parse`), not in `build_get`, because a URL must have exactly one
 spelling: `visit_key`, `template_key`, the Layer-2 gate question, the `Finding`, and the Sitemap
@@ -633,14 +640,26 @@ the class), which `#{bl.dir}#{cand}` and every re-crawled link rely on.
 
 The **host** is refused rather than repaired, by `Url.parse` returning nil: percent-encoding is
 defined for a path, not for a reg-name, and `Import::Builder::HOST_INVALID` already records that
-a real host never carries one of these octets.
+a real host never carries one of these octets. That refusal turned out to close the question
+#397 left open. #397 could not demonstrate a live path to the unguarded
+`CONNECT #{authority} HTTP/1.1` in `proxy/upstream.cr`; there is one, and it runs through here.
+A crawled `<a href="http://ac me.acme.test/x">` passes `Headers.safe_url?` (a space is not
+CR/LF) and `same_or_subdomain?` containment, and with an upstream proxy configured its host
+reaches `Upstream.dial_via_proxy` verbatim. Refusing at parse makes it unreachable, and refusing
+at parse is the only place that covers BOTH synthesized request lines — the GET and the CONNECT —
+since the CONNECT is built far below any Discover gate. `sender_spec` pins it on the socket.
 
 `Sender#fetch` now refuses the whole class rather than CR/LF. That costs no coverage — the
 repairable half never reaches it, having been encoded upstream — and it means the wire seam can
 state the invariant it is there to state: a Discover run never puts a malformed or doubled
 request line on a connection.
 
-### 2026-07-26: a path-confined run brute-forces its own subtree, and an empty frontier is an error
+One instance of the same root cause is knowingly left open, because it is outside this
+subsystem: `Import::Builder::CONTROL_CHAR` (`import/builder.cr`) still stops at `\x1f`, so a
+raw space in a request target imported from a HAR or `--urls` file is stored and replayed
+byte-exact. `HOST_INVALID` covers space, but only for the host.
+
+### 2026-07-26: a path-confined run brute-forces its own subtree, and a run that sends nothing says so
 
 Refines: [P4](#p4). Issue #395, adjacent to #393.
 
@@ -661,16 +680,33 @@ nothing to do" answers a question nobody asked: a seed path deeper than `/` mean
 rooted here* (`confined?`), so **the brute-force base is that subtree's root as a directory**,
 not the seed's containing directory. `/api` and `/api/` therefore both calibrate `http://t/api/`,
 `/a/b` calibrates `http://t/a/b/`, and a seed at `/` is unchanged (no confine, so `dir_of`).
-Every row of the issue's matrix that already worked keeps its exact behaviour; the derivation
-never reaches outside what the operator typed.
 
-Separately, and as the general backstop: **an empty frontier after seeding is now a terminal
-`ErrorEvent`** (`Engine::NOTHING_TO_SEND`), not a `DoneEvent` with zero findings. This is the
-same [P4](#p4) argument `Engine::SEED_BLOCKED` records — an operator reads "0 found" as "there
-is nothing there" rather than "gori sent nothing" — applied to every present and future reason
-the frontier can come up empty, rather than to the one shape this issue found. After the fix
-above the remaining reason is a Layer-2 or containment refusal of the brute-force root on a
-`--no-spider` run, which is a decision worth naming out loud.
+Two consequences are worth stating plainly rather than leaving a reader to discover them:
+
+- The base appends a slash the operator did not type. `/api` and `/api/` are distinct resources
+  on an origin that cares, and the probes now go under the latter. That is the only reading
+  under which a file-shaped seed has a subtree at all, and it is what `build_discover_seed`
+  already does when a run is seeded from Sitemap or History.
+- A file-shaped seed with the spider on now calibrates **twice**, at `/api/` and at the origin
+  root, where it previously calibrated once. The root calibration is the one #393 added to gate
+  `robots.txt`/`sitemap.xml`; it used to be reached because `enqueue_dir` had FAILED and left
+  `@dirs` empty. Both are needed once the subtree is really probed. The rows of the issue's
+  matrix that already brute-forced something — `http://t/` and `http://t/api/` — are unchanged
+  in both request count and destination.
+
+`Url.parse` also now collapses a trailing bare `.`, the one dot-segment shape it let through
+(`/a/.` trips none of `..`, `./`, `//`). That was harmless while nothing read the seed's path
+back, but this entry's derivation does: a seed of `/api/.` produced the confine `/api/.`, which
+nothing can satisfy, and the run went straight back to brute-forcing nothing.
+
+Separately, as the general backstop: **a run that puts no request on the wire now ends in a
+terminal `ErrorEvent`** (`Engine::NOTHING_TO_SEND`) rather than a `DoneEvent` with zero
+findings. The condition is the send counter, deliberately, and not "seeding enqueued nothing" —
+an empty frontier is only the shape this issue found. A frontier whose every task is refused
+later by the per-URL Layer-2 gate ends in exactly the same silence, and `SCOPE_REFUSED` is a
+benign error, so even the error count stays 0. That state became ordinary the moment the gate
+started re-reading the scope mid-run (entry below). A run the operator STOPPED is exempt:
+stopping before the first send is a decision, not a failure to have anything to do.
 
 ### 2026-07-26: Discover's Layer-2 gate reloads on the same schedule as every other sweep
 
@@ -696,8 +732,21 @@ last-known rules stay in force rather than the run breaking or failing open. Thr
 `Outbound` into the engine was rejected for the reason the `ScopePolicy` seam exists at all: the
 engine is deliberately Store-free ([§2.1](#s2-1)).
 
-`boundary?` deliberately does not reload. It is Layer 1, and its only caller (`bounded_url`)
-asks it immediately after `allowed?`, so it already reads rules that call refreshed.
+**`configured?` is snapshotted at construction, and that is the load-bearing half of this
+entry.** It answers "is there a scope to bound the crawl", which is what switches
+`Containment::ScopeAware` between the same-origin fallback and `boundary?` — a Layer-1 question.
+Delegating it live would let the reload rewrite the containment mode mid-run, and the direction
+it rewrites in is catastrophic: on a project with no rules, an operator adding the single
+canonical `exclude string logout` flips `configured?` false to true, and `matches_url?` requires
+at least one INCLUDE (`Scope#allowlisted_unlocked?` — an excludes-only scope is deliberately not
+an allowed range), so `boundary?` becomes false for every URL. The operator asked to skip one
+path and the whole crawl would stop, silently, which is the [P4](#p4) failure the entry above
+exists to remove. [§3](#s3) and the #354 entry already draw the line this respects: Layer 1's
+strictness is settled per surface before the first byte, Layer 2 is the layer that is identical
+everywhere and applied continuously. #396 asked for the second, not the first.
+
+`boundary?` itself needs no reload of its own: its only caller (`bounded_url`) asks it
+immediately after `allowed?`, so it already reads whatever that call refreshed.
 
 ---
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -672,6 +672,33 @@ the frontier can come up empty, rather than to the one shape this issue found. A
 above the remaining reason is a Layer-2 or containment refusal of the brute-force root on a
 `--no-spider` run, which is a decision worth naming out loud.
 
+### 2026-07-26: Discover's Layer-2 gate reloads on the same schedule as every other sweep
+
+Refines: [P5](#p5). Issue #396, surfaced by the review of #391.
+
+The entry above for #354 records one reload semantic for the active-traffic scope gate: the
+scope is re-read from its store before each Layer-2 check, throttled to
+`Outbound::RELOAD_INTERVAL`, "uniform for every LONG-RUNNING job … on all three surfaces".
+Discover was not honouring it. Its Layer 2 goes through the injected `ScopePolicy`
+(`StoreScope#allowed?`) and not through `Outbound#sweep_block`, so `Outbound#refresh` was never
+reached: `cli/run/discover.cr` and `mcp/tools/discover.cr` both use the `Outbound` for
+`Plan.build` plus the up-front Layer-1 guard and then hand the engine a policy that never calls
+back into it. The result was that `gori run project scope add exclude string logout` in a second
+terminal stopped an in-flight fuzz, mine or sequence within a second, while an in-flight
+discover — potentially thousands of probes — kept going against a start-time snapshot. Only the
+TUI was exempt, and by accident: it shares its live `Scope` object, which its own `data_version`
+poll reloads.
+
+`StoreScope#allowed?` now performs the same throttled reload, reusing
+`Outbound::RELOAD_INTERVAL` rather than naming a second interval — same clock-before-reload
+ordering so concurrent worker fibers cannot stampede the store, same swallowed failure so the
+last-known rules stay in force rather than the run breaking or failing open. Threading the
+`Outbound` into the engine was rejected for the reason the `ScopePolicy` seam exists at all: the
+engine is deliberately Store-free ([§2.1](#s2-1)).
+
+`boundary?` deliberately does not reload. It is Layer 1, and its only caller (`bounded_url`)
+asks it immediately after `allowed?`, so it already reads rules that call refreshed.
+
 ---
 
 *Keep this document honest against the code. When you change a subsystem it describes, update

--- a/spec/discover/adapters_spec.cr
+++ b/spec/discover/adapters_spec.cr
@@ -1,0 +1,117 @@
+require "../spec_helper"
+
+private alias D = Gori::Discover
+private alias R = Gori::Repeater::Result
+
+private def with_store(&)
+  path = File.tempname("gori-discover-adapters", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close rescue nil
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def notfound : R
+  head = "HTTP/1.1 404 X\r\nContent-Type: text/html\r\nContent-Length: 9\r\n\r\n".to_slice
+  R.new(head, "not found".to_slice, Gori::Proxy::Codec::Http1.parse_response_head(head), 1000_i64)
+end
+
+private class RouteBackend < D::Backend
+  def initialize(@route : String -> R)
+  end
+
+  def fetch(scheme : String, host : String, port : Int32, target : String) : R
+    @route.call(target)
+  end
+end
+
+# Issue #396 / DESIGN.md §7 ("one reload semantic for the active-traffic scope gate", #354).
+#
+# Discover's Layer 2 runs through the injected ScopePolicy rather than through
+# `Outbound#sweep_block`, so `Outbound#refresh` was never reached on the CLI or MCP and a
+# discover run judged every one of its (potentially thousands of) probes against a
+# start-time snapshot — while an in-flight fuzz/mine/sequence stopped within a second of the
+# same rule being written. These specs pay the wall-clock wait for the throttle window.
+describe Gori::Discover::StoreScope do
+  describe "reload semantics" do
+    it "honours a mid-run EXCLUDE once the throttle window elapses" do
+      with_store do |store|
+        scope = Gori::Scope.load(store)
+        scope.add("include", "host", "acme.test")
+        policy = D::StoreScope.new(scope)
+        policy.allowed?("https://acme.test/logout", "acme.test").should be_true
+
+        # What `gori run project scope add exclude ...` in a second terminal does: it writes
+        # to the SAME db, and nothing notifies the running job (P8 — the job pulls).
+        store.add_scope_rule("exclude", "string", "logout")
+
+        # Inside the window the run keeps its last-known rules — the deliberate tradeoff
+        # DESIGN.md §7 records, since a per-send DB read is what P6 rules out.
+        policy.allowed?("https://acme.test/logout", "acme.test").should be_true
+
+        sleep(Gori::Outbound::RELOAD_INTERVAL + 100.milliseconds)
+
+        policy.allowed?("https://acme.test/logout", "acme.test").should be_false
+        # Unrelated URLs are unaffected — the reload re-read the rules, it did not fail shut.
+        policy.allowed?("https://acme.test/users", "acme.test").should be_true
+      end
+    end
+
+    it "keeps the last-known scope when the reload fails (a closed store must not fail open)" do
+      path = File.tempname("gori-discover-closed", ".db")
+      store = Gori::Store.open(path)
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "acme.test")
+      scope.enable_sandbox
+      policy = D::StoreScope.new(scope)
+      store.close
+      begin
+        sleep(Gori::Outbound::RELOAD_INTERVAL + 100.milliseconds)
+        # The reload raises against the closed store and is swallowed: the rules loaded before
+        # the close stay in force, so Sandbox still blocks an off-allowlist host rather than
+        # the run dying or degrading to allow-everything.
+        policy.allowed?("https://acme.test/s", "acme.test").should be_true
+        policy.allowed?("https://other.test/s", "other.test").should be_false
+      ensure
+        File.delete?(path)
+        File.delete?("#{path}-wal")
+        File.delete?("#{path}-shm")
+      end
+    end
+
+    it "stops an in-flight discover run's brute-forcer" do
+      # The consequence the issue names, end to end: a run already underway must stop, not
+      # finish its wordlist. The exclude is written from inside the FIRST send, so the rule
+      # lands while the engine is mid-run exactly as a second terminal would place it.
+      with_store do |store|
+        scope = Gori::Scope.load(store)
+        cfg = D::Config.new(spider: false, bruteforce: true, calibrate_probes: 1,
+          concurrency: 1, retries: 0)
+        sent = [] of String
+        armed = false
+        backend = RouteBackend.new(->(t : String) do
+          sent << t
+          unless armed
+            armed = true
+            store.add_scope_rule("exclude", "host", "t")
+            sleep(Gori::Outbound::RELOAD_INTERVAL + 100.milliseconds)
+          end
+          notfound
+        end)
+        D::Engine.new("http://t/", %w[admin backup config], backend, cfg,
+          D::StoreScope.new(scope)).run { |_ev| }
+
+        # Only the calibration probe that armed the rule went out. Every wordlist candidate
+        # was refused afterwards — by `enqueue_probes` before it could reach the frontier, and
+        # by `send_with_retries` if it had.
+        sent.size.should eq(1)
+        sent.none?(&.includes?("admin")).should be_true
+      end
+    end
+  end
+end

--- a/spec/discover/adapters_spec.cr
+++ b/spec/discover/adapters_spec.cr
@@ -21,6 +21,24 @@ private def notfound : R
   R.new(head, "not found".to_slice, Gori::Proxy::Codec::Http1.parse_response_head(head), 1000_i64)
 end
 
+# A Scope whose `reload` raises once armed — the only way to exercise `StoreScope#refresh`'s
+# rescue, since a closed Store keeps answering.
+private class RaisingScope < Gori::Scope
+  getter reload_attempts = 0
+
+  def arm! : Nil
+    @armed = true
+  end
+
+  def reload : Nil
+    @reload_attempts += 1
+    raise "scope reload failed" if @armed
+    super
+  end
+
+  @armed = false
+end
+
 private class RouteBackend < D::Backend
   def initialize(@route : String -> R)
   end
@@ -62,25 +80,47 @@ describe Gori::Discover::StoreScope do
       end
     end
 
-    it "keeps the last-known scope when the reload fails (a closed store must not fail open)" do
-      path = File.tempname("gori-discover-closed", ".db")
-      store = Gori::Store.open(path)
-      scope = Gori::Scope.load(store)
-      scope.add("include", "host", "acme.test")
-      scope.enable_sandbox
-      policy = D::StoreScope.new(scope)
-      store.close
-      begin
+    it "keeps the last-known scope when the reload RAISES (must not fail open, must not die)" do
+      # Driven by a Scope whose `reload` actually raises. Closing the store is NOT enough to
+      # produce that: SQLite keeps serving the handle, so a spec written that way asserts
+      # nothing — it passes identically with the `rescue` deleted.
+      with_store do |store|
+        scope = RaisingScope.new(store, [] of Gori::Scope::Rule, true, false)
+        scope.add("include", "host", "acme.test")
+        scope.enable_sandbox
+        policy = D::StoreScope.new(scope)
+        scope.arm!
         sleep(Gori::Outbound::RELOAD_INTERVAL + 100.milliseconds)
-        # The reload raises against the closed store and is swallowed: the rules loaded before
-        # the close stay in force, so Sandbox still blocks an off-allowlist host rather than
-        # the run dying or degrading to allow-everything.
+        # The raise is swallowed and the rules loaded before it stay in force: Sandbox still
+        # blocks an off-allowlist host rather than the run dying or allowing everything.
         policy.allowed?("https://acme.test/s", "acme.test").should be_true
         policy.allowed?("https://other.test/s", "other.test").should be_false
-      ensure
-        File.delete?(path)
-        File.delete?("#{path}-wal")
-        File.delete?("#{path}-shm")
+        scope.reload_attempts.should be > 0
+      end
+    end
+
+    it "does not let the reload rewrite Layer-1 containment mid-run" do
+      # The reload is Layer 2 only. `configured?` decides whether ScopeAware containment uses
+      # the include boundary or falls back to same-origin, and on a rule-less project one
+      # added EXCLUDE would flip it true — at which point `matches_url?` refuses everything,
+      # because it requires at least one INCLUDE. The operator asked to skip one path; the
+      # whole crawl would stop.
+      with_store do |store|
+        scope = Gori::Scope.load(store)
+        policy = D::StoreScope.new(scope)
+        policy.configured?.should be_false
+
+        store.add_scope_rule("exclude", "string", "logout")
+        sleep(Gori::Outbound::RELOAD_INTERVAL + 100.milliseconds)
+
+        # Layer 2 bites — that is the whole point of #396 …
+        policy.allowed?("http://t/logout", "t").should be_false
+        # … while Layer 1 stays exactly as the surface settled it before the first byte, so an
+        # ordinary link is still judged by same-origin rather than by an empty allowlist.
+        policy.configured?.should be_false
+        policy.allowed?("http://t/users", "t").should be_true
+        # The live scope really did flip; only the policy's Layer-1 answer is pinned.
+        scope.configured?.should be_true
       end
     end
 

--- a/spec/discover/engine_spec.cr
+++ b/spec/discover/engine_spec.cr
@@ -322,6 +322,95 @@ describe Gori::Discover::Engine do
     urls.should_not contain("http://t/api-internal/secret") # sibling prefix — must be excluded
   end
 
+  # Issue #395. The brute-force base came from `Url.dir_of(seed)` while the confine came from
+  # the seed's full path, and for a file-shaped seed the two disagreed: `dir_of("http://t/api")`
+  # is the origin root, which `@confine_path` of "/api" then refuses. The seed's own subtree
+  # was never probed, and with --no-spider that was the entire run.
+  describe "a file-shaped seed" do
+    it "brute-forces its own subtree rather than nothing" do
+      cfg = D::Config.new(spider: false, bruteforce: true, calibrate_probes: 2, concurrency: 1,
+        retries: 0, confidence_floor: 0.4)
+      sent = [] of String
+      findings, _ = run_discover("http://t/api", ["admin"], cfg) do |t|
+        sent << t
+        t == "/api/admin" ? html("a real admin page under the api subtree") : notfound
+      end
+      # Calibration probes + the wordlist entry, all under /api/ — never at the origin root,
+      # which is outside what the operator typed.
+      sent.should_not be_empty
+      sent.should contain("/api/admin")
+      sent.all?(&.starts_with?("/api/")).should be_true
+      findings.map(&.url).should contain("http://t/api/admin")
+    end
+
+    it "keeps the brute-force base inside the confine for a deeper path and a query seed" do
+      cfg = D::Config.new(spider: false, bruteforce: true, calibrate_probes: 1, concurrency: 1, retries: 0)
+      %w(http://t/a/b http://t/api?x=1 http://t:8080/api).each do |seed|
+        sent = [] of String
+        run_discover(seed, ["admin"], cfg) do |t|
+          sent << t
+          notfound
+        end
+        base = seed.includes?("/a/b") ? "/a/b/" : "/api/"
+        sent.should_not be_empty
+        sent.all?(&.starts_with?(base)).should be_true
+      end
+    end
+
+    it "leaves a directory seed and an origin seed calibrating exactly where they did" do
+      # The control: the two rows of the issue's matrix that already worked must not move.
+      cfg = D::Config.new(spider: false, bruteforce: true, calibrate_probes: 1, concurrency: 1, retries: 0)
+      {"http://t/api/" => "/api/", "http://t/" => "/"}.each do |seed, base|
+        sent = [] of String
+        run_discover(seed, ["admin"], cfg) { |t| sent << t; notfound }
+        sent.should contain("#{base}admin")
+        sent.all?(&.starts_with?(base)).should be_true
+      end
+    end
+  end
+
+  # Issue #395, the general half: a run that sends nothing must say so.
+  describe "a run whose frontier comes up empty" do
+    it "ends in a terminal ErrorEvent instead of a clean 0-finding Done" do
+      # Brute-force only, with the seed's own subtree refused by Layer 2. The seed itself is
+      # allowed, so SEED_BLOCKED does not fire — yet not one request would go out.
+      #
+      # `concurrency: 4` is load-bearing, not decoration: the terminal event is emitted after
+      # the ordinary shutdown (close @jobs, join every worker), so if this path ever returned
+      # early instead, the four worker fibers would park on `@jobs.receive?` forever and this
+      # example would hang rather than fail.
+      cfg = D::Config.new(spider: false, bruteforce: true, calibrate_probes: 2, concurrency: 4, retries: 0)
+      sent = [] of String
+      backend = RouteBackend.new(->(t : String) { sent << t; notfound })
+      engine = D::Engine.new("http://t/api", ["admin"], backend, cfg,
+        DenyExact.new(Set{"http://t/api/"}))
+      kinds = [] of Symbol
+      messages = [] of String
+      engine.run do |ev|
+        case ev
+        when D::ErrorEvent then kinds << :error; messages << ev.message
+        when D::DoneEvent  then kinds << :done
+        end
+      end
+      kinds.should eq([:error])
+      messages.first.should eq(D::Engine::NOTHING_TO_SEND)
+      sent.should be_empty
+    end
+
+    it "still emits a normal Done when the frontier had work (the control)" do
+      cfg = D::Config.new(spider: false, bruteforce: true, calibrate_probes: 1, concurrency: 1, retries: 0)
+      kinds = [] of Symbol
+      backend = RouteBackend.new(->(_t : String) { notfound })
+      D::Engine.new("http://t/api", ["admin"], backend, cfg).run do |ev|
+        case ev
+        when D::ErrorEvent then kinds << :error
+        when D::DoneEvent  then kinds << :done
+        end
+      end
+      kinds.should eq([:done])
+    end
+  end
+
   # Issue #364 / DESIGN.md §7: the seed and its two derived well-known paths waive Layer 1,
   # the containment mode and the path confine — but never Layer 2 (Sandbox + EXCLUDE).
   describe "the Layer-2 gate on the seed trio" do

--- a/spec/discover/engine_spec.cr
+++ b/spec/discover/engine_spec.cr
@@ -14,6 +14,32 @@ private class RouteBackend < D::Backend
   end
 end
 
+# Records the HOST of every fetch, not just the target — the only way to see what would have
+# gone onto a CONNECT line (`Upstream.dial_via_proxy` builds it from this argument).
+private class HostRecordingBackend < D::Backend
+  def initialize(@hosts : Array(String), @route : String -> R)
+  end
+
+  def fetch(scheme : String, host : String, port : Int32, target : String) : R
+    @hosts << host
+    @route.call(target)
+  end
+end
+
+# Drive an engine to completion and return {terminal event kinds, error messages}. The KINDS
+# list is what distinguishes a terminal error from an error followed by a success Done.
+private def terminal_of(engine : D::Engine) : {Array(Symbol), Array(String)}
+  kinds = [] of Symbol
+  messages = [] of String
+  engine.run do |ev|
+    case ev
+    when D::ErrorEvent then kinds << :error; messages << ev.message
+    when D::DoneEvent  then kinds << :done
+    end
+  end
+  {kinds, messages}
+end
+
 private def make(status : Int32, body : String, ctype : String? = "text/html", location : String? = nil) : R
   head = String.build do |s|
     s << "HTTP/1.1 " << status << " X\r\n"
@@ -343,9 +369,40 @@ describe Gori::Discover::Engine do
       findings.map(&.url).should contain("http://t/api/admin")
     end
 
+    it "brute-forces a seed whose path ends in a bare dot" do
+      # `/api/.` is the one dot-segment shape `Url.parse` used to leave alone, which made
+      # `@confine_path` unsatisfiable — nothing derived can equal `/api/.`, so the run went
+      # back to sending nothing. Normalizing it at parse is what keeps #395 true for this
+      # shape too.
+      cfg = D::Config.new(spider: false, bruteforce: true, calibrate_probes: 1, concurrency: 1, retries: 0)
+      sent = [] of String
+      run_discover("http://t/api/.", ["admin"], cfg) { |t| sent << t; notfound }
+      sent.should contain("/api/admin")
+    end
+
+    it "drops a crawled link whose HOST carries a space, before it can reach a CONNECT line" do
+      # The sweep's chain for the #394 class: `<a href="http://ac me.acme.test/x">` passes
+      # `Headers.safe_url?` (a space is not CR/LF) and `same_or_subdomain?` containment, so on
+      # the way to the wire it would have reached `Upstream.dial_via_proxy`, which writes
+      # `CONNECT ac me.acme.test:80 HTTP/1.1` with no validation of its own. `Url.parse`
+      # refusing the host is what makes that unreachable; the byte-level half is in
+      # sender_spec's "with an upstream proxy configured".
+      cfg = D::Config.new(spider: true, bruteforce: false, max_depth: 4, concurrency: 1,
+        retries: 0, containment: D::Containment::HostAndSubdomains)
+      hosts = [] of String
+      backend = HostRecordingBackend.new(hosts, ->(t : String) {
+        t == "/" ? html(%(<a href="http://ac me.acme.test/x">spaced host</a> <a href="http://ok.acme.test/y">ok</a>)) : html("an ordinary page")
+      })
+      D::Engine.new("http://acme.test/", [] of String, backend, cfg).run { |_ev| }
+      # The control: a sibling subdomain link on the same page WAS crawled, so this is a
+      # verdict about the host guard and not about a crawl that never happened.
+      hosts.should contain("ok.acme.test")
+      hosts.none?(&.includes?(' ')).should be_true
+    end
+
     it "keeps the brute-force base inside the confine for a deeper path and a query seed" do
       cfg = D::Config.new(spider: false, bruteforce: true, calibrate_probes: 1, concurrency: 1, retries: 0)
-      %w(http://t/a/b http://t/api?x=1 http://t:8080/api).each do |seed|
+      %w[http://t/a/b http://t/api?x=1 http://t:8080/api].each do |seed|
         sent = [] of String
         run_discover(seed, ["admin"], cfg) do |t|
           sent << t
@@ -369,45 +426,52 @@ describe Gori::Discover::Engine do
     end
   end
 
-  # Issue #395, the general half: a run that sends nothing must say so.
-  describe "a run whose frontier comes up empty" do
-    it "ends in a terminal ErrorEvent instead of a clean 0-finding Done" do
+  # Issue #395, the general half: a run that puts nothing on the wire must say so. The
+  # condition is the SEND COUNTER, not an empty frontier — an empty frontier is only the
+  # shape #395 found.
+  describe "a run that sends nothing" do
+    it "ends in a terminal ErrorEvent when seeding enqueued nothing" do
       # Brute-force only, with the seed's own subtree refused by Layer 2. The seed itself is
       # allowed, so SEED_BLOCKED does not fire — yet not one request would go out.
-      #
-      # `concurrency: 4` is load-bearing, not decoration: the terminal event is emitted after
-      # the ordinary shutdown (close @jobs, join every worker), so if this path ever returned
-      # early instead, the four worker fibers would park on `@jobs.receive?` forever and this
-      # example would hang rather than fail.
       cfg = D::Config.new(spider: false, bruteforce: true, calibrate_probes: 2, concurrency: 4, retries: 0)
       sent = [] of String
       backend = RouteBackend.new(->(t : String) { sent << t; notfound })
       engine = D::Engine.new("http://t/api", ["admin"], backend, cfg,
         DenyExact.new(Set{"http://t/api/"}))
-      kinds = [] of Symbol
-      messages = [] of String
-      engine.run do |ev|
-        case ev
-        when D::ErrorEvent then kinds << :error; messages << ev.message
-        when D::DoneEvent  then kinds << :done
-        end
-      end
+      kinds, messages = terminal_of(engine)
+      kinds.should eq([:error])
+      messages.first.should eq(D::Engine::NOTHING_TO_SEND)
+      sent.should be_empty
+      # The terminal event is emitted AFTER the ordinary shutdown, never by returning early:
+      # with `concurrency: 4` an early return would leave four worker fibers parked on
+      # `@jobs.receive?` forever. `engine.run` would still return (it only waits on @events),
+      # so the leak is invisible unless the closed channel is asserted directly.
+      engine.@jobs.closed?.should be_true
+    end
+
+    it "ends in a terminal ErrorEvent when the frontier had work but every send was refused" do
+      # The half an empty-frontier test cannot see, and the one that became ordinary with #396:
+      # the seed IS enqueued (its Layer-2 check at construction passes, so SEED_BLOCKED does
+      # not fire) and then every send is refused per-URL in `send_with_retries`. This is
+      # exactly the shape a mid-run EXCLUDE now produces. `SCOPE_REFUSED` is a benign error, so
+      # `errors` stays 0 too — without the send-counter condition the run is completely silent.
+      cfg = D::Config.new(spider: true, bruteforce: false, concurrency: 1, retries: 0)
+      sent = [] of String
+      backend = RouteBackend.new(->(t : String) { sent << t; notfound })
+      engine = D::Engine.new("http://t/api", [] of String, backend, cfg, DenyAfterFirstAsk.new)
+      kinds, messages = terminal_of(engine)
       kinds.should eq([:error])
       messages.first.should eq(D::Engine::NOTHING_TO_SEND)
       sent.should be_empty
     end
 
-    it "still emits a normal Done when the frontier had work (the control)" do
+    it "still emits a normal Done as soon as ONE request goes out (the control)" do
       cfg = D::Config.new(spider: false, bruteforce: true, calibrate_probes: 1, concurrency: 1, retries: 0)
-      kinds = [] of Symbol
-      backend = RouteBackend.new(->(_t : String) { notfound })
-      D::Engine.new("http://t/api", ["admin"], backend, cfg).run do |ev|
-        case ev
-        when D::ErrorEvent then kinds << :error
-        when D::DoneEvent  then kinds << :done
-        end
-      end
+      sent = [] of String
+      backend = RouteBackend.new(->(t : String) { sent << t; notfound })
+      kinds, _ = terminal_of(D::Engine.new("http://t/api", ["admin"], backend, cfg))
       kinds.should eq([:done])
+      sent.should_not be_empty
     end
   end
 

--- a/spec/discover/engine_spec.cr
+++ b/spec/discover/engine_spec.cr
@@ -439,6 +439,25 @@ describe Gori::Discover::Engine do
       findings.map(&.url).none?(&.includes?("evil.test")).should be_true
     end
 
+    # Issue #394, the other half of the same octet class. A raw SPACE is NOT dropped: it is
+    # what handwritten HTML actually contains, so dropping it would silently shrink coverage
+    # and lose a real endpoint. It is percent-encoded at parse, which gives the URL one
+    # spelling for the wire, the scope question, the finding and the Sitemap row alike.
+    it "percent-encodes a crawled link carrying a raw space instead of dropping it" do
+      cfg = D::Config.new(spider: true, bruteforce: false, max_depth: 4, concurrency: 1, retries: 0)
+      sent = [] of String
+      findings, _ = run_discover("http://t/", [] of String, cfg) do |t|
+        sent << t
+        t == "/" ? html(%(<a href="/my file.pdf">doc</a> <a href="/rep ort?q=a b">q</a>)) : html("a real document body")
+      end
+      sent.should contain("/my%20file.pdf")
+      sent.should contain("/rep%20ort?q=a%20b")
+      sent.none?(&.includes?(' ')).should be_true
+      # The finding — and therefore the Sitemap row `Persist` writes from it — carries the
+      # same encoded spelling, so a byte-exact Repeater re-send reproduces a valid request.
+      findings.map(&.url).should contain("http://t/my%20file.pdf")
+    end
+
     it "is dropped when the CRLF sits in the QUERY rather than the path" do
       # `URI.parse("http://t/a?q=1\r\nX: 1").query` keeps the CR/LF, and send_with_retries
       # rebuilds the target as "#{path}?#{query}" — so a path-only check would miss this.

--- a/spec/discover/sender_spec.cr
+++ b/spec/discover/sender_spec.cr
@@ -49,6 +49,41 @@ private def wire_bytes(&) : String
   bytes
 end
 
+# The first line a fake UPSTREAM PROXY receives while `block` runs, or "" if nothing ever
+# connected. `Upstream.dial_via_proxy` synthesizes `CONNECT #{host}:#{port} HTTP/1.1` out of
+# the host it is handed, so this reads the second request line a Discover send can produce.
+private def connect_line(&) : String
+  proxy = TCPServer.new("127.0.0.1", 0)
+  seen = Channel(String).new(1)
+  spawn do
+    if conn = proxy.accept?
+      begin
+        conn.read_timeout = 500.milliseconds
+        seen.send(conn.gets("\r\n", chomp: true) || "")
+        conn << "HTTP/1.1 200 Connection established\r\n\r\n"
+        conn.flush
+      rescue
+        seen.send("") rescue nil
+      end
+      conn.close rescue nil
+    end
+  rescue
+  end
+  Gori::Settings.upstream_proxy = "127.0.0.1:#{proxy.local_address.port}"
+  begin
+    yield
+    select
+    when got = seen.receive
+      got
+    when timeout(2.seconds)
+      "" # never dialled
+    end
+  ensure
+    Gori::Settings.upstream_proxy = ""
+    proxy.close rescue nil
+  end
+end
+
 # Request lines on the wire: "<METHOD> <target> HTTP/1.1". The whole point of #390 is that
 # there can be more than one, so this counts them rather than parsing the first.
 private def request_lines(wire : String) : Array(String)
@@ -116,6 +151,36 @@ describe Gori::Discover::Sender do
     end
     request_lines(wire).should eq(["GET /my%20file.pdf?q=a%20b HTTP/1.1"])
     wire.should match(/\AGET \/my%20file\.pdf\?q=a%20b HTTP\/1\.1\r\nHost: 127\.0\.0\.1:\d+\r\n/)
+  end
+
+  # The CONNECT line is the second request line a Discover send can synthesize, and it is
+  # built far below any Discover gate — `Upstream.dial_via_proxy` writes
+  # `CONNECT #{host}:#{port} HTTP/1.1` out of the host string it is handed
+  # (`proxy/upstream.cr`), with no validation of its own. #397 could not demonstrate a live
+  # path to it; the sweep for #394 found one that runs through Discover, since a crawled
+  # `<a href="http://ac me.acme.test/x">` passes `Headers.safe_url?` (space is not CR/LF) and
+  # `same_or_subdomain?` containment.
+  describe "with an upstream proxy configured" do
+    it "never puts a corrupt authority on the CONNECT line" do
+      result = nil.as(Gori::Repeater::Result?)
+      line = connect_line do
+        result = D::Sender.new(verify: false, timeout: 2.seconds)
+          .fetch("http", "ac me.acme.test", 80, "/x")
+      end
+      # Nothing was dialled at all: the wire-seam guard checks the HOST as well as the target,
+      # so `CONNECT ac me.acme.test:80 HTTP/1.1` — three tokens where the proxy expects two —
+      # is unreachable.
+      line.should eq("")
+      result.not_nil!.error.should eq(D::Sender::UNSAFE_URL)
+    end
+
+    it "still CONNECTs normally for an ordinary host (the control)" do
+      # Without this the example above would pass against a harness that never observes a
+      # CONNECT at all.
+      connect_line do
+        D::Sender.new(verify: false, timeout: 2.seconds).fetch("http", "acme.test", 80, "/x")
+      end.should eq("CONNECT acme.test:80 HTTP/1.1")
+    end
   end
 
   it "sends nothing when the HOST carries a raw CRLF" do

--- a/spec/discover/sender_spec.cr
+++ b/spec/discover/sender_spec.cr
@@ -85,6 +85,39 @@ describe Gori::Discover::Sender do
     result.not_nil!.error.should eq(D::Sender::UNSAFE_URL)
   end
 
+  it "sends nothing at all when the target carries a raw SPACE (request-line corruption)" do
+    # Issue #394. Space is the request line's field separator, so #390's CR/LF-only guard let
+    # this through: the issue captured `GET /my file.pdf HTTP/1.1` off a real socket, which a
+    # lenient origin reads as target `/my` + version `file.pdf`, and a strict one 400s — a 400
+    # that diverges from the soft-404 baseline and scores +0.50 in `Calibrate.hit?`.
+    #
+    # Nothing legitimate is refused by this line: `Url.parse` has already percent-encoded a
+    # spaced href upstream (see the next example), so the only target that reaches here with a
+    # raw space is one no repair applies to.
+    result = nil.as(Gori::Repeater::Result?)
+    wire = wire_bytes do |port|
+      result = D::Sender.new(verify: false, timeout: 2.seconds).fetch("http", "127.0.0.1", port, "/my file.pdf")
+    end
+    wire.should eq("")
+    result.not_nil!.error.should eq(D::Sender::UNSAFE_URL)
+  end
+
+  it "puts the encoded form of a spaced link on the wire as ONE well-formed request line" do
+    # The other half of #394, end to end at the byte level: the href a page carries
+    # (`/my file.pdf`) goes through the same `Url.parse` the engine uses, and what lands on
+    # the socket is the request a browser would have sent. A URL-string assertion could not
+    # have shown this — #390's lesson.
+    target = begin
+      p = D::Url.parse("http://127.0.0.1/my file.pdf?q=a b").not_nil!
+      "#{p.path}?#{p.query}"
+    end
+    wire = wire_bytes do |port|
+      D::Sender.new(verify: false, timeout: 2.seconds).fetch("http", "127.0.0.1", port, target)
+    end
+    request_lines(wire).should eq(["GET /my%20file.pdf?q=a%20b HTTP/1.1"])
+    wire.should match(/\AGET \/my%20file\.pdf\?q=a%20b HTTP\/1\.1\r\nHost: 127\.0\.0\.1:\d+\r\n/)
+  end
+
   it "sends nothing when the HOST carries a raw CRLF" do
     # `URI.parse("http://ev\r\nil.test/a").host` is `"ev\r\nil.test"` verbatim, and the host is
     # spliced into the `Host` header — so checking only the target would leave this open.

--- a/spec/discover/url_spec.cr
+++ b/spec/discover/url_spec.cr
@@ -193,4 +193,95 @@ describe Gori::Discover::Url do
       U.template_key(U.parse("http://h/s?a=1&&b=2").not_nil!).should eq("http://h/s?a&b")
     end
   end
+
+  # Issue #394. `Sender#build_get` writes "GET #{target} HTTP/1.1", so space is the request
+  # line's field separator — and `URI.parse` keeps a raw one verbatim in both path and query.
+  # The class is every octet <= 0x20 plus DEL; the remedy splits by what the octet does.
+  describe "request-line octets" do
+    describe ".request_line_safe?" do
+      it "is false for every octet <= 0x20 and for DEL, true above them" do
+        (0..0x20).each { |b| U.request_line_safe?("/a#{b.unsafe_chr}b").should be_false }
+        U.request_line_safe?("/a\u007Fb").should be_false
+        U.request_line_safe?("/a~b").should be_true # 0x7E, the char below DEL
+        U.request_line_safe?("/my%20file.pdf?q=1&r=2").should be_true
+      end
+
+      it "is true for a multi-byte UTF-8 path (the check is byte-wise, not char-wise)" do
+        # Every continuation byte is >= 0x80, so a non-ASCII path must not be caught by a
+        # test written against the 0x00..0x20 range.
+        U.request_line_safe?("/문서/파일.pdf").should be_true
+      end
+    end
+
+    describe ".parse" do
+      it "percent-encodes a raw space in the path — the #394 repro" do
+        # `<a href="/my file.pdf">` is ordinary handwritten HTML; a browser fetches
+        # /my%20file.pdf. Rejecting it would silently shrink the crawl's coverage.
+        p = U.parse("http://h/my file.pdf").not_nil!
+        p.path.should eq("/my%20file.pdf")
+        U.request_line_safe?(p.path).should be_true
+      end
+
+      it "percent-encodes a raw space in the query" do
+        p = U.parse("http://h/s?q=1 2&r=3").not_nil!
+        p.query.should eq("q=1%202&r=3")
+      end
+
+      it "percent-encodes TAB, DEL and the other C0 octets" do
+        U.parse("http://h/a\tb").not_nil!.path.should eq("/a%09b")
+        U.parse("http://h/a\u007Fb").not_nil!.path.should eq("/a%7Fb")
+        U.parse("http://h/a\vb").not_nil!.path.should eq("/a%0Bb")
+      end
+
+      it "leaves CR and LF RAW so the refusal gates still see them (#390's disposition)" do
+        # The framing half is dropped, not repaired: `Headers.safe_url?` refuses such a URL at
+        # every enqueue and `Sender#fetch` refuses it at the wire. Encoding it here would turn
+        # a splice attempt into a real request for a URL nobody authored.
+        p = U.parse("http://h/a\r\nX-Injected: 1").not_nil!
+        # The space in the injected header line IS encoded — the two halves are independent,
+        # and what matters is that the CR/LF survive so the gates below can still refuse.
+        p.path.should eq("/a\r\nX-Injected:%201")
+        Gori::Discover::Headers.safe_url?(p).should be_false
+        U.request_line_safe?(p.path).should be_false
+      end
+
+      it "is idempotent — an already-encoded path never becomes %2520" do
+        # `#{bl.dir}#{cand}` re-parses a path this method produced, and so does every
+        # re-crawled link. `%` is not in the class, so nothing re-encodes.
+        once = U.parse("http://h/my file.pdf").not_nil!
+        twice = U.parse(U.normalize(once)).not_nil!
+        twice.path.should eq("/my%20file.pdf")
+        U.parse("http://h/a%20b").not_nil!.path.should eq("/a%20b")
+      end
+
+      it "refuses a host carrying a request-line octet rather than encoding it" do
+        # `URI.parse("http://a b/x").host` is "a b" verbatim. Percent-encoding is defined for
+        # a path, not a reg-name, so there is nothing to repair — nil, the same exit every
+        # unparseable URL takes.
+        U.parse("http://a b/x").should be_nil
+        U.parse("http://h /x").should be_nil
+        U.parse("http://ev\r\nil.test/a").should be_nil
+      end
+
+      it "gives the URL ONE spelling across identity, the gate question and the finding" do
+        # The reason this is repaired at parse and not in `build_get`: these five strings all
+        # come off the same Parts, and a raw space left in any of them would make the scope
+        # judge a different URL than the one sent, and `Persist` write a corrupt Sitemap row.
+        p = U.parse("http://h/my file.pdf?q=a b").not_nil!
+        U.normalize(p).should eq("http://h/my%20file.pdf?q=a%20b")
+        U.gate_url(p).should eq("http://h/my%20file.pdf?q=a%20b")
+        U.visit_key(p).should eq("http://h/my%20file.pdf?q=a%20b")
+        U.template_key(p).should eq("http://h/my%20file.pdf?q")
+        U.dir_of(p).should eq("http://h/")
+      end
+    end
+
+    describe ".resolve into .parse" do
+      it "carries a spaced href through to an encoded, sendable URL" do
+        base = U.parse("http://h/dir/page").not_nil!
+        abs = U.resolve(base, "my file.pdf").not_nil!
+        U.parse(abs).not_nil!.path.should eq("/dir/my%20file.pdf")
+      end
+    end
+  end
 end

--- a/spec/discover/url_spec.cr
+++ b/spec/discover/url_spec.cr
@@ -121,6 +121,19 @@ describe Gori::Discover::Url do
       U.parse("http://h/a/./b").not_nil!.path.should eq("/a/b")
     end
 
+    it "collapses a TRAILING bare dot, which the other dot-segment shapes do not cover" do
+      # `/a/.` trips none of `..`, `./`, `//`, so it used to survive un-normalized — the one
+      # dot-segment shape `parse` let through. It matters since #395 derives the brute-force
+      # base from the seed's path: a `@confine_path` of `/api/.` is unsatisfiable, because
+      # every URL derived from it comes back through here normalized.
+      U.parse("http://h/a/.").not_nil!.path.should eq("/a")
+      U.parse("http://h/.").not_nil!.path.should eq("/")
+      # A leading dot is an ordinary segment name and must NOT be touched.
+      U.parse("http://h/a/.env").not_nil!.path.should eq("/a/.env")
+      U.parse("http://h/.well-known/x").not_nil!.path.should eq("/.well-known/x")
+      U.parse("http://h/a/./b").not_nil!.path.should eq("/a/b")
+    end
+
     it "defaults an empty path to /" do
       U.parse("http://h").not_nil!.path.should eq("/")
     end
@@ -198,18 +211,42 @@ describe Gori::Discover::Url do
   # line's field separator — and `URI.parse` keeps a raw one verbatim in both path and query.
   # The class is every octet <= 0x20 plus DEL; the remedy splits by what the octet does.
   describe "request-line octets" do
-    describe ".request_line_safe?" do
+    # The class itself has ONE home (`Codec::Http1.request_token_safe?`, #397) and is specced
+    # there. What has to be pinned HERE is that Discover's per-octet repair set agrees with it
+    # exactly: the encoder needs a per-BYTE test and cannot call a string predicate once per
+    # byte, so the class is written twice — this is what stops the two drifting.
+    it "encodes exactly the class the codec refuses, minus the framing pair" do
+      # The expectation is DERIVED from the codec's predicate, never a second copy of the
+      # range, so widening the class there and not here fails this example. Measured through
+      # `parse` rather than the private per-byte helper: what matters is the octet a request
+      # line would carry. NUL is skipped — `URI.parse` truncates the path at one, so it never
+      # reaches the encoder to be observed.
+      (0x01..0x7F).each do |b|
+        c = b.unsafe_chr
+        path = U.parse("http://h/x#{c}y").try(&.path)
+        next if path.nil?
+        refused = !Gori::Proxy::Codec::Http1.request_token_safe?(c.to_s)
+        framing = b == 0x0d || b == 0x0a
+        if refused && !framing
+          path.should eq("/x%#{b.to_s(16, upcase: true).rjust(2, '0')}y"), "octet 0x#{b.to_s(16)}"
+        elsif framing
+          path.should eq("/x#{c}y"), "framing octet 0x#{b.to_s(16)} must stay raw"
+        end
+      end
+    end
+
+    describe "the codec's class, as Discover applies it" do
       it "is false for every octet <= 0x20 and for DEL, true above them" do
-        (0..0x20).each { |b| U.request_line_safe?("/a#{b.unsafe_chr}b").should be_false }
-        U.request_line_safe?("/a\u007Fb").should be_false
-        U.request_line_safe?("/a~b").should be_true # 0x7E, the char below DEL
-        U.request_line_safe?("/my%20file.pdf?q=1&r=2").should be_true
+        (0..0x20).each { |b| Gori::Proxy::Codec::Http1.request_token_safe?("/a#{b.unsafe_chr}b").should be_false }
+        Gori::Proxy::Codec::Http1.request_token_safe?("/a\u007Fb").should be_false
+        Gori::Proxy::Codec::Http1.request_token_safe?("/a~b").should be_true # 0x7E, the char below DEL
+        Gori::Proxy::Codec::Http1.request_token_safe?("/my%20file.pdf?q=1&r=2").should be_true
       end
 
       it "is true for a multi-byte UTF-8 path (the check is byte-wise, not char-wise)" do
         # Every continuation byte is >= 0x80, so a non-ASCII path must not be caught by a
         # test written against the 0x00..0x20 range.
-        U.request_line_safe?("/문서/파일.pdf").should be_true
+        Gori::Proxy::Codec::Http1.request_token_safe?("/문서/파일.pdf").should be_true
       end
     end
 
@@ -219,7 +256,7 @@ describe Gori::Discover::Url do
         # /my%20file.pdf. Rejecting it would silently shrink the crawl's coverage.
         p = U.parse("http://h/my file.pdf").not_nil!
         p.path.should eq("/my%20file.pdf")
-        U.request_line_safe?(p.path).should be_true
+        Gori::Proxy::Codec::Http1.request_token_safe?(p.path).should be_true
       end
 
       it "percent-encodes a raw space in the query" do
@@ -242,7 +279,7 @@ describe Gori::Discover::Url do
         # and what matters is that the CR/LF survive so the gates below can still refuse.
         p.path.should eq("/a\r\nX-Injected:%201")
         Gori::Discover::Headers.safe_url?(p).should be_false
-        U.request_line_safe?(p.path).should be_false
+        Gori::Proxy::Codec::Http1.request_token_safe?(p.path).should be_false
       end
 
       it "is idempotent — an already-encoded path never becomes %2520" do

--- a/src/gori/discover/adapters.cr
+++ b/src/gori/discover/adapters.cr
@@ -12,9 +12,11 @@ module Gori::Discover
   # include allowlist is the boundary for scope-aware containment.
   class StoreScope < ScopePolicy
     @last_reload : Time::Instant
+    @configured : Bool
 
     def initialize(@scope : Gori::Scope)
       @last_reload = Time.instant
+      @configured = @scope.configured?
     end
 
     # Layer 2, and therefore the line that owes DESIGN.md §7's "one reload semantic for the
@@ -33,14 +35,29 @@ module Gori::Discover
       !@scope.sandbox_blocks?(url, host) && !@scope.excluded?(url, host)
     end
 
-    # Layer 1, and deliberately NOT reloaded: its only caller (`Engine#bounded_url`) asks it
-    # immediately after `allowed?`, so it already reads whatever that call refreshed.
+    # Layer 1, whose only caller (`Engine#bounded_url`) asks it immediately after `allowed?`,
+    # so it already reads whatever that call refreshed.
     def boundary?(url : String, host : String) : Bool
       @scope.matches_url?(url, host)
     end
 
+    # Layer 1, and SNAPSHOT at construction on purpose — the one thing the #396 reload must
+    # not make mutable.
+    #
+    # This answers "does a scope exist to bound the crawl", which is what switches
+    # `Containment::ScopeAware` between the same-origin fallback and `boundary?`. Delegating
+    # it live would let the reload rewrite the containment mode mid-run, and the direction it
+    # rewrites in is catastrophic: on a project with NO rules, an operator adding the single
+    # canonical `exclude string logout` flips `configured?` false→true, and `matches_url?`
+    # requires at least one INCLUDE (`Scope#allowlisted_unlocked?` — an excludes-only scope is
+    # deliberately not an allowed range), so `boundary?` becomes false for EVERY url. The
+    # operator asked to skip one path and the whole crawl would stop, silently.
+    #
+    # DESIGN.md §3 and the #354 entry already draw this line: Layer 1's strictness is settled
+    # per surface before the first byte, Layer 2 is the layer that is identical everywhere and
+    # applied continuously. #396 asked for the second, not the first.
     def configured? : Bool
-      @scope.configured?
+      @configured
     end
 
     # `Outbound#refresh`, mirrored rather than re-decided — including the interval constant, so

--- a/src/gori/discover/adapters.cr
+++ b/src/gori/discover/adapters.cr
@@ -1,5 +1,6 @@
 require "./types"
 require "./engine"
+require "../outbound"
 require "../scope"
 require "../import/builder"
 
@@ -10,19 +11,52 @@ module Gori::Discover
   # ScopePolicy over the project's Gori::Scope: excludes + sandbox deny in every mode; the
   # include allowlist is the boundary for scope-aware containment.
   class StoreScope < ScopePolicy
+    @last_reload : Time::Instant
+
     def initialize(@scope : Gori::Scope)
+      @last_reload = Time.instant
     end
 
+    # Layer 2, and therefore the line that owes DESIGN.md §7's "one reload semantic for the
+    # active-traffic scope gate" (#354). Discover's Layer 2 runs through THIS object and not
+    # through `Outbound#sweep_block`, because the engine is deliberately Store-free — which is
+    # exactly why `Outbound#refresh` was never reached: `cli/run/discover.cr` and
+    # `mcp/tools/discover.cr` both use their `Outbound` for `Plan.build` plus the up-front
+    # Layer-1 guard, and then hand the engine a policy that never calls back into it. So
+    # `gori run project scope add exclude string logout` in a second terminal stopped an
+    # in-flight fuzz/mine/sequence within a second while an in-flight discover — potentially
+    # thousands of probes — kept going against a start-time snapshot (#396). Only the TUI was
+    # exempt, and by accident: it shares its live `Scope` object, which its own data_version
+    # poll reloads.
     def allowed?(url : String, host : String) : Bool
+      refresh
       !@scope.sandbox_blocks?(url, host) && !@scope.excluded?(url, host)
     end
 
+    # Layer 1, and deliberately NOT reloaded: its only caller (`Engine#bounded_url`) asks it
+    # immediately after `allowed?`, so it already reads whatever that call refreshed.
     def boundary?(url : String, host : String) : Bool
       @scope.matches_url?(url, host)
     end
 
     def configured? : Bool
       @scope.configured?
+    end
+
+    # `Outbound#refresh`, mirrored rather than re-decided — including the interval constant, so
+    # the two can never name different numbers. Re-read the scope from its store before a
+    # Layer-2 check, at most once per `Outbound::RELOAD_INTERVAL`; advance the clock BEFORE the
+    # blocking reload so a burst of concurrent worker fibers cannot stampede the store (the
+    # check-then-set is a non-yielding critical section on the single-threaded scheduler); and
+    # swallow a failure so the last-known rules stay in force, degrading to the old snapshot
+    # rather than breaking the run or failing open.
+    private def refresh : Nil
+      now = Time.instant
+      return if now - @last_reload < Gori::Outbound::RELOAD_INTERVAL
+      @last_reload = now
+      @scope.reload
+    rescue
+      # keep the last-known scope on a reload failure
     end
   end
 

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -169,6 +169,12 @@ module Gori::Discover
     # cap: a benign Result, no network, and NOT counted as an error — a scope refusal is a
     # decision the operator asked for, not a failure of the run.
     SCOPE_REFUSED = "blocked by scope (Sandbox or an exclude rule)"
+    # Seeding enqueued nothing, so the run would send zero requests and still finish with a
+    # clean DoneEvent — "0 found", which an operator reads as "there is nothing there" rather
+    # than "gori sent nothing" (P4). Terminal for exactly the reason SEED_BLOCKED is, and
+    # written as a backstop over the whole condition rather than over the one shape that
+    # produced it (#395): whatever the reason the frontier comes up empty, the run says so.
+    NOTHING_TO_SEND = "nothing to send: no crawl page or brute-force directory survived the scope and containment gates"
 
     enum State : UInt8
       Running
@@ -315,6 +321,14 @@ module Gori::Discover
 
     private def orchestrate : Nil
       seed_frontier
+      # Seeding is the ONLY source of initial work, so an empty frontier here means the run
+      # will send nothing at all (see NOTHING_TO_SEND). Recorded now and emitted as the run's
+      # terminal event at the bottom rather than returned early: `start` has already spawned
+      # the workers, so the shutdown sequence below (close @jobs, join every worker) has to
+      # run on this path too or they park on `@jobs.receive?` forever — the fiber + socket
+      # leak the rescue clause guards against. The loop itself is a no-op with an empty
+      # frontier and no pending work: it breaks on its first iteration.
+      nothing_to_send = @frontier.empty?
       @phase = Phase::Crawling
       interval = pace_interval
       loop do
@@ -343,7 +357,13 @@ module Gori::Discover
       drain_pending
       @jobs.close
       @concurrency.times { @finished.receive }
-      @events.send(DoneEvent.new(progress_snapshot, run_stats, @state == State::Stopped))
+      # ErrorEvent is terminal — no trailing DoneEvent — so a consumer cannot settle a
+      # "0 found" success over it, the same shape `start`'s setup-error path uses.
+      if nothing_to_send
+        @events.send(ErrorEvent.new(NOTHING_TO_SEND))
+      else
+        @events.send(DoneEvent.new(progress_snapshot, run_stats, @state == State::Stopped))
+      end
       @events.close
     rescue ex
       # ErrorEvent is terminal (no trailing DoneEvent) so consumers don't mask the error
@@ -378,7 +398,7 @@ module Gori::Discover
         enqueue_well_known("#{root}/robots.txt", Source::Robots)
         enqueue_well_known("#{root}/sitemap.xml", Source::Sitemap)
       end
-      bf_dir = Url.dir_of(@seed_parts)
+      bf_dir = bruteforce_root
       enqueue_dir(bf_dir, 0) if @config.bruteforce?
       # robots.txt/sitemap.xml are GUESSED well-known paths, not organically-linked ones — they
       # deserve the same soft-404 gate a brute-forced wordlist hit gets, not the "exists by
@@ -389,13 +409,12 @@ module Gori::Discover
       # check reuses the bf_dir calibration when that dir IS the origin. Asking @dirs rather
       # than comparing `root_dir == bf_dir` is the whole fix for #393: the old comparison
       # assumed the `enqueue_dir` above had SUCCEEDED, but it goes through `bounded_url`, which
-      # applies the path confine — and the confine refuses the seed's own directory whenever
-      # the seed path is a single segment with no trailing slash. For `http://t/api`,
-      # @confine_path is "/api" while bf_dir is "http://t/", whose path is neither "/api" nor
-      # under "/api/". No Calibrate task was queued, yet @seed_calibration_dir was set, so
-      # robots.txt and sitemap.xml were fetched for real and then parked forever waiting on a
-      # baseline that never arrived: 2 real requests sent, 0 findings recorded, not even
-      # counted in calibrated_out.
+      # can still refuse it (Layer 2, or containment). No Calibrate task would be queued, yet
+      # @seed_calibration_dir was set, so robots.txt and sitemap.xml were fetched for real and
+      # then parked forever waiting on a baseline that never arrived: 2 real requests sent, 0
+      # findings recorded, not even counted in calibrated_out. (The shape that first exposed
+      # it — a file-shaped seed whose bf_dir fell outside its own confine — is gone with #395,
+      # but the assumption it broke was never safe.)
       if @config.spider? && @config.bruteforce?
         root_dir = "#{Url.origin(@seed_parts)}/"
         # @seed_calibration_dir is set even when the Calibrate task below is refused, and that
@@ -708,6 +727,31 @@ module Gori::Discover
     private def confined?(p : Url::Parts) : Bool
       return true unless cp = @confine_path
       p.path == cp || p.path.starts_with?("#{cp}/")
+    end
+
+    # The directory the brute-forcer starts from.
+    #
+    # `Url.dir_of` — everything up to the last '/' — is right only when the seed's path is
+    # already a directory. For a FILE-SHAPED seed it returns the seed's CONTAINING directory,
+    # which a path-confined run then refuses: on `http://t/api`, `dir_of` is `http://t/`,
+    # whose path is neither `/api` nor under `/api/`, so `enqueue_dir`'s `bounded_url` dropped
+    # it and the seed's own subtree was never probed at all. With `--no-spider` that was the
+    # whole run — zero requests, a clean DoneEvent, no reason given (#395).
+    #
+    # The two derivations have to agree, and it is `confined?` that carries the operator's
+    # intent: a seed path deeper than "/" means THE SUBTREE ROOTED HERE, so the brute-force
+    # base is that subtree's root as a directory. It is `dir_of` for a seed already ending in
+    # '/', and the seed's own path plus '/' otherwise — never anything the operator did not
+    # type. Widening `@confine_path` to "/" instead would spray the built-in wordlist
+    # (`admin`, `logout`, `.git/config`, `.env`) at the origin root of a run explicitly scoped
+    # to `/api`, which is the bypass the confine exists to prevent.
+    #
+    # `@seed_parts.path` is already dot-segment- and slash-normalized by `Url.parse`, so the
+    # rchop in `@confine_path` can only ever have removed one real trailing slash.
+    private def bruteforce_root : String
+      cp = @confine_path
+      return Url.dir_of(@seed_parts) unless cp
+      "#{Url.origin(@seed_parts)}#{cp}/"
     end
 
     # A brute-force candidate is `bl.dir` + a wordlist entry, and only the DIRECTORY was ever

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -51,11 +51,11 @@ module Gori::Discover
     # forwarding in absolute form. Returned as a benign error Result rather than raised: the
     # caller's contract is one Result per fetch, and one poisoned link must not end the run.
     #
-    # The refusal covers the whole `Url.request_line_safe?` class, not just CR/LF: a bare SP
-    # forges the line just as effectively (`GET /a b HTTP/1.1` — a lenient origin reads target
-    # `/a`, version `b`), which is what #394 found after #390. Nothing legitimate is lost by
-    # refusing the repairable half here, because `Url.parse` has already percent-encoded it
-    # upstream — this line only ever sees a target no repair applies to.
+    # The refusal covers the whole `Codec::Http1.request_token_safe?` class, not just CR/LF: a
+    # bare SP forges the line just as effectively (`GET /a b HTTP/1.1` — a lenient origin reads
+    # target `/a`, version `b`), which is what #394 found after #390. Nothing legitimate is
+    # lost by refusing the repairable half here, because `Url.parse` has already
+    # percent-encoded it upstream — this line only ever sees a target no repair applies to.
     UNSAFE_URL = "url contains whitespace or a control character"
 
     @header_block : String
@@ -75,7 +75,7 @@ module Gori::Discover
       # this is the only line every send provably passes, so the guarantee "a Discover run
       # never puts a malformed or doubled request line on a connection" is stated where it can
       # actually be enforced (see UNSAFE_URL).
-      unless Url.request_line_safe?(target) && Url.request_line_safe?(host)
+      unless Proxy::Codec::Http1.request_token_safe?(target) && Proxy::Codec::Http1.request_token_safe?(host)
         return Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, UNSAFE_URL)
       end
       req = build_get(scheme, host, port, target)
@@ -169,12 +169,17 @@ module Gori::Discover
     # cap: a benign Result, no network, and NOT counted as an error — a scope refusal is a
     # decision the operator asked for, not a failure of the run.
     SCOPE_REFUSED = "blocked by scope (Sandbox or an exclude rule)"
-    # Seeding enqueued nothing, so the run would send zero requests and still finish with a
-    # clean DoneEvent — "0 found", which an operator reads as "there is nothing there" rather
-    # than "gori sent nothing" (P4). Terminal for exactly the reason SEED_BLOCKED is, and
-    # written as a backstop over the whole condition rather than over the one shape that
-    # produced it (#395): whatever the reason the frontier comes up empty, the run says so.
-    NOTHING_TO_SEND = "nothing to send: no crawl page or brute-force directory survived the scope and containment gates"
+    # The run reached its end without putting a single request on the wire, so a DoneEvent
+    # would report "0 found" — which an operator reads as "there is nothing there" rather than
+    # "gori sent nothing" (P4). Terminal for exactly the reason SEED_BLOCKED is.
+    #
+    # The condition is `@capped.sent == 0`, deliberately, and NOT "seeding enqueued nothing".
+    # An empty frontier is only the shape #395 found; a frontier whose every task is refused
+    # later by the per-URL Layer-2 gate in `send_with_retries` ends in the same silence, and
+    # that state became ordinary the moment the gate started re-reading the scope mid-run
+    # (#396). Anchoring on the send counter covers both, plus whatever comes next: if nothing
+    # went out, the run says so.
+    NOTHING_TO_SEND = "nothing to send: no crawl page or brute-force candidate survived the scope and containment gates"
 
     enum State : UInt8
       Running
@@ -321,14 +326,6 @@ module Gori::Discover
 
     private def orchestrate : Nil
       seed_frontier
-      # Seeding is the ONLY source of initial work, so an empty frontier here means the run
-      # will send nothing at all (see NOTHING_TO_SEND). Recorded now and emitted as the run's
-      # terminal event at the bottom rather than returned early: `start` has already spawned
-      # the workers, so the shutdown sequence below (close @jobs, join every worker) has to
-      # run on this path too or they park on `@jobs.receive?` forever — the fiber + socket
-      # leak the rescue clause guards against. The loop itself is a no-op with an empty
-      # frontier and no pending work: it breaks on its first iteration.
-      nothing_to_send = @frontier.empty?
       @phase = Phase::Crawling
       interval = pace_interval
       loop do
@@ -357,9 +354,17 @@ module Gori::Discover
       drain_pending
       @jobs.close
       @concurrency.times { @finished.receive }
-      # ErrorEvent is terminal — no trailing DoneEvent — so a consumer cannot settle a
-      # "0 found" success over it, the same shape `start`'s setup-error path uses.
-      if nothing_to_send
+      # A run that put nothing on the wire ends in a terminal ErrorEvent — no trailing
+      # DoneEvent, so a consumer cannot settle a "0 found" success over it, the same shape
+      # `start`'s setup-error path uses (see NOTHING_TO_SEND). Decided HERE rather than right
+      # after `seed_frontier` for two reasons: the send counter is only final once the run is,
+      # and the shutdown sequence above (close @jobs, join every worker) has to run either way
+      # or the workers park on `@jobs.receive?` forever — the fiber + socket leak the rescue
+      # clause below guards against.
+      #
+      # A run the operator STOPPED is exempt: stopping before the first send is a decision, not
+      # a failure to have anything to do.
+      if @capped.sent == 0 && @state != State::Stopped
         @events.send(ErrorEvent.new(NOTHING_TO_SEND))
       else
         @events.send(DoneEvent.new(progress_snapshot, run_stats, @state == State::Stopped))
@@ -883,8 +888,10 @@ module Gori::Discover
       #
       # `Url.gate_url`, not `Url.normalize`: the `dir + cand` concat is unnormalized, and the
       # scope must be asked in the port-less form every other Layer-2 consumer uses — see
-      # `Url.gate_url`. NOTE the engine holds a snapshot policy, so this does NOT pick up a
-      # scope edit made mid-run except in the TUI, where the `Scope` object is shared live.
+      # `Url.gate_url`. The policy re-reads its rules on the schedule every other sweep uses
+      # (`StoreScope#allowed?`, throttled to `Outbound::RELOAD_INTERVAL`), so a scope edit made
+      # while the run is in flight stops it here within that window — on every surface, not
+      # only in the TUI where the `Scope` object happens to be shared live (#396).
       unless @scope.allowed?(Url.gate_url(p), p.host)
         return Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, SCOPE_REFUSED)
       end

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -50,7 +50,13 @@ module Gori::Discover
     # because `Upstream.dial` always CONNECT-tunnels (`proxy/upstream.cr`) rather than
     # forwarding in absolute form. Returned as a benign error Result rather than raised: the
     # caller's contract is one Result per fetch, and one poisoned link must not end the run.
-    UNSAFE_URL = "url contains a control character"
+    #
+    # The refusal covers the whole `Url.request_line_safe?` class, not just CR/LF: a bare SP
+    # forges the line just as effectively (`GET /a b HTTP/1.1` — a lenient origin reads target
+    # `/a`, version `b`), which is what #394 found after #390. Nothing legitimate is lost by
+    # refusing the repairable half here, because `Url.parse` has already percent-encoded it
+    # upstream — this line only ever sees a target no repair applies to.
+    UNSAFE_URL = "url contains whitespace or a control character"
 
     @header_block : String
 
@@ -65,10 +71,11 @@ module Gori::Discover
 
     def fetch(scheme : String, host : String, port : Int32, target : String) : Repeater::Result
       # The wire seam's own invariant, not a duplicate of the engine's gate: `Engine#bounded_url`
-      # drops a poisoned URL before it is ever queued, but this is the only line every send
-      # provably passes, so the guarantee "a Discover run never puts two request lines on one
-      # connection" is stated where it can actually be enforced (see UNSAFE_URL).
-      unless Headers.safe_value?(target) && Headers.safe_value?(host)
+      # drops a poisoned URL before it is ever queued and `Url.parse` repairs a spaced one, but
+      # this is the only line every send provably passes, so the guarantee "a Discover run
+      # never puts a malformed or doubled request line on a connection" is stated where it can
+      # actually be enforced (see UNSAFE_URL).
+      unless Url.request_line_safe?(target) && Url.request_line_safe?(host)
         return Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, UNSAFE_URL)
       end
       req = build_get(scheme, host, port, target)
@@ -675,6 +682,12 @@ module Gori::Discover
       # is never requested, so there is no status, length, or content type to claim one with —
       # and `Persist` would then write the poisoned string into the Sitemap as a real flow.
       # It is refused for the same reason any out-of-bounds link is, and takes the same exit.
+      #
+      # Only the FRAMING half of the octet class gets this exit. The rest of it (SP, TAB, DEL,
+      # the other C0) corrupts one request line without starting a second, and `<a href="/my
+      # file.pdf">` is ordinary handwritten HTML — so `Url.parse` has already percent-encoded
+      # those and nothing reaches here to drop (#394, and `Url.encode_unsafe` for why the two
+      # halves are answered differently).
       return nil unless Headers.safe_url?(p)
       return nil unless confined?(p)
       url = Url.normalize(p)

--- a/src/gori/discover/headers.cr
+++ b/src/gori/discover/headers.cr
@@ -86,11 +86,11 @@ module Gori::Discover
     # the connection. Checking only the path would leave the other two open.
     #
     # This is the FRAMING half of the octets a request line cannot carry, and the half whose
-    # answer is refusal. `Url.request_line_safe?` names the whole class (every octet <= 0x20
-    # plus DEL — SP and TAB separate the line's fields without starting a second message), and
-    # `Url.encode_unsafe` repairs the rest at parse instead of dropping it, because a space in
-    # an href is ordinary handwritten HTML (#394). Nothing that reaches this predicate has a
-    # repair.
+    # answer is refusal. `Codec::Http1.request_token_safe?` is the whole class and its one home
+    # (every octet <= 0x20 plus DEL — SP and TAB separate the line's fields without starting a
+    # second message); `Url.parse` percent-encodes the rest instead of dropping it, because a
+    # space in an href is ordinary handwritten HTML (#394). Nothing that reaches this predicate
+    # has a repair.
     def self.safe_url?(parts : Url::Parts) : Bool
       q = parts.query
       safe_value?(parts.host) && safe_value?(parts.path) && (q.nil? || safe_value?(q))

--- a/src/gori/discover/headers.cr
+++ b/src/gori/discover/headers.cr
@@ -84,6 +84,13 @@ module Gori::Discover
     # `Discover::Sender#build_get` splices all three into the request line and the `Host`
     # header — so any one of them can splice a second, fully attacker-chosen request onto
     # the connection. Checking only the path would leave the other two open.
+    #
+    # This is the FRAMING half of the octets a request line cannot carry, and the half whose
+    # answer is refusal. `Url.request_line_safe?` names the whole class (every octet <= 0x20
+    # plus DEL — SP and TAB separate the line's fields without starting a second message), and
+    # `Url.encode_unsafe` repairs the rest at parse instead of dropping it, because a space in
+    # an href is ordinary handwritten HTML (#394). Nothing that reaches this predicate has a
+    # repair.
     def self.safe_url?(parts : Url::Parts) : Bool
       q = parts.query
       safe_value?(parts.host) && safe_value?(parts.path) && (q.nil? || safe_value?(q))

--- a/src/gori/discover/url.cr
+++ b/src/gori/discover/url.cr
@@ -1,4 +1,5 @@
 require "uri"
+require "../proxy/codec/http1"
 
 module Gori::Discover
   # URL parsing, normalization, and the TWO keys that make trap prevention work:
@@ -15,7 +16,7 @@ module Gori::Discover
 
     # Parse an absolute http(s) URL into normalized Parts (host lowercased, path defaulted
     # to "/"), or nil for a non-http / hostless / unparseable URL — or for one whose HOST
-    # carries an octet that cannot be framed (see `request_line_safe?`).
+    # carries an octet that cannot be framed (`Codec::Http1.request_token_safe?`).
     def self.parse(url : String) : Parts?
       uri = URI.parse(url) rescue return nil
       host = uri.host
@@ -26,7 +27,11 @@ module Gori::Discover
       # `://` all sit outside `uri.host`). `URI.parse` copies such a host in verbatim —
       # `http://a b/x` yields `"a b"` — so this is the only line that can refuse it, and nil
       # is the exit every unparseable URL already takes.
-      return nil unless request_line_safe?(host)
+      #
+      # It is also the only line that can protect the CONNECT line: with an upstream proxy
+      # configured, `Upstream.dial` writes `CONNECT #{host}:#{port} HTTP/1.1` out of this
+      # host, and that line is synthesized far below any Discover gate.
+      return nil unless Proxy::Codec::Http1.request_token_safe?(host)
       scheme = (uri.scheme || "http").downcase
       return nil unless scheme == "http" || scheme == "https"
       port = uri.port || (scheme == "https" ? 443 : 80)
@@ -37,7 +42,17 @@ module Gori::Discover
       return "/" if path.nil? || path.empty?
       # Collapse dot-segments so /a/../b and /b share one visit_key (avoids a re-crawl of the
       # same resource reached via an absolute href, which resolve() returns un-normalized).
-      path = normalize_path(path) if path.includes?("..") || path.includes?("./") || path.includes?("//")
+      #
+      # `ends_with?("/.")` catches a TRAILING bare dot, which the other three tests miss:
+      # `/a/..` and `/a/./` both trip them, `/a/.` trips none, so it came back un-normalized
+      # and `/a/.` and `/a/` were two visit_keys for one resource. That mattered little until
+      # `bruteforce_root` (#395) started deriving the brute-force base from the seed's path:
+      # a seed of `/api/.` produced the confine `/api/.`, which NOTHING can satisfy, since
+      # every derived URL comes back through here normalized. The run then brute-forced
+      # nothing — the exact shape #395 exists to remove.
+      if path.includes?("..") || path.includes?("./") || path.includes?("//") || path.ends_with?("/.")
+        path = normalize_path(path)
+      end
       encode_unsafe(path)
     end
 
@@ -48,26 +63,15 @@ module Gori::Discover
 
     PCT_HEX = "0123456789ABCDEF"
 
-    # True when `s` can go onto a request line as-is.
-    #
-    # `Sender#build_get` writes `GET #{target} HTTP/1.1\r\nHost: #{host}\r\n`, so an octet
-    # <= 0x20 or 0x7F is unrepresentable in either slot: SP and TAB separate the request
-    # line's three fields, CR and LF end it, and RFC 3986 forbids the rest unencoded anyway.
-    # One class, stated once, rather than the CR/LF pair that #390 named and the space that
-    # #394 found afterwards. `src/gori/mcp/request_builder.cr` (`reject_token_breakers`)
-    # already applies exactly this rule to the method, the target and the host.
-    #
-    # Byte-wise, not char-wise: a percent-encoded or multi-byte UTF-8 path is untouched
-    # (every continuation byte is >= 0x80).
-    def self.request_line_safe?(s : String) : Bool
-      s.each_byte { |b| return false if b <= 0x20_u8 || b == 0x7f_u8 }
-      true
-    end
-
     # Percent-encode the request-line breakers that a PATH or QUERY may legitimately carry.
     #
-    # The class `request_line_safe?` names has two halves, and they get different remedies
-    # because they do different things to the wire:
+    # The class is `Codec::Http1.request_token_safe?`'s and is not restated here: every octet
+    # <= 0x20 or 0x7F, because `Sender#build_get` writes `GET #{target} HTTP/1.1` and those
+    # octets are unrepresentable in a request-line token. That predicate is the rule's one
+    # home (#397); this method is the only thing Discover adds to it — a REPAIR for the half
+    # of the class that has one.
+    #
+    # The two halves get different remedies because they do different things to the wire:
     #
     #   * CR and LF FRAME. They do not corrupt one request line, they end it and start a
     #     second message (#390). No author writes them into an `<a href>`, so they are left
@@ -104,6 +108,12 @@ module Gori::Discover
       end
     end
 
+    # Membership in the repairable half, per octet. The string-level rule lives in the codec
+    # and must not be restated — but the encoder needs a per-BYTE test, and calling the
+    # codec's predicate once per octet would allocate a String per byte on a path that runs
+    # for every considered link and every brute-force candidate. So this is the one place the
+    # class is written twice, and `url_spec` pins the two against each other over all 256
+    # octets: `encodable?(b) == !request_token_safe?(b) && b is not CR/LF`, for every b.
     private def self.encodable?(b : UInt8) : Bool
       (b <= 0x20_u8 || b == 0x7f_u8) && b != 0x0d_u8 && b != 0x0a_u8
     end

--- a/src/gori/discover/url.cr
+++ b/src/gori/discover/url.cr
@@ -14,20 +14,105 @@ module Gori::Discover
     record Parts, scheme : String, host : String, port : Int32, path : String, query : String?
 
     # Parse an absolute http(s) URL into normalized Parts (host lowercased, path defaulted
-    # to "/"), or nil for a non-http / hostless / unparseable URL.
+    # to "/"), or nil for a non-http / hostless / unparseable URL — or for one whose HOST
+    # carries an octet that cannot be framed (see `request_line_safe?`).
     def self.parse(url : String) : Parts?
       uri = URI.parse(url) rescue return nil
       host = uri.host
       return nil unless host && !host.empty?
+      # A host with a request-line breaker in it is refused rather than repaired: percent
+      # encoding is defined for a path, not for a reg-name, and `Import::Builder::HOST_INVALID`
+      # already states the rule that a real host never carries one (userinfo, port and the
+      # `://` all sit outside `uri.host`). `URI.parse` copies such a host in verbatim —
+      # `http://a b/x` yields `"a b"` — so this is the only line that can refuse it, and nil
+      # is the exit every unparseable URL already takes.
+      return nil unless request_line_safe?(host)
       scheme = (uri.scheme || "http").downcase
       return nil unless scheme == "http" || scheme == "https"
       port = uri.port || (scheme == "https" ? 443 : 80)
-      path = uri.path
-      path = "/" if path.nil? || path.empty?
+      Parts.new(scheme, host.downcase, port, parse_path(uri.path), parse_query(uri.query))
+    end
+
+    private def self.parse_path(path : String?) : String
+      return "/" if path.nil? || path.empty?
       # Collapse dot-segments so /a/../b and /b share one visit_key (avoids a re-crawl of the
       # same resource reached via an absolute href, which resolve() returns un-normalized).
       path = normalize_path(path) if path.includes?("..") || path.includes?("./") || path.includes?("//")
-      Parts.new(scheme, host.downcase, port, path, uri.query.presence)
+      encode_unsafe(path)
+    end
+
+    private def self.parse_query(query : String?) : String?
+      q = query.presence
+      q ? encode_unsafe(q) : nil
+    end
+
+    PCT_HEX = "0123456789ABCDEF"
+
+    # True when `s` can go onto a request line as-is.
+    #
+    # `Sender#build_get` writes `GET #{target} HTTP/1.1\r\nHost: #{host}\r\n`, so an octet
+    # <= 0x20 or 0x7F is unrepresentable in either slot: SP and TAB separate the request
+    # line's three fields, CR and LF end it, and RFC 3986 forbids the rest unencoded anyway.
+    # One class, stated once, rather than the CR/LF pair that #390 named and the space that
+    # #394 found afterwards. `src/gori/mcp/request_builder.cr` (`reject_token_breakers`)
+    # already applies exactly this rule to the method, the target and the host.
+    #
+    # Byte-wise, not char-wise: a percent-encoded or multi-byte UTF-8 path is untouched
+    # (every continuation byte is >= 0x80).
+    def self.request_line_safe?(s : String) : Bool
+      s.each_byte { |b| return false if b <= 0x20_u8 || b == 0x7f_u8 }
+      true
+    end
+
+    # Percent-encode the request-line breakers that a PATH or QUERY may legitimately carry.
+    #
+    # The class `request_line_safe?` names has two halves, and they get different remedies
+    # because they do different things to the wire:
+    #
+    #   * CR and LF FRAME. They do not corrupt one request line, they end it and start a
+    #     second message (#390). No author writes them into an `<a href>`, so they are left
+    #     RAW here on purpose — `Headers.safe_url?` drops such a URL at every enqueue and
+    #     `Sender#fetch` refuses it at the wire, which is the disposition #390 settled.
+    #     Encoding them instead would turn a splice attempt into a real request for a URL
+    #     nobody authored.
+    #   * Everything else (SP, TAB, DEL, the remaining C0) SEPARATES fields. `<a href="/my
+    #     file.pdf">` is ordinary handwritten HTML — a browser percent-encodes it and fetches
+    #     the file — so refusing it would silently shrink a crawl's coverage, and a 400 from
+    #     a strict origin diverges from the soft-404 baseline (`Calibrate.hit?` scores
+    #     `status_div` at +0.50), making it a false-POSITIVE source too. It is repaired.
+    #
+    # Applied at PARSE rather than in `build_get`, because a URL must have exactly ONE
+    # spelling: the same string feeds `visit_key`, `template_key`, the Layer-2 gate question,
+    # the Finding, and the Sitemap row `Persist` writes. Encoding only at the wire would
+    # leave the raw octet in all five — the gate would judge a different URL than the one
+    # sent, and a byte-exact Repeater re-send of a stored finding would reproduce the
+    # corruption. It also makes discover ask the gate the already-encoded form every other
+    # Layer-2 consumer sees, since those targets arrive off the wire from a real client.
+    #
+    # Idempotent, which `#{bl.dir}#{cand}` and any re-crawled link rely on: `%` is not in the
+    # class, so an already-encoded path re-parses unchanged and never becomes `%2520`.
+    private def self.encode_unsafe(s : String) : String
+      return s unless needs_encoding?(s)
+      String.build(s.bytesize + 8) do |io|
+        s.each_byte do |b|
+          if encodable?(b)
+            io << '%' << PCT_HEX[b >> 4] << PCT_HEX[b & 0x0f]
+          else
+            io.write_byte(b)
+          end
+        end
+      end
+    end
+
+    private def self.encodable?(b : UInt8) : Bool
+      (b <= 0x20_u8 || b == 0x7f_u8) && b != 0x0d_u8 && b != 0x0a_u8
+    end
+
+    # `s` itself is returned for every clean URL (the overwhelming majority, and this runs
+    # once per considered link and once per brute-force candidate), so scan before building.
+    private def self.needs_encoding?(s : String) : Bool
+      s.each_byte { |b| return true if encodable?(b) }
+      false
     end
 
     def self.default_port?(scheme : String, port : Int32) : Bool


### PR DESCRIPTION
Three Discover fixes from the review of #398, in issue order, one commit each, plus a fourth commit for the review pass.

Closes #394
Closes #395
Closes #396

## #394 — the decision: encode the repairable half, refuse the framing half

`Headers.safe_url?` rejected CR and LF only, but `Sender#build_get` writes `GET #{target} HTTP/1.1` and **space is that line's field separator**. An ordinary `<a href="/my file.pdf">` — handwritten HTML, no attacker required — put `GET /my file.pdf HTTP/1.1` on a real socket.

The issue asks for a product decision. **Reject, or percent-encode?** The answer is both, split by what the octet does to the wire rather than by which issue found it:

| | what it does | remedy |
|---|---|---|
| CR, LF | **frame** — end the line, begin a second message (#390) | refused |
| SP, TAB, DEL, rest of C0 | **separate fields** — corrupt one line, cannot start a second | percent-encoded |

The argument for encoding SP and friends: a space in an href is a real resource that a browser fetches, so refusing it silently shrinks a crawl's coverage — the failure mode this project already treats as worse than an error (P4), and the same one #395 is about. It is also a **false-positive** source, not just lost coverage: a strict origin 400s, and that 400 diverges from the soft-404 baseline, which `Calibrate.hit?` scores at +0.50.

The argument for still refusing CR/LF: no author writes one into an href. Encoding would convert a splice attempt into a real request for a URL nobody named, and put `%0D%0A` rows in the operator's Sitemap. #390's disposition is unchanged.

**The rule itself is not restated.** After the rebase this branch calls `Proxy::Codec::Http1.request_token_safe?`, the home #399 just built for this exact class — otherwise this PR would have shipped the fourth copy of a rule that was consolidated three days' worth of issues ago. The only thing left local is the per-**octet** membership test the encoder needs (calling a string predicate once per byte would allocate per byte on a hot path), and `url_spec` derives its expectation from the codec's predicate over every ASCII octet, so widening the class there and not here fails the suite.

**Encoded at `Url.parse`, not at `build_get`**, because a URL must have exactly one spelling: `visit_key`, `template_key`, the Layer-2 gate question, the `Finding`, and the Sitemap row `Persist` writes all come off the same `Parts`. Encoding only at the wire leaves the raw octet in all five — the gate would judge a different URL than the one sent, and a byte-exact Repeater re-send of a stored finding would reproduce the corruption. It also makes discover ask the gate the already-encoded form every other Layer-2 consumer sees.

### This is deliberately the opposite call from #397, and it is not an inconsistency

#397 **refuses** an unsafe redirect `Location` on the same octet class. I agree with the coordinator's framing and adopt it: a page's own `<a href>` is text that page authored and that a browser would encode before fetching, so encoding reproduces what the link meant. A redirect `Location` is named by whatever host answered; encoding it would invent a URL the origin never named while gori recorded it as sent. Same class, same one predicate, different answer because the input is a different kind of thing. This is written into DESIGN.md §7 so the next reader does not "fix" the asymmetry.

### Gap 1 (the CONNECT line) — verified, and the parse-time fix does cover it

The sweep is right that `<a href="http://ac me.acme.test/x">` passes `Headers.safe_url?` (a space is not CR/LF) and `same_or_subdomain?` containment, and that its host would reach `Upstream.dial_via_proxy`, which writes `CONNECT #{authority} HTTP/1.1` with no validation of its own. I did not assume the fix covered it — `Url.parse` refusing a host that carries one of these octets is what makes it unreachable, and there are two specs:

- `spec/discover/engine_spec.cr` — the engine chain: such a link is dropped, while a sibling subdomain link on the same page is still crawled (the control).
- `spec/discover/sender_spec.cr` — the **socket bytes**, against a fake upstream proxy: nothing is dialled at all for a spaced host, and the control asserts an ordinary host still produces exactly `CONNECT acme.test:80 HTTP/1.1`. Reverting the host guard fails both.

This is a good argument for where the fix went: parse time is the only place that covers **both** synthesized request lines, since the CONNECT is built far below any Discover gate.

## #395 — the brute-force base, and a run that sends nothing

The base came from `Url.dir_of(seed)` while the confine came from the seed's full path, so for a file-shaped seed the two disagreed: on `http://t/api`, `dir_of` is the origin root, which `@confine_path` of `/api` then refuses. `gori run discover --target https://acme.test/api --no-spider` sent **zero** requests and reported a clean `DoneEvent`.

The issue offers two fixes; the answer is a third that `confined?`'s own documented meaning already implies. Widening the confine to `/` would spray the built-in wordlist (`admin`, `logout`, `.git/config`, `.env`) at the origin root of a run scoped to `/api`. Reporting "nothing to do" answers a question nobody asked. A seed path deeper than `/` means *the subtree rooted here*, so **the brute-force base is that subtree's root as a directory**. Rows of the issue's matrix that already brute-forced something are unchanged in count and destination; two consequences are stated plainly in DESIGN.md (the appended slash, and a second calibration burst for a file-shaped seed with the spider on).

`NOTHING_TO_SEND` is anchored on the **send counter**, not on an empty frontier — a frontier whose every task is refused later by the per-URL Layer-2 gate ends in identical silence (`SCOPE_REFUSED` is benign, so even the error count stays 0), and that state became ordinary with #396. A stopped run is exempt.

## #396 — conform to the one reload semantic, without making Layer 1 mutable

`StoreScope#allowed?` now does the throttled `Scope#reload` that DESIGN.md §7 records for #354, reusing `Outbound::RELOAD_INTERVAL` rather than naming a second interval. Threading the `Outbound` into the engine was rejected for the reason the `ScopePolicy` seam exists: the engine is Store-free (§2.1).

**`configured?` is snapshotted at construction**, and that is the load-bearing half. Left live, the reload rewrote Layer-1 containment mid-run: on a project with no rules, adding the single canonical `exclude string logout` flips `configured?` false→true, and `matches_url?` requires at least one INCLUDE, so `boundary?` goes false for **every** URL — the operator asks to skip one path and the whole crawl stops, silently. I verified that against the real `Scope` before fixing it. §3 and the #354 entry already draw this line: Layer 1 is settled per surface before the first byte, Layer 2 is the layer applied continuously.

## Verification

- `just test` — 4339 examples, 0 failures. `crystal build --no-codegen src/main.cr` clean on the rebased tree (CI never builds the merge result).
- `crystal tool format --check` clean on all 9 changed files; ameba introduces no new finding on them. (`just check` fails tree-wide on two files this branch does not touch — `spec/proxy/tls/tunnel_spec.cr` and `src/gori/proxy/upstream.cr` — identically on `origin/main`; Crystal version drift.)
- **Control runs**: every new spec was re-run with its fix reverted, six separate reverts, and each one fails. The reload-failure example was rewritten after review because the original passed with the `rescue` deleted — a closed `Store` keeps answering, so it now drives a `Scope` whose `reload` actually raises.
- **End to end against the real binary** and a local origin, reading the raw request lines off the socket:
  - spaced href → `GET /api/my%20file.pdf HTTP/1.1`, finding recorded at the encoded URL
  - `--no-spider --target .../api` → 30 requests, every one under `/api/`, none at the origin root (was 0)
  - same run with `/api/` excluded → `discover error: nothing to send: …`, exit 1, zero requests
  - `scope add exclude` from a second terminal mid-run → run stops after 27 sends instead of working through 275 words

## Known remaining instances of the same root cause (not fixed here, out of boundary)

- **`import/builder.cr:109`** — `CONTROL_CHAR = /[\x00-\x1f\x7f]/` misses SP (0x20) for the request **target**, so `/a b` imported from a HAR or `--urls` file is stored and replayed byte-exact by Repeater. `HOST_INVALID` covers space, but only for the host. (Coordinator is filing this.)
- **Port-ful vs port-less Layer-2 spelling** — 3 of 6 `@scope.allowed?` call sites in `discover/engine.cr` ask with `Url.normalize` (port-ful) where the wire check uses `Url.gate_url` (port-less): the seed check, `enqueue_well_known`, and `enqueue_seed_only_calibration`. An exclude that terminates a run with `SEED_BLOCKED` on `:443` does not fire on `:8443`, so the terminal reason is lost. No unauthorized bytes go out — the send chokepoint uses `gate_url` — and it is identical on `origin/main`, so it wants its own issue rather than a drive-by here.
- **`discover/extract.cr`** — `LOC` cannot match a `<loc>` containing a raw space (the entry is dropped whole) and `from_robots` truncates a `Disallow:` value at whitespace. Both are defensible per the sitemaps.org and RFC 9309 rules for those formats, and neither is a framing bug, but it means #394's "a space is a real resource" repair reaches HTML hrefs and the seed, not those two extractors. Worth its own decision.
