### PR TITLE
refactor(tui): give the Project tab sub-tabs instead of five tiled panes

### DIFF
--- a/spec/tui/project_view_spec.cr
+++ b/spec/tui/project_view_spec.cr
@@ -249,36 +249,64 @@ describe "ProjectView AT A GLANCE severity" do
 end
 
 describe "ProjectView#pane_at" do
-  it "hides the ENV pane on short terminals" do
-    tmp_store do |store|
-      view = ProjectView.new(Gori::Scope.load(store), Gori::HostOverrides.load(store))
-      rect = Rect.new(0, 0, 120, 14)
-      view.render(Screen.new(MemoryBackend.new(120, 14)), rect, focused: false)
-      view.env_pane_enabled?.should be_false
-      content_y = rect.y + 5
-      view.pane_at(rect, rect.x + 1, content_y).should eq(:scope)
-      view.pane_at(rect, rect.x + 1, rect.y + 10).should eq(:overrides)
-      (content_y...rect.y + rect.h).each do |y|
-        pane = view.pane_at(rect, rect.x + 1, y)
-        pane.should_not eq(:env) if pane
-      end
-    end
-  end
-
-  it "splits the body into overview + SCOPE/OVERRIDES/ENV (left) / DESCRIPTION over NETWORK (right)" do
+  # The body is now ONE card under a chip strip, not five tiles. The pane the strip selects is
+  # the pane the body belongs to — that mapping is what these pin.
+  it "gives the whole body to the active sub-tab" do
     tmp_store do |store|
       view = ProjectView.new(Gori::Scope.load(store), Gori::HostOverrides.load(store))
       rect = Rect.new(0, 0, 120, 30)
       view.render(Screen.new(MemoryBackend.new(120, 30)), rect, focused: false)
 
       view.pane_at(rect, rect.x + 1, rect.y).should eq(:overview)
-      content_y = rect.y + 12
-      view.pane_at(rect, rect.x + 1, content_y).should eq(:scope)
-      view.pane_at(rect, rect.x + 1, rect.y + 20).should eq(:overrides)
-      view.pane_at(rect, rect.x + 1, rect.y + 26).should eq(:env)
-      view.pane_at(rect, rect.right - 2, content_y).should eq(:desc)
-      view.pane_at(rect, rect.right - 2, rect.y + 26).should eq(:settings)
+      # SCOPE is active by default: both edges of the body belong to it, where the old tiling
+      # would have answered :desc on the right.
+      body_y = rect.y + 14
+      view.pane_at(rect, rect.x + 1, body_y).should eq(:scope)
+      view.pane_at(rect, rect.right - 2, body_y).should eq(:scope)
+
+      view.focus_pane(:settings)
+      view.render(Screen.new(MemoryBackend.new(120, 30)), rect, focused: false)
+      view.pane_at(rect, rect.x + 1, body_y).should eq(:settings)
       view.pane_at(Rect.new(0, 0, 0, 0), 0, 0).should be_nil
+    end
+  end
+
+  # ENV used to drop OUT OF THE TAB RING below a height threshold, so on a short terminal it was
+  # simply unreachable. Panes no longer share the body, so the ring is now height-independent —
+  # that is the behaviour worth pinning, not a pixel offset.
+  it "keeps every sub-tab in the Tab ring regardless of height" do
+    tmp_store do |store|
+      view = ProjectView.new(Gori::Scope.load(store), Gori::HostOverrides.load(store))
+      rect = Rect.new(0, 0, 120, 14) # short enough that the old layout hid ENV
+      view.render(Screen.new(MemoryBackend.new(120, 14)), rect, focused: false)
+
+      visited = [view.pane]
+      while view.pane_advance(1)
+        visited << view.pane
+      end
+      visited.should eq(Gori::Tui::ProjectView::PANES)
+    end
+  end
+
+  # The strip is how the mouse reaches a pane that is not currently drawn.
+  it "selects a sub-tab from a click on the chip strip" do
+    tmp_store do |store|
+      view = ProjectView.new(Gori::Scope.load(store), Gori::HostOverrides.load(store))
+      rect = Rect.new(0, 0, 160, 30)
+      view.render(Screen.new(MemoryBackend.new(160, 30)), rect, focused: true)
+      # Find the strip by scanning down for the row where more than one pane is addressable —
+      # that only happens on the chip row, since the body belongs to a single pane.
+      hits = [] of Symbol
+      (rect.y...rect.bottom).each do |y|
+        row = (rect.x...rect.right).compact_map { |x| view.pane_at(rect, x, y) }.uniq
+        next unless row.size > 1
+        hits = row
+        break
+      end
+      # Every pane is addressable from the strip, including ones the body is not showing.
+      hits.should contain(:scope)
+      hits.should contain(:settings)
+      hits.should contain(:env)
     end
   end
 end
