### PR TITLE
feat(import): Postman, Insomnia, and Burp XML sources

### DIFF
--- a/docs/content/guide/proxy.ko.md
+++ b/docs/content/guide/proxy.ko.md
@@ -148,8 +148,17 @@ gori run history -q 'status:5xx host:api.example.com'
 | **Import: HAR** | 브라우저 또는 프록시 HAR 익스포트 → 전체 요청/응답 플로우 |
 | **Import: URLs** | 한 줄에 URL 하나씩 담긴 텍스트 파일 → 골격 요청 플로우 |
 | **Import: OpenAPI** | OpenAPI/Swagger JSON 또는 YAML → 오퍼레이션마다 요청 템플릿 하나 |
+| **Import: Postman** | Postman Collection v2 익스포트 → 저장된 요청마다 요청 템플릿 하나 |
+| **Import: Insomnia** | Insomnia v4 JSON 익스포트 → 저장된 요청마다 요청 템플릿 하나 |
+| **Import: Burp** | Burp Suite 저장 항목(XML) → 전체 요청/응답 플로우, 바이트 단위 그대로 |
 
 형식이 잘못된 항목은 전체 임포트를 중단시키지 않고 건너뜁니다. 임포트된 플로우는 캡처된 트래픽처럼 History에 들어오므로, 똑같이 필터링하고 Repeater로 재전송하거나 퍼징·스캔할 수 있습니다.
+
+**Postman과 Insomnia**는 컬렉션 자체의 variable 목록(Insomnia는 익스포트된 환경)에서 `{{변수}}`를 치환합니다. 치환되지 않은 변수가 URL에 남은 요청은 `{{baseUrl}}`을 호스트로 그대로 저장하지 않고 건너뜁니다. 모든 요청이 그렇게 건너뛰어지면, 어떤 변수를 채워야 하는지 에러 메시지가 이름을 알려 줍니다. 폴더 중첩은 끝까지 따라가고, 인증은 `bearer`·`basic`·헤더 API 키를 채워 줍니다. 토큰 교환이 필요한 방식(OAuth, AWS SigV4, NTLM 등)은 직접 채워야 합니다.
+
+**Burp** 항목은 저장된 그대로의 wire 바이트를 유지합니다. 이상한 공백, 중복 헤더, 일부러 틀린 `Content-Length`, 요청 타깃 안의 CRLF까지 그대로입니다. 손으로 만든 요청이 Repeater에서 바이트 단위로 똑같이 재전송된다는 점이, 요청을 다시 기술하는 대신 Burp에서 가져오는 이유입니다.
+
+같은 소스를 헤드리스에서도 다룰 수 있습니다. `gori run import --postman PATH`(그리고 `--har` / `--urls` / `--oas` / `--insomnia` / `--burp`)와 MCP의 `import_flows` 도구입니다.
 
 ## 호스트 오버라이드 {#host-overrides}
 

--- a/docs/content/guide/proxy.md
+++ b/docs/content/guide/proxy.md
@@ -148,8 +148,17 @@ You don't have to capture everything live. From the command palette (`Ctrl-P`):
 | **Import: HAR** | Browser or proxy HAR export → full request/response flows |
 | **Import: URLs** | Text file, one URL per line → skeleton request flows |
 | **Import: OpenAPI** | OpenAPI/Swagger JSON or YAML → one request template per operation |
+| **Import: Postman** | Postman Collection v2 export → one request template per saved request |
+| **Import: Insomnia** | Insomnia v4 JSON export → one request template per saved request |
+| **Import: Burp** | Burp Suite saved items (XML) → full request/response flows, byte-exact |
 
 Malformed entries are skipped rather than aborting the whole import. Imported flows land in History like captured traffic, so you can filter, Repeater, Fuzz, and scan them the same way.
+
+**Postman and Insomnia** resolve `{{variables}}` from the collection's own variable list (Insomnia: from the exported environments). A request whose URL still holds an unresolved variable is skipped rather than stored with a literal `{{baseUrl}}` host — if every request is skipped that way, the error names the variables so you know what to add. Folder nesting is walked in full, and auth seeds `bearer`, `basic`, and header API keys; token-exchange schemes (OAuth, AWS SigV4, NTLM, …) are left for you to fill in.
+
+**Burp** items keep their wire bytes exactly as saved — odd spacing, duplicate headers, a deliberately wrong `Content-Length`, a CRLF in the request target. A hand-forged request replays from the Repeater byte-for-byte, which is the point of importing from Burp rather than re-describing the request.
+
+The same sources are scriptable headless: `gori run import --postman PATH` (and `--har` / `--urls` / `--oas` / `--insomnia` / `--burp`), and the MCP `import_flows` tool.
 
 ## Host Overrides
 

--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -61,6 +61,7 @@ gori run <subcommand> [options]
 | `sequence` (`seq`) `[<flow-id>]` | 토큰 무작위성 평가 (라이브 리플레이, 또는 붙여넣은 목록은 `--tokens`) |
 | `probe [QL]` | 패시브 보안 스캔 (요청 없음) |
 | `discover` | 엔드포인트를 스파이더링 & 브루트포스하여 Sitemap으로 반영 |
+| `import` | HAR / URL 목록 / OpenAPI / Postman / Insomnia / Burp 파일에서 History로 플로우 일괄 임포트 |
 | `sitemap [QL]` | 호스트 → 경로 엔드포인트 트리 |
 | `oast listen` · `presets` | 아웃오브밴드 콜백 리스너 (interactsh 및 유사 서비스) |
 | `jwt [<token>]` | JWT 디코드, 재서명, 또는 공격 페이로드 생성 |
@@ -231,6 +232,30 @@ gori run discover --target https://target.example --max-depth 3 --extensions php
 | `--force` | 무제한 실행 안전 게이트 우회 |
 | `--no-store` | 결과를 프로젝트에 기록하지 않음 |
 | `--format` | `text`, `json`, 또는 `jsonl` |
