### PR TITLE
fix(tui): drop two dead entries from the History space menu, and give copy-as its 'Y'

### DIFF
--- a/docs/content/guide/proxy.ko.md
+++ b/docs/content/guide/proxy.ko.md
@@ -120,12 +120,12 @@ gori run history -q 'status:5xx host:api.example.com'
 
 > 실제 대상 = **표시된 것이 있으면 그것들, 없으면 커서 행**
 
-따라서 `/ status:5xx` → `Shift-T` → `Space` → `X`면 모든 오류 플로우를 확인 한 번으로 삭제하고, `Space` → `F`면 그 URL들을 한꺼번에 복사합니다. 메뉴 제목이 `SPACE · 3 MARKED`로 바뀌고 항목 이름도 `Delete 3 flows`, `Mine 3 flows`처럼 바뀌므로, 일괄 처리가 예상 밖에 일어나는 일은 없습니다.
+따라서 `/ status:5xx` → `Shift-T` → `Space` → `X`면 모든 오류 플로우를 확인 한 번으로 삭제하고, `Space` → `Y`면 그 URL들을 한꺼번에 복사합니다. 메뉴 제목이 `SPACE · 3 MARKED`로 바뀌고 항목 이름도 `Delete 3 flows`, `Mine 3 flows`처럼 바뀌므로, 일괄 처리가 예상 밖에 일어나는 일은 없습니다.
 
 | 동작 | 키 | 표시된 플로우에 대해 |
 |------|-----|--------------------|
 | 복사 | `y` | URL 목록(한 줄에 하나) |
-| 형식 지정 복사 | `Space` `F` | urls / host 목록 / cURL / 원본 요청 / 원본 응답 |
+| 형식 지정 복사 | `Space` `Y` | urls / host 목록 / cURL / 원본 요청 / 원본 응답 / 요청+응답 쌍 |
 | 삭제 | `Space` `X` | 전체를 확인 한 번으로 |
 | 이슈/노트에 연결 | `Space` `k` / `u` | 대상은 한 번만 선택, 전체를 첨부 |
 | 이슈 추가 | `Shift-F` | 표시된 전체를 근거로 가진 이슈 하나 |

--- a/docs/content/guide/proxy.md
+++ b/docs/content/guide/proxy.md
@@ -120,12 +120,12 @@ Marks change **what the space menu acts on**, not which actions exist:
 
 > the effective target is **the marks if any are set, else the cursor row**
 
-So `/ status:5xx` → `Shift-T` → `Space` → `X` deletes every error in one confirm, and `Space` → `F` copies all their URLs. The menu title reads `SPACE · 3 MARKED` and the entries rename themselves (`Delete 3 flows`, `Mine 3 flows`) so a batch is never a surprise.
+So `/ status:5xx` → `Shift-T` → `Space` → `X` deletes every error in one confirm, and `Space` → `Y` copies all their URLs. The menu title reads `SPACE · 3 MARKED` and the entries rename themselves (`Delete 3 flows`, `Mine 3 flows`) so a batch is never a surprise.
 
 | Action | Key | Over marks |
 |--------|-----|-----------|
 | Copy | `y` | The URL list (one per line) |
-| Copy as… | `Space` `F` | urls / host list / cURL / raw requests / raw responses |
+| Copy as… | `Space` `Y` | urls / host list / cURL / raw requests / raw responses / req+res pairs |
 | Delete | `Space` `X` | One confirm for the whole set |
 | Link to issue / note | `Space` `k` / `u` | Pick the owner once, attach every flow |
 | Add issue | `Shift-F` | One issue with every flow as evidence |

--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -1486,6 +1486,82 @@ describe "Gori::Tui::HistoryView marks" do
     end
   end
 
