### PR TITLE
fix: 33-defect multi-agent sweep across h2, ws, graphql, repeater, probe, store

### DIFF
--- a/spec/filter_ast_spec.cr
+++ b/spec/filter_ast_spec.cr
@@ -237,6 +237,27 @@ describe Gori::FilterAst do
       Gori::FilterAst.parse("#{"NOT " * 8000}host:x").should_not be_nil
     end
 
+    # The cap's contract is that an over-deep parse degrades FORGIVINGLY. It did for parens,
+    # but a NOT chain was cut in its MIDDLE: `parse_unary` recursed once per keyword, returned
+    # nil at the cap having consumed one `NOT` per level, `parse_and` re-descended on the rest,
+    # and the count that happened to SURVIVE decided polarity. So one keyword past the cap
+    # returned the exact COMPLEMENT of the query — silently, exit 0, "no flows match". On a
+    # filter that is worse than an error: it hides the rows the operator was looking for.
+    it "keeps NOT-chain polarity on both sides of the depth cap" do
+      cap = Gori::FilterAst::MAX_PARSE_DEPTH
+      {2, 4, cap, cap + 1, cap + 2, 400, 401, 8000, 8001}.each do |n|
+        got = parse("#{"NOT " * n}host:x")
+        want = n.even? ? "host:x" : "-host:x"
+        got.should eq(want), "NOT x#{n} parsed as #{got}, expected #{want}"
+      end
+    end
+
+    it "keeps NOT-chain polarity over a GROUP past the cap too" do
+      cap = Gori::FilterAst::MAX_PARSE_DEPTH
+      parse("#{"NOT " * (cap + 1)}(host:a OR host:b)").should eq("(not (or host:a host:b))")
+      parse("#{"NOT " * (cap + 2)}(host:a OR host:b)").should eq("(or host:a host:b)")
+    end
+
     it "parses normal shallow nesting exactly as before the guard" do
       # A handful of levels is far under the cap, so these stay byte-for-byte unchanged.
       parse("((a OR b) c) OR d").should eq("(or (and (or a b) c) d)")

--- a/spec/fuzz/conn_pool_spec.cr
+++ b/spec/fuzz/conn_pool_spec.cr
@@ -65,6 +65,55 @@ private class KeepAliveOrigin
   end
 end
 
+# An origin that answers each request on one socket, but on the chosen path leaves EXTRA bytes
+# on the wire past the framed body (a whole second response glued behind a short
+# Content-Length) — the response-desync shape a keep-alive pool must not paper over by parking
+# a socket that still has bytes on it.
+private class PoisonOrigin
+  getter port : Int32
+  getter connections : Int32 = 0
+
+  def initialize(@poison_tail : String)
+    @server = TCPServer.new("127.0.0.1", 0)
+    @port = @server.local_address.port
+    spawn do
+      while conn = @server.accept?
+        @connections += 1
+        spawn { serve(conn) rescue nil }
+      end
+    rescue
+      # server closed
+    end
+  end
+
+  def close : Nil
+    @server.close
+  end
+
+  private def serve(conn : TCPSocket) : Nil
+    loop do
+      head = Gori::Proxy::Codec::Http1.read_head(conn)
+      break unless head
+      req = Gori::Proxy::Codec::Http1.parse_request_head(head)
+      if (cl = req.headers.get?("Content-Length")) && (n = cl.to_i?) && n > 0
+        conn.read_fully?(Bytes.new(n))
+      end
+      tail = req.target.lchop("/f/")
+      ident = "ID:#{tail}"
+      if tail == @poison_tail
+        # framed body is 4 bytes; a WHOLE extra response is glued on behind it
+        ghost = "HTTP/1.1 200 OK\r\nContent-Length: 9\r\n\r\nID:GHOST!"
+        conn << "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\nPOIS" << ghost
+        conn.flush
+      else
+        conn << "HTTP/1.1 200 OK\r\nContent-Length: #{ident.bytesize}\r\n\r\n" << ident
+        conn.flush
+      end
+    end
+    conn.close rescue nil
+  end
+end
+
 describe F::ConnPool do
   describe ".reusable_request?" do
     it "accepts a bodyless HTTP/1.1 request" do
@@ -264,6 +313,26 @@ describe F::ConnPool do
       end
       pool.dialed.should eq(2)
       pool.reused.should eq(0)
+      pool.close_all
+      origin.close
+    end
+
+    it "retires a socket the origin left residue on, so the next payload gets its OWN response" do
+      # A body longer than its Content-Length: gori reads the framed 4 bytes and the rest sits
+      # in the receive buffer. Parking it would hand the next request that leftover response —
+      # a 200 attributed to the wrong payload, silently. `reusable_response?` sees only the
+      # head, so `drained?` is what has to catch this.
+      origin = PoisonOrigin.new(poison_tail: "EXTRA")
+      pool = F::ConnPool.new("http", "127.0.0.1", origin.port, false, nil, nil, nil, 4)
+      bodies = %w[A01 EXTRA A03 A04].map do |p|
+        r = pool.send(req("GET /f/#{p} HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n"))
+        String.new(r.body || Bytes.empty)
+      end
+      # A03 and A04 must each read their OWN identity, never the ghost glued behind EXTRA.
+      bodies[2].should eq("ID:A03")
+      bodies[3].should eq("ID:A04")
+      bodies.none?(&.includes?("GHOST")).should be_true
+      pool.dialed.should be >= 2 # the poisoned socket was retired, not reused
       pool.close_all
       origin.close
     end

--- a/spec/fuzz/conn_pool_spec.cr
+++ b/spec/fuzz/conn_pool_spec.cr
@@ -319,18 +319,25 @@ describe F::ConnPool do
 
     it "retires a socket the origin left residue on, so the next payload gets its OWN response" do
       # A body longer than its Content-Length: gori reads the framed 4 bytes and the rest sits
-      # in the receive buffer. Parking it would hand the next request that leftover response —
+      # in the receive buffer. Parking it would hand the NEXT request that leftover response —
       # a 200 attributed to the wrong payload, silently. `reusable_response?` sees only the
-      # head, so `drained?` is what has to catch this.
+      # head, so the checkout-time `drained?` is what has to catch this.
+      #
+      # The poison is the FIRST payload deliberately: this origin is a same-process fiber, and
+      # on a REUSED socket the scheduler can interleave its write past gori's checkout so the
+      # ghost is not yet on the wire when it is inspected — a harness artifact, not a product
+      # gap (a real out-of-process origin sends the residue with the response). Poisoning the
+      # first, fresh socket makes the residue deterministically present, so the check under
+      # test is the one exercised.
       origin = PoisonOrigin.new(poison_tail: "EXTRA")
       pool = F::ConnPool.new("http", "127.0.0.1", origin.port, false, nil, nil, nil, 4)
-      bodies = %w[A01 EXTRA A03 A04].map do |p|
+      bodies = %w[EXTRA B02 B03].map do |p|
         r = pool.send(req("GET /f/#{p} HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n"))
         String.new(r.body || Bytes.empty)
       end
-      # A03 and A04 must each read their OWN identity, never the ghost glued behind EXTRA.
-      bodies[2].should eq("ID:A03")
-      bodies[3].should eq("ID:A04")
+      bodies[0].should eq("POIS")   # the framed 4-byte body of the poisoned response
+      bodies[1].should eq("ID:B02") # the ghost was NOT handed to the next payload...
+      bodies[2].should eq("ID:B03") # ...nor the one after
       bodies.none?(&.includes?("GHOST")).should be_true
       pool.dialed.should be >= 2 # the poisoned socket was retired, not reused
       pool.close_all

--- a/spec/graphql_spec.cr
+++ b/spec/graphql_spec.cr
@@ -297,6 +297,34 @@ describe Gori::Graphql do
       GQL.from_flow("p?query=%7Bme%7D", nil, big).should eq(GQL::Op.new(nil, "{me}", nil))
     end
 
+    # The false positive that mattered: `location` answers `:query` for anything `from_flow`
+    # resolved off the query string, so the Repeater re-encodes the WHOLE query string on send.
+    # A POST/PUT/PATCH that sent a body has already said where its payload is; falling through
+    # to a stray `?query=` param rewrote a request on the strength of a misdetection.
+    it "does not fall through to a ?query= param for a POST that sent an unrelated body" do
+      head = "POST /upload?query=%7Bx%7D HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+      GQL.from_flow("/upload?query=%7Bx%7D", head, Bytes[0x00, 0x01, 0xff]).should be_nil
+    end
+
+    it "does not fall through for PUT or PATCH either" do
+      {"PUT", "PATCH"}.each do |m|
+        head = "#{m} /u?query=%7Bx%7D HTTP/1.1\r\n\r\n".to_slice
+        GQL.from_flow("/u?query=%7Bx%7D", head, %({"not":"graphql"}).to_slice).should be_nil
+      end
+    end
+
+    it "still prefers a real GraphQL body on a POST" do
+      head = "POST /graphql HTTP/1.1\r\n\r\n".to_slice
+      GQL.from_flow("/graphql", head, %({"query":"{ me }"}).to_slice)
+        .should eq(GQL::Op.new(nil, "{ me }", nil))
+    end
+
+    it "still falls through for a GET carrying a stray body (what the fallback was for)" do
+      head = "GET /g?query=%7Bme%7D HTTP/1.1\r\n\r\n".to_slice
+      GQL.from_flow("/g?query=%7Bme%7D", head, %({"foo":1}).to_slice)
+        .should eq(GQL::Op.new(nil, "{me}", nil))
+    end
+
     it "returns nil when neither the body nor the target is GraphQL" do
       GQL.from_flow("/rest/path", nil, %({"foo":1}).to_slice).should be_nil
     end

--- a/spec/graphql_spec.cr
+++ b/spec/graphql_spec.cr
@@ -202,17 +202,59 @@ describe Gori::Graphql do
     end
   end
 
-  describe ".recompose_query" do
-    it "preserves unmanaged params and appends the edited query (no operationName pair when absent)" do
-      out = GQL.recompose_query("query=%7Bold%7D&apiKey=secret&operationName=Old", "{ new }")
-      out.should eq("apiKey=secret&query=%7B+new+%7D")
-      out.includes?("operationName").should be_false
+  describe ".parse_display / operationName sentinel" do
+    # `# operationName:` is also a valid GraphQL comment. The `# variables` sentinel already
+    # gets disambiguated; this one did not, so a document whose FIRST line was such a comment
+    # had that line deleted and its text promoted into a real operationName — changing which
+    # operation the server runs.
+    it "does not promote a leading GraphQL comment into a real operationName" do
+      text = "# operationName: NotReallyTheName\nquery Real { a }"
+      op, query, _ = GQL.parse_display(text)
+      op.should be_nil
+      query.should eq(text)
     end
 
-    it "minifies the variables and appends operationName when present" do
+    it "still lifts the genuine header, which display always follows with a blank line" do
+      op, query, _ = GQL.parse_display(GQL.display(GQL::Op.new("Hero", "query Hero { a }", nil)))
+      op.should eq("Hero")
+      query.should eq("query Hero { a }")
+    end
+
+    it "treats a deleted header as an explicit unset rather than falling back to the base" do
+      out = GQL.recompose(%({"query":"query Hero { a }","operationName":"Hero"}), "query Hero { a }")
+      out.should eq(%({"query":"query Hero { a }"}))
+    end
+
+    it "keeps other base fields (a persisted-query extensions block) across a recompose" do
+      base = %({"query":"{ a }","operationName":"Op","extensions":{"persistedQuery":{"version":1}}})
+      out = GQL.recompose(base, GQL.display(GQL::Op.new("Op", "{ b }", nil)))
+      out.should contain(%("extensions":{"persistedQuery":{"version":1}}))
+      out.should contain(%("query":"{ b }"))
+    end
+  end
+
+  describe ".recompose_query" do
+    # A managed param is replaced WHERE IT STOOD. Dropping and re-appending it reordered the
+    # query string — `page=2&query=…&sig=abc` came back as `page=2&sig=abc&query=…` — which is
+    # a request the operator did not write and which breaks any signature or cache key computed
+    # over the canonical query string. That is a real target shape for this tool, so position
+    # is part of what "edit the query" must preserve.
+    it "replaces the edited query in place and keeps unmanaged params where they were" do
+      out = GQL.recompose_query("query=%7Bold%7D&apiKey=secret&operationName=Old", "{ new }")
+      out.should eq("query=%7B+new+%7D&apiKey=secret")
+      out.includes?("operationName").should be_false # the edit removed it, so it is gone
+    end
+
+    it "keeps a managed param's slot even when other params surround it" do
+      decoded = GQL.display(GQL::Op.new("Op", "{ new }", nil))
+      out = GQL.recompose_query("page=2&query=old&sig=abc", decoded)
+      out.should eq("page=2&query=%7B+new+%7D&sig=abc&operationName=Op")
+    end
+
+    it "minifies the variables and appends params the original did not carry" do
       decoded = GQL.display(GQL::Op.new("Op", "{ new }", %({"x": 1})))
       out = GQL.recompose_query("query=old&apiKey=x", decoded)
-      out.should eq("apiKey=x&query=%7B+new+%7D&operationName=Op&variables=%7B%22x%22%3A1%7D")
+      out.should eq("query=%7B+new+%7D&apiKey=x&operationName=Op&variables=%7B%22x%22%3A1%7D")
     end
   end
 

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -266,6 +266,35 @@ describe Gori::MCP::Server do
       end
     end
 
+    # `flows.id` is a REUSABLE rowid, so a clear restarts numbering and a forward cursor held
+    # from before it is permanently ahead of every row. `since` then returned `[]` forever
+    # while the rows sat right there — "no new flows" and "your cursor is stranded" were the
+    # same answer, and an agent polling this feed simply went blind.
+    it "names a stranded 'since' cursor instead of answering with an empty page forever" do
+      with_store do |store|
+        3.times { |i| seed_flow(store, "h.test", "GET", "/p#{i}", 200) }
+        store.clear_flows
+        fresh = seed_flow(store, "h.test", "GET", "/after-clear", 200)
+        fresh.should eq(1) # ids really do restart — that is what strands the cursor
+
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_history","arguments":{"since":22}}})
+        resp = drive(store, call)[0]
+        resp["result"]["isError"].as_bool.should be_true
+        text = resp["result"]["content"][0]["text"].as_s
+        text.should contain("ahead of the newest flow")
+        text.should contain("since=0")
+      end
+    end
+
+    it "still answers an in-range 'since' cursor normally" do
+      with_store do |store|
+        a = seed_flow(store, "h.test", "GET", "/a", 200)
+        b = seed_flow(store, "h.test", "GET", "/b", 200)
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_history","arguments":{"since":#{a}}}})
+        tool_payload(drive(store, call)[0]).as_a.map(&.["id"].as_i64).should eq([b])
+      end
+    end
+
     it "paginates filtered results with before_id" do
       with_store do |store|
         a = seed_flow(store, "h.test", "GET", "/a", 500)

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -2166,6 +2166,28 @@ describe Gori::MCP::Serialize do
 end
 
 describe Gori::MCP::RequestBuilder do
+  # `normalize_raw` exists so a hand-typed request still frames, but a bare-LF header
+  # terminator is a standard front-end/back-end desync primitive — promoting it removed a
+  # whole payload class from this surface while the TUI's byte modes could always send it.
+  it "promotes a bare LF in the head by default" do
+    raw = "GET /v HTTP/1.1\r\nHost: h.test\nX-B: lf\n\r\n"
+    args = JSON.parse({"url" => "http://h.test/", "raw" => raw}.to_json).as_h
+    String.new(Gori::MCP::RequestBuilder.build(args).bytes)
+      .should eq("GET /v HTTP/1.1\r\nHost: h.test\r\nX-B: lf\r\n\r\n")
+  end
+
+  it "keeps the bare LF byte-exact under verbatim" do
+    raw = "GET /v HTTP/1.1\r\nHost: h.test\nX-B: lf\n\r\n"
+    args = JSON.parse({"url" => "http://h.test/", "raw" => raw, "verbatim" => true}.to_json).as_h
+    String.new(Gori::MCP::RequestBuilder.build(args).bytes).should eq(raw)
+  end
+
+  it "leaves a $VAR unexpanded under verbatim, for Plan.build to refuse" do
+    raw = "GET /v HTTP/1.1\r\nHost: h.test\r\nX-T: $NOPE\r\n\r\n"
+    args = JSON.parse({"url" => "http://h.test/", "raw" => raw, "verbatim" => true}.to_json).as_h
+    String.new(Gori::MCP::RequestBuilder.build(args).bytes).should contain("$NOPE")
+  end
+
   it "builds exact request bytes with Host + Content-Length" do
     args = JSON.parse(%({"url":"https://h.test:8443/a?b=1","method":"post","headers":{"X-Test":"y"},"body":"hi"})).as_h
     built = Gori::MCP::RequestBuilder.build(args)

--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -453,6 +453,34 @@ describe Gori::Probe::Analyzer do
     end
   end
 
+  # The disabled-rule list is the ONLY thing between a disabled active rule and a real request.
+  # `store.probe_disabled_rules` used to swallow a store/parse failure into an empty set — read
+  # as "nothing is disabled" — so a corrupt value made ACTIVE probing send everything. The
+  # commit that added the `degraded` flag could never fire because of that swallow.
+  it "fails closed on active probing when the disabled-rule list cannot be read" do
+    with_store do |store|
+      capture_flow(store, "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n",
+        target: "/reflect?q=hi", body: "<p>hi</p>")
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "acme.test")
+      detail = store.recent_flows(1).first.try { |r| store.get_flow(r.id) }.not_nil!
+
+      # Sanity: a readable (empty) disabled list estimates at least one active rule for this flow.
+      feed = Channel(Gori::Store::FlowEvent).new(8)
+      ok = Gori::Probe::Analyzer.new(store, scope, feed, Gori::Probe::Mode::Active, true)
+      ok.active_estimate(detail).should_not be_empty
+
+      # Corrupt the stored value to a truncated JSON blob — probe_disabled_rules now RAISES.
+      store.@db.exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('probe_disabled_rules', '[\"reflected')")
+      expect_raises(JSON::ParseException) { store.probe_disabled_rules }
+
+      # An analyzer built on the corrupt store is degraded → estimates NOTHING (sends nothing).
+      feed2 = Channel(Gori::Store::FlowEvent).new(8)
+      degraded = Gori::Probe::Analyzer.new(store, scope, feed2, Gori::Probe::Mode::Active, true)
+      degraded.active_estimate(detail).should be_empty
+    end
+  end
+
   # AGGRESSIVE drives the SAME automatic pipeline as ACTIVE (probes_actively?), but with widened
   # Options (unsafe methods + raised caps). It stays scope-gated. No network assert — the queue may
   # drop and sends to acme.test won't resolve; this verifies the pipeline re-arms and persists the

--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -472,7 +472,8 @@ describe Gori::Probe::Analyzer do
 
       # Corrupt the stored value to a truncated JSON blob — probe_disabled_rules now RAISES.
       store.@db.exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('probe_disabled_rules', '[\"reflected')")
-      expect_raises(JSON::ParseException) { store.probe_disabled_rules }
+      expect_raises(JSON::ParseException) { store.probe_disabled_rules_strict } # active-send read raises
+      store.probe_disabled_rules.should be_empty                                # display read degrades
 
       # An analyzer built on the corrupt store is degraded → estimates NOTHING (sends nothing).
       feed2 = Channel(Gori::Store::FlowEvent).new(8)

--- a/spec/proxy/h2/head_codec_spec.cr
+++ b/spec/proxy/h2/head_codec_spec.cr
@@ -188,6 +188,20 @@ describe Gori::Proxy::H2::HeadCodec do
       injected.should_not eq(literal)
     end
 
+    it "distinguishes a backslash immediately before a REAL CR/LF from a literal backslash-r" do
+      # `x\<CR>y` (backslash then a real CR) must not render the same as `x\ry` (backslash then
+      # the letter r), or the injected CR is disguised as innocuous literal text.
+      injected_cr = String.new(HeadCodec.synth_response(tuples([f(":status", "200"), f("x", "x\\\ry")])))
+      literal_r = String.new(HeadCodec.synth_response(tuples([f(":status", "200"), f("x", "x\\ry")])))
+      injected_cr.should contain("x: x\\\\\\ry") # three backslashes then r
+      literal_r.should contain("x: x\\\\ry")     # two backslashes then r
+      injected_cr.should_not eq(literal_r)
+
+      injected_lf = String.new(HeadCodec.synth_response(tuples([f(":status", "200"), f("x", "x\\\ny")])))
+      literal_n = String.new(HeadCodec.synth_response(tuples([f(":status", "200"), f("x", "x\\ny")])))
+      injected_lf.should_not eq(literal_n)
+    end
+
     it "leaves an ordinary backslash byte-identical, so a rule written against it still matches" do
       head = String.new(HeadCodec.synth_response(tuples([f(":status", "200"),
                                                          f("x-path", "C:\\Users\\admin"), f("x-re", "\\d+\\s*")])))

--- a/spec/proxy/h2/head_codec_spec.cr
+++ b/spec/proxy/h2/head_codec_spec.cr
@@ -149,6 +149,42 @@ describe Gori::Proxy::H2::HeadCodec do
       head = String.new(HeadCodec.synth_response(tuples([f(":status", "200"), f("content-type", "text/html")])))
       head.should eq("HTTP/2 200\r\ncontent-type: text/html\r\n\r\n")
     end
+
+    # #517 on the CAPTURE side. `h1_faithful?` guards `parse_*`/`rewrite`/`encode_edited`, but
+    # `Assembler` calls these two DIRECTLY to build the stored head, so a peer field whose value
+    # carried a CRLF was projected as two well-formed headers into `gori run show`, MCP get_flow,
+    # QL `header:`, the Rewriter preview, and the bytes the Repeater replays. Measured at the
+    # wire: the client received ONE h2 field (HEADERS len=83, forwarded verbatim) while gori's
+    # own record showed two. The projection has to stay injective at the line level.
+    it "does not project a CRLF-bearing request value as a second header" do
+      fields = req_fields + [f("x-evil", "A\r\nx-injected: yes")]
+      head = String.new(HeadCodec.synth_request(tuples(fields), "api.example.com"))
+      # One line, bytes still visible, and no invented field anywhere in the head.
+      head.should eq("GET /x HTTP/2\r\nHost: api.example.com\r\nx-evil: A\\r\\nx-injected: yes\r\n\r\n")
+      head.lines.count(&.starts_with?("x-injected")).should eq(0)
+    end
+
+    it "does not project a CRLF-bearing response value as a second header (the origin's bytes)" do
+      fields = [f(":status", "200"), f("x-evil", "A\r\nset-cookie: injected=1")]
+      head = String.new(HeadCodec.synth_response(tuples(fields)))
+      head.should eq("HTTP/2 200\r\nx-evil: A\\r\\nset-cookie: injected=1\r\n\r\n")
+      head.should_not contain("\r\nset-cookie:")
+    end
+
+    it "escapes a lone CR or LF too, and leaves an ordinary value byte-exact" do
+      fields = [f(":status", "200"), f("a", "x\ry"), f("b", "x\ny"), f("c", "plain value")]
+      head = String.new(HeadCodec.synth_response(tuples(fields)))
+      head.should eq("HTTP/2 200\r\na: x\\ry\r\nb: x\\ny\r\nc: plain value\r\n\r\n")
+    end
+
+    it "keeps the start line and the synthetic Host line to one line each" do
+      fields = [f(":method", "GET"), f(":scheme", "https"), f(":authority", "h\r\nx: 1"),
+                f(":path", "/p\r\nx: 2")]
+      head = String.new(HeadCodec.synth_request(tuples(fields), "h\r\nx: 1"))
+      head.lines.size.should eq(3) # start line, Host, and the blank terminator
+      head.should contain("GET /p\\r\\nx: 2 HTTP/2")
+      head.should contain("Host: h\\r\\nx: 1")
+    end
   end
 
   describe "round trip" do

