### PR TITLE
fix(h2,probe): connection flow control, six deferred items, and real-binary verification of #549

### DIFF
--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -2056,6 +2056,46 @@ describe "Gori::Probe::Active (safety + coverage)" do
     end
   end
 
+  # `scan_repeaters` had no budget at all, so an MCP `probe_scan active:true` could send far
+  # past its own PROBE_ACTIVE_MAX_FLOWS: repeater tabs are unbounded and the rule set costs 33
+  # requests per tab (47 aggressive). The cap now covers the whole scan.
+  it "spends ONE active budget across flows and repeater tabs" do
+    with_store do |store|
+      capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/a?token=aaaaaaaa", content_type: nil)
+      store.insert_repeater("http://acme.test/r", "GET /r?token=cccccccc HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice,
+        false, true, nil, 0)
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "acme.test")
+      ids = Gori::Probe::Scan.flow_ids(store, nil)
+
+      budget = Gori::Probe::Scan::Budget.new(0)
+      Gori::Probe::Scan.scan_all(store, ids, active: true, scope: scope, active_budget: budget)
+      # Nothing was sent, so the cap was reached — which is the question `active_flows_capped`
+      # should answer, rather than `ids.size > limit` on a pre-filter count.
+      budget.exhausted?.should be_true
+    end
+  end
+
+  # The disabled-rule set is the only thing between an ACTIVE rule the operator switched off
+  # and a real request. Its read used to degrade to an EMPTY set — "nothing is disabled" — on
+  # a store error, which is a fail-OPEN on the half of this config that authorises traffic.
+  it "skips ACTIVE probing when the disabled-rule list could not be read" do
+    with_store do |store|
+      capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/a?token=aaaaaaaa", content_type: nil)
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "acme.test")
+      ids = Gori::Probe::Scan.flow_ids(store, nil)
+      degraded = Gori::Probe::Scan::RuleConfig.new(Set(String).new, [] of Gori::Probe::CustomRule, degraded: true)
+      said = [] of String
+      dets = Gori::Probe::Scan.scan_all(store, ids, active: true, scope: scope, rules: degraded,
+        on_error: ->(where : String, ex : Exception) { said << "#{where}: #{ex.message}"; nil })[0]
+      # It is NAMED, not silent — a scan that quietly stopped probing would read as clean.
+      said.first.should contain("active probing was skipped")
+      # …and the request-free passive half still ran.
+      dets.count { |d| d.code == "secret_in_url" }.should eq(1)
+    end
+  end
+
   it "sends active probes when the scope ALLOWLISTS the target" do
     with_store do |store|
       detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?q=hi", content_type: nil)

--- a/spec/proxy/h2/stream_gate_spec.cr
+++ b/spec/proxy/h2/stream_gate_spec.cr
@@ -748,11 +748,13 @@ describe Gori::Proxy::H2::StreamGate do
       # Fail-open must not overrule a decision already in flight — forwarding a request the
       # operator dropped is the one outcome worse than holding it.
       rig.to_origin.should be_empty
-      # RST_STREAM is what this example is about. A WINDOW_UPDATE rides alongside it now
-      # (the dropped stream's ~1 MiB of parked DATA is credit the client is owed back), so
-      # assert the RST rather than the exact frame list.
-      rig.to_client.map(&.frame_type).should contain(Frame::Type::RstStream)
-      rig.to_client.count { |f| f.frame_type == Frame::Type::RstStream }.should eq(1)
+      # A WINDOW_UPDATE rides alongside the RST now (the dropped stream's ~1 MiB of parked
+      # DATA is credit the client is owed back), so the exact frame list no longer works.
+      # Kept as strict as it was, though: ONE RST and nothing that is not a refund — the
+      # original assertion's real content was "nothing else reaches the client".
+      kinds = rig.to_client.map(&.frame_type)
+      kinds.count(Frame::Type::RstStream).should eq(1)
+      kinds.reject(Frame::Type::RstStream).all?(Frame::Type::WindowUpdate).should be_true
     end
   end
 

--- a/spec/proxy/h2/stream_gate_spec.cr
+++ b/spec/proxy/h2/stream_gate_spec.cr
@@ -490,6 +490,31 @@ describe Gori::Proxy::H2::StreamGate do
     end
   end
 
+  # The sandbox path settles inside `accept`, so the two examples around this one cannot see
+  # the other way a slot gets charged: an operator DROP settles on the WAIT FIBER
+  # (`resolve_locked` -> `drain_locked` -> `release_locked` -> `drop_locked`). With only
+  # `accept` flushing, the credit sat there — and a client whose remaining work is DATA has no
+  # window left to send the frame that would flush it, which is exactly the wedge.
+  it "refunds the window for a dropped request's parked DATA, on the wait fiber" do
+    with_ic do |ic|
+      rig = Rig.new(ic)
+      rig.c2s.accept(headers(1_u32, rig.enc_out.encode(post("/held")), Frame::END_HEADERS))
+      settle
+      rig.c2s.accept(data(1_u32, "A" * 700))
+      settle
+      # Nothing owed yet: the frames are parked behind a live hold, not discarded.
+      rig.to_client.select { |f| f.frame_type == Frame::Type::WindowUpdate }.should be_empty
+
+      ic.pending.each { |it| ic.drop(it.id) }
+      settle
+
+      rig.to_origin.should be_empty # the body never reached the origin, so the credit is owed
+      wu = rig.to_client.select { |f| f.frame_type == Frame::Type::WindowUpdate }
+      wu.map(&.stream_id).uniq.should eq([0_u32])
+      wu.sum { |f| IO::ByteFormat::BigEndian.decode(UInt32, f.payload) }.should eq(700_u32)
+    end
+  end
+
   it "refunds nothing when the DATA was actually forwarded" do
     with_ic(intercept: false) do |ic, scope|
       scope.add("include", "string", "https://api.example.com/api/")
