### PR TITLE
fix: the silent no-op class, and refusals that never named the gate

### DIFF
--- a/FRICTION-AUDIT.md
+++ b/FRICTION-AUDIT.md
@@ -1,0 +1,653 @@
+# gori 운영 마찰(friction) 인벤토리 — HTTP 전송 · TUI 구간
+
+기준: gori 0.2.0 (`30f8856`) · 비교 대상: Burp Suite / Caido
+방법: 8개 축으로 소스 감사 → 각 주장마다 반증 전용 검증 에이전트 1회 → 중복 제거.
+원시 50건 중 35 CONFIRMED · 15 PARTIAL(주장은 성립하되 범위 축소). 여기에 빌드한 바이너리로
+직접 재현한 5건을 더했다.
+
+**이 문서가 다루는 것은 버그가 아니라 마찰이다.** 기준은 "Burp에서는 키 하나인데 gori에서는 몇
+단계인가", "했다고 말해놓고 안 한 게 무엇인가"다. 정확성 결함이라도 조작 비용으로 환산되지 않으면
+검증 단계에서 걸러냈다.
+
+DESIGN.md §7에 기록된 결정(P7 operator bytes 무가공, Verb 레지스트리는 TUI 전용, rule-less scope는
+absent scope가 아님)은 마찰로 세지 않았다.
+
+> **상태:** 아래 항목 중 **Z1 · Z2 · T2 · H6 · X2 · X3 · O1** 7건은 수정되어 머지됨
+> (테마 T-B "하지 않은 일을 했다고 보고한다" + T-C "어느 게이트가 거부했는지 알 수 없다" 일괄).
+> 각 항목 제목 옆의 `[FIXED]` 표시를 참고. 나머지는 미착수이며 §2의 우선순위 표가 그대로 로드맵이다.
+
+---
+
+## 1. 횡단 테마 6가지
+
+### T-A. "seam은 이미 있는데 아무도 안 연결했다" — 가장 큰 부류
+어려운 절반이 이미 작성되어 있고 **다른 호출자에서 프로덕션으로 돌아가는 중**인데, 정작 필요한
+곳에서 호출하지 않는다. `Store#search`의 `before_id`(MCP만 사용), `flags_for`(선언된 seam, 스텁),
+`representative_flow_id`(Sitemap→Repeater는 사용), `insert_fuzz_run`/`insert_fuzz_result`(스키마·
+컴팩션 정책까지 있는데 **호출자 0개**), `detail_request_bytes` + public `repeater_from_request`,
+`Matcher#extract`(config_json으로 왕복하는데 setter 없음), `PlanOptions#processors`(세 서피스 공용
+이라고 문서화됐는데 TUI만 빈 배열), `Session.open` 안의 `store.setting` 6줄.
+→ 설계 공백이 아니라 배선 작업. 해당: H1, H3, H4, R3, Z3, Z4, Z6, Z7, X1, R1
+
+### T-B. "하지 않은 일을 했다고 보고한다" — 메인테이너가 이미 3번 고친 클래스
+`0d59c8a`("three write tools that reported success for work they did not do"), `a0a5bd3`,
+`#488/#489`가 같은 클래스다. 아직 남은 인스턴스: 드롭된 QL 항이 필터를 **넓히는데** 바에는 그대로
+표시(H2), Tab이 절대 매치 못 하는 `flag:`를 제안(H6), `^A`가 거부하고 "auto-marked 1 position"
+토스트(Z1), `y`가 64 KiB에서 자르고 잘린 크기를 복사 크기로 출력(T2), 3200건 전량 거부 후
+"no hidden parameters found" + exit 0(X2), Sandbox 켜진 채 마지막 include 삭제하면 "removed scope
+rule" 토스트 + 프록시 블랙홀(O1), retention이 조용히 삭제하고 `~/.gori/gori.log`에만 기록(O3).
+
+### T-C. "어느 게이트가 거부했는지 알 수 없다"
+`Outbound#sweep_block`이 sandbox와 exclude를 하나의 `"blocked by scope"`로 뭉갠다 — Layer 1을
+방금 `--allow-unscoped`로 면제한 조작자가 **같은 문구**를 다시 본다. 반면 `send_block`은
+`SANDBOX_ERROR = "blocked by sandbox (out of scope)"`로 구분하고, Layer 1 중단은
+`cli/run.cr:356`에서 게이트와 탈출구를 둘 다 말한다 — 모델은 이미 사내에 있다.
+해당: X3, Z2, X2, O1, P2, P3
+
+### T-D. "CLI ≠ TUI ≠ MCP"
+Plan 빌더 작업(#356, #366, #373–#377)이 **조립**은 통일했지만 **각 서피스가 무엇을 보관하고
+보고하는가**는 통일하지 않았다. CLI는 `r.error`를 찍고 TUI는 안 찍음(Z2), `--extract`/`extract`는
+CLI·MCP만(Z6), processor 파이프라인도 CLI·MCP만(Z7), `keep_bodies`는 CLI에서 `:none` 하드코딩(Z8),
+프로젝트별 upstream/timeout은 TUI와 `run capture`만 로드(X1), MCP `send_request`만 History에 기록
+(X4), `gori run repeater send`에는 재타겟 플래그가 없음(R7).
+
+### T-E. "도구 밖으로 못 꺼내는 바이트"
+gori는 저장소까지 byte-exact(P7)인데 **마지막 15cm** — 화면→클립보드, 화면→diff, 스윕→디스크 —
+에서 바이트를 잃거나, 조용히 잃는다. 드래그 선택 불가 + 마우스 기본 on이 터미널 자체 선택을
+뺏음(T1), 키보드 대안은 64 KiB에서 잘리고 오보(T2), `^F`가 **라인** 단위라 minified 본문은 히트
+1개이고 커서는 0열(T4), Comparer는 캡처 플로우만 받고 라인 단위 diff만(R3), CLI는 응답을 버림(Z8).
+
+### T-F. "작은 케이스에서만 동작하는 어포던스"
+전부 소규모에서는 되는데 다음 단계가 없다. 1000건 + 커서 없음(H1), 정렬 없음이라 길이 이상치는
+언제나 페이징 없는 5000행 맨 아래(H5, Z5), 100자 넘는 붙여넣기는 붙이기 전 버퍼를 undo 스택에서
+밀어냄(T3), 80열 터미널에서 50/50 고정 분할(R6), `^F`는 Repeater에서 되니 반사가 생기는데 다른
+5개 탭에서는 조용히 죽음(T5), 세션 중 닿을 수 있는 디스크 레버는 0바이트를 회수(O4).
+
+---
+
+## 2. 우선순위 수정 목록
+
+크기: **S** = 몇 줄, **M** = 파일 하나, **L** = 새 seam/뷰.
+"정직하게 말하기(S)"와 "기능 만들기(L)"가 붙어 있는 항목은 반으로 갈라 각각 배치했다 — 이 저장소가
+역사적으로 실제 출하해 온 방식이기도 하다.
+
+| 순위 | 항목 | 크기 | 조치 |
+|---|---|---|---|
+| 1 | Z2 | S | Fuzzer 결과 행에 `r.error` 렌더; `detail_response_lines`가 retention 문구보다 error를 먼저 분기 |
+| 2 | X3 | S | `sweep_block`이 sandbox/exclude를 구분된 문자열로 반환; `--allow-unscoped` 도움말 3곳을 repeater 쪽 문구에 맞춤 |
+| 3 | O1 | S | scope 룰 write 후 `sandbox? && include_count == 0`이면 기존 `toast_sandbox_state` 줄을 붙임 (CLI stderr·MCP `blocks_all`도 동일) |
+| 4 | Z1 | S | `auto_mark`를 멱등으로(clear→derive), 아니면 전후 diff 후 `mark_word`처럼 정직하게 거부 |
+| 5 | T2-a | S | 잘림 보고를 `Clipboard`로 올려 5개 경로의 누락을 구조적으로 제거 |
+| 6 | H6 | S | `QL_FIELDS`에서 `flag` 제거, `url` 추가, `field_cond`와 spec으로 고정 |
+| 7 | X1 | S | `Session.open`의 `store.setting` 6줄을 `Settings.load_project_network(store)`로 승격해 `CLI::Run.open_store`·MCP bind에서도 호출 |
+| 8 | Z4 | S | `fuzz.repeater` verb 등록 — `runner/miner.cr:54`의 3줄 복사 |
+| 9 | H4 | S | `sitemap.open-flow` 등록 — `representative_flow_id` → `open_detail_id` (`runner/issues.cr:163`과 동형) |
+| 10 | X2 | S/M | Miner·Sequencer에 Discover의 `NOTHING_TO_SEND` 백스톱 부여, 첫 에러 문자열 운반 → 기존 `had_error`로 exit 1 |
+| 11 | H2 | M | `query_note_for`에서 기존 `QL.analyze` 호출, "ignored: …"를 **필터 바**에 렌더(빈 결과 화면만으로는 부족 — 넓어진 쿼리는 비지 않는다) |
+| 12 | H1-a | S | 카운트 칩을 필터 중일 때만이 아니라 항상 렌더(`1000+` 형식은 이미 의도적으로 존재) |
+| 13 | H5-a | S | 컬럼 라벨을 `RESP`로 바꾸거나 합계로 통일 + `respsize:`/`reqsize:`를 `FILTER_HINT`에 노출 |
+| 14 | Z5 | S/M | Fuzzer·Miner·Sequencer에 `body_scroll` 구현(`history_controller.cr:159` 복사) + `cycle_sort`에 방향 플래그 |
+| 15 | O5 | S | `browser.open`에 코드 부여 + 트래픽 생긴 뒤에도 남는 진입점(listen 칩 메뉴) |
+| 16 | O3 | S/M | `write_failures` 옆에 `retention_dropped : Atomic`; Runner의 기존 폴링이 알림으로 전환 |
+| 17 | T5-a | S | `goto_target`이 nil이면 키를 삼키지 말고 "find is not available in this pane" 토스트 |
+| 18 | O4-a | S | `history_clear`가 디스크 크기를 보고하고 compaction을 회수 단계로 명시 |
+| 19 | X4-a | S | `gori run repeater`에 `--record` 추가(MCP `record_outbound_request` 재사용) |
+| 20 | Z8 | M | `--record=none\|matched\|all`을 `Matcher`+`Config`에 배선, `fuzz_row_fields`에 head/body/request 노출 |
+| 21 | Z6 | M | `FuzzAdvancedOverlay`에 `extract`·`m_lines`·`f_lines` 행 + `r.extracted` 컬럼 |
+| 22 | Z3-a | S | 5000행 링과 별개로 실제 `sent`/`hit` 카운터 유지 — 테두리·알림·이벤트 피드가 링 크기를 기록하지 않도록 |
+| 23 | Z7 | M | Fuzzer CONFIG에 처리 파이프라인 행 → `fuzzer_view.cr:941`에서 `processors:`로 전달 |
+| 24 | T3-a | M | 연속 `insert`를 하나의 undo 단위로 합침 — 같은 클래스의 `insert_string`이 이미 패턴 |
+| 25 | O2 | M | `gori run project config export\|import` — 4개 테이블 1문서 |
+| 26 | T5-b | M | Comparer/Fuzzer/Issues/Decoder/JWT에 `goto_symbol` 오버라이드 + `runner.cr`의 5개 `case @search_target` |
+| 27 | R6 | M/L | 분할 비율 영속화 + 방향 플래그 (`half` 계산 지점) |
+| 28 | H1-b | M | 마지막 행에서 `before_id` 기반 load-older |
+| 29 | T4 | L | 히트를 `{line, col}`로 — 스텝이 occurrence 단위가 되고 캐럿이 매치에 안착, regex/대소문자 토글은 파생 |
+| 30 | T1 | L | termisu 포크에서 mode 1002 활성 + motion/release 드롭 중단 (선행 S: press에서 `ev.shift?`를 읽어 anchor 확장) |
+| 31 | Z3-b | L | 기존 `fuzz_runs`/`fuzz_results` writer를 컨트롤러에 배선하고 `restore`에서 로드 |
+| 32 | H3 | L | `flags_for` seam 뒤에 `flow_annotations` + 행 색/코멘트 컬럼 + QL `colour:`/`comment:` |
+| 33 | O4-b | L | capture 정지 → 락 획득 → VACUUM → 재개하는 `project.compact` verb |
+| 34 | T3-b | L | 포크에 bracketed paste(붙여넣은 Tab도 해결) + redo 스택 |
+| 35 | H5-b | L | `Store#search`를 관통하는 `ORDER BY` 선택 + 헤더/키 정렬 사이클 |
+| 36 | R3 | L | 바이트를 담는 Comparer 슬롯 + Repeater/Fuzzer 송신 verb + `Changed` 행 단어 단위 diff |
+
+**정직한 총평:** 상위 19행은 대체로 기계적이고 spec 가능한 작업 일주일치이며, *기만*의 대부분을
+제거한다. 하위 1/3은 진짜 새 표면(스토어 테이블, 업스트림 터미널 변경, ORDER BY seam)이고 어떤
+정렬로도 싸지지 않는다.
+
+---
+
+## 3. 첫 1시간에 걸리는 세 가지
+
+용량 관련 항목(H1, Z3, Z8)은 트래픽이 쌓인 뒤에야 보이므로 이 자리에서 제외했다.
+
+- **T2 — `y`가 64 KiB를 복사하고 성공이라 말한다.** 응답 본문을 밖으로 꺼내는 건 1분차 제스처인데,
+  조작자가 받는 단 하나의 숫자로는 온전한 복사 / 잘린 복사 / 클립보드가 꺼져 있음을 구분할 수 없다.
+- **T1 — 마우스 드래그가 아무것도 선택하지 않는데 마우스는 기본 on이다.** 텍스트를 보면 드래그가
+  첫 본능인데, gori는 캐럿을 옮기고 anchor를 지우며 답한다 — 터미널 자체 선택은 이미 빼앗은 상태로.
+- **T3 — 요청을 붙여넣으면 붙이기 전 상태가 사라지고 `^Z`로 되돌릴 수 없다.** Repeater에 요청을
+  붙여넣는 건 이 도구의 정석 첫 수인데, 현실적인 크기의 요청이면 100칸 undo 스택에서 붙이기 전
+  버퍼가 밀려난다.
+
+차점: **R6** — 80열 터미널의 하드코딩 50/50 분할은 `Authorization` 헤더가 화면에 뜨는 순간 체감된다.
+
+---
+
+## 4. 전체 인벤토리
+
+`[상태/등급]` — CONFIRMED는 인용이 전부 검증됨, PARTIAL은 메커니즘은 실재하나 범위가 축소됨.
+
+### 4.1 프록시 · 인터셉트
+
+**P1. 이미 열린 h2 커넥션에는 인터셉트/Sandbox/M&R 토글이 먹지 않는다** `[CONFIRMED/high]`
+`proxy/tls/tunnel.cr:189`의 `h2_candidate?`가 `sandbox_enabled?`·`intercepts_host?`·`rewriter.active?`
+를 읽는 **유일한** 지점이고, 이건 `tunnel.cr:98`에서 CONNECT당 한 번, 클라이언트 핸드셰이크 **전에**
+실행된다. `proxy/h2/relay.cr:19`의 Relay 생성자는 interceptor/rewriter/scope를 아예 받지 않고,
+`proxy/server.cr:44`에는 커넥션 레지스트리가 없어 토글 시 살아 있는 h2 터널을 회수할 방법이 없다.
+`intercept_controller.cr:316`의 토스트는 "intercept ON — held traffic waits"라고만 하고 이게 **새
+커넥션에만** 적용된다는 힌트가 없다.
+· 지금 비용: 인터셉트를 켜도 브라우저가 이미 h2로 붙어 있으면 아무 일도 안 일어난다. 원인을 모르는
+채 브라우저를 껐다 켜야 한다는 걸 알아내야 한다.
+· Burp: Intercept 토글은 즉시 유효하고, HTTP/2는 프록시가 항상 프레임 단위로 소유한다.
+· 수정: HEADERS 프레임 전달 전에 `h2_candidate?(host)`를 재질의해 false면 GOAWAY로 h1 재협상 유도.
+최소한 토글 토스트에 "applies to new connections" 명시.
+
+**P2. HTTPS 경로의 Sandbox 거부는 gori 어디에도 흔적을 남기지 않는다** `[PARTIAL/high]`
+`proxy/conn/client_conn.cr:1015`의 CONNECT 게이트는 `write_sandbox_block` 후 반환할 뿐
+`record_blocked_request`를 부르지 않는다 — 평문 경로(`client_conn.cr:241`)는 부르고, Aborted 플로우에
+`Outbound::SANDBOX_ERROR`를 실어 남긴다. 투명 리스너(`proxy/server.cr:220`)는 그냥 `close_client`.
+두 줄 위 `server.cr:210`은 SNI 누락을 로깅하며 그 이유를 "a client that mysteriously fails otherwise
+leaves no trace anywhere"라고 적어 뒀다 — 원칙은 이미 서술돼 있고 더 흔한 케이스에 적용만 안 됐다.
+· 범위 축소: 요청 단위 sandbox 차단(터널 내부 HTTPS 포함)은 Aborted 플로우를 남긴다. 흔적이 없는 건
+**요청이 존재하기 전 호스트 레벨에서 거부되는** CONNECT 게이트와 투명 리스너 SNI 게이트뿐.
+· 수정: `FlowSink`에 `on_refused(host, port, reason)` 채널 하나 추가, 두 드롭 지점에서 호출.
+
+**P3. 프록시 거부가 본문 없는 502로 브라우저에 도달해 진단이 화면에 닿지 않는다** `[CONFIRMED/medium]`
+`client_conn.cr:1346` `write_gateway_error`는 `HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n\r\n`.
+정작 필요한 문장은 `client_conn.cr:1093`에 이미 만들어져 있다 — "upstream TLS verification failed:
+host:port — origin certificate not trusted; retry with --insecure-upstream or set SSL_CERT_FILE".
+그게 `record_error`(History 전용)로만 가고 브라우저는 못 받는다. `write_sandbox_block`도 본문 없이
+`X-Gori-Sandbox: blocked` 헤더뿐 — 어떤 브라우저도 안 보여준다. `proxy/conn/self_page.cr`이 이미
+브랜디드 HTML을 raw 소켓에 렌더하므로 기계는 있다.
+· Burp: 프록시 오류를 브라우저 탭에 설명 페이지로 렌더한다.
+
+**P4. 인터셉트 catch 조건에 확장자/MIME 필드가 없고, 요청·응답이 조건 하나를 공유한다** `[CONFIRMED/medium]`
+`intercept_filter.cr:65` `FIELDS = %w(host path method scheme status)`. `:path`는 단순 부분 문자열
+(`:47`)이라 `-path:.js` 우회는 `.json`까지 죽인다. `interceptor.cr:206`/`:215`가 **같은** `@filter`를
+읽어 요청/응답 조건을 다르게 줄 수 없고, `intercept_filter.cr:50`의 `status:`는 `s.status`가 nil이면
+false — 즉 `status:>=500`을 넣는 순간 **모든 요청 보류가 조용히 멈춘다**. 기본값은
+`Direction::Both` + `EMPTY`라 켜는 즉시 in-scope 요청·응답 전부를 잡는다.
+· Burp: 인터셉트 규칙이 요청/응답 각각 별도 테이블이고 파일 확장자·MIME 타입이 1급 필드다.
+
+**P5. Rewriter 미리보기가 request 쪽으로 고정돼 응답 규칙이 "내 규칙이 안 먹네"로 보인다** `[CONFIRMED/low]`
+`rewriter_controller.cr:90`이 `RuleTarget::Request` 리터럴을 넘기고, `rewriter_view.cr:109`는 행마다
+REQ/RES 배지를 그린다 — 응답 규칙이 존재함을 화면이 명시하는데 아래 창은 그걸 실행할 수 없다.
+완화책: 규칙 편집 오버레이는 `rules.preview`로 "affects N of M recent flows"를 보여준다.
+
+**P6. catch 방향·조건이 세션 한정이고, 조건 바의 Esc는 취소가 아니라 삭제** `[PARTIAL/low]`
+`interceptor.cr:81`의 `@direction`/`@filter`는 스토어를 읽지도 쓰지도 않는 평범한 인스턴스 필드다 —
+프로젝트는 scope·sandbox·M&R·host override를 이미 영속화하는데. 공들여 만든 조건을 재시작마다
+다시 친다. (Esc 동작은 결함이 아님: `intercept_view.cr:279`는 `history_view.cr:694`와 정확히 동일한
+`/` 바 관례다.) 부수 효과로 필터가 키 입력마다 라이브 적용돼, 반쯤 친 조건이 실제 트래픽을 지배한다.
+
+**P7. 보류 중인 요청을 Repeater로 보낼 수 없다 — 먼저 origin으로 흘려보내야 한다** `[CONFIRMED/high]`
+`verbs/core.cr:169`~`:241`의 Intercept verb 전체(toggle/forward/drop/forward-all/mark-*/direction/
+filter)에 send-to-anything이 없다. `interceptor.cr:242` `hold_request`는 `flow_id = nil`이라 보류된
+요청은 forward되기 전까지 어떤 플로우 행도 갖지 않는다.
+· 지금 비용: forward → History 탭 전환 → QL 필터 해제 → 행 찾기 → Repeater 키. 그리고 보류는 어느
+쪽이든 풀린다. (편집 자체는 유실되지 않는다 — `client_conn.cr:347-364`가 forward된 결정 바이트를
+캡처하므로 History가 편집된 요청을 그대로 갖는다.)
+· Burp: 인터셉트 창에서 Ctrl+R이면 hold를 유지한 채 Repeater 탭이 생긴다.
+· 수정: `Verb::Scope::Intercept`에 `intercept.repeater` 추가 → Item의 raw 바이트를 기존 public
+`repeater_from_request`(`repeater_controller.cr:1115`)에 전달. 플로우 행 불필요, 바이트는 메모리에 있음.
+
+### 4.2 Repeater
+
+**R1. 마지막 전송 하나만 남는다 — 탭별 요청/응답 이력도, 전송 로그도 없다** `[CONFIRMED/high]`
+`repeater_view.cr:80` `@prev_result`는 diff 기준선 용도 하나, 깊이 2이며 **응답만** 담는다 — 그
+응답을 만든 요청 텍스트는 어디에도 안 남는다. `store/schema.cr:241` `repeaters` 테이블은 탭당
+`request` 컬럼 1개, response_* 1세트. 전송할 때마다 `repeater_controller.cr:797`이 그 한 행을 덮어쓴다.
+· 지금 비용: 페이로드 5개를 순서대로 시험하면 1~3번째의 요청과 응답은 존재하지 않는다. 남기려면
+매번 서브탭을 복제하거나 밖으로 복사해 둬야 한다는 걸 **미리** 알아야 한다.
+· Burp: 탭마다 `<` `>` 화살표로 모든 전송을 왕복하고, 각 전송의 요청과 응답이 짝으로 보존된다.
+· 수정: `repeater_sends` 자식 테이블에 append(현재는 overwrite) + 응답 창에 `[`/`]` 스텝.
+
+**R2. Repeater에 follow-redirect가 없다 — Fuzzer와 Discover에는 있다** `[CONFIRMED/medium]`
+`fuzz/engine.cr:379`가 3xx를 따라가고(`:387`에 구현), TUI(`fuzz_advanced_overlay.cr:32`)와
+CLI(`--follow-redirects`) 양쪽에 노브가 있다. `repeater/engine.cr:36`은 1회 교환 후 반환이고
+`src/gori/repeater/` 어디에도 Location 처리가 없다.
+· 수정: `Fuzz::Engine#follow_redirects`(원격 선택 Location을 P7대로 검증·거부하는 로직 포함)를
+`repeater.follow-redirect` verb 뒤에서 재사용.
+
+**R3. Comparer가 캡처된 플로우만 받고, 줄 단위 diff만 한다** `[CONFIRMED/medium]`
+`runner/comparer.cr:9`가 `FlowPicker.new(store.recent_flows(2000), slot)`이고 슬롯 타입은
+`Store::FlowDetail`. MCP `compare_flows`와 `gori run compare`도 flow id 2개만 받는다. 붙여넣기 입력도
+없다. 그래서 **Repeater 응답이나 fuzz 결과는 영원히 비교 대상이 될 수 없다** — X4에 의해 그 전송들은
+History에도 없으므로 우회로도 없다. `repeater/side_by_side.cr:20-40`의 행은 A줄 전체 대 B줄 전체라
+줄 안쪽 차이 span이 없다.
+· 범위 축소: 한 Repeater 탭의 **연속된 두 전송**은 내장 diff(`d`)로 비교된다. 못 하는 건 임의의 두
+응답이다.
+· Burp: Comparer에 아무 요청/응답이나 붙여넣을 수 있고 word-level diff를 제공한다.
+
+**R4. TARGET 재타겟 시 Host 동기화가 CLI와 TUI에서 다르게 동작한다** `[PARTIAL/medium]`
+`cli/run/repeater.cr:576-586`은 `--target`마다 Host를 다시 쓴다(명시적 `-H Host:`가 없는 한).
+TUI의 `@link_host_to_target`은 `repeater_view.cr:1098` — `load_blank`(^N 빈 탭) **한 곳**에서만
+armed되고 첫 발화 후 영구 해제된다.
+· 범위 축소: 이건 #335에서 기록된 의도적 설계다(캡처되거나 손으로 넣은 Host를 절대 덮어쓰지 않기
+위해). 남은 비대칭은 좁다 — `gori run repeater <flow-id> --target=URL`은 Host를 다시 쓰는데,
+History에서 ^R로 연 뒤 TARGET을 편집하면 안 쓴다. 같은 재타겟 행위가 서피스에 따라 다른 바이트를
+전선에 올린다.
+
+**R5. 스페이스 메뉴의 Toggle diff / Hex dump가 응답 창에 포커스가 없으면 조용히 무반응** `[PARTIAL/medium]`
+`runner/repeater.cr:95`·`:101`이 `return unless v.focus == :response`를 상태 메시지 없이 수행한다.
+verb는 `available: in_repeater`(탭만 확인)로 등록돼 창 포커스와 무관하게 메뉴에 뜬다. 반면 마우스
+경로(`repeater_controller.cr:539`)는 `focus_pane(:response)`를 먼저 호출해 어디서든 동작하고, 형제
+`repeater_toggle_sni`는 침묵 대신 "SNI override (^S) applies to the TARGET pane — ↹ to it"를 낸다.
+· 범위 축소: 도달 경로는 커맨드 팔레트, 그리고 diff에 한해 요청 READ 창의 맨 `d`.
+
+**R6. 요청/응답 분할이 50/50 하드코딩 — 리사이즈·방향 전환·최대화 없음** `[CONFIRMED/medium]`
+`repeater_view.cr:2427` `half = {(content.w - 1) // 2, 1}.max`. 상태도 설정도 없이 매 프레임 폭에서
+계산된다. `settings/display.cr:58`의 레이아웃 prefs에 비율·방향·최대화 항목이 없고, `layout.cr:57`의
+유일한 기하 노브는 `usable?`(폭≥40, 높이≥8)뿐. 좁은 창의 유일한 구제책은 4칸 nudge인 `hscroll_view`.
+· Burp: 창 분할을 드래그로 조절하고 수직/수평 전환과 최대화 버튼이 있다.
+
+**R7. `gori run repeater send`로는 저장된 세션을 읽거나 편집·삭제·재타겟할 수 없다** `[PARTIAL/medium]`
+`cli/run/repeater.cr:301-309`의 플래그 전부: `--project --db -k --diff --allow-unscoped --message
+--idle-ms --format`. `--target`도 `-H`도 `-b`도 `--sni`도 `--http2`도 없다. 그런데 같은 파일
+`:630-637`의 형제 경로(`gori run repeater <flow-id>`)는 그 전부를 파싱한다. `repeater list
+--format=json`은 요청 바이트를 의도적으로 빼고, `update`/`delete` 서브커맨드도 없다.
+MCP는 전체 `update_repeater`(`mcp/tools/repeater.cr:162-180`)를 갖고 있다.
+
+### 4.3 Fuzzer
+
+**Z1. `^A` auto-mark는 § 하나라도 있으면 조용히 거부하고 성공을 보고한다** `[CONFIRMED/high]` **`[FIXED]`**
+`fuzz/template.cr:199` `return text if text.includes?(MARKER)` — 위치가 이미 도출됐는지가 아니라 §
+바이트 **존재** 여부로 중단한다. `fuzzer_view.cr:524`의 `auto_mark`는 그 **변하지 않은** 문자열을
+set_text하고 `@dirty = true`를 세운 뒤 결과의 마커를 세어 "auto-marked N position(s)"를 낸다.
+`fuzzer_controller.cr:941`의 상태줄은 "^A auto-mark · ^K word"를 나란히 광고해 정확히 이 혼합 순서를
+유도한다. 형제 `mark_word`(`fuzzer_view.cr:566`)에는 "no word at the cursor" 가드가 있다 — 이웃한 두
+마킹 verb가 정직성에서 불일치.
+· 수정: `auto_mark`를 멱등으로(clear→derive) 만들거나 전후를 비교해 정직하게 거부.
+
+**Z2. 실패한 전송의 에러 문자열은 계산되지만 어디에도 표시되지 않고, 상세 창은 retention 정책을 탓한다** `[CONFIRMED/high]` **`[FIXED]`**
+`fuzz/engine.cr:90`에서 scope/sandbox 거부는 `Repeater::Result`의 `error`에 이유를 싣고 head는 비운다.
+`fuzz/matcher.cr:284` `present(head)`가 빈 head에 nil을 반환하므로 **`keep_bodies: :all`로도 이유에
+도달할 수 없다**. `fuzzer_view.cr:1845`는 `r.status || (r.error ? "ERR" : "—")`만 그리고, 그 행을 열면
+`:2152`가 "(response not retained — only matched results keep the response)"를 출력한다 — 실제로
+일어난 전송 실패 대신 retention 정책을 지목한다(그 정책은 TUI가 노출하지도 않는다).
+`cli/output.cr:297`은 같은 실행에서 `r.error`를 행마다 붙여 CLI는 자기설명적이다.
+
+**Z3. 스윕 결과는 메모리 전용 — 다음 ^R이 지우고, 5000개에서 잘리고, 그 캡이 실행 크기로 보고된다** `[CONFIRMED/high]`
+`fuzzer_view.cr:98` `@results`는 뷰에만 산다. `restore()`(`:226`)는 target/template/config만 재구성
+하므로 gori를 끄면 완료된 모든 실행의 모든 행이 사라진다. `:662` `begin_run`이 `@results.clear`를
+호출해 두 번째 워드리스트를 시도하는 순간 첫 실행이 제자리에서 파괴된다. `:690` `RESULT_CAP = 5000`
+에서 `@results.shift`로 오래된 행이 화면 고지 없이 축출된다. 그리고 `:1810`에서 실행이 끝나면
+RESULTS 테두리가 진짜 `p.sent`에서 `"#{result_count} sent"`로 바뀌어 20만짜리 cluster bomb이
+"running 200000/200000" → **"5000 sent"**로 스냅된다. 그 잘린 숫자가
+`fuzzer_controller.cr:818`을 통해 완료 알림과 **append-only 이벤트 피드**에도 들어가므로 영속 감사
+기록까지 틀린다.
+· 미배선 seam: `store/fuzz_runs.cr`의 `insert_fuzz_run`/`insert_fuzz_result`/`fuzz_results`가 완전히
+구현돼 있고 `store/schema.cr:315`에 `extracted` 컬럼까지 있으며 `store/compact.cr:171`에 retention
+정책도 있다. **프로덕션 호출자 0개.**
+· Burp: Intruder 공격은 저장·재개 가능하고 결과 테이블은 실행 크기를 정확히 보고한다.
+
+**Z4. fuzz 결과 행에서 Repeater로 보낼 수 없다 — Miner→Repeater도 Repeater→Fuzzer도 있는데** `[CONFIRMED/high]`
+`verbs/history.cr:440`에 `repeater.fuzz`("Send to Fuzzer")가 있고 `:554`에 `mine.repeater`가 있다.
+Fuzzer 스코프의 verb 전체(run/stop/new/automark/chain/list-paste/pretty/http2/clear-marks/copy/
+link-issue/link-note)에는 되돌아가는 핸드오프가 없다. 필요한 조각은 다 있다:
+`fuzzer_view.cr:2139` `detail_request_bytes`가 선택된 결과의 정확한 전선 요청을 이미 재구성하고,
+`fuzzer_controller.cr:803-805`는 `Fuzz::Result`에서 `Store::RepeaterRecord`를 이미 만든다.
+`runner/miner.cr:54`의 구현은 3줄이다.
+· 지금 비용: 흥미로운 히트를 손으로 파고들려면 페이로드를 눈으로 읽고 Repeater 탭을 새로 만들어
+요청을 다시 조립해야 한다 — 퍼징의 핵심 루프인데.
+
+**Z5. RESULTS가 페이징·점프를 못 하고, 정렬은 전진 사이클·오름차순 전용** `[CONFIRMED/medium]`
+`tab_controller.cr:216` `body_scroll`은 기본 false이고 FuzzerController가 오버라이드하지 않아
+PageUp/PageDown/Home/End가 무효다 — History(`:159`)·Issues·Sitemap·Probe·Discover는 전부 구현했으므로
+Fuzzer만 예외다. `fuzzer_controller.cr:465`는 ↑/↓/j/k/↵/o/m/v만 바인딩(g/G도 half-page도 없음).
+`fuzzer_view.cr:1024` `cycle_sort`는 `(i + 1) % 5`로 전진만 하고 방향이 없으며, `:1180`의 모든 분기가
+맨 `sort_by`라 **가장 큰 응답·가장 느린 응답·가장 높은 상태 코드가 언제나 목록 맨 아래**에 있다.
+· Burp: 결과 테이블 헤더 클릭으로 양방향 정렬, 스크롤·점프 자유.
+
+**Z6. Grep-Extract는 엔진·CLI·MCP에서 동작하는데 TUI에는 노브도 컬럼도 없다** `[CONFIRMED/medium]`
+`fuzz/matcher.cr:79` `property extract : Regex?`가 응답마다 평가돼 모든 Result의 `extracted`에 실린다.
+CLI `--extract`(`cli/run/fuzz.cr:79`)는 `cli/output.cr:296`에서 `⟦value⟧`로 행마다 찍고, MCP도
+노출한다. `fuzz_advanced_overlay.cr:27-42`의 필드 전체 목록에 extract가 없고 `--ml`/`--fl`에 대응하는
+match/filter **lines**도 없다. 결정적으로 `fuzzer_view.cr:1391`/`:1421`은 `extract`를 세션 JSON으로
+직렬화하고 복원한다 — **설정할 방법을 주지 않는 노브를 성실히 왕복시킨다.**
+
+**Z7. 페이로드 인코딩이 마커 단위뿐 — 위치마다 ^Y 왕복 1회 vs `--encode=url` 한 번** `[CONFIRMED/medium]`
+`fuzz/plan.cr:71` `PlanOptions#processors`는 "the processing pipeline applied to EVERY set (all three
+surfaces share one list)"라고 문서화됐는데, `fuzzer_view.cr:941`의 TUI `PlanOptions.new`는
+`processors:`를 넘기지 않아 **TUI에서는 이 공유 파이프라인이 항상 비어 있다**. CLI는
+`--prefix/--suffix/--encode/--case/--hash/--regex-replace`를, MCP는 같은 목록을 배열로 받는다.
+TUI의 유일한 등가물은 마커당 `¦chain`이고, 그 편집기는 ^Y로 열려 커서 아래 마커에만 작용하며 이동
+전에 두 번째 ^Y로 커밋해야 한다.
+
+**Z8. `gori run fuzz`는 `keep_bodies: :none` 하드코딩이라 헤드리스 스윕이 응답을 절대 못 보여준다** `[CONFIRMED/high]`
+`cli/run/fuzz.cr:35`와 `:105` 두 곳에 리터럴로 박혀 있고, 40개 플래그 파서 어디에도 이걸 바꾸는 게
+없다(`max_requests`도 마찬가지). TUI는 `:matched`(`fuzzer_view.cr:80`)라 히트의 전체 응답을 보관하고,
+MCP는 `record_history: none|matched|all`로 노출한다. `cli/output.cr:102` `fuzz_row_fields`에 head도
+body도 rendered request도 없다 — `Fuzz::Result#body`가 항상 nil이므로 찍을 코드 경로 자체가 없다.
+· 지금 비용: CI나 스크립트에서 스윕을 돌리면 상태·길이·단어 수만 얻는다. 히트의 본문을 보려면 TUI를
+열어 처음부터 다시 돌려야 한다.
+
+### 4.4 History · QL · Sitemap
+
+**H1. 최신 1000건만 보이고 페이징이 없다** `[PARTIAL/high]`
+`history_view.cr:29` `PAGE = 1000`, `:281`의 `reload`는 커서 인자 없이 `store.search(combined, PAGE)`
+를 호출한다. 정작 `store/reads.cr:40` `Store#search`는 `before_id` 커서를 이미 받는다 —
+`grep -rn 'before_id' src/gori/tui/`는 0건이고 유일한 사용처는 `mcp/tools/flows.cr:25`다.
+· 범위 축소: 잘림이 무신호는 아니다. 필터가 활성일 때 바 칩이 `1000+`로 표시되고
+(`history_view.cr:1908-1912`), 그 주석이 "so the count isn't silently misread as the exact match
+total"이라고 의도를 명시한다. 또 `MAX_ROWS = 5000`이라 라이브 캡처는 PAGE 너머로 append된다.
+진짜 공백은 좁다: (a) **필터가 없으면 카운트 칩이 아예 안 그려지고**, (b) `1000+` 경고를 봐도
+나머지에 도달할 어포던스가 없다 — 탈출구는 다른 터미널의 `gori run history --limit`이나 MCP뿐.
+
+**H2. 컴파일되지 않는 QL 항이 조용히 드롭되어 필터를 넓히는데, 바에는 그대로 남는다** `[CONFIRMED/high]`
+`history_view.cr:305-311` `query_note_for`는 두 경우만 보고한다 — 모든 항이 무효일 때, 그리고 정규식이
+무효일 때. **부분 드롭은 nil을 반환한다.** `ql.cr:173-180` `QL.analyze`가 항별 applied/ignored/
+invalid_regex를 이미 반환하는데 `src/gori/tui`·`src/gori/cli` 어디서도 호출하지 않는다(유일한 호출자
+`mcp/tools/ql.cr`). `ql.cr:87-94`의 내장 REFERENCE는 위험을 자기 입으로 적어 뒀다 — 드롭된 항은
+결과를 **넓히고**, "use strict:true (or ql_explain) to see exactly which terms were dropped before
+relying on results".
+· 재현: `host:acme proto:h2 status:>=50O` → `proto:`는 http/ws/websocket/grpc/sse만 파싱하므로
+(`proto.cr:28-36`) `h2`는 사라지고, 알파벳 O가 섞인 status 항도 사라진다. acme 트래픽 **전부**가
+표시되는데 바는 전체 쿼리를 문법 색으로 되읽어 준다(`:1928-1933`). h2 5xx라고 믿고 목록을 훑는다.
+· Burp: 필터가 체크박스와 고정 드롭다운이라 오타로 필터가 넓어질 방법이 없다. Caido는 파싱 안 되는
+항을 입력 중에 인라인으로 밑줄 친다.
+· 수정: `query_note_for`에서 기존 `QL.analyze`를 돌려 "ignored: proto:h2 …"를 **필터 바에** 렌더.
+빈 결과 화면만으로는 부족하다 — 넓어진 쿼리는 결코 비지 않는다.
+
+**H3. 영속 플로우 주석이 없다 — mark는 세션과 함께 죽고 행에는 색도 코멘트도 없다** `[PARTIAL/high]`
+`history_view.cr:71` `@marks`는 뷰 로컬 `Set(Int64)`이고 mark API에 스토어 왕복이 없다. 렌더되는 행
+(`:1514-1530`)은 TIME/METHOD/PROTO/HOST/PATH/STA/TYPE/SIZE/DUR — 주석 컬럼이 없다.
+`store/reads.cr:363` `flags_for`는 빈 배열을 반환하는 스텁("the call site is the seam")이고 QL `flag:`
+는 매치할 게 없어 free-text로 떨어진다.
+· 범위 축소: 영속 주석이 아예 없진 않다 — Link-to-note / Link-to-issue(`verbs/links.cr:31-36`)가 있고
+mark 집합에 대해 배치로 동작한다. 없는 건 **행 색과 인라인 코멘트**이며, 그래서 분류를 마친 플로우가
+다음 실행에서 안 한 것과 시각적으로 동일하다.
+· Burp: 행 하이라이트 색 6종과 행별 자유 텍스트 코멘트가 기본이고, 둘 다 필터 가능하다.
+
+**H4. Sitemap은 엔드포인트를 보여주지만 그 바이트는 절대 안 보여준다** `[CONFIRMED/medium]`
+`verbs/sitemap.cr:6-104`의 verb 전체(이동/토글/전개/접기/query/mark/tag/fold ids/scope lens/discover/
+send-to-Repeater)에 플로우를 여는 게 없다. 두 절반이 모두 이미 존재한다:
+`store/reads.cr:95` `representative_flow_id(host, method, target)`는 트리 노드를 실제 flow id로 이미
+해석하고(`runner/sitemap.cr:59`가 프로덕션 사용 중), `history_view.cr:763` `open_detail_id`는 목록
+선택과 무관하게 아무 플로우나 연다(`runner/issues.cr:163`이 이미 그렇게 쓴다). 배선만 없다.
+· 지금 비용: 트리에서 흥미로운 엔드포인트를 찾으면 History로 가서 그 경로의 QL 필터를 다시 친다.
+
+**H5. SIZE 컬럼은 응답 전용인데 `size:`는 요청+응답이고, 어떤 컬럼도 정렬되지 않는다** `[PARTIAL/medium]`
+`history_view.cr:1458`이 "SIZE" 헤더를 그리고 `:1529`의 셀은 `fmt_size(row.response_size)`. `ql.cr:
+264-273`의 `size:`는 `(request_size + COALESCE(response_size, 0))`로 컴파일된다. 같은 바의
+FILTER_HINT(`:50`)가 `size:>10000`을 광고한다 — 화면의 숫자와 비교식이 어긋난다.
+`store/reads.cr:54`의 모든 목록 쿼리는 `ORDER BY id`로 끝나고 유일한 노브는 newest/oldest다.
+· 범위 축소: 컬럼과 일치하는 필드 `respsize:`는 `QL_FIELDS`에 있어 **Tab 완성은 된다**. 문제는
+FILTER_HINT가 어긋난 쪽을 광고한다는 것과, 정렬이 없다는 것.
+
+**H6. History 필터의 Tab 완성이 절대 매치될 수 없는 `flag:`를 제안한다** `[CONFIRMED/medium]` **`[FIXED]`**
+`history_view.cr:43` `QL_FIELDS`에서 f로 시작하는 유일한 항목이 "flag"이고, `:723-729`의
+`query_complete`가 `sugg.first`를 끼워 넣으므로 `f` + Tab은 **결정적으로** `flag:`를 만든다.
+`ql.cr:229-237`에는 flag 필드가 없어 토큰 전체가 free-text로 떨어지고, 그 주석은 gori가
+"has no flow-flag store yet … rather than advertising an unimplemented filter"라고 적혀 있다 —
+`:43`이 바로 그걸 광고하는 동안. 반대로 실제 동작하는 `url:`은 `QL_FIELDS`에 없어 제안되지 않는다.
+
+### 4.5 TUI 조작
+
+**T1. 마우스 드래그가 아무것도 선택하지 않고, 마우스 모드가 기본으로 터미널 선택을 빼앗는다** `[PARTIAL/high]`
+`runner.cr:1179` `return unless ev.press? || ev.wheel?` — motion과 release가 버려져 드래그는 최초
+press 외에 아무것도 관측되지 않는다. `read_cursor.cr:120` `click_to_cursor`는 `@anchor = nil`로
+끝나므로 드래그를 시작하는 press가 **기존 선택을 능동적으로 지운다**. 애초에
+`lib/termisu/.../terminal.cr:732-733`의 `enable_mouse`가 mode 1000(press/release)과 1006(SGR)만
+요청하고 1002/1003 button-motion tracking을 켜지 않아 터미널이 드래그 이벤트를 보내지도 않는다.
+그리고 `settings/display.cr:11` `DEFAULT_MOUSE = true` — 즉 박스에서 꺼내자마자 이 상태다
+(`display.cr:56`의 주석 자체가 "off restores native text-selection"이라고 인정한다).
+· 앱 쪽 기계는 이미 있다: `ReadCursor`에 anchor/extend/selection_text/highlight_spans가 있고 모든
+read 창이 하나씩 소유한다. 없는 건 이벤트 소스와 라우팅뿐.
+· 선행 S: press에서 `ev.shift?`를 읽어 anchor를 리셋하는 대신 확장.
+
+**T2. `y`가 최대 64 KiB만 복사하고 잘린 바이트 수를 복사 크기처럼 보고한다** `[CONFIRMED/high]` **`[FIXED]`**
+`clipboard.cr:41`이 `MAX_CLIP = 64 * 1024`에서 조용히 자른다. `Clipboard.copy`는 실제 기록 바이트를
+반환하며 주석이 "so callers can compare against the source size and report when the copy was
+clipped"라고 명시한다 — **그런데 절반의 호출자가 비교하지 않는다.**
+
+| 잘림을 보고함 | 보고하지 않음 |
+|---|---|
+| `repeater_controller.cr:617` (copy-all) | `repeater_controller.cr:602` (`y` copy) |
+| `history_controller.cr:446`, `:460` | `history_controller.cr:541` |
+| `issues_controller.cr:456` | `issues_controller.cr:441` |
+| `project_controller.cr:413` | `project_controller.cr:398` |
+| `decoder_controller.cr:518`, `runner.cr:1698` | `jwt_controller.cr:630` |
+
+같은 파일 안에서 14줄 떨어진 두 경로가 잘림을 언급할 가치가 있는지를 두고 불일치한다.
+추가로 `clipboard.cr:36` `return 0 unless Settings.clipboard_osc52?` — 클립보드를 설정에서 꺼 두면
+모든 경로가 "copied 0b to clipboard"라고 말한다. **0을 특별 처리하는 호출자는 하나도 없다**
+(`grep -rn 'written == 0' src/gori/tui/` → 0건). 즉 하나의 숫자로 온전한 복사 / 잘린 복사 / 꺼진
+클립보드를 구분할 수 없다.
+· 수정: 잘림 보고를 `Clipboard` 안으로(또는 공통 헬퍼로) 올려 구조적으로 누락이 불가능하게 하고,
+비활성 상태를 별도 메시지로 분리.
+
+**T3. 요청을 붙여넣으면 붙이기 전 상태가 파괴된다 — `^Z`로 못 돌리고 redo도 없다** `[CONFIRMED/medium]`
+`paste_newline.cr:7`이 "gori enables no bracketed-paste mode"라고 적어 뒀다 — 붙여넣기가 N개의 독립
+키 이벤트로 도착해 타이핑과 구분되지 않는다. `text_area.cr:164` `insert(ch)`는 **문자마다**
+`push_undo`를 호출하고, `:1008`은 `@undo_stack.shift if @undo_stack.size > 100` — 100자를 넘는 순간
+붙이기 전 버퍼가 가장 오래된 항목으로 축출된다. `runner.cr:731`의 `CHAR_DRAIN_CAP`은 **렌더링**만
+합치고 각 문자는 이미 자기 `push_undo`를 통과한 뒤다. 그리고 `text_area.cr:1011` `undo`가 유일한 이력
+연산 — `redo`는 `src/` 어디에도 없다.
+· 수정: 연속 `insert`를 하나의 undo 단위로 합침 — 같은 클래스의 `insert_string`/`insert_pair`가 이미
+그 패턴이다. 장기적으로는 포크에 bracketed paste(붙여넣은 Tab 문제도 함께 해결).
+
+**T4. `^F`가 텍스트가 아니라 줄을 찾는다 — minified 본문은 히트 1개, 매치는 화면 밖** `[CONFIRMED/medium]`
+`text_area.cr:479` `hits << i if l.includes?(q)` — 매칭되는 **줄**마다 인덱스 하나이므로 한 줄의 세
+occurrence가 히트 하나다. `runner.cr:2635` `search_step`은 줄 인덱스를 순회하므로 같은 줄의 두 번째
+매치에 영원히 도달할 수 없고, `:2650` `jump_to_match`가 하는 일은 줄 번호로 이동하는 것뿐이다.
+`repeater_view.cr:2385` `goto_response_line`은 `@resp_cursor.sync(cy, 0)` — **0열**이며 매치 쪽으로
+수평 스크롤을 조정하지 않는다. 쿼리는 항상 `Regex.escape` + IGNORE_CASE라 정규식도 대소문자 토글도
+없다.
+· 지금 비용: 1줄짜리 4 MB JSON 응답에서 `^F`는 "1 hit"라고 말하고 커서를 0열에 놓는다. 매치는 화면
+어딘가 오른쪽에 있고 도달할 방법이 없다.
+
+**T5. `^F`/`^G`가 Comparer·Fuzzer·Issues 노트·Decoder·JWT 탭에서 조용히 아무 일도 안 한다** `[CONFIRMED/medium]`
+`tab_controller.cr:553-555`의 기본 `goto_symbol`이 nil을 반환하고, 오버라이드는 repeater·project·
+intercept·notes(+위임하는 target) 넷뿐이다. `runner.cr:973`에서 nil 타깃이면 가드가 그냥 통과하고,
+`^F`는 keymap이 바인딩을 거부하는 예약 코드(docs "Reserved Keys")이므로 **토스트도 상태줄도 설명도
+없이** 아무 일도 일어나지 않는다. Repeater에서 되니 반사가 생기는데 다섯 탭에서 죽는다.
+· 최소 조치(S): `goto_target`이 nil이면 키를 삼키는 대신 "find is not available in this pane" 토스트.
+
+### 4.6 크로스 서페이스 · 무음 실패
+
+**X1. 프로젝트별 upstream proxy·타임아웃·capture cap이 TUI에서만 로드된다** `[PARTIAL/high]`
+`settings/network.cr:170`은 이 계층을 "a RUNTIME layer set by Session.open from the OPEN project's
+DB"라고 선언한다. `session.cr:57-62`가 `PROJECT_CONNECT_TIMEOUT_KEY`/`PROJECT_IO_TIMEOUT_KEY`/
+`PROJECT_CAPTURE_MAX_KEY`/`PROJECT_UPSTREAM_KEY`를 읽는 유일한 지점이다.
+`cli/run.cr:273-279` `open_store`는 `Env.load_project(store)`만 수화하고, MCP(`mcp/tools.cr:210`)도
+마찬가지다. `settings/upstream_rules.cr:104`에서 `project_upstream_proxy`는 **최우선순위**이므로
+로드되지 않은 핀은 조용히 규칙 테이블 → 전역 스칼라 → 직접 다이얼로 강등된다.
+· 범위 축소: `gori run capture`는 `Session.open`을 쓰므로 로드된다. 못 하는 건
+`gori run fuzz/mine/sequence/repeater/discover`와 `gori mcp`.
+· 지금 비용: TUI에서 프로젝트에 업스트림 프록시를 핀했는데 헤드리스로 같은 스윕을 돌리면 프록시를
+우회해 직접 나간다. 아무 경고도 없다.
+
+**X2. `gori run mine`·`gori run sequence`가 전량 거부돼도 exit 0이고 거부 문자열을 버린다** `[CONFIRMED/high]` **`[FIXED]`**
+`miner/engine.cr:185` `@errors += 1 unless raw.error == CAP_ERROR` — 전송별 에러 **문자열**을 세고
+버린다. `cli/run/mine.cr:185`의 `exit 1 if had_error`는 오케스트레이션 raise(`Miner::ErrorEvent`)로만
+세워지고 실패·차단된 전송으로는 세워지지 않는다. `cli/run/sequence.cr:205`도 동일하고 `:216`은 갖고
+있는 에러 카운트조차 출력하지 않는다. `miner/baseline.cr:115`는 캘리브레이션이 전멸해도 "baseline
+unreachable" 경고 하나 남기고 워드리스트 전체를 태운다.
+· `cli/run/fuzz.cr:212`에는 #410에서 부여된 백스톱(`exit 1 if matched == 0 && errored > 0`)이 있다 —
+mine과 sequence는 못 받았다.
+· 지금 비용: CI에서 스코프 오타 하나로 3200건 전량 거부돼도 "no hidden parameters found" + exit 0.
+파이프라인은 초록이고 결론은 "숨은 파라미터 없음"이다.
+
+**X3. `--allow-unscoped`를 두 번째 게이트가 뒤집는데 메시지 전체가 "blocked by scope"다** `[CONFIRMED/medium]` **`[FIXED]`**
+`outbound.cr:200-205` `sweep_block`이 `sandbox_blocks?`와 `excluded?`를 구분 불가능한 하나의 판정으로
+뭉개고 `SCOPE_ERROR = "blocked by scope"`(`:35`)를 반환한다 — 조작자가 방금 `--allow-unscoped`로
+면제한 Layer 1과 **같은 문구**다. 형제 `send_block`(`:212-217`)은
+`SANDBOX_ERROR = "blocked by sandbox (out of scope)"`로 구분하니 사내 모델이 있다.
+도움말도 어긋난다: `cli/run/fuzz.cr:83`·`mine.cr:49`·`sequence.cr:60`은 "Send even if the target is
+outside the project scope"라고만 하고, `repeater.cr:305`만 "(Sandbox/exclude still apply)"를 붙인다.
+Layer 1 중단(`cli/run.cr:356`)은 게이트와 탈출구를 둘 다 말한다 — "add a scope include rule or pass
+--allow-unscoped".
+· 실측: Layer 1 거부 메시지는 실제로 훌륭하다(§5 참조). 문제는 Layer 2다.
+
+**X4. TUI/CLI의 Repeater·Fuzzer 전송은 History에 흔적을 남기지 않는다 — MCP는 남긴다** `[PARTIAL/medium]`
+`grep -rn insert_flow src/gori`의 결과는 프록시 `proxy/sink.cr:34-36`과 MCP 두 곳
+(`mcp/tools/send.cr:207`, `mcp/tools/fuzz.cr:106`)뿐이다. `repeater_controller.cr:1382-1389`의 주석이
+직접 말한다 — Repeater의 ^R/send-group/WS/minimize는 "dial Repeater::Engine/H2Engine/WsEngine
+straight from the TUI, bypassing ClientConn's per-request gate entirely", 즉 History를 쓰는
+`Proxy::Sink`를 우회한다.
+· 범위 축소: MCP도 `send_request`만 기본 기록이고 `fuzz_start`의 `record_history`는 기본 `none`이다.
+그리고 History 밖에는 부분 흔적이 있다(Repeater 탭의 마지막 응답 슬롯).
+· 지금 비용: 교전 후 "내가 정확히 뭘 보냈나"를 재구성할 수 없다. Repeater 전송은 감사 대상 트래픽인데
+감사 기록이 없다.
+
+### 4.7 온보딩 · 프로젝트 상태
+
+**O1. Sandbox가 켜진 상태에서 마지막 scope INCLUDE를 지우면 프록시가 블랙홀이 되는데, 모든 서피스가 평범한 성공을 보고한다** `[CONFIRMED/high]` **`[FIXED]`**
+위험 확인 대화는 **켜는 엣지에서만** 뜬다 — `runner.cr:3988` `if !@scope.sandbox? && @scope.
+include_count == 0`. 이미 켜진 scope는 다시 검사되지 않는다.
+`project_controller.cr:459` `scope_delete_rule`은 "removed scope rule: <pattern>"만 토스트하고
+`include_count`도 `sandbox?`도 보지 않는다 — 55줄 아래 `:519` `toast_sandbox_state`는 보는데.
+`cli/run/project.cr:525`도 "Scope rule #N deleted successfully."뿐이고 같은 파일 `:650`은 sandbox
+활성화 엣지에서 크게 경고한다. MCP `delete_scope_rule`은 `{id, deleted:true}`를 반환하고 `set_sandbox`
+는 동일한 결과 상태에 대해 전용 `blocks_all` 필드를 낸다.
+결정타: `project_view.cr:1360`의 실시간 "⚠ no scope → ALL blocked" 표시는 PROJECT SETTINGS 창에
+있는데 `:878`의 render는 한 번에 카드 하나만 그린다 — **SCOPE 창에서 룰을 편집하는 동안 그 경고는
+화면 밖이다.**
+· 지금 비용: 규칙 정리를 하다가 마지막 include를 지운다. "removed scope rule"을 본다. 그때부터
+브라우저의 모든 요청이 조용히 죽는다. 프록시가 고장 났다고 결론 내리기까지의 시간 전부가 비용이다.
+· 참고: fail-closed 자체는 Burp의 "빈 스코프 = 전부 허용"보다 **더 나은 기본값**이고 DESIGN.md §7에
+기록된 결정이다("a rule-less scope is not an absent one"). 고칠 건 정책이 아니라 write 경로의 침묵이다.
+
+**O2. 프로젝트 설정(scope·M&R·env·host override)을 내보내거나 두 번째 프로젝트로 복사할 수 없다** `[PARTIAL/high]`
+`cli/run.cr:171-177`의 `gori run project` 표면 전체는 list/create/delete/scope/sandbox/env/
+host-override — export도 import도 없다. `settings.cr:303`의 설정 프로파일 seam은 명시적으로 "a
+settings subset", 즉 전역 settings.json의 섹션들이지 프로젝트 DB가 아니다. `session.cr:68-70`의
+`Rules.load`/`Scope.load`/`HostOverrides.load`는 전부 프로젝트별 스토어를 읽으므로 프로파일이 나를 수
+있는 파일 안에 없다. `project_picker.cr:45-50`의 액션 메뉴는 Open/Rename/Compress/Delete — duplicate도
+clone도 copy-config도 없다.
+· 범위 축소: 오늘도 스크립트로는 된다 — `gori run project scope|env|host-override --format=json`과
+`gori run rewriter --format=json`이 네 테이블을 덤프하고 대응하는 add 명령이 있다. 없는 건 단일 문서
+왕복과 클론 액션.
+· Burp: 프로젝트 옵션을 JSON으로 내보내고 다른 프로젝트에 불러온다. 팀 표준 설정을 공유하는 기본 경로다.
+
+**O3. retention이 오래된 캡처를 조용히 지우고, 유일한 흔적은 `~/.gori/gori.log`의 한 줄** `[CONFIRMED/medium]`
+`store.cr:166` `RETENTION_DEFAULT = 100_000`이 캡처를 소유하는 모든 open에 기본 적용된다.
+`store.cr:590` `log_retention_drop(dropped) if dropped > 0`이 스윕의 **유일한** 출력이고 —
+이벤트 채널에 아무것도 발행하지 않고 카운터도 올리지 않는다 — `:598`에서 `::Log.info`로 나가
+`app.cr:67`이 지정한 `<GORI_HOME>/gori.log`에 쌓인다. TUI는 그 파일을 읽지도 표시하지도 않는다.
+· 선례가 바로 옆에 있다: `store.cr:235` `write_failures`는 스토어가 서피스를 모른 채 노출하는
+`Atomic(Int32)`이고, `runner.cr:435`의 렌더 루프가 매 틱 폴링해 빨간 상단 바 칩을 띄운다.
+· 수정: `retention_dropped : Atomic(Int64)`를 옆에 두고 `prune`에서 증가 — `store/`의 서피스 무지
+(§2.1)를 지키면서 기존 폴링이 알림으로 바꿔 준다.
+
+**O4. 디스크 회수에 세션 종료가 필요하고, 세션 중 "Clear history"는 모든 플로우를 지우고 0바이트를 회수한다** `[CONFIRMED/medium]`
+`store/compact.cr:15-18`의 문서: compaction은 "runs against a project that is NOT open in this
+process — the ProjectPicker triggers it before any Store/session exists"이고 그동안 capture lock을
+잡는다. `:113` `return nil unless lock`이라 열린 세션(`session.cr:100`이 그 락을 쥠)에서는 `Store.
+compact`가 아예 거부한다. `project_picker.cr:597` `start_compress`는 피커의 SPACE_ENTRIES에서만 닿고
+verb 레지스트리·`cli/run/`·`mcp/tools/` 어디에도 compact 진입점이 없다.
+`store/reads.cr:193-208` `clear_flows`는 DELETE와 FTS delete-all만 하고 VACUUM을 안 하므로 SQLite가
+해제된 페이지를 파일에 그대로 둔다. `history_controller.cr:521`의 피드백은 "history cleared" 한 줄 —
+디스크 크기가 그대로라는 말은 없다.
+· 지금 비용: 디스크가 찬다. History를 비운다. "cleared"를 본다. 파일 크기는 그대로다. 실제 회수는
+gori를 끄고 프로젝트 피커에서 Compress를 골라야 한다는 걸 알아내야 한다.
+
+**O5. "Open browser"에 키 바인딩이 없고, 언급 자체가 첫 플로우 뒤 사라진다** `[CONFIRMED/medium]`
+`verbs/core.cr:70-74`의 주석이 "Palette-only (no chord — used rarely)"라고 적혀 있고 `Verb::Chord`
+없이 등록된다 — 팔레트를 열어 검색해야만 닿는다. 그런데
+`traffic_empty_state.cr:426` `draw_palette_hint`는 "Open browser" 라벨 옆에 ` ^P ` 칩을 그려 **팔레트
+코드를 마치 브라우저 코드인 양** 광고한다. 그 카드는 `history_view.cr:1466-1482`에서 `@rows.empty?`
++ 쿼리 없음 + scope 렌즈 비활성일 때만 그려지므로 **플로우 하나가 도착하는 순간 사라진다**.
+Project 탭의 "first run — … ^P: Open browser · Export CA certificate" 표지판도
+`project_view.cr:901-905`에서 `@flow_count == 0`에 걸려 있다.
+· 그리고 첫 실행 마법사(`setup_wizard.cr:30-34`)의 단계는 Bind / Appearance(테마) / Review뿐 —
+**CA도, 미리 신뢰된 브라우저도 언급하지 않는다.** (실측 §5.2에서 확인)
+· Burp: "Open browser"가 항상 있는 1급 버튼이고, 그 Chromium은 CA를 이미 신뢰한다. 신선한 설치에서
+첫 HTTPS 요청까지 인증서 작업이 0이다.
+
+---
+
+## 5. 빌드한 바이너리로 직접 재현한 것
+
+`shards install && shards build` → `bin/gori`. 격리된 `GORI_HOME`, :18099 raw-echo origin,
+:18100의 4.3 MB JSON, tmux 180x46(120/100/80으로 리사이즈).
+
+**E1. `gori tui`에 `--project NAME`이 없다 — `--db PATH`뿐.**
+`gori tui --help`의 플래그: `-l/--listen`, `-p/--port`, `--db=PATH`, `--ca-dir`,
+`--insecure-upstream`. 반면 모든 `gori run <sub>`은 `--project NAME`을 받는다. 셸에서 이름 붙은
+프로젝트로 TUI를 열려면 먼저 `gori run project list`로 sqlite 경로를 알아내야 한다. gori는 이름 있는
+프로젝트 레지스트리를 갖고 있는데 두 서피스 중 하나만 그걸 쓸 수 있다.
+
+**E2. `--db`와 `--port`를 명시해도 첫 실행 마법사가 뜬다.**
+신선한 `GORI_HOME`에서 `gori tui --db <path> --port 8071`을 띄우면 2단계 마법사(bind IP/port → 테마)가
+먼저 열린다. 마법사가 묻는 두 가지를 방금 커맨드라인으로 줬는데도. 같은 `GORI_HOME`으로 `gori run`을
+아무리 써도 설정 완료로 표시되지 않는다.
+
+**E3. 마법사의 키 힌트가 "next"를 중의적으로 쓴다.**
+푸터는 `↵ next · ↑/↓ field · esc skip`. 1단계(Bind IP / Bind Port)에서 첫 필드에 `↵`를 누르면 힌트가
+`↑/↓`에 귀속시킨 동작인 **두 번째 필드**로 간다. 2단계에 가려면 `↵`를 한 번 더 눌러야 한다.
+"next"가 커서 위치에 따라 필드도 되고 단계도 되는데 힌트는 그 말을 안 한다.
+
+**E4. 마법사는 CA 신뢰를 전혀 다루지 않는다 — 첫 HTTPS 캡처를 막는 유일한 단계인데.**
+단계: (1) bind IP/port, (2) 테마, 그리고 가이드 투어를 제안하는 리뷰 카드. 루트 CA 신뢰는 Project 탭
+배너(`^P: Open browser · Export CA certificate`)와 `gori.proxy` 자체 페이지에 맡겨진다 — 그 배너는
+O5대로 첫 플로우와 함께 사라진다.
+
+**E5. 폭 때문에 잘린 탭은 `⋯ N` 카운트에 잡히지 않는다.**
+`chrome.cr:147-151` `more_label`은 `⋯ #{hidden_count}`를 렌더하고 그 카운트는
+`hidden_tabs`/`split_tabs`(`:128-146`)에서 온다 — **settings:tabs prefs로 숨긴 탭만** 센다.
+200 → 120 → 100 → 80열로 리사이즈하는 동안 배지는 매 폭에서 `⋯ 4`로 고정인데 보이는 탭은 13개에서
+7개로 줄었다. 폭에 밀려난 탭은 `‹` 오버플로 셀(`:160`)로만 표시되고 어디에도 집계되지 않는다.
+80열에서는 조작자가 숫자 단서를 못 받는 탭이 6개다.
+· `more_label`의 버그가 아니다 — 문서대로 동작한다. 마찰은 "이 탭이 안 보인다"의 서로 다른 두 종류가
+하나의 어포던스와 하나의 카운트를 공유한다는 점이다.
+
+---
+
+## 6. 보정 — 이미 잘 되어 있는 것
+
+불평 목록만 있으면 눈금이 어긋나므로, 실측으로 확인한 강점을 함께 남긴다.
+
+**엔진 속도는 문제가 아니다.** 4.3 MB JSON 본문에 대한 `gori run repeater send`가 프로세스 시작 · DB
+open · 전송 · JSON 직렬화를 전부 포함해 **111 ms**.
+
+**byte-exactness가 지켜진다.** `X-Test: 1`과 CRLF 프레이밍이 있는 raw 요청 파일이 raw-echo origin에
+바이트 동일하게 도달했다. `store/models.cr`은 head/body를 전선 옥텟으로 보관하고 파싱된 컬럼을 투영
+으로 둔다. Burp라면 정규화했을 요청이 그대로 살아남는다.
+
+**Layer 1 거부 문구가 훌륭하다.** `127.0.0.1 is out of the project scope — add a scope include rule
+or pass --allow-unscoped` — 호스트와 탈출구를 둘 다 말한다. X3이 고쳐야 할 건 이 모델을 Layer 2에도
+적용하는 것뿐이다.
+
+**exit code가 정확하다.** scope 차단 = 1, 없는 flow = 1, 없는 프로젝트 = 1 (파이프 없이 검증;
+`| head`는 `$?`를 가린다). #410/#415/#416 클래스는 실제로 닫혔다. 남은 건 X2의 mine/sequence뿐.
+
+**서피스 간 상태가 실제로 이어진다.** `gori run repeater create`로 만든 세션이 TUI Repeater 서브탭
+스트립에 응답까지 붙은 채 나타난다.
+
+**컨텍스트 푸터.** 포커스 티어마다 하단 힌트가 바뀐다
+(`TABS ←/→ switch tab …` → `BODY i/↵ edit · ⇧arrows select · y copy · space cmds · ^S SNI · ^R send`).
+
+**빈 상태가 다음 행동을 들고 있다.** Repeater 카드는 `^R repeater from History` / `^N new blank
+repeater tab`을 제시한다.
+
+**공백 가시화.** Repeater 편집기가 공백을 `·`, 줄 끝을 `␍␊`로 렌더한다.
+
+**Intruder 4종이 전부 있다.** `fuzz/types.cr:11-16` — Sniper / BatteringRam / Pitchfork /
+ClusterBomb, `generator.cr`가 교차곱을 실체화하지 않는 지연 블록 기반.
+
+**에이전트 표면은 곁다리가 아니다.** ~130개 MCP 도구가 TUI와 같은 영역을 덮고, 그중 `ql_explain`은
+TUI가 못 하는 드롭된 QL 항 보고를 하며(H2), `intercept_forward_edit`는 byte-exact이고, history
+페이징은 커서 기반이다(H1). Burp에 등가물이 없다.
+
+**구조적으로 서피스가 어긋날 자리가 Burp보다 적다.** Plan 빌더 리팩터(#356, #366, #373–#377)가
+Fuzzer/Miner/Sequencer/Discover/Repeater에 세 서피스 공용 조립 경로를 하나씩 주었고,
+`src/gori/outbound.cr`이 도구별 검사 대신 단일 scope 초크포인트다. 이 문서의 파리티 항목들이 전부
+"조립"이 아니라 "각 서피스가 무엇을 보관하고 보고하는가"에 몰려 있는 건 그 리팩터가 실제로 작동했다는
+증거다.
+
+**단일 정적 바이너리.** JRE 없음, 프로젝트 파일 포맷 없음, 라이선스 체크 없음, `gori run`은 선언된
+TUI 파리티(#352).
+
+**fail-closed sandbox는 더 나은 기본값이다.** O1이 문제 삼는 건 정책이 아니라 write 경로의 침묵이다.
+Burp의 "빈 스코프 = 전부 허용"보다 이쪽이 옳고, DESIGN.md §7에 이유가 기록돼 있다.

--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -272,7 +272,7 @@ gori run discover --target https://target.example --max-depth 3 --extensions php
 | `--concurrency` (20), `--rate`, `--throttle`, `--timeout`, `--retries`, `--max-requests=N` | 속도 제어 |
 | `--no-keep-alive` | origin별 연결 재사용 대신 프로브마다 새로 연결 |
 | `-k`, `--insecure-upstream` | 업스트림 TLS 검증 생략 |
-| `--allow-unscoped` | 대상이 프로젝트 스코프 밖이어도 실행 |
+| `--allow-unscoped` | 대상이 프로젝트 스코프 밖이어도 실행. 사전(Layer 1) 검사만 면제되며 Sandbox 모드와 명시적 exclude 룰은 매 전송마다 그대로 거부합니다. 거부 메시지는 둘 중 어느 게이트가 막았는지 이름을 밝힙니다. |
 | `--force` | 무제한 실행 안전 게이트 우회 |
 | `--no-store` | 결과를 프로젝트에 기록하지 않음 |
 | `--format` | `text`, `json`, 또는 `jsonl` |

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -272,7 +272,7 @@ gori run discover --target https://target.example --max-depth 3 --extensions php
 | `--concurrency` (20), `--rate`, `--throttle`, `--timeout`, `--retries`, `--max-requests=N` | Rate control |
 | `--no-keep-alive` | Dial a fresh connection per probe instead of reusing one per origin |
 | `-k`, `--insecure-upstream` | Skip upstream TLS verification |
-| `--allow-unscoped` | Run even if the target is outside the project scope |
+| `--allow-unscoped` | Run even if the target is outside the project scope. Waives the up-front (Layer 1) check only — Sandbox mode and explicit exclude rules still refuse each send, and the refusal now names which of the two fired. |
 | `--force` | Bypass the unbounded-run safety gate |
 | `--no-store` | Do not write findings into the project |
 | `--format` | `text`, `json`, or `jsonl` |

--- a/spec/fuzz_spec.cr
+++ b/spec/fuzz_spec.cr
@@ -694,7 +694,7 @@ describe F::GatedBackend do
       backend = F::GatedBackend.new(inner, Gori::Outbound.interactive(scope))
       req = "GET / HTTP/1.1\r\nHost: target.test\r\n\r\n".to_slice
 
-      backend.send(req).error.should eq(Gori::Outbound::SCOPE_ERROR)
+      backend.send(req).error.should eq(Gori::Outbound::EXCLUDE_SWEEP_ERROR)
       calls.should eq(0)
       backend.blocked.should eq(1_i64)
     ensure

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -1634,8 +1634,27 @@ describe Gori::MCP::Server do
         listed["rules"][0]["pattern"].as_s.should eq("api.example.com")
 
         del = %({"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"delete_scope_rule","arguments":{"id":#{id}}}})
-        tool_payload(drive(store, del)[0])["deleted"].as_bool.should be_true
+        deleted = tool_payload(drive(store, del)[0])
+        deleted["deleted"].as_bool.should be_true
+        deleted["blocks_all"].as_bool.should be_false # sandbox is off here
         store.scope_rules.should be_empty
+      end
+    end
+
+    it "reports blocks_all when the delete leaves Sandbox holding an empty allowlist" do
+      # set_sandbox already returns blocks_all for exactly this state, but a delete that
+      # CAUSES it returned a bare {id, deleted:true} — so an agent could black-hole the
+      # proxy and read the write as ordinary success. Same question, both edges.
+      with_store do |store|
+        add = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"add_scope_rule","arguments":{"kind":"include","match_type":"host","pattern":"api.example.com"}}})
+        id = tool_payload(drive(store, add)[0])["id"].as_i64
+        sandbox = %({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"set_sandbox","arguments":{"enabled":true}}})
+        tool_payload(drive(store, sandbox)[0])["blocks_all"].as_bool.should be_false # an include still stands
+
+        del = %({"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"delete_scope_rule","arguments":{"id":#{id}}}})
+        deleted = tool_payload(drive(store, del)[0])
+        deleted["deleted"].as_bool.should be_true
+        deleted["blocks_all"].as_bool.should be_true
       end
     end
 

--- a/spec/miner/engine_spec.cr
+++ b/spec/miner/engine_spec.cr
@@ -66,6 +66,20 @@ private class FixedBodyBackend < F::Backend
   end
 end
 
+private class BlockedBackend < F::Backend
+  getter origin : F::Origin
+  getter sent : Int32 = 0
+
+  def initialize(@origin : F::Origin, @reason : String)
+  end
+
+  # The shape Outbound-gated senders return: no head, no response, the reason in `error`.
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    @sent += 1
+    Gori::Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, @reason)
+  end
+end
+
 private def mine(backend : F::Backend, names : Array(String), config : M::Config) : Array(M::Finding)
   base = "GET /api HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
   engine = M::Engine.new(base, http2: false, names: names, backend: backend, config: config)
@@ -204,5 +218,29 @@ describe Gori::Miner::Engine do
     engine.run { |ev| done_progress = ev.progress if ev.is_a?(M::DoneEvent) }
     done_progress.should_not be_nil
     done_progress.not_nil!.errors.should eq(0)
+  end
+
+  describe "a wholly-refused run" do
+    # `@errors` used to count refusals and throw the STRING away, so a scope-blocked sweep
+    # ended "0 found · N sent · N errors" with the reason nowhere and `gori run mine` exiting
+    # 0 — CI read that as "no hidden parameters". The engine stays surface-free; it just
+    # retains the two facts a consumer needs to tell a verdict from a failure.
+    it "retains the first reason and reports that nothing got through" do
+      backend = BlockedBackend.new(F::Origin.new("http", "h", 80), "blocked by sandbox (out of scope)")
+      base = "GET /api?a=1 HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+      engine = M::Engine.new(base, http2: false, names: ["alpha", "beta"], backend: backend, config: cfg)
+      engine.run { }
+      engine.first_error.should eq("blocked by sandbox (out of scope)")
+      engine.successful_sends.should eq(0)
+    end
+
+    it "counts successes, so a run that got answers is not mistaken for a refused one" do
+      backend = HiddenParamBackend.new(F::Origin.new("http", "h", 80), reflect: ["secret"])
+      base = "GET /api?a=1 HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+      engine = M::Engine.new(base, http2: false, names: ["alpha", "secret"], backend: backend, config: cfg)
+      engine.run { }
+      engine.first_error.should be_nil
+      engine.successful_sends.should be > 0
+    end
   end
 end

--- a/spec/outbound_spec.cr
+++ b/spec/outbound_spec.cr
@@ -150,8 +150,33 @@ describe Gori::Outbound do
          Gori::Outbound.cli(scope, false), Gori::Outbound.cli(scope, true),
          Gori::Outbound.interactive(scope), Gori::Outbound.allowlist(scope)].each do |ob|
           ob.send_block("https", "acme.test", "/s?q=hi").should eq(Gori::Outbound::SANDBOX_ERROR)
