### PR TITLE
fix(probe): three stability/perf defects in the rule engine

### DIFF
--- a/bench/probe_passive_bench.cr
+++ b/bench/probe_passive_bench.cr
@@ -98,6 +98,24 @@ JS_BODY = begin
   io.to_slice.dup
 end
 
+# The SAME bundle plus one non-ASCII regex literal — a diacritic/slug normaliser, which real
+# i18n'd bundles ship constantly (`/[—–]/`, `/[가-힣]+/`, …).
+#
+# This is not a cosmetic variant. `strip` blanks the contents of strings and comments, so a
+# non-ASCII byte in either is gone by the time the client rules see the script — but regex
+# literals are deliberately left intact (JsScan's `strip` docs), so a single accented char there
+# makes the STRIPPED text non-ASCII. `String#[]` range slicing is O(1) only on an all-ASCII
+# string; once it isn't, every window slice in `source_in_window` walks from the start, and that
+# runs per sink occurrence. This fixture cost 1765ms against JS_BODY's 9ms until the window
+# arithmetic moved to byte offsets. Same reasoning as the sinks above: a JS fixture whose
+# stripped output is pure ASCII silently skips this branch, so keep the literal here.
+JS_I18N_BODY = begin
+  io = IO::Memory.new
+  io << "var deburr=/[éèêàçñüö—–]/g;" # <- the whole point of this fixture
+  io.write(JS_BODY)
+  io.to_slice.dup
+end
+
 JS_RESP_HEAD = ("HTTP/1.1 200 OK\r\nContent-Type: application/javascript\r\n" \
                 "Server: nginx/1.24.0\r\nCache-Control: max-age=31536000\r\n\r\n").to_slice
 
@@ -105,15 +123,24 @@ JS_FLOW = flow("GET", "/static/app.min.js", "application/javascript",
   ("GET /static/app.min.js HTTP/1.1\r\nHost: app.example.com\r\n\r\n").to_slice, nil,
   JS_RESP_HEAD, JS_BODY)
 
+JS_I18N_FLOW = flow("GET", "/static/app.i18n.min.js", "application/javascript",
+  ("GET /static/app.i18n.min.js HTTP/1.1\r\nHost: app.example.com\r\n\r\n").to_slice, nil,
+  JS_RESP_HEAD, JS_I18N_BODY)
+
 puts "Probe passive scan — full Passive.analyze per flow:"
 puts "  JSON POST body: #{JSON_BODY.size} bytes; HTML document: #{HTML_BODY.size} bytes"
 puts "  JS bundle: #{JS_BODY.size} bytes (at the CLIENT_BODY_CAP ceiling)"
+puts "  JS bundle + non-ASCII regex literal: #{JS_I18N_BODY.size} bytes"
 puts "  (detections: json=#{Gori::Probe::Passive.analyze(JSON_FLOW).size}" \
      " html=#{Gori::Probe::Passive.analyze(HTML_FLOW).size}" \
-     " js=#{Gori::Probe::Passive.analyze(JS_FLOW).size})"
+     " js=#{Gori::Probe::Passive.analyze(JS_FLOW).size}" \
+     " js_i18n=#{Gori::Probe::Passive.analyze(JS_I18N_FLOW).size})"
 
 Benchmark.ips do |x|
-  x.report("JSON API POST flow") { Gori::Probe::Passive.analyze(JSON_FLOW) }
-  x.report("HTML document flow") { Gori::Probe::Passive.analyze(HTML_FLOW) }
-  x.report("JS bundle flow    ") { Gori::Probe::Passive.analyze(JS_FLOW) }
+  x.report("JSON API POST flow ") { Gori::Probe::Passive.analyze(JSON_FLOW) }
+  x.report("HTML document flow ") { Gori::Probe::Passive.analyze(HTML_FLOW) }
+  x.report("JS bundle flow     ") { Gori::Probe::Passive.analyze(JS_FLOW) }
+  # Must stay in the SAME order of magnitude as the plain JS bundle. A large gap here means the
+  # non-ASCII slow path is back.
+  x.report("JS bundle, non-ASCII") { Gori::Probe::Passive.analyze(JS_I18N_FLOW) }
 end

