### PR TITLE
fix(ws): strip the client's permessage-deflate offer from the relayed handshake

### DIFF
--- a/docs/content/guide/proxy.ko.md
+++ b/docs/content/guide/proxy.ko.md
@@ -91,9 +91,11 @@ gori는 지나가는 프로토콜을 인식합니다.
 |----------|---------|
 | **HTTP/1.1** | 전체 캡처 및 리피터 |
 | **HTTP/2** | ALPN 이후 투명 릴레이, 원시 프레임 로그, HPACK 디코드, stream → flow 조립 |
-| **WebSocket** | 실시간 메시지 캡처 및 리피터 (permessage-deflate 미지원) |
+| **WebSocket** | 실시간 메시지 캡처 및 리피터. 핸드셰이크에서 압축이 제거됩니다(아래 참고) |
 | **gRPC** | HTTP/2 위에 프레이밍되고 status 트레일러 포함; protobuf는 원시 바이트로 표시 (`.proto` 스키마 없음) |
 | **Server-Sent Events** | 표시 시점에 개별 이벤트로 파싱 |
+
+**gori를 지나는 WebSocket은 압축되지 않습니다.** gori가 중계하는 핸드셰이크에서 `Sec-WebSocket-Extensions`를 제거하므로 `permessage-deflate`는 협상되지 않고, 캡처된 프레임은 실제로 오간 메시지 그대로입니다. 이 제거가 없으면 양쪽 피어는 gori가 해독하지 않는 압축에 합의하게 되고, History와 상세 뷰, `gori run history show`, MCP 도구, export가 전부 deflate 스트림을 페이로드인 양 보여 주게 됩니다. 믿을 수 있는 캡처의 대가로, 원래라면 압축을 쓸 앱이 gori를 지나는 동안에는 압축을 쓰지 못합니다. 특정 호스트의 소켓을 있는 그대로 중계해야 한다면 그 호스트를 [TLS passthrough](/ko/reference/config/#tls-passthrough)에 등록하세요. 연결에 손대지 않는 대신 그 호스트는 아무것도 캡처되지 않습니다.
 
 와이어 프로토콜 위에서, gori는 흔히 쓰이는 페이로드를 인라인으로 디코드합니다.
 

--- a/docs/content/guide/proxy.md
+++ b/docs/content/guide/proxy.md
@@ -91,9 +91,11 @@ gori understands the protocols it carries:
 |----------|---------|
 | **HTTP/1.1** | Full capture and repeater |
 | **HTTP/2** | Transparent relay after ALPN, raw frame log, HPACK decode, stream → flow assembly |
-| **WebSocket** | Live message capture and repeater (no permessage-deflate) |
+| **WebSocket** | Live message capture and repeater. Compression is removed from the handshake (see below) |
 | **gRPC** | Framed over HTTP/2 with status trailers; protobuf shown as raw bytes (no `.proto` schema) |
 | **Server-Sent Events** | Parsed into discrete events at display time |
+
+**A WebSocket through gori is never compressed.** gori removes `Sec-WebSocket-Extensions` from the handshake it relays, so `permessage-deflate` is never negotiated and every captured frame is the message that was sent. Without that removal the two peers would agree on compression that gori does not decode, and History, the detail view, `gori run history show`, the MCP tools and export would all show you a deflate stream while presenting it as the payload. Removing the offer is the price of a capture you can trust: an app that would have used compression does not get it while it goes through gori. If you need a particular host's sockets relayed exactly as they are, put it under [TLS passthrough](/reference/config/#tls_passthrough), which leaves the connection alone and captures nothing for it.
 
 On top of the wire protocols, gori decodes common payloads inline:
 

--- a/spec/proxy/ws_spec.cr
+++ b/spec/proxy/ws_spec.cr
@@ -1,6 +1,14 @@
 require "../spec_helper"
 require "socket"
 
+# A minimal WebSocket client handshake; `extra` lands between the version and the
+# User-Agent so a stripped line has neighbours on both sides to preserve.
+private def handshake(extra : String) : Bytes
+  ("GET /ws HTTP/1.1\r\nHost: echo.test\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" \
+   "Sec-WebSocket-Key: dGhlIHNhbXBsZQ==\r\nSec-WebSocket-Version: 13\r\n#{extra}" \
+   "User-Agent: probe\r\n\r\n").to_slice
+end
+
 # Builds a masked client text frame for short payloads (<126 bytes).
 private def masked_frame(text : String) : Bytes
   payload = text.to_slice
@@ -15,12 +23,14 @@ end
 
 private class IntegSink < Gori::Proxy::FlowSink
   getter ws = [] of {String, String}
+  getter heads = [] of String
 
   def initialize(@ws_chan : Channel(Nil))
     @next = 0_i64
   end
 
   def on_request(req : Gori::Store::CapturedRequest) : Int64
+    @heads << String.new(req.head)
     @next += 1
   end
 
@@ -328,6 +338,89 @@ describe Gori::Proxy::WS do
   end
 end
 
+describe Gori::Proxy::WS::Handshake do
+  describe ".offers_extensions?" do
+    it "is true for a WebSocket upgrade carrying the header" do
+      req = Gori::Proxy::Codec::Http1.parse_request_head(
+        handshake("Sec-WebSocket-Extensions: permessage-deflate\r\n"))
+      Gori::Proxy::WS::Handshake.offers_extensions?(req.headers).should be_true
+    end
+
+    it "matches the field-name and the upgrade token case-insensitively" do
+      req = Gori::Proxy::Codec::Http1.parse_request_head(
+        ("GET /ws HTTP/1.1\r\nUpgrade: WebSocket\r\n" \
+         "SEC-WEBSOCKET-EXTENSIONS: permessage-deflate\r\n\r\n").to_slice)
+      Gori::Proxy::WS::Handshake.offers_extensions?(req.headers).should be_true
+    end
+
+    it "reads Upgrade as a protocol LIST, not one value" do
+      # RFC 7230 §6.7: `Upgrade: websocket, h2c` is still a WebSocket handshake, and a
+      # whole-value compare would miss it and leave the offer in place.
+      req = Gori::Proxy::Codec::Http1.parse_request_head(
+        ("GET /ws HTTP/1.1\r\nUpgrade: h2c, websocket\r\n" \
+         "Sec-WebSocket-Extensions: permessage-deflate\r\n\r\n").to_slice)
+      Gori::Proxy::WS::Handshake.offers_extensions?(req.headers).should be_true
+    end
+
+    it "is false without the header" do
+      req = Gori::Proxy::Codec::Http1.parse_request_head(handshake(""))
+      Gori::Proxy::WS::Handshake.offers_extensions?(req.headers).should be_false
+    end
+
+    it "is false when the request is not a WebSocket upgrade" do
+      # The field is defined only for the handshake, so on an ordinary request it is inert
+      # and the head stays byte-exact (P7) rather than being rewritten for nothing.
+      req = Gori::Proxy::Codec::Http1.parse_request_head(
+        ("GET /p HTTP/1.1\r\nHost: echo.test\r\n" \
+         "Sec-WebSocket-Extensions: permessage-deflate\r\n\r\n").to_slice)
+      Gori::Proxy::WS::Handshake.offers_extensions?(req.headers).should be_false
+    end
+  end
+
+  describe ".strip_extensions" do
+    it "removes the offer and leaves every other byte alone" do
+      stripped = Gori::Proxy::WS::Handshake.strip_extensions(
+        handshake("Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits\r\n"))
+      stripped.should eq(handshake(""))
+    end
+
+    it "removes EVERY extension line (RFC 6455 allows the offer split across fields)" do
+      stripped = Gori::Proxy::WS::Handshake.strip_extensions(
+        handshake("Sec-WebSocket-Extensions: permessage-deflate\r\n" \
+                  "sec-websocket-extensions: x-webkit-deflate-frame\r\n"))
+      stripped.should eq(handshake(""))
+    end
+
+    it "is a byte-exact no-op when there is no extension line" do
+      Gori::Proxy::WS::Handshake.strip_extensions(handshake("")).should eq(handshake(""))
+    end
+
+    it "keeps a header whose name only STARTS with the stripped name" do
+      extra = "Sec-WebSocket-Extensions-Note: keep\r\n"
+      Gori::Proxy::WS::Handshake.strip_extensions(handshake(extra)).should eq(handshake(extra))
+    end
+
+    it "never drops the start-line, even one shaped like the stripped header" do
+      raw = "sec-websocket-extensions: permessage-deflate\r\nUpgrade: websocket\r\n\r\n"
+      Gori::Proxy::WS::Handshake.strip_extensions(raw.to_slice).should eq(raw.to_slice)
+    end
+
+    it "copies non-UTF-8 header VALUE bytes verbatim" do
+      # A cookie/auth token carrying raw high bytes must survive the rebuild byte-exact —
+      # the strip walks bytes and never round-trips a value through String.
+      io = IO::Memory.new
+      io << "GET /ws HTTP/1.1\r\nUpgrade: websocket\r\nCookie: sid="
+      io.write(Bytes[0xFF, 0xFE, 0x80])
+      io << "\r\nSec-WebSocket-Extensions: permessage-deflate\r\n\r\n"
+      want = IO::Memory.new
+      want << "GET /ws HTTP/1.1\r\nUpgrade: websocket\r\nCookie: sid="
+      want.write(Bytes[0xFF, 0xFE, 0x80])
+      want << "\r\n\r\n"
+      Gori::Proxy::WS::Handshake.strip_extensions(io.to_slice).should eq(want.to_slice)
+    end
+  end
+end
+
 describe "WebSocket through the proxy (end-to-end)" do
   it "detects the 101 upgrade, relays frames, and captures both directions" do
     # origin: respond 101, then echo one client frame back (unmasked)
@@ -371,6 +464,95 @@ describe "WebSocket through the proxy (end-to-end)" do
 
     sink.ws.should contain({"out", "ping"})
     sink.ws.should contain({"in", "ping"})
+  end
+
+  it "strips the client's permessage-deflate offer from the handshake it relays (#518)" do
+    # Without the strip the origin accepts the extension, both peers compress, and every
+    # frame WS::Relay captures is a deflate stream stored as if it were the message. The
+    # offer is the side that gets cut: negotiation is offer-driven, so an origin with
+    # nothing to accept leaves the socket uncompressed.
+    origin = TCPServer.new("127.0.0.1", 0)
+    port = origin.local_address.port
+    seen = Channel(String).new(1)
+    spawn do
+      conn = origin.accept
+      head = Gori::Proxy::Codec::Http1.read_head(conn).not_nil!
+      seen.send(String.new(head))
+      # Answer as a conformant origin would with nothing offered: no acceptance.
+      conn << "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n"
+      conn.flush
+      frame = Gori::Proxy::WS.read_frame(conn).not_nil!
+      conn.write(Bytes[0x81_u8, frame.payload.size.to_u8])
+      conn.write(frame.payload)
+      conn.flush
+    rescue
+    end
+
+    ws_chan = Channel(Nil).new(4)
+    sink = IntegSink.new(ws_chan)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink)
+    proxy.start
+
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    client.read_timeout = 5.seconds
+    client << "GET /ws HTTP/1.1\r\nHost: 127.0.0.1:#{port}\r\n" \
+              "Upgrade: websocket\r\nConnection: Upgrade\r\n" \
+              "Sec-WebSocket-Key: dGhlIHNhbXBsZQ==\r\nSec-WebSocket-Version: 13\r\n" \
+              "Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits\r\n" \
+              "User-Agent: probe\r\n\r\n"
+    client.flush
+
+    origin_head = seen.receive
+    origin_head.downcase.should_not contain("sec-websocket-extensions")
+    origin_head.should contain("Sec-WebSocket-Key: dGhlIHNhbXBsZQ==") # everything else survives
+    origin_head.should contain("User-Agent: probe")
+
+    resp_head = Gori::Proxy::Codec::Http1.read_head(client).not_nil!
+    String.new(resp_head).should contain("101")
+
+    client.write(masked_frame("hello"))
+    client.flush
+    Gori::Proxy::WS.read_frame(client).not_nil!
+    ws_chan.receive # out
+    ws_chan.receive # in
+    client.close
+    proxy.stop
+
+    # The RECORDED request is the handshake gori sent, not the client's offer: an offer
+    # captured beside a 101 with no acceptance would read as "the origin declined".
+    sink.heads.size.should eq(1)
+    sink.heads[0].downcase.should_not contain("sec-websocket-extensions")
+    sink.ws.should contain({"out", "hello"})
+  end
+
+  it "leaves the header alone on a request that is not upgrading" do
+    # The field is defined only for the handshake, so on an ordinary request it is inert
+    # and gori has no reason to spend a byte change on it (P7).
+    origin = TCPServer.new("127.0.0.1", 0)
+    port = origin.local_address.port
+    seen = Channel(String).new(1)
+    spawn do
+      conn = origin.accept
+      seen.send(String.new(Gori::Proxy::Codec::Http1.read_head(conn).not_nil!))
+      conn << "HTTP/1.1 204 No Content\r\n\r\n"
+      conn.flush
+    rescue
+    end
+
+    sink = IntegSink.new(Channel(Nil).new(1))
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink)
+    proxy.start
+
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    client.read_timeout = 5.seconds
+    client << "GET /p HTTP/1.1\r\nHost: 127.0.0.1:#{port}\r\n" \
+              "Sec-WebSocket-Extensions: permessage-deflate\r\n\r\n"
+    client.flush
+
+    seen.receive.should contain("Sec-WebSocket-Extensions: permessage-deflate")
+    Gori::Proxy::Codec::Http1.read_head(client)
+    client.close
+    proxy.stop
   end
 
   it "blind-tunnels a NON-WebSocket 101 upgrade instead of parsing the post-upgrade bytes as HTTP (desync)" do

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -14,6 +14,7 @@ require "../connect"
 require "../upstream"
 require "../pump"
 require "../ws/relay"
