### PR TITLE
fix(proxy): M&R head rewrite desyncs body framing → self-inflicted request smuggling (#403)

### DIFF
--- a/spec/proxy/server_spec.cr
+++ b/spec/proxy/server_spec.cr
@@ -65,6 +65,32 @@ private class BodyRewriter < Gori::Proxy::HeadRewriter
   end
 end
 
+# A Match&Replace rewriter that SHRINKS the request head's Content-Length (a footgun rule,
+# or a deliberate one) without touching the body. The body streams untouched (P6), so unless
+# the head is re-synced the wire head declares fewer bytes than gori forwards — the leftover
+# tail then smuggles as a second request at the origin (#403).
+private class RequestCLShrinkRewriter < Gori::Proxy::HeadRewriter
+  def rewrite_request(head : Bytes, host : String) : Bytes
+    String.new(head).gsub(/Content-Length: \d+/, "Content-Length: 4").to_slice
+  end
+
+  def rewrite_response(head : Bytes, host : String) : Bytes
+    head
+  end
+end
+
+# The response-side counterpart: shrink the response head's Content-Length. Without a re-sync
+# the client is handed a head declaring fewer bytes than the body that follows (response split).
+private class ResponseCLShrinkRewriter < Gori::Proxy::HeadRewriter
+  def rewrite_request(head : Bytes, host : String) : Bytes
+    head
+  end
+
+  def rewrite_response(head : Bytes, host : String) : Bytes
+    String.new(head).gsub(/Content-Length: \d+/, "Content-Length: 2").to_slice
+  end
+end
+
 # Reads from a socket until `marker` appears (or the read times out / EOFs),
 # returning everything read so far. Used to frame one response off a keep-alive
 # connection without consuming the next one.
@@ -696,6 +722,62 @@ describe Gori::Proxy::Server do
 
     sink.requests.first.target.should eq("/hi")                    # capture = sent (modified) bytes
     String.new(sink.responses.first.head).should contain("200 YO") # capture = sent (modified) bytes
+  end
+
+  it "re-syncs a request head whose M&R rule changed Content-Length, so the body can't smuggle (#403)" do
+    seen_body = Channel(String).new(1)
+    done = Channel(Nil).new(1)
+    origin_port = start_body_origin("ok", seen_body)
+
+    sink = RecordingSink.new(done)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink, rewriter: RequestCLShrinkRewriter.new)
+    proxy.start
+
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    # The body's tail is a complete request line: if the shrunk Content-Length (4) reached
+    # the wire, the origin would read only "AAAA" and parse the rest as a SECOND request.
+    body = "AAAAGET /smuggled HTTP/1.1\r\nHost: x\r\n\r\n"
+    client << "POST /legit HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\nContent-Length: #{body.bytesize}\r\n\r\n" << body
+    client.flush
+    client.gets_to_end
+    client.close
+
+    done.receive
+    proxy.stop
+
+    # The origin framed the body by the head gori SENT — with the re-sync it declares the real
+    # length, so the whole body is one request (no smuggled tail). Without the fix this is "AAAA".
+    seen_body.receive.should eq(body)
+    # And the sent/captured head declares the real length, not the rewritten 4.
+    String.new(sink.requests.first.head).should contain("Content-Length: #{body.bytesize}")
+    String.new(sink.requests.first.head).should_not contain("Content-Length: 4")
+  end
+
+  it "re-syncs a response head whose M&R rule changed Content-Length, so it can't split (#403)" do
+    seen = Channel(String).new(1)
+    done = Channel(Nil).new(1)
+    origin_port = start_origin("Hello!", seen) # 6-byte body, Content-Length: 6
+
+    sink = RecordingSink.new(done)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink, rewriter: ResponseCLShrinkRewriter.new)
+    proxy.start
+
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    client << "GET /hello HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\n\r\n"
+    client.flush
+    response = client.gets_to_end
+    client.close
+
+    done.receive
+    proxy.stop
+
+    seen.receive # drain
+    # The head sent to the client declares the real body length (6), not the rewritten 2 —
+    # otherwise the 4 trailing bytes desync whatever reads the client's connection next.
+    response.should contain("Content-Length: 6")
+    response.should_not contain("Content-Length: 2")
+    response.should contain("Hello!")
+    String.new(sink.responses.first.head).should contain("Content-Length: 6")
   end
 
   it "rewrites request/response BODIES and re-frames Content-Length" do

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -213,9 +213,14 @@ module Gori::Proxy
       if rw = @rewriter
         rewritten = rw.rewrite_request(forward_head, host)
         if rewritten != forward_head
-          sent_head = rewritten
-          sent_req = Codec::Http1.parse_request_head(rewritten)
-          record_head = rw.rewrite_request(req.raw_head, host)
+          # A head rule that changed Content-Length/Transfer-Encoding must not desync the
+          # streamed body from the head we send (#403): the body streams UNTOUCHED (P6), so
+          # its framing is `forward_head`'s — restore that onto the rewritten head. No-op
+          # (byte-exact) when the rule left framing alone. `record_head` mirrors it so History
+          # shows exactly what went on the wire.
+          sent_head = restore_framing_headers(rewritten, forward_head)
+          sent_req = Codec::Http1.parse_request_head(sent_head)
+          record_head = restore_framing_headers(rw.rewrite_request(req.raw_head, host), req.raw_head)
           record_req = Codec::Http1.parse_request_head(record_head) unless record_head == req.raw_head
         end
       end
