### PR TITLE
fix(probe): scope three rules to the traffic they were written for

### DIFF
--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -1035,11 +1035,14 @@ describe "Gori::Probe::Passive (new patterns)" do
   end
 
   describe "cacheable JSON API responses" do
+    # The risk is a cache serving ONE user's data to another, so every case here authenticates.
+    authed = "Cookie: sid=abc\r\n"
+
     it "flags application/json without Cache-Control (sensitive data may be stored)" do
       with_store do |store|
         dets = analyze(store,
           resp_head: "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n",
-          content_type: "application/json", body: %({"token":"x"}))
+          content_type: "application/json", body: %({"token":"x"}), req_headers: authed)
         hit = dets.find(&.code.==("cacheable_json")).not_nil!
         hit.severity.should eq(Gori::Store::Severity::Medium)
         hit.title.should contain("missing Cache-Control")
@@ -1055,8 +1058,35 @@ describe "Gori::Probe::Passive (new patterns)" do
         ].each do |cc|
           head = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n#{cc}\r\n\r\n"
           codes_of(analyze(store, resp_head: head, content_type: "application/json",
-            body: "{}")).should contain("cacheable_json")
+            body: "{}", req_headers: authed)).should contain("cacheable_json")
         end
+      end
+    end
+
+    # A public endpoint has nothing user-specific for a cache to leak, and leaving it cacheable is
+    # a performance decision. Without this gate the rule fired on most 2xx JSON on most servers.
+    it "does not flag an UNAUTHENTICATED response" do
+      with_store do |store|
+        codes_of(analyze(store,
+          resp_head: "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n",
+          content_type: "application/json", body: %({"public":true}))).should_not contain("cacheable_json")
+      end
+    end
+
+    it "counts an Authorization request header or a Set-Cookie response as authenticated" do
+      with_store do |store|
+        codes_of(analyze(store,
+          resp_head: "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n",
+          content_type: "application/json", body: %({"me":1}),
+          req_headers: "Authorization: Bearer x\r\n")).should contain("cacheable_json")
+        codes_of(analyze(store,
+          resp_head: "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nSet-Cookie: sid=new\r\n\r\n",
+          content_type: "application/json", body: %({"me":1}))).should contain("cacheable_json")
+        # An empty Cookie header is not authentication.
+        codes_of(analyze(store,
+          resp_head: "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n",
+          content_type: "application/json", body: %({"me":1}),
+          req_headers: "Cookie:  \r\n")).should_not contain("cacheable_json")
       end
     end
 
@@ -1084,7 +1114,7 @@ describe "Gori::Probe::Passive (new patterns)" do
       with_store do |store|
         head = "HTTP/1.1 200 OK\r\nContent-Type: application/problem+json\r\n\r\n"
         codes_of(analyze(store, resp_head: head, content_type: "application/problem+json",
-          body: %({"title":"err"}))).should contain("cacheable_json")
+          body: %({"title":"err"}), req_headers: authed)).should contain("cacheable_json")
       end
     end
   end
@@ -2548,6 +2578,50 @@ describe Gori::Probe::Passive::PostMessage do
     end
   end
 
