### PR TITLE
fix(tls): stop --ca-dir re-moding the operator's directory, and 0600 the CA key from creation

### DIFF
--- a/spec/proxy/tls/cert_authority_spec.cr
+++ b/spec/proxy/tls/cert_authority_spec.cr
@@ -12,7 +12,94 @@ private def with_ca_dir(&)
   end
 end
 
+private def mode_of(path : String) : Int32
+  (File.info(path).permissions.value & 0o777).to_i
+end
+
 describe Gori::Proxy::Tls::CertAuthority do
+  # `--ca-dir` is an operator-named path, so the CA dir gets the same ownership rule as
+  # `--config` (#466): 0700 for one gori CREATES, never a chmod on one it FINDS. What keeps
+  # the secret secret is the key file's own mode, pinned by the group below.
+  describe "the CA directory it was pointed at" do
+    it "creates a missing one at 0700" do
+      with_ca_dir do |dir|
+        Gori::Proxy::Tls::CertAuthority.load_or_create(dir)
+        mode_of(dir).should eq(0o700)
+      end
+    end
+
+    it "leaves a pre-existing one's mode alone" do
+      with_ca_dir do |dir|
+        Dir.mkdir_p(dir)
+        File.chmod(dir, 0o755) # a shared checkout / dotfiles dir the operator named
+        Gori::Proxy::Tls::CertAuthority.load_or_create(dir)
+        mode_of(dir).should eq(0o755)
+      end
+    end
+
+    it "leaves it alone when regenerate! re-establishes it too" do
+      with_ca_dir do |dir|
+        Dir.mkdir_p(dir)
+        File.chmod(dir, 0o755)
+        ca = Gori::Proxy::Tls::CertAuthority.load_or_create(dir)
+        ca.regenerate!
+        mode_of(dir).should eq(0o755)
+        mode_of(File.join(dir, "root.key.pem")).should eq(0o600) # the file still is protected
+      end
+    end
+  end
+
+  describe "the root private key's mode" do
+    it "is 0600 even when the CA dir is world-traversable" do
+      with_ca_dir do |dir|
+        Dir.mkdir_p(dir)
+        File.chmod(dir, 0o755)
+        Gori::Proxy::Tls::CertAuthority.load_or_create(dir)
+        mode_of(File.join(dir, "root.key.pem")).should eq(0o600)
+        mode_of(File.join(dir, "root.crt.pem")).should_not eq(0o600) # the cert is public
+      end
+    end
+
+    # The write is the only moment the mode was ever set, so a key that got loose any other
+    # way — a pre-0600 gori, a restore that dropped the mode, a crash between fopen and the
+    # old post-write chmod — stayed loose for good. Every load re-asserts it now.
+    it "is re-tightened on load when it was left readable" do
+      with_ca_dir do |dir|
+        Gori::Proxy::Tls::CertAuthority.load_or_create(dir)
+        key = File.join(dir, "root.key.pem")
+        File.chmod(key, 0o644)
+        Gori::Proxy::Tls::CertAuthority.load_or_create(dir) # a plain reload, no minting
+        mode_of(key).should eq(0o600)
+      end
+    end
+
+    # fopen() inside BIO_new_file creates at the umask default, so the mode has to be set
+    # BEFORE the key bytes go in — never chmod'd after.
+    it "is 0600 from creation, not from a chmod after the bytes land" do
+      with_ca_dir do |dir|
+        Dir.mkdir_p(dir)
+        path = File.join(dir, "written.key.pem")
+        Gori::Proxy::Tls::KeyPair.generate_ec.write_pem(path)
+        mode_of(path).should eq(0o600)
+        File.read(path).should contain("PRIVATE KEY") # and it really wrote the key
+      end
+    end
+
+    # `perm:` applies only to a file the open CREATES: a `.tmp` left by a crashed write would
+    # otherwise keep 0644 and carry it through install!'s rename onto the live key path.
+    it "tightens a leftover temp file rather than inheriting its mode" do
+      with_ca_dir do |dir|
+        Dir.mkdir_p(dir)
+        stale = File.join(dir, "root.key.pem.tmp")
+        File.write(stale, "leftover")
+        File.chmod(stale, 0o644)
+        ca = Gori::Proxy::Tls::CertAuthority.load_or_create(dir)
+        ca.regenerate! # stages through exactly that path, then renames
+        mode_of(File.join(dir, "root.key.pem")).should eq(0o600)
+      end
+    end
+  end
+
   it "generates and persists a root CA on first run" do
     with_ca_dir do |dir|
       Gori::Proxy::Tls::CertAuthority.load_or_create(dir)

