### PR TITLE
docs: document the features missing from the reference and guides

### DIFF
--- a/docs/content/guide/decoder.ko.md
+++ b/docs/content/guide/decoder.ko.md
@@ -46,11 +46,12 @@ gzip-decompress | json-unescape
 | 범주 | 예시 |
 |----------|----------|
 | **Encoding** | `base64-encode` / `base64-decode`, `base64url-encode`, `url-encode` / `url-decode`, `hex-encode` / `hex-decode`, `base32`, `ascii85`, `base58` |
-| **Compression** | `gzip-compress` / `gzip-decompress`, `zlib-compress` / `zlib-decompress` |
+| **Number bases** | `decimal-encode` / `decimal-decode`, `binary-encode` / `binary-decode`, `octal-encode` / `octal-decode` |
+| **Compression** | `gzip-compress` / `gzip-decompress`, `zlib-compress` / `zlib-decompress`, `deflate-raw` / `inflate-raw` (헤더 없는 RFC 1951) |
 | **Token** | `jwt-decode` (헤더 + 페이로드; 서명은 표시되지만 검증하지 않음) |
-| **Hash** | `md5`, `sha1`, `sha256`, `sha512` |
+| **Hash** | `md5`, `sha1`, `sha224`, `sha256`, `sha384`, `sha512`, `crc32` |
 | **Escape** | `html-escape` / `html-unescape`, `json-escape` / `json-unescape`, `unicode-escape` / `unicode-unescape` |
-| **Text** | `rot13`, `upper`, `lower`, `reverse` |
+| **Text** | `rot13`, `rot47`, `upper`, `lower`, `reverse` |
 
 OUTPUT은 바이너리 결과를 위해 표시 모드(text → hex → base64)를 순환할 수 있습니다. READ 모드에서 `y`로 복사하거나 space 메뉴를 사용하세요.
 

--- a/docs/content/guide/decoder.md
+++ b/docs/content/guide/decoder.md
@@ -46,11 +46,12 @@ Save a chain under a name (**Save chain by name** from the space menu) and reloa
 | Category | Examples |
 |----------|----------|
 | **Encoding** | `base64-encode` / `base64-decode`, `base64url-encode`, `url-encode` / `url-decode`, `hex-encode` / `hex-decode`, `base32`, `ascii85`, `base58` |
-| **Compression** | `gzip-compress` / `gzip-decompress`, `zlib-compress` / `zlib-decompress` |
+| **Number bases** | `decimal-encode` / `decimal-decode`, `binary-encode` / `binary-decode`, `octal-encode` / `octal-decode` |
+| **Compression** | `gzip-compress` / `gzip-decompress`, `zlib-compress` / `zlib-decompress`, `deflate-raw` / `inflate-raw` (headerless, RFC 1951) |
 | **Token** | `jwt-decode` (header + payload; signature shown, not verified) |
-| **Hash** | `md5`, `sha1`, `sha256`, `sha512` |
+| **Hash** | `md5`, `sha1`, `sha224`, `sha256`, `sha384`, `sha512`, `crc32` |
 | **Escape** | `html-escape` / `html-unescape`, `json-escape` / `json-unescape`, `unicode-escape` / `unicode-unescape` |
-| **Text** | `rot13`, `upper`, `lower`, `reverse` |
+| **Text** | `rot13`, `rot47`, `upper`, `lower`, `reverse` |
 
 OUTPUT can cycle display modes (text → hex → base64) for binary results. Copy with `y` in READ mode, or use the space menu.
 

--- a/docs/content/guide/mcp.ko.md
+++ b/docs/content/guide/mcp.ko.md
@@ -87,13 +87,21 @@ Codex와 Grok은 JSON이 아니라 `[mcp_servers.gori]` 테이블이 있는 TOML
 | `list_events` | 작업 수명주기와 에이전트 활동을 추가 전용 피드로 전방 커서 조회. 플로우가 여전히 전체 스트림이며, 이 피드는 플로우 행을 중복하지 않음 |
 | `get_flow` | 한 플로우의 전체 요청 + 응답 |
 | `get_response_body_chunk` | 인라인 64 KiB 상한을 넘는 디코드(또는 원시) 플로우/Repeater 응답을 페이지 단위로 조회 |
-| `list_sitemap` | 고유 엔드포인트(host, method, path) |
+| `list_sitemap` / `list_sitemap_tags` | 고유 엔드포인트(host, method, path)와 거기에 달린 태그 |
 | `list_issues` / `get_issue` | 트리아지된 이슈 읽기 |