@@ -289,10 +317,11 @@ describe "ProjectView NETWORK pane" do
       reset_projnet
       view = ProjectView.new(Gori::Scope.load(store), Gori::HostOverrides.load(store))
       view.refresh_settings
+      view.focus_pane(:settings) # the body shows one card at a time now
       b = MemoryBackend.new(120, 30)
       view.render(Screen.new(b), Rect.new(0, 0, 120, 30), focused: true)
       b.contains?("NETWORK").should be_true
-      b.contains?("ENVIRONMENT").should be_true
+      b.contains?("ENV").should be_true # the chip strip still names every sub-tab
       b.contains?("Scope lens").should be_true
       b.contains?("Sandbox").should be_true
       b.contains?("Bind IP").should be_true
@@ -311,6 +340,7 @@ describe "ProjectView NETWORK pane" do
       Gori::Settings.project_bind_port = 9100
       view = ProjectView.new(Gori::Scope.load(store), Gori::HostOverrides.load(store))
       view.refresh_settings
+      view.focus_pane(:settings)
       b = MemoryBackend.new(120, 30)
       view.render(Screen.new(b), Rect.new(0, 0, 120, 30), focused: true)
       b.contains?("9100").should be_true
@@ -329,8 +359,8 @@ describe "ProjectView NETWORK pane" do
       rect = Rect.new(0, 0, 120, 30)
       view.render(Screen.new(MemoryBackend.new(120, 30)), rect, focused: true) # establish geometry
 
-      view.set_row_at(rect, rect.right - 4, rect.y + 26).should_not be_nil # a row in the settings band
-      view.settings_dirty?.should be_false                                 # fresh, inherited pane
+      view.set_row_at(rect, rect.x + 4, rect.y + 16).should_not be_nil # a row in the (now full-width) settings card
+      view.settings_dirty?.should be_false                             # fresh, inherited pane
 
       view.select_setting(3) # Bind Port (row 0 lens, 1 sandbox, 2 bind IP, 3 bind port)
       view.settings_scope_row?.should be_false

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -58,8 +58,9 @@ module Gori::Tui
       @desc_mode = InputMode::Read
       @desc_read = TextReadState.new
 
-      @pane = :scope # :scope | :overrides | :desc
-      @sel = 0       # selected rule row in the SCOPE list
+      @pane = :scope   # :scope | :overrides | :env | :desc | :settings
+      @strip_start = 0 # first visible sub-tab chip (Chrome.render_tab_strip owns the window)
+      @sel = 0         # selected rule row in the SCOPE list
       # SCOPE add/edit is a centered popup (ScopeRuleOverlay), not an inline row.
 
       # HOST OVERRIDES pane: its own selection + inline add/edit row, fully independent
@@ -208,7 +209,12 @@ module Gori::Tui
       @desc_read.move(@desc_area, 0, delta * 4)
     end
 
-    PANES          = [:scope, :overrides, :env, :desc, :settings]
+    PANES = [:scope, :overrides, :env, :desc, :settings]
+    # Chip labels, in PANES order. Kept parallel rather than derived from the symbols so a
+    # label can read well ("HOST OVERRIDES") without renaming the pane it addresses.
+    PANE_LABELS = ["SCOPE", "HOST OVERRIDES", "ENV", "DESCRIPTION", "PROJECT SETTINGS"]
+    # One row for the sub-tab chips.
+    STRIP_H        =  1
     ENV_MIN_BODY_H = 11
 
     # NETWORK pane rows: two toggles (scope-lens, sandbox) over the three inline network
@@ -249,7 +255,9 @@ module Gori::Tui
     end
 
     private def enabled_panes : Array(Symbol)
-      PANES.reject { |p| p == :env && !@env_pane_enabled }
+      # Every pane is always reachable now that they no longer share the body — the old
+      # height-based ENV drop-out went away with the tiling.
+      PANES
     end
 
     def env_pane_enabled? : Bool
