### PR TITLE
fix(env): refuse an unresolved $NAME at plan-build instead of sending it verbatim

### DIFF
--- a/docs/content/guide/repeater-and-fuzzer.ko.md
+++ b/docs/content/guide/repeater-and-fuzzer.ko.md
@@ -42,7 +42,9 @@ gori run repeater <flow-id> --target https://staging.example.com --diff
 | **Global** | Preferences(`Ctrl-,`) → **Editor & Keys** → **Env**, `Ctrl-P` → **Settings: Env**, 또는 `settings.json`의 `env` 섹션 |
 | **Project** | **Project** 탭 → **ENV** 패널 (`a` 추가, `e` 편집, `d` 삭제) |
 
-기본 접두사는 `$`입니다(ENV space 메뉴의 **Change prefix**나 설정의 `env.prefix`로 변경 가능). 키는 `A-Z a-z _`로 시작해 `A-Z a-z 0-9 _`가 이어집니다. 알 수 없는 토큰은 그대로 둡니다.
+기본 접두사는 `$`입니다(ENV space 메뉴의 **Change prefix**나 설정의 `env.prefix`로 변경 가능). 키는 `A-Z a-z _`로 시작해 `A-Z a-z 0-9 _`가 이어집니다.
+
+알 수 없는 토큰은 요청이 *표시*되는 곳에서는 리터럴 텍스트로 그대로 남습니다. 에디터는 입력한 그대로를 유지하고, 하이라이터가 미등록 토큰을 등록된 토큰과 다르게 칠합니다. 다만 전송되지는 않습니다. Repeater, Fuzzer, Miner, Sequencer, Discover는 요청 라인, 헤더, 타깃에 아무것으로도 해석되지 않는 변수가 남아 있으면 그 이름을 대며 실행을 거부합니다. 변수를 설정하거나 토큰을 지우세요. 검사 범위는 요청 head뿐입니다. 바디 안의 `$`는 바이트로 취급하므로 바이너리 업로드는 그대로 재전송됩니다.
 
 ```http
 GET /api/me HTTP/1.1

--- a/docs/content/guide/repeater-and-fuzzer.md
+++ b/docs/content/guide/repeater-and-fuzzer.md
@@ -42,7 +42,9 @@ Define variables in two places (project wins on a key collision):
 | **Global** | Preferences (`Ctrl-,`) → **Editor & Keys** → **Env**, `Ctrl-P` → **Settings: Env**, or the `env` section of `settings.json` |
 | **Project** | **Project** tab → **ENV** pane (`a` add, `e` edit, `d` delete) |
 
-Default prefix is `$` (changeable via **Change prefix** in the ENV space menu, or `env.prefix` in settings). Keys are `A-Z a-z _` followed by `A-Z a-z 0-9 _`. Unknown tokens are left unchanged.
+Default prefix is `$` (changeable via **Change prefix** in the ENV space menu, or `env.prefix` in settings). Keys are `A-Z a-z _` followed by `A-Z a-z 0-9 _`.
+
+An unknown token stays visible as literal text wherever a request is *shown*. The editor keeps what you typed, and the highlighter marks an unregistered token differently from a registered one. It is not sent, though: Repeater, the Fuzzer, the Miner, the Sequencer and Discover each refuse a run whose request line, headers or target still name a variable that resolves to nothing, and say which one. Set it, or drop the token. The check covers the request head only. A `$` inside a body is treated as a byte, so binary uploads replay unchanged.
 
 ```http
 GET /api/me HTTP/1.1