-          ob.sweep_block("https", "acme.test", "/s?q=hi").should eq(Gori::Outbound::SCOPE_ERROR)
+          ob.sweep_block("https", "acme.test", "/s?q=hi").should eq(Gori::Outbound::SANDBOX_SWEEP_ERROR)
         end
+      end
+    end
+
+    it "names WHICH Layer-2 gate refused, preferring the more specific EXCLUDE" do
+      # Both reasons used to collapse into one bare "blocked by scope" — the same wording as
+      # the Layer-1 abort, so an operator who had just passed --allow-unscoped read those
+      # three words back and concluded the flag had done nothing.
+      #
+      # With the sandbox ON an excluded URL trips BOTH gates (`sandbox_blocks?` is
+      # `sandbox && !allowlisted?`, and an exclude un-allowlists). The exclude wins the
+      # report: telling someone who already HAS a matching include to "add an include rule"
+      # is advice that cannot work, while naming the exclude names the rule to delete.
+      with_scope do |scope, _store|
+        scope.add("include", "host", "acme.test")
+        scope.add("exclude", "string", "/admin")
+        scope.enable_sandbox
+        ob = Gori::Outbound.interactive(scope)
+        # included host, excluded path → the exclude is the actionable reason
+        ob.sweep_block("https", "acme.test", "/admin/panel").should eq(Gori::Outbound::EXCLUDE_SWEEP_ERROR)
+        # not in the allowlist at all, and no exclude matches → sandbox
+        ob.sweep_block("https", "other.test", "/dashboard").should eq(Gori::Outbound::SANDBOX_SWEEP_ERROR)
+        # the two sentences are distinguishable, and each names its own exit
+        Gori::Outbound::SANDBOX_SWEEP_ERROR.should_not eq(Gori::Outbound::EXCLUDE_SWEEP_ERROR)
+        Gori::Outbound::SANDBOX_SWEEP_ERROR.should contain("Sandbox off")
+        Gori::Outbound::EXCLUDE_SWEEP_ERROR.should contain("--allow-unscoped")
       end
     end
 
