### PR TITLE
fix(probe): grade a reflection by what survived, not by whether it came back

### DIFF
--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -2015,19 +2015,91 @@ describe "Gori::Probe::Active (safety + coverage)" do
     end
   end
 
-  it "rates an HTML reflection Medium and a non-HTML (JSON) reflection Low" do
+  # The canary carries a `"'<>` marker; the grade is decided by which of those characters came
+  # back VERBATIM, not by "the value came back" (which is true of correctly-escaped output too).
+  it "grades a reflection by which marker characters survived" do
     with_store do |store|
       detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=hi", content_type: nil)
       plan = Gori::Probe::Active.plan(detail).not_nil!
       canary = plan.params.first.canary
-      html = Gori::Repeater::Result.new(
-        "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n".to_slice,
-        "<p>#{canary}</p>".to_slice, nil, 1_i64)
-      Gori::Probe::Active.detections(plan, html, detail).first.severity.should eq(Gori::Store::Severity::Medium)
-      json = Gori::Repeater::Result.new(
-        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n".to_slice,
-        %({"q":"#{canary}"}).to_slice, nil, 1_i64)
-      Gori::Probe::Active.detections(plan, json, detail).first.severity.should eq(Gori::Store::Severity::Low)
+      raw = Gori::Probe::Active::ReflectedParam.probe_value(canary)
+      html_head = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n"
+      res = ->(head : String, body : String) do
+        Gori::Repeater::Result.new(head.to_slice, body.to_slice, nil, 1_i64)
+      end
+
+      # `<` came back raw in HTML → tag injection possible → the historic Medium.
+      d = Gori::Probe::Active.detections(plan, res.call(html_head, "<p>#{raw}</p>"), detail).first
+      d.severity.should eq(Gori::Store::Severity::Medium)
+      d.title.should contain("unencoded")
+
+      # Same raw echo in a JSON body: not an HTML sink → Low.
+      json_head = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n"
+      Gori::Probe::Active.detections(plan, res.call(json_head, %({"q":"#{raw}"})), detail)
+        .first.severity.should eq(Gori::Store::Severity::Low)
+
+      # Quotes survived but `<` was escaped → attribute context only → Low.
+      attr_echo = %(<a title="#{canary}"'&lt;&gt;">x</a>)
+      d2 = Gori::Probe::Active.detections(plan, res.call(html_head, attr_echo), detail).first
+      d2.severity.should eq(Gori::Store::Severity::Low)
+      d2.title.should contain("attribute context")
+
+      # Everything escaped → a reflection POINT, not a vulnerability → Info, not Medium.
+      escaped = "<p>#{canary}&quot;&#39;&lt;&gt;</p>"
+      d3 = Gori::Probe::Active.detections(plan, res.call(html_head, escaped), detail).first
+      d3.severity.should eq(Gori::Store::Severity::Info)
+      d3.title.should contain("escaped or filtered")
+    end
+  end
+
+  # A value routinely lands in several places in one response, and the ESCAPED one is as likely
+  # to come first as the raw one — a value is only as safe as its weakest sink.
+  it "grades on the weakest sink when the value is reflected more than once" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=hi", content_type: nil)
+      plan = Gori::Probe::Active.plan(detail).not_nil!
+      canary = plan.params.first.canary
+      raw = Gori::Probe::Active::ReflectedParam.probe_value(canary)
+      # Escaped in the page text FIRST, raw inside a later script block.
+      body = "<p>#{canary}&quot;&#39;&lt;&gt;</p><script>var q=\"#{raw}\";</script>"
+      d = Gori::Probe::Active.detections(plan,
+        Gori::Repeater::Result.new("HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n".to_slice,
+          body.to_slice, nil, 1_i64), detail).first
+      d.severity.should eq(Gori::Store::Severity::Medium)
+      d.title.should contain("unencoded")
+    end
+  end
+
+  # Same reasoning across the head/body split: a header echo must not mask a raw body echo.
+  it "grades on the weakest sink across the response head and body" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=hi", content_type: nil)
+      plan = Gori::Probe::Active.plan(detail).not_nil!
+      canary = plan.params.first.canary
+      raw = Gori::Probe::Active::ReflectedParam.probe_value(canary)
+      head = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nX-Echo: #{canary}\r\n\r\n"
+      d = Gori::Probe::Active.detections(plan,
+        Gori::Repeater::Result.new(head.to_slice, "<p>#{raw}</p>".to_slice, nil, 1_i64), detail).first
+      d.severity.should eq(Gori::Store::Severity::Medium)
+    end
+  end
+
+  # The marker has to reach the server as real characters, and the canary must still be findable.
+  it "sends the marker URL-encoded in the query and JSON-escaped in a body" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=hi", content_type: nil)
+      plan = Gori::Probe::Active.plan(detail).not_nil!
+      canary = plan.params.first.canary
+      req = String.new(plan.request)
+      req.should contain("q=#{canary}%22%27%3C%3E")
+      req.should_not contain("<") # nothing raw on the request line
+
+      body_detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/api", method: "POST",
+        req_headers: "Content-Type: application/json\r\n", req_body: %({"q":"hi"}), content_type: nil)
+      unsafe = Gori::Probe::Active::Options.new(allow_unsafe: true)
+      jplan = Gori::Probe::Active::ReflectedParam.new.plan(body_detail, unsafe).not_nil!
+      jc = jplan.params.first.canary
+      String.new(jplan.request).should contain(%(#{jc}\\"'<>))
     end
   end
 
@@ -2833,6 +2905,42 @@ describe "Gori::Probe::Active::BackslashPowered" do
       probe.detections_all(plan,
         [resp.call(200, "welcome"), resp.call(200, "You have an error in your SQL syntax"),
          resp.call(500, ""), resp.call(200, "welcome")], detail).should be_empty
+    end
+  end
+
+  # The technique's central signal is a body that CHANGED, which a {status, error-class}
+  # fingerprint alone could not see: same 200, no recognised error string, completely different
+  # page read as "identical". Body length joins the fingerprint only when the two baselines
+  # proved the endpoint reproduces its own length.
+  it "fires on a body that changed shape with no status flip and no error string" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=hi")
+      plan = probe.plan(detail).not_nil!
+      # Both baselines are byte-identical → length is trustworthy → the `\` leg's shorter body
+      # is a real difference, and the `\\` leg reverting to baseline is the escape asymmetry.
+      dets = probe.detections_all(plan,
+        [resp.call(200, "the full rendered page"), resp.call(200, "the full rendered page"),
+         resp.call(200, "oops"), resp.call(200, "the full rendered page")], detail)
+      dets.size.should eq(1)
+      dets.first.evidence.not_nil!.should contain("body")
+    end
+  end
+
+  # …but a length-jittery endpoint must NOT get the sharper comparison, or every page with a
+  # timestamp in it becomes a finding. It falls back to status + error-class, not to nothing.
+  it "falls back to the status/error fingerprint when the baseline length is not reproducible" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=hi")
+      plan = probe.plan(detail).not_nil!
+      # Baselines differ ONLY in length → length is dropped from the fingerprint → a `\` leg that
+      # differs only in length is no longer a difference.
+      probe.detections_all(plan,
+        [resp.call(200, "rendered at 10:00:00"), resp.call(200, "rendered at 10:00:01x"),
+         resp.call(200, "short"), resp.call(200, "rendered at 10:00:02")], detail).should be_empty
+      # The status flip still fires on that same jittery endpoint — the check is not lost.
+      probe.detections_all(plan,
+        [resp.call(200, "rendered at 10:00:00"), resp.call(200, "rendered at 10:00:01x"),
+         resp.call(500, "boom"), resp.call(200, "rendered at 10:00:02")], detail).size.should eq(1)
     end
   end
 

--- a/src/gori/probe/active/backslash_powered.cr
+++ b/src/gori/probe/active/backslash_powered.cr
@@ -110,15 +110,15 @@ module Gori
         # grouped Detection per host, listing the affected params.
         # results = [baseline, baseline2, single_0, double_0, single_1, double_1, …].
         def detections_all(plan : Plan, results : Array(Repeater::Result), detail : Store::FlowDetail) : Array(Detection)
-          base = stable_baseline(results) || return [] of Detection
+          base, with_size = stable_baseline(results) || return [] of Detection
           hits = [] of String
           plan.params.each_with_index do |param, i|
             single = results[2 + 2 * i]?
             double = results[3 + 2 * i]?
             next unless single && double
             next unless single.ok? && double.ok? # a failed leg ⇒ incomplete comparison, skip
-            sa = attrs(single)
-            da = attrs(double)
+            sa = attrs(single, with_size)
+            da = attrs(double, with_size)
             # The asymmetry that marks an escape being interpreted. A reflecting/echoing endpoint
             # changes for BOTH the `\` and `\\` forms (no asymmetry) and is never flagged here.
             hits << "#{param.name}#{describe_break(base, sa)}" if sa != base && da == base
@@ -189,24 +189,37 @@ module Gori
           dup.join('&')
         end
 
-        # The baseline fingerprint — but only when the endpoint reproduced it on a SECOND identical
-        # request (results[0] and results[1]). nil when either baseline is missing or failed to
-        # send, or when the two disagree: an endpoint whose answer to one request varies on its own
-        # cannot support a difference test, so every asymmetry below would be a coin flip. Returning
-        # nil makes the rule decline rather than guess.
-        private def stable_baseline(results : Array(Repeater::Result)) : {Int32, String?}?
+        # {baseline fingerprint, whether body LENGTH is part of it} — but only when the endpoint
+        # reproduced that fingerprint on a SECOND identical request (results[0] and results[1]).
+        # nil when either baseline is missing or failed to send, or when the two disagree even
+        # ignoring length: an endpoint whose answer to one request varies on its own cannot support
+        # a difference test, so every asymmetry below would be a coin flip.
+        #
+        # The length decision is what the second baseline buys beyond the stability check. Status +
+        # error-class alone missed the technique's central signal — a body that changes COMPLETELY
+        # with no status flip and no recognised error string read as "identical" — but adding length
+        # blindly would have fired on every page with a timestamp in it. Asking the endpoint whether
+        # its own length is reproducible answers that per target instead of guessing globally: a
+        # length-stable endpoint gets the sharper comparison, a jittery one falls back to the
+        # historic status + error-class fingerprint rather than losing the check entirely.
+        private def stable_baseline(results : Array(Repeater::Result)) : { {Int32, String?, Int32}, Bool }?
           first = results[0]?
           second = results[1]?
           return nil unless first && first.ok? && second && second.ok?
-          base = attrs(first)
-          attrs(second) == base ? base : nil
+          sized = attrs(first, true)
+          return {sized, true} if sized == attrs(second, true)
+          blind = attrs(first, false)
+          blind == attrs(second, false) ? {blind, false} : nil
         end
 
-        # A comparable response fingerprint: status code + a coarse interpreter-error class (nil when
-        # the body shows none). Two responses are "the same" iff both match — deliberately NOT a
-        # byte diff, so ordinary dynamic-content jitter doesn't read as a difference.
-        private def attrs(result : Repeater::Result) : {Int32, String?}
-          {response_status(result), error_signature(result)}
+        # A comparable response fingerprint: status code, a coarse interpreter-error class (nil when
+        # the body shows none), and — when `with_size` — the decoded body length. Two responses are
+        # "the same" iff all three match. Still not a byte diff: length moves only when the body
+        # really changed shape, so ordinary same-length content jitter doesn't read as a difference.
+        # `with_size: false` substitutes a constant, so a jittery endpoint compares on the other two.
+        private def attrs(result : Repeater::Result, with_size : Bool) : {Int32, String?, Int32}
+          body = decoded_body(result)
+          {response_status(result), error_signature_of(body), with_size ? body.bytesize : -1}
         end
 
         private def response_status(result : Repeater::Result) : Int32
@@ -229,8 +242,7 @@ module Gori
                        "syntaxerror", "parse error", "invalid escape", "eol while scanning"],
         }
 
