### PR TITLE
fix(probe): give the four differential active rules a control leg

### DIFF
--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -1548,7 +1548,7 @@ describe "Gori::Probe::Active::ForbiddenBypass" do
     end
   end
 
-  it "uses the wider bypass-header set under aggressive opts (still one request)" do
+  it "uses the wider bypass-header set under aggressive opts (still one probe + one control)" do
     with_store do |store|
       forbidden = capture_flow(store, "HTTP/1.1 403 Forbidden\r\n\r\n", target: "/admin", status: 403, content_type: nil)
       base = String.new(probe.plan(forbidden).not_nil!.request)
@@ -1558,8 +1558,8 @@ describe "Gori::Probe::Active::ForbiddenBypass" do
         base.should_not contain("\r\n#{name}: ")
         aggr.scan("\r\n#{name}: 127.0.0.1").size.should eq(1), "expected exactly one #{name} (aggressive)"
       end
-      # Still a single request (a wider header set, not more probes).
-      probe.plan(forbidden, Gori::Probe::Active::Options.new(aggressive: true)).not_nil!.followups.should be_empty
+      # A wider header SET, not more probes: still exactly one control follow-up.
+      probe.plan(forbidden, Gori::Probe::Active::Options.new(aggressive: true)).not_nil!.followups.size.should eq(1)
     end
   end
 
@@ -1589,27 +1589,56 @@ describe "Gori::Probe::Active::ForbiddenBypass" do
     end
   end
 
-  it "flags a possible bypass (Medium) only when the denied response flips to 2xx" do
+  it "flags a possible bypass (Medium) only when the probe flips to 2xx and the control still denies" do
     with_store do |store|
       forbidden = capture_flow(store, "HTTP/1.1 403 Forbidden\r\n\r\n", target: "/admin", status: 403, content_type: nil)
       plan = probe.plan(forbidden).not_nil!
+      ok = Gori::Repeater::Result.new("HTTP/1.1 200 OK\r\n\r\n".to_slice, Bytes.empty, nil, 1_i64)
+      denied = Gori::Repeater::Result.new("HTTP/1.1 403 Forbidden\r\n\r\n".to_slice, Bytes.empty, nil, 1_i64)
 
-      bypassed = Gori::Repeater::Result.new("HTTP/1.1 200 OK\r\n\r\n".to_slice, Bytes.empty, nil, 1_i64)
-      dets = probe.detections(plan, bypassed, forbidden)
+      dets = probe.detections_all(plan, [ok, denied], forbidden)
       dets.size.should eq(1)
       dets.first.code.should eq("forbidden_bypass")
-      # Single-shot flip vs the captured baseline (no control re-send) → Medium "possible", not High.
+      # Two adjacent requests can't rule out disagreeing backends → Medium "possible", not High.
       dets.first.severity.should eq(Gori::Store::Severity::Medium)
+      dets.first.evidence.not_nil!.should contain("control without the headers still 403")
 
-      # Still denied → the gate held → not flagged.
-      still_denied = Gori::Repeater::Result.new("HTTP/1.1 403 Forbidden\r\n\r\n".to_slice, Bytes.empty, nil, 1_i64)
-      probe.detections(plan, still_denied, forbidden).should be_empty
+      # Still denied WITH the headers → the gate held → not flagged.
+      probe.detections_all(plan, [denied, denied], forbidden).should be_empty
       # A redirect (e.g. to login) is ambiguous → not flagged.
       redirect = Gori::Repeater::Result.new("HTTP/1.1 302 Found\r\nLocation: /login\r\n\r\n".to_slice, Bytes.empty, nil, 1_i64)
-      probe.detections(plan, redirect, forbidden).should be_empty
+      probe.detections_all(plan, [redirect, denied], forbidden).should be_empty
       # A send failure never flags.
       errored = Gori::Repeater::Result.new(Bytes.empty, nil, nil, 1_i64, "connection refused")
-      probe.detections(plan, errored, forbidden).should be_empty
+      probe.detections_all(plan, [errored, denied], forbidden).should be_empty
+    end
+  end
+
+  # The control leg is the point of the rule: a 403 that had already cleared on its own answers
+  # 2xx WITHOUT the spoofed headers too, and must not be reported as a header-driven bypass.
+  it "does not flag when the control also succeeds (the gate simply opened)" do
+    with_store do |store|
+      forbidden = capture_flow(store, "HTTP/1.1 403 Forbidden\r\n\r\n", target: "/admin", status: 403, content_type: nil)
+      plan = probe.plan(forbidden).not_nil!
+      ok = Gori::Repeater::Result.new("HTTP/1.1 200 OK\r\n\r\n".to_slice, Bytes.empty, nil, 1_i64)
+      probe.detections_all(plan, [ok, ok], forbidden).should be_empty
+      # A missing or errored control is no attribution either — never fall back to the captured status.
+      probe.detections_all(plan, [ok], forbidden).should be_empty
+      errored = Gori::Repeater::Result.new(Bytes.empty, nil, nil, 1_i64, "connection refused")
+      probe.detections_all(plan, [ok, errored], forbidden).should be_empty
+    end
+  end
+
+  # The two legs must differ in exactly one thing: our forged values. Both drop whatever the
+  # browser sent, so a difference can never come from the browser's own X-Forwarded-For.
+  it "builds a control that is the same request WITHOUT the spoofed headers" do
+    with_store do |store|
+      forbidden = capture_flow(store, "HTTP/1.1 403 Forbidden\r\n\r\n", target: "/admin", status: 403,
+        req_headers: "X-Forwarded-For: 9.9.9.9\r\n", content_type: nil)
+      control = String.new(probe.plan(forbidden).not_nil!.followups.first)
+      control.should start_with("GET /admin ")
+      control.should_not contain("127.0.0.1") # none of our forged values
+      control.should_not contain("9.9.9.9")   # nor the browser's own, dropped on both legs
     end
   end
 
@@ -2559,13 +2588,19 @@ describe "Gori::Probe::Active (manual run estimate)" do
       r = rule.requests_per_flow
       r.begin.should be >= 1
       r.end.should be >= r.begin
-      r.end.should be <= 7 # nothing floods a single flow with probes
+      r.end.should be <= 8 # nothing floods a single flow with probes
     end
-    # BackslashPowered is the only DIFFERENTIAL (multi-probe) rule: a baseline plus a `\`/`\\`
-    # pair per param, capped at 3 params (3..7). Every other built-in sends exactly one request.
     by_id = Gori::Probe::Active::RULES.to_h { |rule| {rule.info.id, rule.requests_per_flow} }