+require "../ws/handshake"
 require "../../flow_mapper"
 require "./self_page"
 
@@ -215,6 +216,11 @@ module Gori::Proxy
         return false
       end
 
+      # WebSocket: remove the client's `Sec-WebSocket-Extensions` offer before the
+      # handshake leaves for the origin (#518). `client_head` is the client's own bytes
+      # with the same removal applied, for the History record. See the helper.
+      client_head, forward_head, record_req = strip_ws_extension_offer(req, forward_head)
+
       # Match&Replace (request head): rewrite the bytes sent upstream. Only when
       # a rule actually changes something do we capture the modified bytes (the
       # user's chosen semantics); otherwise the original client bytes are kept
@@ -230,7 +236,6 @@ module Gori::Proxy
       # shows its intended change. The wire request stays origin-form (unchanged).
       sent_req = req
       sent_head = forward_head
-      record_req = req
       if rw = @rewriter
         rewritten = rw.rewrite_request(forward_head, host)
         if rewritten != forward_head
@@ -241,8 +246,8 @@ module Gori::Proxy
           # shows exactly what went on the wire.
           sent_head = restore_framing_headers(rewritten, forward_head)
           sent_req = Codec::Http1.parse_request_head(sent_head)
-          record_head = restore_framing_headers(rw.rewrite_request(req.raw_head, host), req.raw_head)
-          record_req = Codec::Http1.parse_request_head(record_head) unless record_head == req.raw_head
+          record_head = restore_framing_headers(rw.rewrite_request(client_head, host), client_head)
+          record_req = Codec::Http1.parse_request_head(record_head) unless record_head == client_head
         end
       end
 
