### PR TITLE
fix(cli): fuzz hides send errors, mine --locations= silently auto-detects, oast --once exits 0 on poll failure (#410, #415, #416)

### DIFF
--- a/spec/cli_run_spec.cr
+++ b/spec/cli_run_spec.cr
@@ -254,6 +254,35 @@ describe "gori run probe --active" do
   end
 end
 
+# #410: `gori run fuzz` dropped every errored send from all output formats (the CLI showed only
+# matches), so a headless run that 100%-failed looked identical to one that cleanly matched
+# nothing. `emit_fuzz_result` now emits an errored row too — proven here via a whitebox wrapper.
+module Gori::CLI::Run
+  def self.emit_fuzz_result_for_spec(r : Gori::Fuzz::Result, buffer : Array(Gori::Fuzz::Result)) : Bool
+    emit_fuzz_result(r, :json, buffer) # :json only buffers, no stdout
+  end
+end
+
+private def fuzz_result(matched : Bool, error : String?) : Gori::Fuzz::Result
+  Gori::Fuzz::Result.new(index: 0_i64, payloads: ["p"], position: 0, status: (matched ? 200 : nil),
+    length: 0_i64, words: 0, lines: 0, duration_us: 1_i64, error: error, matched: matched,
+    incomplete: false, extracted: nil)
+end
+
+describe "gori run fuzz — errored result visibility (#410)" do
+  it "emits an errored send, not just a matched one" do
+    buf = [] of Gori::Fuzz::Result
+    # A send failure (scope-blocked / target down): matched? false, error set.
+    Gori::CLI::Run.emit_fuzz_result_for_spec(fuzz_result(false, "connect failed"), buf).should be_true
+    # A plain non-match with no error is still dropped (unchanged).
+    Gori::CLI::Run.emit_fuzz_result_for_spec(fuzz_result(false, nil), buf).should be_false
+    # A match is emitted as before.
+    Gori::CLI::Run.emit_fuzz_result_for_spec(fuzz_result(true, nil), buf).should be_true
+    buf.size.should eq(2) # the errored row + the match; the bare no-match was not buffered
+    buf.any? { |r| r.error == "connect failed" }.should be_true
+  end
+end
+
 # `gori run repeater send`'s session-replay resolution used to live in a private CLI helper
 # (`build_repeater_send`). Since #356 the RESOLUTION is `Repeater::Plan.build`, asserted once
 # for all three surfaces in spec/repeater/plan_spec.cr — but the row → options MAPPING is

--- a/src/gori/cli/run/fuzz.cr
+++ b/src/gori/cli/run/fuzz.cr
@@ -183,20 +183,30 @@ module Gori
                                        host : String, port : Int32, format : Symbol, force : Bool,
                                        fail_if_no_matches : Bool) : Nil
         total = fuzz_preflight(engine, mode, scheme, host, port, force)
-        emitted = 0
+        matched = 0
+        errored = 0
         had_error = false
         buffer = [] of Fuzz::Result
         engine.run do |ev|
           case ev
           when Fuzz::ProgressEvent then fuzz_progress(ev, total)
-          when Fuzz::ResultEvent   then emitted += 1 if emit_fuzz_result(ev.result, format, buffer)
-          when Fuzz::DoneEvent     then fuzz_done(ev, emitted)
-          when Fuzz::ErrorEvent    then had_error = true; STDERR.puts "fuzz error: #{ev.message}"
+          when Fuzz::ResultEvent
+            r = ev.result
+            if emit_fuzz_result(r, format, buffer)
+              r.matched? ? (matched += 1) : (errored += 1)
+            end
+          when Fuzz::DoneEvent  then fuzz_done(ev, matched + errored)
+          when Fuzz::ErrorEvent then had_error = true; STDERR.puts "fuzz error: #{ev.message}"
           end
         end
         puts CLI::Output.fuzz_array_json(buffer) if format == :json
         exit 1 if had_error
-        exit 3 if fail_if_no_matches && emitted == 0
+        exit 3 if fail_if_no_matches && matched == 0
+        # A run where NOTHING matched and every send errored (target down, scope-blocked, TLS
+        # failure) is a failure, not a clean "no matches" — so a scripted caller can tell the two
+        # apart even without --fail-if-no-matches. The errored rows are now shown too (below),
+        # matching the TUI which renders every result. (#410)
+        exit 1 if matched == 0 && errored > 0
       end
 
       # Resolve + announce the request count; gate huge/unknown runs behind --force.
@@ -225,9 +235,11 @@ module Gori
         STDERR.puts "done · #{ev.progress.sent} sent · #{emitted} shown · #{ev.progress.errors} errors#{ev.stopped ? " (stopped)" : ""}"
       end
 
