### PR TITLE
feat(tui): size Miss Ring's bubble to the terminal, not to a flat 34 columns

### DIFF
--- a/spec/tui/pet_spec.cr
+++ b/spec/tui/pet_spec.cr
@@ -570,6 +570,35 @@ describe Gori::Tui::Pet do
       end
     end
 
+    # The bubble used to stop growing at 34 columns, so a notice was cut with an '…' on an
+    # 80-column terminal that had twice that free. Sweep the widths a real Layout produces
+    # rather than pinning one number: the guarantees are monotonicity, the floor, the
+    # ceiling, and never crossing the body.
+    it "widens the bubble cap with the body, between its floor and its ceiling" do
+      caps = [40, 60, 80, 100, 120, 160, 220].map do |cols|
+        Pet.bubble_cap(Layout.compute(cols, 24).body.w)
+      end
+      caps.should eq(caps.sort)                         # never narrower on a wider terminal
+      caps.first.should eq(Pet::BUBBLE_BASE_W)          # the narrow end keeps today's width
+      caps.last.should eq(Pet::BUBBLE_MAX_W)            # …and a huge terminal stops at the ceiling
+      Pet.bubble_cap(76).should be > Pet::BUBBLE_BASE_W # 80 cols, where she is actually read
+    end
+
+    # The fluid cap must not outgrow the narrow bodies the floor is above: at 40x24 the body
+    # is 36, and BUBBLE_BASE_W alone would overhang it.
+    it "keeps a wide bubble inside the body, floor included" do
+      [40, 80, 120, 200].each do |cols|
+        # NOT `body` — an `it` block closes over the describe-level local, and assigning to
+        # it here would hand every later example a 200-column body on an 80x24 backend.
+        wide = Layout.compute(cols, 24).body
+        plate = Pet.place(wide).not_nil!
+        box = Pet.bubble_box(wide, plate, "probe " * 60).not_nil!
+        box.x.should be >= wide.x
+        box.right.should be <= wide.right
+        box.w.should be <= Pet.bubble_cap(wide.w)
+      end
+    end
+
     it "truncates a long bubble inside the body" do
       backend = MemoryBackend.new(80, 24)
       long = "probe " * 60

--- a/src/gori/tui/pet.cr
+++ b/src/gori/tui/pet.cr
@@ -86,7 +86,17 @@ module Gori::Tui
 
     BUBBLE_H     =  3
     BUBBLE_MIN_W = 14 # narrower than this is unreadable — drop the bubble, keep the pose
-    BUBBLE_MAX_W = 34
+    # The bubble's cap is FLUID: it tracks the body, floored at BUBBLE_BASE_W and ceilinged
+    # at BUBBLE_MAX_W. A flat cap sized for the narrow case truncated notices with an '…'
+    # on terminals with columns to spare, which is where most of her lines actually get
+    # read. BUBBLE_SHARE is the slice of the body she may claim — she draws OVER the tab's
+    # content, so a note is never worth more than a comfortable minority of the row, and
+    # past ~60 columns a one-line bubble stops reading as speech and starts reading as a
+    # banner. body.w - 4 still wins over all of it (see .bubble_box).
+    BUBBLE_BASE_W  = 34
+    BUBBLE_MAX_W   = 64
+    BUBBLE_SHARE_N =  2
+    BUBBLE_SHARE_D =  3
 
     getter frame : Mascot::Frame?
     # When the live bubble was set. The bar placement shares the status row's single text
@@ -417,11 +427,18 @@ module Gori::Tui
       Rect.new(x, y, Mascot::W, Mascot::H)
     end
 
+    # How wide she may speak in a body this wide, BEFORE the body's own `- 4` clamp. Pure
+    # arithmetic on a width so a spec can sweep it without a Screen.
+    def self.bubble_cap(body_w : Int32) : Int32
+      share = body_w * BUBBLE_SHARE_N // BUBBLE_SHARE_D
+      share.clamp(BUBBLE_BASE_W, BUBBLE_MAX_W)
+    end
+
     # Above the sprite, right-aligned to it, tail pointing down at her cap. Above rather
     # than beside because the body's right edge is a pane border or a scroll gauge, and a
     # side bubble would cover the list rows the user is actually reading.
     def self.bubble_box(body : Rect, plate : Rect, msg : String) : Rect?
-      cap = {BUBBLE_MAX_W, body.w - 4}.min
+      cap = {bubble_cap(body.w), body.w - 4}.min
       return nil if cap < BUBBLE_MIN_W
       want = {Screen.display_width(msg) + 4, BUBBLE_MIN_W}.max
       w = {want, cap}.min


### PR DESCRIPTION
## What

Miss Ring's speech bubble was capped at a fixed **34 columns**, sized for the narrow case. On a terminal with columns to spare — which is where most of her lines actually get read — notices were cut with an `…`.

The cap is now **fluid**: two thirds of the body width, floored at the old 34 and ceilinged at 64.

- floor 34 → narrow terminals render exactly as before
- ceiling 64 → past that a one-line bubble reads as a banner, not as speech
- the existing `body.w - 4` clamp still wins over all of it, so the narrowest body a real `Layout` can hand her (36, at 40x24) is unchanged

```
== 80 cols (cap 34 -> 50)
│ fuzz job finished: 412 requests, 3 interestin… │

== 120 cols (cap 34 -> 64)
│ fuzz job finished: 412 requests, 3 interesting responses │
```

The `bar` placement is untouched — there she speaks through the status row, which already tracks the terminal width.

## How

`Pet.bubble_cap(body_w)` is a pure function of the width (`(w * 2/3).clamp(34, 64)`), so specs can sweep it without a `Screen`. `BUBBLE_MAX_W` split into `BUBBLE_BASE_W` / `BUBBLE_MAX_W` / `BUBBLE_SHARE_N|D`.

## Test

Two specs added, driven by guarantees rather than by pinned numbers:

- the cap is monotonic across the widths a real `Layout` produces, hits the floor at the narrow end and the ceiling at the wide end
- a long bubble stays inside the body at 40 / 80 / 120 / 200 columns, floor included

`crystal spec spec/tui` → 1614 examples, 0 failures. `crystal build --no-codegen src/main.cr` clean; ameba clean on both touched files.