### PR TITLE
feat(h2): complete the HPACK encoder — dynamic table, never-indexed, RFC vectors

### DIFF
--- a/spec/proxy/h2/hpack_spec.cr
+++ b/spec/proxy/h2/hpack_spec.cr
@@ -105,4 +105,261 @@ describe Gori::Proxy::H2::HPACK do
     # :method GET is static index 2 → a single indexed byte 0x82
     HPACK::Encoder.new.encode([{":method", "GET"}]).should eq(Bytes[0x82])
   end
+
+  it "the default encoder never touches its dynamic table" do
+    # Literal-without-indexing for everything not an exact static hit, so a block
+    # decodes the same against any decoder in any order — see Encoder's comment on
+    # why that is the default on a path where some heads may still pass through raw.
+    enc = HPACK::Encoder.new
+    2.times { enc.encode([{"cookie", "a=1"}, {"authorization", "Bearer x"}]) }
+    enc.dynamic_entries.should be_empty
+    # Both blocks are byte-identical: no history means no drift.
+    a = enc.encode([{"cookie", "a=1"}])
+    b = HPACK::Encoder.new.encode([{"cookie", "a=1"}])
+    a.should eq(b)
+    # 0x00-prefixed = §6.2.2 literal without indexing (not 0x40, not 0x10).
+    (a[0] & 0xf0).should eq(0x00)
+  end
+
+  # --- RFC 7541 Appendix C encode vectors -------------------------------------
+  # Each is asserted BOTH ways: the fixture must decode to the header list (which
+  # validates the fixture itself against the already-trusted decoder) and the
+  # encoder must reproduce the fixture byte-for-byte. That second half is the
+  # interoperability claim — these are the bytes a real HPACK peer emits.
+
+  it "encodes RFC 7541 C.4 (requests, Huffman + incremental indexing)" do
+    enc = HPACK::Encoder.new(indexing: true)
+    dec = HPACK::Decoder.new
+    [
+      {"828684418cf1e3c2e5f23a6ba0ab90f4ff",
+       [{":method", "GET"}, {":scheme", "http"}, {":path", "/"},
+        {":authority", "www.example.com"}]},
+      {"828684be5886a8eb10649cbf",
+       [{":method", "GET"}, {":scheme", "http"}, {":path", "/"},
+        {":authority", "www.example.com"}, {"cache-control", "no-cache"}]},
+      {"828785bf408825a849e95ba97d7f8925a849e95bb8e8b4bf",
+       [{":method", "GET"}, {":scheme", "https"}, {":path", "/index.html"},
+        {":authority", "www.example.com"}, {"custom-key", "custom-value"}]},
+    ].each do |(hex, headers)|
+      dec.decode(hexb(hex)).should eq(headers) # the fixture is what the RFC says
+      enc.encode(headers).should eq(hexb(hex)) # and we emit exactly that
+    end
+    # Both tables ended on the same three entries, in the same order.
+    enc.dynamic_entries.should eq(dec.dynamic_entries)
+  end
+
+  it "encodes RFC 7541 C.6 (responses, Huffman, 256-byte table with eviction)" do
+    enc = HPACK::Encoder.new(max_size: 256, indexing: true)
+    dec = HPACK::Decoder.new(max_size: 256)    # fed the RFC's bytes
+    mirror = HPACK::Decoder.new(max_size: 256) # fed ours
+    c61 = "4882640258 85aec3771a4b 6196d07abe941054d444a8200595040b8166e082a62d1bff " \
+          "6e919d29ad1718 63c78f0b97c8e9ae82ae43d3"
+    c61_headers = [{":status", "302"},
+                   {"cache-control", "private"},
+                   {"date", "Mon, 21 Oct 2013 20:13:21 GMT"},
+                   {"location", "https://www.example.com"}]
+    dec.decode(hexb(c61)).should eq(c61_headers)
+    ours = enc.encode(c61_headers)
+    ours.should eq(hexb(c61))
+    mirror.decode(ours).should eq(c61_headers)
+
+    # C.6.2 is the same response with a new :status, so every other field is a
+    # back-reference into the dynamic table both sides just built.
+    c62 = "4883640eff c1 c0 bf"
+    c62_headers = [{":status", "307"},
+                   {"cache-control", "private"},
+                   {"date", "Mon, 21 Oct 2013 20:13:21 GMT"},
+                   {"location", "https://www.example.com"}]
+    dec.decode(hexb(c62)).should eq(c62_headers)
+    ours = enc.encode(c62_headers)
+    # One byte of deliberate divergence: "307" is 3 raw octets and 17 Huffman bits,
+    # i.e. 3 bytes either way, and we break that tie toward the raw literal (see
+    # Encoder#encode_string) where the RFC's encoder codes it. Same length, and the
+    # three back-references — the part that proves the tables are in step — are the
+    # RFC's bytes exactly.
+    ours.size.should eq(hexb(c62).size)
+    ours[-3, 3].should eq(Bytes[0xc1, 0xc0, 0xbf])
+    mirror.decode(ours).should eq(c62_headers)
+
+    # C.6.2 evicted the ":status 302" entry on all three sides — same §4.1 sizing,
+    # same eviction moment, which is why 0xc1/0xc0/0xbf resolved at all.
+    enc.dynamic_entries.should eq(dec.dynamic_entries)
+    enc.dynamic_entries.should eq(mirror.dynamic_entries)
+    enc.dynamic_entries.first.should eq({":status", "307"})
+  end
+
+  it "re-encodes the existing decode fixtures back through a decoder" do
+    # Cheapest real-traffic check: take blocks a real HPACK encoder produced,
+    # decode them, and put the header list back through our encoder. The block
+    # will NOT be byte-identical (HPACK is stateful and the representation choice
+    # is the encoder's) — the header list must be.
+    ["828684410f7777772e6578616d706c652e636f6d", # C.3.1 request, no Huffman
+     "828684418cf1e3c2e5f23a6ba0ab90f4ff",       # C.4.1 request, Huffman
+     "4882640258 85aec3771a4b 6196d07abe941054d444a8200595040b8166e082a62d1bff " \
+     "6e919d29ad1718 63c78f0b97c8e9ae82ae43d3" # C.6.1 response
+    ].each do |hex|
+      headers = HPACK::Decoder.new.decode(hexb(hex))
+      HPACK::Decoder.new.decode(HPACK::Encoder.new.encode(headers)).should eq(headers)
+      HPACK::Decoder.new(max_size: 256)
+        .decode(HPACK::Encoder.new(max_size: 256, indexing: true).encode(headers))
+        .should eq(headers)
+    end
+  end
+
+  # --- never-indexed (§6.2.3) --------------------------------------------------
+
+  it "preserves the never-indexed marking through decode (RFC 7541 C.2.3)" do
+    # 0x10 prefix, literal name "password", literal value "secret".
+    fields = HPACK::Decoder.new.decode_fields(hexb("1008 70617373776f7264 06 736563726574"))
+    fields.map(&.to_tuple).should eq([{"password", "secret"}])
+    fields[0].never_indexed?.should be_true
+    # C.2.2 §6.2.2 (0x00 prefix) then C.2.4 §6.1 (0x82) — neither is never-indexed,
+    # and neither entered the table.
+    dec = HPACK::Decoder.new
+    plain = dec.decode_fields(hexb("040c 2f73616d706c652f70617468 82"))
+    plain.map(&.to_tuple).should eq([{":path", "/sample/path"}, {":method", "GET"}])
+    plain.map(&.never_indexed?).should eq([false, false])
+    dec.dynamic_entries.should be_empty
+  end
+
+  it "re-emits never-indexed fields as never-indexed and keeps them out of the table" do
+    enc = HPACK::Encoder.new(indexing: true) # indexing ON — the flag still wins
+    fields = [
+      HPACK::Field.new("authorization", "Bearer sk-live-1234567890", never_indexed: true),
+      HPACK::Field.new("x-plain", "indexable"),
+    ]
+    block = enc.encode(fields)
+    (block[0] & 0xf0).should eq(0x10) # §6.2.3 representation, re-emitted
+    # The sensitive header never entered the table; the ordinary one did.
+    enc.dynamic_entries.should eq([{"x-plain", "indexable"}])
+
+    out = HPACK::Decoder.new.decode_fields(block)
+    out.map(&.to_tuple).should eq(fields.map(&.to_tuple))
+    out.map(&.never_indexed?).should eq([true, false]) # marking survives the round trip
+    # And a decoder's table agrees: only the non-sensitive field was indexed.
+    dec = HPACK::Decoder.new
+    dec.decode(block)
+    dec.dynamic_entries.should eq([{"x-plain", "indexable"}])
+  end
+
+  it "keeps the never-indexed representation even on an exact static hit" do
+    # §6.2.3 says forward it with the SAME representation, so an exact static match
+    # must not collapse to a one-byte index — that would drop the marking.
+    enc = HPACK::Encoder.new(indexing: true)
+    block = enc.encode([HPACK::Field.new(":method", "GET", never_indexed: true)])
+    block.should_not eq(Bytes[0x82])
+    (block[0] & 0xf0).should eq(0x10)
+    out = HPACK::Decoder.new.decode_fields(block)
+    out.map(&.to_tuple).should eq([{":method", "GET"}])
+    out[0].never_indexed?.should be_true
+    enc.dynamic_entries.should be_empty
+  end
+
+  it "encodes plain tuples as not-never-indexed" do
+    # The marking is honoured, never guessed from the name: a caller handing us
+    # bare pairs gets the ordinary representation even for a sensitive-looking name.
+    block = HPACK::Encoder.new.encode([{"authorization", "Bearer x"}])
+    (block[0] & 0xf0).should eq(0x00)
+  end
+
+  # --- dynamic table: encoder and decoder stay in step -------------------------
+
+  it "keeps encoder and decoder tables in step across many blocks (with eviction)" do
+    rng = Random.new(0x51ac)
+    enc = HPACK::Encoder.new(max_size: 512, indexing: true)
+    dec = HPACK::Decoder.new(max_size: 512)
+    200.times do
+      headers = Array.new(rng.rand(1..6)) do
+        # A small name pool so entries repeat (exercising indexed hits) mixed with
+        # fresh ones (exercising insertion + eviction at the 512-byte cap).
+        name = ["cookie", "x-req-id", "accept", "user-agent", "x-#{rng.rand(8)}"].sample(rng)
+        value = rng.rand(3) == 0 ? "v#{rng.rand(4)}" : "x" * rng.rand(0..120)
+        {name, value}
+      end
+      dec.decode(enc.encode(headers)).should eq(headers)
+      enc.dynamic_entries.should eq(dec.dynamic_entries)
+    end
+  end
+
+  it "signals a dynamic table size change before the next block (§4.2/§6.3)" do
+    enc = HPACK::Encoder.new(indexing: true)
+    dec = HPACK::Decoder.new
+    dec.decode(enc.encode([{"x-a", "1"}, {"x-b", "2"}]))
+    enc.dynamic_entries.size.should eq(2)
+
+    # 40 bytes holds exactly one 36-byte entry, so the older one is evicted here,
+    # before the decoder has been told anything.
+    enc.max_size = 40
+    enc.dynamic_entries.should eq([{"x-b", "2"}])
+    block = enc.encode([{"x-c", "3"}])
+    (block[0] & 0xe0).should eq(0x20) # §6.3 dynamic table size update leads the block
+    dec.decode(block).should eq([{"x-c", "3"}])
+    dec.max_size.should eq(40)
+    enc.dynamic_entries.should eq(dec.dynamic_entries) # decoder evicted with us
+
+    # Two moves between blocks collapse to {low-water mark, final}: the decoder has
+    # to perform the eviction the low value caused, or every later index is off.
+    enc.max_size = 0
+    enc.max_size = 4096
+    block = enc.encode([{"x-d", "4"}])
+    dec.decode(block).should eq([{"x-d", "4"}])
+    dec.max_size.should eq(4096)
+    enc.dynamic_entries.should eq(dec.dynamic_entries)
+    # No change since the last block → no update byte.
+    (enc.encode([{"x-e", "5"}])[0] & 0xe0).should_not eq(0x20)
+  end
+
+  it "clamps a size update to the bound the decoder enforces" do
+    enc = HPACK::Encoder.new
+    enc.max_size = Int32::MAX
+    enc.max_size.should eq(HPACK::Encoder::MAX_TABLE_SIZE)
+    HPACK::Decoder.new.decode(enc.encode([{"x", "y"}])).should eq([{"x", "y"}]) # not rejected
+  end
+
+  # --- adversarial input (P7: encode what the peer sent, don't judge it) -------
+
+  it "encodes adversarial header content without raising" do
+    long = "A" * 100_000
+    binary = String.new(Bytes[0x00_u8, 0xff_u8, 0xfe_u8, 0x80_u8, 0x0a_u8, 0x0d_u8])
+    headers = [
+      {"", ""},             # empty name AND value
+      {"x-empty", ""},      # empty value
+      {"", "orphan-value"}, # empty name
+      {"x-long", long},     # value past every prefix-int boundary
+      {long, "x"},          # and a name just as long
+      {"x-binary", binary}, # NUL + non-UTF-8 bytes
+      {String.new(Bytes[0xc3_u8, 0x28_u8]), "invalid-utf8-name"},
+      {"x-dup", "1"}, {"x-dup", "2"}, # duplicate names
+      {"x-euckr", String.new(Bytes[0xb0_u8, 0xa1_u8])},
+    ]
+    [HPACK::Encoder.new, HPACK::Encoder.new(indexing: true),
+     HPACK::Encoder.new(max_size: 0, indexing: true)].each do |enc|
+      HPACK::Decoder.new.decode(enc.encode(headers)).should eq(headers)
+    end
+  end
+
+  it "skips Huffman when it would make the literal longer (§5.2)" do
+    # Layout for a literal with a literal name: [repr][name len]["x"][value len]...
+    # High bytes cost 20+ bits each, so 2 of them never compress back down to 2.
+    value = String.new(Bytes[0xff_u8, 0xfe_u8])
+    block = HPACK::Encoder.new.encode([{"x", value}])
+    HPACK::Decoder.new.decode(block).should eq([{"x", value}])
+    block[3].should eq(0x02_u8) # length 2, H-bit clear → raw octets
+    # A compressible value does take the H-bit: 16 'a' = 16×5 bits = 10 bytes.
+    HPACK::Encoder.new.encode([{"x", "a" * 16}])[3].should eq(0x8a_u8)
+  end
+
+  it "round-trips random header lists through encoder and decoder" do
+    rng = Random.new(0xbeef)
+    300.times do
+      headers = Array.new(rng.rand(0..8)) do
+        name = String.new(Bytes.new(rng.rand(0..12)) { rng.rand(0_u8..255_u8) })
+        value = String.new(Bytes.new(rng.rand(0..40)) { rng.rand(0_u8..255_u8) })
+        {name, value}
+      end
+      HPACK::Decoder.new.decode(HPACK::Encoder.new.encode(headers)).should eq(headers)
+      enc = HPACK::Encoder.new(indexing: true)
+      HPACK::Decoder.new.decode(enc.encode(headers)).should eq(headers)
+    end
+  end
 end

