### PR TITLE
fix(update): print one version form, not "0.1.4 → v0.2.0"

### DIFF
--- a/spec/update_spec.cr
+++ b/spec/update_spec.cr
@@ -462,7 +462,16 @@ describe Gori::Update do
           exe_path: "/usr/local/opt/gori/gori",
           release_json: json)
         io.to_s.should match(/not downgrading/i)
+        io.to_s.should contain("Local version v#{Gori::VERSION} is newer than latest release v0.0.1")
       end
+    end
+  end
+
+  describe ".display_version" do
+    it "renders one `v`-prefixed form whether the input carries the prefix or not" do
+      Gori::Update.display_version("0.2.0").should eq("v0.2.0")
+      Gori::Update.display_version("v0.2.0").should eq("v0.2.0")
+      Gori::Update.display_version("V0.2.0").should eq("v0.2.0")
     end
   end
 
@@ -594,7 +603,9 @@ describe Gori::Update do
           Gori::Update.update_binary(target, io, release_json: srv.release_json)
 
           out = io.to_s
-          out.should contain("Updating")
+          # Both sides carry the `v` — `Gori::VERSION` is bare and the tag is not,
+          # so this line is where the two forms used to collide.
+          out.should contain("Updating v#{Gori::VERSION} → v99.0.0")
           out.should contain("Downloading #{want}")
           out.should contain("Downloaded")
           out.should contain("Installed v99.0.0")

--- a/src/gori/update.cr
+++ b/src/gori/update.cr
@@ -302,6 +302,14 @@ module Gori
       v
     end
 
+    # One display form for every version `gori update` prints. Release tags come
+    # back as `v0.2.0` while `Gori::VERSION` is bare `0.2.0`, so a line that
+    # interpolates both raw reads as "Updating 0.1.4 → v0.2.0". Normalize first,
+    # then re-add the prefix, so a tag is never rendered as `vv0.2.0`.
+    def self.display_version(version : String) : String
+      "v#{normalize_version(version)}"
+    end
+
     def self.normalize_os(os : String) : String
       case os.downcase
       when "darwin", "macos", "osx" then "osx"
@@ -1095,11 +1103,11 @@ module Gori
 
       cmp = version_cmp(local, ver)
       if cmp == 0
-        io.puts "Already up to date (v#{ver})."
+        io.puts "Already up to date (#{display_version(ver)})."
         return
       end
       if cmp > 0
-        io.puts "Local version v#{local} is newer than latest release #{release.tag_name}; not downgrading."
+        io.puts "Local version #{display_version(local)} is newer than latest release #{display_version(release.tag_name)}; not downgrading."
         return
       end
 
@@ -1115,13 +1123,13 @@ module Gori
 
       if via_redirect
         io.puts "Note: the GitHub release API was unavailable (rate limit or outage);"
-        io.puts "      resolved #{release.tag_name} from #{RELEASES_LATEST_URL} instead."
+        io.puts "      resolved #{display_version(release.tag_name)} from #{RELEASES_LATEST_URL} instead."
         unless parse_sha256_digest(asset.digest)
-          io.puts "      #{release.tag_name} publishes no SHA256SUMS, so sha256 verification is skipped."
+          io.puts "      #{display_version(release.tag_name)} publishes no SHA256SUMS, so sha256 verification is skipped."
         end
       end
 
-      io.puts "Updating #{VERSION} → #{release.tag_name}"
+      io.puts "Updating #{display_version(VERSION)} → #{display_version(ver)}"
       size_note = asset.size > 0 ? " (#{format_size(asset.size)})" : ""
       io.puts "Downloading #{asset.name}#{size_note}"
 
@@ -1137,7 +1145,7 @@ module Gori
         install_from_download(dest, target_path, asset_is_archive?(asset.name))
       end
 
-      io.puts "Installed #{release.tag_name} → #{target_path}"
+      io.puts "Installed #{display_version(release.tag_name)} → #{target_path}"
       if current_os == "osx"
         io.puts "Note: macOS release keeps gori and lib/ side by side under #{File.dirname(target_path)}."
       end
@@ -1162,7 +1170,7 @@ module Gori
       resolved_family = os_family || load_os_family
       channel = detect_channel(path, owner: resolved_owner, os_family: resolved_family)
 
-      io.puts "gori #{VERSION}"
+      io.puts "gori #{display_version(VERSION)}"
       io.puts "install channel: #{channel.to_s.downcase} (#{path})"
       io.puts ""
 


### PR DESCRIPTION
## Problem

`gori update` printed two spellings of the same thing, one line apart:

```
gori 0.2.0
install channel: binary (/usr/local/bin/gori)

Updating 0.1.4 → v0.2.0
Installed v0.2.0 → /usr/local/bin/gori
```

`Gori::VERSION` is bare (`0.2.0`); a release `tag_name` carries the prefix (`v0.2.0`). Six output lines interpolated one, the other, or both.

## Fix

New `Update.display_version` — normalize first, then re-add the `v`, so a tag never renders as `vv0.2.0`. All six version-bearing lines in `gori update` go through it: the banner, `Updating`, `Already up to date`, `not downgrading`, both redirect-fallback notes, and `Installed`. The `Updating` right-hand side now uses the already-normalized `ver` instead of the raw tag.

Real run of the built binary:

```
gori v0.2.0
install channel: binary (…/gori)

Standalone binary install — downloading the latest GitHub release asset.

Already up to date (v0.2.0).
```

## Scope

`gori --version` / `gori version` stay bare. They are a separate surface, documented as `gori 0.2.0` in `docs/content/getting-started/installation.md` and `.ko.md`, and scripts parse them.

## Specs

- `contain("Updating")` was loose enough to pass through the whole bug — pinned to the literal `Updating v… → v99.0.0`.
- Same for the downgrade line.
- Unit spec for the helper: `0.2.0` / `v0.2.0` / `V0.2.0` all render `v0.2.0`.

`crystal spec spec/update_spec.cr` → 86 examples, 0 failures. `crystal build --no-codegen src/main.cr` passes on the rebased tip (the merge result, not just the branch).