--- a/spec/env_unresolved_spec.cr
+++ b/spec/env_unresolved_spec.cr
@@ -1,0 +1,253 @@
+require "./spec_helper"
+
+# Issue #519: an env token whose variable is not set used to be left on the wire
+# verbatim — a request went out carrying the seven characters `$SESSION` as a header
+# value, the origin answered 401, and nothing distinguished "the variable is unset"
+# from "the target rejects this token".
+#
+# The fix is a refusal at plan-build time on every surface that SENDS, and no change at
+# all to `Env.expand`, whose literal-passthrough is correct on a display path. So this
+# file asserts both halves: the query API and the five builders that use it, plus the
+# display behaviour that had to stay put.
+
+private def ungated : Gori::Outbound
+  Gori::Outbound.waived(nil, Gori::Outbound::Reason::NoProject)
+end
+
+private def with_vars(vars : Array({String, String}), &)
+  Gori::Settings.env_prefix = "$"
+  Gori::Settings.env_vars = vars
+  Gori::Settings.project_env_vars = [] of {String, String}
+  yield
+ensure
+  Gori::Settings.env_vars = [] of {String, String}
+  Gori::Settings.project_env_vars = [] of {String, String}
+  Gori::Settings.env_prefix = "$"
+end
+
+describe Gori::Env do
+  describe ".unresolved" do
+    it "names only the tokens expand would leave literal, in first-appearance order" do
+      with_vars([{"HOST", "api.test"}]) do
+        Gori::Env.unresolved("$HOST/$B?x=$A&y=$B").should eq(["B", "A"])
+      end
+    end
+
+    it "returns nothing when every token resolves, and nothing when there is no token" do
+      with_vars([{"HOST", "api.test"}]) do
+        Gori::Env.unresolved("https://$HOST/a").should be_empty
+        Gori::Env.unresolved("https://api.test/a").should be_empty
+        # `${...}` and `$(...)` are not tokens at all: KEY_HEAD is [A-Za-z_], so the
+        # shell/template payloads that use them are untouched by this check.
+        Gori::Env.unresolved("${7*7} $(id)").should be_empty
+      end
+    end
+
+    it "agrees with expand: every name it reports is one expand left in the output" do
+      with_vars([{"HOST", "api.test"}]) do
+        text = "$HOST $MISSING $$ESCAPED"
+        expanded = Gori::Env.expand(text)
+        Gori::Env.unresolved(text).each do |name|
+          expanded.should contain("$#{name}")
+        end
+        # ...and the converse for the resolved one: it is gone.
+        expanded.should_not contain("$HOST")
+      end
+    end
+
+    it "is byte-safe on invalid UTF-8, where the char-based token_regions is not" do
+      with_vars([] of {String, String}) do
+        # 0x80 is a lone continuation byte — a captured flow's binary body routinely
+        # carries such bytes, and `String#chars` decodes them lossily to U+FFFD.
+        text = String.new(Bytes[0x24, 0x41, 0x80, 0x24, 0x42])
+        Gori::Env.unresolved(text).should eq(["A", "B"])
+      end
+    end
+  end
+
+  describe ".unresolved_wire" do
+    it "checks the head and never the body" do
+      with_vars([] of {String, String}) do
+        wire = "POST /p HTTP/1.1\r\nX-A: $HEADTOKEN\r\n\r\n{\"q\":\"$BODYTOKEN\"}"
+        Gori::Env.unresolved_wire(wire).should eq(["HEADTOKEN"])
+        # The whole-text form still sees both — the narrowing is `_wire`'s alone.
+        Gori::Env.unresolved(wire).should eq(["HEADTOKEN", "BODYTOKEN"])
+      end
+    end
+
+    it "does not refuse a request whose BODY is binary" do
+      with_vars([] of {String, String}) do
+        # The concrete reason the check is head-only: `$` followed by [A-Za-z_] occurs by
+        # chance about once per 1.2KB of high-entropy bytes, so a whole-request check
+        # would refuse essentially every replay of a compressed or encrypted upload.
+        # Modelled here as binary filler carrying a few such byte pairs outright, so the
+        # test states the case rather than relying on a lucky sample.
+        body = Bytes.new(4096) { |i| (i * 31 + 7).to_u8! }
+        body[100] = 0x24_u8 # '$'
+        body[101] = 0x41_u8 # 'A'
+        body[900] = 0x24_u8
+        body[901] = 0x5F_u8 # '_'
+        wire = String.new("POST /u HTTP/1.1\r\nHost: t.test\r\n\r\n".to_slice + body)
+        Gori::Env.unresolved(wire).should_not be_empty # the body alone trips the naive check
+        Gori::Env.unresolved_wire(wire).should be_empty
+      end
+    end
+
+    it "treats a head-only buffer (no blank line) as all head" do
+      with_vars([] of {String, String}) do
+        Gori::Env.unresolved_wire("GET /$MISSING HTTP/1.1\r\nHost: t.test").should eq(["MISSING"])
+      end
+    end
+  end
+
+  it ".token_list renders names back into the spelling the operator typed" do
+    with_vars([] of {String, String}) do
+      Gori::Env.token_list(["A", "B"]).should eq("$A, $B")
+    end
+  end
+
+  # The half of #519 that had to NOT change: a display path keeps showing the literal
+  # token, and `token_regions` keeps marking it unknown for the highlighter.
+  describe "display paths are unchanged" do
+    it "expand still leaves an unregistered token literal" do
+      with_vars([{"HOST", "api.test"}]) do
+        Gori::Env.expand("GET http://$HOST/p\nAuth: $MISSING").should eq(
+          "GET http://api.test/p\nAuth: $MISSING")
+      end
+    end
+
+    it "token_regions still reports the unknown token rather than raising" do
+      with_vars([{"HOST", "h"}]) do
+        Gori::Env.token_regions("http://$HOST/$OTHER").should eq([{7, 12, true}, {13, 19, false}])
+      end
+    end
+  end
+end
+
+# The point of the issue: it is not enough for ONE builder to refuse. All five expand at
+# plan-build time and all five send, so all five are asserted here together — a builder
+# that loses the check fails this block rather than quietly shipping the token.
+describe "plan builders refuse an unresolved env token (#519)" do
+  it "Fuzz::Plan.build refuses and names the token" do
+    with_vars([] of {String, String}) do
+      options = Gori::Fuzz::PlanOptions.new(
+        "GET /a?q=§x§ HTTP/1.1\r\nHost: t.test\r\nAuth: Bearer $SESSION\r\n\r\n",
+        target: "http://t.test",
+        sources: [Gori::Fuzz::InlineList.new(["p"])] of Gori::Fuzz::PayloadSource)
+      ex = expect_raises(Gori::Fuzz::PlanError) { Gori::Fuzz::Plan.build(options, ungated) }
+      ex.reason.should eq(Gori::Fuzz::PlanError::Reason::UnresolvedEnv)
+      ex.detail.should eq("$SESSION")
+    end
+  end
+
+  it "Miner::Plan.build refuses and names the token" do
+    with_vars([] of {String, String}) do
+      options = Gori::Miner::PlanOptions.new(
+        "GET /a HTTP/1.1\r\nHost: t.test\r\nCookie: s=$SESSION\r\n\r\n",
+        target: "http://t.test")
+      ex = expect_raises(Gori::Miner::PlanError) { Gori::Miner::Plan.build(options, ungated) }
+      ex.reason.should eq(Gori::Miner::PlanError::Reason::UnresolvedEnv)
+      ex.detail.should eq("$SESSION")
+    end
+  end
+
+  it "Sequencer::Plan.build refuses and names the token" do
+    with_vars([] of {String, String}) do
+      loc = Gori::Sequencer::TokenLoc.new(kind: Gori::Sequencer::ExtractKind::Cookie, selector: "sid")
+      config = Gori::Sequencer::Config.new(mode: Gori::Sequencer::Mode::LiveReplay, token_loc: loc, goal: 10)
+      options = Gori::Sequencer::PlanOptions.new(
+        "GET /a HTTP/1.1\r\nHost: t.test\r\nAuth: $SESSION\r\n\r\n".to_slice,
+        target: "http://t.test", config: config)
+      ex = expect_raises(Gori::Sequencer::PlanError) { Gori::Sequencer::Plan.build(options, ungated) }
+      ex.reason.should eq(Gori::Sequencer::PlanError::Reason::UnresolvedEnv)
+      ex.detail.should eq("$SESSION")
+    end
+  end
+
+  it "Discover::Plan.build refuses an unresolved SEED and names the token" do
+    with_vars([] of {String, String}) do
+      options = Gori::Discover::PlanOptions.new("$SEED/api")
+      ex = expect_raises(Gori::Discover::PlanError) { Gori::Discover::Plan.build(options, ungated) }
+      ex.reason.should eq(Gori::Discover::PlanError::Reason::UnresolvedEnv)
+      ex.detail.should eq("$SEED")
+    end
+  end
+
+  # Discover expands TWICE inside its builder — the seed and the custom header values —
+  # and the header call is the one a "check the target" fix would miss. An unresolved
+  # token there rides every probe the crawl sends.
+  it "Discover::Plan.build refuses an unresolved custom HEADER and names the token" do
+    with_vars([] of {String, String}) do
+      config = Gori::Discover::Config.new
+      config.headers = [{"Authorization", "Bearer $SESSION"}]
+      options = Gori::Discover::PlanOptions.new("https://t.test/", config: config)
+      ex = expect_raises(Gori::Discover::PlanError) { Gori::Discover::Plan.build(options, ungated) }
+      ex.reason.should eq(Gori::Discover::PlanError::Reason::UnresolvedEnv)
+      ex.detail.should eq("$SESSION")
+    end
+  end
+
+  it "Repeater::Plan.build refuses and names the token" do
+    with_vars([] of {String, String}) do
+      options = Gori::Repeater::PlanOptions.new(
+        ["GET /a HTTP/1.1\r\nHost: t.test\r\nAuth: Bearer $SESSION\r\n\r\n".to_slice],
+        target: "http://t.test")
+      ex = expect_raises(Gori::Repeater::PlanError) { Gori::Repeater::Plan.build(options, ungated) }
+      ex.reason.should eq(Gori::Repeater::PlanError::Reason::UnresolvedEnv)
+      ex.detail.should eq("$SESSION")
+    end
+  end
+
+  # `expand_request: false` means the SURFACE already expanded (MCP's RequestBuilder, the
+  # TUI editor's byte modes). The token is then already sitting in the bytes handed over,
+  # so the builder must still refuse — this is the path a check guarded by
+  # `if options.expand_request?` would let straight through.
+  it "Repeater::Plan.build refuses pre-expanded bytes too (expand_request: false)" do
+    with_vars([] of {String, String}) do
+      options = Gori::Repeater::PlanOptions.new(
+        ["GET /a HTTP/1.1\r\nHost: t.test\r\nAuth: Bearer $SESSION\r\n\r\n".to_slice],
+        expand_request: false, target: "http://t.test")
+      ex = expect_raises(Gori::Repeater::PlanError) { Gori::Repeater::Plan.build(options, ungated) }
+      ex.reason.should eq(Gori::Repeater::PlanError::Reason::UnresolvedEnv)
+    end
+  end
+
+  it "Repeater::Plan.build refuses an unresolved TARGET and an unresolved SNI" do
+    with_vars([] of {String, String}) do
+      wire = ["GET /a HTTP/1.1\r\nHost: t.test\r\n\r\n".to_slice]
+      bad_target = Gori::Repeater::PlanOptions.new(wire, target: "http://$HOST")
+      expect_raises(Gori::Repeater::PlanError) { Gori::Repeater::Plan.build(bad_target, ungated) }
+        .detail.should eq("$HOST")
+
+      bad_sni = Gori::Repeater::PlanOptions.new(wire, target: "https://t.test", sni: "$SNI_HOST")
+      expect_raises(Gori::Repeater::PlanError) { Gori::Repeater::Plan.build(bad_sni, ungated) }
+        .detail.should eq("$SNI_HOST")
+    end
+  end
+
+  # The control the refusals are worth nothing without: with the variable SET, every
+  # builder proceeds and the value — not the token — is what the plan carries.
+  it "builds normally once the variable is set, substituting the value" do
+    with_vars([{"SESSION", "s3cr3t"}, {"HOST", "t.test"}]) do
+      plan = Gori::Repeater::Plan.build(Gori::Repeater::PlanOptions.new(
+        ["GET /a HTTP/1.1\r\nHost: $HOST\r\nAuth: Bearer $SESSION\r\n\r\n".to_slice],
+        target: "http://$HOST"), ungated)
+      plan.host.should eq("t.test")
+      wire = String.new(plan.bytes)
+      wire.should contain("Auth: Bearer s3cr3t")
+      wire.should_not contain("$SESSION")
+    end
+  end
+
+  # A body token is deliberately NOT a refusal (see `Env.unresolved_wire`): the body is
+  # where a `$` is a byte rather than a reference, and refusing there would block every
+  # binary upload replay. Pinned so the narrowing is a stated decision, not an accident.
+  it "does not refuse a token in the BODY" do
+    with_vars([] of {String, String}) do
+      plan = Gori::Repeater::Plan.build(Gori::Repeater::PlanOptions.new(
+        ["POST /a HTTP/1.1\r\nHost: t.test\r\n\r\n{\"q\":\"$NOTATOKEN\"}".to_slice],
+        target: "http://t.test"), ungated)
+      String.new(plan.bytes).should contain("$NOTATOKEN")
+    end
+  end
+end

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -356,6 +356,19 @@ module Gori
         abort "#{cmd}: #{host} is out of the project scope — add a scope include rule or pass --allow-unscoped"
       end
 
