### PR TITLE
docs: correct two comments that claim byte-exactness the code does not deliver

### DIFF
--- a/src/gori/import/builder.cr
+++ b/src/gori/import/builder.cr
@@ -27,7 +27,7 @@ module Gori
       LEADING_SCHEME = /\A[a-z][a-z0-9+.-]*:\/\//i
       HTTP_SCHEME    = /\Ahttps?:\/\//i
 
-      # A raw control byte (CR, LF, NUL, other C0 or DEL) in the PATH or QUERY of an imported
+      # A raw control byte (CR, LF, other C0 or DEL) in the PATH or QUERY of an imported
       # URL is NOT rejected: it is the operator's own payload. Importing a HAR of a deliberately
       # CRLF-bearing request — a smuggling case — is exactly what a security-testing proxy is
       # for, so the entry is stored and replayed byte-exact, never sanitised (P7; DESIGN.md §7).
@@ -35,6 +35,15 @@ module Gori
       # writes the target onto the request line as-is, which faithfully reproduces the operator's
       # forged message on the wire — the point, not a defect. (Header/method/version smuggling is
       # a DIFFERENT boundary and keeps its own guards below; see HEADER_INJECT.)
+      #
+      # KNOWN GAP — NUL (0x00) is the one exception, and it is NOT byte-exact today. Crystal's
+      # `URI.parse` truncates `path` and `query` at a NUL, so an imported
+      # `http://h/nul\0byte` stores target `/nul` and the payload tail is silently lost — no
+      # skip, no warning. CR and LF are unaffected and do round-trip verbatim as described
+      # above. Verified against 0.2.0; `URI.parse("http://h/p?a=b\0c").query == "a=b"`. The same
+      # round-trip truncates the wire target in the proxy's absolute-form rewrite
+      # (`Proxy::Conn::ClientConn#resolve_forward` → `origin_form`), so a fix belongs with that
+      # one, not here. Until then, do not read the paragraph above as covering NUL.
 
       # The HOST is the one place import still rejects a control byte or space, because there it
       # means the string is not a URL at all — a parse failure, not a URL describing a malformed

--- a/src/gori/outbound.cr
+++ b/src/gori/outbound.cr
@@ -238,10 +238,20 @@ module Gori
     # spaces, or a tab) otherwise splits to `["GET", "", "/admin", ...]`, so `[1]?` is the
     # empty string — non-nil, so `|| "/"` never fires — and the scope gate then evaluates an
     # EMPTY path, silently satisfying any string/regex include/exclude rule. That let a
-    # doubled space in the request line bypass BOTH scope layers (Sandbox included). `split`
+    # doubled space in the request line bypass the scope layers on this path. `split`
     # with no argument collapses whitespace runs and drops the empty parts, so the real
     # request-target is recovered from a malformed request line. (The bytes themselves still
     # go on the wire byte-exact — P7 — this only feeds the scope decision.)
+    #
+    # SCOPE OF THIS FIX: `Outbound` only — repeater/fuzz/mine/sequence/discover/active-probe.
+    # The PROXY path does not come through here: ClientConn passes
+    # `Codec::Http1.parse_request_head`'s `target` (a plain `split(' ')[1]?`) straight to
+    # `Interceptor#sandbox_blocks?` / `#intercepts_request?` / `#intercepts_response?`
+    # (client_conn.cr:241, :267, :494), so the same doubled-space/tab line still yields an
+    # empty target there. Verified against 0.2.0: with `include host:…` + `exclude string:/x`
+    # and Sandbox ON, `GET  /x  HTTP/1.1` reaches the origin while `GET /x HTTP/1.1` is 403'd;
+    # with a URL-keyed include it inverts and fails closed. Do not read this comment as
+    # covering the proxy gate.
     def self.request_target(bytes : Bytes) : String
       request_target_line(String.new(bytes).each_line.first? || "")
     end


### PR DESCRIPTION
Two source comments assert a guarantee that is verifiably false today. **Comments only — no behaviour, gate or predicate changes here.** The point is that the next reader does not trust a promise the code has already broken.

