### PR TITLE
fix(tui): make the Project sub-tabs a real focus tier, so the strip owns ←/→ and DESCRIPTION opens in READ

### DIFF
--- a/docs/content/guide/proxy.ko.md
+++ b/docs/content/guide/proxy.ko.md
@@ -210,19 +210,19 @@ gori는 모든 HTTPS 연결을 가로채므로, 인증서를 피닝하는 클라
 
 ## Project 탭 {#project-tab}
 
-**Project** 홈 탭은 단순한 요약 이상입니다. 포커스 가능한 패널들(`Tab`으로 순환):
+**Project** 홈 탭은 단순한 요약 이상입니다. 개요 아래에 서브탭 스트립이 있습니다. `←`/`→`로 카드를 바꾸고, `↓`/`Enter`로 열려 있는 카드 안으로 들어가며, `Esc`(또는 맨 위에서 `↑`)로 다시 스트립으로 올라옵니다.
 
 <figure class="tui-shot">
   <img src="/images/tui/project.svg" alt="개요, 한눈에 보는 상태 바, 스코프, 호스트 오버라이드, 환경 변수, 설명, 네트워크 패널을 갖춘 gori Project 탭">
   <figcaption><strong>Project</strong> 홈: 개요와 한눈에 보는 상태, 그리고 스코프, 호스트 오버라이드, 환경 변수, 프로젝트별 네트워크 설정 패널.</figcaption>
 </figure>
 
-| 패널 | 용도 |
+| 서브탭 | 용도 |
 |------|---------|