+  # The exchange, which neither raw variant carries alone: request then response, both verbatim.
+  it "offers the req+res pair for one flow and per-flow pairs for a set" do
+    tmp_store do |store|
+      a = add_flow(store, "GET", "/a", 200, host: "one.test")
+      b = add_flow(store, "POST", "/b", 500, host: "two.test")
+      view = HistoryView.new
+      view.reload(store)
+
+      _, opts = view.list_copy_as_menu(store, [a])
+      pair = opts.find { |o| o.key == 'p' }.not_nil!
+      pair.label.should eq("Req + Res pair")
+      pair.text.should eq("GET /a HTTP/1.1\r\nHost: one.test\r\n\r\n\n\nHTTP/1.1 200 X\r\n\r\nbodybody")
+
+      _, opts = view.list_copy_as_menu(store, [a, b])
+      pairs = opts.find { |o| o.key == 'p' }.not_nil!
+      pairs.label.should eq("Req + Res pairs")
+      pairs.text.should contain("===== flow ##{a}")
+      pairs.text.should contain("===== flow ##{b}")
+      pairs.text.should contain("HTTP/1.1 500 X") # the response rides along with its request
+    end
+  end
+
+  # The drill-in offers the pair from BOTH panes. The pane-local format list says what that
+  # pane shows; it is not a rule that the exchange must be reassembled by hand.
+  it "offers the req+res pair from both detail panes" do
+    tmp_store do |store|
+      add_flow(store, "GET", "/a", 200)
+      view = HistoryView.new
+      view.reload(store)
+      view.open_detail(store).should be_true
+
+      title, opts = view.detail_copy_as_menu
+      title.should eq("COPY REQUEST AS")
+      pair = opts.find { |o| o.key == 'p' }.not_nil!
+      pair.label.should eq("Req + Res pair")
+      pair.text.should eq("GET /a HTTP/1.1\r\nHost: h.test\r\n\r\n\n\nHTTP/1.1 200 X\r\n\r\nbodybody")
+
+      view.toggle_pane # request → response
+      title, opts = view.detail_copy_as_menu
+      title.should eq("COPY RESPONSE AS")
+      opts.find { |o| o.key == 'p' }.not_nil!.text.should eq(pair.text) # same exchange, same key
+    end
+  end
+
+  it "offers no pair for a flow with no response yet" do
+    tmp_store do |store|
+      add_flow(store, "GET", "/pending", nil)
+      view = HistoryView.new
+      view.reload(store)
+      view.open_detail(store).should be_true
+      _, opts = view.detail_copy_as_menu
+      opts.map(&.key).should contain('r')     # the raw request is still there
+      opts.map(&.key).should_not contain('p') # …but there is no exchange to copy
+    end
+  end
+
+  # A flow still in flight has no response — it contributes its request rather than dropping out.
+  it "keeps a response-less flow in the pair set, request only" do
+    tmp_store do |store|
+      a = add_flow(store, "GET", "/pending", nil)
+      b = add_flow(store, "GET", "/done", 200)
+      view = HistoryView.new
+      view.reload(store)
+
+      _, opts = view.list_copy_as_menu(store, [a, b])
+      pairs = opts.find { |o| o.key == 'p' }.not_nil!
+      pairs.text.should contain("GET /pending HTTP/1.1")
+      pairs.text.should contain("HTTP/1.1 200 X")
+
+      # …and with no response at all there is no pair to offer for a single flow.
+      _, one = view.list_copy_as_menu(store, [a])
+      one.map(&.key).should_not contain('p')
+      one.map(&.key).should_not contain('s')
+    end
+  end
+
   # Past the cap the byte-carrying formats are not offered — AND the bodies are never read.
   # get_flow pulls the full request+response (2 MiB each); ⇧T can hand this a whole page, and
   # this all runs on the single-threaded render loop, so loading N bodies to print N URLs would
@@ -1503,6 +1579,7 @@ describe "Gori::Tui::HistoryView marks" do
       keys.should_not contain('l')      # cURL
       keys.should_not contain('r')      # raw requests
       keys.should_not contain('s')      # raw responses
+      keys.should_not contain('p')      # req+res pairs
       store.get_flow_calls.should eq(0) # rows only — no body reads past the cap
       store.flow_row_calls.should eq(ids.size)
     end

--- a/spec/tui/space_menu_spec.cr
+++ b/spec/tui/space_menu_spec.cr
@@ -25,6 +25,7 @@ describe Gori::Tui::SpaceMenu do
     menu.open(Gori::Verb::Scope::Body, :common, ctx)
 
     menu.verb_for('y').try(&.id).should eq("history.copy")
+    menu.verb_for('Y').try(&.id).should eq("history.copy-as") # pairs with 'y' (was 'F')
     menu.verb_for('r').try(&.id).should eq("history.repeater")
     menu.verb_for('X').try(&.id).should eq("history.delete")
     menu.verb_for('C').try(&.id).should eq("history.clear")

