### PR TITLE
fix(repeater): a request pasted from another tool reached the origin as a 400

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -14,5 +14,5 @@ shards:
 
   termisu:
     git: https://github.com/hahwul/termisu.git
-    version: 0.6.0+git.commit.d54428ad96c3e5eb1ec6d5e9221ce8658414c074
+    version: 0.6.0+git.commit.965cbbb11084ce9be5999c4e9a20520b9fd6354e
 

--- a/shard.yml
+++ b/shard.yml
@@ -23,10 +23,17 @@ dependencies:
     github: hahwul/termisu
     branch: main
     # Temporarily on the fork again. Synced to upstream v0.6.0; the fork carries
-    # only one patch on top — input/parser: a Ctrl/Alt/Meta CSI-u report must not
-    # arm the one-shot dup guard, or the chord eats the next plain key (^P then
-    # "pet" produced "et"). It is queued for upstream. Go back to
-    # `omarluq/termisu` once it lands in a release.
+    # two patches on top, both queued for upstream. Go back to `omarluq/termisu`
+    # once they land in a release.
+    #
+    # 1. input/parser: a Ctrl/Alt/Meta CSI-u report must not arm the one-shot dup
+    #    guard, or the chord eats the next plain key (^P then "pet" produced "et").
+    # 2. termios: `set_mode` passed its `LibC::Termios` (a STRUCT — by value) to
+    #    apply_input_flags/apply_output_flags, so every c_iflag/c_oflag write was
+    #    discarded and raw mode kept ICRNL/IXON/OPOST set. With ICRNL on, the line
+    #    discipline turns CR into NL before gori sees it, so a pasted CRLF is two
+    #    newlines and `Tui::PasteNewline` cannot collapse it (and ^S froze the TUI).
+    #    Ships with `Event::Key#char` reporting which byte produced an Enter.
     #
     # Earlier fork carries, both upstream now and included via the synced main:
     # input/preedit (double-English + jamo-separation: protocol_active dup-guard +

--- a/spec/repeater/flow_request_spec.cr
+++ b/spec/repeater/flow_request_spec.cr
@@ -83,4 +83,64 @@ describe Gori::Repeater::FlowRequest do
       Gori::Repeater::FlowRequest.retarget_version_line("GET /a", false).should be_nil
     end
   end
+
+  describe ".downgrade_version_line" do
+    it "rewrites a version an HTTP/1.x connection cannot carry" do
+      Gori::Repeater::FlowRequest.downgrade_version_line("GET /a HTTP/2").should eq("GET /a HTTP/1.1")
+      Gori::Repeater::FlowRequest.downgrade_version_line("POST /a HTTP/2.0").should eq("POST /a HTTP/1.1")
+      Gori::Repeater::FlowRequest.downgrade_version_line("GET /a HTTP/3").should eq("GET /a HTTP/1.1")
+    end
+
+    # It runs unasked on every send, so — unlike `retarget_version_line`, which backs the
+    # explicit ^V toggle — it must leave a version the operator meant alone.
+    it "leaves every other version alone (nil)" do
+      ["GET /a HTTP/1.1", "GET /a HTTP/1.0", "GET /a HTTP/0.9", "GET /a HTTP/9.9",
+       "GET /a", "not a request line", "GET /a http/2"].each do |line|
+        Gori::Repeater::FlowRequest.downgrade_version_line(line).should be_nil
+      end
+    end
+
+    it "bounds the version by the LAST space, tolerating a raw space in the target" do
+      Gori::Repeater::FlowRequest.downgrade_version_line("GET /a b HTTP/2").should eq("GET /a b HTTP/1.1")
+    end
+  end
+
+  describe ".normalize_multipart_body" do
+    it "restores the CRLF delimiters a multipart body needs" do
+      raw = "POST /u HTTP/1.1\r\nContent-Type: multipart/form-data; boundary=B\r\n\r\n--B\nX: 1\n\nhi\n--B--\n".to_slice
+      String.new(Gori::Repeater::FlowRequest.normalize_multipart_body(raw))
+        .should eq("POST /u HTTP/1.1\r\nContent-Type: multipart/form-data; boundary=B\r\n\r\n--B\r\nX: 1\r\n\r\nhi\r\n--B--\r\n")
+    end
+
+    it "is idempotent on a body that already has CRLF" do
+      raw = "POST /u HTTP/1.1\r\nContent-Type: multipart/mixed; boundary=B\r\n\r\n--B\r\n\r\nhi\r\n--B--\r\n".to_slice
+      Gori::Repeater::FlowRequest.normalize_multipart_body(raw).should eq(raw)
+    end
+
+    it "matches the header name and media type case-insensitively" do
+      raw = "POST /u HTTP/1.1\r\ncontent-type: MULTIPART/Form-Data; boundary=B\r\n\r\n--B\n--B--\n".to_slice
+      String.new(Gori::Repeater::FlowRequest.normalize_multipart_body(raw)).should end_with("--B\r\n--B--\r\n")
+    end
+
+    # A bare 0x0A in any other body is a BYTE, not a line ending — this is the one media
+    # type that opts out of `Env.expand_wire`'s head-only rule.
+    it "leaves every other body untouched" do
+      [
+        "POST /x HTTP/1.1\r\nContent-Type: application/json\r\n\r\n{\n\"a\":1\n}",
+        "POST /x HTTP/1.1\r\nContent-Type: application/octet-stream\r\n\r\n\x01\n\x02",
+        "POST /x HTTP/1.1\r\n\r\nno content-type\nhere",
+        "GET /x HTTP/1.1\r\nContent-Type: multipart/form-data\r\n\r\n", # head-only: no body to touch
+        "GET /x HTTP/1.1\r\nContent-Type: multipart/form-data",         # not even a separator
+      ].each do |text|
+        raw = text.to_slice
+        Gori::Repeater::FlowRequest.normalize_multipart_body(raw).should eq(raw)
+      end
+    end
+
+    # A header VALUE that merely mentions multipart doesn't make the body one.
+    it "keys on the Content-Type header, not on the text anywhere" do
+      raw = "POST /x HTTP/1.1\r\nX-Note: multipart/form-data\r\n\r\na\nb".to_slice
+      Gori::Repeater::FlowRequest.normalize_multipart_body(raw).should eq(raw)
+    end
+  end
 end

