### PR TITLE
fix(cli): three silent-no-op defects in the headless surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ canonical; parsed columns and pretty views are derived projections.
   keeps the octets rather than rejecting. `serialize_head` is the identity function.
 - **The axis is provenance, not byte values.** The same octet gets three different answers:
   - **operator bytes** (imported HAR, an MCP `raw` request, a replay) go out verbatim, never
-    sanitized. See the comment at `src/gori/import/builder.cr:30-37` and
+    sanitized. See the comment at `src/gori/import/builder.cr:31-38` and
     `src/gori/mcp/request_builder.cr` (`normalize_raw`).
   - **page-authored bytes** (a crawled `<a href>`) get percent-encoded where they merely
     break, and refused where they *frame*. See `src/gori/discover/url.cr` (`encode_unsafe`).

--- a/spec/cli_run_spec.cr
+++ b/spec/cli_run_spec.cr
@@ -254,6 +254,31 @@ describe "gori run probe --active" do
   end
 end
 
+# The guard behind `unknown subcommand` on the verb-dispatching subcommands. `issues`/`links`
+# used to end their `case` with `else <the read command>`, so an unrecognized verb silently
+# LISTED and exited 0: `gori run issues remove 1` deleted nothing and reported success. The
+# dispatch itself calls `abort`, so the classification is spec'd here and the messages are
+# covered by the subcommand help.
+describe "Gori::CLI::Run.verb_token?" do
+  it "is true for a bare word — a verb the case must recognize or reject" do
+    Gori::CLI::Run.verb_token?("remove").should be_true
+    Gori::CLI::Run.verb_token?("delet").should be_true # a typo is still a verb token
+    Gori::CLI::Run.verb_token?("severity:high").should be_true
+  end
+
+  it "is false for a flag, which means the default read command" do
+    # `gori run issues --project x` and `gori run links --owner note --id 2` still list.
+    Gori::CLI::Run.verb_token?("--project").should be_false
+    Gori::CLI::Run.verb_token?("-h").should be_false
+    Gori::CLI::Run.verb_token?("--format=json").should be_false
+  end
+
+  it "is false when there is no first token at all" do
+    Gori::CLI::Run.verb_token?(nil).should be_false
+    Gori::CLI::Run.verb_token?("").should be_false
+  end
+end
+
 # #410: `gori run fuzz` dropped every errored send from all output formats (the CLI showed only
 # matches), so a headless run that 100%-failed looked identical to one that cleanly matched
 # nothing. `emit_fuzz_result` now emits an errored row too — proven here via a whitebox wrapper.

--- a/spec/cli_run_spec.cr
+++ b/spec/cli_run_spec.cr
@@ -259,23 +259,29 @@ end
 # LISTED and exited 0: `gori run issues remove 1` deleted nothing and reported success. The
 # dispatch itself calls `abort`, so the classification is spec'd here and the messages are
 # covered by the subcommand help.
+module Gori::CLI::Run
+  def self.verb_token_for_spec(sub : String?) : Bool
+    verb_token?(sub)
+  end
+end
+
 describe "Gori::CLI::Run.verb_token?" do
   it "is true for a bare word — a verb the case must recognize or reject" do
-    Gori::CLI::Run.verb_token?("remove").should be_true
-    Gori::CLI::Run.verb_token?("delet").should be_true # a typo is still a verb token
-    Gori::CLI::Run.verb_token?("severity:high").should be_true
+    Gori::CLI::Run.verb_token_for_spec("remove").should be_true
+    Gori::CLI::Run.verb_token_for_spec("delet").should be_true # a typo is still a verb token
+    Gori::CLI::Run.verb_token_for_spec("severity:high").should be_true
   end
 
   it "is false for a flag, which means the default read command" do
     # `gori run issues --project x` and `gori run links --owner note --id 2` still list.
-    Gori::CLI::Run.verb_token?("--project").should be_false
-    Gori::CLI::Run.verb_token?("-h").should be_false
-    Gori::CLI::Run.verb_token?("--format=json").should be_false
+    Gori::CLI::Run.verb_token_for_spec("--project").should be_false
+    Gori::CLI::Run.verb_token_for_spec("-h").should be_false
+    Gori::CLI::Run.verb_token_for_spec("--format=json").should be_false
   end
 
   it "is false when there is no first token at all" do
-    Gori::CLI::Run.verb_token?(nil).should be_false
-    Gori::CLI::Run.verb_token?("").should be_false
+    Gori::CLI::Run.verb_token_for_spec(nil).should be_false
+    Gori::CLI::Run.verb_token_for_spec("").should be_false
   end
 end
 

--- a/spec/cli_spec.cr
+++ b/spec/cli_spec.cr
@@ -1,0 +1,68 @@
+require "./spec_helper"
+
+# Top-level `gori` dispatch (src/gori/cli.cr). Only the pure argv helpers are exercised
+# here — CLI.run itself starts a TUI / server or calls `exit`, so it is not spec-callable.
+#
+# `global_version_flag?` is private; expose it the way the other CLI specs expose theirs
+# (spec/cli/run/links_spec.cr does the same for resolve_link_ends / parse_link_id).
+module Gori::CLI
+  def self.global_version_flag_for_spec(argv : Array(String)) : Bool
+    global_version_flag?(argv)
+  end
+end
+
+describe "gori — global version flag" do
+  it "claims a version flag standing alone" do
+    Gori::CLI.global_version_flag_for_spec(["-v"]).should be_true
+    Gori::CLI.global_version_flag_for_spec(["-V"]).should be_true
+    Gori::CLI.global_version_flag_for_spec(["--version"]).should be_true
+  end
+
+  it "claims a version flag against a TOP-LEVEL subcommand" do
+    # print_main_help promises version/help work "at the top level too", and one non-flag
+    # token — the top-level subcommand — is still the top level.
+    Gori::CLI.global_version_flag_for_spec(["run", "-v"]).should be_true
+    Gori::CLI.global_version_flag_for_spec(["run", "--version"]).should be_true
+    Gori::CLI.global_version_flag_for_spec(["mcp", "-V"]).should be_true
+    # CLI.run strips `--config PATH` before asking, so the PATH never counts against the
+    # one-non-flag-token budget — `gori --config x.json tui -v` arrives here as ["tui", "-v"].
+    Gori::CLI.global_version_flag_for_spec(["tui", "-v"]).should be_true
+  end
+
+  # The regression this helper exists for: a bare `-v` ANYWHERE in argv used to print the
+  # version and return 0 without running the command — a silent no-op with a SUCCESS status.
+  it "leaves a NESTED subcommand's own -v alone" do
+    # rewriter add / preview document `-vVALUE, --value=VALUE`; this used to create no rule
+    # and still exit 0.
+    Gori::CLI.global_version_flag_for_spec(
+      ["run", "rewriter", "add", "--op", "set_header", "--find", "X", "-v", "boom"]).should be_false
+    Gori::CLI.global_version_flag_for_spec(
+      ["run", "rewriter", "preview", "-v", "x"]).should be_false
+  end
+
+  it "leaves a nested option VALUE that happens to be a version flag alone" do
+    # These sent zero requests / encoded nothing, and reported success.
+    Gori::CLI.global_version_flag_for_spec(
+      ["run", "decoder", "base64-encode", "--input", "-v"]).should be_false
+    Gori::CLI.global_version_flag_for_spec(
+      ["run", "fuzz", "--payloads", "-v"]).should be_false
+    Gori::CLI.global_version_flag_for_spec(
+      ["run", "fuzz", "--payloads", "--version"]).should be_false
+    Gori::CLI.global_version_flag_for_spec(
+      ["run", "history", "--query", "-V"]).should be_false
+  end
+
+  it "does not claim a version flag once any second non-flag token has appeared" do
+    Gori::CLI.global_version_flag_for_spec(["run", "capture", "-v"]).should be_false
+    Gori::CLI.global_version_flag_for_spec(["run", "show", "1", "--version"]).should be_false
+  end
+
+  it "is false when there is no version flag at all" do
+    Gori::CLI.global_version_flag_for_spec([] of String).should be_false
+    Gori::CLI.global_version_flag_for_spec(["run", "history"]).should be_false
+    # A near-miss must not match: only the exact tokens count.
+    Gori::CLI.global_version_flag_for_spec(["--verbose"]).should be_false
+    Gori::CLI.global_version_flag_for_spec(["-vv"]).should be_false
+    Gori::CLI.global_version_flag_for_spec(["run", "decoder", "--input", "-vsomething"]).should be_false
+  end
+end