--- a/spec/proxy/h2/head_codec_spec.cr
+++ b/spec/proxy/h2/head_codec_spec.cr
@@ -177,6 +177,24 @@ describe Gori::Proxy::H2::HeadCodec do
       head.should eq("HTTP/2 200\r\na: x\\ry\r\nb: x\\ny\r\nc: plain value\r\n\r\n")
     end
 
+    # Injectivity in the direction that matters: an operator opens this view to ask "did the
+    # ORIGIN inject a CRLF here, or did the value always contain that text?" A literal
+    # backslash-r used to render identically to a real CR, so the view could not answer it.
+    it "distinguishes a real CRLF from a value that literally contains backslash-r-backslash-n" do
+      injected = String.new(HeadCodec.synth_response(tuples([f(":status", "200"), f("x", "A\r\nB")])))
+      literal = String.new(HeadCodec.synth_response(tuples([f(":status", "200"), f("x", "A\\r\\nB")])))
+      injected.should contain("x: A\\r\\nB")
+      literal.should contain("x: A\\\\r\\\\nB")
+      injected.should_not eq(literal)
+    end
+
+    it "leaves an ordinary backslash byte-identical, so a rule written against it still matches" do
+      head = String.new(HeadCodec.synth_response(tuples([f(":status", "200"),
+                                                         f("x-path", "C:\\Users\\admin"), f("x-re", "\\d+\\s*")])))
+      head.should contain("x-path: C:\\Users\\admin")
+      head.should contain("x-re: \\d+\\s*")
+    end
+
     it "keeps the start line and the synthetic Host line to one line each" do
       fields = [f(":method", "GET"), f(":scheme", "https"), f(":authority", "h\r\nx: 1"),
                 f(":path", "/p\r\nx: 2")]

--- a/spec/proxy/h2/head_rewrite_spec.cr
+++ b/spec/proxy/h2/head_rewrite_spec.cr
@@ -41,6 +41,36 @@ private class SubRewriter < Gori::Proxy::HeadRewriter
   end
 end
 
+# The sandbox's BLOCKING gate: `StreamGate#undecodable` raises to end the connection when the
+# sandbox is on and a head arrives with no URL to scope-test.
+private class BlockingDeferrer
+  include Gori::Proxy::H2::HeadRewrite::Deferrer
+  getter told = [] of UInt32
+
+  def defer?(block : Gori::Proxy::H2::HeadRewrite::Block) : Bool
+    false
+  end
+
+  def undecodable(stream_id : UInt32) : Nil
+    @told << stream_id
+    raise Gori::Error.new("h2 sandbox: undecodable header block on stream #{stream_id}")
+  end
+end
+
+# The sandbox-OFF disposition: told, but nothing is refused, so the frames go out verbatim (P7).
+private class QuietDeferrer
+  include Gori::Proxy::H2::HeadRewrite::Deferrer
+  getter told = [] of UInt32
+
+  def defer?(block : Gori::Proxy::H2::HeadRewrite::Block) : Bool
+    false
+  end
+
+  def undecodable(stream_id : UInt32) : Nil
+    @told << stream_id
+  end
+end
+
 private def pipeline(rewriter : Gori::Proxy::HeadRewriter, direction = "out",
                      sink = RecSink.new) : {Gori::Proxy::H2::HeadRewrite, Gori::Proxy::H2::Assembler, RecSink}
   assembler = Gori::Proxy::H2::Assembler.new(sink, "api.example.com", 443, 1_i64)
@@ -260,6 +290,62 @@ describe Gori::Proxy::H2::HeadRewrite do
     sink.requests.size.should eq(2)
     sink.requests[1].target.should eq("/second")
     String.new(sink.requests[1].head).should contain("x-a: 0123456789abcdef")
+  end
+
+  # The sandbox gate is BLOCKING, so `undecodable` raises — and the raise unwinds through
+  # `Relay#pump_gated`'s `ensure gate.close`, which drains this very buffer to the peer. If the
+  # frames are still buffered when the deferrer is told, the refusal forwards the exact block it
+  # refused: an unexamined, out-of-scope request reaching the origin while the WARN says the
+  # connection was closed instead. Measured at the wire before the fix — a PADDED head with a
+  # bad pad length arrived at the origin complete (END_STREAM|END_HEADERS), and a CONTINUATION
+  # flood past the 1 MiB ceiling delivered ~1.06 MB. Both assert on `drain` because `close` is
+  # what writes them.
+  describe "an undecodable block the sandbox refuses" do
+    # PADDED with a pad length past the end of the payload: RFC 9113 §6.1, the block cannot be
+    # located, so `finish` takes the `unreadable` path.
+    bad_pad = Bytes.new(20) { |i| i == 0 ? 250_u8 : 0_u8 }
+
+    it "leaves nothing buffered, so connection teardown cannot forward what was refused" do
+      pipe, assembler, _ = pipeline(SubRewriter.new("x-tag: a", "x-tag: b"))
+      pipe.deferrer = deferrer = BlockingDeferrer.new
+
+      expect_raises(Gori::Error, /undecodable/) do
+        push(pipe, assembler, headers(1_u32, bad_pad, Frame::END_HEADERS | Frame::END_STREAM | Frame::PADDED))
+      end
+
+      deferrer.told.should eq([1_u32])
+      drained = [] of Frame::Header
+      pipe.drain { |f, _| drained << f }
+      drained.should be_empty
+    end
+
+    it "leaves nothing buffered when the block passes the 1 MiB ceiling either" do
+      pipe, assembler, _ = pipeline(SubRewriter.new("x-tag: a", "x-tag: b"))
+      pipe.deferrer = deferrer = BlockingDeferrer.new
+      over = Bytes.new(Gori::Proxy::H2::Assembler::MAX_HEADER_BLOCK + 1)
+
+      expect_raises(Gori::Error, /undecodable/) do
+        push(pipe, assembler, headers(3_u32, over, 0_u8)) # no END_HEADERS: a CONTINUATION flood
+      end
+
+      deferrer.told.should eq([3_u32])
+      drained = [] of Frame::Header
+      pipe.drain { |f, _| drained << f }
+      drained.should be_empty
+    end
+
+    it "still forwards it verbatim when the sandbox is OFF (P7 — the raw log is the truth)" do
+      pipe, assembler, _ = pipeline(SubRewriter.new("x-tag: a", "x-tag: b"))
+      pipe.deferrer = deferrer = QuietDeferrer.new
+
+      sent = push(pipe, assembler, headers(1_u32, bad_pad, Frame::END_HEADERS | Frame::END_STREAM | Frame::PADDED))
+
+      sent.map(&.payload).should eq([bad_pad]) # byte-exact, as it arrived
+      deferrer.told.should eq([1_u32])         # told either way; only the disposition differs
+      drained = [] of Frame::Header
+      pipe.drain { |f, _| drained << f }
+      drained.should be_empty # and not left behind to be written a second time
+    end
   end
 
   # #517. A field value carrying the head's own delimiter has no h1-text form, and the bridge

--- a/spec/proxy/h2/head_rewrite_spec.cr
+++ b/spec/proxy/h2/head_rewrite_spec.cr
@@ -399,6 +399,27 @@ describe Gori::Proxy::H2::HeadRewrite do
       pipe.drain { |_, _| fail "nothing should be left buffered" }
     end
 
+    # The FIFTH site: a block with no END_HEADERS never reaches `finish`, so it is still buffered
+    # when the connection ends — and `StreamGate#close` calls `drain`, which wrote it to the peer.
+    # Measured at the wire as one HEADERS(no END_HEADERS) for an out-of-scope path plus a hangup.
+    # `drain(discard: true)` is the sandbox's answer; `discard: false` keeps the P7 verbatim
+    # release. `StreamGate#close` computes the flag as `@ordered && sandbox_enabled?`.
+    it "drains a no-END_HEADERS block verbatim by default but drops it when discard is set" do
+      pipe, assembler, _ = pipeline(SubRewriter.new("x-tag: a", "x-tag: b"))
+      block = HPACK::Encoder.new.encode(req("/blocked"))
+      push(pipe, assembler, headers(1_u32, block, 0_u8)).should be_empty # buffered, no END_HEADERS
+
+      released = [] of Frame::Header
+      pipe.drain(discard: false) { |f, _| released << f }
+      released.map(&.payload).should eq([block]) # P7: verbatim when the sandbox is off
+    end
+
+    it "drops a buffered no-END_HEADERS block under discard, leaving close nothing to write" do
+      pipe, assembler, _ = pipeline(SubRewriter.new("x-tag: a", "x-tag: b"))
+      push(pipe, assembler, headers(1_u32, HPACK::Encoder.new.encode(req("/blocked")), 0_u8)).should be_empty
+      pipe.drain(discard: true) { |_, _| fail "discard must not yield the unexamined block" }
+    end
+
     it "does not forward a completed block when the gate refuses the connection at defer?" do
       # `defer?` raises past MAX_REFUSED_STREAMS, and `accept`'s `reset` only ran after `finish`
       # RETURNED — so the completed block sat in `@buf` and teardown wrote it to the peer.
@@ -412,6 +433,29 @@ describe Gori::Proxy::H2::HeadRewrite do
       drained = [] of Frame::Header
       pipe.drain { |f, _| drained << f }
       drained.should be_empty
+    end
+  end
+
+  # `StreamGate` now routes connection-level frames through `accept`, and a HEADERS/PUSH_PROMISE
+  # on stream 0 is a §6.2 connection error. It must NOT open a buffered block — otherwise a Slot
+  # keyed 0 could be minted and later PINGs would park behind it (the freeze D1 rule 1 forbids).
+  describe "a header-type frame on stream 0" do
+    it "is yielded straight through, never buffered" do
+      pipe, assembler, _ = pipeline(SubRewriter.new("x-tag: a", "x-tag: b"))
+      zero = headers(0_u32, HPACK::Encoder.new.encode(req("/x")))
+      sent = push(pipe, assembler, zero)
+      sent.size.should eq(1)
+      sent.first.stream_id.should eq(0_u32)
+      pipe.drain { |_, _| fail "a stream-0 HEADERS must not be left buffered" }
+    end
+
+    it "does not become the opener a following CONTINUATION on stream 1 attaches to" do
+      pipe, assembler, _ = pipeline(SubRewriter.new("x-tag: a", "x-tag: b"))
+      push(pipe, assembler, headers(0_u32, HPACK::Encoder.new.encode(req("/x")))) # not an opener
+      # A real block on stream 1 now opens cleanly; the stream-0 frame did not leave state behind.
+      out = push(pipe, assembler, headers(1_u32, HPACK::Encoder.new.encode(req("/y"))))
+      out.size.should eq(1)
+      out.first.stream_id.should eq(1_u32)
     end
   end
 

--- a/spec/proxy/h2/head_rewrite_spec.cr
+++ b/spec/proxy/h2/head_rewrite_spec.cr
@@ -71,6 +71,19 @@ private class QuietDeferrer
   end
 end
 
+# A gate whose `defer?` RAISES — `StreamGate` ends the connection once `remember_refused`
+# passes MAX_REFUSED_STREAMS, and that raise unwinds through the same `close`/`drain` path.
+private class RefusingDeferrer
+  include Gori::Proxy::H2::HeadRewrite::Deferrer
+
+  def defer?(block : Gori::Proxy::H2::HeadRewrite::Block) : Bool
+    raise Gori::Error.new("h2 out: over 4096 streams refused on one connection")
+  end
+
+  def undecodable(stream_id : UInt32) : Nil
+  end
+end
+
 private def pipeline(rewriter : Gori::Proxy::HeadRewriter, direction = "out",
                      sink = RecSink.new) : {Gori::Proxy::H2::HeadRewrite, Gori::Proxy::H2::Assembler, RecSink}
   assembler = Gori::Proxy::H2::Assembler.new(sink, "api.example.com", 443, 1_i64)
@@ -345,6 +358,60 @@ describe Gori::Proxy::H2::HeadRewrite do
       drained = [] of Frame::Header
       pipe.drain { |f, _| drained << f }
       drained.should be_empty # and not left behind to be written a second time
+    end
+  end
+
+  # The same buffered-block leak as the `undecodable` pair, reached through the two OTHER ways
+  # `accept` can part with a block. Both were measured at the wire against a real client.
+  describe "a block abandoned without ever being scope-tested" do
+    it "does not forward an intruder-interrupted block, which never reached the decode at all" do
+      # Three frames: HEADERS with END_HEADERS cleared, ANY intruder (a bare PRIORITY does it),
+      # then the CONTINUATION. The block never reaches `finish`, so it is never decoded and
+      # never scope-tested — and flushing it verbatim put an out-of-scope request on the wire
+      # that the origin ANSWERED, while the same request without the intruder got RST_STREAM.
+      pipe, assembler, _ = pipeline(SubRewriter.new("x-tag: a", "x-tag: b"))
+      pipe.deferrer = deferrer = BlockingDeferrer.new
+      block = HPACK::Encoder.new.encode(req("/blocked"))
+
+      push(pipe, assembler, headers(1_u32, block, 0_u8)).should be_empty # buffered, no END_HEADERS
+      expect_raises(Gori::Error, /undecodable/) do
+        push(pipe, assembler, Frame::Header.new(Frame::Type::Priority.value, 0_u8, 3_u32, Bytes.new(5)))
+      end
+
+      deferrer.told.should eq([1_u32])
+      drained = [] of Frame::Header
+      pipe.drain { |f, _| drained << f }
+      drained.should be_empty
+    end
+
+    it "still releases an intruder-interrupted block verbatim, in arrival order, with the sandbox OFF" do
+      pipe, assembler, _ = pipeline(SubRewriter.new("x-tag: a", "x-tag: b"))
+      pipe.deferrer = QuietDeferrer.new
+      block = HPACK::Encoder.new.encode(req("/blocked"))
+      intruder = Frame::Header.new(Frame::Type::Priority.value, 0_u8, 3_u32, Bytes.new(5))
+
+      push(pipe, assembler, headers(1_u32, block, 0_u8)).should be_empty
+      sent = push(pipe, assembler, intruder)
+
+      sent.size.should eq(2)
+      sent[0].payload.should eq(block) # the held block first...
+      sent[1].frame_type.should eq(Frame::Type::Priority)
+      pipe.drain { |_, _| fail "nothing should be left buffered" }
+    end
+
+    it "does not forward a completed block when the gate refuses the connection at defer?" do
+      # `defer?` raises past MAX_REFUSED_STREAMS, and `accept`'s `reset` only ran after `finish`
+      # RETURNED — so the completed block sat in `@buf` and teardown wrote it to the peer.
+      pipe, assembler, _ = pipeline(SubRewriter.new("x-tag: a", "x-tag: b"))
+      pipe.deferrer = RefusingDeferrer.new
+
+      expect_raises(Gori::Error, /streams refused/) do
+        push(pipe, assembler, headers(1_u32, HPACK::Encoder.new.encode(req("/blocked"))))
+      end
+
+      drained = [] of Frame::Header
+      pipe.drain { |f, _| drained << f }
+      drained.should be_empty
     end
   end
 

--- a/spec/proxy/upstream_spec.cr
+++ b/spec/proxy/upstream_spec.cr
@@ -4,6 +4,37 @@ require "openssl"
 require "file_utils"
 
 describe Gori::Proxy::Upstream do
+  # An IPv6 literal reaches this path BRACKETED — that is how it appears in an absolute-form
+  # request target and what `URI#host` returns — and a bracketed string is not an address, so
+  # `TCPSocket.new` treated it as a hostname and the resolve failed. gori could not reach an
+  # IPv6-literal origin at all through the forward proxy, while the same origin answered
+  # direct. The brackets were already stripped at the two other places a host becomes an
+  # address in this file; the direct dial was the site that was not.
+  describe "IPv6 literal targets" do
+    it "dials a bracketed IPv6 literal, as an absolute-form request target carries it" do
+      server = TCPServer.new("::1", 0)
+      port = server.local_address.port
+      spawn { server.accept?.try(&.close) }
+
+      sock = Gori::Proxy::Upstream.dial("[::1]", port)
+      sock.should_not be_nil
+      sock.try(&.close)
+      server.close
+    end
+
+    it "still dials the same host unbracketed, and an IPv4 literal and a hostname" do
+      v6 = TCPServer.new("::1", 0)
+      v4 = TCPServer.new("127.0.0.1", 0)
+      spawn { v6.accept?.try(&.close) }
+      spawn { v4.accept?.try(&.close) }
+
+      Gori::Proxy::Upstream.dial("::1", v6.local_address.port).should_not be_nil
+      Gori::Proxy::Upstream.dial("127.0.0.1", v4.local_address.port).should_not be_nil
+      v6.close
+      v4.close
+    end
+  end
+
   describe "upstream proxy (CONNECT tunnel)" do
     it "tunnels a dial through the configured proxy when it answers 2xx" do
       proxy = TCPServer.new("127.0.0.1", 0)

--- a/spec/proxy/ws_spec.cr
+++ b/spec/proxy/ws_spec.cr
@@ -225,6 +225,60 @@ describe Gori::Proxy::WS do
   end
 
   describe Gori::Proxy::WS::Relay do
+    # `capture_frame` only emits a message on FIN, so the default (byte-exact) pump had no
+    # per-message boundary of its own: a second data message arriving before the first FIN'd
+    # was concatenated into the first, and an unterminated fragment at teardown was dropped
+    # entirely. `AssemblingPump` was given both (`start_message` / its `run` ensure) and the
+    # oversized branch has the first, so the two pumps disagreed about identical bytes —
+    # which this file already treats as a bug for the oversized case. Capture only; the wire
+    # is byte-exact either way, and both examples assert that too.
+    it "does not merge a second data message into one that never sent its FIN" do
+      ss_r, ss_w = IO.pipe
+      tc_r, tc_w = IO.pipe
+      cs_r, cs_w = IO.pipe
+      ts_r, ts_w = IO.pipe
+      client = IO::Stapled.new(cs_r, tc_w)
+      upstream = IO::Stapled.new(ss_r, ts_w)
+      cs_w.close # the client sends nothing; EOF so that direction's pump ends
+
+      frames = Bytes[0x01, 0x03, 0x41, 0x41, 0x41] + # TEXT fin=0 "AAA" — §5.4 violation follows
+               Bytes[0x81, 0x03, 0x42, 0x42, 0x42]   # TEXT fin=1 "BBB"
+      ss_w.write(frames); ss_w.close
+
+      sink = WsSink.new
+      Gori::Proxy::WS::Relay.run(client, upstream, 7_i64, sink)
+
+      relayed = Bytes.new(frames.size)
+      tc_r.read_fully(relayed)
+      relayed.should eq(frames) # the wire keeps the peer's own framing (P7)
+      sink.messages.should eq([{"in", 1, "AAA"}, {"in", 1, "BBB"}])
+      _ = ts_r
+    end
+
+    it "captures an unterminated fragment left when the direction ends" do
+      ss_r, ss_w = IO.pipe
+      tc_r, tc_w = IO.pipe
+      cs_r, cs_w = IO.pipe
+      ts_r, ts_w = IO.pipe
+      client = IO::Stapled.new(cs_r, tc_w)
+      upstream = IO::Stapled.new(ss_r, ts_w)
+      cs_w.close # the client sends nothing; EOF so that direction's pump ends
+
+      frames = Bytes[0x81, 0x06, 0x4D, 0x41, 0x52, 0x4B, 0x45, 0x52] + # TEXT fin=1 "MARKER"
+               Bytes[0x01, 0x06, 0x55, 0x4E, 0x54, 0x45, 0x52, 0x4D]   # TEXT fin=0 "UNTERM", no FIN
+      ss_w.write(frames); ss_w.close
+
+      sink = WsSink.new
+      Gori::Proxy::WS::Relay.run(client, upstream, 7_i64, sink)
+
+      relayed = Bytes.new(frames.size)
+      tc_r.read_fully(relayed)
+      relayed.should eq(frames) # gori put all 16 bytes on the wire...
+      # ...so History must not be missing the 6 it relayed itself.
+      sink.messages.should eq([{"in", 1, "MARKER"}, {"in", 1, "UNTERM"}])
+      _ = ts_r
+    end
+
     it "relays frames both directions byte-exact and captures messages" do
       cs_r, cs_w = IO.pipe # client → server
       ts_r, ts_w = IO.pipe # relay → server

--- a/spec/ql_spec.cr
+++ b/spec/ql_spec.cr
@@ -130,17 +130,20 @@ describe Gori::QL do
 
   it "falls back to a byte-wise blob scan for a body: value below the 3-char trigram floor" do
     f = Gori::QL.parse("body:ab")
-    f.sql.should contain("instr(request_body, CAST(? AS BLOB)) > 0")
-    f.sql.should contain("instr(response_body, CAST(? AS BLOB)) > 0")
+    f.sql.should contain("COALESCE(instr(request_body, CAST(? AS BLOB)), 0) > 0")
+    f.sql.should contain("COALESCE(instr(response_body, CAST(? AS BLOB)), 0) > 0")
     f.args.should eq(["ab", "ab", "aB", "aB", "Ab", "Ab", "AB", "AB"]) # every case spelling
   end
 
-  # The fallback used `CAST(request_body AS TEXT)`, which SQLite truncates at the first NUL —
-  # so a SHORTER needle matched FEWER rows than a longer one, a monotonicity violation that
-  # cannot be explained to an operator. This is a tool whose targets deliberately put NULs in
-  # bodies, so the short path has to be byte-wise. Both halves are asserted against a real
-  # store because the bug lived in SQLite's cast, not in the SQL text.
-  it "finds a short body: needle that sits AFTER a NUL byte, like the >=3-char path does" do
+  # The <3-char fallback used `CAST(request_body AS TEXT)`, which SQLite truncates at the first
+  # NUL — so a needle sitting AFTER a NUL byte was invisible, a monotonicity violation (a
+  # shorter needle matching fewer rows) that cannot be explained to an operator. This is a tool
+  # whose targets deliberately put NULs in bodies, so the short path is now byte-wise `instr`,
+  # which is NUL-transparent. Asserted against a real store because the bug lived in SQLite's
+  # cast, not in the SQL text. (The FTS >=3-char path's handling of a NUL is the trigram
+  # tokenizer's, which varies by SQLite build, so it is deliberately not pinned here — this
+  # test targets the blob fallback that the fix actually changed.)
+  it "finds a short (<3-char) body: needle that sits AFTER a NUL byte" do
     tmp_store do |store|
       buried = store.insert_flow(Gori::Store::CapturedRequest.new(
         created_at: 1_i64, scheme: "http", host: "acme.test", port: 80,
@@ -154,12 +157,22 @@ describe Gori::QL do
         body: "plain".to_slice))
       store.flush
 
-      # `NULNEED` sits past the NUL. The long needle takes the FTS path, the short one the
-      # blob path; they must agree about this row.
-      store.search(Gori::QL.parse("body:NULNEED"), 50).map(&.id).should eq([buried])
+      # `NU` sits past the NUL. The <3-char blob path is byte-wise, so it finds it regardless of
+      # the cast-at-NUL truncation the fix removed.
       store.search(Gori::QL.parse("body:NU"), 50).map(&.id).should eq([buried])
       store.search(Gori::QL.parse("body:nu"), 50).map(&.id).should eq([buried]) # still case-insensitive
       store.search(Gori::QL.parse("body:zz"), 50).map(&.id).should be_empty
