### PR TITLE
feat(tui): export a note to Markdown, and ask where to write the Issues report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.1.4
 
+- TUI: export the current note to a Markdown file from the Notes space menu, and ask where to write the Issues report instead of always overwriting `<project dir>/issues.{md,json}`. Export is `⇧E` on both tabs; the Issues list's old `x` is freed, so `x` now means "Select line" everywhere
 - Probe: add active-scan rules — open redirect, CRLF/response-header injection, host-header (X-Forwarded-Host) injection, access-control bypass via path normalization and via X-Original-URL/X-Rewrite-URL, NGINX-style parameter path traversal, active GraphQL introspection, and SSTI (#299)
 - Proxy: fix HTTPS blank pages / empty History — reflect origin ALPN so h1-only origins load, resolve the system CA trust store for upstream verification, and report TLS-verify failures separately from connect failures (#332, #333, #334, #336)
 - Proxy: stop an upstream RST leaving a flow stuck Pending forever (#330)

--- a/spec/notes_spec.cr
+++ b/spec/notes_spec.cr
@@ -25,4 +25,59 @@ describe Gori::Notes do
       doc.notes.first.text.should eq(raw) # stored entry untouched — round-trips raw for persistence
     end
   end
+
+  describe ".export_basename" do
+    it "derives the filename from the note's title" do
+      Gori::Notes.export_basename("My Note\nbody text", 0).should eq("My-Note.md")
+      Gori::Notes.export_basename("  leading blank\n\nfirst real line", 0).should eq("leading-blank.md")
+    end
+
+    it "PRESERVES Korean/CJK titles instead of collapsing them to ASCII" do
+      # The anti-regression against reaching for ProjectRegistry#slugify, which must emit an
+      # ASCII directory slug and so hashes a non-ASCII name to project-<sha256>. A note titled
+      # in Korean has to stay findable in a file listing.
+      Gori::Notes.export_basename("인증 우회\n상세 내용", 0).should eq("인증-우회.md")
+      Gori::Notes.export_basename("日本語のメモ", 0).should eq("日本語のメモ.md")
+    end
+
+    it "replaces path separators, so a title can never traverse" do
+      Gori::Notes.export_basename("../../etc/passwd", 0).should eq("etc-passwd.md")
+      Gori::Notes.export_basename("a/b\\c:d", 0).should eq("a-b-c-d.md")
+      Gori::Notes.export_basename("re*port?<>|\"", 0).should eq("re-port.md")
+    end
+
+    it "falls back to note-N when the title yields nothing usable" do
+      # The index is the sub-tab position, matching NotesView::Note#label's "note N" — a bare
+      # ".md" (hidden, nameless) must be impossible.
+      Gori::Notes.export_basename("", 2).should eq("note-3.md")
+      Gori::Notes.export_basename("   \n\t ", 0).should eq("note-1.md")
+      Gori::Notes.export_basename("..", 4).should eq("note-5.md")
+      Gori::Notes.export_basename(".", 0).should eq("note-1.md")
+      Gori::Notes.export_basename("///", 0).should eq("note-1.md")
+    end
+
+    it "strips control bytes that can never reach a filename" do
+      esc = 27.chr
+      bel = 7.chr
+      out = Gori::Notes.export_basename("ti#{esc}tle#{bel}x", 0)
+      out.includes?(esc).should be_false
+      out.includes?(bel).should be_false
+      out.should eq("ti-tle-x.md")
+    end
+
+    it "caps the length in CHARACTERS with no trailing separator, and always ends in .md" do
+      long = Gori::Notes.export_basename("a" * 200, 0)
+      long.size.should eq(Gori::Notes::FILENAME_MAX_CHARS + 3) # + ".md"
+      long.should end_with(".md")
+
+      # A cut landing on a '-' must not leave one dangling before the extension.
+      cut = Gori::Notes.export_basename("#{"b" * (Gori::Notes::FILENAME_MAX_CHARS - 1)} tail", 0)
+      cut.should_not contain("-.md")
+      cut.should end_with(".md")
+
+      # The cap is chars, not bytes: 48 multi-byte chars stay 48 chars.
+      cjk = Gori::Notes.export_basename("가" * 200, 0)
+      cjk.should eq("#{"가" * Gori::Notes::FILENAME_MAX_CHARS}.md")
+    end
+  end
 end

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -995,6 +995,10 @@ class FakeExecContext < Gori::Verb::ExecContext
     rec(:notes_clear)
   end
 
+  def notes_export : Nil
+    rec(:notes_export)
+  end
+
   def notes_edit : Nil
     rec(:notes_edit)
   end

--- a/spec/tui/export_overlay_spec.cr
+++ b/spec/tui/export_overlay_spec.cr
@@ -1,0 +1,243 @@
+require "../spec_helper"
+require "../support/memory_backend"
+require "../support/overlay_harness"
+
+include Gori::Tui
+
+private def key(k : Termisu::Input::Key, char : Char? = nil) : Termisu::Event::Key
+  Termisu::Event::Key.new(k, Termisu::Input::Modifier::None, char)
+end
+
+private def type(ov : ExportOverlay, text : String) : Nil
+  text.each_char { |c| ov.handle_key(key(Termisu::Input::Key::Unknown, c)) }
+end
+
+private def enter(ov : ExportOverlay) : Symbol
+  ov.handle_key(key(Termisu::Input::Key::Enter))
+end
+
+# Peel the completion dropdown so the NEXT ↵ reaches `validate` instead of accepting a
+# highlighted entry. `validate`'s empty-field and directory branches are dropdown-closed
+# paths: with the list up, ↵ means "take this completion" (ImportOverlay's drilling
+# behaviour, deliberately kept), so an example that wants the validation has to say so.
+private def dismiss_dropdown(ov : ExportOverlay) : Nil
+  ov.handle_key(key(Termisu::Input::Key::Escape))
+end
+
+# Replace the prefilled path wholesale: the field arrives non-empty, so an example that
+# wants a specific destination has to clear it first.
+private def retype(ov : ExportOverlay, path : String) : Nil
+  100.times { ov.handle_key(key(Termisu::Input::Key::Backspace)) }
+  type(ov, path)
+end
+
+private def with_tmpdir(&)
+  dir = File.join(Dir.tempdir, "gori-export-spec-#{Process.pid}-#{rand(1_000_000)}")
+  Dir.mkdir_p(dir)
+  begin
+    yield dir
+  ensure
+    FileUtils.rm_rf(dir)
+  end
+end
+
+describe Gori::Tui::ExportOverlay do
+  it "titles and describes the card by export kind" do
+    {:note => "note", :issues_md => "issues (Markdown)", :issues_json => "issues (JSON)"}.each do |kind, want|
+      ov = ExportOverlay.new(kind, "/tmp/x.md")
+      ov.label.should eq(want)
+      backend = MemoryBackend.new(100, 30)
+      ov.render(Screen.new(backend), Rect.new(0, 0, 100, 30))
+      backend.contains?("EXPORT #{want.upcase}").should be_true
+    end
+  end
+
+  it "arrives PREFILLED with the destination the open-site chose" do
+    # The whole point of the prefill: ↵ on an untouched field is the sane default, which is
+    # what keeps the Issues export a single keystroke after it stopped hardcoding its path.
+    ov = ExportOverlay.new(:issues_md, "/tmp/issues.md")
+    ov.path.should eq("/tmp/issues.md")
+    ov.default_basename.should eq("issues.md")
+    backend = MemoryBackend.new(100, 30)
+    ov.render(Screen.new(backend), Rect.new(0, 0, 100, 30))
+    backend.contains?("/tmp/issues.md").should be_true
+  end
+
+  it "commits an untouched prefill straight through" do
+    with_tmpdir do |dir|
+      ov = ExportOverlay.new(:note, File.join(dir, "fresh.md"))
+      enter(ov).should eq(:commit)
+    end
+  end
+
+  it "leaves the caret at the END of the prefill, so the basename is what gets edited" do
+    ov = ExportOverlay.new(:note, "/tmp/report.md")
+    type(ov, "X")
+    ov.path.should eq("/tmp/report.mdX")
+  end
+
+  it "expands ~ and leaves an absolute path alone in resolved_path" do
+    # resolved_path is the ONE expansion point — the exists-check, the write and the toast
+    # all read it, so they cannot disagree about which file this is.
+    home = ExportOverlay.new(:note, "~/notes/x.md")
+    home.resolved_path.should eq(File.join(Path.home.to_s, "notes", "x.md"))
+    home.resolved_path.should_not contain('~')
+
+    abs = ExportOverlay.new(:note, "/tmp/x.md")
+    abs.resolved_path.should eq("/tmp/x.md")
+  end
+
+  it "refuses an empty field with a notice instead of committing" do
+    ov = ExportOverlay.new(:note, "/tmp/x.md")
+    retype(ov, "")
+    ov.path.should eq("")
+    dismiss_dropdown(ov) # an emptied field lists the cwd; ↵ would otherwise take a row
+    enter(ov).should eq(:stay)
+    backend = MemoryBackend.new(100, 30)
+    ov.render(Screen.new(backend), Rect.new(0, 0, 100, 30))
+    backend.contains?("type a destination path").should be_true
+  end
+
+  it "fills in the file name when the path is a DIRECTORY, then writes on the next ↵" do
+    # A directory isn't an error, it's a half-finished path — the Save-As idiom. Without this
+    # the ↵ after tab-completing into a folder would try to File.write onto the folder.
+    with_tmpdir do |dir|
+      ov = ExportOverlay.new(:note, File.join(dir, "note-1.md"))
+      retype(ov, dir)
+      dismiss_dropdown(ov) # the dir matched itself in the list; ↵ there means "drill in"
+      enter(ov).should eq(:stay)
+      ov.path.should eq(File.join(dir, "note-1.md"))
+      enter(ov).should eq(:commit)
+    end
+  end
+
+  it "refuses a path whose parent directory does not exist (and never mkdir_p's it)" do
+    ov = ExportOverlay.new(:note, "/tmp/x.md")
+    retype(ov, "/nope-does-not-exist-#{Process.pid}/deep/x.md")
+    enter(ov).should eq(:stay)
+    backend = MemoryBackend.new(100, 30)
+    ov.render(Screen.new(backend), Rect.new(0, 0, 100, 30))
+    backend.contains?("no such directory").should be_true
+    Dir.exists?("/nope-does-not-exist-#{Process.pid}").should be_false
+  end
+
+  it "arms on an existing file and overwrites only on the SECOND ↵" do
+    # The Issues export used to clobber issues.md silently; this is the guard that replaced it.
+    with_tmpdir do |dir|
+      target = File.join(dir, "taken.md")
+      File.write(target, "old")
+      ov = ExportOverlay.new(:note, target)
+
+      enter(ov).should eq(:stay)
+      backend = MemoryBackend.new(100, 30)
+      ov.render(Screen.new(backend), Rect.new(0, 0, 100, 30))
+      backend.contains?("file exists").should be_true
+
+      enter(ov).should eq(:commit)
+    end
+  end
+
+  it "DISARMS the overwrite when the path is edited between the two ↵s" do
+    # The ↵ that overwrites must be the one right after the warning, for the path that was
+    # warned about — otherwise typing a second, also-existing name would write unwarned.
+    with_tmpdir do |dir|
+      a = File.join(dir, "a.md")
+      b = File.join(dir, "b.md")
+      File.write(a, "a")
+      File.write(b, "b")
+
+      ov = ExportOverlay.new(:note, a)
+      enter(ov).should eq(:stay) # armed for a.md
+      retype(ov, b)              # …but the user retargets
+      enter(ov).should eq(:stay) # so b.md re-arms rather than being written
+      enter(ov).should eq(:commit)
+    end
+  end
+
+  it "peels the completion dropdown on the first esc, and cancels on the next" do
+    with_tmpdir do |dir|
+      File.write(File.join(dir, "sample.md"), "x")
+      ov = ExportOverlay.new(:note, "/tmp/x.md")
+      retype(ov, "#{dir}/") # opens the dropdown
+      ov.handle_key(key(Termisu::Input::Key::Escape)).should eq(:stay)
+      ov.handle_key(key(Termisu::Input::Key::Escape)).should eq(:cancel)
+    end
+  end
+
+  it "centers the card and declines to draw a phantom box when the window is too small" do
+    ov = ExportOverlay.new(:note, "/tmp/x.md")
+    area = Rect.new(0, 0, 100, 30)
+    box = ov.overlay_box(area).not_nil!
+    (box.x - area.x).should eq(area.right - box.right)
+    (box.y - area.y).should eq(area.bottom - box.bottom)
+
+    ov.overlay_box(Rect.new(0, 0, 30, 30)).should be_nil # too narrow
+    ov.overlay_box(Rect.new(0, 0, 100, 8)).should be_nil # too short
+    ov.overlay_box(Rect.new(0, 0, 0, 0)).should be_nil
+  end
+
+  it "consumes clicks inside the card but dismisses on a click-away" do
+    ov = ExportOverlay.new(:note, "/tmp/x.md")
+    area = Rect.new(0, 0, 100, 30)
+    box = ov.overlay_box(area).not_nil!
+    ov.handle_click(area, box.x + 2, box.y + 3).should eq(:stay)
+    ov.handle_click(area, box.x - 1, box.y).should eq(:cancel)
+  end
+end
+
+# The shell-visible half: the Runner opens this with an on_commit closure that performs the
+# WRITE and dispatches generically, so the overlay itself never touches a controller.
+describe "Gori::Tui::ExportOverlay — Overlay seam" do
+  it "names itself in the focus badge by export SUBJECT" do
+    {:note        => "EXPORT note",
+     :issues_md   => "EXPORT issues (Markdown)",
+     :issues_json => "EXPORT issues (JSON)",
+    }.each do |kind, want|
+      OverlayHarness.new(ExportOverlay.new(kind, "/tmp/x.md")).assert_chrome(OverlayKind::Export, want)
+    end
+  end
+
+  it "hands the RESOLVED path to the commit closure and closes" do
+    with_tmpdir do |dir|
+      ov = ExportOverlay.new(:note, File.join(dir, "out.md"))
+      h = OverlayHarness.new(ov)
+      written = [] of String
+      h.on_commit do
+        written << ov.resolved_path
+        true
+      end
+
+      h.press(Termisu::Input::Key::Enter).should eq(:closed)
+      written.should eq([File.join(dir, "out.md")])
+      h.commits.should eq(1)
+    end
+  end
+
+  it "KEEPS the card up when the write fails, so the typed path survives" do
+    # The `false` return is the whole reason a permission error doesn't cost the operator
+    # their path. It mirrors Runner#submit_ca_import's reject-and-stay-open.
+    with_tmpdir do |dir|
+      ov = ExportOverlay.new(:note, File.join(dir, "out.md"))
+      h = OverlayHarness.new(ov, commit: false)
+      h.press(Termisu::Input::Key::Enter).should eq(:open)
+      h.commits.should eq(1)
+      ov.path.should eq(File.join(dir, "out.md"))
+    end
+  end
+
+  it "esc cancels without writing, and a click-away is a dismiss (never a write)" do
+    h = OverlayHarness.new(ExportOverlay.new(:note, "/tmp/x.md"))
+    h.press(Termisu::Input::Key::Escape).should eq(:closed)
+    h.commits.should eq(0)
+
+    away = OverlayHarness.new(ExportOverlay.new(:note, "/tmp/x.md"))
+    away.click(0, 0).should eq(:closed)
+    away.commits.should eq(0)
+  end
+
+  it "routes IME preedit to the path field" do
+    h = OverlayHarness.new(ExportOverlay.new(:note, "/tmp/x.md"))
+    h.preedit("preedithere")
+    h.rendered?("preedithere").should be_true
+  end
+end

--- a/spec/tui/overlay_dispatch_spec.cr
+++ b/spec/tui/overlay_dispatch_spec.cr
@@ -31,7 +31,7 @@ private EXPECTED_OVERLAY_SYMS = {
   :comparer_pick, :repeater_subtab, :links, :issue_pick, :note_pick, :preferences,
   :settings, :tabs, :hosts, :env, :hotkeys, :notifications, :probe_active,
   :discover_config, :discover_headers, :fuzz_set, :fuzz_advanced, :oast_provider,
-  :probe_rule, :rewriter_rule, :ca_import, :import, :scope_rule, :sequence_config,
+  :probe_rule, :rewriter_rule, :ca_import, :import, :export, :scope_rule, :sequence_config,
   :mine_config, :copy_as, :send_to,
 }
 
@@ -74,6 +74,9 @@ private MIGRATED_KINDS = [
   OverlayKind::Hosts,
   OverlayKind::Env,
   OverlayKind::Hotkeys,
+  # Export — born on the seam (Notes → Export note, Issues → Export issues), so it was
+  # never in MODAL_OVERLAYS to be deleted from.
+  OverlayKind::Export,
 ]
 
 # Never in MODAL_OVERLAYS by design, migrated or not. `None` is "no modal at all" and

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -992,6 +992,10 @@ private class FakeContext < ExecContext
     @calls << :notes_clear
   end
 
+  def notes_export : Nil
+    @calls << :notes_export
+  end
+
   def notes_edit : Nil
     @calls << :notes_edit
   end

--- a/spec/verbs/issues_spec.cr
+++ b/spec/verbs/issues_spec.cr
@@ -131,13 +131,42 @@ describe "Gori::Verbs.register_issues" do
       end
     end
 
-    it "defaults the Issues-scope 'x' chord to the human-readable Markdown report" do
-      # Issues-scoped so 'x' doesn't collide with the hex toggles in other scopes.
+    it "defaults the Issues-scope export key to the human-readable Markdown report" do
       verb = r["issues.export-key"]
-      verb.chords.should eq([Gori::Verb::Chord.new("x")])
+      verb.scope.should eq(Gori::Verb::Scope::Issues)
       ctx = FakeExecContext.new
       verb.call(ctx)
       ctx.args_for(:issues_export).should eq(["markdown"])
+    end
+
+    it "binds export to ⇧E — the SAME key Notes uses — and leaves 'x' to Select line" do
+      # 'x' means "Select line" in all nine read_edit.cr scopes, including the Issues DETAIL
+      # one ↵ away; the list's old 'x' export was the lone exception and collided with its
+      # own tab. Sharing 'E' with notes.export makes export one key across tabs.
+      verb = r["issues.export-key"]
+      verb.menu_key.should eq('E')
+      verb.menu_key.should eq(r["notes.export"].menu_key)
+      verb.hidden?.should be_false
+
+      # Chord.new("E") would be DEAD: Keybind.from_event normalises a typed capital to
+      # shift + lowercase, so the stored chord has to be the shift form.
+      verb.chords.should eq([Gori::Verb::Chord.new("e", shift: true)])
+      verb.chords.map(&.key).should_not contain("x")
+
+      # …and nothing in the Issues list scope claims 'x' any more.
+      r.select(&.scope.issues?).compact_map(&.menu_key).should_not contain('x')
+    end
+
+    it "keeps all three entries on the SAME intent now that the path comes from a popup" do
+      # The destination moved from a hardcoded <project dir>/issues.{md,json} to an
+      # ExportOverlay prompt, but that is purely a shell concern: the verb ids, scopes,
+      # chords and the issues_export(format) signature all had to stay put, so anything
+      # bound to them (palette entries, user keybindings, the MCP/CLI surfaces) is untouched.
+      %w[issues.export-md issues.export-json issues.export-key].each do |id|
+        ctx = FakeExecContext.new
+        r[id].call(ctx)
+        ctx.call_names.should eq([:issues_export])
+      end
     end
   end
 end

--- a/spec/verbs/notes_spec.cr
+++ b/spec/verbs/notes_spec.cr
@@ -14,20 +14,32 @@ describe "Gori::Verbs.register_notes" do
 
   it "gates every Notes verb on the Notes tab" do
     elsewhere = FakeExecContext.new # :history
-    {"notes.new"   => :notes_new,
-     "notes.close" => :notes_close,
-     "notes.clear" => :notes_clear,
-     "notes.edit"  => :notes_edit,
-     "notes.goto"  => :notes_goto,
-     "notes.find"  => :notes_find,
-     "notes.links" => :notes_links,
-     "notes.copy"  => :read_copy,
+    {"notes.new"    => :notes_new,
+     "notes.close"  => :notes_close,
+     "notes.clear"  => :notes_clear,
+     "notes.edit"   => :notes_edit,
+     "notes.goto"   => :notes_goto,
+     "notes.find"   => :notes_find,
+     "notes.links"  => :notes_links,
+     "notes.export" => :notes_export,
+     "notes.copy"   => :read_copy,
     }.each do |id, intent|
       r[id].scope.should eq(Gori::Verb::Scope::Notes)
       r[id].available?(elsewhere).should be_false
       r[id].available?(in_notes).should be_true
       verb_intents(r, id).should eq([intent])
     end
+  end
+
+  it "puts export on the space menu with no chord, under a capital mnemonic" do
+    # 'e' is Edit-in-$EDITOR and 'x' is read_edit.cr's Select line, both already in this
+    # scope — hence the capital, following 'S' (Send selection to). A CHORD would be dead
+    # weight: the Notes body swallows every printable key, so the space menu and the palette
+    # are the only ways in.
+    r["notes.export"].menu_key.should eq('E')
+    r["notes.export"].section.should eq(:common)
+    r["notes.export"].chords.should be_empty
+    r["notes.export"].hidden?.should be_false
   end
 
   it "keeps every mnemonic distinct within the scope" do

--- a/src/gori/notes.cr
+++ b/src/gori/notes.cr
@@ -150,5 +150,35 @@ module Gori
     def self.line_count(text : String) : Int32
       text.split('\n').size
     end
+
+    FILENAME_MAX_CHARS = 48
+
+    # A filesystem-safe basename for "export this note", derived from its title the same
+    # way the sub-tab label is.
+    #
+    # UNICODE IS PRESERVED — a Korean/CJK title stays legible in the filename. Neither of
+    # the codebase's other name-manglers fits: ProjectRegistry#slugify must emit an ASCII
+    # *directory* slug and so hashes a non-ASCII name to project-<sha256>, and Runner's
+    # title_safe caps at 40 with a '…' that has no business in a filename. Only bytes a
+    # path cannot carry are replaced here.
+    #
+    # `index` is the sub-tab position behind the "note N" fallback, matching
+    # NotesView::Note#label, so an untitled note exports as note-3.md and never as a bare
+    # ".md". Path separators are replaced BEFORE the strip, so a title like "../../etc/passwd"
+    # can only ever yield "etc-passwd.md".
+    #
+    # The cap is in CHARACTERS, not bytes: 48 × 4 bytes worst case plus ".md" is still far
+    # under the 255-byte limit every filesystem gori runs on enforces.
+    def self.export_basename(text : String, index : Int32) : String
+      raw = (title(text) || "").scrub
+      safe = raw.gsub { |c| c.control? ? ' ' : c } # NUL/ESC/BEL/CR can never reach a filename
+        .gsub(/[\/\\:*?"<>|]+/, "-")               # path separators + the Windows-hostile set
+        .gsub(/\s+/, "-")
+        .gsub(/-+/, "-")
+        .strip("-. \t") # "." / ".." / a leading dot (hidden) / a trailing dot cannot survive
+      safe = safe[0, FILENAME_MAX_CHARS].strip("-. ") if safe.size > FILENAME_MAX_CHARS
+      safe = "note-#{index + 1}" if safe.empty?
+      "#{safe}.md"
+    end
   end
 end

--- a/src/gori/tui/controllers/issues_controller.cr
+++ b/src/gori/tui/controllers/issues_controller.cr
@@ -346,19 +346,36 @@ module Gori::Tui
       @host.status(msg)
     end
 
-    def issues_export(format : Symbol) : Nil
-      issues = @host.session.store.issues
-      return @host.status("no issues to export") if issues.empty?
-      ext = format == :json ? "json" : "md"
+    # Write the issue report to `path` (the destination came from ExportOverlay — this used
+    # to hardcode <project dir>/issues.{md,json} and clobber it silently). Returns true when
+    # the shell should close the popup; false keeps it up so a correctable failure doesn't
+    # cost the typed path.
+    #
+    # The trailing newline mirrors `gori run issues --export=PATH`, so this and the CLI write
+    # byte-identical files for the same project and format (`--format=markdown|json`; the
+    # CLI's DEFAULT --format is `text`, a different report entirely). JSON.build emits no
+    # trailing newline of its own, so the JSON export gains one here.
+    def issues_export_to(format : Symbol, path : String) : Bool
       store = @host.session.store
+      issues = store.issues
+      if issues.empty?
+        @host.status("no issues to export")
+        return true
+      end
       content = format == :json ? Issues::Export.json(issues, store) : Issues::Export.markdown(issues, store, @host.session.project.name)
-      path = File.join(@host.session.project.dir, "issues.#{ext}")
-      File.write(path, content)
+      File.write(path, content.ends_with?('\n') ? content : "#{content}\n")
       msg = "exported #{issues.size} issue#{issues.size == 1 ? "" : "s"} → #{path}"
-      msg += "  ⚠ temp project — copy it before closing" if @host.session.project.ephemeral?
+      # Only warn when the report landed INSIDE the ephemeral project dir. The path used to
+      # always be in there, so the warning was unconditional; now the operator picks it, and
+      # a file written to their cwd survives the project just fine.
+      if @host.session.project.ephemeral? && path.starts_with?(@host.session.project.dir)
+        msg += "  ⚠ temp project — copy it before closing"
+      end
       @host.status(msg)
+      true
     rescue ex
       @host.status("export failed: #{ex.message}")
+      false
     end
   end
 end

--- a/src/gori/tui/controllers/notes_controller.cr
+++ b/src/gori/tui/controllers/notes_controller.cr
@@ -375,5 +375,28 @@ module Gori::Tui
         @host.status("note cleared")
       end
     end
+
+    # Write the current note to `path` (the destination came from ExportOverlay). Returns
+    # true when the shell should close the popup; false keeps it up so a correctable failure
+    # (a read-only directory, a path that lost its parent) doesn't cost the typed path.
+    #
+    # Deliberately NO save_notes first, unlike notes_duplicate / notes_links: `current_text`
+    # reads the live in-memory TextArea, so the export already carries unsaved edits — the
+    # bytes on screen, which is what the user means by "this note". Exporting mutates no gori
+    # state and so should have no persistence side effect.
+    #
+    # The bytes go out VERBATIM — no scrub_controls. That helper exists for text headed to a
+    # live terminal (see the split in `gori run issues`: the --export branch writes raw, the
+    # STDOUT branch scrubs). A .md file is not a TTY, and scrubbing would corrupt whatever the
+    # operator captured into the note.
+    def notes_export_to(path : String) : Bool
+      text = @notes.current_text
+      File.write(path, text.ends_with?('\n') ? text : "#{text}\n")
+      @host.status("exported note → #{path}")
+      true
+    rescue ex
+      @host.status("export failed: #{ex.message}")
+      false
+    end
   end
 end

--- a/src/gori/tui/export_overlay.cr
+++ b/src/gori/tui/export_overlay.cr
@@ -1,0 +1,260 @@
+require "./screen"
+require "./theme"
+require "./frame"
+require "./text_field"
+require "./path_complete"
+require "./overlay"
+
+module Gori::Tui
+  # Centered popup collecting the DESTINATION path for an export — Notes → "Export note"
+  # and Issues → "Export issues". One path field with an inline PathComplete dropdown:
+  # ImportOverlay's form, pointed the other way.
+  #
+  # Two callers share it because the form is identical and everything that differs (card
+  # title, blurb, prefill, toast noun) is the `kind` axis ImportOverlay already models. The
+  # WRITE itself rides in as the `on_commit` closure supplied by Runner#open_export, so
+  # neither controller learns that a modal exists.
+  #
+  # NOT a subclass of ImportOverlay, and no shared PathFieldOverlay base was extracted:
+  # Crystal has no `override`, so a subclass silently shadows a base contract method, and
+  # the two forms validate in OPPOSITE directions — import demands the file exist, export
+  # demands it be writable and NOT (silently) exist. If a fourth path form ever appears,
+  # extracting the field + dropdown + box geometry is the refactor to make then.
+  #
+  # It defines no handle_click for the same reason ImportOverlay doesn't: the one field is
+  # always focused, so the base default (click inside → stay, outside → dismiss) already IS
+  # this form's behaviour.
+  class ExportOverlay < Overlay
+    getter kind : Symbol
+
+    # The filename the directory fill-in below drops in. Derived from the prefill so the
+    # default name has exactly one source — the open-site's `default_path`.
+    getter default_basename : String
+
+    def initialize(@kind : Symbol, default_path : String)
+      @field = TextField.new(default_path)
+      @default_basename = File.basename(default_path)
+      @path_complete = PathComplete.new
+      @notice = ""
+      @overwrite_armed = false
+      # Deliberately NO @path_complete.refresh here: the field arrives prefilled, and a
+      # dropdown covering the card before the user has touched anything reads as noise.
+      # TextField#set parked the caret at the END, so the basename is what's under it.
+    end
+
+    def path : String
+      @field.value.strip
+    end
+
+    # The path as the filesystem sees it. This is the ONLY place `~`/relative expansion
+    # happens (same idiom as Import.import_file and PathComplete), so the exists-check, the
+    # write and the result toast can never disagree about which file this is. A relative
+    # name resolves against the cwd, matching `gori run issues --export=`.
+    def resolved_path : String
+      p = path
+      p.empty? ? p : Path[p].expand(home: true).to_s
+    end
+
+    # The export SUBJECT, for the card title and the Runner's result toast — one source so
+    # the popup and the toast can't disagree about what was written.
+    def label : String
+      case @kind
+      when :note        then "note"
+      when :issues_md   then "issues (Markdown)"
+      when :issues_json then "issues (JSON)"
+      else                   "file"
+      end
+    end
+
+    private def blurb : String
+      case @kind
+      when :note        then "Write the current note's text to a Markdown file."
+      when :issues_md   then "Write the Markdown issue report to a file."
+      when :issues_json then "Write every issue to a JSON file."
+      else                   "Write the export to a file."
+      end
+    end
+
+    # --- Overlay contract (see overlay.cr) -----------------------------------
+    def key : OverlayKind
+      OverlayKind::Export
+    end
+
+    def title : String
+      "EXPORT #{label}"
+    end
+
+    def hint : String
+      "type to complete · ↹ pick · ↑↓ browse · ↵ write · esc cancel"
+    end
+
+    # --- input ---------------------------------------------------------------
+    # :commit when the destination validates, :cancel on esc, else :stay.
+    def handle_key(ev : Termisu::Event::Key) : Symbol
+      key = ev.key
+
+      # esc peels one layer at a time: the dropdown first, the popup only once it's down —
+      # so a stray esc can't discard a path the user just typed.
+      if key.escape?
+        return :cancel unless @path_complete.open?
+        @path_complete.close
+        return :stay
+      end
+
+      return commit_or_complete(key) if key.tab? || key.enter?
+
+      if key.back_tab? || key.up?
+        @path_complete.move(-1) if @path_complete.open?
+        return :stay
+      end
+      if key.down?
+        @path_complete.move(1) if @path_complete.open?
+        return :stay
+      end
+
+      @field.handle_edit_key(ev)
+      @path_complete.refresh(@field.value) # keep the dropdown in lockstep
+      disarm                               # a retyped path is a DIFFERENT path — re-ask before clobbering it
+      :stay
+    end
+
+    # ↹/↵ with the dropdown up accepts the highlighted entry (a directory keeps the list
+    # open so the user can keep drilling, a file closes it); ↵ landing on a file falls
+    # through to `validate` in the same keystroke. With no dropdown up, ↵ validates what
+    # was typed. ↹ alone never writes.
+    private def commit_or_complete(key : Termisu::Input::Key) : Symbol
+      if @path_complete.open? && (res = @path_complete.accept)
+        insert, is_dir = res
+        @field.set(insert)
+        disarm
+        if is_dir
+          @path_complete.refresh(insert)
+        else
+          @path_complete.close
+          return validate if key.enter?
+        end
+        return :stay
+      end
+      key.enter? ? validate : :stay
+    end
+
+    # The destination checks, in the order a user hits them. Every failure returns :stay so
+    # the typed path stays on screen for in-place correction rather than being thrown away.
+    # Runtime failures (permissions, ENOSPC, a directory that vanished) are NOT checked here
+    # — they belong to the write, which reports them by returning false from on_commit.
+    private def validate : Symbol
+      p = resolved_path
+
+      # Unlike ImportOverlay, an empty field is not a cancel: this form arrives PREFILLED,
+      # so a cleared field means the user is mid-edit, not backing out.
+      if p.empty?
+        @notice = "type a destination path"
+        return :stay
+      end
+
+      # A directory isn't an error, it's a half-finished path — fill in the file name and
+      # let the next ↵ write it, exactly like a Save-As dialog. (PathComplete#accept leaves
+      # a trailing '/' on a directory; File.join handles that.)
+      if File.directory?(p)
+        @field.set(File.join(p, @default_basename))
+        @notice = "filled in the file name — ↵ to write"
+        return :stay
+      end
+
+      # No mkdir_p: silently creating a directory tree from a typo'd path is worse than
+      # refusing to write.
+      parent = File.dirname(p)
+      unless File.directory?(parent)
+        @notice = "no such directory: #{parent}"
+        return :stay
+      end
+
+      if File.exists?(p) && !@overwrite_armed
+        @overwrite_armed = true
+        @notice = "file exists — ↵ again to overwrite"
+        return :stay
+      end
+
+      :commit
+    end
+
+    # Any edit or completion invalidates the arm: the ↵ that overwrites must be the one
+    # immediately after the warning, for the path that was warned about.
+    private def disarm : Nil
+      @overwrite_armed = false
+      @notice = ""
+    end
+
+    def set_preedit(text : String) : Nil
+      @field.set_preedit(text)
+    end
+
+    # Wheel support — the Runner routes a scroll here, and the only scrollable thing is the
+    # completion list.
+    def move(d : Int32) : Nil
+      @path_complete.move(d) if @path_complete.open?
+    end
+
+    # --- rendering -----------------------------------------------------------
+    LABEL_W = 8 # value column offset ("Path" + padding)
+
+    # Tall enough (14) that PathComplete's 8-row cap fits under the field instead of being
+    # clipped; `area` still wins on a short terminal.
+    def overlay_box(area : Rect) : Rect?
+      w = {area.w - 6, 76}.min
+      h = {area.h - 4, 14}.min
+      return nil if w < 40 || h < 8
+      Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
+    end
+
+    def render(screen : Screen, area : Rect) : Nil
+      box = overlay_box(area)
+      unless box
+        unless area.empty?
+          screen.text(area.x + 1, area.y, "export needs a larger window · esc to close",
+            Theme.muted, Theme.bg)
+        end
+        return
+      end
+      Frame.card(screen, box, "EXPORT #{label.upcase} · destination path", bg: Theme.bg,
+        border: Theme.border_focus)
+      screen.text(box.x + 2, box.y + 1, blurb, Theme.muted, Theme.bg, width: box.w - 4)
+      render_field(screen, box)
+      render_footer(screen, box)
+      render_dropdown(screen, box)
+    end
+
+    # Notice and hint SHARE the bottom row rather than stacking. An extra row would sit
+    # under the 8-deep dropdown, which is drawn last and would overdraw it — and the row
+    # the eye is already on is where a warning belongs.
+    private def render_footer(screen : Screen, box : Rect) : Nil
+      text = @notice.empty? ? hint : "⚠ #{@notice}"
+      fg = @notice.empty? ? Theme.muted : Theme.yellow
+      screen.text(box.x + 2, box.bottom - 2, text, fg, Theme.bg, width: box.w - 4)
+    end
+
+    # The single field is always focused (there's nowhere else to go), so it always carries
+    # the focus band.
+    private def render_field(screen : Screen, box : Rect) : Nil
+      y = field_y(box)
+      screen.fill(Rect.new(box.x + 1, y, box.w - 2, 1), Theme.accent_bg)
+      screen.text(box.x + 2, y, "Path", Theme.text_bright, Theme.accent_bg)
+      vx = value_x(box)
+      vw = {box.right - 2 - vx, 1}.max
+      @field.render(screen, vx, y, vw, true, Theme.text_bright, Theme.accent_bg)
+    end
+
+    private def render_dropdown(screen : Screen, box : Rect) : Nil
+      return unless @path_complete.open?
+      @path_complete.render(screen, value_x(box), field_y(box) + 1, box.inset(1, 1))
+    end
+
+    private def field_y(box : Rect) : Int32
+      box.y + 3
+    end
+
+    private def value_x(box : Rect) : Int32
+      box.x + 2 + LABEL_W
+    end
+  end
+end

--- a/src/gori/tui/overlay.cr
+++ b/src/gori/tui/overlay.cr
@@ -48,6 +48,7 @@ module Gori::Tui
     RewriterRule
     CaImport
     Import
+    Export
     ScopeRule
     SequenceConfig
     MineConfig

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -72,6 +72,7 @@ require "./custom_rule_overlay"
 require "./oast_provider_overlay"
 require "./ca_import_overlay"
 require "./import_overlay"
+require "./export_overlay"
 require "../paths"
 require "../browser"
 require "../external_editor"
@@ -3287,6 +3288,22 @@ module Gori::Tui
       @toast = msg
     rescue ex
       @toast = "import failed: #{ex.message}"
+    end
+
+    # --- Export path popup (Notes → Export note, Issues → Export issues) -----
+
+    # One overlay, two callers: the destination form is identical, and the WRITE rides in as
+    # the on_commit closure (see overlay.cr) so neither controller learns about the modal.
+    #
+    # The closure's Bool IS the shell's close decision. A failed write (permissions, a
+    # directory that vanished between the check and the write) returns false, and the card
+    # stays up showing the error toast with the typed path intact instead of making the user
+    # retype it — the same "keep the form up on a correctable failure" the CA import commit
+    # relies on.
+    private def open_export(kind : Symbol, default_path : String, &write : String -> Bool) : Nil
+      ov = ExportOverlay.new(kind, default_path)
+      ov.on_commit = -> { write.call(ov.resolved_path) }
+      open_overlay(ov)
     end
 
     private def render_search_prompt(screen : Screen, rect : Rect) : Nil

--- a/src/gori/tui/runner/issues.cr
+++ b/src/gori/tui/runner/issues.cr
@@ -124,7 +124,16 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     issues_controller.issue_link_move(delta)
   end
 
+  # Ask where to write the report, then write it. The empty-store check happens BEFORE the
+  # popup (asking for a path and then refusing to write is worse than not asking), and uses
+  # count_issues rather than materializing store.issues here and again in the controller.
   def issues_export(format : Symbol) : Nil
-    issues_controller.issues_export(format)
+    if @session.store.count_issues == 0
+      @toast = "no issues to export"
+      return
+    end
+    ext = format == :json ? "json" : "md"
+    kind = format == :json ? :issues_json : :issues_md
+    open_export(kind, File.join(Dir.current, "issues.#{ext}")) { |p| issues_controller.issues_export_to(format, p) }
   end
 end

--- a/src/gori/tui/runner/notes.cr
+++ b/src/gori/tui/runner/notes.cr
@@ -39,6 +39,22 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     notes_controller.notes_clear
   end
 
+  # Write the current note to a .md file (space menu → "Export note…").
+  #
+  # The emptiness check happens BEFORE the popup: asking for a path and then refusing to
+  # write is worse than not asking at all (issues_export's "no issues to export" is the same
+  # call). No focus_pane(:body) either — unlike notes_goto/notes_find, this doesn't target
+  # the body's cursor.
+  def notes_export : Nil
+    view = notes_controller.view
+    if view.current_text.strip.empty?
+      @toast = "note is empty — nothing to export"
+      return
+    end
+    base = Notes.export_basename(view.current_text, view.current_index)
+    open_export(:note, File.join(Dir.current, base)) { |p| notes_controller.notes_export_to(p) }
+  end
+
   def notes_edit : Nil
     focus_pane(:body)
     run_external_editor(notes_controller.view.current_text, :notes) { |t| notes_controller.view.replace_current(t) }

--- a/src/gori/verb/context/notes.cr
+++ b/src/gori/verb/context/notes.cr
@@ -10,6 +10,7 @@ abstract class Gori::Verb::ExecContext
   abstract def notes_copy_all : Nil         # copy the entire current note to the clipboard
   abstract def notes_read_mode? : Bool      # READ vs INS (gates y/copy verbs)
   abstract def notes_clear : Nil            # clear the current note's text
+  abstract def notes_export : Nil           # open the destination-path popup, then write the note as .md
   abstract def notes_edit : Nil             # open the current note in the external editor
   abstract def notes_goto : Nil             # open the go-to-line prompt
   abstract def notes_find : Nil             # open the find-in-note prompt

--- a/src/gori/verbs/issues.cr
+++ b/src/gori/verbs/issues.cr
@@ -133,22 +133,35 @@ module Gori
         "issue.link-up", "Previous related link", "Select the previous related item",
         Verb::Scope::IssuesDetail, [Verb::Chord.new("up"), Verb::Chord.new("k")], hidden: true) { |ctx| ctx.issue_link_move(-1); nil }
 
-      # Export (palette/Global — the issues' way out): write a report to the project dir.
+      # Export (palette/Global — the issues' way out): ask for a destination path, then
+      # write the report there. All three entries below open the same popup, prefilled with
+      # <cwd>/issues.{md,json}; the path used to be hardcoded to the project dir.
       r.register Verb::Definition.new(
-        "issues.export-md", "Export issues (Markdown)", "Write all issues to issues.md in the project dir",
+        "issues.export-md", "Export issues (Markdown)…", "Write all issues to a Markdown file (asks for the path)",
         Verb::Scope::Global, [] of Verb::Chord) { |ctx| ctx.issues_export(:markdown); nil }
 
       r.register Verb::Definition.new(
-        "issues.export-json", "Export issues (JSON)", "Write all issues to issues.json in the project dir",
+        "issues.export-json", "Export issues (JSON)…", "Write all issues to a JSON file (asks for the path)",
         Verb::Scope::Global, [] of Verb::Chord) { |ctx| ctx.issues_export(:json); nil }
 
-      # The discoverable 'x' export chord on the Issues tab (the verbs above are the
-      # palette entries / both formats). Issues-scoped so 'x' doesn't collide with
-      # the hex toggles elsewhere; defaults to the human-readable Markdown report.
-      # NON-hidden so it joins the Issues list's "space" menu (key derives from 'x').
+      # The discoverable export key on the Issues tab (the verbs above are the palette
+      # entries / both formats); defaults to the human-readable Markdown report. NON-hidden
+      # so it joins the Issues list's "space" menu.
+      #
+      # ⇧E, not 'x', and it MATCHES notes.export's mnemonic on purpose. 'x' means "Select
+      # line" everywhere else in the app — all nine read-mode scopes in read_edit.cr, the
+      # Issues DETAIL one ↵ away included. So the list's 'x' was the odd one out, and it
+      # collided with its own tab's detail view. Sharing 'E' with Notes makes export one key
+      # across tabs and leaves x = Select line exception-free.
+      #
+      # The chord is Chord.new("e", shift: true), NOT Chord.new("E"): Keybind.from_event
+      # normalises a typed capital to shift + lowercase, so an "E" chord would never fire.
+      # menu_key skips shift chords, hence the explicit mnemonic — the same pairing
+      # notes.send-to uses for 'S'.
       r.register Verb::Definition.new(
-        "issues.export-key", "Export issues (Markdown)", "Write the Markdown report to the project dir",
-        Verb::Scope::Issues, [Verb::Chord.new("x")]) { |ctx| ctx.issues_export(:markdown); nil }
+        "issues.export-key", "Export issues (Markdown)…", "Write the Markdown report to a file (asks for the path)",
+        Verb::Scope::Issues, [Verb::Chord.new("e", shift: true)],
+        mnemonic: 'E') { |ctx| ctx.issues_export(:markdown); nil }
     end
   end
 end

--- a/src/gori/verbs/notes.cr
+++ b/src/gori/verbs/notes.cr
@@ -51,6 +51,15 @@ module Gori
         "notes.clear", "Clear note", "Clear the current note's text",
         Verb::Scope::Notes, available: in_notes, mnemonic: 'c') { |ctx| ctx.notes_clear; nil }
 
+      # Export the note as Markdown. Mnemonic 'E', not 'e' or 'x': 'e' is Edit-in-$EDITOR
+      # and 'x' is read_edit.cr's Select line, both already in this scope. A capital follows
+      # the precedent 'S' (Send selection to) sets right next to it. No chord either — the
+      # Notes body swallows every printable key, so the space menu and the palette are the
+      # only surfaces this can be reached from.
+      r.register Verb::Definition.new(
+        "notes.export", "Export note…", "Write the current note's text to a Markdown file",
+        Verb::Scope::Notes, available: in_notes, mnemonic: 'E') { |ctx| ctx.notes_export; nil }
+
       r.register Verb::Definition.new(
         "notes.edit", "Edit in $EDITOR", "Open the current note in the external editor",
         Verb::Scope::Notes, available: in_notes, mnemonic: 'e') { |ctx| ctx.notes_edit; nil }


### PR DESCRIPTION
## Why

Two gaps, one shape.

**Notes had no way out to a file.** A note lives only in the `notes.docs` settings blob (no SQL table); the only exits were clipboard copy (`y`) and `$EDITOR` (`e`), so saving a note meant hand-pasting it.

**Issues export had the opposite problem.** `issues_controller.cr` wrote `<project dir>/issues.{md,json}` unconditionally and **clobbered an existing report with no warning** — while `gori run issues --export=PATH` has been able to write anywhere all along.

Both are the same form — collect one destination path, write a file — so they share one overlay.

## What

- **New `src/gori/tui/export_overlay.cr`** — centered path popup with an inline `PathComplete` dropdown. The write rides in as the `on_commit` closure from `Runner#open_export`, so neither controller learns a modal exists, and a failed write returns `false` to keep the card up with the typed path intact rather than making the operator retype it.
- **Notes → `Export note…`** writes the current note as `.md`. Filenames come from a new pure `Notes.export_basename`.
- **Issues → the same popup** from all three entry points (the tab key + both palette entries). Prefill is `<cwd>/issues.{md,json}`.
- **Export is now the same key on both tabs: `⇧E`.**

### Overlay validation

In order: empty field → directory fill-in → missing parent → overwrite arm.

A **directory is a half-finished path, not an error** — it fills in the file name and lets the next `↵` write, Save-As style, so `File.write` can never land on a directory. A missing parent is refused rather than `mkdir_p`'d: silently building a tree from a typo'd path is worse than saying no. Every failure returns `:stay`, so the typed path stays on screen for in-place correction.

The **overwrite arm** (`↵` twice, disarmed by any edit) is why the Issues report can no longer be clobbered by accident. A nested `ConfirmDialog` would have to close the export card first, so cancelling would lose the path — the in-overlay arm costs the same keystroke and keeps it.

### Two decisions worth flagging

**`⇧E` on both tabs, and the Issues list's `x` is retired.** `x` means "Select line" in all nine `read_edit.cr` read-mode scopes — **including the Issues DETAIL one `↵` away**, so the list's `x`=export collided with its own tab. Notes couldn't take `x` for that same reason. Unifying on `E` leaves `x` = Select line exception-free.

The chord is `Chord.new("e", shift: true)`, not `Chord.new("E")`: `Keybind.from_event` normalises a typed capital to `shift` + lowercase (`keybind.cr:35-38`), so an `"E"` chord would silently never fire. `menu_key` skips shift chords (`verb.cr:158`), hence the explicit `mnemonic:` — the pairing `notes.send-to` already uses for `'S'`. Users who rebound `x` are unaffected: `Hotkeys.chord_overrides` keys by verb **id**.

**Unicode is preserved in filenames.** A Korean note title has to stay legible in a file listing, so neither `ProjectRegistry#slugify` (ASCII-only, hashes a non-ASCII name to `project-<sha256>`) nor `Runner`'s `title_safe` (caps at 40 with a `…`) was reusable. Separators are replaced *before* the strip, so `"../../etc/passwd"` can only yield `etc-passwd.md`, and the cap is 48 **characters** (not bytes).

Exported bytes are **verbatim** — no `scrub_controls`. That helper is for TTY-bound text; the same split already exists in `gori run issues` (the `--export` branch writes raw, the STDOUT branch scrubs). A `.md` file is not a terminal, and scrubbing would corrupt captured evidence.

## Not changed

Issues verb ids, scopes, and the `issues_export(format)` signature all stay put — the popup is purely a shell concern. Only the chord moved. That's why four existing Issues specs needed no edits.

## Verification

`crystal build --no-codegen src/main.cr` on the **rebased** tree (CI doesn't build the merge result). `crystal spec`: **4400 examples, 0 failures**. `ameba` clean on every touched file except the pre-existing `Naming/AccessorMethodName` on `set_preedit`, which is the `Overlay` base contract name and is flagged identically on every existing overlay.

Driven live in a tmux pty with an isolated `GORI_HOME`:

| check | result |
|---|---|
| empty note | refused **before** the popup |
| Korean title `인증 우회 / 메모` | → `인증-우회-메모.md`, trailing newline present |
| re-export same path | `⚠ file exists — ↵ again to overwrite`, second `↵` writes |
| edit between the two `↵`s | re-arms instead of writing |
| path is a directory | file name filled in, next `↵` writes |
| parent missing | `⚠ no such directory`, nothing created |
| `/etc/gori-nope.md` | error toast, **card stays up, path preserved**, no file |
| title that sanitizes away (`../..`) | `note-3.md` |
| Issues: `x` | inert — no card, no file |
| Issues: `⇧E` | popup → `exported 1 issue → …` |
| Issues, zero issues | `no issues to export`, no popup |

Also confirmed the TUI and CLI write **byte-identical** files for the same project and format (`--format=markdown` / `--format=json`, diffed). Worth knowing: plain `--export` defaults to `--format=text`, a different report — the code comment says so.

### New specs

- `spec/tui/export_overlay_spec.cr` (18 examples) — prefill, `resolved_path` `~`-expansion, every `validate` branch, the disarm, esc peeling the dropdown, and the keep-open-on-failed-write path via `OverlayHarness`.
- `spec/notes_spec.cr` — `.export_basename`, including an explicit Korean-preservation regression guard.
- `spec/verbs/{notes,issues}_spec.cr` — the shared `'E'`, the shift-form chord, and that nothing in the Issues scope claims `x` any more.