-    by_id["backslash_powered"].should eq(3..7)
-    ["reflected_param", "cors_reflection", "forbidden_bypass"].each { |id| by_id[id].should eq(1..1) }
+    # BackslashPowered: TWO baselines (the second proves the endpoint is stable enough to diff
+    # against) plus a `\`/`\\` pair per param, capped at 3 params → 4..8.
+    by_id["backslash_powered"].should eq(4..8)
+    # The bypass family each carry a control leg, so none of them is a single request:
+    # forbidden_bypass probe+control, url_rewrite_bypass probe+control+control2,
+    # path_normalization_bypass 5-6 variants + the canonical-path control.
+    by_id["forbidden_bypass"].should eq(2..2)
+    by_id["url_rewrite_bypass"].should eq(3..3)
+    by_id["path_normalization_bypass"].should eq(6..7)
+    ["reflected_param", "cors_reflection"].each { |id| by_id[id].should eq(1..1) }
   end
 
   it "estimate_label renders a fixed count and a range" do
@@ -2584,8 +2619,8 @@ describe "Gori::Probe::Active (manual run estimate)" do
       # reflected_param, cors_reflection, backslash_powered all apply — plus crlf_injection and ssti,
       # which reuse the same reflectable-query-param gate.
       est.map(&.info.id).sort.should eq(["backslash_powered", "cors_reflection", "crlf_injection", "reflected_param", "ssti"])
-      # reflected_param (1) + cors_reflection (1) + backslash_powered (≤7) + crlf_injection (1) + ssti (2) = 12
-      est.sum { |e| e.requests.end }.should eq(12)
+      # reflected_param (1) + cors_reflection (1) + backslash_powered (≤8) + crlf_injection (1) + ssti (2) = 13
+      est.sum { |e| e.requests.end }.should eq(13)
     end
   end
 
@@ -2655,10 +2690,11 @@ describe "Gori::Probe::Active::BackslashPowered" do
       detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=hi")
       plan = probe.plan(detail).not_nil!
       plan.params.map(&.name).should eq(["q"])
-      plan.followups.size.should eq(2)
+      plan.followups.size.should eq(3)
       String.new(plan.request).should contain("/s?q=hi ")         # baseline: value unchanged
-      String.new(plan.followups[0]).should contain("q=hi%5C ")    # single: value\
-      String.new(plan.followups[1]).should contain("q=hi%5C%5C ") # double: value\\
+      String.new(plan.followups[0]).should contain("/s?q=hi ")    # baseline again (stability check)
+      String.new(plan.followups[1]).should contain("q=hi%5C ")    # single: value\
+      String.new(plan.followups[2]).should contain("q=hi%5C%5C ") # double: value\\
     end
   end
 
@@ -2667,7 +2703,7 @@ describe "Gori::Probe::Active::BackslashPowered" do
       detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?a=1&b=2&c=3&d=4")
       plan = probe.plan(detail).not_nil!
       plan.params.map(&.name).should eq(["a", "b", "c"])
-      plan.followups.size.should eq(6)                               # 2 per probed param
+      plan.followups.size.should eq(7)                               # 2nd baseline + 2 per probed param
       String.new(plan.request).should contain("/s?a=1&b=2&c=3&d=4 ") # every param kept in the baseline
     end
   end
@@ -2718,7 +2754,8 @@ describe "Gori::Probe::Active::BackslashPowered" do
     with_store do |store|
       detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=hi")
       plan = probe.plan(detail).not_nil!
-      dets = probe.detections_all(plan, [resp.call(200, ""), resp.call(500, ""), resp.call(200, "")], detail)
+      dets = probe.detections_all(plan,
+        [resp.call(200, ""), resp.call(200, ""), resp.call(500, ""), resp.call(200, "")], detail)
       dets.size.should eq(1)
       dets.first.code.should eq("backslash_powered")
       dets.first.category.should eq(Gori::Probe::Category::ACTIVE)
@@ -2731,7 +2768,8 @@ describe "Gori::Probe::Active::BackslashPowered" do
     with_store do |store|
       detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=hi")
       plan = probe.plan(detail).not_nil!
-      results = [resp.call(200, "welcome"), resp.call(200, "You have an error in your SQL syntax"), resp.call(200, "welcome")]
+      results = [resp.call(200, "welcome"), resp.call(200, "welcome"),
+                 resp.call(200, "You have an error in your SQL syntax"), resp.call(200, "welcome")]
       dets = probe.detections_all(plan, results, detail)
       dets.size.should eq(1)
       dets.first.evidence.not_nil!.downcase.should contain("sql")
@@ -2742,7 +2780,8 @@ describe "Gori::Probe::Active::BackslashPowered" do
     with_store do |store|
       detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=hi")
       plan = probe.plan(detail).not_nil!
-      probe.detections_all(plan, [resp.call(200, ""), resp.call(500, ""), resp.call(500, "")], detail).should be_empty
+      probe.detections_all(plan,
+        [resp.call(200, ""), resp.call(200, ""), resp.call(500, ""), resp.call(500, "")], detail).should be_empty
     end
   end
 
@@ -2750,7 +2789,8 @@ describe "Gori::Probe::Active::BackslashPowered" do
     with_store do |store|
       detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=hi")
       plan = probe.plan(detail).not_nil!
-      probe.detections_all(plan, [resp.call(200, ""), resp.call(200, ""), resp.call(200, "")], detail).should be_empty
+      probe.detections_all(plan,
+        [resp.call(200, ""), resp.call(200, ""), resp.call(200, ""), resp.call(200, "")], detail).should be_empty
     end
   end
 
@@ -2759,7 +2799,8 @@ describe "Gori::Probe::Active::BackslashPowered" do
       detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=hi")
       plan = probe.plan(detail).not_nil!
       errored = Gori::Repeater::Result.new(Bytes.empty, nil, nil, 1_i64, "connection refused")
-      probe.detections_all(plan, [resp.call(200, ""), errored, resp.call(200, "")], detail).should be_empty
+      probe.detections_all(plan,
+        [resp.call(200, ""), resp.call(200, ""), errored, resp.call(200, "")], detail).should be_empty
     end
   end
 
@@ -2767,13 +2808,42 @@ describe "Gori::Probe::Active::BackslashPowered" do
     with_store do |store|
       detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?a=1&b=2")
       plan = probe.plan(detail).not_nil!
