### PR TITLE
feat(probe): custom ACTIVE rules — the differential core (#320, 1/N)

### DIFF
--- a/spec/probe/active/custom_active_rule_spec.cr
+++ b/spec/probe/active/custom_active_rule_spec.cr
@@ -1,0 +1,247 @@
+require "../../spec_helper"
+
+# --- file-local harness ----------------------------------------------------------------------
+
+private def with_store(&)
+  path = File.tempname("gori-customactive", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def capture_flow(store, *, target = "/s?q=hi", method = "GET", status = 200,
+                         req_headers = "", req_body : String? = nil,
+                         host = "acme.test") : Gori::Store::FlowDetail
+  head = String.build do |io|
+    io << method << " " << target << " HTTP/1.1\r\nHost: " << host << "\r\n" << req_headers << "\r\n"
+  end
+  req = Gori::Store::CapturedRequest.new(
+    created_at: 1_000_i64, scheme: "https", host: host, port: 443,
+    method: method, target: target, http_version: "HTTP/1.1",
+    head: head.to_slice, body: req_body.try(&.to_slice))
+  id = store.insert_flow(req)
+  store.update_response(Gori::Store::CapturedResponse.new(
+    flow_id: id, status: status, head: "HTTP/1.1 #{status} X\r\n\r\n".to_slice, body: nil,
+    reason: "OK", content_type: nil, duration_us: 1_i64))
+  store.get_flow(id).not_nil!
+end
+
+# A backend that reflects the DIFFERENTIAL: a request carrying `needle` gets a response body
+# containing `marker`, everything else gets a clean body. Keyed on the request content rather than
+# on send order, so the built-in rules (which run first and send their own probes) can't consume
+# the responses meant for the custom rule's probe/control pair.
+private class DifferentialBackend < Gori::Fuzz::Backend
+  getter origin : Gori::Fuzz::Origin
+  getter sent = 0
+
+  def initialize(@origin : Gori::Fuzz::Origin, @needle : String, @marker : String)
+  end
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    @sent += 1
+    body = String.new(bytes).includes?(@needle) ? @marker : "clean"
+    Gori::Repeater::Result.new("HTTP/1.1 200 OK\r\n\r\n".to_slice, body.to_slice, nil, 1_i64)
+  end
+end
+
+private def rule(*, inject = "query", header_name = "", payload = "PAYLOAD",
+                 match_kind = "string", match_pattern = "MATCH", match_region = "body",
+                 severity = Gori::Store::Severity::High, scope = "project",
+                 enabled = true, id = "1", title = "my rule",
+                 description = "") : Gori::Probe::Active::CustomActiveRule
+  Gori::Probe::Active::CustomActiveRule.new(id, title, description, inject, header_name, payload,
+    match_kind, match_pattern, match_region, severity, scope, enabled)
+end
+
+private def probe_and_control(r : Gori::Probe::Active::CustomActiveRule, detail,
+                              opts = Gori::Probe::Active::Options::DEFAULT)
+  r.to_rule.plan(detail, opts).not_nil!
+end
+
+describe Gori::Probe::Active::CustomActiveRule do
+  describe ".valid?" do
+    it "accepts a well-formed string and regex rule" do
+      rule.valid?.should be_true
+      rule(match_kind: "regex", match_pattern: "root:.:0:").valid?.should be_true
+    end
+
+    it "rejects an unknown inject target, an empty payload, and an empty pattern" do
+      rule(inject: "cookie").valid?.should be_false
+      rule(payload: "").valid?.should be_false
+      rule(match_pattern: "").valid?.should be_false
+    end
+
+    it "rejects a header rule with no header name, and an uncompilable regex" do
+      rule(inject: "header", header_name: "  ").valid?.should be_false
+      rule(match_kind: "regex", match_pattern: "(unclosed").valid?.should be_false
+    end
+  end
+
+  describe "#code" do
+    it "namespaces by scope so a global and a project rule with the same id never collide" do
+      rule(scope: "project", id: "7").code.should eq("customactive_p_7")
+      rule(scope: "global", id: "7").code.should eq("customactive_g_7")
+    end
+  end
+
+  describe "the probe/control plan" do
+    it "injects the payload into every query value and leaves the control unchanged" do
+      with_store do |store|
+        detail = capture_flow(store, target: "/s?a=1&b=2")
+        plan = probe_and_control(rule(inject: "query", payload: "X'\"<>"), detail)
+        probe = String.new(plan.request)
+        probe.should contain("a=1X%27%22%3C%3E") # payload URL-encoded, appended to the value
+        probe.should contain("b=2X%27%22%3C%3E")
+        plan.followups.size.should eq(1)
+        control = String.new(plan.followups.first)
+        control.should contain("/s?a=1&b=2 ") # verbatim query, origin-form request line
+        control.should_not contain("X%27")
+      end
+    end
+
+    it "sets the named header on the probe and drops any the browser sent" do
+      with_store do |store|
+        detail = capture_flow(store, req_headers: "X-Test: browser\r\n")
+        plan = probe_and_control(rule(inject: "header", header_name: "X-Test", payload: "forged"), detail)
+        probe = String.new(plan.request)
+        probe.scan("X-Test: forged").size.should eq(1)
+        probe.should_not contain("X-Test: browser")
+        String.new(plan.followups.first).should_not contain("X-Test: forged")
+      end
+    end
+
+    it "appends the payload to the body and resyncs Content-Length" do
+      with_store do |store|
+        detail = capture_flow(store, method: "POST", req_headers: "Content-Type: text/plain\r\n",
+          req_body: "orig")
+        plan = probe_and_control(rule(inject: "body", payload: "-EVIL"), detail,
+          Gori::Probe::Active::Options.new(allow_unsafe: true))
+        probe = String.new(plan.request)
+        probe.should contain("orig-EVIL")
+        probe.should contain("Content-Length: 9")               # "orig-EVIL"
+        String.new(plan.followups.first).should contain("orig") # control body unchanged
+        String.new(plan.followups.first).should_not contain("EVIL")
+      end
+    end
+  end
+
+  describe "the differential confirmation" do
+    it "fires when the pattern is in the probe but NOT the control" do
+      with_store do |store|
+        detail = capture_flow(store, target: "/s?q=hi")
+        r = rule(match_pattern: "MATCH", match_region: "body")
+        plan = probe_and_control(r, detail)
+        dets = r.to_rule.detections_all(plan, [
+          Gori::Repeater::Result.new("HTTP/1.1 200 OK\r\n\r\n".to_slice, "MATCH here".to_slice, nil, 1_i64),
+          Gori::Repeater::Result.new("HTTP/1.1 200 OK\r\n\r\n".to_slice, "clean".to_slice, nil, 1_i64),
+        ], detail)
+        dets.size.should eq(1)
+        dets.first.code.should eq(r.code)
+        dets.first.severity.should eq(Gori::Store::Severity::High)
+        dets.first.category.should eq(Gori::Probe::Category::CUSTOM)
+      end
+    end
+
+    it "does NOT fire when the pattern is already in the control (the page, not the payload)" do
+      with_store do |store|
+        detail = capture_flow(store, target: "/s?q=hi")
+        r = rule(match_pattern: "MATCH")
+        plan = probe_and_control(r, detail)
+        both = "MATCH here"
+        r.to_rule.detections_all(plan, [
+          Gori::Repeater::Result.new("HTTP/1.1 200 OK\r\n\r\n".to_slice, both.to_slice, nil, 1_i64),
+          Gori::Repeater::Result.new("HTTP/1.1 200 OK\r\n\r\n".to_slice, both.to_slice, nil, 1_i64),
+        ], detail).should be_empty
+      end
+    end
+
+    it "refuses when the control failed to send (no attribution)" do
+      with_store do |store|
+        detail = capture_flow(store, target: "/s?q=hi")
+        r = rule(match_pattern: "MATCH")
+        plan = probe_and_control(r, detail)
+        errored = Gori::Repeater::Result.new(Bytes.empty, nil, nil, 1_i64, "connection refused")
+        r.to_rule.detections_all(plan, [
+          Gori::Repeater::Result.new("HTTP/1.1 200 OK\r\n\r\n".to_slice, "MATCH".to_slice, nil, 1_i64),
+          errored,
+        ], detail).should be_empty
+        # …and a missing control leg is refused the same way.
+        r.to_rule.detections_all(plan, [
+          Gori::Repeater::Result.new("HTTP/1.1 200 OK\r\n\r\n".to_slice, "MATCH".to_slice, nil, 1_i64),
+        ], detail).should be_empty
+      end
+    end
+
+    it "matches a regex pattern and honours the header region" do
+      with_store do |store|
+        detail = capture_flow(store, target: "/s?q=hi")
+        r = rule(match_kind: "regex", match_pattern: "Set-Cookie: sess=[a-f0-9]+", match_region: "header")
+        plan = probe_and_control(r, detail)
+        r.to_rule.detections_all(plan, [
+          Gori::Repeater::Result.new("HTTP/1.1 200 OK\r\nSet-Cookie: sess=deadbeef\r\n\r\n".to_slice, Bytes.empty, nil, 1_i64),
+          Gori::Repeater::Result.new("HTTP/1.1 200 OK\r\n\r\n".to_slice, Bytes.empty, nil, 1_i64),
+        ], detail).size.should eq(1)
+      end
+    end
+  end
+
+  describe "gating" do
+    it "does not plan an unsafe method by default, but does under allow_unsafe" do
+      with_store do |store|
+        post = capture_flow(store, target: "/s?q=hi", method: "POST")
+        rule.to_rule.plan(post).should be_nil
+        rule.to_rule.plan(post, Gori::Probe::Active::Options.new(allow_unsafe: true)).should_not be_nil
+      end
+    end
+
+    it "does not plan when the injection target is absent" do
+      with_store do |store|
+        # query rule but no query
+        rule(inject: "query").to_rule.plan(capture_flow(store, target: "/s")).should be_nil
+        # body rule but no body
+        rule(inject: "body").to_rule.plan(
+          capture_flow(store, method: "GET", target: "/s")).should be_nil
+      end
+    end
+
+    it "keeps dedup_key equal to plan.dedup_key (equivalence invariant)" do
+      with_store do |store|
+        ["/s?q=1", "/s", "/a?x=1&y=2"].each do |t|
+          detail = capture_flow(store, target: t)
+          r = rule(inject: "query").to_rule
+          r.dedup_key(detail).should eq(r.plan(detail).try(&.dedup_key))
+        end
+        # header rules apply even without a query, so their key is present on a bare path
+        hr = rule(inject: "header", header_name: "X-Y").to_rule
+        detail = capture_flow(store, target: "/s")
+        hr.dedup_key(detail).should eq(hr.plan(detail).try(&.dedup_key))
+      end
+    end
+  end
+
+  describe "Active.analyze wiring" do
+    it "runs enabled custom rules through the same send/confirm loop and skips disabled ones" do
+      with_store do |store|
+        detail = capture_flow(store, target: "/s?q=hi")
+        scope = Gori::Scope.load(store)
+        scope.add("include", "host", "acme.test")
+        origin = Gori::Fuzz::Origin.new(detail.row.scheme, detail.row.host, detail.row.port)
+        # A request carrying the payload comes back with MATCH; the control (no payload) does not.
+        backend = DifferentialBackend.new(origin, "INJX", "MATCH")
+        enabled = rule(id: "1", payload: "INJX", match_pattern: "MATCH")
+        disabled = rule(id: "2", enabled: false, payload: "INJX", match_pattern: "MATCH")
+        dets = Gori::Probe::Active.analyze(detail, outbound: Gori::Outbound.interactive(scope),
+          backend: backend, custom: [enabled, disabled])
+        codes = dets.map(&.code)
+        codes.should contain("customactive_p_1")
+        codes.should_not contain("customactive_p_2") # disabled → never sent
+      end
+    end
+  end
+end

--- a/spec/probe/active/custom_active_rule_spec.cr
+++ b/spec/probe/active/custom_active_rule_spec.cr
@@ -71,8 +71,15 @@ describe Gori::Probe::Active::CustomActiveRule do
       rule(match_kind: "regex", match_pattern: "root:.:0:").valid?.should be_true
     end
 
+    it "accepts every supported inject target" do
+      %w[query header body cookie path].each do |loc|
+        hn = loc == "header" ? "X-H" : ""
+        rule(inject: loc, header_name: hn).valid?.should be_true, loc
+      end
+    end
+
     it "rejects an unknown inject target, an empty payload, and an empty pattern" do
-      rule(inject: "cookie").valid?.should be_false
+      rule(inject: "referer").valid?.should be_false
       rule(payload: "").valid?.should be_false
       rule(match_pattern: "").valid?.should be_false
     end
@@ -127,6 +134,30 @@ describe Gori::Probe::Active::CustomActiveRule do
         probe.should contain("Content-Length: 9")               # "orig-EVIL"
         String.new(plan.followups.first).should contain("orig") # control body unchanged
         String.new(plan.followups.first).should_not contain("EVIL")
+      end
+    end
+
+    it "appends the RAW payload to every cookie value and leaves the control unchanged" do
+      with_store do |store|
+        detail = capture_flow(store, req_headers: "Cookie: sid=abc; theme=dark\r\n")
+        plan = probe_and_control(rule(inject: "cookie", payload: "'||1"), detail)
+        probe = String.new(plan.request)
+        # raw (not URL-encoded — a cookie value isn't URL-decoded server-side), every value, one line
+        probe.should contain("Cookie: sid=abc'||1; theme=dark'||1")
+        probe.scan("Cookie:").size.should eq(1)
+        String.new(plan.followups.first).should contain("Cookie: sid=abc; theme=dark")
+        String.new(plan.followups.first).should_not contain("'||1")
+      end
+    end
+
+    it "appends the RAW payload to the path, preserving the query, control unchanged" do
+      with_store do |store|
+        detail = capture_flow(store, target: "/files/report?fmt=pdf")
+        plan = probe_and_control(rule(inject: "path", payload: "..%2f..%2fetc%2fpasswd"), detail)
+        line = String.new(plan.request).each_line.first
+        # raw payload kept (traversal must survive), query preserved after it
+        line.should start_with("GET /files/report..%2f..%2fetc%2fpasswd?fmt=pdf ")
+        String.new(plan.followups.first).each_line.first.should start_with("GET /files/report?fmt=pdf ")
       end
     end
   end
@@ -207,6 +238,12 @@ describe Gori::Probe::Active::CustomActiveRule do
         # body rule but no body
         rule(inject: "body").to_rule.plan(
           capture_flow(store, method: "GET", target: "/s")).should be_nil
+        # cookie rule but no Cookie header (or a blank one)
+        rule(inject: "cookie").to_rule.plan(capture_flow(store, target: "/s")).should be_nil
+        rule(inject: "cookie").to_rule.plan(
+          capture_flow(store, target: "/s", req_headers: "Cookie:  \r\n")).should be_nil
+        # path rule always applies — a path is always present
+        rule(inject: "path").to_rule.plan(capture_flow(store, target: "/s")).should_not be_nil
       end
     end
 

--- a/src/gori/probe/active.cr
+++ b/src/gori/probe/active.cr
@@ -13,6 +13,7 @@ require "./active/path_normalization_bypass"
 require "./active/url_rewrite_bypass"
 require "./active/ssti"
 require "./active/nextjs_action_no_auth"
+require "./active/custom_active_rule"
 require "../outbound"
 require "../scope"
 require "../fuzz/engine"
@@ -70,10 +71,15 @@ module Gori
       # `disabled` holds the RuleInfo#ids the operator turned off in the Rules sub-tab — the same
       # set the TUI analyzer filters on before enqueueing (analyzer.cr's maybe_enqueue_active), so
       # a headless scan honours that config too instead of silently running every built-in.
+      # The empty "no user rules" list — a shared constant so the common no-custom call path never
+      # allocates. Mirrors NO_DISABLED / Passive::NO_CUSTOM.
+      NO_CUSTOM = [] of CustomActiveRule
+
       def self.analyze(detail : Store::FlowDetail, verify_upstream : Bool = true,
                        timeout : Time::Span = 10.seconds, *, outbound : Outbound,
                        backend : Fuzz::Backend? = nil, opts : Options = Options::DEFAULT,
-                       disabled : Set(String) = NO_DISABLED) : Array(Detection)
+                       disabled : Set(String) = NO_DISABLED,
+                       custom : Array(CustomActiveRule) = NO_CUSTOM) : Array(Detection)
         out = [] of Detection
         row = detail.row
         origin = Fuzz::Origin.new(row.scheme, row.host, row.port)
@@ -86,7 +92,11 @@ module Gori
                    Fuzz::Sender.new(origin, outbound, http2, verify_upstream, timeout: timeout)
                  end
 
-        RULES.each do |rule|
+        # Built-ins first, then the operator's enabled custom active rules (each adapted to the
+        # same Rule contract, so the send/confirm loop is identical). A disabled custom rule is
+        # skipped at load, and its RuleInfo#id also honours the Rules sub-tab disabled set.
+        rules = RULES.each.chain(custom.select(&.enabled).map(&.to_rule).each)
+        rules.each do |rule|
           next if disabled.includes?(rule.info.id)
           plan = rule.plan(detail, opts)
           next unless plan

--- a/src/gori/probe/active/custom_active_rule.cr
+++ b/src/gori/probe/active/custom_active_rule.cr
@@ -38,7 +38,7 @@ module Gori
         severity : Store::Severity,
         scope : String, # "global" | "project"
         enabled : Bool do
-        INJECTS = %w[query header body]
+        INJECTS = %w[query header body cookie path]
         KINDS   = %w[string regex]
         REGIONS = %w[whole header body]
 
@@ -148,7 +148,8 @@ module Gori
           end
 
           # There must be somewhere for the payload to go: query injection needs a query param,
-          # body injection needs a body, header injection always applies.
+          # body needs a body, cookie needs a Cookie header. header and path always apply (a path is
+          # always present, and header sets its own line).
           private def injectable?(detail : Store::FlowDetail, method_up : String) : Bool
             case @rule.inject
             when "query"
@@ -156,7 +157,9 @@ module Gori
               !query.empty?
             when "body"
               (b = detail.request_body) ? !b.empty? : false
-            else # "header"
+            when "cookie"
+              cookie_header(detail) != nil
+            else # "header" | "path"
               true
             end
           end
@@ -175,6 +178,15 @@ module Gori
               body = detail.request_body
               return nil if body.nil? || body.empty?
               rebuild_body(detail.request_head, inject_body(body), Active.origin_form(target))
+            when "cookie"
+              return nil unless cookie_header(detail)
+              rebuild_cookie(detail.request_head, detail.request_body, Active.origin_form(target))
+            when "path"
+              # Append the RAW payload to the path — path injection's whole point is traversal /
+              # normalization tricks (`..%2f`, `;`, `%2e`), and URL-encoding the `/` and `.` the
+              # operator typed would defeat exactly that. Any query is preserved after it.
+              np = "#{path}#{@rule.payload}"
+              rebuild(detail.request_head, detail.request_body, query.empty? ? np : "#{np}?#{query}")
             else # "header"
               rebuild_header(detail.request_head, detail.request_body, Active.origin_form(target))
             end
@@ -200,6 +212,29 @@ module Gori
             io.write(body)
             io << @rule.payload
             io.to_slice
+          end
+
+          # Append the RAW payload to every cookie VALUE in a `name=value; name2=value2` Cookie
+          # header. Raw, not URL-encoded: a cookie value is not URL-decoded by the server the way a
+          # query value is, so encoding here would change what the app actually receives. Bare
+          # segments with no `=` pass through untouched.
+          private def inject_cookie(value : String) : String
+            value.split(';').map do |part|
+              lead = part[0...(part.size - part.lstrip.size)] # keep the original leading space
+              seg = part.strip
+              next part if seg.empty?
+              eq = seg.index('=')
+              next part unless eq
+              "#{lead}#{seg[0...eq]}=#{seg[(eq + 1)..]}#{@rule.payload}"
+            end.join(';')
+          end
+
+          # The request's Cookie header value, or nil when absent/blank — the cookie-injection gate.
+          private def cookie_header(detail : Store::FlowDetail) : String?
+            req = Proxy::Codec::Http1.parse_request_head(detail.request_head)
+            req.headers.get?("Cookie").try { |v| v.strip.empty? ? nil : v }
+          rescue
+            nil
           end
 
           # --- response matching --------------------------------------------------------------
@@ -327,6 +362,36 @@ module Gori
             end
             io = IO::Memory.new
             io << kept.join(eol) << eol << eol
+            io.write(bbytes) unless bbytes.empty?
+            Fuzz::ContentLength.sync(io.to_slice, false)
+          end
+
+          # Rebuild with the Cookie header rewritten so every cookie value carries the payload;
+          # origin-form request line, body untouched. A request with no Cookie header never reaches
+          # here (injectable? gates it), so exactly one Cookie line is rewritten in place.
+          private def rebuild_cookie(orig_head : Bytes, body : Bytes?, origin_target : String) : Bytes
+            combined = if body && !body.empty?
+                         io = IO::Memory.new(orig_head.size + body.size)
+                         io.write(orig_head)
+                         io.write(body)
+                         io.to_slice
+                       else
+                         orig_head
+                       end
+            hbytes, bbytes, eol = Miner::Inject.split(combined)
+            lines = String.new(hbytes).split(eol)
+            lines.each_with_index do |l, i|
+              next if i == 0
+              next unless header_named?(l, "cookie")
+              c = l.index!(':') # header_named? already proved the colon is there
+              lines[i] = "#{l[0...c]}:#{inject_cookie(l[(c + 1)..])}"
+            end
+            unless lines.empty?
+              rl = lines[0].split(' ')
+              lines[0] = "#{rl[0]} #{origin_target} #{rl[2]}" if rl.size == 3
+            end
+            io = IO::Memory.new
+            io << lines.join(eol) << eol << eol
             io.write(bbytes) unless bbytes.empty?
             Fuzz::ContentLength.sync(io.to_slice, false)
           end

--- a/src/gori/probe/active/custom_active_rule.cr
+++ b/src/gori/probe/active/custom_active_rule.cr
@@ -1,0 +1,341 @@
+require "uri"
+require "./types"
+require "../../miner/inject"
+require "../../fuzz/content_length"
+require "../../proxy/codec/http1"
+require "../../proxy/codec/content_decode"
+require "../../store/safe_regexp"
+
+module Gori
+  module Probe
+    module Active
+      # A USER-DEFINED active rule: it sends a payload into one region of a captured request and
+      # decides a finding by comparing the probe's response to a CONTROL — the same request sent
+      # unchanged. Unlike the passive `Probe::CustomRule` (a match against captured bytes, no
+      # request), this one PROBES: the operator supplies a payload to inject and a pattern that
+      # confirms it landed.
+      #
+      # The confirmation is DIFFERENTIAL by construction, and that is the whole point. A rule that
+      # only asked "does the response match the pattern?" would fire on every page that already
+      # contained the pattern's text — the same false-positive class that #478 removed from the
+      # built-in bypass rules. So the adapter always sends two requests, probe and control, and
+      # reports only when the pattern is present in the probe AND absent from the control: the
+      # payload, not the page, produced the match.
+      #
+      # This is a pure data record; `to_rule` wraps it in an `Active::Rule` the existing pipeline
+      # drives with no special-casing. Persistence (global settings + per-project DB) and the
+      # CRUD surfaces are layered on separately — this file is only the model and the adapter.
+      record CustomActiveRule,
+        id : String, # "<hex>" (global) or the DB row id as text (project); unique per scope
+        title : String,
+        description : String,
+        inject : String,        # WHERE the payload goes: "query" | "header" | "body"
+        header_name : String,   # the header to set when inject == "header" (ignored otherwise)
+        payload : String,       # the bytes injected at that location
+        match_kind : String,    # how `match_pattern` is read: "string" | "regex"
+        match_pattern : String, # confirms the payload landed: present in the probe, absent in the control
+        match_region : String,  # WHICH part of the response the pattern is tested against: "whole" | "header" | "body"
+        severity : Store::Severity,
+        scope : String, # "global" | "project"
+        enabled : Bool do
+        INJECTS = %w[query header body]
+        KINDS   = %w[string regex]
+        REGIONS = %w[whole header body]
+
+        # Stable finding code so (code, host) groups per rule per host, and a global rule cannot
+        # collide with a project rule that happens to share an id. Mirrors CustomRule#code, with a
+        # distinct prefix so a passive and an active custom rule never share a group.
+        def code : String
+          "customactive_#{scope[0]}_#{id}"
+        end
+
+        def global? : Bool
+          scope == "global"
+        end
+
+        # A rule is usable when its injection target is known, its confirming pattern is present
+        # and (for a regex) compilable, and a header-injecting rule names a header. All three write
+        # paths validate through here before persisting, exactly like CustomRule.valid_pattern? —
+        # a rule the match engine can never fire on must not be saveable while every surface
+        # reports it saved fine.
+        def self.valid?(inject : String, header_name : String, payload : String,
+                        match_kind : String, match_pattern : String) : Bool
+          return false unless INJECTS.includes?(inject)
+          return false if payload.empty?
+          return false if inject == "header" && header_name.strip.empty?
+          return false if match_pattern.empty?
+          return true unless match_kind == "regex"
+          SafeRegexp.compile(match_pattern)
+          true
+        rescue
+          false
+        end
+
+        def valid? : Bool
+          self.class.valid?(inject, header_name, payload, match_kind, match_pattern)
+        end
+
+        # The Active::Rule the analyzer drives. Built once per scan from the persisted record, so
+        # the adapter closes over immutable data and stays a pure function of (flow, opts).
+        def to_rule : Rule
+          Adapter.new(self)
+        end
+
+        # Adapts one CustomActiveRule to the Active::Rule contract: build a probe (payload injected)
+        # plus a control (request verbatim), then confirm on the probe-present / control-absent
+        # differential. Gated to SAFE_METHODS unless the operator opted into unsafe — a user payload
+        # can be anything, so re-sending it on a POST/PUT/DELETE must stay an explicit choice.
+        class Adapter < Rule
+          def initialize(@rule : CustomActiveRule)
+          end
+
+          def info : RuleInfo
+            RuleInfo.new(@rule.code, @rule.title,
+              @rule.description.empty? ? "User-defined active rule." : @rule.description,
+              Category::CUSTOM)
+          end
+
+          # Body injection changes the body, so it must be re-sent with the original method and can
+          # never be a plain GET replay of a safe request; still SAFE_METHODS-gated by default like
+          # the rest, and query/header injection is a re-send of the same method too. The gate is
+          # uniform: only the opt-in widens it.
+          def dedup_key(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : String?
+            method, target, malformed = Proxy::Codec::Http1.parse_request_line(detail.request_head)
+            return nil if malformed
+            method_up = method.upcase
+            return nil unless method_allowed?(method_up, opts)
+            return nil unless injectable?(detail, method_up)
+            key_string(detail, method_up, Active.origin_form(target))
+          end
+
+          def plan(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : Plan?
+            method, target, malformed = Proxy::Codec::Http1.parse_request_line(detail.request_head)
+            return nil if malformed
+            method_up = method.upcase
+            return nil unless method_allowed?(method_up, opts)
+            return nil unless injectable?(detail, method_up)
+            probe = build_probe(detail) || return nil
+            # The control is the SAME request, only normalized to origin-form (probes go direct to
+            # the origin, like every other active rule) — so probe and control differ in exactly
+            # one thing: the injected payload.
+            control = rebuild(detail.request_head, detail.request_body, Active.origin_form(target))
+            Plan.new(probe, [] of Param, key_string(detail, method_up, Active.origin_form(target)), [control])
+          end
+
+          # results = [probe, control]. Fire only when the confirming pattern is present in the
+          # probe response and ABSENT from the control — the payload produced the match, not the
+          # page. A control that failed to send is no attribution, so refuse rather than guess.
+          def detections_all(plan : Plan, results : Array(Repeater::Result), detail : Store::FlowDetail) : Array(Detection)
+            probe = results[0]?
+            control = results[1]?
+            return [] of Detection unless probe && probe.ok?
+            return [] of Detection unless control && control.ok?
+            return [] of Detection unless matches?(probe)
+            return [] of Detection if matches?(control)
+            [Detection.new(@rule.code, Category::CUSTOM, detail.row.host, detail.row.url,
+              @rule.title, @rule.severity,
+              "custom active rule matched the probe response only (payload confirmed)", detail.row.id)]
+          rescue
+            [] of Detection
+          end
+
+          def detections(plan : Plan, result : Repeater::Result, detail : Store::FlowDetail) : Array(Detection)
+            detections_all(plan, [result], detail)
+          end
+
+          def requests_per_flow : Range(Int32, Int32)
+            2..2 # probe + control
+          end
+
+          # There must be somewhere for the payload to go: query injection needs a query param,
+          # body injection needs a body, header injection always applies.
+          private def injectable?(detail : Store::FlowDetail, method_up : String) : Bool
+            case @rule.inject
+            when "query"
+              _, query = split_target(Active.origin_form(request_target(detail)))
+              !query.empty?
+            when "body"
+              (b = detail.request_body) ? !b.empty? : false
+            else # "header"
+              true
+            end
+          end
+
+          # Build the probe request with the payload injected at the rule's location, or nil when
+          # the location is not present (guarded by injectable?, but re-checked so plan is total).
+          private def build_probe(detail : Store::FlowDetail) : Bytes?
+            target = request_target(detail)
+            path, query = split_target(Active.origin_form(target))
+            case @rule.inject
+            when "query"
+              return nil if query.empty?
+              nq = inject_query(query)
+              rebuild(detail.request_head, detail.request_body, nq.empty? ? path : "#{path}?#{nq}")
+            when "body"
+              body = detail.request_body
+              return nil if body.nil? || body.empty?
+              rebuild_body(detail.request_head, inject_body(body), Active.origin_form(target))
+            else # "header"
+              rebuild_header(detail.request_head, detail.request_body, Active.origin_form(target))
+            end
+          end
+
+          # Append the payload (URL-encoded) to EVERY query param value: a single request that
+          # exercises each parameter, matching how the built-in reflected/crlf probes fan a payload
+          # across the query. Bare flags / empty segments pass through untouched.
+          private def inject_query(query : String) : String
+            enc = URI.encode_www_form(@rule.payload, space_to_plus: false)
+            query.split('&').map do |pair|
+              next pair if pair.empty?
+              eq = pair.index('=')
+              next pair unless eq
+              "#{pair[0...eq]}=#{pair[(eq + 1)..]}#{enc}"
+            end.join('&')
+          end
+
+          # Append the raw payload to the request body. A user body payload is sent verbatim (the
+          # operator typed it), and Content-Length is resynced by rebuild_body.
+          private def inject_body(body : Bytes) : Bytes
+            io = IO::Memory.new(body.size + @rule.payload.bytesize)
+            io.write(body)
+            io << @rule.payload
+            io.to_slice
+          end
+
+          # --- response matching --------------------------------------------------------------
+
+          # Does the confirming pattern match the chosen region of `result`'s response? Byte-safe:
+          # heads/bodies are scrubbed before the regex (mirrors the passive CustomRule), and a bad
+          # user regex degrades to no-match rather than dropping the whole probe.
+          private def matches?(result : Repeater::Result) : Bool
+            text = region_text(result)
+            return false if text.nil? || text.empty?
+            if @rule.match_kind == "regex"
+              SafeRegexp.compile(@rule.match_pattern).matches?(text)
+            else
+              text.includes?(@rule.match_pattern)
+            end
+          rescue
+            false
+          end
+
+          private def region_text(result : Repeater::Result) : String?
+            head = String.new(result.head).scrub
+            case @rule.match_region
+            when "header"
+              head
+            when "body"
+              body_text(result)
+            else # "whole"
+              b = body_text(result)
+              b ? "#{head}\r\n#{b}" : head
+            end
+          end
+
+          private def body_text(result : Repeater::Result) : String?
+            decoded, _ = Proxy::Codec::ContentDecode.decode(result.head, result.body, BODY_CAP)
+            bytes = decoded || result.body
+            return nil if bytes.nil? || bytes.empty?
+            String.new(bytes[0, {bytes.size, BODY_CAP}.min]).scrub
+          end
+
+          # --- request rebuilding -------------------------------------------------------------
+
+          private def key_string(detail : Store::FlowDetail, method_upcase : String, origin_target : String) : String
+            "#{@rule.code}|#{detail.row.host}:#{detail.row.port}|#{method_upcase}|#{path_only(origin_target)}"
+          end
+
+          private def request_target(detail : Store::FlowDetail) : String
+            _, target, _ = Proxy::Codec::Http1.parse_request_line(detail.request_head)
+            target
+          end
+
+          private def split_target(target : String) : {String, String}
+            qi = target.index('?')
+            return {target, ""} unless qi
+            {target[0...qi], target[(qi + 1)..]}
+          end
+
+          private def path_only(origin_target : String) : String
+            qi = origin_target.index('?')
+            qi ? origin_target[0...qi] : origin_target
+          end
+
+          # Rebuild with a new request-line target (query/control path change); body and headers
+          # untouched, Content-Length resynced in case the caller changed nothing (no-op then).
+          private def rebuild(orig_head : Bytes, body : Bytes?, new_target : String) : Bytes
+            head, _, eol = Miner::Inject.split(orig_head)
+            lines = String.new(head).split(eol)
+            unless lines.empty?
+              parts = lines[0].split(' ')
+              lines[0] = "#{parts[0]} #{new_target} #{parts[2]}" if parts.size == 3
+            end
+            io = IO::Memory.new
+            io << lines.join(eol) << eol << eol
+            b = body || Bytes.empty
+            io.write(b) unless b.empty?
+            Fuzz::ContentLength.sync(io.to_slice, false)
+          end
+
+          # Rebuild with a new body (payload appended) + origin-form request line; Content-Length
+          # resynced to the new body.
+          private def rebuild_body(orig_head : Bytes, new_body : Bytes, origin_target : String) : Bytes
+            head, _, eol = Miner::Inject.split(orig_head)
+            lines = String.new(head).split(eol)
+            unless lines.empty?
+              parts = lines[0].split(' ')
+              lines[0] = "#{parts[0]} #{origin_target} #{parts[2]}" if parts.size == 3
+            end
+            io = IO::Memory.new
+            io << lines.join(eol) << eol << eol
+            io.write(new_body)
+            # add_when_missing: the body grew, so a Content-Length must exist even if the captured
+            # request framed the body some other way — otherwise the origin can't find the payload.
+            Fuzz::ContentLength.sync(io.to_slice, true)
+          end
+
+          # Rebuild with the rule's header set to the payload: drop any copy the browser sent, then
+          # insert one authoritative line after the request line (origin-form). Body untouched.
+          #
+          # The payload (and header name) are written VERBATIM — a CR/LF the operator typed is NOT
+          # stripped. That is deliberate and follows the project's provenance rule: bytes the
+          # operator supplied go out byte-exact, because a header-injection rule whose payload is
+          # `foo\r\nX-Injected: 1` is the operator deliberately testing header/CRLF injection, not a
+          # mistake to sanitize. (The refuse-malformed rule applies to bytes the TARGET supplied —
+          # a crawled href, a redirect Location — never to an operator's own probe.)
+          private def rebuild_header(orig_head : Bytes, body : Bytes?, origin_target : String) : Bytes
+            combined = if body && !body.empty?
+                         io = IO::Memory.new(orig_head.size + body.size)
+                         io.write(orig_head)
+                         io.write(body)
+                         io.to_slice
+                       else
+                         orig_head
+                       end
+            hbytes, bbytes, eol = Miner::Inject.split(combined)
+            lines = String.new(hbytes).split(eol)
+            name_low = @rule.header_name.strip.downcase
+            kept = [] of String
+            lines.each_with_index do |l, i|
+              next if i > 0 && header_named?(l, name_low)
+              kept << l
+            end
+            unless kept.empty?
+              rl = kept[0].split(' ')
+              kept[0] = "#{rl[0]} #{origin_target} #{rl[2]}" if rl.size == 3
+              kept.insert(1, "#{@rule.header_name.strip}: #{@rule.payload}")
+            end
+            io = IO::Memory.new
+            io << kept.join(eol) << eol << eol
+            io.write(bbytes) unless bbytes.empty?
+            Fuzz::ContentLength.sync(io.to_slice, false)
+          end
+
+          private def header_named?(line : String, name_low : String) : Bool
+            (c = line.index(':')) ? line[0...c].strip.downcase == name_low : false
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes the first slice of #320. The Probe custom-rule system is passive only today — a string/regex matched against captured bytes, no request sent. #320 asks for user-defined **active** rules: send a payload, judge the response. This PR is the engine for that, as a **pure, fully-specced core**. Persistence (schema V5 + model + global settings) and the TUI/CLI/MCP CRUD surfaces are separate follow-ups so this stays reviewable.

## What's here

`CustomActiveRule` — a data record (id, inject location, payload, confirming pattern, region, severity, scope, enabled). `to_rule` wraps it in an `Active::Rule` the existing pipeline drives with **zero special-casing**: `Active.analyze` gains a `custom:` parameter and chains the enabled rules after the built-ins through the same send → confirm loop.

## The design: differential by construction

A rule that only asked *"does the response match the pattern?"* would fire on every page that already contained the pattern's text — the exact false-positive class #478 removed from the built-in bypass rules. So the adapter always sends **two** requests:

- **probe** — the payload injected
- **control** — the request verbatim

and reports only when the pattern is **present in the probe AND absent from the control**. The payload produced the match, not the page. A control that failed to send is no attribution, so it **refuses** rather than falling back to the probe alone — the same discipline as the four rules in #478.

## Injection & gating

Three locations, the ones a user rule needs: append the payload to every query value, set a named request header, or append to the body.

- query / header — SAFE_METHODS-gated by default (a user payload can be anything, so re-sending it on a POST/PUT/DELETE stays an explicit `allow_unsafe` opt-in)
- body — needs a body, and the opt-in for a non-GET

Response matching reuses the passive rule's byte-safety exactly: heads/bodies scrubbed before the regex, a bad user pattern degrades to no-match rather than dropping the probe.

Header and payload bytes go out **verbatim** — a CR/LF the operator typed is not stripped, per the project's provenance rule (operator bytes are byte-exact; a `foo\r\nX-Injected: 1` payload is the operator deliberately testing header injection, not a mistake to sanitize).

## Verification

- **15 new specs**: validation, the probe/control shape for each injection location, the present-in-probe / absent-in-control differential (with its no-fire and refuse cases), regex + region matching, method gating, `dedup_key`/`plan` equivalence, and the `Active.analyze` wiring skipping a disabled rule.
- `crystal spec` — **4815 examples, 0 failures**
- `crystal tool format --check`, `crystal build --no-codegen`, ameba on the touched files — all clean

## Not in this PR (follow-ups)

Schema V5 + the `ProbeCustomActiveRule` model, global settings storage, and the TUI/CLI/MCP CRUD. The engine is exercised end-to-end by the specs, so it is **not dead code** while those land.

## Design note for review

I kept the confirmation to a single mode (probe-present / control-absent) rather than exposing a `confirm:` knob — it is the one mode that is FP-safe, and adding others later is additive. Happy to widen it if you'd rather the record carry the mode from the start.