--- a/spec/cli_spec.cr
+++ b/spec/cli_spec.cr
@@ -6,8 +6,11 @@ require "./spec_helper"
 # `global_version_flag?` is private; expose it the way the other CLI specs expose theirs
 # (spec/cli/run/links_spec.cr does the same for resolve_link_ends / parse_link_id).
 module Gori::CLI
+  # Mirrors what CLI.run does: split off the top-level subcommand, then ask about the tail. Kept
+  # at full-argv granularity so these cases read as real command lines.
   def self.global_version_flag_for_spec(argv : Array(String)) : Bool
-    global_version_flag?(argv)
+    _, subargs = split_subcommand(argv)
+    global_version_flag?(subargs)
   end
 end
 
@@ -52,9 +55,17 @@ describe "gori — global version flag" do
       ["run", "history", "--query", "-V"]).should be_false
   end
 
-  it "does not claim a version flag once any second non-flag token has appeared" do
+  it "does not claim a version flag once a nested subcommand has been named" do
     Gori::CLI.global_version_flag_for_spec(["run", "capture", "-v"]).should be_false
     Gori::CLI.global_version_flag_for_spec(["run", "show", "1", "--version"]).should be_false
+  end
+
+  # Keying on the FIRST token of the tail rules a flag's own value out structurally: a
+  # value-taking flag always precedes its value, so a value can never sit at position 0.
+  it "leaves a top-level subcommand flag's own value alone" do
+    Gori::CLI.global_version_flag_for_spec(["run", "--project", "-v"]).should be_false
+    Gori::CLI.global_version_flag_for_spec(["tui", "--db", "-v"]).should be_false
+    Gori::CLI.global_version_flag_for_spec(["mcp", "--project", "--version"]).should be_false
   end
 
   it "is false when there is no version flag at all" do

--- a/spec/import/import_spec.cr
+++ b/spec/import/import_spec.cr
@@ -782,8 +782,11 @@ describe Gori::Import do
         row = store.search(Gori::QL::EMPTY, 1).first
         row.host.should eq("::1") # not "[::1]"
         row.port.should eq(9443)
-        # the Host header line stays RFC 7230 bracketed even though the stored host is bare
-        String.new(store.get_flow(row.id).not_nil!.request_head).should contain("Host: [::1]")
+        # The Host line stays RFC 7230 §5.4 bracketed even though the stored host is bare — AND
+        # carries the non-default port. Asserted as a whole line: `contain("Host: [::1]")` also
+        # passed while the port was being dropped, which is how that went unnoticed.
+        String.new(store.get_flow(row.id).not_nil!.request_head)
+          .should contain("Host: [::1]:9443\r\n")
       end
     ensure
       File.delete?(urls)
@@ -796,7 +799,7 @@ describe Gori::Import::Builder do
     headers = Gori::Import::Builder::Headers.new
     headers << {"X-Foo", "bar\r\nX-Injected: evil"}
     expect_raises(Gori::Error, /control character/) do
-      Gori::Import::Builder.request_head("GET", "/", "HTTP/1.1", "h.test", headers, nil)
+      Gori::Import::Builder.request_head("GET", "/", "HTTP/1.1", "http", "h.test", 80, headers, nil)
     end
   end
 
@@ -811,7 +814,7 @@ describe Gori::Import::Builder do
   it "rejects a method / reason phrase containing CR/LF (start-line smuggling guard)" do
     empty = Gori::Import::Builder::Headers.new
     expect_raises(Gori::Error, /control character/) do
-      Gori::Import::Builder.request_head("GET\r\nHost: evil", "/", "HTTP/1.1", "h.test", empty, nil)
+      Gori::Import::Builder.request_head("GET\r\nHost: evil", "/", "HTTP/1.1", "http", "h.test", 80, empty, nil)
     end
     expect_raises(Gori::Error, /control character/) do
       Gori::Import::Builder.response_head("HTTP/1.1", 200, "OK\r\nX-Injected: evil", empty, nil)
@@ -821,7 +824,7 @@ describe Gori::Import::Builder do
   it "allows a horizontal tab in a header value (a legal field-value byte, not a boundary)" do
     headers = Gori::Import::Builder::Headers.new
     headers << {"X-Foo", "a\tb"}
-    head = String.new(Gori::Import::Builder.request_head("GET", "/", "HTTP/1.1", "h.test", headers, nil))
+    head = String.new(Gori::Import::Builder.request_head("GET", "/", "HTTP/1.1", "http", "h.test", 80, headers, nil))
     head.should contain("X-Foo: a\tb")
   end
 
@@ -835,6 +838,63 @@ describe Gori::Import::Builder do
     pair = Gori::Import::Builder.pending_request(0_i64, "https://[::1]:9443/probe")
     pair.request.host.should eq("::1") # bare, matching the CONNECT path
     pair.request.port.should eq(9443)