@@ -164,7 +189,7 @@ describe Gori::Outbound do
         scope.add("exclude", "string", "/admin")
         [Gori::Outbound.agent(scope, false), Gori::Outbound.cli(scope, false),
          Gori::Outbound.interactive(scope)].each do |ob|
-          ob.sweep_block("https", "acme.test", "/admin/panel").should eq(Gori::Outbound::SCOPE_ERROR)
+          ob.sweep_block("https", "acme.test", "/admin/panel").should eq(Gori::Outbound::EXCLUDE_SWEEP_ERROR)
           ob.send_block("https", "acme.test", "/admin/panel").should be_nil
           ob.sweep_block("https", "acme.test", "/s?q=hi").should be_nil
         end
@@ -192,11 +217,13 @@ describe Gori::Outbound do
       with_scope do |scope, _store|
         scope.add("include", "host", "acme.test")
         scope.enable_sandbox
-        scope.add("exclude", "host", "acme.test") # sandbox now blocks acme.test outright
+        scope.add("exclude", "host", "acme.test") # un-allowlists it: both Layer-2 gates fire
         sender = Gori::Fuzz::Sender.new(ORIGIN, Gori::Outbound.interactive(scope),
           http2: false, verify: false, timeout: 1.second)
         result = sender.send(REQ)
