### PR TITLE
perf(store): move trigram FTS indexing off the capture commit path

### DIFF
--- a/spec/import/import_spec.cr
+++ b/spec/import/import_spec.cr
@@ -62,10 +62,11 @@ describe Gori::Import do
   it "indexes the imported request body for FTS body: search (response-bearing entry)" do
     har = File.tempname("gori", ".har")
     begin
-      # A response is present, so the import writer takes the update_one path (which reuses
-      # the request FTS text computed at insert time instead of reading the row back). The
-      # distinctive token lives ONLY in the REQUEST body, so a body: hit proves the request
-      # FTS column was populated correctly through that path.
+      # A response is present, so the import writer takes the insert_one + update_one path and
+      # the row is left `fts_dirty` for the off-commit indexer (Store V4) — which indexes BOTH
+      # sides in one pass. The distinctive token lives ONLY in the REQUEST body, so a body: hit
+      # proves the indexer populated the request FTS column for an imported pair, not just the
+      # response side it was re-dirtied for.
       File.write(har, <<-JSON)
         {
           "log": {
@@ -89,6 +90,7 @@ describe Gori::Import do
 
       with_store do |store|
         Gori::Import.import_file(store, :har, har).count.should eq(1)
+        store.flush # barrier: the index is written off-commit
         hits = store.search(Gori::QL.parse("body:zephyrquux"), 10)
         hits.size.should eq(1)
         hits.first.target.should eq("/submit")

--- a/spec/ql_spec.cr
+++ b/spec/ql_spec.cr
@@ -324,6 +324,8 @@ describe "Gori::Store#search (QL)" do
         head: "GET /about HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice,
         body: "nothing here".to_slice))
 
+      store.flush # body: reads the trigram index, which is written off-commit (Store V4)
+
       hits = store.search(Gori::QL.parse("body:secrettoken"), 50).map(&.id).sort
       hits.should eq([req_match, resp_match].sort) # case-insensitive, req + resp
 

--- a/spec/store/fts_spec.cr
+++ b/spec/store/fts_spec.cr
@@ -88,6 +88,28 @@ describe "contentless FTS (V24)" do
     end
   end
 
+  # FTS_INDEX_MAX is an indexing-work budget (~30µs per indexed KiB), so it is deliberately
+  # far below the capture body cap. That makes the recall boundary a real, user-visible
+  # property: pin BOTH sides of it here so a future change to the constant has to face what
+  # it costs — and so the documented escape hatch (`body~` scans the whole stored BLOB) is
+  # proven to still reach past the cap.
+  it "indexes only the first FTS_INDEX_MAX body bytes, leaving the rest to body~" do
+    fts_store do |store|
+      cap = Gori::Store::FTS_INDEX_MAX
+      # Both markers are >=3 chars (so `body:` takes the trigram path, not the LIKE
+      # fallback) and are placed clear of the cut so neither straddles the boundary.
+      body = "beforethecapmarker" + ("x" * cap) + "afterthecapmarker"
+      id = store.insert_flow(req_with_body("/big", nil))
+      store.update_response(resp_with_body(id, body))
+      store.flush
+
+      body_hits(store, "beforethecapmarker").should eq([id])
+      body_hits(store, "afterthecapmarker").should be_empty # past the cap: not in the index
+      # ...but still in the stored bytes, so the regex form finds it.
+      store.search(Gori::QL.parse("body~afterthecapmarker"), 10).map(&.id).should eq([id])
+    end
+  end
+
   it "skips a binary response body (never indexed)" do
     fts_store do |store|
       id = store.insert_flow(req_with_body("/c", nil))
@@ -154,6 +176,115 @@ describe "contentless FTS (V24)" do
       store.flush
       body_hits(store, "secondtoken").should eq([id])
       body_hits(store, "firsttoken").should be_empty # no stale posting, no dup-rowid error