--- a/spec/tui/paste_newline_spec.cr
+++ b/spec/tui/paste_newline_spec.cr
@@ -1,0 +1,71 @@
+require "../spec_helper"
+
+private def enter(char : Char) : Termisu::Event::Key
+  Termisu::Event::Key.new(Termisu::Input::Key::Enter, char: char)
+end
+
+private def typed(char : Char) : Termisu::Event::Key
+  Termisu::Event::Key.new(Termisu::Input::Key.from_char(char), char: char)
+end
+
+# Feed a paste's bytes through the filter and count the newlines that survive.
+private def newlines_after_filter(bytes : String) : Int32
+  filter = Gori::Tui::PasteNewline.new
+  bytes.each_char.count do |c|
+    ev = (c == '\r' || c == '\n') ? enter(c) : typed(c)
+    !filter.swallow?(ev) && ev.key.enter?
+  end
+end
+
+describe Gori::Tui::PasteNewline do
+  it "collapses a pasted CRLF into one newline" do
+    filter = Gori::Tui::PasteNewline.new
+    filter.swallow?(enter('\r')).should be_false # the CR is the newline
+    filter.swallow?(enter('\n')).should be_true  # its LF is not a second one
+  end
+
+  it "keeps a lone CR and a lone LF" do
+    filter = Gori::Tui::PasteNewline.new
+    filter.swallow?(enter('\r')).should be_false # keyboard Enter
+    filter.swallow?(typed('a')).should be_false
+
+    filter = Gori::Tui::PasteNewline.new
+    filter.swallow?(enter('\n')).should be_false # Ctrl+J, or an LF-only paste
+  end
+
+  it "keeps consecutive keyboard Enters" do
+    filter = Gori::Tui::PasteNewline.new
+    filter.swallow?(enter('\r')).should be_false
+    filter.swallow?(enter('\r')).should be_false
+  end
+
+  # The head/body separator of a pasted request is CR LF CR LF: two line breaks, which must
+  # stay two, or the body merges into the last header.
+  it "preserves a blank line inside a CRLF paste" do
+    newlines_after_filter("a\r\n\r\nb").should eq(2)
+  end
+
+  # The regression itself: a Burp-copied request line + two headers + the blank line used to
+  # arrive as 8 newlines, ending the head after the request line.
+  it "yields one newline per pasted line" do
+    newlines_after_filter("GET / HTTP/1.1\r\nHost: h\r\nUA: burp\r\n\r\n").should eq(4)
+    # An LF-only paste of the same request is unaffected.
+    newlines_after_filter("GET / HTTP/1.1\nHost: h\nUA: burp\n\n").should eq(4)
+  end
+
+  # A build of termisu that doesn't report which byte produced the Enter reports '\n' for
+  # both halves. Inert (the old doubling) rather than eating real newlines.
+  it "is inert when the event carries no CR/LF distinction" do
+    filter = Gori::Tui::PasteNewline.new
+    plain = Termisu::Event::Key.new(Termisu::Input::Key::Enter)
+    filter.swallow?(plain).should be_false
+    filter.swallow?(plain).should be_false
+  end
+
+  it "ignores a modified Enter" do
+    filter = Gori::Tui::PasteNewline.new
+    filter.swallow?(enter('\r')).should be_false
+    ctrl_enter = Termisu::Event::Key.new(Termisu::Input::Key::Enter, Termisu::Input::Modifier::Ctrl, '\n')
+    filter.swallow?(ctrl_enter).should be_false
+  end
+end