@@ -723,7 +748,11 @@ describe Gori::Proxy::H2::StreamGate do
       # Fail-open must not overrule a decision already in flight — forwarding a request the
       # operator dropped is the one outcome worse than holding it.
       rig.to_origin.should be_empty
-      rig.to_client.map(&.frame_type).should eq([Frame::Type::RstStream])
+      # RST_STREAM is what this example is about. A WINDOW_UPDATE rides alongside it now
+      # (the dropped stream's ~1 MiB of parked DATA is credit the client is owed back), so
+      # assert the RST rather than the exact frame list.
+      rig.to_client.map(&.frame_type).should contain(Frame::Type::RstStream)
+      rig.to_client.count { |f| f.frame_type == Frame::Type::RstStream }.should eq(1)
     end
   end
 

--- a/spec/proxy/h2/stream_gate_spec.cr
+++ b/spec/proxy/h2/stream_gate_spec.cr
@@ -465,6 +465,45 @@ describe Gori::Proxy::H2::StreamGate do
     end
   end
 
+  # RFC 9113 §6.9.1: the connection window is only reduced by DATA and only restored by a
+  # WINDOW_UPDATE — RST_STREAM refunds nothing. gori is normally transparent (it forwards DATA
+  # and the far end's WINDOW_UPDATEs come back through it), but a SWALLOWED frame never reaches
+  # a far end, so nobody generates one for it. Verified against a real client before this spec
+  # existed: 120 KiB pushed at a sandbox-refused stream, credit returned 0 — past the default
+  # 65535 the client can send DATA on NO stream, in-scope ones included.
+  it "refunds the connection window for DATA it swallowed on a refused stream" do
+    with_ic(intercept: false) do |ic, scope|
+      scope.add("include", "string", "https://api.example.com/api/")
+      scope.enable_sandbox
+      rig = Rig.new(ic)
+
+      rig.c2s.accept(headers(1_u32, rig.enc_out.encode(post("/admin")), Frame::END_HEADERS))
+      rig.c2s.accept(data(1_u32, "A" * 900))
+      rig.c2s.accept(data(1_u32, "B" * 124))
+
+      rig.to_origin.should be_empty # still nothing upstream
+      wu = rig.to_client.select { |f| f.frame_type == Frame::Type::WindowUpdate }
+      # Stream 0 — the shared window is the one that wedges the connection; the refused
+      # stream's own window dies with it.
+      wu.map(&.stream_id).uniq.should eq([0_u32])
+      wu.sum { |f| IO::ByteFormat::BigEndian.decode(UInt32, f.payload) }.should eq(1024_u32)
+    end
+  end
+
+  it "refunds nothing when the DATA was actually forwarded" do
+    with_ic(intercept: false) do |ic, scope|
+      scope.add("include", "string", "https://api.example.com/api/")
+      scope.enable_sandbox
+      rig = Rig.new(ic)
+      # In scope: the frames go upstream, so the ORIGIN credits them and a refund here would
+      # hand the client twice the window it is owed.
+      rig.c2s.accept(headers(1_u32, rig.enc_out.encode(post("/api/x")), Frame::END_HEADERS))
+      rig.c2s.accept(data(1_u32, "A" * 500))
+      rig.to_origin.map(&.frame_type).should contain(Frame::Type::Data)
+      rig.to_client.select { |f| f.frame_type == Frame::Type::WindowUpdate }.should be_empty
+    end
+  end
+
   it "lets an in-scope request through on the same connection" do
     with_ic(intercept: false) do |ic, scope|
       scope.add("include", "string", "https://api.example.com/api/")

--- a/spec/proxy/h2/stream_gate_spec.cr
+++ b/spec/proxy/h2/stream_gate_spec.cr
@@ -20,6 +20,15 @@ private class RecSink < Gori::Proxy::FlowSink
 
   def on_ws_message(flow_id : Int64, direction : String, opcode : Int32, payload : Bytes) : Nil
   end
+
+  # The raw h2 frame log — what an operator reads to diagnose a stalled connection. Every byte
+  # gori puts on the wire must appear here, synthesized frames included.
+  getter frames = [] of {String, UInt8, UInt32}
+
+  def on_h2_frame(conn_id : Int64, direction : String, type : UInt8, flags : UInt8,
+                  stream_id : UInt32, payload : Bytes) : Nil
+    @frames << {direction, type, stream_id}
+  end
 end
 
 # A live client+origin pair of gates over in-memory legs, plus a real Interceptor.
@@ -512,6 +521,49 @@ describe Gori::Proxy::H2::StreamGate do
       wu = rig.to_client.select { |f| f.frame_type == Frame::Type::WindowUpdate }
       wu.map(&.stream_id).uniq.should eq([0_u32])
       wu.sum { |f| IO::ByteFormat::BigEndian.decode(UInt32, f.payload) }.should eq(700_u32)
