### PR TITLE
perf(fuzz): reuse one HTTP/1.1 connection across a sweep's requests

### DIFF
--- a/bench/fuzz_keepalive_bench.cr
+++ b/bench/fuzz_keepalive_bench.cr
@@ -1,0 +1,97 @@
+# Fuzz connection-reuse benchmark — the cost a sweep pays for its TRANSPORT, not its CPU.
+#
+# Every other fuzz bench in here measures a per-response code path (render, match, CL sync,
+# frame draw), and those are now down in the tens of microseconds. What a real run actually
+# waits on is the connection: `Repeater::Engine.send` dialed a fresh one, exchanged ONE
+# request and closed it, so an N-request sweep paid N TCP handshakes and, on https, N TLS
+# handshakes — each an RTT (or two or three) before a single payload byte moves, plus the
+# asymmetric crypto on both ends.
+#
+#   OLD: dial → exchange → close, per request.
+#   NEW: Fuzz::ConnPool parks the socket and the next request reuses it, so the run pays
+#        ~concurrency handshakes instead of ~N.
+#
+# This is an END-TO-END measurement over loopback against a real keep-alive origin, so it
+# understates the win: with RTT ≈ 0 the handshake costs only syscalls and (for TLS) CPU,
+# where a remote origin also pays 2-3 round trips per request. Both an http and an https
+# origin are measured because the TLS handshake is where the gap is widest.
+#
+# Build: crystal build bench/fuzz_keepalive_bench.cr -o bin/fuzz_keepalive_bench --release
+# Run:   bin/fuzz_keepalive_bench
+require "benchmark"
+require "socket"
+require "openssl"
+require "http/server"
+
+# `Gori::Error` (src/gori.cr) is what the decoder/codec requires below raise; declare it
+# first, like the other benches, instead of pulling the whole binary in.
+module Gori
+  class Error < Exception; end
+end
+
+require "../src/gori/fuzz"
+require "../src/gori/outbound"
+
+alias F = Gori::Fuzz
+
+REQUESTS    = 2000
+CONCURRENCY =   50
+BODY        = "x" * 1024
+
+# A self-signed cert, generated once into a temp dir — the https origin needs one and a
+# bench must not depend on a fixture file being present.
+private def self_signed : {String, String}
+  dir = File.tempname("gori-bench-tls")
+  Dir.mkdir_p(dir)
+  cert = File.join(dir, "cert.pem")
+  key = File.join(dir, "key.pem")
+  ok = Process.run("openssl", ["req", "-x509", "-newkey", "rsa:2048", "-keyout", key,
+                               "-out", cert, "-days", "1", "-nodes", "-subj", "/CN=localhost"],
+    output: Process::Redirect::Close, error: Process::Redirect::Close).success?
+  abort "openssl is required to generate the bench's TLS cert" unless ok
+  {cert, key}
+end
+
+private def start_origin(tls : Bool) : Int32
+  server = HTTP::Server.new do |ctx|
+    ctx.response.content_type = "text/html"
+    ctx.response.print BODY
+  end
+  port = if tls
+           cert, key = self_signed
+           ctx = OpenSSL::SSL::Context::Server.new
+           ctx.certificate_chain = cert
+           ctx.private_key = key
+           server.bind_tls("127.0.0.1", 0, ctx).port
+         else
+           server.bind_tcp("127.0.0.1", 0).port
+         end
+  spawn { server.listen }
+  port
+end
+
+private def sweep(scheme : String, port : Int32, keep_alive : Bool) : F::ConnPool?
+  tmpl = F::Template.parse("GET /?q=§seed§ HTTP/1.1\r\nHost: 127.0.0.1:#{port}\r\nAccept: */*\r\n\r\n")
+  set = F::PayloadSet.new(F::InlineList.new((1..REQUESTS).map { |i| "word#{i}" }))
+  cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: CONCURRENCY, keep_alive: keep_alive)
+  sender = F::Sender.new(F::Origin.new(scheme, "127.0.0.1", port),
+    Gori::Outbound.waived(nil, Gori::Outbound::Reason::NoProject),
+    http2: false, verify: false, keep_alive: keep_alive, idle_conns: CONCURRENCY)
+  engine = F::Engine.new(F::Generator.new(tmpl, [set], cfg), F::Matcher.new, sender, cfg)
+  engine.run { |_| }
+  sender.pool
+end
+
+{"http", "https"}.each do |scheme|
+  port = start_origin(scheme == "https")
+  sleep 200.milliseconds # let the listener come up
+
+  puts "\n== #{scheme} · #{REQUESTS} requests · concurrency #{CONCURRENCY}"
+  Benchmark.bm do |x|
+    x.report("OLD dial-per-request") { sweep(scheme, port, false) }
+    x.report("NEW keep-alive pool ") { sweep(scheme, port, true) }
+  end
+  if pool = sweep(scheme, port, true)
+    puts "   handshakes: #{pool.dialed} dialed, #{pool.reused} served off a parked socket"
+  end
+end

--- a/docs/content/guide/repeater-and-fuzzer.ko.md
+++ b/docs/content/guide/repeater-and-fuzzer.ko.md
@@ -78,6 +78,14 @@ Fuzzer는 Intruder 스타일 엔진입니다. 요청에서 위치를 표시하�
 
 ffuf 스타일 matcher와 filter로 status, size, words, lines, 본문 정규식에 대해 결과를 필터링합니다. 여기에 시끄러운 기준선을 걸러내는 자동 보정까지 더해집니다. 매칭된 응답은 강조되며 캡처 정규식으로 추출할 수 있습니다.
 
+### 연결 재사용 {#connection-reuse}
+
+스윕은 하나의 HTTP/1.1 연결을 여러 요청에 재사용합니다. 요청마다가 아니라 워커마다 TCP 핸드셰이크를(그리고 `https`라면 TLS 핸드셰이크까지) 한 번만 치릅니다. 원격 오리진을 대상으로 할 때 대개 이것이 실행 시간의 가장 큰 비용입니다.
+
+프레이밍이 명확하다고 증명할 수 없는 요청은 설정과 무관하게 소켓을 공유하지 않습니다. 실제 본문 길이와 어긋나는 `Content-Length`, `CL`+`TE`, 난독화된 프레이밍 헤더, `Connection: close`, `Upgrade`는 각각 자기 연결을 받습니다. 스머글링 페이로드가 다음 페이로드의 결과를 오프레이밍할 수 없다는 뜻입니다. 대상의 동작이 연결 단위일 때(연결 범위 rate limit, 연결로 고정하는 로드 밸런서) 또는 keep-alive 처리 자체를 시험할 때는 `--no-keep-alive`(CLI), `keep_alive: false`(MCP), Fuzzer ADVANCED 오버레이의 **Keep-alive** 토글로 재사용을 끕니다.
+
+`gori run fuzz`는 실제로 치른 비용을 함께 출력합니다: `connections · 50 dialed · 2950 reused`.
+
 ### 헤드리스 실행 {#running-headless}
 
 ```bash

--- a/docs/content/guide/repeater-and-fuzzer.md
+++ b/docs/content/guide/repeater-and-fuzzer.md
@@ -78,6 +78,14 @@ Mark positions with `§…§` markers in the request, or let gori place them aut
 
 Filter results with ffuf-style matchers and filters on status, size, words, lines, and body regex, plus auto-calibration to drop noisy baselines. Matched responses are highlighted and can be extracted with a capture regex.
 
+### Connection Reuse
+
+A sweep reuses one HTTP/1.1 connection across many requests, so a run pays one TCP — and, on `https`, one TLS — handshake per worker instead of one per request. Against a remote origin that is usually the largest single cost of a run.
+
+Requests gori cannot prove unambiguous never share a socket, whatever the setting: a `Content-Length` that does not match the body on the wire, `CL`+`TE`, an obfuscated framing header, `Connection: close`, or `Upgrade` each get their own connection, so a smuggling payload can never misframe the next payload's result. Turn reuse off entirely with `--no-keep-alive` (CLI), `keep_alive: false` (MCP), or the **Keep-alive** toggle in the Fuzzer's ADVANCED overlay when the target's behaviour is per-connection — a connection-scoped rate limit, a load balancer pinning by connection — or when keep-alive handling is itself what you are testing.
+
+`gori run fuzz` reports what the run actually paid: `connections · 50 dialed · 2950 reused`.
+
 ### Running Headless
 
 ```bash

