### PR TITLE
feat(tui): send a fuzz result to the Repeater (#540)

### DIFF
--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -461,6 +461,16 @@ class FakeExecContext < Gori::Verb::ExecContext
     rec(:mine_repeater_selected)
   end
 
+  property? fuzzer_has_result = false
+
+  def fuzzer_result_selected? : Bool
+    @fuzzer_has_result
+  end
+
+  def fuzz_repeater_selected : Nil
+    rec(:fuzz_repeater_selected)
+  end
+
   def sitemap_move(delta : Int32) : Nil
     rec(:sitemap_move, delta)
   end

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -446,6 +446,35 @@ describe Gori::Tui::FuzzerView do
     end
   end
 
+  describe "result_request_bytes (detail pane + Send to Repeater, #540)" do
+    it "hands back the bytes the engine actually sent when the run retained them" do
+      view = loaded_fuzzer
+      sent = "GET /?x=SENT HTTP/1.1\r\nHost: h\r\n\r\n"
+      view.append_result(Gori::Fuzz::Result.new(0_i64, ["p0"], nil, 200, 1200_i64, 40, 5, 1000_i64,
+        nil, true, false, nil, "HTTP/1.1 200 OK\r\n\r\n".to_slice, Bytes.empty, sent.to_slice))
+      r = view.selected_result.not_nil!
+      String.new(view.result_request_bytes(r)).should eq(sent)
+
+      # …and the detail's REQUEST pane reads from the same method, so what the operator
+      # sees is what "Send to Repeater" hands over.
+      view.open_detail
+      view.detail_step_pane(-1) # :response → :request
+      backend = MemoryBackend.new(120, 30)
+      view.render(Screen.new(backend), Rect.new(0, 0, 120, 30))
+      backend.contains?("GET /?x=SENT HTTP/1.1").should be_true
+    end
+
+    it "falls back to re-rendering the template when the row's request was not retained" do
+      view = FuzzerView.new
+      view.load_request("https://h", "GET /?x=§1§ HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
+      view.append_result(fuzz_result(0, 404, 12)) # keep_bodies dropped head/body/request
+      r = view.selected_result.not_nil!
+      # The marked position takes the row's payload, so the row still reads as its own
+      # request. The editor holds LF text; the Repeater seed re-expands to CRLF on send.
+      String.new(view.result_request_bytes(r)).should eq("GET /?x=p0 HTTP/1.1\nHost: h\n\n")
+    end
+  end
+
   it "hscroll_detail scrolls a long RESULT response line sideways into view (shift+←/→)" do
     view = loaded_fuzzer
     long_line = "HEAD" + ("." * 100) + "TAIL"

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -420,6 +420,14 @@ private class FakeContext < ExecContext
     @calls << :mine_repeater_selected
   end
 
+  def fuzzer_result_selected? : Bool
+    false
+  end
+
+  def fuzz_repeater_selected : Nil
+    @calls << :fuzz_repeater_selected
+  end
+
   def sitemap_move(delta : Int32) : Nil
     @calls << :sitemap_move
   end

--- a/spec/verbs/history_spec.cr
+++ b/spec/verbs/history_spec.cr
@@ -303,6 +303,17 @@ describe "Gori::Verbs.register_history" do
       end
     end
 
+    it "gates 'Send to Repeater' on a selected result, not just the Fuzzer tab" do
+      ctx = on(:fuzzer)
+      r["fuzz.repeater"].available?(ctx).should be_false
+      ctx.fuzzer_has_result = true
+      r["fuzz.repeater"].available?(ctx).should be_true
+      other_tab = on(:miner)
+      other_tab.fuzzer_has_result = true
+      r["fuzz.repeater"].available?(other_tab).should be_false
+      verb_intents(r, "fuzz.repeater").should eq([:fuzz_repeater_selected])
+    end
+
     it "shares one sub-tab search/filter counter across the workbench tabs" do
       ctx = on(:fuzzer)
       ctx.subtab_search_tab_count = 2

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -930,6 +930,34 @@ module Gori::Tui
       @host.status("duplicated fuzz session (#{@fuzzers.size} open)")
     end
 
+    # Seed handed to RepeaterController for "Send to Repeater" (a fuzz result row → the
+    # request that produced it). Same shape as MinerController::RepeaterSeed.
+    record RepeaterSeed,
+      target : String,
+      request_text : String,
+      http2 : Bool,
+      sni : String?,
+      label : String # sub-tab chip + toast ("#index payload")
+
+    # True when the focused session has a result row under the cursor (gates space →
+    # Send to Repeater): no run yet, or a filter that hides every row, means no request
+    # to hand over.
+    def result_selected? : Bool
+      !current_view.try(&.selected_result).nil?
+    end
+
+    # The selected result as a Repeater-ready request; nil when nothing is selected.
+    def selected_repeater_seed : RepeaterSeed?
+      return nil unless v = current_view
+      return nil unless r = v.selected_result
+      # Repeater editors store LF text; send expands back to CRLF (RepeaterView#expanded_text_to_bytes).
+      # Same LF shape as History→Repeater (origin_form_text) and the Miner path.
+      text = String.new(v.result_request_bytes(r)).scrub.gsub("\r\n", "\n")
+      payload = r.payloads.join(", ")
+      payload = "#{payload[0, 23]}…" if payload.size > 24
+      RepeaterSeed.new(v.target_origin, text, v.http2?, v.sni_override, "##{r.index} #{payload}".rstrip)
+    end
+
     # ⇧I from History (or Issues evidence): open a captured flow as a fuzz session.
     def fuzz_flow(id : Int64) : Nil
       return unless detail = @host.session.store.get_flow(id)

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -951,7 +951,7 @@ module Gori::Tui
         sources: @sets.map { |s| build_source(s) }, config: @config, matcher: @matcher,
         verify: verify, sni: sni_override, overrides: overrides)
       plan = Fuzz::Plan.build(options, Gori::Outbound.interactive(scope))
-      @pending_template = plan.template # committed to @run_template in begin_run (see detail_request_bytes)
+      @pending_template = plan.template # committed to @run_template in begin_run (see result_request_bytes)
       {plan.engine, nil}
     rescue ex : Fuzz::PlanError
       {nil, fuzz_plan_error(ex)}
@@ -1132,7 +1132,7 @@ module Gori::Tui
       end
       return if @decoded_index == r.index # already decoded this row
       @decoded_index = r.index
-      req = detail_request_bytes(r)
+      req = result_request_bytes(r)
       off, sep_w = req_head_end(req)
       req_head = off ? req[0, off] : req
       req_body = off ? req[(off + sep_w)..] : Bytes.empty
@@ -2153,16 +2153,27 @@ module Gori::Tui
       styled
     end
 
-    # The reconstructed wire request for a result (template with its payloads spliced in).
-    private def detail_request_bytes(r : Fuzz::Result) : Bytes
-      # Render against the run's frozen template (env-expanded, as sent) so a post-run
-      # edit to the live buffer can't truncate/garble the reconstructed request.
+    # The wire request for a result — what the detail pane shows and what "Send to
+    # Repeater" hands over (see FuzzerController#selected_repeater_seed), so the two can
+    # never disagree. Public because the controller needs it for a row the operator
+    # picked in the results table, not just for the open detail.
+    #
+    # `Result#request` is the byte-exact request the engine sent (Job#bytes: payload
+    # chains applied, Content-Length synced), retained under the run's keep_bodies
+    # policy. When it wasn't retained (:none, or :matched and this row missed) fall back
+    # to re-rendering the run's frozen template — env-expanded as sent, so a post-run
+    # edit to the live buffer can't truncate/garble it — which reproduces everything but
+    # the per-position chain transform and the CL sync.
+    def result_request_bytes(r : Fuzz::Result) : Bytes
+      if sent = r.request
+        return sent
+      end
       tmpl = @run_template || Fuzz::Template.parse(Env.expand(@editor.text), @http2)
       tmpl.render(r.payloads)
     end
 
     private def detail_request_lines(r : Fuzz::Result) : Array(String)
-      String.new(detail_request_bytes(r)).scrub.split('\n').map(&.rstrip('\r'))
+      String.new(result_request_bytes(r)).scrub.split('\n').map(&.rstrip('\r'))
     end
 
     private def detail_response_lines(r : Fuzz::Result) : Array(String)

--- a/src/gori/tui/runner/fuzzer.cr
+++ b/src/gori/tui/runner/fuzzer.cr
@@ -92,4 +92,18 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
   def fuzzer_read_mode? : Bool
     fuzzer_controller.fuzzer_read_mode?
   end
+
+  def fuzzer_result_selected? : Bool
+    fuzzer_controller.result_selected?
+  end
+
+  # CROSS-TAB: open the selected fuzz result's request in Repeater (the Miner's
+  # mine_repeater_selected, for a result row instead of a finding).
+  def fuzz_repeater_selected : Nil
+    seed = fuzzer_controller.selected_repeater_seed
+    return (@toast = "select a result first") unless seed
+    repeater_controller.repeater_from_request(seed.target, seed.request_text, seed.http2, seed.sni,
+      name: seed.label)
+    @toast = "repeater ← fuzz: #{seed.label}"
+  end
 end

--- a/src/gori/verb/context/fuzzer.cr
+++ b/src/gori/verb/context/fuzzer.cr
@@ -5,19 +5,21 @@ abstract class Gori::Verb::ExecContext
   abstract def fuzz_toggle_http2 : Nil # flip the fuzz transport h1↔h2 (override seed protocol)
 
   # fuzzer workbench (run/stop/marking handled inline; these power the palette + cross-tab)
-  abstract def fuzz_selected : Nil           # send History's selection to the Fuzzer tab
-  abstract def fuzz_from_repeater : Nil      # turn the current Repeater request into a fuzz template
-  abstract def fuzz_run : Nil                # start the fuzz run
-  abstract def fuzz_stop : Nil               # stop the running fuzz
-  abstract def fuzz_new : Nil                # open a blank fuzz session
-  abstract def fuzz_automark : Nil           # auto-mark every request parameter
-  abstract def fuzz_attach_chain : Nil       # open the chain-edit prompt for the marker at the template cursor
-  abstract def fuzz_list_paste : Nil         # open the payload-set editor pre-seeded to a List (multi-line, one value per line)
-  abstract def fuzz_clear_marks : Nil        # strip all §…§ markers (and their chains) from the template
-  abstract def fuzzer_rename_subtab : Nil    # open the rename prompt for the active sub-tab
-  abstract def fuzzer_close_subtab : Nil     # close the active sub-tab (confirm-gated)
-  abstract def fuzzer_duplicate_subtab : Nil # clone the active sub-tab's content into a new sibling
-  abstract def fuzzer_copy : Nil             # copy selection or current line (READ panes)
-  abstract def fuzzer_copy_all : Nil         # copy the whole focused pane text
-  abstract def fuzzer_read_mode? : Bool      # focused pane is READ (y/copy verbs gate on this)
+  abstract def fuzz_selected : Nil            # send History's selection to the Fuzzer tab
+  abstract def fuzz_from_repeater : Nil       # turn the current Repeater request into a fuzz template
+  abstract def fuzz_run : Nil                 # start the fuzz run
+  abstract def fuzz_stop : Nil                # stop the running fuzz
+  abstract def fuzz_new : Nil                 # open a blank fuzz session
+  abstract def fuzz_automark : Nil            # auto-mark every request parameter
+  abstract def fuzz_attach_chain : Nil        # open the chain-edit prompt for the marker at the template cursor
+  abstract def fuzz_list_paste : Nil          # open the payload-set editor pre-seeded to a List (multi-line, one value per line)
+  abstract def fuzz_clear_marks : Nil         # strip all §…§ markers (and their chains) from the template
+  abstract def fuzzer_rename_subtab : Nil     # open the rename prompt for the active sub-tab
+  abstract def fuzzer_close_subtab : Nil      # close the active sub-tab (confirm-gated)
+  abstract def fuzzer_duplicate_subtab : Nil  # clone the active sub-tab's content into a new sibling
+  abstract def fuzzer_copy : Nil              # copy selection or current line (READ panes)
+  abstract def fuzzer_copy_all : Nil          # copy the whole focused pane text
+  abstract def fuzzer_read_mode? : Bool       # focused pane is READ (y/copy verbs gate on this)
+  abstract def fuzzer_result_selected? : Bool # a result row is selected in the focused fuzz session
+  abstract def fuzz_repeater_selected : Nil   # send the selected fuzz result's request to Repeater
 end

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -446,10 +446,23 @@ module Gori
       r.register Verb::Definition.new(
         "fuzz.stop", "Stop fuzz", "Stop the running fuzz", Verb::Scope::Fuzzer,
         [Verb::Chord.new("x", ctrl: true)], available: in_fuzzer, mnemonic: 's') { |ctx| ctx.fuzz_stop; nil }
+      # Send the selected result row (the request that produced it) to Repeater — the
+      # Miner's mine.repeater for a fuzz result; gated on a selected row so it hides
+      # before the first run. COMMON like the Miner's, so it survives the detail
+      # overlay (FuzzerView#focus goes to :detail, which a section :results entry
+      # would not reach). 'p' is the sibling's key but is taken here by
+      # fuzz.pretty-template (:template, and every section view includes COMMON), so
+      # 'R' — the letter the other tabs use for Repeater, free in Fuzzer.
+      r.register Verb::Definition.new(
+        "fuzz.repeater", "Send to Repeater", "Open the selected result's request in Repeater (payload spliced in)",
+        Verb::Scope::Fuzzer,
+        available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :fuzzer && ctx.fuzzer_result_selected? },
+        mnemonic: 'R') { |ctx| ctx.fuzz_repeater_selected; nil }
       # COMMON (Round 5), not :tab: New-session is a top action the user reaches for
       # from anywhere in the Fuzzer tab, not just the tab bar — mirrors repeater.new
       # (Repeater) and decoder.new (Decoder, Round 4a), both :common. Fuzzer's COMMON