@@ -339,6 +344,34 @@ module Gori::Proxy
       end
       handle_response(upstream, req, flow_id, started, host, port, scheme,
         reused: reused, sent_head: sent_head, can_retry: retryable, sent_req: sent_req)
+    end
+
+    # Removes the client's `Sec-WebSocket-Extensions` offer from the handshake gori is
+    # about to relay (#518), returning {client-form head, wire head, recorded request}.
+    # A no-op returning the inputs untouched (P7) for everything that is not a WebSocket
+    # upgrade carrying an offer, which is every other request on this path.
+    #
+    # gori's FIRST hop-by-hop removal, and it is deliberate — see `WS::Handshake` for why
+    # the client's offer (rather than the origin's acceptance) is the side that gets cut,
+    # and for the cost of cutting it at all. Unconditional by necessity: extension
+    # negotiation happens once, in the 101 handshake, with no renegotiation, so it cannot
+    # be deferred to the moment a capture consumer turns up the way #512's h2 re-encode was.
+    #
+    # The recorded request mirrors the strip so History shows the handshake gori actually
+    # sent. An un-stripped offer captured beside a 101 that carries no acceptance would
+    # read as "the origin declined compression", which is a lie about the origin that no
+    # doc line can undo.
+    #
+    # Runs BEFORE the Match&Replace pass on purpose: a rule (or an intercept edit) that
+    # puts the header back is the operator saying so explicitly, and operator bytes win
+    # here as they do everywhere else on this path. Running early costs nothing either —
+    # an offer hidden from this scan by an obs-fold or `name<SP>:` is never forwarded at
+    # all, because `Codec::Body.request_framing` rejects the whole request just below.
+    private def strip_ws_extension_offer(req : Codec::RawRequest,
+                                         forward_head : Bytes) : {Bytes, Bytes, Codec::RawRequest}
+      return {req.raw_head, forward_head, req} unless WS::Handshake.offers_extensions?(req.headers)
+      client_head = WS::Handshake.strip_extensions(req.raw_head)
+      {client_head, WS::Handshake.strip_extensions(forward_head), Codec::Http1.parse_request_head(client_head)}
     end
 
     # The intercept-hold request path: buffer the body, let the human edit/drop
