### PR TITLE
fix(import): stop rejecting operator-supplied malformed URLs on the replay path (#400)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -748,6 +748,46 @@ everywhere and applied continuously. #396 asked for the second, not the first.
 `boundary?` itself needs no reload of its own: its only caller (`bounded_url`) asks it
 immediately after `allowed?`, so it already reads whatever that call refreshed.
 
+### 2026-07-26: import is deliberately permissive — the host is a URL, the target is a payload
+
+Refines: [P7](#p7). Issue #400.
+
+Import (`src/gori/import/builder.cr`) feeds the replay path, so it obeys [P7](#p7): it stores and
+replays operator-supplied malformed input byte-exact rather than sanitising it. A HAR, OpenAPI
+spec or `--urls` file is a file the operator deliberately handed gori, describing traffic they
+want to reproduce — a CRLF-bearing request line, a raw space in a target, a duplicate `Host` are
+the smuggling *payloads* an operator tests with, not corruption to be repaired. Reproducing a
+broken request is the point of the tool. This closes the inverse of how #400 was first filed:
+the defect was never that a byte slipped *through* the denylist and replayed; it was that a
+denylist rejected the operator's payload at all.
+
+The split that makes this safe to state is **host versus target**:
+
+- A control byte or space in the **path or query** is a URL describing a malformed request →
+  store it, replay it byte-exact. `URI.parse` copies a literal control byte verbatim into
+  `path`/`query`, and `request_head` writes the target onto the request line as-is, so the
+  operator's forged message reaches the wire unchanged.
+- A control byte or space in the **host** is not a URL at all — a parse failure, not a payload.
+  `URI.parse` copies a reg-name authority verbatim, so `not a url at all` becomes a stored
+  "host" of literal spaces. `Builder::HOST_INVALID` (`/[\x00-\x20\x7f]/`) rejects it in
+  `endpoint`, and the parser's per-entry rescue skips just that entry. This is the ONE reject
+  import keeps, and it is a shape check on a URL, not a judgement on a request.
+
+One `CONTROL_CHAR` regex used to match anywhere in the URL and so did both jobs, rejecting the
+payload case along with the parse-failure case; removing it and leaning on the pre-existing
+`HOST_INVALID` restores the distinction. The send layer already encodes the same principle:
+`Codec::Http1.request_token_safe?` (#399) documents itself as applying only where gori
+*synthesizes* a request line from bytes a remote chose, never to operator-replay bytes.
+`spec/repeater/import_replay_wire_spec.cr` pins that on the socket — an imported CRLF target
+replays byte-exact through `Repeater::Plan`, and the guard's own verdict on those same bytes is
+`false`, proving it does not gate the replay path.
+
+Two adjacent guards are NOT relaxed by this decision and stay as they were: `HEADER_INJECT`
+(CR/LF/NUL in a header name/value) and `reject_inject!` (the same in method / HTTP version /
+reason phrase). Those forge a message boundary the same way a CRLF target does, and whether
+import should also carry an operator's header-boundary payload is a separate question #400 did
+not settle — left rejected pending its own call rather than widened by implication.
+
 ---
 
 *Keep this document honest against the code. When you change a subsystem it describes, update

--- a/spec/import/import_spec.cr
+++ b/spec/import/import_spec.cr
@@ -547,11 +547,13 @@ describe Gori::Import do
     end
   end
 
-  it "skips a HAR entry whose URL carries a CRLF injection instead of importing a fabricated request" do
+  it "imports a HAR entry whose URL PATH carries a CRLF, storing the operator's payload byte-exact (P7)" do
     har = File.tempname("gori", ".har")
     begin
-      # The malicious entry's URL smuggles a second fake request via literal CRLFs. Left
-      # unchecked this used to land straight in the stored request line/History row.
+      # A HAR the operator exported of a deliberate request-smuggling test: the CRLF lives in
+      # the PATH, so the host is a real host and the entry is the operator's own payload. gori
+      # must reproduce it, not sanitise it away — that is the point of a security-testing proxy
+      # (P7; see #400, DESIGN.md §7). It is stored and replayed byte-exact, never skipped.
       File.write(har, {log: {entries: [
         {request: {method: "GET", url: "https://a.test/1"}, response: {status: 200, content: {text: "ok"}}},
         {request:  {method: "GET", url: "https://evil.test/path\r\nX-Injected: pwn\r\n\r\nGET /second HTTP/1.1"},
@@ -560,27 +562,51 @@ describe Gori::Import do
       ]}}.to_json)
       with_store do |store|
         result = Gori::Import.import_file(store, :har, har)
-        result.count.should eq(2)   # the two clean entries imported
-        result.skipped.should eq(1) # the CRLF-injected entry skipped, not fabricated
-        store.count.should eq(2)
+        result.count.should eq(3)   # all three imported, the payload entry included
+        result.skipped.should eq(0) # nothing rejected
+        store.count.should eq(3)
         rows = store.search(Gori::QL::EMPTY, 10)
-        rows.each { |r| r.target.should_not match(/[\r\n]/) }
-        rows.map(&.host).sort.should eq(["a.test", "a.test"])
+        payload = rows.find { |r| r.host == "evil.test" }.not_nil!
+        # The forged bytes survive verbatim in both the target column and the stored head.
+        payload.target.should eq("/path\r\nX-Injected: pwn\r\n\r\nGET /second HTTP/1.1")
+        String.new(store.get_flow(payload.id).not_nil!.request_head).should contain("\r\nX-Injected: pwn\r\n")
       end
     ensure
       File.delete?(har)
     end
   end
 
-  it "skips a URL-list line with a raw control character in the path" do
+  it "imports a URL-list line with a raw control character in the PATH byte-exact (operator payload, P7)" do
     urls = File.tempname("gori", ".txt")
     begin
       File.write(urls, "https://a.test/1\nhttp://a.test/\x01\x02control\nhttps://a.test/2\n")
       with_store do |store|
         result = Gori::Import.import_file(store, :urls, urls)
-        result.count.should eq(2)   # the two clean lines imported
-        result.skipped.should eq(1) # the control-char line skipped
-        store.count.should eq(2)
+        result.count.should eq(3)   # all three lines imported, control-char one included
+        result.skipped.should eq(0) # nothing rejected
+        store.count.should eq(3)
+        payload = store.search(Gori::QL::EMPTY, 10).find(&.target.includes?("control")).not_nil!
+        payload.target.should eq("/\x01\x02control") # stored verbatim, not sanitised
+      end
+    ensure
+      File.delete?(urls)
+    end
+  end
+
+  it "still SKIPS a URL-list line whose HOST carries a space (not a URL, per #400)" do
+    urls = File.tempname("gori", ".txt")
+    begin
+      # A space (or control byte) in the HOST is a parse failure, not a payload: URI.parse copies
+      # the reg-name verbatim, so `ev il.test` becomes a bogus "host". Skip it the way a bad
+      # scheme is skipped, while the clean lines around it still import. (CRLF-in-host can't ride
+      # a line-oriented URL file — File.each_line would split it — so it is covered at the
+      # Builder.endpoint unit level below.)
+      File.write(urls, "https://a.test/1\nhttps://ev il.test/x\nhttps://a.test/2\n")
+      with_store do |store|
+        result = Gori::Import.import_file(store, :urls, urls)
+        result.count.should eq(2)   # only the two clean lines
+        result.skipped.should eq(1) # the bogus-host line skipped
+        store.search(Gori::QL::EMPTY, 10).map(&.host).sort!.should eq(["a.test", "a.test"])
       end
     ensure
       File.delete?(urls)

--- a/spec/repeater/import_replay_wire_spec.cr
+++ b/spec/repeater/import_replay_wire_spec.cr
@@ -1,0 +1,117 @@
+require "../spec_helper"
+
+# Issue #400 — an imported CRLF-bearing request target must replay onto the wire BYTE-EXACT.
+#
+# The import path (src/gori/import/builder.cr) deliberately stops rejecting a control byte in a
+# URL's PATH/QUERY: that byte is the operator's own smuggling payload, and reproducing a broken
+# request is the point of a security-testing proxy (P7; DESIGN.md §7). This file proves it end
+# to end, on the SOCKET rather than in a string — #390/#397/#401 established that for this class
+# a string-level assertion proves nothing, because something downstream (a codec guard, an
+# origin re-parse, an Env pass) could re-validate or mangle the bytes between store and wire.
+#
+# The chain under test is the exact one every headless replay takes:
+#   Import::Builder.request_head  (the serializer HAR/OAS/--urls all call)
+#     → Store::FlowDetail          (the captured flow, reconstructed DB-free like replay_reconstruct_spec)
+#       → Repeater::FlowRequest.build → Repeater::Plan → Repeater::Sender → upstream.write
+private def ungated : Gori::Outbound
+  Gori::Outbound.waived(nil, Gori::Outbound::Reason::NoProject)
+end
+
+# Reconstruct a captured flow exactly as `gori run repeater send --flow` does, from a head the
+# IMPORT serializer produced, then read what actually reaches the origin socket.
+private def wire_of(head : Bytes, port : Int32, seen : Channel(Bytes)) : Nil
+  row = Gori::Store::FlowRow.new(
+    id: 1_i64, created_at: 0_i64, scheme: "http", method: "GET", host: "evil.test", port: 80,
+    target: "/", status: 200, size: 0_i64, state: Gori::Store::FlowState::Complete)
+  detail = Gori::Store::FlowDetail.new(row, "HTTP/1.1", head, nil, nil, nil)
+  built = Gori::Repeater::FlowRequest.build(detail)
+
+  plan = Gori::Repeater::Plan.build(
+    Gori::Repeater::PlanOptions.new([built.bytes],
+      target: "127.0.0.1:#{port}", auto_content_length: false, verify: false,
+      timeout: 3.seconds),
+    ungated)
+  plan.send
+end
+
+describe "import → repeater wire fidelity (#400, P7)" do
+  it "replays an imported CRLF-smuggling target byte-exact onto the socket" do
+    # The operator's HAR carried this URL; import stored it via Builder.request_head. The CRLF is
+    # in the PATH, so the host stayed a real host and the entry was NOT skipped.
+    target = "/path\r\nX-Injected: pwn\r\n\r\nGET /second HTTP/1.1"
+    head = Gori::Import::Builder.request_head(
+      "GET", target, "HTTP/1.1", "evil.test", Gori::Import::Builder::Headers.new, nil)
+
+    # The send-layer guard's OWN verdict on these bytes is "unsafe" — it would refuse to
+    # SYNTHESIZE a request line out of them. That it fires here and the replay below still sends
+    # them verbatim is the proof that the guard does NOT gate the operator-replay path (its
+    # docstring, landed by #399, promises exactly this). If this path ever started calling the
+    # guard, the socket assertion below would fail instead — this line just names the contrast.
+    Gori::Proxy::Codec::Http1.request_token_safe?(target).should be_false
+
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.local_address.port
+    seen = Channel(Bytes).new(1)
+    spawn do
+      if sock = server.accept?
+        buf = Bytes.new(8192)
+        n = sock.read(buf)
+        seen.send(buf[0, n].dup)
+        sock << "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        sock.close rescue nil
+      end
+    rescue
+    end
+
+    begin
+      wire_of(head, port, seen)
+      select
+      when wire = seen.receive
+        # Byte-for-byte: the smuggled second request line and injected header reach the wire
+        # exactly as the operator built them. Nothing percent-encoded, normalized, or rejected.
+        String.new(wire).should eq(
+          "GET /path\r\nX-Injected: pwn\r\n\r\nGET /second HTTP/1.1 HTTP/1.1\r\n" \
+          "Host: evil.test\r\n\r\n")
+      when timeout(3.seconds)
+        fail "repeater never dialed the origin — the imported entry did not replay"
+      end
+    ensure
+      server.close
+    end
+  end
+
+  it "replays an imported raw-SPACE target verbatim too (the case #400 was first filed about)" do
+    # A space in the request target is the original, still-correct behaviour: 4 tokens on the
+    # request line, replayed as-is. Confirming it on the wire, not just in a reconstruct string.
+    target = "/a b?x=1 2"
+    head = Gori::Import::Builder.request_head(
+      "GET", target, "HTTP/1.1", "evil.test", Gori::Import::Builder::Headers.new, nil)
+
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.local_address.port
+    seen = Channel(Bytes).new(1)
+    spawn do
+      if sock = server.accept?
+        buf = Bytes.new(8192)
+        n = sock.read(buf)
+        seen.send(buf[0, n].dup)
+        sock << "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        sock.close rescue nil
+      end
+    rescue
+    end
+
+    begin
+      wire_of(head, port, seen)
+      select
+      when wire = seen.receive
+        String.new(wire).should eq(
+          "GET /a b?x=1 2 HTTP/1.1\r\nHost: evil.test\r\n\r\n")
+      when timeout(3.seconds)
+        fail "repeater never dialed the origin"
+      end
+    ensure
+      server.close
+    end
+  end
+end

--- a/src/gori/import/builder.cr
+++ b/src/gori/import/builder.cr
@@ -27,28 +27,28 @@ module Gori
       LEADING_SCHEME = /\A[a-z][a-z0-9+.-]*:\/\//i
       HTTP_SCHEME    = /\Ahttps?:\/\//i
 
-      # A raw CR/LF (or other C0 control / DEL) in a URL is never legitimate — a
-      # PERCENT-ENCODED `%0d%0a` stays encoded text through URI.parse (harmless), but a
-      # LITERAL control byte does not: URI.parse copies it verbatim into host/path with
-      # no rejection, so left unchecked it flows straight into request_head/response_head
-      # and forges a second, fabricated HTTP message inside one stored request/status line
-      # (e.g. `GET /path\r\nX-Injected: pwn\r\n\r\nGET /second HTTP/1.1 HTTP/1.0\r\n...`).
-      # Reject the entry here, at the same point the scheme/shape checks below do, so every
-      # caller's existing skip-a-bad-entry rescue handles it identically to those checks.
-      CONTROL_CHAR = /[\x00-\x1f\x7f]/
+      # A raw control byte (CR, LF, NUL, other C0 or DEL) in the PATH or QUERY of an imported
+      # URL is NOT rejected: it is the operator's own payload. Importing a HAR of a deliberately
+      # CRLF-bearing request — a smuggling case — is exactly what a security-testing proxy is
+      # for, so the entry is stored and replayed byte-exact, never sanitised (P7; DESIGN.md §7).
+      # URI.parse copies a literal control byte verbatim into `path`/`query`, and `request_head`
+      # writes the target onto the request line as-is, which faithfully reproduces the operator's
+      # forged message on the wire — the point, not a defect. (Header/method/version smuggling is
+      # a DIFFERENT boundary and keeps its own guards below; see HEADER_INJECT.)
 
-      # URI.parse copies a reg-name authority into `host` VERBATIM without validating it — a
-      # `--urls`/HAR line like `not a url at all` becomes a stored "host" of literal spaces
+      # The HOST is the one place import still rejects a control byte or space, because there it
+      # means the string is not a URL at all — a parse failure, not a URL describing a malformed
+      # request. URI.parse copies a reg-name authority into `host` VERBATIM without validating it,
+      # so a `--urls`/HAR line like `not a url at all` becomes a stored "host" of literal spaces
       # instead of being skipped the way `ftp://…` and empty URLs already are. A real host
       # (reg-name, IPv4/IPv6 literal, punycode) never contains a space or other C0/DEL byte —
-      # userinfo, port and the `://` sit outside `uri.host` — so reject one in `endpoint`, at
-      # the same raise-to-skip point the scheme/shape checks use. Space (0x20) is what
-      # CONTROL_CHAR misses, so this widens the range to include it.
+      # userinfo, port and the `://` sit outside `uri.host` — so reject one in `endpoint`, at the
+      # same raise-to-skip point the scheme/shape checks use. The range covers all of C0, space
+      # (0x20) and DEL (0x7f).
       HOST_INVALID = /[\x00-\x20\x7f]/
 
       def self.normalize_url(url : String) : String
         u = url.strip
-        raise Gori::Error.new("invalid URL (control character): #{url.inspect}") if u.matches?(CONTROL_CHAR)
         return u if u.starts_with?(HTTP_SCHEME)
         raise Gori::Error.new("invalid URL (missing scheme): #{url}") if u.matches?(LEADING_SCHEME)
         "https://#{u}"
@@ -77,12 +77,14 @@ module Gori
       # A raw CR/LF (or NUL) inside a header NAME or VALUE forges a message boundary once
       # the head is serialized here and later replayed byte-exact (Repeater): a HAR/OAS
       # value of `"a\r\nX-Injected: evil\r\n\r\nGET /admin HTTP/1.1"` would smuggle a whole
-      # second request into the stored head. This is the header analogue of the URL
-      # smuggling normalize_url guards against — reject the entry at the SAME point (a raise
-      # here is caught by every import parser's per-entry rescue, dropping the bad entry
-      # exactly like a bad URL). Narrower than CONTROL_CHAR on purpose: a header VALUE may
-      # legally contain a horizontal tab (RFC 7230 §3.2 field-value), so only CR/LF/NUL —
-      # the bytes that can actually forge a boundary or truncate — are rejected.
+      # second request into the stored head. This guard still fires. Unlike the request
+      # TARGET — deliberately permissive now, a control byte there being the operator's own
+      # payload (see HOST_INVALID above and DESIGN.md §7) — header-boundary import was not
+      # part of the #400 decision and stays rejected pending its own call. Reject the entry
+      # at the SAME point (a raise here is caught by every import parser's per-entry rescue,
+      # dropping the bad entry exactly like a bad host). Only CR/LF/NUL: a header VALUE may
+      # legally contain a horizontal tab (RFC 7230 §3.2 field-value), so bytes that merely
+      # break a value without forging a boundary are left alone.
       HEADER_INJECT = /[\r\n\x00]/
 
       # Reject any header whose name/value could forge a message boundary (see HEADER_INJECT).
@@ -94,7 +96,8 @@ module Gori
 
       # A start-line scalar (method / statusText reason / HTTP version) that reaches the
       # request/status line: same boundary-forging risk as a header, so reject the same
-      # CR/LF/NUL bytes. (`target`/`host` come from normalize_url and are already clean.)
+      # CR/LF/NUL bytes. (`host` is cleaned by HOST_INVALID; `target` is intentionally NOT —
+      # a control byte there is the operator's payload, replayed byte-exact. See DESIGN.md §7.)
       def self.reject_inject!(field : String, label : String) : Nil
         raise Gori::Error.new("invalid #{label} (control character): #{field.inspect}") if field.matches?(HEADER_INJECT)
       end


### PR DESCRIPTION
## What

Import must **reproduce** a broken request byte-exact, not reject it — that is the point of a security-testing proxy (P7). `src/gori/import/builder.cr` rejected any control byte anywhere in an imported URL via `CONTROL_CHAR`, so an operator who exported a HAR of a deliberate CRLF-smuggling request **could not import it**. The entry was silently skipped; gori refused to carry the payload its own user built. That is the defect — the inverse of how #400 was first filed. The maintainer settled the principle (see the correction comment on #400).

## The fix

One `CONTROL_CHAR` regex was doing two jobs — "this string is not a URL" and "this is a URL describing a malformed request". Removing it and leaning on the pre-existing `HOST_INVALID` restores the distinction:

- control byte / space in the **path or query** → the operator's payload → store and replay **byte-exact**.
- control byte / space in the **host** → not a URL → `HOST_INVALID` skips the entry, exactly as before.

`URI.parse` copies raw control bytes / spaces verbatim into `path`/`query` but also into `host`, where `HOST_INVALID` (`/[\x00-\x20\x7f]/`, a superset of the old range) rejects them — so host coverage is unchanged. `HEADER_INJECT` and `reject_inject!` (CR/LF/NUL in a header name/value, method, version, reason) are **unchanged**: a separate boundary #400 did not settle.

## Proven on the wire

Per #390/#397/#401, a string-level assertion proves nothing for this bug class. `spec/repeater/import_replay_wire_spec.cr` reconstructs an imported CRLF target through the real `Repeater::Plan → Sender → socket` path and asserts the **exact bytes on the origin socket**, including the smuggled second request line and injected header. The same test asserts `Codec::Http1.request_token_safe?` returns `false` on those bytes — the #399 send-layer guard's own verdict is "unsafe", yet the replay path sent them anyway, which **proves the guard does not fire on the operator-replay path** (no regression from #399).

## Other changes

- `spec/import/import_spec.cr`: the two tests that asserted skip-on-CRLF now assert byte-exact import; added a test that a space-in-host line is still skipped.
- `DESIGN.md` §7: records the host-vs-target split and why import is deliberately permissive, so the next reader does not harden it back.

## Verification

- `just test` — 4342 examples, 0 failures.
- `crystal build --no-codegen src/main.cr` — clean.
- Touched files pass `crystal tool format --check` and ameba (remaining ameba hits are untouched baseline).
- `/code-review` — zero findings.

Closes #400