-      # Prints/buffers a matched result; returns true when it was emitted.
+      # Prints/buffers a result; returns true when it was emitted. Errored sends are shown too
+      # (the row helpers render "ERR" + the message / `error` field), so a headless run has the
+      # same visibility as the TUI — a scope-block or a dead target is no longer silently dropped.
       private def self.emit_fuzz_result(r : Fuzz::Result, format : Symbol, buffer : Array(Fuzz::Result)) : Bool
-        return false unless r.matched?
+        return false unless r.matched? || r.error
         case format
         when :jsonl then puts CLI::Output.fuzz_row_json(r)
         when :json  then buffer << r

--- a/src/gori/cli/run/mine.cr
+++ b/src/gori/cli/run/mine.cr
@@ -11,7 +11,10 @@ module Gori
         sni : String? = nil
         force_h2 = false
         insecure = false
-        locations = [] of Miner::Location
+        # nil = flag absent (auto-detect); a non-nil (possibly empty) value means --locations was
+        # given. Distinguishing the two lets an explicit `--locations=` error instead of silently
+        # falling back to auto-detect (#415).
+        locations : Array(Miner::Location)? = nil
         wordlist : String? = nil
         bucket : Int32? = nil
         concurrency = 10
@@ -70,12 +73,17 @@ module Gori
         config.retries = retries
         config.max_requests = max_requests
         config.user_wordlist = wordlist
+        # `--locations=` with no usable value (empty, or only blanks/commas) is an operator
+        # mistake, not a request to auto-detect — abort instead of silently mining defaults.
+        if (loc = locations) && loc.empty?
+          abort "gori run mine: --locations was empty — name at least one of query|form|multipart|json|headers|cookies (or omit it to auto-detect)"
+        end
         options = Miner::PlanOptions.new(text,
           default_target: default_target, target: target_override,
           http2: force_h2 || src_h2, bucket: bucket,
           # No --locations at all ⇒ nil, so the builder auto-detects what applies to this
-          # request; an explicit but unusable list stays an error, not a silent default.
-          locations: locations.empty? ? nil : locations,
+          # request; an explicit but unusable list is an error above, never a silent default.
+          locations: locations,
           config: config, verify: !insecure, sni: sni,
           overrides: cli_host_overrides(project_name, db_path, flow_id))
         # Scope gate — see cmd_fuzz / optional_project_outbound: refuse an out-of-scope host unless

--- a/src/gori/cli/run/oast.cr
+++ b/src/gori/cli/run/oast.cr
@@ -338,11 +338,13 @@ module Gori
           Signal::INT.trap { stop.send(nil) rescue nil }
           Signal::TERM.trap { stop.send(nil) rescue nil }
         end
+        once_failed = false
         loop do
           interactions = begin
             prov.poll(http, session)
           rescue ex
             STDERR.puts "poll error: #{ex.message}"
+            once_failed = true
             [] of Oast::Interaction
           end
           interactions.each do |i|
@@ -359,6 +361,9 @@ module Gori
           break if oast_wait_or_stop(stop, interval.seconds)
         end
         prov.deregister(http, session) if once
+        # A --once run whose single poll FAILED must not exit 0 — a scripted caller can't
+        # otherwise tell "polled, found nothing" from "the poll errored". (#416)
+        exit 1 if once && once_failed
       end
 
       # Block up to `interval`, returning true the instant a stop arrives (Ctrl-C via the


### PR DESCRIPTION
Closes #410, #415, #416 — three `gori run` visibility/exit-code fixes.

## #410 — fuzz drops every errored send (medium)

`emit_fuzz_result` returned early `unless r.matched?`, so `gori run fuzz` showed only matches: a 100%-failed run (dead target, scope-blocked) looked identical to a clean no-match run — **exit 0, no detail** — while the TUI renders every result (a real CLI/TUI parity gap). Now errored rows are emitted too (the row helpers already render `ERR` / the `error` field), matched vs errored are counted separately so `--fail-if-no-matches` still keys on matches, and the run **exits 1 when nothing matched and every send errored**.

## #415 — mine `--locations=` silently auto-detects (low)

`--locations=` (flag present, empty value) was indistinguishable from the flag being absent — both became `[]` → `nil` → silent auto-detect. `locations` is now a nilable sentinel and an explicitly-empty list aborts instead of quietly mining defaults.

## #416 — oast `--once` exits 0 on a failed poll (low)

A failed `oast listen --once` poll printed `poll error` but exited 0. Now it exits 1 so a scripted caller can tell "polled, found nothing" from "the poll errored".

## Verification

- New `spec/cli_run_spec.cr` case for the fuzz emit (fails without the fix); `crystal spec spec/cli_run_spec.cr spec/cli_run_oast_stop_spec.cr spec/fuzz_spec.cr` → 95 green.
- Live against the built binary: fuzz to a dead target prints errored rows (jsonl `error` / text `ERR`) and exits 1; `mine --locations=` aborts (exit 1) while `--locations=query` and no-flag auto-detect still work; `oast listen --once` with a failing poll exits 1.

https://claude.ai/code/session_01EvoRaFeTPQUvfrhSeSF1ba