### PR TITLE
feat(tui): horizontal scroll for the Comparer body

### DIFF
--- a/spec/tui/comparer_view_spec.cr
+++ b/spec/tui/comparer_view_spec.cr
@@ -4,13 +4,13 @@ require "../../src/gori/tui/comparer_view"
 
 include Gori::Tui
 
-private def flow(method, target, host = "h.test")
+private def flow(method, target, host = "h.test", body = "body")
   row = Gori::Store::FlowRow.new(
     1_i64, 1_i64, "https", method, host, 443, target,
     200, 100_i64, Gori::Store::FlowState::Complete, 50_i64, 1_i64, "text/plain")
   head = "#{method} #{target} HTTP/1.1\r\nHost: #{host}\r\n\r\n".to_slice
-  resp = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nbody".to_slice
-  Gori::Store::FlowDetail.new(row, "HTTP/1.1", head, nil, resp, "body".to_slice)
+  resp = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n".to_slice
+  Gori::Store::FlowDetail.new(row, "HTTP/1.1", head, nil, resp, body.to_slice)
 end
 
 describe ComparerView do
@@ -123,5 +123,76 @@ describe ComparerView do
     v.pane_chip_at(rect, res + 4, divider_y).should be_nil
     # Wrong row never hits.
     v.pane_chip_at(rect, req, divider_y + 1).should be_nil
+  end
+
+  # A body line wider than a diff column used to be clipped with no way to see the tail,
+  # which is exactly where a comparison matters (a long JSON line, a JWT, a query string).
+  # ⇧←/→ now shifts BOTH columns by one shared offset so the LCS alignment survives.
+  describe "horizontal scroll" do
+    # 40 filler cols + an 8-col tail = 48, past the 38-col column of a width-80 frame.
+    same_line = "#{"x" * 40}SAMETAIL"
+    a_line = "#{"y" * 40}LEFTTAIL"
+    b_line = "#{"y" * 40}RGHTTAIL"
+    left_w = (80 - ComparerView::SEP_W) // 2 # 38
+
+    paint = ->(v : ComparerView) {
+      backend = MemoryBackend.new(80, 20)
+      v.render(Screen.new(backend), Rect.new(0, 0, 80, 20), focused: true)
+      (0...20).map { |y| backend.row(y) }
+    }
+
+    pair = ->(v : ComparerView) {
+      v.set_pair(
+        flow("GET", "/a", body: "#{same_line}\n#{a_line}"),
+        flow("GET", "/a", body: "#{same_line}\n#{b_line}"))
+    }
+
+    it "reveals the clipped tail in BOTH columns, on the styled and the plain path" do
+      v = ComparerView.new
+      pair.call(v)
+      before = paint.call(v)
+      before.any?(&.includes?("SAMETAIL")).should be_false # clipped at col 0
+      before.any?(&.includes?("LEFTTAIL")).should be_false
+
+      100.times { v.hscroll(1) } # clamps to the widest visible row
+      after = paint.call(v)
+      # Unchanged row → the syntax-highlighted path; both columns hold the same text, so
+      # the tail must land twice on that one row (once per column).
+      same_row = after.select(&.includes?("SAMETAIL"))
+      same_row.size.should eq(1)
+      (same_row[0].split("SAMETAIL").size - 1).should eq(2)
+      # Changed row → the plain-text path (diff colours, no syntax overlay).
+      chg = after.find(&.includes?("LEFTTAIL")).not_nil!
+      chg.should contain("RGHTTAIL")
+    end
+
+    it "clamps to the widest row on screen instead of scrolling into blank space" do
+      v = ComparerView.new
+      pair.call(v)
+      100.times { v.hscroll(1) }
+      paint.call(v)
+      v.xscroll.should eq(48 - left_w) # widest line is 48 cols
+    end
+
+    it "steps 4 columns and never goes negative" do
+      v = ComparerView.new
+      pair.call(v)
+      v.hscroll(2)
+      v.xscroll.should eq(8)
+      v.hscroll(-5)
+      v.xscroll.should eq(0)
+    end
+
+    it "returns to the left edge when the compared half changes" do
+      v = ComparerView.new
+      pair.call(v)
+      v.hscroll(1)
+      v.xscroll.should eq(4)
+      v.toggle_pane # RES → REQ: different content, different widths
+      v.xscroll.should eq(0)
+      v.hscroll(2)
+      v.set_pane(:response)
+      v.xscroll.should eq(0)
+    end
   end
 end

