### PR TITLE
feat(proxy): upstream connection rules — per-host routing, SOCKS5, proxy authentication

### DIFF
--- a/docs/content/reference/config.ko.md
+++ b/docs/content/reference/config.ko.md
@@ -70,6 +70,51 @@ CLI `--listen` / `--port`는 현재 프로세스에 한해서만 이 값들을 �
 
 우회된 호스트는 flow를 남기지 않으므로, gori는 호스트별로 처음 중계할 때 로그에 한 줄을 남깁니다. History에서 빠진 호스트의 이유를 추적할 수 있게 하기 위함입니다. 목록은 Preferences → **Network & Tabs** → **Network** → **TLS passthrough**에서 쉼표로 구분해 편집합니다.
 
+### upstream_rules
+
+목적지별 업스트림 라우팅입니다. `network.upstream_proxy`는 *모든* 트래픽에 대한 단일 주소인 반면, 규칙 테이블은 "`*.corp.internal`은 사내 프록시로, 나머지는 직결"을 표현할 수 있고 자격증명을 실을 수 있으며 SOCKS 프록시에 접근할 수 있습니다.
+
+규칙은 **순서가 있고 첫 일치가 이깁니다**. 구체적인 규칙을 위에 두세요. 편집은 `gori settings --edit`.
+
+```json
+{
+  "upstream_rules": [
+    { "host": "intranet.corp.internal", "kind": "direct" },
+    {
+      "host": "*.corp.internal",
+      "kind": "http",
+      "addr": "proxy.corp.internal:3128",
+      "username": "alice",
+      "password_env": "CORP_PROXY_PASS"
+    },
+    { "host": "*.onion", "kind": "socks5", "addr": "127.0.0.1:9050" }
+  ]
+}
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `host` | string | 호스트 패턴. 스코프 `host` 룰과 같은 문법 — `corp.internal`은 해당 호스트와 서브도메인, `*.corp.internal`은 글롭, `*`는 catch-all. 대소문자 무관 |
+| `kind` | string | `direct`, `http`, `socks5`. 알 수 없는 kind는 규칙을 버립니다(`direct`로 취급하면 의도한 프록시를 조용히 비활성화하게 되므로) |
+| `addr` | string | 프록시 `host:port`. 포트 기본값은 `http`가 `8080`, `socks5`가 `1080`. `direct`에는 없어야 합니다 |
+| `username` | string | 선택. `http`는 HTTP Basic(RFC 7617), `socks5`는 RFC 1929 교환으로 전송 |
+| `password_env` | string | 선택. 비밀번호를 담은 **OS 환경변수의 이름** |
+
+**자격증명은 `settings.json`에 저장되지 않습니다.** 사용자명과 환경변수 *이름*만 기록되고, 비밀번호는 dial 시점에 OS 환경에서 읽습니다. 따라서 `export CORP_PROXY_PASS=…`가 재시작 없이 반영됩니다. gori 자체의 `env` 섹션은 의도적으로 쓰지 않습니다 — 그 변수들은 `settings.json`에 평문으로 저장되므로, 결국 다른 경로로 비밀을 파일에 넣는 셈이고 설정 공유·내보내기([#439](https://github.com/hahwul/gori/issues/439))를 무의미하게 만듭니다. `$`가 포함된 `password_env`는 거부됩니다 — 값이 아니라 변수 이름을 담는 필드입니다.
+
+`socks5`의 경우 호스트명 대상은 `ATYP DOMAIN`으로 전송되어 **프록시가** 이름을 해석합니다(`socks5h` 동작). Tor나 점프호스트 뒤의 도달 불가 네트워크가 이 덕분에 동작하며, gori 자체는 dial 경로에서 이름을 해석하지 않습니다.
+
+우선순위(높은 것부터):
+
+| 우선순위 | 출처 |
+|----------|------|
+| 1 (최상) | 프로젝트 `net.upstream_proxy` — 명시적 프로젝트 고정으로, 테이블을 통째로 건너뜁니다 |
+| 2 | `upstream_rules`의 첫 호스트 일치 |
+| 3 | `network.upstream_proxy` — 암묵적 catch-all |
+| 4 (최하) | 직접 연결 |
+
+규칙은 [호스트 오버라이드](#hostname_overrides) 적용 **이전의 원래 호스트명**에 대해 매칭됩니다 — 오버라이드는 어느 IP로 접속할지만 바꿉니다.
+
 ### layout {#layout}
 
 영역별 TUI 레이아웃 환경설정 (커맨드 팔레트 → **Settings: Layout**). 두 값 모두 공장 기본값이면 생략됩니다.

--- a/docs/content/reference/config.md
+++ b/docs/content/reference/config.md
@@ -70,6 +70,51 @@ Empty (the default) means everything is intercepted, which is how gori behaved b
 
 Because a bypassed host produces no flow, gori writes one line to its log the first time each host is relayed, so a host missing from History has a traceable reason. Edit the list from Preferences → **Network & Tabs** → **Network** → **TLS passthrough** (comma-separated).
 
+### upstream_rules
+
+Per-destination upstream routing. `network.upstream_proxy` is a single address for *everything*; a rule table can say "route `*.corp.internal` through the internal proxy, everything else direct", carry credentials, and reach a SOCKS proxy.
+
+Rules are **ordered** and the **first match wins**, so specific rules go above general ones. Edit them with `gori settings --edit`.
+
+```json
+{
+  "upstream_rules": [
+    { "host": "intranet.corp.internal", "kind": "direct" },
+    {
+      "host": "*.corp.internal",
+      "kind": "http",
+      "addr": "proxy.corp.internal:3128",
+      "username": "alice",
+      "password_env": "CORP_PROXY_PASS"
+    },
+    { "host": "*.onion", "kind": "socks5", "addr": "127.0.0.1:9050" }
+  ]
+}
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `host` | string | Host pattern, same dialect as scope `host` rules: `corp.internal` covers that host and its subdomains, `*.corp.internal` is a glob, `*` is the catch-all. Case-insensitive |
+| `kind` | string | `direct`, `http`, or `socks5`. An unknown kind drops the rule rather than being treated as `direct`, which would quietly disable an intended proxy |
+| `addr` | string | Proxy `host:port`. Port defaults to `8080` for `http` and `1080` for `socks5`. Must be absent for `direct` |
+| `username` | string | Optional. Sent as HTTP Basic (RFC 7617) for `http`, or via the RFC 1929 exchange for `socks5` |
+| `password_env` | string | Optional. The **name** of an OS environment variable holding the password |
+
+**Credentials are never stored in `settings.json`.** Only the username and the environment-variable *name* are written; the password is read from the OS environment at dial time, so `export CORP_PROXY_PASS=…` takes effect without a restart. gori's own `env` section is deliberately not used for this — those variables live in `settings.json` in plaintext, which would put the secret in the file by another route and defeat sharing or exporting a config (see [#439](https://github.com/hahwul/gori/issues/439)). A `password_env` containing `$` is rejected: it holds a variable name, not a value.
+
+For `socks5`, a hostname target is sent as `ATYP DOMAIN` so the **proxy** resolves it (the `socks5h` behaviour). That is what makes Tor and a jump host into an otherwise unreachable network work; gori does not resolve names on the dial path itself.
+
+Precedence, highest first:
+
+| Priority | Source |
+|----------|--------|
+| 1 (highest) | Project `net.upstream_proxy` — an explicit per-project pin, which bypasses the table wholesale |
+| 2 | `upstream_rules`, first host match |
+| 3 | `network.upstream_proxy` — the implicit catch-all |
+| 4 (lowest) | Direct |
+
+A rule is matched against the **original** hostname, before any [host override](#hostname_overrides) is applied — an override only changes which IP is dialled.
+
 ### layout
 
 Per-area TUI layout prefs (command palette → **Settings: Layout**). Omitted when both values are factory defaults.

--- a/spec/proxy/upstream_rules_spec.cr
+++ b/spec/proxy/upstream_rules_spec.cr
@@ -1,0 +1,389 @@
+require "../spec_helper"
+require "socket"
+
+# Restore every knob upstream_route consults, so one example can't leak a route into the next.
+private def reset_upstream : Nil
+  Gori::Settings.upstream_rules = [] of Gori::Settings::UpstreamRule
+  Gori::Settings.upstream_proxy = ""
+  Gori::Settings.project_upstream_proxy = nil
+end
+
+private def rule(host : String, kind : String, addr : String = "",
+                 username : String = "", password_env : String = "") : Gori::Settings::UpstreamRule
+  Gori::Settings::UpstreamRule.new(host, kind, addr, username, password_env)
+end
+
+# A one-shot HTTP proxy that captures the whole CONNECT head (request line + headers) and
+# answers 200, so a spec can assert on what gori actually put on the wire.
+private def with_capturing_http_proxy(&)
+  server = TCPServer.new("127.0.0.1", 0)
+  head = Channel(String).new(1)
+  spawn do
+    conn = server.accept
+    buf = String::Builder.new
+    while (line = conn.gets("\r\n", chomp: true)) && !line.empty?
+      buf << line << "\n"
+    end
+    conn << "HTTP/1.1 200 Connection established\r\n\r\n"
+    conn.flush
+    head.send(buf.to_s)
+    sleep 50.milliseconds # hold the tunnel open until the client has read the reply
+    conn.close rescue nil
+  rescue
+  end
+  begin
+    yield server.local_address.port, head
+  ensure
+    server.close rescue nil
+  end
+end
+
+# A one-shot SOCKS5 proxy. Performs method negotiation (offering `auth_method`), the optional
+# RFC 1929 exchange, then reads the CONNECT request and reports what it was asked for instead of
+# actually connecting — the point is to pin the bytes gori emits, not to relay.
+private def with_socks5_proxy(auth_method : UInt8 = 0_u8, auth_ok : Bool = true, &)
+  server = TCPServer.new("127.0.0.1", 0)
+  seen = Channel(NamedTuple(atyp: UInt8, addr: String, port: Int32, user: String, pass: String)).new(1)
+  spawn do
+    conn = server.accept
+    greeting = Bytes.new(2)
+    conn.read_fully(greeting)
+    methods = Bytes.new(greeting[1].to_i)
+    conn.read_fully(methods)
+    conn.write(Bytes[5_u8, auth_method])
+    conn.flush
+
+    user = ""
+    pass = ""
+    if auth_method == 2_u8
+      hdr = Bytes.new(2)
+      conn.read_fully(hdr) # VER, ULEN
+      ubuf = Bytes.new(hdr[1].to_i)
+      conn.read_fully(ubuf)
+      user = String.new(ubuf)
+      plen = Bytes.new(1)
+      conn.read_fully(plen)
+      pbuf = Bytes.new(plen[0].to_i)
+      conn.read_fully(pbuf)
+      pass = String.new(pbuf)
+      conn.write(Bytes[1_u8, auth_ok ? 0_u8 : 1_u8])
+      conn.flush
+      unless auth_ok
+        conn.close rescue nil
+        next
+      end
+    end
+
+    req = Bytes.new(4) # VER CMD RSV ATYP
+    conn.read_fully(req)
+    addr = case req[3]
+           when 1_u8
+             b = Bytes.new(4); conn.read_fully(b); b.join(".")
+           when 4_u8
+             b = Bytes.new(16); conn.read_fully(b)
+             b.each_slice(2).map { |p| "%02x%02x" % {p[0], p[1]} }.join(":")
+           else
+             l = Bytes.new(1); conn.read_fully(l)
+             b = Bytes.new(l[0].to_i); conn.read_fully(b); String.new(b)
+           end
+    pbytes = Bytes.new(2)
+    conn.read_fully(pbytes)
+    seen.send({atyp: req[3], addr: addr, port: (pbytes[0].to_i << 8) | pbytes[1].to_i,
+               user: user, pass: pass})
+    # Success reply with an IPv4 bound address, then hold the "tunnel" open.
+    conn.write(Bytes[5_u8, 0_u8, 0_u8, 1_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8])
+    conn.flush
+    sleep 50.milliseconds
+    conn.close rescue nil
+  rescue
+  end
+  begin
+    yield server.local_address.port, seen
+  ensure
+    server.close rescue nil
+  end
+end
+
+describe "upstream rules" do
+  describe ".upstream_route" do
+    it "matches the FIRST rule, so a specific rule above a catch-all wins" do
+      Gori::Settings.upstream_rules = [
+        rule("*.corp.test", "http", "corp-proxy.test:3128"),
+        rule("*", "direct"),
+      ]
+      route = Gori::Settings.upstream_route("api.corp.test")
+      route.kind.should eq("http")
+      route.host.should eq("corp-proxy.test")
+      route.port.should eq(3128)
+      Gori::Settings.upstream_route("example.test").direct?.should be_true
+    ensure
+      reset_upstream
+    end
+
+    # A "direct" rule is the mechanism for carving an exception out of a broader proxy rule,
+    # so its ordering behaviour is the feature, not a side effect.
+    it "lets a direct rule carve an exception above a broader proxy rule" do
+      Gori::Settings.upstream_rules = [
+        rule("intranet.corp.test", "direct"),
+        rule("*.corp.test", "http", "corp-proxy.test:3128"),
+      ]
+      Gori::Settings.upstream_route("intranet.corp.test").direct?.should be_true
+      Gori::Settings.upstream_route("other.corp.test").host.should eq("corp-proxy.test")
+    ensure
+      reset_upstream
+    end
+
+    it "covers subdomains of a bare pattern and is case-insensitive (shared host dialect)" do
+      Gori::Settings.upstream_rules = [rule("Corp.TEST", "http", "p.test:1")]
+      Gori::Settings.upstream_route("api.corp.test").host.should eq("p.test")
+      Gori::Settings.upstream_route("corp.test").host.should eq("p.test")
+      Gori::Settings.upstream_route("corp.test.evil.test").direct?.should be_true
+    ensure
+      reset_upstream
+    end
+
+    it "defaults the port per kind: 8080 for http, 1080 for socks5" do
+      Gori::Settings.upstream_rules = [rule("a.test", "http", "p.test"), rule("b.test", "socks5", "s.test")]
+      Gori::Settings.upstream_route("a.test").port.should eq(8080)
+      Gori::Settings.upstream_route("b.test").port.should eq(1080)
+      Gori::Settings.upstream_route("b.test").socks5?.should be_true
+    ensure
+      reset_upstream
+    end
+
+    it "falls back to the legacy scalar when no rule matches, and to direct when it is blank" do
+      Gori::Settings.upstream_rules = [rule("only.test", "http", "p.test:1")]
+      Gori::Settings.upstream_proxy = "legacy.test:8888"
+      Gori::Settings.upstream_route("other.test").host.should eq("legacy.test")
+      Gori::Settings.upstream_route("other.test").port.should eq(8888)
+      Gori::Settings.upstream_proxy = ""
+      Gori::Settings.upstream_route("other.test").direct?.should be_true
+    ensure
+      reset_upstream
+    end
+
+    # Back-compat: a project that pinned its own upstream before rules existed must keep
+    # going through it, whatever the global table now says.
+    it "lets a project pin beat the rule table entirely" do
+      Gori::Settings.upstream_rules = [rule("*", "http", "table.test:1")]
+      Gori::Settings.project_upstream_proxy = "pinned.test:9"
+      route = Gori::Settings.upstream_route("anything.test")
+      route.host.should eq("pinned.test")
+      route.port.should eq(9)
+    ensure
+      reset_upstream
+    end
+
+    # An explicit project "" means DIRECT and must not fall through to the table or the
+    # global scalar (the nil-vs-empty distinction is load-bearing).
+    it "treats an explicit empty project pin as direct, not as absent" do
+      Gori::Settings.upstream_rules = [rule("*", "http", "table.test:1")]
+      Gori::Settings.upstream_proxy = "global.test:2"
+      Gori::Settings.project_upstream_proxy = ""
+      Gori::Settings.upstream_route("anything.test").direct?.should be_true
+    ensure
+      reset_upstream
+    end
+
+    it "reads the password from the OS environment at route time, never from settings" do
+      ENV["GORI_SPEC_PROXY_PASS"] = "s3cret"
+      Gori::Settings.upstream_rules = [rule("a.test", "http", "p.test:1", "bob", "GORI_SPEC_PROXY_PASS")]
+      route = Gori::Settings.upstream_route("a.test")
+      route.username.should eq("bob")
+      route.password.should eq("s3cret")
+
+      # Unset the variable and the credential disappears — nothing was cached at load.
+      ENV.delete("GORI_SPEC_PROXY_PASS")
+      Gori::Settings.upstream_route("a.test").password.should be_nil
+    ensure
+      ENV.delete("GORI_SPEC_PROXY_PASS")
+      reset_upstream
+    end
+
+    # A hand-edited file can hold a rule the validator would have rejected. Degrading to
+    # direct beats failing every dial for the host.
+    it "degrades a proxy rule with no address to direct" do
+      Gori::Settings.upstream_rules = [rule("a.test", "http", "")]
+      Gori::Settings.upstream_route("a.test").direct?.should be_true
+    ensure
+      reset_upstream
+    end
+  end
+
+  describe "HTTP proxy authentication" do
+    # The headline fix: before upstream rules, gori emitted no Proxy-Authorization at all, so
+    # an authenticating proxy could not be used.
+    it "sends Basic Proxy-Authorization when the rule carries credentials" do
+      ENV["GORI_SPEC_PROXY_PASS"] = "p4ss"
+      with_capturing_http_proxy do |pport, head|
+        Gori::Settings.upstream_rules = [rule("*", "http", "127.0.0.1:#{pport}", "bob", "GORI_SPEC_PROXY_PASS")]
+        sock = Gori::Proxy::Upstream.dial("example.test", 443)
+        sock.should_not be_nil
+        sent = head.receive
+        sock.try(&.close) rescue nil
+
+        sent.should contain("CONNECT example.test:443 HTTP/1.1")
+        sent.should contain("Proxy-Authorization: Basic #{Base64.strict_encode("bob:p4ss")}")
+      end
+    ensure
+      ENV.delete("GORI_SPEC_PROXY_PASS")
+      reset_upstream
+    end
+
+    it "omits Proxy-Authorization entirely when the rule has no credentials" do
+      with_capturing_http_proxy do |pport, head|
+        Gori::Settings.upstream_rules = [rule("*", "http", "127.0.0.1:#{pport}")]
+        sock = Gori::Proxy::Upstream.dial("example.test", 443)
+        sock.should_not be_nil
+        sent = head.receive
+        sock.try(&.close) rescue nil
+        sent.downcase.should_not contain("proxy-authorization")
+      end
+    ensure
+      reset_upstream
+    end
+
+    # A CR/LF in a credential would inject a header line into gori's OWN CONNECT request —
+    # self-inflicted request smuggling (the #403 shape). These values come from settings.json
+    # and the OS environment, so they are stripped rather than trusted.
+    it "strips CR/LF from credentials instead of injecting a header line" do
+      ENV["GORI_SPEC_PROXY_PASS"] = "p4ss\r\nX-Injected: 1"
+      with_capturing_http_proxy do |pport, head|
+        Gori::Settings.upstream_rules = [rule("*", "http", "127.0.0.1:#{pport}", "bo\r\nb", "GORI_SPEC_PROXY_PASS")]
+        sock = Gori::Proxy::Upstream.dial("example.test", 443)
+        sent = head.receive
+        sock.try(&.close) rescue nil
+
+        sent.should_not contain("X-Injected")
+        sent.should contain("Proxy-Authorization: Basic #{Base64.strict_encode("bob:p4ssX-Injected: 1")}")
+      end
+    ensure
+      ENV.delete("GORI_SPEC_PROXY_PASS")
+      reset_upstream
+    end
+  end
+
+  describe "SOCKS5" do
+    it "reaches a hostname target through a SOCKS5 proxy, letting the proxy resolve it" do
+      with_socks5_proxy do |sport, seen|
+        Gori::Settings.upstream_rules = [rule("*", "socks5", "127.0.0.1:#{sport}")]
+        sock = Gori::Proxy::Upstream.dial("example.test", 443)
+        sock.should_not be_nil
+        got = seen.receive
+        sock.try(&.close) rescue nil
+
+        got[:atyp].should eq(3_u8) # ATYP DOMAIN — remote resolution ("socks5h"), not a local lookup
+        got[:addr].should eq("example.test")
+        got[:port].should eq(443)
+      end
+    ensure
+      reset_upstream
+    end
+
+    it "sends an IPv4 literal target as ATYP IPV4, not as a domain name" do
+      with_socks5_proxy do |sport, seen|
+        Gori::Settings.upstream_rules = [rule("*", "socks5", "127.0.0.1:#{sport}")]
+        sock = Gori::Proxy::Upstream.dial("93.184.216.34", 8080)
+        sock.should_not be_nil
+        got = seen.receive
+        sock.try(&.close) rescue nil
+
+        got[:atyp].should eq(1_u8)
+        got[:addr].should eq("93.184.216.34")
+        got[:port].should eq(8080)
+      end
+    ensure
+      reset_upstream
+    end
+
+    # The brackets are URL syntax; on the wire the address is 16 raw bytes.
+    it "sends a bracketed IPv6 literal as 16 raw bytes (ATYP IPV6), brackets stripped" do
+      with_socks5_proxy do |sport, seen|
+        Gori::Settings.upstream_rules = [rule("*", "socks5", "127.0.0.1:#{sport}")]
+        sock = Gori::Proxy::Upstream.dial("[2001:db8::1]", 443)
+        sock.should_not be_nil
+        got = seen.receive
+        sock.try(&.close) rescue nil
+
+        got[:atyp].should eq(4_u8)
+        got[:addr].should eq("2001:0db8:0000:0000:0000:0000:0000:0001")
+      end
+    ensure
+      reset_upstream
+    end
+
+    it "performs the RFC 1929 username/password exchange when the proxy asks for it" do
+      ENV["GORI_SPEC_SOCKS_PASS"] = "socks-pass"
+      with_socks5_proxy(auth_method: 2_u8) do |sport, seen|
+        Gori::Settings.upstream_rules = [
+          rule("*", "socks5", "127.0.0.1:#{sport}", "alice", "GORI_SPEC_SOCKS_PASS"),
+        ]
+        sock = Gori::Proxy::Upstream.dial("example.test", 443)
+        sock.should_not be_nil
+        got = seen.receive
+        sock.try(&.close) rescue nil
+
+        got[:user].should eq("alice")
+        got[:pass].should eq("socks-pass")
+      end
+    ensure
+      ENV.delete("GORI_SPEC_SOCKS_PASS")
+      reset_upstream
+    end
+
+    it "fails the dial when the proxy rejects the credentials" do
+      ENV["GORI_SPEC_SOCKS_PASS"] = "wrong"
+      with_socks5_proxy(auth_method: 2_u8, auth_ok: false) do |sport, _seen|
+        Gori::Settings.upstream_rules = [
+          rule("*", "socks5", "127.0.0.1:#{sport}", "alice", "GORI_SPEC_SOCKS_PASS"),
+        ]
+        Gori::Proxy::Upstream.dial("example.test", 443).should be_nil
+      end
+    ensure
+      ENV.delete("GORI_SPEC_SOCKS_PASS")
+      reset_upstream
+    end
+
+    # 0xFF is "no acceptable methods" — the dial must fail rather than proceed onto a socket
+    # that is not a tunnel.
+    it "fails the dial when the proxy accepts no offered auth method" do
+      with_socks5_proxy(auth_method: 0xFF_u8) do |sport, _seen|
+        Gori::Settings.upstream_rules = [rule("*", "socks5", "127.0.0.1:#{sport}")]
+        Gori::Proxy::Upstream.dial("example.test", 443).should be_nil
+      end
+    ensure
+      reset_upstream
+    end
+  end
+
+  describe ".upstream_rule_error" do
+    it "accepts a well-formed rule of each kind" do
+      Gori::Settings.upstream_rule_error(rule("*", "direct")).should be_nil
+      Gori::Settings.upstream_rule_error(rule("a.test", "http", "p.test:3128")).should be_nil
+      Gori::Settings.upstream_rule_error(rule("a.test", "socks5", "127.0.0.1:1080")).should be_nil
+    end
+
+    it "rejects a missing host, an unknown kind, and a proxy rule with no address" do
+      Gori::Settings.upstream_rule_error(rule(" ", "http", "p.test:1")).to_s.should contain("host pattern")
+      Gori::Settings.upstream_rule_error(rule("a.test", "socks4", "p.test:1")).to_s.should contain("kind must be")
+      Gori::Settings.upstream_rule_error(rule("a.test", "http", "")).to_s.should contain("needs an address")
+    end
+
+    it "rejects a bad port, so a typo can't silently resolve to the default" do
+      Gori::Settings.upstream_rule_error(rule("a.test", "http", "p.test:8O80")).to_s.should contain("invalid upstream proxy port")
+    end
+
+    # An address on a direct rule means the operator meant http/socks5; accepting it would
+    # route the host DIRECT and look like the rule did nothing.
+    it "rejects an address on a direct rule" do
+      Gori::Settings.upstream_rule_error(rule("a.test", "direct", "p.test:1")).to_s.should contain("no address")
+    end
+
+    # password_env holds a NAME. A "$VALUE" here means the operator expected gori's env
+    # expansion, which deliberately is not used (it would put the secret in settings.json).
+    it "rejects a $-prefixed password_env, which would be a value not a variable name" do
+      Gori::Settings.upstream_rule_error(rule("a.test", "http", "p.test:1", "u", "$SECRET")).to_s
+        .should contain("environment variable NAME")
+    end
+  end
+end

--- a/src/gori/proxy/upstream.cr
+++ b/src/gori/proxy/upstream.cr
@@ -1,3 +1,4 @@
+require "base64" # Proxy-Authorization credentials (dial_via_proxy)
 require "socket"
 require "openssl"
 require "../settings"
@@ -32,10 +33,17 @@ module Gori::Proxy
                   io_timeout : Time::Span = Settings.io_timeout,
                   *, overrides : Gori::HostOverrides? = nil) : TCPSocket?
       target = connect_target(host, overrides)