@@ -636,6 +669,7 @@ module Gori::Proxy
         SocketTuning.relax(@io)
         SocketTuning.relax(upstream)
         if websocket_upgrade?(resp)
+          warn_unoffered_ws_extension(resp, host, sent_req.target)
           WS::Relay.run(@io, upstream, flow_id, @sink) # frames until close (P6/P7)
         else
           Pump.blind_tunnel(@io, upstream) # non-WS upgrade: raw pipe until close
@@ -1002,6 +1036,25 @@ module Gori::Proxy
         H2::Relay.run(client, upstream, host, port, @sink)
       ensure
         upstream.close rescue nil
+      end
+    end
+
+    # A 101 whose `Sec-WebSocket-Extensions` acceptance answers an offer gori removed
+    # (#518). The accept is relayed UNTOUCHED — see `WS::Handshake` for why removing it
+    # is the worse half — so the two peers still agree and the socket works; what is
+    # wrong is gori's own store, because `WS::Relay` records the extension's encoded
+    # bytes as the message. Nothing else on the path can tell, so say it here.
+    #
+    # Reaching this means either an origin that accepted an extension it was not offered
+    # (a protocol violation, RFC 6455 §4.1) or an operator who put the offer back with a
+    # Match&Replace rule. The consequence for capture is the same in both cases.
+    private def warn_unoffered_ws_extension(resp : Codec::RawResponse, host : String, target : String) : Nil
+      accepted = resp.headers.get?("Sec-WebSocket-Extensions")
+      return if accepted.nil? || accepted.blank?
+      ::Log.warn do
+        "ws #{host}#{target}: origin accepted extension #{accepted.inspect} — captured frames on " \
+        "this socket are that extension's encoded bytes, not the messages (gori removes the " \
+        "client's Sec-WebSocket-Extensions offer; see #518)"
       end
     end
 