-      # is now curated most-used-first: Run, Stop, New, Copy, Link-issue, Link-note.
+      # is now curated most-used-first: Run, Stop, Send-to-Repeater, New, Copy,
+      # Link-issue, Link-note.
       r.register Verb::Definition.new(
         "fuzz.new", "New fuzz session", "Open a blank fuzz template", Verb::Scope::Fuzzer,
         [Verb::Chord.new("n", ctrl: true)],


### PR DESCRIPTION
Closes #540

The Miner can take a selected finding into the Repeater. The Fuzzer could not — and this was not a missing registration: **the action did not exist**, by hotkey or otherwise. The two tabs are the same shape of tool (send many probes, read a results table, work the interesting row by hand), so they should not disagree about whether that last step is reachable.

## The design call: which request gets sent

**The bytes the engine actually put on the wire**, not the template.

`Fuzz::Result#request` is `Job#bytes` — the template rendered with this row's payloads, with the per-position decoder chain applied and Content-Length synced. That is what the sender was handed. The operator picks a row *because of the response it produced*, so the Repeater has to open the request that produced it; anything else means the first `^R` in the Repeater sends something the row never saw. It is also what the Fuzzer already does when it hands a result to another subsystem: `FuzzerController#probe_scan_fuzz_result` builds its synthetic `RepeaterRecord` from `result.request`.

Two consequences worth stating:

- **Fallback.** `Result#request` is only retained under the run's `keep_bodies` policy (`:all`, or `:matched` and this row matched). When it was not retained, the seed falls back to re-rendering the run's *frozen* template with the row's payloads — exactly the reconstruction the detail pane was already showing. Gating the action on retention instead would hide it on most rows of a default `:matched` run, which is the opposite of the point. The reconstruction reproduces everything but the chain transform and the CL sync.
- **The two surfaces now share one method.** `detail_request_bytes` became the public `result_request_bytes` and prefers `Result#request` the same way, so the detail pane and the Repeater seed can never show different bytes. Before this, a template with a `¦chain` marker rendered the *untransformed* payload in the detail pane even when the exact sent bytes were sitting on the result. One line, and it removes the "what I read is not what I sent" gap in both places at once.

Env layering is unchanged: `Job#bytes` is pre-`Env.expand_bindings` (the engine expands bindings inside `send`), which is the same layer a Repeater editor holds, so a rotating binding re-expands on the next send rather than being frozen into the tab.

## What it took

- Two `ExecContext` abstracts, `fuzzer_result_selected?` / `fuzz_repeater_selected`, following the Miner's noun-for-predicate / verb-for-action split (`miner_finding_selected?` / `mine_repeater_selected`). The issue wrote the predicate as `fuzz_result_selected?`; `fuzzer_` matches both the sibling and this file's own `fuzzer_read_mode?`.
- `FuzzerController::RepeaterSeed` + `result_selected?` + `selected_repeater_seed`, same shape as `MinerController`'s.
- `FuzzerView#result_request_bytes` public (`selected_result` was already public, contrary to the issue).
- `fuzz.repeater` registered after `fuzz.stop`, mirroring `mine.repeater`'s position after `mine.stop`.
- Both spec doubles updated (`spec/support/fake_context.cr`, `spec/verb/registry_spec.cr`).

**Mnemonic is `R`, not the Miner's `p`.** Every section view is `COMMON + <section>`, and `fuzz.pretty-template` already claims `p` in `:template` — a COMMON `p` collides at boot. `R` is the letter the other tabs use for Repeater (`history.repeater`, `sitemap.repeater`) and is free across every Fuzzer section; uppercase menu keys are established here (`T`, `Y`, `A`, `X`, `O`, `S`).

**COMMON, not `section: :results`.** `FuzzerView#focus` becomes `:detail` when a row is opened, so a `:results` entry would vanish exactly when the operator is reading the row they want to send. COMMON also matches the Miner's own reasoning.

## Verification

Built TUI, tmux + isolated `GORI_HOME`, fuzzing a local server with a 3-value list on `/?x=§1§`:

- **Before any run** — the Fuzzer space menu shows `r/s/n/y/k/u` and no Send-to-Repeater. The `available?` gate holds (and the space menu filters on `available?` while `validate_menu_keys!` does not, so this was checked on screen, not at boot).
- **After the run** — `R Send to Repeater` renders in COMMON between `s Stop fuzz` and `n New fuzz session`, alongside `p Pretty-print template` in the TEMPLATE section. No collision.
- **Selection is honoured** — with row `#2 ccc` selected (not the default row 0), `R` opened a Repeater sub-tab chipped `#2 ccc`, toast `repeater ← fuzz: #2 ccc`, request `GET /?x=ccc HTTP/1.1`, target `http://127.0.0.1:19541`. `^R` in the Repeater sent it: 200.
- **Frozen template** — the seed was correct after the live template buffer had been edited post-run.
- **Miner** — its space menu is unchanged, and with 0 findings its own Send-to-Repeater is correctly absent. No Miner file is touched by this PR.

`crystal spec`: 5411 examples, 8 failures — the 8 pre-existing `capture_status` / `project_registry` failures from a gori already bound to :8070, identical on `main`. `crystal build --no-codegen src/main.cr` clean after rebase. `crystal tool format` and ameba on touched files only; ameba reports 12 findings across them, all pre-existing (none on an added line).