### PR TITLE
fix(probe): stop three passive rules from crying wolf

### DIFF
--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -780,6 +780,37 @@ describe "Gori::Probe::Passive (FP reduction)" do
     end
   end
 
+  # The keyword tests were `includes?`, so any source merely CONTAINING the word scored the
+  # whole policy weak — an allowlisted host or path is not a keyword.
+  it "does not read an allowlisted host/path that merely contains a keyword as that keyword" do
+    with_store do |store|
+      ["script-src 'self' https://unsafe-evaluation.example",
+       "script-src 'self' https://cdn.example.com/unsafe-inline.js",
+       "script-src 'self' https://unsafe-inline-demo.example"].each do |policy|
+        dets = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Security-Policy: #{policy}\r\n\r\n",
+          content_type: "text/html")
+        codes_of(dets).should_not contain("weak_csp"), policy
+      end
+    end
+  end
+
+  # …while the real keywords still fire, quoted (per spec) or bare (as seen in the wild).
+  it "flags the real keywords whether or not they are quoted" do
+    with_store do |store|
+      ["script-src 'self' 'unsafe-eval'", "script-src 'self' unsafe-eval",
+       "script-src 'self' 'unsafe-inline'", "script-src 'self' unsafe-inline"].each do |policy|
+        dets = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Security-Policy: #{policy}\r\n\r\n",
+          content_type: "text/html")
+        codes_of(dets).should contain("weak_csp"), policy
+      end
+      # An unquoted strict-dynamic must still nullify 'unsafe-inline', like the quoted form.
+      lenient = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Security-Policy: " \
+                                          "script-src 'self' strict-dynamic 'unsafe-inline'\r\n\r\n",
+        content_type: "text/html")
+      codes_of(lenient).should_not contain("weak_csp")
+    end
+  end
+
   it "rates a wildcard CORS with credentials Medium (the combination is browser-rejected, not High)" do
     with_store do |store|
       dets = analyze(store,
@@ -2455,14 +2486,59 @@ describe "Gori::Probe::Passive::BodyLeaks (client-side HTML sinks)" do
       codes_of(analyze_html(store, %(<a target="_blank" rel="noopener" href="http://x/">x</a>))).should_not contain("reverse_tabnabbing")
     end
   end
+
+  # ANCHOR_BLANK is /i, so it matches uppercase markup; the rel suppression must be too, or the
+  # very attribute that makes the tag safe goes unrecognised.
+  it "recognises rel=noopener/noreferrer regardless of case" do
+    with_store do |store|
+      [%(<a TARGET="_blank" REL="NOOPENER" href="/x">x</a>),
+       %(<a Target="_blank" Rel="NoReferrer" href="/x">x</a>),
+       %(<a target="_blank" rel="NOREFERRER NOOPENER" href="/x">x</a>)].each do |tag|
+        codes_of(analyze_html(store, tag)).should_not contain("reverse_tabnabbing"), tag
+      end
+    end
+  end
+
+  # Browsers have defaulted target=_blank to noopener since 2021, so this is markup hygiene,
+  # not a vulnerability — an external link is on nearly every page.
+  it "reports reverse-tabnabbing at Info, not Low" do
+    with_store do |store|
+      d = analyze_html(store, %(<a target="_blank" href="http://x/">x</a>))
+        .find(&.code.== "reverse_tabnabbing")
+      d.not_nil!.severity.should eq(Gori::Store::Severity::Info)
+    end
+  end
 end
 
 describe "Gori::Probe::Passive::Secrets (client-side shapes)" do
-  it "flags a JWT and a Slack webhook embedded in a JS bundle" do
+  it "flags a Slack webhook embedded in a JS bundle" do
     with_store do |store|
-      codes_of(analyze_js(store, "var t = '#{JWT}';")).should contain("secret_in_body")
       hook = "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
       codes_of(analyze_js(store, "var w = '#{hook}';")).should contain("secret_in_body")
+    end
+  end
+
+  # A JWT is the one shape in this family an app legitimately hands its own client, so it is
+  # NOT a High secret_in_body — it gets its own Info code (see Secrets::JWT).
+  it "reports a JWT as Info jwt_in_body, never as a High secret_in_body" do
+    with_store do |store|
+      dets = analyze_js(store, "var t = '#{JWT}';")
+      codes_of(dets).should_not contain("secret_in_body")
+      d = dets.find(&.code.== "jwt_in_body").not_nil!
+      d.severity.should eq(Gori::Store::Severity::Info)
+      d.category.should eq(Gori::Probe::Category::INFOLEAK)
+    end
+  end
+
+  # The High tier must still fire on the shapes a server has no business sending a browser,
+  # and a body carrying BOTH must report both — the JWT split must not swallow the real leak.
+  it "still reports a High secret_in_body alongside the JWT note" do
+    with_store do |store|
+      dets = analyze_js(store, "var k='AKIAIOSFODNN7EXAMPLE',t='#{JWT}';")
+      sec = dets.find(&.code.== "secret_in_body").not_nil!
+      sec.severity.should eq(Gori::Store::Severity::High)
+      sec.evidence.should eq("AWS access key id")
+      codes_of(dets).should contain("jwt_in_body")
     end
   end
 end

--- a/src/gori/probe/issue.cr
+++ b/src/gori/probe/issue.cr
@@ -89,6 +89,8 @@ module Gori
       "error_stack_leak"               => "Return generic errors to clients; log stack traces server-side only.",
       "secret_in_body"                 => "Rotate the exposed credential and remove it from the response; never ship keys/tokens to clients.",
       "secret_in_ws"                   => "Rotate the exposed credential and stop sending secrets over the WebSocket; treat frames like any other client-visible channel.",
+      "jwt_in_body"                    => "Informational: a JWT rides in this response body. Usually intended (a login/refresh response hands the client its own token), so this is a note on where tokens flow, not a leak. Worth a look only if the token is not the caller's — e.g. another user's token in a list payload, or a service token embedded in a page.",
+      "jwt_in_ws"                      => "Informational: a JWT rides in this WebSocket traffic. Usually intended (the socket authenticates with the session token), so this is a note on where tokens flow, not a leak. Worth a look only if the token is not the caller's.",
       "mixed_content"                  => "Load all sub-resources over HTTPS; active http:// scripts/iframes on an HTTPS page are blocked and insecure.",
       "insecure_form_action"           => "Point the form action at an HTTPS URL; a form submitting to http:// sends everything the user enters (credentials included) in cleartext.",
       "reflected_param"                => "Context-encode reflected input; this parameter echoes attacker-controlled data and may enable XSS.",
@@ -118,7 +120,7 @@ module Gori
       "document_domain_set"            => "Avoid assigning document.domain; it relaxes the same-origin policy for the whole page. Use postMessage (with an origin check) or CORS for cross-subdomain communication instead.",
       "inline_js_uri"                  => "Replace javascript: URLs in href/src/action with real handlers/URLs; they execute script in the page's origin and are blocked by a script-src CSP.",
       "mixed_passive"                  => "Load images/media over HTTPS; passive http:// sub-resources on an HTTPS page are tampered in transit and downgrade the page's security indicator.",
-      "reverse_tabnabbing"             => "Add rel=\"noopener\" (or noreferrer) to target=\"_blank\" links so the opened page can't repoint this tab via window.opener.",
+      "reverse_tabnabbing"             => "Informational: add rel=\"noopener\" (or noreferrer) to target=\"_blank\" links. Every current browser already applies noopener implicitly to target=\"_blank\" (Chrome 88, Firefox 79, Safari 12.1), so this does not reproduce on a modern browser — it is markup hygiene, and only matters for legacy embedded webviews.",
     } of String => String
 
     TECH_REMEDIATION = "Detected technology — informational; recorded as a project fact."

