### PR TITLE
fix(h2): refuse the head round trip a peer head has no h1-text form for

### DIFF
--- a/spec/proxy/h2/head_codec_spec.cr
+++ b/spec/proxy/h2/head_codec_spec.cr
@@ -15,6 +15,121 @@ private def req_fields : Array(Field)
   [f(":method", "GET"), f(":scheme", "https"), f(":authority", "api.example.com"), f(":path", "/x")]
 end
 
+# The round trip exactly as `HeadRewrite` drives it, with no rule in between: whatever comes
+# back differing from what went in is a field the h1 text could not carry.
+private def round_trip(fields : Array(Field), request : Bool) : Array(Field)?
+  return HeadCodec.parse_response(HeadCodec.synth_response(tuples(fields)), fields) unless request
+  authority = HeadCodec.pseudo(tuples(fields), ":authority") || "conn.example.com"
+  HeadCodec.parse_request(HeadCodec.synth_request(tuples(fields), authority), fields)
+end
+
+private record Entry, label : String, fields : Array(Field), request : Bool, faithful : Bool
+
+# A request/response carrying one field under test, plus a tail field so a truncating or
+# field-dropping round trip is visible and not just a shorter list of one.
+private def rq(field : Field, faithful : Bool, label : String) : Entry
+  Entry.new(label, req_fields + [field, f("x-tail", "z")], true, faithful)
+end
+
+private def rs(field : Field, faithful : Bool, label : String) : Entry
+  Entry.new(label, [f(":status", "200"), field, f("x-tail", "z")], false, faithful)
+end
+
+private def both(field : Field, faithful : Bool, label : String) : Array(Entry)
+  [rq(field, faithful, "#{label} (request)"), rs(field, faithful, "#{label} (response)")]
+end
+
+private INVALID_UTF8_VALUE = String.new(Bytes[0x61_u8, 0xff_u8, 0xfe_u8, 0x62_u8])
+private INVALID_UTF8_NAME  = String.new(Bytes[0x78_u8, 0xff_u8, 0x2d_u8, 0x61_u8])
+
+private CORPUS = [
+  # --- regular fields: what the line-split and the `name: value` cut cannot carry ----------
+  both(f("x-echo", "safe\r\nset-cookie: injected=1"), false, "a CRLF in a value (it becomes TWO fields)"),
+  both(f("x-echo", "a\r\n\r\nGET /x HTTP/1.1"), false, "a double CRLF in a value (it TRUNCATES the head)"),
+  both(f("x-echo", "safe\rset-cookie: injected=1"), false, "a lone CR in a value"),
+  both(f("x-echo", "safe\nset-cookie: injected=1"), false, "a lone LF in a value"),
+  both(f("x-a\rb", "v"), false, "a CR in a field name"),
+  both(f("x-a\nb", "v"), false, "an LF in a field name"),
+  both(f("x-a:b", "v"), false, "a colon in a field name (it renames the field)"),
+  both(f(" x-echo ", "v"), false, "whitespace around a field name"),
+  both(f("X-Echo", "v"), false, "an uppercase field name the PEER sent"),
+  both(f("", "v"), false, "an empty field name"),
+  both(f("x-echo", "   lead"), false, "a leading space in a value (h1 OWS strips it)"),
+  both(f("x-echo", "   "), false, "an all-spaces value"),
+  # --- regular fields the text carries exactly ---------------------------------------------
+  both(f("x-echo", "trail   "), true, "a trailing space in a value"),
+  both(f("x-echo", "\tlead\t"), true, "tabs around a value"),
+  both(f("x-echo", "a: b"), true, "a colon-space inside a value"),
+  both(f("x-echo", "HTTP/1.1 200 OK"), true, "a value shaped like a status line"),
+  both(f("x-echo", "a\u0000b"), true, "a NUL in a value"),
+  both(f("x-echo", "a\vb\fc\td"), true, "other control bytes in a value"),
+  both(f("x-echo", ""), true, "an empty value"),
+  both(f("x-echo", INVALID_UTF8_VALUE), true, "invalid UTF-8 in a value"),
+  both(f(INVALID_UTF8_NAME, "v"), true, "invalid UTF-8 in a field name"),
+  both(f("x a", "v"), true, "a space inside a field name"),
+].flatten + [
+  # --- pseudo-headers: the start line and the synthetic Host line -------------------------
+  Entry.new("a CRLF in :path (it splits the START line)",
+    [f(":method", "GET"), f(":scheme", "https"), f(":authority", "a.test"), f(":path", "/a\r\nx-admin: true")], true, false),
+  Entry.new("a lone LF in :path",
+    [f(":method", "GET"), f(":scheme", "https"), f(":authority", "a.test"), f(":path", "/a\nx-admin: true")], true, false),
+  Entry.new("an empty :path",
+    [f(":method", "GET"), f(":scheme", "https"), f(":authority", "a.test"), f(":path", "")], true, false),
+  Entry.new("a space in :method (it moves the tail into :path)",
+    [f(":method", "GE T"), f(":scheme", "https"), f(":authority", "a.test"), f(":path", "/")], true, false),
+  Entry.new("a CRLF in :method",
+    [f(":method", "GET\r\nx: y"), f(":scheme", "https"), f(":authority", "a.test"), f(":path", "/")], true, false),
+  Entry.new("an empty :method",
+    [f(":method", ""), f(":scheme", "https"), f(":authority", "a.test"), f(":path", "/")], true, false),
+  Entry.new("a CRLF in :authority (it splits the synthetic Host line)",
+    [f(":method", "GET"), f(":scheme", "https"), f(":authority", "a.test\r\nx-admin: true"), f(":path", "/")], true, false),
+  Entry.new("a leading space in :authority",
+    [f(":method", "GET"), f(":scheme", "https"), f(":authority", " a.test"), f(":path", "/")], true, false),
+  Entry.new("an empty :authority with no host field (it DROPS :authority)",
+    [f(":method", "GET"), f(":scheme", "https"), f(":authority", ""), f(":path", "/")], true, false),
+  Entry.new("no :authority and no host field (it INVENTS one from the connection)",
+    [f(":method", "GET"), f(":scheme", "https"), f(":path", "/")], true, false),
+  Entry.new("no :path at all (it INVENTS `/`)",
+    [f(":method", "GET"), f(":scheme", "https"), f(":authority", "a.test")], true, false),
+  Entry.new("a CRLF in :scheme, which is preserved off the original",
+    [f(":method", "GET"), f(":scheme", "https\r\nx: y"), f(":authority", "a.test"), f(":path", "/")], true, true),
+  Entry.new("a CRLF in an unknown pseudo, likewise preserved",
+    [f(":method", "GET"), f(":scheme", "https"), f(":authority", "a.test"), f(":path", "/"), f(":proto", "w\r\nx: y")], true, true),
+  Entry.new("a trailing space in :authority",
+    [f(":method", "GET"), f(":scheme", "https"), f(":authority", "a.test "), f(":path", "/")], true, true),
+  Entry.new("a :path that is only a space",
+    [f(":method", "GET"), f(":scheme", "https"), f(":authority", "a.test"), f(":path", " ")], true, true),
+  Entry.new("a :path ending in a version token",
+    [f(":method", "GET"), f(":scheme", "https"), f(":authority", "a.test"), f(":path", "/a HTTP/9")], true, true),
+  Entry.new("a tab in :method",
+    [f(":method", "GE\tT"), f(":scheme", "https"), f(":authority", "a.test"), f(":path", "/")], true, true),
+  Entry.new("no :authority but an explicit host field",
+    [f(":method", "GET"), f(":scheme", "https"), f(":path", "/"), f("host", "h.test")], true, true),
+  # --- :status, which `synth_response` normalizes through to_i ----------------------------
+  Entry.new("a zero-padded :status (it becomes an ACCEPTED three-digit one)",
+    [f(":status", "0200"), f("x-a", "1")], false, false),
+  Entry.new("a :status with a CRLF", [f(":status", "200\r\nset-cookie: e=1"), f("x-a", "1")], false, false),
+  Entry.new("a non-numeric :status", [f(":status", "abc"), f("x-a", "1")], false, false),
+  Entry.new("a plain :status", [f(":status", "204"), f("x-a", "1")], false, true),
+  # --- pseudo-header count and order (RFC 9113 §8.3) --------------------------------------
+  Entry.new("a duplicate :method (the second is DROPPED)",
+    [f(":method", "GET"), f(":method", "POST"), f(":scheme", "https"), f(":authority", "a.test"), f(":path", "/")], true, false),
+  Entry.new("a duplicate :path", [f(":method", "GET"), f(":scheme", "https"), f(":authority", "a.test"),
+                                  f(":path", "/a"), f(":path", "/b")], true, false),
+  Entry.new("a duplicate :scheme", [f(":method", "GET"), f(":scheme", "https"), f(":scheme", "http"),
+                                    f(":authority", "a.test"), f(":path", "/")], true, false),
+  Entry.new("a duplicate :status", [f(":status", "200"), f(":status", "404"), f("x-a", "1")], false, false),
+  Entry.new("a pseudo-header AFTER a regular one (the order is CORRECTED)",
+    [f(":method", "GET"), f("x-first", "1"), f(":scheme", "https"), f(":authority", "a.test"), f(":path", "/")], true, false),
+  Entry.new("a pseudo-header after a regular one, response",
+    [f("x-first", "1"), f(":status", "200")], false, false),
+  # --- duplicates that DO survive ---------------------------------------------------------
+  Entry.new("duplicate regular fields (h2 cookie crumbs)",
+    [f(":status", "200"), f("cookie", "a=1"), f("cookie", "b=2")], false, true),
+  Entry.new("duplicate host fields", [f(":method", "GET"), f(":scheme", "https"), f(":authority", "a.test"),
+                                      f(":path", "/"), f("host", "one.test"), f("host", "two.test")], true, true),
+]
+
 describe Gori::Proxy::H2::HeadCodec do
   describe "synth" do
     it "renders :authority as a Host line and omits the pseudo-headers" do