+      # One sentence for every `gori run` tool whose builder refused an env token that
+      # resolves to nothing (#519). Shared rather than written per command because, unlike
+      # the other plan reasons, this one names no flag of the command's own — the token is
+      # the whole fact and the remedy is the same everywhere. `detail` is the builder's
+      # prefixed, comma-joined token list (`$SESSION, $TOKEN`).
+      # `where` names the thing that carried the token (e.g. " for session #3") and belongs
+      # on the FACT, not after the remedy — "...or remove the token for session #3" reads as
+      # if the token were the session's.
+      private def self.env_unresolved_error(detail : String?, where : String = "") : String
+        "unresolved env #{detail}#{where} — set it with `gori run project env set KEY value`, " \
+        "or remove the token"
+      end
+
       # QL negation terms ("-field:value" / "-field~rx") begin with '-', so OptionParser
       # aborts them as unknown options before the positional-query join ever runs. Pull
       # them out first so they join the query like any other positional term. A single-

--- a/src/gori/cli/run/discover.cr
+++ b/src/gori/cli/run/discover.cr
@@ -104,6 +104,8 @@ module Gori
           "invalid --target #{ex.detail.inspect} (use http:// or https://)"
         in Discover::PlanError::Reason::Wordlist
           "wordlist error: #{ex.detail}"
+        in Discover::PlanError::Reason::UnresolvedEnv
+          env_unresolved_error(ex.detail)
         in Discover::PlanError::Reason::NoTarget, Discover::PlanError::Reason::NoTechnique
           discover_reason_error(ex.reason)
         end

--- a/src/gori/cli/run/fuzz.cr
+++ b/src/gori/cli/run/fuzz.cr
@@ -146,6 +146,8 @@ module Gori
           "could not determine a target host"
         in Fuzz::PlanError::Reason::NoPayloads
           "no payloads — add -w/--payloads/--numbers/--null/--brute"
