### PR TITLE
fix(settings): stop --config re-moding the operator's directory, and 0600 the file itself

### DIFF
--- a/spec/paths_spec.cr
+++ b/spec/paths_spec.cr
@@ -1,0 +1,64 @@
+require "./spec_helper"
+require "file_utils"
+
+private def mode_of(path : String) : Int32
+  (File.info(path).permissions.value & 0o777).to_i
+end
+
+private def with_tmp_dir(&)
+  dir = File.tempname("gori-paths")
+  Dir.mkdir_p(dir)
+  begin
+    yield dir
+  ensure
+    FileUtils.rm_rf(dir)
+  end
+end
+
+# `ensure_dir` locks gori's own tree to 0700 (captured traffic, the CA key, settings.json).
+# The `tighten:` split exists because ONE caller — Settings.save under `gori --config PATH` —
+# passes a directory the operator named rather than one gori owns, and re-moding that is a
+# side effect nobody asked for.
+describe Gori::Paths do
+  describe ".ensure_dir" do
+    it "creates a missing directory at 0700" do
+      with_tmp_dir do |dir|
+        fresh = File.join(dir, "made", "by", "gori")
+        Gori::Paths.ensure_dir(fresh)
+        mode_of(fresh).should eq(0o700)
+      end
+    end
+
+    it "tightens a pre-existing loose directory by default" do
+      with_tmp_dir do |dir|
+        # An 0755 tree from an install that predates DIR_MODE.
+        File.chmod(dir, 0o755)
+        Gori::Paths.ensure_dir(dir)
+        mode_of(dir).should eq(0o700)
+      end
+    end
+
+    # The regression this pair pins: `--config ~/dotfiles/gori.json` used to chmod
+    # ~/dotfiles to 0700, and a relative `--config gori.json` did it to the working
+    # directory.
+    it "leaves a pre-existing directory's mode alone with tighten: false" do
+      with_tmp_dir do |dir|
+        File.chmod(dir, 0o755)
+        Gori::Paths.ensure_dir(dir, tighten: false)
+        mode_of(dir).should eq(0o755)
+      end
+    end
+
+    # Not owning a directory it FINDS does not mean not owning one it MAKES: an intermediate
+    # gori has to create for the config file is still gori's, so it is created locked.
+    it "still creates a missing directory at 0700 with tighten: false" do
+      with_tmp_dir do |dir|
+        File.chmod(dir, 0o755)
+        nested = File.join(dir, "profiles")
+        Gori::Paths.ensure_dir(nested, tighten: false)
+        mode_of(nested).should eq(0o700)
+        mode_of(dir).should eq(0o755) # the parent it merely passed through is untouched
+      end
+    end
+  end
+end

--- a/spec/settings_profile_spec.cr
+++ b/spec/settings_profile_spec.cr
@@ -62,6 +62,45 @@ describe "settings profiles" do
         File.exists?(nested).should be_true
       end
     end
+
+    # settings.json carries `env` token VALUES and saved decoder sessions. Inside GORI_HOME the
+    # 0700 tree covers it, but --config can put it in a shared checkout or a 0755 home, where
+    # the file's OWN mode is the only thing protecting it.
+    it "writes the settings file owner-only" do
+      with_config_home do |dir|
+        target = File.join(dir, "shared", "profile.json")
+        Gori::Settings.path_override = target
+        Gori::Settings.save.should be_true
+        (File.info(target).permissions.value & 0o777).should eq(0o600)
+      end
+    end
+
+    # A `.tmp` left behind by a crashed save keeps its own mode through the rename, so the
+    # create-time perm alone is not enough — the chmod has to run too.
+    it "tightens a leftover temp file rather than inheriting its mode" do
+      with_config_home do |dir|
+        target = File.join(dir, "profile.json")
+        stale = "#{target}.tmp"
+        File.write(stale, "{}")
+        File.chmod(stale, 0o644)
+        Gori::Settings.path_override = target
+        Gori::Settings.save.should be_true
+        (File.info(target).permissions.value & 0o777).should eq(0o600)
+      end
+    end
+
+    # The regression: `--config` into an existing directory used to chmod that directory to
+    # 0700. It is the operator's, not gori's — and with a relative --config it is the cwd.
+    it "does not re-mode a parent directory the operator named" do
+      with_config_home do |dir|
+        parent = File.join(dir, "shared")
+        Dir.mkdir_p(parent)
+        File.chmod(parent, 0o755)
+        Gori::Settings.path_override = File.join(parent, "profile.json")
+        Gori::Settings.save.should be_true
+        (File.info(parent).permissions.value & 0o777).should eq(0o755)
+      end
+    end
   end
 
   describe ".document_keys" do

