### PR TITLE
feat(tui,settings): a Keys section for the command modifier, so ⌥ can front the shortcuts Ctrl can't reach

### DIFF
--- a/docs/content/getting-started/quick-start.ko.md
+++ b/docs/content/getting-started/quick-start.ko.md
@@ -210,6 +210,8 @@ gori wizard
 
 바인드 단계는 `settings.json`의 공유 기본값을 설정합니다. Preferences → **Network & Tabs** → **Network**와 같은 계층입니다. 프로젝트별 잠금이 아니며, 필요하면 Project 탭에서 평가마다 다른 주소를 고정하세요.
 
+마지막 **Review** 스텝은 선택한 값을 요약하며, 편집 가능한 행이 하나 있습니다 — **Shortcuts**입니다. `←`/`→`로 gori 내장 코드 패밀리(`^P` `^N` `^W` `^1-9`)의 모디파이어를 `Ctrl`과 `Option (⌥)` 사이에서 전환합니다. Option을 고르면 Ctrl을 대체하는 게 아니라 `⌥` 별칭이 *추가*됩니다 — 터미널이나 멀티플렉서가 Ctrl 형태를 전달하지 않을 때 유용합니다. macOS의 Option-as-Meta 요구사항은 [커맨드 모디파이어](/ko/guide/hotkeys/#command-modifier)를 참고하세요.
+
 ## 가이드 UI 투어 {#guided-ui-tour}
 
 탭/패널 이동, 팔레트, space 메뉴, READ/INS 편집 모드를 목업 UI로 따라가는 안내입니다. 실제 프록시 세션 없이 안전하게 실행할 수 있습니다. 각 레슨은 짧은 데모를 보여주고 실제 키를 눌러 보도록 요청하며, 마지막 단계는 네 가지 동작 모두를 직접 해보는 실습 샌드박스와 첫 세션 체크리스트입니다.

--- a/docs/content/getting-started/quick-start.md
+++ b/docs/content/getting-started/quick-start.md
@@ -210,6 +210,8 @@ gori wizard
 
 The bind step sets the shared default in `settings.json`, the same layer as Preferences → **Network & Tabs** → **Network**. It is not a per-project lock; pin a different address per engagement from the Project tab when needed.
 
+The final **Review** step recaps what you picked and carries one editable row: **Shortcuts**, which `←`/`→` flips between `Ctrl` and `Option (⌥)` for gori's built-in chord family (`^P` `^N` `^W` `^1-9`). Choosing Option *adds* `⌥` aliases rather than replacing Ctrl — useful when your terminal or multiplexer never delivers the Ctrl form. See [Command modifier](/guide/hotkeys/#command-modifier) for the macOS Option-as-Meta requirement.
+
 ## Guided UI tour
 
 A mock-UI walkthrough of tab/pane navigation, the palette, the space menu, and READ/INS edit mode. It is safe to run without a live proxy session. Each lesson shows a short demo and asks you to try the real key; the final step is a hands-on sandbox for all four moves, then a first-session checklist.

--- a/docs/content/guide/hotkeys.ko.md
+++ b/docs/content/guide/hotkeys.ko.md
@@ -63,7 +63,9 @@ Ctrl-P  → settings:hotkeys
 - **종료**: `Ctrl-C`, `Ctrl-D`.
 - **명명된 키와 구별 불가**: `Ctrl-M` / `Ctrl-J` (Enter), `Ctrl-I` (Tab), `Ctrl-H` (Backspace), `Ctrl-[` (Escape).
 - **구조적**: `Enter`, `Esc`, `Tab`, `Backspace`, 그리고 맨 `:`(명령줄).
-- **키맵보다 먼저 점유되는 gori 단축키**: `Ctrl-G` (go to line), `Ctrl-F` (find, `Tab`으로 find & replace), `Ctrl-B` (reveal whitespace), `Ctrl-E` (external editor), `Ctrl-P` (command palette), `Ctrl-N` (new repeater/fuzz/note), `Ctrl-W` (close sub-tab), 그리고 `Ctrl-1`…`Ctrl-9` (switch sub-tab). 이들은 키맵보다 먼저 하드코딩된 가드로 처리되므로, 여기에 바인딩해도 절대 발동하지 않습니다. 같은 이유로 **Command palette**, **New repeater request**, **New fuzz session**은 에디터에 나열되지 않습니다. 그 키는 고정입니다.
+- **키맵보다 먼저 점유되는 gori 단축키**: `Ctrl-G` (go to line), `Ctrl-F` (find, `Tab`으로 find & replace), `Ctrl-B` (reveal whitespace), `Ctrl-E` (external editor), `Ctrl-P` (command palette), `Ctrl-N` (new repeater/fuzz/note), `Ctrl-W` (close sub-tab), `Ctrl-,` (Preferences), 그리고 `Ctrl-1`…`Ctrl-9` (switch sub-tab). 이들은 키맵보다 먼저 하드코딩된 가드로 처리되므로, 여기에 바인딩해도 절대 발동하지 않습니다. 같은 이유로 **Command palette**, **New repeater request**, **New fuzz session**은 에디터에 나열되지 않습니다. 그 키는 고정입니다.
+
+  이 패밀리에서 개별 키를 옮길 수는 없지만, 패밀리 전체에 **두 번째 모디파이어**를 줄 수는 있습니다 — 아래 [커맨드 모디파이어](#command-modifier)를 참고하세요.
 
 `Ctrl-S` 같은 흐름 제어/시그널 코드는 예약되어 있지 **않습니다**. gori는 터미널을 raw 모드로 실행하므로 이들이 앱에 도달합니다(Repeater의 SNI 토글은 `Ctrl-S`로 제공됩니다).
 
@@ -73,6 +75,29 @@ Ctrl-P  → settings:hotkeys
 
 현재 OS별 기본값은 동일합니다. 터미널에서 `Ctrl`+글자 코드는 macOS, Linux, Windows 모두에서 애플리케이션에 도달하며, 정말 위험한 키는 위의 예약된 제어 문자들입니다(어디서나 차단됨). 프로파일 메커니즘은 실제 터미널별 충돌이 생겼을 때 디스패치를 건드리지 않고 바로잡을 수 있도록 마련해 둔 것입니다. 지금으로서는 `auto`가 모두에게 옳은 선택입니다.
 
+## 커맨드 모디파이어 {#command-modifier}
+
+*예약된 키*에 나열된 코드 패밀리는 키맵보다 먼저 하드코딩된 가드가 소비하기 때문에 고정입니다. 문제는 **터미널이 Ctrl 형태를 아예 전달하지 않는** 경우입니다.
+
+- **`Ctrl-1`…`Ctrl-9`는 상당수 터미널에서 전달 불가**입니다. 대응하는 제어 문자가 없어서 서브탭 점프가 애초에 도착하지 않습니다.
+- **멀티플렉서가 먼저 먹습니다.** tmux의 기본 프리픽스는 `Ctrl-B`인데, gori도 reveal-whitespace로 씁니다.
+
+**Preferences → Editor & Keys → Keys → Command modifier**(`Ctrl-,`), 또는 팔레트의 **`settings:keys`**에서 이 패밀리를 `Ctrl`과 `Option (⌥)` 사이에서 고를 수 있습니다. 이는 **교체가 아니라 별칭 추가**입니다. Option을 고르면 `⌥P`로도 팔레트가 열리고 `^P`도 그대로 동작합니다. 바뀌는 것은 *표시*뿐입니다 — 상태 힌트, Help 탭, 팔레트가 모두 `⌥P`, `⌥N`, `⌥1-9`로 표시됩니다.
+
+| 모디파이어 | 동작 |
+|-----------|------|
+| `Ctrl` (기본) | `^P` `^N` `^W` `^G` `^F` `^B` `^E` `^,` `^1`-`^9` |
+| `Option (⌥)` | 위 전부 **더하기** `⌥P` `⌥N` `⌥W` `⌥G` `⌥F` `⌥B` `⌥E` `⌥,` `⌥1`-`⌥9` |
+
+Ctrl이 계속 살아있으므로 Option을 골라도 팔레트에 못 들어가는 상황은 생기지 않습니다. 다만 바꾸기 전에 알아둘 점이 있습니다 — **macOS에서는 터미널이 Option을 Meta/Esc+로 보내도록 설정해야** 합니다. 그러지 않으면 `⌥P`가 `π`로 도착해 아무 일도 일어나지 않습니다.
+
+- **Terminal.app**: 설정 → 프로파일 → 키보드 → *Option을 Meta 키로 사용*
+- **iTerm2**: Settings → Profiles → Keys → Left/Right Option key → *Esc+*
+
+하지 않는 일 두 가지. 에디터에서 이미 재지정할 수 있는 코드(`^R` send, `^S` SNI 등)는 건드리지 않습니다 — 그건 동작별로 재지정하세요. 그리고 이 패밀리의 `Option` 코드(예: `alt-n`)에 어떤 동작을 바인딩해 뒀다면, 별칭을 켜는 순간 가려집니다. 가드가 이기고 해당 동작은 기본값으로 되돌아가며, 저장 토스트가 그 동작을 알려줍니다.
+
+첫 실행 마법사의 Review 스텝에서도 이 값을 요약해 보여주므로, 앱에 들어가기 전에 모디파이어를 고를 수 있습니다.
+
 ## 저장 위치 {#where-its-stored}
 
 `~/.gori/settings.json`(디렉터리는 `$GORI_HOME`으로 재정의)의 희소한 `hotkeys` 블록에 저장됩니다. 변경한 바인딩만 동작 id별 코드 라벨 목록으로 기록되며, 빈 목록은 명시적 바인딩 해제입니다.
@@ -81,6 +106,7 @@ Ctrl-P  → settings:hotkeys
 {
   "hotkeys": {
     "os": "auto",
+    "command_modifier": "alt",
     "bindings": {
       "rules.edit": ["g"],
       "scope.edit": []
@@ -88,6 +114,8 @@ Ctrl-P  → settings:hotkeys
   }
 }
 ```
+
+`command_modifier`는 `"ctrl"`(기본) 또는 `"alt"`이며, 알 수 없는 값은 `"ctrl"`로 되돌아갑니다. 손대지 않은 설치본은 `hotkeys` 블록 자체를 쓰지 않습니다.
 
 없는 동작은 프로파일 기본값을 사용합니다. 알 수 없는 id와 파싱 불가능한 코드는 로드할 때 무시되므로, 수동 편집이나 버전 차이가 있어도 무리 없이 동작합니다.
 

--- a/docs/content/guide/hotkeys.md
+++ b/docs/content/guide/hotkeys.md
@@ -63,7 +63,9 @@ Some keys can't be rebound because the terminal or gori needs them:
 - **Quit**: `Ctrl-C`, `Ctrl-D`.
 - **Indistinguishable from named keys**: `Ctrl-M` / `Ctrl-J` (Enter), `Ctrl-I` (Tab), `Ctrl-H` (Backspace), `Ctrl-[` (Escape).
 - **Structural**: `Enter`, `Esc`, `Tab`, `Backspace`, and a bare `:` (the command line).
-- **gori shortcuts claimed before the keymap**: `Ctrl-G` (go to line), `Ctrl-F` (find, then `Tab` for find & replace), `Ctrl-B` (reveal whitespace), `Ctrl-E` (external editor), `Ctrl-P` (command palette), `Ctrl-N` (new repeater/fuzz/note), `Ctrl-W` (close sub-tab), and `Ctrl-1`…`Ctrl-9` (switch sub-tab). These are handled by a hardcoded guard before the keymap, so a binding on them would never fire. For the same reason **Command palette**, **New repeater request**, and **New fuzz session** aren't listed in the editor. Their key is fixed.
+- **gori shortcuts claimed before the keymap**: `Ctrl-G` (go to line), `Ctrl-F` (find, then `Tab` for find & replace), `Ctrl-B` (reveal whitespace), `Ctrl-E` (external editor), `Ctrl-P` (command palette), `Ctrl-N` (new repeater/fuzz/note), `Ctrl-W` (close sub-tab), `Ctrl-,` (Preferences), and `Ctrl-1`…`Ctrl-9` (switch sub-tab). These are handled by a hardcoded guard before the keymap, so a binding on them would never fire. For the same reason **Command palette**, **New repeater request**, and **New fuzz session** aren't listed in the editor. Their key is fixed.
+
+  You can't move an individual key out of that family, but you *can* give the whole family a second modifier — see [Command modifier](#command-modifier) below.
 
 Flow-control/signal chords like `Ctrl-S` are **not** reserved; gori runs the terminal in raw mode, so they reach the app (Repeater's SNI toggle ships on `Ctrl-S`).
 
@@ -73,6 +75,29 @@ The `←` / `→` profile selector picks which **default** key set a fresh (un-o
 
 Today the per-OS defaults are identical: in a terminal, `Ctrl`+letter chords reach the application on macOS, Linux, and Windows alike, and the genuinely hazardous keys are the reserved control characters above (blocked everywhere). The profile mechanism is in place so a real per-terminal clash can be fixed without touching dispatch. For now, `auto` is the right choice for everyone.
 
+## Command Modifier {#command-modifier}
+
+The chord family listed under *Reserved keys* is fixed because a hardcoded guard runs before the keymap. That's a problem when your terminal never delivers the Ctrl form at all:
+
+- **`Ctrl-1`…`Ctrl-9` is undeliverable on many terminals** — there is no control character for it, so the sub-tab jumps simply never arrive.
+- **A multiplexer eats the chord first.** tmux's default prefix is `Ctrl-B`, which gori also uses for reveal-whitespace.
+
+**Preferences → Editor & Keys → Keys → Command modifier** (`Ctrl-,`), or **`settings:keys`** in the palette, switches that family between `Ctrl` and `Option (⌥)`. It is an **alias, not a swap**: with Option selected, `⌥P` opens the palette *and* `^P` still does. Only the advertised form changes — status hints, the Help tab and the palette all start showing `⌥P`, `⌥N`, `⌥1-9`.
+
+| Modifier | Effect |
+|----------|--------|
+| `Ctrl` (default) | `^P` `^N` `^W` `^G` `^F` `^B` `^E` `^,` `^1`-`^9` |
+| `Option (⌥)` | the above **plus** `⌥P` `⌥N` `⌥W` `⌥G` `⌥F` `⌥B` `⌥E` `⌥,` `⌥1`-`⌥9` |
+
+Because Ctrl keeps working, picking Option can never lock you out of the palette — worth knowing before you flip it, since **on macOS your terminal must be set to send Option as Meta/Esc+** or `⌥P` arrives as `π` and nothing happens:
+
+- **Terminal.app**: Settings → Profiles → Keyboard → *Use Option as Meta key*
+- **iTerm2**: Settings → Profiles → Keys → Left/Right Option key → *Esc+*
+
+Two things it does not do. It doesn't touch chords the editor can already rebind (`^R` send, `^S` SNI, …) — rebind those per action instead. And if you had bound an action to an `Option` chord in the family (`alt-n`, say), turning the alias on shadows it: the guard wins, that action reverts to its default, and the save toast names it.
+
+The first-run wizard recaps this on its Review step, so you can pick a modifier before ever reaching the app.
+
 ## Where It's Stored
 
 Saved to `~/.gori/settings.json` (override the directory with `$GORI_HOME`) under a sparse `hotkeys` block. Only the bindings you changed are written, as a list of chord labels per action id; an empty list is an explicit unbind:
@@ -81,6 +106,7 @@ Saved to `~/.gori/settings.json` (override the directory with `$GORI_HOME`) unde
 {
   "hotkeys": {
     "os": "auto",
+    "command_modifier": "alt",
     "bindings": {
       "rules.edit": ["g"],
       "scope.edit": []
@@ -88,6 +114,8 @@ Saved to `~/.gori/settings.json` (override the directory with `$GORI_HOME`) unde
   }
 }
 ```
+
+`command_modifier` is `"ctrl"` (the default) or `"alt"`; an unknown value falls back to `"ctrl"`. An untouched install writes no `hotkeys` block at all.
 
 An absent action uses the profile default. Unknown ids and unparseable chords are ignored on load, so hand-edits and version drift degrade gracefully.
 

--- a/docs/content/guide/settings.ko.md
+++ b/docs/content/guide/settings.ko.md
@@ -72,10 +72,13 @@ Theme 행은 현재 테마를 인라인으로 미리 보여줍니다. 이름과 
 | 섹션 | 필드 |
 |------|------|
 | **Editor** | External editor, Markdown highlight, Mouse, Pretty-print bodies |
+| **Keys** | Command modifier |
 | **Env** | 오프너: 아웃바운드 요청에 쓰는 전역 `$KEY` 변수 |
 | **Hotkeys** | 오프너: 단축키 재지정, OS 기본 프로파일 선택 |
 
-**External editor**는 편집 가능한 필드에서 `^E`가 여는 프로그램입니다. 비워 두면 `$VISUAL` / `$EDITOR` / `vi` 순으로 넘어갑니다. **Mouse**를 끄면 터미널 고유의 텍스트 선택이 돌아옵니다. [단축키](/ko/guide/hotkeys/)와 [환경 변수](/ko/guide/repeater-and-fuzzer/#environment-variables)를 참고하세요.
+**External editor**는 편집 가능한 필드에서 `^E`가 여는 프로그램입니다. 비워 두면 `$VISUAL` / `$EDITOR` / `vi` 순으로 넘어갑니다. **Mouse**를 끄면 터미널 고유의 텍스트 선택이 돌아옵니다.
+
+**Keys**와 **Hotkeys**는 한 쌍입니다. Keys는 gori 내장 코드 패밀리(`^P` `^N` `^W` `^1-9`)를 *어떤 모디파이어로* 열지 고르고(`Option (⌥)`은 Ctrl을 포기하지 않고 `⌥` 별칭을 추가 — Ctrl 형태가 전달되지 않는 터미널에 유용), Hotkeys는 *개별 동작*을 재지정합니다. [커맨드 모디파이어](/ko/guide/hotkeys/#command-modifier), [단축키](/ko/guide/hotkeys/), [환경 변수](/ko/guide/repeater-and-fuzzer/#environment-variables)를 참고하세요.
 
 ### Network & Tabs {#network-tabs}
 

--- a/docs/content/guide/settings.md
+++ b/docs/content/guide/settings.md
@@ -72,10 +72,13 @@ The Theme row previews the current theme inline, showing its name and a swatch o
 | Section | Fields |
 |---------|--------|
 | **Editor** | External editor, Markdown highlight, Mouse, Pretty-print bodies |
+| **Keys** | Command modifier |
 | **Env** | Opener: global `$KEY` variables for outbound requests |
 | **Hotkeys** | Opener: rebind any shortcut, or pick an OS default profile |
 
-**External editor** is what `^E` opens in editable fields; blank falls back to `$VISUAL` / `$EDITOR` / `vi`. Turning **Mouse** off restores your terminal's native text selection. See [Hotkeys](/guide/hotkeys/) and [environment variables](/guide/repeater-and-fuzzer/#environment-variables).
+**External editor** is what `^E` opens in editable fields; blank falls back to `$VISUAL` / `$EDITOR` / `vi`. Turning **Mouse** off restores your terminal's native text selection.
+
+**Keys** and **Hotkeys** are the pair: Keys picks *which modifier* fronts gori's built-in chord family (`^P` `^N` `^W` `^1-9`) — `Option (⌥)` adds `⌥` aliases without giving up Ctrl, for terminals that never deliver the Ctrl form — while Hotkeys rebinds *individual actions*. See [Command modifier](/guide/hotkeys/#command-modifier), [Hotkeys](/guide/hotkeys/) and [environment variables](/guide/repeater-and-fuzzer/#environment-variables).
 
 ### Network & Tabs
 

--- a/docs/content/reference/config.ko.md
+++ b/docs/content/reference/config.ko.md
@@ -503,7 +503,7 @@ retention은 **새 기능이 아닙니다** — gori는 프로젝트 DB가 무�
 | `tabs` | 표시/숨김할 TUI 탭 |
 | `hostname_overrides` | 전역 host → IP 다이얼 맵. 위의 [hostname_overrides](#hostname_overrides) 참고 |
 | `env` | Env 토큰 접두사와 전역 값. 위의 [env](#env) 참고 |
-| `hotkeys` | 키바인딩 오버라이드 (`os` 계층 + `bindings`). [단축키 가이드](/ko/guide/hotkeys/) 참고 |
+| `hotkeys` | 키바인딩 오버라이드 (`os` 계층 + `command_modifier` + `bindings`). [단축키 가이드](/ko/guide/hotkeys/) 참고 |
 | `decoder` | 마지막 입력과 체인, 저장된 Decoder 세션과 이름 붙인 체인 |
 | `mine` | Param Miner의 저장된 기본값. 위 [mine](#mine) 참고 |
 | `layout` | History / Probe / Issues 미리보기 + Sitemap 펼침 깊이. 위의 [layout](#layout) 참고 |

--- a/docs/content/reference/config.md
+++ b/docs/content/reference/config.md
@@ -503,7 +503,7 @@ Surfaces that do not own capture never prune, whatever the cap says: `gori mcp`'
 | `tabs` | Which TUI tabs are shown/hidden |
 | `hostname_overrides` | Global host → IP dial map. See [hostname_overrides](#hostname_overrides) above |
 | `env` | Env-token prefix and global values. See [env](#env) above |
-| `hotkeys` | Keybinding overrides (`os` layer + `bindings`). See the [Hotkeys guide](/guide/hotkeys/) |
+| `hotkeys` | Keybinding overrides (`os` layer + `command_modifier` + `bindings`). See the [Hotkeys guide](/guide/hotkeys/) |
 | `decoder` | Last input and chain, plus saved Decoder sessions and named chains |
 | `mine` | Saved Param Miner defaults. See [mine](#mine) above |
 | `layout` | History / Probe / Issues previews + Sitemap expand depth. See [layout](#layout) above |

--- a/spec/hotkeys_spec.cr
+++ b/spec/hotkeys_spec.cr
@@ -1,5 +1,16 @@
 require "./spec_helper"
 
+# Run `blk` with Settings.command_modifier pinned, restoring it afterwards.
+private def with_modifier(mod : String, &)
+  prev = Gori::Settings.command_modifier
+  begin
+    Gori::Settings.command_modifier = mod
+    yield
+  ensure
+    Gori::Settings.command_modifier = prev
+  end
+end
+
 describe Gori::Hotkeys do
   describe ".rebindable?" do
     it "excludes hidden verbs and the FIXED guard-shadowed/keyless ids" do
@@ -42,12 +53,57 @@ describe Gori::Hotkeys do
   end
 
   describe ".claimed?" do
-    it "covers the pre-keymap ctrl letter/digit set" do
+    it "covers the pre-keymap ctrl letter/digit/punct set" do
       Gori::Hotkeys.claimed?(Gori::Verb::Chord.new("p", ctrl: true)).should be_true
       Gori::Hotkeys.claimed?(Gori::Verb::Chord.new("1", ctrl: true)).should be_true
+      Gori::Hotkeys.claimed?(Gori::Verb::Chord.new(",", ctrl: true)).should be_true # ^, preferences
       Gori::Hotkeys.claimed?(Gori::Verb::Chord.new("c")).should be_false
       Gori::Hotkeys::CLAIMED_CTRL_LETTERS.should contain("g")
       Gori::Hotkeys::CLAIMED_CTRL_LETTERS.should contain("p")
+    end
+
+    it "claims the ⌥ twins only while the alias is on" do
+      with_modifier("ctrl") do
+        Gori::Hotkeys.claimed?(Gori::Verb::Chord.new("p", alt: true)).should be_false
+      end
+      with_modifier("alt") do
+        # Both forms fire the guard under the alias, so both must be refused a binding.
+        Gori::Hotkeys.claimed?(Gori::Verb::Chord.new("p", alt: true)).should be_true
+        Gori::Hotkeys.claimed?(Gori::Verb::Chord.new("p", ctrl: true)).should be_true
+        Gori::Hotkeys.claimed?(Gori::Verb::Chord.new("r", alt: true)).should be_false
+      end
+    end
+  end
+
+  describe ".retag" do
+    it "rewrites only the claimed family, and only under the alias" do
+      with_modifier("ctrl") do
+        Gori::Hotkeys.retag("^P cmds · ^R send").should eq("^P cmds · ^R send")
+      end
+      with_modifier("alt") do
+        Gori::Hotkeys.retag("^P cmds").should eq("⌥P cmds")
+        Gori::Hotkeys.retag("^1-9 jump · ^N new · ^W close").should eq("⌥1-9 jump · ⌥N new · ⌥W close")
+        Gori::Hotkeys.retag("^, preferences").should eq("⌥, preferences")
+        # NOT claimed — these keep their carets or the hints would lie.
+        Gori::Hotkeys.retag("^R send · ^S SNI · ^X hex · ^D quit").should eq("^R send · ^S SNI · ^X hex · ^D quit")
+      end
+    end
+  end
+
+  describe ".alias_conflicts" do
+    it "names verbs whose own alt binding the alias has just shadowed" do
+      reg = Gori::Verbs.registry
+      prev = Gori::Settings.keymap_overrides
+      begin
+        Gori::Settings.keymap_overrides = {"capture.toggle" => ["alt-n"], "scope.edit" => ["alt-r"]}
+        with_modifier("ctrl") { Gori::Hotkeys.alias_conflicts(reg).should be_empty }
+        with_modifier("alt") do
+          # alt-n is a claimed twin (^N new); alt-r is not claimed and survives.
+          Gori::Hotkeys.alias_conflicts(reg).should eq(["capture.toggle"])
+        end
+      ensure
+        Gori::Settings.keymap_overrides = prev
+      end
     end
   end
 
@@ -122,6 +178,29 @@ describe Gori::Hotkeys do
     it "allows ^S (shipped SNI default) and ordinary chords" do
       Gori::Hotkeys.reserved?(Gori::Verb::Chord.new("s", ctrl: true)).should be_nil
       Gori::Hotkeys.reserved?(Gori::Verb::Chord.new("g")).should be_nil
+    end
+
+    it "refuses the ⌥ twin under the alias and names it in the reason" do
+      with_modifier("ctrl") { Gori::Hotkeys.reserved?(Gori::Verb::Chord.new("p", alt: true)).should be_nil }
+      with_modifier("alt") do
+        Gori::Hotkeys.reserved?(Gori::Verb::Chord.new("p", alt: true)).should eq("⌥P is reserved by a gori shortcut")
+        Gori::Hotkeys.reserved?(Gori::Verb::Chord.new("s", alt: true)).should be_nil # still not claimed
+      end
+    end
+  end
+
+  describe ".binding_for under the ⌥ alias" do
+    it "advertises the alt twin for a claimed FIXED verb, and leaves others alone" do
+      reg = Gori::Verbs.registry
+      with_modifier("ctrl") do
+        Gori::Hotkeys.binding_for(reg, "app.palette").should eq(Gori::Verb::Chord.new("p", ctrl: true))
+      end
+      with_modifier("alt") do
+        Gori::Hotkeys.binding_for(reg, "app.palette").should eq(Gori::Verb::Chord.new("p", alt: true))
+        Gori::Hotkeys.binding_label(reg, "app.palette", "∅").should eq("⌥P")
+        # ^R (repeater send) is keymap-driven, not claimed — it must not move.
+        Gori::Hotkeys.binding_for(reg, "repeater.send").should eq(Gori::Verb::Chord.new("r", ctrl: true))
+      end
     end
   end
 

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -797,13 +797,14 @@ describe Gori::Settings do
     end
   end
 
-  it "omits the hotkeys block entirely when untouched (auto + no overrides)" do
+  it "omits the hotkeys block entirely when untouched (auto + default modifier + no overrides)" do
     dir = File.tempname("gori-settings-nohotkeys")
     Dir.mkdir_p(dir)
     prev = ENV["GORI_HOME"]?
     begin
       ENV["GORI_HOME"] = dir
       Gori::Settings.keymap_os = "auto"
+      Gori::Settings.command_modifier = Gori::Settings::DEFAULT_COMMAND_MODIFIER
       Gori::Settings.keymap_overrides = {} of String => Array(String)
       Gori::Settings.save.should be_true
       File.read(Gori::Settings.path).includes?("hotkeys").should be_false
@@ -811,6 +812,48 @@ describe Gori::Settings do
       prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
       FileUtils.rm_rf(dir)
       Gori::Settings.keymap_os = "auto"
+      Gori::Settings.command_modifier = Gori::Settings::DEFAULT_COMMAND_MODIFIER
+      Gori::Settings.keymap_overrides = {} of String => Array(String)
+    end
+  end
+
+  it "round-trips the command modifier — a modifier-only change must still write the block" do
+    dir = File.tempname("gori-settings-cmdmod")
+    Dir.mkdir_p(dir)
+    prev = ENV["GORI_HOME"]?
+    begin
+      ENV["GORI_HOME"] = dir
+      # Everything else at its default: the omit guard must NOT swallow the block here, or
+      # the setting would silently fail to persist.
+      Gori::Settings.keymap_os = "auto"
+      Gori::Settings.keymap_overrides = {} of String => Array(String)
+      Gori::Settings.command_modifier = "alt"
+      Gori::Settings.save.should be_true
+      written = File.read(Gori::Settings.path)
+      written.includes?("hotkeys").should be_true
+      written.includes?("command_modifier").should be_true
+
+      Gori::Settings.command_modifier = "ctrl"
+      Gori::Settings.load
+      Gori::Settings.command_modifier.should eq("alt")
+
+      # Tolerant: an unknown value clamps to the default.
+      File.write(Gori::Settings.path, %({"hotkeys":{"os":"auto","command_modifier":"meta"}}))
+      Gori::Settings.load
+      Gori::Settings.command_modifier.should eq(Gori::Settings::DEFAULT_COMMAND_MODIFIER)
+
+      # A hotkeys block written before this key existed must KEEP the current value rather
+      # than being reset by the absent key (the display.cr parse shape).
+      File.write(Gori::Settings.path, %({"hotkeys":{"os":"linux","bindings":{"rules.edit":["g"]}}}))
+      Gori::Settings.command_modifier = "alt"
+      Gori::Settings.load
+      Gori::Settings.command_modifier.should eq("alt")
+      Gori::Settings.keymap_os.should eq("linux")
+    ensure
+      prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(dir)
+      Gori::Settings.keymap_os = "auto"
+      Gori::Settings.command_modifier = Gori::Settings::DEFAULT_COMMAND_MODIFIER
       Gori::Settings.keymap_overrides = {} of String => Array(String)
     end
   end

--- a/spec/tui/keybind_spec.cr
+++ b/spec/tui/keybind_spec.cr
@@ -20,6 +20,18 @@ private alias Key = Termisu::Input::Key
 private alias Mod = Termisu::Input::Modifier
 private alias Chord = Gori::Verb::Chord
 
+# Run `blk` with Settings.command_modifier pinned, restoring it afterwards (the suite
+# shares one Settings singleton — see spec_helper's GORI_HOME).
+private def with_modifier(mod : String, &)
+  prev = Gori::Settings.command_modifier
+  begin
+    Gori::Settings.command_modifier = mod
+    yield
+  ensure
+    Gori::Settings.command_modifier = prev
+  end
+end
+
 describe Gori::Tui::Keybind do
   describe ".from_event named special keys" do
     it "maps Enter to \"enter\"" do
@@ -267,6 +279,76 @@ describe Gori::Tui::Keybind do
 
     it "returns a value-equal Chord (record equality) rather than an identity" do
       chord(Key::LowerG).should eq(Chord.new("g", ctrl: false, alt: false, shift: false))
+    end
+  end
+
+  # The ⌥ alias (settings:editor "Command modifier"). dealias folds the CLAIMED family's
+  # alt form onto its ctrl form at the event boundary, which is what lets the ~51
+  # hardcoded `ev.ctrl? && key.lower_p?` guards stay untouched.
+  describe ".dealias" do
+    it "is the identity while the modifier is ctrl (the default)" do
+      with_modifier("ctrl") do
+        ev = Gori::Tui::Keybind.dealias(key_event(Key::LowerP, Mod::Alt, 'p'))
+        ev.alt?.should be_true
+        ev.ctrl?.should be_false
+      end
+    end
+
+    it "folds ⌥ + a claimed letter onto its ctrl form" do
+      with_modifier("alt") do
+        ev = Gori::Tui::Keybind.dealias(key_event(Key::LowerP, Mod::Alt, 'p'))
+        ev.ctrl?.should be_true
+        ev.alt?.should be_false
+        ev.key.lower_p?.should be_true # the guards test exactly this
+      end
+    end
+
+    it "normalizes ⌥⇧ + letter (which arrives as UpperP) down to the lowercase ctrl form" do
+      with_modifier("alt") do
+        # "\eP" → Key.from_char('P'); Ctrl+Shift+P is byte-identical to ^P, so both must land
+        # on the same event or every `key.lower_p?` guard misses.
+        ev = Gori::Tui::Keybind.dealias(key_event(Key::UpperP, Mod::Alt | Mod::Shift, 'P'))
+        ev.ctrl?.should be_true
+        ev.shift?.should be_false
+        ev.key.lower_p?.should be_true
+      end
+    end
+
+    it "folds the claimed digits and ^, too" do
+      with_modifier("alt") do
+        dig = Gori::Tui::Keybind.dealias(key_event(Key::Num1, Mod::Alt, '1'))
+        dig.ctrl?.should be_true
+        (dig.char || dig.key.to_char).should eq('1') # the ^1-9 guards read this
+        com = Gori::Tui::Keybind.dealias(key_event(Key::Comma, Mod::Alt, ','))
+        com.ctrl?.should be_true
+        com.key.comma?.should be_true
+      end
+    end
+
+    it "leaves an unclaimed alt chord alone so it still reaches the keymap" do
+      with_modifier("alt") do
+        ev = Gori::Tui::Keybind.dealias(key_event(Key::LowerR, Mod::Alt, 'r'))
+        ev.alt?.should be_true
+        ev.ctrl?.should be_false
+        Gori::Tui::Keybind.from_event(ev).should eq(Chord.new("r", alt: true))
+      end
+    end
+
+    it "leaves a plain ctrl chord alone (the alias is additive, not a swap)" do
+      with_modifier("alt") do
+        ev = Gori::Tui::Keybind.dealias(key_event(Key::LowerP, Mod::Ctrl))
+        ev.ctrl?.should be_true
+        ev.alt?.should be_false
+        ev.key.lower_p?.should be_true
+      end
+    end
+
+    it "passes Resize/nil through #dealias_event untouched" do
+      with_modifier("alt") do
+        Gori::Tui::Keybind.dealias_event(nil).should be_nil
+        resize = Termisu::Event::Resize.new(80, 24)
+        Gori::Tui::Keybind.dealias_event(resize).should eq(resize)
+      end
     end
   end
 end

--- a/spec/tui/settings_catalog_spec.cr
+++ b/spec/tui/settings_catalog_spec.cr
@@ -6,8 +6,8 @@ include Gori::Tui
 # the four dedicated overlays). If a catalog entry named a symbol outside this set, the
 # palette verb and the tab opener would both land on the "coming soon (TODO)" toast.
 KNOWN_SETTINGS_SECTIONS = [
-  :network, :editor, :theme, :layout, :statusline, :display, :notifications, :general,
-  :tabs, :hosts, :env, :hotkeys,
+  :network, :editor, :keys, :theme, :layout, :statusline, :display, :notifications,
+  :general, :tabs, :hosts, :env, :hotkeys,
 ]
 
 # SettingsCatalog is the single source of truth both the Ctrl-P palette and the Settings

--- a/spec/tui/settings_view_spec.cr
+++ b/spec/tui/settings_view_spec.cr
@@ -117,13 +117,14 @@ describe SettingsView do
     dir = File.tempname("gori-settings-reset-ed")
     Dir.mkdir_p(dir)
     prev_home = ENV["GORI_HOME"]?
-    prev = {Gori::Settings.editor, Gori::Settings.editor_markdown, Gori::Settings.mouse, Gori::Settings.pretty_bodies_default}
+    prev = {Gori::Settings.editor, Gori::Settings.editor_markdown, Gori::Settings.mouse, Gori::Settings.pretty_bodies_default, Gori::Settings.command_modifier}
     begin
       ENV["GORI_HOME"] = dir
       Gori::Settings.editor = "code --wait"
       Gori::Settings.editor_markdown = false
       Gori::Settings.mouse = false
       Gori::Settings.pretty_bodies_default = false
+      Gori::Settings.command_modifier = "alt"
       v = SettingsView.new
       v.reload(:editor)
       v.reset_to_defaults
@@ -132,9 +133,46 @@ describe SettingsView do
       Gori::Settings.editor_markdown.should eq(Gori::Settings::DEFAULT_EDITOR_MARKDOWN)
       Gori::Settings.mouse.should eq(Gori::Settings::DEFAULT_MOUSE)
       Gori::Settings.pretty_bodies_default.should eq(Gori::Settings::DEFAULT_PRETTY_BODIES)
+      # The modifier lives in the KEYS section — resetting EDITOR must not touch it.
+      Gori::Settings.command_modifier.should eq("alt")
     ensure
       prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
-      Gori::Settings.editor, Gori::Settings.editor_markdown, Gori::Settings.mouse, Gori::Settings.pretty_bodies_default = prev
+      Gori::Settings.editor, Gori::Settings.editor_markdown, Gori::Settings.mouse, Gori::Settings.pretty_bodies_default, Gori::Settings.command_modifier = prev
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  # Walks the KEYS section the way the modal does, proving the ←/→ cycle reaches
+  # Settings.command_modifier and that reset lands on the documented default.
+  it "saves and resets the KEYS section (command modifier)" do
+    dir = File.tempname("gori-settings-cmdmod-view")
+    Dir.mkdir_p(dir)
+    prev_home = ENV["GORI_HOME"]?
+    prev = {Gori::Settings.editor, Gori::Settings.command_modifier}
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.editor = "vim"
+      Gori::Settings.command_modifier = "ctrl"
+      v = SettingsView.new
+      v.reload(:keys)
+      v.section.should eq(:keys)
+      v.toggle_or_move(1) # Ctrl → Option (⌥)
+      v.save
+      Gori::Settings.command_modifier.should eq("alt")
+      Gori::Settings.editor.should eq("vim") # a sibling section is untouched
+
+      v.toggle_or_move(-1) # cycles back — the choice list wraps both ways
+      v.save
+      Gori::Settings.command_modifier.should eq("ctrl")
+
+      Gori::Settings.command_modifier = "alt"
+      v.reload(:keys)
+      v.reset_to_defaults
+      v.save
+      Gori::Settings.command_modifier.should eq(Gori::Settings::DEFAULT_COMMAND_MODIFIER)
+    ensure
+      prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
+      Gori::Settings.editor, Gori::Settings.command_modifier = prev
       FileUtils.rm_rf(dir)
     end
   end

--- a/src/gori/hotkeys.cr
+++ b/src/gori/hotkeys.cr
@@ -24,23 +24,54 @@ module Gori
     # verb to one would be silently shadowed — the editor refuses them on top of the
     # terminal-reserved set.
     #
-    # **Single source of truth for "claimed" letters.** Runner#handle_key and controllers
-    # must only hardcode Ctrl+letter guards that appear here (or the reserved set). When
-    # adding a new pre-keymap guard, append to CLAIMED_CTRL_LETTERS / CLAIMED_CTRL_DIGITS
-    # first, then wire the handler — the hotkey editor and reserved?() stay in sync.
-    #   • Runner global guards: ^G goto, ^F find, ^B reveal, ^E external editor.
+    # **Single source of truth for "claimed" keys.** Runner#handle_key and controllers
+    # must only hardcode Ctrl+key guards that appear here (or the reserved set). When
+    # adding a new pre-keymap guard, append to CLAIMED_CTRL_LETTERS / CLAIMED_CTRL_DIGITS /
+    # CLAIMED_CTRL_PUNCT first, then wire the handler — the hotkey editor, reserved?() and
+    # Tui::Keybind.dealias all derive from these, so they stay in sync.
+    #   • Runner global guards: ^G goto, ^F find, ^B reveal, ^E external editor, ^, prefs.
     #   • Controllers + Runner: ^P palette, ^N new, ^W close, ^1-9 sub-tab.
     CLAIMED_CTRL_LETTERS = %w(g f b e p n w)
     CLAIMED_CTRL_DIGITS  = ('1'..'9').map(&.to_s)
+    CLAIMED_CTRL_PUNCT   = %w(,)
 
-    CLAIMED_CHORDS = begin
-      cs = CLAIMED_CTRL_LETTERS.map { |k| Verb::Chord.new(k, ctrl: true) }
-      CLAIMED_CTRL_DIGITS.each { |d| cs << Verb::Chord.new(d, ctrl: true) }
-      cs
+    # Every claimed key, modifier-free. The ctrl and alt chord sets below are both built
+    # from this, and Keybind.dealias uses it to decide which events to rewrite.
+    CLAIMED_KEYS = CLAIMED_CTRL_LETTERS + CLAIMED_CTRL_DIGITS + CLAIMED_CTRL_PUNCT
+
+    CLAIMED_CHORDS     = CLAIMED_KEYS.map { |k| Verb::Chord.new(k, ctrl: true) }
+    CLAIMED_ALT_CHORDS = CLAIMED_KEYS.map { |k| Verb::Chord.new(k, alt: true) }
+
+    # Selectable command modifiers (the Settings.command_modifier domain). "ctrl" is the
+    # built-in family's native modifier; "alt" ADDS an ⌥ alias for it (see #alias_active?).
+    COMMAND_MODIFIERS = %w(ctrl alt)
+
+    # Clamped on READ as well as on parse (Settings.normalize_command_modifier), the same
+    # defence #chord_overrides applies to hand-edited bindings: nothing downstream should
+    # have to reason about an unknown modifier, whatever put it there.
+    def self.command_modifier : String
+      m = Settings.command_modifier
+      COMMAND_MODIFIERS.includes?(m) ? m : Settings::DEFAULT_COMMAND_MODIFIER
+    end
+
+    # Whether the ⌥ alias for the claimed family is on. The alias is ADDITIVE: the Ctrl
+    # form keeps firing, so a terminal that doesn't deliver ⌥ as Meta can never lock a
+    # user out of the palette. What the setting changes is which form gets ADVERTISED
+    # (see #binding_for / #retag) and which extra chords are claimed.
+    def self.alias_active? : Bool
+      command_modifier == "alt"
     end
 
     def self.claimed?(chord : Verb::Chord) : Bool
-      CLAIMED_CHORDS.includes?(chord)
+      CLAIMED_CHORDS.includes?(chord) || (alias_active? && CLAIMED_ALT_CHORDS.includes?(chord))
+    end
+
+    # The alt twin of a claimed ctrl chord (nil for anything else) — the form the alias
+    # advertises. Shift/alt-carrying chords are not claimed, so only the plain ctrl set
+    # maps.
+    def self.alt_twin(chord : Verb::Chord) : Verb::Chord?
+      return nil unless CLAIMED_CHORDS.includes?(chord)
+      Verb::Chord.new(chord.key, alt: true)
     end
 
     # Build the dispatch keymap from the registry under the persisted OS profile + user
@@ -86,27 +117,40 @@ module Gori
     end
 
     # A human reason if `chord` is unbindable — terminal-/structurally reserved, or claimed
-    # by a hardcoded gori shortcut before the keymap — else nil.
+    # by a hardcoded gori shortcut before the keymap — else nil. Under an active ⌥ alias
+    # BOTH forms of a claimed key are refused: the guard fires on either, so a binding on
+    # the alt form would be shadowed exactly like one on the ctrl form.
     def self.reserved?(chord : Verb::Chord) : String?
       if reason = Verb::Reserved.reserved?(chord)
         reason
       elsif claimed?(chord)
-        "#{chord.label} is reserved by a gori shortcut"
+        "#{display_label(chord)} is reserved by a gori shortcut"
       end
     end
 
     # The effective PRIMARY chord bound to `id` now (nil = unbound), honouring an optional
     # in-progress overrides map (the editor's working copy) and OS profile.
+    #
+    # Under an active ⌥ alias a CLAIMED chord is reported as its alt twin. The four
+    # FIXED_IDS verbs declare `ctrl: true` defaults (verbs/core.cr, verbs/history.cr) and
+    # can keep doing so: the palette, Help's verb-id rows and the space menu all resolve
+    # through here, so their labels follow the setting from this one place. The Ctrl form
+    # still fires — the alias is additive — but the alt form is the one worth advertising,
+    # since a user only turns the alias on when Ctrl isn't reaching gori.
     def self.binding_for(registry : Verb::Registry, id : String,
                          overrides : Hash(String, Array(Verb::Chord)) = rebindable_overrides(registry),
                          profile : String = Settings.keymap_os) : Verb::Chord?
       verb = registry[id]?
       return nil unless verb
-      Verb::Keymap.effective_chords(verb, Verb::OsProfile.resolve(profile), overrides).first?
+      chord = Verb::Keymap.effective_chords(verb, Verb::OsProfile.resolve(profile), overrides).first?
+      return chord unless chord && alias_active?
+      alt_twin(chord) || chord
     end
 
-    # Compact status/Help token for a chord (`ctrl-r` → `^R`, `shift-i` → `⇧I`, `f` → `f`).
-    # Matches the curated prose style used in body_hint / Help before binding-truth.
+    # Compact status/Help token for a chord (`ctrl-r` → `^R`, `alt-p` → `⌥P`, `shift-i` →
+    # `⇧I`, `f` → `f`). Matches the curated prose style used in body_hint / Help before
+    # binding-truth. A MODIFIED single letter is shown uppercase (`^P`, `⌥P`) while a bare
+    # one stays as typed (`f`), which is the convention the hand-written hints use.
     def self.display_label(chord : Verb::Chord) : String
       if chord.ctrl
         rest = chord.key.size == 1 ? chord.key.upcase : chord.key
@@ -115,8 +159,9 @@ module Gori
       end
       String.build do |io|
         io << "⌥" if chord.alt
-        if chord.shift && chord.key.size == 1
-          io << "⇧" << chord.key.upcase
+        if (chord.shift || chord.alt) && chord.key.size == 1
+          io << "⇧" if chord.shift
+          io << chord.key.upcase
         else
           io << "⇧" if chord.shift
           io << case chord.key
@@ -133,6 +178,35 @@ module Gori
           end
         end
       end
+    end
+
+    # The claimed family as it appears in hand-written hint/help PROSE ("^P cmds",
+    # "^1-9 jump"). A closed set on purpose: ^R/^S/^X/^C/^D are NOT claimed and must keep
+    # their carets, so never widen this to a general `\^(\w)`.
+    CLAIMED_CARET_RE = /\^([gfbepnwGFBEPNW,1-9])/
+
+    # Rewrite the claimed family's carets to ⌥ in a DISPLAY string. Identity unless the
+    # alias is on. This is why ~86 hand-written "^P"/"^N"/"^1-9" literals across the TUI
+    # did not have to be swept: applying it at the few places hint text is drawn (Runner's
+    # key_hints funnel, Help's item rows, the empty-state cards, the tutorial) covers all
+    # of them, and it can be deleted wholesale if the guards ever move into the keymap.
+    def self.retag(s : String) : String
+      return s unless alias_active?
+      s.gsub(CLAIMED_CARET_RE) { "⌥#{$1}" }
+    end
+
+    # Verb ids whose PERSISTED override sits on an alt chord the alias has just claimed.
+    # Pure-alt chords are bindable while the alias is off (Verb::Reserved never refuses
+    # them), so turning it on shadows any such binding — the guard fires before the keymap
+    # and #chord_overrides now drops the chord as reserved, so the verb quietly reverts to
+    # its default. Callers surface these so the revert isn't silent.
+    def self.alias_conflicts(registry : Verb::Registry) : Array(String)
+      return [] of String unless alias_active?
+      Settings.keymap_overrides.compact_map do |id, labels|
+        next unless registry[id]?
+        next unless labels.any? { |l| (c = Verb::Chord.parse(l)) && CLAIMED_ALT_CHORDS.includes?(c) }
+        id
+      end.sort
     end
 
     # Effective binding as a status/Help token, or `fallback` when unbound / unknown.

--- a/src/gori/settings/keymap.cr
+++ b/src/gori/settings/keymap.cr
@@ -4,21 +4,43 @@ require "json"
 # overrides. See settings.cr for the module-level overview and the load/save/
 # serialize orchestration.
 module Gori::Settings
+  # Which modifier fronts gori's BUILT-IN shortcut family — the chords consumed by a
+  # hardcoded guard before the keymap (^P palette, ^N new, ^W close, ^G/^F/^B/^E, ^1-9,
+  # ^,), which the settings:hotkeys editor deliberately cannot reach. "ctrl" is the
+  # default; "alt" ADDS an ⌥ alias (Ctrl keeps working) for terminals/multiplexers that
+  # swallow the Ctrl form — tmux's ^B prefix, or Ctrl+digit, which many terminals never
+  # deliver. See Gori::Hotkeys for the derived chord sets and Tui::Keybind.dealias for
+  # the one place the alias is applied.
+  DEFAULT_COMMAND_MODIFIER = "ctrl"
+
   # Hotkey customization (settings:hotkeys). `keymap_os` pins an OS default profile —
   # "auto" tracks the build's platform; "darwin"/"linux"/"windows" force one.
   # `keymap_overrides` is SPARSE: verb-id → chord-label strings ("ctrl-p", "shift-s").
   # An empty list = explicit unbind; an absent id = use the profile default.
   class_property keymap_os : String = "auto"
   class_property keymap_overrides : Hash(String, Array(String)) = {} of String => Array(String)
+  class_property command_modifier : String = DEFAULT_COMMAND_MODIFIER
 
   # Tolerant hotkey parse: a non-object (or absent) node keeps current values. `os`
   # is normalized (unknown → "auto"); `bindings` is a sparse verb-id → chord-label
   # list (non-array entries dropped; unparseable chord labels dropped; an empty list
   # is PRESERVED as an explicit unbind). Mirrors parse_tab_prefs' robustness.
+  #
+  # `command_modifier` is read only WHEN PRESENT (the display.cr shape), unlike `os` —
+  # a hotkeys block written by a build that predates it must keep the current value
+  # rather than being reset by a nil.
   private def self.parse_hotkeys(node : JSON::Any?) : Nil
     return unless h = node.try(&.as_h?)
     self.keymap_os = normalize_os(h["os"]?.try(&.as_s?))
+    if v = h["command_modifier"]?.try(&.as_s?)
+      self.command_modifier = normalize_command_modifier(v)
+    end
     self.keymap_overrides = parse_keymap_bindings(h["bindings"]?)
+  end
+
+  # Allowed command modifiers; anything else falls back to the default.
+  def self.normalize_command_modifier(s : String) : String
+    {"ctrl", "alt"}.includes?(s) ? s : DEFAULT_COMMAND_MODIFIER
   end
 
   private def self.parse_keymap_bindings(node : JSON::Any?) : Hash(String, Array(String))
@@ -36,13 +58,15 @@ module Gori::Settings
     out
   end
 
-  # Omit when untouched (default profile + no overrides) so an untouched install
-  # never writes a "hotkeys" block.
+  # Omit when untouched (default profile + default modifier + no overrides) so an
+  # untouched install never writes a "hotkeys" block. Every field in the block must
+  # appear in this guard — a modifier-only change would otherwise be dropped.
   private def self.serialize_hotkeys(j : JSON::Builder) : Nil
-    unless keymap_overrides.empty? && keymap_os == "auto"
+    unless keymap_overrides.empty? && keymap_os == "auto" && command_modifier == DEFAULT_COMMAND_MODIFIER
       j.field "hotkeys" do
         j.object do
           j.field "os", keymap_os
+          j.field "command_modifier", command_modifier
           unless keymap_overrides.empty?
             j.field "bindings" do
               j.object do

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -178,7 +178,10 @@ module Gori::Tui
           if (id = item.verb_id) && registry
             key = Hotkeys.binding_label(registry, id, item.key)
           end
-          rows << Row.new(:item, key, item.desc)
+          # Retag both columns: an item with a verb id already resolves through
+          # binding_label, but the keyless rows (^N/^W, ^G/^F, ^1-9) and the chords named
+          # inside descriptions are hand-written literals.
+          rows << Row.new(:item, Hotkeys.retag(key), Hotkeys.retag(item.desc))
         end
       end
       rows

--- a/src/gori/tui/hotkeys_overlay.cr
+++ b/src/gori/tui/hotkeys_overlay.cr
@@ -389,7 +389,9 @@ module Gori::Tui
                 end
         screen.text(box.x + 2, ry, "• #{fb}", color, Theme.panel, width: {box.w - 4, 1}.max)
       elsif (r = @rows[@selected]?) && r.kind == :binding && (v = @registry[r.verb_id]?)
-        screen.text(box.x + 2, ry, v.description, Theme.muted, Theme.panel, width: {box.w - 4, 1}.max)
+        # Retagged: a description may name a claimed chord (settings.editor's "opened by ^E"),
+        # and this is the one surface that renders verb descriptions.
+        screen.text(box.x + 2, ry, Hotkeys.retag(v.description), Theme.muted, Theme.panel, width: {box.w - 4, 1}.max)
       end
     end
 

--- a/src/gori/tui/keybind.cr
+++ b/src/gori/tui/keybind.cr
@@ -1,10 +1,47 @@
 require "../verb"
+require "../hotkeys"
 
 module Gori::Tui
   # Translates a termisu key event into a Verb::Chord so the keymap (which is
   # terminal-agnostic) can resolve it. This is the one place TUI key encoding
   # meets the verb layer.
   module Keybind
+    # Fold an ⌥-aliased event for the CLAIMED family back onto its Ctrl form, so the ~51
+    # hardcoded `ev.ctrl? && key.lower_p?`-style guards spread across the Runner, the
+    # overlays and the controllers keep working untouched. Identity unless
+    # Settings.command_modifier is "alt", and identity for anything outside
+    # Hotkeys::CLAIMED_KEYS (⌥R stays ⌥R and reaches the keymap normally).
+    #
+    # Applied per event loop — Runner#handle_key, ProjectPicker, Tutorial — AFTER each
+    # loop's ^C/^D quit arm and (in the Runner) after the hotkey-capture branch, so quit
+    # stays Ctrl-only and the Hotkeys editor still records ⌥-chords verbatim.
+    #
+    # Two normalizations matter:
+    #   • ⌥⇧P arrives as Key::UpperP (the parser reads "\eP" → from_char('P')), while
+    #     Ctrl+Shift+P is byte-identical to ^P. Downcasing the key and clearing Shift makes
+    #     both paths land on the same event a `key.lower_p?` guard expects.
+    #   • `char: nil` matches what the Ctrl+letter parser branch produces; Event::Key#char
+    #     falls back to key.to_char, so the digit guards (`ev.char || key.to_char`) are
+    #     unaffected either way.
+    #
+    # A ⌃⌥-carrying event is left alone: it already satisfies `ev.ctrl?`, so rewriting it
+    # would change nothing except the shift/alt flags.
+    def self.dealias(ev : Termisu::Event::Key) : Termisu::Event::Key
+      return ev unless Hotkeys.alias_active?
+      return ev unless ev.alt? && !ev.ctrl?
+      c = ev.char || ev.key.to_char
+      return ev unless c && Hotkeys::CLAIMED_KEYS.includes?(c.downcase.to_s)
+      mods = (ev.modifiers & ~Termisu::Input::Modifier::Alt & ~Termisu::Input::Modifier::Shift) |
+             Termisu::Input::Modifier::Ctrl
+      Termisu::Event::Key.new(Termisu::Input::Key.from_char(c.downcase), mods, nil)
+    end
+
+    # #dealias lifted to the `case ev = poll_event` shape used by the standalone loops
+    # (ProjectPicker, Tutorial) — Resize/Mouse/nil pass through untouched.
+    def self.dealias_event(ev : Termisu::Event::Any?) : Termisu::Event::Any?
+      ev.is_a?(Termisu::Event::Key) ? dealias(ev) : ev
+    end
+
     def self.from_event(ev : Termisu::Event::Key) : Verb::Chord?
       key = ev.key
       shift = ev.shift?

--- a/src/gori/tui/preferences_view.cr
+++ b/src/gori/tui/preferences_view.cr
@@ -402,7 +402,9 @@ module Gori::Tui
       note_y = box.bottom - 3
       hint_y = box.bottom - 2
       iw = {box.w - 4, 0}.max
-      note = @status || focused_hint
+      # Retagged: field hints name claimed chords (the external editor's ^E, the command
+      # modifier's own ^P/^N/^W/^1-9), which must read as whichever modifier is configured.
+      note = Hotkeys.retag(@status || focused_hint)
       # Same green/yellow split SettingsView uses — a rejected save must not read as a
       # successful one just because it came through the modal.
       note_fg = @status ? (@status_warn ? Theme.yellow : Theme.green) : Theme.muted

--- a/src/gori/tui/project_picker.cr
+++ b/src/gori/tui/project_picker.cr
@@ -119,7 +119,9 @@ module Gori::Tui
         # here plays the reveal once, then freezes at ART_ANIM_DONE (static after).
         @art_frame += 1 if @art_frame < ART_ANIM_DONE
         @star_frame &+= 1
-        case ev = @term.poll_event(50)
+        # Own event loop, so the Runner's ⌥-alias fold doesn't reach it — apply it here too
+        # or ⌥N (new project) / ⌥, (preferences) would be dead on this screen.
+        case ev = Keybind.dealias_event(@term.poll_event(50))
         when Termisu::Event::Resize
           # termisu already resized its buffer to these dims; re-fit the backend grids in
           # lockstep off the same event dims, and force a full repaint next frame.

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -961,7 +961,8 @@ module Gori::Tui
       # History/Sitemap tabs don't say. The proxy address lives in the status bar /
       # settings, so it isn't repeated here.
       if @flow_count == 0 && y <= max_y
-        screen.text(inner.x + 1, y, "▸ first run — point your client at the proxy · ^P: Open browser · Export CA certificate",
+        screen.text(inner.x + 1, y,
+          Hotkeys.retag("▸ first run — point your client at the proxy · ^P: Open browser · Export CA certificate"),
           Theme.muted, width: {inner.right - inner.x - 1, 0}.max)
         y += 1
       end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -927,6 +927,11 @@ module Gori::Tui
         dispatch_overlay_key(ov, ev)
         return
       end
+      # settings:keys "Command modifier = ⌥" folds ⌥P/⌥N/⌥1… onto ^P/^N/^1… here, so
+      # every claimed-family guard below (and in the overlays + controllers) needs no
+      # per-site change. Deliberately AFTER the quit arm (^C/^D stays Ctrl-only) and after
+      # the capture branch above (the Hotkeys editor must see ⌥ chords verbatim).
+      ev = Keybind.dealias(ev)
       return handle_space_menu_key(ev) if @space_menu_open # the space menu is modal while up
       return handle_copy_as_key(ev) if copy_as_shown?      # the copy-as picker is modal while up
       return handle_send_to_key(ev) if send_to_shown?      # the send-to picker is modal while up
@@ -2759,7 +2764,11 @@ module Gori::Tui
         tabs: vis_tabs, intercept_count: @session.interceptor.pending_count,
         hidden_count: hid_tabs.size, more_focused: @focus == :menu && @menu_more)
       render_body(screen, layout.body)
-      Chrome.render_status(screen, layout.status, focus: focus_label, hints: format_status_message(@toast) || key_hints,
+      # One retag for the whole status row: key_hints already funnels the Runner's own
+      # hint literals, every overlay/prompt hint AND every controller body_hint, and the
+      # toast branch covers the "(^P)" pointers in messages like the bind-failure notice.
+      Chrome.render_status(screen, layout.status, focus: focus_label,
+        hints: Hotkeys.retag(format_status_message(@toast) || key_hints),
         activity: activity_chip, resource: @resource.label, time: clock_label)
       Chrome.render_statusline(screen, layout.statusline, @statusline.segments) unless layout.statusline.empty?
       @palette.render(screen, layout.body) if @overlay.palette?
@@ -4613,7 +4622,7 @@ module Gori::Tui
     # to the modal) would behave differently.
     private def open_settings_section(section : Symbol, back : PreferencesOverlay?) : Nil
       case section
-      when :network, :editor, :layout, :statusline, :display, :notifications, :general
+      when :network, :editor, :keys, :layout, :statusline, :display, :notifications, :general
         open_preferences(section)                       # the unified grouped modal, positioned at this section
       when :theme   then open_overlay(theme_card(back)) # theme keeps its dedicated swatch-list card
       when :tabs    then open_overlay(tabs_editor(back))
@@ -4747,12 +4756,26 @@ module Gori::Tui
               when :theme   then apply_theme(msg)
               when :layout  then apply_layout(msg)
               when :display then apply_display(msg)
+              when :keys    then apply_keys(msg)
               else               msg
               end
       @theme_restore = Settings.theme if section == :theme # saved → don't revert this on esc
       reconcile_mouse                                      # the EDITOR section holds the Mouse toggle — apply it live
       @pretty = Settings.pretty_bodies_default             # …and the Pretty-print-bodies toggle — apply it live too
       toast
+    end
+
+    # The KEYS section carries the command modifier, which changes what every surface
+    # ADVERTISES. Status/body hints resolve per frame so they need nothing, but Help is built
+    # from the registry when the tab opens — reload it or its rows keep naming the old
+    # modifier. Also warn when the ⌥ alias has just shadowed a user's own alt binding: the
+    # guard fires before the keymap, so that override silently reverts to its default.
+    private def apply_keys(save_msg : String) : String
+      help_controller.reload_help(@session.registry)
+      @resized = true # chords are baked into rendered hint text — force a full repaint
+      shadowed = Hotkeys.alias_conflicts(@session.registry)
+      return save_msg if shadowed.empty?
+      "#{save_msg} — ⌥ alias shadows your binding for #{shadowed.join(", ")} (now back to default)"
     end
 
     # Layout prefs apply live: History reloads (list order) + preview; Sitemap rebuilds

--- a/src/gori/tui/settings_catalog.cr
+++ b/src/gori/tui/settings_catalog.cr
@@ -56,6 +56,12 @@ module Gori::Tui
       # Editor & Keys
       Section.new(:editor, "settings.editor", "Editor",
         "Set the external editor opened by ^E in editable fields", :editor, :form),
+      # Distinct from Hotkeys below: Keys sets WHICH MODIFIER fronts gori's built-in
+      # shortcut family (the chords a hardcoded guard claims before the keymap), while
+      # Hotkeys rebinds individual actions. Neither belongs in Editor — that section is
+      # text-editing prefs.
+      Section.new(:keys, "settings.keys", "Keys",
+        "Pick the modifier for gori's built-in shortcuts (^P ^N ^W ^1-9)", :editor, :form),
       Section.new(:env, "settings.env", "Env",
         "Global environment variables for $KEY substitution in requests", :editor, :opener),
       Section.new(:hotkeys, "settings.hotkeys", "Hotkeys",

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -46,11 +46,22 @@ module Gori::Tui
         readonly: true),
       Field.new("Hostname overrides", "↵ to edit the global IP→host map (a /etc/hosts for this proxy)", opener: :hosts),
     ]
+    # Command-modifier labels. The stored values are "ctrl"/"alt" (Settings.command_modifier);
+    # these are what the row shows — see #modifier_label / #modifier_from_label.
+    COMMAND_MODIFIER_CHOICES = ["Ctrl", "Option (⌥)"]
+
     EDITOR_FIELDS = [
       Field.new("External editor", "e.g. vim · code --wait — blank = $VISUAL/$EDITOR/vi"),
       Field.new("Markdown highlight", "syntax-colour markdown in Notes/Project — ←/→/space toggles", bool: true),
       Field.new("Mouse", "click + scroll-wheel navigation (off restores native text selection)", bool: true),
       Field.new("Pretty-print bodies", "reflow JSON/XML/form/… in History detail + Repeater response — display only; ←/→/space toggles", bool: true),
+    ]
+    # KEYS is its own section rather than a row in EDITOR: it configures key INPUT, not text
+    # editing. It sits between Editor and Hotkeys in the same group, so "which modifier" and
+    # "which binding" read as the pair they are.
+    KEYS_FIELDS = [
+      Field.new("Command modifier", "which modifier fronts gori's built-in shortcuts (^P ^N ^W ^G ^F ^B ^E ^, ^1-9) — Option ADDS ⌥ as an alias, Ctrl keeps working; for terminals/multiplexers that swallow the Ctrl form (tmux's ^B, Ctrl+digit). macOS Terminal/iTerm must be set to send Option as Meta. ←/→ cycles",
+        choices: COMMAND_MODIFIER_CHOICES),
     ]
     # The THEME section is special: a single field whose value is the selected theme
     # name, but rendered as a vertical, scrollable list (built-ins + user themes) rather
@@ -141,6 +152,7 @@ module Gori::Tui
     SECTIONS = {
       :network       => NETWORK_FIELDS,
       :editor        => EDITOR_FIELDS,
+      :keys          => KEYS_FIELDS,
       :theme         => THEME_FIELDS,
       :layout        => LAYOUT_FIELDS,
       :statusline    => STATUSLINE_FIELDS,
@@ -177,7 +189,8 @@ module Gori::Tui
       @section = section
       Theme.load_custom if section == :theme # pick up theme files dropped since startup
       @values = case section
-                when :editor        then [Settings.editor, Settings.editor_markdown ? "on" : "off", Settings.mouse ? "on" : "off", Settings.pretty_bodies_default ? "on" : "off"]
+                when :editor        then editor_values
+                when :keys          then keys_values
                 when :theme         then [Theme.canonical(Settings.theme)]
                 when :layout        then layout_values
                 when :statusline    then [Settings.statusline_enabled? ? "on" : "off", Settings.statusline_command, Settings.statusline_interval.to_s]
@@ -208,8 +221,14 @@ module Gori::Tui
     # live-previews the restored default theme in the :theme section.
     def reset_to_defaults : Nil
       @values = case @section
-                when :editor then [Settings::DEFAULT_EDITOR, Settings::DEFAULT_EDITOR_MARKDOWN ? "on" : "off", Settings::DEFAULT_MOUSE ? "on" : "off", Settings::DEFAULT_PRETTY_BODIES ? "on" : "off"]
-                when :theme  then [Theme.canonical(Settings::DEFAULT_THEME)]
+                when :editor then [
+                  Settings::DEFAULT_EDITOR,
+                  Settings::DEFAULT_EDITOR_MARKDOWN ? "on" : "off",
+                  Settings::DEFAULT_MOUSE ? "on" : "off",
+                  Settings::DEFAULT_PRETTY_BODIES ? "on" : "off",
+                ]
+                when :keys  then [modifier_label(Settings::DEFAULT_COMMAND_MODIFIER)]
+                when :theme then [Theme.canonical(Settings::DEFAULT_THEME)]
                 when :layout then [
                   Settings::DEFAULT_HISTORY_PREVIEW ? "on" : "off",
                   Settings::DEFAULT_PROBE_PREVIEW ? "on" : "off",
@@ -269,6 +288,33 @@ module Gori::Tui
         rule_count_label(Settings.outbound_tls.size, "entry", "entries"),
         hostnames_summary,
       ]
+    end
+
+    # The EDITOR row values, read from the live Settings — same reason as #network_values:
+    # the values are positional, so a literal per call site drifts from EDITOR_FIELDS the
+    # moment a row is inserted or removed.
+    private def editor_values : Array(String)
+      [
+        Settings.editor,
+        Settings.editor_markdown ? "on" : "off",
+        Settings.mouse ? "on" : "off",
+        Settings.pretty_bodies_default ? "on" : "off",
+      ]
+    end
+
+    # The KEYS row values (one row today — the command modifier).
+    private def keys_values : Array(String)
+      [modifier_label(Settings.command_modifier)]
+    end
+
+    # "ctrl"/"alt" ↔ the row's display labels (unknown → the Ctrl default, matching
+    # Settings.normalize_command_modifier).
+    private def modifier_label(value : String) : String
+      value == "alt" ? COMMAND_MODIFIER_CHOICES[1] : COMMAND_MODIFIER_CHOICES[0]
+    end
+
+    private def modifier_from_label(label : String) : String
+      label == COMMAND_MODIFIER_CHOICES[1] ? "alt" : "ctrl"
     end
 
     # The GENERAL row values, read from the live Settings — one helper for the load and the
@@ -490,7 +536,12 @@ module Gori::Tui
         Settings.editor_markdown = @values[1] == "on"
         Settings.mouse = @values[2] == "on"
         Settings.pretty_bodies_default = @values[3] == "on"
-        @values = [Settings.editor, Settings.editor_markdown ? "on" : "off", Settings.mouse ? "on" : "off", Settings.pretty_bodies_default ? "on" : "off"]
+        @values = editor_values
+        return persist
+      end
+      if @section == :keys
+        Settings.command_modifier = Settings.normalize_command_modifier(modifier_from_label(@values[0]))
+        @values = keys_values
         return persist
       end
       if @section == :layout
@@ -735,7 +786,7 @@ module Gori::Tui
       elsif focused
         screen.input_line(vx, ry, value, @cursor, @preedit, Theme.text_bright, bg, width: vw)
       elsif value.empty?
-        screen.text(vx, ry, field.hint, Theme.muted, bg, width: vw)
+        screen.text(vx, ry, Hotkeys.retag(field.hint), Theme.muted, bg, width: vw)
       else
         screen.text(vx, ry, value, Theme.text, bg, width: vw)
       end
@@ -818,7 +869,7 @@ module Gori::Tui
         names = Theme.available
         screen.text(box.x + 3, note_y, "theme #{(names.index(@values[0]) || 0) + 1}/#{names.size}", Theme.muted, Theme.panel, width: iw)
       else
-        screen.text(box.x + 3, note_y, fields[@focused].hint, Theme.muted, Theme.panel, width: iw)
+        screen.text(box.x + 3, note_y, Hotkeys.retag(fields[@focused].hint), Theme.muted, Theme.panel, width: iw)
       end
       hint = @section == :theme ? "↑/↓ select · ↵ apply · ^R reset · esc close" : "↑/↓ field · ↵ save · ^R reset · esc close"
       hx = {box.right - hint.size - 2, box.x + 1}.max # never start left of the box interior

--- a/src/gori/tui/setup_wizard.cr
+++ b/src/gori/tui/setup_wizard.cr
@@ -55,6 +55,10 @@ module Gori::Tui
       # on finish and read by `run` (below) to launch the tour in this same terminal.
       @offer = :tour # :tour | :skip
       @launch_tutorial = false
+      # Review step also stages the command modifier (see Settings.command_modifier): a
+      # first-run chance to pick ⌥ before hitting a terminal that eats Ctrl+digit. Kept on
+      # ←/→ rather than the ↑/↓ offer ring, so Review needs no focus ring.
+      @modifier = Settings.command_modifier
     end
 
     # Run the wizard to completion (finish) or skip. Returns when the user is done;
@@ -144,14 +148,16 @@ module Gori::Tui
       end
     end
 
-    # Review step: ↑/↓ pick the tour offer; ↵ finishes (commit + persist, then
-    # launch the tour iff selected); ⇧⇥ back.
+    # Review step: ↑/↓ pick the tour offer; ←/→ flip the command modifier; ↵ finishes
+    # (commit + persist, then launch the tour iff selected); ⇧⇥ back.
     private def handle_review_key(ev : Termisu::Event::Key) : Nil
       key = ev.key
       if key.enter?
         finish
       elsif key.up? || key.down?
         @offer = @offer == :tour ? :skip : :tour
+      elsif key.left? || key.right?
+        @modifier = @modifier == "alt" ? "ctrl" : "alt"
       elsif key.back_tab?
         @step = Step::Appearance
       end
@@ -243,6 +249,7 @@ module Gori::Tui
       Settings.bind_host = effective_ip
       Settings.bind_port = @port.strip.to_i? || Settings.bind_port
       Settings.theme = @theme_name
+      Settings.command_modifier = Settings.normalize_command_modifier(@modifier)
       Settings.save
       @launch_tutorial = @offer == :tour # `run` launches the tour after the loop
       @running = false
@@ -297,12 +304,13 @@ module Gori::Tui
 
     # --- geometry ------------------------------------------------------------
 
-    # The centred step card for `w`×`h`. The THEME step is wider (room for the
-    # preview panel beside the list); the rest use a settings-sized card. Height is
-    # content + 6 rows of chrome, clamped to the space between the header and the
-    # hint. The ONE source of this geometry — render and the mouse hit-tests share it.
+    # The centred step card for `w`×`h`. Only BIND uses the narrow settings-sized card —
+    # Appearance needs room for the preview panel beside the list, and Review's Shortcuts
+    # row spells out a chord family plus how to change it. Height is content + 6 rows of
+    # chrome, clamped to the space between the header and the hint. The ONE source of this
+    # geometry — render and the mouse hit-tests share it.
     private def step_card(w : Int32, h : Int32) : Rect
-      cols = @step.appearance? ? 84 : 64
+      cols = @step.bind? ? 64 : 84
       inner = {w - 4, cols}.min
       cw = {inner, 34}.max
       avail = {h - 3, 3}.max # rows between the header (y0-1) and the hint (y h-1)
@@ -318,7 +326,7 @@ module Gori::Tui
     private def content_rows : Int32
       case @step
       when Step::Bind   then 8 # heading, gap, ip, port, gap, 2 info lines, status
-      when Step::Review then 8 # title, gap, 2 recap rows, gap, offer prompt, 2 offer rows
+      when Step::Review then 9 # title, gap, 3 recap rows, gap, offer prompt, 2 offer rows
       # ≥7 so the preview panel (header + 3 status rows) is never clipped, capped so a
       # long theme list scrolls (the list viewport derives from the card height) instead
       # of demanding the whole screen.
@@ -403,7 +411,7 @@ module Gori::Tui
       hint = case @step
              when Step::Bind       then "↵ next · ↑/↓ field · esc skip"
              when Step::Appearance then "↑/↓ pick theme · ↵ next · ⇧⇥ back · esc skip"
-             else                       "↑/↓ choose · ↵ confirm · ⇧⇥ back · esc skip"
+             else                       "↑/↓ choose · ←/→ shortcuts · ↵ confirm · ⇧⇥ back · esc skip"
              end
       screen.text({(w - hint.size) // 2, 0}.max, h - 1, hint, Theme.muted, Theme.bg)
     end
@@ -536,14 +544,26 @@ module Gori::Tui
       y = box.y + 2
       screen.text(ix, y, "You're all set!", Theme.text_bright, Theme.panel, width: {box.w - 6, 1}.max)
       y += 2
-      recap_labels = ["Proxy (global)", "Theme"]
+      recap_labels = ["Proxy (global)", "Theme", "Shortcuts"]
       vx = ix + recap_labels.max_of(&.size) + 2 # +2 = min visible gap before the value column
       recap(screen, box, ix, vx, y, "Proxy (global)", "#{effective_ip}:#{@port.strip}"); y += 1
-      recap(screen, box, ix, vx, y, "Theme", @theme_name); y += 2
+      recap(screen, box, ix, vx, y, "Theme", @theme_name); y += 1
+      # The only EDITABLE recap row (←/→). Spell out both the chords it moves and the
+      # macOS caveat — a user who picks ⌥ without Option-as-Meta would see nothing happen.
+      recap(screen, box, ix, vx, y, "Shortcuts", modifier_recap); y += 2
       screen.text(ix, y, "New to gori? Take a quick tour of the TUI:", Theme.muted, Theme.panel, width: {box.w - 6, 1}.max)
       y += 1
       render_offer_row(screen, box, y, "Take the guided tour", @offer == :tour); y += 1
       render_offer_row(screen, box, y, "Skip — finish setup", @offer == :skip)
+    end
+
+    # The Shortcuts recap value: what's staged, plus how to change it / what it costs.
+    private def modifier_recap : String
+      if @modifier == "alt"
+        "⌥P ⌥N ⌥W ⌥1-9  (←/→ for Ctrl · needs Option-as-Meta)"
+      else
+        "^P ^N ^W ^1-9  (←/→ to add ⌥ aliases)"
+      end
     end
 
     private def recap(screen : Screen, box : Rect, ix : Int32, vx : Int32, y : Int32, key : String, value : String) : Nil

--- a/src/gori/tui/traffic_empty_state.cr
+++ b/src/gori/tui/traffic_empty_state.cr
@@ -146,7 +146,7 @@ module Gori::Tui
                headline
              end
       screen.text(rect.x + 1, rect.y, headline, Theme.muted, width: {rect.w - 2, 0}.max)
-      screen.text(rect.x + 1, rect.y + 2, hint, Theme.muted, width: {rect.w - 2, 0}.max) if rect.h > 2
+      screen.text(rect.x + 1, rect.y + 2, Hotkeys.retag(hint), Theme.muted, width: {rect.w - 2, 0}.max) if rect.h > 2
     end
 
     # Title rides the top edge; the card is centred in the space below it.
@@ -416,7 +416,9 @@ module Gori::Tui
         break if y >= rect.bottom
         col = i == 0 ? Theme.muted : (i == 1 ? Theme.accent : Theme.muted)
         attr = i == 1 ? Attribute::Bold : Attribute::None
-        screen.text(rect.x + 1, y, line, col, attr: attr, width: {rect.w - 2, 0}.max)
+        # The medium_* builders write "^N"/"^P" literals; retag here so the card advertises
+        # whichever modifier is configured (a no-op on the default).
+        screen.text(rect.x + 1, y, Hotkeys.retag(line), col, attr: attr, width: {rect.w - 2, 0}.max)
       end
     end
 
@@ -429,7 +431,9 @@ module Gori::Tui
       bg = Theme.bg
       screen.text(ix, y, bullet, Theme.muted, bg)
       bx = ix + bullet.size
-      x = Frame.chip(screen, bx, y, chord, true) + 1
+      # Claimed-family chips (^N/^W/^P) follow the configured modifier; ^R and the
+      # "i:CATCH"-style chips are untouched (retag's token set is closed).
+      x = Frame.chip(screen, bx, y, Hotkeys.retag(chord), true) + 1
       screen.text(x, y, " #{label}", Theme.text, bg, width: {ix + iw - x, 0}.max)
       y + 1
     end

--- a/src/gori/tui/tutorial.cr
+++ b/src/gori/tui/tutorial.cr
@@ -124,7 +124,9 @@ module Gori::Tui
       @running = true
       loop do
         render
-        case ev = @term.poll_event(50)
+        # Own event loop — fold ⌥P onto ^P so the "try the palette" goal below can be
+        # completed with whichever modifier the user configured.
+        case ev = Keybind.dealias_event(@term.poll_event(50))
         when Termisu::Event::Resize then (@backend.resize(ev.width, ev.height); @resized = true)
         when Termisu::Event::Key    then handle_key(ev)
         when Termisu::Event::Mouse  then handle_mouse(ev)
@@ -703,7 +705,7 @@ module Gori::Tui
       render_header(screen, w)
       render_progress_rail(screen, w)
       box = step_card(w, h)
-      Frame.card(screen, box, card_title, border: Theme.border_focus)
+      Frame.card(screen, box, Hotkeys.retag(card_title), border: Theme.border_focus)
       case @step
       when Step::Welcome   then render_welcome(screen, box)
       when Step::Navigate  then render_navigate(screen, box)
@@ -878,7 +880,7 @@ module Gori::Tui
         elsif @tried_palette
           "✓ #{tour}"
         else
-          "try ^P · #{tour} to skip"
+          Hotkeys.retag("try ^P · #{tour} to skip")
         end
       when Step::SpaceMenu
         if @overlay == :space
@@ -913,7 +915,7 @@ module Gori::Tui
       y += 1
       [
         "1.  tabs & panes     ←/→  ·  ↓  ·  esc  ·  ⇥",
-        "2.  command palette  ^P   — jump to any action",
+        Hotkeys.retag("2.  command palette  ^P   — jump to any action"),
         "3.  action menu      space — commands for this pane",
         "4.  edit mode        READ / INS — browse, then type",
       ].each do |ln|
@@ -961,10 +963,10 @@ module Gori::Tui
       y = box.y + 2
       screen.text(ix, y, "Jump to any action without hunting tabs or memorizing chords.", Theme.text_bright, Theme.panel, width: iw)
       y += 1
-      screen.text(ix, y, "^P opens it · type to fuzzy-filter · ↑/↓ move · ↵ run · esc close",
+      screen.text(ix, y, Hotkeys.retag("^P opens it · type to fuzzy-filter · ↑/↓ move · ↵ run · esc close"),
         Theme.muted, Theme.panel, width: iw)
       y += 1
-      draw_try_line(screen, ix, y, iw, "Try: press ^P, filter, ↵ to run a command.", @tried_palette)
+      draw_try_line(screen, ix, y, iw, Hotkeys.retag("Try: press ^P, filter, ↵ to run a command."), @tried_palette)
       y += 2
 
       shell = Rect.new(box.x + 2, y, box.w - 4, {box.bottom - 1 - y, 3}.max)
@@ -1045,7 +1047,7 @@ module Gori::Tui
       gx = draw_goal(screen, gx + 2, y, "enter", @p_enter)
       draw_goal(screen, gx + 2, y, "esc back", @p_up)
       y += 1
-      gx = draw_goal(screen, ix, y, "^P", @p_palette)
+      gx = draw_goal(screen, ix, y, Hotkeys.retag("^P"), @p_palette)
       gx = draw_goal(screen, gx + 2, y, "space", @p_space)
       draw_goal(screen, gx + 2, y, "i INS", @p_edit)
       y += 2
@@ -1066,7 +1068,7 @@ module Gori::Tui
             elsif @edit_insert
               "INS mode — type, then esc back to READ."
             else
-              "←/→ tabs · ↓ body · ↑ tabs · ↓ list · ⇥ panes · esc · ^P · space · i"
+              Hotkeys.retag("←/→ tabs · ↓ body · ↑ tabs · ↓ list · ⇥ panes · esc · ^P · space · i")
             end
       screen.text(ix, box.bottom - 2, msg, practice_done? ? Theme.green : Theme.muted, Theme.panel, width: iw)
     end
@@ -1102,7 +1104,7 @@ module Gori::Tui
         y += 1
       end
       y += 1
-      screen.text(ix, y, "Cheat-sheet:  ^P palette · space menu · i/↵ INS · esc READ/back", Theme.muted, Theme.panel, width: iw)
+      screen.text(ix, y, Hotkeys.retag("Cheat-sheet:  ^P palette · space menu · i/↵ INS · esc READ/back"), Theme.muted, Theme.panel, width: iw)
       y += 1
       screen.text(ix, y, "Re-run this tour anytime:  gori tutorial", Theme.muted, Theme.panel, width: iw)
     end


### PR DESCRIPTION
## Why

The chord family a hardcoded guard claims before the keymap — `^P` `^N` `^W` `^G` `^F` `^B` `^E` `^,` `^1`-`^9` — is deliberately unrebindable (`FIXED_IDS` / `CLAIMED_CHORDS` exist to say so). That's a problem when the terminal never delivers the Ctrl form at all:

- **`^1`-`^9` has no control character.** `runner.cr:3950` already concedes it is "undeliverable on many terminals", so sub-tab jumping is simply unreachable there.
- **A multiplexer eats the chord first.** tmux's default prefix is `^B`, which is also gori's reveal-whitespace.

Rebinding can't help: the editor refuses these chords, and the guard would shadow a binding anyway.

## What

**Preferences → Editor & Keys → Keys → Command modifier** (or `settings:keys` in the palette) switches that family between `Ctrl` and `Option (⌥)`.

It is an **alias, not a swap**. With Option selected, `⌥P` opens the palette *and* `^P` still does — so a terminal that isn't set to send Option as Meta can never lock anyone out of the palette. Only the advertised form changes: status hints, Help and the palette start reading `⌥P`, `⌥N`, `⌥1-9`.

Stored in the existing sparse `hotkeys` block as `command_modifier` (`"ctrl"` default | `"alt"`); an untouched install still writes no `hotkeys` block. The first-run wizard's Review step recaps it on `←`/`→`.

`Keys` is its own catalog section rather than a row in `Editor`, so the group name resolves: Editor = text editing, **Keys = which modifier**, Hotkeys = which binding.

## How, since the cheap paths aren't obvious

- **One event-boundary rewrite, not 51 guard edits.** `Tui::Keybind.dealias` folds `⌥P` onto `^P` inside `Runner#handle_key` — *after* the `^C`/`^D` quit arm (quit stays Ctrl-only) and *after* the hotkey-capture branch (the editor still records `⌥` chords verbatim). `ProjectPicker` and `Tutorial` own their event loops, so they call it too. `⌥⇧P` arrives as `Key::UpperP`, so the key is downcased and Shift cleared or every `key.lower_p?` guard misses.
- **One retag at the display funnels, not 86 literal edits.** `Hotkeys.retag` rewrites a **closed** token set (`^[gfbepnw,1-9]`) and is applied where hint text is drawn — `Runner#key_hints` already funnels its own literals, every overlay hint *and* every controller `body_hint`. `^R`/`^S`/`^X` keep their carets.

## Fixed along the way

- **`^,` joins the claimed set.** It was a pre-keymap guard missing from `CLAIMED_CHORDS`, so `⌥P` would have worked while `⌥,` didn't — and a verb bound to `^,` could be silently shadowed.
- **`display_label` rendered alt chords lowercase** (`⌥p`); only the ctrl branch upcased. Unexercised until now, since no verb shipped an alt default.
- **`apply_settings_saved` had no branch for this group**, so a form save there rebuilt nothing (Help is built at open and would keep naming the old modifier).
- **`Hotkeys.alias_conflicts`** reports verbs whose own alt binding the alias has just shadowed, so the revert to default isn't silent.

## Testing

`crystal spec` — 4657 examples, 0 failures. New/extended coverage: settings round-trip including the omit guard (a modifier-only change must still write the block) and the absent-key tolerance; `claimed?` / `reserved?` / `retag` / `binding_for` / `alias_conflicts` under both modes; `dealias` (identity in ctrl mode, `⌥P`→`^P`, the `UpperP` case, digits, `⌥,`, `⌥R` untouched, `^P` untouched); the Keys section save/reset walk.

Also driven in a real pty:

| sent | modifier | result |
|---|---|---|
| `⌥P` | alt | palette opens |
| `⌥P` | ctrl | nothing (correct) |
| `^P` | alt | palette opens — additive confirmed |
| `⌥,` | alt | Preferences opens |
| `⌥,` | ctrl | nothing (correct) |

Status hints flip `^P cmds` ↔ `⌥P cmds`; the full modal path (`^,` → Editor & Keys → Command modifier → `→` → `↵`) writes `command_modifier: "alt"`. `⌥` is one display column, same as `^`, so nothing shifts.

## Known limits

- The wizard's Review row raises **that step's** minimum terminal height from 14 to 15 rows. The step already refuses to render below its content with a clear message, and `esc` still completes setup.
- The wizard has **no spec coverage** (`grep -rln SetupWizard spec/` is empty), so the Review row is verified manually only.
- With the alias on, `⌥E` in a Repeater editor now opens `$EDITOR` where it previously did nothing. That's the feature working, but it's a behaviour change worth knowing.
- Out of scope: making the claimed family *individually* rebindable. That means routing all 51 guard sites through the keymap; `dealias` is a thin alias layer that can be deleted the day that happens.