### PR TITLE
feat(settings): per-project connect/idle timeouts and capture limit

### DIFF
--- a/docs/content/reference/config.ko.md
+++ b/docs/content/reference/config.ko.md
@@ -512,13 +512,15 @@ retention은 **새 기능이 아닙니다** — gori는 프로젝트 DB가 무�
 
 ## 프로젝트별 오버라이드 {#per-project-overrides}
 
-프로젝트는 전역 파일을 수정하지 않고도 자체 네트워크 설정을 고정할 수 있습니다. 이 값들은 프로젝트 데이터베이스에 저장되며(키 `net.bind_host`, `net.bind_port`, `net.upstream_proxy`), **Project** 탭의 설정 패널에서 편집합니다.
+프로젝트는 전역 파일을 수정하지 않고도 자체 네트워크 설정을 고정할 수 있습니다. 이 값들은 프로젝트 데이터베이스에 저장되며(키 `net.bind_host`, `net.bind_port`, `net.upstream_proxy`, `net.connect_timeout_secs`, `net.io_timeout_secs`, `net.capture_max_mib`), **Project** 탭의 **PROJECT SETTINGS** 서브탭에서 편집합니다.
+
+타임아웃과 캡처 상한 키는 머신 속성이 아니라 engagement 속성입니다 — 느린 내부 장비는 자체 유휴 타임아웃이 필요하고, 아주 큰 응답을 주는 대상은 자체 캡처 상한이 필요합니다. 어느 쪽이든 전역으로 올리면 다른 모든 프로젝트가 비용을 치릅니다.
 
 열려 있는 프로젝트의 **유효 바인드 / 업스트림**:
 
 | Priority | Source |
 |----------|--------|
-| 1 (최우선) | 설정되어 있으면 프로젝트 DB `net.bind_host` / `net.bind_port` / `net.upstream_proxy` |
+| 1 (최우선) | 설정되어 있으면 프로젝트 DB `net.bind_host` / `net.bind_port` / `net.upstream_proxy` / `net.connect_timeout_secs` / `net.io_timeout_secs` / `net.capture_max_mib` |
 | 2 | CLI `--listen` / `--port` (전역 계층의 프로세스 한정 오버라이드) |
 | 3 | `settings.json` `network.*` |
 | 4 (최하위) | 공장 기본값 `127.0.0.1:8070` / 직접 연결 |

--- a/docs/content/reference/config.md
+++ b/docs/content/reference/config.md
@@ -512,13 +512,15 @@ Surfaces that do not own capture never prune, whatever the cap says: `gori mcp`'
 
 ## Per-Project Overrides
 
-A project can pin its own network settings without editing the global file. These are stored in the project database (keys `net.bind_host`, `net.bind_port`, `net.upstream_proxy`) and edited from the **Project** tab's settings pane.
+A project can pin its own network settings without editing the global file. These are stored in the project database (keys `net.bind_host`, `net.bind_port`, `net.upstream_proxy`, `net.connect_timeout_secs`, `net.io_timeout_secs`, `net.capture_max_mib`) and edited from the **Project** tab's **PROJECT SETTINGS** sub-tab.
+
+The timeout and capture-limit keys are engagement properties rather than machine ones: a slow internal appliance needs its own idle timeout, and one target returning very large responses needs its own capture cap — raising either globally would tax every other project.
 
 **Effective bind / upstream** for an open project:
 
 | Priority | Source |
 |----------|--------|
-| 1 (highest) | Project DB `net.bind_host` / `net.bind_port` / `net.upstream_proxy` when set |
+| 1 (highest) | Project DB `net.bind_host` / `net.bind_port` / `net.upstream_proxy` / `net.connect_timeout_secs` / `net.io_timeout_secs` / `net.capture_max_mib` when set |
 | 2 | CLI `--listen` / `--port` (process-only override of the global layer) |
 | 3 | `settings.json` `network.*` |
 | 4 (lowest) | Factory defaults `127.0.0.1:8070` / direct |

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -971,3 +971,57 @@ describe Gori::Settings do
     end
   end
 end