@@ -123,6 +238,44 @@ describe Gori::Proxy::H2::HeadCodec do
       HeadCodec.parse_request("no-spaces-at-all\r\n\r\n".to_slice, req_fields).should be_nil
       HeadCodec.parse_request("GET /x HTTP/2\r\nnot a header line\r\n\r\n".to_slice, req_fields).should be_nil
       HeadCodec.parse_response("nonsense\r\n\r\n".to_slice, [f(":status", "200")]).should be_nil
+    end
+  end
+
+  # #517. The round trip is only sound while it is INJECTIVE, and #492's hazard table never
+  # said so. `CORPUS` is the audit that found the ones it missed, kept as an oracle: for every
+  # entry it asserts that `h1_faithful?` and what the round trip ACTUALLY does agree. A future
+  # change to either side that makes them disagree fails here rather than on the wire.
+  describe "h1_faithful? (injectivity)" do
+    CORPUS.each do |entry|
+      it "#{entry.faithful ? "round-trips" : "refuses"} #{entry.label}" do
+        HeadCodec.h1_faithful?(entry.fields, entry.request).should eq(entry.faithful)
+        back = round_trip(entry.fields, entry.request)
+        if entry.faithful
+          # Faithful means EXACTLY these fields back, in this order — not "close enough".
+          tuples(back.not_nil!).should eq(tuples(entry.fields))
+        else
+          back.should be_nil
+        end
+      end
+    end
+
+    it "judges what the PEER sent, never what a rule produced" do
+      # A rule whose replacement carries a CRLF adds two headers here for the same reason the
+      # identical rule does on h1: those are the operator's bytes (P7). Only the peer's head
+      # gates the round trip.
+      fields = [f(":status", "200"), f("x-tag", "a")]
+      HeadCodec.h1_faithful?(fields, false).should be_true
+      back = HeadCodec.parse_response("HTTP/2 200\r\nx-tag: a\r\nset-cookie: op=1\r\n\r\n".to_slice, fields)
+      tuples(back.not_nil!).should eq([{":status", "200"}, {"x-tag", "a"}, {"set-cookie", "op=1"}])
+    end
+
+    it "does not refuse ordinary traffic" do
+      req = req_fields + [f("user-agent", "curl/8"), f("cookie", "a=1"), f("cookie", "b=2"),
+                          f("accept-encoding", "gzip, deflate, br"), f("authorization", "Bearer x", true)]
+      HeadCodec.h1_faithful?(req, true).should be_true
+      resp = [f(":status", "204"), f("date", "Mon, 01 Jan 2024 00:00:00 GMT"),
+              f("content-length", "0"), f("set-cookie", "s=1; Path=/; HttpOnly")]
+      HeadCodec.h1_faithful?(resp, false).should be_true
     end
   end
 