-    String.new(pair.request.head).should contain("Host: [::1]") # RFC 7230 §5.4 valid
+    # RFC 7230 §5.4 valid means BOTH halves: brackets around the literal, and the non-default
+    # port present. The old assertion stopped at `contain("Host: [::1]")`, which held while the
+    # port was silently dropped.
+    String.new(pair.request.head).should contain("Host: [::1]:9443\r\n")
+  end
+
+  # RFC 7230 §5.4 requires the port in Host whenever it is not the scheme's default. It was
+  # being dropped for every reg-name/IPv4 import, because the line was synthesized from
+  # `uri.host` — which never carries a port — while the operator's own Host header was skipped.
+  # The stored head is replayed verbatim, so the wrong Host reached the origin too.
+  describe "the Host header line" do
+    it "carries a non-default port" do
+      pair = Gori::Import::Builder.pending_request(0_i64, "http://127.0.0.1:8099/login")
+      pair.request.port.should eq(8099)
+      String.new(pair.request.head).should contain("Host: 127.0.0.1:8099\r\n")
+    end
+
+    it "omits the port when it is the scheme default" do
+      String.new(Gori::Import::Builder.pending_request(0_i64, "http://example.com/p").request.head)
+        .should contain("Host: example.com\r\n")
+      String.new(Gori::Import::Builder.pending_request(0_i64, "https://example.com/p").request.head)
+        .should contain("Host: example.com\r\n")
+    end
+
+    it "keeps a port that merely looks default for the OTHER scheme" do
+      # http://h:443 and https://h:80 are both non-default for their own scheme.
+      String.new(Gori::Import::Builder.pending_request(0_i64, "http://example.com:443/p").request.head)
+        .should contain("Host: example.com:443\r\n")
+      String.new(Gori::Import::Builder.pending_request(0_i64, "https://example.com:80/p").request.head)
+        .should contain("Host: example.com:80\r\n")
+    end
+
+    it "distinguishes two imports that differ only by port" do
+      # These used to produce an identical Host line, making them indistinguishable by Host.
+      a = String.new(Gori::Import::Builder.pending_request(0_i64, "http://127.0.0.1:8099/x").request.head)
+      b = String.new(Gori::Import::Builder.pending_request(0_i64, "http://127.0.0.1/x").request.head)
+      a.should contain("Host: 127.0.0.1:8099\r\n")
+      b.should contain("Host: 127.0.0.1\r\n")
+      a.should_not eq(b)
+    end
+
+    it "applies to a complete_flow import (HAR) as well as a pending one" do
+      # The HAR's own `Host: 127.0.0.1:8099` is skipped and the line re-synthesized; it must
+      # come back out identical rather than losing the port.
+      req_headers = [{"Host", "127.0.0.1:8099"}] of {String, String}
+      pair = Gori::Import::Builder.complete_flow(
+        0_i64, "http://127.0.0.1:8099/login", "POST", req_headers,
+        nil, "HTTP/1.1", 200, "OK", Gori::Import::Builder::Headers.new, nil, nil, nil)
+      String.new(pair.request.head).should contain("Host: 127.0.0.1:8099\r\n")
+    end
+
+    it "builds the value directly, including the IPv6 + default-port corners" do
+      Gori::Import::Builder.host_header("http", "example.com", 80).should eq("example.com")
+      Gori::Import::Builder.host_header("https", "example.com", 443).should eq("example.com")
+      Gori::Import::Builder.host_header("http", "example.com", 8080).should eq("example.com:8080")
+      Gori::Import::Builder.host_header("https", "::1", 443).should eq("[::1]")
+      Gori::Import::Builder.host_header("https", "::1", 9443).should eq("[::1]:9443")
+    end
   end
 end

--- a/spec/import/import_spec.cr
+++ b/spec/import/import_spec.cr
@@ -799,7 +799,7 @@ describe Gori::Import::Builder do
     headers = Gori::Import::Builder::Headers.new
     headers << {"X-Foo", "bar\r\nX-Injected: evil"}
     expect_raises(Gori::Error, /control character/) do
-      Gori::Import::Builder.request_head("GET", "/", "HTTP/1.1", "http", "h.test", 80, headers, nil)
+      Gori::Import::Builder.request_head("GET", "/", "HTTP/1.1", scheme: "http", host: "h.test", port: 80, headers: headers, body: nil)
     end
   end
 
@@ -814,7 +814,7 @@ describe Gori::Import::Builder do
   it "rejects a method / reason phrase containing CR/LF (start-line smuggling guard)" do
     empty = Gori::Import::Builder::Headers.new
     expect_raises(Gori::Error, /control character/) do
-      Gori::Import::Builder.request_head("GET\r\nHost: evil", "/", "HTTP/1.1", "http", "h.test", 80, empty, nil)
+      Gori::Import::Builder.request_head("GET\r\nHost: evil", "/", "HTTP/1.1", scheme: "http", host: "h.test", port: 80, headers: empty, body: nil)
     end
     expect_raises(Gori::Error, /control character/) do
       Gori::Import::Builder.response_head("HTTP/1.1", 200, "OK\r\nX-Injected: evil", empty, nil)
@@ -824,7 +824,7 @@ describe Gori::Import::Builder do
   it "allows a horizontal tab in a header value (a legal field-value byte, not a boundary)" do
     headers = Gori::Import::Builder::Headers.new
     headers << {"X-Foo", "a\tb"}
-    head = String.new(Gori::Import::Builder.request_head("GET", "/", "HTTP/1.1", "http", "h.test", 80, headers, nil))
+    head = String.new(Gori::Import::Builder.request_head("GET", "/", "HTTP/1.1", scheme: "http", host: "h.test", port: 80, headers: headers, body: nil))
     head.should contain("X-Foo: a\tb")
   end
 

--- a/spec/repeater/import_replay_wire_spec.cr
+++ b/spec/repeater/import_replay_wire_spec.cr
@@ -40,7 +40,7 @@ describe "import → repeater wire fidelity (#400, P7)" do
     # in the PATH, so the host stayed a real host and the entry was NOT skipped.
     target = "/path\r\nX-Injected: pwn\r\n\r\nGET /second HTTP/1.1"
     head = Gori::Import::Builder.request_head(
-      "GET", target, "HTTP/1.1", "evil.test", Gori::Import::Builder::Headers.new, nil)
+      "GET", target, "HTTP/1.1", "http", "evil.test", 80, Gori::Import::Builder::Headers.new, nil)
 
     # The send-layer guard's OWN verdict on these bytes is "unsafe" — it would refuse to
     # SYNTHESIZE a request line out of them. That it fires here and the replay below still sends
@@ -85,7 +85,7 @@ describe "import → repeater wire fidelity (#400, P7)" do
     # request line, replayed as-is. Confirming it on the wire, not just in a reconstruct string.
     target = "/a b?x=1 2"
     head = Gori::Import::Builder.request_head(
-      "GET", target, "HTTP/1.1", "evil.test", Gori::Import::Builder::Headers.new, nil)
+      "GET", target, "HTTP/1.1", "http", "evil.test", 80, Gori::Import::Builder::Headers.new, nil)
 
     server = TCPServer.new("127.0.0.1", 0)
     port = server.local_address.port