--- a/src/gori/proxy/ws/handshake.cr
+++ b/src/gori/proxy/ws/handshake.cr
@@ -1,0 +1,99 @@
+require "../codec/message"
+
+module Gori::Proxy::WS
+  # The one header gori removes from a WebSocket handshake it relays (#518).
+  #
+  # `WS::Relay` stores frame payloads verbatim and never decodes an extension, so a
+  # socket that negotiated `permessage-deflate` was captured as a deflate stream
+  # presented as the message: History, the detail view, `gori run history show`,
+  # MCP `get_flow`, the decoder and export all read those bytes as the payload.
+  # Removing the client's OFFER is what stops the negotiation, because extension
+  # negotiation is offer-driven (RFC 6455 §9.1): a conformant origin can only accept
+  # from what it was offered, so with nothing offered neither peer compresses and the
+  # captured frames are the messages.
+  #
+  # This is gori's first hop-by-hop removal on the WS path and it is DELIBERATE. It
+  # cannot be made lazy the way #512's h2 re-encode was: extension negotiation happens
+  # once, in the 101 handshake, with no renegotiation, so by the time a capture
+  # consumer exists the window has closed. The cost is stated plainly: a
+  # deflate-capable app loses compression through gori, and gori changes bytes on the
+  # wire while merely observing. The trade is that the status quo was not "byte-exact
+  # and correct", it was byte-exact on the wire and WRONG in the store; an operator who
+  # needs a compressed socket untouched has TLS passthrough, which leaves the host
+  # alone entirely.
+  #
+  # The WHOLE field goes, not just the `permessage-deflate` parameter. `Relay` is
+  # extension-blind by construction (it reads the RFC 6455 frame header and stores the
+  # payload), and ANY negotiated extension may transform that payload or give the RSV
+  # bits a meaning, so every one of them breaks capture the same way. Removing the field
+  # entire is also what `Repeater::WsEngine.build_handshake` already does.
+  #
+  # Only the client's offer is removed. The origin's ACCEPT is relayed untouched, see
+  # `Relay`/`ClientConn`: stripping an accept the origin believes in would leave it
+  # compressing into a client that saw no acceptance and must therefore fail the
+  # connection on the first RSV1 frame (RFC 6455 §5.2). That desync would be gori's own
+  # manufacture, and it is the strictly worse half of the same trade.
+  module Handshake
+    # The field-name gori removes, lower-cased for the byte compare.
+    EXTENSIONS_NAME = "sec-websocket-extensions"
+
+    # True when this head is a WebSocket upgrade that offers an extension: the only
+    # shape `strip_extensions` should touch. A `Sec-WebSocket-Extensions` on a request
+    # that is NOT upgrading is inert (the field is defined only for the handshake, RFC
+    # 6455 §11.3.2), so it is left byte-exact (P7) rather than rewritten for nothing.
+    #
+    # `Upgrade` is a comma-separated protocol list (RFC 7230 §6.7), so match the TOKEN
+    # rather than the whole field-value: `Upgrade: websocket, h2c` is still a WebSocket
+    # handshake. Both lookups are allocation-free on the miss, which is every non-WS
+    # request on the hot path.
+    def self.offers_extensions?(headers : Codec::HeaderList) : Bool
+      return false unless headers.has?(EXTENSIONS_NAME)
+      upgrade = headers.get?("Upgrade")
+      return false unless upgrade
+      upgrade.split(',').any? { |token| token.strip.compare("websocket", case_insensitive: true) == 0 }
+    end
+
+    # `head` with every `Sec-WebSocket-Extensions` line removed and every other byte
+    # copied verbatim (P7), including the start-line and the terminating CRLFCRLF.
+    # Header VALUE bytes are never round-tripped through String, so a non-UTF-8
+    # cookie/auth token on the handshake survives byte-exact (mirroring
+    # `Repeater::WsEngine.build_handshake`, which strips the same header from its own
+    # handshake and is the precedent this follows).
+    #
+    # Lines are split on the terminator only and the field-name is matched EXACTLY,
+    # the same view `Codec::Http1.parse_headers` takes. An obs-folded or
+    # `name<SP>:`-obfuscated variant that this scan would miss cannot reach an origin
+    # regardless: `Codec::Body.request_framing` rejects the whole request
+    # (`Http1.obfuscated_header?`) before it is forwarded.
+    def self.strip_extensions(head : Bytes) : Bytes
+      io = IO::Memory.new(head.size)
+      pos = 0
+      start_line = true
+      while pos < head.size
+        lf = head.index(0x0a_u8, pos)
+        stop = lf ? lf + 1 : head.size # the line INCLUDING its terminator
+        line = head[pos, stop - pos]
+        io.write(line) if start_line || !extensions_line?(line)
+        start_line = false
+        pos = stop
+      end
+      io.to_slice
+    end
+
+    # True when the header line's field-name is exactly `Sec-WebSocket-Extensions`
+    # (ASCII case-insensitive). A colon-less line (the blank line that ends the head,
+    # or a garbage line) never matches.
+    private def self.extensions_line?(line : Bytes) : Bool
+      colon = line.index(0x3a_u8) # ':'
+      return false unless colon
+      return false unless colon == EXTENSIONS_NAME.bytesize
+      name = EXTENSIONS_NAME.to_slice
+      colon.times do |i|
+        b = line.unsafe_fetch(i)
+        b |= 0x20_u8 if b >= 0x41_u8 && b <= 0x5a_u8 # ASCII 'A'..'Z' → lower
+        return false unless b == name.unsafe_fetch(i)
+      end
+      true
+    end
+  end
+end