@@ -288,31 +296,42 @@ module Gori::Tui
       content_h >= ENV_MIN_BODY_H
     end
 
+    # SUB-TAB layout. The body shows ONE card at a time, under a chip strip, instead of
+    # tiling all five at once.
+    #
+    # Tiling was the previous design and it ran out of room: five cards split a single body
+    # between them, so SETTINGS got a fixed 6-row slice and ENV was DROPPED entirely below a
+    # height threshold (`env_pane_enabled?`) — a pane silently disappearing is a bad answer to
+    # "the terminal is short". One card at full size removes the threshold, and gives each
+    # editor room to grow (which is what let PROJECT SETTINGS take its per-project overrides).
+    #
+    # The 5-tuple contract is kept deliberately: the ACTIVE pane gets the whole content rect and
+    # the others get zero-height rects. Every existing geometry helper (scope_row_at,
+    # ov_row_at, settings_row_at, pane_at) then keeps working unchanged, because each already
+    # indexes this tuple — an inactive pane simply can't be hit.
     private def body_panes(rect : Rect) : {Rect, Rect, Rect, Rect, Rect}?
       oh = overview_h(rect)
       content = Rect.new(rect.x, rect.y + oh, rect.w, {rect.h - oh, 0}.max)
-      return nil if content.h < 2 || content.w < 4
-      left_w = {(content.w - 1) // 2, 1}.max
-      if env_pane_enabled?(content.h)
-        third = {content.h // 3, 2}.max
-        scope_h = third
-        ov_h = third
-        env_h = {content.h - scope_h - ov_h, 2}.max
-        env_rect = Rect.new(content.x, content.y + scope_h + ov_h, left_w, env_h)
-      else
-        scope_h = {content.h // 2, 1}.max
-        ov_h = {content.h - scope_h, 0}.max
-        env_rect = Rect.new(content.x, content.y + content.h, left_w, 0)
-      end
-      scope_rect = Rect.new(content.x, content.y, left_w, scope_h)
-      ov_rect = Rect.new(content.x, content.y + scope_h, left_w, ov_h)
-      right_x = content.x + left_w + 1
-      right_w = {content.w - left_w - 1, 0}.max
-      set_h = {SETTINGS_H, {content.h - MIN_DESC_H, 1}.max}.min
-      desc_h = {content.h - set_h, 0}.max
-      desc_rect = Rect.new(right_x, content.y, right_w, desc_h)
-      set_rect = Rect.new(right_x, content.y + desc_h, right_w, set_h)
-      {scope_rect, ov_rect, env_rect, desc_rect, set_rect}
+      return nil if content.h < 3 || content.w < 4
+      body = Rect.new(content.x, content.y + STRIP_H, content.w, {content.h - STRIP_H, 0}.max)
+      empty = Rect.new(content.x, content.y + content.h, content.w, 0)
+      active = pane_index
+      {
+        active == 0 ? body : empty,
+        active == 1 ? body : empty,
+        active == 2 ? body : empty,
+        active == 3 ? body : empty,
+        active == 4 ? body : empty,
+      }
+    end
+
+    # The one-row chip strip above the active card.
+    private def strip_rect(rect : Rect) : Rect
+      Rect.new(rect.x, rect.y + overview_h(rect), rect.w, STRIP_H)
+    end
+
+    private def pane_index : Int32
+      PANES.index(@pane) || 0
     end
 
     # --- mouse hit-testing (inverts render's offset math; coords are 0-based) ---
@@ -321,11 +340,16 @@ module Gori::Tui
       return nil if rect.empty? || !rect.contains?(mx, my)
       return :overview if my < rect.y + overview_h(rect)
       return nil unless panes = body_panes(rect)
-      return :scope if panes[0].contains?(mx, my)
-      return :overrides if panes[1].contains?(mx, my)
-      return :env if panes[2].h > 0 && panes[2].contains?(mx, my)
-      return :desc if panes[3].contains?(mx, my)
-      panes[4].contains?(mx, my) ? :settings : nil
+      # A click on the chip strip selects that sub-tab, so the mouse reaches every pane even
+      # though only one is rendered.
+      if strip_rect(rect).contains?(mx, my)
+        seg = Chrome.strip_segments(strip_rect(rect), PANE_LABELS, pane_index, @strip_start).find { |(_, r)| r.contains?(mx, my) }
+        return seg ? PANES[seg[0]] : nil
+      end
+      PANES.each_with_index do |pane, i|
+        return pane if panes[i].h > 0 && panes[i].contains?(mx, my)
+      end
+      nil
     end
 
     # Index of the scope-rule row clicked, or nil outside the populated list.
@@ -894,11 +918,13 @@ module Gori::Tui
       render_overview(screen, ov_rect)
       render_analytics(screen, Rect.new(band.right - vw, band.y, vw, band.h)) if vw > 0
       return unless panes = body_panes(rect)
-      render_scope_card(screen, panes[0], scope_focused)
-      render_overrides_card(screen, panes[1], ov_focused)
+      @strip_start = Chrome.render_tab_strip(screen, strip_rect(rect), PANE_LABELS, pane_index, focused, @strip_start)
+      # Only the active card is drawn; the rest are zero-height (see body_panes).
+      render_scope_card(screen, panes[0], scope_focused) if panes[0].h > 0
+      render_overrides_card(screen, panes[1], ov_focused) if panes[1].h > 0
       render_env_card(screen, panes[2], env_focused) if panes[2].h > 0
-      render_desc_card(screen, panes[3], desc_focused)
-      render_settings_card(screen, panes[4], settings_focused)
+      render_desc_card(screen, panes[3], desc_focused) if panes[3].h > 0
+      render_settings_card(screen, panes[4], settings_focused) if panes[4].h > 0
     end
 
     private def render_overview(screen : Screen, rect : Rect) : Nil


### PR DESCRIPTION
Groundwork for #440 (stays open — this is the layout half).

## Problem

The Project tab's body split one area between **five** panes at once — SCOPE, HOST OVERRIDES, ENV, DESCRIPTION, PROJECT SETTINGS. It was already out of room:

- PROJECT SETTINGS got a fixed 6-row slice;
- below a height threshold, the ENV pane was **dropped from the Tab ring entirely** (`env_pane_enabled?`). A pane silently becoming unreachable is a bad answer to "the terminal is short".

#440 needs three more fields in PROJECT SETTINGS, and there was nowhere to put them.

## Change

One card at a time under a chip strip, reusing `Chrome.render_tab_strip` / `strip_segments` — the same component the Preferences group strip uses, so the visual language matches rather than being reinvented. Each editor gets the full body, and the height threshold disappears along with the tiling.

**The 5-tuple `body_panes` contract is kept deliberately.** The active pane gets the whole content rect; the others get zero-height rects. Every existing geometry helper — `scope_row_at`, `ov_row_at`, `settings_row_at`, `pane_at` — already indexes that tuple, so they keep working unchanged and an inactive pane simply cannot be hit. `@pane` and the Tab ring are untouched too, which is why roughly 70 call sites across the view, the controller and the runner needed **no edits**. The alternative — replacing the pane model — would have been a far larger diff for the same result.

The chip strip is also how the **mouse** reaches a pane the body is not showing: `pane_at` hit-tests the strip first and maps a chip back to its pane symbol.

## Verification

`crystal spec`: **4548 examples, 0 failures**. ameba on `project_view.cr`: 6 findings, identical to the `main` baseline.

Four specs encoded the old tiling and are **rewritten rather than patched**, because what they asserted no longer exists. Two of my replacements had wrong premises and were corrected in turn, which is worth naming:

- a 14-row terminal has no body at all once the overview is drawn, so "ENV is reachable on a short terminal" cannot be a pixel assertion. It now pins the **Tab ring** — which is what actually changed, and what the old threshold actually broke;
- the strip chip reads `ENV`, not the card title `ENVIRONMENT`.

New coverage: the whole body belonging to the active sub-tab (both edges, where the old tiling answered `:desc` on the right), every pane staying in the ring at any height, and the strip being clickable to a pane the body is not showing.

## Next

The per-project override fields (`net.connect_timeout_secs`, `net.io_timeout_secs`, `net.capture_max_mib`) now have somewhere to go. As noted in [#440's scoping comment](https://github.com/hahwul/gori/issues/440#issuecomment-5086768387), the `effective_*` plumbing itself is small — every functional read already funnels through three `Settings` helpers — so the editor was the real cost, and this is it.

https://claude.ai/code/session_017X5VpbYNqcLneDkJkYYm1R