--- a/spec/repeater/import_replay_wire_spec.cr
+++ b/spec/repeater/import_replay_wire_spec.cr
@@ -40,7 +40,8 @@ describe "import → repeater wire fidelity (#400, P7)" do
     # in the PATH, so the host stayed a real host and the entry was NOT skipped.
     target = "/path\r\nX-Injected: pwn\r\n\r\nGET /second HTTP/1.1"
     head = Gori::Import::Builder.request_head(
-      "GET", target, "HTTP/1.1", "http", "evil.test", 80, Gori::Import::Builder::Headers.new, nil)
+      "GET", target, "HTTP/1.1", scheme: "http", host: "evil.test", port: 80,
+      headers: Gori::Import::Builder::Headers.new, body: nil)
 
     # The send-layer guard's OWN verdict on these bytes is "unsafe" — it would refuse to
     # SYNTHESIZE a request line out of them. That it fires here and the replay below still sends
@@ -85,7 +86,8 @@ describe "import → repeater wire fidelity (#400, P7)" do
     # request line, replayed as-is. Confirming it on the wire, not just in a reconstruct string.
     target = "/a b?x=1 2"
     head = Gori::Import::Builder.request_head(
-      "GET", target, "HTTP/1.1", "http", "evil.test", 80, Gori::Import::Builder::Headers.new, nil)
+      "GET", target, "HTTP/1.1", scheme: "http", host: "evil.test", port: 80,
+      headers: Gori::Import::Builder::Headers.new, body: nil)
 
     server = TCPServer.new("127.0.0.1", 0)
     port = server.local_address.port

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -30,24 +30,22 @@ module Gori
       # otherwise reject it through invalid_option.
       argv = extract_config_flag(argv)
 
-      # Global version (works alone, or against a top-level subcommand). Deliberately AFTER the
-      # --config strip: that is the one top-level flag taking a value, and its PATH must not
-      # count against the one-non-flag-token budget below (`gori --config x.json tui -v`).
-      if global_version_flag?(argv)
+      # Split once: the version rule, the top-level help, and the dispatch all key off it.
+      sub, subargs = split_subcommand(argv)
+
+      # Global version (alone, or against a top-level subcommand) — see global_version_flag?.
+      if global_version_flag?(subargs)
         puts "gori #{VERSION}"
         return
       end
 
       # Top-level help when no explicit subcommand is given
-      has_explicit_sub = !argv.empty? && !argv[0].starts_with?("-")
-      if argv.any? { |a| a == "-h" || a == "--help" } && !has_explicit_sub
+      if argv.any? { |a| a == "-h" || a == "--help" } && sub.nil?
         print_main_help
         return
       end
 
-      # Subcommand detection (first non-flag arg, else default to tui for bare `gori`)
-      subcmd = has_explicit_sub ? argv[0] : "tui"
-      subargs = has_explicit_sub ? argv[1..] : argv
+      subcmd = sub || "tui" # bare `gori` (or leading flags only) starts the TUI
 
       case subcmd
       when "tui"
@@ -81,36 +79,35 @@ module Gori
       abort "gori: #{ex.message.presence || ex.class}"
     end
 
-    VERSION_FLAGS = {"-v", "-V", "--version"}
+    private VERSION_FLAGS = {"-v", "-V", "--version"}
+
+    # The top-level subcommand and the arguments belonging to it. A leading flag — or an empty
+    # argv — means none was named, so every token belongs to the default surface (the TUI).
+    # Split once, because three rules key off it: the version flag, the top-level `-h`, and the
+    # dispatch itself.
+    private def self.split_subcommand(argv : Array(String)) : {String?, Array(String)}
+      return {nil, argv} if argv.empty? || argv[0].starts_with?("-")
+      {argv[0], argv[1..]}
+    end
 
     # A version flag belongs to the TOP LEVEL — `gori -v`, `gori --version`, `gori run -v` —
     # which is exactly what print_main_help promises ("Flags like --version and --help work at
-    # the top level too").
+    # the top level too"), and exactly the FIRST token of the subcommand's own args.
     #
-    # It is NOT global once a NESTED subcommand has been named, because there the same token is
-    # that command's own option, or worse its option VALUE. A blanket `argv.any?` claimed all of
-    # them, so `gori run rewriter add --find X -v boom` (rewriter's own documented `-vVALUE`)
-    # and `gori run decoder base64-encode --input -v` printed the version and returned 0
-    # WITHOUT doing the work — a silent no-op carrying a SUCCESS status, the worst failure mode
-    # there is for a surface scripts consume (`… || die` never fires). So stop at the second
-    # non-flag token: at most the top-level subcommand (`run`, `mcp`, `tui`, …) may precede a
-    # global version flag. This mirrors the `-h`/`--help` rule just below, which is narrower
-    # still (`!has_explicit_sub`) because every subcommand's own parser owns `-h`.
+    # It must not be claimed once a NESTED subcommand has been named, because there the same
+    # token is that command's own option, or worse its option VALUE. A blanket `argv.any?`
+    # claimed all of them, so `gori run rewriter add --find X -v boom` (rewriter's own
+    # documented `-vVALUE`) and `gori run decoder base64-encode --input -v` printed the version
+    # and returned 0 WITHOUT doing the work — a silent no-op carrying a SUCCESS status, the
+    # worst failure mode there is for a surface scripts consume (`… || die` never fires).
     #
-    # KNOWN RESIDUAL: a value that is literally `-v` given to a flag of the top-level
-    # subcommand itself (`gori run --project -v`) is still read as the flag, because deciding
-    # otherwise needs to know which flags take values, and that lives in each subcommand's
-    # OptionParser — not built yet at this layer. `--config`'s own PATH is exempt because the
-    # caller strips it before asking. Every nested case, the ones that actually bit, is covered.
-    private def self.global_version_flag?(argv : Array(String)) : Bool
-      non_flags = 0
-      argv.each do |arg|
-        return true if VERSION_FLAGS.includes?(arg)
-        next if arg.starts_with?("-")
-        non_flags += 1
-        break if non_flags > 1
-      end
-      false
+    # Keying on the first token excludes those STRUCTURALLY rather than by counting them: a
+    # value-taking flag always sits ahead of its own value, so a VALUE can never be at position
+    # 0. That covers `gori run --project -v` too, which no positional scan could — deciding it
+    # by inspection would need to know which flags take values, and that lives in each
+    # subcommand's OptionParser, which does not exist yet at this layer.
+    private def self.global_version_flag?(subargs : Array(String)) : Bool
+      (first = subargs.first?) ? VERSION_FLAGS.includes?(first) : false
     end
 
     # Pull `--config PATH` / `--config=PATH` out of argv, point Settings at it, and return the

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -23,18 +23,20 @@ module Gori
   # - `gori update`                 → channel-aware self-update (binary / brew / snap / AUR)
   module CLI
     def self.run(argv : Array(String) = ARGV) : Nil