+    end
+  end
+
+  # --- off-commit indexing (V4 / fts_dirty) ---------------------------------------------
+  #
+  # The point of the flag is that "captured" and "searchable" are now two events. Everything
+  # below pins the seam: that the gap is REPORTED rather than silent, that it always closes,
+  # and that nothing else the store does (prune, clear, a rolled-back index) can strand a row
+  # dirty-but-unsearchable or indexed-but-stale.
+
+  it "leaves a captured flow searchable only after indexing, and SAYS so meanwhile" do
+    fts_store do |store|
+      id = store.insert_flow(req_with_body("/async", "deferredbodytoken"))
+      store.update_response(resp_with_body(id, "deferredresptoken"))
+      # The row is committed and fully readable as a projection...
+      store.flow_row(id).should_not be_nil
+      # ...while the backlog reports the flow whose index has not landed yet. (Nothing has
+      # driven the writer's idle path here, so the dirty row is still waiting.)
+      store.fts_backlog.should eq(1)
+
+      store.flush # the barrier includes the index drain
+      store.fts_backlog.should eq(0)
+      body_hits(store, "deferredbodytoken").should eq([id]) # request side
+      body_hits(store, "deferredresptoken").should eq([id]) # response side, same pass
+    end
+  end
+
+  it "reports an empty backlog once drained, and re-dirties on a later response" do
+    fts_store do |store|
+      id = store.insert_flow(req_with_body("/redirty", "firstpasstoken"))
+      store.flush
+      store.fts_backlog.should eq(0)
+
+      # A response landing after the row was indexed must mark it stale again — otherwise the
+      # response body would never be searchable for a flow the indexer had already visited.
+      store.update_response(resp_with_body(id, "secondpasstoken"))
+      store.fts_backlog.should eq(1)
+      store.flush
+      body_hits(store, "secondpasstoken").should eq([id])
+      body_hits(store, "firstpasstoken").should eq([id]) # the request side survived the re-index
+    end
+  end
+
+  it "index_pending! drains every dirty flow, not just one batch" do
+    fts_store do |store|
+      # More flows than FTS_BATCH, so a single-batch drain would leave a remainder behind.
+      n = Gori::Store::FTS_BATCH * 2 + 3
+      # Zero-padded so no token is a SUBSTRING of another — trigram matching is substring
+      # matching, and "batchtoken1" would otherwise also hit batchtoken10..19.
+      tok = ->(i : Int32) { "batchtoken#{i.to_s.rjust(3, '0')}" }
+      ids = (1..n).map { |i| store.insert_flow(req_with_body("/b#{i}", tok.call(i))) }
+      store.index_pending!.should be >= n
+      store.fts_backlog.should eq(0)
+      body_hits(store, tok.call(n)).should eq([ids.last])  # past the first batch
+      body_hits(store, tok.call(1)).should eq([ids.first]) # and the first batch too
+    end
+  end
+
+  it "finishes a backlog left behind by a previous process (durable across reopen)" do
+    path = File.tempname("gori-fts-reopen", ".db")
+    begin
+      # First store: capture WITHOUT ever letting the indexer run, then abandon it the way a
+      # killed process would — the dirty flag is what makes those flows recoverable at all.
+      db = DB.open("sqlite3:#{path}?journal_mode=wal&busy_timeout=5000")
+      Gori::Store::Schema.migrate!(db)
+      store = Gori::Store.new(db, nil, retention_flows: 0)
+      id = store.insert_flow(req_with_body("/crash", "survivorbodytoken"))
+      store.fts_backlog.should eq(1)
+      store.close
+
+      db2 = DB.open("sqlite3:#{path}?journal_mode=wal&busy_timeout=5000")
+      store2 = Gori::Store.new(db2, nil, retention_flows: 0)
+      begin
+        store2.fts_backlog.should eq(1) # the backlog was in the db, not in the dead process
+        store2.index_pending!.should eq(1)
+        store2.search(Gori::QL.parse("body:survivorbodytoken"), 10).map(&.id).should eq([id])
+      ensure
+        store2.close
+      end
+    ensure
+      File.delete?(path)
+      File.delete?("#{path}-wal")
+      File.delete?("#{path}-shm")
+    end
+  end
+
+  it "drops a still-dirty flow's backlog entry when the flow is deleted" do
+    fts_store do |store|
+      keep = store.insert_flow(req_with_body("/keep", "keptbodytoken"))
+      doomed = store.insert_flow(req_with_body("/doomed", "doomedbodytoken"))
+      store.fts_backlog.should eq(2)
+      # Deleted BEFORE it was ever indexed: the pending re-index must go with the row, not
+      # resurrect as an FTS entry for a rowid that no longer exists.
+      store.delete_flow(doomed)
+      store.flush
+      store.fts_backlog.should eq(0)
+      body_hits(store, "doomedbodytoken").should be_empty
+      body_hits(store, "keptbodytoken").should eq([keep])
+    end
+  end
+
+  it "clears the backlog with the flows on clear_flows" do
+    fts_store do |store|
+      store.insert_flow(req_with_body("/x", "clearedbodytoken"))
+      store.fts_backlog.should eq(1)
+      store.clear_flows
+      store.flush
+      store.fts_backlog.should eq(0)
+      body_hits(store, "clearedbodytoken").should be_empty
     end
   end
 

--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -34,6 +34,54 @@ describe Gori::Tui::HistoryView do
   # so a (future) valid-JSON/XML fixture can't silently reflow and shift assertions.
   before_each { Gori::Settings.pretty_bodies_default = false }
 
+  # Trigram indexing is off the capture commit (Store V4), so a `body:` filter in a LIVE view
+  # can legitimately be answered from an index that hasn't caught up. The view must not stall
+  # to fix that (the one-shot CLI/MCP surfaces drain instead) — it must SAY it, or an operator
+  # reads "no flows match" as "this traffic doesn't exist", which on a security proxy is how a
+  # finding gets missed.
+  it "notes a lagging body-search index instead of silently under-reporting" do
+    tmp_store do |store|
+      id = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "http", host: "h.test", port: 80,
+        method: "POST", target: "/submit", http_version: "HTTP/1.1",
+        head: "POST /submit HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice,
+        body: "lagindexbodytoken".to_slice))
+
+      view = HistoryView.new
+      view.start_query
+      "body:lagindexbodytoken".each_char { |c| view.query_insert(c) }
+      view.reload(store)
+
+      # Captured but not yet indexed: no rows, and a note that explains WHY there are none.
+      view.@rows.should be_empty
+      note = view.@query_note
+      note.should_not be_nil
+      note.not_nil!.should contain("body search")
+      note.not_nil!.should contain("1")
+
+      # Once the index catches up the flow appears and the note goes away — the gap is
+      # temporary, so the warning must not become permanent furniture.
+      store.flush
+      view.reload(store)
+      view.@rows.map(&.id).should eq([id])
+      view.@query_note.should be_nil
+    end
+  end
+
+  # A filter that never touches flows_fts must not pay for (or display) the backlog probe:
+  # its answer is complete the moment the row commits.
+  it "does not note the index backlog for a filter that doesn't read it" do
+    tmp_store do |store|
+      add_flow(store, "GET", "/a", 200)
+      view = HistoryView.new
+      view.start_query
+      "method:GET".each_char { |c| view.query_insert(c) }
+      view.reload(store)
+      view.@rows.size.should eq(1)
+      view.@query_note.should be_nil
+    end
+  end
+
   it "splits the list rect for Req/Res preview when history_preview is on" do
     prev = Gori::Settings.history_preview
     begin

--- a/src/gori/cli/run/history.cr
+++ b/src/gori/cli/run/history.cr
@@ -127,6 +127,11 @@ module Gori
                 store.close
                 abort "gori run history: query #{q.inspect} did not match any field (check syntax, e.g. status:>=500 host:example.com method:POST)"
               end
+              # Trigram indexing is off-commit (Store V4), so a `body:`/free-text query run
+              # right after a capture — or against a db a killed process left behind — would
+              # under-report until the backlog drains. A one-shot answer must be exact, so
+              # wait for it here rather than silently returning fewer rows.
+              store.index_pending! if filter.uses_fts?
               begin
                 store.search(filter, limit, raise_on_error: true)
               rescue ex

--- a/src/gori/cli/run/sitemap.cr
+++ b/src/gori/cli/run/sitemap.cr
@@ -165,6 +165,9 @@ module Gori
       # the TUI lens's per-flow SQL filter and conservative on url-level includes.
       private def self.collect_sitemap(store : Store, filter : QL::Filter, limit : Int32,
                                        in_scope : Bool, group : Bool) : Array(Sitemap::Node)
