### PR TITLE
fix(proxy): HTTP/2 CONTINUATION spoofing + stream-slot DoS + dead MAX_PAYLOAD guard (#409, #412, #417)

### DIFF
--- a/spec/proxy/h2/assembler_spec.cr
+++ b/spec/proxy/h2/assembler_spec.cr
@@ -251,4 +251,58 @@ describe Gori::Proxy::H2::Assembler do
     sink.responses.first.status.should eq(200)
     String.new(sink.responses.first.body.not_nil!).should eq("pushed body")
   end
+
+  # #409: a CONTINUATION frame with no preceding un-terminated HEADERS is a protocol violation
+  # (RFC 9113 §6.10). A hostile peer sends a lone one to FABRICATE a flow on a never-opened
+  # stream — after which the real HEADERS that arrive later would be dropped, spoofing gori's
+  # view. It must be ignored, and must not open/track the stream.
+  it "drops a lone CONTINUATION on a never-opened stream and still emits the real request" do
+    sink = RecSink.new
+    assembler = Gori::Proxy::H2::Assembler.new(sink, "example.com", 443, 1_i64)
+    # A single CONTINUATION with END_HEADERS|END_STREAM, empty payload, on a stream that never
+    # had HEADERS — the fabrication primitive.
+    assembler.feed("out", Frame::Header.new(Frame::Type::Continuation.value,
+      Frame::END_HEADERS | Frame::END_STREAM, 3_u32, Bytes.empty))
+    sink.requests.should be_empty # nothing fabricated
+
+    # The genuine request on the same stream id must still be assembled (not shadowed by a phantom).
+    assembler.feed("out", headers_frame(3_u32, Frame::END_HEADERS | Frame::END_STREAM,
+      hexb("828684418cf1e3c2e5f23a6ba0ab90f4ff")))
+    sink.requests.size.should eq(1)
+    sink.requests.first.method.should eq("GET")
+    sink.requests.first.host.should eq("www.example.com")
+  end
+
+  # #409: a CONTINUATION after a header block already ended (END_HEADERS seen) must also drop,
+  # not append to / re-emit the finished stream.
+  it "drops a CONTINUATION that arrives after the header block already ended" do
+    sink = RecSink.new
+    assembler = Gori::Proxy::H2::Assembler.new(sink, "example.com", 443, 1_i64)
+    assembler.feed("out", headers_frame(5_u32, Frame::END_HEADERS | Frame::END_STREAM,
+      hexb("828684418cf1e3c2e5f23a6ba0ab90f4ff")))
+    sink.requests.size.should eq(1)
+    # A trailing CONTINUATION with a bogus block — awaiting_continuation is already false.
+    assembler.feed("out", Frame::Header.new(Frame::Type::Continuation.value,
+      Frame::END_HEADERS, 5_u32, Bytes[0x88_u8, 0x88_u8]))
+    sink.requests.size.should eq(1) # not re-emitted, not corrupted
+  end
+
+  # #412: only HEADERS opens a stream. A flood of frames that never open one (PRIORITY /
+  # WINDOW_UPDATE / DATA / RST for an unknown id) must not consume MAX_LIVE_STREAMS slots and
+  # blind capture for the rest of the connection.
+  it "does not let non-opening frames exhaust the live-stream cap" do
+    sink = RecSink.new
+    assembler = Gori::Proxy::H2::Assembler.new(sink, "example.com", 443, 1_i64)
+    # More WINDOW_UPDATE frames than the cap, each on a distinct unknown (even) stream id.
+    (1_u32..1500_u32).each do |i|
+      sid = i * 2
+      assembler.feed("in", Frame::Header.new(Frame::Type::WindowUpdate.value, 0_u8, sid,
+        Bytes[0_u8, 0_u8, 0_u8, 1_u8]))
+    end
+    # A genuine request on a fresh odd id must still be tracked and emitted.
+    assembler.feed("out", headers_frame(9001_u32, Frame::END_HEADERS | Frame::END_STREAM,
+      hexb("828684418cf1e3c2e5f23a6ba0ab90f4ff")))
+    sink.requests.size.should eq(1)
+    sink.requests.first.method.should eq("GET")
+  end
 end

--- a/spec/proxy/h2/frame_spec.cr
+++ b/spec/proxy/h2/frame_spec.cr
@@ -65,4 +65,18 @@ describe Gori::Proxy::H2::Frame do
     settings_ack = Frame::Header.new(Frame::Type::Settings.value, Frame::ACK, 0_u32, Bytes.empty)
     settings_ack.ack?.should be_true
   end
+
+  # #417: MAX_PAYLOAD is the 24-bit length field's true maximum, so the default `read` never
+  # rejects a well-formed frame (a relay must forward whatever the peer legally sends) — but a
+  # caller passing a SMALLER cap gets a real, firing guard (it used to be 1<<24, one more than
+  # any 24-bit length, so `len > max_payload` could never be true).
+  it "caps the frame payload at the 24-bit maximum, and a tighter cap bites" do
+    Frame::MAX_PAYLOAD.should eq((1 << 24) - 1)
+    # A 300-byte frame is accepted by default...
+    payload = Bytes.new(300, 0xab_u8)
+    wire = Frame::Header.new(Frame::Type::Data.value, 0_u8, 1_u32, payload).to_bytes
+    Frame.read(IO::Memory.new(wire)).not_nil!.payload.size.should eq(300)
+    # ...but rejected when the caller asks for a tighter ceiling.
+    expect_raises(Gori::Error, /too large/) { Frame.read(IO::Memory.new(wire), max_payload: 100) }
+  end
 end

--- a/src/gori/proxy/h2/assembler.cr
+++ b/src/gori/proxy/h2/assembler.cr
@@ -45,6 +45,11 @@ module Gori::Proxy::H2
       # MAX_HEADER_LIST) only bound ONE block; this bounds the accumulation.
       property header_bytes = 0
       property ended = false
+      # True between a HEADERS without END_HEADERS and the CONTINUATION that ends the block.
+      # A CONTINUATION is only legal while this holds (RFC 9113 §6.10); one arriving otherwise
+      # is a protocol violation a hostile peer uses to fabricate or erase a flow, so it is
+      # dropped (#409).
+      property awaiting_continuation = false
     end
 
     private class Stream
@@ -79,8 +84,21 @@ module Gori::Proxy::H2
     end
 
     private def feed_locked(direction : String, frame : Frame::Header) : Nil
+      # PUSH_PROMISE opens the PROMISED stream itself (with its own cap check) and never touches
+      # frame.stream_id's slot, so handle it before the lookup below — otherwise it would
+      # allocate an unused Stream for the associated id.
+      if frame.frame_type == Frame::Type::PushPromise
+        handle_push_promise(direction, frame, direction == "out" ? @req_decoder : @resp_decoder)
+        return
+      end
+
       stream = @streams[frame.stream_id]?
       if stream.nil?
+        # Only HEADERS opens a stream. Every other frame for an UNKNOWN stream id — DATA,
+        # PRIORITY, WINDOW_UPDATE, RST_STREAM, a bare CONTINUATION — must not allocate a
+        # tracking slot, or a cheap flood of them exhausts MAX_LIVE_STREAMS and blinds capture
+        # for the rest of the connection (#412). The raw frame log stays the truth (P7).
+        return unless frame.frame_type == Frame::Type::Headers
         return if @streams.size >= MAX_LIVE_STREAMS # at cap — don't track new streams
         stream = @streams[frame.stream_id] = Stream.new
       end
@@ -107,11 +125,24 @@ module Gori::Proxy::H2
         return
       when Frame::Type::Headers
         append_header_fragment(side, header_block(frame))
-        finish_header_block(side, decoder) if frame.end_headers?
+        if frame.end_headers?
+          side.awaiting_continuation = false
+          finish_header_block(side, decoder)
+        else
+          side.awaiting_continuation = true # a CONTINUATION may now legally follow
+        end
         side.ended = true if frame.end_stream?
       when Frame::Type::Continuation
+        # A CONTINUATION with no open (un-terminated) header block is a protocol violation
+        # (RFC 9113 §6.10) — a hostile peer uses one to complete a fabricated flow on a
+        # never-opened stream, or to append to an already-finished one, spoofing gori's view
+        # even though the raw frame log stays byte-exact. Drop it (#409).
+        return unless side.awaiting_continuation
         append_header_fragment(side, frame.payload)
-        finish_header_block(side, decoder) if frame.end_headers?
+        if frame.end_headers?
+          side.awaiting_continuation = false
+          finish_header_block(side, decoder)
+        end
         # END_STREAM is illegal on CONTINUATION (RFC 7540 §6.10) but a hostile peer
         # can set it; mirror HEADERS/DATA so the request still emits and the stream
         # closes — otherwise it's silently dropped and the stream leaks (P7).
@@ -119,9 +150,6 @@ module Gori::Proxy::H2
       when Frame::Type::Data
         side.body.write(data_block(frame))
         side.ended = true if frame.end_stream?
-      when Frame::Type::PushPromise
-        handle_push_promise(direction, frame, decoder)
-        return
       else
         return
       end

--- a/src/gori/proxy/h2/frame.cr
+++ b/src/gori/proxy/h2/frame.cr
@@ -14,9 +14,13 @@ module Gori::Proxy::H2
 
     HEADER_SIZE = 9
 
-    # The default SETTINGS_MAX_FRAME_SIZE (RFC 7540 §6.5.2); we accept up to a
-    # generous cap to avoid unbounded allocation from a malformed length field.
-    MAX_PAYLOAD = 16 * 1024 * 1024
+    # The largest value the 24-bit frame length field can hold (RFC 7540 §4.1) — the
+    # inherent hard ceiling on one frame's payload, so `read`'s default never rejects a
+    # well-formed frame (a relay must forward whatever the peer legally sends). It was
+    # `16 * 1024 * 1024` (= 1<<24), one MORE than any 24-bit length, so the `len > max_payload`
+    # guard could never fire; naming the true maximum makes the guard honest and lets a caller
+    # that wants a tighter cap pass a smaller `max_payload` to `read` and have it bite.
+    MAX_PAYLOAD = (1 << 24) - 1
 
     enum Type : UInt8
       Data         = 0x0


### PR DESCRIPTION
Closes #409, #412, #417. Three defects in the h2 frame → flow projection (the raw frame log stays byte-exact; this hardens gori's analyst-facing view — History/QL/Repeater/MCP).

## #409 — CONTINUATION spoofing (high)

A CONTINUATION frame was processed with no requirement that a HEADERS-without-END_HEADERS preceded it (RFC 9113 §6.10). A single 9-byte CONTINUATION with `END_HEADERS|END_STREAM` **fabricated** a flow on a never-opened stream (after which the real HEADERS were dropped), or **appended to** an already-finished one — a probed origin (or MITM'd client) could rewrite gori's record of what happened with one frame. Fix: track a per-side `awaiting_continuation` flag and drop a CONTINUATION that arrives outside an open header block.

## #412 — stream-slot exhaustion (medium)

`MAX_LIVE_STREAMS` was checked before the frame-type dispatch, so PRIORITY / WINDOW_UPDATE / DATA / bare-CONTINUATION frames for an unknown stream id each allocated a tracking slot. ~1024 tiny frames (~14 KB) filled the cap and blinded capture for the rest of the connection. Fix: only HEADERS opens a stream (PUSH_PROMISE opens the promised stream itself, now handled before the lookup); every other frame for an unknown id no-ops without a slot.

## #417 — dead MAX_PAYLOAD guard (low)

`MAX_PAYLOAD` was `1<<24`, one more than any 24-bit length field, so `len > max_payload` in `Frame.read` could never fire. Set it to the true 24-bit maximum `(1<<24)-1`: the default accepts every well-formed frame (a relay must forward what the peer legally sends), while a caller-supplied tighter cap actually bites.

## Verification

- Four new specs (`assembler_spec.cr`, `frame_spec.cr`). **Control-run**: the fabrication, DoS, and payload-cap cases fail without the fix and pass with it.
- Existing 47 h2 specs and the full `spec/proxy` suite (297) stay green.

https://claude.ai/code/session_01EvoRaFeTPQUvfrhSeSF1ba