### PR TITLE
fix(discover): seed Layer-2 gate uses a port-bearing URL, breaking non-default ports both ways (#407)

### DIFF
--- a/spec/discover/engine_spec.cr
+++ b/spec/discover/engine_spec.cr
@@ -67,6 +67,26 @@ private def notfound : R
   make(404, "not found here")
 end
 
+# Allows every url but records the exact string each Layer-2 gate is asked about — so a spec
+# can assert the seed and its derived paths are gated on the PORT-LESS form (#407).
+private class RecordingScope < D::ScopePolicy
+  def initialize(@asked : Array(String))
+  end
+
+  def allowed?(url : String, host : String) : Bool
+    @asked << url
+    true
+  end
+
+  def boundary?(url : String, host : String) : Bool
+    true
+  end
+
+  def configured? : Bool
+    false
+  end
+end
+
 # A ScopePolicy that denies an exact URL set — the shape `StoreScope#allowed?` takes for a
 # regex EXCLUDE rule, or for Sandbox with the host off the allowlist. `configured?` is false
 # so ScopeAware containment falls back to same-origin and only `allowed?` (Layer 2) is under
@@ -819,5 +839,22 @@ describe Gori::Discover::Engine do
     end
     sent.should contain("/clean")
     sent.none?(&.includes?('\r')).should be_true
+  end
+
+  # #407: gori's scope model has no port dimension (Scope.request_url is "scheme://host/target"),
+  # so every Layer-2 gate must ask the PORT-LESS url. The seed check, enqueue_well_known and
+  # enqueue_seed_only_calibration used Url.normalize/origin, which append :port on a non-default
+  # port — so a host-qualified string/regex include falsely denied the seed and an exclude failed
+  # open. This records every url handed to the scope and proves none carries the port.
+  it "asks the scope the port-less url for the seed and its derived paths (#407)" do
+    asked = [] of String
+    scope = RecordingScope.new(asked)
+    cfg = D::Config.new(spider: true, bruteforce: false, retries: 0, max_depth: 1)
+    # A non-default port on the seed — the exact case that regressed.
+    engine = D::Engine.new("http://acme.test:8443/", [] of String, RouteBackend.new(->(_t : String) { notfound }), cfg, scope)
+    engine.run { |_ev| }
+    asked.should_not be_empty
+    asked.select(&.includes?("8443")).should eq([] of String) # never the port-bearing form
+    asked.all?(&.starts_with?("http://acme.test/")).should be_true
   end
 end

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -241,8 +241,12 @@ module Gori::Discover
           # blocked seed blocks everything derived from it, so the alternative is a run that
           # finishes with zero findings and no reason, which reads as "there is nothing
           # there" instead of "gori sent nothing" (P4).
+          # `gate_url`, not `normalize`: gori's scope model has no port dimension, so a
+          # port-bearing URL misses a host-qualified string/regex include/exclude and the
+          # seed check both falsely denies a legitimate non-default-port target and fails
+          # open on an exclude (#407). Report the normalized URL, but ASK the port-less one.
           seed_norm = Url.normalize(sp)
-          @scope.allowed?(seed_norm, sp.host) ? nil : "#{SEED_BLOCKED}: #{seed_norm}"
+          @scope.allowed?(Url.gate_url(sp), sp.host) ? nil : "#{SEED_BLOCKED}: #{seed_norm}"
         end
       @seed_parts = sp || Url::Parts.new("http", "invalid.invalid", 80, "/", nil)
       # A path-scoped run (seed path deeper than "/") confines discovery to that subtree.
@@ -440,8 +444,11 @@ module Gori::Discover
     # #364). A blocked one is skipped silently rather than failing the run: unlike the seed,
     # the crawl is still meaningful without it.
     private def enqueue_well_known(url : String, source : Source) : Nil
-      # `url` is built from Url.origin(@seed_parts), so its host IS the seed's host.
-      return unless @scope.allowed?(url, @seed_parts.host)
+      # `url` is built from Url.origin(@seed_parts), so its host IS the seed's host. Gate on the
+      # PORT-LESS form (gate_url) — gori's scope has no port dimension, so a port-bearing URL
+      # misses a host-qualified string/regex rule (#407). `url` keeps its port for the Fetch.
+      gate = (p = Url.parse(url)) ? Url.gate_url(p) : url
+      return unless @scope.allowed?(gate, @seed_parts.host)
       @frontier << Task.new(TaskKind::Fetch, url, 0, source)
     end
 
@@ -454,8 +461,9 @@ module Gori::Discover
     # seed's formerly ungated blast radius (#364).
     private def enqueue_seed_only_calibration(dir : String) : Nil
       return if @dirs.includes?(dir)
-      return unless Url.parse(dir)
-      return unless @scope.allowed?(dir, @seed_parts.host)
+      return unless p = Url.parse(dir)
+      # Gate on the PORT-LESS form (#407), same as the seed and well-known checks.
+      return unless @scope.allowed?(Url.gate_url(p), @seed_parts.host)
       @dirs << dir
       @frontier << Task.new(TaskKind::Calibrate, dir, 0, Source::Bruteforced, dir: dir, seed_only: true)
     end


### PR DESCRIPTION
Closes #407. Follow-up to #389/#391.

## Problem

gori's scope model has no port dimension — `Scope.request_url` is `scheme://host/target` and every Layer-2 consumer judges a **port-less** URL. `Url.gate_url` was added (`d64428e`) for exactly this and wired into `bounded_url`/`probe_allowed?`/`send_with_retries`, but the three **seed-gate** sites still used `Url.normalize`/`Url.origin`, which append `:port` on a non-default port. So on 8080/8443/etc:

- a host-qualified `string`/`regex` **include** falsely denied the seed (`seed blocked by scope`) — Discover broke outright for common staging ports;
- an **exclude** failed open — the loud terminal refusal #389/#391 guarantee never fired (only `send_with_retries`' own re-derived gate stopped the bytes).

`Url.gate_url`'s own doc comment describes this bug.

## Fix

Ask `gate_url` at all three sites — the seed `SEED_BLOCKED` check, `enqueue_well_known`, and `enqueue_seed_only_calibration` — matching the three lines the same PR already fixed. All six `@scope.allowed?` sites in `engine.cr` now use the port-less form.

## Verification

- New `spec/discover/engine_spec.cr` case records every URL handed to the scope for a `:8443` seed and asserts none carries the port. **Control-run**: fails without the fix (records `http://acme.test:8443/…`), passes with it.
- `crystal spec spec/discover` → 172 green.

https://claude.ai/code/session_01EvoRaFeTPQUvfrhSeSF1ba