### PR DESCRIPTION
Closes #518.

`WS::Relay.capture_frame` appends `frame.payload` verbatim and nothing on the path inflates it, but the proxy never touched `Sec-WebSocket-Extensions`, so `permessage-deflate` negotiated end to end and every captured frame on such a socket was a deflate stream stored as if it were the message. History, the detail view, `gori run history show`, MCP `get_flow`, the decoder and export all read those bytes as the payload.

**Implementing permessage-deflate is not in scope here** (per-direction inflate/re-deflate, RSV1, both `*_max_window_bits`); the issue records that as its own step.

## What changed

`ClientConn#strip_ws_extension_offer` removes `Sec-WebSocket-Extensions` from the handshake gori relays upstream, following `Repeater::WsEngine.build_handshake`, which already strips the same field from its own handshake. `WS::Handshake` holds the removal itself and the reasoning.

## Which side gets cut, and why

**The client's offer, not the origin's acceptance.** Extension negotiation is offer-driven (RFC 6455 §9.1): an origin can only accept from what it was offered, so with nothing offered a conformant origin sends no acceptance and neither peer compresses.

Removing the *acceptance* instead would be actively harmful. The origin would believe compression was negotiated and send RSV1 frames into a client that saw no acceptance and must therefore fail the connection (RFC 6455 §5.2). That desync would be gori's own manufacture, and it breaks a socket that otherwise worked. So the accept is relayed untouched.

