### PR TITLE
docs: dedicated wide README hero shot of History + Space menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ HTTP/2, WebSocket, gRPC, and SSE, and intercept in flight on HTTP/1.1 and HTTP/2
 also a `gori run` subcommand and an MCP tool, so scripts and AI agents can drive the same
 engagement.
 
-![](docs/static/images/tui/history.svg)
+![gori TUI — History with the Space menu open](docs/static/images/tui/readme.svg)
 
 <details>
 <summary><strong>Features</strong></summary>

--- a/docs/static/images/tui/readme.svg
+++ b/docs/static/images/tui/readme.svg
@@ -1,0 +1,465 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1638" height="736" viewBox="0 0 1638.0 736.0" font-family="ui-monospace,'SF Mono','JetBrains Mono',Menlo,Consolas,monospace" font-size="15.0px" role="img" aria-label="gori · History · Space menu">
+<rect x="0.5" y="0.5" width="1637.0" height="735.0" rx="10" ry="10" fill="#0a0a0b" stroke="#313132" stroke-width="1"/>
+<rect x="1" y="1" width="1636.0" height="34.0" rx="10" ry="10" fill="#19191a"/>
+<rect x="1" y="24.0" width="1636.0" height="10" fill="#19191a"/>
+<circle cx="18.0" cy="17.0" r="5.5" fill="#e0645f"/>
+<circle cx="34.0" cy="17.0" r="5.5" fill="#e0b24f"/>
+<circle cx="50.0" cy="17.0" r="5.5" fill="#4fb06a"/>
+<text x="819.0" y="22.0" text-anchor="middle" fill="#919191" font-size="12.3px">gori · History · Space menu</text>
+<rect x="216.00" y="106.00" width="81.00" height="18.00" fill="#19191c"/>
+<rect x="45.00" y="196.00" width="1566.00" height="18.00" fill="#26262c"/>
+<rect x="1359.00" y="376.00" width="252.00" height="18.00" fill="#141417"/>
+<rect x="1359.00" y="394.00" width="9.00" height="18.00" fill="#141417"/>
+<rect x="1368.00" y="394.00" width="234.00" height="18.00" fill="#26262c"/>
+<rect x="1602.00" y="394.00" width="9.00" height="18.00" fill="#141417"/>
+<rect x="1359.00" y="412.00" width="252.00" height="18.00" fill="#141417"/>
+<rect x="1359.00" y="430.00" width="252.00" height="18.00" fill="#141417"/>
+<rect x="1359.00" y="448.00" width="252.00" height="18.00" fill="#141417"/>
+<rect x="1359.00" y="466.00" width="252.00" height="18.00" fill="#141417"/>
+<rect x="1359.00" y="484.00" width="252.00" height="18.00" fill="#141417"/>
+<rect x="1359.00" y="502.00" width="252.00" height="18.00" fill="#141417"/>
+<rect x="1359.00" y="520.00" width="252.00" height="18.00" fill="#141417"/>
+<rect x="1359.00" y="538.00" width="252.00" height="18.00" fill="#141417"/>
+<rect x="1359.00" y="556.00" width="252.00" height="18.00" fill="#141417"/>
+<rect x="1359.00" y="574.00" width="252.00" height="18.00" fill="#141417"/>
+<rect x="1359.00" y="592.00" width="252.00" height="18.00" fill="#141417"/>
+<rect x="1359.00" y="610.00" width="252.00" height="18.00" fill="#141417"/>
+<rect x="1359.00" y="628.00" width="252.00" height="18.00" fill="#141417"/>
+<rect x="1359.00" y="646.00" width="252.00" height="18.00" fill="#141417"/>
+<rect x="1359.00" y="664.00" width="252.00" height="18.00" fill="#141417"/>
+<rect x="1359.00" y="682.00" width="252.00" height="18.00" fill="#141417"/>
+<rect x="36.00" y="700.00" width="63.00" height="18.00" fill="#1b1b1f"/>
+<rect x="99.00" y="700.00" width="1521.00" height="18.00" fill="#141417"/>
+<text x="45.00" y="83.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" font-weight="700" xml:space="preserve">𝓰𝓸𝓻𝓲</text>
+<text x="90.00" y="83.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">·</text>
+<text x="108.00" y="83.68" textLength="63.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">default</text>
+<text x="1143.00" y="83.68" textLength="81.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">scope:off</text>
+<text x="1233.00" y="83.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">·</text>
+<text x="1251.00" y="83.68" textLength="117.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" xml:space="preserve">probe:passive</text>
+<text x="1377.00" y="83.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">·</text>
+<text x="1395.00" y="83.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">●</text>
+<text x="1413.00" y="83.68" textLength="126.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">localhost:8070</text>
+<text x="1548.00" y="83.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">·</text>
+<text x="1566.00" y="83.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">⌘</text>
+<text x="1584.00" y="83.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">·</text>
+<text x="1602.00" y="83.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">⚙</text>
+<text x="36.00" y="101.68" textLength="1584.00" lengthAdjust="spacingAndGlyphs" fill="#2a2a30" xml:space="preserve">────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────</text>
+<text x="54.00" y="119.68" textLength="63.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">Project</text>
+<text x="144.00" y="119.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">Target</text>
+<text x="225.00" y="119.68" textLength="63.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" font-weight="700" xml:space="preserve">History</text>
+<text x="315.00" y="119.68" textLength="81.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">Intercept</text>
+<text x="423.00" y="119.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">Repeater</text>
+<text x="522.00" y="119.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">Fuzzer</text>
+<text x="603.00" y="119.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">OAST</text>
+<text x="666.00" y="119.68" textLength="63.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">Decoder</text>
+<text x="756.00" y="119.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">Comparer</text>
+<text x="855.00" y="119.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">Rewriter</text>
+<text x="954.00" y="119.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">Probe</text>
+<text x="1026.00" y="119.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">Issues</text>
+<text x="1107.00" y="119.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">Notes</text>
+<text x="1179.00" y="119.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">Help</text>
+<text x="1584.00" y="119.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">⋯</text>
+<text x="1602.00" y="119.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">3</text>
+<text x="36.00" y="137.68" textLength="1584.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮</text>
+<text x="36.00" y="155.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="155.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">/</text>
+<text x="72.00" y="155.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">filter</text>
+<text x="144.00" y="155.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">·</text>
+<text x="171.00" y="155.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">host:</text>
+<text x="234.00" y="155.68" textLength="63.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">method:</text>
+<text x="315.00" y="155.68" textLength="108.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">status:&gt;=500</text>
+<text x="441.00" y="155.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">proto:ws</text>
+<text x="531.00" y="155.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">path:</text>
+<text x="594.00" y="155.68" textLength="99.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">size:&gt;10000</text>
+<text x="711.00" y="155.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">dur:&gt;500</text>
+<text x="801.00" y="155.68" textLength="63.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">header:</text>
+<text x="882.00" y="155.68" textLength="90.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">body~regex</text>
+<text x="1413.00" y="155.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" xml:space="preserve">f:follow</text>
+<text x="1494.00" y="155.68" textLength="18.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">⇧S</text>
+<text x="1521.00" y="155.68" textLength="81.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">scope:off</text>
+<text x="1611.00" y="155.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="173.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="173.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">TIME</text>
+<text x="189.00" y="173.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">METHOD</text>
+<text x="261.00" y="173.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">PROTO</text>
+<text x="324.00" y="173.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HOST</text>
+<text x="693.00" y="173.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">PATH</text>
+<text x="1395.00" y="173.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">STA</text>
+<text x="1431.00" y="173.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">TYPE</text>
+<text x="1494.00" y="173.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">SIZE</text>
+<text x="1557.00" y="173.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">DUR</text>
+<text x="1611.00" y="173.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="191.68" textLength="1584.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤</text>
+<text x="36.00" y="209.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="45.00" y="209.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" xml:space="preserve">▎</text>
+<text x="54.00" y="209.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="209.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:23</text>
+<text x="189.00" y="209.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">GET</text>
+<text x="261.00" y="209.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="209.68" textLength="99.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" xml:space="preserve">example.com</text>
+<text x="693.00" y="209.68" textLength="99.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" xml:space="preserve">/robots.txt</text>
+<text x="1395.00" y="209.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#d6a13a" xml:space="preserve">404</text>
+<text x="1431.00" y="209.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">html</text>
+<text x="1494.00" y="209.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">718B</text>
+<text x="1557.00" y="209.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">19ms</text>
+<text x="1611.00" y="209.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="227.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="227.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="227.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:23</text>
+<text x="189.00" y="227.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">GET</text>
+<text x="261.00" y="227.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="227.68" textLength="126.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">api.github.com</text>
+<text x="693.00" y="227.68" textLength="99.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/rate_limit</text>
+<text x="1395.00" y="227.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">200</text>
+<text x="1431.00" y="227.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">json</text>
+<text x="1494.00" y="227.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">1.6KB</text>
+<text x="1557.00" y="227.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">10ms</text>
+<text x="1611.00" y="227.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="245.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="245.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="245.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:23</text>
+<text x="189.00" y="245.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">GET</text>
+<text x="261.00" y="245.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="245.68" textLength="126.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">api.github.com</text>
+<text x="693.00" y="245.68" textLength="162.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/repos/hahwul/gori</text>
+<text x="1395.00" y="245.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">200</text>
+<text x="1431.00" y="245.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">json</text>
+<text x="1494.00" y="245.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">6.7KB</text>
+<text x="1557.00" y="245.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">238ms</text>
+<text x="1611.00" y="245.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="263.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="263.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="263.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:23</text>
+<text x="189.00" y="263.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">GET</text>
+<text x="261.00" y="263.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="263.68" textLength="117.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">httpbingo.org</text>
+<text x="693.00" y="263.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/uuid</text>
+<text x="1395.00" y="263.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">200</text>
+<text x="1431.00" y="263.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">json</text>
+<text x="1494.00" y="263.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">352B</text>
+<text x="1557.00" y="263.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">209ms</text>
+<text x="1611.00" y="263.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="281.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="281.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="281.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:22</text>
+<text x="189.00" y="281.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">GET</text>
+<text x="261.00" y="281.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="281.68" textLength="117.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">httpbingo.org</text>
+<text x="693.00" y="281.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/html</text>
+<text x="1395.00" y="281.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">200</text>
+<text x="1431.00" y="281.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">html</text>
+<text x="1494.00" y="281.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">3.9KB</text>
+<text x="1557.00" y="281.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">205ms</text>
+<text x="1611.00" y="281.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="299.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="299.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="299.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:22</text>
+<text x="189.00" y="299.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">GET</text>
+<text x="261.00" y="299.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="299.68" textLength="117.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">httpbingo.org</text>
+<text x="693.00" y="299.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/gzip</text>
+<text x="1395.00" y="299.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">200</text>
+<text x="1431.00" y="299.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">json</text>
+<text x="1494.00" y="299.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">605B</text>
+<text x="1557.00" y="299.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">174ms</text>
+<text x="1611.00" y="299.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="317.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="317.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="317.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:22</text>
+<text x="189.00" y="317.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">GET</text>
+<text x="261.00" y="317.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="317.68" textLength="117.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">httpbingo.org</text>
+<text x="693.00" y="317.68" textLength="99.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/redirect/1</text>
+<text x="1395.00" y="317.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" xml:space="preserve">302</text>
+<text x="1431.00" y="317.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">—</text>
+<text x="1494.00" y="317.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">267B</text>
+<text x="1557.00" y="317.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">172ms</text>
+<text x="1611.00" y="317.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="335.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="335.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="335.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:22</text>
+<text x="189.00" y="335.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">GET</text>
+<text x="261.00" y="335.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="335.68" textLength="117.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">httpbingo.org</text>
+<text x="693.00" y="335.68" textLength="99.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/status/404</text>
+<text x="1395.00" y="335.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#d6a13a" xml:space="preserve">404</text>
+<text x="1431.00" y="335.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">text</text>
+<text x="1494.00" y="335.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">292B</text>
+<text x="1557.00" y="335.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">169ms</text>
+<text x="1611.00" y="335.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="353.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="353.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="353.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:21</text>
+<text x="189.00" y="353.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">GET</text>
+<text x="261.00" y="353.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="353.68" textLength="117.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">httpbingo.org</text>
+<text x="693.00" y="353.68" textLength="99.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/status/403</text>
+<text x="1395.00" y="353.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#d6a13a" xml:space="preserve">403</text>
+<text x="1431.00" y="353.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">text</text>
+<text x="1494.00" y="353.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">292B</text>
+<text x="1557.00" y="353.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">169ms</text>
+<text x="1611.00" y="353.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="371.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="371.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="371.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:21</text>
+<text x="189.00" y="371.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">GET</text>
+<text x="261.00" y="371.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="371.68" textLength="117.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">httpbingo.org</text>
+<text x="693.00" y="371.68" textLength="99.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/status/401</text>
+<text x="1395.00" y="371.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#d6a13a" xml:space="preserve">401</text>
+<text x="1431.00" y="371.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">text</text>
+<text x="1494.00" y="371.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">336B</text>
+<text x="1557.00" y="371.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">170ms</text>
+<text x="1611.00" y="371.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="389.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="389.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="389.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:21</text>
+<text x="189.00" y="389.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">GET</text>
+<text x="261.00" y="389.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="389.68" textLength="117.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">httpbingo.org</text>
+<text x="693.00" y="389.68" textLength="297.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/anything/admin/config?debug=true</text>
+<text x="1359.00" y="389.68" textLength="18.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">╭─</text>
+<text x="1386.00" y="389.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" font-weight="700" xml:space="preserve">SPACE</text>
+<text x="1440.00" y="389.68" textLength="171.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">──────────────────╮</text>
+<text x="1611.00" y="389.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="407.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="407.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="407.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:21</text>
+<text x="189.00" y="407.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#d6a13a" xml:space="preserve">DELETE</text>
+<text x="261.00" y="407.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="407.68" textLength="117.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">httpbingo.org</text>
+<text x="693.00" y="407.68" textLength="261.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/anything/api/sessions/8f3a1c</text>
+<text x="1359.00" y="407.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1368.00" y="407.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" xml:space="preserve">▎</text>
+<text x="1377.00" y="407.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" font-weight="700" xml:space="preserve">h</text>
+<text x="1395.00" y="407.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" xml:space="preserve">Add</text>
+<text x="1431.00" y="407.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" xml:space="preserve">host</text>
+<text x="1476.00" y="407.68" textLength="18.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" xml:space="preserve">to</text>
+<text x="1503.00" y="407.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" xml:space="preserve">scope</text>
+<text x="1602.00" y="407.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1611.00" y="407.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="425.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="425.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="425.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:20</text>
+<text x="189.00" y="425.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#d6a13a" xml:space="preserve">PUT</text>
+<text x="261.00" y="425.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="425.68" textLength="117.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">httpbingo.org</text>
+<text x="693.00" y="425.68" textLength="198.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/anything/api/users/42</text>
+<text x="1359.00" y="425.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1377.00" y="425.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" font-weight="700" xml:space="preserve">s</text>
+<text x="1395.00" y="425.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">Toggle</text>
+<text x="1458.00" y="425.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">scope</text>
+<text x="1512.00" y="425.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">lens</text>
+<text x="1575.00" y="425.68" textLength="18.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">⇧S</text>
+<text x="1602.00" y="425.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1611.00" y="425.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="443.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="443.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="443.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:20</text>
+<text x="189.00" y="443.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">GET</text>
+<text x="261.00" y="443.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="443.68" textLength="117.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">httpbingo.org</text>
+<text x="693.00" y="443.68" textLength="252.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/anything/api/v2/orders/9182</text>
+<text x="1359.00" y="443.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1377.00" y="443.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" font-weight="700" xml:space="preserve">o</text>
+<text x="1395.00" y="443.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">Open</text>
+<text x="1440.00" y="443.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">flow</text>
+<text x="1485.00" y="443.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">detail</text>
+<text x="1584.00" y="443.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">↵</text>
+<text x="1602.00" y="443.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1611.00" y="443.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="461.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="461.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="461.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:20</text>
+<text x="189.00" y="461.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">GET</text>
+<text x="261.00" y="461.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="461.68" textLength="117.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">httpbingo.org</text>
+<text x="693.00" y="461.68" textLength="396.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/anything/api/v2/orders?status=paid&amp;limit=50</text>
+<text x="1359.00" y="461.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1377.00" y="461.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" font-weight="700" xml:space="preserve">/</text>
+<text x="1395.00" y="461.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">Filter</text>
+<text x="1458.00" y="461.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">(QL)</text>
+<text x="1602.00" y="461.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1611.00" y="461.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="479.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="479.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="479.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:16</text>
+<text x="189.00" y="479.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">GET</text>
+<text x="261.00" y="479.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="479.68" textLength="99.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">example.com</text>
+<text x="693.00" y="479.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/</text>
+<text x="1359.00" y="479.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1377.00" y="479.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" font-weight="700" xml:space="preserve">f</text>
+<text x="1395.00" y="479.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">Toggle</text>
+<text x="1458.00" y="479.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">follow</text>
+<text x="1602.00" y="479.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1611.00" y="479.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="497.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="497.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="497.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:16</text>
+<text x="189.00" y="497.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">GET</text>
+<text x="261.00" y="497.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="497.68" textLength="117.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">httpbingo.org</text>
+<text x="693.00" y="497.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/json</text>
+<text x="1359.00" y="497.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1377.00" y="497.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" font-weight="700" xml:space="preserve">t</text>
+<text x="1395.00" y="497.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">Mark</text>
+<text x="1440.00" y="497.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">flow</text>
+<text x="1602.00" y="497.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1611.00" y="497.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="515.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="515.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="515.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:15</text>
+<text x="189.00" y="515.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">GET</text>
+<text x="261.00" y="515.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="515.68" textLength="117.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">httpbingo.org</text>
+<text x="693.00" y="515.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/headers</text>
+<text x="1359.00" y="515.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1377.00" y="515.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" font-weight="700" xml:space="preserve">T</text>
+<text x="1395.00" y="515.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">Mark</text>
+<text x="1440.00" y="515.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">all</text>
+<text x="1476.00" y="515.68" textLength="90.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">(filtered)</text>
+<text x="1575.00" y="515.68" textLength="18.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">⇧T</text>
+<text x="1602.00" y="515.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1611.00" y="515.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="533.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="533.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="533.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:15</text>
+<text x="189.00" y="533.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">GET</text>
+<text x="261.00" y="533.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="533.68" textLength="117.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">httpbingo.org</text>
+<text x="693.00" y="533.68" textLength="99.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/user-agent</text>
+<text x="1359.00" y="533.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1377.00" y="533.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" font-weight="700" xml:space="preserve">y</text>
+<text x="1395.00" y="533.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">Copy</text>
+<text x="1440.00" y="533.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">flow</text>
+<text x="1602.00" y="533.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1611.00" y="533.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="551.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="551.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="551.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:15</text>
+<text x="189.00" y="551.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#d6a13a" xml:space="preserve">POST</text>
+<text x="261.00" y="551.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="551.68" textLength="117.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">httpbingo.org</text>
+<text x="693.00" y="551.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/post</text>
+<text x="1359.00" y="551.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1377.00" y="551.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" font-weight="700" xml:space="preserve">Y</text>
+<text x="1395.00" y="551.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">Copy</text>
+<text x="1440.00" y="551.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">as…</text>
+<text x="1602.00" y="551.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1611.00" y="551.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="569.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="569.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="569.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:14</text>
+<text x="189.00" y="569.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">GET</text>
+<text x="261.00" y="569.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="569.68" textLength="117.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">httpbingo.org</text>
+<text x="693.00" y="569.68" textLength="99.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/status/500</text>
+<text x="1359.00" y="569.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1377.00" y="569.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" font-weight="700" xml:space="preserve">r</text>
+<text x="1395.00" y="569.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">Repeater</text>
+<text x="1476.00" y="569.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">flow</text>
+<text x="1575.00" y="569.68" textLength="18.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">^R</text>
+<text x="1602.00" y="569.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1611.00" y="569.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="587.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="587.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="587.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:14</text>
+<text x="189.00" y="587.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">GET</text>
+<text x="261.00" y="587.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="587.68" textLength="117.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">httpbingo.org</text>
+<text x="693.00" y="587.68" textLength="243.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/cookies/set?session=8f3a1c</text>
+<text x="1359.00" y="587.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1377.00" y="587.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" font-weight="700" xml:space="preserve">d</text>
+<text x="1395.00" y="587.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">Discover</text>
+<text x="1476.00" y="587.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">from</text>
+<text x="1521.00" y="587.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">flow</text>
+<text x="1602.00" y="587.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1611.00" y="587.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="605.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="605.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="605.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:14</text>
+<text x="189.00" y="605.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">GET</text>
+<text x="261.00" y="605.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="605.68" textLength="126.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">api.github.com</text>
+<text x="693.00" y="605.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/zen</text>
+<text x="1359.00" y="605.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1377.00" y="605.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" font-weight="700" xml:space="preserve">c</text>
+<text x="1395.00" y="605.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">Send</text>
+<text x="1440.00" y="605.68" textLength="18.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">to</text>
+<text x="1467.00" y="605.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">Comparer</text>
+<text x="1602.00" y="605.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1611.00" y="605.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="623.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="623.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="623.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:14</text>
+<text x="189.00" y="623.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">GET</text>
+<text x="261.00" y="623.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="623.68" textLength="126.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">api.github.com</text>
+<text x="693.00" y="623.68" textLength="117.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/users/hahwul</text>
+<text x="1359.00" y="623.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1377.00" y="623.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" font-weight="700" xml:space="preserve">A</text>
+<text x="1395.00" y="623.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">Run</text>
+<text x="1431.00" y="623.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">active</text>
+<text x="1494.00" y="623.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">scan</text>
+<text x="1602.00" y="623.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1611.00" y="623.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="641.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="641.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="641.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:13</text>
+<text x="189.00" y="641.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">GET</text>
+<text x="261.00" y="641.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="641.68" textLength="117.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">httpbingo.org</text>
+<text x="693.00" y="641.68" textLength="315.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/get?search=admin&amp;page=2&amp;debug=true</text>
+<text x="1359.00" y="641.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1377.00" y="641.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" font-weight="700" xml:space="preserve">X</text>
+<text x="1395.00" y="641.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">Delete</text>
+<text x="1458.00" y="641.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">flow</text>
+<text x="1602.00" y="641.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1611.00" y="641.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="659.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="54.00" y="659.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">07-31</text>
+<text x="108.00" y="659.68" textLength="72.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">18:50:13</text>
+<text x="189.00" y="659.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#52c77a" xml:space="preserve">GET</text>
+<text x="261.00" y="659.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">HTTPS</text>
+<text x="324.00" y="659.68" textLength="117.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">httpbingo.org</text>
+<text x="693.00" y="659.68" textLength="324.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">/anything/api/users?role=admin&amp;id=42</text>
+<text x="1359.00" y="659.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1377.00" y="659.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" font-weight="700" xml:space="preserve">C</text>
+<text x="1395.00" y="659.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">Clear</text>
+<text x="1449.00" y="659.68" textLength="63.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">history</text>
+<text x="1602.00" y="659.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1611.00" y="659.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="677.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="1359.00" y="677.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1377.00" y="677.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" font-weight="700" xml:space="preserve">k</text>
+<text x="1395.00" y="677.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">Link</text>
+<text x="1440.00" y="677.68" textLength="18.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">to</text>
+<text x="1467.00" y="677.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#c8c8cc" xml:space="preserve">issue</text>
+<text x="1593.00" y="677.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">▼</text>
+<text x="1602.00" y="677.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">│</text>
+<text x="1611.00" y="677.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">│</text>
+<text x="36.00" y="695.68" textLength="1323.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────</text>
+<text x="1359.00" y="695.68" textLength="252.00" lengthAdjust="spacingAndGlyphs" fill="#3a3a42" xml:space="preserve">╰──────────────────────────╯</text>
+<text x="1611.00" y="695.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">╯</text>
+<text x="45.00" y="713.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" font-weight="700" xml:space="preserve">SPACE</text>
+<text x="108.00" y="713.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">press</text>
+<text x="162.00" y="713.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">a</text>
+<text x="180.00" y="713.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">key</text>
+<text x="216.00" y="713.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">·</text>
+<text x="234.00" y="713.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">↑/↓</text>
+<text x="270.00" y="713.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">select</text>
+<text x="333.00" y="713.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">·</text>
+<text x="351.00" y="713.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">↵</text>
+<text x="369.00" y="713.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">run</text>
+<text x="405.00" y="713.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">·</text>
+<text x="423.00" y="713.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">esc</text>
+<text x="459.00" y="713.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">close</text>
+<text x="1386.00" y="713.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">CPU</text>
+<text x="1422.00" y="713.68" textLength="18.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">2%</text>
+<text x="1449.00" y="713.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">MEM</text>
+<text x="1485.00" y="713.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">22M</text>
+<text x="1521.00" y="713.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">·</text>
+<text x="1539.00" y="713.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">06:50</text>
+<text x="1593.00" y="713.68" textLength="18.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">PM</text>
+</svg>