-      # baseline, a\, a\\, b\, b\\  — only `a` shows the escape asymmetry
-      results = [resp.call(200, ""), resp.call(500, ""), resp.call(200, ""), resp.call(200, ""), resp.call(200, "")]
+      # baseline, baseline2, a\, a\\, b\, b\\  — only `a` shows the escape asymmetry
+      results = [resp.call(200, ""), resp.call(200, ""),
+                 resp.call(500, ""), resp.call(200, ""), resp.call(200, ""), resp.call(200, "")]
       dets = probe.detections_all(plan, results, detail)
       dets.size.should eq(1)
       ev = dets.first.evidence.not_nil!
       ev.should contain("a")
       ev.should_not contain("b")
+    end
+  end
+
+  # The whole rule is a difference test against the baseline, which assumes the endpoint answers
+  # the same request the same way twice. When it does not, an asymmetry carries no information.
+  it "declines when the two baselines disagree (endpoint is not stable enough to diff)" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=hi")
+      plan = probe.plan(detail).not_nil!
+      # Exactly the asymmetry the rule reports — but the endpoint already contradicted itself
+      # on two identical requests, so the `\` leg's 500 proves nothing.
+      probe.detections_all(plan,
+        [resp.call(200, ""), resp.call(503, ""), resp.call(500, ""), resp.call(200, "")], detail).should be_empty
+      # An error signature that appears on only one baseline is the same problem.
+      probe.detections_all(plan,
+        [resp.call(200, "welcome"), resp.call(200, "You have an error in your SQL syntax"),
+         resp.call(500, ""), resp.call(200, "welcome")], detail).should be_empty
+    end
+  end
+
+  it "declines when the second baseline is missing or failed to send" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=hi")
+      plan = probe.plan(detail).not_nil!
+      errored = Gori::Repeater::Result.new(Bytes.empty, nil, nil, 1_i64, "connection refused")
+      probe.detections_all(plan, [resp.call(200, "")], detail).should be_empty
+      probe.detections_all(plan,
+        [resp.call(200, ""), errored, resp.call(500, ""), resp.call(200, "")], detail).should be_empty
     end
   end
 end
@@ -3258,7 +3328,9 @@ describe "Gori::Probe::Active::PathNormalizationBypass" do
       detail = capture_flow(store, "HTTP/1.1 403 Forbidden\r\n\r\n", target: "/admin", status: 403)
       plan = probe.plan(detail).not_nil!
       plan.params.size.should eq(5)
-      plan.followups.size.should eq(4)
+      plan.followups.size.should eq(5) # 4 remaining variants + the canonical-path control
+      # The control is LAST and asks for the canonical path verbatim.
+      String.new(plan.followups.last).should contain("GET /admin ")
       String.new(plan.request).should contain("/admin/..;/admin ")
       # None of the variants collapse to the bare `/admin/` (a known false-positive vector).
       plan.params.map(&.name).should_not contain("double-slash")
@@ -3272,13 +3344,30 @@ describe "Gori::Probe::Active::PathNormalizationBypass" do
     with_store do |store|
       detail = capture_flow(store, "HTTP/1.1 403 Forbidden\r\n\r\n", target: "/admin", status: 403)
       plan = probe.plan(detail).not_nil!
-      # Variant index 1 is `leading-dot-slash`.
-      results = [resp.call(403), resp.call(200), resp.call(403), resp.call(403), resp.call(403)]
+      # Variant index 1 is `leading-dot-slash`; the last entry is the canonical-path control.
+      results = [resp.call(403), resp.call(200), resp.call(403), resp.call(403), resp.call(403), resp.call(403)]
       dets = probe.detections_all(plan, results, detail)
       dets.size.should eq(1)
       dets.first.code.should eq("path_normalization_bypass")
       dets.first.severity.should eq(Gori::Store::Severity::Medium)
       dets.first.evidence.not_nil!.should contain("leading-dot-slash")
+      dets.first.evidence.not_nil!.should contain("canonical path still denied")
+    end
+  end
+
+  # Without the control, a 403 that cleared on its own made EVERY variant look like a bypass.
+  it "does not fire when the canonical path is served too (the gate simply opened)" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 403 Forbidden\r\n\r\n", target: "/admin", status: 403)
+      plan = probe.plan(detail).not_nil!
+      all_open = [resp.call(200), resp.call(200), resp.call(200), resp.call(200), resp.call(200), resp.call(200)]
+      probe.detections_all(plan, all_open, detail).should be_empty
+      # A missing or errored control is no attribution either.
+      probe.detections_all(plan, [resp.call(403), resp.call(200), resp.call(403), resp.call(403), resp.call(403)],
+        detail).should be_empty
+      errored = Gori::Repeater::Result.new(Bytes.empty, nil, nil, 1_i64, "connection refused")
+      probe.detections_all(plan, [resp.call(403), resp.call(200), resp.call(403), resp.call(403), resp.call(403), errored],
+        detail).should be_empty
     end
   end
 
@@ -3286,8 +3375,8 @@ describe "Gori::Probe::Active::PathNormalizationBypass" do
     with_store do |store|
       detail = capture_flow(store, "HTTP/1.1 403 Forbidden\r\n\r\n", target: "/admin", status: 403)
       plan = probe.plan(detail).not_nil!
-      probe.detections_all(plan, Array.new(5) { resp.call(403) }, detail).should be_empty
-      redir = [resp.call(302), resp.call(403), resp.call(403), resp.call(403), resp.call(403)]
+      probe.detections_all(plan, Array.new(6) { resp.call(403) }, detail).should be_empty
+      redir = [resp.call(302), resp.call(403), resp.call(403), resp.call(403), resp.call(403), resp.call(403)]
       probe.detections_all(plan, redir, detail).should be_empty
     end
   end
@@ -3406,8 +3495,9 @@ describe "Gori::Probe::Active::UrlRewriteBypass" do
       req.should contain("GET / ")
       req.should contain("X-Original-URL: /admin")
       req.should contain("X-Rewrite-URL: /admin")
-      plan.followups.size.should eq(1)
-      String.new(plan.followups[0]).should_not contain("X-Original-URL")
+      plan.followups.size.should eq(2) # control + a second control (root-stability check)
+      plan.followups.each { |f| String.new(f).should_not contain("X-Original-URL") }
+      String.new(plan.followups[0]).should eq(String.new(plan.followups[1]))
     end
   end
 