+        # `--query body:…` reads the off-commit trigram index (Store V4); drain it so a
+        # one-shot tree can't be missing endpoints that simply weren't indexed yet.
+        store.index_pending! if filter.uses_fts?
         hosts = Sitemap.build(store.sitemap_entries(filter, limit, raise_on_error: true))
         Sitemap.stamp_tags!(hosts, store.sitemap_tags)
         if in_scope

--- a/src/gori/mcp/tools/flows.cr
+++ b/src/gori/mcp/tools/flows.cr
@@ -19,6 +19,9 @@ module Gori
         query = str(h, "query")
         filter = ql_filter_or_error(h, query)
         return filter if filter.is_a?(Result)
+        # An agent gets one shot at this answer and cannot tell "no match" from "not indexed
+        # yet", so drain the off-commit FTS backlog (Store V4) before a query that reads it.
+        store.index_pending! if filter.uses_fts?
         rows = (query && !query.strip.empty?) ? store.search(filter, limit, before_id, since_id) : store.recent_flows(limit, before_id, since_id)
         Result.new(JSON.build { |j| j.array { rows.each { |r| Serialize.flow_row(j, r) } } })
       end

--- a/src/gori/mcp/tools/sitemap.cr
+++ b/src/gori/mcp/tools/sitemap.cr
@@ -11,6 +11,9 @@ module Gori
         query = str(h, "query")
         filter = ql_filter_or_error(h, query)
         return filter if filter.is_a?(Result)
+        # Same reason as list_history: a `body:` query reads the off-commit trigram index
+        # (Store V4), and an agent can't distinguish "absent" from "not indexed yet".
+        store.index_pending! if filter.uses_fts?
         return collapsed_sitemap(filter, limit) if bool(h, "collapse_transport") || false
         entries = store.sitemap_entries_detailed(filter, limit)
         tags = store.sitemap_tags

--- a/src/gori/probe/scan.cr
+++ b/src/gori/probe/scan.cr
@@ -54,6 +54,10 @@ module Gori
 
       # Flow IDs to scan, oldest-first (ascending id) — a stable, deterministic grouping order.
       def flow_ids(store : Store, filter : QL::Filter?) : Array(Int64)
+        # A scan that silently skipped flows because their trigram entries hadn't been written
+        # yet (indexing is off-commit — Store V4) would under-report FINDINGS, so drain the
+        # backlog before selecting the set to scan.
+        store.index_pending! if filter.try(&.uses_fts?)
         rows = filter ? store.search(filter, Int32::MAX, raise_on_error: true) : store.recent_flows(Int32::MAX)
         rows.map(&.id).reverse! # search/recent_flows are newest-first; reverse → ascending id
       end

--- a/src/gori/ql.cr
+++ b/src/gori/ql.cr
@@ -26,6 +26,16 @@ module Gori
 
       def initialize(@sql : String, @args : Array(DB::Any))
       end
+
+      # Does answering this filter read the trigram index? `body:` and free text are the
+      # only terms that compile to a `flows_fts` subquery (see body_cond / free text below),
+      # and nothing else mentions that table, so matching the name is exact rather than
+      # heuristic. Callers use it to decide whether a stale index would corrupt their answer:
+      # indexing is off-commit (Store V4), so a one-shot surface drains the backlog first
+      # (Store#index_pending!) while a live one reports Store#fts_backlog instead of stalling.
+      def uses_fts? : Bool
+        @sql.includes?("flows_fts")
+      end
     end
 
     EMPTY = Filter.new("1", [] of DB::Any)

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -118,6 +118,18 @@ module Gori
       end
     end
 
+    # Asks the writer to index one slice of the FTS backlog and report how many rows it did
+    # (see Store#index_pending!). Deliberately NOT an ExecTask: an ExecTask body runs inside
+    # the batch's shared transaction, and indexing needs its OWN — both so a nested
+    # transaction isn't opened on the same connection, and so an index failure rolls back
+    # only itself instead of the captured flows batched alongside it.
+    struct IndexBatch < WriteOp
+      getter reply : Channel(Int32)
+
+      def initialize(@reply)
+      end
+    end
+
     # Marks every Pending flow Error (e.g. proxy shutdown before a response landed).
     struct AbandonPending < WriteOp
       getter message : String
@@ -129,11 +141,18 @@ module Gori
 
     BATCH_MAX = 128
 
-    # Cap on @pending_req_fts (see initialize). Far above the in-flight (request sent,
-    # response pending) flow count under any real load, since each entry lives only until
-    # its response lands; overflow (a flood of never-answered requests) clears the memo so
-    # update_one transparently falls back to the readback.
-    PENDING_FTS_MAX = 8192
+    # Flows re-indexed per idle indexing transaction (see index_pending_batch). Small
+    # enough that a batch can't hold the writer long enough to delay a capture that
+    # arrives mid-batch; large enough to amortize the transaction over many rows.
+    FTS_BATCH = 32
+    # How long the writer waits for capture work before spending the idle time on the FTS
+    # backlog. FAST while there may be work (so a backlog drains at a useful rate), SLOW
+    # once a batch comes back empty (so a quiet session isn't waking up 200×/s for nothing).
+    FTS_IDLE_TICK_FAST = 5.milliseconds
+    FTS_IDLE_TICK_SLOW = 250.milliseconds
+    # Ceiling on the backlog probe (see #fts_backlog). The exact number stops mattering
+    # once it's "lots"; capping it keeps the probe O(cap) instead of O(backlog).
+    FTS_BACKLOG_PROBE_MAX = 10_000
 
     # Keep at most this many newest flows; older ones (and their ws/h2 rows) are
     # pruned so the DB plateaus instead of growing forever (freed pages are
@@ -141,8 +160,18 @@ module Gori
     RETENTION_DEFAULT = 100_000
     # Inserts between retention sweeps — amortizes the prune cost.
     PRUNE_INTERVAL = 2_000