The whole field goes, not just the `permessage-deflate` parameter. `Relay` is extension-blind by construction, and any negotiated extension may transform the payload or give the RSV bits a meaning, so all of them break capture the same way.

## The residue the strip cannot close

An origin that accepts an extension it was never offered (a protocol violation, RFC 6455 §4.1) still gets compression: both peers agree, the socket works, and only gori's store is wrong. Stripping the accept would have "fixed" that by breaking the connection, which is the worse trade. Instead gori logs a warning there, because nothing else on the path can tell:

```
WARN - ws 127.0.0.1/ws: origin accepted extension "permessage-deflate" — captured frames on this
socket are that extension's encoded bytes, not the messages (gori removes the client's
Sec-WebSocket-Extensions offer; see #518)
```

## Placement

- **Unconditional.** Extension negotiation happens once, in the 101 handshake, with no renegotiation, so this cannot be made lazy the way #512's h2 re-encode was.
- **Before Match&Replace**, so a rule or an intercept edit that puts the header back is honoured as the operator saying so explicitly.
- **Only on a WebSocket upgrade that carries an offer.** The field is defined only for the handshake (RFC 6455 §11.3.2), so on any other request it is inert and the head stays byte-exact.
- **The recorded request mirrors the strip**, so History shows the handshake gori actually sent. Recording an un-stripped offer beside a 101 with no acceptance would read as "the origin declined compression", which is a lie about the origin that no doc line can undo.
- Header **value** bytes are copied as bytes, never round-tripped through String, so a non-UTF-8 cookie or auth token on the handshake survives byte-exact.