--- a/spec/proxy/h2/head_rewrite_spec.cr
+++ b/spec/proxy/h2/head_rewrite_spec.cr
@@ -261,4 +261,91 @@ describe Gori::Proxy::H2::HeadRewrite do
     sink.requests[1].target.should eq("/second")
     String.new(sink.requests[1].head).should contain("x-a: 0123456789abcdef")
   end
+
+  # #517. A field value carrying the head's own delimiter has no h1-text form, and the bridge
+  # used to turn it into two well-formed wire fields — a message the far endpoint would have
+  # REJECTED (RFC 9113 §8.2.1) arriving as one it accepts. Everything below decodes what the
+  # far side actually receives, with a fresh decoder, exactly as a real peer would.
+  describe "a peer head the h1 text cannot carry (#517)" do
+    it "does not split a CRLF-bearing request value into a second header" do
+      pipe, assembler, _ = pipeline(SubRewriter.new("x-tag: a", "x-tag: b"))
+      fields = req("/x") + [{"x-tag", "a"}, {"x-echo", "safe\r\nx-admin: true"}]
+      block = HPACK::Encoder.new.encode(fields)
+      sent = push(pipe, assembler, headers(1_u32, block))
+
+      origin = HPACK::Decoder.new.decode(sent.first.payload)
+      origin.should eq(fields)                                         # the peer's head, field for field
+      origin.map(&.[0]).should_not contain("x-admin")                  # nothing was invented
+      origin.count { |(n, _)| n == "x-echo" }.should eq(1)             # one field in, one field out
+      origin.find { |(n, _)| n == "x-tag" }.not_nil![1].should eq("a") # the rule did NOT run
+    end
+
+    it "does not split a CRLF-bearing response value into a second header" do
+      pipe, assembler, _ = pipeline(SubRewriter.new("x-tag: a", "x-tag: b"), direction: "in")
+      fields = [{":status", "200"}, {"x-tag", "a"}, {"x-echo", "safe\r\nset-cookie: injected=1"}]
+      block = HPACK::Encoder.new.encode(fields)
+      emitted = [] of Frame::Header
+      pipe.accept(headers(1_u32, block)) { |f, pre| emitted << f; assembler.feed("in", f, pre) }
+
+      client = HPACK::Decoder.new.decode(emitted.first.payload)
+      client.should eq(fields)
+      client.map(&.[0]).should_not contain("set-cookie")
+    end
+
+    it "still RE-ENCODES it once the direction has latched, rather than falling back to passthrough" do
+      # The disposition is "emit the ORIGINAL FIELDS", not "forward the original frames". On an
+      # engaged direction those are not the same thing: the sender's encoder has kept indexing
+      # (§6.2.1) against a table the peer no longer shares, so a passthrough block here would
+      # resolve its dynamic indices against the wrong table. Malformed in, malformed out — but
+      # re-encoded, because the latch is one-way.
+      pipe, assembler, _ = pipeline(SubRewriter.new("x-tag: alpha", "x-tag: beta"), direction: "in")
+      sender = HPACK::Encoder.new(indexing: true)
+      b1 = sender.encode([{":status", "200"}, {"x-tag", "alpha"}, {"x-token", "abcdefghijklmnop"}])
+      evil = [{":status", "200"}, {"x-echo", "safe\r\nset-cookie: injected=1"}, {"x-token", "abcdefghijklmnop"}]
+      b2 = sender.encode(evil)
+
+      peer = HPACK::Decoder.new # ONE decoder for the connection, like a real client
+      out1 = [] of Frame::Header
+      pipe.accept(headers(1_u32, b1)) { |f, pre| out1 << f; assembler.feed("in", f, pre) }
+      peer.decode(out1.first.payload)
+      pipe.engaged?.should be_true
+
+      out2 = [] of Frame::Header
+      pipe.accept(headers(3_u32, b2)) { |f, pre| out2 << f; assembler.feed("in", f, pre) }
+      out2.first.payload.should_not eq(b2) # re-encoded, not forwarded as it arrived
+      peer.decode(out2.first.payload).should eq(evil)
+    end
+
+    it "refuses an intercept edit of one, because the text the operator edited is not the message" do
+      pipe, _, _ = pipeline(SubRewriter.new("x-tag: a", "x-tag: b"), direction: "in")
+      evil = [HPACK::Field.new(":status", "200"),
+              HPACK::Field.new("x-echo", "safe\r\nset-cookie: injected=1")]
+      block = Gori::Proxy::H2::HeadRewrite::Block.new(
+        [] of Frame::Header, HeadBlock.new(evil.map(&.to_tuple)), evil,
+        "HTTP/2 200\r\nx-echo: safe\r\nset-cookie: injected=1\r\n\r\n".to_slice,
+        headers(1_u32, Bytes.empty), Bytes.empty, false)
+      pipe.encode_edited(block, "HTTP/2 200\r\nx-echo: edited\r\n\r\n".to_slice).should be_nil
+
+      # Control: the same edit on a head the text CAN carry is applied as it always was.
+      ok = [HPACK::Field.new(":status", "200"), HPACK::Field.new("x-echo", "safe")]
+      fine = Gori::Proxy::H2::HeadRewrite::Block.new(
+        [] of Frame::Header, HeadBlock.new(ok.map(&.to_tuple)), ok,
+        "HTTP/2 200\r\nx-echo: safe\r\n\r\n".to_slice,
+        headers(1_u32, Bytes.empty), Bytes.empty, false)
+      edited = pipe.encode_edited(fine, "HTTP/2 200\r\nx-echo: edited\r\n\r\n".to_slice).not_nil!
+      edited.fields.map(&.to_tuple).should eq([{":status", "200"}, {"x-echo", "edited"}])
+    end
+
+    it "still adds two headers for a CRLF the OPERATOR wrote — those are their bytes (P7)" do
+      # The guard reads what the PEER sent, never what a rule produced. The identical rule adds
+      # two headers on h1; making h2 disagree would be the silent-divergence class this epic
+      # exists to remove.
+      pipe, assembler, _ = pipeline(SubRewriter.new("x-tag: a", "x-tag: b\r\nx-added: 1"), direction: "in")
+      block = HPACK::Encoder.new.encode([{":status", "200"}, {"x-tag", "a"}])
+      emitted = [] of Frame::Header
+      pipe.accept(headers(1_u32, block)) { |f, pre| emitted << f; assembler.feed("in", f, pre) }
+      HPACK::Decoder.new.decode(emitted.first.payload)
+        .should eq([{":status", "200"}, {"x-tag", "b"}, {"x-added", "1"}])
+    end
+  end
 end