-      # Global version (works before/after any subcommand or alone)
-      if argv.any? { |a| a == "-v" || a == "-V" || a == "--version" }
-        puts "gori #{VERSION}"
-        return
-      end
-
       # `--config PATH` is consumed HERE, before subcommand detection, rather than being added
       # to each subcommand's OptionParser. It must apply to every surface (tui, run, mcp,
       # settings) and take effect before anything reads Settings, so one central strip is both
       # simpler and impossible to forget on a new subcommand — and every parser below would
       # otherwise reject it through invalid_option.
       argv = extract_config_flag(argv)
+
+      # Global version (works alone, or against a top-level subcommand). Deliberately AFTER the
+      # --config strip: that is the one top-level flag taking a value, and its PATH must not
+      # count against the one-non-flag-token budget below (`gori --config x.json tui -v`).
+      if global_version_flag?(argv)
+        puts "gori #{VERSION}"
+        return
+      end
 
       # Top-level help when no explicit subcommand is given
       has_explicit_sub = !argv.empty? && !argv[0].starts_with?("-")
@@ -77,6 +79,38 @@ module Gori
       # file, both landed that way. Deliberately narrow — an IO error, a nil, anything gori
       # did not anticipate still backtraces, because those are bugs and want a trace.
       abort "gori: #{ex.message.presence || ex.class}"
+    end
+
+    VERSION_FLAGS = {"-v", "-V", "--version"}
+
+    # A version flag belongs to the TOP LEVEL — `gori -v`, `gori --version`, `gori run -v` —
+    # which is exactly what print_main_help promises ("Flags like --version and --help work at
+    # the top level too").
+    #
+    # It is NOT global once a NESTED subcommand has been named, because there the same token is
+    # that command's own option, or worse its option VALUE. A blanket `argv.any?` claimed all of
+    # them, so `gori run rewriter add --find X -v boom` (rewriter's own documented `-vVALUE`)
+    # and `gori run decoder base64-encode --input -v` printed the version and returned 0
+    # WITHOUT doing the work — a silent no-op carrying a SUCCESS status, the worst failure mode
+    # there is for a surface scripts consume (`… || die` never fires). So stop at the second
+    # non-flag token: at most the top-level subcommand (`run`, `mcp`, `tui`, …) may precede a
+    # global version flag. This mirrors the `-h`/`--help` rule just below, which is narrower
+    # still (`!has_explicit_sub`) because every subcommand's own parser owns `-h`.
+    #
+    # KNOWN RESIDUAL: a value that is literally `-v` given to a flag of the top-level
+    # subcommand itself (`gori run --project -v`) is still read as the flag, because deciding
+    # otherwise needs to know which flags take values, and that lives in each subcommand's
+    # OptionParser — not built yet at this layer. `--config`'s own PATH is exempt because the
+    # caller strips it before asking. Every nested case, the ones that actually bit, is covered.
+    private def self.global_version_flag?(argv : Array(String)) : Bool
+      non_flags = 0
+      argv.each do |arg|
+        return true if VERSION_FLAGS.includes?(arg)
+        next if arg.starts_with?("-")
+        non_flags += 1
+        break if non_flags > 1
+      end
+      false
     end
 
     # Pull `--config PATH` / `--config=PATH` out of argv, point Settings at it, and return the

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -205,9 +205,16 @@ module Gori
       # rejects a verb it does not know, while a leading flag (`--project x`, meaning "list")
       # and an empty argv still fall through to the read command.
       #
-      # One home for the predicate: any subcommand growing verbs should call this rather than
-      # re-derive the `starts_with?("-")` test next to its own `case`.
-      def self.verb_token?(sub : String?) : Bool
+      # Only applicable to the verb-ONLY subcommands. The ones taking a bare positional —
+      # `history`/`probe`/`sitemap` (a QL query), `notes` (`<n>`), `decoder` (a chain),
+      # `repeater`/`show`/`fuzz` (an id) — legitimately receive a non-flag first token as DATA,
+      # and reject a bad verb downstream when validating it.
+      #
+      # `rewriter`, `project` and `intercept` still hand-roll this same `starts_with?('-')` test
+      # beside their own `case` (7 sites). Routing them through here is worth doing, but it
+      # changes how they treat an empty-string token, so it wants its own change rather than
+      # riding along with a bug fix.
+      private def self.verb_token?(sub : String?) : Bool
         !sub.nil? && !sub.empty? && !sub.starts_with?("-")
       end
 

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -162,9 +162,9 @@ module Gori
         {"probe delete", "Hard-delete a finding (or --all)"},
         {"probe rules", "List/enable/disable scan rules; add or delete custom ones"},
         {"probe mode", "Get/set the scan mode (off, passive, active, aggressive)"},
-        {"notes [<n>]", "Read or write the project's notes (list, show, --all, create, delete)"},
+        {"notes [<n>]", "Read or write the project's notes (list, <n>, --all, create, delete)"},
         {"issues", "List, export, create, update, or delete issues (text, json, markdown)"},
-        {"links", "List/add/remove an issue's or note's evidence links"},
+        {"links", "List/add/delete an issue's or note's evidence links"},
         {"jwt [<token>]", "Decode, re-sign, or generate testing payloads for a JWT"},
         {"decoder <chain>", "Encode/decode/hash via the Decoder engine (base64, hex, url, gzip …)"},
         {"rewriter", "Manage Match & Replace rules (list, add, rm, enable/disable, preview)"},
@@ -194,6 +194,22 @@ module Gori
       end
 
       # --- shared helpers ----------------------------------------------------
+
+      # Is a subcommand's first token a VERB, as opposed to a flag or nothing at all?
+      #
+      # A `case args.first?` that ends in `else <the read command>` treats an unrecognized verb
+      # as the default read, which is how `gori run issues remove 1` printed the issue list and
+      # exited 0 having deleted nothing, and how `gori run links remove …` listed instead of
+      # unlinking. Both are mutations that silently no-op with a SUCCESS status — the worst
+      # failure mode for a surface scripts consume. So the `else` branch asks this first and
+      # rejects a verb it does not know, while a leading flag (`--project x`, meaning "list")
+      # and an empty argv still fall through to the read command.
+      #
+      # One home for the predicate: any subcommand growing verbs should call this rather than
+      # re-derive the `starts_with?("-")` test next to its own `case`.
+      def self.verb_token?(sub : String?) : Bool
+        !sub.nil? && !sub.empty? && !sub.starts_with?("-")
+      end
 
       # --db wins → else --project resolved via ProjectRegistry#find (exact short id
       # → exact dir slug → exact display name → unique id-prefix, all