+  # The origin test used to run over the WHOLE fragment, so one unrelated `.origin` anywhere in a
+  # bundle suppressed every finding in it — the rule detected nothing on real bundles.
+  it "still flags an unchecked handler when an unrelated .origin exists elsewhere in the bundle" do
+    with_store do |store|
+      js = %(var o = location.origin + "/api";) + ("var pad#{1};" * 5) +
+           %(window.addEventListener("message", function(e){ handle(e.data); });)
+      codes_of(analyze_js(store, js)).should contain("postmessage_no_origin")
+    end
+  end
+
+  it "judges each handler separately — a checked one does not vouch for an unchecked one" do
+    with_store do |store|
+      checked = %(window.addEventListener("message", function(e){ if (e.origin === "https://x") a(e.data); });)
+      unchecked = %(window.addEventListener("message", function(e){ b(e.data); });)
+      codes_of(analyze_js(store, checked + unchecked)).should contain("postmessage_no_origin")
+      codes_of(analyze_js(store, checked + checked)).should_not contain("postmessage_no_origin")
+    end
+  end
+
+  # A handler passed by NAME has its body elsewhere, so no window around the call site can say
+  # whether it checks the origin — guessing there would be a false positive.
+  it "does not judge a handler passed by name (body not visible here)" do
+    with_store do |store|
+      js = %(function onMsg(e){ handle(e.data); } window.addEventListener("message", onMsg);)
+      codes_of(analyze_js(store, js)).should_not contain("postmessage_no_origin")
+    end
+  end
+
+  it "flags an arrow-function handler with no origin check" do
+    with_store do |store|
+      js = %(window.addEventListener("message", (e) => { handle(e.data); });)
+      codes_of(analyze_js(store, js)).should contain("postmessage_no_origin")
+    end
+  end
+
+  it "does not flag an origin check that sits far past the handler window" do
+    with_store do |store|
+      js = %(window.onmessage = function(e){ ) + ("noop();" * 400) + %( if (e.origin) ok(); };)
+      # The check is beyond HANDLER_WINDOW, so the handler reads as unchecked — the deliberate
+      # cost of scoping the test to a window rather than the whole fragment.
+      codes_of(analyze_js(store, js)).should contain("postmessage_no_origin")
+    end
+  end
+
   it "flags a wildcard target origin and document.domain relaxation" do
     with_store do |store|
       codes_of(analyze_js(store, %(parent.postMessage(payload, "*");))).should contain("postmessage_wildcard")