--- a/src/gori/proxy/h2/head_codec.cr
+++ b/src/gori/proxy/h2/head_codec.cr
@@ -20,6 +20,16 @@ module Gori::Proxy::H2
   # `parse_request` / `parse_response` invert them, restoring from the ORIGINAL fields what
   # the h1 text has nowhere to carry: `:scheme`, the §6.2.3 never-indexed markings, and
   # whether the `Host:` line was ours or the peer's.
+  #
+  # ## The round trip is only sound while it is INJECTIVE (#517)
+  #
+  # "Invert" holds for a head the text can represent, and NOT for one it cannot: a field value
+  # carrying a CRLF comes back as two fields, a duplicate pseudo-header comes back as one, an
+  # uppercase name comes back lowercased. Every such input is malformed h2 a conformant peer
+  # would REJECT, so the round trip would launder it into a message the far side ACCEPTS —
+  # gori promoting the peer's malformed head, a header-injection primitive that exists only
+  # because of this bridge. `h1_faithful?` is the precondition that says no; `parse_*` refuse
+  # outright rather than trust a caller to ask.
   module HeadCodec
     extend self
 
@@ -57,6 +67,7 @@ module Gori::Proxy::H2
     # Returns nil when the rewritten bytes are no longer a head — the caller then forwards
     # the original block unchanged and says so, rather than guessing (#492 decision A).
     def parse_request(head : Bytes, original : Array(HPACK::Field)) : Array(HPACK::Field)?
+      return nil unless h1_faithful?(original, request: true)
       start, lines = split_head(head)
       return nil unless start
       method, path = request_line(start)
