### PR TITLE
fix(mcp): add_scope_rule returns retryable:true for a deterministic duplicate rejection (#414)

### DIFF
--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -1648,6 +1648,20 @@ describe Gori::MCP::Server do
       end
     end
 
+    # #414: a duplicate rule is a deterministic rejection — reporting it retryable made an agent
+    # that trusts `retryable` loop forever. It must be a non-retryable INVALID_ARGUMENT.
+    it "rejects a duplicate rule as a non-retryable error" do
+      with_store do |store|
+        add = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"add_scope_rule","arguments":{"kind":"include","match_type":"host","pattern":"dup.example.com"}}})
+        drive(store, add)
+        dup = drive(store, add)[0]["result"]
+        dup["isError"].as_bool.should be_true
+        dup["structuredContent"]["error_code"].as_s.should eq("INVALID_ARGUMENT")
+        dup["structuredContent"]["retryable"].as_bool.should be_false
+        store.scope_rules.size.should eq(1) # not duplicated
+      end
+    end
+
     it "toggles the scope lens on/off and reflects it in list_scope" do
       with_store do |store|
         listed0 = tool_payload(drive(store, %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_scope"}}))[0])

--- a/src/gori/mcp/tools/scope.cr
+++ b/src/gori/mcp/tools/scope.cr
@@ -18,7 +18,12 @@ module Gori
         end
         scope = Scope.load(store)
         unless scope.add(kind, match_type, pattern)
-          return busy("failed to add scope rule (duplicate, empty, or invalid)")
+          # kind/match_type/pattern are already validated above, so a false here means the rule
+          # is a DUPLICATE — a deterministic condition that will never succeed on retry. Report it
+          # as a non-retryable INVALID_ARGUMENT, not PROJECT_BUSY/retryable (which made an agent
+          # that trusts `retryable` loop forever, #414).
+          return err("scope rule already exists (identical kind/match_type/pattern)",
+            "INVALID_ARGUMENT", field: "pattern")
         end
         # Scope#add reloads @rules from the store before returning, so this lookup
         # already sees the freshly assigned id.


### PR DESCRIPTION
Closes #414.

`Scope#add` returns `false` only for an empty/invalid/**duplicate** pattern, and kind/match_type/pattern are already validated in the handler — so the realistic path is a **duplicate**, a deterministic condition that will never succeed on retry. It was mapped to `busy(...)` → `PROJECT_BUSY` / `retryable:true`, so an agent that trusts `retryable` loops forever. Now a non-retryable `INVALID_ARGUMENT`.

**Verification**: new `spec/mcp_spec.cr` case — a second identical `add_scope_rule` returns `INVALID_ARGUMENT` / `retryable:false` and does not duplicate the rule. Control-run fails without the fix; full `spec/mcp_spec.cr` (192) green.

https://claude.ai/code/session_01EvoRaFeTPQUvfrhSeSF1ba