@@ -3415,10 +3505,31 @@ describe "Gori::Probe::Active::UrlRewriteBypass" do
     with_store do |store|
       detail = capture_flow(store, "HTTP/1.1 403 F\r\n\r\n", target: "/admin", status: 403)
       plan = probe.plan(detail).not_nil!
-      dets = probe.detections_all(plan, [resp.call(200, "ADMINPAGE"), resp.call(404, "nf")], detail)
+      dets = probe.detections_all(plan,
+        [resp.call(200, "ADMINPAGE"), resp.call(404, "nf"), resp.call(404, "nf")], detail)
       dets.size.should eq(1)
       dets.first.code.should eq("url_rewrite_bypass")
       dets.first.severity.should eq(Gori::Store::Severity::Medium)
+    end
+  end
+
+  # The finding rests entirely on "probe differs from root". A root whose body length moves
+  # between requests (a varying CSRF token, a timestamp) made EVERY 401/403/404 path differ.
+  it "declines when the two root controls disagree (root is not stable enough to diff)" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 403 F\r\n\r\n", target: "/admin", status: 403)
+      plan = probe.plan(detail).not_nil!
+      # Same status, body length jitters by one byte between the two identical root requests.
+      probe.detections_all(plan,
+        [resp.call(200, "ADMINPAGE"), resp.call(200, "HOME"), resp.call(200, "HOME2")], detail).should be_empty
+      # A status that flaps is the same problem.
+      probe.detections_all(plan,
+        [resp.call(200, "ADMINPAGE"), resp.call(200, "HOME"), resp.call(503, "HOME")], detail).should be_empty
+      # A missing or errored second control means the stability question was never answered.
+      probe.detections_all(plan, [resp.call(200, "ADMINPAGE"), resp.call(404, "nf")], detail).should be_empty
+      errored = Gori::Repeater::Result.new(Bytes.empty, nil, nil, 1_i64, "connection refused")
+      probe.detections_all(plan,
+        [resp.call(200, "ADMINPAGE"), resp.call(404, "nf"), errored], detail).should be_empty
     end
   end
 
@@ -3426,8 +3537,10 @@ describe "Gori::Probe::Active::UrlRewriteBypass" do
     with_store do |store|
       detail = capture_flow(store, "HTTP/1.1 403 F\r\n\r\n", target: "/admin", status: 403)
       plan = probe.plan(detail).not_nil!
-      probe.detections_all(plan, [resp.call(200, "HOME"), resp.call(200, "HOME")], detail).should be_empty
-      probe.detections_all(plan, [resp.call(403, "denied"), resp.call(200, "HOME")], detail).should be_empty
+      probe.detections_all(plan,
+        [resp.call(200, "HOME"), resp.call(200, "HOME"), resp.call(200, "HOME")], detail).should be_empty
+      probe.detections_all(plan,
+        [resp.call(403, "denied"), resp.call(200, "HOME"), resp.call(200, "HOME")], detail).should be_empty
     end
   end
 

--- a/src/gori/probe/active.cr
+++ b/src/gori/probe/active.cr
@@ -54,7 +54,7 @@ module Gori
       end
 
       # Compact per-flow request-count label for the Rules sub-tab + manual-run estimate:
-      # "1 req/flow" for the fixed-cost rules, "3–7 req/flow" for the differential BackslashPowered.
+      # "1 req/flow" for the fixed-cost rules, "4–8 req/flow" for the differential BackslashPowered.
       def self.estimate_label(rng : Range(Int32, Int32)) : String
         rng.begin == rng.end ? "#{rng.begin} req/flow" : "#{rng.begin}–#{rng.end} req/flow"
       end

--- a/src/gori/probe/active/backslash_powered.cr
+++ b/src/gori/probe/active/backslash_powered.cr
@@ -26,9 +26,15 @@ module Gori
       # cleanly. So the tell is an ASYMMETRY: `single` differs from `baseline` while `double` matches
       # it. That asymmetry — not any single error string — is what flags a probable injection surface.
       #
-      # This is the active scanner's first DIFFERENTIAL (multi-probe) rule: `plan` builds a baseline
-      # plus a `\`/`\\` pair per param into `Plan.followups`, the analyzer sends them all, and
-      # `detections_all` compares the responses. The differential compares BODIES, so HEAD is always
+      # The comparison assumes the endpoint answers the same request the same way twice, so it sends
+      # the baseline TWICE and reports nothing unless the two agree: on an endpoint that varies on
+      # its own (an intermittent 503, a rate limiter, a rotating backend) noise landing on a `\` leg
+      # but not its `\\` leg reproduces this exact asymmetry, once per probed param. Measuring the
+      # endpoint against itself turns "we cannot tell" into a decline instead of a finding.
+      #
+      # This is the active scanner's first DIFFERENTIAL (multi-probe) rule: `plan` builds two
+      # baselines plus a `\`/`\\` pair per param into `Plan.followups`, the analyzer sends them all,
+      # and `detections_all` compares the responses. The differential compares BODIES, so HEAD is always
       # out; by default GET only (POST/PUT/… are never auto-probed — they mutate state), but an
       # explicit opt-in (Options#allow_unsafe: the manual per-flow scan or AGGRESSIVE mode) widens
       # it to any body-bearing method. Capped at MAX_PROBE_PARAMS params (raised under AGGRESSIVE)
@@ -51,11 +57,11 @@ module Gori
             Category::ACTIVE)
         end
 
-        # baseline + a (`\`, `\\`) pair per probed param: 1 param → 3 requests, MAX_PROBE_PARAMS → 7.
-        # Static annotation for the Rules sub-tab + the manual-run estimate (the analyzer sends the
-        # exact count for the flow at hand).
+        # TWO baselines + a (`\`, `\\`) pair per probed param: 1 param → 4 requests,
+        # MAX_PROBE_PARAMS → 8. Static annotation for the Rules sub-tab + the manual-run estimate
+        # (the analyzer sends the exact count for the flow at hand).
         def requests_per_flow : Range(Int32, Int32)
-          3..(1 + 2 * MAX_PROBE_PARAMS)
+          4..(2 + 2 * MAX_PROBE_PARAMS)
         end
 
         # Dedup key WITHOUT rebuilding probes — derived from the same `injectables` gate `plan` uses,
@@ -74,7 +80,14 @@ module Gori
           method_up, path, pairs, probe = g
           body = detail.request_body
           baseline = rebuild_query(detail.request_head, body, path, pairs.join('&'))