--- a/spec/tui/repeater_view_spec.cr
+++ b/spec/tui/repeater_view_spec.cr
@@ -1267,6 +1267,107 @@ describe Gori::Tui::RepeaterView do
     backend.contains?("RESPONSE").should be_true
   end
 
+  # Everything below is about text that came from ANOTHER tool's clipboard. The editor is a
+  # line buffer (TextArea strips \r off every line), so a request pasted from Burp reaches
+  # the wire only through these three repairs; without them the origin answers 400 and the
+  # only visible symptom is a status code.
+  describe "requests pasted from another tool" do
+    it "terminates a head-only request that has no trailing blank line" do
+      view = RepeaterView.new
+      view.restore("http://h.test", "GET /x HTTP/1.1\nHost: h.test", false, true)
+
+      # Without the terminator the origin waits for more headers until something times out:
+      # the user sees "no response", the origin logs a 400/408.
+      String.new(view.request_bytes).should eq("GET /x HTTP/1.1\r\nHost: h.test\r\n\r\n")
+    end
+
+    it "terminates once, whatever trailing newlines the paste carried" do
+      view = RepeaterView.new
+      view.restore("http://h.test", "GET /x HTTP/1.1\nHost: h.test\n", false, true)
+
+      String.new(view.request_bytes).should eq("GET /x HTTP/1.1\r\nHost: h.test\r\n\r\n")
+    end
+
+    it "leaves a request that already has a body alone" do
+      view = RepeaterView.new
+      view.restore("http://h.test", "POST /x HTTP/1.1\nHost: h.test\nContent-Length: 2\n\nhi", false, true)
+
+      String.new(view.request_bytes).should end_with("\r\n\r\nhi")
+    end
+
+    # RFC 2046 §5.1.1: parts are delimited by CRLF + boundary. A bare-LF multipart body is
+    # unparseable, and auto-CL re-frames it to the shortened length so nothing even hangs.
+    it "restores CRLF delimiters in a multipart body" do
+      view = RepeaterView.new
+      view.restore("http://h.test",
+        "POST /u HTTP/1.1\nHost: h.test\nContent-Type: multipart/form-data; boundary=B\nContent-Length: 9\n\n--B\nContent-Disposition: form-data; name=\"f\"\n\nhi\n--B--\n",
+        false, true)
+
+      sent = String.new(view.request_bytes)
+      body = sent.split("\r\n\r\n", limit: 2)[1]
+      body.should eq("--B\r\nContent-Disposition: form-data; name=\"f\"\r\n\r\nhi\r\n--B--\r\n")
+      # Auto-CL frames the body it actually sends, not the pre-normalization one.
+      sent.should contain("Content-Length: #{body.bytesize}")
+    end
+
+    # The head-only CRLF rule exists to protect bodies where 0x0A is a BYTE, not a line
+    # ending. Only multipart opts out of it.
+    it "leaves a non-multipart body's bare LFs alone" do
+      view = RepeaterView.new
+      view.restore("http://h.test",
+        "POST /x HTTP/1.1\nHost: h.test\nContent-Type: application/json\nContent-Length: 9\n\n{\n\"a\":1\n}",
+        false, true)
+
+      String.new(view.request_bytes).should end_with("\r\n\r\n{\n\"a\":1\n}")
+    end
+
+    it "downgrades an HTTP/2 request line before an h1 send" do
+      view = RepeaterView.new
+      view.restore("https://h.test", "GET /x HTTP/2\nHost: h.test\n\n", false, true)
+
+      view.downgrade_h2_request_lines(group: false).should be_true
+      view.request_text.lines.first.should eq("GET /x HTTP/1.1") # display agrees with the wire
+      String.new(view.request_bytes).should start_with("GET /x HTTP/1.1\r\n")
+    end
+
+    # Narrow on purpose: this runs unasked on every send, so a version the operator meant
+    # must survive it. Only a version h1 CANNOT carry is rewritten.
+    it "leaves a deliberate version alone" do
+      ["GET /x HTTP/1.0", "GET /x HTTP/9.9", "GET /x", "GET /x FTP/1.1"].each do |line|
+        view = RepeaterView.new
+        view.restore("https://h.test", "#{line}\nHost: h.test\n\n", false, true)
+
+        view.downgrade_h2_request_lines(group: false).should be_false
+        view.request_text.lines.first.should eq(line)
+      end
+    end
+
+    it "never rewrites while the tab is on h2 — that request line is correct" do
+      view = RepeaterView.new
+      view.restore("https://h.test", "GET /x HTTP/2\nHost: h.test\n\n", true, true)
+
+      view.downgrade_h2_request_lines(group: false).should be_false
+      view.request_text.lines.first.should eq("GET /x HTTP/2")
+    end
+
+    # A `%%%` means "next request" only for a send group. For a single ^R the whole buffer
+    # is ONE request, so the lines under it are body text and must not be touched.
+    it "downgrades every chunk of a send group, but only the first line of a single send" do
+      text = "GET /a HTTP/2\nHost: h.test\n\n%%%\nGET /b HTTP/2\nHost: h.test\n"
+
+      grouped = RepeaterView.new
+      grouped.restore("https://h.test", text, false, true)
+      grouped.downgrade_h2_request_lines(group: true).should be_true
+      grouped.request_text.should_not contain("HTTP/2")
+
+      single = RepeaterView.new
+      single.restore("https://h.test", text, false, true)
+      single.downgrade_h2_request_lines(group: false).should be_true
+      single.request_text.lines.first.should eq("GET /a HTTP/1.1")
+      single.request_text.should contain("GET /b HTTP/2") # body text — left alone
+    end
+  end
+
   describe "pretty_print_request" do
     it "pretty-prints JSON request body in-place and preserves markers" do
       view = RepeaterView.new