-    # Per-side ceiling on body text fed to the FTS index (keeps the index small).
-    FTS_INDEX_MAX = 64 * 1024
+    # Per-side ceiling on body text fed to the FTS index. Every byte becomes a 3-byte-window
+    # token, so this is a WORK budget, measured at roughly 30µs per indexed KiB (SQLite 3.51,
+    # arm64, one flow per transaction). Indexing runs off the capture commit (V4), so the cap
+    # no longer bounds capture latency directly — it bounds how fast the backlog drains, and
+    # how much index a burst leaves to catch up on. At 64 KiB one text response cost the
+    # indexer ~2ms; 8 KiB keeps the common case (JSON APIs, small HTML) fully indexed at ~250µs.
+    #
+    # The trade is search RECALL, not correctness: `body:` (FTS) sees only the first
+    # 8 KiB per side, while `body~<regex>` still scans the whole stored BLOB, so anything
+    # past the cap stays findable — just with a table scan instead of an index hit. Raising
+    # this affects only flows indexed AFTERWARDS; already-indexed rows keep their entries.
+    FTS_INDEX_MAX = 8 * 1024
 
     @events : Channel(FlowEvent)?
     # Second post-commit notification channel feeding the Probe analyzer. Separate from
@@ -202,13 +231,13 @@ module Gori
       @write_failures = Atomic(Int32).new(0)
       @h2_frames_dropped = Atomic(Int32).new(0)
       @inserts_since_prune = 0
-      # Writer-fiber-only memo of the request-side FTS text keyed by a just-inserted flow id,
-      # so update_one (the response side) reuses it instead of reading the request head +
-      # body back out of the row it just wrote. Populated ONLY post-commit (a rolled-back insert
-      # never enters, so its id can't feed a stale response); bounded so abandoned Pending flows
-      # (a request whose response never arrives) can't grow it without limit — an evicted id
-      # simply falls back to the readback. Single writer fiber ⇒ no lock.
-      @pending_req_fts = {} of Int64 => String
+      # Writer-fiber-only hint: does `flows.fts_dirty = 1` possibly have rows? Starts true so a
+      # db reopened with a backlog (a killed process, or a batch dropped under saturation) gets
+      # drained without waiting for a capture to hint at it; set false the moment an indexing
+      # batch comes back empty, and true again whenever a committed batch dirtied a row. Only a
+      # HINT — it decides how eagerly the writer wakes to index, never whether a row is indexed
+      # (the `fts_dirty` column is the truth). Single writer fiber ⇒ no lock.
+      @fts_backlog_hint = true
       # Bumped after every committed probe_issues mutation (upsert/delete/status).
       # The TUI polls this every main-loop tick — more reliable than PRAGMA data_version
       # (same-process writer visibility is flaky) or the droppable Probe event channel.
@@ -226,6 +255,11 @@ module Gori
     end
 
     # --- write API (called from proxy fibers) --------------------------------
+    #
+    # BARRIER NOTE: a returned flow write is committed and readable through every projection
+    # query — but NOT necessarily through `body:`/free-text yet. Trigram indexing moved off the
+    # commit path (V4/`fts_dirty`), so a caller that must see its own write in an FTS query
+    # calls #flush (or #index_pending!) first; a live surface reports #fts_backlog instead.
 
     # Inserts a Pending flow (request captured) and returns its new id.
     # Blocks the caller until the row is committed.
@@ -281,11 +315,49 @@ module Gori
       nil
     end
 
-    # Blocks until every write enqueued before this call has committed. The single
-    # writer drains its channel FIFO, so a synchronous round-trip also flushes the
-    # fire-and-forget h2-frame writes that precede it (a clean read barrier).
+    # Blocks until every write enqueued before this call has committed AND the search index
+    # has caught up with them. The single writer drains its channel FIFO, so a synchronous
+    # round-trip also flushes the fire-and-forget h2-frame writes that precede it (a clean
+    # read barrier).
+    #
+    # The index drain is part of the barrier on purpose: trigram indexing is off-commit
+    # (V4/`fts_dirty`), so without it a caller that flushed and then ran a `body:` query
+    # would silently under-report — the exact failure the flag exists to prevent. No hot path
+    # calls this; it is the one-shot/`spec` barrier, where correctness beats latency. A live
+    # surface (the TUI) must NOT use it — it reports #fts_backlog instead of stalling.
     def flush : Nil
       exec_task ->(_c : DB::Connection) { nil }
+      index_pending!
+    end
+
+    # Indexes the whole FTS backlog, blocking until it is empty; returns the flows indexed.
+    # Runs on the writer connection (one batch per round-trip) so it interleaves with capture
+    # rather than locking it out.
+    def index_pending! : Int32
+      total = 0
+      begin
+        loop do
+          reply = Channel(Int32).new(1) # buffered: the writer must never block sending a reply
+          @writes.send(IndexBatch.new(reply))
+          n = reply.receive
+          break if n == 0
+          total += n
+        end
+      rescue Channel::ClosedError
+        # store closing — stop draining; the rows stay dirty and durable for the next open
+      end
+      total
+    end
+
+    # How many flows are waiting to be (re)indexed for `body:`/free-text search — i.e. how
+    # far behind the search index is. Capped at FTS_BACKLOG_PROBE_MAX (a bigger number would
+    # only ever be shown as "lots"), and answered from the partial index, so it is cheap
+    # enough for a live surface to poll. 0 means every stored flow is searchable.
+    def fts_backlog : Int32
+      @db.scalar("SELECT COUNT(*) FROM (SELECT 1 FROM flows WHERE fts_dirty = 1 LIMIT #{FTS_BACKLOG_PROBE_MAX})")
+        .as(Int64).to_i32
+    rescue
+      0 # a failed probe must never break a render/poll; it only understates the note
     end
 
     # --- shared read helper (used by both issues.cr and probe_issues.cr) ---
@@ -322,7 +394,10 @@ module Gori
         # writes (the default is 1000 pages; set it explicitly on the writer).
         conn.exec("PRAGMA wal_autocheckpoint=1000") rescue nil
         loop do
-          first = @writes.receive?
+          # Wait for capture work, but spend an idle wait on the FTS backlog instead of just
+          # parking (see await_op). Capture ALWAYS wins: an op arriving mid-wait is taken
+          # immediately, and indexing only ever runs between batches, never inside one.
+          first = await_op(conn)
           break if first.nil? # channel closed: drained, exit
 
           ops = [first]