@@ -108,6 +119,7 @@ module Gori::Proxy::H2
 
     # Invert `synth_response`. See `parse_request`.
     def parse_response(head : Bytes, original : Array(HPACK::Field)) : Array(HPACK::Field)?
+      return nil unless h1_faithful?(original, request: false)
       start, lines = split_head(head)
       return nil unless start
       status = status_code(start)
@@ -144,6 +156,119 @@ module Gori::Proxy::H2
       fields_out = fields.reject { |f| f.name == "content-length" }
       fields_out.concat(orig)
       fields_out
+    end
+
+    # Whether `synth_* -> parse_*` returns these fields UNCHANGED — the precondition the
+    # whole rewrite path rests on, and the one #492's hazard table did not state (#517).
+    #
+    # The h1 head text is a lossy carrier. `synth_*` writes `name: value\r\n` per field and
+    # `parse_*` reads it back by splitting on the line ending and cutting at the first `:`,
+    # so a field the peer sent can come back as two fields, as none, or as a DIFFERENT
+    # well-formed field. Every one of those inputs is malformed h2 (RFC 9113 §8.2.1/§8.3)
+    # that a conformant endpoint would REJECT — which is exactly what makes it matter: the
+    # round trip would hand the far side a message it accepts, so gori would be laundering
+    # the peer's malformed head into a valid one. A header-injection primitive
+    # (`set-cookie`, `location`, `x-admin`, ...) that exists only because of the bridge.
+    #
+    # So the round trip is refused for these fields instead. The caller's disposition is the
+    # one an unparseable rewrite already takes: emit the ORIGINAL fields. On an engaged
+    # direction that is a re-encode of those fields, not a raw frame passthrough, so the
+    # §6.2.1 latch invariant is untouched (`HeadRewrite#finish`) — malformed in, malformed
+    # out, and the far side rejects it exactly as it would have without gori.
+    #
+    # Judged on what the PEER sent, never on what a rule produced. A rule whose replacement
+    # contains a CRLF adds two headers here for the same reason it does on h1: those are the
+    # operator's bytes, and carrying operator-supplied malformed input is the point (P7).
+    #
+    # Deliberately conservative in one place: a duplicate pseudo-header is refused in both
+    # directions, though only `request_pseudo` drops every duplicate while `parse_response`
+    # drops only a second `:status`. Duplicate pseudo-headers are malformed either way.
+    def h1_faithful?(fields : Array(HPACK::Field), request : Bool) : Bool
+      seen = Set(String).new
+      regular = false
+      fields.each do |f|
+        if pseudo?(f.name)
+          # §8.3 puts the pseudo-headers first and `parse_*` re-emits them there, so a peer
+          # that sent one AFTER a regular field would get its order corrected. A duplicate is
+          # dropped outright by the `seen` guard in `request_pseudo`.
+          return false if regular || !seen.add?(f.name)
+          return false unless pseudo_faithful?(f, fields, request)
+        else
+          regular = true
+          return false unless regular_faithful?(f)
+        end
+      end
+      request ? request_shape?(fields, seen) : seen.includes?(":status")
+    end
+
+    # A regular field survives iff the text can hold it: `header_lines` cuts the line at its
+    # FIRST `:` (so a name carrying one renames the field and moves the rest into the value),
+    # `strip`s the name and `lstrip(' ')`s the value (so leading whitespace is eaten — a
+    # trailing space survives, and is left alone), and `append_regular` lowercases the name.
+    # A CR or LF anywhere is a line break in the text: CRLF splits the field in two, a second
+    # CRLF truncates the head and drops every field after it, and a lone CR/LF survives here
+    # today only because the synthesized EOL happens to be CRLF — the same byte still ends
+    # the head early for `StreamGate#split_edit`'s `\n\n` scan on an intercept edit.
+    private def regular_faithful?(f : HPACK::Field) : Bool
+      name = f.name
+      !name.empty? && !name.includes?(':') && !line_broken?(name) &&
+        name == name.strip.downcase &&
+        !line_broken?(f.value) && !f.value.starts_with?(' ')
+    end
+
+    # A pseudo-header survives iff the start line (or the synthetic `Host:` line) can hold it.
+    # A pseudo belonging to the OTHER direction — a `:status` on a request, a `:method` on a
+    # response — is copied straight off `original`, exactly like `:scheme` and an unknown one,
+    # and so cannot be damaged.
+    private def pseudo_faithful?(f : HPACK::Field, fields : Array(HPACK::Field), request : Bool) : Bool
+      request ? request_pseudo_faithful?(f, fields) : response_pseudo_faithful?(f)
+    end
+
+    private def request_pseudo_faithful?(f : HPACK::Field, fields : Array(HPACK::Field)) : Bool
+      value = f.value
+      case f.name
+      when ":method"
+        # `request_line` splits the start line on its FIRST space: a method carrying one comes
+        # back with its tail moved into `:path`.
+        !value.empty? && !value.includes?(' ') && !line_broken?(value)
+      when ":path"
+        # A CRLF here splits the START line — the injected field lands ahead of every real one.
+        !value.empty? && !line_broken?(value)
+      when ":authority"
+        # Only the SYNTHETIC `Host:` line can damage it; with an explicit `host` field
+        # `resolve_authority` preserves `:authority` off the original instead.
+        return true if host_carrier?(fields)
+        !value.empty? && !value.starts_with?(' ') && !line_broken?(value)
+      else
+        true
+      end
+    end
+
+    # `synth_response` normalizes the code through `to_i` so a stored head does not vary with a
+    # peer's padding — which also turns a `:status` of `0200` (§8.3.2 requires exactly three
+    # digits, so a conformant client rejects it) into an accepted `200`.
+    private def response_pseudo_faithful?(f : HPACK::Field) : Bool
+      return true unless f.name == ":status"
+      (f.value.to_i? || 0).to_s == f.value
+    end
+
+    # `synth_request` defaults a missing `:method`/`:path` and `resolve_authority` maps the
+    # `Host:` line back to `:authority`, so a request missing any of the three comes back
+    # with it INVENTED — §8.3.1 requires all three, so that is another malformed head made
+    # acceptable. (`:authority` may legitimately be absent when a `host` field carries it.)
+    private def request_shape?(fields : Array(HPACK::Field), seen : Set(String)) : Bool
+      seen.includes?(":method") && seen.includes?(":path") &&
+        (seen.includes?(":authority") || host_carrier?(fields))
+    end
+
+    private def line_broken?(s : String) : Bool
+      s.includes?('\r') || s.includes?('\n')
+    end
+
+    # `explicit_host?` over decoded fields — the same test `synth_request` makes before it
+    # invents a `Host:` line, without building the tuple array to ask it.
+    private def host_carrier?(fields : Array(HPACK::Field)) : Bool
+      fields.any? { |f| host_field?(f.name) }
     end
 
     def pseudo(fields : Array({String, String}), name : String) : String?