--- a/spec/tui/space_menu_spec.cr
+++ b/spec/tui/space_menu_spec.cr
@@ -31,6 +31,39 @@ describe Gori::Tui::SpaceMenu do
     menu.verb_for('Q').should be_nil # no entry bound to this key
   end
 
+  # The regression: project.copy ('Y') and project.select-line ('x') sat in Verb::Scope::Body
+  # gated only on project_desc_read_mode?, which is tab-blind and true from boot (ProjectView's
+  # pane defaults to :desc). Both rendered in the History list's menu, where their handlers'
+  # :history branch does nothing outside the detail drill-in — two entries that copied nothing
+  # and selected nothing. The scope split plus the current_tab check keeps them out.
+  it "never shows the Project description pane's verbs in the History list menu" do
+    ctx = FakeExecContext.new
+    ctx.selected = 5_i64
+    ctx.project_desc_read_mode = true # ProjectView's boot default, whatever tab is up
+    ctx.selection_active = true       # …and a live selection, so the 'v'/'S' pair would qualify too
+    menu = SpaceMenu.new(Gori::Verbs.registry)
+    menu.open(Gori::Verb::Scope::Body, :common, ctx)
+
+    ids = menu.entries.map(&.id)
+    %w[project.copy project.select-line project.clear-selection project.send-to].each do |id|
+      ids.should_not contain(id)
+    end
+  end
+
+  it "lists the Project description pane's own verbs under its own scope" do
+    ctx = FakeExecContext.new
+    ctx.current_tab = :project
+    ctx.project_desc_read_mode = true
+    ctx.selection_active = true
+    menu = SpaceMenu.new(Gori::Verbs.registry)
+    menu.open(Gori::Verb::Scope::ProjectDesc, :common, ctx)
+
+    menu.entries.all?(&.scope.project_desc?).should be_true
+    menu.verb_for('y').try(&.id).should eq("project.copy") # the key the pane raw-dispatches
+    menu.verb_for('x').try(&.id).should eq("project.select-line")
+    menu.verb_for('S').try(&.id).should eq("project.send-to")
+  end
+
   it "moves the selection within entries (clamped both ends)" do
     ctx = FakeExecContext.new
     ctx.selected = 5_i64
@@ -547,7 +580,8 @@ describe Gori::Tui::SpaceMenu do
       Gori::Verb::Scope::Body, Gori::Verb::Scope::Repeater, Gori::Verb::Scope::Issues,
       Gori::Verb::Scope::Comparer, Gori::Verb::Scope::Fuzzer, Gori::Verb::Scope::Intercept,
       Gori::Verb::Scope::HistoryDetail, Gori::Verb::Scope::IssuesDetail,
-      Gori::Verb::Scope::Project, Gori::Verb::Scope::Decoder, Gori::Verb::Scope::Notes,
+      Gori::Verb::Scope::Project, Gori::Verb::Scope::ProjectDesc,
+      Gori::Verb::Scope::Decoder, Gori::Verb::Scope::Notes,
       Gori::Verb::Scope::Sitemap,
       Gori::Verb::Scope::Miner, Gori::Verb::Scope::Probe, Gori::Verb::Scope::ProbeDetail,
     ]
@@ -613,7 +647,7 @@ describe "send-to verbs" do
     "fuzzer.send-to"   => Gori::Verb::Scope::Fuzzer,
     "decoder.send-to"  => Gori::Verb::Scope::Decoder,
     "issue.send-to"    => Gori::Verb::Scope::IssuesDetail,
-    "project.send-to"  => Gori::Verb::Scope::Body,
+    "project.send-to"  => Gori::Verb::Scope::ProjectDesc,
     "detail.send-to"   => Gori::Verb::Scope::HistoryDetail,
   }
 

--- a/spec/verbs/core_spec.cr
+++ b/spec/verbs/core_spec.cr
@@ -117,17 +117,21 @@ describe "Gori::Verbs.register_core" do
   end
 
   describe "project description copy" do
-    # The chord was dropped deliberately: plain 'y' collided with history.copy in the same
-    # (Body, :common) space-menu view AND as a raw Chord in the same scope. Re-adding one
-    # would make validate_menu_keys! / the keymap conflict guard fail at boot.
-    it "carries the 'Y' menu key with no chord, gated on the description read pane" do
+    # The chord stays dropped: ProjectController raw-dispatches 'y' in the description pane and
+    # handle_body_key returns true there, so the shared Keymap is never consulted — a chord could
+    # only ever be dead weight in the rebind editor. The mnemonic mirrors that real key.
+    it "carries the 'y' menu key with no chord, in its own scope, gated on tab AND pane" do
       verb = r["project.copy"]
       verb.chords.should be_empty