--- a/src/gori/repeater/flow_request.cr
+++ b/src/gori/repeater/flow_request.cr
@@ -1,4 +1,5 @@
 require "uri"
+require "../env"
 require "../store"
 
 module Gori
@@ -149,6 +150,67 @@ module Gori
         want = http2 ? "HTTP/2" : "HTTP/1.1"
         return nil if version == want
         "#{line[0, sp]} #{want}"
+      end
+
+      # HTTP versions an HTTP/1.x connection cannot carry. A request line pasted from
+      # another tool's HTTP/2 view ("GET /p HTTP/2" — Burp renders h2 requests that way)
+      # is put on the wire VERBATIM by the h1 `Engine`, and an origin handed a version
+      # token it doesn't speak answers 400.
+      UNSENDABLE_OVER_H1 = {"HTTP/2", "HTTP/2.0", "HTTP/3", "HTTP/3.0"}
+
+      # The request line rewritten to HTTP/1.1 when it declares a version h1 can't carry,
+      # else nil (nothing to do). Version = the LAST space-delimited token, as in
+      # `retarget_version_line`.
+      #
+      # Deliberately NARROWER than `retarget_version_line`: that one normalizes ANY
+      # mismatch because it backs the explicit ^V toggle, while this runs unasked on every
+      # send, so it must leave a version the operator meant alone. "HTTP/1.0" is a
+      # legitimate thing to hand-type at an origin (and "HTTP/9.9" a legitimate thing to
+      # probe with); "HTTP/2" down an h1 socket is never anything but a mistake.
+      def self.downgrade_version_line(line : String) : String?
+        sp = line.rindex(' ')
+        return nil unless sp
+        return nil unless UNSENDABLE_OVER_H1.includes?(line[(sp + 1)..])
+        "#{line[0, sp]} HTTP/1.1"
+      end
+
+      # Normalize bare LFs in a MULTIPART body to CRLF. Multipart parts are delimited by
+      # CRLF + boundary (RFC 2046 §5.1.1), so a body carrying bare LFs is unparseable and
+      # the origin answers 400 — usually with no hint as to why, because auto-Content-Length
+      # re-frames the shortened body so nothing hangs.
+      #
+      # EDITOR-DERIVED TEXT ONLY — never call this on captured or hand-supplied bytes.
+      # `Env.expand_wire` normalizes the HEAD alone on purpose: a raw 0x0A in a body is a
+      # BYTE (binary/compressed data), not a line ending, and rewriting it corrupts the
+      # request. That reasoning still holds for every verbatim-bytes path (`Repeater::Plan`,
+      # `Miner::Plan`, `Sequencer::Plan`, `FlowRequest.build`), which is why the fix lives
+      # here as an opt-in step rather than inside `expand_wire`. It is sound only where the
+      # CRs are already gone: the TUI editors hold the request as an LF-joined line buffer
+      # (`TextArea#set_text` strips \r off every line), so a multipart body typed or pasted
+      # there cannot reach the wire intact by any other route. ^X hex mode remains the
+      # byte-exact escape hatch for a multipart body with binary parts.
+      def self.normalize_multipart_body(bytes : Bytes) : Bytes
+        text = String.new(bytes)
+        sep = text.index("\r\n\r\n")
+        return bytes unless sep
+        body_at = sep + 4
+        return bytes if body_at >= bytes.size
+        return bytes unless multipart_head?(text[0, sep])
+        head = bytes[0, body_at]
+        body = Env.normalize_crlf(bytes[body_at..])
+        io = IO::Memory.new(head.size + body.size)
+        io.write(head)
+        io.write(body)
+        io.to_slice
+      end
+
+      # True when the head declares a `multipart/*` Content-Type. Case-insensitive on both
+      # the header name and the media type, per RFC 9110 §5.1/§8.3.
+      private def self.multipart_head?(head : String) : Bool
+        head.split("\r\n").any? do |line|
+          next false unless line.lstrip[0, 13]?.try(&.downcase) == "content-type:"
+          line.split(':', 2)[1].lstrip.downcase.starts_with?("multipart/")
+        end
       end
 
       # Returns the origin-form request line for an absolute-form one, else nil

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -1189,9 +1189,10 @@ module Gori::Tui
 
     def repeater_send : Nil
       return unless (tab = current_repeater_tab) && (view = tab.view).loaded?
