### PR TITLE
fix(store): a capture/TUI session corrupts import-created Pending flows to Error (#408)

### DIFF
--- a/spec/store/store_spec.cr
+++ b/spec/store/store_spec.cr
@@ -386,7 +386,8 @@ describe Gori::Store do
         .should eq("GET /x HTTP/1.1\r\nHost: h\r\n\r\n")
 
       Gori::Store::Schema.migrate!(db)
-      db.scalar("PRAGMA user_version").as(Int64).should eq(2_i64)
+      # Migrates all the way to the current schema (the V2 UPDATE this test targets runs en route).
+      db.scalar("PRAGMA user_version").as(Int64).should eq(Gori::Store::Schema::VERSION.to_i64)
 
       recovered = db.query_one("SELECT request FROM repeaters WHERE target = 'https://a.test'", as: Bytes)
       recovered.should eq(with_nul) # full byte-for-byte recovery, embedded NUL and all

--- a/spec/store_extras_spec.cr
+++ b/spec/store_extras_spec.cr
@@ -230,3 +230,33 @@ describe "Gori::Store project-tab aggregates (AT A GLANCE viz)" do
     end
   end
 end
+
+# #408: abandon_pending! finalises orphaned in-flight Pending rows to Error on session
+# start/stop, but an `import --urls`/`--oas` reference is stored Pending with a nil response ON
+# PURPOSE and will never be sent. It must be left alone, not corrupted into a fake network error.
+private def abandon_req(target : String) : Gori::Store::CapturedRequest
+  Gori::Store::CapturedRequest.new(
+    created_at: 1_i64, scheme: "http", host: "h.test", port: 80,
+    method: "GET", target: target, http_version: "HTTP/1.1",
+    head: "GET #{target} HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice, body: nil)
+end
+
+describe "Gori::Store#abandon_pending! and imported reference placeholders" do
+  it "abandons an orphaned in-flight flow but not an unsent import placeholder" do
+    with_store do |store|
+      # An in-flight proxy capture (request in, response never arrived).
+      inflight = store.insert_flow(abandon_req("/in-flight"))
+      # An import reference: a Pending row with a nil response, stored unsent.
+      store.insert_import_batch([{abandon_req("/imported-ref"), nil.as(Gori::Store::CapturedResponse?)}])
+      imported = store.get_flow(inflight + 1).not_nil!.row.id
+
+      store.abandon_pending!("orphaned by a previous session")
+
+      store.get_flow(inflight).not_nil!.row.state.should eq(Gori::Store::FlowState::Error)
+      # The import placeholder stays Pending, with no fabricated error.
+      ref = store.get_flow(imported).not_nil!
+      ref.row.state.should eq(Gori::Store::FlowState::Pending)
+      ref.error.should be_nil
+    end
+  end
+end

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -353,7 +353,9 @@ module Gori
                   batch_reply = op.reply
                   inserted = [] of {Int64, Bool}
                   op.pairs.each do |req, resp|
-                    id, req_fts = insert_one(c, req)
+                    # A response-less import pair is a reference placeholder that will never be
+                    # sent — mark it `unsent` so abandon_pending! never fabricates an error for it (#408).
+                    id, req_fts = insert_one(c, req, unsent: resp.nil?)
                     has_resp = !resp.nil?
                     if r = resp
                       # Hand update_one the request FTS text we just computed so its memo
@@ -498,15 +500,18 @@ module Gori
       # caller gone / channel closed — nothing to unblock
     end
 
-    # Bulk-mark every Pending flow Error; returns the ids touched (for events).
+    # Bulk-mark every Pending flow Error; returns the ids touched (for events). `unsent` rows
+    # (import reference placeholders that were never sent) are EXCLUDED — they are permanently
+    # Pending by design, not orphaned in-flight captures, so finalising them to Error would
+    # fabricate a network failure for data the operator imported (#408).
     private def abandon_all_pending(conn : DB::Connection, message : String) : Array(Int64)
       ids = [] of Int64
-      conn.query("SELECT id FROM flows WHERE state = ?", FlowState::Pending.value) do |rs|
+      conn.query("SELECT id FROM flows WHERE state = ? AND unsent = 0", FlowState::Pending.value) do |rs|
         rs.each { ids << rs.read(Int64) }
       end
       return ids if ids.empty?
       conn.exec(
-        "UPDATE flows SET state = ?, error = ?, status = 0 WHERE state = ?",
+        "UPDATE flows SET state = ?, error = ?, status = 0 WHERE state = ? AND unsent = 0",
         FlowState::Error.value, message, FlowState::Pending.value)
       ids
     end
@@ -527,7 +532,7 @@ module Gori
     # Inserts the request row + its FTS entry, returning {id, req_fts} so the caller can
     # hand the already-computed request-side FTS text to update_one (post-commit) instead of
     # reading the head+body back out of the row.
-    private def insert_one(conn : DB::Connection, req : CapturedRequest) : {Int64, String}
+    private def insert_one(conn : DB::Connection, req : CapturedRequest, unsent : Bool = false) : {Int64, String}
       # request_size is the TRUE wire size (body_size when the BLOB was truncated),
       # so the History size column stays honest even for a capped body.
       body_size = req.body_size || req.body.try(&.size.to_i64) || 0_i64
@@ -536,15 +541,15 @@ module Gori
         INSERT INTO flows
           (created_at, scheme, host, port, method, target, http_version,
            sni, alpn, tls_version, request_head, request_body, request_size, state,
-           h2_conn_id, h2_stream_id, request_body_truncated)
-        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+           h2_conn_id, h2_stream_id, request_body_truncated, unsent)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
         SQL
         req.created_at, req.scheme, req.host, req.port, req.method, req.target,
         req.http_version, req.sni, req.alpn, req.tls_version,
         req.head, req.body,
         req.head.size.to_i64 + body_size,
         FlowState::Pending.value, req.h2_conn_id, req.h2_stream_id,
-        req.body_truncated? ? 1 : 0)
+        req.body_truncated? ? 1 : 0, unsent ? 1 : 0)
       # The INSERT's own result carries the rowid — no separate `SELECT last_insert_rowid()`.
       id = res.last_insert_id
       # Index the request body text now; the response side is filled in by