+| `probe_scan` | 캡처된 플로우와 Repeater 탭 재스캔. `active:true`가 아니면 패시브(요청 0건)이고, 액티브는 쓰기 권한이 필요하며 스코프 게이트를 거침 |
+| `probe_issues` | Probe 탭에 저장된 발견 항목을 트리아지 상태로 조회(기본은 open만) |
+| `list_probe_rules` | 모든 스캔 규칙(패시브, 액티브, 커스텀)과 활성화 여부, 프로젝트의 스캔 모드 |
 | `list_scope` | 현재 스코프 include/exclude 규칙 |
+| `list_links` | 이슈나 노트에서 플로우, Repeater 세션, 잡으로 이어지는 증거 포인터 |
+| `compare_flows` | 두 플로우의 요청 또는 응답 줄 단위 diff |
 | `intercept_list` / `intercept_get` | 라이브 인터셉트 큐와 홀드된 항목 하나의 전체 내용 조회 |
 | `list_projects` | 이 호스트의 모든 gori 프로젝트 |
 | `list_notes` / `get_note` | 프로젝트 노트 읽기 |
 | `list_rules` | 프로젝트의 Match & Replace 규칙을 적용 순서로 나열 |
+| `list_env` | `$KEY` 치환에 쓰이는 프로젝트 env 토큰(값은 가려짐) |
+| `list_host_overrides` | 이 프로젝트에 적용 중인 호스트 → IP 다이얼 맵 |
+| `list_oast_providers` | 설정된 OAST 프로바이더와 현재 활성 프로바이더 |
 | `decode` | `input`에 대해 인코드/디코드/해시/압축 체인을 실행(순수 변환; 네트워크나 상태 없음) |
 | `jwt_decode` / `jwt_encode` / `jwt_attacks` | JWT 디코드, 재서명, 공격 페이로드 생성(순수 계산; `--read-only`에서도 사용 가능) |
 | `sequence_analyze` | 붙여넣은 토큰 목록의 무작위성 / 예측 가능성 평가(순수) |
@@ -112,11 +120,24 @@ Codex와 Grok은 JSON이 아니라 `[mcp_servers.gori]` 테이블이 있는 TOML
 | `send_request` | HTTP 요청 전송 / 재전송(액티브; 기본적으로 History에 기록, `$KEY` 환경 토큰을 확장, 명시적으로 요청하지 않는 한 민감한 응답 헤더 값을 가림) |
 | `send_websocket` | 저장된 WebSocket Repeater 세션을 실행하고 응답을 수집 |
 | `create_repeater` / `update_repeater` / `delete_repeater` | Repeater 세션 관리 |
-| `create_issue` / `update_issue` | 이슈 기록 및 갱신 |
+| `minimize_repeater` | Repeater 요청을 같은 응답이 재현되는 최소 형태로 줄임 |
+| `create_issue` / `update_issue` / `delete_issue` | 이슈 기록, 갱신, 삭제 |
+| `add_link` / `remove_link` | 이슈나 노트의 증거 포인터 연결 / 해제 |
 | `create_note` / `update_note` / `delete_note` | 프로젝트 노트 관리 |
 | `create_rule` / `update_rule` / `set_rule_enabled` / `delete_rule` | Match & Replace 규칙 생성, 편집, 토글, 삭제(이동 중인 요청/응답 헤드 또는 본문 재작성) |
 | `preview_rule` | 규칙을 만들기 전에, 저장된 플로우 중 몇 개가 바뀌었을지 추정 |
+| `import_flows` | HAR / URL 목록 / OpenAPI / Postman / Insomnia / Burp 파일을 History로 일괄 임포트 |
+| `delete_flow` / `clear_history` | 플로우 하나 삭제, 또는 캡처된 History 전체 삭제 |
+| `set_sitemap_tag` | Sitemap 경로에 자유 형식 메모 고정 |
 | `create_project` / `switch_project` / `delete_project` | 프로젝트 생성 또는 다시 열기, 이 서버를 다른 프로젝트로 전환, 프로젝트 삭제. 삭제는 2단계로, `dry_run` 후 확인 토큰 필요 |