@@ -3185,6 +3259,35 @@ describe "Gori::Probe::Active::LfiParamTraversal" do
       probe.plan(capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/dl?file=doc.pdf")).should be_nil
       probe.plan(capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/dl?file=../etc/passwd", body: "X")).should be_nil
       probe.plan(capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/dl?file=doc.pdf", body: "X", method: "POST")).should be_nil
+    end
+  end
+
+  # The name list is checked REGARDLESS of the value, so an everyday application parameter in it
+  # sent three probes at a large share of all traffic for nothing.
+  it "does not treat ordinary application parameters as file parameters" do
+    with_store do |store|
+      ["/u?name=John", "/l?view=grid", "/l?page=2", "/l?load=more", "/go?url=alpha"].each do |t|
+        probe.plan(capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: t, body: "X")).should be_nil, t
+      end
+      # A bare identifier under a real file param is an id, not a filename.
+      probe.plan(capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/d?doc=1234", body: "X")).should be_nil
+      # …but a file-SHAPED value still qualifies under ANY name, so nothing is lost.
+      probe.plan(capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/l?page=home.html", body: "X")).should_not be_nil
+      probe.plan(capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/go?url=a/b", body: "X")).should_not be_nil
+    end
+  end
+
+  # `includes?(".js")` fired inside `.json`, and `.md` inside `.mdx`.
+  it "requires a real extension boundary, not a substring of a longer one" do
+    with_store do |store|
+      # `data.jsonp` / `notes.mdx` are not the .js / .md files the old substring test saw — and
+      # neither name is a file param, so nothing else qualifies them.
+      probe.plan(capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/a?q=data.jsonp", body: "X")).should be_nil
+      probe.plan(capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/a?q=notes.mdx", body: "X")).should be_nil
+      # The real extensions still qualify.
+      ["/a?q=app.js", "/a?q=data.json", "/a?q=notes.md"].each do |t|
+        probe.plan(capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: t, body: "X")).should_not be_nil, t
+      end
     end
   end
 

--- a/src/gori/probe/active/lfi_param_traversal.cr
+++ b/src/gori/probe/active/lfi_param_traversal.cr
@@ -36,11 +36,21 @@ module Gori
         ENC_FOLD = "x/%2e%2e/"  # value -> x/%2e%2e/value      (encoded .. — defeats a literal-".." filter)
         CONTROL  = "x/zzznope/" # value -> x/zzznope/value     (a real subdir that cannot normalize back)
 
-        # Query-param names that conventionally carry a filesystem path/filename.
-        KNOWN_FILE_PARAMS = Set{"file", "filename", "path", "page", "template", "doc", "document",
-                                "download", "view", "include", "load", "name", "url", "dir", "folder"}
-        # File-extension tells (lower-cased, substring match — a value carrying one looks file-like).
-        FILE_EXTS = %w[.pdf .js .css .png .jpg .jpeg .gif .svg .txt .json .xml .html .htm .php .log .csv .md .yml .yaml .ini .conf]
+        # Query-param names that conventionally carry a filesystem path/filename — and little else.
+        # `name`, `url`, `view`, `page`, and `load` were dropped: `?name=John`, `?view=grid`, and
+        # `?page=2` are ordinary application parameters, and this name list is checked REGARDLESS
+        # of the value, so each of them alone sent three probes at a large share of all traffic.
+        # Nothing is lost by dropping them — a genuinely file-shaped value under any name still
+        # qualifies through the `/` or file-extension tests below.
+        KNOWN_FILE_PARAMS = Set{"file", "filename", "filepath", "path", "template", "doc",
+                                "document", "download", "include", "dir", "folder"}
+        # File-extension tells. The extension must not be followed by another word character, so
+        # `.js` no longer matches inside `.json` and `.md` no longer matches inside `.mdx` — the
+        # old plain `includes?` treated both as file-like.
+        FILE_EXT = /\.(?:pdf|js|css|png|jpe?g|gif|svg|txt|json|xml|html?|php|log|csv|md|ya?ml|ini|conf)(?![0-9a-z])/i
+        # A value that is only digits is an identifier, never a traversal-useful filename. Guards
+        # the NAME-based branch, where the value is otherwise unconstrained (`?doc=1234`).
+        NUMERIC_VALUE = /\A\d+\z/
 
         def info : RuleInfo
           RuleInfo.new("lfi_param_traversal", "Parameter path traversal",
@@ -152,12 +162,11 @@ module Gori
         end
 
         # Path-like: the value carries a `/` or a file-extension tell, or the name is a conventional
-        # file/path parameter.
+        # file/path parameter AND the value is not a bare identifier.
         private def path_like?(name : String, value : String) : Bool
           return true if value.includes?('/')
-          low = value.downcase
-          return true if FILE_EXTS.any? { |ext| low.includes?(ext) }
-          KNOWN_FILE_PARAMS.includes?(name.downcase)
+          return true if FILE_EXT.matches?(value)
+          KNOWN_FILE_PARAMS.includes?(name.downcase) && !NUMERIC_VALUE.matches?(value)
         end
 
         # A copy of the query pairs with pair `idx`'s value prefixed (name kept verbatim, every other

--- a/src/gori/probe/passive/cacheable_api.cr
+++ b/src/gori/probe/passive/cacheable_api.cr
@@ -7,6 +7,14 @@ module Gori
       # Sensitive payloads (tokens, PII, account data) left cacheable via missing or weak
       # Cache-Control are a common API footgun — especially `application/json` without
       # `no-store`. Response-gated; document (HTML) headers stay in SecurityHeaders.
+      #
+      # Gated on the response being AUTHENTICATED — the request carried a Cookie or an
+      # Authorization header, or the response sets a cookie. The whole risk is a cache retaining
+      # one user's data and serving it to another, which requires the data to be one user's in the
+      # first place: a public, unauthenticated JSON endpoint left cacheable is a performance
+      # decision, not a finding. Without that gate this fired Medium on every Cache-Control-less
+      # 2xx JSON response, which is most of them on most servers — the rule's volume came almost
+      # entirely from endpoints with nothing to leak.
       class CacheableApi < Rule
         def info : RuleInfo
           RuleInfo.new("cacheable_api", "Cacheable API responses",
@@ -20,6 +28,8 @@ module Gori
           return unless success?(resp)
           # Empty bodies have nothing sensitive to cache; skip pure ACKs.
           return if body_empty?(ctx)
+          # Nothing user-specific in the response ⇒ nothing for a cache to leak across users.
+          return unless authenticated?(ctx, resp)
 
           cc = resp.headers.get?("Cache-Control")
           return if no_store?(cc)
@@ -45,6 +55,17 @@ module Gori
           media = (semi ? ct[0...semi] : ct).strip
           media == "application/json" || media == "text/json" ||
             media.ends_with?("+json") || media.includes?("json")
+        end
+
+        # The response is tied to a particular caller: the request authenticated with a Cookie or
+        # an Authorization header, or the response hands back a Set-Cookie (so it is establishing
+        # or refreshing a session). Any of those means a shared cache serving this body to the
+        # next visitor is a real disclosure; without them it is public data.
+        private def authenticated?(ctx : Context, resp : Proxy::Codec::RawResponse) : Bool
+          req = ctx.req.headers
+          return true if req.get?("Cookie").try { |v| !v.strip.empty? }
+          return true if req.get?("Authorization").try { |v| !v.strip.empty? }
+          !resp.headers.get_all("Set-Cookie").empty?
         end
 
         private def success?(resp : Proxy::Codec::RawResponse) : Bool

--- a/src/gori/probe/passive/post_message.cr
+++ b/src/gori/probe/passive/post_message.cr
@@ -19,11 +19,22 @@ module Gori
             Category::CLIENT)
         end
 
-        # A window message handler (addEventListener('message', …) or an onmessage= assignment).
-        LISTENER = /addEventListener\s*\(\s*["'`]message["'`]|\bonmessage\s*=(?!=)/
-        # Any origin consultation; its mere presence in the script suppresses the no-origin
-        # finding (conservative — we would rather miss than cry wolf).
+        # A window message handler whose body we can actually SEE: the listener must be followed
+        # by an inline function literal (`function (e) {` or `(e) => {`). A handler passed by NAME
+        # (`addEventListener("message", onMsg)`) is deliberately not matched — its body is defined
+        # elsewhere, so no window around this call site can tell whether it checks the origin, and
+        # guessing would be a false positive.
+        LISTENER = /(?:addEventListener\s*\(\s*["'`]message["'`]\s*,|\bonmessage\s*=(?!=))\s*(?:async\s+)?(?:function\b[^(]*\(|\()[^)]*\)\s*(?:=>\s*)?\{/
+        # Any origin consultation. Searched in a WINDOW after the handler opens, not across the
+        # whole fragment: `.origin` is ubiquitous in a bundled SPA, so a whole-fragment test meant
+        # one unrelated occurrence anywhere in a 256 KiB bundle suppressed every finding in it —
+        # the rule detected nothing at all on exactly the targets it matters most for. Scoping the
+        # test to the handler body restores that, and pairing it with the inline-function gate
+        # above keeps the conservative bias: we only judge handlers we can read.
         ORIGIN_CHECK = /\.origin\b/
+        # How far past the handler's opening brace to look. Generous — a real message handler with
+        # its dispatch table still fits, and over-reaching only makes the rule quieter.
+        HANDLER_WINDOW = 2000
         # postMessage(<data>, "*") — the wildcard target origin as the (last) argument.
         WILDCARD_POST = /\.postMessage\s*\([^;\n]*,\s*["'`]\*["'`]\s*\)/
         # document.domain = … (assignment, not the === comparison).
@@ -34,7 +45,7 @@ module Gori
           return if scripts.empty?
           emitted = Set(String).new
           scripts.each do |code|
-            if LISTENER.matches?(code) && !ORIGIN_CHECK.matches?(code) && emitted.add?("no_origin")
+            if unchecked_handler?(code) && emitted.add?("no_origin")
               acc << pm(ctx, "postmessage_no_origin", "postMessage handler without origin check",
                 Store::Severity::Medium, "message listener, no .origin check")
             end
@@ -47,6 +58,18 @@ module Gori
                 Store::Severity::Low, "document.domain =")
             end
           end
+        end
+
+        # True when `code` registers an INLINE message handler whose body does not consult
+        # `.origin` within HANDLER_WINDOW characters of its opening brace. Scans every handler in
+        # the fragment: a bundle can register several, and one that checks its sender must not
+        # vouch for one that does not.
+        private def unchecked_handler?(code : String) : Bool
+          code.scan(LISTENER) do |m|
+            body = code[m.end(0), HANDLER_WINDOW]?
+            return true if body.nil? || !ORIGIN_CHECK.matches?(body)
+          end
+          false
         end
 
         private def pm(ctx : Context, code : String, title : String, sev : Store::Severity, evidence : String) : Detection


### PR DESCRIPTION
Three noise sources from the rule-set review. Each rule was firing far outside the case it describes — and in one of them the over-reach had made the rule useless on real targets.

## `post_message` — one `.origin` anywhere silenced the whole bundle

`postmessage_no_origin` suppressed itself whenever `.origin` appeared **anywhere** in the script fragment. In a bundled SPA — one 256 KiB fragment — something always mentions it, so the rule detected **nothing at all** on exactly the targets it matters most for. It was conservative to the point of being dead code.

The origin test now runs in a window after the handler's opening brace, and each handler is judged on its own (a checked one no longer vouches for an unchecked one).

To keep the conservative bias where it belongs, the listener pattern only matches an **inline function literal**. A handler passed by name (`addEventListener("message", onMsg)`) has its body defined elsewhere, so no window around the call site can say whether it validates the sender — guessing there would be a false positive, so those are skipped.

## `cacheable_api` — it fired on public data

Every Cache-Control-less 2xx JSON response scored Medium, which is most JSON responses on most servers. But the risk is a cache retaining **one user's** data and serving it to another, and that needs the data to be one user's to begin with.

Now gated on the response being authenticated: the request carried a `Cookie` or `Authorization`, or the response sets a cookie. A public endpoint left cacheable is a performance decision, not a finding.

## `lfi_param_traversal` — `?name=John` cost three probes

`KNOWN_FILE_PARAMS` is checked **regardless of the value**, and it contained `name`, `url`, `view`, `page`, and `load` — ordinary application parameters, so a large share of all traffic drew a 3-request probe. Dropped, plus a guard that a bare numeric value under a real file param (`?doc=1234`) is an id, not a filename.

Nothing is lost: a file-*shaped* value still qualifies under **any** name through the `/` and extension tests.

Those extension tests were a plain `includes?`, so:

| value | was | is |
|---|---|---|
| `data.jsonp` | matched `.js` | no match |
| `notes.mdx` | matched `.md` | no match |
| `app.js`, `data.json`, `notes.md` | matched | matched |

Now one regex requiring the extension not be followed by another word character.

## Verification

- `crystal spec` — **4800 examples, 0 failures**
- `crystal tool format --check` on all touched files — clean
- `crystal build --no-codegen src/main.cr` — clean
- ameba on the touched files reports only `cacheable_reason`'s complexity, which is **pre-existing on `main`** (verified against the `origin/main` copies of the same files) and untouched here

New specs cover: an unrelated `.origin` in the bundle no longer suppressing, per-handler judgement, the by-name handler being skipped, arrow-function handlers, the window boundary, unauthenticated JSON not firing, Authorization / Set-Cookie counting as authenticated, an empty Cookie not counting, the dropped param names, the numeric-value guard, and the extension-boundary cases above.

## Review series

This closes the review: #475 (perf), #477 (passive FPs), #478 (active control legs), #480 (reflection grading), #481.