--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -160,7 +160,7 @@ gori run repeater create --flow 42 --name "clone of 42"
 | Mode | `--mode=` `sniper` (기본값), `batteringram`, `pitchfork`, `clusterbomb` |
 | Payloads | `-w`/`--wordlist`, `--payloads=LIST`, `--numbers=FROM-TO[:STEP]`, `--null=N`, `--brute=CHARSET:MIN-MAX` |
 | Processors | `--prefix`, `--suffix`, `--encode` (`url`\|`urlall`\|`base64`\|`hex`), `--case` (`upper`\|`lower`), `--hash` (`md5`\|`sha1`\|`sha256`), `--regex-replace=/pat/rep/` |
-| Rate | `--concurrency` (20), `--rate=RPS`, `--throttle=MS`, `--timeout=SEC`, `--retries=N`, `--follow-redirects` |
+| Rate | `--concurrency` (20), `--rate=RPS`, `--throttle=MS`, `--timeout=SEC`, `--retries=N`, `--follow-redirects`, `--no-keep-alive` |
 | Matchers | `--mc`/`--fc` status, `--ms`/`--fs` size, `--mw`/`--fw` words, `--ml`/`--fl` lines, `--mr`/`--fr` body regex, `--extract=REGEX`, `--ac` auto-calibrate |
 | Output | `--format` (`text`\|`json`\|`jsonl`), `--force`, `--fail-if-no-matches` |
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -160,7 +160,7 @@ Sources: `--flow=ID`, `--request=FILE`, or stdin. Positions: `§…§` markers, 
 | Mode | `--mode=` `sniper` (default), `batteringram`, `pitchfork`, `clusterbomb` |
 | Payloads | `-w`/`--wordlist`, `--payloads=LIST`, `--numbers=FROM-TO[:STEP]`, `--null=N`, `--brute=CHARSET:MIN-MAX` |
 | Processors | `--prefix`, `--suffix`, `--encode` (`url`\|`urlall`\|`base64`\|`hex`), `--case` (`upper`\|`lower`), `--hash` (`md5`\|`sha1`\|`sha256`), `--regex-replace=/pat/rep/` |
-| Rate | `--concurrency` (20), `--rate=RPS`, `--throttle=MS`, `--timeout=SEC`, `--retries=N`, `--follow-redirects` |
+| Rate | `--concurrency` (20), `--rate=RPS`, `--throttle=MS`, `--timeout=SEC`, `--retries=N`, `--follow-redirects`, `--no-keep-alive` |
 | Matchers | `--mc`/`--fc` status, `--ms`/`--fs` size, `--mw`/`--fw` words, `--ml`/`--fl` lines, `--mr`/`--fr` body regex, `--extract=REGEX`, `--ac` auto-calibrate |
 | Output | `--format` (`text`\|`json`\|`jsonl`), `--force`, `--fail-if-no-matches` |
 