@@ -336,6 +411,10 @@ module Gori
           # every blocked caller (and close()) deadlocks. On failure we roll back
           # and unblock each caller with a fallback so the app degrades, not hangs.
           deferred = [] of -> Nil
+          # Index requests are pulled OUT of the batch: they need their own transaction (see
+          # IndexBatch) and they must be answered whether or not the batch itself committed —
+          # the rows they index were dirtied by EARLIER, already-committed batches.
+          index_replies = ops.compact_map { |op| op.as?(IndexBatch).try(&.reply) }
           committed = false
           begin
             conn.transaction do |tx|
@@ -344,25 +423,17 @@ module Gori
                 case op
                 when InsertFlow
                   ins_reply = op.reply
-                  id, req_fts = insert_one(c, op.req)
-                  # Remember the request-side FTS text so this flow's later response update
-                  # skips the row readback. Merged only in the post-commit deferred block, so
-                  # a rolled-back insert leaves no entry behind.
-                  deferred << -> { remember_req_fts(id, req_fts); ins_reply.send(id); publish(FlowEvent.new(id, :inserted)) }
+                  id = insert_one(c, op.req)
+                  deferred << -> { ins_reply.send(id); publish(FlowEvent.new(id, :inserted)) }
                 when InsertImportBatch
                   batch_reply = op.reply
                   inserted = [] of {Int64, Bool}
                   op.pairs.each do |req, resp|
                     # A response-less import pair is a reference placeholder that will never be
                     # sent — mark it `unsent` so abandon_pending! never fabricates an error for it (#408).
-                    id, req_fts = insert_one(c, req, unsent: resp.nil?)
+                    id = insert_one(c, req, unsent: resp.nil?)
                     has_resp = !resp.nil?
                     if r = resp
-                      # Hand update_one the request FTS text we just computed so its memo
-                      # lookup HITS instead of reading the row back (a per-entry SELECT +
-                      # up-to-64KiB body re-materialization on every imported pair with a
-                      # response). delete-on-read in update_one keeps the memo from growing.
-                      remember_req_fts(id, req_fts)
                       update_one(c, Store::CapturedResponse.new(
                         flow_id: id, status: r.status, head: r.head,
                         body: r.body, reason: r.reason,
@@ -425,6 +496,9 @@ module Gori
           # branch can block or throw back into the loop.
           if committed
             deferred.each(&.call)
+            # Any committed flow write left a row `fts_dirty` — tell the idle wait to start
+            # looking again (see @fts_backlog_hint).
+            @fts_backlog_hint = true if ops.any? { |op| dirties_fts?(op) }
             # Count bulk-import rows too — an InsertImportBatch inserts many flows in ONE op,
             # so counting it as a single InsertFlow (or 0) let a large import bypass the
             # retention sweep, keeping the DB far over its cap until enough live captures accrue.
@@ -436,6 +510,9 @@ module Gori
           else
             ops.each { |op| fail_reply(op) }
           end
+          # Outside the batch transaction, and after it, so an explicit drain
+          # (Store#index_pending!) also picks up rows this very batch just dirtied.
+          index_replies.each(&.send(index_pending_batch(conn)))
         end
       end
     end
@@ -531,10 +608,99 @@ module Gori
       nil
     end
 
-    # Inserts the request row + its FTS entry, returning {id, req_fts} so the caller can
-    # hand the already-computed request-side FTS text to update_one (post-commit) instead of
-    # reading the head+body back out of the row.
-    private def insert_one(conn : DB::Connection, req : CapturedRequest, unsent : Bool = false) : {Int64, String}
+    # Blocking receive that puts an otherwise-idle writer to work on the FTS backlog.
+    # Returns the next op, or nil when the channel closed.
+    #
+    # This is what makes trigram indexing off-commit affordable without a second connection:
+    # SQLite has ONE writer, so the index work must still run on this fiber — the win is that
+    # it no longer sits INSIDE the transaction a proxy fiber is blocked on. Capture keeps
+    # strict priority (an op arriving during the wait is returned at once, and a batch is
+    # never interrupted), so under sustained load indexing simply falls behind and the
+    # backlog drains in the gaps — which is what `fts_backlog` exists to make visible.
+    private def await_op(conn : DB::Connection) : WriteOp?
+      loop do
+        tick = @fts_backlog_hint ? FTS_IDLE_TICK_FAST : FTS_IDLE_TICK_SLOW
+        select
+        when op = @writes.receive
+          return op
+        when timeout(tick)
+          # No capture work waiting: index a slice of the backlog and re-check.
+          @fts_backlog_hint = false if index_pending_batch(conn) == 0
+        end
+      end
+    rescue Channel::ClosedError
+      nil # closing: the writer_loop exits; any remaining fts_dirty rows survive in the db
+    end
+
+    # Re-indexes up to FTS_BATCH dirty flows in one transaction; returns how many it did
+    # (0 = backlog empty). Reads the text back out of the row rather than carrying it in
+    # memory: that is what makes the backlog crash-safe and unbounded-in-size safe, and the
+    # readback is cheap next to the tokenization it feeds (the body is SQL-capped to
+    # FTS_INDEX_MAX before it ever crosses into Crystal).
+    #
+    # A failure here must not kill the writer or lose capture: it runs in its own
+    # transaction and swallows errors, leaving the rows dirty for the next attempt.
+    private def index_pending_batch(conn : DB::Connection) : Int32
+      rows = [] of {Int64, Bytes, Bytes?, Bytes?, Bytes?, String?}
+      begin
+        # `content_type` comes from the COLUMN, not from re-parsing response_head: it is the
+        # value the proxy already extracted from that head, and it is what the old on-commit
+        # path skipped binary bodies on. A synthesised response (an import, a test double) can
+        # carry a content type that never appeared in its head bytes, and deriving the marker
+        # from the head would silently start indexing a binary body those callers marked.
+        conn.query(
+          "SELECT id, request_head, substr(request_body, 1, ?), response_head, substr(response_body, 1, ?), " \
+          "content_type FROM flows WHERE fts_dirty = 1 ORDER BY id LIMIT ?",
+          FTS_INDEX_MAX, FTS_INDEX_MAX, FTS_BATCH) do |rs|
+          rs.each do
+            rows << {rs.read(Int64), rs.read(Bytes), rs.read(Bytes?),
+                     rs.read(Bytes?), rs.read(Bytes?), rs.read(String?)}
+          end
+        end
+        return 0 if rows.empty?
+        conn.transaction do |tx|
+          c = tx.connection
+          rows.each do |(id, req_head, req_body, resp_head, resp_body, resp_ct)|
+            # The request side has no content_type column, so its marker comes from its head —
+            # exactly what the old path did for the request body.
+            req = body_fts_text(req_head, req_body)
+            resp = resp_head.nil? ? "" : body_fts_text(resp_head, resp_body, resp_ct)
+            # Contentless FTS5 forbids UPDATE, so a refresh is DELETE (a cheap tombstone under
+            # contentless_delete=1) + INSERT. Unconditional rather than tracking whether this row
+            # was ever indexed: it makes a re-index idempotent — and a double index pass, or one
+            # racing a peer process, can't leave two entries matching the same rowid.
+            c.exec("DELETE FROM flows_fts WHERE rowid = ?", id)
+            c.exec("INSERT INTO flows_fts(rowid, req, resp) VALUES (?, ?, ?)", id, req, resp)
+            c.exec("UPDATE flows SET fts_dirty = 0 WHERE id = ?", id)
+          end
+        end
+        rows.size
+      rescue ex
+        # gori.log, not STDERR (#411). The rows stay dirty, so this self-heals; fts_backlog
+        # keeps reporting them so a persistent failure is visible rather than silent.
+        ::Log.warn { "FTS index batch failed (#{rows.size} flow(s), will retry): #{ex.message}" }
+        0
+      end
+    end
+
+    # The FTS text for one side, given that side's raw head and its already-capped body.
+    # Skips a body that is binary by content type or compressed by Content-Encoding — the same
+    # rule the old on-commit path applied. `ct`, when given (the response side), is the stored
+    # content_type column and takes precedence over whatever the head says; the head is still
+    # scanned for Content-Encoding, which has no column.
+    private def body_fts_text(head : Bytes, body : Bytes?, ct : String? = nil) : String
+      return "" if body.nil? || body.empty?
+      return "" if ct && binary_content?(ct)
+      skip_body_fts?(head) ? "" : String.new(body)
+    end
+
+    # Does this op leave a flow row `fts_dirty`? (Only flow writes touch the index.)
+    private def dirties_fts?(op : WriteOp) : Bool
+      op.is_a?(InsertFlow) || op.is_a?(UpdateResp) || op.is_a?(InsertImportBatch)
+    end
+
+    # Inserts the request row, marked `fts_dirty` for the off-commit indexer.
+    private def insert_one(conn : DB::Connection, req : CapturedRequest, unsent : Bool = false) : Int64
       # request_size is the TRUE wire size (body_size when the BLOB was truncated),
       # so the History size column stays honest even for a capped body.
       body_size = req.body_size || req.body.try(&.size.to_i64) || 0_i64
@@ -543,8 +709,8 @@ module Gori
         INSERT INTO flows
           (created_at, scheme, host, port, method, target, http_version,
            sni, alpn, tls_version, request_head, request_body, request_size, state,
-           h2_conn_id, h2_stream_id, request_body_truncated, unsent)
-        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+           h2_conn_id, h2_stream_id, request_body_truncated, unsent, fts_dirty)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,1)
         SQL
         req.created_at, req.scheme, req.host, req.port, req.method, req.target,
         req.http_version, req.sni, req.alpn, req.tls_version,
