### PR TITLE
fix(fuzz,mine,sequence,tui): a wss:// target dials CLEARTEXT (fold ws/wss at Fuzz::Origin) (#405)

### DIFF
--- a/spec/fuzz/wss_scheme_fold_spec.cr
+++ b/spec/fuzz/wss_scheme_fold_spec.cr
@@ -1,0 +1,50 @@
+require "../spec_helper"
+
+private alias F = Gori::Fuzz
+
+private def ungated : Gori::Outbound
+  Gori::Outbound.waived(nil, Gori::Outbound::Reason::NoProject)
+end
+
+private RAWREQ = "GET /chat HTTP/1.1\r\nHost: t.test\r\nCookie: s=secret\r\n\r\n"
+private MARKED = "GET /chat?q=§x§ HTTP/1.1\r\nHost: t.test\r\nCookie: s=secret\r\n\r\n"
+
+# `Repeater::Engine`/`H2Engine` decide TLS with `scheme == "https"` ALONE, so a `wss://`
+# target that reaches them unfolded dials CLEARTEXT to a TLS port. `Fuzz::Origin` folds
+# ws→http / wss→https at construction so every surface that builds one (the Fuzzer/Miner/
+# Sequencer Plan builders, Repeater Minimize on TUI/CLI/MCP, Probe active) is correct by
+# construction. Before this fold, all of these produced a `wss` origin and dialled plaintext.
+describe "Fuzz::Origin scheme fold (wss:// must not dial cleartext)" do
+  it "folds ws/wss at direct construction (the Repeater Minimize path)" do
+    F::Origin.new("wss", "t.test", 443).scheme.should eq("https")
+    F::Origin.new("ws", "t.test", 80).scheme.should eq("http")
+    F::Origin.new("https", "t.test", 443).scheme.should eq("https") # unchanged
+    F::Origin.new("http", "t.test", 80).scheme.should eq("http")    # unchanged
+  end
+
+  it "folds wss in Fuzz::Plan.build" do
+    plan = F::Plan.build(
+      F::PlanOptions.new(MARKED, target: "wss://t.test/chat",
+        sources: [F::InlineList.new(%w[a])] of F::PayloadSource,
+        config: F::Config.new(mode: F::Mode::Sniper, concurrency: 1, keep_bodies: :none),
+        matcher: F::Matcher.new(keep_bodies: :none), verify: false),
+      ungated)
+    plan.origin.scheme.should eq("https")
+  end
+
+  it "folds wss in Miner::Plan.build" do
+    plan = Gori::Miner::Plan.build(
+      Gori::Miner::PlanOptions.new(RAWREQ, target: "wss://t.test/chat",
+        config: Gori::Miner::Config.new),
+      ungated)
+    plan.origin.scheme.should eq("https")
+  end
+
+  it "folds wss in Sequencer::Plan.build" do
+    plan = Gori::Sequencer::Plan.build(
+      Gori::Sequencer::PlanOptions.new(RAWREQ.to_slice, target: "wss://t.test/chat",
+        config: Gori::Sequencer::Config.new(token_loc: Gori::Sequencer::TokenLoc.cookie("s"))),
+      ungated)
+    plan.origin!.scheme.should eq("https")
+  end
+end

--- a/src/gori/fuzz/engine.cr
+++ b/src/gori/fuzz/engine.cr
@@ -7,7 +7,29 @@ require "../scope"
 
 module Gori::Fuzz
   # The origin a run targets (also the boundary for redirect following).
-  record Origin, scheme : String, host : String, port : Int32
+  #
+  # The scheme is folded ws→http / wss→https at construction so the TLS decision is correct
+  # by construction for EVERY surface that builds an Origin — the Fuzzer/Miner/Sequencer Plan
+  # builders, Repeater Minimize (TUI/CLI/MCP), and Probe active. `Sender#send` dials through
+  # `Repeater::Engine`/`H2Engine`, which decide TLS with `scheme == "https"` ALONE, so a
+  # `wss://` target (from an operator TARGET field, `--target`, an MCP `url`, or a captured WS
+  # flow row replayed one-shot) that reached them unfolded went out CLEARTEXT to a TLS port,
+  # leaking the request's cookies and auth. Only `http`/`https` are recorded by the capture
+  # proxy, so this fold is a no-op on a normal captured origin. Repeater::Plan folds the same
+  # way on its own tuple path; centralising it here removes the ad hoc per-CLI guards.
+  struct Origin
+    getter scheme : String
+    getter host : String
+    getter port : Int32
+
+    def initialize(scheme : String, @host : String, @port : Int32)
+      @scheme = case scheme
+                when "ws"  then "http"
+                when "wss" then "https"
+                else            scheme
+                end
+    end
+  end
 
   # The send seam. Swappable so specs (and the baseline calibrator) can drive the
   # engine without a real socket.


### PR DESCRIPTION
Closes #405.

## Problem

`Repeater::Engine`/`H2Engine` decide TLS with `scheme == "https"` **alone**. `Repeater::Plan` folds `ws`→`http` / `wss`→`https` before dialing, but the sibling `Fuzz`/`Miner`/`Sequencer` Plan builders did not, and TUI/CLI/MCP Repeater **Minimize** constructs a `Fuzz::Origin` directly. A `wss://` target — from an operator TARGET field, `--target`, an MCP `url`, or a captured WebSocket flow row replayed one-shot — therefore reached the engines unfolded and dialed **cleartext** to a TLS port, leaking the request's cookies and auth headers.

## Fix

Fold the scheme at `Fuzz::Origin` construction — the single point all of these converge on (the 3 Plan builders, Repeater Minimize on all three surfaces, and Probe active). The TLS decision is now correct by construction. The capture proxy only records `http`/`https`, so the fold is a no-op on a normal origin; the per-CLI ad hoc scheme guards now only fire for genuinely unsupported schemes, and a `wss` target is accepted and dialed over TLS.

## Verification

- New `spec/fuzz/wss_scheme_fold_spec.cr` covers `Fuzz::Origin` and all three builders. **Control-run**: all 4 fail against the current code (`wss` preserved → cleartext), pass with the fold.
- `crystal spec spec/fuzz spec/miner spec/sequencer spec/probe_spec.cr` → 509 green; `crystal build --no-codegen` clean.
- Live: MCP `fuzz_start` of a captured `wss` flow now emits a TLS ClientHello (first byte `0x16`) instead of plaintext (`0x47 'G'`).

https://claude.ai/code/session_01EvoRaFeTPQUvfrhSeSF1ba