-        private def error_signature(result : Repeater::Result) : String?
-          body = decoded_body(result)
+        private def error_signature_of(body : String) : String?
           return nil if body.empty?
           hay = body.downcase
           ERROR_SIGNATURES.each do |label, needles|
@@ -250,11 +262,15 @@ module Gori
 
         # A short human tag for the evidence line: prefer the interpreter-error class, else the
         # status flip, else nothing (a difference the fingerprint can't name).
-        private def describe_break(base : {Int32, String?}, single : {Int32, String?}) : String
+        private def describe_break(base : {Int32, String?, Int32}, single : {Int32, String?, Int32}) : String
           if err = single[1]
             " (#{err} error)"
           elsif single[0] != base[0]
             " (#{base[0]}→#{single[0]})"
+          elsif single[2] >= 0 && single[2] != base[2]
+            # Same status, no recognised error string, but the body changed shape — the case the
+            # old status-only fingerprint reported as "identical" and silently dropped.
+            " (body #{base[2]}→#{single[2]} bytes)"
           else
             ""
           end

--- a/src/gori/probe/active/reflected_param.cr
+++ b/src/gori/probe/active/reflected_param.cr
@@ -13,9 +13,37 @@ module Gori
     module Active
       # Reflected parameters. For one in-scope flow it replaces each existing parameter value
       # (query / form / JSON) with a distinct canary, sends ONE request, and reports the