+    end
+  end
+
+  # The RESPONSE direction's refund goes to the ORIGIN, not the client — the origin is the
+  # sender of origin->client DATA. Without this example a revert shaped as
+  # `refund_swallowed if @ordered` would strand the origin's credit and the whole suite would
+  # still pass, because every other WindowUpdate assertion in this file reads `to_client`.
+  it "refunds a dropped RESPONSE's parked DATA to the origin, not the client" do
+    with_ic do |ic|
+      ic.set_direction(Gori::Interceptor::Direction::ResponseOnly)
+      rig = Rig.new(ic)
+      rig.c2s.accept(headers(1_u32, rig.enc_out.encode(request("/x")), Frame::END_HEADERS))
+      settle
+      rig.s2c.accept(headers(1_u32, rig.enc_in.encode(response("200")), Frame::END_HEADERS))
+      settle
+      rig.s2c.accept(data(1_u32, "B" * 400))
+      settle
+
+      ic.pending.each { |it| ic.drop(it.id) }
+      settle
+
+      to_origin = rig.to_origin.select { |f| f.frame_type == Frame::Type::WindowUpdate }
+      to_origin.sum { |f| IO::ByteFormat::BigEndian.decode(UInt32, f.payload) }.should eq(400_u32)
+      rig.to_client.select { |f| f.frame_type == Frame::Type::WindowUpdate }.should be_empty
+    end
+  end
+
+  # A synthesized frame is still a frame gori WROTE, so it belongs in the raw log — the same
+  # rule the `@refused` branch cites when it declines to log a frame gori swallowed. Its
+  # sibling `write_cross_rst` goes through `write` and is logged; this one used to bypass it,
+  # so the log disagreed with the wire exactly when an operator would be reading it.
+  it "records the refund in the raw frame log, like every other frame it writes" do
+    with_ic(intercept: false) do |ic, scope|
+      scope.add("include", "string", "https://api.example.com/api/")
+      scope.enable_sandbox
+      rig = Rig.new(ic)
+      rig.c2s.accept(headers(1_u32, rig.enc_out.encode(post("/admin")), Frame::END_HEADERS))
+      rig.c2s.accept(data(1_u32, "A" * 256))
+
+      on_wire = rig.to_client.count { |f| f.frame_type == Frame::Type::WindowUpdate }
+      logged = rig.sink.frames.count { |(_, t, sid)| t == Frame::Type::WindowUpdate.value && sid == 0_u32 }
+      on_wire.should eq(1)
+      logged.should eq(on_wire)
     end
   end
 

--- a/src/gori/cli/run/oast.cr
+++ b/src/gori/cli/run/oast.cr
@@ -201,7 +201,8 @@ module Gori
           name.try(&.strip).presence || existing.name,
           kind.try(&.label) || existing.kind,
           host.try(&.strip).presence || existing.host,
-          token.try(&.strip).presence || existing.token,
+          # See the MCP twin: `--token=` with an empty value is a CLEAR, not an omission.
+          token.nil? ? existing.token : token.strip.presence,
           enabled.nil? ? existing.enabled? : enabled)
         puts "OAST provider p_#{row} updated."
       end

--- a/src/gori/cli/run/probe.cr
+++ b/src/gori/cli/run/probe.cr
@@ -39,6 +39,7 @@ module Gori
         allow_unscoped = false
         unsafe = false
         aggressive = false
+        insecure = false
         positional = [] of String
 
         parser = OptionParser.new do |p|
@@ -64,6 +65,11 @@ module Gori
           p.on("--allow-unscoped", "With --active, probe flows even when outside the project scope (default: only scope-included hosts)") { allow_unscoped = true }
           p.on("--unsafe", "With --active, ALSO probe unsafe methods (POST/PUT/PATCH/DELETE) — re-sends may mutate server data") { unsafe = true }
           p.on("--aggressive", "With --active, raise per-rule caps + wider bypass sets (implies --unsafe)") { aggressive = true }
+          # Every other outbound `gori run` subcommand carries this; probe did not, so
+          # `scan_all`'s `verify_upstream: true` default was unreachable from the CLI and an
+          # internal target with a self-signed certificate failed every active probe with no
+          # way to say otherwise.
+          p.on("-k", "--insecure-upstream", "With --active, do not verify upstream TLS certificates") { insecure = true }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args { |rest, _| positional = rest }
@@ -114,6 +120,7 @@ module Gori
           # complete one and reads as "clean".
           scan_errors = [] of String
           dets, rn = Probe::Scan.scan_all(store, ids, active: active, scope: scope,
+            verify_upstream: !insecure,
             allow_unscoped: allow_unscoped, opts: opts, progress: probe_progress_meter(meter),
             on_error: ->(where : String, ex : Exception) { scan_errors << "#{where}: #{ex.message}"; nil })
           STDERR.print "\r\e[K" if meter # clear the in-place meter before the summary line

--- a/src/gori/mcp/tools/oast_providers.cr
+++ b/src/gori/mcp/tools/oast_providers.cr
@@ -62,7 +62,16 @@ module Gori
 
         name = str(h, "name").try(&.strip).presence || existing.name
         host = str(h, "host").try(&.strip).presence || existing.host
-        token = str(h, "token").try(&.strip).presence || existing.token
+        # `presence ||` cannot express "clear it": an explicit `"token": ""` folded into the
+        # same nil as an OMITTED field, so the old auth credential stayed on the provider and
+        # kept going out. Presence of the KEY decides whether to change it; its value decides
+        # what to. `name`/`host` above keep the fallback deliberately — a provider with no name
+        # or no host is not a thing you can save.
+        token = if present?(h, "token")
+                  str(h, "token").try(&.strip).presence
+                else
+                  existing.token
+                end
         enabled = bool(h, "enabled")
         enabled = existing.enabled? if enabled.nil?
 

--- a/src/gori/mcp/tools/probe.cr
+++ b/src/gori/mcp/tools/probe.cr
@@ -40,13 +40,16 @@ module Gori
         # Cap only the ACTIVE sends (network volume); the request-free PASSIVE scan always
         # covers every flow. (An earlier version truncated `ids`, which silently dropped
         # passive coverage of the newest flows under active:true.)