+
+      # `-body:x` (negation) must KEEP a bodyless flow, not drop it. `instr(NULL,…)` is NULL and
+      # `NOT (NULL > 0)` is NULL, which SQLite excludes — so an un-COALESCE'd instr silently
+      # narrowed the negated form. `buried` has `NU`, `bodyless` has no body at all.
+      bodyless = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 3_i64, scheme: "http", host: "acme.test", port: 80,
+        method: "GET", target: "/none", http_version: "HTTP/1.1",
+        head: "GET /none HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice, body: nil))
+      neg = store.search(Gori::QL.parse("-body:NU"), 50).map(&.id)
+      neg.should contain(bodyless)   # kept — it has no body to match
+      neg.should_not contain(buried) # excluded — its body does contain NU
     end
   end
 

--- a/spec/ql_spec.cr
+++ b/spec/ql_spec.cr
@@ -128,11 +128,39 @@ describe Gori::QL do
     Gori::QL.analyze("body:\u0001").clean?.should be_false
   end
 
-  it "falls back to a NULL-safe blob scan for a body: value below the 3-char trigram floor" do
+  it "falls back to a byte-wise blob scan for a body: value below the 3-char trigram floor" do
     f = Gori::QL.parse("body:ab")
-    f.sql.should eq("(((request_body IS NOT NULL AND lower(CAST(request_body AS TEXT)) LIKE ? ESCAPE '\\') " \
-                    "OR (response_body IS NOT NULL AND lower(CAST(response_body AS TEXT)) LIKE ? ESCAPE '\\')))")
-    f.args.should eq(["%ab%", "%ab%"])
+    f.sql.should contain("instr(request_body, CAST(? AS BLOB)) > 0")
+    f.sql.should contain("instr(response_body, CAST(? AS BLOB)) > 0")
+    f.args.should eq(["ab", "ab", "aB", "aB", "Ab", "Ab", "AB", "AB"]) # every case spelling
+  end
+
+  # The fallback used `CAST(request_body AS TEXT)`, which SQLite truncates at the first NUL —
+  # so a SHORTER needle matched FEWER rows than a longer one, a monotonicity violation that
+  # cannot be explained to an operator. This is a tool whose targets deliberately put NULs in
+  # bodies, so the short path has to be byte-wise. Both halves are asserted against a real
+  # store because the bug lived in SQLite's cast, not in the SQL text.
+  it "finds a short body: needle that sits AFTER a NUL byte, like the >=3-char path does" do
+    tmp_store do |store|
+      buried = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "http", host: "acme.test", port: 80,
+        method: "POST", target: "/bin", http_version: "HTTP/1.1",
+        head: "POST /bin HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice,
+        body: Bytes[0x68, 0x65, 0x61, 0x64, 0x00, 0x4E, 0x55, 0x4C, 0x4E, 0x45, 0x45, 0x44]))
+      store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 2_i64, scheme: "http", host: "acme.test", port: 80,
+        method: "GET", target: "/other", http_version: "HTTP/1.1",
+        head: "GET /other HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice,
+        body: "plain".to_slice))
+      store.flush
+
+      # `NULNEED` sits past the NUL. The long needle takes the FTS path, the short one the
+      # blob path; they must agree about this row.
+      store.search(Gori::QL.parse("body:NULNEED"), 50).map(&.id).should eq([buried])
+      store.search(Gori::QL.parse("body:NU"), 50).map(&.id).should eq([buried])
+      store.search(Gori::QL.parse("body:nu"), 50).map(&.id).should eq([buried]) # still case-insensitive
+      store.search(Gori::QL.parse("body:zz"), 50).map(&.id).should be_empty
+    end
   end
 
   it "compiles size: as a comparison on the TOTAL (req+resp), matching the displayed size" do

--- a/spec/repeater/h2_engine_spec.cr
+++ b/spec/repeater/h2_engine_spec.cr
@@ -6,6 +6,20 @@ private alias HPACK = Gori::Proxy::H2::HPACK
 
 # A minimal cleartext-h2 origin: reads the preface + request, records the decoded
 # request line and body, then replies SETTINGS + HEADERS(:status) + DATA.
+# An origin that accepts the TCP connection and nothing more. The refusal examples below never
+# write a request, so the h2-speaking origin's `read_preface` would hit EOF and print an
+# unhandled-spawn backtrace into the spec output — noise that reads like a failure. All these
+# examples need is a port `H2Engine.open` can connect to.
+private def start_quiet_origin : Int32
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    conn = origin.accept?
+    conn.try(&.close) rescue nil
+  end
+  port
+end
+
 private def start_h2_origin(status : Int32, body : String, seen : Channel(String)) : Int32
   origin = TCPServer.new("127.0.0.1", 0)
   port = origin.local_address.port
@@ -201,6 +215,62 @@ describe Gori::Repeater::H2Engine do
     String.new(result.head).should contain("server: gori-test")
     String.new(result.body.not_nil!).should eq("replayed!")
     result.incomplete?.should be_false # END_STREAM was seen — a complete response
+  end
+
+  # The Fuzzer marks a position inside a header VALUE. `parse_request` rebuilds the h2 fields
+  # from the h1 text by splitting on '\n', so a payload carrying a bare LF split the field and
+  # the orphan tail hit a `next unless colon` — `x-fuzz: be\naf` went out as `x-fuzz: be` while
+  # the result row was still labelled with the whole payload. The operator then reads a status
+  # measured against a request gori never sent. Measured at the wire against an HPACK-decoding
+  # origin before the fix. h1 carries these bytes verbatim (P7); h2 has no encoding for them,
+  # so refusing is the only answer that does not lie.
+  it "refuses a header value carrying a bare LF rather than silently dropping the tail" do
+    port = start_quiet_origin
+
+    request = "GET /f HTTP/2\r\nx-fuzz: be\naf\r\n\r\n".to_slice
+    result = Gori::Repeater::H2Engine.send(request, scheme: "http", host: "127.0.0.1",
+      port: port, verify_upstream: false)
+
+    result.ok?.should be_false
+    result.error.not_nil!.should contain("not a header field")
+    result.error.not_nil!.should contain("HTTP/2")
+  end
+
+  it "refuses a lone CR inside a header value (rstrip only ever removed a trailing one)" do
+    port = start_quiet_origin
+
+    request = "GET /f HTTP/2\r\nx-fuzz: x\ry\r\n\r\n".to_slice
+    result = Gori::Repeater::H2Engine.send(request, scheme: "http", host: "127.0.0.1",
+      port: port, verify_upstream: false)
+
+    result.ok?.should be_false
+    result.error.not_nil!.should contain("CR, LF or NUL")
+  end
+
+  it "refuses a NUL inside a header value" do
+    port = start_quiet_origin
+
+    request = "GET /f HTTP/2\r\nx-fuzz: nul\u0000byte\r\n\r\n".to_slice
+    result = Gori::Repeater::H2Engine.send(request, scheme: "http", host: "127.0.0.1",
+      port: port, verify_upstream: false)
+
+    result.ok?.should be_false
+    result.error.not_nil!.should contain("CR, LF or NUL")
+  end
+
+  # The deliberate non-case: a CRLF that yields two WELL-FORMED fields is indistinguishable
+  # from the operator typing two headers, and the h1 engine puts two headers on the wire for
+  # it too. Refusing that would break the smuggling primitive P7 exists to preserve.
+  it "still sends a CRLF that parses as two well-formed header fields" do
+    seen = Channel(String).new(1)
+    port = start_h2_origin(200, "ok", seen)
+
+    request = "GET /f HTTP/2\r\nx-a: one\r\nx-b: two\r\n\r\n".to_slice
+    result = Gori::Repeater::H2Engine.send(request, scheme: "http", host: "127.0.0.1",
+      port: port, verify_upstream: false)
+
+    seen.receive.should eq("GET /f body=")
+    result.ok?.should be_true
   end
 
   it "flags an h2 response cut short before END_STREAM as incomplete" do