--- a/spec/fuzz/conn_pool_spec.cr
+++ b/spec/fuzz/conn_pool_spec.cr
@@ -1,0 +1,257 @@
+require "../spec_helper"
+require "socket"
+
+private alias F = Gori::Fuzz
+
+private def req(raw : String) : Bytes
+  raw.to_slice
+end
+
+private def result_from(head : String, body : String? = nil, error : String? = nil,
+                        incomplete : Bool = false) : Gori::Repeater::Result
+  raw = head.to_slice
+  resp = head.empty? ? nil : Gori::Proxy::Codec::Http1.parse_response_head(raw)
+  Gori::Repeater::Result.new(raw, body.try(&.to_slice), resp, 1_i64, error, incomplete)
+end
+
+# A keep-alive origin that answers every request on the SAME socket and counts how many
+# connections it ever accepted. `close_after` (when set) makes it hang up after serving
+# that many requests on one connection, so a spec can drive the stale-socket path.
+private class KeepAliveOrigin
+  getter port : Int32
+  getter connections : Int32 = 0
+  getter requests : Int32 = 0
+
+  def initialize(@close_after : Int32? = nil, @announce_close : Bool = false)
+    @server = TCPServer.new("127.0.0.1", 0)
+    @port = @server.local_address.port
+    spawn { accept_loop }
+  end
+
+  def close : Nil
+    @server.close
+  end
+
+  private def accept_loop : Nil
+    while conn = @server.accept?
+      @connections += 1
+      spawn { serve(conn) }
+    end
+  rescue
+    # server closed
+  end
+
+  private def serve(conn : TCPSocket) : Nil
+    served = 0
+    loop do
+      head = Gori::Proxy::Codec::Http1.read_head(conn)
+      break unless head
+      req = Gori::Proxy::Codec::Http1.parse_request_head(head)
+      if (cl = req.headers.get?("Content-Length")) && (n = cl.to_i?) && n > 0
+        buf = Bytes.new(n)
+        conn.read_fully?(buf)
+      end
+      @requests += 1
+      served += 1
+      body = "pong"
+      last = @close_after == served
+      conn << "HTTP/1.1 200 OK\r\nContent-Length: #{body.bytesize}"
+      conn << "\r\nConnection: close" if last && @announce_close
+      conn << "\r\n\r\n" << body
+      conn.flush
+      break if last
+    end
+    conn.close rescue nil
+  end
+end
+
+describe F::ConnPool do
+  describe ".reusable_request?" do
+    it "accepts a bodyless HTTP/1.1 request" do
+      F::ConnPool.reusable_request?(req("GET /a HTTP/1.1\r\nHost: h\r\n\r\n")).should be_true
+    end
+
+    it "accepts a POST whose Content-Length matches the body on the wire" do
+      F::ConnPool.reusable_request?(
+        req("POST /a HTTP/1.1\r\nHost: h\r\nContent-Length: 5\r\n\r\nhello")).should be_true
+    end
+
+    it "refuses a Content-Length that under-declares the body (the smuggling shape)" do
+      # The origin stops reading after 3 bytes; "lo" would start the NEXT request on a
+      # shared socket and misframe whatever payload follows.
+      F::ConnPool.reusable_request?(
+        req("POST /a HTTP/1.1\r\nHost: h\r\nContent-Length: 3\r\n\r\nhello")).should be_false
+    end
+
+    it "refuses a Content-Length that over-declares the body" do
+      F::ConnPool.reusable_request?(
+        req("POST /a HTTP/1.1\r\nHost: h\r\nContent-Length: 99\r\n\r\nhello")).should be_false
+    end
+
+    it "refuses CL+TE" do
+      F::ConnPool.reusable_request?(
+        req("POST /a HTTP/1.1\r\nHost: h\r\nContent-Length: 5\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n")).should be_false
+    end
+
+    it "refuses an obfuscated framing header" do
+      F::ConnPool.reusable_request?(
+        req("POST /a HTTP/1.1\r\nHost: h\r\nContent-Length : 5\r\n\r\nhello")).should be_false
+    end
+
+    it "refuses Connection: close, including inside a token list" do
+      F::ConnPool.reusable_request?(
+        req("GET /a HTTP/1.1\r\nHost: h\r\nConnection: close\r\n\r\n")).should be_false
+      F::ConnPool.reusable_request?(
+        req("GET /a HTTP/1.1\r\nHost: h\r\nConnection: keep-alive, close\r\n\r\n")).should be_false
+    end
+
+    it "refuses HTTP/1.0, CONNECT and Upgrade" do
+      F::ConnPool.reusable_request?(req("GET /a HTTP/1.0\r\nHost: h\r\n\r\n")).should be_false
+      F::ConnPool.reusable_request?(req("CONNECT h:443 HTTP/1.1\r\nHost: h\r\n\r\n")).should be_false
+      F::ConnPool.reusable_request?(
+        req("GET /a HTTP/1.1\r\nHost: h\r\nUpgrade: websocket\r\n\r\n")).should be_false
+    end
+
+    it "accepts a chunked body only when it terminates" do
+      F::ConnPool.reusable_request?(
+        req("POST /a HTTP/1.1\r\nHost: h\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n")).should be_true
+      F::ConnPool.reusable_request?(
+        req("POST /a HTTP/1.1\r\nHost: h\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n")).should be_false
+    end
+
+    it "refuses bytes with no complete head" do
+      F::ConnPool.reusable_request?(req("GET /a HTTP/1.1\r\nHost: h\r\n")).should be_false
+    end
+  end
+
+  describe ".reusable_response?" do
+    it "accepts a Content-Length-framed HTTP/1.1 response" do
+      F::ConnPool.reusable_response?(result_from("HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\n", "pong")).should be_true
+    end
+
+    it "accepts a chunked response" do
+      F::ConnPool.reusable_response?(
+        result_from("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n", "pong")).should be_true
+    end
+
+    it "refuses a close-delimited response (the body ended WITH the socket)" do
+      F::ConnPool.reusable_response?(result_from("HTTP/1.1 200 OK\r\n\r\n", "pong")).should be_false
+    end
+
+    it "refuses Connection: close, an error, an incomplete read, and a 101" do
+      F::ConnPool.reusable_response?(
+        result_from("HTTP/1.1 200 OK\r\nContent-Length: 4\r\nConnection: close\r\n\r\n", "pong")).should be_false
+      F::ConnPool.reusable_response?(result_from("", error: "boom")).should be_false
+      F::ConnPool.reusable_response?(
+        result_from("HTTP/1.1 200 OK\r\nContent-Length: 9\r\n\r\n", "pong", incomplete: true)).should be_false
+      F::ConnPool.reusable_response?(
+        result_from("HTTP/1.1 101 Switching Protocols\r\nContent-Length: 0\r\n\r\n")).should be_false
+    end
+
+    it "accepts HTTP/1.0 only with an explicit keep-alive" do
+      F::ConnPool.reusable_response?(
+        result_from("HTTP/1.0 200 OK\r\nContent-Length: 4\r\n\r\n", "pong")).should be_false
+      F::ConnPool.reusable_response?(
+        result_from("HTTP/1.0 200 OK\r\nContent-Length: 4\r\nConnection: keep-alive\r\n\r\n", "pong")).should be_true
+    end
+  end
+
+  describe "over a real socket" do
+    it "serves a whole sweep on one connection per worker" do
+      origin = KeepAliveOrigin.new
+      tmpl = F::Template.parse("GET /?q=§a§ HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+      set = F::PayloadSet.new(F::InlineList.new((1..20).map(&.to_s)))
+      cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: 1)
+      sender = F::Sender.new(F::Origin.new("http", "127.0.0.1", origin.port), ungated_outbound,
+        http2: false, verify: false, keep_alive: true, idle_conns: 1)
+      engine = F::Engine.new(F::Generator.new(tmpl, [set], cfg), F::Matcher.new, sender, cfg)
+      results = [] of F::Result
+      engine.run { |ev| results << ev.result if ev.is_a?(F::ResultEvent) }
+
+      results.size.should eq(20)
+      results.all? { |r| r.status == 200 }.should be_true
+      pool = sender.pool.should_not be_nil
+      pool.dialed.should eq(1)
+      pool.reused.should eq(19)
+      origin.connections.should eq(1)
+      origin.close
+    end
+
+    it "dials per request when keep_alive is off" do
+      origin = KeepAliveOrigin.new
+      tmpl = F::Template.parse("GET /?q=§a§ HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+      set = F::PayloadSet.new(F::InlineList.new((1..8).map(&.to_s)))
+      cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: 1, keep_alive: false)
+      sender = F::Sender.new(F::Origin.new("http", "127.0.0.1", origin.port), ungated_outbound,
+        http2: false, verify: false, keep_alive: cfg.keep_alive?, idle_conns: 1)
+      engine = F::Engine.new(F::Generator.new(tmpl, [set], cfg), F::Matcher.new, sender, cfg)
+      results = [] of F::Result
+      engine.run { |ev| results << ev.result if ev.is_a?(F::ResultEvent) }
+
+      results.size.should eq(8)
+      sender.pool.should be_nil
+      origin.connections.should eq(8)
+      origin.close
+    end
+
+    it "re-sends on a fresh connection when the origin had closed the parked one" do
+      # The origin serves one request per connection and hangs up WITHOUT saying so, so
+      # every checkout after the first finds a dead socket — the classic idle-timeout
+      # race. No result may be lost to it.
+      origin = KeepAliveOrigin.new(close_after: 1)
+      tmpl = F::Template.parse("GET /?q=§a§ HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+      set = F::PayloadSet.new(F::InlineList.new((1..6).map(&.to_s)))
+      cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: 1)
+      sender = F::Sender.new(F::Origin.new("http", "127.0.0.1", origin.port), ungated_outbound,
+        http2: false, verify: false, keep_alive: true, idle_conns: 1)
+      engine = F::Engine.new(F::Generator.new(tmpl, [set], cfg), F::Matcher.new, sender, cfg)
+      results = [] of F::Result
+      engine.run { |ev| results << ev.result if ev.is_a?(F::ResultEvent) }
+
+      results.size.should eq(6)
+      results.all? { |r| r.status == 200 && r.error.nil? }.should be_true
+      pool = sender.pool.should_not be_nil
+      pool.stale_retries.should be > 0
+      # …and it stops paying for the wasted redial rather than doing it 6 times.
+      pool.pooling?.should be_false
+      origin.close
+    end
+
+    it "does not park a connection the origin said it would close" do
+      origin = KeepAliveOrigin.new(close_after: 1, announce_close: true)
+      tmpl = F::Template.parse("GET /?q=§a§ HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+      set = F::PayloadSet.new(F::InlineList.new((1..5).map(&.to_s)))
+      cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: 1)
+      sender = F::Sender.new(F::Origin.new("http", "127.0.0.1", origin.port), ungated_outbound,
+        http2: false, verify: false, keep_alive: true, idle_conns: 1)
+      engine = F::Engine.new(F::Generator.new(tmpl, [set], cfg), F::Matcher.new, sender, cfg)
+      results = [] of F::Result
+      engine.run { |ev| results << ev.result if ev.is_a?(F::ResultEvent) }
+
+      results.size.should eq(5)
+      results.all? { |r| r.status == 200 && r.error.nil? }.should be_true
+      pool = sender.pool.should_not be_nil
+      pool.dialed.should eq(5)
+      pool.reused.should eq(0)
+      # `Connection: close` is a clean signal, not a stale surprise — no wasted re-sends.
+      pool.stale_retries.should eq(0)
+      origin.close
+    end
+
+    it "keeps a mis-framed request off the shared socket" do
+      # The Content-Length under-declares the body. Reusing here would leave "X" in the
+      # origin's read buffer as the start of the next request.
+      origin = KeepAliveOrigin.new
+      pool = F::ConnPool.new(F::Origin.new("http", "127.0.0.1", origin.port),
+        false, nil, nil, nil, 4)
+      2.times do
+        pool.send(req("POST /a HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 1\r\n\r\naX"))
+          .response.try(&.status).should eq(200)
+      end
+      pool.dialed.should eq(2)
+      pool.reused.should eq(0)
+      pool.close_all
+      origin.close
+    end
+  end
+end

--- a/spec/tui/fuzz_advanced_overlay_spec.cr
+++ b/spec/tui/fuzz_advanced_overlay_spec.cr
@@ -11,7 +11,7 @@ end
 private def blank_snapshot : Gori::Tui::AdvancedSnapshot
   Gori::Tui::AdvancedSnapshot.new(
     conc: "20", rate: "", timeout: "", retries: "0",
-    follow: false, calibrate: false,
+    follow: false, calibrate: false, keep_alive: true,
     m_status: "", m_size: "", m_words: "", m_regex: "",
     f_status: "", f_size: "", f_words: "", f_regex: "")
 end
@@ -130,6 +130,16 @@ describe Gori::Tui::FuzzAdvancedOverlay do
     h.rendered?("advanced editor").should be_true
   end
 
+  it "toggles keep-alive, which starts on" do
+    ov = FuzzAdvancedOverlay.new(blank_snapshot)
+    ov.snapshot.keep_alive.should be_true
+    6.times { ov.handle_key(akey(Termisu::Input::Key::Down)) } # → Keep-alive (row 6)
+    ov.handle_key(akey(Termisu::Input::Key::Space))
+    ov.snapshot.keep_alive.should be_false
+    ov.snapshot.calibrate.should be_false # the neighbouring toggle is untouched
+    ov.snapshot.follow.should be_false
+  end
+
   it "offsets a click by the scroll position once the list has scrolled" do
     # Production hands an overlay `layout.body` — 6 rows shorter and offset from the screen —
     # so this 18-row card renders clipped to 14 and the row list must scroll to reach the
@@ -145,11 +155,13 @@ describe Gori::Tui::FuzzAdvancedOverlay do
     h.rendered?("Filter regex").should be_true # this render is what advances @scroll
     h.type("x")
 
-    # The first VISIBLE row is now ROWS[3] (Retries), not ROWS[0] (Concurrency).
-    h.click_in_box(2, 1).should eq(:open)
+    # The list has scrolled, so the first VISIBLE row is no longer ROWS[0] (Concurrency):
+    # the 4th visible row is "Match status", which is where this click must land.
+    h.click_in_box(2, 4).should eq(:open)
     h.type("9")