-      view.commit_chain_pane        # flush an in-progress CHAIN-pane edit so ^R can't send stale bytes (matches the SEND-chip click)
-      view.sync_host_to_target_once # ^R defers past exit_target_insert!, so mirror a fresh ^N tab's target into Host here too (one-shot)
-      if view.inflight?             # one outstanding round-trip per view — don't pile up fibers on ^R mashing
+      view.commit_chain_pane                        # flush an in-progress CHAIN-pane edit so ^R can't send stale bytes (matches the SEND-chip click)
+      view.sync_host_to_target_once                 # ^R defers past exit_target_insert!, so mirror a fresh ^N tab's target into Host here too (one-shot)
+      view.downgrade_h2_request_lines(group: false) # a request line pasted from an h2 view can't ride this h1 socket (origins answer 400)
+      if view.inflight?                             # one outstanding round-trip per view — don't pile up fibers on ^R mashing
         @host.status("repeater already in flight…")
         return
       end
@@ -1331,6 +1332,7 @@ module Gori::Tui
         @host.status(view.http2? ? "send group is HTTP/1.1 only — ^V to switch off h2" : "send group needs plain text mode (not hex/gRPC/WS/decode)")
         return
       end
+      view.downgrade_h2_request_lines(group: true) # every chunk rides the same h1 connection
       reqs = view.pipeline_requests
       labels = reqs.map(&.[0])
       results = @group_results