+
+# #440: three keys promoted from global-only to per-project. The assertions go through the
+# three LIVE helpers (connect_timeout / io_timeout / capture_max), not the effective_* readers,
+# because those helpers are what every functional read in the codebase actually calls — testing
+# the readers alone would pass even if the helpers had been left pointing at the global value.
+describe "per-project network overrides" do
+  it "prefers the project value and falls back to the global when unset" do
+    Gori::Settings.connect_timeout_secs = 30
+    Gori::Settings.io_timeout_secs = 30
+    Gori::Settings.capture_max_mib = 2
+
+    Gori::Settings.connect_timeout.should eq(30.seconds)
+    Gori::Settings.io_timeout.should eq(30.seconds)
+    Gori::Settings.capture_max.should eq(2 * 1024 * 1024)
+
+    Gori::Settings.project_connect_timeout_secs = 5
+    Gori::Settings.project_io_timeout_secs = 120
+    Gori::Settings.project_capture_max_mib = 20
+
+    Gori::Settings.connect_timeout.should eq(5.seconds)
+    Gori::Settings.io_timeout.should eq(120.seconds)
+    Gori::Settings.capture_max.should eq(20 * 1024 * 1024)
+  ensure
+    Gori::Settings.project_connect_timeout_secs = nil
+    Gori::Settings.project_io_timeout_secs = nil
+    Gori::Settings.project_capture_max_mib = nil
+    Gori::Settings.connect_timeout_secs = Gori::Settings::DEFAULT_CONNECT_TIMEOUT_SECS
+    Gori::Settings.io_timeout_secs = Gori::Settings::DEFAULT_IO_TIMEOUT_SECS
+    Gori::Settings.capture_max_mib = Gori::Settings::DEFAULT_CAPTURE_MAX_MIB
+  end
+
+  # Clearing the override must restore inheritance, so a later global edit propagates — the
+  # reason the Project pane deletes a KV key that equals the global instead of storing it.
+  it "resumes inheriting once the override is cleared" do
+    Gori::Settings.io_timeout_secs = 30
+    Gori::Settings.project_io_timeout_secs = 99
+    Gori::Settings.io_timeout.should eq(99.seconds)
+    Gori::Settings.project_io_timeout_secs = nil
+    Gori::Settings.io_timeout_secs = 45 # a later global edit
+    Gori::Settings.io_timeout.should eq(45.seconds)
+  ensure
+    Gori::Settings.project_io_timeout_secs = nil
+    Gori::Settings.io_timeout_secs = Gori::Settings::DEFAULT_IO_TIMEOUT_SECS
+  end
+
+  # The Int32 clamp has to live at the EFFECTIVE layer: a hand-edited project value reaches
+  # capture_max the same way a global one does, and an unclamped one overflows the proxy hot path.
+  it "clamps an out-of-range project capture cap, not just the global one" do
+    Gori::Settings.project_capture_max_mib = 99_999
+    Gori::Settings.capture_max.should eq(Gori::Settings::MAX_CAPTURE_MAX_MIB * 1024 * 1024)
+  ensure
+    Gori::Settings.project_capture_max_mib = nil
+  end
+end

--- a/src/gori/cli/run/repeater.cr
+++ b/src/gori/cli/run/repeater.cr
@@ -675,7 +675,7 @@ module Gori
         # Content-Length to the stored bytes so the request stays well-formed, but warn that
         # the resent body differs from what the origin originally received.
         if detail.request_body_truncated?
-          cap_mib = Settings.capture_max_mib
+          cap_mib = Settings.effective_capture_max_mib
           STDERR.puts "gori run repeater: request body was truncated at the #{cap_mib} MiB capture cap — resending the stored (shorter) body with a corrected Content-Length"
         end
 

--- a/src/gori/session.cr
+++ b/src/gori/session.cr
@@ -57,6 +57,9 @@ module Gori
         Settings.project_bind_host = store.setting(Settings::PROJECT_BIND_HOST_KEY)
         Settings.project_bind_port = store.setting(Settings::PROJECT_BIND_PORT_KEY).try(&.to_i?)
         Settings.project_upstream_proxy = store.setting(Settings::PROJECT_UPSTREAM_KEY)