-    ov.snapshot.retries.should eq("09") # lands in Concurrency if the click ignores @scroll
-    ov.snapshot.conc.should eq("20")    # …and Concurrency stays untouched
+    ov.snapshot.m_status.should eq("9") # lands in Retries if the click ignores @scroll
+    ov.snapshot.retries.should eq("0")  # …and the un-scrolled rows stay untouched
+    ov.snapshot.conc.should eq("20")
     ov.snapshot.f_regex.should eq("x")
 
     h.press(Termisu::Input::Key::Escape).should eq(:closed)

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -179,13 +179,14 @@ describe Gori::Tui::FuzzerView do
       snap = view.advanced_snapshot
       edited = Gori::Tui::AdvancedSnapshot.new(
         conc: "50", rate: snap.rate, timeout: snap.timeout, retries: snap.retries,
-        follow: true, calibrate: snap.calibrate,
+        follow: true, calibrate: snap.calibrate, keep_alive: false,
         m_status: "200,500", m_size: snap.m_size, m_words: snap.m_words, m_regex: snap.m_regex,
         f_status: snap.f_status, f_size: snap.f_size, f_words: snap.f_words, f_regex: snap.f_regex)
       view.apply_advanced(edited)
       back = view.advanced_snapshot
       back.conc.should eq("50")
       back.follow.should be_true
+      back.keep_alive.should be_false # on by default; the edit must survive the round-trip
       back.m_status.should eq("200,500")
     end
 
@@ -194,7 +195,7 @@ describe Gori::Tui::FuzzerView do
       snap = src.advanced_snapshot
       src.apply_advanced(Gori::Tui::AdvancedSnapshot.new(
         conc: snap.conc, rate: snap.rate, timeout: snap.timeout, retries: snap.retries,
-        follow: snap.follow, calibrate: snap.calibrate,
+        follow: snap.follow, calibrate: snap.calibrate, keep_alive: snap.keep_alive,
         m_status: snap.m_status, m_size: snap.m_size, m_words: "42", m_regex: snap.m_regex,
         f_status: snap.f_status, f_size: snap.f_size, f_words: "7", f_regex: snap.f_regex))
       dst = FuzzerView.new

--- a/src/gori/cli/run/fuzz.cr
+++ b/src/gori/cli/run/fuzz.cr
@@ -26,6 +26,7 @@ module Gori
         timeout : Time::Span? = nil
         retries = 0
         follow = false
+        keep_alive = true
         auto_cal = false
         format = :text
         force = false
@@ -64,6 +65,7 @@ module Gori
           p.on("--timeout=SEC", "Per-request connect + idle timeout (seconds)") { |v| timeout = parse_count(v, "--timeout").seconds }
           p.on("--retries=N", "Retries on a network error") { |v| retries = parse_nonneg(v, "--retries") }
           p.on("--follow-redirects", "Follow same-origin redirects") { follow = true }
+          p.on("--no-keep-alive", "Dial a fresh connection for every request (default: reuse)") { keep_alive = false }
           p.on("--mc=SPEC", "Match status (e.g. 200,302,500-599,2xx)") { |v| matcher.match_status = v }
           p.on("--fc=SPEC", "Filter out status") { |v| matcher.filter_status = v }
           p.on("--ms=SPEC", "Match response size (e.g. 1500,>1000)") { |v| matcher.match_size = v }
@@ -99,7 +101,8 @@ module Gori
           auto_mark: auto, marks: marks, http2: http2,
           sources: sources, processors: processors,
           config: Fuzz::Config.new(mode: mode, concurrency: concurrency, rps: rate, throttle_ms: throttle,
-            retries: retries, timeout: timeout, follow_redirects: follow, auto_calibrate: auto_cal, keep_bodies: :none),
+            retries: retries, timeout: timeout, follow_redirects: follow, auto_calibrate: auto_cal,
+            keep_bodies: :none, keep_alive: keep_alive),
           matcher: matcher, verify: !insecure, sni: sni,
           overrides: cli_host_overrides(project_name, db_path, flow_id))
         # Gate outbound traffic through the ONE seam every surface shares (Gori::Outbound):
@@ -125,7 +128,7 @@ module Gori
         # connection — a raise in there would otherwise leak it.
         begin
           plan.engine.calibrate_baseline if auto_cal
-          run_fuzz_stream(plan.engine, mode, origin.scheme, origin.host, origin.port, format, force, fail_if_no_matches)
+          run_fuzz_stream(plan.engine, mode, origin.scheme, origin.host, origin.port, format, force, fail_if_no_matches, plan.pool)
         ensure
           outbound.close
         end
@@ -181,7 +184,7 @@ module Gori
 
       private def self.run_fuzz_stream(engine : Fuzz::Engine, mode : Fuzz::Mode, scheme : String,
                                        host : String, port : Int32, format : Symbol, force : Bool,
-                                       fail_if_no_matches : Bool) : Nil
+                                       fail_if_no_matches : Bool, pool : Fuzz::ConnPool? = nil) : Nil
         total = fuzz_preflight(engine, mode, scheme, host, port, force)
         matched = 0
         errored = 0
@@ -195,7 +198,7 @@ module Gori
             if emit_fuzz_result(r, format, buffer)
               r.matched? ? (matched += 1) : (errored += 1)
             end
-          when Fuzz::DoneEvent  then fuzz_done(ev, matched + errored)
+          when Fuzz::DoneEvent  then fuzz_done(ev, matched + errored, pool)
           when Fuzz::ErrorEvent then had_error = true; STDERR.puts "fuzz error: #{ev.message}"
           end
         end
@@ -230,9 +233,16 @@ module Gori
         STDERR.flush
       end
 
-      private def self.fuzz_done(ev : Fuzz::DoneEvent, emitted : Int32) : Nil
+      private def self.fuzz_done(ev : Fuzz::DoneEvent, emitted : Int32, pool : Fuzz::ConnPool?) : Nil
         STDERR.print "\r" if STDERR.tty? # clear the in-place meter (none was drawn when piped)
         STDERR.puts "done · #{ev.progress.sent} sent · #{emitted} shown · #{ev.progress.errors} errors#{ev.stopped ? " (stopped)" : ""}"
+        # Handshakes actually paid for. Worth a line: it is how an operator sees whether the
+        # origin honoured keep-alive at all (dialed ≈ sent means it closed after every
+        # response, or the requests were too odd to share a socket — see ConnPool).
+        return unless pool && pool.dialed > 0
+        STDERR.puts "connections · #{pool.dialed} dialed · #{pool.reused} reused" \
+                    "#{pool.stale_retries > 0 ? " · #{pool.stale_retries} re-sent on a closed connection" : ""}" \
+                    "#{pool.pooling? ? "" : " · keep-alive gave up (origin closes every connection)"}"
       end
 
       # Prints/buffers a result; returns true when it was emitted. Errored sends are shown too