+        in Fuzz::PlanError::Reason::UnresolvedEnv
+          env_unresolved_error(ex.detail)
         end
       end
 

--- a/src/gori/cli/run/mine.cr
+++ b/src/gori/cli/run/mine.cr
@@ -123,6 +123,8 @@ module Gori
           "wordlist error: #{ex.detail}"
         in Miner::PlanError::Reason::NoNames
           "no candidate parameter names to mine"
+        in Miner::PlanError::Reason::UnresolvedEnv
+          env_unresolved_error(ex.detail)
         end
       end
 

--- a/src/gori/cli/run/repeater.cr
+++ b/src/gori/cli/run/repeater.cr
@@ -263,6 +263,8 @@ module Gori
           "#{prefix}: could not determine a target host#{where}#{detail ? " from #{detail.inspect}" : ""}"
         in Repeater::PlanError::Reason::UnsupportedScheme
           "#{prefix}: unsupported target scheme #{(detail || "").inspect} (use http:// or https://)"
+        in Repeater::PlanError::Reason::UnresolvedEnv
+          "#{prefix}: #{env_unresolved_error(detail, where)}"
         end)
       end
 

--- a/src/gori/cli/run/sequence.cr
+++ b/src/gori/cli/run/sequence.cr
@@ -134,6 +134,8 @@ module Gori
         in Sequencer::PlanError::Reason::NoTokens
           # Unreachable here: --tokens is handled above and never builds a plan.
           "no tokens to analyze"
+        in Sequencer::PlanError::Reason::UnresolvedEnv
+          env_unresolved_error(ex.detail)
         end
       end
 

--- a/src/gori/discover/plan.cr
+++ b/src/gori/discover/plan.cr
@@ -26,6 +26,10 @@ module Gori::Discover
       NoTechnique
       # The user wordlist could not be read (`detail` = the underlying error message).
       Wordlist
+      # The seed or a custom header still names an env var that resolves to nothing, so
+      # the crawl would put the token's own characters on the wire (`detail` = the
+      # unresolved tokens, prefixed and comma-joined, for surfaces that quote them back).
+      UnresolvedEnv
     end
 
     getter reason : Reason
@@ -137,6 +141,10 @@ module Gori::Discover
       unless Headers.safe_value?(seed)
         raise PlanError.new(PlanError::Reason::BadTarget, "seed contains a control character", raw)
       end
+      # The SECOND expansion this builder owns, and the one easiest to miss: custom header
+      # values go through `Headers.expand` below, so an unresolved `$SESSION` there rides
+      # every probe the crawl sends. Checked on the raw pairs, before that call.
+      refuse_unresolved(config.headers.flat_map { |(_, value)| Env.unresolved(value) }.uniq!)
       words = load_words(config.user_wordlist)
       policy = resolve_policy(outbound, seed, parts.host)
       # `idle_conns` is the run's concurrency for the reason Fuzz uses it: one worker fiber
@@ -151,6 +159,7 @@ module Gori::Discover
     # ONE `Env.expand` over the seed, then the scheme default: `acme.test/admin` means
     # `https://acme.test/admin` on every surface (the TUI used to reject it as invalid).
     private def self.resolve_seed(raw : String) : String