--- a/src/gori/cli/run/issues.cr
+++ b/src/gori/cli/run/issues.cr
@@ -6,11 +6,24 @@ module Gori
       # `case` can grow without pushing the (already large) list command over the
       # cyclomatic-complexity bar.
       private def self.cmd_issues(args : Array(String)) : Nil
-        case args.first?
+        case sub = args.first?
         when "create"       then cmd_issues_create(args[1..])
         when "update"       then cmd_issues_update(args[1..])
         when "delete", "rm" then cmd_issues_delete(args[1..])
-        else                     cmd_issues_list(args)
+        when "list"         then cmd_issues_list(args[1..])
+        else
+          # A non-flag first token is a VERB. An unrecognized one used to fall through to the
+          # list, so `issues remove 1` (the wrong-but-obvious synonym for `delete`) or a
+          # one-letter typo of it printed the issue list and exited 0 having deleted nothing —
+          # a mutation that silently no-ops with a SUCCESS status, which for a scripted surface
+          # is the worst outcome there is (`… || die` never fires). The same fallthrough also
+          # swallowed a positional query: `issues severity:high` listed EVERY issue, since only
+          # the TUI implements Issues::Filter. Reject it, the way rewriter/project/oast/intercept
+          # already reject theirs. A leading flag is not a verb and still means "list".
+          if verb_token?(sub)
+            abort "gori run issues: unknown subcommand '#{sub}' (create, update, delete, list)"
+          end
+          cmd_issues_list(args)
         end
       end
 

--- a/src/gori/cli/run/issues.cr
+++ b/src/gori/cli/run/issues.cr
@@ -12,14 +12,9 @@ module Gori
         when "delete", "rm" then cmd_issues_delete(args[1..])
         when "list"         then cmd_issues_list(args[1..])
         else
-          # A non-flag first token is a VERB. An unrecognized one used to fall through to the
-          # list, so `issues remove 1` (the wrong-but-obvious synonym for `delete`) or a
-          # one-letter typo of it printed the issue list and exited 0 having deleted nothing —
-          # a mutation that silently no-ops with a SUCCESS status, which for a scripted surface
-          # is the worst outcome there is (`… || die` never fires). The same fallthrough also
-          # swallowed a positional query: `issues severity:high` listed EVERY issue, since only
-          # the TUI implements Issues::Filter. Reject it, the way rewriter/project/oast/intercept
-          # already reject theirs. A leading flag is not a verb and still means "list".
+          # Why this guard exists at all: see `verb_token?`. Local to issues — the same
+          # fallthrough swallowed a positional query, so `issues severity:high` listed EVERY
+          # issue rather than narrowing, because only the TUI implements Issues::Filter.
           if verb_token?(sub)
             abort "gori run issues: unknown subcommand '#{sub}' (create, update, delete, list)"
           end

--- a/src/gori/cli/run/links.cr
+++ b/src/gori/cli/run/links.cr
@@ -5,11 +5,19 @@ module Gori
   module CLI
     module Run
       private def self.cmd_links(args : Array(String)) : Nil
-        case args.first?
+        case sub = args.first?
         when "add"          then cmd_links_mutate(args[1..], add: true)
         when "delete", "rm" then cmd_links_mutate(args[1..], add: false)
-        when "list", nil    then cmd_links_list(args.empty? ? args : args[1..])
-        else                     cmd_links_list(args)
+        when "list"         then cmd_links_list(args[1..])
+        else
+          # See the matching guard in cmd_issues: an unrecognized verb fell through to the list,
+          # so `links remove …` — the exact word `gori run -h` used to advertise — silently
+          # listed instead of unlinking. With a mutate-only flag present it did fail, but blamed
+          # the flag (`unknown option: --ref`) and never said `remove` is not a verb.
+          if verb_token?(sub)
+            abort "gori run links: unknown subcommand '#{sub}' (add, delete, list)"
+          end
+          cmd_links_list(args)
         end
       end
 
@@ -21,10 +29,17 @@ module Gori
         format = :text
 
         parser = OptionParser.new do |p|
+          # The mutate verbs belong in this banner: it IS `gori run links --help`, and listing
+          # only the read path left `add`/`delete` implemented but undiscoverable — the more
+          # so because the top-level table used to name a `remove` verb that does not exist.
           p.banner = "Usage: gori run links [list] --owner=issue|note --id=N\n\n" \
                      "List the evidence an issue or note points at. A pointer whose target was\n" \
                      "pruned is shown as (stale) rather than hidden, so \"no evidence\" and\n" \
-                     "\"evidence that is gone\" stay distinguishable."
+                     "\"evidence that is gone\" stay distinguishable.\n\n" \
+                     "Or run with a subcommand:\n" \
+                     "  gori run links add    --owner=issue|note --id=N --ref=KIND --ref-id=M\n" \
+                     "  gori run links delete --owner=issue|note --id=N --ref=KIND --ref-id=M\n" \
+                     "  (--ref is flow|repeater|fuzz|miner; `rm` is accepted for delete)"
           p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("--owner=KIND", "Owner kind: issue (default) | note") { |v| owner_s = v.strip.downcase }

--- a/src/gori/cli/run/links.cr
+++ b/src/gori/cli/run/links.cr
@@ -10,10 +10,10 @@ module Gori
         when "delete", "rm" then cmd_links_mutate(args[1..], add: false)
         when "list"         then cmd_links_list(args[1..])
         else
-          # See the matching guard in cmd_issues: an unrecognized verb fell through to the list,
-          # so `links remove …` — the exact word `gori run -h` used to advertise — silently
-          # listed instead of unlinking. With a mutate-only flag present it did fail, but blamed
-          # the flag (`unknown option: --ref`) and never said `remove` is not a verb.
+          # Why this guard exists at all: see `verb_token?`. Local to links — `remove` is the
+          # exact word `gori run -h` used to advertise, and it silently listed instead of
+          # unlinking; with a mutate-only flag present it did fail, but blamed the flag
+          # (`unknown option: --ref`) and never said `remove` is not a verb.
           if verb_token?(sub)
             abort "gori run links: unknown subcommand '#{sub}' (add, delete, list)"
           end
@@ -29,9 +29,6 @@ module Gori
         format = :text
 
         parser = OptionParser.new do |p|
-          # The mutate verbs belong in this banner: it IS `gori run links --help`, and listing
-          # only the read path left `add`/`delete` implemented but undiscoverable — the more
-          # so because the top-level table used to name a `remove` verb that does not exist.
           p.banner = "Usage: gori run links [list] --owner=issue|note --id=N\n\n" \
                      "List the evidence an issue or note points at. A pointer whose target was\n" \
                      "pruned is shown as (stale) rather than hidden, so \"no evidence\" and\n" \