--- a/docs/tools/tui-capture/README.md
+++ b/docs/tools/tui-capture/README.md
@@ -32,10 +32,21 @@ docs/tools/tui-capture/capture.sh  # writes docs/static/images/tui/*.svg
 
 Requirements: `bash`, `tmux`, `python3`, `curl`, `sqlite3`.
 
+Set `ONLY` to shoot a subset of the three groups (`scenes themes readme`):
+
+```bash
+ONLY=readme docs/tools/tui-capture/capture.sh   # just the README hero
+```
+
 Captures are reproducible but not pixel-identical run to run (timestamps,
 durations, and live response bodies vary), so eyeball the output before
 committing. The theme gallery on the Themes page (`theme-<name>.svg`) is shot in
 the same run by `shoot_themes` — the History scene under each gallery palette.
+
+`readme.svg` is its own shot (`shoot_readme`), not part of the doc set: the
+repo README renders one image edge to edge with no sidebar, so it uses a much
+wider 180x38 pane and tops the throwaway project up with extra traffic first.
+It runs last, so the doc scenes above keep the smaller, stable flow set.
 
 ## Render a single frame by hand
 

--- a/docs/tools/tui-capture/capture.sh
+++ b/docs/tools/tui-capture/capture.sh
@@ -16,6 +16,8 @@
 # Env:    SHOTS="theme:subdir …"   which palettes to shoot and where under tui/.
 #           default: "goridark: goriday:light"  (dark → tui/, light → tui/light/)
 #           e.g. SHOTS="goriday:light" to refresh only the light set.