-          followups = [] of Bytes
+          # A SECOND, identical baseline, sent first among the follow-ups. The whole rule is a
+          # difference test against the baseline fingerprint, which silently assumed the endpoint
+          # answers the same request the same way twice. When it does not — an intermittent 503, a
+          # rate limiter kicking in, a health-checked backend rotating — noise that happens to land
+          # on a `\` leg and not its `\\` leg reproduces the exact asymmetry this rule reports, and
+          # every param gets its own roll of that die. Measuring the endpoint against itself costs
+          # one request and turns "we cannot tell" into a decline instead of a finding.
+          followups = [rebuild_query(detail.request_head, body, path, pairs.join('&'))]
           params = [] of Param
           probe.each do |idx|
             pair = pairs[idx]
@@ -82,7 +95,8 @@ module Gori
             name = pair[0...eq]
             value = pair[(eq + 1)..]
             # Order matters: single (`\`) then double (`\\`) — detections_all reads them back at
-            # results[1 + 2*i] / results[2 + 2*i] for the i-th param.
+            # results[2 + 2*i] / results[3 + 2*i] for the i-th param (results[0] and results[1]
+            # are the two baselines).
             followups << rebuild_query(detail.request_head, body, path, with_value(pairs, idx, name, value + SINGLE))
             followups << rebuild_query(detail.request_head, body, path, with_value(pairs, idx, name, value + DOUBLE))
             params << Param.new("query", decode_name(name), value)
@@ -94,14 +108,13 @@ module Gori
         # Compare the responses: for each probed param, fire when the lone `\` changed the response
         # (status or a surfaced interpreter error) AND the doubled `\\` reverted to baseline. One
         # grouped Detection per host, listing the affected params.
+        # results = [baseline, baseline2, single_0, double_0, single_1, double_1, …].
         def detections_all(plan : Plan, results : Array(Repeater::Result), detail : Store::FlowDetail) : Array(Detection)
-          baseline = results.first?
-          return [] of Detection unless baseline && baseline.ok?
-          base = attrs(baseline)
+          base = stable_baseline(results) || return [] of Detection
           hits = [] of String
           plan.params.each_with_index do |param, i|
-            single = results[1 + 2 * i]?
-            double = results[2 + 2 * i]?
+            single = results[2 + 2 * i]?
+            double = results[3 + 2 * i]?
             next unless single && double
             next unless single.ok? && double.ok? # a failed leg ⇒ incomplete comparison, skip
             sa = attrs(single)
@@ -174,6 +187,19 @@ module Gori
           dup = pairs.dup
           dup[idx] = "#{name}=#{value}"
           dup.join('&')
+        end
+
+        # The baseline fingerprint — but only when the endpoint reproduced it on a SECOND identical
+        # request (results[0] and results[1]). nil when either baseline is missing or failed to
+        # send, or when the two disagree: an endpoint whose answer to one request varies on its own
+        # cannot support a difference test, so every asymmetry below would be a coin flip. Returning
+        # nil makes the rule decline rather than guess.
+        private def stable_baseline(results : Array(Repeater::Result)) : {Int32, String?}?
+          first = results[0]?
+          second = results[1]?
+          return nil unless first && first.ok? && second && second.ok?
+          base = attrs(first)
+          attrs(second) == base ? base : nil
         end
 
         # A comparable response fingerprint: status code + a coarse interpreter-error class (nil when

--- a/src/gori/probe/active/forbidden_bypass.cr
+++ b/src/gori/probe/active/forbidden_bypass.cr
@@ -11,14 +11,21 @@ module Gori
       # tell such a control apart from any other 403/401; re-sending the SAME request with a
       # spoofed loopback IP in those headers surfaces a candidate header-controllable gate.
       #
-      # For one in-scope flow whose captured response was 401/403, it re-sends ONE request with the
-      # full IP-spoofing header set (all 127.0.0.1) and flags a Medium "possible bypass" when the
-      # response flips to 2xx. It is a single-shot probe against the CAPTURED baseline (no control
-      # re-send without the headers), so a transient/rate-limited 403 that later clears can also
-      # flip — hence "possible", to be confirmed by re-sending without the headers. Gated to
-      # safe methods (GET/HEAD) so an automatic probe never mutates server state, and to originally-
-      # denied responses so a normally-200 endpoint is never probed. A control that correctly keys
-      # on the socket peer ignores the headers and still returns 401/403, so it is never flagged.
+      # For one in-scope flow whose captured response was 401/403, it sends TWO requests:
+      #   probe   = the same request + the full IP-spoofing header set (all 127.0.0.1)
+      #   control = the same request, UNCHANGED
+      # and flags a Medium "possible bypass" only when the probe is 2xx AND the control is still
+      # denied. The control is what makes the finding attributable: comparing against the CAPTURED
+      # status alone could not tell "the headers opened the gate" from "the 403 was transient and
+      # had already cleared by the time we probed" — a rate-limited or flapping endpoint produced a
+      # bypass finding with no bypass. The control is sent AFTER the probe, so a 403 that cleared on
+      # its own answers 2xx there too and the finding is suppressed.
+      #
+      # Still Medium, not High: two adjacent requests cannot rule out a load balancer whose backends
+      # disagree, so this remains a lead to confirm — just no longer one that fires on ordinary
+      # flapping. Gated to safe methods (GET/HEAD) so an automatic probe never mutates server state,
+      # and to originally-denied responses so a normally-200 endpoint is never probed. A control
+      # that correctly keys on the socket peer ignores the headers and still returns 401/403.
       #
       # Header set + loopback value follow https://www.hahwul.com/blog/2021/bypass-403/.
       class ForbiddenBypass < Rule
@@ -88,31 +95,55 @@ module Gori
           key_string(detail, method.upcase, target)
         end
 
