### PR TITLE
fix(h2): announce a coalesced stream that skips a body-scoped extract rule (#536)

### DIFF
--- a/spec/proxy/tls/h2_host_scoped_gate_spec.cr
+++ b/spec/proxy/tls/h2_host_scoped_gate_spec.cr
@@ -118,9 +118,25 @@ private def alpn_through_proxy(rewriter : Gori::Proxy::HeadRewriter, tag : Strin
   end
 end
 
-private def gate_pipe(rewriter : Gori::Proxy::HeadRewriter) : {Gori::Proxy::H2::HeadRewrite, Gori::Proxy::H2::Assembler}
+private def with_gate_bindings(&)
+  path = File.tempname("gori-h2-gate-bind", ".db")
+  store = Gori::Store.open(path)
+  begin
+    # Both tables off ONE store, because that is how `Session` wires them: the same proxy
+    # carries `rewriter: rules` and `extractor: bindings`, and the notice has to weigh both.
+    yield Gori::Rules.load(store), Gori::Bindings.load(store)
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def gate_pipe(rewriter : Gori::Proxy::HeadRewriter?,
+                      extractor : Gori::Proxy::ResponseExtract? = nil) : {Gori::Proxy::H2::HeadRewrite, Gori::Proxy::H2::Assembler}
   assembler = Gori::Proxy::H2::Assembler.new(GateSink.new, "api.example.com", 443, 1_i64)
-  {Gori::Proxy::H2::HeadRewrite.new("out", rewriter, assembler, "api.example.com"), assembler}
+  {Gori::Proxy::H2::HeadRewrite.new("out", rewriter, assembler, "api.example.com", extractor), assembler}
 end
 
 private def feed_authority(pipe : Gori::Proxy::H2::HeadRewrite,
@@ -266,9 +282,23 @@ describe "h2 downgrade gate, host-scoped (#526)" do
         Log.capture do |logs|
           feed_authority(pipe, assembler, "alpha.test")
           logs.check(:warn, /stream authority "alpha\.test" is not the CONNECT host "api\.example\.com"/)
+          # ...and it names WHICH kind, so the operator knows which table to look in (#536).
+          logs.entry.message.should contain("a Match&Replace BODY rule")
           # Once per connection, not once per stream.
           feed_authority(pipe, assembler, "alpha.test")
           logs.empty
+        end
+      end
+    end
+
+    it "names the short-circuit rule when that is the kind that was skipped" do
+      with_gate_rules do |rules|
+        rules.add(SCOPED_REQ, SCOPED_HEAD, "/admin", "403 Forbidden", op: SCOPED_SC, host: "alpha.test")
+        pipe, assembler = gate_pipe(rules)
+        Log.capture do |logs|
+          feed_authority(pipe, assembler, "alpha.test")
+          logs.check(:warn, /stream authority "alpha\.test"/)
+          logs.entry.message.should contain("a Match&Replace SHORT-CIRCUIT rule")
         end
       end
     end
@@ -291,6 +321,62 @@ describe "h2 downgrade gate, host-scoped (#526)" do
         Log.capture do |logs|
           feed_authority(pipe, assembler, "alpha.test")
           logs.empty
+        end
+      end
+    end
+
+    # #536: a body-scoped session-binding extract rule (#501 slice 2) is host-scoped through the
+    # same gate and unreachable on this relay for the same reason, so it belongs in this notice.
+    it "names a body-scoped EXTRACT rule that the connection gate never saw" do
+      with_gate_bindings do |rules, bindings|
+        bindings.add("SESSION", "", Gori::ExtractKind::Regex, "tok=(\\w+)", host: "alpha.test").should be_nil
+        # No Match&Replace rule at all — the rewriter is INACTIVE. Before #536 the notice ran
+        # from inside `rewrite`, behind `rw.active?`, so this case produced nothing.
+        rules.active?.should be_false
+        pipe, assembler = gate_pipe(rules, bindings)
+        Log.capture do |logs|
+          feed_authority(pipe, assembler, "alpha.test")
+          logs.check(:warn, /stream authority "alpha\.test" is not the CONNECT host "api\.example\.com"/)
+          logs.entry.message.should contain("a session-binding EXTRACT rule that reads the response body")
+          feed_authority(pipe, assembler, "alpha.test")
+          logs.empty # once per connection, same latch
+        end
+      end
+    end
+
+    it "says nothing for a HEAD-scoped extract rule — `H2::Extract` applies it on the relay" do
+      with_gate_bindings do |rules, bindings|
+        bindings.add("SESSION", "", Gori::ExtractKind::Cookie, "sid", host: "alpha.test").should be_nil
+        bindings.extracts?.should be_true # live, just not unreachable
+        pipe, assembler = gate_pipe(rules, bindings)
+        Log.capture do |logs|
+          feed_authority(pipe, assembler, "alpha.test")
+          logs.empty
+        end
+      end
+    end
+
+    it "says nothing when the extract rule's glob cannot match the coalesced authority" do
+      with_gate_bindings do |rules, bindings|
+        bindings.add("SESSION", "", Gori::ExtractKind::Regex, "tok=(\\w+)", host: "beta.test").should be_nil
+        pipe, assembler = gate_pipe(rules, bindings)
+        Log.capture do |logs|
+          feed_authority(pipe, assembler, "alpha.test")
+          logs.empty
+        end
+      end
+    end
+
+    it "names every kind that matches, in one line" do
+      with_gate_bindings do |rules, bindings|
+        rules.add(SCOPED_REQ, SCOPED_BODY, "secret", "REDACTED", host: "alpha.test")
+        bindings.add("SESSION", "", Gori::ExtractKind::Regex, "tok=(\\w+)", host: "alpha.test").should be_nil
+        pipe, assembler = gate_pipe(rules, bindings)
+        Log.capture do |logs|
+          feed_authority(pipe, assembler, "alpha.test")
+          logs.check(:warn, /stream authority "alpha\.test"/)
+          logs.entry.message.should contain("a Match&Replace BODY rule")
+          logs.entry.message.should contain("a session-binding EXTRACT rule that reads the response body")
         end
       end
     end

--- a/src/gori/proxy/h2/head_rewrite.cr
+++ b/src/gori/proxy/h2/head_rewrite.cr
@@ -3,6 +3,7 @@ require "./hpack"
 require "./head_codec"
 require "./assembler"
 require "../head_rewriter"
+require "../extractor"
 require "../upstream"
 
 module Gori::Proxy::H2
@@ -103,8 +104,13 @@ module Gori::Proxy::H2
     # constructor argument: the gate needs a live `HeadRewrite` to construct itself around.
     property deferrer : Deferrer?
 
+    # `extractor` is read for ONE thing: `notice_coalesced`, which runs on request heads only.
+    # The "in" direction therefore never touches it, and extraction itself happens in
+    # `H2::Extract` on the response side — this seam only has to be able to ASK whether a
+    # body-scoped extract rule would have wanted a stream the connection gate could not see.
     def initialize(@direction : String, @rewriter : Proxy::HeadRewriter?,
-                   @assembler : Assembler, @host : String)
+                   @assembler : Assembler, @host : String,
+                   @extractor : Proxy::ResponseExtract? = nil)
       @encoder = HPACK::Encoder.new
       @engaged = false
       @warned = false
@@ -255,6 +261,11 @@ module Gori::Proxy::H2
 
       request = @direction == "out"
       head = head_text(fields, first, request)
+      # Before the rewrite, and NOT from inside it: what this announces is a seam the relay
+      # cannot reach at all, which is true whether or not a head rule is live. Running it from
+      # `rewrite` put it behind `rw.active?`, so an operator whose only rule is a session-binding
+      # extract descriptor — the case #536 is about — got nothing.
+      notice_coalesced(fields) if request && head
       rewritten = head ? rewrite(fields, head, request) : nil
       emit_fields = rewritten || fields
       built = if rewritten.nil? && !@engaged
@@ -305,7 +316,6 @@ module Gori::Proxy::H2
     private def rewrite(fields : Array(HPACK::Field), head : Bytes, request : Bool) : Array(HPACK::Field)?
       rw = @rewriter
       return nil unless rw && rw.active?
-      notice_coalesced(rw, fields) if request
       # The peer's own head has no faithful h1-text form, so the round trip that runs the
       # rules would hand the far side a DIFFERENT message — see `HeadCodec.h1_faithful?`.
       # `parse_*` refuses it anyway; checking here keeps the rules from running for nothing
@@ -365,36 +375,63 @@ module Gori::Proxy::H2
 
     # The stated cost of #526, kept spoken instead of silent.
     #
-    # The h2 downgrade gate (`tls/tunnel.cr#h2_candidate?`) is per CONNECT, so it can only ask
-    # about the CONNECT host. Since #526 it asks whether a BODY or SHORT-CIRCUIT rule matches
-    # THAT host — which is right for every stream whose `:authority` is that host, and every
-    # stream on a conformant connection is (gori's leaf carries a SAN of exactly the requested
-    # host, `tls/cert_builder.cr`, so a conformant client cannot coalesce onto one). A
-    # hand-rolled client can still coalesce, and then a rule scoped to the coalesced authority
-    # goes unapplied where the pre-#526 blanket downgrade would have caught it. Body rewriting
-    # and short-circuiting are both seams the relay cannot reach, so that failure is silent —
-    # the operator sees a request they stubbed reach the origin with nothing saying why.
+    # Every gate that can cost a connection its protocol (`tls/tunnel.cr#h2_candidate?`) is per
+    # CONNECT, so it can only ask about the CONNECT host. Since #526 it asks whether a rule the
+    # h2 relay cannot run matches THAT host — which is right for every stream whose `:authority`
+    # is that host, and every stream on a conformant connection is (gori's leaf carries a SAN of
+    # exactly the requested host, `tls/cert_builder.cr`, so a conformant client cannot coalesce
+    # onto one). A hand-rolled client can still coalesce, and then a rule scoped to the coalesced
+    # authority goes unapplied where the pre-#526 blanket downgrade would have caught it.
     #
-    # So: one line per connection, naming the authority and the connection host. Costs a string
-    # compare per request head on every normal connection (the authority IS the host, and that
-    # returns before any lock); only a genuinely coalesced stream reaches the rule lookup, and
-    # only until the line is written.
-    private def notice_coalesced(rw : Proxy::HeadRewriter, fields : Array(HPACK::Field)) : Nil
+    # Enforcement is right either way — a rule that cannot scope a stream must not fire on it —
+    # so what is wrong is only that it is SILENT: the operator sees a request they stubbed reach
+    # the origin, or `$SESSION` never bind, with nothing saying why.
+    #
+    # So: one line per connection, naming the authority, the connection host, and WHICH KIND of
+    # rule was skipped — three kinds now share this notice and they fail differently, so a line
+    # that did not name them would send the operator to the wrong rule table (#536). Costs a
+    # string compare per request head on every normal connection (the authority IS the host, and
+    # that returns before any lock); only a genuinely coalesced stream reaches the rule lookups,
+    # and only until the line is written.
+    private def notice_coalesced(fields : Array(HPACK::Field)) : Nil
       return if @warned_coalesced
       authority = HeadCodec.pseudo_of(fields, ":authority")
       return if authority.nil? || authority.empty?
       # `:authority` may carry a port; the gate asked about a bare host.
       host, _ = Upstream.split_host_port(authority, 0)
       return if host.compare(@host, case_insensitive: true) == 0
-      return unless rw.rewrites_body_for_host?(host) || rw.short_circuits_for_host?(host)
+      kinds = unreachable_kinds(host)
+      return if kinds.empty?
       @warned_coalesced = true
       ::Log.warn do
         "h2 #{@direction}: stream authority #{host.inspect} is not the CONNECT host " \
-        "#{@host.inspect} (RFC 9113 §9.1.1 coalescing) and a Match&Replace body or " \
-        "short-circuit rule matches it — those rules are NOT applied on the HTTP/2 relay, and " \
-        "the connection was not downgraded because no such rule matches #{@host.inspect}. " \
-        "Reach this host on its own connection to have them apply."
+        "#{@host.inspect} (RFC 9113 §9.1.1 coalescing), and it is matched by rules this relay " \
+        "cannot apply: #{kinds.join(", ")}. The connection was not downgraded because no such " \
+        "rule matches #{@host.inspect}, so they do not fire on this stream. Reach this host on " \
+        "its own connection to have them apply."
       end
+    end
+
+    # Which of the per-CONNECT gates would have wanted this stream — i.e. which host-scoped
+    # seams the h2 relay cannot reach have a live rule for the coalesced authority. Exactly the
+    # set `h2_candidate?` tests, asked about the authority instead of the CONNECT host, so the
+    # two cannot drift apart in what they consider unreachable.
+    #
+    # Only ever reached on a genuinely coalesced stream and only once per connection, so each
+    # predicate is free to take its lock (all three document themselves as once-per-CONNECT).
+    private def unreachable_kinds(host : String) : Array(String)
+      kinds = [] of String
+      if rw = @rewriter
+        kinds << "a Match&Replace BODY rule" if rw.rewrites_body_for_host?(host)
+        kinds << "a Match&Replace SHORT-CIRCUIT rule" if rw.short_circuits_for_host?(host)
+      end
+      # Head-scoped extraction is deliberately absent: `H2::Extract` reads the response head on
+      # this relay and scopes it on the stream's own request, so a cookie/header descriptor is
+      # applied correctly on a coalesced stream and has nothing to announce.
+      if @extractor.try(&.extracts_body_for_host?(host))
+        kinds << "a session-binding EXTRACT rule that reads the response body"
+      end
+      kinds
     end
 
     private def pairs(fields : Array(HPACK::Field)) : Array({String, String})

--- a/src/gori/proxy/h2/relay.cr
+++ b/src/gori/proxy/h2/relay.cr
@@ -66,9 +66,9 @@ module Gori::Proxy::H2
       ic = @interceptor
       return {nil, nil} unless ic
       out_gate = StreamGate.new("out", @upstream, conn_id, @sink, assembler, @host, @port, ic,
-        HeadRewrite.new("out", @rewriter, assembler, @host))
+        HeadRewrite.new("out", @rewriter, assembler, @host, @extractor))
       in_gate = StreamGate.new("in", @client, conn_id, @sink, assembler, @host, @port, ic,
-        HeadRewrite.new("in", @rewriter, assembler, @host), extract_for(assembler))
+        HeadRewrite.new("in", @rewriter, assembler, @host, @extractor), extract_for(assembler))
       out_gate.peer = in_gate
       in_gate.peer = out_gate
       {out_gate, in_gate}
