### PR TITLE
feat(tui): register sitemap.open-flow so the tree can show its bytes (#539)

### DIFF
--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -497,6 +497,10 @@ class FakeExecContext < Gori::Verb::ExecContext
     rec(:sitemap_repeater)
   end
 
+  def sitemap_open_flow : Nil
+    rec(:sitemap_open_flow)
+  end
+
   def sitemap_mark_toggle : Nil
     rec(:sitemap_mark_toggle)
   end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -456,6 +456,10 @@ private class FakeContext < ExecContext
     @calls << :sitemap_repeater
   end
 
+  def sitemap_open_flow : Nil
+    @calls << :sitemap_open_flow
+  end
+
   def sitemap_mark_toggle : Nil
     @calls << :sitemap_mark_toggle
   end

--- a/spec/verbs/sitemap_spec.cr
+++ b/spec/verbs/sitemap_spec.cr
@@ -29,7 +29,28 @@ describe "Gori::Verbs.register_sitemap" do
      "sitemap.scope-toggle"    => :scope_toggle_lens,
      "sitemap.discover"        => :sitemap_discover,
      "sitemap.repeater"        => :sitemap_repeater,
+     "sitemap.open-flow"       => :sitemap_open_flow,
     }.each { |id, intent| verb_intents(r, id).should eq([intent]) }
+  end
+
+  # #539: the action existed nowhere — no chord, no registry entry — so the space menu could
+  # not reach the bytes behind a tree node. Registering it is what wires BOTH surfaces.
+  it "opens the selected endpoint's flow on `o`, and shows it in the action menu" do
+    verb = r["sitemap.open-flow"]
+    verb.chords.should eq([Gori::Verb::Chord.new("o")])
+    verb.hidden?.should be_false # else it reaches neither the space menu nor Help
+    verb.menu_key.should eq('o') # what for_scope+SpaceMenu need to render a row
+    # Same chord as the two siblings that make the same jump, so `o` means one thing.
+    r["issue.open-flow"].chords.should eq([Gori::Verb::Chord.new("o")])
+    r["probe.open-flow"].chords.should eq([Gori::Verb::Chord.new("o")])
+  end
+
+  # The space menu filters on available? while validate_menu_keys! does not, so an entry can
+  # pass boot validation and still never render. Assert the gate the MENU actually applies.
+  it "stays available in the Sitemap scope with no marks set (the space menu's own gate)" do
+    ctx = FakeExecContext.new
+    ctx.current_tab = :target
+    r["sitemap.open-flow"].available?(ctx).should be_true
   end
 
   it "gives the scope toggle an explicit 's' menu key (its only chord is ⇧S)" do

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -4595,10 +4595,10 @@ module Gori::Tui
 
     # Sitemap verbs that stay SINGLE-target even with marks set, and say so in their menu
     # hint. Discover is single by design (one config popup scans one start target under one
-    # host — see the multi-host refusal in runner/discover.cr) and the Sequencer collects one
-    # endpoint's token; the rest (query / fold / scope-lens) are selection-independent, so a
-    # cursor note there would be noise.
-    SITEMAP_CURSOR_ONLY = {"sitemap.discover", "sitemap.sequence"}
+    # host — see the multi-host refusal in runner/discover.cr), the Sequencer collects one
+    # endpoint's token, and a detail overlay shows one flow; the rest (query / fold /
+    # scope-lens) are selection-independent, so a cursor note there would be noise.
+    SITEMAP_CURSOR_ONLY = {"sitemap.discover", "sitemap.sequence", "sitemap.open-flow"}
 
     # Retitle the Sitemap's menu entries while marks are set, so the menu says what will
     # actually happen — "Tag 3 paths". MUST return nil when nothing is marked, so every

--- a/src/gori/tui/runner/sitemap.cr
+++ b/src/gori/tui/runner/sitemap.cr
@@ -63,6 +63,36 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     end
   end
 
