### PR TITLE
feat(tui): show Rewriter on the tab bar by default, right of Comparer

### DIFF
--- a/docs/content/guide/_index.ko.md
+++ b/docs/content/guide/_index.ko.md
@@ -41,7 +41,6 @@ gori는 탭으로 구성됩니다. `[` / `]`로 탭 사이를 이동하거나 �
 | **Target** | Sitemap(host → path 엔드포인트 트리) + Discover(스파이더 & 디렉터리 브루트포스) |
 | **History** | 캡처(및 임포트)된 플로우와 전체 요청/응답 상세 |
 | **Intercept** | 요청/응답을 붙잡아 수동 판단을 대기 |
-| **Rewriter** | 이동 중인 트래픽을 재작성하는 Match & Replace 규칙 (기본 숨김) |
 | **Repeater** | 요청 워크벤치 (WebSocket 및 gRPC 모드 포함) |
 | **Fuzzer** | 네 가지 공격 모드를 갖춘 Intruder 스타일 Fuzzer |
 | **Miner** | 숨은 파라미터 탐색 (기본 숨김) |
@@ -50,9 +49,10 @@ gori는 탭으로 구성됩니다. `[` / `]`로 탭 사이를 이동하거나 �
 | **Decoder** | 인코드 / 디코드 / 해시 파이프라인 |
 | **JWT** | JSON Web Token 디코드, 재서명, 공격 (기본 숨김) |
 | **Comparer** | 두 플로우의 나란한 diff |
+| **Rewriter** | 이동 중인 트래픽을 재작성하는 Match & Replace 규칙 |
 | **Probe** | 패시브 및 light-touch 액티브 보안 스캐너 |
 | **Issues** | 심각도와 상태로 결과 트리아지 |
 | **Notes** | 프로젝트별 마크다운 노트 |
 | **Help** | 키 바인딩과 링크 |
 
-일부 탭(Rewriter, Miner, Sequencer, JWT)은 탭 바를 깔끔하게 유지하려고 새 설치에서 숨겨져 있습니다. 탭 바의 `⋯` 메뉴, 커맨드 팔레트, 또는 Preferences(`Ctrl-,`) → **Network & Tabs** → **Tabs**에서 언제든 다시 표시할 수 있습니다. 탭은 아니지만 전역적으로 작동하는 렌즈들도 있습니다. **capture**(`c`), **intercept**(`i`), **scope 렌즈**(`s`)는 어디서든 토글할 수 있습니다.
+일부 탭(Miner, Sequencer, JWT)은 탭 바를 깔끔하게 유지하려고 새 설치에서 숨겨져 있습니다. 탭 바의 `⋯` 메뉴, 커맨드 팔레트, 또는 Preferences(`Ctrl-,`) → **Network & Tabs** → **Tabs**에서 언제든 다시 표시할 수 있습니다. 탭은 아니지만 전역적으로 작동하는 렌즈들도 있습니다. **capture**(`c`), **intercept**(`i`), **scope 렌즈**(`s`)는 어디서든 토글할 수 있습니다.

--- a/docs/content/guide/_index.md
+++ b/docs/content/guide/_index.md
@@ -41,7 +41,6 @@ gori is organized into tabs; move between them with `[` / `]` or jump with numbe
 | **Target** | Sitemap (host → path endpoint tree) + Discover (spider & directory brute-force) |
 | **History** | Captured (and imported) flows with full request/response detail |
 | **Intercept** | Hold requests/responses for a manual decision |
-| **Rewriter** | Match & Replace rules that rewrite traffic in flight (hidden by default) |
 | **Repeater** | Request workbench (incl. WebSocket & gRPC modes) |
 | **Fuzzer** | Intruder-style fuzzer with four attack modes |
 | **Miner** | Hidden-parameter discovery (hidden by default) |
@@ -50,9 +49,10 @@ gori is organized into tabs; move between them with `[` / `]` or jump with numbe
 | **Decoder** | Encode / decode / hash pipeline |
 | **JWT** | Decode, re-sign, and attack JSON Web Tokens (hidden by default) |
 | **Comparer** | Side-by-side diff of two flows |
+| **Rewriter** | Match & Replace rules that rewrite traffic in flight |
 | **Probe** | Passive & light-touch active security scanner |
 | **Issues** | Triage results by severity and status |
 | **Notes** | Per-project Markdown notes |
 | **Help** | Key bindings and links |
 
-Some tabs are hidden on a fresh install (Rewriter, Miner, Sequencer, JWT) to keep the bar uncluttered; reveal any of them from the tab-bar `⋯` menu, the command palette, or Preferences (`Ctrl-,`) → **Network & Tabs** → **Tabs**. Global lenses that are not tabs: **capture** (`c`), **intercept** (`i`), and the **scope lens** (`s`) toggle from anywhere.
+Some tabs are hidden on a fresh install (Miner, Sequencer, JWT) to keep the bar uncluttered; reveal any of them from the tab-bar `⋯` menu, the command palette, or Preferences (`Ctrl-,`) → **Network & Tabs** → **Tabs**. Global lenses that are not tabs: **capture** (`c`), **intercept** (`i`), and the **scope lens** (`s`) toggle from anywhere.

--- a/docs/content/guide/proxy.ko.md
+++ b/docs/content/guide/proxy.ko.md
@@ -182,7 +182,7 @@ gori run history -q 'status:5xx host:api.example.com'
 
 ## Match & Replace (Rewriter 탭) {#match-replace}
 
