### PR TITLE
fix(h2): make the deferred-byte ceiling actually fail open

### DIFF
--- a/spec/proxy/h2/stream_gate_spec.cr
+++ b/spec/proxy/h2/stream_gate_spec.cr
@@ -89,6 +89,23 @@ private def request(path : String, authority : String = "api.example.com") : Arr
   [{":method", "GET"}, {":scheme", "https"}, {":authority", authority}, {":path", path}]
 end
 
+private def post(path : String, authority : String = "api.example.com") : Array({String, String})
+  [{":method", "POST"}, {":scheme", "https"}, {":authority", authority}, {":path", path}]
+end
+
+# A peer that ignores its flow-control window — the case `MAX_DEFERRED_BYTES` names as its
+# trigger. Sends `bytes` of DATA in 16 KiB frames without waiting for a WINDOW_UPDATE.
+private def blast(gate : Gate, stream : UInt32, bytes : Int32) : Nil
+  chunk = Bytes.new(16384, 0x41_u8)
+  ((bytes + 16383) // 16384).times do
+    gate.accept(Frame::Header.new(Frame::Type::Data.value, 0_u8, stream, chunk))
+  end
+end
+
+private def data_bytes(frames : Array(Frame::Header), stream : UInt32) : Int32
+  frames.select { |f| f.stream_id == stream && f.frame_type == Frame::Type::Data }.sum(&.payload.size)
+end
+
 private def response(status : String) : Array({String, String})
   [{":status", status}, {"content-type", "text/plain"}]
 end
@@ -575,6 +592,191 @@ describe Gori::Proxy::H2::StreamGate do
       truncated = Bytes[0xff_u8, 0xff_u8, 0xff_u8, 0xff_u8, 0xff_u8, 0xff_u8]
       rig.c2s.accept(headers(1_u32, truncated))
       rig.to_origin.map(&.stream_id).should eq([1_u32])
+    end
+  end
+
+  # ---- #516: the buffer ceiling actually fails OPEN ---------------------------
+  #
+  # `MAX_DEFERRED_BYTES` documents itself as the same disposition as toggle-off, `release_all`
+  # and the #123 reaper. It was not: it nulled the slot's item before forwarding, so the wait
+  # fiber's own `slot.item == item` guard rejected the release and the slot stayed in `@slots`
+  # unready forever — freezing every later stream open on the connection, while the log claimed
+  # the stream had been "forwarded unedited".
+
+  it "fails a held stream OPEN past the buffer ceiling instead of freezing the connection" do
+    with_ic do |ic|
+      ic.set_filter("path:/upload")
+      rig = Rig.new(ic)
+
+      rig.c2s.accept(headers(1_u32, rig.enc_out.encode(post("/upload")), Frame::END_HEADERS))
+      settle
+      ic.pending_count.should eq(1)
+      rig.to_origin.should be_empty
+
+      over = Gate::MAX_DEFERRED_BYTES + 16384
+      blast(rig.c2s, 1_u32, over)
+      settle
+
+      # The queue row is resolved AND the stream actually moved — the row dropping to 0 on its
+      # own is exactly the misleading signal the wedge produced.
+      ic.pending_count.should eq(0)
+      head_of(rig.to_origin, 1_u32).should eq(post("/upload")) # unedited, as the warning says
+      data_bytes(rig.to_origin, 1_u32).should eq(over)         # and every buffered byte followed it
+
+      # The connection is still usable: a LATER stream open still reaches the origin.
+      rig.c2s.accept(headers(3_u32, rig.enc_out.encode(request("/free"))))
+      settle
+      head_of(rig.to_origin, 3_u32).should eq(request("/free"))
+    end
+  end
+
+  it "does not strand an innocent stream queued behind the one that overflowed" do
+    with_ic do |ic|
+      ic.set_filter("path:/upload")
+      rig = Rig.new(ic)
+
+      rig.c2s.accept(headers(1_u32, rig.enc_out.encode(post("/upload")), Frame::END_HEADERS))
+      settle
+      # Stream 3 is innocent — the filter misses it — but §5.1.1 queues its open behind the hold.
+      rig.c2s.accept(headers(3_u32, rig.enc_out.encode(request("/free"))))
+      settle
+      rig.to_origin.should be_empty
+
+      blast(rig.c2s, 1_u32, Gate::MAX_DEFERRED_BYTES + 16384)
+      settle
+      rig.to_origin.map(&.stream_id).uniq!.should eq([1_u32, 3_u32])
+    end
+  end
+
+  it "fails open the stream deferred AHEAD of the one that overflowed, which alone can move it" do
+    with_ic do |ic|
+      ic.set_filter("path:/held")
+      rig = Rig.new(ic)
+
+      rig.c2s.accept(headers(1_u32, rig.enc_out.encode(request("/held"))))
+      settle
+      # Stream 3 is queued for ORDER only (no item of its own), so releasing it is not something
+      # its own hold can do — rule 1 pins it behind stream 1 however it is settled.
+      rig.c2s.accept(headers(3_u32, rig.enc_out.encode(post("/upload")), Frame::END_HEADERS))
+      settle
+      ic.pending_count.should eq(1)
+
+      blast(rig.c2s, 3_u32, Gate::MAX_DEFERRED_BYTES + 16384)
+      settle
+      ic.pending_count.should eq(0)
+      rig.to_origin.map(&.stream_id).uniq!.should eq([1_u32, 3_u32])
+    end
+  end
+
+  it "keeps an operator DROP that was already decided when the ceiling was crossed" do
+    with_ic do |ic|
+      ic.set_filter("path:/upload")
+      rig = Rig.new(ic)
+
+      rig.c2s.accept(headers(1_u32, rig.enc_out.encode(post("/upload")), Frame::END_HEADERS))
+      settle
+      # Decided, but its wait fiber has NOT run yet: the decision sits on the buffered channel
+      # while the flood crosses the ceiling on the pump fiber.
+      ic.drop(ic.pending.first.id)
+      blast(rig.c2s, 1_u32, Gate::MAX_DEFERRED_BYTES + 16384)
+      settle
+
+      # Fail-open must not overrule a decision already in flight — forwarding a request the
+      # operator dropped is the one outcome worse than holding it.
+      rig.to_origin.should be_empty
+      rig.to_client.map(&.frame_type).should eq([Frame::Type::RstStream])
+    end
+  end
+
+  it "fails a held RESPONSE open past the ceiling too" do
+    with_ic do |ic|
+      ic.set_direction(Gori::Interceptor::Direction::ResponseOnly)
+      rig = Rig.new(ic)
+
+      rig.c2s.accept(headers(1_u32, rig.enc_out.encode(request("/x")), Frame::END_HEADERS))
+      rig.s2c.accept(headers(1_u32, rig.enc_in.encode(response("200")), Frame::END_HEADERS))
+      settle
+      ic.pending_count.should eq(1)
+      rig.to_client.should be_empty
+
+      over = Gate::MAX_DEFERRED_BYTES + 16384
+      blast(rig.s2c, 1_u32, over)
+      settle
+      ic.pending_count.should eq(0)
+      head_of(rig.to_client, 1_u32).should eq(response("200"))
+      data_bytes(rig.to_client, 1_u32).should eq(over)
+    end
+  end
+
+  it "parks a multi-frame header block whole, so the ceiling cannot drop its CONTINUATIONs" do
+    with_ic do |ic|
+      ic.set_direction(Gori::Interceptor::Direction::ResponseOnly)
+      rig = Rig.new(ic)
+      rig.c2s.accept(headers(1_u32, rig.enc_out.encode(request("/x")), Frame::END_HEADERS))
+      rig.s2c.accept(headers(1_u32, rig.enc_in.encode(response("200")), Frame::END_HEADERS))
+      settle
+      ic.pending_count.should eq(1)
+
+      blast(rig.s2c, 1_u32, Gate::MAX_DEFERRED_BYTES) # right up to the ceiling, not over it
+      ic.pending_count.should eq(1)
+
+      # Trailers too big for one frame: the latch re-encodes them and `reframe` splits the
+      # result at SETTINGS_MAX_FRAME_SIZE, so `park_block` hands over HEADERS + CONTINUATION and
+      # the FIRST of the two is what crosses the ceiling. Releasing on it would write that frame
+      # and append the rest to a slot already gone from `@slots`.
+      fields = [{"x-trailer", "T" * 20_000}]
+      rig.s2c.accept(headers(1_u32, rig.enc_in.encode(fields), Frame::END_HEADERS | Frame::END_STREAM))
+      settle
+
+      ic.pending_count.should eq(0)
+      sent = rig.to_client.select { |f| f.stream_id == 1_u32 }
+      data_bytes(sent, 1_u32).should eq(Gate::MAX_DEFERRED_BYTES)
+
+      conts = sent.select { |f| f.frame_type == Frame::Type::Continuation }
+      conts.should_not be_empty # the block really did need more than one frame
+      block = IO::Memory.new
+      block.write(sent.reverse_each.find { |f| f.frame_type == Frame::Type::Headers }.not_nil!.payload)
+      conts.each { |f| block.write(f.payload) }
+      HPACK::Decoder.new.decode(block.to_slice).should eq(fields)
+    end
+  end
+
+  # ---- the sibling fail-open paths --------------------------------------------
+  #
+  # Every one of these releases a held item by putting a Decision on `Item#reply` and letting
+  # the gate's own wait fiber settle the slot, which is why none of them shared #516's defect —
+  # `fail_open` was the one that tried to settle by hand. The #123 reaper is literally
+  # `ic.forward(it.id)` (`runner.cr:689`), covered by the release above.
+
+  it "releases every held h2 stream when intercept is toggled OFF" do
+    with_ic do |ic|
+      ic.set_filter("path:/held")
+      rig = Rig.new(ic)
+      rig.c2s.accept(headers(1_u32, rig.enc_out.encode(request("/held"))))
+      settle
+      rig.c2s.accept(headers(3_u32, rig.enc_out.encode(request("/free"))))
+      settle
+      rig.to_origin.should be_empty
+
+      ic.toggle # OFF auto-forwards everything held, so traffic never wedges
+      settle
+      rig.to_origin.map(&.stream_id).should eq([1_u32, 3_u32])
+    end
+  end
+
+  it "releases every held h2 stream on release_all (session shutdown)" do
+    with_ic do |ic|
+      ic.set_filter("path:/held")
+      rig = Rig.new(ic)
+      rig.c2s.accept(headers(1_u32, rig.enc_out.encode(request("/held"))))
+      settle
+      rig.c2s.accept(headers(3_u32, rig.enc_out.encode(request("/free"))))
+      settle
+
+      ic.release_all
+      settle
+      rig.to_origin.map(&.stream_id).should eq([1_u32, 3_u32])
+      ic.pending_count.should eq(0)
     end
   end
 

--- a/src/gori/proxy/h2/stream_gate.cr
+++ b/src/gori/proxy/h2/stream_gate.cr
@@ -155,8 +155,9 @@ module Gori::Proxy::H2
       # error there (RFC 9113 §5.1 — anything but HEADERS/PRIORITY on an idle stream). Bounded,
       # and the bound ends the connection rather than the guarantee (`MAX_REFUSED_STREAMS`).
       @refused = Set(UInt32).new
-      # Cross-direction work produced by `defer?`, which cannot return it: its Bool is the
-      # `Deferrer` contract. Drained by `accept_locked`, its only caller — `defer?` runs
+      # Cross-direction work produced by the two locked paths that cannot return it: `defer?`,
+      # whose Bool is the `Deferrer` contract, and `fail_open`, which is reached from `park` on
+      # the frame path. Drained by `accept_locked`, which both run under — `defer?` runs
       # synchronously inside `@heads.accept`, under the same already-held `@mutex`. The lock
       # invariant is intact: this is still "hand the peer's work back as data", not "touch
       # `@peer` under the lock".
@@ -266,6 +267,7 @@ module Gori::Proxy::H2
           cross = cross + abandon_locked(slot, f)
         else
           park(slot, f, pre)
+          check_ceiling(slot)
         end
       end
       take_deferred_cross(cross)
@@ -296,34 +298,94 @@ module Gori::Proxy::H2
       drain_locked
     end
 
+    # Buffer one frame behind a deferred head. The ceiling is `check_ceiling`'s, deliberately
+    # separate: `fail_open` writes the slot out and takes it out of `@slots`, so anything parked
+    # into it afterwards would never be written at all. One arrival is therefore parked WHOLE
+    # and measured once — `park_block` hands over a multi-frame header block, and releasing
+    # halfway through one would silently drop its remaining CONTINUATIONs.
     private def park(slot : Slot, frame : Frame::Header, pre : Assembler::HeadBlock?) : Nil
       slot.frames << {frame, pre}
       slot.bytes += frame.payload.size
-      fail_open(slot) if slot.bytes > MAX_DEFERRED_BYTES
     end
 
     private def park_block(slot : Slot, block : HeadRewrite::Block) : Nil
       last = block.frames.size - 1
       block.frames.each_with_index { |f, i| park(slot, f, i == last ? block.pre : nil) }
+      check_ceiling(slot)
     end
 
-    # Past the buffer ceiling. Release the hold everything is waiting on with the ORIGINAL head
-    # (fail open), not this slot's — in the request direction a slot may be queued behind an
-    # earlier one and releasing it alone would move nothing.
+    private def check_ceiling(slot : Slot) : Nil
+      fail_open(slot) if slot.bytes > MAX_DEFERRED_BYTES
+    end
+
+    # Past the buffer ceiling. The hold FAILS OPEN: the head goes out as it arrived, the parked
+    # frames follow it, and the queue row is resolved — the disposition `MAX_DEFERRED_BYTES`
+    # documents, and the same one toggle-off, `release_all` and the #123 reaper have.
+    #
+    # Two things this must not do, both of which it did before #516:
+    #
+    #   1. **Null `item` and stop.** `Interceptor#forward` only puts a Decision on the item's
+    #      channel; the RELEASE is `resolve_locked`'s, on the wait fiber, and its first act is
+    #      `slot.item == item`. Clearing the item first made that guard reject the decision, so
+    #      the slot stayed in `@slots` with `ready? == false` and — in the request direction —
+    #      its id stayed at the head of `@opens`, freezing every LATER stream open for the life
+    #      of the connection. That is the "a held stream freezes the connection" failure this
+    #      whole file exists to avoid, reached through the one exit that claimed to avoid it.
+    #      So the settle happens HERE, under the lock, and `forward` is only how the queue row
+    #      and the wait fiber are disposed of.
+    #   2. **Release the overflowing slot alone.** Rule 1 pins releases to `@opens` order, so a
+    #      slot with a deferred open still ahead of it moves nothing however it is settled.
+    #      Every slot from the head of the queue up to this one fails open together, which is
+    #      also the only thing that makes the warning below true.
     private def fail_open(slot : Slot) : Nil
-      target = slot.item ? slot : @slots.values.find(&.item)
-      return unless target
+      targets = blocking_slots(slot)
+      return if targets.empty?
+      warn_overflow(slot, targets.size - 1)
+      targets.each { |target| fail_one_open(target) }
+      @deferred_cross.concat(drain_locked)
+    end
+
+    # Make one slot releasable, with the head as it arrived: `decided` is deliberately left
+    # alone, so `release_locked` writes `pending`. A slot the operator already decided keeps
+    # that decision — this only makes it movable.
+    private def fail_one_open(target : Slot) : Nil
       item = target.item
+      # A decision is already on this item's channel (the operator acted, and its wait fiber has
+      # not been scheduled yet). That fiber owns the settle and will run it in a moment; failing
+      # the slot open here would DISCARD the decision, and forwarding a request the operator
+      # dropped is the one outcome worse than holding it.
+      return if item && @interceptor.get(item.id).nil?
+      target.ready = true
       return unless item
       target.item = nil
-      unless @warned_overflow
-        @warned_overflow = true
-        ::Log.warn do
-          "h2 #{@direction}: held stream #{target.stream_id} buffered over " \
-          "#{MAX_DEFERRED_BYTES} bytes — forwarded it unedited"
-        end
-      end
       @interceptor.forward(item.id)
+    end
+
+    # Every slot that has to move for `slot` to be released, in release order. In the request
+    # direction rule 1 makes that the run of deferred opens from the head of `@opens` up to and
+    # including this one. In the response direction nothing opens streams, so a slot releases on
+    # its own.
+    private def blocking_slots(slot : Slot) : Array(Slot)
+      return [slot] unless @ordered && @opens.includes?(slot.stream_id)
+      ahead = [] of Slot
+      @opens.each do |id|
+        @slots[id]?.try { |s| ahead << s }
+        break if id == slot.stream_id
+      end
+      ahead
+    end
+
+    # Once per direction per connection. It says what actually happens next, which is the other
+    # half of #516: the old text claimed "forwarded it unedited" on a path that forwarded
+    # nothing at all and left the connection dead.
+    private def warn_overflow(slot : Slot, ahead : Int32) : Nil
+      return if @warned_overflow
+      @warned_overflow = true
+      ::Log.warn do
+        also = ahead > 0 ? " (releasing #{ahead} stream(s) deferred ahead of it too)" : ""
+        "h2 #{@direction}: held stream #{slot.stream_id} buffered over #{MAX_DEFERRED_BYTES} " \
+        "bytes — forwarding it unedited#{also}"
+      end
     end
 
     # --- sandbox side --------------------------------------------------------


### PR DESCRIPTION
`StreamGate`'s `MAX_DEFERRED_BYTES` handler documented itself as failing **open** — "the same disposition as toggle-off, `release_all` and the #123 reaper" — and did the opposite: past the ceiling the held stream was neither forwarded nor released, and every later stream open on that connection froze for the life of the connection. gori logged `forwarded it unedited` while nothing had gone anywhere.

## Root cause

`Interceptor#forward` only puts a Decision on the item's channel. The **release** is `resolve_locked`'s, on the wait fiber, and its first act is `slot.item == item`. `fail_open` nulled the item first, so that guard rejected the decision: the slot stayed in `@slots` with `ready? == false`, its id stayed at the head of `@opens`, and `drain_locked`'s `while @opens.first? ... && slot.ready?` loop never fired again — for that stream or any later one. The queue row was already deleted, so it read as resolved while the wire was dead.

## The fix

The settle happens under the lock; `forward` is now only how the queue row and the wait fiber are disposed of.

- The slot is marked ready with `decided`/`dropped?` **untouched**, so `release_locked` writes the head exactly as it arrived and an already-decided slot keeps its decision. Cross-direction work goes back through `@deferred_cross`, the channel `defer?` already uses for the same reason.
- **A slot whose Decision is already on its channel is skipped.** Its wait fiber owns the settle; failing it open here would discard that decision, and forwarding a request the operator *dropped* is the one outcome worse than holding it. (This was broken before too — see the spec below.)
- **Every slot from the head of `@opens` up to the overflowing one fails open together.** Rule 1 pins releases to that order, so releasing the overflowing slot alone moves nothing — which is also what would have kept the warning false. The old `@slots.values.find(&.item)` reached for this but only handled one hold ahead.
- The warning says what actually happens next.

The ceiling test also moves out of `park` into `check_ceiling`, called **once per arrival** rather than once per frame. `park_block` hands over a re-encoded header block that `reframe` may have split at `SETTINGS_MAX_FRAME_SIZE`; releasing on its first frame wrote that frame and appended the remaining CONTINUATIONs to a slot already gone from `@slots`, dropping them silently. Verified as a real regression, not a hypothetical — with the naive in-`park` check the new spec fails:

```
1) parks a multi-frame header block whole, so the ceiling cannot drop its CONTINUATIONs
   Failure/Error: conts.should_not be_empty # the block really did need more than one frame
     Expected: [] not to be empty
```

## Sibling fail-open paths — checked, all of them

| path | verdict |
|---|---|
| toggle-off (`interceptor.cr:146`) | **sound.** Sends `Decision(Forward, raw)` on `Item#reply`; `resolve_locked` does the settle. Now has an h2 spec (there was none). |
| `release_all` (session shutdown) | **sound**, same shape. Now has an h2 spec. |
| `forward_all` (TUI batch) | **sound**, same shape. |
| #123 reaper (`runner.cr:689`) | **sound.** It is literally `ic.forward(it.id)` — the ordinary operator forward, already covered. |
| #515 sandbox refusal | **sound, and not a sibling.** It fails CLOSED and never creates a `Slot`, so there is nothing to strand. |
| `close` (teardown) | **sound.** Clears `@slots`/`@opens` *before* forwarding; `resolve_locked` then finds `@closed`. |
| `abandon_locked` (peer RST) | **sound.** `remove(slot)` + `drain_locked` before the wait fiber runs. |

They share one property `fail_open` lacked: they deliver a Decision and let `resolve_locked` own the settle. The resulting invariant — *no slot stays in `@slots` with no item and `ready? == false`* — now holds on every path (the three `slot.item = nil` sites are `abandon_locked`, `resolve_locked` and `fail_one_open`, each followed by a settle).

## Live verification — real proxy stack, control run

Real `Proxy::Server` + `Tls::Tunnel` + `H2::Relay` + `Interceptor`, a real h2 origin (TLS/ALPN h2), and a raw h2 client that **ignores flow control**. One h2 connection multiplexes `POST /upload` (stream 1, body blasted without waiting for `WINDOW_UPDATE`) and `GET /free` (stream 3, innocent). Intercept on, filtered `path:/upload`; an operator fiber forwards any item held 500 ms. The only variable between the two runs is how many bytes are blasted.

**Before — 512 KiB, under the ceiling (control):**
```
[flood] blasted 524288 bytes on stream 1 (ignored flow control)
[operator] forwarding held #1 POST /upload (held 0.6s)
[origin] <- stream 1 HEADERS /upload
[origin] <- stream 3 HEADERS /free
---- RESULT ----
stream 1 (/upload): HEADERS status=200
stream 3 (/free):   HEADERS status=200
origin saw: stream 1 /upload, stream 3 /free
```

**Before — 1536 KiB, over the ceiling (same binary, same origin):**
```
[flood] after HEADERS(1): intercept queue = 1
WARN - h2 out: held stream 1 buffered over 1048576 bytes — forwarded it unedited
---- RESULT ----
stream 1 (/upload): NO RESPONSE (stream wedged / never served)
stream 3 (/free):   NO RESPONSE (stream wedged / never served)
origin saw: nothing
```
The warning claims the forward; the origin saw nothing, and the innocent `/free` died with it.

**After — 1536 KiB, over the ceiling:**
```
[flood] after HEADERS(1): intercept queue = 1
WARN - h2 out: held stream 1 buffered over 1048576 bytes — forwarding it unedited
[origin] <- stream 1 HEADERS /upload
[origin] -> stream 1 200
[origin] <- stream 3 HEADERS /free
[origin] -> stream 3 200
---- RESULT ----
stream 1 (/upload): HEADERS status=200
stream 3 (/free):   HEADERS status=200
origin saw: stream 1 /upload, stream 3 /free
```
The stream is forwarded unedited, the connection stays usable, and the log matches what happened.

The sibling paths were driven through the same live stack (`toggle` / `release_all` instead of the operator forward) — both released the held stream and both requests reached the origin.

## Specs

Eight new examples in `spec/proxy/h2/stream_gate_spec.cr`, which had **no** case touching `MAX_DEFERRED_BYTES` at all. All five overflow cases fail on `f795222b`:

```
1) fails a held stream OPEN past the buffer ceiling instead of freezing the connection
   head_of(rig.to_origin, 1_u32).should eq(post("/upload"))   Expected: [...] got: nil
2) does not strand an innocent stream queued behind the one that overflowed
   Expected: [1, 3]  got: []
3) fails open the stream deferred AHEAD of the one that overflowed, which alone can move it
   Expected: [1, 3]  got: []
4) keeps an operator DROP that was already decided when the ceiling was crossed
   Expected: [RstStream]  got: []
5) fails a held RESPONSE open past the ceiling too
   Expected: [{":status", "200"}, ...]  got: nil
```

The two sibling specs (toggle-off, `release_all`) pass on `f795222b` as well as after, which is the point — they document the shape `fail_open` should have had.

## Verification

- `crystal spec` — 5180 examples, 0 failures (main's 5172 + 8).
- `./bin/ameba src/gori/proxy/h2/stream_gate.cr spec/proxy/h2/stream_gate_spec.cr` — the source file is clean; the one spec finding is pre-existing (`Rig#drain`, line 70, untouched).
- `crystal build --no-codegen src/main.cr` on `origin/main` (`f795222b`) — clean, no rebase needed.
- `crystal tool format` on the two touched files only.

Closes #516