--- a/src/gori/cli/run/notes.cr
+++ b/src/gori/cli/run/notes.cr
@@ -22,7 +22,16 @@ module Gori
         positional = [] of String
 
         parser = OptionParser.new do |p|
-          p.banner = "Usage: gori run notes [<n>] [options]\n\nList the project's notes; with <n> (1-based) print that note in full, or --all to print them all."
+          # The write verbs are listed here because this banner IS `gori run notes --help` —
+          # documenting only the read path left `notes create` / `notes delete` implemented but
+          # undiscoverable from the CLI, while the top-level table advertised them. Mirrors the
+          # shape `gori run issues --help` already uses.
+          p.banner = "Usage: gori run notes [<n>] [options]\n\n" \
+                     "List the project's notes; with <n> (1-based) print that note in full, " \
+                     "or --all to print them all.\n\n" \
+                     "Or run with a subcommand:\n" \
+                     "  gori run notes create [--text TEXT] [options]\n" \
+                     "  gori run notes delete <n> [options]"
           p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("--all", "Print every note in full instead of the one-line list") { all = true }

--- a/src/gori/cli/run/notes.cr
+++ b/src/gori/cli/run/notes.cr
@@ -22,10 +22,6 @@ module Gori
         positional = [] of String
 
         parser = OptionParser.new do |p|
-          # The write verbs are listed here because this banner IS `gori run notes --help` —
-          # documenting only the read path left `notes create` / `notes delete` implemented but
-          # undiscoverable from the CLI, while the top-level table advertised them. Mirrors the
-          # shape `gori run issues --help` already uses.
           p.banner = "Usage: gori run notes [<n>] [options]\n\n" \
                      "List the project's notes; with <n> (1-based) print that note in full, " \
                      "or --all to print them all.\n\n" \

--- a/src/gori/import/builder.cr
+++ b/src/gori/import/builder.cr
@@ -1,7 +1,7 @@
 require "uri"
 require "../store/models"
 require "../proxy/codec/body"
-require "../discover/url" # Url.default_port? — the one home for the scheme/port default rule
+require "../discover/url" # Url.default_port? — the scheme/port default predicate
 
 module Gori
   module Import
@@ -122,17 +122,26 @@ module Gori
       # The `Host` header value for a stored request, per RFC 7230 §5.4.
       #
       # Takes scheme/host/port rather than a pre-built string so a new caller CANNOT forget the
-      # port half — that is exactly how it went missing. `host` arrives bracket-free (matching
-      # the CONNECT path), so an IPv6 literal is re-bracketed here (`Host: [::1]`); a
-      # reg-name/IPv4 host never contains `:`, since userinfo and port live outside `uri.host`.
+      # port half — that is exactly how it went missing. §5.4 REQUIRES the port whenever it is
+      # not the scheme's default, and synthesizing the line from `uri.host` alone silently
+      # dropped it: `http://h:8099/p` was stored — and REPLAYED — as `Host: h`, so a
+      # name/port-routing origin saw a different request than the one imported, and two imports
+      # differing only in port became indistinguishable by Host.
       #
-      # §5.4 also REQUIRES the port whenever it is not the scheme's default, and synthesizing
-      # the line from `uri.host` alone silently dropped it: `http://h:8099/p` was stored — and
-      # REPLAYED — as `Host: h`, so a name/port-routing origin saw a different request than the
-      # one imported, and two imports differing only in port became indistinguishable by Host.
-      # `default_port?` is reused rather than re-derived; it already has one home.
+      # An IPv6 literal must be bracketed (`Host: [::1]`); a reg-name/IPv4 host never contains
+      # `:`, since userinfo and port live outside `uri.host`. `endpoint` hands us a bracket-free
+      # host (matching the CONNECT path), but the `starts_with?('[')` guard is kept anyway so an
+      # already-bracketed host cannot double-bracket to `[[::1]]` — the same guard every sibling
+      # carries (`store/models.cr:107`, `repeater/h2_engine.cr:300`, `proxy/upstream.cr:206`).
+      #
+      # NOTE: several other places build this same authority (those three, plus
+      # `mcp/request_builder.cr:90`, `discover/engine.cr:187`, `tui/repeater_view.cr:1582`,
+      # `cli/run/repeater.cr:581`) and they do NOT agree — some omit the bracketing, and the CLI
+      # and TUI repeater paths disagree about `wss`. Only the scheme/port half has one home so
+      # far (`Discover::Url.default_port?`, reused here); consolidating the rest spans the h2,
+      # repeater, MCP and discover paths and wants its own change.
       def self.host_header(scheme : String, host : String, port : Int32) : String
-        authority = host.includes?(':') ? "[#{host}]" : host
+        authority = host.includes?(':') && !host.starts_with?('[') ? "[#{host}]" : host
         Discover::Url.default_port?(scheme, port) ? authority : "#{authority}:#{port}"
       end
 

--- a/src/gori/import/builder.cr
+++ b/src/gori/import/builder.cr
@@ -1,6 +1,7 @@
 require "uri"
 require "../store/models"
 require "../proxy/codec/body"
+require "../discover/url" # Url.default_port? — the one home for the scheme/port default rule
 
 module Gori
   module Import
@@ -118,18 +119,32 @@ module Gori
         raise Gori::Error.new("invalid #{label} (control character): #{field.inspect}") if field.matches?(HEADER_INJECT)
       end
 
+      # The `Host` header value for a stored request, per RFC 7230 §5.4.
+      #
+      # Takes scheme/host/port rather than a pre-built string so a new caller CANNOT forget the
+      # port half — that is exactly how it went missing. `host` arrives bracket-free (matching
+      # the CONNECT path), so an IPv6 literal is re-bracketed here (`Host: [::1]`); a
+      # reg-name/IPv4 host never contains `:`, since userinfo and port live outside `uri.host`.
+      #
+      # §5.4 also REQUIRES the port whenever it is not the scheme's default, and synthesizing
+      # the line from `uri.host` alone silently dropped it: `http://h:8099/p` was stored — and
+      # REPLAYED — as `Host: h`, so a name/port-routing origin saw a different request than the
+      # one imported, and two imports differing only in port became indistinguishable by Host.
+      # `default_port?` is reused rather than re-derived; it already has one home.
+      def self.host_header(scheme : String, host : String, port : Int32) : String
+        authority = host.includes?(':') ? "[#{host}]" : host
+        Discover::Url.default_port?(scheme, port) ? authority : "#{authority}:#{port}"
+      end
+
       def self.request_head(method : String, target : String, http_version : String,
-                            host : String, headers : Headers,
+                            scheme : String, host : String, port : Int32, headers : Headers,
                             body : Bytes?) : Bytes
         reject_inject!(method, "method")
         reject_inject!(http_version, "HTTP version")
         reject_header_injection!(headers)
         String.build do |b|
           b << method.upcase << ' ' << target << ' ' << http_version << "\r\n"