## The cost, stated plainly

This is gori's first hop-by-hop removal on the WS path.

**A deflate-capable app loses compression while it goes through gori**, and **gori now changes bytes on the wire while merely observing** — which sits awkwardly beside the byte-exact discipline the h2 relay and `Rules#apply` keep.

The reason it is still the right call: the status quo was not "byte-exact and correct", it was byte-exact on the wire and **wrong in the store**. Preserving fidelity on the wire while destroying it in the store is the worse half. An operator who needs a compressed socket untouched has TLS passthrough (#507), which leaves the host alone entirely; the docs now say so.

## Docs

`docs/content/guide/proxy.md:94` and its `.ko.md` counterpart named a limitation ("no permessage-deflate") that read as "the repeater does not compress". They now say what is true: a WebSocket through gori is never compressed, that is what makes the capture accurate, and passthrough is the escape hatch if a host's sockets must be relayed as they are.

## Verification

Real client (`websockets` 17.0) offering `permessage-deflate` to a `wss://` origin through a built gori binary, sending `AAAA…-permessage-deflate-probe`.

**Control, before the fix** — negotiation succeeds and the capture holds the deflate stream:

```
[client] negotiated extensions: ['PerMessageDeflate(remote_max_window_bits=12, local_max_window_bits=12)']
[origin] negotiated extensions: ['PerMessageDeflate(...)']

=== WEBSOCKET MESSAGES (2) ===
→ rt$·..·.·..··'..ꦤ..$...··.'···
← ru...r$·..·.·..··'..ꦤ..$...··.'···

out|1|31|7274240EE816A416E5A6161727A6A7EAA6A4A6E52496A4EA1614E527A50200
in |1|35|7275F6F0B7722412E816A416E5A6161727A6A7EAA6A4A6E52496A4EA1614E527A50200
```

The recorded request carried `Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits` and the 101 carried `Sec-WebSocket-Extensions: permessage-deflate; server_max_window_bits=12; client_max_window_bits=12`.

**After the fix** — negotiation does not happen, the app still works, and the capture is the message:

```
[client] negotiated extensions: []
[origin] negotiated extensions: []
[client] reply: 'ECHO:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-permessage-deflate-probe'

=== WEBSOCKET MESSAGES (2) ===
→ AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-permessage-deflate-probe
← ECHO:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-permessage-deflate-probe
```

The recorded request and the 101 both carry no `Sec-WebSocket-Extensions`.

The unoffered-acceptance path was exercised separately against a deliberately non-conformant origin; it produced the warning quoted above.

**Suite:** `crystal spec` 5185 examples, 0 failures (main was 5172; 13 added). The new end-to-end test was control-run with the strip disabled and fails there, so it is not vacuous. `ameba` on the touched files reports exactly the pre-existing findings on `main` (`handle_request` 32/12, `handle_response` 18/12, one `MultilineCurlyBlock`); the new file is clean. `crystal build --no-codegen src/main.cr` passes after rebasing on `origin/main` (`f795222b`). `hwaro build` renders both doc pages.