+| **DESCRIPTION** | 자유 형식 프로젝트 노트 |
 | **SCOPE** | include/exclude 규칙 (호스트, 문자열, 정규식) |
 | **HOST OVERRIDES** | 프로젝트별 접속 맵 |
 | **ENV** | 아웃바운드 요청을 위한 프로젝트별 `$KEY` 변수. [Repeater & Fuzzer](/ko/guide/repeater-and-fuzzer/#environment-variables) 참고 |
-| **DESCRIPTION** | 자유 형식 프로젝트 노트 |
 | **NETWORK** | scope 렌즈 + **샌드박스** 토글, 그리고 전역 Settings 기본값을 재정의하는 프로젝트별 네트워크 고정(bind / upstream) |
 
 스코프 규칙과 호스트 오버라이드는 스크립트로도 다룰 수 있습니다: `gori run project scope add --kind=include --type=host --pattern=api.example.com`, `gori run project host-override add --host=api.example.com --ip=10.0.0.1`. 전체 플래그는 [CLI Reference](/ko/reference/cli/#run-project)에 있습니다.

--- a/docs/content/guide/proxy.md
+++ b/docs/content/guide/proxy.md
@@ -210,19 +210,19 @@ Scope will not do this for you. Scope decides what is recorded and acted on; an 
 
 ## Project Tab
 
-The **Project** home tab is more than a summary. Focusable panes (cycle with `Tab`):
+The **Project** home tab is more than a summary. Under the overview sits a sub-tab strip: `←`/`→` switch cards, `↓`/`Enter` drop into the one showing, and `Esc` (or `↑` at the top) comes back up to the strip.
 
 <figure class="tui-shot">
   <img src="/images/tui/project.svg" alt="gori Project tab with overview, at-a-glance status bars, scope, host overrides, environment variables, description, and network panes">
   <figcaption>The <strong>Project</strong> home: overview and status at a glance, plus panes for scope, host overrides, env vars, and per-project network settings.</figcaption>
 </figure>
 
-| Pane | Purpose |
+| Sub-tab | Purpose |
 |------|---------|
+| **DESCRIPTION** | Free-form project notes |
 | **SCOPE** | Include/exclude rules (host, string, or regex) |
 | **HOST OVERRIDES** | Per-project dial map |
 | **ENV** | Per-project `$KEY` variables for outbound requests. See [Repeater & Fuzzer](/guide/repeater-and-fuzzer/#environment-variables) |
-| **DESCRIPTION** | Free-form project notes |
 | **NETWORK** | Scope-lens + **sandbox** toggles, plus per-project network pins (bind / upstream) that override the global Settings default |
 
 Scope rules and host overrides are also scriptable: `gori run project scope add --kind=include --type=host --pattern=api.example.com`, `gori run project host-override add --host=api.example.com --ip=10.0.0.1`. Full flags are in the [CLI Reference](/reference/cli/#run-project).

--- a/spec/tui/project_view_spec.cr
+++ b/spec/tui/project_view_spec.cr
@@ -147,6 +147,33 @@ describe "ProjectView DESCRIPTION scrolling" do
   end
 end
 
+describe "ProjectView DESCRIPTION insert mode" do
+  # Arriving at the DESCRIPTION sub-tab must land in READ mode, where the arrows navigate;
+  # only a click INSIDE the card opens the editor. That is the regression the sub-tab
+  # promotion fixed — selecting the chip used to route through desc_click_to_cursor and drop
+  # straight into INS, where ←/→ became caret movement with no way back out to the strip.
+  it "only enters INS from a click inside its own card" do
+    tmp_store do |store|
+      view = ProjectView.new(Gori::Scope.load(store), Gori::HostOverrides.load(store))
+      view.replace_desc("one\ntwo")
+      rect = Rect.new(0, 0, 120, 30)
+      view.render(Screen.new(MemoryBackend.new(120, 30)), rect, focused: true)
+      view.pane.should eq(:desc)
+      view.desc_insert_mode?.should be_false # the tab opens on DESCRIPTION, in READ
+
+      view.focus_pane(:scope) # another sub-tab is showing…
+      view.render(Screen.new(MemoryBackend.new(120, 30)), rect, focused: true)
+      view.desc_click_to_cursor(rect, rect.x + 2, rect.y + 14)
+      view.desc_insert_mode?.should be_false # …so a click in the body can't reach the editor
+
+      view.focus_pane(:desc)
+      view.render(Screen.new(MemoryBackend.new(120, 30)), rect, focused: true)
+      view.desc_click_to_cursor(rect, rect.x + 2, rect.y + 14)
+      view.desc_insert_mode?.should be_true
+    end
+  end
+end
+
 describe "ProjectView created time" do
   it "shows project creation time in the local timezone" do
     path = File.tempname("gori-projview-created", ".db")
@@ -258,11 +285,11 @@ describe "ProjectView#pane_at" do
       view.render(Screen.new(MemoryBackend.new(120, 30)), rect, focused: false)
 
       view.pane_at(rect, rect.x + 1, rect.y).should eq(:overview)
-      # SCOPE is active by default: both edges of the body belong to it, where the old tiling
-      # would have answered :desc on the right.
+      # DESCRIPTION is the first chip, so it's active by default: both edges of the body
+      # belong to it, where the old tiling would have answered :scope on the left.
       body_y = rect.y + 14
-      view.pane_at(rect, rect.x + 1, body_y).should eq(:scope)
-      view.pane_at(rect, rect.right - 2, body_y).should eq(:scope)
+      view.pane_at(rect, rect.x + 1, body_y).should eq(:desc)
+      view.pane_at(rect, rect.right - 2, body_y).should eq(:desc)
 
       view.focus_pane(:settings)
       view.render(Screen.new(MemoryBackend.new(120, 30)), rect, focused: false)
@@ -271,20 +298,22 @@ describe "ProjectView#pane_at" do
     end
   end
 
-  # ENV used to drop OUT OF THE TAB RING below a height threshold, so on a short terminal it was
+  # ENV used to drop OUT OF THE RING below a height threshold, so on a short terminal it was
   # simply unreachable. Panes no longer share the body, so the ring is now height-independent —
-  # that is the behaviour worth pinning, not a pixel offset.
-  it "keeps every sub-tab in the Tab ring regardless of height" do
+  # that is the behaviour worth pinning, not a pixel offset. DESCRIPTION leads the order.
+  it "walks every sub-tab from the first chip, regardless of height" do
     tmp_store do |store|
       view = ProjectView.new(Gori::Scope.load(store), Gori::HostOverrides.load(store))
       rect = Rect.new(0, 0, 120, 14) # short enough that the old layout hid ENV
       view.render(Screen.new(MemoryBackend.new(120, 14)), rect, focused: false)
 
+      view.pane.should eq(:desc) # the strip opens on DESCRIPTION
       visited = [view.pane]
       while view.pane_advance(1)
         visited << view.pane
       end
       visited.should eq(Gori::Tui::ProjectView::PANES)
+      view.pane_advance(1).should be_false # the strip clamps at the last chip, it does not wrap
     end
   end
 
@@ -297,16 +326,27 @@ describe "ProjectView#pane_at" do
       # Find the strip by scanning down for the row where more than one pane is addressable —
       # that only happens on the chip row, since the body belongs to a single pane.
       hits = [] of Symbol
+      strip_y = -1
       (rect.y...rect.bottom).each do |y|
         row = (rect.x...rect.right).compact_map { |x| view.pane_at(rect, x, y) }.uniq
         next unless row.size > 1
         hits = row
+        strip_y = y
         break
       end
       # Every pane is addressable from the strip, including ones the body is not showing.
       hits.should contain(:scope)
       hits.should contain(:settings)
       hits.should contain(:env)
+
+      # strip_chip_at is the narrower question the controller asks: "is this a CHIP click?" —
+      # it must answer only on the strip row, so a body click can never be mistaken for a
+      # sub-tab switch (and a chip click never opens the DESCRIPTION editor).
+      chips = (rect.x...rect.right).compact_map { |x| view.strip_chip_at(rect, x, strip_y) }.uniq
+      chips.should eq(hits)
+      view.strip_chip_at(rect, rect.x + 1, rect.y + 14).should be_nil # inside the card
+      view.strip_chip_at(rect, rect.x + 1, rect.y).should be_nil      # OVERVIEW band
+      view.strip_chip_at(Rect.new(0, 0, 0, 0), 0, 0).should be_nil    # empty layout
     end
   end
 end

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -4,9 +4,9 @@ require "../clipboard"
 require "../../env"
 
 module Gori::Tui
-  # The Project tab: the two-pane card (SCOPE rule list + DESCRIPTION editor) plus
-  # the project overview. Owns ProjectView. The Scope object itself is session-global
-  # (shared with History/Sitemap filters), so this controller edits it through
+  # The Project tab: the project overview plus five SUB-TABS (DESCRIPTION · SCOPE · HOST
+  # OVERRIDES · ENV · PROJECT SETTINGS). Owns ProjectView. The Scope object itself is
+  # session-global (shared with History/Sitemap filters), so this controller edits it through
   # @host.session.scope; the cross-tab scope quick-actions (add-host, toggle-lens,
   # jump-to-editor) are shell mediators.
   class ProjectController < TabController
@@ -43,35 +43,36 @@ module Gori::Tui
       editing ? :editor : :body
     end
 
-    # Hints depend on the focused pane (SCOPE rule list / HOST OVERRIDES list / their
-    # add-rows vs the DESC editor).
+    # Hints depend on the focused sub-tab (SCOPE rule list / HOST OVERRIDES list / their
+    # add-rows vs the DESC editor). Switching cards is the STRIP's job (esc / ↑-at-top go
+    # back up to it), so no hint advertises a sideways jump between panes any more.
     def body_hint(focus : Symbol) : String
       case @project_view.pane
       when :scope
-        "↑/↓ move · ↓ host-overrides · → desc · a add · ↵/e edit · d del · space cmds · esc"
+        "↑/↓ move · a add · ↵/e edit · d del · space cmds · esc sub-tabs"
       when :overrides
-        @project_view.ov_adding? ? "type \"IP host\" · ↵ save · esc cancel" : "↑/↓ move · ↑ scope · ↓ env · → desc · a add · ↵/e edit · d del · space cmds · esc"
+        @project_view.ov_adding? ? "type \"IP host\" · ↵ save · esc cancel" : "↑/↓ move · a add · ↵/e edit · d del · space cmds · esc sub-tabs"
       when :env
         if @project_view.env_prefix_editing?
           "type prefix · ↵ save · esc cancel"
         elsif @project_view.env_adding?
           "type \"KEY VALUE\" · ↵ save · esc cancel"
         else
-          "↑/↓ move · ↑ overrides · → desc · a add · ↵/e edit · d del · space cmds · esc"
+          "↑/↓ move · a add · ↵/e edit · d del · space cmds · esc sub-tabs"
         end
       when :settings
         if @project_view.settings_text_row?
-          "type to edit · ↵ apply · ←/→ cursor · ↑/↓ move · esc"
+          "type to edit · ↵ apply · ←/→ cursor · ↑/↓ move · esc sub-tabs"
         elsif @project_view.settings_sandbox_row?
-          "space/↵ sandbox — ON blocks ALL out-of-scope traffic · ↑/↓ move · esc"
+          "space/↵ sandbox — ON blocks ALL out-of-scope traffic · ↑/↓ move · esc sub-tabs"
         else
-          "space/↵ toggle lens · ↑/↓ move · ← overrides · ↑ desc · esc"
+          "space/↵ toggle lens · ↑/↓ move · esc sub-tabs"
         end
       else
         if @project_view.desc_insert_mode?
-          "type to edit · esc read · ↑/↓/↔ move · ← scope · ↓ settings · ^G goto · ^F find · ^E $EDITOR"
+          "type to edit · esc read · ↑/↓/↔ move · ^G goto · ^F find · ^E $EDITOR"
         else
-          "i/↵ edit · ⇧arrows select · y copy · space cmds · ↑/↓ move · ← scope · ↓ settings · ^G goto · ^F find · esc tabs"
+          "i/↵ edit · ⇧arrows select · y copy · space cmds · ↑/↓ move · ^G goto · ^F find · esc sub-tabs"
         end
       end
     end
@@ -80,9 +81,59 @@ module Gori::Tui
       @project_view.pane == :desc ? :project : nil
     end
 
+    # --- sub-tab strip (the five cards ARE the sub-tabs) ---------------------
+    # Promoting them off the body's Tab ring is what makes this tab navigate like every other
+    # one: the strip owns ←/→, and the card underneath stays UNFOCUSED until you drop in with
+    # ↓/↵/Tab. While they were body panes, arriving at DESCRIPTION could land straight in the
+    # INS editor, where the arrows are caret movement and there was no way back out sideways.
+    def subtab_labels : Array(String)?
+      ProjectView::PANE_LABELS
+    end
+
+    def subtab_index : Int32
+      @project_view.pane_index
+    end
+
+    # A FIXED chip set — no ^N/^W create/close, no rename (the shell drops those hint tokens).
+    def subtabs_fixed? : Bool
+      true
+    end
+
+    # ProjectView draws the strip itself, UNDER the OVERVIEW band rather than at the body's
+    # top edge, so the shell's strip hit-test would claim OVERVIEW rows instead. handle_click
+    # owns chip clicks here (see the strip_chip_at branch below).
+    def subtab_strip_self_drawn? : Bool
+      true
+    end
+
+    def move_subtab(dir : Int32) : Nil
+      settle_subtab
+      @project_view.pane_advance(dir) # clamps at both ends, like the chips read
+    end
+
+    def jump_subtab(idx : Int32) : Nil
+      return unless pane = ProjectView::PANES[idx]?
+      settle_subtab
+      @project_view.focus_pane(pane)
+    end
+
+    # Everything a sub-tab change has to settle, wherever it came from (strip ←/→, ^1-9, a
+    # chip click). Persist the description + any pending network edit, drop half-composed
+    # inline rows, and — the invariant that keeps the reported bug fixed — return the
+    # DESCRIPTION editor to READ mode. @desc_mode is sticky, so without this you'd only have
+    # to enter INS once for every later visit to that chip to land in the editor again.
+    private def settle_subtab : Nil
+      commit_project_network(on_leave: true)
+      save
+      @project_view.exit_desc_insert!
+      @project_view.cancel_ov_add
+      @project_view.cancel_env_add
+      @project_view.cancel_env_prefix_edit
+    end
+
     def render_body(screen : Screen, rect : Rect, focus : Symbol) : Nil
-      # Self-frames its OVERVIEW + SCOPE|DESCRIPTION cards (multi-pane, like Repeater).
-      @project_view.render(screen, rect, focused: focus == :body)
+      # Self-frames its OVERVIEW band, the sub-tab strip, and the active card.
+      @project_view.render(screen, rect, focused: focus == :body, strip_focused: focus == :subtabs)
     end
 
     def handle_body_key(ev : Termisu::Event::Key) : Bool
@@ -103,6 +154,14 @@ module Gori::Tui
     end
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
+      # Chip strip FIRST: it sits inside this tab's body rect (under the OVERVIEW band), so a
+      # chip click reads as a body click unless it's claimed here. It lands on the STRIP, not
+      # in the card — clicking "DESCRIPTION" selects the sub-tab, it doesn't open the editor.
+      if chip = @project_view.strip_chip_at(rect, mx, my)
+        jump_subtab(ProjectView::PANES.index(chip) || 0)
+        @host.request_focus(:subtabs)
+        return true
+      end
       return true unless pane = @project_view.pane_at(rect, mx, my)
       @host.focus_body
       # Clicking OUT of the settings pane applies any pending network edit (mirrors the
@@ -153,11 +212,14 @@ module Gori::Tui
       true
     end
 
-    # A wheel notch scrolls the pane UNDER the pointer (not the focused one), so a long
-    # DESCRIPTION scrolls into view on a plain wheel-over — no click-to-focus first. The
-    # DESCRIPTION viewport-scrolls (cursor follows) instead of spilling past the card;
-    # the SCOPE rule list moves its selection (selection-follow, like the keyboard).
+    # A wheel notch scrolls the card UNDER the pointer without focusing it first, so a long
+    # DESCRIPTION scrolls into view on a plain wheel-over. The DESCRIPTION viewport-scrolls
+    # (cursor follows) instead of spilling past the card; the lists move their selection
+    # (selection-follow, like the keyboard). A notch over the chip strip is inert — pane_at
+    # answers with the CHIP's pane there, and scrolling a card the body isn't even drawing
+    # would move an invisible selection.
     def handle_wheel_at(step : Int32, mx : Int32, my : Int32, rect : Rect) : Bool
+      return true if @project_view.strip_chip_at(rect, mx, my)
       case @project_view.pane_at(rect, mx, my)
       when :desc      then @project_view.desc_scroll(step)
       when :scope     then @project_view.scope_select(step)
@@ -206,19 +268,15 @@ module Gori::Tui
       true
     end
 
-    # --- focus ring (SCOPE ◂▸ HOST OVERRIDES ◂▸ DESCRIPTION ◂▸ PROJECT SETTINGS) ---
-    def pane_advance(dir : Int32) : Bool
-      # Tab-ing off the settings pane applies its pending network edit before the pane changes.
-      commit_project_network(on_leave: true) if @project_view.pane == :settings
-      @project_view.pane_advance(dir)
-    end
-
-    def focus_first : Nil
-      @project_view.focus_first
-    end
-
-    def focus_last : Nil
-      @project_view.focus_last
+    # --- focus ring ----------------------------------------------------------
+    # Each sub-tab is a single card, so the body ring has nowhere further to step: settle the
+    # card and answer false, and the shell wraps Tab back to the tab bar. Cycling CARDS is the
+    # strip's ←/→ now, not Tab's. (focus_first/focus_last are deliberately NOT overridden —
+    # the shell calls them on every :body focus, and re-picking a pane there would override
+    # the chip the user just selected on the strip.)
+    def pane_advance(_dir : Int32) : Bool
+      settle_subtab
+      false
     end
 
     def on_enter : Nil
@@ -257,6 +315,15 @@ module Gori::Tui
       @project_view.refresh_settings unless @project_view.settings_dirty?
     end
 
+    # Leave the card for the sub-tab strip above it (esc, or ↑ off the top row) — the same
+    # one-step-up gesture Notes/Repeater use, so the chips are always one key away and ←/→
+    # switch cards again. esc from the strip then reaches the tab bar.
+    private def leave_to_strip : Nil
+      save
+      @project_view.exit_desc_insert! # never sit on the strip over a live INS editor
+      @host.request_focus(:subtabs)
+    end
+
     # --- DESCRIPTION pane: READ/INS multi-line editing ---
     private def handle_project_desc_key(ev : Termisu::Event::Key) : Nil
       key = ev.key
@@ -269,8 +336,7 @@ module Gori::Tui
           save
           @project_view.exit_desc_insert!
         else
-          save
-          @host.request_focus(:menu)
+          leave_to_strip
         end
       elsif @project_view.desc_insert_mode?
         edit_desc_insert(ev, key, c)
@@ -293,19 +359,8 @@ module Gori::Tui
       when key.enter?, c == 'i'
         @project_view.enter_desc_insert!
       when key.up?
-        if @project_view.at_top?
-          save
-          @host.request_focus(:menu)
-        else
-          @project_view.desc_read_move(-1, 0, selecting: selecting)
-        end
-      when key.down? && @project_view.desc_at_bottom?
-        save
-        @project_view.focus_pane(:settings)
-      when key.down?
-        @project_view.desc_read_move(1, 0, selecting: selecting)
-      when key.left? && @project_view.desc_at_start?
-        @project_view.focus_pane(:scope)
+        @project_view.at_top? ? leave_to_strip : @project_view.desc_read_move(-1, 0, selecting: selecting)
+      when key.down?               then @project_view.desc_read_move(1, 0, selecting: selecting)
       when key.left? && selecting  then @project_view.desc_read_move(0, -1, selecting: true)
       when key.right? && selecting then @project_view.desc_read_move(0, 1, selecting: true)
       when key.left?               then @project_view.desc_read_move(0, -1)
@@ -321,17 +376,7 @@ module Gori::Tui
       when ev.ctrl_z?     then @project_view.undo
       when key.backspace? then @project_view.backspace
       when key.up?
-        if @project_view.at_top?
-          save
-          @host.request_focus(:menu)
-        else
-          @project_view.move(-1, 0)
-        end
-      when key.left? && @project_view.desc_at_start?
-        @project_view.focus_pane(:scope)
-      when key.down? && @project_view.desc_at_bottom?
-        save
-        @project_view.focus_pane(:settings)
+        @project_view.at_top? ? leave_to_strip : @project_view.move(-1, 0)
       when key.down?  then @project_view.move(1, 0)
       when key.left?  then @project_view.move(0, -1)
       when key.right? then @project_view.move(0, 1)
@@ -380,23 +425,14 @@ module Gori::Tui
         save
         @host.open_palette
       elsif key.escape?
-        save
-        @host.request_focus(:menu)
+        leave_to_strip
       elsif key.up? || key.lower_k?
-        if @project_view.scope_at_top? # ↑/k on the first rule pops up to the tab bar
-          save
-          @host.request_focus(:menu)
-        else
-          @project_view.scope_select(-1)
-        end
+        @project_view.scope_at_top? ? leave_to_strip : @project_view.scope_select(-1)
       elsif key.down? || key.lower_j?
-        if @project_view.scope_at_bottom? # ↓/j on the last rule drops into HOST OVERRIDES (the card below)
-          @project_view.focus_pane(:overrides)
-        else
-          @project_view.scope_select(1)
-        end
-      elsif key.right?
-        @project_view.focus_pane(:desc) # → crosses to the DESCRIPTION (right pane)
+        @project_view.scope_select(1)
+      elsif key.left? || key.right?
+        # Inert: ←/→ belong to the STRIP one tier up, so they must not silently swap cards
+        # from inside one. Swallowed rather than deferred so the keymap can't rebind them here.
       elsif key.enter?
         scope_edit_rule # ↵ opens the same popup as 'e'
       else
@@ -498,24 +534,13 @@ module Gori::Tui
         save
         @host.open_palette
       elsif key.escape?
-        save
-        @host.request_focus(:menu)
+        leave_to_strip
       elsif key.up? || key.lower_k?
-        if @project_view.ov_at_top? # ↑/k on the first override crosses up to the SCOPE pane
-          @project_view.pane_advance(-1)
-        else
-          @project_view.ov_select(-1)
-        end
+        @project_view.ov_at_top? ? leave_to_strip : @project_view.ov_select(-1)
       elsif key.down? || key.lower_j?
-        if @project_view.ov_at_bottom? && @project_view.env_pane_enabled?
-          @project_view.focus_pane(:env)
-        else
-          @project_view.ov_select(1)
-        end
-      elsif key.left?
-        @project_view.pane_advance(-1)
-      elsif key.right?
-        @project_view.focus_pane(:desc)
+        @project_view.ov_select(1)
+      elsif key.left? || key.right?
+        # Inert — ←/→ switch sub-tabs on the strip, not from inside a card.
       elsif key.enter?
         @project_view.ov_edit_start
       else
@@ -549,11 +574,16 @@ module Gori::Tui
     end
 
     # --- HOST OVERRIDES verbs (a/e/d via the keymap + the action menu) ---
+    # Each takes body focus first: the space menu also reaches these from the sub-tab STRIP,
+    # and an inline row that opens while focus sits a tier up would draw a caret nothing types
+    # into (the strip swallows plain keys). Raw focus_body — the pane is already the right one.
     def hostov_add_entry : Nil
+      @host.focus_body
       @project_view.ov_add_start
     end
 
     def hostov_edit_entry : Nil
+      @host.focus_body
       @project_view.ov_edit_start
     end
 
@@ -584,20 +614,13 @@ module Gori::Tui
         save
         @host.open_palette
       elsif key.escape?
-        save
-        @host.request_focus(:menu)
+        leave_to_strip
       elsif key.up? || key.lower_k?
-        if @project_view.env_at_top?
-          @project_view.focus_pane(:overrides)
-        else
-          @project_view.env_select(-1)
-        end
+        @project_view.env_at_top? ? leave_to_strip : @project_view.env_select(-1)
       elsif key.down? || key.lower_j?
         @project_view.env_select(1)
-      elsif key.left?
-        @project_view.pane_advance(-1)
-      elsif key.right?
-        @project_view.focus_pane(:desc)
+      elsif key.left? || key.right?
+        # Inert — ←/→ switch sub-tabs on the strip, not from inside a card.
       elsif key.enter?
         @project_view.env_edit_start
       else
@@ -607,11 +630,14 @@ module Gori::Tui
     end
 
     # --- ENV verbs (a/e/d via the keymap + the Env action menu) ---
+    # Body focus first, for the same reason as the HOST OVERRIDES verbs above.
     def env_add_var : Nil
+      @host.focus_body
       @project_view.env_add_start
     end
 
     def env_edit_var : Nil
+      @host.focus_body
       @project_view.env_edit_start
     end
 
@@ -623,6 +649,7 @@ module Gori::Tui
     end
 
     def env_edit_prefix : Nil
+      @host.focus_body
       @project_view.env_prefix_edit_start
     end
 
@@ -710,9 +737,7 @@ module Gori::Tui
         save
         @host.open_palette
       elsif key.escape?
-        commit_project_network(on_leave: true)
-        save
-        @host.request_focus(:menu)
+        leave_settings_to_strip
       elsif key.up?
         settings_move(-1)
       elsif key.down?
@@ -722,49 +747,46 @@ module Gori::Tui
       end
     end
 
-    # ↑/↓ move between rows, crossing out at the boundaries (↑ off row 0 → DESCRIPTION above;
-    # ↓ off the last row → the tab bar). ONLY ↑/↓ move rows — the text fields need j/k as input.
+    # ↑ off row 0 pops up to the sub-tab strip; ↓ off the last row clamps (the strip is the
+    # single way out, so there's no second exit to hunt for). ONLY ↑/↓ move rows — the text
+    # fields need j/k as input.
     private def settings_move(dir : Int32) : Nil
       if dir < 0 && @project_view.set_at_top?
-        @project_view.focus_pane(:desc)
-      elsif dir > 0 && @project_view.set_at_bottom?
-        commit_project_network(on_leave: true)
-        @host.request_focus(:menu)
+        leave_settings_to_strip
       else
-        @project_view.set_select(dir)
+        @project_view.set_select(dir) # clamps at the last row
       end
+    end
+
+    # Leaving the NETWORK card always applies its pending edit first (the on_leave contract:
+    # an invalid field is dropped rather than kept half-typed).
+    private def leave_settings_to_strip : Nil
+      commit_project_network(on_leave: true)
+      leave_to_strip
     end
 
     private def handle_project_settings_action(ev : Termisu::Event::Key) : Nil
       @project_view.settings_text_row? ? handle_project_settings_field_key(ev) : handle_project_settings_toggle_key(ev)
     end
 
-    # Row 0 (scope lens): space/↵ toggles it; ← crosses to the left column.
-    # The two toggle rows (scope lens, sandbox): space/↵ flips whichever is selected, ← crosses
-    # left. ↑/↓ are handled by settings_move before we get here.
+    # The two toggle rows (scope lens, sandbox): space/↵ flips whichever is selected. ↑/↓ are
+    # handled by settings_move before we get here; ←/→ belong to the strip, so they're inert.
     private def handle_project_settings_toggle_key(ev : Termisu::Event::Key) : Nil
       key = ev.key
       if key.enter? || key.space?
         @project_view.settings_sandbox_row? ? @host.toggle_sandbox : @host.toggle_scope_lens
-      elsif key.left?
-        @project_view.focus_pane(@project_view.env_pane_enabled? ? :env : :overrides)
       end
     end
 
-    # Rows 1-3 (bind IP / port / upstream): type to edit, ↵ applies, ← at the field start
-    # crosses to the left column (else moves the caret).
+    # Rows 2-7 (bind IP / port / upstream / timeouts / capture cap): type to edit, ↵ applies,
+    # ←/→ move the caret (clamped — they no longer escape the card sideways).
     private def handle_project_settings_field_key(ev : Termisu::Event::Key) : Nil
       key = ev.key
       c = ev.char || key.to_char
       if key.enter?
         commit_project_network(on_leave: false)
       elsif key.left?
-        if @project_view.set_at_cursor_start?
-          commit_project_network(on_leave: true)
-          @project_view.focus_pane(:overrides)
-        else
-          @project_view.set_move_cursor(-1)
-        end
+        @project_view.set_move_cursor(-1)
       elsif key.right?
         @project_view.set_move_cursor(1)
       elsif key.backspace?

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -133,7 +133,7 @@ module Gori::Tui
         Item.new("Issues", "list: t mark · ⇧T all · ⇧arrows range · notes: i/↵ edit · x line · y copy · space cmds"),
         Item.new("Probe", "↑/↓ ↵ open · m mode · c dismiss · a all · / filter · ⇧S scope · space cmds"),
         Item.new("Notes", "i/↵ edit · x line · ⇧arrows select · y copy · space cmds (Copy selected when highlighted)"),
-        Item.new("Project", "desc: i/↵ edit · x line · ⇧arrows select · y copy · space cmds"),
+        Item.new("Project", "←/→ sub-tab (desc · scope · hosts · env · network) · ↓/↵ enter · desc: i/↵ edit · x line · y copy"),
         Item.new("Intercept", "↵/e edit · f fwd · d drop · ⇧F all · c catch · / condition · i on/off · ⇧←/→ h-scroll"),
       ]},
       {"DECODER", [

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -37,9 +37,9 @@ module Gori::Tui
     @sev_tally : StaticArray(Int64, 5)
     @desc_area : TextArea
 
-    # The body has two focusable panes (cycled with Tab, like Repeater's panes): the
-    # SCOPE rule editor and the DESCRIPTION editor. @pane drives where keys land while
-    # the Project tab body holds focus.
+    # The body shows ONE card at a time, picked by the shell's sub-tab strip (@focus ==
+    # :subtabs owns ←/→; the card underneath is only focused once you drop in with ↓/↵).
+    # @pane names the active sub-tab, i.e. where keys land while the body holds focus.
     getter pane : Symbol
 
     def initialize(@scope : Scope, @host_overrides : HostOverrides)
@@ -58,7 +58,7 @@ module Gori::Tui
       @desc_mode = InputMode::Read
       @desc_read = TextReadState.new
 
-      @pane = :scope   # :scope | :overrides | :env | :desc | :settings
+      @pane = :desc    # :desc | :scope | :overrides | :env | :settings (PANES order)
       @strip_start = 0 # first visible sub-tab chip (Chrome.render_tab_strip owns the window)
       @sel = 0         # selected rule row in the SCOPE list
       # SCOPE add/edit is a centered popup (ScopeRuleOverlay), not an inline row.
@@ -80,7 +80,6 @@ module Gori::Tui
       @env_input = ""
       @env_icx = 0
       @env_preedit = ""
-      @env_pane_enabled = false
 
       # NETWORK pane: two toggle rows (scope lens, sandbox) + inline-editable network fields
       # (bind IP / bind port / upstream proxy). @set_values holds the three text
@@ -223,13 +222,15 @@ module Gori::Tui
       @desc_read.move(@desc_area, 0, delta * 4)
     end
 
-    PANES = [:scope, :overrides, :env, :desc, :settings]
+    # Sub-tab order, left to right. DESCRIPTION leads: it's the one card you WRITE rather
+    # than configure, so it's both the most-visited chip and the natural landing spot when
+    # the tab opens; the four configuration cards follow.
+    PANES = [:desc, :scope, :overrides, :env, :settings]
     # Chip labels, in PANES order. Kept parallel rather than derived from the symbols so a
     # label can read well ("HOST OVERRIDES") without renaming the pane it addresses.
-    PANE_LABELS = ["SCOPE", "HOST OVERRIDES", "ENV", "DESCRIPTION", "PROJECT SETTINGS"]
+    PANE_LABELS = ["DESCRIPTION", "SCOPE", "HOST OVERRIDES", "ENV", "PROJECT SETTINGS"]
     # One row for the sub-tab chips.
-    STRIP_H        =  1
-    ENV_MIN_BODY_H = 11
+    STRIP_H = 1
 
     # NETWORK pane rows: two toggles (scope-lens, sandbox) over the three inline network
     # fields. The toggle/field boundary is FIELD_BASE — every field access is @set_sel minus
@@ -244,14 +245,6 @@ module Gori::Tui
     SETTINGS_FIELD_BASE  =  2 # first inline-editable network-field row
     SETTINGS_LABEL_W     = 16 # value column starts past the widest label ("Connect timeout")
 
-    def focus_first : Nil
-      @pane = :scope
-    end
-
-    def focus_last : Nil
-      @pane = enabled_panes.last? || :settings # last pane in the ring (PROJECT SETTINGS)
-    end
-
     # The 's' / scope.edit jump target: focus the SCOPE pane fresh (no half-open row in
     # either list).
     def focus_scope : Nil
@@ -261,28 +254,16 @@ module Gori::Tui
       cancel_env_prefix_edit
     end
 
-    # Step between panes; false when there's no further pane in `dir` (the Runner ring
-    # then wraps back to the tab bar). Mirrors RepeaterView#pane_advance.
+    # Step to the neighbouring sub-tab; false at either end (the strip clamps, it does not
+    # wrap — same as the chips read). Driven by the strip's ←/→ via move_subtab.
     def pane_advance(dir : Int32) : Bool
-      panes = enabled_panes
-      i = panes.index(@pane) || 0
-      ni = i + dir
-      return false if ni < 0 || ni >= panes.size
-      @pane = panes[ni]
+      i = pane_index + dir
+      return false if i < 0 || i >= PANES.size
+      @pane = PANES[i]
       true
     end
 
-    private def enabled_panes : Array(Symbol)
-      # Every pane is always reachable now that they no longer share the body — the old
-      # height-based ENV drop-out went away with the tiling.
-      PANES
-    end
-
-    def env_pane_enabled? : Bool
-      @env_pane_enabled
-    end
-
-    # Mouse: focus a body pane directly (click-to-focus). Ignores unknown symbols.
+    # Select a sub-tab directly (a chip click / ^1-9). Ignores unknown symbols.
     def focus_pane(pane : Symbol) : Nil
       @pane = pane if PANES.includes?(pane)
     end
@@ -307,40 +288,31 @@ module Gori::Tui
       vw < VIZ_MIN_W ? 0 : vw
     end
 
-    SETTINGS_H = 10 # 2 toggle rows + 6 network fields + the card's top/bottom border
-    MIN_DESC_H =  3
-
-    private def env_pane_enabled?(content_h : Int32) : Bool
-      content_h >= ENV_MIN_BODY_H
-    end
-
     # SUB-TAB layout. The body shows ONE card at a time, under a chip strip, instead of
     # tiling all five at once.
     #
     # Tiling was the previous design and it ran out of room: five cards split a single body
     # between them, so SETTINGS got a fixed 6-row slice and ENV was DROPPED entirely below a
-    # height threshold (`env_pane_enabled?`) — a pane silently disappearing is a bad answer to
-    # "the terminal is short". One card at full size removes the threshold, and gives each
-    # editor room to grow (which is what let PROJECT SETTINGS take its per-project overrides).
+    # height threshold — a pane silently disappearing is a bad answer to "the terminal is
+    # short". One card at full size removes the threshold, and gives each editor room to grow
+    # (which is what let PROJECT SETTINGS take its per-project overrides).
     #
-    # The 5-tuple contract is kept deliberately: the ACTIVE pane gets the whole content rect and
-    # the others get zero-height rects. Every existing geometry helper (scope_row_at,
-    # ov_row_at, settings_row_at, pane_at) then keeps working unchanged, because each already
-    # indexes this tuple — an inactive pane simply can't be hit.
-    private def body_panes(rect : Rect) : {Rect, Rect, Rect, Rect, Rect}?
+    # The whole content rect belongs to whichever sub-tab is showing; nil when the body is too
+    # small to draw a card at all.
+    private def active_card(rect : Rect) : Rect?
       oh = overview_h(rect)
       content = Rect.new(rect.x, rect.y + oh, rect.w, {rect.h - oh, 0}.max)
       return nil if content.h < 3 || content.w < 4
-      body = Rect.new(content.x, content.y + STRIP_H, content.w, {content.h - STRIP_H, 0}.max)
-      empty = Rect.new(content.x, content.y + content.h, content.w, 0)
-      active = pane_index
-      {
-        active == 0 ? body : empty,
-        active == 1 ? body : empty,
-        active == 2 ? body : empty,
-        active == 3 ? body : empty,
-        active == 4 ? body : empty,
-      }
+      Rect.new(content.x, content.y + STRIP_H, content.w, {content.h - STRIP_H, 0}.max)
+    end
+
+    # The card rect IFF `pane` is the sub-tab currently showing. Every per-pane hit-test goes
+    # through this, so a sub-tab the body isn't drawing simply can't be hit — the property the
+    # retired 5-tuple (active pane gets the rect, the rest get zero-height ones) encoded
+    # positionally, and which a reorder of PANES would have silently repointed.
+    private def card_rect(rect : Rect, pane : Symbol) : Rect?
+      return nil unless @pane == pane
+      active_card(rect)
     end
 
     # The one-row chip strip above the active card.
@@ -348,47 +320,48 @@ module Gori::Tui
       Rect.new(rect.x, rect.y + overview_h(rect), rect.w, STRIP_H)
     end
 
-    private def pane_index : Int32
+    def pane_index : Int32
       PANES.index(@pane) || 0
     end
 
     # --- mouse hit-testing (inverts render's offset math; coords are 0-based) ---
 
+    # The sub-tab chip under (mx,my), or nil when the point isn't on one. Public so the
+    # controller can route a chip click to the shell's :subtabs focus BEFORE it is mistaken
+    # for a click into the card below (the chip strip is how the mouse reaches a sub-tab the
+    # body isn't drawing).
+    def strip_chip_at(rect : Rect, mx : Int32, my : Int32) : Symbol?
+      return nil if rect.empty? || active_card(rect).nil?
+      strip = strip_rect(rect)
+      return nil unless strip.contains?(mx, my)
+      seg = Chrome.strip_segments(strip, PANE_LABELS, pane_index, @strip_start).find { |(_, r)| r.contains?(mx, my) }
+      seg ? PANES[seg[0]] : nil
+    end
+
     def pane_at(rect : Rect, mx : Int32, my : Int32) : Symbol?
       return nil if rect.empty? || !rect.contains?(mx, my)
       return :overview if my < rect.y + overview_h(rect)
-      return nil unless panes = body_panes(rect)
-      # A click on the chip strip selects that sub-tab, so the mouse reaches every pane even
-      # though only one is rendered.
-      if strip_rect(rect).contains?(mx, my)
-        seg = Chrome.strip_segments(strip_rect(rect), PANE_LABELS, pane_index, @strip_start).find { |(_, r)| r.contains?(mx, my) }
-        return seg ? PANES[seg[0]] : nil
-      end
-      PANES.each_with_index do |pane, i|
-        return pane if panes[i].h > 0 && panes[i].contains?(mx, my)
-      end
-      nil
+      return nil unless card = active_card(rect)
+      return strip_chip_at(rect, mx, my) if strip_rect(rect).contains?(mx, my)
+      card.contains?(mx, my) ? @pane : nil
     end
 
     # Index of the scope-rule row clicked, or nil outside the populated list.
     def scope_row_at(rect : Rect, mx : Int32, my : Int32) : Int32?
-      return nil unless pane_at(rect, mx, my) == :scope
-      return nil unless panes = body_panes(rect)
-      row_at(panes[0].inset(1, 1), mx, my, false, @sel, @scope.rules.size)
+      return nil unless card = card_rect(rect, :scope)
+      row_at(card.inset(1, 1), mx, my, false, @sel, @scope.rules.size)
     end
 
     # Index of the host-override row clicked, or nil outside the populated list. Uses the
     # SAME ov_list_inner offset render does, so the example-hint row never drifts the click.
     def ov_row_at(rect : Rect, mx : Int32, my : Int32) : Int32?
-      return nil unless pane_at(rect, mx, my) == :overrides
-      return nil unless panes = body_panes(rect)
-      row_at(ov_list_inner(panes[1].inset(1, 1)), mx, my, @ov_adding, @ov_sel, @host_overrides.entries.size)
+      return nil unless card = card_rect(rect, :overrides)
+      row_at(ov_list_inner(card.inset(1, 1)), mx, my, @ov_adding, @ov_sel, @host_overrides.entries.size)
     end
 
     def env_row_at(rect : Rect, mx : Int32, my : Int32) : Int32?
-      return nil unless pane_at(rect, mx, my) == :env
-      return nil unless panes = body_panes(rect)
-      row_at(env_list_inner(panes[2].inset(1, 1)), mx, my, @env_adding, @env_sel, @env_items.size)
+      return nil unless card = card_rect(rect, :env)
+      row_at(env_list_inner(card.inset(1, 1)), mx, my, @env_adding, @env_sel, @env_items.size)
     end
 
     # Shared row hit-test for the SCOPE/HOST-OVERRIDES list interiors: account for the
@@ -417,18 +390,18 @@ module Gori::Tui
       @ov_sel = idx.clamp(0, n - 1)
     end
 
-    # DESCRIPTION card outer rect (for border chrome hit-tests). Nil when layout is empty.
+    # DESCRIPTION card outer rect (for border chrome hit-tests). Nil unless it's showing.
     def desc_card_rect(rect : Rect) : Rect?
-      body_panes(rect).try &.[3]
+      card_rect(rect, :desc)
     end
 
-    # Mouse: place the description-editor cursor at a click. `rect` is the body rect
-    # render() receives; re-derive the DESCRIPTION card + its 1-cell inset via body_panes
-    # (the same geometry render uses), then map into the @desc_area editor.
+    # Mouse: place the description-editor cursor at a click INSIDE the card, entering INS
+    # like NotesView#click_to_cursor. Selecting the sub-tab (a chip click, ↓ off the strip)
+    # deliberately does NOT come through here — that lands in READ mode, so arrows navigate.
     def desc_click_to_cursor(rect : Rect, mx : Int32, my : Int32) : Nil
-      return unless panes = body_panes(rect)
+      return unless card = card_rect(rect, :desc)
       enter_desc_insert!
-      @desc_area.click_to_cursor(panes[3].inset(1, 1), mx, my)
+      @desc_area.click_to_cursor(card.inset(1, 1), mx, my)
     end
 
     # --- PROJECT SETTINGS pane (delegated from ProjectController#handle_project_settings_key) ---
@@ -453,16 +426,10 @@ module Gori::Tui
       @set_sel >= SETTINGS_FIELD_BASE
     end
 
+    # On row 0 → ↑ pops up to the sub-tab strip. There's no matching at_bottom? / at_cursor_start?
+    # any more: the card no longer has sideways or downward exits, so both ends just clamp.
     def set_at_top? : Bool
       @set_sel <= 0
-    end
-
-    def set_at_bottom? : Bool
-      @set_sel >= SETTINGS_LABELS.size - 1
-    end
-
-    def set_at_cursor_start? : Bool
-      @set_cursor <= 0
     end
 
     # The three network fields, trimmed, for commit: {bind IP, bind port, upstream proxy}.
@@ -527,9 +494,8 @@ module Gori::Tui
 
     # Mouse hit-test: the settings row index under (mx,my), or nil outside the pane's rows.
     def set_row_at(rect : Rect, mx : Int32, my : Int32) : Int32?
-      return nil unless pane_at(rect, mx, my) == :settings
-      return nil unless panes = body_panes(rect)
-      inner = panes[4].inset(1, 1)
+      return nil unless card = card_rect(rect, :settings)
+      inner = card.inset(1, 1)
       return nil if inner.h <= 0 || !inner.contains?(mx, my)
       row = my - inner.y
       (0 <= row < SETTINGS_LABELS.size) ? row : nil
@@ -538,8 +504,8 @@ module Gori::Tui
     # Mouse: place the caret in the focused network field at a click (no-op on the toggle row).
     def setting_click_to_cursor(rect : Rect, mx : Int32, my : Int32) : Nil
       return unless settings_text_row?
-      return unless panes = body_panes(rect)
-      inner = panes[4].inset(1, 1)
+      return unless card = card_rect(rect, :settings)
+      inner = card.inset(1, 1)
       vx = inner.x + 1 + SETTINGS_LABEL_W + 1
       @set_cursor = (mx - vx).clamp(0, @set_values[@set_sel - SETTINGS_FIELD_BASE].size)
     end
@@ -551,16 +517,10 @@ module Gori::Tui
       @sel = (@sel + d).clamp(0, n - 1)
     end
 
-    # Selection on the first rule (or an empty list) → ↑ pops focus to the tab bar,
+    # Selection on the first rule (or an empty list) → ↑ pops focus to the sub-tab strip,
     # mirroring the DESCRIPTION editor's `at_top?`.
     def scope_at_top? : Bool
       @sel <= 0
-    end
-
-    # Selection on the last rule (or an empty list) → ↓ crosses down to the HOST
-    # OVERRIDES pane (the card directly below in the left column).
-    def scope_at_bottom? : Bool
-      @sel >= @scope.rules.size - 1
     end
 
     # The currently selected rule (nil when the list is empty) — seeds the edit popup.
@@ -608,14 +568,9 @@ module Gori::Tui
       @ov_sel = (@ov_sel + d).clamp(0, n - 1)
     end
 
-    # On the first override (or an empty list) → ↑ pops focus to the tab bar.
+    # On the first override (or an empty list) → ↑ pops focus to the sub-tab strip.
     def ov_at_top? : Bool
       @ov_sel <= 0
-    end
-
-    def ov_at_bottom? : Bool
-      n = @host_overrides.entries.size
-      n == 0 || @ov_sel >= n - 1
     end
 
     def ov_add_start : Nil
@@ -900,50 +855,33 @@ module Gori::Tui
       @desc_area.search_hl = q
     end
 
-    # Cursor on the first description line → ↑ pops focus to the tab bar (after saving).
+    # Cursor on the first description line → ↑ pops focus to the sub-tab strip (after saving).
     def at_top? : Bool
       @desc_area.at_top?
     end
 
-    # Cursor at the very start of the description → ← crosses back to the SCOPE pane.
-    def desc_at_start? : Bool
-      @desc_area.at_start?
-    end
-
-    # Cursor on the last line of the description → ↓ crosses down to the PROJECT SETTINGS pane.
-    def desc_at_bottom? : Bool
-      @desc_area.at_bottom?
-    end
-
-    # Self-framed (like Repeater/Intercept): an OVERVIEW card on top (read-only stats),
-    # then SCOPE (top-left) over HOST OVERRIDES (bottom-left) and DESCRIPTION (right) —
-    # three focusable panes. The focused pane's card lights gold.
-    def render(screen : Screen, rect : Rect, focused : Bool = true) : Nil
+    # Self-framed (like Repeater/Intercept): an OVERVIEW card on top (read-only stats), then
+    # the sub-tab chip strip, then the ONE card that strip selects. `focused` = the body holds
+    # focus (the card lights gold); `strip_focused` = the strip does (the chips light instead)
+    # — the two are mutually exclusive tiers of the shell's focus ring, so a focused strip
+    # must leave the card below at rest.
+    def render(screen : Screen, rect : Rect, focused : Bool = true, strip_focused : Bool = false) : Nil
       return if rect.empty?
       oh = overview_h(rect)
-      @env_pane_enabled = env_pane_enabled?({rect.h - oh, 0}.max)
-      if @pane == :env && !@env_pane_enabled
-        @pane = :overrides
-      end
-      scope_focused = focused && @pane == :scope
-      ov_focused = focused && @pane == :overrides
-      env_focused = focused && @pane == :env
-      desc_focused = focused && @pane == :desc
-      settings_focused = focused && @pane == :settings
-
       band = Rect.new(rect.x, rect.y, rect.w, oh)
       vw = viz_width(band.w)
       ov_rect = vw > 0 ? Rect.new(band.x, band.y, band.w - vw - 1, band.h) : band
       render_overview(screen, ov_rect)
       render_analytics(screen, Rect.new(band.right - vw, band.y, vw, band.h)) if vw > 0
-      return unless panes = body_panes(rect)
-      @strip_start = Chrome.render_tab_strip(screen, strip_rect(rect), PANE_LABELS, pane_index, focused, @strip_start)
-      # Only the active card is drawn; the rest are zero-height (see body_panes).
-      render_scope_card(screen, panes[0], scope_focused) if panes[0].h > 0
-      render_overrides_card(screen, panes[1], ov_focused) if panes[1].h > 0
-      render_env_card(screen, panes[2], env_focused) if panes[2].h > 0
-      render_desc_card(screen, panes[3], desc_focused) if panes[3].h > 0
-      render_settings_card(screen, panes[4], settings_focused) if panes[4].h > 0
+      return unless card = active_card(rect)
+      @strip_start = Chrome.render_tab_strip(screen, strip_rect(rect), PANE_LABELS, pane_index, strip_focused, @strip_start)
+      case @pane
+      when :scope     then render_scope_card(screen, card, focused)
+      when :overrides then render_overrides_card(screen, card, focused)
+      when :env       then render_env_card(screen, card, focused)
+      when :settings  then render_settings_card(screen, card, focused)
+      else                 render_desc_card(screen, card, focused)
+      end
     end
 
     private def render_overview(screen : Screen, rect : Rect) : Nil

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1212,7 +1212,7 @@ module Gori::Tui
       end
       return if click_top_bar(layout.topbar, mx, my)
       return click_menu(layout.menu, mx, my) if layout.menu.contains?(mx, my)
-      return if subtabs_shown? && click_subtab_strip(layout.body, mx, my)
+      return if subtabs_shown? && !subtab_strip_self_drawn? && click_subtab_strip(layout.body, mx, my)
       click_body(layout.body, mx, my) if layout.body.contains?(mx, my)
     end
 
@@ -2182,6 +2182,13 @@ module Gori::Tui
       @tabs[@active_tab]?.try(&.subtab_strip_shown?) || false
     end
 
+    # The active tab renders its OWN chip strip away from the body's top edge (Project puts it
+    # under the OVERVIEW band), so the shell's strip rect describes the wrong rows — skip the
+    # shell's strip click path and let the controller's handle_click claim chips itself.
+    private def subtab_strip_self_drawn? : Bool
+      @tabs[@active_tab]?.try(&.subtab_strip_self_drawn?) || false
+    end
+
     # Whether the strip carve includes its hairline (must match framed_body). Repeater
     # returns false so clicks on the filter/divider rows fall through to the body.
     private def subtab_strip_divider? : Bool
@@ -2274,6 +2281,7 @@ module Gori::Tui
 
     private def subtab_commit : Nil
       case @active_tab
+      when :project   then project_controller.commit # description + a pending network edit
       when :repeater  then repeater_controller.save_current_repeater
       when :fuzzer    then fuzzer_controller.save_current
       when :miner     then miner_controller.save_current

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -247,6 +247,14 @@ module Gori::Tui
       (subtab_labels.try(&.size) || 0) >= 2
     end
 
+    # The controller draws its own chip strip somewhere other than the body's top edge, so the
+    # shell's strip geometry does not describe it and must not hit-test with it — the
+    # controller's handle_click owns chip clicks instead. Project sets this: its strip rides
+    # UNDER the OVERVIEW band, and the shell's strip rect would land on OVERVIEW rows.
+    def subtab_strip_self_drawn? : Bool
+      false
+    end
+
     # Move the active sub-tab by ±1 (strip ←/→), or jump to an absolute index (^1-9).
     def move_subtab(dir : Int32) : Nil
     end


### PR DESCRIPTION
## Problem

#454 gave the Project tab a chip strip but left the five cards where they were: **body panes on the Tab ring**. The strip was a label, not a focus tier — it lit on `:body` focus, `:subtabs` was never entered, and the cards kept crossing into each other with arrows (`←` off the DESCRIPTION start → SCOPE, `↓` off its last line → PROJECT SETTINGS, `↓` off the last scope rule → HOST OVERRIDES). Every other tab with a strip reads the opposite way.

The mismatch bit hardest on DESCRIPTION: clicking its chip routed through `desc_click_to_cursor`, which enters INS unconditionally, so you landed in the editor with `←/→` as caret movement and no sideways way out. `@desc_mode` is sticky too, so one visit to INS made every later visit to that chip open the editor again.

## Change

The cards **are** the sub-tabs now. `ProjectController` exposes `subtab_labels` / `subtab_index` / `move_subtab` / `jump_subtab`, so the shell's own handler does the work it already does for Repeater and Notes:

| gesture | before | after |
|---|---|---|
| `↓`/`↵` from the tab bar | straight into a card | lands on the **strip**, card unfocused |
| `←`/`→` on the strip | n/a (no strip focus) | switch sub-tab |
| `←`/`→` inside a card | crossed to another card | inert (they belong to the tier above) |
| `esc` / `↑` at the top | tab bar | back up to the strip |
| click the DESCRIPTION chip | opened the INS editor | selects the sub-tab, READ mode |
| click **inside** the card | INS | INS (unchanged — matches Notes) |

**DESCRIPTION leads the order.** It is the card you *write* rather than configure, so it is both the most-visited chip and the right landing spot when the tab opens.

## Notes on the parts that were not just moving keys around

- **`settle_subtab` is the invariant, not the click fix.** Every sub-tab change (strip `←/→`, `^1-9`, a chip click) persists the description, applies a pending network edit, drops half-composed inline rows, and returns DESCRIPTION to READ. Fixing only the click path would have left the sticky-`@desc_mode` half of the bug alive on the keyboard.
- **`TabController#subtab_strip_self_drawn?`** (new hook, default `false`). `ProjectView` draws its strip *under* the OVERVIEW band, not at the body's top edge, so the shell's strip rect describes OVERVIEW rows — its click path would have eaten clicks on the project stats. The flag turns that path off for one tab; `handle_click` claims chips itself via the new `ProjectView#strip_chip_at`.
- **`focus_first`/`focus_last` are deliberately no longer overridden.** The shell calls them on every `:body` focus, and re-picking a pane there would override the chip just selected on the strip.
- **`render()` no longer reassigns `@pane`.** The old ENV height gate flipped `:env` → `:overrides` mid-frame; on a sub-tab that is the strip jumping under the user's hand. It was already vestigial (`enabled_panes` returned `PANES` unconditionally), so `ENV_MIN_BODY_H` and `env_pane_enabled?` go with it.
- **`card_rect(rect, pane)` replaces the 5-tuple** every hit-test indexed positionally. That tuple encoded "an inactive pane can't be hit" as `panes[0]==SCOPE`, `panes[3]==DESCRIPTION`; reordering `PANES` would have repointed all of it silently.
- **The inline-row verbs** (hostoverride/env add+edit, env prefix) take body focus first. The space menu reaches them from the strip now, and a row that opens a tier up draws a caret nothing types into.

Dead with the crossings: `scope_at_bottom?`, `ov_at_bottom?`, `set_at_bottom?`, `set_at_cursor_start?`, `desc_at_start?`, `desc_at_bottom?` — both ends of every list simply clamp, and the strip is the single exit.

## Behaviour changes

Intentional, per CONTRIBUTING:

- Project pane order is now DESCRIPTION · SCOPE · HOST OVERRIDES · ENV · PROJECT SETTINGS, and the tab opens on DESCRIPTION instead of SCOPE.
- `Tab` inside the Project body returns to the tab bar instead of cycling cards; `←/→` on the strip is the card cycle now.
- Arrow crossings between Project cards are gone (see the table above).

## Verification

- `crystal spec` — 4658 examples, 0 failures. `spec/tui/project_view_spec.cr` gains coverage for the sub-tab order, `strip_chip_at` boundaries (card / OVERVIEW / empty layout), and "only a click inside its own card enters INS".
- Driven against a real TUI in tmux: every keyboard tier, chip / OVERVIEW / in-card clicks, the space-menu-from-strip → inline-row path, and the INS → other chip → back round trip (lands in READ).
- ameba on the touched files: 18 → 17 findings, none new. `crystal tool format --check` clean on every file in the diff. (`spec/proxy/tls/tunnel_spec.cr` fails the whole-tree format check on `main` already — left untouched.)

## Known gap

`docs/static/images/tui/project.svg` still shows the old chip order. The capture tool regenerates the whole gallery from live seed traffic, so that is left for a separate pass. Prose docs (`proxy.md`, `proxy.ko.md`) and the in-app Help entry are updated here.