+| `add_scope_rule` / `update_scope_rule` / `delete_scope_rule` / `set_scope_enabled` | 프로젝트의 include / exclude 규칙 편집과 스코프 렌즈 토글 |
+| `set_sandbox` | 하드 컨테인먼트. 켜면 프록시가 스코프가 허용한 것만 전달하고 나머지는 차단 |
+| `set_env_var` / `delete_env_var` | `$KEY` 치환이 읽는 프로젝트 env 토큰 관리 |
+| `add_host_override` / `update_host_override` / `delete_host_override` | 호스트 → IP 다이얼 맵 관리(요청은 그대로 두고 접속 IP만 변경) |
+| `probe_promote` / `probe_dismiss` / `probe_delete` | Probe 발견 항목을 Issues로 승격, 기각, 또는 삭제 |
+| `set_probe_mode` | 스캔 모드 설정: `off`, `passive`, `active`, `aggressive`(허가된 대상 전용) |
+| `create_probe_rule` / `update_probe_rule` / `delete_probe_rule` / `set_probe_rule_enabled` | 커스텀 매치 규칙 관리와 스캔 규칙 활성화 / 비활성화 |
+| `create_oast_provider` / `update_oast_provider` / `delete_oast_provider` / `set_oast_provider_enabled` | `oast_start`가 사용할 OAST 프로바이더 관리 |
 | `fuzz_start` / `fuzz_status` / `fuzz_results` / `fuzz_stop` | Fuzzer 구동 |
 | `mine_start` / `mine_status` / `mine_results` / `mine_stop` | Param Miner 구동 |
 | `sequence_start` / `sequence_status` / `sequence_results` / `sequence_stop` | 라이브 리플레이로 토큰을 수집해 평가(결과는 리포트만 반환, 토큰은 반환하지 않음) |

--- a/docs/content/guide/mcp.md
+++ b/docs/content/guide/mcp.md
@@ -87,13 +87,21 @@ If a client starts MCP outside your repository directory, the server starts unbo
 | `list_events` | Tail an append-only feed of job lifecycle and agent activity, by forward cursor. Flows stay the firehose; this never duplicates flow rows |
 | `get_flow` | Full request + response for one flow |
 | `get_response_body_chunk` | Page through decoded (or raw) flow/Repeater responses beyond the inline 64 KiB cap |
-| `list_sitemap` | Distinct endpoints (host, method, path) |
+| `list_sitemap` / `list_sitemap_tags` | Distinct endpoints (host, method, path), and the tags placed on them |
 | `list_issues` / `get_issue` | Read triaged issues |
+| `probe_scan` | Rescan captured flows and Repeater tabs. Passive (zero requests) unless `active:true`, which needs write access and is scope-gated |
+| `probe_issues` | The Probe tab's persisted findings, as triage state (open by default) |
+| `list_probe_rules` | Every scan rule (passive, active, custom), which are enabled, and the project's scan mode |
 | `list_scope` | Current scope include/exclude rules |
+| `list_links` | Evidence pointers from an issue or note to a flow, Repeater session, or job |
+| `compare_flows` | Line diff of two flows' request or response |
 | `intercept_list` / `intercept_get` | Inspect the live intercept queue and one held item in full |
 | `list_projects` | Every gori project on this host |
 | `list_notes` / `get_note` | Read project notes |
 | `list_rules` | List the project's Match & Replace rules in apply order |
+| `list_env` | Project env tokens available to `$KEY` substitution (values redacted) |
+| `list_host_overrides` | The host to IP dial map in force for this project |
+| `list_oast_providers` | Configured OAST providers and which one is active |
 | `decode` | Run an encode/decode/hash/compress chain over `input` (pure transform; no network or state) |
 | `jwt_decode` / `jwt_encode` / `jwt_attacks` | Decode, re-sign, or generate attack payloads for a JWT (pure compute; available even under `--read-only`) |
 | `sequence_analyze` | Grade a pasted token list for randomness / predictability (pure) |
@@ -112,11 +120,24 @@ If a client starts MCP outside your repository directory, the server starts unbo
 | `send_request` | Send / resend an HTTP request (active; records History by default, expands `$KEY` env tokens, and redacts sensitive response-header values unless explicitly requested) |
 | `send_websocket` | Execute a saved WebSocket Repeater session and collect the replies |
 | `create_repeater` / `update_repeater` / `delete_repeater` | Manage Repeater sessions |
-| `create_issue` / `update_issue` | Record and update issues |
+| `minimize_repeater` | Shrink a Repeater request to the smallest form that still reproduces the response |
+| `create_issue` / `update_issue` / `delete_issue` | Record, update, and remove issues |
+| `add_link` / `remove_link` | Attach or detach an issue's / note's evidence pointer |
 | `create_note` / `update_note` / `delete_note` | Manage project notes |
 | `create_rule` / `update_rule` / `set_rule_enabled` / `delete_rule` | Create, edit, toggle, and delete Match & Replace rules (rewrites on in-flight request/response head or body) |
 | `preview_rule` | Estimate how many stored flows a rule would change, before creating it |
