### PR TITLE
fix(tui): keep Miss Ring's shudder out of the gutter, and her dirty off screen

### DIFF
--- a/spec/tui/pet_spec.cr
+++ b/spec/tui/pet_spec.cr
@@ -597,25 +597,55 @@ describe Gori::Tui::Pet do
     #
     # Driven by painting the rules FIRST and asserting they survive, rather than by pinning
     # the gutter to a number: the number is the thing that was wrong.
+    #
+    # SWEPT OVER THE SHAKE, because a still frame was not enough the second time either. The
+    # gutter is sized for where she STANDS, and the :error reaction moves her — a frame with
+    # shake: 1 put the right plate strip straight back on the nested rule, reopening the
+    # exact bug below for the 200ms of that beat. Every offset Pet#shake_for can emit has to
+    # hold the same invariant a still frame does.
     it "leaves both stacked pane rules intact, on the right and at the bottom" do
-      backend = MemoryBackend.new(80, 24)
-      screen = Screen.new(backend)
-      # A sub-tabbed tab's shape: the outer card's rule on the body edge, and a nested
-      # Frame.card's one cell inside it. Discover, Sitemap and Repeater all draw this.
-      [1, 2].each do |inset|
-        (body.y...body.bottom).each { |y| screen.cell(body.right - inset, y, '│', Theme.text, Theme.bg) }
-        (body.x...body.right).each { |x| screen.cell(x, body.bottom - inset, '─', Theme.text, Theme.bg) }
+      (-1..1).each do |shake|
+        backend = MemoryBackend.new(80, 24)
+        screen = Screen.new(backend)
+        # A sub-tabbed tab's shape: the outer card's rule on the body edge, and a nested
+        # Frame.card's one cell inside it. Discover, Sitemap and Repeater all draw this.
+        [1, 2].each do |inset|
+          (body.y...body.bottom).each { |y| screen.cell(body.right - inset, y, '│', Theme.text, Theme.bg) }
+          (body.x...body.right).each { |x| screen.cell(x, body.bottom - inset, '─', Theme.text, Theme.bg) }
+        end
+        Pet.draw(screen, body, Mascot::Frame.new(mood: :alarm, shake: shake))
+        rect = Pet.place(body).not_nil!
+        Mascot::H.times do |i|
+          row = backend.row(rect.y + i)
+          row[body.right - 1].should eq('│') # the outer card's rule
+          row[body.right - 2].should eq('│') # …and the nested pane's, the one she ate
+        end
+        [1, 2].each do |inset|
+          rule = backend.row(body.bottom - inset)
+          # She can travel left, so the span she may occlude starts at her leftmost plate.
+          (rect.x - 2..rect.right).each { |x| rule[x].should eq('─') }
+        end
       end
-      Pet.draw(screen, body, Mascot::Frame.new)
-      rect = Pet.place(body).not_nil!
-      Mascot::H.times do |i|
-        row = backend.row(rect.y + i)
-        row[body.right - 1].should eq('│') # the outer card's rule
-        row[body.right - 2].should eq('│') # …and the nested pane's, the one she ate
-      end
-      [1, 2].each do |inset|
-        rule = backend.row(body.bottom - inset)
-        (rect.x - 1..rect.right).each { |x| rule[x].should eq('─') }
+    end
+
+    # The shudder itself, at the source: an offset .draw would have to fold is an offset the
+    # Frame is lying about, and #tick's field-wise compare would then report a change that
+    # paints identical cells. Asserting on the emitted values (not on the painted grid) is
+    # what pins that — the grid assertion above passes either way once .draw clamps.
+    it "never asks to travel into the gutter it reserved" do
+      with_pet(true) do
+        notes = Notifications.new
+        pet = Pet.new(notes)
+        t0 = Time.instant
+        pet.tick(t0)
+        notes.push(:error, "upstream refused the connection")
+        seen = (1..10).map do |i|
+          pet.tick(t0 + Pet::BEAT * i)
+          pet.frame.not_nil!.shake
+        end
+        seen.min.should be >= -1 # she stays inside the body
+        seen.max.should eq(0)    # …and never travels toward the reserved right edge
+        seen.should contain(-1)  # the shudder still plays
       end
     end
 