-      # parameters whose canary echoes back unencoded (XSS candidates). Gated to safe methods
-      # so an automatic probe never mutates server state.
+      # parameters whose canary echoes back — grading each by whether the echo was ENCODED.
+      # Gated to safe methods so an automatic probe never mutates server state.
+      #
+      # The canary carries a MARKER of the four characters that decide whether a reflection is
+      # exploitable: `"`, `'`, `<`, `>`. An alphanumeric canary on its own cannot answer that
+      # question — it survives HTML-escaping unchanged, so "the value came back" was reported
+      # identically for a raw injection point and for output a template escaped correctly. Since
+      # correct escaping is the norm, that made the common case the finding: nearly every
+      # reflecting endpoint scored Medium.
+      #
+      # Reading which marker characters came back VERBATIM, immediately after the canary, splits
+      # them apart:
+      #   * `<` survived        — tag injection is possible; the classic XSS candidate.
+      #   * only `"` / `'`      — an attribute-context break, exploitable only in some sinks.
+      #   * none survived       — the value was escaped, stripped, or encoded. Still worth knowing
+      #                           as a reflection point, so it is reported at Info rather than
+      #                           dropped, but it is not an XSS finding.
+      # A partial survival is read in order, so `"'&lt;&gt;` reports `"'` — an escaped `<` stops
+      # the run exactly where the server's filter did.
       class ReflectedParam < Rule