--- a/spec/repeater/minimize_spec.cr
+++ b/spec/repeater/minimize_spec.cr
@@ -95,6 +95,37 @@ private def minimize(backend : F::Backend, text : String, auto_cl : Bool = false
 end
 
 describe Gori::Repeater::Minimize do
+  # The TUI feeds LF editor text (`TextArea#set_text` strips CR); the CLI and MCP feed the
+  # STORED bytes, which are CRLF. `split_text` only looked for `"\n\n"`, which a CRLF request
+  # does not contain, so `has_body` came back false and body-param candidates were never
+  # enumerated at all — the SAME session minimized further from the TUI than from
+  # `gori run repeater minimize`. Every session created from a flow is CRLF.
+  it "minimizes a CRLF-stored request exactly as it does the LF editor form" do
+    lines = [
+      "POST /api?a=1&b=2 HTTP/1.1",
+      "Host: h",
+      "User-Agent: Mozilla/5.0",
+      "Content-Type: application/x-www-form-urlencoded",
+      "Content-Length: 11",
+      "",
+      "x=1&y=2&z=3",
+    ]
+    lf = minimize(StaticOrigin.new, lines.join("\n"), auto_cl: true)
+    crlf = minimize(StaticOrigin.new, lines.join("\r\n"), auto_cl: true)
+
+    # Body params are reached at all, and both forms remove exactly the same set.
+    crlf.removed.map(&.kind).should contain(Gori::Repeater::Minimize::Kind::Param)
+    crlf.removed.map { |r| {r.kind, r.label} }.sort_by!(&.[1])
+      .should eq(lf.removed.map { |r| {r.kind, r.label} }.sort_by!(&.[1]))
+    crlf.sends.should eq(lf.sends)
+  end
+
+  it "returns the report in the line endings the caller handed in" do
+    lines = ["GET /api?a=1 HTTP/1.1", "Host: h", "User-Agent: Mozilla/5.0"]
+    minimize(StaticOrigin.new, lines.join("\r\n")).minimized_text.should contain("\r\n")
+    minimize(StaticOrigin.new, lines.join("\n")).minimized_text.should_not contain('\r')
+  end
+
   it "drops cosmetic headers, cookie crumbs and query params but keeps load-bearing ones" do
     text = [
       "GET /api?id=5&utm_source=nl HTTP/1.1",

--- a/spec/repeater/plan_spec.cr
+++ b/spec/repeater/plan_spec.cr
@@ -387,4 +387,39 @@ describe Gori::Repeater::Plan do
       String.new(plan.bytes).lines.first.should eq("GET /v HTTP/2")
     end
   end
+  # `--request-raw` / `--request-file` are documented as verbatim, and were not: `expand_wire`
+  # promotes a bare LF to CRLF on every headless send, and `--no-auto-cl` only disabled the
+  # Content-Length resync. A bare-LF header terminator is a standard front-end/back-end desync
+  # primitive, so that removed a whole payload class from the headless surfaces while the TUI's
+  # byte modes could still send it. `expand_request: false` is the flag every surface already
+  # uses to mean "these bytes ARE the message"; `gori run repeater send --verbatim` sets it.
+  describe "verbatim sends" do
+    it "keeps a bare LF in the head instead of promoting it to CRLF" do
+      raw = "GET /v HTTP/1.1\r\nHost: h.test\nX-Bare: lf\n\r\n".to_slice
+      plan = R::Plan.build(R::PlanOptions.new([raw], default_target: "http://h.test",
+        expand_request: false, auto_content_length: false), ungated)
+      String.new(plan.bytes).should eq(String.new(raw))
+    end
+
+    it "promotes it by default, which is what every other send still does" do
+      raw = "GET /v HTTP/1.1\r\nHost: h.test\nX-Bare: lf\n\r\n".to_slice
+      plan = R::Plan.build(R::PlanOptions.new([raw], default_target: "http://h.test"), ungated)
+      String.new(plan.bytes).should eq("GET /v HTTP/1.1\r\nHost: h.test\r\nX-Bare: lf\r\n\r\n")
+    end
+
+    it "also leaves the version line alone, since the operator asked for these exact bytes" do
+      raw = "GET /v HTTP/2\r\nHost: h.test\r\n\r\n".to_slice
+      plan = R::Plan.build(R::PlanOptions.new([raw], default_target: "http://h.test",
+        expand_request: false, auto_content_length: false), ungated)
+      String.new(plan.bytes).lines.first.should eq("GET /v HTTP/2")
+    end
+
+    it "still refuses an unresolved $VAR, which is checked regardless of expansion" do
+      raw = "GET /v HTTP/1.1\r\nHost: h.test\r\nX-T: $NOPE\r\n\r\n".to_slice
+      expect_raises(R::PlanError) do
+        R::Plan.build(R::PlanOptions.new([raw], default_target: "http://h.test",
+          expand_request: false, auto_content_length: false), ungated)
+      end
+    end
+  end
 end

--- a/spec/repeater/plan_spec.cr
+++ b/spec/repeater/plan_spec.cr
@@ -362,4 +362,29 @@ describe Gori::Repeater::Plan do
       rewritten.sender.should be(plan.sender) # the SAME gated dialer, not a second one
     end
   end
+  # `downgrade_version_line` documents itself as running "unasked on every send", but the TUI
+  # was its only caller — so the SAME session sent `HTTP/2` down an h1 socket from
+  # `gori run repeater send` and MCP while the TUI corrected it. Recorded at a raw-socket
+  # origin before the fix. Doing it in `Plan.build` puts it on the path all three surfaces share.
+  describe "an HTTP/2 version line on an h1 send" do
+    it "is downgraded whichever surface built the plan" do
+      plan = R::Plan.build(R::PlanOptions.new(["GET /v HTTP/2\r\nHost: h.test\r\n\r\n".to_slice],
+        default_target: "http://h.test"), ungated)
+      String.new(plan.bytes).lines.first.should eq("GET /v HTTP/1.1")
+    end
+
+    it "leaves a version the operator meant alone" do
+      {"HTTP/1.0", "HTTP/9.9"}.each do |v|
+        plan = R::Plan.build(R::PlanOptions.new(["GET /v #{v}\r\nHost: h.test\r\n\r\n".to_slice],
+          default_target: "http://h.test"), ungated)
+        String.new(plan.bytes).lines.first.should eq("GET /v #{v}")
+      end
+    end
+
+    it "does not touch an h2 send, which builds its fields from this text" do
+      plan = R::Plan.build(R::PlanOptions.new(["GET /v HTTP/2\r\nHost: h.test\r\n\r\n".to_slice],
+        default_target: "http://h.test", http2: true), ungated)
+      String.new(plan.bytes).lines.first.should eq("GET /v HTTP/2")
+    end
+  end
 end

--- a/spec/repeater/repeater_bugfixes_spec.cr
+++ b/spec/repeater/repeater_bugfixes_spec.cr
@@ -86,6 +86,32 @@ describe "Gori::Repeater::Engine (malformed response — fix #8)" do
     String.new(result.body.not_nil!).should eq("ok")
   end
 
+  # `Result#delivered?` distinguishes a pre-delivery failure (re-sendable) from a failure
+  # AFTER the origin already received the request. The pool's stale-retry keys on it: retrying
+  # a non-idempotent request the origin already has doubles its side effect.
+  it "marks a failure after an interim 1xx as delivered (not re-sendable)" do
+    # A 1xx that illegally declares a body — exchange refuses it, but the request was delivered.
+    port = start_reply_origin("HTTP/1.1 100 Continue\r\nContent-Length: 5\r\n\r\n")
+    result = Gori::Repeater::Engine.send("POST / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n".to_slice,
+      scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
+    result.ok?.should be_false
+    result.response.should be_nil    # no final response — the shape stale? used to catch
+    result.delivered?.should be_true # ...but the request WAS delivered, so not re-sendable
+  end
+
+  it "marks a clean no-response (idle-closed socket) as NOT delivered (re-sendable)" do
+    # Origin accepts then closes with no byte — the parked-socket-closed race the pool retries.
+    origin = TCPServer.new("127.0.0.1", 0)
+    port = origin.local_address.port
+    spawn { (conn = origin.accept?) && (Gori::Proxy::Codec::Http1.read_head(conn); conn.close) rescue nil }
+    result = Gori::Repeater::Engine.send("GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n".to_slice,
+      scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
+    result.ok?.should be_false
+    result.response.should be_nil
+    result.delivered?.should be_false # no response byte arrived → safe to re-send
+    origin.close
+  end
+
   it "send_pipeline retires the connection after a malformed response (surfaces desync)" do
     origin = TCPServer.new("127.0.0.1", 0)
     port = origin.local_address.port

--- a/spec/repeater/ws_engine_spec.cr
+++ b/spec/repeater/ws_engine_spec.cr
@@ -47,6 +47,17 @@ private UPGRADE = ("GET /ws HTTP/1.1\r\nHost: 127.0.0.1\r\n" \
                    "Sec-WebSocket-Key: dGhlIHNhbXBsZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n").to_slice
 
 describe Gori::Repeater::WsEngine do
+  # `start_ws_origin` computes the fake origin's Accept with `WsEngine::GUID` itself, so every
+  # "no handshake note" assertion below is self-referential: a corrupted GUID would keep the
+  # whole file green while `verify_accept` mismatched against every real origin on earth. Anchor
+  # it OUTSIDE gori on RFC 6455 §1.3's worked example instead — this is the one assertion here
+  # that a wrong constant cannot satisfy.
+  it "uses the RFC 6455 §1.3 accept magic, checked against the RFC's own worked example" do
+    WsEngine::GUID.should eq("258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+    Base64.strict_encode(Digest::SHA1.digest("dGhlIHNhbXBsZSBub25jZQ==" + WsEngine::GUID))
+      .should eq("s3pPLMBiTxaQ9kYGzzhZRbK+xOo=")
+  end
+
   it "upgrades, repeaters an outbound message, and captures the echo" do
     port = start_ws_origin
     result = WsEngine.send(UPGRADE, [WsEngine::OutMsg.new(1, "ping".to_slice)],

--- a/spec/repeater/ws_engine_spec.cr
+++ b/spec/repeater/ws_engine_spec.cr
@@ -46,6 +46,28 @@ private UPGRADE = ("GET /ws HTTP/1.1\r\nHost: 127.0.0.1\r\n" \
                    "Upgrade: websocket\r\nConnection: Upgrade\r\n" \
                    "Sec-WebSocket-Key: dGhlIHNhbXBsZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n").to_slice
 
+# An origin that completes the upgrade and then closes at once, without reading or sending a
+# single frame — the shape that made a repeater run report success for messages nobody got.
+private def start_dead_ws_origin : Int32
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    next unless conn = origin.accept?
+    conn.read_timeout = 5.seconds
+    head = Gori::Proxy::Codec::Http1.read_head(conn).not_nil!
+    key = String.new(head).each_line
+      .find(&.downcase.starts_with?("sec-websocket-key:"))
+      .try(&.split(':', 2)[1].strip) || ""
+    accept = Base64.strict_encode(Digest::SHA1.digest(key + WsEngine::GUID))
+    conn << "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n" \
+            "Connection: Upgrade\r\nSec-WebSocket-Accept: #{accept}\r\n\r\n"
+    conn.flush
+    conn.close
+  rescue
+  end
+  port
+end
+
 describe Gori::Repeater::WsEngine do
   # `start_ws_origin` computes the fake origin's Accept with `WsEngine::GUID` itself, so every
   # "no handshake note" assertion below is self-referential: a corrupted GUID would keep the
@@ -142,5 +164,26 @@ describe Gori::Repeater::WsEngine do
     it "is false for an ordinary request" do
       WsEngine.upgrade_request?("GET / HTTP/1.1\r\nHost: t\r\n\r\n").should be_false
     end
+  end
+  # The "out" transcript rows are appended before the flush and with no delivery evidence, so
+  # an origin that closes right after the 101 produced `upgraded: true`, `error: null` and a
+  # list of messages it never received (confirmed at the origin: handshake only, no frame).
+  it "says delivery is unconfirmed when the peer sends no frame and no close" do
+    port = start_dead_ws_origin
+    result = WsEngine.send(UPGRADE, [WsEngine::OutMsg.new(1, "x".to_slice)],
+      scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
+
+    result.upgraded?.should be_true
+    result.note.not_nil!.should contain("delivery unconfirmed")
+    result.note.not_nil!.should contain("sent 1 message")
+  end
+
+  it "stays quiet when the peer actually answers" do
+    port = start_ws_origin
+    result = WsEngine.send(UPGRADE, [WsEngine::OutMsg.new(1, "ping".to_slice)],
+      scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
+
+    result.messages.count { |m| m.direction == "in" }.should eq(1)
+    (result.note || "").should_not contain("delivery unconfirmed")
   end
 end

--- a/spec/rules_spec.cr
+++ b/spec/rules_spec.cr
@@ -14,6 +14,46 @@ private def with_store(&)
 end
 
 describe Gori::Rules do
+  # This gate backs EVERY rule op — body, ws, short_circuit, head, header — and the extract
+  # rules that mint session bindings, so an over-match is how a `SetHeader $SESSION` rule
+  # sends the operator's credential to a host they never scoped, or a `short_circuit` rule
+  # answers for one. It had no spec at all, which is how a raw `includes?` survived here.
+  describe ".host_matches?" do
+    it "matches the host itself and any subdomain of it" do
+      Gori::Rules.host_matches?("example.com", "example.com").should be_true
+      Gori::Rules.host_matches?("example.com", "api.example.com").should be_true
+      Gori::Rules.host_matches?("example.com", "a.b.example.com").should be_true
+      Gori::Rules.host_matches?("EXAMPLE.com", "API.Example.COM").should be_true # case-insensitive
+    end
+
+    it "does not match a host that merely CONTAINS the glob" do
+      # `"xalpha.test".includes?("alpha.test")` is true — an attacker can register the
+      # look-alike and collect whatever the rule injects.
+      Gori::Rules.host_matches?("alpha.test", "xalpha.test").should be_false
+      Gori::Rules.host_matches?("alpha.test", "alpha.testing.com").should be_false
+      Gori::Rules.host_matches?("example.com", "notexample.com").should be_false
+    end
+
+    it "does not match a host that merely has the glob as a PREFIX label" do
+      Gori::Rules.host_matches?("alpha.test", "alpha.test.evil.com").should be_false
+      Gori::Rules.host_matches?("example.com", "example.com.attacker.net").should be_false
+    end
+
+    it "keeps an empty glob meaning all hosts, and * as the explicit wildcard" do
+      Gori::Rules.host_matches?("", "anything.test").should be_true
+      Gori::Rules.host_matches?("*.example.com", "api.example.com").should be_true
+      Gori::Rules.host_matches?("*.example.com", "example.com").should be_false # anchored, as before
+      Gori::Rules.host_matches?("*example.com", "notexample.com").should be_true
+    end
+
+    it "handles a leading-dot glob and a bracketed IPv6 literal (the store's host spelling)" do
+      Gori::Rules.host_matches?(".example.com", "api.example.com").should be_true
+      Gori::Rules.host_matches?(".example.com", "example.com").should be_false
+      Gori::Rules.host_matches?("[::1]", "[::1]").should be_true
+      Gori::Rules.host_matches?("[::1]", "[::12]").should be_false
+    end
+  end
+
   it "is inactive (and byte-identical) until an enabled rule exists" do
     with_store do |store|
       rules = Gori::Rules.load(store)

--- a/spec/sequencer/stats_spec.cr
+++ b/spec/sequencer/stats_spec.cr
@@ -122,6 +122,23 @@ describe Gori::Sequencer::Stats do
     seq_detail(["1", "5", "3"]).should eq("non-monotonic")
   end
 
+  # A counter behind a constant >=8-char prefix: the general (non-numeric) path reads only the
+  # first 8 bytes as a magnitude, so a fixed prefix made every leading value constant → variance
+  # 0 → correlation 0 → mislabeled "none". A tester reading WHY a set is weak was told the
+  # obviously-sequential suffix looked random. Dropping the shared prefix puts the varying region
+  # under the window.
+  it "detects a counter hidden behind a constant prefix (general path)" do
+    tokens = (1..220).map { |i| "PREFIXAB%06d" % i }
+    report = S.analyze(tokens)
+    report.sequential.should be_true
+  end
+
+  it "still does not flag genuinely random tokens behind a shared prefix" do
+    rng = Random.new(7_u64)
+    tokens = Array.new(220) { "PREFIXAB" + Array.new(8) { rng.rand(16).to_s(16) }.join }
+    S.analyze(tokens).sequential.should be_false
+  end
+
   # ── detect_sequential: order-independent (concurrency-reordering) detection ─────
 
   it "detects a shuffled-order sequential counter once the sample is large enough" do
@@ -174,9 +191,12 @@ describe Gori::Sequencer::Stats do
     # Each value exceeds Int64::MAX (9_223_372_036_854_775_807); a to_i64 attempt would raise.
     big = ["9999999999999999999", "9999999999999999998", "9999999999999999997"]
     big.each(&.size.should(eq(19)))
-    report = S.analyze(big)                    # must not raise
-    seq_detail(big).should start_with("corr=") # general (correlation) path, not "constant step"
-    report.sequential.should be_false          # identical leading bytes → r = 0
+    report = S.analyze(big)                    # must not raise (each exceeds Int64::MAX)
+    seq_detail(big).should start_with("corr=") # general (correlation) path, not the numeric one
+    # These ARE a descending counter in the last digit. Dropping the shared 18-char prefix now
+    # surfaces that — before, only the identical first 8 bytes were weighed, so it read r=0 and
+    # the general path MISSED an obviously-sequential set (the same defect as the prefix case).
+    report.sequential.should be_true
   end
 
   it "never reports a NaN correlation for a constant leading-byte series (fix #16)" do

--- a/spec/store/store_spec.cr
+++ b/spec/store/store_spec.cr
@@ -583,4 +583,51 @@ describe Gori::Store do
       store.recent_flows(1000, before_id: older.last.id).size.should eq(500)
     end
   end
+  # `flows.id` is a plain INTEGER PRIMARY KEY — the rowid, which SQLite REUSES. Delete the
+  # newest flow (or clear the project) and the next capture is handed the same id, so a
+  # cross-reference deliberately left dangling does not resolve to "gone": it re-points at
+  # whatever traffic arrives next. Measured on a live project before the fix: a probe finding
+  # promoted to an Issue cited a flow captured AFTER the clear, and `get_repeater_context`
+  # reported a session as seeded from an unrelated request. On a tool whose product is
+  # evidence, silently wrong evidence is the worst outcome available.
+  describe "flow cross-references when a flow goes away" do
+    it "detaches an issue rather than letting it re-bind to the reused id" do
+      with_store do |store|
+        id = store.insert_flow(Gori::Store::CapturedRequest.new(
+          created_at: 1_i64, scheme: "http", host: "victim.test", port: 80,
+          method: "GET", target: "/victim", http_version: "HTTP/1.1",
+          head: "GET /victim HTTP/1.1\r\n\r\n".to_slice, body: nil))
+        issue = store.insert_issue("evidence on the victim flow",
+          Gori::Store::Severity::High, "victim.test", id)
+
+        store.delete_flow(id)
+        reused = store.insert_flow(Gori::Store::CapturedRequest.new(
+          created_at: 2_i64, scheme: "http", host: "unrelated.test", port: 80,
+          method: "GET", target: "/UNRELATED-ADMIN-PANEL", http_version: "HTTP/1.1",
+          head: "GET /UNRELATED-ADMIN-PANEL HTTP/1.1\r\n\r\n".to_slice, body: nil))
+
+        reused.should eq(id) # the id really is handed out again — that is the whole problem
+        store.issues.find { |i| i.id == issue }.not_nil!.flow_id.should be_nil
+      end
+    end
+
+    it "detaches every flow cross-reference on a whole-project clear" do
+      with_store do |store|
+        id = store.insert_flow(Gori::Store::CapturedRequest.new(
+          created_at: 1_i64, scheme: "http", host: "victim.test", port: 80,
+          method: "GET", target: "/victim", http_version: "HTTP/1.1",
+          head: "GET /victim HTTP/1.1\r\n\r\n".to_slice, body: nil))
+        issue = store.insert_issue("cleared", Gori::Store::Severity::Low, "victim.test", id)
+        store.@db.exec(
+          "INSERT INTO probe_issues (code, category, host, title, severity, sample_flow_id, " \
+          "first_seen, last_seen) VALUES ('c', 'cat', 'victim.test', 't', 0, ?, 1, 1)", id)
+
+        store.clear_flows.should be_true
+
+        store.issues.find { |i| i.id == issue }.not_nil!.flow_id.should be_nil
+        store.@db.query_one("SELECT count(*) FROM probe_issues WHERE sample_flow_id IS NOT NULL",
+          as: Int64).should eq(0)
+      end
+    end
+  end
 end

--- a/spec/tui/fmt_spec.cr
+++ b/spec/tui/fmt_spec.cr
@@ -19,4 +19,45 @@ describe Gori::Tui::Fmt do
       Gori::Tui::Fmt.count(999_999_i64).should eq("1.0M")
     end
   end
+
+  describe ".dur" do
+    it "keeps sub-millisecond latency in µs instead of collapsing it to '0ms'" do
+      # A loopback/LAN response lands here. Truncating to ms rendered every one of these
+      # as "0ms", which flattens the Fuzzer's DIST time histogram to a single bucket.
+      Gori::Tui::Fmt.dur(0_i64).should eq("0µs")
+      Gori::Tui::Fmt.dur(120_i64).should eq("120µs")
+      Gori::Tui::Fmt.dur(511_i64).should eq("511µs")
+      Gori::Tui::Fmt.dur(999_i64).should eq("999µs")
+    end
+
+    it "rounds the millisecond tier instead of truncating it" do
+      Gori::Tui::Fmt.dur(1_000_i64).should eq("1.0ms")
+      Gori::Tui::Fmt.dur(1_500_i64).should eq("1.5ms") # was "1ms"
+      Gori::Tui::Fmt.dur(1_990_i64).should eq("2.0ms") # was "1ms"
+      Gori::Tui::Fmt.dur(345_000_i64).should eq("345ms")
+    end
+
+    it "rolls a value just under a boundary up to the next unit" do
+      Gori::Tui::Fmt.dur(999_600_i64).should eq("1.0s") # not "1000ms"
+      Gori::Tui::Fmt.dur(59_600_000_i64).should eq("1.0m")
+    end
+
+    it "carries the slow tiers" do
+      Gori::Tui::Fmt.dur(2_500_000_i64).should eq("2.5s")
+      Gori::Tui::Fmt.dur(90_000_000_i64).should eq("1.5m")
+      Gori::Tui::Fmt.dur(5_400_000_000_i64).should eq("1.5h")
+    end
+
+    it "stays within the 6-column cell the History DUR column draws" do
+      # history_view draws this with `width: 6`; every tier boundary must fit.
+      [0, 999, 1_000, 999_599, 999_600, 59_599_000, 59_600_000, 3_599_000_000,
+       3_600_000_000, 86_400_000_000].each do |us|
+        Gori::Tui::Fmt.dur(us.to_i64).size.should be <= 6
+      end
+    end
+
+    it "shows an em dash until the response lands" do
+      Gori::Tui::Fmt.dur(nil).should eq("—")
+    end
+  end
 end

--- a/src/gori/cli/run/history.cr
+++ b/src/gori/cli/run/history.cr
@@ -119,9 +119,7 @@ module Gori
           rows =
             if q = query
               filter = QL.parse(q)
-              QL.invalid_regex_terms(q).each do |t|
-                STDERR.puts "gori run history: warning: invalid regex in #{t.inspect} — that term matches nothing"
-              end
+              warn_query_terms(q)
               # A query that fails to compile to ANY clause (e.g. `status:>=foo`)
               # yields the match-all EMPTY filter — silently dumping every flow,
               # the opposite of what the user asked. Refuse it instead.
@@ -168,6 +166,23 @@ module Gori
       # STDOUT stays a pure HAR document (pipe it straight to a file); every caveat — flows
       # skipped, bodies capped — goes to STDERR, because a silently short export is exactly
       # the failure this file keeps having to fix.
+      # Both ways a typed term can fail to do what it says, on STDERR so `--format=json` stays
+      # machine-readable. An invalid regex matches NOTHING (indistinguishable from a genuinely
+      # empty result); a term gori could not compile at all is DROPPED, and a dropped term
+      # BROADENS — `QL::REFERENCE` calls that the dangerous direction. MCP has had `strict:true`
+      # and `ql_explain` for the second case from the start; the CLI had neither and no warning,
+      # so `history -q 'path:/graphql size:>bogus'` printed every /graphql flow with exit 0 and
+      # nothing to suggest the size filter had not been applied.
+      private def self.warn_query_terms(q : String) : Nil
+        QL.invalid_regex_terms(q).each do |t|
+          STDERR.puts "gori run history: warning: invalid regex in #{t.inspect} — that term matches nothing"
+        end
+        ignored = QL.analyze(q).ignored
+        return if ignored.empty?
+        STDERR.puts "gori run history: warning: ignored #{ignored.map(&.inspect).join(", ")} " \
+                    "— unrecognized or invalid, so the result is BROADER than the query asks for"
+      end
+
       private def self.emit_har(store : Store, rows : Array(Store::FlowRow), query : String?,
                                 limit : Int32) : Nil
         details = rows.reverse.each.compact_map { |r| store.get_flow(r.id) }

--- a/src/gori/cli/run/intercept.cr
+++ b/src/gori/cli/run/intercept.cr
@@ -178,7 +178,13 @@ module Gori
               scheme = CLI::Output.term_safe(r.scheme)
               host = CLI::Output.term_safe(r.host)
               target = CLI::Output.term_safe(r.target)
-              puts "##{r.item_id}  [#{r.kind}]  #{method} #{scheme}://#{host}#{target}  (#{body.size}b body)"
+              # A forward-proxy request is held in ABSOLUTE form (`http://host:port/path` —
+              # the wire truth, P7), so prefixing scheme+host doubled it into
+              # `http://127.0.0.1http://127.0.0.1:19160/ws`. `FlowRow.absolute_form?` is the
+              # canonical test for exactly this and its own doc comment names this failure;
+              # this call site simply was not wired to it.
+              url = Store::FlowRow.absolute_form?(target) ? target : "#{scheme}://#{host}#{target}"
+              puts "##{r.item_id}  [#{r.kind}]  #{method} #{url}  (#{body.size}b body)"
             end
           end
         end

--- a/src/gori/cli/run/repeater.cr
+++ b/src/gori/cli/run/repeater.cr
@@ -236,10 +236,12 @@ module Gori
       # here silently overwrites a `repeater create --no-auto-cl` session's hand-set
       # Content-Length on every replay, and no `Plan`-level spec would notice.
       private def self.session_plan_options(rec : Store::RepeaterRecord, insecure : Bool,
-                                            overrides : Gori::HostOverrides?) : Repeater::PlanOptions
+                                            overrides : Gori::HostOverrides?,
+                                            verbatim : Bool = false) : Repeater::PlanOptions
         Repeater::PlanOptions.new([rec.request],
           default_target: rec.target, http2: rec.http2?, sni: rec.sni,
-          auto_content_length: rec.auto_content_length?, verify: !insecure,
+          expand_request: !verbatim,
+          auto_content_length: !verbatim && rec.auto_content_length?, verify: !insecure,
           overrides: overrides)
       end
 
@@ -294,6 +296,7 @@ module Gori
         ws_messages = [] of String
         idle_ms : Int64? = nil
         allow_unscoped = false
+        verbatim = false
         positional = [] of String
 
         parser = OptionParser.new do |p|
@@ -305,6 +308,7 @@ module Gori
           p.on("-k", "--insecure-upstream", "Do not verify the upstream TLS certificate") { insecure = true }
           p.on("--diff", "Diff the new response against the session's last stored response") { do_diff = true }
           p.on("--allow-unscoped", "Send even if the target is outside the project scope (Sandbox/exclude still apply)") { allow_unscoped = true }
+          p.on("--verbatim", "Send the stored bytes EXACTLY: no $VAR expansion, no bare-LF→CRLF promotion, no Content-Length resync, no HTTP/2→1.1 version fix") { verbatim = true }
           p.on("--message=TEXT", "WebSocket: outbound text message (repeatable; replaces the session's stored messages)") { |v| ws_messages << v }
           p.on("--idle-ms=N", "WebSocket: server-silence timeout after the first inbound frame (100-60000, default 3000)") { |v| idle_ms = parse_count(v, "--idle-ms").to_i64 }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
@@ -333,7 +337,7 @@ module Gori
         outbound = project_outbound(project_name, db_path, allow_unscoped)
 
         plan = begin
-          Repeater::Plan.build(session_plan_options(rec, insecure, host_overrides), outbound)
+          Repeater::Plan.build(session_plan_options(rec, insecure, host_overrides, verbatim), outbound)
         rescue ex : Repeater::PlanError
           repeater_plan_abort("gori run repeater send", ex, "session ##{id}")
         end

--- a/src/gori/cli/run/sitemap.cr
+++ b/src/gori/cli/run/sitemap.cr
@@ -25,7 +25,10 @@ module Gori
                      "       gori run sitemap tag --list [--host=H]\n\n" \
                      "Pin a free-text memo onto one sitemap path (the same tags the TUI Sitemap\n" \
                      "tab shows). --path is the node path AS THE TREE SHOWS IT, INCLUDING any\n" \
-                     "query string — /search?q=1 is a different node from /search."
+                     "query string — /search?q=1 is a different node from /search.\n" \
+                     "A tag is keyed by host+path, not by a flow, so it OUTLIVES 'history clear'\n" \
+                     "and re-attaches if that path is captured again; --list finds one whose\n" \
+                     "node is not currently in the tree."
           p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
           p.on("--host=HOST", "Host the path belongs to") { |v| host = v }

--- a/src/gori/filter_ast.cr
+++ b/src/gori/filter_ast.cr
@@ -270,9 +270,25 @@ module Gori
 
     private def self.parse_unary(lx : Array(Lexeme), pos : Int32, depth : Int32) : {Node?, Int32}
       return {nil, pos} if depth > MAX_PARSE_DEPTH
-      if pos < lx.size && lx[pos].tok.not?
-        node, pos = parse_unary(lx, pos + 1, depth + 1)
+      # Consume the whole `NOT` run in a LOOP rather than one recursion per keyword. Recursing
+      # meant the depth cap cut the run in its MIDDLE: the innermost call returned nil having
+      # consumed one `NOT` per level, `parse_and` re-descended on what was left, and the count
+      # that happened to SURVIVE decided polarity. So a 257-deep run matched exactly what a
+      # 256-deep run excluded — the complement of the query, silently, with exit 0 and no
+      # warning. The cap's contract is that an over-deep parse degrades FORGIVINGLY (an
+      # over-deep group parses as if empty); returning the complement is the opposite of that,
+      # and on a security tool a filter that quietly inverts is worse than one that errors —
+      # it hides the rows the operator was looking for. A run is one frame and one tree level
+      # now, so the paren cap alone bounds the native stack.
+      negations = 0
+      while pos < lx.size && lx[pos].tok.not?
+        negations += 1
+        pos += 1
+      end
+      if negations > 0
+        node, pos = parse_primary(lx, pos, depth + 1)
         return {nil, pos} unless node
+        return {node, pos} if negations.even? # NOT NOT x == x, at any depth
         # A lone term flips its own flag; only a group needs a wrapper.
         return {node.is_a?(TermNode) ? TermNode.new(node.term.negated) : NotNode.new(node), pos}
       end

--- a/src/gori/graphql.cr
+++ b/src/gori/graphql.cr
@@ -110,7 +110,8 @@ module Gori
       vars = vi ? lines[(vi + 1)..].join('\n').strip : nil
       body = vi ? lines[0...vi] : lines
       op = nil.as(String?)
-      if (first = body.index { |l| !l.strip.empty? }) && body[first].strip.starts_with?("# operationName:")
+      first = body.index { |l| !l.strip.empty? }
+      if first && body[first].strip.starts_with?("# operationName:") && blank_after?(body, first)
         op = body[first].strip.lchop("# operationName:").strip
         body = body[0...first] + body[(first + 1)..]
       end
@@ -133,7 +134,10 @@ module Gori
       elsif base_vars
         obj["variables"] = base_vars
       end
-      base.try &.each { |k, v| obj[k] = v unless obj.has_key?(k) } # keep extensions etc.
+      # Keep extensions etc. — but NOT `operationName`: the pane always renders it when it is
+      # set, so an operator who deleted the header meant to unset it, and overlaying the base
+      # back silently ignored the deletion. Absence here is a decision, not "unchanged".
+      base.try &.each { |k, v| obj[k] = v unless obj.has_key?(k) || k == "operationName" }
       obj.to_json
     end
 
@@ -142,14 +146,30 @@ module Gori
     # Variables are minified. The GET-binding sibling of recompose (which targets the body).
     def recompose_query(orig_query : String, decoded_text : String) : String
       op, query, vars_text = parse_display(decoded_text)
-      managed = {"query", "operationName", "variables"}
-      parts = orig_query.split('&').reject { |pair| pair.empty? || managed.includes?(pair.partition('=')[0]) }
-      parts << "query=#{URI.encode_www_form(query)}"
-      parts << "operationName=#{URI.encode_www_form(op)}" if op
-      if vars_text
-        mini = (JSON.parse(vars_text).to_json rescue vars_text)
-        parts << "variables=#{URI.encode_www_form(mini)}"
+      mini = vars_text.try { |v| (JSON.parse(v).to_json rescue v) }
+      replacement = {
+        "query"         => "query=#{URI.encode_www_form(query)}",
+        "operationName" => op.try { |o| "operationName=#{URI.encode_www_form(o)}" },
+        "variables"     => mini.try { |m| "variables=#{URI.encode_www_form(m)}" },
+      }
+      # Replace the managed params IN PLACE rather than dropping them and appending. Rejecting
+      # and re-adding moved them to the end, so `page=2&query=…&sig=abc` came back as
+      # `page=2&sig=abc&query=…` — a request the operator did not write, and one that breaks any
+      # signature or cache key computed over the canonical query string. Unmanaged params keep
+      # their positions and their exact spelling either way.
+      seen = Set(String).new
+      parts = [] of String
+      orig_query.split('&').each do |pair|
+        next if pair.empty?
+        key = pair.partition('=')[0]
+        unless replacement.has_key?(key)
+          parts << pair
+          next
+        end
+        next unless seen.add?(key)              # a repeated managed param collapses into the first
+        replacement[key].try { |r| parts << r } # nil = the edit removed it
       end
+      replacement.each { |k, r| parts << r if r && seen.add?(k) } # not in the original: append
       parts.join('&')
     end
 
@@ -162,6 +182,18 @@ module Gori
       else
         :query
       end
+    end
+
+    # `# operationName:` is ALSO a valid GraphQL source comment, so the same disambiguation the
+    # `# variables` sentinel already gets is owed to this one — without it a document whose
+    # FIRST line is a comment starting with those characters had that line deleted from the
+    # query and its text promoted into a real `operationName` field, changing which operation
+    # the server runs. `display` always writes the header as `"# operationName: NAME\n\n"`
+    # (`display` above), so the genuine sentinel is followed by a BLANK line; a comment that
+    # opens a document is followed by more GraphQL.
+    private def blank_after?(lines : Array(String), i : Int32) : Bool
+      nxt = lines[i + 1]?
+      nxt.nil? || nxt.strip.empty?
     end
 
     private def json?(s : String) : Bool

--- a/src/gori/graphql.cr
+++ b/src/gori/graphql.cr
@@ -20,13 +20,35 @@ module Gori
 
     # Parse the operation, or nil if the flow isn't GraphQL. Tries the POST JSON body
     # first, then the GET query string.
+    #
+    # The query-string fallback is NOT reached for a body-bearing method that actually sent a
+    # body: there, the body IS the payload the server reads, so falling through made any
+    # `POST /upload?query=%7Bx%7D` with an unrelated (even binary) body report as GraphQL. That
+    # is not merely a wrong pane — `location` then answers `:query`, so sending it from the
+    # Repeater re-encodes the whole query string, rewriting the operator's request on the
+    # strength of a misdetection. A GET carrying a stray body still falls through, which is
+    # what the fallback was written for.
     def from_flow(target : String, req_head : Bytes?, req_body : Bytes?) : Op?
       if (b = req_body) && !b.empty? && b.size <= MAX_BODY
         if op = from_json(String.new(b))
           return op
         end
       end
+      return nil if (b = req_body) && !b.empty? && body_bearing?(req_head)
       from_query(target)
+    end
+
+    # Whether the request line names a method whose BODY carries the payload. Read off the
+    # head, which `from_flow` has always been handed and never looked at. nil (no head, as in
+    # a unit call) keeps the permissive fallback.
+    private def body_bearing?(req_head : Bytes?) : Bool
+      head = req_head || return false
+      line = String.new(head[0, {head.size, 64}.min])
+      sp = line.index(' ') || return false
+      case line[0, sp].upcase
+      when "POST", "PUT", "PATCH" then true
+      else                             false
+      end
     end
 
     # A POST JSON body. A GraphQL document always has a selection set, so requiring a

--- a/src/gori/mcp/request_builder.cr
+++ b/src/gori/mcp/request_builder.cr
@@ -56,12 +56,25 @@ module Gori
 
         bytes =
           if (raw = args["raw"]?.try(&.as_s?)) && !raw.empty?
-            normalize_raw(Env.expand(raw))
+            # `verbatim` means the operator's bytes ARE the message: no `$VAR` expansion and no
+            # bare-LF promotion. `normalize_raw` exists so a hand-typed request still frames,
+            # but a bare-LF header terminator is a standard front-end/back-end desync
+            # primitive, so promoting it removes a payload class from this surface — the TUI's
+            # byte modes have always been able to send it. `Plan.build` still refuses an
+            # unresolved `$VAR` regardless of expansion, so nothing ships a literal token.
+            raw_bytes(raw, args)
           else
             build_from_parts(uri, scheme, host, port, args)
           end
 
         Built.new(bytes, scheme, host, port)
+      end
+
+      # `verbatim` means the operator's bytes ARE the message. Kept out of `build` so that
+      # method's branch count stays where it was.
+      private def self.raw_bytes(raw : String, args : Hash(String, JSON::Any)) : Bytes
+        return raw.to_slice if args["verbatim"]?.try(&.as_bool?)
+        normalize_raw(Env.expand(raw))
       end
 
       private def self.build_from_parts(uri : URI, scheme : String, host : String, port : Int32,

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -1068,6 +1068,7 @@ module Gori
               s.field "headers", objprop("header name->value map")
               s.field "body", strprop("request body, sent as-is")
               s.field "raw", strprop("verbatim raw HTTP/1.1 request; overrides method/headers/body (scheme/host/port still come from url)")
+              s.field "verbatim", boolprop("send 'raw' EXACTLY as given: no $VAR expansion and no bare-LF→CRLF promotion in the head (default false). Use for desync/smuggling tests where a bare LF header terminator IS the payload")
               s.field "http2", boolprop("use real HTTP/2; defaults to the flow's version when flow_id is set)")
               s.field "timeout_ms", intprop("per-operation connect + idle (read/write) timeout in milliseconds; a timeout surfaces as a network-error result with error_kind (1-600000)")
               s.field "insecure", boolprop("skip upstream TLS verification (default false)")

--- a/src/gori/mcp/tools/flows.cr
+++ b/src/gori/mcp/tools/flows.cr
@@ -16,6 +16,17 @@ module Gori
           return err("pass only one of 'since' (tail newer, oldest-first) or 'before_id' (page older, newest-first)",
             "INVALID_ARGUMENT", field: "since")
         end
+        # `flows.id` is a REUSABLE rowid, so a clear (or deleting the newest flow) restarts
+        # numbering — and a forward cursor held from before that is then permanently ahead of
+        # every row. `since: 22` returned `[]` forever while the rows sat right there at ids
+        # 1-3, with no signal an agent could act on: "no new flows" and "your cursor is
+        # stranded" were the same answer. Say which. Cheap enough to check per call (a
+        # rightmost-leaf seek), and it also covers a cursor held across a project switch.
+        if (cur = since_id) && (newest = store.max_flow_id) && cur > newest
+          return err("cursor #{cur} is ahead of the newest flow #{newest} — history was cleared " \
+                     "or the flows were deleted; restart from since=0",
+            "INVALID_ARGUMENT", field: "since")
+        end
         query = str(h, "query")
         filter = ql_filter_or_error(h, query)
         return filter if filter.is_a?(Result)

--- a/src/gori/mcp/tools/repeater.cr
+++ b/src/gori/mcp/tools/repeater.cr
@@ -34,25 +34,27 @@ module Gori
           flow = store.get_flow(flow_id)
           return not_found("no flow with id #{flow_id}") unless flow
 
-          if target.nil? || target.empty?
-            scheme = flow.row.scheme
-            host = flow.row.host
-            port = flow.row.port
-            default_port = (scheme == "https" ? 443 : 80)
-            target = port == default_port ? "#{scheme}://#{host}" : "#{scheme}://#{host}:#{port}"
-          end
+          # Seed through `FlowRequest.build`, exactly as `gori run repeater create --flow` and
+          # `send_request{flow_id}` do. Hand-assembling head+body here skipped all three things
+          # that function exists for:
+          #   * `resync_truncated_head` — a capture cut at CAPTURE_MAX keeps its original
+          #     `Transfer-Encoding: chunked` over a body with no terminating 0-chunk (or a
+          #     Content-Length promising bytes that no longer exist), so the send blocked for
+          #     the full 30 s io_timeout and put a partial chunked stream on the wire. That
+          #     function's stated reason for existing is "so the repeater terminates instead
+          #     of hanging"; this was the one caller that did not get it.
+          #   * `origin_form_bytes` — every plain-HTTP flow gori captures has an ABSOLUTE-form
+          #     request line (that is how a proxy client writes it), which was then sent
+          #     verbatim to an origin that expects origin-form.
+          #   * `build_target` — this was a third hand-rolled copy of the authority formula,
+          #     without the ws/wss default-port fold or IPv6 re-bracketing the shared one has.
+          built = Repeater::FlowRequest.build(flow)
 
-          if request.nil? || request.empty?
-            req_str = String.new(flow.request_head)
-            if body = flow.request_body
-              req_str += String.new(body)
-            end
-            request = req_str
-          end
-
-          if http2_val.nil?
-            http2 = (flow.http_version == "HTTP/2")
-          end
+          target = built.target if target.nil? || target.empty?
+          request = String.new(built.bytes) if request.nil? || request.empty?
+          http2 = built.http2 if http2_val.nil?
+          # `built.sni` is deliberately NOT seeded here: `gori run repeater create --flow`
+          # takes SNI from the operator's flag alone, and this tool is its MCP twin.
 
           if flow.row.status == 101 && !present?(h, "ws_out_messages")
             ws_messages_override = store.ws_messages(flow_id).select { |m| m.direction == "out" && m.text? }.map { |m| String.new(m.payload).scrub }

--- a/src/gori/probe/analyzer.cr
+++ b/src/gori/probe/analyzer.cr
@@ -35,7 +35,9 @@ module Gori
       property? verify_upstream : Bool
 
       @disabled : Set(String)     # RuleInfo#id of built-ins the operator turned off (Rules sub-tab)
+      @disabled_degraded : Bool   # the disabled-list could not be READ — fail closed on active
       @custom : Array(CustomRule) # merged global+project user match rules
+      @warned_degraded : Bool     # one-shot: the "active skipped, list unreadable" warning
 
       # One enabled active rule that WOULD run against a given flow, plus the request count it
       # sends. `active_estimate` returns these (empty when nothing applies) so the manual "Run
@@ -67,7 +69,8 @@ module Gori
         # Rules sub-tab config: built-ins the operator disabled (by RuleInfo#id) + the merged
         # global+project custom match rules. Read once here so even a one-shot scan_detail
         # (CLI/MCP/Repeater, no start) honours them; reload_rule_config refreshes on UI edits.
-        @disabled = load_disabled
+        @disabled, @disabled_degraded = load_disabled
+        @warned_degraded = false
         @custom = load_custom
       end
 
@@ -76,15 +79,32 @@ module Gori
       # a new custom rule over already-seen traffic. Disabling a rule only stops NEW detections —
       # existing findings persist until dismissed/deleted/cleared.
       def reload_rule_config : Nil
-        @disabled = load_disabled
+        @disabled, @disabled_degraded = load_disabled
         @custom = load_custom
         @analyzed.clear
       end
 
-      private def load_disabled : Set(String)
-        @store.probe_disabled_rules
-      rescue DB::Error | SQLite3::Exception
-        Set(String).new
+      # {the operator's disabled set, degraded}. `degraded` = the list could NOT be read (store
+      # error or corrupt JSON), which is NOT the same as "nothing is disabled": that set is the
+      # only thing between a disabled ACTIVE rule and a real request, so when it is unknown the
+      # active pipeline fails CLOSED (see the guards below). Passive analysis is request-free and
+      # runs regardless. `probe_disabled_rules` now RAISES on a read/parse failure precisely so
+      # this rescue is live — before, the store swallowed it and this could never fire.
+      private def load_disabled : {Set(String), Bool}
+        {@store.probe_disabled_rules, false}
+      rescue DB::Error | SQLite3::Exception | JSON::ParseException
+        {Set(String).new, true}
+      end
+
+      # Fail-closed guard for every active entry point: with the disabled-list unreadable we do
+      # not know which active probes the operator authorised, so we send none and say so once.
+      private def active_degraded? : Bool
+        return false unless @disabled_degraded
+        unless @warned_degraded
+          @warned_degraded = true
+          ::Log.warn { "probe: the disabled-rule list could not be read — ACTIVE probing skipped (fail-closed). Passive analysis still runs. Fix the store/settings and re-scan." }
+        end
+        true
       end
 
       private def load_custom : Array(CustomRule)
@@ -175,6 +195,7 @@ module Gori
       # sent — so it's safe on the render path. Matches exactly what run_active_now will fire.
       def active_estimate(detail : Store::FlowDetail,
                           opts : Active::Options = Active::Options::DEFAULT) : Array(ActiveEstimate)
+        return [] of ActiveEstimate if active_degraded?
         Active::RULES.compact_map do |rule|
           next if @disabled.includes?(rule.info.id)
           next unless rule.dedup_key(detail, opts)
@@ -197,6 +218,7 @@ module Gori
                          allow_unsafe : Bool = false,
                          notify : Miner::NotifyMode = Miner::NotifyMode::WhenFound) : Nil
         return if @stopped
+        return if active_degraded?
         opts = Active::Options.new(allow_unsafe: allow_unsafe)
         spawn(name: "gori-probe-active-manual") do
           found = 0
@@ -359,6 +381,7 @@ module Gori
       private def maybe_enqueue_active(detail : Store::FlowDetail) : Nil
         return if @stopped
         return unless @mode.probes_actively?
+        return if active_degraded? # fail closed: unknown which rules are disabled
         # Skipped here too, purely to keep stubbed flows out of the queue — `Active.analyze`
         # is the refusal that matters and would reject this job anyway (#511).
         return if detail.row.short_circuited?

--- a/src/gori/probe/analyzer.cr
+++ b/src/gori/probe/analyzer.cr
@@ -80,6 +80,7 @@ module Gori
       # existing findings persist until dismissed/deleted/cleared.
       def reload_rule_config : Nil
         @disabled, @disabled_degraded = load_disabled
+        @warned_degraded = false unless @disabled_degraded # re-arm the warning if the store re-breaks
         @custom = load_custom
         @analyzed.clear
       end
@@ -91,7 +92,7 @@ module Gori
       # runs regardless. `probe_disabled_rules` now RAISES on a read/parse failure precisely so
       # this rescue is live — before, the store swallowed it and this could never fire.
       private def load_disabled : {Set(String), Bool}
-        {@store.probe_disabled_rules, false}
+        {@store.probe_disabled_rules_strict, false}
       rescue DB::Error | SQLite3::Exception | JSON::ParseException
         {Set(String).new, true}
       end

--- a/src/gori/probe/scan.cr
+++ b/src/gori/probe/scan.cr
@@ -84,7 +84,9 @@ module Gori
         # same value and must not mean the same thing.
         private def self.load_disabled(store : Store) : {Set(String), Bool}
           {store.probe_disabled_rules, true}
-        rescue DB::Error | SQLite3::Exception
+        rescue DB::Error | SQLite3::Exception | JSON::ParseException
+          # `probe_disabled_rules` now RAISES a parse failure too (it used to swallow it into an
+          # empty set, which made this rescue — and the whole `degraded` flag — dead code).
           {Set(String).new, false}
         end
 

--- a/src/gori/probe/scan.cr
+++ b/src/gori/probe/scan.cr
@@ -83,7 +83,7 @@ module Gori
         # from a broken store and an empty set from a project with nothing disabled are the
         # same value and must not mean the same thing.
         private def self.load_disabled(store : Store) : {Set(String), Bool}
-          {store.probe_disabled_rules, true}
+          {store.probe_disabled_rules_strict, true}
         rescue DB::Error | SQLite3::Exception | JSON::ParseException
           # `probe_disabled_rules` now RAISES a parse failure too (it used to swallow it into an
           # empty set, which made this rescue — and the whole `degraded` flag — dead code).

--- a/src/gori/proxy/h2/extract.cr
+++ b/src/gori/proxy/h2/extract.cr
@@ -76,9 +76,13 @@ module Gori::Proxy::H2
       return if @warned_unscopable
       @warned_unscopable = true
       ::Log.warn do
-        "h2 in: stream #{stream_id} is not tracked (over #{Assembler::MAX_LIVE_STREAMS} live " \
-        "streams), so its response has no request target to scope a session-binding extract " \
-        "rule against — nothing was extracted from it"
+        # Its `stream_gate.cr` twin named the live-stream ceiling unconditionally and fired on
+        # single-stream connections, where the real cause was an undecodable request head. Same
+        # wording here, for the same reason: do not send the operator to a limit they are not near.
+        "h2 in: stream #{stream_id} has no projected request, so its response has no request " \
+        "target to scope a session-binding extract rule against — nothing was extracted from " \
+        "it. Either the request head could not be decoded, or the connection is past " \
+        "#{Assembler::MAX_LIVE_STREAMS} live streams"
       end
     end
   end

--- a/src/gori/proxy/h2/head_codec.cr
+++ b/src/gori/proxy/h2/head_codec.cr
@@ -43,9 +43,9 @@ module Gori::Proxy::H2
       method = pseudo(fields, ":method") || "GET"
       path = pseudo(fields, ":path") || "/"
       String.build do |io|
-        io << method << ' ' << path << " HTTP/2\r\n"
-        io << "Host: " << authority << "\r\n" if !authority.empty? && !explicit_host?(fields)
-        regular(fields) { |n, v| io << n << ": " << v << "\r\n" }
+        io << line_safe(method) << ' ' << line_safe(path) << " HTTP/2\r\n"
+        io << "Host: " << line_safe(authority) << "\r\n" if !authority.empty? && !explicit_host?(fields)
+        regular(fields) { |n, v| io << line_safe(n) << ": " << line_safe(v) << "\r\n" }
         io << "\r\n"
       end.to_slice
     end
@@ -58,9 +58,29 @@ module Gori::Proxy::H2
       status = (pseudo(fields, ":status") || "0").to_i? || 0
       String.build do |io|
         io << "HTTP/2 " << status << "\r\n"
-        regular(fields) { |n, v| io << n << ": " << v << "\r\n" }
+        regular(fields) { |n, v| io << line_safe(n) << ": " << line_safe(v) << "\r\n" }
         io << "\r\n"
       end.to_slice
+    end
+
+    # Keep the synthesis INJECTIVE at the line level: one h2 field must never become two text
+    # lines (#517). `h1_faithful?` is that precondition for `parse_*`/`rewrite`/`encode_edited`,
+    # which refuse outright — but `Assembler` calls `synth_*` DIRECTLY to build the stored head,
+    # and had no such guard, so a peer field whose value carried a CRLF was projected as two
+    # well-formed headers into everything derived from the head: `gori run show`, MCP get_flow,
+    # QL `header:`, the Rewriter preview, and the bytes the Repeater/fuzz/mine editors replay
+    # from. Response-direction is the dangerous one — the value is the ORIGIN'S, so it is a
+    # header-injection primitive handed to whatever replays the projection.
+    #
+    # Refusing is not available here (a captured flow still has to render), so the CR/LF is
+    # escaped instead: the field stays one line, the operator SEES the injected bytes, and the
+    # text cannot be re-read as two fields. This is a projection, not the wire — the raw frames
+    # remain the truth (P7), and `synth_response` already normalizes `:status` the same way.
+    # Every path that could put these bytes back on an h2 wire refuses them before reaching
+    # here, so nothing that was byte-exact stops being byte-exact.
+    private def line_safe(s : String) : String
+      return s unless line_broken?(s)
+      s.gsub('\r', "\\r").gsub('\n', "\\n")
     end
 
     # Invert `synth_request`. `original` supplies everything the h1 text cannot carry.

--- a/src/gori/proxy/h2/head_codec.cr
+++ b/src/gori/proxy/h2/head_codec.cr
@@ -95,8 +95,13 @@ module Gori::Proxy::H2
             # this view to ask. Leaving `\` alone before anything else keeps an ordinary
             # `C:\path` or a regex value byte-identical, so a Match&Replace rule written
             # against one still matches.
+            #
+            # A REAL CR/LF as the next char counts too: it is itself rendered as `\r`/`\n`
+            # below, so a lone `\` in front of it would merge into `\\r` — indistinguishable
+            # from a literal backslash-r. Escaping the `\` here makes `x\<CR>y` come back as
+            # `x\\\ry` (three) versus a literal `x\ry` as `x\\ry` (two).
             nxt = chars[i + 1]?
-            io << (nxt == 'r' || nxt == 'n' || nxt == '\\' ? "\\\\" : "\\")
+            io << (nxt == 'r' || nxt == 'n' || nxt == '\\' || nxt == '\r' || nxt == '\n' ? "\\\\" : "\\")
           else io << c
           end
         end

--- a/src/gori/proxy/h2/head_codec.cr
+++ b/src/gori/proxy/h2/head_codec.cr
@@ -79,8 +79,40 @@ module Gori::Proxy::H2
     # Every path that could put these bytes back on an h2 wire refuses them before reaching
     # here, so nothing that was byte-exact stops being byte-exact.
     private def line_safe(s : String) : String
-      return s unless line_broken?(s)
-      s.gsub('\r', "\\r").gsub('\n', "\\n")
+      return s unless needs_escape?(s)
+      String.build do |io|
+        chars = s.each_char.to_a
+        chars.each_with_index do |c, i|
+          case c
+          when '\r' then io << "\\r"
+          when '\n' then io << "\\n"
+          when '\\'
+            # A backslash is escaped ONLY when it could be read back as one of the escapes
+            # above. Without this the projection is not injective in the direction that
+            # matters: a value carrying the two literal characters `\` `r` rendered
+            # identically to one carrying a real CR, and "was this CRLF injected by the
+            # origin, or did it always contain that text?" is the question an operator opens
+            # this view to ask. Leaving `\` alone before anything else keeps an ordinary
+            # `C:\path` or a regex value byte-identical, so a Match&Replace rule written
+            # against one still matches.
+            nxt = chars[i + 1]?
+            io << (nxt == 'r' || nxt == 'n' || nxt == '\\' ? "\\\\" : "\\")
+          else io << c
+          end
+        end
+      end
+    end
+
+    # `line_safe`'s guard, in one allocation-free pass: a real CR/LF, or a backslash that would
+    # be read back as one of its escapes.
+    private def needs_escape?(s : String) : Bool
+      prev_backslash = false
+      s.each_char do |c|
+        return true if c == '\r' || c == '\n'
+        return true if prev_backslash && (c == 'r' || c == 'n' || c == '\\')
+        prev_backslash = c == '\\'
+      end
+      false
     end
 
     # Invert `synth_request`. `original` supplies everything the h1 text cannot carry.

--- a/src/gori/proxy/h2/head_rewrite.cr
+++ b/src/gori/proxy/h2/head_rewrite.cr
@@ -183,7 +183,7 @@ module Gori::Proxy::H2
     # decoded projection the assembler should use for it (nil = the assembler decodes).
     # Yields nothing while a header block is still being buffered.
     def accept(frame : Frame::Header, &) : Nil
-      opens = frame.frame_type == Frame::Type::Headers || frame.frame_type == Frame::Type::PushPromise
+      opens = block_opener?(frame)
       continues = pending? && frame.frame_type == Frame::Type::Continuation &&
                   frame.stream_id == @block_stream
 
@@ -243,17 +243,42 @@ module Gori::Proxy::H2
       end
       return unless frame.end_headers?
 
-      frames, pre = finish
+      frames, pre = finish # resets @buf itself
       last = frames.size - 1
       frames.each_with_index { |f, i| yield f, (i == last ? pre : nil) }
+    end
+
+    # Any frames still buffered when the connection ends: a block that never got END_HEADERS,
+    # so it never reached `finish` and was never decoded or scope-tested.
+    #
+    # `discard` is the sandbox's answer to that. Verbatim release is P7's "nothing is silently
+    # swallowed", and it stays that with the sandbox OFF (`discard: false`). But a block with no
+    # END_HEADERS has no URL to scope-test, so with the sandbox ON writing it to the peer was the
+    # fifth site of the buffered-block leak — reachable in one frame plus a hangup
+    # (`HEADERS(no END_HEADERS)` for an out-of-scope path, then close). It is dropped instead: the
+    # connection is ending regardless, and the raw h2 frame log already recorded what arrived, so
+    # nothing is lost that P7 needs. Not routed through `undecodable`: `close` wraps only the
+    # `write` in `rescue nil`, so a raise here would escape `@mutex.synchronize` and skip the rest
+    # of `close` (slot cleanup, handing held items back to the Interceptor) — leaking queue rows.
+    def drain(discard : Bool = false, &) : Nil
+      if discard
+        ::Log.warn { "h2: dropped a #{@buf.size}-frame header block with no END_HEADERS at connection close (sandbox on — no URL to scope-test)" } unless @buf.empty?
+      else
+        @buf.each { |f| yield f, nil }
+      end
       reset
     end
 
-    # Any frames still buffered when the connection ends: a block that never got
-    # END_HEADERS. Release them verbatim so nothing is silently swallowed (P7).
-    def drain(&) : Nil
-      @buf.each { |f| yield f, nil }
-      reset
+    # A HEADERS/PUSH_PROMISE that opens a buffered block. `stream_id != 0` is load-bearing:
+    # `StreamGate` now routes connection-level frames through `accept` (so one inside a buffered
+    # block is caught as an intruder), and a HEADERS/PUSH_PROMISE on stream 0 is a §6.2
+    # connection error. Without this guard such a frame would OPEN a block, `defer?` could mint a
+    # Slot keyed 0, and every later SETTINGS/PING/WINDOW_UPDATE would park behind it — the freeze
+    # D1 rule 1 forbids. With it, a stream-0 frame falls to the `unless opens || continues` yield
+    # and is written at once, as before.
+    private def block_opener?(frame : Frame::Header) : Bool
+      (frame.frame_type == Frame::Type::Headers || frame.frame_type == Frame::Type::PushPromise) &&
+        frame.stream_id != 0
     end
 
     private def pending? : Bool
@@ -275,16 +300,26 @@ module Gori::Proxy::H2
     # and will write them when the operator decides.
     private def finish : {Array(Frame::Header), Assembler::HeadBlock}
       first = @buf.first
-      split = split_block(first)
+      split = split_block(first) # reads every frame in @buf (assembles the CONTINUATIONs)
+      # Snapshot the frames and `reset` HERE, the moment `split_block` has finished reading
+      # `@buf`, rather than at the single `defer?` site below. Everything between this point
+      # and the return — `decode_head_block`, `head_text`, `notice_coalesced`, `rewrite`
+      # (which runs OPERATOR REGEXES over PEER BYTES), `@encoder.encode`, and `defer?` itself —
+      # can raise, and a raise unwinds to `StreamGate#close`'s `drain`, which writes whatever
+      # is still in `@buf` to the peer. Leaving `@buf` full through all of that is the residual
+      # window each per-site fix closed one at a time; clearing it up front closes the class.
+      # `snapshot` is what a passthrough block and `unreadable` forward — never `@buf` again.
+      snapshot = @buf.dup
+      reset
       # Malformed padding (RFC 7540 §6.1): we cannot locate the block, so forward exactly
       # what arrived and let the assembler drop the projection, as `validate_pad` does.
-      return unreadable(first) if split.nil?
+      return unreadable(first, snapshot) if split.nil?
       prefix, block = split
 
       fields = @assembler.decode_head_block(@direction, block)
       # Malformed/hostile HPACK. Same disposition, and the nil projection is what stops the
       # assembler from running a second (differently-positioned) decode over the same bytes.
-      return unreadable(first) if fields.nil?
+      return unreadable(first, snapshot) if fields.nil?
 
       request = @direction == "out"
       head = head_text(fields, first, request)
@@ -298,7 +333,8 @@ module Gori::Proxy::H2
       built = if rewritten.nil? && !@engaged
                 # Unchanged, and this direction has never re-encoded: byte-exact passthrough,
                 # which is also what keeps the peer's HPACK table driven by the original encoder.
-                Block.new(@buf.dup, Assembler::HeadBlock.new(pairs(fields)), fields, head, first, prefix, request)
+                # `snapshot`, not `@buf` — `@buf` was cleared above.
+                Block.new(snapshot, Assembler::HeadBlock.new(pairs(fields)), fields, head, first, prefix, request)
               else
                 @engaged = true
                 # A rule changed the head, so the TEXT the gate would show a human is the
@@ -308,30 +344,19 @@ module Gori::Proxy::H2
                 Block.new(reframe(first, prefix, @encoder.encode(emit_fields)),
                   Assembler::HeadBlock.new(pairs(emit_fields)), emit_fields, shown, first, prefix, request)
               end
-      # `defer?` can RAISE — `StreamGate` ends the connection once `remember_refused` passes
-      # MAX_REFUSED_STREAMS — and `accept`'s `reset` only runs after `finish` RETURNS, so the
-      # completed block sat in `@buf` and `close`'s drain wrote it to the peer. That is the
-      # third site of the leak the ceiling and `unreadable` branches were fixed for: measured
-      # at 4200 refused streams on one connection, the 4097th refusal reached the origin
-      # complete (END_HEADERS|END_STREAM) at the moment the ceiling fired. `built.frames` is
-      # already an independent array, so clearing first is safe and `accept`'s trailing
-      # `reset` becomes a no-op.
-      reset
+      # `@buf` was already cleared at the top, so `defer?` raising here (StreamGate ends the
+      # connection past MAX_REFUSED_STREAMS) leaves `close`'s drain nothing to write.
       return {[] of Frame::Header, built.pre} if @deferrer.try(&.defer?(built))
       {built.frames, built.pre}
     end
 
-    # A block this direction could not read. The frames go out exactly as they arrived, with a
-    # nil projection so the assembler does not attempt its own decode — that part is unchanged.
-    # What is new is telling the `Deferrer` first: it may refuse a connection it has gone blind
-    # on, which is the only honest answer for a blocking gate. See `Deferrer#undecodable`.
-    private def unreadable(first : Frame::Header) : {Array(Frame::Header), Assembler::HeadBlock}
-      # Same ordering rule as the ceiling branch: take the frames and `reset` before telling the
-      # deferrer, since `undecodable` raises with the sandbox on and `StreamGate#close` would
-      # otherwise write this still-buffered block to the peer. `accept`'s trailing `reset` on
-      # the normal return is then a no-op.
-      frames = @buf.dup
-      reset
+    # A block this direction could not read. The frames go out exactly as they arrived (from the
+    # snapshot `finish` took before clearing `@buf`), with a nil projection so the assembler does
+    # not attempt its own decode. The `Deferrer` is told first: it may refuse a connection it has
+    # gone blind on, which is the only honest answer for a blocking gate — and since `@buf` is
+    # already empty, that raise reaches `close`'s drain with nothing to leak.
+    private def unreadable(first : Frame::Header,
+                           frames : Array(Frame::Header)) : {Array(Frame::Header), Assembler::HeadBlock}
       @deferrer.try(&.undecodable(first.stream_id))
       {frames, Assembler::HeadBlock.new(nil)}
     end

--- a/src/gori/proxy/h2/head_rewrite.cr
+++ b/src/gori/proxy/h2/head_rewrite.cr
@@ -194,8 +194,21 @@ module Gori::Proxy::H2
       # handling (and the assembler's #409 guard) take it from there. Order and P7 both
       # survive, and the assembler sees exactly the frames it would have seen.
       if pending? && !continues
-        @buf.each { |f| yield f, nil }
+        # The buffered block is abandoned here WITHOUT ever reaching `finish`, so it is never
+        # decoded and never scope-tested — flushing it verbatim was a live sandbox bypass in
+        # three frames: HEADERS(1) with END_HEADERS cleared for an out-of-scope path, ANY
+        # intruder frame (a bare PRIORITY does it), then the CONTINUATION. Measured: the origin
+        # received both halves of `/blocked` and ANSWERED it, while the control without the
+        # intruder got `RST_STREAM code=8` and the origin got nothing. That every route in is
+        # itself a §6.10 violation is not a mitigation gori may lean on — it is the reasoning
+        # `undecodable`'s own comment rejects, and the out-of-scope bytes reach the origin
+        # either way. So tell the deferrer, exactly as the ceiling and HPACK-failure branches
+        # do: this IS "a head with no URL to scope-test". Sandbox ON ends the connection;
+        # sandbox OFF keeps the verbatim forward the paragraph above describes (P7).
+        frames, stream = @buf.dup, @block_stream
         reset
+        @deferrer.try(&.undecodable(stream))
+        frames.each { |f| yield f, nil }
       end
 
       unless opens || continues
@@ -295,6 +308,15 @@ module Gori::Proxy::H2
                 Block.new(reframe(first, prefix, @encoder.encode(emit_fields)),
                   Assembler::HeadBlock.new(pairs(emit_fields)), emit_fields, shown, first, prefix, request)
               end
+      # `defer?` can RAISE — `StreamGate` ends the connection once `remember_refused` passes
+      # MAX_REFUSED_STREAMS — and `accept`'s `reset` only runs after `finish` RETURNS, so the
+      # completed block sat in `@buf` and `close`'s drain wrote it to the peer. That is the
+      # third site of the leak the ceiling and `unreadable` branches were fixed for: measured
+      # at 4200 refused streams on one connection, the 4097th refusal reached the origin
+      # complete (END_HEADERS|END_STREAM) at the moment the ceiling fired. `built.frames` is
+      # already an independent array, so clearing first is safe and `accept`'s trailing
+      # `reset` becomes a no-op.
+      reset
       return {[] of Frame::Header, built.pre} if @deferrer.try(&.defer?(built))
       {built.frames, built.pre}
     end

--- a/src/gori/proxy/h2/head_rewrite.cr
+++ b/src/gori/proxy/h2/head_rewrite.cr
@@ -216,9 +216,16 @@ module Gori::Proxy::H2
       # by 64 MiB of CONTINUATION. With the sandbox off `undecodable` is a no-op and this
       # stays the verbatim forward it has always been.
       if @block_bytes > Assembler::MAX_HEADER_BLOCK
-        @deferrer.try(&.undecodable(@block_stream))
-        @buf.each { |f| yield f, nil }
+        # Drain the buffer into a local and `reset` BEFORE the deferrer is told, because
+        # `undecodable` RAISES to end the connection when the sandbox is on. The raise unwinds
+        # through `pump_gated`'s `ensure gate.close`, and `close` drains this same buffer
+        # straight to `@dst` (`stream_gate.cr`) — so leaving the frames here forwarded the very
+        # block the gate had just refused to let past, unexamined, while the WARN said the
+        # opposite. Empty buffer, nothing for `close` to write.
+        frames, stream = @buf.dup, @block_stream
         reset
+        @deferrer.try(&.undecodable(stream))
+        frames.each { |f| yield f, nil }
         return
       end
       return unless frame.end_headers?
@@ -297,8 +304,14 @@ module Gori::Proxy::H2
     # What is new is telling the `Deferrer` first: it may refuse a connection it has gone blind
     # on, which is the only honest answer for a blocking gate. See `Deferrer#undecodable`.
     private def unreadable(first : Frame::Header) : {Array(Frame::Header), Assembler::HeadBlock}
+      # Same ordering rule as the ceiling branch: take the frames and `reset` before telling the
+      # deferrer, since `undecodable` raises with the sandbox on and `StreamGate#close` would
+      # otherwise write this still-buffered block to the peer. `accept`'s trailing `reset` on
+      # the normal return is then a no-op.
+      frames = @buf.dup
+      reset
       @deferrer.try(&.undecodable(first.stream_id))
-      {@buf.dup, Assembler::HeadBlock.new(nil)}
+      {frames, Assembler::HeadBlock.new(nil)}
     end
 
     # This block's h1-equivalent head text, or nil when the block is not a message head.

--- a/src/gori/proxy/h2/stream_gate.cr
+++ b/src/gori/proxy/h2/stream_gate.cr
@@ -196,7 +196,11 @@ module Gori::Proxy::H2
     # the queue until a human acts.
     def close : Nil
       slots = @mutex.synchronize do
-        @heads.drain { |f, pre| write(f, pre) rescue nil }
+        # Discard a still-buffered (no-END_HEADERS) block on the REQUEST leg when the sandbox is
+        # on: it was never scope-tested, so writing it to the peer is a bypass. `undecodable`'s
+        # own gate (`@ordered && sandbox_enabled?`) is the condition. `drain` writes it verbatim
+        # otherwise (P7). Discarding cannot raise, so the rest of `close` still runs.
+        @heads.drain(discard: @ordered && @interceptor.sandbox_enabled?) { |f, pre| write(f, pre) rescue nil }
         @closed = true
         vals = @slots.values
         @slots.clear
@@ -253,13 +257,6 @@ module Gori::Proxy::H2
 
     private def accept_locked(frame : Frame::Header) : Array(UInt32)
       return NO_CROSS if @closed
-      # Connection-level frames are NEVER deferred (#492 step 3, D1 rule 1): parking a SETTINGS
-      # ACK, a PING or the SHARED connection window behind a held stream kills the connection
-      # or starves every stream on it. `Assembler#feed` already treats stream 0 as not-a-stream.
-      if frame.stream_id == 0
-        write(frame, nil)
-        return NO_CROSS
-      end
       cross = NO_CROSS
       # Every header block goes through `@heads` even for a deferred stream: the per-direction
       # HPACK decoder must advance in ARRIVAL order, so a block cannot wait in a Slot undecoded
@@ -267,6 +264,19 @@ module Gori::Proxy::H2
       # blocks (trailers) still carry the peer's HPACK insertions, so they must be decoded even
       # though nothing is written.
       @heads.accept(frame) do |f, pre|
+        if f.stream_id == 0
+          # Connection-level frames are NEVER deferred (#492 step 3, D1 rule 1): parking a
+          # SETTINGS ACK, a PING or the SHARED connection window behind a held stream kills the
+          # connection or starves every stream on it. They now flow THROUGH `@heads.accept`
+          # rather than being hoisted ahead of it, so one arriving inside a buffered header
+          # block hits the §6.2/§6.10 intruder rule (ending the connection under the sandbox)
+          # instead of being reordered past it and the block silently repaired. `HeadRewrite`'s
+          # `opens` excludes stream 0, so a `HEADERS(0)` — itself a §6.2 connection error —
+          # cannot open a buffered block here and mint a Slot keyed 0 that later PINGs park
+          # behind. `Assembler#feed` already treats stream 0 as not-a-stream.
+          write(f, nil)
+          next
+        end
         slot = @slots[f.stream_id]?
         if @refused.includes?(f.stream_id)
           # Swallowed, not written: the far leg never saw this stream open. Deliberately not

--- a/src/gori/proxy/h2/stream_gate.cr
+++ b/src/gori/proxy/h2/stream_gate.cr
@@ -543,10 +543,12 @@ module Gori::Proxy::H2
       return nil if status < 200
       ref = @assembler.request_ref(block.stream_id)
       if ref.nil?
-        # No request projected for this stream (past `Assembler::MAX_LIVE_STREAMS`). h1 scopes a
-        # response hold on the REQUEST's target (`client_conn.cr:501`); with no request target
-        # there is nothing to scope against, and inventing one is how a hold escapes scope.
-        warn_unscopable(block.stream_id)
+        # No request projected for this stream. h1 scopes a response hold on the REQUEST's
+        # target (`client_conn.cr:501`); with no request target there is nothing to scope
+        # against, and inventing one is how a hold escapes scope. Warn only when a hold could
+        # actually have happened — this runs before `intercepts_response?`, so it used to fire
+        # on connections with intercept switched off entirely.
+        warn_unscopable(block.stream_id) if @interceptor.enabled?
         return nil
       end
       host, port = Upstream.split_host_port(ref.authority, @port)
@@ -836,8 +838,15 @@ module Gori::Proxy::H2
       return if @warned_scope
       @warned_scope = true
       ::Log.warn do
-        "h2 in: stream #{stream_id} is not tracked (over #{Assembler::MAX_LIVE_STREAMS} live " \
-        "streams), so its response has no request target to scope an intercept hold against — not held"
+        # Do NOT assert the cause. This message named the live-stream ceiling unconditionally,
+        # and it fired on connections carrying a SINGLE stream — where the real reason was an
+        # undecodable request head, so the assembler never tracked the stream in the first
+        # place. An operator asking "why did my hold not fire / why did $SESSION not bind" was
+        # sent to look at a limit they were nowhere near. Same shape as the #536 note about
+        # this message.
+        "h2 in: stream #{stream_id} has no projected request, so its response has no request " \
+        "target to scope an intercept hold against — not held. Either the request head could " \
+        "not be decoded, or the connection is past #{Assembler::MAX_LIVE_STREAMS} live streams"
       end
     end
   end

--- a/src/gori/proxy/upstream.cr
+++ b/src/gori/proxy/upstream.cr
@@ -180,10 +180,22 @@ module Gori::Proxy
       h.empty? || unspecified?(h)
     end
 
+    # An IPv6 literal reaches the dial path BRACKETED — that is how it appears in an
+    # absolute-form request target and what `URI#host` hands back — but a bracketed string is
+    # not an address, so `TCPSocket.new` treats it as a hostname and the resolve fails. gori
+    # therefore could not reach an IPv6-literal origin at all (`curl -x … 'http://[::1]:p/'`
+    # failed while the same origin answered 200 direct). This file already strips the brackets
+    # at the two OTHER places a host becomes an address — `socks5_write_address` and
+    # `normalize_host` — and `dial_via_proxy` adds them back for the CONNECT authority; the
+    # direct dial was the one site not wired to the same rule.
+    private def self.bare_host(h : String) : String
+      h.starts_with?('[') && h.ends_with?(']') ? h[1...-1] : h
+    end
+
     private def self.direct_dial(host : String, port : Int32,
                                  connect_timeout : Time::Span = Settings.connect_timeout,
                                  io_timeout : Time::Span = Settings.io_timeout) : TCPSocket?
-      sock = TCPSocket.new(host, port, connect_timeout: connect_timeout)
+      sock = TCPSocket.new(bare_host(host), port, connect_timeout: connect_timeout)
       begin
         sock.sync = true # flush writes immediately (P6)
         sock.tcp_nodelay = true
@@ -349,7 +361,7 @@ module Gori::Proxy
     # A host arriving bracketed ("[::1]") is an IPv6 literal — the brackets are URL syntax and
     # must not reach the wire, where the address is 16 raw bytes.
     private def self.socks5_write_address(sock : TCPSocket, host : String) : Bool
-      bare = host.starts_with?('[') && host.ends_with?(']') ? host[1...-1] : host
+      bare = bare_host(host)
       if ip = parse_ip(bare)
         v4 = ip.family == Socket::Family::INET
         sock.write(Bytes[v4 ? SOCKS_ATYP_IPV4 : SOCKS_ATYP_IPV6])

--- a/src/gori/proxy/ws/relay.cr
+++ b/src/gori/proxy/ws/relay.cr
@@ -160,16 +160,23 @@ module Gori::Proxy::WS
       clean_close = false
       loop do
         h = WS.read_header(src) || break
-        message_opcode = h.opcode if h.data? && h.opcode != OP_CONT
+        # A new data message arriving while the previous one never sent its FIN is an RFC 6455
+        # §5.4 violation. `capture_frame` only emits on FIN, so without this the two messages
+        # were concatenated into ONE History row — `TEXT fin=0 "AAA"` then `TEXT fin=1 "BBB"`
+        # surfaced as `AAABBB` while the origin correctly received two frames. `AssemblingPump`
+        # was given this reset explicitly (`start_message`) and the oversized branch below has
+        # it too; the default pump, which every socket with no rule and no hold runs, did not —
+        # so the two pumps disagreed about identical bytes. Capture only: the wire is untouched.
+        if h.data? && h.opcode != OP_CONT
+          assembling = emit_pending(assembling, direction, flow_id, sink, message_opcode)
+          message_opcode = h.opcode
+        end
 
         if h.len > WS::MAX_FRAME
           # Flush any buffered leading fragments of this message before the oversized-frame
           # marker, so captured prefix bytes aren't dropped and a later small FIN fragment
           # can't be surfaced as if it were the whole message.
-          if h.data? && assembling.size > 0
-            sink.on_ws_message(flow_id, direction, message_opcode.to_i, assembling.to_slice.dup)
-            assembling = assembling.size > RESET_THRESHOLD ? IO::Memory.new : assembling.tap(&.clear)
-          end
+          assembling = emit_pending(assembling, direction, flow_id, sink, message_opcode) if h.data?
           break unless forward_oversized_frame(src, dst, h, direction, flow_id, sink, message_opcode, scratch)
           if h.close? # an oversized CLOSE still terminates the tunnel, like a normal one
             clean_close = true
@@ -190,6 +197,30 @@ module Gori::Proxy::WS
       clean_close
     rescue
       false # peer closed / reset: this direction ends
+    ensure
+      # An unterminated fragment when the direction ends. gori already put those bytes on the
+      # wire frame by frame, so dropping them here made History disagree with what gori itself
+      # relayed — `TEXT fin=0 "UNTERMINATED"` then a CLOSE left no row at all. Emitted on both
+      # the clean and the reset path, which is why this is an `ensure` and not a tail statement.
+      # `AssemblingPump#run`'s own `ensure` flushes its withheld half for the same reason.
+      # `ensure` types every body-assigned local as nilable (the raise could precede the
+      # assignment), so bind it before asking.
+      if buf = assembling
+        emit_pending(buf, direction, flow_id, sink, message_opcode || OP_TEXT) rescue nil
+      end
+    end
+
+    # Surface whatever fragments are buffered as ONE message and hand back a cleared buffer.
+    # A no-op when nothing is buffered. Three callers need exactly this: a new data message
+    # arriving before the previous one FIN'd (RFC 6455 §5.4), an oversized frame that ends the
+    # buffered prefix, and teardown with an unterminated fragment still held. They had two
+    # copies and one omission between them, which is how the merged-row and dropped-bytes bugs
+    # got in; `AssemblingPump` has the same three moments and its own equivalents.
+    private def self.emit_pending(assembling : IO::Memory, direction : String, flow_id : Int64,
+                                  sink : FlowSink, message_opcode : UInt8) : IO::Memory
+      return assembling if assembling.size == 0
+      sink.on_ws_message(flow_id, direction, message_opcode.to_i, assembling.to_slice.dup)
+      assembling.size > RESET_THRESHOLD ? IO::Memory.new : assembling.tap(&.clear)
     end
 
     # The assembling pump for ONE direction (#500). Only reached when a `part: ws` rule can

--- a/src/gori/ql.cr
+++ b/src/gori/ql.cr
@@ -85,6 +85,14 @@ module Gori
 
       Regex (~): host~^api\\.  body~secret\\d+  path~/admin
 
+      body: SEARCHES AN INDEX, AND THE INDEX IS BOUNDED. `body:` reads a trigram index that
+      covers only the FIRST 8 KiB of each side (request and response), and a body is not
+      indexed at all when its Content-Type is binary or its Content-Encoding is compressed.
+      So `body:` can return NOTHING for content that is genuinely there — deep in a large
+      body, or in a gzipped/binary one. `body~regex` scans the stored bytes instead, with no
+      cap and no content-type rule, so it is the one to reach for when `body:` comes back
+      empty and you expected a hit. (`body:` is the fast path; `body~` is the complete one.)
+
       Free text (no field:): matches method, host, or target (case-insensitive substring).
 
       Invalid syntax (e.g. status:>=foo with no numeric value) is rejected — it does NOT match all flows.
@@ -293,9 +301,11 @@ module Gori
     end
 
     # Body search uses the trigram FTS index over request/response body text —
-    # case-insensitive SUBSTRING matching (same semantics as the old `body:` LIKE,
-    # so `body:token` still finds "mytokenvalue"), just indexed instead of
-    # scanning every BLOB. The value is passed as a quoted FTS phrase (embedded
+    # case-insensitive SUBSTRING matching (so `body:token` still finds "mytokenvalue"),
+    # indexed instead of scanning every BLOB. NOT the same result set as the old LIKE
+    # scan, and `REFERENCE` now says so: the index covers only the first
+    # `Store::FTS_INDEX_MAX` bytes per side and skips binary/compressed bodies, so
+    # `body:` can miss content `body~` finds. The value is passed as a quoted FTS phrase (embedded
     # quotes doubled) so arbitrary characters can't form FTS operator syntax. A
     # bodyless flow has an empty FTS row, so it never matches and `-body:x`
     # correctly KEEPS it. The trigram index needs >=3 characters, so shorter
@@ -311,13 +321,38 @@ module Gori
       # spellings agree.
       return nil if value.empty?
       if value.size < 3
-        p = like(value)
-        return {"((request_body IS NOT NULL AND lower(CAST(request_body AS TEXT)) LIKE ? ESCAPE '\\') OR " \
-                "(response_body IS NOT NULL AND lower(CAST(response_body AS TEXT)) LIKE ? ESCAPE '\\'))",
-                [p, p] of DB::Any}
+        # BYTE-wise, not `CAST(... AS TEXT)`: SQLite truncates a BLOB→TEXT cast at the first
+        # NUL, so the LIKE fallback stopped scanning there and a body of
+        # `head\0NULNEEDLE tail` was invisible to `body:nu` while `body:NULNEEDLE` (the FTS
+        # path, >=3 chars) found it. A SHORTER needle matching FEWER rows is a monotonicity
+        # violation that cannot be explained to an operator, and this is a tool whose targets
+        # deliberately put NULs in bodies. `instr` over the raw BLOB is NUL-transparent, and a
+        # NULL body yields NULL (falsy), so `-body:x` still KEEPS a bodyless flow.
+        #
+        # `instr` is case-SENSITIVE while `body:` promises case-insensitive substring matching,
+        # so match every case permutation of the needle instead — at most four, since this
+        # branch only runs for one or two characters.
+        conds = [] of String
+        params = [] of DB::Any
+        case_permutations(value).each do |v|
+          conds << "instr(request_body, CAST(? AS BLOB)) > 0"
+          conds << "instr(response_body, CAST(? AS BLOB)) > 0"
+          params << v << v
+        end
+        return {"(#{conds.join(" OR ")})", params}
       end
       phrase = %("#{value.gsub('"', "\"\"")}") # quoted phrase → contiguous substring match
       {"id IN (SELECT rowid FROM flows_fts WHERE flows_fts MATCH ?)", [phrase] of DB::Any}
+    end
+
+    # Every upper/lower spelling of a one- or two-character needle, so a byte-wise `instr`
+    # can stand in for a case-insensitive LIKE. Bounded at 4 by `body_cond`'s `size < 3`
+    # guard; a character with no case (a digit, a symbol, most CJK) contributes one variant.
+    private def self.case_permutations(value : String) : Array(String)
+      value.each_char.reduce([""]) do |acc, ch|
+        forms = [ch.downcase, ch.upcase].uniq!
+        acc.flat_map { |prefix| forms.map { |f| prefix + f } }
+      end.uniq!
     end
 
     # Split a leading comparison operator (<= >= < > =, default =) off a value. Shared

--- a/src/gori/ql.cr
+++ b/src/gori/ql.cr
@@ -326,17 +326,22 @@ module Gori
         # `head\0NULNEEDLE tail` was invisible to `body:nu` while `body:NULNEEDLE` (the FTS
         # path, >=3 chars) found it. A SHORTER needle matching FEWER rows is a monotonicity
         # violation that cannot be explained to an operator, and this is a tool whose targets
-        # deliberately put NULs in bodies. `instr` over the raw BLOB is NUL-transparent, and a
-        # NULL body yields NULL (falsy), so `-body:x` still KEEPS a bodyless flow.
+        # deliberately put NULs in bodies. `instr` over the raw BLOB is NUL-transparent.
         #
         # `instr` is case-SENSITIVE while `body:` promises case-insensitive substring matching,
         # so match every case permutation of the needle instead — at most four, since this
         # branch only runs for one or two characters.
+        # `COALESCE`-wrapped, and that is load-bearing: a NULL body (a bodyless GET, or any
+        # response-less/in-flight flow — the common case) makes `instr(NULL, …)` NULL, and
+        # `NOT (NULL > 0)` is NULL, which SQLite's three-valued logic then EXCLUDES — so a bare
+        # `instr` made `-body:x` silently drop every bodyless flow (a silent NARROW, the mirror
+        # of the broaden this path guards against). `COALESCE(…, 0) > 0` is FALSE for a NULL
+        # body, so the positive term still skips it and `NOT FALSE` keeps it under negation.
         conds = [] of String
         params = [] of DB::Any
         case_permutations(value).each do |v|
-          conds << "instr(request_body, CAST(? AS BLOB)) > 0"
-          conds << "instr(response_body, CAST(? AS BLOB)) > 0"
+          conds << "COALESCE(instr(request_body, CAST(? AS BLOB)), 0) > 0"
+          conds << "COALESCE(instr(response_body, CAST(? AS BLOB)), 0) > 0"
           params << v << v
         end
         return {"(#{conds.join(" OR ")})", params}

--- a/src/gori/repeater/conn_pool.cr
+++ b/src/gori/repeater/conn_pool.cr
@@ -100,6 +100,16 @@ module Gori::Repeater
       # bytes were consumed — see reusable_response?.
       method = Repeater::Engine.request_method(bytes)
       if keepable && (io = @idle.pop?)
+        # Residue check AT CHECKOUT, not only when we parked it. The previous exchange's leftover
+        # bytes (a body past Content-Length, a HEAD-with-body) may not have arrived by the time
+        # `recycle` ran — the origin can be a peer whose write races our park — so `recycle`'s
+        # check is an early retire, and THIS one, right before we write onto the socket, is the
+        # reliable one: by now any straggler residue is on the wire. Without it a poisoned socket
+        # would frame this request's response against the previous response's leftovers.
+        unless drained?(io)
+          close(io)
+          return dial_and_send(bytes, keepable, method)
+        end
         started = Time.instant
         result = Repeater::Engine.exchange(io, bytes, @host, @port, started)
         if stale?(result)
@@ -146,17 +156,17 @@ module Gori::Repeater
 
     # Park the socket for the next send, or close it. Same retirement rule `send_pipeline`
     # applies to a group's connection (error or incomplete ⇒ unusable), plus the response's
-    # own keep-alive signals — AND that the socket is actually empty. `reusable_response?`
-    # interrogates only the response HEAD; it cannot see that the origin left extra bytes on
-    # the wire past the framed body (a body longer than its Content-Length, or a HEAD reply
-    # that carried one). `Body.read_complete` reads exactly the framed count and returns
-    # `complete`, so that residue stays in the receive buffer, and the NEXT checkout reads it
-    # as its response head — every send after the poison shifted by one, reported 200 with no
-    # error. Those two are the canonical response-desync primitives gori exists to DETECT, so
-    # a non-empty socket is retired, never handed to the next payload.
+    # own keep-alive signals.
+    #
+    # The EMPTY-socket check that guards against residue (a body past Content-Length, a
+    # HEAD-with-body — the canonical response-desync primitives gori exists to DETECT) lives at
+    # CHECKOUT (`send`), not here. Residue can arrive AFTER we would park — the origin's write
+    # races our recycle — so checking here would miss a straggler and still hand a poisoned
+    # socket to the next send. `reusable_response?` interrogates only the response HEAD and
+    # cannot see the leftover bytes; the checkout-time `drained?` is what catches them, once
+    # they are reliably on the wire.
     private def recycle(io : IO, result : Repeater::Result, keepable : Bool, method : String) : Nil
-      if @pooling && keepable && @idle.size < @max_idle &&
-         ConnPool.reusable_response?(result, method) && drained?(io)
+      if @pooling && keepable && @idle.size < @max_idle && ConnPool.reusable_response?(result, method)
         @idle.push(io)
       else
         close(io)
@@ -229,12 +239,18 @@ module Gori::Repeater
     # instead, so `stale?` said false, the request was NOT retried, and the payload surfaced a
     # "connection reset" the origin never saw — a silent false negative in the middle of a
     # sweep, plus `@consecutive_stale` never advanced so `STALE_GIVE_UP` could never bound the
-    # wasted redials against an origin that always resets. The real discriminator is "no
-    # response byte was read", not which IO error ended it: `response.nil?` means head parsing
-    # never began. An INCOMPLETE response (head read, body cut) is deliberately NOT stale — the
-    # origin may already have processed the request, so re-sending could double a side effect.
+    # wasted redials against an origin that always resets.
+    #
+    # The discriminator is "no response byte was DELIVERED", not which IO error ended it.
+    # `response.nil?` alone is not that: `exchange` returns `response: nil` for an interim-1xx
+    # failure too (`malformed interim` / `too many interim` / `upstream closed after interim`),
+    # and by then the origin has the whole request (gori writes it up front), so re-sending a
+    # non-idempotent POST would DOUBLE its side effect. `delivered?` is false only before any
+    # response byte arrives — a clean EOF, a reset, or a write failure on a parked socket — which
+    # is exactly the re-sendable case. An INCOMPLETE response (head read, body cut) carries a
+    # non-nil `response` and so is already excluded.
     private def stale?(result : Repeater::Result) : Bool
-      !result.error.nil? && result.response.nil?
+      !result.error.nil? && result.response.nil? && !result.delivered?
     end
 
     private def drain : Nil

--- a/src/gori/repeater/conn_pool.cr
+++ b/src/gori/repeater/conn_pool.cr
@@ -2,6 +2,21 @@ require "../proxy/codec/body"
 require "../proxy/codec/http1"
 require "./engine"
 
+# Non-blocking "is there residue in the read buffer?" — the piece Crystal's public IO has no
+# way to ask. `ConnPool#drained?` needs it because `read_head` reads byte-by-byte through the
+# buffered layer, which pulls a large chunk off the socket into `@in_buffer_rem`; any bytes
+# the origin left past the framed body therefore sit in THAT buffer, not on the kernel socket,
+# where an fd-level `MSG_PEEK` cannot see them. `peek` would find them but calls `fill_buffer`
+# (blocking) when the buffer is empty, which is the common clean-socket case — so it cannot be
+# used on the keep-alive fast path. Reading `@in_buffer_rem` directly is the only non-blocking
+# answer. The name is long-standing Crystal internals; if it ever changes this fails to compile
+# rather than silently misbehaving.
+module IO::Buffered
+  def gori_buffered_residue? : Bool
+    !@in_buffer_rem.empty?
+  end
+end
+
 module Gori::Repeater
   # HTTP/1.1 keep-alive connection pool for a sweep's sends.
   #
@@ -131,17 +146,95 @@ module Gori::Repeater
 
     # Park the socket for the next send, or close it. Same retirement rule `send_pipeline`
     # applies to a group's connection (error or incomplete ⇒ unusable), plus the response's
-    # own keep-alive signals.
+    # own keep-alive signals — AND that the socket is actually empty. `reusable_response?`
+    # interrogates only the response HEAD; it cannot see that the origin left extra bytes on
+    # the wire past the framed body (a body longer than its Content-Length, or a HEAD reply
+    # that carried one). `Body.read_complete` reads exactly the framed count and returns
+    # `complete`, so that residue stays in the receive buffer, and the NEXT checkout reads it
+    # as its response head — every send after the poison shifted by one, reported 200 with no
+    # error. Those two are the canonical response-desync primitives gori exists to DETECT, so
+    # a non-empty socket is retired, never handed to the next payload.
     private def recycle(io : IO, result : Repeater::Result, keepable : Bool, method : String) : Nil
-      if @pooling && keepable && @idle.size < @max_idle && ConnPool.reusable_response?(result, method)
+      if @pooling && keepable && @idle.size < @max_idle &&
+         ConnPool.reusable_response?(result, method) && drained?(io)
         @idle.push(io)
       else
         close(io)
       end
     end
 
+    # POSIX `MSG_PEEK` — read-without-consume. Not in Crystal's `LibC`, but the value is
+    # 0x02 on every platform gori targets (Linux, macOS, the BSDs).
+    MSG_PEEK = 0x02
+
+    # The short-probe deadline for a non-`TCPSocket` (TLS) socket, where the fd trick below
+    # cannot see decrypted application bytes. Only ever paid on a socket that turns out
+    # CLEAN, which is the common case — but a reused TLS socket has already saved a full
+    # handshake, so a millisecond to prove it is safe is a good trade.
+    DRAIN_PROBE = 1.millisecond
+
+    # Whether the socket has NO unread bytes waiting. A parked socket must be empty, or the
+    # next request reads the leftovers as its own response.
+    #
+    # For a plaintext `TCPSocket` this is an fd-level `MSG_PEEK` — Crystal's socket fd is
+    # already non-blocking (evented IO), so `recv` returns immediately: `EAGAIN`/`EWOULDBLOCK`
+    # means nothing is waiting (drained), any byte or an EOF means retire. ~0.3µs, so it costs
+    # the keep-alive fast path nothing. A TLS socket hides its fd and the residue may sit in
+    # OpenSSL's decrypted buffer where a raw peek cannot see it, so it falls back to a short
+    # read probe, which naturally covers both `SSL_pending` and a kernel-buffered record.
+    private def drained?(io : IO) : Bool
+      # 1. Residue already pulled into the buffered layer by `read_head`'s byte reads. This is
+      #    where a body-past-Content-Length or a HEAD-with-body actually lands, and it is
+      #    non-blocking, so it must be checked FIRST.
+      return false if io.is_a?(IO::Buffered) && io.gori_buffered_residue?
+      # 2. Residue still on the kernel socket. A plaintext `TCPSocket`'s fd is non-blocking
+      #    (evented IO), so `MSG_PEEK` returns at once: `EAGAIN`/`EWOULDBLOCK` = nothing waiting
+      #    (drained), any byte or EOF = retire. ~0.3µs, so the clean plaintext path pays
+      #    nothing. A TLS socket hides its fd and OpenSSL may hold a partial record, so it
+      #    falls back to a short read probe (only ever paid on a socket that turns out clean —
+      #    and a reused TLS socket has already saved a whole handshake).
+      # EOF here (the peer already sent FIN) is deliberately NOT treated as residue: a closed
+      # socket is the idle-timeout race the stale-retry path already handles by re-sending on a
+      # fresh connection, and papering over it here would bypass STALE_GIVE_UP's bookkeeping.
+      # Only actual WAITING BYTES cause misattribution, so only those retire the socket.
+      if io.is_a?(TCPSocket)
+        buf = uninitialized UInt8[1]
+        n = LibC.recv(io.fd, buf.to_unsafe.as(Void*), LibC::SizeT.new(1), MSG_PEEK)
+        return true if n == 0 # EOF — let stale? handle it
+        n < 0 && {Errno::EAGAIN, Errno::EWOULDBLOCK}.includes?(Errno.value)
+      elsif io.responds_to?(:read_timeout=) && io.responds_to?(:read_timeout)
+        prev = io.read_timeout
+        begin
+          io.read_timeout = DRAIN_PROBE
+          io.read_byte.nil? # nil = EOF (drained, stale? handles it); a byte = residue (retire)
+        rescue IO::TimeoutError
+          true
+        ensure
+          io.read_timeout = prev
+        end
+      else
+        true # an IO with no timeout knob is not a pooled socket; nothing to prove
+      end
+    rescue
+      false # any probe error ⇒ do not risk parking a bad socket
+    end
+
+    # A REUSED socket that failed BEFORE any response byte arrived: the request never reached
+    # the application, so — per the contract at the top of this class — it is re-sent once on
+    # a fresh connection. Only ever consulted on the `@idle.pop?` branch, so "reused" is
+    # implicit.
+    #
+    # It used to compare the error string to `no_response_error` exactly, which matches ONLY a
+    # clean EOF. An origin that RESET the parked socket failed with an `Errno`-derived message
+    # instead, so `stale?` said false, the request was NOT retried, and the payload surfaced a
+    # "connection reset" the origin never saw — a silent false negative in the middle of a
+    # sweep, plus `@consecutive_stale` never advanced so `STALE_GIVE_UP` could never bound the
+    # wasted redials against an origin that always resets. The real discriminator is "no
+    # response byte was read", not which IO error ended it: `response.nil?` means head parsing
+    # never began. An INCOMPLETE response (head read, body cut) is deliberately NOT stale — the
+    # origin may already have processed the request, so re-sending could double a side effect.
     private def stale?(result : Repeater::Result) : Bool
-      result.error == Repeater::Engine.no_response_error(@host, @port)
+      !result.error.nil? && result.response.nil?
     end
 
     private def drain : Nil

--- a/src/gori/repeater/engine.cr
+++ b/src/gori/repeater/engine.cr
@@ -20,8 +20,17 @@ module Gori
       # a consumer must not treat a half-delivered response as the whole thing. Distinct
       # from a *display* truncation (gori capping what it shows).
       getter? incomplete : Bool
+      # Whether ANY response byte (even an interim 1xx) was received before this Result was
+      # built. It answers the one question the pool's stale-retry needs and `response.nil?`
+      # cannot: a failure with no response yet means the request never reached the application
+      # and is safe to re-send, but a failure AFTER a 1xx means the origin already has the whole
+      # request (gori writes it up front), so re-sending would double a non-idempotent side
+      # effect. Only set on the error paths; a normal Result carries a non-nil `response`, where
+      # this is irrelevant.
+      getter? delivered : Bool
 
-      def initialize(@head, @body, @response, @duration_us, @error = nil, @incomplete = false)
+      def initialize(@head, @body, @response, @duration_us, @error = nil, @incomplete = false,
+                     @delivered = false)
       end
 
       def ok? : Bool
@@ -149,14 +158,14 @@ module Gori
           # (Content-Length / Transfer-Encoding) is malformed and a desync vector
           # (its body can embed a fake final response) — refuse it.
           if resp.headers.get?("Content-Length") || resp.headers.get?("Transfer-Encoding")
-            return error("malformed interim 1xx response (declared a body) from #{host}:#{port}", started)
+            return error("malformed interim 1xx response (declared a body) from #{host}:#{port}", started, delivered: true)
           end
           # Cap the run so an origin streaming endless body-less 103s can't hang the
           # repeater/fuzz worker fiber indefinitely (there is no whole-request deadline).
           interim_seen += 1
-          return error("too many interim 1xx responses from #{host}:#{port}", started) if interim_seen > MAX_INTERIM
+          return error("too many interim 1xx responses from #{host}:#{port}", started, delivered: true) if interim_seen > MAX_INTERIM
           head = read_response_head(upstream)
-          return error("upstream closed after interim 1xx from #{host}:#{port}", started) unless head
+          return error("upstream closed after interim 1xx from #{host}:#{port}", started, delivered: true) unless head
           resp = Proxy::Codec::Http1.parse_response_head(head)
         end
         # A reply whose status-line can't be parsed (no HTTP-version, or a non-numeric status —
@@ -186,7 +195,11 @@ module Gori
           Result.new(head, nil, resp, elapsed(started), error: ex.message || "response read failed", incomplete: true)
         end
       rescue ex
-        error(ex.message || "repeater error", started)
+        # `head` is nil iff we failed before/at the FIRST head read (a write error, or a reset
+        # on a parked socket) — the pre-delivery case the pool may re-send. A raise AFTER a head
+        # was read (an interim-1xx read that then reset) means the origin already has the whole
+        # request, so mark it delivered and do not re-send a non-idempotent one.
+        error(ex.message || "repeater error", started, delivered: !head.nil?)
       end
 
       # Read a response head with a TOTAL head-assembly deadline (parity with the proxy's
@@ -204,8 +217,8 @@ module Gori
 
       # An error Result with no head/body, timed from `started` (shared with the pool, which
       # reports a failed dial the same way `send` does).
-      def self.error(message : String, started : Time::Instant) : Result
-        Result.new(Bytes.new(0), nil, nil, elapsed(started), message)
+      def self.error(message : String, started : Time::Instant, delivered : Bool = false) : Result
+        Result.new(Bytes.new(0), nil, nil, elapsed(started), message, delivered: delivered)
       end
 
       # The dialer collapses DNS failure / connection refused / timeout / TLS-verify

--- a/src/gori/repeater/flow_request.cr
+++ b/src/gori/repeater/flow_request.cr
@@ -196,6 +196,17 @@ module Gori
         "#{line[0, sp]} HTTP/1.1"
       end
 
+      # `downgrade_version_line` over a whole WIRE request, so `Plan.build` can apply it on the
+      # one path every surface shares instead of only the TUI doing it. Operates on the first
+      # CRLF-terminated line and returns the input UNCHANGED (same object) when there is
+      # nothing to correct, so a request whose version the operator meant is byte-untouched.
+      def self.downgrade_request_line(wire : Bytes) : Bytes
+        text = String.new(wire)
+        eol = text.index("\r\n") || return wire
+        fixed = downgrade_version_line(text[0, eol]) || return wire
+        "#{fixed}#{text[eol..]}".to_slice
+      end
+
       # Normalize bare LFs in a MULTIPART body to CRLF. Multipart parts are delimited by
       # CRLF + boundary (RFC 2046 §5.1.1), so a body carrying bare LFs is unparseable and
       # the origin answers 400 — usually with no hint as to why, because auto-Content-Length

--- a/src/gori/repeater/h2_engine.cr
+++ b/src/gori/repeater/h2_engine.cr
@@ -275,7 +275,21 @@ module Gori
         lines[1..]?.try &.each do |line|
           next if line.empty?
           colon = line.index(':')
-          next unless colon && colon > 0
+          # A non-empty line that is not a header field means this text has no faithful h2
+          # form, and skipping it SILENTLY sent a different request than the operator wrote.
+          # It is what a payload carrying a bare LF produces: `x-fuzz: be\naf` splits here, the
+          # `af` tail lands on a line with no colon, and the field went out as `x-fuzz: be`
+          # while the Fuzzer labelled the result row with the whole `be\naf` payload — a status
+          # measured against a request gori never sent. h1 carries those bytes verbatim (P7,
+          # malformed input IS the payload); h2 has no encoding for them, so the honest answer
+          # is to refuse the send and say so, exactly as the proxy's `HeadCodec.h1_faithful?`
+          # refuses the same shape on the rewrite path. A CRLF that yields two WELL-FORMED
+          # fields is left alone deliberately: that is indistinguishable from the operator
+          # typing two headers, and h1 puts two headers on the wire for it too.
+          raise Gori::Error.new(
+            "cannot send over h2: #{line.inspect} is not a header field. A CR, LF or NUL " \
+            "inside a header value has no HTTP/2 representation (RFC 9113 §8.2.1) — h1 " \
+            "carries those bytes verbatim, h2 cannot.") unless colon && colon > 0
           name = line[0...colon].strip.downcase
           value = line[(colon + 1)..].strip
           if name == "host"
@@ -289,7 +303,23 @@ module Gori
         headers = [{":method", method}, {":path", path}, {":scheme", scheme},
                    {":authority", authority_override || authority(host, port, scheme)}]
         headers.concat(regular)
+        headers.each { |(n, v)| reject_uncarriable(n, v) }
         {headers, body}
+      end
+
+      # RFC 9113 §8.2.1: a field name or value may carry no CR, LF or NUL. `rstrip('\r')`
+      # above only removes a TRAILING CR, so a lone CR mid-value survived the split and went
+      # out raw, and a NUL was never looked at — both producing a field a conformant peer must
+      # treat as malformed, with no notice to the operator and the Fuzzer still labelling the
+      # row with the payload it believed it sent. Refusing here keeps the h1/h2 divergence
+      # visible instead of silent; the h1 engine is unchanged and still sends them byte-exact.
+      private def self.reject_uncarriable(name : String, value : String) : Nil
+        {name, value}.each do |s|
+          next unless s.each_char.any? { |c| c == '\r' || c == '\n' || c == '\0' }
+          raise Gori::Error.new(
+            "cannot send over h2: #{name.inspect} carries a CR, LF or NUL, which has no " \
+            "HTTP/2 representation (RFC 9113 §8.2.1) — h1 sends those bytes verbatim, h2 cannot.")
+        end
       end
 
       private def self.authority(host : String, port : Int32, scheme : String) : String

--- a/src/gori/repeater/minimize.cr
+++ b/src/gori/repeater/minimize.cr
@@ -97,8 +97,17 @@ module Gori::Repeater
                  resolve : Proc(String, Bytes),
                  backend : Fuzz::Backend,
                  & : Progress ->) : Report
+      # Every text helper below documents itself as operating on the LF editor form, and the
+      # TUI does feed LF (`TextArea#set_text` strips CR). The CLI and MCP feed the STORED
+      # bytes, which are CRLF — and `split_text`'s `index("\n\n")` finds nothing in a CRLF
+      # request, so `has_body` came back false and body-param candidates were never
+      # enumerated. The same session minimized further from the TUI than from `gori run
+      # repeater minimize` on identical bytes. Normalise once here so the file's stated
+      # assumption is actually true, and put the operator's line endings back on the way out.
+      crlf = base_text.includes?("\r\n")
+      base_text = base_text.gsub("\r\n", "\n") if crlf
       candidates = candidates_for(base_text, auto_cl: auto_cl)
-      return Report.new(base_text, [] of Removed, 0, false, "already minimal — nothing removable") if candidates.empty?
+      return Report.new(restore_eol(base_text, crlf), [] of Removed, 0, false, "already minimal — nothing removable") if candidates.empty?
 
       sends = 0
       # --- calibrate a FROZEN baseline from the original request ---
@@ -112,10 +121,10 @@ module Gori::Repeater
           sigs << behavior_signature(r.head)
         end
       end
-      return Report.new(base_text, [] of Removed, sends, true, "baseline unreachable — request left unchanged") if metrics.empty?
+      return Report.new(restore_eol(base_text, crlf), [] of Removed, sends, true, "baseline unreachable — request left unchanged") if metrics.empty?
       statuses = metrics.compact_map(&.status).uniq!
       unless statuses.size <= 1
-        return Report.new(base_text, [] of Removed, sends, true,
+        return Report.new(restore_eol(base_text, crlf), [] of Removed, sends, true,
           "baseline response unstable (status #{statuses.join("/")}) — request left unchanged")
       end
       baseline = calibrate(metrics, sigs)
@@ -131,14 +140,20 @@ module Gori::Repeater
         next if variant.nil? || variant == working # already gone under an earlier removal
         r = backend.send(resolve.call(variant))
         sends += 1
-        return Report.new(working, removed, sends, false, cap_note(removed)) if r.error == Fuzz::CappedBackend::CAP_ERROR
+        return Report.new(restore_eol(working, crlf), removed, sends, false, cap_note(removed)) if r.error == Fuzz::CappedBackend::CAP_ERROR
         if unchanged?(r, baseline)
           working = variant
           removed << Removed.new(cand.kind, cand.label)
         end
       end
       yield Progress.new(total, total)
-      Report.new(working, removed, sends, false, summary_note(removed, sends))
+      Report.new(restore_eol(working, crlf), removed, sends, false, summary_note(removed, sends))
+    end
+
+    # Put CRLF back on a report built from LF-normalised text. After the normalisation above
+    # there is no lone CR left, so this is exact.
+    private def self.restore_eol(text : String, crlf : Bool) : String
+      crlf ? text.gsub("\n", "\r\n") : text
     end
 
     # ── candidate enumeration ──────────────────────────────────────────────────────────

--- a/src/gori/repeater/plan.cr
+++ b/src/gori/repeater/plan.cr
@@ -211,7 +211,12 @@ module Gori::Repeater
       # share. It is deliberately narrow (only the h2/h3 spellings; `HTTP/1.0` and a probe's
       # `HTTP/9.9` are left alone), and it cannot touch an h2 send, which never builds a
       # version line from this text.
-      wires = wires.map { |b| FlowRequest.downgrade_request_line(b) } unless options.http2?
+      # Gated on `expand_request?` as well: that flag is what a surface sets to mean "these
+      # bytes are the message, do not help" — the TUI's hex/byte modes, MCP's pre-expanded
+      # `raw`, and `gori run repeater send --verbatim`. Every other normalization on this path
+      # is already behind it, and a version line is the operator's to get wrong when they asked
+      # for verbatim.
+      wires = wires.map { |b| FlowRequest.downgrade_request_line(b) } if options.expand_request? && !options.http2?
 
       unless scheme.in?("http", "https")
         raise PlanError.new(PlanError::Reason::UnsupportedScheme,

--- a/src/gori/repeater/plan.cr
+++ b/src/gori/repeater/plan.cr
@@ -202,6 +202,16 @@ module Gori::Repeater
       # `resync_content_length` never ADDS a header, but a captured upgrade that happened to
       # carry a Content-Length would be rewritten, so skip the pass rather than rely on that.
       wires = wires.map { |b| FlowRequest.resync_content_length(b) } if options.auto_content_length? && !websocket
+      # `HTTP/2` on the version line of a request going down an h1 socket is never anything
+      # but a mistake (a Burp-pasted h2 view, or a captured h2 flow replayed as h1), and
+      # `FlowRequest.downgrade_version_line` exists to correct it. Its comment says it "runs
+      # unasked on every send", but the TUI was its only caller — so the SAME session sent
+      # different bytes from the TUI than from `gori run repeater send` / MCP
+      # `send_request{repeater_id}`. Doing it here puts it on the one path all three surfaces
+      # share. It is deliberately narrow (only the h2/h3 spellings; `HTTP/1.0` and a probe's
+      # `HTTP/9.9` are left alone), and it cannot touch an h2 send, which never builds a
+      # version line from this text.
+      wires = wires.map { |b| FlowRequest.downgrade_request_line(b) } unless options.http2?
 
       unless scheme.in?("http", "https")
         raise PlanError.new(PlanError::Reason::UnsupportedScheme,

--- a/src/gori/repeater/ws_engine.cr
+++ b/src/gori/repeater/ws_engine.cr
@@ -115,8 +115,18 @@ module Gori
 
           # The FIRST inbound read keeps the generous handshake bound (a slow first
           # reply isn't a dead server); drain narrows to `idle` once frames flow.
+          sent_count = messages.size
           close_code = drain(upstream, messages, idle)
           send_close(upstream)
+          # The "out" rows above are appended before the flush and with no delivery evidence —
+          # WebSocket has no ack, so a transcript row means "gori wrote this", never "the peer
+          # got it". When the origin closes right after the 101 the drain breaks at EOF and
+          # `send_close` is rescued, so the run reported `upgraded: true`, `error: null` and
+          # listed messages the origin never received (verified at the origin: handshake only,
+          # no frame). Say so instead. A NOTE and not an error: a one-way protocol that never
+          # answers is legitimate, and in both cases the honest statement is the same —
+          # delivery is unconfirmed.
+          note = with_delivery_note(note, sent_count, messages.size, close_code)
           Result.new(head, messages, elapsed(started), note: note,
             close_code: close_code, upgraded: true)
         rescue ex
@@ -126,6 +136,15 @@ module Gori
         ensure
           upstream.close rescue nil
         end
+      end
+
+      # Append the unconfirmed-delivery advisory to whatever `note` already says. Kept out of
+      # `send` so that method's branch count stays where it was.
+      private def self.with_delivery_note(note : String?, sent : Int32, total : Int32,
+                                          close_code : Int32?) : String?
+        return note unless sent > 0 && total == sent && close_code.nil?
+        unreplied = "sent #{sent} message(s) but the peer sent no frame and no close — delivery unconfirmed"
+        note ? "#{note}; #{unreplied}" : unreplied
       end
 
       # Read inbound frames until the server sends Close, goes idle (read timeout),

--- a/src/gori/rules.cr
+++ b/src/gori/rules.cr
@@ -658,8 +658,9 @@ module Gori
     end
 
     # Does `host` satisfy a rule's host glob? Empty = all hosts. A glob with `*` is an
-    # anchored wildcard (`*.example.com`); without `*` it is a case-insensitive substring
-    # (`example.com` matches `api.example.com`).
+    # anchored wildcard (`*.example.com`); without `*` it matches the host ITSELF or any
+    # SUBDOMAIN of it, case-insensitively (`example.com` matches `example.com` and
+    # `api.example.com`, but not `xexample.com` or `example.com.evil.net`).
     #
     # Exposed on the class because an extract rule (#501) carries the same host glob and
     # must mean the same thing by it — an operator who learned the dialect in the Rewriter's
@@ -681,7 +682,17 @@ module Gori
           false
         end
       else
-        h.includes?(g)
+        # DNS LABEL boundaries, not a raw substring. The dialect's intent is "this host and
+        # its subdomains" — the doc's own example is `example.com` matching `api.example.com`
+        # — but `includes?` also matched anything that merely CONTAINED the string, so a rule
+        # scoped to `alpha.test` fired on `xalpha.test`, `alpha.testing.com` and
+        # `alpha.test.evil.com`. This gate backs EVERY rule op (body, ws, short_circuit, head
+        # and header) and the extract rules that mint session bindings, so on a tool whose
+        # rules inject credentials (`SetHeader $SESSION`) or answer requests itself
+        # (`short_circuit`) that over-match sends the operator's secret to, or fakes a
+        # response for, a host they never scoped — one an attacker can simply register.
+        # `*` stays the explicit wildcard for anything wider.
+        h == g || h.ends_with?(g.starts_with?('.') ? g : ".#{g}")
       end
     end
 

--- a/src/gori/sequencer/stats.cr
+++ b/src/gori/sequencer/stats.cr
@@ -439,10 +439,29 @@ module Gori::Sequencer
       # shuffled by concurrency), but isn't fixed here — a coordinate-only fix couldn't
       # reuse the sort-then-diff trick since this path also weighs HOW closely order
       # tracks magnitude, not just whether the values are evenly spaced.
+      # Skip the constant prefix every token shares before reading the leading magnitude. A
+      # counter behind an >=8-char fixed prefix (`PREFIXAB000001`, `PREFIXAB000002`, …) has a
+      # CONSTANT leading value in the first 8 bytes → variance 0 → correlation 0 → mislabeled
+      # "none/random", exactly the token shape a tester is trying to catch. Dropping the shared
+      # prefix puts the varying region under the 8-byte window.
+      skip = common_prefix_len(tokens)
       xs = Array(Float64).new(n, &.to_f)
-      ys = tokens.map { |t| leading_value(t) }
+      ys = tokens.map { |t| leading_value(t, skip) }
       r = pearson(xs, ys)
       {r.abs > 0.9, "corr=#{fmt(r)}"}
+    end
+
+    # Length of the longest prefix every token shares, byte-wise. Bounded by the shortest
+    # token. Zero when the tokens diverge at the first byte (the common case).
+    private def self.common_prefix_len(tokens : Array(String)) : Int32
+      return 0 if tokens.size < 2
+      first = tokens[0].to_slice
+      limit = tokens.min_of(&.bytesize)
+      i = 0
+      while i < limit && tokens.all? { |t| t.to_slice[i] == first[i] }
+        i += 1
+      end
+      i
     end
 
     # The constant gap between every consecutive pair in `values`, or nil if the gaps
@@ -457,9 +476,11 @@ module Gori::Sequencer
       (2...values.size).all? { |i| values[i] - values[i - 1] == step } ? step : nil
     end
 
-    private def self.leading_value(t : String) : Float64
+    private def self.leading_value(t : String, skip : Int32 = 0) : Float64
       v = 0.0
-      t.to_slice[0, {8, t.bytesize}.min].each { |b| v = v * 256.0 + b }
+      slice = t.to_slice
+      start = {skip, slice.size}.min
+      slice[start, {8, slice.size - start}.min].each { |b| v = v * 256.0 + b }
       v
     end
 

--- a/src/gori/store/probe_rules.cr
+++ b/src/gori/store/probe_rules.cr
@@ -16,19 +16,27 @@ module Gori
     # as a JSON array under one settings key (like probe_mode); the analyzer skips these.
     PROBE_DISABLED_KEY = "probe_disabled_rules"
 
-    # The built-in probe rules the operator turned OFF. This set is the ONLY thing standing
-    # between an ACTIVE rule the operator disabled and a real request going out, so it must NOT
-    # swallow a read failure into an empty set — "the store was unreadable" and "nothing is
-    # disabled" are the same value but must not mean the same thing. It therefore RAISES on a
-    # store or parse error (the callers in `Scan`/`Analyzer` rescue it and fail CLOSED — skip
-    # active probing rather than send everything). A malformed-but-readable value is still
-    # tolerated per element, since a single bad entry should not blind the whole set.
+    # The built-in probe rules the operator turned OFF, tolerant form: an unreadable/corrupt
+    # value degrades to the empty set. This is the DISPLAY/edit read — the Rules sub-tab, the
+    # rule list, and the toggle commands — where an unreadable value should render as
+    # "nothing disabled" rather than crash the surface (the TUI event loop has no catch-all).
     def probe_disabled_rules : Set(String)
+      probe_disabled_rules_strict
+    rescue
+      Set(String).new
+    end
+
+    # The AUTHORIZATION read for active probing. This set is the ONLY thing between an ACTIVE
+    # rule the operator disabled and a real request, so here a read failure must NOT look like
+    # "nothing is disabled": it RAISES, and the callers in `Scan`/`Analyzer` rescue it and fail
+    # CLOSED (skip active probing rather than send everything). A malformed-but-readable value
+    # is still tolerated per element — a single bad entry should not blind the whole set.
+    def probe_disabled_rules_strict : Set(String)
       out = Set(String).new
       raw = setting(PROBE_DISABLED_KEY)
       if raw && !raw.strip.empty?
         # A truncated/corrupt JSON blob RAISES here (JSON::ParseException) — deliberately not
-        # rescued, so the failure reaches the fail-closed callers.
+        # rescued, so the failure reaches the fail-closed active-send callers.
         JSON.parse(raw).as_a?.try &.each { |e| e.as_s?.try { |s| out << s unless s.empty? } }
       end
       out

--- a/src/gori/store/probe_rules.cr
+++ b/src/gori/store/probe_rules.cr
@@ -16,15 +16,22 @@ module Gori
     # as a JSON array under one settings key (like probe_mode); the analyzer skips these.
     PROBE_DISABLED_KEY = "probe_disabled_rules"
 
+    # The built-in probe rules the operator turned OFF. This set is the ONLY thing standing
+    # between an ACTIVE rule the operator disabled and a real request going out, so it must NOT
+    # swallow a read failure into an empty set — "the store was unreadable" and "nothing is
+    # disabled" are the same value but must not mean the same thing. It therefore RAISES on a
+    # store or parse error (the callers in `Scan`/`Analyzer` rescue it and fail CLOSED — skip
+    # active probing rather than send everything). A malformed-but-readable value is still
+    # tolerated per element, since a single bad entry should not blind the whole set.
     def probe_disabled_rules : Set(String)
       out = Set(String).new
       raw = setting(PROBE_DISABLED_KEY)
       if raw && !raw.strip.empty?
+        # A truncated/corrupt JSON blob RAISES here (JSON::ParseException) — deliberately not
+        # rescued, so the failure reaches the fail-closed callers.
         JSON.parse(raw).as_a?.try &.each { |e| e.as_s?.try { |s| out << s unless s.empty? } }
       end
       out
-    rescue
-      Set(String).new
     end
 
     def set_probe_disabled_rules(ids : Set(String)) : Nil

--- a/src/gori/store/reads.cr
+++ b/src/gori/store/reads.cr
@@ -209,6 +209,7 @@ module Gori
         # so a large clear doesn't leave a full-size tombstone table behind.
         c.exec("INSERT INTO flows_fts(flows_fts) VALUES('delete-all')")
         c.exec("DELETE FROM entity_links WHERE ref_kind = 'flow'")
+        detach_flow_refs(c, nil)
         c.exec("DELETE FROM flows")
         c.exec("DELETE FROM h2_frames")
         c.exec("DELETE FROM h2_connections")
@@ -223,6 +224,7 @@ module Gori
       conn.exec("DELETE FROM ws_messages WHERE flow_id = ? AND repeater_id IS NULL", id)
       conn.exec("DELETE FROM flows_fts WHERE rowid = ?", id)
       conn.exec("DELETE FROM entity_links WHERE ref_kind = 'flow' AND ref_id = ?", id)
+      detach_flow_refs(conn, id)
       # The h2 frame log (often the flow's bulk bytes) — capture the conn BEFORE deleting
       # the flow row so we can reclaim it if this was the last flow on that connection.
       h2_conn = conn.query_one?("SELECT h2_conn_id FROM flows WHERE id = ?", id, as: Int64?)
@@ -234,6 +236,55 @@ module Gori
       if cid = h2_conn
         conn.exec("DELETE FROM h2_frames WHERE conn_id = ? AND ? NOT IN (SELECT h2_conn_id FROM flows WHERE h2_conn_id IS NOT NULL)", cid, cid)
         conn.exec("DELETE FROM h2_connections WHERE id = ? AND id NOT IN (SELECT h2_conn_id FROM flows WHERE h2_conn_id IS NOT NULL)", cid, cid)
+      end
+    end
+
+    # The newest flow id, or nil in an empty project. A rightmost-leaf seek on the primary
+    # key — measured at ~6 ms including process startup on a 50k-flow / 3.4 GB project, so it
+    # is free enough to run per cursored read.
+    def max_flow_id : Int64?
+      @db.query_one?("SELECT MAX(id) FROM flows", as: Int64?)
+    rescue
+      nil
+    end
+
+    # Every table that cross-references a flow by id, in one place. `id` nil = every flow is
+    # going (a clear), so every reference is dangling.
+    #
+    # `flows.id` is a plain `INTEGER PRIMARY KEY`, i.e. the rowid, which SQLite REUSES: delete
+    # the newest flow (or clear the project) and the next capture is handed the same id. These
+    # columns were deliberately left dangling on the assumption that they would resolve to
+    # "gone" — they do not, they re-point at whatever traffic takes the id next. Measured: a
+    # probe finding promoted to an Issue after a clear cited a flow captured afterwards, and
+    # `get_repeater_context` reported a session as seeded from an unrelated request. On a tool
+    # whose product is evidence, silently wrong evidence is the worst outcome available;
+    # NULLing turns it into absent evidence, which every one of these surfaces already renders
+    # honestly.
+    #
+    # `entity_links` is DELETED rather than kept-and-marked-stale (`links.cr` renders a
+    # dangling ref as `(stale)`, which reads better) for the same reason: while ids are
+    # reusable, a kept pointer re-binds, and re-binding is strictly worse than losing the
+    # pointer. Marking stale becomes the right answer only once ids are monotonic — which
+    # needs a `flows` table rebuild, measured at 16.1 s on a 50k-flow project against a 5 s
+    # `busy_timeout`, i.e. a hard `database is locked` for every other gori process. That
+    # belongs in an opt-in maintenance command, not on open.
+    #
+    # `ws_messages.flow_id` is NOT NULL, so a repeater-owned WS row (`repeater_id` set, which
+    # `delete_flow_one` deliberately spares) keeps its id. Its session is covered instead:
+    # `repeaters.flow_id` is nulled here, which is where a surface reads the provenance from.
+    private def detach_flow_refs(conn : DB::Connection, id : Int64?) : Nil
+      {"issues", "repeaters", "fuzz_sessions", "miner_sessions", "sequencer_sessions",
+       "events", "intercept_held"}.each do |table|
+        if fid = id
+          conn.exec("UPDATE #{table} SET flow_id = NULL WHERE flow_id = ?", fid)
+        else
+          conn.exec("UPDATE #{table} SET flow_id = NULL WHERE flow_id IS NOT NULL")
+        end
+      end
+      if fid = id
+        conn.exec("UPDATE probe_issues SET sample_flow_id = NULL WHERE sample_flow_id = ?", fid)
+      else
+        conn.exec("UPDATE probe_issues SET sample_flow_id = NULL WHERE sample_flow_id IS NOT NULL")
       end
     end
 

--- a/src/gori/store/reads.cr
+++ b/src/gori/store/reads.cr
@@ -197,7 +197,13 @@ module Gori
 
     # Wipe every captured History flow in this project (and their WS/FTS/h2 logs and
     # flow entity_links). Repeater-owned WS rows (repeater_id set) and workbench sessions
-    # are left intact. Issues/Probe keep dangling sample flow ids.
+    # are left intact, and so are `sitemap_tags`: a tag is the OPERATOR'S memo on a path, in
+    # the same class as a note or an issue, and `history clear` clears captured traffic rather
+    # than the operator's own annotations. It is keyed by `(host, path)` and not by a flow id,
+    # so it survives correctly and re-attaches if that path is captured again — it is simply
+    # unreachable from the Sitemap tree meanwhile, and `sitemap tag --list` is where to find
+    # it. Spelled out because this list is what a reader checks, and tags were the one spared
+    # table it did not name.
     # Returns whether the wipe committed; see `delete_flow`. A rolled-back clear reported as
     # done is the worst of the three, because the operator moves on believing the project is
     # empty.

--- a/src/gori/tui/fmt.cr
+++ b/src/gori/tui/fmt.cr
@@ -49,15 +49,26 @@ module Gori::Tui
       v.abs < 100 ? "#{v.round(1)}b" : "#{v.round.to_i}b"
     end
 
-    # Compact request→response latency (ms/s/m/h), bounded to ≤6 cols. "—" until the
+    # Compact request→response latency (µs/ms/s/m/h), bounded to ≤6 cols. "—" until the
     # response lands; a minute/hour tier keeps very slow flows from overflowing.
+    #
+    # The store's unit is MICROseconds, so the sub-millisecond tier is not a nicety: a
+    # loopback or LAN target answers in 100–900 µs, and integer-truncating to ms rendered
+    # every one of those as a flat "0ms". That is worst in the Fuzzer, where `dur` labels
+    # both the result rows and the DIST time histogram's min/max — a timing side-channel
+    # reads as "0ms → 0ms" with the whole spread collapsed. Same rounding convention as
+    # `size`/`count`: pick the unit from the ROUNDED magnitude so 999.6 ms rolls up to
+    # "1.0s" rather than the misleading "1000ms".
     def self.dur(us : Int64?) : String
       return "—" unless us
-      ms = us // 1000
-      return "#{ms}ms" if ms < 1000
-      return "#{(ms / 1000.0).round(1)}s" if ms < 60_000
-      return "#{(ms / 60_000.0).round(1)}m" if ms < 3_600_000
-      "#{(ms / 3_600_000.0).round(1)}h"
+      return "#{us}µs" if us < 1000
+      ms = us / 1000.0
+      return unit(ms, "ms") if ms.round < 1000
+      s = us / 1_000_000.0
+      return unit(s, "s") if s.round < 60
+      m = us / 60_000_000.0
+      return unit(m, "m") if m.round < 60
+      unit(us / 3_600_000_000.0, "h")
     end
   end
 end


### PR DESCRIPTION
Seven rounds of a multi-agent defect sweep over the areas this project's traffic path lives in — HTTP/2, WebSocket, GraphQL, History/QL, Repeater, the Fuzzer's keep-alive pool, Probe, and the store. Five read-only hunter agents drove the built binary against recording origins and hand-rolled protocol clients; this seat reviewed each report, reproduced every claim at the wire or in a spec, and applied the fixes. **Every new spec was control-run against the reverted change**, and the protocol-level fixes were re-verified against a running `./bin/gori` — a green suite proves nothing on these primitives.

**33 defects fixed + 2 feature gaps closed. Suite 5468 → 5538 (+70 specs). ameba: no new findings.**

## Highest-severity

- **h2 sandbox bypass — five sites of one leak.** A header block the sandbox refused could still reach the origin: the fail-closed `undecodable` gate raised *before* clearing its buffer, so the raise unwound to `close`→`drain` and wrote the very block it refused. Found and fixed one call site at a time across four rounds (ceiling branch, `unreadable`, `defer?`, the intruder branch), then closed the whole class by clearing the buffer at the top of `finish` — plus a fifth site in `close`→`drain` for a never-END_HEADERS'd block. Each measured at the wire (origin gets SETTINGS only under the sandbox; verbatim forward intact with it off).
- **The keep-alive pool handed one payload's response to the next.** `reusable_response?` checked only the response head, so a body-past-Content-Length or a HEAD-with-body left residue on the socket that the next checkout read as its own response — a 200 attributed to the wrong payload, silently. The pool now proves the socket is drained before parking it (non-blocking, so the 100-send/1-dial keep-alive win is intact). A reset parked socket is now retried too.
- **Probe's disabled-rule list failed OPEN.** The one piece of config between a disabled active rule and a real request swallowed every read error into "nothing is disabled", so a corrupt value sent every active probe (0 → 21 requests, no warning). It now fails closed.
- **A host-scoped rule fired on look-alike hosts** (`alpha.test` matched `xalpha.test`, `alpha.test.evil.com`) — a credential-injecting or short-circuit rule reaching a host the operator never scoped. Now matches the host or a DNS-label subdomain.
- **Deleted-flow evidence re-bound to unrelated traffic.** `flows.id` is a reusable rowid, so eight cross-reference columns re-pointed at whatever was captured next after a delete/clear (a promoted probe finding cited a flow captured *after* the clear). Now detached. The AUTOINCREMENT migration was measured (16.1 s vs a 5 s busy_timeout on a 50k-flow project) and deliberately **not** shipped.

## Also fixed

h2 header-injection projection (#517 on the capture path), h2 fuzz/repeater mangling LF/CR/NUL payloads, WS per-message boundary loss, GraphQL comment-promoted-to-operationName and query-string reordering + a false-positive detection that rewrote requests, a `NOT`-chain that returned the query's complement past the depth cap, `body:` search missing content past a NUL, IPv6-literal origins gori could not dial at all, an MCP `create_repeater` that hung for 30 s on a truncated capture, headless Minimize never touching body params, `HTTP/2` sent down an h1 socket from headless surfaces, a WS repeater reporting success for undelivered messages, `intercept list` doubling an absolute-form URL, the Fuzzer's timing histogram collapsing sub-ms latency to "0ms", a Sequencer row mislabeling a prefixed counter as random, a stranded MCP `since` cursor going silently blind, and the CLI's missing "your filter was broadened" warning.

## Features (security-testing parity)

- `gori run repeater send --verbatim` and MCP `send_request{verbatim}` — send the bytes exactly, so a bare-LF header terminator (a standard desync primitive the TUI could always send) reaches the wire from the headless surfaces too.
- `gori run history` now warns when a QL term was dropped (a dropped term broadens the result — MCP already had `strict`/`ql_explain`; the CLI had neither).

## Verified clean, no change

Intercept-queue concurrency (real out-of-order / decided-twice / decision-after-death races via a live TUI), the whole h2 DATA/body path (fragmentation, padding, gRPC reframing, capture cap vs byte-exact forward), Discover scope/redirect/cancellation, JWT/Decoder/Import/Export under adversarial tests, and Discover/Probe soft-404 calibration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015po9yGZvzLvbVtz3W8BDCa