--- a/src/gori/paths.cr
+++ b/src/gori/paths.cr
@@ -79,12 +79,26 @@ module Gori
     # Race-tolerant `mkdir -p` at 0700 (see DIR_MODE): two gori instances can start
     # simultaneously and both create a fresh dir — one wins the mkdir, the other must
     # not crash.
-    def self.ensure_dir(path : String) : Nil
-      Dir.mkdir_p(path, DIR_MODE)
-      File.chmod(path, DIR_MODE) rescue nil # tighten a pre-0700 dir from an older install
-    rescue File::AlreadyExistsError
-      # created concurrently by another instance — it exists now, fine
-      File.chmod(path, DIR_MODE) rescue nil
+    #
+    # `tighten: false` keeps the 0700 creation but skips the chmod on a directory that was
+    # ALREADY there. The distinction is ownership, not mode: a directory gori makes is gori's
+    # to lock down, one it merely FINDS belongs to whoever made it. Every caller but one names
+    # a path inside GORI_HOME, where the two are the same thing — but `gori --config PATH`
+    # takes an arbitrary path, and its parent can be a shared checkout, a dotfiles repo, or
+    # (for a relative `--config`) the working directory. Silently stripping group/other off
+    # those is a side effect nobody asked for, and it is not what protects the file anyway:
+    # the settings file itself is written 0600 (see Settings.write_private).
+    def self.ensure_dir(path : String, *, tighten : Bool = true) : Nil
+      ours = !Dir.exists?(path) # sampled BEFORE the mkdir: only a dir we create is ours to mode
+      begin
+        Dir.mkdir_p(path, DIR_MODE)
+      rescue File::AlreadyExistsError
+        # created concurrently by another instance — it exists now, at DIR_MODE already
+        ours = false
+      end
+      # 0700 has no group/other bits for any umask to strip, so a dir we created is already
+      # exact; the chmod is for a pre-0700 dir from an older install.
+      File.chmod(path, DIR_MODE) rescue nil if ours || tighten
     end
   end
 end

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -143,7 +143,8 @@ module Gori
     private def self.load_root(raw : String) : JSON::Any?
       JSON.parse(raw)
     rescue
-      (File.write("#{path}.corrupt", raw) rescue nil) if raw.presence
+      # 0600 like the file it is a copy of — it carries the same secrets verbatim.
+      (write_private("#{path}.corrupt", raw) rescue nil) if raw.presence
       nil
     end
 
@@ -170,8 +171,10 @@ module Gori
       Paths.ensure_dirs
       # With --config / $GORI_CONFIG the file can live outside GORI_HOME, whose directory
       # ensure_dirs above does not create. The temp+rename below would fail on a missing
-      # parent, so make it first (0700: the file can carry env values and decoder sessions).
-      Paths.ensure_dir(File.dirname(path))
+      # parent, so make it first — but `tighten: false`, because that parent is a directory
+      # the OPERATOR named and gori does not own (see Paths.ensure_dir). What actually
+      # protects the env values and decoder sessions is the file's own 0600, below.
+      Paths.ensure_dir(File.dirname(path), tighten: false)
       # Atomic write: a torn File.write (crash / two instances / disk-full) would leave a
       # half-written settings.json that load()'s blanket rescue silently resets to factory
       # defaults — losing theme, hotkeys, hostname overrides, tab prefs, decoder sessions.
@@ -185,13 +188,34 @@ module Gori
       # Basing on `mine` keeps "did I change this section?" honest, so an unchanged section
       # always yields to disk on every subsequent save.
       mine = serialize
-      File.write(tmp, merge_with_disk(mine))
+      # Written 0600, and renamed rather than copied, so the FINAL file carries that mode too
+      # (rename moves the inode, permissions and all).
+      write_private(tmp, merge_with_disk(mine))
       File.rename(tmp, path)
       @@loaded_raw = mine
       true
     rescue
       File.delete?("#{path}.tmp") rescue nil
       false