--- a/src/gori/fuzz/conn_pool.cr
+++ b/src/gori/fuzz/conn_pool.cr
@@ -1,0 +1,243 @@
+require "../proxy/codec/body"
+require "../proxy/codec/http1"
+require "../repeater/engine"
+
+module Gori::Fuzz
+  # HTTP/1.1 keep-alive connection pool for a sweep's sends.
+  #
+  # `Repeater::Engine.send` dials a fresh connection, exchanges one request, and closes —
+  # correct for the Repeater (one operator-triggered send) but the dominant cost of a
+  # SWEEP, which sends the same shape thousands of times to one origin. Per request that
+  # is a TCP handshake (1 RTT) plus, on https, a TLS handshake (1-2 more RTTs and the
+  # asymmetric crypto that goes with it) before a single payload byte moves. Reusing the
+  # socket amortises all of it: at concurrency C a run costs ~C handshakes instead of N.
+  #
+  # gori is a security tool pointed at deliberately odd requests, so reuse is OPT-IN per
+  # message, not a blanket keep-alive loop. A connection is parked for reuse only when BOTH
+  # ends of the exchange are unambiguously framed:
+  #
+  #   request  — HTTP/1.1, no `Connection: close`/`Upgrade`, framing that `request_framing`
+  #              accepts (so no CL+TE, no obfuscated header), and a body whose LENGTH ON THE
+  #              WIRE matches what the head declares. That last check is what keeps a
+  #              smuggling payload (a deliberately short/long Content-Length) off a shared
+  #              socket: its leftover bytes would be read by the origin as the START of the
+  #              next request, and the next payload's result would be somebody else's
+  #              response. Those requests get a fresh connection each, exactly as today.
+  #   response — no error, not incomplete, HTTP/1.1 (or 1.0 with an explicit keep-alive),
+  #              no `Connection: close`, not a 101, and framed by Content-Length or chunked
+  #              rather than close-delimited (a close-delimited body ends WITH the socket).
+  #
+  # Concurrency: the scheduler is single-threaded (no `-Dpreview_mt`), and neither the idle
+  # array's `pop`/`push` nor the counter bumps yield, so a worker fiber can never observe a
+  # half-updated pool. The array is a LIFO free list — the most recently used socket is the
+  # least likely to have hit the origin's idle timeout.
+  class ConnPool
+    # A parked socket the origin closed while it sat idle is normal (every server has a
+    # keep-alive idle timeout) and must not surface as a failed result: the request never
+    # reached the application, so it is re-sent once on a fresh connection. Detected as a
+    # clean EOF before ANY response byte — a timeout, or a failure part-way through a
+    # response, is NOT retried, because the origin may well have processed the request.
+    #
+    # An origin that refuses reuse outright would otherwise pay that redial on every single
+    # send (two connections per request — worse than not pooling). After this many
+    # consecutive stale checkouts the pool gives up and runs in dial-per-send mode for the
+    # rest of the run.
+    #
+    # On `max_requests`: a stale re-send is NOT charged a second time against the cap
+    # (CappedBackend counts calls into the Sender, and this retry happens below it). That
+    # keeps the cap meaning what it says — an upper bound on requests the ORIGIN PROCESSES —
+    # since the re-sent one is precisely the one it demonstrably did not. The observable
+    # slack is TCP connections, not requests, and STALE_GIVE_UP bounds it to a handful.
+    STALE_GIVE_UP = 3
+
+    # Connections dialed (== handshakes paid) and requests served off a parked socket.
+    # `dialed + reused == sends` for a run that never hit a stale retry.
+    getter dialed : Int64 = 0_i64
+    getter reused : Int64 = 0_i64
+    # Re-sends caused by a parked socket the origin had already closed (see STALE_GIVE_UP).
+    getter stale_retries : Int64 = 0_i64
+    getter? pooling : Bool = true
+
+    def initialize(@origin : Origin, @verify : Bool, @sni : String?, @timeout : Time::Span?,
+                   @overrides : Gori::HostOverrides?, @max_idle : Int32)
+      @idle = [] of IO
+      @consecutive_stale = 0
+    end
+
+    # Send one request, over a parked connection when both this request and the pool's
+    # state allow it. Never raises: every failure comes back as an error `Result`, exactly
+    # as `Repeater::Engine.send` does.
+    def send(bytes : Bytes) : Repeater::Result
+      keepable = @pooling && ConnPool.reusable_request?(bytes)
+      if keepable && (io = @idle.pop?)
+        started = Time.instant
+        result = Repeater::Engine.exchange(io, bytes, @origin.host, @origin.port, started)
+        if stale?(result)
+          close(io)
+          @stale_retries += 1
+          @consecutive_stale += 1
+          # Give up on pooling for the rest of the run rather than pay a wasted redial on
+          # every send. Already-parked sockets are dropped: they are the same vintage.
+          if @consecutive_stale >= STALE_GIVE_UP
+            @pooling = false
+            drain
+          end
+          return dial_and_send(bytes, keepable)
+        end
+        @consecutive_stale = 0
+        @reused += 1
+        recycle(io, result, keepable)
+        return result
+      end
+      dial_and_send(bytes, keepable)
+    end
+
+    # Close every parked socket. Idempotent; call when a run ends so a stopped sweep does
+    # not leave file descriptors open until GC.
+    def close_all : Nil
+      drain
+    end
+
+    private def dial_and_send(bytes : Bytes, keepable : Bool) : Repeater::Result
+      # Timed from BEFORE the dial, like `Repeater::Engine.send` — a fresh connection's
+      # handshake is part of what that request cost. A reused one honestly reports less.
+      started = Time.instant
+      io = Repeater::Engine.dial(@origin.scheme, @origin.host, @origin.port, @verify,
+        @sni, @timeout, @overrides)
+      unless io
+        return Repeater::Engine.error(
+          Repeater::Engine.connect_error(@origin.scheme, @origin.host, @origin.port, @verify), started)
+      end
+      @dialed += 1
+      result = Repeater::Engine.exchange(io, bytes, @origin.host, @origin.port, started)
+      recycle(io, result, keepable)
+      result
+    end
+
+    # Park the socket for the next send, or close it. Same retirement rule `send_pipeline`
+    # applies to a group's connection (error or incomplete ⇒ unusable), plus the response's
+    # own keep-alive signals.
+    private def recycle(io : IO, result : Repeater::Result, keepable : Bool) : Nil
+      if @pooling && keepable && @idle.size < @max_idle && ConnPool.reusable_response?(result)
+        @idle.push(io)
+      else
+        close(io)
+      end
+    end
+
+    private def stale?(result : Repeater::Result) : Bool
+      result.error == Repeater::Engine.no_response_error(@origin.host, @origin.port)
+    end
+
+    private def drain : Nil
+      while io = @idle.pop?
+        close(io)
+      end
+    end
+
+    private def close(io : IO) : Nil
+      io.close rescue nil
+    end
+
+    # ── reuse predicates (pure; specs drive them directly) ─────────────────────────
+
+    # Whether this exact request may share a connection with the sweep's other requests.
+    # Conservative by construction: anything this cannot prove is unambiguous gets its own
+    # connection, which is just today's behaviour.
+    def self.reusable_request?(bytes : Bytes) : Bool
+      head_len = head_length(bytes)
+      return false unless head_len
+      req = Proxy::Codec::Http1.parse_request_head(bytes[0, head_len])
+      return false if req.malformed?
+      return false unless req.version == "HTTP/1.1"
+      # CONNECT turns the connection into a tunnel; Upgrade hands it to another protocol.
+      return false if req.method.compare("CONNECT", case_insensitive: true) == 0
+      return false if req.headers.has?("Upgrade")
+      return false if connection_close?(req.headers)
+      # Raises on CL+TE, an obfuscated framing header, or a non-chunked TE — all of them
+      # requests whose body length a lenient origin would read differently than gori does.
+      framing, len = Proxy::Codec::Body.request_framing(req)
+      body = bytes.size - head_len
+      case framing
+      in Proxy::Codec::BodyFraming::None
+        body == 0
+      in Proxy::Codec::BodyFraming::Length
+        # The one check that keeps a request-smuggling payload off a shared socket: a
+        # Content-Length that under- or over-declares the body leaves the origin's parser
+        # mid-message, so whatever runs next on this connection is misframed.
+        body.to_i64 == len
+      in Proxy::Codec::BodyFraming::Chunked
+        # A chunked body is reusable only if it actually terminates here. Cheap exact test:
+        # the wire form must end with the zero-chunk + (empty) trailer section.
+        ends_with?(bytes, "0\r\n\r\n".to_slice)
+      in Proxy::Codec::BodyFraming::CloseDelimited
+        false # responses only, but the enum is exhaustive
+      end
+    rescue
+      false # Gori::Error from request_framing, or anything else — do not reuse
+    end
+
+    # Whether the origin left the connection usable for another request.
+    def self.reusable_response?(result : Repeater::Result) : Bool
+      return false unless result.error.nil?
+      return false if result.incomplete?
+      resp = result.response
+      return false unless resp
+      return false if resp.malformed?
+      return false if resp.status == 101 # Switching Protocols — the socket is no longer HTTP/1
+      return false if connection_close?(resp.headers)
+      case resp.version
+      when "HTTP/1.1" then true
+      when "HTTP/1.0" then connection_keep_alive?(resp.headers)
+      else                 false
+      end &&
+        # A close-delimited body ended WITH the connection: there is nothing to park.
+        # `response_framing` re-derives what `exchange` already framed by, so this cannot
+        # disagree with how many bytes were actually consumed off the socket.
+        !close_delimited?(resp)
+    end
+
+    private def self.close_delimited?(resp : Proxy::Codec::RawResponse) : Bool
+      framing, _ = Proxy::Codec::Body.response_framing(resp, "GET")
+      framing.close_delimited?
+    rescue
+      true # unframeable ⇒ treat as unusable
+    end
+
+    # `Connection: close` — matched per token, so `Connection: keep-alive, close` counts.
+    private def self.connection_close?(headers : Proxy::Codec::HeaderList) : Bool
+      connection_token?(headers, "close")
+    end
+
+    private def self.connection_keep_alive?(headers : Proxy::Codec::HeaderList) : Bool
+      connection_token?(headers, "keep-alive")
+    end
+
+    private def self.connection_token?(headers : Proxy::Codec::HeaderList, token : String) : Bool
+      return false unless headers.has?("Connection")
+      headers.get_all("Connection").any? do |v|
+        v.split(',').any? { |t| t.strip.compare(token, case_insensitive: true) == 0 }
+      end
+    end
+
+    # Byte offset just past the head's terminating CRLFCRLF, or nil when the bytes carry no
+    # complete head (which no rendered template should, but a hand-written one can).
+    private def self.head_length(bytes : Bytes) : Int32?
+      i = 0
+      last = bytes.size - 4
+      while i <= last
+        if bytes[i] == 0x0d_u8 && bytes[i + 1] == 0x0a_u8 &&
+           bytes[i + 2] == 0x0d_u8 && bytes[i + 3] == 0x0a_u8
+          return i + 4
+        end
+        i += 1
+      end
+      nil
+    end
+
+    private def self.ends_with?(bytes : Bytes, suffix : Bytes) : Bool
+      return false if bytes.size < suffix.size
+      bytes[(bytes.size - suffix.size), suffix.size] == suffix
+    end
+  end
+end

