### PR TITLE
fix(proxy): scope the h2 downgrade gate to the hosts a rule can match (#526)

### DIFF
--- a/spec/proxy/tls/h2_host_scoped_gate_spec.cr
+++ b/spec/proxy/tls/h2_host_scoped_gate_spec.cr
@@ -1,0 +1,298 @@
+require "../../spec_helper"
+require "log/spec"
+require "socket"
+require "openssl"
+require "file_utils"
+
+# The h2 downgrade gate, narrowed to the host a rule can actually match (#526).
+#
+# Before this, `Tls::Tunnel#h2_candidate?` asked two HOST-BLIND questions — "is any body rule
+# live", "is any short-circuit rule live" — both of which read a global atomic count. One rule
+# scoped to `alpha.test` therefore forced every h2 host on the proxy onto HTTP/1.1, including
+# hosts its own glob can never match, and gori announced the downgrade for them.
+#
+# Every downgrade case here is paired with the control that makes it attributable: same proxy,
+# same origin, same client, only the rule's host glob differs.
+
+include Gori::Proxy
+include Gori::Proxy::Tls
+
+private alias GFrame = Gori::Proxy::H2::Frame
+private alias GHPACK = Gori::Proxy::H2::HPACK
+
+private SCOPED_SC   = Gori::Store::RuleOp::ShortCircuit
+private SCOPED_REQ  = Gori::Store::RuleTarget::Request
+private SCOPED_HEAD = Gori::Store::RulePart::Head
+private SCOPED_BODY = Gori::Store::RulePart::Body
+
+private class GateSink < FlowSink
+  def on_request(req : Gori::Store::CapturedRequest) : Int64
+    1_i64
+  end
+
+  def on_response(resp : Gori::Store::CapturedResponse) : Nil
+  end
+
+  def on_ws_message(flow_id : Int64, direction : String, opcode : Int32, payload : Bytes) : Nil
+  end
+end
+
+# The abstract seam with nothing overridden — what a caller gets from a rewriter that is not
+# `Rules` (the h2c/reverse paths pass one).
+private class NoopRewriter < Gori::Proxy::HeadRewriter
+  def rewrite_request(head : Bytes, host : String) : Bytes
+    head
+  end
+
+  def rewrite_response(head : Bytes, host : String) : Bytes
+    head
+  end
+end
+
+private def with_gate_rules(&)
+  path = File.tempname("gori-h2-gate", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield Gori::Rules.load(store)
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+# An origin that advertises h2 in ALPN and counts accepts, so "the ALPN probe was skipped" is
+# measured rather than inferred. Same shape as http2_toggle_spec's.
+private def start_gate_origin(accepts : Array(Int32)) : Int32
+  cert, key = CertBuilder.build_root("origin.test")
+  ctx = ContextFactory.server_context(cert, key, advertise_h2: true)
+  server = TCPServer.new("127.0.0.1", 0)
+  port = server.local_address.port
+  spawn do
+    while raw = server.accept?
+      accepts[0] += 1
+      begin
+        ssl = OpenSSL::SSL::Socket::Server.new(raw, ctx, sync_close: true)
+        Codec::Http1.read_head(ssl) # a probe connection sends nothing; this parks until close
+      rescue
+      end
+    end
+  end
+  port
+end
+
+private def gate_client(raw : TCPSocket, ca_dir : String) : OpenSSL::SSL::Socket::Client
+  ctx = OpenSSL::SSL::Context::Client.new
+  ctx.alpn_protocol = "h2"
+  ca_cert = Cert.read_pem(File.join(ca_dir, "root.crt.pem"))
+  store = LibSSL.ssl_ctx_get_cert_store(ctx.to_unsafe)
+  LibCrypto.x509_store_add_cert(store, ca_cert.handle)
+  OpenSSL::SSL::Socket::Client.new(raw, context: ctx, sync_close: true, hostname: "localhost")
+end
+
+# CONNECT to `localhost:<origin>` through a proxy carrying `rewriter`, and yield what gori
+# advertised in ALPN plus how many times the origin was dialed.
+private def alpn_through_proxy(rewriter : Gori::Proxy::HeadRewriter, tag : String, &) : Nil
+  dir = File.tempname("gori-ca-#{tag}")
+  accepts = [0]
+  begin
+    origin_port = start_gate_origin(accepts)
+    ca = CertAuthority.load_or_create(dir)
+    proxy = Server.new("127.0.0.1", 0, GateSink.new,
+      tls: Tunnel.new(ca, verify_upstream: false, rewriter: rewriter))
+    proxy.start
+
+    raw = TCPSocket.new("127.0.0.1", proxy.port)
+    raw << "CONNECT localhost:#{origin_port} HTTP/1.1\r\nHost: localhost:#{origin_port}\r\n\r\n"
+    raw.flush
+    Codec::Http1.read_head(raw).not_nil!
+
+    tls = gate_client(raw, dir)
+    negotiated = tls.alpn_protocol
+    tls.close
+    proxy.stop
+    yield negotiated, accepts[0]
+  ensure
+    FileUtils.rm_rf(dir) if Dir.exists?(dir)
+  end
+end
+
+private def gate_pipe(rewriter : Gori::Proxy::HeadRewriter) : {Gori::Proxy::H2::HeadRewrite, Gori::Proxy::H2::Assembler}
+  assembler = Gori::Proxy::H2::Assembler.new(GateSink.new, "api.example.com", 443, 1_i64)
+  {Gori::Proxy::H2::HeadRewrite.new("out", rewriter, assembler, "api.example.com"), assembler}
+end
+
+private def feed_authority(pipe : Gori::Proxy::H2::HeadRewrite,
+                           assembler : Gori::Proxy::H2::Assembler, authority : String) : Nil
+  block = GHPACK::Encoder.new.encode([{":method", "GET"}, {":scheme", "https"},
+                                      {":authority", authority}, {":path", "/x"}])
+  frame = GFrame::Header.new(GFrame::Type::Headers.value,
+    GFrame::END_HEADERS | GFrame::END_STREAM, 1_u32, block)
+  pipe.accept(frame) { |f, pre| assembler.feed("out", f, pre) }
+end
+
+describe "h2 downgrade gate, host-scoped (#526)" do
+  describe Gori::Rules do
+    it "answers false for a host no body rule's glob can match" do
+      with_gate_rules do |rules|
+        rules.add(SCOPED_REQ, SCOPED_BODY, "secret", "REDACTED", host: "alpha.test")
+        # The host-blind pair stays true, and must: `ClientConn` asks it per message on a
+        # connection already pinned to one host, which is not the question #526 narrowed.
+        rules.rewrites_request_body?.should be_true
+
+        rules.rewrites_body_for_host?("alpha.test").should be_true
+        rules.rewrites_body_for_host?("api.alpha.test").should be_true # substring dialect
+        rules.rewrites_body_for_host?("127.0.0.1").should be_false     # the bug
+      end
+    end
+
+    it "answers true everywhere for an UNSCOPED body rule — today's behaviour, unchanged" do
+      with_gate_rules do |rules|
+        rules.add(SCOPED_REQ, SCOPED_BODY, "secret", "REDACTED") # empty glob
+        rules.rewrites_body_for_host?("127.0.0.1").should be_true
+        rules.rewrites_body_for_host?("anything.at.all").should be_true
+      end
+    end
+
+    it "reads a wildcard glob the way the rewrite path does" do
+      with_gate_rules do |rules|
+        rules.add(SCOPED_REQ, SCOPED_BODY, "secret", "REDACTED", host: "*.alpha.test")
+        rules.rewrites_body_for_host?("api.alpha.test").should be_true
+        rules.rewrites_body_for_host?("alpha.test").should be_false
+      end
+    end
+
+    it "scopes the short-circuit question exactly as `short_circuit` itself is scoped" do
+      with_gate_rules do |rules|
+        rules.add(SCOPED_REQ, SCOPED_HEAD, "/admin", "403 Forbidden", op: SCOPED_SC, host: "alpha.test")
+        rules.short_circuits?.should be_true
+        rules.short_circuits_for_host?("alpha.test").should be_true
+        rules.short_circuits_for_host?("127.0.0.1").should be_false
+        # ...and that is precisely the reachability `short_circuit` has for those two hosts,
+        # which is what the gate exists to protect.
+        rules.short_circuit("GET /admin HTTP/1.1\r\n\r\n".to_slice, "alpha.test").should_not be_nil
+        rules.short_circuit("GET /admin HTTP/1.1\r\n\r\n".to_slice, "127.0.0.1").should be_nil
+      end
+    end
+
+    it "ignores a disabled rule, and never counts a HEAD rule" do
+      with_gate_rules do |rules|
+        rules.add(SCOPED_REQ, SCOPED_BODY, "secret", "REDACTED")
+        rules.toggle(rules.rules.first.id)
+        rules.rewrites_body_for_host?("alpha.test").should be_false
+
+        rules.add(SCOPED_REQ, SCOPED_HEAD, "Host: a", "Host: b") # head rules reach h2 since #492 step 2
+        rules.rewrites_body_for_host?("alpha.test").should be_false
+        rules.short_circuits_for_host?("alpha.test").should be_false
+      end
+    end
+
+    it "defaults to false on the seam, matching the host-blind pair" do
+      stub = NoopRewriter.new
+      stub.rewrites_body_for_host?("anything").should be_false
+      stub.short_circuits_for_host?("anything").should be_false
+    end
+  end
+
+  # End to end against a real Tunnel: what the client is actually offered.
+  describe "through the proxy" do
+    it "keeps h2 for a host a BODY rule cannot match, and downgrades the host it can" do
+      with_gate_rules do |rules|
+        rules.add(SCOPED_REQ, SCOPED_BODY, "secret", "REDACTED", host: "alpha.test")
+        # The fix: `localhost` is not `alpha.test`, so the rule costs it nothing.
+        alpn_through_proxy(rules, "body-scoped-away") do |negotiated, accepts|
+          negotiated.should eq("h2")
+          accepts.should eq(1) # the ALPN reflection probe ran, i.e. the gate let it through
+        end
+      end
+
+      # The control: the SAME rule, re-scoped to the host being reached, still downgrades.
+      with_gate_rules do |rules|
+        rules.add(SCOPED_REQ, SCOPED_BODY, "secret", "REDACTED", host: "localhost")
+        alpn_through_proxy(rules, "body-scoped-here") do |negotiated, accepts|
+          negotiated.should_not eq("h2")
+          accepts.should eq(0) # a downgrade short-circuits before reflect_origin_h2 dials
+        end
+      end
+    end
+
+    it "still downgrades EVERY host for an unscoped body rule (the regression guard)" do
+      with_gate_rules do |rules|
+        rules.add(SCOPED_REQ, SCOPED_BODY, "secret", "REDACTED") # empty glob = every host
+        alpn_through_proxy(rules, "body-unscoped") do |negotiated, accepts|
+          negotiated.should_not eq("h2")
+          accepts.should eq(0)
+        end
+      end
+    end
+
+    it "keeps h2 for a host a SHORT-CIRCUIT rule cannot match, and downgrades the host it can" do
+      with_gate_rules do |rules|
+        rules.add(SCOPED_REQ, SCOPED_HEAD, "/admin", "403 Forbidden", op: SCOPED_SC, host: "alpha.test")
+        alpn_through_proxy(rules, "stub-scoped-away") do |negotiated, accepts|
+          negotiated.should eq("h2")
+          accepts.should eq(1)
+        end
+      end
+
+      with_gate_rules do |rules|
+        rules.add(SCOPED_REQ, SCOPED_HEAD, "/admin", "403 Forbidden", op: SCOPED_SC, host: "localhost")
+        alpn_through_proxy(rules, "stub-scoped-here") do |negotiated, accepts|
+          negotiated.should_not eq("h2")
+          accepts.should eq(0)
+        end
+      end
+    end
+
+    it "still downgrades EVERY host for an unscoped short-circuit rule (the regression guard)" do
+      with_gate_rules do |rules|
+        rules.add(SCOPED_REQ, SCOPED_HEAD, "/admin", "403 Forbidden", op: SCOPED_SC)
+        alpn_through_proxy(rules, "stub-unscoped") do |negotiated, accepts|
+          negotiated.should_not eq("h2")
+          accepts.should eq(0)
+        end
+      end
+    end
+  end
+
+  # The cost #526 states up front: a per-CONNECT gate cannot see a stream whose `:authority`
+  # is a different host (RFC 9113 §9.1.1 coalescing). It stays SPOKEN rather than silent.
+  describe "coalesced-stream notice" do
+    it "logs once when a coalesced stream carries a rule the connection gate never saw" do
+      with_gate_rules do |rules|
+        rules.add(SCOPED_REQ, SCOPED_BODY, "secret", "REDACTED", host: "alpha.test")
+        pipe, assembler = gate_pipe(rules)
+        Log.capture do |logs|
+          feed_authority(pipe, assembler, "alpha.test")
+          logs.check(:warn, /stream authority "alpha\.test" is not the CONNECT host "api\.example\.com"/)
+          # Once per connection, not once per stream.
+          feed_authority(pipe, assembler, "alpha.test")
+          logs.empty
+        end
+      end
+    end
+
+    it "says nothing for the ordinary stream — the authority IS the connection host" do
+      with_gate_rules do |rules|
+        rules.add(SCOPED_REQ, SCOPED_BODY, "secret", "REDACTED", host: "api.example.com")
+        pipe, assembler = gate_pipe(rules)
+        Log.capture do |logs|
+          feed_authority(pipe, assembler, "api.example.com")
+          logs.empty
+        end
+      end
+    end
+
+    it "says nothing when no rule matches the coalesced authority either" do
+      with_gate_rules do |rules|
+        rules.add(SCOPED_REQ, SCOPED_BODY, "secret", "REDACTED", host: "beta.test")
+        pipe, assembler = gate_pipe(rules)
+        Log.capture do |logs|
+          feed_authority(pipe, assembler, "alpha.test")
+          logs.empty
+        end
+      end
+    end
+  end
+end

--- a/src/gori/proxy/h2/head_rewrite.cr
+++ b/src/gori/proxy/h2/head_rewrite.cr
@@ -3,6 +3,7 @@ require "./hpack"
 require "./head_codec"
 require "./assembler"
 require "../head_rewriter"
+require "../upstream"
 
 module Gori::Proxy::H2
   # One direction's head-rewrite pipeline: buffer a header block, decode it, run the
@@ -108,6 +109,7 @@ module Gori::Proxy::H2
       @engaged = false
       @warned = false
       @warned_unfaithful = false
+      @warned_coalesced = false
       @buf = [] of Frame::Header
       @block_bytes = 0
       @block_stream = 0_u32
@@ -303,6 +305,7 @@ module Gori::Proxy::H2
     private def rewrite(fields : Array(HPACK::Field), head : Bytes, request : Bool) : Array(HPACK::Field)?
       rw = @rewriter
       return nil unless rw && rw.active?
+      notice_coalesced(rw, fields) if request
       # The peer's own head has no faithful h1-text form, so the round trip that runs the
       # rules would hand the far side a DIFFERENT message — see `HeadCodec.h1_faithful?`.
       # `parse_*` refuses it anyway; checking here keeps the rules from running for nothing
@@ -357,6 +360,40 @@ module Gori::Proxy::H2
         "h2 #{@direction}: the peer sent a #{request ? "request" : "response"} head that has no " \
         "HTTP/1.1 text form (stream #{stream_id}) — Match&Replace and intercept edits are " \
         "not applied to it, the fields go out exactly as they arrived"
+      end
+    end
+
+    # The stated cost of #526, kept spoken instead of silent.
+    #
+    # The h2 downgrade gate (`tls/tunnel.cr#h2_candidate?`) is per CONNECT, so it can only ask
+    # about the CONNECT host. Since #526 it asks whether a BODY or SHORT-CIRCUIT rule matches
+    # THAT host — which is right for every stream whose `:authority` is that host, and every
+    # stream on a conformant connection is (gori's leaf carries a SAN of exactly the requested
+    # host, `tls/cert_builder.cr`, so a conformant client cannot coalesce onto one). A
+    # hand-rolled client can still coalesce, and then a rule scoped to the coalesced authority
+    # goes unapplied where the pre-#526 blanket downgrade would have caught it. Body rewriting
+    # and short-circuiting are both seams the relay cannot reach, so that failure is silent —
+    # the operator sees a request they stubbed reach the origin with nothing saying why.
+    #
+    # So: one line per connection, naming the authority and the connection host. Costs a string
+    # compare per request head on every normal connection (the authority IS the host, and that
+    # returns before any lock); only a genuinely coalesced stream reaches the rule lookup, and
+    # only until the line is written.
+    private def notice_coalesced(rw : Proxy::HeadRewriter, fields : Array(HPACK::Field)) : Nil
+      return if @warned_coalesced
+      authority = HeadCodec.pseudo_of(fields, ":authority")
+      return if authority.nil? || authority.empty?
+      # `:authority` may carry a port; the gate asked about a bare host.
+      host, _ = Upstream.split_host_port(authority, 0)
+      return if host.compare(@host, case_insensitive: true) == 0
+      return unless rw.rewrites_body_for_host?(host) || rw.short_circuits_for_host?(host)
+      @warned_coalesced = true
+      ::Log.warn do
+        "h2 #{@direction}: stream authority #{host.inspect} is not the CONNECT host " \
+        "#{@host.inspect} (RFC 9113 §9.1.1 coalescing) and a Match&Replace body or " \
+        "short-circuit rule matches it — those rules are NOT applied on the HTTP/2 relay, and " \
+        "the connection was not downgraded because no such rule matches #{@host.inspect}. " \
+        "Reach this host on its own connection to have them apply."
       end
     end
 

--- a/src/gori/proxy/head_rewriter.cr
+++ b/src/gori/proxy/head_rewriter.cr
@@ -49,6 +49,26 @@ module Gori::Proxy
       false
     end
 
+    # The same two questions, asked ABOUT ONE HOST (#526). A rule carries a host glob, so
+    # "is a body/stub rule live" and "can a body/stub rule touch this host" are different
+    # questions, and the h2 downgrade gate needs the second one: it costs a host its
+    # protocol, and a rule scoped to `alpha.test` must not cost `127.0.0.1` anything. The
+    # host-blind pair above stays for the per-message callers (`ClientConn` asks whether to
+    # buffer a body at all, on a connection already pinned to one host).
+    #
+    # An UNSCOPED rule (empty glob) matches every host, so it still answers true everywhere
+    # — the pre-#526 behaviour for the rule set most operators have, unchanged.
+    #
+    # Called once per CONNECT, never per message: an implementation may take a lock.
+    # Default false, matching the host-blind pair — a no-op stub rewrites nothing anywhere.
+    def rewrites_body_for_host?(host : String) : Bool
+      false
+    end
+
+    def short_circuits_for_host?(host : String) : Bool
+      false
+    end
+
     # Whether any rewrite is actually configured. The h2 relay checks this before paying
     # to synthesize a head to run rules against (`H2::HeadRewrite`), and the TUI reads it
     # for the Rewriter tab. It used to also be the TLS MITM's reason to force HTTP/1.1;

--- a/src/gori/proxy/tls/tunnel.cr
+++ b/src/gori/proxy/tls/tunnel.cr
@@ -189,8 +189,8 @@ module Gori::Proxy::Tls
     end
 
     # Whether this host may take the fast h2 relay at all. FALSE — forcing HTTP/1.1, the
-    # ClientConn path — when HTTP/2 is switched off OR a Match&Replace BODY rule is live.
-    # Anything else is a candidate, subject to the origin actually speaking h2 (see
+    # ClientConn path — when HTTP/2 is switched off OR a Match&Replace BODY rule is live FOR
+    # THIS HOST. Anything else is a candidate, subject to the origin actually speaking h2 (see
     # reflect_origin_h2). Placing the check here also means a downgrade skips the origin ALPN
     # probe entirely: reflect_origin_h2 consults this before dialing.
     #
@@ -229,13 +229,31 @@ module Gori::Proxy::Tls
     # `https://acme.test/api/*` forward `/admin` to the origin unexamined. It is replaced by a
     # per-stream refusal in `H2::StreamGate` — which also covers something h1 never had to face,
     # a coalesced stream whose `:authority` is not the CONNECT host (§9.1.1).
+    #
+    # ## What #526 narrowed, and what that costs
+    #
+    # Both remaining rewriter terms were HOST-BLIND: they read a global atomic count, so ONE
+    # rule scoped to `alpha.test` downgraded every h2 host on the proxy, including hosts its
+    # own glob can never match. That is the same shape step 2 fixed for head rules — a gate
+    # true for something it is not protecting — and it took the same remedy: narrow, don't
+    # remove. `rewrites_body_for_host?` / `short_circuits_for_host?` (`rules.cr`) keep the
+    # atomic counts as a lock-free fast path and then ask the host glob. An UNSCOPED rule
+    # matches every host and still downgrades everything, exactly as before.
+    #
+    # The cost is a stream whose `:authority` is NOT the CONNECT host (§9.1.1 coalescing):
+    # such a stream can now carry a rule this per-connection gate never saw, where the blanket
+    # downgrade caught it. gori's leaf certs carry a SAN of exactly the requested host
+    # (`cert_builder.cr`), so a conformant client cannot coalesce onto one and the case needs a
+    # hand-rolled peer — but it is not impossible, so it is not left silent: `H2::HeadRewrite`
+    # already computes the per-stream authority for rule scoping and logs once per connection
+    # when a stream's authority differs from this host AND a body/stub rule matches it.
     private def h2_candidate?(host : String) : Bool
       if Gori::Settings.http2_disabled?
         notice_downgrade(host, "HTTP/2 is switched off (settings network.http2; set it back to " \
                                "\"auto\" to keep h2)")
         return false
       end
-      if @rewriter.try { |rw| rw.rewrites_request_body? || rw.rewrites_response_body? }
+      if @rewriter.try(&.rewrites_body_for_host?(host))
         notice_downgrade(host, "a Match&Replace BODY rule is live and body rewriting on HTTP/2 " \
                                "is not implemented yet (disable the body rule to keep h2)")
         return false
@@ -247,7 +265,7 @@ module Gori::Proxy::Tls
       # whole purpose is that the request must NOT reach the origin. Left ungated, an operator
       # who stubbed an endpoint would watch an h2 host send the request anyway, with nothing
       # anywhere saying why.
-      if @rewriter.try(&.short_circuits?)
+      if @rewriter.try(&.short_circuits_for_host?(host))
         notice_downgrade(host, "a Match&Replace short-circuit rule is live and the h2 relay " \
                                "cannot answer a request locally (disable the stub rule to keep h2)")
         return false

--- a/src/gori/rules.cr
+++ b/src/gori/rules.cr
@@ -160,6 +160,26 @@ module Gori
       @resp_body_count.get > 0
     end
 
+    # Whether a body rule that can actually MATCH `host` is live (#526). The two predicates
+    # above answer "is any body rule live", which is the right question for `ClientConn` (it
+    # is deciding whether to pay for a body buffer on a connection already pinned to one
+    # host) and the wrong one for the h2 downgrade gate: that gate costs the host its
+    # protocol, and a rule scoped to `alpha.test` was costing `127.0.0.1` its protocol too.
+    #
+    # The atomic counts are still the fast path — no body rule anywhere means no lock and no
+    # select — and `host_matches?` (memoised, see below) then decides the rest. Both sides
+    # are folded into one question because the gate downgrades for either.
+    #
+    # Once per CONNECT, so the mutex here is not on any hot path.
+    def rewrites_body_for_host?(host : String) : Bool
+      return false if @req_body_count.get == 0 && @resp_body_count.get == 0 # lock-free fast path
+      @mutex.synchronize do
+        @rules.any? do |r|
+          r.enabled? && r.op.rewrite? && !r.pattern.empty? && r.part.body? && host_matches?(r.host, host)
+        end
+      end
+    end
+
     def rewrite_request_body(entity : Bytes, host : String) : Bytes
       apply(entity, Store::RuleTarget::Request, Store::RulePart::Body, @req_body_count, host)
     end
@@ -172,6 +192,19 @@ module Gori
 
     def short_circuits? : Bool
       @short_circuit_count.get > 0
+    end
+
+    # `short_circuits?` narrowed to one host (#526) — the same split, and for the same
+    # reason, as `rewrites_body_for_host?` above. The host filter is exactly the one
+    # `short_circuit` itself applies, so this answers "could `short_circuit` ever return a
+    # stub for this host", which is precisely what the downgrade gate is protecting.
+    def short_circuits_for_host?(host : String) : Bool
+      return false if @short_circuit_count.get == 0 # lock-free fast path
+      @mutex.synchronize do
+        @rules.any? do |r|
+          r.enabled? && r.op.short_circuit? && !r.pattern.empty? && host_matches?(r.host, host)
+        end
+      end
     end
 
     # The stub answering this request head, or nil when no rule claims it. The FIRST matching


### PR DESCRIPTION
Closes #526.

`Tls::Tunnel#h2_candidate?` forced a connection onto HTTP/1.1 whenever a Match&Replace **body** rule or a **short-circuit** rule was live. Both tests read a global atomic count and took no host, so **one rule scoped to `alpha.test` downgraded every h2 host on the proxy** — including hosts its own glob can never match — and gori announced the downgrade for them. An h2-only client (any gRPC client) on such a host could not connect, because of a rule scoped somewhere else.

Same shape #492 step 2 fixed for head rules (a gate true for something it is not protecting), same remedy: **narrow, don't remove**. Both terms are still required — body rewriting on h2 is closed as won't-do (#492 step 5) and the stub seam is only reachable from `ClientConn` (#520).

## What changed

- `Proxy::HeadRewriter#rewrites_body_for_host?(host)` and `#short_circuits_for_host?(host)`, default `false`.
- `Rules` implements both as the **existing atomic counts as a lock-free fast path**, then the already-memoised `host_matches?` over the enabled rules of that kind. Called **once per CONNECT**, not per message, so the mutex is off every hot path.
- The host-blind pair (`rewrites_request_body?` / `rewrites_response_body?` / `short_circuits?`) **stays**: `ClientConn` asks a different question — whether to pay for a body buffer on a connection already pinned to one host — and that is not what #526 narrowed.
- An **unscoped** rule (empty glob) matches every host and still downgrades everything. Only host-scoped rules narrow.
- The three `notice_downgrade` calls are **untouched**. They become accurate instead of over-broad.

## The cost, and the mitigation

A stream whose `:authority` is not the CONNECT host (RFC 9113 §9.1.1 coalescing — the case #515 had to test two URLs for) can now carry a rule this per-connection gate never saw. gori's leaf certs carry a SAN of exactly the requested host (`tls/cert_builder.cr`), so a conformant client cannot coalesce onto one; this needs a hand-rolled peer. But body rewriting and short-circuiting are seams the relay cannot reach, so the failure would be silent — so `H2::HeadRewrite` (which already computes the per-stream authority for rule scoping) now logs **once per connection** when a stream's authority differs from the connection host **and** a body/stub rule matches it.

## Verification against the built binary

An h2-capable Go origin on `127.0.0.1:9443` echoing `r.Proto`, `gori run capture` in front of it, `curl --http2` through the proxy. Same scenarios on a **control binary** built with the gate reverted to host-blind:

| scenario (traffic to `127.0.0.1`) | control (host-blind) | this PR |
| --- | --- | --- |
| no rule at all | `proto=HTTP/2.0` | `proto=HTTP/2.0` |
| BODY rule `--host=alpha.test` | **`proto=HTTP/1.1`** ← the bug | **`proto=HTTP/2.0`** |
| BODY rule `--host=127.0.0.1` (matches) | `proto=HTTP/1.1` | `proto=HTTP/1.1` |
| BODY rule **unscoped** | `proto=HTTP/1.1` | `proto=HTTP/1.1` |
| STUB rule `--host=alpha.test` | **`proto=HTTP/1.1`** ← the bug | **`proto=HTTP/2.0`** |
| STUB rule `--host=127.0.0.1` (matches) | `proto=HTTP/1.1` | `proto=HTTP/1.1` |
| STUB rule **unscoped** | `proto=HTTP/1.1` | `proto=HTTP/1.1` |

The control binary emitted the issue's line verbatim for the `alpha.test`-scoped rule:

```
INFO - h2 downgrade: 127.0.0.1 forced to HTTP/1.1 because a Match&Replace BODY rule is live
and body rewriting on HTTP/2 is not implemented yet (disable the body rule to keep h2).
```

This PR emits it only for the rows that still downgrade. And the retained downgrade still buys the feature — with the stub rule scoped to `127.0.0.1`, `GET /admin` through the proxy answered `HTTP/1.1 403 Forbidden` from gori while `/other` reached the origin.

## Specs

`spec/proxy/tls/h2_host_scoped_gate_spec.cr`, 13 examples: the `Rules` predicates (scoped, unscoped, wildcard glob, disabled rule, head rule, seam default), end-to-end ALPN through a real `Tunnel` for all six rule/scope combinations above (asserting both what gori advertised **and** that a downgrade skips the origin ALPN probe entirely), and the coalesced-stream notice with its two silent controls.

Control run: with the gate reverted to host-blind, exactly the two "keeps h2 for a host the rule cannot match" examples fail (`Expected: "h2" got: nil`); the unscoped and matching-host regression guards pass either way, which is the point.

`crystal spec`: 5300 examples, 0 failures. `ameba` clean on the five touched files. `crystal build --no-codegen src/main.cr` green on the rebased result.