--- a/spec/probe/passive/js_scan_spec.cr
+++ b/spec/probe/passive/js_scan_spec.cr
@@ -1,0 +1,88 @@
+require "../../spec_helper"
+
+# JsScan is pure (no Store/Scope), so this needs no flow harness — it drives the lexers and
+# the source↔sink correlator directly. Everything here is deterministic: the two properties
+# being pinned are "does not crash" and "offsets stay aligned", never a timing.
+
+private alias JsScan = Gori::Probe::Passive::JsScan
+
+# Nesting deeper than MAX_INTERP_DEPTH, UNTERMINATED so no closing delimiters are needed —
+# the recursion happens on the way in, which is what made 3 bytes per level enough to blow
+# an 8 MiB fiber stack from a single 256 KiB response body.
+private def deep_unterminated(levels : Int32) : String
+  "x=" + ("`${" * levels)
+end
+
+private def deep_terminated(levels : Int32) : String
+  "x=" + ("`${" * levels) + "1" + ("}`" * levels) + ";"
+end
+
+describe Gori::Probe::Passive::JsScan do
+  describe "template-literal nesting depth guard" do
+    # Regression: `x=` + "`${" * 87381 (what CLIENT_BODY_CAP / 3 allows) recursed one frame per
+    # level and killed the PROCESS — a Crystal stack overflow is a fatal signal, so the
+    # Analyzer's per-flow `rescue` could not contain it. Well past both the cap and the old
+    # ~87k-frame limit here, so it fails loudly if the guard is ever removed.
+    it "survives nesting far deeper than a response body could carry" do
+      src = deep_unterminated(200_000)
+      JsScan.strip(src).should_not be_empty
+      JsScan.strip_comments(src).should_not be_empty
+    end
+
+    it "survives deep TERMINATED nesting too (the copy_/emit_ interpolation pair)" do
+      src = deep_terminated(100_000)
+      JsScan.strip(src).should_not be_empty
+      JsScan.strip_comments(src).should_not be_empty
+    end
+
+    # The guard blanks the rest of the fragment rather than declining to descend in place, so
+    # the one-char-in-one-char-out invariant the whole file rests on must still hold. This is
+    # what keeps source_in_window's window arithmetic meaningful.
+    it "preserves offsets when the guard trips" do
+      {deep_unterminated(200_000), deep_terminated(100_000)}.each do |src|
+        JsScan.strip(src).size.should eq(src.size)
+        JsScan.strip_comments(src).size.should eq(src.size)
+      end
+    end
+
+    # Nesting a real bundle actually uses must keep working — the guard must not blank code
+    # that sits under the cap.
+    it "still correlates a source through ordinary shallow interpolation" do
+      code = JsScan.strip(%(o.innerHTML = `hello ${location.hash} there`;))
+      JsScan.source_sink_pairs(code).should eq([{"location.hash", "innerHTML"}])
+    end
+
+    it "still correlates a source nested a few interpolations deep" do
+      code = JsScan.strip(%(o.innerHTML = `a${`b${location.hash}c`}d`;))
+      JsScan.source_sink_pairs(code).should eq([{"location.hash", "innerHTML"}])
+    end
+  end
+
+  # source_in_window works on BYTE offsets: char-index slicing was O(1) only while the script
+  # stayed all-ASCII, and one non-ASCII byte turned every window slice into a walk from the
+  # start of the string (measured 9ms -> 1765ms per flow). The pairs must be identical either
+  # way — that equivalence is what the byte-offset rewrite had to preserve, and it is the part
+  # a spec can pin. The COST is guarded by bench/probe_passive_bench.cr's JS fixture.
+  describe "source↔sink correlation is independent of encoding" do
+    it "finds the same pair with and without a non-ASCII regex literal in scope" do
+      ascii = JsScan.strip(%(var r=/[abc]/g; o.innerHTML=location.hash;))
+      utf8 = JsScan.strip(%(var r=/[éèê]/g; o.innerHTML=location.hash;))
+      utf8.ascii_only?.should be_false # the literal survives `strip` by design
+      utf8_pairs = JsScan.source_sink_pairs(utf8)
+      utf8_pairs.should eq(JsScan.source_sink_pairs(ascii))
+      utf8_pairs.should eq([{"location.hash", "innerHTML"}])
+    end
+
+    it "keeps the statement boundary exact when a multi-byte char sits in the window" do
+      # The `;` before the sink ends the previous statement, so the source on its far side must
+      # NOT be picked up — a byte scan that mis-handled a multi-byte char would over-reach.
+      code = JsScan.strip(%(var s=location.hash; var t=/[가-힣]/; o.innerHTML=safe;))
+      JsScan.source_sink_pairs(code).should be_empty
+    end
+
+    it "correlates across a multi-byte char inside the same statement" do
+      code = JsScan.strip(%(o.innerHTML=/[가-힣]/.test(x)?location.hash:y;))
+      JsScan.source_sink_pairs(code).should eq([{"location.hash", "innerHTML"}])
+    end
+  end
+end

--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -29,6 +29,42 @@ private class FixedBackend < Gori::Fuzz::Backend
   end
 end
 
+# A backend whose send ALWAYS raises — the "a rule blew up on this input" case. Before
+# Active.analyze isolated each rule, one of these aborted the entire scan: every rule after it
+# AND (through Scan.scan_flows) every remaining flow, discarding findings already collected.
+private class RaisingBackend < Gori::Fuzz::Backend
+  getter origin : Gori::Fuzz::Origin
+  getter sent = 0
+
+  def initialize(@origin : Gori::Fuzz::Origin)
+  end
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    @sent += 1
+    raise "backend exploded"
+  end
+end
+
+# Raises on the FIRST send only, then answers every later probe with a CORS response echoing the
+# probe origin — so a rule that runs AFTER the one that died can be shown to still produce its
+# finding, which is the actual promise of per-rule isolation.
+private class FlakyCorsBackend < Gori::Fuzz::Backend
+  getter origin : Gori::Fuzz::Origin
+  getter sent = 0
+
+  def initialize(@origin : Gori::Fuzz::Origin)
+  end
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    @sent += 1
+    raise "first probe exploded" if @sent == 1
+    head = "HTTP/1.1 200 OK\r\n" \
+           "Access-Control-Allow-Origin: #{Gori::Probe::Active::CorsReflection::PROBE_ORIGIN}\r\n" \
+           "Access-Control-Allow-Credentials: true\r\n\r\n"
+    Gori::Repeater::Result.new(head.to_slice, Bytes.empty, nil, 1_i64)
+  end
+end
+
 private def with_store(&)
   path = File.tempname("gori-probe", ".db")
   store = Gori::Store.open(path)
@@ -2028,6 +2064,62 @@ describe "Gori::Probe::Active (safety + coverage)" do
       fake = CountingBackend.new(Gori::Fuzz::Origin.new(detail.row.scheme, detail.row.host, detail.row.port))
       Gori::Probe::Active.analyze(detail, outbound: Gori::Outbound.interactive(scope), backend: fake)
       fake.sent.should be > 0 # an include rule (no exclude, sandbox off) lets the probe through