-        capped = active && ids.size > PROBE_ACTIVE_MAX_FLOWS
         # A scan SKIPS an item that blows up rather than losing the batch; count the skips so the
         # agent can tell an incomplete result from a clean one (surfaced as `scan_errors`).
         scan_errors = 0
+        # The budget is built here so `capped` can report whether it actually STOPPED a send,
+        # rather than guessing from the pre-filter id count — see `Scan::Budget#exhausted?`.
+        budget = Probe::Scan::Budget.new(active ? PROBE_ACTIVE_MAX_FLOWS : nil)
         dets, repeater_n = Probe::Scan.scan_all(store, ids, active: active, verify_upstream: @verify_upstream,
-          scope: scope, allow_unscoped: allow_unscoped, opts: opts, active_limit: active ? PROBE_ACTIVE_MAX_FLOWS : nil,
+          scope: scope, allow_unscoped: allow_unscoped, opts: opts, active_budget: budget,
           on_error: ->(_where : String, _ex : Exception) { scan_errors += 1; nil })
+        capped = budget.exhausted?
 
         groups = probe_filter_groups(Probe.group(dets), severity_from(str(h, "severity")), category.as(String?))
         Result.new(probe_scan_json(groups, ids.size, repeater_n, active, allow_unscoped,

--- a/src/gori/probe/from_repeater.cr
+++ b/src/gori/probe/from_repeater.cr
@@ -7,6 +7,23 @@ module Gori
     # Build a synthetic FlowDetail from a persisted Repeater tab so Passive.analyze can
     # run over Repeater send results the same way it runs over History flows. Returns nil
     # when there is no scorable response (no head, or only an error with empty head).
+    # Byte-level subsequence index. `String#index` cannot be used on these bytes: they may not
+    # be valid UTF-8, and scrubbing first is exactly what this file must not do to the body.
+    private def self.index_seq(hay : Bytes, needle : Bytes) : Int32?
+      return nil if needle.empty? || hay.size < needle.size
+      last = hay.size - needle.size
+      i = 0
+      while i <= last
+        j = 0
+        while j < needle.size && hay[i + j] == needle[j]
+          j += 1
+        end
+        return i if j == needle.size
+        i += 1
+      end
+      nil
+    end
+
     def self.detail_from_repeater(record : Store::RepeaterRecord) : Store::FlowDetail?
       head = record.response_head
       return nil if head.nil? || head.empty?
@@ -14,20 +31,30 @@ module Gori
       scheme, host, port = Repeater::FlowRequest.parse_target(record.target)
       return nil if host.empty?
 
-      # scrub: record.request can carry invalid UTF-8 (the repeater editor seeds from a captured
-      # request head+body without scrubbing), which would make the PCRE gsub below raise. This
-      # builds a synthetic FlowDetail for PASSIVE ANALYSIS only (never re-sent), so scrub is
-      # lossless here. Cf. secret_in_url.cr / issues_export.one_line.
-      req_text = String.new(record.request).scrub
+      # The boundary is found in the RAW BYTES, and the two halves are then treated
+      # differently — which is the whole point:
+      #
+      #   * the HEAD is scrubbed and LF→CRLF normalized, because it has to survive a PCRE
+      #     (`record.request` can carry invalid UTF-8: the repeater editor seeds from a
+      #     captured request head+body without scrubbing) and `Http1.parse_headers` reads
+      #     CRLF only. Cf. secret_in_url.cr / issues_export.one_line.
+      #   * the BODY is taken VERBATIM. This file used to say the detail was for "PASSIVE
+      #     ANALYSIS only (never re-sent), so scrub is lossless here" — and that is false:
+      #     `Scan.scan_repeaters` hands it to `Active.analyze`, which puts `plan.request` on
+      #     the wire. Scrubbing turned a binary/protobuf/multipart body's `00 ff 41 fe` into
+      #     `00 ef bf bd 41 ef bf bd`, so the probe measured a request the operator never
+      #     authored — differential rules compared against a differently-framed baseline, and
+      #     corrupted bytes reached the origin.
+      #
       # Take whichever blank-line boundary occurs FIRST — the editor uses bare-LF, so a
       # literal "\r\n\r\n" inside the body must not win over the true earlier "\n\n" head
       # boundary (the naive `crlf || lf` fallback would snap to the body's sequence).
-      sep = [req_text.index("\r\n\r\n"), req_text.index("\n\n")].compact.min?
-      req_head_s = sep ? req_text[0, sep] : req_text
-      req_body_s = if sep
-                     n = req_text[sep, 4]? == "\r\n\r\n" ? 4 : 2
-                     req_text[(sep + n)..]?
-                   end
+      raw_req = record.request
+      sep_crlf = index_seq(raw_req, "\r\n\r\n".to_slice)
+      sep_lf = index_seq(raw_req, "\n\n".to_slice)
+      sep = [sep_crlf, sep_lf].compact.min?
+      req_head_s = String.new(sep ? raw_req[0, sep] : raw_req).scrub
+      body_start = sep ? sep + (sep == sep_crlf ? 4 : 2) : nil
       # The Repeater editor serializes request text with BARE-LF line endings, but
       # Http1.parse_headers recognizes only CRLF: without normalizing the internal separators,
       # the first CRLF found is the appended terminator, so parse_headers starts at the blank
@@ -36,7 +63,7 @@ module Gori
       # Normalize LF→CRLF, then ensure the head ends with a blank line for parse_request_head.
       head_crlf = req_head_s.gsub(/\r?\n/, "\r\n")
       req_head_bytes = (head_crlf.ends_with?("\r\n\r\n") ? head_crlf : "#{head_crlf.rstrip}\r\n\r\n").to_slice
-      req_body = req_body_s.try { |b| b.empty? ? nil : b.to_slice }
+      req_body = body_start.try { |i| i < raw_req.size ? raw_req[i, raw_req.size - i] : nil }
 
       req = Proxy::Codec::Http1.parse_request_head(req_head_bytes)
       method = req.method.presence || "GET"

--- a/src/gori/probe/scan.cr
+++ b/src/gori/probe/scan.cr
@@ -24,14 +24,54 @@ module Gori
     module Scan
       extend self
 
+      # One ACTIVE-send budget for a whole scan. `scan_repeaters` had none at all, so an MCP
+      # `probe_scan active:true` could send far past its own `PROBE_ACTIVE_MAX_FLOWS`: repeater
+      # tabs are unbounded (`store.repeaters` is an uncapped SELECT and `create_repeater` can
+      # mint them) and the 14 rules cost 33 requests per tab, 47 under `aggressive`. Shared
+      # rather than per-half so the cap means what its name says.
+      class Budget
+        def initialize(@remaining : Int32?)
+        end
+
+        # True when this scan may still send. Consumes one unit when it can.
+        def take? : Bool
+          n = @remaining
+          return true unless n
+          if n <= 0
+            @exhausted = true
+            return false
+          end
+          @remaining = n - 1
+          true
+        end
+
+        # Whether the cap actually STOPPED a send. `ids.size > limit` is not the same question:
+        # the ids are counted before the scope allowlist and the has-a-response filter, so a
+        # project with 600 captured flows of which 5 are in scope reported truncated coverage
+        # for a scan that covered everything.
+        def exhausted? : Bool
+          @exhausted
+        end
+
+        @exhausted = false
+      end
+
       # The operator's Rules sub-tab config: built-ins turned off (by RuleInfo#id) + the merged
       # global+project custom match rules. A headless scan MUST honour both or it diverges from
       # what the same project shows in the TUI — a disabled built-in would come back, and a
       # custom rule would never fire at all. Mirrors Analyzer#load_disabled / #load_custom,
       # including their "a broken/locked DB degrades to the built-in defaults" rescue.
-      record RuleConfig, disabled : Set(String), custom : Array(CustomRule) do
+      # `degraded` is true when the disabled-rule set could NOT be read. It matters because
+      # that set is the only thing standing between an ACTIVE rule the operator switched off
+      # and a real request going out: the rescue below returns an EMPTY set, which reads as
+      # "nothing is disabled" — a fail-OPEN on the one half of this config that authorises
+      # traffic. Passive analysis is request-free and degrades harmlessly (it just applies the
+      # built-in defaults, which is what the comment above always described); ACTIVE does not,
+      # so `Scan` skips it and says so rather than sending probes the operator turned off.
+      record RuleConfig, disabled : Set(String), custom : Array(CustomRule), degraded : Bool = false do
         def self.load(store : Store) : RuleConfig
-          new(load_disabled(store), load_custom(store))
+          disabled, ok = load_disabled(store)
+          new(disabled, load_custom(store), degraded: !ok)
         end
 
         # The "no config" default, for callers (specs) that scan without a Rules config.
@@ -39,10 +79,13 @@ module Gori
           new(Passive::NO_DISABLED, Passive::NO_CUSTOM)
         end
 
-        private def self.load_disabled(store : Store) : Set(String)
-          store.probe_disabled_rules
+        # {the set, whether it was actually read}. The pair is the whole point — an empty set
+        # from a broken store and an empty set from a project with nothing disabled are the
+        # same value and must not mean the same thing.
+        private def self.load_disabled(store : Store) : {Set(String), Bool}
+          {store.probe_disabled_rules, true}
         rescue DB::Error | SQLite3::Exception
-          Set(String).new
+          {Set(String).new, false}
         end
 
         private def self.load_custom(store : Store) : Array(CustomRule)
@@ -75,15 +118,26 @@ module Gori
                    active_limit : Int32? = nil, opts : Active::Options = Active::Options::DEFAULT,
                    rules : RuleConfig? = nil,
                    progress : Proc(Int32, Int32, Nil)? = nil,
+                   active_budget : Budget? = nil,
                    on_error : Proc(String, Exception, Nil)? = nil) : {Array(Detection), Int32}
         # Read the Rules config ONCE per scan (not per flow) — same as the Analyzer, which
         # loads it at construction and only re-reads on an explicit rules reload.
         cfg = rules || RuleConfig.load(store)
+        # ONE budget across both halves — see `Budget`. Built here rather than passed down as a
+        # number so the repeater half cannot spend the flow half's allowance again.
+        budget = active_budget || Budget.new(active_limit)
+        if active && cfg.degraded
+          on_error.try &.call("probe rules", Gori::Error.new(
+            "the disabled-rule list could not be read (store busy or unwritable), so gori does " \
+            "not know which ACTIVE checks you switched off — active probing was skipped and " \
+            "only passive analysis ran"))
+        end
         detections = scan_flows(store, ids, active: active, verify_upstream: verify_upstream,
-          scope: scope, allow_unscoped: allow_unscoped, active_limit: active_limit, opts: opts,
-          rules: cfg, progress: progress, on_error: on_error)
+          scope: scope, allow_unscoped: allow_unscoped, opts: opts,
+          rules: cfg, progress: progress, active_budget: budget, on_error: on_error)
         repeater_dets, repeater_n = scan_repeaters(store, active: active, verify_upstream: verify_upstream,
-          scope: scope, allow_unscoped: allow_unscoped, opts: opts, rules: cfg, on_error: on_error)
+          scope: scope, allow_unscoped: allow_unscoped, opts: opts, rules: cfg,
+          active_budget: budget, on_error: on_error)
         detections.concat(repeater_dets)
         {detections, repeater_n}
       end