-        result.error.should eq(Gori::Outbound::SCOPE_ERROR)
+        # The exclude is the reported reason (see the gate-naming spec above): it is the rule
+        # the operator can act on, whereas "add an include" is moot — one is already there.
+        result.error.should eq(Gori::Outbound::EXCLUDE_SWEEP_ERROR)
         result.duration_us.should eq(0_i64) # never dialled
         sender.blocked.should eq(1_i64)
       end
@@ -207,7 +234,7 @@ describe Gori::Outbound do
         scope.add("exclude", "host", "acme.test")
         inner = RecordingBackend.new(ORIGIN)
         gated = Gori::Fuzz::GatedBackend.new(inner, Gori::Outbound.interactive(scope))
-        gated.send(REQ).error.should eq(Gori::Outbound::SCOPE_ERROR)
+        gated.send(REQ).error.should eq(Gori::Outbound::EXCLUDE_SWEEP_ERROR)
         inner.sent.should eq(0)
       end
     end
@@ -258,7 +285,7 @@ describe Gori::Outbound do
         # …and past it, every surface stops sending. All three share ONE Scope object here,
         # so assert on separately-loaded scopes too (the CLI/MCP shape) below.
         surfaces.each do |name, ob|
-          ob.sweep_block("https", "acme.test", "/s").should(eq(Gori::Outbound::SCOPE_ERROR), "#{name} after reload")
+          ob.sweep_block("https", "acme.test", "/s").should(eq(Gori::Outbound::EXCLUDE_SWEEP_ERROR), "#{name} after reload")
         end
       end
     end