--- a/src/gori/fuzz/engine.cr
+++ b/src/gori/fuzz/engine.cr
@@ -4,6 +4,7 @@ require "../repeater/h2_engine"
 require "../proxy/codec/http1"
 require "../outbound"
 require "../scope"
+require "./conn_pool"
 
 module Gori::Fuzz
   # The origin a run targets (also the boundary for redirect following).
@@ -36,6 +37,12 @@ module Gori::Fuzz
   abstract class Backend
     abstract def send(bytes : Bytes) : Repeater::Result
     abstract def origin : Origin
+
+    # Release any transport a backend is holding open (the keep-alive pool's parked
+    # sockets). Called once when a run ends. A no-op by default so the spec doubles and
+    # the connection-per-send backends stay three-line classes.
+    def close : Nil
+    end
   end
 
   # Production backend over the Repeater engines (fresh connection per send — there is
@@ -51,10 +58,23 @@ module Gori::Fuzz
     getter origin : Origin
     # Sends refused by the scope gate — never put on the wire.
     getter blocked : Int64 = 0_i64
+    # The HTTP/1.1 keep-alive pool, or nil for connection-per-send (h2, or keep_alive off).
+    # Exposed so a surface can report how many handshakes a run actually paid for.
+    getter pool : ConnPool?
 
+    # `keep_alive` reuses one connection across many sends (see ConnPool) — the sweep
+    # senders (Fuzzer) opt in; the one-shot senders (Repeater minimize, Probe active) have
+    # nothing to amortise and leave it off. `idle_conns` bounds the parked sockets and
+    # should be the run's concurrency: one per worker fiber is the most that can ever be
+    # checked out at once, so a larger pool would only hold dead sockets open.
     def initialize(@origin : Origin, @outbound : Gori::Outbound, @http2 : Bool, @verify : Bool,
                    @sni : String? = nil, @timeout : Time::Span? = nil,
-                   @overrides : Gori::HostOverrides? = nil)
+                   @overrides : Gori::HostOverrides? = nil,
+                   keep_alive : Bool = false, idle_conns : Int32 = 0)
+      # h2 is excluded: H2Engine frames its own connection per send, and multiplexing it is
+      # a separate change with its own stream-state rules.
+      @pool = (keep_alive && !@http2) ? ConnPool.new(@origin, @verify, @sni, @timeout,
+        @overrides, Math.max(idle_conns, 1)) : nil
     end
 
     def send(bytes : Bytes) : Repeater::Result
@@ -69,10 +89,16 @@ module Gori::Fuzz
       if @http2
         Repeater::H2Engine.send(bytes, scheme: @origin.scheme, host: @origin.host,
           port: @origin.port, verify_upstream: @verify, sni: @sni, timeout: @timeout, overrides: @overrides)
+      elsif p = @pool
+        p.send(bytes)
       else
         Repeater::Engine.send(bytes, scheme: @origin.scheme, host: @origin.host,
           port: @origin.port, verify_upstream: @verify, sni: @sni, timeout: @timeout, overrides: @overrides)
       end
+    end
+
+    def close : Nil
+      @pool.try(&.close_all)
     end
   end
 
@@ -103,6 +129,10 @@ module Gori::Fuzz
       @sent += 1
       @inner.send(bytes)
     end
+
+    def close : Nil
+      @inner.close
+    end
   end
 
   # Applies the `Gori::Outbound` gate to a backend the caller INJECTED (Probe Active lets
@@ -126,6 +156,10 @@ module Gori::Fuzz
         return Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, err)
       end
       @inner.send(bytes)
+    end
+
+    def close : Nil
+      @inner.close
     end
   end
 
@@ -316,6 +350,10 @@ module Gori::Fuzz
 
     private def coordinate : Nil
       @concurrency.times { @finished.receive }
+      # Every worker has left run_one, so no fiber can be holding a checked-out socket:
+      # release the keep-alive pool's parked ones instead of waiting for GC to finalize
+      # them (a stopped 50-worker run would otherwise sit on 50 fds).
+      @backend.close
       @events.send(DoneEvent.new(snapshot, @state == State::Stopped))
       @events.close
     end

--- a/src/gori/fuzz/plan.cr
+++ b/src/gori/fuzz/plan.cr
@@ -120,6 +120,10 @@ module Gori::Fuzz
     getter origin : Origin
     getter template : Template
     getter? http2 : Bool
+    # The run's keep-alive pool, or nil when it runs connection-per-send (h2, or
+    # `keep_alive` off). Surfaces read its counters to report how many handshakes the run
+    # actually paid for — the one directly observable measure of what pooling bought.
+    getter pool : ConnPool?
     # The request-target of the template's first line, taken BEFORE marking so the §…§
     # bytes never leak into the string the scope gate matches on.
     getter request_target : String
@@ -130,7 +134,7 @@ module Gori::Fuzz
     def initialize(@engine : Engine, @generator : Generator, @matcher : Matcher,
                    @config : Config, @origin : Origin, @template : Template,
                    @http2 : Bool, @request_target : String,
-                   @mark_matches : Array({String, Int32}))
+                   @mark_matches : Array({String, Int32}), @pool : ConnPool? = nil)
     end
 
     # Candidate request count, or nil when unknown / Int64-overflowing. Reads the payload
@@ -177,11 +181,16 @@ module Gori::Fuzz
       # The shared decoder registry applies each position's inline `¦chain` at render time.
       # Wired here so a new surface cannot forget it and silently send un-transformed payloads.
       generator = Generator.new(template, gen_sets, config, registry: Decoder.shared_registry)
+      # One parked connection per worker fiber is the ceiling that can ever be checked out
+      # at once, so the pool is sized to the (clamped) concurrency the engine will run at.
       sender = Sender.new(origin, outbound, http2: options.http2?, verify: options.verify?,
-        sni: options.sni, timeout: config.timeout, overrides: options.overrides)
+        sni: options.sni, timeout: config.timeout, overrides: options.overrides,
+        keep_alive: config.keep_alive?,
+        idle_conns: config.concurrency.clamp(1, Engine::MAX_CONCURRENCY))
       new(engine: Engine.new(generator, matcher, sender, config), generator: generator,
         matcher: matcher, config: config, origin: origin, template: template,
-        http2: options.http2?, request_target: request_target, mark_matches: mark_matches)
+        http2: options.http2?, request_target: request_target, mark_matches: mark_matches,
+        pool: sender.pool)
     end
 
     # The explicit target when it has one, else the seeding flow's. Blank counts as absent

--- a/src/gori/fuzz/types.cr
+++ b/src/gori/fuzz/types.cr
@@ -116,6 +116,16 @@ module Gori
       property? auto_calibrate : Bool # drop responses identical to the baseline
       property keep_bodies : Symbol   # :none | :matched | :all
       property max_requests : Int64?  # hard cap on total sends
