### PR TITLE
fix(settings,session): reconcile the listeners array live instead of waiting for a restart

### DIFF
--- a/spec/session_listeners_spec.cr
+++ b/spec/session_listeners_spec.cr
@@ -1,0 +1,262 @@
+require "./spec_helper"
+require "file_utils"
+
+# #508: the `listeners` section is hand-edited in settings.json, so a reconcile is what makes an
+# edit take effect without a restart. These examples drive the REAL sockets and connect to them —
+# the question the issue settles is a lifecycle one, and a recording double would prove nothing
+# about whether a socket actually came up, went down, or was left alone.
+
+private def free_port : Int32
+  s = TCPServer.new("127.0.0.1", 0)
+  port = s.local_address.port
+  s.close
+  port
+end
+
+private def accepts?(port : Int32) : Bool
+  TCPSocket.new("127.0.0.1", port, connect_timeout: 2.seconds).close
+  true
+rescue
+  false
+end
+
+# The live `Proxy::Server` objects. Read off the ivar rather than through a getter on purpose:
+# `Session` deliberately exposes only `listener_rows` (plain values) so the TUI cannot reach a
+# listener's socket through a readout, and proving "this socket was not touched" needs object
+# identity, which is a spec's business and nobody else's.
+private def servers_of(session : Gori::Session) : Array(Gori::Proxy::Server)
+  session.@extra_listeners.map(&.server)
+end
+
+# Open a real Session whose settings.json lives in a temp dir, so `disk_listeners?` reads what
+# the example writes. `Settings.listeners` is seeded from the same file, exactly as a real
+# startup would: the drift this issue is about only exists once the two can diverge.
+private def with_reconcile_session(entries : String, &)
+  root = File.tempname("gori-listen-reconcile")
+  Dir.mkdir_p(root)
+  cfg = File.join(root, "settings.json")
+  prev_host = Gori::Settings.bind_host
+  prev_port = Gori::Settings.bind_port
+  prev_listeners = Gori::Settings.listeners
+  begin
+    Gori::Settings.path_override = cfg
+    Gori::Settings.project_bind_host = nil
+    Gori::Settings.project_bind_port = nil
+    Gori::Settings.bind_host = "127.0.0.1"
+    Gori::Settings.bind_port = 0
+    File.write(cfg, %({"listeners": #{entries}}))
+    Gori::Settings.listeners = Gori::Settings.disk_listeners
+    ca = Gori::Proxy::Tls::CertAuthority.load_or_create(File.join(root, "ca"))
+    project = Gori::ProjectRegistry.new(File.join(root, "projects")).create("reconcile")
+    session = Gori::Session.open(Gori::Config.new(listen: "127.0.0.1", port: 0),
+      ca, Gori::Verbs.registry, project)
+    begin
+      yield session, cfg
+    ensure
+      session.close
+    end
+  ensure
+    Gori::Settings.path_override = nil
+    Gori::Settings.bind_host = prev_host
+    Gori::Settings.bind_port = prev_port
+    Gori::Settings.listeners = prev_listeners
+    FileUtils.rm_rf(root)
+  end
+end
+
+private def rewrite(cfg : String, entries : String) : Nil
+  File.write(cfg, %({"listeners": #{entries}}))
+end
+
+describe Gori::Session, "#reconcile_listeners! (#508)" do
+  it "starts a listener added to settings.json, with no restart" do
+    a, b = free_port, free_port
+    with_reconcile_session(%([{"host": "127.0.0.1", "port": #{a}}])) do |session, cfg|
+      accepts?(a).should be_true
+      accepts?(b).should be_false
+
+      rewrite(cfg, %([{"host": "127.0.0.1", "port": #{a}}, {"host": "127.0.0.1", "port": #{b}}]))
+      result = session.reconcile_listeners!
+      result.should_not be_nil
+      result = result.not_nil!
+      result.added.should eq(1)
+      result.removed.should eq(0)
+      result.serving.should eq(2)
+      accepts?(b).should be_true
+      accepts?(a).should be_true # the one that was already there is still up
+    end
+  end
+
+  it "stops a listener removed from settings.json, with no restart" do
+    a, b = free_port, free_port
+    with_reconcile_session(%([{"host": "127.0.0.1", "port": #{a}}, {"host": "127.0.0.1", "port": #{b}}])) do |session, cfg|
+      accepts?(b).should be_true
+
+      rewrite(cfg, %([{"host": "127.0.0.1", "port": #{a}}]))
+      result = session.reconcile_listeners!.not_nil!
+      result.removed.should eq(1)
+      result.added.should eq(0)
+      result.serving.should eq(1)
+      accepts?(b).should be_false
+      accepts?(a).should be_true
+    end
+  end
+
+  # The requirement the issue is most explicit about: a diff, not stop-all/start-all. Asserted on
+  # the SERVER OBJECT rather than on `accepts?`, because a socket that went down and came back up
+  # inside one reconcile would still pass a connect test having dropped every connection on it.
+  it "never touches a listener the edit did not concern" do
+    a, b = free_port, free_port
+    with_reconcile_session(%([{"host": "127.0.0.1", "port": #{a}}, {"host": "127.0.0.1", "port": #{b}, "mode": "reverse", "origin": "https://one.example"}])) do |session, cfg|
+      untouched = servers_of(session).find { |s| s.port == a }.not_nil!
+
+      rewrite(cfg, %([{"host": "127.0.0.1", "port": #{a}}, {"host": "127.0.0.1", "port": #{b}, "mode": "reverse", "origin": "https://two.example"}]))
+      result = session.reconcile_listeners!.not_nil!
+      result.retargeted.should eq(1)
+      result.added.should eq(0)
+      result.removed.should eq(0)
+
+      # The same object, still listening: the untouched row's accept loop — and every connection
+      # riding it — survived an edit to the row below it.
+      servers_of(session).find { |s| s.port == a }.should be(untouched)
+      untouched.listening?.should be_true
+      # The retargeted one is a NEW socket on the SAME address, now pointed at the new origin.
+      retargeted = servers_of(session).find { |s| s.port == b }.not_nil!
+      retargeted.origin.should eq({"https", "two.example", 443})
+      accepts?(b).should be_true
+    end
+  end
+
+  it "reports a listener that cannot bind, and keeps serving the rest" do
+    a = free_port
+    blocker = TCPServer.new("127.0.0.1", 0)
+    taken = blocker.local_address.port
+    begin
+      with_reconcile_session(%([{"host": "127.0.0.1", "port": #{a}}])) do |session, cfg|
+        rewrite(cfg, %([{"host": "127.0.0.1", "port": #{a}}, {"host": "127.0.0.1", "port": #{taken}}]))
+        result = session.reconcile_listeners!.not_nil!
+        result.added.should eq(1)
+        result.failed.size.should eq(1)
+        result.failed.first.should start_with("127.0.0.1:#{taken} —")
+        # It was never up, so this is a plain failure and not the "was serving" wording.
+        result.dropped.should be_empty
+        result.serving.should eq(1)
+        accepts?(a).should be_true
+
+        # And it reads exactly like a bind failure at open: one row carrying its own reason.
+        row = servers_row(session, taken)
+        row.listening.should be_false
+        row.error.should_not be_nil
+      end
+    ensure
+      blocker.close
+    end
+  end
+
+  # A listener whose bind failed at open is retried, so a reconcile is also how an operator
+  # recovers one after freeing its port — without restarting the ones that did come up.
+  it "retries a listener that is configured but not serving" do
+    a = free_port
+    blocker = TCPServer.new("127.0.0.1", 0)
+    taken = blocker.local_address.port
+    begin
+      entries = %([{"host": "127.0.0.1", "port": #{a}}, {"host": "127.0.0.1", "port": #{taken}}])
+      with_reconcile_session(entries) do |session, _cfg|
+        servers_row(session, taken).listening.should be_false
+        blocker.close
+
+        # settings.json is UNCHANGED — the fix was outside gori.
+        result = session.reconcile_listeners!.not_nil!
+        result.changed?.should be_false
+        result.serving.should eq(2)
+        accepts?(taken).should be_true
+      end
+    ensure
+      blocker.close rescue nil
+    end
+  end
+
+  it "refuses to reconcile against a settings.json it cannot parse" do
+    a = free_port
+    with_reconcile_session(%([{"host": "127.0.0.1", "port": #{a}}])) do |session, cfg|
+      File.write(cfg, "{not json")
+      session.reconcile_listeners!.should be_nil
+      # Nothing was torn down over a typo somewhere else in the document.
+      accepts?(a).should be_true
+      session.listener_rows.size.should eq(1)
+    end
+  end
+
+  it "clears the drift notice once the edit has been applied" do
+    a, b = free_port, free_port
+    with_reconcile_session(%([{"host": "127.0.0.1", "port": #{a}}])) do |session, cfg|
+      session.listeners_changed_on_disk?.should be_false
+      rewrite(cfg, %([{"host": "127.0.0.1", "port": #{b}}]))
+      session.listeners_changed_on_disk?.should be_true
+      session.reconcile_listeners!
+      session.listeners_changed_on_disk?.should be_false
+    end
+  end
+
+  # `Server#rebind`'s rule one level up: not listening means record the new set and bind nothing.
+  it "records the new set without binding while capture is off" do
+    a, b = free_port, free_port
+    with_reconcile_session(%([{"host": "127.0.0.1", "port": #{a}}])) do |session, cfg|
+      session.toggle_capture.should be_false
+      accepts?(a).should be_false
+
+      rewrite(cfg, %([{"host": "127.0.0.1", "port": #{b}}]))
+      result = session.reconcile_listeners!.not_nil!
+      result.capturing.should be_false
+      result.serving.should eq(0)
+      accepts?(b).should be_false
+
+      # The next `c` opens the RECONCILED set, not the one gori started with.
+      session.toggle_capture.should be_true
+      accepts?(b).should be_true
+      accepts?(a).should be_false
+    end
+  end
+end
+
+private def servers_row(session : Gori::Session, port : Int32) : Gori::Session::ListenerRow
+  session.listener_rows.find { |r| r.port == port }.not_nil!
+end
+
+private def reconcile(added = 0, removed = 0, retargeted = 0, serving = 0,
+                      failed = [] of String, dropped = [] of String,
+                      capturing = true) : Gori::Session::ListenerReconcile
+  Gori::Session::ListenerReconcile.new(added, removed, retargeted, serving, failed, dropped, capturing)
+end
+
+describe Gori::Session::ListenerReconcile do
+  it "says nothing moved when nothing moved" do
+    reconcile(serving: 2).summary
+      .should eq("listeners: settings.json already matches the running sockets")
+  end
+
+  it "counts what the edit changed, and how many sockets serve after it" do
+    reconcile(added: 1, removed: 1, retargeted: 1, serving: 3).summary
+      .should eq("listeners: 1 added, 1 removed, 1 retargeted · 3 serving")
+  end
+
+  # A count of failures, not their addresses: each is already a row in the overlay the message
+  # points at, and a message long enough to list them is one nobody reads.
+  it "points a bind failure at the readout that names it" do
+    reconcile(added: 1, serving: 1, failed: ["127.0.0.1:9000 — in use"]).summary
+      .should eq("listeners: 1 added — 1 could not bind (see the listeners chip)")
+  end
+
+  # The one outcome the operator has to act on, and the only one where a socket they still want
+  # went away: it gets its own wording and names the address rather than being counted.
+  it "names a listener that was serving and did not come back" do
+    reconcile(retargeted: 1, serving: 1, failed: ["127.0.0.1:9000 — in use"],
+      dropped: ["127.0.0.1:9000"]).summary
+      .should eq("listeners: 1 retargeted — 127.0.0.1:9000 was serving and could not rebind")
+  end
+
+  it "does not report 0 serving as a failure when capture is simply off" do
+    reconcile(added: 1, capturing: false).summary
+      .should eq("listeners: 1 added — capture is off, press c to start")
+  end
+end

--- a/spec/settings_listeners_spec.cr
+++ b/spec/settings_listeners_spec.cr
@@ -205,4 +205,61 @@ describe Gori::Settings do
       listener("127.0.0.1", 8080, "transparent").effective_target_port(false).should eq(80)
     end
   end
+
+  # #508: the live reconcile validates a set it read from DISK and deliberately does not write
+  # back over `Settings.listeners` (that would let the next save clobber a hand edit), so every
+  # validator has to be able to say which set it means.
+  describe "validating a candidate set (#508)" do
+    it "checks the loop rule against `among`, not the class property" do
+      other = listener("127.0.0.1", 9100)
+      rev = listener("127.0.0.1", 9000, "reverse", origin: "http://127.0.0.1:9100")
+      with_listeners("127.0.0.1", 8070, [] of Gori::Settings::Listener) do
+        # Not in Settings.listeners: nothing to loop against, so it validates.
+        Gori::Settings.listener_error(rev).should be_nil
+        # Named in the candidate set: the origin points at another socket in the same edit.
+        Gori::Settings.listener_error(rev, [rev, other]).should_not be_nil
+      end
+    end
+
+    it "filters and reports errors over the given set" do
+      set = [listener("127.0.0.1", 9000), listener("127.0.0.1", 9001, "reverse")]
+      with_listeners("127.0.0.1", 8070, [] of Gori::Settings::Listener) do
+        Gori::Settings.valid_listeners(set).map(&.port).should eq([9000])
+        Gori::Settings.listener_config_errors(set).size.should eq(1)
+        # The class property is untouched by validating somebody else's array.
+        Gori::Settings.valid_listeners.should be_empty
+        Gori::Settings.listeners.should be_empty
+      end
+    end
+  end
+
+  describe ".disk_listeners?" do
+    it "separates an unreadable file from an absent section" do
+      dir = File.tempname("gori-disk-listeners")
+      Dir.mkdir_p(dir)
+      path = File.join(dir, "settings.json")
+      begin
+        Gori::Settings.path_override = path
+        # No file at all, and a file with no `listeners` key, both mean "the section is empty".
+        Gori::Settings.disk_listeners?.should eq([] of Gori::Settings::Listener)
+        File.write(path, %({"theme": "dark"}))
+        Gori::Settings.disk_listeners?.should eq([] of Gori::Settings::Listener)
+
+        File.write(path, %({"listeners": [{"host": "127.0.0.1", "port": 9000}]}))
+        Gori::Settings.disk_listeners?.try(&.map(&.port)).should eq([9000])
+
+        # Unparseable is NOT "empty": a reconcile acting on that would tear sockets down over a
+        # typo in an unrelated section, so it gets nil and refuses.
+        File.write(path, "{not json")
+        Gori::Settings.disk_listeners?.should be_nil
+        # The drift CHECK keeps its old fallback — it only decides whether to say something.
+        with_listeners("127.0.0.1", 8070, [listener("127.0.0.1", 9000)]) do
+          Gori::Settings.disk_listeners.map(&.port).should eq([9000])
+        end
+      ensure
+        Gori::Settings.path_override = nil
+        FileUtils.rm_rf(dir)
+      end
+    end
+  end
 end

--- a/src/gori/session.cr
+++ b/src/gori/session.cr
@@ -90,10 +90,7 @@ module Gori
         # operator's only other signal is traffic that never arrives).
         listener_errs = Settings.listener_config_errors
         extra = Settings.valid_listeners.map do |l|
-          Proxy::Server.new(l.host, l.port, sink, tls: tunnel,
-            rewriter: rules, interceptor: interceptor, host_overrides: host_overrides,
-            transparent: l.transparent?, target_port: l.target_port,
-            origin: l.origin_target, rewrite_host: l.rewrite_host)
+          build_listener(l, sink, tunnel, rules, interceptor, host_overrides)
         end
         # Per-PROJECT capture lock decides whether THIS instance captures. A 2nd
         # instance of the SAME project can't acquire it → VIEW-ONLY (no 2nd port; it
@@ -112,12 +109,12 @@ module Gori
                 # is COLLECTED rather than swallowed — a redirect rule pointing at a socket that
                 # never bound is invisible from the client's side.
                 extra.each do |e|
-                  e.start
+                  e.server.start
                 rescue ex
                   # BindAddress.authority, not bare interpolation: `listener_rows` matches a
                   # failure back to its server by this prefix, and a raw `::1` bind renders as
                   # the unparseable "::1:8070" (the same bug BindAddress exists to kill).
-                  listener_errs << "#{Gori::BindAddress.authority(e.host, e.port)} — #{ex.message || "could not bind"}"
+                  listener_errs << bind_failure(e.server, ex)
                 end
                 nil
               rescue ex
@@ -148,7 +145,7 @@ module Gori
           store.clear_intercept_state!
           probe.start
         end
-        session = new(config, ca, registry, project, store, proxy, tunnel, events, probe, rules, scope, host_overrides, interceptor, bind_error, lock, extra, listener_errs)
+        session = new(config, ca, registry, project, store, proxy, tunnel, events, probe, rules, scope, host_overrides, interceptor, sink, bind_error, lock, extra, listener_errs)
         session.sync_capture_status!
         session
       rescue ex
@@ -164,31 +161,191 @@ module Gori
       end
     end
 
+    # One additional listener: the settings record it was built from, paired with the socket
+    # serving it. Paired rather than kept in two index-aligned arrays because `reconcile_listeners!`
+    # diffs the RECORDS to decide which sockets to touch, and a pairing that could slip would mean
+    # restarting the wrong one — the exact failure the diff exists to avoid.
+    record ExtraListener, spec : Settings::Listener, server : Proxy::Server
+
+    # Build (but do not start) the socket for one listener entry. Shared by `open` and the live
+    # reconcile so a listener added at runtime is wired to the same sink, TLS tunnel, rewriter,
+    # interceptor and host overrides as one that was there at startup — a second construction
+    # site is how a reconciled listener would quietly stop obeying the project's scope.
+    def self.build_listener(l : Settings::Listener, sink : Proxy::FlowSink,
+                            tunnel : Proxy::Tls::Tunnel, rules : Rules,
+                            interceptor : Interceptor,
+                            host_overrides : HostOverrides) : ExtraListener
+      ExtraListener.new(l, Proxy::Server.new(l.host, l.port, sink, tls: tunnel,
+        rewriter: rules, interceptor: interceptor, host_overrides: host_overrides,
+        transparent: l.transparent?, target_port: l.target_port,
+        origin: l.origin_target, rewrite_host: l.rewrite_host))
+    end
+
+    # The one spelling of a bind failure. `listener_rows` matches a failure back to its server by
+    # the address prefix, so open, capture-toggle and reconcile must all format it identically.
+    def self.bind_failure(server : Proxy::Server, ex : Exception) : String
+      "#{Gori::BindAddress.authority(server.host, server.port)} — #{ex.message || "could not bind"}"
+    end
+
     # A random per-session token stamped on every #123 intercept snapshot/command row, so a
     # stale command from a prior session (whose interceptor item ids reset to 0) can never be
     # applied against a different new held item — the drain acks a token mismatch as stale.
     getter intercept_token : String
 
     def initialize(@config, @ca, @registry, @project, @store, @proxy, @tunnel, @flow_events, @probe,
-                   @rules, @scope, @host_overrides, @interceptor, @bind_error : String? = nil,
+                   @rules, @scope, @host_overrides, @interceptor, @sink : Proxy::FlowSink,
+                   @bind_error : String? = nil,
                    @capture_lock : CaptureLock? = nil,
-                   @extra_listeners : Array(Proxy::Server) = [] of Proxy::Server,
+                   @extra_listeners : Array(ExtraListener) = [] of ExtraListener,
                    @listener_errors : Array(String) = [] of String)
       @intercept_token = Random::Secure.hex(8)
-      @listeners_at_open = Settings.listeners.dup
+      @listeners_applied = Settings.listeners.dup
     end
 
     # True when the `listeners` section on disk no longer matches the one these sockets were
-    # built from (#508). Nothing here reconciles — applying the change live is a lifecycle
-    # problem with its own failure modes and is deliberately out of scope — but the operator
-    # has to be TOLD, because a reverse listener is retargeted interactively and silence after
-    # an edit reads as "applied".
+    # built from (#508) — i.e. there is an edit `reconcile_listeners!` has not applied yet.
     #
-    # Compared against what THIS session opened with, not against `Settings.listeners`: the two
-    # are the same object today, and pinning the comparison to the session is what keeps this
-    # honest if the runtime copy ever starts being refreshed.
+    # Compared against what this session last APPLIED, not against `Settings.listeners`: the
+    # class property is the copy read at startup and is deliberately never refreshed (see
+    # `Settings.listener_error`'s `among` for why writing it back would clobber hand edits), so
+    # only the session knows which section its sockets currently answer to.
     def listeners_changed_on_disk? : Bool
-      Settings.disk_listeners != @listeners_at_open
+      Settings.disk_listeners != @listeners_applied
+    end
+
+    # What one reconcile did. `added`/`removed` count entries the section GAINED and LOST;
+    # `retargeted` counts the ones that kept their address and changed everything else (a
+    # reverse listener pointed at a new origin — the case #499 made interactive and therefore
+    # the case this whole issue is about), which would otherwise read as one of each.
+    #
+    # `dropped` is the wording the issue asked for: an address that WAS serving, is still
+    # wanted, and did not come back. It is the only outcome the operator must act on, and it is
+    # deliberately separate from `failed` (which also covers a listener that never bound).
+    record ListenerReconcile,
+      added : Int32,
+      removed : Int32,
+      retargeted : Int32,
+      serving : Int32,
+      failed : Array(String),
+      dropped : Array(String),
+      capturing : Bool do
+      def changed? : Bool
+        added > 0 || removed > 0 || retargeted > 0
+      end
+
+      # What the reconcile did, in one line. Lives on the record rather than in the TUI shell
+      # for the same reason `ListenerRow` does: it is a pure function of the outcome, and the
+      # branch that matters most (`dropped`) is the one a shell method would be hardest to
+      # exercise. The counts come first because they answer "did my edit land"; a bind failure
+      # comes last and NAMES the address, because that is the part the operator has to go fix.
+      def summary : String
+        parts = [] of String
+        parts << "#{added} added" if added > 0
+        parts << "#{removed} removed" if removed > 0
+        parts << "#{retargeted} retargeted" if retargeted > 0
+        head = parts.empty? ? "listeners: settings.json already matches the running sockets" : "listeners: #{parts.join(", ")}"
+        # Capture off means nothing was bound and nothing could be — "0 serving" would read as a
+        # failure of the reconcile rather than as the state the operator put gori in.
+        return "#{head} — capture is off, press c to start" unless capturing
+        "#{head}#{tail}"
+      end
+
+      private def tail : String
+        # The wording #508 asked for: it WAS serving, it is STILL wanted, and it did not come
+        # back. Distinct from `failed`, which also covers a listener that never bound at all.
+        return " — #{dropped.join(", ")} was serving and could not rebind" if dropped.present?
+        return " — #{failed.size} could not bind (see the listeners chip)" unless failed.empty?
+        changed? ? " · #{serving} serving" : ""
+      end
+    end
+
+    # Re-read the `listeners` section from settings.json and make this session's additional
+    # sockets match it, without a restart (#508). Returns what moved, or nil when the file could
+    # not be read — a reconcile driven by a fallback would tear sockets down over a typo in an
+    # unrelated section, so it refuses instead.
+    #
+    # The shape is the primary bind's live rebind (`runner.cr` `apply_settings`), one level up:
+    # that one early-returns when the address has not moved, this one leaves alone every listener
+    # whose record has not moved. **A listener that is unchanged AND already serving is never
+    # touched** — which is what makes an edit to one row incapable of dropping a working socket
+    # somewhere else in the array. Stop-all/start-all would have done exactly that.
+    #
+    # Fates, all of them defined by `Proxy::Server#stop` closing only the ACCEPT socket:
+    #
+    #   - removed from the section → stops accepting; connections already established finish on
+    #     their own fibers. Same fate as capture-off and as a primary rebind.
+    #   - same address, changed config → stopped then rebuilt, in that order, because the new
+    #     socket wants the address the old one holds. In-flight connections keep running against
+    #     the configuration they were accepted under, which is the only answer that does not
+    #     retarget a request mid-flight.
+    #   - unchanged but NOT serving (its bind failed earlier, or capture was off) → retried. A
+    #     reconcile is also how an operator recovers a listener after freeing its port.
+    #
+    # Nothing is started while capture is off: the sockets are rebuilt so the next `c` opens the
+    # right set, which is `Server#rebind`'s "not listening → just record the new bind" rule.
+    def reconcile_listeners! : ListenerReconcile?
+      desired_raw = Settings.disk_listeners?
+      return nil unless desired_raw
+      desired = Settings.valid_listeners(desired_raw)
+      before = @extra_listeners.map(&.spec)
+      up_before = @extra_listeners.select(&.server.listening?).map { |e| authority_of(e.server) }
+
+      # Phase 1 — every stop, BEFORE any start, so a listener that kept its address can rebind.
+      pending = desired.dup
+      keep = [] of ExtraListener
+      @extra_listeners.each do |e|
+        idx = pending.index(e.spec)
+        if idx && e.server.listening?
+          pending.delete_at(idx)
+          keep << e
+        else
+          e.server.stop rescue nil
+        end
+      end
+
+      # Phase 2 — build and start whatever has no surviving socket.
+      failed = [] of String
+      @extra_listeners = keep
+      pending.each do |l|
+        e = Session.build_listener(l, @sink, @tunnel, @rules, @interceptor, @host_overrides)
+        @extra_listeners << e
+        next unless capturing?
+        begin
+          e.server.start
+        rescue ex
+          failed << Session.bind_failure(e.server, ex)
+          ::Log.warn { "listener #{e.server.host}:#{e.server.port} failed to bind: #{ex.message}" }
+        end
+      end
+
+      # Config-time rejections first, then this reconcile's bind failures — the same two-part
+      # list `start_extra_listeners` maintains, so the readout cannot tell a reconciled session
+      # from a freshly opened one.
+      @listener_errors.clear
+      @listener_errors.concat(Settings.listener_config_errors(desired_raw))
+      @listener_errors.concat(failed)
+      @listeners_applied = desired_raw
+
+      gone = before.reject { |s| desired.includes?(s) }
+      fresh = desired.reject { |s| before.includes?(s) }
+      # Matched by CONSUMING an address, not by `count`: two entries can name the same address
+      # (only one of them ever binds), and an `any?` test would match both against one survivor
+      # and drive `added` negative.
+      unclaimed = fresh.map { |f| {f.host, f.port} }
+      moved = gone.count do |s|
+        (i = unclaimed.index({s.host, s.port})) ? (unclaimed.delete_at(i); true) : false
+      end
+      up_after = @extra_listeners.select(&.server.listening?).map { |e| authority_of(e.server) }
+      ListenerReconcile.new(
+        added: fresh.size - moved, removed: gone.size - moved, retargeted: moved,
+        serving: up_after.size, failed: failed,
+        dropped: up_before.reject { |a| up_after.includes?(a) }
+          .select { |a| desired.any? { |l| Gori::BindAddress.authority(l.host, l.port) == a } },
+        capturing: capturing?)
+    end
+
+    private def authority_of(server : Proxy::Server) : String
+      Gori::BindAddress.authority(server.host, server.port)
     end
 
     # Additional listeners started and stopped alongside the primary. Each failure is
@@ -207,8 +364,9 @@ module Gori
       origin : String, listening : Bool, error : String?
 
     def listener_rows : Array(ListenerRow)
-      rows = @extra_listeners.map do |s|
-        addr = Gori::BindAddress.authority(s.host, s.port)
+      rows = @extra_listeners.map do |e|
+        s = e.server
+        addr = authority_of(s)
         org = s.origin
         ListenerRow.new(s.host, s.port,
           s.origin ? "reverse" : (s.transparent? ? "transparent" : "proxy"),
@@ -230,17 +388,20 @@ module Gori
       # capture toggle, and clearing them would make an unusable listener disappear from the
       # readout on the first `c` press.
       @listener_errors.clear
-      @listener_errors.concat(Settings.listener_config_errors)
-      @extra_listeners.each do |server|
-        server.start
+      # The config errors of the section these sockets were built from — `@listeners_applied`,
+      # not `Settings.listeners`, so a capture toggle after a reconcile does not resurrect the
+      # rejections of the startup section.
+      @listener_errors.concat(Settings.listener_config_errors(@listeners_applied))
+      @extra_listeners.each do |e|
+        e.server.start
       rescue ex
-        @listener_errors << "#{Gori::BindAddress.authority(server.host, server.port)} — #{ex.message || "could not bind"}"
-        ::Log.warn { "listener #{server.host}:#{server.port} failed to bind: #{ex.message}" }
+        @listener_errors << Session.bind_failure(e.server, ex)
+        ::Log.warn { "listener #{e.server.host}:#{e.server.port} failed to bind: #{ex.message}" }
       end
     end
 
     private def stop_extra_listeners : Nil
-      @extra_listeners.each { |server| server.stop rescue nil }
+      @extra_listeners.each { |e| e.server.stop rescue nil }
     end
 
     # Flip upstream TLS verification live (settings:network toggle). Updates the runtime

--- a/src/gori/settings/listeners.cr
+++ b/src/gori/settings/listeners.cr
@@ -125,22 +125,31 @@ module Gori::Settings
 
   # The `listeners` section AS IT IS ON DISK RIGHT NOW. `Settings.listeners` is the copy read
   # at startup and never re-read, and the running sockets were built from THAT — so the two
-  # disagreeing is exactly the #508 drift, and a settings save is the one moment gori is
-  # holding both halves and can say so.
+  # disagreeing is exactly the #508 drift, and a settings save is one of the moments gori is
+  # holding both halves.
   #
   # A missing key means an EMPTY section here, not "keep current" as the tolerant load path
   # has it: deleting every listener is a change the operator should hear about, and the load
   # rule exists to protect a running config from a partial file, which is not this question.
   # An unreadable or unparseable file falls back to "unchanged" — the corrupt-file warning is
-  # `load_root`'s job and crying restart on top of it would just be noise.
+  # `load_root`'s job and crying drift on top of it would just be noise.
   def self.disk_listeners : Array(Listener)
+    disk_listeners? || listeners
+  end
+
+  # Same read, but distinguishing "the file could not be read or parsed" (nil) from "the
+  # section is absent" (an empty array). The drift CHECK can fall back to "unchanged" on an
+  # unreadable file, because all it decides is whether to say something. A RECONCILE cannot:
+  # acting on that fallback would tear live sockets down and rebuild them because of a typo
+  # somewhere else in the document.
+  def self.disk_listeners? : Array(Listener)?
     return [] of Listener unless File.exists?(path)
     node = JSON.parse(File.read(path)).as_h?.try(&.[]?("listeners"))
     arr = node.try(&.as_a?)
     return [] of Listener unless arr
     listeners_from(arr)
   rescue
-    listeners
+    nil
   end
 
   private def self.listeners_from(arr : Array(JSON::Any)) : Array(Listener)
@@ -181,7 +190,15 @@ module Gori::Settings
 
   # nil if `listener` is usable; an error message otherwise. Checked at save time so a bad
   # address surfaces here rather than as an opaque bind failure on the next project open.
-  def self.listener_error(listener : Listener) : String?
+  #
+  # `among` is the set the loop check reads as "gori's other configured sockets". It defaults
+  # to `Settings.listeners` — the startup copy — but a live reconcile (#508) validates a set it
+  # read from disk and deliberately did NOT write back over the class property, so it has to be
+  # able to say which set it means. Writing it back would make the next `Settings.save` treat
+  # `listeners` as a section this process changed, and its 3-way merge would then let our copy
+  # WIN over a hand edit made in between — turning a fix for a silent no-op into a silent
+  # clobber of the operator's own file.
+  def self.listener_error(listener : Listener, among : Array(Listener) = listeners) : String?
     if err = bind_host_error(listener.host)
       return err
     end
@@ -196,13 +213,13 @@ module Gori::Settings
     if listener.target_port > 0 && !listener.transparent?
       return "settings: target_port only applies to a transparent listener"
     end
-    reverse_listener_error(listener)
+    reverse_listener_error(listener, among)
   end
 
   # Same discipline as the target_port check above, for the reverse listener's two fields and
   # in BOTH directions: a missing origin cannot be defaulted (there is nothing to forward to),
   # and a present one in the wrong mode is a mode mistake rather than a field to drop.
-  private def self.reverse_listener_error(listener : Listener) : String?
+  private def self.reverse_listener_error(listener : Listener, among : Array(Listener)) : String?
     unless listener.reverse?
       return "settings: origin only applies to a reverse listener" unless listener.origin.strip.empty?
       return "settings: rewrite_host only applies to a reverse listener" if listener.rewrite_host
@@ -215,7 +232,7 @@ module Gori::Settings
     # validated, but `listener_error` is also called on a candidate that is not yet (and the
     # tightest loop of all — an origin naming this listener's own socket — would be the one
     # missed if this relied on the array alone).
-    if self_target?(target[1], target[2], listener)
+    if self_target?(target[1], target[2], listener, among)
       return "settings: listener origin #{listener.origin} points back at gori itself (forwarding loop)"
     end
     nil
@@ -232,10 +249,11 @@ module Gori::Settings
   # per-connection `Upstream.loops_to_self?` backstop covers the residue for a reverse listener
   # whose origin names ITS OWN port; a cross-port loop through a hostname is not caught by
   # either, and would surface as the 2048-connection wedge described in `upstream.cr:100-119`.
-  private def self.self_target?(host : String, port : Int32, own : Listener) : Bool
+  private def self.self_target?(host : String, port : Int32, own : Listener,
+                                among : Array(Listener)) : Bool
     return true if port == own.port && same_bind_host?(host, own.host)
     return true if port == effective_bind_port && same_bind_host?(host, effective_bind_host)
-    listeners.any? { |l| l.port == port && same_bind_host?(host, l.host) }
+    among.any? { |l| l.port == port && same_bind_host?(host, l.host) }
   end
 
   # The upstream port a transparent connection should use: the listener's configured
@@ -249,9 +267,9 @@ module Gori::Settings
   # Every additional listener that passes validation, with duplicates of the PRIMARY bind
   # removed — binding the same address twice would fail, and the operator would be left with
   # a listener error about an address they can see is configured exactly once.
-  def self.valid_listeners : Array(Listener)
-    listeners.reject do |l|
-      !listener_error(l).nil? || (l.port == effective_bind_port && same_bind_host?(l.host, effective_bind_host))
+  def self.valid_listeners(among : Array(Listener) = listeners) : Array(Listener)
+    among.reject do |l|
+      !listener_error(l, among).nil? || (l.port == effective_bind_port && same_bind_host?(l.host, effective_bind_host))
     end
   end
 
@@ -259,9 +277,9 @@ module Gori::Settings
   # Dropping is right — an unusable entry must not become a socket — but dropping silently is
   # not: the operator's only other signal is that traffic never arrives. Session seeds its
   # `listener_errors` from this so a rejected entry reads the same as one that failed to bind.
-  def self.listener_config_errors : Array(String)
-    listeners.compact_map do |l|
-      if err = listener_error(l)
+  def self.listener_config_errors(among : Array(Listener) = listeners) : Array(String)
+    among.compact_map do |l|
+      if err = listener_error(l, among)
         "#{BindAddress.authority(l.host, l.port)} — #{err.lchop("settings: ")}"
       end
     end

--- a/src/gori/tui/listeners_overlay.cr
+++ b/src/gori/tui/listeners_overlay.cr
@@ -31,14 +31,19 @@ module Gori::Tui
     # raising another modal is the shell's job (see Runner#open_listeners).
     property on_palette : Proc(Nil)?
 
+    # `r`: re-read the `listeners` section from settings.json and make the sockets match it
+    # (#508). Injected rather than called on `@session` here because the reconcile is a
+    # lifecycle change and reporting what it moved is the shell's job — the overlay only asks,
+    # then re-snapshots. Left nil (a plain re-snapshot) this is still the read-only list it was.
+    property on_reload : Proc(Nil)?
+
     def initialize(@session : Gori::Session)
       @selected = 0
       @rows = @session.listener_rows
     end
 
     # Re-snapshot from the live session. The overlay holds a COPY rather than reading per draw
-    # so the rows can't shift under a click hit-tested against the previous frame; `r`
-    # refreshes it on demand (a capture toggle flips every row's `up`/`down`).
+    # so the rows can't shift under a click hit-tested against the previous frame.
     def reload : Nil
       @rows = @session.listener_rows
       @selected = @selected.clamp(0, {@rows.size - 1, 0}.max)
@@ -58,10 +63,11 @@ module Gori::Tui
     end
 
     def hint : String
-      "↑/↓ scroll · r refresh · esc close"
+      "↑/↓ scroll · r reload settings.json · esc close"
     end
 
-    # Read-only: no ↵ commit, nothing to apply. esc closes, r re-snapshots, ↑/↓ scroll.
+    # No ↵ commit — there is nothing here to edit, so the only action is `r`, which re-reads the
+    # section and applies it. esc closes, ↑/↓ scroll.
     def handle_key(ev : Termisu::Event::Key) : Symbol
       k = ev.key
       if ev.ctrl? && k.lower_p?
@@ -73,7 +79,7 @@ module Gori::Tui
       elsif k.down? || k.lower_j?
         move(1)
       elsif (ev.char || k.to_char) == 'r'
-        reload
+        (cb = on_reload) ? cb.call : reload
       end
       :stay
     end
@@ -140,13 +146,14 @@ module Gori::Tui
     #
     #   - the PRIMARY bind is not in this list and is not supposed to be (#499). Naming it here
     #     is cheaper than letting "why isn't :8070 listed?" become a bug report.
-    #   - the section is not applied live (#508). A reverse listener is the first listener kind
-    #     anyone retargets interactively, so silence about that is a trap this feature creates.
+    #   - where the edit happens and what makes it take effect (#508). The section has no editor
+    #     here, so without this the operator has no way to know an edit needs `r` — which is the
+    #     same silence the reconcile exists to end.
     private def draw_footer(screen : Screen, box : Rect) : Nil
       y = box.bottom - 2 # box.bottom - 1 is the card's bottom border (Frame.card)
       return if y <= box.y + 1
       primary = Gori::BindAddress.display(@session.proxy.host, @session.proxy.port, terse: true)
-      screen.text(box.x + 3, y, "#{primary} is the proxy address · restart to apply edits",
+      screen.text(box.x + 3, y, "#{primary} is the proxy address · edit settings.json, then r",
         Theme.muted, Theme.panel, width: {box.w - 4, 1}.max)
     end
 

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -3242,14 +3242,39 @@ module Gori::Tui
     end
 
     # Open the additional-listener inventory (the `listeners:N` top-bar chip + the
-    # app.listeners verb). Read-only, so there is no on_commit — the section is edited in
-    # settings.json and is not applied until restart (#508).
+    # app.listeners verb). No on_commit — the section is edited in settings.json, so the only
+    # action is `r`, which re-reads it and reconciles the sockets (#508).
     def open_listeners : Nil
       ov = ListenersOverlay.new(@session)
       # Same ordering rule as open_passthrough: drop this modal BEFORE raising the palette,
       # and via leave_overlay so no pop-back lands on top of it.
       ov.on_palette = -> { leave_overlay; open_palette }
+      # The reconcile, then a re-snapshot so the rows show the sockets it just moved. The
+      # message goes to the notification list rather than the toast: this modal is covering the
+      # screen, and "nothing changed" is an answer the operator asked for and must still get.
+      ov.on_reload = -> { reload_listeners(quiet_when_unchanged: false); ov.reload }
       open_overlay(ov)
+    end
+
+    # Re-read the `listeners` section and make this session's sockets match it (#508). Returns
+    # the line describing what moved and pushes it as a notification unless nothing changed and
+    # the caller only wanted to hear about changes (the settings-save path, where the toast is
+    # already reporting the save itself).
+    #
+    # A notification rather than a toast for the same reason #509 chose one: this is about the
+    # listener sockets, not about whatever the operator was doing when it ran, and a failed
+    # rebind is something they need to still be able to read a minute later.
+    def reload_listeners(quiet_when_unchanged : Bool = true) : String
+      result = @session.reconcile_listeners!
+      unless result
+        msg = "listeners: settings.json could not be read — sockets left as they are"
+        @notifications.push(:warn, msg)
+        return msg
+      end
+      msg = result.summary
+      return msg if quiet_when_unchanged && !result.changed? && result.failed.empty?
+      @notifications.push(result.failed.empty? ? :info : :warn, msg)
+      msg
     end
 
     # What the chip counts. Deliberately `listener_rows` rather than the running-server count:
@@ -4689,14 +4714,13 @@ module Gori::Tui
     # (existing connections are kept — only the accept socket moves). A failed
     # rebind (port in use / bad address) keeps the current bind.
     private def apply_settings(save_msg : String) : String
-      # The `listeners` section has no TUI editor and is not reconciled live (#508), so a save
-      # is the one moment gori holds both the running sockets and the edited file and can say
-      # they differ. A notification rather than a toast: the toast is about the save that just
-      # happened, and this is about work that has NOT happened yet.
-      if @session.listeners_changed_on_disk?
-        @notifications.push(:warn,
-          "listeners: settings.json no longer matches the running sockets — restart gori to apply")
-      end
+      # The `listeners` section has no TUI editor — it is hand-edited in settings.json — so a
+      # save is one of the two moments gori holds both the running sockets and the edited file.
+      # #509 could only announce the difference here; now it is applied, on the same
+      # edit-then-apply trigger as the primary rebind below. Gated on the drift check for the
+      # same reason that rebind early-returns on an unmoved address: a save that did not touch
+      # this section must not restart anything.
+      reload_listeners if @session.listeners_changed_on_disk?
       proxy = @session.proxy
       # Rebind against the EFFECTIVE bind (a project override wins over the global). So a global
       # settings:network edit while a project pins its own bind is a no-op here (effective


### PR DESCRIPTION
Closes #508.

Editing the `listeners` array in `settings.json` and saving did nothing until gori restarted, and said nothing about it. #509 shipped the honest half — a save announced that the section no longer matched the running sockets. This is the other half: applying it.

## The question the issue left open

> `Settings.listeners` has no TUI editor — the section is hand-edited in `settings.json` — so the reload trigger is whatever path notices the file changed, not a save button. That may make "restart to apply" the honest long-term answer.

It is not, but the reason matters, because the alternative the sentence implies would be **worse than the bug**.

There is no runtime settings reload path at all: `Settings.load` runs once per process, and the only thing that re-reads the file at runtime is `disk_listeners` (added by #509) and the save-time merge. So "whatever path notices the file changed" would have to be invented, and inventing a **file watcher** is the wrong answer twice over:

- `listeners_from` is a **tolerant** parse — a malformed entry is dropped, not refused.
- Hand edits go through editors that truncate before they write.

A watcher firing mid-write reads a short file, sees fewer listeners, and tears down live sockets. That trades a silent no-op for silent destruction.

The third option the issue did not consider is an **explicit operator action**, which is what shipped. There are two of them, driving one mechanism:

- **`r` in the listeners overlay** — where the section is already displayed, and whose footer already had to explain how an edit takes effect. It now reads `edit settings.json, then r` instead of `restart to apply edits`.
- **A settings save**, gated on the same drift check #509 added. That is the same edit-then-apply trigger the primary bind's live rebind already uses, so the #509 notice does not contradict this — it became the gate for it.

## The reconcile

`Session#reconcile_listeners!` **diffs**; it is not stop-all/start-all:

| in the new section | currently serving | what happens |
|---|---|---|
| yes, unchanged | yes | **never touched** |
| yes, unchanged | no | retried — this is how you recover a listener after freeing its port |
| yes, changed at the same address | yes | stopped, then rebuilt (the new socket wants the address the old one holds) |
| no | yes | stopped |

"Never touched" is the property that matters: an edit to one row cannot drop a working socket belonging to another. Nothing binds while capture is off — the set is rebuilt so the next `c` opens the right one, which is `Server#rebind`'s "not listening → just record the new bind" rule one level up.

**In-flight connections.** Every fate above follows from `Proxy::Server#stop` closing only the *accept* socket. A removed listener stops accepting and its established connections finish on their own fibers — the same fate as capture-off and as a primary rebind. A retargeted one keeps serving its in-flight connections under the configuration they were accepted under, which is the only answer that does not retarget a request mid-flight.

**A corrupt file is refused, not acted on.** `disk_listeners` falls back to "unchanged" on an unparseable file, which is right for a check that only decides whether to warn and wrong for one that moves sockets. `disk_listeners?` separates the two: nil means "could not read", and the reconcile leaves everything alone.

**Bind failure on re-apply** lands in `Session#listener_errors` and shows as that listener's own row, exactly like a failure at open. `dropped` is the separate wording the issue asked for — an address that *was* serving, is *still* wanted, and did not come back — kept distinct from `failed`, which also covers a listener that never bound at all.

## Not refreshing `Settings.listeners`

The section read from disk is deliberately **not** written back over the class property. That property is the base of `Settings.save`'s 3-way merge, and today `listeners` is a section this process never changes, so a hand edit always wins at save time. Refreshing it would make the next save treat `listeners` as ours — letting a stale copy clobber a hand edit made in between. Fixing a silent no-op by introducing a silent clobber of the operator's own file is not a trade worth making, so the validators (`listener_error`, `valid_listeners`, `listener_config_errors`) take the candidate set as an argument instead.

## Verification

Full suite green (5055 examples, 0 failures). No new ameba violations on the touched files; `session.cr`'s pre-existing complexity warning went from 16 to 15.

**Control run on the diff claim.** The "never touches a listener the edit did not concern" spec asserts object *identity* on the `Proxy::Server`, not reachability — a socket that went down and came back inside one reconcile would pass a connect test having dropped every connection on it. Forcing the keep-branch off makes exactly that one example fail.

**Live, in the built binary**, with `settings.json` hand-edited from outside a running gori and no restart:

```
BEFORE        56074 ACCEPTS   56075 ACCEPTS   56076 refused   56077 held by another process
edit          keep 56074   ·   remove 56075   ·   add 56076   ·   add 56077 (port taken)
press r
AFTER         56074 ACCEPTS   56075 refused   56076 ACCEPTS   56077 could not bind
```

The overlay after `r`:

```
  proxy       127.0.0.1:56074                                           up
  transparent 127.0.0.1:56076                                           up
  proxy       127.0.0.1:56077  Could not bind to '127.0.0.1:56077': Addr…
  localhost:19508 is the proxy address · edit settings.json, then r
```

and the notification: `listeners: 2 added, 1 removed — 1 could not bind`.

Freeing 56077 and pressing `r` again brought it up without disturbing the two already serving. A request through 56077 — a listener the reconcile created — landed in History, confirming a reconciled socket is wired to the same sink, rules, interceptor and host overrides as one built at startup.