### PR TITLE
docs: stop using the brand gold as garnish in the reading column

### DIFF
--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -2009,21 +2009,16 @@ kbd {
   text-wrap: balance;
 }
 
+/* The page title closes with the same hairline every h2 opens with, so the
+   whole column is ruled by one device. (The first h2 drops its own rule
+   below, otherwise the two would stack.) */
 .docs-main > h1:first-child {
-  position: relative;
+  /* The 13em cap above would end this rule mid-column, out of line with every
+     h2 rule below it. Page titles are short enough to wrap on their own. */
+  max-width: none;
   margin-bottom: 1.35rem;
   padding-bottom: 1.1rem;
-}
-
-.docs-main > h1:first-child::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  width: 7rem;
-  height: 2px;
-  border-radius: 2px;
-  background: linear-gradient(90deg, var(--accent-strong), var(--accent) 46%, transparent);
+  border-bottom: 1px solid var(--line);
 }
 
 .docs-main h2 {
@@ -2081,7 +2076,7 @@ kbd {
 }
 
 .docs-main li::marker {
-  color: var(--accent);
+  color: var(--quiet);
 }
 
 .docs-main strong {
@@ -2155,15 +2150,16 @@ hr {
   height: 1px;
   margin: 3.5rem 0;
   border: 0;
-  background: linear-gradient(90deg, transparent, var(--line-strong), transparent);
+  background: var(--line);
 }
 
+/* Links already own the accent in running text. A neutral chip keeps inline
+   code from reading as a link, and keeps the gold for things you can click. */
 code {
-  padding: 0.16rem 0.38rem;
-  border: 1px solid var(--line-soft);
-  border-radius: 6px;
-  background: rgb(var(--accent-rgb) / 0.1);
-  color: var(--accent-strong);
+  padding: 0.14rem 0.36rem;
+  border-radius: 5px;
+  background: rgb(var(--ink-rgb) / 0.08);
+  color: var(--heading);
   font-family: var(--font-mono);
   font-size: 0.86em;
 }
@@ -2175,10 +2171,7 @@ pre {
   overflow-x: auto;
   border: 1px solid var(--line);
   border-radius: var(--radius);
-  background:
-    linear-gradient(180deg, rgb(var(--ink-rgb) / 0.03), transparent),
-    var(--pre-bg);
-  box-shadow: var(--shadow-soft);
+  background: var(--pre-bg);
   scrollbar-width: thin;
   scrollbar-color: var(--line-strong) transparent;
 }
@@ -2373,61 +2366,63 @@ tbody tr:hover {
   background: rgb(var(--ink-rgb) / 0.035);
 }
 
-blockquote {
-  max-width: 48rem;
+/* Callouts. In this doc set a blockquote is an aside, not a quotation, and the
+   alert shortcode says the same thing in HTML, so the three share one look: a
+   hairline box and a faint tint. No accent stripe, no coloured shouting label —
+   the bold lead-in ("Before you begin.") carries the emphasis. */
+blockquote,
+.alert,
+.info-box {
+  max-width: var(--content-max-w);
   margin: 1.5rem 0;
-  padding: 1rem 1.2rem;
+  padding: 0.95rem 1.1rem;
   border: 1px solid var(--line);
-  border-left: 2px solid rgb(var(--accent-rgb) / 0.5);
-  border-radius: var(--radius);
+  border-radius: var(--radius-sm);
   background: rgb(var(--ink-rgb) / 0.04);
-  color: var(--muted);
+  color: var(--text);
 }
 
-blockquote p:last-child {
+blockquote > :last-child,
+.alert > :last-child,
+.info-box > :last-child {
   margin-bottom: 0;
 }
 
-.info-box {
-  max-width: var(--content-max-w);
-  margin: 1rem 0;
-  padding: 0.95rem 1rem;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  background: rgb(var(--ink-rgb) / 0.045);
+/* markdownify wraps the shortcode body in its own <p>, which would drop the
+   "Note." lead-in onto a line of its own. Inline the first paragraph so an
+   alert reads exactly like the blockquote asides beside it. */
+.alert > strong:first-child + p {
+  display: inline;
 }
 
-.info-box > strong:first-child {
-  color: var(--accent-strong);
-}
-
+/* An index of page titles, nothing more: a ruled two-column list, not a grid
+   of cards sized for descriptions this listing does not carry. */
 ul.section-list {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 0.8rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0 2.5rem;
+  max-width: var(--content-max-w);
+  margin: 0 0 1.6rem;
   padding: 0;
   list-style: none;
 }
 
 ul.section-list li {
-  min-height: 6rem;
   margin: 0;
-  padding: 1rem;
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: rgb(var(--ink-rgb) / 0.045);
-  transition: border-color var(--transition), background var(--transition);
-}
-
-ul.section-list li:hover {
-  border-color: var(--accent);
-  background: rgb(var(--accent-rgb) / 0.08);
+  border-bottom: 1px solid var(--line);
 }
 
 ul.section-list li a {
-  color: var(--heading);
-  font-weight: 760;
+  display: block;
+  padding: 0.62rem 0;
+  color: var(--text);
+  font-weight: 600;
   text-decoration: none;
+  transition: color var(--transition);
+}
+
+ul.section-list li a:hover {
+  color: var(--accent-strong);
 }
 
 nav.pagination {

--- a/docs/templates/shortcodes/alert.html
+++ b/docs/templates/shortcodes/alert.html
@@ -1,3 +1,1 @@
-<div class="alert" style="padding: 0.875rem 1.125rem; border: 1px solid color-mix(in srgb, var(--accent, #c8a860) 32%, transparent); border-left: 2px solid var(--accent, #c8a860); background-color: color-mix(in srgb, var(--accent, #c8a860) 8%, transparent); border-radius: 10px; margin: 1rem 0; color: inherit;">
-  <strong style="color: var(--accent-strong, #dcc084);">{{ type | upper }}:</strong> {{ body | markdownify }}
-</div>
+<div class="alert"><strong>{{ type | capitalize }}.</strong> {{ body | markdownify }}</div>


### PR DESCRIPTION
The doc body had one habit repeated everywhere: the brand accent applied to things that are not interactive.

| Where | Before | After |
|---|---|---|
| `blockquote` | border + gold left stripe + radius + tint | one hairline box + faint tint |
| `h1` | 7rem gradient bar fading to transparent | the same hairline every `h2` opens with |
| `hr` | `transparent → line → transparent` | plain 1px rule |
| inline `code` | `--accent-strong` on a gold tint, in a border | neutral chip (`ink/0.08` + `--heading`) |
| `li::marker` | gold | `--quiet` |
| `pre` | gradient wash + `0 14px 44px` shadow | flat |

Inline `code` mattered most. It shared `--accent-strong` with links, so every backtick in a paragraph read as clickable, and the CLI reference was a wall of gold that told the reader nothing. Gold means "link" again.

Two structural fixes fell out:

- `ul.section-list` was a two-column grid of `min-height: 6rem` bordered cards, but `section.list` emits nothing but a page title, so every card was one word in a large empty box. It is a ruled two-column link list now.
- `.docs-main h1`'s `max-width: 13em` ended the new hairline mid-column, out of line with every `h2` rule below it, so `> h1:first-child` overrides it to `none`. The old gradient bar hid that misalignment by fading out before it got there.

The `alert` shortcode said the same thing as a blockquote in a different visual language (inline styles, its own gold stripe, an all-caps `NOTE:` in accent colour). It now shares the blockquote rule. Currently unused by any content page.

**Deliberately kept:** the sidebar active marker and the TOC rail's left border, because those are position indicators rather than decoration. Table row hover stays too; the long flag tables in the CLI reference are easier to track a row across with it.

## Verification

Headless screenshots in both themes at 1440px and 430px across `quick-start`, `guide`, `guide/proxy`, `reference/cli`. The right-edge clipping headless shows at 430px reproduces identically on `main`'s stylesheet, so it is a rendering artifact, not something this touches.

CSS and one template only; no Crystal, no content changes.