+
+### run import {#run-import}
+
+프로젝트의 History로 플로우를 일괄 임포트합니다. TUI의 Import 오버레이에 대응하는 CLI입니다([Proxy & History → 임포트](/guide/proxy/#import) 참고). 소스 플래그는 정확히 하나만 지정해야 하며, 트래픽은 전혀 보내지 않습니다.
+
+```bash
+gori run import --postman api.postman_collection.json --db ./assessment.db --format json
+```
+
+| Option | Description |
+|--------|-------------|
+| `--har=PATH` | 브라우저/프록시 HAR(HTTP Archive) 익스포트 — 전체 요청/응답 플로우 |
+| `--urls=PATH` | 한 줄에 URL 하나씩 담긴 텍스트 파일(`#` 주석과 빈 줄은 무시) |
+| `--oas=PATH` | OpenAPI/Swagger 스펙(JSON 또는 YAML) — 오퍼레이션마다 템플릿 하나 |
+| `--postman=PATH` | Postman Collection v2 익스포트(JSON) |
+| `--insomnia=PATH` | Insomnia v4 익스포트(JSON) |
+| `--burp=PATH` | Burp Suite 항목 익스포트(XML) — 요청 **과** 응답, 바이트 단위 그대로 |
+| `--project=NAME` | 임포트할 프로젝트(기본값: 가장 최근에 사용한 프로젝트) |
+| `--db=PATH` | 임포트할 SQLite db 파일을 직접 지정(없으면 생성) |
+| `--format` | `text`(기본) 또는 `json` |
+
+임포트는 플로우를 기록하므로 `discover`와 같은 방식으로 대상을 정합니다. `--db`를 주면 생성하거나 다시 열고, 주지 않으면 기본 프로젝트를 몰래 만들지 않고 기존 프로젝트에 씁니다.
+
+형식이 잘못된 항목은 파일 전체를 중단시키지 않고 건너뛰며, 결과에 양쪽 개수가 모두 담깁니다(`{"count": 12, "skipped": 3}`). 응답까지 가져오는 것은 `--har`와 `--burp`뿐이고, 나머지는 요청 템플릿이라 보내기 전까지 History에서 `Pending`으로 보입니다.
 
 ### run sitemap {#run-sitemap}
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -61,6 +61,7 @@ gori run <subcommand> [options]
 | `sequence` (`seq`) `[<flow-id>]` | Grade token randomness (live replay, or `--tokens` for a pasted list) |
 | `probe [QL]` | Passive security scan (no requests) |
 | `discover` | Spider and brute-force endpoints into the Sitemap |
+| `import` | Bulk-import flows into History from a HAR / URL list / OpenAPI / Postman / Insomnia / Burp file |
 | `sitemap [QL]` | Host → path endpoint tree |
 | `oast listen` · `presets` | Out-of-band callback listener (interactsh & friends) |
 | `jwt [<token>]` | Decode, re-sign, or generate attack payloads for a JWT |
@@ -231,6 +232,30 @@ gori run discover --target https://target.example --max-depth 3 --extensions php
 | `--force` | Bypass the unbounded-run safety gate |
 | `--no-store` | Do not write findings into the project |
 | `--format` | `text`, `json`, or `jsonl` |
+
+### run import
+
+Bulk-import flows into the project's History — the CLI counterpart of the TUI's Import overlay (see [Proxy & History → Import](/guide/proxy/#import)). Exactly one source flag is required. Sends no traffic.
+
+```bash
+gori run import --postman api.postman_collection.json --db ./assessment.db --format json
+```
+
+| Option | Description |
+|--------|-------------|
+| `--har=PATH` | A browser/proxy HAR (HTTP Archive) export — full request/response flows |
+| `--urls=PATH` | A text file of URLs, one per line (`#` comments and blanks ignored) |
+| `--oas=PATH` | An OpenAPI/Swagger spec (JSON or YAML) — one template per operation |
+| `--postman=PATH` | A Postman Collection v2 export (JSON) |
+| `--insomnia=PATH` | An Insomnia v4 export (JSON) |
+| `--burp=PATH` | A Burp Suite item export (XML) — request **and** response, byte-exact |
+| `--project=NAME` | Project to import into (default: most-recently-active) |
+| `--db=PATH` | Explicit SQLite db file to import into (created if absent) |
+| `--format` | `text` (default) or `json` |
+
+Import writes flows, so it resolves its target like `discover`: an explicit `--db` is created or reopened, and without one it writes into an existing project rather than silently creating a default.
+
+A malformed entry is skipped rather than aborting the file; the result reports both counts (`{"count": 12, "skipped": 3}`). Only `--har` and `--burp` carry responses — the rest import request templates that show as `Pending` in History until you send them.
 
 ### run sitemap
 

--- a/spec/cli/run/import_spec.cr
+++ b/spec/cli/run/import_spec.cr
@@ -7,8 +7,8 @@ require "json"
 # Private CLI glue — reopen the module for thin bare-call wrappers (same whitebox trick
 # the other CLI specs use).
 module Gori::CLI::Run
-  def self.import_source_for_spec(har : String?, oas : String?, urls : String?) : {Symbol, String}
-    import_source(har, oas, urls)
+  def self.import_source_for_spec(sources : Hash(Symbol, String?)) : {Symbol, String}
+    import_source(sources)
   end
 
   def self.import_result_json_for_spec(kind : Symbol, path : String, result : Import::Result) : String
@@ -20,11 +20,27 @@ module Gori::CLI::Run
   end
 end
 
+private def only(kind : Symbol, path : String) : Hash(Symbol, String?)
+  sources = {} of Symbol => String?
+  Gori::Import::LABELS.each_key { |k| sources[k] = nil }
+  sources[kind] = path
+  sources
+end
+
 describe "gori run import" do
   it "maps each source flag to its {kind, path}" do
-    Gori::CLI::Run.import_source_for_spec("a.har", nil, nil).should eq({:har, "a.har"})
-    Gori::CLI::Run.import_source_for_spec(nil, "api.yaml", nil).should eq({:oas, "api.yaml"})
-    Gori::CLI::Run.import_source_for_spec(nil, nil, "urls.txt").should eq({:urls, "urls.txt"})
+    {har: "a.har", urls: "urls.txt", oas: "api.yaml",
+     postman: "c.postman_collection.json", insomnia: "i.json", burp: "items.xml"}.each do |kind, path|
+      Gori::CLI::Run.import_source_for_spec(only(kind, path)).should eq({kind, path})
+    end
+  end
+
+  it "covers every kind Import.import_file dispatches on" do
+    # A parser reachable from the TUI but not from `gori run import` is a wiring miss; the
+    # flag table and the label table are edited in different files.
+    Gori::Import::LABELS.each_key do |kind|
+      Gori::CLI::Run.import_source_for_spec(only(kind, "f")).should eq({kind, "f"})
+    end
   end
 
   it "carries kind, path, count and skipped in the JSON result" do
@@ -55,5 +71,16 @@ describe "gori run import" do
     one.should eq("imported 1 flow from HAR · d.har (1 entry skipped)")
     many = Gori::CLI::Run.import_result_text_for_spec(:har, "d.har", Gori::Import::Result.new(count: 0, skipped: 4))
     many.should eq("imported 0 flows from HAR · d.har (4 entries skipped)")
+  end
+
+  it "names the source with the same label the TUI card uses" do
+    # One table (Import::LABELS) feeds the CLI line, the overlay title and the TUI toast, so
+    # they cannot drift apart as sources are added.
+    {har: "HAR", urls: "URLs", oas: "OpenAPI",
+     postman: "Postman", insomnia: "Insomnia", burp: "Burp"}.each do |kind, label|
+      Gori::CLI::Run.import_result_text_for_spec(kind, "f", Gori::Import::Result.new(count: 1))
+        .should eq("imported 1 flow from #{label} · f")
+      Gori::Tui::ImportOverlay.new(kind).label.should eq(label)
+    end
   end
 end

--- a/spec/import/burp_spec.cr
+++ b/spec/import/burp_spec.cr
@@ -1,0 +1,217 @@
+require "base64"
+require "../spec_helper"
+
+# src/gori/import/burp.cr — Burp Suite "Save items" XML → BYTE-EXACT request/response flows.
+# The point of this format (versus HAR/Postman/OpenAPI) is that the wire bytes survive
+# unchanged, so most of these examples compare stored head bytes to the source bytes.
+
+private def with_store(&)
+  path = File.tempname("gori-burp", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def with_xml(xml : String, &)
+  path = File.tempname("gori-burp", ".xml")
+  File.write(path, xml)
+  begin
+    yield path
+  ensure
+    File.delete?(path)
+  end
+end
+
+private def parse(xml : String) : Gori::Import::ParseResult
+  with_xml(xml) { |path| Gori::Import::Burp.parse_file(path) }
+end
+
+# One <item> in Burp's shape. `request`/`response` are base64 like a real export.
+private def item(url : String, request : String, response : String? = nil,
+                 time : String = "Tue Mar 05 12:34:56 GMT 2024",
+                 host : String = "target.test", port : String = "443",
+                 protocol : String = "https") : String
+  resp = response ? Base64.strict_encode(response) : ""
+  <<-XML
+    <item>
+      <time>#{time}</time>
+      <url><![CDATA[#{url}]]></url>
+      <host ip="1.2.3.4">#{host}</host>
+      <port>#{port}</port>
+      <protocol>#{protocol}</protocol>
+      <method><![CDATA[GET]]></method>
+      <path><![CDATA[/]]></path>
+      <request base64="true">#{Base64.strict_encode(request)}</request>
+      <status>200</status>
+      <responselength>#{response.try(&.bytesize) || 0}</responselength>
+      <mimetype>JSON</mimetype>
+      <response base64="true">#{resp}</response>
+      <comment>a &amp; b</comment>
+    </item>
+    XML
+end
+
+private def items(*body : String) : String
+  %(<?xml version="1.0"?>\n<!DOCTYPE items [\n<!ELEMENT items (item*)>\n]>\n) +
+    %(<items burpVersion="2024.1" exportTime="Tue Mar 05 12:34:56 GMT 2024">\n) +
+    body.join('\n') + "\n</items>\n"
+end
+
+describe Gori::Import::Burp do
+  it "imports the request AND response of a saved item" do
+    req = "POST /api/x?q=1 HTTP/1.1\r\nHost: target.test\r\nContent-Length: 9\r\n\r\nhello=abc"
+    resp = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{\"ok\":true}"
+    result = parse(items(item("https://target.test/api/x?q=1", req, resp)))
+    result.flows.size.should eq(1)
+    pair = result.flows.first
+    pair.request.method.should eq("POST")
+    pair.request.target.should eq("/api/x?q=1")
+    pair.request.host.should eq("target.test")
+    pair.request.port.should eq(443)
+    String.new(pair.request.body.not_nil!).should eq("hello=abc")
+
+    response = pair.response.not_nil!
+    response.status.should eq(200)
+    response.reason.should eq("OK")
+    response.content_type.should eq("application/json")
+    String.new(response.body.not_nil!).should eq(%({"ok":true}))
+  end
+
+  it "stores the head BYTE-EXACT rather than re-serializing it" do
+    # A saved Burp item is frequently a hand-forged request. Rebuilding the head through
+    # Builder would re-emit Content-Length, reorder nothing but normalize spacing, and
+    # reject the entry on HEADER_INJECT — destroying exactly what makes the item worth
+    # keeping. Odd spacing, a duplicate header and a deliberately WRONG Content-Length all
+    # have to survive.
+    req = "POST /x HTTP/1.1\r\nHost: target.test\r\nX-Odd:  spaced \r\nX-Dup: 1\r\nX-Dup: 2\r\n" \
+          "Content-Length: 999\r\n\r\nshort"
+    resp = "HTTP/1.1 302 Moved\r\nSet-Cookie: a=1\r\nSet-Cookie: b=2\r\n\r\n"
+    result = parse(items(item("https://target.test/x", req, resp)))
+    pair = result.flows.first
+    String.new(pair.request.head).should eq(req[0, req.index("\r\n\r\n").not_nil! + 4])
+    String.new(pair.response.not_nil!.head).should eq(resp)
+  end
+
+  it "keeps a control character in the request target verbatim (P7)" do
+    # The imported TARGET is deliberately not sanitised — a raw CR/LF there is the
+    # operator's own smuggling payload, and it has to replay byte-exact.
+    req = "GET /x\rHTTP/1.1\r\nHost: target.test\r\n\r\n"
+    result = parse(items(item("https://target.test/x", req)))
+    String.new(result.flows.first.request.head).should eq(req)
+  end
+
+  it "normalizes an LF-only head so its headers actually parse" do
+    # Http1.parse_headers scans for CRLF only and returns an EMPTY header list for an
+    # LF-only head, so a Unix-normalized item would otherwise import with no headers.
+    req = "GET /lf HTTP/1.1\nHost: target.test\nA: b\n\nbody"
+    result = parse(items(item("https://target.test/lf", req)))
+    pair = result.flows.first
+    String.new(pair.request.head).should eq("GET /lf HTTP/1.1\r\nHost: target.test\r\nA: b\r\n\r\n")
+    String.new(pair.request.body.not_nil!).should eq("body")
+  end
+
+  it "terminates a head that was saved without its trailing blank line" do
+    result = parse(items(item("https://target.test/t", "GET /t HTTP/1.1\r\nHost: target.test")))
+    String.new(result.flows.first.request.head).should end_with("\r\n\r\n")
+  end
+
+  it "leaves the flow response-less when the item has no response" do
+    result = parse(items(item("https://target.test/pending", "GET /pending HTTP/1.1\r\nHost: target.test\r\n\r\n")))
+    result.flows.first.response.should be_nil
+  end
+
+  it "imports an item whose <time> cannot be parsed" do
+    # A timestamp surprise must never drop the item (same rule as har.cr#parse_started).
+    before = Time.utc.to_unix
+    result = parse(items(item("https://target.test/t", "GET /t HTTP/1.1\r\nHost: target.test\r\n\r\n",
+      time: "not a timestamp at all")))
+    result.flows.size.should eq(1)
+    result.skipped.should eq(0)
+    (result.flows.first.request.created_at // 1_000_000).should be >= before
+  end
+
+  it "reads Burp's Java Date.toString() timestamp" do
+    result = parse(items(item("https://target.test/t", "GET /t HTTP/1.1\r\nHost: target.test\r\n\r\n",
+      time: "Tue Mar 05 12:34:56 GMT 2024")))
+    at = Time.unix(result.flows.first.request.created_at // 1_000_000)
+    at.year.should eq(2024)
+    at.month.should eq(3)
+    at.day.should eq(5)
+  end
+
+  it "does not confuse <response> with <responselength>" do
+    # `<response` is a prefix of `<responselength`; a naive scan reads the length element
+    # as the message and base64-decodes a number.
+    resp = "HTTP/1.1 204 No Content\r\n\r\n"
+    result = parse(items(item("https://target.test/x", "GET /x HTTP/1.1\r\nHost: target.test\r\n\r\n", resp)))
+    result.flows.first.response.not_nil!.status.should eq(204)
+  end
+
+  it "accepts an inline (non-base64) CDATA message" do
+    req = "GET /cdata HTTP/1.1\r\nHost: target.test\r\n\r\n"
+    xml = items(<<-XML)
+      <item>
+        <url><![CDATA[https://target.test/cdata]]></url>
+        <request base64="false"><![CDATA[#{req}]]></request>
+        <response base64="false"></response>
+      </item>
+      XML
+    result = parse(xml)
+    String.new(result.flows.first.request.head).should eq(req)
+  end
+
+  it "falls back to protocol/host/port when the item has no <url>" do
+    xml = items(<<-XML)
+      <item>
+        <host ip="1.2.3.4">fallback.test</host>
+        <port>8443</port>
+        <protocol>http</protocol>
+        <request base64="true">#{Base64.strict_encode("GET /f HTTP/1.1\r\nHost: fallback.test\r\n\r\n")}</request>
+      </item>
+      XML
+    pair = parse(xml).flows.first
+    pair.request.scheme.should eq("http")
+    pair.request.host.should eq("fallback.test")
+    pair.request.port.should eq(8443)
+  end
+
+  it "skips one broken item instead of discarding the export" do
+    good = item("https://target.test/ok", "GET /ok HTTP/1.1\r\nHost: target.test\r\n\r\n")
+    no_request = "<item><url><![CDATA[https://target.test/x]]></url></item>"
+    bad_url = item("ftp://target.test/nope", "GET /nope HTTP/1.1\r\nHost: target.test\r\n\r\n")
+    result = parse(items(good, no_request, bad_url))
+    result.flows.size.should eq(1)
+    result.skipped.should eq(2)
+  end
+
+  it "raises a clean error on a non-Burp file and on an empty export" do
+    expect_raises(Gori::Error, /no <items> root/) { parse("<html><body>nope</body></html>") }
+    expect_raises(Gori::Error, /no <item> entries/) do
+      parse(%(<?xml version="1.0"?>\n<items burpVersion="2024.1"></items>\n))
+    end
+  end
+
+  it "imports end to end through Import.import_file" do
+    req = "GET /shop HTTP/1.1\r\nHost: shop.test\r\nAccept: */*\r\n\r\n"
+    resp = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n<p>ok</p>"
+    with_xml(items(item("https://shop.test/shop", req, resp, host: "shop.test"))) do |path|
+      with_store do |store|
+        result = Gori::Import.import_file(store, :burp, path)
+        result.count.should eq(1)
+        row = store.search(Gori::QL::EMPTY, 10).first
+        row.host.should eq("shop.test")
+        row.target.should eq("/shop")
+        row.status.should eq(200)
+        detail = store.get_flow(row.id).not_nil!
+        String.new(detail.request_head).should eq(req)
+        String.new(detail.response_body.not_nil!).should eq("<p>ok</p>")
+      end
+    end
+  end
+end

--- a/spec/import/insomnia_spec.cr
+++ b/spec/import/insomnia_spec.cr
@@ -1,0 +1,224 @@
+require "../spec_helper"
+
+# src/gori/import/insomnia.cr — Insomnia v4 JSON export → response-less History flows.
+
+private def with_store(&)
+  path = File.tempname("gori-insomnia", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def with_export(json : String, ext = ".json", &)
+  path = File.tempname("gori-insomnia", ext)
+  File.write(path, json)
+  begin
+    yield path
+  ensure
+    File.delete?(path)
+  end
+end
+
+private def parse(json : String) : Gori::Import::ParseResult
+  with_export(json) { |path| Gori::Import::Insomnia.parse_file(path) }
+end
+
+private def heads(result : Gori::Import::ParseResult) : Array(String)
+  result.flows.map { |pair| String.new(pair.request.head) }
+end
+
+describe Gori::Import::Insomnia do
+  it "imports request resources and ignores workspaces, folders and non-HTTP requests" do
+    result = parse(<<-JSON)
+      {"_type": "export", "__export_format": 4, "resources": [
+        {"_id": "wrk_1", "_type": "workspace", "name": "W"},
+        {"_id": "fld_1", "_type": "request_group", "parentId": "wrk_1", "name": "F"},
+        {"_id": "req_1", "_type": "request", "parentId": "fld_1",
+         "method": "GET", "url": "https://a.test/one"},
+        {"_id": "req_2", "_type": "request", "parentId": "wrk_1",
+         "method": "DELETE", "url": "https://a.test/two"},
+        {"_id": "ws_1", "_type": "websocket_request", "parentId": "wrk_1", "url": "wss://a.test/ws"},
+        {"_id": "grpc_1", "_type": "grpc_request", "parentId": "wrk_1", "url": "grpc://a.test"}]}
+      JSON
+    result.flows.map(&.request.target).should eq(["/one", "/two"])
+    result.flows.map(&.request.method).should eq(["GET", "DELETE"])
+    result.flows.map(&.response).should eq([nil, nil])
+  end
+
+  it "expands {{ _.var }} from the base environment merged with the first sub-environment" do
+    result = parse(<<-JSON)
+      {"_type": "export", "__export_format": 4, "resources": [
+        {"_id": "wrk_1", "_type": "workspace"},
+        {"_id": "env_base", "_type": "environment", "parentId": "wrk_1",
+         "data": {"base_url": "https://base.test", "token": "BASE"}},
+        {"_id": "env_dev", "_type": "environment", "parentId": "env_base",
+         "data": {"token": "DEV"}},
+        {"_id": "req_1", "_type": "request", "parentId": "wrk_1", "method": "GET",
+         "url": "{{ _.base_url }}/x",
+         "headers": [{"name": "Authorization", "value": "Bearer {{ _.token }}"}]}]}
+      JSON
+    result.flows.first.request.host.should eq("base.test")
+    heads(result).first.should contain("Authorization: Bearer DEV") # sub-environment wins
+  end
+
+  it "also expands the legacy brace form without the _. prefix" do
+    result = parse(<<-JSON)
+      {"_type": "export", "__export_format": 4, "resources": [
+        {"_id": "wrk_1", "_type": "workspace"},
+        {"_id": "env_base", "_type": "environment", "parentId": "wrk_1",
+         "data": {"base_url": "https://legacy.test"}},
+        {"_id": "req_1", "_type": "request", "parentId": "wrk_1",
+         "method": "GET", "url": "{{ base_url }}/x"}]}
+      JSON
+    result.flows.first.request.host.should eq("legacy.test")
+  end
+
+  it "appends the parameters array as query, skipping disabled rows" do
+    result = parse(<<-JSON)
+      {"_type": "export", "__export_format": 4, "resources": [
+        {"_id": "req_1", "_type": "request", "method": "GET", "url": "https://a.test/s?pre=0",
+         "parameters": [{"name": "page", "value": "2"},
+                        {"name": "off", "value": "x", "disabled": true},
+                        {"name": "q", "value": "a b"}]}]}
+      JSON
+    result.flows.first.request.target.should eq("/s?pre=0&page=2&q=a+b")
+  end
+
+  it "resolves an environment value that is itself templated" do
+    result = parse(<<-JSON)
+      {"_type": "export", "__export_format": 4, "resources": [
+        {"_id": "env_base", "_type": "environment",
+         "data": {"base_url": "{{ _.scheme }}://{{ _.host }}", "scheme": "https", "host": "nested.test"}},
+        {"_id": "req_1", "_type": "request", "method": "GET", "url": "{{ _.base_url }}/x"}]}
+      JSON
+    result.flows.first.request.host.should eq("nested.test")
+  end
+
+  it "skips a URL with a braced host" do
+    result = parse(<<-JSON)
+      {"_type": "export", "__export_format": 4, "resources": [
+        {"_id": "env_base", "_type": "environment", "data": {"ok": "good.test"}},
+        {"_id": "req_1", "_type": "request", "method": "GET", "url": "https://{host}.test/x"},
+        {"_id": "req_2", "_type": "request", "method": "GET", "url": "https://{{ _.ok }}/y"}]}
+      JSON
+    result.skipped.should eq(1)
+    result.flows.map(&.request.host).should eq(["good.test"])
+  end
+
+  it "skips a request whose URL still holds an unresolved variable" do
+    result = parse(<<-JSON)
+      {"_type": "export", "__export_format": 4, "resources": [
+        {"_id": "env_base", "_type": "environment", "data": {"ok": "https://good.test"}},
+        {"_id": "req_1", "_type": "request", "method": "GET", "url": "{{ _.ok }}/yes"},
+        {"_id": "req_2", "_type": "request", "method": "GET", "url": "{{ _.nope }}/no"}]}
+      JSON
+    result.flows.size.should eq(1)
+    result.skipped.should eq(1)
+    result.flows.first.request.host.should eq("good.test")
+  end
+
+  it "names the missing variables when every request was skipped for one" do
+    ex = expect_raises(Gori::Error) do
+      parse(<<-JSON)
+        {"_type": "export", "__export_format": 4, "resources": [
+          {"_id": "req_1", "_type": "request", "method": "GET", "url": "{{ _.base_url }}/a"}]}
+        JSON
+    end
+    msg = ex.message.not_nil!
+    msg.should contain("{{base_url}}")
+    msg.should contain("1 request references")
+    msg.should_not contain("malformed")
+  end
+
+  it "builds urlencoded, multipart and text bodies" do
+    result = parse(<<-JSON)
+      {"_type": "export", "__export_format": 4, "resources": [
+        {"_id": "r1", "_type": "request", "method": "POST", "url": "https://a.test/form",
+         "body": {"mimeType": "application/x-www-form-urlencoded",
+                  "params": [{"name": "u", "value": "a b"}, {"name": "off", "value": "x", "disabled": true}]}},
+        {"_id": "r2", "_type": "request", "method": "POST", "url": "https://a.test/multi",
+         "body": {"mimeType": "multipart/form-data",
+                  "params": [{"name": "field", "value": "val"},
+                             {"name": "upload", "type": "file", "fileName": "/etc/passwd"}]}},
+        {"_id": "r3", "_type": "request", "method": "POST", "url": "https://a.test/json",
+         "body": {"mimeType": "application/json", "text": "{\\"a\\":1}"}},
+        {"_id": "r4", "_type": "request", "method": "POST", "url": "https://a.test/bin",
+         "body": {"mimeType": "application/octet-stream", "fileName": "/etc/passwd"}}]}
+      JSON
+    bodies = result.flows.map { |f| f.request.body.try { |b| String.new(b) } }
+    bodies[0].should eq("u=a+b")
+    bodies[1].not_nil!.should contain(%(Content-Disposition: form-data; name="field"))
+    bodies[1].not_nil!.should_not contain("upload")
+    bodies[2].should eq(%({"a":1}))
+    bodies[3].should be_nil # a `fileName`-only body names a path on the exporter's disk
+    heads(result)[2].should contain("Content-Type: application/json")
+  end
+
+  it "seeds bearer / basic / apikey-header auth and nothing else" do
+    result = parse(<<-JSON)
+      {"_type": "export", "__export_format": 4, "resources": [
+        {"_id": "r1", "_type": "request", "method": "GET", "url": "https://a.test/b",
+         "authentication": {"type": "bearer", "token": "T"}},
+        {"_id": "r2", "_type": "request", "method": "GET", "url": "https://a.test/basic",
+         "authentication": {"type": "basic", "username": "u", "password": "p"}},
+        {"_id": "r3", "_type": "request", "method": "GET", "url": "https://a.test/key",
+         "authentication": {"type": "apikey", "key": "X-Token", "value": "V", "addTo": "header"}},
+        {"_id": "r4", "_type": "request", "method": "GET", "url": "https://a.test/query",
+         "authentication": {"type": "apikey", "key": "k", "value": "V", "addTo": "queryParams"}},
+        {"_id": "r5", "_type": "request", "method": "GET", "url": "https://a.test/off",
+         "authentication": {"type": "bearer", "token": "T", "disabled": true}},
+        {"_id": "r6", "_type": "request", "method": "GET", "url": "https://a.test/oauth",
+         "authentication": {"type": "oauth2", "accessTokenUrl": "https://a.test/t"}}]}
+      JSON
+    hs = heads(result)
+    hs[0].should contain("Authorization: Bearer T")
+    hs[1].should contain("Authorization: Basic dTpw")
+    hs[2].should contain("X-Token: V")
+    hs[3].should_not contain("k: V") # apikey-in-query would have to be spliced into a URL already built
+    hs[4].should_not contain("Authorization")
+    hs[5].should_not contain("Authorization")
+  end
+
+  it "points a v5 export at the right export option instead of failing to parse" do
+    ex = expect_raises(Gori::Error) do
+      with_export("type: collection.insomnia.rest/5.0\nname: W\n", ".yaml") do |path|
+        Gori::Import::Insomnia.parse_file(path)
+      end
+    end
+    ex.message.not_nil!.should contain("v4")
+  end
+
+  it "raises a clean error on invalid JSON and on a wrong-shaped document" do
+    expect_raises(Gori::Error, /not valid JSON/) { parse("{nope") }
+    expect_raises(Gori::Error, /not a JSON object/) { parse("[]") }
+    expect_raises(Gori::Error, /no `resources` array/) { parse(%({"_type": "export"})) }
+    expect_raises(Gori::Error, /no request resources/) do
+      parse(%({"_type": "export", "resources": [{"_id": "w", "_type": "workspace"}]}))
+    end
+  end
+
+  it "imports end to end through Import.import_file" do
+    with_export(<<-JSON) do |path|
+      {"_type": "export", "__export_format": 4, "resources": [
+        {"_id": "env_base", "_type": "environment", "data": {"base_url": "https://shop.test"}},
+        {"_id": "req_1", "_type": "request", "method": "POST", "url": "{{ _.base_url }}/cart",
+         "body": {"mimeType": "text/plain", "text": "qty=1"}}]}
+      JSON
+      with_store do |store|
+        result = Gori::Import.import_file(store, :insomnia, path)
+        result.count.should eq(1)
+        row = store.search(Gori::QL::EMPTY, 10).first
+        row.host.should eq("shop.test")
+        row.target.should eq("/cart")
+        row.status.should be_nil
+        String.new(store.get_flow(row.id).not_nil!.request_body.not_nil!).should eq("qty=1")
+      end
+    end
+  end
+end

--- a/spec/import/postman_spec.cr
+++ b/spec/import/postman_spec.cr
@@ -1,0 +1,314 @@
+require "../spec_helper"
+
+# src/gori/import/postman.cr — Postman Collection v2.0/v2.1 → response-less History flows.
+# Inline temp files rather than fixtures, matching spec/import/import_spec.cr.
+
+private def with_store(&)
+  path = File.tempname("gori-postman", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def with_collection(json : String, &)
+  path = File.tempname("gori", ".postman_collection.json")
+  File.write(path, json)
+  begin
+    yield path
+  ensure
+    File.delete?(path)
+  end
+end
+
+private def parse(json : String) : Gori::Import::ParseResult
+  with_collection(json) { |path| Gori::Import::Postman.parse_file(path) }
+end
+
+private def heads(result : Gori::Import::ParseResult) : Array(String)
+  result.flows.map { |pair| String.new(pair.request.head) }
+end
+
+describe Gori::Import::Postman do
+  it "walks nested folders, not just the top-level item array" do
+    # A flat read of `collection.item` imports almost nothing from a real export: every
+    # request lives inside at least one folder.
+    result = parse(<<-JSON)
+      {"info": {"name": "n"},
+       "item": [
+         {"name": "top", "request": {"method": "GET", "url": "https://a.test/0"}},
+         {"name": "f1", "item": [
+           {"name": "one", "request": {"method": "GET", "url": "https://a.test/1"}},
+           {"name": "f2", "item": [
+             {"name": "two", "request": {"method": "DELETE", "url": "https://a.test/2"}}]}]}]}
+      JSON
+    result.flows.size.should eq(3)
+    result.flows.map(&.request.target).sort!.should eq(["/0", "/1", "/2"])
+    result.flows.map(&.response).should eq([nil, nil, nil]) # request templates, never a response
+  end
+
+  it "reads url as a bare string, as {raw}, and as component parts" do
+    result = parse(<<-JSON)
+      {"info": {"name": "n"},
+       "item": [
+         {"request": "https://a.test/bare"},
+         {"request": {"method": "GET", "url": {"raw": "https://a.test/raw?x=1"}}},
+         {"request": {"method": "GET", "url": {
+            "protocol": "https", "host": ["a", "test"], "port": "8443",
+            "path": ["deep", "path"],
+            "query": [{"key": "k", "value": "v"}, {"key": "off", "value": "no", "disabled": true}]}}}]}
+      JSON
+    result.flows.map(&.request.target).should eq(["/bare", "/raw?x=1", "/deep/path?k=v"])
+    result.flows[2].request.port.should eq(8443)
+  end
+
+  it "expands {{variables}} from the collection and from folder scope" do
+    result = parse(<<-JSON)
+      {"info": {"name": "n"},
+       "variable": [{"key": "baseUrl", "value": "https://root.test"}, {"key": "v", "value": "1"}],
+       "item": [
+         {"request": {"method": "GET", "url": "{{baseUrl}}/a?v={{v}}"}},
+         {"name": "scoped", "variable": [{"key": "baseUrl", "value": "https://folder.test"}],
+          "item": [{"request": {"method": "GET", "url": "{{baseUrl}}/b"}}]}]}
+      JSON
+    result.flows.map { |f| "#{f.request.host}#{f.request.target}" }
+      .should eq(["root.test/a?v=1", "folder.test/b"])
+  end
+
+  it "resolves a variable whose value is itself templated" do
+    # `baseUrl = "{{scheme}}://{{host}}/api"` is routine. A single substitution pass would
+    # leave `{{scheme}}` behind and skip the entry as "variables not defined in the
+    # collection" — naming variables that ARE defined.
+    result = parse(<<-JSON)
+      {"info": {"name": "n"},
+       "variable": [{"key": "baseUrl", "value": "{{scheme}}://{{host}}/api"},
+                    {"key": "scheme", "value": "https"},
+                    {"key": "host", "value": "nested.test"}],
+       "item": [{"request": {"method": "GET", "url": "{{baseUrl}}/x"}}]}
+      JSON
+    result.flows.first.request.host.should eq("nested.test")
+    result.flows.first.request.target.should eq("/api/x")
+  end
+
+  it "gives up on a self-referential variable instead of spinning on it" do
+    # `a -> {{b}} -> {{a}}` must terminate. It ends as an unresolvable entry, which is the
+    # all-skipped path — the point of the example is that it RETURNS.
+    expect_raises(Gori::Error, /variables not defined/) do
+      parse(<<-JSON)
+        {"info": {"name": "n"},
+         "variable": [{"key": "a", "value": "https://{{b}}"}, {"key": "b", "value": "{{a}}"}],
+         "item": [{"request": {"method": "GET", "url": "{{a}}/x"}}]}
+        JSON
+    end
+  end
+
+  it "skips a URL with a braced host but keeps a brace in the path" do
+    # `Vars.unresolved` only sees `{{`, and `Builder::HOST_INVALID` does not reject `{`/`}`,
+    # so a single-brace host (a template form this parser does not speak, or a variable whose
+    # value was a JSON object) would be stored as a structurally impossible host. A brace in
+    # the PATH is the operator's own data and stays verbatim.
+    result = parse(<<-JSON)
+      {"info": {"name": "n"},
+       "variable": [{"key": "ok", "value": "good.test"}],
+       "item": [
+         {"request": {"method": "GET", "url": "https://{host}.test/x"}},
+         {"request": {"method": "GET", "url": "https://{{ok}}/p/{literal}"}}]}
+      JSON
+    result.skipped.should eq(1)
+    result.flows.size.should eq(1)
+    result.flows.first.request.host.should eq("good.test")
+    result.flows.first.request.target.should eq("/p/{literal}")
+  end
+
+  it "skips an entry whose URL still holds an unresolved variable" do
+    # Builder::HOST_INVALID does not reject `{`/`}`, so without this guard the flow would be
+    # STORED with a literal host of `{{baseUrl}}` — unsendable, and indistinguishable in
+    # History from a real capture.
+    result = parse(<<-JSON)
+      {"info": {"name": "n"},
+       "variable": [{"key": "ok", "value": "https://good.test"}],
+       "item": [
+         {"request": {"method": "GET", "url": "{{ok}}/yes"}},
+         {"request": {"method": "GET", "url": "{{missing}}/no"}}]}
+      JSON
+    result.flows.size.should eq(1)
+    result.skipped.should eq(1)
+    result.flows.first.request.host.should eq("good.test")
+  end
+
+  it "names the missing variables when EVERY entry was skipped for one" do
+    # The generic "all N entries were skipped as malformed" blames the file; a collection
+    # whose {{baseUrl}} lives in a separate environment export is not malformed at all.
+    ex = expect_raises(Gori::Error) do
+      parse(<<-JSON)
+        {"info": {"name": "n"},
+         "item": [
+           {"request": {"method": "GET", "url": "{{baseUrl}}/a"}},
+           {"request": {"method": "GET", "url": "{{baseUrl}}/b?k={{apiKey}}"}}]}
+        JSON
+    end
+    msg = ex.message.not_nil!
+    msg.should contain("{{apiKey}}")
+    msg.should contain("{{baseUrl}}")
+    msg.should contain("2 entries reference")
+    msg.should_not contain("malformed")
+  end
+
+  it "fills :pathVariable from url.variable" do
+    result = parse(<<-JSON)
+      {"info": {"name": "n"},
+       "item": [{"request": {"method": "GET", "url": {
+          "raw": "https://a.test:8443/users/:id/posts/:slug",
+          "variable": [{"key": "id", "value": "42"}]}}}]}
+      JSON
+    # `id` is declared and substituted; `:slug` is not declared and passes through, and
+    # neither `https://` nor the `:8443` port is touched.
+    result.flows.first.request.target.should eq("/users/42/posts/:slug")
+    result.flows.first.request.port.should eq(8443)
+  end
+
+  it "drops disabled headers and keeps duplicates in order" do
+    result = parse(<<-JSON)
+      {"info": {"name": "n"},
+       "item": [{"request": {"method": "GET", "url": "https://a.test/h", "header": [
+          {"key": "X-Keep", "value": "1"},
+          {"key": "X-Drop", "value": "2", "disabled": true},
+          {"key": "X-Keep", "value": "3"}]}}]}
+      JSON
+    head = heads(result).first
+    head.should contain("X-Keep: 1\r\n")
+    head.should contain("X-Keep: 3\r\n")
+    head.should_not contain("X-Drop")
+  end
+
+  it "builds each supported body mode and its Content-Type" do
+    result = parse(<<-JSON)
+      {"info": {"name": "n"},
+       "item": [
+         {"request": {"method": "POST", "url": "https://a.test/raw",
+           "body": {"mode": "raw", "raw": "{\\"a\\":1}", "options": {"raw": {"language": "json"}}}}},
+         {"request": {"method": "POST", "url": "https://a.test/form",
+           "body": {"mode": "urlencoded", "urlencoded": [
+             {"key": "u", "value": "a b"}, {"key": "p", "value": "q&z"},
+             {"key": "off", "value": "x", "disabled": true}]}}},
+         {"request": {"method": "POST", "url": "https://a.test/multi",
+           "body": {"mode": "formdata", "formdata": [
+             {"key": "field", "value": "val"},
+             {"key": "upload", "type": "file", "src": "/etc/passwd"}]}}},
+         {"request": {"method": "POST", "url": "https://a.test/gql",
+           "body": {"mode": "graphql", "graphql": {"query": "{ me }", "variables": "{\\"n\\":1}"}}}},
+         {"request": {"method": "POST", "url": "https://a.test/file",
+           "body": {"mode": "file", "file": {"src": "/etc/passwd"}}}}]}
+      JSON
+    bodies = result.flows.map { |f| f.request.body.try { |b| String.new(b) } }
+    bodies[0].should eq(%({"a":1}))
+    bodies[1].should eq("u=a+b&p=q%26z")
+    bodies[2].not_nil!.should contain(%(Content-Disposition: form-data; name="field"))
+    bodies[2].not_nil!.should_not contain("upload") # a `file` part names a path on the exporter's disk
+    bodies[3].should eq(%({"query":"{ me }","variables":{"n":1}}))
+    bodies[4].should be_nil # `file` mode reads nothing off the local filesystem
+
+    head_types = heads(result).map do |h|
+      h.lines.find(&.starts_with?("Content-Type")).try(&.chomp)
+    end
+    head_types[0].should eq("Content-Type: application/json")
+    head_types[1].should eq("Content-Type: application/x-www-form-urlencoded")
+    head_types[2].not_nil!.should start_with("Content-Type: multipart/form-data; boundary=")
+    head_types[3].should eq("Content-Type: application/json")
+    head_types[4].should be_nil
+  end
+
+  it "lets an explicit Content-Type header win over the body mode's" do
+    result = parse(<<-JSON)
+      {"info": {"name": "n"},
+       "item": [{"request": {"method": "POST", "url": "https://a.test/x",
+          "header": [{"key": "Content-Type", "value": "application/vnd.api+json"}],
+          "body": {"mode": "raw", "raw": "{}", "options": {"raw": {"language": "json"}}}}}]}
+      JSON
+    head = heads(result).first
+    head.should contain("Content-Type: application/vnd.api+json")
+    head.should_not contain("Content-Type: application/json")
+  end
+
+  it "seeds bearer / basic / apikey-header auth and nothing else" do
+    result = parse(<<-JSON)
+      {"info": {"name": "n"},
+       "item": [
+         {"request": {"method": "GET", "url": "https://a.test/b",
+           "auth": {"type": "bearer", "bearer": [{"key": "token", "value": "T"}]}}},
+         {"request": {"method": "GET", "url": "https://a.test/basic",
+           "auth": {"type": "basic", "basic": [
+             {"key": "username", "value": "u"}, {"key": "password", "value": "p"}]}}},
+         {"request": {"method": "GET", "url": "https://a.test/key",
+           "auth": {"type": "apikey", "apikey": [
+             {"key": "key", "value": "X-Token"}, {"key": "value", "value": "V"}]}}},
+         {"request": {"method": "GET", "url": "https://a.test/oauth",
+           "auth": {"type": "oauth2", "oauth2": [{"key": "accessToken", "value": "A"}]}}}]}
+      JSON
+    hs = heads(result)
+    hs[0].should contain("Authorization: Bearer T")
+    hs[1].should contain("Authorization: Basic dTpw") # base64("u:p")
+    hs[2].should contain("X-Token: V")
+    # oauth2/awsv4/ntlm/digest/hawk need a live exchange or a signing step; a fabricated
+    # header would be worse than none.
+    hs[3].should_not contain("Authorization")
+  end
+
+  it "inherits collection auth, lets a folder or request override it, and honours noauth" do
+    result = parse(<<-JSON)
+      {"info": {"name": "n"},
+       "auth": {"type": "bearer", "bearer": [{"key": "token", "value": "ROOT"}]},
+       "item": [
+         {"request": {"method": "GET", "url": "https://a.test/inherit"}},
+         {"name": "f", "auth": {"type": "bearer", "bearer": [{"key": "token", "value": "FOLDER"}]},
+          "item": [{"request": {"method": "GET", "url": "https://a.test/folder"}}]},
+         {"request": {"method": "GET", "url": "https://a.test/own",
+           "auth": {"type": "bearer", "bearer": [{"key": "token", "value": "OWN"}]}}},
+         {"request": {"method": "GET", "url": "https://a.test/none", "auth": {"type": "noauth"}}}]}
+      JSON
+    hs = heads(result)
+    hs[0].should contain("Bearer ROOT")
+    hs[1].should contain("Bearer FOLDER")
+    hs[2].should contain("Bearer OWN")
+    hs[3].should_not contain("Authorization")
+  end
+
+  it "rejects a v1 collection with an actionable message" do
+    ex = expect_raises(Gori::Error) do
+      parse(%({"id": "x", "name": "old", "requests": [{"url": "https://a.test/"}]}))
+    end
+    ex.message.not_nil!.should contain("v2.1")
+  end
+
+  it "raises a clean error on invalid JSON and on a wrong-shaped document" do
+    expect_raises(Gori::Error, /not valid JSON/) { parse("{nope") }
+    expect_raises(Gori::Error, /not a JSON object/) { parse("[]") }
+    expect_raises(Gori::Error, /no `item` array/) { parse(%({"info": {"name": "n"}})) }
+  end
+
+  it "imports end to end through Import.import_file" do
+    with_collection(<<-JSON) do |path|
+      {"info": {"name": "n"},
+       "variable": [{"key": "baseUrl", "value": "https://shop.test"}],
+       "item": [{"name": "f", "item": [
+         {"request": {"method": "POST", "url": "{{baseUrl}}/cart",
+          "body": {"mode": "raw", "raw": "qty=1"}}}]}]}
+      JSON
+      with_store do |store|
+        result = Gori::Import.import_file(store, :postman, path)
+        result.count.should eq(1)
+        row = store.search(Gori::QL::EMPTY, 10).first
+        row.host.should eq("shop.test")
+        row.method.should eq("POST")
+        row.target.should eq("/cart")
+        row.status.should be_nil # a template, never a fabricated response
+        String.new(store.get_flow(row.id).not_nil!.request_body.not_nil!).should eq("qty=1")
+      end
+    end
+  end
+end

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -1812,12 +1812,44 @@ describe Gori::MCP::Server do
       end
     end
 
-    it "rejects an invalid kind" do
+    it "imports a Postman collection into History" do
+      with_store do |store|
+        path = File.tempname("gori-mcp-import", ".json")
+        File.write(path, %({"info":{"name":"n"},"variable":[{"key":"b","value":"https://a.test"}],) +
+                         %("item":[{"name":"f","item":[{"request":{"method":"GET","url":"{{b}}/x"}}]}]}))
+        begin
+          call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"import_flows","arguments":{"kind":"postman","path":#{path.to_json}}}})
+          payload = tool_payload(drive(store, call)[0])
+          payload["count"].as_i.should eq(1)
+          store.search(Gori::QL::EMPTY, 1).first.host.should eq("a.test")
+        ensure
+          File.delete?(path)
+        end
+      end
+    end
+
+    it "rejects an invalid kind and lists the accepted ones" do
       with_store do |store|
         call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"import_flows","arguments":{"kind":"csv","path":"/tmp/x"}}})
         resp = drive(store, call)[0]["result"]
         resp["isError"].as_bool.should be_true
         resp["structuredContent"]["field"].as_s.should eq("kind")
+        # The message enumerates the kinds; an agent that guessed wrong gets the real list.
+        resp["content"][0]["text"].as_s.should contain("postman")
+      end
+    end
+
+    it "accepts every kind Import.import_file dispatches on" do
+      # The MCP whitelist (mcp/tools/import.cr) and the parser table are edited in different
+      # files — a format added to one and not the other is invisible to agents.
+      Gori::Import::LABELS.each_key do |kind|
+        with_store do |store|
+          call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"import_flows","arguments":{"kind":#{kind.to_s.to_json},"path":"/no/such/file"}}})
+          resp = drive(store, call)[0]["result"]
+          resp["isError"].as_bool.should be_true
+          # It got past the kind check and failed on the path — which is the point.
+          resp["content"][0]["text"].as_s.should contain("not found")
+        end
       end
     end
   end

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -1170,6 +1170,18 @@ class FakeExecContext < Gori::Verb::ExecContext
   def import_oas : Nil
     rec(:import_oas)
   end
+
+  def import_postman : Nil
+    rec(:import_postman)
+  end
+
+  def import_insomnia : Nil
+    rec(:import_insomnia)
+  end
+
+  def import_burp : Nil
+    rec(:import_burp)
+  end
 end
 
 # Fire one verb on a fresh recording context and return the intents it dispatched, IN

--- a/spec/tui/import_overlay_spec.cr
+++ b/spec/tui/import_overlay_spec.cr
@@ -14,13 +14,34 @@ end
 
 describe Gori::Tui::ImportOverlay do
   it "titles and describes the card by import kind" do
-    {:har => "HAR", :urls => "URLs", :oas => "OpenAPI"}.each do |kind, want|
+    {:har => "HAR", :urls => "URLs", :oas => "OpenAPI",
+     :postman => "Postman", :insomnia => "Insomnia", :burp => "Burp"}.each do |kind, want|
       ov = ImportOverlay.new(kind)
       ov.label.should eq(want)
       backend = MemoryBackend.new(100, 30)
       ov.render(Screen.new(backend), Rect.new(0, 0, 100, 30))
       backend.contains?("IMPORT #{want.upcase}").should be_true
     end
+  end
+
+  it "gives every import kind its own blurb, drawn in full inside the card" do
+    # Two failures at once: the generic "Load flows into History." is the else-branch
+    # fallback (a kind added to the parser table but never described here), and a blurb
+    # longer than the 76-wide card's text column would be silently clipped by `width:`.
+    {:har      => "browser or proxy HAR export",
+     :urls     => "one URL per line",
+     :oas      => "OpenAPI spec",
+     :postman  => "Build request templates from a Postman Collection v2 export.",
+     :insomnia => "Build request templates from an Insomnia v4 JSON export.",
+     :burp     => "Load saved Burp items into History — request and response, byte-exact.",
+    }.each do |kind, fragment|
+      backend = MemoryBackend.new(100, 30)
+      ImportOverlay.new(kind).render(Screen.new(backend), Rect.new(0, 0, 100, 30))
+      backend.contains?(fragment).should be_true
+      backend.contains?("Load flows into History.").should be_false
+    end
+    # Every registered kind is described — no source can be added without a blurb.
+    Gori::Import::LABELS.size.should eq(6)
   end
 
   it "centers the card in the body area" do

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -1103,6 +1103,18 @@ private class FakeContext < ExecContext
   def import_oas : Nil
     @calls << :import_oas
   end
+
+  def import_postman : Nil
+    @calls << :import_postman
+  end
+
+  def import_insomnia : Nil
+    @calls << :import_insomnia
+  end
+
+  def import_burp : Nil
+    @calls << :import_burp
+  end
 end
 
 describe Gori::Verb do

--- a/spec/verbs/import_spec.cr
+++ b/spec/verbs/import_spec.cr
@@ -1,29 +1,42 @@
 require "../spec_helper"
 require "../support/fake_context"
 
-# src/gori/verbs/import.cr — the three palette-only import entries. Each maps to ONE
-# ExecContext method; the CLI mirror of the same three sources is covered in
-# spec/cli/run/import_spec.cr.
+# src/gori/verbs/import.cr — the palette-only import entries. Each maps to ONE ExecContext
+# method; the CLI mirror of the same sources is covered in spec/cli/run/import_spec.cr.
 describe "Gori::Verbs.register_import" do
   r = Gori::Verbs.registry
+  verbs = {
+    "import.har"      => :import_har,
+    "import.urls"     => :import_urls,
+    "import.oas"      => :import_oas,
+    "import.postman"  => :import_postman,
+    "import.insomnia" => :import_insomnia,
+    "import.burp"     => :import_burp,
+  }
 
   it "registers one Global, chordless verb per import source" do
-    {"import.har" => :import_har, "import.urls" => :import_urls, "import.oas" => :import_oas}
-      .each do |id, intent|
-        verb = r[id]
-        verb.scope.should eq(Gori::Verb::Scope::Global)
-        verb.category.should eq(Gori::Verb::Category::Action)
-        verb.chords.should be_empty # palette-only — importing is deliberate, never a keypress
-        verb.available?(FakeExecContext.new).should be_true
-        verb_intents(r, id).should eq([intent])
-      end
+    verbs.each do |id, intent|
+      verb = r[id]
+      verb.scope.should eq(Gori::Verb::Scope::Global)
+      verb.category.should eq(Gori::Verb::Category::Action)
+      verb.chords.should be_empty # palette-only — importing is deliberate, never a keypress
+      verb.available?(FakeExecContext.new).should be_true
+      verb_intents(r, id).should eq([intent])
+    end
   end
 
-  it "keeps the three sources on separate handlers (no shared 'import' dispatcher)" do
+  it "keeps every source on its own handler (no shared 'import' dispatcher)" do
     # A single handler taking a kind would be one closure-capture slip away from importing
-    # a HAR as a URL list; three ids → three intents is the invariant.
+    # a HAR as a URL list; one id → one intent is the invariant, however many sources exist.
     ctx = FakeExecContext.new
-    %w[import.har import.urls import.oas].each { |id| r[id].call(ctx) }
-    ctx.call_names.should eq([:import_har, :import_urls, :import_oas])
+    verbs.each_key { |id| r[id].call(ctx) }
+    ctx.call_names.should eq(verbs.values)
+  end
+
+  it "gives every import kind a way in" do
+    # The palette and the parser table live in different files; this is what catches a
+    # format that was implemented but never registered (or vice versa).
+    Gori::Import::LABELS.each_key { |kind| verbs.has_key?("import.#{kind}").should be_true }
+    verbs.size.should eq(Gori::Import::LABELS.size)
   end
 end

--- a/src/gori/cli/run/import.cr
+++ b/src/gori/cli/run/import.cr
@@ -1,8 +1,9 @@
 # `gori run import` — bulk-import captured flows into the project's History from a
-# HAR export, a URL list, or an OpenAPI/Swagger spec (the CLI counterpart of the
-# TUI's Import overlay). Exactly one source flag is required. Import WRITES flows,
-# so it resolves its target like `discover` (--db create-or-reopen, else an existing
-# project — never silently a fresh default).
+# HAR export, a URL list, an OpenAPI/Swagger spec, a Postman or Insomnia collection,
+# or a Burp item export (the CLI counterpart of the TUI's Import overlay). Exactly one
+# source flag is required. Import WRITES flows, so it resolves its target like
+# `discover` (--db create-or-reopen, else an existing project — never silently a fresh
+# default).
 module Gori
   module CLI
     module Run
@@ -10,32 +11,45 @@ module Gori
         db_path : String? = nil
         project_name : String? = nil
         format = :text
-        har : String? = nil
-        oas : String? = nil
-        urls : String? = nil
+        # One entry per source flag, in the order they appear in --help. Adding a format
+        # means adding a row here and a `p.on` below — nothing else in this file.
+        sources = {
+          :har      => nil.as(String?),
+          :urls     => nil.as(String?),
+          :oas      => nil.as(String?),
+          :postman  => nil.as(String?),
+          :insomnia => nil.as(String?),
+          :burp     => nil.as(String?),
+        }
 
         parser = OptionParser.new do |p|
-          p.banner = "Usage: gori run import (--har PATH | --oas PATH | --urls PATH) [options]\n\n" \
+          p.banner = "Usage: gori run import (--har PATH | --urls PATH | --oas PATH | --postman PATH | --insomnia PATH | --burp PATH) [options]\n\n" \
                      "Bulk-import flows into the project's History. Exactly one source is required:\n" \
-                     "  --har   a browser/proxy HAR (HTTP Archive) export\n" \
-                     "  --urls  a text file of URLs, one per line (# comments and blanks ignored)\n" \
-                     "  --oas   request templates from an OpenAPI/Swagger spec (JSON or YAML)"
-          p.on("--har=PATH", "Import a HAR (HTTP Archive) export") { |v| har = v }
-          p.on("--oas=PATH", "Import an OpenAPI/Swagger spec (JSON or YAML)") { |v| oas = v }
-          p.on("--urls=PATH", "Import a URL list (one URL per line)") { |v| urls = v }
+                     "  --har       a browser/proxy HAR (HTTP Archive) export\n" \
+                     "  --urls      a text file of URLs, one per line (# comments and blanks ignored)\n" \
+                     "  --oas       request templates from an OpenAPI/Swagger spec (JSON or YAML)\n" \
+                     "  --postman   request templates from a Postman Collection v2 export (JSON)\n" \
+                     "  --insomnia  request templates from an Insomnia v4 export (JSON)\n" \
+                     "  --burp      saved Burp items (XML) — request AND response, byte-exact"
+          p.on("--har=PATH", "Import a HAR (HTTP Archive) export") { |v| sources[:har] = v }
+          p.on("--urls=PATH", "Import a URL list (one URL per line)") { |v| sources[:urls] = v }
+          p.on("--oas=PATH", "Import an OpenAPI/Swagger spec (JSON or YAML)") { |v| sources[:oas] = v }
+          p.on("--postman=PATH", "Import a Postman Collection v2 export") { |v| sources[:postman] = v }
+          p.on("--insomnia=PATH", "Import an Insomnia v4 JSON export") { |v| sources[:insomnia] = v }
+          p.on("--burp=PATH", "Import a Burp Suite item export (XML)") { |v| sources[:burp] = v }
           p.on("--project=NAME", "Project to import into (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to import into (created if absent)") { |v| db_path = v }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args do |rest, _|
-            abort "gori run import: unexpected argument#{rest.size == 1 ? "" : "s"} #{rest.join(" ").inspect} — pass the file via --har PATH, --oas PATH, or --urls PATH" unless rest.empty?
+            abort "gori run import: unexpected argument#{rest.size == 1 ? "" : "s"} #{rest.join(" ").inspect} — pass the file via a source flag, e.g. --har PATH" unless rest.empty?
           end
           p.invalid_option { |f| abort "gori run import: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run import: missing value for #{f}" }
         end
         parser.parse(args)
 
-        kind, path = import_source(har, oas, urls)
+        kind, path = import_source(sources)
 
         store = open_store(resolve_import_project(project_name, db_path))
         result = begin
@@ -49,17 +63,19 @@ module Gori
         emit_import_result(kind, path, result, format)
       end
 
-      # Exactly one of --har/--oas/--urls. Zero or two+ is a clean usage error.
-      private def self.import_source(har : String?, oas : String?, urls : String?) : {Symbol, String}
+      # Exactly one source flag. Zero or two+ is a clean usage error.
+      private def self.import_source(sources : Hash(Symbol, String?)) : {Symbol, String}
         chosen = [] of {Symbol, String}
-        chosen << {:har, har} if har
-        chosen << {:oas, oas} if oas
-        chosen << {:urls, urls} if urls
+        sources.each { |kind, path| chosen << {kind, path} if path }
         case chosen.size
-        when 0 then abort "gori run import: a source is required — pass one of --har PATH, --oas PATH, or --urls PATH"
+        when 0 then abort "gori run import: a source is required — pass one of #{import_flags(sources)}"
         when 1 then chosen.first
         else        abort "gori run import: pass exactly one source (got #{chosen.map(&.[0]).join(", ")})"
         end
+      end
+
+      private def self.import_flags(sources : Hash(Symbol, String?)) : String
+        sources.keys.map { |k| "--#{k} PATH" }.join(", ")
       end
 
       # Import WRITES flows, so an explicit --db is create-or-reopened (like capture /
@@ -80,9 +96,9 @@ module Gori
       end
 
       # Mirrors the TUI Import toast wording (runner.cr#apply_import) so the CLI and TUI
-      # describe the same import the same way.
+      # describe the same import the same way. Both read `Import.label`.
       private def self.import_result_text(kind : Symbol, path : String, result : Import::Result) : String
-        s = "imported #{result.count} flow#{result.count == 1 ? "" : "s"} from #{import_label(kind)} · #{path}"
+        s = "imported #{result.count} flow#{result.count == 1 ? "" : "s"} from #{Import.label(kind)} · #{path}"
         s += " (#{result.skipped} #{result.skipped == 1 ? "entry" : "entries"} skipped)" if result.skipped > 0
         s
       end
@@ -95,15 +111,6 @@ module Gori
             j.field "count", result.count
             j.field "skipped", result.skipped
           end
-        end
-      end
-
-      private def self.import_label(kind : Symbol) : String
-        case kind
-        when :har  then "HAR"
-        when :urls then "URLs"
-        when :oas  then "OpenAPI"
-        else            kind.to_s
         end
       end
     end

--- a/src/gori/import.cr
+++ b/src/gori/import.cr
@@ -2,11 +2,32 @@ require "./import/builder"
 require "./import/har"
 require "./import/urls"
 require "./import/oas"
+require "./import/postman"
+require "./import/insomnia"
+require "./import/burp"
 
 module Gori
-  # Bulk-import captured flows from HAR files, URL lists, or OpenAPI specs.
+  # Bulk-import captured flows from HAR files, URL lists, OpenAPI specs, Postman or
+  # Insomnia collections, or a Burp item export.
   module Import
     record Result, count : Int32, skipped : Int32 = 0
+
+    # The human name of each source, in ONE place. The TUI card title, the TUI toast and the
+    # CLI result line all read it, so they cannot drift apart as sources are added — the
+    # comment in `ImportOverlay#label` promised one source of truth and, with six formats,
+    # three parallel `case`s is where that promise breaks.
+    LABELS = {
+      :har      => "HAR",
+      :urls     => "URLs",
+      :oas      => "OpenAPI",
+      :postman  => "Postman",
+      :insomnia => "Insomnia",
+      :burp     => "Burp",
+    }
+
+    def self.label(kind : Symbol) : String
+      LABELS[kind]? || kind.to_s
+    end
 
     # Parsed flows plus a count of malformed entries skipped. Every parser skips a
     # bad ENTRY (invalid base64 body, non-http URL scheme, wrong-shaped path item)
@@ -26,6 +47,18 @@ module Gori
       Oas.parse_file(path)
     end
 
+    def self.from_postman(path : String) : ParseResult
+      Postman.parse_file(path)
+    end
+
+    def self.from_insomnia(path : String) : ParseResult
+      Insomnia.parse_file(path)
+    end
+
+    def self.from_burp(path : String) : ParseResult
+      Burp.parse_file(path)
+    end
+
     # Insert every parsed pair into the store atomically. Returns the committed count.
     def self.insert_all(store : Store, pairs : Array(Builder::FlowPair)) : Int32
       batch = pairs.map do |pair|
@@ -40,10 +73,13 @@ module Gori
       raise Gori::Error.new("not a file: #{expanded}") unless File.file?(expanded)
 
       parsed = case kind
-               when :har  then from_har(expanded)
-               when :urls then from_urls(expanded)
-               when :oas  then from_oas(expanded)
-               else            raise Gori::Error.new("unknown import kind: #{kind}")
+               when :har      then from_har(expanded)
+               when :urls     then from_urls(expanded)
+               when :oas      then from_oas(expanded)
+               when :postman  then from_postman(expanded)
+               when :insomnia then from_insomnia(expanded)
+               when :burp     then from_burp(expanded)
+               else                raise Gori::Error.new("unknown import kind: #{kind}")
                end
       if parsed.flows.empty?
         # Preserve WHY nothing landed: if every entry was skipped as malformed, say so

--- a/src/gori/import/builder.cr
+++ b/src/gori/import/builder.cr
@@ -80,7 +80,14 @@ module Gori
       # second request into the stored head. This guard still fires. Unlike the request
       # TARGET — deliberately permissive now, a control byte there being the operator's own
       # payload (see HOST_INVALID above and DESIGN.md §7) — header-boundary import was not
-      # part of the #400 decision and stays rejected pending its own call. Reject the entry
+      # part of the #400 decision and stays rejected here, for every source that DESCRIBES a
+      # request in parts (HAR, OpenAPI, URL lists, Postman, Insomnia) and has this Builder
+      # serialize a head from them. `Import::Raw` — the Burp item path — is the deliberate
+      # exception and does not pass through here at all: it stores the operator's own wire
+      # bytes byte-exact, where there is no boundary to forge because the bytes ARE the
+      # message. Do not "fix" that inconsistency by routing Raw through Builder; it would
+      # destroy the hand-forged requests that are the whole reason to import from Burp.
+      # Reject the entry
       # at the SAME point (a raise here is caught by every import parser's per-entry rescue,
       # dropping the bad entry exactly like a bad host). Only CR/LF/NUL: a header VALUE may
       # legally contain a horizontal tab (RFC 7230 §3.2 field-value), so bytes that merely

--- a/src/gori/import/burp.cr
+++ b/src/gori/import/burp.cr
@@ -1,0 +1,215 @@
+require "base64"
+require "time"
+require "./builder"
+require "./raw"
+
+module Gori
+  module Import
+    # Burp Suite's "Save items" XML export (Proxy history / Site map / Repeater tabs →
+    # right-click → Save items). Each `<item>` carries the full raw request and response as
+    # base64, which is why this is the only import source that reproduces a captured flow
+    # byte-for-byte instead of rebuilding one from parts (see `Import::Raw`).
+    #
+    # Deliberately parsed with a string scanner rather than `require "xml"`. libxml2 is not
+    # currently linked into gori, and pulling it in would mean adding `libxml2-dev` +
+    # `libxml2-static` (and its transitive static deps) to every packaging path that builds
+    # `--static` — docker/Dockerfile, the release workflow, flake.nix, Homebrew, AUR, snap —
+    # for one import format. Burp's export is machine-generated with a fixed, flat shape, so
+    # a scanner is sufficient and, as a side effect, has no XXE or entity-expansion surface
+    # at all. The bound: this is NOT a general XML parser. Namespaced, re-ordered or
+    # hand-edited variants (and Logger++/other third-party exports) are out of scope.
+    module Burp
+      # Tags read per item. Everything else Burp writes (`<status>`, `<responselength>`,
+      # `<mimetype>`, `<comment>`, …) is a projection of the raw messages we already store,
+      # so it is ignored rather than trusted — the wire bytes are the truth (P7).
+      def self.parse_file(path : String) : ParseResult
+        raw = File.read(path)
+        # A non-base64 `<request>`/`<response>` may carry raw bytes that are not valid UTF-8.
+        # Burp writes base64="true" for both by default, so this only guards the odd export;
+        # scrubbing keeps the scanner's ASCII needles working instead of raising mid-file.
+        raw = raw.scrub unless raw.valid_encoding?
+        raise Gori::Error.new("not a Burp item export (no <items> root): #{path}") unless raw.includes?("<items")
+
+        now = Time.utc.to_unix * 1_000_000
+        pairs = [] of Builder::FlowPair
+        skipped = 0
+        found = 0
+        pos = 0
+        while (block = next_element(raw, "item", pos))
+          inner, pos = block
+          found += 1
+          # One unparseable item (no URL, undecodable base64, a host that isn't a host) skips
+          # rather than discarding the rest of the export — the contract every parser shares.
+          begin
+            pairs << item_to_flow(inner, now)
+          rescue
+            skipped += 1
+          end
+        end
+        raise Gori::Error.new("no <item> entries in #{path}") if found == 0
+        ParseResult.new(pairs, skipped)
+      end
+
+      private def self.item_to_flow(item : String, now : Int64) : Builder::FlowPair
+        request = bytes_of(item, "request")
+        raise Gori::Error.new("item has no <request>") if request.nil? || request.empty?
+        url = item_url(item)
+        Raw.flow(created_at: started_at(item, now), url: url,
+          raw_request: request, raw_response: bytes_of(item, "response"))
+      end
+
+      # `<url>` is the authoritative origin; fall back to composing one from
+      # `<protocol>`/`<host>`/`<port>` for exports that omit it (some Site-map saves do).
+      private def self.item_url(item : String) : String
+        if url = text_of(item, "url").presence
+          return url
+        end
+        host = text_of(item, "host").presence || raise Gori::Error.new("item has no <url> or <host>")
+        proto = text_of(item, "protocol").presence || "https"
+        port = text_of(item, "port").presence
+        port && !port.empty? ? "#{proto}://#{host}:#{port}" : "#{proto}://#{host}"
+      end
+
+      # Burp writes Java's `Date.toString()` — `Tue Mar 05 12:34:56 KST 2024` — NOT RFC 3339,
+      # and Crystal cannot parse a zone ABBREVIATION (`%Z` wants a loadable location name).
+      # Drop the abbreviation and read the rest in UTC when it names UTC/GMT, else in the
+      # local zone: a Burp export is almost always opened on a machine in the same timezone
+      # it was captured in, which makes local the least-wrong reading of an ambiguous stamp.
+      # As in `har.cr#parse_started`, an unparseable stamp falls back to "now" — a timestamp
+      # surprise must never drop the item.
+      JAVA_DATE = /\A\w{3}\s+(\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s+(\S+)\s+(\d{4})\z/
+
+      private def self.started_at(item : String, now : Int64) : Int64
+        s = text_of(item, "time").strip
+        return now if s.empty?
+        time =
+          begin
+            Time.parse_rfc3339(s)
+          rescue Time::Format::Error
+            java_date(s)
+          end
+        time ? time.to_unix * 1_000_000 : now
+      end
+
+      private def self.java_date(s : String) : Time?
+        m = JAVA_DATE.match(s)
+        return nil unless m
+        zone = m[2].upcase
+        loc = zone.in?("UTC", "GMT", "Z") ? Time::Location::UTC : Time::Location.local
+        Time.parse("#{m[1]} #{m[3]}", "%b %d %H:%M:%S %Y", loc)
+      rescue Time::Format::Error
+        nil
+      end
+
+      # --- the scanner ---------------------------------------------------------
+
+      # The inner text of `<name …>…</name>` starting at `from`, plus the offset just past
+      # the closing tag. nil when there is no further occurrence.
+      private def self.next_element(src : String, name : String, from : Int32) : {String, Int32}?
+        needle = "<#{name}"
+        pos = from
+        while (open_at = src.index(needle, pos))
+          after = open_at + needle.size
+          ch = src[after]?
+          # `<response` must not match `<responselength`: the next char has to end the name.
+          unless ch && (ch.whitespace? || ch == '>' || ch == '/')
+            pos = after
+            next
+          end
+          gt = src.index('>', after)
+          return nil unless gt
+          return {"", gt + 1} if src[gt - 1] == '/' # <response/>
+          close = src.index("</#{name}>", gt + 1)
+          return nil unless close
+          return {src[(gt + 1)...close], close + name.size + 3}
+        end
+        nil
+      end
+
+      # `{attributes, inner}` for the first `<name>` in `src`.
+      private def self.element(src : String, name : String) : {String, String}?
+        needle = "<#{name}"
+        pos = 0
+        while (open_at = src.index(needle, pos))
+          after = open_at + needle.size
+          ch = src[after]?
+          unless ch && (ch.whitespace? || ch == '>' || ch == '/')
+            pos = after
+            next
+          end
+          gt = src.index('>', after)
+          return nil unless gt
+          attrs = src[after...gt]
+          return {attrs, ""} if attrs.ends_with?('/')
+          close = src.index("</#{name}>", gt + 1)
+          return nil unless close
+          return {attrs, src[(gt + 1)...close]}
+        end
+        nil
+      end
+
+      private def self.text_of(src : String, name : String) : String
+        el = element(src, name)
+        return "" unless el
+        _, inner = el
+        cdata?(inner) ? uncdata(inner) : unescape(inner)
+      end
+
+      # `<request base64="true">` is the default; `base64="false"` means the message sits
+      # inline as CDATA (Burp only does this for wholly-textual messages).
+      private def self.bytes_of(src : String, name : String) : Bytes?
+        el = element(src, name)
+        return nil unless el
+        attrs, inner = el
+        return nil if inner.empty?
+        if attrs.includes?(%(base64="true")) || attrs.includes?("base64='true'")
+          Base64.decode(inner.strip)
+        else
+          (cdata?(inner) ? uncdata(inner) : unescape(inner)).to_slice
+        end
+      end
+
+      private def self.cdata?(inner : String) : Bool
+        inner.lstrip.starts_with?("<![CDATA[")
+      end
+
+      # CDATA content is literal by definition — never entity-decoded.
+      private def self.uncdata(inner : String) : String
+        s = inner.strip
+        s = s[9..] if s.starts_with?("<![CDATA[")
+        s = s[0...-3] if s.ends_with?("]]>")
+        s
+      end
+
+      ENTITY = /&(#x[0-9a-fA-F]+|#\d+|[a-zA-Z]+);/
+
+      private def self.unescape(text : String) : String
+        return text unless text.includes?('&')
+        text.gsub(ENTITY) do |full, m|
+          e = m[1]
+          case e
+          when "amp"  then "&"
+          when "lt"   then "<"
+          when "gt"   then ">"
+          when "quot" then "\""
+          when "apos" then "'"
+          else
+            if e.starts_with?("#x") || e.starts_with?("#X")
+              e[2..].to_i?(16).try { |cp| safe_chr(cp) } || full
+            elsif e.starts_with?('#')
+              e[1..].to_i?.try { |cp| safe_chr(cp) } || full
+            else
+              full # an unknown named entity stays verbatim rather than vanishing
+            end
+          end
+        end
+      end
+
+      private def self.safe_chr(codepoint : Int32) : String?
+        return nil unless 0 <= codepoint <= Char::MAX_CODEPOINT
+        return nil if 0xD800 <= codepoint <= 0xDFFF # lone surrogate — not a Char
+        codepoint.unsafe_chr.to_s
+      end
+    end
+  end
+end

--- a/src/gori/import/insomnia.cr
+++ b/src/gori/import/insomnia.cr
@@ -1,0 +1,224 @@
+require "json"
+require "uri"
+require "base64"
+require "./builder"
+require "./vars"
+
+module Gori
+  module Import
+    # Insomnia's v4 JSON export (Application → Preferences → Data → Export Data → Insomnia
+    # v4 JSON). Like Postman this describes requests rather than captured traffic, so every
+    # entry lands as a response-less template via `Builder.pending_request`.
+    #
+    # Same bounds as `Postman`: auth seeds only bearer / basic / apikey-in-header, a
+    # `file`-typed form part is dropped, and a binary body (`fileName` with no `text`) is
+    # skipped rather than read off the exporter's disk.
+    module Insomnia
+      # Only HTTP requests. `websocket_request` and `grpc_request` are separate resource
+      # types that History has no request-shaped representation for.
+      REQUEST_TYPE = "request"
+
+      def self.parse_file(path : String) : ParseResult
+        raw = File.read(path)
+        # v5 (Insomnia 9+) exports YAML with a different tree entirely. Detect it by shape
+        # AND by extension so a mis-named file still gets the actionable message instead of
+        # "not valid JSON".
+        if v5?(raw) || File.extname(path).downcase.in?(".yaml", ".yml")
+          raise Gori::Error.new("this looks like an Insomnia v5 (YAML) export — re-export as \"Insomnia v4 (JSON)\"")
+        end
+        doc = begin
+          JSON.parse(raw)
+        rescue ex : JSON::ParseException
+          raise Gori::Error.new("Insomnia export is not valid JSON: #{ex.message}")
+        end
+        root = doc.as_h? || raise Gori::Error.new("Insomnia export is not a JSON object")
+        resources = root["resources"]?.try(&.as_a?)
+        raise Gori::Error.new("Insomnia export has no `resources` array — is this an Insomnia v4 export?") unless resources
+
+        vars = environment_table(resources)
+        now = Time.utc.to_unix * 1_000_000
+        pairs = [] of Builder::FlowPair
+        missing = Set(String).new
+        skipped = 0
+        found = 0
+        resources.each do |res|
+          h = res.as_h?
+          next unless h
+          next unless h["_type"]?.to_s == REQUEST_TYPE
+          found += 1
+          # One bad request skips; the rest of the export still imports.
+          begin
+            pairs << resource_to_flow(now, h, vars, missing)
+          rescue
+            skipped += 1
+          end
+        end
+        raise Gori::Error.new("Insomnia export has no request resources") if found == 0
+        # Same reasoning as Postman: a workspace whose `{{ _.base_url }}` lives in an
+        # environment that was not exported must not be reported as "malformed".
+        raise Gori::Error.new(unresolved_message(skipped, missing)) if pairs.empty? && !missing.empty?
+        ParseResult.new(pairs, skipped)
+      end
+
+      private def self.v5?(raw : String) : Bool
+        raw.includes?("collection.insomnia.rest/5") || raw.lstrip.starts_with?("type: collection")
+      end
+
+      # Insomnia keeps variables in `environment` resources: one BASE environment parented to
+      # the workspace, plus sub-environments parented to that base. Merge base first, then the
+      # first sub-environment — merging every sub would make the winner depend on export
+      # order, which is worse than picking one deterministically.
+      private def self.environment_table(resources : Array(JSON::Any)) : Vars::Table
+        envs = resources.compact_map do |res|
+          h = res.as_h?
+          next unless h
+          next unless h["_type"]?.to_s == "environment"
+          h
+        end
+        ids = envs.compact_map(&.["_id"]?.to_s.presence).to_set
+        base, subs = envs.partition { |h| !ids.includes?(h["parentId"]?.to_s) }
+        table = Vars::Table.new
+        (base + subs.first(1)).each do |h|
+          data = h["data"]?.try(&.as_h?)
+          next unless data
+          data.each { |k, v| table[k] = Vars.value_to_s(v) }
+        end
+        table
+      end
+
+      private def self.resource_to_flow(now : Int64, res : Hash(String, JSON::Any),
+                                        vars : Vars::Table, missing : Set(String)) : Builder::FlowPair
+        method = res["method"]?.to_s.presence || "GET"
+        url = resolve_url(res, vars, missing)
+        headers = header_list(res["headers"]?, vars)
+        body, content_type = body_of(res["body"]?, vars)
+        if content_type && !headers.any? { |(k, _)| k.compare("content-type", case_insensitive: true) == 0 }
+          headers << {"Content-Type", content_type}
+        end
+        headers.concat(auth_headers(res["authentication"]?, vars))
+        Builder.pending_request(now, url, method, headers, body)
+      end
+
+      # `url` plus the separate `parameters` array (Insomnia's query-param editor). Both are
+      # variable-expanded; a leftover `{{ … }}` in the URL rejects the entry, because
+      # `Builder::HOST_INVALID` would happily store `{{ _.base_url }}` as the host.
+      private def self.resolve_url(res : Hash(String, JSON::Any),
+                                   vars : Vars::Table, missing : Set(String)) : String
+        url = Vars.expand(res["url"]?.to_s.strip, vars)
+        query = query_string(res["parameters"]?, vars)
+        unless query.empty?
+          url = url.includes?('?') ? "#{url}&#{query}" : "#{url}?#{query}"
+        end
+        left = Vars.unresolved(url)
+        unless left.empty?
+          left.each { |n| missing << n }
+          raise Gori::Error.new("unresolved variable in URL: #{url}")
+        end
+        raise Gori::Error.new("templated host in URL: #{url}") if Vars.braced_authority?(url)
+        raise Gori::Error.new("request has an empty url") if url.empty?
+        url
+      end
+
+      private def self.query_string(node : JSON::Any?, vars : Vars::Table) : String
+        named(node, vars).map { |(k, v)| "#{URI.encode_www_form(k)}=#{URI.encode_www_form(v)}" }.join('&')
+      end
+
+      # Insomnia's rows are `{name, value, disabled}` (Postman uses `key`); `Vars.merge!`
+      # already accepts either, but headers and params must keep their ORDER and may repeat,
+      # so they are collected as a list rather than a table.
+      private def self.named(node : JSON::Any?, vars : Vars::Table) : Array({String, String})
+        arr = node.try(&.as_a?)
+        return [] of {String, String} unless arr
+        arr.compact_map do |item|
+          h = item.as_h?
+          next unless h
+          next if h["disabled"]?.try(&.as_bool?) == true
+          name = h["name"]?.to_s
+          next if name.empty?
+          {Vars.expand(name, vars), Vars.expand(Vars.value_to_s(h["value"]?), vars)}
+        end
+      end
+
+      private def self.header_list(node : JSON::Any?, vars : Vars::Table) : Builder::Headers
+        list = Builder::Headers.new
+        named(node, vars).each { |pair| list << pair }
+        list
+      end
+
+      FORM_BOUNDARY = "----GoriImportFormBoundary"
+
+      private def self.body_of(node : JSON::Any?, vars : Vars::Table) : {Bytes?, String?}
+        h = node.try(&.as_h?)
+        return {nil, nil} unless h
+        mime = h["mimeType"]?.to_s
+        case mime
+        when "application/x-www-form-urlencoded"
+          pairs = named(h["params"]?, vars).map do |(k, v)|
+            "#{URI.encode_www_form(k)}=#{URI.encode_www_form(v)}"
+          end
+          pairs.empty? ? {nil, nil} : {pairs.join('&').to_slice, mime}
+        when "multipart/form-data"
+          form_data(h["params"]?, vars)
+        else
+          # Everything else is stored as `text` — JSON, XML, GraphQL (already a JSON
+          # `{query, variables}` document), plain text. A body with only `fileName` names a
+          # path on the exporter's disk and yields no body at all.
+          text = Vars.expand(Vars.value_to_s(h["text"]?), vars)
+          return {nil, nil} if text.empty?
+          {text.to_slice, mime.presence}
+        end
+      end
+
+      private def self.form_data(node : JSON::Any?, vars : Vars::Table) : {Bytes?, String?}
+        arr = node.try(&.as_a?)
+        return {nil, nil} unless arr
+        text_parts = arr.select do |item|
+          h = item.as_h?
+          !!h && h["disabled"]?.try(&.as_bool?) != true && h["type"]?.to_s != "file"
+        end
+        pairs = named(JSON::Any.new(text_parts), vars)
+        return {nil, nil} if pairs.empty?
+        body = String.build do |b|
+          pairs.each do |(k, v)|
+            b << "--" << FORM_BOUNDARY << "\r\n"
+            b << %(Content-Disposition: form-data; name="#{k}") << "\r\n\r\n"
+            b << v << "\r\n"
+          end
+          b << "--" << FORM_BOUNDARY << "--\r\n"
+        end
+        {body.to_slice, "multipart/form-data; boundary=#{FORM_BOUNDARY}"}
+      end
+
+      private def self.auth_headers(node : JSON::Any?, vars : Vars::Table) : Builder::Headers
+        list = Builder::Headers.new
+        h = node.try(&.as_h?)
+        return list unless h
+        return list if h["disabled"]?.try(&.as_bool?) == true
+        field = ->(key : String) { Vars.expand(Vars.value_to_s(h[key]?), vars) }
+        case h["type"]?.to_s
+        when "bearer"
+          prefix = field.call("prefix").presence || "Bearer"
+          list << {"Authorization", "#{prefix} #{field.call("token")}"}
+        when "basic"
+          list << {"Authorization", "Basic #{Base64.strict_encode("#{field.call("username")}:#{field.call("password")}")}"}
+        when "apikey"
+          # `addTo` is "header" (default) or "queryParams"; only the header form is seeded,
+          # for the same reason as Postman — the URL is already built and validated by here.
+          if field.call("addTo").presence.in?(nil, "header")
+            list << {field.call("key").presence || "X-API-Key", field.call("value")}
+          end
+        end
+        list
+      end
+
+      private def self.unresolved_message(skipped : Int32, missing : Set(String)) : String
+        shown = missing.to_a.sort!
+        names = shown.first(8).map { |n| "{{#{n}}}" }.join(", ")
+        names += ", …" if shown.size > 8
+        "no flows imported: #{skipped} #{skipped == 1 ? "request references" : "requests reference"} " \
+        "variables not present in the exported environments (#{names}) — export the workspace with " \
+        "its environment, or define them in the base environment"
+      end
+    end
+  end
+end

--- a/src/gori/import/postman.cr
+++ b/src/gori/import/postman.cr
@@ -1,0 +1,354 @@
+require "json"
+require "uri"
+require "base64"
+require "./builder"
+require "./vars"
+
+module Gori
+  module Import
+    # Postman Collection v2.0 / v2.1 (the JSON a collection's "Export" button writes). Like
+    # OpenAPI this is a description of requests, not captured traffic, so every entry lands
+    # as a response-less template via `Builder.pending_request`.
+    #
+    # Bounded on purpose, in the same spirit as `Oas.api_key_header_schemes`:
+    #   * auth seeds only `bearer`, `basic` and `apikey`-in-header. oauth1/oauth2, awsv4,
+    #     ntlm, digest, hawk and edgegrid need a live token exchange or a signing step, so a
+    #     fabricated header would be worse than none.
+    #   * body modes `raw`, `urlencoded`, `graphql` and `formdata` (text parts) are built.
+    #     `file` mode names a path on the exporter's disk — an import never reads it.
+    #   * saved `response` examples are ignored. They are Postman's own mock data, not a
+    #     response the operator observed, and History would present them as if they were.
+    module Postman
+      # Folders nest arbitrarily; a flat read of `collection.item` imports almost nothing
+      # from a real export. The cap is a runaway guard, not a real limit — no human-authored
+      # collection is 32 folders deep.
+      MAX_DEPTH = 32
+
+      def self.parse_file(path : String) : ParseResult
+        doc = begin
+          JSON.parse(File.read(path))
+        rescue ex : JSON::ParseException
+          raise Gori::Error.new("Postman collection is not valid JSON: #{ex.message}")
+        end
+        root = doc.as_h? || raise Gori::Error.new("Postman collection is not a JSON object")
+        if root["item"]?.nil? && root["requests"]?
+          raise Gori::Error.new("this is a Postman v1 collection — re-export it as Collection v2.1 (Export → Collection v2.1)")
+        end
+        items = root["item"]?.try(&.as_a?)
+        raise Gori::Error.new("Postman collection has no `item` array") unless items
+
+        now = Time.utc.to_unix * 1_000_000
+        pairs = [] of Builder::FlowPair
+        missing = Set(String).new
+        skipped = walk(items, Vars.merge!(Vars::Table.new, root["variable"]?), root["auth"]?,
+          0, now, pairs, missing)
+
+        # A collection whose `{{baseUrl}}` lives in a separate ENVIRONMENT file resolves to
+        # nothing, and the generic "all N entries were skipped as malformed" would blame the
+        # file. Name the variables instead — the collection is fine, it just isn't self-contained.
+        if pairs.empty? && !missing.empty?
+          raise Gori::Error.new(unresolved_message(skipped, missing))
+        end
+        ParseResult.new(pairs, skipped)
+      end
+
+      # Depth-first over the item tree. Folders (an `item` array) may scope their own
+      # `variable`/`auth`, both of which the nearest ancestor loses to.
+      private def self.walk(items : Array(JSON::Any), vars : Vars::Table, auth : JSON::Any?,
+                            depth : Int32, now : Int64,
+                            pairs : Array(Builder::FlowPair), missing : Set(String)) : Int32
+        return 0 if depth > MAX_DEPTH
+        skipped = 0
+        items.each do |node|
+          h = node.as_h?
+          next unless h
+          scoped = h["variable"]? ? Vars.merge!(vars.dup, h["variable"]) : vars
+          scoped_auth = h["auth"]? || auth
+          if kids = h["item"]?.try(&.as_a?)
+            skipped += walk(kids, scoped, scoped_auth, depth + 1, now, pairs, missing)
+            next
+          end
+          req = h["request"]?
+          next unless req
+          # One bad request (unresolved variable, non-http scheme, host-less URL) skips
+          # rather than aborting the collection — the contract every import parser shares.
+          begin
+            pairs << request_to_flow(now, req, scoped, scoped_auth, missing)
+          rescue
+            skipped += 1
+          end
+        end
+        skipped
+      end
+
+      private def self.request_to_flow(now : Int64, req : JSON::Any, vars : Vars::Table,
+                                       auth : JSON::Any?, missing : Set(String)) : Builder::FlowPair
+        # `"request": "https://example.com/x"` is legal shorthand for a bare GET.
+        if s = req.as_s?
+          return Builder.pending_request(now, resolve_url(s, vars, missing))
+        end
+        h = req.as_h? || raise Gori::Error.new("request is neither a URL string nor an object")
+        method = h["method"]?.to_s.presence || "GET"
+        url = url_of(h["url"]?, vars, missing)
+        headers = header_list(h["header"]?, vars)
+        body, content_type = body_of(h["body"]?, vars)
+        # An explicit Content-Type header always wins over the one the body mode implies.
+        if content_type && !headers.any? { |(k, _)| k.compare("content-type", case_insensitive: true) == 0 }
+          headers << {"Content-Type", content_type}
+        end
+        headers.concat(auth_headers(h["auth"]? || auth, vars))
+        Builder.pending_request(now, url, method, headers, body)
+      end
+
+      # --- URL -----------------------------------------------------------------
+
+      private def self.url_of(node : JSON::Any?, vars : Vars::Table, missing : Set(String)) : String
+        raise Gori::Error.new("request has no url") unless node
+        if s = node.as_s?
+          return resolve_url(s, vars, missing)
+        end
+        h = node.as_h? || raise Gori::Error.new("url is neither a string nor an object")
+        # `raw` is the canonical form Postman exports; the component fields are a parallel
+        # projection of it. Only compose when `raw` is absent (hand-assembled collections).
+        raw = h["raw"]?.try(&.as_s?).presence || compose(h)
+        fill_path_params(resolve_url(raw, vars, missing), h["variable"]?, vars)
+      end
+
+      private def self.resolve_url(raw : String, vars : Vars::Table, missing : Set(String)) : String
+        url = Vars.expand(raw.strip, vars)
+        # `Builder::HOST_INVALID` does not reject `{`/`}`, so `https://{{baseUrl}}/x` would
+        # otherwise be STORED with a literal host of `{{baseUrl}}` — a flow that can never be
+        # sent, indistinguishable in History from a real one. Record the names and skip.
+        left = Vars.unresolved(url)
+        unless left.empty?
+          left.each { |n| missing << n }
+          raise Gori::Error.new("unresolved variable in URL: #{url}")
+        end
+        raise Gori::Error.new("templated host in URL: #{url}") if Vars.braced_authority?(url)
+        raise Gori::Error.new("request has an empty url") if url.empty?
+        url
+      end
+
+      # `url` as an object: {protocol, host: [...], port, path: [...], query: [{key,value}]}.
+      # Only reached when `raw` is absent — Postman writes `raw` for everything it exports,
+      # but a hand-assembled or API-generated collection may omit it.
+      private def self.compose(h : Hash(String, JSON::Any)) : String
+        proto = h["protocol"]?.to_s.presence || "https"
+        host = join_parts(h["host"]?, '.')
+        return "" if host.empty?
+        port = h["port"]?.to_s.presence
+        path = join_parts(h["path"]?, '/')
+        query = (h["query"]?.try(&.as_a?) || [] of JSON::Any).compact_map do |q|
+          qh = q.as_h?
+          next unless qh
+          next if qh["disabled"]?.try(&.as_bool?) == true
+          key = qh["key"]?.to_s
+          next if key.empty?
+          "#{key}=#{Vars.value_to_s(qh["value"]?)}"
+        end.join('&')
+        String.build do |b|
+          b << proto << "://" << host
+          b << ':' << port if port
+          b << '/' << path unless path.empty?
+          b << '?' << query unless query.empty?
+        end
+      end
+
+      # `host`/`path` are arrays of segments ("api", "example", "com"), but both are
+      # sometimes a plain string in hand-written collections.
+      private def self.join_parts(node : JSON::Any?, sep : Char) : String
+        return "" unless node
+        if s = node.as_s?
+          return s.strip(sep)
+        end
+        arr = node.as_a?
+        return "" unless arr
+        arr.map(&.to_s).reject(&.empty?).join(sep)
+      end
+
+      # `/users/:id` + `url.variable: [{key: "id", value: "1"}]` -> `/users/1`, mirroring
+      # `Oas.fill_path_params`. `:name` only matches a word after a colon, so neither
+      # `https://` nor a `:443` port is touched (and an undeclared `:token` passes through).
+      PATH_PARAM = /:([A-Za-z_][A-Za-z0-9_-]*)/
+
+      private def self.fill_path_params(url : String, node : JSON::Any?, vars : Vars::Table) : String
+        table = Vars.merge!(Vars::Table.new, node)
+        return url if table.empty?
+        url.gsub(PATH_PARAM) { |full, m| table[m[1]]?.try { |v| Vars.expand(v, vars) } || full }
+      end
+
+      # --- headers / body / auth ------------------------------------------------
+
+      private def self.header_list(node : JSON::Any?, vars : Vars::Table) : Builder::Headers
+        list = Builder::Headers.new
+        return list unless node
+        # v2.0 permits one raw "Name: value\n…" blob instead of the array.
+        if blob = node.as_s?
+          blob.each_line do |line|
+            name, sep, value = line.partition(':')
+            next if sep.empty? || name.strip.empty?
+            list << {Vars.expand(name.strip, vars), Vars.expand(value.strip, vars)}
+          end
+          return list
+        end
+        arr = node.as_a?
+        return list unless arr
+        arr.each do |item|
+          h = item.as_h?
+          next unless h
+          next if h["disabled"]?.try(&.as_bool?) == true
+          key = h["key"]?.to_s
+          next if key.empty?
+          list << {Vars.expand(key, vars), Vars.expand(Vars.value_to_s(h["value"]?), vars)}
+        end
+        list
+      end
+
+      # A fixed boundary (not a random one): imports must be reproducible, and two runs over
+      # the same collection should produce byte-identical flows.
+      FORM_BOUNDARY = "----GoriImportFormBoundary"
+
+      private def self.body_of(node : JSON::Any?, vars : Vars::Table) : {Bytes?, String?}
+        h = node.try(&.as_h?)
+        return {nil, nil} unless h
+        return {nil, nil} if h["disabled"]?.try(&.as_bool?) == true
+        case h["mode"]?.to_s
+        when "raw"
+          text = Vars.expand(Vars.value_to_s(h["raw"]?), vars)
+          text.empty? ? {nil, nil} : {text.to_slice, raw_content_type(h)}
+        when "urlencoded"
+          pairs = kv_pairs(h["urlencoded"]?, vars).map do |(k, v)|
+            "#{URI.encode_www_form(k)}=#{URI.encode_www_form(v)}"
+          end
+          pairs.empty? ? {nil, nil} : {pairs.join('&').to_slice, "application/x-www-form-urlencoded"}
+        when "formdata"
+          form_data(h["formdata"]?, vars)
+        when "graphql"
+          graphql(h["graphql"]?, vars)
+        else
+          {nil, nil} # "file" (a path on the exporter's disk) and anything unrecognised
+        end
+      end
+
+      # `options.raw.language` is Postman's editor hint; it is the only Content-Type signal a
+      # raw body carries when the request declares no explicit header.
+      private def self.raw_content_type(h : Hash(String, JSON::Any)) : String?
+        # Every hop guards with as_h? — JSON::Any#[]? RAISES on a non-Hash, and an options
+        # block shaped as an array/scalar would otherwise skip an otherwise-valid request.
+        opts = h["options"]?.try(&.as_h?).try(&.["raw"]?).try(&.as_h?)
+        lang = opts.try(&.["language"]?).to_s
+        case lang
+        when "json"       then "application/json"
+        when "xml"        then "application/xml"
+        when "html"       then "text/html"
+        when "javascript" then "application/javascript"
+        when "text"       then "text/plain"
+        end
+      end
+
+      private def self.kv_pairs(node : JSON::Any?, vars : Vars::Table) : Array({String, String})
+        arr = node.try(&.as_a?)
+        return [] of {String, String} unless arr
+        arr.compact_map do |item|
+          h = item.as_h?
+          next unless h
+          next if h["disabled"]?.try(&.as_bool?) == true
+          key = h["key"]?.to_s
+          next if key.empty?
+          {Vars.expand(key, vars), Vars.expand(Vars.value_to_s(h["value"]?), vars)}
+        end
+      end
+
+      private def self.form_data(node : JSON::Any?, vars : Vars::Table) : {Bytes?, String?}
+        arr = node.try(&.as_a?)
+        return {nil, nil} unless arr
+        text_parts = arr.select do |item|
+          h = item.as_h?
+          # A `type: "file"` part references a path on the exporter's machine. Dropping it
+          # keeps the other fields rather than discarding the whole request.
+          !!h && h["disabled"]?.try(&.as_bool?) != true && h["type"]?.to_s != "file"
+        end
+        pairs = kv_pairs(JSON::Any.new(text_parts), vars)
+        return {nil, nil} if pairs.empty?
+        body = String.build do |b|
+          pairs.each do |(k, v)|
+            b << "--" << FORM_BOUNDARY << "\r\n"
+            b << %(Content-Disposition: form-data; name="#{k}") << "\r\n\r\n"
+            b << v << "\r\n"
+          end
+          b << "--" << FORM_BOUNDARY << "--\r\n"
+        end
+        {body.to_slice, "multipart/form-data; boundary=#{FORM_BOUNDARY}"}
+      end
+
+      private def self.graphql(node : JSON::Any?, vars : Vars::Table) : {Bytes?, String?}
+        h = node.try(&.as_h?)
+        return {nil, nil} unless h
+        query = Vars.expand(Vars.value_to_s(h["query"]?), vars)
+        return {nil, nil} if query.empty?
+        variables = Vars.expand(Vars.value_to_s(h["variables"]?), vars).strip
+        body = String.build do |b|
+          b << %({"query":) << query.to_json
+          unless variables.empty?
+            # Postman stores `variables` as a STRING of JSON. Embed it as an object when it
+            # parses, else as a string, so the body is always valid JSON either way.
+            valid = begin
+              JSON.parse(variables)
+              true
+            rescue JSON::ParseException
+              false
+            end
+            b << %(,"variables":) << (valid ? variables : variables.to_json)
+          end
+          b << '}'
+        end
+        {body.to_slice, "application/json"}
+      end
+
+      # v2.1 stores auth params as `[{key, value, type}]`; v2.0 as a plain object.
+      private def self.auth_params(node : JSON::Any?, vars : Vars::Table) : Vars::Table
+        table = Vars::Table.new
+        return table unless node
+        if node.as_a?
+          Vars.merge!(table, node)
+        elsif h = node.as_h?
+          h.each { |k, v| table[k] = Vars.value_to_s(v) }
+        end
+        expanded = Vars::Table.new
+        table.each { |k, v| expanded[k] = Vars.expand(v, vars) }
+        expanded
+      end
+
+      private def self.auth_headers(node : JSON::Any?, vars : Vars::Table) : Builder::Headers
+        list = Builder::Headers.new
+        h = node.try(&.as_h?)
+        return list unless h
+        type = h["type"]?.to_s
+        return list if type.empty? || type == "noauth"
+        p = auth_params(h[type]?, vars)
+        case type
+        when "bearer"
+          list << {"Authorization", "Bearer #{p["token"]? || ""}"}
+        when "basic"
+          list << {"Authorization", "Basic #{Base64.strict_encode("#{p["username"]? || ""}:#{p["password"]? || ""}")}"}
+        when "apikey"
+          # apikey-in-query would have to be spliced into the URL, which is built and
+          # validated before auth is resolved; header is the common case and the only one seeded.
+          if (p["in"]? || "header") == "header"
+            list << {p["key"]?.presence || "X-API-Key", p["value"]? || ""}
+          end
+        end
+        list
+      end
+
+      private def self.unresolved_message(skipped : Int32, missing : Set(String)) : String
+        shown = missing.to_a.sort!
+        names = shown.first(8).map { |n| "{{#{n}}}" }.join(", ")
+        names += ", …" if shown.size > 8
+        "no flows imported: #{skipped} #{skipped == 1 ? "entry references" : "entries reference"} " \
+        "variables not defined in the collection (#{names}) — define them in the collection's " \
+        "\"variable\" list, or re-export with the environment merged in"
+      end
+    end
+  end
+end

--- a/src/gori/import/raw.cr
+++ b/src/gori/import/raw.cr
@@ -1,0 +1,92 @@
+require "./builder"
+require "../env"
+require "../flow_mapper"
+require "../proxy/codec/http1"
+
+module Gori
+  module Import
+    # Ingest for formats that carry a RAW HTTP message (the wire bytes) rather than a
+    # structured description of one — today that means Burp's item export.
+    #
+    # `Builder` is a SERIALIZER: it takes {method, target, headers, body} and writes a head.
+    # Round-tripping raw bytes through it would normalize the head, re-emit Content-Length
+    # and reject the entry on `Builder::HEADER_INJECT` — destroying exactly what makes a
+    # saved Burp item worth importing, since those are frequently hand-forged requests. So
+    # this path stores the head BYTE-EXACT and only derives the storage projections, which
+    # is the same stance the imported request TARGET already takes (#400, DESIGN.md §7).
+    module Raw
+      # `url` supplies scheme/host/port ONLY. The target comes from the raw request-line, so
+      # a smuggling payload in the path survives import verbatim; the URL is just how we
+      # learn which origin the operator captured it from.
+      def self.flow(created_at : Int64, url : String, raw_request : Bytes,
+                    raw_response : Bytes? = nil, duration_us : Int64? = nil) : Builder::FlowPair
+        scheme, host, port, _ = Builder.endpoint(url)
+
+        head, body = split(raw_request)
+        raise Gori::Error.new("empty raw request") if head.empty?
+        req = Proxy::Codec::Http1.parse_request_head(head)
+        stored, trunc, size = Builder.capped(body)
+        request = FlowMapper.request(req,
+          scheme: scheme, host: host, port: port, created_at: created_at,
+          body: stored, body_truncated: trunc, body_size: size)
+
+        return Builder::FlowPair.new(request, nil) if raw_response.nil? || raw_response.empty?
+
+        resp_head, resp_body = split(raw_response)
+        resp = Proxy::Codec::Http1.parse_response_head(resp_head)
+        resp_stored, resp_trunc, resp_size = Builder.capped(resp_body)
+        response = FlowMapper.response(resp, flow_id: 0,
+          body: resp_stored, duration_us: duration_us,
+          body_truncated: resp_trunc, body_size: resp_size)
+        Builder::FlowPair.new(request, response)
+      end
+
+      # Split wire bytes into {head, body}. Two things matter here:
+      #
+      # 1. The boundary is whichever blank line comes FIRST POSITIONALLY (`\n\n` or
+      #    `\r\n\r\n`), not whichever form is checked first — an LF-only head followed by a
+      #    body containing CRLFCRLF would otherwise split in the wrong place.
+      # 2. The head is CRLF-normalized. `Http1.parse_headers` scans for CRLF only and
+      #    returns an EMPTY header list for an LF-only head (see probe/from_repeater.cr),
+      #    so an editor-authored or Unix-normalized Burp item would import with no headers
+      #    at all. The BODY is never touched — it may be binary.
+      def self.split(bytes : Bytes) : {Bytes, Bytes?}
+        cut, skip = boundary(bytes)
+        head = Env.normalize_crlf(bytes[0, cut])
+        head = terminate(head)
+        body = skip > 0 && cut + skip < bytes.size ? bytes[(cut + skip)..].dup : nil
+        {head, body}
+      end
+
+      # {offset of the blank line, its length} — {bytes.size, 0} when the message is all head.
+      private def self.boundary(bytes : Bytes) : {Int32, Int32}
+        n = bytes.size
+        i = 0
+        while i < n
+          b = bytes.unsafe_fetch(i)
+          if b == 0x0A_u8 && i + 1 < n && bytes.unsafe_fetch(i + 1) == 0x0A_u8
+            return {i + 1, 1}
+          end
+          if b == 0x0D_u8 && i + 3 < n && bytes.unsafe_fetch(i + 1) == 0x0A_u8 &&
+             bytes.unsafe_fetch(i + 2) == 0x0D_u8 && bytes.unsafe_fetch(i + 3) == 0x0A_u8
+            return {i + 2, 2}
+          end
+          i += 1
+        end
+        {n, 0}
+      end
+
+      # Every stored head ends in CRLFCRLF (that is what live capture writes and what
+      # `Http1.read_head` returns), so a body-less item saved without its trailing blank
+      # line still round-trips through the Repeater unchanged.
+      private def self.terminate(head : Bytes) : Bytes
+        return head if head.size >= 4 && head[-4, 4] == "\r\n\r\n".to_slice
+        tail = head.size >= 2 && head[-2, 2] == "\r\n".to_slice ? "\r\n" : "\r\n\r\n"
+        buf = IO::Memory.new(head.size + tail.bytesize)
+        buf.write(head)
+        buf << tail
+        buf.to_slice
+      end
+    end
+  end
+end

--- a/src/gori/import/vars.cr
+++ b/src/gori/import/vars.cr
@@ -1,0 +1,92 @@
+require "json"
+
+module Gori
+  module Import
+    # `{{variable}}` substitution shared by the Postman and Insomnia parsers — the two
+    # request-collection formats that store templated URLs rather than concrete ones.
+    #
+    # Postman writes `{{baseUrl}}`; Insomnia v4 (nunjucks) writes `{{ _.baseUrl }}` and the
+    # older `{{ baseUrl }}`. One pattern covers all three: optional inner whitespace and an
+    # optional `_.` prefix.
+    module Vars
+      # `[^{}\s]+?` (non-greedy, no braces/space) keeps a stray `{{` in a JSON body from
+      # swallowing the rest of the string looking for a closing `}}`.
+      PLACEHOLDER = /\{\{\s*(?:_\.)?([^{}\s]+?)\s*\}\}/
+
+      alias Table = Hash(String, String)
+
+      # A variable's VALUE may itself hold placeholders — `baseUrl = "https://{{host}}/api"`
+      # is routine in real collections. One pass would leave `{{host}}` behind and the entry
+      # would be skipped as "references variables not defined in the collection", naming a
+      # variable that IS defined. So expand to a fixpoint, capped so a self-referential
+      # `a = "{{a}}"` terminates instead of spinning.
+      MAX_PASSES = 5
+
+      # Replace every placeholder `table` defines; leave the rest VERBATIM rather than
+      # blanking it. A leftover `{{token}}` in a header or body is a visible, greppable
+      # placeholder (the same stance `oas.cr` takes with its `PLACEHOLDER` header values);
+      # only the URL is checked for leftovers, by the callers, because there a leftover
+      # would become a literal stored host (see `unresolved`).
+      def self.expand(text : String, table : Table) : String
+        out = text
+        MAX_PASSES.times do
+          break unless out.includes?("{{")
+          pass = out.gsub(PLACEHOLDER) { |full, m| table[m[1]]? || full }
+          break if pass == out # nothing left this table can resolve
+          out = pass
+        end
+        out
+      end
+
+      # The placeholder NAMES still present after `expand`. Callers use this both to reject
+      # an entry (a templated host would otherwise be stored as the literal string
+      # `{{baseUrl}}` — `Builder::HOST_INVALID` does not reject `{`/`}`) and to report which
+      # variables were missing when a whole file resolves to nothing.
+      def self.unresolved(text : String) : Array(String)
+        return [] of String unless text.includes?("{{")
+        text.scan(PLACEHOLDER).map(&.[1])
+      end
+
+      # A brace left in the URL's AUTHORITY after expansion, from something `unresolved`
+      # cannot see: a variable whose value is a JSON object/array (`{"k":"v"}`), or a
+      # single-brace template form this parser does not speak. `Builder::HOST_INVALID`
+      # rejects control bytes and spaces but NOT `{`/`}`, so without this the flow is stored
+      # with a structurally impossible host. Only the authority is checked — a brace in the
+      # path, query or fragment is the operator's own data and stays verbatim.
+      def self.braced_authority?(url : String) : Bool
+        s = url
+        if i = s.index("://")
+          s = s[(i + 3)..]
+        end
+        cut = [s.index('/'), s.index('?'), s.index('#'), s.size].compact.min
+        authority = s[0, cut]
+        authority.includes?('{') || authority.includes?('}')
+      end
+
+      # Collect `[{key/name: …, value: …}]` — the shape Postman's `variable` array and
+      # Insomnia's environment `data` both reduce to — into a table, skipping disabled rows.
+      def self.merge!(table : Table, node : JSON::Any?) : Table
+        arr = node.try(&.as_a?)
+        return table unless arr
+        arr.each do |v|
+          h = v.as_h?
+          next unless h
+          next if h["disabled"]?.try(&.as_bool?) == true
+          key = (h["key"]? || h["name"]?).to_s
+          next if key.empty?
+          table[key] = value_to_s(h["value"]?)
+        end
+        table
+      end
+
+      # A variable value is usually a string but may be a number/bool (Postman does not
+      # enforce a type). `JSON::Any#to_s` on a string returns it unquoted, which is what a
+      # URL/header substitution wants; on a scalar it renders the literal.
+      def self.value_to_s(node : JSON::Any?) : String
+        return "" unless node
+        return "" if node.raw.nil?
+        node.as_s? || node.to_s
+      end
+    end
+  end
+end

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -848,12 +848,14 @@ module Gori
             end
 
             tool j, "import_flows",
-              "Bulk-import flows into the project's History from a HAR export, a URL list, or an " \
-              "OpenAPI/Swagger spec — the MCP equivalent of `gori run import`. `path` is read from " \
+              "Bulk-import flows into the project's History from a HAR export, a URL list, an " \
+              "OpenAPI/Swagger spec, a Postman Collection v2 or Insomnia v4 export, or a Burp Suite " \
+              "item export — the MCP equivalent of `gori run import`. `path` is read from " \
               "the MCP SERVER's local filesystem (this process runs locally, same trust boundary as " \
-              "send_request)." do |s|
-              s.field "kind", strprop("har | urls | oas"), required: true
-              s.field "path", strprop("filesystem path to the HAR/URL-list/OpenAPI file"), required: true
+              "send_request). Only `har` and `burp` carry responses; the rest import request " \
+              "templates with no response." do |s|
+              s.field "kind", strprop("har | urls | oas | postman | insomnia | burp"), required: true
+              s.field "path", strprop("filesystem path to the source file"), required: true
             end
 
             tool j, "create_rule",

--- a/src/gori/mcp/tools/import.cr
+++ b/src/gori/mcp/tools/import.cr
@@ -5,20 +5,26 @@ require "../../import"
 module Gori
   module MCP
     class Tools
-      # Bulk-import flows into the project's History from a HAR export, a URL list,
-      # or an OpenAPI/Swagger spec — the MCP counterpart of `gori run import`. `path`
-      # is resolved on the MCP SERVER's filesystem (same trust boundary as
-      # send_request/repeater — this process runs locally alongside the agent).
+      # Bulk-import flows into the project's History from a HAR export, a URL list, an
+      # OpenAPI/Swagger spec, a Postman or Insomnia collection, or a Burp item export —
+      # the MCP counterpart of `gori run import`. `path` is resolved on the MCP SERVER's
+      # filesystem (same trust boundary as send_request/repeater — this process runs
+      # locally alongside the agent).
+      KINDS = {
+        "har"      => :har,
+        "urls"     => :urls,
+        "oas"      => :oas,
+        "postman"  => :postman,
+        "insomnia" => :insomnia,
+        "burp"     => :burp,
+      }
+
       private def import_flows(h) : Result
         kind_s = str(h, "kind").try(&.strip.downcase)
-        unless kind_s.in?("har", "urls", "oas")
-          return err("invalid 'kind' (expected har|urls|oas)", "INVALID_ARGUMENT", field: "kind")
+        kind = kind_s.try { |k| KINDS[k]? }
+        unless kind_s && kind
+          return err("invalid 'kind' (expected #{KINDS.keys.join("|")})", "INVALID_ARGUMENT", field: "kind")
         end
-        kind = case kind_s
-               when "har"  then :har
-               when "urls" then :urls
-               else             :oas
-               end
         path = str(h, "path").try(&.strip)
         return err("missing required 'path'", "INVALID_ARGUMENT", field: "path") if path.nil? || path.empty?
         result = Import.import_file(store, kind, path)

--- a/src/gori/tui/import_overlay.cr
+++ b/src/gori/tui/import_overlay.cr
@@ -4,6 +4,7 @@ require "./frame"
 require "./text_field"
 require "./path_complete"
 require "./overlay"
+require "../import"
 
 module Gori::Tui
   # Centered popup collecting the source path for palette → "Import: HAR / URLs /
@@ -38,22 +39,20 @@ module Gori::Tui
     end
 
     # The source format, for the card title and the Runner's result toast — one source
-    # so the popup and the toast can't disagree about what was imported.
+    # so the popup, the toast and `gori run import` can't disagree about what was imported.
     def label : String
-      case @kind
-      when :har  then "HAR"
-      when :urls then "URLs"
-      when :oas  then "OpenAPI"
-      else            "file"
-      end
+      Import.label(@kind)
     end
 
     private def blurb : String
       case @kind
-      when :har  then "Load flows from a browser or proxy HAR export into History."
-      when :urls then "Load a text file of URLs into History — one URL per line."
-      when :oas  then "Build request templates from an OpenAPI spec into History."
-      else            "Load flows into History."
+      when :har      then "Load flows from a browser or proxy HAR export into History."
+      when :urls     then "Load a text file of URLs into History — one URL per line."
+      when :oas      then "Build request templates from an OpenAPI spec into History."
+      when :postman  then "Build request templates from a Postman Collection v2 export."
+      when :insomnia then "Build request templates from an Insomnia v4 JSON export."
+      when :burp     then "Load saved Burp items into History — request and response, byte-exact."
+      else                "Load flows into History."
       end
     end
 

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -3303,7 +3303,7 @@ module Gori::Tui
       screen.text({rect.right - hint.size - 1, x + iw}.max, rect.y, hint, Theme.muted, Theme.panel)
     end
 
-    # --- Import path popup (palette → import:har/urls/oas) -------------------
+    # --- Import path popup (palette → import.har/urls/oas/postman/insomnia/burp) ---
 
     private def open_import(kind : Symbol) : Nil
       ov = ImportOverlay.new(kind)
@@ -4470,6 +4470,18 @@ module Gori::Tui
 
     def import_oas : Nil
       open_import(:oas)
+    end
+
+    def import_postman : Nil
+      open_import(:postman)
+    end
+
+    def import_insomnia : Nil
+      open_import(:insomnia)
+    end
+
+    def import_burp : Nil
+      open_import(:burp)
     end
 
     # Palette / verb entry (`settings.*`): nothing to return to, so an editor opened here

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -131,6 +131,9 @@ module Gori
       abstract def import_har : Nil
       abstract def import_urls : Nil
       abstract def import_oas : Nil
+      abstract def import_postman : Nil
+      abstract def import_insomnia : Nil
+      abstract def import_burp : Nil
     end
   end
 end

--- a/src/gori/verbs/import.cr
+++ b/src/gori/verbs/import.cr
@@ -12,6 +12,15 @@ module Gori
       r.register Verb::Definition.new(
         "import.oas", "Import: OpenAPI", "Import request templates from an OpenAPI spec into History",
         Verb::Scope::Global, category: Verb::Category::Action) { |ctx| ctx.import_oas; nil }
+      r.register Verb::Definition.new(
+        "import.postman", "Import: Postman", "Import request templates from a Postman Collection v2 export",
+        Verb::Scope::Global, category: Verb::Category::Action) { |ctx| ctx.import_postman; nil }
+      r.register Verb::Definition.new(
+        "import.insomnia", "Import: Insomnia", "Import request templates from an Insomnia v4 JSON export",
+        Verb::Scope::Global, category: Verb::Category::Action) { |ctx| ctx.import_insomnia; nil }
+      r.register Verb::Definition.new(
+        "import.burp", "Import: Burp", "Import saved Burp items (request + response) into History",
+        Verb::Scope::Global, category: Verb::Category::Action) { |ctx| ctx.import_burp; nil }
     end
   end
 end


### PR DESCRIPTION
Import supported exactly three sources — HAR, a URL list, and OpenAPI — so the two formats an API team actually hands you (a Postman or Insomnia export) and the one a pentester already has open (a Burp item export) had no way in. This adds all three.

| Kind | Source | Shape |
|---|---|---|
| `postman` | Postman Collection v2.0/v2.1 JSON | request templates |
| `insomnia` | Insomnia v4 JSON export | request templates |
| `burp` | Burp Suite "Save items" XML | **request + response, byte-exact** |

Reachable from all three surfaces: palette (`Ctrl-P` → `Import: …`), `gori run import --postman/--insomnia/--burp PATH`, and MCP `import_flows`.

## Burp is stored byte-exact, which needed a new ingest layer

`Import::Builder` is a *serializer* — it takes `{method, target, headers, body}` and writes a head. Round-tripping raw bytes through it would normalize the head, re-emit `Content-Length`, and reject the entry on `HEADER_INJECT`, destroying precisely the hand-forged requests worth keeping.

`Import::Raw` instead normalizes CRLF (`Http1.parse_headers` returns an **empty** header list for an LF-only head — see `probe/from_repeater.cr`), splits at whichever blank line comes first *positionally*, and hands the bytes to `Http1.parse_*_head` + `FlowMapper` — the same projection live capture uses. Odd spacing, duplicate headers, a deliberately wrong `Content-Length` and a raw CRLF in the request target all survive to the wire; a spec proves it through `Repeater::FlowRequest.build`.

This matches the stance the imported request *target* already takes (#400, DESIGN.md §7). `builder.cr`'s `HEADER_INJECT` comment previously said header-boundary import "stays rejected pending its own call" — that call is made here, and the comment now names `Import::Raw` as the deliberate exception so the next reader doesn't "fix" it.

## No libxml2

Burp's XML is read with a ~60-line string scanner rather than `require "xml"`. libxml2 isn't linked into gori today: pulling it in would mean adding `libxml2-dev` + `libxml2-static` and its transitive static deps to `docker/Dockerfile`, the release workflow, `flake.nix`, Homebrew, AUR and snap — for one import format. Burp's export is machine-generated with a fixed flat shape, so a scanner suffices, and as a side effect there's no XXE or entity-expansion surface at all. The bound is stated in the module comment: this is **not** a general XML parser.

## Unresolved `{{variables}}` are skipped, not stored

`Builder::HOST_INVALID` rejects control bytes and spaces but not `{`/`}`, so `https://{{baseUrl}}/x` would otherwise be stored with a literal host of `{{baseUrl}}` — a flow that can never be sent and is indistinguishable in History from a real one. Only the **URL** is checked; a leftover in a header or body stays as a visible placeholder, the stance `oas.cr` already takes. A single-brace authority (`https://{host}.test`, or a variable whose value was a JSON object) is rejected the same way, while a brace in the *path* is the operator's data and stays verbatim.

Crucially, an all-skipped file must not be reported as malformed. Most real collections define `{{baseUrl}}` in a separate **environment** export, so the generic *"all 47 entries were skipped as malformed"* would blame a file that is perfectly well-formed. Both parsers track the distinct unresolved names and raise naming them instead:

```
no flows imported: 47 entries reference variables not defined in the collection
({{apiKey}}, {{baseUrl}}) — define them in the collection's "variable" list, or
re-export with the environment merged in
```

Expansion also runs to a fixpoint (capped at 5 passes): `baseUrl = "{{scheme}}://{{host}}"` is routine, and a single pass would leave `{{scheme}}` behind and then blame a variable that *is* defined.

## Bounded coverage, stated in each module comment

Mirroring `Oas.api_key_header_schemes`:

- **Postman** walks the item tree **recursively** — a flat read of `collection.item` imports almost nothing from a real export — and fills `:pathVariable` from `url.variable`. `url` may be a string, `{raw}`, or component parts. Body modes `raw`/`urlencoded`/`graphql`/`formdata` are built; `file` mode reads nothing off the exporter's disk. Auth resolves to the nearest ancestor, with `noauth` opting out. Saved `response` examples are ignored — they're mock data, and History would present them as observed.
- **Insomnia** merges the base environment with the first sub-environment; merging every sub would make the winner depend on export order.
- Both seed only `bearer`, `basic` and `apikey`-in-header. oauth2/awsv4/ntlm/digest/hawk need a live exchange or a signing step, and a fabricated header is worse than none.
- A v1 Postman collection and a v5 Insomnia YAML export each get an actionable *"re-export as …"* error rather than a confusing parse failure.

## Wiring

Six formats made three parallel `label` case statements the place drift starts, so `Import::LABELS` is now the single table the overlay title, the TUI toast and the CLI result line all read. Dispatch stays an explicit `case`, and the palette keeps one verb per source — `spec/verbs/import_spec.cr` pins *"one id → one intent, no shared dispatcher"*, and three new chordless verbs preserve it. The CLI's `import_source` takes the flag table rather than six positional params.

`gori run import` was also missing from the CLI reference entirely — table row and section added, EN and KO.

## Testing

`crystal spec` → **4597 examples, 0 failures**. 49 new examples across `spec/import/{postman,insomnia,burp}_spec.cr`, plus drift-detectors: the verb, CLI and MCP suites each iterate `Import::LABELS` and fail if a format was implemented but never registered in one of the three places it has to be.

Verified end to end via `gori run import` for all three formats: nested Postman folders land, no `{{` reaches a stored host, Burp items carry both request and response, and the Repeater rebuilds Burp requests byte-identically. The TUI overlay is covered by `MemoryBackend` renders asserting each blurb draws in full inside the card (catches clipping); no live TUI session was run.
