### PR TITLE
feat(cli,settings): --config PATH and settings export/import profiles

### DIFF
--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -560,9 +560,45 @@ gori ca import --cert root.crt.pem --key root.key.pem --yes
 ## gori settings {#gori-settings}
 
 ```bash
-gori settings          # print the settings.json path
-gori settings --edit   # open it in $EDITOR
+gori settings                      # settings.json 경로 출력
+gori settings --edit               # $EDITOR로 열기
+gori settings sections             # 최상위 섹션 목록
+gori settings export [-o FILE]     # 공유 가능한 프로필 출력(기본 stdout)
+gori settings import FILE          # 프로필의 섹션들을 적용
 ```
+
+### 프로필 {#profiles}
+
+`export`와 `import`는 설정을 다른 머신으로 옮기거나, 팀과 공유하거나, 재현 가능한 실행을 위해 저장소에 커밋할 때 씁니다. 단위는 최상위 섹션이며 목록은 `gori settings sections`로 확인합니다.
+
+```bash
+gori settings export --sections network,scan_rules -o team-profile.json
+gori settings import team-profile.json --dry-run     # 무엇이 바뀔지 미리 보기
+gori settings import team-profile.json --sections network
+```
+
+| 플래그 | 대상 | 설명 |
+|------|-----------|-------------|
+| `--sections a,b` | 공통 | 쉼표로 구분한 섹션 이름. export 기본값은 비밀을 담은 섹션을 제외한 전부, import 기본값은 파일에 있는 전부 |
+| `-o`, `--out FILE` | export | stdout 대신 파일로 기록 |
+| `--dry-run` | import | 바뀔 섹션만 출력하고 아무것도 쓰지 않고 종료 |
+
+import는 **섹션 단위로 통째 교체**하며, 선택하지 않은 섹션은 그대로 둡니다. TUI와 동일한 저장 경로를 거치므로 원자적 쓰기가 유지되고, 동시에 실행 중인 gori가 건드리지 않은 섹션에 한 편집을 덮어쓰지 않습니다. 파일에 있는 알 수 없는 섹션은 보고하고 무시합니다.
+
+`env`와 `decoder`는 export에서 기본 제외됩니다 — `env`는 토큰 값을, `decoder`는 마지막 입력과 저장된 세션을 담기 때문입니다. 명시적으로 이름을 적는 것(`--sections env`)이 포함에 대한 동의입니다. `upstream_rules`는 공유해도 안전합니다 — 사용자명과 환경변수 *이름*만 저장하고 비밀번호는 담지 않습니다.
+
+### `--config PATH` {#config-flag}
+
+`--config`는 이번 실행에 쓸 설정 파일을 지정합니다. 서브커맨드 앞에 옵니다.
+
+```bash
+gori --config ./ci-profile.json run capture --target https://api.example.com
+gori --config ~/profiles/corp.json          # 다른 설정으로 TUI 실행
+```
+
+우선순위는 `--config` → `$GORI_CONFIG` → `$GORI_HOME/settings.json`입니다.
+
+이 플래그는 의도적으로 **`GORI_HOME`과 직교**합니다 — 읽고 쓸 설정 파일만 바꾸고 CA, 프로젝트 DB, 테마, 워드리스트는 그대로 둡니다. 이전에는 설정을 바꾸려면 트리 전체를 옮기는 방법밖에 없었습니다.
 
 ## gori wizard {#gori-wizard}
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -560,9 +560,45 @@ Trust only `root.crt.pem` in your clients. Never distribute the private key.
 ## gori settings
 
 ```bash
-gori settings          # print the settings.json path
-gori settings --edit   # open it in $EDITOR
+gori settings                      # print the settings.json path
+gori settings --edit               # open it in $EDITOR
+gori settings sections             # list the top-level sections
+gori settings export [-o FILE]     # write a shareable profile (stdout by default)
+gori settings import FILE          # apply a profile's sections
 ```