+| `import_flows` | Bulk-import a HAR / URL list / OpenAPI / Postman / Insomnia / Burp file into History |
+| `delete_flow` / `clear_history` | Remove one flow, or wipe captured History |
+| `set_sitemap_tag` | Pin a free-text memo onto a sitemap path |
 | `create_project` / `switch_project` / `delete_project` | Create or reopen a project, point this server at another one, or delete one. Deletion is two-step: a `dry_run` first, then a confirmation token |
+| `add_scope_rule` / `update_scope_rule` / `delete_scope_rule` / `set_scope_enabled` | Edit the project's include / exclude rules and toggle the scope lens |
+| `set_sandbox` | Hard containment: when on, the proxy forwards only what scope allows and blocks the rest |
+| `set_env_var` / `delete_env_var` | Manage the project env tokens `$KEY` substitution reads |
+| `add_host_override` / `update_host_override` / `delete_host_override` | Manage the host to IP dial map (changes only the connect IP, never the request) |
+| `probe_promote` / `probe_dismiss` / `probe_delete` | Triage a Probe finding into Issues, dismiss it, or remove it |
+| `set_probe_mode` | Set the scan mode: `off`, `passive`, `active`, or `aggressive` (authorized targets only) |
+| `create_probe_rule` / `update_probe_rule` / `delete_probe_rule` / `set_probe_rule_enabled` | Manage custom match rules and arm or disarm any scan rule |
+| `create_oast_provider` / `update_oast_provider` / `delete_oast_provider` / `set_oast_provider_enabled` | Manage the OAST providers `oast_start` can listen on |
 | `fuzz_start` / `fuzz_status` / `fuzz_results` / `fuzz_stop` | Drive the fuzzer |
 | `mine_start` / `mine_status` / `mine_results` / `mine_stop` | Drive the param miner |
 | `sequence_start` / `sequence_status` / `sequence_results` / `sequence_stop` | Collect tokens by live replay and grade them (results return the report, never the tokens) |

--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -55,6 +55,8 @@ gori run <subcommand> [options]
 | `capture` | 프록시를 실행하고 캡처한 플로우를 STDOUT으로 스트리밍 |
 | `history` (`ls`) | 캡처한 플로우 목록 / 쿼리 |
 | `show <flow-id>` | 플로우 하나의 요청과 응답 출력 |
+| `compare <id-a> <id-b>` | 두 플로우의 요청 또는 응답 diff |
+| `intercept` | 캡처 중인 TUI의 라이브 인터셉트 큐 조회 및 조작 |
 | `repeater <flow-id>` · `list` · `create` | 캡처한 플로우 재전송, 또는 Repeater 워크벤치 세션 목록 / 생성 |
 | `fuzz [<flow-id>]` | Intruder 스타일 퍼저 |
 | `mine [<flow-id>]` | 숨은 파라미터 탐색 |
@@ -68,6 +70,7 @@ gori run <subcommand> [options]
 | `convert <chain> [input]` | Decoder 인코드 / 디코드 / 해시 체인 실행 |
 | `notes [<n>]` · `create` · `delete` | 프로젝트 노트 읽기, 작성, 삭제 |
 | `issues` · `create` · `update` | 이슈 목록 / 내보내기, 또는 이슈 작성 |
+| `links` · `add` · `delete` | 이슈나 노트에서 플로우, Repeater 세션, 잡으로 이어지는 증거 포인터 |
 | `rewriter` · `add` · `rm` · `enable` · `disable` · `preview` | Match & Replace 규칙 관리 |
 | `project [list]` | 알려진 프로젝트 목록 |
 | `project create <name>` | 이름으로 프로젝트 생성 (같은 이름이면 다시 열기) |
@@ -75,6 +78,7 @@ gori run <subcommand> [options]
 | `project scope` | 스코프 규칙 목록 / 추가 / 삭제 / 활성화 / 비활성화 |
 | `project sandbox` | 하드 컨테인먼트 샌드박스 게이트 조회 / 설정 (`status`, `on`, `off`) |
 | `project env` | 프로젝트 env 변수 목록 / 설정 / 삭제 (`$KEY` 치환) |
+| `project host-override` | 프로젝트 호스트 → IP 다이얼 오버라이드 목록 / 추가 / 수정 / 삭제 |
 
 읽기 서브커맨드에 공통인 플래그: `--project=NAME`, `--db=PATH`, `--format=FMT` (보통 `text` 또는 `json`).
 