@@ -109,7 +109,7 @@ module Gori::Proxy::H2
     private def pump_plain(src : IO, dst : IO, conn_id : Int64, direction : String,
                            assembler : Assembler) : Nil
       rw = @rewriter
-      heads = rw ? HeadRewrite.new(direction, rw, assembler, @host) : nil
+      heads = rw ? HeadRewrite.new(direction, rw, assembler, @host, @extractor) : nil
       extract = direction == "in" ? extract_for(assembler) : nil
       begin
         loop do


### PR DESCRIPTION
Closes #536.

`HeadRewrite#notice_coalesced` is the mitigation #531 added when it narrowed the h2 downgrade gate to host scope: the gate is per CONNECT, so a stream whose `:authority` is a different host (RFC 9113 §9.1.1 coalescing) can carry a rule the gate never got to ask about. It named two kinds — a Match&Replace body rule and a short-circuit rule.

#535's body-scoped session-binding extract rule is host-scoped through the same gate (`extracts_body_for_host?`, `tls/tunnel.cr#h2_candidate?`) and unreachable on this relay for the same reason, and it was not in that test. A coalesced stream whose authority the descriptor's glob matches went unextracted with nothing saying why — `$SESSION` simply never bound. #535 could not fix it there: `head_rewrite.cr` was owned by the parallel #500 step-2 worktree at the time.