+
+### Profiles
+
+`export` and `import` move settings between machines, share them with a team, or check a configuration into a repository for a reproducible run. The unit is the top-level section, listed by `gori settings sections`.
+
+```bash
+gori settings export --sections network,scan_rules -o team-profile.json
+gori settings import team-profile.json --dry-run     # show what would change
+gori settings import team-profile.json --sections network
+```
+
+| Flag | Applies to | Description |
+|------|-----------|-------------|
+| `--sections a,b` | both | Comma-separated section names. Export defaults to everything except secret-bearing sections; import defaults to every section in the file |
+| `-o`, `--out FILE` | export | Write to a file instead of stdout |
+| `--dry-run` | import | Print which sections would change, then exit without writing |
+
+Import **replaces whole sections**; a section you do not select is left exactly as it was. It goes through the same writer the TUI uses, so it keeps the atomic write and cannot clobber a concurrently-running gori's edit to a section it did not touch. Unrecognised sections in the file are reported and ignored.
+
+`env` and `decoder` are excluded from an export by default: `env` holds token values and `decoder` holds your last input and saved sessions. Naming one explicitly (`--sections env`) is how you consent to include it. Note that `upstream_rules` is safe to share — it stores a username and an environment-variable *name*, never a password.
+
+### `--config PATH`
+
+`--config` points gori at a specific settings file for one run. It works before any subcommand:
+
+```bash
+gori --config ./ci-profile.json run capture --target https://api.example.com
+gori --config ~/profiles/corp.json          # the TUI, with a different config
+```
+
+Resolution order is `--config` → `$GORI_CONFIG` → `$GORI_HOME/settings.json`.
+
+This is deliberately **orthogonal to `GORI_HOME`**: it changes only which settings file is read and written, leaving the CA, the project databases, the themes and the wordlists where they are. Relocating the whole tree was previously the only way to switch configuration.
 
 ## gori wizard
 

--- a/docs/content/reference/config.ko.md
+++ b/docs/content/reference/config.ko.md
@@ -24,6 +24,8 @@ gori는 전역 환경설정을 `settings.json`에, 각 프로젝트를 자체 SQ
 
 `settings.json`은 JSON입니다. `gori settings` / `gori settings --edit`로 찾거나 편집합니다.
 