+    end
+  end
+
+  # --- per-rule error isolation (the headless path used to have none) ---------------------
+  #
+  # The TUI analyzer has always wrapped each rule in its own rescue (execute_active), so a rule
+  # that raised was merely skipped there. Active.analyze — the CLI / MCP path — had no such
+  # rescue, so the SAME rule killed a whole `gori run probe` batch. These pin the parity.
+
+  it "isolates a rule that raises and keeps running the rest" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=hi", content_type: nil)
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "acme.test")
+      origin = Gori::Fuzz::Origin.new(detail.row.scheme, detail.row.host, detail.row.port)
+      backend = RaisingBackend.new(origin)
+      failed = [] of String
+      dets = Gori::Probe::Active.analyze(detail, outbound: Gori::Outbound.interactive(scope),
+        backend: backend, on_error: ->(where : String, _ex : Exception) { failed << where; nil })
+      dets.should be_empty # nothing could be detected — every send blew up
+      # ...but the loop did not abort on the first raise: more than one rule got to run and
+      # report. Without the rescue this example never reaches an assertion at all.
+      failed.size.should be > 1
+      backend.sent.should eq(failed.size)
+    end
+  end
+
+  it "still produces a later rule's finding after an earlier rule raises" do
+    with_store do |store|
+      # An ACAO on the captured response is cors_reflection's gate; reflected_param (RULES[0])
+      # sends first and is the one that dies.
+      detail = capture_flow(store,
+        "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: https://app.acme.test\r\n\r\n",
+        target: "/s?q=hi", content_type: nil)
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "acme.test")
+      origin = Gori::Fuzz::Origin.new(detail.row.scheme, detail.row.host, detail.row.port)
+      failed = [] of String
+      dets = Gori::Probe::Active.analyze(detail, outbound: Gori::Outbound.interactive(scope),
+        backend: FlakyCorsBackend.new(origin),
+        on_error: ->(where : String, _ex : Exception) { failed << where; nil })
+      # on_error carries the RULE id; the Detection carries its own finding CODE.
+      failed.should eq(["reflected_param"])                    # the first rule died...
+      dets.map(&.code).should contain("cors_arbitrary_origin") # ...a later rule still reported
+    end
+  end
+
+  it "reports no scan errors on a clean Scan.scan_flows run" do
+    with_store do |store|
+      capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/a?token=aaaaaaaa", content_type: nil)
+      ids = Gori::Probe::Scan.flow_ids(store, nil)
+      failed = [] of String
+      dets = Gori::Probe::Scan.scan_flows(store, ids, active: false,
+        on_error: ->(where : String, _ex : Exception) { failed << where; nil })
+      failed.should be_empty
+      dets.should_not be_empty
     end
   end
 

--- a/src/gori/cli/run/probe.cr
+++ b/src/gori/cli/run/probe.cr
@@ -109,9 +109,19 @@ module Gori
           meter = STDERR.tty?
           # --aggressive implies --unsafe (it also raises caps + widens bypass sets).
           opts = Probe::Active::Options.new(allow_unsafe: unsafe || aggressive, aggressive: aggressive)
+          # A scan now SKIPS an item that blows up instead of losing the whole batch, so the
+          # skips have to be reported — otherwise a partial scan prints the same summary as a
+          # complete one and reads as "clean".
+          scan_errors = [] of String
           dets, rn = Probe::Scan.scan_all(store, ids, active: active, scope: scope,
-            allow_unscoped: allow_unscoped, opts: opts, progress: probe_progress_meter(meter))
+            allow_unscoped: allow_unscoped, opts: opts, progress: probe_progress_meter(meter),
+            on_error: ->(where : String, ex : Exception) { scan_errors << "#{where}: #{ex.message}"; nil })
           STDERR.print "\r\e[K" if meter # clear the in-place meter before the summary line
+          unless scan_errors.empty?
+            n = scan_errors.size
+            STDERR.puts "gori run probe: #{n} item#{n == 1 ? "" : "s"} skipped after an error " \
+                        "(results are INCOMPLETE) — first: #{scan_errors.first}"
+          end
           {Probe.group(dets), ids.size, rn}
         ensure
           store.close

--- a/src/gori/mcp/tools/probe.cr
+++ b/src/gori/mcp/tools/probe.cr
@@ -41,12 +41,16 @@ module Gori
         # covers every flow. (An earlier version truncated `ids`, which silently dropped
         # passive coverage of the newest flows under active:true.)
         capped = active && ids.size > PROBE_ACTIVE_MAX_FLOWS
+        # A scan SKIPS an item that blows up rather than losing the batch; count the skips so the
+        # agent can tell an incomplete result from a clean one (surfaced as `scan_errors`).
+        scan_errors = 0
         dets, repeater_n = Probe::Scan.scan_all(store, ids, active: active, verify_upstream: @verify_upstream,
-          scope: scope, allow_unscoped: allow_unscoped, opts: opts, active_limit: active ? PROBE_ACTIVE_MAX_FLOWS : nil)
+          scope: scope, allow_unscoped: allow_unscoped, opts: opts, active_limit: active ? PROBE_ACTIVE_MAX_FLOWS : nil,
+          on_error: ->(_where : String, _ex : Exception) { scan_errors += 1; nil })
 
         groups = probe_filter_groups(Probe.group(dets), severity_from(str(h, "severity")), category.as(String?))
         Result.new(probe_scan_json(groups, ids.size, repeater_n, active, allow_unscoped,
-          scope_configured, capped, unsafe, aggressive, clamp(int(h, "limit"), 200, 2000)))
+          scope_configured, capped, unsafe, aggressive, clamp(int(h, "limit"), 200, 2000), scan_errors))
       end
 
       # --- persisted probe issues + triage (parity with the TUI Probe tab) -------------------