@@ -93,11 +147,12 @@ module Gori
                      active_limit : Int32? = nil, opts : Active::Options = Active::Options::DEFAULT,
                      rules : RuleConfig? = nil,
                      progress : Proc(Int32, Int32, Nil)? = nil,
+                     active_budget : Budget? = nil,
                      on_error : Proc(String, Exception, Nil)? = nil) : Array(Detection)
         cfg = rules || RuleConfig.load(store)
         outbound = outbound_for(scope, allow_unscoped)
         detections = [] of Detection
-        active_sent = 0
+        budget = active_budget || Budget.new(active_limit)
         ids.each_with_index do |id, i|
           begin
             detail = store.get_flow(id)
@@ -105,10 +160,11 @@ module Gori
               ws = detail.row.status == 101 ? store.ws_messages(id, 200) : [] of Store::WsMessage
               # passive is request-free — NEVER capped
               detections.concat(Passive.analyze(detail, ws, disabled: cfg.disabled, custom: cfg.custom))
-              if active && outbound.allows?(detail.row.url, detail.row.host) && !(active_limit && active_sent >= active_limit)
+              # `!cfg.degraded`: the disabled-rule set could not be read, so gori does not
+              # know which ACTIVE rules the operator switched off — see `RuleConfig`.
+              if active && !cfg.degraded && outbound.allows?(detail.row.url, detail.row.host) && budget.take?
                 detections.concat(Active.analyze(detail, verify_upstream, outbound: outbound, opts: opts,
                   disabled: cfg.disabled, on_error: on_error))
