### PR TITLE
fix(repeater): --target Host sync sent a malformed IPv6 authority, and CLI ≠ TUI on wss

### DIFF
--- a/spec/cli_run_spec.cr
+++ b/spec/cli_run_spec.cr
@@ -130,6 +130,53 @@ describe Gori::Repeater::FlowRequest do
     Gori::Repeater::FlowRequest.parse_target("http://h:8080").should eq({"http", "h", 8080})
     Gori::Repeater::FlowRequest.parse_target("h:9000").should eq({"http", "h", 9000}) # bare → http
     Gori::Repeater::FlowRequest.parse_target("https://h:8443/p").should eq({"https", "h", 8443})
+    # ws/wss carry their own defaults, and an IPv6 literal comes back BRACKET-FREE (what
+    # TCPSocket dials) — which is why `authority` has to put the brackets back.
+    Gori::Repeater::FlowRequest.parse_target("wss://h").should eq({"wss", "h", 443})
+    Gori::Repeater::FlowRequest.parse_target("ws://h").should eq({"ws", "h", 80})
+    Gori::Repeater::FlowRequest.parse_target("https://[::1]:8443").should eq({"https", "::1", 8443})
+  end
+
+  # The `Host:` header value, shared by the engine, the CLI's --target sync and the TUI editor.
+  # Both surfaces used to hand-roll it, and both got it wrong — see the authority specs below.
+  describe "Gori::Repeater::FlowRequest.authority" do
+    auth = ->(s : String, h : String, p : Int32) { Gori::Repeater::FlowRequest.authority(s, h, p) }
+
+    it "omits the port when it is the scheme default, ws/wss included" do
+      auth.call("http", "h", 80).should eq("h")
+      auth.call("https", "h", 443).should eq("h")
+      auth.call("ws", "h", 80).should eq("h")
+      # The CLI omitted `wss` from this test, so a wss target (parse_target → 443) produced
+      # `Host: h:443` while the TUI produced `Host: h` for the same session.
+      auth.call("wss", "h", 443).should eq("h")
+    end
+
+    it "keeps a non-default port, including one that is default for the other scheme" do
+      auth.call("http", "h", 8080).should eq("h:8080")
+      auth.call("wss", "h", 8443).should eq("h:8443")
+      auth.call("http", "h", 443).should eq("h:443")
+      auth.call("https", "h", 80).should eq("h:80")
+    end
+
+    it "brackets an IPv6 literal (RFC 7230 §5.4) — neither surface did" do
+      # `Host: ::1:8443` is not a valid authority; a strict origin rejects it and any splitter
+      # reading it back gets host "::" and garbage for the port. Verified on the wire.
+      auth.call("https", "::1", 8443).should eq("[::1]:8443")
+      auth.call("https", "::1", 443).should eq("[::1]")
+      auth.call("wss", "fe80::1", 443).should eq("[fe80::1]")
+    end
+
+    it "does not double-bracket a host that already carries them" do
+      auth.call("https", "[::1]", 8443).should eq("[::1]:8443")
+    end
+
+    it "is the authority half of build_target, so the two cannot drift" do
+      {"https://h", "http://h:8080", "wss://h", "https://[::1]:8443", "wss://[::1]"}.each do |t|
+        scheme, host, port = Gori::Repeater::FlowRequest.parse_target(t)
+        Gori::Repeater::FlowRequest.build_target(scheme, host, port)
+          .should eq("#{scheme}://#{auth.call(scheme, host, port)}")
+      end
+    end
   end
 
   it "only rewrites a well-formed absolute request line" do

--- a/src/gori/cli/run/repeater.cr
+++ b/src/gori/cli/run/repeater.cr
@@ -578,8 +578,12 @@ module Gori
         # with a different claimed Host, so that override must win.
         if (override = target_override) && !custom_headers.has_key?("host")
           scheme_part, host_part, port_part = Repeater::FlowRequest.parse_target(override)
-          default_port = scheme_part == "https" ? 443 : 80
-          host_hdr_val = port_part == default_port ? host_part : "#{host_part}:#{port_part}"
+          # FlowRequest.authority, not a local formula: the two it replaced were both wrong.
+          # This one omitted `wss` from the default-port test, so a `wss://h` target — which
+          # parse_target resolves to port 443 — got `Host: h:443` while the TUI wrote `Host: h`
+          # for the same session. It also never re-bracketed an IPv6 literal (parse_target
+          # returns it bracket-free), emitting the malformed `Host: ::1:8443`.
+          host_hdr_val = Repeater::FlowRequest.authority(scheme_part, host_part, port_part)
           host_idx = new_lines.index { |l| line_name.call(l).compare("Host", case_insensitive: true) == 0 }
           if host_idx
             new_lines[host_idx] = "#{line_name.call(new_lines[host_idx])}: #{host_hdr_val}"