+      # Reuse one HTTP/1.1 connection across many sends instead of dialing per request
+      # (see Fuzz::ConnPool). On by default: a sweep pays one TCP — and, on https, one TLS
+      # — handshake per WORKER rather than per request, which is the single largest cost of
+      # a run against a remote origin. Turn it off to make every request a fresh connection:
+      # per-connection origin state (a connection-scoped rate limit, a load balancer pinning
+      # by connection, a target you are probing for keep-alive behaviour itself) is then
+      # observable per payload again. Requests the pool cannot prove unambiguous — a
+      # mis-declared Content-Length, `Connection: close`, CL+TE — get their own connection
+      # regardless of this flag.
+      property? keep_alive : Bool
 
       def initialize(@mode : Mode = Mode::Sniper,
                      @concurrency : Int32 = 20,
@@ -131,7 +141,8 @@ module Gori
                      @add_content_length_when_missing : Bool = false,
                      @auto_calibrate : Bool = false,
                      @keep_bodies : Symbol = :matched,
-                     @max_requests : Int64? = nil)
+                     @max_requests : Int64? = nil,
+                     @keep_alive : Bool = true)
       end
     end
   end

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -1228,6 +1228,7 @@ module Gori
               s.field "rate", intprop("requests/sec cap (0 = unlimited)")
               s.field "timeout_ms", intprop("per-request connect + idle (read/write) timeout in milliseconds")
               s.field "retries", intprop("retries per request on a network error")
+              s.field "keep_alive", boolprop("reuse one HTTP/1.1 connection across many requests (default true) — one TCP/TLS handshake per worker instead of per request. Set false to dial a fresh connection per request, which is what you want when the target behaves per-connection (connection-scoped rate limits, a load balancer pinning by connection) or when keep-alive handling is itself what you are probing.")
               s.field "http2", boolprop("use real HTTP/2 (default false)")
               s.field "insecure", boolprop("skip upstream TLS verification (default false)")
               s.field "max_requests", intprop("caller cap on total requests")

--- a/src/gori/mcp/tools/fuzz.cr
+++ b/src/gori/mcp/tools/fuzz.cr
@@ -544,7 +544,9 @@ module Gori
           retries: (int(h, "retries") || 0_i64).clamp(0_i64, 1000_i64).to_i,
           timeout: fuzz_timeout(h),
           keep_bodies: fuzz_record_policy(h),
-          max_requests: cap)
+          max_requests: cap,
+          # Absent ⇒ the Config default (on); only an explicit `false` opts out.
+          keep_alive: bool_arg(h, "keep_alive", true))
       end
     end
   end

--- a/src/gori/repeater/engine.cr
+++ b/src/gori/repeater/engine.cr
@@ -42,15 +42,31 @@ module Gori
         # `timeout` is a PER-OPERATION bound (connect, and idle between reads/writes),
         # not a total request deadline — same model as the proxy's IO_TIMEOUT. A true
         # whole-request deadline would need a timer fiber racing a socket close.
-        ct = timeout || Settings.connect_timeout
-        it = timeout || Settings.io_timeout
-        upstream = scheme == "https" ? Proxy::Upstream.dial_tls(host, port, verify: verify_upstream, sni: sni, connect_timeout: ct, io_timeout: it, overrides: overrides) : Proxy::Upstream.dial(host, port, connect_timeout: ct, io_timeout: it, overrides: overrides)
+        upstream = dial(scheme, host, port, verify_upstream, sni, timeout, overrides)
         return error(connect_error(scheme, host, port, verify_upstream), started) unless upstream
 
         begin
           exchange(upstream, request, host, port, started)
         ensure
           upstream.close rescue nil
+        end
+      end
+
+      # Opens ONE upstream connection to the origin, or nil when the dial (or, for https,
+      # the TLS handshake) failed. Public because a keep-alive pool has to own the socket's
+      # lifetime across many exchanges — `send` above is the same dial plus a single
+      # exchange plus a close. `timeout` is the per-operation bound (connect, and idle
+      # between reads/writes), exactly as in `send`.
+      def self.dial(scheme : String, host : String, port : Int32, verify_upstream : Bool,
+                    sni : String?, timeout : Time::Span?,
+                    overrides : Gori::HostOverrides?) : IO?
+        ct = timeout || Settings.connect_timeout
+        it = timeout || Settings.io_timeout
+        if scheme == "https"
+          Proxy::Upstream.dial_tls(host, port, verify: verify_upstream, sni: sni,
+            connect_timeout: ct, io_timeout: it, overrides: overrides)
+        else
+          Proxy::Upstream.dial(host, port, connect_timeout: ct, io_timeout: it, overrides: overrides)
         end
       end
 
@@ -71,9 +87,7 @@ module Gori
                              overrides : Gori::HostOverrides? = nil) : Array(Result)
         results = [] of Result
         return results if requests.empty?
-        ct = timeout || Settings.connect_timeout
-        it = timeout || Settings.io_timeout
-        upstream = scheme == "https" ? Proxy::Upstream.dial_tls(host, port, verify: verify_upstream, sni: sni, connect_timeout: ct, io_timeout: it, overrides: overrides) : Proxy::Upstream.dial(host, port, connect_timeout: ct, io_timeout: it, overrides: overrides)
+        upstream = dial(scheme, host, port, verify_upstream, sni, timeout, overrides)
         unless upstream
           msg = connect_error(scheme, host, port, verify_upstream)
           now = Time.instant
@@ -101,16 +115,28 @@ module Gori
         results
       end
 
+      # The exact error string a clean EOF before ANY response byte produces. A keep-alive
+      # pool matches on it to tell "the origin had already closed this parked socket" (retry
+      # once on a fresh connection) apart from a timeout or a mid-response failure (never
+      # retried — the origin may well have processed the request).
+      def self.no_response_error(host : String, port : Int32) : String
+        "no response from #{host}:#{port}"
+      end
+
       # Writes one request on an already-open connection and reads its single response
       # (skipping interim 1xx). Fully self-contained: any IO/parse failure becomes an error
       # Result rather than propagating, so a group send can decide what to do next. `started`
       # is when timing began (pre-dial for a one-shot send; per-request for a group).
-      private def self.exchange(upstream : IO, request : Bytes, host : String, port : Int32,
-                                started : Time::Instant) : Result
+      #
+      # Public because `send_pipeline` is not the only multi-request-per-connection caller
+      # any more: `Fuzz::ConnPool` reuses one socket across a sweep's requests. Both apply
+      # the SAME retirement rule to the socket afterwards (error or incomplete ⇒ unusable).
+      def self.exchange(upstream : IO, request : Bytes, host : String, port : Int32,
+                        started : Time::Instant) : Result
         upstream.write(request)
         upstream.flush
         head = read_response_head(upstream)
-        return error("no response from #{host}:#{port}", started) unless head
+        return error(no_response_error(host, port), started) unless head
 
         resp = Proxy::Codec::Http1.parse_response_head(head)
         # Skip interim 1xx informational responses (RFC 9110 §15.2): a captured request
@@ -176,7 +202,9 @@ module Gori
           timeout_sock: Proxy::SocketTuning.underlying_socket(upstream))
       end
 
-      private def self.error(message : String, started : Time::Instant) : Result
+      # An error Result with no head/body, timed from `started` (shared with the pool, which
+      # reports a failed dial the same way `send` does).
+      def self.error(message : String, started : Time::Instant) : Result
         Result.new(Bytes.new(0), nil, nil, elapsed(started), message)
       end
 
@@ -184,7 +212,7 @@ module Gori
       # rejection into a single nil socket, so spell out the likely causes — and, for
       # verified https, that a self-signed/expired cert is a common one — rather than
       # leaving the user with a bare "connect failed".
-      private def self.connect_error(scheme : String, host : String, port : Int32, verify : Bool) : String
+      def self.connect_error(scheme : String, host : String, port : Int32, verify : Bool) : String
         if scheme == "https" && verify
           "connect failed: #{host}:#{port} — host unreachable (DNS/refused/timeout) or the origin's TLS certificate failed verification (e.g. self-signed/expired)"
         else

--- a/src/gori/tui/fuzz_advanced_overlay.cr
+++ b/src/gori/tui/fuzz_advanced_overlay.cr
@@ -11,7 +11,7 @@ module Gori::Tui
   # strings (compiled by the view's commit_buffers at build/persist time, unchanged).
   record AdvancedSnapshot,
     conc : String, rate : String, timeout : String, retries : String,
-    follow : Bool, calibrate : Bool,
+    follow : Bool, calibrate : Bool, keep_alive : Bool,
     m_status : String, m_size : String, m_words : String, m_regex : String,
     f_status : String, f_size : String, f_words : String, f_regex : String
 
@@ -31,6 +31,7 @@ module Gori::Tui
       {:retries, "Retries", :text},
       {:follow, "Follow redirects", :toggle},
       {:calibrate, "Auto-calibrate", :toggle},