--- a/src/gori/tui/paste_newline.cr
+++ b/src/gori/tui/paste_newline.cr
@@ -1,0 +1,43 @@
+require "termisu"
+
+module Gori
+  module Tui
+    # Collapses a pasted CRLF into ONE newline.
+    #
+    # Both 0x0D and 0x0A arrive as `Key::Enter`, and gori enables no bracketed-paste mode,
+    # so pasting CRLF text — what every other HTTP tool puts on the clipboard — inserted a
+    # blank line after EVERY line. In the Repeater editor that ends the head right after the
+    # request line: the request goes out with no Host header, and the origin answers 400
+    # (RFC 9112 §3.2 — an HTTP/1.1 request without Host is malformed).
+    #
+    # Only the LF of a CR-then-LF pair is dropped. A keyboard Enter is a lone CR and Ctrl+J
+    # a lone LF (both still one Enter), and a genuine blank line inside a pasted body is
+    # CR LF CR LF — one Enter per pair, so the blank line survives.
+    #
+    # Lives apart from `Runner` (which needs a tty and so can't be driven from a spec) so
+    # the state machine is testable on its own; Runner keeps one and filters every event
+    # through it at the single `handle` funnel.
+    class PasteNewline
+      def initialize
+        @after_cr = false
+      end
+
+      # True when `ev` is the LF half of a pasted CRLF and the caller must drop it.
+      #
+      # Depends on termisu reporting WHICH byte produced the Enter (`Event::Key#char`, set
+      # in input/parser.cr). On a build that doesn't, both halves report '\n' — the pair
+      # never matches and this is inert rather than wrong.
+      def swallow?(ev : Termisu::Event::Any) : Bool
+        if ev.is_a?(Termisu::Event::Key) && ev.key.enter? && !ev.ctrl? && !ev.alt?
+          char = ev.char
+          swallow = @after_cr && char == '\n'
+          @after_cr = char == '\r'
+          swallow
+        else
+          @after_cr = false
+          false
+        end
+      end
+    end
+  end
+end

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -834,8 +834,7 @@ module Gori::Tui
     # the envelope, then send the envelope (the authoritative request) with CL synced.
     private def decoded_request_bytes : Bytes
       commit_decoded
-      raw = expanded_text_to_bytes(@editor.text)
-      @auto_content_length ? sync_content_length(raw) : raw
+      finalize_wire(expanded_text_to_bytes(@editor.text))
     end
 
     # The request HEAD as origin-form text (request line rewritten, headers), WITHOUT
@@ -919,9 +918,7 @@ module Gori::Tui
         end
         unless lines.empty?
           label = lines.first.strip
-          raw = expanded_text_to_bytes(lines.join('\n'))
-          raw = terminate_head(raw) unless has_head_terminator?(raw) # bodyless → add \r\n\r\n
-          reqs << {label, @auto_content_length ? sync_content_length(raw) : raw}
+          reqs << {label, finalize_wire(expanded_text_to_bytes(lines.join('\n')))}
         end
         chunk.clear
       end
@@ -1212,12 +1209,37 @@ module Gori::Tui
       return @req_hex_edit.not_nil!.to_bytes if @req_hex_edit  # byte-exact; NO auto-CL in hex mode
       return decoded_request_bytes if @decode_kind             # envelope + re-encoded decoded payload
       return marked_request_bytes unless marker_regions.empty? # §…§ inline Decoder chains applied on send
-      raw = expanded_editor_bytes
-      @auto_content_length ? sync_content_length(raw) : raw
+      finalize_wire(expanded_editor_bytes)
     end
 
     private def expanded_editor_bytes : Bytes
       expanded_text_to_bytes(@editor.text)
+    end
+
+    # Head terminator + auto-Content-Length: the last two steps every plain-text send
+    # shares. Kept in one place so the single send and `pipeline_requests` cannot disagree
+    # about the bytes they put on the wire.
+    private def finalize_wire(raw : Bytes) : Bytes
+      raw = ensure_head_terminator(raw)
+      @auto_content_length ? sync_content_length(raw) : raw
+    end
+
+    # Append the CRLFCRLF head terminator to a request that carries none. Editor text with
+    # no trailing blank line produced a request the origin could only wait on — it has no
+    # way to know the headers ended — until something timed out, which the user saw as
+    # "no response" and the origin logged as a 400/408. `pipeline_requests` has always
+    # terminated its chunks; the single-send path did not.
+    #
+    # Only a HEAD-ONLY buffer can reach the append (expand_wire turns the editor's blank
+    # line into CRLFCRLF, so a request WITH a body always has a terminator), which is why
+    # trailing newlines here are line noise rather than body bytes: trim them, terminate once.
+    private def ensure_head_terminator(raw : Bytes) : Bytes
+      return raw if has_head_terminator?(raw)
+      n = raw.size
+      while n > 0 && (raw[n - 1] == 0x0A_u8 || raw[n - 1] == 0x0D_u8)
+        n -= 1
+      end
+      terminate_head(raw[0, n])
     end
 
     # Env-expand the LF editor text and normalize to CRLF wire form. Uses
@@ -1225,8 +1247,15 @@ module Gori::Tui
     # whose value itself carries a CRLF isn't doubled into `\r\r\n`, which would corrupt
     # the header line (or the head/body separator). Shared logic with the CLI/MCP repeater
     # send paths so the TUI can't disagree with them on the bytes it puts on the wire.