--- a/src/gori/tui/comparer_view.cr
+++ b/src/gori/tui/comparer_view.cr
@@ -31,6 +31,10 @@ module Gori::Tui
       @slot_b = nil.as(Store::FlowDetail?)
       @pane = :response
       @scroll = 0
+      # Leftmost visible display COLUMN, shared by BOTH columns (⇧←/→). One offset, not
+      # two: the rows are LCS-aligned, so moving A and B together is what keeps a long
+      # line comparable — an independent per-column offset would break that alignment.
+      @xscroll = 0
       @fill_next = :a # the slot the next "Send to Comparer" fills (rings A → B → A …)
       @rows_cache = nil.as(Array(Repeater::SideBySide::Row)?)
       # Styled overlay for the UNCHANGED (same) rows only — parallel to @rows_cache, nil
@@ -88,6 +92,7 @@ module Gori::Tui
       @pane = other.@pane
       @fill_next = other.@fill_next
       @scroll = 0
+      @xscroll = 0
       invalidate
     end
 
@@ -98,6 +103,7 @@ module Gori::Tui
       @slot_b = nil
       @pane = :response
       @scroll = 0
+      @xscroll = 0
       @fill_next = :a
       invalidate
     end
@@ -160,7 +166,8 @@ module Gori::Tui
 
     def toggle_pane : Nil
       @pane = @pane == :response ? :request : :response
-      @scroll = 0 # request/response differ in length — start from the top
+      @scroll = 0  # request/response differ in length — start from the top
+      @xscroll = 0 # …and in width, so start from the left edge too
       invalidate
     end
 
@@ -170,6 +177,7 @@ module Gori::Tui
       return if @pane == pane
       @pane = pane
       @scroll = 0
+      @xscroll = 0
       invalidate
     end
 
@@ -195,8 +203,20 @@ module Gori::Tui
       @scroll = {@scroll + delta, 0}.max # render clamps the ceiling against the body height
     end
 
+    # ⇧←/→: shift BOTH columns by the same amount, 4 columns per step (Repeater/History/
+    # Intercept/Decoder/Fuzzer all use that step). Render clamps the ceiling against the
+    # widest row currently on screen.
+    def hscroll(delta : Int32) : Nil
+      @xscroll = {@xscroll + delta * 4, 0}.max
+    end
+
     def at_top? : Bool
       @scroll == 0
+    end
+
+    # Current h-offset — for the footer readout and specs.
+    def xscroll : Int32
+      @xscroll
     end
 
     # --- diff (memoized; rebuilt only on a slot/pane change) ----------------
@@ -303,6 +323,10 @@ module Gori::Tui
       data = rows
       sr = styled_same
       clamp_scroll(body_h, data.size)
+      # Clamp against the NARROWER column: the two differ by at most one cell (odd frame
+      # width), and pinning to the wider one would leave the narrow column's last cell of
+      # the widest line permanently unreachable.
+      clamp_hscroll(data, body_h, {left_w, right_w}.min)
       (0...body_h).each do |i|
         di = @scroll + i
         break if di >= data.size
@@ -362,15 +386,23 @@ module Gori::Tui
                                       end
       # Unchanged rows get syntax highlighting (both columns hold identical text); changed/
       # added/deleted rows keep the red/green diff colours so the diff signal stays legible.
