### PR TITLE
fix(cli): the rest of the silent-no-op class, plus a regression from #488

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -788,6 +788,39 @@ reason phrase). Those forge a message boundary the same way a CRLF target does, 
 import should also carry an operator's header-boundary payload is a separate question #400 did
 not settle — left rejected pending its own call rather than widened by implication.
 
+### 2026-07-30: an imported request's Host header is the operator's, and carries its port
+
+Refines: [P7](#p7). PR #488 (the port) and its follow-up (the passthrough).
+
+The entry above names "a duplicate `Host`" as one of the payloads import must preserve, but
+`Builder.request_head` was doing the opposite: it skipped every incoming `Host` line and
+synthesized one from `uri.host`. Two defects fell out of that, found by replaying imported
+flows at a raw-echo origin and reading the bytes it received.
+
+- `uri.host` never carries a port, so the synthesized line dropped it. RFC 7230 §5.4 requires
+  the port whenever it is not the scheme default, so a HAR recording `Host: 127.0.0.1:8099`
+  was stored — and replayed — as `Host: 127.0.0.1`. Name/port-based routing at the origin saw
+  a different request than the one imported, and two imports differing only in port became
+  indistinguishable by Host. Only the stored `host`/`port` columns were right, so the raw bytes
+  and the JSON projection disagreed.
+- Synthesizing at all discarded the operator's own bytes. A recorded `Host: evil.example`, or
+  the duplicate `Host` this log already called a payload, was silently replaced — so the
+  Host-header attack the operator imported could not reproduce.
+
+Resolved as two halves of one rule: **a recorded Host goes out verbatim — order kept,
+duplicates kept — and a Host is synthesized only when the source described none.** The
+synthesized form now carries `host:port` unless the port is the scheme default
+(`Builder.host_header`, reusing `Discover::Url.default_port?`). Sources that describe no
+headers (`--urls`, OpenAPI) are the synthesize case; HAR/Postman/Insomnia are the passthrough
+case. `Import::Raw` (Burp) never enters Builder and is unaffected.
+
+Safe because gori already permits a Host that disagrees with the dialled host, deliberately:
+the scope gate judges `Outbound.scope_url` — the host actually dialled — never the request
+line or this header, which is what makes Host-header testing possible at all
+([§3](#s3)). The two guards the entry above kept are untouched: `HEADER_INJECT` still rejects
+CR/LF/NUL in any header, and `request_head` now applies the same check to the `host` it is
+handed, since that field reaches the start of the head and could forge a boundary there.
+
 ---
 
 *Keep this document honest against the code. When you change a subsystem it describes, update

--- a/spec/cli_spec.cr
+++ b/spec/cli_spec.cr
@@ -60,12 +60,32 @@ describe "gori — global version flag" do
     Gori::CLI.global_version_flag_for_spec(["run", "show", "1", "--version"]).should be_false
   end
 
-  # Keying on the FIRST token of the tail rules a flag's own value out structurally: a
-  # value-taking flag always precedes its value, so a value can never sit at position 0.
-  it "leaves a top-level subcommand flag's own value alone" do
-    Gori::CLI.global_version_flag_for_spec(["run", "--project", "-v"]).should be_false
-    Gori::CLI.global_version_flag_for_spec(["tui", "--db", "-v"]).should be_false
-    Gori::CLI.global_version_flag_for_spec(["mcp", "--project", "--version"]).should be_false
+  # Regression: keying on subargs[0] ALONE was too narrow. A version flag after a top-level
+  # subcommand's own flag reached that subcommand's parser and aborted with "unknown option",
+  # while `--help` in the same position worked because every parser owns `-h` — and
+  # print_main_help plus docs/reference/cli.md both promise version works at the top level.
+  it "claims a version flag after a top-level subcommand's own flags" do
+    Gori::CLI.global_version_flag_for_spec(["mcp", "--read-only", "--version"]).should be_true
+    Gori::CLI.global_version_flag_for_spec(["ca", "--pem", "-v"]).should be_true
+    Gori::CLI.global_version_flag_for_spec(["tui", "--insecure-upstream", "-V"]).should be_true
+  end
+
+  # The scan stops dead at the first bare word, because that word is a nested verb and owns
+  # everything after it. This is what keeps every case from the original bug excluded.
+  it "stops at the first bare word, so a nested verb owns its own flags" do
+    Gori::CLI.global_version_flag_for_spec(["run", "oast", "listen", "--version"]).should be_false
+    Gori::CLI.global_version_flag_for_spec(["run", "probe", "rules", "-v"]).should be_false
+    Gori::CLI.global_version_flag_for_spec(["run", "issues", "create", "-v", "x"]).should be_false
+  end
+
+  # KNOWN RESIDUAL, pinned so it is a decision and not a surprise: a `-v` that is the VALUE of a
+  # top-level flag still reads as the flag, because telling a value from a flag needs to know
+  # which flags take values, and that lives in each subcommand's OptionParser. Accepted because
+  # it only misfires on input that is already invalid (`gori run --project x` is not a
+  # subcommand either), whereas excluding it broke `gori mcp --read-only --version` above.
+  it "still misreads a version flag used as a top-level flag's value" do
+    Gori::CLI.global_version_flag_for_spec(["run", "--project", "-v"]).should be_true
+    Gori::CLI.global_version_flag_for_spec(["tui", "--db", "-v"]).should be_true
   end
 
   it "is false when there is no version flag at all" do

--- a/spec/import/import_spec.cr
+++ b/spec/import/import_spec.cr
@@ -1,6 +1,14 @@
 require "base64"
 require "../spec_helper"
 
+# A HAR-shaped import (complete_flow) against a ported URL, so the recorded Host can be made to
+# disagree with the URL authority — see the "a recorded Host header" describe.
+private def har_pair(headers)
+  Gori::Import::Builder.complete_flow(
+    0_i64, "http://127.0.0.1:8098/p", "GET", headers,
+    nil, "HTTP/1.1", 200, "OK", Gori::Import::Builder::Headers.new, nil, nil, nil)
+end
+
 private def with_store(&)
   path = File.tempname("gori-import", ".db")
   store = Gori::Store.open(path)
@@ -879,14 +887,54 @@ describe Gori::Import::Builder do
       a.should_not eq(b)
     end
 
-    it "applies to a complete_flow import (HAR) as well as a pending one" do
-      # The HAR's own `Host: 127.0.0.1:8099` is skipped and the line re-synthesized; it must
-      # come back out identical rather than losing the port.
-      req_headers = [{"Host", "127.0.0.1:8099"}] of {String, String}
+    it "synthesizes the line for a complete_flow import that recorded no Host" do
       pair = Gori::Import::Builder.complete_flow(
-        0_i64, "http://127.0.0.1:8099/login", "POST", req_headers,
+        0_i64, "http://127.0.0.1:8099/login", "POST", Gori::Import::Builder::Headers.new,
         nil, "HTTP/1.1", 200, "OK", Gori::Import::Builder::Headers.new, nil, nil, nil)
       String.new(pair.request.head).should contain("Host: 127.0.0.1:8099\r\n")
+    end
+  end
+
+  # P7, and DESIGN.md §7 by name: a recorded `Host` is the OPERATOR's bytes. §7 lists "a
+  # duplicate `Host`" among the smuggling payloads import must preserve, and a mismatched Host
+  # is a Host-header attack being reproduced. These assert a Host that DIFFERS from the URL
+  # authority — asserting one that matches passes whether the header is preserved or discarded
+  # and re-synthesized, which is how the overwrite went unnoticed.
+  describe "a recorded Host header" do
+    it "goes out verbatim when it disagrees with the URL authority" do
+      head = String.new(har_pair([{"Host", "evil.example"}] of {String, String}).request.head)
+      head.should contain("Host: evil.example\r\n")
+      head.should_not contain("Host: 127.0.0.1:8098") # not silently replaced
+    end
+
+    it "keeps a DUPLICATE Host — the payload DESIGN.md §7 names" do
+      head = String.new(har_pair(
+        [{"Host", "127.0.0.1:8098"}, {"Host", "evil.example"}] of {String, String}).request.head)
+      head.scan(/^Host:/im).size.should eq(2)
+      head.should contain("Host: 127.0.0.1:8098\r\n")
+      head.should contain("Host: evil.example\r\n")
+    end
+
+    it "keeps the operator's spelling rather than canonicalizing the port away" do
+      # A bare Host recorded against a ported URL: previously stored bare (accidentally right),
+      # then :8098 was appended by the port fix. Either way it must be the operator's bytes.
+      head = String.new(har_pair([{"Host", "example.com"}] of {String, String}).request.head)
+      head.should contain("Host: example.com\r\n")
+      head.should_not contain("Host: example.com:8098")
+    end
+
+    it "is matched case-insensitively, so a lowercased HAR header still suppresses the synth" do
+      head = String.new(har_pair([{"host", "evil.example"}] of {String, String}).request.head)
+      head.scan(/^host:/im).size.should eq(1)
+      head.should contain("host: evil.example\r\n")
+    end
+
+    it "still rejects a CR/LF in the host it is handed (boundary guard, not canonicalization)" do
+      expect_raises(Gori::Error, /control character/) do
+        Gori::Import::Builder.request_head("GET", "/", "HTTP/1.1",
+          scheme: "http", host: "h.test\r\nX-Injected: evil", port: 80,
+          headers: Gori::Import::Builder::Headers.new, body: nil)
+      end
     end
 
     it "builds the value directly, including the IPv6 + default-port corners" do

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -90,24 +90,38 @@ module Gori
       {argv[0], argv[1..]}
     end
 
-    # A version flag belongs to the TOP LEVEL — `gori -v`, `gori --version`, `gori run -v` —
-    # which is exactly what print_main_help promises ("Flags like --version and --help work at
-    # the top level too"), and exactly the FIRST token of the subcommand's own args.
+    # A version flag belongs to the TOP LEVEL — `gori -v`, `gori --version`, `gori run -v`,
+    # `gori mcp --read-only --version` — which is what print_main_help and
+    # docs/reference/cli.md both promise ("Flags like --version and --help work at the top
+    # level too").
     #
-    # It must not be claimed once a NESTED subcommand has been named, because there the same
+    # It must NOT be claimed once a NESTED subcommand has been named, because there the same
     # token is that command's own option, or worse its option VALUE. A blanket `argv.any?`
     # claimed all of them, so `gori run rewriter add --find X -v boom` (rewriter's own
     # documented `-vVALUE`) and `gori run decoder base64-encode --input -v` printed the version
     # and returned 0 WITHOUT doing the work — a silent no-op carrying a SUCCESS status, the
     # worst failure mode there is for a surface scripts consume (`… || die` never fires).
     #
-    # Keying on the first token excludes those STRUCTURALLY rather than by counting them: a
-    # value-taking flag always sits ahead of its own value, so a VALUE can never be at position
-    # 0. That covers `gori run --project -v` too, which no positional scan could — deciding it
-    # by inspection would need to know which flags take values, and that lives in each
-    # subcommand's OptionParser, which does not exist yet at this layer.
+    # So scan only the LEADING FLAG RUN of the subcommand's own args and stop dead at the first
+    # bare word: that word is a nested verb, and everything after it belongs to whoever owns it.
+    # Keying on `subargs[0]` alone was too narrow and regressed the promise above — a version
+    # flag sitting after a top-level subcommand's own flag (`gori mcp --read-only --version`,
+    # `gori ca --pem -v`) reached that subcommand's parser and aborted with "unknown option",
+    # while `--help` in the very same position still worked because every parser owns `-h`.
+    #
+    # KNOWN RESIDUAL, and why it is the right trade: a `-v` that is the VALUE of a top-level
+    # flag (`gori run --project -v`) is still read as the flag, because telling a value from a
+    # flag needs to know which flags take values — that lives in each subcommand's OptionParser,
+    # which is not built yet at this layer. It only misfires on input that is already invalid
+    # (`gori run --project x` is not a subcommand either), whereas the alternative broke a
+    # documented, working invocation. Every NESTED case — the ones that actually bit — stays
+    # excluded, because a nested verb is a bare word and ends the scan.
     private def self.global_version_flag?(subargs : Array(String)) : Bool
-      (first = subargs.first?) ? VERSION_FLAGS.includes?(first) : false
+      subargs.each do |arg|
+        return true if VERSION_FLAGS.includes?(arg)
+        return false unless arg.starts_with?('-')
+      end
+      false
     end
 
     # Pull `--config PATH` / `--config=PATH` out of argv, point Settings at it, and return the

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -215,7 +215,7 @@ module Gori
       # changes how they treat an empty-string token, so it wants its own change rather than
       # riding along with a bug fix.
       private def self.verb_token?(sub : String?) : Bool
-        !sub.nil? && !sub.empty? && !sub.starts_with?("-")
+        !sub.nil? && !sub.empty? && !sub.starts_with?('-')
       end
 
       # --db wins → else --project resolved via ProjectRegistry#find (exact short id

--- a/src/gori/cli/run/issues.cr
+++ b/src/gori/cli/run/issues.cr
@@ -16,7 +16,7 @@ module Gori
           # fallthrough swallowed a positional query, so `issues severity:high` listed EVERY
           # issue rather than narrowing, because only the TUI implements Issues::Filter.
           if verb_token?(sub)
-            abort "gori run issues: unknown subcommand '#{sub}' (create, update, delete, list)"
+            abort "gori run issues: unknown subcommand '#{sub}' (create, update, delete/rm, list)"
           end
           cmd_issues_list(args)
         end

--- a/src/gori/cli/run/links.cr
+++ b/src/gori/cli/run/links.cr
@@ -15,7 +15,7 @@ module Gori
           # unlinking; with a mutate-only flag present it did fail, but blamed the flag
           # (`unknown option: --ref`) and never said `remove` is not a verb.
           if verb_token?(sub)
-            abort "gori run links: unknown subcommand '#{sub}' (add, delete, list)"
+            abort "gori run links: unknown subcommand '#{sub}' (add, delete/rm, list)"
           end
           cmd_links_list(args)
         end

--- a/src/gori/cli/run/notes.cr
+++ b/src/gori/cli/run/notes.cr
@@ -6,11 +6,21 @@ module Gori
   module CLI
     module Run
       private def self.cmd_notes(args : Array(String)) : Nil
-        case args.first?
+        case sub = args.first?
         when "create"       then cmd_notes_create(args[1..])
         when "delete", "rm" then cmd_notes_delete(args[1..])
         when "list"         then cmd_notes_read(args[1..])
-        else                     cmd_notes_read(args)
+        else
+          # `notes` takes a bare `<n>`, so `verb_token?` alone cannot decide: "3" is a verb token
+          # but is legitimately DATA. Only a NON-NUMERIC bare word can have been meant as a verb.
+          # Without this, `notes remove 2` aborted with "too many arguments (expected at most one
+          # note number)" — non-zero, so never the silent no-op class, but it never told the
+          # operator that notes has verbs and `remove` is not one, unlike its issues/links siblings.
+          if (s = sub) && verb_token?(s) && s.to_i?.nil?
+            abort "gori run notes: unknown subcommand '#{s}' (create, delete/rm, list) — " \
+                  "or pass a note number"
+          end
+          cmd_notes_read(args)
         end
       end
 

--- a/src/gori/cli/run/oast.cr
+++ b/src/gori/cli/run/oast.cr
@@ -67,14 +67,21 @@ module Gori
       # settings.json and is shared across every project.
 
       private def self.cmd_oast_providers(args : Array(String)) : Nil
-        case args.first?
+        case sub = args.first?
         when "add"          then cmd_oast_provider_write(args[1..], update: false)
         when "update"       then cmd_oast_provider_write(args[1..], update: true)
         when "enable"       then cmd_oast_provider_enabled(args[1..], true)
         when "disable"      then cmd_oast_provider_enabled(args[1..], false)
         when "delete", "rm" then cmd_oast_provider_delete(args[1..])
-        when "list", nil    then cmd_oast_providers_list(args.empty? ? args : args[1..])
-        else                     cmd_oast_providers_list(args)
+        when "list"         then cmd_oast_providers_list(args[1..])
+        else
+          # Same guard, same reason as cmd_issues / cmd_links — see `verb_token?`.
+          # `oast providers remove p_1` listed the providers and exited 0, deleting nothing.
+          if verb_token?(sub)
+            abort "gori run oast providers: unknown subcommand '#{sub}' " \
+                  "(add, update, enable, disable, delete/rm, list)"
+          end
+          cmd_oast_providers_list(args)
         end
       end
 
@@ -301,6 +308,13 @@ module Gori
           p.on("--once", "Poll once and exit (no loop)") { once = true }
           p.on("--json", "Emit each callback as a JSON line (same shape as MCP)") { json = true }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          # This was the ONE parser of 74 under src/gori/cli/ missing these, so OptionParser's
+          # default raised straight past `Run.dispatch` (rescues IO::Error) and `CLI.run`
+          # (rescues Gori::Error) to `main`, printing a Crystal backtrace — the form cli.cr's own
+          # top-level rescue calls "the least usable there is". `gori run oast listen --bogus`
+          # already did it; narrowing the global version scan just routed `--version` there too.
+          p.invalid_option { |f| abort "gori run oast listen: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run oast listen: missing value for #{f}" }
         end
         parser.parse(args)
 

--- a/src/gori/cli/run/probe.cr
+++ b/src/gori/cli/run/probe.cr
@@ -342,13 +342,20 @@ module Gori
       # --- scan rules + mode ----------------------------------------------------------------
 
       private def self.cmd_probe_rules(args : Array(String)) : Nil
-        case args.first?
+        case sub = args.first?
         when "enable"       then cmd_probe_rule_enabled(args[1..], true)
         when "disable"      then cmd_probe_rule_enabled(args[1..], false)
         when "add"          then cmd_probe_rule_add(args[1..])
         when "delete", "rm" then cmd_probe_rule_delete(args[1..])
-        when "list", nil    then cmd_probe_rules_list(args.empty? ? args : args[1..])
-        else                     cmd_probe_rules_list(args)
+        when "list"         then cmd_probe_rules_list(args[1..])
+        else
+          # Same guard, same reason as cmd_issues / cmd_links — see `verb_token?`.
+          # `probe rules remove my-rule` (or `disble`) listed the rules and exited 0.
+          if verb_token?(sub)
+            abort "gori run probe rules: unknown subcommand '#{sub}' " \
+                  "(add, enable, disable, delete/rm, list)"
+          end
+          cmd_probe_rules_list(args)
         end
       end
 

--- a/src/gori/import/builder.cr
+++ b/src/gori/import/builder.cr
@@ -150,18 +150,33 @@ module Gori
                             body : Bytes?) : Bytes
         reject_inject!(method, "method")
         reject_inject!(http_version, "HTTP version")
+        # `host` reaches the Host line, so it forges a message boundary the same way a header
+        # value would. `endpoint`'s HOST_INVALID already covers both internal callers, but this
+        # is a public serializer taking a caller-supplied host, so guard it here too rather than
+        # leave the one field on the start of the head unchecked.
+        reject_inject!(host, "host")
         reject_header_injection!(headers)
+        # P7, and DESIGN.md §7 by name: when the source RECORDED a `Host`, those are the
+        # OPERATOR's bytes and go out verbatim — order kept, duplicates kept. §7 lists "a
+        # duplicate `Host`" among "the smuggling payloads an operator tests with, not corruption
+        # to be repaired", and a deliberately mismatched Host is a Host-header attack the
+        # operator is reproducing. Skipping the incoming line and synthesizing one silently
+        # replaced both: a HAR recording `Host: evil.example` for `http://127.0.0.1:8098/p` was
+        # stored — and replayed — as `Host: 127.0.0.1:8098`, so the recorded attack could not
+        # reproduce. Synthesize ONLY when the source described no Host at all, which is the
+        # `--urls` / OpenAPI case (they carry no headers). Safe because the scope gate judges the
+        # host actually DIALLED (`Outbound.scope_url`), never this line.
+        has_host = headers.any? { |(k, _)| k.compare("host", case_insensitive: true) == 0 }
         String.build do |b|
           b << method.upcase << ' ' << target << ' ' << http_version << "\r\n"
-          b << "Host: " << host_header(scheme, host, port) << "\r\n"
-          # One pass, allocation-free case-insensitive compares. Skip BOTH the Host line and any
-          # incoming Content-Length: the stored head must agree with the body we actually build
-          # and store, but a HAR postData.params entry (no `text`) rebuilds a fresh urlencoded
-          # body whose length differs from the original request's Content-Length. Keeping that
-          # header verbatim left the stored request advertising the wrong length; re-emit one
-          # correct Content-Length below from the true (pre-cap) body size.
+          b << "Host: " << host_header(scheme, host, port) << "\r\n" unless has_host
+          # One pass, allocation-free case-insensitive compares. Skip any incoming
+          # Content-Length: the stored head must agree with the body we actually build and store,
+          # but a HAR postData.params entry (no `text`) rebuilds a fresh urlencoded body whose
+          # length differs from the original request's Content-Length. Keeping that header
+          # verbatim left the stored request advertising the wrong length; re-emit one correct
+          # Content-Length below from the true (pre-cap) body size.
           headers.each do |k, v|
-            next if k.compare("host", case_insensitive: true) == 0
             next if k.compare("content-length", case_insensitive: true) == 0
             b << k << ": " << v << "\r\n"
           end


### PR DESCRIPTION
Follow-up to #488, driven by the `/code-review` pass I should have run before merging
it (I ran `/simplify`, which is quality-only and was explicitly told not to look for
correctness bugs). It found 14 findings; these are the ones worth acting on, including
**a regression #488 introduced**.

## 1. Regression: the top-level version flag after a subcommand's own flag (`9822d17`)

#488 narrowed the global version scan to `subargs[0]`. Too narrow — a version flag
after a top-level subcommand's own flag reached that subcommand's parser and aborted,
while `--help` in the same position kept working because every parser owns `-h`:

```
$ gori mcp --read-only --version
unknown option: --version          # was: gori 0.2.0
$ gori mcp --read-only --help
Usage: gori mcp [options]          # --help unaffected — the inconsistency
```

Both `print_main_help` and `docs/content/reference/cli.md` promise version works at the
top level, so #488 broke a documented invocation. Now scans the **leading flag run** of
the subcommand's args, stopping at the first bare word (a nested verb owns everything
after it) — which keeps every case #488 fixed excluded and restores these.

The trade is now **pinned by a spec** rather than left as a surprise: `gori run --project -v`
reads `-v` as the flag again. That needs to know which flags take values, which lives in
each subcommand's OptionParser. It only misfires on input already invalid (`gori run
--project x` is not a subcommand either). #488 had this backwards — it traded a working
invocation for a nonsense one.

## 2. Two more `else → list` fallthroughs, and the one parser that backtraced (`1c22b8d`)

#488 fixed the silent-no-op dispatch on `issues`/`links` but missed the **nested** ones,
because the sweep behind it tested `oast frobnicate` at the top level and never
`oast providers <verb>`:

```
$ gori run oast providers remove p_1     # the verb is delete/rm
(provider list)                          # exit 0 — deleted nothing
$ gori run probe rules remove my-rule
(rule list)                              # exit 0 — same
```

All six verb-only subcommands now reject an unknown verb. Also: `oast listen` was the
**one parser of 74** with no `invalid_option`/`missing_option` handler, so it raised past
both rescues to `main` and printed a Crystal backtrace. Pre-existing
(`oast listen --bogus` already did it), fixed here so it lands *before* the version
change routes `--version` there. Plus the abort messages now name the `rm` alias they
accept, and `notes remove 2` says the verb is unknown instead of "too many arguments".

## 3. A recorded Host header is the operator's payload (`38bd0eb`)

The one I deferred in #488 **on reasoning DESIGN.md contradicts**. §7 (#400) names "a
duplicate `Host`" as a payload import must preserve; `request_head` skipped every
incoming `Host` and synthesized one:

```
HAR with TWO Host headers (127.0.0.1:8098 and evil.example):
  Host: 127.0.0.1:8098          # both discarded, one synthesized
HAR with Host: evil.example on http://127.0.0.1:8098/p:
  Host: 127.0.0.1:8098          # the Host-header attack payload, gone
```

The stored head replays verbatim, so the recorded attack could not reproduce. #488 fixed
the port on that synthesized line but left the overwrite — and made one case worse: a
bare `Host: example.com` recorded against a ported URL previously round-tripped intact by
accident, then gained a `:8098` the operator never sent.

A recorded Host now goes out verbatim (order and duplicates kept); one is synthesized
only when the source described none — the `--urls`/OpenAPI case. Safe because the scope
gate judges the host actually **dialled** (`Outbound.scope_url`), never this header, which
is what makes Host-header testing possible; re-verified that a spoofed in-scope Host does
not bypass it. `request_head` also now guards the `host` it is handed against CR/LF —
#488 widened it into a public serializer while leaving that one start-line field
unchecked. `HEADER_INJECT` untouched: §7 leaves header-boundary import rejected pending
its own call.

The HAR spec #488 added couldn't tell preservation from replacement (the Host it fed
equalled what gets synthesized, so it passed either way) — replaced with cases whose Host
differs from the URL authority. **DESIGN.md §7 gains the decision entry AGENTS.md asks
for**, which #488 omitted.

## Verification

- `crystal spec`: **4873 examples, 0 failures** (4866 on main; +7).
- All three fixes verified on the wire at a raw-echo origin, including that a mismatched
  `Host: evil.example` now reaches an origin dialled at `127.0.0.1:8098`, and that
  `--urls` still gets a synthesized ported Host.
- ameba: counts identical to `main` on every touched file — no new findings.
- `crystal tool format` on changed files only.

## Left for their own change (from the same review)

- `cli/run/repeater.cr:581-582` and `tui/repeater_view.cr:1583` build a `Host:` line
  without IPv6 bracketing (`Host: ::1:8443` — malformed) and disagree with each other on
  `wss` default-port handling. Real bugs, pre-existing, cross-surface parity.
- The scheme/port default predicate has ~7 homes; `Discover::Url` is a questionable one
  for `Import` to depend on. A neutral home is the right fix and spans h2/repeater/MCP.
- Routing the 7 remaining hand-rolled verb-token tests through `verb_token?`.