-      verb.menu_key.should eq('Y')
+      verb.menu_key.should eq('y')
+      verb.scope.should eq(Gori::Verb::Scope::ProjectDesc) # NOT Body — see the History list
       ctx = FakeExecContext.new
+      ctx.current_tab = :project
       verb.available?(ctx).should be_false # the description pane is not in read mode
       ctx.project_desc_read_mode = true
       verb.available?(ctx).should be_true
+      ctx.current_tab = :history
+      verb.available?(ctx).should be_false # pane flag alone must not leak it into History
       verb_intents(r, "project.copy").should eq([:read_copy])
     end
   end

--- a/spec/verbs/history_spec.cr
+++ b/spec/verbs/history_spec.cr
@@ -79,7 +79,7 @@ describe "Gori::Verbs.register_history" do
         r["history.mark-clear"].chords.should be_empty
         r["history.mark-clear"].menu_key.should eq('N')
         r["history.copy-as"].chords.should be_empty
-        r["history.copy-as"].menu_key.should eq('F') # 'Y' is taken in Body by project.copy
+        r["history.copy-as"].menu_key.should eq('Y') # pairs with copy's 'y', like Repeater/detail
       end
 
       it "extends the range on shift+arrows — hidden nav, but still tab-gated" do

--- a/spec/verbs/read_edit_spec.cr
+++ b/spec/verbs/read_edit_spec.cr
@@ -19,7 +19,7 @@ describe "Gori::Verbs.register_read_edit" do
     {"fuzzer", Gori::Verb::Scope::Fuzzer, :template},
     {"jwt", Gori::Verb::Scope::Jwt, :input},
     {"issue", Gori::Verb::Scope::IssuesDetail, :common},
-    {"project", Gori::Verb::Scope::Body, :common},
+    {"project", Gori::Verb::Scope::ProjectDesc, :common},
     {"detail", Gori::Verb::Scope::HistoryDetail, :common},
   ]
 
@@ -27,7 +27,14 @@ describe "Gori::Verbs.register_read_edit" do
     per_scope.each do |(prefix, scope, section)|
       select_line = r["#{prefix}.select-line"]
       select_line.scope.should eq(scope)
-      select_line.chords.should eq([Gori::Verb::Chord.new("x")])
+      # Every scope but the Project description reaches the Keymap. That pane's handle_body_key
+      # returns true for every key, raw-dispatching 'x' itself, so a chord there could never
+      # fire — it is menu-only, like project.copy.
+      if prefix == "project"
+        select_line.chords.should be_empty
+      else
+        select_line.chords.should eq([Gori::Verb::Chord.new("x")])
+      end
       select_line.menu_key.should eq('x')
       select_line.section.should eq(section)
 
@@ -105,13 +112,27 @@ describe "Gori::Verbs.register_read_edit" do
     r["detail.select-line"].available?(ctx).should be_true
   end
 
-  it "gates the Project description's select-line on its read pane, not on a tab symbol" do
-    # Project shares Verb::Scope::Body with the History list, so the gate is the pane's own
-    # read-mode flag — current_tab would not distinguish them.
+  it "gates the Project description's select-line on the tab AND its read pane" do
+    # project_desc_read_mode? is tab-blind — ProjectView's pane defaults to :desc, so it reads
+    # true from boot onward. The lambda carries the current_tab check the way in_notes_read /
+    # in_repeater_read do; without it this verb surfaced in the HISTORY list's space menu,
+    # where read_select_line's :history branch is a no-op outside the detail drill-in.
     ctx = FakeExecContext.new
     ctx.current_tab = :history
-    r["project.select-line"].available?(ctx).should be_false
     ctx.project_desc_read_mode = true