-                active_sent += 1
               end
             end
           rescue ex : DB::Error | SQLite3::Exception
@@ -130,11 +186,12 @@ module Gori
       def scan_repeaters(store : Store, *, active : Bool, verify_upstream : Bool = true,
                          scope : Scope? = nil, allow_unscoped : Bool = false,
                          opts : Active::Options = Active::Options::DEFAULT,
-                         rules : RuleConfig? = nil,
+                         rules : RuleConfig? = nil, active_budget : Budget? = nil,
                          on_error : Proc(String, Exception, Nil)? = nil) : {Array(Detection), Int32}
         cfg = rules || RuleConfig.load(store)
         outbound = outbound_for(scope, allow_unscoped)
         detections = [] of Detection
+        budget = active_budget || Budget.new(nil)
         n = 0
         store.repeaters.each do |rec|
           next unless detail = Probe.detail_from_repeater(rec)
@@ -145,7 +202,7 @@ module Gori
             Passive.analyze(detail, ws, disabled: cfg.disabled, custom: cfg.custom).each do |d|
               detections << Probe.with_source(d, flow_id: rec.flow_id, repeater_id: rec.id)
             end
-            if active && outbound.allows?(detail.row.url, detail.row.host)
+            if active && !cfg.degraded && outbound.allows?(detail.row.url, detail.row.host) && budget.take?
               Active.analyze(detail, verify_upstream, outbound: outbound, opts: opts,
                 disabled: cfg.disabled, on_error: on_error).each do |d|
                 detections << Probe.with_source(d, flow_id: rec.flow_id, repeater_id: rec.id)

--- a/src/gori/proxy/h2/stream_gate.cr
+++ b/src/gori/proxy/h2/stream_gate.cr
@@ -168,6 +168,9 @@ module Gori::Proxy::H2
       @warned_body = false
       @warned_scope = false
       @warned_overflow = false
+      # Connection-level flow-control credit owed back to the SENDER for DATA this gate
+      # accepted and discarded. Flushed by `refund_swallowed` once `accept` is out of the lock.
+      @swallowed = 0
       # The request direction is the one that opens streams, and the one whose deferred streams
       # the FAR leg has therefore never seen.
       @ordered = @direction == "out"
@@ -177,6 +180,7 @@ module Gori::Proxy::H2
     # Feed one frame off the wire. Never blocks on a human.
     def accept(frame : Frame::Header) : Nil
       run_cross(@mutex.synchronize { accept_locked(frame) })
+      refund_swallowed
     end
 
     # The direction ended. Release the partial block the rewriter may be holding, hand every
@@ -263,6 +267,10 @@ module Gori::Proxy::H2
         if @refused.includes?(f.stream_id)
           # Swallowed, not written: the far leg never saw this stream open. Deliberately not
           # captured either — `write` is what logs a frame and P7 logs what gori actually wrote.
+          # But the sender's CONNECTION window was still charged for these bytes and nothing
+          # downstream will ever credit them back, so they are counted here and refunded once
+          # `accept` is out of the lock. See `refund_swallowed`.
+          @swallowed += f.payload.size if f.frame_type == Frame::Type::Data
         elsif slot.nil?
           write(f, pre)
         elsif f.frame_type == Frame::Type::RstStream
@@ -295,6 +303,9 @@ module Gori::Proxy::H2
         project(b)
         @assembler.drop_stream(slot.stream_id, "stream reset by the peer while held at intercept")
       end
+      # The parked frames are dropped on the floor here, and their DATA was charged to the
+      # sender's connection window just as the refused-branch DATA was. See `refund_swallowed`.
+      charge_swallowed(slot)
       remove(slot)
       write(frame, nil) unless @ordered
       drain_locked