@@ -373,11 +377,15 @@ module Gori
 
       private def probe_scan_json(groups : Array(Probe::Group), flows_scanned : Int32, repeater_n : Int32,
                                   active : Bool, allow_unscoped : Bool, scope_configured : Bool,
-                                  capped : Bool, unsafe : Bool, aggressive : Bool, limit : Int32) : String
+                                  capped : Bool, unsafe : Bool, aggressive : Bool, limit : Int32,
+                                  scan_errors : Int32 = 0) : String
         JSON.build do |j|
           j.object do
             j.field "flows_scanned", flows_scanned
             j.field "repeaters_scanned", repeater_n
+            # Only present when something was skipped: coverage is INCOMPLETE, so a clean-looking
+            # empty result must not be read as "nothing found".
+            j.field "scan_errors", scan_errors if scan_errors > 0
             j.field "active", active
             if active
               j.field "scope_configured", scope_configured

--- a/src/gori/probe/active.cr
+++ b/src/gori/probe/active.cr
@@ -70,10 +70,13 @@ module Gori
       # `disabled` holds the RuleInfo#ids the operator turned off in the Rules sub-tab — the same
       # set the TUI analyzer filters on before enqueueing (analyzer.cr's maybe_enqueue_active), so
       # a headless scan honours that config too instead of silently running every built-in.
+      # `on_error` (optional) is called with the failing rule's id when a rule raises; see the
+      # per-rule rescue below for why that isolation exists at all.
       def self.analyze(detail : Store::FlowDetail, verify_upstream : Bool = true,
                        timeout : Time::Span = 10.seconds, *, outbound : Outbound,
                        backend : Fuzz::Backend? = nil, opts : Options = Options::DEFAULT,
-                       disabled : Set(String) = NO_DISABLED) : Array(Detection)
+                       disabled : Set(String) = NO_DISABLED,
+                       on_error : Proc(String, Exception, Nil)? = nil) : Array(Detection)
         out = [] of Detection
         row = detail.row
         origin = Fuzz::Origin.new(row.scheme, row.host, row.port)
@@ -88,14 +91,25 @@ module Gori
 
         RULES.each do |rule|
           next if disabled.includes?(rule.info.id)
-          plan = rule.plan(detail, opts)
-          next unless plan
-          result = sender.send(plan.request)
-          next unless result.ok?
-          results = [result]
-          plan.followups.each { |req| results << sender.send(req) }
-          dets = rule.detections_all(plan, results, detail)
-          out.concat(dets)
+          # ISOLATE each rule. Without this, one rule raising in plan/detections_all took down
+          # the whole scan — every rule after it AND (via Scan.scan_flows) every remaining flow,
+          # discarding findings already collected. The TUI path has always had this: the analyzer
+          # wraps each rule in its own rescue (analyzer.cr's execute_active), so the same rule
+          # that merely gets skipped in the TUI used to kill a `gori run probe` / MCP probe_scan
+          # batch outright. Send FAILURES are not exceptions (Fuzz returns an errored Result and
+          # `result.ok?` skips), so what this catches is a rule bug on hostile input.
+          begin
+            plan = rule.plan(detail, opts)
+            next unless plan
+            result = sender.send(plan.request)
+            next unless result.ok?
+            results = [result]
+            plan.followups.each { |req| results << sender.send(req) }
+            dets = rule.detections_all(plan, results, detail)
+            out.concat(dets)
+          rescue ex
+            on_error.try &.call(rule.info.id, ex)
+          end
         end
         out
       end

--- a/src/gori/probe/passive/js_scan.cr
+++ b/src/gori/probe/passive/js_scan.cr
@@ -124,7 +124,7 @@ module Gori
             String.build(js.bytesize) do |io|
               i = 0
               while i < n
-                if j = blank_token_at(chars, i, n, io)
+                if j = blank_token_at(chars, i, n, io, 0)
                   i = j
                 else
                   io << chars[i]
@@ -150,8 +150,38 @@ module Gori
           end
         end
 
+        # Template-literal nesting recurses one frame per level (blank_string →
+        # emit_interpolation → blank_token_at → …, and the copy_* mirror of it), and the depth is
+        # ATTACKER-CONTROLLED: it is just response-body text. The recursion happens on the way IN,
+        # so no closing delimiters are needed — an unterminated "`${" costs 3 bytes per level, and
+        # CLIENT_BODY_CAP / 3 = 87381 levels lands past the ~87k frames an 8 MiB fiber stack holds.
+        # A Crystal stack overflow is a FATAL SIGNAL, not a rescuable exception, so Analyzer's
+        # per-flow `rescue` cannot contain it: one 256 KiB response body took the whole process
+        # down (proxy capture, TUI, CLI and MCP alike). The body cap is not a defense here — it
+        # sits on the wrong side of the limit — so the lexers cap the nesting themselves.
+        #
+        # 64 is far past anything real: minifiers do not add template nesting and hand-written
+        # code does not go beyond a handful of levels. Past it we blank the rest of the FRAGMENT
+        # (see blank_rest) rather than stop descending in place — declining to recurse would let a
+        # nested backtick close the enclosing template early and re-lex the remainder, the exact
+        # desync copy_string exists to prevent. Blanking is offset-preserving and cannot desync;
+        # the cost is that content past 64 levels of nesting is not analyzed, which is the safe
+        # direction (a missed lead, never a false one).
+        MAX_INTERP_DEPTH = 64
+
+        # Blank every remaining char of the fragment (one space each, offsets preserved) and
+        # return the end index, so the caller's `while i < n` loop terminates immediately.
+        private def self.blank_rest(chars, i : Int32, n : Int32, io : IO) : Int32
+          while i < n
+            io << ' '
+            i += 1
+          end
+          n
+        end
+
         # If chars[i] starts a // or /* */ comment, blank it (→ spaces, offsets preserved) and
         # return the index just past it; else nil. Shared by the string- and comment-strip lexers.