-      if proxy = Settings.upstream_proxy_addr
-        dial_via_proxy(proxy[0], proxy[1], target, port, connect_timeout, io_timeout)
-      else
+      # ONE decision point for "how do we reach this host": Settings.upstream_route folds the
+      # project pin, the rule table and the legacy scalar together. Resolved on the ORIGINAL
+      # host, not `target` — a rule is written against the name the operator sees, and a
+      # hostname override only changes which IP we dial (see connect_target).
+      route = Settings.upstream_route(host)
+      if route.direct?
         direct_dial(target, port, connect_timeout, io_timeout)
+      elsif route.socks5?
+        dial_via_socks5(route, target, port, connect_timeout, io_timeout)
+      else
+        dial_via_proxy(route, target, port, connect_timeout, io_timeout)
       end
     end
 
@@ -183,16 +191,22 @@ module Gori::Proxy
     # BOTH https and plaintext targets (the tunnel is a raw pipe to the origin, so
     # gori's existing TLS-wrap/forwarding works over it). The proxy must permit
     # CONNECT to the target port.
-    private def self.dial_via_proxy(proxy_host : String, proxy_port : Int32,
+    #
+    # Sends Proxy-Authorization when the route carries credentials. Before upstream rules
+    # existed this header was never emitted at all, which made gori simply unusable behind an
+    # authenticating proxy — there was no setting that could produce it.
+    private def self.dial_via_proxy(route : Settings::UpstreamRoute,
                                     host : String, port : Int32,
                                     connect_timeout : Time::Span = Settings.connect_timeout,
                                     io_timeout : Time::Span = Settings.io_timeout) : TCPSocket?
-      sock = direct_dial(proxy_host, proxy_port, connect_timeout, io_timeout)
+      sock = direct_dial(route.host, route.port, connect_timeout, io_timeout)
       return nil unless sock
       # An IPv6 literal host must be bracketed in the CONNECT request-target / Host header
       # ("CONNECT [::1]:443"), else the upstream proxy sees a malformed authority.
       authority = host.includes?(':') && !host.starts_with?('[') ? "[#{host}]:#{port}" : "#{host}:#{port}"
-      sock << "CONNECT #{authority} HTTP/1.1\r\nHost: #{authority}\r\n\r\n"
+      sock << "CONNECT #{authority} HTTP/1.1\r\nHost: #{authority}\r\n"
+      sock << "Proxy-Authorization: Basic #{basic_credentials(route)}\r\n" if authenticating?(route)
+      sock << "\r\n"
       sock.flush
       return sock if connect_established?(sock)
       sock.close rescue nil
@@ -200,6 +214,164 @@ module Gori::Proxy
     rescue
       sock.try(&.close) rescue nil
       nil
+    end
+
+    # Whether this route has credentials to present. A username alone is legitimate (some
+    # proxies key on it), so either half being present counts.
+    private def self.authenticating?(route : Settings::UpstreamRoute) : Bool
+      !route.username.empty? || !(route.password || "").empty?
+    end
+
+    # base64("user:pass") per RFC 7617. A CR/LF in either half would inject a header line into
+    # our own CONNECT request (self-inflicted request smuggling, the #403 shape), so they are
+    # stripped rather than trusted: these values come from settings.json and the OS
+    # environment, neither of which is validated for wire-safety anywhere else.
+    private def self.basic_credentials(route : Settings::UpstreamRoute) : String
+      user = route.username.delete { |c| c == '\r' || c == '\n' }
+      pass = (route.password || "").delete { |c| c == '\r' || c == '\n' }
+      Base64.strict_encode("#{user}:#{pass}")
+    end
+
+    # --- SOCKS5 (RFC 1928 + RFC 1929 username/password auth) ----------------------------
+    # Reaches an origin through a SOCKS5 proxy — `ssh -D`, Tor, a jump host. The returned
+    # socket sits at the start of the origin stream, exactly like the CONNECT path, so every
+    # caller (dial_tls, the request forwarder) is unaffected.
+    SOCKS_VERSION              =    5_u8
+    SOCKS_AUTH_NONE            =    0_u8
+    SOCKS_AUTH_USERPWD         =    2_u8
+    SOCKS_AUTH_NONE_ACCEPTABLE = 0xFF_u8
+    SOCKS_CMD_CONNECT          =    1_u8
+    SOCKS_ATYP_IPV4            =    1_u8
+    SOCKS_ATYP_DOMAIN          =    3_u8
+    SOCKS_ATYP_IPV6            =    4_u8
+    # RFC 1928 caps a domain name at one length byte, and RFC 1929 caps each credential the
+    # same way. A longer value cannot be encoded, so the dial fails rather than being truncated
+    # into a request for a DIFFERENT host than the caller asked for.
+    SOCKS_MAX_FIELD = 255
+
+    private def self.dial_via_socks5(route : Settings::UpstreamRoute,
+                                     host : String, port : Int32,
+                                     connect_timeout : Time::Span = Settings.connect_timeout,
+                                     io_timeout : Time::Span = Settings.io_timeout) : TCPSocket?
+      sock = direct_dial(route.host, route.port, connect_timeout, io_timeout)
+      return nil unless sock
+      return sock if socks5_handshake(sock, route, host, port)
+      sock.close rescue nil
+      nil
+    rescue
+      sock.try(&.close) rescue nil
+      nil
+    end
+
+    # Method negotiation → optional auth → CONNECT. False on any refusal, so the caller closes.
+    private def self.socks5_handshake(sock : TCPSocket, route : Settings::UpstreamRoute,
+                                      host : String, port : Int32) : Bool
+      methods = authenticating?(route) ? Bytes[SOCKS_AUTH_NONE, SOCKS_AUTH_USERPWD] : Bytes[SOCKS_AUTH_NONE]
+      sock.write(Bytes[SOCKS_VERSION, methods.size.to_u8])
+      sock.write(methods)
+      sock.flush
+      return false unless (reply = socks5_read(sock, 2)) && reply[0] == SOCKS_VERSION
+      case reply[1]
+      when SOCKS_AUTH_NONE
+        # The proxy waived auth. Nothing to send even if we hold credentials.
+      when SOCKS_AUTH_USERPWD
+        return false unless socks5_authenticate(sock, route)
+      else
+        return false # 0xFF "no acceptable methods", or a method we never offered
+      end
+      socks5_connect(sock, host, port)
+    end
+
+    # RFC 1929: VER(1) ULEN(1) UNAME PLEN(1) PASSWD. Status 0 is success.
+    private def self.socks5_authenticate(sock : TCPSocket, route : Settings::UpstreamRoute) : Bool
+      user = route.username.to_slice
+      pass = (route.password || "").to_slice
+      return false if user.size > SOCKS_MAX_FIELD || pass.size > SOCKS_MAX_FIELD
+      sock.write(Bytes[1_u8, user.size.to_u8])
+      sock.write(user)
+      sock.write(Bytes[pass.size.to_u8])
+      sock.write(pass)
+      sock.flush
+      reply = socks5_read(sock, 2)
+      !!(reply && reply[1] == 0)
+    end
+
+    # The CONNECT request, then the reply (whose BND.ADDR must be drained by its own address
+    # type, or the socket would be left mid-reply and the origin stream would start desynced).
+    #
+    # An IP literal target is sent as ATYP IPV4/IPV6; a hostname is sent as ATYP DOMAIN, so the
+    # SOCKS proxy resolves it (the "socks5h" behaviour). That is the right default here: it is
+    # what makes Tor and a jump host into a network gori cannot otherwise see work at all, and
+    # gori deliberately does not resolve names on the dial path anyway (see parse_ip).
+    private def self.socks5_connect(sock : TCPSocket, host : String, port : Int32) : Bool
+      sock.write(Bytes[SOCKS_VERSION, SOCKS_CMD_CONNECT, 0_u8])
+      return false unless socks5_write_address(sock, host)
+      sock.write(Bytes[(port >> 8).to_u8, (port & 0xFF).to_u8])
+      sock.flush
+
+      return false unless (reply = socks5_read(sock, 4)) && reply[0] == SOCKS_VERSION
+      return false unless reply[1] == 0 # REP: 0 = succeeded; 1-8 are the failure codes
+      return false unless bound = socks5_bound_length(sock, reply[3])
+      !!socks5_read(sock, bound + 2) # BND.ADDR + BND.PORT — drained, not used
+    end
+
+    # How many bytes BND.ADDR occupies for `atyp`, consuming the length byte for a DOMAIN
+    # reply. nil for an address type the RFC does not define — the reply is then unusable and
+    # the socket cannot be trusted to be positioned at the start of the origin stream.
+    private def self.socks5_bound_length(sock : TCPSocket, atyp : UInt8) : Int32?
+      case atyp
+      when SOCKS_ATYP_IPV4   then 4
+      when SOCKS_ATYP_IPV6   then 16
+      when SOCKS_ATYP_DOMAIN then socks5_read(sock, 1).try(&.[0].to_i)
+      end
+    end
+
+    # ATYP + address. False when a hostname is too long to encode (see SOCKS_MAX_FIELD).
+    # A host arriving bracketed ("[::1]") is an IPv6 literal — the brackets are URL syntax and
+    # must not reach the wire, where the address is 16 raw bytes.
+    private def self.socks5_write_address(sock : TCPSocket, host : String) : Bool
+      bare = host.starts_with?('[') && host.ends_with?(']') ? host[1...-1] : host
+      if ip = parse_ip(bare)
+        v4 = ip.family == Socket::Family::INET
+        sock.write(Bytes[v4 ? SOCKS_ATYP_IPV4 : SOCKS_ATYP_IPV6])
+        sock.write(socks5_address_bytes(ip))
+        return true
+      end
+      name = host.to_slice
+      return false if name.empty? || name.size > SOCKS_MAX_FIELD
+      sock.write(Bytes[SOCKS_ATYP_DOMAIN, name.size.to_u8])
+      sock.write(name)
+      true
+    end
+
+    # An IP literal's network-order bytes: 4 for IPv4, 16 for IPv6. IPv4 is read off the
+    # canonical dotted text; IPv6 is copied out of the sockaddr the OS already parsed, rather
+    # than re-implementing "::" expansion here (in6_addr is exactly the 16 address bytes).
+    private def self.socks5_address_bytes(ip : Socket::IPAddress) : Bytes
+      return socks5_ipv4_bytes(ip) if ip.family == Socket::Family::INET
+      socks5_ipv6_bytes(ip)
+    end
+
+    private def self.socks5_ipv4_bytes(ip : Socket::IPAddress) : Bytes
+      out = Bytes.new(4)
+      ip.address.split('.').each_with_index { |octet, i| out[i] = octet.to_u8 }
+      out
+    end
+
+    private def self.socks5_ipv6_bytes(ip : Socket::IPAddress) : Bytes
+      addr = ip.to_unsafe.as(Pointer(LibC::SockaddrIn6)).value.sin6_addr
+      ptr = pointerof(addr).as(Pointer(UInt8))
+      out = Bytes.new(16)
+      16.times { |i| out[i] = ptr[i] }
+      out
+    end
+
+    # Read exactly `n` bytes, or nil on EOF/short read — every SOCKS field is fixed-length, so a
+    # partial read is a protocol failure, not something to proceed past.
+    private def self.socks5_read(sock : TCPSocket, n : Int32) : Bytes?
+      return Bytes.empty if n == 0
+      buf = Bytes.new(n)
+      sock.read_fully?(buf) ? buf : nil
     end
 
     # Bounds on the upstream proxy's CONNECT reply so a hostile/broken proxy can't
@@ -246,12 +418,12 @@ module Gori::Proxy
     # bundle FILE carries every root, so files are tried first; the DIRS are the
     # hashed-symlink fallback for systems that ship no bundle file. Kept in probe order.
     SYSTEM_CA_FILES = %w[
-      /etc/ssl/certs/ca-certificates.crt                 # Debian/Ubuntu/Alpine/Gentoo
-      /etc/pki/tls/certs/ca-bundle.crt                   # Fedora/RHEL 6
-      /etc/ssl/ca-bundle.pem                             # openSUSE
+      /etc/ssl/certs/ca-certificates.crt # Debian/Ubuntu/Alpine/Gentoo
+      /etc/pki/tls/certs/ca-bundle.crt # Fedora/RHEL 6
+      /etc/ssl/ca-bundle.pem # openSUSE
       /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem # CentOS/RHEL 7+
-      /etc/pki/tls/cacert.pem                            # OpenELEC
-      /etc/ssl/cert.pem                                  # Alpine/macOS/OpenBSD/FreeBSD
+      /etc/pki/tls/cacert.pem # OpenELEC
+      /etc/ssl/cert.pem # Alpine/macOS/OpenBSD/FreeBSD
     ]
     SYSTEM_CA_DIRS = %w[
       /etc/ssl/certs

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -1,6 +1,7 @@
 require "json"
 require "./paths"
 require "./settings/network"
+require "./settings/upstream_rules"
 require "./settings/env"
 require "./settings/scan_rules"
 require "./settings/oast_providers"
@@ -79,6 +80,7 @@ module Gori
         self.editor = ed["command"]?.try(&.as_s?) || editor
         self.editor_markdown = load_bool(ed, "markdown", editor_markdown)
       end
+      self.upstream_rules = parse_upstream_rules(root["upstream_rules"]?)
       self.tab_prefs = parse_tab_prefs(root["tabs"]?)
       self.hostname_overrides = parse_hostname_overrides(root["hostname_overrides"]?)
       parse_env(root["env"]?)
@@ -213,6 +215,7 @@ module Gori
           serialize_general(j)
           serialize_update(j)
           serialize_network(j)
+          serialize_upstream_rules(j)
           serialize_editor(j)
           serialize_tabs(j)
           serialize_hostname_overrides(j)

--- a/src/gori/settings/network.cr
+++ b/src/gori/settings/network.cr
@@ -180,7 +180,19 @@ module Gori::Settings
   # "host:port" with an optional "http://" scheme prefix; defaults the port to
   # 8080 when omitted.
   def self.upstream_proxy_addr : {String, Int32}?
-    value = effective_upstream_proxy.strip
+    proxy_addr(effective_upstream_proxy, default_port: DEFAULT_HTTP_PROXY_PORT)
+  end
+
+  # Default proxy ports when a rule/scalar names no explicit port: the conventional HTTP-proxy
+  # and SOCKS ports.
+  DEFAULT_HTTP_PROXY_PORT = 8080
+  DEFAULT_SOCKS_PORT      = 1080
+
+  # The shared "host:port" parse behind upstream_proxy_addr and the upstream RULE table
+  # (which needs a different default port per kind). Accepts an optional "http://" prefix and
+  # a bracketed IPv6 literal; nil when blank or when the host part is empty.
+  def self.proxy_addr(value : String, *, default_port : Int32) : {String, Int32}?
+    value = value.strip
     return nil if value.empty?
     value = value.sub(/\Ahttps?:\/\//, "").rstrip('/')
     # Bracketed IPv6 ("[::1]" / "[::1]:8080"): host is inside the brackets, the
@@ -191,15 +203,15 @@ module Gori::Settings
         host = value[1...close]
         return nil if host.empty?
         rest = value[(close + 1)..]
-        return {host, rest.starts_with?(':') ? (rest[1..].to_i? || 8080) : 8080}
+        return {host, rest.starts_with?(':') ? (rest[1..].to_i? || default_port) : default_port}
       end
     end
     idx = value.rindex(':')
-    return {value, 8080} unless idx
+    return {value, default_port} unless idx
     host = value[0...idx]
     return nil if host.empty?
-    return {value, 8080} if host.includes?(':') # unbracketed IPv6 literal → no port
-    {host, value[(idx + 1)..].to_i? || 8080}
+    return {value, default_port} if host.includes?(':') # unbracketed IPv6 literal → no port
+    {host, value[(idx + 1)..].to_i? || default_port}
   end
 
   # nil if `host` is an acceptable proxy BIND address; an error message otherwise. Accepts

--- a/src/gori/settings/upstream_rules.cr
+++ b/src/gori/settings/upstream_rules.cr
@@ -1,0 +1,193 @@
+require "json"
+require "../host_pattern"
+
+# UPSTREAM RULES section (settings:network → Upstream rules): per-destination upstream
+# routing. Replaces the single `network.upstream_proxy` string as the expressive form —
+# that scalar stays as the implicit catch-all, so an existing settings.json keeps working
+# byte-for-byte. See settings.cr for the module-level load/save/serialize orchestration.
+#
+# WHY a table: one global proxy address cannot say "route *.corp.internal through the
+# internal proxy, everything else direct", cannot carry credentials (so gori was unusable
+# behind an authenticating proxy at all), and cannot reach a SOCKS proxy.
+module Gori::Settings
+  # The transports a rule can route through. "direct" is a real, useful rule: it is how an
+  # exception is carved out of a broader proxy rule below it in the table.
+  UPSTREAM_KINDS = ["direct", "http", "socks5"]
+
+  # One routing rule. `host` is a HostPattern (see Gori::HostPattern) — the same dialect as
+  # scope host rules, with "*" as the catch-all. Rules are ORDERED and the FIRST match wins,
+  # so specific rules go above general ones.
+  #
+  # Credentials: only `username` and `password_env` are ever stored, where `password_env` is
+  # the NAME of an OS environment variable. The password itself is never written to
+  # settings.json — deliberately. gori's own `env` section is NOT used for this: those vars
+  # live in settings.json in plaintext, so resolving from there would put the secret in the
+  # file by another route, and the whole point is that a settings file can be shared,
+  # exported (#439), or committed without leaking a proxy credential.
+  record UpstreamRule,
+    host : String,
+    kind : String,
+    addr : String,
+    username : String = "",
+    password_env : String = "" do
+    def direct? : Bool
+      kind == "direct"
+    end
+
+    def socks5? : Bool
+      kind == "socks5"
+    end
+
+    # The password, read from the OS environment at DIAL time (not at load), so exporting a
+    # shell variable takes effect without restarting gori. nil when unset or unnamed — the
+    # caller then attempts an unauthenticated connection, which is the honest behaviour: it
+    # fails at the proxy with a 407 the operator can see, rather than silently sending "".
+    def password : String?
+      password_env.presence.try { |name| ENV[name]?.presence }
+    end
+  end
+
+  # The resolved decision for ONE destination host: collapses the project override, the rule
+  # table and the legacy scalar into a single value, so Upstream.dial has exactly one
+  # decision point instead of three branches that can disagree.
+  record UpstreamRoute,
+    kind : String,
+    host : String = "",
+    port : Int32 = 0,
+    username : String = "",
+    password : String? = nil do
+    def direct? : Bool
+      kind == "direct"
+    end
+
+    def socks5? : Bool
+      kind == "socks5"
+    end
+
+    DIRECT = new("direct")
+  end
+
+  @@upstream_rules : Array(UpstreamRule) = [] of UpstreamRule
+  # Patterns compiled once per assignment, paired with their rule — the proxy resolves a route
+  # per dial, so the glob/suffix decision must not be re-derived there.
+  @@upstream_rules_compiled : Array({HostPattern::Compiled, UpstreamRule}) = [] of {HostPattern::Compiled, UpstreamRule}
+
+  def self.upstream_rules : Array(UpstreamRule)
+    @@upstream_rules
+  end
+
+  def self.upstream_rules=(rules : Array(UpstreamRule)) : Array(UpstreamRule)
+    @@upstream_rules = rules
+    @@upstream_rules_compiled = rules.map { |r| {HostPattern::Compiled.new(r.host), r} }
+    rules
+  end
+
+  # The first rule matching `dest_host`, or nil when the table is empty / nothing matches
+  # (the caller then falls back to the legacy scalar). Order is significant.
+  def self.upstream_rule_for(dest_host : String) : UpstreamRule?
+    return nil if @@upstream_rules_compiled.empty?
+    bare = HostPattern.bare(dest_host.downcase)
+    @@upstream_rules_compiled.find { |(pattern, _)| pattern.matches_bare?(bare) }.try(&.[1])
+  end
+
+  # How to reach `dest_host`. Precedence, highest first:
+  #
+  #   1. the PROJECT upstream override (net.upstream_proxy) — an explicit per-project pin,
+  #      unchanged from before rules existed, so an upgrade can't reroute a pinned project;
+  #   2. the rule table (first host match);
+  #   3. the global `network.upstream_proxy` scalar — the implicit catch-all;
+  #   4. direct.
+  #
+  # A project override deliberately bypasses the table wholesale: "this project goes through
+  # this proxy, period". Per-project RULES are a separate change (#440).
+  def self.upstream_route(dest_host : String) : UpstreamRoute
+    if pinned = project_upstream_proxy
+      # An explicit project "" means direct and must beat a non-blank global (the same
+      # nil-vs-empty distinction effective_upstream_proxy relies on).
+      return UpstreamRoute::DIRECT if pinned.strip.empty?
+      return http_route(pinned) || UpstreamRoute::DIRECT
+    end
+    if rule = upstream_rule_for(dest_host)
+      return rule_route(rule)
+    end
+    http_route(upstream_proxy) || UpstreamRoute::DIRECT
+  end
+
+  # A rule turned into a route. An unparseable/blank addr degrades to DIRECT rather than
+  # failing every dial for the host: the save-time validator rejects such a rule, so reaching
+  # here means a hand-edited file, and refusing to connect at all would be a worse outcome
+  # than ignoring one bad line (which the log records via upstream_rule_error at load).
+  private def self.rule_route(rule : UpstreamRule) : UpstreamRoute
+    return UpstreamRoute::DIRECT if rule.direct?
+    addr = proxy_addr(rule.addr, default_port: rule.socks5? ? DEFAULT_SOCKS_PORT : DEFAULT_HTTP_PROXY_PORT)
+    return UpstreamRoute::DIRECT unless addr
+    UpstreamRoute.new(rule.kind, addr[0], addr[1], rule.username, rule.password)
+  end
+
+  # An "host:port" string as an unauthenticated HTTP-proxy route, or nil when blank/unparseable.
+  private def self.http_route(value : String) : UpstreamRoute?
+    addr = proxy_addr(value, default_port: DEFAULT_HTTP_PROXY_PORT)
+    addr ? UpstreamRoute.new("http", addr[0], addr[1]) : nil
+  end
+
+  # Tolerant parse: entries missing host/kind are dropped, an unknown kind is dropped (rather
+  # than silently treated as "direct", which would quietly disable an intended proxy), and a
+  # non-array node keeps the current value. Mirrors parse_oast_providers' robustness.
+  private def self.parse_upstream_rules(node : JSON::Any?) : Array(UpstreamRule)
+    arr = node.try(&.as_a?)
+    return upstream_rules unless arr
+    out = [] of UpstreamRule
+    arr.each do |e|
+      next unless o = e.as_h?
+      host = o["host"]?.try(&.as_s?).try(&.strip)
+      kind = o["kind"]?.try(&.as_s?).try(&.strip.downcase)
+      next if host.nil? || host.empty? || kind.nil? || !UPSTREAM_KINDS.includes?(kind)
+      out << UpstreamRule.new(
+        host, kind,
+        o["addr"]?.try(&.as_s?).try(&.strip) || "",
+        o["username"]?.try(&.as_s?) || "",
+        o["password_env"]?.try(&.as_s?).try(&.strip) || "",
+      )
+    end
+    out
+  end
+
+  # Omit when empty so an untouched install never writes "upstream_rules": [].
+  private def self.serialize_upstream_rules(j : JSON::Builder) : Nil
+    return if upstream_rules.empty?
+    j.field "upstream_rules" do
+      j.array do
+        upstream_rules.each do |r|
+          j.object do
+            j.field "host", r.host
+            j.field "kind", r.kind
+            j.field "addr", r.addr unless r.addr.empty?
+            j.field "username", r.username unless r.username.empty?
+            j.field "password_env", r.password_env unless r.password_env.empty?
+          end
+        end
+      end
+    end
+  end
+
+  # nil if `rule` is usable; an error message otherwise. A non-direct rule needs an address,
+  # and its port must parse — a typo there would otherwise resolve to the default port and
+  # fail every dial for the host, far from the mistake (same reasoning as
+  # upstream_proxy_port_error, which this reuses for the port check).
+  def self.upstream_rule_error(rule : UpstreamRule) : String?
+    return "settings: upstream rule needs a host pattern" if rule.host.strip.empty?
+    return "settings: upstream rule kind must be one of #{UPSTREAM_KINDS.join(", ")}" unless UPSTREAM_KINDS.includes?(rule.kind)
+    if rule.direct?
+      # A direct rule carrying an address/credentials is a sign the operator meant http/socks5;
+      # accepting it silently would route the host DIRECT and look like the rule did nothing.
+      return "settings: a direct rule takes no address" unless rule.addr.strip.empty?
+      return nil
+    end
+    return "settings: #{rule.kind} rule needs an address (host:port)" if rule.addr.strip.empty?
+    if err = upstream_proxy_port_error(rule.addr)
+      return err
+    end
+    return "settings: upstream rule password_env is an environment variable NAME, not a value" if rule.password_env.includes?('$')
+    nil
+  end
+end


### PR DESCRIPTION
Part of #434 (stays open — see **Still open** below).

> **Stacked on #443.** Base is `hahwul/tls-passthrough`, because both PRs touch `settings/network.cr` and this one builds on `Gori::HostPattern` extracted there. GitHub will retarget to `main` once #443 merges. Review #443 first.

## Problem

The entire outbound path was configured by **one string**, `Settings.upstream_proxy`. Three consequences, all closed here:

1. **No per-destination routing.** "Route `*.corp.internal` through the internal proxy, everything else direct" was inexpressible, and there was no `no_proxy`-style exception list either. The only granularity was global vs. per-project — but a project is usually *one* engagement spanning both internal and external hosts.
2. **No upstream proxy authentication.** `dial_via_proxy` never emitted `Proxy-Authorization` from any code path, so gori simply **could not be used** behind an authenticating corporate proxy. This is the one item where a missing setting was a hard block rather than an inconvenience.
3. **No SOCKS.** `rg -i socks src/` → 0 hits. `ssh -D`, Tor, and jump-host workflows were impossible.

## Change

`upstream_rules` is an **ordered** table, first match wins, sharing the host-pattern dialect with scope host rules (`Gori::HostPattern`, extracted in #443) so a pattern means one thing everywhere. A `direct` rule is the mechanism for carving an exception out of a broader proxy rule above it.

```json
{
  "upstream_rules": [
    { "host": "intranet.corp.internal", "kind": "direct" },
    { "host": "*.corp.internal", "kind": "http", "addr": "proxy.corp.internal:3128",
      "username": "alice", "password_env": "CORP_PROXY_PASS" },
    { "host": "*.onion", "kind": "socks5", "addr": "127.0.0.1:9050" }
  ]
}
```

**One decision point.** `Settings.upstream_route` folds the project pin, the table and the legacy scalar into a single value, so `Upstream.dial` branches once instead of holding three rules that can disagree. Precedence keeps existing installs byte-identical: a project `net.upstream_proxy` pin still wins outright → table → global scalar → direct. An empty table serializes to nothing and behaves exactly as before.

**Credentials are never written to `settings.json`.** A rule stores the username and `password_env` — the *name* of an OS environment variable — and the password is read from the environment at dial time (so `export` takes effect without a restart).

gori's own `env` section is deliberately **not** the mechanism, and this is worth stating because it was the obvious candidate: those variables live in `settings.json` in plaintext, so resolving through them would put the secret in the file by another route and defeat sharing or exporting a config (#439). A `$`-bearing `password_env` is rejected, because that spelling means the operator expected the wrong mechanism.

**CR/LF is stripped from credentials** before they reach the CONNECT head. These values come from `settings.json` and the OS environment, neither validated for wire-safety anywhere else, and a bare CRLF there would inject a header line into gori's own request — the self-inflicted smuggling shape of #403.

**SOCKS5** is RFC 1928 + RFC 1929. A hostname target is sent as `ATYP DOMAIN` so the *proxy* resolves it (`socks5h`), which is what makes Tor and an otherwise unreachable network work at all; gori does not resolve names on the dial path. The reply's `BND.ADDR` is drained by its own address type — otherwise the socket would be handed back mid-reply and the origin stream would start desynced.

## Verification

`crystal spec`: **4456 examples, 0 failures**. ameba on the touched files: 3 findings, identical to the `main` baseline for the same files (the new file contributes none).

23 new specs. Proxy auth and SOCKS5 are asserted **end-to-end against fake servers that report the bytes gori actually emitted**, not by mocking the decision:

- `Proxy-Authorization: Basic …` present with credentials, absent without;
- CR/LF in either credential half does **not** produce an injected header line;
- `ATYP` selection for hostname / IPv4 / bracketed-IPv6 targets, with the IPv6 case checked as 16 raw bytes;
- the RFC 1929 exchange, a credential rejection, and `0xFF` "no acceptable methods" both failing the dial.

Plus rule ordering, the direct-exception carve-out, per-kind default ports (8080 / 1080), scalar fallback, the project pin including its explicit-empty-means-direct case, environment resolution at route time (and the credential vanishing when the variable is unset), and a malformed rule degrading to direct rather than failing every dial.

## Reader's note on one odd line

`socks5_ipv6_bytes` uses `Pointer(LibC::SockaddrIn6)` rather than the `LibC::SockaddrIn6*` sigil. The sigil form placed directly after a multi-line `if … end` in the same method makes the Crystal parser report `can't define def inside def` at the *next* `def`. The `Pointer()` spelling is equivalent and parses; it is not a stylistic preference.

## Still open on #434

- **A TUI editor for the table.** Rules are configured with `gori settings --edit` and documented; a five-field-per-row editor needs its own overlay (a new `OverlayKind`, its dispatch fixtures, and the `on_close` seam), which is a separate change rather than a tail of this one.
- **TLS client certificates**, the fourth gap in #434. They need the `{verify, alpn}` TLS context cache key widened (`upstream.cr`), which #437 also touches — flagged in #434's comment so the two land on one cache key rather than one silently no-op'ing.

## Docs

`reference/config.md` (+ `.ko`): a full `upstream_rules` section with the key table, the credential rationale, the `socks5h` note, and the precedence table.

https://claude.ai/code/session_017X5VpbYNqcLneDkJkYYm1R