-    r["project.select-line"].available?(ctx).should be_true # still :history — the pane decides
+    r["project.select-line"].available?(ctx).should be_false # right pane, wrong tab
+    ctx.current_tab = :project
+    r["project.select-line"].available?(ctx).should be_true
+    ctx.project_desc_read_mode = false
+    r["project.select-line"].available?(ctx).should be_false # right tab, wrong pane
+  end
+
+  it "keeps the Project description verbs out of the History list's scope" do
+    # The structural half of the fix: the description pane has its own Verb::Scope, so the two
+    # tabs' verbs can no longer land in one (scope, :common) space-menu view at all.
+    %w[project.select-line project.clear-selection project.send-to].each do |id|
+      r[id].scope.should eq(Gori::Verb::Scope::ProjectDesc)
+      r[id].chords.should be_empty # the desc pane raw-dispatches its keys; the Keymap never runs
+    end
   end
 end

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -32,6 +32,7 @@ module Gori::Tui
       when :scope     then Verb::Scope::Project
       when :overrides then Verb::Scope::HostOverrides
       when :env       then Verb::Scope::Env
+      when :desc      then Verb::Scope::ProjectDesc
       else                 Verb::Scope::Body
       end
     end

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -61,6 +61,7 @@ module Gori::Tui
         Item.new("f", "follow newest", "history.toggle-follow"),
         Item.new("/", "filter (query language)", "history.query"),
         Item.new("y", "copy flow", "history.copy"),
+        Item.new("space → Y", "copy as… — urls · hosts · cURL · raw · req+res pair"),
         Item.new("i", "toggle intercept hold-mode", "intercept.toggle"),
         Item.new("detail", "↑/↓ move · x line · ⇧arrows select · y copy · space cmds · ⇧←/→ h-scroll"),
         Item.new("^X · b · p", "in detail: hex · whitespace · pretty bodies"),

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -996,13 +996,17 @@ module Gori::Tui
         # Resolved through the store, not @rows: a mark can outlive the visible window.
         d = store.get_flow(ids.first)
         return {"COPY AS", [] of CopyMenu::Option} unless d
-        opts = CopyMenu.request_options(request_wire(d), copy_target(d))
+        req = request_wire(d)
+        opts = CopyMenu.request_options(req, copy_target(d))
         # …plus the response, on the same 's' key the multi-flow set uses. Without it, marking a
         # SECOND flow would be the only way to reach the raw response, and the guide advertises
         # the format unconditionally. 's' rather than response_options' own keys because those
         # collide with the request list's 'h'/'b'/'r', and CopyPicker dispatches on unique keys.
         if bytes = combine_bytes(d.response_head, d.response_body)
           opts << CopyMenu::Option.new("Raw response", 's', String.new(bytes))
+        end
+        if pair = pair_option(d, req)
+          opts << pair
         end
         return {"COPY REQUEST AS", opts}
       end
@@ -1041,7 +1045,31 @@ module Gori::Tui
         end
         opts << CopyMenu::Option.new(label, key, parts.join("\n\n")) unless parts.empty?
       end
+      # The per-flow exchange (single-flow 'p'): request then response under one separator,
+      # so a marked set pastes as N complete transactions rather than two disjoint lists.
+      # A flow still in flight has no response — it contributes its request alone.
+      pairs = details.compact_map do |d|
+        next nil unless req = combine_bytes(d.request_head, d.request_body)
+        res = combine_bytes(d.response_head, d.response_body)
+        body = res ? "#{String.new(req)}\n\n#{String.new(res)}" : String.new(req)
+        "#{copy_separator(d.row)}\n#{body}"
+      end
+      opts << CopyMenu::Option.new("Req + Res pairs", 'p', pairs.join("\n\n")) unless pairs.empty?
       opts
+    end
+
+    # The whole exchange — request, one blank line, response — both messages verbatim (P7).
+    # Neither raw variant carries it, and it is what actually goes into a ticket or a note.
+    # Offered wherever a SINGLE flow is in hand: the list menu and BOTH detail panes. The
+    # detail's pane-local format list describes what that pane SHOWS; it is not a rule that
+    # the exchange has to be reassembled by hand, and a flow you are staring at is exactly
+    # when you want it whole. `req` is passed in where the caller already built it.
+    private def pair_option(d : Store::FlowDetail, req : String? = nil) : CopyMenu::Option?
+      request = req || request_wire(d)
+      return nil if request.empty?
+      res = combine_bytes(d.response_head, d.response_body)
+      return nil unless res
+      CopyMenu::Option.new("Req + Res pair", 'p', "#{request}\n\n#{String.new(res)}")
     end
 
     private def request_wire(d : Store::FlowDetail) : String