--- a/src/gori/tui/pet.cr
+++ b/src/gori/tui/pet.cr
@@ -263,12 +263,23 @@ module Gori::Tui
     end
 
     # The :error reaction gets a three-beat shudder; every other mood sits still.
+    #
+    # LEFT-ONLY, and that is geometry rather than taste. GUTTER reserves exactly three
+    # columns at the body's right edge and .draw's right plate strip already claims one of
+    # them, so a single column of rightward travel puts that strip back on the nested
+    # Frame.card rule at body.right - 2 — the bug GUTTER was widened to 3 to fix, returning
+    # for the 200ms of the beat. .draw clamps it away, but a Frame whose shake the draw
+    # silently folds is no longer an exact description of what is painted, and #tick's
+    # field-wise compare (which is what makes "did the drawn thing change" answerable at
+    # all) would report a change that produces identical cells.
+    #
+    # So flinch-back-flinch instead of left-right-still: same three beats, same read, and
+    # every offset it emits is one .draw honours.
     private def shake_for(mood : Symbol) : Int32
       return 0 unless mood == :alarm
       case @beat - @mood_beat
-      when 0 then -1
-      when 1 then 1
-      else        0
+      when 0, 2 then -1
+      else           0
       end
     end
 
@@ -490,8 +501,13 @@ module Gori::Tui
         end
       end
 
-      # Shake the plate, clamped so she can never walk out of the body.
-      x = (rect.x + frame.shake).clamp(body.x, body.right - rect.w)
+      # Shake the plate. The ceiling is `rect.x`, NOT `body.right - rect.w`: GUTTER reserves
+      # exactly three columns at the right edge and the right plate strip already claims one
+      # of them, so a single column of rightward travel puts that strip back on the nested
+      # Frame.card rule at body.right - 2 — the very bug GUTTER was widened to 3 to fix. The
+      # ceiling therefore folds a +1 to 0 and the shudder plays as a flinch LEFT and back,
+      # which is the only direction with room. The floor keeps her inside the body.
+      x = (rect.x + frame.shake).clamp(body.x, rect.x)
       # A column of plate either side so she never butts against body text. Only the two
       # STRIPS — Mascot.draw already claims every cell it covers opaquely, so filling the
       # whole box first would rewrite cells that are about to be overwritten, on every

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -520,7 +520,16 @@ module Gori::Tui
           # changes, and stops reporting at all once she dozes off (Pet::SLEEP_AFTER).
           # Placed after every controller drain, so a note pushed this tick is announced
           # on THIS frame rather than the next.
-          dirty = true if @pet.tick(now)
+          #
+          # TICKED UNCONDITIONALLY, but her dirty is gated on her actually being ON SCREEN.
+          # #render_pet drops her outright under any overlay, the space menu and a body
+          # editor (see #pet_visible?), and Pet.place drops her again on a terminal too
+          # short for her — in every one of those states her `changed` verdict would buy a
+          # full frame rebuild that paints not one different cell. Left ungated that is ~1
+          # wasted render/second for as long as a modal is up, and for as long as you keep
+          # typing in an editor (every keystroke pokes her, so she never dozes there). The
+          # tick itself still has to run or the frame she comes back with would be stale.
+          dirty = true if @pet.tick(now) && pet_on_screen?
           # Debounced QL filter: fire the deferred search once typing has paused.
           dirty = true if history_controller.flush_query_reload_if_due(now)
           dirty = true if sitemap_controller.flush_query_reload_if_due(now)
@@ -3070,6 +3079,19 @@ module Gori::Tui
       return format_status_message(toast) unless notice
       return notice unless toast && (at = @toast_at)
       @pet.bubble_at.try { |b| b > at } ? notice : format_status_message(toast)