@@ -453,6 +458,17 @@ module Gori::Proxy
       # Match&Replace (response head). Framing/keep-alive/upgrade stay on the
       # ORIGINAL response so the upstream body is read correctly.
       sent_resp_head, sent_resp = apply_response_rewrite(resp_head, resp, host)
+      # A response head rule that changed Content-Length/Transfer-Encoding must not desync the
+      # body streamed to the client from the head sent (#403): the body streams UNTOUCHED, framed
+      # by the ORIGINAL response — restore that framing onto the rewritten head (byte-exact no-op
+      # when the rule left CL/TE alone) and re-parse so capture/streaming agree with the wire.
+      if sent_resp_head != resp_head
+        resynced = restore_framing_headers(sent_resp_head, resp_head)
+        unless resynced == sent_resp_head
+          sent_resp_head = resynced
+          sent_resp = Codec::Http1.parse_response_head(sent_resp_head)
+        end
+      end
       # Body framing must reflect the method the ORIGIN actually received (HEAD/CONNECT
       # are bodyless per RFC 7230 §3.3.3). A Match&Replace / intercept edit can rewrite
       # the request-line method, so key off sent_req, not the client's original req.
@@ -1251,6 +1267,46 @@ module Gori::Proxy
       end
       io << "Content-Length: " << len << eol << eol
       io.to_slice
+    end
+
+    # Force `sent_head`'s body-framing headers (Content-Length / Transfer-Encoding) to match
+    # `orig_head`'s. A head-only Match&Replace rewrite streams the body UNTOUCHED (P6), so the
+    # bytes forwarded are framed by the ORIGINAL head; if the rewrite changed CL/TE, the wire
+    # head would then declare a different body length than gori actually forwards — a
+    # self-inflicted request smuggle / response split (#403). The body-rewrite path already
+    # re-frames to the real length (reframe_to_length); this is the head-only counterpart:
+    # restore the original framing headers (in their original relative order) while keeping
+    # every other rewrite. A no-op — returning `sent_head` byte-for-byte (P7) — when the
+    # rewrite left CL/TE alone, which is the overwhelmingly common case.
+    private def restore_framing_headers(sent_head : Bytes, orig_head : Bytes) : Bytes
+      orig_framing = framing_header_lines(orig_head)
+      sent_framing = framing_header_lines(sent_head)
+      return sent_head if orig_framing == sent_framing # rewrite didn't touch framing → byte-exact
+
+      text = String.new(sent_head)
+      eol = text.index("\r\n") ? "\r\n" : "\n"
+      section = text.split(eol + eol, 2).first # headers up to the blank line
+      lines = section.split(eol)
+      io = IO::Memory.new(sent_head.size + 32)
+      io << lines.first << eol # request / status line, untouched
+      lines[1..].each do |line|
+        next if header_line_named?(line, "transfer-encoding") || header_line_named?(line, "content-length")
+        io << line << eol
+      end
+      orig_framing.each { |line| io << line << eol } # the framing that matches the streamed body
+      io << eol
+      io.to_slice
+    end
+
+    # The Content-Length / Transfer-Encoding header lines of a head, in order — the ones that
+    # decide the body boundary. Compared verbatim so an untouched rewrite stays byte-exact.
+    private def framing_header_lines(head : Bytes) : Array(String)
+      text = String.new(head)
+      eol = text.index("\r\n") ? "\r\n" : "\n"
+      section = text.split(eol + eol, 2).first
+      section.split(eol)[1..]?.try(&.select { |line|
+        header_line_named?(line, "content-length") || header_line_named?(line, "transfer-encoding")
+      }) || [] of String
     end
 
     # True when a header line's field-name (case-insensitive, ignoring leading space) is


### PR DESCRIPTION
Closes #403.

## Problem

A head-only Match&Replace rewrite streams the body **untouched** (P6), so the bytes forwarded are framed by the **original** head. When a head rule changed `Content-Length` / `Transfer-Encoding`, `client_conn.cr` wrote the rewritten head to the wire but streamed the body according to the *original* framing — so the head declared a different body length than gori actually forwarded. A well-formed client request with a `Content-Length` rewrite became **request smuggling** toward the origin; the response leg became **response splitting** toward the client. The body-rewrite path already re-frames to the real length (`reframe_to_length`); the head-only path did not.

## Fix

Restore the original framing headers (`Content-Length` / `Transfer-Encoding`) onto the rewritten head whenever the rule changed them, keeping every other rewrite. A **byte-exact no-op (P7)** when the rule left framing alone — the overwhelmingly common case. Applied on both the request and response non-hold streaming paths (the hold and body-rewrite paths already re-frame).

Per the maintainer decision on #403: **re-frame to the actual forwarded length** (consistent with the body-rewrite path), rather than sending the operator's declared-but-wrong length as a deliberate desync — crafting an exact desync belongs in the Repeater / intercept-edit, which forward byte-exact.

## Verification

- Two new `spec/proxy/server_spec.cr` end-to-end cases: a request head rule and a response head rule that each shrink `Content-Length`. **Control-run**: both fail without the fix (origin reads a truncated body and the tail smuggles as a second request / the client head under-declares), pass with it.
- `crystal spec spec/proxy spec/rules_spec.cr` → 307 green; `crystal build --no-codegen` clean.
- Live: with an active `Content-Length -> 4` rewriter rule, the wire now carries the real length and the embedded request stays body content instead of a smuggled second request.

https://claude.ai/code/session_01EvoRaFeTPQUvfrhSeSF1ba