--- a/src/gori/proxy/tls/cert_authority.cr
+++ b/src/gori/proxy/tls/cert_authority.cr
@@ -32,18 +32,29 @@ module Gori::Proxy::Tls
       @mutex = Mutex.new
     end
 
+    # `tighten: false` because `--ca-dir` is an OPERATOR-named path (four entry points: the
+    # TUI, `gori ca`, `ca regenerate`, `ca import`), exactly like `--config` in #466 — gori
+    # does not own a directory it merely FINDS, and a relative `--ca-dir certs` would re-mode
+    # a checked-out directory, a bare `.` the working directory. A dir gori CREATES is still
+    # made 0700 (see Paths.ensure_dir), and what actually protects the secret either way is
+    # the key file's own 0600 below: the cert beside it is public by design.
     def self.load_or_create(dir : String, common_name : String = DEFAULT_CN) : CertAuthority
-      Gori::Paths.ensure_dir(dir) # race-tolerant (two instances may start at once)
+      Gori::Paths.ensure_dir(dir, tighten: false) # race-tolerant (two instances may start at once)
       cert_path = File.join(dir, CA_CERT_FILE)
       key_path = File.join(dir, CA_KEY_FILE)
 
       if File.exists?(cert_path) && File.exists?(key_path)
+        # Re-assert the mode on EVERY load, not just at mint time: a key can arrive loose
+        # from a pre-0600 gori, a `cp`/restore that dropped the mode, or a crash mid-write —
+        # and nothing else would ever tighten it again. Mirrors Store.harden_permissions
+        # re-locking the db on every open. Best-effort: a filesystem that cannot represent
+        # 0600 (a mounted share) must not make gori refuse to start.
+        File.chmod(key_path, 0o600) rescue nil
         new(Cert.read_pem(cert_path), KeyPair.read_pem(key_path), cert_path)
       else
         cert, key = CertBuilder.build_root(common_name)
         cert.write_pem(cert_path)
-        key.write_pem(key_path)
-        File.chmod(key_path, 0o600) # the CA private key is a machine secret
+        key.write_pem(key_path) # 0600 at CREATE time — see KeyPair#write_pem
         new(cert, key, cert_path)
       end
     end
@@ -141,14 +152,17 @@ module Gori::Proxy::Tls
     # exist, so the on-disk cert/key never disagree past the gap between renames).
     private def install!(cert : Cert, key : KeyPair) : Nil
       dir = File.dirname(@ca_cert_path)
-      Gori::Paths.ensure_dir(dir) # parity with load_or_create: the dir may have been removed at runtime
+      # Full parity with load_or_create, `tighten:` included: the dir may have been removed
+      # at runtime, and re-creating it must not re-mode an operator's --ca-dir either.
+      Gori::Paths.ensure_dir(dir, tighten: false)
       key_path = File.join(dir, CA_KEY_FILE)
       cert_tmp = "#{@ca_cert_path}.tmp"
       key_tmp = "#{key_path}.tmp"
       begin
         cert.write_pem(cert_tmp)
+        # 0600 before any key bytes reach the temp (KeyPair#write_pem); rename moves the
+        # inode, mode and all, so the installed key is never briefly readable.
         key.write_pem(key_tmp)
-        File.chmod(key_tmp, 0o600) # the CA private key is a machine secret
         File.rename(key_tmp, key_path)
         File.rename(cert_tmp, @ca_cert_path)
       rescue ex

--- a/src/gori/proxy/tls/key_pair.cr
+++ b/src/gori/proxy/tls/key_pair.cr
@@ -31,7 +31,24 @@ module Gori::Proxy::Tls
       new(pkey)
     end
 