--- a/src/gori/import/builder.cr
+++ b/src/gori/import/builder.cr
@@ -134,12 +134,15 @@ module Gori
       # already-bracketed host cannot double-bracket to `[[::1]]` — the same guard every sibling
       # carries (`store/models.cr:107`, `repeater/h2_engine.cr:300`, `proxy/upstream.cr:206`).
       #
-      # NOTE: several other places build this same authority (those three, plus
-      # `mcp/request_builder.cr:90`, `discover/engine.cr:187`, `tui/repeater_view.cr:1582`,
-      # `cli/run/repeater.cr:581`) and they do NOT agree — some omit the bracketing, and the CLI
-      # and TUI repeater paths disagree about `wss`. Only the scheme/port half has one home so
-      # far (`Discover::Url.default_port?`, reused here); consolidating the rest spans the h2,
-      # repeater, MCP and discover paths and wants its own change.
+      # NOTE: other places build this same authority and do not all agree — `store/models.cr`,
+      # `repeater/h2_engine.cr` and `proxy/upstream.cr` bracket; `mcp/request_builder.cr:90` and
+      # `discover/engine.cr:187` still do not. The repeater pair that used to be wrong here is
+      # now one home, `Repeater::FlowRequest.authority`.
+      #
+      # This does NOT delegate to that one, deliberately: it is ws/wss-aware, and import speaks
+      # only http/https (`normalize_url`), so `Discover::Url.default_port?` is the right
+      # predicate here and reaching into `Repeater` from `Import` would be the wrong dependency
+      # for no behavioural gain. The remaining MCP/discover copies want their own change.
       def self.host_header(scheme : String, host : String, port : Int32) : String
         authority = host.includes?(':') && !host.starts_with?('[') ? "[#{host}]" : host
         Discover::Url.default_port?(scheme, port) ? authority : "#{authority}:#{port}"

--- a/src/gori/repeater/flow_request.cr
+++ b/src/gori/repeater/flow_request.cr
@@ -83,14 +83,36 @@ module Gori
         "#{lines.join("\r\n")}\r\n\r\n#{body}".to_slice
       end
 
+      # The default port for a scheme, **ws/wss included**.
+      #
+      # Deliberately NOT `Discover::Url.default_port?`, which knows only http/https: it answers
+      # false for wss/443 and so would hang a redundant `:443` on every secure-WebSocket
+      # authority. The crawler never speaks ws; the repeater does. Keep the two apart rather
+      # than "unifying" them into that bug.
+      def self.default_port(scheme : String) : Int32
+        (scheme == "https" || scheme == "wss") ? 443 : 80
+      end
+
+      def self.default_port?(scheme : String, port : Int32) : Bool
+        port == default_port(scheme)
+      end
+
+      # The authority — `host[:port]`, IPv6 literal bracketed, port omitted when it is the
+      # scheme default. This is BOTH the `Host:` header value (RFC 7230 §5.4) and the part
+      # `build_target` hangs off `scheme://`, so both derive from here and cannot drift.
+      #
+      # An IPv6 literal (contains ':') must be bracketed, else the `:port` suffix and
+      # `URI.parse` in `parse_target` split it wrong (host → ""). `parse_target` returns a
+      # BRACKET-FREE host (what TCPSocket wants to dial), so this is where they come back.
+      def self.authority(scheme : String, host : String, port : Int32) : String
+        h = host.includes?(':') && !host.starts_with?('[') ? "[#{host}]" : host
+        default_port?(scheme, port) ? h : "#{h}:#{port}"
+      end
+
       # "scheme://host[:port]", omitting the port when it's the scheme default —
       # matches RepeaterView#build_target so the parsed {scheme,host,port} round-trips.
       def self.build_target(scheme : String, host : String, port : Int32) : String
-        default = (scheme == "https" || scheme == "wss") ? 443 : 80
-        # An IPv6 literal host (contains ':') must be bracketed in a URL, else both the
-        # `:port` suffix below and URI.parse in parse_target split it wrong (host → "").
-        h = host.includes?(':') && !host.starts_with?('[') ? "[#{host}]" : host
-        port == default ? "#{scheme}://#{h}" : "#{scheme}://#{h}:#{port}"
+        "#{scheme}://#{authority(scheme, host, port)}"
       end
 
       # {scheme, host, port} parsed back out of a target string (the inverse of