+    end
+
+    # Will she paint anything at all this frame? This is the gate the run loop puts in front
+    # of her `dirty` — see the #tick call site for why her verdict alone is not enough.
+    #
+    # Mirrors #render_pet: the bar chip is drawn unconditionally, so it is always on screen;
+    # the body sprite needs the visibility gate below AND a body tall enough for Pet.place to
+    # seat her. Height is the only Pet.place term that can fail from a real Layout — the
+    # narrowest body it produces is 36, comfortably over Pet::MIN_W — and @body_h being one
+    # frame stale is harmless, since the resize that changed it is itself an event.
+    private def pet_on_screen? : Bool
+      return true if Settings.pet_in_bar?
+      pet_visible? && @body_h >= Pet::MIN_H
     end
 
     private def pet_visible? : Bool


### PR DESCRIPTION
Functionality / stability / performance audit of the Pet (Miss Ring) feature. Two defects, both fixed here.

## Performance came out clean, and measured

`bench/pet_draw_bench.cr`, built `--release`:

| | |
|---|---|
| `Mascot.palette` (memoised) | 11.5 ns, 0 B/op |
| `Pet.draw` idle (no bubble) | 1.52 µs |
| `Pet.draw` with bubble | 11.85 µs |
| *for scale:* `Screen.fill 116x28` (one body wipe) | 27.45 µs |

So she is ~5% of a single body fill and under 1% of a real frame. The `(Theme.revision, mood, plate)` palette memo holds — body and bar placement are mutually exclusive, so the size-1 cache never thrashes. Counting the idle tracks by hand reproduces the documented cadence: lively ≈ 1.06 frame-changes/s (blink .78 + glint .23 + wink .05), calm ≈ 0.39/s. Off by default costs nothing (first line of `#tick`), and the 90 s doze really does return to zero. Nothing here touches the proxy or store hot path.

Neither fix below is about cost.

## 1. The `:error` shudder walked into the margin `GUTTER` reserves

`GUTTER = 3` was calibrated against where she **stands**, but the reaction **moves** her. `shake: +1` pushed the right plate strip back onto the nested `Frame.card` rule at `body.right - 2` — reopening the missing-hairline bug `GUTTER` was widened to 3 to fix, for the 200 ms of that beat. Reachable from any `:error` notification on a sub-tabbed tab (Discover, Sitemap, Repeater). Every geometry spec drew `Mascot::Frame.new` (shake 0), so nothing caught it.

Fixed at both ends, deliberately:

- `shake_for` goes **left-only** (`-1, 0, -1` — same three beats, and the only direction with room)
- `.draw`'s clamp ceiling becomes `rect.x`

The clamp alone would protect the cells. But an offset the draw silently folds makes the `Frame` a lie, and `Pet#tick`'s field-wise `Frame` compare — the whole basis of *"did the drawn thing change"* — would then report a change that paints identical cells.

## 2. Her `dirty` fired while she was off screen

The run loop took `dirty = true if @pet.tick(now)`, but `render_pet` drops her entirely under any overlay, the space menu and a body editor (`pet_visible?`), and `Pet.place` drops her again on a terminal too short for her.

So a modal left open — or **any sustained typing in an editor**, where every keystroke pokes her so she never dozes — bought a full frame rebuild every second that painted not one different cell. Now gated on a new `pet_on_screen?` that mirrors `render_pet`. The tick itself still runs unconditionally, or the frame she comes back with would be stale.

## Specs

- the stacked-rules assertion now sweeps shake `-1/0/+1` instead of asserting the still frame
- a new example pins the offsets `shake_for` actually emits — the grid assertion passes either way once `.draw` clamps, so it cannot catch the source

Both were **control-run**: red on the unfixed tree (`Expected: '│' got: ' '` / `Expected: 0 got: 1`), green after.

## Verification

- `crystal build --no-codegen src/main.cr` — OK
- full suite — **5542 examples, 0 failures**
- `crystal tool format --check` — clean
- ameba — 0 on `pet.cr` / `pet_spec.cr`; `runner.cr`'s 21 are all pre-existing, on lines this PR does not touch
- bench re-run after the fix — 1.56 µs / 11.94 µs, within noise