@@ -113,6 +117,45 @@ gori run show <flow-id> --format raw
 ```
 
 `--format`은 `text`, `json`, 또는 `raw`(정확한 바이트)입니다. `--request-only` / `--response-only`로 출력을 제한합니다. 디코드된 SAML/JWT/GraphQL/파라미터, WebSocket 메시지, SSE 이벤트가 있으면 함께 포함됩니다.
+
+### run compare {#run-compare}
+
+두 플로우의 줄 단위 diff이며, [Comparer 탭](/ko/guide/scanning/)과 동일한 결과를 냅니다.
+
+```bash
+gori run compare 41 42 --pane response --changes-only
+```
+
+| Option | Description |
+|--------|-------------|
+| `--pane=PANE` | 비교 대상: `request` 또는 `response` (기본값) |
+| `--changes-only` | 변경되지 않은 문맥은 빼고 추가 / 삭제된 줄만 출력 |
+| `--format=FMT` | `text` (기본값) 또는 `json` |
+
+### run intercept {#run-intercept}
+
+캡처 락을 쥔 TUI의 라이브 인터셉트 큐를 조작합니다. 인터셉트는 TUI 전용입니다. 헤드리스 `gori run capture`는 메시지를 붙잡지 않으며, 여기 서브커맨드는 상태를 게시하는 캡처 인스턴스가 없으면 모두 거부합니다.
+
+```bash
+gori run intercept                              # 붙잡힌 항목 + 인터셉트 상태
+gori run intercept get 3 --format json
+gori run intercept forward 3
+gori run intercept edit 3 --raw-file edited.txt
+gori run intercept direction request
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `list` (기본값) | 붙잡힌 항목과 캐치 상태, 방향, 필터 |
+| `get <item-id>` | 붙잡힌 항목 하나의 전체 상세 |
+| `forward <item-id>` | 바이트 그대로 통과 |
+| `drop <item-id>` | 폐기. 클라이언트는 정해진 502를 받음 |
+| `edit <item-id>` | 편집한 바이트로 통과: `--raw=RAW` 또는 `--raw-file=PATH`. 그대로 전달되며(`$KEY` 확장 없음) `Content-Length`만 다시 맞춤 |
+| `enable` / `disable` | 라이브 캐치 켜기 / 끄기 |
+| `filter <query>` | 조건부 인터셉트 쿼리 설정. `""`를 넘기면 해제 |
+| `direction <both\|request\|response>` | 캐치가 붙잡을 구간 선택 |
+
+`list`와 `get`은 `--include-sensitive`를 주지 않으면 민감한 헤더 값을 가립니다. 쓰기 서브커맨드는 프로젝트 데이터베이스를 거쳐 TUI의 ack를 폴링합니다.
 
 ### run repeater {#run-repeater}
 
@@ -355,6 +398,26 @@ gori run notes delete 2
 | `list` | `--all`은 요약 한 줄 대신 모든 노트를 전문으로 출력 |
 | `create` | `--text=TEXT`, 위치 인자, 또는 STDIN |
 | `delete <n>` (`rm`) | 인덱스 `n`의 노트 삭제 |
+
+### run links {#run-links}
+
+이슈나 노트가 가리키는 증거입니다. 캡처된 플로우, Repeater 세션, Fuzz / Miner 실행이 대상이 됩니다. Markdown 이슈 내보내기는 이미 이 포인터를 해석해 넣고, 여기서는 목록 조회와 편집을 합니다.
+
+```bash
+gori run links --owner=issue --id=7
+gori run links add --owner=issue --id=7 --ref=flow --ref-id=42
+gori run links delete --owner=note --id=2 --ref=repeater --ref-id=3
+```
+
+| Option | Description |
+|--------|-------------|
+| `--owner=KIND` | 소유자 종류: `issue` (기본값) 또는 `note` |
+| `--id=N` | 소유 이슈 / 노트 id. 필수 |
+| `--ref=KIND` | `add` / `delete`의 대상 종류: `flow`, `repeater`, `fuzz`, `miner` |
+| `--ref-id=M` | `add` / `delete`의 대상 id |
+| `--format=FMT` | `list`에서 `text` (기본값) 또는 `json` |
+
+대상이 정리(prune)된 포인터는 사라지지 않고 `(stale)`로 표시되므로, "증거가 없음"과 "증거가 사라짐"을 구분할 수 있습니다. `add`는 멱등이며, 양쪽 대상이 모두 존재해야 합니다.
 
 ### run rewriter {#run-rewriter}
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -55,6 +55,8 @@ gori run <subcommand> [options]
 | `capture` | Run the proxy and stream captured flows to STDOUT |
 | `history` (`ls`) | List / query captured flows |
 | `show <flow-id>` | Print one flow's request and response |