+        # No `depth`: a comment never recurses.
         private def self.blank_comment_at(chars, i : Int32, n : Int32, io : IO) : Int32?
           c = chars[i]
           if c == '/' && i + 1 < n && chars[i + 1] == '/'
@@ -164,12 +194,13 @@ module Gori
         # If chars[i] starts a // comment, /* */ comment, or a '…'/"…"/`…` string, blank it
         # (contents → spaces, offsets preserved) and return the index just past it; else nil.
         # Shared by strip and emit_interpolation so the token lexing lives in one place.
-        private def self.blank_token_at(chars, i : Int32, n : Int32, io : IO) : Int32?
+        # `depth` is the template-interpolation nesting level (see MAX_INTERP_DEPTH).
+        private def self.blank_token_at(chars, i : Int32, n : Int32, io : IO, depth : Int32) : Int32?
           if j = blank_comment_at(chars, i, n, io)
             j
           else
             c = chars[i]
-            (c == '\'' || c == '"' || c == '`') ? blank_string(chars, i, n, io) : nil
+            (c == '\'' || c == '"' || c == '`') ? blank_string(chars, i, n, io, depth) : nil
           end
         end
 
@@ -190,7 +221,7 @@ module Gori
                     elsif c == '/' && i + 1 < n && chars[i + 1] == '*'
                       blank_block_comment(chars, i, n, io)
                     elsif c == '\'' || c == '"' || c == '`'
-                      copy_string(chars, i, n, io)
+                      copy_string(chars, i, n, io, 0)
                     else
                       io << c
                       i + 1
@@ -206,7 +237,7 @@ module Gori
         # via copy_interpolation so a NESTED template's backtick inside ${…} is not mistaken
         # for this template's closing delimiter (which would terminate early and re-lex the
         # real remainder, blanking a URL's // as a comment).
-        private def self.copy_string(chars, i : Int32, n : Int32, io : IO) : Int32
+        private def self.copy_string(chars, i : Int32, n : Int32, io : IO, depth : Int32) : Int32
           quote = chars[i]
           io << quote
           i += 1
@@ -218,7 +249,7 @@ module Gori
               next
             end
             if quote == '`' && ch == '$' && i + 1 < n && chars[i + 1] == '{'
-              i = copy_interpolation(chars, i, n, io)
+              i = copy_interpolation(chars, i, n, io, depth)
               next
             end
             io << ch
@@ -232,20 +263,21 @@ module Gori
         # comments inside it, but COPY string literals verbatim (so their contents stay for the
         # string-key rules), tracking brace depth to find the matching `}`. Recurses through
         # copy_string for nested strings/templates. `i` points at `$`. Offset-preserving.
-        private def self.copy_interpolation(chars, i : Int32, n : Int32, io : IO) : Int32
+        private def self.copy_interpolation(chars, i : Int32, n : Int32, io : IO, depth : Int32) : Int32
+          return blank_rest(chars, i, n, io) if depth >= MAX_INTERP_DEPTH
           io << '$' << '{'
           i += 2
-          depth = 1
-          while i < n && depth > 0
+          braces = 1
+          while i < n && braces > 0
             ch = chars[i]
             if ch == '{' || ch == '}'
-              depth += ch == '{' ? 1 : -1
+              braces += ch == '{' ? 1 : -1
               io << ch
               i += 1
             elsif j = blank_comment_at(chars, i, n, io) # real code comment inside ${…} → blank
               i = j
             elsif ch == '\'' || ch == '"' || ch == '`'
-              i = copy_string(chars, i, n, io) # string content kept
+              i = copy_string(chars, i, n, io, depth + 1) # string content kept
             else
               io << ch
               i += 1
@@ -285,7 +317,7 @@ module Gori
         # expression is emitted (via emit_interpolation) instead of blanked — otherwise the
         # common template-literal sink shape (innerHTML = `${location.hash}`) would lose its
         # source and DOM-XSS would miss it.
-        private def self.blank_string(chars, i : Int32, n : Int32, io : IO) : Int32
+        private def self.blank_string(chars, i : Int32, n : Int32, io : IO, depth : Int32) : Int32
           quote = chars[i]
           io << quote # opening delimiter kept
           i += 1
@@ -302,7 +334,7 @@ module Gori
               break
             end
             if quote == '`' && ch == '$' && i + 1 < n && chars[i + 1] == '{'
-              i = emit_interpolation(chars, i, n, io) # ${…} expression kept as code
+              i = emit_interpolation(chars, i, n, io, depth) # ${…} expression kept as code
               next
             end
             io << ' ' # content blanked (incl. newlines inside a template)
@@ -315,20 +347,21 @@ module Gori
         # source/sink keywords inside it survive, but blank nested strings/comments (so their
         # CONTENTS can't false-match) and track brace depth to find the matching `}`. Every
         # consumed char emits exactly one char, so offsets stay aligned. `i` points at `$`.
-        private def self.emit_interpolation(chars, i : Int32, n : Int32, io : IO) : Int32
+        private def self.emit_interpolation(chars, i : Int32, n : Int32, io : IO, depth : Int32) : Int32
+          return blank_rest(chars, i, n, io) if depth >= MAX_INTERP_DEPTH
           io << "  " # blank the '${' delimiter (2 spaces, offset-preserved): keeps the inner
           #            expression as code but removes the '{' so source_in_window's /[;{}\n]/
           #            statement-boundary scan doesn't truncate the window at the interpolation
           #            (else `innerHTML = `${location.hash}`` loses its source and DOM-XSS misses it)
           i += 2
-          depth = 1
-          while i < n && depth > 0
+          braces = 1
+          while i < n && braces > 0
             ch = chars[i]
             if ch == '{' || ch == '}'