+      refuse_unresolved(Env.unresolved(raw.strip))
       target = Env.expand(raw.strip)
       raise PlanError.new(PlanError::Reason::NoTarget, "no seed target") if target.empty?
       target.matches?(/\Ahttps?:\/\//i) ? target : "https://#{target}"
@@ -197,6 +206,20 @@ module Gori::Discover
         return UnscopedStoreScope.new(scope)
       end
       StoreScope.new(scope)
+    end
+
+    # Refuse a crawl whose seed or custom headers still carry a token that resolves to
+    # nothing. `Env.expand` leaves an unregistered `$KEY` literal on purpose — right for
+    # a display path, wrong here, because the seven characters `$SESSION` then go out as
+    # a header value on every probe, the origin answers 401 to all of them, and the run
+    # reports a uniformly locked-down target rather than a variable the operator never
+    # set (#519). This builder is the surface-independent chokepoint every discover
+    # surface expands through, so the check lives here once instead of in each of three.
+    private def self.refuse_unresolved(names : Array(String)) : Nil
+      return if names.empty?
+      detail = Env.token_list(names)
+      raise PlanError.new(PlanError::Reason::UnresolvedEnv,
+        "unresolved env #{detail}", detail)
     end
 
     # A missing/unreadable/binary wordlist is a user mistake, not a crash: every surface

--- a/src/gori/env.cr
+++ b/src/gori/env.cr
@@ -111,6 +111,96 @@ module Gori
       String.new(buf.to_slice)
     end
 
+    # The KEYs in `text` that `expand` would NOT substitute — every `prefix+KEY`
+    # whose KEY is unregistered — in first-appearance order, deduplicated. Empty
+    # means every token resolved.
+    #
+    # This is a QUERY, never a mutation of `expand`'s contract: leaving an unknown
+    # token literal is correct on a display path (it is honest about what could not
+    # be resolved, and `token_regions` already paints it), and wrong on a path that
+    # then puts those bytes on a socket. So the send paths ask this first and refuse,
+    # and `expand` keeps its meaning for everyone else (issue #519).
+    #
+    # Shares `read_key_bytes` and mirrors `expand`'s scan positions exactly —
+    # INCLUDING the `i += plen` advance on a miss — rather than re-deriving the token
+    # grammar. That is what makes the answer trustworthy: a name reported here is a
+    # name `expand` tried to resolve at that same offset and could not, so it is a
+    # name that lands on the wire literally.
+    #
+    # NOT `token_regions`, which computes the same `known` fact: that one is
+    # char-based (`text.chars`), and the text this runs over is routinely not valid
+    # UTF-8 (a captured flow's body loaded verbatim). `String#chars` decodes lossily
+    # to U+FFFD, which can both invent and destroy a token boundary — the exact
+    # hazard `expand` was made byte-level to avoid.
+    def self.unresolved(text : String, vars : Hash(String, String) = effective_vars,
+                        prefix : String = Settings.env_prefix) : Array(String)
+      return [] of String if prefix.empty?
+      return [] of String unless text.byte_index(prefix) # same fast no-op as `expand`
+      scan_unresolved(text.to_slice, vars, prefix)
+    end
+
+    # `unresolved` over the HEAD of wire-form text ALONE — the request line and
+    # headers, through the blank-line separator — never the body.
+    #
+    # Same split, and the same reason, as `expand_wire`'s CRLF normalization: in the
+    # head a `$` starts a reference, in the body it is just a byte. The body is where
+    # that distinction bites, because a body is often not text at all. A `$` followed
+    # by `[A-Za-z_]` occurs by chance roughly once per 1.2KB of high-entropy bytes, so
+    # a whole-request check would refuse essentially EVERY replay carrying a
+    # compressed, encrypted, or otherwise binary body — measured on random bodies:
+    # ~3 token-shaped hits per 4KB, hit in 20 of 20 samples; ~51 per 64KB. Refusing a
+    # captured multipart upload because its JPEG happened to contain `$A` would be a
+    # far worse failure than the one this check exists to stop.
+    #
+    # The boundary is taken on the text as AUTHORED (pre-expansion), because the
+    # question is which tokens the author wrote in the head — not where the head ends
+    # after some var's value has been spliced in.
+    def self.unresolved_wire(text : String, vars : Hash(String, String) = effective_vars,
+                             prefix : String = Settings.env_prefix) : Array(String)
+      return [] of String if prefix.empty?
+      return [] of String unless text.byte_index(prefix)
+      bytes = text.to_slice
+      scan_unresolved(bytes[0...head_body_boundary(bytes)], vars, prefix)
+    end
+
+    # Render token names back into the spelling the operator typed (`["A"]` → `"$A"`),
+    # comma-joined. Every surface quotes the same list, so the prefix is applied here
+    # rather than in five builders that could each drift on whether to include it.
+    def self.token_list(names : Array(String), prefix : String = Settings.env_prefix) : String
+      names.join(", ") { |n| "#{prefix}#{n}" }
+    end
+
+    private def self.scan_unresolved(bytes : Bytes, vars : Hash(String, String),
+                                     prefix : String) : Array(String)
+      names = [] of String
+      seen = Set(String).new
+      prefix_bytes = prefix.to_slice
+      n = bytes.size
+      plen = prefix_bytes.size
+      i = 0
+      while i < n
+        if i + plen <= n && prefix_bytes.each_with_index.all? { |b, j| bytes[i + j] == b }
+          if parsed = read_key_bytes(bytes, i + plen, n)
+            key, consumed = parsed
+            if vars.has_key?(key)
+              i += plen + consumed
+            else
+              names << key if seen.add?(key)
+              # `i += plen`, NOT `plen + consumed`: `expand` re-scans from just past
+              # the prefix on a miss, and this has to walk the same offsets or the two
+              # could disagree about what a later token even is.
+              i += plen
+            end
+          else
+            i += plen
+          end
+        else
+          i += 1
+        end
+      end
+      names
+    end
+
     # Finds the head/body boundary in wire-form text: the byte offset where the
     # body starts, right after the first blank line. Checks for both a bare
     # `\n\n` (how the Repeater/Miner editors store the blob internally) and,

--- a/src/gori/fuzz/plan.cr
+++ b/src/gori/fuzz/plan.cr
@@ -29,6 +29,10 @@ module Gori::Fuzz
       BadTarget
       # No payload sets at all.
       NoPayloads
+      # The template or the target still names an env var that resolves to nothing, so
+      # the run would put the token's own characters on the wire (`detail` = the
+      # unresolved tokens, prefixed and comma-joined, for surfaces that quote them back).
+      UnresolvedEnv
     end
 
     getter reason : Reason
@@ -145,7 +149,9 @@ module Gori::Fuzz
     end
 
     def self.build(options : PlanOptions, outbound : Gori::Outbound) : Plan
-      # ONE `Env.expand` over the template, before anything reads it.
+      # ONE `Env.expand` over the template, before anything reads it — and first, a
+      # refusal when a token in the HEAD resolves to nothing (see `refuse_unresolved`).
+      refuse_unresolved(Env.unresolved_wire(options.template))
       text = Env.expand(options.template)
       text = Template.auto_mark(text) if options.auto_mark?
       marker = Template::MARKER
@@ -198,10 +204,25 @@ module Gori::Fuzz
     private def self.resolve_origin(options : PlanOptions) : Origin
       raw = options.target.presence || options.default_target.presence
       raise PlanError.new(PlanError::Reason::NoTarget, "no target origin") unless raw
+      refuse_unresolved(Env.unresolved(raw))
       url = Env.expand(raw)
       scheme, host, port = Repeater::FlowRequest.parse_target(url)
       raise PlanError.new(PlanError::Reason::BadTarget, "could not parse a host from #{url.inspect}", url) if host.empty?
       Origin.new(scheme, host, port)
+    end
+
+    # Refuse a run whose template or target still carries a token that resolves to
+    # nothing. `Env.expand` leaves an unregistered `$KEY` literal on purpose — right for
+    # a display path, wrong here, because the seven characters `$SESSION` then go out as
+    # a header value, the origin answers 401, and the results read as findings about the
+    # target rather than as a variable the operator never set (#519). This builder is the
+    # surface-independent chokepoint every fuzz surface expands through, so the check
+    # lives here once instead of in each of the three.
+    private def self.refuse_unresolved(names : Array(String)) : Nil
+      return if names.empty?
+      detail = Env.token_list(names)
+      raise PlanError.new(PlanError::Reason::UnresolvedEnv,
+        "unresolved env #{detail}", detail)
     end
 
     # Non-overlapping occurrences of a literal token (mirrors what `String#gsub` will

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -1896,6 +1896,17 @@ module Gori
         present?(h, key) ? "invalid '#{key}' (expected an integer)" : "missing required '#{key}'"
       end
 
+      # One sentence for every MCP tool whose builder refused an env token that resolves to
+      # nothing (#519). Shared rather than written per tool because, unlike the other plan
+      # reasons, this one names no argument of the tool's own — the token is the whole fact
+      # and the remedy is the same everywhere. Naming `set_env_var` matters more here than
+      # on the other surfaces: an agent cannot see the token highlighted the way the TUI
+      # operator can, so the message has to carry both the name and the way to fix it.
+      # `detail` is the builder's prefixed, comma-joined token list (`$SESSION, $TOKEN`).
+      private def env_unresolved_error(detail : String?) : String
+        "unresolved env #{detail} — set it with the set_env_var tool, or remove the token"
+      end
+
       # Coerce a JSON arg to Int64. Accepts a JSON integer, an INTEGRAL float
       # (100.0 → 100; many encoders emit ints as floats), and a numeric STRING
       # ("5" → 5) — clients/LLMs often serialize tool args as strings and the

--- a/src/gori/mcp/tools/discover.cr
+++ b/src/gori/mcp/tools/discover.cr
@@ -108,6 +108,8 @@ module Gori
           "at least one of spider/bruteforce must stay enabled"
         in Discover::PlanError::Reason::Wordlist
           "wordlist error: #{ex.detail}"
+        in Discover::PlanError::Reason::UnresolvedEnv
+          env_unresolved_error(ex.detail)
         end
       end
 

--- a/src/gori/mcp/tools/fuzz.cr
+++ b/src/gori/mcp/tools/fuzz.cr
@@ -255,6 +255,8 @@ module Gori
           "could not parse a host from '#{ex.detail}'"
         in Fuzz::PlanError::Reason::NoPayloads
           %(no payloads — pass 'payloads' as a JSON array of sets, e.g. [{"list":["a","b"]}])
+        in Fuzz::PlanError::Reason::UnresolvedEnv
+          env_unresolved_error(ex.detail)
         end
       end
 

--- a/src/gori/mcp/tools/mine.cr
+++ b/src/gori/mcp/tools/mine.cr
@@ -189,6 +189,8 @@ module Gori
           "wordlist error: #{ex.detail}"
         in Miner::PlanError::Reason::NoNames
           "no candidate parameter names to mine"
+        in Miner::PlanError::Reason::UnresolvedEnv
+          env_unresolved_error(ex.detail)
         end
       end
 

--- a/src/gori/mcp/tools/send.cr
+++ b/src/gori/mcp/tools/send.cr
@@ -445,6 +445,7 @@ module Gori
           in Repeater::PlanError::Reason::NoTarget          then "'url' is required"
           in Repeater::PlanError::Reason::BadTarget         then "could not parse a target host from #{detail.inspect}"
           in Repeater::PlanError::Reason::UnsupportedScheme then "unsupported scheme: #{detail} (only http/https)"
+          in Repeater::PlanError::Reason::UnresolvedEnv     then env_unresolved_error(detail)
           end
         err(message, "INVALID_ARGUMENT", field: field)
       end

--- a/src/gori/mcp/tools/sequence.cr
+++ b/src/gori/mcp/tools/sequence.cr
@@ -177,6 +177,8 @@ module Gori
         in Sequencer::PlanError::Reason::NoTokens
           # Unreachable here: a pasted token list goes to sequence_analyze, which builds no plan.
           "provide a non-empty 'tokens' array"
+        in Sequencer::PlanError::Reason::UnresolvedEnv
+          env_unresolved_error(ex.detail)
         end
       end
 

--- a/src/gori/miner/plan.cr
+++ b/src/gori/miner/plan.cr
@@ -30,6 +30,10 @@ module Gori::Miner
       Wordlist
       # The candidate-name list came back empty, so the run would send nothing.
       NoNames
+      # The request or the target still names an env var that resolves to nothing, so
+      # the run would put the token's own characters on the wire (`detail` = the
+      # unresolved tokens, prefixed and comma-joined, for surfaces that quote them back).
+      UnresolvedEnv
     end
 
     getter reason : Reason
@@ -162,7 +166,9 @@ module Gori::Miner
     end
 
     def self.build(options : PlanOptions, outbound : Gori::Outbound) : Plan
-      # ONE `Env.expand_wire` over the request, before anything reads it.
+      # ONE `Env.expand_wire` over the request, before anything reads it — and first, a
+      # refusal when a token in the HEAD resolves to nothing (see `refuse_unresolved`).
+      refuse_unresolved(Env.unresolved_wire(options.request))
       request = Env.expand_wire(options.request)
       request_target = Gori::Outbound.request_target(request)
       origin = resolve_origin(options)
@@ -191,10 +197,25 @@ module Gori::Miner
     private def self.resolve_origin(options : PlanOptions) : Fuzz::Origin
       raw = options.target.presence || options.default_target.presence
       raise PlanError.new(PlanError::Reason::NoTarget, "no target origin") unless raw
+      refuse_unresolved(Env.unresolved(raw))
       url = Env.expand(raw)
       scheme, host, port = Repeater::FlowRequest.parse_target(url)
       raise PlanError.new(PlanError::Reason::BadTarget, "could not parse a host from #{url.inspect}", url) if host.empty?
       Fuzz::Origin.new(scheme, host, port)
+    end
+
+    # Refuse a run whose request or target still carries a token that resolves to
+    # nothing. `Env.expand` leaves an unregistered `$KEY` literal on purpose — right for
+    # a display path, wrong here, because the seven characters `$SESSION` then go out as
+    # a header value, the origin answers 401, and the results read as findings about the
+    # target rather than as a variable the operator never set (#519). This builder is the
+    # surface-independent chokepoint every mine surface expands through, so the check
+    # lives here once instead of in each of the three.
+    private def self.refuse_unresolved(names : Array(String)) : Nil
+      return if names.empty?
+      detail = Env.token_list(names)
+      raise PlanError.new(PlanError::Reason::UnresolvedEnv,
+        "unresolved env #{detail}", detail)
     end
 
     # Built-in names plus the optional user file, read HERE so a bad path surfaces as a

--- a/src/gori/repeater/plan.cr
+++ b/src/gori/repeater/plan.cr
@@ -25,6 +25,10 @@ module Gori::Repeater
       BadTarget
       # The target's scheme is one the repeater engines cannot dial (`detail` = the scheme).
       UnsupportedScheme
+      # The request, the target or the SNI still names an env var that resolves to
+      # nothing, so the send would put the token's own characters on the wire (`detail` =
+      # the unresolved tokens, prefixed and comma-joined, for surfaces that quote back).
+      UnresolvedEnv
     end
 
     getter reason : Reason
@@ -183,6 +187,11 @@ module Gori::Repeater
       scheme, host, port = resolve_origin(options)
 
       raise PlanError.new(PlanError::Reason::NoRequest, "no request to send") if options.requests.empty?
+      # Checked on `options.requests` REGARDLESS of `expand_request?`, and that is the
+      # point: when it is false the surface expanded already (MCP's `RequestBuilder`, the
+      # TUI editor's byte modes), so an unresolved token is sitting in the bytes it handed
+      # over and this is still the last place anyone looks before they reach a socket.
+      refuse_unresolved(options.requests.flat_map { |b| Env.unresolved_wire(String.new(b)) }.uniq!)
       wires = options.expand_request? ? options.requests.map { |b| Env.expand_wire(String.new(b)) } : options.requests
 
       # Detect the upgrade on the FINAL wire, not the stored text: the bytes that decide
@@ -199,6 +208,7 @@ module Gori::Repeater
           "unsupported target scheme #{scheme.inspect}", scheme)
       end
 