+        Settings.project_connect_timeout_secs = store.setting(Settings::PROJECT_CONNECT_TIMEOUT_KEY).try(&.to_i?)
+        Settings.project_io_timeout_secs = store.setting(Settings::PROJECT_IO_TIMEOUT_KEY).try(&.to_i?)
+        Settings.project_capture_max_mib = store.setting(Settings::PROJECT_CAPTURE_MAX_KEY).try(&.to_i?)
         Env.load_project(store)
         config.listen = Settings.effective_bind_host
         config.port = Settings.effective_bind_port

--- a/src/gori/settings/network.cr
+++ b/src/gori/settings/network.cr
@@ -132,20 +132,39 @@ module Gori::Settings
     true
   end
 
+  def self.effective_connect_timeout_secs : Int32
+    project_connect_timeout_secs || connect_timeout_secs
+  end
+
+  def self.effective_io_timeout_secs : Int32
+    project_io_timeout_secs || io_timeout_secs
+  end
+
+  def self.effective_capture_max_mib : Int32
+    project_capture_max_mib || capture_max_mib
+  end
+
   # The dial timeouts as a Time::Span (what Upstream/the engines actually pass to the socket).
+  #
+  # THESE THREE HELPERS ARE THE WHOLE WIRING. Every functional read of a timeout or the capture
+  # cap goes through connect_timeout / io_timeout / capture_max — the raw properties are read
+  # only by the settings editors and two display strings — so routing them through effective_*
+  # covers every call site by construction rather than by an audit that can miss one.
   def self.connect_timeout : Time::Span
-    connect_timeout_secs.seconds
+    effective_connect_timeout_secs.seconds
   end
 
   def self.io_timeout : Time::Span
-    io_timeout_secs.seconds
+    effective_io_timeout_secs.seconds
   end
 
   # The capture cap in BYTES — the value CaptureBuffer/import bound a body to.
   # Clamped so a large (or hand-edited) MiB value can never overflow Int32 and break
   # the proxy hot path (see MAX_CAPTURE_MAX_MIB).
+  # Clamped at the EFFECTIVE layer, so a hand-edited project value can no more overflow Int32
+  # and break the proxy hot path than a global one can (see MAX_CAPTURE_MAX_MIB).
   def self.capture_max : Int32
-    capture_max_mib.clamp(1, MAX_CAPTURE_MAX_MIB) * 1024 * 1024
+    effective_capture_max_mib.clamp(1, MAX_CAPTURE_MAX_MIB) * 1024 * 1024
   end
 
   # Per-project network overrides — a RUNTIME layer set by Session.open from the OPEN
@@ -157,9 +176,18 @@ module Gori::Settings
   PROJECT_BIND_HOST_KEY = "net.bind_host"
   PROJECT_BIND_PORT_KEY = "net.bind_port"
   PROJECT_UPSTREAM_KEY  = "net.upstream_proxy"
+  # Promoted from global-only (#440). These are ENGAGEMENT properties, not machine ones: a slow
+  # internal appliance needs its own idle timeout, and one target returning fat JSON needs its
+  # own capture cap — raising either globally taxes every other project.
+  PROJECT_CONNECT_TIMEOUT_KEY = "net.connect_timeout_secs"
+  PROJECT_IO_TIMEOUT_KEY      = "net.io_timeout_secs"
+  PROJECT_CAPTURE_MAX_KEY     = "net.capture_max_mib"
   class_property project_bind_host : String? = nil
   class_property project_bind_port : Int32? = nil
   class_property project_upstream_proxy : String? = nil
+  class_property project_connect_timeout_secs : Int32? = nil
+  class_property project_io_timeout_secs : Int32? = nil
+  class_property project_capture_max_mib : Int32? = nil
 
   def self.effective_bind_host : String
     project_bind_host || bind_host

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -781,7 +781,7 @@ module Gori::Tui
     # ↵ keeps it so the user can fix it. Dirty-guarded so an unchanged pane never re-applies.
     private def commit_project_network(on_leave : Bool = false) : Nil
       return unless @project_view.settings_dirty?
-      host, port_s, upstream = @project_view.settings_values
+      host, port_s, upstream, connect_s, idle_s, cap_s = @project_view.settings_values
       return settings_invalid("bind IP is required", on_leave) if host.empty?
       port = port_s.to_i?
       unless port && 0 <= port <= 65535