+    #
+    # Plus the one body-level fixup the editor OWES the wire: `expand_wire` normalizes the
+    # head alone (a raw 0x0A in a body is a byte, not a line ending), but this editor holds
+    # the request as an LF-joined line buffer, so a multipart body could never reach an
+    # origin with the CRLF delimiters RFC 2046 requires. See
+    # `FlowRequest.normalize_multipart_body` for why that step is opt-in here and not
+    # inside `expand_wire`.
     private def expanded_text_to_bytes(text : String) : Bytes
-      Env.expand_wire(text)
+      Repeater::FlowRequest.normalize_multipart_body(Env.expand_wire(text))
     end
 
     # §…§ marker send: parse the CRLF wire form as a Fuzz template and render each marked
@@ -1235,8 +1264,7 @@ module Gori::Tui
     # keeps render's output in wire form so the existing CRLF-based sync_content_length works
     # unchanged. A chain-less `§v§` renders `v`; a failing chain passes the value through.
     private def marked_request_bytes : Bytes
-      raw = render_marked(expanded_editor_bytes)
-      @auto_content_length ? sync_content_length(raw) : raw
+      finalize_wire(render_marked(expanded_editor_bytes))
     end
 
     # Render the §…§ template in `raw` (each marked default through its inline Decoder
@@ -1292,6 +1320,44 @@ module Gori::Tui
       updated = Repeater::FlowRequest.retarget_version_line(first, @http2) || return
       @editor.replace_line(0, updated)
       reflect_content_length_in_editor if @auto_content_length
+    end
+
+    # Bring a request line down to HTTP/1.1 before an h1 send when it declares a version h1
+    # cannot carry — a request line pasted from another tool's HTTP/2 view. Returns true
+    # when it changed anything.
+    #
+    # Runs at SEND PREP (like `sync_host_to_target_once`) rather than on edit: there is no
+    # paste event to hook, and rewriting mid-typing would fight the cursor. Rewriting the
+    # VISIBLE line rather than only the wire bytes is the point — the editor is what the
+    # user reads, so display and wire must agree, exactly as ^V and auto-CL already keep
+    # them. Refused in the byte-exact/own-framing modes; `downgrade_version_line` is itself
+    # narrow enough to leave a deliberate version alone.
+    #
+    # `group` says whether a lone `%%%` line starts a new request. It does for a send-group
+    # (each chunk carries its own request line, and every one of them rides the same h1
+    # connection); for a single ^R the whole buffer is ONE request, so a `%%%` there is body
+    # text and the lines under it must not be touched.
+    def downgrade_h2_request_lines(*, group : Bool) : Bool
+      return false if @http2 || @req_hex_edit || @grpc_mode || @ws_mode
+      changed = false
+      at_request_line = true # line 0 starts a request; with `group`, so does the line after a `%%%`
+      @editor.lines_snapshot.each_with_index do |line, i|
+        stripped = line.strip
+        if group && stripped == PIPELINE_SEP
+          at_request_line = true
+          next
+        end
+        next unless at_request_line
+        next if stripped.empty? # blank padding around a separator — the request line is below it
+        at_request_line = false
+        next unless updated = Repeater::FlowRequest.downgrade_version_line(line)
+        @editor.replace_line(i, updated)
+        changed = true
+      end
+      return false unless changed
+      @dirty = true
+      reflect_content_length_in_editor if @auto_content_length
+      true
     end
 
     def pretty_print_request : String?

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -6,6 +6,7 @@ require "../session"
 require "./screen"
 require "./theme"
 require "./layout"
+require "./paste_newline"
 require "./chrome"
 require "./preferences_view"
 require "./tab_controller"
@@ -849,7 +850,12 @@ module Gori::Tui
       nil
     end
 
+    # Collapses a pasted CRLF into one newline — see `PasteNewline`. Filtered here, at the
+    # single funnel every terminal event passes through, so every editor gets it.
+    @paste_newline = PasteNewline.new
+
     private def handle(ev : Termisu::Event::Any) : Nil
+      return if @paste_newline.swallow?(ev)
       case ev
       when Termisu::Event::Key
         handle_key(ev)


### PR DESCRIPTION
Copying a request out of Burp and into the TUI Repeater produced a 400 with no hint as to why. It turned out to be **four independent causes**, each reproduced by dumping the bytes gori actually put on the wire (raw TCP listener + tmux `paste-buffer -r`, which is a real CRLF paste).

### 1. A pasted CRLF became TWO Enters