--- a/src/gori/proxy/h2/hpack.cr
+++ b/src/gori/proxy/h2/hpack.cr
@@ -1,10 +1,13 @@
 module Gori::Proxy::H2
-  # HPACK header decompression (RFC 7541) — decode only (we observe both peers'
-  # blocks; we never re-encode). One Decoder instance per direction per
-  # connection: the dynamic table is stateful across a connection's HEADERS
-  # frames, which is exactly why a single h2 stream's header bytes cannot be
-  # replayed out of connection context (hence raw-frame fidelity lives at the
-  # frame layer; this is the decoded projection, P7's "derived view").
+  # HPACK header compression (RFC 7541). One `Decoder` AND one `Encoder` instance
+  # per direction per connection: the dynamic table is stateful across a
+  # connection's HEADERS frames, which is exactly why a single h2 stream's header
+  # bytes cannot be replayed out of connection context (hence raw-frame fidelity
+  # lives at the frame layer; this is the decoded projection, P7's "derived view").
+  #
+  # The two halves are deliberately NOT coupled: an encoder's table is its own
+  # (RFC 7541 §2.2 — one table per direction, driven only by what that direction's
+  # encoder emits). Nothing here reads the peer's table to encode with.
   module HPACK
     # Static table (RFC 7541 Appendix A), 1-indexed by the protocol.
     STATIC = [
@@ -284,6 +287,24 @@ module Gori::Proxy::H2
       String.new(buf.to_slice)
     end
 
+    # One decoded header field. Carries the §6.2.3 "never indexed" marking next to
+    # the pair because that bit is an instruction TO intermediaries, not a
+    # compression detail we may drop and re-derive: a peer that sent a header as
+    # never-indexed asked everyone on the path to keep it out of every dynamic
+    # table, and `Encoder` can only honour that if the decode side preserved it.
+    struct Field
+      getter name : String
+      getter value : String
+      getter? never_indexed : Bool
+
+      def initialize(@name : String, @value : String, @never_indexed : Bool = false)
+      end
+
+      def to_tuple : {String, String}
+        {@name, @value}
+      end
+    end
+
     # Per-direction decoder holding the dynamic table (RFC 7541 §2.3.2).
     class Decoder
       ENTRY_OVERHEAD = 32 # per-entry accounting cost (§4.1)
@@ -304,7 +325,14 @@ module Gori::Proxy::H2
 
       # Decodes one header block into an ordered list of (name, value) pairs.
       def decode(block : Bytes) : Array({String, String})
-        headers = [] of {String, String}
+        decode_fields(block).map(&.to_tuple)
+      end
+
+      # Same decode, keeping each field's §6.2.3 never-indexed marking (see
+      # `Field`). `decode` is this minus that bit, so existing callers that only
+      # want the projection are unaffected.
+      def decode_fields(block : Bytes) : Array(Field)
+        headers = [] of Field
         list_size = 0
         pos = 0
         while pos < block.size
@@ -312,28 +340,31 @@ module Gori::Proxy::H2
           if b & 0x80 != 0
             # §6.1 Indexed Header Field
             index, pos = read_int(block, pos, 7)
-            headers << lookup(index)
+            headers << Field.new(*lookup(index))
           elsif b & 0x40 != 0
             # §6.2.1 Literal with Incremental Indexing
             index, pos = read_int(block, pos, 6)
             name, pos = field_name(block, pos, index)
             value, pos = read_string(block, pos)
             add(name, value)
-            headers << {name, value}
+            headers << Field.new(name, value)
           elsif b & 0x20 != 0
             # §6.3 Dynamic Table Size Update
             new_max, pos = read_int(block, pos, 5)
             resize(new_max)
             next
           else
-            # §6.2.2 (no indexing) / §6.2.3 (never indexed) — both 4-bit prefix
+            # §6.2.2 (no indexing) / §6.2.3 (never indexed) — both 4-bit prefix;
+            # bit 0x10 is what separates them, and it is the one an intermediary
+            # MUST carry through (§6.2.3), so it rides along on the Field.
+            never = b & 0x10 != 0
             index, pos = read_int(block, pos, 4)
             name, pos = field_name(block, pos, index)
             value, pos = read_string(block, pos)
-            headers << {name, value}
+            headers << Field.new(name, value, never)
           end
-          n, v = headers[-1]
-          list_size += n.bytesize + v.bytesize + ENTRY_OVERHEAD
+          f = headers[-1]
+          list_size += f.name.bytesize + f.value.bytesize + ENTRY_OVERHEAD
           raise Gori::Error.new("hpack: header list too large") if list_size > MAX_HEADER_LIST
         end
         headers
@@ -431,28 +462,193 @@ module Gori::Proxy::H2
       io.to_slice
     end
 
-    # Stateless HPACK encoder: static-table refs for exact/name matches, literal
-    # WITHOUT indexing for everything else (so it never touches a dynamic table —
-    # any decoder reads it). Foundation for replaying an h2 stream.
+    # HPACK encoder — the return path a rewritten h2 head needs (#492 step 1).
+    # Mirror of `Decoder`: its own dynamic table, its own `add`/`resize`/`evict`,
+    # with identical §4.1 entry accounting, because the two tables agree only if
+    # they are computed the same way. It never reads a Decoder's table.
+    #
+    # ## Dynamic-table insertion is opt-in, and off by default
+    #
+    # Emitting everything as a literal (static refs where they exist, otherwise
+    # WITHOUT indexing) is valid HPACK and leaves this encoder effectively
+    # stateless: the block decodes correctly against any decoder, with no shared
+    # history to keep in step. Insertion buys real compression — a repeated
+    # cookie or authorization header collapses to one byte — but only holds if
+    # THIS encoder is the sole writer of that direction for the whole connection.
+    #
+    # That is precisely what the intercept/rewrite path cannot promise yet. The
+    # h2 relay forwards frames byte-faithfully (`proxy/h2/relay.cr`); the moment
+    # one head is re-encoded and the next passes through untouched, the peer's
+    # decoder table is being driven by two encoders that never agreed on a
+    # history. Its dynamic indices then resolve to the WRONG header — silently,
+    # since an in-range index is not an error — or out of range, which takes the
+    # connection down. A literal-only encoder cannot cause either, at the cost of
+    # bytes on the wire. So the default is the choice that cannot corrupt a
+    # stream, and `indexing: true` is there for a caller that owns every head in
+    # its direction (the repeater's one-shot connection does; #492 step 2 must
+    # establish it before turning this on).
+    #
+    # ## Never-indexed is honoured, not inferred
+    #
+    # `Field#never_indexed?` re-emits §6.2.3 and keeps the field out of the table
+    # even with `indexing: true` — §6.2.3 requires an intermediary to use the same
+    # representation, and it is the sender's mechanism for saying "this is a
+    # secret, do not put it in a compression table". gori is that intermediary.
+    # There is no name-based guessing here: the marking travels with the field
+    # from `Decoder#decode_fields`.
     class Encoder
+      # Same §4.1 accounting as the decoder — an encoder that sized entries
+      # differently would evict at a different moment and shift every index.
+      ENTRY_OVERHEAD = Decoder::ENTRY_OVERHEAD
+
+      # Ceiling on a size update we will emit, mirroring `Decoder#resize`'s bound
+      # so we can never emit an update our own decoder would reject.
+      MAX_TABLE_SIZE = 1 << 20
+
+      getter max_size : Int32
+      getter? indexing : Bool
+
+      # `max_size` is the table size this encoder starts with; it MUST NOT exceed
+      # the peer's SETTINGS_HEADER_TABLE_SIZE (a smaller one is always safe — we
+      # simply evict earlier than the peer's decoder, which leaves the surviving
+      # entries at the same indices). Mid-connection changes go through
+      # `max_size=`, which signals them on the wire.
+      def initialize(max_size : Int32 = 4096, @indexing : Bool = false)
+        @max_size = max_size.clamp(0, MAX_TABLE_SIZE)
+        @table = Deque({String, String}).new # index 0 = most recently added
+        @size = 0
+      end
+
+      # Pending §6.3 size updates (RFC 7541 §4.2): a change is signalled at the
+      # start of the next block, never mid-block.
+      @pending_min : Int32? = nil
+      @pending_size : Int32? = nil
+
+      # Encodes a header list into one HPACK block. Nothing here raises on
+      # adversarial content (empty/duplicate names, huge values, non-UTF-8 bytes):
+      # names and values are treated as opaque octets, exactly as HPACK defines
+      # them (P7 — a rewritten head still has to carry whatever the peer sent).
       def encode(headers : Array({String, String})) : Bytes
         io = IO::Memory.new
-        headers.each { |(name, value)| encode_field(io, name, value) }
+        emit_size_updates(io)
+        headers.each { |(name, value)| encode_field(io, name, value, false) }
         io.to_slice
       end
 
-      private def encode_field(io : IO::Memory, name : String, value : String) : Nil
-        if idx = STATIC_PAIR[{name, value}]?
+      # :ditto:
+      def encode(fields : Array(Field)) : Bytes
+        io = IO::Memory.new
+        emit_size_updates(io)
+        fields.each { |f| encode_field(io, f.name, f.value, f.never_indexed?) }
+        io.to_slice
+      end
+
+      # Changes the table size, to be signalled on the next block (§4.2) — this is
+      # how a peer's SETTINGS_HEADER_TABLE_SIZE update reaches the wire.
+      def max_size=(new_max : Int32) : Nil
+        new_max = new_max.clamp(0, MAX_TABLE_SIZE)
+        return if new_max == @max_size
+        @max_size = new_max
+        low = @pending_min
+        @pending_min = low ? Math.min(low, new_max) : new_max
+        @pending_size = new_max
+        evict
+      end
+
+      # The current dynamic-table entries, newest first (for inspection/specs).
+      def dynamic_entries : Array({String, String})
+        @table.to_a
+      end
+
+      private def encode_field(io : IO::Memory, name : String, value : String,
+                               never_indexed : Bool) : Nil
+        # A never-indexed field skips the indexed representation even on an exact
+        # STATIC hit: §6.2.3's "MUST use the same representation to forward" is
+        # about the representation, not just the table, and collapsing e.g. a
+        # never-indexed ":method GET" to 0x82 would drop the marking for the next
+        # hop. Costs a few bytes on a field nobody wants compressed anyway.
+        if !never_indexed && (idx = index_of(name, value))
           encode_int(io, idx, 7, 0x80_u8) # §6.1 indexed header field
           return
         end
-        # §6.2.2 literal without indexing; 4-bit name index (0 = literal name).
-        name_idx = STATIC_NAME[name]? || 0
-        encode_int(io, name_idx, 4, 0x00_u8)
+        name_idx = name_index(name) || 0 # 0 = literal name follows
+        insert = @indexing && !never_indexed && fits?(name, value)
+        if insert
+          encode_int(io, name_idx, 6, 0x40_u8) # §6.2.1 literal, incremental indexing
+        elsif never_indexed
+          encode_int(io, name_idx, 4, 0x10_u8) # §6.2.3 literal, never indexed
+        else
+          encode_int(io, name_idx, 4, 0x00_u8) # §6.2.2 literal, without indexing
+        end
         encode_string(io, name) if name_idx == 0
         encode_string(io, value)
+        # Every index above refers to the table as the decoder sees it BEFORE this
+        # field, so the insert lands last (§6.2.1's "then added").
+        add(name, value) if insert
       end
 
+      # Exact (name, value) hit. Static first: its indices are one byte and it
+      # costs no table state.
+      private def index_of(name : String, value : String) : Int32?
+        if idx = STATIC_PAIR[{name, value}]?
+          return idx
+        end
+        @table.each_with_index do |entry, i|
+          return STATIC.size + 1 + i if entry[0] == name && entry[1] == value
+        end
+        nil
+      end
+
+      private def name_index(name : String) : Int32?
+        if idx = STATIC_NAME[name]?
+          return idx
+        end
+        @table.each_with_index do |entry, i|
+          return STATIC.size + 1 + i if entry[0] == name
+        end
+        nil
+      end
+
+      # §4.4: adding an entry larger than the whole table empties it. Both sides
+      # would do that consistently, so it is not a correctness problem — it is
+      # just a pure loss, so such a field goes out without indexing instead.
+      private def fits?(name : String, value : String) : Bool
+        name.bytesize + value.bytesize + ENTRY_OVERHEAD <= @max_size
+      end
+
+      private def add(name : String, value : String) : Nil
+        @table.unshift({name, value})
+        @size += name.bytesize + value.bytesize + ENTRY_OVERHEAD
+        evict
+      end
+
+      private def evict : Nil
+        while @size > @max_size && !@table.empty?
+          name, value = @table.pop # oldest
+          @size -= name.bytesize + value.bytesize + ENTRY_OVERHEAD
+        end
+      end
+
+      private def emit_size_updates(io : IO::Memory) : Nil
+        final = @pending_size
+        return if final.nil?
+        low = @pending_min
+        # §4.2: if the max moved more than once since the last block, the decoder
+        # has to see the low-water mark too, otherwise it never performs the
+        # eviction we already performed and every later index is off by that much.
+        encode_int(io, low, 5, 0x20_u8) if low && low != final
+        encode_int(io, final, 5, 0x20_u8)
+        @pending_min = nil
+        @pending_size = nil
+      end
+
+      # §5.2: Huffman only when it actually shrinks the string — the choice is the
+      # encoder's, and a Huffman-coded literal that came out longer is strictly
+      # worse (short or high-entropy values expand: one byte ≥ 0x80 costs 20+ bits).
+      # A tie goes to the raw literal, which costs neither side the coding pass and
+      # leaves the value readable in the raw frame log (P7's truth). That is the one
+      # place we differ from the reference encoder in RFC 7541 Appendix C, which
+      # Huffman-codes ties — see the C.6 spec.
       private def encode_string(io : IO::Memory, s : String) : Nil
         huff = HPACK.huffman_encode(s)
         if huff.size < s.bytesize


### PR DESCRIPTION
Step **1 of #492** — the HPACK encoder. Does not close the epic and does not touch the proxy: `relay.cr`, `assembler.cr`, `tunnel.cr` and `h2_candidate?` are untouched, and step 2 (wiring `HeadRewriter` to h2 heads) is what consumes this.

## One correction to the epic

The checklist says "`hpack.cr` is decode-only". It has not been since `init`: there is a small stateless `Encoder` (static refs, otherwise literal without indexing) that `repeater/h2_engine.cr:92` uses to write one request onto one fresh connection, plus `huffman_encode`. That encoder is correct for what it does, and one-shot replay is exactly the case where statelessness costs nothing.

It is not enough for a rewritten head. HPACK is stateful, and an intermediary that re-emits somebody else's headers has obligations about which of them may enter a compression table at all. So this PR completes the encoder rather than writing one.

## The dynamic table, and why insertion is off by default

The encoder now has its own dynamic table, mirroring `Decoder`'s `add`/`resize`/`evict` and its §4.1 entry accounting — not sharing the decoder's, because HPACK tables are per-connection **and** per-direction (§2.2). An encoder that read a decoder's table would be reading the wrong table.

Insertion is `indexing: true`, and **off by default.**

Literal-only output — static references where they exist, §6.2.2 otherwise — is valid HPACK and effectively stateless: the block decodes against any decoder, in any order, with no shared history to keep in step. Insertion compresses far better; a repeated cookie collapses to one byte.

It is only sound if this encoder is the sole writer of its direction for the whole connection, and **that is exactly what the intercept path cannot promise yet.** The h2 relay forwards frames byte-faithfully. The moment one head is re-encoded and the next passes through untouched, the peer's decoder table is being driven by two encoders that never agreed on a history — and the failure is not a compression miss. A dynamic index that is still in range resolves to *a different header*, silently; one that is out of range takes the connection down. A literal-only encoder cannot cause either.

So the default is the option that cannot corrupt a stream, and the flag is there for a caller that owns every head in its direction. The repeater's one-shot connection does. **Step 2 has to establish it before turning this on** — which is a condition about the relay, not about this file.

Reading it the other way is the point of the epic's own P7 note: a re-encoded head will not be byte-identical to the original even with no edits, and it is *more* different with indexing on.

## Never-indexed

The decoder collapsed §6.2.2 and §6.2.3 into the same pair — the 0x10 bit was read and dropped. Without it, step 2 puts `authorization` headers into a dynamic table.

`Decoder#decode_fields` now returns `Field`s carrying the marking, and `Encoder` re-emits that representation and keeps the field out of its table **even with indexing on**. `Decoder#decode` is unchanged and still returns pairs, so the assembler and the h2 repeater engine see exactly what they saw before.

Two details worth stating:

- The marking is honoured, never inferred. There is no list of sensitive header names here. §6.2.3 is the *sender's* mechanism for saying "do not put this in a compression table", it travels with the field, and gori is the intermediary the clause addresses. A caller handing us bare `{name, value}` pairs gets the ordinary representation even for a name that looks sensitive.
- A never-indexed field skips the indexed representation even on an exact **static** hit. §6.2.3's "MUST use the same representation to forward this header field" is about the representation, not just about the table, so collapsing a never-indexed `:method GET` to `0x82` would drop the marking for the next hop. Costs a few bytes on a field nobody wants compressed anyway.

## Also in

- **Table size updates (§4.2/§6.3).** `max_size=` signals the change at the start of the next block. Two moves between blocks collapse to `{low-water mark, final}`: the decoder has to perform the eviction the low value already caused on our side, or every dynamic index after it is off by that much. Clamped to the same 1 MiB bound `Decoder#resize` enforces, so we can never emit an update our own decoder rejects.
- **Huffman stays conditional (§5.2).** Ties go to the raw literal — same length, no coding pass on either side, and the value stays readable in the raw frame log. That is the one place the output differs from the reference encoder in RFC 7541 Appendix C, which codes ties; the C.6 spec asserts the divergence explicitly instead of hiding it.
- **§4.4 entries too large for the whole table** go out without indexing. Inserting them would empty both tables consistently, so it is not a correctness problem, just a pure loss.

## Verification

`crystal spec` — 4988 examples, 0 failures. `ameba` clean on both touched files.

**RFC 7541 C.4.1–C.4.3 and C.6.1 are reproduced byte-for-byte**, across a sequence of blocks sharing one encoder, including the 256-byte table in C.6 where an eviction has to land at the same moment on both sides for the back-references to resolve at all. Each vector is asserted **both ways** — the fixture must decode to the header list first, which validates the fixture against the already-trusted decoder before the encoder is measured against it, so a mistyped fixture fails loudly rather than being encoded into the expectation.

Beyond the vectors:

- the existing decode fixtures pushed back through the encoder and decoded again (the cheapest real-traffic check: blocks a real HPACK encoder produced);
- encoder and decoder tables asserted equal after every one of 200 generated blocks, at a 512-byte cap chosen so eviction actually fires;
- 300 random header lists round-tripped with indexing both on and off;
- adversarial content that must encode without raising (P7): empty names, empty values, a 100 KB value, a name just as long, duplicate names, NUL bytes, invalid UTF-8, EUC-KR bytes.

Refs #492