+      options.sni.try { |s| refuse_unresolved(Env.unresolved(s)) }
       sni = options.sni.try { |s| Env.expand(s).presence }
       sender = Sender.new(outbound, scheme: scheme, host: host, port: port,
         verify: options.verify?, http2: options.http2?, sni: sni,
@@ -218,10 +228,15 @@ module Gori::Repeater
     # request somewhere the operator did not name.
     private def self.resolve_origin(options : PlanOptions) : {String, String, Int32}
       if o = options.origin
+        # A pre-resolved origin skips `Env.expand` because its builder already ran it —
+        # but an unresolved `$HOST` survives that expansion as the literal host, and this
+        # early return is the one path where nothing else would ever look at it again.
+        refuse_unresolved(Env.unresolved(o.host))
         return {normalize_scheme(o.scheme), o.host, o.port}
       end
       raw = options.target || options.default_target.presence
       raise PlanError.new(PlanError::Reason::NoTarget, "no target origin") unless raw
+      refuse_unresolved(Env.unresolved(raw))
       url = Env.expand(raw)
       scheme, host, port = FlowRequest.parse_target(url)
       if host.empty? || port <= 0
@@ -229,6 +244,20 @@ module Gori::Repeater
           "could not determine a target host from #{url.inspect}", url)
       end
       {normalize_scheme(scheme), host, port}