+        # Appended to every canary. Sent URL-encoded (query/form) or JSON-escaped (body), so the
+        # server decodes real characters; what comes back tells us what its output layer did with
+        # them. Order matters: `survived` reads this prefix-wise.
+        MARKER = "\"'<>"
+
+        # The full value sent for a canary. Public so specs (and a manual re-send) can reproduce
+        # the exact bytes the probe put in the parameter.
+        def self.probe_value(canary : String) : String
+          canary + MARKER
+        end
+
         def info : RuleInfo
           RuleInfo.new("reflected_param", "Reflected parameter",
             "Sends a canary in query parameters and flags unencoded reflection (potential XSS).",
@@ -129,34 +157,96 @@ module Gori
           h.each { |k, v| yield k if v.as_s? }
         end
 
-        # Interpret the probe's response: any reflected-parameter Detection (one grouped row per host).
+        # Interpret the probe's response: at most ONE Detection, graded by the strongest echo seen
+        # (one grouped row per host).
         def detections(plan : Plan, result : Repeater::Result, detail : Store::FlowDetail) : Array(Detection)
-          reflected = reflections(result, plan.params)
-          return [] of Detection if reflected.empty?
-          names = reflected.map { |p| "#{p.name} (#{p.location})" }
-          names.uniq!
-          url = detail.row.url
-          # An echo in an HTML response is a plausible XSS sink (Medium); an echo in a non-HTML
-          # response (JSON/text API) is just a reflected value, not exploitable as XSS (Low).
+          hits = reflections(result, plan.params)
+          return [] of Detection if hits.empty?
           html = response_content_type(result).includes?("html")
-          sev = html ? Store::Severity::Medium : Store::Severity::Low
-          title = html ? "Reflected parameter" : "Reflected parameter (non-HTML context)"
-          [Detection.new("reflected_param", Category::ACTIVE, detail.row.host, url,
+          # Grade on the strongest echo: a raw `<` anywhere outranks a bare quote, which outranks
+          # an escaped echo. Only the params at that tier are named, so the evidence describes the
+          # finding rather than mixing an injection point in with correctly-escaped output.
+          tier, sev, title = grade(hits, html)
+          names = hits.select { |(_, s)| tier_of(s) == tier }
+            .map { |(p, s)| "#{p.name} (#{p.location}#{s.empty? ? "" : ", #{s} survived"})" }
+          names.uniq!
+          [Detection.new("reflected_param", Category::ACTIVE, detail.row.host, detail.row.url,
             title, sev, names.join(", ")[0, 120], detail.row.id)]
         end
 
-        # Scan BOTH the response head (reflected Location/Set-Cookie/custom headers) and the
-        # decoded body for each canary — header reflections (e.g. open-redirect Location) are
-        # invisible to a body-only scan.
-        private def reflections(result : Repeater::Result, params : Array(Param)) : Array(Param)
-          return [] of Param unless result.ok?
+        # 2 = a raw `<` (tag injection), 1 = a quote only (attribute context), 0 = escaped/stripped.
+        private def tier_of(survived : String) : Int32
+          return 2 if survived.includes?('<')
+          survived.empty? ? 0 : 1
+        end
+
+        # {tier, severity, title} for the strongest echo present. Only a raw `<` in an HTML
+        # response keeps the historic Medium; an escaped echo is Info — a reflection point worth
+        # knowing, not a vulnerability.
+        private def grade(hits : Array({Param, String}), html : Bool) : {Int32, Store::Severity, String}
+          tier = hits.max_of { |(_, s)| tier_of(s) }
+          case tier
+          when 2
+            if html
+              {2, Store::Severity::Medium, "Reflected parameter (unencoded, tag injection possible)"}
+            else
+              {2, Store::Severity::Low, "Reflected parameter (unencoded, non-HTML context)"}
+            end
+          when 1
+            {1, Store::Severity::Low, "Reflected parameter (quote survived, attribute context)"}
+          else
+            {0, Store::Severity::Info, "Reflected parameter (escaped or filtered)"}
+          end
+        end
+
+        # {param, surviving marker characters} for every param whose canary echoed back. Scans BOTH
+        # the response head (reflected Location/Set-Cookie/custom headers) and the decoded body —
+        # header reflections (e.g. open-redirect Location) are invisible to a body-only scan.
+        private def reflections(result : Repeater::Result, params : Array(Param)) : Array({Param, String})
+          found = [] of {Param, String}
+          # NOTE: not `out` — that is a Crystal keyword (C-binding output parameters), and
+          # `return out unless …` parses as the keyword, not the local.
+          return found unless result.ok?
           head = String.new(result.head).scrub
           # Canary search only reads the first BODY_CAP bytes, so cap the inflate to match.
           decoded, _ = Proxy::Codec::ContentDecode.decode(result.head, result.body, BODY_CAP)
           bytes = decoded || result.body
           body = (bytes && !bytes.empty?) ? String.new(bytes[0, {bytes.size, BODY_CAP}.min]).scrub : ""
-          hay = "#{head}\n#{body}"
-          params.select { |p| hay.includes?(p.canary) }
+          params.each do |p|
+            # Search head and body separately: concatenating them allocated a full copy of both
+            # (up to BODY_CAP + head) on every probe just to run one substring scan per param.
+            # Take the BEST of the two — a value echoed into several contexts (escaped in the
+            # page text, raw inside a script block or a header) is only as safe as its weakest
+            # sink, so grading on whichever context preserved the most characters is the correct
+            # reading, not merely the first one found.
+            best = [survived(head, p.canary), survived(body, p.canary)].compact.max_by?(&.size)
+            found << {p, best} if best
+          end
+          found
+        end
+
+        # The MARKER characters that came back VERBATIM right after `canary` in `hay`, read
+        # prefix-wise; "" when the canary echoed but every marker character was escaped, stripped,
+        # or re-encoded. nil when the canary does not appear at all.
+        #
+        # Every occurrence is examined, not just the first: the same value routinely lands in more
+        # than one place in one response, and the first hit is as likely to be the escaped one as
+        # the raw one. Returns the longest surviving prefix across them. Occurrences of a 10-char
+        # random canary are few, so the walk is bounded in practice.
+        private def survived(hay : String, canary : String) : String?
+          from = 0
+          best = nil.as(String?)
+          while i = hay.index(canary, from)
+            tail = i + canary.size
+            n = 0
+            while n < MARKER.size && (c = hay[tail + n]?) && c == MARKER[n]
+              n += 1
+            end
+            best = MARKER[0, n] if best.nil? || n > best.size
+            break if n == MARKER.size # nothing can beat a full survival
+            from = tail
+          end
+          best
         end
 
         private def response_content_type(result : Repeater::Result) : String
@@ -188,7 +278,10 @@ module Gori
             next pair if name.empty?
             canary = Miner::Canary.fresh
             params << Param.new(location, decode_name(name), canary)
-            "#{name}=#{canary}"
+            # URL-encoded: the marker carries `"'<>`, which have no business sitting raw in a
+            # request line (the alnum canary alone needed no encoding). space_to_plus:false for
+            # the same reason Ssti#inject uses it — `+` is not universally decoded back to a space.
+            "#{name}=#{URI.encode_www_form(ReflectedParam.probe_value(canary), space_to_plus: false)}"
           end.join('&')
           {rebuilt, params}
         end
@@ -214,7 +307,9 @@ module Gori
             if v.as_s?
               canary = Miner::Canary.fresh
               params << Param.new("json", k, canary)
-              merged[k] = JSON::Any.new(canary)
+              # `to_json` escapes the marker's `"` for the wire; the server decodes it back, so
+              # what it reflects is the real character — exactly what `survived` needs to read.
+              merged[k] = JSON::Any.new(ReflectedParam.probe_value(canary))
             else
               merged[k] = v
             end


### PR DESCRIPTION
Two false negatives from the rule-set review, both cases of a check that could not see the signal it claimed to report.

## `reflected_param` — an alphanumeric canary cannot tell XSS from correct escaping

The rule's own description says it "flags unencoded reflection", but the canary was alphanumeric: **it survives HTML-escaping unchanged.** So "the value came back" was reported identically for a raw injection point and for output a template escaped correctly. Correct escaping being the norm, that made the common case the finding — nearly every reflecting endpoint scored Medium.

The canary now carries a MARKER of the four characters that decide exploitability — `"` `'` `<` `>` — sent URL-encoded in a query/form and JSON-escaped in a body, so the server decodes real characters and what comes back shows what its output layer did with them. The grade reads which of them returned **verbatim**, prefix-wise:

| survived | meaning | severity |
|---|---|---|
| `<` | tag injection possible | **Medium** (HTML) / Low (non-HTML) |
| only `"` / `'` | attribute-context break | Low |
| none | escaped / stripped / re-encoded | **Info** |

A partial survival stops where the filter did, so `"'&lt;&gt;` reports `"'`. The escaped case is reported at Info rather than dropped — a reflection point is worth knowing, it is just not a vulnerability.

**Grading takes the weakest sink, not the first match.** One value routinely lands in several places in one response, and the escaped occurrence is as likely to come first as the raw one. Every occurrence is examined, across both the response head and body, and the longest surviving prefix wins.

## `backslash_powered` — a body that changed completely read as "identical"

The fingerprint was `{status, error-class}`, so the technique's central signal — *the response changed* — was invisible whenever the status held and no recognised error string appeared. A same-200 page swapped for an entirely different one was "no difference".

Body length now joins the fingerprint, **but only when the endpoint has proved it reproduces its own length.** #478's second baseline already exists, so comparing the two size-aware fingerprints answers "is length meaningful on this target?" per endpoint instead of guessing globally:

- length-stable endpoint → the sharper comparison
- jittery endpoint (a timestamp, a rotating token) → falls back to the historic `{status, error-class}` fingerprint

That is the difference between closing the FN and trading it for an FP on every page with a clock in it. Evidence names the change: `(body 1234→56 bytes)`.

## Also

Renamed a local from `out` — that is a Crystal keyword (C-binding output parameters), and `return out unless …` parses as the keyword, not the local. Cost me a confusing `unexpected token: "result"` pointing at the wrong line.

## Verification

- `crystal spec` — **4765 examples, 0 failures**
- `crystal tool format --check` on all touched files — clean
- `crystal build --no-codegen src/main.cr` — clean
- ameba on the touched files: only the **3 warnings already present on `main`**

New specs cover each grade tier, multi-occurrence weakest-sink grading (in-body and across head/body), the wire encoding in both query and JSON, the body-length signal firing, and the jittery-endpoint fallback still catching a status flip.

## Remaining from the review

`post_message`'s whole-fragment origin suppression, `cacheable_json`'s volume, and `lfi_param_traversal`'s over-broad param names — a separate PR.