### PR TITLE
feat(proxy): per-destination outbound TLS — client certificates, protocol floor, ciphers

### DIFF
--- a/docs/content/reference/config.ko.md
+++ b/docs/content/reference/config.ko.md
@@ -115,6 +115,45 @@ CLI `--listen` / `--port`는 현재 프로세스에 한해서만 이 값들을 �
 
 규칙은 [호스트 오버라이드](#hostname_overrides) 적용 **이전의 원래 호스트명**에 대해 매칭됩니다 — 오버라이드는 어느 IP로 접속할지만 바꿉니다.
 
+### outbound_tls
+
+gori가 **거는** 연결의 목적지별 TLS 정책입니다 — 제시할 클라이언트 인증서, 그리고 협상할 프로토콜/암호군 하한. 순서가 있고 첫 일치가 이기며, 호스트 패턴 문법은 동일합니다. 편집은 `gori settings --edit`.
+
+[`upstream_rules`](#upstream_rules)와 의도적으로 분리된 테이블입니다. 둘 다 목적지 호스트로 키를 잡지만 답하는 질문이 다르고, 합치면 가장 흔한 형태를 표현할 수 없게 됩니다 — "전부 사내 프록시 경유 + 한 호스트만 클라이언트 인증서"를 쓰려면 그 호스트 행에 프록시 주소를 중복해야 합니다. 하나의 first-match 테이블은 호스트당 한 행만 적용할 수 있기 때문입니다.
+
+```json
+{
+  "outbound_tls": [
+    {
+      "host": "mtls.example.com",
+      "client_cert": "/home/you/certs/client.crt.pem",
+      "client_key": "/home/you/certs/client.key.pem"
+    },
+    {
+      "host": "legacy-appliance.internal",
+      "min_version": "tls1.0",
+      "ciphers": "ALL:@SECLEVEL=0",
+      "permissive": true
+    }
+  ]
+}
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `host` | string | 호스트 패턴. `upstream_rules`와 동일하며 `*`는 catch-all |
+| `client_cert` | string | 제시할 PEM 인증서 체인 경로(상호 TLS) |
+| `client_key` | string | 대응하는 PEM 개인키 경로. 둘 다 있어야 하거나 둘 다 없어야 합니다 |
+| `min_version` | string | 협상할 최저 프로토콜: `tls1.0`, `tls1.1`, `tls1.2`, `tls1.3`. 비우면 기본값 |
+| `ciphers` | string | TLS 1.2 이하용 OpenSSL 암호군 목록. 비우면 기본값 |
+| `permissive` | bool | 망가진/레거시 서버 상대: OpenSSL security level을 0으로 낮추고 재협상을 허용합니다 |
+
+**`min_version`이 필요한 이유.** gori는 기본 상태로 TLS 1.0/1.1만 지원하는 장비에 접근할 수 없고, `verify_upstream: false`로도 해결되지 않습니다 — 그건 인증서 *검증*을 끄는 것이지 프로토콜 협상과 무관합니다. Crystal의 TLS 클라이언트 컨텍스트가 생성자에서 TLS 1.0과 1.1을 비활성화하므로, 여기서 하한을 낮추는 것이 유일한 방법입니다. 레거시 장비는 보통 `permissive: true`도 함께 필요합니다 — 배포판이 OpenSSL을 옛 암호군을 아예 거부하는 security level로 빌드하기 때문입니다.
+
+**인증서는 인라인 값이 아니라 파일 경로입니다.** 개인키는 공유·내보내기 대상인 `settings.json`에 들어갈 것이 아닙니다([#439](https://github.com/hahwul/gori/issues/439)). 패스프레이즈가 걸린 키는 저장 시 거부됩니다 — OpenSSL이 TUI가 점유한 터미널에 패스프레이즈를 물어보므로, gori가 그냥 멈춘 것처럼 보이게 됩니다. `openssl pkey -in key.pem -out plain.pem`으로 먼저 복호화하세요.
+
+정책은 SNI 오버라이드가 아니라 **실제 접속한 호스트**로 조회합니다 — 인증서와 프로토콜 하한은 실제로 대화하는 장비에 속하는 반면, Repeater의 SNI 필드는 도메인 프론팅·vhost 테스트를 위해 의도적으로 이름을 다르게 보내는 기능입니다.
+
 ### layout {#layout}
 
 영역별 TUI 레이아웃 환경설정 (커맨드 팔레트 → **Settings: Layout**). 두 값 모두 공장 기본값이면 생략됩니다.

--- a/docs/content/reference/config.md
+++ b/docs/content/reference/config.md
@@ -115,6 +115,45 @@ Precedence, highest first:
 
 A rule is matched against the **original** hostname, before any [host override](#hostname_overrides) is applied — an override only changes which IP is dialled.
 
+### outbound_tls
+
+Per-destination TLS policy for the connections gori **makes**: a client certificate to present, and the protocol/cipher floor to negotiate with. Ordered, first match wins, same host-pattern dialect. Edit with `gori settings --edit`.
+
+This is a separate table from [`upstream_rules`](#upstream_rules) on purpose. Both are keyed by destination host, but they answer different questions, and folding them together would make the common shape inexpressible — "everything through the corporate proxy, plus a client certificate for one host" would need the proxy address duplicated onto that host's row, because one first-match table can only apply a single row per host.
+
+```json
+{
+  "outbound_tls": [
+    {
+      "host": "mtls.example.com",
+      "client_cert": "/home/you/certs/client.crt.pem",
+      "client_key": "/home/you/certs/client.key.pem"
+    },
+    {
+      "host": "legacy-appliance.internal",
+      "min_version": "tls1.0",
+      "ciphers": "ALL:@SECLEVEL=0",
+      "permissive": true
+    }
+  ]
+}
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `host` | string | Host pattern, as in `upstream_rules`. `*` is the catch-all |
+| `client_cert` | string | Path to a PEM certificate chain to present (mutual TLS) |
+| `client_key` | string | Path to the matching PEM private key. Both halves are required, or neither |
+| `min_version` | string | Lowest protocol to negotiate: `tls1.0`, `tls1.1`, `tls1.2`, `tls1.3`. Empty leaves the default |
+| `ciphers` | string | OpenSSL cipher list for TLS 1.2 and below. Empty leaves the default |
+| `permissive` | bool | Talk to broken/legacy servers: drops the OpenSSL security level to 0 and allows renegotiation |
+
+**Why `min_version` exists.** gori cannot reach a TLS 1.0/1.1-only appliance out of the box, and `verify_upstream: false` does not help — that turns off certificate *verification*, not protocol negotiation. Crystal's TLS client context disables TLS 1.0 and 1.1 in its constructor, so lowering the floor here is the only way. A legacy appliance usually needs `permissive: true` as well, because distributions build OpenSSL at a security level that rejects the old cipher suites outright.
+
+**Certificates are file paths, not inline material.** A private key does not belong in `settings.json`, which is shareable and exportable ([#439](https://github.com/hahwul/gori/issues/439)). A passphrase-protected key is rejected at save time: OpenSSL would prompt for the passphrase on the terminal the TUI owns, so gori would simply appear to hang. Decrypt it first with `openssl pkey -in key.pem -out plain.pem`.
+
+The policy is looked up on the **dialled** host, not on an SNI override — a certificate and a protocol floor belong to the machine actually being talked to, whereas the Repeater's SNI field deliberately lies about the name for domain-fronting and vhost tests.
+
 ### layout
 
 Per-area TUI layout prefs (command palette → **Settings: Layout**). Omitted when both values are factory defaults.

--- a/spec/proxy/outbound_tls_spec.cr
+++ b/spec/proxy/outbound_tls_spec.cr
@@ -1,0 +1,267 @@
+require "../spec_helper"
+require "socket"
+require "openssl"
+require "file_utils"
+
+include Gori::Proxy::Tls
+
+private def reset_outbound_tls : Nil
+  Gori::Settings.outbound_tls = [] of Gori::Settings::OutboundTlsRule
+end
+
+private def tls_rule(host : String, cert : String = "", key : String = "",
+                     min_version : String = "", ciphers : String = "",
+                     permissive : Bool = false) : Gori::Settings::OutboundTlsRule
+  Gori::Settings::OutboundTlsRule.new(host, cert, key, min_version, ciphers, permissive)
+end
+
+# Write a self-signed cert + key pair to disk and yield their paths — what a client certificate
+# actually is on this path (PEM files, not inline material).
+private def with_client_cert(&)
+  dir = File.tempname("gori-client-cert")
+  Dir.mkdir_p(dir)
+  cert_path = File.join(dir, "client.crt.pem")
+  key_path = File.join(dir, "client.key.pem")
+  cert, key = CertBuilder.build_root("client.test")
+  cert.write_pem(cert_path)
+  key.write_pem(key_path)
+  begin
+    yield cert_path, key_path
+  ensure
+    FileUtils.rm_rf(dir)
+  end
+end
+
+# A TLS server that ASKS for a client certificate and reports the subject it received, so mutual
+# TLS is asserted by what the server saw rather than by "the handshake didn't blow up".
+#
+# `client_ca` is trusted so a presented certificate verifies; without it OpenSSL checks the
+# client chain against an empty store and aborts the handshake, which would make this helper
+# report a failure for the very case it is meant to observe. VerifyMode::PEER *without*
+# FAIL_IF_NO_PEER_CERT is deliberate: a client that presents nothing must still connect, which
+# is what the control example asserts.
+private def start_mtls_origin(seen : Channel(String), client_ca : String? = nil) : Int32
+  cert, key = CertBuilder.build_root("origin.test")
+  ctx = ContextFactory.server_context(cert, key, advertise_h2: false)
+  ctx.verify_mode = OpenSSL::SSL::VerifyMode::PEER
+  ctx.ca_certificates = client_ca if client_ca
+  server = TCPServer.new("127.0.0.1", 0)
+  port = server.local_address.port
+  spawn do
+    while raw = server.accept?
+      begin
+        ssl = OpenSSL::SSL::Socket::Server.new(raw, ctx, sync_close: true)
+        peer = ssl.peer_certificate
+        seen.send(peer ? peer.subject.to_a.map { |e| "#{e[0]}=#{e[1]}" }.join(",") : "(none)")
+        ssl << "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nhi"
+        ssl.flush
+        ssl.close
+      rescue
+        seen.send("(handshake failed)") rescue nil
+      end
+    end
+  end
+  port
+end
+
+describe "outbound TLS policy" do
+  describe ".outbound_tls_for" do
+    it "returns the first matching rule, else the all-defaults policy" do
+      Gori::Settings.outbound_tls = [
+        tls_rule("api.acme.test", min_version: "tls1.0"),
+        tls_rule("*", min_version: "tls1.2"),
+      ]
+      Gori::Settings.outbound_tls_for("api.acme.test").min_version.should eq("tls1.0")
+      Gori::Settings.outbound_tls_for("other.test").min_version.should eq("tls1.2")
+
+      reset_outbound_tls
+      Gori::Settings.outbound_tls_for("anything.test").default?.should be_true
+    ensure
+      reset_outbound_tls
+    end
+
+    it "covers subdomains and is case-insensitive (shared host dialect)" do
+      Gori::Settings.outbound_tls = [tls_rule("Acme.TEST", min_version: "tls1.1")]
+      Gori::Settings.outbound_tls_for("api.acme.test").min_version.should eq("tls1.1")
+      Gori::Settings.outbound_tls_for("acme.test.evil.test").default?.should be_true
+    ensure
+      reset_outbound_tls
+    end
+  end
+
+  # This is the trap both #434 and #437 flagged: the TLS context cache was keyed on
+  # {verify, alpn} only. Any policy field left out of the key means the FIRST context built
+  # wins for the whole process — a client certificate would be presented to hosts it was never
+  # configured for, and a settings change would silently do nothing.
+  describe "context cache key" do
+    it "gives every distinct policy its own key, and shares ONE key for the defaults" do
+      keys = [
+        tls_rule("a", cert: "/c.pem", key: "/k.pem"),
+        tls_rule("a", cert: "/other.pem", key: "/k.pem"),
+        tls_rule("a", min_version: "tls1.0"),
+        tls_rule("a", min_version: "tls1.3"),
+        tls_rule("a", ciphers: "DEFAULT@SECLEVEL=0"),
+        tls_rule("a", permissive: true),
+      ].map(&.cache_key)
+
+      keys.uniq.size.should eq(keys.size) # no two distinct policies collide
+      keys.should_not contain("")         # every non-default policy is distinguishable
+
+      # All-defaults policies share the empty key, so the common case keeps one shared context.
+      tls_rule("a").cache_key.should eq("")
+      tls_rule("b").cache_key.should eq("")
+      Gori::Settings::DEFAULT_OUTBOUND_TLS.cache_key.should eq("")
+    end
+
+    # Concatenating fields without a separator would let two different policies produce one
+    # key (a cert path ending exactly where the next field begins).
+    it "does not let differently-split fields collide into one key" do
+      tls_rule("a", cert: "/ab", key: "/c").cache_key
+        .should_not eq(tls_rule("a", cert: "/a", key: "b/c").cache_key)
+    end
+  end
+
+  describe "client certificates (mutual TLS)" do
+    it "presents the configured certificate to a server that asks for one" do
+      seen = Channel(String).new(2)
+      with_client_cert do |cert, key|
+        port = start_mtls_origin(seen, client_ca: cert)
+        Gori::Settings.outbound_tls = [tls_rule("localhost", cert: cert, key: key)]
+        sock = Gori::Proxy::Upstream.dial_tls("localhost", port, verify: false)
+        sock.should_not be_nil
+        seen.receive.should contain("client.test") # the origin saw OUR certificate
+        sock.try(&.close) rescue nil
+      end
+    ensure
+      reset_outbound_tls
+    end
+
+    # The control: same origin, same dial, no rule — nothing is presented. Without this, the
+    # test above could pass on a server that happened to report something.
+    it "presents nothing when no rule covers the host" do
+      seen = Channel(String).new(2)
+      port = start_mtls_origin(seen)
+      reset_outbound_tls
+      sock = Gori::Proxy::Upstream.dial_tls("localhost", port, verify: false)
+      sock.should_not be_nil
+      seen.receive.should eq("(none)")
+      sock.try(&.close) rescue nil
+    ensure
+      reset_outbound_tls
+    end
+
+    # The consequence of the cache-key fix, stated as behaviour: a certificate configured for
+    # one host must not leak to another host dialed later in the same process.
+    it "does not leak one host's certificate to a host with no rule" do
+      seen = Channel(String).new(4)
+      with_client_cert do |cert, key|
+        port = start_mtls_origin(seen, client_ca: cert)
+        # 127.0.0.1 and localhost are the same origin but different rule keys.
+        Gori::Settings.outbound_tls = [tls_rule("localhost", cert: cert, key: key)]
+        a = Gori::Proxy::Upstream.dial_tls("localhost", port, verify: false)
+        seen.receive.should contain("client.test")
+        a.try(&.close) rescue nil
+
+        b = Gori::Proxy::Upstream.dial_tls("127.0.0.1", port, verify: false)
+        seen.receive.should eq("(none)") # a cached context would have re-presented the cert
+        b.try(&.close) rescue nil
+      end
+    ensure
+      reset_outbound_tls
+    end
+  end
+
+  describe "protocol floor" do
+    # Crystal's Context::Client.new adds NO_TLS_V1 | NO_TLS_V1_1, which is exactly why a
+    # legacy appliance was unreachable at ANY setting before this. Asserted against a real
+    # TLS 1.0-only server, so it pins the behaviour rather than the flag arithmetic.
+    it "reaches a TLS 1.0-only origin only when the floor is lowered" do
+      cert, key = CertBuilder.build_root("legacy.test")
+      ctx = ContextFactory.server_context(cert, key, advertise_h2: false)
+      ctx.security_level = 0
+      ctx.ciphers = "ALL:@SECLEVEL=0"
+      # Force TLS 1.0 only: forbid everything above it.
+      ctx.add_options(OpenSSL::SSL::Options.flags(NO_TLS_V1_2, NO_TLS_V1_3))
+      ctx.remove_options(OpenSSL::SSL::Options.flags(NO_TLS_V1, NO_TLS_V1_1))
+      server = TCPServer.new("127.0.0.1", 0)
+      port = server.local_address.port
+      spawn do
+        while raw = server.accept?
+          begin
+            ssl = OpenSSL::SSL::Socket::Server.new(raw, ctx, sync_close: true)
+            ssl << "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nhi"
+            ssl.flush
+            ssl.close
+          rescue
+          end
+        end
+      end
+
+      begin
+        # Default policy: the constructor's NO_TLS_V1/NO_TLS_V1_1 makes this unreachable.
+        reset_outbound_tls
+        Gori::Proxy::Upstream.dial_tls("localhost", port, verify: false).should be_nil
+
+        # Floor lowered + legacy ciphers allowed: it connects.
+        Gori::Settings.outbound_tls = [
+          tls_rule("localhost", min_version: "tls1.0", ciphers: "ALL:@SECLEVEL=0", permissive: true),
+        ]
+        sock = Gori::Proxy::Upstream.dial_tls("localhost", port, verify: false)
+        sock.should_not be_nil
+        sock.try(&.close) rescue nil
+      ensure
+        server.close rescue nil
+        reset_outbound_tls
+      end
+    end
+  end
+
+  describe ".outbound_tls_error" do
+    it "accepts a rule with neither half of a certificate pair" do
+      Gori::Settings.outbound_tls_error(tls_rule("a.test", min_version: "tls1.2")).should be_nil
+    end
+
+    it "accepts a readable cert/key pair" do
+      with_client_cert do |cert, key|
+        Gori::Settings.outbound_tls_error(tls_rule("a.test", cert: cert, key: key)).should be_nil
+      end
+    end
+
+    it "rejects half a pair, since one half alone can never complete a handshake" do
+      Gori::Settings.outbound_tls_error(tls_rule("a.test", cert: "/tmp/c.pem")).to_s
+        .should contain("BOTH client_cert and client_key")
+      Gori::Settings.outbound_tls_error(tls_rule("a.test", key: "/tmp/k.pem")).to_s
+        .should contain("BOTH client_cert and client_key")
+    end
+
+    it "rejects an unreadable file at save time rather than at the first dial" do
+      Gori::Settings.outbound_tls_error(tls_rule("a.test", cert: "/nope/c.pem", key: "/nope/k.pem")).to_s
+        .should contain("client_cert not readable")
+    end
+
+    it "rejects a missing host and an unknown min_version" do
+      Gori::Settings.outbound_tls_error(tls_rule(" ")).to_s.should contain("host pattern")
+      Gori::Settings.outbound_tls_error(tls_rule("a.test", min_version: "ssl3")).to_s
+        .should contain("min_version must be one of")
+    end
+
+    # An encrypted key makes OpenSSL prompt for a passphrase on the terminal the TUI owns —
+    # the process would look hung with no visible prompt.
+    it "rejects a passphrase-protected key, naming the fix" do
+      with_client_cert do |cert, key|
+        File.write(key, "-----BEGIN ENCRYPTED PRIVATE KEY-----\nAAAA\n-----END ENCRYPTED PRIVATE KEY-----\n")
+        msg = Gori::Settings.outbound_tls_error(tls_rule("a.test", cert: cert, key: key)).to_s
+        msg.should contain("passphrase-protected")
+        msg.should contain("openssl pkey")
+      end
+    end
+
+    it "rejects a traditional-format key carrying the legacy Proc-Type header" do
+      with_client_cert do |cert, key|
+        File.write(key, "-----BEGIN RSA PRIVATE KEY-----\nProc-Type: 4,ENCRYPTED\nDEK-Info: AES-256-CBC,00\n\nAAAA\n")
+        Gori::Settings.outbound_tls_error(tls_rule("a.test", cert: cert, key: key)).to_s
+          .should contain("passphrase-protected")
+      end
+    end
+  end
+end

--- a/src/gori/proxy/upstream.cr
+++ b/src/gori/proxy/upstream.cr
@@ -406,13 +406,20 @@ module Gori::Proxy
     # `alpn` offers an ALPN protocol (e.g. "h2"); nil leaves it unset so the
     # origin answers HTTP/1.1. The caller checks `ssl.alpn_protocol` for what was
     # actually negotiated.
-    # Shared client SSL contexts keyed by {verify, alpn}. SNI + hostname
+    # Shared client SSL contexts keyed by {verify, alpn, outbound-TLS policy}. SNI + hostname
     # verification are applied per-CONNECTION on the SSL socket (the `hostname:`
     # arg below), so the context — which only carries verify_mode + ALPN — is safe
     # to share. This avoids a fresh SSL_CTX alloc + set_default_verify_paths (system
     # CA load) + GC finalizer on EVERY flow. Single-threaded fibers → the lazy ||=
     # is race-free.
-    @@tls_contexts = {} of {Bool, String?} => OpenSSL::SSL::Context::Client
+    #
+    # The THIRD key element is load-bearing, not cosmetic. Anything that mutates the context
+    # — a per-host client certificate, a protocol floor, a cipher list — must appear in the
+    # key or the first context built wins for the whole process: a client certificate would be
+    # presented to hosts it was never configured for, and a settings change would silently do
+    # nothing. `OutboundTlsRule#cache_key` is that identity, and it is "" for the all-defaults
+    # policy so the common case still shares ONE context.
+    @@tls_contexts = {} of {Bool, String?, String} => OpenSSL::SSL::Context::Client
 
     # Standard system CA locations (the same list Go's crypto/x509 probes). A single
     # bundle FILE carries every root, so files are tried first; the DIRS are the
@@ -528,8 +535,9 @@ module Gori::Proxy
       "set SSL_CERT_FILE=/path/to/ca-bundle.crt or run with --insecure-upstream"
     end
 
-    private def self.client_context(verify : Bool, alpn : String?) : OpenSSL::SSL::Context::Client
-      @@tls_contexts[{verify, alpn}] ||= begin
+    private def self.client_context(verify : Bool, alpn : String?,
+                                    tls : Settings::OutboundTlsRule = Settings::DEFAULT_OUTBOUND_TLS) : OpenSSL::SSL::Context::Client
+      @@tls_contexts[{verify, alpn, tls.cache_key}] ||= begin
         ctx = OpenSSL::SSL::Context::Client.new
         if verify
           apply_system_trust(ctx) unless env_ca_override?
@@ -537,7 +545,50 @@ module Gori::Proxy
           ctx.verify_mode = OpenSSL::SSL::VerifyMode::NONE
         end
         ctx.alpn_protocol = alpn if alpn
+        apply_outbound_tls(ctx, tls)
         ctx
+      end
+    end
+
+    # Apply one destination's outbound-TLS policy to a fresh context: the client certificate to
+    # present, the protocol floor, the cipher list, and the permissive switch.
+    #
+    # Failures here are DELIBERATELY not swallowed. A client certificate that cannot be loaded,
+    # or a cipher string OpenSSL rejects, must not degrade into a silent plaintext-policy
+    # connection that then fails at the origin — the settings validator checks these at save
+    # time, so reaching a raise means a hand-edited file or a file removed since, and the
+    # dial_tls_result caller turns it into a recorded Tls error the operator can see.
+    private def self.apply_outbound_tls(ctx : OpenSSL::SSL::Context::Client,
+                                        tls : Settings::OutboundTlsRule) : Nil
+      return if tls.default?
+      if tls.client_auth?
+        ctx.certificate_chain = tls.client_cert
+        ctx.private_key = tls.client_key
+      end
+      apply_tls_floor(ctx, tls.min_version)
+      # Lower the security level BEFORE the cipher list: on a distribution built at
+      # SECLEVEL=2 the legacy suites a caller names here are rejected outright, so setting
+      # ciphers first would raise on exactly the legacy origin this exists to reach.
+      ctx.security_level = 0 if tls.permissive
+      ctx.ciphers = tls.ciphers unless tls.ciphers.empty?
+      # Some legacy appliances renegotiate; Crystal's constructor forbids it by default.
+      ctx.remove_options(OpenSSL::SSL::Options::NO_RENEGOTIATION) if tls.permissive
+    end
+
+    # Move the protocol floor. Crystal's Context::Client.new adds NO_TLS_V1 | NO_TLS_V1_1, so
+    # anything below 1.2 is opt-in by REMOVING those options — that constructor default is why
+    # a TLS 1.0-only appliance was previously unreachable at any setting.
+    private def self.apply_tls_floor(ctx : OpenSSL::SSL::Context::Client, min_version : String) : Nil
+      case min_version
+      when "tls1.0"
+        ctx.remove_options(OpenSSL::SSL::Options.flags(NO_TLS_V1, NO_TLS_V1_1))
+      when "tls1.1"
+        ctx.remove_options(OpenSSL::SSL::Options::NO_TLS_V1_1)
+        ctx.add_options(OpenSSL::SSL::Options::NO_TLS_V1)
+      when "tls1.2"
+        ctx.add_options(OpenSSL::SSL::Options.flags(NO_TLS_V1, NO_TLS_V1_1))
+      when "tls1.3"
+        ctx.add_options(OpenSSL::SSL::Options.flags(NO_TLS_V1, NO_TLS_V1_1, NO_TLS_V1_2))
       end
     end
 
@@ -571,7 +622,12 @@ module Gori::Proxy
                              *, overrides : Gori::HostOverrides? = nil) : {OpenSSL::SSL::Socket::Client?, TlsDialError?}
       tcp = dial(host, port, connect_timeout, io_timeout, overrides: overrides)
       return {nil, TlsDialError::Connect} unless tcp
-      ssl = OpenSSL::SSL::Socket::Client.new(tcp, context: client_context(verify, alpn), sync_close: true, hostname: sni || host)
+      # The outbound-TLS policy is looked up on the DIALED host, not `sni`: a client
+      # certificate and a protocol floor belong to the machine we are actually talking to,
+      # whereas `sni` deliberately lies about the name for domain-fronting / vhost tests.
+      tls_policy = Settings.outbound_tls_for(host)
+      ssl = OpenSSL::SSL::Socket::Client.new(tcp, context: client_context(verify, alpn, tls_policy),
+        sync_close: true, hostname: sni || host)
       ssl.sync = true
       {ssl, nil}
     rescue

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -2,6 +2,7 @@ require "json"
 require "./paths"
 require "./settings/network"
 require "./settings/upstream_rules"
+require "./settings/outbound_tls"
 require "./settings/env"
 require "./settings/scan_rules"
 require "./settings/oast_providers"
@@ -81,6 +82,7 @@ module Gori
         self.editor_markdown = load_bool(ed, "markdown", editor_markdown)
       end
       self.upstream_rules = parse_upstream_rules(root["upstream_rules"]?)
+      self.outbound_tls = parse_outbound_tls(root["outbound_tls"]?)
       self.tab_prefs = parse_tab_prefs(root["tabs"]?)
       self.hostname_overrides = parse_hostname_overrides(root["hostname_overrides"]?)
       parse_env(root["env"]?)
@@ -216,6 +218,7 @@ module Gori
           serialize_update(j)
           serialize_network(j)
           serialize_upstream_rules(j)
+          serialize_outbound_tls(j)
           serialize_editor(j)
           serialize_tabs(j)
           serialize_hostname_overrides(j)

--- a/src/gori/settings/outbound_tls.cr
+++ b/src/gori/settings/outbound_tls.cr
@@ -1,0 +1,172 @@
+require "json"
+require "../host_pattern"
+
+# OUTBOUND TLS section (settings.json "outbound_tls"): per-destination TLS policy for the
+# connections gori MAKES — a client certificate to present, and the protocol/cipher floor to
+# negotiate with. See settings.cr for the load/save/serialize orchestration.
+#
+# Deliberately a SEPARATE table from `upstream_rules` rather than more columns on it. Both are
+# keyed by destination host pattern, but they answer different questions ("how do I reach this
+# host" vs "how do I speak TLS to it") and both are FIRST-MATCH ordered lists. Folding them
+# together makes the common shape inexpressible: "everything through the corporate proxy, plus
+# a client certificate for one host" would need the proxy address duplicated onto that host's
+# row, because a single first-match table can only apply one row per host.
+module Gori::Settings
+  # Protocol floors, lowest first. "" = leave OpenSSL/Crystal's default alone.
+  #
+  # This matters more than it looks: Crystal's OpenSSL::SSL::Context::Client.new adds
+  # NO_TLS_V1 | NO_TLS_V1_1 in its constructor, so gori CANNOT reach a TLS 1.0/1.1-only
+  # appliance out of the box, and `verify_upstream: false` does not help — that turns off
+  # certificate VERIFICATION, not protocol negotiation. Lowering the floor is the only way,
+  # which is why this exists.
+  TLS_VERSIONS = ["tls1.0", "tls1.1", "tls1.2", "tls1.3"]
+
+  # One outbound-TLS rule. `host` is a HostPattern (the dialect shared with scope host rules
+  # and upstream_rules); "*" is the catch-all. First match wins.
+  #
+  # Certificates are FILE PATHS, in PEM, not inline material: a private key does not belong in
+  # settings.json (which is shareable/exportable — #439), and gori already speaks PEM for its
+  # own CA. A PASSPHRASE-PROTECTED key is not supported: OpenSSL would prompt on a terminal
+  # gori has taken over, so outbound_tls_error rejects one at save time instead.
+  record OutboundTlsRule,
+    host : String,
+    client_cert : String = "",
+    client_key : String = "",
+    min_version : String = "",
+    ciphers : String = "",
+    permissive : Bool = false do
+    # Whether this rule asks for mutual TLS. Both halves are required — OpenSSL needs the
+    # chain and the key, and a half-configured pair would fail the handshake with a message
+    # that points at the origin rather than at the settings file.
+    def client_auth? : Bool
+      !client_cert.empty? && !client_key.empty?
+    end
+
+    # True when the rule changes nothing, so the shared default context can be reused.
+    def default? : Bool
+      !client_auth? && min_version.empty? && ciphers.empty? && !permissive
+    end
+
+    # A stable identity for this policy, used as part of the TLS context cache key. Contexts
+    # are shared per distinct policy, so this MUST cover every field that mutates the context —
+    # a field left out here means an edit silently reuses the first context built.
+    # Joined on a NUL escape, which no path or cipher string can contain, so two distinct
+    # policies can never collide into one key. Built with join, not string interpolation:
+    # inside a `record` block body the interpolation form does not compile here.
+    def cache_key : String
+      return "" if default?
+      [client_cert, client_key, min_version, ciphers, permissive.to_s].join('\0')
+    end
+  end
+
+  @@outbound_tls : Array(OutboundTlsRule) = [] of OutboundTlsRule
+  @@outbound_tls_compiled : Array({HostPattern::Compiled, OutboundTlsRule}) = [] of {HostPattern::Compiled, OutboundTlsRule}
+  # The policy used when no rule matches: OpenSSL's defaults, nothing applied.
+  DEFAULT_OUTBOUND_TLS = OutboundTlsRule.new("*")
+
+  def self.outbound_tls : Array(OutboundTlsRule)
+    @@outbound_tls
+  end
+
+  def self.outbound_tls=(rules : Array(OutboundTlsRule)) : Array(OutboundTlsRule)
+    @@outbound_tls = rules
+    @@outbound_tls_compiled = rules.map { |r| {HostPattern::Compiled.new(r.host), r} }
+    rules
+  end
+
+  # The TLS policy for `dest_host` — the first matching rule, else the all-defaults policy.
+  # Called once per TLS dial, so the patterns are precompiled (see the setter above).
+  def self.outbound_tls_for(dest_host : String) : OutboundTlsRule
+    return DEFAULT_OUTBOUND_TLS if @@outbound_tls_compiled.empty?
+    bare = HostPattern.bare(dest_host.downcase)
+    match = @@outbound_tls_compiled.find { |(pattern, _)| pattern.matches_bare?(bare) }
+    match ? match[1] : DEFAULT_OUTBOUND_TLS
+  end
+
+  # Tolerant parse, like every other section: an entry with no host is dropped, an
+  # out-of-range min_version falls back to "" (OpenSSL's default) rather than failing the
+  # load, and a non-array node keeps the current value.
+  private def self.parse_outbound_tls(node : JSON::Any?) : Array(OutboundTlsRule)
+    arr = node.try(&.as_a?)
+    return outbound_tls unless arr
+    out = [] of OutboundTlsRule
+    arr.each do |e|
+      next unless o = e.as_h?
+      host = o["host"]?.try(&.as_s?).try(&.strip)
+      next if host.nil? || host.empty?
+      version = o["min_version"]?.try(&.as_s?).try(&.strip.downcase) || ""
+      version = "" unless TLS_VERSIONS.includes?(version)
+      out << OutboundTlsRule.new(
+        host,
+        o["client_cert"]?.try(&.as_s?).try(&.strip) || "",
+        o["client_key"]?.try(&.as_s?).try(&.strip) || "",
+        version,
+        o["ciphers"]?.try(&.as_s?).try(&.strip) || "",
+        o["permissive"]?.try(&.as_bool?) || false,
+      )
+    end
+    out
+  end
+
+  # Omit when empty so an untouched install never writes "outbound_tls": [].
+  private def self.serialize_outbound_tls(j : JSON::Builder) : Nil
+    return if outbound_tls.empty?
+    j.field "outbound_tls" do
+      j.array do
+        outbound_tls.each do |r|
+          j.object do
+            j.field "host", r.host
+            j.field "client_cert", r.client_cert unless r.client_cert.empty?
+            j.field "client_key", r.client_key unless r.client_key.empty?
+            j.field "min_version", r.min_version unless r.min_version.empty?
+            j.field "ciphers", r.ciphers unless r.ciphers.empty?
+            j.field "permissive", r.permissive if r.permissive
+          end
+        end
+      end
+    end
+  end
+
+  # nil if `rule` is usable; an error message otherwise. Checked at save time so a
+  # half-configured pair or a missing file surfaces here rather than as a handshake failure
+  # that reads like the ORIGIN's fault.
+  def self.outbound_tls_error(rule : OutboundTlsRule) : String?
+    return "settings: outbound TLS rule needs a host pattern" if rule.host.strip.empty?
+    unless rule.min_version.empty? || TLS_VERSIONS.includes?(rule.min_version)
+      return "settings: outbound TLS min_version must be one of #{TLS_VERSIONS.join(", ")}"
+    end
+    cert = rule.client_cert
+    key = rule.client_key
+    if cert.empty? != key.empty?
+      # One half alone can never work, and OpenSSL's error would point at the handshake.
+      return "settings: outbound TLS needs BOTH client_cert and client_key (or neither)"
+    end
+    return nil if cert.empty?
+    return "settings: client_cert not readable: #{cert}" unless file_readable?(cert)
+    return "settings: client_key not readable: #{key}" unless file_readable?(key)
+    # An encrypted key would make OpenSSL prompt for a passphrase on a terminal the TUI owns —
+    # the process would appear to hang with no visible prompt. Refuse it here, where the
+    # message can say what to do, rather than at the first dial.
+    return "settings: client_key is passphrase-protected; decrypt it first (openssl pkey -in #{key} -out key.pem)" if encrypted_key?(key)
+    nil
+  end
+
+  private def self.file_readable?(path : String) : Bool
+    File.file?(path) && File::Info.readable?(path)
+  rescue
+    false
+  end
+
+  # A PEM private key that carries a passphrase: either the PKCS#8 "ENCRYPTED PRIVATE KEY"
+  # header, or a traditional-format key with the legacy `Proc-Type: 4,ENCRYPTED` line. Reads
+  # only the head of the file — enough for both markers, and it avoids pulling a key into
+  # memory just to classify it.
+  private def self.encrypted_key?(path : String) : Bool
+    buf = Bytes.new(4096)
+    n = File.open(path, &.read(buf))
+    head = String.new(buf[0, n])
+    head.includes?("ENCRYPTED PRIVATE KEY") || head.includes?("Proc-Type: 4,ENCRYPTED")
+  rescue
+    false # unreadable was already reported above; never fail the save on a classification error
+  end
+end


### PR DESCRIPTION
Closes #437. Closes the remaining TLS-client-certificate gap from #434.

These land together because both need the **same** fix to the TLS context cache, and either one alone would have silently no-op'd the other — flagged as a shared concern in #434's cross-reference comment.

## The cache key

`@@tls_contexts` was keyed on `{verify, alpn}` only. Contexts are shared per key deliberately (an `SSL_CTX` alloc + system-CA load per flow is expensive), so **any policy field left out of the key means the first context built wins for the process lifetime**: a client certificate would be presented to hosts it was never configured for, and a settings change would appear to do nothing.

The key now carries `OutboundTlsRule#cache_key`, which is `""` for the all-defaults policy so the common case still shares one context.

**The specs for this have teeth, and that was verified rather than assumed.** Control-running with the old two-element key restored, three examples fail: the certificate leak in both directions, and the TLS floor never being applied. A green suite proves nothing on a shared primitive like this, so the negative case was run.

## A separate table, not more columns

`outbound_tls` is its own list rather than fields on `upstream_rules`. Both are keyed by destination host pattern and both are first-match, so folding them makes the common shape inexpressible: *"everything through the corporate proxy, plus a client certificate for one host"* would need the proxy address duplicated onto that host's row, because one first-match table can only apply a single row per host. This resolves the open question #434 raised about where certificates belong.

```json
{
  "outbound_tls": [
    { "host": "mtls.example.com",
      "client_cert": "/certs/client.crt.pem", "client_key": "/certs/client.key.pem" },
    { "host": "legacy-appliance.internal",
      "min_version": "tls1.0", "ciphers": "ALL:@SECLEVEL=0", "permissive": true }
  ]
}
```

## Why `min_version` exists

Crystal's `OpenSSL::SSL::Context::Client.new` adds `NO_TLS_V1 | NO_TLS_V1_1` **in its constructor**. So gori could not reach a TLS 1.0/1.1-only appliance at *any* setting, and `verify_upstream: false` does not help — that disables certificate verification, not protocol negotiation. This is the concrete mechanism behind #437's "legacy targets are unreachable", and lowering the floor means removing those options.

The spec asserts it against a **real TLS 1.0-only server** rather than against the flag arithmetic: the default policy cannot connect, the lowered floor can.

`permissive` is usually needed alongside it, because distributions build OpenSSL at a security level that rejects the old suites outright. Note the ordering in `apply_outbound_tls`: the security level is dropped **before** the cipher list is applied, since the other order raises on exactly the legacy origin this exists to reach.

## Certificates

PEM file paths, not inline material — a private key does not belong in `settings.json`, which is shareable and exportable (#439).

A **passphrase-protected key is refused at save time**, with the fix in the message (`openssl pkey -in … -out …`). Otherwise OpenSSL prompts for the passphrase on the terminal the TUI owns and the process merely appears to hang, with no visible prompt.

The policy is resolved on the **dialled** host, not on an SNI override: a certificate and a protocol floor belong to the machine actually being talked to, whereas the Repeater's SNI field deliberately lies about the name for domain-fronting and vhost-confusion tests.

`apply_outbound_tls` deliberately does **not** swallow load failures. A certificate that cannot be loaded must not degrade into a plaintext-policy connection that then fails at the origin; `dial_tls_result` turns the raise into a recorded `Tls` error the operator can see.

## Verification

`crystal spec`: **4471 examples, 0 failures**. ameba: the new file is clean (0 findings); the touched files match the `main` baseline.

15 new specs — rule matching and the shared host dialect, cache-key distinctness (including a field-boundary collision check, since concatenating without a separator would let two policies produce one key), mutual TLS asserted by **what the server saw** with a no-rule control, the cross-host leak case, the TLS 1.0 floor end-to-end, and the validator (half a pair, unreadable file, unknown version, both encrypted-key formats).

## Still open on #434

A dedicated TUI editor for both tables. Rules are configured with `gori settings --edit` and documented; a per-row editor needs its own overlay (a new `OverlayKind`, dispatch fixtures, the `on_close` seam) and is a separate change.

## Docs

`reference/config.md` (+ `.ko`): an `outbound_tls` section with the key table, why the protocol floor is needed at all, the file-path/passphrase rationale, and the dialled-host-vs-SNI note.

https://claude.ai/code/session_017X5VpbYNqcLneDkJkYYm1R