+    # Owner-only from the first byte. `BIO_new_file` goes through fopen(), which creates at
+    # the umask default (0644 on a stock box) — so chmod'ing AFTER the write leaves both a
+    # window where a machine secret is world-readable and, if the process dies in between, a
+    # key that STAYS that way: nothing re-modes a file that already exists (CertAuthority's
+    # create-time chmod only ever ran on the branch that mints the key). Set the mode first
+    # instead, at the one place every private key is written.
+    #
+    # Truncating here is not a new risk — the "w" BIO truncates anyway — and a caller
+    # replacing a LIVE key stages to a temp file and renames (see CertAuthority#install!),
+    # so a failed write never lands on the real key path.
     def write_pem(path : String) : Nil
+      perm = File::Permissions.new(0o600)
+      # `perm:` applies only to a file File.open CREATES, so chmod as well: a `.tmp` left by
+      # an earlier crashed write would otherwise keep its old mode and carry it through the
+      # rename. Unrescued, unlike the load-path re-assert — a key we are minting right now
+      # and cannot protect is not a key to hand out.
+      File.open(path, "w", perm: perm) { }
+      File.chmod(path, perm)
       bio = LibCrypto.bio_new_file(path, "w")
       raise Gori::Error.new("BIO_new_file(#{path}) failed") if bio.null?
       begin


### PR DESCRIPTION
Follow-up audit of #466: I swept the tree for the same two shapes — gori chmod'ing a path it does not own, and a secret-bearing file that leaves the 0700 tree at the umask default. `--ca-dir` is the same bug one directory over.

## 1. `--ca-dir` re-modes a directory gori merely found

`CertAuthority.load_or_create` passes an operator-named path to `Paths.ensure_dir`, which chmods 0700. Four entry points reach it: the TUI, `gori ca`, `ca regenerate`, `ca import`. Verified against a v0.1.4 binary:

```
drwxr-xr-x  certs/        ← before
$ gori ca --ca-dir certs
drwx------  certs/        ← after
```

With a relative `--ca-dir` the target is a checked-out directory; with `.`, the working directory.

## 2. The CA private key's 0600 was set once, and after the bytes landed

`BIO_new_file` goes through fopen(), so `key.write_pem` created the key at the umask default (0644) and a chmod tightened it a syscall later. That leaves a window — and, worse, nothing ever re-checks a key that exists: the load path never chmod'd. A key made loose by a pre-0600 gori, a restore that dropped the mode, or a crash inside that gap stayed loose forever:

```
$ chmod 644 catest/mine/root.key.pem && gori ca --ca-dir catest/mine
after re-run:  -rw-r--r--  root.key.pem     ← unchanged, every restart
```

## The fix

- `ensure_dir(..., tighten: false)` at both CA sites — a dir gori CREATES is still 0700, one it FINDS is left alone.
- `KeyPair#write_pem` creates the file 0600 *before* any key bytes go in (the chokepoint every private-key write passes through), and chmods too — `perm:` applies only to a file the open creates, so a `.tmp` from a crashed write would otherwise carry 0644 through `install!`'s rename.
- `load_or_create` re-asserts 0600 on every load, best-effort, the way `Store.harden_permissions` already re-locks the db on every open.

Trade accepted: a legacy 0755 ca dir is no longer tightened at startup. The key's own 0600 is what protects it; the cert beside it is public by design.

## Verification

- 6 new specs in `spec/proxy/tls/cert_authority_spec.cr` (dir ownership × create/regenerate, key mode on create/reload/leftover-temp).
- Control-run against the pre-fix source: 4 of the 6 fail, the two that don't are regression pins for behaviour this keeps.
- Full suite green (4687 examples, 0 failures); `crystal build --no-codegen src/main.cr` clean.

## Not in this PR (found in the same sweep)

- Notes/Issues exports write captured evidence at the umask default (`issues_controller.cr:479`, `notes_controller.cr:394`, `cli/run/issues.cr:64`) — deliberately left; needs a product call on whether an evidence export follows `CLI.write_export`'s "secrets → 0600" rule.
- `capture_lock.cr:59` / `capture_status.cr:19` `Dir.mkdir_p` at umask instead of `Paths::DIR_MODE` — currently unreachable (every `--db` entry point but the TUI validates the parent; the TUI fails at `Store.open` first), so it is a latent inconsistency plus a missing `--db` parent check on `gori --db`.