@@ -790,8 +790,22 @@ module Gori::Tui
       if err = Settings.upstream_proxy_port_error(upstream)
         return settings_invalid(err, on_leave)
       end
-      @host.status(@host.apply_project_network(host, port, upstream))
+      connect = positive_secs(connect_s)
+      return settings_invalid("invalid connect timeout #{connect_s.inspect} (seconds, min 1)", on_leave) unless connect
+      idle = positive_secs(idle_s)
+      return settings_invalid("invalid idle timeout #{idle_s.inspect} (seconds, min 1)", on_leave) unless idle
+      cap = positive_secs(cap_s)
+      return settings_invalid("invalid capture limit #{cap_s.inspect} (MiB, min 1)", on_leave) unless cap
+      cap = cap.clamp(1, Settings::MAX_CAPTURE_MAX_MIB) # keep cap*1024*1024 inside Int32
+      @host.status(@host.apply_project_network(host, port, upstream, connect, idle, cap))
       @project_view.refresh_settings
+    end
+
+    # A whole number of at least 1, or nil. Shared by the three numeric project fields so they
+    # reject the same things (blank, non-numeric, 0, negative) with the same wording.
+    private def positive_secs(value : String) : Int32?
+      n = value.strip.to_i?
+      n && n >= 1 ? n : nil
     end
 
     private def settings_invalid(msg : String, on_leave : Bool) : Nil

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -2095,7 +2095,7 @@ module Gori::Tui
       trailer = [] of Highlight::Line
       if truncated
         trailer << Highlight::Line.new
-        trailer << [Highlight::Span.new("— body truncated at capture limit (#{Settings.capture_max_mib} MiB); full size in the list —", Theme.yellow)]
+        trailer << [Highlight::Span.new("— body truncated at capture limit (#{Settings.effective_capture_max_mib} MiB); full size in the list —", Theme.yellow)]
       end
 
       # gRPC: bounded framed hex view — style eagerly into `head`. Flagged binary so the

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -88,7 +88,7 @@ module Gori::Tui
       @set_sel = 0
       @set_values = ["", "", ""]
       @set_overridden = [false, false, false]
-      @set_baseline = {"", "", ""} # the three fields as last loaded; drives settings_dirty?
+      @set_baseline = {"", "", "", "", "", ""} # the six fields as last loaded; drives settings_dirty?
       @set_cursor = 0
       @set_preedit = ""
       load_settings_values
@@ -127,8 +127,22 @@ module Gori::Tui
     # override when pinned, else the global default (Session.open populated Settings.project_*
     # from this project's DB on open). @set_overridden drives the "· project/global" marker.
     private def load_settings_values : Nil
-      @set_values = [Settings.effective_bind_host, Settings.effective_bind_port.to_s, Settings.effective_upstream_proxy]
-      @set_overridden = [!Settings.project_bind_host.nil?, !Settings.project_bind_port.nil?, !Settings.project_upstream_proxy.nil?]
+      @set_values = [
+        Settings.effective_bind_host,
+        Settings.effective_bind_port.to_s,
+        Settings.effective_upstream_proxy,
+        Settings.effective_connect_timeout_secs.to_s,
+        Settings.effective_io_timeout_secs.to_s,
+        Settings.effective_capture_max_mib.to_s,
+      ]
+      @set_overridden = [
+        !Settings.project_bind_host.nil?,
+        !Settings.project_bind_port.nil?,
+        !Settings.project_upstream_proxy.nil?,
+        !Settings.project_connect_timeout_secs.nil?,
+        !Settings.project_io_timeout_secs.nil?,
+        !Settings.project_capture_max_mib.nil?,
+      ]
       @set_cursor = current_set_value.size
       @set_baseline = settings_values # capture the load state so "dirty" means the USER edited a field
     end
@@ -220,11 +234,15 @@ module Gori::Tui
     # NETWORK pane rows: two toggles (scope-lens, sandbox) over the three inline network
     # fields. The toggle/field boundary is FIELD_BASE — every field access is @set_sel minus
     # it (the fields still live in the 3-slot @set_values, indexed @set_sel - FIELD_BASE).