+        # probe (spoofed headers) + control (the request UNCHANGED).
+        def requests_per_flow : Range(Int32, Int32)
+          2..2
+        end
+
         def plan(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : Plan?
           req = Proxy::Codec::Http1.parse_request_head(detail.request_head)
           return nil if req.malformed?
           return nil unless method_allowed?(req.method.upcase, opts)
           return nil unless denied_status?(detail.row.status)
           request = rebuild_with_bypass_headers(detail.request_head, detail.request_body, opts.aggressive)
-          Plan.new(request, [] of Param, key_string(detail, req.method.upcase, req.target))
+          # The control carries NO spoofing headers — but is otherwise rebuilt through the same
+          # path (origin-form request line, browser-sent copies of those headers dropped), so the
+          # two legs differ in exactly one thing: whether our forged values are present.
+          control = rebuild_with_bypass_headers(detail.request_head, detail.request_body,
+            opts.aggressive, insert: false)
+          Plan.new(request, [] of Param, key_string(detail, req.method.upcase, req.target), [control])
         end
 
-        def detections(plan : Plan, result : Repeater::Result, detail : Store::FlowDetail) : Array(Detection)
-          return [] of Detection unless result.ok?
-          status = probe_status(result)
-          # Only a flip INTO 2xx is a confirmed bypass. A 3xx (login redirect) or another 4xx is
+        # results = [probe, control]. Flag only when the spoofed request succeeded AND the control
+        # — the same request without the headers, sent right after — is still denied.
+        def detections_all(plan : Plan, results : Array(Repeater::Result), detail : Store::FlowDetail) : Array(Detection)
+          probe = results[0]?
+          return [] of Detection unless probe && probe.ok?
+          status = probe_status(probe)
+          # Only a flip INTO 2xx is a candidate bypass. A 3xx (login redirect) or another 4xx is
           # ambiguous and would inflate false positives, so it is intentionally not flagged.
           return [] of Detection unless (200..299).includes?(status)
+          control = results[1]?
+          # No usable control ⇒ no attribution. Refuse rather than fall back to the captured
+          # status: that fallback IS the false positive this leg exists to remove.
+          return [] of Detection unless control && control.ok?
+          control_status = probe_status(control)
+          # The control succeeded too ⇒ the resource is simply open now (a transient/rate-limited
+          # 403 that cleared), and the headers proved nothing.
+          return [] of Detection unless denied_status?(control_status)
           orig = detail.row.status
-          # A single-shot flip against the CAPTURED baseline (no control re-send without the
-          # headers at probe time) can't prove the header caused it — a transient/rate-limited
-          # 403 that later clears looks identical. Report it as a Medium "possible" lead, not a
-          # confirmed High bypass, so a naturally-varying 403 doesn't produce a false High.
           [Detection.new("forbidden_bypass", Category::ACTIVE, detail.row.host, detail.row.url,
             "Possible access-control bypass via spoofed client-IP header", Store::Severity::Medium,
-            "#{orig} → #{status} with X-Forwarded-For/X-Real-IP=#{BYPASS_VALUE} (single-shot; confirm by re-sending WITHOUT the headers)", detail.row.id)]
+            "#{orig} → #{status} with X-Forwarded-For/X-Real-IP=#{BYPASS_VALUE}; control without the headers still #{control_status}"[0, 120], detail.row.id)]
         rescue
           [] of Detection
+        end
+
+        # Single-response fallback (module facade / a one-shot caller): the control leg is what
+        # makes this rule's finding attributable, so one response alone yields nothing. The
+        # analyzer always calls detections_all with the full set.
+        def detections(plan : Plan, result : Repeater::Result, detail : Store::FlowDetail) : Array(Detection)
+          detections_all(plan, [result], detail)
         end
 
         # Only responses that DENIED access are worth probing: a normally-served (2xx) endpoint has
@@ -148,7 +179,14 @@ module Gori
         # line: first drop any of those headers the browser already sent (so exactly one authoritative
         # copy of each remains), then insert ours. The body is untouched — none of the inserted names
         # is Content-Length — so no resync is needed. `aggressive` selects the wider header set.
-        private def rebuild_with_bypass_headers(head : Bytes, body : Bytes?, aggressive : Bool) : Bytes
+        #
+        # `insert: false` builds the CONTROL: the same rebuild — same dropped headers, same
+        # origin-form request line — but without our forged values, so the only difference between
+        # the two legs is the thing under test. Dropping the browser's own copies on the control
+        # too is deliberate: if the browser sent an X-Forwarded-For and we kept it only there, a
+        # difference between the legs could come from ITS value rather than ours.
+        private def rebuild_with_bypass_headers(head : Bytes, body : Bytes?, aggressive : Bool,
+                                                insert : Bool = true) : Bytes
           headers = aggressive ? BYPASS_HEADERS_AGGRESSIVE : BYPASS_HEADERS
           drop_set = aggressive ? BYPASS_HEADER_SET_AGGRESSIVE : BYPASS_HEADER_SET
           combined = if body && !body.empty?
@@ -173,7 +211,7 @@ module Gori
           unless kept.empty?
             rl = kept[0].split(' ')
             kept[0] = "#{rl[0]} #{Active.origin_form(rl[1])} #{rl[2]}" if rl.size == 3
-            headers.each_with_index { |name, i| kept.insert(1 + i, "#{name}: #{BYPASS_VALUE}") }
+            headers.each_with_index { |name, i| kept.insert(1 + i, "#{name}: #{BYPASS_VALUE}") } if insert
           end
           io = IO::Memory.new
           io << kept.join(eol) << eol << eol

--- a/src/gori/probe/active/path_normalization_bypass.cr
+++ b/src/gori/probe/active/path_normalization_bypass.cr
@@ -12,13 +12,19 @@ module Gori
       # `/admin` and serves it. Passive analysis cannot tell such a control apart from any 401/403.
       #
       # For one in-scope flow whose captured response was 401/403, it re-requests the SAME resource
-      # through a small set of normalization tricks and flags a Medium "possible bypass" when any
-      # variant flips to 2xx. Single-shot against the captured baseline (no control re-send of the
-      # canonical path), so a transient/rate-limited 403 that clears could also flip — hence
-      # "possible", to be confirmed by re-requesting the canonical path. Gated to safe methods
-      # (GET/HEAD — the confirmation is a status flip, which HEAD provides) and to originally-denied
-      # responses, so a normally-served endpoint is never probed. A control that normalizes correctly
-      # answers every variant with the same 401/403 and is never flagged.
+      # through a small set of normalization tricks, plus a CONTROL request for the canonical path
+      # exactly as captured, and flags a Medium "possible bypass" when a variant flips to 2xx AND
+      # the control is still denied. The control is what makes the flip attributable: judging the
+      # variants against the CAPTURED status alone could not tell "the proxy ACL disagrees with the
+      # backend" from "the 403 was transient and had already cleared", so a rate-limited or flapping
+      # endpoint produced a bypass finding for every variant at once. The control is sent LAST, so a
+      # gate that opened on its own answers 2xx there too and the whole finding is suppressed.
+      #
+      # Still Medium: two adjacent requests cannot rule out backends that disagree, so this remains
+      # a lead — just no longer one that fires on ordinary flapping. Gated to safe methods (GET/HEAD
+      # — the confirmation is a status flip, which HEAD provides) and to originally-denied responses,
+      # so a normally-served endpoint is never probed. A control that normalizes correctly answers
+      # every variant with the same 401/403 and is never flagged.
       #
       # Every variant is chosen to resolve to the ORIGINAL resource (`/admin`), NOT to `/admin/`: a
       # bare trailing slash legitimately 200s on many servers, so tricks that canonicalize to `path/`