@@ -553,12 +719,9 @@ module Gori
         FlowState::Pending.value, req.h2_conn_id, req.h2_stream_id,
         req.body_truncated? ? 1 : 0, unsent ? 1 : 0)
       # The INSERT's own result carries the rowid — no separate `SELECT last_insert_rowid()`.
-      id = res.last_insert_id
-      # Index the request body text now; the response side is filled in by
-      # update_one. Same transaction, so FTS and the row commit together.
-      req_fts = request_fts(req)
-      conn.exec("INSERT INTO flows_fts(rowid, req, resp) VALUES (?, ?, '')", id, req_fts)
-      {id, req_fts}
+      # No flows_fts write here: `fts_dirty = 1` hands the trigram work to the off-commit
+      # indexer, so a capture commit no longer pays for tokenization (see V4 / await_op).
+      res.last_insert_id
     end
 
     private def update_one(conn : DB::Connection, resp : CapturedResponse) : Nil
@@ -572,70 +735,19 @@ module Gori
         UPDATE flows SET
           response_head = ?, response_body = ?, status = ?, reason = ?,
           content_type = ?, response_size = ?, state = ?,
-          ttfb_us = ?, duration_us = ?, error = ?, response_body_truncated = ?
+          ttfb_us = ?, duration_us = ?, error = ?, response_body_truncated = ?,
+          fts_dirty = 1
         WHERE id = ?
         SQL
         resp.head, resp.body, resp.status, resp.reason, resp.content_type,
         response_size,
         resp.state.value, resp.ttfb_us, resp.duration_us, resp.error,
         resp.body_truncated? ? 1 : 0, resp.flow_id)