-    SETTINGS_LABELS      = ["Scope lens", "Sandbox", "Bind IP", "Bind Port", "Upstream proxy"]
+    # Row order is the tuple order everywhere (settings_values, @set_overridden, the controller's
+    # commit). The three timeout/capture fields were global-only until #440; they are ENGAGEMENT
+    # properties, so a slow appliance or a fat-response target no longer taxes every project.
+    SETTINGS_LABELS = ["Scope lens", "Sandbox", "Bind IP", "Bind Port", "Upstream proxy",
+                       "Connect timeout", "Idle timeout", "Capture limit"]
     SETTINGS_SCOPE_ROW   =  0
     SETTINGS_SANDBOX_ROW =  1
     SETTINGS_FIELD_BASE  =  2 # first inline-editable network-field row
-    SETTINGS_LABEL_W     = 14 # value column starts past the widest label ("Upstream proxy")
+    SETTINGS_LABEL_W     = 16 # value column starts past the widest label ("Connect timeout")
 
     def focus_first : Nil
       @pane = :scope
@@ -289,8 +307,8 @@ module Gori::Tui
       vw < VIZ_MIN_W ? 0 : vw
     end
 
-    SETTINGS_H = 7 # 2 toggle rows + 3 network fields + the card's top/bottom border
-    MIN_DESC_H = 3
+    SETTINGS_H = 10 # 2 toggle rows + 6 network fields + the card's top/bottom border
+    MIN_DESC_H =  3
 
     private def env_pane_enabled?(content_h : Int32) : Bool
       content_h >= ENV_MIN_BODY_H
@@ -448,8 +466,9 @@ module Gori::Tui
     end
 
     # The three network fields, trimmed, for commit: {bind IP, bind port, upstream proxy}.
-    def settings_values : {String, String, String}
-      {@set_values[0].strip, @set_values[1].strip, @set_values[2].strip}
+    def settings_values : {String, String, String, String, String, String}
+      {@set_values[0].strip, @set_values[1].strip, @set_values[2].strip,
+       @set_values[3].strip, @set_values[4].strip, @set_values[5].strip}
     end
 
     # True when the user edited a network field since it was last loaded. Diffs against the

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -4443,13 +4443,22 @@ module Gori::Tui
     # stored only when it DIFFERS from the current global (else the KV key is dropped, so the
     # project inherits — and later global edits propagate). Refreshes the Settings runtime
     # override layer, then rebinds the live proxy (the upstream is already live via effective_*).
-    def apply_project_network(bind_host : String, bind_port : Int32, upstream : String) : String
+    def apply_project_network(bind_host : String, bind_port : Int32, upstream : String,
+                              connect_secs : Int32, io_secs : Int32, capture_mib : Int32) : String
       set_or_clear(Settings::PROJECT_BIND_HOST_KEY, bind_host, Settings.bind_host)
       set_or_clear(Settings::PROJECT_BIND_PORT_KEY, bind_port.to_s, Settings.bind_port.to_s)
       set_or_clear(Settings::PROJECT_UPSTREAM_KEY, upstream, Settings.upstream_proxy)
+      set_or_clear(Settings::PROJECT_CONNECT_TIMEOUT_KEY, connect_secs.to_s, Settings.connect_timeout_secs.to_s)
+      set_or_clear(Settings::PROJECT_IO_TIMEOUT_KEY, io_secs.to_s, Settings.io_timeout_secs.to_s)
+      set_or_clear(Settings::PROJECT_CAPTURE_MAX_KEY, capture_mib.to_s, Settings.capture_max_mib.to_s)
       Settings.project_bind_host = bind_host == Settings.bind_host ? nil : bind_host
       Settings.project_bind_port = bind_port == Settings.bind_port ? nil : bind_port
       Settings.project_upstream_proxy = upstream == Settings.upstream_proxy ? nil : upstream