+    end
+
+    # Refuse a send whose request, target or SNI still carries a token that resolves to
+    # nothing. `Env.expand` leaves an unregistered `$KEY` literal on purpose — right for a
+    # display path, wrong here, because the seven characters `$SESSION` then go out as a
+    # header value, the origin answers 401, and the operator reads that as the target
+    # rejecting a token rather than as a variable they never set (#519). This builder is
+    # the surface-independent chokepoint every repeater surface goes through, so the check
+    # lives here once instead of in each of the five paths that used to drift.
+    private def self.refuse_unresolved(names : Array(String)) : Nil
+      return if names.empty?
+      detail = Env.token_list(names)
+      raise PlanError.new(PlanError::Reason::UnresolvedEnv,
+        "unresolved env #{detail}", detail)
     end
 
     # ws/wss are hand-typed spellings of http/https — the capture proxy only ever records

--- a/src/gori/sequencer/plan.cr
+++ b/src/gori/sequencer/plan.cr
@@ -26,6 +26,10 @@ module Gori::Sequencer
       NoTokenLoc
       # Manual mode with nothing to analyze: no pasted token, or all of them blank.
       NoTokens
+      # The request or the target still names an env var that resolves to nothing, so
+      # the run would put the token's own characters on the wire (`detail` = the
+      # unresolved tokens, prefixed and comma-joined, for surfaces that quote them back).
+      UnresolvedEnv
     end
 
     getter reason : Reason
@@ -149,7 +153,9 @@ module Gori::Sequencer
       # it at all, so a `$TOKEN` in a sequenced request went out literally there while
       # resolving on the other two surfaces; `gori run sequence` and MCP each ran it in
       # their source reader, and doing it there AND here would resolve a var whose value
-      # itself contains a `$TOKEN` twice.
+      # itself contains a `$TOKEN` twice. A token in the HEAD that resolves to nothing
+      # refuses the run first (see `refuse_unresolved`).
+      refuse_unresolved(Env.unresolved_wire(String.new(options.request)))
       request = Env.expand_wire(String.new(options.request))
       sender = Fuzz::Sender.new(origin, outbound, http2: options.http2?, verify: options.verify?,
         sni: options.sni, timeout: config.timeout, overrides: options.overrides)
@@ -173,12 +179,28 @@ module Gori::Sequencer
     private def self.resolve_origin(options : PlanOptions) : Fuzz::Origin
       raw = options.target.presence || options.default_target.presence
       raise PlanError.new(PlanError::Reason::NoTarget, "no target origin") unless raw
+      refuse_unresolved(Env.unresolved(raw))
       url = Env.expand(raw)
       scheme, host, port = Repeater::FlowRequest.parse_target(url)
       if host.empty?
         raise PlanError.new(PlanError::Reason::BadTarget, "could not parse a host from #{url.inspect}", url)
       end
       Fuzz::Origin.new(scheme, host, port)
+    end
+
+    # Refuse a collection whose request or target still carries a token that resolves to
+    # nothing. `Env.expand` leaves an unregistered `$KEY` literal on purpose — right for
+    # a display path, wrong here, because the seven characters `$SESSION` then go out as
+    # a header value, the origin answers 401, and the sampled tokens describe a rejected
+    # session rather than the one the operator meant to measure (#519). This builder is
+    # the surface-independent chokepoint every sequence surface expands through, so the
+    # check lives here once instead of in each of the three. The manual (analyse-only)
+    # path returns before this and needs none — it opens no socket.
+    private def self.refuse_unresolved(names : Array(String)) : Nil
+      return if names.empty?
+      detail = Env.token_list(names)
+      raise PlanError.new(PlanError::Reason::UnresolvedEnv,
+        "unresolved env #{detail}", detail)
     end
   end
 end

--- a/src/gori/tui/controllers/discover_controller.cr
+++ b/src/gori/tui/controllers/discover_controller.cr
@@ -217,6 +217,8 @@ module Gori::Tui
         "enable spider or brute-force in the run config first"
       in Discover::PlanError::Reason::Wordlist
         "wordlist error: #{ex.detail}"
+      in Discover::PlanError::Reason::UnresolvedEnv
+        "unresolved env #{ex.detail} — add it in the Project tab's ENV pane"
       end
     end
 

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -1416,6 +1416,8 @@ module Gori::Tui
         "repeater: invalid target — use scheme://host[:port]/path"
       in Repeater::PlanError::Reason::UnsupportedScheme
         "repeater: unsupported scheme #{(ex.detail || "").inspect} — use http:// or https://"