@@ -101,7 +123,7 @@ module Gori
         uri = URI.parse(raw)
         scheme = uri.scheme || "http"
         host = strip_ipv6_brackets(uri.host || "")
-        port = uri.port || ((scheme == "https" || scheme == "wss") ? 443 : 80)
+        port = uri.port || default_port(scheme)
         {scheme, host, port}
       rescue
         {"http", "", 0}

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -1579,8 +1579,10 @@ module Gori::Tui
       return if @req_hex_edit || @ws_mode || @grpc_mode
       scheme, host, port = parse_target
       return if host.empty?
-      default_port = (scheme == "https" || scheme == "wss") ? 443 : 80
-      authority = port == default_port ? host : "#{host}:#{port}"
+      # Shared with the engine and the CLI (build_target derives from the same call), so the
+      # three cannot drift. The local formula this replaced never re-bracketed an IPv6 literal —
+      # parse_target hands back a bracket-free host — and so wrote the malformed `Host: ::1:8443`.
+      authority = Repeater::FlowRequest.authority(scheme, host, port)
       env_sep = @editor.text.index("\n\n")
       return unless env_sep
       head_lines = @editor.text[0, env_sep].split('\n')


### PR DESCRIPTION
The two bugs I flagged as "left for their own change" at the end of #489. Both are in the
`Host:` header value each surface builds beside its `--target` sync — and both surfaces
hand-rolled it while `FlowRequest.build_target`, two functions from the `parse_target`
they each call, had it right all along.

## 1. A malformed IPv6 authority on the wire — both surfaces

`parse_target` deliberately returns a **bracket-free** host (that is what `TCPSocket`
dials), and neither Host builder put the brackets back:

```
$ gori run repeater 1 --target 'http://[::1]:8443'
# what the IPv6 origin actually received:
Host: ::1:8443            # not a valid RFC 7230 §5.4 authority
```

A strict origin rejects it, and anything splitting it back reads host `::` with garbage
for the port. Verified against an IPv6 echo listener before and after — it now receives
`Host: [::1]:8443`.

## 2. `wss` — a CLI/TUI parity break

The CLI computed the default port as `scheme == "https" ? 443 : 80`, omitting `wss`,
which `parse_target` resolves to 443. The same session therefore went out differently
from each surface:

```
                     BEFORE                          AFTER
wss://echo.test      CLI=echo.test:443  TUI=echo.test    both: echo.test
ws://echo.test       agree                              unchanged
https://[::1]:8443   both: ::1:8443  (malformed)        both: [::1]:8443
wss://[::1]          CLI=::1:443       TUI=::1          both: [::1]
```

Against the near-parity convention in AGENTS.md §2, and some origins/CDNs route or reject
on a non-canonical ported Host.

## The fix

One home: `FlowRequest.authority(scheme, host, port)`, placed next to the
`parse_target`/`build_target` pair both surfaces already share. `build_target` now derives
from it (`"#{scheme}://#{authority(...)}"`), so the target and the Host line cannot drift.
The scheme default had a **third** copy in that same file inside `parse_target`; all three
now go through one `default_port`.

This mirrors what the TUI's own `build_target` already does — it delegates to
`FlowRequest` with the comment "shared with the engine (was duplicated)". The *target*
had been consolidated; only the *Host line* had not.

**Deliberately not merged with `Discover::Url.default_port?`**, which the earlier review
suggested as the one home: it knows only http/https and answers `false` for wss/443, so
routing the repeater through it would reintroduce exactly the `:443` bug above. The
crawler never speaks ws; the repeater does. Noted at both ends so neither gets "unified"
into the other later. `Import::Builder.host_header` likewise does not delegate — import
speaks only http/https, and `Import` depending on `Repeater` is the wrong direction for no
behavioural gain; its now-stale note naming these two sites is corrected.

## Verification

- `crystal spec`: **4878 examples, 0 failures** (4873 on main; +5), covering ws/wss
  defaults, the cross-scheme ports (`http://h:443`, `https://h:80`), IPv6 with and without
  a default port, the already-bracketed input, and a round-trip asserting `build_target`
  stays the authority half.
- The IPv6 case verified on the wire at an `[::1]:8443` echo listener, not just in specs.
- ameba: counts identical to `main` on all four touched files.
- `crystal tool format` on changed files only.

## Still open from that review

`mcp/request_builder.cr:90` and `discover/engine.cr:187` build the same authority without
IPv6 bracketing. Left alone here — different subsystems, and neither is the repeater path
this PR is about.