+#         ONLY="scenes themes readme"  which groups to shoot (default: all three).
+#           e.g. ONLY=readme to refresh just the README hero shot.
 #
 # The captures are deliberately reproducible but not pixel-identical run to run
 # (timestamps, durations, and live response bodies vary). Eyeball the output.
@@ -30,6 +32,8 @@ OUT="$TUI_ROOT"
 # 132 columns reads as a real full-width terminal in the docs; at the old 104
 # the SVGs scaled up chunky ("zoomed-in screenshot" feel) in the content column.
 COLS=132 ROWS=26 PORT=8091
+ONLY="${ONLY:-scenes themes readme}"
+want() { case " $ONLY " in *" $1 "*) return 0;; *) return 1;; esac; }
 
 [ -x "$GORI" ] || { echo "gori binary not found/executable at $GORI (run 'shards build' first)"; exit 1; }
 command -v tmux >/dev/null || { echo "tmux is required"; exit 1; }
@@ -87,10 +91,12 @@ done
 # Launches `gori <subcmd>` in a fresh tmux pane, optionally walks the project
 # picker preamble, sends the keys, and renders the capture to SVG. Interleave
 # the literal token SLEEP<seconds> to pause between keys.
+# Set SHOT_COLS for a single call to widen that pane beyond the default $COLS.
 _shoot() {
   local name="$1" rows="$2" title="$3" subcmd="$4" preamble="$5"; shift 5
+  local cols="${SHOT_COLS:-$COLS}"
   tmux kill-session -t goricap 2>/dev/null || true
-  TERM=xterm-256color tmux new-session -d -s goricap -x "$COLS" -y "$rows"
+  TERM=xterm-256color tmux new-session -d -s goricap -x "$cols" -y "$rows"
   tmux send-keys -t goricap \
     "cd $REPO && clear && GORI_HOME=$GORI_HOME TERM=xterm-256color '$GORI' $subcmd 2>/dev/null" C-m
   sleep 3
@@ -162,19 +168,66 @@ shoot_themes() {
   done
 }
 
+# Extra traffic on top of seed_all, so the README's taller History pane reads as
+# a working engagement instead of a dozen rows over a lot of empty space. Only
+# the README shot wants these, and it runs last, so the doc scenes above keep
+# the smaller, stable flow set.
+seed_readme_extra() {
+  seed "https://httpbingo.org/anything/api/v2/orders?status=paid&limit=50"
+  seed "https://httpbingo.org/anything/api/v2/orders/9182"
+  seed -X PUT -H 'Content-Type: application/json' -d '{"role":"editor"}' https://httpbingo.org/anything/api/users/42
+  seed -X DELETE https://httpbingo.org/anything/api/sessions/8f3a1c
+  seed "https://httpbingo.org/anything/admin/config?debug=true"
+  seed https://httpbingo.org/status/401
+  seed https://httpbingo.org/status/403
+  seed https://httpbingo.org/status/404
+  seed https://httpbingo.org/redirect/1
+  seed https://httpbingo.org/gzip
+  seed https://httpbingo.org/html
+  seed https://httpbingo.org/uuid
+  seed https://api.github.com/repos/hahwul/gori
+  seed https://api.github.com/rate_limit
+  seed https://example.com/robots.txt
+}
+
+# The README hero (readme.svg): History with the Space menu open, shot on a much
+# wider pane than the doc scenes. The README renders one image edge to edge with
+# no sidebar, so the 132x26 doc geometry reads as a cramped little window there;
+# 180x38 fills the width and still lands near a 2:1 card.
+shoot_readme() {
+  OUT="$TUI_ROOT"
+  write_settings goridark
+  echo "▸ topping up the throwaway project for the README shot…"
+  "$GORI" run capture --listen 127.0.0.1 --port "$PORT" >/dev/null 2>&1 &
+  local cap=$!; sleep 2
+  seed_readme_extra
+  sleep 1; kill "$cap" 2>/dev/null || true; sleep 1
+  SHOT_COLS=180 run_scene readme 38 "gori · History · Space menu" \
+    3 SLEEP1 Down SLEEP0.3 Space SLEEP1.2
+}
+
 # One pass per "theme:subdir" spec in $SHOTS. The seeded DB is shared across
 # passes; only the theme in settings.json changes between them, so the light and
 # dark galleries show the same flows.
-for spec in $SHOTS; do
-  theme="${spec%%:*}" subdir="${spec#*:}"
-  OUT="$TUI_ROOT${subdir:+/$subdir}"
-  write_settings "$theme"
-  mkdir -p "$OUT"
-  echo "▸ capturing $theme → $OUT"
-  shoot_all
-done
+if want scenes; then
+  for spec in $SHOTS; do
+    theme="${spec%%:*}" subdir="${spec#*:}"
+    OUT="$TUI_ROOT${subdir:+/$subdir}"
+    write_settings "$theme"
+    mkdir -p "$OUT"
+    echo "▸ capturing $theme → $OUT"
+    shoot_all
+  done
+fi
 
-echo "▸ capturing the theme gallery → $TUI_ROOT/theme-*.svg"
-shoot_themes
+if want themes; then
+  echo "▸ capturing the theme gallery → $TUI_ROOT/theme-*.svg"
+  shoot_themes
+fi
+
+if want readme; then
+  echo "▸ capturing the README hero → $TUI_ROOT/readme.svg"
+  shoot_readme
+fi
 
 echo "▸ done. Review the SVGs under $TUI_ROOT"


### PR DESCRIPTION
The README renders one image edge to edge with no sidebar, so the 132x26 doc-scene geometry read as a cramped little window there. This gives the README its own capture instead of reusing `tui/history.svg`.

**`docs/static/images/tui/readme.svg`** — a real TUI capture on a 180x38 pane, showing the **History** tab with the **Space** menu open over a fuller flow list.

### Changes
- `README.md` — points at `tui/readme.svg` (+ alt text). `tui/history.svg` stays; the docs still use it.
- `docs/tools/tui-capture/capture.sh`
  - `_shoot` takes a per-shot `SHOT_COLS` override so one scene can widen its pane
  - `seed_readme_extra` + `shoot_readme`; it runs last, so the doc scenes above keep their smaller, stable flow set
  - `ONLY="scenes themes readme"` selects which groups to shoot — `ONLY=readme docs/tools/tui-capture/capture.sh` refreshes just the hero
- `docs/tools/tui-capture/README.md` — documents both

Docs and capture tooling only; no Crystal code touched. The SVG was regenerated by actually running the script and eyeballed as a render.