### PR TITLE
perf(probe): DOM-XSS scan cost 229ms per JS bundle flow, now 11ms

### DIFF
--- a/bench/probe_passive_bench.cr
+++ b/bench/probe_passive_bench.cr
@@ -79,11 +79,20 @@ HTML_FLOW = flow("GET", "/dashboard", "text/html; charset=utf-8",
 # A minified-bundle-shaped JS response at the Context::CLIENT_BODY_CAP ceiling (256 KiB). This
 # is the worst case for the client-side rules: `client_scripts` is the WHOLE body, and both
 # strip (client_code) and strip_comments (client_scripts_nocomment) lex all of it.
+#
+# The body MUST carry real DOM sinks (`.html(`, `.innerHTML=`, `setTimeout(`) plus a taint
+# source — every shipped jQuery/SPA bundle does. This fixture originally had neither, so
+# `JsScan.source_sink_pairs` bailed on its first miss and the bench reported a healthy 6.2ms
+# while a sink-bearing bundle really cost 240ms (a `Regex#match(code, pos)` loop, since replaced
+# by `scan` + a whole-script source prefilter). A perf fixture that skips the expensive branch is
+# worse than no fixture — keep the sinks and the source here.
 JS_BODY = begin
   io = IO::Memory.new
   i = 0
   while io.bytesize < 256 * 1024
-    io << "function f" << i << "(a,b){var c=\"str" << i << "\",d=/*x*/a+b;return c+d};"
+    io << "function f" << i << "(a,b){var c=\"str" << i << "\",d=/*x*/a+b;$(e).html(c);"
+    io << "setTimeout(function(){o.innerHTML=d},10);return c+d};"
+    io << "o.innerHTML=location.hash+d;" if i % 200 == 0 # a real source→sink pair to correlate
     i += 1
   end
   io.to_slice.dup

--- a/src/gori/probe/passive/js_scan.cr
+++ b/src/gori/probe/passive/js_scan.cr
@@ -343,19 +343,35 @@ module Gori
         # within WINDOW chars each side). Empty when no sink co-occurs with a source.
         def self.source_sink_pairs(code : String) : Array({String, String})
           pairs = [] of {String, String}
+          # Whole-script source prefilter. A sink can only pair with a source that exists SOMEWHERE
+          # in the script, so a bundle with no source at all cannot produce a pair no matter how
+          # many sinks it carries — and a minified SPA/jQuery bundle carries thousands (`.html(`,
+          # `.innerHTML=`, `setTimeout(`). Without this, that bundle paid the full sink walk to
+          # return []: measured 230ms per flow, on the fiber the passive scan shares with the proxy.
+          # 14 whole-body `matches?` passes instead ⇒ 1.0ms (228× — bench/probe_passive_bench).
+          return pairs unless SOURCES.any? { |(re, _)| re.matches?(code) }
           SINKS.each do |(sink_re, sink_label)|
-            pos = 0
-            while m = sink_re.match(code, pos)
-              b = m.begin(0)
-              e = m.end(0)
-              if src = source_in_window(code, b, e)
+            # `scan`, NOT a `while m = sink_re.match(code, pos)` loop: re-entering `match` with a
+            # start offset is ~515× slower than one `scan` walk for the SAME matches and the SAME
+            # allocation (74.00ms vs 143.64µs over 2448 hits in a 256 KiB body — pure CPU inside
+            # the match call; `match_at_byte_index` is just as slow, so it is not char↔byte
+            # conversion). `scan` yields the same MatchData, so begin/end are unchanged.
+            code.scan(sink_re) do |m|
+              if src = source_in_window(code, m.begin(0), m.end(0))
                 pairs << {src, sink_label}
               end
-              pos = e > pos ? e : pos + 1
             end
           end
           pairs
         end
+
+        # The characters that end a statement, hence bound a source↔sink window. Scanned as four
+        # Char searches rather than one `/[;{}\n]/`: `String#rindex(Regex)` walks the whole subject
+        # FORWARD keeping the last match and allocates a MatchData per boundary, and a minified
+        # statement is dense with them. Same idea as the `[a.index('/'), a.index('?'),
+        # a.index('#')].compact.min?` idiom in active/types.cr, written allocation-free here
+        # because this runs once per sink occurrence.
+        BOUNDS = {';', '{', '}', '\n'}
 
         # The first taint source inside the statement window around [from, to), or nil.
         private def self.source_in_window(code : String, from : Int32, to : Int32) : String?
@@ -363,10 +379,20 @@ module Gori
           floor = 0 if floor < 0
           ceil = to + WINDOW
           ceil = code.size if ceil > code.size
+          # Statement start: the LAST boundary before the sink (else the window floor).
           pre = code[floor...from]
-          lo = (rel = pre.rindex(/[;{}\n]/)) ? floor + rel + 1 : floor
+          lo = floor
+          BOUNDS.each do |c|
+            r = pre.rindex(c)
+            lo = floor + r + 1 if r && floor + r + 1 > lo
+          end
+          # Statement end: the FIRST boundary after the sink (else the window ceiling).
           post = code[to...ceil]
-          hi = (rel2 = post.index(/[;{}\n]/)) ? to + rel2 : ceil
+          hi = ceil
+          BOUNDS.each do |c|
+            r = post.index(c)
+            hi = to + r if r && to + r < hi
+          end
           seg = code[lo...hi]
           SOURCES.each { |(re, label)| return label if re.matches?(seg) }
           nil


### PR DESCRIPTION
Found while reviewing the Probe rule set for FP/FN and speed.

## The problem

`JsScan.source_sink_pairs` walked sink matches with `while m = sink_re.match(code, pos)`. In Crystal that shape is **~515× slower** than one `String#scan(re)` doing the same walk — 74.00ms vs 143.64µs over 2448 matches in a 256 KiB ASCII subject, with **identical allocation** (76.5kB both), so the cost is pure CPU inside the match call. `match_at_byte_index` in the same loop is just as slow (72.75ms), which rules out char↔byte index conversion as the cause.

That produced a cliff nothing warned about. A 256 KiB JS bundle cost 6.2ms while it carried no sinks, and **229ms** the moment it carried ordinary `.html(` / `.innerHTML=` / `setTimeout(` — i.e. every shipped jQuery or SPA bundle. This runs on the passive fiber that shares a core with the proxy.

## The change

No behaviour change — detections are identical on every fixture.

1. **Whole-script source prefilter.** A sink can only pair with a taint source that exists *somewhere* in the script, so a bundle with no source cannot produce a pair however many sinks it has. Return before the sink walk instead of after it.
2. **`code.scan(sink_re)`** in place of the `match(code, pos)` loop. `scan` yields the same `MatchData`, so `begin`/`end` are unchanged.
3. **`source_in_window`** bounds the statement with four Char `rindex`/`index` scans instead of `/[;{}\n]/`. `String#rindex(Regex)` walks the whole subject *forward* keeping the last match and allocates a `MatchData` per boundary, and a minified statement is dense with them. Same idiom as `active/types.cr`'s `[a.index('/'), a.index('?'), a.index('#')].compact.min?`.

## Measurements

Control-run on one identical fixture, full `Passive.analyze` on a 256 KiB bundle:

| | time | alloc | detections |
|---|---|---|---|
| before | 229.19ms | 8.93MB/op | js=3 |
| after | **11.30ms** | 4.93MB/op | js=3 |

**20.3× faster, same findings.**

Decomposition, so the next reader does not re-optimise the wrong thing: the **sink match loop alone was 221.88ms of the 228.74ms total**. The window scan and the 14 `SOURCES` regexes per sink hit were never the bottleneck.

### Cost, stated honestly

A JS response with **no sinks at all** is ~6% slower (6.15 → 6.5ms), because the 14 `SOURCES` prefilter passes replace 9 sink passes. A literal `includes?` pre-gate does *not* help — a real bundle contains `document.` and `.data` anyway, so it would only add work on top. Traded against −218ms on the common path.

## Bench fixture

`bench/probe_passive_bench.cr`'s JS fixture carried no sinks, so it never once entered this branch and reported a healthy 6.22ms throughout. The fixture now carries the sinks and a source, with a comment saying why: a perf fixture that skips the expensive branch is worse than no fixture.

## Verification

- `crystal spec` — **4748 examples, 0 failures**
- probe specs (`spec/probe/`, `spec/probe_spec.cr`) — 344 examples, 0 failures
- `crystal tool format --check` on both touched files — clean
- `crystal build --no-codegen src/main.cr` — clean
- `ameba src/gori/probe/passive/js_scan.cr` — 0 failures

## Not in this PR

The same review turned up FP/FN items I have not touched yet: `secret_in_body` rating a plain app JWT as High, `weak_csp?` matching `unsafe-eval` as a substring of a host token, `reverse_tabnabbing` being case-sensitive on `noopener` (and largely obsolete since browsers default `target=_blank` to noopener), and the three "possible bypass" active rules confirming against a captured baseline with no control re-send.