### PR TITLE
fix(mcp): ten defects found auditing the MCP tool surface

### DIFF
--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -3150,3 +3150,49 @@ describe "MCP intercept_forward_edit" do
     end
   end
 end
+
+describe "MCP job project binding" do
+  # A finished job outlives a switch_project (only a RUNNING one blocks the switch), and its
+  # buffered results carry History flow ids that resolve to unrelated rows in the new DB.
+  # Isolated GORI_HOME, like the project-lifecycle spec — switch_project touches the registry.
+  it "refuses to serve a finished job's results after switch_project" do
+    root = File.tempname("gori-jobhome")
+    Dir.mkdir_p(root)
+    prev = ENV["GORI_HOME"]?
+    ENV["GORI_HOME"] = root
+    cur_db = File.join(root, "current.db")
+    store = Gori::Store.open(cur_db)
+    tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false, db_path: cur_db)
+    begin
+      Gori::Scope.load(store).add("include", "host", "127.0.0.1")
+      started = ok_json(tools, "fuzz_start",
+        %({"url":"http://127.0.0.1:1","template":"GET /§x§ HTTP/1.1\\r\\nHost: 127.0.0.1\\r\\n\\r\\n",) +
+        %("payloads":[{"list":["a"]}],"max_requests":1,"retries":0,"timeout_ms":50}))
+      job_id = started["job_id"].as_s
+
+      # Let the job reach a terminal state so it does not block the switch.
+      40.times do
+        break unless JSON.parse(tools.call("fuzz_status", JSON.parse(%({"job_id":"#{job_id}"}))).text)["status"].as_s == "running"
+        sleep 25.milliseconds
+      end
+      ok_json(tools, "fuzz_status", %({"job_id":"#{job_id}"}))["job_complete"].as_bool.should be_true
+
+      other = JSON.parse(tools.call("create_project", JSON.parse(%({"name":"Other"}))).text)["slug"].as_s
+      ok_json(tools, "switch_project", %({"project":#{other.to_json}}))
+
+      # The job is still remembered, but its results are no longer meaningful here.
+      %w[fuzz_status fuzz_results fuzz_stop get_job stop_job].each do |verb|
+        r = tools.call(verb, JSON.parse(%({"job_id":"#{job_id}"})))
+        r.error_code.should eq "PROJECT_CHANGED"
+      end
+      # list_jobs still SHOWS it, flagged, so the agent can see why its id refuses.
+      listed = ok_json(tools, "list_jobs", "{}")["jobs"].as_a.find { |x| x["job_id"].as_s == job_id }
+      listed.should_not be_nil
+      listed.not_nil!["project_changed"].as_bool.should be_true
+    ensure
+      store.close rescue nil
+      prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(root)
+    end
+  end
+end

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -2857,3 +2857,66 @@ describe "code-review follow-ups" do
     end
   end
 end
+
+# A captured request line is parsed with a plain `String.new` over wire bytes (no scrub) and
+# SQLite round-trips those bytes verbatim, so anything derived from captured traffic can be
+# invalid UTF-8. The stdio JSON-RPC transport carries UTF-8 TEXT: one bad byte anywhere makes
+# a strict client reject the entire response line, not just the offending field.
+private def seed_invalid_utf8_flow(store) : Int64
+  bad_target = String.new(Bytes[0x2f, 0x63, 0x61, 0x66, 0xe9]) # "/caf\xE9" — not valid UTF-8
+  bad_target.valid_encoding?.should be_false
+  store.insert_flow(Gori::Store::CapturedRequest.new(
+    created_at: 1_i64, scheme: "https", host: "acme.test", port: 443,
+    method: "GET", target: bad_target, http_version: "HTTP/1.1",
+    head: "GET #{bad_target} HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice))
+end
+
+describe "MCP JSON-RPC UTF-8 validity" do
+  # Assert on the tool's RAW payload string, never on a parsed field: Crystal's JSON parser
+  # reassembles an escaped string char-by-char and silently turns an invalid byte into
+  # U+FFFD, so `JSON.parse(...)["target"]` reports clean text for a payload that is NOT.
+  # Going through Tools (not Server) also bypasses the transport safety net, so these pin
+  # the per-site Serialize.text calls rather than the net that backstops them.
+  it "keeps an invalid-UTF-8 captured target out of list_history's payload" do
+    with_store do |store|
+      seed_invalid_utf8_flow(store)
+      # Round-trip check: the store really does hand the invalid bytes back.
+      store.recent_flows(10, nil, nil).first.target.valid_encoding?.should be_false
+
+      payload = tools_for(store).call("list_history", JSON.parse("{}")).text
+      payload.valid_encoding?.should be_true
+      payload.should contain("caf")
+    end
+  end
+
+  it "keeps it out of list_sitemap's and get_flow's payloads" do
+    with_store do |store|
+      id = seed_invalid_utf8_flow(store)
+      tools = tools_for(store)
+      tools.call("list_sitemap", JSON.parse("{}")).text.valid_encoding?.should be_true
+      tools.call("get_flow", JSON.parse(%({"id":#{id}}))).text.valid_encoding?.should be_true
+    end
+  end
+
+  it "keeps a repeater seeded from a captured request out of its payload" do
+    with_store do |store|
+      bad_host = String.new(Bytes[0x61, 0xe9, 0x2e, 0x74, 0x65, 0x73, 0x74]) # "a\xE9.test"
+      store.insert_repeater("https://#{bad_host}/", "GET / HTTP/1.1\r\n\r\n".to_slice, false, true, nil, 0)
+      tools_for(store).call("get_repeater_context", JSON.parse("{}")).text.valid_encoding?.should be_true
+    end
+  end
+
+  it "scrubs at the transport as a last resort so the whole line stays parseable" do
+    with_store do |store|
+      seed_invalid_utf8_flow(store)
+      input = IO::Memory.new(%({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_history","arguments":{}}}) + "\n")
+      output = IO::Memory.new
+      Gori::MCP::Server.new(store, allow_actions: true, verify_upstream: false,
+        input: input, output: output).run
+      # The emitted BYTES, not just the decoded field: this is the transport contract.
+      output.to_s.each_line.reject(&.strip.empty?).each do |line|
+        line.valid_encoding?.should be_true
+      end
+    end
+  end
+end

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -3063,3 +3063,90 @@ describe "MCP agent event feed" do
     end
   end
 end
+
+# Publish the bridge blob a capturing TUI would, so the intercept write verbs enqueue for
+# real, and auto-ack the first queued command so the tool returns without its 3s poll.
+private def with_live_intercept(store, &)
+  store.set_intercept_bridge({
+    "capturing" => true, "enabled" => true, "direction" => "both", "filter" => "",
+    "session_token" => "sess-1", "heartbeat_ms" => Time.utc.to_unix_ms,
+  }.to_json)
+  spawn do
+    120.times do
+      if row = store.intercept_commands_after(0_i64, 10).first?
+        store.ack_intercept_command(row.id, "edited", "ok")
+        break
+      end
+      sleep 5.milliseconds
+    end
+  end
+  yield
+end
+
+# The bytes actually handed to the capturing instance — the only thing that matters here.
+private def queued_intercept_bytes(store) : Bytes
+  store.intercept_commands_after(0_i64, 10).first.bytes.not_nil!
+end
+
+describe "MCP intercept_forward_edit" do
+  it "forwards a binary body from raw_base64 byte-for-byte" do
+    with_store do |store|
+      # A PNG-ish body holding a bare LF and a non-UTF-8 octet: neither survives a JSON
+      # string, and the old whole-message CRLF gsub rewrote the 0x0A into 0x0D 0x0A.
+      body = Bytes[0x89, 0x50, 0x4e, 0x47, 0x0a, 0xff]
+      wire = IO::Memory.new
+      wire.print "POST /upload HTTP/1.1\r\nHost: acme.test\r\nContent-Length: #{body.size}\r\n\r\n"
+      wire.write body
+
+      with_live_intercept(store) do
+        r = tools_for(store).call("intercept_forward_edit",
+          JSON.parse(%({"item_id":1,"raw_base64":"#{Base64.strict_encode(wire.to_slice)}"})))
+        r.is_error.should be_false
+      end
+
+      queued = queued_intercept_bytes(store)
+      sep = Gori::MCP::Serialize.head_body_split(queued).not_nil!
+      queued[(sep + 4)..].should eq body # untouched, 0x0A and 0xFF included
+    end
+  end
+
+  it "normalizes CRLF in raw's HEADER block but never in its body" do
+    with_store do |store|
+      with_live_intercept(store) do
+        # Hand-typed LF-only head (must still frame) with an LF-separated text body (must not
+        # grow — rewriting it is what desyncs a Content-Length and corrupts non-text bodies).
+        raw = "POST /a HTTP/1.1\\nHost: acme.test\\n\\nline1\\nline2"
+        tools_for(store).call("intercept_forward_edit",
+          JSON.parse(%({"item_id":1,"raw":"#{raw}"}))).is_error.should be_false
+      end
+
+      String.new(queued_intercept_bytes(store))
+        .should eq "POST /a HTTP/1.1\r\nHost: acme.test\r\nContent-Length: 11\r\n\r\nline1\nline2"
+    end
+  end
+
+  it "rejects raw and raw_base64 together instead of silently picking one" do
+    with_store do |store|
+      r = tools_for(store).call("intercept_forward_edit",
+        JSON.parse(%({"item_id":1,"raw":"GET / HTTP/1.1\\r\\n\\r\\n","raw_base64":"R0VUIC8gSFRUUC8xLjENCg0K"})))
+      r.error_code.should eq "INVALID_ARGUMENT"
+      r.text.should contain "only one"
+    end
+  end
+
+  it "rejects invalid base64 with an actionable message" do
+    with_store do |store|
+      r = tools_for(store).call("intercept_forward_edit", JSON.parse(%({"item_id":1,"raw_base64":"!!!not base64!!!"})))
+      r.error_code.should eq "INVALID_ARGUMENT"
+      r.field.should eq "raw_base64"
+    end
+  end
+
+  it "still requires one of the two" do
+    with_store do |store|
+      r = tools_for(store).call("intercept_forward_edit", JSON.parse(%({"item_id":1})))
+      r.error_code.should eq "INVALID_ARGUMENT"
+      r.field.should eq "raw"
+    end
+  end
+end

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -2920,3 +2920,46 @@ describe "MCP JSON-RPC UTF-8 validity" do
     end
   end
 end
+
+describe "MCP project env vars" do
+  it "reports an out-of-band env change instead of a stale in-process copy" do
+    with_store do |store|
+      tools = tools_for(store)
+      ok_json(tools, "list_env", "{}").as_a.should be_empty
+
+      # Another process (`gori run project env set`) writes to the same project DB.
+      store.set_setting(Gori::Env::PROJECT_VARS_KEY, %([{"key":"CLI_TOKEN","value":"abc"}]))
+
+      listed = ok_json(tools, "list_env", %({"include_sensitive":true}))
+      listed.as_a.map { |v| v["key"].as_s }.should eq ["CLI_TOKEN"]
+    end
+  end
+
+  it "does not clobber an out-of-band env var when setting another" do
+    with_store do |store|
+      tools = tools_for(store)
+      ok_json(tools, "list_env", "{}") # bind with an empty set, as a long-lived server would
+
+      store.set_setting(Gori::Env::PROJECT_VARS_KEY, %([{"key":"CLI_TOKEN","value":"abc"}]))
+      ok_json(tools, "set_env_var", %({"key":"MCP_KEY","value":"v"}))
+
+      # set_env_var read-modify-WRITES the whole array; on a stale copy CLI_TOKEN vanished.
+      keys = ok_json(tools, "list_env", "{}").as_a.map { |v| v["key"].as_s }
+      keys.should contain "CLI_TOKEN"
+      keys.should contain "MCP_KEY"
+    end
+  end
+
+  it "does not resurrect a var another process deleted when deleting one" do
+    with_store do |store|
+      tools = tools_for(store)
+      ok_json(tools, "set_env_var", %({"key":"A","value":"1"}))
+      ok_json(tools, "set_env_var", %({"key":"B","value":"2"}))
+
+      store.set_setting(Gori::Env::PROJECT_VARS_KEY, %([{"key":"B","value":"2"}])) # CLI removed A
+      ok_json(tools, "delete_env_var", %({"key":"B"}))
+
+      ok_json(tools, "list_env", "{}").as_a.should be_empty
+    end
+  end
+end

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -2963,3 +2963,34 @@ describe "MCP project env vars" do
     end
   end
 end
+
+describe "MCP send_websocket scope gate" do
+  it "honours a path-scoped include the way send_request does" do
+    with_store do |store|
+      scope = Gori::Scope.load(store)
+      scope.add("include", "string", "/chat")
+      scope.enable
+      ws = "GET /chat HTTP/1.1\r\nHost: acme.test\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" \
+           "Sec-WebSocket-Version: 13\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n"
+      rid = store.insert_repeater("https://acme.test", ws.to_slice, false, true, nil, 0)
+
+      # Anchoring the check on a bare "/" refused this — the include names a PATH.
+      r = tools_for(store).call("send_websocket", JSON.parse(%({"repeater_id":#{rid}})))
+      r.error_code.should_not eq "SCOPE_BLOCKED"
+    end
+  end
+
+  it "still refuses a target the scope does not include" do
+    with_store do |store|
+      scope = Gori::Scope.load(store)
+      scope.add("include", "string", "/chat")
+      scope.enable
+      ws = "GET /admin HTTP/1.1\r\nHost: acme.test\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" \
+           "Sec-WebSocket-Version: 13\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n"
+      rid = store.insert_repeater("https://acme.test", ws.to_slice, false, true, nil, 0)
+
+      r = tools_for(store).call("send_websocket", JSON.parse(%({"repeater_id":#{rid}})))
+      r.error_code.should eq "SCOPE_BLOCKED"
+    end
+  end
+end

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -3252,3 +3252,19 @@ describe "MCP update_repeater" do
     end
   end
 end
+
+describe "MCP get_current_context" do
+  it "emits each key exactly once" do
+    with_store do |store|
+      store.set_setting(Gori::Store::UI_STATE_KEY, %({"active_tab":"history","focus_pane":"body"}))
+      lines = drive(store, %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_current_context","arguments":{}}}),
+        project_name: "acme")
+      raw = lines[0]["result"]["content"][0]["text"].as_s
+      # A duplicate key is first/last-wins by parser and rejected outright by strict ones,
+      # so count the RAW text — JSON.parse would silently collapse it.
+      raw.scan(/"project":/).size.should eq 1
+      JSON.parse(raw)["project"].as_s.should eq "acme"
+      JSON.parse(raw)["active_tab"].as_s.should eq "history"
+    end
+  end
+end

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -3196,3 +3196,59 @@ describe "MCP job project binding" do
     end
   end
 end
+
+describe "MCP create_issue evidence" do
+  it "refuses a flow_id that names no flow" do
+    with_store do |store|
+      r = tools_for(store).call("create_issue", JSON.parse(%({"title":"boom","flow_id":9999})))
+      r.error_code.should eq "NOT_FOUND"
+      # ...and nothing was persisted.
+      store.issues.should be_empty
+    end
+  end
+
+  it "still accepts a real flow_id" do
+    with_store do |store|
+      id = seed_flow(store, "/a")
+      ok_json(tools_for(store), "create_issue", %({"title":"boom","flow_id":#{id}}))["id"].as_i64.should be > 0
+    end
+  end
+end
+
+describe "MCP update_scope_rule" do
+  it "refuses a blank pattern instead of silently keeping the old one" do
+    with_store do |store|
+      tools = tools_for(store)
+      added = ok_json(tools, "add_scope_rule", %({"kind":"include","match_type":"host","pattern":"acme.test"}))
+      r = tools.call("update_scope_rule", JSON.parse(%({"id":#{added["id"]},"pattern":"   "})))
+      r.error_code.should eq "INVALID_ARGUMENT"
+      r.field.should eq "pattern"
+      # Unchanged, and still gating traffic.
+      Gori::Scope.load(store).rules.first.pattern.should eq "acme.test"
+    end
+  end
+
+  it "still keeps the current pattern when it is omitted entirely" do
+    with_store do |store|
+      tools = tools_for(store)
+      added = ok_json(tools, "add_scope_rule", %({"kind":"include","match_type":"host","pattern":"acme.test"}))
+      ok_json(tools, "update_scope_rule", %({"id":#{added["id"]},"kind":"exclude"}))["pattern"].as_s.should eq "acme.test"
+    end
+  end
+end
+
+describe "MCP update_repeater" do
+  it "masks a secret in the summary it hands back" do
+    with_store do |store|
+      Gori::Env.save_project(store, [{"TOKEN", "s3cr3t-value"}])
+      tools = tools_for(store)
+      created = ok_json(tools, "create_repeater",
+        %({"target":"https://acme.test","request":"GET / HTTP/1.1\\r\\nHost: acme.test\\r\\n\\r\\n"}))
+
+      updated = ok_json(tools, "update_repeater",
+        %({"id":#{created["id"]},"request":"GET /a?token=s3cr3t-value HTTP/1.1\\r\\nHost: acme.test\\r\\n\\r\\n"}))
+      updated["summary"].as_s.should_not contain "s3cr3t-value"
+      updated["summary"].as_s.should contain "$TOKEN"
+    end
+  end
+end

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -2994,3 +2994,40 @@ describe "MCP send_websocket scope gate" do
     end
   end
 end
+
+describe "MCP host overrides" do
+  it "reports a duplicate host as a permanent error, not a retryable one" do
+    with_store do |store|
+      tools = tools_for(store)
+      ok_json(tools, "add_host_override", %({"host":"acme.test","ip":"127.0.0.1"}))
+
+      dup = tools.call("add_host_override", JSON.parse(%({"host":"acme.test","ip":"127.0.0.2"})))
+      dup.is_error.should be_true
+      # PROJECT_BUSY/retryable:true made an agent that trusts `retryable` loop forever (#414).
+      dup.error_code.should eq "INVALID_ARGUMENT"
+      dup.retryable.should be_false
+      dup.text.should contain("already exists")
+    end
+  end
+
+  it "reports a collision on update as a permanent error too" do
+    with_store do |store|
+      tools = tools_for(store)
+      ok_json(tools, "add_host_override", %({"host":"a.test","ip":"127.0.0.1"}))
+      second = ok_json(tools, "add_host_override", %({"host":"b.test","ip":"127.0.0.2"}))
+
+      clash = tools.call("update_host_override", JSON.parse(%({"id":#{second["id"]},"host":"a.test","ip":"127.0.0.3"})))
+      clash.error_code.should eq "INVALID_ARGUMENT"
+      clash.retryable.should be_false
+    end
+  end
+
+  it "still allows editing an entry's ip without renaming it" do
+    with_store do |store|
+      tools = tools_for(store)
+      added = ok_json(tools, "add_host_override", %({"host":"a.test","ip":"127.0.0.1"}))
+      edited = ok_json(tools, "update_host_override", %({"id":#{added["id"]},"host":"a.test","ip":"10.0.0.1"}))
+      edited["ip"].as_s.should eq "10.0.0.1"
+    end
+  end
+end

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -3031,3 +3031,35 @@ describe "MCP host overrides" do
     end
   end
 end
+
+describe "MCP agent event feed" do
+  it "records the intercept write verbs the human needs to see" do
+    with_store do |store|
+      tools = tools_for(store)
+      # No live capturing instance, so each verb fails — the feed logs failures too, which is
+      # exactly what an operator wants to see an agent attempting on held traffic.
+      tools.call("intercept_forward", JSON.parse(%({"item_id":1}))).is_error.should be_true
+      tools.call("intercept_toggle", JSON.parse(%({"enable":false}))).is_error.should be_true
+
+      logged = store.events_after(0_i64, 50).select { |e| e.kind == "agent_action" }.map(&.payload)
+      logged.should contain "intercept_forward"
+      logged.should contain "intercept_toggle"
+    end
+  end
+
+  it "records an ACTIVE probe scan but not a passive one" do
+    with_store do |store|
+      seed_flow(store, "/a")
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "acme.test")
+      tools = tools_for(store)
+
+      ok_json(tools, "probe_scan", "{}")                       # passive — sends nothing
+      tools.call("probe_scan", JSON.parse(%({"active":true}))) # sends real requests
+
+      logged = store.events_after(0_i64, 50).select { |e| e.kind == "agent_action" && e.payload == "probe_scan" }
+      # The argument decides, not the tool name: a passive rescan would bury the outbound ones.
+      logged.size.should eq 1
+    end
+  end
+end

--- a/src/gori/mcp/request_builder.cr
+++ b/src/gori/mcp/request_builder.cr
@@ -160,9 +160,14 @@ module Gori
       # block are promoted to CRLF, so a hand-typed request still frames. The body
       # (everything after the first blank line) is left UNTOUCHED — rewriting a bare
       # LF there would grow the payload past the caller's Content-Length and desync
-      # the origin (request smuggling). The header terminator is the first blank
-      # line (`\r\n\r\n` or `\n\n`, whichever comes first).
-      private def self.normalize_raw(raw : String) : Bytes
+      # the origin (request smuggling), and would corrupt any body whose bytes are
+      # not line-oriented text. The header terminator is the first blank line
+      # (`\r\n\r\n` or `\n\n`, whichever comes first).
+      #
+      # PUBLIC because `intercept_forward_edit` needs the identical rule: it used to
+      # gsub the WHOLE message, silently rewriting 0x0A bytes inside the body it was
+      # meant to forward verbatim. One rule, one implementation.
+      def self.normalize_raw(raw : String) : Bytes
         crlf = raw.index("\r\n\r\n")
         lf = raw.index("\n\n")
         ends = [] of Int32

--- a/src/gori/mcp/serialize.cr
+++ b/src/gori/mcp/serialize.cr
@@ -30,6 +30,22 @@ module Gori
         SENSITIVE_HEADERS.includes?(name.strip.downcase)
       end
 
+      # Every string that ORIGINATED OUTSIDE gori — a captured request target/host, a
+      # response header, a regex-extracted fuzz capture, a crawled URL — must pass through
+      # here before it reaches JSON::Builder. The stdio JSON-RPC transport carries UTF-8
+      # text, but `Codec::Http1.parse_request_head` builds `target`/`method` with a plain
+      # `String.new` over raw wire bytes (no scrub), and SQLite round-trips those bytes
+      # verbatim — so a request line like `GET /caf\xE9 HTTP/1.1` puts an invalid byte on
+      # the wire and a strict client rejects the WHOLE response line, not just that field.
+      # `scrub` returns self (zero allocation) for the overwhelmingly common valid case.
+      def self.text(s : String) : String
+        s.scrub
+      end
+
+      def self.text(s : Nil) : Nil
+        nil
+      end
+
       # Replace the value of any sensitive header line in a raw HTTP head/request
       # with [REDACTED], leaving names, the request/status line, and the body
       # untouched. Line endings are preserved. Returns `text` verbatim when
@@ -62,17 +78,17 @@ module Gori
           j.field "id", row.id
           j.field "created_at", row.created_at
           j.field "created_at_iso", unix_micros_iso(row.created_at)
-          j.field "scheme", row.scheme
-          j.field "method", row.method
-          j.field "host", row.host
+          j.field "scheme", text(row.scheme)
+          j.field "method", text(row.method)
+          j.field "host", text(row.host)
           j.field "port", row.port
-          j.field "target", row.target
+          j.field "target", text(row.target)
           j.field "status", row.status
           j.field "state", row.state.to_s.downcase
           j.field "size", row.size
           j.field "response_size", row.response_size
           j.field "duration_us", row.duration_us
-          j.field "content_type", row.content_type
+          j.field "content_type", text(row.content_type)
         end
       end
 
@@ -82,14 +98,14 @@ module Gori
           j.field "id", row.id
           j.field "created_at", row.created_at
           j.field "created_at_iso", unix_micros_iso(row.created_at)
-          j.field "source", row.source
-          j.field "kind", row.kind
-          j.field "level", row.level
-          j.field "message", row.message
-          j.field "goto_tab", row.goto_tab
+          j.field "source", text(row.source)
+          j.field "kind", text(row.kind)
+          j.field "level", text(row.level)
+          j.field "message", text(row.message)
+          j.field "goto_tab", text(row.goto_tab)
           j.field "goto_session_id", row.goto_session_id
           j.field "flow_id", row.flow_id
-          j.field "payload", row.payload
+          j.field "payload", text(row.payload)
         end
       end
 
@@ -123,12 +139,12 @@ module Gori
         preview = "#{preview[0, 1024]}…" if preview.size > 1024
         j.object do
           j.field "item_id", row.item_id
-          j.field "kind", row.kind
-          j.field "method", row.method
-          j.field "host", row.host
+          j.field "kind", text(row.kind)
+          j.field "method", text(row.method)
+          j.field "host", text(row.host)
           j.field "port", row.port
-          j.field "scheme", row.scheme
-          j.field "target", row.target
+          j.field "scheme", text(row.scheme)
+          j.field "target", text(row.target)
           j.field "flow_id", row.flow_id if row.flow_id
           j.field "held_at_ms", row.held_at_ms
           j.field "held_at_iso", unix_micros_iso(row.held_at_ms * 1000)
@@ -148,12 +164,12 @@ module Gori
         head, body = head_and_body(row.raw)
         j.object do
           j.field "item_id", row.item_id
-          j.field "kind", row.kind
-          j.field "method", row.method
-          j.field "host", row.host
+          j.field "kind", text(row.kind)
+          j.field "method", text(row.method)
+          j.field "host", text(row.host)
           j.field "port", row.port
-          j.field "scheme", row.scheme
-          j.field "target", row.target
+          j.field "scheme", text(row.scheme)
+          j.field "target", text(row.target)
           j.field "flow_id", row.flow_id if row.flow_id
           j.field "held_at_ms", row.held_at_ms
           j.field "age_seconds", ((now_ms - row.held_at_ms) // 1000)
@@ -177,15 +193,17 @@ module Gori
       def self.fuzz_result(j : JSON::Builder, r : Fuzz::Result, flow_id : Int64? = nil) : Nil
         j.object do
           j.field "index", r.index
-          j.field("payloads") { j.array { r.payloads.each { |p| j.string p } } }
+          # payloads can come from a caller-supplied wordlist FILE (arbitrary bytes) and
+          # `extracted` is a regex capture out of the RESPONSE body — both are outside-origin.
+          j.field("payloads") { j.array { r.payloads.each { |p| j.string text(p) } } }
           j.field "position", r.position
           j.field "status", r.status
           j.field "length", r.length
           j.field "words", r.words
           j.field "lines", r.lines
           j.field "duration_us", r.duration_us
-          j.field "error", r.error
-          j.field "extracted", r.extracted
+          j.field "error", text(r.error)
+          j.field "extracted", text(r.extracted)
           # Present when record_history recorded this result as a History flow —
           # fetch its full request/response with get_flow (headers redacted).
           j.field "flow_id", flow_id if flow_id
@@ -209,17 +227,17 @@ module Gori
           j.field "id", row.id
           j.field "created_at", row.created_at
           j.field "created_at_iso", unix_micros_iso(row.created_at)
-          j.field "scheme", row.scheme
-          j.field "method", row.method
-          j.field "host", row.host
+          j.field "scheme", text(row.scheme)
+          j.field "method", text(row.method)
+          j.field "host", text(row.host)
           j.field "port", row.port
-          j.field "target", row.target
-          j.field "http_version", detail.http_version
+          j.field "target", text(row.target)
+          j.field "http_version", text(detail.http_version)
           j.field "status", row.status
           j.field "state", row.state.to_s.downcase
           j.field "duration_us", row.duration_us
-          j.field "content_type", row.content_type
-          j.field "error", detail.error
+          j.field "content_type", text(row.content_type)
+          j.field "error", text(detail.error)
           j.field "request_head", redact_head_opt(head_text(detail.request_head), include_sensitive)
           emit_body(j, "request_body", detail.request_head, detail.request_body, detail.request_body_truncated?, body_cap, body_omit)
           j.field "response_head", redact_head_opt(head_text(detail.response_head), include_sensitive)
@@ -316,8 +334,8 @@ module Gori
               j.array do
                 events.first(SSE_EVENTS_MAX).each do |e|
                   j.object do
-                    j.field "type", e.type
-                    j.field "id", e.id
+                    j.field "type", text(e.type)
+                    j.field "id", text(e.id)
                     j.field "retry", e.retry
                     data = e.data.scrub
                     cut = data.size > SSE_DATA_MAX

--- a/src/gori/mcp/server.cr
+++ b/src/gori/mcp/server.cr
@@ -252,10 +252,22 @@ module Gori
         j.field("id") { id ? id.to_json(j) : j.null }
       end
 
+      # Last line of defence for the transport's UTF-8 contract. Every emit site that
+      # touches outside-origin text already routes through `Serialize.text`; this catches
+      # the one a future change forgets. A single invalid byte anywhere in the payload
+      # makes a strict client reject the WHOLE line, so a lossy U+FFFD in one field beats
+      # losing the response. `valid_encoding?` is ~13x cheaper than `scrub` and the
+      # overwhelmingly common case, so the scrub only runs when something slipped through.
+      private def wire_safe(payload : String) : String
+        return payload if payload.valid_encoding?
+        Log.warn { "mcp: response carried invalid UTF-8; scrubbed at the transport (an emit site is missing Serialize.text)" }
+        payload.scrub
+      end
+
       private def send(payload : String) : Nil
         return if @closed
-        @output.puts(payload) # newline framing
-        @output.flush         # or the client blocks on the unterminated line
+        @output.puts(wire_safe(payload)) # newline framing
+        @output.flush                    # or the client blocks on the unterminated line
       rescue ex : IO::Error
         # The client is gone (broken pipe). Stop writing and let the run loop end
         # cleanly instead of unwinding an unhandled exception out of a handler.

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -109,18 +109,25 @@ module Gori
         "import_flows",
       }
 
-      # R2-3 — active/outbound tools that expand or mask `$KEY` env tokens at call
-      # time. Env vars live in a process-global (Settings.project_env_vars) loaded
-      # once at bind time (initialize / switch_project's Env.load_project), so a
-      # mid-session CLI change (`gori run project env set KEY val`) is otherwise
-      # invisible to an already-running MCP server. `call` reloads from the store
-      # before dispatching any of these so the fresh value is picked up without a
-      # switch_project. Deliberately EXCLUDES read tools and the async *_status /
-      # *_results / *_stop pollers (a running job already captured its fully
-      # expanded template at build time).
+      # R2-3 — tools that READ or WRITE the per-project `$KEY` env vars. Env vars live in a
+      # process-global (Settings.project_env_vars) loaded once at bind time (initialize /
+      # switch_project's Env.load_project), so a mid-session CLI change (`gori run project
+      # env set KEY val`) is otherwise invisible to an already-running MCP server. `call`
+      # reloads from the store before dispatching any of these.
+      #
+      # Three populations, all of which need the fresh value:
+      #   - active/outbound tools that EXPAND or MASK `$KEY` at call time;
+      #   - `list_env`, which would otherwise REPORT a stale set as fact;
+      #   - `set_env_var`/`delete_env_var`, which read-modify-WRITE the whole array
+      #     (Env.save_project persists it wholesale) — on a stale copy that silently
+      #     DELETES every var another process added since we bound.
+      # Deliberately EXCLUDES other read tools and the async *_status / *_results /
+      # *_stop pollers (a running job already captured its fully expanded template at
+      # build time).
       ENV_REFRESH_TOOLS = Set{
         "send_request", "send_websocket",
         "fuzz_start", "mine_start", "sequence_start", "discover_start",
+        "list_env", "set_env_var", "delete_env_var",
       }
 
       # A live OAST listening session held server-side across tool calls (oast_start →

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -308,9 +308,11 @@ module Gori
         getter? http2 : Bool
         getter audit : JobAudit
 
+        getter db_path : String?
+
         def initialize(@id : String, @total : Int64?, @engine : Fuzz::Engine,
                        @record_history : Symbol, @origin : Fuzz::Origin, @http2 : Bool,
-                       @audit : JobAudit)
+                       @audit : JobAudit, @db_path : String? = nil)
         end
 
         def stop : Nil
@@ -339,7 +341,10 @@ module Gori
         property stop_requested_at_ms : Int64? = nil
         getter audit : JobAudit
 
-        def initialize(@id : String, @total : Int64, @engine : Miner::Engine, @audit : JobAudit)
+        getter db_path : String?
+
+        def initialize(@id : String, @total : Int64, @engine : Miner::Engine, @audit : JobAudit,
+                       @db_path : String? = nil)
         end
 
         def stop : Nil
@@ -365,7 +370,10 @@ module Gori
         property stop_requested_at_ms : Int64? = nil
         getter audit : JobAudit
 
-        def initialize(@id : String, @goal : Int32, @engine : Sequencer::Engine, @audit : JobAudit)
+        getter db_path : String?
+
+        def initialize(@id : String, @goal : Int32, @engine : Sequencer::Engine, @audit : JobAudit,
+                       @db_path : String? = nil)
         end
 
         def report : Sequencer::Stats::Report
@@ -394,7 +402,10 @@ module Gori
         property stop_requested_at_ms : Int64? = nil
         getter audit : JobAudit
 
-        def initialize(@id : String, @engine : Discover::Engine, @audit : JobAudit)
+        getter db_path : String?
+
+        def initialize(@id : String, @engine : Discover::Engine, @audit : JobAudit,
+                       @db_path : String? = nil)
         end
 
         def stop : Nil
@@ -1735,6 +1746,19 @@ module Gori
           victims << key if job.status != :running
         end
         victims.each { |k| jobs.delete(k) }
+      end
+
+      # A job's buffered results — and above all the History `flow_id`s recorded alongside
+      # them — only mean anything against the project it ran in. `jobs_running?` stops a
+      # switch mid-run, but a FINISHED job outlives one, and after the rebind those ids
+      # resolve to unrelated rows in the NEW database. Refuse the read instead of handing
+      # back evidence pointers that silently changed meaning; the results are kept, so
+      # switching back makes them readable again.
+      private def job_project_mismatch(job : FuzzJob | MineJob | SequenceJob | DiscoverJob) : Result?
+        return nil if job.db_path == @db_path
+        err("job #{job.id} ran against a different project (#{job.db_path || "unknown"}); " \
+            "switch back to that project to read its results",
+          "PROJECT_CHANGED", details: JSON.parse({"job_db_path" => job.db_path, "current_db_path" => @db_path}.to_json))
       end
 
       # A background job's fiber must never exit with the job still :running — that

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -90,6 +90,13 @@ module Gori
       # @store, so a post-hoc append would land in the wrong DB) — only in-project side effects.
       AGENT_ACTION_TOOLS = Set{
         "send_request", "send_websocket",
+        # The intercept write verbs act on LIVE traffic the human is holding — forwarding,
+        # dropping, or rewriting bytes mid-flight is the single most consequential thing an
+        # agent can do here, so it belongs in the feed more than any store mutation does.
+        # toggle/set_filter/set_direction change what the proxy HOLDS next, which silently
+        # reshapes the human's queue; they are recorded for the same reason.
+        "intercept_forward", "intercept_drop", "intercept_forward_edit",
+        "intercept_toggle", "intercept_set_filter", "intercept_set_direction",
         "fuzz_start", "fuzz_stop", "mine_start", "mine_stop", "sequence_start", "sequence_stop", "discover_start", "discover_stop", "stop_job",
         "create_issue", "update_issue",
         "probe_dismiss", "probe_promote", "probe_delete",
@@ -1425,11 +1432,20 @@ module Gori
         result = read_tool(name, h) || action_tool(name, h) ||
                  err("unknown tool: #{name}", "UNKNOWN_TOOL")
         result = classify(result)
-        log_agent_action(name, result) if @allow_actions && AGENT_ACTION_TOOLS.includes?(name)
+        log_agent_action(name, result) if @allow_actions && agent_action?(name, h)
         result
       rescue ex
         Log.warn(exception: ex) { "tool #{name} failed" }
         err("tool error: #{ex.message}", "INTERNAL")
+      end
+
+      # Whether this CALL (not just this tool) is an agent action worth recording. Most are a
+      # flat name lookup, but `probe_scan` is a READ tool whose active:true mode SENDS real
+      # requests — the argument, not the name, decides. Logging every passive rescan would
+      # bury the outbound ones it exists to surface.
+      private def agent_action?(name : String, h) : Bool
+        return true if AGENT_ACTION_TOOLS.includes?(name)
+        name == "probe_scan" && (bool(h, "active") || false)
       end
 
       # #124 — record a completed agent mutation/send into the store event feed so the AI's

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -1828,7 +1828,7 @@ module Gori
       private def emit_scope(j : JSON::Builder, sc : ScopeCheck) : Nil
         j.field "scope_decision", sc.decision
         j.field "scope_rule_id", sc.rule_id if sc.rule_id
-        j.field "effective_host", sc.host
+        j.field "effective_host", Serialize.text(sc.host)
       end
 
       private def str(h, key : String) : String?

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -1812,15 +1812,6 @@ module Gori
         end
       end
 
-      private def fuzz_origin(h, default_target : String?) : Fuzz::Origin
-        url_raw = str(h, "url").presence || default_target
-        raise FuzzArgError.new("provide a 'url' target (scheme://host) or a flow_id that carries one") unless url_raw
-        url = Env.expand(url_raw)
-        scheme, host, port = Repeater::FlowRequest.parse_target(url)
-        raise FuzzArgError.new("could not parse a host from '#{url}'") if host.empty?
-        Fuzz::Origin.new(scheme, host, port)
-      end
-
       private def fuzz_timeout(h) : Time::Span?
         int(h, "timeout_ms").try(&.clamp(1_i64, 600_000_i64).milliseconds)
       end

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -452,8 +452,9 @@ module Gori
 
           tool j, "intercept_get",
             "Full detail for ONE held intercept item (redacted head + body size). Pass " \
-            "include_sensitive:true to ALSO get the full raw message base64 (unredacted, for " \
-            "byte-exact editing with intercept_forward_edit) — otherwise raw is withheld " \
+            "include_sensitive:true to ALSO get the full raw message base64 (unredacted; edit it " \
+            "and send it back as intercept_forward_edit's raw_base64 for a byte-exact round " \
+            "trip) — otherwise raw is withheld " \
             "(raw_redacted:true) since base64 is not redaction. NOT_FOUND if the item was " \
             "already forwarded/dropped or never held. Header values redacted unless " \
             "include_sensitive:true." do |s|
@@ -777,14 +778,17 @@ module Gori
 
             tool j, "intercept_forward_edit",
               "Forward a held intercept item with EDITED bytes. Supply the full replacement wire " \
-              "message in `raw` (fetch the current bytes from intercept_get with " \
-              "include_sensitive:true → raw_base64, edit, send back). Content-Length is recomputed " \
-              "to match the body; otherwise the bytes are " \
-              "forwarded byte-exact (NO variable expansion — a security tool forwards exactly what " \
-              "you send). Applied by the capturing instance + surfaced to the human. Returns " \
+              "message in EITHER `raw_base64` (byte-exact; the round trip for the bytes " \
+              "intercept_get returns as raw_base64, and the only channel a binary body survives) " \
+              "OR `raw` (plain text, for an ordinary edit). Content-Length is recomputed to match " \
+              "the body; otherwise the bytes are forwarded byte-exact (NO variable expansion — a " \
+              "security tool forwards exactly what you send). In `raw`, a lone LF in the HEADER " \
+              "block becomes CRLF so a hand-typed message still frames; the BODY is untouched. " \
+              "Applied by the capturing instance + surfaced to the human. Returns " \
               "forwarded (edited:true) | no_such_item | not_confirmed." do |s|
               s.field "item_id", intprop("held item id from intercept_list"), required: true
-              s.field "raw", strprop("the full edited HTTP wire message (request/status line + headers + body)"), required: true
+              s.field "raw", strprop("the full edited HTTP wire message as text (request/status line + headers + body)")
+              s.field "raw_base64", strprop("the full edited wire message, base64 — byte-exact; use this for a binary body")
             end
 
             tool j, "intercept_toggle",

--- a/src/gori/mcp/tools/context.cr
+++ b/src/gori/mcp/tools/context.cr
@@ -216,13 +216,15 @@ module Gori
         j.object do
           j.field "db_id", r.id
           j.field "position", r.position
-          j.field "target", r.target
+          # target/name/tags/sni are seeded from a captured request without scrubbing, so
+          # they can carry invalid UTF-8 into the JSON-RPC line (see Serialize.text).
+          j.field "target", Serialize.text(r.target)
           j.field "http2", r.http2?
           j.field "auto_content_length", r.auto_content_length?
           j.field "flow_id", r.flow_id if r.flow_id
-          j.field "name", r.name if r.name
-          j.field "tags", r.tags if r.tags
-          j.field "sni", r.sni if r.sni
+          j.field "name", Serialize.text(r.name) if r.name
+          j.field "tags", Serialize.text(r.tags) if r.tags
+          j.field "sni", Serialize.text(r.sni) if r.sni
           r_request_text = String.new(r.request).scrub
           emit_capped_text(j, "request", Serialize.redact_head(r_request_text, include_sensitive)) if include_content
 
@@ -254,7 +256,7 @@ module Gori
           end
 
           if err = r.response_error
-            j.field "last_error", err
+            j.field "last_error", Serialize.text(err)
           end
           if d = r.response_duration_us
             j.field "last_duration_us", d
@@ -267,7 +269,7 @@ module Gori
             end
             if resp
               j.field "last_status", resp.status
-              j.field "last_reason", resp.reason
+              j.field "last_reason", Serialize.text(resp.reason)
             end
             j.field "last_response_head", Serialize.redact_head_opt(Serialize.head_text(head), include_sensitive) if include_content
           end

--- a/src/gori/mcp/tools/context.cr
+++ b/src/gori/mcp/tools/context.cr
@@ -82,7 +82,9 @@ module Gori
               j.field "note", raw.nil? ? "No UI state recorded for this project — the gori TUI may not have run against it." : "Recorded UI state was unreadable."
             else
               j.field "available", true
-              j.field "project", @project_name
+              # NB: "project" is emitted once, above this branch — repeating it here put a
+              # DUPLICATE key in the object (first/last-wins varies by parser, strict ones
+              # reject it). Only the slug/id belong in the available branch.
               j.field "project_slug", @project_slug
               j.field "project_id", @project_id
               j.field "active_tab", parsed["active_tab"]?.try(&.as_s?)

--- a/src/gori/mcp/tools/discover.cr
+++ b/src/gori/mcp/tools/discover.cr
@@ -26,7 +26,7 @@ module Gori
         audit = JobAudit.new(plan.seed, plan.config.rps, plan.config.concurrency,
           plan.config.max_requests, Time.utc.to_unix_ms)
         engine = plan.engine
-        djob = DiscoverJob.new(id, engine, audit)
+        djob = DiscoverJob.new(id, engine, audit, @db_path)
         evict_finished_jobs(@discover_jobs)
         @discover_jobs[id] = djob
         Log.info { "discover_start #{id} #{plan.seed} scope=#{sc.decision}" }
@@ -239,7 +239,9 @@ module Gori
       private def lookup_discover_job(h) : DiscoverJob | Result
         id = str(h, "job_id")
         return Result.new("missing required 'job_id'", is_error: true) if id.nil? || id.empty?
-        @discover_jobs[id]? || not_found("no discover job #{id}")
+        job = @discover_jobs[id]?
+        return not_found("no discover job #{id}") unless job
+        job_project_mismatch(job) || job
       end
     end
   end

--- a/src/gori/mcp/tools/discover.cr
+++ b/src/gori/mcp/tools/discover.cr
@@ -218,11 +218,11 @@ module Gori
 
       private def discover_finding_json(j : JSON::Builder, f : Discover::Finding) : Nil
         j.object do
-          j.field "url", f.url
-          j.field "method", f.method
+          j.field "url", Serialize.text(f.url)
+          j.field "method", Serialize.text(f.method)
           j.field "status", f.status
           j.field "length", f.length
-          j.field "content_type", f.content_type
+          j.field "content_type", Serialize.text(f.content_type)
           j.field "source", f.source.label
           j.field "depth", f.depth
           j.field "confidence", f.confidence.round(2)

--- a/src/gori/mcp/tools/fuzz.cr
+++ b/src/gori/mcp/tools/fuzz.cr
@@ -29,7 +29,7 @@ module Gori
         audit = JobAudit.new("#{origin.scheme}://#{origin.host}:#{origin.port}",
           int(h, "rate").try(&.to_f64), clamp(int(h, "concurrency"), 20, FUZZ_MAX_CONCURRENCY),
           int(h, "max_requests"), Time.utc.to_unix_ms)
-        fjob = FuzzJob.new(id, total, engine, fuzz_record_policy(h), origin, http2, audit)
+        fjob = FuzzJob.new(id, total, engine, fuzz_record_policy(h), origin, http2, audit, @db_path)
         evict_finished_jobs(@jobs)
         @jobs[id] = fjob
         warn = budget_warning(total, int(h, "max_requests"))
@@ -214,7 +214,9 @@ module Gori
       private def lookup_fuzz_job(h) : FuzzJob | Result
         id = str(h, "job_id")
         return Result.new("missing required 'job_id'", is_error: true) if id.nil? || id.empty?
-        @jobs[id]? || not_found("no fuzz job #{id}")
+        job = @jobs[id]?
+        return not_found("no fuzz job #{id}") unless job
+        job_project_mismatch(job) || job
       end
 
       # Build a ready-to-run engine + its origin + total + effective http2 from the

--- a/src/gori/mcp/tools/host_overrides.cr
+++ b/src/gori/mcp/tools/host_overrides.cr
@@ -26,10 +26,20 @@ module Gori
         return err("missing required 'ip'", "INVALID_ARGUMENT", field: "ip") if ip.nil? || ip.empty?
         return err("invalid host/ip (host hostname-shaped, ip an IPv4/IPv6 literal)", "INVALID_ARGUMENT") unless HostOverrides.valid?(host, ip)
         ov = HostOverrides.load(store)
-        unless ov.add(host, ip)
-          return busy("failed to add host override (duplicate host, empty, or invalid)")
+        normalized = host.strip.downcase
+        # host/ip are already validated above and HostOverrides#add reports NOTHING about the
+        # store write, so its only remaining false is a DUPLICATE — a deterministic condition
+        # that can never succeed on retry. Reporting it as retryable PROJECT_BUSY made an agent
+        # that trusts `retryable` loop forever (the #414 shape, fixed there in add_scope_rule).
+        if ov.entries.any? { |e| e.host == normalized }
+          return err("a host override for '#{normalized}' already exists (update it by id with update_host_override)",
+            "INVALID_ARGUMENT", field: "host")
         end
-        entry = ov.entries.find { |e| e.host == host.strip.downcase }
+        unless ov.add(host, ip)
+          return err("host override rejected (host must be hostname-shaped, ip an IPv4/IPv6 literal)",
+            "INVALID_ARGUMENT", field: "host")
+        end
+        entry = ov.entries.find { |e| e.host == normalized }
         Result.new(JSON.build do |j|
           j.object do
             j.field "id", entry.try(&.id)
@@ -48,8 +58,14 @@ module Gori
         ip = str(h, "ip").try(&.strip)
         return err("'host' and 'ip' are both required", "INVALID_ARGUMENT") if host.nil? || host.empty? || ip.nil? || ip.empty?
         return err("invalid host/ip (host hostname-shaped, ip an IPv4/IPv6 literal)", "INVALID_ARGUMENT") unless HostOverrides.valid?(host, ip)
+        # Split the two causes HostOverrides#update collapses into one `false`: a collision with
+        # ANOTHER entry is deterministic (never retry), a rolled-back store write is transient.
+        normalized = host.strip.downcase
+        if ov.entries.any? { |e| e.id != id && e.host == normalized }
+          return err("another host override already covers '#{normalized}'", "INVALID_ARGUMENT", field: "host")
+        end
         unless ov.update(id, host, ip)
-          return busy("failed to update host override (duplicate host, empty, or invalid)")
+          return busy("host override NOT updated (store busy or unwritable); it is unchanged")
         end
         Result.new(JSON.build { |j| j.object { j.field "id", id; j.field "host", host.strip.downcase; j.field "ip", ip } })
       end

--- a/src/gori/mcp/tools/intercept.cr
+++ b/src/gori/mcp/tools/intercept.cr
@@ -1,5 +1,7 @@
+require "base64"
 require "json"
 require "../../store"
+require "../request_builder"
 require "../serialize"
 require "../../fuzz"
 
@@ -97,16 +99,43 @@ module Gori
       private def intercept_forward_edit(h) : Result
         id = int(h, "item_id")
         return err(id_error(h, "item_id"), "INVALID_ARGUMENT", field: "item_id") unless id
-        raw = str(h, "raw")
-        return err("missing required 'raw' (the full edited wire message)", "INVALID_ARGUMENT", field: "raw") if raw.nil? || raw.empty?
-        # Normalize line endings to CRLF (like the human intercept editor), then sync
-        # Content-Length to the edited body. Bytes are LITERAL — no Env.expand_wire, so a remote
-        # agent's $SECRET references are never expanded into forwarded traffic; and no smuggling
-        # guard, because byte-exact forwarding of arbitrary edits is the whole point of an
-        # intercept editor in a security tool (matches the human forward_bytes contract).
-        wire = raw.gsub(/\r?\n/, "\r\n")
-        bytes = Fuzz::ContentLength.sync(wire.to_slice, add_when_missing: true)
+        edited = intercept_edit_bytes(h)
+        return edited if edited.is_a?(Result)
+        # Sync Content-Length to the edited body. Bytes are LITERAL — no Env.expand_wire, so a
+        # remote agent's $SECRET references are never expanded into forwarded traffic; and no
+        # smuggling guard, because byte-exact forwarding of arbitrary edits is the whole point of
+        # an intercept editor in a security tool (matches the human forward_bytes contract).
+        bytes = Fuzz::ContentLength.sync(edited, add_when_missing: true)
         enqueue_intercept("forward_edit", item_id: id, bytes: bytes)
+      end
+
+      # The replacement wire message. `raw_base64` is the byte-exact channel — a JSON string
+      # cannot carry arbitrary octets, so it is the ONLY way a binary body survives the round
+      # trip `intercept_get` starts when it hands back `raw_base64`. `raw` stays for the common
+      # text edit; there, lone LFs in the HEADER block become CRLF (a hand-typed message still
+      # frames) while the BODY is left untouched, via the same rule send_request's `raw` uses.
+      # Exactly one of the two, so a caller that sends both is told rather than silently having
+      # one ignored.
+      private def intercept_edit_bytes(h) : Bytes | Result
+        b64 = str(h, "raw_base64").presence
+        raw = str(h, "raw").presence
+        if b64 && raw
+          return err("pass only one of 'raw' or 'raw_base64'", "INVALID_ARGUMENT", field: "raw_base64")
+        end
+        if b64
+          decoded = begin
+            Base64.decode(b64)
+          rescue
+            return err("invalid 'raw_base64' (not valid base64)", "INVALID_ARGUMENT", field: "raw_base64")
+          end
+          return err("'raw_base64' decoded to an empty message", "INVALID_ARGUMENT", field: "raw_base64") if decoded.empty?
+          return decoded
+        end
+        unless raw
+          return err("missing required 'raw' (the full edited wire message) — or 'raw_base64' for byte-exact bytes",
+            "INVALID_ARGUMENT", field: "raw")
+        end
+        RequestBuilder.normalize_raw(raw)
       end
 
       private def intercept_toggle(h) : Result

--- a/src/gori/mcp/tools/issues.cr
+++ b/src/gori/mcp/tools/issues.cr
@@ -53,6 +53,13 @@ module Gori
         # reject it, consistent with how get_flow rejects a non-integer id.
         flow_id = int(h, "flow_id")
         return Result.new("invalid 'flow_id' (expected an integer)", is_error: true) if flow_id.nil? && present?(h, "flow_id")
+        # ...and a well-formed id that names NO flow is just as broken: it produces an issue
+        # whose evidence pointer resolves to nothing, reported as a success. repeater_id has
+        # always been checked; flow_id was not. flow_row is the row-only read (get_flow would
+        # materialize both BLOBs just to answer "does this exist?").
+        if flow_id && !store.flow_row(flow_id)
+          return not_found("no flow with id #{flow_id}")
+        end
         repeater_id = int(h, "repeater_id")
         return Result.new(id_error(h, "repeater_id"), is_error: true) if repeater_id.nil? && present?(h, "repeater_id")
         if repeater_id && !store.get_repeater(repeater_id)

--- a/src/gori/mcp/tools/jobs.cr
+++ b/src/gori/mcp/tools/jobs.cr
@@ -20,6 +20,7 @@ module Gori
                     j.field "total", f.total
                     j.field "matched", f.matched
                     j.field "target", Serialize.text(f.audit.target)
+                    emit_job_project(j, f)
                   end
                 end
                 @mine_jobs.each_value do |m|
@@ -31,6 +32,7 @@ module Gori
                     j.field "names_total", m.total
                     j.field "found", m.found
                     j.field "target", Serialize.text(m.audit.target)
+                    emit_job_project(j, m)
                   end
                 end
                 @discover_jobs.each_value do |d|
@@ -41,6 +43,7 @@ module Gori
                     j.field "sent", d.sent
                     j.field "found", d.found
                     j.field "target", Serialize.text(d.audit.target)
+                    emit_job_project(j, d)
                   end
                 end
                 @sequence_jobs.each_value do |s|
@@ -51,12 +54,21 @@ module Gori
                     j.field "goal", s.goal
                     j.field "collected", s.collected
                     j.field "target", Serialize.text(s.audit.target)
+                    emit_job_project(j, s)
                   end
                 end
               end
             end
           end
         end)
+      end
+
+      # A job started before a switch_project is still LISTED (so an agent can see why an id
+      # it remembers now refuses), but flagged — its *_results/*_status read PROJECT_CHANGED.
+      private def emit_job_project(j : JSON::Builder, job : FuzzJob | MineJob | DiscoverJob | SequenceJob) : Nil
+        return if job.db_path == @db_path
+        j.field "project_changed", true
+        j.field "job_db_path", job.db_path
       end
 
       # Unified status for a fuzz, mine, discover, or sequence job (dispatch by the id prefix),
@@ -86,6 +98,9 @@ module Gori
         return err("missing required 'job_id'", "INVALID_ARGUMENT", field: "job_id") if id.nil? || id.empty?
         job = @jobs[id]? || @mine_jobs[id]? || @discover_jobs[id]? || @sequence_jobs[id]?
         return not_found("no job #{id}") unless job
+        if mismatch = job_project_mismatch(job)
+          return mismatch
+        end
         job.stop
         wait = bool(h, "wait") || false
         waited_out = false

--- a/src/gori/mcp/tools/jobs.cr
+++ b/src/gori/mcp/tools/jobs.cr
@@ -19,7 +19,7 @@ module Gori
                     j.field "sent", f.sent
                     j.field "total", f.total
                     j.field "matched", f.matched
-                    j.field "target", f.audit.target
+                    j.field "target", Serialize.text(f.audit.target)
                   end
                 end
                 @mine_jobs.each_value do |m|
@@ -30,7 +30,7 @@ module Gori
                     j.field "sent", m.sent
                     j.field "names_total", m.total
                     j.field "found", m.found
-                    j.field "target", m.audit.target
+                    j.field "target", Serialize.text(m.audit.target)
                   end
                 end
                 @discover_jobs.each_value do |d|
@@ -40,7 +40,7 @@ module Gori
                     j.field "status", d.status.to_s
                     j.field "sent", d.sent
                     j.field "found", d.found
-                    j.field "target", d.audit.target
+                    j.field "target", Serialize.text(d.audit.target)
                   end
                 end
                 @sequence_jobs.each_value do |s|
@@ -50,7 +50,7 @@ module Gori
                     j.field "status", s.status.to_s
                     j.field "goal", s.goal
                     j.field "collected", s.collected
-                    j.field "target", s.audit.target
+                    j.field "target", Serialize.text(s.audit.target)
                   end
                 end
               end

--- a/src/gori/mcp/tools/mine.cr
+++ b/src/gori/mcp/tools/mine.cr
@@ -20,7 +20,7 @@ module Gori
         audit = JobAudit.new("#{origin.scheme}://#{origin.host}:#{origin.port}",
           int(h, "rate").try(&.to_f64), clamp(int(h, "concurrency"), 10, MINE_MAX_CONCURRENCY),
           int(h, "max_requests"), Time.utc.to_unix_ms)
-        mjob = MineJob.new(id, total, engine, audit)
+        mjob = MineJob.new(id, total, engine, audit, @db_path)
         evict_finished_jobs(@mine_jobs)
         @mine_jobs[id] = mjob
         Log.info { "mine_start #{id} #{origin.scheme}://#{origin.host}:#{origin.port} scope=#{sc.decision} names=#{total}" }
@@ -130,7 +130,9 @@ module Gori
       private def lookup_mine_job(h) : MineJob | Result
         id = str(h, "job_id")
         return Result.new("missing required 'job_id'", is_error: true) if id.nil? || id.empty?
-        @mine_jobs[id]? || not_found("no mine job #{id}")
+        job = @mine_jobs[id]?
+        return not_found("no mine job #{id}") unless job
+        job_project_mismatch(job) || job
       end
 
       private def mine_finding_json(j : JSON::Builder, f : Miner::Finding) : Nil

--- a/src/gori/mcp/tools/mine.cr
+++ b/src/gori/mcp/tools/mine.cr
@@ -135,11 +135,12 @@ module Gori
 
       private def mine_finding_json(j : JSON::Builder, f : Miner::Finding) : Nil
         j.object do
-          j.field "name", f.name
+          # name comes from a caller-supplied wordlist FILE (arbitrary bytes on disk).
+          j.field "name", Serialize.text(f.name)
           j.field "location", f.location.label
           j.field "evidence", f.evidence.label
           j.field "confidence", f.confidence.label
-          j.field "canary", f.canary
+          j.field "canary", Serialize.text(f.canary)
           j.field "status", f.status
           j.field "delta", f.delta
         end

--- a/src/gori/mcp/tools/mine.cr
+++ b/src/gori/mcp/tools/mine.cr
@@ -193,9 +193,9 @@ module Gori
       end
 
       # {raw request text (BEFORE Env expansion — Miner::Plan owns that), default target,
-      # http2}. The target is handed over raw too: expanding it here AND in fuzz_origin was
-      # a double pass, so a var whose value contained a token resolved one level deeper on
-      # MCP than on the CLI.
+      # http2}. The target is handed over raw too: expanding it here as well as in the plan
+      # builder was a double pass, so a var whose value contained a token resolved one level
+      # deeper on MCP than on the CLI.
       private def mine_template_source(h) : {String, String?, Bool}
         if t = str(h, "template")
           return {t, nil, false} unless t.strip.empty?
@@ -205,22 +205,6 @@ module Gori
           raise FuzzArgError.new("no flow with id #{id}") unless detail
           built = Repeater::FlowRequest.build(detail)
           return {String.new(built.bytes), built.target, built.http2}
-        end
-        raise FuzzArgError.new("provide a 'template' (raw request) or a 'flow_id'")
-      end
-
-      # The pre-expanded Bytes shape, still used by `sequence_start` (which assembles its
-      # engine by hand). `mine_start` goes through `mine_template_source` + Miner::Plan
-      # instead, so that Env.expand runs exactly once for a mining run.
-      private def mine_request_source(h) : {Bytes, String?, Bool}
-        if t = str(h, "template")
-          return {Env.expand_wire(t), nil, false} unless t.strip.empty?
-        end
-        if id = int(h, "flow_id")
-          detail = store.get_flow(id)
-          raise FuzzArgError.new("no flow with id #{id}") unless detail
-          built = Repeater::FlowRequest.build(detail)
-          return {Env.expand_wire(String.new(built.bytes)), Env.expand(built.target), built.http2}
         end
         raise FuzzArgError.new("provide a 'template' (raw request) or a 'flow_id'")
       end

--- a/src/gori/mcp/tools/repeater.cr
+++ b/src/gori/mcp/tools/repeater.cr
@@ -206,8 +206,9 @@ module Gori
           store.update_repeater_ws_messages(id, messages)
         end
 
-        # Derive summary
-        line = request.each_line.first?.try(&.strip) || ""
+        # Derive the summary from the MASKED request, like create_repeater: the raw request may
+        # carry a secret in the request-target (e.g. ?token=…) and this field goes to the LLM.
+        line = masked_request.each_line.first?.try(&.strip) || ""
         parts = line.split(' ')
         s = "#{parts[0]?} #{parts[1]?}".strip
         s = line if s.empty?

--- a/src/gori/mcp/tools/scope.cr
+++ b/src/gori/mcp/tools/scope.cr
@@ -54,6 +54,13 @@ module Gori
         return err("invalid 'kind' (expected include|exclude)", "INVALID_ARGUMENT", field: "kind") unless kind.in?(Scope::KINDS)
         match_type = str(h, "match_type").try(&.strip.downcase) || existing.match_type
         return err("invalid 'match_type' (expected host|string|regex)", "INVALID_ARGUMENT", field: "match_type") unless match_type.in?(Scope::TYPES)
+        # An ABSENT pattern keeps the current one; a SUPPLIED blank one is a mistake, not a
+        # no-op — silently keeping the old pattern would report success for an edit that
+        # never happened, on the rule that gates outbound traffic.
+        if present?(h, "pattern") && str(h, "pattern").try(&.strip).presence.nil?
+          return err("'pattern' must not be blank (omit it to keep the current pattern)",
+            "INVALID_ARGUMENT", field: "pattern")
+        end
         pattern = str(h, "pattern").try(&.strip).presence || existing.pattern
         if e = Scope.validation_error(match_type, pattern)
           return err(e, "INVALID_ARGUMENT", field: "pattern")

--- a/src/gori/mcp/tools/send.cr
+++ b/src/gori/mcp/tools/send.cr
@@ -359,7 +359,10 @@ module Gori
           return send_plan_error(ex, "repeater_id")
         end
         host = plan.host
-        sc = ob.check("#{plan.scheme}://#{host}/", host)
+        # Anchor on the same scheme://host/TARGET url send_request uses (Outbound.scope_url).
+        # Checking a bare "/" made a path-scoped include (e.g. string:/chat) refuse the very
+        # WS repeater it was written to allow, while the identical send_request passed.
+        sc = ob.check(request_scope_url(plan), host)
         return scope_blocked(sc) if sc.blocked?
         # Layer 2 (Sandbox) — allow_unscoped does not lift it; refuse before the link write.
         if reason = plan.refusal

--- a/src/gori/mcp/tools/send.cr
+++ b/src/gori/mcp/tools/send.cr
@@ -80,11 +80,13 @@ module Gori
         j.field "effective_request" do
           j.object do
             j.field "scheme", built.scheme
-            j.field "host", built.host
+            j.field "host", Serialize.text(built.host)
             j.field "port", built.port
-            j.field "method", parts[0]? || ""
-            j.field "target", parts[1]? || "/"
-            j.field "http_version", http2 ? "HTTP/2" : (parts[2]? || "HTTP/1.1")
+            # A `raw` send is byte-exact by contract (P7), so the request line here can hold
+            # any octet the caller typed — scrub the ECHO without touching the wire bytes.
+            j.field "method", Serialize.text(parts[0]? || "")
+            j.field "target", Serialize.text(parts[1]? || "/")
+            j.field "http_version", http2 ? "HTTP/2" : Serialize.text(parts[2]? || "HTTP/1.1")
           end
         end
       end
@@ -274,8 +276,10 @@ module Gori
             end
             if response = result.response
               j.field "status", response.status
-              j.field "reason", response.reason
-              j.field "http_version", response.version
+              # The status line and every header come straight off the REMOTE socket —
+              # the least trustworthy source on this surface for JSON-RPC UTF-8 validity.
+              j.field "reason", Serialize.text(response.reason)
+              j.field "http_version", Serialize.text(response.version)
               redacted = false
               j.field "headers" do
                 j.array do
@@ -283,8 +287,8 @@ module Gori
                     sensitive = sensitive_header?(header.name) && !include_sensitive_headers
                     redacted ||= sensitive
                     j.object do
-                      j.field "name", header.name
-                      j.field "value", sensitive ? "[REDACTED]" : header.value
+                      j.field "name", Serialize.text(header.name)
+                      j.field "value", sensitive ? "[REDACTED]" : Serialize.text(header.value)
                     end
                   end
                 end

--- a/src/gori/mcp/tools/sequence.cr
+++ b/src/gori/mcp/tools/sequence.cr
@@ -182,8 +182,7 @@ module Gori
 
       # {raw request bytes, the seeding flow's target, http2} for a collection. Deliberately
       # UNEXPANDED — `Sequencer::Plan.build` owns `Env.expand`, and expanding here as well
-      # (as the shared `mine_request_source` does for the miner) would resolve a var whose
-      # value itself contains a `$TOKEN` twice.
+      # would resolve a var whose value itself contains a `$TOKEN` twice.
       private def sequence_request_source(h) : {Bytes, String?, Bool}
         if t = str(h, "template")
           return {t.to_slice, nil, false} unless t.strip.empty?

--- a/src/gori/mcp/tools/sequence.cr
+++ b/src/gori/mcp/tools/sequence.cr
@@ -39,7 +39,7 @@ module Gori
         audit = JobAudit.new("#{origin.scheme}://#{origin.host}:#{origin.port}",
           int(h, "rate").try(&.to_f64), clamp(int(h, "concurrency"), 1, SEQUENCE_MAX_CONCURRENCY),
           int(h, "max_requests"), Time.utc.to_unix_ms)
-        sjob = SequenceJob.new(id, goal, plan.engine, audit)
+        sjob = SequenceJob.new(id, goal, plan.engine, audit, @db_path)
         evict_finished_jobs(@sequence_jobs)
         @sequence_jobs[id] = sjob
         Log.info { "sequence_start #{id} #{origin.scheme}://#{origin.host}:#{origin.port} scope=#{sc.decision} goal=#{goal} loc=#{plan.config.token_loc.label}" }
@@ -136,7 +136,9 @@ module Gori
       private def lookup_sequence_job(h) : SequenceJob | Result
         id = str(h, "job_id")
         return Result.new("missing required 'job_id'", is_error: true) if id.nil? || id.empty?
-        @sequence_jobs[id]? || not_found("no sequence job #{id}")
+        job = @sequence_jobs[id]?
+        return not_found("no sequence job #{id}") unless job
+        job_project_mismatch(job) || job
       end
 
       # Normalize the tool args into `Sequencer::PlanOptions` and let the shared builder

--- a/src/gori/mcp/tools/sitemap.cr
+++ b/src/gori/mcp/tools/sitemap.cr
@@ -21,12 +21,12 @@ module Gori
           j.array do
             entries.each do |e|
               j.object do
-                j.field "scheme", e.scheme
-                j.field "host", e.host
+                j.field "scheme", Serialize.text(e.scheme)
+                j.field "host", Serialize.text(e.host)
                 j.field "port", e.port
-                j.field "http_version", e.http_version
-                j.field "method", e.method
-                j.field "target", e.target
+                j.field "http_version", Serialize.text(e.http_version)
+                j.field "method", Serialize.text(e.method)
+                j.field "target", Serialize.text(e.target)
                 j.field "statuses", e.statuses
                 j.field "count", e.count
                 j.field "success_count", e.ok
@@ -38,7 +38,7 @@ module Gori
                 # The operator's free-text memo for this endpoint, when one is pinned. The key
                 # is the tree's node path, which includes any query string.
                 if tag = tags[{e.host, sitemap_tag_path(e.target)}]?
-                  j.field "tag", tag
+                  j.field "tag", Serialize.text(tag)
                 end
               end
             end
@@ -84,9 +84,9 @@ module Gori
             tags.each do |(hst, path), tag|
               next if host && hst != host
               j.object do
-                j.field "host", hst
-                j.field "path", path
-                j.field "tag", tag
+                j.field "host", Serialize.text(hst)
+                j.field "path", Serialize.text(path)
+                j.field "tag", Serialize.text(tag)
               end
             end
           end
@@ -118,7 +118,11 @@ module Gori
         Result.new(JSON.build do |j|
           j.array do
             entries.each do |(host, method, target)|
-              j.object { j.field "host", host; j.field "method", method; j.field "target", target }
+              j.object do
+                j.field "host", Serialize.text(host)
+                j.field "method", Serialize.text(method)
+                j.field "target", Serialize.text(target)
+              end
             end
           end
         end)


### PR DESCRIPTION
An audit of the MCP surface — all 111 tools, `src/gori/mcp/**` — reading for defects rather than adding features. Ten fixes, one per commit, each with specs that fail without it (control-run: reverting `src/` fails all 21 new examples).

| # | defect | why it matters |
|---|---|---|
| 1 | invalid UTF-8 reached the JSON-RPC wire | a strict client rejects the **whole** response line |
| 2 | `set_env_var` clobbered out-of-band env writes | silent loss of project secrets |
| 3 | `send_websocket` scope anchored on `/` | path-scoped projects could not run WS repeaters |
| 4 | duplicate host override → `retryable: true` | the #414 infinite-retry shape, unfixed at this site |
| 5 | intercept writes absent from the event feed | the human could not see the AI edit live traffic |
| 6 | `intercept_forward_edit` byte-exact round trip was fiction | binary bodies could not round-trip at all |
| 7 | finished jobs survived `switch_project` | `flow_id`s silently came to mean other rows |
| 8 | three write tools reported success for no-ops | bad evidence links, a leaked secret, a lost edit |
| 9 | `get_current_context` emitted a duplicate key | parser-dependent output |
| 10 | two dead helpers with comments claiming callers | — |

### The one worth reading twice

`Codec::Http1.parse_request_head` builds `method`/`target` with a plain `String.new` over raw wire bytes — no scrub — and SQLite round-trips those bytes verbatim. So a request line like `GET /caf\xE9 HTTP/1.1` puts an invalid byte into `FlowRow#target`, and from there into `list_history`, `list_sitemap`, `get_repeater_context`, response headers off the remote socket, fuzz `extracted` captures, wordlist-sourced miner names — ~20 emit sites. `Serialize.issue` and `emit_capped_text` already scrubbed and documented exactly this hazard; the sibling sites did not.

Fixed with `Serialize.text` as the single seam for outside-origin strings (`scrub` returns self, zero allocation, for the valid case) plus a last-resort net in `Server#send` that warns to STDERR, so a future emit site cannot put the transport back off-contract silently.

**A trap worth recording:** the first version of these specs asserted on parsed fields and a control run **passed 3 of 4**. Crystal's JSON parser reassembles an *escaped* string char-by-char and substitutes U+FFFD for an invalid byte, so `JSON.parse(resp)["target"].valid_encoding?` reports clean text for a payload that is not. (A string with no escapes takes a slice fast-path and *does* preserve the bytes, which is what makes an isolated probe misleading.) The specs now assert on the raw payload, and go through `Tools` rather than `Server` so they pin the per-site calls instead of the net that backstops them.

### Verification

- `4786 examples, 0 failures` (full suite, after rebase onto `main`)
- `crystal build --no-codegen src/main.cr` on the **rebased** tree — CI never builds the merge result
- format clean; ameba unchanged at 40 findings across `src/gori/mcp/` (no new violations)
- control run: `git checkout -- src/` → all 21 new examples fail, then pass with the fixes