@@ -662,6 +673,8 @@ module Gori::Proxy::H2
       # both. (`abandon_locked` deliberately does not: there the PEER reset the stream, so it is
       # the one that has stopped sending, and charging its cancellations to the ceiling below
       # would let an ordinary client cancel its way into a connection teardown.)
+      # Its parked DATA is never written on either leg — see `charge_swallowed`.
+      charge_swallowed(slot)
       remember_refused(slot.stream_id)
       [slot.stream_id]
     end
@@ -739,6 +752,57 @@ module Gori::Proxy::H2
       peer = @peer
       return unless peer
       ids.each { |id| peer.write_cross_rst(id) }
+    end
+
+    # Count a slot's parked DATA as owed credit. Called where those frames are DISCARDED
+    # rather than written — `abandon_locked` and `drop_locked`. A released slot's frames go
+    # through `write`, so the far end sees them and generates its own WINDOW_UPDATE; only the
+    # discarded ones have nobody to credit them.
+    private def charge_swallowed(slot : Slot) : Nil
+      slot.frames.each do |(f, _)|
+        @swallowed += f.payload.size if f.frame_type == Frame::Type::Data
+      end
+    end
+
+    # Give the SENDER back the connection-level flow-control credit for DATA this gate
+    # accepted and then threw away.
+    #
+    # RFC 9113 §6.9.1: the connection window is only ever reduced by DATA and only ever
+    # restored by a WINDOW_UPDATE — RST_STREAM refunds nothing, and a receiver that discards
+    # accepted DATA must still return the credit or the sender's window shrinks for good.
+    # gori is normally transparent here (it forwards DATA and the far end's WINDOW_UPDATEs
+    # flow back through it), but a SWALLOWED frame never reaches a far end, so no
+    # WINDOW_UPDATE is ever generated for it by anyone. Measured against a real client:
+    # 120 KiB pushed at a sandbox-refused stream, credit returned 0. Past the default 65535
+    # the client can send DATA on NO stream — in-scope ones included.
+    #
+    # Connection level only (stream 0). The stream itself is refused or dropped and its own
+    # window dies with it; it is the shared one that wedges the connection.
+    #
+    # Written on the PEER's leg, because that is the one facing the sender — the same
+    # `@peer` seam `write_cross_rst` uses, and with `@mutex` released for the same reason.
+    private def refund_swallowed : Nil
+      n = @mutex.synchronize do
+        v = @swallowed
+        @swallowed = 0
+        v
+      end
+      return if n <= 0
+      @peer.try(&.write_cross_window_update(n))
+    end
+
+    # Called by the OPPOSITE direction's gate. Takes this gate's lock and nothing else — the
+    # caller has already released its own, exactly as `write_cross_rst` requires.
+    def write_cross_window_update(increment : Int32) : Nil
+      @mutex.synchronize do
+        return if @closed
+        payload = Bytes.new(4)
+        IO::ByteFormat::BigEndian.encode(increment.to_u32 & 0x7fff_ffff_u32, payload)
+        @dst.write(Frame::Header.new(Frame::Type::WindowUpdate.value, 0_u8, 0_u32, payload).wire_bytes)
+        @dst.flush
+      end
+    rescue
+      # The leg is gone; there is nobody left to credit.
     end
 
     # --- small helpers -------------------------------------------------------

--- a/src/gori/proxy/h2/stream_gate.cr
+++ b/src/gori/proxy/h2/stream_gate.cr
@@ -77,8 +77,12 @@ module Gori::Proxy::H2
   #   * every method that mutates gate state is named `*_locked`, runs under `@mutex`, and
   #     RETURNS the opposite direction's work as data (a list of stream ids) instead of doing
   #     it. No `*_locked` method may touch `@peer`.
-  #   * `run_cross` is the only place that touches `@peer`, and it runs after `@mutex` has been
-  #     released. `write_cross_rst` takes its own gate's lock and nothing else.
+  #   * `run_cross` and `refund_swallowed` are the only places that touch `@peer`, and both run
+  #     after `@mutex` has been released. `write_cross_rst` and `write_cross_window_update` take
+  #     their own gate's lock and nothing else.
+  #   * they are PAIRED: every path that can settle a slot must run both, or the cross-leg work
+  #     it produced sits until something else happens to trigger them. `accept` and `wait_for`
+  #     are the two such paths.
   #
   # `Interceptor#hold` is likewise never called under `@mutex` — that is the whole reason the
   # wait lives on its own fiber.
@@ -557,7 +561,14 @@ module Gori::Proxy::H2
     private def wait_for(item : Gori::Interceptor::Item, block : HeadRewrite::Block) : Nil
       spawn do
         decision = item.reply.receive
+        # The same PAIRING `accept` has, and it is not optional here: a DROP settles on THIS
+        # fiber (`resolve_locked` -> `drain_locked` -> `release_locked` -> `drop_locked`), which
+        # charges `@swallowed` for the parked DATA it discards. With only `accept` flushing, the
+        # credit sat until the client happened to send another frame — and a client whose
+        # remaining work is DATA has no window left to send one with, which is the wedge this
+        # refund exists to prevent, reached through the intercept path instead of the sandbox.
         run_cross(@mutex.synchronize { resolve_locked(item, block, decision) })
+        refund_swallowed
       end
     end
 

--- a/src/gori/proxy/h2/stream_gate.cr
+++ b/src/gori/proxy/h2/stream_gate.cr
@@ -809,8 +809,15 @@ module Gori::Proxy::H2
         return if @closed
         payload = Bytes.new(4)
         IO::ByteFormat::BigEndian.encode(increment.to_u32 & 0x7fff_ffff_u32, payload)