**Enforcement was and is correct** — a rule that cannot scope a stream must not fire on it. This adds the announcement and nothing else.

## What changed

- `unreachable_kinds` is the set `h2_candidate?` tests, asked about the stream's authority instead of the CONNECT host, so the gate and the notice cannot drift apart in what they consider unreachable. HEAD-scoped extraction is deliberately absent: `H2::Extract` reads the response head on this relay and scopes it on the stream's own request, so a cookie/header descriptor is applied correctly on a coalesced stream and has nothing to announce.
- The line **names** the kinds it found. Three kinds now share one notice and they fail differently; a line that did not name them would send the operator to the wrong rule table.
- **The call moved out of `rewrite` and into `finish`.** It sat behind `rw.active?`, which was harmless while every kind it could name was a Match&Replace rule, and is exactly wrong now: an operator whose only rule is an extract descriptor has an INACTIVE rewriter, so the case this PR is about was the one case guaranteed to stay silent. The cheap authority-vs-host compare still returns before any rule lookup, so an ordinary stream pays one string compare as before.
- `Relay` passes `@extractor` to the head pipeline for this one question; it is read on the request side only, and extraction itself stays in `H2::Extract`.

```
h2 out: stream authority "alpha.test" is not the CONNECT host "localhost" (RFC 9113 §9.1.1
coalescing), and it is matched by rules this relay cannot apply: a Match&Replace SHORT-CIRCUIT
rule, a session-binding EXTRACT rule that reads the response body. The connection was not
downgraded because no such rule matches "localhost", so they do not fire on this stream. Reach
this host on its own connection to have them apply.
```

## Verification

Against the **built binary** (`gori run capture`) driven by a hand-rolled h2 client that coalesces — no conformant client can, because gori's leaf carries a SAN of exactly the requested host (`tls/cert_builder.cr`), so the client CONNECTs to `localhost` and then opens stream 1 with `:authority: alpha.test`:

| scenario | rule | result |
| --- | --- | --- |
| the bug | body-scoped extract `@alpha.test`, **no Match&Replace rule at all** | line appears, names the EXTRACT rule |
| both kinds | stub `@alpha.test` + body-scoped extract `@alpha.test` | one line, names both |
| regression | Match&Replace body rule `@alpha.test` | line appears, names the BODY rule |
| false positive | body-scoped extract `@beta.test` | silent |
| false positive | **head**-scoped (cookie) extract `@alpha.test` | silent |
| false positive | authority == CONNECT host | silent (the per-CONNECT gate downgraded it itself) |

**Control:** a build with the predicate reverted is silent on the identical traffic. At spec level, reverting the predicate fails 2 of the new examples and re-adding the `rw.active?` guard fails the "no Match&Replace rule" one.

`crystal spec` 5397 examples / 0 failures. `ameba` clean on the three touched files. `crystal build --no-codegen src/main.cr` green after `rebase origin/main`.