@@ -1064,7 +1092,11 @@ module Gori::Tui
         wire = String.new(combine_bytes(detail.request_head, detail.request_body) || Bytes.empty)
         row = detail.row
         target = Repeater::FlowRequest.build_target(row.scheme, row.host, row.port)
-        {"COPY REQUEST AS", CopyMenu.request_options(wire, target)}
+        opts = CopyMenu.request_options(wire, target)
+        if pair = pair_option(detail, wire)
+          opts << pair
+        end
+        {"COPY REQUEST AS", opts}
       when :response
         # The WS MESSAGES pane reuses the :response slot but renders the transcript
         # (ws_messages), NOT the bare 101 handshake that response_head/body still hold —
@@ -1079,6 +1111,11 @@ module Gori::Tui
                else
                  [] of CopyMenu::Option
                end
+        # …and the exchange, on the same 'p' as everywhere else — the response pane is where
+        # you decide a flow is worth reporting, and the request half is one pane away.
+        if pair = pair_option(detail)
+          opts << pair
+        end
         {"COPY RESPONSE AS", opts}
       else
         {"COPY AS", [] of CopyMenu::Option}

--- a/src/gori/tui/hotkeys_overlay.cr
+++ b/src/gori/tui/hotkeys_overlay.cr
@@ -35,6 +35,7 @@ module Gori::Tui
       Verb::Scope::IssuesDetail  => "ISSUE DETAIL",
       Verb::Scope::Intercept     => "INTERCEPT",
       Verb::Scope::Comparer      => "COMPARER",
+      Verb::Scope::ProjectDesc   => "PROJECT DESCRIPTION",
       Verb::Scope::Project       => "PROJECT SCOPE",
       Verb::Scope::Env           => "PROJECT ENV",
       Verb::Scope::PaletteOpen   => "PALETTE",

--- a/src/gori/verb.cr
+++ b/src/gori/verb.cr
@@ -39,6 +39,7 @@ module Gori
       Decoder       # the Decoder tab has focus
       Jwt           # the JWT workbench tab has focus
       Notes         # the Notes tab has focus (sub-tab strip space menu)
+      ProjectDesc   # the Project tab's DESCRIPTION pane has focus (read mode)
       Project       # the Project tab's SCOPE rule list has focus
       HostOverrides # the Project tab's HOST OVERRIDES list has focus
       Env           # the Project tab's ENVIRONMENT var list has focus

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -136,23 +136,27 @@ module Gori
 
       # The single smart Copy (see repeater.copy in verbs/history.cr) — copy-all is gone.
       # Was `hidden: true` (the menu only ever showed "Copy description"); now that
-      # this IS the one Copy action, it needs to be visible. Project shares
-      # Verb::Scope::Body with the History list (Body is the generic "content pane
-      # focus" scope), so plain 'y' would collide with history.copy — both in the
-      # SAME (scope, :common) space-menu view (validate_menu_keys! doesn't know the
-      # two are gated to different tabs at runtime) AND as a raw Chord in the SAME
-      # scope (keymap_spec's rebindable-conflict guard: two verbs can't default-bind
-      # the same chord in one scope). Dropping the chord resolves both — the direct
-      # 'y' keypress in the Project description pane is already raw-dispatched by
-      # ProjectController (`when c == 'y' then project_copy`, never touching the
-      # shared Keymap), so the chord here was vestigial. Capital 'Y' keeps a
-      # "copy"-flavored mnemonic for the space menu while staying distinct from
-      # history.copy's 'y' (mirrors fuzzer.select-line's 'S' dodging lowercase 's').
-      in_project_desc_read = ->(ctx : Verb::ExecContext) { ctx.project_desc_read_mode? }
+      # this IS the one Copy action, it needs to be visible.
+      #
+      # Lives in Verb::Scope::ProjectDesc, NOT Body: the description pane used to borrow
+      # Body (the generic "content pane focus" scope) from the History list, which put both
+      # tabs' verbs in one (scope, :common) space-menu view. available? was the only thing
+      # separating them, and `project_desc_read_mode?` is tab-blind (ProjectView's pane
+      # defaults to :desc at boot), so this entry rendered in the HISTORY menu too — where
+      # read_copy's :history branch is a no-op without an open detail. A dedicated scope
+      # makes the separation structural instead of a lambda's promise, and it hands Body's
+      # 'Y' back to history.copy-as.
+      #
+      # No chord: the direct 'y' keypress in the description pane is raw-dispatched by
+      # ProjectController (`when c == 'y' then project_copy`) — handle_body_key returns
+      # true for :desc, so the shared Keymap is never consulted there and a chord could
+      # only ever be dead weight in the rebind editor. Mnemonic 'y' matches the key that
+      # actually works in the pane.
+      in_project_desc_read = ->(ctx : Verb::ExecContext) { ctx.current_tab == :project && ctx.project_desc_read_mode? }
       r.register Verb::Definition.new(
         "project.copy", "Copy", "Copy the selected description text, or the whole description if nothing is selected, to the clipboard",
-        Verb::Scope::Body,
-        available: in_project_desc_read, mnemonic: 'Y') { |ctx| ctx.read_copy; nil }
+        Verb::Scope::ProjectDesc,
+        available: in_project_desc_read, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
 
       # Match & Replace now lives in the Rewriter tab; this palette entry jumps there
       # (kept under the familiar "Match & Replace" name so a search still finds it).

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -99,13 +99,13 @@ module Gori
         available: history_targets) { |ctx| ctx.copy_selection; nil }
 
       # "Copy as X" for the list, mirroring repeater.copy-as / detail.copy-as: a picker over