+  # Open the bytes behind the cursor row. CROSS-TAB mediator: resolves the tree node through
+  # the store, then drives the History controller + detail overlay — exactly the hop
+  # issue_open_flow (runner/issues.cr) makes from an issue to its evidence.
+  #
+  # Deliberately NOT marked-set aware, unlike sitemap_repeater: a detail overlay shows one
+  # flow, so the cursor row is the only thing it could mean. It uses the same
+  # `selected_endpoint` resolve, so `o` and `r` never disagree about which path is under
+  # the cursor — including a `{uuid}` fold, which both resolve to a real descendant.
+  def sitemap_open_flow : Nil
+    ep = sitemap_controller.view.selected_endpoint
+    unless ep
+      @toast = "select an endpoint to open"
+      return
+    end
+    unless id = @session.store.representative_flow_id(ep[:host], ep[:method], ep[:target])
+      @toast = "no captured request for this path — capture it, or use Discover"
+      return
+    end
+    if history_controller.view.open_detail_id(id, @session.store)
+      @active_tab = :history
+      @focus = :body
+      @overlay = OverlayKind::Detail
+    else
+      # The resolve above just saw this id, so only a prune racing between the two reads
+      # lands here — say so rather than repeating "no captured request", which would read
+      # as "this path was never captured".
+      @toast = "that request was pruned since the tree was built"
+    end
+  end
+
   # Batch over the marks: one Repeater sub-tab per marked endpoint, capped (BATCH_SUBTAB_CAP)
   # like History's ^R. Nothing is SENT here — a Repeater session only fires on ^R — so this
   # just confirms the sub-tab count.

--- a/src/gori/verb/context/sitemap.cr
+++ b/src/gori/verb/context/sitemap.cr
@@ -10,6 +10,7 @@ abstract class Gori::Verb::ExecContext
   abstract def sitemap_tag : Nil             # tag the selected path — or every marked path — with a memo
   abstract def sitemap_toggle_grouping : Nil # fold/unfold numeric path-param sequences
   abstract def sitemap_repeater : Nil        # send the selected/marked endpoints to Repeater
+  abstract def sitemap_open_flow : Nil       # open the selected endpoint's captured flow in History
   # multi-select marks: the batch verbs above act on the marks if any are set, else the cursor row
   abstract def sitemap_mark_toggle : Nil                # flip the cursor row's mark, then step down
   abstract def sitemap_mark_clear : Nil                 # drop every mark

--- a/src/gori/verbs/sitemap.cr
+++ b/src/gori/verbs/sitemap.cr
@@ -93,6 +93,17 @@ module Gori
         "sitemap.discover", "Discover here", "Spider + brute-force the selected host or path subtree",
         Verb::Scope::Sitemap, [Verb::Chord.new("d")], mnemonic: 'd') { |ctx| ctx.sitemap_discover; nil }
 
