### PR TITLE
fix(cli): gori run repeater send/replay/minimize skip the Layer-1 scope allowlist (#406)

### DIFF
--- a/spec/cli_run_spec.cr
+++ b/spec/cli_run_spec.cr
@@ -265,6 +265,43 @@ module Gori::CLI::Run
   end
 end
 
+# #406: `gori run repeater send/<flow-id>/minimize` ran only the Layer-2 (Sandbox/exclude)
+# gate, so a configured project scope was silently inert and there was no --allow-unscoped
+# waiver — unlike fuzz/mine/sequence/discover and MCP. `repeater_out_of_scope?` is the Layer-1
+# decision `abort_if_out_of_scope!` acts on; a Gate::Configured outbound must refuse an
+# out-of-scope origin and a waived one must not.
+module Gori::CLI::Run
+  def self.repeater_out_of_scope_for_spec(ob : Gori::Outbound, plan : Gori::Repeater::Plan) : Bool
+    repeater_out_of_scope?(ob, plan)
+  end
+end
+
+describe "gori run repeater — Layer-1 scope gate (#406)" do
+  it "refuses an out-of-scope origin under a configured scope, and honours --allow-unscoped" do
+    path = File.tempname("gori-repscope", ".db")
+    store = Gori::Store.open(path)
+    begin
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "in.test") # 127.0.0.1 is NOT in scope
+      plan = Gori::Repeater::Plan.build(
+        Gori::Repeater::PlanOptions.new(["GET /x HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n".to_slice],
+          target: "http://127.0.0.1:9/x"), Gori::Outbound.cli(scope, false))
+      # Layer 1 (Gate::Configured) refuses it...
+      Gori::CLI::Run.repeater_out_of_scope_for_spec(Gori::Outbound.cli(scope, false), plan).should be_true
+      # ...and --allow-unscoped (the operator waiver) lets it through.
+      Gori::CLI::Run.repeater_out_of_scope_for_spec(Gori::Outbound.cli(scope, true), plan).should be_false
+      # An in-scope origin is never refused.
+      in_plan = Gori::Repeater::Plan.build(
+        Gori::Repeater::PlanOptions.new(["GET /x HTTP/1.1\r\nHost: in.test\r\n\r\n".to_slice],
+          target: "http://in.test/x"), Gori::Outbound.cli(scope, false))
+      Gori::CLI::Run.repeater_out_of_scope_for_spec(Gori::Outbound.cli(scope, false), in_plan).should be_false
+    ensure
+      store.close
+      File.delete?(path); File.delete?("#{path}-wal"); File.delete?("#{path}-shm")
+    end
+  end
+end
+
 describe "gori run repeater send (session row → PlanOptions mapping)" do
   it "maps the session's target, http2, SNI and auto-CL toggle onto the plan" do
     rec = Gori::Store::RepeaterRecord.new(1_i64, "https://h.test:8443",

--- a/src/gori/cli/run/repeater.cr
+++ b/src/gori/cli/run/repeater.cr
@@ -207,6 +207,24 @@ module Gori
         abort "#{prefix}: #{reason}"
       end
 
+      # The Layer-1 (include-list) gate for the hand-authored repeater send paths. `abort_if_blocked!`
+      # above (plan.refusal → Outbound#send_block) is Layer 2 (Sandbox/exclude) ONLY; without this the
+      # configured project scope was silently inert for `gori run repeater` and there was no
+      # --allow-unscoped waiver, unlike the sibling fuzz/mine/sequence/discover CLIs and MCP's
+      # send_gate (#406). DESIGN.md §3 lists repeater as gated on BOTH layers.
+      private def self.abort_if_out_of_scope!(outbound : Gori::Outbound, plan : Repeater::Plan, prefix : String) : Nil
+        return unless repeater_out_of_scope?(outbound, plan)
+        outbound.close
+        abort "#{prefix}: #{plan.host} is out of the project scope — add a scope include rule or pass --allow-unscoped"
+      end
+
+      # The Layer-1 verdict `abort_if_out_of_scope!` acts on, split out so it can be asserted
+      # without the process-exiting `abort`. True = the include list refuses this plan's origin.
+      private def self.repeater_out_of_scope?(outbound : Gori::Outbound, plan : Repeater::Plan) : Bool
+        target = (bytes = plan.requests.first?) ? Gori::Outbound.request_target(bytes) : "/"
+        outbound.check_request(plan.scheme, plan.host, target).blocked?
+      end
+
       # A saved repeater SESSION row IS the option set: its target, http2 toggle, SNI and
       # auto-Content-Length switch, straight into the one builder every surface assembles
       # through. The builder classifies the request as a WebSocket upgrade too, so the
@@ -273,6 +291,7 @@ module Gori
         format = :text
         ws_messages = [] of String
         idle_ms : Int64? = nil
+        allow_unscoped = false
         positional = [] of String
 
         parser = OptionParser.new do |p|
@@ -283,6 +302,7 @@ module Gori
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("-k", "--insecure-upstream", "Do not verify the upstream TLS certificate") { insecure = true }
           p.on("--diff", "Diff the new response against the session's last stored response") { do_diff = true }
+          p.on("--allow-unscoped", "Send even if the target is outside the project scope (Sandbox/exclude still apply)") { allow_unscoped = true }
           p.on("--message=TEXT", "WebSocket: outbound text message (repeatable; replaces the session's stored messages)") { |v| ws_messages << v }
           p.on("--idle-ms=N", "WebSocket: server-silence timeout after the first inbound frame (100-60000, default 3000)") { |v| idle_ms = parse_count(v, "--idle-ms").to_i64 }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
@@ -308,13 +328,16 @@ module Gori
         # The scope decision every active send passes through. `gori run repeater` dials
         # Repeater::Engine/H2Engine/WsEngine directly, bypassing the proxy's own gate, so
         # Sandbox mode's "blocks ALL out-of-scope traffic" promise lives here.
-        outbound = project_outbound(project_name, db_path, false)
+        outbound = project_outbound(project_name, db_path, allow_unscoped)
 
         plan = begin
           Repeater::Plan.build(session_plan_options(rec, insecure, host_overrides), outbound)
         rescue ex : Repeater::PlanError
           repeater_plan_abort("gori run repeater send", ex, "session ##{id}")
         end
+
+        # Layer 1 (include list) BEFORE Layer 2 — mirrors fuzz/mine/sequence and MCP send_gate.
+        abort_if_out_of_scope!(outbound, plan, "gori run repeater send")
 
         if plan.websocket?
           cmd_repeater_send_ws(id, plan, project_name, db_path, idle_ms, ws_messages, outbound, format)
@@ -588,6 +611,7 @@ module Gori
         format = :text
         headers = [] of String
         body_override : String? = nil
+        allow_unscoped = false
         positional = [] of String
 
         parser = OptionParser.new do |p|
@@ -606,6 +630,7 @@ module Gori
           p.on("--diff", "Diff the new response against the captured one") { do_diff = true }
           p.on("-HHEADER", "--header=HEADER", "Custom header to overwrite/add (repeatable). An explicit Content-Length is honored verbatim (no auto-resync) for CL-mismatch testing") { |v| headers << v }
           p.on("-bBODY", "--body=BODY", "Request body override") { |v| body_override = v }
+          p.on("--allow-unscoped", "Send even if the target is outside the project scope (Sandbox/exclude still apply)") { allow_unscoped = true }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args { |rest, _| positional = rest }
@@ -672,7 +697,7 @@ module Gori
         body_bytes = raw_bytes[crlf_crlf_idx + 4..]
 
         wire, explicit_cl = build_single_flow_request(head_bytes, body_bytes, headers, body_override, target_override)
-        outbound = project_outbound(project_name, db_path, false)
+        outbound = project_outbound(project_name, db_path, allow_unscoped)
         plan = begin
           Repeater::Plan.build(Repeater::PlanOptions.new([wire],
             target: target_override, default_target: built.target,
@@ -682,6 +707,8 @@ module Gori
         rescue ex : Repeater::PlanError
           repeater_plan_abort("gori run repeater", ex)
         end
+        # Layer 1 (include list) BEFORE Layer 2 — mirrors fuzz/mine/sequence and MCP send_gate.
+        abort_if_out_of_scope!(outbound, plan, "gori run repeater")
         abort_if_blocked!(plan, "gori run repeater")
         result = plan.send
         outbound.close

--- a/src/gori/cli/run/repeater_minimize.cr
+++ b/src/gori/cli/run/repeater_minimize.cr
@@ -11,6 +11,7 @@ module Gori
         insecure = false
         apply = false
         format = :text
+        allow_unscoped = false
         positional = [] of String
 
         parser = OptionParser.new do |p|
@@ -23,6 +24,7 @@ module Gori
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("--apply", "Write the minimized request back into the repeater session") { apply = true }
           p.on("-k", "--insecure", "Do not verify the upstream TLS certificate") { insecure = true }
+          p.on("--allow-unscoped", "Minimize even if the target is outside the project scope (Sandbox/exclude still apply)") { allow_unscoped = true }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args { |rest, _| positional = rest }
@@ -45,7 +47,7 @@ module Gori
           store.close
         end
         abort "gori run repeater minimize: no repeater session ##{id}" unless rec
-        outbound = project_outbound(project_name, db_path, false)
+        outbound = project_outbound(project_name, db_path, allow_unscoped)
 
         text = String.new(rec.request)
         scheme, host, port = minimize_target_or_abort(id, rec, text, outbound)
@@ -105,7 +107,14 @@ module Gori
         scheme, host, port = Repeater::FlowRequest.parse_target(Env.expand(rec.target))
         abort "gori run repeater minimize: could not determine a target host for session ##{id}" if host.empty?
         abort "gori run repeater minimize: unsupported target scheme #{scheme.inspect} (use http:// or https://)" unless scheme.in?("http", "https")
-        if reason = outbound.send_block(scheme, host, Gori::Outbound.request_target(text))
+        target = Gori::Outbound.request_target(text)
+        # Layer 1 (include list): the configured project scope, waivable with --allow-unscoped —
+        # mirrors fuzz/mine/sequence and MCP minimize's scope_refusal (#406).
+        if outbound.check_request(scheme, host, target).blocked?
+          abort "gori run repeater minimize: #{host} is out of the project scope — add a scope include rule or pass --allow-unscoped"
+        end
+        # Layer 2 (Sandbox / exclude): applies even under --allow-unscoped.
+        if reason = outbound.send_block(scheme, host, target)
           abort "gori run repeater minimize: #{reason}"
         end
         {scheme, host, port}


### PR DESCRIPTION
Closes #406.

## Problem

`gori run repeater send`, `gori run repeater <flow-id>`, and `gori run repeater minimize` ran only the **Layer-2** gate (`plan.refusal` / `send_block` → Sandbox + exclude), which is **off by default** — so a project's configured **include list** was silently inert for these commands, and there was no `--allow-unscoped` waiver. DESIGN.md §3 lists repeater as gated on **both** layers, and the sibling `fuzz`/`mine`/`sequence`/`discover` CLIs (`guard_outbound`) and MCP's `send_gate`/`scope_refusal` all enforce Layer 1. This predates and survived the #354/#361 single-chokepoint refactor (`c07f7c9` swapped the old Sandbox-only reason for the new Sandbox-only `send_block`).

## Fix

Add the Layer-1 check (`outbound.check_request`) before the existing Layer-2 gate on all three commands, plus an `--allow-unscoped` flag threaded to `project_outbound` — mirroring the sibling commands exactly. The waiver lifts only Layer 1; Sandbox/exclude still apply.

## Verification

- New `spec/cli_run_spec.cr` case pins the Layer-1 verdict: refused under a configured scope, waived by `--allow-unscoped`, never refused in-scope. **Control-run**: the spec references the new helper (compile error without it).
- `crystal spec spec/cli_run_spec.cr spec/outbound_spec.cr` → 55 green.
- Live against the built binary (include host + Sandbox off): `repeater send` and `repeater minimize` to an out-of-scope target are now refused (exit 1, 0 bytes on the wire) and go through with `--allow-unscoped`.

https://claude.ai/code/session_01EvoRaFeTPQUvfrhSeSF1ba