-              depth += ch == '{' ? 1 : -1
-              io << (ch == '}' && depth == 0 ? ' ' : ch) # blank the OUTER closing '}'; keep inner braces
+              braces += ch == '{' ? 1 : -1
+              io << (ch == '}' && braces == 0 ? ' ' : ch) # blank the OUTER closing '}'; keep inner braces
               i += 1
-            elsif j = blank_token_at(chars, i, n, io) # nested string/comment (recurses for a nested template)
+            elsif j = blank_token_at(chars, i, n, io, depth + 1) # nested string/comment (recurses for a nested template)
               i = j
             else
               io << ch
@@ -357,7 +390,7 @@ module Gori
             # the match call; `match_at_byte_index` is just as slow, so it is not char↔byte
             # conversion). `scan` yields the same MatchData, so begin/end are unchanged.
             code.scan(sink_re) do |m|
-              if src = source_in_window(code, m.begin(0), m.end(0))
+              if src = source_in_window(code, m.byte_begin(0), m.byte_end(0))
                 pairs << {src, sink_label}
               end
             end
@@ -365,35 +398,52 @@ module Gori
           pairs
         end
 
-        # The characters that end a statement, hence bound a source↔sink window. Scanned as four
-        # Char searches rather than one `/[;{}\n]/`: `String#rindex(Regex)` walks the whole subject
-        # FORWARD keeping the last match and allocates a MatchData per boundary, and a minified
-        # statement is dense with them. Same idea as the `[a.index('/'), a.index('?'),
-        # a.index('#')].compact.min?` idiom in active/types.cr, written allocation-free here
-        # because this runs once per sink occurrence.
-        BOUNDS = {';', '{', '}', '\n'}
+        # The bytes that end a statement, hence bound a source↔sink window: ';' '{' '}' '\n'.
+        # Held as BYTES, and the window walk below is a direct byte scan outward from the sink —
+        # NOT `String#rindex`/`index` over a substring. Two reasons: `String#rindex(Regex)` walks
+        # the whole subject FORWARD keeping the last match and allocates a MatchData per boundary,
+        # and taking the `pre`/`post` substrings at all is what made this quadratic on a non-ASCII
+        # script. The scan stops at the first boundary in each direction, so it touches at most
+        # WINDOW bytes per side and allocates nothing — and this runs once per sink occurrence.
+        BOUNDS = {0x3Bu8, 0x7Bu8, 0x7Du8, 0x0Au8}
 
         # The first taint source inside the statement window around [from, to), or nil.
+        # Offsets are BYTE offsets. Char-index slicing (`code[floor...from]`) is O(1) only while
+        # the script is all-ASCII; one non-ASCII byte anywhere makes every `String#[]` walk from
+        # the start, and this runs per sink occurrence — thousands of times in a minified bundle.
+        # A single accented char in a regex literal (kept intact by `strip`, by design) is enough:
+        # measured 9ms → 1765ms per flow, on the fiber the passive scan shares with the proxy.
         private def self.source_in_window(code : String, from : Int32, to : Int32) : String?
+          bytes = code.to_slice
           floor = from - WINDOW
           floor = 0 if floor < 0
           ceil = to + WINDOW
-          ceil = code.size if ceil > code.size
-          # Statement start: the LAST boundary before the sink (else the window floor).
-          pre = code[floor...from]
+          ceil = bytes.size if ceil > bytes.size
+          # Statement start: the LAST boundary before the sink (else the window floor). Scanned as
+          # raw bytes: every BOUNDS byte is ASCII, and a UTF-8 continuation byte is always >= 0x80,
+          # so a byte scan can never match inside a multi-byte char.
           lo = floor
-          BOUNDS.each do |c|
-            r = pre.rindex(c)
-            lo = floor + r + 1 if r && floor + r + 1 > lo
+          i = from - 1
+          while i >= floor
+            if BOUNDS.includes?(bytes[i])
+              lo = i + 1
+              break
+            end
+            i -= 1
           end
           # Statement end: the FIRST boundary after the sink (else the window ceiling).
-          post = code[to...ceil]
           hi = ceil
-          BOUNDS.each do |c|
-            r = post.index(c)
-            hi = to + r if r && to + r < hi
+          j = to
+          while j < ceil
+            if BOUNDS.includes?(bytes[j])
+              hi = j
+              break
+            end
+            j += 1
           end
-          seg = code[lo...hi]
+          # A window edge can land mid-char, so scrub before handing the slice to PCRE (invalid
+          # UTF-8 makes the match raise). Bounded to ~2*WINDOW bytes, so this costs nothing.
+          seg = String.new(bytes[lo, hi - lo]).scrub
           SOURCES.each { |(re, label)| return label if re.matches?(seg) }
           nil
         end

--- a/src/gori/probe/scan.cr
+++ b/src/gori/probe/scan.cr
@@ -66,19 +66,24 @@ module Gori
       # `progress.call(i, total)` is invoked per flow so a CLI can draw a meter; MCP passes nil.
       # `active_limit` caps how many flows receive an ACTIVE probe (network volume) WITHOUT
       # limiting the request-free PASSIVE scan — nil means no active cap (the CLI).