+| `compare <id-a> <id-b>` | Diff two flows' request or response |
+| `intercept` | Inspect and drive a capturing TUI's live intercept queue |
 | `repeater <flow-id>` · `list` · `create` | Re-send a captured flow, or list / create Repeater workbench sessions |
 | `fuzz [<flow-id>]` | Intruder-style fuzzer |
 | `mine [<flow-id>]` | Hidden-parameter discovery |
@@ -68,6 +70,7 @@ gori run <subcommand> [options]
 | `convert <chain> [input]` | Run a Decoder encode / decode / hash chain |
 | `notes [<n>]` · `create` · `delete` | Read, write, or delete project notes |
 | `issues` · `create` · `update` | List / export issues, or write issues |
+| `links` · `add` · `delete` | Evidence pointers from an issue or note to a flow, Repeater session, or job |
 | `rewriter` · `add` · `rm` · `enable` · `disable` · `preview` | Manage Match & Replace rules |
 | `project [list]` | List known projects |
 | `project create <name>` | Create (or reopen) a project by name |
@@ -75,6 +78,7 @@ gori run <subcommand> [options]
 | `project scope` | List / add / delete / enable / disable scope rules |
 | `project sandbox` | Get / set the hard-containment sandbox gate (`status`, `on`, `off`) |
 | `project env` | List / set / delete project env vars (`$KEY` substitution) |
+| `project host-override` | List / add / update / delete project host to IP dial overrides |
 
 Common flags across read subcommands: `--project=NAME`, `--db=PATH`, `--format=FMT` (usually `text` or `json`).
 
@@ -113,6 +117,45 @@ gori run show <flow-id> --format raw
 ```
 
 `--format` is `text`, `json`, or `raw` (exact bytes). `--request-only` / `--response-only` limit the output. Decoded SAML/JWT/GraphQL/params, WebSocket messages, and SSE events are included where present.
+
+### run compare
+
+Line diff of two flows, matching the [Comparer tab](/guide/scanning/).
+
+```bash
+gori run compare 41 42 --pane response --changes-only
+```
+
+| Option | Description |
+|--------|-------------|
+| `--pane=PANE` | What to diff: `request` or `response` (default) |
+| `--changes-only` | Print only added / removed lines, omitting unchanged context |
+| `--format=FMT` | `text` (default) or `json` |
+
+### run intercept
+
+Drive the live intercept queue of a TUI holding the capture lock. Interception is TUI-only: a headless `gori run capture` never holds a message, and every subcommand here refuses when no capturing instance is publishing state.
+
+```bash
+gori run intercept                              # held items + intercept state
+gori run intercept get 3 --format json
+gori run intercept forward 3
+gori run intercept edit 3 --raw-file edited.txt
+gori run intercept direction request
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `list` (default) | Held items plus catch state, direction, and filter |
+| `get <item-id>` | Full detail for one held item |
+| `forward <item-id>` | Release a held item byte-exact |
+| `drop <item-id>` | Drop it. The client gets a canned 502 |
+| `edit <item-id>` | Release with edited bytes: `--raw=RAW` or `--raw-file=PATH`. Forwarded verbatim (no `$KEY` expansion), with `Content-Length` resynced |
+| `enable` / `disable` | Arm or disarm the live catch |
+| `filter <query>` | Set the conditional-intercept query. Pass `""` to clear it |
+| `direction <both\|request\|response>` | Which leg(s) the catch holds |
+
+`list` and `get` redact sensitive header values unless `--include-sensitive` is passed. Write subcommands round-trip through the project database and poll for the TUI's ack.
 
 ### run repeater
 
@@ -355,6 +398,26 @@ gori run notes delete 2
 | `list` | `--all` prints every note in full instead of a summary line |
 | `create` | `--text=TEXT`, or a positional argument, or STDIN |
 | `delete <n>` (`rm`) | Delete the note at index `n` |
+
+### run links
+
+The evidence an Issue or Note points at: a captured Flow, a Repeater session, or a Fuzz / Miner run. The Markdown issue export resolves these already; this is the surface that lists and edits them.
+
+```bash
+gori run links --owner=issue --id=7
+gori run links add --owner=issue --id=7 --ref=flow --ref-id=42
+gori run links delete --owner=note --id=2 --ref=repeater --ref-id=3
+```
+
+| Option | Description |
+|--------|-------------|
+| `--owner=KIND` | Owner kind: `issue` (default) or `note` |
+| `--id=N` | Owner issue / note id. Required |
+| `--ref=KIND` | Target kind for `add` / `delete`: `flow`, `repeater`, `fuzz`, `miner` |
+| `--ref-id=M` | Target id for `add` / `delete` |
+| `--format=FMT` | `text` (default) or `json`, on `list` |
+
+A pointer whose target was pruned lists as `(stale)` rather than disappearing, so "no evidence" and "evidence that is gone" stay distinguishable. `add` is idempotent, and both ends must exist.
 
 ### run rewriter
 