-        @dst.write(Frame::Header.new(Frame::Type::WindowUpdate.value, 0_u8, 0_u32, payload).wire_bytes)
-        @dst.flush
+        # Through `write`, exactly as `write_cross_rst` does — so this frame lands in the raw
+        # frame log like every other byte gori puts on the wire. Writing straight to `@dst`
+        # left the operator reading that log during a stalled upload (which is when you read
+        # it) seeing WINDOW_UPDATEs arrive from nowhere, with gori's own record disagreeing
+        # with the wire. The `@refused` branch's "P7 logs what gori actually wrote" cuts both
+        # ways: it justifies not logging a frame gori swallowed, and requires logging one gori
+        # synthesized. Safe on this frame: `feed` returns immediately for stream 0 and
+        # `@extract.observe` needs a `pre`, which a WINDOW_UPDATE never has.
+        write(Frame::Header.new(Frame::Type::WindowUpdate.value, 0_u8, 0_u32, payload), nil)
       end
     rescue
       # The leg is gone; there is nobody left to credit.


### PR DESCRIPTION
Follow-up to #549. That PR shipped 58 fixes verified by specs alone and named two gaps: **nothing had been exercised against a running gori**, and one finding was deliberately left unfixed because it could not be verified without a real HTTP/2 peer. This closes both, plus the six items earlier sweeps had analysed but not fixed.

## HTTP/2 connection flow control — the one #549 left open

RFC 9113 §6.9.1: the connection window is only reduced by DATA and only restored by a WINDOW_UPDATE. RST_STREAM refunds nothing, and a receiver that discards DATA it accepted must still return the credit. gori is normally transparent here — it forwards DATA and the far end's WINDOW_UPDATEs flow back through it — but a **swallowed** frame never reaches a far end, so nobody ever generates one for it, and `rst_frame` was the only frame the gate synthesized.

Measured against a real client through the built binary, before the fix:

```
DATA bytes pushed at a sandbox-refused stream: 122880
frames gori sent the client: SETTINGS, RST_STREAM stream=1
CONNECTION-LEVEL WINDOW_UPDATE credit returned: 0
```

Past the default 65535 a conformant client can send DATA on **no** stream on that connection — the in-scope ones included. After: 81920 pushed, 81920 returned, three runs clean.

Three commits, because the first two attempts were incomplete and the review seat caught both:

- the refund itself, counted where DATA is discarded rather than written;
- **flushed on the DROP path too** — a drop settles on the wait fiber, so it charged and never paid. Worse than it sounds: the credit sat until the client sent another frame, and a client whose remaining work is DATA has no window left to send one. `drain_locked`'s three call sites prove `accept` + `wait_for` is the exhaustive pair;
- **logged like every other frame gori writes.** It bypassed `write`, so the raw h2 frame log disagreed with the wire — exactly when an operator reads that log.

## Six items earlier sweeps analysed but left unfixed

- **The disabled-rule list failed OPEN.** A store error rescued into an empty set, which reads as "nothing is disabled" — and that set is the only thing between an ACTIVE probe rule the operator switched off and a real request. Now distinguishable, ACTIVE is skipped, and the skip is named rather than silent.
- **`scan_repeaters` had no send budget at all**, so an MCP `probe_scan active:true` could send far past its own `PROBE_ACTIVE_MAX_FLOWS` — repeater tabs are unbounded and the rule set costs 33 requests per tab, 47 aggressive. One budget now spans both halves.
- **`active_flows_capped` was computed from the pre-filter id count**, telling an agent coverage was truncated for a scan that covered everything.
- **`gori run probe` had no `-k`**, so an internal target with a self-signed certificate failed every active probe with no way to say otherwise.
- **`detail_from_repeater` scrubbed the body of a request it then RE-SENT.** Its own comment claimed the detail was never re-sent; `Scan.scan_repeaters` hands it to `Active.analyze`, which puts those bytes on the wire. A binary body's `00 ff 41 fe` went out as `00 ef bf bd 41 ef bf bd`.
- **An OAST provider's auth token could not be cleared** — `presence ||` folded an explicit `""` into the same nil as an omitted field.

## Real-binary verification of #549's work

Six scenarios, each with a control run against a build with the fix reverted:

| what | broken build | fixed build |
|---|---|---|
| `$NAME` in a request body | origin read `Content-Length: 13` over a 20-byte body — 7 bytes left as the next request's prefix, session token on the wire as a method | `Content-Length: 20`, matched |
| short-circuit stub | — | origin never saw the stubbed paths; 6 MiB served in full; stored blob capped at 2 MiB with the true size recorded |
| compact / FTS | — | an untouched row kept `fts_dirty=0` and its index row (2→1, not 2→0) |
| WS passthrough buffer | origin got `LEAK` then `LEAKTHIRD` | `LEAK` then `THIRD` |
| h2 flow control | 0 credit for 120 KiB | 1:1 |

**A severity correction worth recording:** the WS leak reaches the *wire* only when the `part: ws` rule actually substitutes. With a non-matching rule `@single_raw` hands back the peer's own frame bytes and only the capture is corrupted. The first control run "passed" on the broken build because of this.

## Notes for review

- **Three of these five commits fix a defect in an earlier one of the same five.** A dedicated adversarial-verification pass found every one; across #549 and this PR that seat has now caught 12 regressions in my own fixes. If any part of this process is worth keeping, it is that one.
- The `bad record mac` that nearly made me revert the flow-control fix was **Python's `ssl.SSLSocket` used from two threads** in my harness, not a proxy bug — the fix only exposed it by sending frequently enough to lose the race. A single-threaded client settles it. Written into the commit message so the next person does not pay for it again.