+      # `on_error` (optional) is called once per SKIPPED item — "flow <id>" / "repeater <id>" /
+      # a rule id — with the exception that caused it. A scan that hits one keeps going and
+      # returns everything else, so the caller must report the count or a partial result reads
+      # as a clean one.
       def scan_all(store : Store, ids : Array(Int64), *, active : Bool,
                    verify_upstream : Bool = true, scope : Scope? = nil, allow_unscoped : Bool = false,
                    active_limit : Int32? = nil, opts : Active::Options = Active::Options::DEFAULT,
                    rules : RuleConfig? = nil,
-                   progress : Proc(Int32, Int32, Nil)? = nil) : {Array(Detection), Int32}
+                   progress : Proc(Int32, Int32, Nil)? = nil,
+                   on_error : Proc(String, Exception, Nil)? = nil) : {Array(Detection), Int32}
         # Read the Rules config ONCE per scan (not per flow) — same as the Analyzer, which
         # loads it at construction and only re-reads on an explicit rules reload.
         cfg = rules || RuleConfig.load(store)
         detections = scan_flows(store, ids, active: active, verify_upstream: verify_upstream,
           scope: scope, allow_unscoped: allow_unscoped, active_limit: active_limit, opts: opts,
-          rules: cfg, progress: progress)
+          rules: cfg, progress: progress, on_error: on_error)
         repeater_dets, repeater_n = scan_repeaters(store, active: active, verify_upstream: verify_upstream,
-          scope: scope, allow_unscoped: allow_unscoped, opts: opts, rules: cfg)
+          scope: scope, allow_unscoped: allow_unscoped, opts: opts, rules: cfg, on_error: on_error)
         detections.concat(repeater_dets)
         {detections, repeater_n}
       end
@@ -87,22 +92,34 @@ module Gori
                      verify_upstream : Bool = true, scope : Scope? = nil, allow_unscoped : Bool = false,
                      active_limit : Int32? = nil, opts : Active::Options = Active::Options::DEFAULT,
                      rules : RuleConfig? = nil,
-                     progress : Proc(Int32, Int32, Nil)? = nil) : Array(Detection)
+                     progress : Proc(Int32, Int32, Nil)? = nil,
+                     on_error : Proc(String, Exception, Nil)? = nil) : Array(Detection)
         cfg = rules || RuleConfig.load(store)
         outbound = outbound_for(scope, allow_unscoped)
         detections = [] of Detection
         active_sent = 0
         ids.each_with_index do |id, i|
-          detail = store.get_flow(id)
-          if detail && detail.response_head
-            ws = detail.row.status == 101 ? store.ws_messages(id, 200) : [] of Store::WsMessage
-            # passive is request-free — NEVER capped
-            detections.concat(Passive.analyze(detail, ws, disabled: cfg.disabled, custom: cfg.custom))
-            if active && outbound.allows?(detail.row.url, detail.row.host) && !(active_limit && active_sent >= active_limit)
-              detections.concat(Active.analyze(detail, verify_upstream, outbound: outbound, opts: opts,
-                disabled: cfg.disabled))
-              active_sent += 1
+          begin
+            detail = store.get_flow(id)
+            if detail && detail.response_head
+              ws = detail.row.status == 101 ? store.ws_messages(id, 200) : [] of Store::WsMessage
+              # passive is request-free — NEVER capped
+              detections.concat(Passive.analyze(detail, ws, disabled: cfg.disabled, custom: cfg.custom))
+              if active && outbound.allows?(detail.row.url, detail.row.host) && !(active_limit && active_sent >= active_limit)
+                detections.concat(Active.analyze(detail, verify_upstream, outbound: outbound, opts: opts,
+                  disabled: cfg.disabled, on_error: on_error))
+                active_sent += 1
+              end
             end
+          rescue ex : DB::Error | SQLite3::Exception
+            # The store is the substrate, not one flow's data: if it is closing or broken every
+            # remaining flow fails too, so surface it rather than looping over thousands of
+            # doomed reads. Same stance as Analyzer#scan_detail, which re-raises these too.
+            raise ex
+          rescue ex
+            # Anything else is THIS flow's problem — skip it and keep the batch (and everything
+            # already collected) alive. See the per-rule rescue in Active.analyze.
+            on_error.try &.call("flow #{id}", ex)
           end
           progress.try &.call(i, ids.size)
         end
@@ -113,7 +130,8 @@ module Gori
       def scan_repeaters(store : Store, *, active : Bool, verify_upstream : Bool = true,
                          scope : Scope? = nil, allow_unscoped : Bool = false,
                          opts : Active::Options = Active::Options::DEFAULT,
-                         rules : RuleConfig? = nil) : {Array(Detection), Int32}
+                         rules : RuleConfig? = nil,
+                         on_error : Proc(String, Exception, Nil)? = nil) : {Array(Detection), Int32}
         cfg = rules || RuleConfig.load(store)
         outbound = outbound_for(scope, allow_unscoped)
         detections = [] of Detection
@@ -121,14 +139,22 @@ module Gori
         store.repeaters.each do |rec|
           next unless detail = Probe.detail_from_repeater(rec)
           n += 1
-          ws = store.ws_messages_for_repeater(rec.id, 200)
-          Passive.analyze(detail, ws, disabled: cfg.disabled, custom: cfg.custom).each do |d|
-            detections << Probe.with_source(d, flow_id: rec.flow_id, repeater_id: rec.id)
-          end
-          if active && outbound.allows?(detail.row.url, detail.row.host)
-            Active.analyze(detail, verify_upstream, outbound: outbound, opts: opts, disabled: cfg.disabled).each do |d|
+          # Isolated per repeater tab, exactly like scan_flows isolates per flow.
+          begin
+            ws = store.ws_messages_for_repeater(rec.id, 200)
+            Passive.analyze(detail, ws, disabled: cfg.disabled, custom: cfg.custom).each do |d|
               detections << Probe.with_source(d, flow_id: rec.flow_id, repeater_id: rec.id)
             end
+            if active && outbound.allows?(detail.row.url, detail.row.host)
+              Active.analyze(detail, verify_upstream, outbound: outbound, opts: opts,
+                disabled: cfg.disabled, on_error: on_error).each do |d|
+                detections << Probe.with_source(d, flow_id: rec.flow_id, repeater_id: rec.id)
+              end
+            end
+          rescue ex : DB::Error | SQLite3::Exception
+            raise ex
+          rescue ex
+            on_error.try &.call("repeater #{rec.id}", ex)
           end
         end
         {detections, n}