+      # `o` — read the bytes behind the selected endpoint: resolve its representative captured
+      # flow and open History's detail on it. Same chord and same shape as the Issues tab's
+      # `issue.open-flow` (verbs/issues.cr) and Probe's `probe.open-flow` — "o opens the
+      # evidence" is now one gesture everywhere a list row stands in for a flow.
+      #
+      # Cursor-only even with marks set (SITEMAP_CURSOR_ONLY in runner.cr): a detail overlay
+      # shows one flow, so there is nothing for a batch to mean here.
+      r.register Verb::Definition.new(
+        "sitemap.open-flow", "Open flow", "Open the selected endpoint's captured request/response in History",
+        Verb::Scope::Sitemap, [Verb::Chord.new("o")], mnemonic: 'o') { |ctx| ctx.sitemap_open_flow; nil }
+
       # `r` — send the selected endpoint (or every marked one) to Repeater, resolving a
       # representative captured flow per path.
       r.register Verb::Definition.new(


### PR DESCRIPTION
The Sitemap tab could send an endpoint to Repeater, Discover or the Sequencer, but it could never just **show** the request behind a node. Both halves already existed — `store/reads.cr` `representative_flow_id(host, method, target)` resolves a tree node to a real flow id (already in production use by `sitemap.repeater`), and `history_view.cr` `open_detail_id` opens any flow regardless of the History list selection (already used that way by `runner/issues.cr:163`). This is the wiring between them.

Declared once as a `Verb::Definition`, which is what gives it the `o` chord **and** the space-menu entry from a single registration — P1, no private dispatch path. Same chord and same cross-tab shape as `issue.open-flow` and `probe.open-flow`, so "`o` opens the evidence" now means one thing everywhere a list row stands in for a flow.

It is cursor-only even with marks set (added to `SITEMAP_CURSOR_ONLY`): a detail overlay shows one flow, so a batch has nothing to mean here. The menu says "Open flow (cursor)" while marks are up, like Discover and the Sequencer already do.

Closes #539.

## Why `fuzz.repeater` is not here

This issue originally paired H4 with **Z4 (`fuzz.repeater`)** and described both as "hotkey-only, missing from the registry". That framing was wrong about Z4, and shipping it under an issue that calls it registration would carry the error forward. `fuzz.repeater` has no hotkey either — the action does not exist in the Fuzzer at all. The audit's "three lines copied from `runner/miner.cr:54`" reads as a registration task but is a feature build: the Miner sibling needs `miner_finding_selected?` + `mine_repeater_selected`, and the Fuzzer equivalent additionally needs `FuzzerView` internals exposed (`detail_request_bytes`, `selected_result`) plus a seed record — two more `ExecContext` abstracts and a new seam. Different size, different risk. It is split to **#540** and untouched here.

## One correction to the issue text

The issue says the action "is reachable by hotkey" and only missing from the registry. It was reachable by **nothing** — no chord existed either, which the audit's own H4 entry says correctly (`verbs/sitemap.cr:6-104` has no open-flow verb, and `SitemapController#handle_body_key` only handles `esc`). That does not change the fix — registering the verb is what creates both the chord and the menu entry — but there was no private dispatch path to remove.

The issue also expects the `Ctrl-P` palette to reach it. It does not, and should not: the palette is Global-scope-only by explicit design (`palette.cr:64`, `registry.cr:94-102` — "app control never clutters the space menu, and area actions never clutter the palette"). Verified live: neither `issue.open-flow` nor `sitemap.repeater` appears there either. Following the sibling means the space menu, which is the surface for area actions.

## Scope

One new `ExecContext` abstract (`sitemap_open_flow`), as the issue anticipated. Both doubles that break on a new abstract — `spec/verb/registry_spec.cr` and `spec/support/fake_context.cr` — are updated.

## Verified in a live TUI

tmux pty, isolated `GORI_HOME`, real proxied traffic through `bin/gori --port 19539`:

- **space menu** lists `o Open flow` on the Sitemap sub-tab, and pressing `o` there opens the detail on `GET /about HTTP/2`. This is the gate the brief flagged: the menu filters on `available?` while `validate_menu_keys!` does not, so passing boot validation would not have been proof. It renders.
- **`o` hotkey** with the tree body focused opens the same detail overlay; closing it lands on the History list with that row selected (`open_detail_id` syncs `@selected`), matching the Issues sibling.
- **marks set** → the entry retitles to `o Open flow (cursor)`; `r` still reads the marked set ("Send 2 paths to Repeater").
- **regressions**: `t` marks, `r` opens a Repeater sub-tab on `GET /about`, `/`, `g`, `⇧T` unchanged.
- **out of scope**: the Discover sub-tab's space menu does not list it, and `o` in the History body is a no-op — `command_scope` returns `Sitemap` only for that sub-tab, so no leak.

Full suite green (5399 examples, 0 failures) on the rebased result; `crystal build --no-codegen src/main.cr` clean; ameba clean on the three source files with real edits (`runner.cr`'s 21 findings are pre-existing and untouched — the edit there is one constant plus a comment).

## Noticed, not fixed — a pre-existing Sitemap resolve gap

While verifying, plain-HTTP proxied traffic would not resolve: the store keeps the wire `target`, which for an absolute-form proxy request line is `http://example.com/about`, while a Sitemap node builds `/about`, so `representative_flow_id` never matches. HTTPS (origin-form after CONNECT) resolves fine. This affects `sitemap.repeater` and `sitemap.sequence` identically and predates this change — `o` and `r` return the same "no captured request for this path" toast on the same row. Out of scope here; worth its own issue.