@@ -272,7 +299,7 @@ describe Gori::Outbound do
 
         store.add_scope_rule("exclude", "host", "acme.test")
         sleep(Gori::Outbound::RELOAD_INTERVAL + 100.milliseconds)
-        ob.sweep_block("https", "acme.test", "/s").should eq(Gori::Outbound::SCOPE_ERROR)
+        ob.sweep_block("https", "acme.test", "/s").should eq(Gori::Outbound::EXCLUDE_SWEEP_ERROR)
       end
     end
 
@@ -289,7 +316,7 @@ describe Gori::Outbound do
         # The reload raises against the closed store and is swallowed; the rules loaded
         # before the close stay in force rather than degrading to "allow everything".
         ob.sweep_block("https", "acme.test", "/s").should be_nil
-        ob.sweep_block("https", "other.test", "/s").should eq(Gori::Outbound::SCOPE_ERROR)
+        ob.sweep_block("https", "other.test", "/s").should eq(Gori::Outbound::SANDBOX_SWEEP_ERROR)
       ensure
         File.delete?(path)
         File.delete?("#{path}-wal")
@@ -339,7 +366,7 @@ describe Gori::Outbound do
         # Dialling the allowed origin is fine…
         ob.sweep_block("https", "acme.test", "/x").should be_nil
         # …but dialling evil.test with an acme.test request line must NOT inherit its rule.