+    end
+
+    # Write a settings document owner-only. Inside GORI_HOME the 0700 tree already covers it,
+    # but `--config` can put this file anywhere — a shared checkout, /tmp, a home directory at
+    # 0755 — and it carries `env` token VALUES and saved decoder sessions (SECRET_SECTIONS
+    # below names both). `CLI.write_export` already does exactly this for the EXPORTED copy;
+    # the live file holds the same secrets and was the one still landing at the umask default.
+    #
+    # The mode is set at CREATE time so the bytes are never on disk at 0644 even briefly, and
+    # chmod'd as well because `File.open`'s perm applies only to a file it actually creates —
+    # a `.tmp` left by a crashed save would otherwise keep its old mode and carry it through
+    # the rename. The chmod is best-effort: a filesystem that cannot represent 0600 (a mounted
+    # share) must not turn every settings save into a failure.
+    private def self.write_private(path : String, doc : String) : Nil
+      perm = File::Permissions.new(0o600)
+      File.open(path, "w", perm: perm) do |f|
+        File.chmod(path, perm) rescue nil
+        f.print(doc)
+      end
     end
 
     # 3-way merge (base = what we loaded, mine = `current` serialization, theirs = the


### PR DESCRIPTION
Found while reviewing the v0.2.0 diff. `--config PATH` is new in this release, and it is the one caller that hands `Paths.ensure_dir` a path gori does not own.

## What was wrong

`Settings.save` called `Paths.ensure_dir(File.dirname(path))`, and `ensure_dir` chmods `0700` unconditionally. That is right for gori's own tree — captured traffic, the CA key — but the config path is arbitrary:

```
$ stat -f '%Sp' ~/shared          # drwxr-xr-x
$ gori settings --config ~/shared/gori.json
$ stat -f '%Sp' ~/shared          # drwx------   ← not gori's directory to re-mode
```

A relative `--config gori.json` resolves `dirname` to `.`, so it does it to the working directory.

The same code protected the wrong thing. Inside `GORI_HOME` the 0700 tree is what keeps `settings.json` private; outside it nothing did — the file landed at the umask default:

```
$ stat -f '%Sp' ~/shared/gori.json   # -rw-r--r--
```

That file carries `env` token **values** and saved decoder sessions — the two sections `SECRET_SECTIONS` already names. `CLI.write_export` got this right for the exported copy in #439; the live file was still missing it.

## The fix

- `Paths.ensure_dir` gains `tighten:`. A directory gori **creates** is still made 0700 — that one is gori's. A directory it merely **finds** is never chmod'd. Only `Settings.save` passes `tighten: false`; every other caller names a path inside `GORI_HOME` and is unchanged.
- `settings.json` is written 0600 at create time (so the bytes are never on disk at 0644 even briefly) and chmod'd as well, because `File.open`'s perm applies only to a file it actually creates — a `.tmp` left by a crashed save would otherwise carry its old mode through the rename. The chmod is best-effort so a filesystem that cannot represent 0600 does not turn every save into a failure.
- The `.corrupt` recovery copy goes the same way. It is a verbatim copy of the same secrets and was also landing at 0644 (pre-existing, but the identical defect one function away).

## Verification

`crystal spec` → **4680 examples, 0 failures** (4673 before; +7 new).

The three `settings_profile_spec` cases were control-run against `a7f11337` in a detached worktree and all three fail there — 0644 where 0600 is expected, 0700 where 0755 is expected — so they pin the regression rather than describing the new code. The `paths_spec` cases cannot compile pre-fix (the parameter does not exist yet).

End-to-end against a freshly built binary:

| | before | after |
|---|---|---|
| operator's dir (`--config ~/shared/…`) | `drwx------` | `drwxr-xr-x` |
| cwd (relative `--config`) | `drwx------` | `drwxr-xr-x` |
| config file | `-rw-r--r--` | `-rw-------` |
| `GORI_HOME` dir / `settings.json` | `drwx------` / — | `drwx------` / `-rw-------` |

Ameba on the touched files reports only pre-existing findings, all on lines this PR does not touch.

## Note

Tightening `settings.json` to 0600 also applies inside `GORI_HOME`, where the 0700 directory already covered it. It is a strictly-tightening change and matches how the CA key and the project DBs are already handled, but it is a behaviour change on the default path, not only the `--config` one.