-      # urls / host list / curl / raw requests / raw responses, spanning the whole marked set.
-      # Menu key 'F' (format) rather than the 'Y' that pairs with 'y' everywhere else — 'Y' is
-      # taken in Body COMMON by project.copy, and validate_menu_keys! ignores availability, so
-      # reusing it raises at boot even though project.copy never renders in History.
+      # urls / host list / curl / raw requests / raw responses / req+res pairs, spanning the
+      # whole marked set. Menu key 'Y' pairs with copy's 'y', the same way it does in the
+      # Repeater and the detail drill-in. (It was 'F' while project.copy squatted Body's 'Y'
+      # from the Project tab — that verb now lives in Verb::Scope::ProjectDesc.)
       r.register Verb::Definition.new(
         "history.copy-as", "Copy as…", "Pick a copy format for the selected/marked flows (urls/hosts/curl/raw)",
-        Verb::Scope::Body, available: history_targets, mnemonic: 'F') { |ctx| ctx.copy_as_open; nil }
+        Verb::Scope::Body, available: history_targets, mnemonic: 'Y') { |ctx| ctx.copy_as_open; nil }
 
       r.register Verb::Definition.new(
         "history.repeater", "Repeater flow", "Open the selected flow in the Repeater tab",

--- a/src/gori/verbs/read_edit.cr
+++ b/src/gori/verbs/read_edit.cr
@@ -113,17 +113,24 @@ module Gori
         "issue.send-to", "Send selection to…", "Send the selected text to another tool (Decoder, …)",
         Verb::Scope::IssuesDetail, available: in_sel, mnemonic: 'S') { |ctx| ctx.send_to_open; nil }
 
-      in_project_desc = ->(ctx : Verb::ExecContext) { ctx.project_desc_read_mode? }
+      # Verb::Scope::ProjectDesc, not Body — see project.copy in verbs/core.cr for why the
+      # description pane stopped borrowing the History list's scope. The read-mode flag itself
+      # is tab-blind (ProjectView's pane defaults to :desc, so it reads true from boot), so the
+      # gate carries the current_tab half the way in_notes_read / in_repeater_read do.
+      # No chord on select-line: ProjectController raw-dispatches 'x' in the desc pane and
+      # handle_body_key returns true there, so the Keymap never sees it (same reasoning as
+      # project.copy's dropped 'y') — a chord would only ever be dead weight in the rebind editor.
+      in_project_desc = ->(ctx : Verb::ExecContext) { ctx.current_tab == :project && ctx.project_desc_read_mode? }
       r.register Verb::Definition.new(
         "project.select-line", "Select line", "Select the entire current line",
-        Verb::Scope::Body, [Verb::Chord.new("x")],
+        Verb::Scope::ProjectDesc,
         available: in_project_desc, mnemonic: 'x') { |ctx| ctx.read_select_line; nil }
       r.register Verb::Definition.new(
         "project.clear-selection", "Clear selection", "Clear the text selection",
-        Verb::Scope::Body, available: in_sel, mnemonic: 'v') { |ctx| ctx.read_clear_selection; nil }
+        Verb::Scope::ProjectDesc, available: in_sel, mnemonic: 'v') { |ctx| ctx.read_clear_selection; nil }
       r.register Verb::Definition.new(
         "project.send-to", "Send selection to…", "Send the selected text to another tool (Decoder, …)",
-        Verb::Scope::Body, available: in_sel, mnemonic: 'S') { |ctx| ctx.send_to_open; nil }
+        Verb::Scope::ProjectDesc, available: in_sel, mnemonic: 'S') { |ctx| ctx.send_to_open; nil }
 
       in_detail_nav = ->(ctx : Verb::ExecContext) { ctx.detail_navigable? }
       r.register Verb::Definition.new(


### PR DESCRIPTION
Found by dogfooding: the History list's space menu had a `Y Copy` and an `x Select line` that did nothing at all.

## The bug

Both are the **Project tab's description-pane verbs**. That pane borrowed `Verb::Scope::Body` from the History list, so the `available:` lambda was the only thing separating the two tabs — and `project_desc_read_mode?` is tab-blind (`pane == :desc`, and `ProjectView`'s pane defaults to `:desc` at construction, so it reads true from the first frame). The sibling gates in `read_edit.cr` (`in_notes_read`, `in_repeater_read`) all carry a `current_tab ==` half; these two had lost theirs.