--- a/src/gori/proxy/h2/head_rewrite.cr
+++ b/src/gori/proxy/h2/head_rewrite.cr
@@ -107,6 +107,7 @@ module Gori::Proxy::H2
       @encoder = HPACK::Encoder.new
       @engaged = false
       @warned = false
+      @warned_unfaithful = false
       @buf = [] of Frame::Header
       @block_bytes = 0
       @block_stream = 0_u32
@@ -152,6 +153,13 @@ module Gori::Proxy::H2
     # edited bytes are no longer a head: the caller then forwards the block as it stood, which
     # is what an unparseable RULE result already does.
     def encode_edited(block : Block, head : Bytes) : Block?
+      # The head shown to the operator is a lossy rendering of what the peer sent, so re-parsing
+      # their edit would apply it to a DIFFERENT message (#517). Refuse the edit rather than
+      # send that; the caller keeps the block as it stood.
+      unless HeadCodec.h1_faithful?(block.fields, block.request)
+        warn_unfaithful(block.stream_id, block.request)
+        return nil
+      end
       parsed = block.request ? HeadCodec.parse_request(head, block.fields) : HeadCodec.parse_response(head, block.fields)
       if parsed.nil?
         warn_unparseable(block.stream_id, "an intercept edit")
@@ -295,6 +303,11 @@ module Gori::Proxy::H2
     private def rewrite(fields : Array(HPACK::Field), head : Bytes, request : Bool) : Array(HPACK::Field)?
       rw = @rewriter
       return nil unless rw && rw.active?
+      # The peer's own head has no faithful h1-text form, so the round trip that runs the
+      # rules would hand the far side a DIFFERENT message — see `HeadCodec.h1_faithful?`.
+      # `parse_*` refuses it anyway; checking here keeps the rules from running for nothing
+      # and, more to the point, keeps the log from blaming a rule for the peer's bytes.
+      return warn_unfaithful(@block_stream, request) unless HeadCodec.h1_faithful?(fields, request)
       authority = request ? (HeadCodec.pseudo_of(fields, ":authority") || @host) : @host
       rewritten_head = request ? rw.rewrite_request(head, authority) : rw.rewrite_response(head, @host)
       return nil if rewritten_head == head # `Rules` returns the same content when nothing matched
@@ -330,6 +343,20 @@ module Gori::Proxy::H2
       ::Log.warn do
         "h2 #{@direction}: #{source} produced a head that is no longer parseable " \
         "(stream #{stream_id}) — forwarded the original head unchanged"
+      end
+    end
+
+    # The mirror of `warn_unparseable` for a head the PEER sent that the h1 text cannot carry
+    # (#517). Not a rule's doing and not the operator's, so it gets its own line — and its own
+    # flag, or whichever of the two happened first would silence the other. Always nil, so
+    # `rewrite` can return it directly: nothing is rewritten and the original fields go out.
+    private def warn_unfaithful(stream_id : UInt32, request : Bool) : Nil
+      return if @warned_unfaithful
+      @warned_unfaithful = true
+      ::Log.warn do
+        "h2 #{@direction}: the peer sent a #{request ? "request" : "response"} head that has no " \
+        "HTTP/1.1 text form (stream #{stream_id}) — Match&Replace and intercept edits are " \
+        "not applied to it, the fields go out exactly as they arrived"
       end
     end
 


### PR DESCRIPTION
Closes #517.

`HeadCodec`'s h1-text round trip is not injective, and #492's step-2 hazard table never said it had to be. #517 reported one instance — a CRLF in a field value comes back as two wire fields. Auditing the whole round trip found **sixteen** inputs of that shape. This closes all of them with one precondition.

## The defect, restated