--- a/docs/content/reference/config.ko.md
+++ b/docs/content/reference/config.ko.md
@@ -494,6 +494,80 @@ retention은 **새 기능이 아닙니다** — gori는 프로젝트 DB가 무�
 
 캡처를 소유하지 않는 표면은 상한과 무관하게 절대 prune하지 않습니다 — `gori mcp`의 스토어, 삭제 미리보기용 개수 집계로만 여는 프로젝트, 새로 생성된 프로젝트.
 
+### oast_providers {#oast-providers}
+
+한 번 정의해두고 모든 프로젝트에서 재사용하는 OAST 프로바이더입니다. 프로젝트 전용 프로바이더는 프로젝트 데이터베이스에 저장되고, 여기 있는 것은 Preferences → **OAST providers**에서 편집하는 전역 목록입니다.
+
+```json
+{
+  "oast_providers": [
+    {
+      "id": "3f9a2c11",
+      "name": "team interactsh",
+      "kind": "interactsh",
+      "host": "oast.example.com",
+      "token": "…",
+      "enabled": true
+    }
+  ]
+}
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `id` | string | 생성 시 부여되는 무작위 hex 토큰. 직접 수정하지 마세요 |
+| `name` | string | OAST 탭에 표시되는 이름 |
+| `kind` | string | 프로바이더 종류. 예: `interactsh` |
+| `host` | string | 프로바이더 호스트 |
+| `token` | string | 프로바이더 인증 토큰(선택) |
+| `enabled` | bool | 선택 가능 여부(기본값 `true`) |
+
+프로바이더를 추가하기 전까지 이 섹션은 아예 기록되지 않습니다. `id`, `name`, `kind`, `host`가 빠진 항목은 로드할 때 버려집니다.
+
+### update {#update}
+
+프로젝트 피커의 "update available" 한 줄 안내를 뒷받침하는 시작 시 업데이트 확인입니다. gori가 자동으로 내보내는 유일한 외부 요청이며, 설치 자체는 `gori update`로만 진행합니다.
+
+```json
+{
+  "update": {
+    "check_enabled": true,
+    "notified_version": "0.2.0",
+    "latest_seen": "0.2.0",
+    "checked_at": 1753600000
+  }
+}
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `check_enabled` | bool | `true` | `false`로 두면 확인 자체를 건너뜀 |
+| `notified_version` | string | `""` | 이미 안내한 최신 버전. 릴리스당 한 번만 표시하기 위한 표식 |
+| `latest_seen` | string | `""` | 릴리스 피드에서 마지막으로 확인한 버전 |
+| `checked_at` | integer | `0` | 마지막 성공 확인의 unix 초. 하루 동안 결과를 캐시 |
+
+아래 셋은 gori가 관리하는 상태이고, 직접 수정할 값은 `check_enabled`뿐입니다. 기본 설치에서는 섹션 전체가 기록되지 않습니다.
+
+### fuzzer {#fuzzer}
+
+Fuzzer의 Payload 오버레이가 기억하는 워드리스트 경로입니다. 프로젝트 데이터가 아니라 임시 상태입니다.
+
+```json
+{
+  "fuzzer": {
+    "recent_wordlists": ["/usr/share/wordlists/params.txt"],
+    "favorite_wordlists": ["/home/me/lists/api.txt"]
+  }
+}
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `recent_wordlists` | array | 최근 적용한 워드리스트 경로. 최신순이며 최대 10개 |
+| `favorite_wordlists` | array | Path 필드에서 별표를 단 경로. 최근 목록보다 먼저 제안됨 |
+
+워드리스트를 적용하거나 별표를 달기 전까지는 기록되지 않습니다.
+
 ### 그 외 섹션 {#other-sections}
 
 | Section | Description |

--- a/docs/content/reference/config.md
+++ b/docs/content/reference/config.md
@@ -494,6 +494,80 @@ Raising the cap takes effect on the next project open. Lowering it does not imme
 
 Surfaces that do not own capture never prune, whatever the cap says: `gori mcp`'s store, a project opened only to count its objects for a delete preview, and a freshly created project.
 
+### oast_providers
+
+OAST providers defined once and reusable across every project. Project-scoped providers live in the project database instead; these are the global library, edited in Preferences → **OAST providers**.
+
+```json
+{
+  "oast_providers": [
+    {
+      "id": "3f9a2c11",
+      "name": "team interactsh",
+      "kind": "interactsh",
+      "host": "oast.example.com",
+      "token": "…",
+      "enabled": true
+    }
+  ]
+}
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `id` | string | Random hex token assigned on creation. Do not hand-edit |
+| `name` | string | Label shown in the OAST tab |
+| `kind` | string | Provider type, e.g. `interactsh` |
+| `host` | string | Provider host |
+| `token` | string | Optional auth token for the provider |
+| `enabled` | bool | Whether the provider is selectable (default `true`) |
+
+The section is omitted entirely until you add a provider. Entries missing `id`, `name`, `kind`, or `host` are dropped on load.
+
+### update
+
+The startup update check behind the project picker's one-line "update available" notice. This is the only automatic outbound call gori makes; `gori update` stays the explicit install path.
+
+```json
+{
+  "update": {
+    "check_enabled": true,
+    "notified_version": "0.2.0",
+    "latest_seen": "0.2.0",
+    "checked_at": 1753600000
+  }
+}
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `check_enabled` | bool | `true` | Set `false` to skip the probe entirely |
+| `notified_version` | string | `""` | Latest version already surfaced, so the notice shows once per release |
+| `latest_seen` | string | `""` | Last version seen from the release feed |
+| `checked_at` | integer | `0` | Unix seconds of the last successful check. Caches the result for a day |
+
+The last three are state gori maintains; only `check_enabled` is meant to be edited. The whole section is omitted on a default install.
+
+### fuzzer
+
+Wordlist paths remembered by the Fuzzer's Payload overlay. Scratch state, not project data.
+
+```json
+{
+  "fuzzer": {
+    "recent_wordlists": ["/usr/share/wordlists/params.txt"],
+    "favorite_wordlists": ["/home/me/lists/api.txt"]
+  }
+}
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `recent_wordlists` | array | Most-recently-applied wordlist paths, newest first, capped at 10 |
+| `favorite_wordlists` | array | Paths starred in the Path field, offered ahead of the recents |
+
+Omitted until you apply or star a wordlist.
+
 ### Other sections
 
 | Section | Description |