--- a/src/gori/probe/passive/body_leaks.cr
+++ b/src/gori/probe/passive/body_leaks.cr
@@ -87,6 +87,11 @@ module Gori
         INLINE_JS_URI = /(?<![-\w])(?:href|src|action|formaction)\s*=\s*["']?javascript:(?!\s*(?:void|;|"|'))/i
         # An <a target="_blank"> tag; reverse-tabnabbing risk unless it carries rel=noopener.
         ANCHOR_BLANK = /<a\b[^>]*(?<![-\w])target\s*=\s*["']?_blank\b[^>]*>/i
+        # The rel token that defuses it. Matched case-INSENSITIVELY: ANCHOR_BLANK is /i, so it
+        # happily matched `<a TARGET="_blank" REL="NOOPENER">`, and the suppression test was a
+        # case-SENSITIVE `includes?` that then failed to recognise the very rel that made the tag
+        # safe — a guaranteed false positive on any uppercase markup.
+        REL_NOOPENER = /\bno(?:opener|referrer)\b/i
 
         def check(ctx : Context, acc : Array(Detection)) : Nil
           return unless ctx.response
@@ -124,6 +129,10 @@ module Gori
           Secrets::PATTERNS.each do |(pat, label)|
             acc << leak(ctx, "secret_in_body", "Credential/secret disclosed in response body", Store::Severity::High, label) if pat.matches?(text)
           end
+          # A JWT is reported separately at Info, NOT as a High `secret_in_body`: shipping the
+          # client its own token is the normal design, not a disclosure (see Secrets::JWT).
+          acc << leak(ctx, "jwt_in_body", "JSON Web Token in a response body",
+            Store::Severity::Info, nil) if Secrets::JWT[0].matches?(text)
           check_html_sinks(ctx, acc, text) if ctx.html?
         end
 
@@ -154,12 +163,20 @@ module Gori
 
         # A target="_blank" anchor with no rel=noopener/noreferrer lets the opened page repoint
         # this tab via window.opener. Report once (grouped by code+host anyway).
+        #
+        # Info, not Low, and deliberately: every current browser has applied `noopener` implicitly
+        # to `target="_blank"` for years (Chrome 88, Firefox 79, Safari 12.1), so the attack this
+        # describes does not reproduce on anything a real user is running. What is left is a
+        # markup-hygiene note that matters only for legacy embedded webviews — and an external
+        # link is on nearly every page, so scoring it as a vulnerability buried the findings that
+        # are one. Kept rather than deleted because the note is still true, and Info is the tier
+        # this codebase already uses for it (mixed_passive, missing_referrer_policy).
         private def flag_reverse_tabnabbing(ctx : Context, acc : Array(Detection), text : String) : Nil
           text.scan(ANCHOR_BLANK) do |m|
             tag = m[0]
-            next if tag.includes?("noopener") || tag.includes?("noreferrer")
+            next if REL_NOOPENER.matches?(tag)
             acc << Detection.new("reverse_tabnabbing", Category::HEADERS, ctx.host, ctx.url,
-              "target=\"_blank\" link without rel=noopener", Store::Severity::Low, nil, ctx.fid)
+              "target=\"_blank\" link without rel=noopener", Store::Severity::Info, nil, ctx.fid)
             break
           end
         end

--- a/src/gori/probe/passive/secrets.cr
+++ b/src/gori/probe/passive/secrets.cr
@@ -4,6 +4,11 @@ module Gori
       # High-confidence credential shapes shared by body and WebSocket payload rules.
       # Evidence is always the credential TYPE label — NEVER the matched value.
       # {pattern, label}.
+      #
+      # Membership here means one thing: seeing this shape in a client-visible payload is a real
+      # disclosure, because the shape is NEVER legitimately handed to a browser. That is what
+      # earns the High severity. A shape an app routinely and correctly ships to its own client
+      # does not belong in this list however secret-looking it is — see JWT below.
       module Secrets
         PATTERNS = [
           {/\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/, "AWS access key id"},
@@ -22,10 +27,26 @@ module Gori
           {/\b(?:pk|sk)\.eyJ[\w\-]{20,}\.[\w\-]{20,}\b/, "Mapbox token"},
           {/\bhttps:\/\/hooks\.slack\.com\/services\/T[0-9A-Za-z]+\/B[0-9A-Za-z]+\/[0-9A-Za-z]{16,}/, "Slack webhook url"},
           {/\bSK[0-9a-f]{32}\b/, "Twilio api key"},
-          # A JSON Web Token embedded in a body. Each segment ≥10 chars keeps random dotted
-          # tokens out; the "eyJ" header prefix is the distinctive first-byte anchor.
-          {/\beyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\b/, "JSON Web Token"},
         ]
+
+        # A JSON Web Token, held OUT of PATTERNS on purpose.
+        #
+        # Every shape above is one a server has no business sending to a browser, so finding one
+        # is a disclosure. A JWT is the opposite: handing the client a token IS the design. A
+        # login response, a refresh call, an RSC payload, a WebSocket auth frame — all deliver a
+        # JWT over TLS to exactly the party it was minted for. Scoring that alongside a leaked AWS
+        # key meant the High tier fired on essentially every authenticated app, and a High that
+        # fires everywhere is a High nobody reads.
+        #
+        # It is still worth surfacing WHERE tokens flow, so the body/WebSocket rules report it as
+        # its own Info-severity code (`jwt_in_body` / `jwt_in_ws`) rather than dropping it. That
+        # also keeps it independently dismissible: muting routine token traffic on a host no
+        # longer mutes a genuine key leak on the same host.
+        #
+        # Each segment ≥10 chars keeps random dotted tokens out; "eyJ" (base64url for `{"`) is the
+        # distinctive first-byte anchor. Token weaknesses themselves (alg:none, missing exp, …)
+        # are the separate `jwt` rule, which decodes the tokens a flow AUTHENTICATES with.
+        JWT = {/\beyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\b/, "JSON Web Token"}
       end
     end
   end

--- a/src/gori/probe/passive/security_headers.cr
+++ b/src/gori/probe/passive/security_headers.cr
@@ -185,6 +185,18 @@ module Gori
         # lowercases, so the value's original case is irrelevant to this prefix test).
         SCRIPT_NONCE_HASH = /\A'(?:nonce|sha256|sha384|sha512)-/
 
+        # CSP source-list keywords, matched as WHOLE tokens. These used to be tested with
+        # `includes?`, which fires on any source that merely CONTAINS the word: a script-src of
+        # `https://unsafe-evaluation.example` read as 'unsafe-eval', and `https://cdn.x/unsafe-
+        # inline.js` read as 'unsafe-inline' — both scoring a safe policy as weak_csp. parse_csp
+        # splits on whitespace and downcases, so each source is already a clean lowercase token
+        # and an exact compare is both correct and cheaper. The unquoted spelling is accepted
+        # alongside the quoted one: browsers require the quotes, but policies in the wild omit
+        # them, and a policy that means 'unsafe-eval' should be judged as one either way.
+        UNSAFE_EVAL    = {"'unsafe-eval'", "unsafe-eval"}
+        UNSAFE_INLINE  = {"'unsafe-inline'", "unsafe-inline"}
+        STRICT_DYNAMIC = {"'strict-dynamic'", "strict-dynamic"}
+
         # Weak when the SCRIPT context (script-src, else the default-src fallback) is unsafe —
         # accounting for CSP Level 3 nullification so a modern, safe policy is NOT a false
         # positive:
@@ -204,10 +216,10 @@ module Gori
         private def weak_csp?(dirs : Hash(String, Array(String))) : Bool
           script = dirs["script-src"]? || dirs["default-src"]?
           return true if script.nil?
-          return true if script.any?(&.includes?("unsafe-eval"))
+          return true if script.any? { |s| UNSAFE_EVAL.includes?(s) }
           nonce_or_hash = script.any? { |s| SCRIPT_NONCE_HASH.matches?(s) }
-          strict_dynamic = script.includes?("'strict-dynamic'")
-          return true if !nonce_or_hash && !strict_dynamic && script.any?(&.includes?("unsafe-inline"))
+          strict_dynamic = script.any? { |s| STRICT_DYNAMIC.includes?(s) }
+          return true if !nonce_or_hash && !strict_dynamic && script.any? { |s| UNSAFE_INLINE.includes?(s) }
           return true if !strict_dynamic && script.any? { |s| s == "*" || s == "data:" || s == "http:" || s == "https:" }
           false
         end

--- a/src/gori/probe/passive/ws_payloads.cr
+++ b/src/gori/probe/passive/ws_payloads.cr
@@ -19,6 +19,7 @@ module Gori
         def check(ctx : Context, acc : Array(Detection)) : Nil
           return if ctx.ws_messages.empty?
           seen = Set(String).new # distinct type labels per flow (avoid ×N from echo/repeater)
+          jwt_seen = false
           ctx.ws_messages.each do |msg|
             next unless msg.text?
             text = payload_text(msg.payload)
@@ -30,6 +31,13 @@ module Gori
               acc << Detection.new("secret_in_ws", Category::INFOLEAK, ctx.host, ctx.url,
                 "Credential/secret disclosed in WebSocket message", Store::Severity::High,
                 label, ctx.fid)
+            end
+            # Reported apart from the High shapes above: a socket carrying the session token it
+            # was authenticated with is the normal design, not a leak (see Secrets::JWT).
+            if !jwt_seen && Secrets::JWT[0].matches?(text)
+              jwt_seen = true
+              acc << Detection.new("jwt_in_ws", Category::INFOLEAK, ctx.host, ctx.url,
+                "JSON Web Token in a WebSocket message", Store::Severity::Info, nil, ctx.fid)
             end
           end
         end


### PR DESCRIPTION
Three confirmed false positives from the Probe rule-set review. None change what the rules are for; each removes a way of firing that was never a finding.

## 1. A JWT in a response body is not a High "credential disclosed"

`Secrets::PATTERNS` is the High tier, and every other member is a shape a server has no business sending a browser — an AWS key, a private key block, a live Stripe key. A JWT is the opposite: **handing the client a token is the design.** A login response, a refresh call, an RSC payload, a WebSocket auth frame all deliver one over TLS to exactly the party it was minted for. Scoring that as High meant the top tier fired on essentially every authenticated app, and a High that fires everywhere is a High nobody reads.

Moved out of `PATTERNS` into `Secrets::JWT` and reported as its own **Info** code (`jwt_in_body` / `jwt_in_ws`) rather than dropped — where tokens flow is worth seeing. A separate code also keeps it independently dismissible: muting routine token traffic on a host no longer mutes a genuine key leak on the same host. A body carrying both still reports both.

## 2. `weak_csp?` read an allowlisted host as a keyword

The keyword tests were `includes?`, so any source merely *containing* the word matched:

| policy | was | is |
|---|---|---|
| `script-src https://unsafe-evaluation.example` | weak_csp | clean |
| `script-src https://cdn.x/unsafe-inline.js` | weak_csp | clean |

`parse_csp` already splits on whitespace and downcases, so each source is a clean lowercase token — an exact compare is correct *and* cheaper. The unquoted spelling is accepted alongside the quoted one: browsers require the quotes, policies in the wild omit them, and a policy that means `'unsafe-eval'` should be judged as one either way. `strict-dynamic` gets the same treatment, so an unquoted one still nullifies `'unsafe-inline'`.

## 3. `reverse_tabnabbing` could not see the rel that made the tag safe

`ANCHOR_BLANK` is `/i` and matched `<a TARGET="_blank" REL="NOOPENER">`, but the suppression was a case-**sensitive** `includes?("noopener")` — a guaranteed false positive on uppercase markup. Now a `/i` regex.

Also **Low → Info**. Every current browser has applied `noopener` implicitly to `target="_blank"` for years (Chrome 88, Firefox 79, Safari 12.1), so the attack does not reproduce on anything a real user runs; what is left is markup hygiene for legacy embedded webviews. An external link is on nearly every page, so scoring it as a vulnerability buried the findings that are one.

Kept rather than deleted because the note is still true, and Info is the tier this codebase already uses for exactly this (`mixed_passive`, `missing_referrer_policy`). Remediation text now says so instead of describing a live threat. **Happy to delete the rule outright instead if you'd rather** — it's a one-line revert either way.

## Verification

- `crystal spec` — **4754 examples, 0 failures** (+6 new regression specs)
- `crystal tool format --check` on all touched files — clean
- `crystal build --no-codegen src/main.cr` — clean
- ameba on the touched files: 1 warning, `security_headers.cr:124` `not_nil!` — pre-existing on `main`, untouched by this PR

New specs cover: uppercase `rel=`, the Info severity, both keyword-substring FPs, quoted **and** unquoted keyword forms, and a body carrying an AWS key *and* a JWT.

## Still open from the review

The active-rule FP items are not in this PR: the three "possible bypass" rules confirm against a captured baseline with no control re-send, and `backslash_powered` never checks that its baseline is stable. Those change request counts, so they're a separate change.