### PR TITLE
fix(scope): a repeated space in the request line bypasses both scope layers (#404)

### DIFF
--- a/spec/outbound_spec.cr
+++ b/spec/outbound_spec.cr
@@ -353,5 +353,29 @@ describe Gori::Outbound do
       Gori::Outbound.request_target("garbage").should eq("/")
       Gori::Outbound.request_target("".to_slice).should eq("/")
     end
+
+    # A request line with a REPEATED space (or a tab) must still yield the real path, not an
+    # empty string — otherwise the scope gate evaluates an empty path and silently satisfies
+    # any string/regex include/exclude rule (a full Sandbox bypass with one extra space).
+    it "recovers the target from a request line with irregular whitespace" do
+      Gori::Outbound.request_target("GET  /admin/x HTTP/1.1\r\nHost: h\r\n\r\n").should eq("/admin/x")
+      Gori::Outbound.request_target("GET   /admin/x HTTP/1.1\r\n".to_slice).should eq("/admin/x")
+      Gori::Outbound.request_target("POST\t/a/b\tHTTP/1.1\r\n").should eq("/a/b")
+    end
+
+    it "keeps the scope gate honest against a doubled-space request line" do
+      with_scope do |scope, _store|
+        scope.add("include", "host", "acme.test")
+        scope.add("exclude", "string", "/admin")
+        scope.enable_sandbox
+        ob = Gori::Outbound.interactive(scope)
+        # A well-formed request to the excluded path is blocked…
+        ob.send_block("https", "acme.test", Gori::Outbound.request_target(
+          "GET /admin/x HTTP/1.1\r\nHost: acme.test\r\n\r\n")).should eq(Gori::Outbound::SANDBOX_ERROR)
+        # …and a doubled space must NOT slip past it.
+        ob.send_block("https", "acme.test", Gori::Outbound.request_target(
+          "GET  /admin/x HTTP/1.1\r\nHost: acme.test\r\n\r\n")).should eq(Gori::Outbound::SANDBOX_ERROR)
+      end
+    end
   end
 end

--- a/src/gori/mcp/tools/send.cr
+++ b/src/gori/mcp/tools/send.cr
@@ -74,7 +74,9 @@ module Gori
       # a caller can confirm scheme/host/port/method/target/version independently
       # of which inputs it supplied (flow_id vs url/raw).
       private def emit_effective_request(j : JSON::Builder, built : RequestBuilder::Built, http2 : Bool) : Nil
-        parts = (String.new(built.bytes).each_line.first? || "").split(' ')
+        # `split` (no arg) collapses whitespace runs so a malformed request line with a
+        # doubled space still reports the real method/target/version (see Outbound.request_target).
+        parts = (String.new(built.bytes).each_line.first? || "").split
         j.field "effective_request" do
           j.object do
             j.field "scheme", built.scheme

--- a/src/gori/outbound.cr
+++ b/src/gori/outbound.cr
@@ -233,14 +233,25 @@ module Gori
     # The request-target (path) from a raw request's first line — the value every caller
     # splices into `scheme://host<target>` to match string/regex scope rules. Was copied
     # verbatim into four files before this.
+    #
+    # Split on RUNS of ASCII whitespace, not a single ' ': `"GET  /admin HTTP/1.1"` (two
+    # spaces, or a tab) otherwise splits to `["GET", "", "/admin", ...]`, so `[1]?` is the
+    # empty string — non-nil, so `|| "/"` never fires — and the scope gate then evaluates an
+    # EMPTY path, silently satisfying any string/regex include/exclude rule. That let a
+    # doubled space in the request line bypass BOTH scope layers (Sandbox included). `split`
+    # with no argument collapses whitespace runs and drops the empty parts, so the real
+    # request-target is recovered from a malformed request line. (The bytes themselves still
+    # go on the wire byte-exact — P7 — this only feeds the scope decision.)
     def self.request_target(bytes : Bytes) : String
-      line = String.new(bytes).each_line.first? || ""
-      line.split(' ')[1]? || "/"
+      request_target_line(String.new(bytes).each_line.first? || "")
     end
 
     def self.request_target(text : String) : String
-      line = text.each_line.first? || ""
-      line.split(' ')[1]? || "/"
+      request_target_line(text.each_line.first? || "")
+    end
+
+    private def self.request_target_line(line : String) : String
+      line.split[1]? || "/"
     end
 
     # The URL the gate evaluates, ALWAYS anchored on the DIAL target (the scheme/host the


### PR DESCRIPTION
Closes #404.

## Problem

`Outbound.request_target` read the request target with `line.split(' ')[1]?`, which does **not** collapse consecutive delimiters. `"GET  /admin/x HTTP/1.1"` (two spaces, or a tab) split to `["GET", "", "/admin/x", ...]`, so `[1]?` returned the empty string — non-nil, so `|| "/"` never fired — and the scope gate then evaluated an **empty path**, silently satisfying any `string`/`regex` include/exclude rule. A single extra space in the request line bypassed **both** scope layers, Sandbox included.

`request_target` is the scope seam for `send_request`, `fuzz_start`/`mine_start`/`sequence_start` (per-payload), `minimize`, and `repeater/sender.cr` (TUI repeater + `gori run repeater`), so every active surface was affected.

## Fix

Split on runs of ASCII whitespace (`split` with no argument, which also drops empty parts) so the real request-target is recovered from a malformed request line. The wire bytes are unchanged — byte-exact per P7 — this only feeds the scope decision. The duplicated `.split(' ')` in the MCP `send.cr` `effective_request` diagnostic is fixed the same way.

## Verification

- New `spec/outbound_spec.cr` cases: `request_target` recovers `/admin/x` from a doubled-space / tab request line, and an end-to-end scope-gate case proves a doubled space no longer slips past a Sandbox exclude. **Control-run**: both fail against the current code (empty target → not blocked → nil), pass with the fix.
- Full `crystal spec` green; `crystal build --no-codegen src/main.cr` clean.
- Live against the built binary (`gori run fuzz`, scope include `127.0.0.1` + exclude `/admin`, enabled):
  - before: `GET  /admin/1` and `GET  /admin/2` reached the origin
  - after: double-space `/admin` is refused (0 origin hits), a double-space `/public` still goes through (2 hits — no over-blocking)

https://claude.ai/code/session_01EvoRaFeTPQUvfrhSeSF1ba