@@ -30,9 +36,9 @@ module Gori
             Category::ACTIVE)
         end
 
-        # baseline .. worst case (aggressive) — the manual-run estimate / Rules sub-tab annotation.
+        # 5 variants (+1 under aggressive) plus the canonical-path control.
         def requests_per_flow : Range(Int32, Int32)
-          5..6
+          6..7
         end
 
         def dedup_key(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : String?
@@ -46,12 +52,23 @@ module Gori
           vs = variants(path, opts.aggressive)
           requests = vs.map { |(_, np)| rebuild_target(detail.request_head, detail.request_body, np) }
           params = vs.map { |(label, np)| Param.new("path", label, np) }
+          # The control is the CANONICAL path, appended LAST so it is sent after every variant:
+          # `params` keeps indexing results 0..n-1 and the control lands at results[params.size].
+          requests << rebuild_target(detail.request_head, detail.request_body, path)
           Plan.new(requests.first, params, key_string(detail, method_up, path, opts), requests[1..])
         end
 
-        # Flag when ANY variant flipped the denied status to 2xx. One grouped Detection per host,
-        # listing which tricks worked.
+        # results = [variant…, control]. Flag when a variant flipped the denied status to 2xx AND
+        # the canonical path is still denied. One grouped Detection per host, listing which tricks
+        # worked.
         def detections_all(plan : Plan, results : Array(Repeater::Result), detail : Store::FlowDetail) : Array(Detection)
+          control = results[plan.params.size]?
+          # No usable control ⇒ no attribution. Refuse rather than fall back to the captured status:
+          # that fallback IS the false positive this leg exists to remove.
+          return [] of Detection unless control && control.ok?
+          # The canonical path serves 2xx now too ⇒ the gate is simply open (a transient/rate-limited
+          # 403 that cleared), and every variant "flip" below is that same clearing, not a bypass.
+          return [] of Detection if (200..299).includes?(probe_status(control))
           orig = detail.row.status
           hits = [] of String
           plan.params.each_with_index do |param, i|
@@ -63,7 +80,7 @@ module Gori
           return [] of Detection if hits.empty?
           [Detection.new("path_normalization_bypass", Category::ACTIVE, detail.row.host, detail.row.url,
             "Possible access-control bypass via path normalization", Store::Severity::Medium,
-            "#{orig} → 2xx via #{hits.join(", ")} (single-shot; confirm against the canonical path)"[0, 120],
+            "#{orig} → 2xx via #{hits.join(", ")}; canonical path still denied"[0, 120],
             detail.row.id)]
         rescue
           [] of Detection

--- a/src/gori/probe/active/url_rewrite_bypass.cr
+++ b/src/gori/probe/active/url_rewrite_bypass.cr
@@ -15,17 +15,26 @@ module Gori
       # were DELIBERATELY excluded from ForbiddenBypass (which forges a single flat client-IP value);
       # this is their dedicated probe.
       #
-      # For one in-scope flow whose captured response was 401/403/404, it sends TWO requests:
-      #   probe   = `GET /` + X-Original-URL/X-Rewrite-URL naming the original (gated) path
-      #   control = plain `GET /` (no rewrite headers)
-      # and flags Medium "possible bypass" when the probe is 2xx AND its response differs from the
-      # control's. The control is the crucial guard: `GET /` usually 200s regardless, so a bare "probe
-      # 200" is meaningless — only a probe response that DIFFERS from the plain-root control shows the
-      # rewrite header actually selected the gated resource. Comparison is a coarse {status, body-size}
-      # fingerprint: it tolerates FIXED-length root jitter (a same-length rotating token) but can still
-      # miss a gated page that happens to match the root's length, or fire when the root's body length
-      # varies between the two sends — hence Medium/"possible", to be confirmed manually. Gated to
-      # body-comparable methods (GET by default, HEAD out; Options#allow_unsafe widens).
+      # For one in-scope flow whose captured response was 401/403/404, it sends THREE requests:
+      #   probe    = `GET /` + X-Original-URL/X-Rewrite-URL naming the original (gated) path
+      #   control  = plain `GET /` (no rewrite headers)
+      #   control2 = plain `GET /` again
+      # and flags Medium "possible bypass" when the probe is 2xx AND its {status, body-size}
+      # fingerprint differs from the control's. `GET /` usually 200s regardless, so a bare "probe
+      # 200" is meaningless — only a probe response that DIFFERS from the plain-root control shows
+      # the rewrite header actually selected the gated resource.
+      #
+      # The SECOND control is what makes that difference trustworthy. With one control, any root
+      # page whose body length moves between two requests — a CSRF token of varying length, a
+      # timestamp, a rotating ad slot, a served-in-N-ms footer — read as "differs from the control"
+      # and fired a bypass finding on EVERY 401/403/404 path on the site. Sending the plain root
+      # twice measures that jitter directly: if the two controls disagree, the root is not stable
+      # enough for a size comparison to mean anything and the rule declines to report rather than
+      # guess. A stable root costs nothing and behaves exactly as before.
+      #
+      # Still Medium/"possible": the fingerprint is coarse, so a gated page that happens to match
+      # the root's status AND length is a miss. Gated to body-comparable methods (GET by default,
+      # HEAD out; Options#allow_unsafe widens).
       class UrlRewriteBypass < Rule
         def info : RuleInfo
           RuleInfo.new("url_rewrite_bypass", "Access-control bypass (URL-rewrite headers)",
@@ -34,7 +43,7 @@ module Gori
         end
 
         def requests_per_flow : Range(Int32, Int32)
-          2..2 # probe + control
+          3..3 # probe + control + a second control (root-stability check)
         end
 
         def dedup_key(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : String?
@@ -47,23 +56,22 @@ module Gori
           method_up, path, orig_full = g
           probe = rebuild_root(detail.request_head, detail.request_body, orig_full)
           control = rebuild_root(detail.request_head, detail.request_body, nil)
-          Plan.new(probe, [] of Param, key_string(detail, method_up, path), [control])
+          control2 = rebuild_root(detail.request_head, detail.request_body, nil)
+          Plan.new(probe, [] of Param, key_string(detail, method_up, path), [control, control2])
         end
 
+        # results = [probe, control, control2].
         def detections_all(plan : Plan, results : Array(Repeater::Result), detail : Store::FlowDetail) : Array(Detection)
           probe = results[0]?
-          control = results[1]?
-          return [] of Detection unless probe && probe.ok? && control && control.ok?
+          return [] of Detection unless probe && probe.ok?
           ps = probe_status(probe)
           return [] of Detection unless (200..299).includes?(ps)
-          cs = probe_status(control)
-          psize = body_size(probe)
-          csize = body_size(control)
+          cs, csize = stable_root(results) || return [] of Detection
           # Header ignored ⇒ the probe is just the plain-root response (same status + size) ⇒ no bypass.
-          return [] of Detection if ps == cs && psize == csize
+          return [] of Detection if ps == cs && body_size(probe) == csize
           [Detection.new("url_rewrite_bypass", Category::ACTIVE, detail.row.host, detail.row.url,
             "Possible access-control bypass via URL-rewrite header", Store::Severity::Medium,
-            "#{detail.row.status} → #{ps} via X-Original-URL/X-Rewrite-URL (differs from root; single-shot, confirm)"[0, 120],
+            "#{detail.row.status} → #{ps} via X-Original-URL/X-Rewrite-URL (differs from a root that answered identically twice)"[0, 120],
             detail.row.id)]
         rescue
           [] of Detection
@@ -90,6 +98,19 @@ module Gori
 
         private def key_string(detail : Store::FlowDetail, method_upcase : String, path : String) : String
           "url_rewrite_bypass|#{detail.row.host}:#{detail.row.port}|#{method_upcase}|#{path}"
+        end
+
+        # The plain-root {status, body-size} fingerprint — but only when the root reproduced it on a
+        # SECOND identical request (results[1] and results[2]). nil when either control is missing or
+        # failed to send, or when the two disagree: this whole finding is "the probe differs from the
+        # root", so a root whose own size moves between requests (a varying CSRF token, a timestamp)
+        # makes every difference meaningless. Returning nil makes the rule decline rather than guess.
+        private def stable_root(results : Array(Repeater::Result)) : {Int32, Int32}?
+          a = results[1]?
+          b = results[2]?
+          return nil unless a && a.ok? && b && b.ok?
+          fp = {probe_status(a), body_size(a)}
+          fp == {probe_status(b), body_size(b)} ? fp : nil
         end
 
         # Rebuild the request as `<method> / <version>`: drop any X-Original-URL/X-Rewrite-URL the


### PR DESCRIPTION
Four active rules decided a finding by comparing a probe against the **captured** response, or against a single control they never checked was stable. Each of those comparisons has a failure mode that manufactures a confident finding out of ordinary server behaviour, and all four are cheap to close: send one more request and make the endpoint contradict itself before believing it.

| rule | was | now | the FP it removes |
|---|---|---|---|
| `forbidden_bypass` | 1 req | 2 (probe + control) | a transient 403 that cleared on its own |
| `path_normalization_bypass` | 5–6 (variants) | 6–7 (+ canonical control) | same, but it fired on *every* variant at once |
| `url_rewrite_bypass` | 2 (probe + control) | 3 (+ 2nd control) | a root page whose body length jitters |
| `backslash_powered` | 3–7 (1 baseline) | 4–8 (2 baselines) | an endpoint that varies run to run |

## forbidden_bypass

Comparing the spoofed-header probe against the captured 401/403 could not tell *"the headers opened the gate"* from *"the 403 was transient and had already cleared."* A rate-limited or flapping endpoint produced a bypass finding with no bypass.

The same request is now re-sent **without** the spoofing headers, after the probe. If the control succeeds too, the resource is simply open and nothing is reported. The control is rebuilt through the same path (origin-form request line, browser-sent copies of those headers dropped on **both** legs), so the two legs differ in exactly one thing — our forged values.

## path_normalization_bypass

Same failure, worse: with the captured status as the only reference, a gate that opened on its own made **every** variant look like a bypass simultaneously. The canonical path is now requested last and must still be denied.

## url_rewrite_bypass

This one already had a control; the problem was *trusting* it. The finding is "the probe's `{status, body-size}` differs from the plain root", so any root whose length moves between two requests — a varying CSRF token, a timestamp, a rotating slot — differed from itself and fired on **every** 401/403/404 path on the site.

Sending the plain root twice measures that jitter directly: if the two controls disagree, the root cannot support a size comparison and the rule declines instead of guessing. A stable root behaves exactly as before.

## backslash_powered

The rule reports an asymmetry: `\` perturbs the response, `\\` does not. That silently assumed the endpoint answers the same request the same way twice. When it does not — an intermittent 503, a rate limiter engaging, a health-checked backend rotating — noise landing on a `\` leg but not its `\\` leg reproduces this exact shape, **once per probed param**. The baseline is now sent twice and nothing is reported unless the two fingerprints agree.

## Notes

- All four stay **Medium / "possible"**: two adjacent requests cannot rule out backends that disagree with each other, so these remain leads to confirm. What changed is that they no longer fire on ordinary flapping.
- Where a control is missing or errored, the rules **refuse** rather than fall back to the captured status — that fallback is precisely the false positive being removed.
- `requests_per_flow` is updated on each rule, so the Rules sub-tab annotation and the manual "Run active scan" estimate show the real cost. The suite's per-flow ceiling moves 7 → 8.

## Verification

- `crystal spec` — **4760 examples, 0 failures**
- `crystal tool format --check` on all touched files — clean
- `crystal build --no-codegen src/main.cr` — clean
- ameba on the touched files reports only the **3 warnings already present on `main`** (backslash_powered's `not_nil!` ×2 and a negated `unless`). The two complexity warnings the control gates introduced are refactored out into `stable_baseline` / `stable_root`.

New specs cover each gate directly: control-also-succeeds, missing control, errored control, disagreeing baselines, and jittering root — plus the updated request/followup shapes.

## Review series

This closes the FP/FN items from the Probe rule-set review, after #475 (perf) and #477 (passive FPs).