+      # The centre marker band rides the frame, not the text: it stays put while the two
+      # columns scroll under it, so the ~/-/+ signal survives any h-offset.
       if styled && r.kind.same?
-        Highlight.draw(screen, x, y, styled, bg: Theme.bg, width: left_w) if left_w > 0
+        shown = @xscroll > 0 ? Highlight.slice_left(styled, @xscroll) : styled
+        Highlight.draw(screen, x, y, shown, bg: Theme.bg, width: left_w) if left_w > 0
         screen.cell(sep_x + 1, y, glyph, gcolor)
-        Highlight.draw(screen, right_x, y, styled, bg: Theme.bg, width: right_w) if right_w > 0
+        Highlight.draw(screen, right_x, y, shown, bg: Theme.bg, width: right_w) if right_w > 0
       else
-        screen.text(x, y, r.left || "", lcolor, width: left_w) if left_w > 0
+        screen.text(x, y, sliced(r.left), lcolor, width: left_w) if left_w > 0
         screen.cell(sep_x + 1, y, glyph, gcolor)
-        screen.text(right_x, y, r.right || "", rcolor, width: right_w) if right_w > 0
+        screen.text(right_x, y, sliced(r.right), rcolor, width: right_w) if right_w > 0
       end
+    end
+
+    private def sliced(text : String?) : String
+      t = text || ""
+      @xscroll > 0 ? Highlight.slice_left_text(t, @xscroll) : t
     end
 
     private def draw_footer(screen : Screen, rect : Rect, y : Int32) : Nil
@@ -378,11 +410,34 @@ module Gori::Tui
       changed = @change_count
       note = changed == 0 ? "identical" : "#{changed} changed line#{changed == 1 ? "" : "s"}"
       note += " · truncated to #{Repeater::Diff::MAX_LINES}/side" if @truncated
+      note += " · col #{@xscroll}" if @xscroll > 0                              # only when scrolled: otherwise it's noise
       screen.text(rect.x + 1, y, note, Theme.muted, width: {rect.w - 2, 1}.max) # pane + ←/→ moved to the divider selector
     end
 
     private def clamp_scroll(body_h : Int32, total : Int32) : Nil
       @scroll = @scroll.clamp(0, {total - body_h, 0}.max)
+    end
+
+    # Pin the h-offset to the widest row CURRENTLY ON SCREEN, across both columns — the
+    # same rule the Repeater response uses. Measured with draw_width_upto so a minified
+    # multi-MB body line is never fully walked once per frame.
+    private def clamp_hscroll(data : Array(Repeater::SideBySide::Row), body_h : Int32, cw : Int32) : Nil
+      if cw <= 0
+        @xscroll = 0
+        return
+      end
+      limit = @xscroll + cw + 1
+      widest = 0
+      (0...body_h).each do |i|
+        r = data[@scroll + i]?
+        break unless r
+        {r.left, r.right}.each do |t|
+          next unless t
+          w = Screen.draw_width_upto(t, limit)
+          widest = w if w > widest
+        end
+      end
+      @xscroll = @xscroll.clamp(0, {widest - cw, 0}.max)
     end
   end
 end

--- a/src/gori/tui/controllers/comparer_controller.cr
+++ b/src/gori/tui/controllers/comparer_controller.cr
@@ -122,6 +122,7 @@ module Gori::Tui
     # Scroll + request/response toggle; a/b/s fall through to the verb keymap.
     def handle_body_key(ev : Termisu::Event::Key) : Bool
       key = ev.key
+      return true if handle_body_hscroll(ev)
       case
       when key.up?, key.lower_k?
         if view.at_top?
@@ -138,6 +139,22 @@ module Gori::Tui
         true
       when key.escape?
         @host.request_focus(:subtabs)