### PR DESCRIPTION
A stability and performance review of the Probe rules (22 passive files / 18 registered rules, 15 active files / 14 rules) turned up three defects. Two of them are in `passive/js_scan.cr` — the largest passive file, on the hot path, and the only one there with no direct spec.

Everything below is measured, not inferred. Baseline before the change: `crystal spec` 4839 examples, 0 failures.

## 1. A single response body could take the whole process down

`JsScan`'s template-literal lexers recurse one frame per nesting level, and the depth is just response-body text. The recursion happens on the way **in**, so no closing delimiters are needed — an unterminated ``` `${ ``` costs 3 bytes per level, and `CLIENT_BODY_CAP / 3 = 87381` levels lands past the ~87k frames the fiber stack holds.

A Crystal stack overflow is a fatal signal, not a rescuable exception, so `Analyzer#scan_detail`'s per-flow `rescue` could not contain it. Reproduced through the real `Passive.analyze` path:

```
body 262173 B (cap 262144) => ~87381 nesting levels after truncation
Stack overflow (e.g., infinite or very deep recursion)
  ... JsScan::blank_token_at (87193 times)
  ... Context#client_code
  ... Passive::analyze
```

The body cap was never a defense here; it sits on the wrong side of the limit. The lexers now cap nesting themselves and blank the rest of the fragment (offset-preserving, and unable to desync the way "stop descending in place" would).

**Margin note for reviewers:** 87,381 reachable vs 87,193 frames is a 0.2% margin, measured on arm64 macOS / Crystal 1.21.0 / release / 8 MiB fiber stack. A different platform or frame size may well land on the "survives" side — one non-reproduction is not evidence the bug isn't there, and the depth cap is correct either way.

## 2. One non-ASCII byte stalled the passive scan by ~190x

`source_in_window` sliced by **character** index, which is O(1) only while the stripped script is all-ASCII. One non-ASCII byte makes every `String#[]` walk from the start, and it runs per sink occurrence — thousands of times in a minified bundle.

The trigger is narrower than it looks, and worse for it. `strip` blanks string and comment contents, so non-ASCII in either is gone; but regex literals are deliberately left intact, so one accented char *there* is enough:

| injected shape | stripped output | `source_sink_pairs` |
|---|---|---|
| `é` in a string literal | ASCII | 9.3 ms |
| `é` in a comment | ASCII | 9.0 ms |
| **`/[éèê]/g`** | **UTF-8** | **1765 ms** |
| **`/[—–]/`** (em-dash) | **UTF-8** | **1729 ms** |
| **`/[가-힣]+/u`** | **UTF-8** | **1724 ms** |

That is a diacritic/slug normaliser, a smart-quote replacer, a CJK range test — not hostile input, just an i18n'd bundle, stalling the fiber the passive scan shares with the proxy for 1.7 seconds.

Window arithmetic now works on byte offsets. Result on `bench/probe_passive_bench.cr`:

| | before | after |
|---|---|---|
| JS-bundle flow | 10.9 ms / **4.93 MB**/op | 8.58 ms / **1.29 MB**/op |
| non-ASCII trigger | 1765 ms | 4.2 ms |

Detections unchanged (`json=2 html=6 js=3`). The allocation drop is the three window substrings that are now gone.

## 3. A rule that raised took the whole headless scan with it

The TUI has always isolated per rule (`Analyzer#execute_active`). The headless path had no equivalent: `Active.analyze` ran RULES in a bare loop and `Scan.scan_flows`/`scan_repeaters` iterated in a bare loop above it, so one raise killed every remaining rule **and** every remaining flow — and since `scan_flows` returns its array only at the end, the findings already collected went with it. Same rules, same input, two levels of robustness depending on which surface you came in through.

Both loops now isolate. `DB::Error`/`SQLite3::Exception` is deliberately **re-raised**: the store is the substrate, not one flow's data, and `Analyzer#scan_detail` already takes that stance.

Skips are **reported**, not swallowed — an incomplete scan that prints a complete-looking summary is worse than the crash it replaces. `on_error` follows the existing `progress` proc convention (optional, nil default, no existing caller changed); the CLI prints the skip count and first reason, MCP emits `scan_errors` only when non-zero.

## Verification

- `crystal spec` **4850 examples, 0 failures**; `shards build` clean.
- New `spec/probe/passive/js_scan_spec.cr` (8 examples) — the depth guard's crash-freedom *and* its offset preservation (the load-bearing half), plus source→sink results being identical with and without a non-ASCII regex literal. **Run against the pre-fix lexer, the spec runner stack-overflows.**
- Three isolation specs in `probe_spec.cr` driven by a raising backend, including "a *later* rule still produces its finding after an earlier one dies" — the actual promise, not just "does not crash". Removing the rescue makes them error.
- Bench gains a `JS_I18N_BODY` fixture, since #2 is a performance defect a spec cannot pin.
- `ameba` reports 11 findings on the touched files — **identical to `main`**, none introduced here.

## Not addressed

Found in the same review, deliberately left out of this PR:

- **Active worker head-of-line blocking.** One worker fiber, 10s timeout, follow-ups sent sequentially. Measured with `dedup_key`: a 403 GET with 4 query params matches 7 rules / up to 24 requests, so one blackholing host locks the only worker for ~240s while `ACTIVE_QUEUE` silently drops everything else. Needs a design call (more workers vs. a per-host circuit breaker).
- `backslash_powered`'s `requests_per_flow` ignores `opts`, so the Rules sub-tab label reads "4–8 req/flow" while AGGRESSIVE sends up to 22. The confirm popup is unaffected (it never passes `aggressive`).
- `post_message.cr:69` has the same char-index slicing as #2, bounded by listener count.
- The probe benches are not wired into `just benchmark`.
- `cacheable_api` and `jwt_in_ws` have no spec coverage.