-      # flows_fts is contentless (V24): FTS5 forbids UPDATE there, so re-write the whole
-      # row. insert_one indexed the request side (searchable while Pending); DELETE that
-      # row and re-INSERT with BOTH sides. The request text was computed at insert time and
-      # memoized (@pending_req_fts) — reuse it rather than reading the head + (capped) body
-      # back from the row on every response; a miss (evicted, an import, or a cross-process
-      # write) falls back to that readback. DELETE is a cheap tombstone (contentless_delete=1)
-      # and also makes a double update_response idempotent (last write wins).
-      # Skip the FTS body text for a binary content type or a compressed (non-identity
-      # Content-Encoding) body. Both markers now ride on CapturedResponse (extracted once
-      # by the proxy where the headers are already parsed), so this no longer copies the
-      # raw head into a String + scans it per flow. A body-less response (204/304/redirect)
-      # has no text to index and short-circuits before the marker checks.
-      resp_body = resp.body
-      resp_fts = (resp_body.nil? || resp_body.empty? || binary_content?(resp.content_type) || encoded?(resp.content_encoding)) ? "" : fts_text(resp_body)
-      req_fts = @pending_req_fts.delete(resp.flow_id) || request_fts_from_row(conn, resp.flow_id)
-      conn.exec("DELETE FROM flows_fts WHERE rowid = ?", resp.flow_id)
-      conn.exec("INSERT INTO flows_fts(rowid, req, resp) VALUES (?, ?, ?)", resp.flow_id, req_fts, resp_fts)
-    end
-
-    # Record a flow's request-side FTS text for its pending response update (writer fiber
-    # only). Clears the memo on overflow rather than growing unbounded — a burst of requests
-    # whose responses never land would otherwise pin memory; after a clear, those responses
-    # take the readback path.
-    private def remember_req_fts(id : Int64, req_fts : String) : Nil
-      @pending_req_fts.clear if @pending_req_fts.size >= PENDING_FTS_MAX
-      @pending_req_fts[id] = req_fts
-    end
-
-    # The request-side FTS text for an already-stored flow, recomputed the same way
-    # request_fts does but reading the head + (SQL-capped) body back from the row —
-    # update_one has only the response, and contentless FTS can't keep the old req
-    # column across a rewrite. A bodyless request (the common GET) reads just the small
-    # head; a binary body is skipped (empty), matching request_fts.
-    private def request_fts_from_row(conn : DB::Connection, flow_id : Int64) : String
-      row = conn.query_one?(
-        "SELECT request_head, substr(request_body, 1, ?) FROM flows WHERE id = ?",
-        FTS_INDEX_MAX, flow_id, as: {Bytes, Bytes?})
-      return "" unless row
-      head, body = row
-      return "" if body.nil? || body.empty?
-      skip_body_fts?(head) ? "" : String.new(body)
-    end
-
-    # Body text fed to the FTS index, capped per side so a large body can't bloat
-    # the index.
-    private def fts_text(bytes : Bytes?) : String
-      return "" unless bytes
-      String.new(bytes[0, {bytes.size, FTS_INDEX_MAX}.min])
-    end
-
-    # The request body's FTS text, skipping the (synchronous, on-commit) trigram
-    # tokenization for a clearly-binary body. The head is scanned for Content-Type
-    # only when a body actually exists (bodyless GETs cost nothing).
-    private def request_fts(req : CapturedRequest) : String
-      body = req.body
-      return "" if body.nil? || body.empty?
-      skip_body_fts?(req.head) ? "" : fts_text(body)
+      # `fts_dirty = 1` again: the response side just appeared (or changed), so whatever the
+      # indexer wrote for this row is stale. Re-dirtying an already-dirty row is a no-op, so
+      # the common case — response landing before the indexer ever reached the row — is
+      # indexed exactly ONCE, with both sides, instead of the old empty-insert + delete +
+      # re-insert. That also makes a double update_response idempotent (last write wins).
     end
 
     # Skip body FTS for clearly-binary content types (images/media/archives/

--- a/src/gori/store/reads.cr
+++ b/src/gori/store/reads.cr
@@ -183,7 +183,8 @@ module Gori
         c.exec("DELETE FROM flows")
         c.exec("DELETE FROM h2_frames")
         c.exec("DELETE FROM h2_connections")
-        @pending_req_fts.clear
+        # No index backlog bookkeeping to undo: a pending re-index is the row's own
+        # `fts_dirty` flag, so deleting the rows deletes the backlog with them.
         nil
       }
     end
@@ -205,7 +206,6 @@ module Gori
         conn.exec("DELETE FROM h2_frames WHERE conn_id = ? AND ? NOT IN (SELECT h2_conn_id FROM flows WHERE h2_conn_id IS NOT NULL)", cid, cid)
         conn.exec("DELETE FROM h2_connections WHERE id = ? AND id NOT IN (SELECT h2_conn_id FROM flows WHERE h2_conn_id IS NOT NULL)", cid, cid)
       end
-      @pending_req_fts.delete(id)
     end
 
     # Distinct host values for History QL Tab-complete (`host:`). Prefix-filtered

--- a/src/gori/store/schema.cr
+++ b/src/gori/store/schema.cr
@@ -569,7 +569,28 @@ module Gori
         "ALTER TABLE flows ADD COLUMN unsent INTEGER NOT NULL DEFAULT 0",
       ]
 
-      MIGRATIONS = [V1, V2, V3]
+      # `fts_dirty` marks a flow whose `flows_fts` entry is missing or stale, so trigram
+      # tokenization can move OFF the capture commit (see Store#index_pending_batch). It was
+      # the dominant capture cost: ~30µs per indexed KiB inside the writer's transaction, which
+      # is where a 64 KiB text response cost ~2ms and collapsed end-to-end capture of text/html
+      # to a few hundred req/s — while the proxy + HTTP/1.1 codec add only ~25µs per request.
+      #
+      # Durability is the reason this is a COLUMN and not an in-memory queue: a killed process
+      # (or a batch dropped under saturation) would otherwise leave those flows permanently
+      # unsearchable with nothing to detect it. The flag persists, so the next open — or the
+      # next idle moment — finishes the job, and `Store#fts_backlog` can SAY how far behind
+      # search is instead of silently under-reporting a `body:` query.
+      #
+      # Existing rows default to 0 (= index current): every already-stored flow WAS indexed by
+      # the old synchronous path, so defaulting to 0 avoids re-indexing whole histories on
+      # upgrade. Only rows written from here on are marked dirty. The partial index keeps the
+      # backlog probe O(backlog) rather than O(table) — it holds nothing at all once drained.
+      V4 = [
+        "ALTER TABLE flows ADD COLUMN fts_dirty INTEGER NOT NULL DEFAULT 0",
+        "CREATE INDEX idx_flows_fts_dirty ON flows (id) WHERE fts_dirty = 1",
+      ]
+
+      MIGRATIONS = [V1, V2, V3, V4]
 
       def self.migrate!(db : DB::Database) : Nil
         db.using_connection do |conn|

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -249,7 +249,7 @@ module Gori::Tui
       invalidate_host_suggest_cache
       prev_id = @rows[@selected]?.try(&.id) # anchor the highlight to the flow, not the index
       query_filter = QL.parse(@query)