+        true
+      else
+        false
+      end
+    end
+
+    # ⇧←/→ scrolls both diff columns sideways. Checked BEFORE the plain ←/→ pane toggle:
+    # the bare arrows keep switching REQ ⇄ RES, the shifted ones never reach that branch.
+    private def handle_body_hscroll(ev : Termisu::Event::Key) : Bool
+      return false unless ev.shift?
+      key = ev.key
+      if key.left?
+        view.hscroll(-1)
+        true
+      elsif key.right?
+        view.hscroll(1)
         true
       else
         false
@@ -166,7 +183,7 @@ module Gori::Tui
       a = Hotkeys.binding_label(reg, "comparer.pick-a", "a")
       b = Hotkeys.binding_label(reg, "comparer.pick-b", "b")
       s = Hotkeys.binding_label(reg, "comparer.swap", "s")
-      "←/→ req|res · ↑/↓ scroll · #{a}/#{b} pick · #{s} swap · ^N new · ^W close · space cmds · ↹/esc tabs"
+      "←/→ req|res · ↑/↓ scroll · ⇧←/→ h-scroll · #{a}/#{b} pick · #{s} swap · ^N new · ^W close · space cmds · ↹/esc tabs"
     end
   end
 end

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -118,6 +118,7 @@ module Gori::Tui
       {"COMPARER", [
         Item.new("a · b", "pick flow A · flow B"),
         Item.new("←/→", "compare requests ⟷ responses"),
+        Item.new("⇧←/→", "h-scroll both columns (long lines)"),
         Item.new("s", "swap A ⇄ B"),
         Item.new("^N / ^W · r", "new / close / rename comparison sub-tab"),
         Item.new("Send to Comparer", "from History (space menu) — fills the active sub-tab"),


### PR DESCRIPTION
A response line wider than a diff column was clipped with no way to reach its tail — which is exactly where the comparison lives (a long JSON line, a JWT, a query string). Both columns showed identical visible prefixes while the real difference sat off-screen.

`⇧←` / `⇧→` now shifts **both** columns by one shared offset.

## Why one offset, not two

The rows are LCS-aligned. Moving A and B together is what keeps a long line comparable; an independent per-column offset would break exactly the alignment the view exists to show. The centre `~`/`-`/`+` marker band rides the frame rather than the text, so the diff signal survives any offset.

## Details

- 4 columns per step, matching Repeater / History / Intercept / Decoder / Fuzzer.
- Clamped to the widest row **currently on screen**, measured against the **narrower** column: the two differ by at most one cell on an odd frame width, and pinning to the wider one leaves the narrow column's last cell of the widest line permanently unreachable. Measured with `draw_width_upto` so a minified multi-MB body line is never fully walked once per frame.
- Footer reads `· col N` only while scrolled.
- Bare `←`/`→` still toggles REQ ⇄ RES — the shifted arrows are claimed before that branch. Switching halves resets the offset (different content, different widths).
- Both draw paths are sliced: the syntax-highlighted path for unchanged rows (`Highlight.slice_left`) and the plain diff-coloured path for changed/added/deleted rows (`Highlight.slice_left_text`).

## Verification

`spec/tui/comparer_view_spec.cr` gains 4 cases: tail revealed in both columns on both draw paths, the clamp value, the 4-column step + no-negative floor, and the reset on a REQ/RES change.

Dogfooded under tmux with a 169-column JSON body. At col 0 the differing tail is invisible:

```
{"user":"alice","tok":"012345678901234567890123456789…  ~  {"user":"alice","tok":"01234567890123456789012345678…
```

After `⇧→`:

```
…89","role":"LEFTROLE_ADMIN"}  ~  …89","role":"RGHTROLE_GUEST"}
1 changed line · col 94
```

It stops at col 94 (further `⇧→` is a no-op), `⇧←` walks back, and a bare `→` still switches to REQ and resets to col 0.

`crystal spec`: 4703 examples, 8 failures — all the known `capture_status` / `project_registry` port-binding failures from a gori already running locally, unrelated to this change. `crystal tool format --check` clean.

Docs don't enumerate Comparer keys, so only the in-app Help view gained a line.