### PR DESCRIPTION
Audited `docs/content` against the source surface and filled every gap I found, EN and KO in parallel.

## CLI reference

Three `gori run` subcommands were dispatched in `src/gori/cli/run.cr` but had **zero** coverage in the reference:

| Added | What it is |
|---|---|
| `run compare` | Diff two flows' request or response (`--pane`, `--changes-only`, `--format`) |
| `run intercept` | Drive a capturing TUI's live intercept queue: `list` / `get` / `forward` / `drop` / `edit` / `enable` / `disable` / `filter` / `direction` |
| `run links` | Evidence pointers from an issue or note to a flow, Repeater session, or job, including the `(stale)` behaviour |

Also adds a `project host-override` row to the subcommand table. It had a detail section already, just no row.

## MCP guide

Extracted every `tool j, "…"` from `src/gori/mcp/tools.cr` (111 tools) and diffed against the guide: **38 were unlisted**. Notably the whole Probe family (`probe_scan`, `probe_issues`, `probe_promote` / `probe_dismiss` / `probe_delete`, `set_probe_mode`, the probe-rule CRUD), scope mutation (`add_scope_rule` and friends, `set_sandbox`), `list_env` / `set_env_var` / `delete_env_var`, the host-override CRUD, the OAST-provider CRUD, `list_links` / `add_link` / `remove_link`, `list_sitemap_tags` / `set_sitemap_tag`, `import_flows`, `compare_flows`, `minimize_repeater`, `clear_history` / `delete_flow`, and `delete_issue`.

Read vs action placement follows the `--read-only` branch in the source rather than guesswork, so e.g. `probe_scan` sits under read tools with a note that `active:true` needs write access.

Re-ran the diff after the edit: all 111 tools are now documented.

## config reference

Adds `oast_providers`, `update`, and `fuzzer`. All three have a live `serialize_*` writing them into `settings.json` today, and none were documented. Each gets an example object, a key table, and the "omitted on a default install" behaviour.

## Decoder guide

Adds `rot47`, `crc32`, `sha224` / `sha384`, `deflate-raw` / `inflate-raw`, and a number-bases row (`decimal` / `binary` / `octal`).

## Verification

- `hwaro build`: clean, 44 pages
- EN/KO anchor parity confirmed on the six new headings (`run-compare`, `run-intercept`, `run-links`, `oast-providers`, `update`, `fuzzer`) by grepping the rendered `id=` attributes on both sides
- `check-punctuation.sh --lang en` and a KO dash grep: no em/en dashes in any added prose (the hits it reports are pre-existing lines outside this diff)

Docs only, no code touched.