-      @query_note = query_note_for(query_filter)
+      @query_note = query_note_for(query_filter, store)
       # A non-blank query that compiles to EMPTY (every term invalid — a typo'd field,
       # a bad numeric like dur:>2sec, an unterminated value) must NOT fall through to a
       # match-all search: that would show EVERY flow while the bar claims a filter is
@@ -289,11 +289,30 @@ module Gori::Tui
     # A short note explaining a filter that matches nothing because it is INVALID (vs a
     # valid filter that genuinely has no matches) — surfaced in the empty-state hint so a
     # typo'd status:/dur:/size: or a broken body~[regex isn't misread as "no traffic".
-    private def query_note_for(filter : QL::Filter) : String?
+    private def query_note_for(filter : QL::Filter, store : Store) : String?
       return nil if @query.blank?
       return "invalid filter — no valid terms" if QL.reject_empty?(@query, filter)
       bad = QL.invalid_regex_terms(@query)
-      bad.empty? ? nil : "invalid regex in #{bad.first}"
+      return "invalid regex in #{bad.first}" unless bad.empty?
+      fts_backlog_note(filter, store)
+    end
+
+    # `body:`/free-text read the trigram index, which is written OFF the capture commit
+    # (Store V4) so a busy proxy is never throttled by tokenization. The cost is that during
+    # a burst the newest flows are captured but not yet indexed — and "not indexed yet" would
+    # otherwise be indistinguishable from "no match", which on a security proxy is the kind of
+    # silence that hides a finding. So SAY it. A live view must not stall to fix this (the
+    # one-shot CLI/MCP surfaces call Store#index_pending! instead), and the backlog drains on
+    # its own as soon as capture goes quiet.
+    #
+    # Probed only for a filter that actually reads the index, since reload re-runs on every
+    # tick while a filter is active.
+    private def fts_backlog_note(filter : QL::Filter, store : Store) : String?
+      return nil unless filter.uses_fts?
+      pending = store.fts_backlog
+      return nil if pending == 0
+      count = pending >= Store::FTS_BACKLOG_PROBE_MAX ? "#{Store::FTS_BACKLOG_PROBE_MAX}+" : pending.to_s
+      "body search is #{count} flow(s) behind — still indexing"
     end
 
     # settings:layout History list order — newest first (default) or oldest first.


### PR DESCRIPTION
## What

Capture, not the proxy, was the bottleneck. The proxy + HTTP/1.1 codec add **~25µs/req**; persisting the flow added **65µs–1.9ms** on top, because `update_one` tokenized the response body for the trigram index *inside* the transaction a proxy fiber was blocked on. Tokenization costs ~30µs per indexed KiB, so at the old 64 KiB cap one text/html response occupied the single writer for ~2ms.

Two changes:

1. **`FTS_INDEX_MAX` 64 KiB → 8 KiB.** A work budget, not a size one. The trade is search *recall*, not correctness: `body:` sees the first 8 KiB per side, `body~<regex>` still scans the whole stored BLOB.
2. **Schema V4 adds `flows.fts_dirty` + a partial index.** The writer indexes the backlog when it would otherwise be parked (`await_op`) instead of inside the capture transaction.

## Measured

End-to-end against the real `Proxy::Server` with a real `StoreSink` (the existing `bench/proxy_bench.cr` uses a `NullSink`, so the DB cost was excluded from it; its backend also served `application/octet-stream`, which makes `update_one` skip body FTS entirely and hides the cost).

| 64 KiB text/html | before | + cap | + off-commit |
|---|---|---|---|
| c=1 | 494 rps | 1,727 | **3,193** |
| c=8 | 401 rps | 2,022 | **4,060** |
| c=8 p99 | 84ms | 12.2ms | **6.8ms** |
| c=8 max | 115ms | 21ms | **7.8ms** |
| db size | 648 MiB | 369 | 371 |

1 KiB c=8: 4,043 → **19,501 rps**. A serial keep-alive client (one browser connection): 2,070 → **8,723 flows/s**.

## Honest caveat

SQLite has one writer, so the index work still runs on that fiber — the win is that it is now **deferrable**, and capture keeps strict priority. Under a writer-saturating synthetic load (conc=64 tight loop, no idle gaps) capture is **~6% slower** and the index lags instead; under any network-bound load the gap is where the backlog drains. Seeding 20k flows leaves 10k in the backlog, drained in 3.7s — total wall still beats the old path (6.0s vs 9.7s), because a flow whose response lands before the indexer reaches it is now indexed **once** with both sides instead of an empty insert + delete + re-insert. `@pending_req_fts` and its memo go away with it.

## The risk this creates, and what guards it

"Captured" and "searchable" become two events, and *not indexed yet* is indistinguishable from *no match* — on a security proxy that is how a finding gets missed.

- The backlog is a **column, not an in-memory queue**: a killed process leaves it recoverable and the next open finishes the job.
- **One-shot surfaces drain first** (CLI `history`/`sitemap`, MCP `list_history`/`list_sitemap`, probe scan). `QL::Filter#uses_fts?` keeps that to queries that actually read the index.
- **The live History view can't stall, so it says it**: `body search is N flow(s) behind — still indexing` in the empty-state note.
- **`Store#flush` now includes the index drain**, so it stays a true read barrier. Two specs that relied on synchronous indexing got the barrier added; a `BARRIER NOTE` on the write API documents the new contract.

## Verification

- `crystal spec`: **4369 examples, 0 failures** (8 new).
- Every new spec **control-run**: forcing `fts_dirty = 0` on insert fails 5 of them; removing the TUI note fails the 6th.
- **Upgrade path exercised for real**: a V3 db captured with the pre-change binary, reopened with the new one — `user_version` 4, existing rows *not* re-marked dirty (0), their FTS entries preserved.
- End-to-end smoke: capture through `gori run capture`, then `gori run history "body:<token>"` returns exact results and clears the backlog.
- `ameba` at the HEAD baseline (21 findings on the touched files, none new).