-        ob.sweep_block("https", "evil.test", "http://acme.test/x").should eq(Gori::Outbound::SCOPE_ERROR)
+        ob.sweep_block("https", "evil.test", "http://acme.test/x").should eq(Gori::Outbound::SANDBOX_SWEEP_ERROR)
         ob.send_block("https", "evil.test", "http://acme.test/x").should eq(Gori::Outbound::SANDBOX_ERROR)
       end
     end

--- a/spec/sequencer/engine_spec.cr
+++ b/spec/sequencer/engine_spec.cr
@@ -27,6 +27,18 @@ private class CounterCookieBackend < F::Backend
   end
 end
 
+private class BlockedBackend < F::Backend
+  getter origin : F::Origin
+
+  def initialize(@origin : F::Origin, @reason : String)
+  end
+
+  # The shape Outbound-gated senders return: no head, no response, the reason in `error`.
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    Gori::Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, @reason)
+  end
+end
+
 private def drain(engine : Q::Engine) : Array(Q::Sample)
   samples = [] of Q::Sample
   engine.run { |ev| samples << ev.sample if ev.is_a?(Q::SampleEvent) }
@@ -110,5 +122,29 @@ describe Gori::Sequencer::Engine do
       done = ev if ev.is_a?(Q::DoneEvent)
     end
     done.not_nil!.collected.should eq(10) # lands exactly on the goal, no overshoot
+  end
+
+  # A run that collects nothing because every replay was REFUSED is a failure, not a clean
+  # "0 collected" — the reason used to be counted into @errors and the string discarded, so
+  # `gori run sequence` printed "0 collected" and exited 0.
+  it "retains the first refusal reason of a wholly-blocked run" do
+    backend = BlockedBackend.new(F::Origin.new("http", "h", 80), "blocked by a scope exclude rule")
+    config = Q::Config.new(token_loc: Q::TokenLoc.cookie("SID"), goal: 5, concurrency: 1, retries: 0)
+    req = "GET / HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+    engine = Q::Engine.new(req, http2: false, backend: backend, config: config)
+    engine.run { }
+    engine.first_error.should eq("blocked by a scope exclude rule")
+    engine.errors.should be > 0
+  end
+
+  it "leaves first_error nil when replays succeed but no token matches" do
+    # The control case the CLI backstop depends on: "responded, but the descriptor found
+    # nothing" is a real verdict and must NOT be reported as a failed run.
+    backend = CounterCookieBackend.new(F::Origin.new("http", "h", 80))
+    config = Q::Config.new(token_loc: Q::TokenLoc.cookie("NOPE"), goal: 3, concurrency: 1, retries: 0)
+    req = "GET / HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+    engine = Q::Engine.new(req, http2: false, backend: backend, config: config)
+    engine.run { }
+    engine.first_error.should be_nil
   end
 end

--- a/spec/tui/clipboard_spec.cr
+++ b/spec/tui/clipboard_spec.cr
@@ -37,4 +37,27 @@ describe Gori::Tui::Clipboard do
     big.bytesize.should be > Gori::Tui::Clipboard::MAX_CLIP # over cap by bytes
     Gori::Tui::Clipboard.copy(big, IO::Memory.new).should eq(Gori::Tui::Clipboard::MAX_CLIP)
   end
+
+  describe ".note" do
+    # The whole point of the helper: the "— clipped from Nb" half used to be hand-written
+    # at six call sites and missing at five more, so `y` on a large selection reported the
+    # TRUNCATED count as the copy size. One formula, asserted once.
+    it "is silent when the whole source was copied" do
+      Gori::Tui::Clipboard.note(120, 120).should eq("")
+    end
+
+    it "names the cap when the copy was clipped" do
+      Gori::Tui::Clipboard.note(65_536, 200_000).should eq(" — clipped from 200000b (64KB cap)")
+    end
+
+    it "names the SETTING when the clipboard is off, not an empty copy" do
+      # copy() returns 0 without touching the tty when clipboard_osc52? is false; "copied
+      # 0b" alone reads as an empty selection, which is a different problem entirely.
+      Gori::Tui::Clipboard.note(0, 4_096).should eq(" — clipboard is off (Settings → General)")
+    end
+
+    it "says nothing for an empty source (0 of 0 is not a failure)" do
+      Gori::Tui::Clipboard.note(0, 0).should eq("")
+    end
+  end
 end

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -17,6 +17,54 @@ private def loaded_fuzzer : FuzzerView
 end
 
 describe Gori::Tui::FuzzerView do