--- a/src/gori/store/schema.cr
+++ b/src/gori/store/schema.cr
@@ -557,7 +557,19 @@ module Gori
         "UPDATE repeaters SET request = CAST(request AS BLOB)",
       ]
 
-      MIGRATIONS = [V1, V2]
+      # `unsent` marks a flow row that will NEVER receive a response because it was never sent —
+      # an `import --urls`/`--oas` reference placeholder (Import::Builder.pending_request stores
+      # it Pending with a nil response ON PURPOSE). abandon_pending! finalises Pending rows to
+      # Error on session start/stop ("nothing else will ever resolve them"), which was FALSE for
+      # these — a capture (or just opening the project) corrupted every imported reference into a
+      # fabricated network error (#408). The gate excludes `unsent = 1`. Existing rows default to
+      # 0: only new imports are marked, so this prevents future corruption without guessing which
+      # already-stored Pending rows were imports.
+      V3 = [
+        "ALTER TABLE flows ADD COLUMN unsent INTEGER NOT NULL DEFAULT 0",
+      ]
+
+      MIGRATIONS = [V1, V2, V3]
 
       def self.migrate!(db : DB::Database) : Nil
         db.using_connection do |conn|


### PR DESCRIPTION
Closes #408.

## Problem

`abandon_pending!` finalises every `Pending` flow to `Error` on capture-session start/stop (`orphaned by a previous session` / `proxy stopped before response`), on the assumption that "nothing else will ever resolve them". That is **false** for `import --urls`/`--oas` reference placeholders, which `Import::Builder.pending_request` stores `Pending` with a nil response **on purpose** — they will never be sent. Opening the project for capture (CLI **or** TUI, since `Session.open` is shared) silently rewrote every imported reference into a fabricated network error, destroying the "not sent yet" distinction, and `capture` printed each as `[Error]`.

## Fix

Add an `unsent` column (schema **V3**): a response-less import pair is marked `unsent`, and `abandon_all_pending` excludes `unsent = 1`. Existing rows default to `0`, so this prevents future corruption without guessing which already-stored `Pending` rows were imports.

## Verification

- New `spec/store_extras_spec.cr` case: an orphaned in-flight flow is still abandoned to `Error` while an unsent import placeholder stays `Pending` with no error. **Control-run**: fails without the fix (placeholder gets flipped to `Error`).
- `crystal spec spec/store spec/store_extras_spec.cr spec/import` → 108 green (the V2-migration spec now asserts the current schema `VERSION` instead of a hardcoded `2`).
- Live: `import --urls` then `capture` leaves the row `state:pending unsent:1 error:NULL` instead of `Error`.

https://claude.ai/code/session_01EvoRaFeTPQUvfrhSeSF1ba