+위치는 `--config PATH` → `$GORI_CONFIG` → `$GORI_HOME/settings.json` 순으로 결정되므로, CA·프로젝트 DB·테마·워드리스트를 옮기지 않고도 다른 설정으로 실행할 수 있습니다. 섹션 단위 이동은 [`gori settings export` / `import`](/ko/reference/cli/#profiles)로 합니다.
+
 ### network {#network}
 
 ```json

--- a/docs/content/reference/config.md
+++ b/docs/content/reference/config.md
@@ -24,6 +24,8 @@ Everything lives under `GORI_HOME` (`$GORI_HOME` if set and non-empty, otherwise
 
 `settings.json` is JSON. Find or edit it with `gori settings` / `gori settings --edit`.
 
+Its location resolves as `--config PATH` → `$GORI_CONFIG` → `$GORI_HOME/settings.json`, so a run can use a different configuration without relocating the CA, project databases, themes and wordlists. Sections can be moved between configs with [`gori settings export` / `import`](/reference/cli/#profiles).
+
 ### network
 
 ```json

--- a/spec/settings_profile_spec.cr
+++ b/spec/settings_profile_spec.cr
@@ -1,0 +1,177 @@
+require "./spec_helper"
+require "file_utils"
+
+private def with_config_home(&)
+  dir = File.tempname("gori-profile")
+  Dir.mkdir_p(dir)
+  prev_home = ENV["GORI_HOME"]?
+  prev_cfg = ENV["GORI_CONFIG"]?
+  begin
+    ENV["GORI_HOME"] = dir
+    ENV.delete("GORI_CONFIG")
+    Gori::Settings.path_override = nil
+    yield dir
+  ensure
+    prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
+    prev_cfg ? (ENV["GORI_CONFIG"] = prev_cfg) : ENV.delete("GORI_CONFIG")
+    Gori::Settings.path_override = nil
+    Gori::Settings.upstream_proxy = ""
+    Gori::Settings.theme = Gori::Settings::DEFAULT_THEME
+    Gori::Settings.env_vars = [] of {String, String}
+    FileUtils.rm_rf(dir)
+  end
+end
+
+describe "settings profiles" do
+  describe ".path resolution" do
+    it "prefers --config over $GORI_CONFIG over GORI_HOME" do
+      with_config_home do |dir|
+        Gori::Settings.path.should eq(File.join(dir, "settings.json"))
+
+        ENV["GORI_CONFIG"] = "/tmp/from-env.json"
+        Gori::Settings.path.should eq("/tmp/from-env.json")
+
+        Gori::Settings.path_override = "/tmp/from-flag.json"
+        Gori::Settings.path.should eq("/tmp/from-flag.json")
+
+        # A blank override is not an override — it must not shadow the env/home fallbacks.
+        Gori::Settings.path_override = ""
+        Gori::Settings.path.should eq("/tmp/from-env.json")
+      end
+    end
+
+    # --config must be orthogonal to GORI_HOME: pointing at another config must NOT relocate
+    # the CA, the project databases, the themes or the wordlists.
+    it "does not move the rest of GORI_HOME" do
+      with_config_home do |dir|
+        Gori::Settings.path_override = File.join(dir, "elsewhere", "profile.json")
+        Gori::Paths.home_dir.should eq(dir)
+        Gori::Paths.default_ca_dir.should eq(File.join(dir, "ca"))
+      end
+    end
+
+    it "creates the parent directory when saving outside GORI_HOME" do
+      with_config_home do |dir|
+        nested = File.join(dir, "profiles", "team", "a.json")
+        Gori::Settings.path_override = nested
+        Gori::Settings.save.should be_true
+        File.exists?(nested).should be_true
+      end
+    end
+  end
+
+  describe ".document_keys" do
+    # Derived from the live serialization rather than a hand-kept list, so a new section is
+    # exportable the moment it is written.
+    it "lists the keys the current settings actually serialize" do
+      with_config_home do
+        keys = Gori::Settings.document_keys
+        keys.should contain("network")
+        keys.should contain("theme")
+        # An optional section that is at its default is absent from both, consistently.
+        Gori::Settings.retention_max_flows.should eq(Gori::Settings::DEFAULT_RETENTION_FLOWS)
+        keys.should_not contain("retention")
+      end
+    end
+  end
+
+  describe ".export_document" do
+    it "omits secret-bearing sections by default" do
+      with_config_home do
+        Gori::Settings.env_vars = [{"TOKEN", "super-secret"}]
+        doc = JSON.parse(Gori::Settings.export_document).as_h
+        doc.has_key?("env").should be_false
+        doc.has_key?("network").should be_true
+      end
+    end
+
+    # Naming a secret section IS the consent to include it — there is no separate flag to
+    # forget, and no way to leak one without having typed its name.
+    it "includes a secret section when it is named explicitly" do
+      with_config_home do
+        Gori::Settings.env_vars = [{"TOKEN", "super-secret"}]
+        doc = JSON.parse(Gori::Settings.export_document(["env"])).as_h
+        doc.keys.should eq(["env"])
+        doc["env"].to_json.should contain("super-secret")
+      end
+    end
+
+    it "narrows to the named sections" do
+      with_config_home do
+        doc = JSON.parse(Gori::Settings.export_document(["network", "theme"])).as_h
+        doc.keys.sort.should eq(["network", "theme"])
+      end
+    end
+  end
+
+  describe ".import_preview" do
+    it "reports only the sections that would actually change, plus unknown keys" do
+      with_config_home do
+        Gori::Settings.theme = "goridark"
+        raw = %({"theme":"goriday","mouse":#{Gori::Settings.mouse},"bogus":{"a":1}})
+        changed, unknown = Gori::Settings.import_preview(raw)
+        changed.should contain("theme")
+        changed.should_not contain("mouse") # identical to current → not a change
+        unknown.should eq(["bogus"])
+      end
+    end
+
+    it "honours a section filter" do
+      with_config_home do
+        raw = %({"theme":"goriday","network":{"bind_port":9999}})
+        changed, _ = Gori::Settings.import_preview(raw, ["network"])
+        changed.should eq(["network"])
+      end
+    end
+  end
+
+  describe ".import_document" do
+    # The core guarantee: a section the operator did not select is left alone.
+    it "applies only the selected sections and leaves the rest untouched" do
+      with_config_home do
+        Gori::Settings.theme = "goridark"
+        Gori::Settings.save
+        raw = %({"theme":"goriday","network":{"bind_port":9191}})
+        Gori::Settings.import_document(raw, ["network"])
+
+        Gori::Settings.bind_port.should eq(9191)
+        Gori::Settings.theme.should eq("goridark") # not selected → unchanged
+        JSON.parse(File.read(Gori::Settings.path)).as_h["theme"].as_s.should eq("goridark")
+      end
+    end
+
+    it "runs the same tolerant per-section parse as a normal load" do
+      with_config_home do
+        # An out-of-range value falls back rather than failing the import — the behaviour
+        # apply_sections already guarantees, reused rather than reimplemented.
+        Gori::Settings.import_document(%({"network":{"http2":"h3","bind_port":8080}}))
+        Gori::Settings.http2.should eq("auto")
+        Gori::Settings.bind_port.should eq(8080)
+      end
+    end
+
+    it "persists through save, leaving a parseable file on disk" do
+      with_config_home do
+        Gori::Settings.import_document(%({"network":{"bind_port":7171}}))
+        on_disk = JSON.parse(File.read(Gori::Settings.path)).as_h
+        on_disk["network"].as_h["bind_port"].as_i.should eq(7171)
+      end
+    end
+
+    # A profile is meant to survive a round trip: export, import elsewhere, same values.
+    it "round-trips an exported profile" do
+      exported = ""
+      with_config_home do
+        Gori::Settings.upstream_proxy = "corp.test:3128"
+        Gori::Settings.theme = "goriday"
+        exported = Gori::Settings.export_document(["network", "theme"])
+      end
+      with_config_home do
+        Gori::Settings.upstream_proxy.should eq("") # a genuinely fresh config
+        Gori::Settings.import_document(exported)
+        Gori::Settings.upstream_proxy.should eq("corp.test:3128")
+        Gori::Settings.theme.should eq("goriday")
+      end
+    end
+  end
+end

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -29,6 +29,13 @@ module Gori
         return
       end
 
+      # `--config PATH` is consumed HERE, before subcommand detection, rather than being added
+      # to each subcommand's OptionParser. It must apply to every surface (tui, run, mcp,
+      # settings) and take effect before anything reads Settings, so one central strip is both
+      # simpler and impossible to forget on a new subcommand — and every parser below would
+      # otherwise reject it through invalid_option.
+      argv = extract_config_flag(argv)
+
       # Top-level help when no explicit subcommand is given
       has_explicit_sub = !argv.empty? && !argv[0].starts_with?("-")
       if argv.any? { |a| a == "-h" || a == "--help" } && !has_explicit_sub
@@ -62,6 +69,35 @@ module Gori
         print_main_help
         exit 1
       end
+    end
+
+    # Pull `--config PATH` / `--config=PATH` out of argv, point Settings at it, and return the
+    # remaining args. Aborts on a missing value rather than silently ignoring the flag — a
+    # config that quietly did not apply is the worst outcome for a reproducible run.
+    private def self.extract_config_flag(argv : Array(String)) : Array(String)
+      rest = [] of String
+      i = 0
+      while i < argv.size
+        arg = argv[i]
+        if arg == "--config"
+          value = argv[i + 1]?
+          # A following flag is not a path — treat `--config --edit` as the missing value it is,
+          # rather than writing settings to a file literally named "--edit".
+          abort "gori: --config needs a path" if value.nil? || value.starts_with?("-")
+          Settings.path_override = value
+          i += 2
+          next
+        elsif arg.starts_with?("--config=")
+          value = arg["--config=".size..]
+          abort "gori: --config needs a path" if value.empty?
+          Settings.path_override = value
+          i += 1
+          next
+        end
+        rest << arg
+        i += 1
+      end
+      rest
     end
 
     private def self.print_main_help : Nil
@@ -130,9 +166,18 @@ module Gori
     # $EDITOR. Lazily created with current defaults on first invocation. ("config"
     # the word is reserved for the runtime Config struct — flags/effective config.)
     private def self.run_settings(args : Array(String)) : Nil
+      case args[0]?
+      when "export"   then return run_settings_export(args[1..])
+      when "import"   then return run_settings_import(args[1..])
+      when "sections" then return run_settings_sections
+      end
+
       edit = false
       parser = OptionParser.new do |p|
-        p.banner = "Usage: gori settings [--edit]"
+        p.banner = "Usage: gori settings [--edit]\n" \
+                   "       gori settings sections\n" \
+                   "       gori settings export [--sections a,b] [-o FILE]\n" \
+                   "       gori settings import FILE [--sections a,b] [--dry-run]"
         p.on("--edit", "Open the settings file in your editor (Settings: Editor / $VISUAL / $EDITOR / vi)") { edit = true }
         p.on("-h", "--help", "Show this help") { puts p; exit 0 }
         p.invalid_option { |flag| abort "unknown option: #{flag}\n#{p}" }
@@ -163,6 +208,98 @@ module Gori
       status = Process.run(cmd[0], cmd[1..] + [path],
         input: Process::Redirect::Inherit, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
       abort "gori settings: editor (#{cmd.join(' ')}) exited #{status.exit_code}" unless status.success?
+    end
+
+    # `gori settings sections` — the top-level keys export/import operate on. Derived from the
+    # live serialization, so a newly added section appears here with no list to update.
+    private def self.run_settings_sections : Nil
+      Settings.load
+      Settings.document_keys.each do |k|
+        puts Settings::SECRET_SECTIONS.includes?(k) ? "#{k}  (holds secrets — excluded unless named)" : k
+      end
+    end
+
+    # `gori settings export` — write a shareable profile to stdout (or -o FILE).
+    private def self.run_settings_export(args : Array(String)) : Nil
+      sections = nil.as(Array(String)?)
+      out = nil.as(String?)
+      parser = OptionParser.new do |p|
+        p.banner = "Usage: gori settings export [--sections a,b] [-o FILE]"
+        p.on("--sections=LIST", "Comma-separated top-level sections (default: all but #{Settings::SECRET_SECTIONS.join('/')})") { |v| sections = split_sections(v) }
+        p.on("-o FILE", "--out=FILE", "Write here instead of stdout") { |v| out = v }
+        p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+        p.invalid_option { |flag| abort "unknown option: #{flag}\n#{p}" }
+        p.missing_option { |flag| abort "missing value for #{flag}" }
+      end
+      parser.parse(args)
+
+      Settings.load
+      if list = sections
+        unknown = list - Settings.document_keys
+        abort "gori settings export: unknown section(s): #{unknown.join(", ")}\nRun 'gori settings sections' for the list." unless unknown.empty?
+      end
+      doc = Settings.export_document(sections)
+      if path = out
+        File.write(path, doc)
+        STDERR.puts "wrote #{path}"
+      else
+        puts doc
+      end
+    end
+
+    # `gori settings import` — apply a profile's sections to this config.
+    private def self.run_settings_import(args : Array(String)) : Nil
+      sections = nil.as(Array(String)?)
+      dry = false
+      parser = OptionParser.new do |p|
+        p.banner = "Usage: gori settings import FILE [--sections a,b] [--dry-run]"
+        p.on("--sections=LIST", "Comma-separated top-level sections to apply (default: every section in FILE)") { |v| sections = split_sections(v) }
+        p.on("--dry-run", "Print which sections would change, then exit without writing") { dry = true }
+        p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+        p.invalid_option { |flag| abort "unknown option: #{flag}\n#{p}" }
+        p.missing_option { |flag| abort "missing value for #{flag}" }
+      end
+      rest = [] of String
+      parser.unknown_args { |before, _| rest = before }
+      parser.parse(args)
+
+      file = rest[0]?
+      abort "gori settings import: needs a file\n#{parser}" unless file
+      raw = begin
+        File.read(file)
+      rescue ex
+        abort "gori settings import: cannot read #{file}: #{ex.message}"
+      end
+      # Reject a non-object before touching anything: apply_sections is tolerant by design and
+      # would silently no-op on a JSON array or scalar, which reads as "imported, nothing
+      # happened" rather than "this is not a settings document".
+      begin
+        abort "gori settings import: #{file} is not a settings document (expected a JSON object)" unless JSON.parse(raw).as_h?
+      rescue
+        abort "gori settings import: #{file} is not valid JSON"
+      end
+
+      Settings.load
+      changed, unknown = Settings.import_preview(raw, sections)
+      STDERR.puts "warning: unrecognised section(s) ignored: #{unknown.join(", ")}" unless unknown.empty?
+
+      if dry
+        if changed.empty?
+          puts "no changes — the selected sections already match #{Settings.path}"
+        else
+          puts "would replace #{changed.size} section(s) in #{Settings.path}:"
+          changed.each { |k| puts "  #{k}" }
+        end
+        return
+      end
+
+      applied = Settings.import_document(raw, sections)
+      known = applied - unknown
+      puts "imported #{known.size} section(s) into #{Settings.path}#{known.empty? ? "" : ": #{known.join(", ")}"}"
+    end
+
+    private def self.split_sections(value : String) : Array(String)
+      value.split(',').compact_map(&.strip.presence)
     end
 
     # `gori ca` is the CA utility surface:

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -43,8 +43,20 @@ module Gori
     # unrelated edit isn't clobbered by this process persisting one unrelated field.
     @@loaded_raw : String? = nil
 
+    # An explicit settings file for THIS process (`gori --config PATH`), overriding both
+    # $GORI_CONFIG and the default under GORI_HOME. Set once from CLI.run before any
+    # subcommand dispatch, so every surface — TUI, `gori run`, `gori mcp` — reads the same
+    # file. Orthogonal to GORI_HOME on purpose: pointing at a different config must not also
+    # relocate the CA, the project databases, the themes and the wordlists, which is the only
+    # thing GORI_HOME could do before this.
+    @@path_override : String? = nil
+
+    def self.path_override=(p : String?) : String?
+      @@path_override = p.try(&.presence)
+    end
+
     def self.path : String
-      File.join(Paths.home_dir, "settings.json")
+      @@path_override || ENV["GORI_CONFIG"]?.presence || File.join(Paths.home_dir, "settings.json")
     end
 
     # Load persisted values into the class properties. Tolerant: a missing or
@@ -63,7 +75,9 @@ module Gori
 
     # Read each top-level section of a parsed settings document into the class properties.
     # Split out of load so load stays a small read → parse → apply flow.
-    private def self.apply_sections(root : JSON::Any) : Nil
+    # Not private: import_document reuses it, so a profile import runs the SAME per-section
+    # readers as a normal load rather than a parallel implementation that could drift.
+    protected def self.apply_sections(root : JSON::Any) : Nil
       if net = root["network"]?
         self.bind_host = net["bind_host"]?.try(&.as_s?) || bind_host
         self.bind_port = net["bind_port"]?.try(&.as_i?) || bind_port
@@ -152,6 +166,10 @@ module Gori
     # not crash the TUI); returns whether it succeeded.
     def self.save : Bool
       Paths.ensure_dirs
+      # With --config / $GORI_CONFIG the file can live outside GORI_HOME, whose directory
+      # ensure_dirs above does not create. The temp+rename below would fail on a missing
+      # parent, so make it first (0700: the file can carry env values and decoder sessions).
+      Paths.ensure_dir(File.dirname(path))
       # Atomic write: a torn File.write (crash / two instances / disk-full) would leave a
       # half-written settings.json that load()'s blanket rescue silently resets to factory
       # defaults — losing theme, hotkeys, hostname overrides, tab prefs, decoder sessions.
@@ -201,6 +219,69 @@ module Gori
       end
     rescue
       current # any merge hiccup falls back to the plain write (never worse than before)
+    end
+
+    # --- profiles: export / import a settings subset (`gori settings export|import`) -------
+    #
+    # The unit is the TOP-LEVEL JSON KEY, and the list of keys is derived from the current
+    # serialization rather than hand-maintained: a new section becomes exportable the moment
+    # it is written, with no second list to keep in step.
+    #
+    # Sections holding SECRETS or machine-local scratch, excluded from an export unless the
+    # operator names them explicitly. `env` carries token VALUES and `decoder` carries the last
+    # input plus saved sessions; the point of an export is that it can be committed or shared.
+    # Note `upstream_rules` is deliberately NOT here — it stores only a username and an
+    # environment-variable NAME, never a password (see settings/upstream_rules.cr).
+    SECRET_SECTIONS = ["env", "decoder"]
+
+    # Every top-level key the current settings would write. Also the answer to
+    # `gori settings sections`.
+    def self.document_keys : Array(String)
+      (JSON.parse(serialize).as_h?.try(&.keys) || [] of String)
+    end
+
+    # The current settings as a JSON document. `only` narrows it to those keys (an unknown key
+    # is simply absent — the caller validates and reports). With `only` nil, everything except
+    # SECRET_SECTIONS is written; naming a secret section explicitly IS the consent to include
+    # it, so no separate flag is needed to leak one by accident.
+    def self.export_document(only : Array(String)? = nil) : String
+      doc = JSON.parse(serialize).as_h
+      keep = only || (doc.keys - SECRET_SECTIONS)
+      JSON.build(indent: "  ") do |j|
+        j.object do
+          doc.each { |k, v| j.field k, v if keep.includes?(k) }
+        end
+      end
+    end
+
+    # The top-level keys in `raw` that would actually CHANGE the current settings, and the keys
+    # it carries that gori does not recognise. Import is destructive at section granularity, so
+    # `--dry-run` prints this before anything is written.
+    def self.import_preview(raw : String, only : Array(String)? = nil) : {Array(String), Array(String)}
+      incoming = JSON.parse(raw).as_h
+      current = JSON.parse(serialize).as_h
+      known = document_keys
+      selected = incoming.keys.select { |k| only.nil? || only.includes?(k) }
+      changed = selected.select { |k| current[k]? != incoming[k] }
+      {changed, selected.reject { |k| known.includes?(k) }}
+    end
+
+    # Apply the selected sections of `raw` to the live settings and persist. Returns the keys
+    # applied. Whole-section REPLACE, matching how merge_with_disk already reasons — a section
+    # is the unit an operator selects, so a half-merged one would be a surprise.
+    #
+    # Reuses `apply_sections`, the same reader `load` uses, so every section's tolerant parse
+    # (unknown enum → safe fallback, junk entry dropped) applies here identically. Persisting
+    # goes through `save`, NOT a raw write: that keeps the atomic temp+rename and the 3-way
+    # merge, so an import cannot clobber a concurrent instance's edit to a section it did not
+    # touch.
+    def self.import_document(raw : String, only : Array(String)? = nil) : Array(String)
+      incoming = JSON.parse(raw).as_h
+      selected = incoming.keys.select { |k| only.nil? || only.includes?(k) }
+      filtered = JSON.build { |j| j.object { selected.each { |k| j.field k, incoming[k] } } }
+      apply_sections(JSON.parse(filtered))
+      save
+      selected
     end
 
     # Builds the full settings.json document by dispatching to each section's


### PR DESCRIPTION
Closes #439.

## Problem

`settings.json` had exactly one location — `$GORI_HOME/settings.json`. Switching configuration meant relocating the **whole** `GORI_HOME`, which also relocates the CA, the project databases, the themes and the wordlists. So:

- "the same projects with a different network profile" was inexpressible;
- **a CI run could not be configured declaratively** — the sharpest version, since headless operation (`gori run`, `gori mcp`, the MCP seam) is a deliberate strength here, and the workaround was to construct a throwaway `GORI_HOME` and copy the CA into it;
- nothing was shareable: scan rules, hostname overrides and hotkeys were entries inside one machine-local file that also holds a plaintext env list.

## `--config PATH`

Resolves ahead of `$GORI_CONFIG` and `$GORI_HOME/settings.json`, and is deliberately **orthogonal to `GORI_HOME`** — it changes only which settings file is read and written.

Consumed centrally in `CLI.run` before subcommand detection, **not** added to each subcommand's `OptionParser`: it has to apply to every surface and take effect before anything reads `Settings`, so one strip is both simpler and impossible to forget on a new subcommand — and every parser would otherwise reject it through `invalid_option`. A following flag counts as a missing value, so `gori --config --edit` aborts rather than writing settings to a file named `--edit`. `save` now creates the parent directory, since the file can live outside the tree `ensure_dirs` makes.

## `gori settings export | import | sections`

The unit is the top-level JSON key, and **the key list is derived from the live serialization** rather than hand-maintained — a new section becomes exportable the moment it is written, with no second list to keep in step.

> #439 proposed driving this from `SettingsCatalog::SECTIONS`. That turned out to be the wrong source: the catalog enumerates *UI* sections, which do not map 1:1 to JSON keys (`upstream_rules`, `outbound_tls`, `retention`, `scan_rules`, `mine`, `fuzzer`, … have no catalog entry). Deriving from the document itself is both correct and self-maintaining.

```bash
gori settings sections
gori settings export --sections network,scan_rules -o team-profile.json
gori settings import team-profile.json --dry-run
gori settings import team-profile.json --sections network
```

**Import reuses `apply_sections`** — the same reader `load` uses — so every section's tolerant parse applies identically instead of through a parallel implementation that could drift. It persists through **`save`**, keeping the atomic temp+rename and the 3-way merge, so an import cannot clobber a concurrently-running gori's edit to a section it did not touch. Replace is whole-section, matching how `merge_with_disk` already reasons.

**Secrets.** `env` and `decoder` are excluded from an export by default — token values, and the last decoder input plus saved sessions. Naming a section explicitly *is* the consent to include it, so there is no separate `--include-secrets` flag to forget and no way to leak one without having typed its name. `upstream_rules` is deliberately **not** excluded: it stores a username and an environment-variable *name*, never a password — which is what that design (#445) bought.

A non-object document is rejected before anything is touched: `apply_sections` is tolerant by design and would silently no-op on a JSON array, reading as "imported, nothing happened" rather than "this is not a settings document".

## Verification

`crystal spec`: **4497 examples, 0 failures**. ameba: 6 findings, identical to the `main` baseline (one new `Style/NegatedConditionsInUnless` was introduced and fixed).

13 new specs cover path precedence (including a blank override not shadowing the fallbacks), `--config` leaving `Paths.home_dir` and the CA dir alone, parent-directory creation, secret exclusion and explicit inclusion, preview reporting only genuinely-changed sections, import leaving unselected sections untouched **on disk as well as in memory**, the tolerant parse being reused, and an export→import round trip into a fresh config.

Also exercised against a **real built binary**, not only specs:

```
$ gori settings export | jq 'keys'          # ["editor","mouse","network","pretty_bodies","probe","theme"] — no env
$ gori settings export --sections env       # includes the token value, because it was named
$ gori settings import profile.json --sections network --dry-run
would replace 1 section(s) in …/settings.json:
  network
$ gori settings import profile.json --sections network
imported 1 section(s) …: network            # theme stayed goridark, not the profile's goriday
$ gori --config ./prof2.json settings import profile.json --sections network
imported 1 section(s) into ./prof2.json: network
```

## Docs

`reference/cli.md` (+ `.ko`): a Profiles section with the flag table, the whole-section replace semantics, the secret-exclusion rule, and a `--config` section covering resolution order and the GORI_HOME orthogonality. `reference/config.md` (+ `.ko`) gains the resolution order where the file is introduced.

https://claude.ai/code/session_017X5VpbYNqcLneDkJkYYm1R