+  describe "a failed send's reason" do
+    # Fuzz::Engine returns a scope/sandbox refusal as a Result whose `error` carries the
+    # reason and whose head is EMPTY — and Matcher#present nils an empty head, so no
+    # keep_bodies setting makes it reachable. The detail pane used to print "(response not
+    # retained — only matched results keep the response)", blaming a retention policy the
+    # TUI does not even expose for a send that never happened. `gori run fuzz` has always
+    # appended r.error per row (cli/output.cr); this is the TUI catching up.
+    it "names the failure instead of the retention policy" do
+      view = loaded_fuzzer
+      view.focus_pane(:results)
+      view.append_result(fuzz_result(0, nil, 0, error: Gori::Outbound::SANDBOX_SWEEP_ERROR))
+      view.detail_plain_lines.first.should eq("(send failed: #{Gori::Outbound::SANDBOX_SWEEP_ERROR})")
+    end
+
+    it "still reports a genuinely unretained response as unretained" do
+      view = loaded_fuzzer
+      view.focus_pane(:results)
+      view.append_result(fuzz_result(0, 200, 1200)) # succeeded, but keep_bodies dropped it
+      view.detail_plain_lines.first.should contain("response not retained")
+    end
+  end
+
+  describe "#auto_mark" do
+    # Fuzz::Template.auto_mark is a deliberate no-op once ANY § is present: it will not
+    # double-mark, and it must not clear the operator's own markers to re-derive them.
+    # The view used to set_text the unchanged string, then COUNT the markers already in it
+    # and report them as "auto-marked N positions" — a success sentence for work it did not
+    # do. mark_word (^K) next door has always refused honestly; these pin the parity.
+    it "reports the positions it actually placed" do
+      view = loaded_fuzzer
+      view.auto_mark.should eq("auto-marked 1 position")
+    end
+
+    it "refuses instead of re-counting when the template is already marked" do
+      view = FuzzerView.new
+      view.load_request("https://h", "GET /?x=§1§ HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
+      view.auto_mark.should contain("already marked (1 position)")
+      # …and the template is untouched, so the refusal is real, not a silent rewrite.
+      view.template_text.should contain("§1§")
+    end
+
+    it "says so when there is nothing to mark" do
+      view = FuzzerView.new
+      view.load_request("https://h", "GET / HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
+      view.auto_mark.should eq("nothing to auto-mark — no query, cookie or body values found")
+    end
+  end
+
   it "CHAIN pane: focus a template marker, type a chain, commit writes it back" do
     view = FuzzerView.new
     # marker at offset 0 → set_text zeroes the cursor, so it sits inside §x§

--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -1611,6 +1611,32 @@ describe "Gori::Tui::HistoryView marks" do
   end
 end
 
+describe "HistoryView::QL_FIELDS" do
+  # Tab-completion must offer exactly what QL implements. `flag:` used to head the list, so
+  # `f` + Tab deterministically produced a field with no store behind it (Store#flags_for is
+  # a stub): it free-texts, matches nothing, and the empty list reads as "no flows match".
+  # `url:` was the reverse — real and working, but never suggested. Pin both directions.
+  it "offers no field QL cannot compile, and hides no field it can" do
+    fields = Gori::Tui::HistoryView::QL_FIELDS
+    fields.should_not contain("flag") # no flow-flag store exists (ql.cr's else branch says so)
+    fields.should contain("url")      # a real field that was missing from the suggestions
+    fields.should eq(fields.uniq)
+  end
+
+  it "suggests a working field for `f`, and never completes to `flag:`" do
+    tmp_store do |store|
+      add_flow(store, "GET", "/x", 200)
+      view = HistoryView.new
+      view.reload(store)
+      view.start_query
+      "f".each_char { |c| view.query_insert(c) }
+      view.query_suggestions.should_not contain("flag:")
+      view.query_complete
+      view.query.should_not eq("flag:")
+    end
+  end
+end
+
 describe Gori::Tui::Keybind do
   it "maps termisu key events to verb chords" do
     ctrl_p = Termisu::Event::Key.new(Termisu::Input::Key::LowerP, Termisu::Input::Modifier::Ctrl)

--- a/src/gori/cli/run/discover.cr
+++ b/src/gori/cli/run/discover.cr
@@ -48,7 +48,7 @@ module Gori
           p.on("--max-requests=N", "Hard cap on total requests sent") { |v| max_requests = parse_count(v, "--max-requests").to_i64 }
           p.on("--no-keep-alive", "Dial a fresh connection for every probe (default: reuse)") { keep_alive = false }
           p.on("-k", "--insecure-upstream", "Do not verify upstream TLS certificates") { insecure = true }
-          p.on("--allow-unscoped", "Run even if the target is outside the project scope") { allow_unscoped = true }
+          p.on("--allow-unscoped", "Run even if the target is outside the project scope (Sandbox/exclude still apply)") { allow_unscoped = true }
           p.on("--force", "Bypass the unbounded-run safety gate") { force = true }
           p.on("--no-store", "Do not write findings into the project (Sitemap)") { no_store = true }
           p.on("--format=FMT", "Output: text (default) | json | jsonl") { |v| format = parse_format(v, [:text, :json, :jsonl]) }
@@ -90,7 +90,7 @@ module Gori
           end
           guard_discover_scope(plan, outbound)
           discover_preflight(plan, force)
-          run_discover_stream(plan.engine, store, format, no_store, ->{ plan.sender.pool_stats })
+          run_discover_stream(plan.engine, store, format, no_store, -> { plan.sender.pool_stats })
         ensure
           store.close
         end

--- a/src/gori/cli/run/fuzz.cr
+++ b/src/gori/cli/run/fuzz.cr
@@ -80,7 +80,7 @@ module Gori
           p.on("--ac", "Auto-calibrate: sample the target's noise and drop matching responses") { auto_cal = true }
           p.on("--format=FMT", "Output: text (default) | json | jsonl") { |v| format = parse_format(v, [:text, :json, :jsonl]) }
           p.on("--force", "Run even when the request count is huge or unknown") { force = true }
-          p.on("--allow-unscoped", "Send even if the target is outside the project scope") { allow_unscoped = true }
+          p.on("--allow-unscoped", "Send even if the target is outside the project scope (Sandbox/exclude still apply)") { allow_unscoped = true }
           p.on("--fail-if-no-matches", "Exit 3 when no result matched") { fail_if_no_matches = true }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args { |rest, _| positional = rest }

--- a/src/gori/cli/run/mine.cr
+++ b/src/gori/cli/run/mine.cr
@@ -46,7 +46,7 @@ module Gori
           p.on("--timeout=SEC", "Per-request connect + idle timeout (seconds)") { |v| timeout = parse_count(v, "--timeout").seconds }
           p.on("--retries=N", "Retries on a network error") { |v| retries = parse_nonneg(v, "--retries") }
           p.on("--max-requests=N", "Hard cap on total requests sent") { |v| max_requests = parse_count(v, "--max-requests").to_i64 }
-          p.on("--allow-unscoped", "Send even if the target is outside the project scope") { allow_unscoped = true }
+          p.on("--allow-unscoped", "Send even if the target is outside the project scope (Sandbox/exclude still apply)") { allow_unscoped = true }
           p.on("--format=FMT", "Output: text (default) | json | jsonl") { |v| format = parse_format(v, [:text, :json, :jsonl]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args { |rest, _| positional = rest }
@@ -183,6 +183,25 @@ module Gori
         end
         puts CLI::Output.mine_array_json(findings) if format == :json
         exit 1 if had_error
+        exit 1 if mine_all_refused?(engine, findings.size)
+      end
+
+      # A run that found nothing because every send was REFUSED is a failure, not a clean
+      # "no hidden parameters" — `had_error` only fires on an orchestration raise, so a
+      # scope-blocked sweep used to print "0 found" and exit 0, and CI read that as a
+      # verdict. Same backstop `gori run fuzz` was given in #410, plus the reason string the
+      # engine now retains instead of counting and discarding. Returns true → exit 1.
+      #
+      # The predicate is "nothing got through", NOT `errors >= sent`: `sent` counts attempts
+      # including Baseline's probes, whose failures never reach the error counter, so the
+      # two are not comparable. `first_error` excludes a --max-requests cap (a budget, not a
+      # failure), so a capped run still exits 0.
+      private def self.mine_all_refused?(engine : Miner::Engine, found : Int32) : Bool
+        return false unless found.zero? && engine.successful_sends.zero?
+        reason = engine.first_error
+        return false unless reason
+        STDERR.puts "mine: every request failed — #{reason}"
+        true
       end
 
       private def self.mine_baseline(ev : Miner::BaselineEvent) : Nil

--- a/src/gori/cli/run/project.cr
+++ b/src/gori/cli/run/project.cr
@@ -446,6 +446,9 @@ module Gori
             abort "gori run project scope update: rule NOT updated (store busy or unwritable); it is unchanged and still gates traffic"
           end
           puts "Scope rule ##{id} updated: #{new_kind} #{new_type} #{new_pattern}"
+          # Re-read: the write went through the store, not this Scope instance, so the
+          # in-memory rule list is one edit stale.
+          warn_scope_blackhole(Scope.load(store), "gori run project scope update")
         ensure
           store.close
         end
@@ -492,6 +495,18 @@ module Gori
         end
       end
 
+      # A scope WRITE that leaves Sandbox holding an empty allowlist turns the proxy into a
+      # black hole — every captured request refused. `sandbox on` already warns on its own
+      # edge (see cmd_sandbox), but the scope-rule paths never re-asked, so deleting the
+      # last include printed a plain "deleted successfully" and the next capture died
+      # silently. Same question, same wording, now on both edges.
+      private def self.warn_scope_blackhole(scope : Scope, prefix : String) : Nil
+        return unless scope.sandbox? && scope.include_count == 0
+        STDERR.puts "#{prefix}: warning — the sandbox is ON and the scope now has no include " \
+                    "rules, so ALL captured traffic is blocked until you add one " \
+                    "(gori run project scope add ...)"
+      end
+
       private def self.cmd_scope_delete(args : Array(String)) : Nil
         db_path : String? = nil
         project_name : String? = nil
@@ -523,6 +538,7 @@ module Gori
           end
           scope.remove(id)
           puts "Scope rule ##{id} deleted successfully."
+          warn_scope_blackhole(scope, "gori run project scope delete")
         ensure
           store.close
         end

--- a/src/gori/cli/run/sequence.cr
+++ b/src/gori/cli/run/sequence.cr
@@ -57,7 +57,7 @@ module Gori
           p.on("--timeout=SEC", "Per-request connect + idle timeout (seconds)") { |v| timeout = parse_count(v, "--timeout").seconds }
           p.on("--retries=N", "Retries on a network error") { |v| retries = parse_nonneg(v, "--retries") }
           p.on("--max-requests=N", "Hard cap on total requests sent") { |v| max_requests = parse_count(v, "--max-requests").to_i64 }
-          p.on("--allow-unscoped", "Send even if the target is outside the project scope") { allow_unscoped = true }
+          p.on("--allow-unscoped", "Send even if the target is outside the project scope (Sandbox/exclude still apply)") { allow_unscoped = true }
           p.on("--format=FMT", "Output: text (default) | json | jsonl") { |v| format = parse_format(v, [:text, :json, :jsonl]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args { |rest, _| positional = rest }
@@ -203,6 +203,14 @@ module Gori
         end
         emit_sequence_report(Sequencer::Stats.analyze(tokens), format)
         exit 1 if had_error
+        # Collecting NO token because every replay was refused is a failure, not a clean
+        # "0 collected" — `had_error` only fires on an orchestration raise. Gated on
+        # `first_error` so a run that merely hit --max-requests (a budget, not a failure)
+        # still exits 0. Mirrors `gori run fuzz`'s #410 backstop and mine's above.
+        if tokens.empty? && (reason = engine.first_error)
+          STDERR.puts "sequence: every replay failed — #{reason}"
+          exit 1
+        end
       end
 
       private def self.sequence_progress(ev : Sequencer::ProgressEvent, goal : Int32) : Nil

--- a/src/gori/mcp/tools/scope.cr
+++ b/src/gori/mcp/tools/scope.cr
@@ -88,7 +88,13 @@ module Gori
         # in-place reload buys nothing here) and confirm it committed — a busy/locked
         # rollback must not report the rule deleted while it still gates active requests.
         return busy("scope rule NOT deleted (store busy or unwritable); it is unchanged and still gates traffic") unless store.remove_scope_rule(id)
-        Result.new(JSON.build { |j| j.object { j.field "id", id; j.field "deleted", true } })
+        # `set_sandbox` reports `blocks_all` for exactly this state; a delete that CAUSES
+        # it used to return a bare {id, deleted:true}, so an agent could black-hole the
+        # proxy and read the write as ordinary success. Re-load — the removal went through
+        # the store, not this throwaway Scope.
+        after = Scope.load(store)
+        blocks_all = after.sandbox? && after.include_count.zero?
+        Result.new(JSON.build { |j| j.object { j.field "id", id; j.field "deleted", true; j.field "blocks_all", blocks_all } })
       end
 
       private def set_scope_enabled(h) : Result

--- a/src/gori/miner/engine.cr
+++ b/src/gori/miner/engine.cr
@@ -49,6 +49,19 @@ module Gori::Miner
     @names_total : Int64
     @last_dispatch : Time::Instant
 
+    # The first per-send failure reason of the run. `@errors` counts refusals and drops the
+    # string, which is how a scope-blocked run could report "0 found" and exit 0 with the
+    # reason nowhere on screen. Kept as ONE string rather than a list: every send in a
+    # wholly-blocked run fails for the same reason, and the point is to name it, not to
+    # tally it. The engine stays surface-free — consumers read it and decide (DESIGN.md §2.1).
+    getter first_error : String? = nil
+
+    # Mining sends that came back WITHOUT an error. `Progress#sent` counts attempts (and
+    # includes Baseline's probes, whose failures never reach `@errors`), so `errors >= sent`
+    # is not the same question as "did anything get through". Zero here with `first_error`
+    # set means the run produced no verdict at all — it was refused, not answered.
+    getter successful_sends : Int64 = 0_i64
+
     def initialize(@base : Bytes, @http2 : Bool, @names : Array(String),
                    backend : Fuzz::Backend, @config : Config)
       # Wrap the backend so max_requests is enforced at every real send (baseline,
@@ -180,9 +193,12 @@ module Gori::Miner
       # detector (decide), so no per-bucket name→canary / canary→name hashes are built.
       pairs = task.names.map { |n| {n, Canary.fresh} }
       raw = send_with_retries(Inject.apply(@base, task.location, pairs, @config.add_content_length_when_missing?))
-      if raw.error
+      if err = raw.error
         # A max-requests cap refusal isn't a network error — don't let it inflate @errors.
-        @errors += 1 unless raw.error == Fuzz::CappedBackend::CAP_ERROR
+        unless err == Fuzz::CappedBackend::CAP_ERROR
+          @errors += 1
+          @first_error ||= err
+        end
         mark_done(task.names.size) # keep the bar monotonic; this bucket is inconclusive
         return [] of Task
       end
@@ -371,7 +387,11 @@ module Gori::Miner
       attempts = 0
       loop do
         raw = @backend.send(bytes)
-        return raw if raw.error.nil? || attempts >= @config.retries
+        if raw.error.nil?
+          @successful_sends += 1
+          return raw
+        end
+        return raw if attempts >= @config.retries
         attempts += 1
         sleep @config.retry_pause
       end

--- a/src/gori/outbound.cr
+++ b/src/gori/outbound.cr
@@ -30,9 +30,17 @@ module Gori
   # MCP did this; `gori run` snapshotted the rules at start-up and the TUI honoured a
   # change only as a side effect of its own data_version poll.
   class Outbound
-    # The per-send error string an automated sweep's blocked Result carries. Stable —
-    # `Fuzz::Engine` surfaces it as a row error and specs assert on it.
-    SCOPE_ERROR = "blocked by scope"
+    # The per-send error strings an automated sweep's blocked Result carries. Stable —
+    # `Fuzz::Engine` surfaces them as a row error and specs assert on them.
+    #
+    # Layer 2 has TWO independent reasons with different remedies, so they get different
+    # sentences. They used to collapse into one bare "blocked by scope", which is also the
+    # wording of the Layer-1 abort — so an operator who had just passed `--allow-unscoped`
+    # read the same three words back and reasonably concluded the flag had done nothing.
+    # `Discover::Engine::SCOPE_REFUSED` already names both possibilities for the same
+    # gate; this splits them so the message names the ONE that fired, and its exit.
+    SANDBOX_SWEEP_ERROR = "blocked by sandbox (out of scope) — add a scope include rule, or turn Sandbox off"
+    EXCLUDE_SWEEP_ERROR = "blocked by a scope exclude rule — excludes hold even under --allow-unscoped"
     # The refusal for ONE hand-authored Repeater send. Distinct wording because Sandbox
     # is the only rule that stops these (see `send_block`), and the TUI/CLI show it verbatim.
     SANDBOX_ERROR = "blocked by sandbox (out of scope)"
@@ -202,7 +210,13 @@ module Gori
       s = @scope
       return nil unless s
       url = Outbound.scope_url(scheme, host, target)
-      (s.sandbox_blocks?(url, host) || s.excluded?(url, host)) ? SCOPE_ERROR : nil
+      # EXCLUDE is tested FIRST because it is the more specific answer. `sandbox_blocks?` is
+      # `sandbox && !allowlisted?`, and an excluded URL is never allowlisted — so with the
+      # sandbox on, an exclude match trips BOTH. Reporting sandbox there would tell an
+      # operator who already has a matching include rule to "add a scope include rule",
+      # which is advice that cannot work. Naming the exclude names the rule they can delete.
+      return EXCLUDE_SWEEP_ERROR if s.excluded?(url, host)
+      s.sandbox_blocks?(url, host) ? SANDBOX_SWEEP_ERROR : nil
     end
 
     # The refusal reason for ONE hand-authored Repeater send, or nil to proceed. Sandbox

--- a/src/gori/sequencer/engine.cr
+++ b/src/gori/sequencer/engine.cr
@@ -40,6 +40,14 @@ module Gori::Sequencer
     @last_dispatch : Time::Instant
     @token_re : Regex? = nil # Regex token descriptor compiled ONCE per run (see run_live)
 
+    # Final per-run counters, read by a consumer AFTER `run` returns (the block form is
+    # synchronous, so they are settled). `first_error` is the first real per-send failure —
+    # a max-requests cap is a budget, not a failure, so it is excluded. Without this the
+    # reason for a wholly-refused run was counted into `@errors` and the string thrown away,
+    # and `gori run sequence` reported "0 collected" and exited 0.
+    getter errors : Int32
+    getter first_error : String? = nil
+
     # `backend` is nil ONLY for manual mode, which analyses pasted tokens offline. Live
     # replay without one is rejected here rather than discovered inside a worker fiber —
     # and modelling it as absent is why manual mode no longer needs a throwaway sender
@@ -207,7 +215,10 @@ module Gori::Sequencer
       status = raw.response.try(&.status)
       len = token.try(&.bytesize) || 0
       err = raw.error || (token ? nil : "no token matched")
-      @errors += 1 if raw.error
+      if e = raw.error
+        @errors += 1
+        @first_error ||= e unless e == Fuzz::CappedBackend::CAP_ERROR
+      end
       @collected += 1 if token
       @events.send(SampleEvent.new(Sample.new(idx, token, status, len, raw.duration_us, err)))
       emit_progress

--- a/src/gori/tui/clipboard.cr
+++ b/src/gori/tui/clipboard.cr
@@ -43,5 +43,20 @@ module Gori::Tui
       io.flush
       data.bytesize
     end
+
+    # The status suffix for a copy, derived from what `copy` actually wrote versus the
+    # source size. Callers append this instead of re-deriving the comparison themselves:
+    # the `— clipped from Nb` half used to be hand-written at six call sites and simply
+    # absent at five more, so `y` on a large selection reported the TRUNCATED count as
+    # the copy size. One formula, one home — the omission can't recur per-caller.
+    #
+    # A disabled clipboard is its own answer: `copy` returns 0 without touching the tty,
+    # and "copied 0b" alone reads as an empty selection rather than a switched-off
+    # setting. Empty source is not an error — it returns "".
+    def self.note(written : Int32, source_bytes : Int32) : String
+      return "" if source_bytes.zero?
+      return " — clipboard is off (Settings → General)" if written.zero?
+      written < source_bytes ? " — clipped from #{source_bytes}b (64KB cap)" : ""
+    end
   end
 end

--- a/src/gori/tui/controllers/decoder_controller.cr
+++ b/src/gori/tui/controllers/decoder_controller.cr
@@ -481,8 +481,8 @@ module Gori::Tui
       if text.empty?
         @host.status("nothing to copy")
       else
-        Clipboard.copy(text)
-        @host.status("output copied to clipboard")
+        written = Clipboard.copy(text)
+        @host.status("output copied to clipboard#{Clipboard.note(written, text.bytesize)}")
       end
     end
 
@@ -496,8 +496,8 @@ module Gori::Tui
       if text.empty?
         @host.status("nothing to copy")
       else
-        Clipboard.copy(text)
-        @host.status("copied #{text.bytesize}b to clipboard")
+        written = Clipboard.copy(text)
+        @host.status("copied #{written}b to clipboard#{Clipboard.note(written, text.bytesize)}")
       end
     end
 
@@ -516,9 +516,7 @@ module Gori::Tui
         @host.status("nothing to copy")
       else
         written = Clipboard.copy(text)
-        msg = "copied all (#{written}b)"
-        msg += " — clipped from #{text.bytesize}b (64KB cap)" if written < text.bytesize
-        @host.status(msg)
+        @host.status("copied all (#{written}b)#{Clipboard.note(written, text.bytesize)}")
       end
     end
 

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -608,7 +608,7 @@ module Gori::Tui
       text = v.pane_copy_text
       return if text.empty?
       written = Clipboard.copy(text)
-      @host.status("copied #{written}b to clipboard")
+      @host.status("copied #{written}b to clipboard#{Clipboard.note(written, text.bytesize)}")
     end
 
     # The focused pane's selection (or current line) text without copying — for the
@@ -623,9 +623,7 @@ module Gori::Tui
       text = v.pane_copy_all_text
       return if text.empty?
       written = Clipboard.copy(text)
-      msg = "copied all (#{written}b)"
-      msg += " — clipped from #{text.bytesize}b (64KB cap)" if written < text.bytesize
-      @host.status(msg)
+      @host.status("copied all (#{written}b)#{Clipboard.note(written, text.bytesize)}")
     end
 
     def fuzzer_read_mode? : Bool

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -444,9 +444,7 @@ module Gori::Tui
       io.write(detail.request_head)
       io.write(detail.request_body.not_nil!) if detail.request_body
       written = Clipboard.copy(String.new(io.to_slice))
-      msg = "copied #{detail.row.method} #{Url.origin_path(detail.row.target)} to clipboard (#{written}b)"
-      msg += " — clipped from #{io.size}b (64KB cap)" if written < io.size
-      @host.status(msg)
+      @host.status("copied #{detail.row.method} #{Url.origin_path(detail.row.target)} to clipboard (#{written}b)#{Clipboard.note(written, io.size)}")
     end
 
     # Multi-mark copy (#442): concatenating N raw request dumps is not what anyone marking
@@ -458,10 +456,9 @@ module Gori::Tui
       return @host.status("copy: no flows left to copy") if urls.empty?
       text = urls.join('\n')
       written = Clipboard.copy(text)
-      msg = "copied #{urls.size} URL#{urls.size == 1 ? "" : "s"} to clipboard (#{written}b)"
       # A thousand marked URLs overrun the 64KB clipboard cap, and a severed list that CLAIMS a
-      # thousand is worse than a short one that admits it (mirrors copy_selection above).
-      msg += " — clipped from #{text.bytesize}b (64KB cap)" if written < text.bytesize
+      # thousand is worse than a short one that admits it (Clipboard.note owns that formula).
+      msg = "copied #{urls.size} URL#{urls.size == 1 ? "" : "s"} to clipboard (#{written}b)#{Clipboard.note(written, text.bytesize)}"
       msg += " — #{ids.size - urls.size} no longer available" if urls.size < ids.size
       @host.status(msg)
     end
@@ -539,7 +536,7 @@ module Gori::Tui
         return
       end
       written = Clipboard.copy(text)
-      @host.status("copied #{written}b to clipboard")
+      @host.status("copied #{written}b to clipboard#{Clipboard.note(written, text.bytesize)}")
     end
 
     # The detail pane's selection (or current line) text without copying — "Send selection to".

--- a/src/gori/tui/controllers/issues_controller.cr
+++ b/src/gori/tui/controllers/issues_controller.cr
@@ -439,7 +439,7 @@ module Gori::Tui
         return
       end
       written = Clipboard.copy(text)
-      @host.status("copied #{written}b to clipboard")
+      @host.status("copied #{written}b to clipboard#{Clipboard.note(written, text.bytesize)}")
     end
 
     # The notes selection (or current line) text without copying — "Send selection to".
@@ -454,9 +454,7 @@ module Gori::Tui
         return
       end
       written = Clipboard.copy(text)
-      msg = "copied notes to clipboard (#{written}b)"
-      msg += " — clipped from #{text.bytesize}b (64KB cap)" if written < text.bytesize
-      @host.status(msg)
+      @host.status("copied notes to clipboard (#{written}b)#{Clipboard.note(written, text.bytesize)}")
     end
 
     # Write the issue report to `path` (the destination came from ExportOverlay — this used

--- a/src/gori/tui/controllers/jwt_controller.cr
+++ b/src/gori/tui/controllers/jwt_controller.cr
@@ -629,7 +629,7 @@ module Gori::Tui
       else
         written = Clipboard.copy(text)
         prefix = label ? "copied \"#{label}\"" : "copied"
-        @host.status("#{prefix} (#{written}b)")
+        @host.status("#{prefix} (#{written}b)#{Clipboard.note(written, text.bytesize)}")
       end
     end
 

--- a/src/gori/tui/controllers/notes_controller.cr
+++ b/src/gori/tui/controllers/notes_controller.cr
@@ -341,7 +341,7 @@ module Gori::Tui
         return
       end
       written = Clipboard.copy(text)
-      @host.status("copied #{written}b to clipboard")
+      @host.status("copied #{written}b to clipboard#{Clipboard.note(written, text.bytesize)}")
     end
 
     # The selection (or current line) text without the clipboard write — for the
@@ -358,9 +358,7 @@ module Gori::Tui
         return
       end
       written = Clipboard.copy(text)
-      msg = "copied note to clipboard (#{written}b)"
-      msg += " — clipped from #{text.bytesize}b (64KB cap)" if written < text.bytesize
-      @host.status(msg)
+      @host.status("copied note to clipboard (#{written}b)#{Clipboard.note(written, text.bytesize)}")
     end
 
     # Wipe the current note's text (the sub-tab stays open). Confirm-gated like every

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -396,7 +396,7 @@ module Gori::Tui
         return
       end
       written = Clipboard.copy(text)
-      @host.status("copied #{written}b to clipboard")
+      @host.status("copied #{written}b to clipboard#{Clipboard.note(written, text.bytesize)}")
     end
 
     # The description selection (or current line) text without copying — "Send selection to".
@@ -411,9 +411,7 @@ module Gori::Tui
         return
       end
       written = Clipboard.copy(text)
-      msg = "copied description to clipboard (#{written}b)"
-      msg += " — clipped from #{text.bytesize}b (64KB cap)" if written < text.bytesize
-      @host.status(msg)
+      @host.status("copied description to clipboard (#{written}b)#{Clipboard.note(written, text.bytesize)}")
     end
 
     # --- SCOPE pane: browse the rule list; a/e open the Miner-style popup overlay ---
@@ -458,8 +456,21 @@ module Gori::Tui
 
     def scope_delete_rule : Nil
       if pat = @project_view.scope_delete
-        @host.status("removed scope rule: #{pat}")
+        @host.status("removed scope rule: #{pat}#{scope_blackhole_note}")
       end
+    end
+
+    # The warning to append to a scope-rule WRITE that has just left Sandbox holding an
+    # empty allowlist — i.e. the proxy now refuses everything. The danger-confirm at
+    # Runner#toggle_sandbox only fires on the ENABLE edge, so a scope already ON was never
+    # re-checked and deleting the last include reported a plain "removed scope rule" while
+    # black-holing every request. The live "no scope → ALL blocked" note on the PROJECT
+    # SETTINGS card cannot cover this: one pane card renders at a time, so it is off-screen
+    # while you are editing rules on the SCOPE pane.
+    private def scope_blackhole_note : String
+      scope = @host.session.scope
+      return "" unless scope.sandbox? && scope.include_count == 0
+      " — ⚠ sandbox ON with NO include rules: ALL traffic is now blocked"
     end
 
     # Apply a rule from the SCOPE popup. Returns true when the overlay should close
@@ -483,6 +494,9 @@ module Gori::Tui
         # a rule but nothing filtered" confusion — the space menu's 's' enables it).
         msg = "scope rule #{verb} — #{n} rule#{n == 1 ? "" : "s"}"
         msg += " · space → s to enable the lens" unless @host.session.scope.enabled? || edited
+        # An EDIT can black-hole the proxy too (flip the last include to an exclude), so
+        # this path re-asks the same question the delete path does.
+        msg += scope_blackhole_note
         @host.status(msg)
         true
       else

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -600,7 +600,7 @@ module Gori::Tui
       text = v.pane_copy_text
       return if text.empty?
       written = Clipboard.copy(text)
-      @host.status("copied #{written}b to clipboard")
+      @host.status("copied #{written}b to clipboard#{Clipboard.note(written, text.bytesize)}")
     end
 
     # The focused pane's selection (or current line) text without copying — for the
@@ -615,9 +615,7 @@ module Gori::Tui
       text = v.pane_copy_all_text
       return if text.empty?
       written = Clipboard.copy(text)
-      msg = "copied all (#{written}b)"
-      msg += " — clipped from #{text.bytesize}b (64KB cap)" if written < text.bytesize
-      @host.status(msg)
+      @host.status("copied all (#{written}b)#{Clipboard.note(written, text.bytesize)}")
     end
 
     def repeater_read_mode? : Bool

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -522,7 +522,16 @@ module Gori::Tui
 
     # --- marking -------------------------------------------------------------
     def auto_mark : String
-      text = Fuzz::Template.auto_mark(@editor.text)
+      before = @editor.text
+      text = Fuzz::Template.auto_mark(before)
+      # `Template.auto_mark` is a deliberate no-op once ANY § is present — it will not
+      # double-mark, and it must not clear the operator's own markers to re-derive them.
+      # Say so instead of counting the markers in the UNCHANGED text and reporting them
+      # as if this keystroke had placed them (mark_word already refuses honestly).
+      if text == before
+        n = Fuzz::Template.parse(before).position_count
+        return n.zero? ? "nothing to auto-mark — no query, cookie or body values found" : "already marked (#{n} position#{n == 1 ? "" : "s"}) — Clear markers first to re-derive"
+      end
       @editor.set_text(text)
       @dirty = true
       n = Fuzz::Template.parse(text).position_count
@@ -1844,7 +1853,14 @@ module Gori::Tui
       x = screen.text(inner.x + 2, y, line, selected ? Theme.text_bright : Theme.text, bg)
       sc = r.status.try(&.to_s) || (r.error ? "ERR" : "—")
       x = screen.text(x + 1, y, sc.ljust(7), status_color(r), bg)
-      screen.text(x, y, "#{Fmt.size(r.length).ljust(8)} #{r.words.to_s.ljust(7)} #{Fmt.dur(r.duration_us)}", selected ? Theme.text : Theme.muted, bg, width: {inner.right - x, 1}.max)
+      # A send that never got a response has no length/words/duration worth showing — the
+      # reason does. `cli/output.cr:fuzz_row_text` already appends `r.error` per row; the
+      # TUI used to drop it entirely, so a scope/sandbox refusal read as a bare "ERR".
+      if err = r.error
+        screen.text(x, y, err, Theme.red, bg, width: {inner.right - x, 1}.max)
+      else
+        screen.text(x, y, "#{Fmt.size(r.length).ljust(8)} #{r.words.to_s.ljust(7)} #{Fmt.dur(r.duration_us)}", selected ? Theme.text : Theme.muted, bg, width: {inner.right - x, 1}.max)
+      end
     end
 
     private def status_color(r : Fuzz::Result) : Color
@@ -2148,6 +2164,13 @@ module Gori::Tui
     end
 
     private def detail_response_lines(r : Fuzz::Result) : Array(String)
+      # The send failed, so there is no response to retain — say THAT, not the retention
+      # policy. Fuzz::Engine builds a refused/failed Result with an empty head (engine.cr,
+      # the scope/sandbox path), and Matcher#present returns nil for it under every
+      # keep_bodies setting, so this branch is the only place the reason can surface.
+      if err = r.error
+        return ["(send failed: #{err})"]
+      end
       head = r.head
       return ["(response not retained — only matched results keep the response)"] unless head
       body = r.body

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -40,8 +40,14 @@ module Gori::Tui
     # We load the MOST RECENT this-many (so a live tail keeps updating) and show an
     # "older not loaded" note; the raw frames remain whole in SQLite.
     DETAIL_LOG_CAP = 10_000
-    QL_FIELDS      = %w(host method status path scheme proto body header size reqsize respsize dur flag)
-    METHOD_VAL     = %w(GET POST PUT DELETE PATCH HEAD OPTIONS QUERY)
+    # Tab-completion offers exactly what `QL.field_cond` implements — no more, no less.
+    # `flag` used to head this list, so `f` + Tab deterministically produced `flag:`, a
+    # field with no store behind it (Store#flags_for is a stub): it free-texts, matches
+    # nothing, and the empty list reads as "no flows match". `url` is the reverse case —
+    # a real, working field that was never suggested. spec/tui/history_view_spec.cr pins
+    # this list against ql.cr so the two cannot drift apart again.
+    QL_FIELDS  = %w(host url method status path scheme proto body header size reqsize respsize dur)
+    METHOD_VAL = %w(GET POST PUT DELETE PATCH HEAD OPTIONS QUERY)
     # Discoverability hints for the QL filter, kept loosely in sync with QL_FIELDS.
     # FILTER_HINT sits on the idle bar (press `/` to start filtering); QUERY_HINT sits
     # on the suggestion row at a cold start (already editing, nothing to Tab-complete

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1696,9 +1696,7 @@ module Gori::Tui
       cp.on_commit = -> {
         if opt = cp.selected_option
           written = Clipboard.copy(opt.text)
-          msg = "copied #{opt.label.downcase} (#{written}b)"
-          msg += " — clipped from #{opt.text.bytesize}b (64KB cap)" if written < opt.text.bytesize
-          @toast = msg
+          @toast = "copied #{opt.label.downcase} (#{written}b)#{Clipboard.note(written, opt.text.bytesize)}"
         end
         true
       }


### PR DESCRIPTION
Seven defects from a friction audit of the HTTP-send and TUI paths — an audit run against Burp Suite as the bar, asking "what makes gori more annoying to actually use" rather than "what is broken". All seven land in the two classes this repo has shipped fixes for before (`a0a5bd3`, `0d59c8a`, #488/#489): **an action that reports success for work it did not do**, and **a refusal the operator cannot act on**.

`FRICTION-AUDIT.md` (added here) carries the full 47-item inventory, six cross-cutting themes, and a ranked 36-row backlog. This PR is its top tier; the fixed items are marked `[FIXED]` there.

## Reported success for work it did not do

| | |
|---|---|
| **Fuzzer `^A`** | `Template.auto_mark` is a deliberate no-op once any `§` is present — it must not clear the operator's own markers to re-derive them. But the view `set_text` the *unchanged* string and then counted the markers already in it: "auto-marked 1 position" for a keystroke that did nothing. It now refuses honestly, as its neighbour `mark_word` always has. |
| **`y` copy** | `Clipboard.copy` truncates at 64 KiB and returns what it wrote so callers can flag it. Six call sites hand-wrote that comparison; **five did not** — so `y` on a large selection printed the *truncated* count as the copy size, and a clipboard switched off in Settings reported "copied 0b" everywhere with no hint that the setting was why. One `Clipboard.note` helper now owns the formula, including the disabled case. |
| **History filter** | `QL_FIELDS` led with `flag`, so `f` + Tab *deterministically* produced a field with no store behind it (`Store#flags_for` is a stub): it free-texts, matches nothing, and the empty list reads as "no flows match". Dropped — and the real-but-never-suggested `url` added. A spec pins the list to `QL.field_cond` so they cannot drift again. |
| **`run mine` / `run sequence`** | A run where every send was refused printed "0 found" and exited 0, so CI read a scope typo as a verdict. Both engines now retain the first refusal reason instead of counting it and throwing the string away, and both CLIs exit 1 — the backstop `gori run fuzz` got in #410. |
| **Scope writes** | The danger-confirm fired only on the sandbox *enable* edge, so deleting the last include under Sandbox black-holed the proxy while the TUI toasted "removed scope rule", the CLI printed "deleted successfully", and MCP returned a bare `{id, deleted:true}`. All three now re-ask the question the enable edge asks; MCP reports `blocks_all`, which `set_sandbox` already did for the identical resulting state. |

Note on the mine/sequence predicate: it is **"nothing got through"**, not `errors >= sent`. `Progress#sent` counts attempts *including Baseline's probes*, whose failures never reach the error counter — the two are not comparable, and the first draft of this fix let a fully-refused run through because of it. A `--max-requests` cap is a budget, not a failure, and still exits 0.

## Refusals that never named the gate

`Outbound#sweep_block` collapsed Sandbox and exclude into one `"blocked by scope"` — **the same words as the Layer-1 abort**, so an operator who had just passed `--allow-unscoped` read them back and reasonably concluded the flag had done nothing. Split into two sentences that each name their own exit.

EXCLUDE is reported first, which is worth stating: `sandbox_blocks?` is `sandbox && !allowlisted?` and an exclude un-allowlists, so with the sandbox on **both gates fire together**. Reporting sandbox there would tell someone who already has a matching include rule to "add a scope include rule" — advice that cannot work. Naming the exclude names the rule they can delete.

`--allow-unscoped`'s help in fuzz/mine/sequence/discover now says what repeater's already said: Sandbox and excludes still apply. The reference docs (en + ko) say it too.

The Fuzzer computed that string and rendered it **nowhere**: a refused row showed a bare `ERR`, and opening it printed `(response not retained — only matched results keep the response)` — blaming a retention policy the TUI does not even expose, for a send that never happened. `Fuzz::Engine` returns a refusal with an empty head and `Matcher#present` nils an empty head, so *no* `keep_bodies` setting made the reason reachable. Both the row and the detail pane now show it, matching `cli/output.cr`, which has always appended `r.error` per row.

## Verification

Against the built binary, not just the suite:

```
$ gori run mine --project verif ... # sandbox ON, zero includes
done · 0 found · 12 sent · 4 errors
mine: every request failed — blocked by sandbox (out of scope) — add a scope include rule, or turn Sandbox off
EXIT=1

$ gori run mine ...                 # scope fixed          → EXIT=0
$ gori run mine ... --max-requests 1 # capped, not failed  → EXIT=0
$ gori run sequence ... --regex 'zzz(.*)'  # responded, no token matched → EXIT=0

$ gori run fuzz --allow-unscoped ...  # target matches an exclude rule
#0  a  ERR  0B  0w  0µs  blocked by a scope exclude rule — excludes hold even under --allow-unscoped

$ gori run project scope delete --project verif 1   # sandbox ON, last include
Scope rule #1 deleted successfully.
gori run project scope delete: warning — the sandbox is ON and the scope now has no include rules, so ALL captured traffic is blocked until you add one (gori run project scope add ...)
```

TUI `^A` on an unmarkable template (tmux): `nothing to auto-mark — no query, cookie or body values found` (was: "auto-marked 0 positions").

`just test` — **4895 examples, 0 failures** (17 new). `crystal tool format --check` clean. Ameba diffed rule-by-rule against `main`: **no new findings**.

## Not in this PR

The remaining 40 audit items, including every `L`-sized one — Fuzzer result persistence (`insert_fuzz_run`/`insert_fuzz_result` are fully implemented with **zero production callers**), History paging past 1000 (`Store#search`'s `before_id` cursor is used only by MCP), mouse drag selection (needs mode 1002 in the termisu fork), and occurrence-shaped `^F`. §2 of `FRICTION-AUDIT.md` ranks all of them by time-saved over cost.