+      in Repeater::PlanError::Reason::UnresolvedEnv
+        "repeater: unresolved env #{ex.detail} — add it in the Project tab's ENV pane"
       end)
       nil
     end

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -969,6 +969,8 @@ module Gori::Tui
         "invalid target — use scheme://host[:port]/path"
       in Fuzz::PlanError::Reason::NoPayloads
         "add a payload set — ^O config · + Add set (^L for a List)"
+      in Fuzz::PlanError::Reason::UnresolvedEnv
+        "unresolved env #{ex.detail} — add it in the Project tab's ENV pane"
       end
     end
 

--- a/src/gori/tui/miner_view.cr
+++ b/src/gori/tui/miner_view.cr
@@ -317,6 +317,8 @@ module Gori::Tui
         "wordlist error: #{ex.detail}"
       in Miner::PlanError::Reason::NoNames
         "wordlist is empty"
+      in Miner::PlanError::Reason::UnresolvedEnv
+        "unresolved env #{ex.detail} — add it in the Project tab's ENV pane"
       end
     end
 

--- a/src/gori/tui/sequencer_view.cr
+++ b/src/gori/tui/sequencer_view.cr
@@ -353,6 +353,8 @@ module Gori::Tui
         "invalid target — use scheme://host[:port]/path"
       in Sequencer::PlanError::Reason::NoTokenLoc
         "set a token location first"
+      in Sequencer::PlanError::Reason::UnresolvedEnv
+        "unresolved env #{ex.detail} — add it in the Project tab's ENV pane"
       end
     end
 


### PR DESCRIPTION
Closes #519.

## The bug

`Env.expand` writes the prefix back and advances past it on a miss (`env.cr:98-101`), so an unregistered `$SESSION` falls through into the output unchanged. All five engines run one expansion at plan-build time and send the result, so a typo'd or unset variable did not fail — the request went out carrying the token's own characters, the origin answered 401, and the operator had no signal separating "the variable is unset" from "the target rejects this token".

Control run before the fix, against a raw-socket sink:

```
$ gori run repeater send 1 --allow-unscoped
→ 200 in 650µs

=== RAW REQUEST ON WIRE ===
GET /me HTTP/1.1
Host: 127.0.0.1:9911
Authorization: Bearer $SESSION
X-Tok: $TOKEN
```

## Where the check goes, and why not in `expand`

`expand` keeps its meaning. Leaving a token literal is correct on a display path, `token_regions` already marks it, and `highlight.cr:243` already paints it — changing `expand` would break exactly the behaviour the issue requires to stay put, at ~25 call sites, most of which do not send.

Instead the builders ask a new query beside it: `Env.unresolved` / `Env.unresolved_wire`. It shares `read_key_bytes` with `expand` and mirrors its scan positions exactly, including the `i += plen` advance on a miss, so a name it reports is a name `expand` tried to resolve at that same offset and could not. It is byte-level for the reason `expand` is: `token_regions` computes the same `known` fact but is char-based, and the wire text here is routinely not valid UTF-8, which `String#chars` decodes lossily to U+FFFD.

## The head-only scope

The wire form checks the request head alone, on the same split and for the same reason as `expand_wire`'s CRLF normalization: in the head a `$` starts a reference, in the body it is a byte.

This is not a judgement call. `$` followed by `[A-Za-z_]` occurs by chance about once per 1.2KB of high-entropy bytes — measured on random bodies at ~3 token-shaped hits per 4KB, present in 20 of 20 samples, and ~51 per 64KB — so a whole-request check would refuse essentially every replay carrying a compressed, encrypted or otherwise binary body. Pinned by a spec, and verified end to end: a 2KB binary body carrying `$A` and `$_` still sends.

## A new `Reason` member, not a reused one

Each engine gets `UnresolvedEnv` and each of its three surfaces gets a branch, 15 in total. That is more edits than reusing `BadTarget`, and it is the right trade twice over: `BadTarget`'s contract is "the target string that failed", so quoting it for a token in a *header* would print "invalid --target" for something that is not the target; and because the three surfaces `case` the reason exhaustively, the compiler proves all five engines and all fifteen surfaces are covered. Coverage that a human has to remember is the exact failure this issue is about.

Each surface names its own remedy, since unlike the other reasons this one names no flag of the command's own: the CLI points at `gori run project env set`, MCP at the `set_env_var` tool, the TUI at the Project tab's ENV pane.

## Verification

All five engines, built binary, against a raw-socket sink. Sink request count went from 2 to 2 across the whole battery — nothing reached the socket:

```
gori run repeater send:  unresolved env $SESSION, $TOKEN for session #1 — set it with `gori run project env set KEY value`, or remove the token
gori run fuzz:           unresolved env $SESSION, $TOKEN — ...
gori run mine:           unresolved env $SESSION, $TOKEN — ...
gori run sequence:       unresolved env $SESSION, $TOKEN — ...
gori run discover:       unresolved env $SEEDHOST — ...     (seed)
gori run discover:       unresolved env $SESSION — ...      (custom header)
```

Discover expands **twice** inside its builder, the seed and the custom header values (`Headers.expand`), and the header call is the one a "check the target" fix would miss — an unresolved token there rides every probe the crawl sends. Both are covered and both are asserted.

MCP refuses with a coded error rather than a bare string:

```json
{"error_code":"INVALID_ARGUMENT","message":"unresolved env $NOPE — set it with the set_env_var tool, or remove the token","field":"url"}
```

Positive control: with the variables set, the same session sends `Authorization: Bearer s3cr3t` and `X-Tok: t0ken`.

- `crystal spec`: 5213 examples, 0 failures (21 new).
- `ameba` on the touched files: no new violations. The two it did flag on added lines (`Performance/ChainedCallWithNoBang`) are fixed.
- Rebased onto #522 and #523; `crystal build --no-codegen src/main.cr` clean on the merge result.

## Not in this PR

Three send paths expand `$KEY` without going through a builder and still ship the token: WebSocket message payloads (CLI/MCP/TUI), Intercept forward (TUI), and Minimize (CLI/MCP/TUI). They are the same silent no-op in places #519 did not enumerate, and none of them raises a `PlanError`, so each needs its own refusal path rather than a new enum member. Filed with file:line as #524.

Session binding (#501) stays out of scope: this is only the case where a name resolves to nothing at all.