-**Rewriter** 탭이 Match & Replace 편집기입니다. 이동 중인 요청/응답을 재작성하는 규칙을 관리합니다. 기본적으로 숨김 상태이므로 탭 바의 `⋯` 메뉴나 커맨드 팔레트(`Ctrl-P` → **Match & Replace** 또는 **Go to Rewriter**)로 엽니다.
+**Rewriter** 탭이 Match & Replace 편집기입니다. 이동 중인 요청/응답을 재작성하는 규칙을 관리합니다. 탭 바에서 Comparer 오른쪽에 있고, 커맨드 팔레트(`Ctrl-P` → **Match & Replace** 또는 **Go to Rewriter**)로도 열 수 있습니다.
 
 각 규칙에는 동작이 있습니다.
 

--- a/docs/content/guide/proxy.md
+++ b/docs/content/guide/proxy.md
@@ -182,7 +182,7 @@ Marks survive a filter change, a re-sort, and leaving the tab and coming back; t
 
 ## Match & Replace (Rewriter tab)
 
-The **Rewriter** tab is the Match & Replace editor: rules that rewrite requests and responses in flight. It is hidden by default, so reach it from the tab-bar `⋯` menu or the command palette (`Ctrl-P` → **Match & Replace**, or **Go to Rewriter**).
+The **Rewriter** tab is the Match & Replace editor: rules that rewrite requests and responses in flight. It sits on the tab bar right of Comparer, and the command palette reaches it too (`Ctrl-P` → **Match & Replace**, or **Go to Rewriter**).
 
 Each rule has an operation:
 

--- a/spec/tui/chrome_tabs_spec.cr
+++ b/spec/tui/chrome_tabs_spec.cr
@@ -14,7 +14,13 @@ describe "Chrome.reconcile" do
     out.find { |(s, _, _)| s == :miner }.not_nil![2].should be_false
     out.find { |(s, _, _)| s == :comparer }.not_nil![2].should be_true # now a default-visible tab
     out.find { |(s, _, _)| s == :decoder }.not_nil![2].should be_true  # now a default-visible tab
+    out.find { |(s, _, _)| s == :rewriter }.not_nil![2].should be_true # now a default-visible tab
     out.find { |(s, _, _)| s == :project }.not_nil![2].should be_true
+  end
+
+  it "places Rewriter immediately right of Comparer" do
+    order = Chrome.reconcile([] of {String, Bool}).map(&.first)
+    order.index(:rewriter).not_nil!.should eq(order.index(:comparer).not_nil! + 1)
   end
 
   it "honors a stored order and visibility, inserting absent catalog tabs at their position" do
@@ -86,7 +92,7 @@ end
 describe "Chrome.hidden_tabs" do
   it "returns the tabs hidden from the bar (Miner + Sequencer + JWT by default) on empty prefs" do
     hid = Chrome.hidden_tabs([] of {String, Bool}).map(&.first)
-    hid.should eq([:rewriter, :miner, :sequencer, :jwt]) # the default-hidden tabs, in catalog order
+    hid.should eq([:miner, :sequencer, :jwt]) # the default-hidden tabs, in catalog order
   end
 
   it "excludes the active tab even when its stored visibility is false (it's force-shown)" do

--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -11,7 +11,6 @@ module Gori::Tui
       {:target, "Target"},
       {:history, "History"},
       {:intercept, "Intercept"},
-      {:rewriter, "Rewriter"},
       {:repeater, "Repeater"},
       {:fuzzer, "Fuzzer"},
       {:miner, "Miner"},
@@ -20,6 +19,7 @@ module Gori::Tui
       {:decoder, "Decoder"},
       {:jwt, "JWT"},
       {:comparer, "Comparer"},
+      {:rewriter, "Rewriter"},
       {:probe, "Probe"},
       {:issues, "Issues"},
       {:notes, "Notes"},
@@ -29,7 +29,7 @@ module Gori::Tui
     # Tabs hidden by default on a fresh install (re-enableable in settings:tabs). Only
     # affects reconcile's append path — once the user saves, tab_prefs is explicit and
     # this no longer applies.
-    DEFAULT_HIDDEN = [:miner, :sequencer, :jwt, :rewriter]
+    DEFAULT_HIDDEN = [:miner, :sequencer, :jwt]
 
     # The human sidebar label for a tab symbol (the catalog name), used off the render
     # path too — e.g. the terminal-window title. Falls back to a capitalized symbol for


### PR DESCRIPTION
## What

Rewriter is now a default-visible tab, positioned immediately right of Comparer.

- `Chrome::TABS` — moved `{:rewriter, "Rewriter"}` from after Intercept to after Comparer.
- `Chrome::DEFAULT_HIDDEN` — dropped `:rewriter`, now `[:miner, :sequencer, :jwt]`.

## Why

The Match & Replace editor was tucked behind the `⋯` menu, so reaching it meant a palette jump or a settings edit. It belongs on the bar next to the other analysis-side tabs.

## Compatibility

`Chrome.reconcile` still lets a stored order and visibility win, so an operator who already customized `settings:tabs` keeps their layout (hand edits are never clobbered). Only installs that never touched the setting pick up the new default; the rest can flip it in Preferences → **Network & Tabs** → **Tabs**.

## Verification

- `crystal build --no-codegen src/main.cr` clean.
- `crystal spec` — 5409 examples, 8 failures, all the pre-existing `capture_status` / `project_registry` port-binding failures from a gori already listening on the host.
- New spec locks Rewriter's default visibility and its position immediately right of Comparer; the `hidden_tabs` expectation was updated.
- Ran the built TUI under tmux: bar renders `… Decoder  Comparer  Rewriter  Probe …  ⋯ 3`, and `^P → Go to Rewriter` opens Match & Replace in place.

## Docs

Guide tab table (EN + KO) reordered with the "hidden by default" note removed, fresh-install hidden list trimmed, and the `proxy.md` / `proxy.ko.md` "reach it from the ⋯ menu" paragraph replaced with the new location.