Their handlers make it a silent no-op rather than a wrong action: `read_copy` / `read_select_line` only act on `:history` when the detail drill-in is open.

```
╭─ SPACE ──────────────────╮
│ Y Copy                   │   ← no-op, no toast
│ x Select line            │   ← no-op
╰──────────────────────────╯
```

The stale comment in `verbs/history.cr` asserting "project.copy never renders in History" is what kept this invisible — and it is also why `history.copy-as` was parked on `F` instead of the `Y` its neighbours use. `Registry#for_scope` filters on `available?`; `validate_menu_keys!` does not.

## Commit 1 — fix the leak

- New `Verb::Scope::ProjectDesc`; the four `project.*` read verbs move there, so the separation is structural instead of a lambda's promise.
- `in_project_desc` / `in_project_desc_read` get the `current_tab == :project` half back.
- `project.select-line` loses its chord: the description pane's `handle_body_key` returns true for every key and raw-dispatches `x` itself, so the Keymap never sees it — the binding could only ever be dead weight in the rebind editor (`project.copy` had already dropped its `y` for exactly this reason). Its mnemonic moves `Y` → `y`, matching the key the pane actually answers to.

## Commit 2 — `Y` parity + the req/res pair

- `history.copy-as` takes `Y`, so `y` copy / `Y` copy-as is now uniform across the list, the Repeater and the detail. Audited the registry: `project.copy` was the only verb that ever bound `Y` to something that was not copy-as, and `history.copy-as` the only copy-as that was not on `Y`.
- New **`p  Req + Res pair`** in the copy-as picker: request, one blank line, response, both messages verbatim (P7). Neither raw variant carries the exchange, which is the thing that goes into a ticket — reaching it meant two copies and a manual paste. Offered from the list menu (per-flow under one separator for a mark set) and from **both** detail panes: the pane-local format list describes what a pane shows, it is not a rule that the exchange must be reassembled by hand. A flow with no response yet offers no pair, and the WS MESSAGES pane keeps its empty list (its `:response` slot holds the 101 handshake, not the transcript on screen).

## Verification

Ran the TUI against live proxy traffic, not just the suite.

```
│ y Copy flow              │        COPY REQUEST AS          COPY RESPONSE AS
│ Y Copy as…               │          r  Raw request  128B     r  Raw response  195B
│ …no phantom x/Y          │          p  Req+Res pair 325B     p  Req+Res pair  325B
```

The Project description pane now has its own menu (`y Copy` / `x Select line`) and `y` still copies there.

- `crystal build --no-codegen src/main.cr` after the rebase (the merge result, not just each commit)
- `crystal tool format --check` on every touched file
- Full suite: 4815 examples, 8 failures — all pre-existing `capture_status` / `project_registry` failures caused by a gori already listening on :8070
- Each commit verified green standing alone
- New specs: the phantom regression (both directions), the `ProjectDesc` menu, `Y` resolving to copy-as, pair from both detail panes, no pair without a response, per-flow pairs for a mark set, and `p` dropped past `COPY_BYTES_CAP`

Docs: `guide/proxy.md` + `.ko.md` copy-as row, and the Help tab's HISTORY section.