+      {:keep_alive, "Keep-alive", :toggle},
       {:m_status, "Match status", :text},
       {:m_size, "Match size", :text},
       {:m_words, "Match words", :text},
@@ -47,6 +48,7 @@ module Gori::Tui
       @scroll = 0
       @follow = snap.follow
       @calibrate = snap.calibrate
+      @keep_alive = snap.keep_alive
       @fields = {
         :conc     => TextField.new(snap.conc),
         :rate     => TextField.new(snap.rate),
@@ -121,8 +123,9 @@ module Gori::Tui
 
     private def toggle_current : Nil
       case current[0]
-      when :follow    then @follow = !@follow
-      when :calibrate then @calibrate = !@calibrate
+      when :follow     then @follow = !@follow
+      when :calibrate  then @calibrate = !@calibrate
+      when :keep_alive then @keep_alive = !@keep_alive
       end
     end
 
@@ -140,7 +143,7 @@ module Gori::Tui
       AdvancedSnapshot.new(
         conc: @fields[:conc].value, rate: @fields[:rate].value,
         timeout: @fields[:timeout].value, retries: @fields[:retries].value,
-        follow: @follow, calibrate: @calibrate,
+        follow: @follow, calibrate: @calibrate, keep_alive: @keep_alive,
         m_status: @fields[:m_status].value, m_size: @fields[:m_size].value,
         m_words: @fields[:m_words].value, m_regex: @fields[:m_regex].value,
         f_status: @fields[:f_status].value, f_size: @fields[:f_size].value,
@@ -183,7 +186,11 @@ module Gori::Tui
       screen.fill(Rect.new(box.x + 1, y, box.w - 2, 1), bg) if foc
       screen.text(box.x + 2, y, label, foc ? Theme.text_bright : Theme.muted, bg)
       if kind == :toggle
-        on = key == :follow ? @follow : @calibrate
+        on = case key
+             when :follow     then @follow
+             when :keep_alive then @keep_alive
+             else                  @calibrate
+             end
         screen.text(vx, y, on ? "‹ on ›" : "‹ off ›", foc ? Theme.text_bright : Theme.text, bg)
       else
         vw = {box.right - 2 - vx, 1}.max

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -797,6 +797,7 @@ module Gori::Tui
       AdvancedSnapshot.new(
         conc: @s_conc, rate: @s_rate, timeout: @s_timeout, retries: @s_retries,
         follow: @config.follow_redirects?, calibrate: @config.auto_calibrate?,
+        keep_alive: @config.keep_alive?,
         m_status: @matcher.match_status || "", m_size: @matcher.match_size || "",
         m_words: @matcher.match_words || "", m_regex: @s_m_regex,
         f_status: @matcher.filter_status || "", f_size: @matcher.filter_size || "",
@@ -813,6 +814,7 @@ module Gori::Tui
       @config.follow_redirects = s.follow
       @config.auto_calibrate = s.calibrate
       @matcher.auto_calibrate = s.calibrate
+      @config.keep_alive = s.keep_alive
       @matcher.match_status = blank_nil(s.m_status)
       @matcher.match_size = blank_nil(s.m_size)
       @matcher.match_words = blank_nil(s.m_words)
@@ -1376,6 +1378,7 @@ module Gori::Tui
           j.field "retries", @config.retries
           j.field "follow", @config.follow_redirects?
           j.field "calibrate", @config.auto_calibrate?
+          j.field "keep_alive", @config.keep_alive?
           j.field("sets") { j.array { @sets.each { |s| j.object { j.field "kind", s.kind.to_s; j.field "value", s.value } } } }
           j.field "match_status", @matcher.match_status
           j.field "filter_status", @matcher.filter_status
@@ -1403,6 +1406,9 @@ module Gori::Tui
       obj["retries"]?.try(&.as_i?).try { |n| @config.retries = n }
       @config.follow_redirects = obj["follow"]?.try(&.as_bool?) || false
       @config.auto_calibrate = obj["calibrate"]?.try(&.as_bool?) || false
+      # A session persisted before this key existed reads as nil ⇒ keep the ctor default
+      # (on). `|| false` here would silently turn keep-alive off for every saved tab.
+      @config.keep_alive = obj["keep_alive"]?.try(&.as_bool?) != false
       apply_sets_json(obj["sets"]?)
       @matcher.match_status = obj["match_status"]?.try(&.as_s?)
       @matcher.filter_status = obj["filter_status"]?.try(&.as_s?)


### PR DESCRIPTION
## Why

The Fuzzer's per-response CPU paths were already optimised — `render`, `Matcher#build`, `ContentLength.sync`, the DIST rebuild and the live-run frame each have a bench in `bench/`. What a run actually *waits on* was untouched: `Repeater::Engine.send` dialed a fresh connection, exchanged ONE request and closed it, so an N-request sweep paid N TCP handshakes and, on `https`, N TLS handshakes before a single payload byte moved.

Measured before changing anything: a warm 3000-request loopback plaintext run was 0.11s wall / 0.06s user — about 2x `ab` without keep-alive. There was nothing left in the CPU path.

## What

`Fuzz::ConnPool` parks the socket and the next request reuses it, so a run pays ~concurrency handshakes rather than ~N.

`bench/fuzz_keepalive_bench.cr` — 2000 requests, concurrency 50, loopback, client and server in one process:

| origin | before | after | |
|---|---|---|---|
| `http` | 0.127s | 0.031s | **4.1x** |
| `https` | 1.411s | 0.071s | **19.8x** |
| `https` client user CPU | 1.31s | 0.06s | 22x |

50 handshakes instead of 2000. Loopback **understates** it: RTT is ~0 here, where a remote origin also pays 2-3 round trips per handshake.

## Reuse is opt-in per message, not a keep-alive loop

gori points deliberately odd requests at targets, so a socket is shared only when both ends are unambiguously framed.

**Request** — HTTP/1.1, no `Connection: close` / `Upgrade` / `CONNECT`, passes `Body.request_framing` (so no CL+TE, no obfuscated framing header), and the load-bearing one: its **body length on the wire equals what the head declares**. That last check is what keeps a smuggling payload off a shared connection — a short or long `Content-Length` leaves the origin's parser mid-message, and its leftover bytes would be read as the start of the next request, so the *next payload's* result would be somebody else's response. Those requests get their own connection, exactly as today.

**Response** — no error, not incomplete, HTTP/1.1 (or 1.0 with an explicit keep-alive), not a 101, and framed by Content-Length or chunked rather than close-delimited.

## Stale sockets

A parked socket the origin closed while it sat idle is normal, not a failed result. Detected as a clean EOF before **any** response byte — never a timeout, since there the origin may well have processed the request — and re-sent once on a fresh connection. After `STALE_GIVE_UP` (3) consecutive stale checkouts the pool stops pooling for the rest of the run, so an origin that closes everything pays a handful of wasted redials rather than one per request.

Verified against exactly such an origin (hangs up after every response, announcing nothing): `200 sent · 200 dialed · 3 re-sent · 0 errors`.

## Surfaces

On by default, with an escape hatch on all three — for a target whose behaviour is per-connection (a connection-scoped rate limit, a load balancer pinning by connection) or when keep-alive handling is itself what you're testing:

- CLI `--no-keep-alive`
- MCP `keep_alive: false`
- TUI **Keep-alive** toggle in the Fuzzer's ADVANCED overlay (persisted; a session saved before the key existed reads as on)

`gori run fuzz` reports what the run paid: `connections · 50 dialed · 2950 reused`.

## Scope

`Repeater::Engine.exchange` / `dial` / `error` / `connect_error` go public for this; `send_pipeline` and the pool now share one socket-retirement rule (error or incomplete ⇒ unusable).

Deliberately **not** included: h2 (`H2Engine` multiplexing is its own change, with its own stream-state rules — the pool is nil there), the one-shot senders (Repeater minimize, Probe active — nothing to amortise), and the other sweeps (Miner, Sequencer — one ctor arg opts them in, but Sequencer in particular may want each connection visible). `Engine#follow_redirects` synthesizes `Connection: close`, so redirect hops keep dialing per hop as before.

## Verification

- `crystal spec` — 4421 examples, 8 failures, all pre-existing (`capture_status` / `project_registry`, a gori already listening on :8070)
- 20 new examples in `spec/fuzz/conn_pool_spec.cr` — the framing predicates, plus four real-socket cases: one connection per worker, `keep_alive: false` dialing per request, the stale re-send + give-up, and a `Connection: close` origin
- `crystal build --no-codegen src/main.cr` clean
- ameba on the touched files: 7 findings, **identical** to the same files at `main` — no new ones