-          # `host` is stored bracket-free (matching the CONNECT path); an IPv6 literal must be
-          # re-bracketed in the Host header line to stay RFC 7230 §5.4 valid (`Host: [::1]`).
-          # A reg-name/IPv4 host never contains `:` (userinfo/port live outside `uri.host`).
-          b << "Host: " << (host.includes?(':') ? "[#{host}]" : host) << "\r\n"
+          b << "Host: " << host_header(scheme, host, port) << "\r\n"
           # One pass, allocation-free case-insensitive compares. Skip BOTH the Host line and any
           # incoming Content-Length: the stored head must agree with the body we actually build
           # and store, but a HAR postData.params entry (no `text`) rebuilds a fresh urlencoded
@@ -167,7 +182,7 @@ module Gori
                                headers : Headers = Headers.new,
                                body : Bytes? = nil, http_version : String = "HTTP/1.1") : FlowPair
         scheme, host, port, target = endpoint(url)
-        head = request_head(method, target, http_version, host, headers, body)
+        head = request_head(method, target, http_version, scheme, host, port, headers, body)
         stored, trunc, size = capped(body)
         req = Store::CapturedRequest.new(
           created_at: created_at, scheme: scheme, host: host, port: port,
@@ -184,7 +199,7 @@ module Gori
                              resp_body : Bytes?, content_type : String?,
                              duration_us : Int64?) : FlowPair
         scheme, host, port, target = endpoint(url)
-        req_head = request_head(method, target, http_version, host, req_headers, req_body)
+        req_head = request_head(method, target, http_version, scheme, host, port, req_headers, req_body)
         req_stored, req_trunc, req_size = capped(req_body)
         req = Store::CapturedRequest.new(
           created_at: created_at, scheme: scheme, host: host, port: port,


### PR DESCRIPTION
Found by exercising `gori run` end-to-end against a raw-echo origin (a server that
replies with the exact request bytes it read, so the wire is the oracle) plus a
`gori run capture` proxy, in an isolated `GORI_HOME`. Three real defects, each its
own commit, then a `/simplify` pass.

All three share a failure mode: **a command that does nothing and reports success.**
On a surface scripts consume, `… || die` never fires.

## F1 — an imported flow's Host header lost the port, and replayed that way (352a235)

`Builder.request_head` skipped the operator's own `Host:` line and synthesized a
replacement from `uri.host`, which never carries a port. RFC 7230 §5.4 requires it
whenever it is not the scheme default, so a HAR carrying `Host: 127.0.0.1:8099` was
stored as `Host: 127.0.0.1` — and the stored head is replayed verbatim, so the echo
origin received the portless Host while the socket went to `:8099`. Name/port-based
routing there sees a different request than the one imported, and two imports
differing only in port became indistinguishable by Host. Only the metadata was
right: `show --format json` reported `"port": 8099` all along.

Affects every source that describes a request in parts (HAR, URL list, OpenAPI,
Postman, Insomnia). **Not** the proxy — live capture preserved the port byte-exact,
verified — and not `Import::Raw`, which bypasses Builder by design.

The one spec that imported a ported URL asserted `contain("Host: [::1]")`, which
held while the port was dropped, and called that "RFC 7230 §5.4 valid" — the thing
§5.4 forbids. That mislabel is plausibly why it went unnoticed.

## F2 — a bare `-v` anywhere in argv silently aborted the command with exit 0 (68e5b8b)

`CLI.run` scanned the whole argv for a version flag before dispatch. `argv.any?`
cannot tell a flag from an option **value**:

```
$ gori run rewriter add --op set_header --find X -v boom   # -vVALUE is documented
gori 0.2.0                                                 # exit 0, no rule created
$ gori run decoder base64-encode --input '-v'
gori 0.2.0                                                 # exit 0 (expected LXY=)
$ gori run fuzz --request t.txt --target … --payloads '-v'
gori 0.2.0                                                 # exit 0, zero requests sent
```

Scoped to the top level, which is what `print_main_help` already promises. `gori -v`,
`gori --version`, `gori run -v`, `gori mcp -V` all still work.

## F3 — an unrecognized verb on `issues`/`links` silently listed and exited 0 (032d622)

Both dispatched with `case args.first?` ending in `else <the read command>`:

```
$ gori run issues remove 1     # the verb is delete/rm
#1  [high/open]  i1            # exit 0 — listed, deleted nothing
$ gori run issues delet 1      # one-letter typo → same
```

`rewriter`, `project`, `oast` and `intercept` already reject their unknown verbs;
these two now match. The same fallthrough also swallowed a positional, so
`gori run issues severity:high` listed **every** issue (only the TUI implements
`Issues::Filter`) — silently returning everything when asked to narrow is the
dangerous direction on a security tool, so that is an error now too.

Also corrects help that pointed at verbs which do not exist and hid ones that do:
the top-level table advertised `links … remove` (the verb is `delete`/`rm`) and a
`notes show` verb (the form is `notes <n>`), while `notes --help` and `links --help`
documented only the read path, leaving the implemented `notes create/delete` and
`links add/delete` undiscoverable.

## `/simplify` pass (3981952)

Quality-only, no behavior change **except** that it closes the residual F2 had
documented as knowingly wrong. `CLI.run` already derived the subcommand split, and
a global version flag is exactly the first token of the subcommand's own args — so
the token-counting loop became one lookup, and `gori run --project -v` is excluded
structurally (a value-taking flag always precedes its value, so a value can never
sit at position 0). `CLI.run` cyclomatic complexity 20 → 16. Also gave
`host_header` the already-bracketed guard its four siblings carry, and removed two
"one home" comment claims that a reader can falsify in the same file.

## Verification

- `crystal spec`: **4866 examples, 0 failures** (4850 before; +16 new).
- Every fix re-verified on the wire after the review pass, not just in specs.
- `crystal tool format` on changed files only (a whole-tree run rewrites 100+
  unrelated files on this Crystal version). `just check` flags
  `src/gori/cli/run/discover.cr`, which this branch does not touch — pre-existing
  drift, left alone.
- ameba: no new findings; all remaining ones on touched files are pre-existing and
  verified against `main`.
- Scope gate re-checked as a regression guard: out-of-scope targets refused, a
  spoofed in-scope `Host:` header does **not** bypass (the gate judges the dialed
  host), and `sandbox on` blocks even with `--allow-unscoped` — with no arrival at
  a connection-logging listener.

## Not done, deliberately

Seven places build the same `host:port` authority and disagree (some omit IPv6
bracketing; the CLI and TUI repeater paths differ on `wss`). Two are `Host:` lines
on the replay path. Real divergence, but consolidating spans the h2, repeater, MCP
and discover paths — worth its own change, noted in the code. Likewise the seven
inline copies of the verb-token test, and deriving help text from a verb table.