Both gaps were found by building 0.2.0 and driving it against a local raw-echo origin, not by reading. Both are recorded as `SCOPE OF THIS FIX` / `KNOWN GAP` notes rather than quietly widening the principle to fit, per AGENTS.md.

## 1. `outbound.cr` — the doubled-space bypass was only half closed

`Outbound.request_target`'s comment says collapsing whitespace runs closed the bypass in *"BOTH scope layers (Sandbox included)"*. It closed it on the **Outbound path only**.

The proxy path does not come through `Outbound`: `ClientConn` passes `parse_request_head`'s `target` — a plain `split(' ')[1]?`, which is `""` for `GET  /x  HTTP/1.1` or a tab-separated line — straight to `Interceptor#sandbox_blocks?` / `#intercepts_request?` / `#intercepts_response?` (`client_conn.cr:241`, `:267`, `:494`). `Scope.request_url` then builds a URL with an **empty path**, so URL-keyed rules cannot match.

Verified against 0.2.0, Sandbox ON:

| scope | request line | result |
| --- | --- | --- |
| `include host:…` + `exclude string:/x` | `GET /x HTTP/1.1` | 403 ✅ |
| `include host:…` + `exclude string:/x` | `GET  /x  HTTP/1.1` | **reaches origin** ❌ fails open |
| `include host:…` + `exclude string:/x` | `GET\t/x\tHTTP/1.1` | **reaches origin** ❌ fails open |
| `include string:/api` only | `GET  /api  HTTP/1.1` | **403** ❌ fails closed |

The same three request lines are correctly blocked through `gori run fuzz` and MCP `send_request`, which *do* go through `Outbound` — so the whitespace-robust reading already exists and is right one layer over. This is a surface-specific gap, not intended behaviour.

Not fixed here because the fix is a design call: reuse `Outbound.request_target` from `client_conn` (smallest diff, but the proxy path reaching into the active-traffic chokepoint may cross a layering line) versus adding a `gate_target` accessor on `RawRequest` (predicate lives with the other request-line predicates, but nothing makes the wrong choice a compile error). AGENTS.md is explicit that this shape must have one home — it has already recurred three times (#390, #394, #397) — so it should not be re-derived a fourth time next to a new caller.

## 2. `import/builder.cr` — NUL is not byte-exact

The P7 paragraph names **NUL** among the control bytes stored and replayed byte-exact, and states that `URI.parse` copies a literal control byte verbatim into `path`/`query`.

That holds for CR and LF. It does not hold for NUL — Crystal's `URI.parse` truncates both:

```crystal
URI.parse("http://h/p?a=b\0c").query   # => "a=b"      truncated
URI.parse("http://h/nul\0byte").path   # => "/nul"     truncated
URI.parse("http://h/p\r\nX: 1").path   # => "/p\r\nX: 1"  fine
```

So an imported `http://h/nul\0byte` silently stores target `/nul` — no skip, no warning. Import's other two boundaries are correct and unchanged: a space in the host is rejected, and CRLF in a header value or method is rejected.

The same `URI.parse` round-trip truncates the **wire** target in the proxy's absolute-form rewrite (`ClientConn#resolve_forward` → `origin_form`), which is the more serious half — absolute-form is what a browser sends for plain HTTP through a proxy:

| sent to proxy | origin actually received |
| --- | --- |
| `GET http://h/nul<NUL>byte HTTP/1.1` | `GET /nul HTTP/1.1` ❌ |
| `GET /nul<NUL>byte HTTP/1.1` (origin-form) | verbatim ✅ |

Nothing refuses it upstream: `request_token_safe?` would reject a NUL but has no call site anywhere in `src/gori/proxy/`, deliberately — its own comment says it does not apply to operator bytes. The comment now points at `resolve_forward` so the two get fixed together.

## Checks

- `crystal spec` — 4698 examples, 0 failures
- `crystal tool format --check` on both changed files — clean
- `ameba` on both changed files — one pre-existing `Lint/NotNil` at `builder.cr:68`, present before this change and untouched by it