+      # Same equals-global-means-inherit rule as the three above: storing a duplicate would
+      # freeze the project against later global edits.
+      Settings.project_connect_timeout_secs = connect_secs == Settings.connect_timeout_secs ? nil : connect_secs
+      Settings.project_io_timeout_secs = io_secs == Settings.io_timeout_secs ? nil : io_secs
+      Settings.project_capture_max_mib = capture_mib == Settings.capture_max_mib ? nil : capture_mib
       apply_settings("project network saved")
     end
 

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -58,7 +58,8 @@ module Gori::Tui
     abstract def toggle_scope_lens : Nil       # flip the scope display lens (Project settings pane row/click)
     abstract def toggle_sandbox : Nil          # flip the scope sandbox — hard block gate (Project NETWORK pane row/click)
     # Persist + apply the Project settings pane's per-project network config; returns a toast.
-    abstract def apply_project_network(bind_host : String, bind_port : Int32, upstream : String) : String
+    abstract def apply_project_network(bind_host : String, bind_port : Int32, upstream : String,
+                                       connect_secs : Int32, io_secs : Int32, capture_mib : Int32) : String
   end
 
   # Shared, state-free body chrome used by BOTH Runner and the per-tab


### PR DESCRIPTION
Closes #440.

Builds on #454, which gave the Project tab sub-tabs so PROJECT SETTINGS had room for these fields.

## Change

Three keys whose own comments said *"Global-only (no per-project override)"* — `connect_timeout_secs`, `io_timeout_secs`, `capture_max_mib` — are engagement properties, not machine ones. A slow internal appliance needs its own idle timeout; one target returning fat JSON needs its own capture cap. Raising either globally taxes every other project.

## The wiring was three lines, not the audit the issue warned about

#440 said the promotion would break at step 2 because "every one of these has multiple read sites". [Scoping it](https://github.com/hahwul/gori/issues/440#issuecomment-5086768387) showed otherwise, and this PR confirms it: every **functional** read already goes through `Settings.connect_timeout` / `io_timeout` / `capture_max`. Routing those three helpers through the new `effective_*` readers covers every call site **by construction** rather than by an audit that can miss one.

The raw properties were read in exactly two other places, both display strings (a truncation notice and the repeater's cap report). Both now show the effective value, so a project-capped truncation notice states the project's number rather than the global one. After the change, `rg` finds **zero** raw reads outside the settings editors.

The `Int32` clamp moved to the effective layer: a hand-edited project value reaches `capture_max` the same way a global one does, and unclamped it overflows the proxy hot path.

## A silent drop the compiler did not catch

`ProjectView#settings_values` grew from a 3-tuple to a 6-tuple. The controller's

```crystal
host, port_s, upstream = @project_view.settings_values
```

**kept compiling.** Crystal allows destructuring fewer targets than the tuple holds, so the three new fields would have been read from the UI and thrown away, with no error anywhere and a pane that looked like it worked. Found by reading the call site, not by the build — worth recording, because the same shape will recur the next time one of these tuples grows.

## Everything else follows the existing pattern

`project_*` runtime properties, hydration in `Session.open` (all six assigned unconditionally, so switching projects resets cleanly), and `set_or_clear` dropping a KV key that equals the global — so a project keeps inheriting later global edits instead of freezing a duplicate.

## Verification

`crystal spec`: **4601 examples, 0 failures**. ameba: 63 findings across the touched files, identical to the `main` baseline.

Three new specs, asserting through the **live helpers** rather than the `effective_*` readers. That distinction is the test: checking the readers alone would pass even if the helpers had been left pointing at the global value — precisely the bug this change could otherwise have shipped. They cover project-wins/global-fallback, inheritance resuming after an override is cleared (so a later global edit propagates), and the clamp applying to a project value.

## Not included

`verify_upstream` and the workbench defaults (`discover` / `mine` / `fuzzer`), which are steps 2 and 3 of the split proposed in the issue. `verify_upstream` re-syncs the running proxy, the active prober and the Repeater/Fuzzer/Miner senders on toggle, so a project layer has to fire that resync on project *open* too — a different shape from these three value reads, and worth its own change.

## Docs

`reference/config.md` (+ `.ko`): the Per-Project Overrides section and its precedence table gain the three keys, plus a line on why they belong to the engagement.

https://claude.ai/code/session_017X5VpbYNqcLneDkJkYYm1R