A field value carrying a CRLF is malformed h2 (RFC 9113 §8.2.1) that a conformant endpoint would **reject**. The round trip turned it into two well-formed headers the endpoint **accepts** — gori promoting a rejected message into a passing one. A header-injection primitive (`set-cookie`, `location`, `x-admin`) that exists only because of the bridge.

Every other break below has the same shape: malformed h2 in, well-formed h2 out.

## The injectivity audit

Judged by round-tripping `synth_* → parse_*` with no rule in between and comparing field-for-field. "Fixed" = `h1_faithful?` now refuses it.

### Breaks — a field is split, dropped, or invented

| # | Input (from the peer) | Round trip produced | Fixed |
|---|---|---|---|
| 1 | `x-echo: safe\r\nset-cookie: injected=1` | **two** fields, the second attacker-controlled | ✅ |
| 2 | `x-echo: a\r\n\r\n…` | head **truncated** — every field after it dropped | ✅ |
| 3 | `:path: /a\r\nx-admin: true` | **start line** split; injected field lands ahead of every real one | ✅ |
| 4 | `:authority: a.test\r\nx-admin: true` | synthetic `Host:` line split; field injected | ✅ |
| 5 | duplicate `:method` / `:path` / `:scheme` | the second is **dropped** (`request_pseudo`'s `seen` guard) | ✅ |
| 6 | duplicate `:status` | the second is **dropped** | ✅ |
| 7 | a pseudo-header sent **after** a regular one | **reordered** to the front, so §8.3 order is corrected | ✅ |
| 8 | no `:authority` and no `host` field | `:authority` **invented** from the connection host | ✅ |
| 9 | `:authority: ` (empty), no `host` field | `:authority` **dropped** | ✅ |
| 10 | no `:path` at all | `:path: /` **invented** | ✅ |

### Breaks — a field is silently mutated into a different, well-formed one

| # | Input | Round trip produced | Fixed |
|---|---|---|---|
| 11 | `x-a:b: v` (colon in the **name**) | `x-a: b: v` — the field is renamed | ✅ |
| 12 | ` x-echo : v` (whitespace around the name) | `x-echo: v` | ✅ |
| 13 | `X-Echo: v` (uppercase name the **peer** sent) | `x-echo: v` | ✅ |
| 14 | `x-echo:    lead` (leading space in the value) | `lead` — h1 OWS is stripped | ✅ |
| 15 | `:status: 0200` / `099` / `abc` | `200` / `99` / `0` — `synth_response` normalizes through `to_i` | ✅ |
| 16 | `:method: GE T` | method `GE`, `:path` `T /` — the start line re-splits | ✅ |

### Survives HeadCodec today, refused anyway

A lone `\r` or a lone `\n` (in a name or a value) round-trips **only** because the synthesized EOL happens to be CRLF. It is still a line break in the text gori hands out: `StreamGate#split_edit` scans for `\n\n` when re-parsing an intercept edit, so the same byte can still end a held head early. Both are malformed h2, so refusing them costs conformant traffic nothing and leaves one rule instead of three.

### Faithful — verified, left alone

Trailing space in a value; leading/trailing tab in a value; `: ` inside a value; NUL and other control bytes; invalid UTF-8 in a name or a value (Crystal's `downcase`/`strip` preserve the raw bytes); duplicate regular fields (h2 cookie crumbs); duplicate `host` fields; a space inside a field name; `:scheme`, `:protocol` and unknown pseudo-headers (copied off the original, so nothing can damage them); a `:path` holding raw spaces or a `HTTP/x` token; a tab in `:method`.

### Already refused before this change

An empty field name (`idx == 0`), an empty `:method` (`sp == 0`), an empty `:path` (`rest.empty?`).

### Deviations left in place, deliberately

- **The never-indexed marking is propagated BY NAME** (#492 side question 2). Two same-named fields with different §6.2.3 markings both come back marked. It only ever costs compression and never changes what the wire says, and it is a standing decision — not touched.
- **`content-length` is restored from the original** (`restore_content_length`, #403). Same.
- **The stored History head text is unchanged.** For a flow whose head has no h1-text form, the *text* `Assembler` stores still renders the CRLF value across two lines — the h1 text genuinely has no faithful form for it, and `synth_*` is the one implementation shared with capture and with the Rewriter tab's preview (#492 decision A), so changing it is a capture-format change with its own review surface. The **wire** is what this PR closes; the raw frame log remains the truth for the derived view (P7). Called out rather than quietly claimed fixed.

## Why refuse, and not carry the value out-of-band

The issue and the brief both point at #512's precedent: never-indexed markings have no h1-text representation, so they are carried outside the text. That does not transfer here, for three reasons.

1. **It only addresses one of the sixteen.** Duplicate pseudo-headers, pseudo-after-regular ordering, `:status` normalization, name casing and `:`-in-name are *structural* losses, not "no room in the text". One predicate closes all sixteen uniformly.
2. **A never-indexed marking is metadata no rule can express; a CRLF value is content rules can see and rewrite.** Taking it out of the text means an operator's `Replace` rule targeting that value silently stops applying — a new silent-divergence surface, which is the failure class this epic exists to remove.
3. **Removing the field from the text is a fidelity loss for History**, which #517 also complains about. Keeping it in the text is what makes the round trip ambiguous in the first place: after a rule has edited the lines, nothing can tell which of them came from the mangled field.

And the two options do not differ in what the peer receives: either way the malformed field goes out as the peer sent it.

## Why this is not the passthrough the brief rules out

The brief is right that a raw frame passthrough on a latched direction is a §6.2.1 desync, and that #512 decision C made re-encoding a coherence requirement. It is worth being precise about what the existing "unparseable → forward the original" rule actually does, because that is what this reuses:

```crystal
built = if rewritten.nil? && !@engaged
          Block.new(@buf.dup, ...)            # byte-exact frames — only while UNENGAGED
        else
          @engaged = true
          Block.new(reframe(first, prefix, @encoder.encode(emit_fields)), ...)
        end                                   # emit_fields == the ORIGINAL decoded fields
```

The disposition is **"emit the original FIELDS"**, not "forward the original frames". On an engaged direction that is a re-encode, so the latch is never broken. On an unengaged direction the byte-exact frames are correct, because nothing has been re-encoded yet. This change adds no new disposition; it reaches the existing one earlier and with an accurate log line.

The latch case is covered by a spec **and** by the live run below, where a single connection-scoped client decoder reads both heads — which it could not do if the second block had been forwarded as it arrived.

## The change

- `HeadCodec.h1_faithful?(fields, request)` — the precondition, judged on what the **peer** sent.
- `parse_request` / `parse_response` refuse outright, so no caller can bypass it (`rewrite`, `encode_edited`, or any future one).
- `HeadRewrite#rewrite` and `#encode_edited` check it first as well — not for safety, but so the rules do not run for nothing and so the warning names the peer instead of blaming a rule or the operator.
- h1 path untouched. `synth_*` untouched, so capture and the rewrite path still cannot drift.

The guard reads what the **peer** sent, never what a rule produced: a rule whose replacement holds a CRLF still adds two headers, because the identical rule does that on h1 and those are the operator's bytes (P7). Locked by a spec.

## Verification

### Specs

`crystal spec` — **5172 examples, 0 failures** (main's 5091 + 81 new).

`spec/proxy/h2/head_codec_spec.cr` keeps the audit as a **corpus that is its own oracle**: for every entry it asserts that `h1_faithful?` and what the round trip *actually does* agree, so a future change to either side fails there rather than on the wire.

### Live — real sockets, real relay, real rules, real origin

Not a spec: two Crystal drivers wire `client ──TCP──> Gori::Proxy::H2::Relay ──TCP──> origin`, with a real `Gori::Rules` head rule loaded from a real SQLite store, and an origin that decodes what it receives with its own `HPACK::Decoder`.

**Request direction** — malicious client, rule `x-tag: a` → `x-tag: b`:

```
                                     BEFORE (fix reverted)          AFTER
client SENT (6 fields)               origin GOT (7 fields)          origin GOT (6 fields)
  :method: GET                         :method: GET                   :method: GET
  :scheme: https                       :scheme: https                 :scheme: https
  :authority: api.example.com          :authority: api.example.com    :authority: api.example.com
  :path: /                             :path: /                       :path: /
  x-tag: a                             x-tag: b                       x-tag: a
  x-echo: safe\r\nx-admin: true        x-echo: safe                   x-echo: safe\r\nx-admin: true
                                       x-admin: true   <-- FORGED

x-admin forged on the origin :  YES  <-- #517            no
fields in / out              :  6 / 7                    6 / 6
origin received exactly what the client sent: false      true
```

**Response direction, with the direction already latched** — malicious origin, rule `x-tag: a` → `x-tag: b`. Stream 1 is a clean head the rule changes (so the `in` direction engages); stream 3 is the malicious one, encoded by the origin **with incremental indexing** against the table entry stream 1 inserted. The client uses **one** connection-scoped decoder:

```
                                            BEFORE                    AFTER
origin SENT stream 3 (4 fields)             client GOT (5 fields)     client GOT (4 fields)
  :status: 200                                :status: 200              :status: 200
  x-tag: a                                    x-tag: b                  x-tag: a
  x-echo: safe\r\nset-cookie: injected=1      x-echo: safe              x-echo: safe\r\nset-cookie: injected=1
  x-token: abc…xyz                            set-cookie: injected=1    x-token: abc…xyz
                                                       ^-- FORGED
                                              x-token: abc…xyz

both heads decoded by one client decoder :  true                      true
rule applied to the clean head (x-tag)   :  "b"                       "b"
set-cookie forged on the client          :  YES  <-- #517             no
client got the evil head exactly as sent :  false                     true
```

That the single client decoder reads stream 3 correctly is the latch proof: the origin's encoder indexed against a table the client never received, so a passthrough block there would have desynced.

Both runs were done twice — reverted (control, reproduces the injection) and fixed — and the tree was diffed byte-for-byte against the pre-control state afterwards.

`gori` also logs it, once per direction per connection, naming neither a rule nor the operator:

```
WARN - h2 out: the peer sent a request head that has no HTTP/1.1 text form (stream 1)
       — Match&Replace and intercept edits are not applied to it, the fields go out
       exactly as they arrived
```

### Lint

`ameba` on the four touched files: clean. The one remaining finding (`head_rewrite_spec.cr:164`, `Style/VerboseBlock`) is pre-existing and identical at `fcfc7c8f`.

## Out of scope

#516 (`fail_open` nulling `slot.item` before forward) is a separate defect in a nearby file. Not touched.