Both `0x0D` and `0x0A` map to `Key::Enter` and gori enables no bracketed-paste mode, so pasting CRLF text — what every other HTTP tool puts on the clipboard — inserted a blank line after **every** line. That ends the head right after the request line, so the request went out with no `Host`, which RFC 9112 §3.2 makes a 400 by definition:

```
before: "GET / HTTP/1.1\r\n\r\nHost: h\n\nUser-Agent: burp\n\n\n\n"
after:  "GET / HTTP/1.1\r\nHost: h\r\nUser-Agent: burp\r\n\r\n"
```

`Tui::PasteNewline` swallows the LF of a CR-then-LF pair at `Runner#handle`, the single funnel every terminal event passes through (so every editor gets it, not just Repeater). A keyboard Enter is a lone CR and Ctrl+J a lone LF — both still one Enter — and a blank line inside a pasted body is `CR LF CR LF`, one Enter per pair, so it survives.

This needs termisu to report which byte produced the Enter **and** its raw mode to stop translating CR to NL — see the dependency note below.

### 2. A multipart body lost its CRLF delimiters

`TextArea` holds the request as an LF-joined line buffer (`set_text` strips `\r` off every line) and `Env.expand_wire` normalizes the **head only** — deliberately, since a `0x0A` in a body is a byte, not a line ending. But multipart parts are delimited by CRLF + boundary (RFC 2046 §5.1.1), so the body was unparseable. Auto-Content-Length then re-framed the shortened body, so nothing hung and the only symptom was the status code.

`FlowRequest.normalize_multipart_body` is opt-in and wired at `RepeaterView#expanded_text_to_bytes` only. The verbatim-bytes paths (`Repeater::Plan`, `Miner::Plan`, `Sequencer::Plan`, `FlowRequest.build`) must not call it — a binary part would be corrupted. `^X` hex mode stays the byte-exact escape hatch.

### 3. `GET /x HTTP/2` rode the h1 socket verbatim

Burp renders h2 requests that way and the h1 `Engine` sends the request line as given. Downgraded at send prep — in the editor as well as on the wire, so the two agree, as `^V` and auto-CL already do. Narrower than the `^V` retarget on purpose: this runs unasked on every send, so only a version h1 **cannot** carry is touched and a deliberate `HTTP/1.0` (or `HTTP/9.9`) still goes out as typed.

### 4. A paste with no trailing blank line got no head terminator

The origin has no way to know the headers ended, so it waits until something times out — "no response" in the workbench, a 400/408 in the origin's log. `pipeline_requests` has always terminated its chunks; the single send never did. Both now share `finalize_wire`, so they cannot disagree about the bytes on the wire.

## Dependency bump

`shard.lock` moves termisu to hahwul/termisu#2, which fixes a bug that sat underneath cause 1: `Termios#set_mode` passed its `LibC::Termios` (a **struct** — by value) to `apply_input_flags` / `apply_output_flags`, so every `c_iflag` / `c_oflag` write was discarded. Raw mode had therefore kept `ICRNL`, `IXON` and `OPOST` set — the opposite of the table documented in termisu's own `terminal/mode.cr`. With `ICRNL` on, the line discipline turns CR into NL before gori ever sees it, so CR and LF are indistinguishable and no application-side fix is possible. Side benefit: `^S` (SNI) no longer freezes the terminal via XOFF.

## Verification

End to end in tmux against a raw TCP listener, pasting a Burp-shaped request (raw CRLF + `HTTP/2` request line + multipart body). What now goes on the wire is byte-for-byte what Burp sends:

```
"POST /upload HTTP/1.1\r\nHost: 127.0.0.1:19999\r\nContent-Type: multipart/form-data; boundary=----WebKitFormBoundaryABC\r\nContent-Length: 155\r\n\r\n------WebKitFormBoundaryABC\r\nContent-Disposition: form-data; name=\"f\"; filename=\"a.txt\"\r\nContent-Type: text/plain\r\n\r\nhello\r\n------WebKitFormBoundaryABC--\r\n"
```

Head-terminator case separately: `"GET /noterm HTTP/1.1\r\nHost: ...\r\n\r\n"` → 200.

30 new specs. Full suite 4839 examples, 0 failures, after rebasing onto `main` (merge result built with `crystal build --no-codegen`, not just the branch alone). Format and ameba clean on the touched lines.

## Not in scope

The Intercept editor (`intercept_view.cr:379`) has cause 2 as well — same shape, left alone here.